### PR TITLE
feat: close read-only UI gaps — add CRUD controls across all pages

### DIFF
--- a/ui/src/hooks/use-guided-flow.ts
+++ b/ui/src/hooks/use-guided-flow.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from "react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { systemApi } from "@/lib/api/system";
 import type { FridayGuidedWizardState, FridayUixWizardResponse } from "@/lib/api/system-types";
 
@@ -24,7 +24,6 @@ export interface UseGuidedFlowResult {
 
 export function useGuidedFlow(options: UseGuidedFlowOptions): UseGuidedFlowResult {
   const { wizardId, assistantSessionKey, enabled = true } = options;
-  const queryClient = useQueryClient();
   const [activeContextId, setActiveContextId] = useState<string | null>(null);
   const [wizardState, setWizardState] = useState<FridayGuidedWizardState | null>(null);
   const [wizardResponse, setWizardResponse] = useState<FridayUixWizardResponse | null>(null);

--- a/ui/src/routes/assistant-page.tsx
+++ b/ui/src/routes/assistant-page.tsx
@@ -2949,6 +2949,12 @@ function IssueCard(props: {
   rollbackPending: boolean;
 }) {
   const action = props.action;
+  const [detailExpanded, setDetailExpanded] = useState(false);
+  const detailQuery = useQuery({
+    queryKey: ["auto-fix", "action", action?.action.actionId],
+    queryFn: () => systemApi.getAutoFixAction(action!.action.actionId),
+    enabled: detailExpanded && action !== null,
+  });
   const playbook = buildAssistantIssuePlaybook({
     issue: props.issue,
     action,
@@ -3024,6 +3030,39 @@ function IssueCard(props: {
               Details
             </Link>
           </div>
+          <button
+            type="button"
+            onClick={() => setDetailExpanded(!detailExpanded)}
+            className="mt-3 flex items-center gap-1 text-xs font-medium text-white/50 transition hover:text-white/80"
+          >
+            <ChevronRight className={`h-3 w-3 transition ${detailExpanded ? "rotate-90" : ""}`} />
+            {detailExpanded ? "Hide evidence" : "Show evidence"}
+          </button>
+          {detailExpanded && (
+            <div className="mt-2 rounded-2xl border border-white/8 bg-white/[0.02] px-3 py-2 text-xs text-white/55">
+              {detailQuery.isLoading ? (
+                <p>Loading action details...</p>
+              ) : detailQuery.data ? (
+                <div className="space-y-2">
+                  <p><span className="text-white/70">Root cause:</span> {detailQuery.data.evidence.rootCauseSummary}</p>
+                  <p><span className="text-white/70">Plan:</span> {detailQuery.data.evidence.selectedPlan.title} — {detailQuery.data.evidence.selectedPlan.summary}</p>
+                  <p><span className="text-white/70">Steps:</span> {String(detailQuery.data.evidence.selectedPlan.stepCount)} · Rollback: {detailQuery.data.evidence.selectedPlan.rollbackPlanAvailable ? "Yes" : "No"}</p>
+                  <p><span className="text-white/70">Risk tier:</span> {detailQuery.data.evidence.riskTier}</p>
+                  {detailQuery.data.evidence.approvalTrail && (
+                    <p><span className="text-white/70">Approval:</span> {detailQuery.data.evidence.approvalTrail.status}{detailQuery.data.evidence.approvalTrail.reason ? ` — ${detailQuery.data.evidence.approvalTrail.reason}` : ""}</p>
+                  )}
+                  {detailQuery.data.action.appliedAt && (
+                    <p><span className="text-white/70">Applied:</span> {new Date(detailQuery.data.action.appliedAt).toLocaleString()}</p>
+                  )}
+                  {detailQuery.data.action.rolledBackAt && (
+                    <p><span className="text-white/70">Rolled back:</span> {new Date(detailQuery.data.action.rolledBackAt).toLocaleString()}</p>
+                  )}
+                </div>
+              ) : (
+                <p>No details available.</p>
+              )}
+            </div>
+          )}
         </div>
       ) : null}
     </article>

--- a/ui/src/routes/memory-page.tsx
+++ b/ui/src/routes/memory-page.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Brain, Search, Tag, Trash2 } from "lucide-react";
+import { Brain, Plus, Search, Tag, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { ActionButton, ShellCard, StatusPill } from "@/components/core/primitives";
 import { memoryApi } from "@/lib/api/memory";
@@ -55,6 +55,21 @@ export function MemoryPage() {
     },
   });
 
+  const storeMutation = useMutation({
+    mutationFn: (input: { namespace: string; content: string; key: string; tags: string[] }) =>
+      memoryApi.store(input),
+    onSuccess: async () => {
+      toast.success("Memory item stored");
+      setShowAddForm(false);
+      await queryClient.invalidateQueries({ queryKey: ["memory"] });
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Failed to store memory item");
+    },
+  });
+
+  const [showAddForm, setShowAddForm] = useState(false);
+
   const handleSearch = () => {
     setActiveSearch(searchQuery.trim());
   };
@@ -108,10 +123,24 @@ export function MemoryPage() {
                 ? `${String(displayItems.length)} results for "${activeSearch}"`
                 : `${String(displayItems.length)} items total`}
             </p>
-            <ActionButton tone="secondary" onClick={() => pruneMutation.mutate()} disabled={pruneMutation.isPending}>
-              Prune Expired
-            </ActionButton>
+            <div className="flex gap-2">
+              <ActionButton tone="secondary" onClick={() => setShowAddForm(!showAddForm)}>
+                <Plus className="mr-1 h-3 w-3" />
+                Add Memory
+              </ActionButton>
+              <ActionButton tone="secondary" onClick={() => pruneMutation.mutate()} disabled={pruneMutation.isPending}>
+                Prune Expired
+              </ActionButton>
+            </div>
           </div>
+
+          {showAddForm && (
+            <AddMemoryForm
+              onSubmit={(input) => storeMutation.mutate(input)}
+              pending={storeMutation.isPending}
+              onCancel={() => setShowAddForm(false)}
+            />
+          )}
         </div>
       </ShellCard>
 
@@ -179,6 +208,91 @@ export function MemoryPage() {
           ))}
         </div>
       )}
