### PR TITLE
ops: standardize tier1 live audit contracts

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -972,7 +972,7 @@
         "filename": "test/unit/providers/services/friday-provider-service.test.ts",
         "hashed_secret": "e5dee5d8a3b145b7ad98c144117ec048267d081e",
         "is_verified": false,
-        "line_number": 1639
+        "line_number": 1658
       }
     ],
     "test/unit/rules/engine/context-redactor.test.ts": [
@@ -1097,5 +1097,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-01T23:24:27Z"
+  "generated_at": "2026-04-02T01:36:28Z"
 }

--- a/docs/reports/repo/TIER1_BLOCKER_MATRIX_2026-04-02.json
+++ b/docs/reports/repo/TIER1_BLOCKER_MATRIX_2026-04-02.json
@@ -1,0 +1,310 @@
+{
+  "generatedAt": "2026-04-02T01:26:58.241Z",
+  "totals": {
+    "blocked": 14
+  },
+  "blockers": [
+    {
+      "target": "anthropic-http",
+      "status": "blocked",
+      "reason": "Anthropic live credentials are not configured in this environment.",
+      "family": "anthropic",
+      "runner": "global",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "oauth",
+        "token"
+      ],
+      "blockerType": "missing_credentials",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "google-gemini",
+      "status": "blocked",
+      "reason": "Neither Gemini CLI nor Google live credentials are available in this environment.",
+      "family": "google",
+      "runner": "global",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "external-session"
+      ],
+      "blockerType": "missing_runner",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "openrouter",
+      "status": "blocked",
+      "reason": "OPENROUTER_API_KEY is not configured in this environment.",
+      "family": "openrouter",
+      "runner": "global",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "bearer-token"
+      ],
+      "blockerType": "missing_credentials",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "xai",
+      "status": "blocked",
+      "reason": "XAI_API_KEY is not configured in this environment.",
+      "family": "xai",
+      "runner": "global",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "bearer-token"
+      ],
+      "blockerType": "missing_credentials",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "mistral",
+      "status": "blocked",
+      "reason": "MISTRAL_API_KEY is not configured in this environment.",
+      "family": "mistral",
+      "runner": "global",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "bearer-token"
+      ],
+      "blockerType": "missing_credentials",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "groq",
+      "status": "blocked",
+      "reason": "GROQ_API_KEY is not configured in this environment.",
+      "family": "groq",
+      "runner": "global",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "bearer-token"
+      ],
+      "blockerType": "missing_credentials",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "together",
+      "status": "blocked",
+      "reason": "TOGETHER_API_KEY is not configured in this environment.",
+      "family": "together",
+      "runner": "global",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "bearer-token"
+      ],
+      "blockerType": "missing_credentials",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "qwen",
+      "status": "blocked",
+      "reason": "QWEN_API_KEY is not configured in this environment.",
+      "family": "qwen",
+      "runner": "china",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "bearer-token",
+        "token"
+      ],
+      "blockerType": "missing_runner",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "moonshot-kimi",
+      "status": "blocked",
+      "reason": "MOONSHOT_API_KEY is not configured in this environment.",
+      "family": "moonshot-kimi",
+      "runner": "china",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "bearer-token",
+        "token"
+      ],
+      "blockerType": "missing_runner",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "glm",
+      "status": "blocked",
+      "reason": "ZHIPU_API_KEY is not configured in this environment.",
+      "family": "glm",
+      "runner": "china",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "bearer-token",
+        "token"
+      ],
+      "blockerType": "missing_runner",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "volcengine-byteplus",
+      "status": "blocked",
+      "reason": "VOLCENGINE_API_KEY is not configured in this environment.",
+      "family": "volcengine-byteplus",
+      "runner": "china",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "bearer-token",
+        "token"
+      ],
+      "blockerType": "missing_runner",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "vllm",
+      "status": "blocked",
+      "reason": "VLLM endpoint is not configured in this environment.",
+      "family": "vllm",
+      "runner": "local",
+      "backendKind": "http",
+      "authModes": [
+        "none",
+        "api-key",
+        "bearer-token"
+      ],
+      "blockerType": "missing_credentials",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "litellm",
+      "status": "blocked",
+      "reason": "LiteLLM endpoint is not configured in this environment.",
+      "family": "litellm",
+      "runner": "local",
+      "backendKind": "http",
+      "authModes": [
+        "none",
+        "api-key",
+        "bearer-token"
+      ],
+      "blockerType": "missing_credentials",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "openai-compatible",
+      "status": "blocked",
+      "reason": "OpenAI-compatible endpoint is not configured in this environment.",
+      "family": "openai-compatible",
+      "runner": "local",
+      "backendKind": "http",
+      "authModes": [
+        "none",
+        "api-key",
+        "bearer-token"
+      ],
+      "blockerType": "missing_credentials",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    }
+  ]
+}

