### PR TITLE
fix: anchor short follow-ups to assistant facts

### DIFF
--- a/src/agent/runtime/friday-agent-answer-alignment.ts
+++ b/src/agent/runtime/friday-agent-answer-alignment.ts
@@ -29,6 +29,11 @@ const STOPWORDS = new Set([
   "you", "your",
 ]);
 
+const POSITIVE_ACTION_CLAIM_TERMS =
+  /\b(successfully|completed|done|finished|opened|launched|focused|connected|transferred|switched|navigated|now you can|you can now)\b/i;
+const CHINESE_POSITIVE_ACTION_CLAIM_TERMS =
+  /(成功|已成功|已经成功|已完成|已经完成|已打开|已经打开|已启动|已经启动|已聚焦|已经聚焦|已连接|已经连接|已切换|已经切换|现在你可以)/;
+
 export interface FridayAnswerAlignmentDecision {
   retryPrompt?: string;
 }
@@ -112,41 +117,42 @@ function selectedBlockSummary(
   return selectedBlocks.map((block) => block.summary).join("\n");
 }
 
-function replyAnchorSpecificTokens(
-  conversationContext: FridayAgentConversationContext | undefined,
-  currentTaskTokens: string[],
-): string[] {
-  const replyAnchorSummary = (conversationContext?.selectedBlocks ?? [])
-    .filter((block) => block.source === "reply_anchor")
-    .map((block) => block.summary)
-    .join("\n");
-  if (replyAnchorSummary.length === 0) {
-    return [];
-  }
-
-  const currentTaskTokenSet = new Set(currentTaskTokens);
-  return tokenize(replyAnchorSummary).filter((token) => !currentTaskTokenSet.has(token));
-}
-
-function replyAnchorAssistantSummary(
+function deriveAnchoredAssistantFact(
   conversationContext: FridayAgentConversationContext | undefined,
 ): string {
   const replyAnchorSummary = (conversationContext?.selectedBlocks ?? [])
     .filter((block) => block.source === "reply_anchor")
     .map((block) => block.summary)
     .join("\n");
-  if (replyAnchorSummary.length === 0) {
-    return "";
+  if (replyAnchorSummary.length > 0) {
+    const assistantMatch = replyAnchorSummary.match(/assistant:\s*([\s\S]+)$/i);
+    return assistantMatch?.[1]?.trim() ?? replyAnchorSummary;
   }
-  const assistantMatch = replyAnchorSummary.match(/assistant:\s*([\s\S]+)$/i);
-  return assistantMatch?.[1]?.trim() ?? replyAnchorSummary;
+
+  const assistantAnchorSummary = (conversationContext?.selectedBlocks ?? [])
+    .find((block) => block.source === "assistant_anchor")
+    ?.summary
+    ?.trim();
+  return assistantAnchorSummary ?? "";
 }
 
-function replyAnchorSalientTokens(
+function anchoredAssistantSpecificTokens(
   conversationContext: FridayAgentConversationContext | undefined,
   currentTaskTokens: string[],
 ): string[] {
-  const assistantSummary = replyAnchorAssistantSummary(conversationContext);
+  const assistantFact = deriveAnchoredAssistantFact(conversationContext);
+  if (assistantFact.length === 0) {
+    return [];
+  }
+  const currentTaskTokenSet = new Set(currentTaskTokens);
+  return tokenize(assistantFact).filter((token) => !currentTaskTokenSet.has(token));
+}
+
+function anchoredAssistantSalientTokens(
+  conversationContext: FridayAgentConversationContext | undefined,
+  currentTaskTokens: string[],
+): string[] {
+  const assistantSummary = deriveAnchoredAssistantFact(conversationContext);
   if (assistantSummary.length === 0) {
     return [];
   }
@@ -173,6 +179,30 @@ function isShortReplyFollowUp(task: string): boolean {
     || /(为什么|什么|这里|这个|那个|连接|打不开|打开)/.test(normalized);
 }
 
+function hasAnchoredAssistantFact(
+  conversationContext: FridayAgentConversationContext | undefined,
+): boolean {
+  return deriveAnchoredAssistantFact(conversationContext).length > 0;
+}
+
+function anchorFactLooksNegative(
+  conversationContext: FridayAgentConversationContext | undefined,
+): boolean {
+  const assistantFact = deriveAnchoredAssistantFact(conversationContext);
+  return assistantFact.length > 0
+    && (
+      ENGLISH_ERROR_FACT_TERMS.test(assistantFact)
+      || CHINESE_ERROR_FACT_TERMS.test(assistantFact)
+    );
+}
+
+function responseClaimsPositiveActionState(responseText: string): boolean {
+  return (
+    POSITIVE_ACTION_CLAIM_TERMS.test(responseText)
+    || CHINESE_POSITIVE_ACTION_CLAIM_TERMS.test(responseText)
+  );
+}
+
 export function evaluateFridayAnswerAlignment(params: {
   task: string;
   responseText: string;
@@ -195,14 +225,20 @@ export function evaluateFridayAnswerAlignment(params: {
   );
   const currentOverlap = countOverlap(responseTokens, currentTaskTokens);
   const anchoredOverlap = countOverlap(responseTokens, anchoredContextTokens);
-  const replyAnchorSpecificOverlap = countOverlap(
+  const anchoredAssistantSpecificOverlap = countOverlap(
     responseTokens,
-    replyAnchorSpecificTokens(params.conversationContext, currentTaskTokens),
+    anchoredAssistantSpecificTokens(params.conversationContext, currentTaskTokens),
   );
-  const replyAnchorSalientOverlap = countOverlap(
+  const anchoredAssistantSalientOverlap = countOverlap(
     responseTokens,
-    replyAnchorSalientTokens(params.conversationContext, currentTaskTokens),
+    anchoredAssistantSalientTokens(params.conversationContext, currentTaskTokens),
   );
+  const hasExplicitReplyAnchor = Boolean(
+    params.conversationContext?.selectedBlocks?.some((block) => block.source === "reply_anchor"),
+  );
+  const hasAssistantFactAnchor = hasAnchoredAssistantFact(params.conversationContext);
+  const anchorBlocks = (params.conversationContext?.selectedBlocks ?? [])
+    .filter((block) => block.source === "reply_anchor" || block.source === "assistant_anchor");
 
   if (turnKind === "status_check") {
     const hasStatusLanguage = STATUS_TERMS.test(responseText) || CHINESE_STATUS_TERMS.test(responseText);
@@ -231,7 +267,7 @@ export function evaluateFridayAnswerAlignment(params: {
   }
 
   if (
-    params.conversationContext?.selectedBlocks?.some((block) => block.source === "reply_anchor")
+    hasAssistantFactAnchor
     && (
       GENERIC_CONTEXT_REQUEST_TERMS.test(responseText)
       || CHINESE_GENERIC_CONTEXT_REQUEST_TERMS.test(responseText)
@@ -241,13 +277,12 @@ export function evaluateFridayAnswerAlignment(params: {
       retryPrompt: [
         "You asked the user for more context even though an explicit reply anchor was already selected for this turn.",
         `Current turn: ${params.task}`,
-        `Reply anchor(s):\n${params.conversationContext.selectedBlocks
-          .filter((block) => block.source === "reply_anchor")
+        `Reply/assistant anchor(s):\n${anchorBlocks
           .map((block) => `- ${block.summary}`)
           .join("\n")}`,
         "Answer the referenced point directly. If the user is asking about a prior statement, first explain what that referenced statement means.",
         "If the underlying root cause is unknown, say that the root cause is unknown after restating the anchored fact.",
-        "Do not ask the user what 'this/that/here' refers to unless the reply anchor itself is ambiguous.",
+        "Do not ask the user what 'this/that/here' refers to unless the selected anchor itself is ambiguous.",
       ].join("\n"),
     };
   }
@@ -270,16 +305,15 @@ export function evaluateFridayAnswerAlignment(params: {
   }
 
   if (
-    params.conversationContext?.selectedBlocks?.some((block) => block.source === "reply_anchor")
+    hasExplicitReplyAnchor
     && (turnKind === "follow_up" || turnKind === "clarification" || turnKind === "continue_active_task")
-    && replyAnchorSpecificOverlap === 0
+    && anchoredAssistantSpecificOverlap === 0
   ) {
     return {
       retryPrompt: [
-        "You answered a reply-anchored follow-up without carrying forward any concrete detail from the anchored context.",
+        "You answered an anchored follow-up without carrying forward any concrete detail from the referenced assistant fact.",
         `Current follow-up: ${params.task}`,
-        `Reply anchor(s):\n${params.conversationContext.selectedBlocks
-          .filter((block) => block.source === "reply_anchor")
+        `Reply/assistant anchor(s):\n${anchorBlocks
           .map((block) => `- ${block.summary}`)
           .join("\n")}`,
         "Answer the anchored follow-up directly and mention the relevant anchored fact(s).",
@@ -291,20 +325,19 @@ export function evaluateFridayAnswerAlignment(params: {
   }
 
   if (
-    params.conversationContext?.selectedBlocks?.some((block) => block.source === "reply_anchor")
+    hasAssistantFactAnchor
     && (turnKind === "follow_up" || turnKind === "clarification" || turnKind === "continue_active_task")
     && (
       GENERIC_TROUBLESHOOTING_TERMS.test(responseText)
       || CHINESE_GENERIC_TROUBLESHOOTING_TERMS.test(responseText)
     )
-    && (replyAnchorSalientOverlap === 0 || isShortReplyFollowUp(params.task))
+    && (anchoredAssistantSalientOverlap === 0 || isShortReplyFollowUp(params.task))
   ) {
     return {
       retryPrompt: [
-        "You answered a reply-anchored follow-up with generic troubleshooting instead of the concrete fact from the referenced earlier reply.",
+        "You answered an anchored follow-up with generic troubleshooting instead of the concrete fact from the referenced earlier reply.",
         `Current follow-up: ${params.task}`,
-        `Reply anchor(s):\n${params.conversationContext.selectedBlocks
-          .filter((block) => block.source === "reply_anchor")
+        `Reply/assistant anchor(s):\n${anchorBlocks
           .map((block) => `- ${block.summary}`)
           .join("\n")}`,
         "Do not give a generic checklist.",
@@ -314,7 +347,7 @@ export function evaluateFridayAnswerAlignment(params: {
   }
 
   if (
-    params.conversationContext?.selectedBlocks?.some((block) => block.source === "reply_anchor")
+    hasAssistantFactAnchor
     && isShortReplyFollowUp(params.task)
     && (
       SPECULATION_TERMS.test(responseText)
@@ -327,10 +360,9 @@ export function evaluateFridayAnswerAlignment(params: {
   ) {
     return {
       retryPrompt: [
-        "You answered a short reply-anchored follow-up by speculating about root causes instead of sticking to the verified earlier fact.",
+        "You answered a short anchored follow-up by speculating about root causes instead of sticking to the verified earlier fact.",
         `Current follow-up: ${params.task}`,
-        `Reply anchor(s):\n${params.conversationContext.selectedBlocks
-          .filter((block) => block.source === "reply_anchor")
+        `Reply/assistant anchor(s):\n${anchorBlocks
           .map((block) => `- ${block.summary}`)
           .join("\n")}`,
         "Restate the anchored fact first.",
@@ -340,21 +372,40 @@ export function evaluateFridayAnswerAlignment(params: {
   }
 
   if (
-    params.conversationContext?.selectedBlocks?.some((block) => block.source === "reply_anchor")
+    hasExplicitReplyAnchor
     && isShortReplyFollowUp(params.task)
-    && replyAnchorSalientTokens(params.conversationContext, currentTaskTokens).length > 0
-    && replyAnchorSalientOverlap === 0
+    && anchoredAssistantSalientTokens(params.conversationContext, currentTaskTokens).length > 0
+    && anchoredAssistantSalientOverlap === 0
   ) {
     return {
       retryPrompt: [
-        "This short reply-anchored follow-up should stay attached to the concrete error/failure fact from the earlier reply.",
+        "This short anchored follow-up should stay attached to the concrete error/failure fact from the earlier reply.",
         `Current follow-up: ${params.task}`,
-        `Reply anchor(s):\n${params.conversationContext.selectedBlocks
-          .filter((block) => block.source === "reply_anchor")
+        `Reply/assistant anchor(s):\n${anchorBlocks
           .map((block) => `- ${block.summary}`)
           .join("\n")}`,
         "Explain the referenced earlier fact directly before adding any broader caveat.",
         "If the deeper cause is unknown, say that explicitly after restating the anchored fact.",
+      ].join("\n"),
+    };
+  }
+
+  if (
+    hasAssistantFactAnchor
+    && !hasExplicitReplyAnchor
+    && isShortReplyFollowUp(params.task)
+    && anchorFactLooksNegative(params.conversationContext)
+    && responseClaimsPositiveActionState(responseText)
+  ) {
+    return {
+      retryPrompt: [
+        "You turned a short anchored follow-up into a new successful action/result, which contradicts the earlier anchored fact.",
+        `Current follow-up: ${params.task}`,
+        `Reply/assistant anchor(s):\n${anchorBlocks
+          .map((block) => `- ${block.summary}`)
+          .join("\n")}`,
+        "Do not claim a new successful action, new connection, or new completion state unless this turn produced new deterministic evidence.",
+        "First restate the anchored earlier fact. If the deeper cause is unknown, say that explicitly instead of inventing a new outcome.",
       ].join("\n"),
     };
   }

--- a/src/agent/runtime/friday-agent-runtime.ts
+++ b/src/agent/runtime/friday-agent-runtime.ts
@@ -56,16 +56,23 @@ function hasCjkText(text: string): boolean {
 function deriveReplyAnchorAssistantFact(
   conversationContext?: FridayAgentConversationContext,
 ): string | undefined {
-  const summary = conversationContext?.selectedBlocks
+  const replyAnchorSummary = conversationContext?.selectedBlocks
     ?.find((block) => block.source === "reply_anchor")
     ?.summary
     ?.trim();
-  if (!summary) {
-    return undefined;
+  if (replyAnchorSummary) {
+    const assistantMatch = replyAnchorSummary.match(/assistant:\s*([\s\S]+)$/i);
+    const fact = assistantMatch?.[1]?.trim() ?? replyAnchorSummary;
+    return fact.length > 0 ? fact : undefined;
   }
-  const assistantMatch = summary.match(/assistant:\s*([\s\S]+)$/i);
-  const fact = assistantMatch?.[1]?.trim() ?? summary;
-  return fact.length > 0 ? fact : undefined;
+
+  const assistantAnchorSummary = conversationContext?.selectedBlocks
+    ?.find((block) => block.source === "assistant_anchor")
+    ?.summary
+    ?.trim();
+  return assistantAnchorSummary && assistantAnchorSummary.length > 0
+    ? assistantAnchorSummary
+    : undefined;
 }
 
 function buildReplyAnchorFallbackResponse(params: {
@@ -251,10 +258,10 @@ export function createFridayAgentRuntime(
       const disabledToolNames = new Set(normalizeToolNameSet(params.disabledToolNames));
       const executionContext = params.executionContext;
       const conversationContext = params.conversationContext;
-      const hasReplyAnchor = Boolean(
-        conversationContext?.selectedBlocks?.some((block) => block.source === "reply_anchor"),
+      const hasAnchoredAssistantFact = Boolean(
+        deriveReplyAnchorAssistantFact(conversationContext),
       );
-      if (hasReplyAnchor && !hasExplicitResearchIntent(params.task)) {
+      if (hasAnchoredAssistantFact && !hasExplicitResearchIntent(params.task)) {
         disabledToolNames.add("web_search");
       }
       const principalId =
@@ -1095,7 +1102,7 @@ export function createFridayAgentRuntime(
               historyMessages: normalizeHistoryMessages(params.historyMessages),
               conversationContext,
             });
-            const maxAnswerAlignmentRetries = hasReplyAnchor ? 2 : 1;
+            const maxAnswerAlignmentRetries = hasAnchoredAssistantFact ? 2 : 1;
             if (
               alignmentDecision.retryPrompt &&
               alignedResponse.trim().length > 0 &&
@@ -1112,7 +1119,7 @@ export function createFridayAgentRuntime(
             if (
               alignmentDecision.retryPrompt
               && alignedResponse.trim().length > 0
-              && hasReplyAnchor
+              && hasAnchoredAssistantFact
             ) {
               const anchoredFallback = buildReplyAnchorFallbackResponse({
                 task: params.task,

--- a/src/sessions/services/friday-session-conversation-orchestrator.ts
+++ b/src/sessions/services/friday-session-conversation-orchestrator.ts
@@ -34,6 +34,24 @@ const STOPWORDS = new Set([
   "which", "who", "why", "you", "your",
 ]);
 
+function isShortContextualFollowUpTask(task: string): boolean {
+  const normalized = normalizeText(task);
+  return normalized.length <= 48
+    || /\b(why|what|that|this|here|it|connect|open)\b/i.test(normalized)
+    || /(为什么|什么|这里|这个|那个|连接|打不开|打开)/.test(normalized);
+}
+
+function isShortAssistantAnchorFollowUpTask(task: string): boolean {
+  const normalized = normalizeText(task);
+  if (normalized.length === 0 || normalized.length > 48) {
+    return false;
+  }
+  return (
+    /\b(why|what|that|this|here|it|same|again|connect|didn't|did not|failed)\b/i.test(normalized)
+    || /(为什么|什么|这里|这个|那个|同一个|还是|连接|打不开|失败|没连上)/.test(normalized)
+  );
+}
+
 export interface FridayPreparedConversationTurn {
   turnKind: FridayConversationTurnKind;
   historyMessages: FridayAgentMessage[];
@@ -184,6 +202,7 @@ export function classifyFridayConversationTurn(input: {
   const latestAssistantOverlap = countOverlap(taskTokens, tokenize(latestAssistant?.contentText ?? focusState?.assistantAnchorSummary ?? ""));
   const latestUserOverlap = countOverlap(taskTokens, tokenize(latestUser?.contentText ?? ""));
   const hasReplyAnchor = Boolean(resolveReplyAnchorRecord(records, input.replyToMessageId));
+  const hasAssistantAnchor = Boolean(latestAssistant?.contentText || focusState?.assistantAnchorSummary);
   const shortTask = task.length > 0 && task.length <= 120;
   const advisoryContinuation =
     ADVISORY_CONTINUATION_HINTS.test(taskLower)
@@ -206,6 +225,13 @@ export function classifyFridayConversationTurn(input: {
     return "clarification";
   }
   if (hasReplyAnchor) {
+    return "follow_up";
+  }
+  if (
+    hasFocus
+    && hasAssistantAnchor
+    && isShortAssistantAnchorFollowUpTask(task)
+  ) {
     return "follow_up";
   }
   if (
@@ -314,6 +340,38 @@ function buildAnchorWindow(
   return nextAssistant ? [anchorRecord, nextAssistant] : [anchorRecord];
 }
 
+function deriveSelectedAssistantFact(input: {
+  selectedBlocks: FridayConversationBlock[];
+  focusState?: FridaySessionConversationFocusState | null;
+}): string | undefined {
+  const replyAnchorSummary = input.selectedBlocks
+    .find((block) => block.source === "reply_anchor")
+    ?.summary
+    ?.trim();
+  if (replyAnchorSummary) {
+    const assistantMatch = replyAnchorSummary.match(/assistant:\s*([\s\S]+)$/i);
+    const replyAssistantFact = assistantMatch?.[1]?.trim() ?? replyAnchorSummary;
+    if (replyAssistantFact.length > 0) {
+      return replyAssistantFact;
+    }
+  }
+
+  const assistantAnchorSummary = input.selectedBlocks
+    .find((block) => block.source === "assistant_anchor")
+    ?.summary
+    ?.trim();
+  if (assistantAnchorSummary && assistantAnchorSummary.length > 0) {
+    return assistantAnchorSummary;
+  }
+
+  const persistedAssistantAnchor = input.focusState?.assistantAnchorSummary?.trim();
+  if (persistedAssistantAnchor && persistedAssistantAnchor.length > 0) {
+    return persistedAssistantAnchor;
+  }
+
+  return undefined;
+}
+
 function buildConversationBlockSelection(input: {
   task: string;
   historyRecords: FridaySessionMessageRecord[];
@@ -363,7 +421,7 @@ function buildConversationBlockSelection(input: {
     registerCandidate(createMessageBlockCandidate({
       id: `assistant:${latestAssistant.id}`,
       source: "assistant_anchor",
-      summary: buildAnchorWindow(records, latestAssistant).map((record) => `${record.role}: ${record.contentText}`).join("\n"),
+      summary: latestAssistant.contentText,
       score: assistantScore,
       reason: assistantOverlap > 0
         ? `Current turn overlaps the latest assistant answer (${String(assistantOverlap)} token match(es)).`
@@ -506,6 +564,15 @@ function buildTaskPrompt(input: {
   const task = normalizeText(input.task);
   const previousTopicSummary = input.focusState?.currentTopicSummary?.trim();
   const hasExplicitReplyAnchor = input.selectedBlocks.some((block) => block.source === "reply_anchor");
+  const assistantFactSummary = deriveSelectedAssistantFact({
+    selectedBlocks: input.selectedBlocks,
+    focusState: input.focusState,
+  });
+  const isShortAssistantFactFollowUp = Boolean(
+    assistantFactSummary
+    && (input.turnKind === "follow_up" || input.turnKind === "clarification" || input.turnKind === "continue_active_task")
+    && isShortContextualFollowUpTask(task),
+  );
   const selectedBlockSummary = input.selectedBlocks.length > 0
     ? input.selectedBlocks
       .map((block) => `- [${block.source}] ${block.summary}`)
@@ -554,6 +621,23 @@ function buildTaskPrompt(input: {
       "An explicit reply anchor was selected. Treat that anchor as the user's intended referent even if the latest turn is short or deictic.",
       "Answer the referenced point directly from the anchored context before asking for more detail.",
       "Do not switch to generic advice or external research unless the user explicitly asked for that broader scope.",
+    ].filter((value): value is string => Boolean(value)).join("\n");
+  }
+
+  if (isShortAssistantFactFollowUp && assistantFactSummary) {
+    return [
+      previousTopicSummary
+        ? `Continue the current topic: ${previousTopicSummary}`
+        : "The user is following up on the latest assistant-stated fact.",
+      `Referenced assistant fact: ${assistantFactSummary}`,
+      selectedBlockSummary ? `Relevant anchors:\n${selectedBlockSummary}` : undefined,
+      hasExplicitReplyAnchor
+        ? "An explicit reply anchor was selected. Treat that anchor as the user's intended referent even if the latest turn is short or deictic."
+        : "Treat this short follow-up as referring to the referenced assistant fact even if the user uses deictic wording like “这里/这个/that one/why didn’t it connect”.",
+      `Latest user turn: ${task}`,
+      "Explain the referenced assistant fact directly before adding any broader caveat.",
+      "Do not claim a new action, a new success state, or a new result unless this turn produced new deterministic evidence.",
+      "If the deeper cause is unknown, say that explicitly instead of speculating.",
     ].filter((value): value is string => Boolean(value)).join("\n");
   }
 

--- a/test/unit/agent/runtime/friday-agent-runtime.test.ts
+++ b/test/unit/agent/runtime/friday-agent-runtime.test.ts
@@ -833,6 +833,157 @@ describe("FridayAgentRuntime", () => {
     );
   });
 
+  it("retries when an implicit assistant-anchor follow-up invents a new successful state", async () => {
+    const capturedCalls: FridayAgentMessage[][] = [];
+    let callIndex = 0;
+
+    const llmClient: FridayAgentLlmClient = {
+      async *stream(params) {
+        capturedCalls.push(params.messages.map((message) => ({
+          role: message.role,
+          content: typeof message.content === "string"
+            ? message.content
+            : JSON.parse(JSON.stringify(message.content)),
+        })));
+        if (callIndex === 0) {
+          callIndex++;
+          yield {
+            type: "text_delta",
+            text: "我已经成功将焦点转移到 Codex 应用。现在你可以查看消息了。",
+          };
+          yield { type: "message_end", stopReason: "end_turn", inputTokens: 8, outputTokens: 18 };
+          return;
+        }
+        yield {
+          type: "text_delta",
+          text: "前面那次并不是已经连上了，而是桌面伴侣没有连接，所以 Friday 当时无法查看桌面内容。更深一层的原因我现在没有可验证证据。",
+        };
+        yield { type: "message_end", stopReason: "end_turn", inputTokens: 9, outputTokens: 24 };
+      },
+    };
+
+    const runtime = createFridayAgentRuntime({
+      db,
+      llmClient,
+      model: "test-model",
+      providerId: "test-provider",
+      systemPrompt: "You are a test agent.",
+      tools: [],
+      eventEmitter: createFridayAgentEventEmitter(),
+      idGenerator,
+      nowIso: () => NOW,
+    });
+
+    const result = await runtime.executeRun({
+      task: "为什么没有connect",
+      taskPrompt: [
+        "Continue the current topic: 看一下我桌面上的codex app给我的回复是什么",
+        "Referenced assistant fact: The desktop companion is not connected.",
+        "Relevant anchors:",
+        "- [assistant_anchor] The desktop companion is not connected.",
+        "Treat this short follow-up as referring to the referenced assistant fact even if the user uses deictic wording like “这里/这个/that one/why didn’t it connect”.",
+        "Latest user turn: 为什么没有connect",
+        "Explain the referenced assistant fact directly before adding any broader caveat.",
+        "Do not claim a new action, a new success state, or a new result unless this turn produced new deterministic evidence.",
+      ].join("\n"),
+      historyMessages: [
+        { role: "user", content: "看一下我桌面上的codex app给我的回复是什么" },
+        { role: "assistant", content: "The desktop companion is not connected." },
+      ],
+      conversationContext: {
+        turnKind: "follow_up",
+        previousTopicSummary: "看一下我桌面上的codex app给我的回复是什么",
+        currentTopicSummary: "看一下我桌面上的codex app给我的回复是什么",
+        selectedBlocks: [
+          {
+            id: "assistant:msg-2",
+            source: "assistant_anchor",
+            summary: "The desktop companion is not connected.",
+            score: 42,
+            reason: "Latest assistant answer is a plausible short-follow-up anchor.",
+            messageIds: ["msg-2"],
+          },
+          {
+            id: "focus:current-topic",
+            source: "focus_topic",
+            summary: "看一下我桌面上的codex app给我的回复是什么",
+            score: 12,
+            reason: "Persisted focus topic kept as a low-weight context block.",
+          },
+        ],
+        selectionReasons: ["assistant_anchor → Latest assistant answer is a plausible short-follow-up anchor."],
+      },
+    });
+
+    expect(result.status).toBe("completed");
+    expect(result.response).toContain("没有连接");
+    expect(capturedCalls).toHaveLength(2);
+    expect(capturedCalls[1]![capturedCalls[1]!.length - 1]).toEqual(
+      expect.objectContaining({
+        role: "user",
+        content: expect.stringContaining("contradicts the earlier anchored fact"),
+      }),
+    );
+  });
+
+  it("falls back deterministically for implicit assistant-anchor follow-ups after exhausting retries", async () => {
+    let callIndex = 0;
+
+    const llmClient: FridayAgentLlmClient = {
+      async *stream() {
+        callIndex++;
+        if (callIndex === 1) {
+          yield { type: "text_delta", text: "我已经成功将焦点转移到 Codex 应用。现在你可以查看消息了。" };
+        } else if (callIndex === 2) {
+          yield { type: "text_delta", text: "常见原因包括网络、权限或者程序设置问题。" };
+        } else {
+          yield { type: "text_delta", text: "Generic troubleshooting still applies here." };
+        }
+        yield { type: "message_end", stopReason: "end_turn", inputTokens: 7, outputTokens: 12 };
+      },
+    };
+
+    const runtime = createFridayAgentRuntime({
+      db,
+      llmClient,
+      model: "test-model",
+      providerId: "test-provider",
+      systemPrompt: "You are a test agent.",
+      tools: [],
+      eventEmitter: createFridayAgentEventEmitter(),
+      idGenerator,
+      nowIso: () => NOW,
+    });
+
+    const result = await runtime.executeRun({
+      task: "这里",
+      historyMessages: [
+        { role: "user", content: "看一下我桌面上的codex app给我的回复是什么" },
+        { role: "assistant", content: "The desktop companion is not connected." },
+      ],
+      conversationContext: {
+        turnKind: "follow_up",
+        currentTopicSummary: "看一下我桌面上的codex app给我的回复是什么",
+        selectedBlocks: [
+          {
+            id: "assistant:msg-2",
+            source: "assistant_anchor",
+            summary: "The desktop companion is not connected.",
+            score: 42,
+            reason: "Latest assistant answer is a plausible short-follow-up anchor.",
+            messageIds: ["msg-2"],
+          },
+        ],
+        selectionReasons: ["assistant_anchor → Latest assistant answer is a plausible short-follow-up anchor."],
+      },
+    });
+
+    expect(callIndex).toBe(3);
+    expect(result.status).toBe("completed");
+    expect(result.response).toContain("The desktop companion is not connected.");
+    expect(result.response).toContain("不做额外假设");
+  });
+
   it("allows up to two alignment retries for reply-anchor follow ups", async () => {
     let callIndex = 0;
     const capturedCalls: FridayAgentMessage[][] = [];

--- a/test/unit/sessions/services/friday-session-conversation-orchestrator.test.ts
+++ b/test/unit/sessions/services/friday-session-conversation-orchestrator.test.ts
@@ -105,7 +105,49 @@ describe("friday-session-conversation-orchestrator", () => {
 
     expect(prepared.turnKind).toBe("follow_up");
     expect(prepared.selectedBlocks.some((block) => block.source === "assistant_anchor")).toBe(true);
-    expect(prepared.taskPrompt).toContain("Relevant anchors");
+    expect(prepared.taskPrompt).toContain("Referenced assistant fact:");
+    expect(prepared.taskPrompt).toContain("desktop companion is not connected");
+    expect(prepared.taskPrompt).toContain("Do not claim a new action");
+  });
+
+  it("keeps a short why-question on the same topic even when the latest assistant anchor uses different wording", () => {
+    const prepared = prepareFridayConversationTurn({
+      task: "为什么没有connect",
+      focusState: {
+        ...baseFocusState,
+        currentTopicSummary: "看一下我桌面上的codex app给我的回复是什么",
+        assistantAnchorSummary: "当前桌面上的 Codex 应用程序无法列出通知，状态为不可用。",
+      },
+      currentUserSequence: 5,
+      historyRecords: [
+        makeMessage({ sequence: 1, role: "user", contentText: "看一下我桌面上的codex app给我的回复是什么" }),
+        makeMessage({ sequence: 2, role: "assistant", contentText: "当前桌面上的 Codex 应用程序无法列出通知，状态为不可用。" }),
+      ],
+    });
+
+    expect(prepared.turnKind).toBe("follow_up");
+    expect(prepared.taskPrompt).toContain("Referenced assistant fact:");
+    expect(prepared.taskPrompt).toContain("Codex 应用程序无法列出通知");
+  });
+
+  it("stores assistant-anchor summaries as assistant facts instead of full user-assistant windows", () => {
+    const prepared = prepareFridayConversationTurn({
+      task: "这里",
+      focusState: {
+        ...baseFocusState,
+        currentTopicSummary: "看一下我桌面上的codex app给我的回复是什么",
+        assistantAnchorSummary: "The desktop companion is not connected.",
+      },
+      currentUserSequence: 5,
+      historyRecords: [
+        makeMessage({ sequence: 1, role: "user", contentText: "看一下我桌面上的codex app给我的回复是什么" }),
+        makeMessage({ sequence: 2, role: "assistant", contentText: "The desktop companion is not connected." }),
+      ],
+    });
+
+    const assistantAnchor = prepared.selectedBlocks.find((block) => block.source === "assistant_anchor");
+    expect(assistantAnchor?.summary).toBe("The desktop companion is not connected.");
+    expect(prepared.taskPrompt).toContain("Referenced assistant fact: The desktop companion is not connected.");
   });
 
   it("resolves reply anchors from platform source message ids", () => {
@@ -147,9 +189,10 @@ describe("friday-session-conversation-orchestrator", () => {
     });
 
     expect(prepared.turnKind).toBe("follow_up");
-    expect(prepared.taskPrompt).toContain("specifically referenced earlier exchange");
+    expect(prepared.taskPrompt).toContain("following up on the latest assistant-stated fact");
+    expect(prepared.taskPrompt).toContain("Referenced assistant fact: I could not open GitHub because the browser session was not connected.");
     expect(prepared.taskPrompt).toContain("Relevant anchors");
-    expect(prepared.taskPrompt).toContain("Do not reinterpret this as a generic troubleshooting or research request");
+    expect(prepared.taskPrompt).toContain("Do not claim a new action, a new success state, or a new result");
   });
 
   it("treats explicit progress checks as status_check and avoids prior answer history", () => {


### PR DESCRIPTION
## Summary
- keep short follow-ups on the active topic when they refer back to the latest assistant fact
- tighten answer alignment for implicit assistant anchors so the model stops inventing new successful states
- add regression coverage for Chinese/English short follow-ups and deterministic fallback behavior

## Validation
- npm run typecheck
- npm run lint
- npx vitest run test/unit/sessions/services/friday-session-conversation-orchestrator.test.ts test/unit/agent/runtime/friday-agent-runtime.test.ts
- real-model smoke on a temporary Friday instance at :3242 for Chinese follow-ups, four-turn Chinese replay, and explicit replyTo anchoring
