### PR TITLE
[codex] Stabilize CLI backends and closure runtime

### DIFF
--- a/docs/reports/repo/CLI_BACKEND_AND_RUNTIME_AUDIT_2026-04-01.md
+++ b/docs/reports/repo/CLI_BACKEND_AND_RUNTIME_AUDIT_2026-04-01.md
@@ -1,0 +1,216 @@
+# CLI Backend And Runtime Audit
+
+Date: 2026-04-01
+
+## Scope
+
+This audit covered:
+
+- `provider/auth/backend matrix`
+- `Codex CLI` / `Claude CLI` real Friday execution paths
+- `agent/runtime` boundaries for CLI backends
+- SQLite migration/bootstrap concurrency
+- `scripts/e2e/run-friday-closure.mjs` finalization
+- docs/runtime drift where it affected real behavior
+
+The audit used real Friday execution evidence, not only static review.
+
+## Release Summary
+
+### Confirmed facts
+
+- `PR1` remains required because current `main` still defaults `Codex CLI` to `codex`; the separate branch changes that default to `gpt-5.4`.
+- `PR2` fixes both originally confirmed engineering gaps:
+  - concurrent `attach-cli` startup against the same SQLite state directory
+  - closure harness finalization / `completedAt`
+- A third high-confidence blocker surfaced during the audit and was fixed in this branch:
+  - CLI backends hard-failed inside `/v1/agent/runs` because the agent runtime always exposed Friday tools
+  - the boundary is now treated as `text-only backend`, so pure inference works and file/tool tasks refuse honestly instead of 501-failing or bluffing
+
+### Recommendation
+
+- `PR1`: safe to land first once its own checks are green
+- `PR2`: safe to land after CI completes; local release gate is green
+- Do **not** claim “full tool-capable CLI backend support”
+- It is accurate to claim:
+  - Friday can use `Codex CLI` and `Claude CLI` as text backends
+  - Friday routes tool-using work to HTTP backends, and CLI backends now refuse tool/file tasks honestly
+
+## Evidence
+
+- PR1 Friday CLI smoke:
+  - [/Users/jarvis/Projects/Friday/.friday/live-smoke/cli-backend-smoke-2026-04-01T09-01-37-838Z.json](/Users/jarvis/Projects/Friday/.friday/live-smoke/cli-backend-smoke-2026-04-01T09-01-37-838Z.json)
+- concurrent `attach-cli` failed before fix:
+  - [/Users/jarvis/Projects/Friday/.friday/live-smoke/attach-cli-concurrency-2026-04-01T09-08-28-094Z.json](/Users/jarvis/Projects/Friday/.friday/live-smoke/attach-cli-concurrency-2026-04-01T09-08-28-094Z.json)
+- concurrent `attach-cli` passed after migration + startup fix:
+  - [/Users/jarvis/Projects/Friday/.friday/live-smoke/attach-cli-concurrency-2026-04-01T09-09-11-666Z.json](/Users/jarvis/Projects/Friday/.friday/live-smoke/attach-cli-concurrency-2026-04-01T09-09-11-666Z.json)
+- auth/profile real output:
+  - [/Users/jarvis/Projects/Friday/.friday/live-smoke/auth-status-2026-04-01T09-16-37Z.json](/Users/jarvis/Projects/Friday/.friday/live-smoke/auth-status-2026-04-01T09-16-37Z.json)
+- closure run that now exits cleanly and writes `completedAt`:
+  - [/Users/jarvis/Projects/Friday/.friday/closure/2026-04-01T09-16-52-793Z/ledger.json](/Users/jarvis/Projects/Friday/.friday/closure/2026-04-01T09-16-52-793Z/ledger.json)
+- CLI backend agent-route probe before truth-boundary hardening:
+  - [/Users/jarvis/Projects/Friday/.friday/live-smoke/cli-agent-route-probe-pretruthfix-2026-04-01T09-20-41Z.json](/Users/jarvis/Projects/Friday/.friday/live-smoke/cli-agent-route-probe-pretruthfix-2026-04-01T09-20-41Z.json)
+- CLI backend agent-route probe after truth-boundary hardening:
+  - [/Users/jarvis/Projects/Friday/.friday/live-smoke/cli-agent-route-probe-posttruthfix-2026-04-01T09-22-12Z.json](/Users/jarvis/Projects/Friday/.friday/live-smoke/cli-agent-route-probe-posttruthfix-2026-04-01T09-22-12Z.json)
+
+## Confirmed Blockers Fixed
+
+### 1. Concurrent `attach-cli` could fail during SQLite startup
+
+**Confirmed fact**
+
+- Two concurrent `attach-cli` processes against the same state directory could fail in two different ways:
+  - `schema_migrations.version` unique constraint collision
+  - `SQLITE_BUSY` during startup `journal_mode = WAL`
+
+**Code changes**
+
+- [/Users/jarvis/Projects/Friday/src/state/sqlite/friday-migration-runner.ts](/Users/jarvis/Projects/Friday/src/state/sqlite/friday-migration-runner.ts)
+- [/Users/jarvis/Projects/Friday/src/state/sqlite/friday-sqlite-pragmas.ts](/Users/jarvis/Projects/Friday/src/state/sqlite/friday-sqlite-pragmas.ts)
+- [/Users/jarvis/Projects/Friday/test/integration/state/sqlite/friday-migration-chain.test.ts](/Users/jarvis/Projects/Friday/test/integration/state/sqlite/friday-migration-chain.test.ts)
+- [/Users/jarvis/Projects/Friday/test/unit/state/sqlite/friday-sqlite-layer.test.ts](/Users/jarvis/Projects/Friday/test/unit/state/sqlite/friday-sqlite-layer.test.ts)
+- [/Users/jarvis/Projects/Friday/test/integration/state/sqlite/helpers/run-friday-migrations-worker.mjs](/Users/jarvis/Projects/Friday/test/integration/state/sqlite/helpers/run-friday-migrations-worker.mjs)
+- [/Users/jarvis/Projects/Friday/test/unit/state/sqlite/helpers/create-sqlite-layer-worker.mjs](/Users/jarvis/Projects/Friday/test/unit/state/sqlite/helpers/create-sqlite-layer-worker.mjs)
+
+**Result**
+
+- The migration pass is now serialized under `BEGIN IMMEDIATE`.
+- Startup write pragmas tolerate transient `SQLITE_BUSY` during parallel initialization.
+- Real concurrent probe now succeeds.
+
+### 2. Closure harness could leave `completedAt=null`
+
+**Confirmed fact**
+
+- Before the fix, the harness could finish the functional stages but still leave `completedAt` null because cleanup/finalization did not reliably release child handles and writable streams.
+
+**Code changes**
+
+- [/Users/jarvis/Projects/Friday/scripts/e2e/run-friday-closure.mjs](/Users/jarvis/Projects/Friday/scripts/e2e/run-friday-closure.mjs)
+- [/Users/jarvis/Projects/Friday/test/unit/e2e/run-friday-closure.test.ts](/Users/jarvis/Projects/Friday/test/unit/e2e/run-friday-closure.test.ts)
+
+**Result**
+
+- The latest closure run exited naturally.
+- `completedAt` is now written.
+- Local readiness is `GO`.
+
+### 3. CLI backends hard-failed inside `/v1/agent/runs`
+
+**Confirmed fact**
+
+- The first real `/v1/agent/runs` probe with `Codex CLI` showed the provider was considered `routingEligible`, but agent runs failed because `FridayAgentLlmClient` rejected any CLI backend when tools were present.
+- In practice, the agent runtime always exposed tools, so even pure inference tasks failed.
+
+**Code changes**
+
+- [/Users/jarvis/Projects/Friday/src/agent/runtime/friday-agent-llm-client.ts](/Users/jarvis/Projects/Friday/src/agent/runtime/friday-agent-llm-client.ts)
+- [/Users/jarvis/Projects/Friday/test/unit/agent/runtime/friday-agent-llm-client-cli.test.ts](/Users/jarvis/Projects/Friday/test/unit/agent/runtime/friday-agent-llm-client-cli.test.ts)
+
+**Result**
+
+- CLI backends are now treated as `text-only`.
+- Pure inference through `/v1/agent/runs` succeeds.
+- Tool/file tasks no longer hard-fail with `501`; instead they refuse honestly and ask for an HTTP backend.
+
+## Layer Findings
+
+### Backend/auth matrix
+
+#### Confirmed facts
+
+- `Codex CLI` and `Claude CLI` both work through Friday’s provider/runtime path for text output.
+- `external-session` auth is functioning for CLI backends.
+- `auth status` correctly reports:
+  - `Codex CLI` healthy
+  - `Claude CLI` healthy
+  - real account metadata for `Claude CLI`
+
+#### Confirmed non-blocker
+
+- `auth status` still reports Anthropic OAuth providers as `authHealth=status_unknown` and `routingEligible=false` with reason `oauth_requires_token_manager_check`, even though real OAuth-backed runs can work elsewhere.
+- This is an operator-surface accuracy issue, not a proven runtime failure in this audit.
+
+### Provider routing and CLI backend boundaries
+
+#### Confirmed facts
+
+- CLI backends are **not** full Friday tool-loop backends.
+- `Codex CLI` and `Claude CLI` should currently be understood as `text-only` execution backends.
+- A real pre-fix probe showed a worse failure mode:
+  - once the model mismatch was removed, the backend could answer a file-reading task without tools and without proof
+
+#### Fix applied
+
+- The runtime boundary message is now explicit:
+  - no file access
+  - no shell access
+  - no web access
+  - no live workspace state
+  - do not claim tool use
+
+#### Recommendation
+
+- Keep CLI backends as text-only for now.
+- Do not market them as general replacements for HTTP/tool-capable providers.
+
+### Runtime / session / workflow / memory
+
+#### Confirmed facts
+
+- World-model markers continue to fire in real runs:
+  - `world_model_episode_extracted`
+  - `world_model_snapshot_saved`
+- The CLI backend boundary fix did not break run completion or post-run world-model hooks.
+- Closure remains `GO` after the runtime and SQLite fixes.
+
+### SQLite / bootstrap / migration
+
+#### Confirmed facts
+
+- The migration model is now `whole-pass atomic` rather than `one transaction per migration`.
+- One unit test had to be updated because it still asserted the old semantics.
+- This is an intentional contract change aligned with the serialization requirement.
+
+### Closure / release / CI path
+
+#### Confirmed facts
+
+- The first post-fix closure run exited cleanly but exposed a real failing unit assertion in `friday-migration-runner.test.ts`.
+- That assertion drift was corrected.
+- The next closure run completed with:
+  - `25 PASS`
+  - `0 FAIL`
+  - `0 BLOCKER`
+  - `repoReady=GO`
+  - `productReadyLocal=GO`
+
+### Docs vs runtime
+
+#### Confirmed non-blocker
+
+- `Gemini CLI` is advertised in the capability/catalog surface, but runtime still throws:
+  - `Gemini CLI backend is not wired for non-interactive inference yet`
+- Relevant source:
+  - [/Users/jarvis/Projects/Friday/src/providers/cli/friday-provider-cli-backend.ts](/Users/jarvis/Projects/Friday/src/providers/cli/friday-provider-cli-backend.ts)
+  - [/Users/jarvis/Projects/Friday/src/providers/model/friday-provider-capabilities.ts](/Users/jarvis/Projects/Friday/src/providers/model/friday-provider-capabilities.ts)
+- This should stay out of the “verified ready” surface until a real non-interactive path exists.
+
+## Confirmed Non-Blockers
+
+- Default provider fallback warning is real and operator-useful:
+  - current default provider has no configured fallback
+- This does not block the audited branch from release, but it remains a resiliency gap in the user’s local state configuration.
+
+## Inference
+
+- The current architecture is converging toward a correct split:
+  - HTTP backends for tool-capable execution
+  - CLI backends for text-only consumer-plan execution
+- The remaining risk is not that the split is wrong; it is that some operator surfaces still describe CLI backends too loosely.
+
+## Recommendations
+
+- Add an explicit doctor/report field for `textOnlyBackend` or equivalent, so operator surfaces stop implying full agent capability when the backend cannot use Friday tools.
+- Downgrade `Gemini CLI` from “ready backend” surfaces until a real non-interactive inference path exists.
+- Keep using real Friday-path probes for CLI backends; bare CLI success is not enough to prove Friday integration correctness.

