### PR TITLE
feat: close all read-only UI gaps + SLO CRUD + approval notifications

### DIFF
--- a/packages/friday-operator-client/src/system-client.ts
+++ b/packages/friday-operator-client/src/system-client.ts
@@ -108,6 +108,18 @@ import type {
   FridayUpdateUserPreferencesRequest,
   FridayUpdateUserPreferencesResponse,
   FridayUserPreference,
+  FridayRegisterAcceptanceTestRequest,
+  FridayRegisterAcceptanceTestResponse,
+  FridayUpdateAcceptanceTestRequest,
+  FridayUpdateAcceptanceTestResponse,
+  FridayDeleteAcceptanceTestResponse,
+  FridayRunAcceptanceTestsRequest,
+  FridayRunAcceptanceTestsResponse,
+  FridayCreateObservabilitySloRequest,
+  FridayCreateObservabilitySloResponse,
+  FridayUpdateObservabilitySloRequest,
+  FridayUpdateObservabilitySloResponse,
+  FridayDeleteObservabilitySloResponse,
 } from "./system-types";
 
 export interface FridayOperatorTransport {
@@ -660,6 +672,43 @@ export function createFridayOperatorClient(options: FridayOperatorClientOptions)
       return data.items;
     },
 
+    async createAcceptanceTest(
+      input: Omit<FridayRegisterAcceptanceTestRequest, "idempotencyKey">,
+    ): Promise<FridayRegisterAcceptanceTestResponse> {
+      return transport.post<FridayRegisterAcceptanceTestRequest, FridayRegisterAcceptanceTestResponse>(
+        "/v1/acceptance/tests",
+        { ...input, idempotencyKey: createIdempotencyKey() },
+      );
+    },
+
+    async updateAcceptanceTest(
+      testId: string,
+      input: FridayUpdateAcceptanceTestRequest,
+    ): Promise<FridayUpdateAcceptanceTestResponse> {
+      return transport.put<FridayUpdateAcceptanceTestRequest, FridayUpdateAcceptanceTestResponse>(
+        `/v1/acceptance/tests/${encodeURIComponent(testId)}`,
+        input,
+      );
+    },
+
+    async deleteAcceptanceTest(
+      testId: string,
+      etag: string,
+    ): Promise<FridayDeleteAcceptanceTestResponse> {
+      return transport.del<FridayDeleteAcceptanceTestResponse>(
+        `/v1/acceptance/tests/${encodeURIComponent(testId)}?etag=${encodeURIComponent(etag)}`,
+      );
+    },
+
+    async runAcceptanceTests(
+      input: Omit<FridayRunAcceptanceTestsRequest, "idempotencyKey">,
+    ): Promise<FridayRunAcceptanceTestsResponse> {
+      return transport.post<FridayRunAcceptanceTestsRequest, FridayRunAcceptanceTestsResponse>(
+        "/v1/acceptance/run",
+        { ...input, idempotencyKey: createIdempotencyKey() },
+      );
+    },
+
     async listRetryEscalations(query?: {
       acknowledged?: boolean;
       limit?: number;
@@ -800,6 +849,31 @@ export function createFridayOperatorClient(options: FridayOperatorClientOptions)
     async getObservabilitySlo(sloId: string) {
       return transport.get<FridayGetObservabilitySloResponse>(
         `/v1/observability/slos/${encodeURIComponent(sloId)}`,
+      );
+    },
+
+    async createObservabilitySlo(
+      input: FridayCreateObservabilitySloRequest,
+    ): Promise<FridayCreateObservabilitySloResponse> {
+      return transport.post<FridayCreateObservabilitySloRequest, FridayCreateObservabilitySloResponse>(
+        "/v1/observability/slos",
+        input,
+      );
+    },
+
+    async updateObservabilitySlo(
+      sloId: string,
+      input: FridayUpdateObservabilitySloRequest,
+    ): Promise<FridayUpdateObservabilitySloResponse> {
+      return transport.put<FridayUpdateObservabilitySloRequest, FridayUpdateObservabilitySloResponse>(
+        `/v1/observability/slos/${encodeURIComponent(sloId)}`,
+        input,
+      );
+    },
+
+    async deleteObservabilitySlo(sloId: string, etag: string): Promise<FridayDeleteObservabilitySloResponse> {
+      return transport.del<FridayDeleteObservabilitySloResponse>(
+        `/v1/observability/slos/${encodeURIComponent(sloId)}?etag=${encodeURIComponent(etag)}`,
       );
     },
 

--- a/packages/friday-operator-client/src/system-types.ts
+++ b/packages/friday-operator-client/src/system-types.ts
@@ -1597,6 +1597,39 @@ export interface FridayGetObservabilitySloResponse {
   burnRates: FridayObservabilityBurnRate[];
 }
 
+export interface FridayCreateObservabilitySloRequest {
+  name: string;
+  description?: string;
+  sliMetric: { name: string; displayName: string; description: string; type: string; unit: string; module: string };
+  target: number;
+  complianceWindowDays?: number;
+  enabled?: boolean;
+  tags?: string[];
+}
+
+export interface FridayCreateObservabilitySloResponse {
+  slo: FridayObservabilitySloDefinition;
+}
+
+export interface FridayUpdateObservabilitySloRequest {
+  etag: string;
+  name?: string;
+  description?: string;
+  target?: number;
+  complianceWindowDays?: number;
+  enabled?: boolean;
+  tags?: string[];
+}
+
+export interface FridayUpdateObservabilitySloResponse {
+  slo: FridayObservabilitySloDefinition;
+}
+
+export interface FridayDeleteObservabilitySloResponse {
+  deleted: true;
+  sloId: string;
+}
+
 export type FridayAlertDestinationType = "slack" | "email";
 
 export type FridayObservabilityAlertDestination =
@@ -1746,6 +1779,59 @@ export interface FridayListAcceptanceTestsResponse {
 export interface FridayListAcceptanceResultsResponse {
   items: FridayAcceptanceRunSummary[];
   total: number;
+}
+
+export interface FridayRegisterAcceptanceTestRequest {
+  name: string;
+  artifactType: string;
+  checkConfig: Record<string, unknown>;
+  description?: string;
+  priority?: number;
+  enabled?: boolean;
+  shortCircuit?: boolean;
+  tags?: string[];
+  idempotencyKey?: string;
+}
+
+export interface FridayRegisterAcceptanceTestResponse {
+  test: FridayAcceptanceTestSummary;
+}
+
+export interface FridayUpdateAcceptanceTestRequest {
+  etag: string;
+  name?: string;
+  description?: string;
+  checkConfig?: Record<string, unknown>;
+  priority?: number;
+  enabled?: boolean;
+  shortCircuit?: boolean;
+  tags?: string[];
+}
+
+export interface FridayUpdateAcceptanceTestResponse {
+  test: FridayAcceptanceTestSummary;
+}
+
+export interface FridayDeleteAcceptanceTestRequest {
+  etag: string;
+}
+
+export interface FridayDeleteAcceptanceTestResponse {
+  deleted: true;
+  testId: string;
+}
+
+export interface FridayRunAcceptanceTestsRequest {
+  executionId: string;
+  artifacts: Array<{ uri: string; type: string; content?: string }>;
+  metadata?: Record<string, unknown>;
+  idempotencyKey?: string;
+}
+
+export interface FridayRunAcceptanceTestsResponse {
+  passed: boolean;
+  runs: FridayAcceptanceRunSummary[];
+  durationMs: number;
 }
 
 export interface FridayRetryEscalationSummary {

--- a/src/api/http/routes/friday-observability-routes.ts
+++ b/src/api/http/routes/friday-observability-routes.ts
@@ -69,6 +69,9 @@ export interface FridayObservabilityRoutesDeps {
   slos: {
     list(query: FridayListSlosQuery): FridayListSlosResponse | Promise<FridayListSlosResponse>;
     get(sloId: UUID): FridayGetSloStatusResponse | Promise<FridayGetSloStatusResponse>;
+    create(input: { name: string; description?: string; sliMetric: Record<string, unknown>; target: number; complianceWindowDays?: number; enabled?: boolean; tags?: string[] }): Promise<FridayGetSloStatusResponse>;
+    update(sloId: UUID, input: { etag: string; name?: string; description?: string; target?: number; complianceWindowDays?: number; enabled?: boolean; tags?: string[] }): Promise<FridayGetSloStatusResponse>;
+    delete(sloId: UUID, etag: string): Promise<{ deleted: true; sloId: string }>;
   };
   alerts: {
     list(query: FridayListAlertsQuery): FridayListAlertsResponse | Promise<FridayListAlertsResponse>;
@@ -201,6 +204,50 @@ export function createFridayObservabilityRoutes(
       async handler(ctx) {
         const { sloId } = ctx.params as { sloId: UUID };
         return deps.slos.get(sloId);
+      },
+    },
+    {
+      operationId: "observability.slos.create",
+      method: "POST",
+      path: "/v1/observability/slos",
+      auth: { public: false, anyOfScopes: ["diagnosis.write"] },
+      async handler(ctx) {
+        const body = ctx.body as { name: string; sliMetric: Record<string, unknown>; target: number; description?: string; complianceWindowDays?: number; enabled?: boolean; tags?: string[] };
+        if (!body || typeof body.name !== "string" || body.name.trim() === "") {
+          throw new FridayDomainError("VALIDATION_ERROR", "name is required", { httpStatus: 400 });
+        }
+        if (typeof body.target !== "number" || body.target <= 0 || body.target > 100) {
+          throw new FridayDomainError("VALIDATION_ERROR", "target must be between 0 and 100", { httpStatus: 400 });
+        }
+        return deps.slos.create(body);
+      },
+    },
+    {
+      operationId: "observability.slos.update",
+      method: "PUT",
+      path: "/v1/observability/slos/:sloId",
+      auth: { public: false, anyOfScopes: ["diagnosis.write"] },
+      async handler(ctx) {
+        const { sloId } = ctx.params as { sloId: UUID };
+        const body = ctx.body as { etag: string; name?: string; description?: string; target?: number; complianceWindowDays?: number; enabled?: boolean; tags?: string[] };
+        if (!body || typeof body.etag !== "string") {
+          throw new FridayDomainError("VALIDATION_ERROR", "etag is required", { httpStatus: 400 });
+        }
+        return deps.slos.update(sloId, body);
+      },
+    },
+    {
+      operationId: "observability.slos.delete",
+      method: "DELETE",
+      path: "/v1/observability/slos/:sloId",
+      auth: { public: false, anyOfScopes: ["diagnosis.write"] },
+      async handler(ctx) {
+        const { sloId } = ctx.params as { sloId: UUID };
+        const etag = (ctx.query as Record<string, string>).etag ?? ((ctx.body as Record<string, string> | null)?.etag);
+        if (typeof etag !== "string" || etag.trim() === "") {
+          throw new FridayDomainError("VALIDATION_ERROR", "etag is required", { httpStatus: 400 });
+        }
+        return deps.slos.delete(sloId, etag);
       },
     },
 

--- a/src/observability/services/friday-observability-api-service.ts
+++ b/src/observability/services/friday-observability-api-service.ts
@@ -1867,6 +1867,67 @@ export function createFridayObservabilityApiService(
       async get(sloId): Promise<FridayGetSloStatusResponse> {
         return getSloStatus(sloId);
       },
+      async create(input) {
+        const id = deps.idGenerator();
+        const now = deps.nowIso();
+        const sliMetric = input.sliMetric as unknown as FridaySliMetric;
+        const record: SloRuntimeRecord = {
+          id,
+          name: input.name,
+          description: input.description ?? "",
+          sliMetric,
+          target: input.target,
+          complianceWindowDays: input.complianceWindowDays ?? 30,
+          enabled: input.enabled ?? true,
+          tags: input.tags ?? [],
+          alertRuleIds: [],
+          etag: deps.idGenerator(),
+          createdAt: now,
+          updatedAt: now,
+        };
+        storeSloRecord(record);
+        return getSloStatus(id);
+      },
+      async update(sloId, input) {
+        const existing = getSloRecord(sloId);
+        if (!existing) {
+          throw new FridayDomainError("OBS_SLO_NOT_FOUND", "SLO not found", { httpStatus: 404 });
+        }
+        if (existing.etag !== input.etag) {
+          throw new FridayDomainError("OBS_SLO_ETAG_MISMATCH", "SLO was modified concurrently", { httpStatus: 409 });
+        }
+        const now = deps.nowIso();
+        const updated: SloRuntimeRecord = {
+          ...existing,
+          name: input.name ?? existing.name,
+          description: input.description ?? existing.description,
+          target: input.target ?? existing.target,
+          complianceWindowDays: input.complianceWindowDays ?? existing.complianceWindowDays,
+          enabled: input.enabled ?? existing.enabled,
+          tags: input.tags ?? existing.tags,
+          etag: deps.idGenerator(),
+          updatedAt: now,
+        };
+        storeSloRecord(updated);
+        return getSloStatus(sloId);
+      },
+      async delete(sloId, etag) {
+        const existing = getSloRecord(sloId);
+        if (!existing) {
+          throw new FridayDomainError("OBS_SLO_NOT_FOUND", "SLO not found", { httpStatus: 404 });
+        }
+        if (existing.etag !== etag) {
+          throw new FridayDomainError("OBS_SLO_ETAG_MISMATCH", "SLO was modified concurrently", { httpStatus: 409 });
+        }
+        if (deps.db) {
+          deps.db.withWriteTransaction((db) => {
+            db.prepare("DELETE FROM obs_slo_definitions WHERE id = ?").run(sloId);
+          });
+        } else {
+          inMemorySloDefinitions.delete(sloId);
+        }
+        return { deleted: true as const, sloId };
+      },
     },
     alerts: {
       list(query): FridayListAlertsResponse {

--- a/ui/src/components/layout/app-shell.tsx
+++ b/ui/src/components/layout/app-shell.tsx
@@ -1,8 +1,10 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Activity, ChartNoAxesCombined, ChevronDown, Command, Home, MessageCircle, MonitorCog, Package, ShieldCheck, ShoppingBag, Wand2, Waypoints } from "lucide-react";
 import { NavLink, Outlet, useLocation } from "react-router-dom";
+import { toast } from "sonner";
 import { useAuth } from "@/hooks/use-auth";
+import { useSystemEvents } from "@/hooks/use-system-events";
 import { healthApi } from "@/lib/api/health";
 import { systemApi } from "@/lib/api/system";
 import { AGENT_OS_NAV_PRIMARY, AGENT_OS_NAV_ADVANCED, resolvePageTitle } from "@/lib/routes/agent-os-nav";
@@ -34,6 +36,28 @@ export function AppShell() {
     retry: 0,
     refetchInterval: 10_000,
   });
+
+  const { data: pendingApprovals } = useQuery({
+    queryKey: ["shell", "pending-approvals"],
+    queryFn: async () => {
+      const response = await systemApi.listAutoFixActions({ status: "planned", limit: 50 });
+      return response.items.filter((item) => item.summary.requiresApproval);
+    },
+    refetchInterval: 15_000,
+  });
+  const pendingApprovalCount = pendingApprovals?.length ?? 0;
+
+  const { events: systemEvents } = useSystemEvents(true);
+  const lastSeenEventCount = useState({ current: 0 })[0];
+  useEffect(() => {
+    const newEvents = systemEvents.slice(lastSeenEventCount.current);
+    lastSeenEventCount.current = systemEvents.length;
+    for (const event of newEvents) {
+      if (event.event === "autofix.action.pending_approval") {
+        toast.info("New auto-fix requires approval", { description: "Check the Assistant page to review and approve." });
+      }
+    }
+  }, [systemEvents, lastSeenEventCount]);
 
   const [showAdvanced, setShowAdvanced] = useState(false);
 
@@ -132,8 +156,15 @@ export function AppShell() {
                     {item.path === "/command-center" ? <MonitorCog className="h-4 w-4" /> : null}
                     {item.path === "/settings" ? <ShieldCheck className="h-4 w-4" /> : null}
                   </div>
-                  <div className="min-w-0">
-                    <p className="text-sm font-semibold text-white">{item.label}</p>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <p className="text-sm font-semibold text-white">{item.label}</p>
+                      {item.path === "/assistant" && pendingApprovalCount > 0 && (
+                        <span className="flex h-5 min-w-5 items-center justify-center rounded-full bg-red-500 px-1.5 text-[10px] font-bold text-white">
+                          {pendingApprovalCount}
+                        </span>
+                      )}
+                    </div>
                     <p className="mt-1 text-xs leading-5 text-white/50">{item.description}</p>
                   </div>
                 </div>

--- a/ui/src/routes/observability-page.tsx
+++ b/ui/src/routes/observability-page.tsx
@@ -372,7 +372,36 @@ export function ObservabilityPage() {
     },
   });
 
+  const createSloMutation = useMutation({
+    mutationFn: (input: { name: string; target: number; description?: string; complianceWindowDays?: number }) =>
+      systemApi.createObservabilitySlo({
+        ...input,
+        sliMetric: { name: "custom.metric", displayName: input.name, description: input.description ?? "", type: "success_rate", unit: "percent", module: "system" },
+      }),
+    onSuccess: () => {
+      toast.success("SLO created.");
+      setShowCreateSlo(false);
+      void queryClient.invalidateQueries({ queryKey: ["observability", "slos"] });
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Could not create SLO.");
+    },
+  });
+
+  const deleteSloMutation = useMutation({
+    mutationFn: (input: { sloId: string; etag: string }) =>
+      systemApi.deleteObservabilitySlo(input.sloId, input.etag),
+    onSuccess: () => {
+      toast.success("SLO deleted.");
+      void queryClient.invalidateQueries({ queryKey: ["observability", "slos"] });
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Could not delete SLO.");
+    },
+  });
+
   const [showCreateDest, setShowCreateDest] = useState(false);
+  const [showCreateSlo, setShowCreateSlo] = useState(false);
 
   const overview = overviewQuery.data;
   const alerts = alertsQuery.data?.items ?? [];
@@ -1012,15 +1041,36 @@ export function ObservabilityPage() {
       </div>
 
       <div className="grid gap-4 xl:grid-cols-[1fr_1fr]">
-        <ShellCard eyebrow="SLO pack" title="Service level state">
+        <ShellCard
+          eyebrow="SLO pack"
+          title="Service level state"
+          aside={
+            <ActionButton tone="secondary" onClick={() => setShowCreateSlo(!showCreateSlo)}>
+              <Plus className="mr-1.5 h-3 w-3" />
+              Add SLO
+            </ActionButton>
+          }
+        >
+          {showCreateSlo && (
+            <CreateSloForm
+              onSubmit={(input) => createSloMutation.mutate(input)}
+              pending={createSloMutation.isPending}
+              onCancel={() => setShowCreateSlo(false)}
+            />
+          )}
           {slos.length > 0 ? (
             <div className="space-y-3">
               {slos.map((slo) => (
-                <SloCard key={slo.id} slo={slo} />
+                <SloCard
+                  key={slo.id}
+                  slo={slo}
+                  onDelete={(id, etag) => deleteSloMutation.mutate({ sloId: id, etag })}
+                  deletePending={deleteSloMutation.isPending}
+                />
               ))}
             </div>
           ) : (
-            <p className="text-sm text-white/60">No SLO definitions are configured yet.</p>
+            <p className="text-sm text-white/60">No SLO definitions are configured yet. Click &quot;Add SLO&quot; to create one.</p>
           )}
         </ShellCard>
 
@@ -1178,7 +1228,11 @@ function CreateDestinationForm(props: {
   );
 }
 
-function SloCard(props: { slo: Awaited<ReturnType<typeof systemApi.listObservabilitySlos>>[number] }) {
+function SloCard(props: {
+  slo: Awaited<ReturnType<typeof systemApi.listObservabilitySlos>>[number];
+  onDelete: (sloId: string, etag: string) => void;
+  deletePending: boolean;
+}) {
   const { slo } = props;
   const [expanded, setExpanded] = useState(false);
   const detailQuery = useQuery({
@@ -1194,9 +1248,21 @@ function SloCard(props: { slo: Awaited<ReturnType<typeof systemApi.listObservabi
           <p className="truncate font-medium text-white">{slo.name}</p>
           <p className="text-xs text-white/50">{slo.sliMetricName}</p>
         </div>
-        <StatusPill tone={slo.status === "healthy" ? "success" : slo.status === "warning" ? "warning" : "danger"}>
-          {slo.status}
-        </StatusPill>
+        <div className="flex items-center gap-2">
+          <StatusPill tone={slo.status === "healthy" ? "success" : slo.status === "warning" ? "warning" : "danger"}>
+            {slo.status}
+          </StatusPill>
+          {detailQuery.data?.slo.etag && (
+            <button
+              type="button"
+              className="rounded-lg p-1.5 text-white/30 transition hover:bg-white/10 hover:text-red-400"
+              disabled={props.deletePending}
+              onClick={() => props.onDelete(slo.id, detailQuery.data!.slo.etag)}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </div>
       </div>
       <div className="mt-3 grid gap-2 text-xs text-white/55">
         <p>Target: {slo.target}%</p>
@@ -1236,6 +1302,59 @@ function SloCard(props: { slo: Awaited<ReturnType<typeof systemApi.listObservabi
       ) : expanded && detailQuery.isLoading ? (
         <p className="mt-3 text-xs text-white/40">Loading...</p>
       ) : null}
+    </div>
+  );
+}
+
+function CreateSloForm(props: {
+  onSubmit: (input: { name: string; target: number; description?: string; complianceWindowDays?: number }) => void;
+  pending: boolean;
+  onCancel: () => void;
+}) {
+  const [name, setName] = useState("");
+  const [target, setTarget] = useState("99.5");
+  const [description, setDescription] = useState("");
+  const [windowDays, setWindowDays] = useState("30");
+
+  const canSubmit = name.trim().length > 0 && Number(target) > 0 && Number(target) <= 100;
+
+  return (
+    <div className="mb-3 rounded-2xl border border-white/10 bg-black/30 p-4 space-y-3">
+      <p className="text-xs uppercase tracking-[0.16em] text-white/40">Create SLO</p>
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label className="mb-1 block text-xs text-white/50">Name</label>
+          <input type="text" value={name} onChange={(e) => setName(e.target.value)} placeholder="e.g. API Availability" className="w-full rounded-xl border border-white/10 bg-black/30 px-3 py-2 text-sm text-white placeholder:text-white/30 focus:border-white/20 focus:outline-none" />
+        </div>
+        <div>
+          <label className="mb-1 block text-xs text-white/50">Target (%)</label>
+          <input type="number" value={target} onChange={(e) => setTarget(e.target.value)} min={0} max={100} step={0.1} className="w-full rounded-xl border border-white/10 bg-black/30 px-3 py-2 text-sm text-white focus:border-white/20 focus:outline-none" />
+        </div>
+      </div>
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label className="mb-1 block text-xs text-white/50">Description</label>
+          <input type="text" value={description} onChange={(e) => setDescription(e.target.value)} placeholder="Optional" className="w-full rounded-xl border border-white/10 bg-black/30 px-3 py-2 text-sm text-white placeholder:text-white/30 focus:border-white/20 focus:outline-none" />
+        </div>
+        <div>
+          <label className="mb-1 block text-xs text-white/50">Compliance window (days)</label>
+          <input type="number" value={windowDays} onChange={(e) => setWindowDays(e.target.value)} min={1} max={365} className="w-full rounded-xl border border-white/10 bg-black/30 px-3 py-2 text-sm text-white focus:border-white/20 focus:outline-none" />
+        </div>
+      </div>
+      <div className="flex gap-2">
+        <ActionButton
+          disabled={!canSubmit || props.pending}
+          onClick={() => props.onSubmit({
+            name: name.trim(),
+            target: Number(target),
+            description: description.trim() || undefined,
+            complianceWindowDays: Number(windowDays) || undefined,
+          })}
+        >
+          {props.pending ? "Creating..." : "Create"}
+        </ActionButton>
+        <ActionButton tone="secondary" onClick={props.onCancel}>Cancel</ActionButton>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Comprehensive audit found Friday's UI was "read-only" — users could see data but couldn't act on it. This PR closes all gaps:

**Phase 1: Wire unused operator client methods to UI**
- Observability: create/edit/delete alert destinations, loop run detail expand, test alert dispatch, expert loop runs
- Settings: agent loop policy pause/resume, auto-apply toggle, expert mode enable/disable
- Memory: add memory store form (namespace, key, content, tags)
- Assistant: auto-fix action evidence expand (root cause, plan, risk tier, approval trail)

**Phase 2: Close backend-first gaps**
- SLO CRUD: new POST/PUT/DELETE routes + service layer + operator client + UI create form + delete
- Acceptance Test CRUD: operator client methods for create/update/delete/run (backend routes already existed)
- Approval push notifications: pending count badge on Assistant nav + toast on new approval events

**Phase 3: Cleanup**
- Remove unused `queryClient` in `use-guided-flow.ts`

## Verification
- typecheck (3 tsconfig projects) ✅
- lint ✅
- build:api + build:ui ✅
- vitest (all tests pass) ✅

## Test plan
- [ ] Verify observability page: create alert destination, toggle enable/disable, delete, test dispatch
- [ ] Verify SLO create form + delete button
- [ ] Verify memory page: add memory item via store form
- [ ] Verify settings page: toggle agent loop policy, expert mode
- [ ] Verify assistant page: expand auto-fix evidence detail
- [ ] Verify app-shell: pending approval badge appears on Assistant nav

https://claude.ai/code/session_01GnUMK67S45EJ1BznYfG1Qb