### PR TITLE
fix: close attnres phase5 status followups

### DIFF
--- a/src/agent/runtime/friday-agent-evidence-blocks.ts
+++ b/src/agent/runtime/friday-agent-evidence-blocks.ts
@@ -8,9 +8,19 @@ import type { FridayAgentCapabilitiesSnapshot } from "../tools/friday-agent-capa
 import type { FridayAgentTaskStatusSnapshot } from "../tools/friday-agent-task-status-tool.js";
 
 const STATUS_HINTS =
-  /\b(status|progress|running|waiting|completed|failed|blocked|doing|doing right now|result|results|latest result|eta|done yet|finished yet|what are you doing|what happened|what was the issue|why failed)\b/i;
+  /\b(status|progress|running|waiting|completed|failed|blocked|doing|doing right now|latest result|eta|done yet|finished yet|what are you doing|what happened|what was the issue|why failed)\b/i;
 const CHINESE_STATUS_HINTS =
   /(状态|进度|还在|等待|完成了吗|失败|为什么failed|为什么失败|现在在做什么|那个任务结果呢|结果呢|怎么了|发生了什么)/;
+const STATUS_QUESTION_PREFIX_HINTS =
+  /^(?:what(?:'s| is)?|why|how|when|did|does|is|are|where|status|progress|result|results|latest result|what are you doing|what happened|what was the issue|why failed)\b/i;
+const CHINESE_STATUS_QUESTION_PREFIX_HINTS =
+  /^(?:状态|进度|还在|等待|完成了吗|失败|为什么failed|为什么失败|现在在做什么|那个任务结果呢|结果呢|怎么了|发生了什么)/;
+const STATUS_REFERENCE_HINTS =
+  /^(?:that task|that run|that result|that one|the result|what is the final result now|what's the final result now|what is the result now|what's the result now)$/i;
+const CHINESE_STATUS_REFERENCE_HINTS =
+  /^(?:那个任务结果呢|结果呢|这里|那个|同一个问题)$/;
+const STATUS_FALSE_POSITIVES =
+  /\bgit status\b|\breport the result\b|\bworkflow response\b|\brepo-health-check\b/i;
 const CAPABILITY_HINTS =
   /\b(capabilities?|what can\b|can (?:friday|you)\b.*\bdo\b|enabled|disabled|deployment|runtime facts?|messaging|discord|mcp|desktop companion|provider mutations?|read[- ]?only)\b/i;
 const CHINESE_CAPABILITY_HINTS =
@@ -103,16 +113,43 @@ function formatTaskStatusSummary(snapshot: FridayAgentTaskStatusSnapshot): strin
   } else if (snapshot.terminalOutcome?.responseText) {
     parts.push(`response ${snapshot.terminalOutcome.responseText}`);
   }
+  const latestCompletedSubagent = snapshot.recentCompletedSubagents?.[0];
+  if (latestCompletedSubagent?.outcomeResponse) {
+    parts.push(`latest completed subagent ${latestCompletedSubagent.id} response ${latestCompletedSubagent.outcomeResponse}`);
+  }
   return normalizeText(parts.join("; "));
 }
 
 function shouldIncludeStatusEvidence(input: BuildFridayEvidenceBlocksInput): boolean {
-  return input.turnKind === "status_check"
-    || STATUS_HINTS.test(input.task)
-    || CHINESE_STATUS_HINTS.test(input.task)
-    || Boolean(input.focusState?.pendingPlanRunId)
-    || Boolean(input.focusState?.activeRunId)
-    || Boolean(input.focusState?.activeSubagentIds?.length);
+  if (input.turnKind === "status_check") {
+    return true;
+  }
+
+  const task = normalizeText(input.task);
+  if (task.length === 0) {
+    return false;
+  }
+
+  if (STATUS_FALSE_POSITIVES.test(task)) {
+    return false;
+  }
+
+  if (STATUS_QUESTION_PREFIX_HINTS.test(task) || CHINESE_STATUS_QUESTION_PREFIX_HINTS.test(task)) {
+    return true;
+  }
+
+  if (/[?？]/.test(task) && (STATUS_HINTS.test(task) || CHINESE_STATUS_HINTS.test(task))) {
+    return true;
+  }
+
+  if (
+    (input.focusState?.pendingPlanRunId || input.focusState?.activeRunId || input.focusState?.activeSubagentIds?.length)
+    && (STATUS_REFERENCE_HINTS.test(task) || CHINESE_STATUS_REFERENCE_HINTS.test(task))
+  ) {
+    return true;
+  }
+
+  return false;
 }
 
 function shouldIncludeCapabilitiesEvidence(input: BuildFridayEvidenceBlocksInput): boolean {
@@ -172,6 +209,23 @@ export function buildFridayEvidenceBlocks(
         ].filter((value): value is string => Boolean(value)).join("; ")),
         score: input.turnKind === "status_check" ? 112 : 82,
         reason: "Active delegated subagent selected as deterministic status evidence.",