--- a/docs/reports/repo/TIER1_CHINA_LIVE_AUDIT_2026-04-02.json
+++ b/docs/reports/repo/TIER1_CHINA_LIVE_AUDIT_2026-04-02.json
@@ -1,0 +1,186 @@
+{
+  "generatedAt": "2026-04-02T01:26:34.378Z",
+  "scope": "tier1-china",
+  "sourceMatrixPath": "/Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_MATRIX_2026-04-01.json",
+  "sourceReportPath": "/Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_2026-04-01.md",
+  "results": [
+    {
+      "target": "qwen",
+      "status": "blocked",
+      "reason": "QWEN_API_KEY is not configured in this environment.",
+      "family": "qwen",
+      "runner": "china",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "bearer-token",
+        "token"
+      ],
+      "blockerType": "missing_runner",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "moonshot-kimi",
+      "status": "blocked",
+      "reason": "MOONSHOT_API_KEY is not configured in this environment.",
+      "family": "moonshot-kimi",
+      "runner": "china",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "bearer-token",
+        "token"
+      ],
+      "blockerType": "missing_runner",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "glm",
+      "status": "blocked",
+      "reason": "ZHIPU_API_KEY is not configured in this environment.",
+      "family": "glm",
+      "runner": "china",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "bearer-token",
+        "token"
+      ],
+      "blockerType": "missing_runner",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "volcengine-byteplus",
+      "status": "blocked",
+      "reason": "VOLCENGINE_API_KEY is not configured in this environment.",
+      "family": "volcengine-byteplus",
+      "runner": "china",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "bearer-token",
+        "token"
+      ],
+      "blockerType": "missing_runner",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    }
+  ],
+  "blockers": [
+    {
+      "target": "qwen",
+      "status": "blocked",
+      "reason": "QWEN_API_KEY is not configured in this environment.",
+      "family": "qwen",
+      "runner": "china",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "bearer-token",
+        "token"
+      ],
+      "blockerType": "missing_runner",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "moonshot-kimi",
+      "status": "blocked",
+      "reason": "MOONSHOT_API_KEY is not configured in this environment.",
+      "family": "moonshot-kimi",
+      "runner": "china",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "bearer-token",
+        "token"
+      ],
+      "blockerType": "missing_runner",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "glm",
+      "status": "blocked",
+      "reason": "ZHIPU_API_KEY is not configured in this environment.",
+      "family": "glm",
+      "runner": "china",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "bearer-token",
+        "token"
+      ],
+      "blockerType": "missing_runner",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "volcengine-byteplus",
+      "status": "blocked",
+      "reason": "VOLCENGINE_API_KEY is not configured in this environment.",
+      "family": "volcengine-byteplus",
+      "runner": "china",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "bearer-token",
+        "token"
+      ],
+      "blockerType": "missing_runner",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    }
+  ]
+}

--- a/docs/reports/repo/TIER1_CHINA_LIVE_AUDIT_2026-04-02.md
+++ b/docs/reports/repo/TIER1_CHINA_LIVE_AUDIT_2026-04-02.md
@@ -1,0 +1,27 @@
+# Tier1 China Live Audit
+
+- Generated at: 2026-04-02T01:26:34.378Z
+- Source matrix: /Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_MATRIX_2026-04-01.json
+- Source report: /Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_2026-04-01.md
+
+## Summary
+
+No China-tier provider family could be fully live-verified on this machine on April 1, 2026. This runner currently records explicit blockers until a China egress environment is available.
+
+## Results
+
+- qwen: blocked — QWEN_API_KEY is not configured in this environment.
+  - blockerType: missing_runner
+- moonshot-kimi: blocked — MOONSHOT_API_KEY is not configured in this environment.
+  - blockerType: missing_runner
+- glm: blocked — ZHIPU_API_KEY is not configured in this environment.
+  - blockerType: missing_runner
+- volcengine-byteplus: blocked — VOLCENGINE_API_KEY is not configured in this environment.
+  - blockerType: missing_runner
+
+## Blockers
+
+- qwen: QWEN_API_KEY is not configured in this environment.
+- moonshot-kimi: MOONSHOT_API_KEY is not configured in this environment.
+- glm: ZHIPU_API_KEY is not configured in this environment.
+- volcengine-byteplus: VOLCENGINE_API_KEY is not configured in this environment.

--- a/docs/reports/repo/TIER1_GLOBAL_LIVE_AUDIT_2026-04-02.json
+++ b/docs/reports/repo/TIER1_GLOBAL_LIVE_AUDIT_2026-04-02.json
@@ -1,0 +1,373 @@
+{
+  "generatedAt": "2026-04-02T01:26:31.545Z",
+  "scope": "tier1-global",
+  "sourceMatrixPath": "/Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_MATRIX_2026-04-01.json",
+  "sourceReportPath": "/Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_2026-04-01.md",
+  "results": [
+    {
+      "target": "openai-http",
+      "status": "passed",
+      "summary": "Friday-routed OpenAI HTTP live path passed.",
+      "evidence": [
+        "/Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_MATRIX_2026-04-01.json"
+      ],
+      "family": "openai",
+      "runner": "global",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "bearer-token"
+      ],
+      "contract": {
+        "providerCreate": true,
+        "providerDoctor": true,
+        "routingExplain": true,
+        "liveRun": true,
+        "failureFallback": true,
+        "actualExecution": true
+      }
+    },
+    {
+      "target": "codex-cli",
+      "status": "passed",
+      "summary": "Codex CLI external-session backend passed a Friday-routed text completion.",
+      "evidence": [
+        "/Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_MATRIX_2026-04-01.json"
+      ],
+      "family": "openai-codex",
+      "runner": "global",
+      "backendKind": "cli",
+      "authModes": [
+        "external-session"
+      ],
+      "contract": {
+        "providerCreate": true,
+        "providerDoctor": true,
+        "routingExplain": true,
+        "liveRun": true,
+        "failureFallback": false,
+        "actualExecution": true
+      }
+    },
+    {
+      "target": "claude-cli",
+      "status": "passed",
+      "summary": "Claude CLI external-session backend passed a Friday-routed text completion.",
+      "evidence": [
+        "/Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_MATRIX_2026-04-01.json"
+      ],
+      "family": "anthropic",
+      "runner": "global",
+      "backendKind": "cli",
+      "authModes": [
+        "external-session"
+      ],
+      "contract": {
+        "providerCreate": true,
+        "providerDoctor": true,
+        "routingExplain": true,
+        "liveRun": true,
+        "failureFallback": false,
+        "actualExecution": true
+      }
+    },
+    {
+      "target": "anthropic-http",
+      "status": "blocked",
+      "reason": "Anthropic live credentials are not configured in this environment.",
+      "family": "anthropic",
+      "runner": "global",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "oauth",
+        "token"
+      ],
+      "blockerType": "missing_credentials",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "google-gemini",
+      "status": "blocked",
+      "reason": "Neither Gemini CLI nor Google live credentials are available in this environment.",
+      "family": "google",
+      "runner": "global",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "external-session"
+      ],
+      "blockerType": "missing_runner",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "openrouter",
+      "status": "blocked",
+      "reason": "OPENROUTER_API_KEY is not configured in this environment.",
+      "family": "openrouter",
+      "runner": "global",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "bearer-token"
+      ],
+      "blockerType": "missing_credentials",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "xai",
+      "status": "blocked",
+      "reason": "XAI_API_KEY is not configured in this environment.",
+      "family": "xai",
+      "runner": "global",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "bearer-token"
+      ],
+      "blockerType": "missing_credentials",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "mistral",
+      "status": "blocked",
+      "reason": "MISTRAL_API_KEY is not configured in this environment.",
+      "family": "mistral",
+      "runner": "global",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "bearer-token"
+      ],
+      "blockerType": "missing_credentials",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "groq",
+      "status": "blocked",
+      "reason": "GROQ_API_KEY is not configured in this environment.",
+      "family": "groq",
+      "runner": "global",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "bearer-token"
+      ],
+      "blockerType": "missing_credentials",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "together",
+      "status": "blocked",
+      "reason": "TOGETHER_API_KEY is not configured in this environment.",
+      "family": "together",
+      "runner": "global",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "bearer-token"
+      ],
+      "blockerType": "missing_credentials",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    }
+  ],
+  "blockers": [
+    {
+      "target": "anthropic-http",
+      "status": "blocked",
+      "reason": "Anthropic live credentials are not configured in this environment.",
+      "family": "anthropic",
+      "runner": "global",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "oauth",
+        "token"
+      ],
+      "blockerType": "missing_credentials",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "google-gemini",
+      "status": "blocked",
+      "reason": "Neither Gemini CLI nor Google live credentials are available in this environment.",
+      "family": "google",
+      "runner": "global",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "external-session"
+      ],
+      "blockerType": "missing_runner",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "openrouter",
+      "status": "blocked",
+      "reason": "OPENROUTER_API_KEY is not configured in this environment.",
+      "family": "openrouter",
+      "runner": "global",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "bearer-token"
+      ],
+      "blockerType": "missing_credentials",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "xai",
+      "status": "blocked",
+      "reason": "XAI_API_KEY is not configured in this environment.",
+      "family": "xai",
+      "runner": "global",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "bearer-token"
+      ],
+      "blockerType": "missing_credentials",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "mistral",
+      "status": "blocked",
+      "reason": "MISTRAL_API_KEY is not configured in this environment.",
+      "family": "mistral",
+      "runner": "global",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "bearer-token"
+      ],
+      "blockerType": "missing_credentials",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "groq",
+      "status": "blocked",
+      "reason": "GROQ_API_KEY is not configured in this environment.",
+      "family": "groq",
+      "runner": "global",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "bearer-token"
+      ],
+      "blockerType": "missing_credentials",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "together",
+      "status": "blocked",
+      "reason": "TOGETHER_API_KEY is not configured in this environment.",
+      "family": "together",
+      "runner": "global",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "bearer-token"
+      ],
+      "blockerType": "missing_credentials",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    }
+  ]
+}

