### PR TITLE
Phase 2: add plugin SDK preview policy summaries

### DIFF
--- a/docs/ops/openclaw-adoption/taskpacks/phase-2.json
+++ b/docs/ops/openclaw-adoption/taskpacks/phase-2.json
@@ -2,51 +2,60 @@
   "schemaVersion": "1.0",
   "phaseId": "phase2",
   "title": "Plugin SDK Preview",
-  "executionMode": "spec_only",
-  "goal": "Define the additive plugin SDK preview work without collapsing Friday's plugin and skills backbones into a single story.",
+  "executionMode": "hybrid",
+  "goal": "Add preview SDK capability metadata and allowlisted-partner policy to the existing plugin surfaces without collapsing Friday's plugin and skills backbones into a single story.",
   "allowedPaths": [
     "src/plugins",
     "src/api/http/routes/friday-plugin-routes.ts",
+    "src/api/model/friday-api-plugin.types.ts",
     "docs/plugin-system-design.md",
+    "docs/ops/openclaw-adoption/taskpacks/phase-2.json",
     "test/e2e/plugins",
-    "test/e2e/api/friday-api-plugins-routes.test.ts"
+    "test/e2e/api/friday-api-plugins-routes.test.ts",
+    "test/unit/plugins",
+    "test/unit/api/http/routes"
   ],
   "implementationWorkers": [
     {
-      "id": "phase2-plugin-sdk-preview-spec",
-      "title": "Load the committed plugin SDK preview taskpack",
+      "id": "phase2-plugin-sdk-preview",
+      "title": "Add preview SDK capability summaries and allowlisted-partner policy to plugin lifecycle surfaces",
       "runner": "command",
       "mode": "implementation",
       "steps": [
         {
-          "label": "phase2-taskpack-spec",
-          "command": "node",
+          "label": "phase2-plugin-targeted-tests",
+          "command": "npx",
           "args": [
-            "-e",
-            "console.log('phase2 taskpack spec validated')"
+            "vitest",
+            "run",
+            "test/unit/plugins/manifest/friday-plugin-manifest-schema.test.ts",
+            "test/unit/plugins/services/friday-plugin-service.test.ts",
+            "test/unit/api/http/routes/friday-plugin-routes.test.ts",
+            "test/e2e/api/friday-api-plugins-routes.test.ts"
           ]
         }
       ]
     }
   ],
   "repairWorker": {
-    "id": "phase2-plugin-sdk-preview-repair-spec",
+    "id": "phase2-plugin-sdk-preview-repair",
     "title": "Diagnose plugin preview blockers without rewriting marketplace ownership",
     "runner": "command",
     "mode": "repair",
     "steps": [
       {
-        "label": "phase2-taskpack-repair-spec",
-        "command": "node",
+        "label": "phase2-plugin-repair-check",
+        "command": "npm",
         "args": [
-          "-e",
-          "console.log('phase2 repair spec validated')"
+          "run",
+          "typecheck"
         ]
       }
     ]
   },
   "successCriteria": [
     "Preview capability manifests remain distinct from the canonical skills lifecycle.",
+    "Only first-party and allowlisted partner plugins can declare preview SDK capabilities.",
     "No arbitrary public package runtime is introduced."
   ],
   "closureEvidence": [
@@ -70,6 +79,7 @@
     }
   ],
   "notes": [
-    "This taskpack remains spec_only until concrete preview SDK implementation commands are authored."
+    "Preview SDK metadata must stay additive to the existing /v1/plugins* and /v1/marketplace/plugins* surfaces.",
+    "Partner allowlisting must remain bounded and must not turn plugin distribution into a second marketplace backbone."
   ]
 }

