### PR TITLE
feat(learning+agent): add expected utility calculator and tool call s…

### DIFF
--- a/src/agent/model/friday-agent.types.ts
+++ b/src/agent/model/friday-agent.types.ts
@@ -1,5 +1,6 @@
 import type { FridayResolvedAgentTaskProfile } from "../runtime/friday-agent-task-profile.js";
 import type { FridayAgentContextCostSummary } from "../runtime/friday-agent-runtime.types.js";
+import type { FridayToolCallSummary } from "../services/friday-tool-call-summary.js";
 
 // ─── Agent run status ───
 
@@ -364,6 +365,8 @@ export interface FridayAgentToolEndPayload {
   errorCode?: string;
   routeId?: string;
   correlationId?: string;
+  /** Lightweight tool call classification for execution trace data collection. */
+  toolCallSummary?: FridayToolCallSummary;
 }
 
 export interface FridayAgentRunCompletedPayload {

--- a/src/agent/runtime/friday-agent-runtime.ts
+++ b/src/agent/runtime/friday-agent-runtime.ts
@@ -49,6 +49,7 @@ import { shouldDelegateFridayAgentTask } from "./friday-agent-delegation-policy.
 import { resolveFridayAgentTaskProfile } from "./friday-agent-task-profile.js";
 import { isMutatingToolCall } from "./friday-agent-tool-mutation.js";
 import { getApprovalRequiredReasonForToolCall } from "./friday-agent-tool-risk.js";
+import { summarizeToolCall } from "../services/friday-tool-call-summary.js";
 
 const RULES_EVALUATE_SCOPE = "rules:evaluate";
 const TERMINAL_CONTEXT_ENGINE_STATUSES: ReadonlySet<FridayAgentRunStatus> = new Set([
@@ -3876,6 +3877,7 @@ function buildToolEndEventPayload(params: {
   result: FridayAgentToolResult;
   routeId: string;
   correlationId: string;
+  toolCallSummary?: ReturnType<typeof summarizeToolCall>;
 }): Record<string, unknown> {
   const browserPayload = readBrowserPresentationPayload(params.result);
   return {
@@ -3890,6 +3892,7 @@ function buildToolEndEventPayload(params: {
       : {}),
     routeId: params.result.routeId ?? params.routeId,
     correlationId: params.result.correlationId ?? params.correlationId,
+    ...(params.toolCallSummary ? { toolCallSummary: params.toolCallSummary } : {}),
     ...(typeof browserPayload?.presentationMode === "string"
       ? { presentationMode: browserPayload.presentationMode }
       : {}),
@@ -4069,6 +4072,7 @@ async function executeToolCall(
       result,
       routeId,
       correlationId,
+      toolCallSummary: summarizeToolCall(toolUse.name, toolUse.input, result, 0, 0),
     }));
 
     return {

--- a/src/agent/services/friday-tool-call-summary.ts
+++ b/src/agent/services/friday-tool-call-summary.ts
@@ -1,0 +1,79 @@
+import type { FridayAgentToolResult } from "../model/friday-agent.types.js";
+
+// ─── Summary types ───
+
+export type FridayToolCallOutputShape = "text" | "json" | "error" | "empty";
+export type FridayToolCallCategory =
+  | "read"
+  | "write"
+  | "query"
+  | "mutate"
+  | "navigate"
+  | "other";
+
+export interface FridayToolCallSummary {
+  toolName: string;
+  /** Top-level keys from tool args (no values — avoids leaking sensitive data). */
+  argKeys: string[];
+  resultIsError: boolean;
+  resultLengthChars: number;
+  outputShape: FridayToolCallOutputShape;
+  toolCategory: FridayToolCallCategory;
+  turnIndex: number;
+  toolIndex: number;
+}
+
+// ─── Category classification ───
+
+const READ_TOOLS = new Set(["read", "glob", "grep", "web_fetch", "web_search", "skills_list"]);
+const WRITE_TOOLS = new Set(["write", "edit"]);
+const QUERY_TOOLS = new Set(["system", "todo_read"]);
+const NAVIGATE_TOOLS = new Set(["browser", "canvas", "desktop"]);
+const MUTATE_TOOLS = new Set(["exec", "shell", "skill_run", "workflow_run", "todo_write"]);
+
+function classifyToolCategory(toolName: string): FridayToolCallCategory {
+  if (READ_TOOLS.has(toolName)) return "read";
+  if (WRITE_TOOLS.has(toolName)) return "write";
+  if (QUERY_TOOLS.has(toolName)) return "query";
+  if (NAVIGATE_TOOLS.has(toolName)) return "navigate";
+  if (MUTATE_TOOLS.has(toolName)) return "mutate";
+  return "other";
+}
+
+// ─── Output shape detection ───
+
+function detectOutputShape(result: FridayAgentToolResult): FridayToolCallOutputShape {
+  if (result.isError) return "error";
+  const content = result.content;
+  if (!content || content.trim().length === 0) return "empty";
+  const trimmed = content.trimStart();
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+    return "json";
+  }
+  return "text";
+}
+
+// ─── Public API ───
+
+/**
+ * Produces a lightweight, privacy-safe summary of a tool call.
+ * Pure function — no I/O, no side effects, < 0.1ms.
+ */
+export function summarizeToolCall(
+  toolName: string,
+  args: Record<string, unknown>,
+  result: FridayAgentToolResult,
+  turnIndex: number,
+  toolIndex: number,
+): FridayToolCallSummary {
+  return {
+    toolName,
+    argKeys: Object.keys(args),
+    resultIsError: result.isError ?? false,
+    resultLengthChars: result.content.length,
+    outputShape: detectOutputShape(result),
+    toolCategory: classifyToolCategory(toolName),
+    turnIndex,
+    toolIndex,
+  };
+}

--- a/src/learning/index.ts
+++ b/src/learning/index.ts
@@ -118,6 +118,13 @@ export type { FridayAutoFixPlanService } from "./services/friday-auto-fix-plan-s
 export { createFridayAutoFixRiskAssessmentService } from "./services/friday-auto-fix-risk-assessment-service.js";
 export type { FridayAutoFixRiskAssessmentService } from "./services/friday-auto-fix-risk-assessment-service.js";
 
+export { FridayHeuristicUtilityStrategy } from "./services/friday-expected-utility-calculator.js";
+export type {
+  FridayUtilityInput,
+  FridayUtilityResult,
+  FridayUtilityStrategy,
+} from "./services/friday-expected-utility-calculator.js";
+
 export { createFridayAutoFixExecutionService } from "./services/friday-auto-fix-execution-service.js";
 export type { FridayAutoFixExecutionService, StepExecutor, StepVerifier } from "./services/friday-auto-fix-execution-service.js";
 

--- a/src/learning/model/friday-auto-fix.types.ts
+++ b/src/learning/model/friday-auto-fix.types.ts
@@ -7,6 +7,7 @@ import type {
   JsonValue,
   UUID,
 } from "./friday-learning.types.js";
+import type { FridayUtilityResult } from "../services/friday-expected-utility-calculator.js";
 
 export type FridayAutoFixRiskTier = 0 | 1 | 2;
 export type FridayAutoFixActionStatus = "planned" | "applied" | "rolled_back" | "rejected";
@@ -135,6 +136,8 @@ export interface FridayRiskAssessment {
   reasons: string[];
   requiresApproval: boolean;
   autoApplyAllowed: boolean;
+  /** Expected utility analysis (when available). Informational — does not change existing decisions. */
+  utilityResult?: FridayUtilityResult;
 }
 
 export interface FridayAutoFixExecutionResult {

--- a/src/learning/services/friday-auto-fix-risk-assessment-service.ts
+++ b/src/learning/services/friday-auto-fix-risk-assessment-service.ts
@@ -7,18 +7,27 @@ import type {
   FridayAutoFixStepKind,
   FridayRiskAssessment,
 } from "../model/friday-auto-fix.types.js";
+import {
+  FridayHeuristicUtilityStrategy,
+  type FridayUtilityInput,
+  type FridayUtilityStrategy,
+} from "./friday-expected-utility-calculator.js";
 
 export interface FridayAutoFixRiskAssessmentService {
   assess(input: {
     incident: FridayErrorIncidentEntity;
     plan: FridayAutoFixPlan;
     nowIso: string;
+    /** Diagnosis confidence (0..1). When provided, enables expected utility calculation. */
+    confidence?: number;
   }): FridayRiskAssessment;
 }
 
 export interface CreateAutoFixRiskAssessmentServiceDeps {
   db: FridaySqliteLayer;
   actionRepo: FridayAutoFixActionRepository;
+  /** Pluggable utility strategy. Defaults to FridayHeuristicUtilityStrategy. */
+  utilityStrategy?: FridayUtilityStrategy;
 }
 
 /** Steps that are stateless / safe to auto-apply. */
@@ -43,6 +52,8 @@ const TIER_2_STEPS: Set<FridayAutoFixStepKind> = new Set([
 export function createFridayAutoFixRiskAssessmentService(
   deps: CreateAutoFixRiskAssessmentServiceDeps,
 ): FridayAutoFixRiskAssessmentService {
+  const strategy = deps.utilityStrategy ?? new FridayHeuristicUtilityStrategy();
+
   return {
     assess(input) {
       const { incident, plan, nowIso } = input;
@@ -111,11 +122,27 @@ export function createFridayAutoFixRiskAssessmentService(
         reasons.push("Stateless remediation — safe to auto-apply");
       }
 
+      // Compute expected utility when confidence is available
+      const confidence = input.confidence;
+      let utilityResult: FridayRiskAssessment["utilityResult"];
+      if (confidence !== undefined) {
+        const recurrence = plan.evidence.recurrenceCount;
+        const utilityInput: FridayUtilityInput = {
+          riskTier,
+          confidence,
+          predictedSuccessProb: confidence,
+          estimatedBenefitScore: Math.min(1, Math.log2(1 + recurrence) / 5),
+          estimatedCostScore: riskTier / 2,
+        };
+        utilityResult = strategy.compute(utilityInput);
+      }
+
       return {
         riskTier,
         reasons,
         requiresApproval,
         autoApplyAllowed,
+        utilityResult,
       };
     },
   };

--- a/src/learning/services/friday-expected-utility-calculator.ts
+++ b/src/learning/services/friday-expected-utility-calculator.ts
@@ -1,0 +1,71 @@
+import type { FridayAutoFixRiskTier } from "../model/friday-auto-fix.types.js";
+
+// ─── Input / Output types ───
+
+export interface FridayUtilityInput {
+  /** Risk tier from auto-fix assessment (0 = safe, 1 = needs rollback, 2 = needs approval). */
+  riskTier: FridayAutoFixRiskTier;
+  /** Diagnosis confidence (0..1). */
+  confidence: number;
+  /** Predicted probability of fix success (0..1). Initially equals confidence. */
+  predictedSuccessProb: number;
+  /** Estimated benefit of fixing this issue (0..1). Initially = normalize(recurrenceCount). */
+  estimatedBenefitScore: number;
+  /** Estimated cost of attempting the fix (0..1). Initially = riskTier / 2. */
+  estimatedCostScore: number;
+}
+
+export interface FridayUtilityResult {
+  /** Expected utility score (roughly -1..1). */
+  expectedUtility: number;
+  /** Action recommendation based on utility. */
+  recommendation: "auto_apply" | "suggest" | "defer";
+  /** Human-readable reasoning string for observability. */
+  reasoning: string;
+}
+
+// ─── Strategy interface (pluggable for future ML models) ───
+
+export interface FridayUtilityStrategy {
+  compute(input: FridayUtilityInput): FridayUtilityResult;
+}
+
+// ─── Default heuristic strategy ───
+
+/**
+ * Computes expected utility using a simple benefit/cost model:
+ *
+ *   EU = benefit × P(success) - cost × P(failure) - riskPenalty
+ *
+ * This is intentionally simple — the interface is designed so a trained model
+ * can replace this class without changing any callers.
+ */
+export class FridayHeuristicUtilityStrategy implements FridayUtilityStrategy {
+  compute(input: FridayUtilityInput): FridayUtilityResult {
+    const eu =
+      input.estimatedBenefitScore * input.predictedSuccessProb -
+      input.estimatedCostScore * (1 - input.predictedSuccessProb);
+    const riskPenalty = input.riskTier * 0.15;
+    const adjusted = eu - riskPenalty;
+
+    let recommendation: FridayUtilityResult["recommendation"];
+    if (adjusted > 0.3) {
+      recommendation = "auto_apply";
+    } else if (adjusted > 0) {
+      recommendation = "suggest";
+    } else {
+      recommendation = "defer";
+    }
+
+    return {
+      expectedUtility: adjusted,
+      recommendation,
+      reasoning:
+        `EU=${adjusted.toFixed(3)}` +
+        ` (benefit=${input.estimatedBenefitScore.toFixed(2)}` +
+        `, P(success)=${input.predictedSuccessProb.toFixed(2)}` +
+        `, cost=${input.estimatedCostScore.toFixed(2)}` +
+        `, riskPenalty=${riskPenalty.toFixed(2)})`,
+    };
+  }
+}

--- a/test/unit/agent/services/friday-tool-call-summary.test.ts
+++ b/test/unit/agent/services/friday-tool-call-summary.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from "vitest";
+import {
+  summarizeToolCall,
+  type FridayToolCallSummary,
+} from "../../../../src/agent/services/friday-tool-call-summary.js";
+import type { FridayAgentToolResult } from "../../../../src/agent/model/friday-agent.types.js";
+
+function makeResult(overrides: Partial<FridayAgentToolResult> = {}): FridayAgentToolResult {
+  return {
+    content: "some result text",
+    ...overrides,
+  };
+}
+
+describe("summarizeToolCall", () => {
+  describe("toolCategory classification", () => {
+    it("classifies read tools", () => {
+      for (const tool of ["read", "glob", "grep", "web_fetch", "web_search", "skills_list"]) {
+        const summary = summarizeToolCall(tool, {}, makeResult(), 0, 0);
+        expect(summary.toolCategory).toBe("read");
+      }
+    });
+
+    it("classifies write tools", () => {
+      for (const tool of ["write", "edit"]) {
+        const summary = summarizeToolCall(tool, {}, makeResult(), 0, 0);
+        expect(summary.toolCategory).toBe("write");
+      }
+    });
+
+    it("classifies query tools", () => {
+      for (const tool of ["system", "todo_read"]) {
+        const summary = summarizeToolCall(tool, {}, makeResult(), 0, 0);
+        expect(summary.toolCategory).toBe("query");
+      }
+    });
+
+    it("classifies navigate tools", () => {
+      for (const tool of ["browser", "canvas", "desktop"]) {
+        const summary = summarizeToolCall(tool, {}, makeResult(), 0, 0);
+        expect(summary.toolCategory).toBe("navigate");
+      }
+    });
+
+    it("classifies mutate tools", () => {
+      for (const tool of ["exec", "shell", "skill_run", "workflow_run", "todo_write"]) {
+        const summary = summarizeToolCall(tool, {}, makeResult(), 0, 0);
+        expect(summary.toolCategory).toBe("mutate");
+      }
+    });
+
+    it("classifies unknown tools as other", () => {
+      const summary = summarizeToolCall("some_custom_tool", {}, makeResult(), 0, 0);
+      expect(summary.toolCategory).toBe("other");
+    });
+  });
+
+  describe("outputShape detection", () => {
+    it("detects error shape", () => {
+      const summary = summarizeToolCall("read", {}, makeResult({ isError: true, content: "error message" }), 0, 0);
+      expect(summary.outputShape).toBe("error");
+    });
+
+    it("detects empty shape", () => {
+      const summary = summarizeToolCall("read", {}, makeResult({ content: "" }), 0, 0);
+      expect(summary.outputShape).toBe("empty");
+    });
+
+    it("detects empty shape for whitespace-only content", () => {
+      const summary = summarizeToolCall("read", {}, makeResult({ content: "   \n  " }), 0, 0);
+      expect(summary.outputShape).toBe("empty");
+    });
+
+    it("detects json shape for object content", () => {
+      const summary = summarizeToolCall("read", {}, makeResult({ content: '{"key": "value"}' }), 0, 0);
+      expect(summary.outputShape).toBe("json");
+    });
+
+    it("detects json shape for array content", () => {
+      const summary = summarizeToolCall("read", {}, makeResult({ content: '[1, 2, 3]' }), 0, 0);
+      expect(summary.outputShape).toBe("json");
+    });
+
+    it("detects json shape with leading whitespace", () => {
+      const summary = summarizeToolCall("read", {}, makeResult({ content: '  {"key": "value"}' }), 0, 0);
+      expect(summary.outputShape).toBe("json");
+    });
+
+    it("detects text shape for plain text", () => {
+      const summary = summarizeToolCall("read", {}, makeResult({ content: "Hello world" }), 0, 0);
+      expect(summary.outputShape).toBe("text");
+    });
+  });
+
+  describe("argKeys extraction", () => {
+    it("extracts top-level keys from args", () => {
+      const summary = summarizeToolCall("exec", { command: "ls", cwd: "/tmp" }, makeResult(), 0, 0);
+      expect(summary.argKeys).toEqual(["command", "cwd"]);
+    });
+
+    it("returns empty array for empty args", () => {
+      const summary = summarizeToolCall("read", {}, makeResult(), 0, 0);
+      expect(summary.argKeys).toEqual([]);
+    });
+
+    it("does not include values in argKeys", () => {
+      const summary = summarizeToolCall("exec", { secret: "my-api-key-123" }, makeResult(), 0, 0);
+      expect(summary.argKeys).toEqual(["secret"]);
+      expect(JSON.stringify(summary)).not.toContain("my-api-key-123");
+    });
+  });
+
+  describe("metadata fields", () => {
+    it("captures tool name", () => {
+      const summary = summarizeToolCall("browser", {}, makeResult(), 0, 0);
+      expect(summary.toolName).toBe("browser");
+    });
+
+    it("captures resultIsError", () => {
+      const ok = summarizeToolCall("read", {}, makeResult({ isError: false }), 0, 0);
+      expect(ok.resultIsError).toBe(false);
+
+      const err = summarizeToolCall("read", {}, makeResult({ isError: true }), 0, 0);
+      expect(err.resultIsError).toBe(true);
+    });
+
+    it("defaults resultIsError to false when undefined", () => {
+      const summary = summarizeToolCall("read", {}, makeResult({ isError: undefined }), 0, 0);
+      expect(summary.resultIsError).toBe(false);
+    });
+
+    it("captures resultLengthChars", () => {
+      const summary = summarizeToolCall("read", {}, makeResult({ content: "abc" }), 0, 0);
+      expect(summary.resultLengthChars).toBe(3);
+    });
+
+    it("captures turnIndex and toolIndex", () => {
+      const summary = summarizeToolCall("read", {}, makeResult(), 5, 3);
+      expect(summary.turnIndex).toBe(5);
+      expect(summary.toolIndex).toBe(3);
+    });
+  });
+});

--- a/test/unit/learning/services/friday-expected-utility-calculator.test.ts
+++ b/test/unit/learning/services/friday-expected-utility-calculator.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from "vitest";
+import {
+  FridayHeuristicUtilityStrategy,
+  type FridayUtilityInput,
+} from "../../../../src/learning/services/friday-expected-utility-calculator.js";
+
+describe("FridayHeuristicUtilityStrategy", () => {
+  const strategy = new FridayHeuristicUtilityStrategy();
+
+  function makeInput(overrides: Partial<FridayUtilityInput> = {}): FridayUtilityInput {
+    return {
+      riskTier: 0,
+      confidence: 0.5,
+      predictedSuccessProb: 0.5,
+      estimatedBenefitScore: 0.5,
+      estimatedCostScore: 0.5,
+      ...overrides,
+    };
+  }
+
+  it("recommends auto_apply for high benefit + high success + low risk", () => {
+    const result = strategy.compute(
+      makeInput({
+        riskTier: 0,
+        confidence: 0.9,
+        predictedSuccessProb: 0.9,
+        estimatedBenefitScore: 0.8,
+        estimatedCostScore: 0.1,
+      }),
+    );
+    expect(result.recommendation).toBe("auto_apply");
+    expect(result.expectedUtility).toBeGreaterThan(0.3);
+  });
+
+  it("recommends defer for low benefit + low success + high risk", () => {
+    const result = strategy.compute(
+      makeInput({
+        riskTier: 2,
+        confidence: 0.2,
+        predictedSuccessProb: 0.2,
+        estimatedBenefitScore: 0.1,
+        estimatedCostScore: 0.8,
+      }),
+    );
+    expect(result.recommendation).toBe("defer");
+    expect(result.expectedUtility).toBeLessThan(0);
+  });
+
+  it("recommends suggest for moderate input", () => {
+    const result = strategy.compute(
+      makeInput({
+        riskTier: 0,
+        confidence: 0.6,
+        predictedSuccessProb: 0.6,
+        estimatedBenefitScore: 0.5,
+        estimatedCostScore: 0.3,
+      }),
+    );
+    expect(result.recommendation).toBe("suggest");
+    expect(result.expectedUtility).toBeGreaterThan(0);
+    expect(result.expectedUtility).toBeLessThanOrEqual(0.3);
+  });
+
+  it("applies risk penalty proportional to tier", () => {
+    const base = makeInput({
+      predictedSuccessProb: 0.7,
+      estimatedBenefitScore: 0.6,
+      estimatedCostScore: 0.2,
+    });
+
+    const tier0 = strategy.compute({ ...base, riskTier: 0 });
+    const tier1 = strategy.compute({ ...base, riskTier: 1 });
+    const tier2 = strategy.compute({ ...base, riskTier: 2 });
+
+    expect(tier0.expectedUtility).toBeGreaterThan(tier1.expectedUtility);
+    expect(tier1.expectedUtility).toBeGreaterThan(tier2.expectedUtility);
+    // Each tier step adds 0.15 penalty
+    expect(tier0.expectedUtility - tier1.expectedUtility).toBeCloseTo(0.15, 5);
+    expect(tier1.expectedUtility - tier2.expectedUtility).toBeCloseTo(0.15, 5);
+  });
+
+  it("handles all-zero input", () => {
+    const result = strategy.compute(
+      makeInput({
+        riskTier: 0,
+        confidence: 0,
+        predictedSuccessProb: 0,
+        estimatedBenefitScore: 0,
+        estimatedCostScore: 0,
+      }),
+    );
+    expect(result.expectedUtility).toBe(0);
+    expect(result.recommendation).toBe("defer");
+  });
+
+  it("handles all-max input (tier 0)", () => {
+    const result = strategy.compute(
+      makeInput({
+        riskTier: 0,
+        confidence: 1,
+        predictedSuccessProb: 1,
+        estimatedBenefitScore: 1,
+        estimatedCostScore: 0,
+      }),
+    );
+    // EU = 1*1 - 0*0 - 0 = 1
+    expect(result.expectedUtility).toBe(1);
+    expect(result.recommendation).toBe("auto_apply");
+  });
+
+  it("handles worst case input (tier 2, all against)", () => {
+    const result = strategy.compute(
+      makeInput({
+        riskTier: 2,
+        confidence: 0,
+        predictedSuccessProb: 0,
+        estimatedBenefitScore: 0,
+        estimatedCostScore: 1,
+      }),
+    );
+    // EU = 0*0 - 1*1 - 0.3 = -1.3
+    expect(result.expectedUtility).toBe(-1.3);
+    expect(result.recommendation).toBe("defer");
+  });
+
+  it("includes reasoning string with all components", () => {
+    const result = strategy.compute(
+      makeInput({
+        riskTier: 1,
+        predictedSuccessProb: 0.7,
+        estimatedBenefitScore: 0.5,
+        estimatedCostScore: 0.3,
+      }),
+    );
+    expect(result.reasoning).toContain("EU=");
+    expect(result.reasoning).toContain("benefit=");
+    expect(result.reasoning).toContain("P(success)=");
+    expect(result.reasoning).toContain("cost=");
+    expect(result.reasoning).toContain("riskPenalty=");
+  });
+
+  it("implements FridayUtilityStrategy interface correctly", () => {
+    // Verify the strategy can be used polymorphically
+    const compute = (s: { compute: typeof strategy.compute }) =>
+      s.compute(makeInput());
+    const result = compute(strategy);
+    expect(result).toHaveProperty("expectedUtility");
+    expect(result).toHaveProperty("recommendation");
+    expect(result).toHaveProperty("reasoning");
+  });
+});


### PR DESCRIPTION
…ummary for world model prep

Add pluggable FridayUtilityStrategy interface with FridayHeuristicUtilityStrategy default implementation. The risk assessment service now computes expected utility (EU = benefit × P(success)
- cost × P(failure) - riskPenalty) when confidence is provided, attached as optional utilityResult on FridayRiskAssessment. Extend agent.run.tool_end event payload with lightweight FridayToolCallSummary (toolCategory, outputShape, argKeys) for execution trace data collection — no new tables, no new SQLite transactions, zero impact on existing behavior.

## Summary

<!-- Brief description of what this PR does -->

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would break existing functionality)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor / cleanup
- [ ] 🛡️ Security fix

## Checklist

### Required
- [ ] Tests added/updated for changed behavior
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] `npm test` passes

### If Applicable
- [ ] Migration added → migration chain is contiguous (`npm run check:migrations`)
- [ ] SSD updated → markers present (`npm run check:ssd`)
- [ ] Adversarial tests not skipped (`npm run check:adversarial`)
- [ ] API surface changed → routes documented in SSD
- [ ] Security-sensitive change → adversarial test added

### Documentation
- [ ] SSD (`docs/distributed-architecture.md`) updated if architecture changed
- [ ] README updated if user-facing behavior changed
- [ ] CHANGELOG entry added

## Related Issues

<!-- Link to related issues: Fixes #123, Closes #456 -->
