### PR TITLE
[codex] tighten closure evidence and tier1 reporting

### DIFF
--- a/docs/current-source-of-truth.md
+++ b/docs/current-source-of-truth.md
@@ -57,7 +57,7 @@ This document is the current architecture reference for steady-state Friday runt
 
 - Public route families `/v1/diagnosis/*`, `/v1/auto-fix/*`, and `/v1/uix/*` are part of the active steady-state product surface.
 - Self-healing is supervised by default: higher-risk fixes require explicit approval, and rollback/evidence are part of the public contract.
-- Auto-fix execution is active, but only a subset is hub-wired operational side effects today. `disable_skill` is hub-backed; `retry_node`, `switch_model_fallback`, `trim_payload`, `apply_config_patch`, `grant_permission`, and `pause_workflow` currently execute via deterministic directive-level executors/verifiers that produce verification evidence without claiming full runtime-side automation.
+- Auto-fix execution is active. `disable_skill`, `retry_node`, `switch_model_fallback`, `trim_payload`, and `pause_workflow` now execute through hub-wired executors/verifiers that produce runtime-side effects plus verification evidence. `apply_config_patch` and `grant_permission` remain approval-gated deterministic directive-level executors/verifiers and are not yet hub-wired operational side effects.
 - Failures must surface as incidents, diagnoses, actions, or evidence; do not hide self-healing failures behind silent fallback.
 - `/assistant` is the beginner-first web surface for plain-language intent resolution, guided wizards, issue inbox, fix approvals, and direct skill generation.
 - Expert autonomy is an opt-in layer above the supervised defaults. It may infer bounded context, run safe probes, and continue through cross-surface reasoning, but destructive or production-sensitive actions still require final approval.
@@ -166,7 +166,7 @@ This document is the current architecture reference for steady-state Friday runt
 - The self-learning context enrichment service is wired through hub bootstrap (`_learningContextRef`) and becomes available after self-learning runtime creation.
 - Persona settings affect wording, guidance, and clarification style only. They must not weaken approval gates, rollback rules, or destructive-action safeguards.
 - Guided wizard contexts in `/assistant` are persisted in SQLite (`uix_guided_contexts`) and can be resumed after service restart. Onboarding session progress is also persisted in SQLite (`uix_onboarding_sessions`) and restored on boot.
-- Learning feedback is not yet user-visible. Users cannot inspect or edit learned preference facts through any current UI surface.
+- Learned preference facts are now user-visible through `/v1/uix/learned-facts` and the current Home/Settings UI surfaces. Direct editing of learned preference facts is not yet part of the current UI surface.
 
 ## Runtime admin and security surfaces
 

--- a/docs/reports/repo/TIER1_BLOCKER_MATRIX_2026-04-02.json
+++ b/docs/reports/repo/TIER1_BLOCKER_MATRIX_2026-04-02.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-02T01:26:58.241Z",
+  "generatedAt": "2026-04-02T03:30:31.733Z",
   "totals": {
     "blocked": 14
   },
@@ -8,6 +8,10 @@
       "target": "anthropic-http",
       "status": "blocked",
       "reason": "Anthropic live credentials are not configured in this environment.",
+      "blockerType": "missing_credentials",
+      "blockerTypes": [
+        "missing_credentials"
+      ],
       "family": "anthropic",
       "runner": "global",
       "backendKind": "http",
@@ -16,7 +20,11 @@
         "oauth",
         "token"
       ],
-      "blockerType": "missing_credentials",
+      "requiredEnv": [
+        "ANTHROPIC_API_KEY",
+        "FRIDAY_E2E_LIVE_ANTHROPIC"
+      ],
+      "requiredRunner": "global-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -30,6 +38,11 @@
       "target": "google-gemini",
       "status": "blocked",
       "reason": "Neither Gemini CLI nor Google live credentials are available in this environment.",
+      "blockerType": "missing_runner",
+      "blockerTypes": [
+        "missing_runner",
+        "missing_credentials"
+      ],
       "family": "google",
       "runner": "global",
       "backendKind": "http",
@@ -37,7 +50,11 @@
         "api-key",
         "external-session"
       ],
-      "blockerType": "missing_runner",
+      "requiredEnv": [
+        "GOOGLE_API_KEY"
+      ],
+      "requiredBinary": "gemini",
+      "requiredRunner": "global-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -51,6 +68,10 @@
       "target": "openrouter",
       "status": "blocked",
       "reason": "OPENROUTER_API_KEY is not configured in this environment.",
+      "blockerType": "missing_credentials",
+      "blockerTypes": [
+        "missing_credentials"
+      ],
       "family": "openrouter",
       "runner": "global",
       "backendKind": "http",
@@ -58,7 +79,10 @@
         "api-key",
         "bearer-token"
       ],
-      "blockerType": "missing_credentials",
+      "requiredEnv": [
+        "OPENROUTER_API_KEY"
+      ],
+      "requiredRunner": "global-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -72,6 +96,10 @@
       "target": "xai",
       "status": "blocked",
       "reason": "XAI_API_KEY is not configured in this environment.",
+      "blockerType": "missing_credentials",
+      "blockerTypes": [
+        "missing_credentials"
+      ],
       "family": "xai",
       "runner": "global",
       "backendKind": "http",
@@ -79,7 +107,10 @@
         "api-key",
         "bearer-token"
       ],
-      "blockerType": "missing_credentials",
+      "requiredEnv": [
+        "XAI_API_KEY"
+      ],
+      "requiredRunner": "global-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -93,6 +124,10 @@
       "target": "mistral",
       "status": "blocked",
       "reason": "MISTRAL_API_KEY is not configured in this environment.",
+      "blockerType": "missing_credentials",
+      "blockerTypes": [
+        "missing_credentials"
+      ],
       "family": "mistral",
       "runner": "global",
       "backendKind": "http",
@@ -100,7 +135,10 @@
         "api-key",
         "bearer-token"
       ],
-      "blockerType": "missing_credentials",
+      "requiredEnv": [
+        "MISTRAL_API_KEY"
+      ],
+      "requiredRunner": "global-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -114,6 +152,10 @@
       "target": "groq",
       "status": "blocked",
       "reason": "GROQ_API_KEY is not configured in this environment.",
+      "blockerType": "missing_credentials",
+      "blockerTypes": [
+        "missing_credentials"
+      ],
       "family": "groq",
       "runner": "global",
       "backendKind": "http",
@@ -121,7 +163,10 @@
         "api-key",
         "bearer-token"
       ],
-      "blockerType": "missing_credentials",
+      "requiredEnv": [
+        "GROQ_API_KEY"
+      ],
+      "requiredRunner": "global-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -135,6 +180,10 @@
       "target": "together",
       "status": "blocked",
       "reason": "TOGETHER_API_KEY is not configured in this environment.",
+      "blockerType": "missing_credentials",
+      "blockerTypes": [
+        "missing_credentials"
+      ],
       "family": "together",
       "runner": "global",
       "backendKind": "http",
@@ -142,7 +191,10 @@
         "api-key",
         "bearer-token"
       ],
-      "blockerType": "missing_credentials",
+      "requiredEnv": [
+        "TOGETHER_API_KEY"
+      ],
+      "requiredRunner": "global-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -156,6 +208,11 @@
       "target": "qwen",
       "status": "blocked",
       "reason": "QWEN_API_KEY is not configured in this environment.",
+      "blockerType": "missing_runner",
+      "blockerTypes": [
+        "missing_runner",
+        "missing_credentials"
+      ],
       "family": "qwen",
       "runner": "china",
       "backendKind": "http",
@@ -164,7 +221,10 @@
         "bearer-token",
         "token"
       ],
-      "blockerType": "missing_runner",
+      "requiredEnv": [
+        "QWEN_API_KEY"
+      ],
+      "requiredRunner": "china-egress-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -178,6 +238,11 @@
       "target": "moonshot-kimi",
       "status": "blocked",
       "reason": "MOONSHOT_API_KEY is not configured in this environment.",
+      "blockerType": "missing_runner",
+      "blockerTypes": [
+        "missing_runner",
+        "missing_credentials"
+      ],
       "family": "moonshot-kimi",
       "runner": "china",
       "backendKind": "http",
@@ -186,7 +251,10 @@
         "bearer-token",
         "token"
       ],
-      "blockerType": "missing_runner",
+      "requiredEnv": [
+        "MOONSHOT_API_KEY"
+      ],
+      "requiredRunner": "china-egress-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -200,6 +268,11 @@
       "target": "glm",
       "status": "blocked",
       "reason": "ZHIPU_API_KEY is not configured in this environment.",
+      "blockerType": "missing_runner",
+      "blockerTypes": [
+        "missing_runner",
+        "missing_credentials"
+      ],
       "family": "glm",
       "runner": "china",
       "backendKind": "http",
@@ -208,7 +281,10 @@
         "bearer-token",
         "token"
       ],
-      "blockerType": "missing_runner",
+      "requiredEnv": [
+        "ZHIPU_API_KEY"
+      ],
+      "requiredRunner": "china-egress-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -222,6 +298,11 @@
       "target": "volcengine-byteplus",
       "status": "blocked",
       "reason": "VOLCENGINE_API_KEY is not configured in this environment.",
+      "blockerType": "missing_runner",
+      "blockerTypes": [
+        "missing_runner",
+        "missing_credentials"
+      ],
       "family": "volcengine-byteplus",
       "runner": "china",
       "backendKind": "http",
@@ -230,7 +311,10 @@
         "bearer-token",
         "token"
       ],
-      "blockerType": "missing_runner",
+      "requiredEnv": [
+        "VOLCENGINE_API_KEY"
+      ],
+      "requiredRunner": "china-egress-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -244,6 +328,10 @@
       "target": "vllm",
       "status": "blocked",
       "reason": "VLLM endpoint is not configured in this environment.",
+      "blockerType": "missing_endpoint",
+      "blockerTypes": [
+        "missing_endpoint"
+      ],
       "family": "vllm",
       "runner": "local",
       "backendKind": "http",
