### PR TITLE
feat(uix): add click-first guided flow system with goal-oriented home…

### DIFF
--- a/packages/friday-operator-client/src/system-types.ts
+++ b/packages/friday-operator-client/src/system-types.ts
@@ -408,18 +408,32 @@ export interface FridayActionTemplateSummary {
   }>;
 }
 
+export interface FridayGuidedWizardStepChoice {
+  value: string;
+  label: string;
+  description: string;
+  outcome: string;
+  risk?: "low" | "medium" | "high";
+  recommended?: boolean;
+  reason?: string;
+}
+
+export interface FridayGuidedWizardStep {
+  id: string;
+  title: string;
+  prompt: string;
+  inputKey: string;
+  kind?: "input" | "choice" | "investigation" | "confirmation";
+  choices?: FridayGuidedWizardStepChoice[];
+}
+
 export interface FridayGuidedWizardState {
   wizardId: string;
   contextId: string;
   title: string;
-  status: "awaiting_input" | "ready" | "completed";
+  status: "awaiting_input" | "investigating" | "ready" | "completed" | "failed";
   currentStepId: string;
-  steps: Array<{
-    id: string;
-    title: string;
-    prompt: string;
-    inputKey: string;
-  }>;
+  steps: FridayGuidedWizardStep[];
   collectedValues: Record<string, unknown>;
   nextActionLabel?: string;
   objective?: string;
@@ -427,6 +441,18 @@ export interface FridayGuidedWizardState {
   unknowns?: string[];
   successTest?: string;
   fallbackPath?: string;
+}
+
+export type FridayUserProfileType = "beginner" | "developer" | "creator" | "business";
+
+export interface FridayUserProfileResponse {
+  profileType: FridayUserProfileType | null;
+  onboardedAt: string | null;
+}
+
+export interface FridayInvestigateResponse {
+  runId: string;
+  wizardId: string;
 }
 
 export type FridayCommunicationMbti =

--- a/src/api/http/routes/friday-uix-routes.ts
+++ b/src/api/http/routes/friday-uix-routes.ts
@@ -3,11 +3,14 @@ import type { FridayUixSurfaceService } from "../../../uix/services/friday-uix-s
 import type { FridayRouteDefinition } from "../../model/friday-api-common.types.js";
 import type {
   FridayBeginnerIntentResolution,
+  FridayInvestigateResponse,
   FridayUixDiagnosticsResponse,
   FridayUixIssuesResponse,
   FridayUixTemplateExecutionResponse,
   FridayUixTemplatesResponse,
   FridayUixWizardResponse,
+  FridayUserProfileResponse,
+  FridayUserProfileType,
 } from "../../model/friday-api-uix-surface.types.js";
 import type {
   FridayDeleteUserPreferenceResponse,
@@ -225,6 +228,78 @@ export function createFridayUixRoutes(
             : undefined;
         return {
           items: deps.service.listIssues({ userId, limit: Number.isFinite(limit) ? limit : undefined }),
+        };
+      },
+    },
+    {
+      operationId: "uix.user.profile.get",
+      method: "GET",
+      path: "/v1/uix/user-profile",
+      auth: { public: false, anyOfScopes: ["agent.run"] },
+      async handler(ctx): Promise<FridayUserProfileResponse> {
+        const userId = requireUserId(ctx.principal);
+        const prefs = deps.service.listPreferences({ userId, category: "uix" });
+        const profilePref = prefs.items.find((p) => p.key === "user.profile_type");
+        const onboardedPref = prefs.items.find((p) => p.key === "user.onboarded_at");
+        return {
+          profileType: (profilePref?.value as FridayUserProfileType | undefined) ?? null,
+          onboardedAt: (onboardedPref?.value as string | undefined) ?? null,
+        };
+      },
+    },
+    {
+      operationId: "uix.user.profile.update",
+      method: "PUT",
+      path: "/v1/uix/user-profile",
+      auth: { public: false, anyOfScopes: ["agent.run"] },
+      async handler(ctx): Promise<FridayUserProfileResponse> {
+        const userId = requireUserId(ctx.principal);
+        const body = (ctx.body && typeof ctx.body === "object" && !Array.isArray(ctx.body))
+          ? ctx.body as Record<string, unknown>
+          : {};
+        const profileType = typeof body.profileType === "string" ? body.profileType : undefined;
+        const onboardedAt = typeof body.onboardedAt === "string" ? body.onboardedAt : undefined;
+        const preferences: Array<{ category: string; key: string; value: unknown }> = [];
+        if (profileType) {
+          preferences.push({ category: "uix", key: "user.profile_type", value: profileType });
+        }
+        if (onboardedAt) {
+          preferences.push({ category: "uix", key: "user.onboarded_at", value: onboardedAt });
+        }
+        if (preferences.length > 0) {
+          deps.service.updatePreferences({
+            userId,
+            request: { preferences } as never,
+          });
+        }
+        return {
+          profileType: (profileType as FridayUserProfileType | undefined) ?? null,
+          onboardedAt: onboardedAt ?? null,
+        };
+      },
+    },
+    {
+      operationId: "uix.investigate",
+      method: "POST",
+      path: "/v1/uix/investigate",
+      auth: { public: false, anyOfScopes: ["agent.run"] },
+      async handler(ctx): Promise<FridayInvestigateResponse> {
+        const userId = requireUserId(ctx.principal);
+        const body = (ctx.body && typeof ctx.body === "object" && !Array.isArray(ctx.body))
+          ? ctx.body as Record<string, unknown>
+          : {};
+        const goalCategoryId = typeof body.goalCategoryId === "string" ? body.goalCategoryId.trim() : "";
+        if (!goalCategoryId) {
+          throw new FridayDomainError("VALIDATION_ERROR", "goalCategoryId is required", { httpStatus: 400 });
+        }
+        const wizardResponse = deps.service.startWizard({
+          wizardId: goalCategoryId,
+          userId,
+          assistantSessionKey: readAssistantSessionKey(ctx.body),
+        });
+        return {
+          runId: wizardResponse.wizard.contextId,
+          wizardId: goalCategoryId,
         };
       },
     },

--- a/src/api/model/friday-api-uix-surface.types.ts
+++ b/src/api/model/friday-api-uix-surface.types.ts
@@ -44,18 +44,32 @@ export interface FridayActionTemplateSummary {
   }>;
 }
 
