### PR TITLE
Add tier1 live matrix harness and reports

### DIFF
--- a/docs/reports/repo/TIER1_CHINA_LIVE_AUDIT_2026-04-01.json
+++ b/docs/reports/repo/TIER1_CHINA_LIVE_AUDIT_2026-04-01.json
@@ -1,0 +1,50 @@
+{
+  "generatedAt": "2026-04-01T22:17:44.725Z",
+  "scope": "tier1-china",
+  "sourceMatrixPath": "/Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_MATRIX_2026-04-01.json",
+  "sourceReportPath": "/Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_2026-04-01.md",
+  "results": [
+    {
+      "target": "qwen",
+      "status": "blocked",
+      "reason": "QWEN_API_KEY is not configured in this environment."
+    },
+    {
+      "target": "moonshot-kimi",
+      "status": "blocked",
+      "reason": "MOONSHOT_API_KEY is not configured in this environment."
+    },
+    {
+      "target": "glm",
+      "status": "blocked",
+      "reason": "ZHIPU_API_KEY is not configured in this environment."
+    },
+    {
+      "target": "volcengine-byteplus",
+      "status": "blocked",
+      "reason": "VOLCENGINE_API_KEY is not configured in this environment."
+    }
+  ],
+  "blockers": [
+    {
+      "target": "qwen",
+      "status": "blocked",
+      "reason": "QWEN_API_KEY is not configured in this environment."
+    },
+    {
+      "target": "moonshot-kimi",
+      "status": "blocked",
+      "reason": "MOONSHOT_API_KEY is not configured in this environment."
+    },
+    {
+      "target": "glm",
+      "status": "blocked",
+      "reason": "ZHIPU_API_KEY is not configured in this environment."
+    },
+    {
+      "target": "volcengine-byteplus",
+      "status": "blocked",
+      "reason": "VOLCENGINE_API_KEY is not configured in this environment."
+    }
+  ]
+}

--- a/docs/reports/repo/TIER1_CHINA_LIVE_AUDIT_2026-04-01.md
+++ b/docs/reports/repo/TIER1_CHINA_LIVE_AUDIT_2026-04-01.md
@@ -1,0 +1,23 @@
+# Tier1 China Live Audit
+
+- Generated at: 2026-04-01T22:17:44.725Z
+- Source matrix: /Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_MATRIX_2026-04-01.json
+- Source report: /Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_2026-04-01.md
+
+## Summary
+
+No China-tier provider family could be fully live-verified on this machine on April 1, 2026. This runner currently records explicit blockers until a China egress environment is available.
+
+## Results
+
+- qwen: blocked — QWEN_API_KEY is not configured in this environment.
+- moonshot-kimi: blocked — MOONSHOT_API_KEY is not configured in this environment.
+- glm: blocked — ZHIPU_API_KEY is not configured in this environment.
+- volcengine-byteplus: blocked — VOLCENGINE_API_KEY is not configured in this environment.
+
+## Blockers
+
+- qwen: QWEN_API_KEY is not configured in this environment.
+- moonshot-kimi: MOONSHOT_API_KEY is not configured in this environment.
+- glm: ZHIPU_API_KEY is not configured in this environment.
+- volcengine-byteplus: VOLCENGINE_API_KEY is not configured in this environment.

