### PR TITLE
feat(ui): sweep workflow builder palette and diagnostics

### DIFF
--- a/test/unit/ui/workflow-builder-canvas.test.ts
+++ b/test/unit/ui/workflow-builder-canvas.test.ts
@@ -2,10 +2,14 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildBuilderPaletteGroups,
+  buildValidationIssueNavigationItems,
   describeWorkflowEdgeLabel,
   edgeKeyFor,
+  findClosestDropTargetNodeId,
   snapFlowPositionToGrid,
   summarizeWorkflowValidationIssues,
+  validationIssueKeyFor,
+  validationIssueTargetKeyFor,
 } from "../../../ui/src/lib/workflows/builder-canvas";
 import type { FridayWorkflowBuilderValidationReport } from "../../../ui/src/lib/api/types";
 
@@ -41,6 +45,67 @@ describe("workflow builder canvas helpers", () => {
   it("snaps preview coordinates onto the workflow grid", () => {
     expect(snapFlowPositionToGrid({ x: 15, y: 41 })).toEqual({ x: 28, y: 28 });
     expect(snapFlowPositionToGrid({ x: 57, y: 73 }, { gridSize: 16 })).toEqual({ x: 64, y: 80 });
+  });
+
+  it("builds stable navigation items and issue keys for focusable diagnostics", () => {
+    const validation: FridayWorkflowBuilderValidationReport = {
+      valid: false,
+      generatedAt: "2026-03-25T00:00:00.000Z",
+      issues: [
+        {
+          code: "missing-ref",
+          stage: "graph_compile",
+          severity: "error",
+          message: "step-a has no ref",
+          stepId: "step-a",
+        },
+        {
+          code: "edge-condition",
+          stage: "compiled_graph",
+          severity: "warning",
+          message: "true branch is too broad",
+          edgeRef: { from: "step-a", to: "step-b", when: "true" },
+        },
+        {
+          code: "workflow-metadata",
+          stage: "graph_compile",
+          severity: "warning",
+          message: "description is empty",
+        },
+      ],
+    };
+
+    const items = buildValidationIssueNavigationItems(validation);
+
+    expect(validationIssueTargetKeyFor(validation.issues[0]!)).toBe("step-a");
+    expect(validationIssueTargetKeyFor(validation.issues[1]!)).toBe("step-a:step-b:true");
+    expect(validationIssueTargetKeyFor(validation.issues[2]!)).toBeNull();
+    expect(validationIssueKeyFor(validation.issues[0]!, 0)).toBe("graph_compile::missing-ref::step-a::0");
+    expect(items).toEqual([
+      {
+        key: "graph_compile::missing-ref::step-a::0",
+        issue: validation.issues[0],
+        targetKey: "step-a",
+        targetKind: "node",
+      },
+      {
+        key: "compiled_graph::edge-condition::step-a:step-b:true::1",
+        issue: validation.issues[1],
+        targetKey: "step-a:step-b:true",
+        targetKind: "edge",
+      },
+    ]);
+  });
+
+  it("finds the nearest drop target node within a threshold", () => {
+    const nodes = [
+      { id: "step-a", position: { x: 120, y: 100 }, width: 240, height: 124 },
+      { id: "step-b", position: { x: 520, y: 240 }, width: 240, height: 124 },
+    ];
+
+    expect(findClosestDropTargetNodeId(nodes, { x: 270, y: 166 })).toBe("step-a");
+    expect(findClosestDropTargetNodeId(nodes, { x: 640, y: 320 })).toBe("step-b");
+    expect(findClosestDropTargetNodeId(nodes, { x: 20, y: 20 }, { thresholdPx: 80 })).toBeNull();
   });
 
   it("groups compile issues by node id and edge ref with severity-aware tones", () => {

--- a/test/unit/ui/workflow-builder-canvas.test.ts
+++ b/test/unit/ui/workflow-builder-canvas.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  buildBuilderPaletteGroups,
   describeWorkflowEdgeLabel,
   edgeKeyFor,
+  snapFlowPositionToGrid,
   summarizeWorkflowValidationIssues,
 } from "../../../ui/src/lib/workflows/builder-canvas";
 import type { FridayWorkflowBuilderValidationReport } from "../../../ui/src/lib/api/types";
@@ -15,6 +17,30 @@ describe("workflow builder canvas helpers", () => {
     expect(describeWorkflowEdgeLabel({ branch: "success", condition: undefined })).toBe("On success");
     expect(describeWorkflowEdgeLabel({ branch: undefined, condition: "result.ok == true" })).toBe("result.ok == true");
     expect(describeWorkflowEdgeLabel({ branch: undefined, condition: undefined }, { includeFallback: true })).toBe("Always");
+  });
+
+  it("groups palette entries by domain and filters by search query", () => {
+    expect(buildBuilderPaletteGroups().map((group) => group.label)).toEqual([
+      "Execution",
+      "Logic",
+      "Data",
+    ]);
+    expect(buildBuilderPaletteGroups().find((group) => group.label === "Execution")?.entries.map((entry) => entry.type)).toEqual([
+      "action",
+      "ai",
+    ]);
+    expect(buildBuilderPaletteGroups({ query: "logic" }).flatMap((group) => group.entries.map((entry) => entry.type))).toEqual([
+      "condition",
+      "approval",
+    ]);
+    expect(buildBuilderPaletteGroups({ query: "transform" }).flatMap((group) => group.entries.map((entry) => entry.type))).toEqual([
+      "data",
+    ]);
+  });
+
+  it("snaps preview coordinates onto the workflow grid", () => {
+    expect(snapFlowPositionToGrid({ x: 15, y: 41 })).toEqual({ x: 28, y: 28 });
+    expect(snapFlowPositionToGrid({ x: 57, y: 73 }, { gridSize: 16 })).toEqual({ x: 64, y: 80 });
   });
 
   it("groups compile issues by node id and edge ref with severity-aware tones", () => {
@@ -51,14 +77,47 @@ describe("workflow builder canvas helpers", () => {
     expect(summary.nodeIssues.get("step-a")).toMatchObject({
       tone: "danger",
       count: 2,
+      primaryIssueMessage: "step-a has no ref",
+      remainingCount: 1,
     });
     expect(summary.edgeIssues.get("step-b:step-c:false")).toMatchObject({
       tone: "danger",
       count: 1,
+      primaryIssueMessage: "false branch is dangling",
+      remainingCount: 0,
     });
     expect(summary.nodeIssues.get("step-a")?.issues.map((issue) => issue.code)).toEqual([
       "missing-ref",
       "missing-timeout",
     ]);
+    expect(summary.globalIssues).toEqual([]);
+    expect(summary.focusableIssues).toHaveLength(3);
+  });
+
+  it("separates non-focusable global issues from node and edge diagnostics", () => {
+    const validation: FridayWorkflowBuilderValidationReport = {
+      valid: false,
+      generatedAt: "2026-03-25T00:00:00.000Z",
+      issues: [
+        {
+          code: "workflow-metadata",
+          stage: "graph_compile",
+          severity: "warning",
+          message: "workflow description is empty",
+        },
+        {
+          code: "edge-condition",
+          stage: "compiled_graph",
+          severity: "warning",
+          message: "edge condition is too broad",
+          edgeRef: { from: "step-a", to: "step-b", when: "success" },
+        },
+      ],
+    };
+
+    const summary = summarizeWorkflowValidationIssues(validation);
+
+    expect(summary.globalIssues.map((issue) => issue.code)).toEqual(["workflow-metadata"]);
+    expect(summary.focusableIssues.map((issue) => issue.code)).toEqual(["edge-condition"]);
   });
 });

--- a/test/unit/ui/workflow-builder-page.test.ts
+++ b/test/unit/ui/workflow-builder-page.test.ts
@@ -1,0 +1,511 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { parseHTML } from "linkedom";
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { WorkflowBuilderPage } from "../../../ui/src/routes/workflow-builder-page";
+
+const mocks = vi.hoisted(() => ({
+  listTemplates: vi.fn(),
+  getTemplate: vi.fn(),
+  instantiateTemplate: vi.fn(),
+  listDrafts: vi.fn(),
+  createDraft: vi.fn(),
+  getDraft: vi.fn(),
+  saveDraft: vi.fn(),
+  autosaveDraft: vi.fn(),
+  compileDraft: vi.fn(),
+  publishDraft: vi.fn(),
+  acquireLock: vi.fn(),
+  renewLock: vi.fn(),
+  releaseLock: vi.fn(),
+  listWorkflows: vi.fn(),
+  createWorkflow: vi.fn(),
+  listSkills: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+  setCenter: vi.fn(),
+  screenToFlowPosition: vi.fn((input: { x: number; y: number }) => input),
+}));
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({
+    user: { id: "user-1" },
+  }),
+}));
+
+vi.mock("@/lib/api/workflow-builder", () => ({
+  workflowBuilderApi: {
+    listTemplates: mocks.listTemplates,
+    getTemplate: mocks.getTemplate,
+    instantiateTemplate: mocks.instantiateTemplate,
+    listDrafts: mocks.listDrafts,
+    createDraft: mocks.createDraft,
+    getDraft: mocks.getDraft,
+    saveDraft: mocks.saveDraft,
+    autosaveDraft: mocks.autosaveDraft,
+    compileDraft: mocks.compileDraft,
+    publishDraft: mocks.publishDraft,
+    acquireLock: mocks.acquireLock,
+    renewLock: mocks.renewLock,
+    releaseLock: mocks.releaseLock,
+  },
+}));
+
+vi.mock("@/lib/api/workflows", () => ({
+  workflowsApi: {
+    list: mocks.listWorkflows,
+    create: mocks.createWorkflow,
+  },
+}));
+
+vi.mock("@/lib/api/skills", () => ({
+  skillsApi: {
+    listSkills: mocks.listSkills,
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: mocks.toastSuccess,
+    error: mocks.toastError,
+  },
+}));
+
+vi.mock("@xyflow/react", async () => {
+  const react = await import("react");
+
+  return {
+    Background: () => react.createElement("div", { "data-testid": "mock-flow-background" }),
+    BaseEdge: (props: { id?: string }) => react.createElement("div", { "data-testid": `mock-edge-base-${props.id ?? "edge"}` }),
+    Controls: () => react.createElement("div", { "data-testid": "mock-flow-controls" }),
+    EdgeLabelRenderer: ({ children }: { children?: react.ReactNode }) => react.createElement(react.Fragment, null, children),
+    Handle: () => react.createElement("span", { "data-testid": "mock-flow-handle" }),
+    MarkerType: {
+      ArrowClosed: "arrowclosed",
+    },
+    MiniMap: () => react.createElement("div", { "data-testid": "mock-flow-minimap" }),
+    Position: {
+      Left: "left",
+      Right: "right",
+    },
+    ReactFlow: ({
+      nodes,
+      edges,
+      nodeTypes,
+      edgeTypes,
+      children,
+    }: {
+      nodes: Array<Record<string, unknown>>;
+      edges: Array<Record<string, unknown>>;
+      nodeTypes?: Record<string, (props: Record<string, unknown>) => react.ReactNode>;
+      edgeTypes?: Record<string, (props: Record<string, unknown>) => react.ReactNode>;
+      children?: react.ReactNode;
+    }) => react.createElement(
+      "div",
+      { "data-testid": "mock-react-flow" },
+      [
+        ...(nodes ?? []).map((node) => {
+          const NodeRenderer = nodeTypes?.[String(node.type)] ?? ((props: { data?: { name?: string } }) => react.createElement("div", null, props.data?.name ?? "node"));
+          return react.createElement(
+            "div",
+            { key: `node-${String(node.id)}`, "data-node-id": String(node.id) },
+            react.createElement(NodeRenderer, {
+              id: node.id,
+              data: node.data,
+              selected: node.selected ?? false,
+              type: node.type,
+              dragging: false,
+              zIndex: 1,
+              isConnectable: true,
+              targetPosition: "left",
+              sourcePosition: "right",
+              positionAbsoluteX: (node.position as { x: number; y: number } | undefined)?.x ?? 0,
+              positionAbsoluteY: (node.position as { x: number; y: number } | undefined)?.y ?? 0,
+            }),
+          );
+        }),
+        ...(edges ?? []).map((edge) => {
+          const EdgeRenderer = edgeTypes?.[String(edge.type)] ?? (() => null);
+          return react.createElement(
+            "div",
+            { key: `edge-${String(edge.id)}`, "data-edge-id": String(edge.id) },
+            react.createElement(EdgeRenderer, {
+              id: edge.id,
+              source: edge.source,
+              target: edge.target,
+              selected: edge.selected ?? false,
+              data: edge.data,
+              markerEnd: edge.markerEnd,
+              sourceX: 0,
+              sourceY: 0,
+              targetX: 100,
+              targetY: 32,
+              sourcePosition: "right",
+              targetPosition: "left",
+            }),
+          );
+        }),
+        children,
+      ],
+    ),
+    ReactFlowProvider: ({ children }: { children?: react.ReactNode }) => react.createElement(react.Fragment, null, children),
+    applyEdgeChanges: (_changes: unknown, edges: unknown) => edges,
+    applyNodeChanges: (_changes: unknown, nodes: unknown) => nodes,
+    getBezierPath: () => ["M0,0", 48, 20],
+    useReactFlow: () => ({
+      screenToFlowPosition: mocks.screenToFlowPosition,
+      setCenter: mocks.setCenter,
+    }),
+  };
+});
+
+function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function flushCycles(count = 8): Promise<void> {
+  for (let index = 0; index < count; index += 1) {
+    await flush();
+  }
+}
+
+async function waitFor<T>(factory: () => T, predicate: (value: T) => boolean, attempts = 20): Promise<T> {
+  for (let index = 0; index < attempts; index += 1) {
+    const value = factory();
+    if (predicate(value)) {
+      return value;
+    }
+    await act(async () => {
+      await flushCycles();
+    });
+  }
+  return factory();
+}
+
+function defineGlobal<K extends keyof typeof globalThis>(key: K, value: (typeof globalThis)[K]): void {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    writable: true,
+    value,
+  });
+}
+
+function buildDraft() {
+  return {
+    draftId: "draft-1",
+    workflowId: "workflow-1",
+    ownerUserId: "user-1",
+    title: "Workflow Draft",
+    status: "active" as const,
+    revision: 3,
+    spec: {
+      schemaVersion: "1.0",
+      workflowId: "workflow-1",
+      name: "Workflow Draft",
+      description: "Workflow builder page coverage",
+      startStepId: "step-a",
+      trigger: { type: "manual" as const },
+      inputs: [],
+      steps: [
+        {
+          id: "step-a",
+          type: "skill_call" as const,
+          ref: "browser-qa-report",
+          args: {
+            taskProfile: "review",
+            integrationMode: "stable_skill",
+          },
+        },
+      ],
+      edges: [],
+      outputs: [],
+      errorPolicy: { onFailure: "fail_fast" as const, notifyUser: true },
+      tests: [],
+    },
+    visual: {
+      schemaVersion: "1.0",
+      workflowId: "workflow-1",
+      viewport: { x: 0, y: 0, zoom: 1 },
+      selectedNodeId: null,
+      selectedEdgeKey: null,
+      panelLayout: { leftOpen: true, rightOpen: true, bottomOpen: false },
+      nodes: [
+        { nodeId: "__trigger__", x: 24, y: 120, width: 220, height: 120 },
+        { nodeId: "step-a", x: 320, y: 120, width: 240, height: 120 },
+      ],
+      edges: [
+        { edgeKey: "__trigger__:step-a:any", sourceHandle: "any", targetHandle: "in" },
+      ],
+    },
+    createdAt: "2026-03-25T00:00:00.000Z",
+    updatedAt: "2026-03-25T00:00:00.000Z",
+    autosave: {
+      enabled: true,
+      intervalMs: 15000,
+      lastSavedAt: "2026-03-25T00:00:00.000Z",
+    },
+  };
+}
+
+describe("workflow builder page", () => {
+  let root: Root | null = null;
+  let container: HTMLElement | null = null;
+  let queryClient: QueryClient;
+  let windowRef: Window & typeof globalThis;
+  let previousWindow: typeof globalThis.window | undefined;
+  let previousDocument: typeof globalThis.document | undefined;
+  let previousNavigator: typeof globalThis.navigator | undefined;
+  let previousHTMLElement: typeof globalThis.HTMLElement | undefined;
+  let previousSVGElement: typeof globalThis.SVGElement | undefined;
+  let previousNode: typeof globalThis.Node | undefined;
+  let previousMutationObserver: typeof globalThis.MutationObserver | undefined;
+  let previousEvent: typeof globalThis.Event | undefined;
+  let previousMouseEvent: typeof globalThis.MouseEvent | undefined;
+  let previousInputEvent: typeof globalThis.InputEvent | undefined;
+
+  async function renderPage(path = "/workflows/builder?workflowId=workflow-1&draftId=draft-1&focus=draft"): Promise<void> {
+    await act(async () => {
+      root!.render(
+        createElement(
+          MemoryRouter,
+          { initialEntries: [path], key: path },
+          createElement(
+            QueryClientProvider,
+            { client: queryClient },
+            createElement(WorkflowBuilderPage),
+          ),
+        ),
+      );
+      await flushCycles();
+    });
+  }
+
+  function getByTestId<T extends HTMLElement = HTMLElement>(testId: string): T {
+    const element = container?.querySelector<T>(`[data-testid="${testId}"]`);
+    expect(element, `Missing test id ${testId}`).not.toBeNull();
+    return element!;
+  }
+
+  function getButtonByText(label: string): HTMLButtonElement {
+    const button = Array.from(container?.querySelectorAll("button") ?? []).find((candidate) =>
+      candidate.textContent?.includes(label),
+    ) as HTMLButtonElement | undefined;
+    expect(button, `Missing button ${label}`).toBeDefined();
+    return button!;
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+    const draft = buildDraft();
+
+    mocks.listTemplates.mockResolvedValue({
+      items: [],
+      stableItems: [],
+    });
+    mocks.getTemplate.mockResolvedValue({ template: null });
+    mocks.instantiateTemplate.mockResolvedValue({ draft });
+    mocks.listDrafts.mockResolvedValue({ items: [draft] });
+    mocks.createDraft.mockResolvedValue({ draft });
+    mocks.getDraft.mockResolvedValue({ draft });
+    mocks.saveDraft.mockResolvedValue({
+      draft: {
+        ...draft,
+        revision: 4,
+        updatedAt: "2026-03-25T00:10:00.000Z",
+      },
+    });
+    mocks.autosaveDraft.mockResolvedValue({ draft: null });
+    mocks.compileDraft.mockResolvedValue({
+      compiled: {
+        schemaVersion: "2.0",
+        workflowId: "workflow-1",
+        graph: {
+          nodes: [{ id: "step-a", type: "skill_call", ref: "browser-qa-report" }],
+          edges: [],
+        },
+      },
+      validation: {
+        valid: false,
+        generatedAt: "2026-03-25T00:05:00.000Z",
+        issues: [
+          {
+            code: "missing-ref",
+            stage: "graph_compile",
+            severity: "error",
+            message: "Action step needs a ref",
+            stepId: "step-a",
+          },
+        ],
+      },
+    });
+    mocks.publishDraft.mockResolvedValue({
+      workflowId: "workflow-1",
+      workflowVersionId: "version-1",
+      versionNumber: 1,
+      published: true,
+      checksum: "checksum-1",
+      validation: {
+        valid: true,
+        generatedAt: "2026-03-25T00:06:00.000Z",
+        issues: [],
+      },
+    });
+    mocks.acquireLock.mockResolvedValue({
+      acquired: true,
+      lock: {
+        workflowId: "workflow-1",
+        lockToken: "lock-1",
+        ownerUserId: "user-1",
+        ownerSessionId: "session-1",
+        expiresAt: "2026-03-25T00:10:00.000Z",
+      },
+    });
+    mocks.renewLock.mockResolvedValue({
+      lock: {
+        workflowId: "workflow-1",
+        lockToken: "lock-1",
+        ownerUserId: "user-1",
+        ownerSessionId: "session-1",
+        expiresAt: "2026-03-25T00:10:00.000Z",
+      },
+    });
+    mocks.releaseLock.mockResolvedValue({ released: true });
+    mocks.listWorkflows.mockResolvedValue({
+      items: [{ id: "workflow-1", name: "Workflow Draft" }],
+    });
+    mocks.createWorkflow.mockResolvedValue({
+      workflow: { id: "workflow-2" },
+    });
+    mocks.listSkills.mockResolvedValue([
+      { skillId: "browser-qa-report", name: "Browser QA Report" },
+    ]);
+
+    const { window } = parseHTML("<html><body><div id='root'></div></body></html>");
+    windowRef = window as unknown as Window & typeof globalThis;
+    previousWindow = globalThis.window;
+    previousDocument = globalThis.document;
+    previousNavigator = globalThis.navigator;
+    previousHTMLElement = globalThis.HTMLElement;
+    previousSVGElement = globalThis.SVGElement;
+    previousNode = globalThis.Node;
+    previousMutationObserver = globalThis.MutationObserver;
+    previousEvent = globalThis.Event;
+    previousMouseEvent = globalThis.MouseEvent;
+    previousInputEvent = globalThis.InputEvent;
+
+    defineGlobal("window", windowRef);
+    defineGlobal("document", windowRef.document);
+    defineGlobal("navigator", windowRef.navigator);
+    defineGlobal("HTMLElement", windowRef.HTMLElement);
+    defineGlobal("SVGElement", windowRef.SVGElement);
+    defineGlobal("Node", windowRef.Node);
+    defineGlobal("MutationObserver", windowRef.MutationObserver);
+    defineGlobal("Event", windowRef.Event);
+    defineGlobal("MouseEvent", windowRef.MouseEvent);
+    defineGlobal("InputEvent", windowRef.InputEvent);
+
+    container = windowRef.document.getElementById("root") as HTMLElement;
+    root = createRoot(container);
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => {
+        root!.unmount();
+        await flushCycles();
+      });
+    }
+
+    defineGlobal("window", previousWindow as typeof globalThis.window);
+    defineGlobal("document", previousDocument as typeof globalThis.document);
+    defineGlobal("navigator", previousNavigator as typeof globalThis.navigator);
+    defineGlobal("HTMLElement", previousHTMLElement as typeof globalThis.HTMLElement);
+    defineGlobal("SVGElement", previousSVGElement as typeof globalThis.SVGElement);
+    defineGlobal("Node", previousNode as typeof globalThis.Node);
+    defineGlobal("MutationObserver", previousMutationObserver as typeof globalThis.MutationObserver);
+    defineGlobal("Event", previousEvent as typeof globalThis.Event);
+    defineGlobal("MouseEvent", previousMouseEvent as typeof globalThis.MouseEvent);
+    defineGlobal("InputEvent", previousInputEvent as typeof globalThis.InputEvent);
+  });
+
+  it("shows grouped node palette sections and filters them by the local search query", async () => {
+    await renderPage();
+
+    const initialText = await waitFor(
+      () => getByTestId("workflow-builder-node-library").textContent ?? "",
+      (value) => value.includes("Node Library"),
+    );
+
+    expect(initialText).toContain("Execution");
+    expect(initialText).toContain("Logic");
+    expect(initialText).toContain("Data");
+    expect(initialText).toContain("Action");
+    expect(initialText).toContain("AI / Tool");
+    expect(initialText).toContain("Condition");
+    expect(initialText).toContain("Approval");
+    expect(initialText).toContain("Transform");
+
+    const searchInput = getByTestId<HTMLInputElement>("workflow-builder-node-search");
+    await act(async () => {
+      searchInput.value = "logic";
+      searchInput.dispatchEvent(new windowRef.InputEvent("input", { bubbles: true, data: "logic", inputType: "insertText" }));
+      searchInput.dispatchEvent(new windowRef.Event("change", { bubbles: true }));
+      await flushCycles();
+    });
+
+    const filteredText = getByTestId("workflow-builder-node-library").textContent ?? "";
+    expect(filteredText).toContain("Logic");
+    expect(filteredText).toContain("Condition");
+    expect(filteredText).toContain("Approval");
+    expect(filteredText).not.toContain("AI / Tool");
+    expect(filteredText).not.toContain("Transform");
+  });
+
+  it("projects compile diagnostics into the canvas summary and focuses the affected node", async () => {
+    await renderPage();
+
+    await waitFor(
+      () => container?.textContent ?? "",
+      (value) => value.includes("Compile") && value.includes("lock"),
+    );
+
+    await act(async () => {
+      getButtonByText("Compile").click();
+      await flushCycles();
+    });
+
+    await waitFor(
+      () => mocks.compileDraft.mock.calls.length,
+      (value) => value > 0,
+    );
+
+    const summary = await waitFor(
+      () => container?.querySelector<HTMLElement>('[data-testid="workflow-builder-compile-summary"]')?.textContent ?? "",
+      (value) => value.includes("1 errors"),
+    );
+    expect(summary).toContain("1 errors");
+
+    const text = container?.textContent ?? "";
+    expect(text).toContain("Compile report");
+    expect(text).toContain("Node issues");
+    expect(text).toContain("Action step needs a ref");
+
+    await act(async () => {
+      getButtonByText("Jump to next issue").dispatchEvent(new windowRef.Event("click", { bubbles: true }));
+      await flushCycles();
+    });
+
+    expect(mocks.setCenter).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/unit/ui/workflow-builder-page.test.ts
+++ b/test/unit/ui/workflow-builder-page.test.ts
@@ -219,8 +219,24 @@ function buildDraft() {
             integrationMode: "stable_skill",
           },
         },
+        {
+          id: "step-b",
+          type: "transform" as const,
+          ref: "reshape-result",
+          args: {
+            mapping: {
+              summary: "$steps.step-a.output.summary",
+            },
+          },
+        },
       ],
