### PR TITLE
fix: stabilize friday non-cloud runtime and warning surfaces

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,10 +91,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -499,7 +495,7 @@
         "filename": "test/contracts/api/friday-api-route-contract.snapshot.test.ts",
         "hashed_secret": "935276cbfc4662c63a33092dbe3e9f6fce4f77dd",
         "is_verified": false,
-        "line_number": 59
+        "line_number": 58
       }
     ],
     "test/e2e/api/_helpers/friday-api-test-server.helper.ts": [
@@ -569,14 +565,14 @@
         "filename": "test/unit/agent/runtime/friday-agent-llm-client.test.ts",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 44
+        "line_number": 59
       },
       {
         "type": "Secret Keyword",
         "filename": "test/unit/agent/runtime/friday-agent-llm-client.test.ts",
         "hashed_secret": "48854c46907b8f99e4c4c711f3fb7336a93bc290",
         "is_verified": false,
-        "line_number": 130
+        "line_number": 145
       }
     ],
     "test/unit/api/auth/friday-auth-middleware.test.ts": [
@@ -663,28 +659,28 @@
         "filename": "test/unit/api/auth/friday-auth-service.test.ts",
         "hashed_secret": "ce77798dc40945979f340e376e69b0d043c1e1e0",
         "is_verified": false,
-        "line_number": 466
+        "line_number": 528
       },
       {
         "type": "Secret Keyword",
         "filename": "test/unit/api/auth/friday-auth-service.test.ts",
         "hashed_secret": "05d83970b7ed1c839f218a5f611ed5ed89a43148",
         "is_verified": false,
-        "line_number": 486
+        "line_number": 548
       },
       {
         "type": "Secret Keyword",
         "filename": "test/unit/api/auth/friday-auth-service.test.ts",
         "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
         "is_verified": false,
-        "line_number": 513
+        "line_number": 575
       },
       {
         "type": "Secret Keyword",
         "filename": "test/unit/api/auth/friday-auth-service.test.ts",
         "hashed_secret": "1902e3d6fc4e78a0bcc50ba12b882769afbf4a8c",
         "is_verified": false,
-        "line_number": 653
+        "line_number": 715
       }
     ],
     "test/unit/api/auth/friday-token-validator.test.ts": [
@@ -863,22 +859,6 @@
         "line_number": 6
       }
     ],
