### PR TITLE
fix: make real-world llm judge opt-in

### DIFF
--- a/test/unit/validation/real-world-judge.test.ts
+++ b/test/unit/validation/real-world-judge.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { finalizeArtifact, runLlmJudge } from "../../../validation/real-world/lib/judge.mjs";
+
+describe("real-world judge gating", () => {
+  it("skips the llm judge unless the scenario explicitly opts in", async () => {
+    const client = {
+      startAgentRun: vi.fn(),
+    };
+    const judge = await runLlmJudge({
+      client,
+      scenario: {
+        id: "l1-chat-ui",
+        layer: "L1",
+        routeFamily: "surface",
+        expectedEvidence: ["page becomes visibly interactive"],
+        execution: { kind: "ui_probe" },
+      },
+      artifact: { result: "passed" },
+      envTruth: {},
+      judgePolicy: "auto",
+    });
+
+    expect(judge).toEqual({
+      available: false,
+      reason: "judge disabled for this run",
+    });
+    expect(client.startAgentRun).not.toHaveBeenCalled();
+  });
+
+  it("parses fenced json even when the judge adds leading commentary", async () => {
+    const client = {
+      startAgentRun: vi.fn().mockResolvedValue({
+        data: {
+          finalResponse: [
+            "Tool evidence gathered successfully.",
+            "```json",
+            '{"verdict":"pass","confidence":0.81,"reasons":["deterministic evidence satisfied"],"misroute":false}',
+            "```",
+          ].join("\n"),
+        },
+      }),
+    };
+
+    const judge = await runLlmJudge({
+      client,
+      scenario: {
+        id: "l4-file-tool-roundtrip",
+        layer: "L4",
+        routeFamily: "file tool",
+        expectedEvidence: ["agent run completes"],
+        execution: { kind: "agent_run", useJudge: true },
+      },
+      artifact: {
+        result: "passed",
+        observedEvidence: ["turn 1 run run-123", "turn 1 status completed"],
+        raw: {
+          lane: { providerId: "provider-default" },
+          outputText: "Friday",
+        },
+      },
+      envTruth: {
+        providerLanes: {
+          default: { providerId: "provider-default", model: "claude-sonnet-4-20250514" },
+          fallback: { providerId: "provider-fallback", model: "gpt-4o-mini" },
+        },
+        enabledProviderLanes: [],
+      },
+      judgePolicy: "auto",
+    });
+
+    expect(judge.available).toBe(true);
+    expect(judge.verdict).toBe("pass");
+    expect(judge.confidence).toBe(0.81);
+    expect(judge.reasons).toEqual(["deterministic evidence satisfied"]);
+  });
+
+  it("keeps a passed artifact green when the judge is disabled", () => {
+    const artifact = finalizeArtifact({
+      scenario: {
+        id: "l2-health-contract",
+        severityOnFailure: "P1",
+      },
+      artifact: {
+        result: "passed",
+        observedEvidence: ["HTTP 200 GET /v1/health"],
+        raw: {},
+      },
+      rubric: {
+        available: false,
+        pass: true,
+        confidence: 0,
+        reasons: [],
+        parsedJson: null,
+      },
+      judge: {
+        available: false,
+        reason: "judge disabled for this run",
+      },
+    });
+
+    expect(artifact.result).toBe("passed");
+    expect(artifact.humanReviewRequired).not.toBe(true);
+  });
+});

--- a/validation/real-world/catalog/scenarios.mjs
+++ b/validation/real-world/catalog/scenarios.mjs
@@ -564,6 +564,7 @@ export const REAL_WORLD_SCENARIOS = [
       "tool result is visible in run metadata",
     ],
     execution: {
+      useJudge: true,
       expectToolCallCountMin: 1,
       constraints: { readOnly: true },
     },

--- a/validation/real-world/lib/judge.mjs
+++ b/validation/real-world/lib/judge.mjs
@@ -11,8 +11,43 @@ function getTextOutput(artifact) {
   );
 }
 
+function extractEmbeddedJson(text) {
+  const normalized = typeof text === "string" ? text.trim() : "";
+  if (!normalized) {
+    return null;
+  }
+
+  const direct = safeJsonParse(stripMarkdownFences(normalized));
+  if (direct && typeof direct === "object") {
+    return direct;
+  }
+
+  const fencedMatches = [...normalized.matchAll(/```(?:json)?\s*([\s\S]*?)```/gi)];
+  for (const match of fencedMatches) {
+    const parsed = safeJsonParse((match[1] ?? "").trim());
+    if (parsed && typeof parsed === "object") {
+      return parsed;
+    }
+  }
+
+  const firstBrace = normalized.indexOf("{");
+  const lastBrace = normalized.lastIndexOf("}");
+  if (firstBrace >= 0 && lastBrace > firstBrace) {
+    const parsed = safeJsonParse(normalized.slice(firstBrace, lastBrace + 1));
+    if (parsed && typeof parsed === "object") {
+      return parsed;
+    }
+  }
+
+  return null;
+}
+
+function shouldRunJudge(scenario) {
+  return scenario?.execution?.useJudge === true;
+}
+
 function toJson(text) {
-  return safeJsonParse(stripMarkdownFences(text));
+  return extractEmbeddedJson(text);
 }
 
 export function evaluateBehavioralRubric({ scenario, artifact }) {
@@ -113,7 +148,7 @@ export function evaluateBehavioralRubric({ scenario, artifact }) {
 }
 
 export async function runLlmJudge({ client, scenario, artifact, envTruth, judgePolicy = "auto" }) {
-  if (judgePolicy === "never" || artifact.result === "blocked") {
+  if (judgePolicy === "never" || artifact.result === "blocked" || !shouldRunJudge(scenario)) {
     return { available: false, reason: "judge disabled for this run" };
   }
 
@@ -124,6 +159,8 @@ export async function runLlmJudge({ client, scenario, artifact, envTruth, judgeP
 
   const prompt = [
     "You are validating a Friday real-world scenario run.",
+    "Do not call tools.",
+    "Base the verdict only on the evidence below.",
     "Return JSON only with this shape:",
     '{"verdict":"pass|fail|manual_review","confidence":0.0,"reasons":["..."],"misroute":false}',
     "",


### PR DESCRIPTION
## Summary
- make the real-world LLM judge opt-in so deterministic probes do not get downgraded into false `manual_review` results
- harden judge JSON extraction so fenced JSON still parses even when the model adds commentary
- keep judge coverage on the file-tool scenario while letting deterministic smoke scenarios rely on their existing oracles and rubrics

## Verification
- `npx vitest run test/unit/validation/real-world-judge.test.ts test/unit/validation/real-world-local-auth.test.ts`
- `node scripts/validation/run-real-world-validation.mjs --suite smoke --scenario l1-chat-ui,l2-health-contract,l3-long-summary-direct --mint-local-admin-token`
- `npm run validate:real-world:smoke` (manual_review flood removed; remaining failures are separate clusters)
