### PR TITLE
Sync detect-secrets baseline line numbers

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -972,7 +972,7 @@
         "filename": "test/unit/providers/services/friday-provider-service.test.ts",
         "hashed_secret": "e5dee5d8a3b145b7ad98c144117ec048267d081e",
         "is_verified": false,
-        "line_number": 1122
+        "line_number": 1639
       }
     ],
     "test/unit/rules/engine/context-redactor.test.ts": [
@@ -1097,5 +1097,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-01T23:09:41Z"
+  "generated_at": "2026-04-01T23:24:27Z"
 }


### PR DESCRIPTION
## Summary
- sync the detect-secrets baseline after the #71 provider-test cleanup changed the tracked line number
- fix the remaining `secrets` failure on the latest `main` commit without changing runtime behavior

## Validation
- local `detect-secrets-hook` reproduction using the CI command from `.github/workflows/ci.yml`
