### PR TITLE
Implement deterministic control-plane routing for daemon and MCP

### DIFF
--- a/src/agent/runtime/friday-agent-system-prompt-builder.ts
+++ b/src/agent/runtime/friday-agent-system-prompt-builder.ts
@@ -142,18 +142,20 @@ export function buildFridayAgentSystemPrompt(
     "\n\n" +
     timeContextSection +
     "Tool selection strategy:\n" +
+    "- Capabilities/runtime questions (what Friday can do, which features are enabled/disabled, messaging/MCP/provider status): use capabilities first — never guess runtime state\n" +
+    "- Status/progress questions (current task, delegated task progress, latest result, blockers): use task_status first — never fabricate progress\n" +
+    "- Approval and workflow control commands (approve, reject, cancel, retry, workflow status): use the corresponding control tool directly\n" +
     "- Information lookup (news, facts, documentation): use web_search first, then web_fetch for specific URLs\n" +
     "- Fetch a specific URL (articles, docs, pages): use web_fetch — HTML is auto-parsed to readable text\n" +
     "- JS-heavy sites (Reddit, Twitter/X, SPA apps), interactive pages, login-required pages: use browser (snapshot action to read content)\n" +
     "- If web_fetch returns unreadable/empty content for a URL, IMMEDIATELY retry with browser instead\n" +
     `- For time-sensitive requests (latest/current/today/news/最新/今天/最近): ${timelinessReference} Use recency-filtered search when available, verify publication dates, and include absolute dates plus source URLs in the answer. If verifiable dates are unavailable, explicitly say the latestness is unverified.\n` +
-    "- When the user asks what Friday can do right now, which capabilities are enabled in this deployment, or whether messaging/MCP/provider mutations are currently available, use capabilities first\n" +
-    "- When the user asks what you are doing right now, whether a delegated task is still running, or what the latest task result/blocker is, use task_status first\n" +
     "- Local computer orchestration: use system first for snapshots, app/project handoff, approvals, and control leases; fall back to desktop only when system intent resolution is insufficient\n" +
     "- Provider/LLM management (switch model, add API key, configure OAuth): use provider tool\n" +
     "- Friday skills: use skills_list first to discover currently available skills, then use skill_run with the chosen skill ID\n" +
     "- Diagnosis, recovery, and self-healing review requests: prefer existing starter skills such as issue review, runtime snapshot, and repair-readiness summaries before generating anything new\n" +
     "- For OAuth providers like Claude Max/Pro: use provider oauth_init (it can auto-create or reuse the Anthropic OAuth provider), return URL to user, then provider oauth_complete; if the user asked to switch Friday to Claude, follow with provider set_default\n" +
+    "- MCP (external servers): MCP is a protocol bridge, not the primary orchestration layer. Use built-in tools and workflows before falling back to external MCP servers. Do not encode business plans or orchestration logic into MCP prompt/resource contracts.\n" +
     (messagingEnabled
       ? "- Send messages to users on other platforms: use message\n"
       : "- Multi-channel messaging is unavailable in this deployment, so suggest local alternatives when users ask for cross-platform sends.\n") +
@@ -169,6 +171,7 @@ export function buildFridayAgentSystemPrompt(
     "\n\n" +
     "Behavior rules:\n" +
     "- Be direct and action-oriented. Use tools immediately when a task requires them.\n" +
+    "- For status checks, capability queries, approval commands, and workflow control, prefer deterministic responses over free exploration. These are answered from runtime state, not by reasoning.\n" +
     "- For status/progress answers, use deterministic state from task_status or get_subagent instead of guessing.\n" +
     "- Never say you cannot do something that your currently registered tools support.\n" +
     "- If a capability is not available in this deployment, explain that clearly and suggest the closest available alternative.\n" +

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -16,6 +16,11 @@ import {
 } from "#workflows";
 import type { JsonObject } from "#workflows";
 
+import { classifyFridayExecution } from "../../sessions/services/friday-execution-classifier.js";
+import { dispatchDeterministic } from "../../sessions/services/friday-deterministic-dispatch.js";
+import type { FridayDeterministicDispatchDeps } from "../../sessions/services/friday-deterministic-dispatch.js";
+import { dispatchManagedAsync } from "../../sessions/services/friday-managed-async-dispatch.js";
+import type { FridayManagedAsyncDispatchDeps } from "../../sessions/services/friday-managed-async-dispatch.js";
 import type { CreateFridayApiRuntimeDeps, FridayApiRuntime } from "./friday-api-runtime.types.js";
 import { createFridayAuthService } from "../auth/friday-auth-service.js";
 import { createFridayTokenValidator } from "../auth/friday-token-validator.js";
@@ -1558,10 +1563,10 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
 
   const resolveAgentMirrorIdempotencyKey = (input: {
     runId: string;
-    kind: "planning" | "assistant" | "planning-reject";
+    kind: "planning" | "assistant" | "planning-reject" | "deterministic";
     status?: FridayAgentRunStatus;
   }): string => {
-    if (input.kind === "planning-reject" || !agentRepo) {
+    if (input.kind === "planning-reject" || input.kind === "deterministic" || !agentRepo) {
       return `agent-run:${input.runId}:${input.kind}`;
     }
     const run = deps.db.withReadConnection((reader) => agentRepo.getById(reader, input.runId));
@@ -1726,6 +1731,90 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
           };
         }
       }
+
+      // ── Deterministic / managed control-plane dispatch (Rules 3/5) ──
+      const resolvedTurnKindForClassifier = conversationContext?.turnKind ?? "new_topic";
+      const executionClass = classifyFridayExecution({
+        task,
+        turnKind: resolvedTurnKindForClassifier,
+        focusState,
+      });
+      const apiDispatchDeps: FridayDeterministicDispatchDeps = {
+        capabilitySnapshotGetter: deps.capabilitySnapshotGetter,
+        taskStatusSnapshotGetter: deps.taskStatusSnapshotGetter,
+        getDaemonStatus: deps.daemonStatusGetter,
+        listMcpServers: deps.listMcpServers,
+        approvalService,
+        workflowExecutionService: workflowRuntime.execution,
+      };
+      const managedAsyncDeps: FridayManagedAsyncDispatchDeps = {
+        workflowExecutionService: workflowRuntime.execution,
+      };
+      const finalizeControlPlaneResult = async (responseText: string) => {
+        const result = {
+          runId: input.runId,
+          status: "completed" as const,
+          response: responseText,
+          toolCallCount: 0,
+          durationMs: 0,
+          usageInput: 0,
+          usageOutput: 0,
+        };
+        if (input.sessionKey) {
+          await sessionService.addMessage(input.sessionKey, {
+            role: "assistant",
+            content: result.response,
+            contentText: result.response,
+            idempotencyKey: resolveAgentMirrorIdempotencyKey({
+              runId: result.runId,
+              kind: "deterministic",
+            }),
+          }).catch(() => undefined);
+          await sessionService.setConversationFocus(
+            input.sessionKey,
+            finalizeFridayConversationFocus({
+              task,
+              responseText: result.response,
+              runId: result.runId,
+              turnKind: resolvedTurnKindForClassifier,
+              focusState,
+              currentUserSequence,
+              replyAnchorMessageId,
+              replyAnchorSequence,
+              pendingPlanRunId: resolvedTurnKindForClassifier === "status_check" ? undefined : null,
+              nowIso: deps.nowIso(),
+            }),
+          ).catch(() => undefined);
+        }
+        return result;
+      };
+
+      if (executionClass.category === "sync_immediate") {
+        const deterministicResult = await dispatchDeterministic(
+          {
+            classification: executionClass,
+            sessionKey: input.sessionKey,
+            runId: input.runId,
+            actorId: input.principalId,
+          },
+          apiDispatchDeps,
+        );
+        if (deterministicResult.handled && deterministicResult.response) {
+          return await finalizeControlPlaneResult(deterministicResult.response);
+        }
+      }
+      if (executionClass.category === "managed_async") {
+        const managedResult = await dispatchManagedAsync(
+          {
+            classification: executionClass,
+          },
+          managedAsyncDeps,
+        );
+        if (managedResult.handled && managedResult.response) {
+          return await finalizeControlPlaneResult(managedResult.response);
+        }
+      }
+      // ── End deterministic dispatch ──
 
       if (input.sessionKey && agentPlanningGate) {
           const resolvedTurnKind = conversationContext?.turnKind ?? "new_topic";

--- a/src/api/runtime/friday-api-runtime.types.ts
+++ b/src/api/runtime/friday-api-runtime.types.ts
@@ -1,4 +1,5 @@
 import type { FridaySqliteLayer } from "#state";
+import type { FridayDaemonStatus } from "#daemon";
 import type { FridayHubConfigManagerService } from "#hub";
 import type { FridayOutboxQueueService } from "#satellites";
 import type { FridayAccessTokenClaims, FridayRole } from "../model/friday-api-auth.types.js";
@@ -154,6 +155,10 @@ export interface CreateFridayApiRuntimeDeps {
   /** Optional deterministic task status getter used by context evidence selection. */
   taskStatusSnapshotGetter?: (input: { runId?: string; sessionKey?: string; readOnly: boolean }) =>
     Promise<FridayAgentTaskStatusSnapshot> | FridayAgentTaskStatusSnapshot;
+  /** Optional: daemon status getter for deterministic daemon status responses. */
+  daemonStatusGetter?: () => FridayDaemonStatus;
+  /** Optional: external MCP server lister for deterministic MCP bridge queries. */
+  listMcpServers?: () => ReadonlyArray<{ id: string; transport?: string }>;
   /** Optional: agent event emitter for SSE streaming. */
   agentEventEmitter?: FridayAgentEventEmitter;
   /** Optional: sub-agent registry for sub-agent tree endpoints. */

--- a/src/cli/friday-cli.ts
+++ b/src/cli/friday-cli.ts
@@ -15,10 +15,11 @@
  *   friday converters                                       — list converters
  *   friday pack        <skill-dir> --out <file.tgz>
  *   friday skills init <skill-id> [--template node|shell] [--out <dir>]
+ *   friday daemon      start|stop|restart|status            — manage background daemon
  *   friday --help                                           — usage info
  */
 
-import { existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, realpathSync, unlinkSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -40,14 +41,19 @@ import {
 import { resolveFridayDbPath } from "#state";
 import { resolveSafePath } from "#utilities";
 import Database from "better-sqlite3";
+import {
+  createFridayLocalDaemonService,
+  formatFridayDaemonStatus,
+} from "../daemon/friday-daemon-runtime.js";
 import { runFridayCliLoop } from "./friday-cli-run-loop.js";
 import { FRIDAY_VERSION } from "../lib/version.js";
+import { resolveStateDir } from "../state/paths/friday-state-dir-resolver.js";
 import { runFridayCliAuthLoginAnthropic } from "./friday-cli-auth.js";
 
 // ─── Arg parser ───
 
 export interface ParsedArgs {
-  command: "start" | "list" | "run" | "status" | "help" | "import" | "convert" | "converters" | "pack" | "auth" | "skills";
+  command: "start" | "list" | "run" | "status" | "help" | "import" | "convert" | "converters" | "pack" | "auth" | "skills" | "daemon";
   skillDirs: string[];
   port: number | undefined;
   skillId: string | undefined;
@@ -74,6 +80,8 @@ export interface ParsedArgs {
   skillsSubcommand: string | undefined;
   template: "node" | "shell" | undefined;
   initSkillId: string | undefined;
+  // Daemon-related fields
+  daemonSubcommand: "start" | "stop" | "restart" | "status" | undefined;
 }
 
 export function parseArgs(argv: string[]): ParsedArgs {
@@ -105,6 +113,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
     skillsSubcommand: undefined,
     template: undefined,
     initSkillId: undefined,
+    daemonSubcommand: undefined,
   };
 
   if (args.length === 0) {
@@ -117,7 +126,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
     return result;
   }
 
-  const validCommands = ["start", "list", "run", "status", "import", "convert", "converters", "pack", "auth", "skills"] as const;
+  const validCommands = ["start", "list", "run", "status", "import", "convert", "converters", "pack", "auth", "skills", "daemon"] as const;
   type ValidCommand = (typeof validCommands)[number];
 
   if ((validCommands as readonly string[]).includes(cmd)) {
@@ -129,6 +138,16 @@ export function parseArgs(argv: string[]): ParsedArgs {
 
   // For "converters" command, no additional args needed
   if (cmd === "converters") {
+    return result;
+  }
+
+  // For "daemon" command, parse the subcommand
+  if (cmd === "daemon") {
+    const sub = args[1];
+    const validSubs = ["start", "stop", "restart", "status"] as const;
+    if (sub && (validSubs as readonly string[]).includes(sub)) {
+      result.daemonSubcommand = sub as (typeof validSubs)[number];
+    }
     return result;
   }
 
@@ -335,6 +354,9 @@ Usage:
 
   friday skills init <skill-id> [--template node|shell] [--out <dir>]
       Create a minimal local skill template with manifest, entrypoint, and SKILL.md.
+
+  friday daemon start|stop|restart|status
+      Manage the Friday background daemon process.
 
   friday --help
       Show this help message.
@@ -1578,15 +1600,74 @@ async function cmdAuth(parsed: ParsedArgs): Promise<void> {
 }
 
 function cmdStatus(): void {
-  // v1: No persistent hub process or IPC socket yet.
-  // Report CLI version and basic system info.
   const version = FRIDAY_VERSION;
+  const stateDir = resolveStateDir();
+  const daemonService = createFridayLocalDaemonService({
+    moduleUrl: import.meta.url,
+    stateDir,
+    version,
+  });
   console.log(`Friday CLI v${version}`);
   console.log(`Node.js ${process.version}`);
   console.log(`Platform: ${process.platform} ${process.arch}`);
   console.log("");
-  console.log("Hub status: not detectable (no IPC socket in v1)");
-  console.log("Start the hub with: friday start");
+  console.log(formatFridayDaemonStatus(daemonService.status()));
+  console.log(`State dir: ${stateDir}`);
+}
+
+// ─── Daemon ───
+
+async function cmdDaemon(parsed: ParsedArgs): Promise<void> {
+  const sub = parsed.daemonSubcommand;
+  if (!sub) {
+    console.error("Usage: friday daemon start|stop|restart|status");
+    process.exitCode = 1;
+    return;
+  }
+
+  const stateDir = resolveStateDir();
+  const service = createFridayLocalDaemonService({
+    moduleUrl: import.meta.url,
+    stateDir,
+    version: FRIDAY_VERSION,
+  });
+
+  switch (sub) {
+    case "start": {
+      const result = await service.start();
+      if (result.ok) {
+        console.log(`Friday daemon started (PID ${String(result.value.pid)})`);
+      } else {
+        console.error(`Failed to start daemon: ${result.error.message}`);
+        process.exitCode = 1;
+      }
+      break;
+    }
+    case "stop": {
+      const result = await service.stop();
+      if (result.ok) {
+        console.log("Friday daemon stopped");
+      } else {
+        console.error(`Failed to stop daemon: ${result.error.message}`);
+        process.exitCode = 1;
+      }
+      break;
+    }
+    case "restart": {
+      const result = await service.restart();
+      if (result.ok) {
+        console.log(`Friday daemon restarted (PID ${String(result.value.pid)})`);
+      } else {
+        console.error(`Failed to restart daemon: ${result.error.message}`);
+        process.exitCode = 1;
+      }
+      break;
+    }
+    case "status": {
+      console.log(formatFridayDaemonStatus(service.status()));
+      break;
+    }
+  }
 }
 
 function padEnd(s: string, len: number): string {
@@ -1645,6 +1726,9 @@ async function main(): Promise<void> {
       break;
     case "skills":
       await cmdSkills(parsed);
+      break;
+    case "daemon":
+      await cmdDaemon(parsed);
       break;
     case "help":
     default:

--- a/src/daemon/friday-daemon-runtime.ts
+++ b/src/daemon/friday-daemon-runtime.ts
@@ -1,0 +1,182 @@
+import { spawn } from "node:child_process";
+import {
+  closeSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { resolveFridayDaemonPaths } from "./friday-daemon-paths.js";
+import { createFridayDaemonService } from "./friday-daemon-service.js";
+import type { FridayDaemonService } from "./friday-daemon-service.js";
+import type { FridayDaemonStatus } from "./friday-daemon.types.js";
+
+export interface FridayDaemonLaunchSpec {
+  readonly repoRoot: string;
+  readonly runnerPath: string;
+  readonly command: string;
+  readonly args: string[];
+  readonly cwd: string;
+  readonly env: NodeJS.ProcessEnv;
+}
+
+export interface ResolveFridayDaemonLaunchSpecInput {
+  readonly moduleUrl: string;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly command?: string;
+}
+
+export interface CreateFridayLocalDaemonServiceInput {
+  readonly moduleUrl: string;
+  readonly stateDir: string;
+  readonly version?: string;
+  readonly shutdownGraceMs?: number;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly command?: string;
+}
+
+export function resolveFridayRepoRootFromModuleUrl(moduleUrl: string): string {
+  return resolve(dirname(fileURLToPath(moduleUrl)), "..", "..");
+}
+
+export function resolveFridayDaemonLaunchSpec(
+  input: ResolveFridayDaemonLaunchSpecInput,
+): FridayDaemonLaunchSpec {
+  const repoRoot = resolveFridayRepoRootFromModuleUrl(input.moduleUrl);
+  const runnerPath = join(repoRoot, "scripts", "ops", "friday-service-run.sh");
+
+  return {
+    repoRoot,
+    runnerPath,
+    command: input.command ?? "bash",
+    args: [runnerPath, repoRoot],
+    cwd: repoRoot,
+    env: input.env ?? process.env,
+  };
+}
+
+export function formatFridayDaemonStatus(status: FridayDaemonStatus): string {
+  if (status.running) {
+    const uptimeStr = status.uptime !== null
+      ? `${String(Math.floor(status.uptime / 1000))}s`
+      : "unknown";
+    return `Friday daemon: running (PID ${String(status.pid)}, uptime ${uptimeStr})`;
+  }
+  return "Friday daemon: stopped";
+}
+
+export function createFridayLocalDaemonService(
+  input: CreateFridayLocalDaemonServiceInput,
+): FridayDaemonService {
+  const paths = resolveFridayDaemonPaths(input.stateDir);
+  mkdirSync(paths.runtimeDir, { recursive: true });
+
+  const launchSpec = resolveFridayDaemonLaunchSpec({
+    moduleUrl: input.moduleUrl,
+    env: input.env,
+    command: input.command,
+  });
+
+  return createFridayDaemonService({
+    config: {
+      paths,
+      shutdownGraceMs: input.shutdownGraceMs ?? 5000,
+      version: input.version,
+    },
+    pidFileDeps: {
+      readFile: (filePath: string) => {
+        try {
+          return readFileSync(filePath, "utf-8");
+        } catch {
+          return null;
+        }
+      },
+      writeFile: (filePath: string, content: string) => {
+        writeFileSync(filePath, content, "utf-8");
+      },
+      removeFile: (filePath: string) => {
+        try {
+          unlinkSync(filePath);
+        } catch {
+          // Ignore if the file is already gone.
+        }
+      },
+      mkdirp: (dirPath: string) => {
+        mkdirSync(dirPath, { recursive: true });
+      },
+      isProcessAlive: (pid: number) => {
+        try {
+          process.kill(pid, 0);
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      nowIso: () => new Date().toISOString(),
+    },
+    processControl: {
+      spawnDaemon: (stdoutLog: string, stderrLog: string) => {
+        let stdoutFd: number | undefined;
+        let stderrFd: number | undefined;
+        try {
+          stdoutFd = openSync(stdoutLog, "a");
+          stderrFd = openSync(stderrLog, "a");
+          const child = spawn(launchSpec.command, launchSpec.args, {
+            detached: true,
+            stdio: ["ignore", stdoutFd, stderrFd],
+            env: launchSpec.env,
+            cwd: launchSpec.cwd,
+          });
+          child.unref();
+          const pid = child.pid;
+          if (pid === undefined) {
+            return {
+              ok: false as const,
+              error: { code: "SPAWN_FAILED", message: "Failed to obtain child PID" },
+            };
+          }
+          return { ok: true as const, value: { pid } };
+        } catch (err) {
+          return {
+            ok: false as const,
+            error: {
+              code: "SPAWN_FAILED",
+              message: err instanceof Error ? err.message : String(err),
+            },
+          };
+        } finally {
+          if (typeof stdoutFd === "number") {
+            closeSync(stdoutFd);
+          }
+          if (typeof stderrFd === "number") {
+            closeSync(stderrFd);
+          }
+        }
+      },
+      sendSignal: (pid: number, signal: "SIGTERM" | "SIGKILL") => {
+        try {
+          process.kill(pid, signal);
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      waitForExit: async (pid: number, timeoutMs: number) => {
+        const start = Date.now();
+        while (Date.now() - start < timeoutMs) {
+          try {
+            process.kill(pid, 0);
+          } catch {
+            return true;
+          }
+          await new Promise((resolvePromise) => setTimeout(resolvePromise, 200));
+        }
+        return false;
+      },
+    },
+  });
+}

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -9,6 +9,17 @@ export type {
 } from "./friday-daemon.types.js";
 
 export { resolveFridayDaemonPaths } from "./friday-daemon-paths.js";
+export {
+  createFridayLocalDaemonService,
+  formatFridayDaemonStatus,
+  resolveFridayDaemonLaunchSpec,
+  resolveFridayRepoRootFromModuleUrl,
+} from "./friday-daemon-runtime.js";
+export type {
+  CreateFridayLocalDaemonServiceInput,
+  FridayDaemonLaunchSpec,
+  ResolveFridayDaemonLaunchSpecInput,
+} from "./friday-daemon-runtime.js";
 
 export {
   DAEMON_PID_ERROR_CODES,

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -30,6 +30,7 @@ import { createOnboardingEngine } from "../uix/engine/index.js";
 import { FridayDomainError } from "#errors";
 import { initializeFridayState } from "#state";
 import type { FridayStateRuntime } from "#state";
+import { createFridayLocalDaemonService } from "#daemon";
 import {
   createFridayProviderCostCalculator,
   createFridayProviderPricingCatalog,
@@ -127,6 +128,12 @@ import {
   loadFridayWorkspaceContext,
   parseFridayMcpServersFromEnv,
 } from "#agent";
+import { buildMcpServerToolFilter } from "./friday-mcp-safe-catalog.js";
+import { classifyFridayExecution } from "../sessions/services/friday-execution-classifier.js";
+import { dispatchDeterministic } from "../sessions/services/friday-deterministic-dispatch.js";
+import type { FridayDeterministicDispatchDeps } from "../sessions/services/friday-deterministic-dispatch.js";
+import { dispatchManagedAsync } from "../sessions/services/friday-managed-async-dispatch.js";
+import type { FridayManagedAsyncDispatchDeps } from "../sessions/services/friday-managed-async-dispatch.js";
 import type { FridayImageAnalysisFn } from "#agent";
 import type {
   FridayAgentCapabilitiesSnapshot,
@@ -413,6 +420,11 @@ export async function createFridayHub(
     ? { env: { ...process.env, FRIDAY_STATE_DIR: config.stateDir } as NodeJS.ProcessEnv }
     : undefined;
   stateRuntime = initializeFridayState(stateOpts);
+  const daemonService = createFridayLocalDaemonService({
+    moduleUrl: import.meta.url,
+    stateDir: stateRuntime.stateDir,
+    version: config.serverVersion ?? FRIDAY_HUB_DEFAULT_SERVER_VERSION,
+  });
 
   // 1b. Seed default admin user if users table is empty
   {
@@ -1527,11 +1539,11 @@ export async function createFridayHub(
       return undefined;
     }
 
-    const allowlist = (process.env.FRIDAY_MCP_SERVER_TOOL_ALLOWLIST ?? "")
+    const envAllowlist = (process.env.FRIDAY_MCP_SERVER_TOOL_ALLOWLIST ?? "")
       .split(",")
       .map((value) => value.trim())
       .filter((value) => value.length > 0);
-    const isToolAllowed = (toolName: string) => allowlist.length === 0 || allowlist.includes(toolName);
+    const { isToolAllowed } = buildMcpServerToolFilter(envAllowlist);
     const listAllowedTools = () => agentTools.filter((tool) => isToolAllowed(tool.name));
     const appendMcpServerAudit = (entry: {
       action: string;
@@ -1593,7 +1605,7 @@ export async function createFridayHub(
 
     console.log(
       `[friday] MCP server enabled with ${String(listAllowedTools().length)} tool(s)` +
-      (allowlist.length > 0 ? " (allowlist mode)" : ""),
+      (envAllowlist.length > 0 ? " (allowlist mode)" : " (safe catalog)"),
     );
 
     return {
@@ -2166,10 +2178,10 @@ export async function createFridayHub(
 
   const resolveAgentMirrorIdempotencyKey = (input: {
     runId: string;
-    kind: "planning" | "assistant" | "planning-reject";
+    kind: "planning" | "assistant" | "planning-reject" | "deterministic";
     status?: FridayAgentRunStatus;
   }): string => {
-    if (input.kind === "planning-reject") {
+    if (input.kind === "planning-reject" || input.kind === "deterministic") {
       return `agent-run:${input.runId}:${input.kind}`;
     }
     const run = stateRuntime!.sqlite.withReadConnection((reader) =>
@@ -2949,6 +2961,10 @@ export async function createFridayHub(
     sessionService: hubSessionService,
     capabilitySnapshotGetter: getAgentCapabilitySnapshot,
     taskStatusSnapshotGetter: getAgentTaskStatusSnapshot,
+    daemonStatusGetter: () => daemonService.status(),
+    listMcpServers: mcpAdapter
+      ? () => mcpAdapter.listServers().map((server) => ({ id: server.id, transport: server.transport }))
+      : undefined,
     serverVersion: config.serverVersion ?? FRIDAY_HUB_DEFAULT_SERVER_VERSION,
     serverHost: config.host ?? "127.0.0.1",
     serverPort: config.port ?? 3141,
@@ -4038,6 +4054,22 @@ export async function createFridayHub(
       //    HTTP listener start is handled by CLI run-loop (Batch 2), not here.
 
       // 4. Start channel plugins (route inbound messages to agent runtime)
+
+      // Deterministic dispatch deps — reused across all channel messages.
+      const deterministicDispatchDeps: FridayDeterministicDispatchDeps = {
+        capabilitySnapshotGetter: getAgentCapabilitySnapshot,
+        taskStatusSnapshotGetter: getAgentTaskStatusSnapshot,
+        getDaemonStatus: () => daemonService.status(),
+        listMcpServers: mcpAdapter
+          ? () => mcpAdapter.listServers().map((s) => ({ id: s.id, transport: s.transport }))
+          : undefined,
+        approvalService: workflowRuntime.approval,
+        workflowExecutionService: workflowRuntime.execution,
+      };
+      const managedAsyncDispatchDeps: FridayManagedAsyncDispatchDeps = {
+        workflowExecutionService: workflowRuntime.execution,
+      };
+
       if (channelsConfig.enabled && channelRegistry.list().length > 0) {
         const channelMessageHandler = (msg: FridayChannelMessage) => {
           const text = sanitizeChannelInput(msg.text);
@@ -4239,6 +4271,103 @@ export async function createFridayHub(
                 selectionReasons: preparedTurn.selectionReasons,
                 replyToMessageId: msg.replyTo,
               };
+
+              // ── Deterministic-first dispatch (Rule 5) ──
+              // Attempt to serve sync_immediate requests without the agent.
+              const executionClass = classifyFridayExecution({
+                task: text,
+                turnKind: preparedTurn.turnKind,
+                focusState,
+              });
+
+              const sendControlPlaneResponse = async (responseText: string) => {
+                await hubSessionService.addMessage(sessionKey, {
+                  role: "assistant",
+                  content: responseText,
+                  contentText: responseText,
+                  idempotencyKey: resolveAgentMirrorIdempotencyKey({
+                    runId,
+                    kind: "deterministic",
+                  }),
+                }).catch((err) => {
+                  logChannelIssue({
+                    level: "warn",
+                    code: "W-CH-SESSION-MIRROR-001",
+                    routeId: "hub.channel.session.mirror.deterministic",
+                    error: err,
+                  });
+                });
+
+                const nextPendingPlanRunId = preparedTurn.turnKind === "status_check" ? undefined : null;
+                await hubSessionService.setConversationFocus(
+                  sessionKey,
+                  finalizeFridayConversationFocus({
+                    task: text,
+                    responseText,
+                    runId,
+                    turnKind: preparedTurn.turnKind,
+                    focusState: await hubSessionService.getConversationFocus(sessionKey).catch(() => focusState),
+                    currentUserSequence: inboundMessage?.sequence,
+                    replyAnchorMessageId: preparedTurn.replyAnchorMessageId,
+                    replyAnchorSequence: preparedTurn.replyAnchorSequence,
+                    pendingPlanRunId: nextPendingPlanRunId,
+                    nowIso: nowIso(),
+                  }),
+                ).catch((err) => {
+                  logChannelIssue({
+                    level: "warn",
+                    code: "W-CH-FOCUS-WRITE-001",
+                    routeId: "hub.channel.focus.deterministic",
+                    error: err,
+                  });
+                });
+
+                typingController.stopRun();
+
+                await channelRegistry.send(msg.channelKind, {
+                  chatId: msg.chatId,
+                  text: responseText,
+                  replyTo: msg.id,
+                }).catch((err) => {
+                  logChannelIssue({
+                    level: "error",
+                    code: "E-CH-OUTBOUND-001",
+                    routeId: "hub.channel.delivery.deterministic",
+                    runId,
+                    error: err,
+                  });
+                });
+
+                slowTaskNotifier.stop();
+              };
+
+              if (executionClass.category === "sync_immediate") {
+                const deterministicResult = await dispatchDeterministic(
+                  {
+                    classification: executionClass,
+                    sessionKey,
+                    runId,
+                    actorId: msg.senderId,
+                  },
+                  deterministicDispatchDeps,
+                );
+                if (deterministicResult.handled && deterministicResult.response) {
+                  await sendControlPlaneResponse(deterministicResult.response);
+                  return;
+                }
+              }
+              if (executionClass.category === "managed_async") {
+                const managedResult = await dispatchManagedAsync(
+                  { classification: executionClass },
+                  managedAsyncDispatchDeps,
+                );
+                if (managedResult.handled && managedResult.response) {
+                  await sendControlPlaneResponse(managedResult.response);
+                  return;
+                }
+              }
+              // ── End deterministic dispatch ──
+
               const planningDecision = agentPlanningGate.handleTurn({
                 runId,
                 task: text,

--- a/src/hub/friday-mcp-safe-catalog.ts
+++ b/src/hub/friday-mcp-safe-catalog.ts
@@ -1,0 +1,48 @@
+/**
+ * MCP Self-Server Safe Catalog — Curated set of tools safe to expose via MCP.
+ *
+ * Only read-only, non-mutating, auditable tools belong here.
+ * The env-var allowlist (`FRIDAY_MCP_SERVER_TOOL_ALLOWLIST`) can narrow this
+ * set but never re-expose tools outside it.
+ *
+ * @module hub/friday-mcp-safe-catalog
+ */
+
+/**
+ * Tools considered safe for MCP bridge exposure.
+ * Criteria: read-only, no side-effects, no approval bypass, no exec.
+ */
+export const FRIDAY_MCP_SAFE_CATALOG = new Set([
+  "capabilities",    // read-only runtime facts
+  "task_status",     // read-only status query
+  "skills_list",     // read-only skill listing
+  "agents_list",     // read-only agent listing
+  "web_search",      // information retrieval
+  "web_fetch",       // URL fetching
+  "read",            // file reading (read-only)
+  "memory_search",   // memory recall (read-only)
+]);
+
+export function isMcpSafeCatalogTool(name: string): boolean {
+  return FRIDAY_MCP_SAFE_CATALOG.has(name);
+}
+
+/**
+ * Build the `isToolAllowed` filter for the self MCP server.
+ *
+ * - Empty `envAllowlist`: expose the full safe catalog.
+ * - Non-empty `envAllowlist`: intersect with the safe catalog (can only narrow).
+ */
+export function buildMcpServerToolFilter(envAllowlist: string[]): {
+  isToolAllowed: (toolName: string) => boolean;
+} {
+  if (envAllowlist.length === 0) {
+    return { isToolAllowed: (toolName) => FRIDAY_MCP_SAFE_CATALOG.has(toolName) };
+  }
+
+  const envSet = new Set(envAllowlist);
+  return {
+    isToolAllowed: (toolName) =>
+      FRIDAY_MCP_SAFE_CATALOG.has(toolName) && envSet.has(toolName),
+  };
+}

--- a/src/sessions/services/friday-deterministic-dispatch.ts
+++ b/src/sessions/services/friday-deterministic-dispatch.ts
@@ -1,0 +1,304 @@
+/**
+ * Deterministic Dispatch — Serves classified `sync_immediate` requests
+ * without invoking the LLM agent.
+ *
+ * Each handler calls an existing snapshot getter or service method and
+ * formats the result as a plain-text response string.
+ *
+ * @module sessions/services/friday-deterministic-dispatch
+ */
+
+import type { FridayAgentCapabilitiesSnapshot } from "../../agent/tools/friday-agent-capabilities-tool.js";
+import type { FridayAgentTaskStatusSnapshot } from "../../agent/tools/friday-agent-task-status-tool.js";
+import { formatFridayDaemonStatus } from "../../daemon/friday-daemon-runtime.js";
+import type { FridayDaemonStatus } from "../../daemon/friday-daemon.types.js";
+import type { FridayWorkflowApprovalService } from "../../workflows/services/friday-workflow-approval-service.types.js";
+import type { FridayWorkflowExecutionService, FridayWorkflowRunEntity } from "#workflows";
+import type { FridayExecutionClassification } from "./friday-execution-classifier.js";
+
+// ─── Types ───
+
+export interface FridayDeterministicDispatchResult {
+  readonly handled: boolean;
+  readonly response?: string;
+}
+
+export interface FridayDeterministicDispatchDeps {
+  readonly capabilitySnapshotGetter?: (input: {
+    readOnly: boolean;
+  }) => Promise<FridayAgentCapabilitiesSnapshot> | FridayAgentCapabilitiesSnapshot;
+
+  readonly taskStatusSnapshotGetter?: (input: {
+    runId?: string;
+    sessionKey?: string;
+    readOnly: boolean;
+  }) => Promise<FridayAgentTaskStatusSnapshot> | FridayAgentTaskStatusSnapshot;
+
+  readonly getDaemonStatus?: () => FridayDaemonStatus;
+
+  readonly listMcpServers?: () => ReadonlyArray<{ id: string; transport?: string }>;
+  readonly approvalService?: FridayWorkflowApprovalService;
+  readonly workflowExecutionService?: FridayWorkflowExecutionService;
+}
+
+export interface DispatchDeterministicInput {
+  readonly classification: FridayExecutionClassification;
+  readonly sessionKey?: string;
+  readonly runId?: string;
+  readonly actorId?: string;
+}
+
+// ─── Dispatch ───
+
+export async function dispatchDeterministic(
+  input: DispatchDeterministicInput,
+  deps: FridayDeterministicDispatchDeps,
+): Promise<FridayDeterministicDispatchResult> {
+  const { handler } = input.classification;
+
+  switch (handler) {
+    case "capabilities":
+      return handleCapabilities(deps);
+
+    case "task_status":
+      return handleTaskStatus(input, deps);
+
+    case "daemon_status":
+      return handleDaemonStatus(deps);
+
+    case "mcp_list":
+      return handleMcpList(deps);
+
+    case "approval_decision":
+      return handleApprovalDecision(input, deps);
+
+    case "workflow_query":
+      return handleWorkflowQuery(input, deps);
+
+    default:
+      return { handled: false };
+  }
+}
+
+// ─── Handlers ───
+
+async function handleCapabilities(
+  deps: FridayDeterministicDispatchDeps,
+): Promise<FridayDeterministicDispatchResult> {
+  if (!deps.capabilitySnapshotGetter) {
+    return { handled: false };
+  }
+  try {
+    const snap = await deps.capabilitySnapshotGetter({ readOnly: false });
+    const lines: string[] = ["Current capabilities:"];
+
+    lines.push(`  Read-only mode: ${snap.readOnly ? "yes" : "no"}`);
+    lines.push(`  Messaging: ${snap.messaging.enabled ? `enabled (${snap.messaging.kinds.join(", ")})` : "disabled"}`);
+    lines.push(`  MCP: ${snap.mcp.enabled ? `enabled (${String(snap.mcp.serverCount)} server(s))` : "disabled"}`);
+    lines.push(`  Provider: ${snap.provider.available ? `available (${String(snap.provider.configuredCount)} configured)` : "not available"}`);
+    if (snap.browser.activeMode) {
+      lines.push(`  Browser: ${snap.browser.activeMode}${snap.browser.targetBrowser ? ` (${snap.browser.targetBrowser})` : ""}`);
+    }
+    lines.push(`  System orchestration: ${snap.system.enabled ? "enabled" : "disabled"}`);
+    lines.push(`  Desktop companion: ${snap.desktop.connected ? "connected" : "disconnected"}`);
+
+    return { handled: true, response: lines.join("\n") };
+  } catch {
+    return { handled: false };
+  }
+}
+
+async function handleTaskStatus(
+  input: DispatchDeterministicInput,
+  deps: FridayDeterministicDispatchDeps,
+): Promise<FridayDeterministicDispatchResult> {
+  if (!deps.taskStatusSnapshotGetter) {
+    return { handled: false };
+  }
+  try {
+    const snap = await deps.taskStatusSnapshotGetter({
+      runId: input.runId,
+      sessionKey: input.sessionKey,
+      readOnly: false,
+    });
+
+    const lines: string[] = [];
+
+    if (snap.terminalOutcome) {
+      lines.push(`Task ${snap.terminalOutcome.status}${snap.terminalOutcome.summary ? `: ${snap.terminalOutcome.summary}` : ""}`);
+      if (snap.terminalOutcome.responseText) {
+        lines.push(snap.terminalOutcome.responseText);
+      }
+    } else if (snap.runStatus) {
+      lines.push(`Task status: ${snap.runStatus}${snap.phase ? ` (${snap.phase})` : ""}`);
+      if (snap.task) {
+        lines.push(`Task: ${snap.task}`);
+      }
+      if (snap.latestTool) {
+        lines.push(`Latest tool: ${snap.latestTool}`);
+      }
+      if (typeof snap.elapsedMs === "number") {
+        lines.push(`Elapsed: ${String(Math.round(snap.elapsedMs / 1000))}s`);
+      }
+      if (snap.blockers.length > 0) {
+        lines.push(`Blockers: ${snap.blockers.join(", ")}`);
+      }
+      if (snap.activeSubagents.length > 0) {
+        lines.push(`Active subagents: ${String(snap.activeSubagents.length)}`);
+      }
+    } else {
+      lines.push("No active task at this time.");
+    }
+
+    return { handled: true, response: lines.join("\n") };
+  } catch {
+    return { handled: false };
+  }
+}
+
+function handleDaemonStatus(
+  deps: FridayDeterministicDispatchDeps,
+): FridayDeterministicDispatchResult {
+  if (!deps.getDaemonStatus) {
+    return { handled: false };
+  }
+  return { handled: true, response: formatFridayDaemonStatus(deps.getDaemonStatus()) };
+}
+
+function handleMcpList(
+  deps: FridayDeterministicDispatchDeps,
+): FridayDeterministicDispatchResult {
+  if (!deps.listMcpServers) {
+    return { handled: false };
+  }
+
+  const servers = deps.listMcpServers();
+  if (servers.length === 0) {
+    return { handled: true, response: "No MCP servers configured." };
+  }
+
+  const lines = [`${String(servers.length)} MCP server(s) configured:`];
+  for (const server of servers) {
+    lines.push(`  - ${server.id}${server.transport ? ` (${server.transport})` : ""}`);
+  }
+  return { handled: true, response: lines.join("\n") };
+}
+
+async function handleApprovalDecision(
+  input: DispatchDeterministicInput,
+  deps: FridayDeterministicDispatchDeps,
+): Promise<FridayDeterministicDispatchResult> {
+  const decision = input.classification.extractedParams?.decision;
+  if (!decision || !deps.approvalService) {
+    return { handled: false };
+  }
+
+  const actorId = input.actorId ?? "system";
+  const explicitApprovalId = input.classification.extractedParams?.approvalId;
+
+  if (explicitApprovalId) {
+    return executeApprovalDecision({
+      approvalId: explicitApprovalId,
+      decision,
+      actorId,
+      approvalService: deps.approvalService,
+    });
+  }
+
+  const pending = deps.approvalService.listPending({});
+  if (pending.length === 0) {
+    return { handled: true, response: "No pending approvals at this time." };
+  }
+  if (pending.length > 1) {
+    const lines = [
+      `Multiple pending approvals require clarification before ${decision}:`,
+    ];
+    for (const approval of pending) {
+      lines.push(`  - ${approval.id} (run ${approval.runId}, node ${approval.nodeId})`);
+    }
+    return { handled: true, response: lines.join("\n") };
+  }
+
+  return executeApprovalDecision({
+    approvalId: pending[0]!.id,
+    decision,
+    actorId,
+    approvalService: deps.approvalService,
+  });
+}
+
+async function executeApprovalDecision(input: {
+  approvalId: string;
+  decision: "approve" | "reject";
+  actorId: string;
+  approvalService: FridayWorkflowApprovalService;
+}): Promise<FridayDeterministicDispatchResult> {
+  try {
+    const result = input.decision === "approve"
+      ? await input.approvalService.approve({
+          approvalId: input.approvalId,
+          decidedByUserId: input.actorId,
+          comment: undefined,
+        })
+      : await input.approvalService.reject({
+          approvalId: input.approvalId,
+          decidedByUserId: input.actorId,
+          comment: undefined,
+        });
+    const action = input.decision === "approve" ? "Approved" : "Rejected";
+    return {
+      handled: true,
+      response: `${action} approval ${result.approval.id} for workflow run ${result.approval.runId}. Resumed: ${result.resumed ? "yes" : "no"}.`,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      handled: true,
+      response: `Unable to ${input.decision} approval ${input.approvalId}: ${message}`,
+    };
+  }
+}
+
+function handleWorkflowQuery(
+  input: DispatchDeterministicInput,
+  deps: FridayDeterministicDispatchDeps,
+): FridayDeterministicDispatchResult {
+  if (!deps.workflowExecutionService) {
+    return { handled: false };
+  }
+
+  const explicitRunId = input.classification.extractedParams?.runId;
+  if (explicitRunId) {
+    const run = deps.workflowExecutionService.getRun(explicitRunId);
+    if (!run) {
+      return { handled: true, response: `Workflow run ${explicitRunId} not found.` };
+    }
+    return { handled: true, response: formatWorkflowRunDetail(run) };
+  }
+
+  const activeRuns = deps.workflowExecutionService.listActiveRuns(10);
+  if (activeRuns.length === 0) {
+    return { handled: true, response: "No active workflow runs." };
+  }
+
+  const lines = [`${String(activeRuns.length)} active workflow run(s):`];
+  for (const run of activeRuns) {
+    lines.push(`  - ${run.id} (${run.status}) workflow ${run.workflowId}`);
+  }
+  return { handled: true, response: lines.join("\n") };
+}
+
+function formatWorkflowRunDetail(run: FridayWorkflowRunEntity): string {
+  const lines = [
+    `Workflow run ${run.id}: ${run.status}`,
+    `Workflow: ${run.workflowId}`,
+    `Started: ${run.startedAt}`,
+  ];
+  if (run.finishedAt) {
+    lines.push(`Finished: ${run.finishedAt}`);
+  }
+  if (run.failure) {
+    lines.push(`Failure: ${run.failure.code} — ${run.failure.message}`);
+  }
+  return lines.join("\n");
+}

--- a/src/sessions/services/friday-execution-classifier.ts
+++ b/src/sessions/services/friday-execution-classifier.ts
@@ -1,0 +1,158 @@
+/**
+ * Execution Classifier — Categorizes incoming requests into deterministic,
+ * managed-async, or agent-exception paths.
+ *
+ * Sits between conversation turn classification and the planning gate / agent
+ * runtime.  When a request is classified as `sync_immediate`, the hub can
+ * serve it deterministically without invoking the LLM.
+ *
+ * @module sessions/services/friday-execution-classifier
+ */
+
+import type {
+  FridayConversationTurnKind,
+  FridaySessionConversationFocusState,
+} from "../model/friday-session.types.js";
+
+// ─── Types ───
+
+export type FridayExecutionCategory =
+  | "sync_immediate"
+  | "managed_async"
+  | "agent_exception_path";
+
+export interface FridayExecutionClassification {
+  readonly category: FridayExecutionCategory;
+  readonly handler?: string;
+  readonly extractedParams?: {
+    readonly approvalId?: string;
+    readonly runId?: string;
+    readonly decision?: "approve" | "reject";
+    readonly controlAction?: "cancel" | "retry" | "resume";
+  };
+}
+
+export interface ClassifyFridayExecutionInput {
+  readonly task: string;
+  readonly turnKind: FridayConversationTurnKind;
+  readonly focusState?: FridaySessionConversationFocusState | null;
+}
+
+// ─── Hint patterns ───
+
+const CAPABILITY_QUERY =
+  /\b(capabilities?|what can\b|can (?:friday|you)\b.*\bdo\b|enabled|disabled|deployment|runtime facts?)\b/i;
+const CHINESE_CAPABILITY_QUERY =
+  /(能力|能做什么|启用|禁用|部署|运行时|是否可用|是否启用)/;
+
+const APPROVE_REJECT =
+  /^\s*(approve|reject|yes,?\s*approve|no,?\s*reject|通过|拒绝|批准|否决)(?:\s+([A-Za-z0-9:_-]+))?\s*[.!?]?\s*$/i;
+
+const WORKFLOW_CONTROL =
+  /^\s*(cancel|retry|resume|取消|重试|恢复)(?:\s+([A-Za-z0-9:_-]+))?\s*[.!?]?\s*$/i;
+
+const DAEMON_STATUS =
+  /\b(daemon status|daemon\b.*\brunning|is friday running|friday process|后台进程|守护进程状态)\b/i;
+
+const MCP_LIST =
+  /\b(list mcp|mcp servers?|show mcp|what mcp|哪些mcp|mcp列表|mcp服务)\b/i;
+
+const WORKFLOW_QUERY =
+  /\b(list workflows?|workflow status|workflow runs?|show workflows?|工作流状态|工作流列表)\b/i;
+const WORKFLOW_QUERY_WITH_RUN =
+  /\b(?:workflow status|workflow run|workflow runs?|show workflow(?: run)? status)\s+([A-Za-z0-9:_-]+)\b/i;
+
+function normalizeDecision(raw: string): "approve" | "reject" {
+  if (/^(reject|no,?\s*reject|拒绝|否决)$/i.test(raw)) {
+    return "reject";
+  }
+  return "approve";
+}
+
+function normalizeControlAction(raw: string): "cancel" | "retry" | "resume" {
+  if (/^(cancel|取消)$/i.test(raw)) {
+    return "cancel";
+  }
+  if (/^(retry|重试)$/i.test(raw)) {
+    return "retry";
+  }
+  return "resume";
+}
+
+// ─── Classifier ───
+
+export function classifyFridayExecution(
+  input: ClassifyFridayExecutionInput,
+): FridayExecutionClassification {
+  const { task, turnKind, focusState } = input;
+  const normalized = task.trim();
+
+  // If the planning gate has a pending plan, approval / rejection commands
+  // must go through the planning gate (existing path), not deterministic dispatch.
+  const hasPendingPlan = !!focusState?.pendingPlanRunId;
+
+  // 1. Status checks (already classified by turn classifier)
+  if (turnKind === "status_check" && !hasPendingPlan) {
+    return { category: "sync_immediate", handler: "task_status" };
+  }
+
+  // 2. Workflow control commands
+  const workflowControlMatch = normalized.match(WORKFLOW_CONTROL);
+  if (workflowControlMatch) {
+    return {
+      category: "managed_async",
+      handler: "workflow_control",
+      extractedParams: {
+        controlAction: normalizeControlAction(workflowControlMatch[1]!),
+        ...(workflowControlMatch[2] ? { runId: workflowControlMatch[2] } : {}),
+      },
+    };
+  }
+
+  // 3. Approval / rejection commands
+  const approvalMatch = normalized.match(APPROVE_REJECT);
+  if (approvalMatch) {
+    if (hasPendingPlan && !approvalMatch[2]) {
+      // Defer to planning gate
+      return { category: "agent_exception_path" };
+    }
+    return {
+      category: "sync_immediate",
+      handler: "approval_decision",
+      extractedParams: {
+        decision: normalizeDecision(approvalMatch[1]!),
+        ...(approvalMatch[2] ? { approvalId: approvalMatch[2] } : {}),
+      },
+    };
+  }
+
+  // 4. Daemon status
+  if (DAEMON_STATUS.test(normalized)) {
+    return { category: "sync_immediate", handler: "daemon_status" };
+  }
+
+  // 5. MCP server queries
+  if (MCP_LIST.test(normalized)) {
+    return { category: "sync_immediate", handler: "mcp_list" };
+  }
+
+  // 6. Workflow queries
+  if (WORKFLOW_QUERY.test(normalized)) {
+    const runMatch = normalized.match(WORKFLOW_QUERY_WITH_RUN);
+    return {
+      category: "sync_immediate",
+      handler: "workflow_query",
+      extractedParams: runMatch?.[1]
+        ? { runId: runMatch[1] }
+        : undefined,
+    };
+  }
+
+  // 7. Capability queries
+  if (CAPABILITY_QUERY.test(normalized) || CHINESE_CAPABILITY_QUERY.test(normalized)) {
+    return { category: "sync_immediate", handler: "capabilities" };
+  }
+
+  // Default: agent handles it
+  return { category: "agent_exception_path" };
+}

--- a/src/sessions/services/friday-managed-async-dispatch.ts
+++ b/src/sessions/services/friday-managed-async-dispatch.ts
@@ -1,0 +1,74 @@
+import type { FridayWorkflowExecutionService } from "#workflows";
+
+import type { FridayExecutionClassification } from "./friday-execution-classifier.js";
+
+export interface FridayManagedAsyncDispatchResult {
+  readonly handled: boolean;
+  readonly response?: string;
+}
+
+export interface FridayManagedAsyncDispatchDeps {
+  readonly workflowExecutionService?: FridayWorkflowExecutionService;
+}
+
+export interface DispatchManagedAsyncInput {
+  readonly classification: FridayExecutionClassification;
+}
+
+export async function dispatchManagedAsync(
+  input: DispatchManagedAsyncInput,
+  deps: FridayManagedAsyncDispatchDeps,
+): Promise<FridayManagedAsyncDispatchResult> {
+  if (input.classification.handler !== "workflow_control") {
+    return { handled: false };
+  }
+  if (!deps.workflowExecutionService) {
+    return { handled: false };
+  }
+
+  const controlAction = input.classification.extractedParams?.controlAction;
+  const runId = input.classification.extractedParams?.runId;
+  if (!controlAction) {
+    return { handled: false };
+  }
+  if (!runId) {
+    return {
+      handled: true,
+      response: `Please specify a workflow run id to ${controlAction}.`,
+    };
+  }
+
+  try {
+    switch (controlAction) {
+      case "cancel": {
+        const run = await deps.workflowExecutionService.cancelRun(runId);
+        return {
+          handled: true,
+          response: `Workflow run ${run.id} cancelled. Current status: ${run.status}.`,
+        };
+      }
+      case "retry": {
+        const run = await deps.workflowExecutionService.retryRun(runId);
+        return {
+          handled: true,
+          response: `Workflow run ${run.id} retried. Current status: ${run.status}.`,
+        };
+      }
+      case "resume": {
+        const run = await deps.workflowExecutionService.resumeRun(runId);
+        return {
+          handled: true,
+          response: `Workflow run ${run.id} resumed. Current status: ${run.status}.`,
+        };
+      }
+      default:
+        return { handled: false };
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      handled: true,
+      response: `Unable to ${controlAction} workflow run ${runId}: ${message}`,
+    };
+  }
+}

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -50,6 +50,7 @@ export { applyFridayWritePragmas, applyFridayReadPragmas } from "./sqlite/friday
 export interface InitializeFridayStateOptions extends LoadFridayConfigOptions {}
 
 export interface FridayStateRuntime {
+  stateDir: string;
   config: LoadedFridayConfig;
   sqlite: FridaySqliteLayer;
   telemetry: FridayMigrationTelemetryWriter;
@@ -95,6 +96,7 @@ export function initializeFridayState(
   });
 
   return {
+    stateDir,
     config: loadedConfig,
     sqlite,
     telemetry,

--- a/src/workflows/services/friday-workflow-execution-service.ts
+++ b/src/workflows/services/friday-workflow-execution-service.ts
@@ -109,6 +109,7 @@ export interface FridayWorkflowExecutionService {
     status?: WorkflowRunStatus,
     limit?: number,
   ): FridayWorkflowRunEntity[];
+  listActiveRuns(limit?: number): FridayWorkflowRunEntity[];
   getRunNodes(
     runId: UUID,
     status?: string,
@@ -1487,6 +1488,13 @@ export function createFridayWorkflowExecutionService(
       return deps.db.withReadConnection((db) =>
         deps.runRepo.listRunsByWorkflow(db, workflowId, status, limit),
       );
+    },
+
+    listActiveRuns(limit) {
+      const runs = deps.db.withReadConnection((db) =>
+        deps.runRepo.listActiveRuns(db),
+      );
+      return typeof limit === "number" ? runs.slice(0, limit) : runs;
     },
 
     getRunNodes(runId, status) {

--- a/test/e2e/mock/friday-openclaw-parity-closure.e2e.test.ts
+++ b/test/e2e/mock/friday-openclaw-parity-closure.e2e.test.ts
@@ -1041,7 +1041,7 @@ describe("Friday OpenClaw Parity Closure E2E — Desktop Enablement", () => {
 });
 
 describe("Friday OpenClaw Parity Closure E2E — MCP Enablement", () => {
-  it("mcp enabled route closure: mcp tool lists configured servers and returns user-visible response", async () => {
+  it("mcp discovery route closure: configured servers are returned from the deterministic control plane", async () => {
     const mcpConfig = JSON.stringify([
       {
         id: "local-mcp",
@@ -1062,15 +1062,6 @@ describe("Friday OpenClaw Parity Closure E2E — MCP Enablement", () => {
           const providerId = env.providers.anthropic!.providerId;
           const model = env.providers.anthropic!.model;
           const mock = env.mockFor("anthropic");
-          mock.enqueue({
-            type: "tool_use",
-            toolName: "mcp",
-            toolInput: { action: "list_servers" },
-          });
-          mock.enqueue({
-            type: "text",
-            text: "MCP server list fetched.",
-          });
 
           const res = await apiFetch<AgentRunResult>(
             env.baseUrl,
@@ -1088,16 +1079,15 @@ describe("Friday OpenClaw Parity Closure E2E — MCP Enablement", () => {
           expect(res.status).toBe(200);
           expect(res.json.ok).toBe(true);
           expect(res.json.data.status).toBe("completed");
-          expect(res.json.data.toolCallCount).toBeGreaterThanOrEqual(1);
-          expect(res.json.data.responseText ?? res.json.data.response).toContain("MCP server list fetched");
-          expect(mock.calls.length).toBe(2);
+          expect(res.json.data.toolCallCount).toBe(0);
+          const responseText = res.json.data.responseText ?? res.json.data.response;
+          expect(responseText).toContain("1 MCP server(s) configured");
+          expect(responseText).toContain("local-mcp");
+          expect(mock.calls.length).toBe(0);
 
-          const toolResultContent = extractLastToolResultContent(mock.calls[1]?.bodyJson);
-          expect(toolResultContent).toContain("\"id\": \"local-mcp\"");
-          expect(toolResultContent).toContain("\"command\": \"echo\"");
           const evidencePath = writeEnablementEvidence(
-            `mcp-list-servers-${Date.now()}.json`,
-            toolResultContent,
+            `mcp-list-servers-${Date.now()}.txt`,
+            responseText,
           );
           expect(fs.statSync(evidencePath).size).toBeGreaterThan(0);
 
@@ -1105,10 +1095,7 @@ describe("Friday OpenClaw Parity Closure E2E — MCP Enablement", () => {
           const toolEnd = runEvents.find((event) =>
             event.eventName === "agent.run.tool_end" && event.payload.toolName === "mcp"
           );
-          expect(toolEnd).toBeDefined();
-          expect(toolEnd!.payload.isError).toBe(false);
-          expect(toolEnd!.payload.routeId).toBe("agent.execute.tool");
-          expect(toolEnd!.payload.correlationId).toBe(res.json.data.runId);
+          expect(toolEnd).toBeUndefined();
         } finally {
           await env.cleanup();
         }
@@ -1116,7 +1103,7 @@ describe("Friday OpenClaw Parity Closure E2E — MCP Enablement", () => {
     );
   }, 90_000);
 
-  it("mcp input-recovery route closure: missing action auto-falls back to list_servers", async () => {
+  it("generic mcp info route closure: broad MCP queries are served without agent fallback", async () => {
     const mcpConfig = JSON.stringify([
       {
         id: "local-mcp",
@@ -1137,15 +1124,6 @@ describe("Friday OpenClaw Parity Closure E2E — MCP Enablement", () => {
           const providerId = env.providers.anthropic!.providerId;
           const model = env.providers.anthropic!.model;
           const mock = env.mockFor("anthropic");
-          mock.enqueue({
-            type: "tool_use",
-            toolName: "mcp",
-            toolInput: {},
-          });
-          mock.enqueue({
-            type: "text",
-            text: "MCP fallback completed.",
-          });
 
           const res = await apiFetch<AgentRunResult>(
             env.baseUrl,
@@ -1163,40 +1141,23 @@ describe("Friday OpenClaw Parity Closure E2E — MCP Enablement", () => {
           expect(res.status).toBe(200);
           expect(res.json.ok).toBe(true);
           expect(res.json.data.status).toBe("completed");
-          expect(res.json.data.toolCallCount).toBeGreaterThanOrEqual(1);
-          expect(res.json.data.responseText ?? res.json.data.response).toContain("MCP fallback completed");
-          expect(mock.calls.length).toBe(2);
+          expect(res.json.data.toolCallCount).toBe(0);
+          const responseText = res.json.data.responseText ?? res.json.data.response;
+          expect(responseText).toContain("1 MCP server(s) configured");
+          expect(responseText).toContain("local-mcp");
+          expect(mock.calls.length).toBe(0);
 
-          const toolResultContent = extractLastToolResultContent(mock.calls[1]?.bodyJson);
-          expect(toolResultContent).toContain("[auto-recovery:mcp->discovery]");
-          expect(toolResultContent).toContain("\"id\": \"local-mcp\"");
           const evidencePath = writeEnablementEvidence(
-            `mcp-input-recovery-${Date.now()}.json`,
-            toolResultContent,
+            `mcp-input-recovery-${Date.now()}.txt`,
+            responseText,
           );
           expect(fs.statSync(evidencePath).size).toBeGreaterThan(0);
 
           const runEvents = listAgentRunEvents(env.stateDir, res.json.data.runId);
-          const primaryToolEnd = runEvents.find((event) =>
-            event.eventName === "agent.run.tool_end"
-            && event.payload.toolName === "mcp"
-            && event.payload.routeId === "agent.execute.tool"
+          const toolEnd = runEvents.find((event) =>
+            event.eventName === "agent.run.tool_end" && event.payload.toolName === "mcp"
           );
-          expect(primaryToolEnd).toBeDefined();
-          expect(primaryToolEnd!.payload.isError).toBe(false);
-          expect(primaryToolEnd!.payload.routeId).toBe("agent.execute.tool");
-          expect(primaryToolEnd!.payload.correlationId).toBe(res.json.data.runId);
-
-          const recoveryToolEnd = runEvents.find((event) =>
-            event.eventName === "agent.run.tool_end"
-            && event.payload.toolName === "mcp"
-            && typeof event.payload.toolCallId === "string"
-            && event.payload.toolCallId.endsWith(":input-recovery")
-          );
-          expect(recoveryToolEnd).toBeDefined();
-          expect(recoveryToolEnd!.payload.isError).toBe(false);
-          expect(recoveryToolEnd!.payload.routeId).toBe("agent.execute.tool.input_recovery");
-          expect(recoveryToolEnd!.payload.correlationId).toBe(res.json.data.runId);
+          expect(toolEnd).toBeUndefined();
         } finally {
           await env.cleanup();
         }

--- a/test/integration/hub/friday-hub-bootstrap-integration.test.ts
+++ b/test/integration/hub/friday-hub-bootstrap-integration.test.ts
@@ -107,7 +107,7 @@ describe("FridayHub Bootstrap Integration", () => {
         process.env.FRIDAY_DESKTOP_SANDBOX_ALLOWED_ROOTS = prevSandboxRoots;
       }
     }
-  });
+  }, 30_000);
 
   it("registers late-bound setup tools on the top-level agent runtime", async () => {
     const prevMcpServerEnabled = process.env.FRIDAY_MCP_SERVER_ENABLED;
@@ -118,15 +118,16 @@ describe("FridayHub Bootstrap Integration", () => {
       const tools = await Promise.resolve(hub.apiRuntime.mcpServer!.listTools());
       const toolNames = tools.map((tool) => tool.name);
 
-      expect(toolNames).toContain("autonomous");
-      expect(toolNames).toContain("setup");
-      expect(toolNames).toContain("setup_assistant");
-
-      const setupAssistantResult = await hub.apiRuntime.mcpServer!.callTool({
-        name: "setup_assistant",
-        args: { action: "get_progress" },
-      });
-      expect(setupAssistantResult.isError).toBe(false);
+      // MCP self-server now defaults to a curated safe catalog.
+      // Unsafe tools (autonomous, setup, setup_assistant) are no longer
+      // exposed by default — only safe read-only tools are listed.
+      expect(toolNames).toContain("capabilities");
+      expect(toolNames).toContain("task_status");
+      expect(toolNames).toContain("read");
+      expect(toolNames).not.toContain("sessions");
+      expect(toolNames).not.toContain("autonomous");
+      expect(toolNames).not.toContain("setup");
+      expect(toolNames).not.toContain("exec");
     } finally {
       if (prevMcpServerEnabled === undefined) {
         delete process.env.FRIDAY_MCP_SERVER_ENABLED;

--- a/test/unit/agent/tools/friday-agent-workflow-tool.test.ts
+++ b/test/unit/agent/tools/friday-agent-workflow-tool.test.ts
@@ -27,6 +27,7 @@ function mockExecutionService(
   error?: Error,
 ): FridayWorkflowExecutionService {
   return {
+    setDistributedDispatcher: vi.fn(),
     startRun: error
       ? vi.fn().mockRejectedValue(error)
       : vi.fn().mockResolvedValue(runEntity ?? makeRunEntity()),
@@ -35,8 +36,10 @@ function mockExecutionService(
     retryRun: vi.fn(),
     getRun: vi.fn().mockReturnValue(null),
     listRuns: vi.fn().mockReturnValue([]),
+    listActiveRuns: vi.fn().mockReturnValue([]),
     getRunNodes: vi.fn().mockReturnValue([]),
     recoverActiveRuns: vi.fn().mockResolvedValue(0),
+    reportRemoteNodeResult: vi.fn(),
     reapExpiredLeases: vi.fn().mockResolvedValue(0),
     sweepTimedOutRuns: vi.fn().mockResolvedValue(0),
     sweepTimedOutNodes: vi.fn().mockResolvedValue(0),

--- a/test/unit/api/runtime/friday-api-runtime-deterministic-dispatch.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-deterministic-dispatch.test.ts
@@ -84,7 +84,7 @@ describe("FridayApiRuntime deterministic dispatch", () => {
         desktop: { connected: false },
         companion: { connected: false },
       }),
-      tokenSecret: "test-secret-key-that-is-at-least-32-chars-long!!",
+      tokenSecret: "test-secret-key-that-is-at-least-32-chars-long!!", // pragma: allowlist secret
       allowLocalBypassLogin: true,
       computeChecksum: (content: string) => `checksum-${content.length}`,
       resolveSkill: () => null,

--- a/test/unit/api/runtime/friday-api-runtime-deterministic-dispatch.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-deterministic-dispatch.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createFridayApiRuntime } from "#api";
+import {
+  createFridayAgentEventEmitter,
+  type FridayAgentRuntime,
+} from "#agent";
+import type { FridayProviderService } from "#providers";
+import type { FridaySqliteLayer } from "#state";
+import { createTestDb } from "../../../helpers/friday-test-db.helper.js";
+
+const NOW = "2026-03-24T12:00:00.000Z";
+
+function makeIdGenerator(): () => string {
+  let counter = 0;
+  return () => `id-${String(++counter)}`;
+}
+
+function makeProviderService(): FridayProviderService {
+  return {
+    listProviders: vi.fn(async () => []),
+    getProvider: vi.fn(async () => null),
+    createProvider: vi.fn(async () => ({} as never)),
+    updateProvider: vi.fn(async () => ({} as never)),
+    deleteProvider: vi.fn(async () => undefined),
+    validateProvider: vi.fn(async () => ({ status: "ok" as const, checkedAt: NOW })),
+    getRoutingConfig: vi.fn(async () => ({ defaultProviderId: "p-1", fallbackProviderIds: [] })),
+    setRoutingConfig: vi.fn(async (input) => input),
+    resolveRoute: vi.fn(async () => ({
+      provider: {
+        id: "p-1",
+        kind: "openai" as const,
+        name: "OpenAI",
+        baseUrl: "https://api.openai.com",
+        enabled: true,
+        config: {
+          api: "openai-responses" as const,
+          authMode: "api-key" as const,
+          keySource: { kind: "env-ref" as const, envVar: "OPENAI_API_KEY" },
+          supportedModels: ["gpt-5.1"],
+          validation: { status: "ok" as const, checkedAt: NOW },
+        },
+        createdAt: NOW,
+        updatedAt: NOW,
+      },
+      model: "gpt-5.1",
+    })),
+    runWithFallback: vi.fn(async () => ({} as never)),
+  } as unknown as FridayProviderService;
+}
+
+describe("FridayApiRuntime deterministic dispatch", () => {
+  let db: FridaySqliteLayer;
+
+  afterEach(() => {
+    db?.close();
+  });
+
+  it("handles capability queries without a session key and does not invoke the agent", async () => {
+    db = createTestDb();
+    const executeRun = vi.fn(async () => {
+      throw new Error("agent should not run");
+    });
+    const agentRuntime: FridayAgentRuntime = {
+      executeRun,
+      registerTool: vi.fn(),
+      resumeStaleRunsOnBoot: vi.fn(() => 0),
+    };
+
+    const runtime = createFridayApiRuntime({
+      db,
+      idGenerator: makeIdGenerator(),
+      nowIso: () => NOW,
+      providerService: makeProviderService(),
+      agentRuntime,
+      agentEventEmitter: createFridayAgentEventEmitter(),
+      capabilitySnapshotGetter: () => ({
+        readOnly: false,
+        messaging: { enabled: false, kinds: [] },
+        mcp: { enabled: false, serverCount: 0 },
+        provider: { available: true, configuredCount: 0, mutationBlockedByReadOnly: false },
+        browser: {},
+        system: { enabled: false },
+        desktop: { connected: false },
+        companion: { connected: false },
+      }),
+      tokenSecret: "test-secret-key-that-is-at-least-32-chars-long!!",
+      allowLocalBypassLogin: true,
+      computeChecksum: (content: string) => `checksum-${content.length}`,
+      resolveSkill: () => null,
+      invokeSkill: async () => ({}),
+    });
+
+    const startRoute = runtime.routes.getRoutes().find((route) => route.operationId === "agent.runs.start");
+    expect(startRoute).toBeDefined();
+
+    const result = await startRoute!.handler({
+      body: {
+        task: "What can you do right now?",
+      },
+      principal: {
+        principalType: "user",
+        principalId: "user-1",
+        userId: "user-1",
+        scopes: ["agent.run"],
+        tokenId: "tok-1",
+        tokenKind: "access",
+        issuedAt: NOW,
+      },
+    } as never);
+
+    expect(result.status).toBe("completed");
+    expect(result.response).toContain("Current capabilities:");
+    expect(executeRun).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/cli/friday-cli-daemon.test.ts
+++ b/test/unit/cli/friday-cli-daemon.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { parseArgs } from "#cli";
+
+describe("parseArgs — daemon command", () => {
+  const argv = (...args: string[]) => ["node", "friday-cli.js", ...args];
+
+  it("parses 'daemon' as command", () => {
+    const result = parseArgs(argv("daemon"));
+    expect(result.command).toBe("daemon");
+  });
+
+  it("parses 'daemon start' subcommand", () => {
+    const result = parseArgs(argv("daemon", "start"));
+    expect(result.command).toBe("daemon");
+    expect(result.daemonSubcommand).toBe("start");
+  });
+
+  it("parses 'daemon stop' subcommand", () => {
+    const result = parseArgs(argv("daemon", "stop"));
+    expect(result.command).toBe("daemon");
+    expect(result.daemonSubcommand).toBe("stop");
+  });
+
+  it("parses 'daemon restart' subcommand", () => {
+    const result = parseArgs(argv("daemon", "restart"));
+    expect(result.command).toBe("daemon");
+    expect(result.daemonSubcommand).toBe("restart");
+  });
+
+  it("parses 'daemon status' subcommand", () => {
+    const result = parseArgs(argv("daemon", "status"));
+    expect(result.command).toBe("daemon");
+    expect(result.daemonSubcommand).toBe("status");
+  });
+
+  it("leaves daemonSubcommand undefined for bare 'daemon'", () => {
+    const result = parseArgs(argv("daemon"));
+    expect(result.command).toBe("daemon");
+    expect(result.daemonSubcommand).toBeUndefined();
+  });
+
+  it("leaves daemonSubcommand undefined for unknown sub", () => {
+    const result = parseArgs(argv("daemon", "foo"));
+    expect(result.command).toBe("daemon");
+    expect(result.daemonSubcommand).toBeUndefined();
+  });
+});

--- a/test/unit/daemon/friday-daemon-runtime.test.ts
+++ b/test/unit/daemon/friday-daemon-runtime.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatFridayDaemonStatus,
+  resolveFridayDaemonLaunchSpec,
+} from "../../../src/daemon/friday-daemon-runtime.js";
+
+describe("Friday daemon runtime helpers", () => {
+  it("resolves the operational runner from a source CLI module URL", () => {
+    const spec = resolveFridayDaemonLaunchSpec({
+      moduleUrl: "file:///repo/src/cli/friday-cli.ts",
+      env: { TEST_ENV: "1" },
+    });
+
+    expect(spec.repoRoot).toBe("/repo");
+    expect(spec.runnerPath).toBe("/repo/scripts/ops/friday-service-run.sh");
+    expect(spec.command).toBe("bash");
+    expect(spec.args).toEqual([
+      "/repo/scripts/ops/friday-service-run.sh",
+      "/repo",
+    ]);
+    expect(spec.cwd).toBe("/repo");
+    expect(spec.env.TEST_ENV).toBe("1");
+  });
+
+  it("resolves the operational runner from a built CLI module URL", () => {
+    const spec = resolveFridayDaemonLaunchSpec({
+      moduleUrl: "file:///repo/dist/cli/friday-cli.js",
+    });
+
+    expect(spec.repoRoot).toBe("/repo");
+    expect(spec.runnerPath).toBe("/repo/scripts/ops/friday-service-run.sh");
+    expect(spec.args).toEqual([
+      "/repo/scripts/ops/friday-service-run.sh",
+      "/repo",
+    ]);
+  });
+
+  it("formats running daemon status consistently", () => {
+    expect(formatFridayDaemonStatus({
+      running: true,
+      pid: 4321,
+      startedAt: "2026-03-24T00:00:00.000Z",
+      uptime: 61000,
+    })).toBe("Friday daemon: running (PID 4321, uptime 61s)");
+  });
+
+  it("formats stopped daemon status consistently", () => {
+    expect(formatFridayDaemonStatus({
+      running: false,
+      pid: null,
+      startedAt: null,
+      uptime: null,
+    })).toBe("Friday daemon: stopped");
+  });
+});

--- a/test/unit/hub/friday-mcp-safe-catalog.test.ts
+++ b/test/unit/hub/friday-mcp-safe-catalog.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import {
+  FRIDAY_MCP_SAFE_CATALOG,
+  isMcpSafeCatalogTool,
+  buildMcpServerToolFilter,
+} from "../../../src/hub/friday-mcp-safe-catalog.js";
+
+describe("FRIDAY_MCP_SAFE_CATALOG", () => {
+  it("contains only read-only, non-mutating tools", () => {
+    const expected = new Set([
+      "capabilities",
+      "task_status",
+      "skills_list",
+      "agents_list",
+      "web_search",
+      "web_fetch",
+      "read",
+      "memory_search",
+    ]);
+    expect(FRIDAY_MCP_SAFE_CATALOG).toEqual(expected);
+  });
+
+  it("does not contain dangerous tools", () => {
+    const dangerous = [
+      "exec", "write", "edit", "system", "desktop",
+      "spawn_subagent", "message", "browser", "autonomous",
+      "skill_run", "workflow_run", "cron", "provider",
+      "mcp", "nodes", "gateway", "feedback", "canvas",
+      "memory_store", "skill_generate", "workflow_generate",
+      "setup", "setup_assistant", "tts", "xhs",
+      "skill_import", "image_analysis", "memory_extract",
+    ];
+    for (const tool of dangerous) {
+      expect(FRIDAY_MCP_SAFE_CATALOG.has(tool)).toBe(false);
+    }
+  });
+});
+
+describe("isMcpSafeCatalogTool", () => {
+  it("returns true for catalog members", () => {
+    expect(isMcpSafeCatalogTool("capabilities")).toBe(true);
+    expect(isMcpSafeCatalogTool("task_status")).toBe(true);
+    expect(isMcpSafeCatalogTool("read")).toBe(true);
+  });
+
+  it("returns false for non-members", () => {
+    expect(isMcpSafeCatalogTool("exec")).toBe(false);
+    expect(isMcpSafeCatalogTool("system")).toBe(false);
+    expect(isMcpSafeCatalogTool("sessions")).toBe(false);
+    expect(isMcpSafeCatalogTool("")).toBe(false);
+  });
+});
+
+describe("buildMcpServerToolFilter", () => {
+  describe("empty env allowlist (default)", () => {
+    const { isToolAllowed } = buildMcpServerToolFilter([]);
+
+    it("allows all safe catalog tools", () => {
+      for (const tool of FRIDAY_MCP_SAFE_CATALOG) {
+        expect(isToolAllowed(tool)).toBe(true);
+      }
+    });
+
+    it("blocks unsafe tools", () => {
+      expect(isToolAllowed("exec")).toBe(false);
+      expect(isToolAllowed("write")).toBe(false);
+      expect(isToolAllowed("system")).toBe(false);
+      expect(isToolAllowed("desktop")).toBe(false);
+      expect(isToolAllowed("spawn_subagent")).toBe(false);
+    });
+  });
+
+  describe("non-empty env allowlist", () => {
+    it("narrows within safe catalog", () => {
+      const { isToolAllowed } = buildMcpServerToolFilter(["capabilities", "task_status"]);
+
+      expect(isToolAllowed("capabilities")).toBe(true);
+      expect(isToolAllowed("task_status")).toBe(true);
+      expect(isToolAllowed("web_search")).toBe(false);
+      expect(isToolAllowed("read")).toBe(false);
+    });
+
+    it("cannot re-expose unsafe tools", () => {
+      const { isToolAllowed } = buildMcpServerToolFilter(["exec", "system", "capabilities"]);
+
+      expect(isToolAllowed("exec")).toBe(false);
+      expect(isToolAllowed("system")).toBe(false);
+      expect(isToolAllowed("capabilities")).toBe(true);
+    });
+
+    it("returns false for all when env list has only unsafe tools", () => {
+      const { isToolAllowed } = buildMcpServerToolFilter(["exec", "write", "desktop"]);
+
+      expect(isToolAllowed("exec")).toBe(false);
+      expect(isToolAllowed("write")).toBe(false);
+      expect(isToolAllowed("desktop")).toBe(false);
+      expect(isToolAllowed("capabilities")).toBe(false);
+    });
+  });
+});

--- a/test/unit/sessions/friday-deterministic-dispatch.test.ts
+++ b/test/unit/sessions/friday-deterministic-dispatch.test.ts
@@ -1,0 +1,455 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  dispatchDeterministic,
+} from "../../../src/sessions/services/friday-deterministic-dispatch.js";
+import type {
+  FridayDeterministicDispatchDeps,
+} from "../../../src/sessions/services/friday-deterministic-dispatch.js";
+import type { FridayAgentCapabilitiesSnapshot } from "../../../src/agent/tools/friday-agent-capabilities-tool.js";
+import type { FridayAgentTaskStatusSnapshot } from "../../../src/agent/tools/friday-agent-task-status-tool.js";
+import type { FridayWorkflowApprovalService } from "../../../src/workflows/services/friday-workflow-approval-service.types.js";
+import type { FridayWorkflowExecutionService, FridayWorkflowRunEntity } from "#workflows";
+import type { FridayWorkflowApprovalRequestEntity } from "../../../src/workflows/model/friday-workflow-engine.types.js";
+
+function makeWorkflowRun(overrides?: Partial<FridayWorkflowRunEntity>): FridayWorkflowRunEntity {
+  return {
+    id: "wf-run-1",
+    workflowId: "wf-1",
+    workflowVersionId: "wf-v-1",
+    status: "running",
+    triggerType: "manual",
+    startedAt: "2026-03-24T10:00:00.000Z",
+    createdAt: "2026-03-24T10:00:00.000Z",
+    updatedAt: "2026-03-24T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeApproval(overrides?: Partial<FridayWorkflowApprovalRequestEntity>): FridayWorkflowApprovalRequestEntity {
+  return {
+    id: "approval-1",
+    workflowId: "wf-1",
+    workflowVersionId: "wf-v-1",
+    runId: "wf-run-1",
+    runNodeAttemptId: "attempt-1",
+    nodeId: "approval-node",
+    status: "pending",
+    requestPayload: {},
+    createdAt: "2026-03-24T10:00:00.000Z",
+    updatedAt: "2026-03-24T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function createMockDeps(overrides?: Partial<FridayDeterministicDispatchDeps>): FridayDeterministicDispatchDeps {
+  return {
+    capabilitySnapshotGetter: vi.fn().mockResolvedValue({
+      readOnly: false,
+      messaging: { enabled: true, kinds: ["discord"] },
+      mcp: { enabled: true, serverCount: 2 },
+      provider: { available: true, configuredCount: 1, mutationBlockedByReadOnly: false },
+      browser: { activeMode: "puppeteer" },
+      system: { enabled: true },
+      desktop: { connected: false },
+      companion: { connected: false },
+    } satisfies FridayAgentCapabilitiesSnapshot),
+    taskStatusSnapshotGetter: vi.fn().mockResolvedValue({
+      readOnly: false,
+      runStatus: "executing",
+      task: "Build feature X",
+      phase: "executing",
+      elapsedMs: 5000,
+      latestTool: "exec",
+      activeSubagents: [],
+      blockers: [],
+    } satisfies FridayAgentTaskStatusSnapshot),
+    getDaemonStatus: () => ({
+      running: true,
+      pid: 12345,
+      startedAt: "2026-01-01T00:00:00Z",
+      uptime: 60000,
+    }),
+    approvalService: {
+      requestForNode: vi.fn(),
+      listPending: vi.fn(() => []),
+      getById: vi.fn(() => null),
+      approve: vi.fn(async (input: { approvalId: string }) => ({
+        approval: makeApproval({ id: input.approvalId, status: "approved" }),
+        resumed: true,
+      })),
+      reject: vi.fn(async (input: { approvalId: string }) => ({
+        approval: makeApproval({ id: input.approvalId, status: "rejected" }),
+        resumed: false,
+      })),
+      expirePending: vi.fn(async () => 0),
+    } satisfies FridayWorkflowApprovalService,
+    workflowExecutionService: {
+      setDistributedDispatcher: vi.fn(),
+      startRun: vi.fn(),
+      resumeRun: vi.fn(async (runId: string) => makeWorkflowRun({ id: runId, status: "running" })),
+      cancelRun: vi.fn(async (runId: string) => makeWorkflowRun({ id: runId, status: "cancelled", finishedAt: "2026-03-24T10:05:00.000Z" })),
+      retryRun: vi.fn(async (runId: string) => makeWorkflowRun({ id: runId, status: "queued" })),
+      getRun: vi.fn((runId: string) => makeWorkflowRun({ id: runId })),
+      listRuns: vi.fn(() => []),
+      listActiveRuns: vi.fn(() => [
+        makeWorkflowRun({ id: "wf-run-1", workflowId: "wf-1", status: "running" }),
+        makeWorkflowRun({ id: "wf-run-2", workflowId: "wf-2", status: "queued" }),
+      ]),
+      getRunNodes: vi.fn(() => []),
+      recoverActiveRuns: vi.fn(async () => 0),
+      reportRemoteNodeResult: vi.fn(),
+      reapExpiredLeases: vi.fn(async () => 0),
+      sweepTimedOutRuns: vi.fn(async () => 0),
+      sweepTimedOutNodes: vi.fn(async () => 0),
+    } satisfies FridayWorkflowExecutionService,
+    ...overrides,
+  };
+}
+
+describe("dispatchDeterministic", () => {
+  describe("capabilities handler", () => {
+    it("returns formatted capabilities", async () => {
+      const deps = createMockDeps();
+      const result = await dispatchDeterministic(
+        {
+          classification: { category: "sync_immediate", handler: "capabilities" },
+          sessionKey: "test",
+          runId: "run-1",
+        },
+        deps,
+      );
+      expect(result.handled).toBe(true);
+      expect(result.response).toContain("Current capabilities:");
+      expect(result.response).toContain("Messaging: enabled (discord)");
+      expect(result.response).toContain("MCP: enabled (2 server(s))");
+    });
+
+    it("returns handled:false when snapshot getter throws", async () => {
+      const deps = createMockDeps({
+        capabilitySnapshotGetter: vi.fn().mockRejectedValue(new Error("fail")),
+      });
+      const result = await dispatchDeterministic(
+        {
+          classification: { category: "sync_immediate", handler: "capabilities" },
+          sessionKey: "test",
+          runId: "run-1",
+        },
+        deps,
+      );
+      expect(result.handled).toBe(false);
+    });
+  });
+
+  describe("task_status handler", () => {
+    it("returns formatted task status", async () => {
+      const deps = createMockDeps();
+      const result = await dispatchDeterministic(
+        {
+          classification: { category: "sync_immediate", handler: "task_status" },
+          sessionKey: "test",
+          runId: "run-1",
+        },
+        deps,
+      );
+      expect(result.handled).toBe(true);
+      expect(result.response).toContain("Task status: executing");
+      expect(result.response).toContain("Build feature X");
+    });
+
+    it("shows terminal outcome when available", async () => {
+      const deps = createMockDeps({
+        taskStatusSnapshotGetter: vi.fn().mockResolvedValue({
+          readOnly: false,
+          activeSubagents: [],
+          blockers: [],
+          terminalOutcome: {
+            status: "completed",
+            summary: "Done building feature X",
+          },
+        } satisfies FridayAgentTaskStatusSnapshot),
+      });
+      const result = await dispatchDeterministic(
+        {
+          classification: { category: "sync_immediate", handler: "task_status" },
+          sessionKey: "test",
+          runId: "run-1",
+        },
+        deps,
+      );
+      expect(result.handled).toBe(true);
+      expect(result.response).toContain("Task completed");
+      expect(result.response).toContain("Done building feature X");
+    });
+
+    it("shows no active task when status is empty", async () => {
+      const deps = createMockDeps({
+        taskStatusSnapshotGetter: vi.fn().mockResolvedValue({
+          readOnly: false,
+          activeSubagents: [],
+          blockers: [],
+        } satisfies FridayAgentTaskStatusSnapshot),
+      });
+      const result = await dispatchDeterministic(
+        {
+          classification: { category: "sync_immediate", handler: "task_status" },
+          sessionKey: "test",
+          runId: "run-1",
+        },
+        deps,
+      );
+      expect(result.handled).toBe(true);
+      expect(result.response).toContain("No active task");
+    });
+  });
+
+  describe("daemon_status handler", () => {
+    it("returns running status when daemon is available", async () => {
+      const deps = createMockDeps();
+      const result = await dispatchDeterministic(
+        {
+          classification: { category: "sync_immediate", handler: "daemon_status" },
+          sessionKey: "test",
+          runId: "run-1",
+        },
+        deps,
+      );
+      expect(result.handled).toBe(true);
+      expect(result.response).toContain("running");
+      expect(result.response).toContain("12345");
+    });
+
+    it("returns not available when daemon service is missing", async () => {
+      const deps = createMockDeps({ getDaemonStatus: undefined });
+      const result = await dispatchDeterministic(
+        {
+          classification: { category: "sync_immediate", handler: "daemon_status" },
+          sessionKey: "test",
+          runId: "run-1",
+        },
+        deps,
+      );
+      expect(result.handled).toBe(false);
+    });
+  });
+
+  describe("mcp_list handler", () => {
+    it("returns server list when adapter is available", async () => {
+      const deps = createMockDeps({
+        listMcpServers: () => [
+          { id: "filesystem", transport: "stdio" },
+          { id: "remote-api", transport: "http" },
+        ],
+      });
+      const result = await dispatchDeterministic(
+        {
+          classification: { category: "sync_immediate", handler: "mcp_list" },
+          sessionKey: "test",
+          runId: "run-1",
+        },
+        deps,
+      );
+      expect(result.handled).toBe(true);
+      expect(result.response).toContain("2 MCP server(s)");
+      expect(result.response).toContain("filesystem");
+      expect(result.response).toContain("remote-api");
+    });
+
+    it("returns no servers when adapter is missing", async () => {
+      const deps = createMockDeps({ listMcpServers: undefined });
+      const result = await dispatchDeterministic(
+        {
+          classification: { category: "sync_immediate", handler: "mcp_list" },
+          sessionKey: "test",
+          runId: "run-1",
+        },
+        deps,
+      );
+      expect(result.handled).toBe(false);
+    });
+  });
+
+  describe("approval_decision handler", () => {
+    it("returns no pending approvals when none exist", async () => {
+      const deps = createMockDeps();
+      const result = await dispatchDeterministic(
+        {
+          classification: {
+            category: "sync_immediate",
+            handler: "approval_decision",
+            extractedParams: { decision: "approve" },
+          },
+          sessionKey: "test",
+          runId: "run-1",
+          actorId: "user-1",
+        },
+        deps,
+      );
+      expect(result.handled).toBe(true);
+      expect(result.response).toContain("No pending approvals");
+    });
+
+    it("auto-approves the single pending approval when no id is provided", async () => {
+      const deps = createMockDeps({
+        approvalService: {
+          requestForNode: vi.fn(),
+          listPending: vi.fn(() => [makeApproval({ id: "approval-7", runId: "wf-run-7" })]),
+          getById: vi.fn(() => makeApproval({ id: "approval-7", runId: "wf-run-7" })),
+          approve: vi.fn(async () => ({
+            approval: makeApproval({ id: "approval-7", runId: "wf-run-7", status: "approved" }),
+            resumed: true,
+          })),
+          reject: vi.fn(async () => ({ approval: makeApproval({ status: "rejected" }), resumed: false })),
+          expirePending: vi.fn(async () => 0),
+        } satisfies FridayWorkflowApprovalService,
+      });
+      const result = await dispatchDeterministic(
+        {
+          classification: {
+            category: "sync_immediate",
+            handler: "approval_decision",
+            extractedParams: { decision: "approve" },
+          },
+          actorId: "user-7",
+        },
+        deps,
+      );
+
+      expect(result.handled).toBe(true);
+      expect(deps.approvalService!.approve).toHaveBeenCalledWith({
+        approvalId: "approval-7",
+        decidedByUserId: "user-7",
+        comment: undefined,
+      });
+      expect(result.response).toContain("Approved approval approval-7");
+      expect(result.response).toContain("wf-run-7");
+    });
+
+    it("returns deterministic clarification when multiple pending approvals exist", async () => {
+      const deps = createMockDeps({
+        approvalService: {
+          requestForNode: vi.fn(),
+          listPending: vi.fn(() => [
+            makeApproval({ id: "approval-1", runId: "wf-run-1" }),
+            makeApproval({ id: "approval-2", runId: "wf-run-2" }),
+          ]),
+          getById: vi.fn(() => null),
+          approve: vi.fn(async () => ({ approval: makeApproval({ status: "approved" }), resumed: true })),
+          reject: vi.fn(async () => ({ approval: makeApproval({ status: "rejected" }), resumed: false })),
+          expirePending: vi.fn(async () => 0),
+        } satisfies FridayWorkflowApprovalService,
+      });
+
+      const result = await dispatchDeterministic(
+        {
+          classification: {
+            category: "sync_immediate",
+            handler: "approval_decision",
+            extractedParams: { decision: "reject" },
+          },
+          actorId: "user-1",
+        },
+        deps,
+      );
+
+      expect(result.handled).toBe(true);
+      expect(result.response).toContain("Multiple pending approvals");
+      expect(result.response).toContain("approval-1");
+      expect(result.response).toContain("approval-2");
+      expect(deps.approvalService!.reject).not.toHaveBeenCalled();
+    });
+
+    it("uses an explicit approval id when provided", async () => {
+      const deps = createMockDeps();
+      const result = await dispatchDeterministic(
+        {
+          classification: {
+            category: "sync_immediate",
+            handler: "approval_decision",
+            extractedParams: { decision: "reject", approvalId: "approval-99" },
+          },
+          actorId: "user-99",
+        },
+        deps,
+      );
+
+      expect(result.handled).toBe(true);
+      expect(deps.approvalService!.reject).toHaveBeenCalledWith({
+        approvalId: "approval-99",
+        decidedByUserId: "user-99",
+        comment: undefined,
+      });
+      expect(result.response).toContain("Rejected approval approval-99");
+    });
+  });
+
+  describe("workflow_query handler", () => {
+    it("lists active workflow runs for generic workflow status queries", async () => {
+      const deps = createMockDeps();
+
+      const result = await dispatchDeterministic(
+        {
+          classification: {
+            category: "sync_immediate",
+            handler: "workflow_query",
+          },
+        },
+        deps,
+      );
+
+      expect(result.handled).toBe(true);
+      expect(result.response).toContain("2 active workflow run(s)");
+      expect(result.response).toContain("wf-run-1");
+      expect(result.response).toContain("wf-run-2");
+    });
+
+    it("returns a specific workflow run when a run id is provided", async () => {
+      const deps = createMockDeps();
+
+      const result = await dispatchDeterministic(
+        {
+          classification: {
+            category: "sync_immediate",
+            handler: "workflow_query",
+            extractedParams: { runId: "wf-run-42" },
+          },
+        },
+        deps,
+      );
+
+      expect(result.handled).toBe(true);
+      expect(result.response).toContain("Workflow run wf-run-42");
+      expect(result.response).toContain("running");
+      expect(deps.workflowExecutionService!.getRun).toHaveBeenCalledWith("wf-run-42");
+    });
+  });
+
+  describe("unknown handler", () => {
+    it("returns handled:false", async () => {
+      const deps = createMockDeps();
+      const result = await dispatchDeterministic(
+        {
+          classification: { category: "sync_immediate", handler: "unknown_handler" },
+          sessionKey: "test",
+          runId: "run-1",
+        },
+        deps,
+      );
+      expect(result.handled).toBe(false);
+    });
+  });
+
+  describe("no handler specified", () => {
+    it("returns handled:false", async () => {
+      const deps = createMockDeps();
+      const result = await dispatchDeterministic(
+        {
+          classification: { category: "sync_immediate" },
+          sessionKey: "test",
+          runId: "run-1",
+        },
+        deps,
+      );
+      expect(result.handled).toBe(false);
+    });
+  });
+});

--- a/test/unit/sessions/friday-execution-classifier.test.ts
+++ b/test/unit/sessions/friday-execution-classifier.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyFridayExecution,
+} from "../../../src/sessions/services/friday-execution-classifier.js";
+import type { FridaySessionConversationFocusState } from "../../../src/sessions/model/friday-session.types.js";
+
+function makeFocus(overrides?: Partial<FridaySessionConversationFocusState>): FridaySessionConversationFocusState {
+  return { updatedAt: "2026-01-01T00:00:00Z", ...overrides };
+}
+
+describe("classifyFridayExecution", () => {
+  describe("status checks", () => {
+    it("classifies status_check turn as sync_immediate/task_status", () => {
+      const result = classifyFridayExecution({
+        task: "What's the status?",
+        turnKind: "status_check",
+        focusState: makeFocus(),
+      });
+      expect(result.category).toBe("sync_immediate");
+      expect(result.handler).toBe("task_status");
+    });
+
+    it("does not classify status_check when pending plan exists", () => {
+      const result = classifyFridayExecution({
+        task: "What's the status?",
+        turnKind: "status_check",
+        focusState: makeFocus({ pendingPlanRunId: "plan-123" }),
+      });
+      // Should not hit task_status because pending plan; will fall through
+      // to capability check or agent path
+      expect(result.category).not.toBe("sync_immediate");
+    });
+  });
+
+  describe("capability queries", () => {
+    it("classifies 'what can you do' as capabilities", () => {
+      const result = classifyFridayExecution({
+        task: "What can you do?",
+        turnKind: "new_topic",
+        focusState: null,
+      });
+      expect(result.category).toBe("sync_immediate");
+      expect(result.handler).toBe("capabilities");
+    });
+
+    it("classifies 'capabilities' as capabilities", () => {
+      const result = classifyFridayExecution({
+        task: "Show me the capabilities",
+        turnKind: "new_topic",
+        focusState: null,
+      });
+      expect(result.category).toBe("sync_immediate");
+      expect(result.handler).toBe("capabilities");
+    });
+
+    it("classifies Chinese capability query", () => {
+      const result = classifyFridayExecution({
+        task: "能做什么",
+        turnKind: "new_topic",
+        focusState: null,
+      });
+      expect(result.category).toBe("sync_immediate");
+      expect(result.handler).toBe("capabilities");
+    });
+
+    it("classifies 'is mcp enabled' as capabilities", () => {
+      const result = classifyFridayExecution({
+        task: "Is MCP enabled?",
+        turnKind: "new_topic",
+        focusState: null,
+      });
+      expect(result.category).toBe("sync_immediate");
+      expect(result.handler).toBe("capabilities");
+    });
+  });
+
+  describe("approval commands", () => {
+    it("classifies 'approve' without pending plan as approval_decision", () => {
+      const result = classifyFridayExecution({
+        task: "approve",
+        turnKind: "new_topic",
+        focusState: makeFocus(),
+      });
+      expect(result.category).toBe("sync_immediate");
+      expect(result.handler).toBe("approval_decision");
+      expect(result.extractedParams).toEqual({
+        decision: "approve",
+      });
+    });
+
+    it("defers 'approve' with pending plan to agent (planning gate)", () => {
+      const result = classifyFridayExecution({
+        task: "approve",
+        turnKind: "new_topic",
+        focusState: makeFocus({ pendingPlanRunId: "plan-456" }),
+      });
+      expect(result.category).toBe("agent_exception_path");
+    });
+
+    it("classifies explicit approval id for direct control", () => {
+      const result = classifyFridayExecution({
+        task: "reject approval-123",
+        turnKind: "new_topic",
+        focusState: makeFocus(),
+      });
+      expect(result.category).toBe("sync_immediate");
+      expect(result.handler).toBe("approval_decision");
+      expect(result.extractedParams).toEqual({
+        approvalId: "approval-123",
+        decision: "reject",
+      });
+    });
+
+    it("classifies 'reject' without pending plan as approval_decision", () => {
+      const result = classifyFridayExecution({
+        task: "reject",
+        turnKind: "new_topic",
+        focusState: makeFocus(),
+      });
+      expect(result.category).toBe("sync_immediate");
+      expect(result.handler).toBe("approval_decision");
+      expect(result.extractedParams).toEqual({
+        decision: "reject",
+      });
+    });
+  });
+
+  describe("daemon status", () => {
+    it("classifies 'daemon status' as daemon_status", () => {
+      const result = classifyFridayExecution({
+        task: "daemon status",
+        turnKind: "new_topic",
+        focusState: null,
+      });
+      expect(result.category).toBe("sync_immediate");
+      expect(result.handler).toBe("daemon_status");
+    });
+
+    it("classifies 'is friday running' as daemon_status", () => {
+      const result = classifyFridayExecution({
+        task: "Is Friday running?",
+        turnKind: "new_topic",
+        focusState: null,
+      });
+      expect(result.category).toBe("sync_immediate");
+      expect(result.handler).toBe("daemon_status");
+    });
+  });
+
+  describe("MCP queries", () => {
+    it("classifies 'list mcp servers' as mcp_list", () => {
+      const result = classifyFridayExecution({
+        task: "List MCP servers",
+        turnKind: "new_topic",
+        focusState: null,
+      });
+      expect(result.category).toBe("sync_immediate");
+      expect(result.handler).toBe("mcp_list");
+    });
+  });
+
+  describe("workflow queries", () => {
+    it("classifies 'workflow status' as workflow_query", () => {
+      const result = classifyFridayExecution({
+        task: "Show me the workflow status",
+        turnKind: "new_topic",
+        focusState: null,
+      });
+      expect(result.category).toBe("sync_immediate");
+      expect(result.handler).toBe("workflow_query");
+    });
+
+    it("extracts a workflow run id for specific workflow status queries", () => {
+      const result = classifyFridayExecution({
+        task: "workflow status wf-run-42",
+        turnKind: "new_topic",
+        focusState: null,
+      });
+      expect(result.category).toBe("sync_immediate");
+      expect(result.handler).toBe("workflow_query");
+      expect(result.extractedParams).toEqual({
+        runId: "wf-run-42",
+      });
+    });
+  });
+
+  describe("workflow control commands", () => {
+    it("classifies cancel with run id as managed_async workflow control", () => {
+      const result = classifyFridayExecution({
+        task: "cancel wf-run-42",
+        turnKind: "new_topic",
+        focusState: null,
+      });
+      expect(result.category).toBe("managed_async");
+      expect(result.handler).toBe("workflow_control");
+      expect(result.extractedParams).toEqual({
+        controlAction: "cancel",
+        runId: "wf-run-42",
+      });
+    });
+
+    it("classifies retry without run id as managed_async clarification path", () => {
+      const result = classifyFridayExecution({
+        task: "retry",
+        turnKind: "new_topic",
+        focusState: null,
+      });
+      expect(result.category).toBe("managed_async");
+      expect(result.handler).toBe("workflow_control");
+      expect(result.extractedParams).toEqual({
+        controlAction: "retry",
+      });
+    });
+  });
+
+  describe("agent fallback", () => {
+    it("classifies free-text question as agent_exception_path", () => {
+      const result = classifyFridayExecution({
+        task: "Help me write a function to sort numbers",
+        turnKind: "new_topic",
+        focusState: null,
+      });
+      expect(result.category).toBe("agent_exception_path");
+    });
+
+    it("classifies follow_up turn as agent_exception_path", () => {
+      const result = classifyFridayExecution({
+        task: "Can you elaborate on that?",
+        turnKind: "follow_up",
+        focusState: makeFocus(),
+      });
+      expect(result.category).toBe("agent_exception_path");
+    });
+
+    it("classifies complex request as agent_exception_path", () => {
+      const result = classifyFridayExecution({
+        task: "Create a new workflow that sends daily Slack summaries",
+        turnKind: "new_topic",
+        focusState: null,
+      });
+      expect(result.category).toBe("agent_exception_path");
+    });
+  });
+});

--- a/test/unit/sessions/friday-managed-async-dispatch.test.ts
+++ b/test/unit/sessions/friday-managed-async-dispatch.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { dispatchManagedAsync } from "../../../src/sessions/services/friday-managed-async-dispatch.js";
+import type { FridayManagedAsyncDispatchDeps } from "../../../src/sessions/services/friday-managed-async-dispatch.js";
+import type { FridayWorkflowExecutionService, FridayWorkflowRunEntity } from "#workflows";
+
+function makeRun(overrides?: Partial<FridayWorkflowRunEntity>): FridayWorkflowRunEntity {
+  return {
+    id: "wf-run-1",
+    workflowId: "wf-1",
+    workflowVersionId: "wf-v-1",
+    status: "running",
+    triggerType: "manual",
+    startedAt: "2026-03-24T10:00:00.000Z",
+    createdAt: "2026-03-24T10:00:00.000Z",
+    updatedAt: "2026-03-24T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function createExecutionService(): FridayWorkflowExecutionService {
+  return {
+    setDistributedDispatcher: vi.fn(),
+    startRun: vi.fn(),
+    resumeRun: vi.fn(async (runId: string) => makeRun({ id: runId, status: "running" })),
+    cancelRun: vi.fn(async (runId: string) => makeRun({ id: runId, status: "cancelled", finishedAt: "2026-03-24T10:05:00.000Z" })),
+    retryRun: vi.fn(async (runId: string) => makeRun({ id: runId, status: "queued" })),
+    getRun: vi.fn(() => null),
+    listRuns: vi.fn(() => []),
+    listActiveRuns: vi.fn(() => []),
+    getRunNodes: vi.fn(() => []),
+    recoverActiveRuns: vi.fn(async () => 0),
+    reportRemoteNodeResult: vi.fn(),
+    reapExpiredLeases: vi.fn(async () => 0),
+    sweepTimedOutRuns: vi.fn(async () => 0),
+    sweepTimedOutNodes: vi.fn(async () => 0),
+  };
+}
+
+function createDeps(overrides?: Partial<FridayManagedAsyncDispatchDeps>): FridayManagedAsyncDispatchDeps {
+  return {
+    workflowExecutionService: createExecutionService(),
+    ...overrides,
+  };
+}
+
+describe("dispatchManagedAsync", () => {
+  it("returns handled:false when workflow execution service is missing", async () => {
+    const result = await dispatchManagedAsync(
+      {
+        classification: {
+          category: "managed_async",
+          handler: "workflow_control",
+          extractedParams: { controlAction: "cancel", runId: "wf-run-1" },
+        },
+      },
+      { workflowExecutionService: undefined },
+    );
+
+    expect(result.handled).toBe(false);
+  });
+
+  it("asks for a run id when control action omits one", async () => {
+    const result = await dispatchManagedAsync(
+      {
+        classification: {
+          category: "managed_async",
+          handler: "workflow_control",
+          extractedParams: { controlAction: "retry" },
+        },
+      },
+      createDeps(),
+    );
+
+    expect(result.handled).toBe(true);
+    expect(result.response).toContain("Please specify a workflow run id");
+    expect(result.response).toContain("retry");
+  });
+
+  it("cancels a workflow run through the execution service", async () => {
+    const deps = createDeps();
+
+    const result = await dispatchManagedAsync(
+      {
+        classification: {
+          category: "managed_async",
+          handler: "workflow_control",
+          extractedParams: { controlAction: "cancel", runId: "wf-run-9" },
+        },
+      },
+      deps,
+    );
+
+    expect(result.handled).toBe(true);
+    expect(deps.workflowExecutionService!.cancelRun).toHaveBeenCalledWith("wf-run-9");
+    expect(result.response).toContain("Workflow run wf-run-9");
+    expect(result.response).toContain("cancelled");
+  });
+
+  it("retries a workflow run through the execution service", async () => {
+    const deps = createDeps();
+
+    const result = await dispatchManagedAsync(
+      {
+        classification: {
+          category: "managed_async",
+          handler: "workflow_control",
+          extractedParams: { controlAction: "retry", runId: "wf-run-9" },
+        },
+      },
+      deps,
+    );
+
+    expect(result.handled).toBe(true);
+    expect(deps.workflowExecutionService!.retryRun).toHaveBeenCalledWith("wf-run-9");
+    expect(result.response).toContain("Workflow run wf-run-9");
+    expect(result.response).toContain("queued");
+  });
+
+  it("resumes a workflow run through the execution service", async () => {
+    const deps = createDeps();
+
+    const result = await dispatchManagedAsync(
+      {
+        classification: {
+          category: "managed_async",
+          handler: "workflow_control",
+          extractedParams: { controlAction: "resume", runId: "wf-run-9" },
+        },
+      },
+      deps,
+    );
+
+    expect(result.handled).toBe(true);
+    expect(deps.workflowExecutionService!.resumeRun).toHaveBeenCalledWith("wf-run-9");
+    expect(result.response).toContain("Workflow run wf-run-9");
+    expect(result.response).toContain("running");
+  });
+});

--- a/test/unit/state/friday-state-index.test.ts
+++ b/test/unit/state/friday-state-index.test.ts
@@ -40,6 +40,7 @@ describe("state-index (initializeFridayState)", () => {
 
     expect(runtime.config.exists).toBe(true);
     expect(runtime.config.config.stateDir).toBe(tmpDir);
+    expect(runtime.stateDir).toBe(tmpDir);
     expect(runtime.sqlite).toBeTruthy();
     expect(runtime.sqlite.writer).toBeTruthy();
     expect(runtime.telemetry).toBeTruthy();


### PR DESCRIPTION
## Summary\n- wire daemon management through a shared local runtime and single state-dir truth source\n- enforce a safe self-MCP catalog and deterministic-first dispatch for daemon/MCP/workflow control\n- add no-fake-pass tests covering daemon launch, safe MCP exposure, deterministic dispatch, managed async dispatch, and hub/API parity\n\n## Validation\n- npm run typecheck\n- npm test\n- npm run lint\n- npm run build:api\n- npm run build:ui