+    </div>
+  );
+}
+
+function AddMemoryForm(props: {
+  onSubmit: (input: { namespace: string; content: string; key: string; tags: string[] }) => void;
+  pending: boolean;
+  onCancel: () => void;
+}) {
+  const [namespace, setNamespace] = useState("user");
+  const [key, setKey] = useState("");
+  const [content, setContent] = useState("");
+  const [tagsInput, setTagsInput] = useState("");
+
+  const canSubmit = key.trim().length > 0 && content.trim().length > 0;
+
+  return (
+    <div className="rounded-2xl border border-white/10 bg-black/30 p-4 space-y-3">
+      <p className="text-xs uppercase tracking-[0.16em] text-white/40">Add memory item</p>
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label className="mb-1 block text-xs text-white/50">Namespace</label>
+          <select
+            value={namespace}
+            onChange={(e) => setNamespace(e.target.value)}
+            className="w-full rounded-xl border border-white/10 bg-black/30 px-3 py-2 text-sm text-white focus:border-white/20 focus:outline-none"
+          >
+            <option value="user">user</option>
+            <option value="preference">preference</option>
+            <option value="system">system</option>
+            <option value="agent">agent</option>
+          </select>
+        </div>
+        <div>
+          <label className="mb-1 block text-xs text-white/50">Key</label>
+          <input
+            type="text"
+            placeholder="e.g. favorite-language"
+            value={key}
+            onChange={(e) => setKey(e.target.value)}
+            className="w-full rounded-xl border border-white/10 bg-black/30 px-3 py-2 text-sm text-white placeholder:text-white/30 focus:border-white/20 focus:outline-none"
+          />
+        </div>
+      </div>
+      <div>
+        <label className="mb-1 block text-xs text-white/50">Content</label>
+        <textarea
+          rows={3}
+          placeholder="The information to remember..."
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          className="w-full rounded-xl border border-white/10 bg-black/30 px-3 py-2 text-sm text-white placeholder:text-white/30 focus:border-white/20 focus:outline-none resize-none"
+        />
+      </div>
+      <div>
+        <label className="mb-1 block text-xs text-white/50">Tags (comma-separated)</label>
+        <input
+          type="text"
+          placeholder="e.g. lang, preference"
+          value={tagsInput}
+          onChange={(e) => setTagsInput(e.target.value)}
+          className="w-full rounded-xl border border-white/10 bg-black/30 px-3 py-2 text-sm text-white placeholder:text-white/30 focus:border-white/20 focus:outline-none"
+        />
+      </div>
+      <div className="flex gap-2">
+        <ActionButton
+          disabled={!canSubmit || props.pending}
+          onClick={() =>
+            props.onSubmit({
+              namespace,
+              key: key.trim(),
+              content: content.trim(),
+              tags: tagsInput
+                .split(",")
+                .map((t) => t.trim())
+                .filter(Boolean),
+            })
+          }
+        >
+          {props.pending ? "Storing..." : "Store"}
+        </ActionButton>
+        <ActionButton tone="secondary" onClick={props.onCancel}>
+          Cancel
+        </ActionButton>
+      </div>
     </div>
   );
 }