--- a/docs/reports/repo/TIER1_GLOBAL_LIVE_AUDIT_2026-04-01.json
+++ b/docs/reports/repo/TIER1_GLOBAL_LIVE_AUDIT_2026-04-01.json
@@ -1,0 +1,104 @@
+{
+  "generatedAt": "2026-04-01T22:17:44.724Z",
+  "scope": "tier1-global",
+  "sourceMatrixPath": "/Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_MATRIX_2026-04-01.json",
+  "sourceReportPath": "/Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_2026-04-01.md",
+  "results": [
+    {
+      "target": "openai-http",
+      "status": "passed",
+      "summary": "Friday-routed OpenAI HTTP live path passed.",
+      "evidence": [
+        "/Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_MATRIX_2026-04-01.json"
+      ]
+    },
+    {
+      "target": "codex-cli",
+      "status": "passed",
+      "summary": "Codex CLI external-session backend passed a Friday-routed text completion.",
+      "evidence": [
+        "/Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_MATRIX_2026-04-01.json"
+      ]
+    },
+    {
+      "target": "claude-cli",
+      "status": "passed",
+      "summary": "Claude CLI external-session backend passed a Friday-routed text completion.",
+      "evidence": [
+        "/Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_MATRIX_2026-04-01.json"
+      ]
+    },
+    {
+      "target": "anthropic-http",
+      "status": "blocked",
+      "reason": "Anthropic live credentials are not configured in this environment."
+    },
+    {
+      "target": "google-gemini",
+      "status": "blocked",
+      "reason": "Neither Gemini CLI nor Google live credentials are available in this environment."
+    },
+    {
+      "target": "openrouter",
+      "status": "blocked",
+      "reason": "OPENROUTER_API_KEY is not configured in this environment."
+    },
+    {
+      "target": "xai",
+      "status": "blocked",
+      "reason": "XAI_API_KEY is not configured in this environment."
+    },
+    {
+      "target": "mistral",
+      "status": "blocked",
+      "reason": "MISTRAL_API_KEY is not configured in this environment."
+    },
+    {
+      "target": "groq",
+      "status": "blocked",
+      "reason": "GROQ_API_KEY is not configured in this environment."
+    },
+    {
+      "target": "together",
+      "status": "blocked",
+      "reason": "TOGETHER_API_KEY is not configured in this environment."
+    }
+  ],
+  "blockers": [
+    {
+      "target": "anthropic-http",
+      "status": "blocked",
+      "reason": "Anthropic live credentials are not configured in this environment."
+    },
+    {
+      "target": "google-gemini",
+      "status": "blocked",
+      "reason": "Neither Gemini CLI nor Google live credentials are available in this environment."
+    },
+    {
+      "target": "openrouter",
+      "status": "blocked",
+      "reason": "OPENROUTER_API_KEY is not configured in this environment."
+    },
+    {
+      "target": "xai",
+      "status": "blocked",
+      "reason": "XAI_API_KEY is not configured in this environment."
+    },
+    {
+      "target": "mistral",
+      "status": "blocked",
+      "reason": "MISTRAL_API_KEY is not configured in this environment."
+    },
+    {
+      "target": "groq",
+      "status": "blocked",
+      "reason": "GROQ_API_KEY is not configured in this environment."
+    },
+    {
+      "target": "together",
+      "status": "blocked",
+      "reason": "TOGETHER_API_KEY is not configured in this environment."
+    }
+  ]
+}

--- a/docs/reports/repo/TIER1_GLOBAL_LIVE_AUDIT_2026-04-01.md
+++ b/docs/reports/repo/TIER1_GLOBAL_LIVE_AUDIT_2026-04-01.md
@@ -1,0 +1,32 @@
+# Tier1 Global Live Audit
+
+- Generated at: 2026-04-01T22:17:44.724Z
+- Source matrix: /Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_MATRIX_2026-04-01.json
+- Source report: /Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_2026-04-01.md
+
+## Summary
+
+Passed 3 of 10 global tier1 targets on April 1, 2026. Missing or unrun families are explicitly marked as blockers.
+
+## Results
+
+- openai-http: passed — Friday-routed OpenAI HTTP live path passed.
+- codex-cli: passed — Codex CLI external-session backend passed a Friday-routed text completion.
+- claude-cli: passed — Claude CLI external-session backend passed a Friday-routed text completion.
+- anthropic-http: blocked — Anthropic live credentials are not configured in this environment.
+- google-gemini: blocked — Neither Gemini CLI nor Google live credentials are available in this environment.
+- openrouter: blocked — OPENROUTER_API_KEY is not configured in this environment.
+- xai: blocked — XAI_API_KEY is not configured in this environment.
+- mistral: blocked — MISTRAL_API_KEY is not configured in this environment.
+- groq: blocked — GROQ_API_KEY is not configured in this environment.
+- together: blocked — TOGETHER_API_KEY is not configured in this environment.
+
+## Blockers
+
+- anthropic-http: Anthropic live credentials are not configured in this environment.
+- google-gemini: Neither Gemini CLI nor Google live credentials are available in this environment.
+- openrouter: OPENROUTER_API_KEY is not configured in this environment.
+- xai: XAI_API_KEY is not configured in this environment.
+- mistral: MISTRAL_API_KEY is not configured in this environment.
+- groq: GROQ_API_KEY is not configured in this environment.
+- together: TOGETHER_API_KEY is not configured in this environment.

