### PR TITLE
feat: add evidence-aware context selection

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -237,6 +237,11 @@ export type {
 } from "./tools/friday-agent-task-status-tool.js";
 export { createFridayAgentTaskStatusTool } from "./tools/friday-agent-task-status-tool.js";
 
+// ─── Evidence block selector ───
+
+export type { BuildFridayEvidenceBlocksInput } from "./runtime/friday-agent-evidence-blocks.js";
+export { buildFridayEvidenceBlocks } from "./runtime/friday-agent-evidence-blocks.js";
+
 // ─── MCP adapter ───
 
 export type {

--- a/src/agent/runtime/friday-agent-answer-alignment.ts
+++ b/src/agent/runtime/friday-agent-answer-alignment.ts
@@ -117,6 +117,68 @@ function selectedBlockSummary(
   return selectedBlocks.map((block) => block.summary).join("\n");
 }
 
+function selectedBlockBySource(
+  conversationContext: FridayAgentConversationContext | undefined,
+  source: string,
+): string | undefined {
+  return conversationContext?.selectedBlocks
+    ?.find((block) => block.source === source)
+    ?.summary;
+}
+
+function hasCapabilityContradiction(
+  conversationContext: FridayAgentConversationContext | undefined,
+  responseText: string,
+): boolean {
+  const summary = selectedBlockBySource(conversationContext, "capabilities_block");
+  if (!summary) {
+    return false;
+  }
+
+  const response = normalizeText(responseText);
+  const summaryNormalized = normalizeText(summary);
+  const discordEnabled = /messaging enabled \(discord\)/i.test(summaryNormalized);
+  const mcpEnabled = /\bMCP enabled\b/i.test(summaryNormalized);
+  const providerBlocked = /provider mutations blocked by read.?only/i.test(summaryNormalized);
+
+  const responseDiscordDisabled =
+    /\bdiscord\b(?:[^.;,\n]{0,40})?(?:disabled|not enabled|unavailable)\b/i.test(response);
+  const responseDiscordEnabled =
+    /\bdiscord\b(?:[^.;,\n]{0,40})?\benabled\b/i.test(response) && !responseDiscordDisabled;
+  if (discordEnabled && responseDiscordDisabled) {
+    return true;
+  }
+  if (!discordEnabled && responseDiscordEnabled) {
+    return true;
+  }
+
+  const responseMcpDisabled =
+    /\bmcp\b(?:[^.;,\n]{0,40})?(?:disabled|not enabled|unavailable)\b/i.test(response);
+  const responseMcpEnabled =
+    /\bmcp\b(?:[^.;,\n]{0,40})?\benabled\b/i.test(response) && !responseMcpDisabled;
+  if (mcpEnabled && responseMcpDisabled) {
+    return true;
+  }
+  if (!mcpEnabled && responseMcpEnabled) {
+    return true;
+  }
+
+  const responseProviderAvailable =
+    /provider mutation(?:s)? .*not blocked by read.?only/i.test(response)
+    || /provider mutation(?:s)? .*available/i.test(response);
+  const responseProviderBlocked =
+    /provider mutation(?:s)? .*blocked by read.?only/i.test(response)
+    && !responseProviderAvailable;
+  if (providerBlocked && responseProviderAvailable) {
+    return true;
+  }
+  if (!providerBlocked && responseProviderBlocked) {
+    return true;
+  }
+
+  return false;
+}
+
 function deriveAnchoredAssistantFact(
   conversationContext: FridayAgentConversationContext | undefined,
 ): string {
@@ -251,6 +313,18 @@ export function evaluateFridayAnswerAlignment(params: {
         ].join("\n"),
       };
     }
+  }
+
+  if (hasCapabilityContradiction(params.conversationContext, responseText)) {
+    return {
+      retryPrompt: [
+        "You contradicted deterministic runtime capability facts selected for this turn.",
+        `Current question: ${params.task}`,
+        `Capability facts:\n- ${selectedBlockBySource(params.conversationContext, "capabilities_block")}`,
+        "Answer only with the selected deterministic capability facts.",
+        "Do not negate or reinterpret those facts.",
+      ].join("\n"),
+    };
   }
 
   if (turnKind === "new_topic" && anchoredOverlap >= 2 && currentOverlap === 0) {

--- a/src/agent/runtime/friday-agent-evidence-blocks.ts
+++ b/src/agent/runtime/friday-agent-evidence-blocks.ts
@@ -1,0 +1,206 @@
+import type {
+  FridayConversationTurnKind,
+  FridayEvidenceBlock,
+  FridaySessionConversationFocusState,
+} from "#sessions";
+
+import type { FridayAgentCapabilitiesSnapshot } from "../tools/friday-agent-capabilities-tool.js";
+import type { FridayAgentTaskStatusSnapshot } from "../tools/friday-agent-task-status-tool.js";
+
+const STATUS_HINTS =
+  /\b(status|progress|running|waiting|completed|failed|blocked|doing|doing right now|result|results|latest result|eta|done yet|finished yet|what are you doing|what happened|what was the issue|why failed)\b/i;
+const CHINESE_STATUS_HINTS =
+  /(状态|进度|还在|等待|完成了吗|失败|为什么failed|为什么失败|现在在做什么|那个任务结果呢|结果呢|怎么了|发生了什么)/;
+const CAPABILITY_HINTS =
+  /\b(capabilities?|what can\b|can (?:friday|you)\b.*\bdo\b|enabled|disabled|deployment|runtime facts?|messaging|discord|mcp|desktop companion|provider mutations?|read[- ]?only)\b/i;
+const CHINESE_CAPABILITY_HINTS =
+  /(能力|能做什么|启用|禁用|部署|运行时|discord|mcp|桌面伴侣|提供者修改|只读)/i;
+
+export interface BuildFridayEvidenceBlocksInput {
+  task: string;
+  turnKind: FridayConversationTurnKind;
+  focusState?: FridaySessionConversationFocusState | null;
+  capabilitiesSnapshot?: FridayAgentCapabilitiesSnapshot;
+  taskStatusSnapshot?: FridayAgentTaskStatusSnapshot;
+}
+
+function normalizeText(text: string): string {
+  return text.trim().replace(/\s+/g, " ");
+}
+
+function formatElapsed(elapsedMs: number | undefined): string {
+  if (typeof elapsedMs !== "number" || !Number.isFinite(elapsedMs) || elapsedMs < 0) {
+    return "unknown";
+  }
+  if (elapsedMs < 1000) {
+    return `${String(elapsedMs)}ms`;
+  }
+  const seconds = Math.round(elapsedMs / 1000);
+  if (seconds < 90) {
+    return `${String(seconds)}s`;
+  }
+  return `${String(Math.round(seconds / 60))}m`;
+}
+
+function formatCapabilitiesSummary(snapshot: FridayAgentCapabilitiesSnapshot): string {
+  const messagingSummary = snapshot.messaging.enabled
+    ? `messaging enabled (${snapshot.messaging.kinds.join(", ")})`
+    : "messaging disabled";
+  const mcpSummary = snapshot.mcp.enabled
+    ? `MCP enabled (${String(snapshot.mcp.serverCount)} server${snapshot.mcp.serverCount === 1 ? "" : "s"})`
+    : "MCP disabled";
+  const providerSummary = snapshot.provider.available
+    ? `provider mutations ${snapshot.provider.mutationBlockedByReadOnly ? "blocked by readOnly" : "available"}`
+    : "provider unavailable";
+  const browserSummary = snapshot.browser.activeMode || snapshot.browser.targetBrowser
+    ? `browser ${snapshot.browser.activeMode ?? "unknown"}${snapshot.browser.targetBrowser ? ` (${snapshot.browser.targetBrowser})` : ""}`
+    : "browser mode unavailable";
+  const desktopSummary = snapshot.desktop.connected
+    ? "desktop connected"
+    : "desktop disconnected";
+  const companionSummary = snapshot.companion.connected
+    ? "desktop companion connected"
+    : "desktop companion disconnected";
+  return normalizeText(
+    [
+      messagingSummary,
+      mcpSummary,
+      providerSummary,
+      browserSummary,
+      snapshot.system.enabled ? "system enabled" : "system disabled",
+      desktopSummary,
+      companionSummary,
+    ].join("; "),
+  );
+}
+
+function formatTaskStatusSummary(snapshot: FridayAgentTaskStatusSnapshot): string {
+  const parts: string[] = [];
+  if (snapshot.trackedRunId) {
+    parts.push(`run ${snapshot.trackedRunId}`);
+  } else if (snapshot.pendingPlanRunId) {
+    parts.push(`pending plan ${snapshot.pendingPlanRunId}`);
+  } else {
+    parts.push("no tracked run");
+  }
+  if (snapshot.runStatus) {
+    parts.push(`status ${snapshot.runStatus}`);
+  }
+  if (snapshot.phase) {
+    parts.push(`phase ${snapshot.phase}`);
+  }
+  if (snapshot.elapsedMs !== undefined) {
+    parts.push(`elapsed ${formatElapsed(snapshot.elapsedMs)}`);
+  }
+  if (snapshot.latestTool) {
+    parts.push(`latest tool ${snapshot.latestTool}`);
+  }
+  if (snapshot.blockers.length > 0) {
+    parts.push(`blockers ${snapshot.blockers.join(" | ")}`);
+  }
+  if (snapshot.terminalOutcome?.summary) {
+    parts.push(`summary ${snapshot.terminalOutcome.summary}`);
+  } else if (snapshot.terminalOutcome?.responseText) {
+    parts.push(`response ${snapshot.terminalOutcome.responseText}`);
+  }
+  return normalizeText(parts.join("; "));
+}
+
+function shouldIncludeStatusEvidence(input: BuildFridayEvidenceBlocksInput): boolean {
+  return input.turnKind === "status_check"
+    || STATUS_HINTS.test(input.task)
+    || CHINESE_STATUS_HINTS.test(input.task)
+    || Boolean(input.focusState?.pendingPlanRunId)
+    || Boolean(input.focusState?.activeRunId)
+    || Boolean(input.focusState?.activeSubagentIds?.length);
+}
+
+function shouldIncludeCapabilitiesEvidence(input: BuildFridayEvidenceBlocksInput): boolean {
+  return CAPABILITY_HINTS.test(input.task) || CHINESE_CAPABILITY_HINTS.test(input.task);
+}
+
+export function buildFridayEvidenceBlocks(
+  input: BuildFridayEvidenceBlocksInput,
+): FridayEvidenceBlock[] {
+  const blocks: FridayEvidenceBlock[] = [];
+
+  if (input.capabilitiesSnapshot && shouldIncludeCapabilitiesEvidence(input)) {
+    blocks.push({
+      id: "evidence:capabilities",
+      source: "capabilities_block",
+      summary: formatCapabilitiesSummary(input.capabilitiesSnapshot),
+      score: 120,
+      reason: "Deterministic runtime capability facts selected for a deployment/capabilities question.",
+    });
+  }
+
+  if (input.taskStatusSnapshot && shouldIncludeStatusEvidence(input)) {
+    blocks.push({
+      id: "evidence:task-status",
+      source: "task_status_block",
+      summary: formatTaskStatusSummary(input.taskStatusSnapshot),
+      score: input.turnKind === "status_check" ? 125 : 92,
+      reason: "Deterministic task status snapshot selected for a status/progress/result question.",
+    });
+
+    if (input.taskStatusSnapshot.phase || input.taskStatusSnapshot.latestTool) {
+      blocks.push({
+        id: "evidence:run-activity",
+        source: "run_event_block",
+        summary: normalizeText([
+          input.taskStatusSnapshot.phase ? `latest phase ${input.taskStatusSnapshot.phase}` : undefined,
+          input.taskStatusSnapshot.latestTool ? `latest tool ${input.taskStatusSnapshot.latestTool}` : undefined,
+          input.taskStatusSnapshot.elapsedMs !== undefined
+            ? `elapsed ${formatElapsed(input.taskStatusSnapshot.elapsedMs)}`
+            : undefined,
+        ].filter((value): value is string => Boolean(value)).join("; ")),
+        score: input.turnKind === "status_check" ? 114 : 84,
+        reason: "Latest run activity derived from deterministic run-event-backed task status.",
+      });
+    }
+
+    for (const subagent of input.taskStatusSnapshot.activeSubagents.slice(0, 2)) {
+      blocks.push({
+        id: `evidence:subagent:${subagent.id}`,
+        source: "delegated_task_block",
+        summary: normalizeText([
+          `subagent ${subagent.id}`,
+          subagent.label ? `label ${subagent.label}` : undefined,
+          `status ${subagent.status}`,
+          `task ${subagent.task}`,
+          subagent.childRunId ? `child run ${subagent.childRunId}` : undefined,
+        ].filter((value): value is string => Boolean(value)).join("; ")),
+        score: input.turnKind === "status_check" ? 112 : 82,
+        reason: "Active delegated subagent selected as deterministic status evidence.",
+      });
+    }
+
+    if (
+      input.taskStatusSnapshot.pendingPlanRunId
+      || input.taskStatusSnapshot.runStatus === "awaiting_clarification"
+      || input.taskStatusSnapshot.runStatus === "awaiting_plan_approval"
+    ) {
+      blocks.push({
+        id: "evidence:planning-gate",
+        source: "plan_block",
+        summary: normalizeText([
+          input.taskStatusSnapshot.pendingPlanRunId
+            ? `pending plan run ${input.taskStatusSnapshot.pendingPlanRunId}`
+            : undefined,
+          input.taskStatusSnapshot.runStatus
+            ? `planning state ${input.taskStatusSnapshot.runStatus}`
+            : undefined,
+          input.taskStatusSnapshot.blockers.length > 0
+            ? `blockers ${input.taskStatusSnapshot.blockers.join(" | ")}`
+            : undefined,
+        ].filter((value): value is string => Boolean(value)).join("; ")),
+        score: 118,
+        reason: "Planning gate state selected as deterministic evidence for approval/clarification follow-ups.",
+      });
+    }
+  }
+
+  return blocks
+    .filter((block) => block.summary.length > 0)
+    .sort((left, right) => right.score - left.score || left.id.localeCompare(right.id));
+}

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -89,6 +89,7 @@ import type {
   FridayAgentMessage,
   FridayAgentRunStatus,
 } from "#agent";
+import { buildFridayEvidenceBlocks } from "#agent";
 import { createFridayHealthRoutes } from "../http/routes/friday-health-routes.js";
 import { createFridayApiTokenRepository } from "../persistence/friday-api-token-repository.js";
 import type { FridayAuthPrincipal } from "../model/friday-api-common.types.js";
@@ -1640,7 +1641,7 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
           currentUserSequence = lastMatchingUserMessage?.sequence;
         }
 