--- a/ui/src/routes/observability-page.tsx
+++ b/ui/src/routes/observability-page.tsx
@@ -9,10 +9,12 @@ import {
   BellRing,
   CheckCircle2,
   ChevronRight,
+  Edit3,
   HeartPulse,
   Mail,
   Pause,
   Play,
+  Plus,
   RotateCcw,
   ShieldCheck,
   Siren,
@@ -325,6 +327,35 @@ export function ObservabilityPage() {
       toast.error(error instanceof Error ? error.message : "Could not delete destination.");
     },
   });
+
+  const createDestinationMutation = useMutation({
+    mutationFn: (input: { type: "slack"; name: string; webhookUrl: string }) =>
+      systemApi.createObservabilityAlertDestination(input),
+    onSuccess: () => {
+      toast.success("Alert destination created.");
+      void queryClient.invalidateQueries({ queryKey: ["observability", "alert-destinations"] });
+      setShowCreateDest(false);
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Could not create destination.");
+    },
+  });
+
+  const updateDestinationMutation = useMutation({
+    mutationFn: (input: { id: string; name?: string; enabled?: boolean }) => {
+      const { id, ...patch } = input;
+      return systemApi.updateObservabilityAlertDestination(id, patch);
+    },
+    onSuccess: () => {
+      toast.success("Alert destination updated.");
+      void queryClient.invalidateQueries({ queryKey: ["observability", "alert-destinations"] });
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Could not update destination.");
+    },
+  });
+
+  const [showCreateDest, setShowCreateDest] = useState(false);
 
   const overview = overviewQuery.data;
   const alerts = alertsQuery.data?.items ?? [];
