### PR TITLE
Phase 3: add channel contract starter skills

### DIFF
--- a/docs/ops/openclaw-adoption/taskpacks/phase-3.json
+++ b/docs/ops/openclaw-adoption/taskpacks/phase-3.json
@@ -2,51 +2,57 @@
   "schemaVersion": "1.0",
   "phaseId": "phase3",
   "title": "Channel Contract",
-  "executionMode": "spec_only",
-  "goal": "Define the channel contract work while preserving core ownership of message, session, audit, and evidence behavior.",
+  "executionMode": "hybrid",
+  "goal": "Make the channel/core contract explicit while preserving core ownership of message, session, audit, and evidence behavior.",
   "allowedPaths": [
     "src/channels",
     "src/hub",
     "src/skills",
+    "skills",
+    "docs/ops/openclaw-adoption/taskpacks/phase-3.json",
     "test/unit/channels",
+    "test/unit/skills/executor",
     "test/e2e/mock/friday-openclaw-parity-closure.e2e.test.ts"
   ],
   "implementationWorkers": [
     {
-      "id": "phase3-channel-contract-spec",
-      "title": "Load the committed channel contract taskpack",
+      "id": "phase3-channel-contract",
+      "title": "Add explicit channel contract metadata, registry introspection, and curated readonly channel skills",
       "runner": "command",
       "mode": "implementation",
       "steps": [
         {
-          "label": "phase3-taskpack-spec",
-          "command": "node",
+          "label": "phase3-channel-tests",
+          "command": "npx",
           "args": [
-            "-e",
-            "console.log('phase3 taskpack spec validated')"
+            "vitest",
+            "run",
+            "test/unit/channels/friday-channel-registry.test.ts",
+            "test/unit/skills/executor/friday-skill-executor.test.ts"
           ]
         }
       ]
     }
   ],
   "repairWorker": {
-    "id": "phase3-channel-contract-repair-spec",
+    "id": "phase3-channel-contract-repair",
     "title": "Diagnose channel contract blockers without expanding connector scope",
     "runner": "command",
     "mode": "repair",
     "steps": [
       {
-        "label": "phase3-taskpack-repair-spec",
-        "command": "node",
+        "label": "phase3-channel-repair-check",
+        "command": "npm",
         "args": [
-          "-e",
-          "console.log('phase3 repair spec validated')"
+          "run",
+          "typecheck"
         ]
       }
     ]
   },
   "successCriteria": [
     "Core retains message, session, audit, and evidence authority.",
+    "Curated starter skills expose mature channel health and contract views without expanding connector scope.",
     "No long-tail connector expansion is introduced."
   ],
   "closureEvidence": [
@@ -68,6 +74,7 @@
     }
   ],
   "notes": [
-    "This taskpack remains spec_only until curated channel implementation commands are authored."
+    "Channel skills in this phase remain readonly and operator-safe; outbound message authority stays in core delivery paths.",
+    "Contract metadata must stay descriptive and additive instead of replacing runtime ownership."
   ]
 }

--- a/skills/_shared/channel-status-skill-utils.mjs
+++ b/skills/_shared/channel-status-skill-utils.mjs
@@ -1,0 +1,64 @@
+import {
+  asArray,
+  asRecord,
+  asString,
+  compact,
+  requireChannelsContext,
+} from "./friday-runtime-skill-utils.mjs";
+
+export async function buildChannelStatusSkill(kind, label, ctx = {}) {
+  const channels = requireChannelsContext(ctx);
+  const channel = await channels.getChannel(kind);
+
+  if (!channel) {
+    return {
+      summary: `${label} channel is not registered in this Friday runtime.`,
+      nextStep: `Enable and configure the ${label} channel, then rerun this skill to inspect its connection contract and recovery hints.`,
+      details: {
+        kind,
+        registered: false,
+      },
+    };
+  }
+
+  const contract = asRecord(channel.contract);
+  const supports = asRecord(contract.supports);
+  const allowlist = asRecord(channel.allowlist);
+  const curatedSkillIds = asArray(contract.curatedSkillIds).filter((value) => typeof value === "string");
+  const diagnostics = asRecord(channel.diagnostics);
+  const status = asString(channel.status, "unknown");
+  const running = Boolean(channel.running);
+  const supportsThreads = Boolean(supports.threads);
+  const supportsTyping = Boolean(supports.typing);
+  const allowedUsersCount = Number(allowlist.allowedUsersCount ?? 0) || 0;
+  const allowedChatsCount = Number(allowlist.allowedChatsCount ?? 0) || 0;
+
+  let nextStep = `Review ${label} diagnostics and retry after fixing config or credentials if the channel is not connected.`;
+  if (status === "connected" && running) {
+    nextStep = `The ${label} channel is healthy. Use its curated skill suggestions or continue with another channel check if you need broader coverage.`;
+  } else if (asString(diagnostics.lastError)) {
+    nextStep = `Start with the reported ${label} error, then re-run this skill after reconnecting the channel.`;
+  }
+
+  const summary = compact(
+    `${label} channel is ${status}${running ? " and running" : ""}. Threads are ${supportsThreads ? "supported" : "not supported"}, typing is ${supportsTyping ? "supported" : "not supported"}, and allowlists cover ${allowedUsersCount} user(s) and ${allowedChatsCount} chat(s).`,
+    220,
+  );
+
+  return {
+    summary,
+    nextStep,
+    details: {
+      kind,
+      registered: true,
+      status,
+      running,
+      diagnostics,
+      contract,
+      supportsThreads,
+      supportsTyping,
+      curatedSkillIds,
+      allowlist,
+    },
+  };
+}

--- a/skills/_shared/friday-runtime-skill-utils.mjs
+++ b/skills/_shared/friday-runtime-skill-utils.mjs
@@ -43,6 +43,17 @@ export function requireBrowserContext(ctx) {
   return ctx.browser;
 }
 
