### PR TITLE
feat: surface slow task progress across channels and UI

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -44,6 +44,8 @@ export type {
   FridayAgentRunStartedPayload,
   FridayAgentRunPlanningPayload,
   FridayAgentRunExecutingPayload,
+  FridayAgentEtaConfidence,
+  FridayAgentRunProgressPayload,
   FridayAgentToolStartPayload,
   FridayAgentToolEndPayload,
   FridayAgentRunCompletedPayload,
@@ -64,6 +66,7 @@ export type {
   CreateFridayAgentRuntimeDeps,
 } from "./runtime/friday-agent-runtime.types.js";
 export { createFridayAgentRuntime } from "./runtime/friday-agent-runtime.js";
+export { resolveFridayPublicRunUrl } from "./runtime/friday-public-run-url.js";
 
 // ─── System prompt builder ───
 

--- a/src/agent/model/friday-agent.types.ts
+++ b/src/agent/model/friday-agent.types.ts
@@ -244,6 +244,20 @@ export interface FridayAgentRunExecutingPayload {
   description: string;
 }
 
+export type FridayAgentEtaConfidence = "low" | "medium" | "high" | "unavailable";
+
+export interface FridayAgentRunProgressPayload {
+  runId: string;
+  phase: FridayAgentRunStatus;
+  elapsedMs: number;
+  activeTool?: string;
+  subagentCount: number;
+  latestSubagentId?: string;
+  activeSubagentIds?: string[];
+  eta?: number;
+  etaConfidence: FridayAgentEtaConfidence;
+}
+
 export interface FridayAgentToolStartPayload {
   runId: string;
   toolName: string;
@@ -327,6 +341,7 @@ export interface FridayAgentEventMap {
   "agent.run.started": FridayAgentRunStartedPayload;
   "agent.run.planning": FridayAgentRunPlanningPayload;
   "agent.run.executing": FridayAgentRunExecutingPayload;
+  "agent.run.progress": FridayAgentRunProgressPayload;
   "agent.run.tool_start": FridayAgentToolStartPayload;
   "agent.run.tool_end": FridayAgentToolEndPayload;
   "agent.run.completed": FridayAgentRunCompletedPayload;

--- a/src/agent/runtime/friday-agent-runtime.ts
+++ b/src/agent/runtime/friday-agent-runtime.ts
@@ -16,8 +16,10 @@ import type {
   FridayAgentActualTurn,
   FridayAgentArtifact,
   FridayAgentContentBlock,
+  FridayAgentEtaConfidence,
   FridayAgentImageBlock,
   FridayAgentMessage,
+  FridayAgentRunStatus,
   FridayAgentTestResult,
   FridayAgentToolCallRecord,
   FridayAgentToolDefinition,
@@ -175,12 +177,103 @@ export function createFridayAgentRuntime(
           ? params.principalId
           : undefined;
       const scopes = normalizeScopes(params.scopes);
+      let currentPhase: FridayAgentRunStatus = "pending";
+      let activeToolName: string | undefined;
+      let latestSubagentId: string | undefined;
+      const activeSubagentIds = new Set<string>();
 
       // Resolve per-run overrides (FIX-1)
       const requestedProviderId = normalizeDefaultRouteSentinel(params.providerId)
         ?? normalizeDefaultRouteSentinel(providerId);
       const requestedModel = normalizeDefaultRouteSentinel(params.model)
         ?? normalizeDefaultRouteSentinel(model);
+
+      function deriveEta(elapsedMs: number): { eta?: number; etaConfidence: FridayAgentEtaConfidence } {
+        if (timeoutMs > elapsedMs) {
+          return {
+            eta: timeoutMs - elapsedMs,
+            etaConfidence: "low",
+          };
+        }
+        return { etaConfidence: "unavailable" };
+      }
+
+      const emitProgressEvent = (): void => {
+        const elapsedMs = Math.max(0, Date.now() - startedAt);
+        const eta = deriveEta(elapsedMs);
+        emitRunEvent("agent.run.progress", {
+          runId,
+          phase: currentPhase,
+          elapsedMs,
+          ...(activeToolName ? { activeTool: activeToolName } : {}),
+          subagentCount: activeSubagentIds.size,
+          ...(latestSubagentId ? { latestSubagentId } : {}),
+          ...(activeSubagentIds.size > 0 ? { activeSubagentIds: [...activeSubagentIds] } : {}),
+          ...(typeof eta.eta === "number" ? { eta: eta.eta } : {}),
+          etaConfidence: eta.etaConfidence,
+        }, runId);
+      };
+
+      const handleTrackedEvent = (eventName: string, payload: Record<string, unknown>): void => {
+        switch (eventName) {
+          case "agent.run.started":
+            currentPhase = "pending";
+            break;
+          case "agent.run.planning":
+            currentPhase = "planning";
+            break;
+          case "agent.run.executing":
+            currentPhase = "executing";
+            break;
+          case "agent.run.tool_start":
+            if (typeof payload.toolName === "string" && payload.toolName.trim().length > 0) {
+              activeToolName = payload.toolName;
+            }
+            break;
+          case "agent.run.tool_end":
+            if (typeof payload.toolName === "string" && payload.toolName === activeToolName) {
+              activeToolName = undefined;
+            }
+            break;
+          case "agent.run.completed":
+            currentPhase = "completed";
+            activeToolName = undefined;
+            break;
+          case "agent.run.failed":
+            currentPhase = "failed";
+            activeToolName = undefined;
+            break;
+          case "agent.run.cancelled":
+            currentPhase = "cancelled";
+            activeToolName = undefined;
+            break;
+        }
+
+        emitRunEvent(eventName, payload, runId);
+        if (eventName !== "agent.run.text_delta" && eventName !== "agent.run.progress") {
+          emitProgressEvent();
+        }
+      };
+
+      const onSubagentSpawned = (payload: { parentRunId: string; subagentId: string }): void => {
+        if (payload.parentRunId !== runId) return;
+        activeSubagentIds.add(payload.subagentId);
+        latestSubagentId = payload.subagentId;
+        emitProgressEvent();
+      };
+
+      const onSubagentCompleted = (payload: { parentRunId: string; subagentId: string }): void => {
+        if (payload.parentRunId !== runId) return;
+        activeSubagentIds.delete(payload.subagentId);
+        latestSubagentId = payload.subagentId;
+        emitProgressEvent();
+      };
+
+      eventEmitter.on("agent.subagent.spawned", onSubagentSpawned);
+      eventEmitter.on("agent.subagent.completed", onSubagentCompleted);
+      const progressTimer = setInterval(() => {
+        emitProgressEvent();
+      }, 15_000);
 
       // 1. Create run record
       db.withWriteTransaction((writer) =>
@@ -320,7 +413,7 @@ export function createFridayAgentRuntime(
               }),
             );
 
-            emitRunEvent("agent.run.failed", {
+            handleTrackedEvent("agent.run.failed", {
               runId,
               error: {
                 code: FRIDAY_AGENT_ERROR_CODES.VALIDATION_ERROR,
@@ -329,7 +422,7 @@ export function createFridayAgentRuntime(
               durationMs,
               routeId: "agent.execute.run.policy",
               correlationId: runCorrelationId,
-            }, runId);
+            });
 
             return {
               runId,
@@ -343,12 +436,12 @@ export function createFridayAgentRuntime(
           }
         }
 
-        emitRunEvent("agent.run.started", {
+        handleTrackedEvent("agent.run.started", {
           runId,
           task: params.task,
           model: requestedModel,
           providerId: requestedProviderId,
-        }, runId);
+        });
 
         db.withWriteTransaction((writer) =>
           repo.update(writer, {
@@ -398,7 +491,7 @@ export function createFridayAgentRuntime(
               }),
             );
 
-            emitRunEvent("agent.run.failed", {
+            handleTrackedEvent("agent.run.failed", {
               runId,
               error: {
                 code: FRIDAY_AGENT_ERROR_CODES.VALIDATION_ERROR,
@@ -407,7 +500,7 @@ export function createFridayAgentRuntime(
               durationMs,
               routeId: "agent.execute.run.review",
               correlationId: runCorrelationId,
-            }, runId);
+            });
 
             return {
               runId,
@@ -437,10 +530,10 @@ export function createFridayAgentRuntime(
           }),
         );
 
-        emitRunEvent("agent.run.planning", {
+        handleTrackedEvent("agent.run.planning", {
           runId,
           message: `Planning approach (${String(planSummary.stepCount)} step(s))`,
-        }, runId);
+        });
 
         // 3. Add user message (with optional inline images for vision)
         if (params.images && params.images.length > 0) {
@@ -502,11 +595,11 @@ export function createFridayAgentRuntime(
           iterations++;
 
           // Emit executing event per iteration (IMPL-3)
-          emitRunEvent("agent.run.executing", {
+          handleTrackedEvent("agent.run.executing", {
             runId,
             step: iterations,
             description: `LLM turn ${String(iterations)}`,
-          }, runId);
+          });
 
           const { assistantText, toolUseBlocks, inputTokens, outputTokens, turnMeta } =
             await streamLlmResponse({
@@ -519,7 +612,7 @@ export function createFridayAgentRuntime(
               signal: runAbortController.signal,
               eventEmitter,
               runId,
-              emitRunEvent: (name, payload) => emitRunEvent(name, payload, runId),
+              emitRunEvent: (name, payload) => handleTrackedEvent(name, payload),
             });
 
           totalInputTokens += inputTokens;
@@ -668,14 +761,14 @@ export function createFridayAgentRuntime(
               };
               allToolCalls.push(blockedRecord);
 
-              emitRunEvent("agent.run.tool_start", {
+              handleTrackedEvent("agent.run.tool_start", {
                 runId,
                 toolName: toolUse.name,
                 toolCallId: toolUse.id,
                 params: toolUse.input,
-              }, runId);
+              });
 
-              emitRunEvent("agent.run.tool_end", {
+              handleTrackedEvent("agent.run.tool_end", {
                 runId,
                 toolName: toolUse.name,
                 toolCallId: toolUse.id,
@@ -685,7 +778,7 @@ export function createFridayAgentRuntime(
                 errorCode: FRIDAY_AGENT_ERROR_CODES.VALIDATION_ERROR,
                 routeId: "agent.execute.tool.guard",
                 correlationId: runId,
-              }, runId);
+              });
 
               toolResultBlocks.push({
                 type: "tool_result",
@@ -728,14 +821,14 @@ export function createFridayAgentRuntime(
                 };
                 allToolCalls.push(blockedRecord);
 
-                emitRunEvent("agent.run.tool_start", {
+                handleTrackedEvent("agent.run.tool_start", {
                   runId,
                   toolName: toolUse.name,
                   toolCallId: toolUse.id,
                   params: toolUse.input,
-                }, runId);
+                });
 
-                emitRunEvent("agent.run.tool_end", {
+                handleTrackedEvent("agent.run.tool_end", {
                   runId,
                   toolName: toolUse.name,
                   toolCallId: toolUse.id,
@@ -745,7 +838,7 @@ export function createFridayAgentRuntime(
                   errorCode: FRIDAY_AGENT_ERROR_CODES.VALIDATION_ERROR,
                   routeId: "agent.execute.tool.policy",
                   correlationId: runId,
-                }, runId);
+                });
 
                 toolResultBlocks.push({
                   type: "tool_result",
@@ -773,14 +866,14 @@ export function createFridayAgentRuntime(
               };
               allToolCalls.push(blockedRecord);
 
-              emitRunEvent("agent.run.tool_start", {
+              handleTrackedEvent("agent.run.tool_start", {
                 runId,
                 toolName: toolUse.name,
                 toolCallId: toolUse.id,
                 params: toolUse.input,
-              }, runId);
+              });
 
-              emitRunEvent("agent.run.tool_end", {
+              handleTrackedEvent("agent.run.tool_end", {
                 runId,
                 toolName: toolUse.name,
                 toolCallId: toolUse.id,
@@ -790,7 +883,7 @@ export function createFridayAgentRuntime(
                 errorCode: FRIDAY_AGENT_ERROR_CODES.VALIDATION_ERROR,
                 routeId: "agent.execute.tool.readonly",
                 correlationId: runId,
-              }, runId);
+              });
 
               toolResultBlocks.push({
                 type: "tool_result",
@@ -817,14 +910,14 @@ export function createFridayAgentRuntime(
               };
               allToolCalls.push(blockedRecord);
 
-              emitRunEvent("agent.run.tool_start", {
+              handleTrackedEvent("agent.run.tool_start", {
                 runId,
                 toolName: toolUse.name,
                 toolCallId: toolUse.id,
                 params: toolUse.input,
-              }, runId);
+              });
 
-              emitRunEvent("agent.run.tool_end", {
+              handleTrackedEvent("agent.run.tool_end", {
                 runId,
                 toolName: toolUse.name,
                 toolCallId: toolUse.id,
@@ -834,7 +927,7 @@ export function createFridayAgentRuntime(
                 errorCode: FRIDAY_AGENT_ERROR_CODES.VALIDATION_ERROR,
                 routeId: "agent.execute.tool.approval_required",
                 correlationId: runId,
-              }, runId);
+              });
 
               toolResultBlocks.push({
                 type: "tool_result",
@@ -856,7 +949,7 @@ export function createFridayAgentRuntime(
               principalId,
               executionContext,
               nowIso,
-              emitRunEvent: (name, payload) => emitRunEvent(name, payload, runId),
+              emitRunEvent: (name, payload) => handleTrackedEvent(name, payload),
             });
 
             allToolCalls.push(toolCallRecord);
@@ -933,7 +1026,7 @@ export function createFridayAgentRuntime(
             }),
           );
 
-          emitRunEvent("agent.run.cancelled", { runId }, runId);
+          handleTrackedEvent("agent.run.cancelled", { runId });
 
           return {
             runId,
@@ -969,6 +1062,8 @@ export function createFridayAgentRuntime(
           db.withWriteTransaction((writer) =>
             repo.update(writer, { id: runId, status: "testing" }),
           );
+          currentPhase = "testing";
+          emitProgressEvent();
 
           try {
             testResults = await selfTestService.runTests({
@@ -1042,7 +1137,7 @@ export function createFridayAgentRuntime(
               }),
             );
 
-            emitRunEvent("agent.run.failed", {
+            handleTrackedEvent("agent.run.failed", {
               runId,
               error: {
                 code: FRIDAY_AGENT_ERROR_CODES.VALIDATION_ERROR,
@@ -1051,7 +1146,7 @@ export function createFridayAgentRuntime(
               durationMs,
               routeId: "agent.execute.run.validation",
               correlationId: runCorrelationId,
-            }, runId);
+            });
 
             return {
               runId,
@@ -1113,7 +1208,7 @@ export function createFridayAgentRuntime(
             }),
           );
 
-          emitRunEvent("agent.run.failed", {
+          handleTrackedEvent("agent.run.failed", {
             runId,
             error: {
               code: outputClosureGap.errorCode,
@@ -1126,7 +1221,7 @@ export function createFridayAgentRuntime(
             },
             routeId: "agent.execute.run.output_closure",
             correlationId: runCorrelationId,
-          }, runId);
+          });
 
           return {
             runId,
@@ -1172,13 +1267,13 @@ export function createFridayAgentRuntime(
           }),
         );
 
-        emitRunEvent("agent.run.completed", {
+        handleTrackedEvent("agent.run.completed", {
           runId,
           durationMs,
           toolCallCount: allToolCalls.length,
           testsPassed,
           artifacts: persistedArtifacts.artifacts.map((a) => ({ type: a.type, path: a.path })),
-        }, runId);
+        });
 
         // ─── IMPL-6: Session mirror ───
         if (sessionMirror && responseText) {
@@ -1248,13 +1343,13 @@ export function createFridayAgentRuntime(
           }),
         );
 
-        emitRunEvent("agent.run.failed", {
+        handleTrackedEvent("agent.run.failed", {
           runId,
           error: { code: errorCode, message: errorMessage },
           durationMs,
           routeId: "agent.execute.run.unhandled",
           correlationId: runCorrelationId,
-        }, runId);
+        });
 
         return {
           runId,
@@ -1268,6 +1363,9 @@ export function createFridayAgentRuntime(
       } finally {
         clearTimeout(abortTimer);
         params.signal?.removeEventListener("abort", onExternalAbort);
+        clearInterval(progressTimer);
+        eventEmitter.off("agent.subagent.spawned", onSubagentSpawned);
+        eventEmitter.off("agent.subagent.completed", onSubagentCompleted);
         runSeqCounters.delete(runId);
       }
     },

--- a/src/agent/runtime/friday-public-run-url.ts
+++ b/src/agent/runtime/friday-public-run-url.ts
@@ -1,0 +1,17 @@
+export function resolveFridayPublicRunUrl(
+  runId: string,
+  baseUrl = process.env.FRIDAY_PUBLIC_APP_BASE_URL,
+): string | undefined {
+  const normalizedBase = typeof baseUrl === "string" ? baseUrl.trim() : "";
+  if (!normalizedBase) {
+    return undefined;
+  }
+
+  try {
+    const url = new URL("/command-center", normalizedBase.endsWith("/") ? normalizedBase : `${normalizedBase}/`);
+    url.searchParams.set("runId", runId);
+    return url.toString();
+  } catch {
+    return undefined;
+  }
+}

--- a/src/channels/friday-channel-slow-task-notifier.ts
+++ b/src/channels/friday-channel-slow-task-notifier.ts
@@ -1,0 +1,158 @@
+import type { FridayAgentEventEmitter, FridayAgentEventMap } from "#agent";
+import type { FridayChannelRegistry } from "./friday-channel-registry.js";
+
+interface FridaySlowTaskSnapshot {
+  elapsedMs: number;
+  phase: string;
+  activeTool?: string;
+  subagentCount: number;
+  latestSubagentId?: string;
+  eta?: number;
+  etaConfidence?: "low" | "medium" | "high" | "unavailable";
+}
+
+export interface FridayChannelSlowTaskNotifierOptions {
+  eventEmitter: FridayAgentEventEmitter;
+  channelRegistry: FridayChannelRegistry;
+  channelKind: string;
+  chatId: string;
+  replyTo?: string;
+  runId: string;
+  publicRunUrl?: string;
+  nowMs?: () => number;
+  setTimeoutFn?: typeof setTimeout;
+  clearTimeoutFn?: typeof clearTimeout;
+}
+
+export interface FridayChannelSlowTaskNotifier {
+  stop(): void;
+}
+
+function formatDuration(valueMs: number): string {
+  const totalSeconds = Math.max(0, Math.floor(valueMs / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes < 1) return `${seconds}s`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 1) return `${minutes}m ${seconds}s`;
+  return `${hours}h ${minutes % 60}m`;
+}
+
+function buildSlowTaskMessage(input: {
+  runId: string;
+  snapshot: FridaySlowTaskSnapshot;
+  publicRunUrl?: string;
+}): string {
+  const etaText = typeof input.snapshot.eta === "number"
+    ? `up to ${formatDuration(input.snapshot.eta)} (${input.snapshot.etaConfidence ?? "low"} confidence)`
+    : "ETA unavailable";
+  const linkLine = input.publicRunUrl
+    ? `Watch live: ${input.publicRunUrl}`
+    : `Track with runId: ${input.runId}`;
+
+  return [
+    `Still working on your request after ${formatDuration(input.snapshot.elapsedMs)}.`,
+    `Phase: ${input.snapshot.phase}`,
+    `Active tool: ${input.snapshot.activeTool ?? "none"}`,
+    `Subagents: ${String(input.snapshot.subagentCount)}`,
+    `ETA: ${etaText}`,
+    linkLine,
+  ].join("\n");
+}
+
+export function createFridayChannelSlowTaskNotifier(
+  options: FridayChannelSlowTaskNotifierOptions,
+): FridayChannelSlowTaskNotifier {
+  const nowMs = options.nowMs ?? (() => Date.now());
+  const setTimeoutFn = options.setTimeoutFn ?? setTimeout;
+  const clearTimeoutFn = options.clearTimeoutFn ?? clearTimeout;
+  const startedAtMs = nowMs();
+
+  let snapshot: FridaySlowTaskSnapshot = {
+    elapsedMs: 0,
+    phase: "pending",
+    subagentCount: 0,
+    etaConfidence: "unavailable",
+  };
+  let stopped = false;
+  let firstNotificationSent = false;
+  let lastSentPhase: string | undefined;
+  let heartbeatTimer: ReturnType<typeof setTimeout> | undefined;
+  let initialTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const sendUpdate = async (): Promise<void> => {
+    if (stopped) return;
+    firstNotificationSent = true;
+    lastSentPhase = snapshot.phase;
+    await options.channelRegistry.send(options.channelKind, {
+      chatId: options.chatId,
+      text: buildSlowTaskMessage({
+        runId: options.runId,
+        snapshot: {
+          ...snapshot,
+          elapsedMs: Math.max(snapshot.elapsedMs, nowMs() - startedAtMs),
+        },
+        publicRunUrl: options.publicRunUrl,
+      }),
+      replyTo: options.replyTo,
+    });
+  };
+
+  const scheduleHeartbeat = (): void => {
+    if (stopped) return;
+    heartbeatTimer = setTimeoutFn(() => {
+      void sendUpdate()
+        .catch(() => undefined)
+        .finally(() => {
+          scheduleHeartbeat();
+        });
+    }, 60_000);
+  };
+
+  initialTimer = setTimeoutFn(() => {
+    void sendUpdate()
+      .catch(() => undefined)
+      .finally(() => {
+        scheduleHeartbeat();
+      });
+  }, 30_000);
+
+  const onProgress = (payload: FridayAgentEventMap["agent.run.progress"]): void => {
+    if (payload.runId !== options.runId) return;
+    snapshot = {
+      elapsedMs: payload.elapsedMs,
+      phase: payload.phase,
+      activeTool: payload.activeTool,
+      subagentCount: payload.subagentCount,
+      latestSubagentId: payload.latestSubagentId,
+      eta: payload.eta,
+      etaConfidence: payload.etaConfidence,
+    };
+    if (firstNotificationSent && snapshot.phase !== lastSentPhase) {
+      void sendUpdate().catch(() => undefined);
+    }
+  };
+
+  const stop = (): void => {
+    if (stopped) return;
+    stopped = true;
+    if (initialTimer) clearTimeoutFn(initialTimer);
+    if (heartbeatTimer) clearTimeoutFn(heartbeatTimer);
+    options.eventEmitter.off("agent.run.progress", onProgress);
+    options.eventEmitter.off("agent.run.completed", stopOnTerminal);
+    options.eventEmitter.off("agent.run.failed", stopOnTerminal);
+    options.eventEmitter.off("agent.run.cancelled", stopOnTerminal);
+  };
+
+  const stopOnTerminal = (payload: { runId: string }): void => {
+    if (payload.runId !== options.runId) return;
+    stop();
+  };
+
+  options.eventEmitter.on("agent.run.progress", onProgress);
+  options.eventEmitter.on("agent.run.completed", stopOnTerminal);
+  options.eventEmitter.on("agent.run.failed", stopOnTerminal);
+  options.eventEmitter.on("agent.run.cancelled", stopOnTerminal);
+
+  return { stop };
+}

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -97,6 +97,14 @@ export { createFridayChannelTypingController } from "./friday-channel-typing-con
 export type { FridayChannelInboundDebouncer, CreateInboundDebouncerOptions } from "./friday-channel-inbound-debouncer.js";
 export { createFridayChannelInboundDebouncer } from "./friday-channel-inbound-debouncer.js";
 
+// ─── Slow Task Notifier ───
+
+export type {
+  FridayChannelSlowTaskNotifier,
+  FridayChannelSlowTaskNotifierOptions,
+} from "./friday-channel-slow-task-notifier.js";
+export { createFridayChannelSlowTaskNotifier } from "./friday-channel-slow-task-notifier.js";
+
 // ─── Channel Implementations ───
 
 export { createFridayQqChannel } from "./qq/friday-qq-channel.js";

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -168,6 +168,8 @@ import {
 } from "#channels";
 import type { FridayChannelMessage } from "#channels";
 import { createFridayChannelInboundDebouncer, createFridayChannelTypingController, sanitizeChannelInput } from "#channels";
+import { createFridayChannelSlowTaskNotifier } from "../channels/friday-channel-slow-task-notifier.js";
+import { resolveFridayPublicRunUrl } from "../agent/runtime/friday-public-run-url.js";
 import {
   createFridaySatelliteRepository,
   createFridaySatelliteRuntime,
@@ -3792,6 +3794,16 @@ export async function createFridayHub(
           typingController.start();
 
           void (async () => {
+            const runId = idGenerator();
+            const slowTaskNotifier = createFridayChannelSlowTaskNotifier({
+              eventEmitter: agentEventEmitter,
+              channelRegistry,
+              channelKind: msg.channelKind,
+              chatId: msg.chatId,
+              replyTo: msg.id,
+              runId,
+              publicRunUrl: resolveFridayPublicRunUrl(runId),
+            });
             try {
               const inboundMessage = await hubSessionService.addMessage(sessionKey, {
                 role: "user",
@@ -3848,6 +3860,7 @@ export async function createFridayHub(
 
               const result = await agentRuntime.executeRun({
                 task: text,
+                runId,
                 taskPrompt: preparedTurn.taskPrompt,
                 images: msg.images,
                 sessionKey,
@@ -3975,6 +3988,7 @@ export async function createFridayHub(
                   });
                 });
             } finally {
+              slowTaskNotifier.stop();
               typingController.stopDispatch();
             }
           })()

--- a/test/unit/agent/runtime/friday-agent-runtime.test.ts
+++ b/test/unit/agent/runtime/friday-agent-runtime.test.ts
@@ -1695,6 +1695,62 @@ describe("FridayAgentRuntime", () => {
     expect(events[1].event).toBe("completed");
   });
 
+  it("emits progress events with phase, active tool, and ETA metadata", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(NOW));
+    try {
+      const llmClient = createMockLlmClient([
+        [
+          { type: "tool_use", id: "call-1", name: "echo", input: { message: "hello" } },
+          { type: "message_end", stopReason: "tool_use", inputTokens: 5, outputTokens: 3 },
+        ],
+        [
+          { type: "text_delta", text: "done" },
+          { type: "message_end", stopReason: "end_turn", inputTokens: 7, outputTokens: 4 },
+        ],
+      ]);
+
+      const emitter = createFridayAgentEventEmitter();
+      const progressEvents: Array<{
+        phase: string;
+        activeTool?: string;
+        subagentCount: number;
+        etaConfidence: string;
+      }> = [];
+      emitter.on("agent.run.progress", (payload) => {
+        progressEvents.push({
+          phase: payload.phase,
+          activeTool: payload.activeTool,
+          subagentCount: payload.subagentCount,
+          etaConfidence: payload.etaConfidence,
+        });
+      });
+
+      const runtime = createFridayAgentRuntime({
+        db,
+        llmClient,
+        model: "test-model",
+        providerId: "test-provider",
+        systemPrompt: "You are a test agent.",
+        tools: [createEchoTool()],
+        eventEmitter: emitter,
+        idGenerator,
+        nowIso: () => NOW,
+      });
+
+      await runtime.executeRun({ task: "Progress test" });
+
+      expect(progressEvents.length).toBeGreaterThan(0);
+      expect(progressEvents.some((event) => event.phase === "executing")).toBe(true);
+      expect(progressEvents.some((event) => event.activeTool === "echo")).toBe(true);
+      expect(progressEvents.at(-1)?.phase).toBe("completed");
+      expect(progressEvents.every((event) => event.subagentCount === 0)).toBe(true);
+      expect(progressEvents.every((event) => event.etaConfidence === "low" || event.etaConfidence === "unavailable")).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   // ─── Unknown tool ───
 
   it("returns error for unknown tool calls", async () => {

--- a/test/unit/agent/runtime/friday-public-run-url.test.ts
+++ b/test/unit/agent/runtime/friday-public-run-url.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { resolveFridayPublicRunUrl } from "#agent";
+
+describe("resolveFridayPublicRunUrl", () => {
+  it("builds a command-center URL when a public app base URL is configured", () => {
+    expect(resolveFridayPublicRunUrl("run-123", "https://friday.example.com")).toBe(
+      "https://friday.example.com/command-center?runId=run-123",
+    );
+  });
+
+  it("returns undefined when the public app base URL is missing", () => {
+    expect(resolveFridayPublicRunUrl("run-123", undefined)).toBeUndefined();
+    expect(resolveFridayPublicRunUrl("run-123", "")).toBeUndefined();
+  });
+
+  it("returns undefined when the public app base URL is invalid", () => {
+    expect(resolveFridayPublicRunUrl("run-123", "not a url")).toBeUndefined();
+  });
+});

--- a/test/unit/channels/friday-channel-slow-task-notifier.test.ts
+++ b/test/unit/channels/friday-channel-slow-task-notifier.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createFridayChannelRegistry,
+  createFridayChannelSlowTaskNotifier,
+  type FridayChannelPlugin,
+} from "#channels";
+import { createFridayAgentEventEmitter } from "#agent";
+
+function createMockPlugin(kind = "discord"): FridayChannelPlugin {
+  return {
+    kind,
+    init: vi.fn(async () => {}),
+    start: vi.fn(async () => {}),
+    stop: vi.fn(async () => {}),
+    send: vi.fn(async () => ({ messageId: "sent-1" })),
+  };
+}
+
+describe("FridayChannelSlowTaskNotifier", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("sends the first slow-task update after 30 seconds", async () => {
+    const registry = createFridayChannelRegistry();
+    const plugin = createMockPlugin();
+    registry.register(plugin);
+    await registry.startAll(() => {});
+
+    const emitter = createFridayAgentEventEmitter();
+    createFridayChannelSlowTaskNotifier({
+      eventEmitter: emitter,
+      channelRegistry: registry,
+      channelKind: "discord",
+      chatId: "chat-1",
+      runId: "run-1",
+      publicRunUrl: "https://friday.example.com/command-center?runId=run-1",
+    });
+
+    emitter.emit("agent.run.progress", {
+      runId: "run-1",
+      phase: "executing",
+      elapsedMs: 31_000,
+      activeTool: "browser",
+      subagentCount: 1,
+      latestSubagentId: "sub-1",
+      activeSubagentIds: ["sub-1"],
+      eta: 45_000,
+      etaConfidence: "low",
+    });
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(plugin.send).toHaveBeenCalledTimes(1);
+    expect(plugin.send).toHaveBeenCalledWith(expect.objectContaining({
+      chatId: "chat-1",
+      text: expect.stringContaining("Still working on your request after"),
+    }));
+    expect(plugin.send).toHaveBeenCalledWith(expect.objectContaining({
+      text: expect.stringContaining("Active tool: browser"),
+    }));
+    expect(plugin.send).toHaveBeenCalledWith(expect.objectContaining({
+      text: expect.stringContaining("Watch live: https://friday.example.com/command-center?runId=run-1"),
+    }));
+  });
+
+  it("sends an immediate follow-up when the phase changes after the first notification", async () => {
+    const registry = createFridayChannelRegistry();
+    const plugin = createMockPlugin();
+    registry.register(plugin);
+    await registry.startAll(() => {});
+
+    const emitter = createFridayAgentEventEmitter();
+    createFridayChannelSlowTaskNotifier({
+      eventEmitter: emitter,
+      channelRegistry: registry,
+      channelKind: "discord",
+      chatId: "chat-1",
+      runId: "run-2",
+    });
+
+    emitter.emit("agent.run.progress", {
+      runId: "run-2",
+      phase: "executing",
+      elapsedMs: 31_000,
+      activeTool: "exec",
+      subagentCount: 0,
+      etaConfidence: "unavailable",
+    });
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(plugin.send).toHaveBeenCalledTimes(1);
+
+    emitter.emit("agent.run.progress", {
+      runId: "run-2",
+      phase: "testing",
+      elapsedMs: 46_000,
+      subagentCount: 0,
+      etaConfidence: "unavailable",
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(plugin.send).toHaveBeenCalledTimes(2);
+    expect(plugin.send).toHaveBeenLastCalledWith(expect.objectContaining({
+      text: expect.stringContaining("Phase: testing"),
+    }));
+  });
+
+  it("stops notifying once the run reaches a terminal state", async () => {
+    const registry = createFridayChannelRegistry();
+    const plugin = createMockPlugin();
+    registry.register(plugin);
+    await registry.startAll(() => {});
+
+    const emitter = createFridayAgentEventEmitter();
+    createFridayChannelSlowTaskNotifier({
+      eventEmitter: emitter,
+      channelRegistry: registry,
+      channelKind: "discord",
+      chatId: "chat-1",
+      runId: "run-3",
+    });
+
+    emitter.emit("agent.run.progress", {
+      runId: "run-3",
+      phase: "executing",
+      elapsedMs: 31_000,
+      subagentCount: 0,
+      etaConfidence: "unavailable",
+    });
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(plugin.send).toHaveBeenCalledTimes(1);
+
+    emitter.emit("agent.run.completed", {
+      runId: "run-3",
+      durationMs: 31_000,
+      toolCallCount: 1,
+      testsPassed: true,
+      artifacts: [],
+    });
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(plugin.send).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/src/hooks/use-agent-run-events.ts
+++ b/ui/src/hooks/use-agent-run-events.ts
@@ -33,6 +33,18 @@ export interface SubagentNodeViewModel {
   durationMs?: number;
 }
 
+export interface RunProgressViewModel {
+  phase?: AgentRunStatus;
+  startedAt?: string;
+  elapsedMs: number;
+  activeTool?: string;
+  subagentCount: number;
+  latestSubagentId?: string;
+  activeSubagentIds: string[];
+  eta?: number;
+  etaConfidence: "low" | "medium" | "high" | "unavailable";
+}
+
 // ─── Options + Result ───
 
 export interface UseAgentRunEventsOptions {
@@ -49,6 +61,7 @@ export interface UseAgentRunEventsResult {
   events: AgentRunStreamEvent[];
   toolCalls: ToolCallViewModel[];
   subagents: SubagentNodeViewModel[];
+  progress: RunProgressViewModel;
   errorMessage?: string;
   reconnect: () => void;
 }
@@ -92,6 +105,12 @@ export function useAgentRunEvents(
   const [events, setEvents] = React.useState<AgentRunStreamEvent[]>([]);
   const [toolCalls, setToolCalls] = React.useState<ToolCallViewModel[]>([]);
   const [subagents, setSubagents] = React.useState<SubagentNodeViewModel[]>([]);
+  const [progress, setProgress] = React.useState<RunProgressViewModel>({
+    elapsedMs: 0,
+    subagentCount: 0,
+    activeSubagentIds: [],
+    etaConfidence: "unavailable",
+  });
   const [errorMessage, setErrorMessage] = React.useState<string | undefined>();
   const [reconnectTrigger, setReconnectTrigger] = React.useState(0);
 
@@ -106,6 +125,21 @@ export function useAgentRunEvents(
   const reconnect = React.useCallback(() => {
     setReconnectTrigger((n) => n + 1);
   }, []);
+
+  React.useEffect(() => {
+    if (!progress.startedAt) return;
+    if (isTerminalStatus(status)) return;
+    const interval = window.setInterval(() => {
+      setProgress((prev) => {
+        if (!prev.startedAt) return prev;
+        return {
+          ...prev,
+          elapsedMs: Math.max(prev.elapsedMs, Date.now() - new Date(prev.startedAt).getTime()),
+        };
+      });
+    }, 1000);
+    return () => window.clearInterval(interval);
+  }, [progress.startedAt, status]);
 
   React.useEffect(() => {
     if (!runId || !enabled) {
@@ -190,6 +224,14 @@ export function useAgentRunEvents(
           const eventType = parsed.type;
           const eventTime = parsed.emittedAt ?? parsed.timestamp ?? new Date().toISOString();
 
+          if (eventType === "agent.run.started") {
+            setProgress((prev) => ({
+              ...prev,
+              startedAt: eventTime,
+              elapsedMs: 0,
+            }));
+          }
+
           // Text delta
           if (eventType === "agent.run.text_delta" && parsed.delta) {
             setOutputText((prev) => prev + parsed.delta);
@@ -204,6 +246,21 @@ export function useAgentRunEvents(
               onTerminalRef.current?.(parsed.status);
               return;
             }
+          }
+
+          if (eventType === "agent.run.progress") {
+            setProgress((prev) => ({
+              ...prev,
+              ...(parsed.phase ? { phase: parsed.phase } : {}),
+              ...(typeof parsed.elapsedMs === "number" ? { elapsedMs: parsed.elapsedMs } : {}),
+              ...(typeof parsed.activeTool === "string" ? { activeTool: parsed.activeTool } : { activeTool: undefined }),
+              ...(typeof parsed.subagentCount === "number" ? { subagentCount: parsed.subagentCount } : {}),
+              ...(typeof parsed.latestSubagentId === "string" ? { latestSubagentId: parsed.latestSubagentId } : {}),
+              ...(Array.isArray(parsed.activeSubagentIds) ? { activeSubagentIds: parsed.activeSubagentIds } : {}),
+              ...(typeof parsed.eta === "number" ? { eta: parsed.eta } : { eta: undefined }),
+              etaConfidence: parsed.etaConfidence ?? prev.etaConfidence,
+              startedAt: prev.startedAt ?? eventTime,
+            }));
           }
 
           // Tool start
@@ -274,6 +331,14 @@ export function useAgentRunEvents(
                 },
               ];
             });
+            setProgress((prev) => ({
+              ...prev,
+              subagentCount: Math.max(prev.subagentCount, prev.activeSubagentIds.length + 1),
+              latestSubagentId: parsed.subagentId,
+              activeSubagentIds: prev.activeSubagentIds.includes(parsed.subagentId!)
+                ? prev.activeSubagentIds
+                : [...prev.activeSubagentIds, parsed.subagentId!],
+            }));
           }
 
           // Subagent completed
@@ -290,6 +355,12 @@ export function useAgentRunEvents(
                   : sa,
               ),
             );
+            setProgress((prev) => ({
+              ...prev,
+              latestSubagentId: parsed.subagentId,
+              activeSubagentIds: prev.activeSubagentIds.filter((id) => id !== parsed.subagentId),
+              subagentCount: Math.max(0, prev.activeSubagentIds.filter((id) => id !== parsed.subagentId).length),
+            }));
           }
 
           // Terminal events
@@ -330,6 +401,12 @@ export function useAgentRunEvents(
     setEvents([]);
     setToolCalls([]);
     setSubagents([]);
+    setProgress({
+      elapsedMs: 0,
+      subagentCount: 0,
+      activeSubagentIds: [],
+      etaConfidence: "unavailable",
+    });
     setStatus(null);
     setErrorMessage(undefined);
     seenSeqRef.current = new Set();
@@ -349,6 +426,7 @@ export function useAgentRunEvents(
     events,
     toolCalls,
     subagents,
+    progress,
     errorMessage,
     reconnect,
   };

--- a/ui/src/lib/api/types.ts
+++ b/ui/src/lib/api/types.ts
@@ -646,6 +646,14 @@ export interface AgentRunStreamEvent {
   seq?: number;
   emittedAt?: string;
   replayed?: boolean;
+  phase?: AgentRunStatus;
+  elapsedMs?: number;
+  activeTool?: string;
+  subagentCount?: number;
+  latestSubagentId?: string;
+  activeSubagentIds?: string[];
+  eta?: number;
+  etaConfidence?: "low" | "medium" | "high" | "unavailable";
   // text_delta
   delta?: string;
   // tool events

--- a/ui/src/routes/agent-page.tsx
+++ b/ui/src/routes/agent-page.tsx
@@ -10,7 +10,7 @@ import {
   startAuthentication,
   startRegistration,
 } from "@simplewebauthn/browser";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import {
   AlertTriangle,
   AppWindow,
@@ -78,6 +78,17 @@ function formatRelative(value?: string): string {
   if (hours < 24) return `${hours}h ago`;
   const days = Math.floor(hours / 24);
   return `${days}d ago`;
+}
+
+function formatDuration(valueMs?: number): string {
+  if (typeof valueMs !== "number" || !Number.isFinite(valueMs) || valueMs < 0) return "0s";
+  const totalSeconds = Math.floor(valueMs / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes < 1) return `${seconds}s`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 1) return `${minutes}m ${seconds}s`;
+  return `${hours}h ${minutes % 60}m`;
 }
 
 function mapTone(status?: string): "neutral" | "success" | "warning" | "danger" {
@@ -152,6 +163,7 @@ function scoreStarterSkill(input: {
 
 export function AgentPage() {
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const queryClient = useQueryClient();
   const [task, setTask] = useState("");
   const [readOnly, setReadOnly] = useState(false);
@@ -161,6 +173,7 @@ export function AgentPage() {
   const passkeysSupported = typeof PublicKeyCredential !== "undefined";
   const operatorUserId = authStorage.getUser()?.id?.trim() || "anonymous";
   const commandCenterSessionKey = `ui:command-center:${operatorUserId}`;
+  const runIdFromUrl = searchParams.get("runId");
 
   const { data: session, error: sessionError } = useQuery({
     queryKey: systemKeys.session(),
@@ -200,7 +213,7 @@ export function AgentPage() {
   const { data: runs = [], refetch: refetchRuns } = useQuery({
     queryKey: ["agent-os", "runs"],
     queryFn: () => agentApi.listRuns({ limit: 8 }),
-    refetchInterval: 20_000,
+    refetchInterval: 5_000,
   });
 
   const { data: starterSkills = [] } = useQuery({
@@ -253,6 +266,21 @@ export function AgentPage() {
       .slice(0, 3),
     [approvalCards.length, blockedApprovalEvents.length, starterSkills, task, state?.health.status],
   );
+
+  useEffect(() => {
+    if (runIdFromUrl && runIdFromUrl !== currentRunId) {
+      setCurrentRunId(runIdFromUrl);
+    }
+  }, [currentRunId, runIdFromUrl]);
+
+  useEffect(() => {
+    if (!currentRunId || currentRunId === runIdFromUrl) return;
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      next.set("runId", currentRunId);
+      return next;
+    }, { replace: true });
+  }, [currentRunId, runIdFromUrl, setSearchParams]);
 
   useEffect(() => {
     if (currentRunId) return;
@@ -566,6 +594,40 @@ export function AgentPage() {
             </StatusPill>
           ) : undefined}
         >
+          <div className="mb-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+            <Metric
+              label="Phase"
+              value={runEvents.progress.phase ?? runEvents.status ?? "idle"}
+              tone={mapTone(runEvents.progress.phase ?? runEvents.status ?? "neutral")}
+            />
+            <Metric
+              label="Elapsed"
+              value={formatDuration(runEvents.progress.elapsedMs)}
+              tone={runEvents.progress.elapsedMs >= 30_000 ? "warning" : "neutral"}
+            />
+            <Metric
+              label="ETA"
+              value={
+                typeof runEvents.progress.eta === "number"
+                  ? `up to ${formatDuration(runEvents.progress.eta)}`
+                  : "ETA unavailable"
+              }
+            />
+            <Metric
+              label="Active Tool"
+              value={runEvents.progress.activeTool ?? "none"}
+            />
+            <Metric
+              label="Subagents"
+              value={String(runEvents.progress.subagentCount)}
+              tone={runEvents.progress.subagentCount > 0 ? "success" : "neutral"}
+            />
+            <Metric
+              label="Run Link"
+              value={currentRunId ? `/command-center?runId=${currentRunId}` : "no active run"}
+              mono
+            />
+          </div>
           <div className="grid gap-4 lg:grid-cols-[1.25fr_0.75fr]">
             <div className="rounded-[24px] border border-white/10 bg-black/20 p-4">
               <div className="mb-3 flex items-center justify-between gap-3">
@@ -593,12 +655,13 @@ export function AgentPage() {
             <div className="space-y-3">
               <div className="rounded-[24px] border border-white/10 bg-black/20 p-4">
                 <p className="text-xs font-semibold uppercase tracking-[0.18em] text-white/40">
-                  Tools
+                  Tools and Subagents
                 </p>
                 <div className="mt-3 space-y-2">
-                  {runEvents.toolCalls.length === 0 ? (
+                  {runEvents.toolCalls.length === 0 && runEvents.subagents.length === 0 ? (
                     <p className="text-sm text-white/50">No tool activity yet.</p>
-                  ) : runEvents.toolCalls.slice(-4).map((tool) => (
+                  ) : null}
+                  {runEvents.toolCalls.slice(-4).map((tool) => (
                     <div key={tool.id} className="rounded-2xl border border-white/[0.08] bg-white/[0.04] p-3">
                       <div className="flex items-center justify-between gap-3">
                         <span className="font-medium text-white">{tool.toolName}</span>
@@ -627,6 +690,19 @@ export function AgentPage() {
                           Fallback: {tool.fallbackReason}
                         </p>
                       ) : null}
+                    </div>
+                  ))}
+                  {runEvents.subagents.slice(-4).map((subagent) => (
+                    <div key={subagent.id} className="rounded-2xl border border-emerald-300/10 bg-emerald-300/[0.05] p-3">
+                      <div className="flex items-center justify-between gap-3">
+                        <span className="font-medium text-white">subagent</span>
+                        <StatusPill tone={mapTone(subagent.status)}>{subagent.status}</StatusPill>
+                      </div>
+                      <p className="mt-2 text-xs text-white/50">{subagent.task || subagent.id}</p>
+                      <p className="mt-2 text-[11px] text-white/35">
+                        Started {formatTimestamp(subagent.startedAt)}
+                        {subagent.durationMs ? ` · ${formatDuration(subagent.durationMs)}` : ""}
+                      </p>
                     </div>
                   ))}
                 </div>

--- a/ui/src/routes/assistant-page.tsx
+++ b/ui/src/routes/assistant-page.tsx
@@ -17,6 +17,8 @@ import {
   Waypoints,
 } from "lucide-react";
 import { toast } from "sonner";
+import { useAgentRunEvents } from "@/hooks/use-agent-run-events";
+import { agentApi } from "@/lib/api/agent";
 import { fleetApi } from "@/lib/api/fleet";
 import {
   marketplaceApi,
@@ -42,6 +44,7 @@ import type {
   FridayWorkflowOverview,
 } from "@/lib/api/system-types";
 import type {
+  AgentRunRecord,
   FridayFleetOverviewResponse,
   FridayFleetSatelliteCard,
   FridayPendingSatellitePairingRequest,
@@ -127,6 +130,17 @@ function formatRelative(value?: string): string {
   if (hours < 24) return `${hours}h ago`;
   const days = Math.floor(hours / 24);
   return `${days}d ago`;
+}
+
+function formatRunDuration(valueMs?: number): string {
+  if (typeof valueMs !== "number" || !Number.isFinite(valueMs) || valueMs < 0) return "0s";
+  const totalSeconds = Math.floor(valueMs / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes < 1) return `${seconds}s`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 1) return `${minutes}m ${seconds}s`;
+  return `${hours}h ${minutes % 60}m`;
 }
 
 function mapTone(
@@ -279,6 +293,12 @@ export function AssistantPage() {
     queryKey: ["assistant-shell", "loop-runs"],
     queryFn: () => systemApi.listAgentLoopRuns({ limit: 8 }),
     refetchInterval: 20_000,
+  });
+
+  const agentRunsQuery = useQuery({
+    queryKey: ["assistant-shell", "agent-runs"],
+    queryFn: () => agentApi.listRuns({ limit: 8 }),
+    refetchInterval: 5_000,
   });
 
   const workflowsQuery = useQuery({
@@ -604,6 +624,16 @@ export function AssistantPage() {
   const marketplaceAssets = marketplaceAssetsQuery.data ?? [];
   const marketplaceCreators = marketplaceCreatorsQuery.data ?? [];
   const marketplaceRequests = marketplaceRequestsQuery.data ?? [];
+  const activeAssistantRun = useMemo(
+    () =>
+      (agentRunsQuery.data ?? []).find((run) =>
+        ["pending", "planning", "executing", "testing", "fixing"].includes(run.status),
+      ) ?? null,
+    [agentRunsQuery.data],
+  );
+  const assistantRunEvents = useAgentRunEvents(activeAssistantRun?.id ?? null, {
+    enabled: activeAssistantRun !== null,
+  });
 
   const degradedSatellites = useMemo(
     () =>
@@ -820,6 +850,11 @@ export function AssistantPage() {
           </div>
 
           <div className="space-y-6">
+            <AssistantRunPulseCard
+              run={activeAssistantRun}
+              progress={assistantRunEvents.progress}
+            />
+
             <RecoveryCommandCenterSection paths={recoveryPaths} />
 
             <IssueInboxSection
@@ -848,6 +883,51 @@ export function AssistantPage() {
         </div>
       </ShellCard>
     </div>
+  );
+}
+
+function AssistantRunPulseCard(props: {
+  run: AgentRunRecord | null;
+  progress: {
+    phase?: string;
+    elapsedMs: number;
+    subagentCount: number;
+    activeTool?: string;
+    eta?: number;
+  };
+}) {
+  if (!props.run) {
+    return (
+      <ShellCard eyebrow="Live task pulse" title="No operator run is active right now">
+        <p className="text-sm text-white/58">
+          Assistant will surface active operator work here once a long-running task is in flight.
+        </p>
+      </ShellCard>
+    );
+  }
+
+  return (
+    <ShellCard
+      eyebrow="Live task pulse"
+      title="Assistant keeps the operator run visible while work is in progress"
+      aside={<StatusPill tone={mapTone(props.progress.phase ?? props.run.status)}>{props.progress.phase ?? props.run.status}</StatusPill>}
+    >
+      <div className="grid gap-3 sm:grid-cols-2">
+        <MetricStat label="Elapsed" value={formatRunDuration(props.progress.elapsedMs)} tone={props.progress.elapsedMs >= 30_000 ? "warning" : "neutral"} />
+        <MetricStat label="ETA" value={typeof props.progress.eta === "number" ? `up to ${formatRunDuration(props.progress.eta)}` : "unknown"} />
+        <MetricStat label="Subagents" value={String(props.progress.subagentCount)} tone={props.progress.subagentCount > 0 ? "success" : "neutral"} />
+        <MetricStat label="Active tool" value={props.progress.activeTool ?? "none"} />
+      </div>
+      <p className="mt-4 text-sm leading-6 text-white/62">{props.run.task}</p>
+      <div className="mt-4 flex flex-wrap gap-2">
+        <Link
+          className="inline-flex items-center rounded-2xl bg-white/10 px-4 py-2 text-sm text-white hover:bg-white/[0.14]"
+          to={`/command-center?runId=${encodeURIComponent(props.run.id)}`}
+        >
+          Open live run
+        </Link>
+      </div>
+    </ShellCard>
   );
 }
 


### PR DESCRIPTION
## Summary
- emit runtime progress events with elapsed, phase, active tool, subagent count, and ETA
- notify channels when tasks run past 30 seconds and expose live run links
- surface live run progress in command center and assistant views

## Validation
- npm run typecheck
- npm run lint
- npm run build
- npx vitest run test/unit/agent/runtime/friday-public-run-url.test.ts test/unit/channels/friday-channel-slow-task-notifier.test.ts test/unit/agent/runtime/friday-agent-runtime.test.ts
- live smoke: API slow run, command-center replay, assistant live pulse