### PR TITLE
fix: audit fixes — wire decision engine, data lifecycle, UX hints

### DIFF
--- a/src/agent/runtime/friday-agent-runtime.ts
+++ b/src/agent/runtime/friday-agent-runtime.ts
@@ -142,6 +142,7 @@ export function createFridayAgentRuntime(
     communicationPromptBuilder,
     delegationHandler,
     contextEngine,
+    decisionEngine,
   } = deps;
 
   // Clone the tools array so registerTool does not mutate the caller's array.

--- a/src/agent/runtime/friday-agent-world-state-manager.ts
+++ b/src/agent/runtime/friday-agent-world-state-manager.ts
@@ -79,7 +79,7 @@ export function createFridayWorldStateManager(
 ): FridayWorldStateManager {
   const { db, idGenerator, nowIso } = deps;
 
-  return {
+  const manager: FridayWorldStateManager = {
     async loadState(userId) {
       // Try loading latest snapshot
       const row = db.withReadConnection((conn) =>
@@ -131,7 +131,21 @@ export function createFridayWorldStateManager(
             now,
           });
         }
+
+        // Prune stale entities: remove those not mentioned in last 90 days with low mention count
+        conn
+          .prepare(
+            `DELETE FROM friday_world_entities
+             WHERE user_id = ?
+               AND mention_count < 2
+               AND last_mentioned < datetime(?, '-90 days')`,
+          )
+          .run(userId, now);
       });
+
+      // Persist a snapshot after updating entities
+      const updatedState = await manager.loadState(userId);
+      await manager.saveSnapshot(updatedState);
     },
 
     async saveSnapshot(state) {
@@ -170,6 +184,8 @@ export function createFridayWorldStateManager(
       return rows.map(rowToEpisode);
     },
   };
+
+  return manager;
 }
 
 // ─── Helpers ────────────────────────────────────────────────────

--- a/src/api/http/routes/friday-setup-routes.ts
+++ b/src/api/http/routes/friday-setup-routes.ts
@@ -190,7 +190,7 @@ function assertSetupBaseUrlSafe(baseUrl: string, opts?: { allowPrivateNetwork?: 
     allowPrivate: opts?.allowPrivateNetwork,
   });
   if (!result.valid) {
-    throw new FridayDomainError("PROVIDER_UNREACHABLE", `Base URL blocked by security policy: ${result.error ?? "private/loopback address"}`, { httpStatus: 422 });
+    throw new FridayDomainError("PROVIDER_UNREACHABLE", `Base URL blocked by security policy: ${result.error ?? "private/loopback address"}`, { httpStatus: 422, details: { hint: "Friday blocks localhost/private IPs by default. For local providers like Ollama, use the setup wizard which enables private network access." } });
   }
 }
 
