### PR TITLE
[codex] Fix uix user-profile persistence

### DIFF
--- a/src/api/http/routes/friday-uix-routes.ts
+++ b/src/api/http/routes/friday-uix-routes.ts
@@ -102,6 +102,16 @@ function buildTenantContext(principal: unknown): FridayProviderTenantContext | u
   };
 }
 
+function readUserProfileResponse(service: FridayUixSurfaceService, userId: string): FridayUserProfileResponse {
+  const prefs = service.listPreferences({ userId, category: "uix" });
+  const profilePref = prefs.items.find((p) => p.key === "user.profile_type");
+  const onboardedPref = prefs.items.find((p) => p.key === "user.onboarded_at");
+  return {
+    profileType: (profilePref?.value as FridayUserProfileType | undefined) ?? null,
+    onboardedAt: (onboardedPref?.value as string | undefined) ?? null,
+  };
+}
+
 export function createFridayUixRoutes(
   deps: FridayUixRoutesDeps,
 ): FridayRouteDefinition<unknown, unknown, unknown, unknown>[] {
@@ -313,13 +323,25 @@ export function createFridayUixRoutes(
       auth: { public: false, anyOfScopes: ["agent.run"] },
       async handler(ctx): Promise<FridayUserProfileResponse> {
         const userId = requireUserId(ctx.principal);
-        const prefs = deps.service.listPreferences({ userId, category: "uix" });
-        const profilePref = prefs.items.find((p) => p.key === "user.profile_type");
-        const onboardedPref = prefs.items.find((p) => p.key === "user.onboarded_at");
-        return {
-          profileType: (profilePref?.value as FridayUserProfileType | undefined) ?? null,
-          onboardedAt: (onboardedPref?.value as string | undefined) ?? null,
-        };
+        const current = readUserProfileResponse(deps.service, userId);
+        const profileType = current.profileType ?? "beginner";
+        const onboardedAt = current.onboardedAt ?? new Date().toISOString();
+        if (current.profileType === null || current.onboardedAt === null) {
+          deps.service.updatePreferences({
+            userId,
+            request: {
+              preferences: [
+                ...(current.profileType === null
+                  ? [{ category: "uix", key: "user.profile_type", value: profileType }]
+                  : []),
+                ...(current.onboardedAt === null
+                  ? [{ category: "uix", key: "user.onboarded_at", value: onboardedAt }]
+                  : []),
+              ],
+            } as never,
+          });
+        }
+        return { profileType, onboardedAt };
       },
     },
     {
@@ -347,10 +369,7 @@ export function createFridayUixRoutes(
             request: { preferences } as never,
           });
         }
-        return {
-          profileType: (profileType as FridayUserProfileType | undefined) ?? null,
-          onboardedAt: onboardedAt ?? null,
-        };
+        return readUserProfileResponse(deps.service, userId);
       },
     },
     {

--- a/src/uix/services/friday-uix-surface-service.ts
+++ b/src/uix/services/friday-uix-surface-service.ts
@@ -432,6 +432,9 @@ const TEMPLATE_DEFINITIONS: FridayActionTemplateSummary[] = [
   },
 ];
 
