### PR TITLE
test(api-runtime): fix workflow generator route registration assertion

### DIFF
--- a/test/unit/api/runtime/friday-api-runtime-workflow-generator-registration.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-workflow-generator-registration.test.ts
@@ -73,11 +73,20 @@ describe("API Runtime — Workflow Generator Registration", () => {
     });
 
     const allRoutes = runtime.routes.getRoutes();
-    const generatorRoutes = allRoutes.filter((r) =>
-      r.operationId.startsWith("workflows.generator."),
-    );
+    const generatorRouteIds = allRoutes
+      .filter((r) => r.operationId.startsWith("workflows.generator."))
+      .map((r) => r.operationId)
+      .sort();
 
-    expect(generatorRoutes.length).toBe(6);
+    expect(generatorRouteIds).toEqual([
+      "workflows.generator.sessions.approve",
+      "workflows.generator.sessions.cancel",
+      "workflows.generator.sessions.create",
+      "workflows.generator.sessions.evidence.get",
+      "workflows.generator.sessions.generate",
+      "workflows.generator.sessions.get",
+      "workflows.generator.sessions.messages.create",
+    ]);
   });
 
   it("does not register generator routes when workflowGenerator is omitted", () => {


### PR DESCRIPTION
## Summary
- update the workflow generator registration test to assert the exact operation ids instead of a stale route count
- keep the runtime route surface unchanged, including the workflow evidence route
- leave unrelated runtime-health work on its own branch

## Testing
- npx vitest run test/unit/api/runtime/friday-api-runtime-workflow-generator-registration.test.ts
- npx vitest run test/unit/api/http/routes/friday-workflow-generator-routes.test.ts
- npm run -s lint
- npm run -s typecheck
- FRIDAY_E2E_CORE=1 npm test
- npm run test:e2e:ui