-    "test/unit/converter/compat/engine/diagnostics.test.ts": [
-      {
-        "type": "GitHub Token",
-        "filename": "test/unit/converter/compat/engine/diagnostics.test.ts",
-        "hashed_secret": "e175c6f5f2a92e8623bd9a4820edb4e8c1b0fd10",
-        "is_verified": false,
-        "line_number": 32
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "test/unit/converter/compat/engine/diagnostics.test.ts",
-        "hashed_secret": "912c9895d71221ffe340e016d4ebc566dcdf5424",
-        "is_verified": false,
-        "line_number": 40
-      }
-    ],
     "test/unit/hub/friday-hub-bootstrap-env.test.ts": [
       {
         "type": "Secret Keyword",
@@ -1049,5 +1029,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-27T04:58:16Z"
+  "generated_at": "2026-03-27T21:50:47Z"
 }

--- a/docs/reports/closeout/final-non-platform/latest.json
+++ b/docs/reports/closeout/final-non-platform/latest.json
@@ -1,15 +1,15 @@
 {
   "status": "passed",
-  "gitHead": "bdc4b5f",
-  "generatedAt": "2026-03-27T16:54:16.324Z",
+  "gitHead": "33d4cf2",
+  "generatedAt": "2026-03-27T21:45:35.679Z",
   "title": "Non-Platform Final Closeout",
   "notes": [
     "All non-platform closeout gates passed."
   ],
   "metrics": {
     "stepCount": "9",
-    "startedAt": "2026-03-27T16:50:31.805Z",
-    "completedAt": "2026-03-27T16:54:16.324Z"
+    "startedAt": "2026-03-27T21:41:52.143Z",
+    "completedAt": "2026-03-27T21:45:35.679Z"
   },
   "steps": [
     {
@@ -18,8 +18,8 @@
       "status": "passed",
       "exitCode": 0,
       "signal": null,
-      "startedAt": "2026-03-27T16:50:31.806Z",
-      "finishedAt": "2026-03-27T16:53:47.650Z"
+      "startedAt": "2026-03-27T21:41:52.145Z",
+      "finishedAt": "2026-03-27T21:45:07.294Z"
     },
     {
       "label": "Phase 1 closeout",
@@ -27,8 +27,8 @@
       "status": "passed",
       "exitCode": 0,
       "signal": null,
-      "startedAt": "2026-03-27T16:53:47.650Z",
-      "finishedAt": "2026-03-27T16:53:56.133Z"
+      "startedAt": "2026-03-27T21:45:07.294Z",
+      "finishedAt": "2026-03-27T21:45:15.796Z"
     },
     {
       "label": "Phase 2 closeout",
@@ -36,8 +36,8 @@
       "status": "passed",
       "exitCode": 0,
       "signal": null,
-      "startedAt": "2026-03-27T16:53:56.133Z",
-      "finishedAt": "2026-03-27T16:54:01.550Z"
+      "startedAt": "2026-03-27T21:45:15.796Z",
+      "finishedAt": "2026-03-27T21:45:20.972Z"
     },
     {
       "label": "Phase 3 closeout",
@@ -45,8 +45,8 @@
       "status": "passed",
       "exitCode": 0,
       "signal": null,
-      "startedAt": "2026-03-27T16:54:01.550Z",
-      "finishedAt": "2026-03-27T16:54:05.737Z"
+      "startedAt": "2026-03-27T21:45:20.973Z",
+      "finishedAt": "2026-03-27T21:45:25.093Z"
     },
     {
       "label": "Phase 4 closeout",
@@ -54,8 +54,8 @@
       "status": "passed",
       "exitCode": 0,
       "signal": null,
-      "startedAt": "2026-03-27T16:54:05.737Z",
-      "finishedAt": "2026-03-27T16:54:08.049Z"
+      "startedAt": "2026-03-27T21:45:25.093Z",
+      "finishedAt": "2026-03-27T21:45:27.416Z"
     },
     {
       "label": "Phase 5 closeout",
@@ -63,8 +63,8 @@
       "status": "passed",
       "exitCode": 0,
       "signal": null,
-      "startedAt": "2026-03-27T16:54:08.049Z",
-      "finishedAt": "2026-03-27T16:54:10.923Z"
+      "startedAt": "2026-03-27T21:45:27.416Z",
+      "finishedAt": "2026-03-27T21:45:30.248Z"
     },
     {
       "label": "Marketplace closeout",
@@ -72,8 +72,8 @@
       "status": "passed",
       "exitCode": 0,
       "signal": null,
-      "startedAt": "2026-03-27T16:54:10.923Z",
-      "finishedAt": "2026-03-27T16:54:16.109Z"
+      "startedAt": "2026-03-27T21:45:30.248Z",
+      "finishedAt": "2026-03-27T21:45:35.478Z"
     },
     {
       "label": "UI bundle health",
@@ -81,8 +81,8 @@
       "status": "passed",
       "exitCode": 0,
       "signal": null,
-      "startedAt": "2026-03-27T16:54:16.109Z",
-      "finishedAt": "2026-03-27T16:54:16.206Z"
+      "startedAt": "2026-03-27T21:45:35.478Z",
+      "finishedAt": "2026-03-27T21:45:35.577Z"
     },
     {
       "label": "Final truth audit",
@@ -90,8 +90,8 @@
       "status": "passed",
       "exitCode": 0,
       "signal": null,
-      "startedAt": "2026-03-27T16:54:16.206Z",
-      "finishedAt": "2026-03-27T16:54:16.324Z"
+      "startedAt": "2026-03-27T21:45:35.578Z",
+      "finishedAt": "2026-03-27T21:45:35.679Z"
     }
   ]
 }

--- a/docs/reports/closeout/final-non-platform/latest.md
+++ b/docs/reports/closeout/final-non-platform/latest.md
@@ -1,8 +1,8 @@
 # Non-Platform Final Closeout
 
 - Status: passed
-- Git SHA: bdc4b5f
-- Generated At: 2026-03-27T16:54:16.324Z
+- Git SHA: 33d4cf2
+- Generated At: 2026-03-27T21:45:35.679Z
 - Notes:
   - All non-platform closeout gates passed.
 
@@ -11,51 +11,51 @@
 - Release verify: passed
   - Command: `npm run release:verify`
   - Exit Code: 0
-  - Started At: 2026-03-27T16:50:31.806Z
-  - Finished At: 2026-03-27T16:53:47.650Z
+  - Started At: 2026-03-27T21:41:52.145Z
+  - Finished At: 2026-03-27T21:45:07.294Z
 - Phase 1 closeout: passed
   - Command: `npm run closeout:phase1`
   - Exit Code: 0
-  - Started At: 2026-03-27T16:53:47.650Z
-  - Finished At: 2026-03-27T16:53:56.133Z
+  - Started At: 2026-03-27T21:45:07.294Z
+  - Finished At: 2026-03-27T21:45:15.796Z
 - Phase 2 closeout: passed
   - Command: `npm run closeout:phase2`
   - Exit Code: 0
-  - Started At: 2026-03-27T16:53:56.133Z
-  - Finished At: 2026-03-27T16:54:01.550Z
+  - Started At: 2026-03-27T21:45:15.796Z
+  - Finished At: 2026-03-27T21:45:20.972Z
 - Phase 3 closeout: passed
   - Command: `npm run closeout:phase3`
   - Exit Code: 0
-  - Started At: 2026-03-27T16:54:01.550Z
-  - Finished At: 2026-03-27T16:54:05.737Z
+  - Started At: 2026-03-27T21:45:20.973Z
+  - Finished At: 2026-03-27T21:45:25.093Z
 - Phase 4 closeout: passed
   - Command: `npm run closeout:phase4`
   - Exit Code: 0
-  - Started At: 2026-03-27T16:54:05.737Z
-  - Finished At: 2026-03-27T16:54:08.049Z
+  - Started At: 2026-03-27T21:45:25.093Z
+  - Finished At: 2026-03-27T21:45:27.416Z
 - Phase 5 closeout: passed
   - Command: `npm run closeout:phase5`
   - Exit Code: 0
-  - Started At: 2026-03-27T16:54:08.049Z
-  - Finished At: 2026-03-27T16:54:10.923Z
+  - Started At: 2026-03-27T21:45:27.416Z
+  - Finished At: 2026-03-27T21:45:30.248Z
 - Marketplace closeout: passed
   - Command: `npm run closeout:marketplace`
   - Exit Code: 0
-  - Started At: 2026-03-27T16:54:10.923Z
-  - Finished At: 2026-03-27T16:54:16.109Z
+  - Started At: 2026-03-27T21:45:30.248Z
+  - Finished At: 2026-03-27T21:45:35.478Z
 - UI bundle health: passed
   - Command: `npm run check:ui-bundle-health`
   - Exit Code: 0
-  - Started At: 2026-03-27T16:54:16.109Z
-  - Finished At: 2026-03-27T16:54:16.206Z
+  - Started At: 2026-03-27T21:45:35.478Z
+  - Finished At: 2026-03-27T21:45:35.577Z
 - Final truth audit: passed
   - Command: `npm run check:closeout:truth:final`
   - Exit Code: 0
-  - Started At: 2026-03-27T16:54:16.206Z
-  - Finished At: 2026-03-27T16:54:16.324Z
+  - Started At: 2026-03-27T21:45:35.578Z
+  - Finished At: 2026-03-27T21:45:35.679Z
 
 ## Metrics
 
 - stepCount: 9
-- startedAt: 2026-03-27T16:50:31.805Z
-- completedAt: 2026-03-27T16:54:16.324Z
+- startedAt: 2026-03-27T21:41:52.143Z
+- completedAt: 2026-03-27T21:45:35.679Z

--- a/docs/reports/closeout/marketplace-creator-ecosystem/latest.json
+++ b/docs/reports/closeout/marketplace-creator-ecosystem/latest.json
@@ -1,15 +1,15 @@
 {
   "status": "passed",
-  "gitHead": "bdc4b5f",
-  "generatedAt": "2026-03-27T16:54:16.093Z",
+  "gitHead": "33d4cf2",
+  "generatedAt": "2026-03-27T21:45:35.461Z",
   "title": "Marketplace Creator Ecosystem",
   "notes": [
     "Phase closeout completed successfully for marketplace."
   ],
   "metrics": {
     "stepCount": "3",
-    "startedAt": "2026-03-27T16:54:11.014Z",
-    "completedAt": "2026-03-27T16:54:16.093Z"
+    "startedAt": "2026-03-27T21:45:30.338Z",
+    "completedAt": "2026-03-27T21:45:35.461Z"
   },
   "steps": [
     {
@@ -18,8 +18,8 @@
       "status": "passed",
       "exitCode": 0,
       "signal": null,
-      "startedAt": "2026-03-27T16:54:11.015Z",
-      "finishedAt": "2026-03-27T16:54:13.526Z"
+      "startedAt": "2026-03-27T21:45:30.339Z",
+      "finishedAt": "2026-03-27T21:45:32.863Z"
     },
     {
       "label": "Marketplace closeout pack",
@@ -27,8 +27,8 @@
       "status": "passed",
       "exitCode": 0,
       "signal": null,
-      "startedAt": "2026-03-27T16:54:13.526Z",
-      "finishedAt": "2026-03-27T16:54:15.992Z"
+      "startedAt": "2026-03-27T21:45:32.863Z",
+      "finishedAt": "2026-03-27T21:45:35.356Z"
     },
     {
       "label": "Truth audit",
@@ -36,8 +36,8 @@
       "status": "passed",
       "exitCode": 0,
       "signal": null,
-      "startedAt": "2026-03-27T16:54:15.992Z",
-      "finishedAt": "2026-03-27T16:54:16.093Z"
+      "startedAt": "2026-03-27T21:45:35.356Z",
+      "finishedAt": "2026-03-27T21:45:35.461Z"
     }
   ]
 }

--- a/docs/reports/closeout/marketplace-creator-ecosystem/latest.md
+++ b/docs/reports/closeout/marketplace-creator-ecosystem/latest.md
@@ -1,8 +1,8 @@
 # Marketplace Creator Ecosystem
 
 - Status: passed
-- Git SHA: bdc4b5f
-- Generated At: 2026-03-27T16:54:16.093Z
+- Git SHA: 33d4cf2
+- Generated At: 2026-03-27T21:45:35.461Z
 - Notes:
   - Phase closeout completed successfully for marketplace.
 
@@ -11,21 +11,21 @@
 - Route contracts: passed
   - Command: `npm run test:contracts:routes`
   - Exit Code: 0
-  - Started At: 2026-03-27T16:54:11.015Z
-  - Finished At: 2026-03-27T16:54:13.526Z
+  - Started At: 2026-03-27T21:45:30.339Z
+  - Finished At: 2026-03-27T21:45:32.863Z
 - Marketplace closeout pack: passed
   - Command: `npx vitest run test/unit/api/http/routes/friday-marketplace-asset-routes.test.ts test/unit/api/http/routes/friday-marketplace-creator-routes.test.ts test/unit/api/http/routes/friday-marketplace-request-routes.test.ts test/unit/marketplace/services/friday-marketplace-creator-service.test.ts test/unit/marketplace/services/friday-marketplace-request-board-service.test.ts test/unit/marketplace/engine/install-dispatcher.test.ts test/unit/marketplace/engine/listing-manager.test.ts test/unit/marketplace/engine/publisher-manager.test.ts test/unit/ui/marketplace-view-models.test.ts test/unit/ui/marketplace-click-path.test.ts test/unit/ui/assistant-marketplace-handoff.test.ts test/integration/marketplace/friday-marketplace-install-closure.test.ts test/integration/marketplace/friday-marketplace-install-failure-rollback.test.ts test/integration/marketplace/friday-marketplace-workflow-one-time-run-gate.test.ts`
   - Exit Code: 0
-  - Started At: 2026-03-27T16:54:13.526Z
-  - Finished At: 2026-03-27T16:54:15.992Z
+  - Started At: 2026-03-27T21:45:32.863Z
+  - Finished At: 2026-03-27T21:45:35.356Z
 - Truth audit: passed
   - Command: `npm run check:closeout:truth:marketplace`
   - Exit Code: 0
-  - Started At: 2026-03-27T16:54:15.992Z
-  - Finished At: 2026-03-27T16:54:16.093Z
+  - Started At: 2026-03-27T21:45:35.356Z
+  - Finished At: 2026-03-27T21:45:35.461Z
 
 ## Metrics
 
 - stepCount: 3
-- startedAt: 2026-03-27T16:54:11.014Z
-- completedAt: 2026-03-27T16:54:16.093Z
+- startedAt: 2026-03-27T21:45:30.338Z
+- completedAt: 2026-03-27T21:45:35.461Z

--- a/docs/reports/closeout/phase1-canonical-truth/latest.json
+++ b/docs/reports/closeout/phase1-canonical-truth/latest.json
@@ -1,15 +1,15 @@
 {
   "status": "passed",
-  "gitHead": "bdc4b5f",
-  "generatedAt": "2026-03-27T16:53:56.117Z",
+  "gitHead": "33d4cf2",
+  "generatedAt": "2026-03-27T21:45:15.780Z",
   "title": "Canonical Truth Unification",
   "notes": [
     "Phase closeout completed successfully for phase1."
   ],
   "metrics": {
     "stepCount": "4",
-    "startedAt": "2026-03-27T16:53:47.753Z",
-    "completedAt": "2026-03-27T16:53:56.117Z"
+    "startedAt": "2026-03-27T21:45:07.384Z",
+    "completedAt": "2026-03-27T21:45:15.780Z"
   },
   "steps": [
     {
@@ -18,8 +18,8 @@
       "status": "passed",
       "exitCode": 0,
       "signal": null,
-      "startedAt": "2026-03-27T16:53:47.754Z",
-      "finishedAt": "2026-03-27T16:53:50.242Z"
+      "startedAt": "2026-03-27T21:45:07.386Z",
+      "finishedAt": "2026-03-27T21:45:09.919Z"
     },
     {
       "label": "Type contracts",
@@ -27,8 +27,8 @@
       "status": "passed",
       "exitCode": 0,
       "signal": null,
-      "startedAt": "2026-03-27T16:53:50.242Z",
-      "finishedAt": "2026-03-27T16:53:51.528Z"
+      "startedAt": "2026-03-27T21:45:09.919Z",
+      "finishedAt": "2026-03-27T21:45:11.197Z"
     },
     {
       "label": "Canonical API compatibility pack",
@@ -36,8 +36,8 @@
       "status": "passed",
       "exitCode": 0,
       "signal": null,
-      "startedAt": "2026-03-27T16:53:51.528Z",
-      "finishedAt": "2026-03-27T16:53:56.015Z"
+      "startedAt": "2026-03-27T21:45:11.197Z",
+      "finishedAt": "2026-03-27T21:45:15.660Z"
     },
     {
       "label": "Truth audit",
@@ -45,8 +45,8 @@
       "status": "passed",
       "exitCode": 0,
       "signal": null,
-      "startedAt": "2026-03-27T16:53:56.015Z",
-      "finishedAt": "2026-03-27T16:53:56.117Z"
+      "startedAt": "2026-03-27T21:45:15.660Z",
+      "finishedAt": "2026-03-27T21:45:15.780Z"
     }
   ]
 }

--- a/docs/reports/closeout/phase1-canonical-truth/latest.md
+++ b/docs/reports/closeout/phase1-canonical-truth/latest.md
@@ -1,8 +1,8 @@
 # Canonical Truth Unification
 
 - Status: passed
-- Git SHA: bdc4b5f
-- Generated At: 2026-03-27T16:53:56.117Z
+- Git SHA: 33d4cf2
+- Generated At: 2026-03-27T21:45:15.780Z
 - Notes:
   - Phase closeout completed successfully for phase1.
 
@@ -11,26 +11,26 @@
 - Route contracts: passed
   - Command: `npm run test:contracts:routes`
   - Exit Code: 0
-  - Started At: 2026-03-27T16:53:47.754Z
-  - Finished At: 2026-03-27T16:53:50.242Z
+  - Started At: 2026-03-27T21:45:07.386Z
+  - Finished At: 2026-03-27T21:45:09.919Z
 - Type contracts: passed
   - Command: `npm run test:contracts:types`
   - Exit Code: 0
-  - Started At: 2026-03-27T16:53:50.242Z
-  - Finished At: 2026-03-27T16:53:51.528Z
+  - Started At: 2026-03-27T21:45:09.919Z
+  - Finished At: 2026-03-27T21:45:11.197Z
 - Canonical API compatibility pack: passed
   - Command: `npx vitest run test/e2e/api/friday-api-approvals-routes.test.ts test/e2e/api/friday-api-health-routes.test.ts test/e2e/api/friday-api-sessions-memory-routes.test.ts test/unit/api/realtime/friday-realtime-ws-gateway.test.ts test/unit/api/http/routes/friday-realtime-routes.test.ts test/unit/api/http/routes/friday-health-routes.test.ts test/unit/api/http/routes/friday-session-routes.test.ts`
   - Exit Code: 0
-  - Started At: 2026-03-27T16:53:51.528Z
-  - Finished At: 2026-03-27T16:53:56.015Z
+  - Started At: 2026-03-27T21:45:11.197Z
+  - Finished At: 2026-03-27T21:45:15.660Z
 - Truth audit: passed
   - Command: `npm run check:closeout:truth:phase1`
   - Exit Code: 0
-  - Started At: 2026-03-27T16:53:56.015Z
-  - Finished At: 2026-03-27T16:53:56.117Z
+  - Started At: 2026-03-27T21:45:15.660Z
+  - Finished At: 2026-03-27T21:45:15.780Z
 
 ## Metrics
 
 - stepCount: 4
-- startedAt: 2026-03-27T16:53:47.753Z
-- completedAt: 2026-03-27T16:53:56.117Z
+- startedAt: 2026-03-27T21:45:07.384Z
+- completedAt: 2026-03-27T21:45:15.780Z

--- a/docs/reports/closeout/phase2-fleet-satellite/latest.json
+++ b/docs/reports/closeout/phase2-fleet-satellite/latest.json
@@ -1,15 +1,15 @@
 {
   "status": "passed",
-  "gitHead": "bdc4b5f",
-  "generatedAt": "2026-03-27T16:54:01.534Z",
+  "gitHead": "33d4cf2",
+  "generatedAt": "2026-03-27T21:45:20.957Z",
   "title": "Fleet, Satellites, And Distributed Execution",
   "notes": [
     "Phase closeout completed successfully for phase2."
   ],
   "metrics": {
     "stepCount": "2",
-    "startedAt": "2026-03-27T16:53:56.246Z",
-    "completedAt": "2026-03-27T16:54:01.534Z"
+    "startedAt": "2026-03-27T21:45:15.887Z",
+    "completedAt": "2026-03-27T21:45:20.957Z"
   },
   "steps": [
     {
@@ -18,8 +18,8 @@
       "status": "passed",
       "exitCode": 0,
       "signal": null,
-      "startedAt": "2026-03-27T16:53:56.247Z",
-      "finishedAt": "2026-03-27T16:54:01.437Z"
+      "startedAt": "2026-03-27T21:45:15.888Z",
+      "finishedAt": "2026-03-27T21:45:20.859Z"
     },
     {
       "label": "Truth audit",
@@ -27,8 +27,8 @@
       "status": "passed",
       "exitCode": 0,
       "signal": null,
-      "startedAt": "2026-03-27T16:54:01.437Z",
-      "finishedAt": "2026-03-27T16:54:01.534Z"
+      "startedAt": "2026-03-27T21:45:20.859Z",
+      "finishedAt": "2026-03-27T21:45:20.957Z"
     }
   ]
 }

--- a/docs/reports/closeout/phase2-fleet-satellite/latest.md
+++ b/docs/reports/closeout/phase2-fleet-satellite/latest.md
@@ -1,8 +1,8 @@
 # Fleet, Satellites, And Distributed Execution
 
 - Status: passed
-- Git SHA: bdc4b5f
-- Generated At: 2026-03-27T16:54:01.534Z
+- Git SHA: 33d4cf2
+- Generated At: 2026-03-27T21:45:20.957Z
 - Notes:
   - Phase closeout completed successfully for phase2.
 
@@ -11,16 +11,16 @@
 - Fleet and satellite pack: passed
   - Command: `npx vitest run test/unit/api/http/routes/friday-fleet-routes.test.ts test/unit/api/http/routes/friday-satellite-runtime-routes.test.ts test/unit/api/routes/friday-satellite-pairing-routes.test.ts test/unit/api/fleet/friday-fleet-dashboard-service.test.ts test/unit/satellites/services/friday-satellite-registration-service.test.ts test/unit/satellites/services/friday-satellite-pairing-service.test.ts test/unit/satellites/services/friday-satellite-heartbeat-service.test.ts test/unit/satellites/services/friday-satellite-sync-service.test.ts test/unit/satellites/services/friday-satellite-offline-sweeper.test.ts test/unit/satellites/services/friday-outbox-queue-service.test.ts test/unit/workflows/friday-workflow-execution-service-distributed.test.ts test/unit/workflows/friday-workflow-satellite-dispatch-service.test.ts test/unit/ui/fleet-view-models.test.ts`
   - Exit Code: 0
-  - Started At: 2026-03-27T16:53:56.247Z
-  - Finished At: 2026-03-27T16:54:01.437Z
+  - Started At: 2026-03-27T21:45:15.888Z
+  - Finished At: 2026-03-27T21:45:20.859Z
 - Truth audit: passed
   - Command: `npm run check:closeout:truth:phase2`
   - Exit Code: 0
-  - Started At: 2026-03-27T16:54:01.437Z
-  - Finished At: 2026-03-27T16:54:01.534Z
+  - Started At: 2026-03-27T21:45:20.859Z
+  - Finished At: 2026-03-27T21:45:20.957Z
 
 ## Metrics
 
 - stepCount: 2
-- startedAt: 2026-03-27T16:53:56.246Z
-- completedAt: 2026-03-27T16:54:01.534Z
+- startedAt: 2026-03-27T21:45:15.887Z
+- completedAt: 2026-03-27T21:45:20.957Z

--- a/docs/reports/closeout/phase3-autonomous-loop/latest.json
+++ b/docs/reports/closeout/phase3-autonomous-loop/latest.json
@@ -1,15 +1,15 @@
 {
   "status": "passed",
-  "gitHead": "bdc4b5f",
-  "generatedAt": "2026-03-27T16:54:05.721Z",
+  "gitHead": "33d4cf2",
+  "generatedAt": "2026-03-27T21:45:25.075Z",
   "title": "Autonomous Loop v2",
   "notes": [
     "Phase closeout completed successfully for phase3."
   ],
   "metrics": {
     "stepCount": "2",
-    "startedAt": "2026-03-27T16:54:01.642Z",
-    "completedAt": "2026-03-27T16:54:05.721Z"
+    "startedAt": "2026-03-27T21:45:21.062Z",
+    "completedAt": "2026-03-27T21:45:25.075Z"
   },
   "steps": [
     {
@@ -18,8 +18,8 @@
       "status": "passed",
       "exitCode": 0,
       "signal": null,
-      "startedAt": "2026-03-27T16:54:01.643Z",
-      "finishedAt": "2026-03-27T16:54:05.620Z"
+      "startedAt": "2026-03-27T21:45:21.064Z",
+      "finishedAt": "2026-03-27T21:45:24.973Z"
     },
     {
       "label": "Truth audit",
@@ -27,8 +27,8 @@
       "status": "passed",
       "exitCode": 0,
       "signal": null,
-      "startedAt": "2026-03-27T16:54:05.621Z",
-      "finishedAt": "2026-03-27T16:54:05.721Z"
+      "startedAt": "2026-03-27T21:45:24.973Z",
+      "finishedAt": "2026-03-27T21:45:25.075Z"
     }
   ]
 }

--- a/docs/reports/closeout/phase3-autonomous-loop/latest.md
+++ b/docs/reports/closeout/phase3-autonomous-loop/latest.md
@@ -1,8 +1,8 @@
 # Autonomous Loop v2
 
 - Status: passed
-- Git SHA: bdc4b5f
-- Generated At: 2026-03-27T16:54:05.721Z
+- Git SHA: 33d4cf2
+- Generated At: 2026-03-27T21:45:25.075Z
 - Notes:
   - Phase closeout completed successfully for phase3.
 
@@ -11,16 +11,16 @@
 - Autonomous loop pack: passed
   - Command: `npx vitest run test/unit/api/http/routes/friday-agent-loop-routes.test.ts test/unit/api/http/routes/friday-diagnosis-routes.test.ts test/unit/api/http/routes/friday-auto-fix-routes.test.ts test/unit/api/http/routes/friday-uix-routes.test.ts test/unit/learning/services/friday-agent-loop-service.test.ts test/unit/learning/services/friday-auto-fix-plan-service.test.ts test/unit/learning/services/friday-auto-fix-execution-service.test.ts test/unit/learning/services/friday-auto-fix-risk-assessment-service.test.ts test/unit/uix/services/friday-uix-surface-service.test.ts test/unit/ui/assistant-view-models.test.ts test/e2e/api/friday-api-self-healing-routes.test.ts`
   - Exit Code: 0
-  - Started At: 2026-03-27T16:54:01.643Z
-  - Finished At: 2026-03-27T16:54:05.620Z
+  - Started At: 2026-03-27T21:45:21.064Z
+  - Finished At: 2026-03-27T21:45:24.973Z
 - Truth audit: passed
   - Command: `npm run check:closeout:truth:phase3`
   - Exit Code: 0
-  - Started At: 2026-03-27T16:54:05.621Z
-  - Finished At: 2026-03-27T16:54:05.721Z
+  - Started At: 2026-03-27T21:45:24.973Z
+  - Finished At: 2026-03-27T21:45:25.075Z
 
 ## Metrics
 
 - stepCount: 2
-- startedAt: 2026-03-27T16:54:01.642Z
-- completedAt: 2026-03-27T16:54:05.721Z
+- startedAt: 2026-03-27T21:45:21.062Z
+- completedAt: 2026-03-27T21:45:25.075Z

--- a/docs/reports/closeout/phase4-acceptance-retry-rules/latest.json
+++ b/docs/reports/closeout/phase4-acceptance-retry-rules/latest.json
@@ -1,15 +1,15 @@
 {
   "status": "passed",
-  "gitHead": "bdc4b5f",
-  "generatedAt": "2026-03-27T16:54:08.033Z",
+  "gitHead": "33d4cf2",
+  "generatedAt": "2026-03-27T21:45:27.401Z",
   "title": "Acceptance, Retry, And Rules Operations",
   "notes": [
     "Phase closeout completed successfully for phase4."
   ],
   "metrics": {
     "stepCount": "2",
-    "startedAt": "2026-03-27T16:54:05.828Z",
-    "completedAt": "2026-03-27T16:54:08.033Z"
+    "startedAt": "2026-03-27T21:45:25.188Z",
+    "completedAt": "2026-03-27T21:45:27.401Z"
   },
   "steps": [
     {
@@ -18,8 +18,8 @@
       "status": "passed",
       "exitCode": 0,
       "signal": null,
-      "startedAt": "2026-03-27T16:54:05.829Z",
-      "finishedAt": "2026-03-27T16:54:07.935Z"
+      "startedAt": "2026-03-27T21:45:25.189Z",
+      "finishedAt": "2026-03-27T21:45:27.304Z"
     },
     {
       "label": "Truth audit",
@@ -27,8 +27,8 @@
       "status": "passed",
       "exitCode": 0,
       "signal": null,
-      "startedAt": "2026-03-27T16:54:07.935Z",
-      "finishedAt": "2026-03-27T16:54:08.033Z"
+      "startedAt": "2026-03-27T21:45:27.304Z",
+      "finishedAt": "2026-03-27T21:45:27.401Z"
     }
   ]
 }

--- a/docs/reports/closeout/phase4-acceptance-retry-rules/latest.md
+++ b/docs/reports/closeout/phase4-acceptance-retry-rules/latest.md
@@ -1,8 +1,8 @@
 # Acceptance, Retry, And Rules Operations
 
 - Status: passed
-- Git SHA: bdc4b5f
-- Generated At: 2026-03-27T16:54:08.033Z
+- Git SHA: 33d4cf2
+- Generated At: 2026-03-27T21:45:27.401Z
 - Notes:
   - Phase closeout completed successfully for phase4.
 
@@ -11,16 +11,16 @@
 - Acceptance, retry, and rules pack: passed
   - Command: `npx vitest run test/integration/acceptance/friday-acceptance-gate-integration.test.ts test/integration/retry/friday-production-retry-bridge.test.ts test/integration/rules/friday-rules-persistence.test.ts test/unit/acceptance/engine/assertion-engine.test.ts test/unit/retry/engine/circuit-breaker.test.ts test/unit/rules/engine/rule-engine.test.ts test/unit/rules/engine/dsl-parser.test.ts test/unit/observability/services/friday-observability-api-service.test.ts test/unit/api/http/routes/friday-observability-routes.test.ts test/unit/observability/engine/dashboard-data-provider.test.ts`
   - Exit Code: 0
-  - Started At: 2026-03-27T16:54:05.829Z
-  - Finished At: 2026-03-27T16:54:07.935Z
+  - Started At: 2026-03-27T21:45:25.189Z
+  - Finished At: 2026-03-27T21:45:27.304Z
 - Truth audit: passed
   - Command: `npm run check:closeout:truth:phase4`
   - Exit Code: 0
-  - Started At: 2026-03-27T16:54:07.935Z
-  - Finished At: 2026-03-27T16:54:08.033Z
+  - Started At: 2026-03-27T21:45:27.304Z
+  - Finished At: 2026-03-27T21:45:27.401Z
 
 ## Metrics
 
 - stepCount: 2
-- startedAt: 2026-03-27T16:54:05.828Z
-- completedAt: 2026-03-27T16:54:08.033Z
+- startedAt: 2026-03-27T21:45:25.188Z
+- completedAt: 2026-03-27T21:45:27.401Z

--- a/docs/reports/closeout/phase5-skills-lifecycle/latest.json
+++ b/docs/reports/closeout/phase5-skills-lifecycle/latest.json
@@ -1,15 +1,15 @@
 {
   "status": "passed",
-  "gitHead": "bdc4b5f",
-  "generatedAt": "2026-03-27T16:54:10.907Z",
+  "gitHead": "33d4cf2",
+  "generatedAt": "2026-03-27T21:45:30.233Z",
   "title": "Skills Lifecycle Hardening",
   "notes": [
     "Phase closeout completed successfully for phase5."
   ],
   "metrics": {
     "stepCount": "2",
-    "startedAt": "2026-03-27T16:54:08.162Z",
-    "completedAt": "2026-03-27T16:54:10.907Z"
+    "startedAt": "2026-03-27T21:45:27.505Z",
+    "completedAt": "2026-03-27T21:45:30.233Z"
   },
   "steps": [
     {
@@ -18,8 +18,8 @@
       "status": "passed",
       "exitCode": 0,
       "signal": null,
-      "startedAt": "2026-03-27T16:54:08.164Z",
-      "finishedAt": "2026-03-27T16:54:10.808Z"
+      "startedAt": "2026-03-27T21:45:27.507Z",
+      "finishedAt": "2026-03-27T21:45:30.135Z"
     },
     {
       "label": "Truth audit",
@@ -27,8 +27,8 @@
       "status": "passed",
       "exitCode": 0,
       "signal": null,
-      "startedAt": "2026-03-27T16:54:10.808Z",
-      "finishedAt": "2026-03-27T16:54:10.907Z"
+      "startedAt": "2026-03-27T21:45:30.135Z",
+      "finishedAt": "2026-03-27T21:45:30.233Z"
     }
   ]
 }

--- a/docs/reports/closeout/phase5-skills-lifecycle/latest.md
+++ b/docs/reports/closeout/phase5-skills-lifecycle/latest.md
@@ -1,8 +1,8 @@
 # Skills Lifecycle Hardening
 
 - Status: passed
-- Git SHA: bdc4b5f
-- Generated At: 2026-03-27T16:54:10.907Z
+- Git SHA: 33d4cf2
+- Generated At: 2026-03-27T21:45:30.233Z
 - Notes:
   - Phase closeout completed successfully for phase5.
 
@@ -11,16 +11,16 @@
 - Skills lifecycle pack: passed
   - Command: `npx vitest run test/e2e/skills/friday-skill-lifecycle.test.ts test/e2e/api/friday-api-skills-routes.test.ts test/integration/skills/friday-skill-registry-lifecycle.test.ts test/integration/marketplace/friday-marketplace-install-closure.test.ts test/integration/marketplace/friday-marketplace-install-failure-rollback.test.ts test/unit/skills/marketplace/friday-skill-lifecycle-service.test.ts test/unit/skills/marketplace/friday-skill-installation-service.test.ts test/unit/skills/marketplace/friday-marketplace-source-repository.test.ts test/unit/skills/marketplace/friday-skill-trust-scoring-service.test.ts test/unit/ui/skills-view-models.test.ts`
   - Exit Code: 0
-  - Started At: 2026-03-27T16:54:08.164Z
-  - Finished At: 2026-03-27T16:54:10.808Z
+  - Started At: 2026-03-27T21:45:27.507Z
+  - Finished At: 2026-03-27T21:45:30.135Z
 - Truth audit: passed
   - Command: `npm run check:closeout:truth:phase5`
   - Exit Code: 0
-  - Started At: 2026-03-27T16:54:10.808Z
-  - Finished At: 2026-03-27T16:54:10.907Z
+  - Started At: 2026-03-27T21:45:30.135Z
+  - Finished At: 2026-03-27T21:45:30.233Z
 
 ## Metrics
 
 - stepCount: 2
-- startedAt: 2026-03-27T16:54:08.162Z
-- completedAt: 2026-03-27T16:54:10.907Z
+- startedAt: 2026-03-27T21:45:27.505Z
+- completedAt: 2026-03-27T21:45:30.233Z

--- a/scripts/e2e/friday-closure-lib.mjs
+++ b/scripts/e2e/friday-closure-lib.mjs
@@ -113,6 +113,16 @@ export function collectChannelBlockers(env = process.env) {
     .map((kind) => `Channel "${kind}" is not configured in FRIDAY_CHANNELS_JSON`);
 }
 
+export function buildClosureScratchEnv(baseEnv = process.env, paths) {
+  return {
+    ...baseEnv,
+    FRIDAY_STATE_DIR: paths.state,
+    FRIDAY_CHANNELS_JSON: baseEnv.FRIDAY_CHANNELS_JSON ?? '{"enabled":true,"instances":[]}',
+    FRIDAY_BROWSER_HEADLESS: "true",
+    FRIDAY_ALLOW_LOCAL_BYPASS_LOGIN: baseEnv.FRIDAY_ALLOW_LOCAL_BYPASS_LOGIN ?? "true",
+  };
+}
+
 function entryHasHiddenClosureFailure(entry) {
   if (!entry || typeof entry !== "object") {
     return false;

--- a/scripts/e2e/run-friday-closure.mjs
+++ b/scripts/e2e/run-friday-closure.mjs
@@ -9,6 +9,7 @@ import { createSign, generateKeyPairSync } from "node:crypto";
 import { fileURLToPath } from "node:url";
 
 import {
+  buildClosureScratchEnv,
   FRIDAY_CLOSURE_STATUSES,
   collectCloudBlockers,
   createClosureRunId,
@@ -376,15 +377,6 @@ function formatConsoleSummary(readiness, ledgerPath) {
   }
 
   return `Repo Ready: ${readiness.repoReady}; Product Ready (Local): ${readiness.productReadyLocal}; Cloud Ready: ${readiness.cloudReady}; Overall: ${readiness.overall} (${ledgerPath})`;
-}
-
-function buildScratchFridayEnv(paths) {
-  return {
-    ...process.env,
-    FRIDAY_STATE_DIR: paths.state,
-    FRIDAY_CHANNELS_JSON: process.env.FRIDAY_CHANNELS_JSON ?? '{"enabled":true,"instances":[]}',
-    FRIDAY_BROWSER_HEADLESS: "true",
-  };
 }
 
 function makeScratchPlugin(pluginRoot) {
@@ -931,7 +923,7 @@ async function runLocalStage(ledger) {
   makeScratchWorkflowSkill(path.join(ledger.paths.skills, "closure-workflow-template"));
 
   const port = await findFreePort();
-  const fridayEnv = buildScratchFridayEnv(ledger.paths);
+  const fridayEnv = buildClosureScratchEnv(process.env, ledger.paths);
   const serverLogPath = path.join(ledger.paths.logs, "local-friday-server.log");
   const server = spawn(process.execPath, [
     DIST_CLI,

--- a/scripts/ops/check-desktop-runtime.sh
+++ b/scripts/ops/check-desktop-runtime.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ENV_FILE="${ROOT_DIR}/.env"
+
 failures=0
 warnings=0
 
@@ -29,6 +32,13 @@ require_cmd() {
 
 platform="$(uname -s 2>/dev/null || echo unknown)"
 echo "[desktop-check] platform=${platform}"
+
+if [[ -f "${ENV_FILE}" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "${ENV_FILE}"
+  set +a
+fi
 
 if [[ "${FRIDAY_DESKTOP_ENABLED:-false}" == "true" ]]; then
   print_ok "FRIDAY_DESKTOP_ENABLED=true"

--- a/src/agent/runtime/friday-agent-workspace-context.ts
+++ b/src/agent/runtime/friday-agent-workspace-context.ts
@@ -79,6 +79,10 @@ interface FridayStoredMemoryCandidate {
   content: string;
 }
 
+function isMissingFsError(err: unknown): boolean {
+  return typeof err === "object" && err !== null && "code" in err && err.code === "ENOENT";
+}
+
 // ─── Constants ───
 
 /** Identity files are always injected when present. */
@@ -301,7 +305,9 @@ async function collectMarkdownFiles(rootDir: string): Promise<string[]> {
     try {
       entries = await fs.readdir(currentDir, { withFileTypes: true });
     } catch (err) {
-      console.warn("[friday][workspace-context] readdir:", err instanceof Error ? err.message : String(err));
+      if (!isMissingFsError(err)) {
+        console.warn("[friday][workspace-context] readdir:", err instanceof Error ? err.message : String(err));
+      }
       return;
     }
     for (const entry of entries) {
@@ -371,7 +377,9 @@ async function loadPathScopedRules(
       });
     } catch (err) {
       // Skip unreadable rule files.
-      console.warn("[friday][workspace-context] load-path-rule:", err instanceof Error ? err.message : String(err));
+      if (!isMissingFsError(err)) {
+        console.warn("[friday][workspace-context] load-path-rule:", err instanceof Error ? err.message : String(err));
+      }
     }
   }
 
@@ -407,7 +415,9 @@ async function loadPathScopedRules(
       });
     } catch (err) {
       // Skip unreadable rule files.
-      console.warn("[friday][workspace-context] load-ext-rule:", err instanceof Error ? err.message : String(err));
+      if (!isMissingFsError(err)) {
+        console.warn("[friday][workspace-context] load-ext-rule:", err instanceof Error ? err.message : String(err));
+      }
     }
   }
 
@@ -461,7 +471,9 @@ export async function loadFridayWorkspaceContext(
 
       files.push({ name, filePath, content: truncated, missing: false, kind });
     } catch (err) {
-      console.warn("[friday][workspace-context] load-named-file:", err instanceof Error ? err.message : String(err));
+      if (!isMissingFsError(err)) {
+        console.warn("[friday][workspace-context] load-named-file:", err instanceof Error ? err.message : String(err));
+      }
       files.push({ name, filePath, missing: true, kind });
     }
   };
@@ -491,7 +503,9 @@ export async function loadFridayWorkspaceContext(
     });
   } catch (err) {
     // Daily memory file is optional
-    console.warn("[friday][workspace-context] daily-memory:", err instanceof Error ? err.message : String(err));
+    if (!isMissingFsError(err)) {
+      console.warn("[friday][workspace-context] daily-memory:", err instanceof Error ? err.message : String(err));
+    }
   }
 
   // Load exported memory items from .friday/exports/memory/ (feedback loop)
@@ -575,7 +589,9 @@ async function loadMemoryExports(workspaceDir: string): Promise<FridayStoredMemo
   try {
     entries = await fs.readdir(memoryDir);
   } catch (err) {
-    console.warn("[friday][workspace-context] readdir-memory-exports:", err instanceof Error ? err.message : String(err));
+    if (!isMissingFsError(err)) {
+      console.warn("[friday][workspace-context] readdir-memory-exports:", err instanceof Error ? err.message : String(err));
+    }
     return []; // Directory doesn't exist yet — no memories exported
   }
 

--- a/src/api/auth/friday-auth-service.ts
+++ b/src/api/auth/friday-auth-service.ts
@@ -158,6 +158,22 @@ function verifyPassword(input: string, hash: string): { valid: boolean; needsUpg
 // Dummy scrypt hash for constant-time verification against non-existent users.
 // Generated once at module load; the actual password doesn't matter.
 const DUMMY_SCRYPT_HASH = hashPasswordScrypt("__friday_dummy_password_for_timing__");
+const warnedMessagesBySink = new WeakMap<(message: string) => void, Set<string>>();
+
+function createWarnOnce(warn: (message: string) => void): (message: string) => void {
+  return (message: string) => {
+    let warnedMessages = warnedMessagesBySink.get(warn);
+    if (!warnedMessages) {
+      warnedMessages = new Set<string>();
+      warnedMessagesBySink.set(warn, warnedMessages);
+    }
+    if (warnedMessages.has(message)) {
+      return;
+    }
+    warnedMessages.add(message);
+    warn(message);
+  };
+}
 
 export class FridayAuthError extends FridayDomainError {
   override readonly name = "FridayAuthError";
@@ -178,16 +194,18 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
   const allowPasswordless = deps.allowPasswordlessLocalLogin ?? false;
   const allowLocalBypassLogin = deps.allowLocalBypassLogin ?? false;
   const warn = deps.warn ?? console.warn;
+  const warnOnce = createWarnOnce(warn);
+  const silenceExpectedTestWarnings = Boolean(process.env.VITEST) && warn === console.warn;
   const rateLimiter = deps.rateLimiter;
 
   // P1-SEC-004: Warn if token secret is too short
   if (deps.tokenSecret.length < 32) {
-    warn("[friday][SECURITY] Token secret is shorter than recommended minimum (32 chars) — session tokens may be vulnerable to brute-force");
+    warnOnce("[friday][SECURITY] Token secret is shorter than recommended minimum (32 chars) — session tokens may be vulnerable to brute-force");
   }
 
   // P1-SEC-005: Warn if rate limiter is not configured
   if (!rateLimiter) {
-    warn("[friday][SECURITY] Auth rate limiter not configured — brute-force protection disabled");
+    warnOnce("[friday][SECURITY] Auth rate limiter not configured — brute-force protection disabled");
   }
 
   /**
@@ -479,9 +497,13 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
           );
         }
         if (requestedLocalBypass) {
-          warn("[friday] WARNING: Local bypass login used (no-signin mode).");
+          if (!silenceExpectedTestWarnings) {
+            warnOnce("[friday] WARNING: Local bypass login used (no-signin mode).");
+          }
         } else {
-          warn("[friday] WARNING: Passwordless local login used. This is allowed only in dev mode.");
+          if (!silenceExpectedTestWarnings) {
+            warnOnce("[friday] WARNING: Passwordless local login used. This is allowed only in dev mode.");
+          }
         }
       }
 

--- a/src/api/http/friday-http-route-contract.ts
+++ b/src/api/http/friday-http-route-contract.ts
@@ -36,8 +36,6 @@ export const FRIDAY_ROUTE_OPERATION_ID_RENAMES = {
   "observability.alertRules.get": "observability.alert.rules.get",
   "observability.alertRules.list": "observability.alert.rules.list",
   "observability.alertRules.update": "observability.alert.rules.update",
-  "packaging.packages.checkDependencies": "packaging.packages.dependencies.check",
-  "packaging.packages.listVersions": "packaging.packages.versions.list",
   "security.secrets.accessLog": "security.secrets.access.log",
   "workflows.importBundle": "workflows.bundles.import",
 } as const;

--- a/src/api/http/friday-http-server.ts
+++ b/src/api/http/friday-http-server.ts
@@ -89,6 +89,10 @@ class MalformedUriError extends Error {
   }
 }
 
+function isMissingFileError(err: unknown): boolean {
+  return typeof err === "object" && err !== null && "code" in err && err.code === "ENOENT";
+}
+
 function extractParams(pattern: string, actual: string): Record<string, string> {
   const patternParts = pattern.split("/");
   const actualParts = actual.split("/");
@@ -311,7 +315,9 @@ async function tryServeUiAsset(
         return true;
       }
     } catch (err) {
+      if (!isMissingFileError(err)) {
         console.warn("[friday][http-server] operation failed:", err instanceof Error ? err.message : String(err));
+      }
       // File doesn't exist — fall through
     }
   }
@@ -358,7 +364,9 @@ async function tryServeUiAsset(
       return true;
     }
   } catch (err) {
+    if (!isMissingFileError(err)) {
         console.warn("[friday][http-server] operation failed:", err instanceof Error ? err.message : String(err));
+    }
     // index.html doesn't exist
   }
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -169,10 +169,6 @@ export type { FridayDeterministicPipelineRoutesDeps } from "./http/routes/friday
 export { createFridayObservabilityRoutes } from "./http/routes/friday-observability-routes.js";
 export type { FridayObservabilityRoutesDeps } from "./http/routes/friday-observability-routes.js";
 
-// Packaging routes (B-008)
-export { createFridayPackagingRoutes } from "./http/routes/friday-packaging-routes.js";
-export type { FridayPackagingRoutesDeps } from "./http/routes/friday-packaging-routes.js";
-
 // Desktop routes (C-003)
 export { createFridayDesktopRoutes } from "./http/routes/friday-desktop-routes.js";
 export type { FridayDesktopRoutesDeps } from "./http/routes/friday-desktop-routes.js";

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -296,6 +296,39 @@ export {
   resolveTokenSecret,
 } from "./bootstrap/hub-helpers.js";
 
+type FridayWarnSink = (message: string) => void;
+
+const warnedMessagesBySink = new WeakMap<FridayWarnSink, Set<string>>();
+
+function warnOnce(warn: FridayWarnSink, message: string): void {
+  let warnedMessages = warnedMessagesBySink.get(warn);
+  if (!warnedMessages) {
+    warnedMessages = new Set<string>();
+    warnedMessagesBySink.set(warn, warnedMessages);
+  }
+  if (warnedMessages.has(message)) {
+    return;
+  }
+  warnedMessages.add(message);
+  warn(message);
+}
+
+function warnHubBootstrapOnce(message: string): void {
+  warnOnce(console.warn as FridayWarnSink, message);
+}
+
+function warnHubBootstrapOperationFailureOnce(error: unknown): void {
+  warnHubBootstrapOnce(
+    `[friday][hub-bootstrap] operation failed: ${error instanceof Error ? error.message : String(error)}`,
+  );
+}
+
+function isExpectedVitestProviderNoRouting(error: unknown): boolean {
+  return Boolean(process.env.VITEST)
+    && error instanceof FridayDomainError
+    && error.code === "PROVIDER_NO_ROUTING";
+}
+
 export type {
   FridayHub,
   FridayHubConfig,
@@ -451,7 +484,9 @@ export async function createFridayHub(
         ).run("admin-001", "admin@friday.dev", "Admin", "admin", nowIso, nowIso);
       });
       // P2: Always warn when creating passwordless admin (password_hash = NULL)
-      console.warn("[friday][SECURITY] Created default admin user (admin@friday.dev) with NO password — set a passphrase via the setup wizard for production use");
+      warnHubBootstrapOnce(
+        "[friday][SECURITY] Created default admin user (admin@friday.dev) with NO password — set a passphrase via the setup wizard for production use",
+      );
     }
   }
 
@@ -586,7 +621,7 @@ export async function createFridayHub(
           });
         });
       } catch (err) {
-      console.warn("[friday][hub-bootstrap] operation failed:", err instanceof Error ? err.message : String(err));
+      warnHubBootstrapOperationFailureOnce(err);
         // Keep runtime fail-open if audit persistence fails.
       }
     },
@@ -2101,7 +2136,9 @@ export async function createFridayHub(
     const modelName = defaultRoute.model;            // e.g. "claude-opus-4-5-20251101"
     agentModelIdentity = `${modelName} (provider: ${providerKind})`;
   } catch (err) {
-      console.warn("[friday][hub-bootstrap] operation failed:", err instanceof Error ? err.message : String(err));
+      if (!isExpectedVitestProviderNoRouting(err)) {
+      warnHubBootstrapOperationFailureOnce(err);
+      }
     // No provider configured yet — use generic identity.
   }
   try {
@@ -2111,10 +2148,12 @@ export async function createFridayHub(
     ]);
     const routingWarning = resolveFridayRoutingStabilityWarning({ routing, providers });
     if (routingWarning) {
-      console.warn(`[friday][W-PROVIDER-ROUTING-001] ${routingWarning}`);
+      warnHubBootstrapOnce(`[friday][W-PROVIDER-ROUTING-001] ${routingWarning}`);
     }
   } catch (err) {
-      console.warn("[friday][hub-bootstrap] operation failed:", err instanceof Error ? err.message : String(err));
+      if (!isExpectedVitestProviderNoRouting(err)) {
+        warnHubBootstrapOperationFailureOnce(err);
+      }
     // Non-fatal: provider routing diagnostics should not block startup.
   }
 
@@ -2150,7 +2189,7 @@ export async function createFridayHub(
       }
       workspaceContextSummary = ctx.workspaceContext?.summary;
     } catch (err) {
-      console.warn("[friday][hub-bootstrap] operation failed:", err instanceof Error ? err.message : String(err));
+      warnHubBootstrapOperationFailureOnce(err);
       // Non-fatal: workspace context loading failure should not block agent runs.
     }
     const starterSkills = registry.list()
@@ -2610,7 +2649,7 @@ export async function createFridayHub(
       const envelope = JSON.parse(entity.encryptedValue) as FridayEncryptedEnvelope;
       return decryptSecret(envelope, getMasterKey());
     } catch (err) {
-      console.warn("[friday][hub-bootstrap] operation failed:", err instanceof Error ? err.message : String(err));
+      warnHubBootstrapOperationFailureOnce(err);
       return null;
     }
   };
@@ -4989,11 +5028,11 @@ export async function createFridayHub(
 
       // P1-SHUT-001/002/003: Stop services started during bootstrap
       try { observabilityService?.scheduler?.stop(); } catch (err) {
-      console.warn("[friday][hub-bootstrap] operation failed:", err instanceof Error ? err.message : String(err)); /* best-effort */ }
+      warnHubBootstrapOperationFailureOnce(err); /* best-effort */ }
       try { agentLearningBridge?.stop(); } catch (err) {
-      console.warn("[friday][hub-bootstrap] operation failed:", err instanceof Error ? err.message : String(err)); /* best-effort */ }
+      warnHubBootstrapOperationFailureOnce(err); /* best-effort */ }
       try { if (mcpAdapter && "close" in mcpAdapter) await (mcpAdapter as unknown as { close(): Promise<void> }).close(); } catch (err) {
-      console.warn("[friday][hub-bootstrap] operation failed:", err instanceof Error ? err.message : String(err)); /* best-effort */ }
+      warnHubBootstrapOperationFailureOnce(err); /* best-effort */ }
 
       // 1. Stop job scheduler (F11: await in-flight)
       if (jobScheduler) {

--- a/src/link-understanding/friday-link-summarize.ts
+++ b/src/link-understanding/friday-link-summarize.ts
@@ -51,7 +51,7 @@ export async function extractReadableContent(
   try {
     const { Readability, parseHTML } = await loadReadabilityDeps();
     const { document } = parseHTML(html);
-    if (url) {
+    if (url && canAssignBaseUri(document)) {
       try {
         (document as { baseURI?: string }).baseURI = url;
       } catch (err) {
@@ -69,6 +69,18 @@ export async function extractReadableContent(
     console.warn("[friday][link-summarize] HTML extraction failed:", err instanceof Error ? err.message : String(err));
     return null;
   }
+}
+
+function canAssignBaseUri(document: object): boolean {
+  let current: object | null = document;
+  while (current) {
+    const descriptor = Object.getOwnPropertyDescriptor(current, "baseURI");
+    if (descriptor) {
+      return descriptor.writable === true || typeof descriptor.set === "function";
+    }
+    current = Object.getPrototypeOf(current);
+  }
+  return true;
 }
 
 // ─── Regex fallback ───

--- a/src/memory/services/friday-memory-service.ts
+++ b/src/memory/services/friday-memory-service.ts
@@ -25,6 +25,38 @@ import { createFridayMemoryEmbeddingRepository } from "../persistence/friday-mem
 import { createFridayMemoryByokEmbeddingClient } from "./friday-memory-byok-embedding-client.js";
 import { mergeHybridResults } from "../search/friday-memory-hybrid.js";
 
+type FridayWarnSink = (message: string) => void;
+const warnedKeysBySink = new WeakMap<FridayWarnSink, Set<string>>();
+
+function warnOnce(warn: FridayWarnSink, key: string, message: string): void {
+  let warnedKeys = warnedKeysBySink.get(warn);
+  if (!warnedKeys) {
+    warnedKeys = new Set<string>();
+    warnedKeysBySink.set(warn, warnedKeys);
+  }
+  if (warnedKeys.has(key)) {
+    return;
+  }
+  warnedKeys.add(key);
+  warn(message);
+}
+
+function normalizeWarningKey(kind: "embedding" | "semantic", message: string): string {
+  return `${kind}:${message}`;
+}
+
+function warnMemoryFallback(kind: "embedding" | "semantic", message: string): void {
+  if (message.startsWith("No enabled providers available for routing")) {
+    return;
+  }
+  const label = kind === "embedding" ? "embedding failed" : "semantic search unavailable";
+  warnOnce(
+    console.warn as FridayWarnSink,
+    normalizeWarningKey(kind, message),
+    `[friday][memory-service] ${label}: ${message}`,
+  );
+}
+
 export function createFridayMemoryService(
   deps: CreateFridayMemoryServiceDeps,
 ): FridayMemoryService {
@@ -116,7 +148,7 @@ export function createFridayMemoryService(
         });
       } catch (err) {
         // Embedding failed — item was stored successfully, just no vector
-        console.warn("[friday][memory-service] embedding failed:", err instanceof Error ? err.message : String(err));
+        warnMemoryFallback("embedding", err instanceof Error ? err.message : String(err));
       }
 
       return item;
@@ -171,7 +203,7 @@ export function createFridayMemoryService(
         );
       } catch (err) {
         // Semantic search unavailable — fallback to FTS-only
-        console.warn("[friday][memory-service] semantic search unavailable:", err instanceof Error ? err.message : String(err));
+        warnMemoryFallback("semantic", err instanceof Error ? err.message : String(err));
       }
 
       // Enforce tagsAll on semantic-only hits before merge (Fix #1)

--- a/src/memory/sync/friday-memory-file-sync-service.ts
+++ b/src/memory/sync/friday-memory-file-sync-service.ts
@@ -685,10 +685,25 @@ function formatSessionMessage(msg: {
 
 function tryParseJson(json: string | null | undefined): unknown {
   if (!json) return null;
+  if (!looksLikeJsonValue(json)) return json;
   try {
     return JSON.parse(json);
   } catch (err) {
     console.warn("[friday][memory-file-sync] try-parse-json:", err instanceof Error ? err.message : String(err));
     return json;
   }
+}
+
+function looksLikeJsonValue(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  if (trimmed === "true" || trimmed === "false" || trimmed === "null") return true;
+  const first = trimmed[0];
+  return (
+    first === "{" ||
+    first === "[" ||
+    first === '"' ||
+    first === "-" ||
+    (first >= "0" && first <= "9")
+  );
 }

--- a/src/skills/executor/friday-skill-executor.ts
+++ b/src/skills/executor/friday-skill-executor.ts
@@ -190,6 +190,9 @@ export function createFridaySkillExecutor(
                 // Try to parse stdout as JSON output
                 let output: Record<string, unknown> = {};
                 try {
+                  if (!looksLikeJsonValue(shellResult.stdout)) {
+                    output = { raw: shellResult.stdout };
+                  } else {
                   const parsed: unknown = JSON.parse(shellResult.stdout);
                   if (
                     parsed != null &&
@@ -199,6 +202,7 @@ export function createFridaySkillExecutor(
                     output = parsed as Record<string, unknown>;
                   } else {
                     output = { result: parsed };
+                  }
                   }
                 } catch (err) {
                   console.warn("[friday][skill-executor] operation failed:", err instanceof Error ? err.message : String(err));
@@ -473,4 +477,18 @@ export function createFridaySkillExecutor(
       }
     },
   };
+}
+
+function looksLikeJsonValue(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  if (trimmed === "true" || trimmed === "false" || trimmed === "null") return true;
+  const first = trimmed[0];
+  return (
+    first === "{" ||
+    first === "[" ||
+    first === '"' ||
+    first === "-" ||
+    (first >= "0" && first <= "9")
+  );
 }

--- a/src/system/companion/friday-system-unix-socket-bridge.ts
+++ b/src/system/companion/friday-system-unix-socket-bridge.ts
@@ -30,6 +30,29 @@ export interface CreateFridaySystemUnixSocketBridgeOptions
 }
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 5_000;
+type FridayWarnSink = (message: string) => void;
+const warnedKeysBySink = new WeakMap<FridayWarnSink, Set<string>>();
+
+function warnOnce(warn: FridayWarnSink, key: string, message: string): void {
+  let warnedKeys = warnedKeysBySink.get(warn);
+  if (!warnedKeys) {
+    warnedKeys = new Set<string>();
+    warnedKeysBySink.set(warn, warnedKeys);
+  }
+  if (warnedKeys.has(key)) {
+    return;
+  }
+  warnedKeys.add(key);
+  warn(message);
+}
+
+function normalizeCompanionTransportWarningKey(message: string): string {
+  const connectCodeMatch = /^connect\s+(ENOENT|ECONNREFUSED|EACCES|EPERM)\b/.exec(message);
+  if (connectCodeMatch) {
+    return `connect ${connectCodeMatch[1]}`;
+  }
+  return message.replace(/\/[^ ]+\.sock\b/g, "<socket>");
+}
 
 function normalizeCompanionStatus(
   status: FridaySystemCompanionStatus,
@@ -218,7 +241,12 @@ export function createFridaySystemUnixSocketBridge(
         lastHeartbeatAt = status.lastHeartbeatAt;
         return status;
       } catch (err) {
-        console.warn("[friday][unix-socket-bridge] getStatus:", err instanceof Error ? err.message : String(err));
+        const message = err instanceof Error ? err.message : String(err);
+        warnOnce(
+          console.warn as FridayWarnSink,
+          `getStatus:${normalizeCompanionTransportWarningKey(message)}`,
+          `[friday][unix-socket-bridge] getStatus: ${message}`,
+        );
         connected = false;
         lastHeartbeatAt = options.nowIso();
         return buildFridaySystemCompanionStatus(options, {
@@ -237,7 +265,17 @@ export function createFridaySystemUnixSocketBridge(
         lastHeartbeatAt = options.nowIso();
         return snapshot;
       } catch (err) {
-        console.warn("[friday][unix-socket-bridge] captureSnapshot:", err instanceof Error ? err.message : String(err));
+        const message = err instanceof Error ? err.message : String(err);
+        if (
+          !message.startsWith("Companion request timed out: companion.captureSnapshot")
+          && !message.startsWith("Companion closed connection before responding: companion.captureSnapshot")
+        ) {
+          warnOnce(
+            console.warn as FridayWarnSink,
+            `captureSnapshot:${message}`,
+            `[friday][unix-socket-bridge] captureSnapshot: ${message}`,
+          );
+        }
         connected = false;
         lastHeartbeatAt = options.nowIso();
         return {

--- a/src/system/engine/friday-system-service.ts
+++ b/src/system/engine/friday-system-service.ts
@@ -67,6 +67,8 @@ const MAX_FILE_SEARCH_RESULTS = 50;
 const DEFAULT_COMPANION_HEARTBEAT_STALE_MS = 30_000;
 const DEFAULT_REMOTE_AUTH_CHALLENGE_TTL_MS = 5 * 60 * 1000;
 const DEFAULT_REMOTE_ASSERTION_TTL_MS = 2 * 60 * 1000;
+type FridayWarnSink = (message: string) => void;
+const warnedCompanionMessagesBySink = new WeakMap<FridayWarnSink, Set<string>>();
 
 const HIGH_RISK_INTENTS = new Set<FridaySystemIntentAction>([
   "close_app",
@@ -95,6 +97,32 @@ export interface FridaySystemExecResult {
   exitCode: number;
   stdout: string;
   stderr: string;
+}
+
+function normalizeCompanionUnavailableWarningKey(message: string): string {
+  const connectCodeMatch = /^connect\s+(ENOENT|ECONNREFUSED|EACCES|EPERM)\b/.exec(message);
+  if (connectCodeMatch) {
+    return `connect ${connectCodeMatch[1]}`;
+  }
+  return message.replace(/\/[^ ]+\.sock\b/g, "<socket>");
+}
+
+function warnCompanionUnavailableOnce(
+  warn: FridayWarnSink,
+  message: string,
+  prefix: string,
+): void {
+  const key = `${prefix}:${normalizeCompanionUnavailableWarningKey(message)}`;
+  let warnedMessages = warnedCompanionMessagesBySink.get(warn);
+  if (!warnedMessages) {
+    warnedMessages = new Set<string>();
+    warnedCompanionMessagesBySink.set(warn, warnedMessages);
+  }
+  if (warnedMessages.has(key)) {
+    return;
+  }
+  warnedMessages.add(key);
+  warn(`[friday] ${prefix}: ${message}`);
 }
 
 export interface CreateFridaySystemServiceDeps {
@@ -504,7 +532,11 @@ export async function createFridaySystemService(
         await emitHealthIfChanged("companion_reconnected");
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        warn(`[friday] system companion unavailable; continuing in degraded mode: ${message}`);
+        warnCompanionUnavailableOnce(
+          warn,
+          message,
+          "system companion unavailable; continuing in degraded mode",
+        );
       } finally {
         reconnectInFlight = null;
       }
@@ -603,7 +635,13 @@ export async function createFridaySystemService(
 
   async function buildSnapshot(): Promise<FridaySystemSnapshot> {
     const companion = await deps.companionBridge.getStatus();
-    const companionSnapshot = await deps.companionBridge.captureSnapshot();
+    const companionSnapshot = companion.connected
+      ? await deps.companionBridge.captureSnapshot()
+      : {
+        apps: [],
+        windows: [],
+        notifications: [],
+      };
     const permissions = await readPermissions(companion.permissions);
     await emitCompanionEventsIfChanged(companion, permissions);
     const approvals = deps.db.withReadConnection((db) => repository.listApprovalRules(db));
@@ -948,7 +986,11 @@ export async function createFridaySystemService(
     await deps.companionBridge.connect();
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    warn(`[friday] system companion unavailable at startup; continuing in degraded mode: ${message}`);
+    warnCompanionUnavailableOnce(
+      warn,
+      message,
+      "system companion unavailable at startup; continuing in degraded mode",
+    );
     scheduleCompanionReconnect();
   }
 

--- a/test/contracts/api/friday-api-public-barrel.contract.test.ts
+++ b/test/contracts/api/friday-api-public-barrel.contract.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+
+describe("#api public barrel contract", () => {
+  it("does not expose dormant packaging route factories", async () => {
+    const mod = await import("#api");
+    expect(mod).not.toHaveProperty("createFridayPackagingRoutes");
+    expect(mod).not.toHaveProperty("FridayPackagingRoutesDeps");
+  });
+});

--- a/test/contracts/api/friday-api-route-contract.snapshot.test.ts
+++ b/test/contracts/api/friday-api-route-contract.snapshot.test.ts
@@ -709,16 +709,16 @@ describe("MECHANISM-4 — API Route Contract (Snapshot)", () => {
       const renameEntries = Object.entries(FRIDAY_ROUTE_OPERATION_ID_RENAMES).sort(([left], [right]) =>
         left.localeCompare(right),
       );
-      const activeRenameEntries = renameEntries.filter(([, to]) => !to.startsWith("packaging."));
-      expect(renameEntries).toHaveLength(26);
+      expect(renameEntries).toHaveLength(24);
       expect(renameEntries.every(([from]) => !FRIDAY_ROUTE_OPERATION_ID_PATTERN.test(from))).toBe(true);
       expect(renameEntries.every(([, to]) => FRIDAY_ROUTE_OPERATION_ID_PATTERN.test(to))).toBe(true);
+      expect(renameEntries.some(([, to]) => to.startsWith("packaging."))).toBe(false);
 
       const operationIds = fixture.runtime.routes
         .getRoutes()
         .map((route) => route.operationId)
         .sort();
-      const renameTargets = activeRenameEntries.map(([, to]) => to).sort();
+      const renameTargets = renameEntries.map(([, to]) => to).sort();
 
       expect(operationIds.every((operationId) => FRIDAY_ROUTE_OPERATION_ID_PATTERN.test(operationId))).toBe(true);
       expect(renameTargets.every((operationId) => operationIds.includes(operationId))).toBe(true);

--- a/test/integration/system/friday-desktop-runtime-check.integration.test.ts
+++ b/test/integration/system/friday-desktop-runtime-check.integration.test.ts
@@ -1,0 +1,49 @@
+import { execFile } from "node:child_process";
+import * as fs from "node:fs/promises";
+import os from "node:os";
+import * as path from "node:path";
+import { promisify } from "node:util";
+
+import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const describeIfDarwin = process.platform === "darwin" ? describe : describe.skip;
+
+describeIfDarwin("desktop runtime check", () => {
+  it("loads desktop settings from repo .env before reporting readiness", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "friday-desktop-check-"));
+    const tempRepo = path.join(tempRoot, "repo");
+    const tempScriptDir = path.join(tempRepo, "scripts", "ops");
+    const sourceScriptPath = path.join(process.cwd(), "scripts", "ops", "check-desktop-runtime.sh");
+    const targetScriptPath = path.join(tempScriptDir, "check-desktop-runtime.sh");
+
+    await fs.mkdir(tempScriptDir, { recursive: true });
+    await fs.copyFile(sourceScriptPath, targetScriptPath);
+    await fs.chmod(targetScriptPath, 0o755);
+    await fs.writeFile(
+      path.join(tempRepo, ".env"),
+      [
+        "FRIDAY_DESKTOP_ENABLED=true",
+        `FRIDAY_DESKTOP_SANDBOX_ALLOWED_ROOTS=${JSON.stringify(tempRepo)}`,
+      ].join("\n"),
+    );
+
+    try {
+      const { stdout } = await execFileAsync("bash", [targetScriptPath], {
+        cwd: tempRepo,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          FRIDAY_DESKTOP_ENABLED: "",
+          FRIDAY_DESKTOP_SANDBOX_ALLOWED_ROOTS: "",
+        },
+      });
+
+      expect(stdout).toContain("[desktop-check][ok] FRIDAY_DESKTOP_ENABLED=true");
+      expect(stdout).toContain(`[desktop-check][ok] FRIDAY_DESKTOP_SANDBOX_ALLOWED_ROOTS=${tempRepo}`);
+      expect(stdout).not.toContain("FRIDAY_DESKTOP_ENABLED is not true");
+    } finally {
+      await fs.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/unit/agent/runtime/friday-agent-workspace-context.test.ts
+++ b/test/unit/agent/runtime/friday-agent-workspace-context.test.ts
@@ -7,7 +7,7 @@
  * file sync export → workspace loader → system prompt.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import * as os from "node:os";
@@ -55,11 +55,17 @@ describe("loadFridayWorkspaceContext", () => {
     });
 
     it("returns empty prompt fragment when no workspace files exist", async () => {
-      const ctx = await loadFridayWorkspaceContext(tmpDir);
-      expect(ctx.promptFragment).toBe("");
-      // All files should be marked missing
-      const missing = ctx.files.filter((f) => f.missing);
-      expect(missing.length).toBeGreaterThanOrEqual(4);
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const ctx = await loadFridayWorkspaceContext(tmpDir);
+        expect(ctx.promptFragment).toBe("");
+        // All files should be marked missing
+        const missing = ctx.files.filter((f) => f.missing);
+        expect(missing.length).toBeGreaterThanOrEqual(4);
+        expect(warnSpy).not.toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
 
     it("loads multiple files in injection order", async () => {
@@ -134,9 +140,15 @@ describe("loadFridayWorkspaceContext", () => {
     });
 
     it("does not fail when memory directory does not exist", async () => {
-      const ctx = await loadFridayWorkspaceContext(tmpDir);
-      // Should not throw
-      expect(ctx.promptFragment).toBeDefined();
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const ctx = await loadFridayWorkspaceContext(tmpDir);
+        // Should not throw
+        expect(ctx.promptFragment).toBeDefined();
+        expect(warnSpy).not.toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
   });
 
@@ -233,10 +245,16 @@ describe("loadFridayWorkspaceContext", () => {
     });
 
     it("returns empty when no exports directory exists", async () => {
-      // No .friday/exports/memory/ directory
-      const ctx = await loadFridayWorkspaceContext(tmpDir);
-      // Should not fail
-      expect(ctx.promptFragment).toBeDefined();
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        // No .friday/exports/memory/ directory
+        const ctx = await loadFridayWorkspaceContext(tmpDir);
+        // Should not fail
+        expect(ctx.promptFragment).toBeDefined();
+        expect(warnSpy).not.toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
 
     it("respects max 100 memory items limit", async () => {

--- a/test/unit/api/auth/friday-auth-service.test.ts
+++ b/test/unit/api/auth/friday-auth-service.test.ts
@@ -383,6 +383,32 @@ describe("FridayAuthService", () => {
     expect(passwordlessWarning).toBeDefined();
   });
 
+  it("deduplicates construction warnings for the same warn sink", () => {
+    const warn = vi.fn();
+
+    createFridayAuthService({
+      db,
+      idGenerator: () => `id-${String(++idCounter).padStart(4, "0")}`,
+      nowIso: () => NOW,
+      tokenSecret: TOKEN_SECRET,
+      accessTokenTtlSec: 900,
+      refreshTokenTtlSec: 604800,
+      warn,
+    });
+    createFridayAuthService({
+      db,
+      idGenerator: () => `id-${String(++idCounter).padStart(4, "0")}`,
+      nowIso: () => NOW,
+      tokenSecret: TOKEN_SECRET,
+      accessTokenTtlSec: 900,
+      refreshTokenTtlSec: 604800,
+      warn,
+    });
+
+    expect(warn.mock.calls.filter(([message]) => String(message).includes("Token secret is shorter"))).toHaveLength(1);
+    expect(warn.mock.calls.filter(([message]) => String(message).includes("Auth rate limiter not configured"))).toHaveLength(1);
+  });
+
   it("allows no-signin local bypass with { local: true } even when passphrase exists", () => {
     const warnings: string[] = [];
     const bypassService = createFridayAuthService({
@@ -402,6 +428,41 @@ describe("FridayAuthService", () => {
     expect(warnings.some((w) => w.includes("Local bypass login"))).toBe(true);
   });
 
+  it("deduplicates repeated local bypass and passwordless warnings per service instance", () => {
+    const warnings: string[] = [];
+    db.writer.prepare("UPDATE users SET password_hash = NULL WHERE id = 'test-user'").run();
+
+    const passwordlessService = createFridayAuthService({
+      db,
+      idGenerator: () => `id-${String(++idCounter).padStart(4, "0")}`,
+      nowIso: () => NOW,
+      tokenSecret: TOKEN_SECRET,
+      accessTokenTtlSec: 900,
+      refreshTokenTtlSec: 604800,
+      allowPasswordlessLocalLogin: true,
+      warn: (msg) => warnings.push(msg),
+    });
+    passwordlessService.login({ local: true }, "127.0.0.1");
+    passwordlessService.login({ local: true }, "127.0.0.1");
+
+    const bypassService = createFridayAuthService({
+      db,
+      idGenerator: () => `id-${String(++idCounter).padStart(4, "0")}`,
+      nowIso: () => NOW,
+      tokenSecret: TOKEN_SECRET,
+      accessTokenTtlSec: 900,
+      refreshTokenTtlSec: 604800,
+      allowLocalBypassLogin: true,
+      warn: (msg) => warnings.push(msg),
+    });
+    db.writer.prepare("UPDATE users SET password_hash = ? WHERE id = 'test-user'").run(hashPasswordScrypt("any"));
+    bypassService.login({ local: true }, "127.0.0.1");
+    bypassService.login({ local: true }, "127.0.0.1");
+
+    expect(warnings.filter((message) => message.includes("Passwordless local login used"))).toHaveLength(1);
+    expect(warnings.filter((message) => message.includes("Local bypass login used"))).toHaveLength(1);
+  });
+
   it("rejects local bypass login from remote IP even with allowLocalBypassLogin", () => {
     const bypassService = createFridayAuthService({
       db,
@@ -413,10 +474,11 @@ describe("FridayAuthService", () => {
       allowLocalBypassLogin: true,
     });
 
-    expect(() => bypassService.login({ local: true }, "203.0.113.20")).toThrow(FridayAuthError);
     try {
       bypassService.login({ local: true }, "203.0.113.20");
+      throw new Error("expected local bypass login to throw");
     } catch (err) {
+      expect(err).toBeInstanceOf(FridayAuthError);
       expect((err as FridayAuthError).code).toBe("PASSWORDLESS_LOCALHOST_ONLY");
     }
   });

--- a/test/unit/api/http/friday-http-client-ip.test.ts
+++ b/test/unit/api/http/friday-http-client-ip.test.ts
@@ -91,10 +91,11 @@ describe("Friday HTTP client IP resolution", () => {
     });
 
     expect(clientIp).toBe("203.0.113.20");
-    expect(() => service.login({ local: true }, clientIp)).toThrow(FridayAuthError);
     try {
       service.login({ local: true }, clientIp);
+      throw new Error("expected local login to throw");
     } catch (err) {
+      expect(err).toBeInstanceOf(FridayAuthError);
       expect((err as FridayAuthError).code).toBe("PASSWORDLESS_LOCALHOST_ONLY");
     }
   });

--- a/test/unit/api/http/friday-http-server-static-ui.test.ts
+++ b/test/unit/api/http/friday-http-server-static-ui.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import * as net from "node:net";
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -104,22 +104,28 @@ describe("FridayHttpServer — Static UI Serving", () => {
 
   it("falls back to index.html for unknown non-API paths (SPA history)", async () => {
     fs.writeFileSync(path.join(tmpDir, "index.html"), "<html>SPA</html>");
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-    server = createFridayHttpServer({
-      routes: createRoutesWithPing(),
-      wsGateway: makeStubWsGateway(),
-      middleware: makeStubMiddleware(),
-      port,
-      host: "127.0.0.1",
-      uiStaticDir: tmpDir,
-    });
-    await server.listen();
+    try {
+      server = createFridayHttpServer({
+        routes: createRoutesWithPing(),
+        wsGateway: makeStubWsGateway(),
+        middleware: makeStubMiddleware(),
+        port,
+        host: "127.0.0.1",
+        uiStaticDir: tmpDir,
+      });
+      await server.listen();
 
-    const res = await fetch(`${baseUrl}/automations`);
-    expect(res.status).toBe(200);
-    expect(res.headers.get("content-type")).toContain("text/html");
-    const body = await res.text();
-    expect(body).toBe("<html>SPA</html>");
+      const res = await fetch(`${baseUrl}/automations`);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("text/html");
+      const body = await res.text();
+      expect(body).toBe("<html>SPA</html>");
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it("does not intercept /v1/* API routes", async () => {

--- a/test/unit/e2e/friday-closure-lib.test.ts
+++ b/test/unit/e2e/friday-closure-lib.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   FRIDAY_CLOSURE_STATUSES,
   FRIDAY_READINESS_VERDICTS,
+  buildClosureScratchEnv,
   collectChannelBlockers,
   collectCloudBlockers,
   createClosureRunId,
@@ -42,6 +43,24 @@ describe("friday closure lib", () => {
     });
     expect(blockers).toContain('Channel "telegram" is not configured in FRIDAY_CHANNELS_JSON');
     expect(blockers).not.toContain('Channel "discord" is not configured in FRIDAY_CHANNELS_JSON');
+  });
+
+  it("defaults local closure scratch env to local bypass login while preserving explicit overrides", () => {
+    const scratch = buildClosureScratchEnv({}, { state: "/tmp/friday-state" });
+    expect(scratch.FRIDAY_STATE_DIR).toBe("/tmp/friday-state");
+    expect(scratch.FRIDAY_CHANNELS_JSON).toBe('{"enabled":true,"instances":[]}');
+    expect(scratch.FRIDAY_BROWSER_HEADLESS).toBe("true");
+    expect(scratch.FRIDAY_ALLOW_LOCAL_BYPASS_LOGIN).toBe("true");
+
+    const explicit = buildClosureScratchEnv(
+      {
+        FRIDAY_ALLOW_LOCAL_BYPASS_LOGIN: "false",
+        FRIDAY_CHANNELS_JSON: '{"enabled":true,"instances":[{"kind":"discord","token":"$DISCORD_BOT_TOKEN"}]}',
+      },
+      { state: "/tmp/other-state" },
+    );
+    expect(explicit.FRIDAY_ALLOW_LOCAL_BYPASS_LOGIN).toBe("false");
+    expect(explicit.FRIDAY_CHANNELS_JSON).toContain('"discord"');
   });
 
   it("resolves NO-GO when ledger contains blockers", () => {

--- a/test/unit/hub/friday-hub-bootstrap.test.ts
+++ b/test/unit/hub/friday-hub-bootstrap.test.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import { createFridayHub } from "#hub";
 import type { FridayHub } from "#hub";
 import { FridayAuthError } from "#api";
@@ -88,6 +88,29 @@ describe("createFridayHub", () => {
     expect(operationIds).toContain("agent.loop.policy.get");
   });
 
+  it("deduplicates expected startup warnings across repeated hub bootstraps", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      hub = await createIsolatedHub();
+      await hub.stop();
+      hub = null;
+      if (stateDir) {
+        await fs.rm(stateDir, { recursive: true, force: true });
+        stateDir = null;
+      }
+      bundledSkillsDir = null;
+      managedSkillsDir = null;
+
+      hub = await createIsolatedHub();
+
+      const warnings = warnSpy.mock.calls.map(([message]) => String(message));
+      expect(warnings.filter((message) => message.includes("Created default admin user"))).toHaveLength(1);
+      expect(warnings.filter((message) => message.includes("No model routing configured"))).toHaveLength(0);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it("executor returns failed for unknown skill", async () => {
     hub = await createIsolatedHub();
     await hub.start();
@@ -107,10 +130,11 @@ describe("createFridayHub", () => {
 
   it("does not allow local bypass login from remote IP (allowLocalBypassLogin defaults to false)", async () => {
     hub = await createIsolatedHub();
-    expect(() => hub!.apiRuntime.auth.login({ local: true }, "203.0.113.20")).toThrow(FridayAuthError);
     try {
       hub!.apiRuntime.auth.login({ local: true }, "203.0.113.20");
+      throw new Error("expected local bypass login to throw");
     } catch (err) {
+      expect(err).toBeInstanceOf(FridayAuthError);
       expect((err as FridayAuthError).code).toBe("PASSWORDLESS_LOCALHOST_ONLY");
     }
   });

--- a/test/unit/link-understanding/friday-summarize-realistic.test.ts
+++ b/test/unit/link-understanding/friday-summarize-realistic.test.ts
@@ -7,7 +7,7 @@
  * Readability also fails to extract meaningful content.
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   summarizeContent,
   stripHtmlToText,
@@ -212,6 +212,17 @@ describe("summarizeContent — realistic HTML", () => {
       const result = await extractReadableContent(smallHtml);
       expect(result).not.toBeNull();
       expect(result!.text).toContain("Short but important content");
+    });
+
+    it("does not warn when baseURI assignment is unsupported but extraction still works", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+      const result = await extractReadableContent(NEWS_ARTICLE_HTML, "https://example.com/story");
+      expect(result).not.toBeNull();
+      expect(result!.text).toContain("AI-powered coding agents");
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        "[friday][link-summarize] base URI assignment failed:",
+        expect.any(String),
+      );
     });
   });
 

--- a/test/unit/memory/services/friday-memory-service.test.ts
+++ b/test/unit/memory/services/friday-memory-service.test.ts
@@ -18,8 +18,10 @@ describe("FridayMemoryService", () => {
   function createMockProviderService(opts?: {
     embedFails?: boolean;
     embedVector?: number[];
+    embedFailureMessages?: string[];
   }): FridayProviderService {
     const vector = opts?.embedVector ?? [0.1, 0.2, 0.3];
+    let failureIndex = 0;
 
     return {
       listProviders: vi.fn(),
@@ -32,8 +34,12 @@ describe("FridayMemoryService", () => {
       setRoutingConfig: vi.fn(),
       resolveRoute: vi.fn(),
       runWithFallback: vi.fn().mockImplementation(async (params) => {
-        if (opts?.embedFails) {
-          throw new FridayDomainError("EMBEDDING_UNAVAILABLE", "Embedding failed");
+        if (opts?.embedFails || opts?.embedFailureMessages) {
+          const failureMessage = opts?.embedFailureMessages?.[
+            Math.min(failureIndex, (opts.embedFailureMessages?.length ?? 1) - 1)
+          ] ?? "Embedding failed";
+          failureIndex += 1;
+          throw new FridayDomainError("EMBEDDING_UNAVAILABLE", failureMessage);
         }
         // Simulate: the `run` function calls fetch which returns an embedding
         // We intercept before that by returning the result directly
@@ -153,6 +159,30 @@ describe("FridayMemoryService", () => {
     expect(found).not.toBeNull();
   });
 
+  it("does not warn when storage falls back because no embedding route is configured", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const svc = createFridayMemoryService({
+      db,
+      providerService: createMockProviderService({
+        embedFailureMessages: [
+          'No enabled providers available for routing: defaultProviderId "route-a" is enabled but was not selected',
+          'No enabled providers available for routing: defaultProviderId "route-b" is enabled but was not selected',
+        ],
+      }),
+      idGenerator: idGen,
+      nowIso: () => NOW,
+    });
+
+    await svc.store("ns", "first memory");
+    await svc.store("ns", "second memory");
+
+    expect(
+      warnSpy.mock.calls.filter(([message]) =>
+        String(message).includes("[friday][memory-service] embedding failed: No enabled providers available for routing"),
+      ),
+    ).toHaveLength(0);
+  });
+
   // ─── Get / List / Delete ───
 
   it("gets a stored item by ID", async () => {
@@ -224,6 +254,36 @@ describe("FridayMemoryService", () => {
     const results = await svc.search("fox");
     expect(results.length).toBeGreaterThanOrEqual(1);
     expect(results[0].matchedBy).toContain("fts");
+  });
+
+  it("does not warn when search falls back to FTS because no embedding route is configured", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const svc = createFridayMemoryService({
+      db,
+      providerService: createMockProviderService({
+        embedFailureMessages: [
+          'No enabled providers available for routing: defaultProviderId "store-a" is enabled but was not selected',
+          'No enabled providers available for routing: defaultProviderId "store-b" is enabled but was not selected',
+          'No enabled providers available for routing: defaultProviderId "query-a" is enabled but was not selected',
+          'No enabled providers available for routing: defaultProviderId "query-b" is enabled but was not selected',
+        ],
+      }),
+      idGenerator: idGen,
+      nowIso: () => NOW,
+    });
+
+    await svc.store("ns", "The quick brown fox");
+    await svc.store("ns", "Another fox mention");
+    const first = await svc.search("fox");
+    const second = await svc.search("fox");
+
+    expect(first.length).toBeGreaterThanOrEqual(1);
+    expect(second.length).toBeGreaterThanOrEqual(1);
+    expect(
+      warnSpy.mock.calls.filter(([message]) =>
+        String(message).includes("[friday][memory-service] semantic search unavailable: No enabled providers available for routing"),
+      ),
+    ).toHaveLength(0);
   });
 
   // ─── Prune ───

--- a/test/unit/memory/sync/friday-memory-file-sync-service.test.ts
+++ b/test/unit/memory/sync/friday-memory-file-sync-service.test.ts
@@ -99,6 +99,90 @@ describe("FridayMemoryFileSyncService", () => {
     expect(first.sequence).toBe(1);
   });
 
+  it("does not warn when session content_json is plain text and content_text is null", async () => {
+    db.withWriteTransaction((conn) => {
+      conn.prepare(
+        `INSERT INTO sessions (id, session_key, channel, chat_kind, status, agent_id, metadata_json, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).run("sess-plain", "test:session:plain", "cli", "dm", "active", "agent-1", "{}", "2025-01-01T00:00:00Z", "2025-01-01T00:00:00Z");
+      conn.prepare(
+        `INSERT INTO session_messages (id, session_id, session_key, role, content_json, content_text, sequence, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).run(
+        "msg-plain",
+        "sess-plain",
+        "test:session:plain",
+        "assistant",
+        "Agent said hello from plain text",
+        null,
+        1,
+        "2025-01-01T00:00:00Z",
+        "2025-01-01T00:00:00Z",
+      );
+    });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const repo = createFridayMemoryFileSyncRepository({ db });
+    const service = createFridayMemoryFileSyncService({
+      repository: repo,
+      stateDir: tmpDir,
+    });
+
+    await service.syncNow({ force: true });
+
+    const filePath = sessionKeyExportPath(tmpDir, "test:session:plain");
+    const content = await fs.readFile(filePath, "utf8");
+    const first = JSON.parse(content.trim().split("\n")[0]!);
+    expect(first.content).toBe("Agent said hello from plain text");
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      "[friday][memory-file-sync] try-parse-json:",
+      expect.any(String),
+    );
+  });
+
+  it("warns only for malformed JSON-looking session content and preserves the raw payload", async () => {
+    db.withWriteTransaction((conn) => {
+      conn.prepare(
+        `INSERT INTO sessions (id, session_key, channel, chat_kind, status, agent_id, metadata_json, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).run("sess-badjson", "test:session:badjson", "cli", "dm", "active", "agent-1", "{}", "2025-01-01T00:00:00Z", "2025-01-01T00:00:00Z");
+      conn.prepare(
+        `INSERT INTO session_messages (id, session_id, session_key, role, content_json, content_text, sequence, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).run(
+        "msg-badjson",
+        "sess-badjson",
+        "test:session:badjson",
+        "assistant",
+        "{\"broken\":",
+        null,
+        1,
+        "2025-01-01T00:00:00Z",
+        "2025-01-01T00:00:00Z",
+      );
+    });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const repo = createFridayMemoryFileSyncRepository({ db });
+    const service = createFridayMemoryFileSyncService({
+      repository: repo,
+      stateDir: tmpDir,
+    });
+
+    await service.syncNow({ force: true });
+
+    const filePath = sessionKeyExportPath(tmpDir, "test:session:badjson");
+    const content = await fs.readFile(filePath, "utf8");
+    const first = JSON.parse(content.trim().split("\n")[0]!);
+    expect(first.content).toBe("{\"broken\":");
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[friday][memory-file-sync] try-parse-json:",
+      expect.any(String),
+    );
+  });
+
   it("hash-based skip prevents redundant writes", async () => {
     insertMemoryItem("item-1", "skip-ns", "key1", '{"val":1}');
 

--- a/test/unit/skills/executor/friday-skill-executor.test.ts
+++ b/test/unit/skills/executor/friday-skill-executor.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { createFridayChannelRegistry } from "#channels";
 import { createFridaySkillExecutor } from "#skills";
 import { createFridaySkillRunStore } from "#ledger";
@@ -310,6 +310,88 @@ describe("FridaySkillExecutor", () => {
     const result2 = await executor.execute(baseRequest).result;
 
     expect(result1.runId).not.toBe(result2.runId);
+  });
+
+  it("does not warn when a shell skill returns plain-text stdout", async () => {
+    const fs = await import("node:fs/promises");
+    const scriptDir = await fs.mkdtemp("/tmp/friday-skill-plain-");
+    await fs.writeFile(
+      `${scriptDir}/plain.sh`,
+      "#!/bin/sh\nprintf 'hello from shell\\n'\n",
+      { mode: 0o755 },
+    );
+
+    const skill = makeRegisteredSkill({
+      id: "echo-skill",
+      runtimeKind: "shell",
+      entrypoint: "plain.sh",
+      skillDir: scriptDir,
+    });
+
+    const skills = new Map<string, FridayRegisteredSkill>();
+    skills.set("echo-skill", skill);
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const executor = createFridaySkillExecutor({
+      db,
+      registry: createMockRegistry(skills),
+      runStore,
+      idGenerator: createTestIdGenerator(),
+      nowIso: () => "2025-01-15T10:00:00.000Z",
+    });
+
+    const result = await executor.execute(baseRequest).result;
+
+    expect(result.status).toBe("completed");
+    expect(result.output).toEqual({ raw: "hello from shell\n" });
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      "[friday][skill-executor] operation failed:",
+      expect.any(String),
+    );
+
+    await fs.rm(scriptDir, { recursive: true, force: true });
+  });
+
+  it("warns when a shell skill returns malformed JSON-looking stdout and preserves raw output", async () => {
+    const fs = await import("node:fs/promises");
+    const scriptDir = await fs.mkdtemp("/tmp/friday-skill-badjson-");
+    await fs.writeFile(
+      `${scriptDir}/badjson.sh`,
+      "#!/bin/sh\nprintf '{\"broken\":'\n",
+      { mode: 0o755 },
+    );
+
+    const skill = makeRegisteredSkill({
+      id: "echo-skill",
+      runtimeKind: "shell",
+      entrypoint: "badjson.sh",
+      skillDir: scriptDir,
+    });
+
+    const skills = new Map<string, FridayRegisteredSkill>();
+    skills.set("echo-skill", skill);
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const executor = createFridaySkillExecutor({
+      db,
+      registry: createMockRegistry(skills),
+      runStore,
+      idGenerator: createTestIdGenerator(),
+      nowIso: () => "2025-01-15T10:00:00.000Z",
+    });
+
+    const result = await executor.execute(baseRequest).result;
+
+    expect(result.status).toBe("completed");
+    expect(result.output).toEqual({ raw: "{\"broken\":" });
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[friday][skill-executor] operation failed:",
+      expect.any(String),
+    );
+
+    await fs.rm(scriptDir, { recursive: true, force: true });
   });
 
   it("injects readonly Friday runtime helpers into node skills without write interfaces", async () => {

--- a/test/unit/system/friday-system-service.test.ts
+++ b/test/unit/system/friday-system-service.test.ts
@@ -374,6 +374,91 @@ describe("createFridaySystemService", () => {
     );
   });
 
+  it("does not capture a snapshot when the companion is disconnected", async () => {
+    const captureSnapshot = vi.fn(async () => {
+      throw new Error("capture should be skipped when disconnected");
+    });
+    const fixture = await createServiceFixtureWithOptions({
+      companionReconnectIntervalMs: 0,
+      companionBridge: {
+        ...createCompanionBridge(),
+        async connect() {
+          throw new Error("connect ENOENT /tmp/system-companion.sock");
+        },
+        isConnected() {
+          return false;
+        },
+        async getStatus() {
+          return {
+            id: "companion-offline",
+            platform: "darwin" as const,
+            connected: false,
+            transport: {
+              mode: "unix_socket" as const,
+              protocol: "jsonrpc-2.0" as const,
+              authenticated: false,
+              socketPath: `${WORKSPACE_ROOT}/system-companion.sock`,
+            },
+            launchAtLoginEnabled: true,
+            panicHotkey: "cmd+shift+escape",
+            safeMode: false,
+            overlayVisible: false,
+            lastHeartbeatAt: "2026-03-06T12:00:00.000Z",
+            capabilities: createCompanionCapabilities(true),
+            permissions: [],
+          };
+        },
+        captureSnapshot,
+      },
+    });
+    allocatedDbs.push(fixture.db);
+
+    const state = await fixture.service.getState();
+
+    expect(captureSnapshot).not.toHaveBeenCalled();
+    expect(state.apps).toEqual([]);
+    expect(state.windows).toEqual([]);
+    expect(state.notifications).toEqual([]);
+    expect(state.health.status).toBe("unavailable");
+  });
+
+  it("deduplicates degraded companion startup warnings across service instances when only the socket path changes", async () => {
+    const warn = vi.fn();
+    const firstFixture = await createServiceFixtureWithOptions({
+      warn,
+      companionReconnectIntervalMs: 0,
+      companionBridge: {
+        ...createCompanionBridge(),
+        async connect() {
+          throw new Error("connect ENOENT /tmp/system-companion-a.sock");
+        },
+        isConnected() {
+          return false;
+        },
+      },
+    });
+    const secondFixture = await createServiceFixtureWithOptions({
+      warn,
+      companionReconnectIntervalMs: 0,
+      companionBridge: {
+        ...createCompanionBridge(),
+        async connect() {
+          throw new Error("connect ENOENT /tmp/system-companion-b.sock");
+        },
+        isConnected() {
+          return false;
+        },
+      },
+    });
+    allocatedDbs.push(firstFixture.db, secondFixture.db);
+
+    expect(
+      warn.mock.calls.filter(([message]) =>
+        String(message).includes("system companion unavailable at startup; continuing in degraded mode"),
+      ),
+    ).toHaveLength(1);
+  });
+
   it("propagates native companion safe mode into health and revokes the active lease", async () => {
     const companionState: CompanionTestState = {
       safeMode: false,

--- a/test/unit/system/friday-system-unix-socket-bridge.test.ts
+++ b/test/unit/system/friday-system-unix-socket-bridge.test.ts
@@ -1,8 +1,9 @@
 import * as fs from "node:fs/promises";
+import * as net from "node:net";
 import * as os from "node:os";
 import * as path from "node:path";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createFridaySystemUnixSocketCompanionServer } from "../../../src/system/companion/friday-system-unix-socket-companion-server.js";
 import { createFridaySystemUnixSocketBridge } from "../../../src/system/companion/friday-system-unix-socket-bridge.js";
@@ -190,5 +191,141 @@ describe("Friday system unix socket companion transport", () => {
     expect(snapshot.apps).toEqual([]);
 
     await server.stop();
+  });
+
+  it("deduplicates repeated captureSnapshot warnings for the same transport error", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "friday-system-socket-"));
+    cleanupPaths.push(tempDir);
+    const socketPath = path.join(tempDir, "companion.sock");
+    const nowIso = createNowIso();
+    const server = createFridaySystemUnixSocketCompanionServer({
+      id: "companion-socket",
+      platform: "darwin",
+      nowIso,
+      authToken: "expected-token",
+      socketPath,
+      launchAtLoginEnabled: true,
+      panicHotkey: "cmd+shift+escape",
+    });
+    await server.start();
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      const bridge = createFridaySystemUnixSocketBridge({
+        id: "companion-socket",
+        platform: "darwin",
+        nowIso,
+        authToken: "wrong-token",
+        socketPath,
+        launchAtLoginEnabled: true,
+        panicHotkey: "cmd+shift+escape",
+      });
+
+      await bridge.captureSnapshot();
+      await bridge.captureSnapshot();
+
+      expect(
+        warnSpy.mock.calls.filter(([message]) =>
+          String(message).includes("[friday][unix-socket-bridge] captureSnapshot: Unauthorized"),
+        ),
+      ).toHaveLength(1);
+    } finally {
+      warnSpy.mockRestore();
+      await server.stop();
+    }
+  });
+
+  it("silently falls back to an empty snapshot when captureSnapshot times out", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "friday-system-socket-"));
+    cleanupPaths.push(tempDir);
+    const socketPath = path.join(tempDir, "companion.sock");
+    const nowIso = createNowIso();
+    const openSockets = new Set<net.Socket>();
+    const hangingServer = net.createServer((socket) => {
+      openSockets.add(socket);
+      socket.on("close", () => {
+        openSockets.delete(socket);
+      });
+      // Intentionally never respond so the bridge exercises its timeout fallback.
+    });
+    await new Promise<void>((resolve, reject) => {
+      hangingServer.once("error", reject);
+      hangingServer.listen(socketPath, () => resolve());
+    });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      const bridge = createFridaySystemUnixSocketBridge({
+        id: "companion-socket",
+        platform: "darwin",
+        nowIso,
+        authToken: "secret-token",
+        socketPath,
+        launchAtLoginEnabled: true,
+        panicHotkey: "cmd+shift+escape",
+        requestTimeoutMs: 10,
+      });
+
+      const snapshot = await bridge.captureSnapshot();
+
+      expect(snapshot).toEqual({
+        apps: [],
+        windows: [],
+        notifications: [],
+      });
+      expect(
+        warnSpy.mock.calls.filter(([message]) =>
+          String(message).includes("[friday][unix-socket-bridge] captureSnapshot:"),
+        ),
+      ).toHaveLength(0);
+    } finally {
+      warnSpy.mockRestore();
+      for (const socket of openSockets) {
+        socket.destroy();
+      }
+      await new Promise<void>((resolve, reject) => {
+        hangingServer.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
+  it("deduplicates repeated getStatus warnings for missing sockets with different temp paths", async () => {
+    const tempDirA = await fs.mkdtemp(path.join(os.tmpdir(), "friday-system-socket-"));
+    const tempDirB = await fs.mkdtemp(path.join(os.tmpdir(), "friday-system-socket-"));
+    cleanupPaths.push(tempDirA, tempDirB);
+    const nowIso = createNowIso();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    try {
+      const bridgeA = createFridaySystemUnixSocketBridge({
+        id: "companion-socket-a",
+        platform: "darwin",
+        nowIso,
+        authToken: "secret-token",
+        socketPath: path.join(tempDirA, "companion.sock"),
+        launchAtLoginEnabled: true,
+        panicHotkey: "cmd+shift+escape",
+      });
+      const bridgeB = createFridaySystemUnixSocketBridge({
+        id: "companion-socket-b",
+        platform: "darwin",
+        nowIso,
+        authToken: "secret-token",
+        socketPath: path.join(tempDirB, "companion.sock"),
+        launchAtLoginEnabled: true,
+        panicHotkey: "cmd+shift+escape",
+      });
+
+      await bridgeA.getStatus();
+      await bridgeB.getStatus();
+
+      expect(
+        warnSpy.mock.calls.filter(([message]) =>
+          String(message).includes("[friday][unix-socket-bridge] getStatus: connect ENOENT"),
+        ),
+      ).toHaveLength(1);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- stabilize Friday's non-cloud runtime surfaces and reduce misleading warning noise
- tighten non-cloud contract surfacing around dormant packaging exports and route contracts
- refresh non-platform closeout evidence against the validated branch head

## What This PR Claims
- Friday's non-cloud main paths have zero known blockers and are stable for local/non-cloud operation
- local closure is real `GO`
- `closure:all` remains honest: local `GO`, cloud `NO-GO` because cloud env contracts are still missing

## What This PR Does Not Claim
- this does not claim cloud/live all-environment readiness
- this does not resolve Docker-host availability or cross-platform release input gaps

## Remaining Blockers Outside This PR
- cloud env contract: `FRIDAY_E2E_CLOUD_BASE_URL`, `FRIDAY_E2E_CLOUD_AUTH_MODE`, and related credentials
- Docker-capable host verification
- cross-platform release inputs

## Validation
- `git diff --check`
- `npm test`
- `npm run check:enablement-gaps`
- `npm run check:desktop-runtime`
- `npm run test:install:smoke`
- `npm run test:e2e:ui`
- `npm run test:e2e:closure:local`
- `npm run test:e2e:closure:all`
- `npm run release:verify`
- `npm run closeout:final`