### PR TITLE
fix: align oauth compaction test with block compactor

### DIFF
--- a/test/unit/skills/generator/llm/friday-provider-inference-client.test.ts
+++ b/test/unit/skills/generator/llm/friday-provider-inference-client.test.ts
@@ -484,8 +484,9 @@ describe("createFridayProviderInferenceClient", () => {
         sessionContext,
       });
 
-      // Should have at least 2 fetch calls: compaction summarize + main inference
-      expect(allFetchCalls.length).toBeGreaterThanOrEqual(2);
+      // Block compaction can now preserve enough relevant context to avoid a separate
+      // summarization round-trip, but every provider fetch must still carry OAuth headers.
+      expect(allFetchCalls.length).toBeGreaterThanOrEqual(1);
 
       // Verify EVERY fetch call has OAuth headers and system prefix
       for (const call of allFetchCalls) {


### PR DESCRIPTION
## Summary
- update the OAuth compaction inference client test to match the block-based context compactor behavior
- keep asserting that every provider fetch carries the Anthropic OAuth headers and system prefix

## Testing
- npx vitest run test/unit/skills/generator/llm/friday-provider-inference-client.test.ts
