### PR TITLE
Align real-world mint token secret resolution with runtime

### DIFF
--- a/test/unit/validation/real-world-local-auth.test.ts
+++ b/test/unit/validation/real-world-local-auth.test.ts
@@ -1,0 +1,55 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { loadMintTokenSecret } from "../../../validation/real-world/lib/local-auth.mjs";
+
+describe("real-world local auth token secret resolution", () => {
+  let tempDir: string | null = null;
+
+  afterEach(() => {
+    if (tempDir) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+      tempDir = null;
+    }
+  });
+
+  it("prefers the token secret file over a repo .env fallback", () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "friday-real-world-auth-"));
+    const envFilePath = path.join(tempDir, ".env");
+    const tokenSecretFile = path.join(tempDir, "token.secret");
+    fs.writeFileSync(envFilePath, "FRIDAY_TOKEN_SECRET=stale-dotenv-secret\n", "utf8");
+    fs.writeFileSync(tokenSecretFile, "runtime-file-secret\n", "utf8");
+
+    const result = loadMintTokenSecret({
+      processEnv: {},
+      tokenSecretFile,
+      envFilePath,
+    });
+
+    expect(result).toEqual({
+      secret: "runtime-file-secret",
+      source: tokenSecretFile,
+    });
+  });
+
+  it("still prefers the exported FRIDAY_TOKEN_SECRET env var when present", () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "friday-real-world-auth-"));
+    const tokenSecretFile = path.join(tempDir, "token.secret");
+    fs.writeFileSync(tokenSecretFile, "runtime-file-secret\n", "utf8");
+
+    const result = loadMintTokenSecret({
+      processEnv: {
+        FRIDAY_TOKEN_SECRET: "process-env-secret",
+      },
+      tokenSecretFile,
+    });
+
+    expect(result).toEqual({
+      secret: "process-env-secret",
+      source: "FRIDAY_TOKEN_SECRET",
+    });
+  });
+});

--- a/validation/real-world/lib/local-auth.mjs
+++ b/validation/real-world/lib/local-auth.mjs
@@ -236,24 +236,22 @@ function parsePositiveInteger(value, defaultValue) {
   return parsed;
 }
 
-function loadTokenSecret({
+export function loadMintTokenSecret({
   processEnv = process.env,
   explicitSecret,
   tokenSecretFile,
-  envFilePath,
+  envFilePath: _envFilePath,
 }) {
-  const dotEnv = loadDotEnvOverrides({ processEnv, envFilePath });
-  const mergedEnv = { ...dotEnv, ...processEnv };
   if (typeof explicitSecret === "string" && explicitSecret.trim().length > 0) {
     return {
       secret: explicitSecret.trim(),
       source: "FRIDAY_TOKEN_SECRET",
     };
   }
-  if (typeof mergedEnv.FRIDAY_TOKEN_SECRET === "string" && mergedEnv.FRIDAY_TOKEN_SECRET.trim().length > 0) {
+  if (typeof processEnv.FRIDAY_TOKEN_SECRET === "string" && processEnv.FRIDAY_TOKEN_SECRET.trim().length > 0) {
     return {
-      secret: mergedEnv.FRIDAY_TOKEN_SECRET.trim(),
-      source: processEnv.FRIDAY_TOKEN_SECRET ? "FRIDAY_TOKEN_SECRET" : ".env:FRIDAY_TOKEN_SECRET",
+      secret: processEnv.FRIDAY_TOKEN_SECRET.trim(),
+      source: "FRIDAY_TOKEN_SECRET",
     };
   }
   const resolvedPath = resolveFridayTokenSecretPath(tokenSecretFile);
@@ -332,11 +330,10 @@ export function mintLocalAdminAccessToken(options = {}) {
   });
   const mergedEnv = { ...dotEnv, ...processEnv };
   const dbPath = resolveFridayDbPath(mergedEnv, options.stateDbPath);
-  const { secret, source } = loadTokenSecret({
+  const { secret, source } = loadMintTokenSecret({
     processEnv: mergedEnv,
     explicitSecret: options.tokenSecret,
     tokenSecretFile: options.tokenSecretFile,
-    envFilePath: options.envFilePath,
   });
   const accessTokenTtlSec = parsePositiveInteger(options.accessTokenTtlSec, 3600);
   const db = new Database(dbPath, { readonly: true, fileMustExist: true });


### PR DESCRIPTION
## Summary
- align local real-world validation mint token-secret resolution with the live runtime
- stop falling back to repo `.env` for `FRIDAY_TOKEN_SECRET` during mint-local-admin auth
- add a regression test for stale `.env` secret vs runtime token secret file precedence

## Root cause
The validation harness was reading `FRIDAY_TOKEN_SECRET` from the repo `.env`, while the running Friday runtime was verifying tokens with its live process/file secret. That let mint-local-admin create a token that immediately failed `/v1/auth/me` with `INVALID_SIGNATURE`.

## Validation
- `npx vitest run test/unit/validation/real-world-local-auth.test.ts`
- direct auth verification with `mintLocalAdminAccessToken()` now returns `200` from `/v1/auth/me`
