### PR TITLE
test(ci): fix cd6efb4 secrets gate regression

### DIFF
--- a/test/unit/cli/friday-cli.test.ts
+++ b/test/unit/cli/friday-cli.test.ts
@@ -610,7 +610,7 @@ describe("prepareStartupChannelsConfig", () => {
         JSON.stringify({
           channels: {
             discord: {
-              token: "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAuR2FiY0RlLkFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFla",
+              token: "discord-test-token-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
               allowedUsers: ["jarvis"],
             },
           },
@@ -632,7 +632,7 @@ describe("prepareStartupChannelsConfig", () => {
         .prepare("SELECT channels_json FROM friday_setup_state WHERE id = 'singleton'")
         .get() as { channels_json: string };
       expect(setupRow.channels_json).toContain("secret://channel/");
-      expect(setupRow.channels_json).not.toContain("fake-discord-token");
+      expect(setupRow.channels_json).not.toContain("discord-test-token-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
 
       const secretCount = db
         .prepare("SELECT COUNT(*) AS count FROM secrets WHERE scope = 'channel'")
@@ -651,7 +651,7 @@ describe("prepareStartupChannelsConfig", () => {
     const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "friday-cli-channels-fallback-"));
     const legacyDir = path.join(tmpHome, ".friday");
     const legacyPath = path.join(legacyDir, "friday.json");
-    const testToken = "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAuR2FiY0RlLkFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFla";
+    const testToken = "discord-test-token-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     fs.mkdirSync(legacyDir, { recursive: true });
     fs.writeFileSync(
       legacyPath,


### PR DESCRIPTION
## Summary
- replace the high-entropy Discord placeholder token introduced in PR #46
- keep the stricter Discord token validation intact
- preserve the migration/fallback test semantics while avoiding detect-secrets false positives

## Validation
- npx vitest run --project default test/unit/cli/friday-cli.test.ts
- git ls-files -z | xargs -0 /tmp/friday-ds-venv/bin/detect-secrets-hook --baseline .secrets.baseline --exclude-files ...
- npm run typecheck
- npm run lint
- npm run build:api
- npm run build:ui
- npm run test:contracts
- npx vitest run test/adversarial
- npm run test:integration:openclaw-overlap
- npm test
- npm run test:e2e:ui