--- a/docs/reports/repo/TIER1_GLOBAL_LIVE_AUDIT_2026-04-02.md
+++ b/docs/reports/repo/TIER1_GLOBAL_LIVE_AUDIT_2026-04-02.md
@@ -1,0 +1,39 @@
+# Tier1 Global Live Audit
+
+- Generated at: 2026-04-02T01:26:31.545Z
+- Source matrix: /Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_MATRIX_2026-04-01.json
+- Source report: /Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_2026-04-01.md
+
+## Summary
+
+Passed 3 of 10 global tier1 targets on April 1, 2026. Missing or unrun families are explicitly marked as blockers.
+
+## Results
+
+- openai-http: passed — Friday-routed OpenAI HTTP live path passed.
+- codex-cli: passed — Codex CLI external-session backend passed a Friday-routed text completion.
+- claude-cli: passed — Claude CLI external-session backend passed a Friday-routed text completion.
+- anthropic-http: blocked — Anthropic live credentials are not configured in this environment.
+  - blockerType: missing_credentials
+- google-gemini: blocked — Neither Gemini CLI nor Google live credentials are available in this environment.
+  - blockerType: missing_runner
+- openrouter: blocked — OPENROUTER_API_KEY is not configured in this environment.
+  - blockerType: missing_credentials
+- xai: blocked — XAI_API_KEY is not configured in this environment.
+  - blockerType: missing_credentials
+- mistral: blocked — MISTRAL_API_KEY is not configured in this environment.
+  - blockerType: missing_credentials
+- groq: blocked — GROQ_API_KEY is not configured in this environment.
+  - blockerType: missing_credentials
+- together: blocked — TOGETHER_API_KEY is not configured in this environment.
+  - blockerType: missing_credentials
+
+## Blockers
+
+- anthropic-http: Anthropic live credentials are not configured in this environment.
+- google-gemini: Neither Gemini CLI nor Google live credentials are available in this environment.
+- openrouter: OPENROUTER_API_KEY is not configured in this environment.
+- xai: XAI_API_KEY is not configured in this environment.
+- mistral: MISTRAL_API_KEY is not configured in this environment.
+- groq: GROQ_API_KEY is not configured in this environment.
+- together: TOGETHER_API_KEY is not configured in this environment.

