### PR TITLE
fix: keep desktop inspection tasks read-only

### DIFF
--- a/src/agent/runtime/friday-agent-runtime.ts
+++ b/src/agent/runtime/friday-agent-runtime.ts
@@ -967,6 +967,7 @@ export function createFridayAgentRuntime(
         let evidenceEnforcementRetries = 0;
         let timelinessEnforcementRetries = 0;
         let answerAlignmentRetries = 0;
+        let desktopInspectionRetries = 0;
 
         while (iterations < FRIDAY_AGENT_MAX_LOOP_ITERATIONS) {
           if (runAbortController.signal.aborted) {
@@ -1096,6 +1097,24 @@ export function createFridayAgentRuntime(
             }
 
             const alignedResponse = timelinessDecision.responseText;
+            if (
+              taskRequiresReadOnlyDesktopInspection(params.task)
+              && hasDesktopContentInspectionCoverageEvidence(allToolCalls)
+              && alignedResponse.trim().length > 0
+              && !responseAddressesDesktopContentInspection(alignedResponse)
+              && desktopInspectionRetries < 1
+            ) {
+              desktopInspectionRetries++;
+              messages.push({
+                role: "user",
+                content: buildDesktopContentInspectionRetryPrompt({
+                  task: params.task,
+                  toolCalls: allToolCalls,
+                }),
+              });
+              continue;
+            }
+
             const alignmentDecision = evaluateFridayAnswerAlignment({
               task: params.task,
               responseText: alignedResponse,
@@ -2256,6 +2275,164 @@ function taskLooksLikeDesktopAction(task: string): boolean {
   return english.test(task) || chinese.test(task);
 }
 
+function taskLooksLikeDesktopContentInspection(task: string): boolean {
+  const englishDesktop =
+    /\b(desktop|screen|window|app|application|notification|message|reply|response)\b/i;
+  const englishInspection =
+    /\b(read|look(?:\s+at)?|check|see|show|what(?:'s| is)?|content|message|reply|response|notification|says?)\b/i;
+  const chineseDesktop =
+    /(桌面|屏幕|窗口|应用|app|通知|消息|回复)/;
+  const chineseInspection =
+    /(看一下|看下|看看|读取|读一下|回复是什么|说了什么|内容是什么|消息是什么|通知是什么|显示什么)/;
+  return (
+    (englishDesktop.test(task) && englishInspection.test(task))
+    || (chineseDesktop.test(task) && chineseInspection.test(task))
+  );
+}
+
+function taskExplicitlyRequestsDesktopMutation(task: string): boolean {
+  const english =
+    /\b(open|launch|start|click|type|press|focus|arrange|close|scroll|drag|navigate|switch)\b/i;
+  const chinese =
+    /(打开|启动|点开|点击|输入|按下|聚焦|排列|关闭|滚动|拖动|切换)/;
+  return english.test(task) || chinese.test(task);
+}
+
+function taskRequiresReadOnlyDesktopInspection(task: string): boolean {
+  if (!taskLooksLikeDesktopContentInspection(task)) {
+    return false;
+  }
+  return !taskExplicitlyRequestsDesktopMutation(task);
+}
+
+function responseAddressesDesktopContentInspection(responseText: string): boolean {
+  const normalized = responseText.trim();
+  if (normalized.length === 0) return false;
+  const englishVerdict =
+    /\b(cannot|can't|unable|not able|could not|did not|didn't|can see|i see|visible|not visible|not readable|couldn't read|cannot read|reply is|response is|message says|content says|i found)\b/i;
+  const chineseVerdict =
+    /(无法|不能|未能|看不到|没看到|无法读取|不能读取|无法确认|不能确认|看到了|我看到|可见|不可见|回复是|消息是|内容是|我找到了)/;
+  return englishVerdict.test(normalized) || chineseVerdict.test(normalized);
+}
+
+function snapshotSuggestsDesktopUnavailable(toolCalls: FridayAgentToolCallRecord[]): boolean {
+  return toolCalls.some((call) => {
+    if (call.toolName !== "system" || call.result.isError || call.args.action !== "snapshot") {
+      return false;
+    }
+    const content = call.result.content;
+    return /desktopConnected\"\s*:\s*false/i.test(content)
+      || /desktop_session_unavailable/i.test(content)
+      || /safe_mode/i.test(content)
+      || /safeMode\"\s*:\s*true/i.test(content);
+  });
+}
+
+function hasDesktopContentInspectionCoverageEvidence(
+  toolCalls: FridayAgentToolCallRecord[],
+): boolean {
+  return toolCalls.some((call) => {
+    if (call.result.isError) {
+      return false;
+    }
+    if (call.toolName !== "system") {
+      return false;
+    }
+    return call.args.action === "snapshot"
+      || call.args.action === "notification_list"
+      || call.args.action === "read_notification"
+      || call.args.action === "triage_notifications";
+  });
+}
+
+function buildDesktopContentInspectionRetryPrompt(params: {
+  task: string;
+  toolCalls: FridayAgentToolCallRecord[];
+}): string {
+  const unavailableHint = snapshotSuggestsDesktopUnavailable(params.toolCalls)
+    ? "The current snapshot indicates desktop/session limitations (for example safe mode or desktop not connected). Make that explicit."
+    : "";
+  return [
+    "You answered a desktop content-inspection request with environment/app status, but you did not clearly answer whether the requested content was actually visible.",
+    "Answer the user's actual question directly.",
+    "If the requested reply/content is visible from current tool evidence, say what it is.",
+    "If it is not currently readable or not verified, say that explicitly and explain why using the existing tool evidence.",
+    "Do not just list running apps, PIDs, or generic environment status.",
+    unavailableHint,
+  ].filter((part) => part.length > 0).join(" ");
+}
+
+function toolCallViolatesDesktopInspectionIntent(params: {
+  task: string;
+  toolName: string;
+  toolArgs: Record<string, unknown>;
+}): string | null {
+  if (!taskRequiresReadOnlyDesktopInspection(params.task)) {
+    return null;
+  }
+
+  if (params.toolName === "system") {
+    const action = typeof params.toolArgs.action === "string" ? params.toolArgs.action : "";
+    const blockedActions = new Set([
+      "open",
+      "focus",
+      "arrange_windows",
+      "launch_app",
+      "close_app",
+      "open_url",
+      "open_project",
+      "search_file",
+      "handoff_to_browser",
+      "handoff_to_terminal",
+      "recover_ui",
+      "clipboard_write",
+      "request_control",
+      "release_control",
+      "approve",
+      "deny",
+    ]);
+    if (blockedActions.has(action)) {
+      return `This task asked to inspect existing desktop/app content, not to mutate the desktop. Do not use system.${action}; use system.snapshot, notification_list/read_notification, or desktop screenshot/session_info instead.`;
+    }
+  }
+
+  if (params.toolName === "desktop") {
+    const action = typeof params.toolArgs.action === "string" ? params.toolArgs.action : "";
+    if (action === "execute") {
+      const actionType = typeof params.toolArgs.actionType === "string" ? params.toolArgs.actionType : "";
+      const blockedActionTypes = new Set([
+        "type",
+        "keypress",
+        "launch_app",
+        "close_app",
+        "file_operation",
+      ]);
+      if (blockedActionTypes.has(actionType)) {
+        return `This task asked to inspect existing desktop/app content, not to perform desktop execute.${actionType}. Use desktop.screenshot, inspect_element, search_elements, session_info, or a read-only system action instead.`;
+      }
+      if (actionType === "clipboard") {
+        const operation = typeof params.toolArgs.operation === "string" ? params.toolArgs.operation : "";
+        if (operation !== "" && operation !== "read") {
+          return "This task asked to inspect existing desktop/app content, not to mutate the clipboard. Use a read-only action instead.";
+        }
+      }
+    }
+    if (action === "start_recording" || action === "stop_recording") {
+      return `This task asked to inspect existing desktop/app content, not to ${action.replace("_", " ")}. Use screenshot/session_info/inspect_element instead.`;
+    }
+  }
+
+  if (params.toolName === "browser") {
+    const action = typeof params.toolArgs.action === "string" ? params.toolArgs.action : "";
+    const blockedActions = new Set(["open", "navigate", "goto", "act", "type", "click"]);
+    if (blockedActions.has(action)) {
+      return `This task asked to inspect existing desktop/app content, not to perform browser.${action}. Use the current desktop/system evidence instead.`;
+    }
+  }
+
+  return null;
+}
+
 function classifyEvidenceTask(task: string): "web" | "desktop" | null {
   if (taskLooksLikeDesktopAction(task)) return "desktop";
   if (taskLooksLikeExternalAction(task)) return "web";
@@ -3189,6 +3366,40 @@ async function executeToolCall(
     const unavailableMessage = buildUnavailableToolMessage(toolUse.name);
     const result = {
       content: unavailableMessage,
+      isError: true,
+    };
+    const durationMs = Date.now() - startedAt;
+
+    emitRunEvent("agent.run.tool_end", {
+      runId,
+      toolName: toolUse.name,
+      toolCallId: toolUse.id,
+      durationMs,
+      isError: true,
+      summary: result.content.slice(0, 200),
+      errorCode: FRIDAY_AGENT_ERROR_CODES.TOOL_ERROR,
+      routeId,
+      correlationId,
+    });
+
+    return {
+      toolCallId: toolUse.id,
+      toolName: toolUse.name,
+      args: toolUse.input,
+      result,
+      durationMs,
+      startedAt: nowIso(),
+    };
+  }
+
+  const taskIntentViolation = toolCallViolatesDesktopInspectionIntent({
+    task: params.taskPrompt ?? "",
+    toolName: toolUse.name,
+    toolArgs,
+  });
+  if (taskIntentViolation) {
+    const result = {
+      content: taskIntentViolation,
       isError: true,
     };
     const durationMs = Date.now() - startedAt;

--- a/test/unit/agent/runtime/friday-agent-runtime.test.ts
+++ b/test/unit/agent/runtime/friday-agent-runtime.test.ts
@@ -238,6 +238,63 @@ describe("FridayAgentRuntime", () => {
     };
   }
 
+  function createSystemTool(spy?: ReturnType<typeof vi.fn>): FridayAgentToolDefinition {
+    return {
+      name: "system",
+      description: "Mock system tool",
+      parameters: {
+        properties: {
+          action: { type: "string" },
+          appIdentifier: { type: "string" },
+        },
+        required: ["action"],
+      },
+      async execute(args) {
+        spy?.(args);
+        const action = typeof args.action === "string" ? args.action : "";
+        if (action === "snapshot") {
+          return {
+            content: JSON.stringify({
+              id: "system-snapshot-1",
+              action: "snapshot",
+              status: "completed",
+              message: "System snapshot captured",
+              payload: {
+                snapshot: {
+                  health: {
+                    status: "safe_mode",
+                    desktopConnected: false,
+                    companionConnected: false,
+                    reasons: ["desktop_session_unavailable"],
+                  },
+                  notifications: [],
+                },
+              },
+            }),
+          };
+        }
+        if (action === "open") {
+          return {
+            content: JSON.stringify({
+              id: "system-open-1",
+              action: "launch_app",
+              status: "completed",
+              message: `Launched ${String(args.appIdentifier ?? "app")}`,
+            }),
+          };
+        }
+        return {
+          content: JSON.stringify({
+            id: `system-${action || "unknown"}`,
+            action,
+            status: "completed",
+            message: `Ran ${action || "unknown"}`,
+          }),
+        };
+      },
+    };
+  }
+
   function createFailingDesktopTool(
     errorMessage = "Desktop session is not connected.",
     spy?: ReturnType<typeof vi.fn>,
@@ -1995,6 +2052,209 @@ describe("FridayAgentRuntime", () => {
     expect(result.toolCallCount).toBe(1);
     expect(execSpy).toHaveBeenCalledTimes(1);
     expect(result.response).toContain("可验证结果");
+  });
+
+  it("blocks app-launch tool calls for desktop content inspection tasks and retries with read-only evidence", async () => {
+    const systemSpy = vi.fn();
+    const llmClient = createMockLlmClient([
+      [
+        {
+          type: "tool_use",
+          id: "call-open",
+          name: "system",
+          input: { action: "open", appIdentifier: "codex app" },
+        },
+        { type: "message_end", stopReason: "tool_use", inputTokens: 8, outputTokens: 5 },
+      ],
+      [
+        {
+          type: "tool_use",
+          id: "call-snapshot",
+          name: "system",
+          input: { action: "snapshot" },
+        },
+        { type: "message_end", stopReason: "tool_use", inputTokens: 8, outputTokens: 5 },
+      ],
+      [
+        { type: "text_delta", text: "我目前只能确认桌面未连接，所以还看不到 Codex 回复。" },
+        { type: "message_end", stopReason: "end_turn", inputTokens: 8, outputTokens: 6 },
+      ],
+    ]);
+
+    const emitter = createFridayAgentEventEmitter();
+    const toolEndEvents: Array<Record<string, unknown>> = [];
+    emitter.on("agent.run.tool_end", (payload) => {
+      toolEndEvents.push(payload as Record<string, unknown>);
+    });
+
+    const runtime = createFridayAgentRuntime({
+      db,
+      llmClient,
+      model: "test-model",
+      providerId: "test-provider",
+      systemPrompt: "You are a test agent.",
+      tools: [createSystemTool(systemSpy)],
+      eventEmitter: emitter,
+      idGenerator,
+      nowIso: () => NOW,
+    });
+
+    const result = await runtime.executeRun({
+      task: "看一下我桌面上的codex app给我的回复是什么",
+    });
+
+    expect(result.status).toBe("completed");
+    expect(result.toolCallCount).toBe(2);
+    expect(systemSpy).toHaveBeenCalledTimes(1);
+    expect(systemSpy.mock.calls[0]?.[0]).toMatchObject({ action: "snapshot" });
+    expect(result.response).toContain("桌面未连接");
+    expect(toolEndEvents[0]?.toolName).toBe("system");
+    expect(toolEndEvents[0]?.isError).toBe(true);
+    expect(String(toolEndEvents[0]?.summary ?? "")).toContain("inspect existing desktop/app content");
+  });
+
+  it("allows app-launch tool calls when the task explicitly asks to open the app", async () => {
+    const systemSpy = vi.fn();
+    const llmClient = createMockLlmClient([
+      [
+        {
+          type: "tool_use",
+          id: "call-open",
+          name: "system",
+          input: { action: "open", appIdentifier: "codex app" },
+        },
+        { type: "message_end", stopReason: "tool_use", inputTokens: 8, outputTokens: 5 },
+      ],
+      [
+        { type: "text_delta", text: "已打开 Codex。" },
+        { type: "message_end", stopReason: "end_turn", inputTokens: 6, outputTokens: 4 },
+      ],
+    ]);
+
+    const runtime = createFridayAgentRuntime({
+      db,
+      llmClient,
+      model: "test-model",
+      providerId: "test-provider",
+      systemPrompt: "You are a test agent.",
+      tools: [createSystemTool(systemSpy)],
+      eventEmitter: createFridayAgentEventEmitter(),
+      idGenerator,
+      nowIso: () => NOW,
+    });
+
+    const result = await runtime.executeRun({
+      task: "打开 codex app",
+    });
+
+    expect(result.status).toBe("completed");
+    expect(result.toolCallCount).toBe(1);
+    expect(systemSpy).toHaveBeenCalledTimes(1);
+    expect(systemSpy.mock.calls[0]?.[0]).toMatchObject({ action: "open", appIdentifier: "codex app" });
+    expect(result.response).toContain("已打开 Codex");
+  });
+
+  it("blocks file-search tool calls for desktop content inspection tasks and retries with snapshot evidence", async () => {
+    const systemSpy = vi.fn();
+    const llmClient = createMockLlmClient([
+      [
+        {
+          type: "tool_use",
+          id: "call-search",
+          name: "system",
+          input: { action: "search_file", query: "codex app" },
+        },
+        { type: "message_end", stopReason: "tool_use", inputTokens: 8, outputTokens: 5 },
+      ],
+      [
+        {
+          type: "tool_use",
+          id: "call-snapshot",
+          name: "system",
+          input: { action: "snapshot" },
+        },
+        { type: "message_end", stopReason: "tool_use", inputTokens: 8, outputTokens: 5 },
+      ],
+      [
+        { type: "text_delta", text: "我目前只能确认桌面不可用，所以还看不到 Codex 回复。" },
+        { type: "message_end", stopReason: "end_turn", inputTokens: 8, outputTokens: 6 },
+      ],
+    ]);
+
+    const emitter = createFridayAgentEventEmitter();
+    const toolEndEvents: Array<Record<string, unknown>> = [];
+    emitter.on("agent.run.tool_end", (payload) => {
+      toolEndEvents.push(payload as Record<string, unknown>);
+    });
+
+    const runtime = createFridayAgentRuntime({
+      db,
+      llmClient,
+      model: "test-model",
+      providerId: "test-provider",
+      systemPrompt: "You are a test agent.",
+      tools: [createSystemTool(systemSpy)],
+      eventEmitter: emitter,
+      idGenerator,
+      nowIso: () => NOW,
+    });
+
+    const result = await runtime.executeRun({
+      task: "看一下我桌面上的codex app给我的回复是什么",
+    });
+
+    expect(result.status).toBe("completed");
+    expect(result.toolCallCount).toBe(2);
+    expect(systemSpy).toHaveBeenCalledTimes(1);
+    expect(systemSpy.mock.calls[0]?.[0]).toMatchObject({ action: "snapshot" });
+    expect(result.response).toContain("桌面不可用");
+    expect(toolEndEvents[0]?.isError).toBe(true);
+    expect(String(toolEndEvents[0]?.summary ?? "")).toContain("not to mutate the desktop");
+  });
+
+  it("re-prompts desktop content inspection answers that only list environment status without a visibility verdict", async () => {
+    const systemSpy = vi.fn();
+    const llmClient = createMockLlmClient([
+      [
+        {
+          type: "tool_use",
+          id: "call-snapshot",
+          name: "system",
+          input: { action: "snapshot" },
+        },
+        { type: "message_end", stopReason: "tool_use", inputTokens: 8, outputTokens: 5 },
+      ],
+      [
+        { type: "text_delta", text: "系统快照已成功捕获。当前前台应用是 Codex，处于安全模式。" },
+        { type: "message_end", stopReason: "end_turn", inputTokens: 8, outputTokens: 6 },
+      ],
+      [
+        { type: "text_delta", text: "我现在只能确认 Codex 在前台运行，但还没有看到你要的回复内容；当前快照也提示桌面不可用/安全模式，所以内容暂时无法验证。" },
+        { type: "message_end", stopReason: "end_turn", inputTokens: 8, outputTokens: 6 },
+      ],
+    ]);
+
+    const runtime = createFridayAgentRuntime({
+      db,
+      llmClient,
+      model: "test-model",
+      providerId: "test-provider",
+      systemPrompt: "You are a test agent.",
+      tools: [createSystemTool(systemSpy)],
+      eventEmitter: createFridayAgentEventEmitter(),
+      idGenerator,
+      nowIso: () => NOW,
+    });
+
+    const result = await runtime.executeRun({
+      task: "看一下我桌面上的codex app给我的回复是什么",
+    });
+
+    expect(result.status).toBe("completed");
+    expect(result.toolCallCount).toBe(1);
+    expect(systemSpy).toHaveBeenCalledTimes(1);
+    expect(result.response).toContain("没有看到你要的回复内容");
+    expect(result.response).toContain("无法验证");
   });
 
   it("retries desktop evidence path when prior desktop tools all failed", async () => {


### PR DESCRIPTION
## Summary
- keep desktop content-inspection tasks on read-only evidence paths
- block launch/search-file drift for desktop reply-reading prompts
- require a visibility verdict when snapshot-only answers just list environment state

## Validation
- npm run typecheck
- npm run lint
- npx vitest run test/unit/agent/runtime/friday-agent-runtime.test.ts
- real-model smoke on clean merged-main runtime (desktop reply-reading Chinese follow-up + explicit reply anchor)