### PR TITLE
feat: coordinate delegated agent tasks

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -62,11 +62,14 @@ export type {
   FridayAgentRuntime,
   FridayAgentRuntimeResult,
   FridayAgentConversationContext,
+  FridayAgentDelegationRequest,
+  FridayAgentDelegationResult,
   FridayAgentExecutionContext,
   CreateFridayAgentRuntimeDeps,
 } from "./runtime/friday-agent-runtime.types.js";
 export { createFridayAgentRuntime } from "./runtime/friday-agent-runtime.js";
 export { resolveFridayPublicRunUrl } from "./runtime/friday-public-run-url.js";
+export { shouldDelegateFridayAgentTask } from "./runtime/friday-agent-delegation-policy.js";
 
 // ─── System prompt builder ───
 
@@ -214,6 +217,15 @@ export type {
   FridayAgentCapabilitiesSnapshot,
 } from "./tools/friday-agent-capabilities-tool.js";
 export { createFridayAgentCapabilitiesTool } from "./tools/friday-agent-capabilities-tool.js";
+
+// ─── Task status tool ───
+
+export type {
+  CreateFridayAgentTaskStatusToolOptions,
+  FridayAgentTaskStatusSnapshot,
+  FridayAgentTaskStatusSubagentSnapshot,
+} from "./tools/friday-agent-task-status-tool.js";
+export { createFridayAgentTaskStatusTool } from "./tools/friday-agent-task-status-tool.js";
 
 // ─── MCP adapter ───
 

