### PR TITLE
Harden runtime chat and immediate run contracts

### DIFF
--- a/src/api/http/routes/friday-agent-routes.ts
+++ b/src/api/http/routes/friday-agent-routes.ts
@@ -1,5 +1,14 @@
 import type { FridayRouteDefinition } from "../../model/friday-api-common.types.js";
 import type {
+  FridayAgentRunExecutionResponse,
+  FridayCancelAgentRunResponse,
+  FridayGetAgentRunResponse,
+  FridayListAgentRunsQuery,
+  FridayListAgentRunsResponse,
+  FridayStartAgentRunRequest,
+  FridayStartAgentRunResponse,
+} from "../../model/friday-api-agent.types.js";
+import type {
   FridayAgentAutomationSchedule,
   FridayAgentAutomationService,
   FridayAgentAutomationSessionTarget,
@@ -76,6 +85,24 @@ export interface FridayAgentRoutesDeps {
   automationService: FridayAgentAutomationService;
 }
 
+function toFridayAgentRunExecutionResponse(
+  result: FridayAgentRuntimeResult,
+): FridayAgentRunExecutionResponse {
+  return {
+    runId: result.runId,
+    status: result.status,
+    response: result.response,
+    toolCallCount: result.toolCallCount,
+    durationMs: result.durationMs,
+    usageInput: result.usageInput,
+    usageOutput: result.usageOutput,
+    ...(result.images ? { images: result.images } : {}),
+    ...(result.finalResponse ? { finalResponse: result.finalResponse } : {}),
+    ...(result.contextCostSummary ? { contextCostSummary: result.contextCostSummary } : {}),
+    ...(result.taskProfile ? { taskProfile: result.taskProfile } : {}),
+  };
+}
+
 // ─── SSE response type ───
 
 /** Describes the raw Node `ServerResponse` shape needed for SSE streaming. */
@@ -136,7 +163,7 @@ export function createFridayAgentRoutes(
       auth: { public: false, anyOfScopes: [...AGENT_RUN_SCOPES] },
       rateLimitPolicyId: "agent.run",
       async handler(ctx) {
-        const body = ctx.body as Record<string, unknown> | null;
+        const body = ctx.body as FridayStartAgentRunRequest | null;
         if (!body || typeof body.task !== "string" || body.task.trim() === "") {
           throw new FridayDomainError(
             "VALIDATION_ERROR",
@@ -286,7 +313,11 @@ export function createFridayAgentRoutes(
           executionContext,
           ...principalInput,
         });
-        return result;
+        const response: FridayStartAgentRunResponse = {
+          ...toFridayAgentRunExecutionResponse(result),
+          eventStreamAvailable: true,
+        };
+        return response;
       },
     },
 
@@ -297,7 +328,7 @@ export function createFridayAgentRoutes(
       path: "/v1/agent/runs",
       auth: { public: false, anyOfScopes: [...AGENT_READ_SCOPES] },
       async handler(ctx) {
-        const query = ctx.query as Record<string, string | undefined>;
+        const query = ctx.query as FridayListAgentRunsQuery;
 
         let limit: number | undefined;
         if (query.limit !== undefined) {
@@ -315,7 +346,8 @@ export function createFridayAgentRoutes(
         const status = query.status as FridayAgentRunStatus | undefined;
 
         const items = deps.listRuns({ status, limit, cursor: query.cursor });
-        return { items };
+        const response: FridayListAgentRunsResponse = { items };
+        return response;
       },
     },
 
@@ -335,7 +367,8 @@ export function createFridayAgentRoutes(
             { httpStatus: 404 },
           );
         }
-        return { run };
+        const response: FridayGetAgentRunResponse = { run };
+        return response;
       },
     },
 
@@ -363,7 +396,8 @@ export function createFridayAgentRoutes(
           );
         }
         deps.cancelRun(runId);
-        return { cancelled: true, runId };
+        const response: FridayCancelAgentRunResponse = { cancelled: true, runId };
+        return response;
       },
     },
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -180,6 +180,15 @@ export type { FridayUixRoutesDeps } from "./http/routes/friday-uix-routes.js";
 // Discovery routes (C-005)
 export { createFridayDiscoveryRoutes } from "./http/routes/friday-discovery-routes.js";
 export type { FridayDiscoveryRoutesDeps } from "./http/routes/friday-discovery-routes.js";
+export type {
+  FridayAgentRunExecutionResponse,
+  FridayCancelAgentRunResponse,
+  FridayGetAgentRunResponse,
+  FridayListAgentRunsQuery,
+  FridayListAgentRunsResponse,
+  FridayStartAgentRunRequest,
+  FridayStartAgentRunResponse,
+} from "./model/friday-api-agent.types.js";
 
 // MCP server routes (C-011)
 export { createFridayMcpServerRoutes } from "./http/routes/friday-mcp-server-routes.js";