+export function requireChannelsContext(ctx) {
+  if (
+    !ctx?.channels
+    || typeof ctx.channels.listChannels !== "function"
+    || typeof ctx.channels.getChannel !== "function"
+  ) {
+    throw new Error("This skill requires Friday's readonly channels runtime context.");
+  }
+  return ctx.channels;
+}
+
 function errorMessage(error) {
   if (typeof error === "string") {
     return error.trim();

--- a/skills/discord-channel-status/SKILL.md
+++ b/skills/discord-channel-status/SKILL.md
@@ -1,0 +1,4 @@
+# Discord Channel Status
+
+Use this skill to inspect Friday's Discord channel registration, connection
+state, thread support, and recovery hints.

--- a/skills/discord-channel-status/index.mjs
+++ b/skills/discord-channel-status/index.mjs
@@ -1,0 +1,5 @@
+import { buildChannelStatusSkill } from "../_shared/channel-status-skill-utils.mjs";
+
+export async function execute(_input = {}, ctx = {}) {
+  return buildChannelStatusSkill("discord", "Discord", ctx);
+}

--- a/skills/discord-channel-status/skill.manifest.json
+++ b/skills/discord-channel-status/skill.manifest.json
@@ -1,0 +1,91 @@
+{
+  "schemaVersion": "2.0",
+  "id": "discord-channel-status",
+  "name": "Discord Channel Status",
+  "description": "Summarize Discord channel connectivity, thread support, and recovery hints.",
+  "version": "1.0.0",
+  "kind": "system",
+  "category": "communication",
+  "author": {
+    "name": "Friday"
+  },
+  "tags": [
+    "starter",
+    "communication",
+    "discord",
+    "channel"
+  ],
+  "runtime": {
+    "kind": "node",
+    "entrypoint": "index.mjs",
+    "minHubVersion": "1.0.0",
+    "apiVersion": "1",
+    "timeoutMsDefault": 30000
+  },
+  "triggers": {
+    "intents": [
+      "discord_channel_status"
+    ],
+    "phrases": [
+      "check discord channel",
+      "show discord status",
+      "is discord connected"
+    ],
+    "channels": [
+      "*"
+    ]
+  },
+  "invocation": {
+    "userInvocable": true,
+    "modelInvocable": true,
+    "priority": 88,
+    "modes": [
+      "intent"
+    ]
+  },
+  "requirements": {
+    "bins": [],
+    "env": [],
+    "config": [],
+    "os": [
+      "darwin",
+      "linux"
+    ]
+  },
+  "inputs": [],
+  "outputs": [
+    {
+      "key": "summary",
+      "type": "string",
+      "description": "High-level Discord channel health summary."
+    },
+    {
+      "key": "nextStep",
+      "type": "string",
+      "description": "Recommended next recovery or verification step."
+    },
+    {
+      "key": "details",
+      "type": "object",
+      "description": "Structured Discord channel contract and diagnostics."
+    }
+  ],
+  "permissions": {
+    "grants": [],
+    "promptOn": []
+  },
+  "schemas": null,
+  "flow": null,
+  "executionTargets": {
+    "allowedSatelliteTypes": [
+      "desktop",
+      "cloud-vm"
+    ],
+    "requiredCapabilities": []
+  },
+  "telemetry": {
+    "events": [
+      "starter_skill_invoked"
+    ]
+  }
+}

--- a/skills/slack-channel-status/SKILL.md
+++ b/skills/slack-channel-status/SKILL.md
@@ -1,0 +1,4 @@
+# Slack Channel Status
+
+Use this skill to inspect Friday's Slack channel registration, connection state,
+contract boundaries, and recovery hints.

--- a/skills/slack-channel-status/index.mjs
+++ b/skills/slack-channel-status/index.mjs
@@ -1,0 +1,5 @@
+import { buildChannelStatusSkill } from "../_shared/channel-status-skill-utils.mjs";
+
+export async function execute(_input = {}, ctx = {}) {
+  return buildChannelStatusSkill("slack", "Slack", ctx);
+}

--- a/skills/slack-channel-status/skill.manifest.json
+++ b/skills/slack-channel-status/skill.manifest.json
@@ -1,0 +1,91 @@
+{
+  "schemaVersion": "2.0",
+  "id": "slack-channel-status",
+  "name": "Slack Channel Status",
+  "description": "Summarize Slack channel connectivity, contract boundaries, and recovery hints.",
+  "version": "1.0.0",
+  "kind": "system",
+  "category": "communication",
+  "author": {
+    "name": "Friday"
+  },
+  "tags": [
+    "starter",
+    "communication",
+    "slack",
+    "channel"
+  ],
+  "runtime": {
+    "kind": "node",
+    "entrypoint": "index.mjs",
+    "minHubVersion": "1.0.0",
+    "apiVersion": "1",
+    "timeoutMsDefault": 30000
+  },
+  "triggers": {
+    "intents": [
+      "slack_channel_status"
+    ],
+    "phrases": [
+      "check slack channel",
+      "show slack status",
+      "is slack connected"
+    ],
+    "channels": [
+      "*"
+    ]
+  },
+  "invocation": {
+    "userInvocable": true,
+    "modelInvocable": true,
+    "priority": 88,
+    "modes": [
+      "intent"
+    ]
+  },
+  "requirements": {
+    "bins": [],
+    "env": [],
+    "config": [],
+    "os": [
+      "darwin",
+      "linux"
+    ]
+  },
+  "inputs": [],
+  "outputs": [
+    {
+      "key": "summary",
+      "type": "string",
+      "description": "High-level Slack channel health summary."
+    },
+    {
+      "key": "nextStep",
+      "type": "string",
+      "description": "Recommended next recovery or verification step."
+    },
+    {
+      "key": "details",
+      "type": "object",
+      "description": "Structured Slack channel contract and diagnostics."
+    }
+  ],
+  "permissions": {
+    "grants": [],
+    "promptOn": []
+  },
+  "schemas": null,
+  "flow": null,
+  "executionTargets": {
+    "allowedSatelliteTypes": [
+      "desktop",
+      "cloud-vm"
+    ],
+    "requiredCapabilities": []
+  },
+  "telemetry": {
+    "events": [
+      "starter_skill_invoked"
+    ]
+  }
+}

--- a/skills/telegram-channel-status/SKILL.md
+++ b/skills/telegram-channel-status/SKILL.md
@@ -1,0 +1,4 @@
+# Telegram Channel Status
+
+Use this skill to inspect Friday's Telegram channel registration, connection
+state, and recovery hints.

--- a/skills/telegram-channel-status/index.mjs
+++ b/skills/telegram-channel-status/index.mjs
@@ -1,0 +1,5 @@
+import { buildChannelStatusSkill } from "../_shared/channel-status-skill-utils.mjs";
+
+export async function execute(_input = {}, ctx = {}) {
+  return buildChannelStatusSkill("telegram", "Telegram", ctx);
+}

--- a/skills/telegram-channel-status/skill.manifest.json
+++ b/skills/telegram-channel-status/skill.manifest.json
@@ -1,0 +1,91 @@
+{
+  "schemaVersion": "2.0",
+  "id": "telegram-channel-status",
+  "name": "Telegram Channel Status",
+  "description": "Summarize Telegram channel connectivity, polling or webhook mode, and recovery hints.",
+  "version": "1.0.0",
+  "kind": "system",
+  "category": "communication",
+  "author": {
+    "name": "Friday"
+  },
+  "tags": [
+    "starter",
+    "communication",
+    "telegram",
+    "channel"
+  ],
+  "runtime": {
+    "kind": "node",
+    "entrypoint": "index.mjs",
+    "minHubVersion": "1.0.0",
+    "apiVersion": "1",
+    "timeoutMsDefault": 30000
+  },
+  "triggers": {
+    "intents": [
+      "telegram_channel_status"
+    ],
+    "phrases": [
+      "check telegram channel",
+      "show telegram status",
+      "is telegram connected"
+    ],
+    "channels": [
+      "*"
+    ]
+  },
+  "invocation": {
+    "userInvocable": true,
+    "modelInvocable": true,
+    "priority": 88,
+    "modes": [
+      "intent"
+    ]
+  },
+  "requirements": {
+    "bins": [],
+    "env": [],
+    "config": [],
+    "os": [
+      "darwin",
+      "linux"
+    ]
+  },
+  "inputs": [],
+  "outputs": [
+    {
+      "key": "summary",
+      "type": "string",
+      "description": "High-level Telegram channel health summary."
+    },
+    {
+      "key": "nextStep",
+      "type": "string",
+      "description": "Recommended next recovery or verification step."
+    },
+    {
+      "key": "details",
+      "type": "object",
+      "description": "Structured Telegram channel contract and diagnostics."
+    }
+  ],
+  "permissions": {
+    "grants": [],
+    "promptOn": []
+  },
+  "schemas": null,
+  "flow": null,
+  "executionTargets": {
+    "allowedSatelliteTypes": [
+      "desktop",
+      "cloud-vm"
+    ],
+    "requiredCapabilities": []
+  },
+  "telemetry": {
+    "events": [
+      "starter_skill_invoked"
+    ]
+  }
+}

--- a/skills/webchat-channel-status/SKILL.md
+++ b/skills/webchat-channel-status/SKILL.md
@@ -1,0 +1,4 @@
+# Webchat Channel Status
+
+Use this skill to inspect Friday's Webchat channel registration, connection
+state, and recovery hints.

--- a/skills/webchat-channel-status/index.mjs
+++ b/skills/webchat-channel-status/index.mjs
@@ -1,0 +1,5 @@
+import { buildChannelStatusSkill } from "../_shared/channel-status-skill-utils.mjs";
+
+export async function execute(_input = {}, ctx = {}) {
+  return buildChannelStatusSkill("webchat", "Webchat", ctx);
+}

--- a/skills/webchat-channel-status/skill.manifest.json
+++ b/skills/webchat-channel-status/skill.manifest.json
@@ -1,0 +1,91 @@
+{
+  "schemaVersion": "2.0",
+  "id": "webchat-channel-status",
+  "name": "Webchat Channel Status",
+  "description": "Summarize Webchat channel connectivity, contract boundaries, and recovery hints.",
+  "version": "1.0.0",
+  "kind": "system",
+  "category": "communication",
+  "author": {
+    "name": "Friday"
+  },
+  "tags": [
+    "starter",
+    "communication",
+    "webchat",
+    "channel"
+  ],
+  "runtime": {
+    "kind": "node",
+    "entrypoint": "index.mjs",
+    "minHubVersion": "1.0.0",
+    "apiVersion": "1",
+    "timeoutMsDefault": 30000
+  },
+  "triggers": {
+    "intents": [
+      "webchat_channel_status"
+    ],
+    "phrases": [
+      "check webchat channel",
+      "show webchat status",
+      "is webchat connected"
+    ],
+    "channels": [
+      "*"
+    ]
+  },
+  "invocation": {
+    "userInvocable": true,
+    "modelInvocable": true,
+    "priority": 88,
+    "modes": [
+      "intent"
+    ]
+  },
+  "requirements": {
+    "bins": [],
+    "env": [],
+    "config": [],
+    "os": [
+      "darwin",
+      "linux"
+    ]
+  },
+  "inputs": [],
+  "outputs": [
+    {
+      "key": "summary",
+      "type": "string",
+      "description": "High-level Webchat channel health summary."
+    },
+    {
+      "key": "nextStep",
+      "type": "string",
+      "description": "Recommended next recovery or verification step."
+    },
+    {
+      "key": "details",
+      "type": "object",
+      "description": "Structured Webchat channel contract and diagnostics."
+    }
+  ],
+  "permissions": {
+    "grants": [],
+    "promptOn": []
+  },
+  "schemas": null,
+  "flow": null,
+  "executionTargets": {
+    "allowedSatelliteTypes": [
+      "desktop",
+      "cloud-vm"
+    ],
+    "requiredCapabilities": []
+  },
+  "telemetry": {
+    "events": [
+      "starter_skill_invoked"
+    ]
+  }
+}

--- a/skills/whatsapp-channel-status/SKILL.md
+++ b/skills/whatsapp-channel-status/SKILL.md
@@ -1,0 +1,4 @@
+# WhatsApp Channel Status
+
+Use this skill to inspect Friday's WhatsApp channel registration, connection
+state, pairing boundary, and recovery hints.

--- a/skills/whatsapp-channel-status/index.mjs
+++ b/skills/whatsapp-channel-status/index.mjs
@@ -1,0 +1,5 @@
+import { buildChannelStatusSkill } from "../_shared/channel-status-skill-utils.mjs";
+
+export async function execute(_input = {}, ctx = {}) {
+  return buildChannelStatusSkill("whatsapp", "WhatsApp", ctx);
+}

--- a/skills/whatsapp-channel-status/skill.manifest.json
+++ b/skills/whatsapp-channel-status/skill.manifest.json
@@ -1,0 +1,91 @@
+{
+  "schemaVersion": "2.0",
+  "id": "whatsapp-channel-status",
+  "name": "WhatsApp Channel Status",
+  "description": "Summarize WhatsApp channel connectivity, pairing boundaries, and recovery hints.",
+  "version": "1.0.0",
+  "kind": "system",
+  "category": "communication",
+  "author": {
+    "name": "Friday"
+  },
+  "tags": [
+    "starter",
+    "communication",
+    "whatsapp",
+    "channel"
+  ],
+  "runtime": {
+    "kind": "node",
+    "entrypoint": "index.mjs",
+    "minHubVersion": "1.0.0",
+    "apiVersion": "1",
+    "timeoutMsDefault": 30000
+  },
+  "triggers": {
+    "intents": [
+      "whatsapp_channel_status"
+    ],
+    "phrases": [
+      "check whatsapp channel",
+      "show whatsapp status",
+      "is whatsapp connected"
+    ],
+    "channels": [
+      "*"
+    ]
+  },
+  "invocation": {
+    "userInvocable": true,
+    "modelInvocable": true,
+    "priority": 88,
+    "modes": [
+      "intent"
+    ]
+  },
+  "requirements": {
+    "bins": [],
+    "env": [],
+    "config": [],
+    "os": [
+      "darwin",
+      "linux"
+    ]
+  },
+  "inputs": [],
+  "outputs": [
+    {
+      "key": "summary",
+      "type": "string",
+      "description": "High-level WhatsApp channel health summary."
+    },
+    {
+      "key": "nextStep",
+      "type": "string",
+      "description": "Recommended next recovery or verification step."
+    },
+    {
+      "key": "details",
+      "type": "object",
+      "description": "Structured WhatsApp channel contract and diagnostics."
+    }
+  ],
+  "permissions": {
+    "grants": [],
+    "promptOn": []
+  },
+  "schemas": null,
+  "flow": null,
+  "executionTargets": {
+    "allowedSatelliteTypes": [
+      "desktop",
+      "cloud-vm"
+    ],
+    "requiredCapabilities": []
+  },
+  "telemetry": {
+    "events": [
+      "starter_skill_invoked"
+    ]
+  }
+}

--- a/src/channels/discord/friday-discord-channel.ts
+++ b/src/channels/discord/friday-discord-channel.ts
@@ -315,6 +315,29 @@ export function createFridayDiscordChannel(deps: DiscordChannelDeps = {}): Frida
   const plugin: FridayChannelPlugin = {
     kind: "discord",
     adapters,
+    contract: {
+      coreAuthority: {
+        messageRouting: true,
+        sessionMirroring: true,
+        audit: true,
+        evidence: true,
+      },
+      pluginResponsibilities: {
+        config: true,
+        auth: true,
+        pairing: false,
+        outboundDelivery: true,
+        threadResolution: true,
+        providerRetries: false,
+      },
+      supports: {
+        directMessages: true,
+        groupMessages: true,
+        threads: true,
+        typing: true,
+      },
+      curatedSkillIds: ["discord-channel-status"],
+    },
 
     async init(rawConfig) {
       config = configAdapter.validate(rawConfig);

--- a/src/channels/friday-channel-registry.ts
+++ b/src/channels/friday-channel-registry.ts
@@ -11,6 +11,7 @@
 
 import type { FridayChannelStatus } from "./friday-channel-adapters.types.js";
 import type {
+  FridayChannelCapabilityContract,
   FridayChannelMessage,
   FridayChannelPlugin,
   FridayChannelSendOptions,
@@ -29,6 +30,20 @@ export interface FridayChannelRegistryEntry {
   plugin: FridayChannelPlugin;
   allowlist: FridayChannelAllowlistConfig;
   running: boolean;
+}
+
+export interface FridayChannelRegistryView {
+  kind: string;
+  running: boolean;
+  status: FridayChannelStatus;
+  diagnostics?: Record<string, unknown>;
+  contract?: FridayChannelCapabilityContract;
+  allowlist: {
+    hasAllowedUsers: boolean;
+    allowedUsersCount: number;
+    hasAllowedChats: boolean;
+    allowedChatsCount: number;
+  };
 }
 
 export type FridayChannelMessageHandler = (msg: FridayChannelMessage) => void;
@@ -67,6 +82,12 @@ export interface FridayChannelRegistry {
 
   /** List all registered channel kinds. */
   list(): string[];
+
+  /** Describe a registered channel with status, diagnostics, and contract metadata. */
+  describe(kind: string): FridayChannelRegistryView | undefined;
+
+  /** List channel views including status, diagnostics, and contract metadata. */
+  listViews(): FridayChannelRegistryView[];
 
   /** Send a message through a specific channel kind. */
   send(kind: string, options: FridayChannelSendOptions): Promise<{ messageId: string }>;
@@ -170,6 +191,15 @@ export function createFridayChannelRegistry(): FridayChannelRegistry {
   function formatStartError(reason: unknown): string {
     if (reason instanceof Error) return reason.message;
     return String(reason);
+  }
+
+  function buildAllowlistSummary(allowlist: FridayChannelAllowlistConfig) {
+    return {
+      hasAllowedUsers: allowlist.allowedUsers !== undefined,
+      allowedUsersCount: allowlist.allowedUsers?.length ?? 0,
+      hasAllowedChats: allowlist.allowedChats !== undefined,
+      allowedChatsCount: allowlist.allowedChats?.length ?? 0,
+    };
   }
 
   return {
@@ -324,6 +354,27 @@ export function createFridayChannelRegistry(): FridayChannelRegistry {
 
     list() {
       return Array.from(entries.keys());
+    },
+
+    describe(kind) {
+      const entry = entries.get(kind);
+      if (!entry) {
+        return undefined;
+      }
+      return {
+        kind,
+        running: entry.running,
+        status: this.status(kind),
+        diagnostics: this.diagnostics(kind),
+        contract: entry.plugin.contract,
+        allowlist: buildAllowlistSummary(entry.allowlist),
+      };
+    },
+
+    listViews() {
+      return this.list()
+        .map((kind) => this.describe(kind))
+        .filter((view): view is FridayChannelRegistryView => view !== undefined);
     },
 
     async send(kind, options) {

--- a/src/channels/friday-channel.types.ts
+++ b/src/channels/friday-channel.types.ts
@@ -9,6 +9,36 @@
 
 import type { FridayChannelAdapters } from "./friday-channel-adapters.types.js";
 
+export interface FridayChannelCoreAuthority {
+  messageRouting: true;
+  sessionMirroring: true;
+  audit: true;
+  evidence: true;
+}
+
+export interface FridayChannelPluginResponsibilities {
+  config: boolean;
+  auth: boolean;
+  pairing: boolean;
+  outboundDelivery: boolean;
+  threadResolution: boolean;
+  providerRetries: boolean;
+}
+
+export interface FridayChannelSupportProfile {
+  directMessages: boolean;
+  groupMessages: boolean;
+  threads: boolean;
+  typing: boolean;
+}
+
+export interface FridayChannelCapabilityContract {
+  coreAuthority: FridayChannelCoreAuthority;
+  pluginResponsibilities: FridayChannelPluginResponsibilities;
+  supports: FridayChannelSupportProfile;
+  curatedSkillIds?: string[];
+}
+
 // ─── Inbound Message ───
 
 export interface FridayChannelMessage {
@@ -83,6 +113,12 @@ export interface FridayChannelPlugin {
    * Returns the platform-assigned message ID.
    */
   send(options: FridayChannelSendOptions): Promise<{ messageId: string }>;
+
+  /**
+   * Optional contract metadata that makes the channel/core boundary explicit.
+   * Core remains authoritative for routing, session mirroring, audit, and evidence.
+   */
+  contract?: FridayChannelCapabilityContract;
 
   /**
    * Optional adapter set for modular channel architecture.

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -1,9 +1,13 @@
 // ─── Core Types ───
 
 export type {
+  FridayChannelCapabilityContract,
+  FridayChannelCoreAuthority,
   FridayChannelMessage,
   FridayChannelSendOptions,
+  FridayChannelPluginResponsibilities,
   FridayChannelPlugin,
+  FridayChannelSupportProfile,
 } from "./friday-channel.types.js";
 
 // ─── Adapter Types ───
@@ -23,6 +27,7 @@ export type {
 export type {
   FridayChannelRegistry,
   FridayChannelRegistryEntry,
+  FridayChannelRegistryView,
   FridayChannelAllowlistConfig,
   FridayChannelStartFailure,
   FridayChannelStartSummary,

--- a/src/channels/slack/friday-slack-channel.ts
+++ b/src/channels/slack/friday-slack-channel.ts
@@ -177,6 +177,29 @@ export function createFridaySlackChannel(deps: SlackChannelDeps = {}): FridayCha
   const plugin: FridayChannelPlugin = {
     kind: "slack",
     adapters,
+    contract: {
+      coreAuthority: {
+        messageRouting: true,
+        sessionMirroring: true,
+        audit: true,
+        evidence: true,
+      },
+      pluginResponsibilities: {
+        config: true,
+        auth: true,
+        pairing: false,
+        outboundDelivery: true,
+        threadResolution: true,
+        providerRetries: false,
+      },
+      supports: {
+        directMessages: true,
+        groupMessages: true,
+        threads: true,
+        typing: false,
+      },
+      curatedSkillIds: ["slack-channel-status"],
+    },
 
     async init(rawConfig) {
       config = configAdapter.validate(rawConfig);

--- a/src/channels/telegram/friday-telegram-channel.ts
+++ b/src/channels/telegram/friday-telegram-channel.ts
@@ -179,6 +179,29 @@ export function createFridayTelegramChannel(deps: TelegramChannelDeps = {}): Fri
   const plugin: FridayChannelPlugin = {
     kind: "telegram",
     adapters,
+    contract: {
+      coreAuthority: {
+        messageRouting: true,
+        sessionMirroring: true,
+        audit: true,
+        evidence: true,
+      },
+      pluginResponsibilities: {
+        config: true,
+        auth: true,
+        pairing: false,
+        outboundDelivery: true,
+        threadResolution: false,
+        providerRetries: true,
+      },
+      supports: {
+        directMessages: true,
+        groupMessages: true,
+        threads: false,
+        typing: false,
+      },
+      curatedSkillIds: ["telegram-channel-status"],
+    },
 
     async init(rawConfig) {
       config = configAdapter.validate(rawConfig);

--- a/src/channels/webchat/friday-webchat-channel.ts
+++ b/src/channels/webchat/friday-webchat-channel.ts
@@ -144,6 +144,29 @@ export function createFridayWebchatChannel(deps: WebchatChannelDeps = {}): Frida
   const plugin: FridayChannelPlugin = {
     kind: "webchat",
     adapters,
+    contract: {
+      coreAuthority: {
+        messageRouting: true,
+        sessionMirroring: true,
+        audit: true,
+        evidence: true,
+      },
+      pluginResponsibilities: {
+        config: true,
+        auth: true,
+        pairing: false,
+        outboundDelivery: true,
+        threadResolution: false,
+        providerRetries: false,
+      },
+      supports: {
+        directMessages: true,
+        groupMessages: false,
+        threads: false,
+        typing: false,
+      },
+      curatedSkillIds: ["webchat-channel-status"],
+    },
 
     async init(rawConfig) {
       config = configAdapter.validate(rawConfig);

--- a/src/channels/whatsapp/friday-whatsapp-channel.ts
+++ b/src/channels/whatsapp/friday-whatsapp-channel.ts
@@ -194,6 +194,29 @@ export function createFridayWhatsappChannel(deps: WhatsappChannelDeps = {}): Fri
   const plugin: FridayChannelPlugin = {
     kind: "whatsapp",
     adapters,
+    contract: {
+      coreAuthority: {
+        messageRouting: true,
+        sessionMirroring: true,
+        audit: true,
+        evidence: true,
+      },
+      pluginResponsibilities: {
+        config: true,
+        auth: true,
+        pairing: true,
+        outboundDelivery: true,
+        threadResolution: false,
+        providerRetries: false,
+      },
+      supports: {
+        directMessages: true,
+        groupMessages: false,
+        threads: false,
+        typing: false,
+      },
+      curatedSkillIds: ["whatsapp-channel-status"],
+    },
 
     async init(rawConfig) {
       config = configAdapter.validate(rawConfig);

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -180,7 +180,7 @@ import {
   parseFridayChannelsConfig,
   resolveFridayChannelSecretPolicy,
 } from "#channels";
-import type { FridayChannelMessage } from "#channels";
+import type { FridayChannelMessage, FridayChannelRegistry } from "#channels";
 import { createFridayChannelInboundDebouncer, createFridayChannelTypingController, sanitizeChannelInput } from "#channels";
 import { createFridayChannelSlowTaskNotifier } from "../channels/friday-channel-slow-task-notifier.js";
 import { resolveFridayPublicRunUrl } from "../agent/runtime/friday-public-run-url.js";
@@ -531,6 +531,7 @@ export async function createFridayHub(
   });
 
   let browserManager: FridayBrowserManager | undefined;
+  const channelRegistry: FridayChannelRegistry = createFridayChannelRegistry();
 
   // 7. Create executor with providerService injected for ai-inference BYOK path
   const executor = createFridaySkillExecutor({
@@ -543,6 +544,7 @@ export async function createFridayHub(
     getSystemService: () => systemService,
     getSelfHealingService: () => selfHealingApiService,
     getBrowserManager: () => browserManager,
+    getChannelRegistry: () => channelRegistry,
   });
 
   const rulesRepository = createFridayRulesRepository();
@@ -2293,7 +2295,6 @@ export async function createFridayHub(
 
   // ─── Channel registry ───
 
-  const channelRegistry = createFridayChannelRegistry();
   const webchatWsService = createWebchatWsService();
   const lineWebhookRelay = createLineWebhookListenerService();
   const whatsappWebhookRelay = createWhatsappWebhookService();

--- a/src/skills/executor/friday-skill-executor.types.ts
+++ b/src/skills/executor/friday-skill-executor.types.ts
@@ -1,6 +1,11 @@
 import type { FridaySqliteLayer } from "#state";
 import type { FridaySkillRunStore } from "#ledger";
 import type { FridayBrowserManager } from "#browser";
+import type {
+  FridayChannelCapabilityContract,
+  FridayChannelRegistry,
+  FridayChannelStatus,
+} from "#channels";
 import type { FridaySkillRegistry } from "../registry/friday-skill-registry.types.js";
 
 // ─── Shell executor types ───
@@ -92,12 +97,32 @@ export interface FridaySkillReadonlyBrowserContext {
   closeSession(sessionId: string): Promise<void>;
 }
 
+export interface FridaySkillReadonlyChannelView {
+  kind: string;
+  running: boolean;
+  status: FridayChannelStatus;
+  diagnostics?: Record<string, unknown>;
+  contract?: FridayChannelCapabilityContract;
+  allowlist: {
+    hasAllowedUsers: boolean;
+    allowedUsersCount: number;
+    hasAllowedChats: boolean;
+    allowedChatsCount: number;
+  };
+}
+
+export interface FridaySkillReadonlyChannelsContext {
+  listChannels(): Promise<FridaySkillReadonlyChannelView[]>;
+  getChannel(kind: string): Promise<FridaySkillReadonlyChannelView | null>;
+}
+
 export interface FridaySkillNodeRuntimeContext {
   ai?: FridaySkillAiHelperContext;
   system?: FridaySkillReadonlySystemContext;
   diagnosis?: FridaySkillReadonlyDiagnosisContext;
   autofix?: FridaySkillReadonlyAutofixContext;
   browser?: FridaySkillReadonlyBrowserContext;
+  channels?: FridaySkillReadonlyChannelsContext;
 }
 
 export interface FridaySkillReadonlySystemServiceLike {
@@ -175,6 +200,7 @@ export interface CreateFridaySkillExecutorDeps {
   getSystemService?: () => FridaySkillReadonlySystemServiceLike | undefined;
   getSelfHealingService?: () => FridaySkillReadonlySelfHealingServiceLike | undefined;
   getBrowserManager?: () => FridayBrowserManager | undefined;
+  getChannelRegistry?: () => FridayChannelRegistry | undefined;
 }
 
 /**

--- a/src/skills/executor/friday-skill-runtime-bridge.ts
+++ b/src/skills/executor/friday-skill-runtime-bridge.ts
@@ -32,13 +32,14 @@ function cloneJson<T>(value: T): T {
 }
 
 export function createFridaySkillReadonlyRuntimeContext(
-  deps: Pick<CreateFridaySkillExecutorDeps, "getSelfHealingService" | "getSystemService" | "getBrowserManager">,
+  deps: Pick<CreateFridaySkillExecutorDeps, "getSelfHealingService" | "getSystemService" | "getBrowserManager" | "getChannelRegistry">,
   request: Pick<FridaySkillExecuteRequest, "userId" | "sessionId" | "skillId">,
 ): Omit<FridaySkillNodeRuntimeContext, "ai"> | undefined {
   const runtimeContext: Omit<FridaySkillNodeRuntimeContext, "ai"> = {};
   const systemService = deps.getSystemService?.();
   const selfHealingService = deps.getSelfHealingService?.();
   const browserManager = deps.getBrowserManager?.();
+  const channelRegistry = deps.getChannelRegistry?.();
 
   if (systemService) {
     runtimeContext.system = {
@@ -219,6 +220,17 @@ export function createFridaySkillReadonlyRuntimeContext(
       },
       async closeSession(sessionId: string) {
         await browserManager.close(sessionId);
+      },
+    };
+  }
+
+  if (channelRegistry) {
+    runtimeContext.channels = {
+      async listChannels() {
+        return cloneJson(channelRegistry.listViews());
+      },
+      async getChannel(kind: string) {
+        return cloneJson(channelRegistry.describe(kind) ?? null);
       },
     };
   }

--- a/test/unit/channels/friday-channel-registry.test.ts
+++ b/test/unit/channels/friday-channel-registry.test.ts
@@ -6,13 +6,14 @@ import {
   type FridayChannelRegistry,
 } from "#channels";
 
-function createMockPlugin(kind = "test"): FridayChannelPlugin {
+function createMockPlugin(kind = "test", overrides: Partial<FridayChannelPlugin> = {}): FridayChannelPlugin {
   return {
     kind,
     init: vi.fn(async () => {}),
     start: vi.fn(async (onMessage) => {}),
     stop: vi.fn(async () => {}),
     send: vi.fn(async () => ({ messageId: "sent-1" })),
+    ...overrides,
   };
 }
 
@@ -57,6 +58,59 @@ describe("FridayChannelRegistry", () => {
       registry.register(createMockPlugin("qq"));
       registry.register(createMockPlugin("lark"));
       expect(registry.list()).toEqual(["qq", "lark"]);
+    });
+
+    it("describes registered channel contracts and diagnostics", () => {
+      const plugin = createMockPlugin("discord", {
+        contract: {
+          coreAuthority: {
+            messageRouting: true,
+            sessionMirroring: true,
+            audit: true,
+            evidence: true,
+          },
+          pluginResponsibilities: {
+            config: true,
+            auth: true,
+            pairing: false,
+            outboundDelivery: true,
+            threadResolution: true,
+            providerRetries: false,
+          },
+          supports: {
+            directMessages: true,
+            groupMessages: true,
+            threads: true,
+            typing: true,
+          },
+          curatedSkillIds: ["discord-channel-status"],
+        },
+        adapters: {
+          status: {
+            status: () => "connected",
+            diagnostics: () => ({ mode: "gateway" }),
+          },
+        },
+      });
+
+      registry.register(plugin, { allowedUsers: ["u-1"], allowedChats: ["c-1", "c-2"] });
+
+      expect(registry.describe("discord")).toMatchObject({
+        kind: "discord",
+        status: "connected",
+        contract: {
+          supports: { threads: true },
+          curatedSkillIds: ["discord-channel-status"],
+        },
+        allowlist: {
+          hasAllowedUsers: true,
+          allowedUsersCount: 1,
+          hasAllowedChats: true,
+          allowedChatsCount: 2,
+        },
+      });
+
+      expect(registry.listViews()).toHaveLength(1);
     });
   });
 

--- a/test/unit/skills/executor/friday-skill-executor.test.ts
+++ b/test/unit/skills/executor/friday-skill-executor.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createFridayChannelRegistry } from "#channels";
 import { createFridaySkillExecutor } from "#skills";
 import { createFridaySkillRunStore } from "#ledger";
 import { createTestDb, createTestIdGenerator } from "../../satellites/_helpers/create-test-db.helper.js";
@@ -389,6 +390,97 @@ export async function execute(_input, ctx) {
       incidentId: "incident-1",
       actionCount: 1,
       actionId: "action-1",
+    });
+
+    await fs.rm(scriptDir, { recursive: true, force: true });
+  });
+
+  it("injects readonly channel runtime helpers into node skills", async () => {
+    const fs = await import("node:fs/promises");
+    const scriptDir = await fs.mkdtemp("/tmp/friday-node-channels-");
+    await fs.writeFile(
+      `${scriptDir}/index.mjs`,
+      `
+export async function execute(_input, ctx) {
+  const channels = await ctx.channels.listChannels();
+  const discord = await ctx.channels.getChannel("discord");
+  return {
+    hasChannels: typeof ctx?.channels?.listChannels === "function",
+    channelCount: channels.length,
+    discordStatus: discord?.status,
+    discordThreads: Boolean(discord?.contract?.supports?.threads),
+  };
+}
+`,
+      "utf8",
+    );
+
+    const channelRegistry = createFridayChannelRegistry();
+    channelRegistry.register({
+      kind: "discord",
+      init: async () => {},
+      start: async () => {},
+      stop: async () => {},
+      send: async () => ({ messageId: "sent-1" }),
+      contract: {
+        coreAuthority: {
+          messageRouting: true,
+          sessionMirroring: true,
+          audit: true,
+          evidence: true,
+        },
+        pluginResponsibilities: {
+          config: true,
+          auth: true,
+          pairing: false,
+          outboundDelivery: true,
+          threadResolution: true,
+          providerRetries: false,
+        },
+        supports: {
+          directMessages: true,
+          groupMessages: true,
+          threads: true,
+          typing: true,
+        },
+      },
+      adapters: {
+        status: {
+          status: () => "connected",
+        },
+      },
+    });
+
+    const skill = makeRegisteredSkill({
+      id: "node-channel-runtime-skill",
+      runtimeKind: "node",
+      entrypoint: "index.mjs",
+      skillDir: scriptDir,
+    });
+
+    const skills = new Map<string, FridayRegisteredSkill>();
+    skills.set("node-channel-runtime-skill", skill);
+
+    const executor = createFridaySkillExecutor({
+      db,
+      registry: createMockRegistry(skills),
+      runStore,
+      idGenerator: createTestIdGenerator(),
+      nowIso: () => "2025-01-15T10:00:00.000Z",
+      getChannelRegistry: () => channelRegistry,
+    });
+
+    const result = await executor.execute({
+      ...baseRequest,
+      skillId: "node-channel-runtime-skill",
+    }).result;
+
+    expect(result.status).toBe("completed");
+    expect(result.output).toMatchObject({
+      hasChannels: true,
+      channelCount: 1,
+      discordStatus: "connected",
+      discordThreads: true,
     });
 
     await fs.rm(scriptDir, { recursive: true, force: true });

--- a/test/unit/skills/runtime/friday-wave23-starter-skills.test.ts
+++ b/test/unit/skills/runtime/friday-wave23-starter-skills.test.ts
@@ -411,4 +411,92 @@ describe("wave 2 and wave 3 Friday starter skills", () => {
     expect(result.details.runtimeUnavailable).toBe(true);
     expect(readFileSync(path.join(repoRoot, "index.html"), "utf8")).toContain("<title>Vite App</title>");
   });
+
+  it("reports channel contract and status for slack-channel-status", async () => {
+    const { execute } = await import("../../../../skills/slack-channel-status/index.mjs");
+
+    const result = await execute(
+      {},
+      {
+        channels: {
+          listChannels: async () => [
+            {
+              kind: "slack",
+              running: true,
+              status: "connected",
+              diagnostics: { mode: "socket" },
+              contract: {
+                coreAuthority: {
+                  messageRouting: true,
+                  sessionMirroring: true,
+                  audit: true,
+                  evidence: true,
+                },
+                pluginResponsibilities: {
+                  config: true,
+                  auth: true,
+                  pairing: false,
+                  outboundDelivery: true,
+                  threadResolution: true,
+                  providerRetries: false,
+                },
+                supports: {
+                  directMessages: true,
+                  groupMessages: true,
+                  threads: true,
+                  typing: false,
+                },
+                curatedSkillIds: ["slack-channel-status"],
+              },
+              allowlist: {
+                hasAllowedUsers: false,
+                allowedUsersCount: 0,
+                hasAllowedChats: false,
+                allowedChatsCount: 0,
+              },
+            },
+          ],
+          getChannel: async () => ({
+            kind: "slack",
+            running: true,
+            status: "connected",
+            diagnostics: { mode: "socket" },
+            contract: {
+              coreAuthority: {
+                messageRouting: true,
+                sessionMirroring: true,
+                audit: true,
+                evidence: true,
+              },
+              pluginResponsibilities: {
+                config: true,
+                auth: true,
+                pairing: false,
+                outboundDelivery: true,
+                threadResolution: true,
+                providerRetries: false,
+              },
+              supports: {
+                directMessages: true,
+                groupMessages: true,
+                threads: true,
+                typing: false,
+              },
+              curatedSkillIds: ["slack-channel-status"],
+            },
+            allowlist: {
+              hasAllowedUsers: false,
+              allowedUsersCount: 0,
+              hasAllowedChats: false,
+              allowedChatsCount: 0,
+            },
+          }),
+        },
+      },
+    );
+
+    expect(result.summary).toContain("Slack channel is connected");
+    expect(result.details.supportsThreads).toBe(true);
+    expect(result.details.curatedSkillIds).toEqual(["slack-channel-status"]);
+  });
 });


### PR DESCRIPTION
## Summary
- add explicit channel capability contract metadata for mature Friday channels
- expose readonly channel registry introspection to the skill runtime
- add curated starter channel status skills for Slack, Discord, Telegram, Webchat, and WhatsApp

## Architecture
- additive-only change inside existing channel, hub, and skill surfaces
- no new route family and no connector expansion
- core retains outbound send, session, audit, and evidence authority

## Verification
- npx vitest run test/unit/channels/friday-channel-registry.test.ts test/unit/skills/executor/friday-skill-executor.test.ts test/unit/channels/slack/friday-slack-channel.test.ts test/unit/channels/discord/friday-discord-channel.test.ts test/unit/channels/telegram/friday-telegram-channel.test.ts test/unit/channels/webchat/friday-webchat-channel.test.ts test/unit/channels/whatsapp/friday-whatsapp-channel.test.ts
- npx vitest run test/unit/channels/friday-channel-registry.test.ts test/unit/skills/executor/friday-skill-executor.test.ts test/unit/skills/runtime/friday-wave23-starter-skills.test.ts
- npm run typecheck
- npm run lint
- npm run build
- detect-secrets-hook --baseline .secrets.baseline $(git diff --cached --name-only --diff-filter=ACM | tr '\n' ' ')
