### PR TITLE
providers: enrich routing decision traces

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -972,7 +972,7 @@
         "filename": "test/unit/providers/services/friday-provider-service.test.ts",
         "hashed_secret": "e5dee5d8a3b145b7ad98c144117ec048267d081e",
         "is_verified": false,
-        "line_number": 1639
+        "line_number": 1658
       }
     ],
     "test/unit/rules/engine/context-redactor.test.ts": [
@@ -1097,5 +1097,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-01T23:24:27Z"
+  "generated_at": "2026-04-02T01:36:28Z"
 }

--- a/src/api/model/friday-api-self-healing.types.ts
+++ b/src/api/model/friday-api-self-healing.types.ts
@@ -21,6 +21,7 @@ import type {
   FridayRollbackHotspotRecord,
   FridayRouteDecisionDiffRecord,
 } from "#learning";
+import type { FridayProviderRoutingExplainReport } from "#providers";
 
 export interface FridayDiagnosisSummary {
   incidentId: string;
@@ -168,30 +169,7 @@ export interface FridayPinRouteRequest {
   reason?: string;
 }
 
-export interface FridayProviderRoutingExplainCandidate {
-  providerId: string;
-  providerKind: string;
-  model: string;
-  backendKind: "http" | "cli" | "sdk";
-  originalRank: number;
-  finalRank: number;
-  pinned: boolean;
-  routePenalty?: number;
-  historicalSuccessRate?: number;
-  historicalFailureRate?: number;
-  sampleCount?: number;
-}
-
-export interface FridayProviderRoutingExplainResponse {
-  requestedProviderId?: string;
-  requestedModel?: string;
-  taskProfileId?: string;
-  requiresNativeTools: boolean;
-  selected?: FridayProviderRoutingExplainCandidate;
-  candidates: FridayProviderRoutingExplainCandidate[];
-  learningAdjusted: boolean;
-  reason: string;
-}
+export type FridayProviderRoutingExplainResponse = FridayProviderRoutingExplainReport;
 
 export interface FridayRouteAdjustmentRecord extends FridayLearningRouteAdjustmentRecord {}
 export interface FridayRouteBiasRecord extends FridayLearningRouteBiasRecord {}

--- a/src/learning/services/friday-self-healing-api-service.ts
+++ b/src/learning/services/friday-self-healing-api-service.ts
@@ -185,6 +185,7 @@ export interface FridayRouteDecisionDiffRecord {
   actualProviderId?: string;
   actualModel?: string;
   reasonCode?: string;
+  reasonText?: string;
   learningAdjusted: boolean;
   learningSignalsPresent: boolean;
   selectedBeforeLearning?: {
@@ -807,6 +808,7 @@ export function createFridaySelfHealingApiService(
             ? { actualModel: actualExecution.actualModel }
             : {}),
           ...(typeof routeDecisionTrace.reasonCode === "string" ? { reasonCode: routeDecisionTrace.reasonCode } : {}),
+          ...(typeof routeDecisionTrace.reasonText === "string" ? { reasonText: routeDecisionTrace.reasonText } : {}),
           learningAdjusted: routeDecisionTrace.learningAdjusted === true,
           learningSignalsPresent: routeDecisionTrace.learningSignalsPresent === true,
           ...(selectedBeforeLearning ? { selectedBeforeLearning } : {}),

--- a/src/providers/model/friday-provider.types.ts
+++ b/src/providers/model/friday-provider.types.ts
@@ -343,6 +343,11 @@ export interface FridayProviderRoutingExplainCandidate {
   routePenaltyScore: number;
   pinBonus: number;
   finalScore: number;
+  historyStats?: {
+    sampleCount: number;
+    successRate: number;
+    failureRate: number;
+  };
   matchedLessonIds: string[];
   matchedPatternIds: string[];
 }
@@ -389,6 +394,7 @@ export interface FridayProviderRoutingExplainReport {
   selectedAdjusted: boolean;
   reasonCode: FridayProviderRoutingReasonCode;
   reason: string;
+  reasonText: string;
   historyWindow: FridayProviderRoutingHistoryWindow;
 }
 

--- a/src/providers/services/friday-provider-service.ts
+++ b/src/providers/services/friday-provider-service.ts
@@ -740,6 +740,15 @@ export function createFridayProviderService(
         routePenaltyScore: state.routePenaltyScore,
         pinBonus: state.pinBonus,
         finalScore: state.finalScore,
+        ...(state.history
+          ? {
+              historyStats: {
+                sampleCount: state.history.sampleCount,
+                successRate: successRate ?? 0,
+                failureRate: failureRate ?? 0,
+              },
+            }
+          : {}),
         matchedLessonIds: [...state.matchedLessonIds],
         matchedPatternIds: [...state.matchedPatternIds],
       } satisfies FridayProviderRoutingExplainCandidate;
@@ -1293,6 +1302,7 @@ export function createFridayProviderService(
         selectedAdjusted: traceBuilder.trace.selectedAdjusted,
         reasonCode: traceBuilder.trace.reasonCode,
         reason: traceBuilder.trace.reasonText,
+        reasonText: traceBuilder.trace.reasonText,
         historyWindow: traceBuilder.trace.historyWindow,
       };
     },

--- a/test/unit/providers/api/friday-provider-routes.test.ts
+++ b/test/unit/providers/api/friday-provider-routes.test.ts
@@ -227,6 +227,7 @@ describe("FridayProviderRoutes", () => {
         selectedAdjusted: false,
         reasonCode: "configured" as const,
         reason: "default route",
+        reasonText: "default route",
         historyWindow: { sampleLimit: 250 },
       })),
       pinRoute: vi.fn(async () => undefined),

--- a/test/unit/providers/services/friday-provider-service.test.ts
+++ b/test/unit/providers/services/friday-provider-service.test.ts
@@ -966,6 +966,7 @@ describe("FridayProviderService", () => {
       });
 
       expect(explain.selected.providerId).toBe("test-id-0002");
+      expect(explain.reasonCode).toBe("requested_model");
       expect(explain.candidates.some((candidate) => candidate.backendKind === "cli")).toBe(true);
       expect(
         explain.candidates.find((candidate) => candidate.backendKind === "cli"),
@@ -1027,6 +1028,7 @@ describe("FridayProviderService", () => {
       expect(explain.selected.providerId).toBe(pinned.id);
       expect(explain.learningAdjusted).toBe(true);
       expect(explain.reason).toContain("Operator pinned");
+      expect(explain.reasonText).toContain("Operator pinned");
       expect(explain.candidates[0]).toMatchObject({
         providerId: pinned.id,
         pinned: true,
@@ -1468,6 +1470,23 @@ describe("FridayProviderService", () => {
         expect(route.provider.id).toBe("test-id-0002");
         expect(routingDecision.learningAdjusted).toBe(true);
         expect(routingDecision.reason).toContain("Historical route outcomes influenced candidate scoring.");
+
+        const explain = await service.explainRouting({
+          routingContext: {
+            estimatedInputTokens: 1800,
+            complexity: "medium",
+            taskProfileId: "review",
+          },
+        });
+
+        expect(explain.reasonText).toContain("Historical route outcomes influenced candidate scoring.");
+        expect(
+          explain.candidateScores.find((candidate) => candidate.providerId === "test-id-0002")?.historyStats,
+        ).toMatchObject({
+          sampleCount: 2,
+          successRate: 1,
+          failureRate: 0,
+        });
       } finally {
         delete process.env.OPENAI_KEY;
         delete process.env.ANTHROPIC_KEY;

--- a/ui/src/lib/api/types.ts
+++ b/ui/src/lib/api/types.ts
@@ -1802,6 +1802,11 @@ export interface FridayProviderRoutingExplainCandidate {
   routePenaltyScore: number;
   pinBonus: number;
   finalScore: number;
+  historyStats?: {
+    sampleCount: number;
+    successRate: number;
+    failureRate: number;
+  };
   matchedLessonIds: string[];
   matchedPatternIds: string[];
 }
@@ -1822,6 +1827,7 @@ export interface FridayProviderRoutingExplainReport {
   selectedAdjusted: boolean;
   reasonCode: string;
   reason: string;
+  reasonText: string;
   historyWindow: {
     sampleLimit: number;
   };
@@ -1876,6 +1882,7 @@ export interface FridayRouteDecisionDiffRecord {
   actualProviderId?: string;
   actualModel?: string;
   reasonCode?: string;
+  reasonText?: string;
   learningAdjusted: boolean;
   learningSignalsPresent: boolean;
   selectedBeforeLearning?: FridayProviderRoutingSelection;

--- a/ui/src/routes/assistant-page.tsx
+++ b/ui/src/routes/assistant-page.tsx
@@ -1157,6 +1157,9 @@ export function AssistantPage() {
                           ? `${learningOverviewQuery.data.recentDecisionDiffs[0].selectedAfterLearning.providerId} / ${learningOverviewQuery.data.recentDecisionDiffs[0].selectedAfterLearning.model}`
                           : "n/a"}
                       </p>
+                      {learningOverviewQuery.data.recentDecisionDiffs[0].reasonText ? (
+                        <p className="mt-2 text-xs text-white/50">{learningOverviewQuery.data.recentDecisionDiffs[0].reasonText}</p>
+                      ) : null}
                       <p className="mt-3 text-xs text-white/50">
                         Matched lessons {learningOverviewQuery.data.recentDecisionDiffs[0].matchedLessonIds.length} · matched patterns {learningOverviewQuery.data.recentDecisionDiffs[0].matchedPatternIds.length}
                       </p>

--- a/ui/src/routes/observability-page.tsx
+++ b/ui/src/routes/observability-page.tsx
@@ -759,6 +759,9 @@ export function ObservabilityPage() {
                       ? `${record.selectedAfterLearning.providerId} / ${record.selectedAfterLearning.model}`
                       : "n/a"}
                   </p>
+                  {record.reasonText ? (
+                    <p className="mt-2 text-xs text-white/50">{record.reasonText}</p>
+                  ) : null}
                 </div>
               ))}
             </div>

--- a/ui/src/routes/settings-page.tsx
+++ b/ui/src/routes/settings-page.tsx
@@ -352,7 +352,7 @@ export function SettingsPage() {
                     {routingExplain.learningAdjusted ? "adjusted" : routingExplain.learningSignalsPresent ? "signals present" : "configured"}
                   </StatusPill>
                 </div>
-                <p className="mt-3 text-sm text-white/70">{routingExplain.reason}</p>
+                <p className="mt-3 text-sm text-white/70">{routingExplain.reasonText}</p>
                 <div className="mt-3 grid gap-3 md:grid-cols-2">
                   <DiagnosticRow
                     label="Before learning"
@@ -379,6 +379,16 @@ export function SettingsPage() {
                     <p className="mt-2 text-xs text-white/50">
                       score {candidate.finalScore.toFixed(2)} = base {candidate.baseRankScore.toFixed(2)} + history {candidate.historyScore.toFixed(2)} + lesson {candidate.lessonScore.toFixed(2)} + pattern {candidate.patternScore.toFixed(2)} + pin {candidate.pinBonus.toFixed(2)} + penalty {candidate.routePenaltyScore.toFixed(2)}
                     </p>
+                    {candidate.historyStats ? (
+                      <p className="mt-2 text-xs text-white/45">
+                        history {candidate.historyStats.sampleCount} samples · success {(candidate.historyStats.successRate * 100).toFixed(0)}% · failure {(candidate.historyStats.failureRate * 100).toFixed(0)}%
+                      </p>
+                    ) : null}
+                    {(candidate.matchedLessonIds.length > 0 || candidate.matchedPatternIds.length > 0) ? (
+                      <p className="mt-2 text-xs text-white/45">
+                        matched lessons {candidate.matchedLessonIds.length} · matched patterns {candidate.matchedPatternIds.length}
+                      </p>
+                    ) : null}
                     {candidate.ineligibilityReasons.length > 0 ? (
                       <p className="mt-2 text-xs text-yellow-300">{candidate.ineligibilityReasons.join(", ")}</p>
                     ) : null}


### PR DESCRIPTION
## Summary
- enrich routing explainability with `reasonText` and candidate-level `historyStats`
- propagate richer route decision details into learning overview and operator-facing UI surfaces
- remove duplicated route explain API contract drift from self-healing API types by aliasing the canonical provider report

## Validation
- `npm run build`
- `npx vitest run test/unit/providers/services/friday-provider-service.test.ts test/unit/providers/api/friday-provider-routes.test.ts`
- `npx vitest run test/e2e/api/friday-api-self-healing-routes.test.ts`