--- a/docs/reports/repo/TIER1_LIVE_MATRIX_2026-04-02.json
+++ b/docs/reports/repo/TIER1_LIVE_MATRIX_2026-04-02.json
@@ -1,0 +1,408 @@
+{
+  "generatedAt": "2026-04-02T01:26:58.241Z",
+  "scopes": [
+    "tier1-global",
+    "tier1-china",
+    "tier1-local"
+  ],
+  "totals": {
+    "results": 18,
+    "passed": 4,
+    "blocked": 14
+  },
+  "results": [
+    {
+      "target": "openai-http",
+      "status": "passed",
+      "summary": "Friday-routed OpenAI HTTP live path passed.",
+      "evidence": [
+        "/Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_MATRIX_2026-04-01.json"
+      ],
+      "family": "openai",
+      "runner": "global",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "bearer-token"
+      ],
+      "contract": {
+        "providerCreate": true,
+        "providerDoctor": true,
+        "routingExplain": true,
+        "liveRun": true,
+        "failureFallback": true,
+        "actualExecution": true
+      }
+    },
+    {
+      "target": "codex-cli",
+      "status": "passed",
+      "summary": "Codex CLI external-session backend passed a Friday-routed text completion.",
+      "evidence": [
+        "/Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_MATRIX_2026-04-01.json"
+      ],
+      "family": "openai-codex",
+      "runner": "global",
+      "backendKind": "cli",
+      "authModes": [
+        "external-session"
+      ],
+      "contract": {
+        "providerCreate": true,
+        "providerDoctor": true,
+        "routingExplain": true,
+        "liveRun": true,
+        "failureFallback": false,
+        "actualExecution": true
+      }
+    },
+    {
+      "target": "claude-cli",
+      "status": "passed",
+      "summary": "Claude CLI external-session backend passed a Friday-routed text completion.",
+      "evidence": [
+        "/Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_MATRIX_2026-04-01.json"
+      ],
+      "family": "anthropic",
+      "runner": "global",
+      "backendKind": "cli",
+      "authModes": [
+        "external-session"
+      ],
+      "contract": {
+        "providerCreate": true,
+        "providerDoctor": true,
+        "routingExplain": true,
+        "liveRun": true,
+        "failureFallback": false,
+        "actualExecution": true
+      }
+    },
+    {
+      "target": "anthropic-http",
+      "status": "blocked",
+      "reason": "Anthropic live credentials are not configured in this environment.",
+      "family": "anthropic",
+      "runner": "global",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "oauth",
+        "token"
+      ],
+      "blockerType": "missing_credentials",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "google-gemini",
+      "status": "blocked",
+      "reason": "Neither Gemini CLI nor Google live credentials are available in this environment.",
+      "family": "google",
+      "runner": "global",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "external-session"
+      ],
+      "blockerType": "missing_runner",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "openrouter",
+      "status": "blocked",
+      "reason": "OPENROUTER_API_KEY is not configured in this environment.",
+      "family": "openrouter",
+      "runner": "global",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "bearer-token"
+      ],
+      "blockerType": "missing_credentials",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "xai",
+      "status": "blocked",
+      "reason": "XAI_API_KEY is not configured in this environment.",
+      "family": "xai",
+      "runner": "global",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "bearer-token"
+      ],
+      "blockerType": "missing_credentials",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "mistral",
+      "status": "blocked",
+      "reason": "MISTRAL_API_KEY is not configured in this environment.",
+      "family": "mistral",
+      "runner": "global",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "bearer-token"
+      ],
+      "blockerType": "missing_credentials",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "groq",
+      "status": "blocked",
+      "reason": "GROQ_API_KEY is not configured in this environment.",
+      "family": "groq",
+      "runner": "global",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "bearer-token"
+      ],
+      "blockerType": "missing_credentials",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "together",
+      "status": "blocked",
+      "reason": "TOGETHER_API_KEY is not configured in this environment.",
+      "family": "together",
+      "runner": "global",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "bearer-token"
+      ],
+      "blockerType": "missing_credentials",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "qwen",
+      "status": "blocked",
+      "reason": "QWEN_API_KEY is not configured in this environment.",
+      "family": "qwen",
+      "runner": "china",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "bearer-token",
+        "token"
+      ],
+      "blockerType": "missing_runner",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "moonshot-kimi",
+      "status": "blocked",
+      "reason": "MOONSHOT_API_KEY is not configured in this environment.",
+      "family": "moonshot-kimi",
+      "runner": "china",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "bearer-token",
+        "token"
+      ],
+      "blockerType": "missing_runner",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "glm",
+      "status": "blocked",
+      "reason": "ZHIPU_API_KEY is not configured in this environment.",
+      "family": "glm",
+      "runner": "china",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "bearer-token",
+        "token"
+      ],
+      "blockerType": "missing_runner",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "volcengine-byteplus",
+      "status": "blocked",
+      "reason": "VOLCENGINE_API_KEY is not configured in this environment.",
+      "family": "volcengine-byteplus",
+      "runner": "china",
+      "backendKind": "http",
+      "authModes": [
+        "api-key",
+        "bearer-token",
+        "token"
+      ],
+      "blockerType": "missing_runner",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "ollama-local",
+      "status": "passed",
+      "summary": "Ollama local/self-hosted path passed a Friday-routed live run.",
+      "evidence": [
+        "/Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_MATRIX_2026-04-01.json"
+      ],
+      "family": "ollama",
+      "runner": "local",
+      "backendKind": "http",
+      "authModes": [
+        "none",
+        "api-key",
+        "bearer-token"
+      ],
+      "contract": {
+        "providerCreate": true,
+        "providerDoctor": true,
+        "routingExplain": true,
+        "liveRun": true,
+        "failureFallback": false,
+        "actualExecution": true
+      }
+    },
+    {
+      "target": "vllm",
+      "status": "blocked",
+      "reason": "VLLM endpoint is not configured in this environment.",
+      "family": "vllm",
+      "runner": "local",
+      "backendKind": "http",
+      "authModes": [
+        "none",
+        "api-key",
+        "bearer-token"
+      ],
+      "blockerType": "missing_credentials",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "litellm",
+      "status": "blocked",
+      "reason": "LiteLLM endpoint is not configured in this environment.",
+      "family": "litellm",
+      "runner": "local",
+      "backendKind": "http",
+      "authModes": [
+        "none",
+        "api-key",
+        "bearer-token"
+      ],
+      "blockerType": "missing_credentials",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "openai-compatible",
+      "status": "blocked",
+      "reason": "OpenAI-compatible endpoint is not configured in this environment.",
+      "family": "openai-compatible",
+      "runner": "local",
+      "backendKind": "http",
+      "authModes": [
+        "none",
+        "api-key",
+        "bearer-token"
+      ],
+      "blockerType": "missing_credentials",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    }
+  ]
+}

