### PR TITLE
[codex] Fix cross-border assistant handoff race on main

### DIFF
--- a/ui/src/routes/assistant-inbox-page.tsx
+++ b/ui/src/routes/assistant-inbox-page.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { ArrowRight, CheckCircle2, RefreshCcw, ShieldAlert, Sparkles } from "lucide-react";
-import { useSearchParams } from "react-router-dom";
+import { useLocation, useSearchParams } from "react-router-dom";
 import { ActionButton, ShellCard, StatusPill } from "@/components/core/primitives";
 import { CrossBorderAssistantHandoffCard } from "@/components/packs/cross-border-assistant-handoff-card";
 import { PackAssistantHandoffCard } from "@/components/packs/pack-assistant-handoff-card";
@@ -22,11 +22,21 @@ import {
 } from "@/lib/runs/run-health";
 import { buildSkillHref } from "@/lib/skills/view-models";
 import { useAppLocale } from "@/providers/locale-provider";
+import type { FridayCrossBorderSnapshot } from "../../../src/packs/cross-border/friday-cross-border-pack.types";
+
+function readNavigationCrossBorderSnapshot(value: unknown): FridayCrossBorderSnapshot | undefined {
+  if (!value || typeof value !== "object" || !("crossBorderSnapshot" in value)) {
+    return undefined;
+  }
+  const snapshot = (value as { crossBorderSnapshot?: FridayCrossBorderSnapshot }).crossBorderSnapshot;
+  return snapshot?.profile ? snapshot : undefined;
+}
 
 export function AssistantInboxPage() {
   const navigate = useAppNavigate();
   const { locale } = useAppLocale();
   const { profileType } = useUserProfile();
+  const location = useLocation();
   const [searchParams] = useSearchParams();
   const { pinnedPackIds } = useHomeSurfacePreferences(profileType);
   const pollInterval = useAdaptivePollingInterval({ activeMs: 12_000, backgroundMs: 36_000 });
@@ -38,11 +48,15 @@ export function AssistantInboxPage() {
     refetchInterval: pollInterval,
   });
   const selectedPackId = searchParams.get("packId");
+  const navigationCrossBorderSnapshot = selectedPackId === "industry-cross-border-ecommerce"
+    ? readNavigationCrossBorderSnapshot(location.state)
+    : undefined;
   const crossBorderSnapshotQuery = useQuery({
     queryKey: ["cross-border-pack", "snapshot"],
     queryFn: () => crossBorderPackApi.getSnapshot(),
     refetchInterval: pollInterval,
     enabled: selectedPackId === "industry-cross-border-ecommerce" || pinnedPackIds.includes("industry-cross-border-ecommerce"),
+    initialData: navigationCrossBorderSnapshot,
   });
 
   const approvals = snapshotQuery.data?.approvals ?? [];

--- a/ui/src/routes/cross-border-pack-setup-page.tsx
+++ b/ui/src/routes/cross-border-pack-setup-page.tsx
@@ -65,7 +65,18 @@ function parseCompetitors(text: string, regionFocus: SetupState["regionFocus"]):
         platform: regionFocus === "sea_tiktok" ? "tiktok_shop" : "amazon",
         ...(productName ? { productName } : {}),
       };
-    });
+  });
+}
+
+function buildCrossBorderAssistantNavigationState(
+  snapshot: Awaited<ReturnType<typeof crossBorderPackApi.getSnapshot>> | undefined,
+) {
+  if (!snapshot?.profile) {
+    return undefined;
+  }
+  return {
+    crossBorderSnapshot: snapshot,
+  };
 }
 
 async function readFileAsText(file: File): Promise<string> {
@@ -108,6 +119,15 @@ export function CrossBorderPackSetupPage() {
     queryKey: ["cross-border-pack", "snapshot"],
     queryFn: () => crossBorderPackApi.getSnapshot(),
   });