--- a/scripts/e2e/run-friday-closure.mjs
+++ b/scripts/e2e/run-friday-closure.mjs
@@ -54,6 +54,116 @@ function writeText(filePath, text) {
   fs.writeFileSync(filePath, text, "utf8");
 }
 
+export async function closeWritableStream(stream, timeoutMs = 5_000) {
+  if (!stream || stream.destroyed || stream.closed) {
+    return;
+  }
+  await new Promise((resolve) => {
+    let settled = false;
+    const settle = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      stream.removeListener("finish", settle);
+      stream.removeListener("close", settle);
+      stream.removeListener("error", settle);
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      try {
+        stream.destroy();
+      } catch {
+        // ignore cleanup failure
+      }
+      settle();
+    }, timeoutMs);
+    stream.once("finish", settle);
+    stream.once("close", settle);
+    stream.once("error", settle);
+    try {
+      if (!stream.writableEnded) {
+        stream.end();
+      } else if (stream.closed || stream.destroyed) {
+        settle();
+      }
+    } catch {
+      settle();
+    }
+  });
+}
+
+export async function stopManagedChildProcess(
+  child,
+  { graceMs = 5_000, forceKillMs = 2_000 } = {},
+) {
+  if (!child || child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+  await new Promise((resolve) => {
+    let settled = false;
+    const settle = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(forceKillTimer);
+      clearTimeout(finalTimer);
+      child.removeListener("close", settle);
+      child.removeListener("error", settle);
+      resolve();
+    };
+    const forceKillTimer = setTimeout(() => {
+      if (child.exitCode === null && child.signalCode === null) {
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          settle();
+        }
+      }
+    }, graceMs);
+    const finalTimer = setTimeout(() => {
+      if (child.exitCode === null && child.signalCode === null) {
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          // ignore duplicate cleanup failure
+        }
+      }
+      settle();
+    }, graceMs + forceKillMs);
+    child.once("close", settle);
+    child.once("error", settle);
+    try {
+      child.kill("SIGTERM");
+    } catch {
+      settle();
+    }
+  });
+}
+
+function createCleanupRegistry() {
+  const tasks = [];
+  return {
+    add(task) {
+      tasks.push(task);
+    },
+    async run() {
+      const errors = [];
+      while (tasks.length > 0) {
+        const task = tasks.pop();
+        try {
+          await task();
+        } catch (error) {
+          errors.push(error instanceof Error ? error.message : String(error));
+        }
+      }
+      return errors;
+    },
+  };
+}
+
 function sanitizeName(value) {
   return value.replace(/[^a-z0-9._-]+/gi, "-");
 }
