### PR TITLE
Add routing explainability operator UI

### DIFF
--- a/ui/src/lib/api/learning.ts
+++ b/ui/src/lib/api/learning.ts
@@ -1,0 +1,41 @@
+import { apiClient } from "./client";
+import type { FridayLearningOverview } from "./types";
+
+interface GetLearningOverviewResponse extends FridayLearningOverview {}
+
+export const learningApi = {
+  async getOverview(limit = 20): Promise<FridayLearningOverview> {
+    const params = new URLSearchParams({ limit: String(limit) });
+    return apiClient.get<GetLearningOverviewResponse>(
+      `/v1/diagnosis/learning/overview?${params.toString()}`,
+    );
+  },
+
+  async setLessonEnabled(input: {
+    lessonId: string;
+    enabled: boolean;
+    reason?: string;
+  }): Promise<void> {
+    await apiClient.post<{ enabled: boolean; reason?: string }, { lesson: unknown }>(
+      `/v1/diagnosis/learning/lessons/${encodeURIComponent(input.lessonId)}/enabled`,
+      {
+        enabled: input.enabled,
+        ...(input.reason ? { reason: input.reason } : {}),
+      },
+    );
+  },
+
+  async demotePattern(input: {
+    patternId: string;
+    factor: number;
+    reason?: string;
+  }): Promise<void> {
+    await apiClient.post<{ factor: number; reason?: string }, { pattern: unknown }>(
+      `/v1/diagnosis/learning/patterns/${encodeURIComponent(input.patternId)}/demote`,
+      {
+        factor: input.factor,
+        ...(input.reason ? { reason: input.reason } : {}),
+      },
+    );
+  },
+};

--- a/ui/src/lib/api/providers.ts
+++ b/ui/src/lib/api/providers.ts
@@ -11,6 +11,7 @@ import type {
   FridayProviderBackendKind,
   FridayProviderCliConfig,
   FridayProviderDoctorReport,
+  FridayProviderRoutingExplainReport,
 } from "./types";
 
 // ─── Request types ───
@@ -104,6 +105,10 @@ interface GetProviderDoctorResponse {
   doctor: FridayProviderDoctorReport;
 }
 
