### PR TITLE
feat: add block-based conversation compaction

### DIFF
--- a/src/providers/context/friday-provider-context-compactor.ts
+++ b/src/providers/context/friday-provider-context-compactor.ts
@@ -1,4 +1,6 @@
 import type {
+  FridayContextCompactionBlockKind,
+  FridayContextCompactionBlockSummary,
   FridayContextCompactionResult,
   FridayContextCompactionSummary,
   FridayProviderContextMessage,
@@ -6,18 +8,22 @@ import type {
 import type { FridayProviderTokenEstimator } from "./friday-provider-token-estimator.js";
 import type { FridayProviderContextPruner } from "./friday-provider-context-pruner.js";
 
-// ─── Constants ───
-
-/** Trigger compaction when estimated tokens exceed this ratio of context window. */
 const COMPACTION_TRIGGER_RATIO = 0.70;
+const MAX_RAW_BLOCKS = 3;
 
-/** Number of most-recent turns to always keep verbatim. */
-const KEEP_RECENT_TURNS = 8;
+const STOPWORDS = new Set([
+  "a", "an", "and", "are", "as", "at", "be", "for", "from", "how", "i", "in", "is", "it",
+  "of", "on", "or", "that", "the", "this", "to", "what", "when", "where", "which", "who",
+  "why", "you", "your",
+]);
 
-/** Max tokens for the generated summary. */
-const SUMMARY_MAX_TOKENS = 1_200;
-
-// ─── Interface ───
+interface FridayProviderContextCompactionBlock {
+  id: string;
+  kind: FridayContextCompactionBlockKind;
+  messages: FridayProviderContextMessage[];
+  summary: FridayContextCompactionBlockSummary;
+  score: number;
+}
 
 export interface FridayProviderContextCompactor {
   compact(params: {
@@ -29,7 +35,223 @@ export interface FridayProviderContextCompactor {
   }): Promise<FridayContextCompactionResult>;
 }
 
-// ─── Factory ───
+function normalizeText(text: string): string {
+  return text.trim().replace(/\s+/g, " ");
+}
+
+function clampSummary(text: string, limit = 220): string {
+  const normalized = normalizeText(text);
+  if (normalized.length <= limit) {
+    return normalized;
+  }
+  return `${normalized.slice(0, limit - 1)}…`;
+}
+
+function tokenize(text: string): string[] {
+  return normalizeText(text)
+    .replace(/([\u4e00-\u9fff])([a-z0-9])/gi, "$1 $2")
+    .replace(/([a-z0-9])([\u4e00-\u9fff])/gi, "$1 $2")
+    .toLowerCase()
+    .split(/[^a-z0-9\u4e00-\u9fff]+/i)
+    .map((token) => token.trim())
+    .filter((token) => token.length >= 2 && !STOPWORDS.has(token));
+}
+
+function countOverlap(left: Iterable<string>, right: Iterable<string>): number {
+  const rightSet = new Set(right);
+  let matches = 0;
+  for (const token of left) {
+    if (rightSet.has(token)) {
+      matches++;
+    }
+  }
+  return matches;
+}
+
+function extractFileOperations(text: string): string[] {
+  const matches = text.match(/(?:^|\s)(?:\.{0,2}\/)?[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)+(?:\.[A-Za-z0-9._-]+)?/g) ?? [];
+  return [...new Set(matches.map((match) => match.trim()).filter((match) => match.length > 0))].slice(0, 4);
+}
+
+function classifyBlockKind(messages: readonly FridayProviderContextMessage[]): FridayContextCompactionBlockKind {
+  const combined = messages.map((message) => message.content).join("\n").toLowerCase();
+  if (
+    /\b(plan|approval|approve|approved|reject|clarif(?:y|ication)|awaiting plan|awaiting clarification)\b/i.test(combined)
+    || /(计划|批准|审批|驳回|澄清|等待批准)/.test(combined)
+  ) {
+    return "plan_block";
+  }
+  if (
+    /\b(status|progress|still running|still working|blocked|eta|done yet)\b/i.test(combined)
+    || /(状态|进度|还在|阻塞|ETA|完成了吗)/.test(combined)
+  ) {
+    return "task_status_block";
+  }
+  if (
+    /\b(subagent|delegat(?:e|ed|ion)|worker|child run|spawned)\b/i.test(combined)
+    || /(子任务|子代理|委派|工作线程)/.test(combined)
+  ) {
+    return "delegated_task_block";
+  }
+  if (
+    /\b(failed|failure|error|unable|cannot|could not|couldn't|blocked|timed out|not connected|invalid|denied)\b/i.test(combined)
+    || /(失败|错误|无法|未连接|超时|无效|拒绝)/.test(combined)
+  ) {
+    return "tool_failure_block";
+  }
+  const hasUser = messages.some((message) => message.role === "user");
+  const hasAssistant = messages.some((message) => message.role === "assistant");
+  return hasUser && hasAssistant ? "topic_block" : "conversation_block";
+}
+
+function summarizeBlock(messages: readonly FridayProviderContextMessage[]): FridayContextCompactionBlockSummary {
+  const kind = classifyBlockKind(messages);
+  const userSummaries = messages
+    .filter((message) => message.role === "user")
+    .map((message) => clampSummary(message.content, 120));
+  const assistantSummaries = messages
+    .filter((message) => message.role === "assistant" || message.role === "tool-result")
+    .map((message) => clampSummary(message.content, 140));
+  const summaryText = clampSummary(
+    [
+      userSummaries.length > 0 ? `User: ${userSummaries.join(" | ")}` : undefined,
+      assistantSummaries.length > 0 ? `Assistant: ${assistantSummaries.join(" | ")}` : undefined,
+    ]
+      .filter((value): value is string => Boolean(value))
+      .join(" "),
+  );
+  const combined = messages.map((message) => message.content).join("\n");
+  const toolFailures = kind === "tool_failure_block"
+    ? messages.map((message) => clampSummary(message.content, 120)).slice(-2)
+    : [];
+  const openQuestions = messages
+    .filter((message) => message.role === "user" && /(?:\?|？)\s*$/.test(message.content.trim()))
+    .map((message) => clampSummary(message.content, 120))
+    .slice(-2);
+  const decisions = messages
+    .filter((message) => /\b(recommend|decide|should|best|prefer|plan)\b/i.test(message.content))
+    .map((message) => clampSummary(message.content, 120))
+    .slice(0, 3);
+  const todos = messages
+    .filter((message) => /\b(todo|next|follow up|need to|should)\b/i.test(message.content) || /(下一步|待办|需要)/.test(message.content))
+    .map((message) => clampSummary(message.content, 120))
+    .slice(0, 3);
+
+  return {
+    id: `block:${messages[0]?.messageId ?? "unknown"}:${messages[messages.length - 1]?.messageId ?? "unknown"}`,
+    kind,
+    summaryText,
+    decisions,
+    todos,
+    openQuestions,
+    toolFailures,
+    fileOperations: extractFileOperations(combined),
+    messageIds: messages.map((message) => message.messageId),
+  };
+}
+
+function buildBlocks(messages: readonly FridayProviderContextMessage[]): FridayProviderContextCompactionBlock[] {
+  if (messages.length === 0) {
+    return [];
+  }
+
+  const rawBlocks: FridayProviderContextMessage[][] = [];
+  let current: FridayProviderContextMessage[] = [];
+
+  const flushCurrent = () => {
+    if (current.length === 0) {
+      return;
+    }
+    rawBlocks.push(current);
+    current = [];
+  };
+
+  for (const message of messages) {
+    if (message.role === "user" && current.some((entry) => entry.role === "user")) {
+      flushCurrent();
+    }
+    current.push(message);
+  }
+  flushCurrent();
+
+  return rawBlocks.map((blockMessages) => ({
+    id: `block:${blockMessages[0]?.messageId ?? "unknown"}`,
+    kind: classifyBlockKind(blockMessages),
+    messages: blockMessages,
+    summary: summarizeBlock(blockMessages),
+    score: 0,
+  }));
+}
+
+function scoreBlocks(
+  blocks: readonly FridayProviderContextCompactionBlock[],
+  userPrompt: string,
+): FridayProviderContextCompactionBlock[] {
+  const taskTokens = tokenize(userPrompt);
+  const totalBlocks = blocks.length;
+  return blocks.map((block, index) => {
+    const summaryTokens = tokenize([
+      block.summary.summaryText,
+      ...block.summary.decisions,
+      ...block.summary.todos,
+      ...block.summary.openQuestions,
+      ...block.summary.toolFailures,
+      ...block.summary.fileOperations,
+    ].join("\n"));
+    const taskOverlap = countOverlap(taskTokens, summaryTokens);
+    const recencyBonus = Math.max(1, totalBlocks - index);
+    const kindBonus = block.kind === "tool_failure_block"
+      ? 14
+      : block.kind === "task_status_block"
+        ? 12
+        : block.kind === "delegated_task_block"
+          ? 10
+          : block.kind === "plan_block"
+            ? 8
+            : block.kind === "topic_block"
+              ? 6
+              : 4;
+    return {
+      ...block,
+      score: (taskOverlap * 14) + recencyBonus + kindBonus,
+    };
+  });
+}
+
+function formatSummaryContext(blocks: readonly FridayContextCompactionBlockSummary[]): string {
+  const parts = ["[Conversation Block Summaries]"];
+  blocks.forEach((block, index) => {
+    parts.push(`\n[Block ${String(index + 1)} | ${block.kind}]`);
+    parts.push(block.summaryText);
+    if (block.decisions.length > 0) {
+      parts.push(`Decisions: ${block.decisions.join(" | ")}`);
+    }
+    if (block.todos.length > 0) {
+      parts.push(`TODOs: ${block.todos.join(" | ")}`);
+    }
+    if (block.openQuestions.length > 0) {
+      parts.push(`Open questions: ${block.openQuestions.join(" | ")}`);
+    }
+    if (block.toolFailures.length > 0) {
+      parts.push(`Tool failures: ${block.toolFailures.join(" | ")}`);
+    }
+    if (block.fileOperations.length > 0) {
+      parts.push(`File operations: ${block.fileOperations.join(" | ")}`);
+    }
+  });
+  return parts.join("\n");
+}
+
+function combineSummaries(blocks: readonly FridayContextCompactionBlockSummary[]): FridayContextCompactionSummary {
+  return {
+    summaryText: blocks.map((block) => `[${block.kind}] ${block.summaryText}`).join("\n"),
+    decisions: blocks.flatMap((block) => block.decisions),
+    todos: blocks.flatMap((block) => block.todos),
+    openQuestions: blocks.flatMap((block) => block.openQuestions),
+    toolFailures: blocks.flatMap((block) => block.toolFailures),
+    fileOperations: blocks.flatMap((block) => block.fileOperations),
+  };
+}
 
 export function createFridayProviderContextCompactor(deps: {
   estimator: FridayProviderTokenEstimator;
@@ -39,19 +261,17 @@ export function createFridayProviderContextCompactor(deps: {
 
   return {
     async compact(params) {
-      const { systemPrompt, userPrompt, messages, contextWindowTokens, summarize } = params;
+      const { systemPrompt, userPrompt, messages, contextWindowTokens } = params;
 
-      // Estimate baseline token usage (system + user + all messages)
       const baseTokens =
         estimator.estimateTextTokens(systemPrompt) +
         estimator.estimateTextTokens(userPrompt);
       const messageTokens = estimator.estimateMessagesTokens(
-        messages.map((m) => ({ role: m.role, content: m.content })),
+        messages.map((message) => ({ role: message.role, content: message.content })),
       );
       const totalBefore = baseTokens + messageTokens;
       const threshold = Math.floor(contextWindowTokens * COMPACTION_TRIGGER_RATIO);
 
-      // No compaction needed
       if (totalBefore <= threshold) {
         return {
           compacted: false,
@@ -63,51 +283,61 @@ export function createFridayProviderContextCompactor(deps: {
         };
       }
 
-      // Step 1: prune oversized content in older messages
       const pruneResult = pruner.prune(messages);
       const prunedMessages = pruneResult.messages;
+      const scoredBlocks = scoreBlocks(buildBlocks(prunedMessages), userPrompt);
 
-      // Step 2: split into old (to summarize) and recent (to keep)
-      const keepCount = Math.min(KEEP_RECENT_TURNS, prunedMessages.length);
-      const splitIndex = prunedMessages.length - keepCount;
-      const oldMessages = prunedMessages.slice(0, splitIndex);
-      const recentMessages = prunedMessages.slice(splitIndex);
-
-      // If no old messages to summarize, just return pruned result
-      if (oldMessages.length === 0) {
+      if (scoredBlocks.length <= MAX_RAW_BLOCKS) {
         const afterTokens =
           baseTokens +
           estimator.estimateMessagesTokens(
-            recentMessages.map((m) => ({ role: m.role, content: m.content })),
+            prunedMessages.map((message) => ({ role: message.role, content: message.content })),
           );
         return {
           compacted: pruneResult.prunedCount > 0,
           estimatedTokensBefore: totalBefore,
           estimatedTokensAfter: afterTokens,
-          keptMessages: recentMessages,
+          keptMessages: prunedMessages,
           droppedMessages: [],
           prunedMessageCount: pruneResult.prunedCount,
+          blocks: scoredBlocks.map((block) => block.summary),
         };
       }
 
-      // Step 3: summarize old messages via LLM
-      const summaryPrompt = buildSummaryPrompt(oldMessages);
-      const rawSummary = await summarize(summaryPrompt);
-      const summary = parseSummary(rawSummary);
+      const rawBlockIds = new Set(
+        [...scoredBlocks]
+          .sort((left, right) => right.score - left.score || left.id.localeCompare(right.id))
+          .slice(0, MAX_RAW_BLOCKS)
+          .map((block) => block.id),
+      );
+      const rawBlocks = scoredBlocks
+        .filter((block) => rawBlockIds.has(block.id))
+        .sort((left, right) =>
+          (left.messages[0]?.createdAt ?? "").localeCompare(right.messages[0]?.createdAt ?? ""),
+        );
+      const summarizedBlocks = scoredBlocks
+        .filter((block) => !rawBlockIds.has(block.id))
+        .sort((left, right) =>
+          (left.messages[0]?.createdAt ?? "").localeCompare(right.messages[0]?.createdAt ?? ""),
+        );
 
-      // Build a synthetic summary message to prepend
-      const summaryMessage: FridayProviderContextMessage = {
-        messageId: "compaction-summary",
-        role: "system",
-        content: formatSummaryAsContext(summary),
-        createdAt: new Date().toISOString(),
-      };
+      const summaryMessage: FridayProviderContextMessage | null = summarizedBlocks.length > 0
+        ? {
+            messageId: "compaction-summary",
+            role: "system",
+            content: formatSummaryContext(summarizedBlocks.map((block) => block.summary)),
+            createdAt: new Date().toISOString(),
+          }
+        : null;
 
-      const keptMessages = [summaryMessage, ...recentMessages];
+      const keptMessages = [
+        ...(summaryMessage ? [summaryMessage] : []),
+        ...rawBlocks.flatMap((block) => block.messages),
+      ];
       const afterTokens =
         baseTokens +
         estimator.estimateMessagesTokens(
-          keptMessages.map((m) => ({ role: m.role, content: m.content })),
+          keptMessages.map((message) => ({ role: message.role, content: message.content })),
         );
 
       return {
@@ -115,80 +345,13 @@ export function createFridayProviderContextCompactor(deps: {
         estimatedTokensBefore: totalBefore,
         estimatedTokensAfter: afterTokens,
         keptMessages,
-        droppedMessages: oldMessages,
+        droppedMessages: summarizedBlocks.flatMap((block) => block.messages),
         prunedMessageCount: pruneResult.prunedCount,
-        summary,
+        summary: summarizedBlocks.length > 0
+          ? combineSummaries(summarizedBlocks.map((block) => block.summary))
+          : undefined,
+        blocks: scoredBlocks.map((block) => block.summary),
       };
     },
   };
-}
-
-// ─── Summary prompt ───
-
-function buildSummaryPrompt(
-  messages: readonly FridayProviderContextMessage[],
-): { system: string; user: string } {
-  const system = `You are a conversation compactor. Summarize the following conversation turns into a structured summary. Respond as JSON with fields: summaryText (string), decisions (string[]), todos (string[]), openQuestions (string[]), toolFailures (string[]), fileOperations (string[]). Max ${String(SUMMARY_MAX_TOKENS)} tokens.`;
-
-  const turns = messages
-    .map((m) => `[${m.role}] ${m.content.slice(0, 2000)}`)
-    .join("\n\n");
-
-  return { system, user: turns };
-}
-
-// ─── Parse summary JSON ───
-
-function parseSummary(raw: string): FridayContextCompactionSummary {
-  try {
-    const parsed: unknown = JSON.parse(raw);
-    if (parsed !== null && typeof parsed === "object") {
-      const obj = parsed as Record<string, unknown>;
-      return {
-        summaryText: typeof obj["summaryText"] === "string" ? obj["summaryText"] : raw,
-        decisions: asStringArray(obj["decisions"]),
-        todos: asStringArray(obj["todos"]),
-        openQuestions: asStringArray(obj["openQuestions"]),
-        toolFailures: asStringArray(obj["toolFailures"]),
-        fileOperations: asStringArray(obj["fileOperations"]),
-      };
-    }
-  } catch {
-    // Fallback: use raw text as summary
-  }
-  return {
-    summaryText: raw,
-    decisions: [],
-    todos: [],
-    openQuestions: [],
-    toolFailures: [],
-    fileOperations: [],
-  };
-}
-
-function asStringArray(val: unknown): string[] {
-  if (!Array.isArray(val)) return [];
-  return val.filter((v): v is string => typeof v === "string");
-}
-
-// ─── Format summary for context injection ───
-
-function formatSummaryAsContext(summary: FridayContextCompactionSummary): string {
-  const parts = [`[Conversation Summary]\n${summary.summaryText}`];
-  if (summary.decisions.length > 0) {
-    parts.push(`\n[Decisions]\n${summary.decisions.map((d) => `- ${d}`).join("\n")}`);
-  }
-  if (summary.todos.length > 0) {
-    parts.push(`\n[TODOs]\n${summary.todos.map((t) => `- ${t}`).join("\n")}`);
-  }
-  if (summary.openQuestions.length > 0) {
-    parts.push(`\n[Open Questions]\n${summary.openQuestions.map((q) => `- ${q}`).join("\n")}`);
-  }
-  if (summary.toolFailures.length > 0) {
-    parts.push(`\n[Tool Failures]\n${summary.toolFailures.map((f) => `- ${f}`).join("\n")}`);
-  }
-  if (summary.fileOperations.length > 0) {
-    parts.push(`\n[File Operations]\n${summary.fileOperations.map((f) => `- ${f}`).join("\n")}`);
-  }
-  return parts.join("\n");
 }

--- a/src/providers/model/friday-provider-context.types.ts
+++ b/src/providers/model/friday-provider-context.types.ts
@@ -37,6 +37,20 @@ export interface FridayContextCompactionSummary {
   fileOperations: string[];
 }
 
+export type FridayContextCompactionBlockKind =
+  | "topic_block"
+  | "plan_block"
+  | "task_status_block"
+  | "tool_failure_block"
+  | "delegated_task_block"
+  | "conversation_block";
+
+export interface FridayContextCompactionBlockSummary extends FridayContextCompactionSummary {
+  id: string;
+  kind: FridayContextCompactionBlockKind;
+  messageIds: string[];
+}
+
 // ─── Result of compaction pass ───
 
 export interface FridayContextCompactionResult {
@@ -47,6 +61,7 @@ export interface FridayContextCompactionResult {
   droppedMessages: FridayProviderContextMessage[];
   prunedMessageCount: number;
   summary?: FridayContextCompactionSummary;
+  blocks?: FridayContextCompactionBlockSummary[];
 }
 
 // ─── Cache hint configuration per provider ───

--- a/src/sessions/index.ts
+++ b/src/sessions/index.ts
@@ -34,6 +34,8 @@ export type {
   FridayConversationTurnKind,
   FridayConversationBlockSource,
   FridayConversationBlock,
+  FridayConversationHistoryBlockKind,
+  FridayConversationHistoryBlockSummary,
   FridayContextSelectionResult,
   FridaySessionKeyParts,
   FridaySessionSendPolicy,

--- a/src/sessions/model/friday-session.types.ts
+++ b/src/sessions/model/friday-session.types.ts
@@ -15,7 +15,35 @@ export type FridayConversationBlockSource =
   | "focus_topic"
   | "active_run"
   | "pending_plan"
-  | "status_anchor";
+  | "status_anchor"
+  | "topic_block"
+  | "plan_block"
+  | "task_status_block"
+  | "tool_failure_block"
+  | "delegated_task_block"
+  | "conversation_block";
+
+export type FridayConversationHistoryBlockKind =
+  | "topic_block"
+  | "plan_block"
+  | "task_status_block"
+  | "tool_failure_block"
+  | "delegated_task_block"
+  | "conversation_block";
+
+export interface FridayConversationHistoryBlockSummary {
+  id: string;
+  kind: FridayConversationHistoryBlockKind;
+  summaryText: string;
+  decisions: string[];
+  todos: string[];
+  openQuestions: string[];
+  toolFailures: string[];
+  fileOperations: string[];
+  messageIds: string[];
+  sequenceStart?: number;
+  sequenceEnd?: number;
+}
 
 export interface FridayConversationBlock {
   id: string;

--- a/src/sessions/services/friday-session-conversation-orchestrator.ts
+++ b/src/sessions/services/friday-session-conversation-orchestrator.ts
@@ -5,6 +5,8 @@ import type { FridayAgentMessage } from "#agent";
 import type {
   FridayContextSelectionResult,
   FridayConversationBlock,
+  FridayConversationHistoryBlockKind,
+  FridayConversationHistoryBlockSummary,
   FridayConversationTurnKind,
   FridaySessionConversationFocusState,
   FridaySessionMessageRecord,
@@ -13,6 +15,9 @@ import type {
 const MAX_TOPIC_SUMMARY_CHARS = 180;
 const MAX_FOLLOW_UP_HISTORY = 12;
 const MAX_STATUS_HISTORY = 6;
+const MAX_SELECTED_BLOCKS = 6;
+const MAX_RELEVANT_HISTORY_BLOCKS = 3;
+const MAX_BLOCK_SUMMARY_CHARS = 240;
 const FOLLOW_UP_HINTS =
   /\b(that|it|this|those|these|also|and|then|what about|more about|continue|same|again|summari[sz]e|summary|recap|recommendation|recommendations)\b/i;
 const CHINESE_FOLLOW_UP_HINTS = /(这个|那个|这里|这儿|继续|还有|然后|刚才|上一个|同一个|总结|概括|再说|细讲)/;
@@ -87,6 +92,13 @@ export interface FinalizeFridayConversationFocusInput {
 
 interface FridayConversationBlockCandidate {
   block: FridayConversationBlock;
+  messages: FridayAgentMessage[];
+}
+
+interface FridayConversationHistoryBlockCandidate {
+  summary: FridayConversationHistoryBlockSummary;
+  score: number;
+  reason: string;
   messages: FridayAgentMessage[];
 }
 
@@ -211,6 +223,14 @@ export function classifyFridayConversationTurn(input: {
     FOLLOW_UP_HINTS.test(taskLower)
     || CHINESE_FOLLOW_UP_HINTS.test(task)
     || DEICTIC_FOLLOW_UP_HINTS.test(taskLower);
+  const assistantOverlapSignal = latestAssistantOverlap >= 2
+    || (
+      latestAssistantOverlap >= 1
+      && hasFocus
+      && hasAssistantAnchor
+      && isShortAssistantAnchorFollowUpTask(task)
+    );
+  const userOverlapSignal = latestUserOverlap >= 2;
 
   if (STATUS_CHECK_HINTS.test(taskLower) || CHINESE_STATUS_CHECK_HINTS.test(task)) {
     return "status_check";
@@ -235,11 +255,11 @@ export function classifyFridayConversationTurn(input: {
     return "follow_up";
   }
   if (
-    (hasFocus || latestAssistantOverlap >= 1 || latestUserOverlap >= 2)
+    (hasFocus || assistantOverlapSignal || userOverlapSignal)
     && (
       overlap >= 2
-      || latestAssistantOverlap >= 1
-      || latestUserOverlap >= 2
+      || assistantOverlapSignal
+      || userOverlapSignal
       || advisoryContinuation
       || followUpHint
     )
@@ -292,6 +312,163 @@ function resolveReplyAnchorRecord(
     record.id === normalizedReplyId || resolveSourceMessageId(record) === normalizedReplyId);
 }
 
+function clampSummary(text: string, limit = MAX_BLOCK_SUMMARY_CHARS): string {
+  const normalized = normalizeText(text);
+  if (normalized.length <= limit) {
+    return normalized;
+  }
+  return `${normalized.slice(0, limit - 1)}…`;
+}
+
+function extractFileOperations(text: string): string[] {
+  const matches = text.match(/(?:^|\s)(?:\.{0,2}\/)?[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)+(?:\.[A-Za-z0-9._-]+)?/g) ?? [];
+  return [...new Set(matches.map((match) => match.trim()).filter((match) => match.length > 0))].slice(0, 4);
+}
+
+function classifyConversationHistoryBlockKind(
+  records: readonly FridaySessionMessageRecord[],
+): FridayConversationHistoryBlockKind {
+  const combined = records.map((record) => record.contentText).join("\n").toLowerCase();
+  if (
+    /\b(plan|approval|approve|approved|reject|rejected|clarif(?:y|ication)|awaiting plan|awaiting clarification|review required)\b/i.test(combined)
+    || /(计划|批准|审批|驳回|澄清|需要更多信息|等待批准)/.test(combined)
+  ) {
+    return "plan_block";
+  }
+  if (
+    STATUS_CHECK_HINTS.test(combined)
+    || CHINESE_STATUS_CHECK_HINTS.test(combined)
+  ) {
+    return "task_status_block";
+  }
+  if (
+    /\b(subagent|delegat(?:e|ed|ion)|worker|child run|spawned|spawn_subagent|hand[- ]?off)\b/i.test(combined)
+    || /(子任务|子代理|委派|工作线程|分配给)/.test(combined)
+  ) {
+    return "delegated_task_block";
+  }
+  if (
+    /\b(failed|failure|error|unable|cannot|could not|couldn't|blocked|timed out|not connected|invalid|denied)\b/i.test(combined)
+    || /(失败|错误|无法|不能|未连接|阻止|超时|无效|拒绝)/.test(combined)
+  ) {
+    return "tool_failure_block";
+  }
+  const hasUser = records.some((record) => record.role === "user");
+  const hasAssistant = records.some((record) => record.role === "assistant");
+  return hasUser && hasAssistant ? "topic_block" : "conversation_block";
+}
+
+function summarizeConversationHistoryBlock(
+  records: readonly FridaySessionMessageRecord[],
+): FridayConversationHistoryBlockSummary {
+  const kind = classifyConversationHistoryBlockKind(records);
+  const userSummaries = records
+    .filter((record) => record.role === "user")
+    .map((record) => clampSummary(record.contentText, 140));
+  const assistantSummaries = records
+    .filter((record) => record.role === "assistant")
+    .map((record) => clampSummary(record.contentText, 160));
+  const summaryText = clampSummary(
+    [
+      userSummaries.length > 0 ? `User: ${userSummaries.join(" | ")}` : undefined,
+      assistantSummaries.length > 0 ? `Assistant: ${assistantSummaries.join(" | ")}` : undefined,
+    ]
+      .filter((value): value is string => Boolean(value))
+      .join(" "),
+  );
+  const combined = records.map((record) => record.contentText).join("\n");
+  const toolFailures = kind === "tool_failure_block"
+    ? records.map((record) => clampSummary(record.contentText, 120)).slice(-2)
+    : [];
+  const openQuestions = records
+    .filter((record) => record.role === "user" && /(?:\?|？)\s*$/.test(record.contentText.trim()))
+    .map((record) => clampSummary(record.contentText, 120))
+    .slice(-2);
+  const decisions = records
+    .filter((record) => record.role === "assistant" && /\b(recommend|decide|should|best|prefer|plan)\b/i.test(record.contentText))
+    .map((record) => clampSummary(record.contentText, 120))
+    .slice(0, 3);
+  const todos = records
+    .filter((record) => /\b(todo|next|follow up|need to|should)\b/i.test(record.contentText) || /(下一步|待办|需要)/.test(record.contentText))
+    .map((record) => clampSummary(record.contentText, 120))
+    .slice(0, 3);
+
+  return {
+    id: `history-block:${records[0]?.id ?? "unknown"}:${records[records.length - 1]?.id ?? "unknown"}`,
+    kind,
+    summaryText,
+    decisions,
+    todos,
+    openQuestions,
+    toolFailures,
+    fileOperations: extractFileOperations(combined),
+    messageIds: records.map((record) => record.id),
+    sequenceStart: records[0]?.sequence,
+    sequenceEnd: records[records.length - 1]?.sequence,
+  };
+}
+
+function buildConversationHistoryBlocks(
+  records: readonly FridaySessionMessageRecord[],
+): FridayConversationHistoryBlockSummary[] {
+  if (records.length === 0) {
+    return [];
+  }
+
+  const blocks: FridayConversationHistoryBlockSummary[] = [];
+  let current: FridaySessionMessageRecord[] = [];
+
+  const flushCurrent = () => {
+    if (current.length === 0) {
+      return;
+    }
+    blocks.push(summarizeConversationHistoryBlock(current));
+    current = [];
+  };
+
+  for (const record of records) {
+    if (record.role === "user" && current.some((entry) => entry.role === "user")) {
+      flushCurrent();
+    }
+    current.push(record);
+  }
+  flushCurrent();
+  return blocks;
+}
+
+function formatConversationHistoryBlockSummary(
+  block: FridayConversationHistoryBlockSummary,
+): string {
+  const parts = [`${block.kind}: ${block.summaryText}`];
+  if (block.decisions.length > 0) {
+    parts.push(`decisions=${block.decisions.join(" | ")}`);
+  }
+  if (block.todos.length > 0) {
+    parts.push(`todos=${block.todos.join(" | ")}`);
+  }
+  if (block.openQuestions.length > 0) {
+    parts.push(`openQuestions=${block.openQuestions.join(" | ")}`);
+  }
+  if (block.toolFailures.length > 0) {
+    parts.push(`toolFailures=${block.toolFailures.join(" | ")}`);
+  }
+  if (block.fileOperations.length > 0) {
+    parts.push(`fileOperations=${block.fileOperations.join(" | ")}`);
+  }
+  return parts.join(" | ");
+}
+
+function rehydrateConversationHistoryBlockMessages(
+  block: FridayConversationHistoryBlockSummary,
+  records: readonly FridaySessionMessageRecord[],
+): FridayAgentMessage[] {
+  return block.messageIds
+    .map((messageId) => records.find((record) => record.id === messageId))
+    .filter((record): record is FridaySessionMessageRecord => Boolean(record))
+    .map(mapSessionMessageToAgentMessage)
+    .filter((message): message is FridayAgentMessage => message !== null);
+}
+
 function createMessageBlockCandidate(input: {
   id: string;
   source: FridayConversationBlock["source"];
@@ -315,6 +492,20 @@ function createMessageBlockCandidate(input: {
       sequenceEnd: input.records[input.records.length - 1]?.sequence,
     },
     messages: historyMessages,
+  };
+}
+
+function createHistoryBlockCandidate(input: {
+  summary: FridayConversationHistoryBlockSummary;
+  score: number;
+  reason: string;
+  records: readonly FridaySessionMessageRecord[];
+}): FridayConversationHistoryBlockCandidate {
+  return {
+    summary: input.summary,
+    score: input.score,
+    reason: input.reason,
+    messages: rehydrateConversationHistoryBlockMessages(input.summary, input.records),
   };
 }
 
@@ -464,6 +655,13 @@ function buildConversationBlockSelection(input: {
     });
   }
 
+  const useCrossTopicRecapWindow =
+    input.turnKind === "follow_up"
+    && (
+      CROSS_TOPIC_RECAP_HINTS.test(input.task)
+      || CHINESE_CROSS_TOPIC_RECAP_HINTS.test(input.task)
+    );
+
   const topicWindowRecords = (
     (input.turnKind === "follow_up" || input.turnKind === "clarification" || input.turnKind === "continue_active_task")
     && typeof focusState?.currentTopicStartSequence === "number"
@@ -475,14 +673,29 @@ function buildConversationBlockSelection(input: {
       .map((record) => `${record.role}: ${record.contentText}`)
       .join("\n");
     const topicWindowScore = 36 + (countOverlap(taskTokens, tokenize(topicWindowSummary)) * 10);
-    registerCandidate(createMessageBlockCandidate({
-      id: `topic-window:${String(focusState?.currentTopicStartSequence)}`,
-      source: "focus_topic",
-      summary: topicWindowSummary,
-      score: topicWindowScore,
-      reason: "Current turn is still inside the persisted topic window.",
-      records: topicWindowRecords,
-    }));
+    if (topicWindowRecords.length > MAX_FOLLOW_UP_HISTORY) {
+      registerCandidate({
+        block: {
+          id: `topic-window:${String(focusState?.currentTopicStartSequence)}`,
+          source: "focus_topic",
+          summary: summarizeTopic(topicWindowSummary),
+          score: topicWindowScore,
+          reason: "Current turn is still inside the persisted topic window; the long topic window is now represented as a compacted summary block.",
+          sequenceStart: topicWindowRecords[0]?.sequence,
+          sequenceEnd: topicWindowRecords[topicWindowRecords.length - 1]?.sequence,
+        },
+        messages: [],
+      });
+    } else {
+      registerCandidate(createMessageBlockCandidate({
+        id: `topic-window:${String(focusState?.currentTopicStartSequence)}`,
+        source: "focus_topic",
+        summary: topicWindowSummary,
+        score: topicWindowScore,
+        reason: "Current turn is still inside the persisted topic window.",
+        records: topicWindowRecords,
+      }));
+    }
   }
 
   if (input.turnKind === "status_check" && (focusState?.activeRunId || focusState?.pendingPlanRunId || focusState?.activeSubagentIds?.length)) {
@@ -505,49 +718,150 @@ function buildConversationBlockSelection(input: {
     });
   }
 
-  const useCrossTopicRecapWindow =
-    input.turnKind === "follow_up"
-    && (
-      CROSS_TOPIC_RECAP_HINTS.test(input.task)
-      || CHINESE_CROSS_TOPIC_RECAP_HINTS.test(input.task)
+  const historyBlockCandidates: FridayConversationHistoryBlockCandidate[] = [];
+  const seenHistoryBlockIds = new Set<string>();
+  const registerHistoryBlock = (candidate: FridayConversationHistoryBlockCandidate | null) => {
+    if (!candidate || seenHistoryBlockIds.has(candidate.summary.id) || candidate.score <= 0) {
+      return;
+    }
+    seenHistoryBlockIds.add(candidate.summary.id);
+    historyBlockCandidates.push(candidate);
+  };
+
+  const candidateHistoryRecords = useCrossTopicRecapWindow
+    ? records
+    : topicWindowRecords;
+  if (
+    candidateHistoryRecords.length > MAX_FOLLOW_UP_HISTORY
+    && input.turnKind !== "new_topic"
+  ) {
+    const alreadyAnchoredMessageIds = new Set(
+      candidates.flatMap((candidate) => candidate.block.messageIds ?? []),
     );
+    const historyBlocks = buildConversationHistoryBlocks(candidateHistoryRecords);
+    const totalBlockCount = historyBlocks.length;
+    const focusTokens = tokenize(focusState?.currentTopicSummary ?? "");
+
+    historyBlocks.forEach((block, index) => {
+      const unanchoredMessageIds = block.messageIds.filter((messageId) => !alreadyAnchoredMessageIds.has(messageId));
+      if (unanchoredMessageIds.length === 0) {
+        return;
+      }
+
+      const formattedSummary = formatConversationHistoryBlockSummary(block);
+      const blockTokens = tokenize(formattedSummary);
+      const taskOverlap = countOverlap(taskTokens, blockTokens);
+      const focusOverlap = focusTokens.length > 0 ? countOverlap(focusTokens, blockTokens) : 0;
+      const recencyBonus = Math.max(1, totalBlockCount - index);
+      const kindBonus = block.kind === "tool_failure_block"
+        ? 14
+        : block.kind === "task_status_block"
+          ? 12
+          : block.kind === "delegated_task_block"
+            ? 10
+            : block.kind === "plan_block"
+              ? 8
+              : block.kind === "topic_block"
+                ? 6
+                : 4;
+      const score = (taskOverlap * 14) + (focusOverlap * 8) + recencyBonus + kindBonus;
+
+      registerHistoryBlock(createHistoryBlockCandidate({
+        summary: {
+          ...block,
+          messageIds: unanchoredMessageIds,
+        },
+        score,
+        reason: taskOverlap > 0 || focusOverlap > 0
+          ? `Compacted ${block.kind} matched the current turn (${String(taskOverlap)} task token match(es), ${String(focusOverlap)} focus token match(es)).`
+          : `Compacted ${block.kind} kept as a recency-weighted history block.`,
+        records: candidateHistoryRecords,
+      }));
+    });
+  }
 
   const scoreThreshold = input.turnKind === "new_topic" ? 60 : 1;
   const selectedCandidates = candidates
     .filter((candidate) => candidate.block.score >= scoreThreshold || candidate.block.source === "reply_anchor")
     .sort((left, right) => right.block.score - left.block.score || left.block.id.localeCompare(right.block.id))
     .slice(0, input.turnKind === "status_check" ? 3 : 4);
-  const selectionReasons = selectedCandidates.map((candidate) =>
-    `${candidate.block.source} → ${candidate.block.reason}`);
+  const selectedHistoryCandidates = historyBlockCandidates
+    .filter((candidate) => candidate.score >= scoreThreshold)
+    .sort((left, right) => right.score - left.score || left.summary.id.localeCompare(right.summary.id))
+    .slice(0, input.turnKind === "status_check" ? 1 : MAX_RELEVANT_HISTORY_BLOCKS);
+  const selectionReasons = [
+    ...selectedCandidates.map((candidate) => `${candidate.block.source} → ${candidate.block.reason}`),
+    ...selectedHistoryCandidates.map((candidate) => `${candidate.summary.kind} → ${candidate.reason}`),
+  ];
 
-  const messageMap = new Map<string, { sequence: number; message: FridayAgentMessage }>();
-  for (const candidate of selectedCandidates) {
-    for (const messageRecord of candidate.block.messageIds ?? []) {
-      const record = records.find((entry) => entry.id === messageRecord);
-      const mapped = record ? mapSessionMessageToAgentMessage(record) : null;
-      if (record && mapped) {
-        messageMap.set(record.id, { sequence: record.sequence, message: mapped });
+  const historyMessageLimit = input.turnKind === "status_check"
+    ? MAX_STATUS_HISTORY
+    : MAX_FOLLOW_UP_HISTORY + 6;
+  const prioritizedHistoryEntries: Array<{ id: string; sequence: number; message: FridayAgentMessage }> = [];
+  const seenHistoryMessageIds = new Set<string>();
+
+  const appendHistoryMessages = (messageIds: readonly string[], messages: readonly FridayAgentMessage[]) => {
+    messageIds.forEach((messageId, index) => {
+      if (seenHistoryMessageIds.has(messageId) || prioritizedHistoryEntries.length >= historyMessageLimit) {
+        return;
       }
-    }
+      const record = records.find((entry) => entry.id === messageId);
+      const mapped = messages[index]
+        ?? (record ? mapSessionMessageToAgentMessage(record) : null);
+      if (record && mapped) {
+        seenHistoryMessageIds.add(messageId);
+        prioritizedHistoryEntries.push({
+          id: record.id,
+          sequence: record.sequence,
+          message: mapped,
+        });
+      }
+    });
+  };
+
+  for (const candidate of selectedCandidates) {
+    appendHistoryMessages(candidate.block.messageIds ?? [], candidate.messages);
+  }
+  for (const candidate of selectedHistoryCandidates) {
+    appendHistoryMessages(candidate.summary.messageIds, candidate.messages);
   }
 
   if (useCrossTopicRecapWindow && records.length > 0) {
     const maxCount = input.turnKind === "status_check" ? MAX_STATUS_HISTORY : MAX_FOLLOW_UP_HISTORY;
     for (const record of records.slice(Math.max(0, records.length - maxCount))) {
+      if (seenHistoryMessageIds.has(record.id) || prioritizedHistoryEntries.length >= historyMessageLimit) {
+        continue;
+      }
       const mapped = mapSessionMessageToAgentMessage(record);
       if (mapped) {
-        messageMap.set(record.id, { sequence: record.sequence, message: mapped });
+        seenHistoryMessageIds.add(record.id);
+        prioritizedHistoryEntries.push({ id: record.id, sequence: record.sequence, message: mapped });
       }
     }
   }
 
-  const historyMessages = [...messageMap.values()]
+  const historyMessages = prioritizedHistoryEntries
     .sort((left, right) => left.sequence - right.sequence)
-    .slice(-(input.turnKind === "status_check" ? MAX_STATUS_HISTORY : MAX_FOLLOW_UP_HISTORY))
     .map((entry) => entry.message);
 
+  const selectedBlocks = [
+    ...selectedCandidates.map((candidate) => candidate.block),
+    ...selectedHistoryCandidates.map((candidate): FridayConversationBlock => ({
+      id: candidate.summary.id,
+      source: candidate.summary.kind,
+      summary: formatConversationHistoryBlockSummary(candidate.summary),
+      score: candidate.score,
+      reason: candidate.reason,
+      messageIds: candidate.summary.messageIds,
+      sequenceStart: candidate.summary.sequenceStart,
+      sequenceEnd: candidate.summary.sequenceEnd,
+    })),
+  ]
+    .sort((left, right) => right.score - left.score || left.id.localeCompare(right.id))
+    .slice(0, MAX_SELECTED_BLOCKS);
+
   return {
-    selectedBlocks: selectedCandidates.map((candidate) => candidate.block),
+    selectedBlocks,
     selectionReasons,
     historyMessages,
     replyAnchorMessageId: replyAnchor?.id,

--- a/test/unit/providers/context/friday-provider-context-compactor.test.ts
+++ b/test/unit/providers/context/friday-provider-context-compactor.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+
+import { createFridayProviderContextCompactor } from "#providers";
+import type { FridayProviderContextMessage } from "#providers";
+
+function makeMessage(input: {
+  index: number;
+  role: FridayProviderContextMessage["role"];
+  content: string;
+}): FridayProviderContextMessage {
+  return {
+    messageId: `msg-${String(input.index)}`,
+    role: input.role,
+    content: input.content,
+    createdAt: new Date(Date.UTC(2026, 2, 17, 10, input.index, 0)).toISOString(),
+  };
+}
+
+describe("friday-provider-context-compactor", () => {
+  it("keeps the most relevant earlier block raw instead of only the most recent turns", async () => {
+    const compactor = createFridayProviderContextCompactor({
+      estimator: {
+        estimateTextTokens(text) {
+          return Math.ceil(text.length / 4);
+        },
+        estimateMessagesTokens(messages) {
+          return messages.reduce((total, message) => total + Math.ceil(message.content.length / 4) + 8, 0);
+        },
+        getContextWindow() {
+          return 256;
+        },
+      },
+      pruner: {
+        prune(messages) {
+          return { messages: [...messages], prunedCount: 0 };
+        },
+      },
+    });
+
+    const messages: FridayProviderContextMessage[] = [
+      makeMessage({ index: 1, role: "user", content: "Open GitHub in the browser." }),
+      makeMessage({ index: 2, role: "assistant", content: "I could not open GitHub because the browser session was not connected." }),
+      makeMessage({ index: 3, role: "user", content: "Summarize the rollout plan." }),
+      makeMessage({ index: 4, role: "assistant", content: "Reconnect browser, rerun smoke, verify Discord." }),
+      makeMessage({ index: 5, role: "user", content: "What about logging?" }),
+      makeMessage({ index: 6, role: "assistant", content: "Capture logs before and after reconnecting." }),
+      makeMessage({ index: 7, role: "user", content: "Should we collect screenshots?" }),
+      makeMessage({ index: 8, role: "assistant", content: "Yes, collect screenshots for the regression report." }),
+      makeMessage({ index: 9, role: "user", content: "Anything else?" }),
+      makeMessage({ index: 10, role: "assistant", content: "That covers the rollout checklist." }),
+    ];
+
+    const result = await compactor.compact({
+      systemPrompt: "You are a workflow generator.",
+      userPrompt: "Why didn't it connect/open? Explain the earlier failure clearly.",
+      messages,
+      contextWindowTokens: 80,
+      summarize: async () => "{\"summaryText\":\"unused\"}",
+    });
+
+    expect(result.compacted).toBe(true);
+    expect(result.blocks?.some((block) => block.kind === "tool_failure_block")).toBe(true);
+    expect(result.keptMessages.some((message) =>
+      message.content.includes("browser session was not connected"))).toBe(true);
+    expect(result.keptMessages.some((message) =>
+      message.messageId === "compaction-summary")).toBe(true);
+  });
+
+  it("emits structured block summaries for summarized blocks", async () => {
+    const compactor = createFridayProviderContextCompactor({
+      estimator: {
+        estimateTextTokens(text) {
+          return Math.ceil(text.length / 4);
+        },
+        estimateMessagesTokens(messages) {
+          return messages.reduce((total, message) => total + Math.ceil(message.content.length / 4) + 8, 0);
+        },
+        getContextWindow() {
+          return 256;
+        },
+      },
+      pruner: {
+        prune(messages) {
+          return { messages: [...messages], prunedCount: 0 };
+        },
+      },
+    });
+
+    const messages: FridayProviderContextMessage[] = [
+      makeMessage({ index: 1, role: "user", content: "Please summarize the workflow plan." }),
+      makeMessage({ index: 2, role: "assistant", content: "Plan: reconnect browser, rerun smoke, verify Discord." }),
+      makeMessage({ index: 3, role: "user", content: "What failed first?" }),
+      makeMessage({ index: 4, role: "assistant", content: "The browser session was not connected, so opening GitHub failed." }),
+      makeMessage({ index: 5, role: "user", content: "What should we do next?" }),
+      makeMessage({ index: 6, role: "assistant", content: "Next, collect logs and screenshots." }),
+      makeMessage({ index: 7, role: "user", content: "Any blockers?" }),
+      makeMessage({ index: 8, role: "assistant", content: "No blockers beyond the missing browser connection." }),
+    ];
+
+    const result = await compactor.compact({
+      systemPrompt: "You are a workflow generator.",
+      userPrompt: "Build a final summary of the plan and earlier browser failure.",
+      messages,
+      contextWindowTokens: 70,
+      summarize: async () => "{\"summaryText\":\"unused\"}",
+    });
+
+    expect(result.compacted).toBe(true);
+    expect(result.summary?.summaryText).toContain("[");
+    expect(result.blocks?.length).toBeGreaterThanOrEqual(3);
+    expect(result.keptMessages[0]?.messageId).toBe("compaction-summary");
+    expect(result.keptMessages[0]?.content).toContain("[Conversation Block Summaries]");
+  });
+});

--- a/test/unit/sessions/services/friday-session-conversation-orchestrator.test.ts
+++ b/test/unit/sessions/services/friday-session-conversation-orchestrator.test.ts
@@ -250,6 +250,99 @@ describe("friday-session-conversation-orchestrator", () => {
     expect(prepared.historyMessages).toHaveLength(5);
   });
 
+  it("rehydrates relevant earlier history blocks for long follow-up conversations", () => {
+    const historyRecords: FridaySessionMessageRecord[] = [
+      makeMessage({ sequence: 1, role: "user", contentText: "Open GitHub in the browser." }),
+      makeMessage({ sequence: 2, role: "assistant", contentText: "I could not open GitHub because the browser session was not connected." }),
+      makeMessage({ sequence: 3, role: "user", contentText: "What does the error imply?" }),
+      makeMessage({ sequence: 4, role: "assistant", contentText: "It implies the browser bridge was unavailable." }),
+      makeMessage({ sequence: 5, role: "user", contentText: "How should we test the fix?" }),
+      makeMessage({ sequence: 6, role: "assistant", contentText: "Run a smoke test after reconnecting the browser session." }),
+      makeMessage({ sequence: 7, role: "user", contentText: "Should we also check Discord?" }),
+      makeMessage({ sequence: 8, role: "assistant", contentText: "Yes, verify Discord notifications after the browser smoke test." }),
+      makeMessage({ sequence: 9, role: "user", contentText: "What about logging?" }),
+      makeMessage({ sequence: 10, role: "assistant", contentText: "Capture logs before and after reconnecting." }),
+      makeMessage({ sequence: 11, role: "user", contentText: "Summarize the rollout order." }),
+      makeMessage({ sequence: 12, role: "assistant", contentText: "Reconnect browser, rerun smoke, verify Discord, then inspect logs." }),
+      makeMessage({ sequence: 13, role: "user", contentText: "Do we need screenshots?" }),
+      makeMessage({ sequence: 14, role: "assistant", contentText: "Yes, collect screenshots for the regression report." }),
+      makeMessage({ sequence: 15, role: "user", contentText: "Anything else?" }),
+      makeMessage({ sequence: 16, role: "assistant", contentText: "That covers the rollout checklist." }),
+    ];
+
+    const prepared = prepareFridayConversationTurn({
+      task: "why didn't it connect/open?",
+      focusState: {
+        ...baseFocusState,
+        currentTopicSummary: "Open GitHub in the browser and understand why it failed to connect.",
+        currentTopicStartSequence: 1,
+        assistantAnchorSummary: "That covers the rollout checklist.",
+      },
+      currentUserSequence: 17,
+      historyRecords,
+    });
+
+    expect(prepared.turnKind).toBe("follow_up");
+    expect(prepared.selectedBlocks.some((block) => block.source === "tool_failure_block")).toBe(true);
+    expect(prepared.historyMessages.some((message) =>
+      message.role === "assistant"
+      && typeof message.content === "string"
+      && message.content.includes("browser session was not connected"))).toBe(true);
+    expect(prepared.taskPrompt).toContain("tool_failure_block");
+  });
+
+  it("does not let compacted older blocks pollute a new topic", () => {
+    const historyRecords: FridaySessionMessageRecord[] = Array.from({ length: 16 }, (_, index) => {
+      const sequence = index + 1;
+      return makeMessage({
+        sequence,
+        role: sequence % 2 === 1 ? "user" : "assistant",
+        contentText: sequence % 2 === 1
+          ? `Discuss browser rollout step ${String(sequence)}`
+          : `Assistant rollout answer ${String(sequence)} about reconnecting the browser.`,
+      });
+    });
+
+    const prepared = prepareFridayConversationTurn({
+      task: "How do I bake sourdough bread?",
+      focusState: {
+        ...baseFocusState,
+        currentTopicSummary: "Open GitHub in the browser and understand why it failed to connect.",
+        currentTopicStartSequence: 1,
+      },
+      currentUserSequence: 17,
+      historyRecords,
+    });
+
+    expect(prepared.turnKind).toBe("new_topic");
+    expect(prepared.historyMessages).toEqual([]);
+    expect(prepared.taskPrompt).toContain("Current question: How do I bake sourdough bread?");
+    expect(prepared.taskPrompt).toContain("Previous topic");
+  });
+
+  it("does not treat a new topic as follow-up when the only overlap is a weak assistant token", () => {
+    const prepared = prepareFridayConversationTurn({
+      task: "How do I bake sourdough bread? Answer in one sentence.",
+      focusState: {
+        ...baseFocusState,
+        currentTopicSummary: "Say exactly this sentence and nothing else: GitHub did not open because the browser session was not connected.",
+        currentTopicStartSequence: 1,
+        assistantAnchorSummary: "GitHub did not open because the browser session was not connected.",
+      },
+      currentUserSequence: 19,
+      historyRecords: [
+        makeMessage({ sequence: 1, role: "user", contentText: "Say exactly this sentence and nothing else: GitHub did not open because the browser session was not connected." }),
+        makeMessage({ sequence: 2, role: "assistant", contentText: "GitHub did open successfully and returned an HTTP 200 OK status." }),
+        makeMessage({ sequence: 3, role: "user", contentText: "For that same browser-session problem, in one short sentence, summarize the smoke test." }),
+        makeMessage({ sequence: 4, role: "assistant", contentText: "I do not have deeper root-cause evidence beyond that, so I won't speculate." }),
+      ],
+    });
+
+    expect(prepared.turnKind).toBe("new_topic");
+    expect(prepared.historyMessages).toEqual([]);
+    expect(prepared.taskPrompt).toContain("Current question: How do I bake sourdough bread?");
+  });
+
   it("persists new-topic focus state with the current sequence", () => {
     const focus = finalizeFridayConversationFocus({
       task: "How do I bake sourdough bread?",


### PR DESCRIPTION
## Summary
- replace fixed recent-turn compaction with block-based session compaction
- keep relevant older raw blocks available for long follow-up turns
- add provider context compactor block summaries and regression tests

## Verification
- npm run typecheck
- npm run lint
- npm run build
- npx vitest run test/unit/sessions/services/friday-session-conversation-orchestrator.test.ts test/unit/providers/context/friday-provider-context-compactor.test.ts
- real-model launchd smoke for long follow-up and new-topic isolation
