### PR TITLE
feat: add relevant workspace memory blocks

### DIFF
--- a/src/agent/runtime/friday-agent-runtime.ts
+++ b/src/agent/runtime/friday-agent-runtime.ts
@@ -942,6 +942,8 @@ export function createFridayAgentRuntime(
             nowIso: runTimeContext.nowIso,
             timezone: runTimeContext.timezone,
             localDate: runTimeContext.localDate,
+            task: params.task,
+            conversationContext,
           }))
           : (staticSystemPrompt ?? "You are an AI assistant.");
 

--- a/src/agent/runtime/friday-agent-runtime.types.ts
+++ b/src/agent/runtime/friday-agent-runtime.types.ts
@@ -70,6 +70,8 @@ export interface FridayAgentSystemPromptContext {
   nowIso: string;
   timezone: string;
   localDate: string;
+  task?: string;
+  conversationContext?: FridayAgentConversationContext;
 }
 
 // ─── Runtime interface ───

--- a/src/agent/runtime/friday-agent-workspace-context.ts
+++ b/src/agent/runtime/friday-agent-workspace-context.ts
@@ -17,6 +17,7 @@
 
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import type { FridayConversationBlock } from "#sessions";
 import { FRIDAY_MEMORY_FILE_SYNC_EXPORT_DIR } from "../../memory/sync/friday-memory-file-sync.constants.js";
 
 // ─── Types ───