+interface GetProviderRoutingExplainResponse {
+  explain: FridayProviderRoutingExplainReport;
+}
+
 interface ListProviderAuthProfilesResponse {
   items: Array<{
     id: string;
@@ -122,6 +127,30 @@ interface ListProviderAuthProfilesResponse {
 
 interface ActivateProviderAuthProfileResponse {
   profile: ListProviderAuthProfilesResponse["items"][number];
+}
+
+export interface ExplainRoutingInput {
+  requestedProviderId?: string;
+  requestedModel?: string;
+  taskProfileId?: string;
+  estimatedInputTokens?: number;
+  complexity?: "simple" | "medium" | "complex";
+  requiresNativeTools?: boolean;
+}
+
+interface PinRouteInput {
+  taskProfileId?: string;
+  providerId: string;
+  model: string;
+  backendKind: FridayProviderBackendKind;
+  reason?: string;
+}
+
+interface ClearRoutePenaltyInput {
+  taskProfileId?: string;
+  providerId: string;
+  model: string;
+  backendKind: FridayProviderBackendKind;
 }
 
 // ─── API ───
@@ -175,6 +204,33 @@ export const providersApi = {
       `/v1/providers/${encodeURIComponent(providerId)}/doctor`,
     );
     return data.doctor;
+  },
+
+  async explainRouting(input: ExplainRoutingInput): Promise<FridayProviderRoutingExplainReport> {
+    const params = new URLSearchParams();
+    if (input.requestedProviderId) params.set("requestedProviderId", input.requestedProviderId);
+    if (input.requestedModel) params.set("requestedModel", input.requestedModel);
+    if (input.taskProfileId) params.set("taskProfileId", input.taskProfileId);
+    if (typeof input.estimatedInputTokens === "number") params.set("estimatedInputTokens", String(input.estimatedInputTokens));
+    if (input.complexity) params.set("complexity", input.complexity);
+    if (typeof input.requiresNativeTools === "boolean") params.set("requiresNativeTools", String(input.requiresNativeTools));
+    const qs = params.toString();
+    const data = await apiClient.get<GetProviderRoutingExplainResponse>(
+      `/v1/providers/routing/explain${qs ? `?${qs}` : ""}`,
+    );
+    return data.explain;
+  },
+
+  async pinRoute(input: PinRouteInput): Promise<void> {
+    await apiClient.post<PinRouteInput, { pinned: true }>("/v1/providers/routing/pin", input);
+  },
+
+  async clearRoutePenalty(input: ClearRoutePenaltyInput): Promise<boolean> {
+    const data = await apiClient.post<ClearRoutePenaltyInput, { cleared: boolean }>(
+      "/v1/providers/routing/penalties/clear",
+      input,
+    );
+    return data.cleared;
   },
 
   async listAuthProfiles(providerId: string): Promise<ListProviderAuthProfilesResponse["items"]> {

--- a/ui/src/lib/api/types.ts
+++ b/ui/src/lib/api/types.ts
@@ -1773,6 +1773,175 @@ export interface FridayProviderDoctorReport {
   cliSession?: FridayCliSessionStatus;
 }
 
+export interface FridayProviderRoutingSelection {
+  providerId: string;
+  providerKind: FridayProviderKind;
+  model: string;
+  backendKind: FridayProviderBackendKind;
+}
+
+export interface FridayProviderRoutingExplainCandidate {
+  providerId: string;
+  providerKind: FridayProviderKind;
+  model: string;
+  backendKind: FridayProviderBackendKind;
+  originalRank: number;
+  finalRank: number;
+  selected: boolean;
+  eligible: boolean;
+  ineligibilityReasons: string[];
+  pinned: boolean;
+  routePenalty?: number;
+  historicalSuccessRate?: number;
+  historicalFailureRate?: number;
+  sampleCount?: number;
+  baseRankScore: number;
+  historyScore: number;
+  patternScore: number;
+  lessonScore: number;
+  routePenaltyScore: number;
+  pinBonus: number;
+  finalScore: number;
+  matchedLessonIds: string[];
+  matchedPatternIds: string[];
+}
+
+export interface FridayProviderRoutingExplainReport {
+  requestedProviderId?: string;
+  requestedModel?: string;
+  taskProfileId?: string;
+  requiresNativeTools: boolean;
+  selectedBeforeLearning?: FridayProviderRoutingSelection;
+  selectedAfterLearning?: FridayProviderRoutingSelection;
+  selected?: FridayProviderRoutingExplainCandidate;
+  candidates: FridayProviderRoutingExplainCandidate[];
+  candidateScores: FridayProviderRoutingExplainCandidate[];
+  learningAdjusted: boolean;
+  learningSignalsPresent: boolean;
+  orderingAdjusted: boolean;
+  selectedAdjusted: boolean;
+  reasonCode: string;
+  reason: string;
+  historyWindow: {
+    sampleLimit: number;
+  };
+}
+
+export interface FridayLearningLessonRecord {
+  lesson: {
+    id: string;
+    title: string;
+    cause: string;
+    fix: string;
+    confidence: number;
+    createdAt: string;
+    updatedAt: string;
+  };
+  disabled: boolean;
+  disabledReason?: string;
+}
+
+export interface FridayLearningPatternRecord {
+  patternId: string;
+  userId: string;
+  kind: string;
+  description: string;
+  pattern: Record<string, unknown>;
+  confidence: number;
+  sampleCount: number;
+  lastUpdated: string;
+  createdAt: string;
+  demoted: boolean;
+  demotionFactor?: number;
+  demotionReason?: string;
+}
+
+export interface FridayLearningRouteAdjustmentRecord {
+  kind: "pin" | "penalty";
+  key: string;
+  taskProfileId?: string;
+  providerId?: string;
+  model?: string;
+  backendKind?: FridayProviderBackendKind;
+  confidence: number;
+  value: Record<string, unknown>;
+}
+
+export interface FridayRouteDecisionDiffRecord {
+  runId: string;
+  createdAt: string;
+  taskProfileId?: string;
+  requestedProviderId?: string;
+  requestedModel?: string;
+  actualProviderId?: string;
+  actualModel?: string;
+  reasonCode?: string;
+  learningAdjusted: boolean;
+  learningSignalsPresent: boolean;
+  selectedBeforeLearning?: FridayProviderRoutingSelection;
+  selectedAfterLearning?: FridayProviderRoutingSelection;
+  matchedLessonIds: string[];
+  matchedPatternIds: string[];
+  trace: {
+    candidateScores: FridayProviderRoutingExplainCandidate[];
+  };
+}
+
+export interface FridayBlockedRouteRecord {
+  taskProfileId?: string;
+  providerId: string;
+  model: string;
+  backendKind: FridayProviderBackendKind;
+  reasons: string[];
+  count: number;
+  lastSeenAt: string;
+}
+
+export interface FridayRejectedFixRecord {
+  actionId: string;
+  incidentId: string;
+  title: string;
+  fingerprint: string;
+  reason?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface FridayRollbackHotspotRecord {
+  fingerprint: string;
+  rolledBackCount: number;
+  appliedCount: number;
+  rejectedCount: number;
+  totalCount: number;
+  lastSeenAt: string;
+}
+
+export interface FridayLearningOverview {
+  lessons: FridayLearningLessonRecord[];
+  patterns: FridayLearningPatternRecord[];
+  routeAdjustments: FridayLearningRouteAdjustmentRecord[];
+  routeBiases: FridayLearningRouteAdjustmentRecord[];
+  operatorPins: FridayLearningRouteAdjustmentRecord[];
+  penaltyFacts: FridayLearningRouteAdjustmentRecord[];
+  recentDecisionDiffs: FridayRouteDecisionDiffRecord[];
+  blockedRoutes: FridayBlockedRouteRecord[];
+  rejectedFixes: FridayRejectedFixRecord[];
+  recentRejectedFixes: FridayRejectedFixRecord[];
+  rollbackHotspots: FridayRollbackHotspotRecord[];
+  coverage: {
+    lessons: number;
+    patterns: number;
+    routeAdjustments: number;
+    recentDecisionDiffs: number;
+    blockedRoutes: number;
+    rejectedFixes: number;
+    rollbackHotspots: number;
+    incidents: number;
+    diagnoses: number;
+    autoFixActions: number;
+  };
+}
+
 // ─── Provider usage types ───
 
 export interface FridayProviderUsageSummaryRow {

--- a/ui/src/routes/assistant-page.tsx
+++ b/ui/src/routes/assistant-page.tsx
@@ -21,6 +21,7 @@ import { useAgentRunEvents } from "@/hooks/use-agent-run-events";
 import { agentApi } from "@/lib/api/agent";
 import { assistantDiagnosticsApi } from "@/lib/api/assistant-diagnostics";
 import { fleetApi } from "@/lib/api/fleet";
+import { learningApi } from "@/lib/api/learning";
 import {
   marketplaceApi,
   type FridayCreatorProfile,
@@ -514,6 +515,12 @@ export function AssistantPage() {
     queryKey: ["assistant-shell", "auto-fix-metrics"],
     queryFn: () => systemApi.getAutoFixMetrics(),
     refetchInterval: 30_000,
+  });
+
+  const learningOverviewQuery = useQuery({
+    queryKey: ["assistant-shell", "learning-overview"],
+    queryFn: () => learningApi.getOverview(6),
+    refetchInterval: 20_000,
   });
 
   const loopPolicyQuery = useQuery({
@@ -1118,6 +1125,51 @@ export function AssistantPage() {
               expertModeEnabled={expertModeQuery.data?.enabled ?? false}
             />
 
+            <ShellCard eyebrow="Operator learning" title="Why Friday changed routes, and what it learned from prior runs">
+              {learningOverviewQuery.data ? (
+                <div className="space-y-4">
+                  <div className="grid gap-3 md:grid-cols-4">
+                    <AssistantMetric label="Lessons" value={String(learningOverviewQuery.data.coverage.lessons)} />
+                    <AssistantMetric label="Patterns" value={String(learningOverviewQuery.data.coverage.patterns)} />
+                    <AssistantMetric label="Route shifts" value={String(learningOverviewQuery.data.coverage.recentDecisionDiffs)} />
+                    <AssistantMetric label="Blocked routes" value={String(learningOverviewQuery.data.coverage.blockedRoutes)} />
+                  </div>
+                  {learningOverviewQuery.data.recentDecisionDiffs[0] ? (
+                    <div className="agent-subcard p-4">
+                      <div className="flex items-center justify-between gap-3">
+                        <div>
+                          <p className="font-medium text-white">Latest route decision diff</p>
+                          <p className="text-xs text-white/50">
+                            {learningOverviewQuery.data.recentDecisionDiffs[0].reasonCode ?? "configured"} · {formatTimestamp(learningOverviewQuery.data.recentDecisionDiffs[0].createdAt)}
+                          </p>
+                        </div>
+                        <StatusPill tone={learningOverviewQuery.data.recentDecisionDiffs[0].learningAdjusted ? "success" : "warning"}>
+                          {learningOverviewQuery.data.recentDecisionDiffs[0].learningAdjusted ? "selection changed" : "signals only"}
+                        </StatusPill>
+                      </div>
+                      <p className="mt-3 text-sm text-white/70">
+                        Before: {learningOverviewQuery.data.recentDecisionDiffs[0].selectedBeforeLearning
+                          ? `${learningOverviewQuery.data.recentDecisionDiffs[0].selectedBeforeLearning.providerId} / ${learningOverviewQuery.data.recentDecisionDiffs[0].selectedBeforeLearning.model}`
+                          : "n/a"}
+                      </p>
+                      <p className="mt-1 text-sm text-white/70">
+                        After: {learningOverviewQuery.data.recentDecisionDiffs[0].selectedAfterLearning
+                          ? `${learningOverviewQuery.data.recentDecisionDiffs[0].selectedAfterLearning.providerId} / ${learningOverviewQuery.data.recentDecisionDiffs[0].selectedAfterLearning.model}`
+                          : "n/a"}
+                      </p>
+                      <p className="mt-3 text-xs text-white/50">
+                        Matched lessons {learningOverviewQuery.data.recentDecisionDiffs[0].matchedLessonIds.length} · matched patterns {learningOverviewQuery.data.recentDecisionDiffs[0].matchedPatternIds.length}
+                      </p>
+                    </div>
+                  ) : (
+                    <p className="text-sm text-white/60">No recent route shifts yet.</p>
+                  )}
+                </div>
+              ) : (
+                <p className="text-sm text-white/60">Learning overview is loading...</p>
+              )}
+            </ShellCard>
+
             <OutcomeReceiptCard
               receipt={latestOutcomeReceipt}
               savePending={saveAutomationMutation.isPending}
@@ -1679,6 +1731,15 @@ function GoalIntakeCard(props: {
         ) : null}
       </div>
     </ShellCard>
+  );
+}
+
+function AssistantMetric(props: { label: string; value: string }) {
+  return (
+    <div className="rounded-[22px] border border-white/[0.08] bg-black/20 p-4">
+      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-white/40">{props.label}</p>
+      <p className="mt-3 text-lg font-semibold text-white">{props.value}</p>
+    </div>
   );
 }
 

--- a/ui/src/routes/observability-page.tsx
+++ b/ui/src/routes/observability-page.tsx
@@ -25,6 +25,7 @@ import {
 import { toast } from "sonner";
 import { ActionButton, ShellCard, StatusPill } from "@/components/core/primitives";
 import { assistantDiagnosticsApi } from "@/lib/api/assistant-diagnostics";
+import { learningApi } from "@/lib/api/learning";
 import { systemApi } from "@/lib/api/system";
 import {
   buildObservabilityActionQueue,
@@ -288,6 +289,12 @@ export function ObservabilityPage() {
     refetchInterval: 10_000,
   });
 
+  const learningOverviewQuery = useQuery({
+    queryKey: ["observability", "learning-overview"],
+    queryFn: () => learningApi.getOverview(12),
+    refetchInterval: 20_000,
+  });
+
   const acknowledgeAlertMutation = useMutation({
     mutationFn: (input: { alertId: string; note?: string }) =>
       systemApi.acknowledgeObservabilityAlert(input.alertId, input.note),
@@ -420,6 +427,7 @@ export function ObservabilityPage() {
   const retryCostSummary = retryCostSummaryQuery.data;
   const rulesAuditLog = rulesAuditLogQuery.data ?? [];
   const assistantDiagnostics = assistantDiagnosticsQuery.data;
+  const learningOverview = learningOverviewQuery.data;
   const latestAssistantRun = assistantDiagnostics?.recentRuns[0] ?? null;
   const assistantMcpStateCounts = (assistantDiagnostics?.mcpServerStates ?? []).reduce(
     (summary, state) => {
@@ -716,6 +724,49 @@ export function ObservabilityPage() {
       </div>
 
       <div className="grid gap-4 xl:grid-cols-[1fr_1fr]">
+        <ShellCard eyebrow="Learning explainability" title="Lessons, route shifts, and blocked candidates">
+          {learningOverview ? (
+            <div className="space-y-4">
+              <div className="grid gap-3 sm:grid-cols-2">
+                <ObservabilityTile
+                  icon={<CheckCircle2 className="h-4 w-4" />}
+                  label="Lessons"
+                  value={String(learningOverview.coverage.lessons)}
+                  detail={`${learningOverview.coverage.routeAdjustments} route adjustments available to operator controls`}
+                />
+                <ObservabilityTile
+                  icon={<RotateCcw className="h-4 w-4" />}
+                  label="Recent route shifts"
+                  value={String(learningOverview.coverage.recentDecisionDiffs)}
+                  detail={`${learningOverview.coverage.blockedRoutes} blocked routes observed in recent decision traces`}
+                />
+              </div>
+              {learningOverview.recentDecisionDiffs.slice(0, 2).map((record) => (
+                <div key={record.runId} className="agent-subcard p-4">
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <p className="font-medium text-white">{record.reasonCode ?? "configured"}</p>
+                      <p className="text-xs text-white/50">{formatTimestamp(record.createdAt)}</p>
+                    </div>
+                    <StatusPill tone={record.learningAdjusted ? "success" : "warning"}>
+                      {record.learningAdjusted ? "selection changed" : "signals present"}
+                    </StatusPill>
+                  </div>
+                  <p className="mt-3 text-sm text-white/70">
+                    {record.selectedBeforeLearning
+                      ? `${record.selectedBeforeLearning.providerId} / ${record.selectedBeforeLearning.model}`
+                      : "n/a"} → {record.selectedAfterLearning
+                      ? `${record.selectedAfterLearning.providerId} / ${record.selectedAfterLearning.model}`
+                      : "n/a"}
+                  </p>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm text-white/60">Learning overview is loading...</p>
+          )}
+        </ShellCard>
+
         {focus === "overview" || focus === "assistant" ? (
           <ShellCard eyebrow="Assistant diagnostics" title="Context governance, MCP loading, and task profiles">
             {assistantDiagnostics ? (

--- a/ui/src/routes/settings-page.tsx
+++ b/ui/src/routes/settings-page.tsx
@@ -10,6 +10,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { AlertTriangle, Brain, Cpu, DollarSign, KeyRound, MessageCircleMore, Shield, Sliders, Wifi, Wrench } from "lucide-react";
 import { toast } from "sonner";
 import { healthApi } from "@/lib/api/health";
+import { learningApi } from "@/lib/api/learning";
 import { providerUsageApi } from "@/lib/api/provider-usage";
 import { providersApi } from "@/lib/api/providers";
 import { securityApi } from "@/lib/api/security";
@@ -128,6 +129,100 @@ export function SettingsPage() {
     retry: 0,
   });
 
+  const { data: routingConfig } = useQuery({
+    queryKey: ["settings", "routing-config"],
+    queryFn: () => providersApi.getRouting(),
+    retry: 0,
+  });
+
+  const { data: learningOverview } = useQuery({
+    queryKey: ["settings", "learning-overview"],
+    queryFn: () => learningApi.getOverview(12),
+    retry: 0,
+  });
+
+  const selectedProviderId = routingConfig?.defaultProviderId ?? providers[0]?.id;
+  const { data: routingExplain } = useQuery({
+    queryKey: ["settings", "routing-explain", selectedProviderId],
+    enabled: Boolean(selectedProviderId),
+    queryFn: () => providersApi.explainRouting({
+      requestedProviderId: selectedProviderId,
+      taskProfileId: "review",
+      estimatedInputTokens: 1200,
+      complexity: "medium",
+      requiresNativeTools: true,
+    }),
+    retry: 0,
+  });
+
+  const pinRouteMutation = useMutation({
+    mutationFn: (input: { providerId: string; model: string; backendKind: "http" | "cli" | "sdk"; taskProfileId?: string }) =>
+      providersApi.pinRoute({
+        providerId: input.providerId,
+        model: input.model,
+        backendKind: input.backendKind,
+        taskProfileId: input.taskProfileId,
+        reason: "Pinned from settings operator console",
+      }),
+    onSuccess: async () => {
+      toast.success("Route pinned");
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["settings", "routing-explain"] }),
+        queryClient.invalidateQueries({ queryKey: ["settings", "learning-overview"] }),
+      ]);
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Could not pin route");
+    },
+  });
+
+  const clearPenaltyMutation = useMutation({
+    mutationFn: (input: { providerId: string; model: string; backendKind: "http" | "cli" | "sdk"; taskProfileId?: string }) =>
+      providersApi.clearRoutePenalty(input),
+    onSuccess: async () => {
+      toast.success("Route penalty cleared");
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["settings", "routing-explain"] }),
+        queryClient.invalidateQueries({ queryKey: ["settings", "learning-overview"] }),
+      ]);
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Could not clear route penalty");
+    },
+  });
+
+  const lessonToggleMutation = useMutation({
+    mutationFn: (input: { lessonId: string; enabled: boolean }) =>
+      learningApi.setLessonEnabled({
+        lessonId: input.lessonId,
+        enabled: input.enabled,
+        reason: "Updated from settings operator console",
+      }),
+    onSuccess: async () => {
+      toast.success("Lesson updated");
+      await queryClient.invalidateQueries({ queryKey: ["settings", "learning-overview"] });
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Could not update lesson");
+    },
+  });
+
+  const demotePatternMutation = useMutation({
+    mutationFn: (patternId: string) =>
+      learningApi.demotePattern({
+        patternId,
+        factor: 0.5,
+        reason: "Demoted from settings operator console",
+      }),
+    onSuccess: async () => {
+      toast.success("Pattern demoted");
+      await queryClient.invalidateQueries({ queryKey: ["settings", "learning-overview"] });
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Could not demote pattern");
+    },
+  });
+
   useEffect(() => {
     if (persona) {
       setDraft(buildPersonaDraft(persona));
@@ -241,6 +336,84 @@ export function SettingsPage() {
                 </div>
               ))}
             </div>
+          )}
+        </ShellCard>
+
+        <ShellCard eyebrow="Operator" title="Routing Explainability">
+          {routingExplain ? (
+            <div className="space-y-4">
+              <div className="rounded-[22px] border border-white/[0.08] bg-black/20 p-4">
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <p className="font-medium text-white">Current decision</p>
+                    <p className="text-xs text-white/50">{routingExplain.reasonCode} · history window {routingExplain.historyWindow.sampleLimit}</p>
+                  </div>
+                  <StatusPill tone={routingExplain.learningAdjusted ? "success" : routingExplain.learningSignalsPresent ? "warning" : "neutral"}>
+                    {routingExplain.learningAdjusted ? "adjusted" : routingExplain.learningSignalsPresent ? "signals present" : "configured"}
+                  </StatusPill>
+                </div>
+                <p className="mt-3 text-sm text-white/70">{routingExplain.reason}</p>
+                <div className="mt-3 grid gap-3 md:grid-cols-2">
+                  <DiagnosticRow
+                    label="Before learning"
+                    value={routingExplain.selectedBeforeLearning ? `${routingExplain.selectedBeforeLearning.providerId} / ${routingExplain.selectedBeforeLearning.model}` : "n/a"}
+                  />
+                  <DiagnosticRow
+                    label="After learning"
+                    value={routingExplain.selectedAfterLearning ? `${routingExplain.selectedAfterLearning.providerId} / ${routingExplain.selectedAfterLearning.model}` : "n/a"}
+                  />
+                </div>
+              </div>
+              <div className="space-y-3">
+                {routingExplain.candidateScores.slice(0, 4).map((candidate) => (
+                  <div key={`${candidate.providerId}:${candidate.model}:${candidate.backendKind}`} className="rounded-[22px] border border-white/[0.08] bg-black/20 p-4">
+                    <div className="flex items-center justify-between gap-3">
+                      <div>
+                        <p className="font-medium text-white">{candidate.providerId} / {candidate.model}</p>
+                        <p className="text-xs text-white/50">{candidate.backendKind} · rank {candidate.originalRank} → {candidate.finalRank}</p>
+                      </div>
+                      <StatusPill tone={candidate.selected ? "success" : candidate.eligible ? "neutral" : "warning"}>
+                        {candidate.selected ? "selected" : candidate.eligible ? "eligible" : "blocked"}
+                      </StatusPill>
+                    </div>
+                    <p className="mt-2 text-xs text-white/50">
+                      score {candidate.finalScore.toFixed(2)} = base {candidate.baseRankScore.toFixed(2)} + history {candidate.historyScore.toFixed(2)} + lesson {candidate.lessonScore.toFixed(2)} + pattern {candidate.patternScore.toFixed(2)} + pin {candidate.pinBonus.toFixed(2)} + penalty {candidate.routePenaltyScore.toFixed(2)}
+                    </p>
+                    {candidate.ineligibilityReasons.length > 0 ? (
+                      <p className="mt-2 text-xs text-yellow-300">{candidate.ineligibilityReasons.join(", ")}</p>
+                    ) : null}
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      <ActionButton
+                        tone="secondary"
+                        disabled={pinRouteMutation.isPending}
+                        onClick={() => pinRouteMutation.mutate({
+                          providerId: candidate.providerId,
+                          model: candidate.model,
+                          backendKind: candidate.backendKind,
+                          taskProfileId: routingExplain.taskProfileId,
+                        })}
+                      >
+                        Pin Route
+                      </ActionButton>
+                      <ActionButton
+                        tone="secondary"
+                        disabled={clearPenaltyMutation.isPending}
+                        onClick={() => clearPenaltyMutation.mutate({
+                          providerId: candidate.providerId,
+                          model: candidate.model,
+                          backendKind: candidate.backendKind,
+                          taskProfileId: routingExplain.taskProfileId,
+                        })}
+                      >
+                        Clear Penalty
+                      </ActionButton>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : (
+            <p className="text-sm text-white/60">Routing explain preview unavailable.</p>
           )}
         </ShellCard>
 
@@ -480,6 +653,75 @@ export function SettingsPage() {
             </div>
           </ShellCard>
         ) : null}
+
+        <ShellCard eyebrow="Operator" title="Learning Controls">
+          {learningOverview ? (
+            <div className="space-y-4">
+              <div className="grid gap-3 sm:grid-cols-2">
+                <DiagnosticTile icon={<Brain className="h-4 w-4" />} label="Lessons" value={String(learningOverview.coverage.lessons)} />
+                <DiagnosticTile icon={<Brain className="h-4 w-4" />} label="Patterns" value={String(learningOverview.coverage.patterns)} />
+                <DiagnosticTile icon={<Sliders className="h-4 w-4" />} label="Route Adjustments" value={String(learningOverview.coverage.routeAdjustments)} />
+                <DiagnosticTile icon={<AlertTriangle className="h-4 w-4" />} label="Blocked Routes" value={String(learningOverview.coverage.blockedRoutes)} />
+              </div>
+              <div className="space-y-3">
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-white/40">Lessons</p>
+                {learningOverview.lessons.slice(0, 3).map((record) => (
+                  <div key={record.lesson.id} className="rounded-[22px] border border-white/[0.08] bg-black/20 p-4">
+                    <div className="flex items-center justify-between gap-3">
+                      <div>
+                        <p className="font-medium text-white">{record.lesson.title}</p>
+                        <p className="text-xs text-white/50">{record.lesson.cause}</p>
+                      </div>
+                      <StatusPill tone={record.disabled ? "warning" : "success"}>
+                        {record.disabled ? "disabled" : "enabled"}
+                      </StatusPill>
+                    </div>
+                    <p className="mt-2 text-sm text-white/70">{record.lesson.fix}</p>
+                    <div className="mt-3 flex gap-2">
+                      <ActionButton
+                        tone="secondary"
+                        disabled={lessonToggleMutation.isPending}
+                        onClick={() => lessonToggleMutation.mutate({
+                          lessonId: record.lesson.id,
+                          enabled: record.disabled,
+                        })}
+                      >
+                        {record.disabled ? "Enable Lesson" : "Disable Lesson"}
+                      </ActionButton>
+                    </div>
+                  </div>
+                ))}
+              </div>
+              <div className="space-y-3">
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-white/40">Patterns</p>
+                {learningOverview.patterns.slice(0, 3).map((record) => (
+                  <div key={record.patternId} className="rounded-[22px] border border-white/[0.08] bg-black/20 p-4">
+                    <div className="flex items-center justify-between gap-3">
+                      <div>
+                        <p className="font-medium text-white">{record.description}</p>
+                        <p className="text-xs text-white/50">{record.kind} · samples {record.sampleCount}</p>
+                      </div>
+                      <StatusPill tone={record.demoted ? "warning" : "neutral"}>
+                        {record.demoted ? "demoted" : "active"}
+                      </StatusPill>
+                    </div>
+                    <div className="mt-3 flex gap-2">
+                      <ActionButton
+                        tone="secondary"
+                        disabled={demotePatternMutation.isPending}
+                        onClick={() => demotePatternMutation.mutate(record.patternId)}
+                      >
+                        Demote Pattern
+                      </ActionButton>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : (
+            <p className="text-sm text-white/60">Learning controls unavailable.</p>
+          )}
+        </ShellCard>
 
         <ShellCard eyebrow="Security" title="Security Center">
           {securityCenter ? (

--- a/ui/src/routes/setup-page.tsx
+++ b/ui/src/routes/setup-page.tsx
@@ -60,6 +60,67 @@ const STARTER_SKILL_EXAMPLES: Record<string, string> = {
   "incident-brief-generator": "Turn these logs and notes into a concise incident brief.",
 };
 
+type SetupProviderRecommendation = {
+  backend: string;
+  auth: string;
+  why: string;
+  boundary: string;
+  operatorNote: string;
+};
+
+function getProviderBootstrapRecommendation(kind: ProviderKind): SetupProviderRecommendation {
+  switch (kind) {
+    case "openai":
+      return {
+        backend: "HTTP for native tools, Codex CLI later for consumer-plan text work",
+        auth: "API key or bearer token",
+        why: "OpenAI HTTP is the reliable path when Friday needs native tools, route fallback, and full run evidence.",
+        boundary: "ChatGPT / Codex consumer sessions are intentionally attached later as CLI backends, not reused as HTTP OAuth credentials.",
+        operatorNote: "Use Settings after setup if you want to attach Codex CLI for text-only review, analysis, or coding assistance.",
+      };
+    case "anthropic":
+      return {
+        backend: "HTTP first, Claude CLI optional later",
+        auth: "API key, token/setup-token, or OAuth",
+        why: "Anthropic HTTP keeps tool-capable runs and verification inside Friday while Claude CLI stays a text-only backend.",
+        boundary: "Claude CLI should not be treated as a native-tool backend for runs that require Friday tools.",
+        operatorNote: "Attach Claude CLI later in Settings when you want a consumer-plan text route beside the HTTP provider.",
+      };
+    case "google":
+      return {
+        backend: "HTTP first, Gemini CLI only if explicitly installed",
+        auth: "API key",
+        why: "Google HTTP is the stable route for tool-capable work and routing explainability.",
+        boundary: "Gemini CLI is optional and environment-dependent; setup does not assume it exists.",
+        operatorNote: "If Gemini CLI is installed later, attach it as an external-session backend from Settings.",
+      };
+    case "ollama":
+      return {
+        backend: "Local/self-hosted HTTP",
+        auth: "None or local token if configured",
+        why: "Ollama is the preferred no-egress or local-only route and stays fully explainable inside Friday's HTTP stack.",
+        boundary: "Local models trade cost and privacy benefits against capability and latency differences.",
+        operatorNote: "Use local-only policies in Settings when you want Ollama to outrank hosted providers for sensitive tasks.",
+      };
+    case "openai-compatible":
+      return {
+        backend: "HTTP",
+        auth: "API key or bearer token",
+        why: "OpenAI-compatible gateways fit Friday's routed HTTP path and keep doctor, explain, and fallback behavior consistent.",
+        boundary: "Friday only treats officially compatible HTTP gateways as first-class here; it does not infer hidden consumer OAuth flows.",
+        operatorNote: "Add region and no-egress constraints later in Settings if this gateway fronts a local or regional deployment.",
+      };
+    default:
+      return {
+        backend: "HTTP",
+        auth: "API key",
+        why: "HTTP keeps Friday's provider routing, auditing, and explainability intact during setup.",
+        boundary: "Specialized backend behavior is added later from Settings if the provider family supports it.",
+        operatorNote: "Finish setup with the stable HTTP path first, then attach advanced backends after the shell is healthy.",
+      };
+  }
+}
+
 function titleCase(value: string): string {
   return value
     .split(/[-_]/g)
@@ -176,6 +237,11 @@ export function SetupPage() {
       ? discovered.filter((kind): kind is ChannelKind => DEFAULT_CHANNELS.includes(kind as ChannelKind))
       : DEFAULT_CHANNELS;
   }, [supportedHealth?.capabilities?.channels?.supportedKinds]);
+
+  const providerRecommendation = useMemo(
+    () => getProviderBootstrapRecommendation(providerKind),
+    [providerKind],
+  );
 
   const detectProviderMutation = useMutation({
     mutationFn: () =>
@@ -441,6 +507,24 @@ export function SetupPage() {
                   </div>
                 </div>
               ) : null}
+              <div className="rounded-[22px] border border-cyan-300/20 bg-cyan-300/[0.06] p-4">
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-cyan-100/70">
+                  Recommended backend/auth
+                </p>
+                <div className="mt-3 grid gap-3 md:grid-cols-2">
+                  <div>
+                    <p className="text-xs uppercase tracking-[0.16em] text-white/35">Backend</p>
+                    <p className="mt-1 text-sm font-medium text-white">{providerRecommendation.backend}</p>
+                  </div>
+                  <div>
+                    <p className="text-xs uppercase tracking-[0.16em] text-white/35">Auth</p>
+                    <p className="mt-1 text-sm font-medium text-white">{providerRecommendation.auth}</p>
+                  </div>
+                </div>
+                <p className="mt-3 text-sm leading-6 text-white/72">{providerRecommendation.why}</p>
+                <p className="mt-3 text-sm leading-6 text-white/52">{providerRecommendation.boundary}</p>
+                <p className="mt-3 text-sm leading-6 text-cyan-100/70">{providerRecommendation.operatorNote}</p>
+              </div>
             </div>
           </ShellCard>
 


### PR DESCRIPTION
## Summary
- add the operator-facing routing explainability data clients and UI surfaces
- surface lessons, patterns, provider routing signals, and operator controls in setup/settings/assistant/observability
- keep the UI-only stack separate from the runtime-core and live-audit artifact PRs

## Validation
- `npm run build`
