### PR TITLE
fix: land serene-chaum audit remediation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -341,7 +341,7 @@
         "filename": "src/api/http/routes/friday-setup-routes.ts",
         "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
         "is_verified": false,
-        "line_number": 453
+        "line_number": 455
       }
     ],
     "src/observability/model/friday-observability.types.ts": [
@@ -359,7 +359,7 @@
         "filename": "src/providers/services/friday-provider-service.ts",
         "hashed_secret": "90c5d1358d128117989fc21f2897a25c99205e50",
         "is_verified": false,
-        "line_number": 51
+        "line_number": 52
       }
     ],
     "src/security/multi-tenant/api/friday-multi-tenant-security-api.types.ts": [
@@ -663,28 +663,28 @@
         "filename": "test/unit/api/auth/friday-auth-service.test.ts",
         "hashed_secret": "ce77798dc40945979f340e376e69b0d043c1e1e0",
         "is_verified": false,
-        "line_number": 465
+        "line_number": 466
       },
       {
         "type": "Secret Keyword",
         "filename": "test/unit/api/auth/friday-auth-service.test.ts",
         "hashed_secret": "05d83970b7ed1c839f218a5f611ed5ed89a43148",
         "is_verified": false,
-        "line_number": 485
+        "line_number": 486
       },
       {
         "type": "Secret Keyword",
         "filename": "test/unit/api/auth/friday-auth-service.test.ts",
         "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
         "is_verified": false,
-        "line_number": 512
+        "line_number": 513
       },
       {
         "type": "Secret Keyword",
         "filename": "test/unit/api/auth/friday-auth-service.test.ts",
         "hashed_secret": "1902e3d6fc4e78a0bcc50ba12b882769afbf4a8c",
         "is_verified": false,
-        "line_number": 652
+        "line_number": 653
       }
     ],
     "test/unit/api/auth/friday-token-validator.test.ts": [
@@ -817,7 +817,7 @@
         "filename": "test/unit/channels/lark/friday-lark-channel.test.ts",
         "hashed_secret": "5332dacad20a47ed30ac276f31420d348a122341",
         "is_verified": false,
-        "line_number": 151
+        "line_number": 152
       }
     ],
     "test/unit/channels/line/friday-line-channel.test.ts": [
@@ -835,7 +835,7 @@
         "filename": "test/unit/channels/qq/friday-qq-channel.test.ts",
         "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
         "is_verified": false,
-        "line_number": 117
+        "line_number": 118
       }
     ],
     "test/unit/channels/slack/friday-slack-channel.test.ts": [
@@ -1049,5 +1049,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-26T18:40:01Z"
+  "generated_at": "2026-03-27T04:58:16Z"
 }

--- a/docs/comprehensive-audit-report-2026-03-26.md
+++ b/docs/comprehensive-audit-report-2026-03-26.md
@@ -1,0 +1,269 @@
+# Friday v0.4.2 — 全面代码审计报告
+
+> **审计日期**: 2026-03-26
+> **分支**: `serene-chaum`
+> **范围**: 全部 src/ 源码（954个TS文件）、677个测试文件、63个迁移文件
+> **方法**: 逐行代码审查 + 静态分析 + 全量测试执行
+
+---
+
+## 审计总结
+
+| 严重度 | 数量 | 描述 |
+|--------|------|------|
+| **P0 (Critical)** | **1** | Hub Bootstrap 部分失败无资源清理 |
+| **P1 (High)** | **14** | 安全漏洞、运行时闭环缺陷、关闭序列缺失 |
+| **P2 (Medium)** | **39** | 类型安全、静默错误、性能、配置问题 |
+| **P3 (Low)** | **23** | 代码风格、文档、低风险边缘情况 |
+
+### 历史审计修复状态
+
+| 历史问题 | 状态 |
+|----------|------|
+| FRI-SEC-001 (认证绕过) | **已修复** |
+| FRI-SEC-002 (默认 token secret) | **已修复** (随机生成+持久化) |
+| FRI-SEC-004 (SHA-256 弱哈希) | **已修复** (Scrypt+自动迁移) |
+| FRI-SEC-005 (token 撤销) | **已修复** (内存撤销表) |
+| FRI-SEC-006 (PKCE state=verifier) | **已修复** (独立随机+TTL) |
+| CX-001 (batchSize=0 死循环) | **已修复** (MIN_BATCH_SIZE=1) |
+| CX-002 (approval before resume) | **已修复** |
+| CX-003 (expired approval 阻塞) | **已修复** (双重回退) |
+| CX-005 (when:"success" 条件边) | **已修复** |
+| CX-006 (transform config 形状) | **已修复** |
+| audit-fix #1 (shell 注入) | **已修复** (execFileSync) |
+| audit-fix #2 (路径穿越 12处) | **已修复** (resolveSafePath) |
+| API-ROUTE-001 (路由遮蔽) | **已修复** (specificity 算法) |
+| cx-api-audit 全部 P1/P2 | **已修复** |
+
+---
+
+## 基线检查结果
+
+| 检查项 | 结果 |
+|--------|------|
+| TypeScript 严格类型检查 (`tsc --noEmit`) | **通过** — 零错误 |
+| ESLint + Security 插件 | **2 错误** (import 排序，非阻塞) |
+| `@ts-ignore` / `@ts-nocheck` / `eslint-disable` | **零** |
+| `TODO` / `FIXME` / `HACK` 注释 | **零** (src/内) |
+| `as any` 类型转换 | **14 处** (5个文件) |
+| 空 `catch {}` 块 | **357 处** (139个文件) — 最大风险 |
+| `throw new Error()` (非 FridayDomainError) | **225 处** (81个文件) |
+
+---
+
+## P0 — Critical
+
+### P0-001: Hub Bootstrap 部分初始化失败无资源清理
+**文件**: `src/hub/friday-hub-bootstrap.ts:416-4896`
+
+`createFridayHub()` 无顶层 try/finally。如果 SQLite 初始化成功(L427)但后续服务初始化失败，SQLite 连接将永远不会关闭。
+
+**修复**: 添加 `finally` 块，在部分失败时关闭 `stateRuntime`。
+
+---
+
+## P1 — High (14 个)
+
+### 安全类
+
+#### P1-SEC-001: `web_fetch` SSRF guard 是可选依赖
+**文件**: `src/agent/tools/friday-agent-web-fetch-tool.ts:67,135-137`
+
+当 `ssrfGuard` 未注入时，工具直接使用 `fetch()` 而无任何 SSRF 防护。云元数据端点可被访问。
+
+#### P1-SEC-002: `browser:evaluate` 执行任意 JavaScript
+**文件**: `src/agent/tools/friday-agent-browser-tool.ts:867-868`
+
+LLM 提供的文本直接传入 `page.evaluate(text)`, 无沙箱、CSP 限制或作用域约束。
+
+#### P1-SEC-003: `desktop:file_operation` 无路径边界检查
+**文件**: `src/agent/tools/friday-agent-desktop-tool.ts:469-502`
+
+`file_operation` 动作（read/write/delete/move）的 `path` 参数直接来自 LLM，无工作空间边界验证。
+
+#### P1-SEC-004: Token 签名密钥无最小熵要求
+**文件**: `src/api/auth/friday-auth-service.types.ts:34`
+
+`tokenSecret` 接受任意字符串包括空字符串。无最小长度/熵检查。
+
+#### P1-SEC-005: Rate Limiter 为可选依赖
+**文件**: `src/api/auth/friday-auth-service.ts:181,198`
+
+`rateLimiter` 为可选参数。未注入时所有限流被静默跳过，允许无限暴力破解。
+
+#### P1-SEC-006: `safeEvaluateRules` 失败时 fail-open
+**文件**: `src/agent/runtime/friday-agent-runtime.ts:1984-2003`
+
+规则引擎崩溃时返回 `null`（无策略限制），所有运行和工具调用将绕过策略执行。
+
+### 运行时闭环类
+
+#### P1-RT-001: Workflow `resumeRun` 异步失败未标记 run 为 failed
+**文件**: `src/workflows/services/friday-workflow-execution-service.ts:1342-1347`
+
+`.catch()` 仅记录日志，不将 run 标记为 failed。Run 将永久停留在 `running` 状态。
+
+#### P1-RT-002: Workflow `retryRun` 同样问题
+**文件**: `src/workflows/services/friday-workflow-execution-service.ts:1469-1474`
+
+#### P1-RT-003: Workflow `recoverActiveRuns` 同样问题
+**文件**: `src/workflows/services/friday-workflow-execution-service.ts:1531-1536`
+
+#### P1-RT-004: `paused` runs 不在 `listActiveRuns` 结果中
+**文件**: `src/workflows/persistence/friday-workflow-run-repository.ts:183`
+
+重启后 paused runs 对恢复/超时扫描不可见，将成为孤儿。
+
+### 关闭序列类
+
+#### P1-SHUT-001: `observabilityService.scheduler` 未在 stop() 中停止
+**文件**: `src/hub/friday-hub-bootstrap.ts:3354, 4838-4872`
+
+#### P1-SHUT-002: `agentLearningBridge` 未在 stop() 中停止
+**文件**: `src/hub/friday-hub-bootstrap.ts:3381`
+
+#### P1-SHUT-003: `mcpAdapter` 未在 stop() 中关闭 — 子进程泄漏
+**文件**: `src/hub/friday-hub-bootstrap.ts:1274`
+
+### 通道类
+
+#### P1-CH-001: QQ 和 Lark 无 Zod 配置验证 schema
+**文件**: `src/channels/qq/friday-qq-channel.ts:347`, `src/channels/lark/friday-lark-channel.ts:332`
+
+手动 `as string` 类型转换，无运行时验证。
+
+---
+
+## P2 — Medium (39 个，按类别)
+
+### DAG/Workflow 引擎 (9)
+- DAG 边条件求值异常静默禁用边 (`friday-workflow-dag-scheduler.ts:108-121`)
+- Node machine: `failed` 同时是终态和有出站转换 (`friday-workflow-node-machine.ts:36,45`)
+- `updateRunStatus` 不执行状态机校验 (`friday-workflow-run-repository.ts:130-141`)
+- Approval 暂停绕过状态机 (running→paused 直接) (`friday-workflow-execution-service.ts:696`)
+- Retry delay 阻塞执行批次 (`friday-workflow-execution-service.ts:463-468`)
+- `String.replace` 只替换第一个出现 (`friday-workflow-node-executor.ts:186-189`)
+- 节点超时计时器未在成功完成时取消 (`friday-workflow-execution-service.ts:800-820`)
+- 租约 TTL 使用 `Date.now()` 而非注入时钟 (`friday-workflow-execution-service.ts:646`)
+- Trigger service 触发失败静默吞没 (5个 catch 块)
+
+### 安全 (5)
+- Master key 缓存无 TTL/失效机制 (`friday-secret-crypto.ts:76`)
+- `validateWithDns()` 有 TOCTOU 窗口 (`friday-agent-ssrf-guard.ts:543`)
+- `allowLocalBypassLogin` 允许 localhost 无凭证发 token (`friday-auth-service.ts:436`)
+- ReDoS 启发式检测不全面 (`condition-evaluator.ts:37-44`)
+- Master key 文件权限读取时不验证 (`friday-secret-crypto.ts:111-121`)
+
+### Agent 工具 (5)
+- `desktop:launch_app` 无应用白名单 (`friday-agent-desktop-tool.ts:447`)
+- `xhs:post` 图片路径无工作空间边界检查 (`friday-agent-xhs-tool.ts:160`)
+- `browser:upload` 路径验证不解析符号链接 (`friday-agent-browser-tool.ts:1176`)
+- Risk 分类仅覆盖 exec/write/edit (`friday-agent-tool-risk.ts:61-83`)
+- `sessions:send` 可触发递归无界代理执行 (`friday-agent-sessions-tool.ts:244`)
+
+### Hub Bootstrap (5)
+- `configManager` 永久为 stub (`friday-hub-bootstrap.ts:479`)
+- `memoryState` 永久为 stub (`friday-hub-bootstrap.ts:481`)
+- 规则引擎加载失败被静默吞没 (`friday-hub-bootstrap.ts:584-608`)
+- `hubState` 在清理前即设为 "stopped" (`friday-hub-bootstrap.ts:4840`)
+- 默认管理员用户在非生产环境可无密码 (`friday-hub-bootstrap.ts:441-448`)
+
+### 通道 (5)
+- Slack Socket Mode 无重连 (`slack-service.ts`)
+- Signal SSE 无重连 (`signal-service.ts:176-189`)
+- IRC socket 断连无重连 (`irc-service.ts:188-192`)
+- QQ 重连无指数退避 (`friday-qq-channel.ts:190`)
+- WhatsApp `appSecret` 可选导致签名验证可跳过 (`whatsapp-config.schema.ts:25`)
+
+### Agent Runtime (3)
+- Planning gate `seqCounters` Map 永不清理 (`friday-agent-planning-gate.ts:247`)
+- Tool call 限制是后循环检查 (`friday-agent-runtime.ts:1548`)
+- 无子代理深度限制在此层 (`friday-agent-runtime.ts`)
+
+### 数据层 (3)
+- `SQLiteLayer.close()` 非幂等 (`friday-sqlite-layer.ts:50-53`)
+- 42 处 `JSON.parse(row.x) as Type` 无运行时验证
+- 4 处 P1 级复杂类型转换在 agent run repository
+
+### API 层 (2)
+- Agent/session/memory/webhook 变更端点缺少限流
+- 5 个通道缺少 capability contract
+
+### 可观测性 (2)
+- 审计轨迹仅内存存储 (`audit-trail.ts`)
+- Alert/dashboard 数据无界增长 (`alert-engine.ts`, `dashboard-data-provider.ts`)
+
+---
+
+## 关键闭环验证结果
+
+### Agent Runtime `executeRun()` — **通过**
+- 6 项资源（abortTimer, externalAbort listener, progressTimer, 2 subagent listeners, seqCounters entry）全部在 `finally` 块中清理
+- 工具级 `executeToolCall()` 也通过 `finally` 清理
+- 状态机覆盖所有状态转换路径
+- 超时/最大迭代/最大工具调用限制全部强制执行
+
+### Workflow Engine — **有条件通过**
+- 状态机转换基本完整
+- CX-002/003/005/006 全部已修复
+- **但**: resumeRun/retryRun/recoverActiveRuns 的 catch 块不标记 failed (P1)
+- **但**: paused runs 对恢复扫描不可见 (P1)
+
+### Hub Bootstrap — **有条件通过**
+- 所有服务成功布线
+- CORS 默认禁用（非通配符）
+- **但**: 关闭序列缺 3 项 (P1)
+- **但**: 部分失败无清理 (P0)
+
+### 10 通道闭环 — **5/10 完整**
+- **完整**: Discord, Telegram, WhatsApp, Webchat, Lark (带重连)
+- **缺失重连**: Slack Socket Mode, Signal SSE, IRC
+- **缺 schema**: QQ, Lark
+
+### API 层 — **通过**
+- 45 个路由文件全部注册
+- Auth middleware 通过类型系统强制执行 (fail-closed)
+- 安全头全路径覆盖
+- UI-Backend 100% 对齐（6 个 UI 客户端全部匹配）
+
+---
+
+## 代码质量热点
+
+### 最高风险文件 (silent catch 数量)
+1. `agent/runtime/friday-agent-runtime.ts` — 16 处
+2. `system/companion/friday-system-named-pipe-bridge.ts` — 11 处
+3. `system/companion/friday-system-unix-socket-bridge.ts` — 11 处
+4. `workflows/runtime/friday-workflow-runtime.ts` — 9 处
+5. `api/runtime/friday-deterministic-pipeline-runtime.ts` — 9 处
+
+### `as any` 安全分析
+- **高风险** (5处): `friday-satellite-pairing-routes.ts` — RBAC scope 声明绕过类型联合
+- **中风险** (4处): `friday-provider-fallback.ts` — 错误对象属性提取
+- **低风险** (5处): `friday-desktop-adapters.ts`, `friday-billing-reconciliation-job.ts`
+
+---
+
+## 建议修复优先级
+
+### 立即修复 (P0 + 关键 P1)
+1. Hub bootstrap 添加 `finally` 清理块
+2. SSRF guard 设为必选依赖
+3. Workflow resumeRun/retryRun/recoverActiveRuns catch 块添加 failed 标记
+4. Hub stop() 添加 observability/learning/mcp 清理
+5. `paused` 加入 `listActiveRuns` 查询
+
+### 短期修复 (其余 P1)
+6. Browser evaluate 添加沙箱/限制
+7. Desktop file_operation 添加路径边界检查
+8. Token secret 添加最小熵要求
+9. Rate limiter 设为必选或添加显著警告
+10. QQ/Lark 添加 Zod config schema
+11. safeEvaluateRules 改为 fail-closed 或添加日志
+
+### 中期改进 (P2)
+12. Signal/Slack/IRC 添加重连逻辑
+13. Agent/session/webhook 端点添加限流
+14. JSON parse 关键路径添加运行时验证
+15. SQLite close() 添加幂等性
+16. 清理 357 个 silent catch（至少添加日志）

--- a/src/acceptance/engine/assertion-engine.ts
+++ b/src/acceptance/engine/assertion-engine.ts
@@ -1,3 +1,5 @@
+import { FridayDomainError } from "#errors";
+
 /**
  * Assertion Engine — evaluate acceptance assertions against artifact content.
  *
@@ -658,16 +660,16 @@ function executeSandboxedCustomAssertion(
   }) as Partial<FridayAcceptanceVerdict> | undefined;
 
   if (!result || typeof result !== "object") {
-    throw new Error("Sandboxed custom check must return a verdict object");
+    throw new FridayDomainError("VALIDATION_ERROR", "Sandboxed custom check must return a verdict object", { httpStatus: 400 });
   }
 
   const verdict = result.verdict;
   const severity = result.severity;
   if (verdict !== "pass" && verdict !== "fail" && verdict !== "warn") {
-    throw new Error("Sandboxed custom check returned an invalid verdict");
+    throw new FridayDomainError("VALIDATION_ERROR", "Sandboxed custom check returned an invalid verdict", { httpStatus: 400 });
   }
   if (severity !== "critical" && severity !== "major" && severity !== "minor" && severity !== "info") {
-    throw new Error("Sandboxed custom check returned an invalid severity");
+    throw new FridayDomainError("VALIDATION_ERROR", "Sandboxed custom check returned an invalid severity", { httpStatus: 400 });
   }
 
   const evidence = Array.isArray(result.evidence)

--- a/src/acceptance/engine/fixture-manager.ts
+++ b/src/acceptance/engine/fixture-manager.ts
@@ -1,3 +1,5 @@
+import { FridayDomainError } from "#errors";
+
 /**
  * Fixture Manager — load, cache, and manage test fixtures and mock data.
  *
@@ -86,7 +88,7 @@ export class AcceptanceFixtureManager {
     }
 
     if (!overwrite && nsMap.has(fixture.id)) {
-      throw new Error(`Fixture "${fixture.id}" already exists in namespace "${ns}". Use overwrite: true to replace.`);
+      throw new FridayDomainError("VALIDATION_ERROR", `Fixture "${fixture.id}" already exists in namespace "${ns}". Use overwrite: true to replace.`, { httpStatus: 400 });
     }
 
     nsMap.set(fixture.id, fixture);

--- a/src/acceptance/engine/test-suite-runner.ts
+++ b/src/acceptance/engine/test-suite-runner.ts
@@ -1,3 +1,5 @@
+import { FridayDomainError } from "#errors";
+
 /**
  * Test Suite Runner — execute acceptance test suites against agent/skill outputs.
  *
@@ -76,7 +78,7 @@ export class InMemoryTestRegistry implements FridayAcceptanceTestRegistry {
 
   register(test: FridayAcceptanceTest): void {
     if (this.byId.has(test.id)) {
-      throw new Error(`Acceptance test with ID "${test.id}" is already registered`);
+      throw new FridayDomainError("VALIDATION_ERROR", `Acceptance test with ID "${test.id}" is already registered`, { httpStatus: 400 });
     }
 
     this.byId.set(test.id, test);
@@ -661,8 +663,9 @@ export class AcceptanceTestSuiteRunner {
     if (this.onRollback) {
       try {
         this.onRollback(event);
-      } catch {
+      } catch (err) {
         // Rollback emission should not break deterministic run completion.
+        console.warn("[friday][test-suite-runner] rollback emission failed:", err instanceof Error ? err.message : String(err));
       }
     }
 

--- a/src/acceptance/model/friday-acceptance.types.ts
+++ b/src/acceptance/model/friday-acceptance.types.ts
@@ -1,3 +1,5 @@
+import { FridayDomainError } from "#errors";
+
 /**
  * Acceptance Testing Layer — Domain Model and Data Contract.
  *
@@ -299,7 +301,7 @@ export function assertAcceptanceRunStateTransition(
   to: AcceptanceRunState,
 ): void {
   if (!canTransitionAcceptanceRunState(from, to)) {
-    throw new Error(`Invalid acceptance run state transition: ${from} -> ${to}`);
+    throw new FridayDomainError("VALIDATION_ERROR", `Invalid acceptance run state transition: ${from} -> ${to}`, { httpStatus: 400 });
   }
 }
 

--- a/src/acceptance/persistence/friday-acceptance-repository.ts
+++ b/src/acceptance/persistence/friday-acceptance-repository.ts
@@ -12,7 +12,8 @@ function parseJson<T>(value: string | null | undefined, fallback: T): T {
   if (!value) return fallback;
   try {
     return JSON.parse(value) as T;
-  } catch {
+  } catch (err) {
+    console.warn("[friday][acceptance-repository] JSON parse failed:", err instanceof Error ? err.message : String(err));
     return fallback;
   }
 }

--- a/src/agent/autonomous/friday-autonomous-engine.ts
+++ b/src/agent/autonomous/friday-autonomous-engine.ts
@@ -10,6 +10,8 @@
  * @module agent/autonomous
  */
 
+import { FridayDomainError } from "#errors";
+
 import type {
   CreateFridayAutonomousEngineDeps,
   FridayAutonomousActionResult,
@@ -118,7 +120,8 @@ export function createFridayAutonomousEngine(
       const result = await desktopSessionManager.executeAction({ type: "screenshot" });
       if (result.status === "failed") return null;
       return result.screenshotBase64 ?? null;
-    } catch {
+    } catch (err) {
+      console.warn("[friday][autonomous-engine] desktop screenshot failed:", err instanceof Error ? err.message : String(err));
       return null;
     }
   }
@@ -128,7 +131,8 @@ export function createFridayAutonomousEngine(
     try {
       const result = await browserManager.screenshot(sessionId);
       return result.base64;
-    } catch {
+    } catch (err) {
+      console.warn("[friday][autonomous-engine] browser screenshot failed:", err instanceof Error ? err.message : String(err));
       return null;
     }
   }
@@ -138,7 +142,8 @@ export function createFridayAutonomousEngine(
     try {
       const result = await browserManager.snapshot(sessionId);
       return result.content;
-    } catch {
+    } catch (err) {
+      console.warn("[friday][autonomous-engine] browser snapshot failed:", err instanceof Error ? err.message : String(err));
       return null;
     }
   }
@@ -148,7 +153,8 @@ export function createFridayAutonomousEngine(
     try {
       const elements = await desktopSessionManager.searchElements(query);
       return JSON.stringify(elements, null, 2);
-    } catch {
+    } catch (err) {
+      console.warn("[friday][autonomous-engine] desktop element search failed:", err instanceof Error ? err.message : String(err));
       return null;
     }
   }
@@ -466,7 +472,8 @@ export function createFridayAutonomousEngine(
         };
       }
       return { passed: false, actual: result.response };
-    } catch {
+    } catch (err) {
+      console.warn("[friday][autonomous-engine] verification failed:", err instanceof Error ? err.message : String(err));
       return { passed: false, actual: "Verification failed due to error" };
     }
   }
@@ -522,7 +529,8 @@ export function createFridayAutonomousEngine(
           item.verification,
         ),
       );
-    } catch {
+    } catch (err) {
+      console.warn("[friday][autonomous-engine] plan decomposition failed:", err instanceof Error ? err.message : String(err));
       return [createStep(goalId, 0, "Execute the goal directly", "composite")];
     }
   }
@@ -557,7 +565,7 @@ export function createFridayAutonomousEngine(
    */
   function updateGoal(goalId: UUID, updates: Partial<FridayAutonomousGoal>): FridayAutonomousGoal {
     const current = goals.get(goalId);
-    if (!current) throw new Error(`Goal ${goalId} not found`);
+    if (!current) throw new FridayDomainError("NOT_FOUND", `Goal ${goalId} not found`, { httpStatus: 404 });
     const updated = { ...current, ...updates } as FridayAutonomousGoal;
     goals.set(goalId, updated);
     return updated;
@@ -568,7 +576,7 @@ export function createFridayAutonomousEngine(
    */
   function updateStep(stepId: UUID, updates: Partial<FridayAutonomousStep>): FridayAutonomousStep {
     const current = steps.get(stepId);
-    if (!current) throw new Error(`Step ${stepId} not found`);
+    if (!current) throw new FridayDomainError("NOT_FOUND", `Step ${stepId} not found`, { httpStatus: 404 });
     const updated = { ...current, ...updates } as FridayAutonomousStep;
     steps.set(stepId, updated);
     return updated;

--- a/src/agent/mcp/friday-mcp-adapter.ts
+++ b/src/agent/mcp/friday-mcp-adapter.ts
@@ -1,3 +1,4 @@
+import { FridayDomainError } from "#errors";
 import { spawn } from "node:child_process";
 
 import { FRIDAY_VERSION } from "../../lib/version.js";
@@ -207,8 +208,8 @@ export function parseFridayMcpServersFromEnv(
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
-  } catch {
-    warn("[friday] WARNING: FRIDAY_MCP_SERVERS is not valid JSON; MCP adapter disabled.");
+  } catch (err) {
+    warn(`[friday] WARNING: FRIDAY_MCP_SERVERS is not valid JSON; MCP adapter disabled: ${err instanceof Error ? err.message : String(err)}`);
     return [];
   }
 
@@ -1059,7 +1060,7 @@ function createHttpMcpSession(params: {
   return {
     async request(method, requestParams, options): Promise<unknown> {
       if (closed) {
-        throw new Error(`MCP session is closed for server '${params.server.id}'`);
+        throw new FridayDomainError("NOT_INITIALIZED", `MCP session is closed for server '${params.server.id}'`, { httpStatus: 503 });
       }
 
       const id = nextId;
@@ -1082,7 +1083,7 @@ function createHttpMcpSession(params: {
       const message = normalizeRecord(response);
       if (Object.prototype.hasOwnProperty.call(message, "error")) {
         const rpcError = normalizeRpcError(message.error);
-        throw new Error(`MCP error ${String(rpcError.code)}: ${rpcError.message}`);
+        throw new FridayDomainError("INTERNAL_ERROR", `MCP error ${String(rpcError.code)}: ${rpcError.message}`, { httpStatus: 500 });
       }
 
       return message.result;
@@ -1130,7 +1131,7 @@ async function sendHttpRpc(
   if (input.signal) {
     if (input.signal.aborted) {
       clearTimeout(timeout);
-      throw new Error("MCP HTTP request aborted");
+      throw new FridayDomainError("INTERNAL_ERROR", "MCP HTTP request aborted", { httpStatus: 500 });
     }
     const onAbort = () => timeoutController.abort(input.signal?.reason);
     input.signal.addEventListener("abort", onAbort, { once: true });
@@ -1150,7 +1151,7 @@ async function sendHttpRpc(
 
     if (!response.ok) {
       const body = await response.text().catch(() => "");
-      throw new Error(`MCP HTTP ${String(response.status)} ${response.statusText}${body ? `: ${body}` : ""}`);
+      throw new FridayDomainError("INTERNAL_ERROR", `MCP HTTP ${String(response.status)} ${response.statusText}${body ? `: ${body}` : ""}`, { httpStatus: 500 });
     }
 
     const rawText = await response.text();
@@ -1160,8 +1161,9 @@ async function sendHttpRpc(
 
     try {
       return JSON.parse(rawText);
-    } catch {
-      throw new Error("MCP HTTP response is not valid JSON");
+    } catch (err) {
+      console.warn("[friday][mcp-adapter] parse-http-response:", err instanceof Error ? err.message : String(err));
+      throw new FridayDomainError("INTERNAL_ERROR", "MCP HTTP response is not valid JSON", { httpStatus: 500 });
     }
   } catch (error) {
     throw toError(error);
@@ -1244,7 +1246,7 @@ function createStdioMcpSession(params: {
   return {
     async request(method, requestParams, options): Promise<unknown> {
       if (isClosed) {
-        throw new Error(`MCP session is closed for server '${params.server.id}'`);
+        throw new FridayDomainError("NOT_INITIALIZED", `MCP session is closed for server '${params.server.id}'`, { httpStatus: 503 });
       }
 
       const id = nextId;
@@ -1313,8 +1315,9 @@ function createStdioMcpSession(params: {
             params: requestParams,
           },
         );
-      } catch {
+      } catch (err) {
         // Best-effort notification only.
+        console.warn("[friday][mcp-adapter] send-notification:", err instanceof Error ? err.message : String(err));
       }
     },
 
@@ -1332,14 +1335,16 @@ function createStdioMcpSession(params: {
             params: {},
           },
         );
-      } catch {
+      } catch (err) {
         // ignore
+        console.warn("[friday][mcp-adapter] write-exit-frame:", err instanceof Error ? err.message : String(err));
       }
 
       try {
         child.stdin.end();
-      } catch {
+      } catch (err) {
         // ignore
+        console.warn("[friday][mcp-adapter] end-stdin:", err instanceof Error ? err.message : String(err));
       }
 
       await Promise.race([
@@ -1350,8 +1355,9 @@ function createStdioMcpSession(params: {
       if (!isClosed) {
         try {
           child.kill("SIGTERM");
-        } catch {
+        } catch (err) {
           // ignore
+          console.warn("[friday][mcp-adapter] kill-sigterm:", err instanceof Error ? err.message : String(err));
         }
         await Promise.race([
           exitPromise,
@@ -1362,8 +1368,9 @@ function createStdioMcpSession(params: {
       if (!isClosed) {
         try {
           child.kill("SIGKILL");
-        } catch {
+        } catch (err) {
           // ignore
+          console.warn("[friday][mcp-adapter] kill-sigkill:", err instanceof Error ? err.message : String(err));
         }
       }
     },
@@ -1430,7 +1437,7 @@ function* decodeFrames(
     const headerText = buffer.subarray(0, headerEnd).toString("utf8");
     const contentLength = readContentLength(headerText);
     if (contentLength < 0) {
-      throw new Error("MCP frame missing Content-Length header");
+      throw new FridayDomainError("VALIDATION_ERROR", "MCP frame missing Content-Length header", { httpStatus: 400 });
     }
 
     const messageStart = headerEnd + FRAME_SEPARATOR.length;

--- a/src/agent/persistence/friday-agent-automation-repository.ts
+++ b/src/agent/persistence/friday-agent-automation-repository.ts
@@ -1,6 +1,7 @@
 import type Database from "better-sqlite3";
 
 import { FridayDomainError } from "#errors";
+import { safeJsonParse } from "#utilities";
 
 import { FRIDAY_AGENT_ERROR_CODES } from "../friday-agent.constants.js";
 import type {
@@ -57,15 +58,9 @@ function rowToRecord(row: FridayAgentAutomationRow): FridayAgentAutomationRecord
     description: row.description ?? undefined,
     sourceRunId: row.source_run_id ?? undefined,
     taskTemplate: row.task_template,
-    variables: row.variables
-      ? (JSON.parse(row.variables) as Record<string, string>)
-      : undefined,
-    skillIds: row.skill_ids
-      ? (JSON.parse(row.skill_ids) as string[])
-      : undefined,
-    workflowIds: row.workflow_ids
-      ? (JSON.parse(row.workflow_ids) as string[])
-      : undefined,
+    variables: safeJsonParse<Record<string, string>>(row.variables),
+    skillIds: safeJsonParse<string[]>(row.skill_ids),
+    workflowIds: safeJsonParse<string[]>(row.workflow_ids),
     triggerId: row.trigger_id ?? undefined,
     schedule: row.schedule_cron_expr
       ? {

--- a/src/agent/persistence/friday-agent-run-event-repository.ts
+++ b/src/agent/persistence/friday-agent-run-event-repository.ts
@@ -1,4 +1,5 @@
 import type Database from "better-sqlite3";
+import { safeJsonParse } from "#utilities";
 
 // ─── Run event record ───
 
@@ -30,7 +31,7 @@ function rowToRecord(row: FridayAgentRunEventRow): FridayAgentRunEventRecord {
     runId: row.run_id,
     seq: row.seq,
     eventName: row.event_name,
-    payload: JSON.parse(row.payload_json) as Record<string, unknown>,
+    payload: safeJsonParse<Record<string, unknown>>(row.payload_json) ?? {},
     emittedAt: row.emitted_at,
     createdAt: row.created_at,
   };

--- a/src/agent/persistence/friday-agent-run-repository.ts
+++ b/src/agent/persistence/friday-agent-run-repository.ts
@@ -1,6 +1,7 @@
 import type Database from "better-sqlite3";
 
 import { FridayDomainError } from "#errors";
+import { safeJsonParse } from "#utilities";
 
 import { FRIDAY_AGENT_ACTIVE_STATUSES, FRIDAY_AGENT_ERROR_CODES } from "../friday-agent.constants.js";
 import type {
@@ -13,6 +14,7 @@ import type {
   FridayAgentTestResult,
 } from "../model/friday-agent.types.js";
 import type { FridayAgentContextCostSummary } from "../runtime/friday-agent-runtime.types.js";
+
 import type { FridayResolvedAgentTaskProfile } from "../runtime/friday-agent-task-profile.js";
 
 // ─── Row shape from SQLite ───
@@ -57,12 +59,8 @@ function rowToRecord(row: FridayAgentRunRow): FridayAgentRunRecord {
     model: row.model ?? undefined,
     attempt: row.attempt,
     maxAttempts: row.max_attempts,
-    artifacts: row.artifacts
-      ? (JSON.parse(row.artifacts) as FridayAgentArtifact[])
-      : undefined,
-    testResults: row.test_results
-      ? (JSON.parse(row.test_results) as FridayAgentTestResult[])
-      : undefined,
+    artifacts: safeJsonParse<FridayAgentArtifact[]>(row.artifacts),
+    testResults: safeJsonParse<FridayAgentTestResult[]>(row.test_results),
     errorCode: row.error_code ?? undefined,
     errorMessage: row.error_message ?? undefined,
     createdAt: row.created_at,
@@ -72,24 +70,14 @@ function rowToRecord(row: FridayAgentRunRow): FridayAgentRunRecord {
     usageInput: row.usage_input ?? undefined,
     usageOutput: row.usage_output ?? undefined,
     costUsd: row.cost_usd ?? undefined,
-    planReview: row.plan_review_json
-      ? (JSON.parse(row.plan_review_json) as FridayAgentPlanReviewPayload)
-      : undefined,
-    actualExecution: row.actual_execution_json
-      ? (JSON.parse(row.actual_execution_json) as FridayAgentActualExecution)
-      : undefined,
-    constraints: row.constraints_json && row.constraints_json !== "{}"
-      ? (JSON.parse(row.constraints_json) as FridayAgentRunConstraints)
-      : undefined,
+    planReview: safeJsonParse<FridayAgentPlanReviewPayload>(row.plan_review_json),
+    actualExecution: safeJsonParse<FridayAgentActualExecution>(row.actual_execution_json),
+    constraints: safeJsonParse<FridayAgentRunConstraints>(row.constraints_json && row.constraints_json !== "{}" ? row.constraints_json : undefined),
     responseText: row.response_text ?? undefined,
     summary: row.summary ?? undefined,
     artifactDir: row.artifact_dir ?? undefined,
-    contextCostSummary: row.context_cost_summary_json
-      ? (JSON.parse(row.context_cost_summary_json) as FridayAgentContextCostSummary)
-      : undefined,
-    taskProfile: row.task_profile_json
-      ? (JSON.parse(row.task_profile_json) as FridayResolvedAgentTaskProfile)
-      : undefined,
+    contextCostSummary: safeJsonParse<FridayAgentContextCostSummary>(row.context_cost_summary_json),
+    taskProfile: safeJsonParse<FridayResolvedAgentTaskProfile>(row.task_profile_json),
   };
 }
 

--- a/src/agent/persistence/friday-subagent-run-repository.ts
+++ b/src/agent/persistence/friday-subagent-run-repository.ts
@@ -1,6 +1,7 @@
 import type Database from "better-sqlite3";
 
 import { FridayDomainError } from "#errors";
+import { safeJsonParse } from "#utilities";
 
 import { FRIDAY_SUBAGENT_ERROR_CODES } from "../subagent/friday-subagent-constants.js";
 import type {
@@ -46,9 +47,7 @@ function rowToRecord(row: FridaySubagentRunRow): FridaySubagentRunRecord {
     model: row.model ?? undefined,
     depth: row.depth,
     status: row.status as FridaySubagentRunStatus,
-    outcome: row.outcome
-      ? (JSON.parse(row.outcome) as FridaySubagentOutcome)
-      : undefined,
+    outcome: safeJsonParse<FridaySubagentOutcome>(row.outcome),
     createdAt: row.created_at,
     startedAt: row.started_at ?? undefined,
     completedAt: row.completed_at ?? undefined,

--- a/src/agent/runtime/friday-agent-context-engine.ts
+++ b/src/agent/runtime/friday-agent-context-engine.ts
@@ -50,7 +50,8 @@ export async function notifyFridayContextEngineAfterTurn(
 ): Promise<void> {
   try {
     await Promise.resolve(engine?.afterTurn?.(input));
-  } catch {
+  } catch (err) {
     // Preview hook failures must never fail an agent run.
+    console.warn("[friday][agent-context-engine] afterTurn hook failed:", err instanceof Error ? err.message : String(err));
   }
 }

--- a/src/agent/runtime/friday-agent-event-emitter.ts
+++ b/src/agent/runtime/friday-agent-event-emitter.ts
@@ -50,8 +50,9 @@ export function createFridayAgentEventEmitter(): FridayAgentEventEmitter {
       for (const listener of set) {
         try {
           listener(payload);
-        } catch {
+        } catch (err) {
           // Swallow listener errors to prevent breaking the agent loop
+          console.warn("[friday][agent-event-emitter] listener error:", err instanceof Error ? err.message : String(err));
         }
       }
     },

--- a/src/agent/runtime/friday-agent-llm-client.ts
+++ b/src/agent/runtime/friday-agent-llm-client.ts
@@ -673,7 +673,8 @@ async function* parseOpenAISSEStream(
           for (const [, tc] of toolCalls) {
             let input: Record<string, unknown> = {};
             if (tc.args) {
-              try { input = JSON.parse(tc.args) as Record<string, unknown>; } catch {
+              try { input = JSON.parse(tc.args) as Record<string, unknown>; } catch (err) {
+                console.warn("[friday][agent-llm-client] tool call args parse failed:", err instanceof Error ? err.message : String(err));
                 input = { _parseError: true, _rawJson: tc.args };
               }
             }
@@ -693,7 +694,7 @@ async function* parseOpenAISSEStream(
       }
 
       let event: Record<string, unknown>;
-      try { event = JSON.parse(data) as Record<string, unknown>; } catch { continue; }
+      try { event = JSON.parse(data) as Record<string, unknown>; } catch (err) { console.warn("[friday][agent-llm-client] SSE event parse failed:", err instanceof Error ? err.message : String(err)); continue; }
 
       // Handle usage
       const usage = event.usage as Record<string, unknown> | undefined;
@@ -740,7 +741,8 @@ async function* parseOpenAISSEStream(
         for (const [, tc] of toolCalls) {
           let input: Record<string, unknown> = {};
           if (tc.args) {
-            try { input = JSON.parse(tc.args) as Record<string, unknown>; } catch {
+            try { input = JSON.parse(tc.args) as Record<string, unknown>; } catch (err) {
+              console.warn("[friday][agent-llm-client] tool call args parse failed:", err instanceof Error ? err.message : String(err));
               input = { _parseError: true, _rawJson: tc.args };
             }
           }
@@ -798,7 +800,8 @@ async function* parseAnthropicSSEStream(
       let event: Record<string, unknown>;
       try {
         event = JSON.parse(data) as Record<string, unknown>;
-      } catch {
+      } catch (err) {
+        console.warn("[friday][agent-llm-client] Anthropic SSE parse failed:", err instanceof Error ? err.message : String(err));
         continue;
       }
 
@@ -842,8 +845,9 @@ async function* parseAnthropicSSEStream(
           if (toolInputJson) {
             try {
               input = JSON.parse(toolInputJson) as Record<string, unknown>;
-            } catch {
+            } catch (err) {
               // Malformed JSON from LLM — flag so runtime can produce a helpful error
+              console.warn("[friday][agent-llm-client] tool input JSON malformed:", err instanceof Error ? err.message : String(err));
               input = { _parseError: true, _rawJson: toolInputJson };
             }
           }

--- a/src/agent/runtime/friday-agent-planning-gate.ts
+++ b/src/agent/runtime/friday-agent-planning-gate.ts
@@ -49,6 +49,8 @@ export interface FridayAgentPlanningGateService {
   rejectPlan(input: {
     runId: string;
   }): FridayAgentRuntimeResult;
+  /** P2-RUNTIME: Clean up internal state for a completed/failed run. */
+  cleanupRun(runId: string): void;
 }
 
 export interface CreateFridayAgentPlanningGateServiceDeps {
@@ -753,6 +755,11 @@ export function createFridayAgentPlanningGateService(
         usageOutput: 0,
         finalResponse: response,
       };
+    },
+
+    // P2-RUNTIME-005: Clean up seqCounters entry to prevent memory leak
+    cleanupRun(runId: string): void {
+      seqCounters.delete(runId);
     },
   };
 }

--- a/src/agent/runtime/friday-agent-runtime.ts
+++ b/src/agent/runtime/friday-agent-runtime.ts
@@ -164,7 +164,8 @@ export function createFridayAgentRuntime(
             runEventRepository.list(reader, runId),
           );
           current = existingEvents.at(-1)?.seq ?? 0;
-        } catch {
+        } catch (err) {
+          console.warn("[friday][agent-runtime] seq-counter-recover:", err instanceof Error ? err.message : String(err));
           current = 0;
         }
       } else {
@@ -197,8 +198,9 @@ export function createFridayAgentRuntime(
             createdAt: now,
           }),
         );
-      } catch {
+      } catch (err) {
         // Non-fatal: event persistence failure should not kill the run
+        console.warn("[friday][agent-runtime] event-persist:", err instanceof Error ? err.message : String(err));
       }
     }
     eventEmitter.emit(eventName as keyof typeof eventEmitter extends never ? never : Parameters<typeof eventEmitter.emit>[0], payload as never);
@@ -489,8 +491,9 @@ export function createFridayAgentRuntime(
           if (learningCtx.preferences && typeof learningCtx.preferences === "object") {
             learnedPreferences = learningCtx.preferences;
           }
-        } catch {
+        } catch (err) {
           // Non-fatal: preference enrichment failure should not kill the run.
+          console.warn("[friday][agent-runtime] preference-enrichment:", err instanceof Error ? err.message : String(err));
         }
       }
       const runTimeContext = buildRunTimeContext(
@@ -647,9 +650,10 @@ export function createFridayAgentRuntime(
             sessionId: sessionKey,
             scopes,
           }, runAbortController.signal);
-          if (runPolicy && !runPolicy.allowed) {
+          // P1-SEC-006: Treat null (rules evaluation error) as deny — fail-closed
+          if (runPolicy === null || (runPolicy && !runPolicy.allowed)) {
             const durationMs = Date.now() - startedAt;
-            const message = runPolicy.message ?? "Agent run denied by policy";
+            const message = runPolicy?.message ?? "Agent run denied by policy";
             db.withWriteTransaction((writer) =>
               repo.update(writer, {
                 id: runId,
@@ -1042,8 +1046,9 @@ export function createFridayAgentRuntime(
             if (fragment && fragment.trim().length > 0) {
               effectiveSystemPrompt += `\n\n${fragment.trim()}`;
             }
-          } catch {
+          } catch (err) {
             // Non-fatal: persona enrichment failure should not kill the run
+            console.warn("[friday][agent-runtime] persona-enrichment:", err instanceof Error ? err.message : String(err));
           }
         }
 
@@ -1106,8 +1111,9 @@ export function createFridayAgentRuntime(
                 outputTokens,
                 costUsd: turnMeta.costUsd,
               });
-            } catch {
+            } catch (err) {
               // Non-fatal: usage persistence should not break run execution.
+              console.warn("[friday][agent-runtime] usage-persist:", err instanceof Error ? err.message : String(err));
             }
           }
 
@@ -1337,8 +1343,9 @@ export function createFridayAgentRuntime(
                 sessionId: sessionKey,
                 scopes,
               }, runAbortController.signal);
-              if (policyResult && !policyResult.allowed) {
-                const message = policyResult.message
+              // P1-SEC-006: Treat null (rules evaluation error) as deny — fail-closed
+              if (policyResult === null || (policyResult && !policyResult.allowed)) {
+                const message = policyResult?.message
                   ?? `Tool '${toolUse.name}' blocked by policy`;
                 const blockedResult = {
                   content: message,
@@ -1488,6 +1495,11 @@ export function createFridayAgentRuntime(
             });
 
             allToolCalls.push(toolCallRecord);
+
+            // P2-RUNTIME-006: Early exit if tool call limit reached mid-batch
+            if (allToolCalls.length >= FRIDAY_AGENT_MAX_TOOL_CALLS) {
+              break;
+            }
 
             toolResultBlocks.push({
               type: "tool_result",
@@ -2000,7 +2012,9 @@ async function safeEvaluateRules(
       },
       signal,
     );
-  } catch {
+  } catch (err) {
+    // P1-SEC-006: Log the error — callers treat null as deny (fail-closed)
+    console.warn("[friday][SECURITY] Rules evaluation failed:", err);
     return null;
   }
 }
@@ -2057,7 +2071,7 @@ function extractImagePathsFromToolCalls(
             images.push(parsed.path);
           }
         }
-      } catch { /* not JSON or no path */ }
+      } catch (err) { /* not JSON or no path */ console.warn("[friday][agent-runtime] extract-image-paths:", err instanceof Error ? err.message : String(err)); }
     }
   }
   return images;
@@ -2378,7 +2392,8 @@ function detectSourceArtifactCompletionGap(params: {
   let sourceText = "";
   try {
     sourceText = readFileSync(sourcePath, "utf8");
-  } catch {
+  } catch (err) {
+    console.warn("[friday][agent-runtime] read-source-file:", err instanceof Error ? err.message : String(err));
     return null;
   }
 
@@ -2416,8 +2431,9 @@ function listSuccessfulWrittenTextArtifacts(
       const content = readFileSync(filePath, "utf8");
       seen.add(filePath);
       artifacts.push({ path: filePath, content });
-    } catch {
+    } catch (err) {
       // Best-effort read: skip binary/unavailable artifacts.
+      console.warn("[friday][agent-runtime] read-artifact:", err instanceof Error ? err.message : String(err));
     }
   }
 
@@ -3074,7 +3090,8 @@ function normalizeIanaTimezone(value: string | undefined): string | undefined {
   try {
     Intl.DateTimeFormat("en-US", { timeZone: timezone }).format(new Date());
     return timezone;
-  } catch {
+  } catch (err) {
+    console.warn("[friday][agent-runtime] validate-timezone:", err instanceof Error ? err.message : String(err));
     return undefined;
   }
 }
@@ -3567,7 +3584,8 @@ function recoverToolCallsFromAssistantText(
     let parsed: unknown;
     try {
       parsed = JSON.parse(candidate);
-    } catch {
+    } catch (err) {
+      console.warn("[friday][agent-runtime] parse-tool-call-json:", err instanceof Error ? err.message : String(err));
       continue;
     }
 
@@ -3619,7 +3637,8 @@ function normalizeToolCallArgs(value: unknown): Record<string, unknown> | null {
         return parsed as Record<string, unknown>;
       }
       return { _raw: value };
-    } catch {
+    } catch (err) {
+      console.warn("[friday][agent-runtime] parse-tool-input:", err instanceof Error ? err.message : String(err));
       return { _raw: value };
     }
   }
@@ -3709,7 +3728,8 @@ function loadDelegatedToolCalls(
       return [];
     }
     return parsed as FridayAgentToolCallRecord[];
-  } catch {
+  } catch (err) {
+    console.warn("[friday][agent-runtime] load-delegated-tool-calls:", err instanceof Error ? err.message : String(err));
     return [];
   }
 }
@@ -3733,7 +3753,8 @@ function loadDelegatedToolEvents(input: {
         eventName: event.eventName,
         payload: event.payload,
       }));
-  } catch {
+  } catch (err) {
+    console.warn("[friday][agent-runtime] load-delegated-tool-events:", err instanceof Error ? err.message : String(err));
     return [];
   }
 }
@@ -3754,7 +3775,8 @@ function countDelegatedToolCalls(input: {
     );
     const toolEndCount = events.filter((event) => event.eventName === "agent.run.tool_end").length;
     return toolEndCount > 0 ? toolEndCount : input.fallback;
-  } catch {
+  } catch (err) {
+    console.warn("[friday][agent-runtime] count-delegated-tool-calls:", err instanceof Error ? err.message : String(err));
     return input.fallback;
   }
 }
@@ -4680,7 +4702,8 @@ function parseJsonObject(content: string): Record<string, unknown> | null {
     const parsed = JSON.parse(content);
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
     return parsed as Record<string, unknown>;
-  } catch {
+  } catch (err) {
+    console.warn("[friday][agent-runtime] parse-json-object:", err instanceof Error ? err.message : String(err));
     return null;
   }
 }

--- a/src/agent/runtime/friday-agent-tool-risk.ts
+++ b/src/agent/runtime/friday-agent-tool-risk.ts
@@ -94,5 +94,21 @@ export function getApprovalRequiredReasonForToolCall(
     return getApprovalRequiredReasonForFileMutation(filePath, [oldText, newText]);
   }
 
+  // P1-SEC-002: browser:evaluate requires approval — arbitrary JS execution
+  if (toolName === "browser") {
+    const action = typeof args.action === "string" ? args.action : "";
+    if (action === "evaluate") {
+      return "Executing arbitrary JavaScript in the browser requires explicit approval.";
+    }
+  }
+
+  // P2-SEC-010: desktop:launch_app requires approval — OS application control
+  if (toolName === "desktop") {
+    const action = typeof args.action === "string" ? args.action : "";
+    if (action === "launch_app" || action === "close_app") {
+      return "Launching or closing desktop applications requires explicit approval.";
+    }
+  }
+
   return null;
 }

--- a/src/agent/runtime/friday-agent-workspace-context.ts
+++ b/src/agent/runtime/friday-agent-workspace-context.ts
@@ -300,7 +300,8 @@ async function collectMarkdownFiles(rootDir: string): Promise<string[]> {
     let entries: Dirent[];
     try {
       entries = await fs.readdir(currentDir, { withFileTypes: true });
-    } catch {
+    } catch (err) {
+      console.warn("[friday][workspace-context] readdir:", err instanceof Error ? err.message : String(err));
       return;
     }
     for (const entry of entries) {
@@ -368,8 +369,9 @@ async function loadPathScopedRules(
           matchedPaths,
         },
       });
-    } catch {
+    } catch (err) {
       // Skip unreadable rule files.
+      console.warn("[friday][workspace-context] load-path-rule:", err instanceof Error ? err.message : String(err));
     }
   }
 
@@ -403,8 +405,9 @@ async function loadPathScopedRules(
           matchedPaths,
         },
       });
-    } catch {
+    } catch (err) {
       // Skip unreadable rule files.
+      console.warn("[friday][workspace-context] load-ext-rule:", err instanceof Error ? err.message : String(err));
     }
   }
 
@@ -443,8 +446,9 @@ export async function loadFridayWorkspaceContext(
       let realPath = filePath;
       try {
         realPath = await fs.realpath(filePath);
-      } catch {
+      } catch (err) {
         // Use lexical path if realpath fails
+        console.warn("[friday][workspace-context] realpath:", err instanceof Error ? err.message : String(err));
       }
       if (seenRealPaths.has(realPath)) {
         return;
@@ -456,7 +460,8 @@ export async function loadFridayWorkspaceContext(
         : content;
 
       files.push({ name, filePath, content: truncated, missing: false, kind });
-    } catch {
+    } catch (err) {
+      console.warn("[friday][workspace-context] load-named-file:", err instanceof Error ? err.message : String(err));
       files.push({ name, filePath, missing: true, kind });
     }
   };
@@ -484,8 +489,9 @@ export async function loadFridayWorkspaceContext(
       missing: false,
       kind: "candidate",
     });
-  } catch {
+  } catch (err) {
     // Daily memory file is optional
+    console.warn("[friday][workspace-context] daily-memory:", err instanceof Error ? err.message : String(err));
   }
 
   // Load exported memory items from .friday/exports/memory/ (feedback loop)
@@ -568,7 +574,8 @@ async function loadMemoryExports(workspaceDir: string): Promise<FridayStoredMemo
   let entries: string[];
   try {
     entries = await fs.readdir(memoryDir);
-  } catch {
+  } catch (err) {
+    console.warn("[friday][workspace-context] readdir-memory-exports:", err instanceof Error ? err.message : String(err));
     return []; // Directory doesn't exist yet — no memories exported
   }
 
@@ -613,8 +620,9 @@ async function loadMemoryExports(workspaceDir: string): Promise<FridayStoredMemo
         });
         itemCount++;
       }
-    } catch {
+    } catch (err) {
       // Skip malformed files
+      console.warn("[friday][workspace-context] parse-memory-export:", err instanceof Error ? err.message : String(err));
     }
   }
 

--- a/src/agent/runtime/friday-public-run-url.ts
+++ b/src/agent/runtime/friday-public-run-url.ts
@@ -11,7 +11,8 @@ export function resolveFridayPublicRunUrl(
     const url = new URL("/command-center", normalizedBase.endsWith("/") ? normalizedBase : `${normalizedBase}/`);
     url.searchParams.set("runId", runId);
     return url.toString();
-  } catch {
+  } catch (err) {
+    console.warn("[friday][public-run-url] URL construction failed:", err instanceof Error ? err.message : String(err));
     return undefined;
   }
 }

--- a/src/agent/security/friday-agent-fetch-guard.ts
+++ b/src/agent/security/friday-agent-fetch-guard.ts
@@ -85,7 +85,8 @@ export async function fetchWithFridayAgentSsrfGuard(
     let nextUrl: string;
     try {
       nextUrl = new URL(location, currentUrl).href;
-    } catch {
+    } catch (err) {
+      console.warn("[friday][agent-fetch-guard] invalid redirect URL:", err instanceof Error ? err.message : String(err));
       throw new FridaySsrfBlockedError(`SSRF guard: invalid redirect URL — ${location}`);
     }
 

--- a/src/agent/security/friday-agent-ssrf-guard.ts
+++ b/src/agent/security/friday-agent-ssrf-guard.ts
@@ -498,7 +498,8 @@ export function createFridayAgentSsrfGuard(policy?: FridaySsrfPolicy): FridayAge
       let parsed: URL;
       try {
         parsed = new URL(url);
-      } catch {
+      } catch (err) {
+        console.warn("[friday][agent-ssrf-guard] invalid URL:", err instanceof Error ? err.message : String(err));
         throw new FridaySsrfBlockedError(`SSRF guard: invalid URL — ${url}`);
       }
 
@@ -541,6 +542,9 @@ export function createFridayAgentSsrfGuard(policy?: FridaySsrfPolicy): FridayAge
     },
 
     async validateWithDns(url: string): Promise<void> {
+      // P2-SEC: TOCTOU note — DNS is resolved here for validation, but the HTTP client
+      // may re-resolve during the actual request. For DNS-rebinding-safe requests, use
+      // `resolvePinnedHostname()` + `createPinnedLookup()` which bind validated IPs.
       // Run synchronous checks first
       this.validate(url);
 

--- a/src/agent/tools/friday-agent-browser-tool.ts
+++ b/src/agent/tools/friday-agent-browser-tool.ts
@@ -1,3 +1,4 @@
+import { FridayDomainError } from "#errors";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -368,7 +369,7 @@ export function createFridayAgentBrowserTool(
       return profile; // Use as session ID for new sessions
     }
 
-    throw new Error("No session specified. Provide sessionId, targetId, or profile.");
+    throw new FridayDomainError("VALIDATION_ERROR", "No session specified. Provide sessionId, targetId, or profile.", { httpStatus: 400 });
   }
 
   function resolveSessionIdForOpenOrStart(args: Record<string, unknown>): string {
@@ -419,7 +420,8 @@ export function createFridayAgentBrowserTool(
     if (url) {
       try {
         return new URL(url).hostname.replace(/^www\./, "");
-      } catch {
+      } catch (err) {
+        console.warn("[friday][agent-browser-tool] URL parse failed:", err instanceof Error ? err.message : String(err));
         if (url.trim().length > 0) {
           return url.trim();
         }
@@ -865,7 +867,16 @@ export function createFridayAgentBrowserTool(
       }
       case "evaluate": {
         const text = readStringParam(args, "text", { required: true });
-        const evalResult = await page.evaluate(text);
+        // P1-SEC-002: Timeout wrapper to prevent script hangs
+        const evalTimeout = 10_000;
+        let evalTimeoutHandle: ReturnType<typeof setTimeout> | undefined;
+        const evalResult = await Promise.race([
+          page.evaluate(text),
+          new Promise<never>((_, reject) => {
+            evalTimeoutHandle = setTimeout(() => reject(new Error("evaluate timed out after 10s")), evalTimeout);
+          }),
+        ]);
+        if (evalTimeoutHandle !== undefined) clearTimeout(evalTimeoutHandle);
         return browserJsonResult(
           {
             sessionId,
@@ -1174,9 +1185,20 @@ export function createFridayAgentBrowserTool(
    * path.relative + path.isAbsolute (not string prefix) to prevent traversal.
    */
   function isPathContainedIn(filePath: string, allowedDir: string): boolean {
-    const resolved = path.resolve(filePath);
-    const base = path.resolve(allowedDir);
-    const rel = path.relative(base, resolved);
+    // P2-SEC-009: Use realpathSync to resolve symlinks before containment check.
+    // Both paths must use the same resolution method to ensure consistent comparison.
+    let fileResolved: string;
+    let baseResolved: string;
+    try {
+      fileResolved = fs.realpathSync(filePath);
+      baseResolved = fs.realpathSync(allowedDir);
+    } catch (err) {
+      // Fall back to path.resolve for both if either path does not exist
+      console.warn("[friday][agent-browser-tool] realpath fallback:", err instanceof Error ? err.message : String(err));
+      fileResolved = path.resolve(filePath);
+      baseResolved = path.resolve(allowedDir);
+    }
+    const rel = path.relative(baseResolved, fileResolved);
     // Must not be empty, must not start with "..", and must not be absolute
     return !!rel && !rel.startsWith("..") && !path.isAbsolute(rel);
   }

--- a/src/agent/tools/friday-agent-canvas-tool.ts
+++ b/src/agent/tools/friday-agent-canvas-tool.ts
@@ -1,3 +1,4 @@
+import { FridayDomainError } from "#errors";
 import type { FridayAgentToolDefinition, FridayAgentToolResult } from "../model/friday-agent.types.js";
 import {
   errorResult,
@@ -131,7 +132,7 @@ export function createFridayAgentCanvasTool(
     const canvasId = readStringParam(args, "canvasId");
     if (canvasId) return canvasId;
     if (required) {
-      throw new Error("canvasId is required for this action.");
+      throw new FridayDomainError("VALIDATION_ERROR", "canvasId is required for this action.", { httpStatus: 400 });
     }
     return `canvas-${Date.now()}`;
   }

--- a/src/agent/tools/friday-agent-cron-tool.ts
+++ b/src/agent/tools/friday-agent-cron-tool.ts
@@ -179,8 +179,9 @@ export function createFridayAgentCronTool(
       if (nextIso) {
         schedulerRepository.setNextRunAt(id, nextIso, now);
       }
-    } catch {
+    } catch (err) {
       // best-effort: isValidCronExpression already validated
+      console.warn("[friday][agent-cron-tool] next run computation failed:", err instanceof Error ? err.message : String(err));
     }
 
     // Register executable job definition so the scheduler can actually run it
@@ -263,8 +264,9 @@ export function createFridayAgentCronTool(
           if (nextIso) {
             schedulerRepository.setNextRunAt(id, nextIso, now);
           }
-        } catch {
+        } catch (err) {
           // best-effort
+          console.warn("[friday][agent-cron-tool] next run update failed:", err instanceof Error ? err.message : String(err));
         }
       }
     }

--- a/src/agent/tools/friday-agent-desktop-tool.ts
+++ b/src/agent/tools/friday-agent-desktop-tool.ts
@@ -467,6 +467,10 @@ export function createFridayAgentDesktopTool(
       }
       case "file_operation": {
         const filePath = readStringParam(args, "path", { required: true });
+        // P1-SEC-003: Reject paths with directory traversal segments
+        if (/(?:^|[\\/])\.\.(?:[\\/]|$)/.test(filePath)) {
+          return null;
+        }
         const operation = readStringParam(args, "operation") ?? "read";
         switch (operation) {
           case "write":

--- a/src/agent/tools/friday-agent-exec-tool.ts
+++ b/src/agent/tools/friday-agent-exec-tool.ts
@@ -100,7 +100,8 @@ export function createFridayAgentExecTool(
       let resolvedWorkdir: string;
       try {
         resolvedWorkdir = realpathSyncFn(workdir) as string;
-      } catch {
+      } catch (err) {
+        console.warn("[friday][agent-exec-tool] workdir resolve failed:", err instanceof Error ? err.message : String(err));
         return errorResult(
           `Working directory "${workdir}" does not exist or is not accessible.`,
         );
@@ -108,7 +109,8 @@ export function createFridayAgentExecTool(
       let resolvedRoot: string;
       try {
         resolvedRoot = realpathSyncFn(workspaceRoot) as string;
-      } catch {
+      } catch (err) {
+        console.warn("[friday][agent-exec-tool] workspace root resolve failed:", err instanceof Error ? err.message : String(err));
         resolvedRoot = path.resolve(workspaceRoot);
       }
       if (!resolvedWorkdir.startsWith(resolvedRoot + path.sep) && resolvedWorkdir !== resolvedRoot) {

--- a/src/agent/tools/friday-agent-file-tools.ts
+++ b/src/agent/tools/friday-agent-file-tools.ts
@@ -1,3 +1,4 @@
+import { FridayDomainError } from "#errors";
 import * as fs from "node:fs/promises";
 import * as fsSync from "node:fs";
 import * as path from "node:path";
@@ -34,7 +35,7 @@ function openWritableFileNoFollow(filePath: string, options?: { create?: boolean
       try {
         const st = fsSync.lstatSync(filePath);
         if (st.isSymbolicLink()) {
-          throw new Error(`Path is a symlink (rejected): ${filePath}`);
+          throw new FridayDomainError("VALIDATION_ERROR", `Path is a symlink (rejected): ${filePath}`, { httpStatus: 400 });
         }
       } catch (lstatErr) {
         if (isNodeError(lstatErr) && lstatErr.code === "ENOENT" && options?.create) {
@@ -82,7 +83,8 @@ function validateFilePath(filePath: string, workspaceRoot: string): string | nul
   let resolvedRoot: string;
   try {
     resolvedRoot = fsSync.realpathSync(workspaceRoot);
-  } catch {
+  } catch (err) {
+    console.warn("[friday][file-tools] realpath-workspace-root:", err instanceof Error ? err.message : String(err));
     resolvedRoot = path.resolve(workspaceRoot);
   }
 
@@ -91,8 +93,9 @@ function validateFilePath(filePath: string, workspaceRoot: string): string | nul
   let resolved: string;
   try {
     resolved = fsSync.realpathSync(filePath);
-  } catch {
+  } catch (err) {
     // Path doesn't exist — walk up to the nearest existing ancestor and resolve from there
+    console.warn("[friday][file-tools] realpath-target:", err instanceof Error ? err.message : String(err));
     const absolute = path.resolve(filePath);
     let ancestor = path.dirname(absolute);
     let tail = path.basename(absolute);
@@ -103,7 +106,8 @@ function validateFilePath(filePath: string, workspaceRoot: string): string | nul
         const resolvedAncestor = fsSync.realpathSync(ancestor);
         resolved = path.join(resolvedAncestor, tail);
         break;
-      } catch {
+      } catch (err) {
+        console.warn("[friday][file-tools] realpath-ancestor:", err instanceof Error ? err.message : String(err));
         tail = path.join(path.basename(ancestor), tail);
         const parent = path.dirname(ancestor);
         if (parent === ancestor) {
@@ -260,7 +264,8 @@ function createWriteTool(workspaceRoot: string): FridayAgentToolDefinition {
         let resolvedRoot: string;
         try {
           resolvedRoot = fsSync.realpathSync(workspaceRoot);
-        } catch {
+        } catch (err) {
+          console.warn("[friday][file-tools] realpath-write-root:", err instanceof Error ? err.message : String(err));
           resolvedRoot = path.resolve(workspaceRoot);
         }
         const resolvedDir = fsSync.realpathSync(dir);
@@ -278,7 +283,7 @@ function createWriteTool(workspaceRoot: string): FridayAgentToolDefinition {
           const fdStat = fsSync.fstatSync(fd);
           const fileStat = fsSync.statSync(safePath);
           if (fdStat.ino !== fileStat.ino || fdStat.dev !== fileStat.dev) {
-            throw new Error(`File identity mismatch (TOCTOU): ${safePath}`);
+            throw new FridayDomainError("CONFLICT", `File identity mismatch (TOCTOU): ${safePath}`, { httpStatus: 409 });
           }
           // Truncate only after identity checks to avoid destructive partial failures.
           fsSync.ftruncateSync(fd, 0);
@@ -287,8 +292,9 @@ function createWriteTool(workspaceRoot: string): FridayAgentToolDefinition {
           if (fd !== null) {
             try {
               fsSync.closeSync(fd);
-            } catch {
+            } catch (err) {
               // Best-effort close
+              console.warn("[friday][file-tools] close-write-fd:", err instanceof Error ? err.message : String(err));
             }
           }
         }
@@ -346,7 +352,8 @@ function createEditTool(workspaceRoot: string): FridayAgentToolDefinition {
         let resolvedRoot: string;
         try {
           resolvedRoot = fsSync.realpathSync(workspaceRoot);
-        } catch {
+        } catch (err) {
+          console.warn("[friday][file-tools] realpath-edit-root:", err instanceof Error ? err.message : String(err));
           resolvedRoot = path.resolve(workspaceRoot);
         }
         const resolvedFile = fsSync.realpathSync(filePath);
@@ -370,7 +377,7 @@ function createEditTool(workspaceRoot: string): FridayAgentToolDefinition {
           fd = openWritableFileNoFollow(resolvedFile, { create: false });
           const fdStat = fsSync.fstatSync(fd);
           if (fdStat.ino !== beforeStat.ino || fdStat.dev !== beforeStat.dev) {
-            throw new Error(`File identity mismatch (TOCTOU): ${resolvedFile}`);
+            throw new FridayDomainError("CONFLICT", `File identity mismatch (TOCTOU): ${resolvedFile}`, { httpStatus: 409 });
           }
           // Truncate only after identity checks to avoid destructive partial failures.
           fsSync.ftruncateSync(fd, 0);
@@ -379,8 +386,9 @@ function createEditTool(workspaceRoot: string): FridayAgentToolDefinition {
           if (fd !== null) {
             try {
               fsSync.closeSync(fd);
-            } catch {
+            } catch (err) {
               // Best-effort close
+              console.warn("[friday][file-tools] close-edit-fd:", err instanceof Error ? err.message : String(err));
             }
           }
         }

--- a/src/agent/tools/friday-agent-gateway-validation.ts
+++ b/src/agent/tools/friday-agent-gateway-validation.ts
@@ -1,3 +1,4 @@
+import { FridayDomainError } from "#errors";
 import { URL } from "node:url";
 
 // ─── Constants ───
@@ -54,7 +55,8 @@ export function validateGatewayUrl(
   let url: URL;
   try {
     url = new URL(rawUrl);
-  } catch {
+  } catch (err) {
+    console.warn("[friday][agent-gateway-validation] invalid URL:", err instanceof Error ? err.message : String(err));
     return { valid: false, error: `Invalid URL: '${rawUrl}'` };
   }
 
@@ -103,7 +105,7 @@ export function parseGatewayUrl(
 ): URL {
   const result = validateGatewayUrl(rawUrl, options);
   if (!result.valid || !result.url) {
-    throw new Error(result.error ?? `Invalid gateway URL: '${rawUrl}'`);
+    throw new FridayDomainError("VALIDATION_ERROR", result.error ?? `Invalid gateway URL: '${rawUrl}'`, { httpStatus: 400 });
   }
   return result.url;
 }

--- a/src/agent/tools/friday-agent-image-analysis-helpers.ts
+++ b/src/agent/tools/friday-agent-image-analysis-helpers.ts
@@ -1,3 +1,4 @@
+import { FridayDomainError } from "#errors";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -46,7 +47,7 @@ export interface ImageValidationResult {
 export function validateDetail(detail: string | undefined): ImageDetail {
   if (!detail) return "auto";
   if (!VALID_DETAILS.has(detail)) {
-    throw new Error(`Invalid detail "${detail}". Valid: low, high, auto.`);
+    throw new FridayDomainError("VALIDATION_ERROR", `Invalid detail "${detail}". Valid: low, high, auto.`, { httpStatus: 400 });
   }
   return detail as ImageDetail;
 }
@@ -81,11 +82,11 @@ export function normalizeImageInput(input: string, options?: NormalizeImageOptio
   // Data URI
   if (trimmed.startsWith("data:")) {
     if (Buffer.byteLength(trimmed, "utf8") > MAX_DATA_URI_BYTES) {
-      throw new Error(`Data URI exceeds maximum size of ${MAX_DATA_URI_BYTES} bytes.`);
+      throw new FridayDomainError("VALIDATION_ERROR", `Data URI exceeds maximum size of ${MAX_DATA_URI_BYTES} bytes.`, { httpStatus: 400 });
     }
     const match = /^data:([^;]+);base64,(.+)$/.exec(trimmed);
     if (!match) {
-      throw new Error("Invalid data URI format. Expected data:<mime>;base64,<data>");
+      throw new FridayDomainError("VALIDATION_ERROR", "Invalid data URI format. Expected data:<mime>;base64,<data>", { httpStatus: 400 });
     }
     return { type: "base64", mimeType: match[1], data: match[2] };
   }
@@ -105,21 +106,25 @@ export function normalizeImageInput(input: string, options?: NormalizeImageOptio
   const withinTemp = isPathWithinDirectory(resolved, tempDir);
 
   if (!withinWorkspace && !withinTemp) {
-    throw new Error(
+    throw new FridayDomainError(
+      "VALIDATION_ERROR",
       `Image path "${trimmed}" is outside the allowed directories (workspace or temp). ` +
       `Resolved: ${resolved}`,
+      { httpStatus: 400 },
     );
   }
 
   if (!fs.existsSync(resolved)) {
-    throw new Error(`Image file not found: ${resolved}`);
+    throw new FridayDomainError("NOT_FOUND", `Image file not found: ${resolved}`, { httpStatus: 404 });
   }
 
   const ext = path.extname(resolved).toLowerCase();
   const mime = IMAGE_MIME_MAP[ext];
   if (!mime) {
-    throw new Error(
+    throw new FridayDomainError(
+      "UNSUPPORTED_OPERATION",
       `Unsupported image format "${ext}". Supported: ${Object.keys(IMAGE_MIME_MAP).join(", ")}`,
+      { httpStatus: 400 },
     );
   }
 

--- a/src/agent/tools/friday-agent-sessions-tool.ts
+++ b/src/agent/tools/friday-agent-sessions-tool.ts
@@ -1,3 +1,4 @@
+import { FridayDomainError } from "#errors";
 import type {
   FridayAgentMessage,
   FridayAgentToolDefinition,
@@ -31,6 +32,10 @@ type SessionsAction = "list" | "history" | "send" | "spawn";
 
 const VALID_ACTIONS = new Set<SessionsAction>(["list", "history", "send", "spawn"]);
 
+// P2-SEC: Track recursive sessions:send depth to prevent unbounded execution
+const MAX_SESSION_SEND_DEPTH = 3;
+const activeSessionSendDepth = new Map<string, number>();
+
 /** Default message limit for history action. */
 const DEFAULT_HISTORY_LIMIT = 50;
 
@@ -48,7 +53,7 @@ export function createFridayAgentSessionsTool(
   function getRuntime(): FridayAgentRuntime {
     const rt = deps.agentRuntimeGetter?.() ?? deps.agentRuntime;
     if (!rt) {
-      throw new Error("Agent runtime is not available yet. It may still be initializing.");
+      throw new FridayDomainError("NOT_INITIALIZED", "Agent runtime is not available yet. It may still be initializing.", { httpStatus: 503 });
     }
     return rt;
   }
@@ -240,15 +245,29 @@ export function createFridayAgentSessionsTool(
       })
       .catch(() => [] as FridayAgentMessage[]);
 
+    // P2-SEC: Guard against recursive unbounded execution via sessions:send
+    const currentDepth = activeSessionSendDepth.get(sessionId) ?? 0;
+    if (currentDepth >= MAX_SESSION_SEND_DEPTH) {
+      return errorResult(`Maximum sessions:send recursion depth (${MAX_SESSION_SEND_DEPTH}) exceeded. Cannot trigger further nested agent runs.`);
+    }
+
     // Trigger agent execution on this session
+    activeSessionSendDepth.set(sessionId, currentDepth + 1);
     const runtime = getRuntime();
-    const result = await runtime.executeRun({
-      task: message,
-      sessionKey: sessionId,
-      signal,
-      historyMessages,
-      timezone: getFridayAgentToolExecutionContext(signal)?.timezone,
-    });
+    let result;
+    try {
+      result = await runtime.executeRun({
+        task: message,
+        sessionKey: sessionId,
+        signal,
+        historyMessages,
+        timezone: getFridayAgentToolExecutionContext(signal)?.timezone,
+      });
+    } finally {
+      const depth = activeSessionSendDepth.get(sessionId) ?? 1;
+      if (depth <= 1) activeSessionSendDepth.delete(sessionId);
+      else activeSessionSendDepth.set(sessionId, depth - 1);
+    }
 
     return jsonResult({
       sessionKey: sessionId,

--- a/src/agent/tools/friday-agent-web-fetch-tool.ts
+++ b/src/agent/tools/friday-agent-web-fetch-tool.ts
@@ -46,8 +46,9 @@ export function rewriteUrl(raw: string): string {
       u.hostname = "old.reddit.com";
       return u.toString();
     }
-  } catch {
+  } catch (err) {
     // Malformed URL — let fetch() handle the error downstream
+    console.warn("[friday][agent-web-fetch-tool] URL rewrite failed:", err instanceof Error ? err.message : String(err));
   }
   return raw;
 }
@@ -65,6 +66,11 @@ export function createFridayAgentWebFetchTool(
   options?: CreateFridayAgentWebFetchToolOptions,
 ): FridayAgentToolDefinition {
   const ssrfGuard = options?.ssrfGuard;
+
+  // P1-SEC-001: Warn when SSRF guard is not configured
+  if (!ssrfGuard) {
+    console.warn("[friday][SECURITY] web_fetch tool created without SSRF guard — internal network requests will not be blocked");
+  }
 
   return {
     name: "web_fetch",

--- a/src/agent/tools/friday-agent-web-search-tool.ts
+++ b/src/agent/tools/friday-agent-web-search-tool.ts
@@ -1,3 +1,4 @@
+import { FridayDomainError } from "#errors";
 import type { FridayAgentToolDefinition, FridayAgentToolResult } from "../model/friday-agent.types.js";
 import {
   errorResult,
@@ -229,7 +230,7 @@ async function searchSerper(
   });
 
   if (!response.ok) {
-    throw new Error(`Serper API error: HTTP ${String(response.status)}`);
+    throw new FridayDomainError("INTERNAL_ERROR", `Serper API error: HTTP ${String(response.status)}`, { httpStatus: 500 });
   }
 
   const data = await response.json() as {
@@ -276,7 +277,7 @@ async function searchTavily(
   });
 
   if (!response.ok) {
-    throw new Error(`Tavily API error: HTTP ${String(response.status)}`);
+    throw new FridayDomainError("INTERNAL_ERROR", `Tavily API error: HTTP ${String(response.status)}`, { httpStatus: 500 });
   }
 
   const data = await response.json() as {
@@ -314,7 +315,7 @@ async function searchDuckDuckGo(
   });
 
   if (!response.ok) {
-    throw new Error(`DuckDuckGo error: HTTP ${String(response.status)}`);
+    throw new FridayDomainError("INTERNAL_ERROR", `DuckDuckGo error: HTTP ${String(response.status)}`, { httpStatus: 500 });
   }
 
   const html = await response.text();

--- a/src/agent/tools/friday-agent-xhs-tool.ts
+++ b/src/agent/tools/friday-agent-xhs-tool.ts
@@ -160,6 +160,13 @@ export function createFridayAgentXhsTool(
     const images = readArrayParam(args, "images");
     const tags = readArrayParam(args, "tags");
 
+    // P2-SEC-011: Validate image paths do not contain directory traversal
+    for (const imagePath of images) {
+      if (/(?:^|[\\/])\.\.(?:[\\/]|$)/.test(imagePath)) {
+        return errorResult(`Image path "${imagePath}" contains directory traversal.`);
+      }
+    }
+
     if (images.length === 0) {
       return errorResult("At least one image is required for an XHS post.");
     }

--- a/src/api/auth/friday-auth-service.ts
+++ b/src/api/auth/friday-auth-service.ts
@@ -180,6 +180,16 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
   const warn = deps.warn ?? console.warn;
   const rateLimiter = deps.rateLimiter;
 
+  // P1-SEC-004: Warn if token secret is too short
+  if (deps.tokenSecret.length < 32) {
+    warn("[friday][SECURITY] Token secret is shorter than recommended minimum (32 chars) — session tokens may be vulnerable to brute-force");
+  }
+
+  // P1-SEC-005: Warn if rate limiter is not configured
+  if (!rateLimiter) {
+    warn("[friday][SECURITY] Auth rate limiter not configured — brute-force protection disabled");
+  }
+
   /**
    * Derive a principal key for lockout tracking.
    * Keys are scoped to the actual principal (email / user ID), NOT the IP,

--- a/src/api/auth/friday-token-validator.ts
+++ b/src/api/auth/friday-token-validator.ts
@@ -72,7 +72,8 @@ export function createFridayTokenValidator(
       let claims: FridayAccessTokenClaims;
       try {
         claims = JSON.parse(payloadJson) as FridayAccessTokenClaims;
-      } catch {
+      } catch (err) {
+        console.warn("[friday][token-validator] token payload parse failed:", err instanceof Error ? err.message : String(err));
         throw new FridayTokenValidationError("INVALID_FORMAT", "Token payload is invalid JSON");
       }
 

--- a/src/api/fleet/friday-fleet-dashboard-service.ts
+++ b/src/api/fleet/friday-fleet-dashboard-service.ts
@@ -40,7 +40,8 @@ type FridayFleetSatelliteRecoveryInput = Pick<
 function parseJsonOr<T>(raw: string, fallback: T): T {
   try {
     return JSON.parse(raw) as T;
-  } catch {
+  } catch (err) {
+    console.warn("[friday][fleet-dashboard-service] operation failed:", err instanceof Error ? err.message : String(err));
     return fallback;
   }
 }

--- a/src/api/http/friday-http-client-ip.ts
+++ b/src/api/http/friday-http-client-ip.ts
@@ -1,3 +1,4 @@
+import { FridayDomainError } from "#errors";
 import * as net from "node:net";
 import { isPrivateIp } from "../../agent/security/friday-agent-ssrf-guard.js";
 
@@ -88,8 +89,10 @@ export function parseFridayHttpTrustProxyMode(value: string | undefined): Friday
   if (normalized === "off" || normalized === "loopback" || normalized === "private_network") {
     return normalized;
   }
-  throw new Error(
+  throw new FridayDomainError(
+    "VALIDATION_ERROR",
     `Invalid FRIDAY_HTTP_TRUST_PROXY value: ${value}. Expected one of: off, loopback, private_network.`,
+    { httpStatus: 400 },
   );
 }
 

--- a/src/api/http/friday-http-server.ts
+++ b/src/api/http/friday-http-server.ts
@@ -99,7 +99,8 @@ function extractParams(pattern: string, actual: string): Record<string, string> 
     if (segment.startsWith(":")) {
       try {
         params[segment.slice(1)] = decodeURIComponent(actualParts[i]!);
-      } catch {
+      } catch (err) {
+        console.warn("[friday][http-server] operation failed:", err instanceof Error ? err.message : String(err));
         throw new MalformedUriError(actualParts[i]!);
       }
     }
@@ -309,7 +310,8 @@ async function tryServeUiAsset(
         serveStaticFile(res, safePath, fileStat.size, headOnly, secHeaders);
         return true;
       }
-    } catch {
+    } catch (err) {
+        console.warn("[friday][http-server] operation failed:", err instanceof Error ? err.message : String(err));
       // File doesn't exist — fall through
     }
   }
@@ -355,7 +357,8 @@ async function tryServeUiAsset(
       serveStaticFile(res, indexPath, indexStat.size, headOnly, secHeaders);
       return true;
     }
-  } catch {
+  } catch (err) {
+        console.warn("[friday][http-server] operation failed:", err instanceof Error ? err.message : String(err));
     // index.html doesn't exist
   }
 
@@ -494,7 +497,8 @@ export function createFridayHttpServer(deps: FridayHttpServerDeps): FridayHttpSe
         if (raw.length > 0) {
           try {
             body = JSON.parse(raw);
-          } catch {
+          } catch (err) {
+        console.warn("[friday][http-server] operation failed:", err instanceof Error ? err.message : String(err));
             sendJsonWithHeaders(res, 400, {
               ok: false,
               error: buildFridayApiError(FRIDAY_API_ERROR_CODES.INVALID_JSON, "Request body is not valid JSON"),
@@ -829,7 +833,8 @@ export function createFridayHttpServer(deps: FridayHttpServerDeps): FridayHttpSe
             const clientFrame = JSON.parse(payloadData.toString("utf-8")) as FridayRealtimeClientFrame;
             const responses = deps.wsGateway.handleClientFrame(conn, clientFrame);
             sendFrames(responses);
-          } catch {
+          } catch (err) {
+        console.warn("[friday][http-server] operation failed:", err instanceof Error ? err.message : String(err));
             // Malformed JSON — send error frame
             const errFrame: FridayRealtimeServerFrame = {
               type: "error",

--- a/src/api/http/routes/friday-agent-routes.ts
+++ b/src/api/http/routes/friday-agent-routes.ts
@@ -109,6 +109,7 @@ export function createFridayAgentRoutes(
       method: "POST",
       path: "/v1/agent/runs",
       auth: { public: false, anyOfScopes: [...AGENT_RUN_SCOPES] },
+      rateLimitPolicyId: "agent.run",
       async handler(ctx) {
         const body = ctx.body as Record<string, unknown> | null;
         if (!body || typeof body.task !== "string" || body.task.trim() === "") {
@@ -766,7 +767,8 @@ function parseOptionalIanaTimezone(value: unknown, path: string): string | undef
   const timezone = value.trim();
   try {
     Intl.DateTimeFormat("en-US", { timeZone: timezone }).format(new Date());
-  } catch {
+  } catch (err) {
+    console.warn("[friday][agent-routes] operation failed:", err instanceof Error ? err.message : String(err));
     throw new FridayDomainError(
       "VALIDATION_ERROR",
       `${path} is not a valid IANA timezone`,
@@ -836,7 +838,8 @@ function parseAutomationSchedule(
     timezone = raw.timezone.trim();
     try {
       Intl.DateTimeFormat("en-US", { timeZone: timezone }).format(new Date());
-    } catch {
+    } catch (err) {
+    console.warn("[friday][agent-routes] operation failed:", err instanceof Error ? err.message : String(err));
       throw new FridayDomainError(
         "VALIDATION_ERROR",
         `${options.path}.timezone is not a valid IANA timezone`,

--- a/src/api/http/routes/friday-memory-routes.ts
+++ b/src/api/http/routes/friday-memory-routes.ts
@@ -156,6 +156,7 @@ export function createFridayMemoryRoutes(
       method: "POST",
       path: "/v1/memory/store",
       auth: { public: false, anyOfScopes: ["hub.admin"] },
+      rateLimitPolicyId: "memory.write",
       async handler(ctx): Promise<FridayMemoryStoreResponse> {
         // DX-003: Default namespace to "default" if not provided
         if (ctx.body != null && typeof ctx.body === "object") {

--- a/src/api/http/routes/friday-satellite-pairing-routes.ts
+++ b/src/api/http/routes/friday-satellite-pairing-routes.ts
@@ -152,7 +152,7 @@ export function createFridaySatellitePairingRoutes(
       operationId: "satellites.pairing.list",
       method: "GET",
       path: "/v1/satellites/pairing",
-      auth: { public: false, anyOfScopes: ["satellite.read" as any] },
+      auth: { public: false, anyOfScopes: ["satellite.read"] },
       async handler() {
         return deps.listPendingPairings();
       },
@@ -163,7 +163,7 @@ export function createFridaySatellitePairingRoutes(
       operationId: "satellites.pairing.get",
       method: "GET",
       path: "/v1/satellites/:satelliteId/pairing",
-      auth: { public: false, anyOfScopes: ["satellite.read" as any] },
+      auth: { public: false, anyOfScopes: ["satellite.read"] },
       async handler(ctx: Ctx) {
         const params = ctx.params as Record<string, string>;
         const request = await deps.getPairingRequest(params.satelliteId);
@@ -179,7 +179,7 @@ export function createFridaySatellitePairingRoutes(
       operationId: "satellites.pairing.approve",
       method: "POST",
       path: "/v1/satellites/:satelliteId/pairing/approve",
-      auth: { public: false, anyOfScopes: ["satellite.write" as any] },
+      auth: { public: false, anyOfScopes: ["satellite.write"] },
       async handler(ctx: Ctx) {
         const params = ctx.params as Record<string, string>;
         const body = ctx.body as Record<string, unknown>;
@@ -205,7 +205,7 @@ export function createFridaySatellitePairingRoutes(
       operationId: "satellites.pairing.reject",
       method: "POST",
       path: "/v1/satellites/:satelliteId/pairing/reject",
-      auth: { public: false, anyOfScopes: ["satellite.write" as any] },
+      auth: { public: false, anyOfScopes: ["satellite.write"] },
       async handler(ctx: Ctx) {
         const params = ctx.params as Record<string, string>;
         const body = ctx.body as Record<string, unknown>;
@@ -263,7 +263,7 @@ export function createFridaySatellitePairingRoutes(
       operationId: "satellites.revoke",
       method: "POST",
       path: "/v1/satellites/:satelliteId/revoke",
-      auth: { public: false, anyOfScopes: ["security.write" as any] },
+      auth: { public: false, anyOfScopes: ["security.write"] },
       async handler(ctx: Ctx) {
         const params = ctx.params as Record<string, string>;
         const body = ctx.body as Record<string, unknown>;

--- a/src/api/http/routes/friday-satellite-runtime-routes.ts
+++ b/src/api/http/routes/friday-satellite-runtime-routes.ts
@@ -110,7 +110,8 @@ function decodePayloadCiphertext(raw: string): unknown {
   try {
     const decoded = Buffer.from(raw, "base64").toString("utf8");
     return JSON.parse(decoded) as unknown;
-  } catch {
+  } catch (err) {
+    console.warn("[friday][satellite-runtime-routes] operation failed:", err instanceof Error ? err.message : String(err));
     return { raw };
   }
 }

--- a/src/api/http/routes/friday-session-routes.ts
+++ b/src/api/http/routes/friday-session-routes.ts
@@ -199,7 +199,8 @@ function validateRunBody(body: unknown): asserts body is FridaySessionRunRequest
     } else {
       try {
         Intl.DateTimeFormat("en-US", { timeZone: b.timezone.trim() }).format(new Date());
-      } catch {
+      } catch (err) {
+        console.warn("[friday][session-routes] operation failed:", err instanceof Error ? err.message : String(err));
         errors.push("timezone is not a valid IANA timezone");
       }
     }
@@ -355,7 +356,8 @@ function decodeSessionKeyParam(raw: string): string {
   let decoded: string;
   try {
     decoded = decodeURIComponent(raw);
-  } catch {
+  } catch (err) {
+        console.warn("[friday][session-routes] operation failed:", err instanceof Error ? err.message : String(err));
     throw new FridayDomainError(
       FRIDAY_SESSION_ERROR_CODES.INVALID_KEY,
       `Invalid URL-encoded session key: '${raw}'`,
@@ -499,6 +501,7 @@ export function createFridaySessionRoutes(
       method: "POST",
       path: "/v1/sessions",
       auth: { public: false, anyOfScopes: ["session.write"] },
+      rateLimitPolicyId: "session.write",
       async handler(ctx): Promise<FridaySessionCreateResponse> {
         validateCreateSessionBody(ctx.body);
         const body = ctx.body;

--- a/src/api/http/routes/friday-setup-routes.ts
+++ b/src/api/http/routes/friday-setup-routes.ts
@@ -134,7 +134,8 @@ function parseStepIds(raw: string): string[] {
     const parsed = JSON.parse(raw);
     if (!Array.isArray(parsed)) return [];
     return parsed.filter((step): step is string => typeof step === "string");
-  } catch {
+  } catch (err) {
+    console.warn("[friday][setup-routes] operation failed:", err instanceof Error ? err.message : String(err));
     return [];
   }
 }
@@ -395,7 +396,8 @@ export function createFridaySetupRoutes(
               entry !== null &&
               (entry as { enabled?: unknown }).enabled === true,
             ).length;
-          } catch {
+          } catch (err) {
+    console.warn("[friday][setup-routes] operation failed:", err instanceof Error ? err.message : String(err));
             return 0;
           }
         })();

--- a/src/api/http/routes/friday-system-routes.ts
+++ b/src/api/http/routes/friday-system-routes.ts
@@ -159,7 +159,8 @@ function readOrigin(ctx: { headers: Record<string, string | undefined> }): strin
   }
   try {
     return new URL(referer).origin;
-  } catch {
+  } catch (err) {
+    console.warn("[friday][system-routes] operation failed:", err instanceof Error ? err.message : String(err));
     return undefined;
   }
 }

--- a/src/api/model/friday-api-auth.types.ts
+++ b/src/api/model/friday-api-auth.types.ts
@@ -70,7 +70,10 @@ export type FridayRateLimitPolicyId =
   | "marketplace.checkout"
   | "marketplace.write"
   | "playbook.promote"
-  | "playbook.select";
+  | "playbook.select"
+  | "agent.run"
+  | "session.write"
+  | "memory.write";
 
 // ─── Auth Principal ───
 

--- a/src/api/persistence/friday-api-token-repository.ts
+++ b/src/api/persistence/friday-api-token-repository.ts
@@ -1,4 +1,5 @@
 import type Database from "better-sqlite3";
+import { safeJsonParse } from "#utilities";
 import type { FridayApiTokenRow } from "#satellites";
 
 // ─── Repository ───
@@ -95,7 +96,7 @@ export function createFridayApiTokenRepository(): FridayApiTokenRepository {
         .all(now) as Array<{ scopes_json: string }>;
 
       return rows.filter((row) => {
-        const scopes = JSON.parse(row.scopes_json) as string[];
+        const scopes = safeJsonParse<string[]>(row.scopes_json) ?? [];
         return scopes.includes("hub.admin") || scopes.includes("security.write");
       }).length;
     },

--- a/src/api/persistence/friday-realtime-event-repository.ts
+++ b/src/api/persistence/friday-realtime-event-repository.ts
@@ -1,4 +1,5 @@
 import type Database from "better-sqlite3";
+import { safeJsonParse } from "#utilities";
 import type { FridayRealtimeEventEnvelope, FridayRealtimeEventName } from "../model/friday-api-realtime.types.js";
 
 // ─── Row type ───
@@ -41,12 +42,10 @@ function rowToEnvelope(row: FridayRealtimeEventRow): FridayRealtimeEventEnvelope
     streamId: row.stream_id,
     seq: row.seq,
     event: row.event as FridayRealtimeEventName,
-    payload: JSON.parse(row.payload_json),
+    payload: safeJsonParse<FridayRealtimeEventEnvelope["payload"]>(row.payload_json)!,
     emittedAt: row.emitted_at,
     correlationId: row.correlation_id ?? undefined,
-    stateVersion: row.state_version_json
-      ? JSON.parse(row.state_version_json)
-      : undefined,
+    stateVersion: safeJsonParse<FridayRealtimeEventEnvelope["stateVersion"]>(row.state_version_json),
   };
 }
 

--- a/src/api/persistence/friday-workflow-conflict-repository.ts
+++ b/src/api/persistence/friday-workflow-conflict-repository.ts
@@ -1,4 +1,5 @@
 import type Database from "better-sqlite3";
+import { safeJsonParse } from "#utilities";
 import type {
   FridayWorkflowConflictEntity,
   FridayWorkflowConflictKind,
@@ -38,7 +39,7 @@ function rowToEntity(row: FridayWorkflowConflictRow): FridayWorkflowConflictEnti
     resolvedAt: row.resolved_at ?? undefined,
     resolvedByUserId: row.resolved_by_user_id ?? undefined,
     summary: row.summary,
-    patches: JSON.parse(row.patches_json) as FridayWorkflowConflictEntity["patches"],
+    patches: safeJsonParse<FridayWorkflowConflictEntity["patches"]>(row.patches_json) ?? [],
   };
 }
 

--- a/src/api/realtime/friday-execution-control-event-emitter.ts
+++ b/src/api/realtime/friday-execution-control-event-emitter.ts
@@ -176,7 +176,8 @@ export function createExecutionControlEventEmitter(
             envelope.emittedAt,
           );
           deps.auditSink(record);
-        } catch {
+        } catch (err) {
+          console.warn("[friday][execution-control-event-emitter] operation failed:", err instanceof Error ? err.message : String(err));
           // Audit sink failure is non-fatal
         }
       }

--- a/src/api/realtime/friday-realtime-event-bus.ts
+++ b/src/api/realtime/friday-realtime-event-bus.ts
@@ -92,7 +92,8 @@ export function createFridayRealtimeEventBus(
       for (const listener of listeners) {
         try {
           listener(envelope);
-        } catch {
+        } catch (err) {
+          console.warn("[friday][realtime-event-bus] operation failed:", err instanceof Error ? err.message : String(err));
           // Swallow listener errors to avoid breaking event flow
         }
       }

--- a/src/api/runtime/friday-deterministic-pipeline-runtime.ts
+++ b/src/api/runtime/friday-deterministic-pipeline-runtime.ts
@@ -1,5 +1,6 @@
 import { FridayDomainError } from "#errors";
 import type { FridaySqliteLayer } from "#state";
+import { safeJsonParse } from "#utilities";
 import {
   AcceptanceRunState,
   AcceptanceTestSuiteRunner,
@@ -200,12 +201,8 @@ function mapBundleRow(row: FridayPolicyBundleRow): FridayPolicyBundle {
     priority: row.priority,
     enabled: row.enabled === 1,
     tags: (() => {
-      try {
-        const parsed = JSON.parse(row.tags_json);
-        return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === "string") : [];
-      } catch {
-        return [];
-      }
+      const parsed = safeJsonParse(row.tags_json);
+      return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === "string") : [];
     })(),
     source: row.source === "import" || row.source === "system" ? row.source : "user",
     etag: row.etag,
@@ -216,12 +213,8 @@ function mapBundleRow(row: FridayPolicyBundleRow): FridayPolicyBundle {
 
 function mapRuleRow(row: FridayRuleRow): FridayRule {
   const conditions = (() => {
-    try {
-      const parsed = JSON.parse(row.conditions_json);
-      return typeof parsed === "object" && parsed !== null ? parsed as FridayRule["conditions"] : {};
-    } catch {
-      return {};
-    }
+    const parsed = safeJsonParse(row.conditions_json);
+    return typeof parsed === "object" && parsed !== null ? parsed as FridayRule["conditions"] : {};
   })();
 
   return {
@@ -598,8 +591,9 @@ export function createFridayDeterministicPipelineRuntime(
             created_at: entry.evaluatedAt,
           });
         });
-      } catch {
+      } catch (err) {
         // Keep rule enforcement fail-open for audit persistence write failures.
+        console.warn("[friday][pipeline-runtime] rule-audit-persist:", err instanceof Error ? err.message : String(err));
       }
     },
   });
@@ -619,8 +613,9 @@ export function createFridayDeterministicPipelineRuntime(
         rulesEngine.loadDomainBundle(bundle, rules);
       }
     });
-  } catch {
+  } catch (err) {
     // Rules tables may not exist on very old installations; runtime can still boot.
+    console.warn("[friday][pipeline-runtime] load-rules:", err instanceof Error ? err.message : String(err));
   }
 
   const evaluateRules = async (
@@ -756,7 +751,8 @@ export function createFridayDeterministicPipelineRuntime(
             acceptanceRepository.insertVersion(db, versionRow);
           }
         });
-      } catch {
+      } catch (err) {
+        console.warn("[friday][pipeline-runtime] acceptance-baseline-persist:", err instanceof Error ? err.message : String(err));
         acceptancePersistenceAvailable = false;
       }
     }
@@ -774,7 +770,8 @@ export function createFridayDeterministicPipelineRuntime(
         syncAcceptanceRegistry(test);
       }
     });
-  } catch {
+  } catch (err) {
+    console.warn("[friday][pipeline-runtime] load-acceptance-tests:", err instanceof Error ? err.message : String(err));
     acceptancePersistenceAvailable = false;
   }
 
@@ -843,7 +840,8 @@ export function createFridayDeterministicPipelineRuntime(
         });
       }
     });
-  } catch {
+  } catch (err) {
+    console.warn("[friday][pipeline-runtime] load-retry-policy:", err instanceof Error ? err.message : String(err));
     retryPersistenceAvailable = false;
   }
 
@@ -1228,7 +1226,8 @@ export function createFridayDeterministicPipelineRuntime(
             deps.db.withWriteTransaction((db) => {
               acceptanceRepository.insertRun(db, toAcceptanceRunRow(result, artifact, asString(payload.idempotencyKey) ?? undefined));
             });
-          } catch {
+          } catch (err) {
+            console.warn("[friday][pipeline-runtime] acceptance-run-persist:", err instanceof Error ? err.message : String(err));
             acceptancePersistenceAvailable = false;
           }
         }
@@ -1259,7 +1258,8 @@ export function createFridayDeterministicPipelineRuntime(
                 offset: asNumber(query.offset, 0),
               }),
             );
-          } catch {
+          } catch (err) {
+            console.warn("[friday][pipeline-runtime] acceptance-list-runs:", err instanceof Error ? err.message : String(err));
             acceptancePersistenceAvailable = false;
           }
         }

--- a/src/automation/openclaw-adoption/friday-openclaw-phase-controller.ts
+++ b/src/automation/openclaw-adoption/friday-openclaw-phase-controller.ts
@@ -125,7 +125,8 @@ function loadStateFromDisk(paths: FridayOpenClawPhaseControllerPaths, nowIso: st
       if (parsed.schemaVersion === "1.0" && parsed.programId === "openclaw-adoption") {
         return parsed;
       }
-    } catch {
+    } catch (err) {
+      console.warn("[friday][openclaw-phase-controller] operation failed:", err instanceof Error ? err.message : String(err));
       continue;
     }
   }
@@ -755,18 +756,21 @@ function defaultPlatform(): FridayPhaseAutomationPlatform {
         try {
           ensureOk("git", ["fetch", "origin", mainBranch], repoRoot);
           remoteMainHead = ensureOk("git", ["rev-parse", `origin/${mainBranch}`], repoRoot);
-        } catch {
+        } catch (err) {
+      console.warn("[friday][openclaw-phase-controller] operation failed:", err instanceof Error ? err.message : String(err));
           remoteMainHead = undefined;
         }
         workingTreeClean = ensureOk("git", ["status", "--porcelain"], repoRoot).length === 0;
-      } catch {
+      } catch (err) {
+      console.warn("[friday][openclaw-phase-controller] operation failed:", err instanceof Error ? err.message : String(err));
         gitAvailable = false;
       }
 
       try {
         ensureOk("gh", ["--version"], repoRoot);
         ghAuthenticated = runProcess("gh", ["auth", "status"], repoRoot).status === 0;
-      } catch {
+      } catch (err) {
+      console.warn("[friday][openclaw-phase-controller] operation failed:", err instanceof Error ? err.message : String(err));
         ghAvailable = false;
       }
 

--- a/src/browser/friday-browser-manager.ts
+++ b/src/browser/friday-browser-manager.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { spawn } from "node:child_process";
+import { FridayDomainError } from "#errors";
 
 // ─── Constants ───
 
@@ -164,7 +165,8 @@ function matchesOrigin(url: string, allowedOrigins: string[]): boolean {
   let parsed: URL;
   try {
     parsed = new URL(url);
-  } catch {
+  } catch (err) {
+    console.warn("[friday][browser-manager] parse-origin-url:", err instanceof Error ? err.message : String(err));
     return false;
   }
 
@@ -196,7 +198,8 @@ function validateUrl(url: string, allowedOrigins: string[]): string | undefined 
   let parsed: URL;
   try {
     parsed = new URL(url);
-  } catch {
+  } catch (err) {
+    console.warn("[friday][browser-manager] validate-url:", err instanceof Error ? err.message : String(err));
     return `Invalid URL: ${url}`;
   }
 
@@ -217,7 +220,7 @@ export function sanitizeArtifactPathSegment(input: string): string {
   const raw = input.trim();
   const segments = raw.split(/[\\/]+/).filter(Boolean);
   if (segments.length === 0 || segments.some((s) => s === "." || s === "..")) {
-    throw new Error(`Invalid artifact path segment "${input}"`);
+    throw new FridayDomainError("VALIDATION_ERROR", `Invalid artifact path segment "${input}"`, { httpStatus: 400 });
   }
 
   const sanitized = segments
@@ -226,7 +229,7 @@ export function sanitizeArtifactPathSegment(input: string): string {
     .replace(/^[._-]+|[._-]+$/g, "");
 
   if (!sanitized) {
-    throw new Error(`Invalid artifact path segment "${input}"`);
+    throw new FridayDomainError("VALIDATION_ERROR", `Invalid artifact path segment "${input}"`, { httpStatus: 400 });
   }
   return sanitized;
 }
@@ -253,7 +256,8 @@ function resolvePlaywrightBrowsersCacheDir(platform: NodeJS.Platform): string | 
   let userHome = "";
   try {
     userHome = os.userInfo().homedir;
-  } catch {
+  } catch (err) {
+    console.warn("[friday][browser-manager] resolve-homedir:", err instanceof Error ? err.message : String(err));
     userHome = os.homedir();
   }
   if (!userHome) {
@@ -312,7 +316,8 @@ function findChromeExecutable(customPath?: string): string | undefined {
     try {
       fs.accessSync(executable, fs.constants.X_OK);
       return executable;
-    } catch {
+    } catch (err) {
+      console.warn("[friday][browser-manager] access-chrome-app:", err instanceof Error ? err.message : String(err));
       return undefined;
     }
   }
@@ -320,7 +325,8 @@ function findChromeExecutable(customPath?: string): string | undefined {
     try {
       fs.accessSync(customPath, fs.constants.X_OK);
       return customPath;
-    } catch {
+    } catch (err) {
+      console.warn("[friday][browser-manager] access-custom-chrome:", err instanceof Error ? err.message : String(err));
       return undefined;
     }
   }
@@ -329,7 +335,8 @@ function findChromeExecutable(customPath?: string): string | undefined {
       try {
         fs.accessSync(p, fs.constants.X_OK);
         return p;
-      } catch {
+      } catch (err) {
+        console.warn("[friday][browser-manager] access-chrome-path:", err instanceof Error ? err.message : String(err));
         continue;
       }
     }
@@ -360,7 +367,8 @@ async function probeCdpEndpoint(port: number): Promise<string | undefined> {
     if (!res.ok) return undefined;
     const data = (await res.json()) as { webSocketDebuggerUrl?: string };
     return data.webSocketDebuggerUrl ?? undefined;
-  } catch {
+  } catch (err) {
+    console.warn("[friday][browser-manager] discover-cdp-endpoint:", err instanceof Error ? err.message : String(err));
     return undefined;
   }
 }
@@ -411,10 +419,7 @@ async function resolveHostChromeEndpoint(
   // 2. Find and launch user's Chrome with CDP
   const exe = findChromeExecutable(chromePath);
   if (!exe) {
-    throw new Error(
-      "[friday] Host Chrome executable not found. " +
-      "Install Google Chrome or set FRIDAY_BROWSER_CHROME_PATH.",
-    );
+    throw new FridayDomainError("NOT_FOUND", "[friday] Host Chrome executable not found. Install Google Chrome or set FRIDAY_BROWSER_CHROME_PATH.", { httpStatus: 404 });
   }
 
   console.log(`[friday] Launching Chrome with CDP on port ${String(port)}: ${exe}`);
@@ -430,10 +435,7 @@ async function resolveHostChromeEndpoint(
     }
   }
 
-  throw new Error(
-    `[friday] Chrome CDP did not become available on port ${String(port)} after 15 seconds. ` +
-    "Ensure Chrome is not blocked from starting or try setting FRIDAY_BROWSER_WS_ENDPOINT manually.",
-  );
+  throw new FridayDomainError("NOT_INITIALIZED", `[friday] Chrome CDP did not become available on port ${String(port)} after 15 seconds. Ensure Chrome is not blocked from starting or try setting FRIDAY_BROWSER_WS_ENDPOINT manually.`, { httpStatus: 503 });
 }
 
 // ─── Factory ───
@@ -509,7 +511,7 @@ export function createFridayBrowserManager(
   function reservePageSlot(): () => void {
     const projectedTotal = totalOpenPages() + reservedPageSlots;
     if (projectedTotal >= maxTotalPages) {
-      throw new Error(`Maximum total pages (${String(maxTotalPages)}) reached.`);
+      throw new FridayDomainError("VALIDATION_ERROR", `Maximum total pages (${String(maxTotalPages)}) reached.`, { httpStatus: 400 });
     }
 
     reservedPageSlots += 1;
@@ -604,9 +606,7 @@ export function createFridayBrowserManager(
     }
 
     if (sessions.size >= maxSessions) {
-      throw new Error(
-        `Maximum sessions (${String(maxSessions)}) reached. Close an existing session first.`,
-      );
+      throw new FridayDomainError("VALIDATION_ERROR", `Maximum sessions (${String(maxSessions)}) reached. Close an existing session first.`, { httpStatus: 400 });
     }
 
     signal?.throwIfAborted();
@@ -749,15 +749,13 @@ export function createFridayBrowserManager(
   ): Promise<{ tabId: string; page: Page }> {
     const session = sessions.get(sessionId);
     if (!session) {
-      throw new Error(`Session "${sessionId}" not found. Use "open" action first.`);
+      throw new FridayDomainError("NOT_FOUND", `Session "${sessionId}" not found. Use "open" action first.`, { httpStatus: 404 });
     }
 
     // Detect dead browser and evict so caller can re-open
     if (!isSessionAlive(session)) {
       await evictDeadSession(sessionId);
-      throw new Error(
-        `Session "${sessionId}" browser has disconnected. Use "open" action to start a new session.`,
-      );
+      throw new FridayDomainError("NOT_INITIALIZED", `Session "${sessionId}" browser has disconnected. Use "open" action to start a new session.`, { httpStatus: 503 });
     }
 
     const targetTabId = getOpts?.tabId ?? session.activeTabId;
@@ -780,13 +778,11 @@ export function createFridayBrowserManager(
     }
 
     if (!getOpts?.createIfMissing) {
-      throw new Error(`Tab "${targetTabId}" not found in session "${sessionId}".`);
+      throw new FridayDomainError("NOT_FOUND", `Tab "${targetTabId}" not found in session "${sessionId}".`, { httpStatus: 404 });
     }
 
     if (session.tabs.size >= maxTabsPerSession) {
-      throw new Error(
-        `Maximum tabs per session (${String(maxTabsPerSession)}) reached. Close a tab first.`,
-      );
+      throw new FridayDomainError("VALIDATION_ERROR", `Maximum tabs per session (${String(maxTabsPerSession)}) reached. Close a tab first.`, { httpStatus: 400 });
     }
 
     const releasePageSlot = reservePageSlot();

--- a/src/browser/friday-browser-target-id.ts
+++ b/src/browser/friday-browser-target-id.ts
@@ -6,6 +6,7 @@
  * Supports profile-based disambiguation for multi-profile environments.
  */
 
+import { FridayDomainError } from "#errors";
 import type { BrowserSession, FridayBrowserManager } from "./friday-browser-manager.js";
 
 // ─── Types ───
@@ -92,27 +93,23 @@ export function resolveBrowserTarget(
       sessionId = profileSessions[0]!.sessionId;
     }
     if (!sessionId) {
-      throw new Error(
-        `No session found for profile "${options.profile}". Launch a browser session first.`,
-      );
+      throw new FridayDomainError("NOT_FOUND", `No session found for profile "${options.profile}". Launch a browser session first.`, { httpStatus: 404 });
     }
   }
 
   if (!sessionId) {
-    throw new Error("No session specified. Provide sessionId, targetId, or profile.");
+    throw new FridayDomainError("VALIDATION_ERROR", "No session specified. Provide sessionId, targetId, or profile.", { httpStatus: 400 });
   }
 
   const session = manager.getSession(sessionId);
   if (!session) {
-    throw new Error(`Session "${sessionId}" not found. Use "open" action first.`);
+    throw new FridayDomainError("NOT_FOUND", `Session "${sessionId}" not found. Use "open" action first.`, { httpStatus: 404 });
   }
 
   // Resolve tab
   const resolvedTabId = tabId ?? session.activeTabId;
   if (!session.tabs.has(resolvedTabId)) {
-    throw new Error(
-      `Tab "${resolvedTabId}" not found in session "${sessionId}".`,
-    );
+    throw new FridayDomainError("NOT_FOUND", `Tab "${resolvedTabId}" not found in session "${sessionId}".`, { httpStatus: 404 });
   }
 
   return { sessionId, tabId: resolvedTabId, session };

--- a/src/channels/discord/discord-service.ts
+++ b/src/channels/discord/discord-service.ts
@@ -6,6 +6,8 @@
  * making it easy to mock in tests and swap implementations.
  */
 
+import { FridayDomainError } from "#errors";
+
 // ─── Types ───
 
 export interface DiscordGatewayEvent {
@@ -200,8 +202,10 @@ export function createDiscordRestService(): DiscordRestService {
 
       if (!res.ok) {
         const body = await res.text().catch(() => "");
-        throw new Error(
+        throw new FridayDomainError(
+          "INTERNAL_ERROR",
           `Discord REST API error ${res.status}: ${res.statusText} — ${body}`,
+          { httpStatus: 500 },
         );
       }
 
@@ -219,8 +223,10 @@ export function createDiscordRestService(): DiscordRestService {
 
       if (!res.ok) {
         const body = await res.text().catch(() => "");
-        throw new Error(
+        throw new FridayDomainError(
+          "INTERNAL_ERROR",
           `Discord typing API error ${res.status}: ${res.statusText} — ${body}`,
+          { httpStatus: 500 },
         );
       }
     },
@@ -255,7 +261,8 @@ export function createDiscordGatewayService(): DiscordGatewayService {
     if (ws !== null) {
       try {
         ws.close(1000, "Client disconnect");
-      } catch {
+      } catch (err) {
+        console.warn("[friday][discord-service] operation failed:", err instanceof Error ? err.message : String(err));
         // Already closed — ignore.
       }
       ws = null;
@@ -336,8 +343,10 @@ export function createDiscordGatewayService(): DiscordGatewayService {
 
     if (!gatewayRes.ok) {
       const body = await gatewayRes.text().catch(() => "");
-      throw new Error(
+      throw new FridayDomainError(
+        "INTERNAL_ERROR",
         `Failed to fetch Discord gateway URL: ${gatewayRes.status} — ${body}`,
+        { httpStatus: 500 },
       );
     }
 
@@ -367,7 +376,8 @@ export function createDiscordGatewayService(): DiscordGatewayService {
         let parsed: DiscordGatewayEvent;
         try {
           parsed = JSON.parse(String(event.data)) as DiscordGatewayEvent;
-        } catch {
+        } catch (err) {
+        console.warn("[friday][discord-service] operation failed:", err instanceof Error ? err.message : String(err));
           return; // Ignore malformed frames.
         }
 

--- a/src/channels/discord/friday-discord-channel.ts
+++ b/src/channels/discord/friday-discord-channel.ts
@@ -11,6 +11,7 @@
  * External API calls are stubbed behind DiscordGatewayService / DiscordRestService.
  */
 
+import { FridayDomainError } from "#errors";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 
@@ -50,7 +51,8 @@ function isHttpUrl(value: string): boolean {
   try {
     const parsed = new URL(value);
     return parsed.protocol === "http:" || parsed.protocol === "https:";
-  } catch {
+  } catch (err) {
+    console.warn("[friday][discord-channel] operation failed:", err instanceof Error ? err.message : String(err));
     return false;
   }
 }
@@ -193,7 +195,7 @@ export function createFridayDiscordChannel(deps: DiscordChannelDeps = {}): Frida
 
   const outboundAdapter: FridayChannelOutboundAdapter = {
     async send(options: FridayChannelSendOptions): Promise<{ messageId: string }> {
-      if (!config) throw new Error("Discord channel not initialized");
+      if (!config) throw new FridayDomainError("NOT_INITIALIZED", "Discord channel not initialized", { httpStatus: 503 });
 
       const embeds: Array<{ image?: { url: string } }> = [];
       const files: Array<{ filename: string; data: Uint8Array; contentType?: string }> = [];
@@ -219,7 +221,8 @@ export function createFridayDiscordChannel(deps: DiscordChannelDeps = {}): Frida
               contentType: guessImageMimeType(image),
             });
           }
-        } catch {
+        } catch (err) {
+    console.warn("[friday][discord-channel] operation failed:", err instanceof Error ? err.message : String(err));
           skipped.push(image);
         }
       }
@@ -247,7 +250,7 @@ export function createFridayDiscordChannel(deps: DiscordChannelDeps = {}): Frida
       return { messageId: result.id };
     },
     async typing(chatId: string): Promise<void> {
-      if (!config) throw new Error("Discord channel not initialized");
+      if (!config) throw new FridayDomainError("NOT_INITIALIZED", "Discord channel not initialized", { httpStatus: 503 });
       await rest.sendTyping(config.token, chatId);
     },
   };
@@ -271,7 +274,7 @@ export function createFridayDiscordChannel(deps: DiscordChannelDeps = {}): Frida
 
   const lifecycleAdapter: FridayChannelLifecycleAdapter = {
     async connect(eventHandler: (rawEvent: unknown) => void) {
-      if (!config) throw new Error("Discord channel not initialized");
+      if (!config) throw new FridayDomainError("NOT_INITIALIZED", "Discord channel not initialized", { httpStatus: 503 });
 
       // Re-entry guard: if already connected, skip — the gateway handles its own reconnect internally.
       if (connectionStatus === "connected" && gateway.isConnected()) return;
@@ -344,7 +347,7 @@ export function createFridayDiscordChannel(deps: DiscordChannelDeps = {}): Frida
     },
 
     async start(handler) {
-      if (!config) throw new Error("Discord channel not initialized");
+      if (!config) throw new FridayDomainError("NOT_INITIALIZED", "Discord channel not initialized", { httpStatus: 503 });
 
       // Delegate to lifecycle adapter to avoid dual gateway.connect() paths.
       await lifecycleAdapter.connect((event) => {

--- a/src/channels/friday-channel-loader.ts
+++ b/src/channels/friday-channel-loader.ts
@@ -6,6 +6,7 @@
  * based on configuration. Supports both legacy plugins and adapter-based plugins.
  */
 
+import { FridayDomainError } from "#errors";
 import type { FridayChannelPlugin } from "./friday-channel.types.js";
 
 // ─── Types ───
@@ -78,9 +79,11 @@ export function createFridayChannelLoader(
     create(kind) {
       const factory = factories.get(kind);
       if (!factory) {
-        throw new Error(
+        throw new FridayDomainError(
+          "NOT_FOUND",
           `No channel factory registered for kind "${kind}". ` +
             `Available: ${Array.from(factories.keys()).join(", ") || "(none)"}`,
+          { httpStatus: 404 },
         );
       }
       return factory();

--- a/src/channels/friday-channel-registry.ts
+++ b/src/channels/friday-channel-registry.ts
@@ -9,6 +9,7 @@
  * - Route through adapters when present, fallback to legacy methods
  */
 
+import { FridayDomainError } from "#errors";
 import type { FridayChannelStatus } from "./friday-channel-adapters.types.js";
 import type {
   FridayChannelCapabilityContract,
@@ -205,7 +206,7 @@ export function createFridayChannelRegistry(): FridayChannelRegistry {
   return {
     register(plugin, allowlist = {}) {
       if (entries.has(plugin.kind)) {
-        throw new Error(`Channel kind "${plugin.kind}" is already registered`);
+        throw new FridayDomainError("CONFLICT", `Channel kind "${plugin.kind}" is already registered`, { httpStatus: 409 });
       }
       entries.set(plugin.kind, { plugin, allowlist, running: false });
     },
@@ -273,11 +274,13 @@ export function createFridayChannelRegistry(): FridayChannelRegistry {
         }),
       );
 
-      throw new Error(
+      throw new FridayDomainError(
+        "INTERNAL_ERROR",
         `Failed to start ${String(failures.length)} channel(s): ` +
           failures
             .map((failure) => `${failure.kind}: ${failure.message}`)
             .join("; "),
+        { httpStatus: 500 },
       );
     },
 
@@ -339,11 +342,13 @@ export function createFridayChannelRegistry(): FridayChannelRegistry {
         (result): result is PromiseRejectedResult => result.status === "rejected",
       );
       if (failures.length > 0) {
-        throw new Error(
+        throw new FridayDomainError(
+          "INTERNAL_ERROR",
           `Failed to stop ${String(failures.length)} channel(s): ` +
             failures
               .map((f) => (f.reason instanceof Error ? f.reason.message : String(f.reason)))
               .join("; "),
+          { httpStatus: 500 },
         );
       }
     },
@@ -380,10 +385,10 @@ export function createFridayChannelRegistry(): FridayChannelRegistry {
     async send(kind, options) {
       const entry = entries.get(kind);
       if (!entry) {
-        throw new Error(`Channel kind "${kind}" is not registered`);
+        throw new FridayDomainError("NOT_FOUND", `Channel kind "${kind}" is not registered`, { httpStatus: 404 });
       }
       if (!entry.running) {
-        throw new Error(`Channel kind "${kind}" is not running`);
+        throw new FridayDomainError("NOT_INITIALIZED", `Channel kind "${kind}" is not running`, { httpStatus: 503 });
       }
 
       // Use outbound adapter if available, otherwise legacy send

--- a/src/channels/friday-channel-security.ts
+++ b/src/channels/friday-channel-security.ts
@@ -159,7 +159,8 @@ export function parseFridayChannelSecretRef(raw: string): string | null {
   try {
     const decoded = decodeURIComponent(encoded);
     return decoded.trim().length > 0 ? decoded : null;
-  } catch {
+  } catch (err) {
+    console.warn("[friday][channel-security] operation failed:", err instanceof Error ? err.message : String(err));
     return null;
   }
 }

--- a/src/channels/irc/friday-irc-channel.ts
+++ b/src/channels/irc/friday-irc-channel.ts
@@ -5,6 +5,7 @@
  * Sends via PRIVMSG commands.
  */
 
+import { FridayDomainError } from "#errors";
 import type {
   FridayChannelMessage,
   FridayChannelPlugin,
@@ -88,7 +89,7 @@ export function createFridayIrcChannel(deps: IrcChannelDeps = {}): FridayChannel
 
   const outboundAdapter: FridayChannelOutboundAdapter = {
     async send(options: FridayChannelSendOptions): Promise<{ messageId: string }> {
-      if (!config) throw new Error("IRC channel not initialized");
+      if (!config) throw new FridayDomainError("NOT_INITIALIZED", "IRC channel not initialized", { httpStatus: 503 });
 
       await connection.sendMessage(options.chatId, options.text);
 
@@ -119,7 +120,7 @@ export function createFridayIrcChannel(deps: IrcChannelDeps = {}): FridayChannel
 
   const lifecycleAdapter: FridayChannelLifecycleAdapter = {
     async connect(eventHandler: (rawEvent: unknown) => void) {
-      if (!config) throw new Error("IRC channel not initialized");
+      if (!config) throw new FridayDomainError("NOT_INITIALIZED", "IRC channel not initialized", { httpStatus: 503 });
       connectionStatus = "connecting";
 
       await connection.connect(
@@ -158,13 +159,18 @@ export function createFridayIrcChannel(deps: IrcChannelDeps = {}): FridayChannel
   const plugin: FridayChannelPlugin = {
     kind: "irc",
     adapters,
+    contract: {
+      coreAuthority: { messageRouting: true, sessionMirroring: true, audit: true, evidence: true },
+      pluginResponsibilities: { config: true, auth: true, pairing: false, outboundDelivery: true, threadResolution: false, providerRetries: false },
+      supports: { directMessages: false, groupMessages: true, threads: false, typing: false },
+    },
 
     async init(rawConfig) {
       config = configAdapter.validate(rawConfig);
     },
 
     async start(handler) {
-      if (!config) throw new Error("IRC channel not initialized");
+      if (!config) throw new FridayDomainError("NOT_INITIALIZED", "IRC channel not initialized", { httpStatus: 503 });
       connectionStatus = "connecting";
 
       await connection.connect(

--- a/src/channels/irc/irc-service.ts
+++ b/src/channels/irc/irc-service.ts
@@ -2,6 +2,7 @@
  * IRC service — stubbed interfaces for TCP socket connection.
  */
 
+import { FridayDomainError } from "#errors";
 import * as net from "node:net";
 import * as tls from "node:tls";
 
@@ -109,13 +110,14 @@ function parsePrefix(prefix: string): {
 export function createIrcConnectionService(): IrcConnectionService {
   let socket: net.Socket | tls.TLSSocket | null = null;
   let connected = false;
+  let stopped = false; // P2-CH: Track explicit stop
   let channels: string[] = [];
   let lineBuffer = "";
 
   /** Write a raw IRC command followed by CRLF. */
   function sendRaw(command: string): void {
     if (!socket || socket.destroyed) {
-      throw new Error("IRC socket is not connected");
+      throw new FridayDomainError("NOT_INITIALIZED", "IRC socket is not connected", { httpStatus: 503 });
     }
     socket.write(`${command}\r\n`);
   }
@@ -189,6 +191,10 @@ export function createIrcConnectionService(): IrcConnectionService {
           connected = false;
           channels = [];
           socket = null;
+          if (!stopped) {
+            // P2-CH: Log disconnection — the channel registry health monitor will auto-restart
+            console.warn("[friday] IRC socket closed unexpectedly");
+          }
         });
 
         function handleLine(line: string): void {
@@ -289,10 +295,12 @@ export function createIrcConnectionService(): IrcConnectionService {
     },
 
     async disconnect(): Promise<void> {
+      stopped = true;
       if (socket && !socket.destroyed) {
         try {
           sendRaw("QUIT :Goodbye");
-        } catch {
+        } catch (err) {
+          console.warn("[friday][irc-service] operation failed:", err instanceof Error ? err.message : String(err));
           // Socket may already be broken
         }
         socket.destroy();
@@ -305,7 +313,7 @@ export function createIrcConnectionService(): IrcConnectionService {
 
     async sendMessage(target: string, message: string): Promise<void> {
       if (!connected || !socket || socket.destroyed) {
-        throw new Error("IRC: cannot send message — not connected");
+        throw new FridayDomainError("NOT_INITIALIZED", "IRC: cannot send message — not connected", { httpStatus: 503 });
       }
       sendRaw(`PRIVMSG ${target} :${message}`);
     },

--- a/src/channels/lark/friday-lark-channel.ts
+++ b/src/channels/lark/friday-lark-channel.ts
@@ -15,6 +15,7 @@
  *   - https://open.larksuite.com/document/server-docs/overview
  */
 
+import { FridayDomainError } from "#errors";
 import type {
   FridayChannelMessage,
   FridayChannelPlugin,
@@ -88,7 +89,7 @@ export function createFridayLarkChannel(deps: LarkChannelDeps = {}): FridayChann
     });
 
     if (!response.ok) {
-      throw new Error(`Lark token refresh failed: ${response.status} ${response.statusText}`);
+      throw new FridayDomainError("INTERNAL_ERROR", `Lark token refresh failed: ${response.status} ${response.statusText}`, { httpStatus: 500 });
     }
 
     const data = (await response.json()) as {
@@ -99,7 +100,7 @@ export function createFridayLarkChannel(deps: LarkChannelDeps = {}): FridayChann
     };
 
     if (data.code !== 0) {
-      throw new Error(`Lark token refresh error: ${data.code} ${data.msg}`);
+      throw new FridayDomainError("INTERNAL_ERROR", `Lark token refresh error: ${data.code} ${data.msg}`, { httpStatus: 500 });
     }
 
     token = {
@@ -143,7 +144,8 @@ export function createFridayLarkChannel(deps: LarkChannelDeps = {}): FridayChann
       try {
         const parsed = JSON.parse(content) as { text?: string };
         text = parsed.text ?? content;
-      } catch {
+      } catch (err) {
+      console.warn("[friday][lark-channel] operation failed:", err instanceof Error ? err.message : String(err));
         text = content;
       }
     }
@@ -182,7 +184,7 @@ export function createFridayLarkChannel(deps: LarkChannelDeps = {}): FridayChann
     });
 
     if (!response.ok) {
-      throw new Error(`Lark WS endpoint fetch failed: ${response.status}`);
+      throw new FridayDomainError("INTERNAL_ERROR", `Lark WS endpoint fetch failed: ${response.status}`, { httpStatus: 500 });
     }
 
     const data = (await response.json()) as {
@@ -192,7 +194,7 @@ export function createFridayLarkChannel(deps: LarkChannelDeps = {}): FridayChann
 
     const wsUrl = data.data?.URL ?? data.data?.url;
     if (!wsUrl) {
-      throw new Error("Lark WS endpoint returned no URL");
+      throw new FridayDomainError("INTERNAL_ERROR", "Lark WS endpoint returned no URL", { httpStatus: 500 });
     }
 
     return wsUrl;
@@ -230,7 +232,8 @@ export function createFridayLarkChannel(deps: LarkChannelDeps = {}): FridayChann
       let data: Record<string, unknown>;
       try {
         data = JSON.parse(String(event.data)) as Record<string, unknown>;
-      } catch {
+      } catch (err) {
+      console.warn("[friday][lark-channel] operation failed:", err instanceof Error ? err.message : String(err));
         return;
       }
 
@@ -328,20 +331,24 @@ export function createFridayLarkChannel(deps: LarkChannelDeps = {}): FridayChann
   const plugin: FridayChannelPlugin = {
     kind: "lark",
     adapters,
+    contract: {
+      coreAuthority: { messageRouting: true, sessionMirroring: true, audit: true, evidence: true },
+      pluginResponsibilities: { config: true, auth: true, pairing: false, outboundDelivery: true, threadResolution: false, providerRetries: false },
+      supports: { directMessages: true, groupMessages: true, threads: false, typing: false },
+    },
 
     async init(rawConfig) {
+      // P1-CH-001: Use Zod schema for runtime config validation
+      const { FridayLarkChannelConfigSchema } = await import("./lark-config.schema.js");
+      const parsed = FridayLarkChannelConfigSchema.parse({ kind: rawConfig.useFeishu ? "feishu" : "lark", ...rawConfig });
       config = {
-        appId: rawConfig.appId as string,
-        appSecret: rawConfig.appSecret as string,
-        useFeishu: (rawConfig.useFeishu as boolean) ?? false,
-        allowedUsers: rawConfig.allowedUsers as string[] | undefined,
-        allowedChats: rawConfig.allowedChats as string[] | undefined,
-        receiveMode: (rawConfig.receiveMode as "websocket" | "webhook") ?? "websocket",
+        appId: parsed.appId,
+        appSecret: parsed.appSecret,
+        useFeishu: parsed.useFeishu,
+        allowedUsers: parsed.allowedUsers,
+        allowedChats: parsed.allowedChats,
+        receiveMode: parsed.receiveMode,
       };
-
-      if (!config.appId || !config.appSecret) {
-        throw new Error("Lark channel requires appId and appSecret");
-      }
 
       // Override kind for Feishu
       if (config.useFeishu) {
@@ -361,7 +368,7 @@ export function createFridayLarkChannel(deps: LarkChannelDeps = {}): FridayChann
           connectWebSocket(wsUrl);
         } else {
           if (!webhookRelay) {
-            throw new Error("Lark webhook mode requires webhookRelay dependency");
+            throw new FridayDomainError("VALIDATION_ERROR", "Lark webhook mode requires webhookRelay dependency", { httpStatus: 400 });
           }
           await webhookRelay.start((event) => {
             const msg = parseMessageEvent(event);
@@ -384,7 +391,8 @@ export function createFridayLarkChannel(deps: LarkChannelDeps = {}): FridayChann
         if (ws) {
           try {
             ws.close();
-          } catch {
+          } catch (err) {
+      console.warn("[friday][lark-channel] operation failed:", err instanceof Error ? err.message : String(err));
             // ignore
           }
           ws = null;
@@ -447,7 +455,7 @@ export function createFridayLarkChannel(deps: LarkChannelDeps = {}): FridayChann
 
       if (!response.ok) {
         const errorText = await response.text();
-        throw new Error(`Lark send failed: ${response.status} ${errorText}`);
+        throw new FridayDomainError("INTERNAL_ERROR", `Lark send failed: ${response.status} ${errorText}`, { httpStatus: 500 });
       }
 
       const result = (await response.json()) as {
@@ -456,7 +464,7 @@ export function createFridayLarkChannel(deps: LarkChannelDeps = {}): FridayChann
       };
 
       if (result.code !== 0) {
-        throw new Error(`Lark send error: code ${result.code}`);
+        throw new FridayDomainError("INTERNAL_ERROR", `Lark send error: code ${result.code}`, { httpStatus: 500 });
       }
 
       return { messageId: result.data?.message_id ?? "" };

--- a/src/channels/lark/lark-config.schema.ts
+++ b/src/channels/lark/lark-config.schema.ts
@@ -1,0 +1,25 @@
+/**
+ * Lark/Feishu channel configuration schema.
+ * P1-CH-001: Runtime config validation via Zod.
+ */
+
+import { z } from "zod";
+
+export const FridayLarkChannelConfigSchema = z.object({
+  kind: z.union([z.literal("lark"), z.literal("feishu")]),
+  enabled: z.boolean().default(true),
+  /** Lark/Feishu application ID. */
+  appId: z.string().min(1),
+  /** Lark/Feishu application secret. */
+  appSecret: z.string().min(1),
+  /** Use Feishu (China) API endpoints instead of Lark (international). */
+  useFeishu: z.boolean().default(false),
+  /** If set, only accept messages from these user IDs. */
+  allowedUsers: z.array(z.string()).optional(),
+  /** If set, only accept messages from these chat IDs. */
+  allowedChats: z.array(z.string()).optional(),
+  /** Receive mode: websocket (default) or webhook relay. */
+  receiveMode: z.enum(["websocket", "webhook"]).default("websocket"),
+});
+
+export type FridayLarkChannelConfig = z.infer<typeof FridayLarkChannelConfigSchema>;

--- a/src/channels/lark/lark-webhook-relay.ts
+++ b/src/channels/lark/lark-webhook-relay.ts
@@ -50,7 +50,8 @@ export function createLarkWebhookRelayService(): LarkWebhookRelayService {
       let payload: Record<string, unknown>;
       try {
         payload = JSON.parse(rawBody) as Record<string, unknown>;
-      } catch {
+      } catch (err) {
+      console.warn("[friday][lark-webhook-relay] operation failed:", err instanceof Error ? err.message : String(err));
         return {
           accepted: false,
           statusCode: 400,

--- a/src/channels/line/friday-line-channel.ts
+++ b/src/channels/line/friday-line-channel.ts
@@ -5,6 +5,7 @@
  * Supports both push messages and reply messages.
  */
 
+import { FridayDomainError } from "#errors";
 import type {
   FridayChannelMessage,
   FridayChannelPlugin,
@@ -116,7 +117,7 @@ export function createFridayLineChannel(deps: LineChannelDeps = {}): FridayChann
 
   const outboundAdapter: FridayChannelOutboundAdapter = {
     async send(options: FridayChannelSendOptions): Promise<{ messageId: string }> {
-      if (!config) throw new Error("LINE channel not initialized");
+      if (!config) throw new FridayDomainError("NOT_INITIALIZED", "LINE channel not initialized", { httpStatus: 503 });
 
       await api.pushMessage(config.channelAccessToken, {
         to: options.chatId,
@@ -146,7 +147,7 @@ export function createFridayLineChannel(deps: LineChannelDeps = {}): FridayChann
 
   const lifecycleAdapter: FridayChannelLifecycleAdapter = {
     async connect(eventHandler: (rawEvent: unknown) => void) {
-      if (!config) throw new Error("LINE channel not initialized");
+      if (!config) throw new FridayDomainError("NOT_INITIALIZED", "LINE channel not initialized", { httpStatus: 503 });
       connectionStatus = "connecting";
 
       await webhookListener.start(config.webhookPath, config.channelSecret, (payload) => {
@@ -174,13 +175,18 @@ export function createFridayLineChannel(deps: LineChannelDeps = {}): FridayChann
   const plugin: FridayChannelPlugin = {
     kind: "line",
     adapters,
+    contract: {
+      coreAuthority: { messageRouting: true, sessionMirroring: true, audit: true, evidence: true },
+      pluginResponsibilities: { config: true, auth: true, pairing: false, outboundDelivery: true, threadResolution: false, providerRetries: false },
+      supports: { directMessages: true, groupMessages: true, threads: false, typing: false },
+    },
 
     async init(rawConfig) {
       config = configAdapter.validate(rawConfig);
     },
 
     async start(handler) {
-      if (!config) throw new Error("LINE channel not initialized");
+      if (!config) throw new FridayDomainError("NOT_INITIALIZED", "LINE channel not initialized", { httpStatus: 503 });
       connectionStatus = "connecting";
 
       await webhookListener.start(config.webhookPath, config.channelSecret, (payload) => {

--- a/src/channels/line/line-service.ts
+++ b/src/channels/line/line-service.ts
@@ -2,6 +2,7 @@
  * LINE Messaging API service — stubbed interfaces.
  */
 
+import { FridayDomainError } from "#errors";
 import { createHmac, timingSafeEqual } from "node:crypto";
 
 // ─── Types ───
@@ -113,7 +114,8 @@ export function validateLineWebhookSignature(
       return false;
     }
     return timingSafeEqual(received, expected);
-  } catch {
+  } catch (err) {
+    console.warn("[friday][line-service] operation failed:", err instanceof Error ? err.message : String(err));
     return false;
   }
 }
@@ -199,7 +201,8 @@ export function createLineWebhookListenerService(): LineWebhookListenerService {
           accepted: true,
           statusCode: 200,
         };
-      } catch {
+      } catch (err) {
+    console.warn("[friday][line-service] operation failed:", err instanceof Error ? err.message : String(err));
         return {
           accepted: false,
           statusCode: 400,
@@ -248,8 +251,10 @@ export function createLineApiService(): LineApiService {
 
     if (!response.ok) {
       const errorBody = await response.text().catch(() => "<unreadable>");
-      throw new Error(
+      throw new FridayDomainError(
+        "INTERNAL_ERROR",
         `LINE API error: ${response.status} ${response.statusText} — ${errorBody}`,
+        { httpStatus: 500 },
       );
     }
   }

--- a/src/channels/qq/friday-qq-channel.ts
+++ b/src/channels/qq/friday-qq-channel.ts
@@ -12,6 +12,7 @@
  *   - https://bot.q.qq.com/wiki/develop/api-v2/
  */
 
+import { FridayDomainError } from "#errors";
 import type {
   FridayChannelMessage,
   FridayChannelPlugin,
@@ -79,7 +80,7 @@ export function createFridayQqChannel(): FridayChannelPlugin {
     });
 
     if (!response.ok) {
-      throw new Error(`QQ token refresh failed: ${response.status} ${response.statusText}`);
+      throw new FridayDomainError("INTERNAL_ERROR", `QQ token refresh failed: ${response.status} ${response.statusText}`, { httpStatus: 500 });
     }
 
     const data = (await response.json()) as {
@@ -110,7 +111,7 @@ export function createFridayQqChannel(): FridayChannelPlugin {
     });
 
     if (!response.ok) {
-      throw new Error(`QQ gateway fetch failed: ${response.status}`);
+      throw new FridayDomainError("INTERNAL_ERROR", `QQ gateway fetch failed: ${response.status}`, { httpStatus: 500 });
     }
 
     const data = (await response.json()) as { url: string };
@@ -187,15 +188,22 @@ export function createFridayQqChannel(): FridayChannelPlugin {
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   let reconnectEpoch = 0;
 
-  function scheduleReconnect(gatewayUrl: string, delayMs = 5000): void {
+  // P2-CH: Exponential backoff for reconnection
+  const QQ_RECONNECT_INITIAL_MS = 1_000;
+  const QQ_RECONNECT_MAX_MS = 60_000;
+  let qqReconnectDelay = QQ_RECONNECT_INITIAL_MS;
+
+  function scheduleReconnect(gatewayUrl: string, delayMs?: number): void {
     if (stopped || reconnectTimer) return;
     const epoch = reconnectEpoch;
+    const effectiveDelay = delayMs ?? qqReconnectDelay;
 
     reconnectTimer = setTimeout(() => {
       reconnectTimer = null;
       if (stopped || epoch !== reconnectEpoch) return;
+      qqReconnectDelay = Math.min(qqReconnectDelay * 2, QQ_RECONNECT_MAX_MS);
       reconnect(gatewayUrl);
-    }, delayMs);
+    }, effectiveDelay);
   }
 
   function connectWebSocket(gatewayUrl: string): void {
@@ -208,7 +216,8 @@ export function createFridayQqChannel(): FridayChannelPlugin {
       let data: Record<string, unknown>;
       try {
         data = JSON.parse(String(event.data)) as Record<string, unknown>;
-      } catch {
+      } catch (err) {
+      console.warn("[friday][qq-channel] operation failed:", err instanceof Error ? err.message : String(err));
         return;
       }
 
@@ -222,6 +231,7 @@ export function createFridayQqChannel(): FridayChannelPlugin {
             (data.d as Record<string, unknown>)?.heartbeat_interval as number | undefined;
 
           sendIdentify();
+          qqReconnectDelay = QQ_RECONNECT_INITIAL_MS; // Reset backoff on successful connect
 
           if (heartbeatTimer) clearInterval(heartbeatTimer);
           heartbeatTimer = setInterval(
@@ -283,7 +293,8 @@ export function createFridayQqChannel(): FridayChannelPlugin {
     if (socket) {
       try {
         socket.close();
-      } catch {
+      } catch (err) {
+      console.warn("[friday][qq-channel] operation failed:", err instanceof Error ? err.message : String(err));
         // ignore
       }
     }
@@ -343,19 +354,23 @@ export function createFridayQqChannel(): FridayChannelPlugin {
   const plugin: FridayChannelPlugin = {
     kind: "qq",
     adapters,
+    contract: {
+      coreAuthority: { messageRouting: true, sessionMirroring: true, audit: true, evidence: true },
+      pluginResponsibilities: { config: true, auth: true, pairing: false, outboundDelivery: true, threadResolution: false, providerRetries: false },
+      supports: { directMessages: true, groupMessages: true, threads: false, typing: false },
+    },
 
     async init(rawConfig) {
+      // P1-CH-001: Use Zod schema for runtime config validation
+      const { FridayQqChannelConfigSchema } = await import("./qq-config.schema.js");
+      const parsed = FridayQqChannelConfigSchema.parse({ kind: "qq", ...rawConfig });
       config = {
-        appId: rawConfig.appId as string,
-        appSecret: rawConfig.appSecret as string,
-        sandbox: (rawConfig.sandbox as boolean) ?? false,
-        allowedUsers: rawConfig.allowedUsers as string[] | undefined,
-        allowedGroups: rawConfig.allowedGroups as string[] | undefined,
+        appId: parsed.appId,
+        appSecret: parsed.appSecret,
+        sandbox: parsed.sandbox,
+        allowedUsers: parsed.allowedUsers,
+        allowedGroups: parsed.allowedGroups,
       };
-
-      if (!config.appId || !config.appSecret) {
-        throw new Error("QQ channel requires appId and appSecret");
-      }
     },
 
     async start(handler) {
@@ -380,7 +395,8 @@ export function createFridayQqChannel(): FridayChannelPlugin {
         if (ws) {
           try {
             ws.close();
-          } catch {
+          } catch (err) {
+      console.warn("[friday][qq-channel] operation failed:", err instanceof Error ? err.message : String(err));
             // ignore
           }
           ws = null;
@@ -440,7 +456,7 @@ export function createFridayQqChannel(): FridayChannelPlugin {
 
       if (!response.ok) {
         const errorText = await response.text();
-        throw new Error(`QQ send failed: ${response.status} ${errorText}`);
+        throw new FridayDomainError("INTERNAL_ERROR", `QQ send failed: ${response.status} ${errorText}`, { httpStatus: 500 });
       }
 
       const result = (await response.json()) as { id?: string };

--- a/src/channels/qq/qq-config.schema.ts
+++ b/src/channels/qq/qq-config.schema.ts
@@ -1,0 +1,23 @@
+/**
+ * QQ channel configuration schema.
+ * P1-CH-001: Runtime config validation via Zod.
+ */
+
+import { z } from "zod";
+
+export const FridayQqChannelConfigSchema = z.object({
+  kind: z.literal("qq"),
+  enabled: z.boolean().default(true),
+  /** QQ Bot application ID. */
+  appId: z.string().min(1),
+  /** QQ Bot application secret. */
+  appSecret: z.string().min(1),
+  /** Use QQ sandbox environment. */
+  sandbox: z.boolean().default(false),
+  /** If set, only accept messages from these user IDs. */
+  allowedUsers: z.array(z.string()).optional(),
+  /** If set, only accept messages from these group IDs. */
+  allowedGroups: z.array(z.string()).optional(),
+});
+
+export type FridayQqChannelConfig = z.infer<typeof FridayQqChannelConfigSchema>;

--- a/src/channels/signal/friday-signal-channel.ts
+++ b/src/channels/signal/friday-signal-channel.ts
@@ -5,6 +5,7 @@
  * External calls are stubbed behind SignalSseService / SignalRpcService.
  */
 
+import { FridayDomainError } from "#errors";
 import type {
   FridayChannelMessage,
   FridayChannelPlugin,
@@ -101,7 +102,7 @@ export function createFridaySignalChannel(deps: SignalChannelDeps = {}): FridayC
 
   const outboundAdapter: FridayChannelOutboundAdapter = {
     async send(options: FridayChannelSendOptions): Promise<{ messageId: string }> {
-      if (!config) throw new Error("Signal channel not initialized");
+      if (!config) throw new FridayDomainError("NOT_INITIALIZED", "Signal channel not initialized", { httpStatus: 503 });
 
       const result = await rpc.sendMessage(config.baseUrl, config.account, {
         recipients: [options.chatId],
@@ -132,7 +133,7 @@ export function createFridaySignalChannel(deps: SignalChannelDeps = {}): FridayC
 
   const lifecycleAdapter: FridayChannelLifecycleAdapter = {
     async connect(eventHandler: (rawEvent: unknown) => void) {
-      if (!config) throw new Error("Signal channel not initialized");
+      if (!config) throw new FridayDomainError("NOT_INITIALIZED", "Signal channel not initialized", { httpStatus: 503 });
       connectionStatus = "connecting";
 
       await sse.connect(config.baseUrl, config.account, (msg) => {
@@ -160,13 +161,18 @@ export function createFridaySignalChannel(deps: SignalChannelDeps = {}): FridayC
   const plugin: FridayChannelPlugin = {
     kind: "signal",
     adapters,
+    contract: {
+      coreAuthority: { messageRouting: true, sessionMirroring: true, audit: true, evidence: true },
+      pluginResponsibilities: { config: true, auth: true, pairing: false, outboundDelivery: true, threadResolution: false, providerRetries: false },
+      supports: { directMessages: true, groupMessages: true, threads: false, typing: false },
+    },
 
     async init(rawConfig) {
       config = configAdapter.validate(rawConfig);
     },
 
     async start(handler) {
-      if (!config) throw new Error("Signal channel not initialized");
+      if (!config) throw new FridayDomainError("NOT_INITIALIZED", "Signal channel not initialized", { httpStatus: 503 });
       connectionStatus = "connecting";
 
       await sse.connect(config.baseUrl, config.account, (msg) => {

--- a/src/channels/signal/signal-service.ts
+++ b/src/channels/signal/signal-service.ts
@@ -2,6 +2,8 @@
  * Signal service — stubbed interfaces for signal-cli daemon SSE and JSON-RPC.
  */
 
+import { FridayDomainError } from "#errors";
+
 // ─── Types ───
 
 export interface SignalInboundMessage {
@@ -107,6 +109,7 @@ export function createSignalRpcServiceStub(): SignalRpcService {
  */
 export function createSignalSseService(): SignalSseService {
   let connected = false;
+  let stopped = false; // P2-CH: Track explicit stop to prevent reconnection logging after stop
   let abortController: AbortController | null = null;
 
   return {
@@ -116,7 +119,7 @@ export function createSignalSseService(): SignalSseService {
       onMessage: (msg: SignalInboundMessage) => void,
     ): Promise<void> {
       if (connected) {
-        throw new Error("Signal SSE service is already connected");
+        throw new FridayDomainError("CONFLICT", "Signal SSE service is already connected", { httpStatus: 409 });
       }
 
       abortController = new AbortController();
@@ -130,13 +133,15 @@ export function createSignalSseService(): SignalSseService {
 
       if (!response.ok) {
         const errorBody = await response.text().catch(() => "<unreadable>");
-        throw new Error(
+        throw new FridayDomainError(
+          "INTERNAL_ERROR",
           `Signal SSE connection failed: ${response.status} ${response.statusText} — ${errorBody}`,
+          { httpStatus: 500 },
         );
       }
 
       if (!response.body) {
-        throw new Error("Signal SSE response has no readable body");
+        throw new FridayDomainError("INTERNAL_ERROR", "Signal SSE response has no readable body", { httpStatus: 500 });
       }
 
       connected = true;
@@ -168,7 +173,8 @@ export function createSignalSseService(): SignalSseService {
               try {
                 const parsed = JSON.parse(jsonStr) as SignalInboundMessage;
                 onMessage(parsed);
-              } catch {
+              } catch (err) {
+                console.warn("[friday][signal-service] operation failed:", err instanceof Error ? err.message : String(err));
                 // Skip malformed JSON lines
               }
             }
@@ -184,12 +190,18 @@ export function createSignalSseService(): SignalSseService {
       };
 
       // Fire-and-forget; errors after initial connect surface in onMessage consumer
+      stopped = false;
       processStream().catch(() => {
         connected = false;
+        if (!stopped) {
+          // P2-CH: Log disconnection — the channel registry health monitor will auto-restart
+          console.warn("[friday] Signal SSE stream ended unexpectedly");
+        }
       });
     },
 
     async disconnect(): Promise<void> {
+      stopped = true;
       connected = false;
       if (abortController) {
         abortController.abort();
@@ -236,8 +248,10 @@ export function createSignalRpcService(): SignalRpcService {
 
       if (!response.ok) {
         const errorBody = await response.text().catch(() => "<unreadable>");
-        throw new Error(
+        throw new FridayDomainError(
+          "INTERNAL_ERROR",
           `Signal send failed: ${response.status} ${response.statusText} — ${errorBody}`,
+          { httpStatus: 500 },
         );
       }
 

--- a/src/channels/slack/friday-slack-channel.ts
+++ b/src/channels/slack/friday-slack-channel.ts
@@ -5,6 +5,7 @@
  * Sends via Slack Web API (chat.postMessage).
  */
 
+import { FridayDomainError } from "#errors";
 import type {
   FridayChannelMessage,
   FridayChannelPlugin,
@@ -105,7 +106,7 @@ export function createFridaySlackChannel(deps: SlackChannelDeps = {}): FridayCha
 
   const outboundAdapter: FridayChannelOutboundAdapter = {
     async send(options: FridayChannelSendOptions): Promise<{ messageId: string }> {
-      if (!config) throw new Error("Slack channel not initialized");
+      if (!config) throw new FridayDomainError("NOT_INITIALIZED", "Slack channel not initialized", { httpStatus: 503 });
 
       const result = await webApi.sendMessage(config.botToken, {
         channel: options.chatId,
@@ -136,12 +137,12 @@ export function createFridaySlackChannel(deps: SlackChannelDeps = {}): FridayCha
 
   const lifecycleAdapter: FridayChannelLifecycleAdapter = {
     async connect(eventHandler: (rawEvent: unknown) => void) {
-      if (!config) throw new Error("Slack channel not initialized");
+      if (!config) throw new FridayDomainError("NOT_INITIALIZED", "Slack channel not initialized", { httpStatus: 503 });
       connectionStatus = "connecting";
 
       if (config.mode === "http") {
         if (!config.signingSecret) {
-          throw new Error("Slack HTTP mode requires signingSecret in config");
+          throw new FridayDomainError("VALIDATION_ERROR", "Slack HTTP mode requires signingSecret in config", { httpStatus: 400 });
         }
         await httpEvents.start(config.signingSecret, (event) => {
           eventHandler(event);
@@ -206,7 +207,7 @@ export function createFridaySlackChannel(deps: SlackChannelDeps = {}): FridayCha
     },
 
     async start(handler) {
-      if (!config) throw new Error("Slack channel not initialized");
+      if (!config) throw new FridayDomainError("NOT_INITIALIZED", "Slack channel not initialized", { httpStatus: 503 });
       connectionStatus = "connecting";
 
       const eventHandler = (event: SlackMessageEvent) => {
@@ -216,7 +217,7 @@ export function createFridaySlackChannel(deps: SlackChannelDeps = {}): FridayCha
 
       if (config.mode === "http") {
         if (!config.signingSecret) {
-          throw new Error("Slack HTTP mode requires signingSecret in config");
+          throw new FridayDomainError("VALIDATION_ERROR", "Slack HTTP mode requires signingSecret in config", { httpStatus: 400 });
         }
         await httpEvents.start(config.signingSecret, eventHandler);
       } else {

--- a/src/channels/slack/slack-service.ts
+++ b/src/channels/slack/slack-service.ts
@@ -6,6 +6,8 @@
  * No external dependencies required.
  */
 
+import { FridayDomainError } from "#errors";
+
 // ─── Types ───
 
 export interface SlackMessageEvent {
@@ -163,8 +165,10 @@ export function createSlackWebApiService(): SlackWebApiService {
       });
 
       if (!res.ok) {
-        throw new Error(
+        throw new FridayDomainError(
+          "INTERNAL_ERROR",
           `Slack chat.postMessage HTTP error: ${res.status} ${res.statusText}`,
+          { httpStatus: 500 },
         );
       }
 
@@ -177,7 +181,7 @@ export function createSlackWebApiService(): SlackWebApiService {
       };
 
       if (!data.ok) {
-        throw new Error(`Slack chat.postMessage API error: ${data.error ?? "unknown"}`);
+        throw new FridayDomainError("INTERNAL_ERROR", `Slack chat.postMessage API error: ${data.error ?? "unknown"}`, { httpStatus: 500 });
       }
 
       return {
@@ -198,8 +202,10 @@ export function createSlackWebApiService(): SlackWebApiService {
       });
 
       if (!res.ok) {
-        throw new Error(
+        throw new FridayDomainError(
+          "INTERNAL_ERROR",
           `Slack users.info HTTP error: ${res.status} ${res.statusText}`,
+          { httpStatus: 500 },
         );
       }
 
@@ -212,7 +218,7 @@ export function createSlackWebApiService(): SlackWebApiService {
       if (!data.ok) {
         // user_not_found is a normal condition, return null
         if (data.error === "user_not_found") return null;
-        throw new Error(`Slack users.info API error: ${data.error ?? "unknown"}`);
+        throw new FridayDomainError("INTERNAL_ERROR", `Slack users.info API error: ${data.error ?? "unknown"}`, { httpStatus: 500 });
       }
 
       if (!data.user) return null;
@@ -237,11 +243,19 @@ const SOCKET_HEARTBEAT_INTERVAL_MS = 30_000;
  * pings, and `events_api` envelope acknowledgement. Message events are
  * forwarded to the caller-provided callback.
  */
+// P2-CH: Reconnection constants
+const SLACK_RECONNECT_INITIAL_MS = 1_000;
+const SLACK_RECONNECT_MAX_MS = 60_000;
+
 export function createSlackSocketService(): SlackSocketService {
   let ws: WebSocket | null = null;
   let connected = false;
+  let stopped = false;
   let abortController: AbortController | null = null;
   let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  let reconnectDelay = SLACK_RECONNECT_INITIAL_MS;
+  let lastConnectArgs: { appToken: string; botToken: string; onEvent: (event: SlackMessageEvent) => void } | null = null;
 
   function cleanup() {
     connected = false;
@@ -254,7 +268,8 @@ export function createSlackSocketService(): SlackSocketService {
     if (ws) {
       try {
         ws.close();
-      } catch {
+      } catch (err) {
+        console.warn("[friday][slack-service] operation failed:", err instanceof Error ? err.message : String(err));
         // already closed — ignore
       }
       ws = null;
@@ -269,6 +284,8 @@ export function createSlackSocketService(): SlackSocketService {
   return {
     async connect(appToken, _botToken, onEvent) {
       if (connected) return;
+      stopped = false;
+      lastConnectArgs = { appToken, botToken: _botToken, onEvent };
 
       abortController = new AbortController();
 
@@ -283,8 +300,10 @@ export function createSlackSocketService(): SlackSocketService {
       });
 
       if (!openRes.ok) {
-        throw new Error(
+        throw new FridayDomainError(
+          "INTERNAL_ERROR",
           `Slack apps.connections.open HTTP error: ${openRes.status} ${openRes.statusText}`,
+          { httpStatus: 500 },
         );
       }
 
@@ -295,8 +314,10 @@ export function createSlackSocketService(): SlackSocketService {
       };
 
       if (!openData.ok || !openData.url) {
-        throw new Error(
+        throw new FridayDomainError(
+          "INTERNAL_ERROR",
           `Slack apps.connections.open API error: ${openData.error ?? "missing url"}`,
+          { httpStatus: 500 },
         );
       }
 
@@ -327,13 +348,15 @@ export function createSlackSocketService(): SlackSocketService {
 
           try {
             envelope = JSON.parse(String(event.data));
-          } catch {
+          } catch (err) {
+        console.warn("[friday][slack-service] operation failed:", err instanceof Error ? err.message : String(err));
             return; // ignore malformed frames
           }
 
           // Handle hello — marks connection as ready
           if (envelope.type === "hello") {
             connected = true;
+            reconnectDelay = SLACK_RECONNECT_INITIAL_MS; // Reset backoff on successful connect
 
             // Start heartbeat pings
             heartbeatTimer = setInterval(() => {
@@ -358,7 +381,8 @@ export function createSlackSocketService(): SlackSocketService {
             if (innerEvent && innerEvent.type === "message") {
               try {
                 onEvent(innerEvent);
-              } catch {
+              } catch (err) {
+        console.warn("[friday][slack-service] operation failed:", err instanceof Error ? err.message : String(err));
                 // Callback error must not break the socket loop
               }
             }
@@ -377,6 +401,9 @@ export function createSlackSocketService(): SlackSocketService {
           cleanup();
           if (!wasConnected) {
             reject(new Error("Socket Mode WebSocket closed before hello"));
+          } else if (!stopped) {
+            // P2-CH: Log disconnection — the channel registry health monitor will auto-restart
+            console.warn("[friday] Slack Socket Mode disconnected unexpectedly");
           }
         });
 
@@ -395,6 +422,8 @@ export function createSlackSocketService(): SlackSocketService {
     },
 
     async disconnect() {
+      stopped = true;
+      if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
       cleanup();
     },
 

--- a/src/channels/telegram/friday-telegram-channel.ts
+++ b/src/channels/telegram/friday-telegram-channel.ts
@@ -7,6 +7,7 @@
  * External API calls are stubbed behind TelegramPollingService / TelegramApiService.
  */
 
+import { FridayDomainError } from "#errors";
 import type {
   FridayChannelMessage,
   FridayChannelPlugin,
@@ -107,7 +108,7 @@ export function createFridayTelegramChannel(deps: TelegramChannelDeps = {}): Fri
 
   const outboundAdapter: FridayChannelOutboundAdapter = {
     async send(options: FridayChannelSendOptions): Promise<{ messageId: string }> {
-      if (!config) throw new Error("Telegram channel not initialized");
+      if (!config) throw new FridayDomainError("NOT_INITIALIZED", "Telegram channel not initialized", { httpStatus: 503 });
 
       const result = await api.sendMessage(config.botToken, {
         chat_id: options.chatId,
@@ -138,12 +139,12 @@ export function createFridayTelegramChannel(deps: TelegramChannelDeps = {}): Fri
 
   const lifecycleAdapter: FridayChannelLifecycleAdapter = {
     async connect(eventHandler: (rawEvent: unknown) => void) {
-      if (!config) throw new Error("Telegram channel not initialized");
+      if (!config) throw new FridayDomainError("NOT_INITIALIZED", "Telegram channel not initialized", { httpStatus: 503 });
       connectionStatus = "connecting";
 
       if (config.mode === "webhook") {
         if (!config.webhookUrl) {
-          throw new Error("Telegram webhook mode requires webhookUrl in config");
+          throw new FridayDomainError("VALIDATION_ERROR", "Telegram webhook mode requires webhookUrl in config", { httpStatus: 400 });
         }
         await webhookService.startWebhook(config.botToken, config.webhookUrl, (update) => {
           eventHandler(update);
@@ -208,7 +209,7 @@ export function createFridayTelegramChannel(deps: TelegramChannelDeps = {}): Fri
     },
 
     async start(handler) {
-      if (!config) throw new Error("Telegram channel not initialized");
+      if (!config) throw new FridayDomainError("NOT_INITIALIZED", "Telegram channel not initialized", { httpStatus: 503 });
       connectionStatus = "connecting";
 
       const updateHandler = (update: TelegramUpdate) => {
@@ -218,7 +219,7 @@ export function createFridayTelegramChannel(deps: TelegramChannelDeps = {}): Fri
 
       if (config.mode === "webhook") {
         if (!config.webhookUrl) {
-          throw new Error("Telegram webhook mode requires webhookUrl in config");
+          throw new FridayDomainError("VALIDATION_ERROR", "Telegram webhook mode requires webhookUrl in config", { httpStatus: 400 });
         }
         await webhookService.startWebhook(config.botToken, config.webhookUrl, updateHandler);
       } else {

--- a/src/channels/telegram/telegram-service.ts
+++ b/src/channels/telegram/telegram-service.ts
@@ -4,6 +4,8 @@
  * Real implementations use Node's built-in fetch (Node 22+).
  */
 
+import { FridayDomainError } from "#errors";
+
 // ─── Types ───
 
 export interface TelegramUser {
@@ -176,8 +178,10 @@ export function createTelegramPollingService(
 
         if (!res.ok) {
           const text = await res.text().catch(() => "");
-          throw new Error(
+          throw new FridayDomainError(
+            "INTERNAL_ERROR",
             `Telegram getUpdates failed: HTTP ${res.status} ${res.statusText}${text ? ` — ${text}` : ""}`,
+            { httpStatus: 500 },
           );
         }
 
@@ -188,8 +192,10 @@ export function createTelegramPollingService(
         };
 
         if (!json.ok) {
-          throw new Error(
+          throw new FridayDomainError(
+            "INTERNAL_ERROR",
             `Telegram getUpdates returned ok=false: ${json.description ?? "unknown error"}`,
+            { httpStatus: 500 },
           );
         }
 
@@ -271,8 +277,10 @@ export function createTelegramWebhookService(): TelegramWebhookService {
 
       if (!res.ok) {
         const text = await res.text().catch(() => "");
-        throw new Error(
+        throw new FridayDomainError(
+          "INTERNAL_ERROR",
           `Telegram setWebhook failed: HTTP ${res.status} ${res.statusText}${text ? ` — ${text}` : ""}`,
+          { httpStatus: 500 },
         );
       }
 
@@ -282,8 +290,10 @@ export function createTelegramWebhookService(): TelegramWebhookService {
       };
 
       if (!json.ok) {
-        throw new Error(
+        throw new FridayDomainError(
+          "INTERNAL_ERROR",
           `Telegram setWebhook returned ok=false: ${json.description ?? "unknown error"}`,
+          { httpStatus: 500 },
         );
       }
 
@@ -311,8 +321,10 @@ export function createTelegramWebhookService(): TelegramWebhookService {
 
         if (!res.ok) {
           const text = await res.text().catch(() => "");
-          throw new Error(
+          throw new FridayDomainError(
+            "INTERNAL_ERROR",
             `Telegram deleteWebhook failed: HTTP ${res.status} ${res.statusText}${text ? ` — ${text}` : ""}`,
+            { httpStatus: 500 },
           );
         }
       } finally {
@@ -344,8 +356,10 @@ export function createTelegramApiService(): TelegramApiService {
 
       if (!res.ok) {
         const text = await res.text().catch(() => "");
-        throw new Error(
+        throw new FridayDomainError(
+          "INTERNAL_ERROR",
           `Telegram sendMessage failed: HTTP ${res.status} ${res.statusText}${text ? ` — ${text}` : ""}`,
+          { httpStatus: 500 },
         );
       }
 
@@ -354,8 +368,10 @@ export function createTelegramApiService(): TelegramApiService {
       };
 
       if (!json.ok) {
-        throw new Error(
+        throw new FridayDomainError(
+          "INTERNAL_ERROR",
           `Telegram sendMessage returned ok=false: ${json.description ?? "unknown error"}`,
+          { httpStatus: 500 },
         );
       }
 

--- a/src/channels/webchat/friday-webchat-channel.ts
+++ b/src/channels/webchat/friday-webchat-channel.ts
@@ -5,6 +5,7 @@
  * to send and receive messages from Friday.
  */
 
+import { FridayDomainError } from "#errors";
 import type {
   FridayChannelMessage,
   FridayChannelPlugin,
@@ -116,7 +117,7 @@ export function createFridayWebchatChannel(deps: WebchatChannelDeps = {}): Frida
 
   const lifecycleAdapter: FridayChannelLifecycleAdapter = {
     async connect(eventHandler: (rawEvent: unknown) => void) {
-      if (!config) throw new Error("Webchat channel not initialized");
+      if (!config) throw new FridayDomainError("NOT_INITIALIZED", "Webchat channel not initialized", { httpStatus: 503 });
       connectionStatus = "connecting";
 
       await wsService.start(config.wsPath, config.allowedOrigins, (msg) => {
@@ -173,7 +174,7 @@ export function createFridayWebchatChannel(deps: WebchatChannelDeps = {}): Frida
     },
 
     async start(handler) {
-      if (!config) throw new Error("Webchat channel not initialized");
+      if (!config) throw new FridayDomainError("NOT_INITIALIZED", "Webchat channel not initialized", { httpStatus: 503 });
       connectionStatus = "connecting";
 
       await wsService.start(config.wsPath, config.allowedOrigins, (msg) => {

--- a/src/channels/webchat/webchat-service.ts
+++ b/src/channels/webchat/webchat-service.ts
@@ -164,7 +164,8 @@ export function createWebchatWsService(): WebchatWsService {
         try {
           sendWsClose(socket, 1001);
           socket.destroy();
-        } catch {
+        } catch (err) {
+        console.warn("[friday][webchat-service] operation failed:", err instanceof Error ? err.message : String(err));
           // Best-effort cleanup.
         }
       }
@@ -238,7 +239,8 @@ export function createWebchatWsService(): WebchatWsService {
         try {
           sendWsClose(previous, 1001);
           previous.destroy();
-        } catch {
+        } catch (err) {
+        console.warn("[friday][webchat-service] operation failed:", err instanceof Error ? err.message : String(err));
           // Best-effort stale client replacement.
         }
       }
@@ -292,7 +294,8 @@ export function createWebchatWsService(): WebchatWsService {
             let parsed: unknown;
             try {
               parsed = JSON.parse(payloadData.toString("utf-8"));
-            } catch {
+            } catch (err) {
+        console.warn("[friday][webchat-service] operation failed:", err instanceof Error ? err.message : String(err));
               writeJsonToClient(socket, {
                 type: "error",
                 code: "INVALID_JSON",

--- a/src/channels/whatsapp/friday-whatsapp-channel.ts
+++ b/src/channels/whatsapp/friday-whatsapp-channel.ts
@@ -6,6 +6,7 @@
  * - bridge: Third-party bridge (e.g. whatsapp-web.js bridge)
  */
 
+import { FridayDomainError } from "#errors";
 import type {
   FridayChannelMessage,
   FridayChannelPlugin,
@@ -124,11 +125,11 @@ export function createFridayWhatsappChannel(deps: WhatsappChannelDeps = {}): Fri
 
   const outboundAdapter: FridayChannelOutboundAdapter = {
     async send(options: FridayChannelSendOptions): Promise<{ messageId: string }> {
-      if (!config) throw new Error("WhatsApp channel not initialized");
+      if (!config) throw new FridayDomainError("NOT_INITIALIZED", "WhatsApp channel not initialized", { httpStatus: 503 });
 
       if (config.provider === "cloud-api") {
         if (!config.accessToken || !config.phoneNumberId) {
-          throw new Error("WhatsApp Cloud API requires accessToken and phoneNumberId");
+          throw new FridayDomainError("VALIDATION_ERROR", "WhatsApp Cloud API requires accessToken and phoneNumberId", { httpStatus: 400 });
         }
 
         const result = await api.sendMessage(config.accessToken, config.phoneNumberId, {
@@ -165,7 +166,7 @@ export function createFridayWhatsappChannel(deps: WhatsappChannelDeps = {}): Fri
 
   const lifecycleAdapter: FridayChannelLifecycleAdapter = {
     async connect(eventHandler: (rawEvent: unknown) => void) {
-      if (!config) throw new Error("WhatsApp channel not initialized");
+      if (!config) throw new FridayDomainError("NOT_INITIALIZED", "WhatsApp channel not initialized", { httpStatus: 503 });
       connectionStatus = "connecting";
 
       webhook.setAppSecret?.(config.appSecret);
@@ -220,10 +221,14 @@ export function createFridayWhatsappChannel(deps: WhatsappChannelDeps = {}): Fri
 
     async init(rawConfig) {
       config = configAdapter.validate(rawConfig);
+      // P2-SEC: Warn if appSecret is missing — webhook signatures cannot be verified
+      if (!config.appSecret) {
+        console.warn("[friday][SECURITY] WhatsApp appSecret not configured — webhook signature validation will be skipped");
+      }
     },
 
     async start(handler) {
-      if (!config) throw new Error("WhatsApp channel not initialized");
+      if (!config) throw new FridayDomainError("NOT_INITIALIZED", "WhatsApp channel not initialized", { httpStatus: 503 });
       connectionStatus = "connecting";
 
       webhook.setAppSecret?.(config.appSecret);

--- a/src/channels/whatsapp/whatsapp-config.schema.ts
+++ b/src/channels/whatsapp/whatsapp-config.schema.ts
@@ -21,7 +21,7 @@ export const FridayWhatsappChannelConfigSchema = z.object({
   allowedUsers: z.array(z.string()).optional(),
   /** If set, only accept messages from these chat IDs. */
   allowedChats: z.array(z.string()).optional(),
-  /** Meta App Secret for webhook HMAC-SHA256 signature validation. */
+  /** Meta App Secret for webhook HMAC-SHA256 signature validation. Recommended for secure webhook verification. */
   appSecret: z.string().optional(),
 });
 

--- a/src/channels/whatsapp/whatsapp-service.ts
+++ b/src/channels/whatsapp/whatsapp-service.ts
@@ -2,6 +2,7 @@
  * WhatsApp Cloud API / Bridge service — stubbed interfaces.
  */
 
+import { FridayDomainError } from "#errors";
 import { createHmac, timingSafeEqual } from "node:crypto";
 
 // ─── Webhook Signature Validation ───
@@ -44,7 +45,8 @@ export function validateWhatsappWebhookSignature(
     }
 
     return timingSafeEqual(receivedBuf, expectedBuf);
-  } catch {
+  } catch (err) {
+    console.warn("[friday][whatsapp-service] operation failed:", err instanceof Error ? err.message : String(err));
     // Defensive: any unexpected error → treat as invalid
     return false;
   }
@@ -272,7 +274,8 @@ export function createWhatsappWebhookService(): WhatsappWebhookService {
           accepted: true,
           statusCode: 200,
         };
-      } catch {
+      } catch (err) {
+    console.warn("[friday][whatsapp-service] operation failed:", err instanceof Error ? err.message : String(err));
         return {
           accepted: false,
           statusCode: 400,
@@ -318,8 +321,10 @@ export function createWhatsappApiService(): WhatsappApiService {
 
       if (!response.ok) {
         const errorBody = await response.text().catch(() => "<unreadable>");
-        throw new Error(
+        throw new FridayDomainError(
+          "INTERNAL_ERROR",
           `WhatsApp Cloud API error: ${response.status} ${response.statusText} — ${errorBody}`,
+          { httpStatus: 500 },
         );
       }
 

--- a/src/cli/friday-cli-run-loop.ts
+++ b/src/cli/friday-cli-run-loop.ts
@@ -78,14 +78,16 @@ export function runFridayCliLoop(deps: FridayCliRunLoopDeps): Promise<void> {
 
       try {
         await httpServer.close();
-      } catch {
+      } catch (err) {
         // Best-effort close
+        console.warn("[friday][cli-run-loop] http server close failed:", err instanceof Error ? err.message : String(err));
       }
 
       try {
         await hub.stop();
-      } catch {
+      } catch (err) {
         // Best-effort stop
+        console.warn("[friday][cli-run-loop] hub stop failed:", err instanceof Error ? err.message : String(err));
       }
 
       resolve();

--- a/src/cli/friday-cli-tui.ts
+++ b/src/cli/friday-cli-tui.ts
@@ -6,6 +6,7 @@
  * @module cli/friday-cli-tui
  */
 
+import { FridayDomainError } from "#errors";
 import { createFridayTuiApiClient } from "../tui/friday-tui-api-client.js";
 import { createFridayTuiRenderer } from "../tui/friday-tui-renderer.js";
 import { createFridayTuiController } from "../tui/friday-tui-controller.js";
@@ -37,7 +38,7 @@ export async function runFridayCliTui(options: FridayCliTuiOptions = {}): Promis
         body: init?.body,
         headers: init?.headers,
       });
-      if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`);
+      if (!res.ok) throw new FridayDomainError("INTERNAL_ERROR", `HTTP ${res.status}: ${res.statusText}`, { httpStatus: 500 });
       return res.json() as Promise<T>;
     },
     baseUrl: config.apiBaseUrl,

--- a/src/cli/friday-cli.ts
+++ b/src/cli/friday-cli.ts
@@ -40,7 +40,7 @@ import {
 } from "#providers";
 import { parseFridayHttpTrustProxyMode } from "#api";
 import { resolveFridayDbPath } from "#state";
-import { resolveSafePath } from "#utilities";
+import { resolveSafePath, safeJsonParse } from "#utilities";
 import Database from "better-sqlite3";
 import {
   createFridayLocalDaemonService,
@@ -906,24 +906,20 @@ function readSetupStateChannels(db: Database.Database): FridayPersistedSetupChan
   if (!row?.channels_json) {
     return [];
   }
-  try {
-    const parsed = JSON.parse(row.channels_json) as unknown;
-    if (!Array.isArray(parsed)) {
-      return [];
-    }
-    return parsed
-      .filter((item): item is { kind?: unknown; enabled?: unknown; config?: unknown } =>
-        isObject(item),
-      )
-      .map((item) => ({
-        kind: String(item.kind ?? "").trim() as FridaySupportedChannelKind,
-        enabled: item.enabled !== false,
-        config: isObject(item.config) ? item.config : {},
-      }))
-      .filter((item) => item.kind.length > 0);
-  } catch {
+  const parsed = safeJsonParse(row.channels_json) as unknown;
+  if (!Array.isArray(parsed)) {
     return [];
   }
+  return parsed
+    .filter((item): item is { kind?: unknown; enabled?: unknown; config?: unknown } =>
+      isObject(item),
+    )
+    .map((item) => ({
+      kind: String(item.kind ?? "").trim() as FridaySupportedChannelKind,
+      enabled: item.enabled !== false,
+      config: isObject(item.config) ? item.config : {},
+    }))
+    .filter((item) => item.kind.length > 0);
 }
 
 function buildPersistedChannelsFromLegacyMap(rawMap: JsonObject): FridayPersistedSetupChannel[] {
@@ -1196,7 +1192,8 @@ export function loadProcessEnvFromDotEnvFile(options?: {
   let text = "";
   try {
     text = readFileSync(envPath, "utf8");
-  } catch {
+  } catch (err) {
+    console.warn("[friday][cli] .env file read failed:", err instanceof Error ? err.message : String(err));
     return;
   }
 
@@ -1270,7 +1267,8 @@ export function readSetupNetworkBinding(dbPath: string): FridayStartupNetworkBin
     if (!host || !port) return undefined;
 
     return { host, port };
-  } catch {
+  } catch (err) {
+    console.warn("[friday][cli] daemon address lookup failed:", err instanceof Error ? err.message : String(err));
     return undefined;
   } finally {
     db?.close();
@@ -2067,7 +2065,8 @@ export function isCliEntrypointPath(argvPath: string | undefined, moduleUrl: str
 
   try {
     return realpathSync(argvPath) === realpathSync(modulePath);
-  } catch {
+  } catch (err) {
+    console.warn("[friday][cli] entrypoint path resolution failed:", err instanceof Error ? err.message : String(err));
     return argvPath === modulePath;
   }
 }

--- a/src/config/friday-config-backup-rotation.ts
+++ b/src/config/friday-config-backup-rotation.ts
@@ -10,15 +10,17 @@ export async function rotateFridayConfigBackups(
   // Check if original config file exists
   try {
     await fs.access(configPath);
-  } catch {
+  } catch (err) {
+    console.warn("[friday][config-backup-rotation] config file not accessible:", err instanceof Error ? err.message : String(err));
     return; // Nothing to back up
   }
 
   // Drop the oldest backup if it exists
   try {
     await fs.unlink(`${configPath}.bak.${maxBackups - 1}`);
-  } catch {
+  } catch (err) {
     // Doesn't exist, fine
+    console.warn("[friday][config-backup-rotation] oldest backup removal skipped:", err instanceof Error ? err.message : String(err));
   }
 
   // Rotate existing numbered backups downward: .bak.i -> .bak.(i+1)
@@ -27,16 +29,18 @@ export async function rotateFridayConfigBackups(
     const dest = `${configPath}.bak.${i + 1}`;
     try {
       await fs.rename(src, dest);
-    } catch {
+    } catch (err) {
       // Source doesn't exist, skip
+      console.warn("[friday][config-backup-rotation] backup rotation skipped:", err instanceof Error ? err.message : String(err));
     }
   }
 
   // Rotate .bak -> .bak.1
   try {
     await fs.rename(`${configPath}.bak`, `${configPath}.bak.1`);
-  } catch {
+  } catch (err) {
     // .bak doesn't exist, skip
+    console.warn("[friday][config-backup-rotation] bak rename skipped:", err instanceof Error ? err.message : String(err));
   }
 
   // Copy current config to .bak

--- a/src/daemon/friday-daemon-pidfile.ts
+++ b/src/daemon/friday-daemon-pidfile.ts
@@ -56,7 +56,8 @@ export function readPidRecord(
       };
     }
     return { ok: true, value: record };
-  } catch {
+  } catch (err) {
+    console.warn("[friday][daemon-pidfile] PID file parse failed:", err instanceof Error ? err.message : String(err));
     return {
       ok: false,
       error: {
@@ -101,8 +102,9 @@ export function removePidFile(
 ): void {
   try {
     deps.removeFile(pidFilePath);
-  } catch {
+  } catch (err) {
     // Ignore — file may already be removed
+    console.warn("[friday][daemon-pidfile] pid file removal failed:", err instanceof Error ? err.message : String(err));
   }
 }
 

--- a/src/daemon/friday-daemon-runtime.ts
+++ b/src/daemon/friday-daemon-runtime.ts
@@ -91,7 +91,8 @@ export function createFridayLocalDaemonService(
       readFile: (filePath: string) => {
         try {
           return readFileSync(filePath, "utf-8");
-        } catch {
+        } catch (err) {
+          console.warn("[friday][daemon-runtime] pid file read failed:", err instanceof Error ? err.message : String(err));
           return null;
         }
       },
@@ -101,8 +102,9 @@ export function createFridayLocalDaemonService(
       removeFile: (filePath: string) => {
         try {
           unlinkSync(filePath);
-        } catch {
+        } catch (err) {
           // Ignore if the file is already gone.
+          console.warn("[friday][daemon-runtime] pid file remove failed:", err instanceof Error ? err.message : String(err));
         }
       },
       mkdirp: (dirPath: string) => {
@@ -112,7 +114,8 @@ export function createFridayLocalDaemonService(
         try {
           process.kill(pid, 0);
           return true;
-        } catch {
+        } catch (err) {
+          console.warn("[friday][daemon-runtime] process alive check failed:", err instanceof Error ? err.message : String(err));
           return false;
         }
       },
@@ -161,7 +164,8 @@ export function createFridayLocalDaemonService(
         try {
           process.kill(pid, signal);
           return true;
-        } catch {
+        } catch (err) {
+          console.warn("[friday][daemon-runtime] signal send failed:", err instanceof Error ? err.message : String(err));
           return false;
         }
       },
@@ -170,7 +174,8 @@ export function createFridayLocalDaemonService(
         while (Date.now() - start < timeoutMs) {
           try {
             process.kill(pid, 0);
-          } catch {
+          } catch (err) {
+            console.warn("[friday][daemon-runtime] process exit detected:", err instanceof Error ? err.message : String(err));
             return true;
           }
           await new Promise((resolvePromise) => setTimeout(resolvePromise, 200));

--- a/src/desktop/engine/action-executor.ts
+++ b/src/desktop/engine/action-executor.ts
@@ -152,7 +152,7 @@ function validateAction(action: FridayDesktopAction): string | null {
   if (!action || typeof action !== "object") {
     return "Action must be a non-null object";
   }
-  if (!FRIDAY_DESKTOP_ACTION_TYPES.includes((action as { type?: string }).type as any)) {
+  if (!(FRIDAY_DESKTOP_ACTION_TYPES as readonly string[]).includes((action as { type?: string }).type ?? "")) {
     return `Unknown action type: '${(action as { type?: string }).type}'`;
   }
 
@@ -193,7 +193,7 @@ function validateAction(action: FridayDesktopAction): string | null {
       }
       return null;
     case "clipboard":
-      if (!FRIDAY_DESKTOP_CLIPBOARD_OPERATIONS.includes(action.operation as any)) {
+      if (!(FRIDAY_DESKTOP_CLIPBOARD_OPERATIONS as readonly string[]).includes(action.operation)) {
         return "Clipboard action requires valid 'operation' field";
       }
       if (action.operation === "write" && !isNonEmptyString(action.content)) {
@@ -201,7 +201,7 @@ function validateAction(action: FridayDesktopAction): string | null {
       }
       return null;
     case "file_operation":
-      if (!FRIDAY_DESKTOP_FILE_OPERATIONS.includes(action.operation as any)) {
+      if (!(FRIDAY_DESKTOP_FILE_OPERATIONS as readonly string[]).includes(action.operation)) {
         return "FileOperation action requires valid 'operation' field";
       }
       if (!isNonEmptyString(action.path)) {
@@ -325,7 +325,8 @@ async function evaluateSandboxBoundary(
         const normalizedRoot = path.resolve(rootPath);
         try {
           return await resolveRealSandboxPath(normalizedRoot);
-        } catch {
+        } catch (err) {
+          console.warn("[friday][action-executor] sandbox path resolution failed:", err instanceof Error ? err.message : String(err));
           return normalizedRoot;
         }
       }),

--- a/src/desktop/engine/friday-desktop-adapters.ts
+++ b/src/desktop/engine/friday-desktop-adapters.ts
@@ -1,3 +1,5 @@
+import { FridayDomainError } from "#errors";
+
 /**
  * C-001 Real Desktop Adapters — macOS, Windows, and Linux implementations
  * of the FridayDesktopAdapterRuntime interface.
@@ -112,7 +114,8 @@ async function detectOsVersion(
         return result.exitCode === 0 ? result.stdout : "unknown";
       }
     }
-  } catch {
+  } catch (err) {
+    console.warn("[friday][desktop-adapters] detect-os-version:", err instanceof Error ? err.message : String(err));
     return "unknown";
   }
 }
@@ -216,21 +219,21 @@ function escapePowerShellSingleQuoted(value: string): string {
 
 function ensureFiniteInteger(value: number, fieldName: string): number {
   if (!Number.isFinite(value)) {
-    throw new Error(`Invalid ${fieldName}: must be a finite number`);
+    throw new FridayDomainError("VALIDATION_ERROR", `Invalid ${fieldName}: must be a finite number`, { httpStatus: 400 });
   }
   return Math.trunc(value);
 }
 
 function ensureSafeAppIdentifier(value: string): string {
   if (!SAFE_APP_IDENTIFIER_RE.test(value)) {
-    throw new Error("Unsafe app identifier");
+    throw new FridayDomainError("VALIDATION_ERROR", "Unsafe app identifier", { httpStatus: 400 });
   }
   return value;
 }
 
 function ensureSafeXdotoolKeyCombo(value: string): string {
   if (!SAFE_XDOTOOL_KEY_RE.test(value)) {
-    throw new Error("Unsafe key combo");
+    throw new FridayDomainError("VALIDATION_ERROR", "Unsafe key combo", { httpStatus: 400 });
   }
   return value;
 }
@@ -450,7 +453,8 @@ export async function createDarwinAdapter(
           selector.appBundleId ?? "unknown",
           { x: 0, y: 0, width: 0, height: 0 },
         );
-      } catch {
+      } catch (err) {
+        console.warn("[friday][desktop-adapters] darwin-inspectElement:", err instanceof Error ? err.message : String(err));
         return null;
       }
     },
@@ -469,7 +473,8 @@ export async function createDarwinAdapter(
           appBundleId ?? "unknown",
           { x: 0, y: 0, width: 0, height: 0 },
         ));
-      } catch {
+      } catch (err) {
+        console.warn("[friday][desktop-adapters] darwin-searchElements:", err instanceof Error ? err.message : String(err));
         return [];
       }
     },
@@ -491,7 +496,7 @@ export async function createDarwinAdapter(
             try {
               const result = await exec("osascript -e 'tell application \"System Events\" to get name of first process' 2>&1");
               status = result.exitCode === 0 ? "granted" : "denied";
-            } catch { status = "denied"; }
+            } catch (err) { console.warn("[friday][desktop-adapters] darwin-check-accessibility:", err instanceof Error ? err.message : String(err)); status = "denied"; }
             instructions = "System Settings → Privacy & Security → Accessibility → Enable Friday";
             break;
           case "screen_recording":
@@ -695,7 +700,8 @@ export async function createWin32Adapter(
           selector.appBundleId ?? "unknown",
           { x: 0, y: 0, width: 0, height: 0 },
         );
-      } catch {
+      } catch (err) {
+        console.warn("[friday][desktop-adapters] win32-inspectElement:", err instanceof Error ? err.message : String(err));
         return null;
       }
     },
@@ -752,14 +758,14 @@ export async function createLinuxAdapter(
   try {
     const deResult = await exec("echo $XDG_CURRENT_DESKTOP 2>/dev/null || echo unknown");
     desktopEnv = deResult.stdout || "unknown";
-  } catch { /* keep unknown */ }
+  } catch (err) { /* keep unknown */ console.warn("[friday][desktop-adapters] detect-desktop-env:", err instanceof Error ? err.message : String(err)); }
 
   // Check for xdotool
   let hasXdotool = false;
   try {
     const xdResult = await exec("which xdotool 2>/dev/null");
     hasXdotool = xdResult.exitCode === 0;
-  } catch { /* not available */ }
+  } catch (err) { /* not available */ console.warn("[friday][desktop-adapters] detect-xdotool:", err instanceof Error ? err.message : String(err)); }
 
   const metadata: FridayDesktopAdapter = {
     id: "linux-atspi-v1",
@@ -800,7 +806,7 @@ export async function createLinuxAdapter(
           const mods = (action.modifiers ?? []).map((modifier) => {
             const mapped = modifier === "meta" || modifier === "command" ? "super" : modifier;
             if (!SAFE_XDOTOOL_KEY_RE.test(mapped)) {
-              throw new Error("Unsafe modifier");
+              throw new FridayDomainError("VALIDATION_ERROR", "Unsafe modifier", { httpStatus: 400 });
             }
             return mapped;
           });
@@ -962,7 +968,7 @@ export async function createLinuxAdapter(
             try {
               const result = await exec("dbus-send --session --dest=org.a11y.Bus --print-reply /org/a11y/bus org.freedesktop.DBus.Peer.Ping 2>/dev/null");
               status = result.exitCode === 0 ? "granted" : "not_determined";
-            } catch { status = "not_determined"; }
+            } catch (err) { console.warn("[friday][desktop-adapters] linux-check-accessibility:", err instanceof Error ? err.message : String(err)); status = "not_determined"; }
             instructions = "Enable AT-SPI2: gsettings set org.gnome.desktop.interface toolkit-accessibility true";
             break;
           }

--- a/src/desktop/engine/permission-guard.ts
+++ b/src/desktop/engine/permission-guard.ts
@@ -1,3 +1,5 @@
+import { FridayDomainError } from "#errors";
+
 /**
  * Permission Guard — Multi-layer permission checking for desktop actions.
  *
@@ -226,7 +228,7 @@ function riskRequiresConfirmation(riskLevel: FridayDesktopRiskLevel): boolean {
 }
 
 function assertNever(value: never): never {
-  throw new Error(`Unhandled desktop action variant: ${JSON.stringify(value)}`);
+  throw new FridayDomainError("INTERNAL_ERROR", `Unhandled desktop action variant: ${JSON.stringify(value)}`, { httpStatus: 500 });
 }
 
 function resolveRequiredCapability(action: FridayDesktopAction): FridayDesktopCapability {

--- a/src/desktop/engine/recording-engine.ts
+++ b/src/desktop/engine/recording-engine.ts
@@ -1,3 +1,5 @@
+import { FridayDomainError } from "#errors";
+
 /**
  * Recording Engine — Record and replay desktop interaction sequences.
  *
@@ -203,15 +205,11 @@ export function createRecordingEngine(config: RecordingEngineConfig): RecordingE
   ): FridayDesktopRecording {
     const recording = recordings.get(recordingId);
     if (!recording) {
-      throw new Error(
-        `${FRIDAY_DESKTOP_ERROR_CODES.RECORDING_NOT_FOUND}: Recording '${recordingId}' not found`,
-      );
+      throw new FridayDomainError("NOT_FOUND", `${FRIDAY_DESKTOP_ERROR_CODES.RECORDING_NOT_FOUND}: Recording '${recordingId}' not found`, { httpStatus: 404 });
     }
 
     if (!isValidTransition(recording.state, targetState)) {
-      throw new Error(
-        `${FRIDAY_DESKTOP_ERROR_CODES.RECORDING_INVALID_STATE}: Cannot transition from '${recording.state}' to '${targetState}'`,
-      );
+      throw new FridayDomainError("VALIDATION_ERROR", `${FRIDAY_DESKTOP_ERROR_CODES.RECORDING_INVALID_STATE}: Cannot transition from '${recording.state}' to '${targetState}'`, { httpStatus: 400 });
     }
 
     const now = config.nowIso();
@@ -272,14 +270,10 @@ export function createRecordingEngine(config: RecordingEngineConfig): RecordingE
     ): FridayDesktopRecordingStep {
       const recording = recordings.get(recordingId);
       if (!recording) {
-        throw new Error(
-          `${FRIDAY_DESKTOP_ERROR_CODES.RECORDING_NOT_FOUND}: Recording '${recordingId}' not found`,
-        );
+        throw new FridayDomainError("NOT_FOUND", `${FRIDAY_DESKTOP_ERROR_CODES.RECORDING_NOT_FOUND}: Recording '${recordingId}' not found`, { httpStatus: 404 });
       }
       if (recording.state !== "recording") {
-        throw new Error(
-          `${FRIDAY_DESKTOP_ERROR_CODES.RECORDING_INVALID_STATE}: Recording is '${recording.state}', expected 'recording'`,
-        );
+        throw new FridayDomainError("VALIDATION_ERROR", `${FRIDAY_DESKTOP_ERROR_CODES.RECORDING_INVALID_STATE}: Recording is '${recording.state}', expected 'recording'`, { httpStatus: 400 });
       }
 
       const recordingSteps = steps.get(recordingId)!;
@@ -339,14 +333,10 @@ export function createRecordingEngine(config: RecordingEngineConfig): RecordingE
     ): Promise<ReplayResult> {
       const recording = recordings.get(recordingId);
       if (!recording) {
-        throw new Error(
-          `${FRIDAY_DESKTOP_ERROR_CODES.RECORDING_NOT_FOUND}: Recording '${recordingId}' not found`,
-        );
+        throw new FridayDomainError("NOT_FOUND", `${FRIDAY_DESKTOP_ERROR_CODES.RECORDING_NOT_FOUND}: Recording '${recordingId}' not found`, { httpStatus: 404 });
       }
       if (recording.state !== "stopped") {
-        throw new Error(
-          `${FRIDAY_DESKTOP_ERROR_CODES.RECORDING_INVALID_STATE}: Recording must be stopped for replay, current state: '${recording.state}'`,
-        );
+        throw new FridayDomainError("VALIDATION_ERROR", `${FRIDAY_DESKTOP_ERROR_CODES.RECORDING_INVALID_STATE}: Recording must be stopped for replay, current state: '${recording.state}'`, { httpStatus: 400 });
       }
 
       const recordingSteps = steps.get(recordingId) ?? [];
@@ -404,9 +394,7 @@ export function createRecordingEngine(config: RecordingEngineConfig): RecordingE
     ): FridayDesktopRecording {
       const recording = recordings.get(recordingId);
       if (!recording) {
-        throw new Error(
-          `${FRIDAY_DESKTOP_ERROR_CODES.RECORDING_NOT_FOUND}: Recording '${recordingId}' not found`,
-        );
+        throw new FridayDomainError("NOT_FOUND", `${FRIDAY_DESKTOP_ERROR_CODES.RECORDING_NOT_FOUND}: Recording '${recordingId}' not found`, { httpStatus: 404 });
       }
 
       const updated: FridayDesktopRecording = {

--- a/src/desktop/engine/session-manager.ts
+++ b/src/desktop/engine/session-manager.ts
@@ -1,3 +1,5 @@
+import { FridayDomainError } from "#errors";
+
 /**
  * Desktop Session Manager — Orchestrates the desktop control runtime lifecycle.
  *
@@ -234,7 +236,7 @@ export function createDesktopSessionManager(
 
   function ensureConnected(): void {
     if (state !== "connected") {
-      throw new Error("Desktop session is not connected");
+      throw new FridayDomainError("NOT_INITIALIZED", "Desktop session is not connected", { httpStatus: 503 });
     }
   }
 
@@ -392,7 +394,7 @@ export function createDesktopSessionManager(
         .filter((recording) => recording.state === "recording" || recording.state === "paused");
 
       if (activeRecordings.length > 0) {
-        throw new Error("A recording is already active; stop it before starting a new recording");
+        throw new FridayDomainError("VALIDATION_ERROR", "A recording is already active; stop it before starting a new recording", { httpStatus: 400 });
       }
 
       const recording = engine.start(options);

--- a/src/harness/persistence/friday-template-harness-repository.ts
+++ b/src/harness/persistence/friday-template-harness-repository.ts
@@ -1,6 +1,7 @@
 import type Database from "better-sqlite3";
 
 import type { FridaySqliteLayer } from "#state";
+import { safeJsonParse } from "#utilities";
 
 import type {
   FridayHarnessDeliveryContractV1,
@@ -166,7 +167,7 @@ function tagsForArtifact(
 
 function parseArtifact<T>(row: MemoryItemRow | undefined): T | null {
   if (!row) return null;
-  return JSON.parse(row.value_json) as T;
+  return safeJsonParse<T>(row.value_json) ?? null;
 }
 
 export function createFridayTemplateHarnessRepository(

--- a/src/heartbeat/friday-heartbeat-active-hours.ts
+++ b/src/heartbeat/friday-heartbeat-active-hours.ts
@@ -47,8 +47,9 @@ function getHour(nowIso: string, timezone?: string): number {
     if (!Number.isNaN(parsed)) {
       return parsed % 24;
     }
-  } catch {
+  } catch (err) {
     // Invalid timezone fallback to local hour.
+    console.warn("[friday][heartbeat-active-hours] timezone conversion failed:", err instanceof Error ? err.message : String(err));
   }
   return date.getHours();
 }

--- a/src/heartbeat/friday-heartbeat-runner.ts
+++ b/src/heartbeat/friday-heartbeat-runner.ts
@@ -149,7 +149,8 @@ function resolvePrompt(config: FridayHeartbeatConfig): string {
   try {
     const filePrompt = readFileSync(config.promptPath, "utf-8").trim();
     return filePrompt.length > 0 ? filePrompt : defaultPrompt;
-  } catch {
+  } catch (err) {
+    console.warn("[friday][heartbeat-runner] prompt file read failed:", err instanceof Error ? err.message : String(err));
     return defaultPrompt;
   }
 }

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -9,6 +9,7 @@ import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
+import { safeJsonParse } from "#utilities";
 import type { FridayAgentMessage } from "#agent";
 import type {
   FridayChannelInstanceConfig,
@@ -95,7 +96,8 @@ export function parseFridayChannelIdentityMap(raw: string | undefined): Record<s
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
-  } catch {
+  } catch (err) {
+    console.warn("[friday][hub-helpers] parse-identity-map:", err instanceof Error ? err.message : String(err));
     return {};
   }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
@@ -224,7 +226,8 @@ export function resolveBrowserHostConfigFromEnv(
           .map((item) => item.trim())
           .filter((item) => item.length > 0);
       }
-    } catch {
+    } catch (err) {
+      console.warn("[friday][hub-helpers] parse-browser-launch-args:", err instanceof Error ? err.message : String(err));
       launchArgs = rawLaunchArgs
         .split(/\s+/)
         .map((item) => item.trim())
@@ -329,14 +332,10 @@ export function normalizeScopeList(scopes: readonly string[] | undefined): strin
 
 export function mapPolicyBundleRow(row: FridayPolicyBundleRow): FridayPolicyBundle {
   const tags = (() => {
-    try {
-      const parsed = JSON.parse(row.tags_json);
-      return Array.isArray(parsed)
-        ? parsed.filter((item): item is string => typeof item === "string")
-        : [];
-    } catch {
-      return [];
-    }
+    const parsed = safeJsonParse(row.tags_json);
+    return Array.isArray(parsed)
+      ? parsed.filter((item): item is string => typeof item === "string")
+      : [];
   })();
 
   return {
@@ -356,14 +355,10 @@ export function mapPolicyBundleRow(row: FridayPolicyBundleRow): FridayPolicyBund
 
 export function mapRuleRow(row: FridayRuleRow): FridayRule {
   const conditions = (() => {
-    try {
-      const parsed = JSON.parse(row.conditions_json);
-      return typeof parsed === "object" && parsed !== null
-        ? parsed as FridayRule["conditions"]
-        : {};
-    } catch {
-      return {};
-    }
+    const parsed = safeJsonParse(row.conditions_json);
+    return typeof parsed === "object" && parsed !== null
+      ? parsed as FridayRule["conditions"]
+      : {};
   })();
 
   return {
@@ -411,12 +406,7 @@ export function loadChannelsConfigFromSetupState(
     return undefined;
   }
 
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(row.channels_json);
-  } catch {
-    return undefined;
-  }
+  const parsed: unknown = safeJsonParse(row.channels_json);
   if (!Array.isArray(parsed)) {
     return undefined;
   }
@@ -575,8 +565,9 @@ export function resolveTokenSecret(
     if (content.length > 0) {
       return { secret: content, source: "file" };
     }
-  } catch {
+  } catch (err) {
     // File missing/unreadable — fall through to generate
+    console.warn("[friday][hub-helpers] read-token-secret:", err instanceof Error ? err.message : String(err));
   }
 
   // 4. Generate random and persist
@@ -587,9 +578,10 @@ export function resolveTokenSecret(
     fs.writeFileSync(FRIDAY_TOKEN_SECRET_FILE, generated + "\n", {
       mode: 0o600,
     });
-  } catch {
+  } catch (err) {
     console.warn(
       "[friday] WARNING: Could not persist token secret to " + FRIDAY_TOKEN_SECRET_FILE,
+      err instanceof Error ? err.message : String(err),
     );
   }
 
@@ -755,7 +747,7 @@ export interface FridayHub {
 }
 
 export interface FridayHubStatus {
-  state: "starting" | "running" | "stopped";
+  state: "starting" | "running" | "stopping" | "stopped";
   skillCount: number;
   upSince: string | null;
 }

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -417,7 +417,7 @@ export function resolveFridayHubConfig(
 export async function createFridayHub(
   config: FridayHubConfig,
 ): Promise<FridayHub> {
-  let hubState: "starting" | "running" | "stopped" = "stopped";
+  let hubState: "starting" | "running" | "stopping" | "stopped" = "stopped";
   let upSince: string | null = null;
   let stateRuntime: FridayStateRuntime | null = null;
 
@@ -426,6 +426,10 @@ export async function createFridayHub(
     ? { env: { ...process.env, FRIDAY_STATE_DIR: config.stateDir } as NodeJS.ProcessEnv }
     : undefined;
   stateRuntime = initializeFridayState(stateOpts);
+
+  // P0-001: Wrap remaining bootstrap in try/catch to ensure SQLite cleanup on partial failure
+  try {
+
   const daemonService = createFridayLocalDaemonService({
     moduleUrl: import.meta.url,
     stateDir: stateRuntime.stateDir,
@@ -446,7 +450,8 @@ export async function createFridayHub(
            VALUES (?, ?, ?, ?, NULL, 1, NULL, ?, ?, NULL)`,
         ).run("admin-001", "admin@friday.dev", "Admin", "admin", nowIso, nowIso);
       });
-      console.log("[friday] Created default admin user (admin@friday.dev)");
+      // P2: Always warn when creating passwordless admin (password_hash = NULL)
+      console.warn("[friday][SECURITY] Created default admin user (admin@friday.dev) with NO password — set a passphrase via the setup wizard for production use");
     }
   }
 
@@ -476,7 +481,10 @@ export async function createFridayHub(
     }
   }
 
-  // 2. Create stub services for standalone operation
+  // 2. Create stub services for standalone operation.
+  // P2: configManager and memoryState are intentionally stubbed for v0.4.x standalone mode.
+  // Full implementations with persistence are planned for the multi-node milestone.
+  // Config mutations via API are silently no-ops; use env vars and friday.config.yaml instead.
   const configManager = createStubConfigManager(config, stateRuntime);
   const auditLogPath = resolveFridayAuditLogPath(config.stateDir ?? ".");
   const memoryState = createStubMemoryState(auditLogPath);
@@ -577,7 +585,8 @@ export async function createFridayHub(
             created_at: entry.evaluatedAt,
           });
         });
-      } catch {
+      } catch (err) {
+      console.warn("[friday][hub-bootstrap] operation failed:", err instanceof Error ? err.message : String(err));
         // Keep runtime fail-open if audit persistence fails.
       }
     },
@@ -2055,7 +2064,8 @@ export async function createFridayHub(
     const providerKind = defaultRoute.provider.kind; // e.g. "anthropic"
     const modelName = defaultRoute.model;            // e.g. "claude-opus-4-5-20251101"
     agentModelIdentity = `${modelName} (provider: ${providerKind})`;
-  } catch {
+  } catch (err) {
+      console.warn("[friday][hub-bootstrap] operation failed:", err instanceof Error ? err.message : String(err));
     // No provider configured yet — use generic identity.
   }
   try {
@@ -2067,7 +2077,8 @@ export async function createFridayHub(
     if (routingWarning) {
       console.warn(`[friday][W-PROVIDER-ROUTING-001] ${routingWarning}`);
     }
-  } catch {
+  } catch (err) {
+      console.warn("[friday][hub-bootstrap] operation failed:", err instanceof Error ? err.message : String(err));
     // Non-fatal: provider routing diagnostics should not block startup.
   }
 
@@ -2102,7 +2113,8 @@ export async function createFridayHub(
         workspaceContext = ctx.promptFragment;
       }
       workspaceContextSummary = ctx.workspaceContext?.summary;
-    } catch {
+    } catch (err) {
+      console.warn("[friday][hub-bootstrap] operation failed:", err instanceof Error ? err.message : String(err));
       // Non-fatal: workspace context loading failure should not block agent runs.
     }
     const starterSkills = registry.list()
@@ -2338,6 +2350,23 @@ export async function createFridayHub(
     nowIso,
   });
 
+  // P2: Wire planning gate cleanup to agent run completion events
+  agentEventEmitter.on("agent.run.completed", (payload) => {
+    if (payload && typeof payload === "object" && "runId" in payload) {
+      agentPlanningGate.cleanupRun((payload as { runId: string }).runId);
+    }
+  });
+  agentEventEmitter.on("agent.run.failed", (payload) => {
+    if (payload && typeof payload === "object" && "runId" in payload) {
+      agentPlanningGate.cleanupRun((payload as { runId: string }).runId);
+    }
+  });
+  agentEventEmitter.on("agent.run.cancelled", (payload) => {
+    if (payload && typeof payload === "object" && "runId" in payload) {
+      agentPlanningGate.cleanupRun((payload as { runId: string }).runId);
+    }
+  });
+
   const resolveAgentMirrorIdempotencyKey = (input: {
     runId: string;
     kind: "planning" | "assistant" | "planning-reject" | "deterministic";
@@ -2544,7 +2573,8 @@ export async function createFridayHub(
       }
       const envelope = JSON.parse(entity.encryptedValue) as FridayEncryptedEnvelope;
       return decryptSecret(envelope, getMasterKey());
-    } catch {
+    } catch (err) {
+      console.warn("[friday][hub-bootstrap] operation failed:", err instanceof Error ? err.message : String(err));
       return null;
     }
   };
@@ -2829,9 +2859,7 @@ export async function createFridayHub(
           const candidates = deriveMarketplaceSkillIdCandidates(input.packageName);
           const resolved = candidates.find((skillId) => registry.get(skillId));
           if (!resolved) {
-            throw new Error(
-              `Marketplace skill asset "${input.packageName}@${input.packageVersion}" not found in local registry`,
-            );
+            throw new FridayDomainError("NOT_FOUND", `Marketplace skill asset "${input.packageName}@${input.packageVersion}" not found in local registry`, { httpStatus: 404 });
           }
           return;
         }
@@ -2839,23 +2867,19 @@ export async function createFridayHub(
           const byId = workflowRuntime.crud.getWorkflow(input.packageName);
           const bySlug = workflowRuntime.crud.getWorkflowBySlug(input.packageName);
           if (!byId && !bySlug) {
-            throw new Error(
-              `Marketplace workflow asset "${input.packageName}@${input.packageVersion}" not found in local runtime`,
-            );
+            throw new FridayDomainError("NOT_FOUND", `Marketplace workflow asset "${input.packageName}@${input.packageVersion}" not found in local runtime`, { httpStatus: 404 });
           }
           return;
         }
         case "agent": {
           if (!agentRuntime) {
-            throw new Error(
-              `Marketplace agent asset "${input.packageName}@${input.packageVersion}" requires an active agent runtime`,
-            );
+            throw new FridayDomainError("NOT_INITIALIZED", `Marketplace agent asset "${input.packageName}@${input.packageVersion}" requires an active agent runtime`, { httpStatus: 503 });
           }
           return;
         }
         default: {
           const exhaustive: never = input.assetType;
-          throw new Error(`Unsupported marketplace asset type: ${String(exhaustive)}`);
+          throw new FridayDomainError("VALIDATION_ERROR", `Unsupported marketplace asset type: ${String(exhaustive)}`, { httpStatus: 400 });
         }
       }
     }
@@ -3693,7 +3717,7 @@ export async function createFridayHub(
         : async () => {
             const errMsg = marketplaceInitError?.message ?? "unknown init error";
             console.error(`[friday] marketplace-sync skipped: MARKETPLACE_RUNTIME_INIT_FAILED — ${errMsg}`);
-            throw new Error(`MARKETPLACE_RUNTIME_INIT_FAILED: ${errMsg}`);
+            throw new FridayDomainError("NOT_INITIALIZED", `MARKETPLACE_RUNTIME_INIT_FAILED: ${errMsg}`, { httpStatus: 503 });
           };
 
       schedulerJobs.push({
@@ -3852,7 +3876,7 @@ export async function createFridayHub(
           );
           if (nextRunAtMs == null) {
             schedulerRepoRef.disableJob(jobId, now);
-            throw new Error(`Invalid cron schedule for automation ${automation.id}`);
+            throw new FridayDomainError("VALIDATION_ERROR", `Invalid cron schedule for automation ${automation.id}`, { httpStatus: 400 });
           }
 
           schedulerRepoRef.upsert({
@@ -3885,9 +3909,7 @@ export async function createFridayHub(
                 const suffix = result.response.trim().length > 0
                   ? `: ${result.response}`
                   : "";
-                throw new Error(
-                  `[E-SCHED-AUTOMATION-RUN-FAILED] Automation ${automation.id} finished with status ${result.status}${suffix}`,
-                );
+                throw new FridayDomainError("INTERNAL_ERROR", `[E-SCHED-AUTOMATION-RUN-FAILED] Automation ${automation.id} finished with status ${result.status}${suffix}`, { httpStatus: 500 });
               }
             },
           });
@@ -4000,7 +4022,7 @@ export async function createFridayHub(
 
         if (!response.ok) {
           const body = await response.text().catch(() => "");
-          throw new Error(`Vision API error ${String(response.status)}: ${body}`);
+          throw new FridayDomainError("INTERNAL_ERROR", `Vision API error ${String(response.status)}: ${body}`, { httpStatus: 500 });
         }
 
         const json = await response.json() as {
@@ -4078,18 +4100,18 @@ export async function createFridayHub(
             switch (action) {
               case "click":
                 if (typeof args.selector !== "string") {
-                  throw new Error("Browser action \"click\" requires a string selector.");
+                  throw new FridayDomainError("VALIDATION_ERROR", "Browser action \"click\" requires a string selector.", { httpStatus: 400 });
                 }
                 await page.click(args.selector);
                 return { ok: true };
               case "fill":
                 if (typeof args.selector !== "string" || typeof args.value !== "string") {
-                  throw new Error("Browser action \"fill\" requires selector and value strings.");
+                  throw new FridayDomainError("VALIDATION_ERROR", "Browser action \"fill\" requires selector and value strings.", { httpStatus: 400 });
                 }
                 await page.fill(args.selector, args.value);
                 return { ok: true };
               default:
-                throw new Error(`Unsupported browser action "${action}" in autonomous wrapper.`);
+                throw new FridayDomainError("VALIDATION_ERROR", `Unsupported browser action "${action}" in autonomous wrapper.`, { httpStatus: 400 });
             }
           },
           navigate: async (sessionId: string, url: string) => {
@@ -4912,8 +4934,17 @@ export async function createFridayHub(
 
     async stop(): Promise<void> {
       // Shutdown in reverse order: API → workflows → skills → state
-      hubState = "stopped";
+      // P2-DATA: Use transitional "stopping" state — set "stopped" after cleanup completes
+      hubState = "stopping";
       upSince = null;
+
+      // P1-SHUT-001/002/003: Stop services started during bootstrap
+      try { observabilityService?.scheduler?.stop(); } catch (err) {
+      console.warn("[friday][hub-bootstrap] operation failed:", err instanceof Error ? err.message : String(err)); /* best-effort */ }
+      try { agentLearningBridge?.stop(); } catch (err) {
+      console.warn("[friday][hub-bootstrap] operation failed:", err instanceof Error ? err.message : String(err)); /* best-effort */ }
+      try { if (mcpAdapter && "close" in mcpAdapter) await (mcpAdapter as unknown as { close(): Promise<void> }).close(); } catch (err) {
+      console.warn("[friday][hub-bootstrap] operation failed:", err instanceof Error ? err.message : String(err)); /* best-effort */ }
 
       // 1. Stop job scheduler (F11: await in-flight)
       if (jobScheduler) {
@@ -4944,6 +4975,7 @@ export async function createFridayHub(
       await registry.close();
       // 7. State
       stateRuntime?.close();
+      hubState = "stopped";
     },
 
     status(): FridayHubStatus {
@@ -4968,4 +5000,10 @@ export async function createFridayHub(
   };
 
   return hub;
+
+  } catch (bootstrapError) {
+    // P0-001: Clean up SQLite connections on partial bootstrap failure
+    stateRuntime?.close();
+    throw bootstrapError;
+  }
 }

--- a/src/jobs/marketplace/friday-marketplace-sync-job.ts
+++ b/src/jobs/marketplace/friday-marketplace-sync-job.ts
@@ -59,7 +59,8 @@ export function createFridayMarketplaceSyncJob(
     try {
       await job.runOnce();
       consecutiveFailures = 0;
-    } catch {
+    } catch (err) {
+    console.warn("[friday][marketplace-sync-job] operation failed:", err instanceof Error ? err.message : String(err));
       consecutiveFailures++;
     }
 

--- a/src/jobs/satellites/friday-satellite-offline-sweep-job.ts
+++ b/src/jobs/satellites/friday-satellite-offline-sweep-job.ts
@@ -76,7 +76,8 @@ export function createFridaySatelliteOfflineSweepJob(
     if (!running) return;
     try {
       await job.runOnce();
-    } catch {
+    } catch (err) {
+    console.warn("[friday][satellite-offline-sweep-job] operation failed:", err instanceof Error ? err.message : String(err));
       // continue on failure
     }
     if (running) {

--- a/src/jobs/satellites/friday-satellite-pairing-expiry-job.ts
+++ b/src/jobs/satellites/friday-satellite-pairing-expiry-job.ts
@@ -70,7 +70,8 @@ export function createFridaySatellitePairingExpiryJob(
     if (!running) return;
     try {
       await job.runOnce();
-    } catch {
+    } catch (err) {
+    console.warn("[friday][satellite-pairing-expiry-job] operation failed:", err instanceof Error ? err.message : String(err));
       // continue
     }
     if (running) {

--- a/src/jobs/scheduler/friday-job-schedule-utils.ts
+++ b/src/jobs/scheduler/friday-job-schedule-utils.ts
@@ -1,3 +1,5 @@
+import { FridayDomainError } from "#errors";
+
 /**
  * Job Schedule Utilities
  *
@@ -21,7 +23,7 @@ export function resolveJobSchedule(def: {
 }): FridayJobSchedule {
   if (def.schedule) return def.schedule;
   if (def.intervalMs != null) return { kind: "every", everyMs: def.intervalMs };
-  throw new Error("Job definition must specify either schedule or intervalMs");
+  throw new FridayDomainError("VALIDATION_ERROR", "Job definition must specify either schedule or intervalMs", { httpStatus: 400 });
 }
 
 /**
@@ -87,7 +89,8 @@ export function computeNextRunAtMs(
         const interval = CronExpressionParser.parse(schedule.cronExpr, options);
         const next = interval.next();
         return next.getTime();
-      } catch {
+      } catch (err) {
+    console.warn("[friday][job-schedule-utils] operation failed:", err instanceof Error ? err.message : String(err));
         return null;
       }
     }
@@ -105,7 +108,8 @@ export function isValidCronExpression(expr: string): boolean {
   try {
     CronExpressionParser.parse(expr);
     return true;
-  } catch {
+  } catch (err) {
+    console.warn("[friday][job-schedule-utils] operation failed:", err instanceof Error ? err.message : String(err));
     return false;
   }
 }

--- a/src/jobs/sessions/friday-session-lifecycle-job.ts
+++ b/src/jobs/sessions/friday-session-lifecycle-job.ts
@@ -54,7 +54,8 @@ export function createFridaySessionLifecycleJob(
           if (result.queued) {
             extractionsQueued++;
           }
-        } catch {
+        } catch (err) {
+        console.warn("[friday][session-lifecycle-job] operation failed:", err instanceof Error ? err.message : String(err));
           // Best-effort; extraction failures don't break lifecycle
         }
       }

--- a/src/learning/persistence/friday-agent-loop-repository.ts
+++ b/src/learning/persistence/friday-agent-loop-repository.ts
@@ -15,7 +15,8 @@ function parseJsonArray(value: string | null): string[] {
     return Array.isArray(parsed)
       ? parsed.filter((entry): entry is string => typeof entry === "string")
       : [];
-  } catch {
+  } catch (err) {
+    console.warn("[friday][agent-loop-repository] JSON array parse failed:", err instanceof Error ? err.message : String(err));
     return [];
   }
 }
@@ -26,7 +27,8 @@ function parseJsonValue<T>(value: string | null, fallback: T): T {
   }
   try {
     return JSON.parse(value) as T;
-  } catch {
+  } catch (err) {
+    console.warn("[friday][agent-loop-repository] JSON parse failed:", err instanceof Error ? err.message : String(err));
     return fallback;
   }
 }

--- a/src/learning/persistence/friday-approval-request-repository.ts
+++ b/src/learning/persistence/friday-approval-request-repository.ts
@@ -1,4 +1,5 @@
 import type Database from "better-sqlite3";
+import { safeJsonParse } from "#utilities";
 import type {
   FridayApprovalRequestEntity,
   FridayApprovalRequestRow,
@@ -59,7 +60,7 @@ function rowToEntity(row: FridayApprovalRequestRow): FridayApprovalRequestEntity
     userId: row.user_id,
     description: row.description,
     riskTier: row.risk_tier,
-    plan: JSON.parse(row.plan_json) as FridayAutoFixPlan,
+    plan: safeJsonParse<FridayAutoFixPlan>(row.plan_json) ?? ({} as FridayAutoFixPlan),
     requestedAt: row.requested_at,
     expiresAt: row.expires_at,
     status: row.status,

--- a/src/learning/persistence/friday-auto-fix-action-repository.ts
+++ b/src/learning/persistence/friday-auto-fix-action-repository.ts
@@ -1,4 +1,5 @@
 import type Database from "better-sqlite3";
+import { safeJsonParse } from "#utilities";
 import type {
   FridayAutoFixActionEntity,
   FridayAutoFixActionRow,
@@ -74,16 +75,14 @@ export interface FridayAutoFixActionRepository {
 }
 
 function rowToEntity(row: FridayAutoFixActionRow): FridayAutoFixActionEntity {
-  const plan = JSON.parse(row.plan_json) as FridayAutoFixPlan;
+  const plan = safeJsonParse<FridayAutoFixPlan>(row.plan_json) ?? ({} as FridayAutoFixPlan);
   return {
     actionId: row.action_id,
     incidentId: row.incident_id,
     userId: row.user_id,
     riskTier: row.risk_tier,
     plan,
-    rollbackPlan: row.rollback_plan_json
-      ? (JSON.parse(row.rollback_plan_json) as FridayAutoFixPlan["rollbackPlan"])
-      : undefined,
+    rollbackPlan: safeJsonParse<FridayAutoFixPlan["rollbackPlan"]>(row.rollback_plan_json),
     status: row.status,
     outcome: row.outcome,
     appliedAt: row.applied_at ?? undefined,

--- a/src/learning/persistence/friday-diagnosis-record-repository.ts
+++ b/src/learning/persistence/friday-diagnosis-record-repository.ts
@@ -1,4 +1,5 @@
 import type Database from "better-sqlite3";
+import { safeJsonParse } from "#utilities";
 import type {
   FridayDiagnosisRecordEntity,
   FridayDiagnosisRecordRow,
@@ -55,7 +56,7 @@ function rowToEntity(row: FridayDiagnosisRecordRow): FridayDiagnosisRecordEntity
     nodeId: row.node_id ?? undefined,
     errorFingerprint: row.error_fingerprint,
     confidence: row.confidence,
-    diagnosis: JSON.parse(row.diagnosis_json) as JsonObject,
+    diagnosis: safeJsonParse<JsonObject>(row.diagnosis_json) ?? {},
     resolvedAt: row.resolved_at ?? undefined,
     createdAt: row.created_at,
     updatedAt: row.updated_at,

--- a/src/learning/persistence/friday-error-incident-repository.ts
+++ b/src/learning/persistence/friday-error-incident-repository.ts
@@ -1,4 +1,5 @@
 import type Database from "better-sqlite3";
+import { safeJsonParse } from "#utilities";
 import type {
   FridayErrorIncidentEntity,
   FridayErrorIncidentRow,
@@ -59,7 +60,7 @@ function rowToEntity(row: FridayErrorIncidentRow): FridayErrorIncidentEntity {
     category: row.category,
     severity: row.severity,
     signature: row.signature,
-    context: JSON.parse(row.context_json) as JsonObject,
+    context: safeJsonParse<JsonObject>(row.context_json) ?? {},
     autoFixEligible: row.auto_fix_eligible === 1,
     status: row.status,
     createdAt: row.created_at,

--- a/src/learning/persistence/friday-learned-lesson-repository.ts
+++ b/src/learning/persistence/friday-learned-lesson-repository.ts
@@ -1,4 +1,5 @@
 import type Database from "better-sqlite3";
+import { safeJsonParse } from "#utilities";
 import type {
   FridayLearnedLessonEntity,
   FridayLearnedLessonRow,
@@ -39,9 +40,7 @@ function rowToEntity(row: FridayLearnedLessonRow): FridayLearnedLessonEntity {
     title: row.title,
     cause: row.cause,
     fix: row.fix,
-    mitigation: row.mitigation_json
-      ? (JSON.parse(row.mitigation_json) as JsonObject)
-      : undefined,
+    mitigation: safeJsonParse<JsonObject>(row.mitigation_json),
     occurrences: row.occurrences,
     lastSeenAt: row.last_seen_at,
     sourceIncidentId: row.source_incident_id ?? undefined,

--- a/src/learning/persistence/friday-preference-fact-repository.ts
+++ b/src/learning/persistence/friday-preference-fact-repository.ts
@@ -1,4 +1,5 @@
 import type Database from "better-sqlite3";
+import { safeJsonParse } from "#utilities";
 import type {
   FridayPreferenceFactEntity,
   FridayPreferenceFactRow,
@@ -56,11 +57,11 @@ function rowToEntity(row: FridayPreferenceFactRow): FridayPreferenceFactEntity {
     factId: row.fact_id,
     userId: row.user_id,
     key: row.key,
-    value: JSON.parse(row.value_json) as JsonValue,
+    value: safeJsonParse<JsonValue>(row.value_json) as JsonValue,
     confidence: row.confidence,
     evidenceCount: row.evidence_count,
     lastConfirmedAt: row.last_confirmed_at,
-    sourceEventIds: JSON.parse(row.source_event_ids_json) as string[],
+    sourceEventIds: safeJsonParse<string[]>(row.source_event_ids_json) ?? [],
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };

--- a/src/learning/services/friday-learning-pattern-recognition-service.ts
+++ b/src/learning/services/friday-learning-pattern-recognition-service.ts
@@ -1,4 +1,5 @@
 import type { FridaySqliteLayer } from "#state";
+import { safeJsonParse } from "#utilities";
 import type { FridayErrorIncidentRepository } from "../persistence/friday-error-incident-repository.js";
 import type { FridayPreferenceFactRepository } from "../persistence/friday-preference-fact-repository.js";
 import type {
@@ -122,7 +123,7 @@ export function createFridayLearningPatternRecognitionService(
 
         const correctionKeyCounts = new Map<string, number>();
         for (const row of correctionRows) {
-          const payload = JSON.parse(row.payload_json) as Record<
+          const payload = safeJsonParse(row.payload_json) as Record<
             string,
             unknown
           >;
@@ -171,7 +172,7 @@ export function createFridayLearningPatternRecognitionService(
 
           const correctedNormalizedKeys = new Set<string>();
           for (const row of recentCorrections) {
-            const payload = JSON.parse(row.payload_json) as Record<string, unknown>;
+            const payload = safeJsonParse(row.payload_json) as Record<string, unknown>;
             const field = readCorrectionPayload(payload).correctedField;
             if (field) {
               correctedNormalizedKeys.add(normalizeFieldToKey(field));
@@ -223,7 +224,7 @@ export function createFridayLearningPatternRecognitionService(
 
         const fieldValues = new Map<string, Set<string>>();
         for (const row of driftRows) {
-          const payload = JSON.parse(row.payload_json) as Record<
+          const payload = safeJsonParse(row.payload_json) as Record<
             string,
             unknown
           >;

--- a/src/learning/services/friday-self-healing-api-service.ts
+++ b/src/learning/services/friday-self-healing-api-service.ts
@@ -1,4 +1,5 @@
 import type { FridaySqliteLayer } from "#state";
+import { FridayDomainError } from "#errors";
 import type {
   FridayApprovalRequestEntity,
   FridayApprovalRequestStatus,
@@ -434,7 +435,7 @@ export function createFridaySelfHealingApiService(
         deps.approvalRepo.getByActionId(db, input.actionId),
       );
       if (!approval) {
-        throw new Error(`Approval request not found for action ${input.actionId}`);
+        throw new FridayDomainError("NOT_FOUND", `Approval request not found for action ${input.actionId}`, { httpStatus: 404 });
       }
       await deps.approvalService.approve({
         requestId: approval.requestId,
@@ -444,7 +445,7 @@ export function createFridaySelfHealingApiService(
       });
       const details = this.getAction({ actionId: input.actionId });
       if (!details) {
-        throw new Error(`Action ${input.actionId} not found after approval`);
+        throw new FridayDomainError("NOT_FOUND", `Action ${input.actionId} not found after approval`, { httpStatus: 404 });
       }
       emitActionEvent("autofix.action.approved", details, approval.requestId);
       await deps.observability?.recordAutoFixActionEvent({
@@ -465,7 +466,7 @@ export function createFridaySelfHealingApiService(
         deps.approvalRepo.getByActionId(db, input.actionId),
       );
       if (!approval) {
-        throw new Error(`Approval request not found for action ${input.actionId}`);
+        throw new FridayDomainError("NOT_FOUND", `Approval request not found for action ${input.actionId}`, { httpStatus: 404 });
       }
       await deps.approvalService.reject({
         requestId: approval.requestId,
@@ -475,7 +476,7 @@ export function createFridaySelfHealingApiService(
       });
       const details = this.getAction({ actionId: input.actionId });
       if (!details) {
-        throw new Error(`Action ${input.actionId} not found after rejection`);
+        throw new FridayDomainError("NOT_FOUND", `Action ${input.actionId} not found after rejection`, { httpStatus: 404 });
       }
       emitActionEvent("autofix.action.rejected", details, approval.requestId);
       await deps.observability?.recordAutoFixActionEvent({
@@ -496,7 +497,7 @@ export function createFridaySelfHealingApiService(
         deps.actionRepo.getById(db, input.actionId),
       );
       if (!action) {
-        throw new Error(`Action ${input.actionId} not found`);
+        throw new FridayDomainError("NOT_FOUND", `Action ${input.actionId} not found`, { httpStatus: 404 });
       }
 
       let result: FridayAutoFixExecutionResult;

--- a/src/ledger/learning/friday-learning-event-ledger.ts
+++ b/src/ledger/learning/friday-learning-event-ledger.ts
@@ -1,4 +1,5 @@
 import type { FridaySqliteLayer } from "#state";
+import { safeJsonParse } from "#utilities";
 import type {
   FridayLearningEventAppendInput,
   FridayLearningEventKind,
@@ -116,7 +117,7 @@ export function createFridayLearningEventLedger(
           sessionId: row.session_id ?? undefined,
           runId: row.run_id ?? undefined,
           kind: row.kind,
-          payload: JSON.parse(row.payload_json) as Record<string, unknown>,
+          payload: safeJsonParse<Record<string, unknown>>(row.payload_json) ?? {},
         }));
       });
     },

--- a/src/ledger/runs/friday-skill-run-store.ts
+++ b/src/ledger/runs/friday-skill-run-store.ts
@@ -1,5 +1,6 @@
 import type { FridaySqliteLayer } from "#state";
 import type { SkillRunStatus } from "#skills";
+import { safeJsonParse } from "#utilities";
 import type { FridaySkillRunListInput, FridaySkillRunSnapshot } from "./friday-skill-run-store.types.js";
 
 export interface FridaySkillRunStore {
@@ -49,7 +50,7 @@ export function createFridaySkillRunStore(
           .prepare("SELECT value_json FROM memory_items WHERE namespace = ? AND key = ?")
           .get(NAMESPACE, runId) as { value_json: string } | undefined;
         if (!row) return null;
-        return JSON.parse(row.value_json) as FridaySkillRunSnapshot<TState>;
+        return safeJsonParse<FridaySkillRunSnapshot<TState>>(row.value_json) ?? null;
       });
     },
 
@@ -80,7 +81,7 @@ export function createFridaySkillRunStore(
         }
 
         const rows = db.prepare(sql).all(...params) as Array<{ value_json: string }>;
-        return rows.map((row) => JSON.parse(row.value_json) as FridaySkillRunSnapshot);
+        return rows.map((row) => safeJsonParse<FridaySkillRunSnapshot>(row.value_json)).filter((s): s is FridaySkillRunSnapshot => s !== undefined);
       });
     },
 

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -11,7 +11,8 @@ function readPackageVersion(): string {
     const pkgPath = path.resolve(__dirname, "../../package.json");
     const pkg = require(pkgPath) as { version?: string };
     return pkg.version ?? "0.0.0";
-  } catch {
+  } catch (err) {
+    console.warn("[friday][version] package.json read failed:", err instanceof Error ? err.message : String(err));
     return "0.0.0";
   }
 }

--- a/src/link-understanding/friday-link-detect.ts
+++ b/src/link-understanding/friday-link-detect.ts
@@ -83,7 +83,8 @@ export function normalizeUrl(url: string): string {
       normalized = normalized.replace(/\/$/, "");
     }
     return normalized;
-  } catch {
+  } catch (err) {
+    console.warn("[friday][link-detect] URL normalization failed:", err instanceof Error ? err.message : String(err));
     return url.toLowerCase();
   }
 }

--- a/src/link-understanding/friday-link-summarize.ts
+++ b/src/link-understanding/friday-link-summarize.ts
@@ -54,8 +54,9 @@ export async function extractReadableContent(
     if (url) {
       try {
         (document as { baseURI?: string }).baseURI = url;
-      } catch {
+      } catch (err) {
         // Best-effort base URI for relative links.
+        console.warn("[friday][link-summarize] base URI assignment failed:", err instanceof Error ? err.message : String(err));
       }
     }
     const reader = new Readability(document, { charThreshold: 0 });
@@ -64,7 +65,8 @@ export async function extractReadableContent(
 
     const text = parsed.textContent.replace(/\s+/g, " ").trim();
     return text ? { text, title: parsed.title || undefined } : null;
-  } catch {
+  } catch (err) {
+    console.warn("[friday][link-summarize] HTML extraction failed:", err instanceof Error ? err.message : String(err));
     return null;
   }
 }

--- a/src/link-understanding/friday-link-understanding-service.ts
+++ b/src/link-understanding/friday-link-understanding-service.ts
@@ -105,8 +105,9 @@ export function createFridayLinkUnderstandingService(
             cached: false,
             processingMs: Date.now() - startTime,
           });
-        } catch {
+        } catch (err) {
           // Skip failed fetches silently
+          console.warn("[friday][link-understanding-service] fetch failed:", err instanceof Error ? err.message : String(err));
           continue;
         }
       }

--- a/src/marketplace/billing/friday-billing-reconciliation-job.ts
+++ b/src/marketplace/billing/friday-billing-reconciliation-job.ts
@@ -12,6 +12,8 @@
 
 import type {
   FridayBillingEvent,
+  FridayListing,
+  FridayListingVersion,
   FridayPayoutBatch,
   FridayPayoutEntry,
   FridayPurchase,
@@ -245,8 +247,8 @@ export function createFridayBillingReconciliationJob(
 
     const completeResult = completePurchase(
       purchase,
-      listing as any,
-      version as any,
+      listing as FridayListing,
+      version as FridayListingVersion,
       { externalPaymentId: externalId },
       engineDeps,
     );
@@ -398,7 +400,8 @@ export function createFridayBillingReconciliationJob(
     try {
       await job.runOnce();
       consecutiveFailures = 0;
-    } catch {
+    } catch (err) {
+      console.warn("[friday][billing-reconciliation-job] run cycle failed:", err instanceof Error ? err.message : String(err));
       consecutiveFailures++;
     }
 

--- a/src/marketplace/persistence/friday-marketplace-commerce-persistence.ts
+++ b/src/marketplace/persistence/friday-marketplace-commerce-persistence.ts
@@ -1899,7 +1899,8 @@ function parsePermissionManifestJson(
       requiresExplicitApproval:
         parsed.requiresExplicitApproval === true,
     };
-  } catch {
+  } catch (err) {
+    console.warn("[friday][marketplace-commerce-persistence] permission manifest parse failed:", err instanceof Error ? err.message : String(err));
     return {
       permissions: [],
       requiresExplicitApproval: false,
@@ -2144,7 +2145,8 @@ function parseJsonObject(value: string): JsonObject {
 function parseJson<T>(value: string, fallback: T): T {
   try {
     return JSON.parse(value) as T;
-  } catch {
+  } catch (err) {
+    console.warn("[friday][marketplace-commerce-persistence] JSON parse failed:", err instanceof Error ? err.message : String(err));
     return fallback;
   }
 }

--- a/src/media/friday-tts-service.ts
+++ b/src/media/friday-tts-service.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { FridayDomainError } from "#errors";
 
 // ─── Constants ───
 
@@ -92,17 +93,17 @@ export interface FridayTtsService {
 
 export function validateTtsText(text: string): void {
   if (!text || text.trim().length === 0) {
-    throw new Error("Text is required for TTS.");
+    throw new FridayDomainError("VALIDATION_ERROR", "Text is required for TTS.", { httpStatus: 400 });
   }
   if (text.length > MAX_TEXT_LENGTH) {
-    throw new Error(`Text exceeds maximum length of ${MAX_TEXT_LENGTH} characters.`);
+    throw new FridayDomainError("VALIDATION_ERROR", `Text exceeds maximum length of ${MAX_TEXT_LENGTH} characters.`, { httpStatus: 400 });
   }
 }
 
 export function validateTtsFormat(format: string | undefined): FridayTtsFormat {
   if (!format) return DEFAULT_FORMAT;
   if (!VALID_FORMATS.has(format)) {
-    throw new Error(`Invalid format "${format}". Valid: ${Array.from(VALID_FORMATS).join(", ")}.`);
+    throw new FridayDomainError("VALIDATION_ERROR", `Invalid format "${format}". Valid: ${Array.from(VALID_FORMATS).join(", ")}.`, { httpStatus: 400 });
   }
   return format as FridayTtsFormat;
 }
@@ -110,7 +111,7 @@ export function validateTtsFormat(format: string | undefined): FridayTtsFormat {
 export function validateTtsSpeed(speed: number | undefined): number {
   if (speed === undefined) return DEFAULT_SPEED;
   if (speed < MIN_SPEED || speed > MAX_SPEED) {
-    throw new Error(`Speed must be between ${MIN_SPEED} and ${MAX_SPEED}. Got: ${speed}`);
+    throw new FridayDomainError("VALIDATION_ERROR", `Speed must be between ${MIN_SPEED} and ${MAX_SPEED}. Got: ${speed}`, { httpStatus: 400 });
   }
   return speed;
 }

--- a/src/memory/persistence/friday-memory-embedding-repository.ts
+++ b/src/memory/persistence/friday-memory-embedding-repository.ts
@@ -5,6 +5,7 @@ import type {
   FridayMemorySemanticHit,
 } from "../model/friday-memory.types.js";
 import { FridayDomainError } from "#errors";
+import { safeJsonParse } from "#utilities";
 import { FRIDAY_MEMORY_ERROR_CODES } from "../friday-memory.constants.js";
 
 // ─── Row shape ───
@@ -76,7 +77,7 @@ function rowToEmbedding(row: EmbeddingRow): FridayMemoryEmbedding {
     providerId: row.provider_id,
     model: row.model,
     dimensions: row.dimensions,
-    vector: JSON.parse(row.vector_json) as number[],
+    vector: safeJsonParse<number[]>(row.vector_json) ?? [],
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -206,10 +207,8 @@ export function createFridayMemoryEmbeddingRepository(): FridayMemoryEmbeddingRe
       const minScore = input.minScore ?? 0;
 
       for (const row of candidateRows) {
-        let vector: number[];
-        try {
-          vector = JSON.parse(row.vector_json) as number[];
-        } catch {
+        const vector = safeJsonParse<number[]>(row.vector_json);
+        if (!vector) {
           // Skip rows with unparseable vector JSON
           continue;
         }

--- a/src/memory/persistence/friday-memory-item-repository.ts
+++ b/src/memory/persistence/friday-memory-item-repository.ts
@@ -7,6 +7,7 @@ import type {
   FridayMemorySearchQuery,
 } from "../model/friday-memory.types.js";
 import { FridayDomainError } from "#errors";
+import { safeJsonParse } from "#utilities";
 import { FRIDAY_MEMORY_ERROR_CODES } from "../friday-memory.constants.js";
 
 // ─── Row shape ───
@@ -57,10 +58,10 @@ export interface FridayMemoryItemRepository {
 // ─── Helpers ───
 
 function rowToItem(row: MemoryItemRow): FridayMemoryItem {
-  const tagsJson: unknown = JSON.parse(row.tags_json);
+  const tagsJson: unknown = safeJsonParse<unknown>(row.tags_json);
   const tags: string[] = Array.isArray(tagsJson) ? (tagsJson as string[]) : [];
   const metadata: Record<string, unknown> =
-    row.metadata_json ? (JSON.parse(row.metadata_json) as Record<string, unknown>) : {};
+    safeJsonParse<Record<string, unknown>>(row.metadata_json) ?? {};
 
   return {
     id: row.id,

--- a/src/memory/services/friday-memory-service.ts
+++ b/src/memory/services/friday-memory-service.ts
@@ -114,8 +114,9 @@ export function createFridayMemoryService(
             updatedAt: embeddingNow,
           });
         });
-      } catch {
+      } catch (err) {
         // Embedding failed — item was stored successfully, just no vector
+        console.warn("[friday][memory-service] embedding failed:", err instanceof Error ? err.message : String(err));
       }
 
       return item;
@@ -168,8 +169,9 @@ export function createFridayMemoryService(
             minScore: options?.minScore,
           }),
         );
-      } catch {
+      } catch (err) {
         // Semantic search unavailable — fallback to FTS-only
+        console.warn("[friday][memory-service] semantic search unavailable:", err instanceof Error ? err.message : String(err));
       }
 
       // Enforce tagsAll on semantic-only hits before merge (Fix #1)

--- a/src/memory/sync/friday-memory-file-sync-service.ts
+++ b/src/memory/sync/friday-memory-file-sync-service.ts
@@ -305,8 +305,9 @@ export function createFridayMemoryFileSyncService(
           try {
             const readPath = existingState.filePath === filePath ? filePath : existingState.filePath;
             existingContent = await fs.readFile(readPath, "utf8");
-          } catch {
+          } catch (err) {
             // File missing or unreadable — fall through to full rewrite
+            console.warn("[friday][memory-file-sync] read-session-file:", err instanceof Error ? err.message : String(err));
           }
 
           if (existingContent != null) {
@@ -401,9 +402,10 @@ export function createFridayMemoryFileSyncService(
     let fileContent: string;
     try {
       fileContent = await fs.readFile(filePath, "utf8");
-    } catch {
+    } catch (err) {
       // File was deleted externally — this is a valid case
       // We could delete the DB data too, but for safety we skip
+      console.warn("[friday][memory-file-sync] reindex-read-file:", err instanceof Error ? err.message : String(err));
       result.errors.push({
         entityType,
         entityKey,
@@ -621,8 +623,9 @@ async function atomicWrite(filePath: string, content: string): Promise<void> {
     // Best-effort fsync: ensures data is on disk before rename
     try {
       await fd.sync();
-    } catch {
+    } catch (err) {
       // fsync not critical on all platforms — proceed with rename
+      console.warn("[friday][memory-file-sync] fsync:", err instanceof Error ? err.message : String(err));
     }
 
     await fd.close();
@@ -631,10 +634,10 @@ async function atomicWrite(filePath: string, content: string): Promise<void> {
     await fs.rename(tmpPath, filePath);
   } catch (err) {
     if (fd) {
-      try { await fd.close(); } catch { /* ignore */ }
+      try { await fd.close(); } catch (err) { /* ignore */ console.warn("[friday][memory-file-sync] fd-close:", err instanceof Error ? err.message : String(err)); }
     }
     // Clean up temp file on failure
-    try { await fs.unlink(tmpPath); } catch { /* ignore */ }
+    try { await fs.unlink(tmpPath); } catch (err) { /* ignore */ console.warn("[friday][memory-file-sync] unlink-tmp:", err instanceof Error ? err.message : String(err)); }
     throw err;
   }
 }
@@ -643,8 +646,9 @@ async function atomicWrite(filePath: string, content: string): Promise<void> {
 async function safeUnlink(filePath: string): Promise<void> {
   try {
     await fs.unlink(filePath);
-  } catch {
+  } catch (err) {
     // File may not exist — that's fine
+    console.warn("[friday][memory-file-sync] safe-unlink:", err instanceof Error ? err.message : String(err));
   }
 }
 
@@ -653,7 +657,8 @@ async function getFileMtimeMs(filePath: string): Promise<number | null> {
   try {
     const stat = await fs.stat(filePath);
     return stat.mtimeMs;
-  } catch {
+  } catch (err) {
+    console.warn("[friday][memory-file-sync] get-file-mtime:", err instanceof Error ? err.message : String(err));
     return null;
   }
 }
@@ -682,7 +687,8 @@ function tryParseJson(json: string | null | undefined): unknown {
   if (!json) return null;
   try {
     return JSON.parse(json);
-  } catch {
+  } catch (err) {
+    console.warn("[friday][memory-file-sync] try-parse-json:", err instanceof Error ? err.message : String(err));
     return json;
   }
 }

--- a/src/memory/sync/friday-memory-file-sync-watcher.ts
+++ b/src/memory/sync/friday-memory-file-sync-watcher.ts
@@ -81,8 +81,9 @@ export function createFridayMemoryFileSyncWatcher(
         if (state.lastExportedHash === fileHash) {
           return;
         }
-      } catch {
+      } catch (err) {
         // File may have been deleted — that's a valid external change
+        console.warn("[friday][memory-file-sync-watcher] file read failed:", err instanceof Error ? err.message : String(err));
       }
     }
 

--- a/src/node-runner/engine/adapter-registry.ts
+++ b/src/node-runner/engine/adapter-registry.ts
@@ -13,6 +13,8 @@
  * @module node-runner/engine
  */
 
+import { FridayDomainError } from "#errors";
+
 import type {
   FridayNodeAdapter,
   FridayNodeAdapterRegistry,
@@ -40,7 +42,7 @@ export class NodeAdapterRegistry implements FridayNodeAdapterRegistry {
 
   register(adapter: FridayNodeAdapter): void {
     if (!adapter.nodeType) {
-      throw new Error("Adapter must have a non-empty nodeType");
+      throw new FridayDomainError("VALIDATION_ERROR", "Adapter must have a non-empty nodeType", { httpStatus: 400 });
     }
     this.adapters.set(adapter.nodeType, adapter);
   }

--- a/src/node-runner/engine/agent-node-adapter.ts
+++ b/src/node-runner/engine/agent-node-adapter.ts
@@ -1,3 +1,5 @@
+import { FridayDomainError } from "#errors";
+
 import type {
   FridayNodeAdapter,
   FridayNodeExecutionContext,
@@ -77,5 +79,5 @@ function throwIfAborted(signal?: AbortSignal): void {
   if (signal.reason instanceof Error) {
     throw signal.reason;
   }
-  throw new Error("Agent node operation aborted");
+  throw new FridayDomainError("INTERNAL_ERROR", "Agent node operation aborted", { httpStatus: 500 });
 }

--- a/src/node-runner/engine/node-runner-pipeline.ts
+++ b/src/node-runner/engine/node-runner-pipeline.ts
@@ -14,6 +14,8 @@
  * @module node-runner/engine
  */
 
+import { FridayDomainError } from "#errors";
+
 import type {
   FridayEvaluationContext,
   FridayEvaluationResult,
@@ -62,10 +64,10 @@ export class NodeRunnerPipeline implements FridayNodeRunnerPipeline {
 
   constructor(config: FridayNodeRunnerPipelineConfig) {
     if (!config.adapterRegistry) {
-      throw new Error("NodeRunnerPipeline requires an adapterRegistry");
+      throw new FridayDomainError("VALIDATION_ERROR", "NodeRunnerPipeline requires an adapterRegistry", { httpStatus: 400 });
     }
     if (!config.evaluateRules) {
-      throw new Error("NodeRunnerPipeline requires an evaluateRules function (fail-closed)");
+      throw new FridayDomainError("VALIDATION_ERROR", "NodeRunnerPipeline requires an evaluateRules function (fail-closed)", { httpStatus: 400 });
     }
     this.config = config;
   }

--- a/src/node-runner/engine/rules-context-builder.ts
+++ b/src/node-runner/engine/rules-context-builder.ts
@@ -7,6 +7,8 @@
  * @module node-runner/engine
  */
 
+import { FridayDomainError } from "#errors";
+
 import type {
   FridayEvaluationContext,
   FridayRuleResource,
@@ -36,7 +38,7 @@ export function mapNodeTypeToResource(nodeType: string): FridayRuleResource {
   if (Object.prototype.hasOwnProperty.call(NODE_TYPE_RESOURCE_MAP, nodeType)) {
     return NODE_TYPE_RESOURCE_MAP[nodeType as WorkflowNodeType];
   }
-  throw new Error(`No rules resource mapping defined for node type "${nodeType}"`);
+  throw new FridayDomainError("VALIDATION_ERROR", `No rules resource mapping defined for node type "${nodeType}"`, { httpStatus: 400 });
 }
 
 // ─── Pre-Rules Context ───

--- a/src/node-runner/engine/state-machine.ts
+++ b/src/node-runner/engine/state-machine.ts
@@ -7,6 +7,8 @@
  * @module node-runner/engine
  */
 
+import { FridayDomainError } from "#errors";
+
 import type {
   FridayNodeExecutionStatus,
   FridayNodeRunnerStateTransition,
@@ -76,9 +78,11 @@ export function transition(
   to: FridayNodeExecutionStatus,
 ): FridayNodeExecutionStatus {
   if (!isValidTransition(from, to)) {
-    throw new Error(
+    throw new FridayDomainError(
+      "VALIDATION_ERROR",
       `Invalid state transition: "${from}" → "${to}". ` +
         `Valid targets from "${from}": [${getValidTargets(from).join(", ")}]`,
+      { httpStatus: 400 },
     );
   }
   return to;

--- a/src/node-runner/engine/tool-node-adapter.ts
+++ b/src/node-runner/engine/tool-node-adapter.ts
@@ -1,3 +1,5 @@
+import { FridayDomainError } from "#errors";
+
 import type {
   FridayNodeAdapter,
   FridayNodeExecutionContext,
@@ -77,5 +79,5 @@ function throwIfAborted(signal?: AbortSignal): void {
   if (signal.reason instanceof Error) {
     throw signal.reason;
   }
-  throw new Error("Tool node operation aborted");
+  throw new FridayDomainError("INTERNAL_ERROR", "Tool node operation aborted", { httpStatus: 500 });
 }

--- a/src/node-runner/engine/workflow-action-adapter.ts
+++ b/src/node-runner/engine/workflow-action-adapter.ts
@@ -8,6 +8,8 @@
  * @module node-runner/engine
  */
 
+import { FridayDomainError } from "#errors";
+
 import type {
   FridayNodeAdapter,
   FridayNodeExecutionContext,
@@ -65,12 +67,12 @@ export class WorkflowActionAdapter implements FridayNodeAdapter {
     const skillId = (config.skillId ?? config.ref) as string | undefined;
 
     if (!skillId) {
-      throw new Error("action node missing skillId or ref in config");
+      throw new FridayDomainError("VALIDATION_ERROR", "action node missing skillId or ref in config", { httpStatus: 400 });
     }
 
     const skill = this.resolveSkill(skillId);
     if (!skill) {
-      throw new Error(`skill '${skillId}' not found`);
+      throw new FridayDomainError("NOT_FOUND", `skill '${skillId}' not found`, { httpStatus: 404 });
     }
 
     return { ...config, _resolvedSkillId: skillId };
@@ -141,5 +143,5 @@ function resolveArgs(
 function throwIfAborted(signal?: AbortSignal): void {
   if (!signal?.aborted) return;
   if (signal.reason instanceof Error) throw signal.reason;
-  throw new Error("Action node operation aborted");
+  throw new FridayDomainError("INTERNAL_ERROR", "Action node operation aborted", { httpStatus: 500 });
 }

--- a/src/node-runner/engine/workflow-ai-adapter.ts
+++ b/src/node-runner/engine/workflow-ai-adapter.ts
@@ -9,6 +9,8 @@
  * @module node-runner/engine
  */
 
+import { FridayDomainError } from "#errors";
+
 import type {
   FridayNodeAdapter,
   FridayNodeExecutionContext,
@@ -61,7 +63,7 @@ export class WorkflowAiAdapter implements FridayNodeAdapter {
     const prompt = config.prompt as string | undefined;
 
     if (!prompt) {
-      throw new Error("ai node missing 'prompt' in config");
+      throw new FridayDomainError("VALIDATION_ERROR", "ai node missing 'prompt' in config", { httpStatus: 400 });
     }
 
     return { ...config };
@@ -105,8 +107,9 @@ export class WorkflowAiAdapter implements FridayNodeAdapter {
           refExpr,
           String(val ?? ""),
         );
-      } catch {
+      } catch (err) {
         // Leave unresolved refs as-is
+        console.warn("[friday][workflow-ai-adapter] ref interpolation failed:", err instanceof Error ? err.message : String(err));
       }
     }
 
@@ -134,5 +137,5 @@ export class WorkflowAiAdapter implements FridayNodeAdapter {
 function throwIfAborted(signal?: AbortSignal): void {
   if (!signal?.aborted) return;
   if (signal.reason instanceof Error) throw signal.reason;
-  throw new Error("AI node operation aborted");
+  throw new FridayDomainError("INTERNAL_ERROR", "AI node operation aborted", { httpStatus: 500 });
 }

--- a/src/node-runner/engine/workflow-approval-adapter.ts
+++ b/src/node-runner/engine/workflow-approval-adapter.ts
@@ -8,6 +8,8 @@
  * @module node-runner/engine
  */
 
+import { FridayDomainError } from "#errors";
+
 import type {
   FridayNodeAdapter,
   FridayNodeExecutionContext,
@@ -65,5 +67,5 @@ export class WorkflowApprovalAdapter implements FridayNodeAdapter {
 function throwIfAborted(signal?: AbortSignal): void {
   if (!signal?.aborted) return;
   if (signal.reason instanceof Error) throw signal.reason;
-  throw new Error("Approval node operation aborted");
+  throw new FridayDomainError("INTERNAL_ERROR", "Approval node operation aborted", { httpStatus: 500 });
 }

--- a/src/node-runner/engine/workflow-condition-adapter.ts
+++ b/src/node-runner/engine/workflow-condition-adapter.ts
@@ -8,6 +8,8 @@
  * @module node-runner/engine
  */
 
+import { FridayDomainError } from "#errors";
+
 import type {
   FridayNodeAdapter,
   FridayNodeExecutionContext,
@@ -49,7 +51,7 @@ export class WorkflowConditionAdapter implements FridayNodeAdapter {
     const conditionExpr = config.condition as string | undefined;
 
     if (!conditionExpr) {
-      throw new Error("condition node missing 'condition' in config");
+      throw new FridayDomainError("VALIDATION_ERROR", "condition node missing 'condition' in config", { httpStatus: 400 });
     }
 
     return { ...config };
@@ -98,5 +100,5 @@ export class WorkflowConditionAdapter implements FridayNodeAdapter {
 function throwIfAborted(signal?: AbortSignal): void {
   if (!signal?.aborted) return;
   if (signal.reason instanceof Error) throw signal.reason;
-  throw new Error("Condition node operation aborted");
+  throw new FridayDomainError("INTERNAL_ERROR", "Condition node operation aborted", { httpStatus: 500 });
 }

--- a/src/node-runner/engine/workflow-data-adapter.ts
+++ b/src/node-runner/engine/workflow-data-adapter.ts
@@ -8,6 +8,8 @@
  * @module node-runner/engine
  */
 
+import { FridayDomainError } from "#errors";
+
 import type {
   FridayNodeAdapter,
   FridayNodeExecutionContext,
@@ -112,5 +114,5 @@ function resolveArgs(
 function throwIfAborted(signal?: AbortSignal): void {
   if (!signal?.aborted) return;
   if (signal.reason instanceof Error) throw signal.reason;
-  throw new Error("Data node operation aborted");
+  throw new FridayDomainError("INTERNAL_ERROR", "Data node operation aborted", { httpStatus: 500 });
 }

--- a/src/node-runner/engine/workflow-node-runner-facade.ts
+++ b/src/node-runner/engine/workflow-node-runner-facade.ts
@@ -13,6 +13,7 @@
  * @module node-runner/engine
  */
 
+import { FridayDomainError } from "#errors";
 import * as crypto from "node:crypto";
 
 import type {
@@ -236,7 +237,7 @@ export function createWorkflowNodeRunnerFacade(
 
           const gateResult = await deps.acceptanceGate.evaluate(acceptanceContext);
           if (!gateResult.passed) {
-            throw new Error(`ACCEPTANCE_FAILED: ${gateResult.errorMessage ?? "Acceptance gate rejected output"}`);
+            throw new FridayDomainError("VALIDATION_ERROR", `ACCEPTANCE_FAILED: ${gateResult.errorMessage ?? "Acceptance gate rejected output"}`, { httpStatus: 400 });
           }
         }
 
@@ -250,7 +251,7 @@ export function createWorkflowNodeRunnerFacade(
       // can handle retries and error recording as before
       const errorMsg = result.errorMessage ?? `Node execution failed with status: ${result.status}`;
       const errorCode = result.errorCode ?? "NODE_EXECUTION_FAILED";
-      throw new Error(`${errorCode}: ${errorMsg}`);
+      throw new FridayDomainError("INTERNAL_ERROR", `${errorCode}: ${errorMsg}`, { httpStatus: 500 });
     },
   };
 }

--- a/src/node-runner/engine/workflow-trigger-adapter.ts
+++ b/src/node-runner/engine/workflow-trigger-adapter.ts
@@ -8,6 +8,8 @@
  * @module node-runner/engine
  */
 
+import { FridayDomainError } from "#errors";
+
 import type {
   FridayNodeAdapter,
   FridayNodeExecutionContext,
@@ -67,5 +69,5 @@ export class WorkflowTriggerAdapter implements FridayNodeAdapter {
 function throwIfAborted(signal?: AbortSignal): void {
   if (!signal?.aborted) return;
   if (signal.reason instanceof Error) throw signal.reason;
-  throw new Error("Trigger node operation aborted");
+  throw new FridayDomainError("INTERNAL_ERROR", "Trigger node operation aborted", { httpStatus: 500 });
 }

--- a/src/observability/engine/audit-trail.ts
+++ b/src/observability/engine/audit-trail.ts
@@ -1,6 +1,11 @@
 /**
  * Audit Trail — Immutable audit log with tamper-evident hash chain.
  *
+ * NOTE: This module provides in-memory audit entry construction and hash-chain
+ * integrity. Entries are NOT persisted to disk by this module — durability is
+ * the responsibility of the consuming service (e.g. hub audit log writer).
+ * This is a deliberate design choice to keep the audit trail composable.
+ *
  * Records all significant operations as append-only audit entries.
  * Each entry includes a SHA-256 integrity hash computed over the previous
  * entry's hash concatenated with the canonical serialization of the current

--- a/src/observability/engine/metrics-collector.ts
+++ b/src/observability/engine/metrics-collector.ts
@@ -1,3 +1,5 @@
+import { FridayDomainError } from "#errors";
+
 /**
  * Metrics Collector — Collects and aggregates runtime metrics.
  *
@@ -140,7 +142,7 @@ export class FridayMetricsCollector {
   /** Register a new counter metric. Throws if already registered. */
   registerCounter(name: string, module: FridayObservabilityModule): void {
     if (this.counters.has(name)) {
-      throw new Error(`Counter "${name}" is already registered`);
+      throw new FridayDomainError("VALIDATION_ERROR", `Counter "${name}" is already registered`, { httpStatus: 400 });
     }
     this.counters.set(name, { module, states: new Map() });
   }
@@ -148,7 +150,7 @@ export class FridayMetricsCollector {
   /** Register a new gauge metric. Throws if already registered. */
   registerGauge(name: string, module: FridayObservabilityModule): void {
     if (this.gauges.has(name)) {
-      throw new Error(`Gauge "${name}" is already registered`);
+      throw new FridayDomainError("VALIDATION_ERROR", `Gauge "${name}" is already registered`, { httpStatus: 400 });
     }
     this.gauges.set(name, { module, states: new Map() });
   }
@@ -160,7 +162,7 @@ export class FridayMetricsCollector {
     buckets: readonly number[] = DEFAULT_HISTOGRAM_BUCKETS,
   ): void {
     if (this.histograms.has(name)) {
-      throw new Error(`Histogram "${name}" is already registered`);
+      throw new FridayDomainError("VALIDATION_ERROR", `Histogram "${name}" is already registered`, { httpStatus: 400 });
     }
     const sorted = [...buckets].sort((a, b) => a - b);
     this.histogramBoundaries.set(name, sorted);
@@ -172,11 +174,11 @@ export class FridayMetricsCollector {
   /** Increment a counter by a positive delta (default 1). */
   incrementCounter(name: string, labels: MetricLabels = {}, delta: number = 1): void {
     if (delta < 0) {
-      throw new Error(`Counter delta must be non-negative, got ${delta}`);
+      throw new FridayDomainError("VALIDATION_ERROR", `Counter delta must be non-negative, got ${delta}`, { httpStatus: 400 });
     }
     const entry = this.counters.get(name);
     if (!entry) {
-      throw new Error(`Counter "${name}" is not registered`);
+      throw new FridayDomainError("NOT_FOUND", `Counter "${name}" is not registered`, { httpStatus: 404 });
     }
     const key = labelKey(labels);
     const state = entry.states.get(key);
@@ -193,7 +195,7 @@ export class FridayMetricsCollector {
   setGauge(name: string, value: number, labels: MetricLabels = {}): void {
     const entry = this.gauges.get(name);
     if (!entry) {
-      throw new Error(`Gauge "${name}" is not registered`);
+      throw new FridayDomainError("NOT_FOUND", `Gauge "${name}" is not registered`, { httpStatus: 404 });
     }
     const key = labelKey(labels);
     const state = entry.states.get(key);
@@ -208,7 +210,7 @@ export class FridayMetricsCollector {
   incrementGauge(name: string, delta: number = 1, labels: MetricLabels = {}): void {
     const entry = this.gauges.get(name);
     if (!entry) {
-      throw new Error(`Gauge "${name}" is not registered`);
+      throw new FridayDomainError("NOT_FOUND", `Gauge "${name}" is not registered`, { httpStatus: 404 });
     }
     const key = labelKey(labels);
     const state = entry.states.get(key);
@@ -225,7 +227,7 @@ export class FridayMetricsCollector {
   recordHistogram(name: string, value: number, labels: MetricLabels = {}): void {
     const entry = this.histograms.get(name);
     if (!entry) {
-      throw new Error(`Histogram "${name}" is not registered`);
+      throw new FridayDomainError("NOT_FOUND", `Histogram "${name}" is not registered`, { httpStatus: 404 });
     }
     const boundaries = this.histogramBoundaries.get(name)!;
     const key = labelKey(labels);

--- a/src/observability/engine/trace-manager.ts
+++ b/src/observability/engine/trace-manager.ts
@@ -1,3 +1,5 @@
+import { FridayDomainError } from "#errors";
+
 /**
  * Trace Manager — Distributed tracing with spans, parent-child relationships,
  * and context propagation.
@@ -196,16 +198,16 @@ export class FridayTraceManager {
     const parentContext = options.parentContext;
     const traceId = parentContext?.traceId;
     if (!traceId || !parentContext) {
-      throw new Error("parentContext with traceId is required to start a child span");
+      throw new FridayDomainError("VALIDATION_ERROR", "parentContext with traceId is required to start a child span", { httpStatus: 400 });
     }
 
     const spanMap = this.activeSpans.get(traceId);
     if (!spanMap) {
-      throw new Error(`Trace "${traceId}" not found or already completed`);
+      throw new FridayDomainError("NOT_FOUND", `Trace "${traceId}" not found or already completed`, { httpStatus: 404 });
     }
 
     if (!spanMap.has(parentContext.spanId)) {
-      throw new Error(`Parent span "${parentContext.spanId}" not found in trace "${traceId}"`);
+      throw new FridayDomainError("NOT_FOUND", `Parent span "${parentContext.spanId}" not found in trace "${traceId}"`, { httpStatus: 404 });
     }
 
     const span: FridaySpan = {

--- a/src/observability/services/friday-observability-api-service.ts
+++ b/src/observability/services/friday-observability-api-service.ts
@@ -619,7 +619,8 @@ function metricValueFromSnapshots(snapshots: ReturnType<FridayMetricsCollector["
 function parseStoredJson<T>(value: string, fallback: T): T {
   try {
     return JSON.parse(value) as T;
-  } catch {
+  } catch (err) {
+    console.warn("[friday][observability-api-service] JSON parse failed:", err instanceof Error ? err.message : String(err));
     return fallback;
   }
 }
@@ -803,7 +804,8 @@ export function createFridayObservabilityApiService(
           ).all() as FridayAlertChannelRow[]
         ).map(parseAlertDestinationRow),
       );
-    } catch {
+    } catch (err) {
+      console.warn("[friday][observability-api-service] alert destinations list failed:", err instanceof Error ? err.message : String(err));
       return [];
     }
   }
@@ -819,7 +821,8 @@ export function createFridayObservabilityApiService(
           .get(destinationId) as FridayAlertChannelRow | undefined;
         return row ? parseAlertDestinationRow(row) : null;
       });
-    } catch {
+    } catch (err) {
+      console.warn("[friday][observability-api-service] alert destination get failed:", err instanceof Error ? err.message : String(err));
       return null;
     }
   }
@@ -910,7 +913,8 @@ export function createFridayObservabilityApiService(
           ).all() as FridaySloDefinitionRow[]
         ).map(parseSloDefinitionRow),
       );
-    } catch {
+    } catch (err) {
+      console.warn("[friday][observability-api-service] SLO definitions list failed:", err instanceof Error ? err.message : String(err));
       return [];
     }
   }
@@ -926,7 +930,8 @@ export function createFridayObservabilityApiService(
           .get(sloId) as FridaySloDefinitionRow | undefined;
         return row ? parseSloDefinitionRow(row) : null;
       });
-    } catch {
+    } catch (err) {
+      console.warn("[friday][observability-api-service] SLO record get failed:", err instanceof Error ? err.message : String(err));
       return null;
     }
   }
@@ -1446,7 +1451,7 @@ export function createFridayObservabilityApiService(
       if (destination.config.type === "slack") {
         const webhookUrl = readStoredSecret(destination.config.webhookRefKey);
         if (!webhookUrl) {
-          throw new Error(`Missing Slack webhook secret for ${destination.id}`);
+          throw new FridayDomainError("NOT_FOUND", `Missing Slack webhook secret for ${destination.id}`, { httpStatus: 404 });
         }
         const response = await fetch(webhookUrl, {
           method: "POST",
@@ -1457,12 +1462,12 @@ export function createFridayObservabilityApiService(
           }),
         });
         if (!response.ok) {
-          throw new Error(`Slack webhook responded with ${response.status}`);
+          throw new FridayDomainError("INTERNAL_ERROR", `Slack webhook responded with ${response.status}`, { httpStatus: 500 });
         }
       } else {
         const password = readStoredSecret(destination.config.passwordRefKey);
         if (!password && destination.config.username) {
-          throw new Error(`Missing SMTP password secret for ${destination.id}`);
+          throw new FridayDomainError("NOT_FOUND", `Missing SMTP password secret for ${destination.id}`, { httpStatus: 404 });
         }
         await sendSmtpMail({
           host: destination.config.smtpHost,

--- a/src/packaging/engine/semver.ts
+++ b/src/packaging/engine/semver.ts
@@ -1,3 +1,5 @@
+import { FridayDomainError } from "#errors";
+
 /**
  * Semver — Lightweight semantic versioning parser and range matcher.
  *
@@ -86,7 +88,7 @@ export function compareSemver(a: SemverParsed, b: SemverParsed): number {
 export function compareSemverStr(a: string, b: string): number {
   const pa = parseSemver(a);
   const pb = parseSemver(b);
-  if (!pa || !pb) throw new Error(`Invalid semver: ${!pa ? a : b}`);
+  if (!pa || !pb) throw new FridayDomainError("VALIDATION_ERROR", `Invalid semver: ${!pa ? a : b}`, { httpStatus: 400 });
   return compareSemver(pa, pb);
 }
 

--- a/src/playbook/engine/feedback-loop.ts
+++ b/src/playbook/engine/feedback-loop.ts
@@ -1,3 +1,5 @@
+import { FridayDomainError } from "#errors";
+
 /**
  * Feedback Loop — Track playbook success/failure rates and adjust
  * confidence scores using multi-dimensional scoring with exponential decay.
@@ -49,7 +51,7 @@ export function createScoreCalculator(deps: ScoreCalculatorDeps): FridayPlaybook
     async recalculate(playbookId: UUID): Promise<FridayPlaybookScore> {
       const playbook = store.getPlaybook(playbookId);
       if (!playbook) {
-        throw new Error(`Playbook not found: ${playbookId}`);
+        throw new FridayDomainError("NOT_FOUND", `Playbook not found: ${playbookId}`, { httpStatus: 404 });
       }
       return calculateAndPersistScore(playbook);
     },
@@ -165,7 +167,7 @@ export function createPromotionEngine(deps: PromotionEngineDeps): FridayPlaybook
     async evaluate(candidateId: UUID): Promise<FridayPromotionDecision> {
       const candidate = store.getCandidate(candidateId);
       if (!candidate) {
-        throw new Error(`Candidate not found: ${candidateId}`);
+        throw new FridayDomainError("NOT_FOUND", `Candidate not found: ${candidateId}`, { httpStatus: 404 });
       }
       return evaluateCandidate(candidate);
     },

--- a/src/playbook/engine/playbook-learning-loop.ts
+++ b/src/playbook/engine/playbook-learning-loop.ts
@@ -215,8 +215,9 @@ export function createPlaybookLearningLoop(
         if (sel.playbookId) {
           try {
             await scoreCalculator.recalculate(sel.playbookId);
-          } catch {
+          } catch (err) {
             // Score recalculation failure is non-fatal
+            console.warn("[friday][playbook-learning-loop] score recalculation failed:", err instanceof Error ? err.message : String(err));
           }
         }
       }

--- a/src/playbook/engine/playbook-sqlite-store.ts
+++ b/src/playbook/engine/playbook-sqlite-store.ts
@@ -1,5 +1,6 @@
 import type Database from "better-sqlite3";
 import type { FridaySqliteLayer } from "#state";
+import { FridayDomainError } from "#errors";
 
 import type {
   FridayPlaybook,
@@ -33,7 +34,8 @@ function parseJsonValue(raw: string | null | undefined): JsonValue {
   if (!raw) return {};
   try {
     return JSON.parse(raw) as JsonValue;
-  } catch {
+  } catch (err) {
+    console.warn("[friday][playbook-sqlite-store] JSON parse failed:", err instanceof Error ? err.message : String(err));
     return {};
   }
 }
@@ -195,7 +197,7 @@ function hasPlaybookTables(db: Database.Database): boolean {
 export function createSqlitePlaybookStore(deps: SqlitePlaybookStoreDeps): PlaybookStore {
   deps.db.withReadConnection((db) => {
     if (!hasPlaybookTables(db)) {
-      throw new Error("PLAYBOOK_TABLES_NOT_AVAILABLE");
+      throw new FridayDomainError("NOT_INITIALIZED", "PLAYBOOK_TABLES_NOT_AVAILABLE", { httpStatus: 503 });
     }
   });
 

--- a/src/playbook/engine/promoter-job.ts
+++ b/src/playbook/engine/promoter-job.ts
@@ -7,6 +7,7 @@
  * @module playbook/engine
  */
 
+import { FridayDomainError } from "#errors";
 import type {
   FridayPlaybookCandidate,
   FridayPlaybookPromotionEngine,
@@ -283,7 +284,7 @@ export function createPromoterJobRunner(deps: PromoterJobRunnerDeps): PromoterJo
 
     start(intervalMs: number) {
       if (intervalMs <= 0) {
-        throw new Error("intervalMs must be > 0");
+        throw new FridayDomainError("VALIDATION_ERROR", "intervalMs must be > 0", { httpStatus: 400 });
       }
 
       if (intervalHandle !== null) {

--- a/src/playbook/persistence/playbook-sqlite-repository.ts
+++ b/src/playbook/persistence/playbook-sqlite-repository.ts
@@ -9,6 +9,7 @@
  */
 
 import type { Database } from "better-sqlite3";
+import { safeJsonParse } from "#utilities";
 import type { PlaybookStore } from "../engine/playbook-store.js";
 import type {
   FridayPlaybook,
@@ -47,7 +48,7 @@ function mapPlaybookRow(row: FridayPlaybookRow): FridayPlaybook {
     name: row.name,
     description: row.description ?? undefined,
     workflowType: row.workflow_type,
-    tags: JSON.parse(row.tags_json) as string[],
+    tags: safeJsonParse<string[]>(row.tags_json) ?? [],
     status: row.status as FridayPlaybookStatus,
     activeVersionNumber: row.active_version_number,
     sourceCandidateId: row.source_candidate_id as UUID,
@@ -68,15 +69,15 @@ function mapCandidateRow(row: FridayPlaybookCandidateRow): FridayPlaybookCandida
     id: row.id as UUID,
     fingerprint: row.fingerprint,
     workflowType: row.workflow_type,
-    tags: JSON.parse(row.tags_json) as string[],
-    pattern: JSON.parse(row.pattern_json) as JsonObject,
+    tags: safeJsonParse<string[]>(row.tags_json) ?? [],
+    pattern: safeJsonParse<JsonObject>(row.pattern_json) ?? {},
     status: row.status as FridayPlaybookCandidateStatus,
     evidenceCount: row.evidence_count,
     successCount: row.success_count,
     failureCount: row.failure_count,
     totalDurationMs: row.total_duration_ms,
-    totalCost: JSON.parse(row.total_cost_json) as FridayPlaybookCostDimensions,
-    sourceRunIds: JSON.parse(row.source_run_ids_json) as UUID[],
+    totalCost: safeJsonParse<FridayPlaybookCostDimensions>(row.total_cost_json) ?? { tokenCost: 0, apiCallCost: 0, latencyMs: 0 },
+    sourceRunIds: safeJsonParse<UUID[]>(row.source_run_ids_json) ?? [],
     promotedPlaybookId: (row.promoted_playbook_id ?? undefined) as UUID | undefined,
     firstObservedAt: row.first_observed_at as ISODateTime,
     lastObservedAt: row.last_observed_at as ISODateTime,
@@ -91,7 +92,7 @@ function mapVersionRow(row: FridayPlaybookVersionRow): FridayPlaybookVersion {
     playbookId: row.playbook_id as UUID,
     versionNumber: row.version_number,
     fingerprint: row.fingerprint,
-    pattern: JSON.parse(row.pattern_json) as JsonObject,
+    pattern: safeJsonParse<JsonObject>(row.pattern_json) ?? {},
     candidateId: row.candidate_id as UUID,
     changeNote: row.change_note ?? undefined,
     createdAt: row.created_at as ISODateTime,
@@ -123,7 +124,7 @@ function mapSelectionRow(row: FridayPlaybookSelectionRow): FridayPlaybookMatch {
     matchScore: row.match_score ?? null,
     similarity: row.similarity ?? null,
     reason: row.reason as FridayPlaybookMatchReason,
-    context: JSON.parse(row.context_json) as FridayPlaybookSelector,
+    context: safeJsonParse<FridayPlaybookSelector>(row.context_json) ?? ({} as FridayPlaybookSelector),
     selectedAt: row.selected_at as ISODateTime,
   };
 }
@@ -134,11 +135,9 @@ function mapDecisionRow(row: FridayPromotionDecisionRow): FridayPromotionDecisio
     candidateId: row.candidate_id as UUID,
     decision: row.decision as FridayPromotionDecisionOutcome,
     reason: row.reason,
-    ruleResults: JSON.parse(row.rule_results_json) as FridayPromotionRuleResult[],
-    rulesResult: row.rules_result_json
-      ? (JSON.parse(row.rules_result_json) as FridayEvaluationResult)
-      : undefined,
-    scoreSnapshot: JSON.parse(row.score_snapshot_json) as FridayPlaybookScore,
+    ruleResults: safeJsonParse<FridayPromotionRuleResult[]>(row.rule_results_json) ?? [],
+    rulesResult: safeJsonParse<FridayEvaluationResult>(row.rules_result_json),
+    scoreSnapshot: safeJsonParse<FridayPlaybookScore>(row.score_snapshot_json) ?? ({} as FridayPlaybookScore),
     decidedAt: row.decided_at as ISODateTime,
   };
 }

--- a/src/plugins/persistence/friday-plugin-repository.ts
+++ b/src/plugins/persistence/friday-plugin-repository.ts
@@ -5,6 +5,7 @@
 import type Database from "better-sqlite3";
 
 import { FridayDomainError } from "#errors";
+import { safeJsonParse } from "#utilities";
 import type {
   FridayPluginEntity,
   FridayPluginKind,
@@ -67,9 +68,9 @@ function rowToEntity(row: FridayPluginRow): FridayPluginEntity {
     enabled: row.enabled === 1,
     trustMode: row.trust_mode as FridayPluginTrustMode,
     installPath: row.install_path,
-    kinds: JSON.parse(row.kinds_json) as FridayPluginKind[],
-    manifest: JSON.parse(row.manifest_json) as FridayPluginManifest,
-    config: JSON.parse(row.config_json) as Record<string, unknown>,
+    kinds: safeJsonParse<FridayPluginKind[]>(row.kinds_json) ?? [],
+    manifest: safeJsonParse<FridayPluginManifest>(row.manifest_json) ?? ({} as FridayPluginManifest),
+    config: safeJsonParse<Record<string, unknown>>(row.config_json) ?? {},
     signatureAlgorithm: row.signature_algorithm,
     signatureKeyId: row.signature_key_id,
     signatureValue: row.signature_value,

--- a/src/plugins/security/friday-plugin-signature-verifier.ts
+++ b/src/plugins/security/friday-plugin-signature-verifier.ts
@@ -74,7 +74,8 @@ export function createFridayPluginSignatureVerifier(
     try {
       const publicKey = createPublicKey(publicKeyPem);
       return verify(null, payload, publicKey, sigValue);
-    } catch {
+    } catch (err) {
+      console.warn("[friday][plugin-signature-verifier] Ed25519 verification failed:", err instanceof Error ? err.message : String(err));
       return false;
     }
   });

--- a/src/plugins/services/friday-plugin-discovery-service.ts
+++ b/src/plugins/services/friday-plugin-discovery-service.ts
@@ -40,14 +40,16 @@ export function createFridayPluginDiscoveryService(
   const readdir = deps.readdir ?? ((p: string) => {
     try {
       return fs.readdirSync(p);
-    } catch {
+    } catch (err) {
+      console.warn("[friday][plugin-discovery-service] readdir failed:", err instanceof Error ? err.message : String(err));
       return [];
     }
   });
   const isDirectory = deps.isDirectory ?? ((p: string) => {
     try {
       return fs.statSync(p).isDirectory();
-    } catch {
+    } catch (err) {
+      console.warn("[friday][plugin-discovery-service] stat failed:", err instanceof Error ? err.message : String(err));
       return false;
     }
   });

--- a/src/providers/cost/friday-provider-budget-service.ts
+++ b/src/providers/cost/friday-provider-budget-service.ts
@@ -1,4 +1,5 @@
 import type { FridaySqliteLayer } from "#state";
+import { safeJsonParse } from "#utilities";
 import type {
   FridayBudgetState,
   FridayLlmBudgetConfig,
@@ -35,7 +36,7 @@ export function createFridayProviderBudgetService(deps: {
         .get(BUDGET_SETTINGS_KEY) as { value_json: string } | undefined,
     );
     if (!row) return null;
-    return JSON.parse(row.value_json) as FridayLlmBudgetConfig;
+    return safeJsonParse<FridayLlmBudgetConfig>(row.value_json) ?? null;
   }
 
   function saveConfig(config: FridayLlmBudgetConfig): void {

--- a/src/providers/oauth/friday-anthropic-oauth.ts
+++ b/src/providers/oauth/friday-anthropic-oauth.ts
@@ -250,7 +250,7 @@ export function createFridayAnthropicOAuthProvider(
 
       const data: unknown = await response.json();
       if (!isAnthropicTokenResponse(data)) {
-        throw new Error("Anthropic token response has unexpected shape");
+        throw new FridayDomainError("INTERNAL_ERROR", "Anthropic token response has unexpected shape", { httpStatus: 500 });
       }
 
       // Clean up stored verifier
@@ -292,7 +292,7 @@ export function createFridayAnthropicOAuthProvider(
 
       const data: unknown = await response.json();
       if (!isAnthropicTokenResponse(data)) {
-        throw new Error("Anthropic token refresh response has unexpected shape");
+        throw new FridayDomainError("INTERNAL_ERROR", "Anthropic token refresh response has unexpected shape", { httpStatus: 500 });
       }
 
       const expiresAt = new Date(nowMs() + data.expires_in * 1000 - 5 * 60 * 1000).toISOString();

--- a/src/providers/oauth/friday-oauth-credential-store.ts
+++ b/src/providers/oauth/friday-oauth-credential-store.ts
@@ -2,6 +2,7 @@
  * SQLite-backed OAuth credential storage with envelope encryption.
  */
 
+import { FridayDomainError } from "#errors";
 import type { FridaySqliteLayer } from "#state";
 
 import type {
@@ -44,8 +45,9 @@ export interface CreateFridayOAuthCredentialStoreDeps {
 function parseEnvelope(raw: string, field: string): FridayEncryptedEnvelope {
   try {
     return JSON.parse(raw) as FridayEncryptedEnvelope;
-  } catch {
-    throw new Error(`OAuth credential row has invalid JSON in ${field}`);
+  } catch (err) {
+    console.warn("[friday][oauth-credential-store] invalid JSON in credential:", err instanceof Error ? err.message : String(err));
+    throw new FridayDomainError("INTERNAL_ERROR", `OAuth credential row has invalid JSON in ${field}`, { httpStatus: 500 });
   }
 }
 
@@ -134,7 +136,7 @@ export function createFridayOAuthCredentialStore(
       // Re-read to get the actual persisted row (may use existing id on conflict)
       const stored = this.getByProviderProfileId(input.providerProfileId);
       if (!stored) {
-        throw new Error("Failed to read back OAuth credential after upsert");
+        throw new FridayDomainError("INTERNAL_ERROR", "Failed to read back OAuth credential after upsert", { httpStatus: 500 });
       }
       return stored;
     },

--- a/src/providers/persistence/friday-provider-profile-repository.ts
+++ b/src/providers/persistence/friday-provider-profile-repository.ts
@@ -1,4 +1,5 @@
 import type Database from "better-sqlite3";
+import { safeJsonParse } from "#utilities";
 
 import type {
   FridayProviderConfigJson,
@@ -19,9 +20,8 @@ export interface FridayProviderProfileRepository {
 // ─── Row ↔ Entity mapping ───
 
 function rowToProfile(row: FridayProviderProfileRow): FridayProviderProfile {
-  const config: FridayProviderConfigJson = row.config_json
-    ? (JSON.parse(row.config_json) as FridayProviderConfigJson)
-    : {
+  const config: FridayProviderConfigJson = safeJsonParse<FridayProviderConfigJson>(row.config_json)
+    ?? {
         api: "openai-completions",
         authMode: "api-key",
         keySource: { kind: "none" },

--- a/src/providers/routing/friday-provider-fallback.ts
+++ b/src/providers/routing/friday-provider-fallback.ts
@@ -60,10 +60,10 @@ const TRANSIENT_ERROR_PATTERNS = [
 function extractErrorText(err: unknown): string {
   if (err instanceof Error) {
     let text = err.message;
-    const code = (err as any).code;
-    const status = (err as any).status;
-    if (code !== undefined) text += ` code=${code}`;
-    if (status !== undefined) text += ` status=${status}`;
+    const code = "code" in err ? (err as { code: unknown }).code : undefined;
+    const status = "status" in err ? (err as { status: unknown }).status : undefined;
+    if (code !== undefined) text += ` code=${String(code)}`;
+    if (status !== undefined) text += ` status=${String(status)}`;
     return text;
   }
 
@@ -92,8 +92,12 @@ function classifyProviderError(err: unknown): {
   code?: string;
 } {
   const text = extractErrorText(err);
-  const status = typeof (err as any)?.status === "number" ? (err as any).status as number : undefined;
-  const code = typeof (err as any)?.code === "string" ? (err as any).code as string : undefined;
+  const status = err instanceof Error && "status" in err && typeof (err as { status: unknown }).status === "number"
+    ? (err as { status: number }).status
+    : undefined;
+  const code = err instanceof Error && "code" in err && typeof (err as { code: unknown }).code === "string"
+    ? (err as { code: string }).code
+    : undefined;
 
   if (isTransientError(text)) {
     return { reason: "transient", status, code };

--- a/src/providers/security/friday-secret-crypto.ts
+++ b/src/providers/security/friday-secret-crypto.ts
@@ -73,7 +73,10 @@ export function decryptSecret(
 
 // ─── Master key resolution ───
 
+// P2-SEC: Master key cache with TTL for rotation support (re-reads from env/file after 1 hour)
 let cachedMasterKey: Buffer | null = null;
+let cachedMasterKeyExpiresAt = 0;
+const MASTER_KEY_CACHE_TTL_MS = 3_600_000; // 1 hour
 
 const MASTER_KEY_DIR = path.join(os.homedir(), ".friday");
 const MASTER_KEY_FILE = path.join(MASTER_KEY_DIR, "master.key");
@@ -88,9 +91,11 @@ const MASTER_KEY_FILE = path.join(MASTER_KEY_DIR, "master.key");
  * - On subsequent runs, reads from that file so secrets survive restarts.
  */
 export function getMasterKey(): Buffer {
-  if (cachedMasterKey) {
+  // P2-SEC: Honor TTL — invalidate cache after expiry to support key rotation
+  if (cachedMasterKey && Date.now() < cachedMasterKeyExpiresAt) {
     return cachedMasterKey;
   }
+  cachedMasterKey = null;
 
   // 1. Prefer explicit env var
   const envKey = process.env.FRIDAY_MASTER_KEY;
@@ -104,20 +109,29 @@ export function getMasterKey(): Buffer {
       );
     }
     cachedMasterKey = buf;
+    cachedMasterKeyExpiresAt = Date.now() + MASTER_KEY_CACHE_TTL_MS;
     return cachedMasterKey;
   }
 
   // 2. Try to read persisted key file
   try {
     const hex = fs.readFileSync(MASTER_KEY_FILE, "utf8").trim();
+    // P2-SEC: Verify master key file permissions are not too open
+    try {
+      const stat = fs.statSync(MASTER_KEY_FILE);
+      if ((stat.mode & 0o077) !== 0) {
+        console.warn(`[friday][SECURITY] Master key file permissions too open — expected 0600, got 0o${(stat.mode & 0o777).toString(8)}`);
+      }
+    } catch (err) { console.warn("[friday][secret-crypto] stat check failed:", err instanceof Error ? err.message : String(err)); }
     const buf = Buffer.from(hex, "hex");
     if (buf.length === KEY_BYTES) {
       cachedMasterKey = buf;
       return cachedMasterKey;
     }
     // Invalid length — fall through to regenerate
-  } catch {
+  } catch (err) {
     // File unreadable — fall through to regenerate
+    console.warn("[friday][secret-crypto] master key file unreadable:", err instanceof Error ? err.message : String(err));
   }
 
   // 3. Generate, persist, and warn
@@ -128,10 +142,11 @@ export function getMasterKey(): Buffer {
     fs.writeFileSync(MASTER_KEY_FILE, newKey.toString("hex") + "\n", {
       mode: 0o600,
     });
-  } catch {
+  } catch (err) {
     // Best-effort: if we can't write, the key lives only in memory this run
     console.warn(
       "[friday] WARNING: Could not persist master key to " + MASTER_KEY_FILE,
+      err instanceof Error ? err.message : String(err),
     );
   }
 
@@ -143,6 +158,7 @@ export function getMasterKey(): Buffer {
   );
 
   cachedMasterKey = newKey;
+  cachedMasterKeyExpiresAt = Date.now() + MASTER_KEY_CACHE_TTL_MS;
   return cachedMasterKey;
 }
 

--- a/src/providers/services/friday-provider-oauth-selection.ts
+++ b/src/providers/services/friday-provider-oauth-selection.ts
@@ -1,3 +1,4 @@
+import { FridayDomainError } from "#errors";
 import type { FridayProviderApi, FridayProviderKind, FridayProviderProfile } from "../model/friday-provider.types.js";
 import type { FridayProviderService } from "./friday-provider-service.types.js";
 
@@ -77,8 +78,9 @@ export async function resolveExistingOAuthProvider(
   const kind = readOAuthProviderKind(input.kind);
   const existing = await selectReusableOAuthProvider(providerService, input, kind);
   if (!existing) {
-    throw new Error(
+    throw new FridayDomainError("VALIDATION_ERROR",
       `No ${kind} OAuth provider is configured yet. Run oauth_init first or specify providerId.`,
+      { httpStatus: 400 },
     );
   }
 
@@ -109,8 +111,9 @@ async function selectReusableOAuthProvider(
       return { provider: namedMatches[0]!, resolution: "reused-by-name" };
     }
     if (namedMatches.length > 1) {
-      throw new Error(
+      throw new FridayDomainError("VALIDATION_ERROR",
         `Multiple ${kind} OAuth providers match name "${input.name}". Specify providerId.`,
+        { httpStatus: 400 },
       );
     }
   }
@@ -123,8 +126,9 @@ async function selectReusableOAuthProvider(
       return { provider: modelMatches[0]!, resolution: "reused-by-default-model" };
     }
     if (modelMatches.length > 1) {
-      throw new Error(
+      throw new FridayDomainError("VALIDATION_ERROR",
         `Multiple ${kind} OAuth providers use default model "${input.defaultModel}". Specify providerId.`,
+        { httpStatus: 400 },
       );
     }
   }
@@ -142,8 +146,9 @@ async function selectReusableOAuthProvider(
     return { provider: enabledCandidates[0]!, resolution: "reused-enabled" };
   }
 
-  throw new Error(
+  throw new FridayDomainError("VALIDATION_ERROR",
     `Multiple ${kind} OAuth providers are available. Specify providerId. Candidates: ${candidates.map(formatProviderCandidate).join("; ")}`,
+    { httpStatus: 400 },
   );
 }
 
@@ -154,7 +159,7 @@ async function requireProviderById(
 ): Promise<FridayProviderProfile> {
   const provider = await providerService.getProvider(providerId);
   if (!provider) {
-    throw new Error(`Provider "${providerId}" not found for ${actionLabel}.`);
+    throw new FridayDomainError("NOT_FOUND", `Provider "${providerId}" not found for ${actionLabel}.`, { httpStatus: 404 });
   }
   return provider;
 }
@@ -164,13 +169,15 @@ function assertOAuthReadyProvider(
   actionLabel: string,
 ): void {
   if (provider.config.authMode !== "oauth") {
-    throw new Error(
+    throw new FridayDomainError("VALIDATION_ERROR",
       `Provider "${provider.id}" uses ${provider.config.authMode} auth, not oauth, so ${actionLabel} cannot use it.`,
+      { httpStatus: 400 },
     );
   }
   if (provider.kind !== DEFAULT_OAUTH_PROVIDER_KIND) {
-    throw new Error(
+    throw new FridayDomainError("UNSUPPORTED_OPERATION",
       `OAuth automation currently supports ${DEFAULT_OAUTH_PROVIDER_KIND} providers only. Provider "${provider.id}" is kind "${provider.kind}".`,
+      { httpStatus: 400 },
     );
   }
 }
@@ -178,8 +185,9 @@ function assertOAuthReadyProvider(
 function readOAuthProviderKind(kind: FridayProviderKind | undefined): FridayProviderKind {
   const resolved = kind ?? DEFAULT_OAUTH_PROVIDER_KIND;
   if (resolved !== DEFAULT_OAUTH_PROVIDER_KIND) {
-    throw new Error(
+    throw new FridayDomainError("UNSUPPORTED_OPERATION",
       `OAuth automation currently supports ${DEFAULT_OAUTH_PROVIDER_KIND} providers only.`,
+      { httpStatus: 400 },
     );
   }
   return resolved;
@@ -190,7 +198,8 @@ async function safeGetRoutingConfig(
 ): Promise<{ defaultProviderId: string } | null> {
   try {
     return await providerService.getRoutingConfig();
-  } catch {
+  } catch (err) {
+    console.warn("[friday][provider-oauth-selection] routing config fetch failed:", err instanceof Error ? err.message : String(err));
     return null;
   }
 }

--- a/src/providers/services/friday-provider-service.ts
+++ b/src/providers/services/friday-provider-service.ts
@@ -20,6 +20,7 @@ import type {
   FridayProviderService,
 } from "./friday-provider-service.types.js";
 
+import { safeJsonParse } from "#utilities";
 import { createFridayProviderProfileRepository } from "../persistence/friday-provider-profile-repository.js";
 import { createFridaySecretRepository } from "../persistence/friday-secret-repository.js";
 import { createFridayProviderUsageRepository } from "../persistence/friday-provider-usage-repository.js";
@@ -295,7 +296,7 @@ export function createFridayProviderService(
         .get(ROUTING_SETTINGS_KEY) as { value_json: string } | undefined,
     );
     if (!row) return null;
-    return JSON.parse(row.value_json) as FridayModelRoutingConfig;
+    return safeJsonParse<FridayModelRoutingConfig>(row.value_json) ?? null;
   }
 
   function saveRoutingConfig(config: FridayModelRoutingConfig): void {
@@ -1070,8 +1071,9 @@ export function createFridayProviderService(
           authMode: "oauth",
         });
         profile.config.validation = validationState;
-      } catch {
+      } catch (err) {
         // Don't block the flow — just warn via validation state
+        console.warn("[friday][provider-service] post-login validation failed:", err instanceof Error ? err.message : String(err));
         profile.config.validation = {
           status: "failed",
           checkedAt: deps.nowIso(),

--- a/src/providers/validation/friday-provider-validator.ts
+++ b/src/providers/validation/friday-provider-validator.ts
@@ -1,3 +1,4 @@
+import { FridayDomainError } from "#errors";
 import type {
   FridayProviderApi,
   FridayProviderKind,
@@ -49,7 +50,7 @@ async function fetchWithTimeout(
 function assertBaseUrlSafe(baseUrl: string, opts?: { allowLoopback?: boolean }): void {
   const result = validateGatewayUrl(baseUrl, { allowLoopback: opts?.allowLoopback });
   if (!result.valid) {
-    throw new Error(`SSRF_BLOCKED: ${result.error ?? "URL blocked by security policy"}`);
+    throw new FridayDomainError("VALIDATION_ERROR", `SSRF_BLOCKED: ${result.error ?? "URL blocked by security policy"}`, { httpStatus: 400 });
   }
 }
 
@@ -125,8 +126,9 @@ async function validateAnthropic(
         if (errBody.error?.type === "invalid_api_key") {
           return makeFailedState("PROVIDER_AUTH_INVALID", errBody.error.message ?? "Invalid API key", 400);
         }
-      } catch {
+      } catch (err) {
         // ignore parse errors
+        console.warn("[friday][provider-validator] response body parse failed:", err instanceof Error ? err.message : String(err));
       }
     }
     return makeFailedState("PROVIDER_UNREACHABLE", `HTTP ${String(res.status)}`, res.status);
@@ -224,7 +226,8 @@ export function createFridayProviderValidator(): FridayProviderValidator {
       const isOllamaApi = params.api === "ollama";
       try {
         assertBaseUrlSafe(params.baseUrl, { allowLoopback: isOllamaApi });
-      } catch {
+      } catch (err) {
+        console.warn("[friday][provider-validator] base URL blocked:", err instanceof Error ? err.message : String(err));
         return makeFailedState("PROVIDER_UNREACHABLE", "Base URL blocked by security policy (private/loopback address)");
       }
 

--- a/src/retry/engine/retry-context.ts
+++ b/src/retry/engine/retry-context.ts
@@ -1,3 +1,5 @@
+import { FridayDomainError } from "#errors";
+
 /**
  * Retry Context Tracker — Tracks retry history, attempt counts, and timing
  * for active retry sequences.
@@ -245,9 +247,7 @@ export function createRetryContextTracker(config: RetryContextTrackerConfig) {
 
     for (const next of path) {
       if (!ALLOWED_TRANSITIONS[current].includes(next)) {
-        throw new Error(
-          `Invalid retry context transition (${current} -> ${next}) during ${mutation}`,
-        );
+        throw new FridayDomainError("VALIDATION_ERROR", `Invalid retry context transition (${current} -> ${next}) during ${mutation}`, { httpStatus: 400 });
       }
 
       current = next;
@@ -265,9 +265,7 @@ export function createRetryContextTracker(config: RetryContextTrackerConfig) {
   function assertMutable(ctx: RetryContextState, mutation: string): void {
     const lifecycle = toLifecycleState(ctx);
     if (TERMINAL_STATES.has(lifecycle)) {
-      throw new Error(
-        `Cannot mutate terminal retry context (${lifecycle}) during ${mutation}`,
-      );
+      throw new FridayDomainError("VALIDATION_ERROR", `Cannot mutate terminal retry context (${lifecycle}) during ${mutation}`, { httpStatus: 400 });
     }
   }
 

--- a/src/retry/engine/retry-orchestrator.ts
+++ b/src/retry/engine/retry-orchestrator.ts
@@ -1,3 +1,5 @@
+import { FridayDomainError } from "#errors";
+
 /**
  * Retry Orchestrator — End-to-end retry execution pipeline.
  *
@@ -251,7 +253,7 @@ export class RetryOrchestrator {
     const maxExecutionAttempts = config.maxExecutionAttempts ?? 100;
 
     if (maxExecutionAttempts < 1) {
-      throw new Error("maxExecutionAttempts must be >= 1");
+      throw new FridayDomainError("VALIDATION_ERROR", "maxExecutionAttempts must be >= 1", { httpStatus: 400 });
     }
 
     let currentAttemptNumber = 0;

--- a/src/retry/persistence/friday-retry-repository.ts
+++ b/src/retry/persistence/friday-retry-repository.ts
@@ -18,7 +18,8 @@ function parseJson<T>(value: string | null | undefined, fallback: T): T {
   if (!value) return fallback;
   try {
     return JSON.parse(value) as T;
-  } catch {
+  } catch (err) {
+    console.warn("[friday][retry-repository] JSON parse failed:", err instanceof Error ? err.message : String(err));
     return fallback;
   }
 }

--- a/src/routing/friday-reply-queue-job.ts
+++ b/src/routing/friday-reply-queue-job.ts
@@ -69,7 +69,8 @@ export function createFridayReplyQueueJob(
     if (!running) return;
     try {
       await job.runOnce();
-    } catch {
+    } catch (err) {
+    console.warn("[friday][reply-queue-job] operation failed:", err instanceof Error ? err.message : String(err));
       // continue
     }
     if (running) {

--- a/src/rules/engine/condition-evaluator.ts
+++ b/src/rules/engine/condition-evaluator.ts
@@ -1,3 +1,5 @@
+import { FridayDomainError } from "#errors";
+
 /**
  * Condition Evaluator — evaluates rule conditions against an evaluation context.
  *
@@ -36,11 +38,18 @@ const FORBIDDEN_FIELD_SEGMENTS: ReadonlySet<string> = new Set(["__proto__", "con
  */
 const REDOS_NESTED_QUANTIFIER_RE = /[+*}]\s*\)[\s)]*[+*?{]/;
 const REDOS_STAR_PLUS_ALTERNATION_RE = /\([^)]*\|[^)]*\)[+*]{1}/;
+// P2-SEC: Additional ReDoS heuristics for broader coverage
+const REDOS_LOOKAHEAD_QUANTIFIER_RE = /\(\?[=!][^)]*[+*]\)/; // Quantifier inside lookahead
+const REDOS_REPETITION_OVERLAP_RE = /\[[^\]]*\]\+[^?][^\[]*\[[^\]]*\]\+/; // Adjacent char-class quantifiers
+const REDOS_DEEP_NESTING_RE = /\({3,}/; // Deeply nested groups (3+ levels)
 
 function isUnsafeRegexPattern(pattern: string): boolean {
   if (pattern.length > MAX_REGEX_PATTERN_LENGTH) return true;
   if (REDOS_NESTED_QUANTIFIER_RE.test(pattern)) return true;
   if (REDOS_STAR_PLUS_ALTERNATION_RE.test(pattern)) return true;
+  if (REDOS_LOOKAHEAD_QUANTIFIER_RE.test(pattern)) return true;
+  if (REDOS_REPETITION_OVERLAP_RE.test(pattern)) return true;
+  if (REDOS_DEEP_NESTING_RE.test(pattern)) return true;
   return false;
 }
 
@@ -58,9 +67,7 @@ export function precompileRegexPattern(pattern: string): RegExp {
   }
 
   if (isUnsafeRegexPattern(pattern)) {
-    throw new Error(
-      `Regex pattern rejected: potentially unsafe (ReDoS risk or exceeds max length ${String(MAX_REGEX_PATTERN_LENGTH)})`,
-    );
+    throw new FridayDomainError("VALIDATION_ERROR", `Regex pattern rejected: potentially unsafe (ReDoS risk or exceeds max length ${String(MAX_REGEX_PATTERN_LENGTH)})`, { httpStatus: 400 });
   }
 
   const compiled = new RegExp(pattern);
@@ -179,9 +186,10 @@ function evaluateRegex(fieldValue: JsonValue | undefined, pattern: JsonValue | u
   if (typeof fieldValue !== "string" || typeof pattern !== "string") return false;
   try {
     return precompileRegexPattern(pattern).test(fieldValue);
-  } catch {
+  } catch (err) {
     // Invalid regex — treated as non-match at evaluation time.
     // Validation should catch this at rule creation/import time.
+    console.warn("[friday][condition-evaluator] regex evaluation failed:", err instanceof Error ? err.message : String(err));
     return false;
   }
 }

--- a/src/rules/engine/rule-engine.ts
+++ b/src/rules/engine/rule-engine.ts
@@ -374,8 +374,9 @@ export class FridayRuleEngine {
       if (hook.phase === phase && hook.source === source) {
         try {
           await hook.handler(context, result);
-        } catch {
+        } catch (err) {
           // Hook failures are isolated from enforcement decisions.
+          console.warn("[friday][rule-engine] hook execution failed:", err instanceof Error ? err.message : String(err));
           hadFailure = true;
         }
       }
@@ -432,8 +433,9 @@ export class FridayRuleEngine {
     try {
       this.auditLogSink(entrySnapshot);
       return true;
-    } catch {
+    } catch (err) {
       // Telemetry failures must not affect enforcement results.
+      console.warn("[friday][rule-engine] audit log sink failed:", err instanceof Error ? err.message : String(err));
       return false;
     }
   }
@@ -468,16 +470,18 @@ export class FridayRuleEngine {
     if (this.onTransition) {
       try {
         this.onTransition(transition);
-      } catch {
+      } catch (err) {
         // Transition observer failures must not affect enforcement results.
+        console.warn("[friday][rule-engine] transition observer failed:", err instanceof Error ? err.message : String(err));
       }
     }
 
     if (localObserver) {
       try {
         localObserver(transition);
-      } catch {
+      } catch (err) {
         // Transition observer failures must not affect enforcement results.
+        console.warn("[friday][rule-engine] local transition observer failed:", err instanceof Error ? err.message : String(err));
       }
     }
   }

--- a/src/rules/persistence/friday-eval-audit-repository.ts
+++ b/src/rules/persistence/friday-eval-audit-repository.ts
@@ -1,5 +1,6 @@
 import * as crypto from "node:crypto";
 import type Database from "better-sqlite3";
+import { safeJsonParse } from "#utilities";
 import type {
   FridayRuleEvaluationLogRow,
   ISODateTime,
@@ -80,10 +81,10 @@ function rowToRecord(row: FridayRuleEvaluationLogRow): EvalAuditRecord {
     decision: row.decision,
     resource: row.resource,
     action: row.action,
-    contextRedacted: JSON.parse(row.context_redacted_json) as JsonObject,
+    contextRedacted: safeJsonParse<JsonObject>(row.context_redacted_json) ?? {},
     redactionApplied: row.redaction_applied === 1,
-    redactedFields: JSON.parse(row.redacted_fields_json) as string[],
-    matchedRules: JSON.parse(row.matched_rules_json) as JsonObject[],
+    redactedFields: safeJsonParse<string[]>(row.redacted_fields_json) ?? [],
+    matchedRules: safeJsonParse<JsonObject[]>(row.matched_rules_json) ?? [],
     durationMs: row.duration_ms,
     runId: row.run_id ?? undefined,
     workflowId: row.workflow_id ?? undefined,

--- a/src/rules/persistence/friday-policy-bundle-repository.ts
+++ b/src/rules/persistence/friday-policy-bundle-repository.ts
@@ -1,6 +1,7 @@
 import * as crypto from "node:crypto";
 import type Database from "better-sqlite3";
 import { FridayDomainError } from "#errors";
+import { safeJsonParse } from "#utilities";
 import type {
   FridayPolicyBundle,
   FridayPolicyBundleRow,
@@ -79,7 +80,7 @@ function bundleRowToEntity(row: FridayPolicyBundleRow): FridayPolicyBundle {
     version: row.version,
     priority: row.priority,
     enabled: row.enabled === 1,
-    tags: JSON.parse(row.tags_json) as string[],
+    tags: safeJsonParse<string[]>(row.tags_json) ?? [],
     source: row.source as FridayPolicyBundle["source"],
     etag: row.etag,
     createdAt: row.created_at,
@@ -104,7 +105,7 @@ function versionRowToRecord(row: BundleVersionRow): BundleVersionRecord {
     id: row.id,
     bundleId: row.bundle_id,
     version: row.version,
-    snapshot: JSON.parse(row.snapshot_json) as JsonObject,
+    snapshot: safeJsonParse<JsonObject>(row.snapshot_json) ?? {},
     changedBy: row.changed_by ?? undefined,
     changeNote: row.change_note ?? undefined,
     createdAt: row.created_at,

--- a/src/rules/persistence/friday-rules-repository.ts
+++ b/src/rules/persistence/friday-rules-repository.ts
@@ -7,6 +7,7 @@
 import * as crypto from "node:crypto";
 import type Database from "better-sqlite3";
 import { FridayDomainError } from "#errors";
+import { safeJsonParse } from "#utilities";
 import type {
   FridayPolicyBundleRow,
   FridayRule,
@@ -97,16 +98,8 @@ function generateEtag(): string {
 }
 
 function rowToRule(row: FridayRuleRow): FridayRule {
-  const conditions = (() => {
-    try {
-      const parsed = JSON.parse(row.conditions_json);
-      return typeof parsed === "object" && parsed !== null
-        ? parsed as FridayRule["conditions"]
-        : {};
-    } catch {
-      return {};
-    }
-  })();
+  const parsed = safeJsonParse<FridayRule["conditions"]>(row.conditions_json);
+  const conditions = typeof parsed === "object" && parsed !== null ? parsed : {};
 
   return {
     id: row.id,
@@ -129,16 +122,10 @@ function rowToRule(row: FridayRuleRow): FridayRule {
 }
 
 function rowToRuleVersion(row: FridayRuleVersionRow): FridayRuleVersion {
-  const snapshot = (() => {
-    try {
-      const parsed = JSON.parse(row.snapshot_json);
-      return typeof parsed === "object" && parsed !== null
-        ? parsed as FridayRuleVersion["snapshot"]
-        : {};
-    } catch {
-      return {} as FridayRuleVersion["snapshot"];
-    }
-  })();
+  const snapshotParsed = safeJsonParse<FridayRuleVersion["snapshot"]>(row.snapshot_json);
+  const snapshot = typeof snapshotParsed === "object" && snapshotParsed !== null
+    ? snapshotParsed
+    : {} as FridayRuleVersion["snapshot"];
 
   return {
     id: row.id,
@@ -292,8 +279,9 @@ export function createFridayRulesRepository(): FridayRulesRepository {
           INSERT INTO rule_eval_audit (id, rule_id, policy_bundle_id, decision, resource, action, context_redacted_json, redaction_applied, redacted_fields_json, matched_rules_json, duration_ms, run_id, workflow_id, principal_id, context_hash, created_at)
           VALUES (@id, @rule_id, @policy_bundle_id, @decision, @resource, @action, @context_redacted_json, @redaction_applied, @redacted_fields_json, @matched_rules_json, @duration_ms, @run_id, @workflow_id, @principal_id, NULL, @created_at)
         `).run(entry);
-      } catch {
+      } catch (err) {
         // table may not exist on legacy schemas
+        console.warn("[friday][rules-repository] audit log insert failed:", err instanceof Error ? err.message : String(err));
       }
     },
 

--- a/src/satellites/persistence/friday-stream-checkpoint-repository.ts
+++ b/src/satellites/persistence/friday-stream-checkpoint-repository.ts
@@ -1,4 +1,5 @@
 import type Database from "better-sqlite3";
+import { safeJsonParse } from "#utilities";
 
 /**
  * Manages protocol epoch and per-stream ack checkpoints
@@ -27,7 +28,7 @@ export function createFridayStreamCheckpointRepository(): FridayStreamCheckpoint
         .prepare("SELECT value_json FROM hub_settings WHERE key = ?")
         .get(EPOCH_KEY) as { value_json: string } | undefined;
       if (!row) return 0;
-      return JSON.parse(row.value_json) as number;
+      return safeJsonParse<number>(row.value_json) ?? 0;
     },
 
     bumpEpoch(db, nowIso) {
@@ -50,7 +51,7 @@ export function createFridayStreamCheckpointRepository(): FridayStreamCheckpoint
         .prepare("SELECT value_json FROM hub_settings WHERE key = ?")
         .get(key) as { value_json: string } | undefined;
       if (!row) return 0;
-      return JSON.parse(row.value_json) as number;
+      return safeJsonParse<number>(row.value_json) ?? 0;
     },
 
     setLastAckedSeq(db, input) {

--- a/src/satellites/protocol/friday-ack-resume-validator.ts
+++ b/src/satellites/protocol/friday-ack-resume-validator.ts
@@ -15,7 +15,8 @@ export function createFridayAckResumeValidator(
       let cursorPayload;
       try {
         cursorPayload = cursorSigner.verify(frame.cursor);
-      } catch {
+      } catch (err) {
+        console.warn("[friday][ack-resume-validator] cursor HMAC verification failed:", err instanceof Error ? err.message : String(err));
         return {
           ok: false,
           code: "AUTH_UNAUTHORIZED",

--- a/src/satellites/services/friday-satellite-pairing-service.ts
+++ b/src/satellites/services/friday-satellite-pairing-service.ts
@@ -108,7 +108,8 @@ function verifyChallengeSignature(
     verifier.update(challengeNonce);
     verifier.end();
     return verifier.verify(publicKeyPem, signedChallenge, "base64");
-  } catch {
+  } catch (err) {
+    console.warn("[friday][satellite-pairing-service] challenge verification failed:", err instanceof Error ? err.message : String(err));
     return false;
   }
 }

--- a/src/satellites/services/friday-satellite-sync-service.ts
+++ b/src/satellites/services/friday-satellite-sync-service.ts
@@ -160,7 +160,8 @@ export function createFridaySatelliteSyncService(
                 });
                 continue;
               }
-            } catch {
+            } catch (err) {
+              console.warn("[friday][satellite-sync-service] invalid ack cursor:", err instanceof Error ? err.message : String(err));
               conflicts.push({
                 streamId: ack.streamId,
                 seq: ack.seq,

--- a/src/security/friday-audit-log.ts
+++ b/src/security/friday-audit-log.ts
@@ -143,8 +143,9 @@ export function resolveFridayAuditLogPath(stateDir: string): string {
 async function bestEffortChmod(filePath: string, mode: number): Promise<void> {
   try {
     await fs.chmod(filePath, mode);
-  } catch {
+  } catch (err) {
     // Best-effort — some filesystems don't support chmod
+    console.warn("[friday][audit-log] chmod failed:", err instanceof Error ? err.message : String(err));
   }
 }
 
@@ -194,8 +195,9 @@ export async function appendFridayAuditLog(
         await fs.writeFile(filePath, kept.join("\n") + "\n", { encoding: "utf8", mode: FILE_MODE });
         await bestEffortChmod(filePath, FILE_MODE);
       }
-    } catch {
+    } catch (err) {
       // Rotation failure is non-fatal — log continues to work
+      console.warn("[friday][audit-log] rotation failed:", err instanceof Error ? err.message : String(err));
     }
   });
 }

--- a/src/security/multi-tenant/engine/policy-engine.ts
+++ b/src/security/multi-tenant/engine/policy-engine.ts
@@ -559,7 +559,8 @@ export class PolicyEngine {
         if (typeof fieldValue === "string" && typeof condValue === "string") {
           try {
             return new RegExp(condValue).test(fieldValue);
-          } catch {
+          } catch (err) {
+            console.warn("[friday][policy-engine] regex match failed:", err instanceof Error ? err.message : String(err));
             return false;
           }
         }

--- a/src/sessions/persistence/friday-session-memory-extraction-repository.ts
+++ b/src/sessions/persistence/friday-session-memory-extraction-repository.ts
@@ -1,4 +1,5 @@
 import type Database from "better-sqlite3";
+import { safeJsonParse } from "#utilities";
 
 import type {
   FridaySessionMemoryExtractionJobRecord,
@@ -35,9 +36,7 @@ function rowToRecord(row: FridayExtractionJobRow): FridaySessionMemoryExtraction
     sessionKey: row.session_key,
     trigger: row.trigger as FridaySessionMemoryExtractionTrigger,
     status: row.status as FridaySessionMemoryExtractionJobStatus,
-    requestedMessageIds: row.requested_message_ids_json
-      ? (JSON.parse(row.requested_message_ids_json) as string[])
-      : undefined,
+    requestedMessageIds: safeJsonParse<string[]>(row.requested_message_ids_json),
     batchSize: row.batch_size,
     maxBatches: row.max_batches,
     attempts: row.attempts,

--- a/src/sessions/persistence/friday-session-message-repository.ts
+++ b/src/sessions/persistence/friday-session-message-repository.ts
@@ -1,6 +1,7 @@
 import type Database from "better-sqlite3";
 
 import { FridayDomainError } from "#errors";
+import { safeJsonParse } from "#utilities";
 
 import { FRIDAY_SESSION_ERROR_CODES } from "../friday-session.constants.js";
 import type {
@@ -40,13 +41,13 @@ function rowToRecord(row: FridaySessionMessageRow): FridaySessionMessageRecord {
     sessionKey: row.session_key ?? "",
     sequence: row.sequence,
     role: row.role as FridaySessionRole,
-    content: JSON.parse(row.content_json) as unknown,
+    content: safeJsonParse<unknown>(row.content_json),
     contentText: row.content_text ?? "",
-    toolCalls: row.tool_calls_json ? JSON.parse(row.tool_calls_json) as unknown[] : undefined,
+    toolCalls: safeJsonParse<unknown[]>(row.tool_calls_json),
     tokenCount: row.token_count,
     idempotencyKey: row.idempotency_key ?? undefined,
     parentMessageId: row.parent_message_id ?? undefined,
-    metadata: row.metadata_json ? JSON.parse(row.metadata_json) as Record<string, unknown> : {},
+    metadata: safeJsonParse<Record<string, unknown>>(row.metadata_json) ?? {},
     memoryExtractStatus: row.memory_extract_status as FridaySessionMessageRecord["memoryExtractStatus"],
     memoryExtractedAt: row.memory_extracted_at ?? undefined,
     occurredAt: row.occurred_at ?? row.created_at,

--- a/src/sessions/persistence/friday-session-repository.ts
+++ b/src/sessions/persistence/friday-session-repository.ts
@@ -1,6 +1,7 @@
 import type Database from "better-sqlite3";
 
 import { FridayDomainError } from "#errors";
+import { safeJsonParse } from "#utilities";
 
 import { FRIDAY_SESSION_ERROR_CODES } from "../friday-session.constants.js";
 import type {
@@ -57,7 +58,7 @@ function rowToRecord(row: FridaySessionRow): FridaySessionRecord {
     rootSessionKey: row.root_session_key ?? undefined,
     forkedFromMessageId: row.forked_from_message_id ?? undefined,
     sendPolicy: row.send_policy as FridaySessionSendPolicy | undefined ?? undefined,
-    metadata: row.metadata_json ? JSON.parse(row.metadata_json) as Record<string, unknown> : {},
+    metadata: safeJsonParse<Record<string, unknown>>(row.metadata_json) ?? {},
     contextInputTokens: row.context_input_tokens,
     contextOutputTokens: row.context_output_tokens,
     contextTotalTokens: row.context_total_tokens,

--- a/src/sessions/services/friday-deterministic-dispatch.ts
+++ b/src/sessions/services/friday-deterministic-dispatch.ts
@@ -103,7 +103,8 @@ async function handleCapabilities(
     lines.push(`  Desktop companion: ${snap.desktop.connected ? "connected" : "disconnected"}`);
 
     return { handled: true, response: lines.join("\n") };
-  } catch {
+  } catch (err) {
+    console.warn("[friday][deterministic-dispatch] status dispatch failed:", err instanceof Error ? err.message : String(err));
     return { handled: false };
   }
 }
@@ -151,7 +152,8 @@ async function handleTaskStatus(
     }
 
     return { handled: true, response: lines.join("\n") };
-  } catch {
+  } catch (err) {
+    console.warn("[friday][deterministic-dispatch] task status failed:", err instanceof Error ? err.message : String(err));
     return { handled: false };
   }
 }

--- a/src/sessions/services/friday-session-memory-extraction-llm-client.ts
+++ b/src/sessions/services/friday-session-memory-extraction-llm-client.ts
@@ -207,7 +207,8 @@ function parseJsonFromText(rawText: string): unknown {
   const trimmed = rawText.trim();
   try {
     return JSON.parse(trimmed);
-  } catch {
+  } catch (err) {
+    console.warn("[friday][session-memory-extraction-llm-client] JSON parse failed:", err instanceof Error ? err.message : String(err));
     const fenceMatch = /```(?:json)?\s*\n?([\s\S]*?)\n?```/.exec(trimmed);
     if (fenceMatch?.[1]) {
       return JSON.parse(fenceMatch[1].trim());

--- a/src/sessions/services/friday-session-memory-extraction-service.ts
+++ b/src/sessions/services/friday-session-memory-extraction-service.ts
@@ -1,4 +1,5 @@
 import { FridayDomainError } from "#errors";
+import { safeJsonParse } from "#utilities";
 
 import {
   FRIDAY_SESSION_MEMORY_EXTRACTION_DEFAULT_BATCH_SIZE,
@@ -87,16 +88,16 @@ export function createFridaySessionMemoryExtractionService(
       sessionKey: (row["session_key"] as string | null) ?? "",
       sequence: row["sequence"] as number,
       role: row["role"] as FridaySessionMessageRecord["role"],
-      content: JSON.parse(row["content_json"] as string) as unknown,
+      content: safeJsonParse(row["content_json"] as string) as unknown,
       contentText: (row["content_text"] as string | null) ?? "",
       toolCalls: row["tool_calls_json"]
-        ? (JSON.parse(row["tool_calls_json"] as string) as unknown[])
+        ? (safeJsonParse(row["tool_calls_json"] as string) as unknown[])
         : undefined,
       tokenCount: row["token_count"] as number,
       idempotencyKey: (row["idempotency_key"] as string | null) ?? undefined,
       parentMessageId: (row["parent_message_id"] as string | null) ?? undefined,
       metadata: row["metadata_json"]
-        ? (JSON.parse(row["metadata_json"] as string) as Record<string, unknown>)
+        ? (safeJsonParse(row["metadata_json"] as string) as Record<string, unknown>)
         : {},
       memoryExtractStatus: row["memory_extract_status"] as FridaySessionMessageRecord["memoryExtractStatus"],
       memoryExtractedAt: (row["memory_extracted_at"] as string | null) ?? undefined,
@@ -554,8 +555,9 @@ export function createFridaySessionMemoryExtractionService(
               }),
             );
             result.sessionsQueued.push(key);
-          } catch {
+          } catch (err) {
             // Ignore unique constraint violations (already has an open job)
+            console.warn("[friday][session-memory-extraction-service] job queue insert failed:", err instanceof Error ? err.message : String(err));
           }
         }
       }

--- a/src/sessions/services/friday-session-service.ts
+++ b/src/sessions/services/friday-session-service.ts
@@ -253,8 +253,9 @@ export function createFridaySessionService(
             updates.push("memory_namespace = ?");
             params.push(memoryNamespace);
           }
-        } catch {
+        } catch (err) {
           // Memory namespace resolution is best-effort for getOrCreate
+          console.warn("[friday][session-service] memory namespace resolution failed:", err instanceof Error ? err.message : String(err));
         }
 
         if (updates.length > 0) {
@@ -338,8 +339,9 @@ export function createFridaySessionService(
                 updates.push("memory_namespace = ?");
                 params.push(memoryNamespace);
               }
-            } catch {
+            } catch (err) {
               // Memory namespace resolution is best-effort
+              console.warn("[friday][session-service] memory namespace resolution failed:", err instanceof Error ? err.message : String(err));
             }
 
             if (updates.length > 0) {
@@ -611,8 +613,9 @@ export function createFridaySessionService(
             memoryNamespace = resolveFridaySessionMemoryNamespace(parent, (k) =>
               sessionRepo.getByKey(db, k),
             );
-          } catch {
+          } catch (err) {
             // Best-effort
+            console.warn("[friday][session-service] fork memory namespace failed:", err instanceof Error ? err.message : String(err));
           }
         }
 

--- a/src/setup/friday-setup-environment-scanner.ts
+++ b/src/setup/friday-setup-environment-scanner.ts
@@ -43,7 +43,8 @@ export function createFridayEnvironmentScanner(): FridayEnvironmentScanner {
       try {
         await execCommand("which", [command]);
         return true;
-      } catch {
+      } catch (err) {
+        console.warn("[friday][setup-environment-scanner] command not found:", err instanceof Error ? err.message : String(err));
         return false;
       }
     },
@@ -52,7 +53,8 @@ export function createFridayEnvironmentScanner(): FridayEnvironmentScanner {
       try {
         const output = await execCommand(command, ["--version"]);
         return extractVersion(output);
-      } catch {
+      } catch (err) {
+        console.warn("[friday][setup-environment-scanner] version check failed:", err instanceof Error ? err.message : String(err));
         return null;
       }
     },
@@ -67,7 +69,8 @@ export function createFridayEnvironmentScanner(): FridayEnvironmentScanner {
         });
         clearTimeout(timer);
         return response.ok || response.status < 500;
-      } catch {
+      } catch (err) {
+        console.warn("[friday][setup-environment-scanner] reachability check failed:", err instanceof Error ? err.message : String(err));
         return false;
       }
     },
@@ -76,7 +79,8 @@ export function createFridayEnvironmentScanner(): FridayEnvironmentScanner {
       try {
         await access(path, constants.F_OK);
         return true;
-      } catch {
+      } catch (err) {
+        console.warn("[friday][setup-environment-scanner] file access check failed:", err instanceof Error ? err.message : String(err));
         return false;
       }
     },

--- a/src/setup/friday-setup-recipe-executor.ts
+++ b/src/setup/friday-setup-recipe-executor.ts
@@ -1,3 +1,5 @@
+import { FridayDomainError } from "#errors";
+
 /**
  * Setup Recipe Executor — Executes setup recipes using the autonomous engine.
  *
@@ -270,7 +272,7 @@ export function createFridaySetupRecipeExecutor(
     updates: Partial<FridaySetupExecution>,
   ): FridaySetupExecution {
     const current = executions.get(executionId);
-    if (!current) throw new Error(`Execution ${executionId} not found`);
+    if (!current) throw new FridayDomainError("NOT_FOUND", `Execution ${executionId} not found`, { httpStatus: 404 });
     const updated = { ...current, ...updates } as FridaySetupExecution;
     executions.set(executionId, updated);
     return updated;
@@ -282,7 +284,7 @@ export function createFridaySetupRecipeExecutor(
     async execute(params: FridaySetupExecuteParams): Promise<FridaySetupExecution> {
       const recipe = registry.get(params.recipeId);
       if (!recipe) {
-        throw new Error(`Recipe "${params.recipeId}" not found`);
+        throw new FridayDomainError("NOT_FOUND", `Recipe "${params.recipeId}" not found`, { httpStatus: 404 });
       }
 
       const executionId = idGenerator();
@@ -383,7 +385,7 @@ export function createFridaySetupRecipeExecutor(
 
     async checkPrerequisites(recipeId: string): Promise<readonly FridaySetupPrerequisiteResult[]> {
       const recipe = registry.get(recipeId);
-      if (!recipe) throw new Error(`Recipe "${recipeId}" not found`);
+      if (!recipe) throw new FridayDomainError("NOT_FOUND", `Recipe "${recipeId}" not found`, { httpStatus: 404 });
       return checkPrerequisitesInternal(recipe);
     },
 

--- a/src/skills/bridge/friday-legacy-skill-bridge.ts
+++ b/src/skills/bridge/friday-legacy-skill-bridge.ts
@@ -278,7 +278,8 @@ function readSkillBody(skillMdPath: string): string {
     const raw = readFileSync(skillMdPath, "utf-8");
     const result = parseFridaySkillFrontmatter(raw);
     return result.ok ? result.value.body : raw;
-  } catch {
+  } catch (err) {
+    console.warn("[friday][legacy-skill-bridge] operation failed:", err instanceof Error ? err.message : String(err));
     return "";
   }
 }

--- a/src/skills/converter/code-repo/friday-capability-extractor.ts
+++ b/src/skills/converter/code-repo/friday-capability-extractor.ts
@@ -147,7 +147,8 @@ function extractNpmScriptCapabilities(
   let parsed: unknown;
   try {
     parsed = JSON.parse(packageJsonContent);
-  } catch {
+  } catch (err) {
+    console.warn("[friday][capability-extractor] operation failed:", err instanceof Error ? err.message : String(err));
     return;
   }
   if (!parsed || typeof parsed !== "object") return;

--- a/src/skills/converter/code-repo/friday-source-materializer.ts
+++ b/src/skills/converter/code-repo/friday-source-materializer.ts
@@ -149,7 +149,8 @@ function materializeLocalSource(
   let rootStats;
   try {
     rootStats = statSync(rootPath);
-  } catch {
+  } catch (err) {
+    console.warn("[friday][source-materializer] operation failed:", err instanceof Error ? err.message : String(err));
     throw new FridayDomainError(
       "CONVERTER_SOURCE_NOT_FOUND",
       `Code repository source not found: ${sourceUri}`,
@@ -178,7 +179,8 @@ function materializeLocalSource(
     let entries: Array<{ name: string; isDirectory: () => boolean; isFile: () => boolean }>;
     try {
       entries = readdirSync(dir, { withFileTypes: true });
-    } catch {
+    } catch (err) {
+    console.warn("[friday][source-materializer] operation failed:", err instanceof Error ? err.message : String(err));
       return;
     }
 
@@ -209,7 +211,8 @@ function materializeLocalSource(
       try {
         const raw = readFileSync(absolute, "utf-8");
         content = raw.slice(0, maxFileBytes);
-      } catch {
+      } catch (err) {
+    console.warn("[friday][source-materializer] operation failed:", err instanceof Error ? err.message : String(err));
         continue;
       }
 
@@ -388,7 +391,8 @@ function validateExtractedPaths(baseDir: string): void {
     let entries;
     try {
       entries = readdirSync(dir, { withFileTypes: true });
-    } catch {
+    } catch (err) {
+    console.warn("[friday][source-materializer] operation failed:", err instanceof Error ? err.message : String(err));
       return;
     }
 
@@ -429,7 +433,8 @@ function calculateDirSize(dir: string, limit: number): number {
     let entries;
     try {
       entries = readdirSync(d, { withFileTypes: true });
-    } catch {
+    } catch (err) {
+    console.warn("[friday][source-materializer] operation failed:", err instanceof Error ? err.message : String(err));
       return;
     }
     for (const entry of entries) {
@@ -440,7 +445,8 @@ function calculateDirSize(dir: string, limit: number): number {
       } else if (entry.isFile()) {
         try {
           total += statSync(fullPath).size;
-        } catch {
+        } catch (err) {
+    console.warn("[friday][source-materializer] operation failed:", err instanceof Error ? err.message : String(err));
           // skip
         }
       }
@@ -460,7 +466,8 @@ function createTempWorkspace(prefix: string): string {
 export function cleanupTempWorkspace(dir: string): void {
   try {
     rmSync(dir, { recursive: true, force: true });
-  } catch {
+  } catch (err) {
+    console.warn("[friday][source-materializer] operation failed:", err instanceof Error ? err.message : String(err));
     // Best effort cleanup
   }
 }

--- a/src/skills/converter/converters/friday-clawdbot-skill-md-converter.ts
+++ b/src/skills/converter/converters/friday-clawdbot-skill-md-converter.ts
@@ -52,7 +52,8 @@ export function createClawdbotSkillMdConverter(): FridaySkillConverter {
       let content: string;
       try {
         content = readFileSync(skillMdPath, "utf-8");
-      } catch {
+      } catch (err) {
+      console.warn("[friday][clawdbot-skill-md-converter] operation failed:", err instanceof Error ? err.message : String(err));
         return null;
       }
 

--- a/src/skills/converter/converters/friday-code-repo-converter.ts
+++ b/src/skills/converter/converters/friday-code-repo-converter.ts
@@ -92,7 +92,8 @@ export function createFridayCodeRepoConverter(): FridaySkillConverter {
             `Detected capabilities: ${capabilities.length}`,
           ],
         };
-      } catch {
+      } catch (err) {
+      console.warn("[friday][code-repo-converter] operation failed:", err instanceof Error ? err.message : String(err));
         return null;
       }
     },

--- a/src/skills/converter/converters/friday-n8n-node-converter.ts
+++ b/src/skills/converter/converters/friday-n8n-node-converter.ts
@@ -71,7 +71,8 @@ export function createFridayN8nNodeConverter(): FridaySkillConverter {
       let parsed: unknown;
       try {
         parsed = JSON.parse(content);
-      } catch {
+      } catch (err) {
+      console.warn("[friday][n8n-node-converter] operation failed:", err instanceof Error ? err.message : String(err));
         return null;
       }
 
@@ -113,7 +114,8 @@ export function createFridayN8nNodeConverter(): FridaySkillConverter {
       let parsed: unknown;
       try {
         parsed = JSON.parse(content);
-      } catch {
+      } catch (err) {
+      console.warn("[friday][n8n-node-converter] operation failed:", err instanceof Error ? err.message : String(err));
         throw new FridayDomainError("PARSE_ERROR", "N8nNodeConverter: source is not valid JSON", { httpStatus: 422 });
       }
 
@@ -201,7 +203,8 @@ function resolveSourceContent(source: FridaySkillConversionSource): string | nul
   if (source.contentBase64) {
     try {
       return Buffer.from(source.contentBase64, "base64").toString("utf-8");
-    } catch {
+    } catch (err) {
+      console.warn("[friday][n8n-node-converter] operation failed:", err instanceof Error ? err.message : String(err));
       return null;
     }
   }
@@ -237,7 +240,8 @@ function tryReadAsFile(filePath: string): string | null {
     }
     const stat = readFileSync(filePath, "utf-8");
     return stat;
-  } catch {
+  } catch (err) {
+      console.warn("[friday][n8n-node-converter] operation failed:", err instanceof Error ? err.message : String(err));
     return null;
   }
 }
@@ -558,7 +562,8 @@ ${propNames.map((n) => `    params[${JSON.stringify(n)}] = getNodeParameter(${JS
     let nodeModule;
     try {
       nodeModule = await import(${JSON.stringify(nodeName)});
-    } catch {
+    } catch (err) {
+      console.warn("[friday][n8n-node-converter] operation failed:", err instanceof Error ? err.message : String(err));
       // Node module not available — return gathered parameters
       return {
         result: {

--- a/src/skills/converter/converters/friday-native-skill-package-converter.ts
+++ b/src/skills/converter/converters/friday-native-skill-package-converter.ts
@@ -66,7 +66,8 @@ export function createNativeSkillPackageConverter(): FridaySkillConverter {
           confidence: 0.6,
           reasons: ["Found skill.manifest.json but schemaVersion is not 2.0"],
         };
-      } catch {
+      } catch (err) {
+      console.warn("[friday][native-skill-package-converter] operation failed:", err instanceof Error ? err.message : String(err));
         return null;
       }
     },
@@ -91,7 +92,8 @@ export function createNativeSkillPackageConverter(): FridaySkillConverter {
       let rawObj: unknown;
       try {
         rawObj = JSON.parse(rawText);
-      } catch {
+      } catch (err) {
+      console.warn("[friday][native-skill-package-converter] operation failed:", err instanceof Error ? err.message : String(err));
         throw new FridayDomainError("PARSE_ERROR", `Invalid JSON in skill.manifest.json at: ${manifestPath}`, { httpStatus: 422 });
       }
 
@@ -112,7 +114,8 @@ export function createNativeSkillPackageConverter(): FridaySkillConverter {
       if (existsSync(uiSchemaPath)) {
         try {
           uiSchema = JSON.parse(readFileSync(uiSchemaPath, "utf-8")) as FridaySkillUiSchemaV1;
-        } catch {
+        } catch (err) {
+      console.warn("[friday][native-skill-package-converter] operation failed:", err instanceof Error ? err.message : String(err));
           throw new FridayDomainError("PARSE_ERROR", `Invalid JSON in skill.ui.json at: ${uiSchemaPath}`, { httpStatus: 422 });
         }
       } else {

--- a/src/skills/converter/converters/friday-openai-gpt-action-converter.ts
+++ b/src/skills/converter/converters/friday-openai-gpt-action-converter.ts
@@ -245,7 +245,8 @@ function resolveSourceContent(source: FridaySkillConversionSource): string | nul
   if (source.contentBase64) {
     try {
       return Buffer.from(source.contentBase64, "base64").toString("utf-8");
-    } catch {
+    } catch (err) {
+    console.warn("[friday][openai-gpt-action-converter] operation failed:", err instanceof Error ? err.message : String(err));
       return null;
     }
   }
@@ -258,7 +259,8 @@ function resolveSourceContent(source: FridaySkillConversionSource): string | nul
   if (existsSync(source.uri)) {
     try {
       return readFileSync(source.uri, "utf-8");
-    } catch {
+    } catch (err) {
+    console.warn("[friday][openai-gpt-action-converter] operation failed:", err instanceof Error ? err.message : String(err));
       // Not a file, try directory
     }
 
@@ -272,7 +274,8 @@ function resolveSourceContent(source: FridaySkillConversionSource): string | nul
       if (existsSync(filePath)) {
         try {
           return readFileSync(filePath, "utf-8");
-        } catch {
+        } catch (err) {
+    console.warn("[friday][openai-gpt-action-converter] operation failed:", err instanceof Error ? err.message : String(err));
           continue;
         }
       }
@@ -288,7 +291,8 @@ function parseJsonOrYaml(content: string): unknown | null {
   // Try JSON first
   try {
     return JSON.parse(content);
-  } catch {
+  } catch (err) {
+    console.warn("[friday][openai-gpt-action-converter] operation failed:", err instanceof Error ? err.message : String(err));
     // Not JSON, try YAML
   }
 
@@ -297,7 +301,8 @@ function parseJsonOrYaml(content: string): unknown | null {
     if (result && typeof result === "object") {
       return result;
     }
-  } catch {
+  } catch (err) {
+    console.warn("[friday][openai-gpt-action-converter] operation failed:", err instanceof Error ? err.message : String(err));
     // Not YAML either
   }
 
@@ -367,7 +372,8 @@ function extractServerHosts(spec: OpenApiSpec): string[] {
       if (url.hostname && !hosts.includes(url.hostname)) {
         hosts.push(url.hostname);
       }
-    } catch {
+    } catch (err) {
+    console.warn("[friday][openai-gpt-action-converter] operation failed:", err instanceof Error ? err.message : String(err));
       // Not a valid URL, skip
     }
   }

--- a/src/skills/converter/converters/friday-recording-converter.ts
+++ b/src/skills/converter/converters/friday-recording-converter.ts
@@ -167,7 +167,8 @@ function tryParseRecording(
   if (source.contentBase64) {
     try {
       raw = Buffer.from(source.contentBase64, "base64").toString("utf-8");
-    } catch {
+    } catch (err) {
+    console.warn("[friday][recording-converter] operation failed:", err instanceof Error ? err.message : String(err));
       return null;
     }
   }
@@ -187,7 +188,8 @@ function tryParseRecording(
       return obj as RecordingPayload;
     }
     return null;
-  } catch {
+  } catch (err) {
+    console.warn("[friday][recording-converter] operation failed:", err instanceof Error ? err.message : String(err));
     return null;
   }
 }
@@ -426,11 +428,11 @@ export default async function execute(input, ctx) {
 
   const desktop = ctx.desktop;
   if (!desktop) {
-    throw new Error("Desktop helper is not available — this skill requires desktop control.");
+    throw new FridayDomainError("NOT_INITIALIZED", "Desktop helper is not available — this skill requires desktop control.", { httpStatus: 503 });
   }
 
   if (!desktop.isConnected()) {
-    throw new Error("Desktop session is not connected.");
+    throw new FridayDomainError("NOT_INITIALIZED", "Desktop session is not connected.", { httpStatus: 503 });
   }
 
   const stepResults = [];

--- a/src/skills/converter/converters/friday-undocumented-api-converter.ts
+++ b/src/skills/converter/converters/friday-undocumented-api-converter.ts
@@ -132,7 +132,8 @@ export function createFridayUndocumentedApiConverter(): FridaySkillConverter {
 function safeDecodeBase64(input: string): string | null {
   try {
     return Buffer.from(input, "base64").toString("utf-8");
-  } catch {
+  } catch (err) {
+    console.warn("[friday][undocumented-api-converter] operation failed:", err instanceof Error ? err.message : String(err));
     return null;
   }
 }

--- a/src/skills/converter/discovery/friday-program-discovery-service.ts
+++ b/src/skills/converter/discovery/friday-program-discovery-service.ts
@@ -53,7 +53,8 @@ export function createFridayProgramDiscoveryService(
 
       try {
         programs = await deps.scanner.scan(policy);
-      } catch {
+      } catch (err) {
+      console.warn("[friday][program-discovery-service] operation failed:", err instanceof Error ? err.message : String(err));
         scanErrors++;
         programs = [];
       }

--- a/src/skills/converter/discovery/friday-program-scanner-darwin.ts
+++ b/src/skills/converter/discovery/friday-program-scanner-darwin.ts
@@ -71,7 +71,8 @@ export function createDarwinProgramScanner(): FridayProgramScanner {
               discoveredAt: now,
             });
           }
-        } catch {
+        } catch (err) {
+        console.warn("[friday][program-scanner-darwin] operation failed:", err instanceof Error ? err.message : String(err));
           // Directory read failed — skip silently
         }
       }
@@ -102,7 +103,8 @@ export function createDarwinProgramScanner(): FridayProgramScanner {
               discoveredAt: now,
             });
           }
-        } catch {
+        } catch (err) {
+        console.warn("[friday][program-scanner-darwin] operation failed:", err instanceof Error ? err.message : String(err));
           // Skip
         }
       }
@@ -139,7 +141,8 @@ function readAppBundleInfo(appPath: string): AppBundleInfo | null {
       bundleId: extractPlistValue(output, "CFBundleIdentifier"),
       publisher: extractPlistValue(output, "NSHumanReadableCopyright"),
     };
-  } catch {
+  } catch (err) {
+        console.warn("[friday][program-scanner-darwin] operation failed:", err instanceof Error ? err.message : String(err));
     // Fall back to basename
     return { name: basename(appPath, ".app") };
   }

--- a/src/skills/converter/discovery/friday-program-scanner-linux.ts
+++ b/src/skills/converter/discovery/friday-program-scanner-linux.ts
@@ -76,7 +76,8 @@ export function createLinuxProgramScanner(): FridayProgramScanner {
               discoveredAt: now,
             });
           }
-        } catch {
+        } catch (err) {
+        console.warn("[friday][program-scanner-linux] operation failed:", err instanceof Error ? err.message : String(err));
           // Directory read failed — skip
         }
       }
@@ -107,7 +108,8 @@ export function createLinuxProgramScanner(): FridayProgramScanner {
               discoveredAt: now,
             });
           }
-        } catch {
+        } catch (err) {
+        console.warn("[friday][program-scanner-linux] operation failed:", err instanceof Error ? err.message : String(err));
           // Skip
         }
       }
@@ -187,7 +189,8 @@ function parseDesktopFile(path: string): DesktopFileInfo | null {
     }
 
     return info;
-  } catch {
+  } catch (err) {
+        console.warn("[friday][program-scanner-linux] operation failed:", err instanceof Error ? err.message : String(err));
     return null;
   }
 }

--- a/src/skills/converter/discovery/friday-program-scanner-win32.ts
+++ b/src/skills/converter/discovery/friday-program-scanner-win32.ts
@@ -70,7 +70,8 @@ export function createWin32ProgramScanner(): FridayProgramScanner {
               discoveredAt: now,
             });
           }
-        } catch {
+        } catch (err) {
+        console.warn("[friday][program-scanner-win32] operation failed:", err instanceof Error ? err.message : String(err));
           // Registry query failed — skip
         }
       }
@@ -99,7 +100,8 @@ export function createWin32ProgramScanner(): FridayProgramScanner {
               discoveredAt: now,
             });
           }
-        } catch {
+        } catch (err) {
+        console.warn("[friday][program-scanner-win32] operation failed:", err instanceof Error ? err.message : String(err));
           // Directory read failed — skip
         }
       }
@@ -126,7 +128,8 @@ function queryRegistryUninstallKeys(regPath: string): RegistryEntry[] {
       { encoding: "utf-8", timeout: 10000 },
     );
     return parseRegistryOutput(output);
-  } catch {
+  } catch (err) {
+        console.warn("[friday][program-scanner-win32] operation failed:", err instanceof Error ? err.message : String(err));
     return [];
   }
 }

--- a/src/skills/converter/services/friday-skill-import-installer.ts
+++ b/src/skills/converter/services/friday-skill-import-installer.ts
@@ -170,7 +170,8 @@ function sanitizeDraftFileContent(relativePath: string, content: string): string
     const leaf = basename(sourceRef.replace(/[\\/]+$/, ""));
     parsed.sourceRef = leaf.length > 0 ? `local:${leaf}` : "local:redacted";
     return JSON.stringify(parsed, null, 2);
-  } catch {
+  } catch (err) {
+    console.warn("[friday][skill-import-installer] operation failed:", err instanceof Error ? err.message : String(err));
     return content;
   }
 }

--- a/src/skills/converter/undocumented-api/friday-api-doc-crawler.ts
+++ b/src/skills/converter/undocumented-api/friday-api-doc-crawler.ts
@@ -54,7 +54,8 @@ export function createFridayApiDocCrawler(
         let decoded: string;
         try {
           decoded = Buffer.from(source.contentBase64, "base64").toString("utf-8");
-        } catch {
+        } catch (err) {
+    console.warn("[friday][api-doc-crawler] operation failed:", err instanceof Error ? err.message : String(err));
           throw new FridayDomainError(
             "VALIDATION_ERROR",
             "Invalid contentBase64 for undocumented API source",
@@ -168,7 +169,8 @@ async function crawlMultiPage(
     let rawHtml: string;
     try {
       rawHtml = await fetchTextWithLimit(fetchFn, ssrfGuard, url, timeoutMs, maxBytes);
-    } catch {
+    } catch (err) {
+    console.warn("[friday][api-doc-crawler] operation failed:", err instanceof Error ? err.message : String(err));
       // Skip pages that fail to fetch — don't abort the entire crawl
       continue;
     }
@@ -235,7 +237,8 @@ export function extractSameOriginLinks(
     let resolvedUrl: string;
     try {
       resolvedUrl = new URL(href, pageUrl).href;
-    } catch {
+    } catch (err) {
+    console.warn("[friday][api-doc-crawler] operation failed:", err instanceof Error ? err.message : String(err));
       continue;
     }
 
@@ -274,7 +277,8 @@ export function extractOrigin(url: string): string {
   try {
     const parsed = new URL(url);
     return `${parsed.protocol}//${parsed.host}`;
-  } catch {
+  } catch (err) {
+    console.warn("[friday][api-doc-crawler] operation failed:", err instanceof Error ? err.message : String(err));
     return "";
   }
 }
@@ -282,7 +286,8 @@ export function extractOrigin(url: string): string {
 function extractPath(url: string): string {
   try {
     return new URL(url).pathname;
-  } catch {
+  } catch (err) {
+    console.warn("[friday][api-doc-crawler] operation failed:", err instanceof Error ? err.message : String(err));
     return "";
   }
 }
@@ -298,7 +303,8 @@ function normalizeUrl(url: string): string {
     }
     parsed.pathname = path;
     return parsed.href;
-  } catch {
+  } catch (err) {
+    console.warn("[friday][api-doc-crawler] operation failed:", err instanceof Error ? err.message : String(err));
     return url;
   }
 }

--- a/src/skills/converter/undocumented-api/friday-api-example-parser.ts
+++ b/src/skills/converter/undocumented-api/friday-api-example-parser.ts
@@ -80,7 +80,8 @@ function normalizeTarget(target: string): { path: string; origin?: string } | nu
       const parsed = new URL(target);
       const path = parsed.pathname || "/";
       return { path: path.startsWith("/") ? path : `/${path}`, origin: parsed.origin };
-    } catch {
+    } catch (err) {
+    console.warn("[friday][api-example-parser] operation failed:", err instanceof Error ? err.message : String(err));
       return null;
     }
   }

--- a/src/skills/converter/undocumented-api/friday-openapi-synthesizer.ts
+++ b/src/skills/converter/undocumented-api/friday-openapi-synthesizer.ts
@@ -65,7 +65,8 @@ function inferTitle(sourceRef: string): string {
       const host = new URL(sourceRef).hostname;
       return `${host} API`;
     }
-  } catch {
+  } catch (err) {
+    console.warn("[friday][openapi-synthesizer] operation failed:", err instanceof Error ? err.message : String(err));
     // ignore
   }
   const cleaned = sourceRef.split(/[\\/]/).pop() ?? sourceRef;
@@ -80,7 +81,8 @@ function inferServerUrl(endpoints: FridayParsedApiEndpoint[], sourceRef: string)
     try {
       const parsed = new URL(sourceRef);
       return parsed.origin;
-    } catch {
+    } catch (err) {
+    console.warn("[friday][openapi-synthesizer] operation failed:", err instanceof Error ? err.message : String(err));
       return null;
     }
   }

--- a/src/skills/executor/friday-shell-executor.ts
+++ b/src/skills/executor/friday-shell-executor.ts
@@ -40,7 +40,8 @@ export function createFridayShellExecutor(): FridayShellExecutor {
             if (child.pid != null) {
               process.kill(-child.pid, "SIGKILL");
             }
-          } catch {
+          } catch (err) {
+            console.warn("[friday][shell-executor] operation failed:", err instanceof Error ? err.message : String(err));
             // Process may already be gone
             child.kill("SIGKILL");
           }

--- a/src/skills/executor/friday-skill-desktop-helper.ts
+++ b/src/skills/executor/friday-skill-desktop-helper.ts
@@ -8,6 +8,7 @@
  * @module skills/executor/friday-skill-desktop-helper
  */
 
+import { FridayDomainError } from "#errors";
 import type { DesktopSessionManager } from "../../desktop/engine/session-manager.js";
 import type {
   FridayDesktopAction,
@@ -62,28 +63,28 @@ export function createFridaySkillDesktopHelper(
   return {
     async executeAction(action: FridayDesktopAction): Promise<FridayDesktopActionResult> {
       if (!desktopSessionManager.isConnected()) {
-        throw new Error("Desktop session is not connected");
+        throw new FridayDomainError("NOT_INITIALIZED", "Desktop session is not connected", { httpStatus: 503 });
       }
       return desktopSessionManager.executeAction(action);
     },
 
     async inspectElement(selector: FridayDesktopElementSelector): Promise<FridayDesktopElement | null> {
       if (!desktopSessionManager.isConnected()) {
-        throw new Error("Desktop session is not connected");
+        throw new FridayDomainError("NOT_INITIALIZED", "Desktop session is not connected", { httpStatus: 503 });
       }
       return desktopSessionManager.inspectElement(selector);
     },
 
     async searchElements(query: string, appBundleId?: string): Promise<readonly FridayDesktopElement[]> {
       if (!desktopSessionManager.isConnected()) {
-        throw new Error("Desktop session is not connected");
+        throw new FridayDomainError("NOT_INITIALIZED", "Desktop session is not connected", { httpStatus: 503 });
       }
       return desktopSessionManager.searchElements(query, appBundleId);
     },
 
     async checkPermissions(): Promise<readonly FridayDesktopPermission[]> {
       if (!desktopSessionManager.isConnected()) {
-        throw new Error("Desktop session is not connected");
+        throw new FridayDomainError("NOT_INITIALIZED", "Desktop session is not connected", { httpStatus: 503 });
       }
       return desktopSessionManager.checkPermissions();
     },

--- a/src/skills/executor/friday-skill-executor.ts
+++ b/src/skills/executor/friday-skill-executor.ts
@@ -200,7 +200,8 @@ export function createFridaySkillExecutor(
                   } else {
                     output = { result: parsed };
                   }
-                } catch {
+                } catch (err) {
+                  console.warn("[friday][skill-executor] operation failed:", err instanceof Error ? err.message : String(err));
                   output = { raw: shellResult.stdout };
                 }
 

--- a/src/skills/executor/friday-skill-runtime-bridge.ts
+++ b/src/skills/executor/friday-skill-runtime-bridge.ts
@@ -1,3 +1,4 @@
+import { FridayDomainError } from "#errors";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { browserArtifactDir, sanitizeArtifactPathSegment } from "#browser";
@@ -86,7 +87,7 @@ export function createFridaySkillReadonlyRuntimeContext(
       async inspectPage(input) {
         const requestedUrl = typeof input.url === "string" ? input.url.trim() : "";
         if (requestedUrl.length === 0) {
-          throw new Error("Browser inspection requires a non-empty url.");
+          throw new FridayDomainError("VALIDATION_ERROR", "Browser inspection requires a non-empty url.", { httpStatus: 400 });
         }
 
         const requestedSessionId = typeof input.sessionId === "string" ? input.sessionId.trim() : "";
@@ -193,7 +194,8 @@ export function createFridaySkillReadonlyRuntimeContext(
               path: screenshotPath,
               fullPage: true,
             });
-          } catch {
+          } catch (err) {
+          console.warn("[friday][skill-runtime-bridge] operation failed:", err instanceof Error ? err.message : String(err));
             screenshotPath = null;
           }
 

--- a/src/skills/generator/llm/friday-provider-inference-client.ts
+++ b/src/skills/generator/llm/friday-provider-inference-client.ts
@@ -277,7 +277,8 @@ function parseJsonFromText<T>(rawText: string): T {
   const trimmed = rawText.trim();
   try {
     return JSON.parse(trimmed) as T;
-  } catch {
+  } catch (err) {
+    console.warn("[friday][provider-inference-client] operation failed:", err instanceof Error ? err.message : String(err));
     // Try to extract JSON from code fences
     const fenceMatch = /```(?:json)?\s*\n?([\s\S]*?)\n?```/.exec(trimmed);
     if (fenceMatch?.[1]) {

--- a/src/skills/generator/persistence/friday-skill-generation-session-repository.ts
+++ b/src/skills/generator/persistence/friday-skill-generation-session-repository.ts
@@ -2,6 +2,7 @@ import type Database from "better-sqlite3";
 
 import { FridayDomainError } from "#errors";
 import type { FridaySqliteLayer } from "#state";
+import { safeJsonParse } from "#utilities";
 
 import type {
   FridaySkillGenerationSession,
@@ -159,7 +160,7 @@ export function createFridaySkillGenerationSessionRepository(
           sessionKey(sessionId),
         );
         if (!row) return null;
-        return JSON.parse(row.value_json) as FridaySkillGenerationSession;
+        return safeJsonParse<FridaySkillGenerationSession>(row.value_json) ?? null;
       });
     },
 
@@ -209,7 +210,7 @@ export function createFridaySkillGenerationSessionRepository(
           turnKeyPrefix(sessionId),
         );
         return rows.map(
-          (row) => JSON.parse(row.value_json) as FridaySkillGenerationTurn,
+          (row) => safeJsonParse<FridaySkillGenerationTurn>(row.value_json)!,
         );
       });
     },

--- a/src/skills/generator/services/friday-skill-generator-service.ts
+++ b/src/skills/generator/services/friday-skill-generator-service.ts
@@ -3,7 +3,7 @@ import { dirname, extname, join } from "node:path";
 import { tmpdir } from "node:os";
 
 import { FridayDomainError } from "#errors";
-import { resolveSafeInstallDir, resolveSafePath } from "#utilities";
+import { resolveSafeInstallDir, resolveSafePath, safeJsonParse } from "#utilities";
 import {
   buildHarnessSchemaTest,
   createFridayTemplateHarnessService,
@@ -454,7 +454,7 @@ export function createFridaySkillGeneratorService(
         .prepare("SELECT value_json FROM memory_items WHERE namespace = ? AND key = ?")
         .get(DRAFT_NAMESPACE, sessionId) as { value_json: string } | undefined;
       if (!row) return undefined;
-      return JSON.parse(row.value_json) as FridayGeneratedSkillDraft;
+      return safeJsonParse<FridayGeneratedSkillDraft>(row.value_json);
     });
   }
 
@@ -491,7 +491,8 @@ export function createFridaySkillGeneratorService(
       if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
         return parsed as Record<string, unknown>;
       }
-    } catch {
+    } catch (err) {
+      console.warn("[friday][skill-generator-service] operation failed:", err instanceof Error ? err.message : String(err));
       return null;
     }
     return null;
@@ -681,7 +682,8 @@ export function createFridaySkillGeneratorService(
     } finally {
       try {
         rmSync(tempDir, { recursive: true, force: true });
-      } catch {
+      } catch (err) {
+      console.warn("[friday][skill-generator-service] operation failed:", err instanceof Error ? err.message : String(err));
         // Best-effort cleanup.
       }
     }
@@ -1549,10 +1551,11 @@ export function createFridaySkillGeneratorService(
           parsed === null ||
           Array.isArray(parsed)
         ) {
-          throw new Error("Spec must be a plain object");
+          throw new FridayDomainError("VALIDATION_ERROR", "Spec must be a plain object", { httpStatus: 400 });
         }
         spec = parsed as Record<string, unknown>;
-      } catch {
+      } catch (err) {
+      console.warn("[friday][skill-generator-service] operation failed:", err instanceof Error ? err.message : String(err));
         throw new FridayDomainError(
           "VALIDATION_ERROR",
           "No valid specification available. Continue the conversation to provide requirements.",
@@ -1791,7 +1794,8 @@ export function createFridaySkillGeneratorService(
         // ── Stage: Clean up temp dir ──
         try {
           rmSync(tempDir, { recursive: true, force: true });
-        } catch {
+        } catch (err) {
+      console.warn("[friday][skill-generator-service] operation failed:", err instanceof Error ? err.message : String(err));
           // Best-effort cleanup
         }
       }
@@ -1825,7 +1829,8 @@ export function createFridaySkillGeneratorService(
       try {
         await deps.registry.refresh();
         registryRefreshed = true;
-      } catch {
+      } catch (err) {
+      console.warn("[friday][skill-generator-service] operation failed:", err instanceof Error ? err.message : String(err));
         // Non-fatal — skill is saved but registry didn't refresh
       }
 

--- a/src/skills/persistence/friday-marketplace-cache-repository.ts
+++ b/src/skills/persistence/friday-marketplace-cache-repository.ts
@@ -1,4 +1,5 @@
 import type Database from "better-sqlite3";
+import { safeJsonParse } from "#utilities";
 import type {
   FridayMarketplaceCacheEntity,
   FridayMarketplaceCacheRow,
@@ -83,7 +84,7 @@ function mapRow(row: FridayMarketplaceCacheRow): FridayMarketplaceCacheEntity {
     sourceId: row.source_id,
     skillId: row.skill_id,
     version: row.version,
-    manifestJson: JSON.parse(row.manifest_json) as JsonValue,
+    manifestJson: safeJsonParse<JsonValue>(row.manifest_json) as JsonValue,
     signatureValid: row.signature_valid === 1,
     indexedAt: row.indexed_at,
     trustScore: row.trust_score,

--- a/src/skills/persistence/friday-marketplace-source-repository.ts
+++ b/src/skills/persistence/friday-marketplace-source-repository.ts
@@ -1,4 +1,5 @@
 import type Database from "better-sqlite3";
+import { safeJsonParse } from "#utilities";
 import type {
   FridayMarketplaceSourceCreateInput,
   FridayMarketplaceSourceEntity,
@@ -54,7 +55,7 @@ function mapRow(row: FridayMarketplaceSourceRow): FridayMarketplaceSourceEntity 
     baseUrl: row.base_url,
     enabled: row.enabled === 1,
     trustPolicy: row.trust_policy as FridayMarketplaceTrustPolicy,
-    pinnedKeyIds: JSON.parse(row.pinned_key_ids_json) as string[],
+    pinnedKeyIds: safeJsonParse<string[]>(row.pinned_key_ids_json) ?? [],
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };

--- a/src/skills/persistence/friday-skill-installation-repository.ts
+++ b/src/skills/persistence/friday-skill-installation-repository.ts
@@ -1,4 +1,5 @@
 import type Database from "better-sqlite3";
+import { safeJsonParse } from "#utilities";
 import type {
   FridaySkillInstallationEntity,
   FridaySkillInstallationRow,
@@ -63,7 +64,7 @@ function mapRow(row: FridaySkillInstallationRow): FridaySkillInstallationEntity 
     version: row.version,
     satelliteId: row.satellite_id ?? undefined,
     status: row.status as FridaySkillInstallationStatus,
-    permissionsGranted: JSON.parse(row.permissions_granted_json) as string[],
+    permissionsGranted: safeJsonParse<string[]>(row.permissions_granted_json) ?? [],
     lastError: row.last_error ?? undefined,
     createdAt: row.created_at,
     updatedAt: row.updated_at,

--- a/src/skills/persistence/friday-skill-repository.ts
+++ b/src/skills/persistence/friday-skill-repository.ts
@@ -1,4 +1,5 @@
 import type Database from "better-sqlite3";
+import { safeJsonParse } from "#utilities";
 import type { SkillManifestV2 } from "../model/friday-skill-manifest-v2.types.js";
 import type { SkillLifecycleStatus } from "../model/friday-skill-lifecycle.types.js";
 import type { SkillOrigin, SkillSource } from "../model/friday-skill-source.types.js";
@@ -76,9 +77,7 @@ function mapRow(row: FridaySkillRow): FridaySkillEntity {
     latestVersion: row.latest_version ?? undefined,
     installedVersion: row.installed_version ?? undefined,
     status: row.status as SkillLifecycleStatus,
-    currentManifest: row.current_manifest_json
-      ? (JSON.parse(row.current_manifest_json) as SkillManifestV2)
-      : undefined,
+    currentManifest: safeJsonParse<SkillManifestV2>(row.current_manifest_json),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
     deletedAt: row.deleted_at ?? undefined,

--- a/src/skills/persistence/friday-skill-version-repository.ts
+++ b/src/skills/persistence/friday-skill-version-repository.ts
@@ -1,4 +1,5 @@
 import type Database from "better-sqlite3";
+import { safeJsonParse } from "#utilities";
 import type { SkillManifestV2 } from "../model/friday-skill-manifest-v2.types.js";
 import type {
   FridayMarketplaceSignatureAlgorithm,
@@ -86,7 +87,7 @@ function mapRow(row: FridaySkillVersionRow): FridaySkillVersionEntity {
     checksum: row.checksum,
     packageUrl: row.package_url ?? undefined,
     signature,
-    manifest: JSON.parse(row.manifest_json) as SkillManifestV2,
+    manifest: safeJsonParse<SkillManifestV2>(row.manifest_json) ?? ({} as SkillManifestV2),
     releasedAt: row.released_at,
     yankedAt: row.yanked_at ?? undefined,
     createdAt: row.created_at,

--- a/src/skills/registry/friday-skill-discovery.ts
+++ b/src/skills/registry/friday-skill-discovery.ts
@@ -112,7 +112,8 @@ export function discoverFridaySkillCandidates(
     let entries: string[];
     try {
       entries = readdirSync(root.dir).sort(); // lexical sort for determinism
-    } catch {
+    } catch (err) {
+      console.warn("[friday][skill-discovery] operation failed:", err instanceof Error ? err.message : String(err));
       continue;
     }
 
@@ -120,7 +121,8 @@ export function discoverFridaySkillCandidates(
       const candidateDir = join(root.dir, entry);
       try {
         if (!statSync(candidateDir).isDirectory()) continue;
-      } catch {
+      } catch (err) {
+      console.warn("[friday][skill-discovery] operation failed:", err instanceof Error ? err.message : String(err));
         continue;
       }
 

--- a/src/skills/registry/friday-skill-registry.ts
+++ b/src/skills/registry/friday-skill-registry.ts
@@ -290,7 +290,8 @@ export class FridaySkillRegistryImpl implements FridaySkillRegistry {
         caller: "FridaySkillRegistry.emitReloadFailureAudit",
         details: { reason },
       });
-    } catch {
+    } catch (err) {
+    console.warn("[friday][skill-registry] operation failed:", err instanceof Error ? err.message : String(err));
       // Best-effort audit logging; don't fail the reload flow
     }
   }

--- a/src/skills/services/friday-skill-installation-service.ts
+++ b/src/skills/services/friday-skill-installation-service.ts
@@ -108,7 +108,8 @@ export function createFridaySkillInstallationService(
             const sigUrl = `${source.baseUrl.replace(/\/$/, "")}/skills/${resolved.skillId}/versions/${resolved.version}/signature.json`;
             signatureDoc = await deps.httpClient.fetchSignature(sigUrl);
             publisherKey = await deps.httpClient.fetchPublisherKey(source.baseUrl, signatureDoc.keyId);
-          } catch {
+          } catch (err) {
+          console.warn("[friday][skill-installation-service] operation failed:", err instanceof Error ? err.message : String(err));
             // Signature artifacts optional for non-strict policies
           }
         }

--- a/src/skills/services/friday-skill-package-installer.ts
+++ b/src/skills/services/friday-skill-package-installer.ts
@@ -142,7 +142,8 @@ export function createFridaySkillPackageInstaller(
             rmSync(backup, { recursive: true, force: true });
           }
           rmSync(src, { recursive: true, force: true });
-        } catch {
+        } catch (err) {
+        console.warn("[friday][skill-package-installer] operation failed:", err instanceof Error ? err.message : String(err));
           // Activation already succeeded; lingering temp paths are safe to clean later.
         }
       } catch (err) {

--- a/src/skills/validation/friday-skill-filesystem-scope-validator.ts
+++ b/src/skills/validation/friday-skill-filesystem-scope-validator.ts
@@ -30,13 +30,15 @@ function getAllowedScopeRoots(
   // Add canonicalized workspace and skill dirs
   try {
     roots.push(fs.realpathSync(workspaceDir));
-  } catch {
+  } catch (err) {
+    console.warn("[friday][skill-filesystem-scope-validator] operation failed:", err instanceof Error ? err.message : String(err));
     roots.push(path.resolve(workspaceDir));
   }
 
   try {
     roots.push(fs.realpathSync(skillDir));
-  } catch {
+  } catch (err) {
+    console.warn("[friday][skill-filesystem-scope-validator] operation failed:", err instanceof Error ? err.message : String(err));
     roots.push(path.resolve(skillDir));
   }
 
@@ -44,7 +46,8 @@ function getAllowedScopeRoots(
   for (const prefix of absoluteAllowPrefixes) {
     try {
       roots.push(fs.realpathSync(prefix));
-    } catch {
+    } catch (err) {
+    console.warn("[friday][skill-filesystem-scope-validator] operation failed:", err instanceof Error ? err.message : String(err));
       roots.push(path.resolve(prefix));
     }
   }

--- a/src/skills/validation/friday-skill-schema-compiler.ts
+++ b/src/skills/validation/friday-skill-schema-compiler.ts
@@ -70,7 +70,8 @@ export function compileFridaySkillSchemas(
     let schemaObj: unknown;
     try {
       schemaObj = JSON.parse(schemaText);
-    } catch {
+    } catch (err) {
+    console.warn("[friday][skill-schema-compiler] operation failed:", err instanceof Error ? err.message : String(err));
       issues.push({
         stage: "schema-compile",
         severity: "error",

--- a/src/state/sqlite/friday-sqlite-layer.ts
+++ b/src/state/sqlite/friday-sqlite-layer.ts
@@ -30,6 +30,9 @@ export function createFridaySqliteLayer(
     pragmas,
   });
 
+  // P2-DATA: Track closed state for idempotent close()
+  let closed = false;
+
   return {
     dbPath,
     writer,
@@ -48,6 +51,8 @@ export function createFridaySqliteLayer(
     },
 
     close(): void {
+      if (closed) return;
+      closed = true;
       reads.close();
       writer.close();
     },

--- a/src/system/companion/friday-system-companion-daemon.ts
+++ b/src/system/companion/friday-system-companion-daemon.ts
@@ -1,4 +1,5 @@
 import * as path from "node:path";
+import { FridayDomainError } from "#errors";
 
 import { createFridaySystemUnixSocketCompanionServer } from "./friday-system-unix-socket-companion-server.js";
 
@@ -19,7 +20,7 @@ async function main(): Promise<void> {
     : path.join(workspaceRoot, ".friday", "run", "system-companion.sock");
   const authToken = process.env.FRIDAY_SYSTEM_COMPANION_AUTH_TOKEN;
   if (!authToken) {
-    throw new Error("FRIDAY_SYSTEM_COMPANION_AUTH_TOKEN is required for the companion daemon");
+    throw new FridayDomainError("NOT_INITIALIZED", "FRIDAY_SYSTEM_COMPANION_AUTH_TOKEN is required for the companion daemon", { httpStatus: 503 });
   }
 
   const server = createFridaySystemUnixSocketCompanionServer({

--- a/src/system/companion/friday-system-companion-runtime.ts
+++ b/src/system/companion/friday-system-companion-runtime.ts
@@ -1,5 +1,6 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+import { FridayDomainError } from "#errors";
 
 import type { FridayDesktopPlatform } from "../../desktop/model/friday-desktop.types.js";
 import type {
@@ -253,7 +254,7 @@ async function readDarwinDesktopBounds(): Promise<FridaySystemBounds> {
     .map((value) => Number.parseInt(value.trim(), 10))
     .filter((value) => Number.isFinite(value));
   if (values.length !== 4) {
-    throw new Error("Unable to read desktop bounds");
+    throw new FridayDomainError("INTERNAL_ERROR", "Unable to read desktop bounds", { httpStatus: 500 });
   }
   return {
     x: values[0]!,

--- a/src/system/companion/friday-system-named-pipe-bridge.ts
+++ b/src/system/companion/friday-system-named-pipe-bridge.ts
@@ -145,7 +145,8 @@ export function createFridaySystemNamedPipeBridge(
         let response: FridayJsonRpcResponse;
         try {
           response = JSON.parse(line) as FridayJsonRpcResponse;
-        } catch {
+        } catch (err) {
+          console.warn("[friday][named-pipe-bridge] parse-rpc-response:", err instanceof Error ? err.message : String(err));
           finish(() => {
             socket.destroy();
             reject(new Error("Invalid JSON-RPC response from companion"));
@@ -216,7 +217,8 @@ export function createFridaySystemNamedPipeBridge(
         connected = true;
         lastHeartbeatAt = status.lastHeartbeatAt;
         return status;
-      } catch {
+      } catch (err) {
+        console.warn("[friday][named-pipe-bridge] getStatus:", err instanceof Error ? err.message : String(err));
         connected = false;
         lastHeartbeatAt = options.nowIso();
         return buildFridaySystemCompanionStatus(options, {
@@ -234,7 +236,8 @@ export function createFridaySystemNamedPipeBridge(
         connected = true;
         lastHeartbeatAt = options.nowIso();
         return snapshot;
-      } catch {
+      } catch (err) {
+        console.warn("[friday][named-pipe-bridge] captureSnapshot:", err instanceof Error ? err.message : String(err));
         connected = false;
         lastHeartbeatAt = options.nowIso();
         return {
@@ -254,7 +257,8 @@ export function createFridaySystemNamedPipeBridge(
         connected = true;
         lastHeartbeatAt = options.nowIso();
         return result;
-      } catch {
+      } catch (err) {
+        console.warn("[friday][named-pipe-bridge] arrangeWindows:", err instanceof Error ? err.message : String(err));
         connected = false;
         lastHeartbeatAt = options.nowIso();
         return null;
@@ -267,7 +271,8 @@ export function createFridaySystemNamedPipeBridge(
         connected = true;
         lastHeartbeatAt = options.nowIso();
         return result as Awaited<ReturnType<FridaySystemCompanionBridge["launchApp"]>>;
-      } catch {
+      } catch (err) {
+        console.warn("[friday][named-pipe-bridge] launchApp:", err instanceof Error ? err.message : String(err));
         connected = false;
         lastHeartbeatAt = options.nowIso();
         return null;
@@ -283,7 +288,8 @@ export function createFridaySystemNamedPipeBridge(
         connected = true;
         lastHeartbeatAt = options.nowIso();
         return result as Awaited<ReturnType<FridaySystemCompanionBridge["focusTarget"]>>;
-      } catch {
+      } catch (err) {
+        console.warn("[friday][named-pipe-bridge] focusTarget:", err instanceof Error ? err.message : String(err));
         connected = false;
         lastHeartbeatAt = options.nowIso();
         return null;
@@ -296,7 +302,8 @@ export function createFridaySystemNamedPipeBridge(
         connected = true;
         lastHeartbeatAt = options.nowIso();
         return result as Awaited<ReturnType<FridaySystemCompanionBridge["openUrl"]>>;
-      } catch {
+      } catch (err) {
+        console.warn("[friday][named-pipe-bridge] openUrl:", err instanceof Error ? err.message : String(err));
         connected = false;
         lastHeartbeatAt = options.nowIso();
         return null;
@@ -309,7 +316,8 @@ export function createFridaySystemNamedPipeBridge(
         connected = true;
         lastHeartbeatAt = options.nowIso();
         return result as Awaited<ReturnType<FridaySystemCompanionBridge["openProject"]>>;
-      } catch {
+      } catch (err) {
+        console.warn("[friday][named-pipe-bridge] openProject:", err instanceof Error ? err.message : String(err));
         connected = false;
         lastHeartbeatAt = options.nowIso();
         return null;
@@ -322,7 +330,8 @@ export function createFridaySystemNamedPipeBridge(
         connected = true;
         lastHeartbeatAt = options.nowIso();
         return result as Awaited<ReturnType<FridaySystemCompanionBridge["listNotifications"]>>;
-      } catch {
+      } catch (err) {
+        console.warn("[friday][named-pipe-bridge] listNotifications:", err instanceof Error ? err.message : String(err));
         connected = false;
         lastHeartbeatAt = options.nowIso();
         return [];
@@ -338,7 +347,8 @@ export function createFridaySystemNamedPipeBridge(
         connected = true;
         lastHeartbeatAt = options.nowIso();
         return result as Awaited<ReturnType<FridaySystemCompanionBridge["actOnNotification"]>>;
-      } catch {
+      } catch (err) {
+        console.warn("[friday][named-pipe-bridge] actOnNotification:", err instanceof Error ? err.message : String(err));
         connected = false;
         lastHeartbeatAt = options.nowIso();
         return null;
@@ -351,7 +361,8 @@ export function createFridaySystemNamedPipeBridge(
         connected = true;
         lastHeartbeatAt = options.nowIso();
         return result as Awaited<ReturnType<FridaySystemCompanionBridge["setOverlayVisible"]>>;
-      } catch {
+      } catch (err) {
+        console.warn("[friday][named-pipe-bridge] setOverlayVisible:", err instanceof Error ? err.message : String(err));
         connected = false;
         lastHeartbeatAt = options.nowIso();
         return {

--- a/src/system/companion/friday-system-unix-socket-bridge.ts
+++ b/src/system/companion/friday-system-unix-socket-bridge.ts
@@ -144,7 +144,8 @@ export function createFridaySystemUnixSocketBridge(
         let response: FridayJsonRpcResponse;
         try {
           response = JSON.parse(line) as FridayJsonRpcResponse;
-        } catch {
+        } catch (err) {
+          console.warn("[friday][unix-socket-bridge] parse-rpc-response:", err instanceof Error ? err.message : String(err));
           finish(() => {
             socket.destroy();
             reject(new Error("Invalid JSON-RPC response from companion"));
@@ -216,7 +217,8 @@ export function createFridaySystemUnixSocketBridge(
         connected = true;
         lastHeartbeatAt = status.lastHeartbeatAt;
         return status;
-      } catch {
+      } catch (err) {
+        console.warn("[friday][unix-socket-bridge] getStatus:", err instanceof Error ? err.message : String(err));
         connected = false;
         lastHeartbeatAt = options.nowIso();
         return buildFridaySystemCompanionStatus(options, {
@@ -234,7 +236,8 @@ export function createFridaySystemUnixSocketBridge(
         connected = true;
         lastHeartbeatAt = options.nowIso();
         return snapshot;
-      } catch {
+      } catch (err) {
+        console.warn("[friday][unix-socket-bridge] captureSnapshot:", err instanceof Error ? err.message : String(err));
         connected = false;
         lastHeartbeatAt = options.nowIso();
         return {
@@ -254,7 +257,8 @@ export function createFridaySystemUnixSocketBridge(
         connected = true;
         lastHeartbeatAt = options.nowIso();
         return result;
-      } catch {
+      } catch (err) {
+        console.warn("[friday][unix-socket-bridge] arrangeWindows:", err instanceof Error ? err.message : String(err));
         connected = false;
         lastHeartbeatAt = options.nowIso();
         return null;
@@ -267,7 +271,8 @@ export function createFridaySystemUnixSocketBridge(
         connected = true;
         lastHeartbeatAt = options.nowIso();
         return result as Awaited<ReturnType<FridaySystemCompanionBridge["launchApp"]>>;
-      } catch {
+      } catch (err) {
+        console.warn("[friday][unix-socket-bridge] launchApp:", err instanceof Error ? err.message : String(err));
         connected = false;
         lastHeartbeatAt = options.nowIso();
         return null;
@@ -283,7 +288,8 @@ export function createFridaySystemUnixSocketBridge(
         connected = true;
         lastHeartbeatAt = options.nowIso();
         return result as Awaited<ReturnType<FridaySystemCompanionBridge["focusTarget"]>>;
-      } catch {
+      } catch (err) {
+        console.warn("[friday][unix-socket-bridge] focusTarget:", err instanceof Error ? err.message : String(err));
         connected = false;
         lastHeartbeatAt = options.nowIso();
         return null;
@@ -296,7 +302,8 @@ export function createFridaySystemUnixSocketBridge(
         connected = true;
         lastHeartbeatAt = options.nowIso();
         return result as Awaited<ReturnType<FridaySystemCompanionBridge["openUrl"]>>;
-      } catch {
+      } catch (err) {
+        console.warn("[friday][unix-socket-bridge] openUrl:", err instanceof Error ? err.message : String(err));
         connected = false;
         lastHeartbeatAt = options.nowIso();
         return null;
@@ -309,7 +316,8 @@ export function createFridaySystemUnixSocketBridge(
         connected = true;
         lastHeartbeatAt = options.nowIso();
         return result as Awaited<ReturnType<FridaySystemCompanionBridge["openProject"]>>;
-      } catch {
+      } catch (err) {
+        console.warn("[friday][unix-socket-bridge] openProject:", err instanceof Error ? err.message : String(err));
         connected = false;
         lastHeartbeatAt = options.nowIso();
         return null;
@@ -322,7 +330,8 @@ export function createFridaySystemUnixSocketBridge(
         connected = true;
         lastHeartbeatAt = options.nowIso();
         return result as Awaited<ReturnType<FridaySystemCompanionBridge["listNotifications"]>>;
-      } catch {
+      } catch (err) {
+        console.warn("[friday][unix-socket-bridge] listNotifications:", err instanceof Error ? err.message : String(err));
         connected = false;
         lastHeartbeatAt = options.nowIso();
         return [];
@@ -338,7 +347,8 @@ export function createFridaySystemUnixSocketBridge(
         connected = true;
         lastHeartbeatAt = options.nowIso();
         return result as Awaited<ReturnType<FridaySystemCompanionBridge["actOnNotification"]>>;
-      } catch {
+      } catch (err) {
+        console.warn("[friday][unix-socket-bridge] actOnNotification:", err instanceof Error ? err.message : String(err));
         connected = false;
         lastHeartbeatAt = options.nowIso();
         return null;
@@ -351,7 +361,8 @@ export function createFridaySystemUnixSocketBridge(
         connected = true;
         lastHeartbeatAt = options.nowIso();
         return result as Awaited<ReturnType<FridaySystemCompanionBridge["setOverlayVisible"]>>;
-      } catch {
+      } catch (err) {
+        console.warn("[friday][unix-socket-bridge] setOverlayVisible:", err instanceof Error ? err.message : String(err));
         connected = false;
         lastHeartbeatAt = options.nowIso();
         return {

--- a/src/system/companion/friday-system-unix-socket-companion-server.ts
+++ b/src/system/companion/friday-system-unix-socket-companion-server.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs/promises";
 import * as net from "node:net";
 import * as path from "node:path";
+import { FridayDomainError } from "#errors";
 
 import {
   createFridaySystemCompanionRuntimeController,
@@ -116,7 +117,7 @@ export function createFridaySystemUnixSocketCompanionServer(
       case "companion.setOverlayVisible":
         return controller.setOverlayVisible(Boolean(params?.visible));
       default:
-        throw new Error(`Unknown companion method: ${method}`);
+        throw new FridayDomainError("VALIDATION_ERROR", `Unknown companion method: ${method}`, { httpStatus: 400 });
     }
   }
 
@@ -124,7 +125,8 @@ export function createFridaySystemUnixSocketCompanionServer(
     let request: FridayJsonRpcRequest;
     try {
       request = JSON.parse(raw) as FridayJsonRpcRequest;
-    } catch {
+    } catch (err) {
+      console.warn("[friday][unix-socket-companion-server] JSON-RPC parse error:", err instanceof Error ? err.message : String(err));
       return buildErrorResponse(null, -32700, "Parse error");
     }
 

--- a/src/system/engine/friday-system-service.ts
+++ b/src/system/engine/friday-system-service.ts
@@ -705,7 +705,7 @@ export async function createFridaySystemService(
         : { bin: "xdg-open", args: [target] };
     const result = await execCommand(command.bin, command.args);
     if (result.exitCode !== 0) {
-      throw new Error(result.stderr || `Failed to open target: ${target}`);
+      throw new FridayDomainError("INTERNAL_ERROR", result.stderr || `Failed to open target: ${target}`, { httpStatus: 500 });
     }
   }
 
@@ -1100,7 +1100,8 @@ export async function createFridaySystemService(
     try {
       const hostname = new URL(resolvedOrigin).hostname.trim();
       return hostname.length > 0 ? hostname : remoteAuthRpId;
-    } catch {
+    } catch (err) {
+      console.warn("[friday][system-service] origin hostname parse failed:", err instanceof Error ? err.message : String(err));
       return remoteAuthRpId;
     }
   }

--- a/src/system/persistence/friday-system-repository.ts
+++ b/src/system/persistence/friday-system-repository.ts
@@ -19,6 +19,7 @@ import type {
   FridaySystemRemoteSession,
   FridaySystemRemoteSessionRecord,
 } from "../model/friday-system.types.js";
+import { safeJsonParse } from "#utilities";
 
 export interface FridaySystemApprovalRuleFilters {
   action?: string;
@@ -201,9 +202,7 @@ function remotePasskeyRowToEntity(row: FridaySystemRemotePasskeyRecord): FridayS
     credentialId: row.credential_id,
     publicKey: row.public_key_b64u,
     counter: row.counter,
-    transports: row.transports_json
-      ? JSON.parse(row.transports_json) as string[]
-      : undefined,
+    transports: safeJsonParse<string[]>(row.transports_json),
     deviceType: row.device_type ?? undefined,
     backedUp: row.backed_up === 1,
     registeredAt: row.registered_at,
@@ -261,7 +260,7 @@ function eventRowToEntity(row: FridaySystemEventRecord): FridaySystemEvent {
     seq: row.seq,
     event: row.event_name,
     emittedAt: row.emitted_at,
-    payload: JSON.parse(row.payload_json) as Record<string, unknown>,
+    payload: safeJsonParse<Record<string, unknown>>(row.payload_json) ?? {},
   };
 }
 

--- a/src/uix/persistence/friday-uix-user-preference-repository.ts
+++ b/src/uix/persistence/friday-uix-user-preference-repository.ts
@@ -1,4 +1,5 @@
 import type Database from "better-sqlite3";
+import { safeJsonParse } from "#utilities";
 
 import type {
   FridayUserPreference,
@@ -41,7 +42,7 @@ function mapRow(row: FridayUserPreferenceRow): FridayUserPreference {
     principalId: row.principal_id,
     category: row.category as FridayUserPreferenceCategory,
     key: row.key,
-    value: JSON.parse(row.value_json) as JsonValue,
+    value: safeJsonParse<JsonValue>(row.value_json) as JsonValue,
     source: row.source as "explicit" | "implicit",
     confidence: row.confidence,
     createdAt: row.created_at,

--- a/src/utilities/friday-safe-json.ts
+++ b/src/utilities/friday-safe-json.ts
@@ -1,0 +1,13 @@
+/**
+ * P2-DATA: Defensive JSON.parse that returns undefined instead of throwing on malformed data.
+ * Use at persistence boundaries where stored JSON may have drifted from the expected schema.
+ */
+export function safeJsonParse<T>(json: string | null | undefined): T | undefined {
+  if (!json) return undefined;
+  try {
+    return JSON.parse(json) as T;
+  } catch (err) {
+    console.warn("[friday][safe-json] JSON parse failed:", err instanceof Error ? err.message : String(err));
+    return undefined;
+  }
+}

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -5,3 +5,4 @@ export { computeFridayBackoff, sleepWithAbort } from "./friday-backoff.js";
 export type { FridayBackoffOptions } from "./friday-backoff.js";
 export { retryFridayAsync } from "./friday-retry.js";
 export type { FridayRetryOptions, FridayRetryInfo } from "./friday-retry.js";
+export { safeJsonParse } from "./friday-safe-json.js";

--- a/src/workflows/builder/persistence/friday-workflow-builder-draft-repository.ts
+++ b/src/workflows/builder/persistence/friday-workflow-builder-draft-repository.ts
@@ -1,6 +1,7 @@
 import type Database from "better-sqlite3";
 import type { UUID } from "../../model/friday-workflow.types.js";
 import { FridayDomainError } from "#errors";
+import { safeJsonParse } from "#utilities";
 import type {
   FridayWorkflowDraftEntity,
   FridayWorkflowDraftStatus,
@@ -50,7 +51,7 @@ export function createFridayWorkflowBuilderDraftRepository(): FridayWorkflowBuil
           `SELECT value_json FROM memory_items WHERE namespace = ? AND key LIKE ?`,
         )
         .get(NAMESPACE, `%:${draftId}`) as { value_json: string } | undefined;
-      return row ? (JSON.parse(row.value_json) as FridayWorkflowDraftEntity) : null;
+      return row ? safeJsonParse<FridayWorkflowDraftEntity>(row.value_json) ?? null : null;
     },
 
     listByWorkflow(db, workflowId) {
@@ -59,7 +60,7 @@ export function createFridayWorkflowBuilderDraftRepository(): FridayWorkflowBuil
           `SELECT value_json FROM memory_items WHERE namespace = ? AND key LIKE ? ORDER BY updated_at DESC`,
         )
         .all(NAMESPACE, `${workflowId}:%`) as Array<{ value_json: string }>;
-      return rows.map((r) => JSON.parse(r.value_json) as FridayWorkflowDraftEntity);
+      return rows.map((r) => safeJsonParse<FridayWorkflowDraftEntity>(r.value_json)).filter((r): r is FridayWorkflowDraftEntity => r !== undefined);
     },
 
     listByStatus(db, status) {
@@ -69,7 +70,7 @@ export function createFridayWorkflowBuilderDraftRepository(): FridayWorkflowBuil
         )
         .all(NAMESPACE) as Array<{ value_json: string }>;
       return rows
-        .map((r) => JSON.parse(r.value_json) as FridayWorkflowDraftEntity)
+        .map((r) => safeJsonParse<FridayWorkflowDraftEntity>(r.value_json)).filter((d): d is FridayWorkflowDraftEntity => d !== undefined)
         .filter((d) => d.status === status);
     },
 

--- a/src/workflows/builder/persistence/friday-workflow-builder-lock-repository.ts
+++ b/src/workflows/builder/persistence/friday-workflow-builder-lock-repository.ts
@@ -1,4 +1,5 @@
 import type Database from "better-sqlite3";
+import { safeJsonParse } from "#utilities";
 import type { UUID } from "../../model/friday-workflow.types.js";
 import type { FridayWorkflowEditLock } from "../model/friday-workflow-builder-collaboration.types.js";
 
@@ -24,7 +25,7 @@ export function createFridayWorkflowBuilderLockRepository(): FridayWorkflowBuild
       const row = db
         .prepare(`SELECT value_json FROM hub_settings WHERE key = ?`)
         .get(lockKey(workflowId)) as { value_json: string } | undefined;
-      return row ? (JSON.parse(row.value_json) as FridayWorkflowEditLock) : null;
+      return row ? safeJsonParse<FridayWorkflowEditLock>(row.value_json) ?? null : null;
     },
 
     setLock(db, lock) {

--- a/src/workflows/builder/persistence/friday-workflow-builder-spec-version-repository.ts
+++ b/src/workflows/builder/persistence/friday-workflow-builder-spec-version-repository.ts
@@ -1,4 +1,5 @@
 import type Database from "better-sqlite3";
+import { safeJsonParse } from "#utilities";
 import type { ISODateTime, UUID } from "../../model/friday-workflow.types.js";
 import type { FridayWorkflowSpecV1 } from "../../model/friday-workflow-spec.types.js";
 
@@ -53,7 +54,7 @@ export function createFridayWorkflowBuilderSpecVersionRepository(): FridayWorkfl
           `SELECT value_json FROM memory_items WHERE namespace = ? AND key LIKE ?`,
         )
         .get(NAMESPACE, `%:${workflowVersionId}`) as { value_json: string } | undefined;
-      return row ? (JSON.parse(row.value_json) as FridayWorkflowSpecVersionRecord) : null;
+      return row ? safeJsonParse<FridayWorkflowSpecVersionRecord>(row.value_json) ?? null : null;
     },
 
     listByWorkflow(db, workflowId) {
@@ -62,7 +63,7 @@ export function createFridayWorkflowBuilderSpecVersionRepository(): FridayWorkfl
           `SELECT value_json FROM memory_items WHERE namespace = ? AND key LIKE ? ORDER BY created_at DESC`,
         )
         .all(NAMESPACE, `${workflowId}:%`) as Array<{ value_json: string }>;
-      return rows.map((r) => JSON.parse(r.value_json) as FridayWorkflowSpecVersionRecord);
+      return rows.map((r) => safeJsonParse<FridayWorkflowSpecVersionRecord>(r.value_json)).filter((r): r is FridayWorkflowSpecVersionRecord => r !== undefined);
     },
   };
 }

--- a/src/workflows/builder/persistence/friday-workflow-builder-template-repository.ts
+++ b/src/workflows/builder/persistence/friday-workflow-builder-template-repository.ts
@@ -1,6 +1,7 @@
 import type Database from "better-sqlite3";
 import type { UUID } from "../../model/friday-workflow.types.js";
 import { FridayDomainError } from "#errors";
+import { safeJsonParse } from "#utilities";
 import type {
   FridayWorkflowTemplateEntity,
   FridayWorkflowTemplateScope,
@@ -50,7 +51,7 @@ export function createFridayWorkflowBuilderTemplateRepository(): FridayWorkflowB
           `SELECT value_json FROM memory_items WHERE namespace = ? AND key LIKE ?`,
         )
         .get(NAMESPACE, `%:${templateId}`) as { value_json: string } | undefined;
-      return row ? (JSON.parse(row.value_json) as FridayWorkflowTemplateEntity) : null;
+      return row ? safeJsonParse<FridayWorkflowTemplateEntity>(row.value_json) ?? null : null;
     },
 
     list(db, scope, ownerUserId) {
@@ -69,7 +70,7 @@ export function createFridayWorkflowBuilderTemplateRepository(): FridayWorkflowB
       }
 
       const rows = db.prepare(query).all(...params) as Array<{ value_json: string }>;
-      return rows.map((r) => JSON.parse(r.value_json) as FridayWorkflowTemplateEntity);
+      return rows.map((r) => safeJsonParse<FridayWorkflowTemplateEntity>(r.value_json)).filter((r): r is FridayWorkflowTemplateEntity => r !== undefined);
     },
 
     update(db, template) {

--- a/src/workflows/builder/persistence/friday-workflow-builder-test-run-repository.ts
+++ b/src/workflows/builder/persistence/friday-workflow-builder-test-run-repository.ts
@@ -1,4 +1,5 @@
 import type Database from "better-sqlite3";
+import { safeJsonParse } from "#utilities";
 import type { UUID } from "../../model/friday-workflow.types.js";
 import type { FridayWorkflowTestRunResult } from "../model/friday-workflow-builder-test.types.js";
 
@@ -43,7 +44,7 @@ export function createFridayWorkflowBuilderTestRunRepository(): FridayWorkflowBu
           `SELECT value_json FROM memory_items WHERE namespace = ? AND id = ?`,
         )
         .get(NAMESPACE, runId) as { value_json: string } | undefined;
-      return row ? (JSON.parse(row.value_json) as FridayWorkflowTestRunResult) : null;
+      return row ? safeJsonParse<FridayWorkflowTestRunResult>(row.value_json) ?? null : null;
     },
 
     listByDraft(db, draftId, limit) {
@@ -52,7 +53,7 @@ export function createFridayWorkflowBuilderTestRunRepository(): FridayWorkflowBu
           `SELECT value_json FROM memory_items WHERE namespace = ? AND key LIKE ? ORDER BY created_at DESC LIMIT ?`,
         )
         .all(NAMESPACE, `${draftId}:%`, limit ?? 50) as Array<{ value_json: string }>;
-      return rows.map((r) => JSON.parse(r.value_json) as FridayWorkflowTestRunResult);
+      return rows.map((r) => safeJsonParse<FridayWorkflowTestRunResult>(r.value_json)).filter((r): r is FridayWorkflowTestRunResult => r !== undefined);
     },
   };
 }

--- a/src/workflows/builder/services/friday-workflow-builder-validation-service.ts
+++ b/src/workflows/builder/services/friday-workflow-builder-validation-service.ts
@@ -290,7 +290,8 @@ function validateEdgeConditions(
           outputs: [],
           tests: [],
         });
-      } catch {
+      } catch (err) {
+        console.warn("[friday][workflow-builder-validation] condition expression invalid:", err instanceof Error ? err.message : String(err));
         issues.push({
           code: "EXPRESSION_INVALID",
           stage: "expressions",

--- a/src/workflows/compiler/friday-workflow-validator.ts
+++ b/src/workflows/compiler/friday-workflow-validator.ts
@@ -252,7 +252,8 @@ export function createFridayWorkflowValidator(): FridayWorkflowValidator {
         if (edge.condition) {
           try {
             exprEval.parse(edge.condition);
-          } catch {
+          } catch (err) {
+            console.warn("[friday][workflow-validator] invalid condition expression:", err instanceof Error ? err.message : String(err));
             errors.push({
               code: "WORKFLOW_EXPRESSION_INVALID",
               message: `Edge '${edge.id}' has invalid condition expression: '${edge.condition}'`,

--- a/src/workflows/engine/friday-workflow-dag-scheduler.ts
+++ b/src/workflows/engine/friday-workflow-dag-scheduler.ts
@@ -116,8 +116,10 @@ export function createFridayWorkflowDagScheduler(): FridayWorkflowDagScheduler {
             }
           } catch (err) {
             console.warn(
-              `[friday] Workflow DAG edge condition evaluation failed for edge ${pred}→${nodeId}: ${err instanceof Error ? err.message : String(err)}`,
+              `[friday] Workflow DAG edge condition evaluation failed for edge ${pred}→${nodeId}: ${err instanceof Error ? err.message : String(err)}. Treating edge as enabled (fail-open).`,
             );
+            // P2-WF-001: Fail-open — treat evaluation error as edge enabled rather than silently disabling
+            anyEnabledEdge = true;
           }
         } else {
           anyEnabledEdge = true;

--- a/src/workflows/engine/friday-workflow-node-executor.ts
+++ b/src/workflows/engine/friday-workflow-node-executor.ts
@@ -183,12 +183,14 @@ export function createFridayWorkflowNodeExecutor(
                 refExpr,
                 expressionContext,
               );
-              interpolatedPrompt = interpolatedPrompt.replace(
+              // P2-WF-002: Use replaceAll to substitute all occurrences, not just the first
+              interpolatedPrompt = interpolatedPrompt.replaceAll(
                 refExpr,
                 String(val ?? ""),
               );
-            } catch {
+            } catch (err) {
               // Leave unresolved refs as-is
+              console.warn("[friday][workflow-node-executor] ref interpolation failed:", err instanceof Error ? err.message : String(err));
             }
           }
 

--- a/src/workflows/engine/friday-workflow-node-machine.ts
+++ b/src/workflows/engine/friday-workflow-node-machine.ts
@@ -42,6 +42,10 @@ const VALID_TRANSITIONS: ReadonlyMap<
   ["cancelled", new Set<NodeAttemptStatus>([])],
 ]);
 
+// P2: "failed" is included as terminal for DAG scheduling purposes (predecessor is "done").
+// However, `failed` can transition to `retrying` when a retry policy triggers — this is
+// handled by the retry manager BEFORE the DAG scheduler re-evaluates, so the semantics
+// are consistent: "terminal" means "current attempt is done", not "can never change".
 const TERMINAL_STATUSES: ReadonlySet<NodeAttemptStatus> = new Set([
   "completed",
   "failed",

--- a/src/workflows/generator/persistence/friday-workflow-generation-session-repository.ts
+++ b/src/workflows/generator/persistence/friday-workflow-generation-session-repository.ts
@@ -2,6 +2,7 @@ import type Database from "better-sqlite3";
 
 import { FridayDomainError } from "#errors";
 import type { FridaySqliteLayer } from "#state";
+import { safeJsonParse } from "#utilities";
 
 import type {
   FridayWorkflowGenerationSession,
@@ -159,7 +160,7 @@ export function createFridayWorkflowGenerationSessionRepository(
           sessionKey(sessionId),
         );
         if (!row) return null;
-        return JSON.parse(row.value_json) as FridayWorkflowGenerationSession;
+        return safeJsonParse<FridayWorkflowGenerationSession>(row.value_json) ?? null;
       });
     },
 
@@ -209,7 +210,7 @@ export function createFridayWorkflowGenerationSessionRepository(
           turnKeyPrefix(sessionId),
         );
         return rows.map(
-          (row) => JSON.parse(row.value_json) as FridayWorkflowGenerationTurn,
+          (row) => safeJsonParse<FridayWorkflowGenerationTurn>(row.value_json)!,
         );
       });
     },

--- a/src/workflows/generator/services/friday-workflow-generator-service.ts
+++ b/src/workflows/generator/services/friday-workflow-generator-service.ts
@@ -1,4 +1,5 @@
 import { FridayDomainError } from "#errors";
+import { safeJsonParse } from "#utilities";
 import { createFridayProviderInferenceClient } from "#skills/generator";
 import type { FridayProviderInferenceClient } from "#skills/generator";
 import {
@@ -360,7 +361,7 @@ export function createFridayWorkflowGeneratorService(
         .prepare("SELECT value_json FROM memory_items WHERE namespace = ? AND key = ?")
         .get(DRAFT_NAMESPACE, sessionId) as { value_json: string } | undefined;
       if (!row) return undefined;
-      return JSON.parse(row.value_json) as FridayGeneratedWorkflowDraft;
+      return safeJsonParse<FridayGeneratedWorkflowDraft>(row.value_json);
     });
   }
 
@@ -388,7 +389,8 @@ export function createFridayWorkflowGeneratorService(
       if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
         return parsed as FridayWorkflowGenerationRequirements;
       }
-    } catch {
+    } catch (err) {
+      console.warn("[friday][workflow-generator-service] requirements parse failed:", err instanceof Error ? err.message : String(err));
       return null;
     }
     return null;
@@ -1308,7 +1310,8 @@ export function createFridayWorkflowGeneratorService(
       let requirements: FridayWorkflowGenerationRequirements;
       try {
         requirements = JSON.parse(session.requirementsSummary) as FridayWorkflowGenerationRequirements;
-      } catch {
+      } catch (err) {
+        console.warn("[friday][workflow-generator-service] requirements JSON invalid:", err instanceof Error ? err.message : String(err));
         throw new FridayDomainError(
           "VALIDATION_ERROR",
           "No valid requirements available. Continue the conversation to provide requirements.",

--- a/src/workflows/persistence/friday-workflow-approval-repository.ts
+++ b/src/workflows/persistence/friday-workflow-approval-repository.ts
@@ -4,6 +4,7 @@ import type {
   FridayWorkflowApprovalStatus,
 } from "../model/friday-workflow-engine.types.js";
 import type { FridaySqliteLayer } from "#state";
+import { safeJsonParse } from "#utilities";
 
 // ─── Interface ───
 
@@ -55,10 +56,7 @@ function mapApprovalRow(
     approverUserId: row.approver_user_id ?? undefined,
     approverRole: row.approver_role ?? undefined,
     status: row.status as FridayWorkflowApprovalStatus,
-    requestPayload: JSON.parse(row.request_payload_json) as Record<
-      string,
-      unknown
-    >,
+    requestPayload: safeJsonParse<Record<string, unknown>>(row.request_payload_json) ?? {},
     timeoutAt: row.timeout_at ?? undefined,
     decidedAt: row.decided_at ?? undefined,
     decidedByUserId: row.decided_by_user_id ?? undefined,

--- a/src/workflows/persistence/friday-workflow-artifact-repository.ts
+++ b/src/workflows/persistence/friday-workflow-artifact-repository.ts
@@ -1,4 +1,5 @@
 import type Database from "better-sqlite3";
+import { safeJsonParse } from "#utilities";
 import type {
   FridayWorkflowArtifactEntity,
   FridayWorkflowArtifactRow,
@@ -40,9 +41,7 @@ function mapArtifactRow(
     artifactType: row.artifact_type as FridayWorkflowArtifactEntity["artifactType"],
     uri: row.uri,
     checksum: row.checksum ?? undefined,
-    metadata: row.metadata_json
-      ? (JSON.parse(row.metadata_json) as JsonObject)
-      : undefined,
+    metadata: safeJsonParse<JsonObject>(row.metadata_json),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };

--- a/src/workflows/persistence/friday-workflow-repository.ts
+++ b/src/workflows/persistence/friday-workflow-repository.ts
@@ -1,6 +1,7 @@
 import type Database from "better-sqlite3";
 import type { FridaySqliteLayer } from "#state";
 import { FridayDomainError } from "#errors";
+import { safeJsonParse } from "#utilities";
 import type {
   FridayWorkflowCreateInput,
   FridayWorkflowEntity,
@@ -115,7 +116,7 @@ function mapWorkflowRow(row: FridayWorkflowRow): FridayWorkflowEntity {
     slug: row.slug,
     name: row.name,
     description: row.description ?? undefined,
-    tags: JSON.parse(row.tags_json) as string[],
+    tags: safeJsonParse<string[]>(row.tags_json) ?? [],
     ownerUserId: row.owner_user_id ?? undefined,
     latestVersionNumber: row.latest_version_number,
     publishedVersionNumber: row.published_version_number ?? undefined,
@@ -135,7 +136,7 @@ function mapVersionRow(row: FridayWorkflowVersionRow): FridayWorkflowVersionEnti
     workflowId: row.workflow_id,
     versionNumber: row.version_number,
     checksum: row.checksum,
-    graphJson: JSON.parse(row.graph_json) as JsonValue,
+    graphJson: safeJsonParse<JsonValue>(row.graph_json) as JsonValue,
     createdByUserId: row.created_by_user_id ?? undefined,
     isPublished: row.is_published === 1,
     changeNote: row.change_note ?? undefined,

--- a/src/workflows/persistence/friday-workflow-run-checkpoint-repository.ts
+++ b/src/workflows/persistence/friday-workflow-run-checkpoint-repository.ts
@@ -4,6 +4,7 @@ import type {
   FridayWorkflowRunStatus,
 } from "../model/friday-workflow-engine.types.js";
 import type { FridaySqliteLayer } from "#state";
+import { safeJsonParse } from "#utilities";
 
 // ─── Interface ───
 
@@ -28,13 +29,11 @@ function mapCheckpointRow(
     runId: row.run_id,
     checkpointSeq: row.checkpoint_seq,
     runStatus: row.run_status as FridayWorkflowRunStatus,
-    activeNodeIds: JSON.parse(row.active_node_ids_json) as string[],
-    completedNodeIds: JSON.parse(row.completed_node_ids_json) as string[],
-    failedNodeIds: JSON.parse(row.failed_node_ids_json) as string[],
-    waitingApprovalNodeIds: JSON.parse(
-      row.waiting_approval_node_ids_json,
-    ) as string[],
-    context: JSON.parse(row.context_json) as Record<string, unknown>,
+    activeNodeIds: safeJsonParse<string[]>(row.active_node_ids_json) ?? [],
+    completedNodeIds: safeJsonParse<string[]>(row.completed_node_ids_json) ?? [],
+    failedNodeIds: safeJsonParse<string[]>(row.failed_node_ids_json) ?? [],
+    waitingApprovalNodeIds: safeJsonParse<string[]>(row.waiting_approval_node_ids_json) ?? [],
+    context: safeJsonParse<Record<string, unknown>>(row.context_json) ?? {},
     lastNodeId: row.last_node_id ?? undefined,
     updatedAt: row.updated_at,
   };

--- a/src/workflows/persistence/friday-workflow-run-node-repository.ts
+++ b/src/workflows/persistence/friday-workflow-run-node-repository.ts
@@ -1,4 +1,5 @@
 import type Database from "better-sqlite3";
+import { safeJsonParse } from "#utilities";
 import type {
   FridayWorkflowRunNodeEntity,
   FridayWorkflowRunNodeRow,
@@ -104,16 +105,14 @@ function mapNodeRow(row: FridayWorkflowRunNodeRow): FridayWorkflowRunNodeEntity 
     leaseExpiresAt: row.lease_expires_at ?? undefined,
     startedAt: row.started_at ?? undefined,
     finishedAt: row.finished_at ?? undefined,
-    input: row.input_json ? (JSON.parse(row.input_json) as JsonValue) : undefined,
-    output: row.output_json ? (JSON.parse(row.output_json) as JsonValue) : undefined,
-    error: row.error_json
-      ? (JSON.parse(row.error_json) as {
+    input: safeJsonParse<JsonValue>(row.input_json),
+    output: safeJsonParse<JsonValue>(row.output_json),
+    error: safeJsonParse<{
           code: string;
           message: string;
           retryable: boolean;
           details?: JsonValue;
-        })
-      : undefined,
+        }>(row.error_json),
     idempotencyKey: row.idempotency_key,
     createdAt: row.created_at,
     updatedAt: row.updated_at,

--- a/src/workflows/persistence/friday-workflow-run-repository.ts
+++ b/src/workflows/persistence/friday-workflow-run-repository.ts
@@ -1,4 +1,5 @@
 import type Database from "better-sqlite3";
+import { safeJsonParse } from "#utilities";
 import type {
   FridayWorkflowRunEntity,
   FridayWorkflowRunRow,
@@ -60,25 +61,19 @@ function mapRunRow(row: FridayWorkflowRunRow): FridayWorkflowRunEntity {
     workflowVersionId: row.workflow_version_id,
     status: row.status as WorkflowRunStatus,
     triggerType: row.trigger_type,
-    triggerPayload: row.trigger_payload_json
-      ? (JSON.parse(row.trigger_payload_json) as JsonObject)
-      : undefined,
+    triggerPayload: safeJsonParse<JsonObject>(row.trigger_payload_json),
     startedByUserId: row.started_by_user_id ?? undefined,
     startedBySatelliteId: row.started_by_satellite_id ?? undefined,
     startedAt: row.started_at,
     finishedAt: row.finished_at ?? undefined,
     correlationId: row.correlation_id ?? undefined,
-    context: row.context_json
-      ? (JSON.parse(row.context_json) as JsonObject)
-      : undefined,
+    context: safeJsonParse<JsonObject>(row.context_json),
     failure:
       row.failure_code
         ? {
             code: row.failure_code,
             message: row.failure_message ?? "",
-            details: row.failure_details_json
-              ? (JSON.parse(row.failure_details_json) as JsonValue)
-              : undefined,
+            details: safeJsonParse<JsonValue>(row.failure_details_json),
           }
         : undefined,
     createdAt: row.created_at,
@@ -128,9 +123,10 @@ export function createFridayWorkflowRunRepository(): FridayWorkflowRunRepository
     },
 
     updateRunStatus(db, id, status, nowIso, failure) {
-      db.prepare(
+      // P2-WF: Enforce state transition by including current status check in WHERE clause
+      const result = db.prepare(
         `UPDATE workflow_runs SET status = ?, failure_code = ?, failure_message = ?,
-         failure_details_json = ?, updated_at = ? WHERE id = ?`,
+         failure_details_json = ?, updated_at = ? WHERE id = ? AND status != ?`,
       ).run(
         status,
         failure?.code ?? null,
@@ -138,7 +134,11 @@ export function createFridayWorkflowRunRepository(): FridayWorkflowRunRepository
         failure?.details !== undefined ? JSON.stringify(failure.details) : null,
         nowIso,
         id,
+        status, // Prevent no-op updates (same status)
       );
+      if (result.changes === 0) {
+        // Either the run doesn't exist or it's already in the target status — acceptable no-op
+      }
     },
 
     finalizeRun(db, id, status, nowIso, failure) {
@@ -179,7 +179,7 @@ export function createFridayWorkflowRunRepository(): FridayWorkflowRunRepository
       return (
         db
           .prepare(
-            "SELECT * FROM workflow_runs WHERE status IN ('queued', 'running', 'pausing', 'compensating')",
+            "SELECT * FROM workflow_runs WHERE status IN ('queued', 'running', 'paused', 'pausing', 'compensating')",
           )
           .all() as FridayWorkflowRunRow[]
       ).map(mapRunRow);
@@ -190,9 +190,7 @@ export function createFridayWorkflowRunRepository(): FridayWorkflowRunRepository
         .prepare("SELECT context_json FROM workflow_runs WHERE id = ?")
         .get(id) as { context_json: string | null } | undefined;
 
-      const existing = row?.context_json
-        ? (JSON.parse(row.context_json) as Record<string, unknown>)
-        : {};
+      const existing = safeJsonParse<Record<string, unknown>>(row?.context_json) ?? {};
       const merged = { ...existing, ...context };
 
       db.prepare(

--- a/src/workflows/runtime/friday-workflow-runtime.ts
+++ b/src/workflows/runtime/friday-workflow-runtime.ts
@@ -1,7 +1,9 @@
+import { FridayDomainError } from "#errors";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
 import type { FridaySqliteLayer } from "#state";
+import { safeJsonParse } from "#utilities";
 import {
   AcceptanceTestSuiteRunner,
   type FridayAcceptanceArtifactType,
@@ -149,7 +151,8 @@ function parseJsonObject(value: string | null | undefined): Record<string, unkno
   try {
     const parsed = JSON.parse(value);
     return asRecord(parsed);
-  } catch {
+  } catch (err) {
+    console.warn("[friday][workflow-runtime] parse-json-object:", err instanceof Error ? err.message : String(err));
     return {};
   }
 }
@@ -157,7 +160,8 @@ function parseJsonObject(value: string | null | undefined): Record<string, unkno
 function stringifyForKey(value: unknown): string {
   try {
     return JSON.stringify(value) ?? "";
-  } catch {
+  } catch (err) {
+    console.warn("[friday][workflow-runtime] stringify-for-key:", err instanceof Error ? err.message : String(err));
     return "";
   }
 }
@@ -209,14 +213,10 @@ function mapBundleRow(row: FridayPolicyBundleRow): FridayPolicyBundle {
     priority: row.priority,
     enabled: row.enabled === 1,
     tags: (() => {
-      try {
-        const parsed = JSON.parse(row.tags_json);
-        return Array.isArray(parsed)
-          ? parsed.filter((item): item is string => typeof item === "string")
-          : [];
-      } catch {
-        return [];
-      }
+      const parsed = safeJsonParse(row.tags_json);
+      return Array.isArray(parsed)
+        ? parsed.filter((item): item is string => typeof item === "string")
+        : [];
     })(),
     source: row.source === "import" || row.source === "system" ? row.source : "user",
     etag: row.etag,
@@ -227,14 +227,10 @@ function mapBundleRow(row: FridayPolicyBundleRow): FridayPolicyBundle {
 
 function mapRuleRow(row: FridayRuleRow): FridayRule {
   const conditions = (() => {
-    try {
-      const parsed = JSON.parse(row.conditions_json);
-      return typeof parsed === "object" && parsed !== null
-        ? parsed as FridayRule["conditions"]
-        : {};
-    } catch {
-      return {};
-    }
+    const parsed = safeJsonParse(row.conditions_json);
+    return typeof parsed === "object" && parsed !== null
+      ? parsed as FridayRule["conditions"]
+      : {};
   })();
 
   return {
@@ -500,8 +496,9 @@ export function createFridayWorkflowRuntime(
             created_at: entry.evaluatedAt,
           });
         });
-      } catch {
+      } catch (err) {
         // Keep rule enforcement fail-open for audit persistence write failures.
+        console.warn("[friday][workflow-runtime] rule-audit-persist:", err instanceof Error ? err.message : String(err));
       }
     },
   });
@@ -521,8 +518,9 @@ export function createFridayWorkflowRuntime(
         rulesEngine.loadDomainBundle(bundle, rules);
       }
     });
-  } catch {
+  } catch (err) {
     // Legacy instances may not have the Rules tables yet.
+    console.warn("[friday][workflow-runtime] load-rules:", err instanceof Error ? err.message : String(err));
   }
 
   const evaluateRules = async (
@@ -839,7 +837,7 @@ export function createFridayWorkflowRuntime(
           }
 
           if (gateResult.blocksCompletion && pipelineEnforceMode) {
-            throw new Error("NODE_ACCEPTANCE_FAILED");
+            throw new FridayDomainError("VALIDATION_ERROR", "NODE_ACCEPTANCE_FAILED", { httpStatus: 400 });
           }
         }
 
@@ -1575,7 +1573,8 @@ export function createFridayWorkflowRuntime(
       const filePath = path.join(runDir, `${exportId}.json`);
       fs.writeFileSync(filePath, content, "utf8");
       return { uri: toFileUri(filePath), filePersisted: true };
-    } catch {
+    } catch (err) {
+      console.warn("[friday][workflow-runtime] persist-evidence-export:", err instanceof Error ? err.message : String(err));
       return { uri: defaultUri, filePersisted: false };
     }
   };
@@ -1586,7 +1585,8 @@ export function createFridayWorkflowRuntime(
   ): FridayWorkflowRunEvidenceResponse => {
     try {
       return JSON.parse(primaryPayloadJson) as FridayWorkflowRunEvidenceResponse;
-    } catch {
+    } catch (err) {
+      console.warn("[friday][workflow-runtime] parse-evidence-payload:", err instanceof Error ? err.message : String(err));
       return JSON.parse(fallbackPayloadJson) as FridayWorkflowRunEvidenceResponse;
     }
   };
@@ -1605,7 +1605,8 @@ export function createFridayWorkflowRuntime(
       }
       const payloadJson = fs.readFileSync(filePath, "utf8");
       return { payloadJson, filePersisted: true, filePath };
-    } catch {
+    } catch (err) {
+      console.warn("[friday][workflow-runtime] read-evidence-export:", err instanceof Error ? err.message : String(err));
       return { payloadJson: fallbackPayloadJson, filePersisted: false, filePath };
     }
   };

--- a/src/workflows/services/friday-workflow-approval-service.ts
+++ b/src/workflows/services/friday-workflow-approval-service.ts
@@ -212,12 +212,14 @@ export function createFridayWorkflowApprovalService(
           await deps.executionService.resumeRun(approval.runId, {
             approvalDecision: "rejected",
           });
-        } catch {
+        } catch (err) {
           // Resume failed (e.g. run already terminal) — try cancelling as fallback
+          console.warn("[friday][workflow-approval-service] resume failed:", err instanceof Error ? err.message : String(err));
           try {
             await deps.executionService.cancelRun(approval.runId, "Approval expired");
-          } catch {
+          } catch (err2) {
             // Run may already be in a terminal state — nothing to do
+            console.warn("[friday][workflow-approval-service] cancel fallback failed:", err2 instanceof Error ? err2.message : String(err2));
           }
         }
       }

--- a/src/workflows/services/friday-workflow-execution-service.ts
+++ b/src/workflows/services/friday-workflow-execution-service.ts
@@ -461,9 +461,11 @@ export function createFridayWorkflowExecutionService(
     });
 
     if (effectiveRetryDecision.shouldRetry) {
+      // P2-WF: Cap delay to avoid blocking the execution batch for too long
       if (effectiveRetryDecision.delayMs > 0) {
+        const cappedDelay = Math.min(effectiveRetryDecision.delayMs, 30_000);
         await new Promise((resolve) =>
-          setTimeout(resolve, effectiveRetryDecision.delayMs),
+          setTimeout(resolve, cappedDelay),
         );
       }
       return "retrying";
@@ -643,7 +645,8 @@ export function createFridayWorkflowExecutionService(
 
             // Check for approval nodes — these block until explicit decision
             if (node.type === "approval") {
-              const leaseExpiresAt = new Date(Date.now() + LEASE_TTL_MS).toISOString();
+              // P2-WF: Use injected clock instead of Date.now() for testable lease TTL
+              const leaseExpiresAt = new Date(new Date(deps.nowIso()).getTime() + LEASE_TTL_MS).toISOString();
               const leaseAcquired = deps.db.withWriteTransaction((db) =>
                 deps.nodeRepo.acquireLease(
                   db,
@@ -797,6 +800,8 @@ export function createFridayWorkflowExecutionService(
             }
 
             const timeoutMs = node.timeoutMs ?? 300_000;
+            // P2-WF-003: Store timeout handle for cleanup on success
+            let nodeTimeoutHandle: ReturnType<typeof setTimeout> | undefined;
             const result = await Promise.race([
               deps.nodeExecutor.executeNode({
                 runId,
@@ -811,13 +816,14 @@ export function createFridayWorkflowExecutionService(
                 ),
                 signal: runSignal,
               }),
-              new Promise<never>((_, reject) =>
-                setTimeout(
+              new Promise<never>((_, reject) => {
+                nodeTimeoutHandle = setTimeout(
                   () => reject(new Error("NODE_TIMEOUT")),
                   timeoutMs,
-                ),
-              ),
+                );
+              }),
             ]);
+            if (nodeTimeoutHandle !== undefined) clearTimeout(nodeTimeoutHandle);
 
             deps.db.withWriteTransaction((db) => {
               deps.nodeRepo.updateNodeAttempt(db, attempt.id, {
@@ -1339,11 +1345,31 @@ export function createFridayWorkflowExecutionService(
         deps.runRepo.updateRunStatus(db, runId, "running", deps.nowIso());
       });
 
-      scheduleRunExecution(plan).catch((error) => {
+      scheduleRunExecution(plan).catch(async (error) => {
         const errorMessage = error instanceof Error ? error.message : String(error);
         console.error(
           `[friday][E-WF-RUN-ASYNC-002] Resume execution failed for run ${runId}: ${errorMessage}`,
         );
+        // P1-RT-001: Mark run as failed on unhandled resume errors
+        deps.db.withWriteTransaction((db) => {
+          deps.runRepo.finalizeRun(db, runId, "failed", deps.nowIso(), {
+            code: "WORKFLOW_EXECUTION_ERROR",
+            message: `Resume execution error: ${errorMessage}`,
+          });
+        });
+        const counts = deps.db.withReadConnection((db) =>
+          deps.nodeRepo.countByStatus(db, runId),
+        );
+        await notifyRunCompleted({
+          runId,
+          workflowId: runEntity.workflowId,
+          workflowVersionId: runEntity.workflowVersionId,
+          status: "failed",
+          plan,
+          failedNodes: counts.failed,
+          completedNodes: counts.completed,
+          cancelledNodes: counts.cancelled,
+        });
       });
 
       return deps.db.withReadConnection((db) =>
@@ -1466,11 +1492,31 @@ export function createFridayWorkflowExecutionService(
         deps.runRepo.updateRunStatus(db, runId, "running", deps.nowIso());
       });
 
-      scheduleRunExecution(plan).catch((error) => {
+      scheduleRunExecution(plan).catch(async (error) => {
         const errorMessage = error instanceof Error ? error.message : String(error);
         console.error(
           `[friday][E-WF-RUN-ASYNC-003] Retry execution failed for run ${runId}: ${errorMessage}`,
         );
+        // P1-RT-002: Mark run as failed on unhandled retry errors
+        deps.db.withWriteTransaction((db) => {
+          deps.runRepo.finalizeRun(db, runId, "failed", deps.nowIso(), {
+            code: "WORKFLOW_EXECUTION_ERROR",
+            message: `Retry execution error: ${errorMessage}`,
+          });
+        });
+        const counts = deps.db.withReadConnection((db) =>
+          deps.nodeRepo.countByStatus(db, runId),
+        );
+        await notifyRunCompleted({
+          runId,
+          workflowId: runEntity.workflowId,
+          workflowVersionId: runEntity.workflowVersionId,
+          status: "failed",
+          plan,
+          failedNodes: counts.failed,
+          completedNodes: counts.completed,
+          cancelledNodes: counts.cancelled,
+        });
       });
 
       return deps.db.withReadConnection((db) =>
@@ -1528,11 +1574,31 @@ export function createFridayWorkflowExecutionService(
         );
         activePlans.set(run.id, plan);
 
-        scheduleRunExecution(plan).catch((error) => {
+        scheduleRunExecution(plan).catch(async (error) => {
           const errorMessage = error instanceof Error ? error.message : String(error);
           console.error(
             `[friday][E-WF-RUN-ASYNC-004] Recovery execution failed for run ${run.id}: ${errorMessage}`,
           );
+          // P1-RT-003: Mark run as failed on unhandled recovery errors
+          deps.db.withWriteTransaction((db) => {
+            deps.runRepo.finalizeRun(db, run.id, "failed", deps.nowIso(), {
+              code: "WORKFLOW_EXECUTION_ERROR",
+              message: `Recovery execution error: ${errorMessage}`,
+            });
+          });
+          const counts = deps.db.withReadConnection((db) =>
+            deps.nodeRepo.countByStatus(db, run.id),
+          );
+          await notifyRunCompleted({
+            runId: run.id,
+            workflowId: run.workflowId,
+            workflowVersionId: run.workflowVersionId,
+            status: "failed",
+            plan,
+            failedNodes: counts.failed,
+            completedNodes: counts.completed,
+            cancelledNodes: counts.cancelled,
+          });
         });
         recovered++;
       }

--- a/src/workflows/services/friday-workflow-product-service.ts
+++ b/src/workflows/services/friday-workflow-product-service.ts
@@ -613,8 +613,9 @@ export function createFridayWorkflowProductService(
         if (acquiredLockToken) {
           try {
             deps.builderRuntime.collaboration.releaseLock(input.workflowId, acquiredLockToken);
-          } catch {
+          } catch (err) {
             // Best-effort release for one-click deploy helper locks.
+            console.warn("[friday][workflow-product-service] lock release failed:", err instanceof Error ? err.message : String(err));
           }
         }
       }

--- a/src/workflows/services/friday-workflow-trigger-service.ts
+++ b/src/workflows/services/friday-workflow-trigger-service.ts
@@ -138,7 +138,9 @@ async function fireCronRegistration(
     }
 
     return true;
-  } catch {
+  } catch (err) {
+    // P2-WF-004: Log trigger fire failures instead of silent swallow
+    console.warn("[friday] Cron trigger fire failed:", err instanceof Error ? err.message : String(err));
     return false;
   }
 }
@@ -263,8 +265,9 @@ export function createFridayWorkflowTriggerService(
                 triggerPayload: ctx.payload,
               });
               runIds.push(run.id);
-            } catch {
-              // Log and continue
+            } catch (err) {
+              // P2-WF-004: Log event trigger failures
+              console.warn("[friday] Event trigger startRun failed:", err instanceof Error ? err.message : String(err));
             }
           }
         }
@@ -352,8 +355,9 @@ export function createFridayWorkflowTriggerService(
               if (next) {
                 nextFireAt = next.toISOString();
               }
-            } catch {
-              // Invalid cron expression — log and leave nextFireAt undefined (disables auto-fire)
+            } catch (err) {
+              // P2-WF-004: Log invalid cron expression
+              console.warn("[friday] Invalid cron expression during trigger sync:", err instanceof Error ? err.message : String(err));
             }
           }
 
@@ -453,7 +457,9 @@ export function createFridayWorkflowTriggerService(
         deps.triggerRepo.markFired(reg.id, deps.nowIso());
 
         return { accepted: true, runId: run.id };
-      } catch {
+      } catch (err) {
+        // P2-WF-004: Log webhook trigger failures
+        console.warn("[friday] Webhook trigger handling failed:", err instanceof Error ? err.message : String(err));
         return { accepted: false };
       }
     },
@@ -483,8 +489,9 @@ export function createFridayWorkflowTriggerService(
 
           deps.triggerRepo.markFired(reg.id, deps.nowIso());
           started++;
-        } catch {
-          // Log and continue
+        } catch (err) {
+          // P2-WF-004: Log event handler failures
+          console.warn("[friday] Event handler startRun failed:", err instanceof Error ? err.message : String(err));
         }
       }
 

--- a/src/xhs/friday-xhs-pages.ts
+++ b/src/xhs/friday-xhs-pages.ts
@@ -167,7 +167,8 @@ export function createXhsPageInteractions(deps: CreateXhsPageInteractionsDeps): 
     let safeSessionId: string;
     try {
       safeSessionId = sanitizeArtifactPathSegment(sessionId);
-    } catch {
+    } catch (err) {
+      console.warn("[friday][xhs-pages] invalid sessionId for artifact path:", err instanceof Error ? err.message : String(err));
       return { status: "error", message: "Invalid sessionId for artifact path." };
     }
     const qrPath = path.join(artifactDir, `xhs-qr-${safeSessionId}-${Date.now()}.png`);
@@ -268,7 +269,8 @@ export function createXhsPageInteractions(deps: CreateXhsPageInteractionsDeps): 
         await fileInput.setInputFiles(images);
         await xhsSleep(2000, 4000);
       }
-    } catch {
+    } catch (err) {
+      console.warn("[friday][xhs-pages] image upload input not found:", err instanceof Error ? err.message : String(err));
       return { status: "error", message: "Failed to find image upload input" };
     }
 
@@ -282,7 +284,8 @@ export function createXhsPageInteractions(deps: CreateXhsPageInteractionsDeps): 
         await titleInput.fill(title);
         await xhsSleep();
       }
-    } catch {
+    } catch (err) {
+      console.warn("[friday][xhs-pages] title input not found:", err instanceof Error ? err.message : String(err));
       return { status: "error", message: "Failed to find title input" };
     }
 
@@ -296,7 +299,8 @@ export function createXhsPageInteractions(deps: CreateXhsPageInteractionsDeps): 
         await contentInput.fill(content);
         await xhsSleep();
       }
-    } catch {
+    } catch (err) {
+      console.warn("[friday][xhs-pages] content input not found:", err instanceof Error ? err.message : String(err));
       return { status: "error", message: "Failed to find content input" };
     }
 
@@ -307,8 +311,9 @@ export function createXhsPageInteractions(deps: CreateXhsPageInteractionsDeps): 
         await xhsSleep(500, 1000);
         await page.keyboard.press("Enter");
         await xhsSleep(300, 600);
-      } catch {
+      } catch (err) {
         // Tag input may not be available, continue
+        console.warn("[friday][xhs-pages] tag input failed:", err instanceof Error ? err.message : String(err));
       }
     }
 
@@ -317,7 +322,8 @@ export function createXhsPageInteractions(deps: CreateXhsPageInteractionsDeps): 
       const publishBtn = page.getByRole("button", { name: /^(发布|Publish)$/ }).first();
       await publishBtn.click({ timeout: 5000 });
       await xhsSleep(3000, 5000);
-    } catch {
+    } catch (err) {
+      console.warn("[friday][xhs-pages] publish button not found:", err instanceof Error ? err.message : String(err));
       return { status: "error", message: "Failed to find publish button" };
     }
 

--- a/src/xhs/friday-xhs-session.ts
+++ b/src/xhs/friday-xhs-session.ts
@@ -1,6 +1,7 @@
 // ─── XHS Session Manager — cookie-based session persistence ───
 
 import type { FridaySqliteLayer } from "#state";
+import { safeJsonParse } from "#utilities";
 import { decryptSecret, encryptSecret, getMasterKey } from "#providers";
 import type { FridayEncryptedEnvelope } from "#providers";
 import { xhsRandomUserAgent } from "./friday-xhs-stealth.js";
@@ -85,10 +86,11 @@ export function createXhsSessionManager(deps: CreateXhsSessionManagerDeps): XhsS
       if (!row?.cookies_encrypted) return undefined;
 
       try {
-        const envelope = JSON.parse(row.cookies_encrypted) as FridayEncryptedEnvelope;
+        const envelope = safeJsonParse(row.cookies_encrypted) as FridayEncryptedEnvelope;
         const plaintext = decryptSecret(envelope, getMasterKey());
-        return JSON.parse(plaintext) as XhsCookie[];
-      } catch {
+        return safeJsonParse(plaintext) as XhsCookie[];
+      } catch (err) {
+        console.warn("[friday][xhs-session] cookie decryption failed:", err instanceof Error ? err.message : String(err));
         return undefined;
       }
     });
@@ -109,10 +111,11 @@ export function createXhsSessionManager(deps: CreateXhsSessionManagerDeps): XhsS
 
       let cookies: XhsCookie[];
       try {
-        const envelope = JSON.parse(row.cookies_encrypted) as FridayEncryptedEnvelope;
+        const envelope = safeJsonParse(row.cookies_encrypted) as FridayEncryptedEnvelope;
         const plaintext = decryptSecret(envelope, getMasterKey());
-        cookies = JSON.parse(plaintext) as XhsCookie[];
-      } catch {
+        cookies = safeJsonParse(plaintext) as XhsCookie[];
+      } catch (err) {
+        console.warn("[friday][xhs-session] session validation cookie parse failed:", err instanceof Error ? err.message : String(err));
         return false;
       }
 

--- a/test/contracts/api/__snapshots__/friday-api-route-contract.snapshot.test.ts.snap
+++ b/test/contracts/api/__snapshots__/friday-api-route-contract.snapshot.test.ts.snap
@@ -2347,7 +2347,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
     "method": "POST",
     "operationId": "memory.store",
     "path": "/v1/memory/store",
-    "rateLimitPolicyId": null,
+    "rateLimitPolicyId": "memory.write",
     "roles": [],
     "scopes": [
       "hub.admin",
@@ -2455,7 +2455,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
     "method": "POST",
     "operationId": "sessions.create",
     "path": "/v1/sessions",
-    "rateLimitPolicyId": null,
+    "rateLimitPolicyId": "session.write",
     "roles": [],
     "scopes": [
       "session.write",
@@ -2793,7 +2793,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
     "method": "POST",
     "operationId": "agent.runs.start",
     "path": "/v1/agent/runs",
-    "rateLimitPolicyId": null,
+    "rateLimitPolicyId": "agent.run",
     "roles": [],
     "scopes": [
       "agent.run",

--- a/test/unit/api/auth/friday-auth-service.test.ts
+++ b/test/unit/api/auth/friday-auth-service.test.ts
@@ -378,8 +378,9 @@ describe("FridayAuthService", () => {
       warn: (msg) => warnings.push(msg),
     });
     devService.login({ local: true }, "127.0.0.1");
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0]).toContain("Passwordless");
+    // P1-SEC-004/005: Now also logs token secret + rate limiter warnings at construction
+    const passwordlessWarning = warnings.find((w) => w.includes("Passwordless"));
+    expect(passwordlessWarning).toBeDefined();
   });
 
   it("allows no-signin local bypass with { local: true } even when passphrase exists", () => {

--- a/test/unit/channels/lark/friday-lark-channel.test.ts
+++ b/test/unit/channels/lark/friday-lark-channel.test.ts
@@ -142,7 +142,8 @@ describe("FridayLarkChannel", () => {
 
   describe("init", () => {
     it("validates appId and appSecret are required", async () => {
-      await expect(plugin.init({})).rejects.toThrow("Lark channel requires appId and appSecret");
+      // P1-CH-001: Now uses Zod validation — throws ZodError for missing required fields
+      await expect(plugin.init({})).rejects.toThrow();
     });
 
     it("initializes with valid config (international Lark)", async () => {

--- a/test/unit/channels/qq/friday-qq-channel.test.ts
+++ b/test/unit/channels/qq/friday-qq-channel.test.ts
@@ -108,7 +108,8 @@ describe("FridayQqChannel", () => {
 
   describe("init", () => {
     it("validates appId and appSecret are required", async () => {
-      await expect(plugin.init({})).rejects.toThrow("QQ channel requires appId and appSecret");
+      // P1-CH-001: Now uses Zod validation — throws ZodError for missing required fields
+      await expect(plugin.init({})).rejects.toThrow();
     });
 
     it("initializes with valid config", async () => {

--- a/test/unit/workflows/friday-workflow-dag-scheduler.test.ts
+++ b/test/unit/workflows/friday-workflow-dag-scheduler.test.ts
@@ -223,7 +223,7 @@ describe("FridayWorkflowDagScheduler", () => {
     expect(result.deadEndedNodes).toContain("B");
   });
 
-  it("warns when condition evaluation fails and treats the edge as disabled", () => {
+  it("warns when condition evaluation fails and treats the edge as enabled (fail-open)", () => {
     const graph = makeGraph(
       [{ id: "A" }, { id: "B" }],
       [
@@ -250,8 +250,9 @@ describe("FridayWorkflowDagScheduler", () => {
     );
 
     expect(warnSpy).toHaveBeenCalledTimes(1);
-    expect(result.readyNodes).not.toContain("B");
-    expect(result.deadEndedNodes).toContain("B");
+    // P2-WF-001: Changed from fail-disabled to fail-open — B should now be ready
+    expect(result.readyNodes).toContain("B");
+    expect(result.deadEndedNodes).not.toContain("B");
   });
 
   it("entry nodes computation", () => {


### PR DESCRIPTION
## Summary
- cherry-pick `3f7e10e` from local `serene-chaum`
- land the comprehensive audit remediation on top of current `main`
- explicitly exclude the uncommitted `pnpm-lock.yaml` drift in the `serene-chaum` worktree

## Validation
- npm run -s lint
- npm run -s typecheck
- npm run -s build:api
- npx vitest run test/contracts/api/friday-api-route-contract.snapshot.test.ts test/unit/api/auth/friday-auth-service.test.ts test/unit/api/runtime/friday-api-runtime-workflow-generator-registration.test.ts test/unit/channels/lark/friday-lark-channel.test.ts test/unit/channels/qq/friday-qq-channel.test.ts test/unit/workflows/friday-workflow-dag-scheduler.test.ts

## Notes
- source branch for the committed change is local-only `serene-chaum`
- the dirty `pnpm-lock.yaml` in `/Users/jarvis/.claude-worktrees/Friday/serene-chaum` is intentionally not part of this PR