### PR TITLE
Fix secret scan false positives in provider tests

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -406,7 +410,7 @@
         "filename": "src/api/http/routes/friday-provider-routes.ts",
         "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
         "is_verified": false,
-        "line_number": 90
+        "line_number": 93
       }
     ],
     "src/api/http/routes/friday-setup-routes.ts": [
@@ -433,7 +437,7 @@
         "filename": "src/providers/services/friday-provider-service.ts",
         "hashed_secret": "90c5d1358d128117989fc21f2897a25c99205e50",
         "is_verified": false,
-        "line_number": 65
+        "line_number": 72
       }
     ],
     "src/security/multi-tenant/api/friday-multi-tenant-security-api.types.ts": [
@@ -582,7 +586,7 @@
         "filename": "test/e2e/api/_helpers/friday-api-test-server.helper.ts",
         "hashed_secret": "c037ddcf4baaba918834d51ca46cd88ec704c283",
         "is_verified": false,
-        "line_number": 44
+        "line_number": 45
       }
     ],
     "test/e2e/cli/friday-cli-start-runtime.test.ts": [
@@ -966,51 +970,9 @@
       {
         "type": "Secret Keyword",
         "filename": "test/unit/providers/services/friday-provider-service.test.ts",
-        "hashed_secret": "b442e3565a2e01950b68b938201e59ac8c43569c",
-        "is_verified": false,
-        "line_number": 87
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "test/unit/providers/services/friday-provider-service.test.ts",
-        "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
-        "is_verified": false,
-        "line_number": 110
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "test/unit/providers/services/friday-provider-service.test.ts",
-        "hashed_secret": "6608a3a8a5e243c029ba8387a31999b4f2a7113e",
-        "is_verified": false,
-        "line_number": 163
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "test/unit/providers/services/friday-provider-service.test.ts",
-        "hashed_secret": "4e102bd8782fca6a54e1f830dc08e005801be918",
-        "is_verified": false,
-        "line_number": 315
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "test/unit/providers/services/friday-provider-service.test.ts",
-        "hashed_secret": "e389d8caa4d8425c2b32609210ecdad38c9bad9e",
-        "is_verified": false,
-        "line_number": 353
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "test/unit/providers/services/friday-provider-service.test.ts",
-        "hashed_secret": "1c89a67304c453ebf7a27a24fd31745aea73fd21",
-        "is_verified": false,
-        "line_number": 399
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "test/unit/providers/services/friday-provider-service.test.ts",
         "hashed_secret": "e5dee5d8a3b145b7ad98c144117ec048267d081e",
         "is_verified": false,
-        "line_number": 974
+        "line_number": 1122
       }
     ],
     "test/unit/rules/engine/context-redactor.test.ts": [
@@ -1135,5 +1097,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-01T06:06:41Z"
+  "generated_at": "2026-04-01T23:09:41Z"
 }

--- a/test/unit/providers/services/friday-provider-service.test.ts
+++ b/test/unit/providers/services/friday-provider-service.test.ts
@@ -85,7 +85,7 @@ describe("FridayProviderService", () => {
         baseUrl: "https://api.openai.com",
         authMode: "api-key",
         api: "openai-completions",
-        apiKey: "test-real-key-123",
+        apiKey: "test-real-key-123", // pragma: allowlist secret
         supportedModels: ["gpt-4o"],
         validateOnSave: false,
       });
