### PR TITLE
fix: use runtime token secret for real-world local auth

### DIFF
--- a/test/unit/validation/real-world-local-auth.test.ts
+++ b/test/unit/validation/real-world-local-auth.test.ts
@@ -2,9 +2,14 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 
+import Database from "better-sqlite3";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { loadMintTokenSecret } from "../../../validation/real-world/lib/local-auth.mjs";
+import { createFridayTokenValidator } from "#api";
+import {
+  loadMintTokenSecret,
+  mintLocalAdminAccessToken,
+} from "../../../validation/real-world/lib/local-auth.mjs";
 
 describe("real-world local auth token secret resolution", () => {
   let tempDir: string | null = null;
@@ -51,5 +56,58 @@ describe("real-world local auth token secret resolution", () => {
       secret: "process-env-secret",
       source: "FRIDAY_TOKEN_SECRET",
     });
+  });
+
+  it("ignores stale repo .env FRIDAY_TOKEN_SECRET when minting a local admin token", () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "friday-real-world-auth-"));
+    const envFilePath = path.join(tempDir, ".env");
+    const tokenSecretFile = path.join(tempDir, "token.secret");
+    const stateDbPath = path.join(tempDir, "friday.db");
+    fs.writeFileSync(envFilePath, "FRIDAY_TOKEN_SECRET=stale-dotenv-secret\n", "utf8");
+    fs.writeFileSync(tokenSecretFile, "runtime-file-secret\n", "utf8");
+
+    const db = new Database(stateDbPath);
+    try {
+      db.exec(`
+        CREATE TABLE users (
+          id TEXT PRIMARY KEY,
+          email TEXT,
+          display_name TEXT,
+          role TEXT NOT NULL,
+          last_login_at TEXT
+        );
+      `);
+      db.prepare(`
+        INSERT INTO users (id, email, display_name, role, last_login_at)
+        VALUES (?, ?, ?, ?, ?)
+      `).run(
+        "admin-001",
+        "admin@friday.dev",
+        "Admin",
+        "admin",
+        "2026-04-04T04:00:00.000Z",
+      );
+    } finally {
+      db.close();
+    }
+
+    const minted = mintLocalAdminAccessToken({
+      processEnv: {},
+      envFilePath,
+      stateDbPath,
+      tokenSecretFile,
+    });
+
+    expect(minted.metadata.tokenSecretSource).toBe(tokenSecretFile);
+
+    const validator = createFridayTokenValidator({
+      tokenSecret: "runtime-file-secret",
+      nowMs: () => Date.now(),
+      lookupTokenRevocation: () => false,
+    });
+    const validated = validator.validate(minted.accessToken);
+
+    expect(validated.principal.principalId).toBe("admin-001");
+    expect(validated.principal.role).toBe("admin");
   });
 });

--- a/validation/real-world/lib/local-auth.mjs
+++ b/validation/real-world/lib/local-auth.mjs
@@ -331,7 +331,7 @@ export function mintLocalAdminAccessToken(options = {}) {
   const mergedEnv = { ...dotEnv, ...processEnv };
   const dbPath = resolveFridayDbPath(mergedEnv, options.stateDbPath);
   const { secret, source } = loadMintTokenSecret({
-    processEnv: mergedEnv,
+    processEnv,
     explicitSecret: options.tokenSecret,
     tokenSecretFile: options.tokenSecretFile,
   });


### PR DESCRIPTION
## Summary
- stop `mintLocalAdminAccessToken()` from re-introducing stale repo `.env` `FRIDAY_TOKEN_SECRET` into the validation mint path
- add a regression test that proves real-world local admin minting validates against the live runtime token secret file
- verify the real-world smoke run now gets past `/v1/auth/me` and resolves default/fallback provider lanes

## Verification
- `npx vitest run test/unit/validation/real-world-local-auth.test.ts`
- direct probe: `mint_local_admin -> /v1/auth/me` returns `200`
- `npm run validate:real-world:smoke` (auth blockage cleared; next failures are separate clusters)