--- a/docs/reports/repo/TIER1_LOCAL_LIVE_AUDIT_2026-04-01.json
+++ b/docs/reports/repo/TIER1_LOCAL_LIVE_AUDIT_2026-04-01.json
@@ -1,0 +1,48 @@
+{
+  "generatedAt": "2026-04-01T22:17:44.725Z",
+  "scope": "tier1-local",
+  "sourceMatrixPath": "/Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_MATRIX_2026-04-01.json",
+  "sourceReportPath": "/Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_2026-04-01.md",
+  "results": [
+    {
+      "target": "ollama-local",
+      "status": "passed",
+      "summary": "Ollama local/self-hosted path passed a Friday-routed live run.",
+      "evidence": [
+        "/Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_MATRIX_2026-04-01.json"
+      ]
+    },
+    {
+      "target": "vllm",
+      "status": "blocked",
+      "reason": "VLLM endpoint is not configured in this environment."
+    },
+    {
+      "target": "litellm",
+      "status": "blocked",
+      "reason": "LiteLLM endpoint is not configured in this environment."
+    },
+    {
+      "target": "openai-compatible",
+      "status": "blocked",
+      "reason": "OpenAI-compatible endpoint is not configured in this environment."
+    }
+  ],
+  "blockers": [
+    {
+      "target": "vllm",
+      "status": "blocked",
+      "reason": "VLLM endpoint is not configured in this environment."
+    },
+    {
+      "target": "litellm",
+      "status": "blocked",
+      "reason": "LiteLLM endpoint is not configured in this environment."
+    },
+    {
+      "target": "openai-compatible",
+      "status": "blocked",
+      "reason": "OpenAI-compatible endpoint is not configured in this environment."
+    }
+  ]
+}

--- a/docs/reports/repo/TIER1_LOCAL_LIVE_AUDIT_2026-04-01.md
+++ b/docs/reports/repo/TIER1_LOCAL_LIVE_AUDIT_2026-04-01.md
@@ -1,0 +1,22 @@
+# Tier1 Local Live Audit
+
+- Generated at: 2026-04-01T22:17:44.725Z
+- Source matrix: /Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_MATRIX_2026-04-01.json
+- Source report: /Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_2026-04-01.md
+
+## Summary
+
+Passed 1 of 4 local/self-hosted tier1 targets on April 1, 2026. Remaining targets are explicitly blocked until their endpoints are configured.
+
+## Results
+
+- ollama-local: passed — Ollama local/self-hosted path passed a Friday-routed live run.
+- vllm: blocked — VLLM endpoint is not configured in this environment.
+- litellm: blocked — LiteLLM endpoint is not configured in this environment.
+- openai-compatible: blocked — OpenAI-compatible endpoint is not configured in this environment.
+
+## Blockers
+
+- vllm: VLLM endpoint is not configured in this environment.
+- litellm: LiteLLM endpoint is not configured in this environment.
+- openai-compatible: OpenAI-compatible endpoint is not configured in this environment.

--- a/scripts/e2e/run-tier1-china-live-audit.mjs
+++ b/scripts/e2e/run-tier1-china-live-audit.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+
+import path from "node:path";
+
+import {
+  DATE_STAMP,
+  REPORT_DIR,
+  SOURCE_MATRIX_PATH,
+  SOURCE_REPORT_PATH,
+  buildMarkdownReport,
+  blockStatus,
+  hasEnv,
+  loadSourceMatrix,
+  writeJson,
+  writeText,
+} from "./tier1-live-audit-lib.mjs";
+
+loadSourceMatrix();
+
+const reportJsonPath = path.join(REPORT_DIR, `TIER1_CHINA_LIVE_AUDIT_${DATE_STAMP}.json`);
+const reportMdPath = path.join(REPORT_DIR, `TIER1_CHINA_LIVE_AUDIT_${DATE_STAMP}.md`);
+
+const families = [
+  ["qwen", "QWEN_API_KEY"],
+  ["moonshot-kimi", "MOONSHOT_API_KEY"],
+  ["glm", "ZHIPU_API_KEY"],
+  ["volcengine-byteplus", "VOLCENGINE_API_KEY"],
+];
+
+const results = families.map(([target, envName]) =>
+  hasEnv(envName)
+    ? blockStatus(target, `${envName} is present, but this machine is not running the dedicated China egress live harness yet.`)
+    : blockStatus(target, `${envName} is not configured in this environment.`),
+);
+
+const blockers = results;
+const summary = "No China-tier provider family could be fully live-verified on this machine on April 1, 2026. This runner currently records explicit blockers until a China egress environment is available.";
+
+const payload = {
+  generatedAt: new Date().toISOString(),
+  scope: "tier1-china",
+  sourceMatrixPath: SOURCE_MATRIX_PATH,
+  sourceReportPath: SOURCE_REPORT_PATH,
+  results,
+  blockers,
+};
+
+writeJson(reportJsonPath, payload);
+writeText(
+  reportMdPath,
+  buildMarkdownReport({
+    title: "Tier1 China Live Audit",
+    generatedAt: payload.generatedAt,
+    sourceMatrixPath: SOURCE_MATRIX_PATH,
+    sourceReportPath: SOURCE_REPORT_PATH,
+    summary,
+    results,
+    blockers,
+  }),
+);
+
+console.log(JSON.stringify({ ok: true, reportJsonPath, reportMdPath, blockers: blockers.length }, null, 2));

