### PR TITLE
fix: keep deictic followups anchored

### DIFF
--- a/src/agent/runtime/friday-agent-answer-alignment.ts
+++ b/src/agent/runtime/friday-agent-answer-alignment.ts
@@ -33,6 +33,12 @@ const POSITIVE_ACTION_CLAIM_TERMS =
   /\b(successfully|completed|done|finished|opened|launched|focused|connected|transferred|switched|navigated|now you can|you can now)\b/i;
 const CHINESE_POSITIVE_ACTION_CLAIM_TERMS =
   /(成功|已成功|已经成功|已完成|已经完成|已打开|已经打开|已启动|已经启动|已聚焦|已经聚焦|已连接|已经连接|已切换|已经切换|现在你可以)/;
+const DEICTIC_LITERAL_FOLLOW_UP_TERMS =
+  /^(?:here|there|that one|this one|same one|same issue|that issue|this issue|that part|this part|这里|这儿|这个|那个|同一个问题)$/i;
+const ENGLISH_DEICTIC_LITERAL_ECHO_TERMS =
+  /\b(?:about|regarding|for)\s+(?:the\s+)?(?:"|“)?(?:here|there|that one|this one)(?:"|”)?\s+(?:question|issue|part)\b/i;
+const CHINESE_DEICTIC_LITERAL_ECHO_TERMS =
+  /关于您提到的[“"]?(?:这里|这儿|这个|那个)[”"]?问题|关于[“"]?(?:这里|这儿|这个|那个)[”"]?问题/;
 
 export interface FridayAnswerAlignmentDecision {
   retryPrompt?: string;
@@ -239,6 +245,10 @@ function isShortReplyFollowUp(task: string): boolean {
   return normalized.length <= 48
     || /\b(why|what|that|this|here|it|connect|open)\b/i.test(normalized)
     || /(为什么|什么|这里|这个|那个|连接|打不开|打开)/.test(normalized);
+}
+
+function isPureDeicticLiteralTask(task: string): boolean {
+  return DEICTIC_LITERAL_FOLLOW_UP_TERMS.test(normalizeText(task));
 }
 
 function hasAnchoredAssistantFact(
@@ -460,6 +470,28 @@ export function evaluateFridayAnswerAlignment(params: {
           .join("\n")}`,
         "Explain the referenced earlier fact directly before adding any broader caveat.",
         "If the deeper cause is unknown, say that explicitly after restating the anchored fact.",
+      ].join("\n"),
+    };
+  }
+
+  if (
+    hasAssistantFactAnchor
+    && isPureDeicticLiteralTask(params.task)
+    && (
+      ENGLISH_DEICTIC_LITERAL_ECHO_TERMS.test(responseText)
+      || CHINESE_DEICTIC_LITERAL_ECHO_TERMS.test(responseText)
+    )
+  ) {
+    return {
+      retryPrompt: [
+        "The user used a pure deictic follow-up such as '这里/that one', but you echoed that literal token as if it were a new standalone issue.",
+        `Current follow-up: ${params.task}`,
+        `Reply/assistant anchor(s):\n${anchorBlocks
+          .map((block) => `- ${block.summary}`)
+          .join("\n")}`,
+        "Treat the deictic phrase only as a pointer to the anchored earlier fact.",
+        "Do not add a separate sentence like 'the issue about here/that one is unknown'.",
+        "Answer the anchored fact directly and, if needed, say only whether the deeper cause is known or unknown.",
       ].join("\n"),
     };
   }

--- a/test/unit/agent/runtime/friday-agent-answer-alignment.test.ts
+++ b/test/unit/agent/runtime/friday-agent-answer-alignment.test.ts
@@ -3,6 +3,50 @@ import { describe, expect, it } from "vitest";
 import { evaluateFridayAnswerAlignment } from "../../../../src/agent/runtime/friday-agent-answer-alignment.js";
 
 describe("evaluateFridayAnswerAlignment", () => {
+  it("requests a retry when a pure deictic follow-up is echoed as a standalone issue", () => {
+    const decision = evaluateFridayAnswerAlignment({
+      task: "这里",
+      responseText:
+        "目前桌面快照显示Codex应用程序正在运行，但其具体回复内容无法查看。关于您提到的“这里”问题，具体原因当前未知。",
+      historyMessages: [],
+      conversationContext: {
+        turnKind: "follow_up",
+        selectedBlocks: [
+          {
+            source: "assistant_anchor",
+            summary:
+              "当前桌面快照显示Codex应用程序正在运行，但其具体回复内容无法查看。这是因为系统处于安全模式。",
+            score: 28,
+          },
+        ],
+      },
+    });
+
+    expect(decision.retryPrompt).toContain("pure deictic follow-up");
+  });
+
+  it("does not request a retry when a pure deictic follow-up stays anchored to the prior fact", () => {
+    const decision = evaluateFridayAnswerAlignment({
+      task: "这里",
+      responseText:
+        "目前桌面快照显示Codex应用程序正在运行，但其具体回复内容无法查看。这是因为系统处于安全模式；更深层原因当前未知。",
+      historyMessages: [],
+      conversationContext: {
+        turnKind: "follow_up",
+        selectedBlocks: [
+          {
+            source: "assistant_anchor",
+            summary:
+              "当前桌面快照显示Codex应用程序正在运行，但其具体回复内容无法查看。这是因为系统处于安全模式。",
+            score: 28,
+          },
+        ],
+      },
+    });
+
+    expect(decision.retryPrompt).toBeUndefined();
+  });
+
   it("requests a retry when the response contradicts deterministic capability facts", () => {
     const decision = evaluateFridayAnswerAlignment({
       task: "discord enabled? mcp enabled? is provider mutation blocked by readOnly?",


### PR DESCRIPTION
## Summary
- add a deictic follow-up alignment guard so replies like `这里/that one` stay anchored instead of inventing a second standalone issue
- cover the guard with answer-alignment unit tests

## Testing
- npm run typecheck
- npm run lint
- npm run build
- npx vitest run test/unit/agent/runtime/friday-agent-answer-alignment.test.ts test/unit/sessions/services/friday-session-conversation-orchestrator.test.ts test/unit/agent/runtime/friday-agent-evidence-blocks.test.ts test/unit/agent/runtime/friday-agent-planning-gate.test.ts test/unit/api/runtime/friday-api-runtime-planning-gate.test.ts
- merged-main live smoke: Chinese short follow-ups, planning continuity, subagent final result, capabilities self-report