@@ -216,21 +326,24 @@ async function runCommand({
     }
   }, timeoutMs + 5_000);
 
-  const result = await new Promise((resolve, reject) => {
-    child.on("error", reject);
-    child.on("close", (code, signal) => {
-      resolve({
-        code: code ?? 1,
-        signal,
-        output: combined,
-        durationMs: Date.now() - startedAt,
+  let result;
+  try {
+    result = await new Promise((resolve, reject) => {
+      child.on("error", reject);
+      child.on("close", (code, signal) => {
+        resolve({
+          code: code ?? 1,
+          signal,
+          output: combined,
+          durationMs: Date.now() - startedAt,
+        });
       });
     });
-  }).finally(() => {
+  } finally {
     clearTimeout(timeout);
     clearTimeout(forceKillTimeout);
-    stream.end();
-  });
+    await closeWritableStream(stream, 5_000);
+  }
 
   return {
     id,
@@ -942,6 +1055,13 @@ async function runLocalStage(ledger) {
     stdio: ["ignore", "pipe", "pipe"],
   });
   const serverLogStream = fs.createWriteStream(serverLogPath, { flags: "w" });
+  const cleanupRegistry = createCleanupRegistry();
+  cleanupRegistry.add(async () => {
+    await closeWritableStream(serverLogStream, 5_000);
+  });
+  cleanupRegistry.add(async () => {
+    await stopManagedChildProcess(server, { graceMs: 5_000, forceKillMs: 2_000 });
+  });
   server.stdout.on("data", (chunk) => serverLogStream.write(chunk));
   server.stderr.on("data", (chunk) => serverLogStream.write(chunk));
 
@@ -2184,29 +2304,10 @@ async function runLocalStage(ledger) {
       });
     }
   } finally {
-    await new Promise((resolve) => {
-      if (server.exitCode !== null || server.signalCode !== null) {
-        resolve();
-        return;
-      }
-      let settled = false;
-      const settle = () => {
-        if (settled) {
-          return;
-        }
-        settled = true;
-        clearTimeout(forceKillTimer);
-        resolve();
-      };
-      const forceKillTimer = setTimeout(() => {
-        if (server.exitCode === null && server.signalCode === null) {
-          server.kill("SIGKILL");
-        }
-      }, 5_000);
-      server.once("close", settle);
-      server.kill("SIGTERM");
-    });
-    serverLogStream.end();
+    const cleanupErrors = await cleanupRegistry.run();
+    if (cleanupErrors.length > 0) {
+      writeJson(path.join(ledger.paths.logs, "local-runtime-cleanup-errors.json"), cleanupErrors);
+    }
   }
 }
 

--- a/src/agent/runtime/friday-agent-llm-client.ts
+++ b/src/agent/runtime/friday-agent-llm-client.ts
@@ -71,6 +71,14 @@ const CLAUDE_CODE_TO_FRIDAY_NAMES: ReadonlyMap<string, string> = new Map(
   [...FRIDAY_TO_CLAUDE_CODE_NAMES.entries()].map(([friday, cc]) => [cc, friday]),
 );
 
+const FRIDAY_CLI_BACKEND_TEXT_ONLY_NOTE = [
+  "Runtime capability boundary:",
+  "- Friday tools are unavailable in this backend.",
+  "- You do not have access to files, shell, browser, network, or live workspace state.",
+  "- Never claim to have read a file, inspected the repository, run a command, browsed the web, or used a Friday tool.",
+  "- If the request depends on those capabilities, clearly say this Friday CLI backend is text-only and ask to reroute to an HTTP backend for tool-using tasks.",
+].join("\n");
+
 function toOAuthToolName(fridayName: string): string {
   return FRIDAY_TO_CLAUDE_CODE_NAMES.get(fridayName) ?? fridayName;
 }
@@ -121,13 +129,6 @@ export function createFridayAgentLlmClient(
             { httpStatus: 500 },
           );
         }