@@ -252,7 +340,10 @@
         "api-key",
         "bearer-token"
       ],
-      "blockerType": "missing_credentials",
+      "requiredEnv": [
+        "VLLM_BASE_URL"
+      ],
+      "requiredRunner": "local-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -266,6 +357,10 @@
       "target": "litellm",
       "status": "blocked",
       "reason": "LiteLLM endpoint is not configured in this environment.",
+      "blockerType": "missing_endpoint",
+      "blockerTypes": [
+        "missing_endpoint"
+      ],
       "family": "litellm",
       "runner": "local",
       "backendKind": "http",
@@ -274,7 +369,10 @@
         "api-key",
         "bearer-token"
       ],
-      "blockerType": "missing_credentials",
+      "requiredEnv": [
+        "LITELLM_BASE_URL"
+      ],
+      "requiredRunner": "local-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -288,6 +386,10 @@
       "target": "openai-compatible",
       "status": "blocked",
       "reason": "OpenAI-compatible endpoint is not configured in this environment.",
+      "blockerType": "missing_endpoint",
+      "blockerTypes": [
+        "missing_endpoint"
+      ],
       "family": "openai-compatible",
       "runner": "local",
       "backendKind": "http",
@@ -296,7 +398,10 @@
         "api-key",
         "bearer-token"
       ],
-      "blockerType": "missing_credentials",
+      "requiredEnv": [
+        "OPENAI_COMPATIBLE_BASE_URL"
+      ],
+      "requiredRunner": "local-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,

--- a/docs/reports/repo/TIER1_CHINA_LIVE_AUDIT_2026-04-02.json
+++ b/docs/reports/repo/TIER1_CHINA_LIVE_AUDIT_2026-04-02.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-02T01:26:34.378Z",
+  "generatedAt": "2026-04-02T03:30:31.696Z",
   "scope": "tier1-china",
   "sourceMatrixPath": "/Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_MATRIX_2026-04-01.json",
   "sourceReportPath": "/Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_2026-04-01.md",
@@ -8,6 +8,11 @@
       "target": "qwen",
       "status": "blocked",
       "reason": "QWEN_API_KEY is not configured in this environment.",
+      "blockerType": "missing_runner",
+      "blockerTypes": [
+        "missing_runner",
+        "missing_credentials"
+      ],
       "family": "qwen",
       "runner": "china",
       "backendKind": "http",
@@ -16,7 +21,10 @@
         "bearer-token",
         "token"
       ],
-      "blockerType": "missing_runner",
+      "requiredEnv": [
+        "QWEN_API_KEY"
+      ],
+      "requiredRunner": "china-egress-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -30,6 +38,11 @@
       "target": "moonshot-kimi",
       "status": "blocked",
       "reason": "MOONSHOT_API_KEY is not configured in this environment.",
+      "blockerType": "missing_runner",
+      "blockerTypes": [
+        "missing_runner",
+        "missing_credentials"
+      ],
       "family": "moonshot-kimi",
       "runner": "china",
       "backendKind": "http",
@@ -38,7 +51,10 @@
         "bearer-token",
         "token"
       ],
-      "blockerType": "missing_runner",
+      "requiredEnv": [
+        "MOONSHOT_API_KEY"
+      ],
+      "requiredRunner": "china-egress-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -52,6 +68,11 @@
       "target": "glm",
       "status": "blocked",
       "reason": "ZHIPU_API_KEY is not configured in this environment.",
+      "blockerType": "missing_runner",
+      "blockerTypes": [
+        "missing_runner",
+        "missing_credentials"
+      ],
       "family": "glm",
       "runner": "china",
       "backendKind": "http",
@@ -60,7 +81,10 @@
         "bearer-token",
         "token"
       ],
-      "blockerType": "missing_runner",
+      "requiredEnv": [
+        "ZHIPU_API_KEY"
+      ],
+      "requiredRunner": "china-egress-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -74,6 +98,11 @@
       "target": "volcengine-byteplus",
       "status": "blocked",
       "reason": "VOLCENGINE_API_KEY is not configured in this environment.",
+      "blockerType": "missing_runner",
+      "blockerTypes": [
+        "missing_runner",
+        "missing_credentials"
+      ],
       "family": "volcengine-byteplus",
       "runner": "china",
       "backendKind": "http",
@@ -82,7 +111,10 @@
         "bearer-token",
         "token"
       ],
-      "blockerType": "missing_runner",
+      "requiredEnv": [
+        "VOLCENGINE_API_KEY"
+      ],
+      "requiredRunner": "china-egress-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -98,6 +130,11 @@
       "target": "qwen",
       "status": "blocked",
       "reason": "QWEN_API_KEY is not configured in this environment.",
+      "blockerType": "missing_runner",
+      "blockerTypes": [
+        "missing_runner",
+        "missing_credentials"
+      ],
       "family": "qwen",
       "runner": "china",
       "backendKind": "http",
@@ -106,7 +143,10 @@
         "bearer-token",
         "token"
       ],
-      "blockerType": "missing_runner",
+      "requiredEnv": [
+        "QWEN_API_KEY"
+      ],
+      "requiredRunner": "china-egress-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -120,6 +160,11 @@
       "target": "moonshot-kimi",
       "status": "blocked",
       "reason": "MOONSHOT_API_KEY is not configured in this environment.",
+      "blockerType": "missing_runner",
+      "blockerTypes": [
+        "missing_runner",
+        "missing_credentials"
+      ],
       "family": "moonshot-kimi",
       "runner": "china",
       "backendKind": "http",
@@ -128,7 +173,10 @@
         "bearer-token",
         "token"
       ],
-      "blockerType": "missing_runner",
+      "requiredEnv": [
+        "MOONSHOT_API_KEY"
+      ],
+      "requiredRunner": "china-egress-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -142,6 +190,11 @@
       "target": "glm",
       "status": "blocked",
       "reason": "ZHIPU_API_KEY is not configured in this environment.",
+      "blockerType": "missing_runner",
+      "blockerTypes": [
+        "missing_runner",
+        "missing_credentials"
+      ],
       "family": "glm",
       "runner": "china",
       "backendKind": "http",
@@ -150,7 +203,10 @@
         "bearer-token",
         "token"
       ],
-      "blockerType": "missing_runner",
+      "requiredEnv": [
+        "ZHIPU_API_KEY"
+      ],
+      "requiredRunner": "china-egress-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -164,6 +220,11 @@
       "target": "volcengine-byteplus",
       "status": "blocked",
       "reason": "VOLCENGINE_API_KEY is not configured in this environment.",
+      "blockerType": "missing_runner",
+      "blockerTypes": [
+        "missing_runner",
+        "missing_credentials"
+      ],
       "family": "volcengine-byteplus",
       "runner": "china",
       "backendKind": "http",
@@ -172,7 +233,10 @@
         "bearer-token",
         "token"
       ],
-      "blockerType": "missing_runner",
+      "requiredEnv": [
+        "VOLCENGINE_API_KEY"
+      ],
+      "requiredRunner": "china-egress-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,

--- a/docs/reports/repo/TIER1_CHINA_LIVE_AUDIT_2026-04-02.md
+++ b/docs/reports/repo/TIER1_CHINA_LIVE_AUDIT_2026-04-02.md
@@ -1,6 +1,6 @@
 # Tier1 China Live Audit
 
-- Generated at: 2026-04-02T01:26:34.378Z
+- Generated at: 2026-04-02T03:30:31.696Z
 - Source matrix: /Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_MATRIX_2026-04-01.json
 - Source report: /Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_2026-04-01.md
 
@@ -11,13 +11,13 @@ No China-tier provider family could be fully live-verified on this machine on Ap
 ## Results
 
 - qwen: blocked — QWEN_API_KEY is not configured in this environment.
-  - blockerType: missing_runner
+  - blockerTypes: missing_runner, missing_credentials
 - moonshot-kimi: blocked — MOONSHOT_API_KEY is not configured in this environment.
-  - blockerType: missing_runner
+  - blockerTypes: missing_runner, missing_credentials
 - glm: blocked — ZHIPU_API_KEY is not configured in this environment.
-  - blockerType: missing_runner
+  - blockerTypes: missing_runner, missing_credentials
 - volcengine-byteplus: blocked — VOLCENGINE_API_KEY is not configured in this environment.
-  - blockerType: missing_runner
+  - blockerTypes: missing_runner, missing_credentials
 
 ## Blockers
 