-        const preparedTurn = prepareFridayConversationTurn({
+        let preparedTurn = prepareFridayConversationTurn({
           task,
           historyRecords: historyRecords.filter((message) =>
             !inboundIdempotencyKey || message.idempotencyKey !== inboundIdempotencyKey),
@@ -1648,6 +1649,36 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
           currentUserSequence,
           replyToMessageId: input.replyToMessageId,
         });
+
+        const evidenceBlocks = buildFridayEvidenceBlocks({
+          task,
+          turnKind: preparedTurn.turnKind,
+          focusState,
+          capabilitiesSnapshot: deps.capabilitySnapshotGetter
+            ? await Promise.resolve(deps.capabilitySnapshotGetter({
+                readOnly: input.constraints?.readOnly ?? false,
+              })).catch(() => undefined)
+            : undefined,
+          taskStatusSnapshot: deps.taskStatusSnapshotGetter
+            ? await Promise.resolve(deps.taskStatusSnapshotGetter({
+                runId: input.runId,
+                sessionKey: input.sessionKey,
+                readOnly: input.constraints?.readOnly ?? false,
+              })).catch(() => undefined)
+            : undefined,
+        });
+
+        if (evidenceBlocks.length > 0) {
+          preparedTurn = prepareFridayConversationTurn({
+            task,
+            historyRecords: historyRecords.filter((message) =>
+              !inboundIdempotencyKey || message.idempotencyKey !== inboundIdempotencyKey),
+            focusState,
+            currentUserSequence,
+            replyToMessageId: input.replyToMessageId,
+            evidenceBlocks,
+          });
+        }
         if (
           input.sessionKey
           && preparedTurn.turnKind !== "status_check"
@@ -1672,8 +1703,32 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
         };
         replyAnchorMessageId = preparedTurn.replyAnchorMessageId;
         replyAnchorSequence = preparedTurn.replyAnchorSequence;
+      } else if (deps.capabilitySnapshotGetter) {
+        const evidenceBlocks = buildFridayEvidenceBlocks({
+          task,
+          turnKind: "new_topic",
+          capabilitiesSnapshot: await Promise.resolve(deps.capabilitySnapshotGetter({
+            readOnly: input.constraints?.readOnly ?? false,
+          })).catch(() => undefined),
+        });
+        if (evidenceBlocks.length > 0) {
+          conversationContext = {
+            turnKind: "new_topic",
+            currentTopicSummary: task,
+            selectedBlocks: evidenceBlocks.map((block) => ({
+              id: block.id,
+              source: block.source,
+              summary: block.summary,
+              score: block.score,
+              reason: block.reason,
+            })),
+            selectionReasons: evidenceBlocks.map((block) => `${block.source} → ${block.reason}`),
+          };
+        }
+      }
 
-        if (agentPlanningGate) {
+      if (input.sessionKey && agentPlanningGate) {
+          const resolvedTurnKind = conversationContext?.turnKind ?? "new_topic";
           planningDecision = agentPlanningGate.handleTurn({
             runId: input.runId,
             task,
@@ -1703,11 +1758,11 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
                 task,
                 responseText: planningDecision.result.response,
                 runId: planningDecision.result.runId,
-                turnKind: conversationContext.turnKind ?? "new_topic",
+                turnKind: resolvedTurnKind,
                 focusState,
                 currentUserSequence,
-                replyAnchorMessageId: preparedTurn.replyAnchorMessageId,
-                replyAnchorSequence: preparedTurn.replyAnchorSequence,
+                replyAnchorMessageId,
+                replyAnchorSequence,
                 pendingPlanRunId: planningDecision.pendingPlanRunId ?? null,
                 nowIso: deps.nowIso(),
               }),
@@ -1737,11 +1792,11 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
                 task,
                 responseText: approved.response,
                 runId: approved.runId,
-                turnKind: conversationContext.turnKind ?? "new_topic",
+                turnKind: resolvedTurnKind,
                 focusState: await sessionService.getConversationFocus(input.sessionKey).catch(() => focusState),
                 currentUserSequence,
-                replyAnchorMessageId: preparedTurn.replyAnchorMessageId,
-                replyAnchorSequence: preparedTurn.replyAnchorSequence,
+                replyAnchorMessageId,
+                replyAnchorSequence,
                 pendingPlanRunId:
                   approved.status === "awaiting_clarification" || approved.status === "awaiting_plan_approval"
                     ? approved.runId
@@ -1771,18 +1826,17 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
                 task,
                 responseText: rejected.response,
                 runId: rejected.runId,
-                turnKind: conversationContext.turnKind ?? "new_topic",
+                turnKind: resolvedTurnKind,
                 focusState,
                 currentUserSequence,
-                replyAnchorMessageId: preparedTurn.replyAnchorMessageId,
-                replyAnchorSequence: preparedTurn.replyAnchorSequence,
+                replyAnchorMessageId,
+                replyAnchorSequence,
                 pendingPlanRunId: null,
                 nowIso: deps.nowIso(),
               }),
             ).catch(() => undefined);
             return rejected;
           }
