### PR TITLE
feat: align conversation turns with active topic

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -59,6 +59,7 @@ export type {
 export type {
   FridayAgentRuntime,
   FridayAgentRuntimeResult,
+  FridayAgentConversationContext,
   FridayAgentExecutionContext,
   CreateFridayAgentRuntimeDeps,
 } from "./runtime/friday-agent-runtime.types.js";

--- a/src/agent/runtime/friday-agent-answer-alignment.ts
+++ b/src/agent/runtime/friday-agent-answer-alignment.ts
@@ -1,0 +1,95 @@
+import type { FridayAgentMessage } from "../model/friday-agent.types.js";
+import type { FridayAgentConversationContext } from "./friday-agent-runtime.types.js";
+
+const STATUS_TERMS =
+  /\b(status|progress|running|waiting|completed|failed|blocked|in progress|eta|minutes?|seconds?)\b/i;
+const CHINESE_STATUS_TERMS = /(状态|进度|运行|等待|完成|失败|阻塞|分钟|秒|还在)/;
+const STOPWORDS = new Set([
+  "a", "an", "and", "are", "as", "at", "be", "for", "from", "how", "in", "is", "it", "of",
+  "on", "or", "that", "the", "this", "to", "what", "when", "where", "which", "who", "why",
+  "you", "your",
+]);
+
+export interface FridayAnswerAlignmentDecision {
+  retryPrompt?: string;
+}
+
+function normalizeText(text: string): string {
+  return text.trim().replace(/\s+/g, " ");
+}
+
+function tokenize(text: string): string[] {
+  return normalizeText(text)
+    .toLowerCase()
+    .split(/[^a-z0-9\u4e00-\u9fff]+/i)
+    .map((token) => token.trim())
+    .filter((token) => token.length >= 2 && !STOPWORDS.has(token));
+}
+
+function countOverlap(left: Iterable<string>, right: Iterable<string>): number {
+  const rightSet = new Set(right);
+  let matches = 0;
+  for (const token of left) {
+    if (rightSet.has(token)) {
+      matches++;
+    }
+  }
+  return matches;
+}
+
+function latestAssistantSummary(historyMessages: FridayAgentMessage[]): string | undefined {
+  const assistantMessages = historyMessages
+    .filter((message) => message.role === "assistant")
+    .map((message) => typeof message.content === "string" ? message.content : "")
+    .filter((message) => message.trim().length > 0);
+  return assistantMessages.length > 0
+    ? assistantMessages[assistantMessages.length - 1]
+    : undefined;
+}
+
+export function evaluateFridayAnswerAlignment(params: {
+  task: string;
+  responseText: string;
+  historyMessages: FridayAgentMessage[];
+  conversationContext?: FridayAgentConversationContext;
+}): FridayAnswerAlignmentDecision {
+  const responseText = normalizeText(params.responseText);
+  if (responseText.length === 0) {
+    return {};
+  }
+
+  const turnKind = params.conversationContext?.turnKind;
+  const responseTokens = tokenize(responseText);
+  const currentTaskTokens = tokenize(params.task);
+  const previousTopicTokens = tokenize(params.conversationContext?.previousTopicSummary ?? latestAssistantSummary(params.historyMessages) ?? "");
+  const currentOverlap = countOverlap(responseTokens, currentTaskTokens);
+  const previousOverlap = countOverlap(responseTokens, previousTopicTokens);
+
+  if (turnKind === "status_check") {
+    const hasStatusLanguage = STATUS_TERMS.test(responseText) || CHINESE_STATUS_TERMS.test(responseText);
+    if (!hasStatusLanguage) {
+      return {
+        retryPrompt: [
+          "You answered the content of a task instead of the user's current status question.",
+          `Current status question: ${params.task}`,
+          "Answer only with deterministic task status or say that you cannot verify the status yet.",
+        ].join("\n"),
+      };
+    }
+  }
+
+  if (turnKind === "new_topic" && previousOverlap >= 2 && currentOverlap === 0) {
+    return {
+      retryPrompt: [
+        "You answered the previous topic instead of the user's current question.",
+        `Current question: ${params.task}`,
+        params.conversationContext?.previousTopicSummary
+          ? `Previous topic to avoid unless explicitly requested: ${params.conversationContext.previousTopicSummary}`
+          : "Ignore the previous topic unless the user explicitly referenced it.",
+        "Answer only the current question. If you cannot answer it from the available evidence, say that clearly.",
+      ].join("\n"),
+    };
+  }
+
+  return {};
+}

--- a/src/agent/runtime/friday-agent-runtime.ts
+++ b/src/agent/runtime/friday-agent-runtime.ts
@@ -29,10 +29,12 @@ import { createFridayAgentRunRepository } from "../persistence/friday-agent-run-
 import type { FridayAgentLlmStreamEvent } from "./friday-agent-llm-client.types.js";
 import type {
   CreateFridayAgentRuntimeDeps,
+  FridayAgentConversationContext,
   FridayAgentExecutionContext,
   FridayAgentRuntime,
   FridayAgentRuntimeResult,
 } from "./friday-agent-runtime.types.js";
+import { evaluateFridayAnswerAlignment } from "./friday-agent-answer-alignment.js";
 import { attachFridayAgentToolExecutionContext } from "./friday-agent-tool-execution-context.js";
 import { isMutatingToolCall } from "./friday-agent-tool-mutation.js";
 import { getApprovalRequiredReasonForToolCall } from "./friday-agent-tool-risk.js";
@@ -167,6 +169,7 @@ export function createFridayAgentRuntime(
       const isReadOnly = constraints?.readOnly === true;
       const disabledToolNames = normalizeToolNameSet(params.disabledToolNames);
       const executionContext = params.executionContext;
+      const conversationContext = params.conversationContext;
       const principalId =
         typeof params.principalId === "string" && params.principalId.trim().length > 0
           ? params.principalId
@@ -210,6 +213,9 @@ export function createFridayAgentRuntime(
       }
 
       const messages: FridayAgentMessage[] = normalizeHistoryMessages(params.historyMessages);
+      const llmTask = typeof params.taskPrompt === "string" && params.taskPrompt.trim().length > 0
+        ? params.taskPrompt.trim()
+        : params.task;
       let learnedPreferences: Record<string, unknown> = {};
       if (learningContextBuilder && principalId) {
         try {
@@ -439,7 +445,7 @@ export function createFridayAgentRuntime(
         // 3. Add user message (with optional inline images for vision)
         if (params.images && params.images.length > 0) {
           const userContent: FridayAgentContentBlock[] = [
-            { type: "text", text: params.task },
+            { type: "text", text: llmTask },
             ...params.images.map((url): FridayAgentImageBlock => ({
               type: "image",
               source: { type: "url", url },
@@ -447,7 +453,7 @@ export function createFridayAgentRuntime(
           ];
           messages.push({ role: "user", content: userContent });
         } else {
-          messages.push({ role: "user", content: params.task });
+          messages.push({ role: "user", content: llmTask });
         }
 
         // 4. Transition to executing and enter LLM loop
@@ -486,6 +492,7 @@ export function createFridayAgentRuntime(
         let iterations = 0;
         let evidenceEnforcementRetries = 0;
         let timelinessEnforcementRetries = 0;
+        let answerAlignmentRetries = 0;
 
         while (iterations < FRIDAY_AGENT_MAX_LOOP_ITERATIONS) {
           if (runAbortController.signal.aborted) {
@@ -614,7 +621,27 @@ export function createFridayAgentRuntime(
               continue;
             }
 
-            responseText = timelinessDecision.responseText;
+            const alignedResponse = timelinessDecision.responseText;
+            const alignmentDecision = evaluateFridayAnswerAlignment({
+              task: params.task,
+              responseText: alignedResponse,
+              historyMessages: normalizeHistoryMessages(params.historyMessages),
+              conversationContext,
+            });
+            if (
+              alignmentDecision.retryPrompt &&
+              alignedResponse.trim().length > 0 &&
+              answerAlignmentRetries < 1
+            ) {
+              answerAlignmentRetries++;
+              messages.push({
+                role: "user",
+                content: alignmentDecision.retryPrompt,
+              });
+              continue;
+            }
+
+            responseText = alignedResponse;
             break;
           }
 

--- a/src/agent/runtime/friday-agent-runtime.types.ts
+++ b/src/agent/runtime/friday-agent-runtime.types.ts
@@ -21,6 +21,12 @@ export interface FridayAgentExecutionContext {
   browserPresentationMode?: "auto" | "headless" | "host_chrome_visible";
 }
 
+export interface FridayAgentConversationContext {
+  turnKind?: "new_topic" | "follow_up" | "clarification" | "status_check" | "continue_active_task";
+  previousTopicSummary?: string;
+  currentTopicSummary?: string;
+}
+
 export interface FridayAgentSystemPromptContext {
   toolNames: string[];
   nowIso: string;
@@ -37,6 +43,10 @@ export interface FridayAgentRuntime {
     images?: string[];
     /** Optional prior conversation history to prepend before the new task. */
     historyMessages?: FridayAgentMessage[];
+    /** Optional prompt variant for the current turn. Stored task stays unchanged. */
+    taskPrompt?: string;
+    /** Optional current-turn metadata for answer alignment and context gating. */
+    conversationContext?: FridayAgentConversationContext;
     sessionKey?: string;
     runId?: string;
     providerId?: string;
@@ -85,6 +95,8 @@ export interface FridayAgentRuntimeResult {
   usageOutput: number;
   /** Image file paths extracted from tool call results (e.g. browser screenshots). */
   images?: string[];
+  /** Final answer after any alignment retry/correction. */
+  finalResponse?: string;
 }
 
 export interface FridayAgentUsageTurn {

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -1533,7 +1533,7 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
     nowIso: deps.nowIso,
   });
 
-  async function loadSessionHistoryRecords(sessionKey: string): Promise<FridaySessionMessageRecord[]> {
+  async function loadSessionHistoryMessages(sessionKey: string): Promise<FridaySessionMessageRecord[]> {
     return sessionService
       .getMessages(sessionKey, SESSION_CONTEXT_HISTORY_LIMIT * 2)
       .catch(() => [] as FridaySessionMessageRecord[]);
@@ -1587,7 +1587,7 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
         }
         | undefined;
       if (input.sessionKey) {
-        const historyRecords = await loadSessionHistoryRecords(input.sessionKey);
+        const historyRecords = await loadSessionHistoryMessages(input.sessionKey);
         if (input.taskAlreadyInHistory && !shouldPersistUserMessage) {
           const lastMatchingUserMessage = [...historyRecords]
             .reverse()

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -1,7 +1,12 @@
 import { FridayDomainError } from "#errors";
 import { createFridayMemoryGuardServiceFactory } from "#memory";
 import { createFridaySecretAdminService } from "#providers";
-import { createFridaySessionMemoryExtractionService, createFridaySessionService } from "#sessions";
+import {
+  createFridaySessionMemoryExtractionService,
+  createFridaySessionService,
+  finalizeFridayConversationFocus,
+  prepareFridayConversationTurn,
+} from "#sessions";
 import type { FridaySessionMessageRecord } from "#sessions";
 import {
   createFridayWorkflowBuilderRuntime,
@@ -156,28 +161,6 @@ function asRecord(value: unknown): Record<string, unknown> {
 
 function asString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0 ? value : undefined;
-}
-
-function mapSessionMessageToAgentMessage(
-  message: FridaySessionMessageRecord,
-): FridayAgentMessage | null {
-  if (message.role !== "user" && message.role !== "assistant") {
-    return null;
-  }
-
-  if (typeof message.content === "string") {
-    const content = message.content.trim();
-    if (content.length > 0) {
-      return { role: message.role, content };
-    }
-  }
-
-  const fallbackText = message.contentText.trim();
-  if (fallbackText.length > 0) {
-    return { role: message.role, content: fallbackText };
-  }
-
-  return null;
 }
 
 function isPrivilegedRunEvidencePrincipal(principal: FridayAuthPrincipal | null): boolean {
@@ -1550,22 +1533,10 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
     nowIso: deps.nowIso,
   });
 
-  async function loadSessionHistoryMessages(
-    sessionKey: string,
-    excludeIdempotencyKey?: string,
-  ): Promise<FridayAgentMessage[]> {
-    const records = await sessionService
-      .getMessages(sessionKey, SESSION_CONTEXT_HISTORY_LIMIT + 1)
+  async function loadSessionHistoryRecords(sessionKey: string): Promise<FridaySessionMessageRecord[]> {
+    return sessionService
+      .getMessages(sessionKey, SESSION_CONTEXT_HISTORY_LIMIT * 2)
       .catch(() => [] as FridaySessionMessageRecord[]);
-    const mapped = records
-      .filter((message) =>
-        !excludeIdempotencyKey || message.idempotencyKey !== excludeIdempotencyKey)
-      .map(mapSessionMessageToAgentMessage)
-      .filter((message): message is FridayAgentMessage => message !== null);
-    if (mapped.length <= SESSION_CONTEXT_HISTORY_LIMIT) {
-      return mapped;
-    }
-    return mapped.slice(mapped.length - SESSION_CONTEXT_HISTORY_LIMIT);
   }
 
   const executeAgentRunWithSessionContext = deps.agentRuntime
@@ -1590,35 +1561,60 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
       const task = input.task.trim();
       const shouldPersistUserMessage = input.sessionKey && input.persistTaskMessage !== false;
       let inboundIdempotencyKey: string | undefined;
+      let currentUserSequence: number | undefined;
+      let focusState = input.sessionKey
+        ? await sessionService.getConversationFocus(input.sessionKey).catch(() => null)
+        : null;
 
       if (input.sessionKey && shouldPersistUserMessage) {
         inboundIdempotencyKey = `${input.idempotencyPrefix}:${input.runId}:user`;
-        await sessionService.addMessage(input.sessionKey, {
+        const inboundMessage = await sessionService.addMessage(input.sessionKey, {
           role: "user",
           content: task,
           contentText: task,
           idempotencyKey: inboundIdempotencyKey,
         });
+        currentUserSequence = inboundMessage.sequence;
       }
 
       let historyMessages: FridayAgentMessage[] | undefined;
-      if (input.sessionKey) {
-        historyMessages = await loadSessionHistoryMessages(
-          input.sessionKey,
-          inboundIdempotencyKey,
-        );
-        if (input.taskAlreadyInHistory && !shouldPersistUserMessage && historyMessages.length > 0) {
-          const lastMessage = historyMessages[historyMessages.length - 1];
-          if (lastMessage?.role === "user" && typeof lastMessage.content === "string") {
-            if (lastMessage.content.trim() === task) {
-              historyMessages = historyMessages.slice(0, historyMessages.length - 1);
-            }
-          }
+      let taskPrompt = task;
+      let conversationContext:
+        | {
+          turnKind?: "new_topic" | "follow_up" | "clarification" | "status_check" | "continue_active_task";
+          previousTopicSummary?: string;
+          currentTopicSummary?: string;
         }
+        | undefined;
+      if (input.sessionKey) {
+        const historyRecords = await loadSessionHistoryRecords(input.sessionKey);
+        if (input.taskAlreadyInHistory && !shouldPersistUserMessage) {
+          const lastMatchingUserMessage = [...historyRecords]
+            .reverse()
+            .find((message) => message.role === "user" && message.contentText.trim() === task);
+          currentUserSequence = lastMatchingUserMessage?.sequence;
+        }
+
+        const preparedTurn = prepareFridayConversationTurn({
+          task,
+          historyRecords: historyRecords.filter((message) =>
+            !inboundIdempotencyKey || message.idempotencyKey !== inboundIdempotencyKey),
+          focusState,
+          currentUserSequence,
+        });
+        historyMessages = preparedTurn.historyMessages;
+        taskPrompt = preparedTurn.taskPrompt;
+        conversationContext = {
+          turnKind: preparedTurn.turnKind,
+          previousTopicSummary: preparedTurn.previousTopicSummary,
+          currentTopicSummary: preparedTurn.currentTopicSummary,
+        };
       }
 
-      return deps.agentRuntime!.executeRun({
+      const result = await deps.agentRuntime!.executeRun({
         task,
+        taskPrompt,
+        conversationContext,
         sessionKey: input.sessionKey,
         runId: input.runId,
         providerId: input.providerId,
@@ -1633,6 +1629,23 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
         executionContext: input.executionContext,
         historyMessages,
       });
+
+      if (input.sessionKey && conversationContext?.turnKind) {
+        await sessionService.setConversationFocus(
+          input.sessionKey,
+          finalizeFridayConversationFocus({
+            task,
+            responseText: result.response,
+            runId: result.runId,
+            turnKind: conversationContext.turnKind,
+            focusState,
+            currentUserSequence,
+            nowIso: deps.nowIso(),
+          }),
+        ).catch(() => undefined);
+      }
+
+      return result;
     }
     : undefined;
 

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -88,7 +88,11 @@ import {
 } from "#plugins";
 import type { FridayPluginService } from "#plugins";
 import { createFridayMemoryFileSyncRepository, createFridayMemoryFileSyncService, createFridayMemoryService } from "#memory";
-import { createFridaySessionMemoryExtractionService } from "#sessions";
+import {
+  createFridaySessionMemoryExtractionService,
+  finalizeFridayConversationFocus,
+  prepareFridayConversationTurn,
+} from "#sessions";
 import type { FridayMemoryFileSyncService, FridayMemoryService } from "#memory";
 import {
   buildFridayAgentSystemPrompt,
@@ -3789,7 +3793,7 @@ export async function createFridayHub(
 
           void (async () => {
             try {
-              await hubSessionService.addMessage(sessionKey, {
+              const inboundMessage = await hubSessionService.addMessage(sessionKey, {
                 role: "user",
                 content: text,
                 contentText: text,
@@ -3802,20 +3806,30 @@ export async function createFridayHub(
                   routeId: "hub.channel.session.mirror",
                   error: err,
                 });
+                return undefined;
               });
 
-              const historyMessages = await hubSessionService
-                .getMessages(sessionKey, FRIDAY_CHANNEL_CONTEXT_HISTORY_LIMIT + 1)
-                .then((messages) => {
-                  const mapped = messages
-                    .filter((message) => message.idempotencyKey !== inboundIdempotencyKey)
-                    .map(mapSessionMessageToAgentMessage)
-                    .filter((message): message is FridayAgentMessage => message !== null);
-                  if (mapped.length <= FRIDAY_CHANNEL_CONTEXT_HISTORY_LIMIT) {
-                    return mapped;
-                  }
-                  return mapped.slice(mapped.length - FRIDAY_CHANNEL_CONTEXT_HISTORY_LIMIT);
-                })
+              const focusState = await hubSessionService
+                .getConversationFocus(sessionKey)
+                .catch((err) => {
+                  logChannelIssue({
+                    level: "warn",
+                    code: "W-CH-HISTORY-001",
+                    routeId: "hub.channel.focus.read",
+                    error: err,
+                  });
+                  return null;
+                });
+
+              const preparedTurn = await hubSessionService
+                .getMessages(sessionKey, FRIDAY_CHANNEL_CONTEXT_HISTORY_LIMIT * 2)
+                .then((messages) =>
+                  prepareFridayConversationTurn({
+                    task: text,
+                    historyRecords: messages.filter((message) => message.idempotencyKey !== inboundIdempotencyKey),
+                    focusState,
+                    currentUserSequence: inboundMessage?.sequence,
+                  }))
                 .catch((err) => {
                   logChannelIssue({
                     level: "warn",
@@ -3823,16 +3837,48 @@ export async function createFridayHub(
                     routeId: "hub.channel.history.read",
                     error: err,
                   });
-                  return [] as FridayAgentMessage[];
+                  return {
+                    turnKind: "new_topic" as const,
+                    historyMessages: [] as FridayAgentMessage[],
+                    taskPrompt: text,
+                    previousTopicSummary: undefined,
+                    currentTopicSummary: text,
+                  };
                 });
 
               const result = await agentRuntime.executeRun({
                 task: text,
+                taskPrompt: preparedTurn.taskPrompt,
                 images: msg.images,
                 sessionKey,
-                historyMessages,
+                historyMessages: preparedTurn.historyMessages,
+                conversationContext: {
+                  turnKind: preparedTurn.turnKind,
+                  previousTopicSummary: preparedTurn.previousTopicSummary,
+                  currentTopicSummary: preparedTurn.currentTopicSummary,
+                },
                 principalId: msg.senderId,
                 timezone: msg.timezone,
+              });
+
+              await hubSessionService.setConversationFocus(
+                sessionKey,
+                finalizeFridayConversationFocus({
+                  task: text,
+                  responseText: result.response,
+                  runId: result.runId,
+                  turnKind: preparedTurn.turnKind,
+                  focusState,
+                  currentUserSequence: inboundMessage?.sequence,
+                  nowIso: nowIso(),
+                }),
+              ).catch((err) => {
+                logChannelIssue({
+                  level: "warn",
+                  code: "W-CH-FOCUS-WRITE-001",
+                  routeId: "hub.channel.focus.write",
+                  error: err,
+                });
               });
 
               typingController.stopRun();

--- a/src/sessions/index.ts
+++ b/src/sessions/index.ts
@@ -31,8 +31,10 @@ export type {
   FridaySessionStatus,
   FridaySessionRole,
   FridaySessionChatKind,
+  FridayConversationTurnKind,
   FridaySessionKeyParts,
   FridaySessionSendPolicy,
+  FridaySessionConversationFocusState,
   FridaySessionRecord,
   FridaySessionMessageRecord,
   FridaySessionMessageInput,
@@ -89,6 +91,16 @@ export {
 
 export type { FridaySessionService, FridaySessionSweepResult, CreateFridaySessionServiceDeps } from "./services/friday-session-service.types.js";
 export { createFridaySessionService } from "./services/friday-session-service.js";
+export type {
+  FridayPreparedConversationTurn,
+  PrepareFridayConversationTurnInput,
+  FinalizeFridayConversationFocusInput,
+} from "./services/friday-session-conversation-orchestrator.js";
+export {
+  classifyFridayConversationTurn,
+  prepareFridayConversationTurn,
+  finalizeFridayConversationFocus,
+} from "./services/friday-session-conversation-orchestrator.js";
 
 // ─── Memory extraction constants ───
 

--- a/src/sessions/model/friday-session.types.ts
+++ b/src/sessions/model/friday-session.types.ts
@@ -1,6 +1,12 @@
 export type FridaySessionStatus = "active" | "idle" | "archived" | "pruned";
 export type FridaySessionRole = "system" | "user" | "assistant" | "tool";
 export type FridaySessionChatKind = "dm" | "group" | "channel" | "thread";
+export type FridayConversationTurnKind =
+  | "new_topic"
+  | "follow_up"
+  | "clarification"
+  | "status_check"
+  | "continue_active_task";
 
 /**
  * Send policy controls whether outbound messages are allowed for a session.
@@ -46,6 +52,20 @@ export interface FridaySessionRecord {
   idleAt?: string;
   archivedAt?: string;
   prunedAt?: string;
+}
+
+export interface FridaySessionConversationFocusState {
+  currentTopicFingerprint?: string;
+  currentTopicSummary?: string;
+  currentTopicStartSequence?: number;
+  lastAnsweredQuestion?: string;
+  lastAssistantAskedQuestion?: boolean;
+  lastRunId?: string;
+  activeRunId?: string;
+  activeSubagentIds?: string[];
+  pendingPlanRunId?: string;
+  lastTurnKind?: FridayConversationTurnKind;
+  updatedAt: string;
 }
 
 export interface FridaySessionMessageRecord {

--- a/src/sessions/persistence/friday-session-repository.ts
+++ b/src/sessions/persistence/friday-session-repository.ts
@@ -127,6 +127,11 @@ export interface FridaySessionRepository {
     db: Database.Database,
     input: { key: string; sendPolicy: string | null; nowIso: string },
   ): FridaySessionRecord | null;
+
+  updateMetadata(
+    db: Database.Database,
+    input: { key: string; metadata: Record<string, unknown>; nowIso: string },
+  ): FridaySessionRecord | null;
 }
 
 // ─── Factory ───
@@ -426,6 +431,18 @@ export function createFridaySessionRepository(): FridaySessionRepository {
       const result = db.prepare(
         `UPDATE sessions SET send_policy = ?, updated_at = ? WHERE session_key = ?`,
       ).run(input.sendPolicy, input.nowIso, input.key);
+
+      if (result.changes === 0) {
+        return null;
+      }
+
+      return this.getByKey(db, input.key);
+    },
+
+    updateMetadata(db, input) {
+      const result = db.prepare(
+        `UPDATE sessions SET metadata_json = ?, updated_at = ? WHERE session_key = ?`,
+      ).run(JSON.stringify(input.metadata), input.nowIso, input.key);
 
       if (result.changes === 0) {
         return null;

--- a/src/sessions/services/friday-session-conversation-orchestrator.ts
+++ b/src/sessions/services/friday-session-conversation-orchestrator.ts
@@ -1,0 +1,296 @@
+import { createHash } from "node:crypto";
+
+import type { FridayAgentMessage } from "#agent";
+
+import type {
+  FridayConversationTurnKind,
+  FridaySessionConversationFocusState,
+  FridaySessionMessageRecord,
+} from "../model/friday-session.types.js";
+
+const MAX_TOPIC_SUMMARY_CHARS = 180;
+const MAX_FOLLOW_UP_HISTORY = 12;
+const MAX_STATUS_HISTORY = 6;
+const FOLLOW_UP_HINTS =
+  /\b(that|it|this|those|these|also|and|then|what about|more about|continue|same|again|summari[sz]e|summary|recap|recommendation|recommendations)\b/i;
+const CHINESE_FOLLOW_UP_HINTS = /(这个|那个|继续|还有|然后|刚才|上一个|同一个|总结|概括|再说|细讲)/;
+const ADVISORY_CONTINUATION_HINTS = /\b(prefer|preference|recommend|recommendation|recommendations|should i|best)\b/i;
+const STATUS_CHECK_HINTS =
+  /\b(status|progress|still working|what are you doing|what's happening|how long|eta|done yet|finished yet|running)\b/i;
+const CHINESE_STATUS_CHECK_HINTS = /(状态|进度|还在|多久|完成了吗|现在在做什么|刚才那个任务|还没好|ETA)/;
+const CONTINUE_HINTS =
+  /\b(continue|go ahead|proceed|keep going|do it|start it|carry on)\b/i;
+const CHINESE_CONTINUE_HINTS = /(继续|开始吧|继续做|接着做|往下做|执行吧)/;
+const STOPWORDS = new Set([
+  "a", "an", "and", "are", "as", "at", "be", "can", "for", "from", "how", "i", "in",
+  "is", "it", "me", "my", "of", "on", "one", "or", "please", "should", "short", "single",
+  "sentence", "answer", "brief", "that", "the", "this", "to", "what", "when", "where",
+  "which", "who", "why", "you", "your",
+]);
+
+export interface FridayPreparedConversationTurn {
+  turnKind: FridayConversationTurnKind;
+  historyMessages: FridayAgentMessage[];
+  taskPrompt: string;
+  previousTopicSummary?: string;
+  currentTopicSummary?: string;
+}
+
+export interface PrepareFridayConversationTurnInput {
+  task: string;
+  historyRecords: FridaySessionMessageRecord[];
+  focusState?: FridaySessionConversationFocusState | null;
+  currentUserSequence?: number;
+}
+
+export interface FinalizeFridayConversationFocusInput {
+  task: string;
+  responseText: string;
+  runId: string;
+  turnKind: FridayConversationTurnKind;
+  focusState?: FridaySessionConversationFocusState | null;
+  currentUserSequence?: number;
+  pendingPlanRunId?: string;
+  nowIso: string;
+}
+
+function normalizeText(text: string): string {
+  return text.trim().replace(/\s+/g, " ");
+}
+
+function summarizeTopic(text: string): string {
+  const normalized = normalizeText(text);
+  if (normalized.length <= MAX_TOPIC_SUMMARY_CHARS) {
+    return normalized;
+  }
+  return `${normalized.slice(0, MAX_TOPIC_SUMMARY_CHARS - 1)}…`;
+}
+
+function tokenize(text: string): string[] {
+  return normalizeText(text)
+    .toLowerCase()
+    .split(/[^a-z0-9\u4e00-\u9fff]+/i)
+    .map((token) => token.trim())
+    .filter((token) => token.length >= 2 && !STOPWORDS.has(token));
+}
+
+function countOverlap(left: Iterable<string>, right: Iterable<string>): number {
+  const rightSet = new Set(right);
+  let matches = 0;
+  for (const token of left) {
+    if (rightSet.has(token)) {
+      matches++;
+    }
+  }
+  return matches;
+}
+
+function fingerprintTopic(text: string): string {
+  const normalized = summarizeTopic(text).toLowerCase();
+  return createHash("sha1").update(normalized).digest("hex").slice(0, 16);
+}
+
+function mapSessionMessageToAgentMessage(
+  message: FridaySessionMessageRecord,
+): FridayAgentMessage | null {
+  if (message.role !== "user" && message.role !== "assistant") {
+    return null;
+  }
+  if (typeof message.content === "string") {
+    const content = message.content.trim();
+    if (content.length > 0) {
+      return { role: message.role, content };
+    }
+  }
+  const fallbackText = message.contentText.trim();
+  if (fallbackText.length > 0) {
+    return { role: message.role, content: fallbackText };
+  }
+  return null;
+}
+
+export function classifyFridayConversationTurn(input: {
+  task: string;
+  focusState?: FridaySessionConversationFocusState | null;
+}): FridayConversationTurnKind {
+  const task = normalizeText(input.task);
+  const focusState = input.focusState ?? null;
+  const taskLower = task.toLowerCase();
+  const focusSummary = focusState?.currentTopicSummary ?? "";
+  const hasFocus = Boolean(focusState?.currentTopicSummary);
+  const taskTokens = tokenize(task);
+  const focusTokens = tokenize(focusSummary);
+  const overlap = countOverlap(taskTokens, focusTokens);
+  const shortTask = task.length > 0 && task.length <= 120;
+  const advisoryContinuation =
+    ADVISORY_CONTINUATION_HINTS.test(taskLower)
+    && ADVISORY_CONTINUATION_HINTS.test(focusSummary.toLowerCase());
+
+  if (STATUS_CHECK_HINTS.test(taskLower) || CHINESE_STATUS_CHECK_HINTS.test(task)) {
+    return "status_check";
+  }
+  if (CONTINUE_HINTS.test(taskLower) || CHINESE_CONTINUE_HINTS.test(task)) {
+    return "continue_active_task";
+  }
+  if (
+    Boolean(focusState?.lastAssistantAskedQuestion)
+    && shortTask
+  ) {
+    return "clarification";
+  }
+  if (
+    hasFocus
+    && (
+      overlap >= 2
+      || advisoryContinuation
+      || FOLLOW_UP_HINTS.test(taskLower)
+      || CHINESE_FOLLOW_UP_HINTS.test(task)
+    )
+  ) {
+    return "follow_up";
+  }
+  return "new_topic";
+}
+
+function selectConversationRecords(input: {
+  historyRecords: FridaySessionMessageRecord[];
+  focusState?: FridaySessionConversationFocusState | null;
+  turnKind: FridayConversationTurnKind;
+  currentUserSequence?: number;
+}): FridaySessionMessageRecord[] {
+  const focusState = input.focusState ?? null;
+  let records = [...input.historyRecords];
+
+  if (typeof input.currentUserSequence === "number") {
+    records = records.filter((record) => record.sequence < input.currentUserSequence!);
+  }
+
+  if (input.turnKind === "new_topic") {
+    return [];
+  }
+
+  const topicStartSequence = focusState?.currentTopicStartSequence;
+  if (
+    (input.turnKind === "follow_up" || input.turnKind === "clarification" || input.turnKind === "continue_active_task")
+    && typeof topicStartSequence === "number"
+  ) {
+    records = records.filter((record) => record.sequence >= topicStartSequence);
+  }
+
+  const maxCount = input.turnKind === "status_check" ? MAX_STATUS_HISTORY : MAX_FOLLOW_UP_HISTORY;
+  if (records.length <= maxCount) {
+    return records;
+  }
+  return records.slice(records.length - maxCount);
+}
+
+function buildTaskPrompt(input: {
+  task: string;
+  turnKind: FridayConversationTurnKind;
+  focusState?: FridaySessionConversationFocusState | null;
+}): string {
+  const task = normalizeText(input.task);
+  const previousTopicSummary = input.focusState?.currentTopicSummary?.trim();
+
+  if (input.turnKind === "new_topic" && previousTopicSummary) {
+    return [
+      "This user started a new question.",
+      `Current question: ${task}`,
+      `Previous topic (do not answer this unless the user explicitly asked for it): ${previousTopicSummary}`,
+      "Answer only the current question. If context from the previous topic is not needed, ignore it.",
+    ].join("\n");
+  }
+
+  if (input.turnKind === "status_check") {
+    return [
+      `The user is asking for a status update: ${task}`,
+      previousTopicSummary
+        ? `Active topic reference: ${previousTopicSummary}`
+        : "No active topic summary is available.",
+      "Do not answer the content of the previous task unless the user explicitly asked for that content.",
+      "If you do not have deterministic status evidence in this turn, say that clearly instead of assuming.",
+    ].join("\n");
+  }
+
+  if (input.turnKind === "clarification" && previousTopicSummary) {
+    return [
+      `The user is replying to your clarification request: ${task}`,
+      `Current topic: ${previousTopicSummary}`,
+      "Use this answer to continue the current topic.",
+    ].join("\n");
+  }
+
+  if ((input.turnKind === "follow_up" || input.turnKind === "continue_active_task") && previousTopicSummary) {
+    return [
+      `Continue the current topic: ${previousTopicSummary}`,
+      `Latest user turn: ${task}`,
+    ].join("\n");
+  }
+
+  return task;
+}
+
+export function prepareFridayConversationTurn(
+  input: PrepareFridayConversationTurnInput,
+): FridayPreparedConversationTurn {
+  const focusState = input.focusState ?? null;
+  const turnKind = classifyFridayConversationTurn({
+    task: input.task,
+    focusState,
+  });
+  const selectedRecords = selectConversationRecords({
+    historyRecords: input.historyRecords,
+    focusState,
+    turnKind,
+    currentUserSequence: input.currentUserSequence,
+  });
+  const historyMessages = selectedRecords
+    .map(mapSessionMessageToAgentMessage)
+    .filter((message): message is FridayAgentMessage => message !== null);
+  const currentTopicSummary = turnKind === "new_topic"
+    ? summarizeTopic(input.task)
+    : focusState?.currentTopicSummary ?? summarizeTopic(input.task);
+
+  return {
+    turnKind,
+    historyMessages,
+    taskPrompt: buildTaskPrompt({
+      task: input.task,
+      turnKind,
+      focusState,
+    }),
+    previousTopicSummary: focusState?.currentTopicSummary,
+    currentTopicSummary,
+  };
+}
+
+export function finalizeFridayConversationFocus(
+  input: FinalizeFridayConversationFocusInput,
+): FridaySessionConversationFocusState {
+  const previous = input.focusState ?? null;
+  const currentTopicSummary = input.turnKind === "new_topic"
+    ? summarizeTopic(input.task)
+    : previous?.currentTopicSummary ?? summarizeTopic(input.task);
+  const currentTopicFingerprint = input.turnKind === "new_topic"
+    ? fingerprintTopic(input.task)
+    : previous?.currentTopicFingerprint ?? fingerprintTopic(input.task);
+  const currentTopicStartSequence = input.turnKind === "new_topic"
+    ? input.currentUserSequence
+    : previous?.currentTopicStartSequence ?? input.currentUserSequence;
+  const activeSubagentIds = previous?.activeSubagentIds;
+  const assistantAskedQuestion = /(?:\?|？)\s*$/.test(input.responseText.trim());
+
+  return {
+    currentTopicFingerprint,
+    currentTopicSummary,
+    currentTopicStartSequence,
+    lastAnsweredQuestion: summarizeTopic(input.task),
+    lastAssistantAskedQuestion: assistantAskedQuestion,
+    lastRunId: input.runId,
+    activeRunId: undefined,
+    activeSubagentIds: activeSubagentIds && activeSubagentIds.length > 0 ? activeSubagentIds : undefined,
+    pendingPlanRunId: input.pendingPlanRunId ?? previous?.pendingPlanRunId,
+    lastTurnKind: input.turnKind,
+    updatedAt: input.nowIso,
+  };
+}

--- a/src/sessions/services/friday-session-service.ts
+++ b/src/sessions/services/friday-session-service.ts
@@ -16,6 +16,7 @@ import {
   FRIDAY_SESSION_PRUNE_TIMEOUT_MS,
 } from "../friday-session.constants.js";
 import type {
+  FridaySessionConversationFocusState,
   FridaySessionCreateInput,
   FridaySessionForkCreateInput,
   FridaySessionForkCreateResult,
@@ -42,6 +43,52 @@ export function createFridaySessionService(
 ): FridaySessionService {
   const sessionRepo = createFridaySessionRepository();
   const messageRepo = createFridaySessionMessageRepository();
+  const FOCUS_METADATA_KEY = "conversationFocus";
+
+  function readConversationFocus(
+    session: FridaySessionRecord | null,
+  ): FridaySessionConversationFocusState | null {
+    const raw = session?.metadata?.[FOCUS_METADATA_KEY];
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+      return null;
+    }
+
+    const candidate = raw as Record<string, unknown>;
+    if (typeof candidate.updatedAt !== "string" || candidate.updatedAt.trim().length === 0) {
+      return null;
+    }
+
+    return {
+      currentTopicFingerprint:
+        typeof candidate.currentTopicFingerprint === "string" ? candidate.currentTopicFingerprint : undefined,
+      currentTopicSummary:
+        typeof candidate.currentTopicSummary === "string" ? candidate.currentTopicSummary : undefined,
+      currentTopicStartSequence:
+        typeof candidate.currentTopicStartSequence === "number" ? candidate.currentTopicStartSequence : undefined,
+      lastAnsweredQuestion:
+        typeof candidate.lastAnsweredQuestion === "string" ? candidate.lastAnsweredQuestion : undefined,
+      lastAssistantAskedQuestion:
+        typeof candidate.lastAssistantAskedQuestion === "boolean" ? candidate.lastAssistantAskedQuestion : undefined,
+      lastRunId:
+        typeof candidate.lastRunId === "string" ? candidate.lastRunId : undefined,
+      activeRunId:
+        typeof candidate.activeRunId === "string" ? candidate.activeRunId : undefined,
+      activeSubagentIds: Array.isArray(candidate.activeSubagentIds)
+        ? candidate.activeSubagentIds.filter((value): value is string => typeof value === "string")
+        : undefined,
+      pendingPlanRunId:
+        typeof candidate.pendingPlanRunId === "string" ? candidate.pendingPlanRunId : undefined,
+      lastTurnKind:
+        candidate.lastTurnKind === "new_topic"
+          || candidate.lastTurnKind === "follow_up"
+          || candidate.lastTurnKind === "clarification"
+          || candidate.lastTurnKind === "status_check"
+          || candidate.lastTurnKind === "continue_active_task"
+          ? candidate.lastTurnKind
+          : undefined,
+      updatedAt: candidate.updatedAt,
+    };
+  }
 
   /** Walk parent chain to find rootSessionKey. */
   function resolveRootSessionKey(parentKey: string): string {
@@ -733,6 +780,9 @@ export function createFridaySessionService(
           );
         }
 
+        const metadata = { ...session.metadata };
+        delete metadata[FOCUS_METADATA_KEY];
+
         // Delete all messages for this session
         db.prepare("DELETE FROM session_messages WHERE session_key = ?").run(key);
 
@@ -743,12 +793,13 @@ export function createFridaySessionService(
             context_output_tokens = 0,
             context_total_tokens = 0,
             message_count = 0,
+            metadata_json = ?,
             status = 'active',
             status_changed_at = ?,
             last_activity_at = ?,
             updated_at = ?
           WHERE session_key = ?`,
-        ).run(now, now, now, key);
+        ).run(JSON.stringify(metadata), now, now, now, key);
 
         const updated = sessionRepo.getByKey(db, key);
         if (!updated) {
@@ -761,6 +812,56 @@ export function createFridaySessionService(
 
         return updated;
       });
+    },
+
+    async getConversationFocus(key) {
+      key = canonicalizeFridaySessionKey(key);
+
+      const session = deps.db.withReadConnection((db) => sessionRepo.getByKey(db, key));
+      if (!session) {
+        throw new FridayDomainError(
+          FRIDAY_SESSION_ERROR_CODES.NOT_FOUND,
+          `Session '${key}' not found`,
+          { httpStatus: 404 },
+        );
+      }
+
+      return readConversationFocus(session);
+    },
+
+    async setConversationFocus(key, focusState) {
+      key = canonicalizeFridaySessionKey(key);
+
+      const now = deps.nowIso();
+      const updated = deps.db.withWriteTransaction((db) => {
+        const session = sessionRepo.getByKey(db, key);
+        if (!session) {
+          return null;
+        }
+
+        const metadata = { ...session.metadata };
+        if (focusState) {
+          metadata[FOCUS_METADATA_KEY] = focusState;
+        } else {
+          delete metadata[FOCUS_METADATA_KEY];
+        }
+
+        return sessionRepo.updateMetadata(db, {
+          key,
+          metadata,
+          nowIso: now,
+        });
+      });
+
+      if (!updated) {
+        throw new FridayDomainError(
+          FRIDAY_SESSION_ERROR_CODES.NOT_FOUND,
+          `Session '${key}' not found`,
+          { httpStatus: 404 },
+        );
+      }
+
+      return updated;
     },
 
     async setSendPolicy(key, policy) {

--- a/src/sessions/services/friday-session-service.types.ts
+++ b/src/sessions/services/friday-session-service.types.ts
@@ -1,6 +1,7 @@
 import type { FridaySqliteLayer } from "#state";
 
 import type {
+  FridaySessionConversationFocusState,
   FridaySessionCreateInput,
   FridaySessionForkCreateInput,
   FridaySessionForkCreateResult,
@@ -35,6 +36,13 @@ export interface FridaySessionService {
   setSendPolicy(key: string, policy: FridaySessionSendPolicy | null): Promise<FridaySessionRecord>;
   /** Resolve the effective send policy for a session (session override > default "allow"). */
   evaluateSendPolicy(key: string): Promise<FridaySessionSendPolicy>;
+  /** Read the persisted conversation focus state for a session. */
+  getConversationFocus(key: string): Promise<FridaySessionConversationFocusState | null>;
+  /** Persist or clear the conversation focus state for a session. */
+  setConversationFocus(
+    key: string,
+    focusState: FridaySessionConversationFocusState | null,
+  ): Promise<FridaySessionRecord>;
 }
 
 export interface FridaySessionSweepResult {

--- a/test/e2e/mock/friday-mock-multi-turn.e2e.test.ts
+++ b/test/e2e/mock/friday-mock-multi-turn.e2e.test.ts
@@ -109,6 +109,42 @@ describe("Friday Mock Multi-Turn E2E", () => {
     }
   });
 
+  it("treats an unrelated second turn as a new topic instead of replaying the prior answer", async () => {
+    const mock = env.mockFor("anthropic");
+    const sessionKey = "api:e2e:multi-turn-new-topic";
+
+    mock.setDefault({ type: "text", text: "Paris is the capital of France." });
+    const r1 = await apiFetch<AgentRunResult>(
+      env.baseUrl,
+      env.accessToken,
+      "POST",
+      "/v1/agent/runs",
+      { task: "What is the capital of France?", providerId, model, timeoutMs: 10_000, sessionKey },
+    );
+    expect(r1.json.data.status).toBe("completed");
+
+    mock.reset();
+    resetMockCounters();
+
+    mock.setDefault({ type: "text", text: "Use a starter and let the dough ferment overnight." });
+    const r2 = await apiFetch<AgentRunResult>(
+      env.baseUrl,
+      env.accessToken,
+      "POST",
+      "/v1/agent/runs",
+      { task: "How do I bake sourdough bread?", providerId, model, timeoutMs: 10_000, sessionKey },
+    );
+    expect(r2.json.data.status).toBe("completed");
+
+    const r2Body = mock.calls[0]?.bodyJson as { messages?: Array<{ role: string; content?: string }> } | undefined;
+    expect(r2Body?.messages).toBeDefined();
+    if (r2Body?.messages) {
+      const joined = r2Body.messages.map((message) => message.content ?? "").join(" ");
+      expect(joined).not.toContain("Paris is the capital of France.");
+      expect(joined).toContain("How do I bake sourdough bread?");
+    }
+  });
+
   it("three-turn accumulation: by round 3, LLM receives history from rounds 1 and 2", async () => {
     const mock = env.mockFor("anthropic");
     const sessionKey = "api:e2e:multi-turn-three-turns";

--- a/test/unit/agent/runtime/friday-agent-runtime.test.ts
+++ b/test/unit/agent/runtime/friday-agent-runtime.test.ts
@@ -495,6 +495,71 @@ describe("FridayAgentRuntime", () => {
     ]);
   });
 
+  it("uses taskPrompt for the current turn and retries when the answer matches the previous topic", async () => {
+    const capturedCalls: FridayAgentMessage[][] = [];
+    let callIndex = 0;
+
+    const llmClient: FridayAgentLlmClient = {
+      async *stream(params) {
+        capturedCalls.push(params.messages.map((message) => ({
+          role: message.role,
+          content: typeof message.content === "string"
+            ? message.content
+            : JSON.parse(JSON.stringify(message.content)),
+        })));
+        if (callIndex === 0) {
+          callIndex++;
+          yield { type: "text_delta", text: "Paris is the capital of France." };
+          yield { type: "message_end", stopReason: "end_turn", inputTokens: 6, outputTokens: 4 };
+          return;
+        }
+        yield { type: "text_delta", text: "Use a sourdough starter and let the dough ferment overnight." };
+        yield { type: "message_end", stopReason: "end_turn", inputTokens: 5, outputTokens: 7 };
+      },
+    };
+
+    const runtime = createFridayAgentRuntime({
+      db,
+      llmClient,
+      model: "test-model",
+      providerId: "test-provider",
+      systemPrompt: "You are a test agent.",
+      tools: [],
+      eventEmitter: createFridayAgentEventEmitter(),
+      idGenerator,
+      nowIso: () => NOW,
+    });
+
+    const result = await runtime.executeRun({
+      task: "How do I bake sourdough bread?",
+      taskPrompt: "This is a new question. Ignore the previous France topic.\nCurrent question: How do I bake sourdough bread?",
+      historyMessages: [
+        { role: "user", content: "What is the capital of France?" },
+        { role: "assistant", content: "Paris is the capital of France." },
+      ],
+      conversationContext: {
+        turnKind: "new_topic",
+        previousTopicSummary: "What is the capital of France?",
+        currentTopicSummary: "How do I bake sourdough bread?",
+      },
+    });
+
+    expect(result.status).toBe("completed");
+    expect(result.response).toContain("sourdough starter");
+    expect(capturedCalls).toHaveLength(2);
+    expect(capturedCalls[0]).toEqual([
+      { role: "user", content: "What is the capital of France?" },
+      { role: "assistant", content: "Paris is the capital of France." },
+      { role: "user", content: "This is a new question. Ignore the previous France topic.\nCurrent question: How do I bake sourdough bread?" },
+    ]);
+    expect(capturedCalls[1]![capturedCalls[1]!.length - 1]).toEqual(
+      expect.objectContaining({
+        role: "user",
+        content: expect.stringContaining("You answered the previous topic instead"),
+      }),
+    );
+  });
+
   it("records usage metadata when LLM reports actual provider fields", async () => {
     const llmClient = createMockLlmClient([
       [

--- a/test/unit/sessions/services/friday-session-conversation-orchestrator.test.ts
+++ b/test/unit/sessions/services/friday-session-conversation-orchestrator.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  classifyFridayConversationTurn,
+  finalizeFridayConversationFocus,
+  prepareFridayConversationTurn,
+} from "#sessions";
+import type {
+  FridaySessionConversationFocusState,
+  FridaySessionMessageRecord,
+} from "#sessions";
+
+function makeMessage(input: {
+  sequence: number;
+  role: "user" | "assistant";
+  contentText: string;
+}): FridaySessionMessageRecord {
+  return {
+    id: `msg-${String(input.sequence)}`,
+    sessionId: "session-1",
+    sessionKey: "discord:default:test",
+    sequence: input.sequence,
+    role: input.role,
+    content: input.contentText,
+    contentText: input.contentText,
+    tokenCount: 0,
+    metadata: {},
+    memoryExtractStatus: "skipped",
+    occurredAt: "2026-03-15T10:00:00.000Z",
+    createdAt: "2026-03-15T10:00:00.000Z",
+    updatedAt: "2026-03-15T10:00:00.000Z",
+  };
+}
+
+describe("friday-session-conversation-orchestrator", () => {
+  const baseFocusState: FridaySessionConversationFocusState = {
+    currentTopicFingerprint: "topic-1",
+    currentTopicSummary: "Explain the capital of France and related geography.",
+    currentTopicStartSequence: 1,
+    lastAnsweredQuestion: "What is the capital of France?",
+    lastAssistantAskedQuestion: false,
+    lastRunId: "run-1",
+    updatedAt: "2026-03-15T10:00:00.000Z",
+  };
+
+  it("classifies an unrelated question as a new topic", () => {
+    expect(classifyFridayConversationTurn({
+      task: "How do I bake sourdough bread?",
+      focusState: baseFocusState,
+    })).toBe("new_topic");
+  });
+
+  it("keeps only the active topic window for follow-up turns", () => {
+    const prepared = prepareFridayConversationTurn({
+      task: "What country is that city in?",
+      focusState: baseFocusState,
+      currentUserSequence: 5,
+      historyRecords: [
+        makeMessage({ sequence: 1, role: "user", contentText: "What is the capital of France?" }),
+        makeMessage({ sequence: 2, role: "assistant", contentText: "Paris is the capital of France." }),
+        makeMessage({ sequence: 3, role: "user", contentText: "Explain it briefly." }),
+        makeMessage({ sequence: 4, role: "assistant", contentText: "Paris is in north-central France." }),
+      ],
+    });
+
+    expect(prepared.turnKind).toBe("follow_up");
+    expect(prepared.historyMessages).toHaveLength(4);
+    expect(prepared.taskPrompt).toContain("Continue the current topic");
+  });
+
+  it("drops prior content history for a new topic", () => {
+    const prepared = prepareFridayConversationTurn({
+      task: "How do I bake sourdough bread?",
+      focusState: baseFocusState,
+      currentUserSequence: 5,
+      historyRecords: [
+        makeMessage({ sequence: 1, role: "user", contentText: "What is the capital of France?" }),
+        makeMessage({ sequence: 2, role: "assistant", contentText: "Paris is the capital of France." }),
+        makeMessage({ sequence: 3, role: "user", contentText: "Explain it briefly." }),
+        makeMessage({ sequence: 4, role: "assistant", contentText: "Paris is in north-central France." }),
+      ],
+    });
+
+    expect(prepared.turnKind).toBe("new_topic");
+    expect(prepared.historyMessages).toEqual([]);
+    expect(prepared.taskPrompt).toContain("Current question: How do I bake sourdough bread?");
+  });
+
+  it("treats explicit progress checks as status_check and avoids prior answer history", () => {
+    const prepared = prepareFridayConversationTurn({
+      task: "刚才那个任务现在进度怎么样？",
+      focusState: baseFocusState,
+      currentUserSequence: 5,
+      historyRecords: [
+        makeMessage({ sequence: 1, role: "user", contentText: "Open Facebook and sign up." }),
+        makeMessage({ sequence: 2, role: "assistant", contentText: "I delegated the task to a browser worker." }),
+      ],
+    });
+
+    expect(prepared.turnKind).toBe("status_check");
+    expect(prepared.historyMessages).toHaveLength(2);
+    expect(prepared.taskPrompt).toContain("asking for a status update");
+  });
+
+  it("persists new-topic focus state with the current sequence", () => {
+    const focus = finalizeFridayConversationFocus({
+      task: "How do I bake sourdough bread?",
+      responseText: "Use a starter and let the dough ferment overnight.",
+      runId: "run-2",
+      turnKind: "new_topic",
+      focusState: baseFocusState,
+      currentUserSequence: 9,
+      nowIso: "2026-03-15T11:00:00.000Z",
+    });
+
+    expect(focus.currentTopicSummary).toBe("How do I bake sourdough bread?");
+    expect(focus.currentTopicStartSequence).toBe(9);
+    expect(focus.lastRunId).toBe("run-2");
+    expect(focus.lastTurnKind).toBe("new_topic");
+  });
+});

--- a/test/unit/sessions/services/friday-session-service.test.ts
+++ b/test/unit/sessions/services/friday-session-service.test.ts
@@ -1114,4 +1114,46 @@ describe("FridaySessionService", () => {
       expect(resetResult.messageCount).toBe(0);
     });
   });
+
+  describe("conversation focus", () => {
+    it("persists and reads conversation focus state", async () => {
+      await service.createSession({ channel: "discord", chatId: "focus-1" });
+
+      await service.setConversationFocus("discord:default:focus-1", {
+        currentTopicFingerprint: "topic-1",
+        currentTopicSummary: "How do I bake sourdough bread?",
+        currentTopicStartSequence: 3,
+        lastAnsweredQuestion: "How do I bake sourdough bread?",
+        lastAssistantAskedQuestion: false,
+        lastRunId: "run-1",
+        lastTurnKind: "new_topic",
+        updatedAt: NOW,
+      });
+
+      const focus = await service.getConversationFocus("discord:default:focus-1");
+      expect(focus).toEqual({
+        currentTopicFingerprint: "topic-1",
+        currentTopicSummary: "How do I bake sourdough bread?",
+        currentTopicStartSequence: 3,
+        lastAnsweredQuestion: "How do I bake sourdough bread?",
+        lastAssistantAskedQuestion: false,
+        lastRunId: "run-1",
+        lastTurnKind: "new_topic",
+        updatedAt: NOW,
+      });
+    });
+
+    it("clears conversation focus on resetSession", async () => {
+      await service.createSession({ channel: "discord", chatId: "focus-reset" });
+      await service.setConversationFocus("discord:default:focus-reset", {
+        currentTopicSummary: "Existing topic",
+        updatedAt: NOW,
+      });
+
+      await service.resetSession("discord:default:focus-reset");
+
+      const focus = await service.getConversationFocus("discord:default:focus-reset");
+      expect(focus).toBeNull();
+    });
+  });
 });

--- a/ui/src/routes/agent-page.tsx
+++ b/ui/src/routes/agent-page.tsx
@@ -25,6 +25,7 @@ import {
 import { toast } from "sonner";
 import { agentApi } from "@/lib/api/agent";
 import { skillsApi } from "@/lib/api/skills";
+import { authStorage } from "@/lib/storage/auth-storage";
 import { systemApi } from "@/lib/api/system";
 import type {
   FridaySystemApprovalRule,
@@ -158,6 +159,8 @@ export function AgentPage() {
   const [remoteLabel, setRemoteLabel] = useState("");
   const [remoteFingerprint, setRemoteFingerprint] = useState("");
   const passkeysSupported = typeof PublicKeyCredential !== "undefined";
+  const operatorUserId = authStorage.getUser()?.id?.trim() || "anonymous";
+  const commandCenterSessionKey = `ui:command-center:${operatorUserId}`;
 
   const { data: session, error: sessionError } = useQuery({
     queryKey: systemKeys.session(),
@@ -276,6 +279,7 @@ export function AgentPage() {
         task: input.task,
         readOnly: input.readOnly,
         requireReview: false,
+        sessionKey: commandCenterSessionKey,
         executionContext: {
           surface: "agent_page",
           interactive: true,


### PR DESCRIPTION
## Summary\n- add session-level conversation focus state and turn classification\n- trim cross-turn history for new topics while preserving follow-ups\n- add answer alignment retry and stable command-center session keys\n\n## Verification\n- npm run typecheck\n- npm run lint\n- npx vitest run test/unit/sessions/services/friday-session-service.test.ts test/unit/sessions/services/friday-session-conversation-orchestrator.test.ts test/unit/agent/runtime/friday-agent-runtime.test.ts test/e2e/mock/friday-mock-multi-turn.e2e.test.ts\n- npm run build\n- local smoke on http://127.0.0.1:3141 with same-session follow-up and topic switch