--- a/docs/reports/repo/TIER1_ENVIRONMENT_CHECKLIST_2026-04-02.md
+++ b/docs/reports/repo/TIER1_ENVIRONMENT_CHECKLIST_2026-04-02.md
@@ -1,0 +1,102 @@
+# Tier1 Environment Checklist
+
+- Generated at: 2026-04-02T03:30:31.733Z
+
+## anthropic-http
+
+- Reason: Anthropic live credentials are not configured in this environment.
+- blockerTypes: missing_credentials
+- Action: set ANTHROPIC_API_KEY, FRIDAY_E2E_LIVE_ANTHROPIC
+- Action: run on global-runner
+
+## google-gemini
+
+- Reason: Neither Gemini CLI nor Google live credentials are available in this environment.
+- blockerTypes: missing_runner, missing_credentials
+- Action: set GOOGLE_API_KEY
+- Action: install binary gemini
+- Action: run on global-runner
+
+## openrouter
+
+- Reason: OPENROUTER_API_KEY is not configured in this environment.
+- blockerTypes: missing_credentials
+- Action: set OPENROUTER_API_KEY
+- Action: run on global-runner
+
+## xai
+
+- Reason: XAI_API_KEY is not configured in this environment.
+- blockerTypes: missing_credentials
+- Action: set XAI_API_KEY
+- Action: run on global-runner
+
+## mistral
+
+- Reason: MISTRAL_API_KEY is not configured in this environment.
+- blockerTypes: missing_credentials
+- Action: set MISTRAL_API_KEY
+- Action: run on global-runner
+
+## groq
+
+- Reason: GROQ_API_KEY is not configured in this environment.
+- blockerTypes: missing_credentials
+- Action: set GROQ_API_KEY
+- Action: run on global-runner
+
+## together
+
+- Reason: TOGETHER_API_KEY is not configured in this environment.
+- blockerTypes: missing_credentials
+- Action: set TOGETHER_API_KEY
+- Action: run on global-runner
+
+## qwen
+
+- Reason: QWEN_API_KEY is not configured in this environment.
+- blockerTypes: missing_runner, missing_credentials
+- Action: set QWEN_API_KEY
+- Action: run on china-egress-runner
+
+## moonshot-kimi
+
+- Reason: MOONSHOT_API_KEY is not configured in this environment.
+- blockerTypes: missing_runner, missing_credentials
+- Action: set MOONSHOT_API_KEY
+- Action: run on china-egress-runner
+
+## glm
+
+- Reason: ZHIPU_API_KEY is not configured in this environment.
+- blockerTypes: missing_runner, missing_credentials
+- Action: set ZHIPU_API_KEY
+- Action: run on china-egress-runner
+
+## volcengine-byteplus
+
+- Reason: VOLCENGINE_API_KEY is not configured in this environment.
+- blockerTypes: missing_runner, missing_credentials
+- Action: set VOLCENGINE_API_KEY
+- Action: run on china-egress-runner
+
+## vllm
+
+- Reason: VLLM endpoint is not configured in this environment.
+- blockerTypes: missing_endpoint
+- Action: set VLLM_BASE_URL
+- Action: run on local-runner
+
+## litellm
+
+- Reason: LiteLLM endpoint is not configured in this environment.
+- blockerTypes: missing_endpoint
+- Action: set LITELLM_BASE_URL
+- Action: run on local-runner
+
+## openai-compatible
+
+- Reason: OpenAI-compatible endpoint is not configured in this environment.
+- blockerTypes: missing_endpoint
+- Action: set OPENAI_COMPATIBLE_BASE_URL
+- Action: run on local-runner

--- a/docs/reports/repo/TIER1_GLOBAL_LIVE_AUDIT_2026-04-02.json
+++ b/docs/reports/repo/TIER1_GLOBAL_LIVE_AUDIT_2026-04-02.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-02T01:26:31.545Z",
+  "generatedAt": "2026-04-02T03:30:31.707Z",
   "scope": "tier1-global",
   "sourceMatrixPath": "/Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_MATRIX_2026-04-01.json",
   "sourceReportPath": "/Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_2026-04-01.md",
@@ -75,6 +75,10 @@
       "target": "anthropic-http",
       "status": "blocked",
       "reason": "Anthropic live credentials are not configured in this environment.",
+      "blockerType": "missing_credentials",
+      "blockerTypes": [
+        "missing_credentials"
+      ],
       "family": "anthropic",
       "runner": "global",
       "backendKind": "http",
@@ -83,7 +87,11 @@
         "oauth",
         "token"
       ],
-      "blockerType": "missing_credentials",
+      "requiredEnv": [
+        "ANTHROPIC_API_KEY",
+        "FRIDAY_E2E_LIVE_ANTHROPIC"
+      ],
+      "requiredRunner": "global-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -97,6 +105,11 @@
       "target": "google-gemini",
       "status": "blocked",
       "reason": "Neither Gemini CLI nor Google live credentials are available in this environment.",
+      "blockerType": "missing_runner",
+      "blockerTypes": [
+        "missing_runner",
+        "missing_credentials"
+      ],
       "family": "google",
       "runner": "global",
       "backendKind": "http",
@@ -104,7 +117,11 @@
         "api-key",
         "external-session"
       ],
-      "blockerType": "missing_runner",
+      "requiredEnv": [
+        "GOOGLE_API_KEY"
+      ],
+      "requiredBinary": "gemini",
+      "requiredRunner": "global-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -118,6 +135,10 @@
       "target": "openrouter",
       "status": "blocked",
       "reason": "OPENROUTER_API_KEY is not configured in this environment.",
+      "blockerType": "missing_credentials",
+      "blockerTypes": [
+        "missing_credentials"
+      ],
       "family": "openrouter",
       "runner": "global",
       "backendKind": "http",
@@ -125,7 +146,10 @@
         "api-key",
         "bearer-token"
       ],
-      "blockerType": "missing_credentials",
+      "requiredEnv": [
+        "OPENROUTER_API_KEY"
+      ],
+      "requiredRunner": "global-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -139,6 +163,10 @@
       "target": "xai",
       "status": "blocked",
       "reason": "XAI_API_KEY is not configured in this environment.",
+      "blockerType": "missing_credentials",
+      "blockerTypes": [
+        "missing_credentials"
+      ],
       "family": "xai",
       "runner": "global",
       "backendKind": "http",
@@ -146,7 +174,10 @@
         "api-key",
         "bearer-token"
       ],
-      "blockerType": "missing_credentials",
+      "requiredEnv": [
+        "XAI_API_KEY"
+      ],
+      "requiredRunner": "global-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -160,6 +191,10 @@
       "target": "mistral",
       "status": "blocked",
       "reason": "MISTRAL_API_KEY is not configured in this environment.",
+      "blockerType": "missing_credentials",
+      "blockerTypes": [
+        "missing_credentials"
+      ],
       "family": "mistral",
       "runner": "global",
       "backendKind": "http",
@@ -167,7 +202,10 @@
         "api-key",
         "bearer-token"
       ],
-      "blockerType": "missing_credentials",
+      "requiredEnv": [
+        "MISTRAL_API_KEY"
+      ],
+      "requiredRunner": "global-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -181,6 +219,10 @@
       "target": "groq",
       "status": "blocked",
       "reason": "GROQ_API_KEY is not configured in this environment.",
+      "blockerType": "missing_credentials",
+      "blockerTypes": [
+        "missing_credentials"
+      ],
       "family": "groq",
       "runner": "global",
       "backendKind": "http",
@@ -188,7 +230,10 @@
         "api-key",
         "bearer-token"
       ],
-      "blockerType": "missing_credentials",
+      "requiredEnv": [
+        "GROQ_API_KEY"
+      ],
+      "requiredRunner": "global-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -202,6 +247,10 @@
       "target": "together",
       "status": "blocked",
       "reason": "TOGETHER_API_KEY is not configured in this environment.",
+      "blockerType": "missing_credentials",
+      "blockerTypes": [
+        "missing_credentials"
+      ],
       "family": "together",
       "runner": "global",
       "backendKind": "http",
@@ -209,7 +258,10 @@
         "api-key",
         "bearer-token"
       ],
-      "blockerType": "missing_credentials",
+      "requiredEnv": [
+        "TOGETHER_API_KEY"
+      ],
+      "requiredRunner": "global-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -225,6 +277,10 @@
       "target": "anthropic-http",
       "status": "blocked",
       "reason": "Anthropic live credentials are not configured in this environment.",
+      "blockerType": "missing_credentials",
+      "blockerTypes": [
+        "missing_credentials"
+      ],
       "family": "anthropic",
       "runner": "global",
       "backendKind": "http",
@@ -233,7 +289,11 @@
         "oauth",
         "token"
       ],
-      "blockerType": "missing_credentials",
+      "requiredEnv": [
+        "ANTHROPIC_API_KEY",
+        "FRIDAY_E2E_LIVE_ANTHROPIC"
+      ],
+      "requiredRunner": "global-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -247,6 +307,11 @@
       "target": "google-gemini",
       "status": "blocked",
       "reason": "Neither Gemini CLI nor Google live credentials are available in this environment.",
+      "blockerType": "missing_runner",
+      "blockerTypes": [
+        "missing_runner",
+        "missing_credentials"
+      ],
       "family": "google",
       "runner": "global",
       "backendKind": "http",
@@ -254,7 +319,11 @@
         "api-key",
         "external-session"
       ],
-      "blockerType": "missing_runner",
+      "requiredEnv": [
+        "GOOGLE_API_KEY"
+      ],
+      "requiredBinary": "gemini",
+      "requiredRunner": "global-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -268,6 +337,10 @@
       "target": "openrouter",
       "status": "blocked",
       "reason": "OPENROUTER_API_KEY is not configured in this environment.",
+      "blockerType": "missing_credentials",
+      "blockerTypes": [
+        "missing_credentials"
+      ],
       "family": "openrouter",
       "runner": "global",
       "backendKind": "http",
@@ -275,7 +348,10 @@
         "api-key",
         "bearer-token"
       ],
-      "blockerType": "missing_credentials",
+      "requiredEnv": [
+        "OPENROUTER_API_KEY"
+      ],
+      "requiredRunner": "global-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -289,6 +365,10 @@
       "target": "xai",
       "status": "blocked",
       "reason": "XAI_API_KEY is not configured in this environment.",
+      "blockerType": "missing_credentials",
+      "blockerTypes": [
+        "missing_credentials"
+      ],
       "family": "xai",
       "runner": "global",
       "backendKind": "http",
@@ -296,7 +376,10 @@
         "api-key",
         "bearer-token"
       ],
-      "blockerType": "missing_credentials",
+      "requiredEnv": [
+        "XAI_API_KEY"
+      ],
+      "requiredRunner": "global-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -310,6 +393,10 @@
       "target": "mistral",
       "status": "blocked",
       "reason": "MISTRAL_API_KEY is not configured in this environment.",
+      "blockerType": "missing_credentials",
+      "blockerTypes": [
+        "missing_credentials"
+      ],
       "family": "mistral",
       "runner": "global",
       "backendKind": "http",
@@ -317,7 +404,10 @@
         "api-key",
         "bearer-token"
       ],
-      "blockerType": "missing_credentials",
+      "requiredEnv": [
+        "MISTRAL_API_KEY"
+      ],
+      "requiredRunner": "global-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -331,6 +421,10 @@
       "target": "groq",
       "status": "blocked",
       "reason": "GROQ_API_KEY is not configured in this environment.",
+      "blockerType": "missing_credentials",
+      "blockerTypes": [
+        "missing_credentials"
+      ],
       "family": "groq",
       "runner": "global",
       "backendKind": "http",