@@ -845,43 +876,14 @@ export function ObservabilityPage() {
           {agentLoopRuns.length > 0 || rulesAuditLog.length > 0 ? (
             <div className="space-y-3">
               {agentLoopRuns.slice(0, 3).map((record) => (
-                <div key={record.run.loopRunId} className="agent-subcard p-4">
-                  <div className="flex items-center justify-between gap-3">
-                    <div>
-                      <p className="font-medium text-white">{record.action?.summary.title ?? record.incident?.summary.rootCauseSummary ?? "Loop run"}</p>
-                      <p className="text-xs text-white/50">{record.run.loopRunId}</p>
-                    </div>
-                    <StatusPill tone={record.run.status === "verified" ? "success" : record.run.status === "halted" ? "warning" : "neutral"}>
-                      {record.run.status.replaceAll("_", " ")}
-                    </StatusPill>
-                  </div>
-                  <p className="mt-3 text-xs text-white/55">
-                    Verification: {record.run.verificationPassed === undefined ? "pending" : record.run.verificationPassed ? "passed" : "failed"} ·
-                    Rollback: {record.run.rollbackAttempted ? (record.run.rollbackSucceeded ? " succeeded" : " attempted") : " not needed"}
-                  </p>
-                  <div className="mt-3 flex flex-wrap gap-2">
-                    {record.run.status === "paused" ? (
-                      <ActionButton
-                        tone="secondary"
-                        disabled={resumeLoopRunMutation.isPending}
-                        onClick={() => resumeLoopRunMutation.mutate(record.run.loopRunId)}
-                      >
-                        <Play className="mr-1.5 h-3 w-3" />
-                        Resume
-                      </ActionButton>
-                    ) : null}
-                    {record.run.status === "running" || record.run.status === "paused" ? (
-                      <ActionButton
-                        tone="secondary"
-                        disabled={cancelLoopRunMutation.isPending}
-                        onClick={() => cancelLoopRunMutation.mutate(record.run.loopRunId)}
-                      >
-                        <Square className="mr-1.5 h-3 w-3" />
-                        Cancel
-                      </ActionButton>
-                    ) : null}
-                  </div>
-                </div>
+                <LoopRunCard
+                  key={record.run.loopRunId}
+                  record={record}
+                  onResume={(id) => resumeLoopRunMutation.mutate(id)}
+                  onCancel={(id) => cancelLoopRunMutation.mutate(id)}
+                  resumePending={resumeLoopRunMutation.isPending}
+                  cancelPending={cancelLoopRunMutation.isPending}
+                />
               ))}
               {rulesAuditLog.slice(0, 3).map((entry) => (
                 <div key={entry.id} className="agent-subcard p-4">
@@ -981,7 +983,17 @@ export function ObservabilityPage() {
           )}
         </ShellCard>
 
-        <ShellCard eyebrow="Alert routing" title="Who gets notified when Friday escalates">
+        <ShellCard
+          eyebrow="Alert routing"
+          title="Who gets notified when Friday escalates"
+          aside={
+            <ActionButton tone="secondary" onClick={() => setShowCreateDest(!showCreateDest)}>
+              <Plus className="mr-1.5 h-3 w-3" />
+              Add destination
+            </ActionButton>
+          }
+        >
+          {showCreateDest && <CreateDestinationForm onSubmit={(input) => createDestinationMutation.mutate(input)} pending={createDestinationMutation.isPending} onCancel={() => setShowCreateDest(false)} />}
           {destinations.length > 0 ? (
             <div className="space-y-3">
               {destinations.map((destination) => (
@@ -997,9 +1009,14 @@ export function ObservabilityPage() {
                       </div>
                     </div>
                     <div className="flex items-center gap-2">
-                      <StatusPill tone={destination.enabled ? "success" : "warning"}>
+                      <button
+                        type="button"
+                        className={`rounded-full px-2.5 py-0.5 text-xs font-medium transition ${destination.enabled ? "bg-emerald-300/15 text-emerald-200 hover:bg-emerald-300/25" : "bg-white/[0.06] text-white/50 hover:bg-white/10"}`}
+                        disabled={updateDestinationMutation.isPending}
+                        onClick={() => updateDestinationMutation.mutate({ id: destination.id, enabled: !destination.enabled })}
+                      >
                         {destination.enabled ? "enabled" : "disabled"}
-                      </StatusPill>
+                      </button>
                       <button
                         type="button"
                         className="rounded-lg p-1.5 text-white/30 transition hover:bg-white/10 hover:text-red-400"
@@ -1013,10 +1030,108 @@ export function ObservabilityPage() {
                 </div>
               ))}
             </div>
-          ) : (
+          ) : !showCreateDest ? (
             <p className="text-sm text-white/60">No alert destinations are configured yet.</p>
-          )}
+          ) : null}
         </ShellCard>
+      </div>
+    </div>
+  );
+}
+
+function LoopRunCard(props: {
+  record: Awaited<ReturnType<typeof systemApi.listAgentLoopRuns>>[number];
+  onResume: (id: string) => void;
+  onCancel: (id: string) => void;
+  resumePending: boolean;
+  cancelPending: boolean;
+}) {
+  const { record } = props;
+  const [expanded, setExpanded] = useState(false);
+  const detailQuery = useQuery({
+    queryKey: ["observability", "loop-run-detail", record.run.loopRunId],
+    queryFn: () => systemApi.getAgentLoopRun(record.run.loopRunId),
+    enabled: expanded,
+  });
+
+  return (
+    <div className="agent-subcard p-4">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <p className="font-medium text-white">{record.action?.summary.title ?? record.incident?.summary.rootCauseSummary ?? "Loop run"}</p>
+          <p className="text-xs text-white/50">{record.run.loopRunId}</p>
+        </div>
+        <StatusPill tone={record.run.status === "verified" ? "success" : record.run.status === "halted" ? "warning" : "neutral"}>
+          {record.run.status.replaceAll("_", " ")}
+        </StatusPill>
+      </div>
+      <p className="mt-3 text-xs text-white/55">
+        Verification: {record.run.verificationPassed === undefined ? "pending" : record.run.verificationPassed ? "passed" : "failed"} ·
+        Rollback: {record.run.rollbackAttempted ? (record.run.rollbackSucceeded ? " succeeded" : " attempted") : " not needed"}
+      </p>
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        {record.run.status === "paused" ? (
+          <ActionButton tone="secondary" disabled={props.resumePending} onClick={() => props.onResume(record.run.loopRunId)}>
+            <Play className="mr-1.5 h-3 w-3" />Resume
+          </ActionButton>
+        ) : null}
+        {record.run.status === "running" || record.run.status === "paused" ? (
+          <ActionButton tone="secondary" disabled={props.cancelPending} onClick={() => props.onCancel(record.run.loopRunId)}>
+            <Square className="mr-1.5 h-3 w-3" />Cancel
+          </ActionButton>
+        ) : null}
+        <button
+          type="button"
+          onClick={() => setExpanded(!expanded)}
+          className="flex items-center gap-1 text-xs font-medium text-white/50 transition hover:text-white/80"
+        >
+          <ChevronRight className={`h-3 w-3 transition ${expanded ? "rotate-90" : ""}`} />
+          {expanded ? "Less" : "Detail"}
+        </button>
+      </div>
+      {expanded && detailQuery.data ? (
+        <div className="mt-3 rounded-xl border border-white/8 bg-white/[0.02] p-3 text-xs text-white/55 space-y-1">
+          <p>Risk tier: {detailQuery.data.run.riskTier}</p>
+          <p>Attempt: {detailQuery.data.run.attemptNumber}</p>
+          <p>Approval required: {detailQuery.data.run.approvalRequired ? "yes" : "no"}</p>
+          {detailQuery.data.run.haltReason ? <p>Halt reason: {detailQuery.data.run.haltReason}</p> : null}
+          {detailQuery.data.run.lastError ? <p>Last error: {detailQuery.data.run.lastError}</p> : null}
+          {detailQuery.data.run.correlationId ? <p>Correlation: {detailQuery.data.run.correlationId}</p> : null}
+        </div>
+      ) : expanded && detailQuery.isLoading ? (
+        <p className="mt-3 text-xs text-white/40">Loading...</p>
+      ) : null}
+    </div>
+  );
+}
+
+function CreateDestinationForm(props: {
+  onSubmit: (input: { type: "slack"; name: string; webhookUrl: string }) => void;
+  pending: boolean;
+  onCancel: () => void;
+}) {
+  const [name, setName] = useState("");
+  const [webhookUrl, setWebhookUrl] = useState("");
+  return (
+    <div className="mb-3 rounded-2xl border border-white/10 bg-white/[0.03] p-4 space-y-3">
+      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-white/40">New Slack destination</p>
+      <input
+        className="w-full rounded-xl border border-white/10 bg-black/30 px-3 py-2 text-sm text-white placeholder:text-white/30 focus:border-emerald-300/40 focus:outline-none"
+        placeholder="Name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+      />
+      <input
+        className="w-full rounded-xl border border-white/10 bg-black/30 px-3 py-2 text-sm text-white placeholder:text-white/30 focus:border-emerald-300/40 focus:outline-none"
+        placeholder="Webhook URL"
+        value={webhookUrl}
+        onChange={(e) => setWebhookUrl(e.target.value)}
+      />
+      <div className="flex gap-2">
+        <ActionButton disabled={props.pending || !name.trim() || !webhookUrl.trim()} onClick={() => props.onSubmit({ type: "slack", name: name.trim(), webhookUrl: webhookUrl.trim() })}>
+          Create
+        </ActionButton>
+        <ActionButton tone="secondary" onClick={props.onCancel}>Cancel</ActionButton>
       </div>
     </div>
   );

--- a/ui/src/routes/observability-page.tsx
+++ b/ui/src/routes/observability-page.tsx
@@ -214,6 +214,12 @@ export function ObservabilityPage() {
     refetchInterval: 15_000,
   });
 
+  const expertLoopRunsQuery = useQuery({
+    queryKey: ["observability", "expert-loop-runs"],
+    queryFn: () => systemApi.listExpertAgentLoopRuns({ limit: 8 }),
+    refetchInterval: 15_000,
+  });
+
   const seriesQuery = useQuery({
     queryKey: ["observability", "time-series", "learning-failures"],
     queryFn: () => {
@@ -355,6 +361,17 @@ export function ObservabilityPage() {
     },
   });
 
+  const testAlertDispatchMutation = useMutation({
+    mutationFn: (input: { alertId: string; destinationId?: string }) =>
+      systemApi.testObservabilityAlertDispatch(input.alertId, input.destinationId),
+    onSuccess: () => {
+      toast.success("Test alert dispatched.");
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Could not dispatch test alert.");
+    },
+  });
+
   const [showCreateDest, setShowCreateDest] = useState(false);
 
   const overview = overviewQuery.data;
@@ -363,6 +380,7 @@ export function ObservabilityPage() {
   const traces = tracesQuery.data?.items ?? [];
   const auditEntries = auditQuery.data?.items ?? [];
   const agentLoopRuns = agentLoopRunsQuery.data ?? [];
+  const expertLoopRuns = expertLoopRunsQuery.data ?? [];
   const series = seriesQuery.data;
   const slos = slosQuery.data ?? [];
   const destinations = destinationsQuery.data ?? [];
@@ -789,6 +807,14 @@ export function ObservabilityPage() {
                         Acknowledge
                       </button>
                     ) : null}
+                    <button
+                      className="inline-flex items-center rounded-2xl bg-white/10 px-4 py-2 text-sm text-white hover:bg-white/[0.14] disabled:cursor-not-allowed disabled:opacity-60"
+                      disabled={testAlertDispatchMutation.isPending}
+                      onClick={() => testAlertDispatchMutation.mutate({ alertId: alert.id })}
+                      type="button"
+                    >
+                      Test dispatch
+                    </button>
                   </div>
                 </div>
               ))}
@@ -873,7 +899,7 @@ export function ObservabilityPage() {
         </ShellCard>
 
         <ShellCard eyebrow="Agent loop and rules" title="Autonomous recovery and policy state">
-          {agentLoopRuns.length > 0 || rulesAuditLog.length > 0 ? (
+          {agentLoopRuns.length > 0 || expertLoopRuns.length > 0 || rulesAuditLog.length > 0 ? (
             <div className="space-y-3">
               {agentLoopRuns.slice(0, 3).map((record) => (
                 <LoopRunCard
@@ -885,6 +911,21 @@ export function ObservabilityPage() {
                   cancelPending={cancelLoopRunMutation.isPending}
                 />
               ))}
+              {expertLoopRuns.length > 0 && (
+                <div className="border-t border-white/8 pt-3">
+                  <p className="mb-2 text-xs uppercase tracking-[0.16em] text-white/40">Expert mode runs</p>
+                  {expertLoopRuns.slice(0, 3).map((record) => (
+                    <LoopRunCard
+                      key={record.run.loopRunId}
+                      record={record}
+                      onResume={(id) => resumeLoopRunMutation.mutate(id)}
+                      onCancel={(id) => cancelLoopRunMutation.mutate(id)}
+                      resumePending={resumeLoopRunMutation.isPending}
+                      cancelPending={cancelLoopRunMutation.isPending}
+                    />
+                  ))}
+                </div>
+              )}
               {rulesAuditLog.slice(0, 3).map((entry) => (
                 <div key={entry.id} className="agent-subcard p-4">
                   <div className="flex items-center justify-between gap-3">

--- a/ui/src/routes/settings-page.tsx
+++ b/ui/src/routes/settings-page.tsx
@@ -148,6 +148,29 @@ export function SettingsPage() {
     },
   });
 
+  const updatePolicyMutation = useMutation({
+    mutationFn: (patch: { paused?: boolean; autoApplyLowRisk?: boolean; cooldownMinutes?: number }) =>
+      systemApi.updateAgentLoopPolicy(patch),
+    onSuccess: () => {
+      toast.success("Agent loop policy updated.");
+      void queryClient.invalidateQueries({ queryKey: systemKeys.agentLoopPolicy() });
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Could not update policy.");
+    },
+  });
+
+  const toggleExpertMutation = useMutation({
+    mutationFn: (enabled: boolean) => systemApi.updateAgentLoopExpertMode({ enabled }),
+    onSuccess: (result) => {
+      toast.success(result.enabled ? "Expert mode enabled" : "Expert mode disabled");
+      void queryClient.invalidateQueries({ queryKey: systemKeys.agentLoopExpertMode() });
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Could not toggle expert mode.");
+    },
+  });
+
   const preview = buildPersonaPreview(draft.settings);
 
   return (
@@ -521,20 +544,43 @@ export function SettingsPage() {
           {agentLoopPolicy ? (
             <div className="space-y-3">
               <div className="grid gap-3 sm:grid-cols-2">
-                <DiagnosticTile icon={<Sliders className="h-4 w-4" />} label="Status" value={agentLoopPolicy.paused ? "paused" : "active"} />
                 <DiagnosticTile icon={<Sliders className="h-4 w-4" />} label="Max Attempts" value={String(agentLoopPolicy.maxAttemptsPerFingerprint)} />
+                <DiagnosticTile icon={<Sliders className="h-4 w-4" />} label="Cooldown" value={`${agentLoopPolicy.cooldownMinutes} min`} />
               </div>
-              {agentLoopPolicy.cooldownMinutes ? (
-                <DiagnosticRow label="Cooldown" value={`${String(agentLoopPolicy.cooldownMinutes)} min`} />
-              ) : null}
+              <div className="flex flex-wrap gap-2">
+                <ActionButton
+                  tone={agentLoopPolicy.paused ? "primary" : "secondary"}
+                  disabled={updatePolicyMutation.isPending}
+                  onClick={() => updatePolicyMutation.mutate({ paused: !agentLoopPolicy.paused })}
+                >
+                  {agentLoopPolicy.paused ? "Resume loop" : "Pause loop"}
+                </ActionButton>
+                <ActionButton
+                  tone="secondary"
+                  disabled={updatePolicyMutation.isPending}
+                  onClick={() => updatePolicyMutation.mutate({ autoApplyLowRisk: !agentLoopPolicy.autoApplyLowRisk })}
+                >
+                  {agentLoopPolicy.autoApplyLowRisk ? "Disable auto-apply" : "Enable auto-apply"}
+                </ActionButton>
+              </div>
+              <DiagnosticRow label="Require rollback plan" value={agentLoopPolicy.requireRollbackPlan ? "yes" : "no"} />
+              <DiagnosticRow label="Require acceptance check" value={agentLoopPolicy.requireAcceptanceCheck ? "yes" : "no"} />
             </div>
           ) : (
             <p className="text-sm text-white/60">Agent loop policy unavailable.</p>
           )}
           {expertMode ? (
             <div className="mt-4 space-y-2 border-t border-white/10 pt-4">
-              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-white/40">Expert Mode</p>
-              <DiagnosticRow label="Enabled" value={expertMode.enabled ? "yes" : "no"} />
+              <div className="flex items-center justify-between">
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-white/40">Expert Mode</p>
+                <ActionButton
+                  tone={expertMode.enabled ? "danger" : "primary"}
+                  disabled={toggleExpertMutation.isPending}
+                  onClick={() => toggleExpertMutation.mutate(!expertMode.enabled)}
+                >
+                  {expertMode.enabled ? "Disable" : "Enable"}
+                </ActionButton>
+              </div>
               {expertMode.contextInferenceAllowed !== undefined ? (
                 <DiagnosticRow label="Context Inference" value={expertMode.contextInferenceAllowed ? "allowed" : "denied"} />
               ) : null}


### PR DESCRIPTION
Addresses the audit finding that backend implements full CRUD but UI only implements Read. Users can now ACT on what they see instead of just viewing it.

Changes:
- observability: add Create Alert Destination form, enable/disable toggle, loop run detail expand with getAgentLoopRun query
- settings: add Agent Loop Policy edit controls (pause/resume, auto-apply toggle, expert mode enable/disable)
- memory: add Store Memory form (namespace, key, content, tags)
- assistant: add auto-fix action evidence expand (root cause, plan, risk tier, approval trail, timestamps)

https://claude.ai/code/session_01GnUMK67S45EJ1BznYfG1Qb

## Summary

<!-- Brief description of what this PR does -->

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would break existing functionality)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor / cleanup
- [ ] 🛡️ Security fix

## Checklist

### Required
- [ ] Tests added/updated for changed behavior
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] `npm test` passes

### If Applicable
- [ ] Migration added → migration chain is contiguous (`npm run check:migrations`)
- [ ] SSD updated → markers present (`npm run check:ssd`)
- [ ] Adversarial tests not skipped (`npm run check:adversarial`)
- [ ] API surface changed → routes documented in SSD
- [ ] Security-sensitive change → adversarial test added

### Documentation
- [ ] SSD (`docs/distributed-architecture.md`) updated if architecture changed
- [ ] README updated if user-facing behavior changed
- [ ] CHANGELOG entry added

## Related Issues

<!-- Link to related issues: Fixes #123, Closes #456 -->