-        if (params.tools.length > 0) {
-          throw new FridayDomainError(
-            FRIDAY_AGENT_ERROR_CODES.LLM_ERROR,
-            "CLI backend does not support Friday tool loop yet. Route to an HTTP backend for tool-using tasks.",
-            { httpStatus: 501 },
-          );
-        }
         const conversation = params.messages
           .map((message) =>
             `${message.role.toUpperCase()}: ${
@@ -137,9 +138,12 @@ export function createFridayAgentLlmClient(
             }`,
           )
           .join("\n\n");
+        const cliSystemPrompt = params.tools.length > 0
+          ? `${params.systemPrompt}\n\n${FRIDAY_CLI_BACKEND_TEXT_ONLY_NOTE}`
+          : params.systemPrompt;
         const output = await runFridayCliBackendTextCompletion({
           cliConfig: deps.cliConfig,
-          systemPrompt: params.systemPrompt,
+          systemPrompt: cliSystemPrompt,
           conversation,
           model: params.model,
         });

--- a/src/state/sqlite/friday-migration-runner.ts
+++ b/src/state/sqlite/friday-migration-runner.ts
@@ -12,77 +12,79 @@ export interface RunFridayMigrationsOptions {
 }
 
 /**
- * Applies pending migrations in a transaction per version.
- * Validates checksum for already-applied versions.
+ * Applies the full pending migration pass under a single IMMEDIATE transaction.
+ * This serializes concurrent runners against the same SQLite file and preserves
+ * all-or-nothing semantics for a migration batch.
  */
 export function runFridayMigrations(
   options: RunFridayMigrationsOptions,
 ): RunFridayMigrationsResult {
   const { db, migrations, now = () => new Date() } = options;
 
-  // Ensure schema_migrations table exists
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS schema_migrations (
-      version INTEGER PRIMARY KEY,
-      name TEXT NOT NULL,
-      checksum TEXT NOT NULL,
-      applied_at TEXT NOT NULL
-    )
-  `);
-
   const applied: RunFridayMigrationsResult["applied"] = [];
   const skippedVersions: number[] = [];
+  db.exec("BEGIN IMMEDIATE");
+  try {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS schema_migrations (
+        version INTEGER PRIMARY KEY,
+        name TEXT NOT NULL,
+        checksum TEXT NOT NULL,
+        applied_at TEXT NOT NULL
+      )
+    `);
 
-  const getApplied = db.prepare(
-    "SELECT version, name, checksum, applied_at FROM schema_migrations WHERE version = ?",
-  );
-  const insertApplied = db.prepare(
-    "INSERT INTO schema_migrations (version, name, checksum, applied_at) VALUES (?, ?, ?, ?)",
-  );
+    const getApplied = db.prepare(
+      "SELECT version, name, checksum, applied_at FROM schema_migrations WHERE version = ?",
+    );
+    const insertApplied = db.prepare(
+      "INSERT INTO schema_migrations (version, name, checksum, applied_at) VALUES (?, ?, ?, ?)",
+    );
 
-  for (const migration of migrations) {
-    const existing = getApplied.get(migration.version) as
-      | { version: number; name: string; checksum: string; applied_at: string }
-      | undefined;
+    for (const migration of migrations) {
+      const existing = getApplied.get(migration.version) as
+        | { version: number; name: string; checksum: string; applied_at: string }
+        | undefined;
 
-    if (existing) {
-      // Validate checksum
-      const acceptedChecksums = new Set([
-        migration.checksum,
-        ...(migration.acceptedChecksums ?? []),
-      ]);
-      if (!acceptedChecksums.has(existing.checksum)) {
-        throw new FridayDomainError(
-          "MIGRATION_CHECKSUM_MISMATCH",
-          `Migration checksum mismatch for version ${migration.version} (${migration.name}): ` +
-            `expected ${migration.checksum}, found ${existing.checksum}`,
-          { httpStatus: 500 },
-        );
+      if (existing) {
+        const acceptedChecksums = new Set([
+          migration.checksum,
+          ...(migration.acceptedChecksums ?? []),
+        ]);
+        if (!acceptedChecksums.has(existing.checksum)) {
+          throw new FridayDomainError(
+            "MIGRATION_CHECKSUM_MISMATCH",
+            `Migration checksum mismatch for version ${migration.version} (${migration.name}): ` +
+              `expected ${migration.checksum}, found ${existing.checksum}`,
+            { httpStatus: 500 },
+          );
+        }
+        skippedVersions.push(migration.version);
+        continue;
       }
-      skippedVersions.push(migration.version);
-      continue;
-    }
 
-    // Apply migration in its own transaction
-    const appliedAt = now().toISOString();
-    const applyMigration = db.transaction(() => {
+      const appliedAt = now().toISOString();
       if (typeof migration.apply === "function") {
         migration.apply(db);
       } else {
         db.exec(migration.sql);
       }
       insertApplied.run(migration.version, migration.name, migration.checksum, appliedAt);
-    });
 
-    applyMigration();
+      applied.push({
+        version: migration.version,
+        name: migration.name,
+        checksum: migration.checksum,
+        appliedAt,
+      });
+    }
 
-    applied.push({
-      version: migration.version,
-      name: migration.name,
-      checksum: migration.checksum,
-      appliedAt,
-    });
+    db.exec("COMMIT");
+    return { applied, skippedVersions };
+  } catch (error) {
+    if (db.inTransaction) {
+      db.exec("ROLLBACK");
+    }
+    throw error;
   }
-
-  return { applied, skippedVersions };
 }

--- a/src/state/sqlite/friday-sqlite-layer.ts
+++ b/src/state/sqlite/friday-sqlite-layer.ts
@@ -5,6 +5,8 @@ import { createFridaySqliteReadPool } from "./friday-sqlite-read-pool.js";
 import { runFridayMigrations } from "./friday-migration-runner.js";
 import { FRIDAY_SQLITE_MIGRATIONS } from "./migrations/index.js";
 
