### PR TITLE
fix: pre-release cleanup — timestamp fallbacks, self-repair notifications

### DIFF
--- a/ui/src/components/core/learning-insight-card.tsx
+++ b/ui/src/components/core/learning-insight-card.tsx
@@ -104,6 +104,30 @@ export function LearningInsightCard() {
               </p>
             </div>
           )}
+
+          {overview.coverage.autoFixActions > 0 && overview.rollbackHotspots.length === 0 && (
+            <div className="mt-3 rounded-xl bg-emerald-50 px-3 py-2">
+              <p className="text-xs text-emerald-700">
+                {localize(
+                  locale,
+                  `Friday 已自动修复 ${String(overview.coverage.autoFixActions)} 个问题，无需人工干预。`,
+                  `Friday auto-fixed ${String(overview.coverage.autoFixActions)} issue(s) without manual intervention.`,
+                )}
+              </p>
+            </div>
+          )}
+
+          {overview.rollbackHotspots.length > 0 && (
+            <div className="mt-3 rounded-xl bg-amber-50 px-3 py-2">
+              <p className="text-xs text-amber-700">
+                {localize(
+                  locale,
+                  `${String(overview.rollbackHotspots.length)} 个热点问题频繁回滚 — Friday 正在学习更好的修复方案。`,
+                  `${String(overview.rollbackHotspots.length)} hotspot(s) with frequent rollbacks — Friday is learning better fixes.`,
+                )}
+              </p>
+            </div>
+          )}
         </>
       ) : (
         <p className="text-sm text-[color:var(--color-text-secondary)]">

--- a/ui/src/routes/agent-page.tsx
+++ b/ui/src/routes/agent-page.tsx
@@ -84,15 +84,15 @@ const ACTIVE_RUN_STATUSES = [
 ] as const;
 
 function formatTimestamp(value?: string): string {
-  if (!value) return "Never";
+  if (!value) return "—";
   return new Date(value).toLocaleString();
 }
 
 function formatRelative(value?: string): string {
-  if (!value) return "Never";
+  if (!value) return "—";
   const ms = Date.now() - new Date(value).getTime();
   const minutes = Math.max(0, Math.floor(ms / 60_000));
-  if (minutes < 1) return "Just now";
+  if (minutes < 1) return "—";
   if (minutes < 60) return `${minutes}m ago`;
   const hours = Math.floor(minutes / 60);
   if (hours < 24) return `${hours}h ago`;

--- a/ui/src/routes/automations-page.tsx
+++ b/ui/src/routes/automations-page.tsx
@@ -10,7 +10,7 @@ import { localize } from "@/lib/i18n/localized-text";
 import { useAppLocale } from "@/providers/locale-provider";
 
 function formatTimestamp(value?: string): string {
-  if (!value) return "Never";
+  if (!value) return "—";
   return new Date(value).toLocaleString();
 }
 

--- a/ui/src/routes/observability-page.tsx
+++ b/ui/src/routes/observability-page.tsx
@@ -94,7 +94,7 @@ function toneForIssueSeverity(
 }
 
 function formatTimestamp(value?: string): string {
-  if (!value) return "Unknown";
+  if (!value) return "—";
   return new Date(value).toLocaleString();
 }
 

--- a/ui/src/routes/settings-page.tsx
+++ b/ui/src/routes/settings-page.tsx
@@ -32,7 +32,7 @@ import {
 } from "@/lib/persona/communication-persona";
 
 function formatTimestamp(value?: string): string {
-  if (!value) return "Never";
+  if (!value) return "—";
   return new Date(value).toLocaleString();
 }
 

--- a/ui/src/routes/skills-page.tsx
+++ b/ui/src/routes/skills-page.tsx
@@ -23,7 +23,7 @@ import {
 } from "@/lib/skills/view-models";
 
 function formatTimestamp(value?: string): string {
-  if (!value) return "Unknown";
+  if (!value) return "—";
   return new Date(value).toLocaleString();
 }
 

--- a/ui/src/routes/workflows-page.tsx
+++ b/ui/src/routes/workflows-page.tsx
@@ -19,7 +19,7 @@ import {
 } from "@/lib/workflows/view-models";
 
 function formatTimestamp(value?: string): string {
-  if (!value) return "Unknown";
+  if (!value) return "—";
   return new Date(value).toLocaleString();
 }
 


### PR DESCRIPTION
## Pre-release cleanup

1. **Timestamp fallbacks**: Replace hardcoded "Never"/"Unknown"/"Just now" with language-neutral "—" across 6 pages
2. **Self-repair notifications**: LearningInsightCard shows green banner for auto-fix success, amber for rollback hotspots

## Test plan
- [x] `npm run typecheck` — 0 errors
- [x] Frontend build — clean
- [x] 9,986 tests passed

https://claude.ai/code/session_01DG1jcRq1axQ6WkH1mQJY42