--- a/docs/plugin-system-design.md
+++ b/docs/plugin-system-design.md
@@ -279,6 +279,22 @@ export interface FridayPluginApi {
 }
 ```
 
+Preview SDK policy:
+
+- Preview registration metadata is additive and explicit. Plugins may declare a `previewSdk` block in `friday.plugin.json` with:
+  - `sdkVersion`
+  - `capabilities`: `registerTool`, `registerChannel`, `registerProvider`, `registerSkillPack`, `registerRoutes`, `registerHooks`
+  - optional `publisherId`
+- Declaring `previewSdk` does **not** create a second marketplace backbone and does **not** replace the canonical skills lifecycle.
+- Preview SDK installs and enablement are bounded to:
+  - first-party plugins (`friday.*`)
+  - explicitly allowlisted partner plugins or publishers
+- Untrusted plugins may still participate in the existing bounded plugin lifecycle, but they may not claim preview SDK registration surfaces.
+- Route families remain unchanged:
+  - `/v1/plugins*`
+  - `/v1/marketplace/plugins*`
+- API responses may add `capabilitySummary` and `policySummary`, but must not rename or replace the existing lifecycle routes.
+
 Lifecycle state machine:
 
 - `install -> configured -> enabled -> running -> disabled -> uninstalled`

--- a/src/api/http/routes/friday-plugin-routes.ts
+++ b/src/api/http/routes/friday-plugin-routes.ts
@@ -252,6 +252,9 @@ export function createFridayPluginRoutes(
             author: detail.author,
             downloads: detail.downloads,
             updatedAt: detail.updatedAt,
+            previewSdk: detail.previewSdk,
+            capabilitySummary: detail.capabilitySummary,
+            policySummary: detail.policySummary,
           },
         };
       },

--- a/src/api/model/friday-api-plugin.types.ts
+++ b/src/api/model/friday-api-plugin.types.ts
@@ -3,10 +3,10 @@
  */
 
 import type {
+  FridayPluginCapabilitySummary,
   FridayPluginEntity,
-  FridayPluginKind,
-  FridayPluginSource,
-  FridayPluginStatus,
+  FridayPluginPolicySummary,
+  FridayPluginSdkPreviewManifest,
 } from "#plugins";
 
 // ─── List Plugins ───
@@ -61,6 +61,9 @@ export interface FridayMarketplaceSearchResponse {
     author: string;
     downloads: number;
     updatedAt: string;
+    previewSdk?: FridayPluginSdkPreviewManifest;
+    capabilitySummary?: FridayPluginCapabilitySummary;
+    policySummary?: FridayPluginPolicySummary;
   }>;
   total: number;
 }
@@ -76,6 +79,9 @@ export interface FridayMarketplacePluginDetailResponse {
     author: string;
     downloads: number;
     updatedAt: string;
+    previewSdk?: FridayPluginSdkPreviewManifest;
+    capabilitySummary?: FridayPluginCapabilitySummary;
+    policySummary?: FridayPluginPolicySummary;
   };
 }
 

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -5,6 +5,8 @@ export type {
   FridayPluginSource,
   FridayPluginStatus,
   FridayPluginTrustMode,
+  FridayPluginSdkPreviewCapability,
+  FridayPluginPublisherProgram,
   FridayPluginPermissionResource,
   FridayPluginPermissionAction,
   FridayPluginPermissionGrant,
@@ -12,6 +14,9 @@ export type {
   FridayPluginPermissionPolicy,
   FridayPluginPromptOnAction,
   FridayPluginSignature,
+  FridayPluginSdkPreviewManifest,
+  FridayPluginCapabilitySummary,
+  FridayPluginPolicySummary,
   FridayPluginManifest,
   FridayPluginEntity,
   FridayPluginDependencyEntity,
@@ -38,6 +43,8 @@ export {
   FRIDAY_PLUGIN_VALID_KINDS,
   FRIDAY_PLUGIN_VALID_SOURCES,
   FRIDAY_PLUGIN_VALID_TRUST_MODES,
+  FRIDAY_PLUGIN_SDK_PREVIEW_VERSION,
+  FRIDAY_PLUGIN_VALID_SDK_PREVIEW_CAPABILITIES,
 } from "./model/friday-plugin.types.js";
 
 // ─── Manifest ───
@@ -115,6 +122,7 @@ export { createFridayPluginMarketplaceClient } from "./services/friday-plugin-ma
 export type {
   FridayPluginService,
   FridayPluginInstallInput,
+  FridayPluginPreviewPolicyConfig,
   FridayPluginVersionInfo,
   FridayMarketplacePluginVersionInfo,
   CreateFridayPluginServiceDeps,

--- a/src/plugins/manifest/friday-plugin-manifest.schema.ts
+++ b/src/plugins/manifest/friday-plugin-manifest.schema.ts
@@ -10,10 +10,13 @@ import type {
   FridayPluginManifest,
   FridayPluginPermissionGrant,
   FridayPluginPermissionPolicy,
+  FridayPluginSdkPreviewCapability,
+  FridayPluginSdkPreviewManifest,
 } from "../model/friday-plugin.types.js";
 import {
   FRIDAY_PLUGIN_ERROR_CODES,
   FRIDAY_PLUGIN_VALID_KINDS,
+  FRIDAY_PLUGIN_VALID_SDK_PREVIEW_CAPABILITIES,
 } from "../model/friday-plugin.types.js";
 
 // ─── Validation Helpers ───
@@ -128,6 +131,57 @@ function validatePermissions(permissions: unknown): FridayPluginPermissionPolicy
   return { grants, promptOn: p.promptOn as FridayPluginPermissionPolicy["promptOn"] };
 }
 
+function validatePreviewSdk(previewSdk: unknown): FridayPluginSdkPreviewManifest {
+  if (previewSdk == null || typeof previewSdk !== "object" || Array.isArray(previewSdk)) {
+    throw new FridayDomainError(
+      FRIDAY_PLUGIN_ERROR_CODES.MANIFEST_INVALID,
+      "previewSdk must be an object",
+      { httpStatus: 400 },
+    );
+  }
+
+  const p = previewSdk as Record<string, unknown>;
+  const errors: string[] = [];
+
+  if (!isNonEmptyString(p.sdkVersion)) {
+    errors.push("sdkVersion is required");
+  }
+
+  if (!Array.isArray(p.capabilities) || p.capabilities.length === 0) {
+    errors.push("capabilities must be a non-empty array");
+  } else {
+    for (const capability of p.capabilities) {
+      if (
+        typeof capability !== "string"
+        || !(FRIDAY_PLUGIN_VALID_SDK_PREVIEW_CAPABILITIES as readonly string[]).includes(capability)
+      ) {
+        errors.push(
+          `capabilities must contain only: ${FRIDAY_PLUGIN_VALID_SDK_PREVIEW_CAPABILITIES.join(", ")}`,
+        );
+        break;
+      }
+    }
+  }
+
+  if (p.publisherId !== undefined && !isNonEmptyString(p.publisherId)) {
+    errors.push("publisherId must be a non-empty string when provided");
+  }
+
+  if (errors.length > 0) {
+    throw new FridayDomainError(
+      FRIDAY_PLUGIN_ERROR_CODES.MANIFEST_INVALID,
+      `previewSdk: ${errors.join("; ")}`,
+      { httpStatus: 400 },
+    );
+  }
+
+  return {
+    sdkVersion: p.sdkVersion as string,
+    capabilities: p.capabilities as FridayPluginSdkPreviewCapability[],
+    publisherId: p.publisherId as string | undefined,
+  };
+}
+
 // ─── Main Validator ───
 
 /** Validates a parsed JSON object as a FridayPluginManifest. */
@@ -234,6 +288,8 @@ export function validateFridayPluginManifest(raw: unknown): FridayPluginManifest
   // Validate permissions separately (throws on error)
   const permissions = validatePermissions(m.permissions);
 
+  const previewSdk = m.previewSdk === undefined ? undefined : validatePreviewSdk(m.previewSdk);
+
   // Validate signature shape if present
   if (m.signature !== undefined) {
     if (m.signature == null || typeof m.signature !== "object") {
@@ -279,5 +335,6 @@ export function validateFridayPluginManifest(raw: unknown): FridayPluginManifest
     permissions,
     compatibility: m.compatibility as FridayPluginManifest["compatibility"],
     signature: m.signature as FridayPluginManifest["signature"],
+    previewSdk,
   };
 }

--- a/src/plugins/model/friday-plugin.types.ts
+++ b/src/plugins/model/friday-plugin.types.ts
@@ -42,6 +42,7 @@ export const FRIDAY_PLUGIN_ERROR_CODES = {
   SIGNATURE_INVALID: "PLUGIN_SIGNATURE_INVALID",
   TRUST_FINGERPRINT_MISMATCH: "PLUGIN_TRUST_FINGERPRINT_MISMATCH",
   DISCOVERY_FAILED: "PLUGIN_DISCOVERY_FAILED",
+  PREVIEW_POLICY_BLOCKED: "PLUGIN_PREVIEW_POLICY_BLOCKED",
 } as const;
 
 export const FRIDAY_PLUGIN_VALID_STATUSES: readonly FridayPluginStatus[] = [
@@ -74,6 +75,17 @@ export const FRIDAY_PLUGIN_VALID_TRUST_MODES: readonly FridayPluginTrustMode[] =
   "trust_on_install",
 ];
 
+export const FRIDAY_PLUGIN_SDK_PREVIEW_VERSION = "2026-03-preview" as const;
+
+export const FRIDAY_PLUGIN_VALID_SDK_PREVIEW_CAPABILITIES: readonly FridayPluginSdkPreviewCapability[] = [
+  "registerTool",
+  "registerChannel",
+  "registerProvider",
+  "registerSkillPack",
+  "registerRoutes",
+  "registerHooks",
+];
+
 // ─── Core Types ───
 
 export type FridayPluginKind =
@@ -96,6 +108,19 @@ export type FridayPluginStatus =
   | "uninstalled";
 
 export type FridayPluginTrustMode = "signed" | "trust_on_install";
+
+export type FridayPluginSdkPreviewCapability =
+  | "registerTool"
+  | "registerChannel"
+  | "registerProvider"
+  | "registerSkillPack"
+  | "registerRoutes"
+  | "registerHooks";
+
+export type FridayPluginPublisherProgram =
+  | "first_party"
+  | "allowlisted_partner"
+  | "untrusted";
 
 // ─── Permission Types ───
 
@@ -159,6 +184,27 @@ export interface FridayPluginSignature {
   value: string;
 }
 
+export interface FridayPluginSdkPreviewManifest {
+  sdkVersion: string;
+  capabilities: FridayPluginSdkPreviewCapability[];
+  publisherId?: string;
+}
+
+export interface FridayPluginCapabilitySummary {
+  previewEnabled: boolean;
+  sdkVersion: string | null;
+  requestedCapabilities: FridayPluginSdkPreviewCapability[];
+  supportedCapabilities: FridayPluginSdkPreviewCapability[];
+  unsupportedCapabilities: FridayPluginSdkPreviewCapability[];
+}
+
+export interface FridayPluginPolicySummary {
+  publisherProgram: FridayPluginPublisherProgram;
+  installAllowed: boolean;
+  enableAllowed: boolean;
+  reasons: string[];
+}
+
 // ─── Manifest ───
 
 export interface FridayPluginManifest {
@@ -176,6 +222,7 @@ export interface FridayPluginManifest {
     apiVersion: "1";
   };
   signature?: FridayPluginSignature;
+  previewSdk?: FridayPluginSdkPreviewManifest;
 }
 
 // ─── Persistence Entity ───
@@ -203,6 +250,8 @@ export interface FridayPluginEntity {
   updatedAt: string;
   lastErrorCode: string | null;
   lastErrorMessage: string | null;
+  capabilitySummary?: FridayPluginCapabilitySummary;
+  policySummary?: FridayPluginPolicySummary;
 }
 
 export interface FridayPluginDependencyEntity {

--- a/src/plugins/services/friday-plugin-marketplace-client.ts
+++ b/src/plugins/services/friday-plugin-marketplace-client.ts
@@ -5,7 +5,12 @@
  */
 
 import { FridayDomainError } from "#errors";
-import type { FridayPluginManifest } from "../model/friday-plugin.types.js";
+import type {
+  FridayPluginCapabilitySummary,
+  FridayPluginManifest,
+  FridayPluginPolicySummary,
+  FridayPluginSdkPreviewManifest,
+} from "../model/friday-plugin.types.js";
 import { FRIDAY_PLUGIN_ERROR_CODES } from "../model/friday-plugin.types.js";
 
 // ─── Types ───
@@ -18,6 +23,9 @@ export interface FridayMarketplacePluginSummary {
   author: string;
   downloads: number;
   updatedAt: string;
+  previewSdk?: FridayPluginSdkPreviewManifest;
+  capabilitySummary?: FridayPluginCapabilitySummary;
+  policySummary?: FridayPluginPolicySummary;
 }
 
 export interface FridayMarketplacePluginDetail {
@@ -31,6 +39,9 @@ export interface FridayMarketplacePluginDetail {
   checksum: string;
   packageUrl: string;
   updatedAt: string;
+  previewSdk?: FridayPluginSdkPreviewManifest;
+  capabilitySummary?: FridayPluginCapabilitySummary;
+  policySummary?: FridayPluginPolicySummary;
 }
 
 export interface FridayMarketplaceSearchQuery {

--- a/src/plugins/services/friday-plugin-service.ts
+++ b/src/plugins/services/friday-plugin-service.ts
@@ -11,8 +11,18 @@ import {
   FRIDAY_CORE_CHANNEL_PLUGIN_IDS,
   FRIDAY_PLUGIN_ERROR_CODES,
   FRIDAY_PLUGIN_MANIFEST_FILENAME,
+  FRIDAY_PLUGIN_SDK_PREVIEW_VERSION,
+  FRIDAY_PLUGIN_VALID_SDK_PREVIEW_CAPABILITIES,
 } from "../model/friday-plugin.types.js";
-import type { FridayPluginEntity, FridayPluginListQuery, FridayPluginManifest } from "../model/friday-plugin.types.js";
+import type {
+  FridayPluginCapabilitySummary,
+  FridayPluginEntity,
+  FridayPluginListQuery,
+  FridayPluginManifest,
+  FridayPluginPolicySummary,
+  FridayPluginPublisherProgram,
+  FridayPluginSdkPreviewCapability,
+} from "../model/friday-plugin.types.js";
 import type {
   CreateFridayPluginServiceDeps,
   FridayPluginInstallInput,
@@ -35,6 +45,7 @@ export function createFridayPluginService(
     loader,
     marketplace,
     signatureVerifier,
+    previewPolicy,
     nowIso,
   } = deps;
 
@@ -43,6 +54,13 @@ export function createFridayPluginService(
   );
 
   const coreIds = new Set<string>(FRIDAY_CORE_CHANNEL_PLUGIN_IDS);
+  const supportedCapabilities = new Set<FridayPluginSdkPreviewCapability>(
+    previewPolicy?.supportedCapabilities ?? FRIDAY_PLUGIN_VALID_SDK_PREVIEW_CAPABILITIES,
+  );
+  const firstPartyIdPrefixes = previewPolicy?.firstPartyIdPrefixes ?? ["friday."];
+  const allowlistedPluginIds = new Set(previewPolicy?.allowlistedPluginIds ?? []);
+  const allowlistedPublisherIds = new Set(previewPolicy?.allowlistedPublisherIds ?? []);
+  const supportedSdkVersion = previewPolicy?.sdkVersion ?? FRIDAY_PLUGIN_SDK_PREVIEW_VERSION;
 
   /**
    * Builds synthetic package bytes from a local install directory by reading
@@ -88,13 +106,100 @@ export function createFridayPluginService(
     }
   }
 
+  function classifyPublisherProgram(
+    pluginId: string,
+    manifest: FridayPluginManifest,
+  ): FridayPluginPublisherProgram {
+    if (firstPartyIdPrefixes.some((prefix) => pluginId.startsWith(prefix))) {
+      return "first_party";
+    }
+    if (
+      allowlistedPluginIds.has(pluginId)
+      || (manifest.previewSdk?.publisherId !== undefined && allowlistedPublisherIds.has(manifest.previewSdk.publisherId))
+    ) {
+      return "allowlisted_partner";
+    }
+    return "untrusted";
+  }
+
+  function buildCapabilitySummary(manifest: FridayPluginManifest): FridayPluginCapabilitySummary {
+    const requestedCapabilities = manifest.previewSdk?.capabilities ?? [];
+    const supportedList = requestedCapabilities.filter((capability) => supportedCapabilities.has(capability));
+    const unsupportedList = requestedCapabilities.filter((capability) => !supportedCapabilities.has(capability));
+
+    return {
+      previewEnabled: manifest.previewSdk !== undefined,
+      sdkVersion: manifest.previewSdk?.sdkVersion ?? null,
+      requestedCapabilities,
+      supportedCapabilities: supportedList,
+      unsupportedCapabilities: unsupportedList,
+    };
+  }
+
+  function buildPolicySummary(
+    pluginId: string,
+    manifest: FridayPluginManifest,
+  ): FridayPluginPolicySummary {
+    const capabilitySummary = buildCapabilitySummary(manifest);
+    const publisherProgram = classifyPublisherProgram(pluginId, manifest);
+    const reasons: string[] = [];
+
+    if (manifest.previewSdk?.sdkVersion && manifest.previewSdk.sdkVersion !== supportedSdkVersion) {
+      reasons.push(
+        `Preview SDK version "${manifest.previewSdk.sdkVersion}" is not supported by this hub. Expected "${supportedSdkVersion}".`,
+      );
+    }
+
+    if (capabilitySummary.unsupportedCapabilities.length > 0) {
+      reasons.push(
+        `Unsupported preview capabilities: ${capabilitySummary.unsupportedCapabilities.join(", ")}`,
+      );
+    }
+
+    if (manifest.previewSdk !== undefined && publisherProgram === "untrusted") {
+      reasons.push("Preview SDK plugins are limited to first-party and allowlisted partner publishers.");
+    }
+
+    const allowed = reasons.length === 0;
+
+    return {
+      publisherProgram,
+      installAllowed: allowed,
+      enableAllowed: allowed,
+      reasons,
+    };
+  }
+
+  function assertPreviewPolicy(pluginId: string, manifest: FridayPluginManifest): void {
+    if (manifest.previewSdk === undefined) {
+      return;
+    }
+    const policySummary = buildPolicySummary(pluginId, manifest);
+    if (!policySummary.installAllowed) {
+      throw new FridayDomainError(
+        FRIDAY_PLUGIN_ERROR_CODES.PREVIEW_POLICY_BLOCKED,
+        `Preview SDK policy blocked plugin "${pluginId}"`,
+        { httpStatus: 403, details: { pluginId, policySummary } },
+      );
+    }
+  }
+
+  function enrichPluginEntity(entity: FridayPluginEntity): FridayPluginEntity {
+    return {
+      ...entity,
+      capabilitySummary: buildCapabilitySummary(entity.manifest),
+      policySummary: buildPolicySummary(entity.id, entity.manifest),
+    };
+  }
+
   return {
     listPlugins(query?: FridayPluginListQuery): FridayPluginEntity[] {
-      return registry.list(query);
+      return registry.list(query).map((entity) => enrichPluginEntity(entity));
     },
 
     getPlugin(pluginId: string): FridayPluginEntity | null {
-      return registry.get(pluginId);
+      const entity = registry.get(pluginId);
+      return entity ? enrichPluginEntity(entity) : null;
     },
 
     listPluginVersions(pluginId: string) {
@@ -111,6 +216,8 @@ export function createFridayPluginService(
 
     installPlugin(input: FridayPluginInstallInput): FridayPluginEntity {
       const { manifest, installPath, source, packageBytes, userApproved } = input;
+
+      assertPreviewPolicy(manifest.id, manifest);
 
       // Check not already installed
       const existing = registry.get(manifest.id);
@@ -217,11 +324,20 @@ export function createFridayPluginService(
         nowIso: now,
       });
 
-      return entity;
+      return enrichPluginEntity(entity);
     },
 
     async enablePlugin(pluginId: string): Promise<FridayPluginEntity> {
       const entity = requirePlugin(pluginId);
+      const policySummary = buildPolicySummary(pluginId, entity.manifest);
+
+      if (!policySummary.enableAllowed) {
+        throw new FridayDomainError(
+          FRIDAY_PLUGIN_ERROR_CODES.PREVIEW_POLICY_BLOCKED,
+          `Preview SDK policy blocked enablement for plugin "${pluginId}"`,
+          { httpStatus: 403, details: { pluginId, policySummary } },
+        );
+      }
 
       if (entity.status === "enabled" || entity.status === "running") {
         throw new FridayDomainError(
@@ -250,7 +366,7 @@ export function createFridayPluginService(
       // Load the plugin via loader to keep runtime state in sync
       await loader.load(loadPlan);
 
-      return requirePlugin(pluginId);
+      return enrichPluginEntity(requirePlugin(pluginId));
     },
 
     async disablePlugin(pluginId: string): Promise<FridayPluginEntity> {
@@ -291,7 +407,7 @@ export function createFridayPluginService(
         registry.setEnabled(pluginId, false, nowIso());
       }
 
-      return requirePlugin(pluginId);
+      return enrichPluginEntity(requirePlugin(pluginId));
     },
 
     async uninstallPlugin(pluginId: string, force?: boolean): Promise<void> {
@@ -334,7 +450,36 @@ export function createFridayPluginService(
         // This keeps marketplace discovery UI/API paths functional in local mode.
         return { items: [], total: 0 };
       }
-      return marketplace.search(query);
+      const result = await marketplace.search(query);
+      return {
+        ...result,
+        items: result.items.map((item) => {
+          const manifest = item.previewSdk
+            ? {
+                schemaVersion: "1.0" as const,
+                id: item.id,
+                version: item.version,
+                name: item.name,
+                description: item.description,
+                kinds: [],
+                entrypoints: {},
+                permissions: { grants: [], promptOn: [] },
+                compatibility: { minHubVersion: "0.0.0", apiVersion: "1" as const },
+                previewSdk: item.previewSdk,
+              }
+            : undefined;
+
+          return {
+            ...item,
+            capabilitySummary: manifest
+              ? buildCapabilitySummary(manifest)
+              : item.capabilitySummary,
+            policySummary: manifest
+              ? buildPolicySummary(item.id, manifest)
+              : item.policySummary,
+          };
+        }),
+      };
     },
 
     async listMarketplacePluginVersions(pluginId: string) {
@@ -361,7 +506,12 @@ export function createFridayPluginService(
           { httpStatus: 503 },
         );
       }
-      return marketplace.getPluginDetail(pluginId);
+      const detail = await marketplace.getPluginDetail(pluginId);
+      return {
+        ...detail,
+        capabilitySummary: buildCapabilitySummary(detail.manifest),
+        policySummary: buildPolicySummary(detail.id, detail.manifest),
+      };
     },
 
     async installFromMarketplace(pluginId: string): Promise<FridayPluginEntity> {

--- a/src/plugins/services/friday-plugin-service.types.ts
+++ b/src/plugins/services/friday-plugin-service.types.ts
@@ -7,6 +7,7 @@ import type {
   FridayPluginEntity,
   FridayPluginListQuery,
   FridayPluginManifest,
+  FridayPluginSdkPreviewCapability,
 } from "../model/friday-plugin.types.js";
 import type { FridayPluginRegistryService } from "./friday-plugin-registry-service.js";
 import type { FridayPluginDependencyResolver } from "./friday-plugin-dependency-resolver.js";
@@ -68,6 +69,14 @@ export interface FridayPluginInstallInput {
   userApproved?: boolean;
 }
 
+export interface FridayPluginPreviewPolicyConfig {
+  sdkVersion?: string;
+  supportedCapabilities?: FridayPluginSdkPreviewCapability[];
+  firstPartyIdPrefixes?: string[];
+  allowlistedPluginIds?: string[];
+  allowlistedPublisherIds?: string[];
+}
+
 // ─── Deps ───
 
 export interface CreateFridayPluginServiceDeps {
@@ -77,6 +86,7 @@ export interface CreateFridayPluginServiceDeps {
   loader: FridayPluginLoader;
   marketplace?: FridayPluginMarketplaceClient;
   signatureVerifier: FridayPluginSignatureVerifier;
+  previewPolicy?: FridayPluginPreviewPolicyConfig;
   nowIso: () => string;
   idGenerator: () => string;
   /** Read a file from disk as a Buffer. Used to compute fingerprints for local installs. */

--- a/test/unit/api/http/routes/friday-plugin-routes.test.ts
+++ b/test/unit/api/http/routes/friday-plugin-routes.test.ts
@@ -102,6 +102,24 @@ describe("FridayPluginRoutes", () => {
         checksum: "abc",
         packageUrl: "url",
         updatedAt: NOW,
+        previewSdk: {
+          sdkVersion: "2026-03-preview",
+          capabilities: ["registerTool"],
+          publisherId: "partner.preview",
+        },
+        capabilitySummary: {
+          previewEnabled: true,
+          sdkVersion: "2026-03-preview",
+          requestedCapabilities: ["registerTool"],
+          supportedCapabilities: ["registerTool"],
+          unsupportedCapabilities: [],
+        },
+        policySummary: {
+          publisherProgram: "allowlisted_partner",
+          installAllowed: true,
+          enableAllowed: true,
+          reasons: [],
+        },
       })),
       listMarketplacePluginVersions: vi.fn(async () => [
         { version: "1.0.0", releasedAt: NOW, checksum: "abc123" },
@@ -262,7 +280,14 @@ describe("FridayPluginRoutes", () => {
   it("gets marketplace plugin detail", async () => {
     const route = findRoute("marketplace.plugins.get");
     const result = await route.handler(makeCtx({ params: { id: "friday.test.mp" } }));
-    expect(result).toMatchObject({ plugin: { id: "friday.test.mp" } });
+    expect(result).toMatchObject({
+      plugin: {
+        id: "friday.test.mp",
+        previewSdk: { sdkVersion: "2026-03-preview" },
+        capabilitySummary: { requestedCapabilities: ["registerTool"] },
+        policySummary: { publisherProgram: "allowlisted_partner" },
+      },
+    });
   });
 
   // ─── marketplace.plugins.versions.list ───

--- a/test/unit/plugins/manifest/friday-plugin-manifest-schema.test.ts
+++ b/test/unit/plugins/manifest/friday-plugin-manifest-schema.test.ts
@@ -80,6 +80,22 @@ describe("validateFridayPluginManifest", () => {
     expect(result.permissions.promptOn).toEqual(["filesystem.write"]);
   });
 
+  it("accepts manifest with previewSdk metadata", () => {
+    const result = validateFridayPluginManifest(validManifest({
+      previewSdk: {
+        sdkVersion: "2026-03-preview",
+        capabilities: ["registerTool", "registerHooks"],
+        publisherId: "partner.weather",
+      },
+    }));
+
+    expect(result.previewSdk).toEqual({
+      sdkVersion: "2026-03-preview",
+      capabilities: ["registerTool", "registerHooks"],
+      publisherId: "partner.weather",
+    });
+  });
+
   // ─── Required fields ───
 
   it("rejects null input", () => {
@@ -208,6 +224,24 @@ describe("validateFridayPluginManifest", () => {
         promptOn: ["invalid.action"],
       },
     }))).toThrow("promptOn");
+  });
+
+  it("rejects previewSdk with invalid capability", () => {
+    expect(() => validateFridayPluginManifest(validManifest({
+      previewSdk: {
+        sdkVersion: "2026-03-preview",
+        capabilities: ["registerTool", "explodeRuntime"],
+      },
+    }))).toThrow("previewSdk");
+  });
+
+  it("rejects previewSdk without sdkVersion", () => {
+    expect(() => validateFridayPluginManifest(validManifest({
+      previewSdk: {
+        sdkVersion: "",
+        capabilities: ["registerTool"],
+      },
+    }))).toThrow("previewSdk");
   });
 
   // ─── Signature validation ───

--- a/test/unit/plugins/services/friday-plugin-service.test.ts
+++ b/test/unit/plugins/services/friday-plugin-service.test.ts
@@ -92,6 +92,90 @@ describe("FridayPluginService", () => {
     expect(entity.trustMode).toBe("trust_on_install");
   });
 
+  it("surfaces preview capability and policy summaries for first-party preview plugins", () => {
+    const manifest = makeManifest("friday.test.preview", {
+      previewSdk: {
+        sdkVersion: "2026-03-preview",
+        capabilities: ["registerTool", "registerHooks"],
+      },
+    });
+
+    const entity = service.installPlugin({
+      manifest,
+      installPath: "/plugins/friday.test.preview",
+      source: "local",
+      userApproved: true,
+    });
+
+    expect(entity.capabilitySummary).toMatchObject({
+      previewEnabled: true,
+      sdkVersion: "2026-03-preview",
+      requestedCapabilities: ["registerTool", "registerHooks"],
+      supportedCapabilities: ["registerTool", "registerHooks"],
+      unsupportedCapabilities: [],
+    });
+    expect(entity.policySummary).toMatchObject({
+      publisherProgram: "first_party",
+      installAllowed: true,
+      enableAllowed: true,
+    });
+  });
+
+  it("blocks preview SDK installs for untrusted publishers", () => {
+    const manifest = makeManifest("partner.test.preview", {
+      previewSdk: {
+        sdkVersion: "2026-03-preview",
+        capabilities: ["registerTool"],
+        publisherId: "partner.test",
+      },
+    });
+
+    expect(() =>
+      service.installPlugin({
+        manifest,
+        installPath: "/plugins/partner.test.preview",
+        source: "local",
+        userApproved: true,
+      }),
+    ).toThrow(FridayDomainError);
+  });
+
+  it("allows preview SDK installs for allowlisted partners", () => {
+    const allowlistedService = createFridayPluginService({
+      sqlite: db,
+      registry,
+      resolver,
+      loader,
+      signatureVerifier,
+      previewPolicy: {
+        allowlistedPluginIds: ["partner.test.preview"],
+        allowlistedPublisherIds: ["partner.test"],
+      },
+      nowIso: () => NOW,
+      idGenerator: () => "test-id",
+      readFileAsBuffer: () => Buffer.from("mock-file-content"),
+    });
+
+    const entity = allowlistedService.installPlugin({
+      manifest: makeManifest("partner.test.preview", {
+        previewSdk: {
+          sdkVersion: "2026-03-preview",
+          capabilities: ["registerRoutes", "registerHooks"],
+          publisherId: "partner.test",
+        },
+      }),
+      installPath: "/plugins/partner.test.preview",
+      source: "local",
+      userApproved: true,
+    });
+
+    expect(entity.policySummary).toMatchObject({
+      publisherProgram: "allowlisted_partner",
+      installAllowed: true,
+      enableAllowed: true,
+    });
+  });
+
   it("computes and stores fingerprint for local install without packageBytes", () => {
     const manifest = makeManifest("friday.test.alpha");
     const entity = service.installPlugin({
@@ -423,7 +507,25 @@ describe("FridayPluginService", () => {
 
   it("searches marketplace when configured", async () => {
     const mockMarketplace: FridayPluginMarketplaceClient = {
-      search: vi.fn(async () => ({ items: [], total: 0 })),
+      search: vi.fn(async () => ({
+        items: [
+          {
+            id: "partner.preview.plugin",
+            name: "Preview Plugin",
+            description: "Test preview plugin",
+            version: "1.0.0",
+            author: "Partner",
+            downloads: 0,
+            updatedAt: NOW,
+            previewSdk: {
+              sdkVersion: "2026-03-preview",
+              capabilities: ["registerTool"],
+              publisherId: "partner.preview",
+            },
+          },
+        ],
+        total: 1,
+      })),
       getPluginDetail: vi.fn(async () => ({
         id: "test",
         name: "Test",
@@ -453,13 +555,78 @@ describe("FridayPluginService", () => {
       loader,
       marketplace: mockMarketplace,
       signatureVerifier,
+      previewPolicy: {
+        allowlistedPublisherIds: ["partner.preview"],
+      },
       nowIso: () => NOW,
       idGenerator: () => "test-id",
     });
 
     const result = await serviceWithMp.searchMarketplace({ query: "test" });
-    expect(result.items).toEqual([]);
+    expect(result.items[0]?.capabilitySummary).toMatchObject({
+      previewEnabled: true,
+      requestedCapabilities: ["registerTool"],
+    });
+    expect(result.items[0]?.policySummary).toMatchObject({
+      publisherProgram: "allowlisted_partner",
+      installAllowed: true,
+    });
     expect(mockMarketplace.search).toHaveBeenCalled();
+  });
+
+  it("enriches marketplace detail with preview policy summaries", async () => {
+    const mockMarketplace: FridayPluginMarketplaceClient = {
+      search: vi.fn(async () => ({ items: [], total: 0 })),
+      getPluginDetail: vi.fn(async () => ({
+        id: "partner.detail.preview",
+        name: "Detail Preview",
+        description: "Test",
+        version: "1.0.0",
+        author: "Partner",
+        downloads: 1,
+        manifest: makeManifest("partner.detail.preview", {
+          previewSdk: {
+            sdkVersion: "2026-03-preview",
+            capabilities: ["registerProvider"],
+            publisherId: "partner.detail",
+          },
+        }),
+        checksum: "abc",
+        packageUrl: "url",
+        updatedAt: NOW,
+      })),
+      listVersions: vi.fn(async () => []),
+      downloadPackage: vi.fn(async () => ({
+        packageBytes: Buffer.from("data"),
+        checksum: "checksum-123",
+        manifest: makeManifest("partner.detail.preview"),
+      })),
+    };
+
+    const serviceWithMp = createFridayPluginService({
+      sqlite: db,
+      registry,
+      resolver,
+      loader,
+      marketplace: mockMarketplace,
+      signatureVerifier,
+      previewPolicy: {
+        allowlistedPublisherIds: ["partner.detail"],
+      },
+      nowIso: () => NOW,
+      idGenerator: () => "test-id",
+    });
+
+    const detail = await serviceWithMp.getMarketplacePlugin("partner.detail.preview");
+
+    expect(detail.capabilitySummary).toMatchObject({
+      previewEnabled: true,
+      requestedCapabilities: ["registerProvider"],
+    });
+    expect(detail.policySummary).toMatchObject({
+      publisherProgram: "allowlisted_partner",
+      installAllowed: true,
+    });
   });
 
   it("lists marketplace plugin versions when configured", async () => {


### PR DESCRIPTION
## Summary
- add additive preview SDK metadata and allowlisted-partner policy summaries to plugin lifecycle surfaces
- validate optional previewSdk manifests and block untrusted preview SDK installs/enables
- update phase2 taskpack, plugin design docs, and route/service tests without changing route families or the skills backbone

## Verification
- npx vitest run test/unit/plugins/manifest/friday-plugin-manifest-schema.test.ts test/unit/plugins/services/friday-plugin-service.test.ts test/unit/api/http/routes/friday-plugin-routes.test.ts test/e2e/api/friday-api-plugins-routes.test.ts
- npx vitest run test/e2e/plugins/friday-plugin-local-lifecycle.test.ts test/e2e/plugins/friday-plugin-marketplace-lifecycle.test.ts
- npm run typecheck
- npm run lint
- npm run build
- detect-secrets-hook --baseline .secrets.baseline $(git diff --name-only --diff-filter=ACM | tr "\n" " ")

## Architecture
- additive-only changes inside existing /v1/plugins* and /v1/marketplace/plugins* surfaces
- no new route family, no second registry, no plugin/skills backbone collapse
- no changes to channels, hub authority, fleet, satellites, browser, or agent runtime