+export const FRIDAY_SQLITE_STARTUP_BUSY_TIMEOUT_FLOOR_MS = 30_000;
+
 /**
  * Creates Phase 0 sqlite runtime:
  * writer connection -> pragmas -> migrations -> read pool.
@@ -16,11 +18,21 @@ export function createFridaySqliteLayer(
 
   // 1. Open writer connection
   const writer = new Database(dbPath);
-  applyFridayWritePragmas(writer, pragmas);
+  const startupPragmas = {
+    ...pragmas,
+    busyTimeoutMs: Math.max(pragmas.busyTimeoutMs, FRIDAY_SQLITE_STARTUP_BUSY_TIMEOUT_FLOOR_MS),
+  };
+  applyFridayWritePragmas(writer, startupPragmas);
 
-  // 2. Run migrations on writer
-  if (shouldRunMigrations) {
-    runFridayMigrations({ db: writer, migrations: FRIDAY_SQLITE_MIGRATIONS });
+  try {
+    // 2. Run migrations on writer
+    if (shouldRunMigrations) {
+      runFridayMigrations({ db: writer, migrations: FRIDAY_SQLITE_MIGRATIONS });
+    }
+  } finally {
+    if (startupPragmas.busyTimeoutMs !== pragmas.busyTimeoutMs) {
+      writer.pragma(`busy_timeout = ${pragmas.busyTimeoutMs}`);
+    }
   }
 
   // 3. Open read pool

--- a/src/state/sqlite/friday-sqlite-pragmas.ts
+++ b/src/state/sqlite/friday-sqlite-pragmas.ts
@@ -1,14 +1,29 @@
 import type Database from "better-sqlite3";
 import type { FridaySqlitePragmaConfig } from "./friday-sqlite.types.js";
 
+function isBusyPragmaError(error: unknown): boolean {
+  return !!(
+    error
+    && typeof error === "object"
+    && "code" in error
+    && (error as { code?: unknown }).code === "SQLITE_BUSY"
+  );
+}
+
 /** Applies write-connection pragmas: WAL, foreign_keys, busy_timeout, synchronous. */
 export function applyFridayWritePragmas(
   db: Database.Database,
   pragmas: FridaySqlitePragmaConfig,
 ): void {
-  db.pragma(`journal_mode = WAL`);
-  db.pragma(`foreign_keys = ON`);
   db.pragma(`busy_timeout = ${pragmas.busyTimeoutMs}`);
+  try {
+    db.pragma(`journal_mode = WAL`);
+  } catch (error) {
+    if (!isBusyPragmaError(error)) {
+      throw error;
+    }
+  }
+  db.pragma(`foreign_keys = ON`);
   db.pragma(`synchronous = ${pragmas.synchronous}`);
 }
 

--- a/test/helpers/friday-ensure-api-build.helper.ts
+++ b/test/helpers/friday-ensure-api-build.helper.ts
@@ -1,0 +1,78 @@
+import { existsSync } from "node:fs";
+import { mkdir, open, rm } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+import { setTimeout as delay } from "node:timers/promises";
+import { createHash } from "node:crypto";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
+const DIST_STATE_ENTRY = join(REPO_ROOT, "dist", "state", "index.js");
+const LOCK_PATH = join(
+  tmpdir(),
+  `friday-build-api-${createHash("sha1").update(REPO_ROOT).digest("hex")}.lock`,
+);
+const LOCK_WAIT_TIMEOUT_MS = 180_000;
+const LOCK_POLL_INTERVAL_MS = 250;
+
+function getNpmCommand(): string {
+  return process.platform === "win32" ? "npm.cmd" : "npm";
+}
+
+export async function ensureFridayApiBuildForNodeWorkers(): Promise<void> {
+  if (existsSync(DIST_STATE_ENTRY)) {
+    return;
+  }
+
+  await mkdir(dirname(LOCK_PATH), { recursive: true });
+  const deadline = Date.now() + LOCK_WAIT_TIMEOUT_MS;
+
+  let lockHandle: Awaited<ReturnType<typeof open>> | null = null;
+  while (!lockHandle) {
+    try {
+      lockHandle = await open(LOCK_PATH, "wx");
+    } catch (error) {
+      if (
+        !error
+        || typeof error !== "object"
+        || !("code" in error)
+        || (error as NodeJS.ErrnoException).code !== "EEXIST"
+      ) {
+        throw error;
+      }
+
+      if (existsSync(DIST_STATE_ENTRY)) {
+        return;
+      }
+      if (Date.now() >= deadline) {
+        throw new Error(
+          `Timed out waiting for API build lock at ${LOCK_PATH}`,
+        );
+      }
+      await delay(LOCK_POLL_INTERVAL_MS);
+    }
+  }
+
+  try {
+    if (existsSync(DIST_STATE_ENTRY)) {
+      return;
+    }
+
+    const result = spawnSync(getNpmCommand(), ["run", "build:api"], {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+      stdio: "pipe",
+    });
+    if (result.status !== 0) {
+      const stderr = result.stderr?.trim() || result.stdout?.trim() || "unknown build failure";
+      throw new Error(`Failed to build API artifacts for node workers: ${stderr}`);
+    }
+    if (!existsSync(DIST_STATE_ENTRY)) {
+      throw new Error(`API build completed without ${DIST_STATE_ENTRY}`);
+    }
+  } finally {
+    await lockHandle.close();
+    await rm(LOCK_PATH, { force: true });
+  }
+}

--- a/test/integration/state/sqlite/friday-migration-chain.test.ts
+++ b/test/integration/state/sqlite/friday-migration-chain.test.ts
@@ -57,7 +57,10 @@ describe("Friday Migration Chain (V001–V024)", () => {
     expect(second.skippedVersions).toEqual(expectedVersions);
   });
 