@@ -108,7 +108,7 @@ describe("FridayProviderService", () => {
     });
 
     it("validates on save by default", async () => {
-      process.env.OPENAI_API_KEY = "test-openai-key";
+      process.env.OPENAI_API_KEY = "test-openai-key"; // pragma: allowlist secret
       try {
         const profile = await service.createProvider({
           kind: "openai",
@@ -161,7 +161,7 @@ describe("FridayProviderService", () => {
         baseUrl: "https://api.anthropic.com",
         authMode: "token",
         api: "anthropic-messages",
-        apiKey: "test-ant-token-real",
+        apiKey: "test-ant-token-real", // pragma: allowlist secret
         supportedModels: ["claude-sonnet-4-20250514"],
         validateOnSave: false,
       });
@@ -177,7 +177,7 @@ describe("FridayProviderService", () => {
         baseUrl: "https://api.anthropic.com",
         authMode: "token",
         api: "anthropic-messages",
-        apiKey: "test-ant-token-real",
+        apiKey: "test-ant-token-real", // pragma: allowlist secret
         supportedModels: ["claude-sonnet-4-20250514"],
         validateOnSave: false,
       });
@@ -313,7 +313,7 @@ describe("FridayProviderService", () => {
       });
 
       const updated = await service.updateProvider("test-id-0001", {
-        apiKey: "test-new-key",
+        apiKey: "test-new-key", // pragma: allowlist secret
         validateOnSave: false,
       });
 
@@ -351,7 +351,7 @@ describe("FridayProviderService", () => {
 
       await service.updateProvider("test-id-0001", {
         authMode: "token",
-        apiKey: "test-ant-token-switch",
+        apiKey: "test-ant-token-switch", // pragma: allowlist secret
       });
 
       expect(listAuthProfiles()).toEqual([
@@ -397,7 +397,7 @@ describe("FridayProviderService", () => {
         baseUrl: "https://api.openai.com",
         authMode: "api-key",
         api: "openai-completions",
-        apiKey: "test-delete-me",
+        apiKey: "test-delete-me", // pragma: allowlist secret
         supportedModels: ["gpt-4o"],
         validateOnSave: false,
       });
@@ -441,7 +441,7 @@ describe("FridayProviderService", () => {
         baseUrl: "https://api.anthropic.com",
         authMode: "token",
         api: "anthropic-messages",
-        apiKey: "test-ant-token-real",
+        apiKey: "test-ant-token-real", // pragma: allowlist secret
         supportedModels: ["claude-sonnet-4-20250514"],
         validateOnSave: false,
       });
@@ -463,7 +463,7 @@ describe("FridayProviderService", () => {
         baseUrl: "https://api.anthropic.com",
         authMode: "token",
         api: "anthropic-messages",
-        apiKey: "test-ant-token-real",
+        apiKey: "test-ant-token-real", // pragma: allowlist secret
         supportedModels: ["claude-sonnet-4-20250514"],
         validateOnSave: false,
       });
@@ -945,7 +945,7 @@ describe("FridayProviderService", () => {
         baseUrl: "https://api.openai.com",
         authMode: "api-key",
         api: "openai-responses",
-        apiKey: "test-http-key",
+        apiKey: "test-http-key", // pragma: allowlist secret
         supportedModels: ["gpt-5.4"],
         defaultModel: "gpt-5.4",
         validateOnSave: false,
@@ -982,7 +982,7 @@ describe("FridayProviderService", () => {
         baseUrl: "https://api.openai.com",
         authMode: "api-key",
         api: "openai-completions",
-        apiKey: "test-primary-key",
+        apiKey: "test-primary-key", // pragma: allowlist secret
         supportedModels: ["gpt-4o"],
         defaultModel: "gpt-4o",
         validateOnSave: false,
@@ -993,7 +993,7 @@ describe("FridayProviderService", () => {
         baseUrl: "https://api.openai.com",
         authMode: "api-key",
         api: "openai-completions",
-        apiKey: "test-pinned-key",
+        apiKey: "test-pinned-key", // pragma: allowlist secret
         supportedModels: ["gpt-4o"],
         defaultModel: "gpt-4o",
         validateOnSave: false,
@@ -1119,7 +1119,7 @@ describe("FridayProviderService", () => {
           baseUrl: "https://api.openai.com",
           authMode: "api-key",
           api: "openai-completions",
-          apiKey: "global-secret",
+          apiKey: "global-secret", // pragma: allowlist secret
           supportedModels: ["gpt-4o"],
           defaultModel: "gpt-4o",
           validateOnSave: false,
@@ -1849,7 +1849,7 @@ describe("FridayProviderService", () => {
 
       const updated = await service.updateProvider("test-id-0001", {
         authMode: "token",
-        apiKey: "test-ant-token-switch",
+        apiKey: "test-ant-token-switch", // pragma: allowlist secret
       });
 
       expect(updated.config.authMode).toBe("token");


### PR DESCRIPTION
## Summary
- add inline allowlist pragmas for clearly fake provider test credentials
- update `.secrets.baseline` so detect-secrets line references match the current file layout
- fix the main-branch `secrets` failure introduced after #67 landed

## Validation
- `npx vitest run test/unit/providers/services/friday-provider-service.test.ts`
- local `detect-secrets-hook` reproduction using the CI command from `.github/workflows/ci.yml`
