### PR TITLE
fix(agent): preserve delegated mutations for operational tasks

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -388,6 +388,7 @@ export type {
 export {
   inferFridaySubagentProfile,
   resolveFridaySubagentProfile,
+  taskLikelyNeedsWriteAccessForSubagent,
 } from "./subagent/friday-subagent-profile.js";
 
 export { createFridaySubagentRegistry } from "./subagent/friday-subagent-registry.js";

--- a/src/agent/subagent/friday-subagent-profile.ts
+++ b/src/agent/subagent/friday-subagent-profile.ts
@@ -102,3 +102,51 @@ export function inferFridaySubagentProfile(task: string, label?: string): Friday
   }
   return "explore";
 }
+
+const DIRECT_WRITE_HINTS =
+  /\b(write|edit|modify|update|patch|rewrite|rename|delete|remove)\b/i;
+const IMPLEMENTATION_HINTS =
+  /\b(fix|implement|refactor)\b/i;
+const IMPLEMENTATION_DOMAINS =
+  /\b(file|files|code|repo|repository|workflow|skill|test|tests|docs|document|folder|directory|workspace|project)\b/i;
+const BROWSER_MUTATION_HINTS =
+  /\b(open|navigate|click|type|fill|select|press|drag|upload|take|capture|attach)\b/i;
+const BROWSER_MUTATION_DOMAINS =
+  /\b(browser|page|site|website|url|screenshot|screen shot|image|tab)\b|https?:\/\/|(?:^|\s)[\w-]+\.(com|net|org|io|dev|app)\b/i;
+const EXEC_MUTATION_HINTS =
+  /\b(run|execute|launch|start|stop|restart|deploy|build|install|lint|typecheck|migrate|publish|release|export)\b/i;
+const EXEC_MUTATION_DOMAINS =
+  /\b(command|shell|bash|script|server|service|process|package|dependency|tests?|build|deployment|release|migration)\b/i;
+const MESSAGE_MUTATION_HINTS =
+  /\b(send|post|reply|attach|upload|publish)\b/i;
+const MESSAGE_MUTATION_DOMAINS =
+  /\b(discord|slack|telegram|message|email|screenshot|file|artifact)\b/i;
+
+export function taskLikelyNeedsWriteAccessForSubagent(task: string, label?: string): boolean {
+  const text = `${label ?? ""}\n${task}`.trim();
+  if (text.length === 0) {
+    return false;
+  }
+
+  if (DIRECT_WRITE_HINTS.test(text)) {
+    return true;
+  }
+
+  if (IMPLEMENTATION_HINTS.test(text) && IMPLEMENTATION_DOMAINS.test(text)) {
+    return true;
+  }
+
+  if (BROWSER_MUTATION_HINTS.test(text) && BROWSER_MUTATION_DOMAINS.test(text)) {
+    return true;
+  }
+
+  if (EXEC_MUTATION_HINTS.test(text) && EXEC_MUTATION_DOMAINS.test(text)) {
+    return true;
+  }
+
+  if (MESSAGE_MUTATION_HINTS.test(text) && MESSAGE_MUTATION_DOMAINS.test(text)) {
+    return true;
+  }
+
+  return false;
+}

