### PR TITLE
Fix real-world smoke follow-ups

### DIFF
--- a/src/learning/services/friday-self-healing-api-service.ts
+++ b/src/learning/services/friday-self-healing-api-service.ts
@@ -1,3 +1,4 @@
+import type Database from "better-sqlite3";
 import type { FridaySqliteLayer } from "#state";
 import { FridayDomainError } from "#errors";
 import type {
@@ -419,6 +420,29 @@ function normalizeLearningKeySegment(value: string): string {
     .toLowerCase()
     .replace(/[^a-z0-9._-]+/g, "-")
     .replace(/^-+|-+$/g, "");
+}
+
+function sqliteTableExists(db: Database.Database, tableName: string): boolean {
+  return db.prepare(
+    `SELECT 1
+       FROM sqlite_master
+      WHERE type = 'table'
+        AND name = ?
+      LIMIT 1`,
+  ).get(tableName) != null;
+}
+
+function countRowsIfTableExists(
+  db: Database.Database,
+  tableName: string,
+  sql: string,
+  ...params: unknown[]
+): number {
+  if (!sqliteTableExists(db, tableName)) {
+    return 0;
+  }
+  const row = db.prepare(sql).get(...params) as { count?: number } | undefined;
+  return row?.count ?? 0;
 }
 
 export function createFridaySelfHealingApiService(
@@ -855,14 +879,28 @@ export function createFridaySelfHealingApiService(
       .slice(0, limit);
 
     const incidentCount = deps.db.withReadConnection((db) =>
-      db.prepare(`SELECT COUNT(*) AS count FROM friday_error_incidents WHERE user_id = ?`).get(input.userId) as { count: number },
-    ).count;
+      countRowsIfTableExists(
+        db,
+        "friday_error_incidents",
+        `SELECT COUNT(*) AS count FROM friday_error_incidents WHERE user_id = ?`,
+        input.userId,
+      ),
+    );
     const diagnosisCount = deps.db.withReadConnection((db) =>
-      db.prepare(`SELECT COUNT(*) AS count FROM friday_diagnosis_records`).get() as { count: number },
-    ).count;
+      countRowsIfTableExists(
+        db,
+        "friday_diagnosis_records",
+        `SELECT COUNT(*) AS count FROM friday_diagnosis_records`,
+      ),
+    );
     const actionCount = deps.db.withReadConnection((db) =>
-      db.prepare(`SELECT COUNT(*) AS count FROM friday_auto_fix_actions WHERE user_id = ?`).get(input.userId) as { count: number },
-    ).count;
+      countRowsIfTableExists(
+        db,
+        "friday_auto_fix_actions",
+        `SELECT COUNT(*) AS count FROM friday_auto_fix_actions WHERE user_id = ?`,
+        input.userId,
+      ),
+    );
 
     return {
       lessons,

--- a/test/unit/learning/services/friday-self-healing-api-service.test.ts
+++ b/test/unit/learning/services/friday-self-healing-api-service.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { FridaySqliteLayer } from "#state";
+import {
+  createFridayApprovalRequestRepository,
+  createFridayAutoFixActionRepository,
+  createFridayDiagnosisRecordRepository,
+  createFridayErrorIncidentRepository,
+  createFridayLearnedLessonRepository,
+  createFridayPreferenceFactRepository,
+  createFridaySelfHealingApiService,
+  createFridaySelfLearningRuntime,
+} from "#learning";
+import { createTestDb, createTestIdGenerator } from "../../satellites/_helpers/create-test-db.helper.js";
+
+const NOW = "2026-04-04T02:00:00.000Z";
+
+describe("FridaySelfHealingApiService", () => {
+  let db: FridaySqliteLayer;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("returns a learning overview when incidents table is absent", () => {
+    const idGenerator = createTestIdGenerator();
+    const runtime = createFridaySelfLearningRuntime({
+      db,
+      idGenerator,
+      nowIso: () => NOW,
+    });
+    const service = createFridaySelfHealingApiService({
+      db,
+      idGenerator,
+      nowIso: () => NOW,
+      incidentRepo: createFridayErrorIncidentRepository(),
+      diagnosisRepo: createFridayDiagnosisRecordRepository(),
+      lessonRepo: createFridayLearnedLessonRepository(),
+      actionRepo: createFridayAutoFixActionRepository(),
+      approvalRepo: createFridayApprovalRequestRepository(),
+      factRepo: createFridayPreferenceFactRepository(),
+      diagnosisService: runtime.diagnosis,
+      planService: runtime.autoFixPlan,
+      riskService: runtime.autoFixRisk,
+      executionService: runtime.autoFixExecution,
+      rollbackService: runtime.autoFixRollback,
+      approvalService: runtime.approvals,
+      autoFixDispatcher: runtime.autoFixDispatcher,
+      metricsService: runtime.metrics,
+      pipeline: runtime.pipeline,
+    });
+
+    const overview = service.getLearningOverview({ userId: "user-1", limit: 10 });
+
+    expect(overview.coverage.incidents).toBe(0);
+    expect(overview.lessons).toEqual([]);
+    expect(overview.patterns).toEqual([]);
+  });
+});

--- a/validation/real-world/lib/executors.mjs
+++ b/validation/real-world/lib/executors.mjs
@@ -201,7 +201,11 @@ async function executeUiProbe({ artifact, client, scenario, reportRoot, uiBaseUr
   const browser = await chromium.launch({ headless: true });
   const requestUrls = [];
   const requestFailures = [];
+  const reloadAbortedRequestFailures = [];
   const consoleErrors = [];
+  const requestOrder = new WeakMap();
+  let requestSequence = 0;
+  let reloadAbortCutoff = null;
   const startedAt = Date.now();
 
   try {
@@ -231,9 +235,19 @@ async function executeUiProbe({ artifact, client, scenario, reportRoot, uiBaseUr
     const page = await context.newPage();
     page.on("request", (request) => {
       requestUrls.push(request.url());
+      requestSequence += 1;
+      requestOrder.set(request, requestSequence);
     });
     page.on("requestfailed", (request) => {
-      requestFailures.push(`${request.method()} ${request.url()} :: ${request.failure()?.errorText ?? "failed"}`);
+      const message = `${request.method()} ${request.url()} :: ${request.failure()?.errorText ?? "failed"}`;
+      const errorText = request.failure()?.errorText ?? "failed";
+      const startedBeforeIntentionalReload = reloadAbortCutoff != null
+        && (requestOrder.get(request) ?? Number.POSITIVE_INFINITY) <= reloadAbortCutoff;
+      if (startedBeforeIntentionalReload && /ERR_ABORTED/i.test(errorText)) {
+        reloadAbortedRequestFailures.push(message);
+        return;
+      }
+      requestFailures.push(message);
     });
     page.on("console", (message) => {
       if (message.type() === "error") {
@@ -265,13 +279,16 @@ async function executeUiProbe({ artifact, client, scenario, reportRoot, uiBaseUr
       );
     };
 
+    const idleWindowMs = execution.idleWindowMs ?? 1_500;
     await waitForReady();
     const firstVisibleSignalMs = Date.now() - startedAt;
+    await page.waitForTimeout(idleWindowMs);
     if (execution.reloadCheck) {
+      reloadAbortCutoff = requestSequence;
       await page.reload({ waitUntil: "domcontentloaded", timeout: scenarioTimeout(scenario, 90_000) });
       await waitForReady();
+      await page.waitForTimeout(idleWindowMs);
     }
-    await page.waitForTimeout(execution.idleWindowMs ?? 1_500);
 
     const screenshotPath = path.join(
       reportRoot,
@@ -310,6 +327,7 @@ async function executeUiProbe({ artifact, client, scenario, reportRoot, uiBaseUr
       allowedFinalPathPrefixes,
       consoleErrors,
       requestFailures,
+      reloadAbortedRequestFailures,
       significantRequestFailures,
       requestUrls,
       statusCode: gotoResponse?.status() ?? 0,


### PR DESCRIPTION
## Summary
- make learning overview coverage counts tolerate missing self-healing tables instead of returning 500
- treat harness-triggered reload aborts separately so L1 UI probes stop flagging intentional reload noise as failures
- add a unit test for missing-table learning overview behavior

## Verification
- `npx vitest run test/unit/learning/services/friday-self-healing-api-service.test.ts`
- `npm run validate:real-world:smoke -- --mint-local-admin-token --judge never --layer L1`
- `npm run validate:real-world:smoke -- --mint-local-admin-token --judge never`