@@ -338,7 +432,10 @@
         "api-key",
         "bearer-token"
       ],
-      "blockerType": "missing_credentials",
+      "requiredEnv": [
+        "GROQ_API_KEY"
+      ],
+      "requiredRunner": "global-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -352,6 +449,10 @@
       "target": "together",
       "status": "blocked",
       "reason": "TOGETHER_API_KEY is not configured in this environment.",
+      "blockerType": "missing_credentials",
+      "blockerTypes": [
+        "missing_credentials"
+      ],
       "family": "together",
       "runner": "global",
       "backendKind": "http",
@@ -359,7 +460,10 @@
         "api-key",
         "bearer-token"
       ],
-      "blockerType": "missing_credentials",
+      "requiredEnv": [
+        "TOGETHER_API_KEY"
+      ],
+      "requiredRunner": "global-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,

--- a/docs/reports/repo/TIER1_GLOBAL_LIVE_AUDIT_2026-04-02.md
+++ b/docs/reports/repo/TIER1_GLOBAL_LIVE_AUDIT_2026-04-02.md
@@ -1,6 +1,6 @@
 # Tier1 Global Live Audit
 
-- Generated at: 2026-04-02T01:26:31.545Z
+- Generated at: 2026-04-02T03:30:31.707Z
 - Source matrix: /Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_MATRIX_2026-04-01.json
 - Source report: /Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_2026-04-01.md
 
@@ -14,19 +14,19 @@ Passed 3 of 10 global tier1 targets on April 1, 2026. Missing or unrun families 
 - codex-cli: passed — Codex CLI external-session backend passed a Friday-routed text completion.
 - claude-cli: passed — Claude CLI external-session backend passed a Friday-routed text completion.
 - anthropic-http: blocked — Anthropic live credentials are not configured in this environment.
-  - blockerType: missing_credentials
+  - blockerTypes: missing_credentials
 - google-gemini: blocked — Neither Gemini CLI nor Google live credentials are available in this environment.
-  - blockerType: missing_runner
+  - blockerTypes: missing_runner, missing_credentials
 - openrouter: blocked — OPENROUTER_API_KEY is not configured in this environment.
-  - blockerType: missing_credentials
+  - blockerTypes: missing_credentials
 - xai: blocked — XAI_API_KEY is not configured in this environment.
-  - blockerType: missing_credentials
+  - blockerTypes: missing_credentials
 - mistral: blocked — MISTRAL_API_KEY is not configured in this environment.
-  - blockerType: missing_credentials
+  - blockerTypes: missing_credentials
 - groq: blocked — GROQ_API_KEY is not configured in this environment.
-  - blockerType: missing_credentials
+  - blockerTypes: missing_credentials
 - together: blocked — TOGETHER_API_KEY is not configured in this environment.
-  - blockerType: missing_credentials
+  - blockerTypes: missing_credentials
 
 ## Blockers
 

--- a/docs/reports/repo/TIER1_LIVE_MATRIX_2026-04-02.json
+++ b/docs/reports/repo/TIER1_LIVE_MATRIX_2026-04-02.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-02T01:26:58.241Z",
+  "generatedAt": "2026-04-02T03:30:31.733Z",
   "scopes": [
     "tier1-global",
     "tier1-china",
@@ -82,6 +82,10 @@
       "target": "anthropic-http",
       "status": "blocked",
       "reason": "Anthropic live credentials are not configured in this environment.",
+      "blockerType": "missing_credentials",
+      "blockerTypes": [
+        "missing_credentials"
+      ],
       "family": "anthropic",
       "runner": "global",
       "backendKind": "http",
@@ -90,7 +94,11 @@
         "oauth",
         "token"
       ],
-      "blockerType": "missing_credentials",
+      "requiredEnv": [
+        "ANTHROPIC_API_KEY",
+        "FRIDAY_E2E_LIVE_ANTHROPIC"
+      ],
+      "requiredRunner": "global-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -104,6 +112,11 @@
       "target": "google-gemini",
       "status": "blocked",
       "reason": "Neither Gemini CLI nor Google live credentials are available in this environment.",
+      "blockerType": "missing_runner",
+      "blockerTypes": [
+        "missing_runner",
+        "missing_credentials"
+      ],
       "family": "google",
       "runner": "global",
       "backendKind": "http",
@@ -111,7 +124,11 @@
         "api-key",
         "external-session"
       ],
-      "blockerType": "missing_runner",
+      "requiredEnv": [
+        "GOOGLE_API_KEY"
+      ],
+      "requiredBinary": "gemini",
+      "requiredRunner": "global-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -125,6 +142,10 @@
       "target": "openrouter",
       "status": "blocked",
       "reason": "OPENROUTER_API_KEY is not configured in this environment.",
+      "blockerType": "missing_credentials",
+      "blockerTypes": [
+        "missing_credentials"
+      ],
       "family": "openrouter",
       "runner": "global",
       "backendKind": "http",
@@ -132,7 +153,10 @@
         "api-key",
         "bearer-token"
       ],
-      "blockerType": "missing_credentials",
+      "requiredEnv": [
+        "OPENROUTER_API_KEY"
+      ],
+      "requiredRunner": "global-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -146,6 +170,10 @@
       "target": "xai",
       "status": "blocked",
       "reason": "XAI_API_KEY is not configured in this environment.",
+      "blockerType": "missing_credentials",
+      "blockerTypes": [
+        "missing_credentials"
+      ],
       "family": "xai",
       "runner": "global",
       "backendKind": "http",
@@ -153,7 +181,10 @@
         "api-key",
         "bearer-token"
       ],
-      "blockerType": "missing_credentials",
+      "requiredEnv": [
+        "XAI_API_KEY"
+      ],
+      "requiredRunner": "global-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -167,6 +198,10 @@
       "target": "mistral",
       "status": "blocked",
       "reason": "MISTRAL_API_KEY is not configured in this environment.",
+      "blockerType": "missing_credentials",
+      "blockerTypes": [
+        "missing_credentials"
+      ],
       "family": "mistral",
       "runner": "global",
       "backendKind": "http",
@@ -174,7 +209,10 @@
         "api-key",
         "bearer-token"
       ],
-      "blockerType": "missing_credentials",
+      "requiredEnv": [
+        "MISTRAL_API_KEY"
+      ],
+      "requiredRunner": "global-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -188,6 +226,10 @@
       "target": "groq",
       "status": "blocked",
       "reason": "GROQ_API_KEY is not configured in this environment.",
+      "blockerType": "missing_credentials",
+      "blockerTypes": [
+        "missing_credentials"
+      ],
       "family": "groq",
       "runner": "global",
       "backendKind": "http",
@@ -195,7 +237,10 @@
         "api-key",
         "bearer-token"
       ],
-      "blockerType": "missing_credentials",
+      "requiredEnv": [
+        "GROQ_API_KEY"
+      ],
+      "requiredRunner": "global-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -209,6 +254,10 @@
       "target": "together",
       "status": "blocked",
       "reason": "TOGETHER_API_KEY is not configured in this environment.",
+      "blockerType": "missing_credentials",
+      "blockerTypes": [
+        "missing_credentials"
+      ],
       "family": "together",
       "runner": "global",
       "backendKind": "http",
@@ -216,7 +265,10 @@
         "api-key",
         "bearer-token"
       ],
-      "blockerType": "missing_credentials",
+      "requiredEnv": [
+        "TOGETHER_API_KEY"
+      ],
+      "requiredRunner": "global-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -230,6 +282,11 @@
       "target": "qwen",
       "status": "blocked",
       "reason": "QWEN_API_KEY is not configured in this environment.",
+      "blockerType": "missing_runner",
+      "blockerTypes": [
+        "missing_runner",
+        "missing_credentials"
+      ],
       "family": "qwen",
       "runner": "china",
       "backendKind": "http",
@@ -238,7 +295,10 @@
         "bearer-token",
         "token"
       ],
-      "blockerType": "missing_runner",
+      "requiredEnv": [
+        "QWEN_API_KEY"
+      ],
+      "requiredRunner": "china-egress-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -252,6 +312,11 @@
       "target": "moonshot-kimi",
       "status": "blocked",
       "reason": "MOONSHOT_API_KEY is not configured in this environment.",
+      "blockerType": "missing_runner",
+      "blockerTypes": [
+        "missing_runner",
+        "missing_credentials"
+      ],
       "family": "moonshot-kimi",
       "runner": "china",
       "backendKind": "http",
@@ -260,7 +325,10 @@
         "bearer-token",
         "token"
       ],
-      "blockerType": "missing_runner",
+      "requiredEnv": [
+        "MOONSHOT_API_KEY"
+      ],
+      "requiredRunner": "china-egress-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -274,6 +342,11 @@
       "target": "glm",
       "status": "blocked",
       "reason": "ZHIPU_API_KEY is not configured in this environment.",
+      "blockerType": "missing_runner",
+      "blockerTypes": [
+        "missing_runner",
+        "missing_credentials"
+      ],
       "family": "glm",
       "runner": "china",
       "backendKind": "http",
@@ -282,7 +355,10 @@
         "bearer-token",
         "token"
       ],
-      "blockerType": "missing_runner",
+      "requiredEnv": [
+        "ZHIPU_API_KEY"
+      ],
+      "requiredRunner": "china-egress-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -296,6 +372,11 @@
       "target": "volcengine-byteplus",
       "status": "blocked",
       "reason": "VOLCENGINE_API_KEY is not configured in this environment.",
+      "blockerType": "missing_runner",
+      "blockerTypes": [
+        "missing_runner",
+        "missing_credentials"
+      ],
       "family": "volcengine-byteplus",
       "runner": "china",
       "backendKind": "http",
@@ -304,7 +385,10 @@
         "bearer-token",
         "token"
       ],
-      "blockerType": "missing_runner",
+      "requiredEnv": [
+        "VOLCENGINE_API_KEY"
+      ],
+      "requiredRunner": "china-egress-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -342,6 +426,10 @@
       "target": "vllm",
       "status": "blocked",
       "reason": "VLLM endpoint is not configured in this environment.",