--- a/src/agent/subagent/friday-subagent.types.ts
+++ b/src/agent/subagent/friday-subagent.types.ts
@@ -6,7 +6,10 @@ import type {
 import type { FridayAgentEventEmitter } from "../runtime/friday-agent-event-emitter.js";
 import type { FridayAgentTaskProfileInput } from "../runtime/friday-agent-task-profile.js";
 import type { FridayAgentRunConstraints } from "../model/friday-agent.types.js";
-import type { FridaySubagentProfileId } from "./friday-subagent-profile.js";
+import type {
+  FridaySubagentProfileId,
+  FridaySubagentProfileInput,
+} from "./friday-subagent-profile.js";
 
 // ─── Sub-agent run status ───
 
@@ -130,7 +133,7 @@ export interface FridaySubagentRegistrySpawnInput {
   label?: string;
   providerId?: string;
   model?: string;
-  profile?: FridaySubagentProfileId;
+  profile?: FridaySubagentProfileId | FridaySubagentProfileInput;
   timezone?: string;
   timeoutMs?: number;
   conversationContext?: FridayAgentConversationContext;

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -130,6 +130,7 @@ import {
   parseFridayMcpServersFromEnv,
   resolveFridayAgentTaskProfile,
   resolveFridayContextEnginePromptFragment,
+  taskLikelyNeedsWriteAccessForSubagent,
 } from "#agent";
 import type { loadFridayWorkspaceContext } from "#agent";
 import { buildMcpServerToolFilter } from "./friday-mcp-safe-catalog.js";
@@ -2193,12 +2194,23 @@ export async function createFridayHub(
       return buildFridayCommunicationPromptFragment(persona);
     },
     delegationHandler: async (input) => {
+      const inferredProfile = inferFridaySubagentProfile(input.task);
       const detached = subagentRegistry.spawnDetached({
         task: input.task,
         taskPrompt: input.taskPrompt,
         providerId: input.providerId,
         model: input.model,
-        profile: inferFridaySubagentProfile(input.task),
+        profile: taskLikelyNeedsWriteAccessForSubagent(input.task)
+          ? {
+              id: inferredProfile,
+              readOnly: false,
+              ...(typeof input.taskProfile === "string"
+                ? { taskProfile: input.taskProfile }
+                : input.taskProfile?.id
+                  ? { taskProfile: input.taskProfile.id }
+                  : {}),
+            }
+          : inferredProfile,
         timezone: input.timezone,
         timeoutMs: input.timeoutMs,
         conversationContext: input.conversationContext,

--- a/test/e2e/ui/friday-starter-skills-closeout.test.ts
+++ b/test/e2e/ui/friday-starter-skills-closeout.test.ts
@@ -53,7 +53,7 @@ describe("Friday starter skills closeout", () => {
     }
   });
 
-  it("keeps only the wave-1 fixed assistant cards while exposing all gstack-style starter skills", { timeout: CLOSEOUT_TIMEOUT_MS }, async () => {
+  it("surfaces the expanded assistant starter cards while exposing all gstack-style starter skills", { timeout: CLOSEOUT_TIMEOUT_MS }, async () => {
     env = await createFridayBrowserE2eEnv();
 
     const templates = await env.apiFetch<{
@@ -130,15 +130,18 @@ describe("Friday starter skills closeout", () => {
     await pageHandle.page.goto("/assistant");
     await pageHandle.page.waitForSelector('[data-testid="assistant-goal-input"]');
     const starterStories = pageHandle.page.locator('[data-testid="assistant-task-story"]');
-    expect(await starterStories.count()).toBe(5);
+    expect(await starterStories.count()).toBe(8);
     const starterText = (await starterStories.allTextContents()).join("\n");
+    expect(starterText).toContain("Open workflow builder");
     expect(starterText).toContain("Clarify an idea");
     expect(starterText).toContain("Review implementation plan");
     expect(starterText).toContain("QA this page or app");
     expect(starterText).toContain("Review current changes");
     expect(starterText).toContain("Sync release docs");
-    expect(starterText).not.toContain("Benchmark this page");
-    expect(starterText).not.toContain("Run security review");
+    expect(starterText).toContain("Review integration mode");
+    expect(starterText).toContain("Review context governance");
+    expect(starterText).not.toContain("Page Benchmark Report");
+    expect(starterText).not.toContain("Security Review");
 
     await pageHandle.page.goto("/skills?skillId=page-benchmark-report");
     await pageHandle.page.waitForFunction(

--- a/test/unit/agent/subagent/friday-subagent-profile.test.ts
+++ b/test/unit/agent/subagent/friday-subagent-profile.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { inferFridaySubagentProfile, resolveFridaySubagentProfile } from "#agent";
 
-describe("Friday subagent profiles", () => {
+import {
+  inferFridaySubagentProfile,
+  resolveFridaySubagentProfile,
+  taskLikelyNeedsWriteAccessForSubagent,
+} from "#agent";
+
+describe("Friday subagent profile helpers", () => {
   it("resolves plan profile with its default task profile", () => {
     const profile = resolveFridaySubagentProfile("plan");
 
@@ -16,5 +21,30 @@ describe("Friday subagent profiles", () => {
   it("infers review and debug profiles from task text", () => {
     expect(inferFridaySubagentProfile("review this diff for regressions")).toBe("review");
     expect(inferFridaySubagentProfile("debug this failing log pipeline")).toBe("debug");
+  });
+
+  it("keeps reconnaissance tasks read-only by default", () => {
+    expect(taskLikelyNeedsWriteAccessForSubagent("Search for nodejs testing frameworks")).toBe(false);
+    expect(taskLikelyNeedsWriteAccessForSubagent("Review the workflow diff and summarize risks")).toBe(false);
+  });
+
+  it("detects delegated tasks that need mutating tools", () => {
+    expect(taskLikelyNeedsWriteAccessForSubagent("Write a file")).toBe(true);
+    expect(taskLikelyNeedsWriteAccessForSubagent("Continue and fix the failing workflow generator tests")).toBe(true);
+    expect(taskLikelyNeedsWriteAccessForSubagent("Open example.com and take a screenshot")).toBe(true);
+    expect(taskLikelyNeedsWriteAccessForSubagent("Run the build command and deploy the app")).toBe(true);
+  });
+
+  it("allows automatic delegation to preserve the inferred profile while disabling readOnly", () => {
+    const inferred = inferFridaySubagentProfile("Open example.com and take a screenshot");
+    const resolved = resolveFridaySubagentProfile({
+      id: inferred,
+      readOnly: false,
+      taskProfile: "deterministic",
+    });
+
+    expect(inferred).toBe("explore");
+    expect(resolved.readOnly).toBe(false);
+    expect(resolved.taskProfile).toBe("deterministic");
   });
 });


### PR DESCRIPTION
## Summary
- keep automatic delegation for operational work but opt mutating child tasks out of readOnly
- widen internal subagent spawn profile typing so the hub can override readOnly without changing public tool contracts
- add regression coverage for delegated write/screenshot style tasks

## Validation
- npm run typecheck
- npm run lint
- npm run build:ui
- npx vitest run test/unit/agent/subagent/friday-subagent-profile.test.ts
- npx vitest run test/e2e/mock/friday-mock-tool-invocations.e2e.test.ts --testNamePattern "write tool round-trip creates file on disk"
- npx vitest run test/e2e/mock/friday-mock-multi-turn.e2e.test.ts --testNamePattern "cross-run tool results: run 1 writes file, run 2 reads it"
- npx vitest run test/e2e/mock/friday-openclaw-parity-closure.e2e.test.ts --testNamePattern "browser screenshot produces user-visible artifact path and on-disk file|webchat completed run returns user-visible message plus image artifacts|discord inbound message produces user-visible outbound message with attached artifact file"