-  it("serializes concurrent migration runners against the same sqlite file", async () => {
+  it(
+    "serializes concurrent migration runners against the same sqlite file",
+    { timeout: 60_000 },
+    async () => {
     await ensureFridayApiBuildForNodeWorkers();
 
     const root = mkdtempSync(join(tmpdir(), "friday-migration-race-"));
@@ -133,7 +136,8 @@ describe("Friday Migration Chain (V001–V024)", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
-  });
+    },
+  );
 
   // ─── Expected tables from V001 ───
 

--- a/test/integration/state/sqlite/friday-migration-chain.test.ts
+++ b/test/integration/state/sqlite/friday-migration-chain.test.ts
@@ -93,8 +93,8 @@ describe("Friday Migration Chain (V001–V024)", () => {
     try {
       const [first, second] = await Promise.all([runWorker(), runWorker()]);
 
-      expect(first.code).toBe(0);
-      expect(second.code).toBe(0);
+      expect(first.code, first.stderr || first.stdout).toBe(0);
+      expect(second.code, second.stderr || second.stdout).toBe(0);
 
       const firstResult = JSON.parse(first.stdout.trim()) as {
         ok: boolean;

--- a/test/integration/state/sqlite/friday-migration-chain.test.ts
+++ b/test/integration/state/sqlite/friday-migration-chain.test.ts
@@ -1,4 +1,9 @@
 import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import Database from "better-sqlite3";
 import { runFridayMigrations, FRIDAY_SQLITE_MIGRATIONS } from "#state";
 
@@ -49,6 +54,82 @@ describe("Friday Migration Chain (V001–V024)", () => {
     expect(second.skippedVersions).toHaveLength(FRIDAY_SQLITE_MIGRATIONS.length);
     const expectedVersions = FRIDAY_SQLITE_MIGRATIONS.map((m) => m.version);
     expect(second.skippedVersions).toEqual(expectedVersions);
+  });
+
+  it("serializes concurrent migration runners against the same sqlite file", async () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-migration-race-"));
+    const dbPath = join(root, "race.db");
+    const workerPath = fileURLToPath(
+      new URL("./helpers/run-friday-migrations-worker.mjs", import.meta.url),
+    );
+
+    async function runWorker(): Promise<{
+      code: number | null;
+      stdout: string;
+      stderr: string;
+    }> {
+      return await new Promise((resolve, reject) => {
+        const child = spawn(process.execPath, [workerPath, dbPath, "350"], {
+          cwd: process.cwd(),
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+        let stdout = "";
+        let stderr = "";
+        child.stdout.setEncoding("utf8");
+        child.stderr.setEncoding("utf8");
+        child.stdout.on("data", (chunk) => {
+          stdout += chunk;
+        });
+        child.stderr.on("data", (chunk) => {
+          stderr += chunk;
+        });
+        child.on("error", reject);
+        child.on("close", (code) => {
+          resolve({ code, stdout, stderr });
+        });
+      });
+    }
+
+    try {
+      const [first, second] = await Promise.all([runWorker(), runWorker()]);
+
+      expect(first.code).toBe(0);
+      expect(second.code).toBe(0);
+
+      const firstResult = JSON.parse(first.stdout.trim()) as {
+        ok: boolean;
+        result: { applied: Array<{ version: number }>; skippedVersions: number[] };
+      };
+      const secondResult = JSON.parse(second.stdout.trim()) as {
+        ok: boolean;
+        result: { applied: Array<{ version: number }>; skippedVersions: number[] };
+      };
+
+      expect(firstResult.ok).toBe(true);
+      expect(secondResult.ok).toBe(true);
+
+      const appliedCounts = [firstResult, secondResult]
+        .map((item) => item.result.applied.length)
+        .sort((a, b) => a - b);
+      const skippedCounts = [firstResult, secondResult]
+        .map((item) => item.result.skippedVersions.length)
+        .sort((a, b) => a - b);
+
+      expect(appliedCounts).toEqual([0, 1]);
+      expect(skippedCounts).toEqual([0, 1]);
+
+      const verifyDb = new Database(dbPath);
+      const rows = verifyDb
+        .prepare("SELECT version, checksum FROM schema_migrations ORDER BY version")
+        .all() as Array<{ version: number; checksum: string }>;
+      verifyDb.close();
+
+      expect(rows).toEqual([
+        { version: 1, checksum: "concurrency-probe-v1" },
+      ]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   // ─── Expected tables from V001 ───

--- a/test/integration/state/sqlite/friday-migration-chain.test.ts
+++ b/test/integration/state/sqlite/friday-migration-chain.test.ts
@@ -6,6 +6,7 @@ import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import Database from "better-sqlite3";
 import { runFridayMigrations, FRIDAY_SQLITE_MIGRATIONS } from "#state";
+import { ensureFridayApiBuildForNodeWorkers } from "../../../helpers/friday-ensure-api-build.helper.js";
 
 describe("Friday Migration Chain (V001–V024)", () => {
   const dbs: Database.Database[] = [];
@@ -57,6 +58,8 @@ describe("Friday Migration Chain (V001–V024)", () => {
   });
 
   it("serializes concurrent migration runners against the same sqlite file", async () => {
+    await ensureFridayApiBuildForNodeWorkers();
+
     const root = mkdtempSync(join(tmpdir(), "friday-migration-race-"));
     const dbPath = join(root, "race.db");
     const workerPath = fileURLToPath(

--- a/test/integration/state/sqlite/helpers/run-friday-migrations-worker.mjs
+++ b/test/integration/state/sqlite/helpers/run-friday-migrations-worker.mjs
@@ -10,7 +10,7 @@ if (!dbPath) {
 
 const holdMs = Number(holdMsArg ?? "0");
 const db = new Database(dbPath);
-db.pragma("busy_timeout = 5000");
+db.pragma("busy_timeout = 30000");
 
 const migrations = [
   {

--- a/test/integration/state/sqlite/helpers/run-friday-migrations-worker.mjs
+++ b/test/integration/state/sqlite/helpers/run-friday-migrations-worker.mjs
@@ -1,0 +1,38 @@
+import Database from "better-sqlite3";
+
+import { runFridayMigrations } from "#state";
+
+const [dbPath, holdMsArg] = process.argv.slice(2);
+if (!dbPath) {
+  console.error("dbPath is required");
+  process.exit(1);
+}
+
+const holdMs = Number(holdMsArg ?? "0");
+const db = new Database(dbPath);
+db.pragma("busy_timeout = 5000");
+
+const migrations = [
+  {
+    version: 1,
+    name: "v001_concurrency_probe",
+    checksum: "concurrency-probe-v1",
+    apply(writer) {
+      const end = Date.now() + holdMs;
+      while (Date.now() < end) {
+        // Keep the migration transaction busy long enough for the second process to contend.
+      }
+      writer.exec("CREATE TABLE IF NOT EXISTS concurrency_probe (id TEXT PRIMARY KEY)");
+    },
+  },
+];
+
+try {
+  const result = runFridayMigrations({ db, migrations });
+  console.log(JSON.stringify({ ok: true, result }));
+} catch (error) {
+  console.error(error instanceof Error ? error.stack ?? error.message : String(error));
+  process.exitCode = 1;
+} finally {
+  db.close();
+}

--- a/test/unit/agent/runtime/friday-agent-llm-client-cli.test.ts
+++ b/test/unit/agent/runtime/friday-agent-llm-client-cli.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const { runFridayCliBackendTextCompletionMock } = vi.hoisted(() => ({
+  runFridayCliBackendTextCompletionMock: vi.fn(),
+}));
+
+vi.mock("#providers", async () => {
+  const actual = await vi.importActual<typeof import("#providers")>("#providers");
+  return {
+    ...actual,
+    runFridayCliBackendTextCompletion: runFridayCliBackendTextCompletionMock,
+  };
+});
+
+import { createFridayAgentLlmClient } from "#agent";
+
+describe("FridayAgentLlmClient CLI backend", () => {
+  beforeEach(() => {
+    runFridayCliBackendTextCompletionMock.mockReset();
+  });
+
+  it("treats CLI backends as text-only and does not hard-fail when tools are present", async () => {
+    runFridayCliBackendTextCompletionMock.mockResolvedValue("CLI_OK");
+
+    const client = createFridayAgentLlmClient({
+      backendKind: "cli",
+      cliConfig: { backendId: "codex-cli" },
+    });
+
+    const events = [];
+    for await (const event of client.stream({
+      model: "gpt-5.4",
+      systemPrompt: "You are Friday.",
+      messages: [{ role: "user", content: "Say hi" }],
+      tools: [{
+        name: "read",
+        description: "Read a file",
+        parameters: { properties: { path: { type: "string" } } },
+        async execute() { return { content: "" }; },
+      }],
+      signal: new AbortController().signal,
+    })) {
+      events.push(event);
+    }
+
+    expect(runFridayCliBackendTextCompletionMock).toHaveBeenCalledOnce();
+    expect(runFridayCliBackendTextCompletionMock.mock.calls[0]?.[0]).toMatchObject({
+      model: "gpt-5.4",
+      conversation: "USER: Say hi",
+    });
+    expect(runFridayCliBackendTextCompletionMock.mock.calls[0]?.[0]?.systemPrompt).toContain(
+      "Friday tools are unavailable in this backend.",
+    );
+    expect(events).toEqual([
+      { type: "text_delta", text: "CLI_OK" },
+      {
+        type: "message_end",
+        stopReason: "end_turn",
+        inputTokens: 0,
+        outputTokens: 0,
+      },
+    ]);
+  });
+});

--- a/test/unit/e2e/run-friday-closure.test.ts
+++ b/test/unit/e2e/run-friday-closure.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+
+import {
+  closeWritableStream,
+  stopManagedChildProcess,
+} from "../../../scripts/e2e/run-friday-closure.mjs";
+
+describe("run-friday-closure helpers", () => {
+  it("closeWritableStream flushes and closes a write stream", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "friday-closure-stream-"));
+    const filePath = join(dir, "stream.log");
+    const stream = fs.createWriteStream(filePath, { flags: "w" });
+    stream.write("hello");
+    stream.write(" world");
+
+    await closeWritableStream(stream, 2_000);
+
+    expect(readFileSync(filePath, "utf8")).toBe("hello world");
+    expect(stream.writableEnded || stream.closed || stream.destroyed).toBe(true);
+
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("stopManagedChildProcess escalates to SIGKILL when a child ignores SIGTERM", async () => {
+    const child = spawn(process.execPath, [
+      "-e",
+      "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);",
+    ], {
+      stdio: "ignore",
+    });
+
+    await stopManagedChildProcess(child, { graceMs: 150, forceKillMs: 150 });
+
+    expect(child.exitCode !== null || child.signalCode !== null).toBe(true);
+  });
+});

--- a/test/unit/state/sqlite/friday-migration-runner.test.ts
+++ b/test/unit/state/sqlite/friday-migration-runner.test.ts
@@ -126,7 +126,7 @@ describe("friday-migration-runner", () => {
     expect(result.skippedVersions).toEqual([31, 32]);
   });
 
-  it("failed migration rolls back that migration transaction", () => {
+  it("failed migration rolls back the entire pending migration batch", () => {
     const badMigration: FridaySqliteMigration = {
       version: 2,
       name: "bad-migration",
@@ -140,11 +140,11 @@ describe("friday-migration-runner", () => {
       runFridayMigrations({ db, migrations: [V001_INITIAL_MIGRATION, badMigration] }),
     ).toThrow();
 
-    // First migration (V001) should have been applied (separate transaction)
+    // The full pending migration batch is atomic under one IMMEDIATE transaction.
     const tables = db
       .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='users'")
       .all();
-    expect(tables).toHaveLength(1);
+    expect(tables).toHaveLength(0);
 
     // Bad migration's table should not exist (rolled back)
     const badTables = db

--- a/test/unit/state/sqlite/friday-sqlite-layer.test.ts
+++ b/test/unit/state/sqlite/friday-sqlite-layer.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { createFridaySqliteLayer } from "#state";
 import type { FridaySqliteLayer } from "#state";
 
@@ -92,5 +94,44 @@ describe("friday-sqlite-layer", () => {
     });
 
     expect(() => layer.checkpoint("FULL")).not.toThrow();
+  });
+
+  it("allows two processes to initialize the same sqlite file concurrently", async () => {
+    const dbPath = path.join(tmpDir, "concurrent.db");
+    const workerPath = fileURLToPath(
+      new URL("./helpers/create-sqlite-layer-worker.mjs", import.meta.url),
+    );
+
+    async function runWorker(): Promise<{
+      code: number | null;
+      stdout: string;
+      stderr: string;
+    }> {
+      return await new Promise((resolve, reject) => {
+        const child = spawn(process.execPath, [workerPath, dbPath], {
+          cwd: process.cwd(),
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+        let stdout = "";
+        let stderr = "";
+        child.stdout.setEncoding("utf8");
+        child.stderr.setEncoding("utf8");
+        child.stdout.on("data", (chunk) => {
+          stdout += chunk;
+        });
+        child.stderr.on("data", (chunk) => {
+          stderr += chunk;
+        });
+        child.on("error", reject);
+        child.on("close", (code) => resolve({ code, stdout, stderr }));
+      });
+    }
+
+    const [first, second] = await Promise.all([runWorker(), runWorker()]);
+
+    expect(first.code).toBe(0);
+    expect(second.code).toBe(0);
+    expect(JSON.parse(first.stdout.trim())).toMatchObject({ ok: true, dbPath });
+    expect(JSON.parse(second.stdout.trim())).toMatchObject({ ok: true, dbPath });
   });
 });

--- a/test/unit/state/sqlite/friday-sqlite-layer.test.ts
+++ b/test/unit/state/sqlite/friday-sqlite-layer.test.ts
@@ -129,9 +129,20 @@ describe("friday-sqlite-layer", () => {
 
     const [first, second] = await Promise.all([runWorker(), runWorker()]);
 
-    expect(first.code).toBe(0);
-    expect(second.code).toBe(0);
+    expect(first.code, first.stderr || first.stdout).toBe(0);
+    expect(second.code, second.stderr || second.stdout).toBe(0);
     expect(JSON.parse(first.stdout.trim())).toMatchObject({ ok: true, dbPath });
     expect(JSON.parse(second.stdout.trim())).toMatchObject({ ok: true, dbPath });
+  });
+
+  it("restores the configured busy timeout after startup serialization", () => {
+    layer = createFridaySqliteLayer({
+      dbPath: path.join(tmpDir, "startup-timeout-reset.db"),
+      readPoolSize: 1,
+      pragmas: { busyTimeoutMs: 5000, synchronous: "NORMAL" },
+    });
+
+    const timeout = layer.writer.pragma("busy_timeout", { simple: true }) as number;
+    expect(timeout).toBe(5000);
   });
 });

--- a/test/unit/state/sqlite/friday-sqlite-layer.test.ts
+++ b/test/unit/state/sqlite/friday-sqlite-layer.test.ts
@@ -97,7 +97,10 @@ describe("friday-sqlite-layer", () => {
     expect(() => layer.checkpoint("FULL")).not.toThrow();
   });
 
-  it("allows two processes to initialize the same sqlite file concurrently", async () => {
+  it(
+    "allows two processes to initialize the same sqlite file concurrently",
+    { timeout: 60_000 },
+    async () => {
     await ensureFridayApiBuildForNodeWorkers();
 
     const dbPath = path.join(tmpDir, "concurrent.db");
@@ -136,7 +139,8 @@ describe("friday-sqlite-layer", () => {
     expect(second.code, second.stderr || second.stdout).toBe(0);
     expect(JSON.parse(first.stdout.trim())).toMatchObject({ ok: true, dbPath });
     expect(JSON.parse(second.stdout.trim())).toMatchObject({ ok: true, dbPath });
-  });
+    },
+  );
 
   it("restores the configured busy timeout after startup serialization", () => {
     layer = createFridaySqliteLayer({

--- a/test/unit/state/sqlite/friday-sqlite-layer.test.ts
+++ b/test/unit/state/sqlite/friday-sqlite-layer.test.ts
@@ -6,6 +6,7 @@ import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { createFridaySqliteLayer } from "#state";
 import type { FridaySqliteLayer } from "#state";
+import { ensureFridayApiBuildForNodeWorkers } from "../../../helpers/friday-ensure-api-build.helper.js";
 
 describe("friday-sqlite-layer", () => {
   let tmpDir: string;
@@ -97,6 +98,8 @@ describe("friday-sqlite-layer", () => {
   });
 
   it("allows two processes to initialize the same sqlite file concurrently", async () => {
+    await ensureFridayApiBuildForNodeWorkers();
+
     const dbPath = path.join(tmpDir, "concurrent.db");
     const workerPath = fileURLToPath(
       new URL("./helpers/create-sqlite-layer-worker.mjs", import.meta.url),

--- a/test/unit/state/sqlite/helpers/create-sqlite-layer-worker.mjs
+++ b/test/unit/state/sqlite/helpers/create-sqlite-layer-worker.mjs
@@ -1,0 +1,22 @@
+import { createFridaySqliteLayer } from "#state";
+
+const [dbPath] = process.argv.slice(2);
+if (!dbPath) {
+  console.error("dbPath is required");
+  process.exit(1);
+}
+
+let layer;
+try {
+  layer = createFridaySqliteLayer({
+    dbPath,
+    readPoolSize: 1,
+    pragmas: { busyTimeoutMs: 5000, synchronous: "NORMAL" },
+  });
+  console.log(JSON.stringify({ ok: true, dbPath: layer.dbPath }));
+} catch (error) {
+  console.error(error instanceof Error ? error.stack ?? error.message : String(error));
+  process.exitCode = 1;
+} finally {
+  layer?.close();
+}


### PR DESCRIPTION
## Summary
- serialize SQLite migrations so concurrent `attach-cli` startup no longer races on `schema_migrations`
- harden SQLite startup pragmas for concurrent initialization
- fix `test:e2e:closure:local` finalization so the harness exits and always writes `completedAt`
- treat CLI backends as explicit text-only backends in the agent path instead of hard-failing when tools are exposed
- add an architecture/runtime audit report with confirmed blockers, non-blockers, and release guidance

## Why
Two real engineering gaps were still blocking a clean release path after the CLI backend work:
1. concurrent `attach-cli` runs could hit a real SQLite migration race
2. the closure harness could reach `GO` but hang before final ledger finalization

The audit also surfaced a deeper truth-boundary issue for CLI backends: Friday was still exposing tool-enabled agent runs to backends that only support text inference. This PR fixes that by making the boundary explicit and honest.

## Impact
- `attach-cli` is safer under concurrent startup
- closure artifacts are now reliable enough to use as a release gate
- Codex CLI / Claude CLI can be used through Friday's agent path for text inference without pretending they have Friday-native tool access
- release guidance is clearer and based on real evidence, not paper capability drift

## Validation
- `npm run build`
- `npx vitest run test/unit/state/sqlite/friday-migration-runner.test.ts test/unit/state/sqlite/friday-sqlite-layer.test.ts test/integration/state/sqlite/friday-migration-chain.test.ts test/unit/e2e/run-friday-closure.test.ts`
- `npx vitest run test/unit/agent/runtime/friday-agent-llm-client.test.ts test/unit/agent/runtime/friday-agent-llm-client-cli.test.ts`
- `npm run check:adversarial`
- `npm run test:adversarial`
- `npm run test:e2e:closure:local` (`overall = GO`)
- real Friday-path Codex CLI / Claude CLI probes
- real provider doctor/auth status probe

## Audit report
- `docs/reports/repo/CLI_BACKEND_AND_RUNTIME_AUDIT_2026-04-01.md`

## Release note
This PR intentionally does **not** claim full tool-capable CLI backend support. The confirmed production-safe boundary is: Codex CLI / Claude CLI are usable as text backends through Friday, while tool-backed workflows should stay on HTTP backends.