### PR TITLE
Use gpt-5.4 for Codex CLI defaults

### DIFF
--- a/src/agent/tools/friday-agent-provider-tool.ts
+++ b/src/agent/tools/friday-agent-provider-tool.ts
@@ -623,7 +623,7 @@ export function createFridayAgentProviderTool(
       case "openai":
         return ["gpt-4o", "gpt-4o-mini", "gpt-4.1"];
       case "openai-codex":
-        return ["codex"];
+        return ["gpt-5.4"];
       case "anthropic":
         return ["claude-sonnet-4-20250514", "claude-opus-4-20250514"];
       case "google":

--- a/src/cli/friday-cli-auth.ts
+++ b/src/cli/friday-cli-auth.ts
@@ -48,8 +48,8 @@ const CLI_AUTH_TARGETS = {
     kind: "openai-codex" as FridayProviderKind,
     backendId: "codex-cli" as FridayProviderCliBackendId,
     name: "Codex CLI",
-    supportedModels: ["codex"],
-    defaultModel: "codex",
+    supportedModels: ["gpt-5.4"],
+    defaultModel: "gpt-5.4",
   },
   claude: {
     kind: "anthropic" as FridayProviderKind,

--- a/test/unit/agent/tools/friday-agent-provider-tool.test.ts
+++ b/test/unit/agent/tools/friday-agent-provider-tool.test.ts
@@ -262,7 +262,7 @@ describe("createFridayAgentProviderTool", () => {
         deploymentKind: "consumer-cli",
         regionTag: "global",
         keySource: { kind: "none" },
-        supportedModels: ["codex"],
+        supportedModels: ["gpt-5.4"],
         cliConfig: { backendId: "codex-cli", binaryPath: "/usr/local/bin/codex" },
         validation: { status: "never" },
       },
@@ -279,8 +279,8 @@ describe("createFridayAgentProviderTool", () => {
       backendKind: "cli",
       cliBackendId: "codex-cli",
       cliBinaryPath: "/usr/local/bin/codex",
-      supportedModels: ["codex"],
-      defaultModel: "codex",
+      supportedModels: ["gpt-5.4"],
+      defaultModel: "gpt-5.4",
     }, signal());
     const parsed = JSON.parse(result.content) as Record<string, any>;
 

--- a/test/unit/providers/services/friday-provider-service.test.ts
+++ b/test/unit/providers/services/friday-provider-service.test.ts
@@ -205,7 +205,7 @@ describe("FridayProviderService", () => {
           binaryPath: "/usr/local/bin/codex",
         },
         api: "openai-responses",
-        supportedModels: ["codex"],
+        supportedModels: ["gpt-5.4"],
         validateOnSave: false,
       });
 


### PR DESCRIPTION
## Summary
- switch Codex CLI default and recommended model from `codex` to `gpt-5.4`
- update provider tool expectations and provider service tests to match the real CLI-supported model
- keep the change scoped to the four files needed for the CLI backend fix

## Validation
- `npm run build`
- `npx vitest run test/unit/cli/friday-cli-auth.test.ts test/unit/providers/services/friday-provider-service.test.ts test/unit/agent/tools/friday-agent-provider-tool.test.ts`
- real Friday smoke through providerService -> agent LLM client using Codex CLI and Claude CLI
  - artifact: `.friday/live-smoke/cli-backend-smoke-2026-04-01T09-01-37-838Z.json`

## Notes
- this PR intentionally does not include the concurrent `attach-cli` migration fix or the closure harness finalization fix; those will land in a follow-up draft PR