-        }
       }
 
       if (!input.sessionKey && agentPlanningGate) {
@@ -1847,6 +1901,12 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
         const latestFocusState = await sessionService
           .getConversationFocus(input.sessionKey)
           .catch(() => focusState);
+        const nextPendingPlanRunId = result.status === "awaiting_clarification"
+          || result.status === "awaiting_plan_approval"
+          ? result.runId
+          : conversationContext.turnKind === "status_check"
+            ? undefined
+            : null;
         await sessionService.setConversationFocus(
           input.sessionKey,
           finalizeFridayConversationFocus({
@@ -1854,16 +1914,13 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
             responseText: result.response,
             runId: result.runId,
             turnKind: conversationContext.turnKind,
-            focusState: latestFocusState,
-            currentUserSequence,
-            replyAnchorMessageId,
-            replyAnchorSequence,
-            pendingPlanRunId:
-              result.status === "awaiting_clarification" || result.status === "awaiting_plan_approval"
-                ? result.runId
-                : null,
-            nowIso: deps.nowIso(),
-          }),
+                focusState: latestFocusState,
+                currentUserSequence,
+                replyAnchorMessageId,
+                replyAnchorSequence,
+                pendingPlanRunId: nextPendingPlanRunId,
+                nowIso: deps.nowIso(),
+              }),
         ).catch(() => undefined);
       }
 

