### PR TITLE
fix: second-round audit remediation — P2 remaining fixes + learned-fa…

### DIFF
--- a/src/api/http/routes/friday-discovery-routes.ts
+++ b/src/api/http/routes/friday-discovery-routes.ts
@@ -7,6 +7,7 @@
  * @module api/http/routes
  */
 
+import { FridayDomainError } from "#errors";
 import type { FridayHttpContext, FridayRouteDefinition } from "../../model/friday-api-common.types.js";
 import type {
   FridayDiscoveryFilterOptions,
@@ -72,7 +73,7 @@ export function createFridayDiscoveryRoutes(
       handler: async (_ctx: Ctx) => {
         const catalog = deps.discovery.getCachedCatalog();
         if (!catalog) {
-          return { status: 404, body: { error: "No catalog available — run a scan first" } };
+          throw new FridayDomainError("CATALOG_NOT_AVAILABLE", "No catalog available — run a scan first", { httpStatus: 404 });
         }
         return { status: 200, body: { catalog } };
       },
@@ -87,7 +88,7 @@ export function createFridayDiscoveryRoutes(
       handler: async (ctx: Ctx) => {
         const catalog = deps.discovery.getCachedCatalog();
         if (!catalog) {
-          return { status: 404, body: { error: "No catalog available — run a scan first" } };
+          throw new FridayDomainError("CATALOG_NOT_AVAILABLE", "No catalog available — run a scan first", { httpStatus: 404 });
         }
 
         const query = ctx.query ?? {};

--- a/src/api/http/routes/friday-satellite-pairing-routes.ts
+++ b/src/api/http/routes/friday-satellite-pairing-routes.ts
@@ -4,6 +4,7 @@
  * @module api/http/routes/friday-satellite-pairing-routes
  */
 
+import { FridayDomainError } from "#errors";
 import type { FridayHttpContext, FridayRouteDefinition } from "../../model/friday-api-common.types.js";
 
 type Ctx = FridayHttpContext<unknown, Record<string, string>, unknown>;
@@ -168,7 +169,7 @@ export function createFridaySatellitePairingRoutes(
         const params = ctx.params as Record<string, string>;
         const request = await deps.getPairingRequest(params.satelliteId);
         if (!request) {
-          return { error: { code: "NOT_FOUND", message: "No pairing request found" } };
+          throw new FridayDomainError("NOT_FOUND", "No pairing request found", { httpStatus: 404 });
         }
         return request;
       },
@@ -185,7 +186,7 @@ export function createFridaySatellitePairingRoutes(
         const body = ctx.body as Record<string, unknown>;
         const pairingReq = await deps.getPairingRequest(params.satelliteId);
         if (!pairingReq) {
-          return { error: { code: "NOT_FOUND", message: "No pending pairing request" } };
+          throw new FridayDomainError("NOT_FOUND", "No pending pairing request", { httpStatus: 404 });
         }
 
         const result = await deps.approvePairing({
@@ -211,7 +212,7 @@ export function createFridaySatellitePairingRoutes(
         const body = ctx.body as Record<string, unknown>;
         const pairingReq = await deps.getPairingRequest(params.satelliteId);
         if (!pairingReq) {
-          return { error: { code: "NOT_FOUND", message: "No pending pairing request" } };
+          throw new FridayDomainError("NOT_FOUND", "No pending pairing request", { httpStatus: 404 });
         }
 
         const result = await deps.rejectPairing({

--- a/src/api/http/routes/friday-uix-routes.ts
+++ b/src/api/http/routes/friday-uix-routes.ts
@@ -22,6 +22,8 @@ import type {
 
 export interface FridayUixRoutesDeps {
   service: FridayUixSurfaceService;
+  /** Optional: expose learned preference facts to users for transparency. */
+  listLearnedFacts?: (input: { userId: string }) => Array<{ key: string; value: unknown; confidence: number; evidenceCount: number; lastConfirmedAt: string }>;
 }
 
 function requireUserId(principal: { userId?: string } | null): string {
@@ -313,6 +315,22 @@ export function createFridayUixRoutes(
           runId: wizardResponse.wizard.contextId,
           wizardId: goalCategoryId,
         };
+      },
+    },
+
+    // ── Learned Facts (learning feedback visibility) ──
+    {
+      operationId: "uix.learnedfacts.list",
+      method: "GET",
+      path: "/v1/uix/learned-facts",
+      auth: { public: false, anyOfScopes: ["agent.run"] },
+      async handler(ctx) {
+        const userId = requireUserId(ctx.principal);
+        if (!deps.listLearnedFacts) {
+          return { items: [] };
+        }
+        const items = deps.listLearnedFacts({ userId });
+        return { items };
       },
     },
   ];

--- a/src/cli/friday-cli.ts
+++ b/src/cli/friday-cli.ts
@@ -633,6 +633,11 @@ function normalizeLegacyChannelEntry(
         warnLegacyChannelSkip(kind, "missing token");
         return null;
       }
+      // P2-05: Basic format validation — accept secret refs ($ENV, secret://) and validate raw tokens.
+      if (!token.startsWith("secret://") && !token.startsWith("$") && (token.length < 50 || !/^[A-Za-z0-9._\-]+$/.test(token))) {
+        warnLegacyChannelSkip(kind, "token format appears invalid (expected 50+ chars or secret:// / $ENV reference)");
+        return null;
+      }
       const instance: JsonObject = { kind: "discord", enabled: true, token };
       const allowedUsers = asStringArray(raw.allowedUsers) ?? asStringArray(raw.allowFrom);
       const allowedChannels = asStringArray(raw.allowedChannels) ?? asStringArray(raw.allowedChats);

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -645,22 +645,11 @@ export function createFridayHubAutoFixExecutionSupport(deps: {
   memoryState: FridayHubMemoryStateService;
   nowIso: () => string;
 }): FridayHubAutoFixExecutionSupport {
-  const unsupportedKinds: FridayAutoFixStepKind[] = [
-    "retry_node",
-    "switch_model_fallback",
-    "trim_payload",
-    "apply_config_patch",
-    "grant_permission",
-    "pause_workflow",
-  ];
-
+  // P2-07: Only override step kinds that need hub-level service access.
+  // All other kinds use DEFAULT_EXECUTORS from the execution service which
+  // correctly set directive markers and return true.
   const stepExecutors: Partial<Record<FridayAutoFixStepKind, StepExecutor>> = {};
   const stepVerifiers: Partial<Record<FridayAutoFixStepKind, StepVerifier>> = {};
-
-  for (const kind of unsupportedKinds) {
-    stepExecutors[kind] = async () => false;
-    stepVerifiers[kind] = async () => false;
-  }
 
   stepExecutors.disable_skill = async (step) => {
     if (!step.target) {

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -252,6 +252,7 @@ import {
 import type { FridaySystemRemoteMode, FridaySystemService } from "../system/index.js";
 import { buildFridayCommunicationPromptFragment, resolveFridayCommunicationPersona } from "../uix/services/friday-communication-persona.js";
 import { createFridayUixUserPreferenceRepository } from "../uix/persistence/friday-uix-user-preference-repository.js";
+import { createFridayOnboardingSessionRepository } from "../uix/persistence/friday-onboarding-session-repository.js";
 import { createFridayUixSurfaceService } from "../uix/services/friday-uix-surface-service.js";
 import { resolveFridayAuditLogPath } from "./services/friday-hub-audit-log-writer.js";
 import { createFridayGatewayService } from "./services/friday-gateway-service.js";
@@ -3308,7 +3309,12 @@ export async function createFridayHub(
     observability: observabilityService.routes,
     observabilityService,
     system: systemRouteDeps,
-    uix: { service: uixService },
+    uix: {
+      service: uixService,
+      listLearnedFacts: (input: { userId: string }) =>
+        selfLearningRuntime.facts.listActiveFacts({ userId: input.userId, minConfidence: 0, limit: 200 })
+          .map((f) => ({ key: f.key, value: f.value, confidence: f.confidence, evidenceCount: f.evidenceCount, lastConfirmedAt: f.lastConfirmedAt })),
+    },
     searchHealth: {
       provider: configuredSearchProvider && configuredSearchProvider.length > 0
         ? configuredSearchProvider
@@ -4247,7 +4253,13 @@ export async function createFridayHub(
       idGenerator,
       nowIso,
     });
-    const onboardingEngine = createOnboardingEngine();
+    const onboardingSessionRepo = createFridayOnboardingSessionRepository();
+    const onboardingEngine = createOnboardingEngine({
+      persistence: {
+        save: (session) => stateRuntime.sqlite.withWriteTransaction((db) => onboardingSessionRepo.save(db, session)),
+        loadActive: () => stateRuntime.sqlite.withReadConnection((db) => onboardingSessionRepo.listActive(db)),
+      },
+    });
     const setupCoordinator = createFridaySetupCoordinator({
       idGenerator,
       nowIso,

--- a/src/state/sqlite/friday-sqlite-read-pool.ts
+++ b/src/state/sqlite/friday-sqlite-read-pool.ts
@@ -35,7 +35,20 @@ export function createFridaySqliteReadPool(
     withReadConnection<T>(fn: (db: Database.Database) => T): T {
       const conn = connections[index % connections.length];
       index = (index + 1) % connections.length;
-      return fn(conn);
+      // P2-11: Error handling and slow-query diagnostics.
+      const start = performance.now();
+      try {
+        const result = fn(conn);
+        const elapsed = performance.now() - start;
+        if (elapsed > 5000) {
+          console.warn(`[friday][sqlite-read-pool] slow query: ${elapsed.toFixed(0)}ms`);
+        }
+        return result;
+      } catch (err) {
+        const elapsed = performance.now() - start;
+        console.warn(`[friday][sqlite-read-pool] query error after ${elapsed.toFixed(0)}ms:`, err instanceof Error ? err.message : String(err));
+        throw err;
+      }
     },
 
     close(): void {

--- a/src/state/sqlite/migrations/index.ts
+++ b/src/state/sqlite/migrations/index.ts
@@ -58,6 +58,7 @@ import { V056_INCENTIVE_ALIGNMENT_FOUNDATION_MIGRATION } from "./v056-incentive-
 import { V057_AGENT_AUTOMATION_SESSION_TARGETS_MIGRATION } from "./v057-agent-automation-session-targets.js";
 import { V058_AGENT_RUN_CONTEXT_PROFILE_MIGRATION } from "./v058-agent-run-context-profile.js";
 import { V059_RULES_AUDIT_CANONICALIZATION_MIGRATION } from "./v059-rules-audit-canonicalization.js";
+import { V060_UIX_ONBOARDING_SESSIONS_MIGRATION } from "./v060-uix-onboarding-sessions.js";
 
 /**
  * Ordered migration list, always ascending by version.
@@ -122,6 +123,7 @@ export const FRIDAY_SQLITE_MIGRATIONS: readonly FridaySqliteMigration[] = [
   V057_AGENT_AUTOMATION_SESSION_TARGETS_MIGRATION,
   V058_AGENT_RUN_CONTEXT_PROFILE_MIGRATION,
   V059_RULES_AUDIT_CANONICALIZATION_MIGRATION,
+  V060_UIX_ONBOARDING_SESSIONS_MIGRATION,
 ];
 
 export { V003_PROVIDER_USAGE_COST_ROUTING_MIGRATION };

--- a/src/state/sqlite/migrations/v060-uix-onboarding-sessions.ts
+++ b/src/state/sqlite/migrations/v060-uix-onboarding-sessions.ts
@@ -1,0 +1,30 @@
+import { computeFridayMigrationChecksum } from "./friday-migration.types.js";
+import type { FridaySqliteMigration } from "./friday-migration.types.js";
+
+export const V060_UIX_ONBOARDING_SESSIONS_SQL = `
+-- V060: Persist onboarding session progress so it survives process restarts.
+
+CREATE TABLE IF NOT EXISTS uix_onboarding_sessions (
+  id TEXT PRIMARY KEY,
+  flow_id TEXT NOT NULL,
+  principal_id TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'not_started',
+  step_progress TEXT NOT NULL DEFAULT '[]',
+  current_step_index INTEGER NOT NULL DEFAULT 0,
+  started_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  finished_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_uix_onboarding_flow_principal
+  ON uix_onboarding_sessions(flow_id, principal_id);
+`;
+
+const V060_CHECKSUM = computeFridayMigrationChecksum(V060_UIX_ONBOARDING_SESSIONS_SQL);
+
+export const V060_UIX_ONBOARDING_SESSIONS_MIGRATION: FridaySqliteMigration = {
+  version: 60,
+  name: "v060-uix-onboarding-sessions",
+  sql: V060_UIX_ONBOARDING_SESSIONS_SQL,
+  checksum: V060_CHECKSUM,
+};

--- a/src/uix/engine/onboarding-engine.ts
+++ b/src/uix/engine/onboarding-engine.ts
@@ -305,8 +305,15 @@ interface SessionMetricState {
 
 // ─── Factory ───
 
+/** P2-02: Optional persistence callbacks for surviving process restarts. */
+export interface OnboardingPersistence {
+  save: (session: OnboardingSession) => void;
+  loadActive: () => OnboardingSession[];
+}
+
 /** Create an onboarding engine instance. */
-export function createOnboardingEngine(): OnboardingEngine {
+export function createOnboardingEngine(options?: { persistence?: OnboardingPersistence }): OnboardingEngine {
+  const persistence = options?.persistence;
   const flows = new Map<string, OnboardingFlowDefinition>();
   const sessions = new Map<string, OnboardingSession>();
   /** Secondary index: `${flowId}:${principalId}` → session ID. */
@@ -316,6 +323,28 @@ export function createOnboardingEngine(): OnboardingEngine {
   /** Persisted telemetry/audit events. */
   const telemetryEvents: OnboardingTelemetryEvent[] = [];
   let sessionCounter = 0;
+
+  // P2-02: Restore active sessions from persistence layer on startup.
+  if (persistence) {
+    try {
+      const restored = persistence.loadActive();
+      for (const session of restored) {
+        sessions.set(session.id, session);
+        userFlowIndex.set(`${session.flowId}:${session.principalId}`, session.id);
+        sessionCounter = Math.max(sessionCounter, Number(session.id.replace(/\D/g, "")) || 0);
+      }
+    } catch (err) {
+      console.warn("[friday][onboarding] failed to restore sessions:", err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  function persistSession(session: OnboardingSession): void {
+    try {
+      persistence?.save(session);
+    } catch (err) {
+      console.warn("[friday][onboarding] persist failed:", err instanceof Error ? err.message : String(err));
+    }
+  }
 
   function userFlowKey(flowId: string, principalId: string): string {
     return `${flowId}:${principalId}`;
@@ -435,6 +464,7 @@ export function createOnboardingEngine(): OnboardingEngine {
       if (session.stepProgress.length > 0) {
         session.currentStepIndex = session.stepProgress.length - 1;
       }
+      persistSession(session);
 
       const metrics = findSessionMetricState(session.id);
       if (metrics && metrics.completedAt === undefined) {
@@ -551,6 +581,7 @@ export function createOnboardingEngine(): OnboardingEngine {
 
       sessions.set(sessionId, session);
       userFlowIndex.set(key, sessionId);
+      persistSession(session);
 
       emitTelemetry({
         type: "session_started",
@@ -614,6 +645,7 @@ export function createOnboardingEngine(): OnboardingEngine {
       activeStep.completedAt = transitionTime;
       activeStep.data = structuredClone(data);
       session.updatedAt = transitionTime;
+      persistSession(session);
 
       emitTelemetry({
         type: "step_completed",
@@ -665,6 +697,7 @@ export function createOnboardingEngine(): OnboardingEngine {
       activeStep.status = "skipped";
       activeStep.completedAt = transitionTime;
       session.updatedAt = transitionTime;
+      persistSession(session);
 
       emitTelemetry({
         type: "step_skipped",
@@ -727,6 +760,7 @@ export function createOnboardingEngine(): OnboardingEngine {
 
       session.currentStepIndex = previousCompletedIndex;
       session.updatedAt = transitionTime;
+      persistSession(session);
       activateStepTiming(session.id, previousCompletedStep.stepId, transitionTimeMs);
 
       emitTelemetry({
@@ -764,6 +798,7 @@ export function createOnboardingEngine(): OnboardingEngine {
       session.status = "dismissed";
       session.finishedAt = dismissTime;
       session.updatedAt = dismissTime;
+      persistSession(session);
 
       const metrics = findSessionMetricState(session.id);
       if (metrics) {

--- a/src/uix/persistence/friday-onboarding-session-repository.ts
+++ b/src/uix/persistence/friday-onboarding-session-repository.ts
@@ -1,0 +1,73 @@
+/**
+ * P2-02: SQLite-backed onboarding session repository.
+ * Persists onboarding progress so it survives process restarts.
+ */
+
+import type Database from "better-sqlite3";
+import type { OnboardingSession, OnboardingStepProgress } from "../engine/onboarding-engine.js";
+
+export interface FridayOnboardingSessionRepository {
+  save(db: Database.Database, session: OnboardingSession): void;
+  findByFlowAndPrincipal(db: Database.Database, flowId: string, principalId: string): OnboardingSession | null;
+  listActive(db: Database.Database): OnboardingSession[];
+  delete(db: Database.Database, sessionId: string): void;
+}
+
+export function createFridayOnboardingSessionRepository(): FridayOnboardingSessionRepository {
+  return {
+    save(db, session) {
+      db.prepare(`
+        INSERT OR REPLACE INTO uix_onboarding_sessions
+          (id, flow_id, principal_id, status, step_progress, current_step_index, started_at, updated_at, finished_at)
+        VALUES
+          (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        session.id,
+        session.flowId,
+        session.principalId,
+        session.status,
+        JSON.stringify(session.stepProgress),
+        session.currentStepIndex,
+        session.startedAt,
+        session.updatedAt,
+        session.finishedAt ?? null,
+      );
+    },
+
+    findByFlowAndPrincipal(db, flowId, principalId) {
+      const row = db.prepare(`
+        SELECT * FROM uix_onboarding_sessions
+        WHERE flow_id = ? AND principal_id = ?
+        ORDER BY updated_at DESC LIMIT 1
+      `).get(flowId, principalId) as Record<string, unknown> | undefined;
+      return row ? rowToSession(row) : null;
+    },
+
+    listActive(db) {
+      const rows = db.prepare(`
+        SELECT * FROM uix_onboarding_sessions
+        WHERE status IN ('not_started', 'in_progress')
+        ORDER BY updated_at DESC
+      `).all() as Array<Record<string, unknown>>;
+      return rows.map(rowToSession);
+    },
+
+    delete(db, sessionId) {
+      db.prepare("DELETE FROM uix_onboarding_sessions WHERE id = ?").run(sessionId);
+    },
+  };
+}
+
+function rowToSession(row: Record<string, unknown>): OnboardingSession {
+  return {
+    id: String(row.id),
+    flowId: String(row.flow_id),
+    principalId: String(row.principal_id),
+    status: String(row.status) as OnboardingSession["status"],
+    stepProgress: JSON.parse(String(row.step_progress ?? "[]")) as OnboardingStepProgress[],
+    currentStepIndex: Number(row.current_step_index ?? 0),
+    startedAt: String(row.started_at),
+    updatedAt: String(row.updated_at),
+    finishedAt: row.finished_at ? String(row.finished_at) : undefined,
+  };
+}

--- a/test/contracts/api/__snapshots__/friday-api-route-contract.snapshot.test.ts.snap
+++ b/test/contracts/api/__snapshots__/friday-api-route-contract.snapshot.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures route count to detect accidental additions/removals 1`] = `246`;
+exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures route count to detect accidental additions/removals 1`] = `247`;
 
 exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route surface as a stable contract 1`] = `
 [
@@ -1709,6 +1709,18 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
     "authKind": "authenticated",
     "index": 140,
     "method": "GET",
+    "operationId": "uix.learnedfacts.list",
+    "path": "/v1/uix/learned-facts",
+    "rateLimitPolicyId": null,
+    "roles": [],
+    "scopes": [
+      "agent.run",
+    ],
+  },
+  {
+    "authKind": "authenticated",
+    "index": 141,
+    "method": "GET",
     "operationId": "skills.converters.list",
     "path": "/v1/skills/converters",
     "rateLimitPolicyId": null,
@@ -1719,7 +1731,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 141,
+    "index": 142,
     "method": "POST",
     "operationId": "skills.convert",
     "path": "/v1/skills/convert",
@@ -1731,7 +1743,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 142,
+    "index": 143,
     "method": "POST",
     "operationId": "skills.import",
     "path": "/v1/skills/import",
@@ -1743,7 +1755,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 143,
+    "index": 144,
     "method": "POST",
     "operationId": "skills.pack",
     "path": "/v1/skills/pack",
@@ -1755,7 +1767,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 144,
+    "index": 145,
     "method": "POST",
     "operationId": "workflows.generator.sessions.create",
     "path": "/v1/workflows/generator/sessions",
@@ -1767,7 +1779,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 145,
+    "index": 146,
     "method": "GET",
     "operationId": "workflows.generator.sessions.get",
     "path": "/v1/workflows/generator/sessions/:sessionId",
@@ -1779,7 +1791,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 146,
+    "index": 147,
     "method": "POST",
     "operationId": "workflows.generator.sessions.messages.create",
     "path": "/v1/workflows/generator/sessions/:sessionId/messages",
@@ -1791,7 +1803,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 147,
+    "index": 148,
     "method": "POST",
     "operationId": "workflows.generator.sessions.generate",
     "path": "/v1/workflows/generator/sessions/:sessionId/generate",
@@ -1803,7 +1815,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 148,
+    "index": 149,
     "method": "GET",
     "operationId": "workflows.generator.sessions.evidence.get",
     "path": "/v1/workflows/generator/sessions/:sessionId/evidence",
@@ -1815,7 +1827,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 149,
+    "index": 150,
     "method": "POST",
     "operationId": "workflows.generator.sessions.approve",
     "path": "/v1/workflows/generator/sessions/:sessionId/approve",
@@ -1827,7 +1839,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 150,
+    "index": 151,
     "method": "DELETE",
     "operationId": "workflows.generator.sessions.cancel",
     "path": "/v1/workflows/generator/sessions/:sessionId",
@@ -1839,7 +1851,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 151,
+    "index": 152,
     "method": "GET",
     "operationId": "rules.bundles.list",
     "path": "/v1/rules/bundles",
@@ -1851,7 +1863,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 152,
+    "index": 153,
     "method": "GET",
     "operationId": "rules.bundles.get",
     "path": "/v1/rules/bundles/:bundleId",
@@ -1863,7 +1875,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 153,
+    "index": 154,
     "method": "POST",
     "operationId": "rules.bundles.create",
     "path": "/v1/rules/bundles",
@@ -1875,7 +1887,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 154,
+    "index": 155,
     "method": "GET",
     "operationId": "rules.list",
     "path": "/v1/rules/bundles/:bundleId/rules",
@@ -1887,7 +1899,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 155,
+    "index": 156,
     "method": "POST",
     "operationId": "rules.evaluate",
     "path": "/v1/rules/evaluate",
@@ -1899,7 +1911,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 156,
+    "index": 157,
     "method": "POST",
     "operationId": "rules.simulate",
     "path": "/v1/rules/simulate",
@@ -1911,7 +1923,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 157,
+    "index": 158,
     "method": "GET",
     "operationId": "rules.versions.list",
     "path": "/v1/rules/:ruleId/versions",
@@ -1923,7 +1935,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 158,
+    "index": 159,
     "method": "GET",
     "operationId": "rules.audit.log.list",
     "path": "/v1/rules/audit-log",
@@ -1935,7 +1947,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 159,
+    "index": 160,
     "method": "POST",
     "operationId": "node.runner.execute",
     "path": "/v1/node-runner/execute",
@@ -1947,7 +1959,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 160,
+    "index": 161,
     "method": "GET",
     "operationId": "node.runner.executions.get",
     "path": "/v1/node-runner/executions/:executionId",
@@ -1959,7 +1971,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 161,
+    "index": 162,
     "method": "GET",
     "operationId": "node.runner.executions.list",
     "path": "/v1/node-runner/executions",
@@ -1971,7 +1983,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 162,
+    "index": 163,
     "method": "POST",
     "operationId": "acceptance.run",
     "path": "/v1/acceptance/run",
@@ -1983,7 +1995,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 163,
+    "index": 164,
     "method": "GET",
     "operationId": "acceptance.results.get",
     "path": "/v1/acceptance/results/:resultId",
@@ -1995,7 +2007,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 164,
+    "index": 165,
     "method": "GET",
     "operationId": "acceptance.results.list",
     "path": "/v1/acceptance/results",
@@ -2007,7 +2019,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 165,
+    "index": 166,
     "method": "GET",
     "operationId": "acceptance.runs.get",
     "path": "/v1/acceptance/runs/:runId",
@@ -2019,7 +2031,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 166,
+    "index": 167,
     "method": "GET",
     "operationId": "acceptance.tests.list",
     "path": "/v1/acceptance/tests",
@@ -2031,7 +2043,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 167,
+    "index": 168,
     "method": "GET",
     "operationId": "acceptance.tests.get",
     "path": "/v1/acceptance/tests/:testId",
@@ -2043,7 +2055,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 168,
+    "index": 169,
     "method": "POST",
     "operationId": "acceptance.tests.create",
     "path": "/v1/acceptance/tests",
@@ -2055,7 +2067,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 169,
+    "index": 170,
     "method": "PUT",
     "operationId": "acceptance.tests.update",
     "path": "/v1/acceptance/tests/:testId",
@@ -2067,7 +2079,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 170,
+    "index": 171,
     "method": "DELETE",
     "operationId": "acceptance.tests.delete",
     "path": "/v1/acceptance/tests/:testId",
@@ -2079,7 +2091,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 171,
+    "index": 172,
     "method": "GET",
     "operationId": "acceptance.tests.versions.list",
     "path": "/v1/acceptance/tests/:testId/versions",
@@ -2091,7 +2103,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 172,
+    "index": 173,
     "method": "GET",
     "operationId": "acceptance.artifacts.history",
     "path": "/v1/acceptance/artifacts/history",
@@ -2103,7 +2115,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 173,
+    "index": 174,
     "method": "GET",
     "operationId": "retry.policies.list",
     "path": "/v1/retry/policies",
@@ -2115,7 +2127,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 174,
+    "index": 175,
     "method": "GET",
     "operationId": "retry.policies.get",
     "path": "/v1/retry/policies/:policyId",
@@ -2127,7 +2139,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 175,
+    "index": 176,
     "method": "POST",
     "operationId": "retry.policies.create",
     "path": "/v1/retry/policies",
@@ -2139,7 +2151,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 176,
+    "index": 177,
     "method": "PUT",
     "operationId": "retry.policies.update",
     "path": "/v1/retry/policies/:policyId",
@@ -2151,7 +2163,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 177,
+    "index": 178,
     "method": "DELETE",
     "operationId": "retry.policies.delete",
     "path": "/v1/retry/policies/:policyId",
@@ -2163,7 +2175,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 178,
+    "index": 179,
     "method": "POST",
     "operationId": "retry.classify",
     "path": "/v1/retry/classify",
@@ -2175,7 +2187,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 179,
+    "index": 180,
     "method": "POST",
     "operationId": "retry.decide",
     "path": "/v1/retry/decide",
@@ -2187,7 +2199,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 180,
+    "index": 181,
     "method": "GET",
     "operationId": "retry.traces.list",
     "path": "/v1/retry/traces",
@@ -2199,7 +2211,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 181,
+    "index": 182,
     "method": "GET",
     "operationId": "retry.traces.get",
     "path": "/v1/retry/traces/:traceId",
@@ -2211,7 +2223,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 182,
+    "index": 183,
     "method": "GET",
     "operationId": "retry.costs.summary",
     "path": "/v1/retry/costs",
@@ -2223,7 +2235,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 183,
+    "index": 184,
     "method": "GET",
     "operationId": "retry.escalations.list",
     "path": "/v1/retry/escalations",
@@ -2235,7 +2247,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 184,
+    "index": 185,
     "method": "POST",
     "operationId": "retry.escalations.acknowledge",
     "path": "/v1/retry/escalations/:escalationId/acknowledge",
@@ -2247,7 +2259,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 185,
+    "index": 186,
     "method": "GET",
     "operationId": "retry.circuit.breakers.list",
     "path": "/v1/retry/circuit-breakers",
@@ -2259,7 +2271,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 186,
+    "index": 187,
     "method": "GET",
     "operationId": "playbook.list",
     "path": "/v1/playbooks",
@@ -2271,7 +2283,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 187,
+    "index": 188,
     "method": "GET",
     "operationId": "playbook.get",
     "path": "/v1/playbooks/:playbookId",
@@ -2283,7 +2295,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 188,
+    "index": 189,
     "method": "POST",
     "operationId": "playbook.select",
     "path": "/v1/playbooks/select",
@@ -2295,7 +2307,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 189,
+    "index": 190,
     "method": "GET",
     "operationId": "playbook.candidates.list",
     "path": "/v1/playbooks/candidates",
@@ -2307,7 +2319,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 190,
+    "index": 191,
     "method": "POST",
     "operationId": "playbook.candidates.promote",
     "path": "/v1/playbooks/candidates/:candidateId/promote",
@@ -2319,7 +2331,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 191,
+    "index": 192,
     "method": "POST",
     "operationId": "playbook.rollback",
     "path": "/v1/playbooks/:playbookId/rollback",
@@ -2331,7 +2343,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 192,
+    "index": 193,
     "method": "GET",
     "operationId": "playbook.scores",
     "path": "/v1/playbooks/:playbookId/scores",
@@ -2343,7 +2355,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 193,
+    "index": 194,
     "method": "POST",
     "operationId": "memory.store",
     "path": "/v1/memory/store",
@@ -2355,7 +2367,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 194,
+    "index": 195,
     "method": "POST",
     "operationId": "memory.search",
     "path": "/v1/memory/search",
@@ -2367,7 +2379,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 195,
+    "index": 196,
     "method": "GET",
     "operationId": "memory.get",
     "path": "/v1/memory/items/:id",
@@ -2379,7 +2391,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 196,
+    "index": 197,
     "method": "GET",
     "operationId": "memory.list",
     "path": "/v1/memory/items",
@@ -2391,7 +2403,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 197,
+    "index": 198,
     "method": "DELETE",
     "operationId": "memory.delete",
     "path": "/v1/memory/items/:id",
@@ -2403,7 +2415,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 198,
+    "index": 199,
     "method": "POST",
     "operationId": "memory.prune",
     "path": "/v1/memory/prune",
@@ -2415,7 +2427,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 199,
+    "index": 200,
     "method": "GET",
     "operationId": "sessions.usage.get",
     "path": "/v1/sessions/:sessionKey/usage",
@@ -2427,7 +2439,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 200,
+    "index": 201,
     "method": "GET",
     "operationId": "sessions.usage.list",
     "path": "/v1/sessions/usage",
@@ -2439,7 +2451,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 201,
+    "index": 202,
     "method": "GET",
     "operationId": "sessions.list",
     "path": "/v1/sessions",
@@ -2451,7 +2463,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 202,
+    "index": 203,
     "method": "POST",
     "operationId": "sessions.create",
     "path": "/v1/sessions",
@@ -2463,7 +2475,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 203,
+    "index": 204,
     "method": "GET",
     "operationId": "sessions.get",
     "path": "/v1/sessions/:sessionKey",
@@ -2475,7 +2487,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 204,
+    "index": 205,
     "method": "POST",
     "operationId": "sessions.archive",
     "path": "/v1/sessions/:sessionKey/archive",
@@ -2487,7 +2499,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 205,
+    "index": 206,
     "method": "POST",
     "operationId": "sessions.reset",
     "path": "/v1/sessions/:sessionKey/reset",
@@ -2499,7 +2511,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 206,
+    "index": 207,
     "method": "POST",
     "operationId": "sessions.prune",
     "path": "/v1/sessions/prune",
@@ -2511,7 +2523,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 207,
+    "index": 208,
     "method": "POST",
     "operationId": "sessions.sweep",
     "path": "/v1/sessions/sweep",
@@ -2523,7 +2535,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 208,
+    "index": 209,
     "method": "GET",
     "operationId": "sessions.messages.list",
     "path": "/v1/sessions/:sessionKey/messages",
@@ -2535,7 +2547,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 209,
+    "index": 210,
     "method": "POST",
     "operationId": "sessions.messages.create",
     "path": "/v1/sessions/:sessionKey/messages",
@@ -2547,7 +2559,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 210,
+    "index": 211,
     "method": "POST",
     "operationId": "sessions.run",
     "path": "/v1/sessions/:sessionKey/run",
@@ -2561,7 +2573,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 211,
+    "index": 212,
     "method": "GET",
     "operationId": "sessions.memory.namespace.get",
     "path": "/v1/sessions/:sessionKey/memory-namespace",
@@ -2573,7 +2585,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 212,
+    "index": 213,
     "method": "POST",
     "operationId": "sessions.forks.create",
     "path": "/v1/sessions/:sessionKey/fork",
@@ -2585,7 +2597,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 213,
+    "index": 214,
     "method": "GET",
     "operationId": "sessions.forks.list",
     "path": "/v1/sessions/:sessionKey/forks",
@@ -2597,7 +2609,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 214,
+    "index": 215,
     "method": "POST",
     "operationId": "sessions.forks.merge",
     "path": "/v1/sessions/:sessionKey/merge",
@@ -2609,7 +2621,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 215,
+    "index": 216,
     "method": "POST",
     "operationId": "sessions.memory.extract",
     "path": "/v1/sessions/:sessionKey/memory/extract",
@@ -2621,7 +2633,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 216,
+    "index": 217,
     "method": "POST",
     "operationId": "sessions.memory.remember",
     "path": "/v1/sessions/:sessionKey/memory/remember",
@@ -2633,7 +2645,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 217,
+    "index": 218,
     "method": "GET",
     "operationId": "sessions.memory.extraction.get",
     "path": "/v1/sessions/:sessionKey/memory/extraction",
@@ -2645,7 +2657,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 218,
+    "index": 219,
     "method": "POST",
     "operationId": "sessions.memory.extraction.retry",
     "path": "/v1/sessions/memory/extraction/retry",
@@ -2657,7 +2669,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 219,
+    "index": 220,
     "method": "GET",
     "operationId": "plugins.list",
     "path": "/v1/plugins",
@@ -2669,7 +2681,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 220,
+    "index": 221,
     "method": "GET",
     "operationId": "plugins.get",
     "path": "/v1/plugins/:id",
@@ -2681,7 +2693,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 221,
+    "index": 222,
     "method": "GET",
     "operationId": "plugins.versions.list",
     "path": "/v1/plugins/:id/versions",
@@ -2693,7 +2705,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 222,
+    "index": 223,
     "method": "POST",
     "operationId": "plugins.install",
     "path": "/v1/plugins/:id/install",
@@ -2705,7 +2717,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 223,
+    "index": 224,
     "method": "POST",
     "operationId": "plugins.enable",
     "path": "/v1/plugins/:id/enable",
@@ -2717,7 +2729,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 224,
+    "index": 225,
     "method": "POST",
     "operationId": "plugins.disable",
     "path": "/v1/plugins/:id/disable",
@@ -2729,7 +2741,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 225,
+    "index": 226,
     "method": "DELETE",
     "operationId": "plugins.uninstall",
     "path": "/v1/plugins/:id",
@@ -2741,7 +2753,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 226,
+    "index": 227,
     "method": "GET",
     "operationId": "marketplace.plugins.list",
     "path": "/v1/marketplace/plugins",
@@ -2753,7 +2765,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 227,
+    "index": 228,
     "method": "GET",
     "operationId": "marketplace.plugins.get",
     "path": "/v1/marketplace/plugins/:id",
@@ -2765,7 +2777,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 228,
+    "index": 229,
     "method": "GET",
     "operationId": "marketplace.plugins.versions.list",
     "path": "/v1/marketplace/plugins/:id/versions",
@@ -2777,7 +2789,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 229,
+    "index": 230,
     "method": "POST",
     "operationId": "marketplace.plugins.install",
     "path": "/v1/marketplace/plugins/:id/install",
@@ -2789,7 +2801,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 230,
+    "index": 231,
     "method": "POST",
     "operationId": "agent.runs.start",
     "path": "/v1/agent/runs",
@@ -2802,7 +2814,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 231,
+    "index": 232,
     "method": "GET",
     "operationId": "agent.runs.list",
     "path": "/v1/agent/runs",
@@ -2815,7 +2827,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 232,
+    "index": 233,
     "method": "GET",
     "operationId": "agent.runs.get",
     "path": "/v1/agent/runs/:runId",
@@ -2828,7 +2840,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 233,
+    "index": 234,
     "method": "POST",
     "operationId": "agent.runs.cancel",
     "path": "/v1/agent/runs/:runId/cancel",
@@ -2841,7 +2853,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 234,
+    "index": 235,
     "method": "POST",
     "operationId": "agent.runs.approve.plan",
     "path": "/v1/agent/runs/:runId/approve-plan",
@@ -2854,7 +2866,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 235,
+    "index": 236,
     "method": "POST",
     "operationId": "agent.runs.reject.plan",
     "path": "/v1/agent/runs/:runId/reject-plan",
@@ -2867,7 +2879,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 236,
+    "index": 237,
     "method": "GET",
     "operationId": "agent.runs.events",
     "path": "/v1/agent/runs/:runId/events",
@@ -2880,7 +2892,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 237,
+    "index": 238,
     "method": "POST",
     "operationId": "agent.automations.create",
     "path": "/v1/agent/automations",
@@ -2893,7 +2905,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 238,
+    "index": 239,
     "method": "GET",
     "operationId": "agent.automations.list",
     "path": "/v1/agent/automations",
@@ -2906,7 +2918,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 239,
+    "index": 240,
     "method": "GET",
     "operationId": "agent.automations.get",
     "path": "/v1/agent/automations/:automationId",
@@ -2919,7 +2931,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 240,
+    "index": 241,
     "method": "PATCH",
     "operationId": "agent.automations.update",
     "path": "/v1/agent/automations/:automationId",
@@ -2932,7 +2944,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 241,
+    "index": 242,
     "method": "DELETE",
     "operationId": "agent.automations.delete",
     "path": "/v1/agent/automations/:automationId",
@@ -2945,7 +2957,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 242,
+    "index": 243,
     "method": "POST",
     "operationId": "agent.automations.run",
     "path": "/v1/agent/automations/:automationId/run",
@@ -2958,7 +2970,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 243,
+    "index": 244,
     "method": "GET",
     "operationId": "agent.subagents.list",
     "path": "/v1/agent/subagents",
@@ -2970,7 +2982,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 244,
+    "index": 245,
     "method": "GET",
     "operationId": "agent.subagents.get",
     "path": "/v1/agent/subagents/:subagentId",
@@ -2982,7 +2994,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "authenticated",
-    "index": 245,
+    "index": 246,
     "method": "GET",
     "operationId": "agent.runs.subagents.list",
     "path": "/v1/agent/runs/:runId/subagents",

--- a/test/unit/api/http/routes/friday-uix-routes.test.ts
+++ b/test/unit/api/http/routes/friday-uix-routes.test.ts
@@ -176,7 +176,7 @@ function makeService(): FridayUixSurfaceService {
 describe("FridayUixRoutes", () => {
   it("creates assistant route definitions", () => {
     const routes = createFridayUixRoutes({ service: makeService() });
-    expect(routes).toHaveLength(14);
+    expect(routes).toHaveLength(15);
     expect(routes.map((route) => route.operationId)).toEqual([
       "uix.intents.resolve",
       "uix.templates.list",
@@ -192,6 +192,7 @@ describe("FridayUixRoutes", () => {
       "uix.user.profile.get",
       "uix.user.profile.update",
       "uix.investigate",
+      "uix.learnedfacts.list",
     ]);
   });
 

--- a/test/unit/api/routes/friday-satellite-pairing-routes.test.ts
+++ b/test/unit/api/routes/friday-satellite-pairing-routes.test.ts
@@ -190,8 +190,7 @@ describe("createFridaySatellitePairingRoutes", () => {
       const routes = createFridaySatellitePairingRoutes(deps);
       const route = findRoute(routes, "satellites.pairing.get");
 
-      const result = await route.handler(makeCtx({ params: { satelliteId: "sat-999" } }) as any);
-      expect(result).toEqual({ error: expect.objectContaining({ code: "NOT_FOUND" }) });
+      await expect(route.handler(makeCtx({ params: { satelliteId: "sat-999" } }) as any)).rejects.toThrow("No pairing request found");
     });
   });
 
@@ -226,8 +225,7 @@ describe("createFridaySatellitePairingRoutes", () => {
       const routes = createFridaySatellitePairingRoutes(deps);
       const route = findRoute(routes, "satellites.pairing.approve");
 
-      const result = await route.handler(makeCtx({ params: { satelliteId: "sat-001" }, body: {} }) as any);
-      expect(result).toEqual({ error: expect.objectContaining({ code: "NOT_FOUND" }) });
+      await expect(route.handler(makeCtx({ params: { satelliteId: "sat-001" }, body: {} }) as any)).rejects.toThrow("No pending pairing request");
     });
 
     it("falls back to 'system' when no principal is present", async () => {
@@ -272,8 +270,7 @@ describe("createFridaySatellitePairingRoutes", () => {
       const routes = createFridaySatellitePairingRoutes(deps);
       const route = findRoute(routes, "satellites.pairing.reject");
 
-      const result = await route.handler(makeCtx({ params: { satelliteId: "sat-001" }, body: {} }) as any);
-      expect(result).toEqual({ error: expect.objectContaining({ code: "NOT_FOUND" }) });
+      await expect(route.handler(makeCtx({ params: { satelliteId: "sat-001" }, body: {} }) as any)).rejects.toThrow("No pending pairing request");
     });
   });
 

--- a/test/unit/cli/friday-cli.test.ts
+++ b/test/unit/cli/friday-cli.test.ts
@@ -610,7 +610,7 @@ describe("prepareStartupChannelsConfig", () => {
         JSON.stringify({
           channels: {
             discord: {
-              token: "fake-discord-token",
+              token: "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAuR2FiY0RlLkFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFla",
               allowedUsers: ["jarvis"],
             },
           },
@@ -651,13 +651,14 @@ describe("prepareStartupChannelsConfig", () => {
     const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "friday-cli-channels-fallback-"));
     const legacyDir = path.join(tmpHome, ".friday");
     const legacyPath = path.join(legacyDir, "friday.json");
+    const testToken = "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAuR2FiY0RlLkFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFla";
     fs.mkdirSync(legacyDir, { recursive: true });
     fs.writeFileSync(
       legacyPath,
       JSON.stringify({
         channels: {
           discord: {
-            token: "fake-discord-token",
+            token: testToken,
           },
         },
       }, null, 2),
@@ -675,7 +676,7 @@ describe("prepareStartupChannelsConfig", () => {
       instances: [
         expect.objectContaining({
           kind: "discord",
-          token: "fake-discord-token",
+          token: testToken,
         }),
       ],
     });

--- a/test/unit/hub/bootstrap/hub-helpers.test.ts
+++ b/test/unit/hub/bootstrap/hub-helpers.test.ts
@@ -78,18 +78,9 @@ describe("createFridayHubAutoFixExecutionSupport", () => {
       nowIso: () => "2026-03-13T10:00:00.000Z",
     });
 
-    await expect(support.stepExecutors.pause_workflow?.({
-      stepId: "step-pause-001",
-      kind: "pause_workflow",
-      target: "wf-123",
-      payload: {},
-    })).resolves.toBe(false);
-    await expect(support.stepVerifiers.pause_workflow?.({
-      stepId: "step-pause-001",
-      kind: "pause_workflow",
-      target: "wf-123",
-      payload: {},
-      verify: { method: "error_absent", timeoutMs: 5000 },
-    })).resolves.toBe(false);
+    // P2-07: Hub no longer overrides unsupported kinds — DEFAULT_EXECUTORS handle them.
+    // pause_workflow is not in hub-level stepExecutors (falls through to defaults).
+    expect(support.stepExecutors.pause_workflow).toBeUndefined();
+    expect(support.stepVerifiers.pause_workflow).toBeUndefined();
   });
 });

--- a/test/unit/skills/converter/discovery/friday-program-discovery.test.ts
+++ b/test/unit/skills/converter/discovery/friday-program-discovery.test.ts
@@ -529,8 +529,7 @@ describe("FridayDiscoveryRoutes", () => {
       const routes = createFridayDiscoveryRoutes(deps);
       const route = routes.find((r) => r.operationId === "discovery.catalog.get")!;
 
-      const result = await route.handler(makeCtx());
-      expect(result).toEqual({ status: 404, body: { error: expect.any(String) } });
+      await expect(route.handler(makeCtx())).rejects.toThrow("No catalog available");
     });
 
     it("returns catalog when cached", async () => {
@@ -559,8 +558,7 @@ describe("FridayDiscoveryRoutes", () => {
       const routes = createFridayDiscoveryRoutes(deps);
       const route = routes.find((r) => r.operationId === "discovery.programs.list")!;
 
-      const result = await route.handler(makeCtx());
-      expect(result).toEqual({ status: 404, body: { error: expect.any(String) } });
+      await expect(route.handler(makeCtx())).rejects.toThrow("No catalog available");
     });
 
     it("returns programs with filtering", async () => {


### PR DESCRIPTION
…cts endpoint

P2-07: Remove unsupported auto-fix step kind overrides in hub-helpers.
  Previously 6 step kinds (retry_node, switch_model_fallback, trim_payload,
  apply_config_patch, grant_permission, pause_workflow) were blocked with
  `async () => false`, preventing DEFAULT_EXECUTORS from running. Now they
  fall through to the directive-based defaults that set payload markers and
  return true.

P2-10: Unify error response format in discovery and satellite pairing routes.
  Replace raw `{ error: "..." }` returns with `throw FridayDomainError()`
  so the HTTP error mapper produces the standard `{ok, error, requestId}`
  envelope consistently.

P2-05: Add Discord token format validation in legacy channel normalization.
  Rejects tokens shorter than 50 chars or with invalid characters, while
  accepting secret:// references and $ENV variable patterns.

P2-11: Add error handling and slow-query diagnostics to SQLite read pool.
  Wraps withReadConnection in try-catch with timing; warns on queries
  exceeding 5 seconds.

P2-02: Persist onboarding session state to SQLite.
  - New migration v060 creates uix_onboarding_sessions table
  - New repository for session CRUD
  - Onboarding engine accepts optional persistence callbacks
  - Sessions restored from DB on startup, saved on state changes

Learned-facts endpoint: Add GET /v1/uix/learned-facts to expose learned
  preference facts to users for transparency. Wired to
  selfLearningRuntime.facts.listActiveFacts() in hub bootstrap.

## Summary

<!-- Brief description of what this PR does -->

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would break existing functionality)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor / cleanup
- [ ] 🛡️ Security fix

## Checklist

### Required
- [ ] Tests added/updated for changed behavior
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] `npm test` passes

### If Applicable
- [ ] Migration added → migration chain is contiguous (`npm run check:migrations`)
- [ ] SSD updated → markers present (`npm run check:ssd`)
- [ ] Adversarial tests not skipped (`npm run check:adversarial`)
- [ ] API surface changed → routes documented in SSD
- [ ] Security-sensitive change → adversarial test added

### Documentation
- [ ] SSD (`docs/distributed-architecture.md`) updated if architecture changed
- [ ] README updated if user-facing behavior changed
- [ ] CHANGELOG entry added

## Related Issues

<!-- Link to related issues: Fixes #123, Closes #456 -->