-      edges: [],
+      edges: [
+        {
+          from: "step-a",
+          to: "step-b",
+          when: "success" as const,
+        },
+      ],
       outputs: [],
       errorPolicy: { onFailure: "fail_fast" as const, notifyUser: true },
       tests: [],
@@ -235,9 +251,11 @@ function buildDraft() {
       nodes: [
         { nodeId: "__trigger__", x: 24, y: 120, width: 220, height: 120 },
         { nodeId: "step-a", x: 320, y: 120, width: 240, height: 120 },
+        { nodeId: "step-b", x: 640, y: 120, width: 240, height: 120 },
       ],
       edges: [
         { edgeKey: "__trigger__:step-a:any", sourceHandle: "any", targetHandle: "in" },
+        { edgeKey: "step-a:step-b:success", sourceHandle: "success", targetHandle: "in" },
       ],
     },
     createdAt: "2026-03-25T00:00:00.000Z",
@@ -297,6 +315,26 @@ describe("workflow builder page", () => {
     return button!;
   }
 
+  function dispatchKey(target: HTMLElement, key: string): void {
+    const event = new windowRef.Event("keydown", { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "key", {
+      configurable: true,
+      value: key,
+    });
+    target.dispatchEvent(event);
+  }
+
+  function createDataTransfer(type: string) {
+    return {
+      types: ["application/friday-workflow-node-type"],
+      effectAllowed: "move",
+      dropEffect: "move",
+      setData: vi.fn(),
+      getData: vi.fn((mime: string) => (mime === "application/friday-workflow-node-type" ? type : type)),
+      setDragImage: vi.fn(),
+    };
+  }
+
   beforeEach(async () => {
     vi.clearAllMocks();
     (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -325,8 +363,13 @@ describe("workflow builder page", () => {
         schemaVersion: "2.0",
         workflowId: "workflow-1",
         graph: {
-          nodes: [{ id: "step-a", type: "skill_call", ref: "browser-qa-report" }],
-          edges: [],
+          nodes: [
+            { id: "step-a", type: "skill_call", ref: "browser-qa-report" },
+            { id: "step-b", type: "transform", ref: "reshape-result" },
+          ],
+          edges: [
+            { from: "step-a", to: "step-b", when: "success" },
+          ],
         },
       },
       validation: {
@@ -339,6 +382,13 @@ describe("workflow builder page", () => {
             severity: "error",
             message: "Action step needs a ref",
             stepId: "step-a",
+          },
+          {
+            code: "edge-condition",
+            stage: "compiled_graph",
+            severity: "warning",
+            message: "Success branch is too broad",
+            edgeRef: { from: "step-a", to: "step-b", when: "success" },
           },
         ],
       },
@@ -439,7 +489,7 @@ describe("workflow builder page", () => {
     defineGlobal("InputEvent", previousInputEvent as typeof globalThis.InputEvent);
   });
 
-  it("shows grouped node palette sections and filters them by the local search query", async () => {
+  it("supports palette collapse, search override, and keyboard insertion", async () => {
     await renderPage();
 
     const initialText = await waitFor(
@@ -456,23 +506,49 @@ describe("workflow builder page", () => {
     expect(initialText).toContain("Approval");
     expect(initialText).toContain("Transform");
 
+    await act(async () => {
+      getByTestId("workflow-builder-palette-toggle-execution").click();
+      await flushCycles();
+    });
+
+    const collapsedText = getByTestId("workflow-builder-node-library").textContent ?? "";
+    expect(collapsedText).toContain("Group collapsed");
+    expect(collapsedText).not.toContain("Call a stable skill or external operation as a concrete workflow step.");
+
     const searchInput = getByTestId<HTMLInputElement>("workflow-builder-node-search");
     await act(async () => {
-      searchInput.value = "logic";
-      searchInput.dispatchEvent(new windowRef.InputEvent("input", { bubbles: true, data: "logic", inputType: "insertText" }));
+      searchInput.value = "action";
+      searchInput.dispatchEvent(new windowRef.InputEvent("input", { bubbles: true, data: "action", inputType: "insertText" }));
       searchInput.dispatchEvent(new windowRef.Event("change", { bubbles: true }));
       await flushCycles();
     });
 
     const filteredText = getByTestId("workflow-builder-node-library").textContent ?? "";
-    expect(filteredText).toContain("Logic");
-    expect(filteredText).toContain("Condition");
-    expect(filteredText).toContain("Approval");
-    expect(filteredText).not.toContain("AI / Tool");
-    expect(filteredText).not.toContain("Transform");
+    expect(filteredText).toContain("Action");
+    expect(filteredText).not.toContain("Approval");
+
+    await act(async () => {
+      dispatchKey(searchInput, "ArrowDown");
+      dispatchKey(searchInput, "Enter");
+      await flushCycles();
+    });
+
+    expect(getByTestId("workflow-builder-palette-entry-action").getAttribute("data-keyboard-active")).toBe("true");
+    expect(container?.querySelectorAll("[data-node-id]").length).toBe(4);
+
+    await act(async () => {
+      searchInput.value = "";
+      searchInput.dispatchEvent(new windowRef.InputEvent("input", { bubbles: true, data: "", inputType: "deleteContentBackward" }));
+      searchInput.dispatchEvent(new windowRef.Event("change", { bubbles: true }));
+      await flushCycles();
+    });
+
+    const restoredText = getByTestId("workflow-builder-node-library").textContent ?? "";
+    expect(restoredText).toContain("Group collapsed");
+    expect(restoredText).not.toContain("Call a stable skill or external operation as a concrete workflow step.");
   });
 
-  it("projects compile diagnostics into the canvas summary and focuses the affected node", async () => {
+  it("navigates active issues across nodes and edges from the compile summary", async () => {
     await renderPage();
 
     await waitFor(
@@ -492,20 +568,77 @@ describe("workflow builder page", () => {
 
     const summary = await waitFor(
       () => container?.querySelector<HTMLElement>('[data-testid="workflow-builder-compile-summary"]')?.textContent ?? "",
-      (value) => value.includes("1 errors"),
+      (value) => value.includes("1 errors") && value.includes("1 warnings"),
     );
     expect(summary).toContain("1 errors");
+    expect(summary).toContain("1 warnings");
 
     const text = container?.textContent ?? "";
     expect(text).toContain("Compile report");
     expect(text).toContain("Node issues");
+    expect(text).toContain("Edge issues");
     expect(text).toContain("Action step needs a ref");
+    expect(text).toContain("Success branch is too broad");
+    expect(getByTestId("workflow-builder-issue-nav-status").textContent).toContain("Issue 1 of 2");
+    expect(getByTestId("workflow-builder-active-issue-message").textContent).toContain("Action step needs a ref");
+    expect(getByTestId("workflow-builder-node-step-a").getAttribute("data-active-issue")).toBe("true");
+    expect(getByTestId("workflow-builder-compile-item-graph_compile::missing-ref::step-a::0").getAttribute("data-active-issue")).toBe("true");
 
     await act(async () => {
-      getButtonByText("Jump to next issue").dispatchEvent(new windowRef.Event("click", { bubbles: true }));
+      getByTestId("workflow-builder-issue-next").click();
       await flushCycles();
     });
 
+    expect(getByTestId("workflow-builder-issue-nav-status").textContent).toContain("Issue 2 of 2");
+    expect(getByTestId("workflow-builder-active-issue-message").textContent).toContain("Success branch is too broad");
+    expect(getByTestId("workflow-builder-edge-label-step-a:step-b:success").getAttribute("data-active-issue")).toBe("true");
+    expect(getByTestId("workflow-builder-compile-item-compiled_graph::edge-condition::step-a:step-b:success::1").getAttribute("data-active-issue")).toBe("true");
     expect(mocks.setCenter).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      getByTestId("workflow-builder-issue-prev").click();
+      await flushCycles();
+    });
+
+    expect(getByTestId("workflow-builder-issue-nav-status").textContent).toContain("Issue 1 of 2");
+    expect(getByTestId("workflow-builder-node-step-a").getAttribute("data-active-issue")).toBe("true");
+    expect(mocks.setCenter).toHaveBeenCalledTimes(2);
+  });
+
+  it("shows drag feedback, highlights drop targets, and commits dropped nodes", async () => {
+    await renderPage();
+
+    await waitFor(
+      () => container?.textContent ?? "",
+      (value) => value.includes("Canvas") && value.includes("lock"),
+    );
+
+    const canvas = getByTestId("workflow-builder-canvas");
+    const dataTransfer = createDataTransfer("condition");
+
+    await act(async () => {
+      const dragOverEvent = new windowRef.Event("dragover", { bubbles: true, cancelable: true });
+      Object.defineProperty(dragOverEvent, "dataTransfer", { configurable: true, value: dataTransfer });
+      Object.defineProperty(dragOverEvent, "clientX", { configurable: true, value: 460 });
+      Object.defineProperty(dragOverEvent, "clientY", { configurable: true, value: 180 });
+      canvas.dispatchEvent(dragOverEvent);
+      await flushCycles();
+    });
+
+    expect(getByTestId("workflow-builder-drop-feedback").textContent).toContain("Drop Condition");
+    expect(container?.querySelectorAll("[data-node-id]").length).toBe(4);
+    expect(getByTestId("workflow-builder-node-step-a").getAttribute("data-drop-target")).toBe("true");
+
+    await act(async () => {
+      const dropEvent = new windowRef.Event("drop", { bubbles: true, cancelable: true });
+      Object.defineProperty(dropEvent, "dataTransfer", { configurable: true, value: dataTransfer });
+      Object.defineProperty(dropEvent, "clientX", { configurable: true, value: 460 });
+      Object.defineProperty(dropEvent, "clientY", { configurable: true, value: 180 });
+      canvas.dispatchEvent(dropEvent);
+      await flushCycles();
+    });
+
+    expect(container?.querySelector('[data-testid="workflow-builder-drop-feedback"]')).toBeNull();
+    expect(container?.querySelectorAll("[data-node-id]").length).toBe(4);
   });
 });

--- a/ui/src/lib/workflows/builder-canvas.ts
+++ b/ui/src/lib/workflows/builder-canvas.ts
@@ -31,6 +31,20 @@ export interface BuilderPaletteGroup {
   entries: BuilderPaletteEntry[];
 }
 
+export interface BuilderValidationIssueNavigationItem {
+  key: string;
+  issue: FridayWorkflowBuilderValidationIssue;
+  targetKey: string;
+  targetKind: "node" | "edge";
+}
+
+export interface BuilderDropTargetNodeInput {
+  id: string;
+  position: { x: number; y: number };
+  width?: number;
+  height?: number;
+}
+
 export const BUILDER_NODE_PALETTE: BuilderPaletteEntry[] = [
   {
     type: "action",
@@ -143,6 +157,75 @@ export function snapFlowPositionToGrid(
     x: Math.round(input.x / gridSize) * gridSize,
     y: Math.round(input.y / gridSize) * gridSize,
   };
+}
+
+export function validationIssueTargetKeyFor(issue: FridayWorkflowBuilderValidationIssue): string | null {
+  if (issue.stepId) {
+    return issue.stepId;
+  }
+  if (issue.edgeRef) {
+    return edgeKeyFor({
+      source: issue.edgeRef.from,
+      target: issue.edgeRef.to,
+      branch: issue.edgeRef.when,
+    });
+  }
+  return null;
+}
+
+export function validationIssueKeyFor(
+  issue: FridayWorkflowBuilderValidationIssue,
+  index: number,
+): string {
+  return [
+    issue.stage,
+    issue.code,
+    validationIssueTargetKeyFor(issue) ?? "global",
+    String(index),
+  ].join("::");
+}
+
+export function buildValidationIssueNavigationItems(
+  validation?: FridayWorkflowBuilderValidationReport | null,
+): BuilderValidationIssueNavigationItem[] {
+  return (validation?.issues ?? []).flatMap((issue, index) => {
+    const targetKey = validationIssueTargetKeyFor(issue);
+    if (!targetKey) {
+      return [];
+    }
+    return [{
+      key: validationIssueKeyFor(issue, index),
+      issue,
+      targetKey,
+      targetKind: issue.stepId ? "node" : "edge",
+    }];
+  });
+}
+
+export function findClosestDropTargetNodeId(
+  nodes: BuilderDropTargetNodeInput[],
+  position: { x: number; y: number },
+  options?: { thresholdPx?: number; fallbackWidth?: number; fallbackHeight?: number },
+): string | null {
+  const thresholdPx = Math.max(1, options?.thresholdPx ?? 220);
+  const fallbackWidth = Math.max(1, options?.fallbackWidth ?? 240);
+  const fallbackHeight = Math.max(1, options?.fallbackHeight ?? 124);
+
+  let closestId: string | null = null;
+  let closestDistance = Number.POSITIVE_INFINITY;
+
+  for (const node of nodes) {
+    const centerX = node.position.x + ((node.width ?? fallbackWidth) / 2);
+    const centerY = node.position.y + ((node.height ?? fallbackHeight) / 2);
+    const distance = Math.hypot(centerX - position.x, centerY - position.y);
+    if (distance > thresholdPx || distance >= closestDistance) {
+      continue;
+    }
+    closestId = node.id;
+    closestDistance = distance;
+  }
+
+  return closestId;
 }
 
 function toneRank(severity: FridayWorkflowBuilderValidationIssue["severity"]): number {

--- a/ui/src/lib/workflows/builder-canvas.ts
+++ b/ui/src/lib/workflows/builder-canvas.ts
@@ -3,15 +3,71 @@ import type {
   FridayWorkflowBuilderValidationReport,
   FridayWorkflowEditorEdge,
   FridayWorkflowSpecEdgeWhen,
+  WorkflowNodeType,
 } from "@/lib/api/types";
 
 export type BuilderValidationTone = "warning" | "danger";
+export type BuilderPaletteGroupId = "execution" | "logic" | "data";
+
+export interface BuilderPaletteEntry {
+  type: Exclude<WorkflowNodeType, "trigger">;
+  label: string;
+  description: string;
+  groupId: BuilderPaletteGroupId;
+  groupLabel: string;
+}
 
 export interface BuilderValidationIssueSummary {
   tone: BuilderValidationTone;
   issues: FridayWorkflowBuilderValidationIssue[];
   count: number;
+  primaryIssueMessage: string;
+  remainingCount: number;
 }
+
+export interface BuilderPaletteGroup {
+  id: BuilderPaletteGroupId;
+  label: string;
+  entries: BuilderPaletteEntry[];
+}
+
+export const BUILDER_NODE_PALETTE: BuilderPaletteEntry[] = [
+  {
+    type: "action",
+    label: "Action",
+    description: "Call a stable skill or external operation as a concrete workflow step.",
+    groupId: "execution",
+    groupLabel: "Execution",
+  },
+  {
+    type: "ai",
+    label: "AI / Tool",
+    description: "Run an AI completion or direct tool invocation inside the workflow graph.",
+    groupId: "execution",
+    groupLabel: "Execution",
+  },
+  {
+    type: "condition",
+    label: "Condition",
+    description: "Branch on true/false or success/failure logic without editing raw JSON.",
+    groupId: "logic",
+    groupLabel: "Logic",
+  },
+  {
+    type: "approval",
+    label: "Approval",
+    description: "Gate execution behind a human review or owner/operator approval step.",
+    groupId: "logic",
+    groupLabel: "Logic",
+  },
+  {
+    type: "data",
+    label: "Transform",
+    description: "Map, template, or reshape data between workflow steps.",
+    groupId: "data",
+    groupLabel: "Data",
+  },
+];
 
 export function edgeKeyFor(input: { source: string; target: string; branch?: string }): string {
   return `${input.source}:${input.target}:${input.branch ?? "any"}`;
@@ -46,6 +102,49 @@ export function describeWorkflowEdgeLabel(
   return options?.includeFallback ? "Always" : null;
 }
 
+export function buildBuilderPaletteGroups(options?: { query?: string }): BuilderPaletteGroup[] {
+  const normalizedQuery = options?.query?.trim().toLowerCase() ?? "";
+  const filteredEntries =
+    normalizedQuery.length === 0
+      ? BUILDER_NODE_PALETTE
+      : BUILDER_NODE_PALETTE.filter((entry) => (
+          entry.label.toLowerCase().includes(normalizedQuery)
+          || entry.groupLabel.toLowerCase().includes(normalizedQuery)
+          || entry.description.toLowerCase().includes(normalizedQuery)
+        ));
+
+  const groups = new Map<BuilderPaletteGroupId, BuilderPaletteGroup>();
+  for (const entry of filteredEntries) {
+    const existing = groups.get(entry.groupId);
+    if (existing) {
+      existing.entries.push(entry);
+      continue;
+    }
+    groups.set(entry.groupId, {
+      id: entry.groupId,
+      label: entry.groupLabel,
+      entries: [entry],
+    });
+  }
+
+  return [
+    groups.get("execution"),
+    groups.get("logic"),
+    groups.get("data"),
+  ].filter((group): group is BuilderPaletteGroup => Boolean(group));
+}
+
+export function snapFlowPositionToGrid(
+  input: { x: number; y: number },
+  options?: { gridSize?: number },
+): { x: number; y: number } {
+  const gridSize = Math.max(1, options?.gridSize ?? 28);
+  return {
+    x: Math.round(input.x / gridSize) * gridSize,
+    y: Math.round(input.y / gridSize) * gridSize,
+  };
+}
+
 function toneRank(severity: FridayWorkflowBuilderValidationIssue["severity"]): number {
   if (severity === "error") return 2;
   if (severity === "warning") return 1;
@@ -67,6 +166,8 @@ function appendIssue(
       tone: toneFromSeverity(issue.severity),
       issues: [issue],
       count: 1,
+      primaryIssueMessage: issue.message,
+      remainingCount: 0,
     });
     return;
   }
@@ -80,19 +181,26 @@ function appendIssue(
     tone: nextTone,
     issues: [...existing.issues, issue],
     count: existing.count + 1,
+    primaryIssueMessage: existing.primaryIssueMessage,
+    remainingCount: existing.count,
   });
 }
 
 export function summarizeWorkflowValidationIssues(validation?: FridayWorkflowBuilderValidationReport | null): {
   nodeIssues: Map<string, BuilderValidationIssueSummary>;
   edgeIssues: Map<string, BuilderValidationIssueSummary>;
+  globalIssues: FridayWorkflowBuilderValidationIssue[];
+  focusableIssues: FridayWorkflowBuilderValidationIssue[];
 } {
   const nodeIssues = new Map<string, BuilderValidationIssueSummary>();
   const edgeIssues = new Map<string, BuilderValidationIssueSummary>();
+  const globalIssues: FridayWorkflowBuilderValidationIssue[] = [];
+  const focusableIssues: FridayWorkflowBuilderValidationIssue[] = [];
 
   for (const issue of validation?.issues ?? []) {
     if (issue.stepId) {
       appendIssue(nodeIssues, issue.stepId, issue);
+      focusableIssues.push(issue);
     }
     if (issue.edgeRef) {
       appendIssue(
@@ -104,8 +212,12 @@ export function summarizeWorkflowValidationIssues(validation?: FridayWorkflowBui
         }),
         issue,
       );
+      focusableIssues.push(issue);
+    }
+    if (!issue.stepId && !issue.edgeRef) {
+      globalIssues.push(issue);
     }
   }
 
-  return { nodeIssues, edgeIssues };
+  return { nodeIssues, edgeIssues, globalIssues, focusableIssues };
 }

--- a/ui/src/routes/workflow-builder-page.tsx
+++ b/ui/src/routes/workflow-builder-page.tsx
@@ -1,6 +1,6 @@
 import "@xyflow/react/dist/style.css";
 
-import { createContext, useContext, useEffect, useMemo, useRef, useState, type DragEvent as ReactDragEvent } from "react";
+import { createContext, useContext, useEffect, useMemo, useRef, useState, type DragEvent as ReactDragEvent, type KeyboardEvent as ReactKeyboardEvent } from "react";
 import {
   Background,
   BaseEdge,
@@ -29,6 +29,8 @@ import { Link, useSearchParams } from "react-router-dom";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   ArrowRightLeft,
+  ChevronDown,
+  ChevronRight,
   Copy,
   Loader2,
   Lock,
@@ -64,12 +66,16 @@ import type {
 import { cn } from "@/lib/utils/cn";
 import { createDefaultRawGraph, createDefaultSpec, createDefaultVisual, getDefaultNodeConfig, getNextNodeName } from "@/lib/workflows/defaults";
 import {
+  buildValidationIssueNavigationItems,
   describeWorkflowEdgeLabel,
   BUILDER_NODE_PALETTE,
   buildBuilderPaletteGroups,
   edgeKeyFor,
+  findClosestDropTargetNodeId,
   snapFlowPositionToGrid,
   summarizeWorkflowValidationIssues,
+  type BuilderPaletteGroupId,
+  type BuilderValidationIssueNavigationItem,
   type BuilderValidationIssueSummary,
   type BuilderValidationTone,
 } from "@/lib/workflows/builder-canvas";
@@ -87,6 +93,9 @@ type FlowNodeData = FridayWorkflowNodeDefinition & {
     issueCount?: number;
     primaryIssueMessage?: string;
     remainingCount?: number;
+    activeIssue?: boolean;
+    visitedIssue?: boolean;
+    dropTarget?: boolean;
     preview?: boolean;
   };
 };
@@ -96,6 +105,8 @@ type FlowEdgeData = NonNullable<FridayWorkflowEditorEdge["data"]> & {
   issueCount?: number;
   primaryIssueMessage?: string;
   remainingCount?: number;
+  activeIssue?: boolean;
+  visitedIssue?: boolean;
 };
 
 type FlowNode = Node<FlowNodeData, "workflow_node">;
@@ -112,6 +123,13 @@ interface EditorSnapshot {
 interface DropPreviewState {
   type: Exclude<WorkflowNodeType, "trigger">;
   position: { x: number; y: number };
+}
+
+interface CanvasDropFeedbackState {
+  tone: "valid" | "invalid";
+  type: Exclude<WorkflowNodeType, "trigger">;
+  message: string;
+  targetNodeId: string | null;
 }
 
 interface WorkflowCanvasInteractionContextValue {
@@ -151,6 +169,10 @@ const EDGE_BRANCH_OPTIONS: Array<{ value: "" | FridayWorkflowSpecEdgeWhen; label
 const NODE_LIBRARY_DND_MIME = "application/friday-workflow-node-type";
 
 const CANVAS_GRID_SIZE = 28;
+
+function describePaletteEntry(type: Exclude<WorkflowNodeType, "trigger">) {
+  return BUILDER_NODE_PALETTE.find((entry) => entry.type === type) ?? null;
+}
 
 function parseFocus(value: string | null): FridayWorkflowBuilderFocus {
   if (value === "draft" || value === "publish") {
@@ -429,6 +451,9 @@ function WorkflowCanvasNode(props: NodeProps<FlowNode>) {
   const isCondition = node.type === "condition";
   const isTrigger = node.type === "trigger";
   const isPreview = node.__ui?.preview === true;
+  const isActiveIssue = node.__ui?.activeIssue === true;
+  const isVisitedIssue = node.__ui?.visitedIssue === true;
+  const isDropTarget = node.__ui?.dropTarget === true;
   const integrationMode = typeof node.rawArgs?.integrationMode === "string" ? node.rawArgs.integrationMode : null;
   const taskProfile = typeof node.rawArgs?.taskProfile === "string" ? node.rawArgs.taskProfile : null;
   const issueTone = node.__ui?.issueTone;
@@ -439,26 +464,39 @@ function WorkflowCanvasNode(props: NodeProps<FlowNode>) {
 
   return (
     <div
+      data-testid={`workflow-builder-node-${node.id}`}
+      data-active-issue={isActiveIssue ? "true" : "false"}
+      data-drop-target={isDropTarget ? "true" : "false"}
       className={`relative min-w-[220px] rounded-[24px] border px-4 py-3 shadow-[0_18px_45px_rgba(0,0,0,0.28)] ${
         isPreview
           ? "border-dashed border-emerald-300/42 bg-emerald-300/[0.08]"
+          : isActiveIssue
+          ? "border-sky-300/58 bg-slate-950/96 ring-2 ring-sky-300/30"
           : selected
-          ? "border-emerald-300/55 bg-slate-950/96 ring-1 ring-emerald-300/30"
-          : issueTone === "danger"
+            ? "border-emerald-300/55 bg-slate-950/96 ring-1 ring-emerald-300/30"
+            : isDropTarget
+              ? "border-emerald-300/55 bg-slate-950/96 ring-2 ring-emerald-300/30"
+              : issueTone === "danger"
             ? "border-rose-300/50 bg-slate-950/96 ring-1 ring-rose-300/20"
             : issueTone === "warning"
               ? "border-amber-300/45 bg-slate-950/94 ring-1 ring-amber-300/18"
-              : "border-white/[0.12] bg-slate-950/92"
+              : isVisitedIssue
+                ? "border-white/[0.16] bg-slate-950/94"
+                : "border-white/[0.12] bg-slate-950/92"
       }`}
       style={isPreview ? { opacity: 0.9 } : undefined}
     >
       {issueTone && !isPreview ? (
         <div
           className={cn(
-            "absolute inset-y-3 left-1.5 w-1 rounded-full",
+            "absolute inset-y-3 left-1.5 rounded-full",
+            isActiveIssue ? "w-1.5" : "w-1",
             issueTone === "danger" ? "bg-rose-300/85" : "bg-amber-300/82",
           )}
         />
+      ) : null}
+      {isVisitedIssue && !isActiveIssue && !isPreview ? (
+        <div className="absolute right-3 top-3 h-2.5 w-2.5 rounded-full bg-sky-200/80" />
       ) : null}
       {!isTrigger && !isPreview ? <Handle type="target" id="in" position={Position.Left} className="!h-3 !w-3 !border-none !bg-emerald-200" /> : null}
       <div className="space-y-2">
@@ -472,6 +510,7 @@ function WorkflowCanvasNode(props: NodeProps<FlowNode>) {
             {issueCount > 0 ? (
               canFocusIssue ? (
                 <button
+                  data-testid={`workflow-builder-node-issue-pill-${node.id}`}
                   type="button"
                   onClick={(event) => {
                     event.preventDefault();
@@ -489,6 +528,7 @@ function WorkflowCanvasNode(props: NodeProps<FlowNode>) {
                 </StatusPill>
               )
             ) : null}
+            {isDropTarget && !isPreview ? <StatusPill tone="success">drop target</StatusPill> : null}
           </div>
         </div>
         <p className="text-xs text-white/56">{node.stepRef ?? "No bound ref yet"}</p>
@@ -551,6 +591,8 @@ function WorkflowCanvasNode(props: NodeProps<FlowNode>) {
 function WorkflowCanvasEdge(props: EdgeProps<FlowEdge>) {
   const { sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition, data, selected, markerEnd } = props;
   const interaction = useContext(WorkflowCanvasInteractionContext);
+  const isActiveIssue = data?.activeIssue === true;
+  const isVisitedIssue = data?.visitedIssue === true;
   const [path, labelX, labelY] = getBezierPath({
     sourceX,
     sourceY,
@@ -559,7 +601,9 @@ function WorkflowCanvasEdge(props: EdgeProps<FlowEdge>) {
     targetY,
     targetPosition,
   });
-  const edgeStroke = issueToneToEdgeStroke(data?.issueTone, selected);
+  const edgeStroke = isActiveIssue
+    ? "rgba(125, 211, 252, 0.96)"
+    : issueToneToEdgeStroke(data?.issueTone, selected);
   const label = describeWorkflowEdgeLabel(data, {
     includeFallback: selected || Boolean(data?.issueCount) || Boolean(data?.primaryIssueMessage),
   });
@@ -574,12 +618,15 @@ function WorkflowCanvasEdge(props: EdgeProps<FlowEdge>) {
         markerEnd={markerEnd}
         style={{
           stroke: edgeStroke,
-          strokeWidth: selected ? 2.6 : data?.issueTone ? 2.2 : 1.6,
+          strokeWidth: isActiveIssue ? 3 : selected ? 2.6 : data?.issueTone ? 2.2 : 1.6,
+          strokeDasharray: isActiveIssue ? "8 5" : undefined,
         }}
       />
       {label || primaryIssueMessage ? (
         <EdgeLabelRenderer>
           <button
+            data-testid={data?.edgeKey ? `workflow-builder-edge-label-${data.edgeKey}` : undefined}
+            data-active-issue={isActiveIssue ? "true" : "false"}
             type="button"
             disabled={!canFocusIssue}
             onClick={(event) => {
@@ -594,6 +641,8 @@ function WorkflowCanvasEdge(props: EdgeProps<FlowEdge>) {
             }}
             className={cn(
               "pointer-events-auto absolute min-w-[152px] rounded-[18px] border px-3 py-2 text-left text-[11px] font-semibold uppercase tracking-[0.16em] text-white shadow-[0_14px_28px_rgba(0,0,0,0.32)]",
+              isActiveIssue && "ring-2 ring-sky-300/35",
+              isVisitedIssue && !isActiveIssue && "border-white/[0.18]",
               data?.issueTone === "danger" && "border-rose-300/45 bg-rose-400/12 text-rose-100",
               data?.issueTone === "warning" && "border-amber-300/40 bg-amber-400/12 text-amber-100",
               !data?.issueTone && "border-white/[0.14] bg-slate-950/92 text-white/74",
@@ -653,14 +702,18 @@ function WorkflowBuilderEditor() {
   const [readonlyReason, setReadonlyReason] = useState<string | null>(null);
   const [lockState, setLockState] = useState<FridayAcquireWorkflowLockResponse["lock"] | null>(null);
   const [paletteQuery, setPaletteQuery] = useState("");
+  const [collapsedPaletteGroups, setCollapsedPaletteGroups] = useState<BuilderPaletteGroupId[]>([]);
+  const [keyboardPaletteIndex, setKeyboardPaletteIndex] = useState(-1);
   const [compileReport, setCompileReport] = useState<{
     validation: FridayWorkflowBuilderValidationReport;
     nodes: number;
     edges: number;
   } | null>(null);
+  const [activeIssueKey, setActiveIssueKey] = useState<string | null>(null);
+  const [visitedIssueKeys, setVisitedIssueKeys] = useState<string[]>([]);
   const [draggingPaletteType, setDraggingPaletteType] = useState<Exclude<WorkflowNodeType, "trigger"> | null>(null);
-  const [isCanvasDropActive, setIsCanvasDropActive] = useState(false);
   const [dropPreview, setDropPreview] = useState<DropPreviewState | null>(null);
+  const [dropFeedback, setDropFeedback] = useState<CanvasDropFeedbackState | null>(null);
   const [publishedVersionNumber, setPublishedVersionNumber] = useState<number | null>(null);
   const [localDraftOverride, setLocalDraftOverride] = useState<FridayWorkflowDraftEntity | null>(null);
   const historyRef = useRef<EditorSnapshot[]>([]);
@@ -734,6 +787,16 @@ function WorkflowBuilderEditor() {
   });
 
   const issueSummaries = useMemo(() => summarizeWorkflowValidationIssues(compileReport?.validation), [compileReport]);
+  const issueNavigationItems = useMemo(
+    () => buildValidationIssueNavigationItems(compileReport?.validation),
+    [compileReport],
+  );
+  const activeIssueIndex = useMemo(
+    () => issueNavigationItems.findIndex((item) => item.key === activeIssueKey),
+    [activeIssueKey, issueNavigationItems],
+  );
+  const activeIssueItem = activeIssueIndex >= 0 ? issueNavigationItems[activeIssueIndex] ?? null : null;
+  const visitedIssueKeySet = useMemo(() => new Set(visitedIssueKeys), [visitedIssueKeys]);
 
   const selectedNodeIssueSummary = selectedNode
     ? issueSummaries.nodeIssues.get(selectedNode.id) ?? null
@@ -750,6 +813,20 @@ function WorkflowBuilderEditor() {
     : null;
 
   const paletteGroups = useMemo(() => buildBuilderPaletteGroups({ query: paletteQuery }), [paletteQuery]);
+  const collapsedPaletteGroupSet = useMemo(() => new Set(collapsedPaletteGroups), [collapsedPaletteGroups]);
+  const visiblePaletteGroups = useMemo(() => {
+    const revealMatches = paletteQuery.trim().length > 0;
+    return paletteGroups.map((group) => ({
+      ...group,
+      collapsed: !revealMatches && collapsedPaletteGroupSet.has(group.id),
+      visibleEntries: (!revealMatches && collapsedPaletteGroupSet.has(group.id)) ? [] : group.entries,
+    }));
+  }, [collapsedPaletteGroupSet, paletteGroups, paletteQuery]);
+  const keyboardPaletteEntries = useMemo(
+    () => visiblePaletteGroups.flatMap((group) => group.visibleEntries),
+    [visiblePaletteGroups],
+  );
+  const keyboardPaletteEntry = keyboardPaletteIndex >= 0 ? keyboardPaletteEntries[keyboardPaletteIndex] ?? null : null;
   const compileIssueCounts = useMemo(() => {
     const issues = compileReport?.validation.issues ?? [];
     return {
@@ -757,26 +834,65 @@ function WorkflowBuilderEditor() {
       warnings: issues.filter((issue) => issue.severity === "warning").length,
     };
   }, [compileReport]);
+  const activeNodeIssueTarget = activeIssueItem?.targetKind === "node" ? activeIssueItem.targetKey : null;
+  const activeEdgeIssueTarget = activeIssueItem?.targetKind === "edge" ? activeIssueItem.targetKey : null;
+  const visitedNodeIssueTargets = useMemo(() => (
+    new Set(
+      issueNavigationItems
+        .filter((item) => item.targetKind === "node" && visitedIssueKeySet.has(item.key))
+        .map((item) => item.targetKey),
+    )
+  ), [issueNavigationItems, visitedIssueKeySet]);
+  const visitedEdgeIssueTargets = useMemo(() => (
+    new Set(
+      issueNavigationItems
+        .filter((item) => item.targetKind === "edge" && visitedIssueKeySet.has(item.key))
+        .map((item) => item.targetKey),
+    )
+  ), [issueNavigationItems, visitedIssueKeySet]);
+  const dropTargetNodeId = dropFeedback?.tone === "valid" ? dropFeedback.targetNodeId : null;
+
+  useEffect(() => {
+    if (issueNavigationItems.length === 0) {
+      setActiveIssueKey(null);
+      setVisitedIssueKeys([]);
+      return;
+    }
+    setActiveIssueKey((current) => issueNavigationItems.some((item) => item.key === current) ? current : issueNavigationItems[0]!.key);
+    setVisitedIssueKeys((current) => current.filter((key) => issueNavigationItems.some((item) => item.key === key)));
+  }, [issueNavigationItems]);
+
+  useEffect(() => {
+    setKeyboardPaletteIndex((current) => {
+      if (keyboardPaletteEntries.length === 0) {
+        return -1;
+      }
+      if (current < 0) {
+        return current;
+      }
+      return Math.min(current, keyboardPaletteEntries.length - 1);
+    });
+  }, [keyboardPaletteEntries]);
 
   const canvasNodes = useMemo(() => {
       const nextNodes: FlowNode[] = nodes.map((node) => {
         const summary = issueSummaries.nodeIssues.get(node.id);
+        const nextUi = {
+          issueTone: summary?.tone,
+          issueCount: summary?.count,
+          primaryIssueMessage: summary?.primaryIssueMessage,
+          remainingCount: summary?.remainingCount,
+          activeIssue: activeNodeIssueTarget === node.id,
+          visitedIssue: visitedNodeIssueTargets.has(node.id),
+          dropTarget: dropTargetNodeId === node.id,
+        };
+        const hasUiState = Object.values(nextUi).some((value) => value !== undefined && value !== false && value !== 0);
         return {
           ...node,
-          data: summary
-            ? {
-                ...node.data,
-                __ui: {
-                  issueTone: summary.tone,
-                  issueCount: summary.count,
-                  primaryIssueMessage: summary.primaryIssueMessage,
-                  remainingCount: summary.remainingCount,
-                },
-              }
-            : {
-                ...node.data,
-                __ui: undefined,
-              },
+          data: {
+            ...node.data,
+            __ui: hasUiState ? nextUi : undefined,
+          },
         };
       });
 
@@ -812,7 +928,7 @@ function WorkflowBuilderEditor() {
       }
 
       return nextNodes;
-    }, [activeDraft, dropPreview, issueSummaries.nodeIssues, nodes, readonlyReason]);
+    }, [activeDraft, activeNodeIssueTarget, dropPreview, dropTargetNodeId, issueSummaries.nodeIssues, nodes, readonlyReason, visitedNodeIssueTargets]);
 
   const canvasEdges = useMemo(() => (
     edges.map((edge) => {
@@ -834,6 +950,8 @@ function WorkflowBuilderEditor() {
           issueCount: summary?.count,
           primaryIssueMessage: summary?.primaryIssueMessage,
           remainingCount: summary?.remainingCount,
+          activeIssue: activeEdgeIssueTarget === edgeKey,
+          visitedIssue: visitedEdgeIssueTargets.has(edgeKey),
         },
         markerEnd: { type: MarkerType.ArrowClosed, color: stroke },
         style: {
@@ -842,7 +960,7 @@ function WorkflowBuilderEditor() {
         },
       } satisfies FlowEdge;
     })
-  ), [edges, issueSummaries.edgeIssues]);
+  ), [activeEdgeIssueTarget, edges, issueSummaries.edgeIssues, visitedEdgeIssueTargets]);
 
   const groupedRegularTemplates = useMemo(() => ({
     builtin: regularTemplates.filter((item) => item.kind === "builtin"),
@@ -1215,7 +1333,7 @@ function WorkflowBuilderEditor() {
     if (!activeDraft || readonlyReason) {
       setDraggingPaletteType(null);
       setDropPreview(null);
-      setIsCanvasDropActive(false);
+      setDropFeedback(null);
     }
   }, [activeDraft, readonlyReason]);
 
@@ -1447,6 +1565,59 @@ function WorkflowBuilderEditor() {
     });
   };
 
+  const togglePaletteGroup = (groupId: BuilderPaletteGroupId) => {
+    setCollapsedPaletteGroups((current) => (
+      current.includes(groupId)
+        ? current.filter((candidate) => candidate !== groupId)
+        : [...current, groupId]
+    ));
+  };
+
+  const handlePaletteSearchKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (keyboardPaletteEntries.length === 0) {
+      if (event.key === "Escape" && paletteQuery.length > 0) {
+        setPaletteQuery("");
+        setKeyboardPaletteIndex(-1);
+      }
+      return;
+    }
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setKeyboardPaletteIndex((current) => {
+        if (current < 0) return 0;
+        return (current + 1) % keyboardPaletteEntries.length;
+      });
+      return;
+    }
+
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setKeyboardPaletteIndex((current) => {
+        if (current < 0) return keyboardPaletteEntries.length - 1;
+        return (current - 1 + keyboardPaletteEntries.length) % keyboardPaletteEntries.length;
+      });
+      return;
+    }
+
+    if (event.key === "Enter") {
+      const nextEntry = keyboardPaletteEntry ?? keyboardPaletteEntries[0];
+      if (!nextEntry) return;
+      event.preventDefault();
+      addNode(nextEntry.type);
+      setKeyboardPaletteIndex(keyboardPaletteEntries.findIndex((entry) => entry.type === nextEntry.type));
+      return;
+    }
+
+    if (event.key === "Escape") {
+      if (paletteQuery.length > 0) {
+        event.preventDefault();
+        setPaletteQuery("");
+      }
+      setKeyboardPaletteIndex(-1);
+    }
+  };
+
   const handlePaletteDragStart = (event: ReactDragEvent<HTMLButtonElement>, type: WorkflowNodeType) => {
     if (!activeDraft || readonlyReason) {
       event.preventDefault();
@@ -1456,8 +1627,9 @@ function WorkflowBuilderEditor() {
     event.dataTransfer.setData("text/plain", type);
     event.dataTransfer.effectAllowed = "move";
     setDraggingPaletteType(type as Exclude<WorkflowNodeType, "trigger">);
+    setKeyboardPaletteIndex(BUILDER_NODE_PALETTE.findIndex((entry) => entry.type === type));
     if (typeof document !== "undefined") {
-      const paletteEntry = BUILDER_NODE_PALETTE.find((entry) => entry.type === type);
+      const paletteEntry = describePaletteEntry(type as Exclude<WorkflowNodeType, "trigger">);
       const ghost = document.createElement("div");
       ghost.style.position = "absolute";
       ghost.style.top = "-9999px";
@@ -1487,7 +1659,7 @@ function WorkflowBuilderEditor() {
   const handlePaletteDragEnd = () => {
     setDraggingPaletteType(null);
     setDropPreview(null);
-    setIsCanvasDropActive(false);
+    setDropFeedback(null);
   };
 
   const handleCanvasDragOver = (event: ReactDragEvent<HTMLDivElement>) => {
@@ -1498,10 +1670,18 @@ function WorkflowBuilderEditor() {
     const dragType = draggingPaletteType
       ?? (event.dataTransfer.getData(NODE_LIBRARY_DND_MIME) as Exclude<WorkflowNodeType, "trigger">);
     const canDrop = Boolean(activeDraft) && !readonlyReason && dragType.length > 0;
-    setIsCanvasDropActive(canDrop);
     event.dataTransfer.dropEffect = canDrop ? "move" : "none";
+    const paletteEntry = describePaletteEntry(dragType);
     if (!canDrop) {
       setDropPreview(null);
+      setDropFeedback({
+        tone: "invalid",
+        type: dragType,
+        message: !activeDraft
+          ? `Open a draft before dropping ${paletteEntry?.label ?? dragType}.`
+          : readonlyReason ?? `This draft is read-only. ${paletteEntry?.label ?? dragType} cannot be dropped.`,
+        targetNodeId: null,
+      });
       return;
     }
     const snappedPosition = snapFlowPositionToGrid(
@@ -1511,9 +1691,31 @@ function WorkflowBuilderEditor() {
       }),
       { gridSize: CANVAS_GRID_SIZE },
     );
+    const targetNodeId = findClosestDropTargetNodeId(
+      nodes
+        .filter((node) => node.data.type !== "trigger")
+        .map((node) => ({
+          id: node.id,
+          position: node.position,
+          width: node.width,
+          height: node.height,
+        })),
+      snappedPosition,
+    );
     setDropPreview({
       type: dragType,
       position: snappedPosition,
+    });
+    const targetNode = targetNodeId
+      ? nodes.find((node) => node.id === targetNodeId) ?? null
+      : null;
+    setDropFeedback({
+      tone: "valid",
+      type: dragType,
+      message: targetNode
+        ? `Drop ${paletteEntry?.label ?? dragType} near ${targetNode.data.name} · snap ${Math.round(snappedPosition.x)}, ${Math.round(snappedPosition.y)}`
+        : `Drop ${paletteEntry?.label ?? dragType} on canvas · snap ${Math.round(snappedPosition.x)}, ${Math.round(snappedPosition.y)}`,
+      targetNodeId,
     });
   };
 
@@ -1522,13 +1724,14 @@ function WorkflowBuilderEditor() {
       return;
     }
     event.preventDefault();
-    setIsCanvasDropActive(false);
     setDraggingPaletteType(null);
     if (!activeDraft) {
+      setDropFeedback(null);
       toast.error("Create or open a draft before dropping nodes onto the canvas.");
       return;
     }
     if (readonlyReason) {
+      setDropFeedback(null);
       toast.error(readonlyReason);
       return;
     }
@@ -1536,6 +1739,7 @@ function WorkflowBuilderEditor() {
       ?? (event.dataTransfer.getData(NODE_LIBRARY_DND_MIME) as Exclude<WorkflowNodeType, "trigger">);
     if (!droppedType) {
       setDropPreview(null);
+      setDropFeedback(null);
       return;
     }
     const nextPosition = dropPreview?.type === droppedType
@@ -1548,10 +1752,24 @@ function WorkflowBuilderEditor() {
           { gridSize: CANVAS_GRID_SIZE },
         );
     setDropPreview(null);
+    setDropFeedback(null);
     addNode(droppedType, nextPosition);
   };
 
+  const markIssueVisited = (issueKey: string | null) => {
+    if (!issueKey) return;
+    setVisitedIssueKeys((current) => current.includes(issueKey) ? current : [...current, issueKey]);
+  };
+
+  const syncActiveIssueToTarget = (targetKind: BuilderValidationIssueNavigationItem["targetKind"], targetKey: string) => {
+    const nextIssue = issueNavigationItems.find((item) => item.targetKind === targetKind && item.targetKey === targetKey) ?? null;
+    setActiveIssueKey(nextIssue?.key ?? null);
+  };
+
   const focusValidationIssue = (issue: FridayWorkflowBuilderValidationReport["issues"][number]) => {
+    const issueItem = issueNavigationItems.find((item) => item.issue === issue) ?? null;
+    setActiveIssueKey(issueItem?.key ?? null);
+    markIssueVisited(issueItem?.key ?? null);
     if (issue.stepId) {
       const node = nodes.find((candidate) => candidate.id === issue.stepId);
       if (node) {
@@ -1625,29 +1843,19 @@ function WorkflowBuilderEditor() {
       selectedEdgeIds: [],
       dirty: false,
     });
+    setActiveIssueKey(null);
   };
 
-  const jumpToNextIssue = () => {
-    if (issueSummaries.focusableIssues.length === 0) {
+  const navigateIssue = (direction: "next" | "previous") => {
+    if (issueNavigationItems.length === 0) {
       return;
     }
-    const currentSelection = selectedNodeIds[0]
-      ?? selectedEdge?.data?.edgeKey
-      ?? "";
-    const currentIndex = issueSummaries.focusableIssues.findIndex((issue) => (
-      issue.stepId ? issue.stepId === currentSelection
-        : issue.edgeRef
-          ? edgeKeyFor({
-              source: issue.edgeRef.from,
-              target: issue.edgeRef.to,
-              branch: issue.edgeRef.when,
-            }) === currentSelection
-          : false
-    ));
-    const nextIndex = currentIndex >= 0
-      ? (currentIndex + 1) % issueSummaries.focusableIssues.length
+    const nextIndex = activeIssueIndex >= 0
+      ? direction === "next"
+        ? (activeIssueIndex + 1) % issueNavigationItems.length
+        : (activeIssueIndex - 1 + issueNavigationItems.length) % issueNavigationItems.length
       : 0;
-    focusValidationIssue(issueSummaries.focusableIssues[nextIndex]!);
+    focusValidationIssue(issueNavigationItems[nextIndex]!.issue);
   };
 
   const removeSelection = () => {
@@ -1941,35 +2149,60 @@ function WorkflowBuilderEditor() {
                 value={paletteQuery}
                 onInput={(event) => setPaletteQuery(event.currentTarget.value)}
                 onChange={(event) => setPaletteQuery(event.target.value)}
+                onKeyDown={handlePaletteSearchKeyDown}
                 className="agent-input"
                 placeholder="Search by node or group"
               />
             </label>
-            {paletteGroups.length === 0 ? (
+            {visiblePaletteGroups.length === 0 ? (
               <p className="text-sm text-white/55">No node cards match this filter.</p>
-            ) : paletteGroups.map((group) => (
+            ) : visiblePaletteGroups.map((group) => (
               <div key={group.id} className="space-y-3">
                 <div className="flex items-center justify-between gap-3">
-                  <p className="text-xs font-semibold uppercase tracking-[0.18em] text-white/46">{group.label}</p>
+                  <button
+                    data-testid={`workflow-builder-palette-toggle-${group.id}`}
+                    type="button"
+                    onClick={() => togglePaletteGroup(group.id)}
+                    className="inline-flex items-center gap-2 text-left"
+                  >
+                    {group.collapsed ? <ChevronRight className="h-4 w-4 text-white/55" /> : <ChevronDown className="h-4 w-4 text-white/55" />}
+                    <p className="text-xs font-semibold uppercase tracking-[0.18em] text-white/46">{group.label}</p>
+                  </button>
                   <StatusPill>{group.entries.length}</StatusPill>
                 </div>
+                {group.visibleEntries.length === 0 ? (
+                  <p className="rounded-[18px] border border-white/[0.08] bg-white/[0.03] px-3 py-2 text-xs text-white/45">
+                    Group collapsed. Search still reveals matching nodes without changing this state.
+                  </p>
+                ) : (
                 <div className="grid gap-3 sm:grid-cols-2">
-                  {group.entries.map((entry) => (
+                  {group.visibleEntries.map((entry) => (
                     <button
                       key={entry.type}
+                      data-testid={`workflow-builder-palette-entry-${entry.type}`}
+                      data-keyboard-active={keyboardPaletteEntry?.type === entry.type ? "true" : "false"}
                       type="button"
                       disabled={!activeDraft || Boolean(readonlyReason)}
                       draggable={Boolean(activeDraft) && !readonlyReason}
                       onDragStart={(event) => handlePaletteDragStart(event, entry.type)}
                       onDragEnd={handlePaletteDragEnd}
+                      onMouseEnter={() => {
+                        const nextIndex = keyboardPaletteEntries.findIndex((candidate) => candidate.type === entry.type);
+                        setKeyboardPaletteIndex(nextIndex);
+                      }}
                       onClick={() => addNode(entry.type)}
-                      className="agent-selection-card text-left disabled:cursor-not-allowed disabled:opacity-60"
+                      className={cn(
+                        "agent-selection-card text-left disabled:cursor-not-allowed disabled:opacity-60",
+                        keyboardPaletteEntry?.type === entry.type && "ring-2 ring-sky-300/28",
+                        draggingPaletteType === entry.type && "border-emerald-300/40 bg-emerald-300/[0.06]",
+                      )}
                     >
                       <p className="font-medium text-white">{entry.label}</p>
                       <p className="mt-1 text-xs text-white/55">{entry.description}</p>
                     </button>
                   ))}
                 </div>
+                )}
               </div>
             ))}
           </div>
@@ -2056,12 +2289,25 @@ function WorkflowBuilderEditor() {
                 <span className="text-xs uppercase tracking-[0.16em] text-white/46">
                   Compiled {formatTimestamp(compileReport.validation.generatedAt)}
                 </span>
+                {issueNavigationItems.length > 0 ? (
+                  <span data-testid="workflow-builder-issue-nav-status" className="text-xs uppercase tracking-[0.16em] text-sky-100/78">
+                    {activeIssueIndex >= 0 ? `Issue ${activeIssueIndex + 1} of ${issueNavigationItems.length}` : `${issueNavigationItems.length} issues`}
+                  </span>
+                ) : null}
+                {activeIssueItem ? (
+                  <span data-testid="workflow-builder-active-issue-message" className="max-w-[320px] truncate text-xs text-white/62">
+                    {activeIssueItem.issue.message}
+                  </span>
+                ) : null}
                 <div className="ml-auto flex flex-wrap gap-3">
-                  <ActionButton tone="secondary" disabled={issueSummaries.focusableIssues.length === 0} onClick={jumpToNextIssue}>
-                    Jump to next issue
+                  <ActionButton data-testid="workflow-builder-issue-prev" tone="secondary" disabled={issueNavigationItems.length === 0} onClick={() => navigateIssue("previous")}>
+                    Previous issue
                   </ActionButton>
-                  <ActionButton tone="secondary" disabled={selectedNodeIds.length === 0 && selectedEdgeIds.length === 0} onClick={clearSelection}>
-                    Clear selection
+                  <ActionButton data-testid="workflow-builder-issue-next" tone="secondary" disabled={issueNavigationItems.length === 0} onClick={() => navigateIssue("next")}>
+                    Next issue
+                  </ActionButton>
+                  <ActionButton data-testid="workflow-builder-issue-clear" tone="secondary" disabled={!activeIssueKey && selectedNodeIds.length === 0 && selectedEdgeIds.length === 0} onClick={clearSelection}>
+                    Clear focus
                   </ActionButton>
                 </div>
               </div>
@@ -2069,16 +2315,33 @@ function WorkflowBuilderEditor() {
             <div
               data-testid="workflow-builder-canvas"
               className={cn(
-                "h-[700px] overflow-hidden rounded-[28px] border bg-slate-950/88 transition",
-                isCanvasDropActive ? "border-emerald-300/45 ring-1 ring-emerald-300/25" : "border-white/[0.08]",
+                "relative h-[700px] overflow-hidden rounded-[28px] border bg-slate-950/88 transition",
+                dropFeedback?.tone === "valid"
+                  ? "border-emerald-300/45 ring-1 ring-emerald-300/25"
+                  : dropFeedback?.tone === "invalid"
+                    ? "border-rose-300/45 ring-1 ring-rose-300/25"
+                    : "border-white/[0.08]",
               )}
               onDragOver={handleCanvasDragOver}
               onDrop={handleCanvasDrop}
               onDragLeave={() => {
-                setIsCanvasDropActive(false);
                 setDropPreview(null);
+                setDropFeedback(null);
               }}
             >
+              {dropFeedback ? (
+                <div
+                  data-testid="workflow-builder-drop-feedback"
+                  className={cn(
+                    "pointer-events-none absolute left-4 top-4 z-20 rounded-[18px] border px-3 py-2 text-xs font-medium shadow-[0_18px_45px_rgba(0,0,0,0.24)]",
+                    dropFeedback.tone === "valid"
+                      ? "border-emerald-300/25 bg-emerald-300/[0.10] text-emerald-100"
+                      : "border-rose-300/25 bg-rose-300/[0.10] text-rose-100",
+                  )}
+                >
+                  {dropFeedback.message}
+                </div>
+              ) : null}
               <WorkflowCanvasInteractionContext.Provider value={canvasInteractionValue}>
                 <ReactFlow
                   nodes={canvasNodes}
@@ -2095,6 +2358,9 @@ function WorkflowBuilderEditor() {
                       selectedNodeIds: [],
                       dirty: false,
                     });
+                    if (edge.data?.edgeKey) {
+                      syncActiveIssueToTarget("edge", edge.data.edgeKey);
+                    }
                   }}
                   onNodeClick={(_, node) => {
                     updateGraph({
@@ -2102,6 +2368,7 @@ function WorkflowBuilderEditor() {
                       selectedEdgeIds: [],
                       dirty: false,
                     });
+                    syncActiveIssueToTarget("node", node.id);
                   }}
                   onSelectionChange={({ nodes: selectedNodes, edges: selectedCanvasEdges }) => {
                     setSelectedNodeIds(selectedNodes.map((node) => node.id));
@@ -2123,6 +2390,7 @@ function WorkflowBuilderEditor() {
                     nodeColor={(node) => {
                       const uiState = (node.data as FlowNodeData | undefined)?.__ui;
                       if (uiState?.preview) return "rgba(52,211,153,0.56)";
+                      if (uiState?.activeIssue) return "rgba(125,211,252,0.88)";
                       if (node.selected) return "rgba(110,231,183,0.85)";
                       if (uiState?.issueTone === "danger") return "rgba(251,113,133,0.8)";
                       if (uiState?.issueTone === "warning") return "rgba(251,191,36,0.78)";
@@ -2446,6 +2714,7 @@ function WorkflowBuilderEditor() {
           {compileReport ? (
             <CompileReportPanel
               report={compileReport}
+              activeIssueKey={activeIssueKey}
               onFocusIssue={focusValidationIssue}
             />
           ) : null}
@@ -2543,11 +2812,13 @@ function CompileReportPanel(props: {
     nodes: number;
     edges: number;
   };
+  activeIssueKey: string | null;
   onFocusIssue: (issue: FridayWorkflowBuilderValidationReport["issues"][number]) => void;
 }) {
   const nodeIssues = props.report.validation.issues.filter((issue) => Boolean(issue.stepId));
   const edgeIssues = props.report.validation.issues.filter((issue) => Boolean(issue.edgeRef));
   const globalIssues = props.report.validation.issues.filter((issue) => !issue.stepId && !issue.edgeRef);
+  const navigationItems = buildValidationIssueNavigationItems(props.report.validation);
 
   const renderIssueList = (
     issues: FridayWorkflowBuilderValidationReport["issues"],
@@ -2558,14 +2829,19 @@ function CompileReportPanel(props: {
     ) : issues.map((issue) => {
       const location = describeIssueLocation(issue);
       const focusable = Boolean(issue.stepId || issue.edgeRef);
+      const activeItem = navigationItems.find((item) => item.issue === issue) ?? null;
+      const isActive = activeItem?.key === props.activeIssueKey;
       return (
         <button
+          data-testid={activeItem ? `workflow-builder-compile-item-${activeItem.key}` : undefined}
+          data-active-issue={isActive ? "true" : "false"}
           key={`${issue.stage}:${issue.code}:${issue.message}:${location ?? "global"}`}
           type="button"
           disabled={!focusable}
           onClick={() => props.onFocusIssue(issue)}
           className={cn(
             "w-full rounded-[18px] border px-3 py-3 text-left transition",
+            isActive && "ring-2 ring-sky-300/30",
             issue.severity === "error"
               ? "border-rose-300/20 bg-rose-300/[0.06] hover:bg-rose-300/[0.1]"
               : "border-amber-300/18 bg-amber-300/[0.05] hover:bg-amber-300/[0.08]",

--- a/ui/src/routes/workflow-builder-page.tsx
+++ b/ui/src/routes/workflow-builder-page.tsx
@@ -1,6 +1,6 @@
 import "@xyflow/react/dist/style.css";
 
-import { useEffect, useMemo, useRef, useState, type DragEvent as ReactDragEvent } from "react";
+import { createContext, useContext, useEffect, useMemo, useRef, useState, type DragEvent as ReactDragEvent } from "react";
 import {
   Background,
   BaseEdge,
@@ -65,7 +65,10 @@ import { cn } from "@/lib/utils/cn";
 import { createDefaultRawGraph, createDefaultSpec, createDefaultVisual, getDefaultNodeConfig, getNextNodeName } from "@/lib/workflows/defaults";
 import {
   describeWorkflowEdgeLabel,
+  BUILDER_NODE_PALETTE,
+  buildBuilderPaletteGroups,
   edgeKeyFor,
+  snapFlowPositionToGrid,
   summarizeWorkflowValidationIssues,
   type BuilderValidationIssueSummary,
   type BuilderValidationTone,
@@ -82,12 +85,17 @@ type FlowNodeData = FridayWorkflowNodeDefinition & {
   __ui?: {
     issueTone?: BuilderValidationTone;
     issueCount?: number;
+    primaryIssueMessage?: string;
+    remainingCount?: number;
+    preview?: boolean;
   };
 };
 
 type FlowEdgeData = NonNullable<FridayWorkflowEditorEdge["data"]> & {
   issueTone?: BuilderValidationTone;
   issueCount?: number;
+  primaryIssueMessage?: string;
+  remainingCount?: number;
 };
 
 type FlowNode = Node<FlowNodeData, "workflow_node">;
@@ -100,6 +108,18 @@ interface EditorSnapshot {
   selectedNodeIds: string[];
   selectedEdgeIds: string[];
 }
+
+interface DropPreviewState {
+  type: Exclude<WorkflowNodeType, "trigger">;
+  position: { x: number; y: number };
+}
+
+interface WorkflowCanvasInteractionContextValue {
+  focusNodeIssue: (nodeId: string) => void;
+  focusEdgeIssue: (edgeKey: string) => void;
+}
+
+const WorkflowCanvasInteractionContext = createContext<WorkflowCanvasInteractionContextValue | null>(null);
 
 const TASK_PROFILE_OPTIONS: Array<{
   id: AgentTaskProfileId;
@@ -130,13 +150,7 @@ const EDGE_BRANCH_OPTIONS: Array<{ value: "" | FridayWorkflowSpecEdgeWhen; label
 
 const NODE_LIBRARY_DND_MIME = "application/friday-workflow-node-type";
 
-const NODE_LIBRARY_ENTRIES: Array<{ type: WorkflowNodeType; label: string }> = [
-  { type: "action", label: "Action" },
-  { type: "ai", label: "AI / Tool" },
-  { type: "condition", label: "Condition" },
-  { type: "data", label: "Transform" },
-  { type: "approval", label: "Approval" },
-];
+const CANVAS_GRID_SIZE = 28;
 
 function parseFocus(value: string | null): FridayWorkflowBuilderFocus {
   if (value === "draft" || value === "publish") {
@@ -411,26 +425,42 @@ function issueToneToEdgeStroke(tone?: BuilderValidationTone, selected?: boolean)
 
 function WorkflowCanvasNode(props: NodeProps<FlowNode>) {
   const { data: node, selected } = props;
+  const interaction = useContext(WorkflowCanvasInteractionContext);
   const isCondition = node.type === "condition";
   const isTrigger = node.type === "trigger";
+  const isPreview = node.__ui?.preview === true;
   const integrationMode = typeof node.rawArgs?.integrationMode === "string" ? node.rawArgs.integrationMode : null;
   const taskProfile = typeof node.rawArgs?.taskProfile === "string" ? node.rawArgs.taskProfile : null;
   const issueTone = node.__ui?.issueTone;
   const issueCount = node.__ui?.issueCount ?? 0;
+  const primaryIssueMessage = node.__ui?.primaryIssueMessage;
+  const remainingCount = node.__ui?.remainingCount ?? 0;
+  const canFocusIssue = Boolean(!isPreview && issueCount > 0 && interaction);
 
   return (
     <div
-      className={`min-w-[220px] rounded-[24px] border px-4 py-3 shadow-[0_18px_45px_rgba(0,0,0,0.28)] ${
-        selected
+      className={`relative min-w-[220px] rounded-[24px] border px-4 py-3 shadow-[0_18px_45px_rgba(0,0,0,0.28)] ${
+        isPreview
+          ? "border-dashed border-emerald-300/42 bg-emerald-300/[0.08]"
+          : selected
           ? "border-emerald-300/55 bg-slate-950/96 ring-1 ring-emerald-300/30"
           : issueTone === "danger"
             ? "border-rose-300/50 bg-slate-950/96 ring-1 ring-rose-300/20"
             : issueTone === "warning"
               ? "border-amber-300/45 bg-slate-950/94 ring-1 ring-amber-300/18"
-          : "border-white/[0.12] bg-slate-950/92"
+              : "border-white/[0.12] bg-slate-950/92"
       }`}
+      style={isPreview ? { opacity: 0.9 } : undefined}
     >
-      {!isTrigger ? <Handle type="target" id="in" position={Position.Left} className="!h-3 !w-3 !border-none !bg-emerald-200" /> : null}
+      {issueTone && !isPreview ? (
+        <div
+          className={cn(
+            "absolute inset-y-3 left-1.5 w-1 rounded-full",
+            issueTone === "danger" ? "bg-rose-300/85" : "bg-amber-300/82",
+          )}
+        />
+      ) : null}
+      {!isTrigger && !isPreview ? <Handle type="target" id="in" position={Position.Left} className="!h-3 !w-3 !border-none !bg-emerald-200" /> : null}
       <div className="space-y-2">
         <div className="flex items-center justify-between gap-3">
           <div>
@@ -438,11 +468,26 @@ function WorkflowCanvasNode(props: NodeProps<FlowNode>) {
             <p className="mt-1 text-sm font-semibold text-white">{node.name}</p>
           </div>
           <div className="flex flex-col items-end gap-2">
-            <StatusPill tone={selected ? "success" : "neutral"}>{node.type}</StatusPill>
+            <StatusPill tone={isPreview || selected ? "success" : "neutral"}>{isPreview ? "preview" : node.type}</StatusPill>
             {issueCount > 0 ? (
-              <StatusPill tone={issueToneToStatusTone(issueTone)}>
-                {issueCount} issue{issueCount > 1 ? "s" : ""}
-              </StatusPill>
+              canFocusIssue ? (
+                <button
+                  type="button"
+                  onClick={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    interaction?.focusNodeIssue(node.id);
+                  }}
+                >
+                  <StatusPill tone={issueToneToStatusTone(issueTone)}>
+                    {issueCount} issue{issueCount > 1 ? "s" : ""}
+                  </StatusPill>
+                </button>
+              ) : (
+                <StatusPill tone={issueToneToStatusTone(issueTone)}>
+                  {issueCount} issue{issueCount > 1 ? "s" : ""}
+                </StatusPill>
+              )
             ) : null}
           </div>
         </div>
@@ -451,8 +496,41 @@ function WorkflowCanvasNode(props: NodeProps<FlowNode>) {
           {taskProfile ? <StatusPill>{taskProfile}</StatusPill> : null}
           {integrationMode ? <StatusPill>{integrationMode}</StatusPill> : null}
         </div>
+        {primaryIssueMessage ? (
+          canFocusIssue ? (
+            <button
+              type="button"
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                interaction?.focusNodeIssue(node.id);
+              }}
+              className={cn(
+                "flex w-full items-center justify-between gap-3 rounded-[18px] border px-3 py-2 text-left text-xs transition",
+                issueTone === "danger"
+                  ? "border-rose-300/25 bg-rose-300/[0.08] text-rose-100 hover:bg-rose-300/[0.12]"
+                  : "border-amber-300/22 bg-amber-300/[0.08] text-amber-100 hover:bg-amber-300/[0.12]",
+              )}
+            >
+              <span className="min-w-0 flex-1 truncate">{primaryIssueMessage}</span>
+              {remainingCount > 0 ? <span className="shrink-0 text-[10px] uppercase tracking-[0.16em] text-white/72">+{remainingCount} more</span> : null}
+            </button>
+          ) : (
+            <div
+              className={cn(
+                "rounded-[18px] border px-3 py-2 text-xs",
+                issueTone === "danger"
+                  ? "border-rose-300/22 bg-rose-300/[0.08] text-rose-100"
+                  : "border-amber-300/20 bg-amber-300/[0.08] text-amber-100",
+              )}
+            >
+              <span>{primaryIssueMessage}</span>
+              {remainingCount > 0 ? <span className="ml-2 text-[10px] uppercase tracking-[0.16em] text-white/72">+{remainingCount} more</span> : null}
+            </div>
+          )
+        ) : null}
       </div>
-      {isTrigger ? (
+      {isPreview ? null : isTrigger ? (
         <Handle type="source" id="any" position={Position.Right} className="!h-3 !w-3 !border-none !bg-amber-200" />
       ) : isCondition ? (
         <>
@@ -472,6 +550,7 @@ function WorkflowCanvasNode(props: NodeProps<FlowNode>) {
 
 function WorkflowCanvasEdge(props: EdgeProps<FlowEdge>) {
   const { sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition, data, selected, markerEnd } = props;
+  const interaction = useContext(WorkflowCanvasInteractionContext);
   const [path, labelX, labelY] = getBezierPath({
     sourceX,
     sourceY,
@@ -482,8 +561,11 @@ function WorkflowCanvasEdge(props: EdgeProps<FlowEdge>) {
   });
   const edgeStroke = issueToneToEdgeStroke(data?.issueTone, selected);
   const label = describeWorkflowEdgeLabel(data, {
-    includeFallback: selected || Boolean(data?.issueCount),
+    includeFallback: selected || Boolean(data?.issueCount) || Boolean(data?.primaryIssueMessage),
   });
+  const primaryIssueMessage = data?.primaryIssueMessage;
+  const remainingCount = data?.remainingCount ?? 0;
+  const canFocusIssue = Boolean(data?.edgeKey && primaryIssueMessage && interaction);
 
   return (
     <>
@@ -495,22 +577,40 @@ function WorkflowCanvasEdge(props: EdgeProps<FlowEdge>) {
           strokeWidth: selected ? 2.6 : data?.issueTone ? 2.2 : 1.6,
         }}
       />
-      {label ? (
+      {label || primaryIssueMessage ? (
         <EdgeLabelRenderer>
-          <div
+          <button
+            type="button"
+            disabled={!canFocusIssue}
+            onClick={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              if (data?.edgeKey) {
+                interaction?.focusEdgeIssue(data.edgeKey);
+              }
+            }}
             style={{
               transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
             }}
             className={cn(
-              "pointer-events-none absolute rounded-full border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-white shadow-[0_14px_28px_rgba(0,0,0,0.32)]",
+              "pointer-events-auto absolute min-w-[152px] rounded-[18px] border px-3 py-2 text-left text-[11px] font-semibold uppercase tracking-[0.16em] text-white shadow-[0_14px_28px_rgba(0,0,0,0.32)]",
               data?.issueTone === "danger" && "border-rose-300/45 bg-rose-400/12 text-rose-100",
               data?.issueTone === "warning" && "border-amber-300/40 bg-amber-400/12 text-amber-100",
               !data?.issueTone && "border-white/[0.14] bg-slate-950/92 text-white/74",
+              !canFocusIssue && "cursor-default",
             )}
           >
-            <span>{label}</span>
-            {data?.issueCount ? <span className="ml-2 text-[10px] tracking-[0.12em] text-white/75">{data.issueCount}</span> : null}
-          </div>
+            <div className="flex items-center justify-between gap-3">
+              <span>{label ?? "Always"}</span>
+              {data?.issueCount ? <span className="text-[10px] tracking-[0.12em] text-white/75">{data.issueCount}</span> : null}
+            </div>
+            {primaryIssueMessage ? (
+              <div className="mt-1.5 border-t border-white/10 pt-1.5 text-[10px] normal-case tracking-normal text-white/84">
+                <span>{primaryIssueMessage}</span>
+                {remainingCount > 0 ? <span className="ml-2 uppercase tracking-[0.16em] text-white/62">+{remainingCount}</span> : null}
+              </div>
+            ) : null}
+          </button>
         </EdgeLabelRenderer>
       ) : null}
     </>
@@ -552,12 +652,15 @@ function WorkflowBuilderEditor() {
   const [dirty, setDirty] = useState(false);
   const [readonlyReason, setReadonlyReason] = useState<string | null>(null);
   const [lockState, setLockState] = useState<FridayAcquireWorkflowLockResponse["lock"] | null>(null);
+  const [paletteQuery, setPaletteQuery] = useState("");
   const [compileReport, setCompileReport] = useState<{
     validation: FridayWorkflowBuilderValidationReport;
     nodes: number;
     edges: number;
   } | null>(null);
+  const [draggingPaletteType, setDraggingPaletteType] = useState<Exclude<WorkflowNodeType, "trigger"> | null>(null);
   const [isCanvasDropActive, setIsCanvasDropActive] = useState(false);
+  const [dropPreview, setDropPreview] = useState<DropPreviewState | null>(null);
   const [publishedVersionNumber, setPublishedVersionNumber] = useState<number | null>(null);
   const [localDraftOverride, setLocalDraftOverride] = useState<FridayWorkflowDraftEntity | null>(null);
   const historyRef = useRef<EditorSnapshot[]>([]);
@@ -646,45 +749,91 @@ function WorkflowBuilderEditor() {
     ) ?? null
     : null;
 
-  const canvasNodes = useMemo(() => (
-    nodes.map((node) => {
-      const summary = issueSummaries.nodeIssues.get(node.id);
-      return {
-        ...node,
-        data: summary
-          ? {
-              ...node.data,
-              __ui: {
-                issueTone: summary.tone,
-                issueCount: summary.count,
+  const paletteGroups = useMemo(() => buildBuilderPaletteGroups({ query: paletteQuery }), [paletteQuery]);
+  const compileIssueCounts = useMemo(() => {
+    const issues = compileReport?.validation.issues ?? [];
+    return {
+      errors: issues.filter((issue) => issue.severity === "error").length,
+      warnings: issues.filter((issue) => issue.severity === "warning").length,
+    };
+  }, [compileReport]);
+
+  const canvasNodes = useMemo(() => {
+      const nextNodes: FlowNode[] = nodes.map((node) => {
+        const summary = issueSummaries.nodeIssues.get(node.id);
+        return {
+          ...node,
+          data: summary
+            ? {
+                ...node.data,
+                __ui: {
+                  issueTone: summary.tone,
+                  issueCount: summary.count,
+                  primaryIssueMessage: summary.primaryIssueMessage,
+                  remainingCount: summary.remainingCount,
+                },
+              }
+            : {
+                ...node.data,
+                __ui: undefined,
               },
-            }
-          : {
-              ...node.data,
-              __ui: undefined,
+        };
+      });
+
+      if (dropPreview && activeDraft && !readonlyReason) {
+        const previewConfig = getDefaultNodeConfig(dropPreview.type);
+        const previewEntry = BUILDER_NODE_PALETTE.find((entry) => entry.type === dropPreview.type);
+        nextNodes.push({
+          id: `preview-${dropPreview.type}`,
+          type: "workflow_node",
+          position: dropPreview.position,
+          draggable: false,
+          selectable: false,
+          connectable: false,
+          focusable: false,
+          data: {
+            id: `preview-${dropPreview.type}`,
+            type: dropPreview.type,
+            name: `${previewEntry?.label ?? dropPreview.type} preview`,
+            config: previewConfig,
+            stepType: defaultStepTypeForNodeType(dropPreview.type),
+            stepRef:
+              "skillId" in previewConfig
+                ? previewConfig.skillId
+                : "toolId" in previewConfig
+                  ? previewConfig.toolId
+                  : undefined,
+            rawArgs: {},
+            __ui: {
+              preview: true,
             },
-      };
-    })
-  ), [nodes, issueSummaries.nodeIssues]);
+          },
+        });
+      }
+
+      return nextNodes;
+    }, [activeDraft, dropPreview, issueSummaries.nodeIssues, nodes, readonlyReason]);
 
   const canvasEdges = useMemo(() => (
     edges.map((edge) => {
-      const summary = issueSummaries.edgeIssues.get(
-        edge.data?.edgeKey
+      const edgeKey = edge.data?.edgeKey
           ?? edgeKeyFor({
             source: edge.source,
             target: edge.target,
             branch: edge.data?.branch,
-          }),
-      );
+          });
+      const summary = issueSummaries.edgeIssues.get(edgeKey);
       const stroke = issueToneToEdgeStroke(summary?.tone, edge.selected);
       return {
         ...edge,
         type: "workflow_edge",
         data: {
           ...(edge.data ?? {}),
+          edgeKey,
           issueTone: summary?.tone,
           issueCount: summary?.count,
+          primaryIssueMessage: summary?.primaryIssueMessage,
+          remainingCount: summary?.remainingCount,
         },
         markerEnd: { type: MarkerType.ArrowClosed, color: stroke },
         style: {
@@ -750,6 +899,8 @@ function WorkflowBuilderEditor() {
     if (!activeDraft) {
       return;
     }
+    const previouslyLoadedDraftId = loadedDraftKeyRef.current?.split(":")[0] ?? null;
+    const isSameDraftEntity = previouslyLoadedDraftId === activeDraft.draftId;
     const fingerprint = `${activeDraft.draftId}:${activeDraft.revision}`;
     if (loadedDraftKeyRef.current === fingerprint) {
       return;
@@ -768,8 +919,10 @@ function WorkflowBuilderEditor() {
     setJsonEditorText(JSON.stringify((nextNodes.find((node) => node.id === graph.selectedNodeId)?.data.rawArgs ?? {}), null, 2));
     setDirty(false);
     setReadonlyReason(null);
-    setCompileReport(null);
-    setPublishedVersionNumber(null);
+    if (!isSameDraftEntity) {
+      setCompileReport(null);
+      setPublishedVersionNumber(null);
+    }
     const snapshot = createSnapshot({
       nodes: nextNodes,
       edges: nextEdges,
@@ -1058,6 +1211,14 @@ function WorkflowBuilderEditor() {
     };
   }, [edges, nodes, selectedEdgeIds, selectedNodeIds, viewport]);
 
+  useEffect(() => {
+    if (!activeDraft || readonlyReason) {
+      setDraggingPaletteType(null);
+      setDropPreview(null);
+      setIsCanvasDropActive(false);
+    }
+  }, [activeDraft, readonlyReason]);
+
   const instantiateMutation = useMutation({
     mutationFn: async () => {
       const effectiveTitle = title.trim() || selectedStableTemplate?.label || selectedTemplate?.name || "Workflow draft";
@@ -1240,6 +1401,14 @@ function WorkflowBuilderEditor() {
   };
 
   const addNode = (type: WorkflowNodeType, position?: { x: number; y: number }) => {
+    if (!activeDraft) {
+      toast.error("Create or open a draft before adding nodes to the canvas.");
+      return;
+    }
+    if (readonlyReason) {
+      toast.error(readonlyReason);
+      return;
+    }
     const nodeId = `${type}-${Math.random().toString(36).slice(2, 8)}`;
     const existingNames = nodes.map((node) => node.data.name);
     const config = getDefaultNodeConfig(type);
@@ -1286,6 +1455,39 @@ function WorkflowBuilderEditor() {
     event.dataTransfer.setData(NODE_LIBRARY_DND_MIME, type);
     event.dataTransfer.setData("text/plain", type);
     event.dataTransfer.effectAllowed = "move";
+    setDraggingPaletteType(type as Exclude<WorkflowNodeType, "trigger">);
+    if (typeof document !== "undefined") {
+      const paletteEntry = BUILDER_NODE_PALETTE.find((entry) => entry.type === type);
+      const ghost = document.createElement("div");
+      ghost.style.position = "absolute";
+      ghost.style.top = "-9999px";
+      ghost.style.left = "-9999px";
+      ghost.style.padding = "10px 14px";
+      ghost.style.borderRadius = "18px";
+      ghost.style.border = "1px solid rgba(167, 243, 208, 0.45)";
+      ghost.style.background = "rgba(2, 6, 23, 0.95)";
+      ghost.style.color = "white";
+      ghost.style.fontSize = "12px";
+      ghost.style.fontWeight = "600";
+      ghost.style.letterSpacing = "0.08em";
+      ghost.style.textTransform = "uppercase";
+      ghost.style.boxShadow = "0 16px 40px rgba(0,0,0,0.3)";
+      ghost.innerHTML = `
+        <div style="opacity:0.58;font-size:10px;margin-bottom:4px;">${paletteEntry?.groupLabel ?? "Workflow node"}</div>
+        <div>${paletteEntry?.label ?? type}</div>
+      `;
+      document.body.appendChild(ghost);
+      event.dataTransfer.setDragImage(ghost, 24, 18);
+      window.setTimeout(() => {
+        ghost.remove();
+      }, 0);
+    }
+  };
+
+  const handlePaletteDragEnd = () => {
+    setDraggingPaletteType(null);
+    setDropPreview(null);
+    setIsCanvasDropActive(false);
   };
 
   const handleCanvasDragOver = (event: ReactDragEvent<HTMLDivElement>) => {
@@ -1293,8 +1495,26 @@ function WorkflowBuilderEditor() {
       return;
     }
     event.preventDefault();
-    setIsCanvasDropActive(Boolean(activeDraft) && !readonlyReason);
-    event.dataTransfer.dropEffect = activeDraft && !readonlyReason ? "move" : "none";
+    const dragType = draggingPaletteType
+      ?? (event.dataTransfer.getData(NODE_LIBRARY_DND_MIME) as Exclude<WorkflowNodeType, "trigger">);
+    const canDrop = Boolean(activeDraft) && !readonlyReason && dragType.length > 0;
+    setIsCanvasDropActive(canDrop);
+    event.dataTransfer.dropEffect = canDrop ? "move" : "none";
+    if (!canDrop) {
+      setDropPreview(null);
+      return;
+    }
+    const snappedPosition = snapFlowPositionToGrid(
+      reactFlow.screenToFlowPosition({
+        x: event.clientX,
+        y: event.clientY,
+      }),
+      { gridSize: CANVAS_GRID_SIZE },
+    );
+    setDropPreview({
+      type: dragType,
+      position: snappedPosition,
+    });
   };
 
   const handleCanvasDrop = (event: ReactDragEvent<HTMLDivElement>) => {
@@ -1303,6 +1523,7 @@ function WorkflowBuilderEditor() {
     }
     event.preventDefault();
     setIsCanvasDropActive(false);
+    setDraggingPaletteType(null);
     if (!activeDraft) {
       toast.error("Create or open a draft before dropping nodes onto the canvas.");
       return;
@@ -1311,17 +1532,23 @@ function WorkflowBuilderEditor() {
       toast.error(readonlyReason);
       return;
     }
-    const droppedType = event.dataTransfer.getData(NODE_LIBRARY_DND_MIME) as WorkflowNodeType;
+    const droppedType = draggingPaletteType
+      ?? (event.dataTransfer.getData(NODE_LIBRARY_DND_MIME) as Exclude<WorkflowNodeType, "trigger">);
     if (!droppedType) {
+      setDropPreview(null);
       return;
     }
-    addNode(
-      droppedType,
-      reactFlow.screenToFlowPosition({
-        x: event.clientX,
-        y: event.clientY,
-      }),
-    );
+    const nextPosition = dropPreview?.type === droppedType
+      ? dropPreview.position
+      : snapFlowPositionToGrid(
+          reactFlow.screenToFlowPosition({
+            x: event.clientX,
+            y: event.clientY,
+          }),
+          { gridSize: CANVAS_GRID_SIZE },
+        );
+    setDropPreview(null);
+    addNode(droppedType, nextPosition);
   };
 
   const focusValidationIssue = (issue: FridayWorkflowBuilderValidationReport["issues"][number]) => {
@@ -1376,6 +1603,51 @@ function WorkflowBuilderEditor() {
         }
       }
     }
+  };
+
+  const focusNodeIssue = (nodeId: string) => {
+    const issue = issueSummaries.nodeIssues.get(nodeId)?.issues[0];
+    if (issue) {
+      focusValidationIssue(issue);
+    }
+  };
+
+  const focusEdgeIssue = (key: string) => {
+    const issue = issueSummaries.edgeIssues.get(key)?.issues[0];
+    if (issue) {
+      focusValidationIssue(issue);
+    }
+  };
+
+  const clearSelection = () => {
+    updateGraph({
+      selectedNodeIds: [],
+      selectedEdgeIds: [],
+      dirty: false,
+    });
+  };
+
+  const jumpToNextIssue = () => {
+    if (issueSummaries.focusableIssues.length === 0) {
+      return;
+    }
+    const currentSelection = selectedNodeIds[0]
+      ?? selectedEdge?.data?.edgeKey
+      ?? "";
+    const currentIndex = issueSummaries.focusableIssues.findIndex((issue) => (
+      issue.stepId ? issue.stepId === currentSelection
+        : issue.edgeRef
+          ? edgeKeyFor({
+              source: issue.edgeRef.from,
+              target: issue.edgeRef.to,
+              branch: issue.edgeRef.when,
+            }) === currentSelection
+          : false
+    ));
+    const nextIndex = currentIndex >= 0
+      ? (currentIndex + 1) % issueSummaries.focusableIssues.length
+      : 0;
+    focusValidationIssue(issueSummaries.focusableIssues[nextIndex]!);
   };
 
   const removeSelection = () => {
@@ -1539,6 +1811,11 @@ function WorkflowBuilderEditor() {
     updateGraph({ nodes: nextNodes, pushHistory: true });
   };
 
+  const canvasInteractionValue: WorkflowCanvasInteractionContextValue = {
+    focusNodeIssue,
+    focusEdgeIssue,
+  };
+
   return (
     <div className="grid gap-4 xl:grid-cols-[0.82fr_1.18fr_0.94fr]">
       <div className="space-y-4">
@@ -1656,19 +1933,44 @@ function WorkflowBuilderEditor() {
         </ShellCard>
 
         <ShellCard eyebrow="Node Library" title="Add workflow nodes">
-          <div className="grid gap-3 sm:grid-cols-2">
-            {NODE_LIBRARY_ENTRIES.map((entry) => (
-              <button
-                key={entry.type}
-                type="button"
-                draggable={Boolean(activeDraft) && !readonlyReason}
-                onDragStart={(event) => handlePaletteDragStart(event, entry.type)}
-                onClick={() => addNode(entry.type)}
-                className="agent-selection-card text-left"
-              >
-                <p className="font-medium text-white">{entry.label}</p>
-                <p className="mt-1 text-xs text-white/55">Drag onto the canvas or click to add a new {entry.label.toLowerCase()} node.</p>
-              </button>
+          <div data-testid="workflow-builder-node-library" className="space-y-4">
+            <label className="grid gap-2">
+              <span className="text-xs font-semibold uppercase tracking-[0.18em] text-white/48">Search nodes</span>
+              <input
+                data-testid="workflow-builder-node-search"
+                value={paletteQuery}
+                onInput={(event) => setPaletteQuery(event.currentTarget.value)}
+                onChange={(event) => setPaletteQuery(event.target.value)}
+                className="agent-input"
+                placeholder="Search by node or group"
+              />
+            </label>
+            {paletteGroups.length === 0 ? (
+              <p className="text-sm text-white/55">No node cards match this filter.</p>
+            ) : paletteGroups.map((group) => (
+              <div key={group.id} className="space-y-3">
+                <div className="flex items-center justify-between gap-3">
+                  <p className="text-xs font-semibold uppercase tracking-[0.18em] text-white/46">{group.label}</p>
+                  <StatusPill>{group.entries.length}</StatusPill>
+                </div>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  {group.entries.map((entry) => (
+                    <button
+                      key={entry.type}
+                      type="button"
+                      disabled={!activeDraft || Boolean(readonlyReason)}
+                      draggable={Boolean(activeDraft) && !readonlyReason}
+                      onDragStart={(event) => handlePaletteDragStart(event, entry.type)}
+                      onDragEnd={handlePaletteDragEnd}
+                      onClick={() => addNode(entry.type)}
+                      className="agent-selection-card text-left disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      <p className="font-medium text-white">{entry.label}</p>
+                      <p className="mt-1 text-xs text-white/55">{entry.description}</p>
+                    </button>
+                  ))}
+                </div>
+              </div>
             ))}
           </div>
         </ShellCard>
@@ -1744,67 +2046,94 @@ function WorkflowBuilderEditor() {
                 <span>Autosave: {formatTimestamp(lastAutosaveAtRef.current ?? activeDraft.autosave.lastSavedAt)}</span>
               </div>
             </div>
+            {compileReport ? (
+              <div
+                data-testid="workflow-builder-compile-summary"
+                className="flex flex-wrap items-center gap-3 rounded-[22px] border border-white/[0.08] bg-slate-950/72 px-4 py-3 text-sm text-white/72"
+              >
+                <StatusPill tone={compileIssueCounts.errors > 0 ? "danger" : "success"}>{compileIssueCounts.errors} errors</StatusPill>
+                <StatusPill tone={compileIssueCounts.warnings > 0 ? "warning" : "neutral"}>{compileIssueCounts.warnings} warnings</StatusPill>
+                <span className="text-xs uppercase tracking-[0.16em] text-white/46">
+                  Compiled {formatTimestamp(compileReport.validation.generatedAt)}
+                </span>
+                <div className="ml-auto flex flex-wrap gap-3">
+                  <ActionButton tone="secondary" disabled={issueSummaries.focusableIssues.length === 0} onClick={jumpToNextIssue}>
+                    Jump to next issue
+                  </ActionButton>
+                  <ActionButton tone="secondary" disabled={selectedNodeIds.length === 0 && selectedEdgeIds.length === 0} onClick={clearSelection}>
+                    Clear selection
+                  </ActionButton>
+                </div>
+              </div>
+            ) : null}
             <div
+              data-testid="workflow-builder-canvas"
               className={cn(
                 "h-[700px] overflow-hidden rounded-[28px] border bg-slate-950/88 transition",
                 isCanvasDropActive ? "border-emerald-300/45 ring-1 ring-emerald-300/25" : "border-white/[0.08]",
               )}
               onDragOver={handleCanvasDragOver}
               onDrop={handleCanvasDrop}
-              onDragLeave={() => setIsCanvasDropActive(false)}
+              onDragLeave={() => {
+                setIsCanvasDropActive(false);
+                setDropPreview(null);
+              }}
             >
-              <ReactFlow
-                nodes={canvasNodes}
-                edges={canvasEdges}
-                nodeTypes={WORKFLOW_NODE_TYPES}
-                edgeTypes={WORKFLOW_EDGE_TYPES}
-                onNodesChange={handleNodesChange}
-                onEdgesChange={handleEdgesChange}
-                onConnect={handleConnect}
-                onNodeDragStop={() => pushHistory()}
-                onEdgeClick={(_, edge) => {
-                  updateGraph({
-                    selectedEdgeIds: [edge.id],
-                    selectedNodeIds: [],
-                    dirty: false,
-                  });
-                }}
-                onNodeClick={(_, node) => {
-                  updateGraph({
-                    selectedNodeIds: [node.id],
-                    selectedEdgeIds: [],
-                    dirty: false,
-                  });
-                }}
-                onSelectionChange={({ nodes: selectedNodes, edges: selectedCanvasEdges }) => {
-                  setSelectedNodeIds(selectedNodes.map((node) => node.id));
-                  setSelectedEdgeIds(selectedCanvasEdges.map((edge) => edge.id));
-                }}
-                deleteKeyCode={null}
-                fitView
-                proOptions={{ hideAttribution: true }}
-                viewport={viewport}
-                onViewportChange={setViewport}
-                minZoom={0.25}
-                maxZoom={1.8}
-                className="!bg-transparent"
-              >
-                <MiniMap
-                  pannable
-                  zoomable
-                  nodeStrokeWidth={3}
-                  nodeColor={(node) => {
-                    const issueTone = (node.data as FlowNodeData | undefined)?.__ui?.issueTone;
-                    if (node.selected) return "rgba(110,231,183,0.85)";
-                    if (issueTone === "danger") return "rgba(251,113,133,0.8)";
-                    if (issueTone === "warning") return "rgba(251,191,36,0.78)";
-                    return "rgba(148,163,184,0.45)";
+              <WorkflowCanvasInteractionContext.Provider value={canvasInteractionValue}>
+                <ReactFlow
+                  nodes={canvasNodes}
+                  edges={canvasEdges}
+                  nodeTypes={WORKFLOW_NODE_TYPES}
+                  edgeTypes={WORKFLOW_EDGE_TYPES}
+                  onNodesChange={handleNodesChange}
+                  onEdgesChange={handleEdgesChange}
+                  onConnect={handleConnect}
+                  onNodeDragStop={() => pushHistory()}
+                  onEdgeClick={(_, edge) => {
+                    updateGraph({
+                      selectedEdgeIds: [edge.id],
+                      selectedNodeIds: [],
+                      dirty: false,
+                    });
                   }}
-                  className="!rounded-2xl !border !border-white/[0.08] !bg-slate-950/85"
-                />
-                <Controls className="!rounded-2xl !border !border-white/[0.08] !bg-slate-950/85" />
-                <Background color="rgba(255,255,255,0.08)" gap={28} />
-              </ReactFlow>
+                  onNodeClick={(_, node) => {
+                    updateGraph({
+                      selectedNodeIds: [node.id],
+                      selectedEdgeIds: [],
+                      dirty: false,
+                    });
+                  }}
+                  onSelectionChange={({ nodes: selectedNodes, edges: selectedCanvasEdges }) => {
+                    setSelectedNodeIds(selectedNodes.map((node) => node.id));
+                    setSelectedEdgeIds(selectedCanvasEdges.map((edge) => edge.id));
+                  }}
+                  deleteKeyCode={null}
+                  fitView
+                  proOptions={{ hideAttribution: true }}
+                  viewport={viewport}
+                  onViewportChange={setViewport}
+                  minZoom={0.25}
+                  maxZoom={1.8}
+                  className="!bg-transparent"
+                >
+                  <MiniMap
+                    pannable
+                    zoomable
+                    nodeStrokeWidth={3}
+                    nodeColor={(node) => {
+                      const uiState = (node.data as FlowNodeData | undefined)?.__ui;
+                      if (uiState?.preview) return "rgba(52,211,153,0.56)";
+                      if (node.selected) return "rgba(110,231,183,0.85)";
+                      if (uiState?.issueTone === "danger") return "rgba(251,113,133,0.8)";
+                      if (uiState?.issueTone === "warning") return "rgba(251,191,36,0.78)";
+                      return "rgba(148,163,184,0.45)";
+                    }}
+                    className="!rounded-2xl !border !border-white/[0.08] !bg-slate-950/85"
+                  />
+                  <Controls className="!rounded-2xl !border !border-white/[0.08] !bg-slate-950/85" />
+                  <Background color="rgba(255,255,255,0.08)" gap={CANVAS_GRID_SIZE} />
+                </ReactFlow>
+              </WorkflowCanvasInteractionContext.Provider>
             </div>
           </div>
         ) : (
@@ -2216,6 +2545,46 @@ function CompileReportPanel(props: {
   };
   onFocusIssue: (issue: FridayWorkflowBuilderValidationReport["issues"][number]) => void;
 }) {
+  const nodeIssues = props.report.validation.issues.filter((issue) => Boolean(issue.stepId));
+  const edgeIssues = props.report.validation.issues.filter((issue) => Boolean(issue.edgeRef));
+  const globalIssues = props.report.validation.issues.filter((issue) => !issue.stepId && !issue.edgeRef);
+
+  const renderIssueList = (
+    issues: FridayWorkflowBuilderValidationReport["issues"],
+    emptyLabel: string,
+  ) => (
+    issues.length === 0 ? (
+      <p className="text-xs text-white/55">{emptyLabel}</p>
+    ) : issues.map((issue) => {
+      const location = describeIssueLocation(issue);
+      const focusable = Boolean(issue.stepId || issue.edgeRef);
+      return (
+        <button
+          key={`${issue.stage}:${issue.code}:${issue.message}:${location ?? "global"}`}
+          type="button"
+          disabled={!focusable}
+          onClick={() => props.onFocusIssue(issue)}
+          className={cn(
+            "w-full rounded-[18px] border px-3 py-3 text-left transition",
+            issue.severity === "error"
+              ? "border-rose-300/20 bg-rose-300/[0.06] hover:bg-rose-300/[0.1]"
+              : "border-amber-300/18 bg-amber-300/[0.05] hover:bg-amber-300/[0.08]",
+            !focusable && "cursor-default opacity-80 hover:bg-inherit",
+          )}
+        >
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-white/52">{issue.stage}</p>
+            <StatusPill tone={issue.severity === "error" ? "danger" : "warning"}>{issue.severity}</StatusPill>
+          </div>
+          <p className="mt-2 text-sm text-white">{issue.message}</p>
+          {location ? (
+            <p className="mt-2 text-xs text-white/55">{location} · click to focus</p>
+          ) : null}
+        </button>
+      );
+    })
+  );
+
   return (
     <div className="mt-4 agent-subcard p-4">
       <div className="flex items-center justify-between gap-3">
@@ -2227,37 +2596,28 @@ function CompileReportPanel(props: {
       <p className="mt-2 text-sm text-white/66">
         Nodes: {props.report.nodes} · Edges: {props.report.edges}
       </p>
-      <div className="mt-3 space-y-2">
-        {props.report.validation.issues.length === 0 ? (
-          <p className="text-xs text-white/55">No validation issues.</p>
-        ) : props.report.validation.issues.map((issue) => {
-          const location = describeIssueLocation(issue);
-          const focusable = Boolean(issue.stepId || issue.edgeRef);
-          return (
-            <button
-              key={`${issue.stage}:${issue.code}:${issue.message}:${location ?? "global"}`}
-              type="button"
-              disabled={!focusable}
-              onClick={() => props.onFocusIssue(issue)}
-              className={cn(
-                "w-full rounded-[18px] border px-3 py-3 text-left transition",
-                issue.severity === "error"
-                  ? "border-rose-300/20 bg-rose-300/[0.06] hover:bg-rose-300/[0.1]"
-                  : "border-amber-300/18 bg-amber-300/[0.05] hover:bg-amber-300/[0.08]",
-                !focusable && "cursor-default opacity-80 hover:bg-inherit",
-              )}
-            >
-              <div className="flex items-center justify-between gap-3">
-                <p className="text-xs font-semibold uppercase tracking-[0.16em] text-white/52">{issue.stage}</p>
-                <StatusPill tone={issue.severity === "error" ? "danger" : "warning"}>{issue.severity}</StatusPill>
-              </div>
-              <p className="mt-2 text-sm text-white">{issue.message}</p>
-              {location ? (
-                <p className="mt-2 text-xs text-white/55">{location} · click to focus</p>
-              ) : null}
-            </button>
-          );
-        })}
+      <div className="mt-4 space-y-4">
+        <div className="space-y-2">
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-white/46">Node issues</p>
+            <StatusPill>{nodeIssues.length}</StatusPill>
+          </div>
+          <div className="space-y-2">{renderIssueList(nodeIssues, "No node-specific issues.")}</div>
+        </div>
+        <div className="space-y-2">
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-white/46">Edge issues</p>
+            <StatusPill>{edgeIssues.length}</StatusPill>
+          </div>
+          <div className="space-y-2">{renderIssueList(edgeIssues, "No edge-specific issues.")}</div>
+        </div>
+        <div className="space-y-2">
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-white/46">Global issues</p>
+            <StatusPill>{globalIssues.length}</StatusPill>
+          </div>
+          <div className="space-y-2">{renderIssueList(globalIssues, "No global validation issues.")}</div>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- group the workflow node palette by domain, add local search, and support drag/drop preview states on the canvas
- project compile diagnostics directly onto nodes and edges, with jump-to-issue and grouped compile report sections
- add page-level workflow builder UI coverage and fix the regression where saving the same draft revision cleared compile feedback

## Validation
- npm run typecheck
- npx vitest run test/unit/ui/workflow-builder-canvas.test.ts test/unit/ui/workflow-editor-adapters.test.ts test/unit/ui/workflow-builder-page.test.ts test/unit/ui/skill-generator-page.test.ts test/unit/api/http/routes/friday-workflow-builder-routes.test.ts test/unit/workflows/friday-stable-workflow-templates.test.ts
- npm run build:ui
