### PR TITLE
fix: use workspace-relative path in file tool validation

### DIFF
--- a/validation/real-world/catalog/scenarios.mjs
+++ b/validation/real-world/catalog/scenarios.mjs
@@ -557,7 +557,7 @@ export const REAL_WORLD_SCENARIOS = [
     productArea: "tools",
     entrySurface: "/v1/agent/runs",
     routeFamily: "file tool",
-    realWorldPrompt: "Use the filesystem to read {{repoRoot}}/README.md and answer with its top H1 heading only.",
+    realWorldPrompt: "Use the filesystem to read README.md from the current workspace root and answer with its top H1 heading only.",
     expectedEvidence: [
       "agent uses at least one tool call",
       "output reflects filesystem content rather than a guess",
@@ -571,6 +571,10 @@ export const REAL_WORLD_SCENARIOS = [
     oracles: {
       behavior: {
         minimumTextLength: 3,
+        forbiddenSubstrings: [
+          "outside the allowed workspace root",
+          "cannot access the file",
+        ],
       },
     },
   }),


### PR DESCRIPTION
## Summary
- stop the file-tool real-world scenario from referencing the harness worktree's absolute path
- use a workspace-relative README path so the live runtime and the validation harness agree on the accessible root
- add explicit forbidden substrings for access-denied responses so the scenario fails truthfully if the file tool is still blocked

## Verification
- `node scripts/validation/run-real-world-validation.mjs --suite smoke --scenario l4-file-tool-roundtrip --mint-local-admin-token`
- `npm run validate:real-world:smoke`