+      "blockerType": "missing_endpoint",
+      "blockerTypes": [
+        "missing_endpoint"
+      ],
       "family": "vllm",
       "runner": "local",
       "backendKind": "http",
@@ -350,7 +438,10 @@
         "api-key",
         "bearer-token"
       ],
-      "blockerType": "missing_credentials",
+      "requiredEnv": [
+        "VLLM_BASE_URL"
+      ],
+      "requiredRunner": "local-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -364,6 +455,10 @@
       "target": "litellm",
       "status": "blocked",
       "reason": "LiteLLM endpoint is not configured in this environment.",
+      "blockerType": "missing_endpoint",
+      "blockerTypes": [
+        "missing_endpoint"
+      ],
       "family": "litellm",
       "runner": "local",
       "backendKind": "http",
@@ -372,7 +467,10 @@
         "api-key",
         "bearer-token"
       ],
-      "blockerType": "missing_credentials",
+      "requiredEnv": [
+        "LITELLM_BASE_URL"
+      ],
+      "requiredRunner": "local-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -386,6 +484,10 @@
       "target": "openai-compatible",
       "status": "blocked",
       "reason": "OpenAI-compatible endpoint is not configured in this environment.",
+      "blockerType": "missing_endpoint",
+      "blockerTypes": [
+        "missing_endpoint"
+      ],
       "family": "openai-compatible",
       "runner": "local",
       "backendKind": "http",
@@ -394,7 +496,10 @@
         "api-key",
         "bearer-token"
       ],
-      "blockerType": "missing_credentials",
+      "requiredEnv": [
+        "OPENAI_COMPATIBLE_BASE_URL"
+      ],
+      "requiredRunner": "local-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,

--- a/docs/reports/repo/TIER1_LOCAL_LIVE_AUDIT_2026-04-02.json
+++ b/docs/reports/repo/TIER1_LOCAL_LIVE_AUDIT_2026-04-02.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-02T01:26:37.164Z",
+  "generatedAt": "2026-04-02T03:30:31.706Z",
   "scope": "tier1-local",
   "sourceMatrixPath": "/Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_MATRIX_2026-04-01.json",
   "sourceReportPath": "/Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_2026-04-01.md",
@@ -32,6 +32,10 @@
       "target": "vllm",
       "status": "blocked",
       "reason": "VLLM endpoint is not configured in this environment.",
+      "blockerType": "missing_endpoint",
+      "blockerTypes": [
+        "missing_endpoint"
+      ],
       "family": "vllm",
       "runner": "local",
       "backendKind": "http",
@@ -40,7 +44,10 @@
         "api-key",
         "bearer-token"
       ],
-      "blockerType": "missing_credentials",
+      "requiredEnv": [
+        "VLLM_BASE_URL"
+      ],
+      "requiredRunner": "local-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -54,6 +61,10 @@
       "target": "litellm",
       "status": "blocked",
       "reason": "LiteLLM endpoint is not configured in this environment.",
+      "blockerType": "missing_endpoint",
+      "blockerTypes": [
+        "missing_endpoint"
+      ],
       "family": "litellm",
       "runner": "local",
       "backendKind": "http",
@@ -62,7 +73,10 @@
         "api-key",
         "bearer-token"
       ],
-      "blockerType": "missing_credentials",
+      "requiredEnv": [
+        "LITELLM_BASE_URL"
+      ],
+      "requiredRunner": "local-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -76,6 +90,10 @@
       "target": "openai-compatible",
       "status": "blocked",
       "reason": "OpenAI-compatible endpoint is not configured in this environment.",
+      "blockerType": "missing_endpoint",
+      "blockerTypes": [
+        "missing_endpoint"
+      ],
       "family": "openai-compatible",
       "runner": "local",
       "backendKind": "http",
@@ -84,7 +102,10 @@
         "api-key",
         "bearer-token"
       ],
-      "blockerType": "missing_credentials",
+      "requiredEnv": [
+        "OPENAI_COMPATIBLE_BASE_URL"
+      ],
+      "requiredRunner": "local-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -100,6 +121,10 @@
       "target": "vllm",
       "status": "blocked",
       "reason": "VLLM endpoint is not configured in this environment.",
+      "blockerType": "missing_endpoint",
+      "blockerTypes": [
+        "missing_endpoint"
+      ],
       "family": "vllm",
       "runner": "local",
       "backendKind": "http",
@@ -108,7 +133,10 @@
         "api-key",
         "bearer-token"
       ],
-      "blockerType": "missing_credentials",
+      "requiredEnv": [
+        "VLLM_BASE_URL"
+      ],
+      "requiredRunner": "local-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -122,6 +150,10 @@
       "target": "litellm",
       "status": "blocked",
       "reason": "LiteLLM endpoint is not configured in this environment.",
+      "blockerType": "missing_endpoint",
+      "blockerTypes": [
+        "missing_endpoint"
+      ],
       "family": "litellm",
       "runner": "local",
       "backendKind": "http",
@@ -130,7 +162,10 @@
         "api-key",
         "bearer-token"
       ],
-      "blockerType": "missing_credentials",
+      "requiredEnv": [
+        "LITELLM_BASE_URL"
+      ],
+      "requiredRunner": "local-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,
@@ -144,6 +179,10 @@
       "target": "openai-compatible",
       "status": "blocked",
       "reason": "OpenAI-compatible endpoint is not configured in this environment.",
+      "blockerType": "missing_endpoint",
+      "blockerTypes": [
+        "missing_endpoint"
+      ],
       "family": "openai-compatible",
       "runner": "local",
       "backendKind": "http",
@@ -152,7 +191,10 @@
         "api-key",
         "bearer-token"
       ],