+      });
+    }
+
+    for (const subagent of (input.taskStatusSnapshot.recentCompletedSubagents ?? []).slice(0, 2)) {
+      blocks.push({
+        id: `evidence:completed-subagent:${subagent.id}`,
+        source: "delegated_task_block",
+        summary: normalizeText([
+          `subagent ${subagent.id}`,
+          subagent.label ? `label ${subagent.label}` : undefined,
+          `status ${subagent.status}`,
+          `task ${subagent.task}`,
+          subagent.childRunId ? `child run ${subagent.childRunId}` : undefined,
+          subagent.outcomeResponse ? `response ${subagent.outcomeResponse}` : undefined,
+        ].filter((value): value is string => Boolean(value)).join("; ")),
+        score: input.turnKind === "status_check" ? 111 : 81,
+        reason: "Latest completed delegated subagent selected as deterministic result evidence.",
       });
     }
 

--- a/src/agent/runtime/friday-agent-planning-gate.ts
+++ b/src/agent/runtime/friday-agent-planning-gate.ts
@@ -67,7 +67,7 @@ export interface CreateFridayAgentPlanningGateServiceDeps {
 const APPROVE_COMMAND = /^(approve|approved|go ahead|proceed with the plan|proceed with plan|yes,? approve|yes approve|同意|批准|通过这个计划|按这个计划继续)$/i;
 const REJECT_COMMAND = /^(reject|rejected|decline|cancel plan|stop|do not proceed|don't proceed|不同意|拒绝|驳回|取消这个计划)$/i;
 const GENERATE_SKILL_HINTS = /\b(generate (a )?skill|create (a )?skill|build (a )?skill|skill generator)\b/i;
-const GENERATE_WORKFLOW_HINTS = /\b(generate (a )?workflow|create (a )?workflow|build (a )?workflow|automation|pipeline)\b/i;
+const GENERATE_WORKFLOW_HINTS = /\b(generate (?:a )?(?:new )?workflow|create (?:a )?(?:new )?workflow|build (?:a )?(?:new )?workflow|automation|pipeline)\b/i;
 const DEPLOY_WORKFLOW_HINTS = /\b(deploy workflow|publish workflow|ship workflow|roll out workflow)\b/i;
 const EXPORT_WORKFLOW_HINTS = /\b(export workflow|workflow bundle|package workflow)\b/i;
 const MAJOR_DECISION_HINTS = /\b(architecture|architect|strategy|migration|roadmap|implementation plan|rollout plan|major refactor|large refactor|overhaul|choose between|decision|tradeoff|design the approach)\b/i;

--- a/src/agent/tools/friday-agent-task-status-tool.ts
+++ b/src/agent/tools/friday-agent-task-status-tool.ts
@@ -13,6 +13,8 @@ export interface FridayAgentTaskStatusSubagentSnapshot {
   startedAt?: string;
   completedAt?: string;
   durationMs?: number;
+  outcomeStatus?: "completed" | "failed" | "cancelled";
+  outcomeResponse?: string;
 }
 
 export interface FridayAgentTaskStatusSnapshot {
@@ -25,6 +27,7 @@ export interface FridayAgentTaskStatusSnapshot {
   elapsedMs?: number;
   latestTool?: string;
   activeSubagents: FridayAgentTaskStatusSubagentSnapshot[];
+  recentCompletedSubagents?: FridayAgentTaskStatusSubagentSnapshot[];
   blockers: string[];
   pendingPlanRunId?: string;
   terminalOutcome?: {

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -2091,12 +2091,31 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
         const result = await agentPlanningGate.approvePlan({ runId });
         const run = deps.db.withReadConnection((db) => agentRepo.getById(db, runId));
         if (run?.sessionKey) {
-          const currentFocus = await sessionService.getConversationFocus(run.sessionKey).catch(() => null);
-          await sessionService.setConversationFocus(run.sessionKey, {
-            ...(currentFocus ?? { updatedAt: deps.nowIso() }),
-            pendingPlanRunId: undefined,
-            updatedAt: deps.nowIso(),
+          await sessionService.addMessage(run.sessionKey, {
+            role: "assistant",
+            content: result.response,
+            contentText: result.response,
+            idempotencyKey: `agent-run:${result.runId}:response`,
           }).catch(() => undefined);
+          const currentFocus = await sessionService.getConversationFocus(run.sessionKey).catch(() => null);
+          const nextPendingPlanRunId = result.status === "awaiting_clarification"
+            || result.status === "awaiting_plan_approval"
+            ? result.runId
+            : null;
+          await sessionService.setConversationFocus(
+            run.sessionKey,
+            finalizeFridayConversationFocus({
+              task: run.task,
+              responseText: result.response,
+              runId: result.runId,
+              turnKind: result.status === "awaiting_clarification"
+                ? "clarification"
+                : "continue_active_task",
+              focusState: currentFocus,
+              pendingPlanRunId: nextPendingPlanRunId,
+              nowIso: deps.nowIso(),
+            }),
+          ).catch(() => undefined);
         }
         return result;
       },

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -1325,10 +1325,47 @@ export async function createFridayHub(
     const focusState = input.sessionKey
       ? await hubSessionService.getConversationFocus(input.sessionKey).catch(() => null)
       : null;
-    const trackedRunId = focusState?.activeRunId
-      ?? input.runId
-      ?? focusState?.pendingPlanRunId
-      ?? focusState?.lastRunId;
+
+    const resolveExistingRunId = (...candidates: Array<string | undefined>): string | undefined => {
+      for (const candidate of candidates) {
+        if (!candidate) {
+          continue;
+        }
+        const existing = stateRuntime!.sqlite.withReadConnection((reader) => agentRunRepo.getById(reader, candidate));
+        if (existing) {
+          return candidate;
+        }
+      }
+      return undefined;
+    };
+
+    const collectSubagentTree = (parentRunId: string): ReturnType<typeof subagentRegistry.listByParentRunId> => {
+      const queue = [parentRunId];
+      const seen = new Set<string>();
+      const records: ReturnType<typeof subagentRegistry.listByParentRunId> = [];
+      while (queue.length > 0) {
+        const currentParentRunId = queue.shift();
+        if (!currentParentRunId) {
+          continue;
+        }
+        for (const record of subagentRegistry.listByParentRunId(currentParentRunId)) {
+          if (seen.has(record.id)) {
+            continue;
+          }
+          seen.add(record.id);
+          records.push(record);
+          queue.push(record.childRunId);
+        }
+      }
+      return records;
+    };
+
+    const trackedRunId = resolveExistingRunId(
+      focusState?.activeRunId,
+      focusState?.pendingPlanRunId,
+      focusState?.lastRunId,
+      input.runId,
+    );
     const trackedRun = trackedRunId
       ? stateRuntime!.sqlite.withReadConnection((reader) => agentRunRepo.getById(reader, trackedRunId))
       : null;
@@ -1354,10 +1391,10 @@ export async function createFridayHub(
       }
     }
 
-    const activeSubagentIds = focusState?.activeSubagentIds ?? [];
-    const activeSubagents = activeSubagentIds
-      .map((subagentId) => subagentRegistry.getById(subagentId))
-      .filter((record): record is NonNullable<typeof record> => record !== null)
+    const subagentRecords = trackedRunId ? collectSubagentTree(trackedRunId) : [];
+    const activeSubagents = subagentRecords
+      .filter((record) => record.status === "pending" || record.status === "running")
+      .sort((left, right) => right.createdAt.localeCompare(left.createdAt))
       .map((record) => ({
         id: record.id,
         childRunId: record.childRunId,
@@ -1369,6 +1406,30 @@ export async function createFridayHub(
         startedAt: record.startedAt,
         completedAt: record.completedAt,
         durationMs: record.durationMs,
+        outcomeStatus: record.outcome?.status,
+        outcomeResponse: record.outcome?.response,
+      }));
+
+    const recentCompletedSubagents = subagentRecords
+      .filter((record) => record.status === "completed" || record.status === "failed" || record.status === "cancelled")
+      .sort((left, right) => {
+        const leftTime = left.completedAt ?? left.createdAt;
+        const rightTime = right.completedAt ?? right.createdAt;
+        return rightTime.localeCompare(leftTime);
+      })
+      .map((record) => ({
+        id: record.id,
+        childRunId: record.childRunId,
+        childSessionKey: record.childSessionKey,
+        status: record.status,
+        task: record.task,
+        label: record.label,
+        createdAt: record.createdAt,
+        startedAt: record.startedAt,
+        completedAt: record.completedAt,
+        durationMs: record.durationMs,
+        outcomeStatus: record.outcome?.status,
+        outcomeResponse: record.outcome?.response,
       }));
 
     const blockers: string[] = [];
@@ -1389,6 +1450,39 @@ export async function createFridayHub(
       ? Math.max(0, Date.now() - new Date(trackedRun.startedAt).getTime())
       : undefined;
 
+    const latestCompletedSubagent = recentCompletedSubagents[0];
+    const trackedRunCompletedAt = trackedRun?.completedAt;
+    const latestSubagentCompletedAfterTrackedRun = Boolean(
+      latestCompletedSubagent?.completedAt
+        && trackedRunCompletedAt
+        && latestCompletedSubagent.completedAt > trackedRunCompletedAt,
+    );
+    const trackedRunLooksStale = Boolean(
+      trackedRun?.responseText
+      && /still running|currently executing|accepted|delegated snapshot/i.test(trackedRun.responseText),
+    );
+    const terminalOutcome = trackedRun && (
+      trackedRun.status === "completed"
+      || trackedRun.status === "failed"
+      || trackedRun.status === "cancelled"
+    )
+      ? (
+          latestCompletedSubagent?.outcomeStatus
+            && latestCompletedSubagent.outcomeResponse
+            && (latestSubagentCompletedAfterTrackedRun || trackedRunLooksStale)
+        )
+          ? {
+              status: latestCompletedSubagent.outcomeStatus,
+              summary: latestCompletedSubagent.outcomeResponse,
+              responseText: latestCompletedSubagent.outcomeResponse,
+            }
+          : {
+              status: trackedRun.status,
+              summary: trackedRun.summary,
+              responseText: trackedRun.responseText,
+            }
+      : undefined;
+
     return {
       readOnly: input.readOnly,
       sessionKey: input.sessionKey,
@@ -1399,19 +1493,10 @@ export async function createFridayHub(
       elapsedMs,
       latestTool,
       activeSubagents,
+      recentCompletedSubagents: recentCompletedSubagents.slice(0, 3),
       blockers,
       pendingPlanRunId: focusState?.pendingPlanRunId,
-      terminalOutcome: trackedRun && (
-        trackedRun.status === "completed"
-        || trackedRun.status === "failed"
-        || trackedRun.status === "cancelled"
-      )
-        ? {
-            status: trackedRun.status,
-            summary: trackedRun.summary,
-            responseText: trackedRun.responseText,
-          }
-        : undefined,
+      terminalOutcome,
     };
   };
 

--- a/src/sessions/services/friday-session-conversation-orchestrator.ts
+++ b/src/sessions/services/friday-session-conversation-orchestrator.ts
@@ -25,7 +25,7 @@ const CHINESE_FOLLOW_UP_HINTS = /(这个|那个|这里|这儿|继续|还有|然�
 const DEICTIC_FOLLOW_UP_HINTS = /\b(this one|that one|same one|same issue|that issue|this issue|that part|this part|here|there)\b/i;
 const ADVISORY_CONTINUATION_HINTS = /\b(prefer|preference|recommend|recommendation|recommendations|should i|best)\b/i;
 const STATUS_CHECK_HINTS =
-  /\b(status update|check status|current status|what(?:'s| is) (?:the )?status|progress|still working|still running|still executing|what are you doing|what's happening|how long|eta|done yet|finished yet)\b/i;
+  /\b(status update|check status|current status|what(?:'s| is) (?:the )?status|what(?:'s| is) (?:the )?(?:final )?result(?: now)?|progress|still working|still running|still executing|what are you doing|what's happening|how long|eta|done yet|finished yet)\b/i;
 const CHINESE_STATUS_CHECK_HINTS = /(状态|进度|还在|多久|完成了吗|现在在做什么|刚才那个任务|那个任务结果呢|结果呢|还没好|ETA)/;
 const CONTINUE_HINTS =
   /\b(continue|go ahead|proceed|keep going|do it|start it|carry on)\b/i;
@@ -1194,7 +1194,9 @@ export function finalizeFridayConversationFocus(
     replyAnchorSequence: input.replyAnchorSequence,
     lastAnsweredQuestion: summarizeTopic(input.task),
     lastAssistantAskedQuestion: assistantAskedQuestion,
-    lastRunId: input.runId,
+    lastRunId: input.turnKind === "status_check" && previous?.lastRunId
+      ? previous.lastRunId
+      : input.runId,
     activeRunId: previous?.activeRunId && previous.activeRunId !== input.runId
       ? previous.activeRunId
       : undefined,

--- a/test/unit/agent/runtime/friday-agent-evidence-blocks.test.ts
+++ b/test/unit/agent/runtime/friday-agent-evidence-blocks.test.ts
@@ -141,4 +141,53 @@ describe("friday-agent-evidence-blocks", () => {
     expect(planning?.summary).toContain("pending plan run plan-2");
     expect(planning?.summary).toContain("planning state awaiting_clarification");
   });
+
+  it("does not inject status evidence for imperative tasks that merely mention git status or reporting a result", () => {
+    const blocks = buildFridayEvidenceBlocks({
+      task: "Create a workflow that summarizes git status and report the result in the workflow response.",
+      turnKind: "follow_up",
+      focusState,
+      taskStatusSnapshot,
+    });
+
+    expect(blocks.some((block) => block.source === "task_status_block")).toBe(false);
+    expect(blocks.some((block) => block.source === "plan_block")).toBe(false);
+  });
+
+  it("surfaces the latest completed delegated outcome for status/result follow-ups", () => {
+    const blocks = buildFridayEvidenceBlocks({
+      task: "What is the final result now?",
+      turnKind: "status_check",
+      taskStatusSnapshot: {
+        ...taskStatusSnapshot,
+        runStatus: "completed",
+        phase: "completed",
+        activeSubagents: [],
+        recentCompletedSubagents: [
+          {
+            id: "sub-final",
+            childRunId: "child-run-final",
+            childSessionKey: "subagent:child-final",
+            status: "completed",
+            task: "say CHILD_OK",
+            createdAt: "2026-03-17T10:00:00.000Z",
+            completedAt: "2026-03-17T10:00:10.000Z",
+            outcomeStatus: "completed",
+            outcomeResponse: "CHILD_OK",
+          },
+        ],
+        terminalOutcome: {
+          status: "completed",
+          summary: "CHILD_OK",
+          responseText: "CHILD_OK",
+        },
+      },
+    });
+
+    expect(blocks.find((block) => block.source === "task_status_block")?.summary)
+      .toContain("latest completed subagent sub-final response CHILD_OK");
+    expect(blocks.some((block) =>
+      block.source === "delegated_task_block"
+      && block.summary.includes("response CHILD_OK"))).toBe(true);
+  });
 });

--- a/test/unit/agent/runtime/friday-agent-planning-gate.test.ts
+++ b/test/unit/agent/runtime/friday-agent-planning-gate.test.ts
@@ -154,6 +154,23 @@ describe("friday-agent-planning-gate", () => {
     expect(runs.get("run-1")?.planReview?.gate?.planMarkdown).toContain("Reply `approve` to continue");
   });
 
+  it("treats 'create a new workflow' as a planning-gated workflow request", () => {
+    const service = createService();
+
+    const decision = service.handleTurn({
+      runId: "run-new-workflow",
+      task: "Create a new workflow that runs every weekday morning, summarizes git status, and returns the summary in the workflow response.",
+      sessionKey: "ui:assistant:1",
+    });
+
+    expect(decision.action).toBe("return");
+    if (decision.action !== "return") {
+      throw new Error("Expected return decision");
+    }
+    expect(decision.result.status).toBe("awaiting_clarification");
+    expect(decision.pendingPlanRunId).toBe("run-new-workflow");
+  });
+
   it("moves from clarification to plan approval when the user answers follow-up questions", () => {
     const service = createService();
 

--- a/test/unit/api/runtime/friday-api-runtime-planning-gate.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-planning-gate.test.ts
@@ -207,4 +207,136 @@ describe("FridayApiRuntime — planning gate session loop", () => {
     expect(assistantMessages.some((message) => message.includes("Question 3/3"))).toBe(true);
     expect(assistantMessages).toContain(answerThree.response);
   });
+
+  it("preserves pending plan focus when plan approval happens through the direct approve endpoint", async () => {
+    db = createTestDb();
+    const idGenerator = makeIdGenerator();
+    const runRepo = createFridayAgentRunRepository();
+    const eventEmitter = createFridayAgentEventEmitter();
+    let sessionServiceRef:
+      | ReturnType<typeof createFridayApiRuntime>["sessionService"]
+      | undefined;
+    const clarificationQuestions = [
+      "What time on Friday should this workflow run?",
+      "Which Slack channel or webhook should receive the release status summary?",
+      "What specific workspace root path should be checked for release readiness?",
+    ];
+
+    const agentRuntime: FridayAgentRuntime = {
+      executeRun: vi.fn(async (params) => {
+        const existing = db.withReadConnection((reader) => runRepo.getById(reader, params.runId!));
+        const nextPlanReview = {
+          ...(params.planReviewOverride ?? existing?.planReview ?? {
+            plan: {
+              task: params.task,
+              stepCount: 3,
+              description: "Planning gate for generate workflow",
+            },
+          }),
+          gate: {
+            ...(params.planReviewOverride?.gate ?? existing?.planReview?.gate ?? {
+              kind: "generate_workflow" as const,
+            }),
+            state: "awaiting_clarification" as const,
+            clarificationQuestions,
+            answers: existing?.planReview?.gate?.answers ?? [],
+          },
+        };
+        const response = [
+          "I hit a real blocker while continuing workflow generation: the downstream generator still needs a few specific details before it can proceed.",
+          "",
+          "Please answer these questions in the same thread:",
+          "1. What time on Friday should this workflow run?",
+          "2. Which Slack channel or webhook should receive the release status summary?",
+          "3. What specific workspace root path should be checked for release readiness?",
+          "",
+          "After you answer them, Friday will update the plan and wait for confirmation again before continuing.",
+        ].join("\n");
+
+        db.withWriteTransaction((writer) =>
+          runRepo.update(writer, {
+            id: params.runId!,
+            status: "awaiting_clarification",
+            responseText: response,
+            summary: "Workflow generation needs clarification",
+            planReview: nextPlanReview,
+          }));
+
+        if (params.sessionKey && sessionServiceRef) {
+          await sessionServiceRef.addMessage(params.sessionKey, {
+            role: "assistant",
+            content: response,
+            contentText: response,
+            idempotencyKey: `agent-run:${params.runId}:response`,
+          });
+        }
+
+        return {
+          runId: params.runId!,
+          status: "awaiting_clarification",
+          response,
+          toolCallCount: 1,
+          durationMs: 10,
+          usageInput: 1,
+          usageOutput: 1,
+          finalResponse: response,
+        };
+      }),
+      registerTool: vi.fn(),
+      resumeStaleRunsOnBoot: vi.fn(() => 0),
+    };
+
+    const runtime = createFridayApiRuntime({
+      db,
+      idGenerator,
+      nowIso: () => NOW,
+      providerService: makeProviderService(),
+      agentRuntime,
+      agentEventEmitter: eventEmitter,
+      tokenSecret: "test-secret-key-that-is-at-least-32-chars-long!!", // pragma: allowlist secret
+      allowLocalBypassLogin: true,
+      computeChecksum: (content: string) => `checksum-${content.length}`,
+      resolveSkill: () => null,
+      invokeSkill: async () => ({}),
+    });
+    sessionServiceRef = runtime.sessionService;
+
+    const startRoute = runtime.routes.getRoutes().find((route) => route.operationId === "agent.runs.start");
+    const approveRoute = runtime.routes.getRoutes().find((route) => route.operationId === "agent.runs.approve.plan");
+    expect(startRoute).toBeDefined();
+    expect(approveRoute).toBeDefined();
+
+    const sessionKey = "ui:planning-direct-approve:test";
+    const initial = await startRoute!.handler({
+      body: {
+        task: "Generate a workflow that runs every Friday, collects workspace release status, posts the summary to Slack, keeps the execution read-only, and reports blockers before deployment.",
+        sessionKey,
+      },
+    } as never);
+    expect(initial.status).toBe("awaiting_plan_approval");
+
+    const approved = await approveRoute!.handler({
+      params: { runId: initial.runId },
+    } as never);
+    expect(approved.status).toBe("awaiting_clarification");
+    expect(approved.runId).toBe(initial.runId);
+
+    const focusAfterApprove = await runtime.sessionService.getConversationFocus(sessionKey);
+    expect(focusAfterApprove?.pendingPlanRunId).toBe(initial.runId);
+
+    const answerOne = await startRoute!.handler({
+      body: {
+        task: "Every Friday at 10:00 AM Pacific time.",
+        sessionKey,
+      },
+    } as never);
+    expect(answerOne.runId).toBe(initial.runId);
+    expect(answerOne.status).toBe("awaiting_clarification");
+
+    const messages = await runtime.sessionService.getMessages(sessionKey, 20);
+    const assistantMessages = messages
+      .filter((message) => message.role === "assistant")
+      .map((message) => message.contentText);
+    expect(assistantMessages).toContain(approved.response);
+  });
 });

--- a/test/unit/sessions/services/friday-session-conversation-orchestrator.test.ts
+++ b/test/unit/sessions/services/friday-session-conversation-orchestrator.test.ts
@@ -52,6 +52,16 @@ describe("friday-session-conversation-orchestrator", () => {
     })).toBe("new_topic");
   });
 
+  it("classifies explicit final-result questions as status checks", () => {
+    expect(classifyFridayConversationTurn({
+      task: "What is the final result now?",
+      focusState: {
+        ...baseFocusState,
+        currentTopicSummary: "Use a subagent to say exactly CHILD_OK and then report the result.",
+      },
+    })).toBe("status_check");
+  });
+
   it("keeps only the active topic window for follow-up turns", () => {
     const prepared = prepareFridayConversationTurn({
       task: "What country is that city in?",
@@ -523,6 +533,23 @@ describe("friday-session-conversation-orchestrator", () => {
 
     expect(focus.activeRunId).toBe("run-long-task");
     expect(focus.activeSubagentIds).toEqual(["sub-1"]);
+  });
+
+  it("preserves the tracked root run when a status-check turn finishes", () => {
+    const focus = finalizeFridayConversationFocus({
+      task: "那个任务结果呢？",
+      responseText: "The delegated child has completed with CHILD_OK.",
+      runId: "run-status-followup",
+      turnKind: "status_check",
+      focusState: {
+        ...baseFocusState,
+        lastRunId: "run-root-task",
+      },
+      currentUserSequence: 10,
+      nowIso: "2026-03-15T11:00:00.000Z",
+    });
+
+    expect(focus.lastRunId).toBe("run-root-task");
   });
 
   it("clears pending plan state when finalize receives an explicit null plan reference", () => {


### PR DESCRIPTION
## Summary
- tighten status/evidence selection so imperative tasks like "report the result" no longer get misclassified as status reads
- preserve planning/session continuity across direct `approve-plan` calls and expand workflow planning phrase coverage
- surface latest completed leaf subagent outcomes through task status so follow-up questions resolve to the real final result

## Testing
- npm run typecheck
- npm run lint
- npm run build
- npx vitest run test/unit/sessions/services/friday-session-conversation-orchestrator.test.ts test/unit/agent/runtime/friday-agent-evidence-blocks.test.ts test/unit/agent/runtime/friday-agent-planning-gate.test.ts test/unit/api/runtime/friday-api-runtime-planning-gate.test.ts
- npm run test:e2e:closure:local
- live smoke: planning continuity, subagent final result follow-up, Chinese short follow-ups, capabilities self-report