--- a/src/api/runtime/friday-api-runtime.types.ts
+++ b/src/api/runtime/friday-api-runtime.types.ts
@@ -27,6 +27,8 @@ import type {
   FridayAgentRuntime,
   FridaySubagentRegistry,
 } from "#agent";
+import type { FridayAgentCapabilitiesSnapshot } from "#agent";
+import type { FridayAgentTaskStatusSnapshot } from "#agent";
 import type { FridayDeterministicPipelineRoutesDeps } from "../http/routes/friday-deterministic-pipeline-routes.js";
 import type { FridayDesktopRoutesDeps } from "../http/routes/friday-desktop-routes.js";
 import type { FridayDiscoveryRoutesDeps } from "../http/routes/friday-discovery-routes.js";
@@ -146,6 +148,12 @@ export interface CreateFridayApiRuntimeDeps {
   sessionService?: FridaySessionService;
   /** Optional: agent runtime for agent run endpoints. */
   agentRuntime?: FridayAgentRuntime;
+  /** Optional deterministic runtime capability getter used by context evidence selection. */
+  capabilitySnapshotGetter?: (input: { readOnly: boolean }) =>
+    Promise<FridayAgentCapabilitiesSnapshot> | FridayAgentCapabilitiesSnapshot;
+  /** Optional deterministic task status getter used by context evidence selection. */
+  taskStatusSnapshotGetter?: (input: { runId?: string; sessionKey?: string; readOnly: boolean }) =>
+    Promise<FridayAgentTaskStatusSnapshot> | FridayAgentTaskStatusSnapshot;
   /** Optional: agent event emitter for SSE streaming. */
   agentEventEmitter?: FridayAgentEventEmitter;
   /** Optional: sub-agent registry for sub-agent tree endpoints. */

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -98,6 +98,7 @@ import type { FridayConversationBlock } from "#sessions";
 import type { FridayMemoryFileSyncService, FridayMemoryService } from "#memory";
 import {
   buildFridayAgentSystemPrompt,
+  buildFridayEvidenceBlocks,
   createFridayAgentAgentsListTool,
   createFridayAgentArtifactWriter,
   createFridayAgentCronTool,
@@ -1324,7 +1325,10 @@ export async function createFridayHub(
     const focusState = input.sessionKey
       ? await hubSessionService.getConversationFocus(input.sessionKey).catch(() => null)
       : null;
-    const trackedRunId = focusState?.activeRunId ?? input.runId ?? focusState?.lastRunId;
+    const trackedRunId = focusState?.activeRunId
+      ?? input.runId
+      ?? focusState?.pendingPlanRunId
+      ?? focusState?.lastRunId;
     const trackedRun = trackedRunId
       ? stateRuntime!.sqlite.withReadConnection((reader) => agentRunRepo.getById(reader, trackedRunId))
       : null;
@@ -1372,7 +1376,13 @@ export async function createFridayHub(
       blockers.push(trackedRun.errorMessage);
     }
     if (focusState?.pendingPlanRunId) {
-      blockers.push(`Awaiting plan approval for run ${focusState.pendingPlanRunId}.`);
+      if (trackedRun?.status === "awaiting_clarification") {
+        blockers.push(`Awaiting clarification for run ${focusState.pendingPlanRunId}.`);
+      } else if (trackedRun?.status === "awaiting_plan_approval") {
+        blockers.push(`Awaiting plan approval for run ${focusState.pendingPlanRunId}.`);
+      } else {
+        blockers.push(`Pending planning gate for run ${focusState.pendingPlanRunId}.`);
+      }
     }
 
     const elapsedMs = trackedRun?.startedAt
@@ -2852,6 +2862,8 @@ export async function createFridayHub(
     supportedChannelKinds: [...FRIDAY_SUPPORTED_CHANNEL_KINDS],
     enabledChannelKinds,
     sessionService: hubSessionService,
+    capabilitySnapshotGetter: getAgentCapabilitySnapshot,
+    taskStatusSnapshotGetter: getAgentTaskStatusSnapshot,
     serverVersion: config.serverVersion ?? FRIDAY_HUB_DEFAULT_SERVER_VERSION,
     serverHost: config.host ?? "127.0.0.1",
     serverPort: config.port ?? 3141,
@@ -4082,14 +4094,38 @@ export async function createFridayHub(
 
               const preparedTurn = await hubSessionService
                 .getMessages(sessionKey, FRIDAY_CHANNEL_CONTEXT_HISTORY_LIMIT * 2)
-                .then((messages) =>
-                  prepareFridayConversationTurn({
+                .then(async (messages) => {
+                  const filteredMessages = messages.filter((message) => message.idempotencyKey !== inboundIdempotencyKey);
+                  let preparedTurn = prepareFridayConversationTurn({
                     task: text,
-                    historyRecords: messages.filter((message) => message.idempotencyKey !== inboundIdempotencyKey),
+                    historyRecords: filteredMessages,
                     focusState,
                     currentUserSequence: inboundMessage?.sequence,
                     replyToMessageId: msg.replyTo,
-                  }))
+                  });
+                  const evidenceBlocks = buildFridayEvidenceBlocks({
+                    task: text,
+                    turnKind: preparedTurn.turnKind,
+                    focusState,
+                    capabilitiesSnapshot: await getAgentCapabilitySnapshot({ readOnly: false }).catch(() => undefined),
+                    taskStatusSnapshot: await getAgentTaskStatusSnapshot({
+                      runId,
+                      sessionKey,
+                      readOnly: false,
+                    }).catch(() => undefined),
+                  });
+                  if (evidenceBlocks.length > 0) {
+                    preparedTurn = prepareFridayConversationTurn({
+                      task: text,
+                      historyRecords: filteredMessages,
+                      focusState,
+                      currentUserSequence: inboundMessage?.sequence,
+                      replyToMessageId: msg.replyTo,
+                      evidenceBlocks,
+                    });
+                  }
+                  return preparedTurn;
+                })
                 .catch((err) => {
                   logChannelIssue({
                     level: "warn",
@@ -4215,6 +4251,15 @@ export async function createFridayHub(
                 });
               }
 
+              const nextPendingPlanRunId = planningDecision.action === "return"
+                ? (planningDecision.pendingPlanRunId ?? null)
+                : (
+                  result.status === "awaiting_clarification" || result.status === "awaiting_plan_approval"
+                    ? result.runId
+                    : preparedTurn.turnKind === "status_check"
+                      ? undefined
+                      : null
+                );
               await hubSessionService.setConversationFocus(
                 sessionKey,
                 finalizeFridayConversationFocus({
@@ -4226,14 +4271,7 @@ export async function createFridayHub(
                   currentUserSequence: inboundMessage?.sequence,
                   replyAnchorMessageId: preparedTurn.replyAnchorMessageId,
                   replyAnchorSequence: preparedTurn.replyAnchorSequence,
-                  pendingPlanRunId:
-                    planningDecision.action === "return"
-                      ? (planningDecision.pendingPlanRunId ?? null)
-                      : (
-                        result.status === "awaiting_clarification" || result.status === "awaiting_plan_approval"
-                          ? result.runId
-                          : null
-                      ),
+                  pendingPlanRunId: nextPendingPlanRunId,
                   nowIso: nowIso(),
                 }),
               ).catch((err) => {

--- a/src/sessions/index.ts
+++ b/src/sessions/index.ts
@@ -34,6 +34,7 @@ export type {
   FridayConversationTurnKind,
   FridayConversationBlockSource,
   FridayConversationBlock,
+  FridayEvidenceBlock,
   FridayConversationHistoryBlockKind,
   FridayConversationHistoryBlockSummary,
   FridayContextSelectionResult,

--- a/src/sessions/model/friday-session.types.ts
+++ b/src/sessions/model/friday-session.types.ts
@@ -16,6 +16,8 @@ export type FridayConversationBlockSource =
   | "active_run"
   | "pending_plan"
   | "status_anchor"
+  | "capabilities_block"
+  | "run_event_block"
   | "topic_block"
   | "plan_block"
   | "task_status_block"
@@ -54,6 +56,14 @@ export interface FridayConversationBlock {
   messageIds?: string[];
   sequenceStart?: number;
   sequenceEnd?: number;
+}
+
+export interface FridayEvidenceBlock {
+  id: string;
+  source: FridayConversationBlockSource;
+  summary: string;
+  score: number;
+  reason: string;
 }
 
 export interface FridayContextSelectionResult {

--- a/src/sessions/services/friday-session-conversation-orchestrator.ts
+++ b/src/sessions/services/friday-session-conversation-orchestrator.ts
@@ -8,6 +8,7 @@ import type {
   FridayConversationHistoryBlockKind,
   FridayConversationHistoryBlockSummary,
   FridayConversationTurnKind,
+  FridayEvidenceBlock,
   FridaySessionConversationFocusState,
   FridaySessionMessageRecord,
 } from "../model/friday-session.types.js";
@@ -25,7 +26,7 @@ const DEICTIC_FOLLOW_UP_HINTS = /\b(this one|that one|same one|same issue|that i
 const ADVISORY_CONTINUATION_HINTS = /\b(prefer|preference|recommend|recommendation|recommendations|should i|best)\b/i;
 const STATUS_CHECK_HINTS =
   /\b(status update|check status|current status|what(?:'s| is) (?:the )?status|progress|still working|still running|still executing|what are you doing|what's happening|how long|eta|done yet|finished yet)\b/i;
-const CHINESE_STATUS_CHECK_HINTS = /(状态|进度|还在|多久|完成了吗|现在在做什么|刚才那个任务|还没好|ETA)/;
+const CHINESE_STATUS_CHECK_HINTS = /(状态|进度|还在|多久|完成了吗|现在在做什么|刚才那个任务|那个任务结果呢|结果呢|还没好|ETA)/;
 const CONTINUE_HINTS =
   /\b(continue|go ahead|proceed|keep going|do it|start it|carry on)\b/i;
 const CHINESE_CONTINUE_HINTS = /(继续|开始吧|继续做|接着做|往下做|执行吧)/;
@@ -106,6 +107,7 @@ export interface PrepareFridayConversationTurnInput {
   focusState?: FridaySessionConversationFocusState | null;
   currentUserSequence?: number;
   replyToMessageId?: string;
+  evidenceBlocks?: FridayEvidenceBlock[];
 }
 
 export interface FinalizeFridayConversationFocusInput {
@@ -134,6 +136,22 @@ interface FridayConversationHistoryBlockCandidate {
   reason: string;
   messages: FridayAgentMessage[];
   taskOverlap: number;
+}
+
+function createEvidenceBlockCandidate(
+  block: FridayEvidenceBlock,
+): FridayConversationBlockCandidate {
+  return {
+    block: {
+      id: block.id,
+      source: block.source,
+      summary: summarizeTopic(block.summary),
+      score: block.score,
+      reason: block.reason,
+    },
+    messages: [],
+    fallbackOnly: false,
+  };
 }
 
 function normalizeText(text: string): string {
@@ -605,6 +623,7 @@ function buildConversationBlockSelection(input: {
   focusState?: FridaySessionConversationFocusState | null;
   turnKind: FridayConversationTurnKind;
   replyToMessageId?: string;
+  evidenceBlocks?: FridayEvidenceBlock[];
 }): FridayContextSelectionResult & { historyMessages: FridayAgentMessage[]; replyAnchorMessageId?: string; replyAnchorSequence?: number } {
   const taskTokens = tokenize(input.task);
   const taskLower = normalizeText(input.task).toLowerCase();
@@ -801,6 +820,10 @@ function buildConversationBlockSelection(input: {
       },
       messages: [],
     });
+  }
+
+  for (const evidenceBlock of input.evidenceBlocks ?? []) {
+    registerCandidate(createEvidenceBlockCandidate(evidenceBlock));
   }
 
   const historyBlockCandidates: FridayConversationHistoryBlockCandidate[] = [];
@@ -1119,6 +1142,7 @@ export function prepareFridayConversationTurn(
     focusState,
     turnKind,
     replyToMessageId: input.replyToMessageId,
+    evidenceBlocks: input.evidenceBlocks,
   });
   const currentTopicSummary = turnKind === "new_topic"
     ? summarizeTopic(input.task)

--- a/test/unit/agent/runtime/friday-agent-answer-alignment.test.ts
+++ b/test/unit/agent/runtime/friday-agent-answer-alignment.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { evaluateFridayAnswerAlignment } from "../../../../src/agent/runtime/friday-agent-answer-alignment.js";
+
+describe("evaluateFridayAnswerAlignment", () => {
+  it("requests a retry when the response contradicts deterministic capability facts", () => {
+    const decision = evaluateFridayAnswerAlignment({
+      task: "discord enabled? mcp enabled? is provider mutation blocked by readOnly?",
+      responseText:
+        "Discord is enabled, MCP is not enabled, and provider mutation is not blocked by readOnly.",
+      historyMessages: [],
+      conversationContext: {
+        previousTopicSummary: "",
+        selectedBlocks: [
+          {
+            source: "capabilities_block",
+            summary:
+              "messaging enabled (discord); MCP disabled; provider mutations blocked by readOnly; browser headless (Playwright Chromium); system enabled; desktop disconnected; desktop companion connected",
+            score: 120,
+          },
+        ],
+      },
+    });
+
+    expect(decision.retryPrompt).toContain("contradicted deterministic runtime capability facts");
+  });
+
+  it("does not request a retry when the response matches deterministic capability facts", () => {
+    const decision = evaluateFridayAnswerAlignment({
+      task: "discord enabled? mcp enabled? is provider mutation blocked by readOnly?",
+      responseText:
+        "Discord is enabled, MCP is not enabled, and provider mutation is blocked by readOnly.",
+      historyMessages: [],
+      conversationContext: {
+        previousTopicSummary: "",
+        selectedBlocks: [
+          {
+            source: "capabilities_block",
+            summary:
+              "messaging enabled (discord); MCP disabled; provider mutations blocked by readOnly; browser headless (Playwright Chromium); system enabled; desktop disconnected; desktop companion connected",
+            score: 120,
+          },
+        ],
+      },
+    });
+
+    expect(decision.retryPrompt).toBeUndefined();
+  });
+});

--- a/test/unit/agent/runtime/friday-agent-evidence-blocks.test.ts
+++ b/test/unit/agent/runtime/friday-agent-evidence-blocks.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+
+import { buildFridayEvidenceBlocks } from "#agent";
+import type {
+  FridayAgentCapabilitiesSnapshot,
+  FridayAgentTaskStatusSnapshot,
+} from "#agent";
+import type { FridaySessionConversationFocusState } from "#sessions";
+
+describe("friday-agent-evidence-blocks", () => {
+  const focusState: FridaySessionConversationFocusState = {
+    currentTopicSummary: "Investigate why the GitHub browser task failed.",
+    currentTopicFingerprint: "topic-1",
+    currentTopicStartSequence: 1,
+    lastAnsweredQuestion: "What happened to the GitHub task?",
+    lastAssistantAskedQuestion: false,
+    lastRunId: "run-1",
+    activeRunId: "run-2",
+    activeSubagentIds: ["sub-1"],
+    pendingPlanRunId: "plan-1",
+    updatedAt: "2026-03-17T10:00:00.000Z",
+  };
+
+  const capabilitiesSnapshot: FridayAgentCapabilitiesSnapshot = {
+    readOnly: true,
+    messaging: {
+      enabled: true,
+      kinds: ["discord"],
+    },
+    mcp: {
+      enabled: false,
+      serverCount: 0,
+    },
+    provider: {
+      available: true,
+      configuredCount: 2,
+      mutationBlockedByReadOnly: true,
+    },
+    browser: {
+      activeMode: "headless",
+      targetBrowser: "Google Chrome",
+    },
+    system: {
+      enabled: true,
+    },
+    desktop: {
+      connected: false,
+    },
+    companion: {
+      connected: true,
+    },
+  };
+
+  const taskStatusSnapshot: FridayAgentTaskStatusSnapshot = {
+    readOnly: true,
+    sessionKey: "webchat:default:test",
+    trackedRunId: "run-2",
+    task: "Open GitHub and inspect the current page.",
+    runStatus: "awaiting_plan_approval",
+    phase: "planning",
+    elapsedMs: 45_000,
+    latestTool: "browser",
+    activeSubagents: [
+      {
+        id: "sub-1",
+        childRunId: "child-run-1",
+        childSessionKey: "subagent:child-1",
+        status: "running",
+        task: "Open GitHub in the browser.",
+        createdAt: "2026-03-17T10:00:00.000Z",
+      },
+    ],
+    blockers: ["Awaiting plan approval for run plan-1."],
+    pendingPlanRunId: "plan-1",
+  };
+
+  it("builds deterministic capability evidence for deployment fact questions", () => {
+    const blocks = buildFridayEvidenceBlocks({
+      task: "discord enabled? mcp enabled? and is provider mutation blocked by readOnly?",
+      turnKind: "new_topic",
+      capabilitiesSnapshot,
+    });
+
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]?.source).toBe("capabilities_block");
+    expect(blocks[0]?.summary).toContain("messaging enabled (discord)");
+    expect(blocks[0]?.summary).toContain("MCP disabled");
+    expect(blocks[0]?.summary).toContain("provider mutations blocked by readOnly");
+    expect(blocks[0]?.summary).toContain("desktop disconnected");
+  });
+
+  it("builds status, planning, run-activity, and delegated-task evidence for status questions", () => {
+    const blocks = buildFridayEvidenceBlocks({
+      task: "What are you doing right now and what is the latest task result?",
+      turnKind: "status_check",
+      focusState,
+      taskStatusSnapshot,
+      capabilitiesSnapshot,
+    });
+
+    expect(blocks.some((block) => block.source === "task_status_block")).toBe(true);
+    expect(blocks.some((block) => block.source === "run_event_block")).toBe(true);
+    expect(blocks.some((block) => block.source === "delegated_task_block")).toBe(true);
+    expect(blocks.some((block) => block.source === "plan_block")).toBe(true);
+    expect(blocks.find((block) => block.source === "task_status_block")?.summary)
+      .toContain("status awaiting_plan_approval");
+    expect(blocks.find((block) => block.source === "run_event_block")?.summary)
+      .toContain("latest tool browser");
+    expect(blocks.find((block) => block.source === "delegated_task_block")?.summary)
+      .toContain("subagent sub-1");
+    expect(blocks.find((block) => block.source === "plan_block")?.summary)
+      .toContain("pending plan run plan-1");
+  });
+
+  it("uses pending plan context instead of saying there is no tracked run", () => {
+    const blocks = buildFridayEvidenceBlocks({
+      task: "那个任务结果呢？",
+      turnKind: "status_check",
+      focusState: {
+        ...focusState,
+        activeRunId: undefined,
+        lastRunId: undefined,
+        pendingPlanRunId: "plan-2",
+      },
+      taskStatusSnapshot: {
+        readOnly: false,
+        sessionKey: "webchat:default:test",
+        runStatus: "awaiting_clarification",
+        blockers: ["Awaiting clarification for run plan-2."],
+        pendingPlanRunId: "plan-2",
+        activeSubagents: [],
+      },
+    });
+
+    const taskStatus = blocks.find((block) => block.source === "task_status_block");
+    expect(taskStatus?.summary).toContain("pending plan plan-2");
+    expect(taskStatus?.summary).toContain("status awaiting_clarification");
+    expect(taskStatus?.summary).not.toContain("no tracked run");
+
+    const planning = blocks.find((block) => block.source === "plan_block");
+    expect(planning?.summary).toContain("pending plan run plan-2");
+    expect(planning?.summary).toContain("planning state awaiting_clarification");
+  });
+});

--- a/test/unit/sessions/services/friday-session-conversation-orchestrator.test.ts
+++ b/test/unit/sessions/services/friday-session-conversation-orchestrator.test.ts
@@ -6,6 +6,7 @@ import {
   prepareFridayConversationTurn,
 } from "#sessions";
 import type {
+  FridayEvidenceBlock,
   FridaySessionConversationFocusState,
   FridaySessionMessageRecord,
 } from "#sessions";
@@ -210,6 +211,60 @@ describe("friday-session-conversation-orchestrator", () => {
     expect(prepared.historyMessages).toHaveLength(2);
     expect(prepared.taskPrompt).toContain("asking for a status update");
     expect(prepared.taskPrompt).toContain("Use the task_status tool before answering.");
+  });
+
+  it("treats Chinese result follow-ups as status_check", () => {
+    const prepared = prepareFridayConversationTurn({
+      task: "那个任务结果呢？",
+      focusState: {
+        ...baseFocusState,
+        pendingPlanRunId: "run-plan-1",
+      },
+      currentUserSequence: 5,
+      historyRecords: [
+        makeMessage({ sequence: 1, role: "user", contentText: "create a new workflow that watches release blockers and posts a summary to Slack every weekday morning" }),
+        makeMessage({ sequence: 2, role: "assistant", contentText: "Before I execute this major decision, I need one detail to make sure the direction is correct." }),
+      ],
+    });
+
+    expect(prepared.turnKind).toBe("status_check");
+    expect(prepared.taskPrompt).toContain("asking for a status update");
+    expect(prepared.taskPrompt).toContain("Pending plan run: run-plan-1");
+  });
+
+  it("selects deterministic evidence blocks for status questions", () => {
+    const evidenceBlocks: FridayEvidenceBlock[] = [
+      {
+        id: "evidence:task-status",
+        source: "task_status_block",
+        summary: "run run-2; status running; phase executing; latest tool browser",
+        score: 125,
+        reason: "Deterministic task status snapshot selected for a status/progress/result question.",
+      },
+      {
+        id: "evidence:run-activity",
+        source: "run_event_block",
+        summary: "latest phase executing; latest tool browser; elapsed 12s",
+        score: 114,
+        reason: "Latest run activity derived from deterministic run-event-backed task status.",
+      },
+    ];
+
+    const prepared = prepareFridayConversationTurn({
+      task: "你现在在做什么？",
+      focusState: baseFocusState,
+      currentUserSequence: 3,
+      historyRecords: [
+        makeMessage({ sequence: 1, role: "user", contentText: "Open Facebook and sign up." }),
+        makeMessage({ sequence: 2, role: "assistant", contentText: "I delegated the task to a browser worker." }),
+      ],
+      evidenceBlocks,
+    });
+
+    expect(prepared.turnKind).toBe("status_check");
+    expect(prepared.selectedBlocks.some((block) => block.source === "task_status_block")).toBe(true);
+    expect(prepared.selectedBlocks.some((block) => block.source === "run_event_block")).toBe(true);
+    expect(prepared.taskPrompt).toContain("[task_status_block] run run-2; status running; phase executing; latest tool browser");
   });
 
   it("does not treat workflow requirements containing release status as a status check", () => {


### PR DESCRIPTION
## Summary
- add deterministic evidence blocks for capabilities, task status, planning state, and delegated subagents
- feed evidence blocks into API and hub conversation selection so status/capability follow-ups reuse the same context selector
- harden answer alignment against contradictions with deterministic capability facts and add phase 4 regression coverage

## Testing
- npm run typecheck
- npm run lint
- npx vitest run test/unit/sessions/services/friday-session-conversation-orchestrator.test.ts test/unit/agent/runtime/friday-agent-answer-alignment.test.ts test/unit/agent/runtime/friday-agent-evidence-blocks.test.ts test/unit/agent/runtime/friday-agent-runtime.test.ts test/unit/api/runtime/friday-api-runtime-planning-gate.test.ts
- real-model smoke on launchd Friday for capabilities, planning status/result follow-up, and why-failed follow-up