-      "blockerType": "missing_credentials",
+      "requiredEnv": [
+        "OPENAI_COMPATIBLE_BASE_URL"
+      ],
+      "requiredRunner": "local-runner",
       "contract": {
         "providerCreate": false,
         "providerDoctor": false,

--- a/docs/reports/repo/TIER1_LOCAL_LIVE_AUDIT_2026-04-02.md
+++ b/docs/reports/repo/TIER1_LOCAL_LIVE_AUDIT_2026-04-02.md
@@ -1,6 +1,6 @@
 # Tier1 Local Live Audit
 
-- Generated at: 2026-04-02T01:26:37.164Z
+- Generated at: 2026-04-02T03:30:31.706Z
 - Source matrix: /Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_MATRIX_2026-04-01.json
 - Source report: /Users/jarvis/Projects/Friday/docs/reports/repo/SELF_EVOLUTION_LIVE_AUDIT_2026-04-01.md
 
@@ -12,11 +12,11 @@ Passed 1 of 4 local/self-hosted tier1 targets on April 1, 2026. Remaining target
 
 - ollama-local: passed — Ollama local/self-hosted path passed a Friday-routed live run.
 - vllm: blocked — VLLM endpoint is not configured in this environment.
-  - blockerType: missing_credentials
+  - blockerTypes: missing_endpoint
 - litellm: blocked — LiteLLM endpoint is not configured in this environment.
-  - blockerType: missing_credentials
+  - blockerTypes: missing_endpoint
 - openai-compatible: blocked — OpenAI-compatible endpoint is not configured in this environment.
-  - blockerType: missing_credentials
+  - blockerTypes: missing_endpoint
 
 ## Blockers
 

--- a/docs/reports/repo/VERIFIED_VS_UNVERIFIED_2026-04-02.md
+++ b/docs/reports/repo/VERIFIED_VS_UNVERIFIED_2026-04-02.md
@@ -1,0 +1,34 @@
+# Verified vs Unverified Friday Scope
+
+- Generated at: 2026-04-02T03:30:31.733Z
+- Passed tier1 targets: 4
+- Blocked tier1 targets: 14
+
+## Verified live targets
+
+- openai-http: openai / global / http
+- codex-cli: openai-codex / global / cli
+- claude-cli: anthropic / global / cli
+- ollama-local: ollama / local / http
+
+## Blocked live targets
+
+- anthropic-http: Anthropic live credentials are not configured in this environment.
+- google-gemini: Neither Gemini CLI nor Google live credentials are available in this environment.
+- openrouter: OPENROUTER_API_KEY is not configured in this environment.
+- xai: XAI_API_KEY is not configured in this environment.
+- mistral: MISTRAL_API_KEY is not configured in this environment.
+- groq: GROQ_API_KEY is not configured in this environment.
+- together: TOGETHER_API_KEY is not configured in this environment.
+- qwen: QWEN_API_KEY is not configured in this environment.
+- moonshot-kimi: MOONSHOT_API_KEY is not configured in this environment.
+- glm: ZHIPU_API_KEY is not configured in this environment.
+- volcengine-byteplus: VOLCENGINE_API_KEY is not configured in this environment.
+- vllm: VLLM endpoint is not configured in this environment.
+- litellm: LiteLLM endpoint is not configured in this environment.
+- openai-compatible: OpenAI-compatible endpoint is not configured in this environment.
+
+## Product layers not yet fully live-dogfooded
+
+- Realtime / Channels / UIX / Observability: closure local plus targeted live audit and existing suite coverage; gap: not every operator surface and transport has been fully live-dogfooded with the same rigor as provider tier1 routes
+- Marketplace / Skills / Plugins: closure local and existing suite coverage; gap: not every marketplace and plugin path is yet covered by a dedicated live matrix family harness

--- a/scripts/e2e/friday-closure-lib.mjs
+++ b/scripts/e2e/friday-closure-lib.mjs
@@ -1,6 +1,7 @@
 import path from "node:path";
 
 export const FRIDAY_CLOSURE_STATUSES = Object.freeze({
+  RUNNING: "RUNNING",
   PASS: "PASS",
   FAIL: "FAIL",
   BLOCKER: "BLOCKER",

--- a/scripts/e2e/run-friday-closure.mjs
+++ b/scripts/e2e/run-friday-closure.mjs
@@ -185,27 +185,30 @@ async function findFreePort() {
   });
 }
 
-function createLedger(paths) {
+export function createLedger(paths) {
   return {
     runId: paths.runId,
     startedAt: nowIso(),
     completedAt: null,
+    lastUpdatedAt: nowIso(),
     cwd: REPO_ROOT,
     mode: CLOSURE_MODE,
     commitSha: spawnSyncOutput("git", ["rev-parse", "HEAD"]).trim(),
     paths,
     entries: [],
+    activeStep: null,
     summary: { pass: 0, fail: 0, blocker: 0 },
     verdict: "NO-GO",
     readiness: null,
   };
 }
 
-function persistLedger(ledger) {
+export function persistLedger(ledger) {
   const resolved = resolveClosureVerdict(ledger.entries);
   ledger.summary = resolved.summary;
   ledger.verdict = resolved.verdict;
   ledger.readiness = resolveReadinessReport(ledger.entries, ledger.mode);
+  ledger.lastUpdatedAt = nowIso();
   writeJson(path.join(ledger.paths.root, "ledger.json"), ledger);
 }
 
@@ -417,15 +420,22 @@ function buildEntrySkeleton(id, stage, description) {
     startedAt: nowIso(),
     completedAt: null,
     durationMs: 0,
-    status: FRIDAY_CLOSURE_STATUSES.FAIL,
+    status: FRIDAY_CLOSURE_STATUSES.RUNNING,
     evidence: {},
     details: {},
   };
 }
 
-async function runStep(ledger, { id, stage, description }, fn) {
+export async function runStep(ledger, { id, stage, description }, fn) {
   const entry = buildEntrySkeleton(id, stage, description);
   const startedAtMs = Date.now();
+  ledger.activeStep = {
+    id,
+    stage,
+    description,
+    startedAt: entry.startedAt,
+  };
+  appendLedgerEntry(ledger, entry);
   try {
     const result = await fn(entry);
     entry.status = result?.status ?? FRIDAY_CLOSURE_STATUSES.PASS;
@@ -440,7 +450,10 @@ async function runStep(ledger, { id, stage, description }, fn) {
   } finally {
     entry.completedAt = nowIso();
     entry.durationMs = Date.now() - startedAtMs;
-    appendLedgerEntry(ledger, entry);
+    if (ledger.activeStep?.id === id) {
+      ledger.activeStep = null;
+    }
+    persistLedger(ledger);
   }
   return entry;
 }
@@ -2071,8 +2084,13 @@ async function runLocalStage(ledger) {
             },
           },
         );
-        deployAttempts.push(deploy.json);
+        deployAttempts.push({
+          status: deploy.status,
+          json: deploy.json,
+        });
       }
+      const deployProbeStatuses = deployAttempts.map((attempt) => attempt.status);
+      const unexpectedDeployProbeStatuses = deployProbeStatuses.filter((status) => status < 400 || status >= 500);
 
       const workflowIncidents = await apiFetch(baseUrl, token, "GET", "/v1/diagnosis/incidents");
       const workflowItems = workflowIncidents.json?.data?.items ?? workflowIncidents.json?.items ?? [];
@@ -2085,11 +2103,15 @@ async function runLocalStage(ledger) {
           details: {
             reason: "Repeated workflow deploy failures did not materialize enough workflow incidents with action plans to validate deny and approve flows.",
             actionCount: workflowActionItems.length,
+            deployProbeStatuses,
+            deployProbeExpectation: "Expected repeated 4xx template execute responses for a missing sessionId so the self-healing loop could materialize workflow incidents.",
           },
           evidence: {
             responsePath: writeResponseEvidence(ledger.paths, "local-self-healing", {
               policyBefore,
               policyUpdate: policyUpdate.json,
+              deployProbeExpectation: "Expected repeated 4xx template execute responses for a missing sessionId so the self-healing loop could materialize workflow incidents.",
+              deployProbeStatuses,
               deployAttempts,
               workflowIncidents: workflowIncidents.json,
             }),
@@ -2129,11 +2151,15 @@ async function runLocalStage(ledger) {
           status: FRIDAY_CLOSURE_STATUSES.BLOCKER,
           details: {
             reason: "Satellite degraded heartbeat did not materialize a config auto-fix action for execute and rollback validation.",
+            deployProbeStatuses,
+            deployProbeExpectation: "Expected repeated 4xx template execute responses for a missing sessionId so the self-healing loop could materialize workflow incidents.",
           },
           evidence: {
             responsePath: writeResponseEvidence(ledger.paths, "local-self-healing", {
               policyBefore,
               policyUpdate: policyUpdate.json,
+              deployProbeExpectation: "Expected repeated 4xx template execute responses for a missing sessionId so the self-healing loop could materialize workflow incidents.",
+              deployProbeStatuses,
               deployAttempts,
               workflowIncidents: workflowIncidents.json,
               deny: deny.json,
@@ -2161,6 +2187,8 @@ async function runLocalStage(ledger) {
       const responsePath = writeResponseEvidence(ledger.paths, "local-self-healing", {
         policyBefore,
         policyUpdate: policyUpdate.json,
+        deployProbeExpectation: "Expected repeated 4xx template execute responses for a missing sessionId so the self-healing loop could materialize workflow incidents.",
+        deployProbeStatuses,
         deployAttempts,
         workflowIncidents: workflowIncidents.json,
         approvedWorkflowActionDetail: approvedWorkflowActionDetail.json,
@@ -2187,6 +2215,9 @@ async function runLocalStage(ledger) {
       if (approve.status !== 200 || !approve.json.ok) {
         throw new Error(`Auto-fix approve failed: ${JSON.stringify(approve.json)}`);
       }
+      if (unexpectedDeployProbeStatuses.length > 0) {
+        throw new Error(`Workflow incident probes returned unexpected statuses: ${unexpectedDeployProbeStatuses.join(", ")}`);
+      }
       if (execute.status !== 200 || !execute.json.ok) {
         throw new Error(`Auto-fix execute failed: ${JSON.stringify(execute.json)}`);
       }
@@ -2200,6 +2231,8 @@ async function runLocalStage(ledger) {
           approvedActionId: approveActionId,
           executedActionId: configActionId,
           configSatelliteId: configSatellite.satelliteId,
+          deployProbeStatuses,
+          deployProbeExpectation: "Expected repeated 4xx template execute responses for a missing sessionId so the self-healing loop could materialize workflow incidents.",
         },
       };
     });

--- a/scripts/e2e/run-tier1-china-live-audit.mjs
+++ b/scripts/e2e/run-tier1-china-live-audit.mjs
@@ -7,7 +7,7 @@ import {
   REPORT_DIR,
   SOURCE_MATRIX_PATH,
   SOURCE_REPORT_PATH,
-  blockerTypeFromEnvironment,
+  blockerTypesFromEnvironment,
   buildMarkdownReport,
   blockStatus,
   contractStatus,
@@ -36,7 +36,9 @@ const results = families.map(([target, envName]) =>
         runner: "china",
         backendKind: "http",
         authModes: ["api-key", "bearer-token", "token"],
-        blockerType: "missing_runner",
+        blockerTypes: ["missing_runner"],
+        requiredEnv: [envName],
+        requiredRunner: "china-egress-runner",
         contract: contractStatus({}),
       })
     : blockStatus(target, `${envName} is not configured in this environment.`, {
@@ -44,7 +46,9 @@ const results = families.map(([target, envName]) =>
         runner: "china",
         backendKind: "http",
         authModes: ["api-key", "bearer-token", "token"],
-        blockerType: blockerTypeFromEnvironment({ credentialEnv: [envName], runner: false }),
+        blockerTypes: blockerTypesFromEnvironment({ credentialEnv: [envName], runner: false }),
+        requiredEnv: [envName],
+        requiredRunner: "china-egress-runner",
         contract: contractStatus({}),
       }),
 );

--- a/scripts/e2e/run-tier1-global-live-audit.mjs
+++ b/scripts/e2e/run-tier1-global-live-audit.mjs
@@ -7,7 +7,7 @@ import {
   REPORT_DIR,
   SOURCE_MATRIX_PATH,
   SOURCE_REPORT_PATH,
-  blockerTypeFromEnvironment,
+  blockerTypesFromEnvironment,
   buildMarkdownReport,
   blockStatus,
   contractStatus,
@@ -50,7 +50,9 @@ if (matrix.live?.openaiHttp?.repeatRun1?.status === "completed") {
       runner: "global",
       backendKind: "http",
       authModes: ["api-key", "bearer-token"],
-      blockerType: blockerTypeFromEnvironment({ credentialEnv: ["OPENAI_API_KEY"] }),
+      blockerTypes: blockerTypesFromEnvironment({ credentialEnv: ["OPENAI_API_KEY"] }),
+      requiredEnv: ["OPENAI_API_KEY"],
+      requiredRunner: "global-runner",
       contract: contractStatus({}),
     }),
   );
@@ -80,7 +82,9 @@ if (matrix.live?.codexCli?.textCompletion?.text?.includes("CODEX_FRIDAY_OK")) {
       runner: "global",
       backendKind: "cli",
       authModes: ["external-session"],
-      blockerType: blockerTypeFromEnvironment({ binary: "codex", productSupport: true }),
+      blockerTypes: blockerTypesFromEnvironment({ binary: "codex", productSupport: true }),
+      requiredBinary: "codex",
+      requiredRunner: "global-runner",
       contract: contractStatus({}),
     }),
   );
@@ -110,7 +114,9 @@ if (matrix.live?.claudeCli?.textCompletion?.text?.includes("CLAUDE_FRIDAY_OK")) 
       runner: "global",
       backendKind: "cli",
       authModes: ["external-session"],
-      blockerType: blockerTypeFromEnvironment({ binary: "claude", productSupport: true }),
+      blockerTypes: blockerTypesFromEnvironment({ binary: "claude", productSupport: true }),
+      requiredBinary: "claude",
+      requiredRunner: "global-runner",
       contract: contractStatus({}),
     }),
   );
@@ -123,7 +129,9 @@ results.push(
         runner: "global",
         backendKind: "http",
         authModes: ["api-key", "oauth", "token"],
-        blockerType: "not_yet_executed",
+        blockerTypes: ["not_yet_executed"],
+        requiredEnv: ["ANTHROPIC_API_KEY", "FRIDAY_E2E_LIVE_ANTHROPIC"],
+        requiredRunner: "global-runner",
         contract: contractStatus({}),
       })
     : blockStatus("anthropic-http", "Anthropic live credentials are not configured in this environment.", {
@@ -131,7 +139,9 @@ results.push(
         runner: "global",
         backendKind: "http",
         authModes: ["api-key", "oauth", "token"],
-        blockerType: "missing_credentials",
+        blockerTypes: ["missing_credentials"],
+        requiredEnv: ["ANTHROPIC_API_KEY", "FRIDAY_E2E_LIVE_ANTHROPIC"],
+        requiredRunner: "global-runner",
         contract: contractStatus({}),
       }),
 );
@@ -143,7 +153,10 @@ results.push(
         runner: "global",
         backendKind: hasBinary("gemini") ? "cli" : "http",
         authModes: hasBinary("gemini") ? ["external-session"] : ["api-key"],
-        blockerType: "not_yet_executed",
+        blockerTypes: ["not_yet_executed"],
+        requiredEnv: ["GOOGLE_API_KEY"],
+        requiredBinary: hasBinary("gemini") ? "gemini" : undefined,
+        requiredRunner: "global-runner",
         contract: contractStatus({}),
       })
     : blockStatus("google-gemini", "Neither Gemini CLI nor Google live credentials are available in this environment.", {
@@ -151,7 +164,10 @@ results.push(
         runner: "global",
         backendKind: "http",
         authModes: ["api-key", "external-session"],
-        blockerType: blockerTypeFromEnvironment({ credentialEnv: ["GOOGLE_API_KEY"], binary: "gemini" }),
+        blockerTypes: blockerTypesFromEnvironment({ credentialEnv: ["GOOGLE_API_KEY"], binary: "gemini" }),
+        requiredEnv: ["GOOGLE_API_KEY"],
+        requiredBinary: "gemini",
+        requiredRunner: "global-runner",
         contract: contractStatus({}),
       }),
 );
