### PR TITLE
fix(ci): restore main checks

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,21 +139,21 @@
         "filename": ".env.example",
         "hashed_secret": "05c668c4033b0bbcc572d8d43f1d110ce16a9e30",
         "is_verified": false,
-        "line_number": 60
+        "line_number": 62
       },
       {
         "type": "Secret Keyword",
         "filename": ".env.example",
         "hashed_secret": "8531762e64e6ec06e8c5bd396dfa745a646aea14",
         "is_verified": false,
-        "line_number": 63
+        "line_number": 65
       },
       {
         "type": "Secret Keyword",
         "filename": ".env.example",
         "hashed_secret": "4ddec4c116456ac18ae6bc5ba5d7980bf1a09990",
         "is_verified": false,
-        "line_number": 66
+        "line_number": 68
       }
     ],
     "docs/CX-FIX-PLAN.md": [
@@ -1058,5 +1058,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-11T18:09:02Z"
+  "generated_at": "2026-03-13T20:14:11Z"
 }

--- a/src/agent/tools/friday-agent-provider-tool.ts
+++ b/src/agent/tools/friday-agent-provider-tool.ts
@@ -17,8 +17,8 @@ import type {
 import {
   errorResult,
   jsonResult,
-  readStringParam,
   readBooleanParam,
+  readStringParam,
 } from "./friday-agent-tool-helpers.js";
 
 // ─── Types ───


### PR DESCRIPTION
## Summary
- fix provider tool import ordering so eslint passes in CI
- refresh `.secrets.baseline` after `.env.example` line-number drift
- keep scope limited to CI recovery with no behavior changes

## Validation
- `npm run lint`
- `git ls-files -z | xargs -0 detect-secrets-hook --baseline .secrets.baseline --exclude-files '(^|/)node_modules(/|$)|(^|/)dist(/|$)|(^|/)coverage(/|$)|(^|/)package-lock\\.json$|(^|/)pnpm-lock\\.yaml$|\\.snap$|(^|/)managed-skills/[^/]+/conversion\\.report\\.json$|(^|/)docs/reports/ops/.*\\.csv$'