--- a/scripts/e2e/run-tier1-global-live-audit.mjs
+++ b/scripts/e2e/run-tier1-global-live-audit.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+
+import path from "node:path";
+
+import {
+  DATE_STAMP,
+  REPORT_DIR,
+  SOURCE_MATRIX_PATH,
+  SOURCE_REPORT_PATH,
+  buildMarkdownReport,
+  blockStatus,
+  hasBinary,
+  hasEnv,
+  loadSourceMatrix,
+  passStatus,
+  writeJson,
+  writeText,
+} from "./tier1-live-audit-lib.mjs";
+
+const matrix = loadSourceMatrix();
+const reportJsonPath = path.join(REPORT_DIR, `TIER1_GLOBAL_LIVE_AUDIT_${DATE_STAMP}.json`);
+const reportMdPath = path.join(REPORT_DIR, `TIER1_GLOBAL_LIVE_AUDIT_${DATE_STAMP}.md`);
+
+const results = [];
+
+if (matrix.live?.openaiHttp?.repeatRun1?.status === "completed") {
+  results.push(
+    passStatus("openai-http", "Friday-routed OpenAI HTTP live path passed.", [SOURCE_MATRIX_PATH]),
+  );
+} else {
+  results.push(
+    blockStatus("openai-http", "OpenAI HTTP live path was not verified in the source live audit."),
+  );
+}
+
+if (matrix.live?.codexCli?.textCompletion?.text?.includes("CODEX_FRIDAY_OK")) {
+  results.push(
+    passStatus("codex-cli", "Codex CLI external-session backend passed a Friday-routed text completion.", [SOURCE_MATRIX_PATH]),
+  );
+} else {
+  results.push(
+    blockStatus("codex-cli", "Codex CLI backend was not verified by the source live audit."),
+  );
+}
+
+if (matrix.live?.claudeCli?.textCompletion?.text?.includes("CLAUDE_FRIDAY_OK")) {
+  results.push(
+    passStatus("claude-cli", "Claude CLI external-session backend passed a Friday-routed text completion.", [SOURCE_MATRIX_PATH]),
+  );
+} else {
+  results.push(
+    blockStatus("claude-cli", "Claude CLI backend was not verified by the source live audit."),
+  );
+}
+
+results.push(
+  hasEnv("ANTHROPIC_API_KEY") || hasEnv("FRIDAY_E2E_LIVE_ANTHROPIC")
+    ? blockStatus("anthropic-http", "Anthropic credentials are present, but this tier1 global runner has not yet executed a dedicated Anthropic HTTP/OAuth/token live harness.")
+    : blockStatus("anthropic-http", "Anthropic live credentials are not configured in this environment."),
+);
+
+results.push(
+  hasBinary("gemini") || hasEnv("GOOGLE_API_KEY")
+    ? blockStatus("google-gemini", "Google/Gemini capability is partially present, but no dedicated tier1 global live harness has executed yet.")
+    : blockStatus("google-gemini", "Neither Gemini CLI nor Google live credentials are available in this environment."),
+);
+
+for (const family of [
+  ["openrouter", "OPENROUTER_API_KEY"],
+  ["xai", "XAI_API_KEY"],
+  ["mistral", "MISTRAL_API_KEY"],
+  ["groq", "GROQ_API_KEY"],
+  ["together", "TOGETHER_API_KEY"],
+]) {
+  const [target, envName] = family;
+  results.push(
+    hasEnv(envName)
+      ? blockStatus(target, `${envName} is present, but a dedicated tier1 global live harness for ${target} has not been executed yet.`)
+      : blockStatus(target, `${envName} is not configured in this environment.`),
+  );
+}
+
+const blockers = results.filter((result) => result.status === "blocked");
+const summary = `Passed ${results.length - blockers.length} of ${results.length} global tier1 targets on April 1, 2026. Missing or unrun families are explicitly marked as blockers.`;
+
+const payload = {
+  generatedAt: new Date().toISOString(),
+  scope: "tier1-global",
+  sourceMatrixPath: SOURCE_MATRIX_PATH,
+  sourceReportPath: SOURCE_REPORT_PATH,
+  results,
+  blockers,
+};
+
+writeJson(reportJsonPath, payload);
+writeText(
+  reportMdPath,
+  buildMarkdownReport({
+    title: "Tier1 Global Live Audit",
+    generatedAt: payload.generatedAt,
+    sourceMatrixPath: SOURCE_MATRIX_PATH,
+    sourceReportPath: SOURCE_REPORT_PATH,
+    summary,
+    results,
+    blockers,
+  }),
+);
+
+console.log(JSON.stringify({ ok: true, reportJsonPath, reportMdPath, blockers: blockers.length }, null, 2));