@@ -171,7 +187,9 @@ for (const family of [
           runner: "global",
           backendKind: "http",
           authModes: ["api-key", "bearer-token"],
-          blockerType: "not_yet_executed",
+          blockerTypes: ["not_yet_executed"],
+          requiredEnv: [envName],
+          requiredRunner: "global-runner",
           contract: contractStatus({}),
         })
       : blockStatus(target, `${envName} is not configured in this environment.`, {
@@ -179,7 +197,9 @@ for (const family of [
           runner: "global",
           backendKind: "http",
           authModes: ["api-key", "bearer-token"],
-          blockerType: "missing_credentials",
+          blockerTypes: ["missing_credentials"],
+          requiredEnv: [envName],
+          requiredRunner: "global-runner",
           contract: contractStatus({}),
         }),
   );

--- a/scripts/e2e/run-tier1-live-matrix-summary.mjs
+++ b/scripts/e2e/run-tier1-live-matrix-summary.mjs
@@ -3,7 +3,14 @@
 import fs from "node:fs";
 import path from "node:path";
 
-import { DATE_STAMP, REPORT_DIR, ensureDir, writeJson } from "./tier1-live-audit-lib.mjs";
+import {
+  DATE_STAMP,
+  REPORT_DIR,
+  ensureDir,
+  formatBlockedTargetActionItems,
+  writeJson,
+  writeText,
+} from "./tier1-live-audit-lib.mjs";
 
 const scopes = ["GLOBAL", "CHINA", "LOCAL"];
 
@@ -21,6 +28,8 @@ const blockers = results.filter((result) => result.status === "blocked");
 
 const matrixPath = path.join(REPORT_DIR, `TIER1_LIVE_MATRIX_${DATE_STAMP}.json`);
 const blockerPath = path.join(REPORT_DIR, `TIER1_BLOCKER_MATRIX_${DATE_STAMP}.json`);
+const verifiedSummaryPath = path.join(REPORT_DIR, `VERIFIED_VS_UNVERIFIED_${DATE_STAMP}.md`);
+const checklistPath = path.join(REPORT_DIR, `TIER1_ENVIRONMENT_CHECKLIST_${DATE_STAMP}.md`);
 
 ensureDir(REPORT_DIR);
 writeJson(matrixPath, {
@@ -42,10 +51,71 @@ writeJson(blockerPath, {
   blockers,
 });
 
+const verified = results.filter((result) => result.status === "passed");
+const knownCoverageGaps = [
+  {
+    layer: "Realtime / Channels / UIX / Observability",
+    currentValidation: "closure local plus targeted live audit and existing suite coverage",
+    gap: "not every operator surface and transport has been fully live-dogfooded with the same rigor as provider tier1 routes",
+  },
+  {
+    layer: "Marketplace / Skills / Plugins",
+    currentValidation: "closure local and existing suite coverage",
+    gap: "not every marketplace and plugin path is yet covered by a dedicated live matrix family harness",
+  },
+];
+
+writeText(
+  verifiedSummaryPath,
+  [
+    "# Verified vs Unverified Friday Scope",
+    "",
+    `- Generated at: ${new Date().toISOString()}`,
+    `- Passed tier1 targets: ${verified.length}`,
+    `- Blocked tier1 targets: ${blockers.length}`,
+    "",
+    "## Verified live targets",
+    "",
+    ...verified.map((result) => `- ${result.target}: ${result.family} / ${result.runner} / ${result.backendKind}`),
+    "",
+    "## Blocked live targets",
+    "",
+    ...blockers.map((result) => `- ${result.target}: ${result.reason}`),
+    "",
+    "## Product layers not yet fully live-dogfooded",
+    "",
+    ...knownCoverageGaps.map((gap) => `- ${gap.layer}: ${gap.currentValidation}; gap: ${gap.gap}`),
+    "",
+  ].join("\n"),
+);
+
+writeText(
+  checklistPath,
+  [
+    "# Tier1 Environment Checklist",
+    "",
+    `- Generated at: ${new Date().toISOString()}`,
+    "",
+    ...blockers.flatMap((result) => {
+      const items = formatBlockedTargetActionItems(result);
+      return [
+        `## ${result.target}`,
+        "",
+        `- Reason: ${result.reason}`,
+        `- blockerTypes: ${Array.isArray(result.blockerTypes) && result.blockerTypes.length > 0 ? result.blockerTypes.join(", ") : result.blockerType ?? "unknown"}`,
+        ...(items.length > 0 ? items.map((item) => `- Action: ${item}`) : ["- Action: inspect blocker manually"]),
+        "",
+      ];
+    }),
+  ].join("\n"),
+);
+
 console.log(JSON.stringify({
   ok: true,
   matrixPath,
   blockerPath,
+  verifiedSummaryPath,
+  checklistPath,
   passed: results.filter((result) => result.status === "passed").length,
   blocked: blockers.length,
 }, null, 2));

--- a/scripts/e2e/run-tier1-local-live-audit.mjs
+++ b/scripts/e2e/run-tier1-local-live-audit.mjs
@@ -7,7 +7,6 @@ import {
   REPORT_DIR,
   SOURCE_MATRIX_PATH,
   SOURCE_REPORT_PATH,
-  blockerTypeFromEnvironment,
   buildMarkdownReport,
   blockStatus,
   contractStatus,
@@ -48,7 +47,8 @@ if (matrix.live?.ollamaLocal?.run?.status === "completed") {
       runner: "local",
       backendKind: "http",
       authModes: ["none", "api-key", "bearer-token"],
-      blockerType: "not_yet_executed",
+      blockerTypes: ["not_yet_executed"],
+      requiredRunner: "local-runner",
       contract: contractStatus({}),
     }),
   );
@@ -61,7 +61,9 @@ results.push(
         runner: "local",
         backendKind: "http",
         authModes: ["none", "api-key", "bearer-token"],
-        blockerType: "not_yet_executed",
+        blockerTypes: ["not_yet_executed"],
+        requiredEnv: ["VLLM_BASE_URL"],
+        requiredRunner: "local-runner",
         contract: contractStatus({}),
       })
     : blockStatus("vllm", "VLLM endpoint is not configured in this environment.", {
@@ -69,7 +71,9 @@ results.push(
         runner: "local",
         backendKind: "http",
         authModes: ["none", "api-key", "bearer-token"],
-        blockerType: "missing_credentials",
+        blockerTypes: ["missing_endpoint"],
+        requiredEnv: ["VLLM_BASE_URL"],
+        requiredRunner: "local-runner",
         contract: contractStatus({}),
       }),
 );
@@ -81,7 +85,9 @@ results.push(
         runner: "local",
         backendKind: "http",
         authModes: ["none", "api-key", "bearer-token"],
-        blockerType: "not_yet_executed",
+        blockerTypes: ["not_yet_executed"],
+        requiredEnv: ["LITELLM_BASE_URL"],
+        requiredRunner: "local-runner",
         contract: contractStatus({}),
       })
     : blockStatus("litellm", "LiteLLM endpoint is not configured in this environment.", {
@@ -89,7 +95,9 @@ results.push(
         runner: "local",
         backendKind: "http",
         authModes: ["none", "api-key", "bearer-token"],
-        blockerType: "missing_credentials",
+        blockerTypes: ["missing_endpoint"],
+        requiredEnv: ["LITELLM_BASE_URL"],
+        requiredRunner: "local-runner",
         contract: contractStatus({}),
       }),
 );
@@ -101,7 +109,9 @@ results.push(
         runner: "local",
         backendKind: "http",
         authModes: ["none", "api-key", "bearer-token"],
-        blockerType: "not_yet_executed",
+        blockerTypes: ["not_yet_executed"],
+        requiredEnv: ["OPENAI_COMPATIBLE_BASE_URL"],
+        requiredRunner: "local-runner",
         contract: contractStatus({}),
       })
     : blockStatus("openai-compatible", "OpenAI-compatible endpoint is not configured in this environment.", {
@@ -109,7 +119,9 @@ results.push(
         runner: "local",
         backendKind: "http",
         authModes: ["none", "api-key", "bearer-token"],
-        blockerType: "missing_credentials",
+        blockerTypes: ["missing_endpoint"],
+        requiredEnv: ["OPENAI_COMPATIBLE_BASE_URL"],
+        requiredRunner: "local-runner",
         contract: contractStatus({}),
       }),
 );