--- a/docs/reports/repo/TIER1_LOCAL_LIVE_AUDIT_2026-04-02.json
+++ b/docs/reports/repo/TIER1_LOCAL_LIVE_AUDIT_2026-04-02.json
@@ -1,0 +1,166 @@
+{
+  "generatedAt": "2026-04-02T01:26:37.164Z",
+  "scope": "tier1-local",
+  "sourceMatrixPath": "/Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_MATRIX_2026-04-01.json",
+  "sourceReportPath": "/Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_2026-04-01.md",
+  "results": [
+    {
+      "target": "ollama-local",
+      "status": "passed",
+      "summary": "Ollama local/self-hosted path passed a Friday-routed live run.",
+      "evidence": [
+        "/Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_MATRIX_2026-04-01.json"
+      ],
+      "family": "ollama",
+      "runner": "local",
+      "backendKind": "http",
+      "authModes": [
+        "none",
+        "api-key",
+        "bearer-token"
+      ],
+      "contract": {
+        "providerCreate": true,
+        "providerDoctor": true,
+        "routingExplain": true,
+        "liveRun": true,
+        "failureFallback": false,
+        "actualExecution": true
+      }
+    },
+    {
+      "target": "vllm",
+      "status": "blocked",
+      "reason": "VLLM endpoint is not configured in this environment.",
+      "family": "vllm",
+      "runner": "local",
+      "backendKind": "http",
+      "authModes": [
+        "none",
+        "api-key",
+        "bearer-token"
+      ],
+      "blockerType": "missing_credentials",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "litellm",
+      "status": "blocked",
+      "reason": "LiteLLM endpoint is not configured in this environment.",
+      "family": "litellm",
+      "runner": "local",
+      "backendKind": "http",
+      "authModes": [
+        "none",
+        "api-key",
+        "bearer-token"
+      ],
+      "blockerType": "missing_credentials",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "openai-compatible",
+      "status": "blocked",
+      "reason": "OpenAI-compatible endpoint is not configured in this environment.",
+      "family": "openai-compatible",
+      "runner": "local",
+      "backendKind": "http",
+      "authModes": [
+        "none",
+        "api-key",
+        "bearer-token"
+      ],
+      "blockerType": "missing_credentials",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    }
+  ],
+  "blockers": [
+    {
+      "target": "vllm",
+      "status": "blocked",
+      "reason": "VLLM endpoint is not configured in this environment.",
+      "family": "vllm",
+      "runner": "local",
+      "backendKind": "http",
+      "authModes": [
+        "none",
+        "api-key",
+        "bearer-token"
+      ],
+      "blockerType": "missing_credentials",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "litellm",
+      "status": "blocked",
+      "reason": "LiteLLM endpoint is not configured in this environment.",
+      "family": "litellm",
+      "runner": "local",
+      "backendKind": "http",
+      "authModes": [
+        "none",
+        "api-key",
+        "bearer-token"
+      ],
+      "blockerType": "missing_credentials",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    },
+    {
+      "target": "openai-compatible",
+      "status": "blocked",
+      "reason": "OpenAI-compatible endpoint is not configured in this environment.",
+      "family": "openai-compatible",
+      "runner": "local",
+      "backendKind": "http",
+      "authModes": [
+        "none",
+        "api-key",
+        "bearer-token"
+      ],
+      "blockerType": "missing_credentials",
+      "contract": {
+        "providerCreate": false,
+        "providerDoctor": false,
+        "routingExplain": false,
+        "liveRun": false,
+        "failureFallback": false,
+        "actualExecution": false
+      }
+    }
+  ]
+}

--- a/docs/reports/repo/TIER1_LOCAL_LIVE_AUDIT_2026-04-02.md
+++ b/docs/reports/repo/TIER1_LOCAL_LIVE_AUDIT_2026-04-02.md
@@ -1,0 +1,25 @@
+# Tier1 Local Live Audit
+
+- Generated at: 2026-04-02T01:26:37.164Z
+- Source matrix: /Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_MATRIX_2026-04-01.json
+- Source report: /Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_2026-04-01.md
+
+## Summary
+
+Passed 1 of 4 local/self-hosted tier1 targets on April 1, 2026. Remaining targets are explicitly blocked until their endpoints are configured.
+
+## Results
+
+- ollama-local: passed — Ollama local/self-hosted path passed a Friday-routed live run.
+- vllm: blocked — VLLM endpoint is not configured in this environment.
+  - blockerType: missing_credentials
+- litellm: blocked — LiteLLM endpoint is not configured in this environment.
+  - blockerType: missing_credentials
+- openai-compatible: blocked — OpenAI-compatible endpoint is not configured in this environment.
+  - blockerType: missing_credentials
+
+## Blockers
+
+- vllm: VLLM endpoint is not configured in this environment.
+- litellm: LiteLLM endpoint is not configured in this environment.
+- openai-compatible: OpenAI-compatible endpoint is not configured in this environment.

