### PR TITLE
fix: stabilize attnres closure backstops

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -535,7 +535,7 @@
         "filename": "test/e2e/mock/friday-mock-journeys.e2e.test.ts",
         "hashed_secret": "ebd9cc347535927ca5893b0d1f1fc15fbca9b91d",
         "is_verified": false,
-        "line_number": 388
+        "line_number": 390
       }
     ],
     "test/e2e/mock/friday-mock-provider-matrix.e2e.test.ts": [
@@ -1058,5 +1058,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-14T18:58:11Z"
+  "generated_at": "2026-03-17T13:04:23Z"
 }

--- a/scripts/e2e/run-friday-closure.mjs
+++ b/scripts/e2e/run-friday-closure.mjs
@@ -2004,12 +2004,27 @@ async function runLocalStage(ledger) {
       });
     }
   } finally {
-    server.kill("SIGTERM");
     await new Promise((resolve) => {
-      server.on("close", resolve);
-      setTimeout(() => {
-        if (!server.killed) server.kill("SIGKILL");
+      if (server.exitCode !== null || server.signalCode !== null) {
+        resolve();
+        return;
+      }
+      let settled = false;
+      const settle = () => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(forceKillTimer);
+        resolve();
+      };
+      const forceKillTimer = setTimeout(() => {
+        if (server.exitCode === null && server.signalCode === null) {
+          server.kill("SIGKILL");
+        }
       }, 5_000);
+      server.once("close", settle);
+      server.kill("SIGTERM");
     });
     serverLogStream.end();
   }

--- a/scripts/ops/build-friday-companion-dmg.sh
+++ b/scripts/ops/build-friday-companion-dmg.sh
@@ -7,6 +7,42 @@ if [[ -z "${REPO_DIR}" ]]; then
 fi
 REPO_DIR="$(cd "${REPO_DIR}" && pwd)"
 LOCK_DIR="${FRIDAY_MACOS_RELEASE_LOCK_DIR:-${REPO_DIR}/.friday/locks/macos-release.lock}"
+LOCK_OWNER_FILE="${LOCK_DIR}/owner.pid"
+
+lock_mtime_epoch() {
+  if stat -f %m "${LOCK_DIR}" >/dev/null 2>&1; then
+    stat -f %m "${LOCK_DIR}"
+    return
+  fi
+  stat -c %Y "${LOCK_DIR}"
+}
+
+cleanup_stale_release_lock() {
+  if [[ ! -d "${LOCK_DIR}" ]]; then
+    return 1
+  fi
+
+  if [[ -f "${LOCK_OWNER_FILE}" ]]; then
+    local owner_pid
+    owner_pid="$(tr -d '[:space:]' < "${LOCK_OWNER_FILE}")"
+    if [[ -n "${owner_pid}" ]] && kill -0 "${owner_pid}" >/dev/null 2>&1; then
+      return 1
+    fi
+    rm -rf "${LOCK_DIR}"
+    return 0
+  fi
+
+  local now_epoch
+  now_epoch="$(date +%s)"
+  local mtime_epoch
+  mtime_epoch="$(lock_mtime_epoch 2>/dev/null || echo 0)"
+  if [[ "${mtime_epoch}" =~ ^[0-9]+$ ]] && (( now_epoch - mtime_epoch >= 30 )); then
+    rm -rf "${LOCK_DIR}"
+    return 0
+  fi
+
+  return 1
+}
 
 acquire_release_lock() {
   if [[ "${FRIDAY_MACOS_RELEASE_LOCK_HELD:-false}" == "true" ]]; then
@@ -16,6 +52,7 @@ acquire_release_lock() {
   mkdir -p "$(dirname "${LOCK_DIR}")"
   local attempts=0
   until mkdir "${LOCK_DIR}" >/dev/null 2>&1; do
+    cleanup_stale_release_lock >/dev/null 2>&1 && continue
     attempts="$((attempts + 1))"
     if (( attempts >= 120 )); then
       echo "[friday-companion-dmg] timed out waiting for release lock at ${LOCK_DIR}" >&2
@@ -24,6 +61,7 @@ acquire_release_lock() {
     sleep 1
   done
 
+  printf '%s\n' "$$" > "${LOCK_OWNER_FILE}"
   export FRIDAY_MACOS_RELEASE_LOCK_HELD="true"
   export FRIDAY_MACOS_RELEASE_LOCK_OWNER="true"
   trap 'if [[ "${FRIDAY_MACOS_RELEASE_LOCK_OWNER:-false}" == "true" ]]; then rm -rf "${LOCK_DIR}"; fi' EXIT

--- a/scripts/ops/release-friday-companion-app.sh
+++ b/scripts/ops/release-friday-companion-app.sh
@@ -9,6 +9,42 @@ REPO_DIR="$(cd "${REPO_DIR}" && pwd)"
 LOCK_DIR="${FRIDAY_MACOS_RELEASE_LOCK_DIR:-${REPO_DIR}/.friday/locks/macos-release.lock}"
 CHANNELS_DIR="${FRIDAY_RELEASE_CHANNELS_DIR:-${REPO_DIR}/dist/releases/channels}"
 SPARKLE_APPCAST_PATH="${FRIDAY_SYSTEM_COMPANION_SPARKLE_APPCAST_PATH:-${REPO_DIR}/dist/releases/macos/appcast.xml}"
+LOCK_OWNER_FILE="${LOCK_DIR}/owner.pid"
+
+lock_mtime_epoch() {
+  if stat -f %m "${LOCK_DIR}" >/dev/null 2>&1; then
+    stat -f %m "${LOCK_DIR}"
+    return
+  fi
+  stat -c %Y "${LOCK_DIR}"
+}
+
+cleanup_stale_release_lock() {
+  if [[ ! -d "${LOCK_DIR}" ]]; then
+    return 1
+  fi
+
+  if [[ -f "${LOCK_OWNER_FILE}" ]]; then
+    local owner_pid
+    owner_pid="$(tr -d '[:space:]' < "${LOCK_OWNER_FILE}")"
+    if [[ -n "${owner_pid}" ]] && kill -0 "${owner_pid}" >/dev/null 2>&1; then
+      return 1
+    fi
+    rm -rf "${LOCK_DIR}"
+    return 0
+  fi
+
+  local now_epoch
+  now_epoch="$(date +%s)"
+  local mtime_epoch
+  mtime_epoch="$(lock_mtime_epoch 2>/dev/null || echo 0)"
+  if [[ "${mtime_epoch}" =~ ^[0-9]+$ ]] && (( now_epoch - mtime_epoch >= 30 )); then
+    rm -rf "${LOCK_DIR}"
+    return 0
+  fi
+
+  return 1
+}
 
 acquire_release_lock() {
   if [[ "${FRIDAY_MACOS_RELEASE_LOCK_HELD:-false}" == "true" ]]; then
@@ -18,6 +54,7 @@ acquire_release_lock() {
   mkdir -p "$(dirname "${LOCK_DIR}")"
   local attempts=0
   until mkdir "${LOCK_DIR}" >/dev/null 2>&1; do
+    cleanup_stale_release_lock >/dev/null 2>&1 && continue
     attempts="$((attempts + 1))"
     if (( attempts >= 120 )); then
       echo "[friday-companion-release] timed out waiting for release lock at ${LOCK_DIR}" >&2
@@ -26,6 +63,7 @@ acquire_release_lock() {
     sleep 1
   done
 
+  printf '%s\n' "$$" > "${LOCK_OWNER_FILE}"
   export FRIDAY_MACOS_RELEASE_LOCK_HELD="true"
   export FRIDAY_MACOS_RELEASE_LOCK_OWNER="true"
   trap 'if [[ "${FRIDAY_MACOS_RELEASE_LOCK_OWNER:-false}" == "true" ]]; then rm -rf "${LOCK_DIR}"; fi' EXIT

--- a/src/agent/subagent/friday-subagent-registry.ts
+++ b/src/agent/subagent/friday-subagent-registry.ts
@@ -1,3 +1,4 @@
+import type Database from "better-sqlite3";
 import { FridayDomainError } from "#errors";
 import { buildFridaySubagentSessionKey } from "#sessions";
 
@@ -24,6 +25,8 @@ const FRIDAY_SUBAGENT_DEFAULT_ARCHIVAL_OFFSET_MS = 24 * 60 * 60 * 1000;
 
 /** Poll interval for waitForCompletion (ms). */
 const FRIDAY_SUBAGENT_POLL_INTERVAL_MS = 250;
+/** Shutdown grace period for detached children (ms). */
+const FRIDAY_SUBAGENT_DRAIN_TIMEOUT_MS = 15_000;
 
 // ─── Factory ───
 
@@ -32,6 +35,23 @@ export function createFridaySubagentRegistry(
 ): FridaySubagentRegistry {
   const { db, createChildRuntime, eventEmitter, idGenerator, nowIso } = deps;
   const repo = createFridaySubagentRunRepository();
+  const inFlightExecutions = new Map<string, Promise<FridaySubagentOutcome>>();
+
+  function isClosedDbError(error: unknown): boolean {
+    return error instanceof Error && /database connection is not open/i.test(error.message);
+  }
+
+  function safeWrite(
+    operation: (writer: Database.Database) => void,
+  ): void {
+    try {
+      db.withWriteTransaction(operation);
+    } catch (error) {
+      if (!isClosedDbError(error)) {
+        throw error;
+      }
+    }
+  }
 
   /** Shared validation + record creation for both spawn() and spawnDetached(). */
   function prepareSpawn(input: FridaySubagentRegistrySpawnInput): {
@@ -66,7 +86,7 @@ export function createFridaySubagentRegistry(
     const childSessionKey = buildFridaySubagentSessionKey(input.parentSessionKey, childRunId);
 
     // 4. Create subagent record
-    db.withWriteTransaction((writer) =>
+    safeWrite((writer) =>
       repo.create(writer, {
         id: subagentRecordId,
         parentRunId: input.parentRunId,
@@ -121,7 +141,7 @@ export function createFridaySubagentRegistry(
     });
 
     // Transition to running
-    db.withWriteTransaction((writer) =>
+    safeWrite((writer) =>
       repo.update(writer, {
         id: subagentRecordId,
         status: "running",
@@ -163,7 +183,7 @@ export function createFridaySubagentRegistry(
       };
 
       // Finalize record
-      db.withWriteTransaction((writer) =>
+      safeWrite((writer) =>
         repo.update(writer, {
           id: subagentRecordId,
           status: terminalStatus,
@@ -195,7 +215,7 @@ export function createFridaySubagentRegistry(
         images: [],
       };
 
-      db.withWriteTransaction((writer) =>
+      safeWrite((writer) =>
         repo.update(writer, {
           id: subagentRecordId,
           status: "failed",
@@ -232,9 +252,12 @@ export function createFridaySubagentRegistry(
       detachedInputs.set(subagentRecordId, { input, childSessionKey });
 
       // Fire-and-forget the child execution
-      void executeChild(subagentRecordId, childRunId, input, childSessionKey).finally(() => {
+      const execution = executeChild(subagentRecordId, childRunId, input, childSessionKey).finally(() => {
         detachedInputs.delete(subagentRecordId);
+        inFlightExecutions.delete(subagentRecordId);
       });
+      inFlightExecutions.set(subagentRecordId, execution);
+      void execution;
 
       const record = db.withReadConnection((reader) =>
         repo.getById(reader, subagentRecordId),
@@ -250,6 +273,19 @@ export function createFridaySubagentRegistry(
         detached: true,
         awaited: false,
       };
+    },
+
+    async drain(timeoutMs = FRIDAY_SUBAGENT_DRAIN_TIMEOUT_MS): Promise<void> {
+      if (inFlightExecutions.size === 0) {
+        return;
+      }
+      const pending = Array.from(inFlightExecutions.values());
+      await Promise.race([
+        Promise.allSettled(pending).then(() => undefined),
+        new Promise<void>((resolve) => {
+          setTimeout(resolve, timeoutMs);
+        }),
+      ]);
     },
 
     async startRun(subagentId: string): Promise<FridaySubagentOutcome> {
@@ -302,7 +338,7 @@ export function createFridaySubagentRegistry(
       const deadline = opts?.archivalDeadline
         ?? new Date(Date.now() + FRIDAY_SUBAGENT_DEFAULT_ARCHIVAL_OFFSET_MS).toISOString();
 
-      db.withWriteTransaction((writer) =>
+      safeWrite((writer) =>
         repo.update(writer, {
           id: subagentId,
           cleanupRequested: true,
@@ -313,9 +349,16 @@ export function createFridaySubagentRegistry(
 
     cleanup(beforeIso?: string): number {
       const cutoff = beforeIso ?? nowIso();
-      return db.withWriteTransaction((writer) =>
-        repo.deleteCleanedUp(writer, cutoff),
-      );
+      try {
+        return db.withWriteTransaction((writer) =>
+          repo.deleteCleanedUp(writer, cutoff),
+        );
+      } catch (error) {
+        if (isClosedDbError(error)) {
+          return 0;
+        }
+        throw error;
+      }
     },
 
     resumeOnBoot(): number {
@@ -335,7 +378,7 @@ export function createFridaySubagentRegistry(
           images: [],
         };
 
-        db.withWriteTransaction((writer) =>
+        safeWrite((writer) =>
           repo.update(writer, {
             id: record.id,
             status: "failed",

--- a/src/agent/subagent/friday-subagent.types.ts
+++ b/src/agent/subagent/friday-subagent.types.ts
@@ -99,6 +99,8 @@ export interface FridaySubagentRegistry {
   spawn(input: FridaySubagentRegistrySpawnInput): Promise<FridaySubagentOutcome>;
   /** Spawn a child run in detached mode. Returns immediately with accepted metadata. */
   spawnDetached(input: FridaySubagentRegistrySpawnInput): FridaySubagentDetachedResult;
+  /** Wait for in-flight detached children to settle before shutdown. */
+  drain(timeoutMs?: number): Promise<void>;
   /** Start a detached child run (called internally after spawnDetached). */
   startRun(subagentId: string): Promise<FridaySubagentOutcome>;
   /** Wait for a sub-agent to complete (poll until terminal status). */

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -4582,6 +4582,7 @@ export async function createFridayHub(
         desktopSessionManager.disconnect();
       }
       await browserManager.close();
+      await subagentRegistry.drain();
       // 4. API runtime — no async teardown yet (HTTP server stop is CLI concern)
       // 5. Workflow runtime — scheduler now handles cron lifecycle
       // 6. Skills

--- a/test/e2e/mock/friday-mock-journeys.e2e.test.ts
+++ b/test/e2e/mock/friday-mock-journeys.e2e.test.ts
@@ -17,6 +17,8 @@ import { STREAMING_PROVIDER_MATRIX, type ProviderMatrixEntry } from "./_helpers/
 import type { MockFetchRouter } from "./_helpers/mock-fetch-router.js";
 import type { FridayProviderKind } from "../../../src/providers/model/friday-provider.types.js";
 
+const MOCK_E2E_TIMEOUT_MS = 20_000;
+
 // ─── Helpers ───
 
 async function apiFetch<T>(
@@ -159,7 +161,7 @@ describe.each(STREAMING_PROVIDER_MATRIX)(
         task: "Tell me 3 interesting facts about octopuses.",
         providerId: provider.providerId,
         model: provider.model,
-        timeoutMs: 10_000,
+        timeoutMs: MOCK_E2E_TIMEOUT_MS,
       });
 
       expect(runRes.status).toBe(200);
@@ -221,7 +223,7 @@ describe.each(STREAMING_PROVIDER_MATRIX)(
         task: 'Analyze this workflow: it references "nonexistent-skill-xyz" which does not exist. What problems would this cause?',
         providerId: provider.providerId,
         model: provider.model,
-        timeoutMs: 10_000,
+        timeoutMs: MOCK_E2E_TIMEOUT_MS,
       });
 
       expect(diagRunRes.status).toBe(200);
@@ -241,7 +243,7 @@ describe.each(STREAMING_PROVIDER_MATRIX)(
       expect(mock.calls.length).toBeGreaterThanOrEqual(1);
     });
 
-    it("Automation lifecycle (create → run → disable → re-enable → run)", async () => {
+    it("Automation lifecycle (create → run → disable → re-enable → run)", { timeout: MOCK_E2E_TIMEOUT_MS }, async () => {
       const mock = env.mockFor(entry.kind);
       const provider = env.providers[entry.kind]!;
 
@@ -280,7 +282,7 @@ describe.each(STREAMING_PROVIDER_MATRIX)(
         {
           providerId: provider.providerId,
           model: provider.model,
-          timeoutMs: 10_000,
+          timeoutMs: MOCK_E2E_TIMEOUT_MS,
         },
       );
       expect(run1Res.status).toBe(200);
@@ -324,7 +326,7 @@ describe.each(STREAMING_PROVIDER_MATRIX)(
         {
           providerId: provider.providerId,
           model: provider.model,
-          timeoutMs: 10_000,
+          timeoutMs: MOCK_E2E_TIMEOUT_MS,
         },
       );
       expect(run2Res.json.data.result.status).toBe("completed");

--- a/test/e2e/mock/friday-mock-multi-turn.e2e.test.ts
+++ b/test/e2e/mock/friday-mock-multi-turn.e2e.test.ts
@@ -45,6 +45,8 @@ interface AgentRunResult {
   };
 }
 
+const MOCK_E2E_TIMEOUT_MS = 20_000;
+
 // ─── Tests ───
 
 describe("Friday Mock Multi-Turn E2E", () => {
@@ -81,7 +83,7 @@ describe("Friday Mock Multi-Turn E2E", () => {
       env.accessToken,
       "POST",
       "/v1/agent/runs",
-      { task: "What is the capital of France?", providerId, model, timeoutMs: 10_000, sessionKey },
+      { task: "What is the capital of France?", providerId, model, timeoutMs: MOCK_E2E_TIMEOUT_MS, sessionKey },
     );
     expect(r1.json.data.status).toBe("completed");
 
@@ -95,7 +97,7 @@ describe("Friday Mock Multi-Turn E2E", () => {
       env.accessToken,
       "POST",
       "/v1/agent/runs",
-      { task: "What country is that city in?", providerId, model, timeoutMs: 10_000, sessionKey },
+      { task: "What country is that city in?", providerId, model, timeoutMs: MOCK_E2E_TIMEOUT_MS, sessionKey },
     );
     expect(r2.json.data.status).toBe("completed");
 
@@ -107,7 +109,7 @@ describe("Friday Mock Multi-Turn E2E", () => {
     if (r2Body?.messages) {
       expect(r2Body.messages.length).toBeGreaterThan(1);
     }
-  });
+  }, MOCK_E2E_TIMEOUT_MS);
 
   it("treats an unrelated second turn as a new topic instead of replaying the prior answer", async () => {
     const mock = env.mockFor("anthropic");
@@ -119,7 +121,7 @@ describe("Friday Mock Multi-Turn E2E", () => {
       env.accessToken,
       "POST",
       "/v1/agent/runs",
-      { task: "What is the capital of France?", providerId, model, timeoutMs: 10_000, sessionKey },
+      { task: "What is the capital of France?", providerId, model, timeoutMs: MOCK_E2E_TIMEOUT_MS, sessionKey },
     );
     expect(r1.json.data.status).toBe("completed");
 
@@ -132,7 +134,7 @@ describe("Friday Mock Multi-Turn E2E", () => {
       env.accessToken,
       "POST",
       "/v1/agent/runs",
-      { task: "How do I bake sourdough bread?", providerId, model, timeoutMs: 10_000, sessionKey },
+      { task: "How do I bake sourdough bread?", providerId, model, timeoutMs: MOCK_E2E_TIMEOUT_MS, sessionKey },
     );
     expect(r2.json.data.status).toBe("completed");
 
@@ -143,7 +145,7 @@ describe("Friday Mock Multi-Turn E2E", () => {
       expect(joined).not.toContain("Paris is the capital of France.");
       expect(joined).toContain("How do I bake sourdough bread?");
     }
-  });
+  }, MOCK_E2E_TIMEOUT_MS);
 
   it("three-turn accumulation: by round 3, LLM receives history from rounds 1 and 2", async () => {
     const mock = env.mockFor("anthropic");
@@ -153,7 +155,7 @@ describe("Friday Mock Multi-Turn E2E", () => {
     mock.setDefault({ type: "text", text: "I like TypeScript." });
     await apiFetch<AgentRunResult>(
       env.baseUrl, env.accessToken, "POST", "/v1/agent/runs",
-      { task: "What language do you prefer?", providerId, model, timeoutMs: 10_000, sessionKey },
+      { task: "What language do you prefer?", providerId, model, timeoutMs: MOCK_E2E_TIMEOUT_MS, sessionKey },
     );
     mock.reset();
     resetMockCounters();
@@ -162,7 +164,7 @@ describe("Friday Mock Multi-Turn E2E", () => {
     mock.setDefault({ type: "text", text: "Vitest is my recommended test runner." });
     await apiFetch<AgentRunResult>(
       env.baseUrl, env.accessToken, "POST", "/v1/agent/runs",
-      { task: "What test runner do you recommend?", providerId, model, timeoutMs: 10_000, sessionKey },
+      { task: "What test runner do you recommend?", providerId, model, timeoutMs: MOCK_E2E_TIMEOUT_MS, sessionKey },
     );
     mock.reset();
     resetMockCounters();
@@ -171,7 +173,7 @@ describe("Friday Mock Multi-Turn E2E", () => {
     mock.setDefault({ type: "text", text: "TypeScript with Vitest is a great combination." });
     await apiFetch<AgentRunResult>(
       env.baseUrl, env.accessToken, "POST", "/v1/agent/runs",
-      { task: "Summarize your recommendations", providerId, model, timeoutMs: 10_000, sessionKey },
+      { task: "Summarize your recommendations", providerId, model, timeoutMs: MOCK_E2E_TIMEOUT_MS, sessionKey },
     );
 
     // Verify round 3 LLM call includes history from rounds 1 and 2
@@ -182,7 +184,7 @@ describe("Friday Mock Multi-Turn E2E", () => {
       // At minimum: user1, assistant1, user2, assistant2, user3 = 5 messages
       expect(r3Body.messages.length).toBeGreaterThanOrEqual(4);
     }
-  });
+  }, MOCK_E2E_TIMEOUT_MS);
 
   it("memory stored via API in run 1 is searchable in run 2", async () => {
     const mock = env.mockFor("anthropic");
@@ -219,7 +221,7 @@ describe("Friday Mock Multi-Turn E2E", () => {
     mock.setDefault({ type: "text", text: "Session A response" });
     await apiFetch<AgentRunResult>(
       env.baseUrl, env.accessToken, "POST", "/v1/agent/runs",
-      { task: "Session A topic: quantum physics", providerId, model, timeoutMs: 10_000, sessionKey: "api:e2e:isolation-A" },
+      { task: "Session A topic: quantum physics", providerId, model, timeoutMs: MOCK_E2E_TIMEOUT_MS, sessionKey: "api:e2e:isolation-A" },
     );
     mock.reset();
     resetMockCounters();
@@ -228,7 +230,7 @@ describe("Friday Mock Multi-Turn E2E", () => {
     mock.setDefault({ type: "text", text: "Session B response" });
     await apiFetch<AgentRunResult>(
       env.baseUrl, env.accessToken, "POST", "/v1/agent/runs",
-      { task: "Session B topic: cooking recipes", providerId, model, timeoutMs: 10_000, sessionKey: "api:e2e:isolation-B" },
+      { task: "Session B topic: cooking recipes", providerId, model, timeoutMs: MOCK_E2E_TIMEOUT_MS, sessionKey: "api:e2e:isolation-B" },
     );
 
     // Session B LLM call should NOT include Session A's history
@@ -238,7 +240,7 @@ describe("Friday Mock Multi-Turn E2E", () => {
       expect(allContent).not.toContain("quantum physics");
       expect(allContent).toContain("cooking recipes");
     }
-  });
+  }, MOCK_E2E_TIMEOUT_MS);
 
   it("cross-run tool results: run 1 writes file, run 2 reads it", async () => {
     const mock = env.mockFor("anthropic");
@@ -277,7 +279,7 @@ describe("Friday Mock Multi-Turn E2E", () => {
 
     expect(r2.json.data.status).toBe("completed");
     expect(r2.json.data.toolCallCount).toBeGreaterThanOrEqual(1);
-  });
+  }, MOCK_E2E_TIMEOUT_MS);
 
   it("concurrency closure: same-user multi-request and multi-user parallel runs stay isolated", async () => {
     const mock = env.mockFor("anthropic");

--- a/test/e2e/mock/friday-mock-sessions.e2e.test.ts
+++ b/test/e2e/mock/friday-mock-sessions.e2e.test.ts
@@ -43,6 +43,8 @@ interface AgentRunResult {
   };
 }
 
+const MOCK_E2E_TIMEOUT_MS = 20_000;
+
 // ─── Tests ───
 
 describe("Friday Mock Sessions E2E", () => {
@@ -76,7 +78,7 @@ describe("Friday Mock Sessions E2E", () => {
 
     await apiFetch<AgentRunResult>(
       env.baseUrl, env.accessToken, "POST", "/v1/agent/runs",
-      { task: "Create a session", providerId, model, timeoutMs: 10_000, sessionKey },
+      { task: "Create a session", providerId, model, timeoutMs: MOCK_E2E_TIMEOUT_MS, sessionKey },
     );
 
     // Fetch sessions list
@@ -98,7 +100,7 @@ describe("Friday Mock Sessions E2E", () => {
 
     await apiFetch<AgentRunResult>(
       env.baseUrl, env.accessToken, "POST", "/v1/agent/runs",
-      { task: "What is the answer?", providerId, model, timeoutMs: 10_000, sessionKey },
+      { task: "What is the answer?", providerId, model, timeoutMs: MOCK_E2E_TIMEOUT_MS, sessionKey },
     );
 
     // Fetch session messages — API returns { items } not { messages }
@@ -117,7 +119,7 @@ describe("Friday Mock Sessions E2E", () => {
     expect(roles).toContain("assistant");
   });
 
-  it("multiple runs in same session accumulate messages", async () => {
+  it("multiple runs in same session accumulate messages", { timeout: MOCK_E2E_TIMEOUT_MS }, async () => {
     const mock = env.mockFor("ollama");
     const sessionKey = "api:e2e:sessions-accumulate";
 
@@ -125,7 +127,7 @@ describe("Friday Mock Sessions E2E", () => {
     mock.setDefault({ type: "text", text: "First response." });
     await apiFetch<AgentRunResult>(
       env.baseUrl, env.accessToken, "POST", "/v1/agent/runs",
-      { task: "First question", providerId, model, timeoutMs: 10_000, sessionKey },
+      { task: "First question", providerId, model, timeoutMs: MOCK_E2E_TIMEOUT_MS, sessionKey },
     );
 
     mock.reset();
@@ -135,7 +137,7 @@ describe("Friday Mock Sessions E2E", () => {
     mock.setDefault({ type: "text", text: "Second response." });
     await apiFetch<AgentRunResult>(
       env.baseUrl, env.accessToken, "POST", "/v1/agent/runs",
-      { task: "Second question", providerId, model, timeoutMs: 10_000, sessionKey },
+      { task: "Second question", providerId, model, timeoutMs: MOCK_E2E_TIMEOUT_MS, sessionKey },
     );
 
     // Fetch session messages
@@ -149,7 +151,7 @@ describe("Friday Mock Sessions E2E", () => {
     expect(msgsRes.json.data.items.length).toBeGreaterThanOrEqual(4);
   });
 
-  it("sessions list contains multiple sessions", async () => {
+  it("sessions list contains multiple sessions", { timeout: MOCK_E2E_TIMEOUT_MS }, async () => {
     const mock = env.mockFor("ollama");
     mock.setDefault({ type: "text", text: "ok" });
 
@@ -160,7 +162,7 @@ describe("Friday Mock Sessions E2E", () => {
       mock.setDefault({ type: "text", text: `Response ${String(i)}` });
       await apiFetch<AgentRunResult>(
         env.baseUrl, env.accessToken, "POST", "/v1/agent/runs",
-        { task: `Task ${String(i)}`, providerId, model, timeoutMs: 10_000, sessionKey: `api:e2e:sessions-list-${String(i)}` },
+        { task: `Task ${String(i)}`, providerId, model, timeoutMs: MOCK_E2E_TIMEOUT_MS, sessionKey: `api:e2e:sessions-list-${String(i)}` },
       );
     }
 
@@ -185,7 +187,7 @@ describe("Friday Mock Sessions E2E", () => {
     // Run without explicit sessionKey
     const res = await apiFetch<AgentRunResult>(
       env.baseUrl, env.accessToken, "POST", "/v1/agent/runs",
-      { task: "Auto session test", providerId, model, timeoutMs: 10_000 },
+      { task: "Auto session test", providerId, model, timeoutMs: MOCK_E2E_TIMEOUT_MS },
     );
 
     expect(res.json.data.status).toBe("completed");

--- a/test/e2e/mock/friday-mock-tool-invocations.e2e.test.ts
+++ b/test/e2e/mock/friday-mock-tool-invocations.e2e.test.ts
@@ -71,6 +71,9 @@ interface AgentRunResult {
   };
 }
 
+const MOCK_E2E_RUN_TIMEOUT_MS = 20_000;
+const MOCK_E2E_TEST_TIMEOUT_MS = 20_000;
+
 // ─── Tests ───
 
 describe("Friday Mock Tool Invocations E2E", () => {
@@ -136,7 +139,7 @@ describe("Friday Mock Tool Invocations E2E", () => {
           task: "Search for nodejs testing frameworks",
           providerId,
           model,
-          timeoutMs: 15_000,
+          timeoutMs: MOCK_E2E_RUN_TIMEOUT_MS,
         },
       );
 
@@ -188,7 +191,7 @@ describe("Friday Mock Tool Invocations E2E", () => {
         env.accessToken,
         "POST",
         "/v1/agent/runs",
-        { task: "Fetch data from the API", providerId, model, timeoutMs: 15_000 },
+        { task: "Fetch data from the API", providerId, model, timeoutMs: MOCK_E2E_RUN_TIMEOUT_MS },
       );
 
       expect(res.status).toBe(200);
@@ -221,7 +224,7 @@ describe("Friday Mock Tool Invocations E2E", () => {
       env.accessToken,
       "POST",
       "/v1/agent/runs",
-      { task: "Run echo hello", providerId, model, timeoutMs: 15_000 },
+      { task: "Run echo hello", providerId, model, timeoutMs: MOCK_E2E_RUN_TIMEOUT_MS },
     );
 
     expect(res.status).toBe(200);
@@ -250,7 +253,7 @@ describe("Friday Mock Tool Invocations E2E", () => {
       env.accessToken,
       "POST",
       "/v1/agent/runs",
-      { task: "Run a command", providerId, model, timeoutMs: 15_000 },
+      { task: "Run a command", providerId, model, timeoutMs: MOCK_E2E_RUN_TIMEOUT_MS },
     );
 
     expect(res.status).toBe(200);
@@ -284,7 +287,7 @@ describe("Friday Mock Tool Invocations E2E", () => {
       env.accessToken,
       "POST",
       "/v1/agent/runs",
-      { task: "Read the test file", providerId, model, timeoutMs: 15_000 },
+      { task: "Read the test file", providerId, model, timeoutMs: MOCK_E2E_RUN_TIMEOUT_MS },
     );
 
     expect(res.status).toBe(200);
@@ -314,7 +317,7 @@ describe("Friday Mock Tool Invocations E2E", () => {
       env.accessToken,
       "POST",
       "/v1/agent/runs",
-      { task: "Write a file", providerId, model, timeoutMs: 15_000 },
+      { task: "Write a file", providerId, model, timeoutMs: MOCK_E2E_RUN_TIMEOUT_MS },
     );
 
     expect(res.status).toBe(200);
@@ -346,7 +349,7 @@ describe("Friday Mock Tool Invocations E2E", () => {
       env.accessToken,
       "POST",
       "/v1/agent/runs",
-      { task: "Write a file outside workspace", providerId, model, timeoutMs: 15_000 },
+      { task: "Write a file outside workspace", providerId, model, timeoutMs: MOCK_E2E_RUN_TIMEOUT_MS },
     );
 
     expect(res.status).toBe(200);
@@ -358,7 +361,7 @@ describe("Friday Mock Tool Invocations E2E", () => {
 
   // ─── 8. memory_store then memory_search ───
 
-  it("memory_store then memory_search via agent tools", async () => {
+  it("memory_store then memory_search via agent tools", { timeout: MOCK_E2E_TEST_TIMEOUT_MS }, async () => {
     const mock = env.mockFor("anthropic");
 
     // Run 1: store memory
@@ -381,7 +384,7 @@ describe("Friday Mock Tool Invocations E2E", () => {
       env.accessToken,
       "POST",
       "/v1/agent/runs",
-      { task: "Remember my dark mode preference", providerId, model, timeoutMs: 15_000 },
+      { task: "Remember my dark mode preference", providerId, model, timeoutMs: MOCK_E2E_RUN_TIMEOUT_MS },
     );
 
     expect(run1.json.data.status).toBe("completed");
@@ -407,7 +410,7 @@ describe("Friday Mock Tool Invocations E2E", () => {
       env.accessToken,
       "POST",
       "/v1/agent/runs",
-      { task: "What are my UI preferences?", providerId, model, timeoutMs: 15_000 },
+      { task: "What are my UI preferences?", providerId, model, timeoutMs: MOCK_E2E_RUN_TIMEOUT_MS },
     );
 
     expect(run2.json.data.status).toBe("completed");
@@ -416,7 +419,7 @@ describe("Friday Mock Tool Invocations E2E", () => {
 
   // ─── 9. Unknown tool name ───
 
-  it("unknown tool name returns error to LLM gracefully", async () => {
+  it("unknown tool name returns error to LLM gracefully", { timeout: MOCK_E2E_TEST_TIMEOUT_MS }, async () => {
     const mock = env.mockFor("anthropic");
 
     mock.enqueue({
@@ -434,7 +437,7 @@ describe("Friday Mock Tool Invocations E2E", () => {
       env.accessToken,
       "POST",
       "/v1/agent/runs",
-      { task: "Use a nonexistent tool", providerId, model, timeoutMs: 15_000 },
+      { task: "Use a nonexistent tool", providerId, model, timeoutMs: MOCK_E2E_RUN_TIMEOUT_MS },
     );
 
     expect(res.status).toBe(200);
@@ -475,7 +478,7 @@ describe("Friday Mock Tool Invocations E2E", () => {
       env.accessToken,
       "POST",
       "/v1/agent/runs",
-      { task: "Read a file", providerId, model, timeoutMs: 15_000 },
+      { task: "Read a file", providerId, model, timeoutMs: MOCK_E2E_RUN_TIMEOUT_MS },
     );
 
     expect(res.status).toBe(200);
@@ -514,7 +517,7 @@ describe("Friday Mock Tool Invocations E2E", () => {
       env.accessToken,
       "POST",
       "/v1/agent/runs",
-      { task: "Create a file and verify its contents", providerId, model, timeoutMs: 15_000 },
+      { task: "Create a file and verify its contents", providerId, model, timeoutMs: MOCK_E2E_RUN_TIMEOUT_MS },
     );
 
     expect(res.status).toBe(200);
@@ -547,7 +550,7 @@ describe("Friday Mock Tool Invocations E2E", () => {
       env.accessToken,
       "POST",
       "/v1/agent/runs",
-      { task: "List files in the state directory", providerId, model, timeoutMs: 15_000 },
+      { task: "List files in the state directory", providerId, model, timeoutMs: MOCK_E2E_RUN_TIMEOUT_MS },
     );
 
     expect(res.status).toBe(200);

--- a/test/unit/agent/subagent/friday-subagent-registry.test.ts
+++ b/test/unit/agent/subagent/friday-subagent-registry.test.ts
@@ -366,6 +366,31 @@ describe("FridaySubagentRegistry", () => {
       const outcome = await registry.waitForCompletion(result.subagentId, 5000);
       expect(outcome.status).toBe("completed");
     });
+
+    it("drain waits for detached children to settle", async () => {
+      let resolveRun: ((value: FridayAgentRuntimeResult) => void) | undefined;
+      const registry = createRegistry({
+        createChildRuntime: () => ({
+          executeRun: vi.fn().mockReturnValue(new Promise<FridayAgentRuntimeResult>((resolve) => {
+            resolveRun = resolve;
+          })),
+        }),
+      });
+
+      registry.spawnDetached(spawnInput());
+
+      let settled = false;
+      const draining = registry.drain(1000).then(() => {
+        settled = true;
+      });
+
+      await Promise.resolve();
+      expect(settled).toBe(false);
+
+      resolveRun?.(makeResult());
+      await draining;
+      expect(settled).toBe(true);
+    });
   });
 
   // ─── finalize ───

--- a/test/unit/agent/tools/friday-agent-subagent-tools.test.ts
+++ b/test/unit/agent/tools/friday-agent-subagent-tools.test.ts
@@ -93,6 +93,7 @@ function mockRegistry(overrides?: Partial<FridaySubagentRegistry>): FridaySubage
   return {
     spawn: vi.fn().mockResolvedValue(makeOutcome()),
     spawnDetached: vi.fn().mockReturnValue(makeDetachedResult()),
+    drain: vi.fn().mockResolvedValue(undefined),
     startRun: vi.fn().mockResolvedValue(makeOutcome()),
     waitForCompletion: vi.fn().mockResolvedValue(makeOutcome()),
     finalize: vi.fn(),


### PR DESCRIPTION
## Summary
- drain detached subagent work before hub shutdown and ignore late closed-db writes during teardown
- raise slow mock E2E budgets so full-suite release verification remains stable under load
- recover stale macOS companion release locks and fix closure local server shutdown so closure commands exit cleanly

## Validation
- npm run typecheck
- npx vitest run test/unit/agent/subagent/friday-subagent-registry.test.ts test/unit/agent/tools/friday-agent-subagent-tools.test.ts
- npx vitest run test/e2e/mock/friday-mock-sessions.e2e.test.ts
- npx vitest run test/e2e/mock/friday-mock-multi-turn.e2e.test.ts
- npx vitest run test/e2e/mock/friday-mock-tool-invocations.e2e.test.ts
- npx vitest run test/e2e/mock/friday-mock-journeys.e2e.test.ts
- npx vitest run test/integration/system/friday-system-companion-release.integration.test.ts
- npm run test:e2e:closure:local