### PR TITLE
chore(release): v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project follows Semantic Versioning.
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-03-24
+
+### Fixed
+- macOS release no longer fails the entire tagged release when optional Homebrew tap publication is rejected; the workflow now continues with generated cask artifacts and release manifest metadata.
+- Homebrew tap publication now surfaces the underlying `git clone` / `git push` error output instead of failing with an opaque exit code.
+
 ## [0.4.1] - 2026-03-24
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "friday",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "friday",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "friday",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "description": "Friday visual AI automation platform",
   "license": "MIT",

--- a/scripts/ops/publish-friday-homebrew-cask.sh
+++ b/scripts/ops/publish-friday-homebrew-cask.sh
@@ -79,6 +79,15 @@ run_git() {
   "$@"
 }
 
+print_git_failure() {
+  local prefix="$1"
+  local log_path="$2"
+  echo "${prefix}" >&2
+  if [[ -f "${log_path}" ]]; then
+    sed 's/^/[friday-homebrew-publish] /' "${log_path}" >&2
+  fi
+}
+
 clone_target() {
   if [[ "${TAP_REPO}" == /* || "${TAP_REPO}" == file://* || "${TAP_REPO}" == *.git ]]; then
     printf '%s\n' "${TAP_REPO}"
@@ -90,7 +99,11 @@ clone_target() {
 }
 
 REMOTE_URL="$(clone_target)"
-run_git git clone "${REMOTE_URL}" "${TEMP_DIR}/tap" >/dev/null 2>&1
+CLONE_ERROR_LOG="${TEMP_DIR}/clone.stderr"
+if ! run_git git clone "${REMOTE_URL}" "${TEMP_DIR}/tap" >/dev/null 2>"${CLONE_ERROR_LOG}"; then
+  print_git_failure "[friday-homebrew-publish] failed to clone tap repo ${TAP_REPO}." "${CLONE_ERROR_LOG}"
+  exit 128
+fi
 
 mkdir -p "${TEMP_DIR}/tap/Casks"
 cp "${CASK_PATH}" "${TEMP_DIR}/tap/Casks/friday.rb"
@@ -102,7 +115,11 @@ else
   git add Casks/friday.rb
   git -c user.name="Codex" -c user.email="codex@openai.com" \
     commit -m "friday: update cask" >/dev/null
-  run_git git push origin HEAD >/dev/null 2>&1
+  PUSH_ERROR_LOG="${TEMP_DIR}/push.stderr"
+  if ! run_git git push origin HEAD >/dev/null 2>"${PUSH_ERROR_LOG}"; then
+    print_git_failure "[friday-homebrew-publish] failed to push cask update to ${TAP_REPO}." "${PUSH_ERROR_LOG}"
+    exit 128
+  fi
 fi
 popd >/dev/null
 

--- a/scripts/ops/release-friday-companion-app.sh
+++ b/scripts/ops/release-friday-companion-app.sh
@@ -139,8 +139,13 @@ node "${REPO_DIR}/scripts/ops/write-friday-release-manifest.mjs" >/dev/null
 
 if [[ -n "${FRIDAY_HOMEBREW_TAP_REPO:-}" && -n "${FRIDAY_HOMEBREW_TAP_GITHUB_TOKEN:-}" ]]; then
   echo "[friday-companion-release] publishing Homebrew cask" >&2
-  bash "${REPO_DIR}/scripts/ops/publish-friday-homebrew-cask.sh" "${REPO_DIR}" >/dev/null
-  echo "[friday-companion-release] refreshing release manifest after Homebrew publication" >&2
+  if bash "${REPO_DIR}/scripts/ops/publish-friday-homebrew-cask.sh" "${REPO_DIR}" >/dev/null; then
+    echo "[friday-companion-release] refreshing release manifest after Homebrew publication" >&2
+  else
+    echo "[friday-companion-release] Homebrew cask publication failed; continuing with generated cask only" >&2
+    rm -f "${CHANNELS_DIR}/homebrew.json"
+    echo "[friday-companion-release] refreshing release manifest after Homebrew publication fallback" >&2
+  fi
   node "${REPO_DIR}/scripts/ops/write-friday-release-manifest.mjs" >/dev/null
 fi
 

--- a/test/integration/system/friday-homebrew-cask-publication.integration.test.ts
+++ b/test/integration/system/friday-homebrew-cask-publication.integration.test.ts
@@ -7,6 +7,11 @@ import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
 
 const execFileAsync = promisify(execFile);
+type ExecFailure = Error & {
+  code?: number;
+  stdout?: string;
+  stderr?: string;
+};
 
 describe("Friday Homebrew cask publication", () => {
   it("publishes the generated cask to a local tap repository and writes channel metadata", async () => {
@@ -72,5 +77,67 @@ describe("Friday Homebrew cask publication", () => {
     expect(channelMetadata.channel).toBe("homebrew");
     expect(channelMetadata.availability).toBe("published");
     expect(channelMetadata.tapRepo).toBe(remoteRepo);
+  });
+
+  it("surfaces push failures with actionable stderr", async () => {
+    const repoRoot = process.cwd();
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "friday-homebrew-publish-fail-"));
+    const workRepo = path.join(tempRoot, "tap-work");
+    const remoteRepo = path.join(tempRoot, "tap-remote.git");
+    const caskDir = path.join(tempRoot, "dist", "releases", "homebrew", "Casks");
+    const channelsDir = path.join(tempRoot, "dist", "releases", "channels");
+
+    await fs.mkdir(workRepo, { recursive: true });
+    await execFileAsync("git", ["init", "-b", "main"], { cwd: workRepo });
+    await fs.writeFile(path.join(workRepo, "README.md"), "# friday tap\n", "utf8");
+    await execFileAsync("git", ["add", "README.md"], { cwd: workRepo });
+    await execFileAsync("git", ["-c", "user.name=Codex", "-c", "user.email=codex@openai.com", "commit", "-m", "init"], { cwd: workRepo });
+    await execFileAsync("git", ["clone", "--bare", workRepo, remoteRepo]);
+    await execFileAsync("git", ["remote", "add", "origin", remoteRepo], { cwd: workRepo });
+    await execFileAsync("git", ["push", "-u", "origin", "main"], { cwd: workRepo });
+    await fs.writeFile(
+      path.join(remoteRepo, "hooks", "pre-receive"),
+      "#!/bin/sh\necho 'remote rejected cask update' >&2\nexit 1\n",
+      "utf8",
+    );
+    await fs.chmod(path.join(remoteRepo, "hooks", "pre-receive"), 0o755);
+
+    await fs.mkdir(caskDir, { recursive: true });
+    await fs.writeFile(
+      path.join(caskDir, "friday.rb"),
+      [
+        'cask "friday" do',
+        '  version "1.2.4"',
+        '  sha256 "def456"',
+        '  url "https://example.test/friday.dmg"',
+        '  app "FridayCompanion.app"',
+        "end",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const error = await execFileAsync(
+      "bash",
+      [path.join(repoRoot, "scripts/ops/publish-friday-homebrew-cask.sh"), repoRoot],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          FRIDAY_HOMEBREW_TAP_REPO: remoteRepo,
+          FRIDAY_SYSTEM_COMPANION_HOMEBREW_CASK_PATH: path.join(caskDir, "friday.rb"),
+          FRIDAY_RELEASE_CHANNELS_DIR: channelsDir,
+        },
+      },
+    ).then(
+      () => null,
+      (failure) => failure as ExecFailure,
+    );
+
+    expect(error).not.toBeNull();
+    expect(error?.code).toBe(128);
+    expect(error?.stderr ?? "").toContain("failed to push cask update");
+    expect(error?.stderr ?? "").toContain("remote rejected cask update");
   });
 });

--- a/test/integration/system/friday-system-companion-release.integration.test.ts
+++ b/test/integration/system/friday-system-companion-release.integration.test.ts
@@ -31,6 +31,29 @@ async function runReleaseScript(
 }
 
 describeIfDarwin("Friday native companion release workflow", () => {
+  async function createRejectingHomebrewTap(prefix: string): Promise<string> {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+    const workRepo = path.join(tempRoot, "tap-work");
+    const remoteRepo = path.join(tempRoot, "tap-remote.git");
+
+    await fs.mkdir(workRepo, { recursive: true });
+    await execFileAsync("git", ["init", "-b", "main"], { cwd: workRepo });
+    await fs.writeFile(path.join(workRepo, "README.md"), "# friday tap\n", "utf8");
+    await execFileAsync("git", ["add", "README.md"], { cwd: workRepo });
+    await execFileAsync("git", ["-c", "user.name=Codex", "-c", "user.email=codex@openai.com", "commit", "-m", "init"], { cwd: workRepo });
+    await execFileAsync("git", ["clone", "--bare", workRepo, remoteRepo]);
+    await execFileAsync("git", ["remote", "add", "origin", remoteRepo], { cwd: workRepo });
+    await execFileAsync("git", ["push", "-u", "origin", "main"], { cwd: workRepo });
+    await fs.writeFile(
+      path.join(remoteRepo, "hooks", "pre-receive"),
+      "#!/bin/sh\necho 'remote rejected cask update' >&2\nexit 1\n",
+      "utf8",
+    );
+    await fs.chmod(path.join(remoteRepo, "hooks", "pre-receive"), 0o755);
+
+    return remoteRepo;
+  }
+
   it("runs the local release workflow and verifies the packaged app", async () => {
     const repoRoot = process.cwd();
     const releaseEnv = await runReleaseScript(
@@ -190,6 +213,37 @@ describeIfDarwin("Friday native companion release workflow", () => {
     const contents = await fs.readFile(evidencePath, "utf8");
     expect(contents).toContain("Status: pending");
     expect(contents).toContain("Release mode: local");
+  }, 180_000);
+
+  it("degrades to generated Homebrew metadata when tap publication fails", async () => {
+    const repoRoot = process.cwd();
+    const remoteRepo = await createRejectingHomebrewTap("friday-release-homebrew-fallback-");
+    const releaseResult = await runReleaseScript(
+      path.join(repoRoot, "scripts/ops/release-friday-companion-app.sh"),
+      {
+        FRIDAY_MACOS_RELEASE_MODE: "local",
+        FRIDAY_HOMEBREW_TAP_REPO: remoteRepo,
+        FRIDAY_HOMEBREW_TAP_GITHUB_TOKEN: "local-test-token",
+      },
+    );
+
+    expect(releaseResult.stderr).toContain("publishing Homebrew cask");
+    expect(releaseResult.stderr).toContain("failed to push cask update");
+    expect(releaseResult.stderr).toContain("Homebrew cask publication failed; continuing with generated cask only");
+
+    const releaseRecord = JSON.parse(
+      await fs.readFile(path.join(repoRoot, "dist", "macos", "FridayCompanion.release.json"), "utf8"),
+    ) as {
+      manifestJsonPath: string | null;
+    };
+    const manifest = JSON.parse(
+      await fs.readFile(releaseRecord.manifestJsonPath!, "utf8"),
+    ) as {
+      channels: { homebrew: { availability: string; tapRepo: string | null } };
+    };
+
+    expect(manifest.channels.homebrew.availability).toBe("generated");
+    expect(manifest.channels.homebrew.tapRepo).toBeNull();
   }, 180_000);
 
   it("rejects notarized release mode when Apple credentials are missing", async () => {


### PR DESCRIPTION
## Summary
- keep macOS release going when optional Homebrew tap publication fails
- surface Homebrew tap clone/push stderr in CI logs
- bump release metadata to `0.4.2`

## Verification
- `npx vitest run test/integration/system/friday-homebrew-cask-publication.integration.test.ts`
- `npx vitest run test/integration/system/friday-system-companion-release.integration.test.ts`
- `npm run release:verify`