--- a/src/api/model/friday-api-agent.types.ts
+++ b/src/api/model/friday-api-agent.types.ts
@@ -1,0 +1,59 @@
+import type {
+  FridayAgentContextCostSummary,
+  FridayAgentExecutionContext,
+  FridayAgentRunRecord,
+  FridayAgentRunStatus,
+  FridayAgentTaskProfileInput,
+  FridayResolvedAgentTaskProfile,
+} from "#agent";
+import type { FridayPaginationQuery } from "./friday-api-common.types.js";
+
+export interface FridayStartAgentRunRequest {
+  task: string;
+  marketplaceListingId?: string;
+  providerId?: string;
+  model?: string;
+  replyToMessageId?: string;
+  sessionKey?: string;
+  timezone?: string;
+  timeoutMs?: number;
+  requireReview?: boolean;
+  constraints?: { readOnly?: boolean };
+  taskProfile?: FridayAgentTaskProfileInput;
+  executionContext?: FridayAgentExecutionContext;
+}
+
+export interface FridayAgentRunExecutionResponse {
+  runId: string;
+  status: FridayAgentRunStatus;
+  response: string;
+  toolCallCount: number;
+  durationMs: number;
+  usageInput: number;
+  usageOutput: number;
+  images?: string[];
+  finalResponse?: string;
+  contextCostSummary?: FridayAgentContextCostSummary;
+  taskProfile?: FridayResolvedAgentTaskProfile;
+}
+
+export interface FridayStartAgentRunResponse extends FridayAgentRunExecutionResponse {
+  eventStreamAvailable: true;
+}
+
+export interface FridayListAgentRunsQuery extends FridayPaginationQuery {
+  status?: FridayAgentRunStatus;
+}
+
+export interface FridayListAgentRunsResponse {
+  items: FridayAgentRunRecord[];
+}
+
+export interface FridayGetAgentRunResponse {
+  run: FridayAgentRunRecord;
+}
+
+export interface FridayCancelAgentRunResponse {
+  cancelled: boolean;
+  runId: string;
+}

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -99,6 +99,7 @@ import type {
 } from "#agent";
 import { buildFridayEvidenceBlocks } from "#agent";
 import { createFridayOrchestrationEngine } from "#engine";
+import { createFridayImmediateRunPersistence } from "#engine";
 import type { FridayEngineRunResult } from "#engine";
 import type { CreateFridayEngineTurnPreparerDeps } from "#engine";
 import type { CreateFridayEngineRunExecutorDeps } from "#engine";
@@ -1709,6 +1710,16 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
       sessionService.setConversationFocus(key, state).then(() => undefined),
   };
 
