### PR TITLE
chore(release): v0.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,9 @@ jobs:
       - name: Unit/Integration + Core E2E tests
         env:
           FRIDAY_E2E_CORE: "1"
-        run: npm test
+        run: |
+          npm test
+          npm run test:e2e:ui
 
   # ── MECHANISM-2: Gate 3 — Migration Chain Integrity ──
   migrations:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -520,15 +520,6 @@
         "line_number": 25
       }
     ],
-    "test/e2e/mock/_helpers/mock-env.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "test/e2e/mock/_helpers/mock-env.ts",
-        "hashed_secret": "dfab2e513122494cf5b02fe39b8ea2a31fce02a5",
-        "is_verified": false,
-        "line_number": 203
-      }
-    ],
     "test/e2e/mock/friday-mock-journeys.e2e.test.ts": [
       {
         "type": "Secret Keyword",
@@ -1058,5 +1049,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-17T13:04:23Z"
+  "generated_at": "2026-03-24T22:41:59Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,28 @@ and this project follows Semantic Versioning.
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-03-24
+
 ### Added
+- Assistant `Outcome Receipt` guidance with direct follow-up actions for saving, scheduling, packaging, and deferring publication.
+- Standalone browser E2E lane for incentive-alignment journeys via `npm run test:e2e:ui`.
 - One-command local demo workflow runner: `npm run demo` (`scripts/demo/minimal-workflow-demo.mjs` + sample workflow JSON).
 - Troubleshooting and self-recovery runbook: `docs/TROUBLESHOOTING.md`.
 - Extension guide and copy-ready templates for skills/plugins/workflows: `docs/EXTENDING.md` and `examples/templates/*`.
 - Release notes template and closed-loop usability blueprint docs.
 
 ### Changed
+- `/automations` now surfaces leverage-oriented metadata including time-saved estimates, reuse counts, promotion state, and outcome score ranking.
+- Marketplace asset ranking and creator reputation now use proof-of-use signals instead of install-count-first ordering, with typed scoring policy support.
+- Assistant handoff into automations and marketplace requests now preserves task context and prefill data across the full loop.
+- CI and `release:verify` now run the browser E2E lane explicitly instead of relying on default `npm test`.
 - README now surfaces one-command demo, troubleshooting, extensibility, release links, and CI/release status badges.
 - `docs/RELEASING.md` now includes release artifact completeness checks (version/changelog/release notes/license/security/CI).
 - Hub bootstrap env test now reads package version dynamically (no hardcoded `0.3.0`), preventing version-bump CI regressions.
+
+### Fixed
+- `detect-secrets` false positives in browser/mock support tests are now inline-allowlisted, and the secrets baseline is synchronized with the new allowlist.
+- GitHub CI no longer fails by trying to run browser E2E through the default `npm test` entry without a built UI bundle.
 
 ## [0.3.1] - 2026-02-27
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "friday",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "friday",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "friday",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "type": "module",
   "description": "Friday visual AI automation platform",
   "license": "MIT",
@@ -44,8 +44,8 @@
     "start:companion": "node dist/system/companion/friday-system-companion-daemon.js",
     "demo:minimal": "node scripts/demo/minimal-workflow-demo.mjs",
     "demo": "npm run demo:minimal",
-    "test": "vitest run",
-    "test:watch": "vitest",
+    "test": "vitest run --project default --project typecheck --project llm-e2e",
+    "test:watch": "vitest --project default",
     "test:adversarial": "vitest run test/adversarial",
     "test:integration:openclaw-overlap": "vitest run test/integration/agent/friday-openclaw-overlap-acceptance.test.ts",
     "lint": "eslint src",
@@ -103,7 +103,7 @@
     "closeout:phase5": "node scripts/quality/run-closeout-phase.mjs phase5",
     "closeout:marketplace": "node scripts/quality/run-closeout-phase.mjs marketplace",
     "closeout:final": "node scripts/quality/run-closeout-final.mjs",
-    "release:verify": "npm run typecheck && npm run lint && npm run build && npm test && npm run test:integration:openclaw-overlap && npm run check:all && npm run test:install:smoke && npm run release:check",
+    "release:verify": "npm run typecheck && npm run lint && npm run build && npm test && npm run test:e2e:ui && npm run test:integration:openclaw-overlap && npm run check:all && npm run test:install:smoke && npm run release:check",
     "ui:dev": "vite --config ui/vite.config.ts",
     "ui:preview": "vite preview --config ui/vite.config.ts"
   },

--- a/test/e2e/mock/_helpers/mock-env.ts
+++ b/test/e2e/mock/_helpers/mock-env.ts
@@ -200,7 +200,7 @@ async function installProvider(
     validateOnSave: false,
     // For api-key providers, provide a mock key
     ...(entry.authMode === "api-key"
-      ? { apiKey: "mock-key-for-testing" }
+      ? { apiKey: "mock-key-for-testing" } // pragma: allowlist secret
       : {}),
   }, fetchImpl);
 

--- a/test/unit/api/http/friday-http-client-ip.test.ts
+++ b/test/unit/api/http/friday-http-client-ip.test.ts
@@ -76,7 +76,7 @@ describe("Friday HTTP client IP resolution", () => {
       db,
       idGenerator: () => `id-${String(++idCounter).padStart(4, "0")}`,
       nowIso: () => "2025-06-15T10:00:00.000Z",
-      tokenSecret: "test-route-secret",
+      tokenSecret: "test-route-secret", // pragma: allowlist secret
       accessTokenTtlSec: 900,
       refreshTokenTtlSec: 604800,
       allowLocalBypassLogin: true,


### PR DESCRIPTION
## Summary
- fix the `f0417fd` CI blockers by isolating browser E2E from default `npm test` and wiring it back into CI/release verification
- sync detect-secrets allowlists and baseline so the false positives no longer fail main CI
- bump Friday to `0.4.0` and publish release notes in `CHANGELOG.md`

## Validation
- `npm test`
- `npm run test:e2e:ui`
- `npm run release:verify`
- `npm run verify:product-local`