+
+  const openAssistant = () => {
+    if (snapshotQuery.data) {
+      queryClient.setQueryData(["cross-border-pack", "snapshot"], snapshotQuery.data);
+    }
+    navigate(buildPackAssistantHref(CROSS_BORDER_PACK_ID), {
+      state: buildCrossBorderAssistantNavigationState(snapshotQuery.data),
+    });
+  };
 
   useEffect(() => {
     if (!profileQuery.data) {
@@ -405,7 +425,7 @@ export function CrossBorderPackSetupPage() {
               <ActionButton
                 data-testid="cross-border-open-assistant-direct"
                 tone="secondary"
-                onClick={() => navigate(buildPackAssistantHref(CROSS_BORDER_PACK_ID))}
+                onClick={openAssistant}
                 disabled={!profileQuery.data && !snapshotQuery.data?.profile}
               >
                 {localize(locale, "去助手看交接", "Open assistant handoff")}
@@ -524,7 +544,7 @@ export function CrossBorderPackSetupPage() {
         <CrossBorderActionBoard
           snapshot={snapshotQuery.data}
           onOpenSetup={() => window.scrollTo({ top: 0, behavior: "smooth" })}
-          onOpenAssistant={() => navigate(buildPackAssistantHref(CROSS_BORDER_PACK_ID))}
+          onOpenAssistant={openAssistant}
           onOpenWorkflowTemplate={(templateId) => navigate(`/workflows/builder?templateId=${encodeURIComponent(templateId)}`)}
           onOpenManagedWorkflow={(workflowId) => navigate(`/workflows/builder?workflowId=${encodeURIComponent(workflowId)}`)}
           onApplyDefaultWorkflows={() => applyDefaultWorkflows()}

--- a/ui/src/routes/home-page.tsx
+++ b/ui/src/routes/home-page.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowRight, CheckCircle2, Clock3, ListFilter, Pin, Plus, Sparkles } from "lucide-react";
 import { ActionButton, ShellCard, StatusPill } from "@/components/core/primitives";
 import { ContextualHelp } from "@/components/core/contextual-help";
@@ -76,6 +76,7 @@ function formatAutomationNextRun(
 
 export function HomePage() {
   const navigate = useAppNavigate();
+  const queryClient = useQueryClient();
   const { locale } = useAppLocale();
   const { profileType } = useUserProfile();
   const {
@@ -110,6 +111,17 @@ export function HomePage() {
     queryFn: () => crossBorderPackApi.getSnapshot(),
     refetchInterval: pollInterval,
   });
+
+  const openCrossBorderAssistant = () => {
+    if (crossBorderSnapshotQuery.data) {
+      queryClient.setQueryData(["cross-border-pack", "snapshot"], crossBorderSnapshotQuery.data);
+    }
+    navigate(buildPackAssistantHref("industry-cross-border-ecommerce"), {
+      state: crossBorderSnapshotQuery.data?.profile
+        ? { crossBorderSnapshot: crossBorderSnapshotQuery.data }
+        : undefined,
+    });
+  };
 
   useEffect(() => {
     if (!pendingPackPath) {
@@ -218,7 +230,7 @@ export function HomePage() {
         <CrossBorderActionBoard
           snapshot={crossBorderSnapshotQuery.data}
           onOpenSetup={() => navigate("/packs/cross-border/setup?packId=industry-cross-border-ecommerce&mode=adjust")}
-          onOpenAssistant={() => navigate("/assistant?packId=industry-cross-border-ecommerce")}
+          onOpenAssistant={openCrossBorderAssistant}
           onOpenWorkflowTemplate={(templateId) => navigate(`/workflows/builder?templateId=${encodeURIComponent(templateId)}`)}
           onOpenManagedWorkflow={(workflowId) => navigate(`/workflows/builder?workflowId=${encodeURIComponent(workflowId)}`)}
           onApplyDefaultWorkflows={() => applyDefaultWorkflows()}


### PR DESCRIPTION
## Summary
- fix the cross-border pack handoff race that left `/assistant` blank on slow CI paths after setup
- seed the cross-border snapshot into navigation state and query cache before opening the assistant handoff
- keep the assistant snapshot query refresh behavior unchanged after the initial render

## What Changed
### UI / Product Surface
- `cross-border-pack-setup-page` now opens `/assistant` with the current cross-border snapshot in router state
- `home-page` now does the same for the cross-border action board entry point
- `assistant-inbox-page` now accepts navigation-seeded snapshot data as initial query data so the structured handoff renders immediately

### Read Model / API
- no public API shape changes

### Runtime / Workflow Correctness
- no runtime or workflow engine behavior changes

### Maintenance / Assets
- no asset or maintenance changes

## Why This Fix Exists
GitHub CI on `main` failed after PR #100 merged because the browser-e2e test `Friday cross-border pack setup > saves a cross-border operating profile and shows the assistant handoff` timed out waiting for `[data-testid="cross-border-assistant-handoff"]` on `/assistant?packId=industry-cross-border-ecommerce`.

The local and CI evidence both pointed to a slow-path race: setup saved the profile correctly, but the assistant handoff page could still miss the cross-border snapshot on initial navigation. This fix removes that fragile gap by carrying the already-known snapshot forward into the assistant surface and letting the existing query refresh in the background.

## Validation
- `npm run typecheck`
- `npm run test:e2e:ui:file -- test/e2e/ui/friday-cross-border-pack-setup.e2e.test.ts`
- repeated targeted runs of the same browser-e2e spec
- `npm run test:e2e:ui`
- `npm run release:verify`

## Still Open But Not Blocking
- `Workflow Builder` remains slower than `Home` / `Packs` / `Assistant`
- strict historical pack backfill still intentionally leaves ambiguous legacy runs unattributed
- release warnings are classified, not globally silenced