+  const persistImmediateRunResult = agentRepo && agentRunEventRepo
+    ? createFridayImmediateRunPersistence({
+      db: deps.db,
+      repo: agentRepo,
+      runEventRepository: agentRunEventRepo,
+      idGenerator: deps.idGenerator,
+      nowIso: deps.nowIso,
+    })
+    : undefined;
+
   const orchestrationEngine = deps.agentRuntime
     ? createFridayOrchestrationEngine({
       turnPreparerDeps: {
@@ -1726,6 +1737,7 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
         sessionDeps: engineSessionDeps,
         planningGate: agentPlanningGate,
         nowIso: deps.nowIso,
+        persistImmediateRunResult,
         dispatchDeterministic,
         dispatchManagedAsync,
         finalizeFocus: finalizeFridayConversationFocus as CreateFridayEngineRunExecutorDeps["finalizeFocus"],

--- a/src/engine/adapters/friday-channel-entry-adapter.ts
+++ b/src/engine/adapters/friday-channel-entry-adapter.ts
@@ -38,6 +38,10 @@ export interface FridayChannelInboundMessage {
   replyToMessageId?: string;
   /** Optional timezone. */
   timezone?: string;
+  /** Optional unix timestamp in milliseconds. */
+  timestamp?: number;
+  /** Optional image attachments already normalized by the channel layer. */
+  images?: string[];
 }
 
 // ─── Adapter ───
@@ -46,7 +50,7 @@ export interface FridayChannelEntryAdapterDeps {
   engine: FridayOrchestrationEngine;
   idGenerator: () => string;
   /** Resolve a session key from channel + chat identifiers. */
-  resolveSessionKey: (channelKind: string, chatId: string) => string;
+  resolveSessionKey: (message: FridayChannelInboundMessage) => string;
 }
 
 export function createFridayChannelEntryAdapter(deps: FridayChannelEntryAdapterDeps) {
@@ -71,10 +75,16 @@ export function createFridayChannelEntryAdapter(deps: FridayChannelEntryAdapterD
     const input: FridayEngineRunInput = {
       task,
       runId: idGenerator(),
-      sessionKey: resolveSessionKey(msg.channelKind, msg.chatId),
+      sessionKey: resolveSessionKey(msg),
       replyToMessageId: msg.replyToMessageId,
       timezone: msg.timezone,
       principalId: msg.senderId,
+      images: msg.images,
+      taskAlreadyInHistory: true,
+      executionContext: {
+        surface: "channel",
+        interactive: true,
+      },
       tenantContext: {
         hubId: "default",
         userId: msg.senderId,

--- a/src/engine/friday-engine-run-executor.ts
+++ b/src/engine/friday-engine-run-executor.ts
@@ -126,6 +126,15 @@ export interface CreateFridayEngineRunExecutorDeps {
   sessionDeps?: FridayEngineTurnPreparerSessionDeps;
   planningGate?: FridayEnginePlanningGate;
   nowIso: () => string;
+  persistImmediateRunResult?: (input: {
+    runId: string;
+    task: string;
+    sessionKey?: string;
+    providerId?: string;
+    model?: string;
+    constraints?: { readOnly?: boolean };
+    responseText: string;
+  }) => void | Promise<void>;
 
   // Dispatch functions injected for testability
   dispatchDeterministic: (
@@ -200,6 +209,7 @@ export function createFridayEngineRunExecutor(deps: CreateFridayEngineRunExecuto
     deterministicDispatchDeps,
     managedAsyncDispatchDeps,
     resolveIdempotencyKey,
+    persistImmediateRunResult,
   } = deps;
 
   /**
@@ -220,6 +230,16 @@ export function createFridayEngineRunExecutor(deps: CreateFridayEngineRunExecuto
       durationMs: 0,
       turnKind: prepared.conversationContext?.turnKind,
     };
+
+    await persistImmediateRunResult?.({
+      runId: input.runId,
+      task: input.task,
+      sessionKey: input.sessionKey,
+      providerId: input.providerId,
+      model: input.model,
+      constraints: input.constraints,
+      responseText,
+    });
 
     if (input.sessionKey && sessionDeps) {
       await sessionDeps

--- a/src/engine/friday-immediate-run-persistence.ts
+++ b/src/engine/friday-immediate-run-persistence.ts
@@ -1,0 +1,86 @@
+import type {
+  FridayAgentRunEventRepository,
+  FridayAgentRunRepository,
+} from "#agent";
+import type { FridaySqliteLayer } from "#state";
+
+export interface CreateFridayImmediateRunPersistenceDeps {
+  db: FridaySqliteLayer;
+  repo: FridayAgentRunRepository;
+  runEventRepository: FridayAgentRunEventRepository;
+  idGenerator: () => string;
+  nowIso: () => string;
+}
+
+export interface FridayImmediateRunPersistenceInput {
+  runId: string;
+  task: string;
+  sessionKey?: string;
+  providerId?: string;
+  model?: string;
+  constraints?: { readOnly?: boolean };
+  responseText: string;
+}
+
+export function createFridayImmediateRunPersistence(
+  deps: CreateFridayImmediateRunPersistenceDeps,
+) {
+  return (input: FridayImmediateRunPersistenceInput): void => {
+    const existingRun = deps.db.withReadConnection((reader) => deps.repo.getById(reader, input.runId));
+    if (existingRun) {
+      return;
+    }
+
+    const now = deps.nowIso();
+    const sessionKey = input.sessionKey ?? `agent:run:${input.runId}`;
+
+    deps.db.withWriteTransaction((writer) => {
+      deps.repo.create(writer, {
+        id: input.runId,
+        task: input.task,
+        sessionKey,
+        providerId: input.providerId,
+        model: input.model,
+        maxAttempts: 1,
+        nowIso: now,
+        constraints: input.constraints,
+      });
+      deps.repo.update(writer, {
+        id: input.runId,
+        status: "completed",
+        startedAt: now,
+        completedAt: now,
+        durationMs: 0,
+        responseText: input.responseText,
+        summary: input.responseText,
+      });
+      deps.runEventRepository.append(writer, {
+        eventId: deps.idGenerator(),
+        runId: input.runId,
+        seq: 1,
+        eventName: "agent.run.text_delta",
+        payload: {
+          runId: input.runId,
+          delta: input.responseText,
+        },
+        emittedAt: now,
+        createdAt: now,
+      });
+      deps.runEventRepository.append(writer, {
+        eventId: deps.idGenerator(),
+        runId: input.runId,
+        seq: 2,
+        eventName: "agent.run.completed",
+        payload: {
+          runId: input.runId,
+          durationMs: 0,
+          toolCallCount: 0,
+          testsPassed: true,
+          artifacts: [],
+        },
+        emittedAt: now,
+        createdAt: now,
+      });
+    });
+  };
+}

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -34,6 +34,11 @@ export type {
   FridayEngineRunExecutorAgentRuntime,
   FridayEnginePlanningGate,
 } from "./friday-engine-run-executor.js";
+export { createFridayImmediateRunPersistence } from "./friday-immediate-run-persistence.js";
+export type {
+  CreateFridayImmediateRunPersistenceDeps,
+  FridayImmediateRunPersistenceInput,
+} from "./friday-immediate-run-persistence.js";
 
 // Entry adapters
 export { createFridayApiEntryAdapter } from "./adapters/friday-api-entry-adapter.js";

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -144,7 +144,8 @@ import { dispatchDeterministic } from "../sessions/services/friday-deterministic
 import type { FridayDeterministicDispatchDeps } from "../sessions/services/friday-deterministic-dispatch.js";
 import { dispatchManagedAsync } from "../sessions/services/friday-managed-async-dispatch.js";
 import type { FridayManagedAsyncDispatchDeps } from "../sessions/services/friday-managed-async-dispatch.js";
-import { createFridayOrchestrationEngine } from "#engine";
+import { createFridayChannelEntryAdapter, createFridayOrchestrationEngine } from "#engine";
+import { createFridayImmediateRunPersistence } from "#engine";
 import type { CreateFridayEngineRunExecutorDeps, CreateFridayEngineTurnPreparerDeps } from "#engine";
 import type { FridayImageAnalysisFn } from "#agent";
 import type {
@@ -4735,6 +4736,13 @@ export async function createFridayHub(
       const managedAsyncDispatchDeps: FridayManagedAsyncDispatchDeps = {
         workflowExecutionService: workflowRuntime.execution,
       };
+      const persistImmediateRunResult = createFridayImmediateRunPersistence({
+        db: stateRuntime!.sqlite,
+        repo: agentRunRepo,
+        runEventRepository: agentRunEventRepository,
+        idGenerator,
+        nowIso,
+      });
 
       // ── Channel Orchestration Engine (Initiative A-WIRE) ──
       const channelEngineSessionDeps = {
@@ -4761,6 +4769,7 @@ export async function createFridayHub(
           sessionDeps: channelEngineSessionDeps,
           planningGate: agentPlanningGate,
           nowIso,
+          persistImmediateRunResult,
           dispatchDeterministic,
           dispatchManagedAsync,
           finalizeFocus: finalizeFridayConversationFocus as CreateFridayEngineRunExecutorDeps["finalizeFocus"],
@@ -4769,7 +4778,6 @@ export async function createFridayHub(
           resolveIdempotencyKey: resolveAgentMirrorIdempotencyKey,
         },
       });
-
       if (channelsConfig.enabled && channelRegistry.list().length > 0) {
         const channelMessageHandler = (msg: FridayChannelMessage) => {
           const text = sanitizeChannelInput(msg.text);
@@ -4866,6 +4874,26 @@ export async function createFridayHub(
 
           void (async () => {
             const runId = idGenerator();
+            const channelEntryAdapter = createFridayChannelEntryAdapter({
+              engine: channelOrchestrationEngine,
+              idGenerator: () => runId,
+              resolveSessionKey: (inboundMessage) => resolveFridayChannelSessionKey({
+                channelKind: inboundMessage.channelKind,
+                chatId: inboundMessage.chatId,
+                senderId: inboundMessage.senderId,
+                senderName: inboundMessage.senderName,
+                text: inboundMessage.text,
+                id: inboundMessage.id,
+                timestamp: inboundMessage.timestamp ?? Date.now(),
+                chatType: inboundMessage.chatType,
+                replyTo: inboundMessage.replyToMessageId,
+                timezone: inboundMessage.timezone,
+                images: inboundMessage.images,
+              }, {
+                crossChannelIdentityEnabled,
+                identityMap: crossChannelIdentityMap,
+              }),
+            });
             const slowTaskNotifier = createFridayChannelSlowTaskNotifier({
               eventEmitter: agentEventEmitter,
               channelRegistry,
@@ -4902,20 +4930,18 @@ export async function createFridayHub(
               // evidence blocks, deterministic dispatch, planning gate,
               // agent runtime execution, and focus finalization.
               // Alignment invariant: the engine injects historyMessages, into executeRun() internally.
-              const engineResult = await channelOrchestrationEngine.executeRun({
-                task: text,
-                runId,
-                sessionKey,
+              const engineResult = await channelEntryAdapter.handleMessage({
+                id: msg.id,
+                channelKind: msg.channelKind,
+                senderId: msg.senderId,
+                senderName: msg.senderName,
+                chatId: msg.chatId,
+                chatType: msg.chatType,
+                text,
+                occurredAt: new Date(msg.timestamp).toISOString(),
                 replyToMessageId: msg.replyTo,
                 timezone: msg.timezone,
-                principalId: msg.senderId,
                 images: msg.images,
-                taskAlreadyInHistory: true, // hub persists user message above
-                idempotencyPrefix: `channel-${msg.channelKind}`,
-                executionContext: {
-                  surface: "channel",
-                  interactive: true,
-                },
               });
               const result = {
                 runId: engineResult.runId,

--- a/test/e2e/mock/friday-mock-sessions.e2e.test.ts
+++ b/test/e2e/mock/friday-mock-sessions.e2e.test.ts
@@ -202,4 +202,53 @@ describe("Friday Mock Sessions E2E", () => {
     expect(getRunRes.json.ok).toBe(true);
     expect(getRunRes.json.data.run.status).toBe("completed");
   });
+
+  it("deterministic immediate runs remain readable via getRun and replayable via events", async () => {
+    const sessionKey = "chat:default:mock-deterministic-events";
+
+    const runRes = await apiFetch<{
+      ok: boolean;
+      data: {
+        runId: string;
+        status: string;
+        response: string;
+        eventStreamAvailable: boolean;
+      };
+    }>(
+      env.baseUrl,
+      env.accessToken,
+      "POST",
+      "/v1/agent/runs",
+      { task: "What can you do right now?", sessionKey },
+    );
+
+    expect(runRes.status).toBe(200);
+    expect(runRes.json.ok).toBe(true);
+    expect(runRes.json.data.status).toBe("completed");
+    expect(runRes.json.data.eventStreamAvailable).toBe(true);
+    expect(runRes.json.data.response).toContain("Current capabilities:");
+
+    const getRunRes = await apiFetch<{
+      ok: boolean;
+      data: { run: { id: string; status: string; responseText?: string } };
+    }>(env.baseUrl, env.accessToken, "GET", `/v1/agent/runs/${runRes.json.data.runId}`);
+
+    expect(getRunRes.status).toBe(200);
+    expect(getRunRes.json.data.run.status).toBe("completed");
+    expect(getRunRes.json.data.run.responseText).toContain("Current capabilities:");
+
+    const eventsRes = await fetch(
+      `${env.baseUrl}/v1/agent/runs/${encodeURIComponent(runRes.json.data.runId)}/events`,
+      {
+        headers: {
+          Authorization: `Bearer ${env.accessToken}`,
+          Accept: "text/event-stream",
+        },
+      },
+    );
+    const eventsText = await eventsRes.text();
+    expect(eventsRes.status).toBe(200);
+    expect(eventsText).toContain('"type":"agent.run.text_delta"');
+    expect(eventsText).toContain('"type":"agent.run.completed"');
+  });
 });

--- a/test/e2e/ui/friday-agent-os-browser-journeys.test.ts
+++ b/test/e2e/ui/friday-agent-os-browser-journeys.test.ts
@@ -21,6 +21,11 @@ async function waitForAssistant(pageHandle: FridayBrowserPageHandle): Promise<vo
   await pageHandle.page.waitForSelector('[data-testid="assistant-goal-input"]');
 }
 
+async function waitForChat(pageHandle: FridayBrowserPageHandle): Promise<void> {
+  await pageHandle.page.goto("/chat");
+  await pageHandle.page.waitForSelector('textarea[placeholder*="Ask Friday anything"]');
+}
+
 async function waitForOutcomeAction(
   pageHandle: FridayBrowserPageHandle,
   action: "save" | "schedule" | "package" | "publish_later",
@@ -109,6 +114,19 @@ describe.skipIf(!CHROMIUM_AVAILABLE)("Friday Agent OS browser incentive journeys
       await env.cleanup();
       env = null;
     }
+  });
+
+  it("chat handles immediate capability answers without hanging on the stream", { timeout: BROWSER_E2E_TIMEOUT_MS }, async () => {
+    env = await createFridayBrowserE2eEnv();
+    pageHandle = await env.newPage();
+    await waitForChat(pageHandle);
+
+    await pageHandle.page.getByRole("button", { name: "Help" }).click();
+    await pageHandle.page.waitForFunction(() =>
+      document.body.textContent?.includes("Current capabilities:") ?? false
+    );
+
+    expect(await pageHandle.page.locator("body").textContent()).not.toContain("Failed to send message");
   });
 
   it("assistant -> outcome receipt -> save creates a leverage-scored automation", { timeout: BROWSER_E2E_TIMEOUT_MS }, async () => {

--- a/test/unit/api/http/routes/friday-agent-routes.test.ts
+++ b/test/unit/api/http/routes/friday-agent-routes.test.ts
@@ -183,7 +183,10 @@ describe("FridayAgentRoutes", () => {
         model: "gpt-4",
         timeoutMs: 60000,
       });
-      expect(result).toEqual(createStubResult());
+      expect(result).toEqual({
+        ...createStubResult(),
+        eventStreamAvailable: true,
+      });
     });
 
     it("forwards replyToMessageId when provided", async () => {

--- a/test/unit/api/runtime/friday-api-runtime-deterministic-dispatch.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-deterministic-dispatch.test.ts
@@ -111,6 +111,63 @@ describe("FridayApiRuntime deterministic dispatch", () => {
 
     expect(result.status).toBe("completed");
     expect(result.response).toContain("Current capabilities:");
+    expect(result.eventStreamAvailable).toBe(true);
     expect(executeRun).not.toHaveBeenCalled();
+
+    const getRoute = runtime.routes.getRoutes().find((route) => route.operationId === "agent.runs.get");
+    expect(getRoute).toBeDefined();
+
+    const getResult = await getRoute!.handler({
+      params: { runId: result.runId },
+      query: {},
+      body: null,
+      headers: {},
+      principal: {
+        principalType: "user",
+        principalId: "user-1",
+        userId: "user-1",
+        scopes: ["agent.read"],
+        tokenId: "tok-1",
+        tokenKind: "access",
+        issuedAt: NOW,
+      },
+    } as never);
+
+    expect(getResult.run.id).toBe(result.runId);
+    expect(getResult.run.status).toBe("completed");
+    expect(getResult.run.responseText).toContain("Current capabilities:");
+
+    const eventsRoute = runtime.routes.getRoutes().find((route) => route.operationId === "agent.runs.events");
+    expect(eventsRoute).toBeDefined();
+    const raw = {
+      writeHead: vi.fn(),
+      write: vi.fn(),
+      end: vi.fn(),
+      on: vi.fn(),
+    };
+    await eventsRoute!.handler({
+      params: { runId: result.runId },
+      query: {},
+      body: null,
+      headers: {},
+      principal: {
+        principalType: "user",
+        principalId: "user-1",
+        userId: "user-1",
+        scopes: ["agent.read"],
+        tokenId: "tok-1",
+        tokenKind: "access",
+        issuedAt: NOW,
+      },
+      _raw: raw,
+    } as never);
+
+    expect(raw.write).toHaveBeenCalledWith(
+      expect.stringContaining('"type":"agent.run.text_delta"'),
+    );
+    expect(raw.write).toHaveBeenCalledWith(
+      expect.stringContaining('"type":"agent.run.completed"'),
+    );
+    expect(raw.end).toHaveBeenCalled();
   });
 });

--- a/test/unit/engine/adapters/friday-channel-entry-adapter.test.ts
+++ b/test/unit/engine/adapters/friday-channel-entry-adapter.test.ts
@@ -16,7 +16,7 @@ describe("FridayChannelEntryAdapter", () => {
         executeRun,
       },
       idGenerator: () => "run-1",
-      resolveSessionKey: (channelKind, chatId) => `${channelKind}:default:${chatId}`,
+      resolveSessionKey: (message) => `${message.channelKind}:default:${message.chatId}`,
     });
 
     await adapter.handleMessage({
@@ -30,6 +30,11 @@ describe("FridayChannelEntryAdapter", () => {
 
     expect(executeRun).toHaveBeenCalledWith(expect.objectContaining({
       principalId: "user-42",
+      taskAlreadyInHistory: true,
+      executionContext: {
+        surface: "channel",
+        interactive: true,
+      },
       tenantContext: {
         hubId: "default",
         userId: "user-42",

--- a/test/unit/engine/friday-engine-run-executor.test.ts
+++ b/test/unit/engine/friday-engine-run-executor.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createFridayEngineRunExecutor } from "../../../src/engine/friday-engine-run-executor.js";
+
+describe("FridayEngineRunExecutor", () => {
+  it("persists deterministic control-plane results as real runs", async () => {
+    const persistImmediateRunResult = vi.fn();
+    const agentRuntime = {
+      executeRun: vi.fn(async () => {
+        throw new Error("agent runtime should not run for deterministic control-plane turns");
+      }),
+    };
+
+    const executor = createFridayEngineRunExecutor({
+      agentRuntime,
+      nowIso: () => "2026-04-03T18:40:00.000Z",
+      persistImmediateRunResult,
+      dispatchDeterministic: vi.fn(async () => ({
+        handled: true,
+        response: "Friday can help with workflows, skills, and diagnostics.",
+      })),
+      dispatchManagedAsync: vi.fn(async () => ({ handled: false })),
+      finalizeFocus: vi.fn(() => ({
+        currentTask: null,
+        lastAssistantSummary: null,
+        pendingPlanRunId: null,
+        updatedAt: "2026-04-03T18:40:00.000Z",
+      })),
+      deterministicDispatchDeps: {},
+      managedAsyncDispatchDeps: {},
+      resolveIdempotencyKey: ({ runId, kind }) => `${runId}:${kind}`,
+    });
+
+    const result = await executor.execute(
+      {
+        runId: "run-det-001",
+        task: "What can you do?",
+        sessionKey: "chat:default:chat-det-001",
+      },
+      {
+        executionClassification: { category: "sync_immediate", handler: "capabilities" },
+        conversationContext: { turnKind: "new_topic" } as never,
+        historyMessages: [],
+        focusState: null,
+        currentUserSequence: 1,
+      } as never,
+    );
+
+    expect(result.status).toBe("completed");
+    expect(result.response).toContain("Friday can help");
+    expect(persistImmediateRunResult).toHaveBeenCalledWith({
+      runId: "run-det-001",
+      task: "What can you do?",
+      sessionKey: "chat:default:chat-det-001",
+      providerId: undefined,
+      model: undefined,
+      constraints: undefined,
+      responseText: "Friday can help with workflows, skills, and diagnostics.",
+    });
+    expect(agentRuntime.executeRun).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/engine/friday-immediate-run-persistence.test.ts
+++ b/test/unit/engine/friday-immediate-run-persistence.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  createFridayAgentRunEventRepository,
+  createFridayAgentRunRepository,
+} from "#agent";
+import { createFridayImmediateRunPersistence } from "#engine";
+import type { FridaySqliteLayer } from "#state";
+import { createTestDb } from "../../helpers/friday-test-db.helper.js";
+
+describe("FridayImmediateRunPersistence", () => {
+  let db: FridaySqliteLayer;
+
+  afterEach(() => {
+    db?.close();
+  });
+
+  it("creates a durable run record and replayable terminal events once", () => {
+    db = createTestDb();
+    const repo = createFridayAgentRunRepository();
+    const runEventRepository = createFridayAgentRunEventRepository();
+
+    const persist = createFridayImmediateRunPersistence({
+      db,
+      repo,
+      runEventRepository,
+      idGenerator: (() => {
+        let seq = 0;
+        return () => `evt-${String(++seq)}`;
+      })(),
+      nowIso: () => "2026-04-03T21:10:00.000Z",
+    });
+
+    persist({
+      runId: "run-immediate-001",
+      task: "What can you do?",
+      sessionKey: "chat:default:chat-immediate-001",
+      responseText: "Current capabilities:\n- Skills\n- Workflows",
+    });
+    persist({
+      runId: "run-immediate-001",
+      task: "What can you do?",
+      sessionKey: "chat:default:chat-immediate-001",
+      responseText: "Current capabilities:\n- Skills\n- Workflows",
+    });
+
+    const run = db.withReadConnection((reader) => repo.getById(reader, "run-immediate-001"));
+    const events = db.withReadConnection((reader) => runEventRepository.list(reader, "run-immediate-001"));
+
+    expect(run?.status).toBe("completed");
+    expect(run?.responseText).toContain("Current capabilities:");
+    expect(events).toHaveLength(2);
+    expect(events[0]?.eventName).toBe("agent.run.text_delta");
+    expect(events[1]?.eventName).toBe("agent.run.completed");
+  });
+});

--- a/test/unit/ui/use-chat-session.test.ts
+++ b/test/unit/ui/use-chat-session.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildChatSessionKey,
+  coercePersistedChatSessionKey,
+  isTerminalChatRunStatus,
+  resolveImmediateChatResponse,
+} from "../../../ui/src/hooks/use-chat-session";
+
+describe("useChatSession session key handling", () => {
+  it("builds canonical three-segment chat session keys", () => {
+    expect(buildChatSessionKey("chat-abc123")).toBe("chat:default:chat-abc123");
+  });
+
+  it("migrates legacy one-segment chat keys from local storage", () => {
+    expect(coercePersistedChatSessionKey("chat-mnee68fu-n7k3by")).toBe(
+      "chat:default:chat-mnee68fu-n7k3by",
+    );
+  });
+
+  it("migrates malformed stored keys by preserving the chat id segment", () => {
+    expect(coercePersistedChatSessionKey(":chat-mnee68fu-n7k3by")).toBe(
+      "chat:default:chat-mnee68fu-n7k3by",
+    );
+    expect(coercePersistedChatSessionKey("chat::chat-mnee68fu-n7k3by")).toBe(
+      "chat:default:chat-mnee68fu-n7k3by",
+    );
+  });
+
+  it("preserves canonical chat session keys", () => {
+    expect(coercePersistedChatSessionKey("chat:default:chat-xyz")).toBe(
+      "chat:default:chat-xyz",
+    );
+  });
+
+  it("detects terminal chat run statuses", () => {
+    expect(isTerminalChatRunStatus("completed")).toBe(true);
+    expect(isTerminalChatRunStatus("failed")).toBe(true);
+    expect(isTerminalChatRunStatus("executing")).toBe(false);
+  });
+
+  it("extracts immediate completed responses for chat", () => {
+    expect(resolveImmediateChatResponse({
+      status: "completed",
+      response: "Immediate answer",
+    })).toBe("Immediate answer");
+
+    expect(resolveImmediateChatResponse({
+      status: "completed",
+      response: "",
+      finalResponse: "Final immediate answer",
+    })).toBe("Final immediate answer");
+
+    expect(resolveImmediateChatResponse({
+      status: "executing",
+      response: "Should wait for SSE",
+    })).toBeNull();
+  });
+});

--- a/ui/src/hooks/use-chat-session.ts
+++ b/ui/src/hooks/use-chat-session.ts
@@ -15,6 +15,7 @@ export interface ChatMessage {
 
 export interface UseChatSessionResult {
   messages: ChatMessage[];
+  sessionKey: string;
   currentRunId: string | null;
   runEvents: UseAgentRunEventsResult;
   sendMessage: (text: string) => Promise<void>;
@@ -27,11 +28,71 @@ export interface UseChatSessionResult {
 
 const SESSION_KEY_STORAGE = "friday-chat-session-key";
 const HISTORY_STORAGE = "friday-chat-history";
+const CHAT_SESSION_CHANNEL = "chat";
+const CHAT_SESSION_ACCOUNT = "default";
+const SESSION_KEY_SEGMENT_PATTERN = /^[a-z0-9._-]+$/;
+const TERMINAL_RUN_STATUSES = new Set(["completed", "failed", "cancelled", "failed_tests"]);
+
+function normalizeSessionKeySegment(raw: string): string {
+  return raw
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+function createChatConversationId(): string {
+  return `chat-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export function buildChatSessionKey(chatId = createChatConversationId()): string {
+  const normalizedChatId = normalizeSessionKeySegment(chatId);
+  return `${CHAT_SESSION_CHANNEL}:${CHAT_SESSION_ACCOUNT}:${normalizedChatId}`;
+}
+
+function isCanonicalConversationSessionKey(raw: string): boolean {
+  const segments = raw.split(":");
+  return segments.length === 3 && segments.every((segment) =>
+    segment.length > 0 && SESSION_KEY_SEGMENT_PATTERN.test(segment)
+  );
+}
+
+export function coercePersistedChatSessionKey(raw: string | null): string {
+  if (!raw) {
+    return buildChatSessionKey();
+  }
+
+  if (isCanonicalConversationSessionKey(raw)) {
+    return raw;
+  }
+
+  const meaningfulSegments = raw
+    .split(":")
+    .map((segment) => normalizeSessionKeySegment(segment))
+    .filter((segment) => segment.length > 0);
+
+  const candidateChatId = meaningfulSegments.at(-1);
+  return buildChatSessionKey(candidateChatId);
+}
+
+export function isTerminalChatRunStatus(status: string | null | undefined): boolean {
+  return typeof status === "string" && TERMINAL_RUN_STATUSES.has(status);
+}
+
+export function resolveImmediateChatResponse(input: {
+  status?: string;
+  response?: string;
+  finalResponse?: string;
+}): string | null {
+  if (!isTerminalChatRunStatus(input.status)) {
+    return null;
+  }
+  const text = input.finalResponse ?? input.response;
+  return typeof text === "string" && text.trim().length > 0 ? text : null;
+}
 
 function getOrCreateSessionKey(): string {
-  const existing = localStorage.getItem(SESSION_KEY_STORAGE);
-  if (existing) return existing;
-  const key = `chat-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  const key = coercePersistedChatSessionKey(localStorage.getItem(SESSION_KEY_STORAGE));
   localStorage.setItem(SESSION_KEY_STORAGE, key);
   return key;
 }
@@ -60,8 +121,9 @@ function saveHistory(messages: ChatMessage[]) {
 
 export function useChatSession(): UseChatSessionResult {
   const [messages, setMessages] = useState<ChatMessage[]>(loadHistory);
+  const [sessionKey, setSessionKey] = useState<string>(() => getOrCreateSessionKey());
   const [currentRunId, setCurrentRunId] = useState<string | null>(null);
-  const sessionKeyRef = useRef(getOrCreateSessionKey());
+  const sessionKeyRef = useRef(sessionKey);
   const outputTextRef = useRef("");
 
   const runEvents = useAgentRunEvents(currentRunId, {
@@ -115,7 +177,7 @@ export function useChatSession(): UseChatSessionResult {
 
     try {
       // Start a new agent run
-      const { runId } = await agentApi.startRun({
+      const result = await agentApi.startRun({
         task: trimmed,
         sessionKey: sessionKeyRef.current,
         executionContext: {
@@ -124,12 +186,35 @@ export function useChatSession(): UseChatSessionResult {
         },
       });
 
+      const immediateResponse = resolveImmediateChatResponse(result);
+      if (immediateResponse) {
+        const assistantMsg: ChatMessage = {
+          id: `msg-${Date.now().toString(36)}-reply`,
+          role: "assistant",
+          content: immediateResponse,
+          runId: result.runId,
+          timestamp: new Date().toISOString(),
+          status: result.status === "completed" ? "done" : "error",
+        };
+
+        setMessages((prev) => {
+          const updated = [...prev, assistantMsg];
+          saveHistory(updated);
+          return updated;
+        });
+        return;
+      }
+
+      if (result.eventStreamAvailable === false) {
+        throw new Error("Run started without event stream support");
+      }
+
       // Add placeholder assistant message
       const assistantMsg: ChatMessage = {
         id: `msg-${Date.now().toString(36)}-reply`,
         role: "assistant",
         content: "",
-        runId,
+        runId: result.runId,
         timestamp: new Date().toISOString(),
         status: "streaming",
       };
@@ -140,7 +225,7 @@ export function useChatSession(): UseChatSessionResult {
         return updated;
       });
 
-      setCurrentRunId(runId);
+      setCurrentRunId(result.runId);
     } catch (err) {
       // Add error message
       const errMsg: ChatMessage = {
@@ -162,14 +247,18 @@ export function useChatSession(): UseChatSessionResult {
     setMessages([]);
     localStorage.removeItem(HISTORY_STORAGE);
     localStorage.removeItem(SESSION_KEY_STORAGE);
-    sessionKeyRef.current = getOrCreateSessionKey();
+    const nextSessionKey = getOrCreateSessionKey();
+    sessionKeyRef.current = nextSessionKey;
+    setSessionKey(nextSessionKey);
   }, []);
 
   const startNewConversation = useCallback(() => {
     // Generate a fresh session key so the agent starts a new context,
     // but keep previous messages visible as a read-only log.
     localStorage.removeItem(SESSION_KEY_STORAGE);
-    sessionKeyRef.current = getOrCreateSessionKey();
+    const nextSessionKey = getOrCreateSessionKey();
+    sessionKeyRef.current = nextSessionKey;
+    setSessionKey(nextSessionKey);
     // Add a visual separator message
     const separator: ChatMessage = {
       id: `sep-${Date.now().toString(36)}`,
@@ -187,6 +276,7 @@ export function useChatSession(): UseChatSessionResult {
 
   return {
     messages,
+    sessionKey,
     currentRunId,
     runEvents,
     sendMessage,

--- a/ui/src/lib/api/agent.ts
+++ b/ui/src/lib/api/agent.ts
@@ -25,11 +25,6 @@ interface StartRunInput {
   taskProfile?: AgentTaskProfileInput;
 }
 
-interface StartRunResponse {
-  runId: string;
-  status: AgentRunStatus;
-}
-
 interface GetRunResponse {
   run: AgentRunRecord;
 }
@@ -67,7 +62,7 @@ interface ListSubagentsResponse {
 // ─── Agent API ───
 
 export const agentApi = {
-  async startRun(input: StartRunInput): Promise<StartRunResponse> {
+  async startRun(input: StartRunInput): Promise<AgentRuntimeResult> {
     const payload = {
       task: input.task,
       model: input.model,
@@ -78,7 +73,7 @@ export const agentApi = {
       executionContext: input.executionContext,
       taskProfile: input.taskProfile,
     };
-    return apiClient.post<typeof payload, StartRunResponse>("/v1/agent/runs", payload);
+    return apiClient.post<typeof payload, AgentRuntimeResult>("/v1/agent/runs", payload);
   },
 
   async listRuns(query?: { status?: AgentRunStatus; limit?: number }): Promise<AgentRunRecord[]> {

--- a/ui/src/lib/api/types.ts
+++ b/ui/src/lib/api/types.ts
@@ -265,6 +265,7 @@ export interface AgentRuntimeResult {
   durationMs: number;
   usageInput: number;
   usageOutput: number;
+  eventStreamAvailable?: boolean;
   images?: string[];
   finalResponse?: string;
   contextCostSummary?: AgentContextCostSummary;

--- a/ui/src/routes/chat-page.tsx
+++ b/ui/src/routes/chat-page.tsx
@@ -10,6 +10,7 @@ import { sessionsApi, type SessionUsageResponse } from "@/lib/api/sessions";
 export function ChatPage() {
   const {
     messages,
+    sessionKey,
     runEvents,
     sendMessage,
     isStreaming,
@@ -20,16 +21,15 @@ export function ChatPage() {
   const scrollRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const [sessionUsage, setSessionUsage] = useState<SessionUsageResponse | null>(null);
-  const sessionKeyRef = useRef<string | null>(null);
 
   // Fetch session usage after each completed run
   useEffect(() => {
-    // Get session key from localStorage (same source as useChatSession)
-    const key = localStorage.getItem("friday-chat-session-key");
-    if (!key || key === sessionKeyRef.current && sessionUsage) return;
-    sessionKeyRef.current = key;
-    sessionsApi.getUsage(key).then(setSessionUsage).catch(() => { /* non-fatal */ });
-  }, [messages.length, sessionUsage]);
+    if (!sessionKey) {
+      setSessionUsage(null);
+      return;
+    }
+    sessionsApi.getUsage(sessionKey).then(setSessionUsage).catch(() => { /* non-fatal */ });
+  }, [messages.length, sessionKey]);
 
   // Auto-scroll to bottom on new messages or streaming output
   useEffect(() => {


### PR DESCRIPTION
## Summary
- harden runtime chat and immediate run contracts
- persist immediate responses as agent runs/events so run details and history stay consistent
- normalize chat session keys and return full start-run execution payloads to the UI

## Validation
- `git diff --check main..codex/runtime-contracts-followup`
- `npx vitest run test/unit/ui/use-chat-session.test.ts test/unit/engine/friday-engine-run-executor.test.ts test/unit/engine/friday-immediate-run-persistence.test.ts test/unit/api/runtime/friday-api-runtime-deterministic-dispatch.test.ts test/unit/api/http/routes/friday-agent-routes.test.ts test/unit/engine/adapters/friday-channel-entry-adapter.test.ts`
- `npm run lint`
- `npm run build`
- `node scripts/validation/run-real-world-validation.mjs --suite smoke --scenario l3-chat-direct-answer,l3-multi-turn-memory --mint-local-admin-token --judge never`

## Notes
- excludes the remaining archived `codex/efficiency-audit-fixes` patches by design
- does not modify `claude/investigate-twitter-thread-4PNHG`
