### PR TITLE
chore(release): v0.4.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,9 @@ jobs:
             exit 1
           fi
 
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
       - name: Release verify
         run: npm run release:verify
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project follows Semantic Versioning.
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-03-24
+
+### Fixed
+- Release workflow `verify` job now installs Playwright Chromium before running `release:verify`, matching main CI and preventing browser-backed mock E2E failures during tag validation.
+
 ## [0.4.0] - 2026-03-24
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "friday",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "friday",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "friday",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "description": "Friday visual AI automation platform",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- install Playwright Chromium in the release verify job before `npm run release:verify`
- bump release metadata to `0.4.1`
- document the release workflow fix in the changelog

## Verification
- `npm run release:verify`