--- a/scripts/e2e/run-tier1-local-live-audit.mjs
+++ b/scripts/e2e/run-tier1-local-live-audit.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+import path from "node:path";
+
+import {
+  DATE_STAMP,
+  REPORT_DIR,
+  SOURCE_MATRIX_PATH,
+  SOURCE_REPORT_PATH,
+  buildMarkdownReport,
+  blockStatus,
+  hasEnv,
+  loadSourceMatrix,
+  passStatus,
+  writeJson,
+  writeText,
+} from "./tier1-live-audit-lib.mjs";
+
+const matrix = loadSourceMatrix();
+const reportJsonPath = path.join(REPORT_DIR, `TIER1_LOCAL_LIVE_AUDIT_${DATE_STAMP}.json`);
+const reportMdPath = path.join(REPORT_DIR, `TIER1_LOCAL_LIVE_AUDIT_${DATE_STAMP}.md`);
+
+const results = [];
+
+if (matrix.live?.ollamaLocal?.run?.status === "completed") {
+  results.push(
+    passStatus("ollama-local", "Ollama local/self-hosted path passed a Friday-routed live run.", [SOURCE_MATRIX_PATH]),
+  );
+} else {
+  results.push(
+    blockStatus("ollama-local", "Ollama local/self-hosted live path was not verified in the source live audit."),
+  );
+}
+
+results.push(
+  hasEnv("VLLM_BASE_URL")
+    ? blockStatus("vllm", "VLLM endpoint is configured, but a dedicated local tier1 harness has not been executed yet.")
+    : blockStatus("vllm", "VLLM endpoint is not configured in this environment."),
+);
+
+results.push(
+  hasEnv("LITELLM_BASE_URL")
+    ? blockStatus("litellm", "LiteLLM endpoint is configured, but a dedicated local tier1 harness has not been executed yet.")
+    : blockStatus("litellm", "LiteLLM endpoint is not configured in this environment."),
+);
+
+results.push(
+  hasEnv("OPENAI_COMPATIBLE_BASE_URL")
+    ? blockStatus("openai-compatible", "OpenAI-compatible endpoint is configured, but a dedicated local tier1 harness has not been executed yet.")
+    : blockStatus("openai-compatible", "OpenAI-compatible endpoint is not configured in this environment."),
+);
+
+const blockers = results.filter((result) => result.status === "blocked");
+const summary = `Passed ${results.length - blockers.length} of ${results.length} local/self-hosted tier1 targets on April 1, 2026. Remaining targets are explicitly blocked until their endpoints are configured.`;
+
+const payload = {
+  generatedAt: new Date().toISOString(),
+  scope: "tier1-local",
+  sourceMatrixPath: SOURCE_MATRIX_PATH,
+  sourceReportPath: SOURCE_REPORT_PATH,
+  results,
+  blockers,
+};
+
+writeJson(reportJsonPath, payload);
+writeText(
+  reportMdPath,
+  buildMarkdownReport({
+    title: "Tier1 Local Live Audit",
+    generatedAt: payload.generatedAt,
+    sourceMatrixPath: SOURCE_MATRIX_PATH,
+    sourceReportPath: SOURCE_REPORT_PATH,
+    summary,
+    results,
+    blockers,
+  }),
+);
+
+console.log(JSON.stringify({ ok: true, reportJsonPath, reportMdPath, blockers: blockers.length }, null, 2));