@@ -30,6 +31,14 @@ export interface FridayWorkspaceContextFile {
   content?: string;
   /** True if the file does not exist on disk. */
   missing: boolean;
+  /** Identity blocks are always injected; candidate blocks are relevance-ranked. */
+  kind?: "identity" | "candidate";
+  /** Whether this block was selected into the prompt fragment. */
+  selected?: boolean;
+  /** Deterministic relevance score used for candidate selection. */
+  selectionScore?: number;
+  /** Human-readable explanation for why a block was selected. */
+  selectionReason?: string;
 }
 
 export interface FridayWorkspaceContext {
@@ -39,12 +48,27 @@ export interface FridayWorkspaceContext {
   promptFragment: string;
 }
 
+export interface FridayWorkspaceContextSelectionInput {
+  task?: string;
+  selectedBlocks?: FridayConversationBlock[];
+}
+
+interface FridayStoredMemoryCandidate {
+  name: string;
+  filePath: string;
+  content: string;
+}
+
 // ─── Constants ───
 
-/** Standard workspace context filenames, in injection order. */
-const WORKSPACE_CONTEXT_FILES = [
+/** Identity files are always injected when present. */
+const IDENTITY_WORKSPACE_FILES = [
   "AGENTS.md",
   "SOUL.md",
+ ] as const;
+
+/** Candidate files are injected only when relevant to the current turn. */
+const CANDIDATE_WORKSPACE_FILES = [
   "USER.md",
   "MEMORY.md",
   "memory.md",
@@ -59,6 +83,156 @@ const MAX_TOTAL_CONTEXT_CHARS = 64_000;
 /** Maximum memory items to include from exported JSON files. */
 const MAX_MEMORY_EXPORT_ITEMS = 100;
 
+/** Maximum candidate blocks to inject when task-aware selection is active. */
+const MAX_SELECTED_CANDIDATE_BLOCKS = 3;
+
+const WORKSPACE_CONTEXT_STOPWORDS = new Set([
+  "a", "an", "and", "are", "as", "at", "be", "by", "for", "from", "how", "i",
+  "if", "in", "is", "it", "me", "my", "of", "on", "or", "please", "that", "the",
+  "this", "to", "user", "what", "when", "where", "why", "with", "you", "your",
+]);
+
+function normalizeText(text: string): string {
+  return text
+    .normalize("NFKC")
+    .replace(/[\u2018\u2019]/g, "'")
+    .replace(/[\u201C\u201D]/g, "\"")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function tokenize(text: string): string[] {
+  const normalized = normalizeText(text).toLowerCase();
+  if (normalized.length === 0) {
+    return [];
+  }
+  return normalized
+    .split(/[^a-z0-9\u4e00-\u9fff]+/u)
+    .map((token) => token.trim())
+    .filter((token) => token.length > 1 && !WORKSPACE_CONTEXT_STOPWORDS.has(token))
+    .flatMap((token) => {
+      if (/^[a-z]+ies$/u.test(token) && token.length > 4) {
+        return [token, `${token.slice(0, -3)}y`];
+      }
+      if (/^[a-z]+s$/u.test(token) && token.length > 3) {
+        return [token, token.slice(0, -1)];
+      }
+      return [token];
+    });
+}
+
+function countOverlap(left: readonly string[], right: readonly string[]): number {
+  if (left.length === 0 || right.length === 0) {
+    return 0;
+  }
+  const rightSet = new Set(right);
+  let count = 0;
+  for (const token of left) {
+    if (rightSet.has(token)) {
+      count++;
+    }
+  }
+  return count;
+}
+
+function deriveSelectionReason(input: {
+  file: FridayWorkspaceContextFile;
+  taskOverlap: number;
+  selectedBlockOverlap: number;
+  recencyBonus: number;
+}): string {
+  const reasons: string[] = [];
+  if (input.taskOverlap > 0) {
+    reasons.push(`task overlap ${String(input.taskOverlap)}`);
+  }
+  if (input.selectedBlockOverlap > 0) {
+    reasons.push(`session overlap ${String(input.selectedBlockOverlap)}`);
+  }
+  if (input.recencyBonus > 0) {
+    reasons.push(`recency bonus ${String(input.recencyBonus)}`);
+  }
+  if (reasons.length === 0) {
+    return `${input.file.name} retained by default ordering`;
+  }
+  return `${input.file.name} matched via ${reasons.join(", ")}`;
+}
+
+function scoreWorkspaceCandidate(input: {
+  file: FridayWorkspaceContextFile;
+  taskTokens: readonly string[];
+  selectedBlockTokens: readonly string[];
+}): { score: number; reason: string } {
+  const contentTokens = tokenize(input.file.content ?? "");
+  const taskOverlap = countOverlap(input.taskTokens, contentTokens);
+  const selectedBlockOverlap = countOverlap(input.selectedBlockTokens, contentTokens);
+  const recencyBonus = input.file.name.startsWith("memory/")
+    ? 6
+    : input.file.name === "stored-memories"
+      ? 4
+      : 0;
+  const score = (taskOverlap * 20) + (selectedBlockOverlap * 14) + recencyBonus;
+  return {
+    score,
+    reason: deriveSelectionReason({
+      file: input.file,
+      taskOverlap,
+      selectedBlockOverlap,
+      recencyBonus,
+    }),
+  };
+}
+
+function selectWorkspaceContextFiles(
+  files: FridayWorkspaceContextFile[],
+  options?: FridayWorkspaceContextSelectionInput,
+): FridayWorkspaceContextFile[] {
+  const presentFiles = files.filter((file) => !file.missing && Boolean(file.content?.trim()));
+  const identityFiles = presentFiles
+    .filter((file) => file.kind === "identity")
+    .map((file) => ({ ...file, selected: true, selectionReason: `${file.name} is an identity block` }));
+  const candidateFiles = presentFiles.filter((file) => file.kind === "candidate");
+
+  const taskTokens = tokenize(options?.task ?? "");
+  const selectedBlockTokens = tokenize((options?.selectedBlocks ?? []).map((block) => block.summary).join(" "));
+  const hasSelectionContext = taskTokens.length > 0 || selectedBlockTokens.length > 0;
+
+  if (!hasSelectionContext) {
+    return [
+      ...identityFiles,
+      ...candidateFiles.map((file) => ({
+        ...file,
+        selected: true,
+        selectionReason: `${file.name} included because no task-aware filtering was requested`,
+      })),
+    ];
+  }
+
+  const rankedCandidates = candidateFiles
+    .map((file, index) => {
+      const { score, reason } = scoreWorkspaceCandidate({
+        file,
+        taskTokens,
+        selectedBlockTokens,
+      });
+      return {
+        file: {
+          ...file,
+          selectionScore: score,
+          selectionReason: reason,
+        },
+        index,
+      };
+    })
+    .filter((entry) => (entry.file.selectionScore ?? 0) > 0)
+    .sort((left, right) =>
+      (right.file.selectionScore ?? 0) - (left.file.selectionScore ?? 0)
+      || left.index - right.index)
+    .slice(0, MAX_SELECTED_CANDIDATE_BLOCKS)
+    .map((entry) => ({ ...entry.file, selected: true }));
+
+  return [...identityFiles, ...rankedCandidates];
+}
+
 // ─── Loader ───
 
 /**
@@ -68,12 +242,16 @@ const MAX_MEMORY_EXPORT_ITEMS = 100;
  */
 export async function loadFridayWorkspaceContext(
   workspaceDir: string,
+  options?: FridayWorkspaceContextSelectionInput,
 ): Promise<FridayWorkspaceContext> {
   const resolvedDir = path.resolve(workspaceDir);
   const files: FridayWorkspaceContextFile[] = [];
   const seenRealPaths = new Set<string>();
 
-  for (const name of WORKSPACE_CONTEXT_FILES) {
+  const loadNamedFile = async (
+    name: string,
+    kind: "identity" | "candidate",
+  ): Promise<void> => {
     const filePath = path.join(resolvedDir, name);
     try {
       const content = await fs.readFile(filePath, "utf-8");
@@ -86,7 +264,7 @@ export async function loadFridayWorkspaceContext(
         // Use lexical path if realpath fails
       }
       if (seenRealPaths.has(realPath)) {
-        continue;
+        return;
       }
       seenRealPaths.add(realPath);
 
@@ -94,10 +272,17 @@ export async function loadFridayWorkspaceContext(
         ? content.slice(0, MAX_FILE_SIZE_CHARS) + "\n...(truncated)"
         : content;
 
-      files.push({ name, filePath, content: truncated, missing: false });
+      files.push({ name, filePath, content: truncated, missing: false, kind });
     } catch {
-      files.push({ name, filePath, missing: true });
+      files.push({ name, filePath, missing: true, kind });
     }
+  };
+
+  for (const name of IDENTITY_WORKSPACE_FILES) {
+    await loadNamedFile(name, "identity");
+  }
+  for (const name of CANDIDATE_WORKSPACE_FILES) {
+    await loadNamedFile(name, "candidate");
   }
 
   // Also load daily memory file (memory/YYYY-MM-DD.md)
@@ -109,24 +294,31 @@ export async function loadFridayWorkspaceContext(
     const truncated = content.length > MAX_FILE_SIZE_CHARS
       ? content.slice(0, MAX_FILE_SIZE_CHARS) + "\n...(truncated)"
       : content;
-    files.push({ name: `memory/${today}.md`, filePath: dailyMemoryPath, content: truncated, missing: false });
+    files.push({
+      name: `memory/${today}.md`,
+      filePath: dailyMemoryPath,
+      content: truncated,
+      missing: false,
+      kind: "candidate",
+    });
   } catch {
     // Daily memory file is optional
   }
 
   // Load exported memory items from .friday/exports/memory/ (feedback loop)
-  const memoryExportContent = await loadMemoryExports(resolvedDir);
-  if (memoryExportContent) {
+  const memoryExportCandidates = await loadMemoryExports(resolvedDir);
+  for (const memoryExportCandidate of memoryExportCandidates) {
     files.push({
-      name: "stored-memories",
-      filePath: path.join(resolvedDir, FRIDAY_MEMORY_FILE_SYNC_EXPORT_DIR, "memory"),
-      content: memoryExportContent,
+      name: memoryExportCandidate.name,
+      filePath: memoryExportCandidate.filePath,
+      content: memoryExportCandidate.content,
       missing: false,
+      kind: "candidate",
     });
   }
 
   // Build prompt fragment from loaded files
-  const promptFragment = buildWorkspacePromptFragment(files);
+  const promptFragment = buildWorkspacePromptFragment(selectWorkspaceContextFiles(files, options));
 
   return { files, promptFragment };
 }
@@ -137,20 +329,20 @@ export async function loadFridayWorkspaceContext(
  * agent uses `memory_store`. This closes the feedback loop so stored
  * memories appear in the next run's system prompt.
  */
-async function loadMemoryExports(workspaceDir: string): Promise<string | null> {
+async function loadMemoryExports(workspaceDir: string): Promise<FridayStoredMemoryCandidate[]> {
   const memoryDir = path.join(workspaceDir, FRIDAY_MEMORY_FILE_SYNC_EXPORT_DIR, "memory");
 
   let entries: string[];
   try {
     entries = await fs.readdir(memoryDir);
   } catch {
-    return null; // Directory doesn't exist yet — no memories exported
+    return []; // Directory doesn't exist yet — no memories exported
   }
 
   const jsonFiles = entries.filter((e) => e.endsWith(".json")).sort();
-  if (jsonFiles.length === 0) return null;
+  if (jsonFiles.length === 0) return [];
 
-  const lines: string[] = [];
+  const candidates: FridayStoredMemoryCandidate[] = [];
   let itemCount = 0;
 
   for (const file of jsonFiles) {
@@ -161,6 +353,7 @@ async function loadMemoryExports(workspaceDir: string): Promise<string | null> {
       const parsed = JSON.parse(raw) as {
         namespace?: string;
         items?: Array<{
+          id?: string;
           contentText?: string | null;
           value?: unknown;
           tags?: string[];
@@ -178,7 +371,13 @@ async function loadMemoryExports(workspaceDir: string): Promise<string | null> {
 
         const tags = item.tags && item.tags.length > 0 ? ` [${item.tags.join(", ")}]` : "";
         const date = item.createdAt ? ` (${item.createdAt.slice(0, 10)})` : "";
-        lines.push(`- ${text}${tags}${date}`);
+        const safeNamespace = (parsed.namespace ?? "memory").replace(/[^a-z0-9._-]+/gi, "_");
+        const safeId = (item.id ?? `${itemCount + 1}`).replace(/[^a-z0-9._-]+/gi, "_");
+        candidates.push({
+          name: `stored-memories/${safeNamespace}/${safeId}`,
+          filePath: path.join(memoryDir, file),
+          content: `- ${text}${tags}${date}`,
+        });
         itemCount++;
       }
     } catch {
@@ -186,8 +385,7 @@ async function loadMemoryExports(workspaceDir: string): Promise<string | null> {
     }
   }
 
-  if (lines.length === 0) return null;
-  return `Previously stored memories (from memory_store):\n${lines.join("\n")}`;
+  return candidates;
 }
 
 /**

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -94,6 +94,7 @@ import {
   finalizeFridayConversationFocus,
   prepareFridayConversationTurn,
 } from "#sessions";
+import type { FridayConversationBlock } from "#sessions";
 import type { FridayMemoryFileSyncService, FridayMemoryService } from "#memory";
 import {
   buildFridayAgentSystemPrompt,
@@ -1891,10 +1892,17 @@ export async function createFridayHub(
     nowIso: string;
     timezone: string;
     localDate: string;
+    task?: string;
+    conversationContext?: {
+      selectedBlocks?: FridayConversationBlock[];
+    };
   }) => {
     let workspaceContext: string | undefined;
     try {
-      const ctx = await loadFridayWorkspaceContext(workspaceRoot);
+      const ctx = await loadFridayWorkspaceContext(workspaceRoot, {
+        task: input.task,
+        selectedBlocks: input.conversationContext?.selectedBlocks,
+      });
       if (ctx.promptFragment) {
         workspaceContext = ctx.promptFragment;
       }

--- a/test/unit/agent/runtime/friday-agent-workspace-context.test.ts
+++ b/test/unit/agent/runtime/friday-agent-workspace-context.test.ts
@@ -12,6 +12,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import * as os from "node:os";
 import { loadFridayWorkspaceContext } from "../../../../src/agent/runtime/friday-agent-workspace-context.js";
+import type { FridayConversationBlock } from "../../../../src/sessions/index.js";
 
 let tmpDir: string;
 
@@ -286,6 +287,103 @@ describe("loadFridayWorkspaceContext", () => {
       const ctx = await loadFridayWorkspaceContext(tmpDir);
       // Total should be capped
       expect(ctx.promptFragment.length).toBeLessThan(70_000); // Some overhead for headers
+    });
+  });
+
+  describe("task-aware relevant block selection", () => {
+    it("keeps identity blocks and filters candidate blocks by task relevance", async () => {
+      await fs.writeFile(path.join(tmpDir, "AGENTS.md"), "Always follow repository instructions.");
+      await fs.writeFile(path.join(tmpDir, "SOUL.md"), "Stay concise.");
+      await fs.writeFile(path.join(tmpDir, "USER.md"), "User likes sourdough recipes.");
+      await fs.writeFile(path.join(tmpDir, "MEMORY.md"), "User prefers dark mode in editors.");
+
+      const ctx = await loadFridayWorkspaceContext(tmpDir, {
+        task: "How do I bake sourdough bread?",
+      });
+
+      expect(ctx.promptFragment).toContain("## AGENTS.md");
+      expect(ctx.promptFragment).toContain("## SOUL.md");
+      expect(ctx.promptFragment).toContain("sourdough recipes");
+      expect(ctx.promptFragment).not.toContain("dark mode in editors");
+    });
+
+    it("uses selected session blocks to pull in relevant stored memory for generic follow-ups", async () => {
+      const exportDir = path.join(tmpDir, ".friday", "exports", "memory");
+      await fs.mkdir(exportDir, { recursive: true });
+      await fs.writeFile(
+        path.join(exportDir, "session.json"),
+        JSON.stringify({
+          namespace: "agent:session:test",
+          items: [
+            {
+              id: "mem-1",
+              contentText: "GitHub browser issue was caused by browser not connected",
+              tags: ["incident"],
+              createdAt: "2026-03-16T10:00:00Z",
+            },
+            {
+              id: "mem-2",
+              contentText: "Unrelated note about sourdough hydration",
+              tags: ["recipe"],
+              createdAt: "2026-03-15T10:00:00Z",
+            },
+          ],
+        }),
+      );
+
+      const selectedBlocks: FridayConversationBlock[] = [
+        {
+          id: "reply:1",
+          source: "reply_anchor",
+          summary: "The GitHub issue was browser not connected.",
+          score: 100,
+          reason: "Explicit reply anchor",
+          messageIds: ["assistant-1"],
+        },
+      ];
+
+      const ctx = await loadFridayWorkspaceContext(tmpDir, {
+        task: "Why did that fail?",
+        selectedBlocks,
+      });
+
+      expect(ctx.promptFragment).toContain("browser not connected");
+      expect(ctx.promptFragment).not.toContain("sourdough hydration");
+    });
+
+    it("matches simple singular/plural variants when selecting stored memories", async () => {
+      const exportDir = path.join(tmpDir, ".friday", "exports", "memory");
+      await fs.mkdir(exportDir, { recursive: true });
+      await fs.writeFile(
+        path.join(exportDir, "session.json"),
+        JSON.stringify({
+          namespace: "agent:session:test",
+          items: [
+            {
+              id: "mem-1",
+              contentText: "The user likes matcha drinks",
+              tags: ["preference"],
+              createdAt: "2026-03-17T00:00:00Z",
+            },
+          ],
+        }),
+      );
+
+      const ctx = await loadFridayWorkspaceContext(tmpDir, {
+        task: "What drink do I like?",
+      });
+
+      expect(ctx.promptFragment).toContain("matcha drinks");
+    });
+
+    it("includes all candidate blocks when no task-aware filtering input is provided", async () => {
+      await fs.writeFile(path.join(tmpDir, "USER.md"), "User likes sourdough recipes.");
+      await fs.writeFile(path.join(tmpDir, "MEMORY.md"), "User prefers dark mode in editors.");
+
+      const ctx = await loadFridayWorkspaceContext(tmpDir);
+
+      expect(ctx.promptFragment).toContain("sourdough recipes");
+      expect(ctx.promptFragment).toContain("dark mode in editors");
     });
   });
 });


### PR DESCRIPTION
## Summary
- select USER/MEMORY/daily/stored workspace blocks by deterministic relevance instead of injecting them all in fixed order
- keep AGENTS.md and SOUL.md as always-on identity blocks while letting task + selected session blocks drive candidate memory selection
- split stored memory exports into individual candidate blocks and normalize simple singular/plural matches so direct queries like drink/drinks still recall the right memory

## Verification
- npm run typecheck
- npm run lint
- npx vitest run test/unit/agent/runtime/friday-agent-workspace-context.test.ts test/unit/agent/runtime/friday-agent-runtime.test.ts
- real-model smoke on launchd Friday for sourdough recall, matcha recall, clean math answer, and GitHub session-anchor precedence