--- a/scripts/e2e/tier1-live-audit-lib.mjs
+++ b/scripts/e2e/tier1-live-audit-lib.mjs
@@ -74,10 +74,18 @@ export function readSourceReport() {
 }
 
 export function blockStatus(target, reason, extra = {}) {
+  const blockerTypes = Array.isArray(extra.blockerTypes)
+    ? [...new Set(extra.blockerTypes.filter((value) => typeof value === "string" && value.trim().length > 0))]
+    : [];
+  const blockerType = typeof extra.blockerType === "string" && extra.blockerType.trim().length > 0
+    ? extra.blockerType
+    : blockerTypes[0];
   return {
     target,
     status: "blocked",
     reason,
+    ...(blockerType ? { blockerType } : {}),
+    ...(blockerTypes.length > 0 ? { blockerTypes } : {}),
     ...extra,
   };
 }
@@ -103,20 +111,27 @@ export function contractStatus(input) {
   };
 }
 
-export function blockerTypeFromEnvironment({ credentialEnv = [], binary = null, runner = true, productSupport = true }) {
+export function blockerTypesFromEnvironment({ credentialEnv = [], binary = null, runner = true, productSupport = true }) {
+  const blockerTypes = [];
   if (runner !== true) {
-    return "missing_runner";
+    blockerTypes.push("missing_runner");
   }
   if (productSupport !== true) {
-    return "product_boundary";
+    blockerTypes.push("unsupported_boundary");
   }
   if (binary && !hasBinary(binary)) {
-    return "missing_runner";
+    blockerTypes.push("missing_runner");
   }
   if (credentialEnv.length > 0 && !credentialEnv.some((name) => hasEnv(name))) {
-    return "missing_credentials";
+    blockerTypes.push("missing_credentials");
   }
-  return "not_yet_executed";
+  return blockerTypes.length > 0
+    ? [...new Set(blockerTypes)]
+    : ["not_yet_executed"];
+}
+
+export function blockerTypeFromEnvironment(input) {
+  return blockerTypesFromEnvironment(input)[0];
 }
 
 export function buildMarkdownReport({ title, generatedAt, sourceMatrixPath, sourceReportPath, summary, results, blockers }) {
@@ -138,7 +153,9 @@ export function buildMarkdownReport({ title, generatedAt, sourceMatrixPath, sour
     lines.push(
       `- ${result.target}: ${result.status}${result.summary ? ` — ${result.summary}` : ""}${result.reason ? ` — ${result.reason}` : ""}`,
     );
-    if (result.blockerType) {
+    if (Array.isArray(result.blockerTypes) && result.blockerTypes.length > 0) {
+      lines.push(`  - blockerTypes: ${result.blockerTypes.join(", ")}`);
+    } else if (result.blockerType) {
       lines.push(`  - blockerType: ${result.blockerType}`);
     }
   }
@@ -163,4 +180,21 @@ export function hasBinary(name) {
     encoding: "utf8",
   });
   return result.status === 0;
+}
+
+export function formatBlockedTargetActionItems(result) {
+  const items = [];
+  if (Array.isArray(result.requiredEnv) && result.requiredEnv.length > 0) {
+    items.push(`set ${result.requiredEnv.join(", ")}`);
+  }
+  if (typeof result.requiredBinary === "string" && result.requiredBinary.trim().length > 0) {
+    items.push(`install binary ${result.requiredBinary}`);
+  }
+  if (typeof result.requiredRunner === "string" && result.requiredRunner.trim().length > 0) {
+    items.push(`run on ${result.requiredRunner}`);
+  }
+  if (Array.isArray(result.blockerTypes) && result.blockerTypes.includes("not_yet_executed")) {
+    items.push("execute the dedicated live harness");
+  }
+  return items;
 }

--- a/test/unit/e2e/run-friday-closure.test.ts
+++ b/test/unit/e2e/run-friday-closure.test.ts
@@ -7,8 +7,12 @@ import fs from "node:fs";
 
 import {
   closeWritableStream,
+  createLedger,
+  persistLedger,
+  runStep,
   stopManagedChildProcess,
 } from "../../../scripts/e2e/run-friday-closure.mjs";
+import { FRIDAY_CLOSURE_STATUSES } from "../../../scripts/e2e/friday-closure-lib.mjs";
 
 describe("run-friday-closure helpers", () => {
   it("closeWritableStream flushes and closes a write stream", async () => {
@@ -37,5 +41,48 @@ describe("run-friday-closure helpers", () => {
     await stopManagedChildProcess(child, { graceMs: 150, forceKillMs: 150 });
 
     expect(child.exitCode !== null || child.signalCode !== null).toBe(true);
+  });
+
+  it("runStep persists an in-progress active step before completion", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "friday-closure-ledger-"));
+    const paths = {
+      runId: "test-run",
+      root: dir,
+      state: join(dir, "state"),
+      skills: join(dir, "skills"),
+      artifacts: join(dir, "artifacts"),
+      logs: join(dir, "logs"),
+      exports: join(dir, "exports"),
+      responses: join(dir, "responses"),
+      transcripts: join(dir, "transcripts"),
+    };
+    for (const value of Object.values(paths)) {
+      if (typeof value === "string") {
+        fs.mkdirSync(value, { recursive: true });
+      }
+    }
+
+    const ledger = createLedger(paths);
+    persistLedger(ledger);
+
+    let runningSnapshot = null;
+    await runStep(ledger, {
+      id: "local.backstop.release-verify",
+      stage: "local.backstop",
+      description: "Run npm run release:verify as a closure backstop",
+    }, async () => {
+      runningSnapshot = JSON.parse(readFileSync(join(dir, "ledger.json"), "utf8"));
+      return { status: FRIDAY_CLOSURE_STATUSES.PASS };
+    });
+
+    expect(runningSnapshot?.activeStep?.id).toBe("local.backstop.release-verify");
+    expect(runningSnapshot?.entries?.at(-1)?.status).toBe(FRIDAY_CLOSURE_STATUSES.RUNNING);
+
+    const finalSnapshot = JSON.parse(readFileSync(join(dir, "ledger.json"), "utf8"));
+    expect(finalSnapshot.activeStep).toBeNull();
+    expect(finalSnapshot.entries.at(-1)?.status).toBe(FRIDAY_CLOSURE_STATUSES.PASS);
+    expect(finalSnapshot.entries.at(-1)?.completedAt).toBeTruthy();
+
+    rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/test/unit/e2e/tier1-live-audit-lib.test.ts
+++ b/test/unit/e2e/tier1-live-audit-lib.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  blockStatus,
+  blockerTypesFromEnvironment,
+} from "../../../scripts/e2e/tier1-live-audit-lib.mjs";
+
+describe("tier1 live audit lib", () => {
+  it("returns multiple blocker reasons when both runner and credentials are missing", () => {
+    const blockerTypes = blockerTypesFromEnvironment({
+      credentialEnv: ["FRIDAY_TEST_ENV_THAT_DOES_NOT_EXIST"],
+      runner: false,
+    });
+
+    expect(blockerTypes).toContain("missing_runner");
+    expect(blockerTypes).toContain("missing_credentials");
+  });
+
+  it("preserves blockerTypes while exposing the primary blockerType for compatibility", () => {
+    const result = blockStatus("china-provider", "runner and credentials missing", {
+      blockerTypes: ["missing_runner", "missing_credentials"],
+    });
+
+    expect(result.blockerType).toBe("missing_runner");
+    expect(result.blockerTypes).toEqual(["missing_runner", "missing_credentials"]);
+  });
+});


### PR DESCRIPTION
## What changed
- make closure ledgers persist in-progress step state (`RUNNING` + `activeStep`) so long backstop work is observable instead of looking stuck
- clarify self-healing deploy probe evidence so expected 4xx negative-path probes are recorded explicitly
- correct `docs/current-source-of-truth.md` to match the current hub-wired self-healing steps and learned-facts UI visibility
- improve tier1 live blocker classification to support multiple concurrent reasons (`missing_runner`, `missing_credentials`, `missing_endpoint`, `unsupported_boundary`)
- add generated operator-facing artifacts for verified vs unverified coverage and next-step environment checklist
- add unit coverage for closure in-progress persistence and multi-reason tier1 blocker reporting

## Why
A deeper audit showed that the remaining gaps were mostly in trust and operator clarity rather than a broken core path:
- closure local could look hung because the ledger only showed completed steps while `release:verify` was still running
- source-of-truth docs had drifted behind the runtime
- tier1 blocker reports made some blocked families look like a single runner problem when they were actually missing both runner and credentials

## Impact
- operators can now see which closure step is actively running and when it started
- closure evidence now distinguishes expected negative-path deploy probes from unexpected behavior
- source-of-truth statements now match the current runtime and UI
- tier1 blocker reports are actionable enough to drive environment bring-up without re-reading raw logs

## Validation
- `npm run build`
- `npx vitest run test/unit/e2e/run-friday-closure.test.ts test/unit/e2e/tier1-live-audit-lib.test.ts`
- `node scripts/e2e/run-tier1-global-live-audit.mjs`
- `node scripts/e2e/run-tier1-china-live-audit.mjs`
- `node scripts/e2e/run-tier1-local-live-audit.mjs && node scripts/e2e/run-tier1-live-matrix-summary.mjs`
- `npm run test:e2e:closure:local`

## Root cause
The main issue was not that closure finalization was broken. The issue was that the ledger did not persist in-progress state, so a long-running `release:verify` backstop step looked indistinguishable from a stuck finalization path. In parallel, tier1 reporting compressed multiple environment blockers into a single coarse type, and the source-of-truth document had fallen behind the live runtime.