--- a/src/agent/runtime/friday-agent-delegation-policy.ts
+++ b/src/agent/runtime/friday-agent-delegation-policy.ts
@@ -1,0 +1,53 @@
+import type { FridayAgentConversationContext } from "./friday-agent-runtime.types.js";
+
+const DIRECT_STATUS_HINTS =
+  /\b(status|progress|eta|done yet|finished yet|what are you doing|what's happening|what are you working on)\b/i;
+const DIRECT_CAPABILITY_HINTS =
+  /\b(what can you do|which capabilities|capabilities|what's enabled|is mcp enabled|is discord enabled|read.?only)\b/i;
+const ACTION_HINTS =
+  /\b(open|run|check|inspect|review|analyze|diagnose|debug|fix|search|look up|browse|navigate|read|write|edit|update|create|generate|deploy|export|build|test|lint|typecheck|configure|switch|set|use|send|install|triage|summarize|investigate)\b/i;
+const TOOL_DOMAIN_HINTS =
+  /\b(browser|chrome|desktop|system|provider|oauth|model|workflow|skill|repo|repository|file|files|code|shell|command|discord|slack|telegram|memory|session|subagent|agent|log|logs|service|port|process|database|api)\b/i;
+
+export interface FridayAgentDelegationPolicyInput {
+  task: string;
+  conversationContext?: FridayAgentConversationContext;
+}
+
+export function shouldDelegateFridayAgentTask(
+  input: FridayAgentDelegationPolicyInput,
+): boolean {
+  const task = input.task.trim();
+  if (task.length === 0) {
+    return false;
+  }
+
+  const turnKind = input.conversationContext?.turnKind;
+  if (turnKind === "status_check" || turnKind === "clarification") {
+    return false;
+  }
+
+  if (DIRECT_STATUS_HINTS.test(task) || DIRECT_CAPABILITY_HINTS.test(task)) {
+    return false;
+  }
+
+  if (turnKind === "continue_active_task") {
+    return true;
+  }
+
+  if (ACTION_HINTS.test(task) || TOOL_DOMAIN_HINTS.test(task)) {
+    return true;
+  }
+
+  const normalized = task.toLowerCase();
+  const shortQuestion =
+    task.length <= 120
+    && normalized.includes("?")
+    && !/[/:\\]/.test(task)
+    && !/\bhttps?:\/\//i.test(task);
+  if (shortQuestion) {
+    return false;
+  }
+
+  return task.length > 180;
+}

--- a/src/agent/runtime/friday-agent-runtime.ts
+++ b/src/agent/runtime/friday-agent-runtime.ts
@@ -38,6 +38,7 @@ import type {
 } from "./friday-agent-runtime.types.js";
 import { evaluateFridayAnswerAlignment } from "./friday-agent-answer-alignment.js";
 import { attachFridayAgentToolExecutionContext } from "./friday-agent-tool-execution-context.js";
+import { shouldDelegateFridayAgentTask } from "./friday-agent-delegation-policy.js";
 import { isMutatingToolCall } from "./friday-agent-tool-mutation.js";
 import { getApprovalRequiredReasonForToolCall } from "./friday-agent-tool-risk.js";
 
@@ -69,6 +70,7 @@ export function createFridayAgentRuntime(
     evaluateRules,
     learningContextBuilder,
     communicationPromptBuilder,
+    delegationHandler,
   } = deps;
 
   // Clone the tools array so registerTool does not mutate the caller's array.
@@ -534,6 +536,132 @@ export function createFridayAgentRuntime(
           runId,
           message: `Planning approach (${String(planSummary.stepCount)} step(s))`,
         });
+
+        if (
+          delegationHandler
+          && shouldDelegateFridayAgentTask({
+            task: params.task,
+            conversationContext,
+          })
+        ) {
+          handleTrackedEvent("agent.run.executing", {
+            runId,
+            step: 1,
+            description: "Delegating task to sub-agent",
+          });
+
+          const delegated = await delegationHandler({
+            runId,
+            sessionKey,
+            task: params.task,
+            timezone: params.timezone,
+            timeoutMs,
+            signal: runAbortController.signal,
+            constraints,
+            principalId,
+            conversationContext,
+          });
+
+          if (delegated) {
+            responseText = delegated.outcome.response;
+            const durationMs = Date.now() - startedAt;
+            const completedAt = nowIso();
+            const summaryText = deriveSummary(responseText);
+            const terminalStatus = delegated.outcome.status;
+            const terminalResponse = responseText.trim().length > 0
+              ? responseText
+              : terminalStatus === "completed"
+                ? `Delegated sub-agent ${delegated.subagentId} completed without a response.`
+                : `Delegated sub-agent ${delegated.subagentId} ${terminalStatus}.`;
+            const persistedArtifacts = persistRunArtifacts({
+              status: terminalStatus,
+              response: terminalResponse,
+              durationMs,
+              completedAt,
+              testResults: [],
+              artifacts: [],
+            });
+
+            db.withWriteTransaction((writer) =>
+              repo.update(writer, {
+                id: runId,
+                status: terminalStatus,
+                completedAt,
+                durationMs,
+                usageInput: 0,
+                usageOutput: 0,
+                artifacts: persistedArtifacts.artifacts,
+                responseText: terminalResponse,
+                summary: summaryText || undefined,
+                artifactDir: persistedArtifacts.artifactDir,
+              }),
+            );
+
+            if (terminalStatus === "completed") {
+              handleTrackedEvent("agent.run.completed", {
+                runId,
+                durationMs,
+                toolCallCount: 0,
+                testsPassed: true,
+                artifacts: persistedArtifacts.artifacts.map((a) => ({ type: a.type, path: a.path })),
+              });
+
+              if (sessionMirror && terminalResponse) {
+                try {
+                  await sessionMirror(sessionKey, {
+                    role: "assistant",
+                    content: terminalResponse,
+                    contentText: terminalResponse,
+                    idempotencyKey: `agent-run:${runId}:response`,
+                  });
+                } catch (error) {
+                  console.warn(
+                    `[friday][W-AG-SESSION-MIRROR-001] Failed to mirror assistant response for delegated run ${runId}:`,
+                    error instanceof Error ? error.message : String(error),
+                  );
+                }
+              }
+
+              return {
+                runId,
+                status: "completed",
+                response: terminalResponse,
+                toolCallCount: 0,
+                durationMs,
+                usageInput: 0,
+                usageOutput: 0,
+              };
+            }
+
+            if (terminalStatus === "cancelled") {
+              handleTrackedEvent("agent.run.cancelled", {
+                runId,
+                reason: terminalResponse,
+              });
+            } else {
+              handleTrackedEvent("agent.run.failed", {
+                runId,
+                error: {
+                  code: FRIDAY_AGENT_ERROR_CODES.LLM_ERROR,
+                  message: terminalResponse,
+                },
+                durationMs,
+                routeId: "agent.execute.run.delegated",
+                correlationId: delegated.childRunId,
+              });
+            }
+
+            return {
+              runId,
+              status: terminalStatus,
+              response: terminalResponse,
+              toolCallCount: 0,
+              durationMs,
+              usageInput: 0,
+              usageOutput: 0,
+            };
+          }
+        }
 
         // 3. Add user message (with optional inline images for vision)
         if (params.images && params.images.length > 0) {

--- a/src/agent/runtime/friday-agent-runtime.types.ts
+++ b/src/agent/runtime/friday-agent-runtime.types.ts
@@ -27,6 +27,34 @@ export interface FridayAgentConversationContext {
   currentTopicSummary?: string;
 }
 
+export interface FridayAgentDelegationRequest {
+  runId: string;
+  sessionKey: string;
+  task: string;
+  timezone?: string;
+  timeoutMs: number;
+  signal: AbortSignal;
+  constraints?: FridayAgentRunConstraints;
+  principalId?: string;
+  conversationContext?: FridayAgentConversationContext;
+}
+
+export interface FridayAgentDelegationResult {
+  delegated: true;
+  subagentId: string;
+  childRunId: string;
+  childSessionKey: string;
+  statusSnapshot: "pending" | "running" | "completed" | "failed" | "cancelled";
+  outcome: {
+    status: "completed" | "failed" | "cancelled";
+    response: string;
+    toolCallCount: number;
+    durationMs: number;
+    usageInput: number;
+    usageOutput: number;
+  };
+}
+
 export interface FridayAgentSystemPromptContext {
   toolNames: string[];
   nowIso: string;
@@ -158,4 +186,7 @@ export interface CreateFridayAgentRuntimeDeps {
   learningContextBuilder?: (input: { userId: string; nowIso: string }) => { preferences: Record<string, unknown> };
   /** Optional callback that returns a communication persona prompt fragment for the current user. */
   communicationPromptBuilder?: (input: { userId: string; nowIso: string }) => string | null;
+  /** Optional deterministic delegation hook for top-level coordinator runs. */
+  delegationHandler?: (input: FridayAgentDelegationRequest) =>
+    Promise<FridayAgentDelegationResult | null>;
 }

--- a/src/agent/runtime/friday-agent-system-prompt-builder.ts
+++ b/src/agent/runtime/friday-agent-system-prompt-builder.ts
@@ -148,6 +148,7 @@ export function buildFridayAgentSystemPrompt(
     "- If web_fetch returns unreadable/empty content for a URL, IMMEDIATELY retry with browser instead\n" +
     `- For time-sensitive requests (latest/current/today/news/最新/今天/最近): ${timelinessReference} Use recency-filtered search when available, verify publication dates, and include absolute dates plus source URLs in the answer. If verifiable dates are unavailable, explicitly say the latestness is unverified.\n` +
     "- When the user asks what Friday can do right now, which capabilities are enabled in this deployment, or whether messaging/MCP/provider mutations are currently available, use capabilities first\n" +
+    "- When the user asks what you are doing right now, whether a delegated task is still running, or what the latest task result/blocker is, use task_status first\n" +
     "- Local computer orchestration: use system first for snapshots, app/project handoff, approvals, and control leases; fall back to desktop only when system intent resolution is insufficient\n" +
     "- Provider/LLM management (switch model, add API key, configure OAuth): use provider tool\n" +
     "- Friday skills: use skills_list first to discover currently available skills, then use skill_run with the chosen skill ID\n" +
@@ -160,7 +161,7 @@ export function buildFridayAgentSystemPrompt(
       ? "- Schedule recurring or delayed tasks: use cron\n"
       : "- Scheduled or delayed execution is unavailable in this deployment.\n") +
     (subagentsEnabled
-      ? "- Complex multi-step tasks that benefit from delegation: use spawn_subagent. If the user needs the child result now, use wait=true or keep polling get_subagent until terminal state instead of treating the initial delegated snapshot as final.\n"
+      ? "- Complex multi-step tasks that benefit from delegation: use spawn_subagent. Default to delegation for non-trivial operational work. If the user needs the child result now, use wait=true or keep polling get_subagent until terminal state instead of treating the initial delegated snapshot as final.\n"
       : "- Sub-agent delegation is unavailable in this deployment.\n") +
     (selfLearningEnabled
       ? "- Record user corrections or stated preferences: use feedback\n"
@@ -168,6 +169,7 @@ export function buildFridayAgentSystemPrompt(
     "\n\n" +
     "Behavior rules:\n" +
     "- Be direct and action-oriented. Use tools immediately when a task requires them.\n" +
+    "- For status/progress answers, use deterministic state from task_status or get_subagent instead of guessing.\n" +
     "- Never say you cannot do something that your currently registered tools support.\n" +
     "- If a capability is not available in this deployment, explain that clearly and suggest the closest available alternative.\n" +
     "- When asked about your current deployment capabilities, use capabilities before answering. Use the prompt for model/version framing, not for guessing runtime state.\n" +

--- a/src/agent/runtime/friday-agent-tool-mutation.ts
+++ b/src/agent/runtime/friday-agent-tool-mutation.ts
@@ -86,6 +86,7 @@ const READ_ONLY_TOOLS = new Set([
   "agents_list",
   "skills_list",
   "capabilities",
+  "task_status",
   "image_analysis",
 ]);
 

--- a/src/agent/tools/friday-agent-task-status-tool.ts
+++ b/src/agent/tools/friday-agent-task-status-tool.ts
@@ -1,0 +1,68 @@
+import type { FridayAgentToolDefinition, FridayAgentToolResult } from "../model/friday-agent.types.js";
+import { getFridayAgentToolExecutionContext } from "../runtime/friday-agent-tool-execution-context.js";
+import { jsonResult } from "./friday-agent-tool-helpers.js";
+
+export interface FridayAgentTaskStatusSubagentSnapshot {
+  id: string;
+  childRunId: string;
+  childSessionKey: string;
+  status: "pending" | "running" | "completed" | "failed" | "cancelled";
+  task: string;
+  label?: string;
+  createdAt: string;
+  startedAt?: string;
+  completedAt?: string;
+  durationMs?: number;
+}
+
+export interface FridayAgentTaskStatusSnapshot {
+  readOnly: boolean;
+  sessionKey?: string;
+  trackedRunId?: string;
+  task?: string;
+  runStatus?: string;
+  phase?: string;
+  elapsedMs?: number;
+  latestTool?: string;
+  activeSubagents: FridayAgentTaskStatusSubagentSnapshot[];
+  blockers: string[];
+  pendingPlanRunId?: string;
+  terminalOutcome?: {
+    status: "completed" | "failed" | "cancelled";
+    summary?: string;
+    responseText?: string;
+  };
+}
+
+export interface CreateFridayAgentTaskStatusToolOptions {
+  getSnapshot: (input: {
+    runId?: string;
+    sessionKey?: string;
+    readOnly: boolean;
+  }) => Promise<FridayAgentTaskStatusSnapshot> | FridayAgentTaskStatusSnapshot;
+}
+
+export function createFridayAgentTaskStatusTool(
+  options: CreateFridayAgentTaskStatusToolOptions,
+): FridayAgentToolDefinition {
+  return {
+    name: "task_status",
+    description:
+      "Return deterministic status for the current session or run, including active delegated sub-agents, elapsed time, " +
+      "latest tool, current phase, blockers, and terminal outcome. Use this before answering questions like what Friday " +
+      "is doing right now, whether a delegated task is still running, or what the latest result is.",
+    parameters: {
+      properties: {},
+      required: [],
+    },
+    async execute(_args: Record<string, unknown>, signal: AbortSignal): Promise<FridayAgentToolResult> {
+      const context = getFridayAgentToolExecutionContext(signal);
+      const snapshot = await options.getSnapshot({
+        runId: context?.runId,
+        sessionKey: context?.sessionKey,
+        readOnly: context?.readOnly ?? false,
+      });
+      return jsonResult(snapshot);
+    },
+  };
+}

--- a/src/agent/tools/friday-agent-tool-registry.ts
+++ b/src/agent/tools/friday-agent-tool-registry.ts
@@ -50,6 +50,10 @@ import {
   createFridayAgentCapabilitiesTool,
   type FridayAgentCapabilitiesSnapshot,
 } from "./friday-agent-capabilities-tool.js";
+import {
+  createFridayAgentTaskStatusTool,
+  type FridayAgentTaskStatusSnapshot,
+} from "./friday-agent-task-status-tool.js";
 
 // ─── Registry options ───
 
@@ -107,6 +111,9 @@ export interface CreateFridayAgentToolRegistryOptions {
   /** Deterministic runtime capability snapshot getter for the capabilities tool. */
   capabilitySnapshotGetter?: (input: { readOnly: boolean }) =>
     Promise<FridayAgentCapabilitiesSnapshot> | FridayAgentCapabilitiesSnapshot;
+  /** Deterministic task status snapshot getter for coordinator/status questions. */
+  taskStatusSnapshotGetter?: (input: { runId?: string; sessionKey?: string; readOnly: boolean }) =>
+    Promise<FridayAgentTaskStatusSnapshot> | FridayAgentTaskStatusSnapshot;
 }
 
 // ─── Factory ───
@@ -269,6 +276,12 @@ export function createFridayAgentToolRegistry(
   if (options?.capabilitySnapshotGetter) {
     tools.push(
       createFridayAgentCapabilitiesTool({ getSnapshot: options.capabilitySnapshotGetter }),
+    );
+  }
+
+  if (options?.taskStatusSnapshotGetter) {
+    tools.push(
+      createFridayAgentTaskStatusTool({ getSnapshot: options.taskStatusSnapshotGetter }),
     );
   }
 

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -1566,6 +1566,10 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
         ? await sessionService.getConversationFocus(input.sessionKey).catch(() => null)
         : null;
 
+      if (input.sessionKey) {
+        focusState = await sessionService.getConversationFocus(input.sessionKey).catch(() => focusState);
+      }
+
       if (input.sessionKey && shouldPersistUserMessage) {
         inboundIdempotencyKey = `${input.idempotencyPrefix}:${input.runId}:user`;
         const inboundMessage = await sessionService.addMessage(input.sessionKey, {
@@ -1602,6 +1606,18 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
           focusState,
           currentUserSequence,
         });
+        if (
+          input.sessionKey
+          && preparedTurn.turnKind !== "status_check"
+          && preparedTurn.turnKind !== "clarification"
+        ) {
+          await sessionService.setConversationFocus(input.sessionKey, {
+            ...(focusState ?? { updatedAt: deps.nowIso() }),
+            activeRunId: input.runId,
+            updatedAt: deps.nowIso(),
+          }).catch(() => undefined);
+          focusState = await sessionService.getConversationFocus(input.sessionKey).catch(() => focusState);
+        }
         historyMessages = preparedTurn.historyMessages;
         taskPrompt = preparedTurn.taskPrompt;
         conversationContext = {
@@ -1623,7 +1639,9 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
         timeoutMs: input.timeoutMs,
         signal: input.signal,
         reviewRequired: input.reviewRequired,
-        constraints: input.constraints,
+        constraints: conversationContext?.turnKind === "status_check"
+          ? { ...(input.constraints ?? {}), readOnly: true }
+          : input.constraints,
         principalId: input.principalId,
         scopes: input.scopes,
         executionContext: input.executionContext,
@@ -1631,6 +1649,9 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
       });
 
       if (input.sessionKey && conversationContext?.turnKind) {
+        const latestFocusState = await sessionService
+          .getConversationFocus(input.sessionKey)
+          .catch(() => focusState);
         await sessionService.setConversationFocus(
           input.sessionKey,
           finalizeFridayConversationFocus({
@@ -1638,7 +1659,7 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
             responseText: result.response,
             runId: result.runId,
             turnKind: conversationContext.turnKind,
-            focusState,
+            focusState: latestFocusState,
             currentUserSequence,
             nowIso: deps.nowIso(),
           }),

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -109,6 +109,7 @@ import {
   createFridayAgentMessageTool,
   createFridayAgentReviewGate,
   createFridayAgentRunEventRepository,
+  createFridayAgentRunRepository,
   createFridayAgentRuntime,
   createFridayAgentSelfTestService,
   createFridayAgentSkillGeneratorTool,
@@ -130,6 +131,7 @@ import type {
   FridayAgentMessage,
   FridayAgentReviewMode,
   FridayAgentRuntime,
+  FridayAgentTaskStatusSnapshot,
 } from "#agent";
 import {
   createDiscordGatewayService,
@@ -747,6 +749,7 @@ export async function createFridayHub(
 
   // IMPL-3: Durable run event repository
   const agentRunEventRepository = createFridayAgentRunEventRepository();
+  const agentRunRepo = createFridayAgentRunRepository();
 
   // IMPL-4: SSRF guard
   const agentSsrfGuard = createFridayAgentSsrfGuard();
@@ -1235,6 +1238,7 @@ export async function createFridayHub(
   // receives a deferred reference that resolves once runtime is wired up.
   let _agentRuntimeRef: FridayAgentRuntime | undefined;
   const agentRuntimeGetter = () => _agentRuntimeRef;
+  let subagentRegistry!: ReturnType<typeof createFridaySubagentRegistry>;
 
   // Optional MCP adapter (JSON config from FRIDAY_MCP_SERVERS).
   // Example:
@@ -1308,6 +1312,95 @@ export async function createFridayHub(
     };
   };
 
+  const getAgentTaskStatusSnapshot = async (input: {
+    runId?: string;
+    sessionKey?: string;
+    readOnly: boolean;
+  }): Promise<FridayAgentTaskStatusSnapshot> => {
+    const focusState = input.sessionKey
+      ? await hubSessionService.getConversationFocus(input.sessionKey).catch(() => null)
+      : null;
+    const trackedRunId = focusState?.activeRunId ?? input.runId ?? focusState?.lastRunId;
+    const trackedRun = trackedRunId
+      ? stateRuntime!.sqlite.withReadConnection((reader) => agentRunRepo.getById(reader, trackedRunId))
+      : null;
+    const trackedEvents = trackedRunId
+      ? stateRuntime!.sqlite.withReadConnection((reader) => agentRunEventRepository.list(reader, trackedRunId))
+      : [];
+
+    let latestPhase: string | undefined;
+    let latestTool: string | undefined;
+    for (const event of trackedEvents) {
+      if (event.eventName === "agent.run.progress" && typeof event.payload.phase === "string") {
+        latestPhase = event.payload.phase;
+      }
+      if (event.eventName === "agent.run.tool_start" && typeof event.payload.toolName === "string") {
+        latestTool = event.payload.toolName;
+      }
+      if (
+        event.eventName === "agent.run.tool_end"
+        && typeof event.payload.toolName === "string"
+        && event.payload.toolName === latestTool
+      ) {
+        latestTool = undefined;
+      }
+    }
+
+    const activeSubagentIds = focusState?.activeSubagentIds ?? [];
+    const activeSubagents = activeSubagentIds
+      .map((subagentId) => subagentRegistry.getById(subagentId))
+      .filter((record): record is NonNullable<typeof record> => record !== null)
+      .map((record) => ({
+        id: record.id,
+        childRunId: record.childRunId,
+        childSessionKey: record.childSessionKey,
+        status: record.status,
+        task: record.task,
+        label: record.label,
+        createdAt: record.createdAt,
+        startedAt: record.startedAt,
+        completedAt: record.completedAt,
+        durationMs: record.durationMs,
+      }));
+
+    const blockers: string[] = [];
+    if (trackedRun?.status === "failed" && trackedRun.errorMessage) {
+      blockers.push(trackedRun.errorMessage);
+    }
+    if (focusState?.pendingPlanRunId) {
+      blockers.push(`Awaiting plan approval for run ${focusState.pendingPlanRunId}.`);
+    }
+
+    const elapsedMs = trackedRun?.startedAt
+      ? Math.max(0, Date.now() - new Date(trackedRun.startedAt).getTime())
+      : undefined;
+
+    return {
+      readOnly: input.readOnly,
+      sessionKey: input.sessionKey,
+      trackedRunId: trackedRun?.id,
+      task: trackedRun?.task,
+      runStatus: trackedRun?.status,
+      phase: latestPhase ?? trackedRun?.status,
+      elapsedMs,
+      latestTool,
+      activeSubagents,
+      blockers,
+      pendingPlanRunId: focusState?.pendingPlanRunId,
+      terminalOutcome: trackedRun && (
+        trackedRun.status === "completed"
+        || trackedRun.status === "failed"
+        || trackedRun.status === "cancelled"
+      )
+        ? {
+            status: trackedRun.status,
+            summary: trackedRun.summary,
+            responseText: trackedRun.responseText,
+          }
+        : undefined,
+    };
+  };
+
   const agentTools = createFridayAgentToolRegistry({
     workdir: workspaceRoot,
     skillExecutor: executor,
@@ -1327,6 +1420,7 @@ export async function createFridayHub(
     webSearchProvider: process.env.FRIDAY_SEARCH_PROVIDER,
     webSearchApiKey: process.env.FRIDAY_SERPER_API_KEY ?? process.env.FRIDAY_TAVILY_API_KEY,
     capabilitySnapshotGetter: getAgentCapabilitySnapshot,
+    taskStatusSnapshotGetter: getAgentTaskStatusSnapshot,
   });
 
   const mcpServer = (() => {
@@ -1890,6 +1984,31 @@ export async function createFridayHub(
       });
       return buildFridayCommunicationPromptFragment(persona);
     },
+    delegationHandler: async (input) => {
+      const detached = subagentRegistry.spawnDetached({
+        task: input.task,
+        timezone: input.timezone,
+        timeoutMs: input.timeoutMs,
+        parentRunId: input.runId,
+        parentSessionKey: input.sessionKey,
+        depth: 0,
+        rootRunId: input.runId,
+        constraints: input.constraints,
+        signal: input.signal,
+      });
+
+      const outcome = await subagentRegistry.waitForCompletion(detached.subagentId, input.timeoutMs);
+      const completedRecord = subagentRegistry.getById(detached.subagentId);
+
+      return {
+        delegated: true,
+        subagentId: detached.subagentId,
+        childRunId: detached.childRunId,
+        childSessionKey: detached.childSessionKey,
+        statusSnapshot: completedRecord?.status ?? detached.statusSnapshot,
+        outcome,
+      };
+    },
     usageRecorder: async (usage) => {
       await providerService.recordUsage({
         providerId: usage.providerId,
@@ -1915,7 +2034,7 @@ export async function createFridayHub(
 
   // ─── Sub-agent registry ───
 
-  const subagentRegistry = createFridaySubagentRegistry({
+  subagentRegistry = createFridaySubagentRegistry({
     db: stateRuntime!.sqlite,
     createChildRuntime: (params) => {
       let childRuntimeRef: FridayAgentRuntime | undefined;
@@ -1952,6 +2071,7 @@ export async function createFridayHub(
         webSearchProvider: process.env.FRIDAY_SEARCH_PROVIDER,
         webSearchApiKey: process.env.FRIDAY_SERPER_API_KEY ?? process.env.FRIDAY_TAVILY_API_KEY,
         capabilitySnapshotGetter: getAgentCapabilitySnapshot,
+        taskStatusSnapshotGetter: getAgentTaskStatusSnapshot,
       });
       const childRuntime = createFridayAgentRuntime({
         db: stateRuntime!.sqlite,
@@ -2015,6 +2135,75 @@ export async function createFridayHub(
   const lineWebhookRelay = createLineWebhookListenerService();
   const whatsappWebhookRelay = createWhatsappWebhookService();
   const larkWebhookRelay = createLarkWebhookRelayService();
+
+  const updateConversationFocus = (
+    sessionKey: string,
+    updater: (current: Awaited<ReturnType<typeof hubSessionService.getConversationFocus>>) =>
+      Awaited<ReturnType<typeof hubSessionService.getConversationFocus>>,
+  ): void => {
+    void (async () => {
+      const current = await hubSessionService.getConversationFocus(sessionKey).catch(() => null);
+      const next = updater(current);
+      await hubSessionService.setConversationFocus(sessionKey, next).catch(() => undefined);
+    })();
+  };
+
+  const resolveAgentRun = (runId: string) =>
+    stateRuntime!.sqlite.withReadConnection((reader) => agentRunRepo.getById(reader, runId));
+
+  const clearActiveRun = (runId: string): void => {
+    const run = resolveAgentRun(runId);
+    if (!run) return;
+    updateConversationFocus(run.sessionKey, (current) => ({
+      ...(current ?? { updatedAt: nowIso() }),
+      activeRunId: current?.activeRunId === runId ? undefined : current?.activeRunId,
+      updatedAt: nowIso(),
+    }));
+  };
+
+  agentEventEmitter.on("agent.run.completed", (payload) => {
+    clearActiveRun(payload.runId);
+  });
+  agentEventEmitter.on("agent.run.failed", (payload) => {
+    clearActiveRun(payload.runId);
+  });
+  agentEventEmitter.on("agent.run.cancelled", (payload) => {
+    clearActiveRun(payload.runId);
+  });
+
+  agentEventEmitter.on("agent.subagent.spawned", (payload) => {
+    const record = subagentRegistry.getById(payload.subagentId);
+    if (!record) return;
+    updateConversationFocus(record.parentSessionKey, (current) => ({
+      ...(current ?? { updatedAt: nowIso() }),
+      activeRunId: record.childRunId,
+      activeSubagentIds: current?.activeSubagentIds?.includes(record.id)
+        ? current.activeSubagentIds
+        : [...(current?.activeSubagentIds ?? []), record.id],
+      updatedAt: nowIso(),
+    }));
+    updateConversationFocus(record.childSessionKey, (current) => ({
+      ...(current ?? { updatedAt: nowIso() }),
+      activeRunId: record.childRunId,
+      updatedAt: nowIso(),
+    }));
+  });
+
+  agentEventEmitter.on("agent.subagent.completed", (payload) => {
+    const record = subagentRegistry.getById(payload.subagentId);
+    if (!record) return;
+    updateConversationFocus(record.parentSessionKey, (current) => ({
+      ...(current ?? { updatedAt: nowIso() }),
+      activeRunId: current?.activeRunId === record.childRunId ? undefined : current?.activeRunId,
+      activeSubagentIds: (current?.activeSubagentIds ?? []).filter((id) => id !== record.id),
+      updatedAt: nowIso(),
+    }));
+    updateConversationFocus(record.childSessionKey, (current) => ({
+      ...(current ?? { updatedAt: nowIso() }),
+      activeRunId: current?.activeRunId === record.childRunId ? undefined : current?.activeRunId,
+      updatedAt: nowIso(),
+    }));
+  });
 
   // Parse channel config and register channel plugins via loader.
   // Precedence: explicit config (CLI/env) > setup wizard persisted state.
@@ -3804,6 +3993,38 @@ export async function createFridayHub(
               runId,
               publicRunUrl: resolveFridayPublicRunUrl(runId),
             });
+            let delegatedNoticeSent = false;
+            const onSubagentSpawnedForChannel = (payload: {
+              parentRunId: string;
+              subagentId: string;
+              childRunId: string;
+            }): void => {
+              if (payload.parentRunId !== runId || delegatedNoticeSent) {
+                return;
+              }
+              delegatedNoticeSent = true;
+              const liveUrl = resolveFridayPublicRunUrl(payload.childRunId) ?? resolveFridayPublicRunUrl(runId);
+              channelRegistry.send(msg.channelKind, {
+                chatId: msg.chatId,
+                text: [
+                  "I delegated this task to a worker and I am tracking it.",
+                  `runId: ${runId}`,
+                  `subagentId: ${payload.subagentId}`,
+                  `childRunId: ${payload.childRunId}`,
+                  liveUrl ? `watch: ${liveUrl}` : "watch: use the runId to query status",
+                ].join("\n"),
+                replyTo: msg.id,
+              }).catch((err) => {
+                logChannelIssue({
+                  level: "warn",
+                  code: "W-CH-OUTBOUND-002",
+                  routeId: "hub.channel.delivery.delegated_notice",
+                  runId,
+                  error: err,
+                });
+              });
+            };
+            agentEventEmitter.on("agent.subagent.spawned", onSubagentSpawnedForChannel);
             try {
               const inboundMessage = await hubSessionService.addMessage(sessionKey, {
                 role: "user",
@@ -3858,6 +4079,21 @@ export async function createFridayHub(
                   };
                 });
 
+              if (preparedTurn.turnKind !== "status_check" && preparedTurn.turnKind !== "clarification") {
+                await hubSessionService.setConversationFocus(sessionKey, {
+                  ...(focusState ?? { updatedAt: nowIso() }),
+                  activeRunId: runId,
+                  updatedAt: nowIso(),
+                }).catch((err) => {
+                  logChannelIssue({
+                    level: "warn",
+                    code: "W-CH-FOCUS-WRITE-001",
+                    routeId: "hub.channel.focus.active_run",
+                    error: err,
+                  });
+                });
+              }
+
               const result = await agentRuntime.executeRun({
                 task: text,
                 runId,
@@ -3870,6 +4106,7 @@ export async function createFridayHub(
                   previousTopicSummary: preparedTurn.previousTopicSummary,
                   currentTopicSummary: preparedTurn.currentTopicSummary,
                 },
+                constraints: preparedTurn.turnKind === "status_check" ? { readOnly: true } : undefined,
                 principalId: msg.senderId,
                 timezone: msg.timezone,
               });
@@ -3881,7 +4118,7 @@ export async function createFridayHub(
                   responseText: result.response,
                   runId: result.runId,
                   turnKind: preparedTurn.turnKind,
-                  focusState,
+                  focusState: await hubSessionService.getConversationFocus(sessionKey).catch(() => focusState),
                   currentUserSequence: inboundMessage?.sequence,
                   nowIso: nowIso(),
                 }),
@@ -3988,6 +4225,7 @@ export async function createFridayHub(
                   });
                 });
             } finally {
+              agentEventEmitter.off("agent.subagent.spawned", onSubagentSpawnedForChannel);
               slowTaskNotifier.stop();
               typingController.stopDispatch();
             }

--- a/src/sessions/services/friday-session-conversation-orchestrator.ts
+++ b/src/sessions/services/friday-session-conversation-orchestrator.ts
@@ -207,6 +207,8 @@ function buildTaskPrompt(input: {
       previousTopicSummary
         ? `Active topic reference: ${previousTopicSummary}`
         : "No active topic summary is available.",
+      "Use the task_status tool before answering.",
+      "Do not retry, resume, or reconstruct the original task in this turn unless the user explicitly asked for a new action.",
       "Do not answer the content of the previous task unless the user explicitly asked for that content.",
       "If you do not have deterministic status evidence in this turn, say that clearly instead of assuming.",
     ].join("\n");
@@ -287,7 +289,9 @@ export function finalizeFridayConversationFocus(
     lastAnsweredQuestion: summarizeTopic(input.task),
     lastAssistantAskedQuestion: assistantAskedQuestion,
     lastRunId: input.runId,
-    activeRunId: undefined,
+    activeRunId: previous?.activeRunId && previous.activeRunId !== input.runId
+      ? previous.activeRunId
+      : undefined,
     activeSubagentIds: activeSubagentIds && activeSubagentIds.length > 0 ? activeSubagentIds : undefined,
     pendingPlanRunId: input.pendingPlanRunId ?? previous?.pendingPlanRunId,
     lastTurnKind: input.turnKind,

--- a/test/unit/agent/runtime/friday-agent-delegation-policy.test.ts
+++ b/test/unit/agent/runtime/friday-agent-delegation-policy.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldDelegateFridayAgentTask } from "#agent";
+
+describe("shouldDelegateFridayAgentTask", () => {
+  it("does not delegate status checks or clarifications", () => {
+    expect(shouldDelegateFridayAgentTask({
+      task: "刚才那个任务现在怎么样？",
+      conversationContext: { turnKind: "status_check" },
+    })).toBe(false);
+
+    expect(shouldDelegateFridayAgentTask({
+      task: "Use Claude",
+      conversationContext: { turnKind: "clarification" },
+    })).toBe(false);
+  });
+
+  it("keeps simple direct questions on the main agent", () => {
+    expect(shouldDelegateFridayAgentTask({
+      task: "What is the capital of France?",
+    })).toBe(false);
+  });
+
+  it("delegates operational or multi-step work", () => {
+    expect(shouldDelegateFridayAgentTask({
+      task: "Open Facebook in the browser and tell me what is on the page.",
+    })).toBe(true);
+
+    expect(shouldDelegateFridayAgentTask({
+      task: "Run the release-readiness-check skill and summarize blockers.",
+    })).toBe(true);
+
+    expect(shouldDelegateFridayAgentTask({
+      task: "Continue and fix the failing workflow generator tests.",
+      conversationContext: { turnKind: "continue_active_task" },
+    })).toBe(true);
+  });
+});

--- a/test/unit/agent/runtime/friday-agent-runtime-delegation.test.ts
+++ b/test/unit/agent/runtime/friday-agent-runtime-delegation.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createFridayAgentEventEmitter,
+  createFridayAgentRunRepository,
+  createFridayAgentRuntime,
+  createFridayAgentRunEventRepository,
+} from "#agent";
+import { createTestDb, createTestIdGenerator } from "../../satellites/_helpers/create-test-db.helper.js";
+
+describe("FridayAgentRuntime delegation", () => {
+  it("delegates non-trivial operational work before entering the LLM loop", async () => {
+    const db = createTestDb();
+    const idGenerator = createTestIdGenerator();
+    const eventEmitter = createFridayAgentEventEmitter();
+    const runEventRepository = createFridayAgentRunEventRepository();
+    const llmClient = {
+      stream: vi.fn(async function *neverCalled() {
+        yield { type: "message_end" as const };
+      }),
+    };
+    const delegationHandler = vi.fn(async () => ({
+      delegated: true as const,
+      subagentId: "sub-1",
+      childRunId: "child-run-1",
+      childSessionKey: "subagent:child-run-1",
+      statusSnapshot: "completed" as const,
+      outcome: {
+        status: "completed" as const,
+        response: "Delegated child completed successfully.",
+        toolCallCount: 3,
+        durationMs: 2_500,
+        usageInput: 120,
+        usageOutput: 45,
+      },
+    }));
+    const runtime = createFridayAgentRuntime({
+      db,
+      llmClient,
+      model: "test-model",
+      providerId: "provider-1",
+      systemPrompt: "You are Friday.",
+      tools: [],
+      eventEmitter,
+      idGenerator,
+      nowIso: () => "2026-03-15T12:00:00.000Z",
+      runEventRepository,
+      delegationHandler,
+    });
+
+    const result = await runtime.executeRun({
+      task: "Open Facebook and tell me what is on the page.",
+      runId: "run-1",
+      sessionKey: "ui:command-center:test",
+    });
+
+    expect(delegationHandler).toHaveBeenCalledOnce();
+    expect(llmClient.stream).not.toHaveBeenCalled();
+    expect(result.status).toBe("completed");
+    expect(result.response).toContain("Delegated child completed successfully.");
+
+    const runRepo = createFridayAgentRunRepository();
+    const run = db.withReadConnection((reader) => runRepo.getById(reader, "run-1"));
+    expect(run?.status).toBe("completed");
+    expect(run?.responseText).toContain("Delegated child completed successfully.");
+    db.close();
+  });
+});

--- a/test/unit/agent/runtime/friday-agent-system-prompt-builder.test.ts
+++ b/test/unit/agent/runtime/friday-agent-system-prompt-builder.test.ts
@@ -163,6 +163,18 @@ describe("buildFridayAgentSystemPrompt", () => {
     expect(withRuntimeSupport).toContain("use capabilities first");
   });
 
+  it("documents deterministic task status guidance", () => {
+    const prompt = buildFridayAgentSystemPrompt({
+      toolNames: ["task_status", "spawn_subagent"],
+      modelIdentity: "test-model (provider: test)",
+      version: "0.0.0-test",
+    });
+
+    expect(prompt).toContain("use task_status first");
+    expect(prompt).toContain("Default to delegation for non-trivial operational work");
+    expect(prompt).toContain("use deterministic state from task_status or get_subagent instead of guessing");
+  });
+
   it("describes cron, subagents, marketplace, and self-learning truthfully", () => {
     const prompt = buildFridayAgentSystemPrompt({
       toolNames: ["cron", "spawn_subagent", "feedback"],

--- a/test/unit/agent/tools/friday-agent-task-status-tool.test.ts
+++ b/test/unit/agent/tools/friday-agent-task-status-tool.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createFridayAgentTaskStatusTool } from "#agent";
+import { attachFridayAgentToolExecutionContext } from "../../../../src/agent/runtime/friday-agent-tool-execution-context.js";
+
+function signalWithContext(readOnly: boolean): AbortSignal {
+  const controller = new AbortController();
+  return attachFridayAgentToolExecutionContext(controller.signal, {
+    runId: "run-123",
+    sessionKey: "ui:command-center:test",
+    readOnly,
+  });
+}
+
+describe("createFridayAgentTaskStatusTool", () => {
+  it("returns deterministic status for the current run/session", async () => {
+    const getSnapshot = vi.fn(async ({ runId, sessionKey, readOnly }) => ({
+      readOnly,
+      sessionKey,
+      trackedRunId: runId,
+      task: "Open Facebook",
+      runStatus: "executing",
+      phase: "executing",
+      elapsedMs: 31_000,
+      latestTool: "browser",
+      activeSubagents: [
+        {
+          id: "sub-1",
+          childRunId: "child-1",
+          childSessionKey: "subagent:child-1",
+          status: "running" as const,
+          task: "Open Facebook",
+          createdAt: "2026-03-15T00:00:00.000Z",
+        },
+      ],
+      blockers: [],
+    }));
+    const tool = createFridayAgentTaskStatusTool({ getSnapshot });
+
+    const result = await tool.execute({}, signalWithContext(true));
+
+    expect(getSnapshot).toHaveBeenCalledWith({
+      runId: "run-123",
+      sessionKey: "ui:command-center:test",
+      readOnly: true,
+    });
+    expect(JSON.parse(result.content)).toMatchObject({
+      readOnly: true,
+      trackedRunId: "run-123",
+      latestTool: "browser",
+      activeSubagents: [{ id: "sub-1", childRunId: "child-1" }],
+    });
+  });
+});

--- a/test/unit/agent/tools/friday-agent-tool-registry.test.ts
+++ b/test/unit/agent/tools/friday-agent-tool-registry.test.ts
@@ -201,4 +201,17 @@ describe("createFridayAgentToolRegistry", () => {
     const names = tools.map((t) => t.name);
     expect(names).toContain("capabilities");
   });
+
+  it("includes task_status tool when taskStatusSnapshotGetter is provided", () => {
+    const tools = createFridayAgentToolRegistry({
+      taskStatusSnapshotGetter: () => ({
+        readOnly: false,
+        trackedRunId: "run-1",
+        activeSubagents: [],
+        blockers: [],
+      }),
+    });
+    const names = tools.map((t) => t.name);
+    expect(names).toContain("task_status");
+  });
 });

--- a/test/unit/sessions/services/friday-session-conversation-orchestrator.test.ts
+++ b/test/unit/sessions/services/friday-session-conversation-orchestrator.test.ts
@@ -100,6 +100,7 @@ describe("friday-session-conversation-orchestrator", () => {
     expect(prepared.turnKind).toBe("status_check");
     expect(prepared.historyMessages).toHaveLength(2);
     expect(prepared.taskPrompt).toContain("asking for a status update");
+    expect(prepared.taskPrompt).toContain("Use the task_status tool before answering.");
   });
 
   it("persists new-topic focus state with the current sequence", () => {
@@ -117,5 +118,24 @@ describe("friday-session-conversation-orchestrator", () => {
     expect(focus.currentTopicStartSequence).toBe(9);
     expect(focus.lastRunId).toBe("run-2");
     expect(focus.lastTurnKind).toBe("new_topic");
+  });
+
+  it("preserves another active run when a status-check turn finishes", () => {
+    const focus = finalizeFridayConversationFocus({
+      task: "刚才那个任务现在怎么样？",
+      responseText: "It is still running in a delegated subagent.",
+      runId: "run-status-check",
+      turnKind: "status_check",
+      focusState: {
+        ...baseFocusState,
+        activeRunId: "run-long-task",
+        activeSubagentIds: ["sub-1"],
+      },
+      currentUserSequence: 10,
+      nowIso: "2026-03-15T11:00:00.000Z",
+    });
+
+    expect(focus.activeRunId).toBe("run-long-task");
+    expect(focus.activeSubagentIds).toEqual(["sub-1"]);
   });
 });


### PR DESCRIPTION
## Summary
- add deterministic task status and delegation policy support for main-agent coordination
- preserve active session focus while delegated work is in flight and tighten status-check turns to read-only truth paths
- emit truthful delegated coordination cues in channels and cover the new behavior with unit and live smoke evidence

## Validation
- npm run typecheck
- npm run lint
- npm run build
- npx vitest run test/unit/agent/runtime/friday-agent-delegation-policy.test.ts test/unit/agent/runtime/friday-agent-runtime-delegation.test.ts test/unit/agent/runtime/friday-agent-system-prompt-builder.test.ts test/unit/agent/tools/friday-agent-task-status-tool.test.ts test/unit/agent/tools/friday-agent-tool-registry.test.ts test/unit/sessions/services/friday-session-conversation-orchestrator.test.ts
- live local smoke with OpenAI provider pin for simple Q&A, delegated shell task, and in-flight status follow-up