### PR TITLE
Fix real-world file tool workspace path

### DIFF
--- a/validation/real-world/catalog/scenarios.mjs
+++ b/validation/real-world/catalog/scenarios.mjs
@@ -557,7 +557,7 @@ export const REAL_WORLD_SCENARIOS = [
     productArea: "tools",
     entrySurface: "/v1/agent/runs",
     routeFamily: "file tool",
-    realWorldPrompt: "Use the filesystem to read /Users/jarvis/Projects/Friday/README.md and answer with its top H1 heading only.",
+    realWorldPrompt: "Use the filesystem to read {{repoRoot}}/README.md and answer with its top H1 heading only.",
     expectedEvidence: [
       "agent uses at least one tool call",
       "output reflects filesystem content rather than a guess",

--- a/validation/real-world/lib/executors.mjs
+++ b/validation/real-world/lib/executors.mjs
@@ -160,19 +160,27 @@ async function executeEnvTruth({ artifact, scenario, envTruth }) {
 }
 
 function resolveAgentTurnPrompt({ scenario, execution, suite, attemptIndex, turn, turnIndex }) {
+  const applyPromptVariables = (value) => {
+    if (typeof value !== "string" || value.length === 0) {
+      return value;
+    }
+    return value
+      .replaceAll("{{repoRoot}}", process.cwd())
+      .replaceAll("{{workspaceRoot}}", process.cwd());
+  };
   if (typeof turn?.prompt === "string" && turn.prompt.trim().length > 0) {
-    return turn.prompt;
+    return applyPromptVariables(turn.prompt);
   }
   const bySuite = execution.promptVariantsBySuite?.[suite];
   if (Array.isArray(bySuite) && bySuite.length > 0) {
     const index = Math.max(0, ((attemptIndex ?? 1) - 1 + turnIndex) % bySuite.length);
-    return bySuite[index];
+    return applyPromptVariables(bySuite[index]);
   }
   if (Array.isArray(execution.promptVariants) && execution.promptVariants.length > 0) {
     const index = Math.max(0, ((attemptIndex ?? 1) - 1 + turnIndex) % execution.promptVariants.length);
-    return execution.promptVariants[index];
+    return applyPromptVariables(execution.promptVariants[index]);
   }
-  return scenario.realWorldPrompt;
+  return applyPromptVariables(scenario.realWorldPrompt);
 }
 
 async function executeHttpProbe({ artifact, client, scenario }) {


### PR DESCRIPTION
## Summary
- resolve real-world agent prompts against the current repo root so file-tool scenarios do not point at a stale worktree path
- keep the L4 file roundtrip scenario portable across clean worktrees and merged-main validation runs

## Verification
- `npm run validate:real-world:smoke -- --mint-local-admin-token --judge never --scenario l4-file-tool-roundtrip`
- `npm run validate:real-world:smoke -- --mint-local-admin-token --judge never`