--- a/scripts/e2e/tier1-live-audit-lib.mjs
+++ b/scripts/e2e/tier1-live-audit-lib.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+export const REPO_ROOT = process.cwd();
+export const DATE_STAMP = new Date().toISOString().slice(0, 10);
+export const REPORT_DIR = path.join(REPO_ROOT, "docs", "reports", "repo");
+export const SOURCE_MATRIX_PATH = path.join(
+  REPORT_DIR,
+  `SELF_EVOLUTION_LIVE_AUDIT_MATRIX_${DATE_STAMP}.json`,
+);
+export const SOURCE_REPORT_PATH = path.join(
+  REPORT_DIR,
+  `SELF_EVOLUTION_LIVE_AUDIT_${DATE_STAMP}.md`,
+);
+
+export function ensureDir(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+export function writeJson(filePath, value) {
+  ensureDir(path.dirname(filePath));
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2) + "\n", "utf8");
+}
+
+export function writeText(filePath, value) {
+  ensureDir(path.dirname(filePath));
+  fs.writeFileSync(filePath, value, "utf8");
+}
+
+export function sourceMatrixExists() {
+  return fs.existsSync(SOURCE_MATRIX_PATH);
+}
+
+export function ensureSourceMatrix() {
+  if (sourceMatrixExists()) {
+    return;
+  }
+  const result = spawnSync("node", [path.join(REPO_ROOT, "scripts", "e2e", "run-self-evolution-live-audit.mjs")], {
+    cwd: REPO_ROOT,
+    env: process.env,
+    encoding: "utf8",
+    stdio: "inherit",
+  });
+  if (result.status !== 0 || !sourceMatrixExists()) {
+    throw new Error("Failed to generate source self-evolution live audit matrix");
+  }
+}
+
+export function loadSourceMatrix() {
+  ensureSourceMatrix();
+  return JSON.parse(fs.readFileSync(SOURCE_MATRIX_PATH, "utf8"));
+}
+
+export function readSourceReport() {
+  if (!fs.existsSync(SOURCE_REPORT_PATH)) {
+    return null;
+  }
+  return fs.readFileSync(SOURCE_REPORT_PATH, "utf8");
+}
+
+export function blockStatus(target, reason, extra = {}) {
+  return {
+    target,
+    status: "blocked",
+    reason,
+    ...extra,
+  };
+}
+
+export function passStatus(target, summary, evidence = [], extra = {}) {
+  return {
+    target,
+    status: "passed",
+    summary,
+    evidence,
+    ...extra,
+  };
+}
+
+export function buildMarkdownReport({ title, generatedAt, sourceMatrixPath, sourceReportPath, summary, results, blockers }) {
+  const lines = [
+    `# ${title}`,
+    "",
+    `- Generated at: ${generatedAt}`,
+    `- Source matrix: ${sourceMatrixPath}`,
+    `- Source report: ${sourceReportPath}`,
+    "",
+    "## Summary",
+    "",
+    summary,
+    "",
+    "## Results",
+    "",
+  ];
+  for (const result of results) {
+    lines.push(
+      `- ${result.target}: ${result.status}${result.summary ? ` — ${result.summary}` : ""}${result.reason ? ` — ${result.reason}` : ""}`,
+    );
+  }
+  if (blockers.length > 0) {
+    lines.push("", "## Blockers", "");
+    for (const blocker of blockers) {
+      lines.push(`- ${blocker.target}: ${blocker.reason}`);
+    }
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+export function hasEnv(name) {
+  return typeof process.env[name] === "string" && process.env[name].trim().length > 0;
+}
+
+export function hasBinary(name) {
+  const result = spawnSync("bash", ["-lc", `command -v ${name}`], {
+    cwd: REPO_ROOT,
+    env: process.env,
+    encoding: "utf8",
+  });
+  return result.status === 0;
+}


### PR DESCRIPTION
## Summary
- add reusable tier1 live audit runners for global, china, and local/self-hosted environments
- check in the 2026-04-01 tier1 live audit reports for each runner class
- keep the tier1 live matrix work isolated from the runtime-core, audit-artifact, and UI PRs

## Validation
- `node --check scripts/e2e/run-tier1-global-live-audit.mjs`
- `node --check scripts/e2e/run-tier1-china-live-audit.mjs`
- `node --check scripts/e2e/run-tier1-local-live-audit.mjs`
- `node --check scripts/e2e/tier1-live-audit-lib.mjs`