+const FRIDAY_UIX_PROFILE_TYPES = new Set(["beginner", "developer", "creator", "business"]);
+const FRIDAY_UIX_PREFERENCE_KEYS = new Set(["user.profile_type", "user.onboarded_at"]);
+
 const HIGH_RISK_KEYWORDS = [
   "delete",
   "drop",
@@ -518,6 +521,22 @@ function isValidCommunicationPreference(
   }
   const allowedValues = COMMUNICATION_ENUMS[settingName as keyof typeof COMMUNICATION_ENUMS] as readonly string[];
   return typeof value === "string" && allowedValues.includes(value);
+}
+
+function isValidUixPreference(
+  key: string,
+  value: unknown,
+): boolean {
+  if (!FRIDAY_UIX_PREFERENCE_KEYS.has(key)) {
+    return false;
+  }
+  if (key === "user.profile_type") {
+    return typeof value === "string" && FRIDAY_UIX_PROFILE_TYPES.has(value);
+  }
+  if (key === "user.onboarded_at") {
+    return typeof value === "string" && value.trim().length > 0 && Number.isFinite(Date.parse(value));
+  }
+  return false;
 }
 
 function summarizeWorkflowName(goal: string): string {
@@ -1366,32 +1385,40 @@ export function createFridayUixSurfaceService(
       if (!deps.db || !deps.preferenceRepo) {
         throw new FridayDomainError(
           "UIX_PREFERENCE_PERSISTENCE_UNAVAILABLE",
-          "Communication preferences are not available in this runtime",
+          "UI preferences are not available in this runtime",
           { httpStatus: 503 },
         );
       }
       const existingByKey = new Map(
-        listCommunicationPreferences(input.userId).map((preference) => [preference.key, preference]),
+        deps.db.withReadConnection((db) =>
+          deps.preferenceRepo!.listByPrincipal(db, {
+            principalId: input.userId,
+          })).map((preference) => [`${preference.category}:${preference.key}`, preference]),
       );
       let created = 0;
       let updated = 0;
       const preferences = deps.db.withWriteTransaction((db) =>
         input.request.preferences.map((preference) => {
-          if (preference.category !== "communication") {
+          const isCommunicationPreference = preference.category === "communication";
+          const isUixPreference = preference.category === "uix";
+          if (!isCommunicationPreference && !isUixPreference) {
             throw new FridayDomainError(
               "UIX_PREFERENCE_VALIDATION_FAILED",
-              "Only communication preferences are supported by this surface",
+              `Unsupported preference category: ${preference.category}`,
               { httpStatus: 400 },
             );
           }
-          if (!isValidCommunicationPreference(preference.key, preference.value)) {
+          if (
+            (isCommunicationPreference && !isValidCommunicationPreference(preference.key, preference.value))
+            || (isUixPreference && !isValidUixPreference(preference.key, preference.value))
+          ) {
             throw new FridayDomainError(
               "UIX_PREFERENCE_VALIDATION_FAILED",
-              `Invalid communication preference: ${preference.key}`,
+              `Invalid ${preference.category} preference: ${preference.key}`,
               { httpStatus: 400 },
             );
           }
-          const existing = existingByKey.get(preference.key);
+          const existing = existingByKey.get(`${preference.category}:${preference.key}`);
           if (existing) {
             updated += 1;
           } else {
@@ -1407,7 +1434,7 @@ export function createFridayUixSurfaceService(
             confidence: 1,
             nowIso: nowIso(),
           });
-          existingByKey.set(saved.key, saved);
+          existingByKey.set(`${saved.category}:${saved.key}`, saved);
           return saved;
         }));
       // Emit learning events so the learning pipeline can extract preference facts.

--- a/test/unit/api/http/routes/friday-uix-routes.test.ts
+++ b/test/unit/api/http/routes/friday-uix-routes.test.ts
@@ -178,6 +178,25 @@ function makeService(): FridayUixSurfaceService {
   };
 }
 
+function makePreference(input: {
+  id: string;
+  category: "communication" | "uix";
+  key: string;
+  value: unknown;
+}) {
+  return {
+    id: input.id,
+    principalId: "user-1",
+    category: input.category,
+    key: input.key,
+    value: input.value,
+    source: "explicit" as const,
+    confidence: 1,
+    createdAt: NOW,
+    updatedAt: NOW,
+  };
+}
+
 describe("FridayUixRoutes", () => {
   it("creates assistant route definitions", () => {
     const routes = createFridayUixRoutes({ service: makeService() });
@@ -345,5 +364,82 @@ describe("FridayUixRoutes", () => {
 
     expect(service.listIssues).toHaveBeenCalledWith({ userId: "user-1", limit: 5 });
     expect(result.items[0]?.id).toBe("issue-1");
+  });
+
+  it("self-heals missing user-profile preferences on read", async () => {
+    const service = makeService();
+    vi.mocked(service.listPreferences).mockReturnValueOnce({
+      items: [],
+      nextCursor: undefined,
+    }).mockReturnValueOnce({
+      items: [
+        makePreference({ id: "uix-1", category: "uix", key: "user.profile_type", value: "beginner" }),
+        makePreference({ id: "uix-2", category: "uix", key: "user.onboarded_at", value: NOW }),
+      ],
+      nextCursor: undefined,
+    });
+    vi.mocked(service.updatePreferences).mockReturnValue({
+      preferences: [],
+      created: 2,
+      updated: 0,
+    });
+    const routes = createFridayUixRoutes({ service });
+    const route = routes.find((entry) => entry.operationId === "uix.user.profile.get")!;
+
+    const result = await route.handler(makeCtx()) as { profileType: string; onboardedAt: string };
+
+    expect(service.updatePreferences).toHaveBeenCalledWith({
+      userId: "user-1",
+      request: {
+        preferences: [
+          { category: "uix", key: "user.profile_type", value: "beginner" },
+          { category: "uix", key: "user.onboarded_at", value: expect.any(String) },
+        ],
+      },
+    });
+    expect(result.profileType).toBe("beginner");
+    expect(typeof result.onboardedAt).toBe("string");
+    expect(Number.isFinite(Date.parse(result.onboardedAt))).toBe(true);
+  });
+
+  it("returns persisted user-profile values after update", async () => {
+    const service = makeService();
+    vi.mocked(service.listPreferences).mockReturnValue({
+      items: [
+        makePreference({ id: "uix-1", category: "uix", key: "user.profile_type", value: "developer" }),
+        makePreference({ id: "uix-2", category: "uix", key: "user.onboarded_at", value: NOW }),
+      ],
+      nextCursor: undefined,
+    });
+    vi.mocked(service.updatePreferences).mockReturnValue({
+      preferences: [],
+      created: 1,
+      updated: 1,
+    });
+    const routes = createFridayUixRoutes({ service });
+    const route = routes.find((entry) => entry.operationId === "uix.user.profile.update")!;
+
+    const result = await route.handler(
+      makeCtx({
+        body: {
+          profileType: "developer",
+          onboardedAt: NOW,
+        },
+      }),
+    ) as { profileType: string; onboardedAt: string };
+
+    expect(service.updatePreferences).toHaveBeenCalledWith({
+      userId: "user-1",
+      request: {
+        preferences: [
+          { category: "uix", key: "user.profile_type", value: "developer" },
+          { category: "uix", key: "user.onboarded_at", value: NOW },
+        ],
+      },
+    });
+    expect(result).toEqual({
+      profileType: "developer",
+      onboardedAt: NOW,
+    });
   });
 });

--- a/test/unit/uix/services/friday-uix-surface-service.test.ts
+++ b/test/unit/uix/services/friday-uix-surface-service.test.ts
@@ -22,6 +22,57 @@ describe("createFridayUixSurfaceService", () => {
     return { db, wizardContextRepo, persisted };
   }
 
+  function createPreferencePersistenceHarness() {
+    const stored = new Map<string, {
+      id: string;
+      principalId: string;
+      category: string;
+      key: string;
+      value: unknown;
+      source: "explicit" | "implicit";
+      confidence: number;
+      createdAt: string;
+      updatedAt: string;
+    }>();
+    const db = {
+      withWriteTransaction: <T>(callback: (db: Record<string, never>) => T) => callback({}),
+      withReadConnection: <T>(callback: (db: Record<string, never>) => T) => callback({}),
+    };
+    const preferenceRepo = {
+      listByPrincipal: vi.fn((_db: unknown, input: { principalId: string; category?: string }) =>
+        [...stored.values()].filter((item) =>
+          item.principalId === input.principalId && (!input.category || item.category === input.category)
+        )),
+      upsert: vi.fn((_db: unknown, input: {
+        id: string;
+        principalId: string;
+        category: string;
+        key: string;
+        value: unknown;
+        source: "explicit" | "implicit";
+        confidence: number;
+        nowIso: string;
+      }) => {
+        const mapKey = `${input.principalId}:${input.category}:${input.key}`;
+        const existing = stored.get(mapKey);
+        const saved = {
+          id: input.id,
+          principalId: input.principalId,
+          category: input.category,
+          key: input.key,
+          value: input.value,
+          source: input.source,
+          confidence: input.confidence,
+          createdAt: existing?.createdAt ?? input.nowIso,
+          updatedAt: input.nowIso,
+        };
+        stored.set(mapKey, saved);
+        return saved;
+      }),
+    };
+    return { db, preferenceRepo, stored };
+  }
+
   it("writes the latest harness summary into assistant focus for skill generation", async () => {
     const sessionService = {
       getOrCreateSession: vi.fn(async () => ({ key: "ui:assistant:assistant-shell" })),
@@ -71,6 +122,39 @@ describe("createFridayUixSurfaceService", () => {
         lastHarnessSummary: "Skill draft is ready for review.",
       }),
     );
+  });
+
+  it("persists uix user-profile preferences instead of rejecting them", () => {
+    const persistence = createPreferencePersistenceHarness();
+    const service = createFridayUixSurfaceService({
+      db: persistence.db as never,
+      preferenceRepo: persistence.preferenceRepo as never,
+      idGenerator: (() => {
+        let counter = 0;
+        return () => `pref-${++counter}`;
+      })(),
+      nowIso: () => "2026-04-04T02:00:00.000Z",
+      selfHealing: {
+        listIssueCards: vi.fn(() => []),
+      } as never,
+    });
+
+    const result = service.updatePreferences({
+      userId: "user-1",
+      request: {
+        preferences: [
+          { category: "uix", key: "user.profile_type", value: "developer" },
+          { category: "uix", key: "user.onboarded_at", value: "2026-04-04T02:00:00.000Z" },
+        ],
+      },
+    });
+
+    expect(result.created).toBe(2);
+    expect(result.updated).toBe(0);
+    expect(service.listPreferences({ userId: "user-1", category: "uix" }).items).toEqual([
+      expect.objectContaining({ category: "uix", key: "user.profile_type", value: "developer" }),
+      expect.objectContaining({ category: "uix", key: "user.onboarded_at", value: "2026-04-04T02:00:00.000Z" }),
+    ]);
   });
 
   it("writes harness focus for wizard clarification continuations", async () => {


### PR DESCRIPTION
## What changed
- allow `uix` preference writes in `FridayUixSurfaceService.updatePreferences()` instead of rejecting them as communication-only
- make `GET /v1/uix/user-profile` self-heal missing `user.profile_type` and `user.onboarded_at`
- make `PUT /v1/uix/user-profile` return the persisted merged profile state
- add targeted unit coverage for the route and service behavior

## Root cause
The UIX user-profile API existed, but the underlying preference service only accepted `communication` preferences. The onboarding UI therefore wrote local fallback state in the browser, while server-side `uix` profile values never persisted. Fresh sessions and validation harness runs then saw `profileType=null` and `onboardedAt=null`, which caused setup-complete sessions to look like first-time users.

## Impact
- onboarding state now persists server-side instead of only in localStorage
- missing `uix` profile state is repaired on read
- setup-complete sessions stop looking like perpetual first visits in real-world validation

## Validation
- `npx vitest run test/unit/api/http/routes/friday-uix-routes.test.ts test/unit/uix/services/friday-uix-surface-service.test.ts`