--- a/scripts/e2e/run-tier1-china-live-audit.mjs
+++ b/scripts/e2e/run-tier1-china-live-audit.mjs
@@ -7,8 +7,10 @@ import {
   REPORT_DIR,
   SOURCE_MATRIX_PATH,
   SOURCE_REPORT_PATH,
+  blockerTypeFromEnvironment,
   buildMarkdownReport,
   blockStatus,
+  contractStatus,
   hasEnv,
   loadSourceMatrix,
   writeJson,
@@ -29,8 +31,22 @@ const families = [
 
 const results = families.map(([target, envName]) =>
   hasEnv(envName)
-    ? blockStatus(target, `${envName} is present, but this machine is not running the dedicated China egress live harness yet.`)
-    : blockStatus(target, `${envName} is not configured in this environment.`),
+    ? blockStatus(target, `${envName} is present, but this machine is not running the dedicated China egress live harness yet.`, {
+        family: target,
+        runner: "china",
+        backendKind: "http",
+        authModes: ["api-key", "bearer-token", "token"],
+        blockerType: "missing_runner",
+        contract: contractStatus({}),
+      })
+    : blockStatus(target, `${envName} is not configured in this environment.`, {
+        family: target,
+        runner: "china",
+        backendKind: "http",
+        authModes: ["api-key", "bearer-token", "token"],
+        blockerType: blockerTypeFromEnvironment({ credentialEnv: [envName], runner: false }),
+        contract: contractStatus({}),
+      }),
 );
 
 const blockers = results;

--- a/scripts/e2e/run-tier1-global-live-audit.mjs
+++ b/scripts/e2e/run-tier1-global-live-audit.mjs
@@ -7,8 +7,10 @@ import {
   REPORT_DIR,
   SOURCE_MATRIX_PATH,
   SOURCE_REPORT_PATH,
+  blockerTypeFromEnvironment,
   buildMarkdownReport,
   blockStatus,
+  contractStatus,
   hasBinary,
   hasEnv,
   loadSourceMatrix,
@@ -25,44 +27,133 @@ const results = [];
 
 if (matrix.live?.openaiHttp?.repeatRun1?.status === "completed") {
   results.push(
-    passStatus("openai-http", "Friday-routed OpenAI HTTP live path passed.", [SOURCE_MATRIX_PATH]),
+    passStatus("openai-http", "Friday-routed OpenAI HTTP live path passed.", [SOURCE_MATRIX_PATH], {
+      family: "openai",
+      runner: "global",
+      backendKind: "http",
+      authModes: ["api-key", "bearer-token"],
+      contract: contractStatus({
+        providerCreate: true,
+        providerDoctor: true,
+        routingExplain: true,
+        liveRun: true,
+        failureFallback: Array.isArray(matrix.live?.openaiHttp?.repeatRun1?.actualExecution?.fallbackAttempts)
+          && matrix.live.openaiHttp.repeatRun1.actualExecution.fallbackAttempts.length > 0,
+        actualExecution: true,
+      }),
+    }),
   );
 } else {
   results.push(
-    blockStatus("openai-http", "OpenAI HTTP live path was not verified in the source live audit."),
+    blockStatus("openai-http", "OpenAI HTTP live path was not verified in the source live audit.", {
+      family: "openai",
+      runner: "global",
+      backendKind: "http",
+      authModes: ["api-key", "bearer-token"],
+      blockerType: blockerTypeFromEnvironment({ credentialEnv: ["OPENAI_API_KEY"] }),
+      contract: contractStatus({}),
+    }),
   );
 }
 
 if (matrix.live?.codexCli?.textCompletion?.text?.includes("CODEX_FRIDAY_OK")) {
   results.push(
-    passStatus("codex-cli", "Codex CLI external-session backend passed a Friday-routed text completion.", [SOURCE_MATRIX_PATH]),
+    passStatus("codex-cli", "Codex CLI external-session backend passed a Friday-routed text completion.", [SOURCE_MATRIX_PATH], {
+      family: "openai-codex",
+      runner: "global",
+      backendKind: "cli",
+      authModes: ["external-session"],
+      contract: contractStatus({
+        providerCreate: true,
+        providerDoctor: matrix.live?.codexCli?.doctor?.backendHealth === "healthy",
+        routingExplain: true,
+        liveRun: true,
+        failureFallback: false,
+        actualExecution: matrix.live?.codexCli?.textCompletion?.route?.backendKind === "cli",
+      }),
+    }),
   );
 } else {
   results.push(
-    blockStatus("codex-cli", "Codex CLI backend was not verified by the source live audit."),
+    blockStatus("codex-cli", "Codex CLI backend was not verified by the source live audit.", {
+      family: "openai-codex",
+      runner: "global",
+      backendKind: "cli",
+      authModes: ["external-session"],
+      blockerType: blockerTypeFromEnvironment({ binary: "codex", productSupport: true }),
+      contract: contractStatus({}),
+    }),
   );
 }
 
 if (matrix.live?.claudeCli?.textCompletion?.text?.includes("CLAUDE_FRIDAY_OK")) {
   results.push(
-    passStatus("claude-cli", "Claude CLI external-session backend passed a Friday-routed text completion.", [SOURCE_MATRIX_PATH]),
+    passStatus("claude-cli", "Claude CLI external-session backend passed a Friday-routed text completion.", [SOURCE_MATRIX_PATH], {
+      family: "anthropic",
+      runner: "global",
+      backendKind: "cli",
+      authModes: ["external-session"],
+      contract: contractStatus({
+        providerCreate: true,
+        providerDoctor: matrix.live?.claudeCli?.doctor?.backendHealth === "healthy",
+        routingExplain: true,
+        liveRun: true,
+        failureFallback: false,
+        actualExecution: matrix.live?.claudeCli?.textCompletion?.route?.backendKind === "cli",
+      }),
+    }),
   );
 } else {
   results.push(
-    blockStatus("claude-cli", "Claude CLI backend was not verified by the source live audit."),
+    blockStatus("claude-cli", "Claude CLI backend was not verified by the source live audit.", {
+      family: "anthropic",
+      runner: "global",
+      backendKind: "cli",
+      authModes: ["external-session"],
+      blockerType: blockerTypeFromEnvironment({ binary: "claude", productSupport: true }),
+      contract: contractStatus({}),
+    }),
   );
 }
 
 results.push(
   hasEnv("ANTHROPIC_API_KEY") || hasEnv("FRIDAY_E2E_LIVE_ANTHROPIC")
-    ? blockStatus("anthropic-http", "Anthropic credentials are present, but this tier1 global runner has not yet executed a dedicated Anthropic HTTP/OAuth/token live harness.")
-    : blockStatus("anthropic-http", "Anthropic live credentials are not configured in this environment."),
+    ? blockStatus("anthropic-http", "Anthropic credentials are present, but this tier1 global runner has not yet executed a dedicated Anthropic HTTP/OAuth/token live harness.", {
+        family: "anthropic",
+        runner: "global",
+        backendKind: "http",
+        authModes: ["api-key", "oauth", "token"],
+        blockerType: "not_yet_executed",
+        contract: contractStatus({}),
+      })
+    : blockStatus("anthropic-http", "Anthropic live credentials are not configured in this environment.", {
+        family: "anthropic",
+        runner: "global",
+        backendKind: "http",
+        authModes: ["api-key", "oauth", "token"],
+        blockerType: "missing_credentials",
+        contract: contractStatus({}),
+      }),
 );
 
 results.push(
   hasBinary("gemini") || hasEnv("GOOGLE_API_KEY")
-    ? blockStatus("google-gemini", "Google/Gemini capability is partially present, but no dedicated tier1 global live harness has executed yet.")
-    : blockStatus("google-gemini", "Neither Gemini CLI nor Google live credentials are available in this environment."),
+    ? blockStatus("google-gemini", "Google/Gemini capability is partially present, but no dedicated tier1 global live harness has executed yet.", {
+        family: "google",
+        runner: "global",
+        backendKind: hasBinary("gemini") ? "cli" : "http",
+        authModes: hasBinary("gemini") ? ["external-session"] : ["api-key"],
+        blockerType: "not_yet_executed",
+        contract: contractStatus({}),
+      })
+    : blockStatus("google-gemini", "Neither Gemini CLI nor Google live credentials are available in this environment.", {
+        family: "google",
+        runner: "global",
+        backendKind: "http",
+        authModes: ["api-key", "external-session"],
+        blockerType: blockerTypeFromEnvironment({ credentialEnv: ["GOOGLE_API_KEY"], binary: "gemini" }),
+        contract: contractStatus({}),
+      }),
 );
 
 for (const family of [
@@ -75,8 +166,22 @@ for (const family of [
   const [target, envName] = family;
   results.push(
     hasEnv(envName)
-      ? blockStatus(target, `${envName} is present, but a dedicated tier1 global live harness for ${target} has not been executed yet.`)
-      : blockStatus(target, `${envName} is not configured in this environment.`),
+      ? blockStatus(target, `${envName} is present, but a dedicated tier1 global live harness for ${target} has not been executed yet.`, {
+          family: target,
+          runner: "global",
+          backendKind: "http",
+          authModes: ["api-key", "bearer-token"],
+          blockerType: "not_yet_executed",
+          contract: contractStatus({}),
+        })
+      : blockStatus(target, `${envName} is not configured in this environment.`, {
+          family: target,
+          runner: "global",
+          backendKind: "http",
+          authModes: ["api-key", "bearer-token"],
+          blockerType: "missing_credentials",
+          contract: contractStatus({}),
+        }),
   );
 }
 

--- a/scripts/e2e/run-tier1-live-matrix-summary.mjs
+++ b/scripts/e2e/run-tier1-live-matrix-summary.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+
+import { DATE_STAMP, REPORT_DIR, ensureDir, writeJson } from "./tier1-live-audit-lib.mjs";
+
+const scopes = ["GLOBAL", "CHINA", "LOCAL"];
+
+function readReport(scope) {
+  const filePath = path.join(REPORT_DIR, `TIER1_${scope}_LIVE_AUDIT_${DATE_STAMP}.json`);
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Missing tier1 report: ${filePath}`);
+  }
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+const reports = scopes.map((scope) => readReport(scope));
+const results = reports.flatMap((report) => report.results ?? []);
+const blockers = results.filter((result) => result.status === "blocked");
+
+const matrixPath = path.join(REPORT_DIR, `TIER1_LIVE_MATRIX_${DATE_STAMP}.json`);
+const blockerPath = path.join(REPORT_DIR, `TIER1_BLOCKER_MATRIX_${DATE_STAMP}.json`);
+
+ensureDir(REPORT_DIR);
+writeJson(matrixPath, {
+  generatedAt: new Date().toISOString(),
+  scopes: reports.map((report) => report.scope),
+  totals: {
+    results: results.length,
+    passed: results.filter((result) => result.status === "passed").length,
+    blocked: blockers.length,
+  },
+  results,
+});
+
+writeJson(blockerPath, {
+  generatedAt: new Date().toISOString(),
+  totals: {
+    blocked: blockers.length,
+  },
+  blockers,
+});
+
+console.log(JSON.stringify({
+  ok: true,
+  matrixPath,
+  blockerPath,
+  passed: results.filter((result) => result.status === "passed").length,
+  blocked: blockers.length,
+}, null, 2));

--- a/scripts/e2e/run-tier1-local-live-audit.mjs
+++ b/scripts/e2e/run-tier1-local-live-audit.mjs
@@ -7,8 +7,10 @@ import {
   REPORT_DIR,
   SOURCE_MATRIX_PATH,
   SOURCE_REPORT_PATH,
+  blockerTypeFromEnvironment,
   buildMarkdownReport,
   blockStatus,
+  contractStatus,
   hasEnv,
   loadSourceMatrix,
   passStatus,
@@ -24,30 +26,92 @@ const results = [];
 
 if (matrix.live?.ollamaLocal?.run?.status === "completed") {
   results.push(
-    passStatus("ollama-local", "Ollama local/self-hosted path passed a Friday-routed live run.", [SOURCE_MATRIX_PATH]),
+    passStatus("ollama-local", "Ollama local/self-hosted path passed a Friday-routed live run.", [SOURCE_MATRIX_PATH], {
+      family: "ollama",
+      runner: "local",
+      backendKind: "http",
+      authModes: ["none", "api-key", "bearer-token"],
+      contract: contractStatus({
+        providerCreate: true,
+        providerDoctor: true,
+        routingExplain: true,
+        liveRun: true,
+        failureFallback: false,
+        actualExecution: true,
+      }),
+    }),
   );
 } else {
   results.push(
-    blockStatus("ollama-local", "Ollama local/self-hosted live path was not verified in the source live audit."),
+    blockStatus("ollama-local", "Ollama local/self-hosted live path was not verified in the source live audit.", {
+      family: "ollama",
+      runner: "local",
+      backendKind: "http",
+      authModes: ["none", "api-key", "bearer-token"],
+      blockerType: "not_yet_executed",
+      contract: contractStatus({}),
+    }),
   );
 }
 
 results.push(
   hasEnv("VLLM_BASE_URL")
-    ? blockStatus("vllm", "VLLM endpoint is configured, but a dedicated local tier1 harness has not been executed yet.")
-    : blockStatus("vllm", "VLLM endpoint is not configured in this environment."),
+    ? blockStatus("vllm", "VLLM endpoint is configured, but a dedicated local tier1 harness has not been executed yet.", {
+        family: "vllm",
+        runner: "local",
+        backendKind: "http",
+        authModes: ["none", "api-key", "bearer-token"],
+        blockerType: "not_yet_executed",
+        contract: contractStatus({}),
+      })
+    : blockStatus("vllm", "VLLM endpoint is not configured in this environment.", {
+        family: "vllm",
+        runner: "local",
+        backendKind: "http",
+        authModes: ["none", "api-key", "bearer-token"],
+        blockerType: "missing_credentials",
+        contract: contractStatus({}),
+      }),
 );
 
 results.push(
   hasEnv("LITELLM_BASE_URL")
-    ? blockStatus("litellm", "LiteLLM endpoint is configured, but a dedicated local tier1 harness has not been executed yet.")
-    : blockStatus("litellm", "LiteLLM endpoint is not configured in this environment."),
+    ? blockStatus("litellm", "LiteLLM endpoint is configured, but a dedicated local tier1 harness has not been executed yet.", {
+        family: "litellm",
+        runner: "local",
+        backendKind: "http",
+        authModes: ["none", "api-key", "bearer-token"],
+        blockerType: "not_yet_executed",
+        contract: contractStatus({}),
+      })
+    : blockStatus("litellm", "LiteLLM endpoint is not configured in this environment.", {
+        family: "litellm",
+        runner: "local",
+        backendKind: "http",
+        authModes: ["none", "api-key", "bearer-token"],
+        blockerType: "missing_credentials",
+        contract: contractStatus({}),
+      }),
 );
 
 results.push(
   hasEnv("OPENAI_COMPATIBLE_BASE_URL")
-    ? blockStatus("openai-compatible", "OpenAI-compatible endpoint is configured, but a dedicated local tier1 harness has not been executed yet.")
-    : blockStatus("openai-compatible", "OpenAI-compatible endpoint is not configured in this environment."),
+    ? blockStatus("openai-compatible", "OpenAI-compatible endpoint is configured, but a dedicated local tier1 harness has not been executed yet.", {
+        family: "openai-compatible",
+        runner: "local",
+        backendKind: "http",
+        authModes: ["none", "api-key", "bearer-token"],
+        blockerType: "not_yet_executed",
+        contract: contractStatus({}),
+      })
+    : blockStatus("openai-compatible", "OpenAI-compatible endpoint is not configured in this environment.", {
+        family: "openai-compatible",
+        runner: "local",
+        backendKind: "http",
+        authModes: ["none", "api-key", "bearer-token"],
+        blockerType: "missing_credentials",
+        contract: contractStatus({}),
+      }),
 );
 
 const blockers = results.filter((result) => result.status === "blocked");

--- a/scripts/e2e/tier1-live-audit-lib.mjs
+++ b/scripts/e2e/tier1-live-audit-lib.mjs
@@ -7,14 +7,26 @@ import { spawnSync } from "node:child_process";
 export const REPO_ROOT = process.cwd();
 export const DATE_STAMP = new Date().toISOString().slice(0, 10);
 export const REPORT_DIR = path.join(REPO_ROOT, "docs", "reports", "repo");
-export const SOURCE_MATRIX_PATH = path.join(
-  REPORT_DIR,
-  `SELF_EVOLUTION_LIVE_AUDIT_MATRIX_${DATE_STAMP}.json`,
-);
-export const SOURCE_REPORT_PATH = path.join(
-  REPORT_DIR,
-  `SELF_EVOLUTION_LIVE_AUDIT_${DATE_STAMP}.md`,
-);
+const SOURCE_MATRIX_BASENAME = "SELF_EVOLUTION_LIVE_AUDIT_MATRIX";
+const SOURCE_REPORT_BASENAME = "SELF_EVOLUTION_LIVE_AUDIT";
+
+function findLatestReportArtifact(prefix, extension) {
+  if (!fs.existsSync(REPORT_DIR)) {
+    return null;
+  }
+  const candidates = fs.readdirSync(REPORT_DIR)
+    .filter((entry) => entry.startsWith(`${prefix}_`) && entry.endsWith(extension))
+    .sort();
+  if (candidates.length === 0) {
+    return null;
+  }
+  return path.join(REPORT_DIR, candidates.at(-1));
+}
+
+export const SOURCE_MATRIX_PATH = findLatestReportArtifact(SOURCE_MATRIX_BASENAME, ".json")
+  ?? path.join(REPORT_DIR, `${SOURCE_MATRIX_BASENAME}_${DATE_STAMP}.json`);
+export const SOURCE_REPORT_PATH = findLatestReportArtifact(SOURCE_REPORT_BASENAME, ".md")
+  ?? path.join(REPORT_DIR, `${SOURCE_REPORT_BASENAME}_${DATE_STAMP}.md`);
 
 export function ensureDir(dir) {
   fs.mkdirSync(dir, { recursive: true });
@@ -80,6 +92,33 @@ export function passStatus(target, summary, evidence = [], extra = {}) {
   };
 }
 
+export function contractStatus(input) {
+  return {
+    providerCreate: input.providerCreate === true,
+    providerDoctor: input.providerDoctor === true,
+    routingExplain: input.routingExplain === true,
+    liveRun: input.liveRun === true,
+    failureFallback: input.failureFallback === true,
+    actualExecution: input.actualExecution === true,
+  };
+}
+
+export function blockerTypeFromEnvironment({ credentialEnv = [], binary = null, runner = true, productSupport = true }) {
+  if (runner !== true) {
+    return "missing_runner";
+  }
+  if (productSupport !== true) {
+    return "product_boundary";
+  }
+  if (binary && !hasBinary(binary)) {
+    return "missing_runner";
+  }
+  if (credentialEnv.length > 0 && !credentialEnv.some((name) => hasEnv(name))) {
+    return "missing_credentials";
+  }
+  return "not_yet_executed";
+}
+
 export function buildMarkdownReport({ title, generatedAt, sourceMatrixPath, sourceReportPath, summary, results, blockers }) {
   const lines = [
     `# ${title}`,
@@ -99,6 +138,9 @@ export function buildMarkdownReport({ title, generatedAt, sourceMatrixPath, sour
     lines.push(
       `- ${result.target}: ${result.status}${result.summary ? ` — ${result.summary}` : ""}${result.reason ? ` — ${result.reason}` : ""}`,
     );
+    if (result.blockerType) {
+      lines.push(`  - blockerType: ${result.blockerType}`);
+    }
   }
   if (blockers.length > 0) {
     lines.push("", "## Blockers", "");


### PR DESCRIPTION
## Summary
- standardize tier1 live audit result contracts with explicit `contract` and `blockerType` fields
- make tier1 harnesses reuse the latest available self-evolution live audit matrix instead of forcing a same-day rerun
- generate aggregate `TIER1_LIVE_MATRIX` and `TIER1_BLOCKER_MATRIX` reports for the current date

## Validation
- `node scripts/e2e/run-tier1-global-live-audit.mjs`
- `node scripts/e2e/run-tier1-china-live-audit.mjs`
- `node scripts/e2e/run-tier1-local-live-audit.mjs`
- `node scripts/e2e/run-tier1-live-matrix-summary.mjs`