@@ -202,7 +202,7 @@ async function fetchOpenAiModels(baseUrl: string, apiKey: string, ssrf?: { allow
     headers: { Authorization: `Bearer ${apiKey}` },
   });
   if (res.status === 401 || res.status === 403) {
-    throw new FridayDomainError("PROVIDER_AUTH_INVALID", "Invalid API key", { httpStatus: 401 });
+    throw new FridayDomainError("PROVIDER_AUTH_INVALID", "Invalid API key", { httpStatus: 401, details: { hint: "OpenAI keys start with 'sk-'. Check your key at https://platform.openai.com/api-keys" } });
   }
   if (res.status === 429) {
     throw new FridayDomainError("PROVIDER_RATE_LIMITED", "Upstream rate limit", { httpStatus: 429, retryable: true });
@@ -257,7 +257,7 @@ async function fetchAnthropicModels(baseUrl: string, apiKey: string, ssrf?: { al
     });
 
     if (res.status === 401 || res.status === 403) {
-      throw new FridayDomainError("PROVIDER_AUTH_INVALID", "Invalid API key", { httpStatus: 401 });
+      throw new FridayDomainError("PROVIDER_AUTH_INVALID", "Invalid API key", { httpStatus: 401, details: { hint: "Anthropic keys start with 'sk-ant-'. Check your key at https://console.anthropic.com/settings/keys" } });
     }
     if (res.status === 429) {
       throw new FridayDomainError("PROVIDER_RATE_LIMITED", "Upstream rate limit", { httpStatus: 429, retryable: true });
@@ -278,7 +278,7 @@ async function fetchGoogleModels(baseUrl: string, apiKey: string, ssrf?: { allow
   const url = `${baseUrl.replace(/\/+$/, "")}/v1beta/models`;
   const res = await fetchWithTimeout(url, { method: "GET", headers: { "x-goog-api-key": apiKey } });
   if (res.status === 401 || res.status === 403) {
-    throw new FridayDomainError("PROVIDER_AUTH_INVALID", "Invalid API key", { httpStatus: 401 });
+    throw new FridayDomainError("PROVIDER_AUTH_INVALID", "Invalid API key", { httpStatus: 401, details: { hint: "Google AI keys can be generated at https://aistudio.google.com/app/apikey" } });
   }
   if (res.status === 429) {
     throw new FridayDomainError("PROVIDER_RATE_LIMITED", "Upstream rate limit", { httpStatus: 429, retryable: true });
@@ -326,7 +326,7 @@ async function fetchCompatibleModels(baseUrl: string, apiKey?: string, ssrf?: { 
   }
   const res = await fetchWithTimeout(url, { method: "GET", headers });
   if (res.status === 401 || res.status === 403) {
-    throw new FridayDomainError("PROVIDER_AUTH_INVALID", "Invalid API key", { httpStatus: 401 });
+    throw new FridayDomainError("PROVIDER_AUTH_INVALID", "Invalid API key", { httpStatus: 401, details: { hint: "Verify the API key is correct and the provider supports the OpenAI-compatible /v1/models endpoint" } });
   }
   if (res.status === 429) {
     throw new FridayDomainError("PROVIDER_RATE_LIMITED", "Upstream rate limit", { httpStatus: 429, retryable: true });

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -90,7 +90,7 @@ import {
   createFridayPluginSignatureVerifier,
 } from "#plugins";
 import type { FridayPluginService } from "#plugins";
-import { createFridayMemoryFileSyncRepository, createFridayMemoryFileSyncService, createFridayMemoryService } from "#memory";
+import { createFridayEpisodeExtractor, createFridayMemoryFileSyncRepository, createFridayMemoryFileSyncService, createFridayMemoryService } from "#memory";
 import {
   createFridaySessionMemoryExtractionService,
   finalizeFridayConversationFocus,
@@ -137,7 +137,7 @@ import {
 } from "#agent";
 import type { loadFridayWorkspaceContext } from "#agent";
 import { buildMcpServerToolFilter } from "./friday-mcp-safe-catalog.js";
-import { createFridayEpisodeExtractor } from "../memory/services/friday-episode-extractor.js";
+
 import { classifyFridayExecution } from "../sessions/services/friday-execution-classifier.js";
 import { dispatchDeterministic } from "../sessions/services/friday-deterministic-dispatch.js";
 import type { FridayDeterministicDispatchDeps } from "../sessions/services/friday-deterministic-dispatch.js";
@@ -5191,6 +5191,17 @@ export async function createFridayHub(
 
       hubState = "running";
       upSince = new Date().toISOString();
+
+      // ─── Startup diagnostics ───
+      {
+        const providerCount = (await providerService.listProviders()).length;
+        const channelCount = channelRegistry.list().length;
+        const skillCount = registry.list().length;
+        console.log("[friday] ✓ Friday is running");
+        console.log(`[friday]   Providers: ${String(providerCount)}${providerCount === 0 ? " — set ANTHROPIC_API_KEY or visit /setup to add one" : ""}`);
+        console.log(`[friday]   Channels:  ${String(channelCount)}${channelCount === 0 ? " — no messaging channels configured" : ""}`);
+        console.log(`[friday]   Skills:    ${String(skillCount)}`);
+      }
     },
 
     async stop(): Promise<void> {

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -152,3 +152,11 @@ export type {
   FridayMemoryGuardServiceFactory,
   CreateFridayMemoryGuardServiceFactoryDeps,
 } from "./guard/index.js";
+
+// ─── Episode & Pattern Extractors ───
+
+export type { FridayEpisodeExtractor, CreateFridayEpisodeExtractorDeps } from "./services/friday-episode-extractor.js";
+export { createFridayEpisodeExtractor } from "./services/friday-episode-extractor.js";
+
+export type { FridayPatternExtractor, CreateFridayPatternExtractorDeps } from "./services/friday-pattern-extractor.js";
+export { createFridayPatternExtractor } from "./services/friday-pattern-extractor.js";

--- a/src/memory/services/friday-episode-extractor.ts
+++ b/src/memory/services/friday-episode-extractor.ts
@@ -115,8 +115,21 @@ export function createFridayEpisodeExtractor(
         createdAt: nowIso(),
       };
 
-      // 8. Persist
-      db.withWriteTransaction((conn) => insertEpisode(conn, episode));
+      // 8. Persist and prune old episodes
+      db.withWriteTransaction((conn) => {
+        insertEpisode(conn, episode);
+
+        // Keep last 500 episodes per user
+        conn
+          .prepare(
+            `DELETE FROM friday_episodes
+             WHERE user_id = ? AND id NOT IN (
+               SELECT id FROM friday_episodes
+               WHERE user_id = ? ORDER BY created_at DESC LIMIT 500
+             )`,
+          )
+          .run(userId, userId);
+      });
 
       return episode;
     },

--- a/test/unit/memory/services/friday-world-state-manager.test.ts
+++ b/test/unit/memory/services/friday-world-state-manager.test.ts
@@ -151,4 +151,58 @@ describe("FridayWorldStateManager", () => {
     expect(episodes[0].taskIntent).toBe("task 2");
     expect(episodes[2].taskIntent).toBe("task 0");
   });
+
+  it("updateFromEpisode persists a world state snapshot", async () => {
+    const mgr = createFridayWorldStateManager({ db, idGenerator: idGen, nowIso });
+    const episode = makeEpisode();
+
+    await mgr.updateFromEpisode("user-1", episode);
+
+    const count = db.withReadConnection((conn) =>
+      (conn.prepare("SELECT COUNT(*) as c FROM friday_world_state_snapshots WHERE user_id = ?").get("user-1") as { c: number }).c,
+    );
+    expect(count).toBeGreaterThanOrEqual(1);
+  });
+
+  it("updateFromEpisode prunes stale entities older than 90 days with low mention count", async () => {
+    const mgr = createFridayWorldStateManager({ db, idGenerator: idGen, nowIso });
+
+    // Seed an old entity with low mention count
+    db.withWriteTransaction((conn) => {
+      conn
+        .prepare(
+          `INSERT INTO friday_world_entities
+             (id, user_id, type, name, attributes_json, relations_json,
+              last_mentioned, mention_count, created_at, updated_at)
+           VALUES (?, 'user-1', 'concept', 'OldThing', '{}', '[]', '2025-01-01T00:00:00.000Z', 1, '2025-01-01T00:00:00.000Z', '2025-01-01T00:00:00.000Z')`,
+        )
+        .run(idGen());
+    });
+
+    // Seed an old entity with HIGH mention count (should survive)
+    db.withWriteTransaction((conn) => {
+      conn
+        .prepare(
+          `INSERT INTO friday_world_entities
+             (id, user_id, type, name, attributes_json, relations_json,
+              last_mentioned, mention_count, created_at, updated_at)
+           VALUES (?, 'user-1', 'concept', 'ImportantThing', '{}', '[]', '2025-01-01T00:00:00.000Z', 5, '2025-01-01T00:00:00.000Z', '2025-01-01T00:00:00.000Z')`,
+        )
+        .run(idGen());
+    });
+
+    await mgr.updateFromEpisode("user-1", makeEpisode());
+
+    const entities = db.withReadConnection((conn) =>
+      conn
+        .prepare("SELECT name FROM friday_world_entities WHERE user_id = ?")
+        .all("user-1") as Array<{ name: string }>,
+    );
+    const names = entities.map((e) => e.name);
+
+    // OldThing should be pruned (mention_count=1, >90 days old)
+    expect(names).not.toContain("OldThing");
+    // ImportantThing should survive (mention_count=5)
+    expect(names).toContain("ImportantThing");
+  });
 });


### PR DESCRIPTION
## Summary

- **Wire decisionEngine** in agent runtime destructuring (was silently dropped after being passed in)
- **Persist world state snapshots** by calling `saveSnapshot()` after `updateFromEpisode()` 
- **Add data lifecycle management**: episode retention (500/user), entity expiry (90 days + low mention count)
- **Add barrel exports** for episode/pattern extractors in `#memory`; fix bootstrap to use barrel import
- **Add startup diagnostics** showing provider/channel/skill counts with actionable hints
- **Add error recovery hints** for auth failures and SSRF blocks in setup routes
- **Add tests** for snapshot persistence and entity cleanup

## Test plan

- [x] `npx tsc --noEmit` — zero type errors
- [x] `npx eslint .` — zero warnings
- [x] `npm run build` — builds successfully
- [x] `npx vitest run` — 9,451 tests pass, 0 failures
- [ ] CI 10/10 checks green

https://claude.ai/code/session_01GnUMK67S45EJ1BznYfG1Qb