+export interface FridayGuidedWizardStepChoice {
+  value: string;
+  label: string;
+  description: string;
+  outcome: string;
+  risk?: "low" | "medium" | "high";
+  recommended?: boolean;
+  reason?: string;
+}
+
+export interface FridayGuidedWizardStep {
+  id: string;
+  title: string;
+  prompt: string;
+  inputKey: string;
+  kind?: "input" | "choice" | "investigation" | "confirmation";
+  choices?: FridayGuidedWizardStepChoice[];
+}
+
 export interface FridayGuidedWizardState {
   wizardId: string;
   contextId: string;
   title: string;
-  status: "awaiting_input" | "ready" | "completed";
+  status: "awaiting_input" | "investigating" | "ready" | "completed" | "failed";
   currentStepId: string;
-  steps: Array<{
-    id: string;
-    title: string;
-    prompt: string;
-    inputKey: string;
-  }>;
+  steps: FridayGuidedWizardStep[];
   collectedValues: Record<string, unknown>;
   nextActionLabel?: string;
   objective?: string;
@@ -63,6 +77,24 @@ export interface FridayGuidedWizardState {
   unknowns?: string[];
   successTest?: string;
   fallbackPath?: string;
+}
+
+export type FridayUserProfileType = "beginner" | "developer" | "creator" | "business";
+
+export interface FridayUserProfileResponse {
+  profileType: FridayUserProfileType | null;
+  onboardedAt: string | null;
+}
+
+export interface FridayInvestigateRequest {
+  goalCategoryId: string;
+  context?: Record<string, unknown>;
+  assistantSessionKey?: string;
+}
+
+export interface FridayInvestigateResponse {
+  runId: string;
+  wizardId: string;
 }
 
 export interface FridayUixTemplatesResponse {

--- a/src/cli/friday-cli-run-loop.ts
+++ b/src/cli/friday-cli-run-loop.ts
@@ -5,6 +5,7 @@
  * an HTTP server and handling graceful shutdown via SIGINT/SIGTERM.
  */
 
+import { exec } from "node:child_process";
 import { resolve } from "node:path";
 import type { FridayHub } from "#hub";
 import { createFridayHttpServer } from "../api/http/friday-http-server.js";
@@ -51,7 +52,20 @@ export function runFridayCliLoop(deps: FridayCliRunLoopDeps): Promise<void> {
     httpServer
       .listen()
       .then(() => {
-        console.log(`🚀 Friday API server listening on http://${listenHost}:${port}`);
+        const url = `http://${listenHost === "0.0.0.0" ? "localhost" : listenHost}:${String(port)}`;
+        console.log(`🚀 Friday API server listening on ${url}`);
+
+        // Auto-open browser for local mode (not when binding to all interfaces for remote access).
+        if (listenHost === "127.0.0.1" || listenHost === "localhost") {
+          const openCmd = process.platform === "darwin"
+            ? `open "${url}"`
+            : process.platform === "win32"
+              ? `start "" "${url}"`
+              : `xdg-open "${url}"`;
+          exec(openCmd, () => {
+            // Best-effort — ignore errors (e.g., headless server, no display).
+          });
+        }
       })
       .catch((err: unknown) => {
         console.error("❌ Failed to start HTTP server:", err);

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -366,9 +366,10 @@ export function resolveFridayHubConfig(
   const isProduction = env.NODE_ENV === "production";
   const tokenSecretExplicit = tokenSecretResult.source === "config" || tokenSecretResult.source === "env";
   const allowPasswordlessLocalLogin = !tokenSecretExplicit && !isProduction;
-  const allowLocalBypassLogin = ["1", "true", "yes", "on"].includes(
-    (env.FRIDAY_ALLOW_LOCAL_BYPASS_LOGIN ?? "").trim().toLowerCase(),
-  );
+  const localBypassExplicit = (env.FRIDAY_ALLOW_LOCAL_BYPASS_LOGIN ?? "").trim().toLowerCase();
+  const allowLocalBypassLogin = localBypassExplicit
+    ? ["1", "true", "yes", "on"].includes(localBypassExplicit)
+    : allowPasswordlessLocalLogin;
 
   const serverVersion = input.serverVersion ?? FRIDAY_HUB_DEFAULT_SERVER_VERSION;
 
@@ -500,9 +501,10 @@ export async function createFridayHub(
   const isProduction = process.env.NODE_ENV === "production";
   const tokenSecretExplicit = tokenSecretResult.source === "config" || tokenSecretResult.source === "env";
   const allowPasswordlessLocalLogin = !tokenSecretExplicit && !isProduction;
-  const allowLocalBypassLogin = ["1", "true", "yes", "on"].includes(
-    (process.env.FRIDAY_ALLOW_LOCAL_BYPASS_LOGIN ?? "").trim().toLowerCase(),
-  );
+  const localBypassExplicit2 = (process.env.FRIDAY_ALLOW_LOCAL_BYPASS_LOGIN ?? "").trim().toLowerCase();
+  const allowLocalBypassLogin = localBypassExplicit2
+    ? ["1", "true", "yes", "on"].includes(localBypassExplicit2)
+    : allowPasswordlessLocalLogin;
   const pipelineRuntimeConfig = resolveFridayPipelineRuntimeConfig(process.env);
   const capabilityGates = resolveFridayCapabilityGates(process.env);
   const crossChannelIdentityEnabled = process.env.FRIDAY_CROSS_CHANNEL_IDENTITY_ENABLED === "true";

--- a/src/uix/model/friday-uix.types.ts
+++ b/src/uix/model/friday-uix.types.ts
@@ -453,7 +453,8 @@ export type FridayUserPreferenceCategory =
   | "formatting"
   | "disclosure"
   | "provider"
-  | "communication";
+  | "communication"
+  | "uix";
 
 /**
  * A single user preference entry.

--- a/src/uix/services/friday-uix-surface-service.ts
+++ b/src/uix/services/friday-uix-surface-service.ts
@@ -2019,7 +2019,22 @@ export function createFridayUixSurfaceService(
     },
 
     startWizard(input) {
-      if (input.wizardId !== "guided-assistant") {
+      const goalWizardDefs: Record<string, { title: string; goalPrompt: string }> = {
+        "guided-assistant": { title: "Guided Assistant", goalPrompt: "Tell Friday what you want to do in one sentence." },
+        "build-new": { title: "Build Something New", goalPrompt: "Describe what you want to build. Friday will plan and guide you." },
+        "fix-broken": { title: "Fix What's Broken", goalPrompt: "Describe the problem. Friday will diagnose and suggest fixes." },
+        "ship-fast": { title: "Ship & Release", goalPrompt: "What are you shipping? Friday will run QA, checks, and docs." },
+        "understand-system": { title: "Understand Your System", goalPrompt: "What do you want to understand? Friday will investigate." },
+        "automate-work": { title: "Automate Repetitive Work", goalPrompt: "What task do you want automated? Friday will build the workflow." },
+        "content-social": { title: "Content & Social Media", goalPrompt: "What content or social media operation? Friday will plan the flow." },
+        "ecommerce": { title: "E-commerce & Cross-border", goalPrompt: "What e-commerce goal? Friday will research products, platforms, and data." },
+        "team-management": { title: "Manage a Team", goalPrompt: "What team operation? Friday will set up task tracking and workflows." },
+        "ai-saas-build": { title: "Build an AI App / SaaS", goalPrompt: "Describe the AI product idea. Friday will plan architecture and implementation." },
+        "invest-trade": { title: "Investment & Trading", goalPrompt: "What investment goal? Friday will research and automate your analysis." },
+      };
+
+      const wizardDef = goalWizardDefs[input.wizardId];
+      if (!wizardDef) {
         throw new FridayDomainError("UIX_GUIDED_WORKFLOW_NOT_FOUND", "Wizard not found", {
           httpStatus: 404,
         });
@@ -2033,14 +2048,14 @@ export function createFridayUixSurfaceService(
         wizardId: input.wizardId,
         contextId: deps.idGenerator(),
         assistantSessionKey: input.assistantSessionKey,
-        title: "Guided Assistant",
+        title: wizardDef.title,
         status: "awaiting_input",
         currentStepId: "goal",
         steps: [
           {
             id: "goal",
             title: "Describe your goal",
-            prompt: "Tell Friday what you want to do in one sentence.",
+            prompt: wizardDef.goalPrompt,
             inputKey: "goal",
           },
           {

--- a/test/contracts/api/__snapshots__/friday-api-route-contract.snapshot.test.ts.snap
+++ b/test/contracts/api/__snapshots__/friday-api-route-contract.snapshot.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures route count to detect accidental additions/removals 1`] = `243`;
+exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures route count to detect accidental additions/removals 1`] = `246`;
 
 exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route surface as a stable contract 1`] = `
 [
@@ -1673,6 +1673,42 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
     "authKind": "authenticated",
     "index": 137,
     "method": "GET",
+    "operationId": "uix.user.profile.get",
+    "path": "/v1/uix/user-profile",
+    "rateLimitPolicyId": null,
+    "roles": [],
+    "scopes": [
+      "agent.run",
+    ],
+  },
+  {
+    "authKind": "authenticated",
+    "index": 138,
+    "method": "PUT",
+    "operationId": "uix.user.profile.update",
+    "path": "/v1/uix/user-profile",
+    "rateLimitPolicyId": null,
+    "roles": [],
+    "scopes": [
+      "agent.run",
+    ],
+  },
+  {
+    "authKind": "authenticated",
+    "index": 139,
+    "method": "POST",
+    "operationId": "uix.investigate",
+    "path": "/v1/uix/investigate",
+    "rateLimitPolicyId": null,
+    "roles": [],
+    "scopes": [
+      "agent.run",
+    ],
+  },
+  {
+    "authKind": "authenticated",
+    "index": 140,
+    "method": "GET",
     "operationId": "skills.converters.list",
     "path": "/v1/skills/converters",
     "rateLimitPolicyId": null,
@@ -1683,7 +1719,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 138,
+    "index": 141,
     "method": "POST",
     "operationId": "skills.convert",
     "path": "/v1/skills/convert",
@@ -1695,7 +1731,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 139,
+    "index": 142,
     "method": "POST",
     "operationId": "skills.import",
     "path": "/v1/skills/import",
@@ -1707,7 +1743,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 140,
+    "index": 143,
     "method": "POST",
     "operationId": "skills.pack",
     "path": "/v1/skills/pack",
@@ -1719,7 +1755,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 141,
+    "index": 144,
     "method": "POST",
     "operationId": "workflows.generator.sessions.create",
     "path": "/v1/workflows/generator/sessions",
@@ -1731,7 +1767,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 142,
+    "index": 145,
     "method": "GET",
     "operationId": "workflows.generator.sessions.get",
     "path": "/v1/workflows/generator/sessions/:sessionId",
@@ -1743,7 +1779,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 143,
+    "index": 146,
     "method": "POST",
     "operationId": "workflows.generator.sessions.messages.create",
     "path": "/v1/workflows/generator/sessions/:sessionId/messages",
@@ -1755,7 +1791,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 144,
+    "index": 147,
     "method": "POST",
     "operationId": "workflows.generator.sessions.generate",
     "path": "/v1/workflows/generator/sessions/:sessionId/generate",
@@ -1767,7 +1803,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 145,
+    "index": 148,
     "method": "GET",
     "operationId": "workflows.generator.sessions.evidence.get",
     "path": "/v1/workflows/generator/sessions/:sessionId/evidence",
@@ -1779,7 +1815,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 146,
+    "index": 149,
     "method": "POST",
     "operationId": "workflows.generator.sessions.approve",
     "path": "/v1/workflows/generator/sessions/:sessionId/approve",
@@ -1791,7 +1827,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 147,
+    "index": 150,
     "method": "DELETE",
     "operationId": "workflows.generator.sessions.cancel",
     "path": "/v1/workflows/generator/sessions/:sessionId",
@@ -1803,7 +1839,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 148,
+    "index": 151,
     "method": "GET",
     "operationId": "rules.bundles.list",
     "path": "/v1/rules/bundles",
@@ -1815,7 +1851,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 149,
+    "index": 152,
     "method": "GET",
     "operationId": "rules.bundles.get",
     "path": "/v1/rules/bundles/:bundleId",
@@ -1827,7 +1863,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 150,
+    "index": 153,
     "method": "POST",
     "operationId": "rules.bundles.create",
     "path": "/v1/rules/bundles",
@@ -1839,7 +1875,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 151,
+    "index": 154,
     "method": "GET",
     "operationId": "rules.list",
     "path": "/v1/rules/bundles/:bundleId/rules",
@@ -1851,7 +1887,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 152,
+    "index": 155,
     "method": "POST",
     "operationId": "rules.evaluate",
     "path": "/v1/rules/evaluate",
@@ -1863,7 +1899,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 153,
+    "index": 156,
     "method": "POST",
     "operationId": "rules.simulate",
     "path": "/v1/rules/simulate",
@@ -1875,7 +1911,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 154,
+    "index": 157,
     "method": "GET",
     "operationId": "rules.versions.list",
     "path": "/v1/rules/:ruleId/versions",
@@ -1887,7 +1923,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 155,
+    "index": 158,
     "method": "GET",
     "operationId": "rules.audit.log.list",
     "path": "/v1/rules/audit-log",
@@ -1899,7 +1935,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 156,
+    "index": 159,
     "method": "POST",
     "operationId": "node.runner.execute",
     "path": "/v1/node-runner/execute",
@@ -1911,7 +1947,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 157,
+    "index": 160,
     "method": "GET",
     "operationId": "node.runner.executions.get",
     "path": "/v1/node-runner/executions/:executionId",
@@ -1923,7 +1959,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 158,
+    "index": 161,
     "method": "GET",
     "operationId": "node.runner.executions.list",
     "path": "/v1/node-runner/executions",
@@ -1935,7 +1971,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 159,
+    "index": 162,
     "method": "POST",
     "operationId": "acceptance.run",
     "path": "/v1/acceptance/run",
@@ -1947,7 +1983,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 160,
+    "index": 163,
     "method": "GET",
     "operationId": "acceptance.results.get",
     "path": "/v1/acceptance/results/:resultId",
@@ -1959,7 +1995,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 161,
+    "index": 164,
     "method": "GET",
     "operationId": "acceptance.results.list",
     "path": "/v1/acceptance/results",
@@ -1971,7 +2007,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 162,
+    "index": 165,
     "method": "GET",
     "operationId": "acceptance.runs.get",
     "path": "/v1/acceptance/runs/:runId",
@@ -1983,7 +2019,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 163,
+    "index": 166,
     "method": "GET",
     "operationId": "acceptance.tests.list",
     "path": "/v1/acceptance/tests",
@@ -1995,7 +2031,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 164,
+    "index": 167,
     "method": "GET",
     "operationId": "acceptance.tests.get",
     "path": "/v1/acceptance/tests/:testId",
@@ -2007,7 +2043,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 165,
+    "index": 168,
     "method": "POST",
     "operationId": "acceptance.tests.create",
     "path": "/v1/acceptance/tests",
@@ -2019,7 +2055,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 166,
+    "index": 169,
     "method": "PUT",
     "operationId": "acceptance.tests.update",
     "path": "/v1/acceptance/tests/:testId",
@@ -2031,7 +2067,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 167,
+    "index": 170,
     "method": "DELETE",
     "operationId": "acceptance.tests.delete",
     "path": "/v1/acceptance/tests/:testId",
@@ -2043,7 +2079,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 168,
+    "index": 171,
     "method": "GET",
     "operationId": "acceptance.tests.versions.list",
     "path": "/v1/acceptance/tests/:testId/versions",
@@ -2055,7 +2091,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 169,
+    "index": 172,
     "method": "GET",
     "operationId": "acceptance.artifacts.history",
     "path": "/v1/acceptance/artifacts/history",
@@ -2067,7 +2103,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 170,
+    "index": 173,
     "method": "GET",
     "operationId": "retry.policies.list",
     "path": "/v1/retry/policies",
@@ -2079,7 +2115,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 171,
+    "index": 174,
     "method": "GET",
     "operationId": "retry.policies.get",
     "path": "/v1/retry/policies/:policyId",
@@ -2091,7 +2127,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 172,
+    "index": 175,
     "method": "POST",
     "operationId": "retry.policies.create",
     "path": "/v1/retry/policies",
@@ -2103,7 +2139,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 173,
+    "index": 176,
     "method": "PUT",
     "operationId": "retry.policies.update",
     "path": "/v1/retry/policies/:policyId",
@@ -2115,7 +2151,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 174,
+    "index": 177,
     "method": "DELETE",
     "operationId": "retry.policies.delete",
     "path": "/v1/retry/policies/:policyId",
@@ -2127,7 +2163,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 175,
+    "index": 178,
     "method": "POST",
     "operationId": "retry.classify",
     "path": "/v1/retry/classify",
@@ -2139,7 +2175,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 176,
+    "index": 179,
     "method": "POST",
     "operationId": "retry.decide",
     "path": "/v1/retry/decide",
@@ -2151,7 +2187,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 177,
+    "index": 180,
     "method": "GET",
     "operationId": "retry.traces.list",
     "path": "/v1/retry/traces",
@@ -2163,7 +2199,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 178,
+    "index": 181,
     "method": "GET",
     "operationId": "retry.traces.get",
     "path": "/v1/retry/traces/:traceId",
@@ -2175,7 +2211,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 179,
+    "index": 182,
     "method": "GET",
     "operationId": "retry.costs.summary",
     "path": "/v1/retry/costs",
@@ -2187,7 +2223,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 180,
+    "index": 183,
     "method": "GET",
     "operationId": "retry.escalations.list",
     "path": "/v1/retry/escalations",
@@ -2199,7 +2235,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 181,
+    "index": 184,
     "method": "POST",
     "operationId": "retry.escalations.acknowledge",
     "path": "/v1/retry/escalations/:escalationId/acknowledge",
@@ -2211,7 +2247,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 182,
+    "index": 185,
     "method": "GET",
     "operationId": "retry.circuit.breakers.list",
     "path": "/v1/retry/circuit-breakers",
@@ -2223,7 +2259,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 183,
+    "index": 186,
     "method": "GET",
     "operationId": "playbook.list",
     "path": "/v1/playbooks",
@@ -2235,7 +2271,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 184,
+    "index": 187,
     "method": "GET",
     "operationId": "playbook.get",
     "path": "/v1/playbooks/:playbookId",
@@ -2247,7 +2283,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 185,
+    "index": 188,
     "method": "POST",
     "operationId": "playbook.select",
     "path": "/v1/playbooks/select",
@@ -2259,7 +2295,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 186,
+    "index": 189,
     "method": "GET",
     "operationId": "playbook.candidates.list",
     "path": "/v1/playbooks/candidates",
@@ -2271,7 +2307,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 187,
+    "index": 190,
     "method": "POST",
     "operationId": "playbook.candidates.promote",
     "path": "/v1/playbooks/candidates/:candidateId/promote",
@@ -2283,7 +2319,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 188,
+    "index": 191,
     "method": "POST",
     "operationId": "playbook.rollback",
     "path": "/v1/playbooks/:playbookId/rollback",
@@ -2295,7 +2331,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 189,
+    "index": 192,
     "method": "GET",
     "operationId": "playbook.scores",
     "path": "/v1/playbooks/:playbookId/scores",
@@ -2307,7 +2343,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 190,
+    "index": 193,
     "method": "POST",
     "operationId": "memory.store",
     "path": "/v1/memory/store",
@@ -2319,7 +2355,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 191,
+    "index": 194,
     "method": "POST",
     "operationId": "memory.search",
     "path": "/v1/memory/search",
@@ -2331,7 +2367,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 192,
+    "index": 195,
     "method": "GET",
     "operationId": "memory.get",
     "path": "/v1/memory/items/:id",
@@ -2343,7 +2379,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 193,
+    "index": 196,
     "method": "GET",
     "operationId": "memory.list",
     "path": "/v1/memory/items",
@@ -2355,7 +2391,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 194,
+    "index": 197,
     "method": "DELETE",
     "operationId": "memory.delete",
     "path": "/v1/memory/items/:id",
@@ -2367,7 +2403,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 195,
+    "index": 198,
     "method": "POST",
     "operationId": "memory.prune",
     "path": "/v1/memory/prune",
@@ -2379,7 +2415,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 196,
+    "index": 199,
     "method": "GET",
     "operationId": "sessions.usage.get",
     "path": "/v1/sessions/:sessionKey/usage",
@@ -2391,7 +2427,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 197,
+    "index": 200,
     "method": "GET",
     "operationId": "sessions.usage.list",
     "path": "/v1/sessions/usage",
@@ -2403,7 +2439,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 198,
+    "index": 201,
     "method": "GET",
     "operationId": "sessions.list",
     "path": "/v1/sessions",
@@ -2415,7 +2451,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 199,
+    "index": 202,
     "method": "POST",
     "operationId": "sessions.create",
     "path": "/v1/sessions",
@@ -2427,7 +2463,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 200,
+    "index": 203,
     "method": "GET",
     "operationId": "sessions.get",
     "path": "/v1/sessions/:sessionKey",
@@ -2439,7 +2475,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 201,
+    "index": 204,
     "method": "POST",
     "operationId": "sessions.archive",
     "path": "/v1/sessions/:sessionKey/archive",
@@ -2451,7 +2487,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 202,
+    "index": 205,
     "method": "POST",
     "operationId": "sessions.reset",
     "path": "/v1/sessions/:sessionKey/reset",
@@ -2463,7 +2499,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 203,
+    "index": 206,
     "method": "POST",
     "operationId": "sessions.prune",
     "path": "/v1/sessions/prune",
@@ -2475,7 +2511,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 204,
+    "index": 207,
     "method": "POST",
     "operationId": "sessions.sweep",
     "path": "/v1/sessions/sweep",
@@ -2487,7 +2523,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 205,
+    "index": 208,
     "method": "GET",
     "operationId": "sessions.messages.list",
     "path": "/v1/sessions/:sessionKey/messages",
@@ -2499,7 +2535,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 206,
+    "index": 209,
     "method": "POST",
     "operationId": "sessions.messages.create",
     "path": "/v1/sessions/:sessionKey/messages",
@@ -2511,7 +2547,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 207,
+    "index": 210,
     "method": "POST",
     "operationId": "sessions.run",
     "path": "/v1/sessions/:sessionKey/run",
@@ -2525,7 +2561,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 208,
+    "index": 211,
     "method": "GET",
     "operationId": "sessions.memory.namespace.get",
     "path": "/v1/sessions/:sessionKey/memory-namespace",
@@ -2537,7 +2573,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 209,
+    "index": 212,
     "method": "POST",
     "operationId": "sessions.forks.create",
     "path": "/v1/sessions/:sessionKey/fork",
@@ -2549,7 +2585,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 210,
+    "index": 213,
     "method": "GET",
     "operationId": "sessions.forks.list",
     "path": "/v1/sessions/:sessionKey/forks",
@@ -2561,7 +2597,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 211,
+    "index": 214,
     "method": "POST",
     "operationId": "sessions.forks.merge",
     "path": "/v1/sessions/:sessionKey/merge",
@@ -2573,7 +2609,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 212,
+    "index": 215,
     "method": "POST",
     "operationId": "sessions.memory.extract",
     "path": "/v1/sessions/:sessionKey/memory/extract",
@@ -2585,7 +2621,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 213,
+    "index": 216,
     "method": "POST",
     "operationId": "sessions.memory.remember",
     "path": "/v1/sessions/:sessionKey/memory/remember",
@@ -2597,7 +2633,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 214,
+    "index": 217,
     "method": "GET",
     "operationId": "sessions.memory.extraction.get",
     "path": "/v1/sessions/:sessionKey/memory/extraction",
@@ -2609,7 +2645,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 215,
+    "index": 218,
     "method": "POST",
     "operationId": "sessions.memory.extraction.retry",
     "path": "/v1/sessions/memory/extraction/retry",
@@ -2621,7 +2657,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 216,
+    "index": 219,
     "method": "GET",
     "operationId": "plugins.list",
     "path": "/v1/plugins",
@@ -2633,7 +2669,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 217,
+    "index": 220,
     "method": "GET",
     "operationId": "plugins.get",
     "path": "/v1/plugins/:id",
@@ -2645,7 +2681,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 218,
+    "index": 221,
     "method": "GET",
     "operationId": "plugins.versions.list",
     "path": "/v1/plugins/:id/versions",
@@ -2657,7 +2693,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 219,
+    "index": 222,
     "method": "POST",
     "operationId": "plugins.install",
     "path": "/v1/plugins/:id/install",
@@ -2669,7 +2705,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 220,
+    "index": 223,
     "method": "POST",
     "operationId": "plugins.enable",
     "path": "/v1/plugins/:id/enable",
@@ -2681,7 +2717,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 221,
+    "index": 224,
     "method": "POST",
     "operationId": "plugins.disable",
     "path": "/v1/plugins/:id/disable",
@@ -2693,7 +2729,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 222,
+    "index": 225,
     "method": "DELETE",
     "operationId": "plugins.uninstall",
     "path": "/v1/plugins/:id",
@@ -2705,7 +2741,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 223,
+    "index": 226,
     "method": "GET",
     "operationId": "marketplace.plugins.list",
     "path": "/v1/marketplace/plugins",
@@ -2717,7 +2753,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 224,
+    "index": 227,
     "method": "GET",
     "operationId": "marketplace.plugins.get",
     "path": "/v1/marketplace/plugins/:id",
@@ -2729,7 +2765,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 225,
+    "index": 228,
     "method": "GET",
     "operationId": "marketplace.plugins.versions.list",
     "path": "/v1/marketplace/plugins/:id/versions",
@@ -2741,7 +2777,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 226,
+    "index": 229,
     "method": "POST",
     "operationId": "marketplace.plugins.install",
     "path": "/v1/marketplace/plugins/:id/install",
@@ -2753,7 +2789,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 227,
+    "index": 230,
     "method": "POST",
     "operationId": "agent.runs.start",
     "path": "/v1/agent/runs",
@@ -2766,7 +2802,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 228,
+    "index": 231,
     "method": "GET",
     "operationId": "agent.runs.list",
     "path": "/v1/agent/runs",
@@ -2779,7 +2815,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 229,
+    "index": 232,
     "method": "GET",
     "operationId": "agent.runs.get",
     "path": "/v1/agent/runs/:runId",
@@ -2792,7 +2828,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 230,
+    "index": 233,
     "method": "POST",
     "operationId": "agent.runs.cancel",
     "path": "/v1/agent/runs/:runId/cancel",
@@ -2805,7 +2841,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 231,
+    "index": 234,
     "method": "POST",
     "operationId": "agent.runs.approve.plan",
     "path": "/v1/agent/runs/:runId/approve-plan",
@@ -2818,7 +2854,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 232,
+    "index": 235,
     "method": "POST",
     "operationId": "agent.runs.reject.plan",
     "path": "/v1/agent/runs/:runId/reject-plan",
@@ -2831,7 +2867,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 233,
+    "index": 236,
     "method": "GET",
     "operationId": "agent.runs.events",
     "path": "/v1/agent/runs/:runId/events",
@@ -2844,7 +2880,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 234,
+    "index": 237,
     "method": "POST",
     "operationId": "agent.automations.create",
     "path": "/v1/agent/automations",
@@ -2857,7 +2893,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 235,
+    "index": 238,
     "method": "GET",
     "operationId": "agent.automations.list",
     "path": "/v1/agent/automations",
@@ -2870,7 +2906,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 236,
+    "index": 239,
     "method": "GET",
     "operationId": "agent.automations.get",
     "path": "/v1/agent/automations/:automationId",
@@ -2883,7 +2919,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 237,
+    "index": 240,
     "method": "PATCH",
     "operationId": "agent.automations.update",
     "path": "/v1/agent/automations/:automationId",
@@ -2896,7 +2932,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 238,
+    "index": 241,
     "method": "DELETE",
     "operationId": "agent.automations.delete",
     "path": "/v1/agent/automations/:automationId",
@@ -2909,7 +2945,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 239,
+    "index": 242,
     "method": "POST",
     "operationId": "agent.automations.run",
     "path": "/v1/agent/automations/:automationId/run",
@@ -2922,7 +2958,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 240,
+    "index": 243,
     "method": "GET",
     "operationId": "agent.subagents.list",
     "path": "/v1/agent/subagents",
@@ -2934,7 +2970,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 241,
+    "index": 244,
     "method": "GET",
     "operationId": "agent.subagents.get",
     "path": "/v1/agent/subagents/:subagentId",
@@ -2946,7 +2982,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 242,
+    "index": 245,
     "method": "GET",
     "operationId": "agent.runs.subagents.list",
     "path": "/v1/agent/runs/:runId/subagents",

--- a/test/e2e/ui/_helpers/browser-env.ts
+++ b/test/e2e/ui/_helpers/browser-env.ts
@@ -103,11 +103,22 @@ export async function createFridayBrowserE2eEnv(input?: {
       };
     },
     async newPage() {
+      const onboardedProfile = {
+        profileType: "developer",
+        onboardedAt: new Date().toISOString(),
+      };
       const context = await browser.newContext({
         baseURL: hubEnv.baseUrl,
         timezoneId: "America/Los_Angeles",
       });
+
+      // Seed the user profile in localStorage so the onboarding gate is skipped
+      // even before the API call resolves in the browser.
+      await context.addInitScript({
+        content: `window.localStorage.setItem("friday.uix.user-profile", ${JSON.stringify(JSON.stringify(onboardedProfile))});`,
+      });
       const page = await context.newPage();
+
       return {
         context,
         page,

--- a/test/unit/api/http/routes/friday-uix-routes.test.ts
+++ b/test/unit/api/http/routes/friday-uix-routes.test.ts
@@ -176,7 +176,7 @@ function makeService(): FridayUixSurfaceService {
 describe("FridayUixRoutes", () => {
   it("creates assistant route definitions", () => {
     const routes = createFridayUixRoutes({ service: makeService() });
-    expect(routes).toHaveLength(11);
+    expect(routes).toHaveLength(14);
     expect(routes.map((route) => route.operationId)).toEqual([
       "uix.intents.resolve",
       "uix.templates.list",
@@ -189,6 +189,9 @@ describe("FridayUixRoutes", () => {
       "uix.wizards.start",
       "uix.wizards.continue",
       "uix.issues.list",
+      "uix.user.profile.get",
+      "uix.user.profile.update",
+      "uix.investigate",
     ]);
   });
 

--- a/test/unit/hub/friday-hub-bootstrap-env.test.ts
+++ b/test/unit/hub/friday-hub-bootstrap-env.test.ts
@@ -164,8 +164,18 @@ describe("resolveFridayHubConfig", () => {
     expect(resolved.allowLocalBypassLogin).toBe(true);
   });
 
-  it("keeps allowLocalBypassLogin disabled by default", () => {
+  it("inherits allowLocalBypassLogin from passwordless local in dev mode", () => {
     const resolved = resolveFridayHubConfig(makeConfig(), emptyEnv());
+    expect(resolved.allowLocalBypassLogin).toBe(true);
+  });
+
+  it("disables allowLocalBypassLogin in production", () => {
+    const resolved = resolveFridayHubConfig(makeConfig(), { NODE_ENV: "production" });
+    expect(resolved.allowLocalBypassLogin).toBe(false);
+  });
+
+  it("respects explicit FRIDAY_ALLOW_LOCAL_BYPASS_LOGIN=false even in dev mode", () => {
+    const resolved = resolveFridayHubConfig(makeConfig(), { FRIDAY_ALLOW_LOCAL_BYPASS_LOGIN: "false" });
     expect(resolved.allowLocalBypassLogin).toBe(false);
   });
 

--- a/test/unit/ui/agent-os-nav.test.ts
+++ b/test/unit/ui/agent-os-nav.test.ts
@@ -4,6 +4,7 @@ import { AGENT_OS_NAV_ITEMS, resolvePageTitle } from "../../../ui/src/lib/routes
 describe("agent os navigation", () => {
   it("keeps the shell focused on the assistant-first control flow", () => {
     expect(AGENT_OS_NAV_ITEMS.map((item) => item.path)).toEqual([
+      "/home",
       "/assistant",
       "/marketplace",
       "/workflows",
@@ -17,7 +18,9 @@ describe("agent os navigation", () => {
   });
 
   it("maps the assistant and deferred legacy routes to the correct titles", () => {
-    expect(resolvePageTitle("/")).toBe("Assistant");
+    expect(resolvePageTitle("/")).toBe("Home");
+    expect(resolvePageTitle("/home")).toBe("Home");
+    expect(resolvePageTitle("/flow/build-new")).toBe("Guided Flow");
     expect(resolvePageTitle("/assistant")).toBe("Assistant");
     expect(resolvePageTitle("/marketplace")).toBe("Marketplace");
     expect(resolvePageTitle("/skills")).toBe("Skills");

--- a/ui/src/components/guided/choice-card.tsx
+++ b/ui/src/components/guided/choice-card.tsx
@@ -1,0 +1,84 @@
+import { CheckCircle2 } from "lucide-react";
+import { cn } from "@/lib/utils/cn";
+
+export interface ChoiceCardProps {
+  title: string;
+  description: string;
+  outcome: string;
+  risk?: "low" | "medium" | "high";
+  recommended?: boolean;
+  selected?: boolean;
+  disabled?: boolean;
+  reason?: string;
+  onSelect: () => void;
+}
+
+const RISK_TONES = {
+  low: { label: "Low risk", border: "border-emerald-400/30", bg: "bg-emerald-400/10", text: "text-emerald-100" },
+  medium: { label: "Medium risk", border: "border-amber-300/30", bg: "bg-amber-300/10", text: "text-amber-100" },
+  high: { label: "High risk", border: "border-rose-400/30", bg: "bg-rose-400/10", text: "text-rose-100" },
+} as const;
+
+export function ChoiceCard(props: ChoiceCardProps) {
+  const { title, description, outcome, risk, recommended, selected, disabled, reason, onSelect } = props;
+  const riskStyle = risk ? RISK_TONES[risk] : null;
+
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onSelect}
+      className={cn(
+        "group relative flex flex-col gap-3 rounded-3xl border p-5 text-left transition-all",
+        "hover:scale-[1.01] active:scale-[0.99]",
+        "disabled:pointer-events-none disabled:opacity-40",
+        selected
+          ? "border-[var(--accent-strong)]/50 bg-[var(--accent-strong)]/10"
+          : recommended
+            ? "border-emerald-300/30 bg-emerald-300/[0.06] hover:border-emerald-300/50 hover:bg-emerald-300/10"
+            : "border-white/10 bg-white/[0.04] hover:border-white/[0.18] hover:bg-white/[0.07]",
+      )}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <p className="text-sm font-semibold text-white">{title}</p>
+            {recommended && (
+              <span className="rounded-full border border-emerald-400/30 bg-emerald-400/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-emerald-100">
+                Recommended
+              </span>
+            )}
+          </div>
+          <p className="mt-1.5 text-xs leading-5 text-white/60">{description}</p>
+        </div>
+        {selected && (
+          <CheckCircle2 className="h-5 w-5 shrink-0 text-[var(--accent-strong)]" />
+        )}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        {riskStyle && (
+          <span
+            className={cn(
+              "inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em]",
+              riskStyle.border,
+              riskStyle.bg,
+              riskStyle.text,
+            )}
+          >
+            {riskStyle.label}
+          </span>
+        )}
+        <span className="text-[11px] text-white/40">
+          <span className="font-medium text-white/50">Outcome:</span> {outcome}
+        </span>
+      </div>
+
+      {reason && recommended && (
+        <p className="rounded-2xl border border-emerald-400/10 bg-emerald-400/[0.04] px-3 py-2 text-[11px] leading-4 text-emerald-200/70">
+          {reason}
+        </p>
+      )}
+    </button>
+  );
+}

--- a/ui/src/components/guided/goal-card.tsx
+++ b/ui/src/components/guided/goal-card.tsx
@@ -1,0 +1,62 @@
+import type { LucideIcon } from "lucide-react";
+import { cn } from "@/lib/utils/cn";
+
+export interface GoalCardProps {
+  icon: LucideIcon;
+  title: string;
+  subtitle: string;
+  outcome: string;
+  recommended?: boolean;
+  active?: boolean;
+  disabled?: boolean;
+  onClick: () => void;
+}
+
+export function GoalCard(props: GoalCardProps) {
+  const { icon: Icon, title, subtitle, outcome, recommended, active, disabled, onClick } = props;
+
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+      className={cn(
+        "group relative flex flex-col gap-3 rounded-3xl border p-5 text-left transition-all",
+        "hover:scale-[1.02] active:scale-[0.98]",
+        "disabled:pointer-events-none disabled:opacity-40",
+        active
+          ? "border-[var(--accent-strong)]/40 bg-[var(--accent-strong)]/10"
+          : recommended
+            ? "border-emerald-300/30 bg-emerald-300/[0.06] hover:border-emerald-300/50 hover:bg-emerald-300/10"
+            : "border-white/10 bg-white/[0.04] hover:border-white/[0.18] hover:bg-white/[0.07]",
+      )}
+    >
+      {recommended && (
+        <span className="absolute -top-2.5 right-4 rounded-full border border-emerald-400/30 bg-emerald-400/10 px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-emerald-100">
+          Recommended
+        </span>
+      )}
+
+      <div className="flex items-start gap-3">
+        <div
+          className={cn(
+            "rounded-2xl border p-2.5",
+            recommended
+              ? "border-emerald-300/20 bg-emerald-300/10 text-emerald-200"
+              : "border-white/10 bg-white/[0.07] text-white/70 group-hover:text-white",
+          )}
+        >
+          <Icon className="h-5 w-5" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-semibold text-white">{title}</p>
+          <p className="mt-1 text-xs leading-5 text-white/50">{subtitle}</p>
+        </div>
+      </div>
+
+      <p className="text-[11px] leading-4 text-white/40">
+        <span className="font-medium text-white/50">Outcome:</span> {outcome}
+      </p>
+    </button>
+  );
+}

--- a/ui/src/components/guided/guided-flow-container.tsx
+++ b/ui/src/components/guided/guided-flow-container.tsx
@@ -1,0 +1,64 @@
+import type { ReactNode } from "react";
+import { ArrowLeft, X } from "lucide-react";
+import { cn } from "@/lib/utils/cn";
+import { StepProgress, type StepProgressStep } from "./step-progress";
+
+export interface GuidedFlowContainerProps {
+  title: string;
+  steps: StepProgressStep[];
+  currentStepIndex: number;
+  children: ReactNode;
+  onBack?: () => void;
+  onCancel?: () => void;
+  showBack?: boolean;
+  showCancel?: boolean;
+}
+
+export function GuidedFlowContainer(props: GuidedFlowContainerProps) {
+  const {
+    title,
+    steps,
+    currentStepIndex,
+    children,
+    onBack,
+    onCancel,
+    showBack = true,
+    showCancel = true,
+  } = props;
+
+  return (
+    <div className="mx-auto w-full max-w-2xl space-y-6">
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex items-center gap-3">
+          {showBack && onBack && currentStepIndex > 0 && (
+            <button
+              type="button"
+              onClick={onBack}
+              className="rounded-xl border border-white/10 bg-white/[0.04] p-2 text-white/60 transition hover:bg-white/[0.08] hover:text-white"
+            >
+              <ArrowLeft className="h-4 w-4" />
+            </button>
+          )}
+          <h2 className="text-lg font-semibold text-white">{title}</h2>
+        </div>
+        {showCancel && onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-xl border border-white/10 bg-white/[0.04] p-2 text-white/40 transition hover:bg-white/[0.08] hover:text-white"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+
+      {steps.length > 1 && (
+        <StepProgress steps={steps} orientation="horizontal" />
+      )}
+
+      <div className={cn("transition-opacity duration-200")}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/guided/investigation-panel.tsx
+++ b/ui/src/components/guided/investigation-panel.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useRef, useState } from "react";
+import { Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils/cn";
+
+export interface InvestigationLine {
+  id: string;
+  text: string;
+  type?: "info" | "discovery" | "analysis" | "conclusion";
+}
+
+export interface InvestigationPanelProps {
+  lines: InvestigationLine[];
+  isStreaming: boolean;
+  title?: string;
+}
+
+function lineColor(type: InvestigationLine["type"]) {
+  switch (type) {
+    case "discovery":
+      return "text-emerald-200/80";
+    case "analysis":
+      return "text-amber-200/70";
+    case "conclusion":
+      return "text-white";
+    default:
+      return "text-white/60";
+  }
+}
+
+export function InvestigationPanel(props: InvestigationPanelProps) {
+  const { lines, isStreaming, title } = props;
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const [visibleCount, setVisibleCount] = useState(0);
+
+  useEffect(() => {
+    if (lines.length > visibleCount) {
+      const timer = setTimeout(() => {
+        setVisibleCount((prev) => Math.min(prev + 1, lines.length));
+      }, 80);
+      return () => clearTimeout(timer);
+    }
+  }, [lines.length, visibleCount]);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [visibleCount]);
+
+  return (
+    <div className="rounded-3xl border border-white/10 bg-white/[0.02] p-5">
+      <div className="flex items-center gap-2.5">
+        {isStreaming && <Loader2 className="h-4 w-4 animate-spin text-[var(--accent-strong)]" />}
+        <p className="text-sm font-medium text-white/70">
+          {title ?? "Friday is investigating..."}
+        </p>
+      </div>
+
+      <div className="mt-4 space-y-1.5 font-mono text-[13px] leading-6">
+        {lines.slice(0, visibleCount).map((line, index) => (
+          <p
+            key={line.id}
+            className={cn(
+              "transition-opacity duration-300",
+              index === visibleCount - 1 ? "animate-in fade-in slide-in-from-bottom-1 duration-300" : "",
+              lineColor(line.type),
+            )}
+          >
+            {line.text}
+          </p>
+        ))}
+        {isStreaming && visibleCount >= lines.length && (
+          <span className="inline-block h-4 w-1.5 animate-pulse bg-white/40" />
+        )}
+        <div ref={bottomRef} />
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/guided/journey-tracker.tsx
+++ b/ui/src/components/guided/journey-tracker.tsx
@@ -1,0 +1,76 @@
+import { Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils/cn";
+import { StepProgress, type StepProgressStep } from "./step-progress";
+
+export type JourneyPhaseStatus =
+  | "pending"
+  | "investigating"
+  | "choosing"
+  | "planning"
+  | "executing"
+  | "completed"
+  | "error";
+
+export interface JourneyPhase {
+  id: string;
+  label: string;
+  status: JourneyPhaseStatus;
+  detail?: string;
+}
+
+export interface JourneyTrackerProps {
+  goalTitle: string;
+  phases: JourneyPhase[];
+  currentPhaseIndex: number;
+}
+
+function phaseToStepStatus(status: JourneyPhaseStatus): StepProgressStep["status"] {
+  switch (status) {
+    case "completed":
+      return "completed";
+    case "error":
+      return "error";
+    case "pending":
+      return "pending";
+    default:
+      return "active";
+  }
+}
+
+export function JourneyTracker(props: JourneyTrackerProps) {
+  const { goalTitle, phases, currentPhaseIndex } = props;
+  const currentPhase = phases[currentPhaseIndex];
+
+  const progressSteps: StepProgressStep[] = phases.map((phase) => ({
+    id: phase.id,
+    label: phase.label,
+    status: phaseToStepStatus(phase.status),
+    detail: phase.detail,
+  }));
+
+  return (
+    <div className="rounded-3xl border border-white/10 bg-white/[0.02] p-5">
+      <div className="flex items-center gap-2.5">
+        {currentPhase && currentPhase.status !== "completed" && currentPhase.status !== "error" && (
+          <Loader2 className="h-4 w-4 animate-spin text-[var(--accent-strong)]" />
+        )}
+        <div>
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/40">
+            Working on
+          </p>
+          <p className="text-sm font-medium text-white">{goalTitle}</p>
+        </div>
+      </div>
+
+      <div className="mt-4">
+        <StepProgress steps={progressSteps} orientation="horizontal" />
+      </div>
+
+      {currentPhase?.detail && (
+        <p className={cn("mt-3 text-xs", currentPhase.status === "error" ? "text-rose-200/70" : "text-white/50")}>
+          {currentPhase.detail}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/guided/one-click-action.tsx
+++ b/ui/src/components/guided/one-click-action.tsx
@@ -1,0 +1,69 @@
+import type { LucideIcon } from "lucide-react";
+import { Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils/cn";
+
+export interface OneClickActionProps {
+  icon: LucideIcon;
+  title: string;
+  summary: string;
+  tone?: "neutral" | "success" | "warning" | "danger";
+  ctaLabel: string;
+  isPending?: boolean;
+  disabled?: boolean;
+  onExecute: () => void;
+}
+
+function toneBorder(tone: OneClickActionProps["tone"]) {
+  switch (tone) {
+    case "success":
+      return "border-emerald-400/20 hover:border-emerald-400/40";
+    case "warning":
+      return "border-amber-300/20 hover:border-amber-300/40";
+    case "danger":
+      return "border-rose-400/20 hover:border-rose-400/40";
+    default:
+      return "border-white/10 hover:border-white/20";
+  }
+}
+
+function toneIcon(tone: OneClickActionProps["tone"]) {
+  switch (tone) {
+    case "success":
+      return "text-emerald-300";
+    case "warning":
+      return "text-amber-300";
+    case "danger":
+      return "text-rose-300";
+    default:
+      return "text-white/60";
+  }
+}
+
+export function OneClickAction(props: OneClickActionProps) {
+  const { icon: Icon, title, summary, tone = "neutral", ctaLabel, isPending, disabled, onExecute } = props;
+
+  return (
+    <button
+      type="button"
+      disabled={disabled || isPending}
+      onClick={onExecute}
+      className={cn(
+        "flex w-full items-start gap-3 rounded-2xl border bg-white/[0.02] p-4 text-left transition-all",
+        "hover:bg-white/[0.05] active:scale-[0.99]",
+        "disabled:pointer-events-none disabled:opacity-40",
+        toneBorder(tone),
+      )}
+    >
+      <div className={cn("mt-0.5 shrink-0", toneIcon(tone))}>
+        {isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Icon className="h-4 w-4" />}
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-medium text-white">{title}</p>
+        <p className="mt-0.5 text-xs text-white/50">{summary}</p>
+      </div>
+      <span className="shrink-0 rounded-xl border border-white/10 bg-white/[0.06] px-2.5 py-1 text-[11px] font-medium text-white/70">
+        {ctaLabel}
+      </span>
+    </button>
+  );
+}

--- a/ui/src/components/guided/plan-review-visual.tsx
+++ b/ui/src/components/guided/plan-review-visual.tsx
@@ -1,0 +1,171 @@
+import { ShieldAlert, CheckCircle2, AlertTriangle, XCircle } from "lucide-react";
+import { cn } from "@/lib/utils/cn";
+import { StepProgress, type StepProgressStep } from "./step-progress";
+import { ActionButton } from "@/components/core/primitives";
+
+export interface PlanStep {
+  id: string;
+  label: string;
+  detail?: string;
+  risk?: "low" | "medium" | "high";
+  status: "pending" | "active" | "completed" | "error";
+}
+
+export interface PlanReviewVisualProps {
+  title: string;
+  summary: string;
+  steps: PlanStep[];
+  assumptions?: string[];
+  unknowns?: string[];
+  riskLevel?: "low" | "medium" | "high";
+  isApproving?: boolean;
+  isRejecting?: boolean;
+  onApprove: () => void;
+  onReject: () => void;
+  clarificationQuestion?: string;
+  clarificationChoices?: Array<{ label: string; value: string }>;
+  onClarificationAnswer?: (value: string) => void;
+}
+
+function riskIcon(level?: "low" | "medium" | "high") {
+  switch (level) {
+    case "high":
+      return <XCircle className="h-4 w-4 text-rose-300" />;
+    case "medium":
+      return <AlertTriangle className="h-4 w-4 text-amber-300" />;
+    default:
+      return <CheckCircle2 className="h-4 w-4 text-emerald-300" />;
+  }
+}
+
+function riskTone(level?: "low" | "medium" | "high") {
+  switch (level) {
+    case "high":
+      return "border-rose-400/20 bg-rose-400/[0.06]";
+    case "medium":
+      return "border-amber-300/20 bg-amber-300/[0.06]";
+    default:
+      return "border-emerald-400/20 bg-emerald-400/[0.06]";
+  }
+}
+
+export function PlanReviewVisual(props: PlanReviewVisualProps) {
+  const {
+    title,
+    summary,
+    steps,
+    assumptions,
+    unknowns,
+    riskLevel,
+    isApproving,
+    isRejecting,
+    onApprove,
+    onReject,
+    clarificationQuestion,
+    clarificationChoices,
+    onClarificationAnswer,
+  } = props;
+
+  const progressSteps: StepProgressStep[] = steps.map((step) => ({
+    id: step.id,
+    label: step.label,
+    status: step.status,
+    detail: step.detail,
+  }));
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-3xl border border-white/10 bg-white/[0.02] p-5">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/40">
+              Plan Review
+            </p>
+            <h3 className="mt-1 text-lg font-semibold text-white">{title}</h3>
+          </div>
+          <div className={cn("rounded-2xl border p-2", riskTone(riskLevel))}>
+            {riskIcon(riskLevel)}
+          </div>
+        </div>
+
+        <p className="mt-3 text-sm leading-6 text-white/60">{summary}</p>
+
+        {steps.length > 0 && (
+          <div className="mt-5">
+            <StepProgress steps={progressSteps} orientation="vertical" />
+          </div>
+        )}
+
+        {assumptions && assumptions.length > 0 && (
+          <div className="mt-4 rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-3">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/40">
+              Assumptions
+            </p>
+            <ul className="mt-2 space-y-1">
+              {assumptions.map((assumption, index) => (
+                <li key={index} className="text-xs leading-5 text-white/50">
+                  {assumption}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {unknowns && unknowns.length > 0 && (
+          <div className="mt-3 rounded-2xl border border-amber-300/10 bg-amber-300/[0.03] px-4 py-3">
+            <p className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.18em] text-amber-200/60">
+              <ShieldAlert className="h-3 w-3" />
+              Unknowns
+            </p>
+            <ul className="mt-2 space-y-1">
+              {unknowns.map((unknown, index) => (
+                <li key={index} className="text-xs leading-5 text-amber-100/50">
+                  {unknown}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+
+      {clarificationQuestion && (
+        <div className="rounded-3xl border border-amber-300/20 bg-amber-300/[0.04] p-5">
+          <p className="text-sm font-medium text-amber-100">{clarificationQuestion}</p>
+          {clarificationChoices && clarificationChoices.length > 0 && (
+            <div className="mt-3 flex flex-wrap gap-2">
+              {clarificationChoices.map((choice) => (
+                <button
+                  key={choice.value}
+                  type="button"
+                  onClick={() => onClarificationAnswer?.(choice.value)}
+                  className="rounded-2xl border border-white/10 bg-white/[0.06] px-3.5 py-2 text-sm text-white transition hover:border-white/20 hover:bg-white/10"
+                >
+                  {choice.label}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      <div className="flex items-center gap-3">
+        <ActionButton
+          tone="primary"
+          onClick={onApprove}
+          disabled={isApproving || isRejecting}
+          className="flex-1"
+        >
+          {isApproving ? "Approving..." : "Approve Plan"}
+        </ActionButton>
+        <ActionButton
+          tone="secondary"
+          onClick={onReject}
+          disabled={isApproving || isRejecting}
+          className="flex-1"
+        >
+          {isRejecting ? "Rejecting..." : "Reject"}
+        </ActionButton>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/guided/step-progress.tsx
+++ b/ui/src/components/guided/step-progress.tsx
@@ -1,0 +1,121 @@
+import { Check, AlertTriangle, Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils/cn";
+
+export interface StepProgressStep {
+  id: string;
+  label: string;
+  status: "pending" | "active" | "completed" | "error";
+  detail?: string;
+}
+
+export interface StepProgressProps {
+  steps: StepProgressStep[];
+  orientation?: "horizontal" | "vertical";
+}
+
+function StepIcon(props: { status: StepProgressStep["status"] }) {
+  switch (props.status) {
+    case "completed":
+      return <Check className="h-3.5 w-3.5 text-emerald-300" />;
+    case "error":
+      return <AlertTriangle className="h-3.5 w-3.5 text-rose-300" />;
+    case "active":
+      return <Loader2 className="h-3.5 w-3.5 animate-spin text-[var(--accent-strong)]" />;
+    default:
+      return <div className="h-2 w-2 rounded-full bg-white/20" />;
+  }
+}
+
+function stepTone(status: StepProgressStep["status"]) {
+  switch (status) {
+    case "completed":
+      return "border-emerald-400/30 bg-emerald-400/10";
+    case "error":
+      return "border-rose-400/30 bg-rose-400/10";
+    case "active":
+      return "border-[var(--accent-strong)]/40 bg-[var(--accent-strong)]/10";
+    default:
+      return "border-white/10 bg-white/[0.04]";
+  }
+}
+
+export function StepProgress(props: StepProgressProps) {
+  const { steps, orientation = "horizontal" } = props;
+
+  if (orientation === "vertical") {
+    return (
+      <div className="flex flex-col gap-0">
+        {steps.map((step, index) => (
+          <div key={step.id} className="flex gap-3">
+            <div className="flex flex-col items-center">
+              <div
+                className={cn(
+                  "flex h-7 w-7 items-center justify-center rounded-full border",
+                  stepTone(step.status),
+                )}
+              >
+                <StepIcon status={step.status} />
+              </div>
+              {index < steps.length - 1 && (
+                <div
+                  className={cn(
+                    "w-px flex-1 min-h-6",
+                    step.status === "completed" ? "bg-emerald-400/30" : "bg-white/10",
+                  )}
+                />
+              )}
+            </div>
+            <div className="pb-6 pt-1">
+              <p
+                className={cn(
+                  "text-sm font-medium",
+                  step.status === "active" ? "text-white" : step.status === "completed" ? "text-white/70" : "text-white/40",
+                )}
+              >
+                {step.label}
+              </p>
+              {step.detail && (
+                <p className="mt-0.5 text-xs text-white/40">{step.detail}</p>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-1">
+      {steps.map((step, index) => (
+        <div key={step.id} className="flex items-center gap-1">
+          <div className="flex items-center gap-1.5">
+            <div
+              className={cn(
+                "flex h-6 w-6 items-center justify-center rounded-full border",
+                stepTone(step.status),
+              )}
+            >
+              <StepIcon status={step.status} />
+            </div>
+            <span
+              className={cn(
+                "text-xs font-medium whitespace-nowrap",
+                step.status === "active" ? "text-white" : step.status === "completed" ? "text-white/60" : "text-white/30",
+              )}
+            >
+              {step.label}
+            </span>
+          </div>
+          {index < steps.length - 1 && (
+            <div
+              className={cn(
+                "h-px w-6",
+                step.status === "completed" ? "bg-emerald-400/30" : "bg-white/10",
+              )}
+            />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/ui/src/components/layout/app-shell.tsx
+++ b/ui/src/components/layout/app-shell.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { Activity, ChartNoAxesCombined, Command, MonitorCog, Package, ShieldCheck, Wand2, Waypoints } from "lucide-react";
+import { Activity, ChartNoAxesCombined, Command, Home, MonitorCog, Package, ShieldCheck, ShoppingBag, Wand2, Waypoints } from "lucide-react";
 import { NavLink, Outlet, useLocation } from "react-router-dom";
 import { useAuth } from "@/hooks/use-auth";
 import { healthApi } from "@/lib/api/health";
@@ -36,6 +36,7 @@ export function AppShell() {
 
   const pageTitle = resolvePageTitle(location.pathname);
   const systemHealth = systemSession?.health;
+  const isSimplifiedView = location.pathname === "/home" || location.pathname.startsWith("/flow/");
 
   return (
     <div className="min-h-screen bg-[var(--bg-canvas)] text-white">
@@ -82,7 +83,9 @@ export function AppShell() {
               >
                 <div className="flex items-start gap-3">
                   <div className="mt-0.5 rounded-2xl border border-white/10 bg-white/[0.07] p-2">
+                    {item.path === "/home" ? <Home className="h-4 w-4" /> : null}
                     {item.path === "/assistant" ? <Wand2 className="h-4 w-4" /> : null}
+                    {item.path === "/marketplace" ? <ShoppingBag className="h-4 w-4" /> : null}
                     {item.path === "/workflows" ? <Activity className="h-4 w-4" /> : null}
                     {item.path === "/skills" ? <Package className="h-4 w-4" /> : null}
                     {item.path === "/fleet" ? <Waypoints className="h-4 w-4" /> : null}
@@ -124,26 +127,28 @@ export function AppShell() {
         </aside>
 
         <main className="relative flex min-h-[calc(100vh-2rem)] flex-1 flex-col gap-4">
-          <header className="agent-header">
-            <div>
-              <p className="agent-eyebrow">Friday Control Plane</p>
-              <h1 className="font-[var(--font-display)] text-3xl font-semibold tracking-tight text-white">
-                {pageTitle}
-              </h1>
-            </div>
+          {!isSimplifiedView && (
+            <header className="agent-header">
+              <div>
+                <p className="agent-eyebrow">Friday Control Plane</p>
+                <h1 className="font-[var(--font-display)] text-3xl font-semibold tracking-tight text-white">
+                  {pageTitle}
+                </h1>
+              </div>
 
-            <div className="flex flex-wrap items-center gap-2">
-              <StatusPill tone={toneForHealth(health?.status)}>
-                API {health?.status ?? "loading"}
-              </StatusPill>
-              <StatusPill tone={toneForHealth(systemHealth?.status)}>
-                System {systemHealth?.status ?? "unavailable"}
-              </StatusPill>
-              <StatusPill tone={systemSession?.companion.connected ? "success" : "warning"}>
-                Companion {systemSession?.companion.connected ? "connected" : "degraded"}
-              </StatusPill>
-            </div>
-          </header>
+              <div className="flex flex-wrap items-center gap-2">
+                <StatusPill tone={toneForHealth(health?.status)}>
+                  API {health?.status ?? "loading"}
+                </StatusPill>
+                <StatusPill tone={toneForHealth(systemHealth?.status)}>
+                  System {systemHealth?.status ?? "unavailable"}
+                </StatusPill>
+                <StatusPill tone={systemSession?.companion.connected ? "success" : "warning"}>
+                  Companion {systemSession?.companion.connected ? "connected" : "degraded"}
+                </StatusPill>
+              </div>
+            </header>
+          )}
 
           {systemHealth && systemHealth.status !== "healthy" ? (
             <div className="rounded-3xl border border-amber-300/[0.24] bg-amber-300/10 px-4 py-3 text-sm text-amber-100">

--- a/ui/src/hooks/use-guided-flow.ts
+++ b/ui/src/hooks/use-guided-flow.ts
@@ -1,0 +1,120 @@
+import { useCallback, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { systemApi } from "@/lib/api/system";
+import type { FridayGuidedWizardState, FridayUixWizardResponse } from "@/lib/api/system-types";
+
+export interface UseGuidedFlowOptions {
+  wizardId: string;
+  assistantSessionKey?: string;
+  enabled?: boolean;
+}
+
+export interface UseGuidedFlowResult {
+  wizard: FridayGuidedWizardState | null;
+  wizardResponse: FridayUixWizardResponse | null;
+  isLoading: boolean;
+  isStarting: boolean;
+  isContinuing: boolean;
+  error: Error | null;
+  start: () => void;
+  continueStep: (values: Record<string, unknown>) => void;
+  cancel: () => void;
+  reset: () => void;
+}
+
+export function useGuidedFlow(options: UseGuidedFlowOptions): UseGuidedFlowResult {
+  const { wizardId, assistantSessionKey, enabled = true } = options;
+  const queryClient = useQueryClient();
+  const [activeContextId, setActiveContextId] = useState<string | null>(null);
+  const [wizardState, setWizardState] = useState<FridayGuidedWizardState | null>(null);
+  const [wizardResponse, setWizardResponse] = useState<FridayUixWizardResponse | null>(null);
+  const [cancelled, setCancelled] = useState(false);
+
+  const startMutation = useMutation({
+    mutationFn: async () => {
+      return systemApi.startAssistantWizard(wizardId, assistantSessionKey);
+    },
+    onSuccess: (wizard) => {
+      setWizardState(wizard);
+      setActiveContextId(wizard.contextId);
+      setCancelled(false);
+    },
+  });
+
+  const continueMutation = useMutation({
+    mutationFn: async (values: Record<string, unknown>) => {
+      if (!activeContextId) {
+        throw new Error("No active wizard context");
+      }
+      return systemApi.continueAssistantWizard({
+        wizardId,
+        contextId: activeContextId,
+        values,
+        assistantSessionKey,
+      });
+    },
+    onSuccess: (response) => {
+      setWizardState(response.wizard);
+      setWizardResponse(response);
+    },
+  });
+
+  const start = useCallback(() => {
+    if (enabled && !startMutation.isPending) {
+      startMutation.mutate();
+    }
+  }, [enabled, startMutation]);
+
+  const continueStep = useCallback(
+    (values: Record<string, unknown>) => {
+      if (!continueMutation.isPending && activeContextId) {
+        continueMutation.mutate(values);
+      }
+    },
+    [continueMutation, activeContextId],
+  );
+
+  const cancel = useCallback(() => {
+    setCancelled(true);
+    setWizardState(null);
+    setWizardResponse(null);
+    setActiveContextId(null);
+  }, []);
+
+  const reset = useCallback(() => {
+    setCancelled(false);
+    setWizardState(null);
+    setWizardResponse(null);
+    setActiveContextId(null);
+    startMutation.reset();
+    continueMutation.reset();
+  }, [startMutation, continueMutation]);
+
+  return useMemo(
+    () => ({
+      wizard: cancelled ? null : wizardState,
+      wizardResponse: cancelled ? null : wizardResponse,
+      isLoading: startMutation.isPending || continueMutation.isPending,
+      isStarting: startMutation.isPending,
+      isContinuing: continueMutation.isPending,
+      error: startMutation.error ?? continueMutation.error ?? null,
+      start,
+      continueStep,
+      cancel,
+      reset,
+    }),
+    [
+      cancelled,
+      wizardState,
+      wizardResponse,
+      startMutation.isPending,
+      startMutation.error,
+      continueMutation.isPending,
+      continueMutation.error,
+      start,
+      continueStep,
+      cancel,
+      reset,
+    ],
+  );
+}

--- a/ui/src/hooks/use-investigation-events.ts
+++ b/ui/src/hooks/use-investigation-events.ts
@@ -1,0 +1,72 @@
+import { useMemo } from "react";
+import { useAgentRunEvents, type UseAgentRunEventsOptions } from "./use-agent-run-events";
+import type { InvestigationLine } from "@/components/guided/investigation-panel";
+
+export interface UseInvestigationEventsOptions extends UseAgentRunEventsOptions {
+  enabled?: boolean;
+}
+
+export interface UseInvestigationEventsResult {
+  findings: InvestigationLine[];
+  isStreaming: boolean;
+  isComplete: boolean;
+  outputText: string;
+  status: string | null;
+  errorMessage?: string;
+}
+
+function classifyLineType(text: string): InvestigationLine["type"] {
+  const lower = text.toLowerCase();
+  if (lower.startsWith("found") || lower.startsWith("discovered") || lower.includes("detected")) {
+    return "discovery";
+  }
+  if (lower.startsWith("analyzing") || lower.startsWith("evaluating") || lower.startsWith("comparing")) {
+    return "analysis";
+  }
+  if (lower.startsWith("recommendation") || lower.startsWith("conclusion") || lower.startsWith("result")) {
+    return "conclusion";
+  }
+  return "info";
+}
+
+function parseOutputToLines(text: string): InvestigationLine[] {
+  if (!text.trim()) return [];
+
+  return text
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+    .map((line, index) => ({
+      id: `line-${String(index)}`,
+      text: line.trim(),
+      type: classifyLineType(line),
+    }));
+}
+
+export function useInvestigationEvents(
+  runId: string | null,
+  options: UseInvestigationEventsOptions = {},
+): UseInvestigationEventsResult {
+  const { enabled = true, onTerminal } = options;
+
+  const runEvents = useAgentRunEvents(runId, { enabled, onTerminal });
+
+  const findings = useMemo(
+    () => parseOutputToLines(runEvents.outputText),
+    [runEvents.outputText],
+  );
+
+  const isStreaming = runEvents.connectionState === "streaming" || runEvents.connectionState === "connecting";
+  const isComplete = runEvents.connectionState === "closed" && runEvents.status !== null;
+
+  return useMemo(
+    () => ({
+      findings,
+      isStreaming,
+      isComplete,
+      outputText: runEvents.outputText,
+      status: runEvents.status,
+      errorMessage: runEvents.errorMessage,
+    }),
+    [findings, isStreaming, isComplete, runEvents.outputText, runEvents.status, runEvents.errorMessage],
+  );
+}

--- a/ui/src/hooks/use-user-profile.ts
+++ b/ui/src/hooks/use-user-profile.ts
@@ -1,0 +1,101 @@
+import { useCallback, useMemo } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { apiClient } from "@/lib/api/client";
+
+export type UserProfileType = "beginner" | "developer" | "creator" | "business";
+
+interface UserProfileResponse {
+  profileType: UserProfileType | null;
+  onboardedAt: string | null;
+}
+
+const USER_PROFILE_KEY = ["uix", "user-profile"] as const;
+
+const FALLBACK_STORAGE_KEY = "friday.uix.user-profile";
+
+function readFallbackProfile(): UserProfileResponse {
+  if (typeof window === "undefined") {
+    return { profileType: null, onboardedAt: null };
+  }
+  try {
+    const raw = window.localStorage.getItem(FALLBACK_STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as UserProfileResponse) : { profileType: null, onboardedAt: null };
+  } catch {
+    return { profileType: null, onboardedAt: null };
+  }
+}
+
+function writeFallbackProfile(data: UserProfileResponse) {
+  if (typeof window !== "undefined") {
+    window.localStorage.setItem(FALLBACK_STORAGE_KEY, JSON.stringify(data));
+  }
+}
+
+export interface UseUserProfileResult {
+  profileType: UserProfileType;
+  isFirstVisit: boolean;
+  isLoading: boolean;
+  setProfileType: (type: UserProfileType) => void;
+  markOnboarded: () => void;
+}
+
+export function useUserProfile(): UseUserProfileResult {
+  const queryClient = useQueryClient();
+
+  const profileQuery = useQuery({
+    queryKey: USER_PROFILE_KEY,
+    queryFn: async (): Promise<UserProfileResponse> => {
+      try {
+        return await apiClient.get<UserProfileResponse>("/v1/uix/user-profile");
+      } catch {
+        return readFallbackProfile();
+      }
+    },
+    staleTime: 60_000,
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: async (input: Partial<UserProfileResponse>) => {
+      try {
+        await apiClient.put<Partial<UserProfileResponse>, UserProfileResponse>("/v1/uix/user-profile", input);
+      } catch {
+        // Fallback to localStorage if endpoint not yet available
+        const current = readFallbackProfile();
+        const updated = { ...current, ...input };
+        writeFallbackProfile(updated);
+      }
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: USER_PROFILE_KEY });
+    },
+  });
+
+  const profileType = profileQuery.data?.profileType ?? readFallbackProfile().profileType ?? "beginner";
+  const onboardedAt = profileQuery.data?.onboardedAt ?? readFallbackProfile().onboardedAt;
+
+  const setProfileType = useCallback(
+    (type: UserProfileType) => {
+      writeFallbackProfile({ profileType: type, onboardedAt: readFallbackProfile().onboardedAt });
+      updateMutation.mutate({ profileType: type });
+    },
+    [updateMutation],
+  );
+
+  const markOnboarded = useCallback(() => {
+    const now = new Date().toISOString();
+    const current = readFallbackProfile();
+    writeFallbackProfile({ ...current, onboardedAt: now });
+    updateMutation.mutate({ onboardedAt: now });
+  }, [updateMutation]);
+
+  return useMemo(
+    () => ({
+      profileType: profileType as UserProfileType,
+      isFirstVisit: !onboardedAt,
+      isLoading: profileQuery.isLoading,
+      setProfileType,
+      markOnboarded,
+    }),
+    [profileType, onboardedAt, profileQuery.isLoading, setProfileType, markOnboarded],
+  );
+}

--- a/ui/src/lib/guided/flow-adapters.ts
+++ b/ui/src/lib/guided/flow-adapters.ts
@@ -1,0 +1,137 @@
+import type { StepProgressStep } from "@/components/guided/step-progress";
+import type { ChoiceCardProps } from "@/components/guided/choice-card";
+import type { JourneyPhase } from "@/components/guided/journey-tracker";
+import type { PlanStep } from "@/components/guided/plan-review-visual";
+import type { FridayGuidedWizardState } from "@/lib/api/system-types";
+
+export function wizardStepsToProgress(wizard: FridayGuidedWizardState): StepProgressStep[] {
+  const currentIndex = wizard.steps.findIndex((step) => step.id === wizard.currentStepId);
+
+  return wizard.steps.map((step, index) => ({
+    id: step.id,
+    label: step.title,
+    status:
+      index < currentIndex
+        ? "completed"
+        : index === currentIndex
+          ? "active"
+          : "pending",
+  }));
+}
+
+export interface WizardStepChoice {
+  value: string;
+  label: string;
+  description: string;
+  outcome: string;
+  risk?: "low" | "medium" | "high";
+  recommended?: boolean;
+  reason?: string;
+}
+
+export function wizardStepToChoiceCards(
+  choices: WizardStepChoice[],
+  selectedValue?: string,
+  onSelect?: (value: string) => void,
+): Omit<ChoiceCardProps, "onSelect">[] {
+  return choices.map((choice) => ({
+    title: choice.label,
+    description: choice.description,
+    outcome: choice.outcome,
+    risk: choice.risk,
+    recommended: choice.recommended,
+    reason: choice.reason,
+    selected: selectedValue === choice.value,
+  }));
+}
+
+export function buildGuidedFlowJourneyPhases(
+  wizard: FridayGuidedWizardState | null,
+  investigationActive: boolean,
+  executionActive: boolean,
+): JourneyPhase[] {
+  const phases: JourneyPhase[] = [
+    {
+      id: "investigate",
+      label: "Investigate",
+      status: investigationActive
+        ? "investigating"
+        : wizard?.status === "awaiting_input" || wizard?.status === "ready" || wizard?.status === "completed"
+          ? "completed"
+          : "pending",
+    },
+    {
+      id: "choose",
+      label: "Choose",
+      status:
+        wizard?.status === "awaiting_input"
+          ? "choosing"
+          : wizard?.status === "ready" || wizard?.status === "completed"
+            ? "completed"
+            : "pending",
+    },
+    {
+      id: "plan",
+      label: "Plan",
+      status:
+        wizard?.status === "ready"
+          ? "planning"
+          : wizard?.status === "completed"
+            ? "completed"
+            : "pending",
+    },
+    {
+      id: "execute",
+      label: "Execute",
+      status: executionActive
+        ? "executing"
+        : wizard?.status === "completed"
+          ? "completed"
+          : "pending",
+    },
+    {
+      id: "done",
+      label: "Done",
+      status: wizard?.status === "completed" ? "completed" : "pending",
+    },
+  ];
+
+  return phases;
+}
+
+export function buildGuidedFlowCurrentPhaseIndex(
+  phases: JourneyPhase[],
+): number {
+  const activeIndex = phases.findIndex(
+    (phase) => phase.status !== "completed" && phase.status !== "pending",
+  );
+  return activeIndex >= 0 ? activeIndex : 0;
+}
+
+export function planReviewStepsFromMarkdown(planMarkdown: string): PlanStep[] {
+  const lines = planMarkdown.split("\n").filter((line) => line.trim().length > 0);
+  const steps: PlanStep[] = [];
+  let stepIndex = 0;
+
+  for (const line of lines) {
+    const listMatch = line.match(/^\s*[-*]\s+(.+)/);
+    const numberedMatch = line.match(/^\s*\d+[.)]\s+(.+)/);
+    const match = listMatch ?? numberedMatch;
+
+    if (match) {
+      const text = match[1].trim();
+      const hasHighRisk = /\b(danger|destructive|irreversible|breaking)\b/i.test(text);
+      const hasMediumRisk = /\b(risk|careful|approval|manual)\b/i.test(text);
+
+      steps.push({
+        id: `plan-step-${String(stepIndex)}`,
+        label: text,
+        risk: hasHighRisk ? "high" : hasMediumRisk ? "medium" : "low",
+        status: "pending",
+      });
+      stepIndex++;
+    }
+  }
+
+  return steps;
+}

--- a/ui/src/lib/guided/goal-categories.ts
+++ b/ui/src/lib/guided/goal-categories.ts
@@ -1,0 +1,138 @@
+import {
+  Activity,
+  Cpu,
+  Hammer,
+  PenTool,
+  RefreshCcw,
+  Rocket,
+  ShoppingCart,
+  TrendingUp,
+  Users,
+  Wrench,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import type { UserProfileType } from "@/hooks/use-user-profile";
+
+export interface FridayGoalCategory {
+  id: string;
+  icon: LucideIcon;
+  title: string;
+  subtitle: string;
+  outcome: string;
+  wizardId: string;
+  profilePriority: Partial<Record<UserProfileType, number>>;
+  recommended?: boolean;
+}
+
+export const FRIDAY_GOAL_CATEGORIES: FridayGoalCategory[] = [
+  {
+    id: "build-new",
+    icon: Hammer,
+    title: "Build something new",
+    subtitle: "From idea to implementation. Friday helps you plan and build step by step.",
+    outcome: "A concrete plan and working implementation of your idea.",
+    wizardId: "build-new",
+    profilePriority: { developer: 1, creator: 5, business: 6, beginner: 3 },
+    recommended: true,
+  },
+  {
+    id: "fix-broken",
+    icon: Wrench,
+    title: "Fix what's broken",
+    subtitle: "Friday diagnoses the problem, suggests fixes, and executes the repair.",
+    outcome: "Root cause identified and fix applied with verification.",
+    wizardId: "fix-broken",
+    profilePriority: { developer: 2, creator: 8, business: 7, beginner: 5 },
+  },
+  {
+    id: "ship-fast",
+    icon: Rocket,
+    title: "Ship & release",
+    subtitle: "QA checks, release docs, deploy verification — all in one flow.",
+    outcome: "Verified release with documentation and deploy evidence.",
+    wizardId: "ship-fast",
+    profilePriority: { developer: 3, creator: 9, business: 8, beginner: 7 },
+  },
+  {
+    id: "understand-system",
+    icon: Activity,
+    title: "Understand my system",
+    subtitle: "Health check, observability snapshot, and clear report of what's happening.",
+    outcome: "A structured system health report with actionable next steps.",
+    wizardId: "understand-system",
+    profilePriority: { developer: 4, creator: 10, business: 5, beginner: 8 },
+  },
+  {
+    id: "automate-work",
+    icon: RefreshCcw,
+    title: "Automate repetitive work",
+    subtitle: "Turn manual operations into automated workflows that run on schedule.",
+    outcome: "A deployed automation that handles the task without manual intervention.",
+    wizardId: "automate-work",
+    profilePriority: { developer: 5, creator: 3, business: 3, beginner: 4 },
+  },
+  {
+    id: "content-social",
+    icon: PenTool,
+    title: "Create content & run social media",
+    subtitle: "Create, schedule, and publish across platforms like Xiaohongshu, TikTok, and more.",
+    outcome: "Content created, scheduled, and distributed across your chosen platforms.",
+    wizardId: "content-social",
+    profilePriority: { developer: 9, creator: 1, business: 4, beginner: 2 },
+    recommended: true,
+  },
+  {
+    id: "ecommerce",
+    icon: ShoppingCart,
+    title: "E-commerce & cross-border trade",
+    subtitle: "Product selection, platform comparison, data monitoring, and full process automation.",
+    outcome: "Clear data-driven decisions with automated operations across platforms.",
+    wizardId: "ecommerce",
+    profilePriority: { developer: 8, creator: 4, business: 1, beginner: 6 },
+    recommended: true,
+  },
+  {
+    id: "team-management",
+    icon: Users,
+    title: "Manage a team",
+    subtitle: "Task assignment, progress tracking, and team collaboration workflows.",
+    outcome: "Organized team workflow with clear task ownership and progress visibility.",
+    wizardId: "team-management",
+    profilePriority: { developer: 7, creator: 7, business: 2, beginner: 9 },
+  },
+  {
+    id: "ai-saas-build",
+    icon: Cpu,
+    title: "Build an AI app / SaaS",
+    subtitle: "From concept to launch — architecture, implementation, and deployment of your AI product.",
+    outcome: "A working AI application or SaaS ready for users.",
+    wizardId: "ai-saas-build",
+    profilePriority: { developer: 6, creator: 6, business: 9, beginner: 10 },
+  },
+  {
+    id: "invest-trade",
+    icon: TrendingUp,
+    title: "Investment & trading automation",
+    subtitle: "Research analysis, trading strategy automation, and data-driven insights.",
+    outcome: "Automated research and trading workflows with structured data analysis.",
+    wizardId: "invest-trade",
+    profilePriority: { developer: 10, creator: 8, business: 10, beginner: 1 },
+  },
+];
+
+export function getGoalCategoriesForProfile(
+  profileType: UserProfileType,
+  limit?: number,
+): FridayGoalCategory[] {
+  const sorted = [...FRIDAY_GOAL_CATEGORIES].sort((a, b) => {
+    const aPriority = a.profilePriority[profileType] ?? 50;
+    const bPriority = b.profilePriority[profileType] ?? 50;
+    return aPriority - bPriority;
+  });
+
+  return limit ? sorted.slice(0, limit) : sorted;
+}
+
+export function getGoalCategoryById(id: string): FridayGoalCategory | undefined {
+  return FRIDAY_GOAL_CATEGORIES.find((category) => category.id === id);
+}

--- a/ui/src/lib/routes/agent-os-nav.ts
+++ b/ui/src/lib/routes/agent-os-nav.ts
@@ -6,9 +6,14 @@ export interface AgentOsNavItem {
 
 export const AGENT_OS_NAV_ITEMS: AgentOsNavItem[] = [
   {
+    label: "Home",
+    path: "/home",
+    description: "Goal-first starting point with guided flows",
+  },
+  {
     label: "Assistant",
     path: "/assistant",
-    description: "Primary control center for goals, plans, actions, and issue recovery",
+    description: "Full dashboard for goals, plans, actions, and issue recovery",
   },
   {
     label: "Marketplace",
@@ -53,7 +58,13 @@ export const AGENT_OS_NAV_ITEMS: AgentOsNavItem[] = [
 ];
 
 export function resolvePageTitle(pathname: string): string {
-  if (pathname === "/" || pathname.startsWith("/assistant")) {
+  if (pathname === "/" || pathname === "/home") {
+    return "Home";
+  }
+  if (pathname.startsWith("/flow/")) {
+    return "Guided Flow";
+  }
+  if (pathname.startsWith("/assistant")) {
     return "Assistant";
   }
   if (pathname.startsWith("/marketplace")) {

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -3,15 +3,19 @@ import { Navigate, Outlet, createBrowserRouter, useLocation } from "react-router
 import { AppShell } from "@/components/layout/app-shell";
 import { useAuth } from "@/hooks/use-auth";
 import { useSetupStatusQuery } from "@/hooks/use-setup";
+import { useUserProfile } from "@/hooks/use-user-profile";
 import { resolveLegacyRedirect } from "@/lib/routes/legacy-routes";
 
 const AgentPage = lazy(async () => import("@/routes/agent-page").then((module) => ({ default: module.AgentPage })));
 const AssistantPage = lazy(async () => import("@/routes/assistant-page").then((module) => ({ default: module.AssistantPage })));
 const AutomationsPage = lazy(async () => import("@/routes/automations-page").then((module) => ({ default: module.AutomationsPage })));
 const FleetPage = lazy(async () => import("@/routes/fleet-page").then((module) => ({ default: module.FleetPage })));
+const GuidedFlowPage = lazy(async () => import("@/routes/guided-flow-page").then((module) => ({ default: module.GuidedFlowPage })));
+const HomePage = lazy(async () => import("@/routes/home-page").then((module) => ({ default: module.HomePage })));
 const LoginPage = lazy(async () => import("@/routes/login-page").then((module) => ({ default: module.LoginPage })));
 const MarketplacePage = lazy(async () => import("@/routes/marketplace-page").then((module) => ({ default: module.MarketplacePage })));
 const ObservabilityPage = lazy(async () => import("@/routes/observability-page").then((module) => ({ default: module.ObservabilityPage })));
+const OnboardingPage = lazy(async () => import("@/routes/onboarding-page").then((module) => ({ default: module.OnboardingPage })));
 const SettingsPage = lazy(async () => import("@/routes/settings-page").then((module) => ({ default: module.SettingsPage })));
 const SetupPage = lazy(async () => import("@/routes/setup-page").then((module) => ({ default: module.SetupPage })));
 const SkillsPage = lazy(async () => import("@/routes/skills-page").then((module) => ({ default: module.SkillsPage })));
@@ -63,8 +67,9 @@ function RouteSuspense(props: { title: string; detail: string; children: ReactNo
 function SetupGate() {
   const location = useLocation();
   const { data: setupStatus, isLoading, isError } = useSetupStatusQuery();
+  const { isFirstVisit, isLoading: profileLoading } = useUserProfile();
 
-  if (isLoading) {
+  if (isLoading || profileLoading) {
     return (
       <FullscreenMessage
         title="Inspecting local setup"
@@ -84,6 +89,10 @@ function SetupGate() {
 
   if (setupStatus?.needsSetup && location.pathname !== "/setup") {
     return <Navigate to="/setup" replace />;
+  }
+
+  if (!setupStatus?.needsSetup && isFirstVisit && location.pathname !== "/onboarding") {
+    return <Navigate to="/onboarding" replace />;
   }
 
   return <Outlet />;
@@ -121,8 +130,32 @@ export const router = createBrowserRouter([
         ),
       },
       {
+        path: "onboarding",
+        element: (
+          <RouteSuspense title="Welcome" detail="Friday is preparing your onboarding experience.">
+            <OnboardingPage />
+          </RouteSuspense>
+        ),
+      },
+      {
         element: <AppShell />,
         children: [
+          {
+            path: "home",
+            element: (
+              <RouteSuspense title="Loading home" detail="Friday is preparing your goal-first home screen.">
+                <HomePage />
+              </RouteSuspense>
+            ),
+          },
+          {
+            path: "flow/:wizardId",
+            element: (
+              <RouteSuspense title="Loading guided flow" detail="Friday is preparing your guided experience.">
+                <GuidedFlowPage />
+              </RouteSuspense>
+            ),
+          },
           {
             path: "assistant",
             element: (
@@ -133,7 +166,7 @@ export const router = createBrowserRouter([
           },
           {
             index: true,
-            element: <Navigate to="/assistant" replace />,
+            element: <Navigate to="/home" replace />,
           },
           {
             path: "command-center",
@@ -226,5 +259,5 @@ export const router = createBrowserRouter([
       },
     ],
   },
-  { path: "*", element: <Navigate to="/assistant" replace /> },
+  { path: "*", element: <Navigate to="/home" replace /> },
 ]);

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -1,4 +1,4 @@
-import { Suspense, lazy, type ReactNode } from "react";
+import { Suspense, lazy, useEffect, useState, type ReactNode } from "react";
 import { Navigate, Outlet, createBrowserRouter, useLocation } from "react-router-dom";
 import { AppShell } from "@/components/layout/app-shell";
 import { useAuth } from "@/hooks/use-auth";
@@ -38,13 +38,24 @@ function FullscreenMessage(props: { title: string; detail: string }) {
 }
 
 function RequireAuth({ children }: { children: ReactNode }) {
-  const { isAuthenticated, isLoading } = useAuth();
+  const { isAuthenticated, isLoading, login: doLogin } = useAuth();
+  const [retrying, setRetrying] = useState(false);
 
-  if (isLoading) {
+  // If not authenticated and not loading, retry local auto-login once before showing login page.
+  useEffect(() => {
+    if (!isLoading && !isAuthenticated && !retrying) {
+      setRetrying(true);
+      doLogin({ local: true }).catch(() => {
+        // Auto-login failed — will fall through to login page.
+      });
+    }
+  }, [isLoading, isAuthenticated, retrying, doLogin]);
+
+  if (isLoading || (!isAuthenticated && retrying)) {
     return (
       <FullscreenMessage
-        title="Restoring session"
-        detail="Friday is checking the current operator session before loading the control shell."
+        title="Starting Friday"
+        detail="Friday is preparing your local session."
       />
     );
   }

--- a/ui/src/routes/guided-flow-page.tsx
+++ b/ui/src/routes/guided-flow-page.tsx
@@ -1,0 +1,488 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import { useMutation } from "@tanstack/react-query";
+import { CheckCircle2, RefreshCcw } from "lucide-react";
+import { toast } from "sonner";
+import { agentApi } from "@/lib/api/agent";
+import { GuidedFlowContainer } from "@/components/guided/guided-flow-container";
+import { InvestigationPanel } from "@/components/guided/investigation-panel";
+import { ChoiceCard } from "@/components/guided/choice-card";
+import { PlanReviewVisual, type PlanStep } from "@/components/guided/plan-review-visual";
+import { JourneyTracker, type JourneyPhase } from "@/components/guided/journey-tracker";
+import { ActionButton, ShellCard } from "@/components/core/primitives";
+import { useGuidedFlow } from "@/hooks/use-guided-flow";
+import { useInvestigationEvents } from "@/hooks/use-investigation-events";
+import { useAgentRunEvents } from "@/hooks/use-agent-run-events";
+import { getGoalCategoryById } from "@/lib/guided/goal-categories";
+import { planReviewStepsFromMarkdown, type WizardStepChoice } from "@/lib/guided/flow-adapters";
+
+type FlowPhase = "investigating" | "choosing" | "planning" | "executing" | "completed" | "failed";
+
+function buildChoicesFromWizardResponse(
+  wizardQuestions: string[],
+  wizardSummary?: string,
+): WizardStepChoice[] {
+  if (wizardQuestions.length > 0) {
+    return [
+      {
+        value: "proceed",
+        label: "Proceed with Friday's approach",
+        description: wizardSummary ?? "Friday will proceed based on its analysis.",
+        outcome: "Friday handles the details and asks only when essential.",
+        risk: "low",
+        recommended: true,
+        reason: "Friday has enough context to proceed safely.",
+      },
+      ...wizardQuestions.map((question, index) => ({
+        value: `clarify-${String(index)}`,
+        label: question,
+        description: "Answer this question to help Friday refine the approach.",
+        outcome: "A more precise execution aligned with your intent.",
+        risk: "low" as const,
+      })),
+      {
+        value: "explore",
+        label: "Investigate further",
+        description: "Ask Friday to research more alternatives before proceeding.",
+        outcome: "Deeper analysis with more options.",
+        risk: "low",
+      },
+    ];
+  }
+
+  return [
+    {
+      value: "proceed",
+      label: "Proceed with recommended approach",
+      description: wizardSummary ?? "Friday will execute the plan it generated.",
+      outcome: "Optimal result based on investigation.",
+      risk: "low",
+      recommended: true,
+      reason: "Friday determined this is the best approach.",
+    },
+    {
+      value: "customize",
+      label: "Customize before executing",
+      description: "Review and modify the approach before Friday proceeds.",
+      outcome: "A tailored execution matching your specific needs.",
+      risk: "medium",
+    },
+    {
+      value: "explore",
+      label: "Explore more options",
+      description: "Ask Friday to investigate further and present more alternatives.",
+      outcome: "Additional options and deeper analysis.",
+      risk: "low",
+    },
+  ];
+}
+
+export function GuidedFlowPage() {
+  const { wizardId } = useParams<{ wizardId: string }>();
+  const navigate = useNavigate();
+  const [phase, setPhase] = useState<FlowPhase>("investigating");
+  const [investigationRunId, setInvestigationRunId] = useState<string | null>(null);
+  const [executionRunId, setExecutionRunId] = useState<string | null>(null);
+  const [selectedChoice, setSelectedChoice] = useState<string | null>(null);
+  const [planSteps, setPlanSteps] = useState<PlanStep[]>([]);
+  const [wizardAdvanced, setWizardAdvanced] = useState(false);
+
+  const goalCategory = wizardId ? getGoalCategoryById(wizardId) : undefined;
+  const goalTitle = goalCategory?.title ?? wizardId ?? "Goal";
+  const investigationTask = goalCategory
+    ? `Investigate and analyze options for: ${goalCategory.title}. ${goalCategory.subtitle} Provide structured findings with recommendations.`
+    : `Investigate and analyze options for the goal: ${wizardId ?? "unknown"}`;
+
+  // ─── Wizard lifecycle (backend state machine) ───
+  const guidedFlow = useGuidedFlow({
+    wizardId: wizardId ?? "",
+    enabled: !!wizardId,
+  });
+
+  // ─── Start investigation agent run on mount ───
+  const startInvestigation = useMutation({
+    mutationFn: async () => {
+      return agentApi.startRun({
+        task: investigationTask,
+        sessionKey: `guided:${wizardId ?? "unknown"}`,
+        executionContext: { surface: "guided-flow", interactive: true },
+      });
+    },
+    onSuccess: (result) => {
+      setInvestigationRunId(result.runId);
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Failed to start investigation");
+      setPhase("failed");
+    },
+  });
+
+  // Start both wizard and investigation on mount
+  useEffect(() => {
+    if (wizardId && !investigationRunId && !startInvestigation.isPending) {
+      guidedFlow.start();
+      startInvestigation.mutate();
+    }
+  }, [wizardId]);
+
+  // ─── Investigation SSE events ───
+  const investigation = useInvestigationEvents(investigationRunId, {
+    enabled: phase === "investigating",
+    onTerminal: (status) => {
+      if (status === "completed") {
+        // Investigation done → advance wizard with the goal
+        if (!wizardAdvanced) {
+          setWizardAdvanced(true);
+          guidedFlow.continueStep({ goal: investigationTask });
+        }
+        setPhase("choosing");
+      } else {
+        setPhase("failed");
+      }
+    },
+  });
+
+  // ─── Execution SSE events ───
+  const execution = useAgentRunEvents(executionRunId, {
+    enabled: phase === "executing" || phase === "planning",
+    onTerminal: (status) => {
+      if (status === "completed") {
+        setPhase("completed");
+      } else {
+        setPhase("failed");
+      }
+    },
+  });
+
+  // ─── Detect plan approval from execution ───
+  const isAwaitingPlan = execution.status === "awaiting_plan_approval";
+
+  useEffect(() => {
+    if (isAwaitingPlan && phase !== "planning") {
+      setPhase("planning");
+      if (execution.outputText) {
+        setPlanSteps(planReviewStepsFromMarkdown(execution.outputText));
+      }
+    }
+  }, [isAwaitingPlan, phase, execution.outputText]);
+
+  // ─── Build choices from wizard response ───
+  const choices = useMemo<WizardStepChoice[]>(() => {
+    if (phase !== "choosing") return [];
+
+    const wizardResponse = guidedFlow.wizardResponse;
+    const wizardQuestions = (wizardResponse?.wizard.collectedValues.questions as string[] | undefined) ?? [];
+    const wizardSummary = wizardResponse?.summary;
+
+    return buildChoicesFromWizardResponse(wizardQuestions, wizardSummary ?? undefined);
+  }, [phase, guidedFlow.wizardResponse]);
+
+  // ─── Handle choice selection → execute ───
+  const executeChoice = useMutation({
+    mutationFn: async () => {
+      const choice = choices.find((c) => c.value === selectedChoice);
+
+      // If user chose "explore", restart investigation
+      if (selectedChoice === "explore") {
+        setPhase("investigating");
+        setInvestigationRunId(null);
+        setWizardAdvanced(false);
+        startInvestigation.mutate();
+        return null;
+      }
+
+      // If user chose a clarification, submit the answer via wizard
+      if (selectedChoice?.startsWith("clarify-")) {
+        guidedFlow.continueStep({ answer: choice?.label ?? selectedChoice });
+        // After answering, the wizard may complete or ask more
+        setPhase("choosing");
+        setSelectedChoice(null);
+        return null;
+      }
+
+      // Otherwise, proceed with execution
+      const choiceLabel = choice?.label ?? selectedChoice ?? "recommended approach";
+      const result = await agentApi.startRun({
+        task: `Execute the ${choiceLabel} for: ${goalTitle}. Based on the previous investigation, proceed with implementation.`,
+        requireReview: true,
+        sessionKey: `guided:${wizardId ?? "unknown"}`,
+        executionContext: { surface: "guided-flow", interactive: true },
+      });
+      return result;
+    },
+    onSuccess: (result) => {
+      if (result) {
+        setExecutionRunId(result.runId);
+        setPhase("executing");
+      }
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Failed to start execution");
+    },
+  });
+
+  // ─── Plan approval ───
+  const approvePlan = useMutation({
+    mutationFn: async () => {
+      if (!executionRunId) throw new Error("No execution run");
+      return agentApi.approvePlan(executionRunId);
+    },
+    onSuccess: () => {
+      setPhase("executing");
+    },
+  });
+
+  const rejectPlan = useMutation({
+    mutationFn: async () => {
+      if (!executionRunId) throw new Error("No execution run");
+      return agentApi.rejectPlan(executionRunId);
+    },
+    onSuccess: () => {
+      setPhase("choosing");
+      setExecutionRunId(null);
+      setSelectedChoice(null);
+    },
+  });
+
+  // ─── Cancel / Retry ───
+  function handleCancel() {
+    guidedFlow.cancel();
+    navigate("/home");
+  }
+
+  function handleRetry() {
+    setPhase("investigating");
+    setInvestigationRunId(null);
+    setExecutionRunId(null);
+    setSelectedChoice(null);
+    setPlanSteps([]);
+    setWizardAdvanced(false);
+    guidedFlow.reset();
+    guidedFlow.start();
+    startInvestigation.mutate();
+  }
+
+  // ─── Journey phases ───
+  const journeyPhases = useMemo<JourneyPhase[]>(() => {
+    const phaseOrder: FlowPhase[] = ["investigating", "choosing", "planning", "executing", "completed"];
+    const currentIdx = phaseOrder.indexOf(phase);
+
+    function resolveStatus(phaseIdx: number): JourneyPhase["status"] {
+      if (phase === "failed" && phaseIdx >= currentIdx) return "error";
+      if (phaseIdx < currentIdx) return "completed";
+      if (phaseIdx === currentIdx) {
+        const activeLabels: Record<string, JourneyPhase["status"]> = {
+          investigating: "investigating",
+          choosing: "choosing",
+          planning: "planning",
+          executing: "executing",
+          completed: "completed",
+        };
+        return activeLabels[phase] ?? "pending";
+      }
+      return "pending";
+    }
+
+    return [
+      { id: "investigate", label: "Investigate", status: resolveStatus(0) },
+      { id: "choose", label: "Choose", status: resolveStatus(1) },
+      { id: "plan", label: "Plan", status: resolveStatus(2) },
+      { id: "execute", label: "Execute", status: resolveStatus(3) },
+      {
+        id: "done",
+        label: "Done",
+        status: resolveStatus(4),
+        detail: phase === "failed" ? "Something went wrong" : undefined,
+      },
+    ];
+  }, [phase]);
+
+  const currentPhaseIndex = journeyPhases.findIndex(
+    (p) => p.status !== "completed" && p.status !== "pending",
+  );
+
+  const containerSteps = journeyPhases.map((p) => ({
+    id: p.id,
+    label: p.label,
+    status: p.status === "investigating" || p.status === "choosing" || p.status === "planning" || p.status === "executing"
+      ? "active" as const
+      : p.status === "completed"
+        ? "completed" as const
+        : p.status === "error"
+          ? "error" as const
+          : "pending" as const,
+  }));
+
+  // ─── Render ───
+  return (
+    <div className="py-4">
+      <GuidedFlowContainer
+        title={goalTitle}
+        steps={containerSteps}
+        currentStepIndex={Math.max(0, currentPhaseIndex)}
+        onBack={() => navigate("/home")}
+        onCancel={handleCancel}
+      >
+        {/* Phase: Investigating */}
+        {phase === "investigating" && (
+          <InvestigationPanel
+            lines={investigation.findings}
+            isStreaming={investigation.isStreaming}
+            title={`Investigating: ${goalTitle}`}
+          />
+        )}
+
+        {/* Phase: Choosing */}
+        {phase === "choosing" && (
+          <div className="space-y-4">
+            <p className="text-sm text-white/60">
+              {guidedFlow.wizardResponse?.summary
+                ?? "Based on the investigation, here are your options. Click to select, then proceed."}
+            </p>
+
+            {guidedFlow.wizard?.unknowns && guidedFlow.wizard.unknowns.length > 0 && (
+              <div className="rounded-2xl border border-amber-300/10 bg-amber-300/[0.03] px-4 py-3">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-amber-200/60">
+                  Open questions
+                </p>
+                <ul className="mt-2 space-y-1">
+                  {guidedFlow.wizard.unknowns.map((unknown, i) => (
+                    <li key={i} className="text-xs leading-5 text-amber-100/50">{unknown}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            <div className="space-y-3">
+              {choices.map((choice) => (
+                <ChoiceCard
+                  key={choice.value}
+                  title={choice.label}
+                  description={choice.description}
+                  outcome={choice.outcome}
+                  risk={choice.risk}
+                  recommended={choice.recommended}
+                  reason={choice.reason}
+                  selected={selectedChoice === choice.value}
+                  onSelect={() => setSelectedChoice(choice.value)}
+                />
+              ))}
+            </div>
+
+            {selectedChoice && (
+              <ActionButton
+                onClick={() => executeChoice.mutate()}
+                disabled={executeChoice.isPending || guidedFlow.isContinuing}
+                className="w-full"
+              >
+                {executeChoice.isPending || guidedFlow.isContinuing
+                  ? "Working..."
+                  : selectedChoice === "explore"
+                    ? "Investigate further"
+                    : selectedChoice?.startsWith("clarify-")
+                      ? "Submit answer"
+                      : "Proceed"}
+              </ActionButton>
+            )}
+          </div>
+        )}
+
+        {/* Phase: Planning (awaiting plan approval) */}
+        {phase === "planning" && (
+          <PlanReviewVisual
+            title={`Plan for: ${goalTitle}`}
+            summary={execution.outputText.slice(0, 300)}
+            steps={planSteps}
+            assumptions={guidedFlow.wizard?.assumptions}
+            unknowns={guidedFlow.wizard?.unknowns}
+            riskLevel="low"
+            isApproving={approvePlan.isPending}
+            isRejecting={rejectPlan.isPending}
+            onApprove={() => approvePlan.mutate()}
+            onReject={() => rejectPlan.mutate()}
+          />
+        )}
+
+        {/* Phase: Executing */}
+        {phase === "executing" && !isAwaitingPlan && (
+          <div className="space-y-4">
+            <JourneyTracker
+              goalTitle={goalTitle}
+              phases={journeyPhases}
+              currentPhaseIndex={Math.max(0, currentPhaseIndex)}
+            />
+            <InvestigationPanel
+              lines={execution.outputText
+                .split("\n")
+                .filter((line) => line.trim().length > 0)
+                .map((text, i) => ({ id: `exec-${String(i)}`, text, type: "info" as const }))}
+              isStreaming={execution.connectionState === "streaming"}
+              title="Executing..."
+            />
+          </div>
+        )}
+
+        {/* Phase: Completed */}
+        {phase === "completed" && (
+          <div className="space-y-6">
+            <ShellCard className="text-center">
+              <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-3xl border border-emerald-400/20 bg-emerald-400/10">
+                <CheckCircle2 className="h-6 w-6 text-emerald-300" />
+              </div>
+              <h3 className="mt-4 text-lg font-semibold text-white">Done</h3>
+              <p className="mt-2 text-sm text-white/60">
+                Friday has completed the task for: {goalTitle}
+              </p>
+              {execution.outputText && (
+                <div className="mt-4 rounded-2xl border border-white/10 bg-white/[0.03] p-4 text-left">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/40">
+                    Result
+                  </p>
+                  <p className="mt-2 whitespace-pre-wrap text-xs leading-5 text-white/60">
+                    {execution.outputText.slice(0, 500)}
+                  </p>
+                </div>
+              )}
+            </ShellCard>
+
+            <div className="flex gap-3">
+              <Link to="/automations" className="flex-1">
+                <ActionButton tone="secondary" className="w-full">
+                  <RefreshCcw className="mr-2 h-4 w-4" />
+                  Automate this
+                </ActionButton>
+              </Link>
+              <Link to="/home" className="flex-1">
+                <ActionButton tone="primary" className="w-full">
+                  Back to Home
+                </ActionButton>
+              </Link>
+            </div>
+          </div>
+        )}
+
+        {/* Phase: Failed */}
+        {phase === "failed" && (
+          <div className="space-y-4">
+            <ShellCard className="text-center">
+              <h3 className="text-lg font-semibold text-rose-200">Something went wrong</h3>
+              <p className="mt-2 text-sm text-white/50">
+                {investigation.errorMessage ?? execution.errorMessage ?? "The operation could not be completed."}
+              </p>
+            </ShellCard>
+            <div className="flex gap-3">
+              <ActionButton tone="secondary" onClick={handleRetry} className="flex-1">
+                Try again
+              </ActionButton>
+              <Link to="/home" className="flex-1">
+                <ActionButton tone="primary" className="w-full">
+                  Back to Home
+                </ActionButton>
+              </Link>
+            </div>
+          </div>
+        )}
+      </GuidedFlowContainer>
+    </div>
+  );
+}

--- a/ui/src/routes/home-page.tsx
+++ b/ui/src/routes/home-page.tsx
@@ -1,0 +1,185 @@
+import { useMemo, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { ArrowRight, ChevronRight, Loader2, Sparkles } from "lucide-react";
+import { agentApi } from "@/lib/api/agent";
+import { systemApi } from "@/lib/api/system";
+import { GoalCard } from "@/components/guided/goal-card";
+import { OneClickAction } from "@/components/guided/one-click-action";
+import { JourneyTracker } from "@/components/guided/journey-tracker";
+import { ShellCard, StatusPill } from "@/components/core/primitives";
+import { useUserProfile } from "@/hooks/use-user-profile";
+import { getGoalCategoriesForProfile } from "@/lib/guided/goal-categories";
+import { buildGuidedFlowJourneyPhases, buildGuidedFlowCurrentPhaseIndex } from "@/lib/guided/flow-adapters";
+import type { FridayGoalCategory } from "@/lib/guided/goal-categories";
+
+function greetingForTimeOfDay(): string {
+  const hour = new Date().getHours();
+  if (hour < 6) return "Late night?";
+  if (hour < 12) return "Good morning.";
+  if (hour < 18) return "Good afternoon.";
+  return "Good evening.";
+}
+
+function RunSummaryCard(props: {
+  task: string;
+  status: string;
+  startedAt?: string;
+}) {
+  const elapsed = props.startedAt
+    ? Math.floor((Date.now() - new Date(props.startedAt).getTime()) / 60_000)
+    : 0;
+  const timeLabel = elapsed < 1 ? "Just now" : elapsed < 60 ? `${String(elapsed)}m ago` : `${String(Math.floor(elapsed / 60))}h ago`;
+
+  return (
+    <div className="flex items-start gap-3 rounded-2xl border border-white/10 bg-white/[0.02] px-4 py-3">
+      <StatusPill
+        tone={
+          props.status === "completed"
+            ? "success"
+            : props.status === "failed"
+              ? "danger"
+              : "neutral"
+        }
+      >
+        {props.status}
+      </StatusPill>
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm text-white/70">{props.task}</p>
+        <p className="mt-0.5 text-xs text-white/40">{timeLabel}</p>
+      </div>
+    </div>
+  );
+}
+
+export function HomePage() {
+  const navigate = useNavigate();
+  const { profileType } = useUserProfile();
+  const [hoveredGoal, setHoveredGoal] = useState<string | null>(null);
+
+  const goalCategories = useMemo(
+    () => getGoalCategoriesForProfile(profileType, 6),
+    [profileType],
+  );
+
+  const recentRunsQuery = useQuery({
+    queryKey: ["home", "recent-runs"],
+    queryFn: () => agentApi.listRuns({ limit: 3 }),
+    refetchInterval: 10_000,
+  });
+
+  const alertsQuery = useQuery({
+    queryKey: ["home", "alerts"],
+    queryFn: () => systemApi.listObservabilityAlerts({ status: "firing", limit: 2 }),
+    refetchInterval: 15_000,
+  });
+
+  const recentRuns = recentRunsQuery.data ?? [];
+  const activeRun = recentRuns.find(
+    (run) =>
+      run.status === "pending" ||
+      run.status === "executing" ||
+      run.status === "planning" ||
+      run.status === "awaiting_plan_approval" ||
+      run.status === "awaiting_clarification",
+  );
+
+  function handleGoalClick(category: FridayGoalCategory) {
+    navigate(`/flow/${encodeURIComponent(category.wizardId)}`);
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-3xl space-y-8 py-4">
+      {/* Greeting */}
+      <div className="space-y-1">
+        <p className="text-sm text-white/40">{greetingForTimeOfDay()}</p>
+        <h1 className="font-[var(--font-display)] text-3xl font-semibold tracking-tight text-white">
+          What do you want to achieve?
+        </h1>
+        <p className="text-sm leading-6 text-white/50">
+          Pick a goal. Friday will investigate, present options, and guide you step by step.
+        </p>
+      </div>
+
+      {/* Active flow */}
+      {activeRun && (
+        <JourneyTracker
+          goalTitle={activeRun.task}
+          phases={buildGuidedFlowJourneyPhases(null, false, activeRun.status === "executing")}
+          currentPhaseIndex={buildGuidedFlowCurrentPhaseIndex(
+            buildGuidedFlowJourneyPhases(null, false, activeRun.status === "executing"),
+          )}
+        />
+      )}
+
+      {/* Goal grid */}
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {goalCategories.map((category) => (
+          <GoalCard
+            key={category.id}
+            icon={category.icon}
+            title={category.title}
+            subtitle={category.subtitle}
+            outcome={category.outcome}
+            recommended={category.recommended}
+            onClick={() => handleGoalClick(category)}
+          />
+        ))}
+      </div>
+
+      {/* Show all goals link */}
+      {goalCategories.length < 10 && (
+        <button
+          type="button"
+          onClick={() => {
+            // Show all goals - could navigate to a goals index or expand the grid
+            navigate("/flow/browse");
+          }}
+          className="flex items-center gap-1.5 text-xs font-medium text-white/40 transition hover:text-white/70"
+        >
+          Show all goals
+          <ChevronRight className="h-3 w-3" />
+        </button>
+      )}
+
+      {/* Recent activity */}
+      {recentRuns.length > 0 && (
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/40">
+              Recent
+            </p>
+            <Link
+              to="/assistant"
+              className="flex items-center gap-1 text-xs text-white/40 transition hover:text-white/60"
+            >
+              Full dashboard
+              <ArrowRight className="h-3 w-3" />
+            </Link>
+          </div>
+          <div className="space-y-2">
+            {recentRuns.slice(0, 3).map((run) => (
+              <RunSummaryCard
+                key={run.id}
+                task={run.task}
+                status={run.status}
+                startedAt={run.startedAt}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Expert mode link */}
+      <div className="border-t border-white/[0.06] pt-4">
+        <Link
+          to="/assistant"
+          className="flex items-center gap-2 text-xs text-white/30 transition hover:text-white/50"
+        >
+          <Sparkles className="h-3.5 w-3.5" />
+          Switch to full Assistant dashboard (expert mode)
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/routes/onboarding-page.tsx
+++ b/ui/src/routes/onboarding-page.tsx
@@ -1,0 +1,208 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { ArrowRight, Cpu, MessageSquare, MousePointer2, PenTool, Search, Users, Wrench } from "lucide-react";
+import { useUserProfile, type UserProfileType } from "@/hooks/use-user-profile";
+import { ChoiceCard } from "@/components/guided/choice-card";
+import { ActionButton } from "@/components/core/primitives";
+import { cn } from "@/lib/utils/cn";
+
+type OnboardingStep = "welcome" | "profile" | "ready";
+
+const PROFILE_CHOICES: Array<{
+  type: UserProfileType;
+  title: string;
+  description: string;
+  outcome: string;
+  icon: typeof Wrench;
+}> = [
+  {
+    type: "developer",
+    title: "Developer",
+    description: "I write code and want help shipping, testing, reviewing, and automating my workflow.",
+    outcome: "Friday prioritizes build, fix, ship, and AI/SaaS goals.",
+    icon: Wrench,
+  },
+  {
+    type: "creator",
+    title: "Creator",
+    description: "I make content and want help creating, scheduling, and distributing across platforms.",
+    outcome: "Friday prioritizes content creation, social media, and automation goals.",
+    icon: PenTool,
+  },
+  {
+    type: "business",
+    title: "Business",
+    description: "I run a business and want help with operations, e-commerce, team, and data analysis.",
+    outcome: "Friday prioritizes e-commerce, team management, and trading goals.",
+    icon: Users,
+  },
+  {
+    type: "beginner",
+    title: "Just exploring",
+    description: "I'm new and want to see what Friday can do. Show me everything.",
+    outcome: "Friday shows all goals with gentle guidance.",
+    icon: Search,
+  },
+];
+
+function WelcomeStep(props: { onContinue: () => void }) {
+  const steps = [
+    {
+      icon: MessageSquare,
+      title: "Tell Friday your goal",
+      description: "Pick what you want to achieve. No technical knowledge needed.",
+    },
+    {
+      icon: Search,
+      title: "Friday investigates",
+      description: "Friday researches your situation, analyzes options, and finds the best approach.",
+    },
+    {
+      icon: MousePointer2,
+      title: "You click to decide",
+      description: "Friday presents clear options with recommendations. You just click to choose.",
+    },
+  ];
+
+  return (
+    <div className="space-y-8">
+      <div className="text-center">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--accent-strong)]">
+          Welcome to Friday
+        </p>
+        <h1 className="mt-3 font-[var(--font-display)] text-3xl font-semibold tracking-tight text-white">
+          Your AI assistant that gets things done
+        </h1>
+        <p className="mx-auto mt-3 max-w-md text-sm leading-6 text-white/50">
+          Friday helps you achieve complex goals with simple clicks. Here's how it works:
+        </p>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-3">
+        {steps.map((step, index) => (
+          <div
+            key={step.title}
+            className="rounded-3xl border border-white/10 bg-white/[0.02] p-5 text-center"
+          >
+            <div className="mx-auto flex h-10 w-10 items-center justify-center rounded-2xl border border-white/10 bg-white/[0.06]">
+              <step.icon className="h-5 w-5 text-[var(--accent-strong)]" />
+            </div>
+            <p className="mt-3 text-sm font-semibold text-white">{step.title}</p>
+            <p className="mt-1.5 text-xs leading-5 text-white/50">{step.description}</p>
+          </div>
+        ))}
+      </div>
+
+      <div className="text-center">
+        <ActionButton onClick={props.onContinue} className="px-8">
+          Get started
+          <ArrowRight className="ml-2 h-4 w-4" />
+        </ActionButton>
+      </div>
+    </div>
+  );
+}
+
+function ProfileStep(props: { onSelect: (type: UserProfileType) => void; selected: UserProfileType | null }) {
+  return (
+    <div className="space-y-6">
+      <div className="text-center">
+        <h2 className="font-[var(--font-display)] text-2xl font-semibold tracking-tight text-white">
+          What describes you best?
+        </h2>
+        <p className="mt-2 text-sm text-white/50">
+          This helps Friday show you the most relevant goals first. You can change this later.
+        </p>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        {PROFILE_CHOICES.map((choice) => (
+          <ChoiceCard
+            key={choice.type}
+            title={choice.title}
+            description={choice.description}
+            outcome={choice.outcome}
+            selected={props.selected === choice.type}
+            onSelect={() => props.onSelect(choice.type)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ReadyStep(props: { profileType: UserProfileType; onFinish: () => void }) {
+  const labels: Record<UserProfileType, string> = {
+    developer: "Developer",
+    creator: "Creator",
+    business: "Business",
+    beginner: "Explorer",
+  };
+
+  return (
+    <div className="space-y-6 text-center">
+      <div>
+        <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-3xl border border-emerald-400/20 bg-emerald-400/10">
+          <Cpu className="h-7 w-7 text-emerald-300" />
+        </div>
+        <h2 className="mt-4 font-[var(--font-display)] text-2xl font-semibold tracking-tight text-white">
+          You're all set
+        </h2>
+        <p className="mt-2 text-sm text-white/50">
+          Friday is configured for you as a <span className="font-medium text-white/70">{labels[props.profileType]}</span>.
+          Your home screen will show the most relevant goals for you.
+        </p>
+      </div>
+
+      <ActionButton onClick={props.onFinish} className="px-8">
+        Go to Home
+        <ArrowRight className="ml-2 h-4 w-4" />
+      </ActionButton>
+    </div>
+  );
+}
+
+export function OnboardingPage() {
+  const navigate = useNavigate();
+  const { setProfileType, markOnboarded } = useUserProfile();
+  const [step, setStep] = useState<OnboardingStep>("welcome");
+  const [selectedProfile, setSelectedProfile] = useState<UserProfileType | null>(null);
+
+  function handleProfileSelect(type: UserProfileType) {
+    setSelectedProfile(type);
+    setProfileType(type);
+    setStep("ready");
+  }
+
+  function handleFinish() {
+    markOnboarded();
+    navigate("/home", { replace: true });
+  }
+
+  return (
+    <div className="flex min-h-[calc(100vh-6rem)] items-center justify-center px-4">
+      <div className="w-full max-w-2xl">
+        {step === "welcome" && <WelcomeStep onContinue={() => setStep("profile")} />}
+        {step === "profile" && (
+          <ProfileStep selected={selectedProfile} onSelect={handleProfileSelect} />
+        )}
+        {step === "ready" && selectedProfile && (
+          <ReadyStep profileType={selectedProfile} onFinish={handleFinish} />
+        )}
+
+        {/* Step indicators */}
+        <div className="mt-8 flex items-center justify-center gap-2">
+          {(["welcome", "profile", "ready"] as const).map((s) => (
+            <div
+              key={s}
+              className={cn(
+                "h-1.5 rounded-full transition-all",
+                s === step ? "w-6 bg-[var(--accent-strong)]" : "w-1.5 bg-white/20",
+              )}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
… page

Replace the dashboard-dump default landing with an iOS-style goal-first experience. New users get a 3-step onboarding (welcome → profile → home), then pick from 10 visual goal cards that launch a guided flow: investigate (typewriter SSE) → choose (dynamic choice cards from wizard backend) → plan review (visual approve/reject) → execute (progress tracker) → result.

Key changes:
- New /home route as default landing with 10 goal categories filtered by user profile (developer/creator/business/beginner)
- New /onboarding route for first-time user profiling
- New /flow/:wizardId route for the full guided flow lifecycle
- 8 guided UI components (GoalCard, ChoiceCard, StepProgress, InvestigationPanel, PlanReviewVisual, JourneyTracker, OneClickAction, GuidedFlowContainer)
- 3 hooks (useGuidedFlow, useUserProfile, useInvestigationEvents)
- Backend: extended wizard types with choices metadata, added 10 wizard definitions, 3 new API routes (user-profile get/put, investigate)
- Wizard ↔ agent run integration: investigation results feed into wizard continueStep, choices derived from wizard response questions
- /assistant remains fully intact for expert users

## Summary

<!-- Brief description of what this PR does -->

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would break existing functionality)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor / cleanup
- [ ] 🛡️ Security fix

## Checklist

### Required
- [ ] Tests added/updated for changed behavior
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] `npm test` passes

### If Applicable
- [ ] Migration added → migration chain is contiguous (`npm run check:migrations`)
- [ ] SSD updated → markers present (`npm run check:ssd`)
- [ ] Adversarial tests not skipped (`npm run check:adversarial`)
- [ ] API surface changed → routes documented in SSD
- [ ] Security-sensitive change → adversarial test added

### Documentation
- [ ] SSD (`docs/distributed-architecture.md`) updated if architecture changed
- [ ] README updated if user-facing behavior changed
- [ ] CHANGELOG entry added

## Related Issues

<!-- Link to related issues: Fixes #123, Closes #456 -->
