### PR TITLE
Pre-release audit: security, UI/UX, refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project follows Semantic Versioning.
 
 ## [Unreleased]
 
+### Added
+- Deep link protocol: `friday://` import protocol for provider templates, skill sources, MCP server configs, workflow templates, and marketplace assets with preview + validate + confirm flow.
+- PolicyExtensionChain: authorization chain where extensions can only tighten (deny) decisions, never loosen core policy, with full audit trail.
+- Shell safety scanner: rules-based preflight scanner for shell-based skills detecting `rm -rf`, `sudo`, `curl | sh`, path traversal, and 20+ dangerous patterns.
+- MCP management UI: `/mcp` page for viewing MCP server status, transport, tool/resource counts, and configuration guidance.
+- Session browser: `/sessions` page with status filtering, transcript viewer, and JSON/Markdown export.
+- Cost dashboard: `/usage` page with provider health, request counts, error rates, and cost estimation.
+- Capability grant lifecycle: SQLite persistence, revoke API, and grant routes for full issue-use-expire-revoke flow.
+- SIEM export: JSONL file export and HTTP webhook export sinks on the existing hash-chained audit trail.
+- Linux packaging: complete .deb and .AppImage packaging with build scripts.
+- Communication persona system: MBTI-based with 16 personality templates, 9 configurable dimensions, and learned preference integration.
+- Learning-adaptive communication: learned preference facts from the self-learning pipeline feed into persona resolution with confidence-decaying Bayesian-inspired updates.
+- User preference management: full CRUD API for user preferences at `/v1/uix/preferences`, persona preview, user profile onboarding, and assistant diagnostics.
+- Expected utility calculator: pluggable utility scoring for auto-fix decisions (`EU = benefit * P(success) - cost * P(failure) - riskPenalty`).
+- Tool call summary: privacy-safe tool execution summaries (arg keys only, no values) for observability and world model training data.
+- OpenAI Responses API: full streaming support for the `openai-responses` API format alongside existing `openai-completions`.
+
+### Changed
+- Warn-once architecture: cross-module log deduplication (7+ modules) for cleaner runtime output.
+- Workflow realtime events: buffered event publishing enables live workflow progress tracking via SSE/WebSocket.
+- Setup diagnostics: user-friendly error messages and remediation hints for setup/auth failures in UI.
+- Provider templates and lane health: setup/settings now consume template-driven bootstrap and lane visibility.
+- Skill preflight verdicts: grouped blocking/warning/advisory preflight checks across manifest, integrity, requirements, permissions, runtime dry-run, and trust.
+
+### Fixed
+- WebSocket buffer accumulation now capped at 4 MB to prevent DoS via fragmented frames.
+- Session key recursive parsing now enforces maximum subagent nesting depth of 10 to prevent stack overflow.
+- Agent runtime progress timer and event listeners are now created inside the try block to prevent leaks on early failures.
+- Subagent drain timeout now logs remaining in-flight execution count for shutdown diagnostics.
+- Master key file-read cache path now sets TTL expiry, preventing stale cached keys from blocking rotation.
+- Master key file permissions too-open warning now attempts `chmod 0600` remediation.
+- Channel input sanitizer now enforces 50,000 character limit and applies Unicode NFC normalization.
+- Error diagnosis lesson-disabled check logic simplified to prevent disabled lessons from being included when `factRepo` is unavailable.
+- Auto-fix risk assessment 1h spike threshold now uses `Math.ceil()` for correct integer comparison against hourly baseline.
+- Provider OAuth hardening: Claude Code request format matching for OAuth inference (Anthropic PKCE).
+
 ## [0.4.2] - 2026-03-24
 
 ### Fixed

--- a/src/agent/runtime/friday-agent-runtime.ts
+++ b/src/agent/runtime/friday-agent-runtime.ts
@@ -592,9 +592,7 @@ export function createFridayAgentRuntime(
 
       eventEmitter.on("agent.subagent.spawned", onSubagentSpawned);
       eventEmitter.on("agent.subagent.completed", onSubagentCompleted);
-      const progressTimer = setInterval(() => {
-        emitProgressEvent();
-      }, 15_000);
+      let progressTimer: ReturnType<typeof setInterval> | undefined;
 
       // 1. Create run record unless we are resuming a previously gated run.
       if (!existingRun) {
@@ -856,6 +854,10 @@ export function createFridayAgentRuntime(
       };
 
       try {
+        progressTimer = setInterval(() => {
+          emitProgressEvent();
+        }, 15_000);
+
         // 2. Emit started event and transition to planning
         if (evaluateRules) {
           const runPolicy = await safeEvaluateRules(evaluateRules, {
@@ -2562,7 +2564,7 @@ export function createFridayAgentRuntime(
       } finally {
         clearTimeout(abortTimer);
         params.signal?.removeEventListener("abort", onExternalAbort);
-        clearInterval(progressTimer);
+        if (progressTimer) clearInterval(progressTimer);
         eventEmitter.off("agent.subagent.spawned", onSubagentSpawned);
         eventEmitter.off("agent.subagent.completed", onSubagentCompleted);
         runSeqCounters.delete(runId);

--- a/src/agent/subagent/friday-subagent-registry.ts
+++ b/src/agent/subagent/friday-subagent-registry.ts
@@ -358,13 +358,18 @@ export function createFridaySubagentRegistry(
       if (inFlightExecutions.size === 0) {
         return;
       }
+      const remaining = inFlightExecutions.size;
       const pending = Array.from(inFlightExecutions.values());
-      await Promise.race([
-        Promise.allSettled(pending).then(() => undefined),
-        new Promise<void>((resolve) => {
-          setTimeout(resolve, timeoutMs);
+      const settled = await Promise.race([
+        Promise.allSettled(pending).then(() => true),
+        new Promise<false>((resolve) => {
+          setTimeout(() => resolve(false), timeoutMs);
         }),
       ]);
+      if (!settled && inFlightExecutions.size > 0) {
+        // eslint-disable-next-line no-console
+        console.warn(`[friday][subagent] drain timed out with ${inFlightExecutions.size} of ${remaining} executions still in-flight`);
+      }
     },
 
     async startRun(subagentId: string): Promise<FridaySubagentOutcome> {

--- a/src/api/http/friday-http-server.ts
+++ b/src/api/http/friday-http-server.ts
@@ -851,6 +851,13 @@ export function createFridayHttpServer(deps: FridayHttpServerDeps): FridayHttpSe
     socket.on("data", (chunk: Buffer) => {
       buffer = Buffer.concat([buffer, chunk]);
 
+      // Guard against accumulated buffer exceeding max size (prevents DoS via fragmented frames)
+      const MAX_WS_BUFFER_SIZE = 4_194_304; // 4 MB
+      if (buffer.length > MAX_WS_BUFFER_SIZE) {
+        socket.destroy();
+        return;
+      }
+
       // Parse WebSocket frames
       while (buffer.length >= 2) {
         const firstByte = buffer[0]!;

--- a/src/api/realtime/friday-realtime-subscription-service.ts
+++ b/src/api/realtime/friday-realtime-subscription-service.ts
@@ -132,7 +132,7 @@ export interface CreateFridayRealtimeSubscriptionServiceDeps {
 export function createFridayRealtimeSubscriptionService(
   deps: CreateFridayRealtimeSubscriptionServiceDeps,
 ): FridayRealtimeSubscriptionService {
-  const cursorSecret = deps.cursorSecret ?? deps.nowIso().replace(/\D/g, "").slice(0, 16);
+  const cursorSecret = deps.cursorSecret ?? crypto.randomBytes(16).toString("hex");
 
   /** Check if a streamId is valid for the given topic based on prefix rules. */
   function isStreamValidForTopic(topic: FridayRealtimeTopic, streamId: string): boolean {

--- a/src/channels/friday-channel-input-sanitizer.ts
+++ b/src/channels/friday-channel-input-sanitizer.ts
@@ -1,13 +1,22 @@
 /**
  * Sanitizes inbound channel message text before it reaches the agent runtime.
  * Strips control characters, zero-width characters, and normalizes whitespace.
+ * Enforces a maximum length to prevent memory/performance issues.
  */
 
 const CONTROL_CHARS = /[\u0000-\u001F\u007F]/g;
 const ZERO_WIDTH = /[\u200B-\u200D\uFEFF]/g;
 
+/** Maximum channel input length in characters (100 KB of UTF-16). */
+export const FRIDAY_MAX_CHANNEL_INPUT_LENGTH = 50_000;
+
 export function sanitizeChannelInput(input: string): string {
-  return input
+  // Truncate before expensive regex processing to bound CPU cost
+  const bounded = input.length > FRIDAY_MAX_CHANNEL_INPUT_LENGTH
+    ? input.slice(0, FRIDAY_MAX_CHANNEL_INPUT_LENGTH)
+    : input;
+  return bounded
+    .normalize("NFC")
     .replace(CONTROL_CHARS, " ")
     .replace(ZERO_WIDTH, "")
     .replace(/\s+/g, " ")

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -90,7 +90,7 @@ export {
 
 // ─── Input Sanitization ───
 
-export { sanitizeChannelInput } from "./friday-channel-input-sanitizer.js";
+export { sanitizeChannelInput, FRIDAY_MAX_CHANNEL_INPUT_LENGTH } from "./friday-channel-input-sanitizer.js";
 
 // ─── Typing Controller (OC-005) ───
 

--- a/src/deeplink/friday-deeplink-validator.ts
+++ b/src/deeplink/friday-deeplink-validator.ts
@@ -14,17 +14,28 @@ import type {
   FridayDeepLinkPreviewResult,
 } from "./friday-deeplink-types.js";
 
-const PRIVATE_IP_PATTERNS = [
-  /^https?:\/\/127\./,
-  /^https?:\/\/10\./,
-  /^https?:\/\/192\.168\./,
-  /^https?:\/\/172\.(1[6-9]|2\d|3[01])\./,
-  /^https?:\/\/localhost/i,
-  /^https?:\/\/\[::1\]/,
-];
-
-function isPrivateUrl(url: string): boolean {
-  return PRIVATE_IP_PATTERNS.some((pattern) => pattern.test(url));
+function isPrivateUrl(urlString: string): boolean {
+  try {
+    const parsed = new URL(urlString);
+    const hostname = parsed.hostname.toLowerCase();
+    // Check for private/reserved hostnames
+    if (hostname === "localhost" || hostname === "[::1]" || hostname === "::1") return true;
+    // Check for private IP ranges (strip brackets for IPv6)
+    const ip = hostname.replace(/^\[|\]$/g, "");
+    if (/^127\./.test(ip)) return true;
+    if (/^10\./.test(ip)) return true;
+    if (/^192\.168\./.test(ip)) return true;
+    if (/^172\.(1[6-9]|2\d|3[01])\./.test(ip)) return true;
+    if (ip === "::1" || ip === "0.0.0.0" || ip === "0:0:0:0:0:0:0:1") return true;
+    // Check for link-local and other reserved ranges
+    if (/^169\.254\./.test(ip)) return true;
+    if (/^fc[0-9a-f]{2}:/i.test(ip) || /^fd[0-9a-f]{2}:/i.test(ip)) return true;
+    if (/^fe80:/i.test(ip)) return true;
+    return false;
+  } catch {
+    // If URL parsing fails, treat as potentially private (fail-closed)
+    return true;
+  }
 }
 
 function isValidSha256(hash: string): boolean {

--- a/src/desktop/engine/friday-desktop-adapters.ts
+++ b/src/desktop/engine/friday-desktop-adapters.ts
@@ -69,7 +69,7 @@ export interface AdapterHealthCheck {
   readonly details: Record<string, string | boolean | number>;
 }
 
-const SAFE_APP_IDENTIFIER_RE = /^[A-Za-z0-9._:/\\\-\s]+$/;
+const SAFE_APP_IDENTIFIER_RE = /^[A-Za-z0-9._:/\\\- ]+$/;
 const SAFE_XDOTOOL_KEY_RE = /^[A-Za-z0-9_+\-]+$/;
 
 // ─── Default Shell Executor ───
@@ -225,7 +225,7 @@ function ensureFiniteInteger(value: number, fieldName: string): number {
 }
 
 function ensureSafeAppIdentifier(value: string): string {
-  if (!SAFE_APP_IDENTIFIER_RE.test(value)) {
+  if (value.length > 256 || !SAFE_APP_IDENTIFIER_RE.test(value)) {
     throw new FridayDomainError("VALIDATION_ERROR", "Unsafe app identifier", { httpStatus: 400 });
   }
   return value;

--- a/src/learning/services/friday-auto-fix-risk-assessment-service.ts
+++ b/src/learning/services/friday-auto-fix-risk-assessment-service.ts
@@ -107,7 +107,7 @@ export function createFridayAutoFixRiskAssessmentService(
         const baseline24h = counts24h.executed > 0
           ? counts24h.rolledBack / 24
           : 0;
-        if (baseline24h > 0 && counts1h.rolledBack > 3 * baseline24h) {
+        if (baseline24h > 0 && counts1h.rolledBack > Math.ceil(3 * baseline24h)) {
           riskTier = 2;
           reasons.push(
             `1h error spike (${counts1h.rolledBack} rollbacks) > 3x baseline (${baseline24h.toFixed(1)}/h) disables auto-apply`,

--- a/src/learning/services/friday-error-diagnosis-service.ts
+++ b/src/learning/services/friday-error-diagnosis-service.ts
@@ -65,9 +65,11 @@ export function createFridayErrorDiagnosisService(
     const lessonDisabled = lesson && deps.factRepo
       ? deps.factRepo.getByUserAndKey(db, incident.userId, `lesson_disabled:${lesson.id}`)
       : null;
-    let matchedLessons = lesson && !(lessonDisabled?.value === true || (typeof lessonDisabled?.value === "object" && lessonDisabled?.value !== null && "disabled" in lessonDisabled.value && lessonDisabled.value.disabled === true))
-      ? [lesson]
-      : [];
+    const isLessonDisabled = lessonDisabled != null && (
+      lessonDisabled.value === true
+      || (typeof lessonDisabled.value === "object" && lessonDisabled.value !== null && "disabled" in lessonDisabled.value && (lessonDisabled.value as Record<string, unknown>).disabled === true)
+    );
+    let matchedLessons = lesson && !isLessonDisabled ? [lesson] : [];
 
     // 1b. Check for rejected/negative lessons — avoid recommending same fix
     const isNegativeLesson = lesson?.mitigation &&

--- a/src/providers/security/friday-secret-crypto.ts
+++ b/src/providers/security/friday-secret-crypto.ts
@@ -116,16 +116,27 @@ export function getMasterKey(): Buffer {
   // 2. Try to read persisted key file
   try {
     const hex = fs.readFileSync(MASTER_KEY_FILE, "utf8").trim();
-    // P2-SEC: Verify master key file permissions are not too open
+    // P2-SEC: Verify and fix master key file permissions
     try {
       const stat = fs.statSync(MASTER_KEY_FILE);
       if ((stat.mode & 0o077) !== 0) {
-        console.warn(`[friday][SECURITY] Master key file permissions too open — expected 0600, got 0o${(stat.mode & 0o777).toString(8)}`);
+        // eslint-disable-next-line no-console
+        console.warn(`[friday][SECURITY] Master key file permissions too open (0o${(stat.mode & 0o777).toString(8)}) — attempting chmod 0600`);
+        try {
+          fs.chmodSync(MASTER_KEY_FILE, 0o600);
+        } catch (chmodErr) {
+          // eslint-disable-next-line no-console
+          console.warn("[friday][SECURITY] Could not fix master key file permissions:", chmodErr instanceof Error ? chmodErr.message : String(chmodErr));
+        }
       }
-    } catch (err) { console.warn("[friday][secret-crypto] stat check failed:", err instanceof Error ? err.message : String(err)); }
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn("[friday][secret-crypto] stat check failed:", err instanceof Error ? err.message : String(err));
+    }
     const buf = Buffer.from(hex, "hex");
     if (buf.length === KEY_BYTES) {
       cachedMasterKey = buf;
+      cachedMasterKeyExpiresAt = Date.now() + MASTER_KEY_CACHE_TTL_MS;
       return cachedMasterKey;
     }
     // Invalid length — fall through to regenerate

--- a/src/sessions/services/friday-session-key.ts
+++ b/src/sessions/services/friday-session-key.ts
@@ -89,8 +89,17 @@ export function buildFridaySubagentSessionKey(
 
 // ─── Key parsing ───
 
+const FRIDAY_SESSION_MAX_SUBAGENT_DEPTH = 10;
+
 /** Parse a canonical session key into its constituent parts. */
-export function parseFridaySessionKey(key: string): FridaySessionKeyParts {
+export function parseFridaySessionKey(key: string, _depth = 0): FridaySessionKeyParts {
+  if (_depth > FRIDAY_SESSION_MAX_SUBAGENT_DEPTH) {
+    throw new FridayDomainError(
+      FRIDAY_SESSION_ERROR_CODES.INVALID_KEY,
+      `Session key exceeds maximum subagent nesting depth of ${FRIDAY_SESSION_MAX_SUBAGENT_DEPTH}`,
+      { httpStatus: 400 },
+    );
+  }
   if (!key) {
     throw new FridayDomainError(
       FRIDAY_SESSION_ERROR_CODES.INVALID_KEY,
@@ -118,7 +127,7 @@ export function parseFridaySessionKey(key: string): FridaySessionKeyParts {
 
     validateSegment(taskId, "taskId");
     // Recursively validate the parent key
-    const parentParts = parseFridaySessionKey(parentKey);
+    const parentParts = parseFridaySessionKey(parentKey, _depth + 1);
 
     return {
       kind: "subagent",
@@ -165,7 +174,14 @@ export function validateFridaySessionKey(key: string): void {
  * Applies lowercase + segment normalization to each segment.
  * Returns the canonicalized key string. Throws on structurally invalid keys.
  */
-export function canonicalizeFridaySessionKey(rawKey: string): string {
+export function canonicalizeFridaySessionKey(rawKey: string, _depth = 0): string {
+  if (_depth > FRIDAY_SESSION_MAX_SUBAGENT_DEPTH) {
+    throw new FridayDomainError(
+      FRIDAY_SESSION_ERROR_CODES.INVALID_KEY,
+      `Session key exceeds maximum subagent nesting depth of ${FRIDAY_SESSION_MAX_SUBAGENT_DEPTH}`,
+      { httpStatus: 400 },
+    );
+  }
   if (!rawKey) {
     throw new FridayDomainError(
       FRIDAY_SESSION_ERROR_CODES.INVALID_KEY,
@@ -188,7 +204,7 @@ export function canonicalizeFridaySessionKey(rawKey: string): string {
 
     const parentKey = rest.slice(0, lastColon);
     const taskId = rest.slice(lastColon + 1);
-    const normalizedParent = canonicalizeFridaySessionKey(parentKey);
+    const normalizedParent = canonicalizeFridaySessionKey(parentKey, _depth + 1);
     const normalizedTaskId = normalizeSegment(taskId);
     validateSegment(normalizedTaskId, "taskId");
 

--- a/src/workflows/engine/friday-workflow-dag-scheduler.ts
+++ b/src/workflows/engine/friday-workflow-dag-scheduler.ts
@@ -115,11 +115,11 @@ export function createFridayWorkflowDagScheduler(): FridayWorkflowDagScheduler {
               anyEnabledEdge = true;
             }
           } catch (err) {
+            // eslint-disable-next-line no-console
             console.warn(
-              `[friday] Workflow DAG edge condition evaluation failed for edge ${pred}→${nodeId}: ${err instanceof Error ? err.message : String(err)}. Treating edge as enabled (fail-open).`,
+              `[friday] Workflow DAG edge condition evaluation failed for edge ${pred}→${nodeId}: ${err instanceof Error ? err.message : String(err)}. Treating edge as DISABLED (fail-closed).`,
             );
-            // P2-WF-001: Fail-open — treat evaluation error as edge enabled rather than silently disabling
-            anyEnabledEdge = true;
+            // P2-WF-001: Fail-closed — expression errors block the edge to prevent unintended execution
           }
         } else {
           anyEnabledEdge = true;

--- a/src/workflows/services/friday-workflow-execution-service.ts
+++ b/src/workflows/services/friday-workflow-execution-service.ts
@@ -232,6 +232,15 @@ export function createFridayWorkflowExecutionService(
     error?: { code: string; message: string };
   }
 
+  /** Return type for single-node execution within a batch. */
+  type NodeExecutionOutcome = {
+    nodeId: string;
+    status: "completed" | "failed" | "retrying" | "paused" | "dispatched" | "blocked" | "skipped";
+    output?: unknown;
+    error?: { code: string; message: string; retryable?: boolean };
+    satelliteId?: UUID;
+  };
+
   function buildExpressionContext(
     runEntity: FridayWorkflowRunEntity,
     nodeContexts: Map<string, NodeContextEntry>,
@@ -478,6 +487,511 @@ export function createFridayWorkflowExecutionService(
     return "failed";
   }
 
+  // ─── Extracted from executeRun: mark unreachable nodes as cancelled ───
+
+  function cancelDeadEndedNodes(
+    runId: UUID,
+    deadEndedNodes: string[],
+    nodeStatuses: Map<string, NodeAttemptStatus>,
+    exprContext: FridayExpressionContext,
+  ): void {
+    deps.db.withWriteTransaction((db) => {
+      for (const nodeId of deadEndedNodes) {
+        const currentStatus = nodeStatuses.get(nodeId);
+        if (currentStatus) {
+          continue;
+        }
+
+        const latestAttempt = deps.nodeRepo.getLatestAttempt(db, runId, nodeId);
+        if (latestAttempt) {
+          nodeStatuses.set(nodeId, latestAttempt.status);
+          continue;
+        }
+
+        const attemptId = deps.idGenerator();
+        const entity: FridayWorkflowRunNodeEntity = {
+          id: deps.idGenerator(),
+          runId,
+          nodeId,
+          attempt: 1,
+          attemptId,
+          status: "cancelled",
+          idempotencyKey: deps.retryManager.generateIdempotencyKey(
+            runId,
+            nodeId,
+            1,
+          ),
+          input: exprContext as unknown as JsonValue,
+          finishedAt: deps.nowIso(),
+          createdAt: deps.nowIso(),
+          updatedAt: deps.nowIso(),
+        };
+
+        deps.nodeRepo.insertNodeAttempt(db, entity);
+        nodeStatuses.set(nodeId, "cancelled");
+      }
+    });
+  }
+
+  // ─── Extracted from executeRun: create or reuse attempt records for ready nodes ───
+
+  function prepareNodeAttempts(
+    runId: UUID,
+    readyNodes: string[],
+    nodeStatuses: Map<string, NodeAttemptStatus>,
+    exprContext: FridayExpressionContext,
+  ): FridayWorkflowRunNodeEntity[] {
+    const attempts: FridayWorkflowRunNodeEntity[] = [];
+    deps.db.withWriteTransaction((db) => {
+      for (const nodeId of readyNodes) {
+        const currentNodeStatus = nodeStatuses.get(nodeId);
+        if (currentNodeStatus === "retrying") {
+          const existingAttempt = deps.db.withReadConnection((rdb) =>
+            deps.nodeRepo.getLatestAttempt(rdb, runId, nodeId),
+          );
+          if (existingAttempt && existingAttempt.status === "retrying") {
+            attempts.push(existingAttempt);
+            continue;
+          }
+        }
+
+        const latestAttempt = deps.db.withReadConnection((rdb) =>
+          deps.nodeRepo.getLatestAttempt(rdb, runId, nodeId),
+        );
+        const actualAttempt = latestAttempt
+          ? latestAttempt.attempt + 1
+          : 1;
+
+        const attemptId = deps.idGenerator();
+        const idempotencyKey = deps.retryManager.generateIdempotencyKey(
+          runId,
+          nodeId,
+          actualAttempt,
+        );
+
+        const entity: FridayWorkflowRunNodeEntity = {
+          id: deps.idGenerator(),
+          runId,
+          nodeId,
+          attempt: actualAttempt,
+          attemptId,
+          status: "queued",
+          idempotencyKey,
+          // SAFETY: exprContext is a Record-based expression context, runtime-compatible with JsonValue
+          input: exprContext as unknown as JsonValue,
+          createdAt: deps.nowIso(),
+          updatedAt: deps.nowIso(),
+        };
+
+        deps.nodeRepo.insertNodeAttempt(db, entity);
+        attempts.push(entity);
+      }
+    });
+    return attempts;
+  }
+
+  // ─── Extracted from executeRun: execute a single node (approval / satellite / local) ───
+
+  async function executeSingleNode(
+    runId: UUID,
+    attempt: FridayWorkflowRunNodeEntity,
+    plan: FridayWorkflowExecutionPlan,
+    runEntity: FridayWorkflowRunEntity,
+    nodeContexts: Map<string, NodeContextEntry>,
+    runSignal: AbortSignal,
+  ): Promise<NodeExecutionOutcome> {
+    try {
+      const node = plan.nodeMap.get(attempt.nodeId)!;
+
+      // ── Approval nodes: block until explicit decision ──
+      if (node.type === "approval") {
+        const leaseExpiresAt = new Date(new Date(deps.nowIso()).getTime() + LEASE_TTL_MS).toISOString();
+        const leaseAcquired = deps.db.withWriteTransaction((db) =>
+          deps.nodeRepo.acquireLease(db, attempt.id, "hub", leaseExpiresAt, deps.nowIso()),
+        );
+        if (!leaseAcquired) {
+          return { nodeId: attempt.nodeId, status: "skipped" };
+        }
+
+        deps.db.withWriteTransaction((db) => {
+          deps.nodeRepo.updateNodeAttempt(db, attempt.id, {
+            status: "blocked_offline",
+            nowIso: deps.nowIso(),
+          });
+        });
+
+        if (deps.requestNodeApproval) {
+          const nodeConfig = node.config as Record<string, unknown> | undefined;
+          try {
+            await deps.requestNodeApproval({
+              workflowId: runEntity.workflowId,
+              workflowVersionId: runEntity.workflowVersionId,
+              runId,
+              runNodeAttemptId: attempt.id,
+              nodeId: attempt.nodeId,
+              approverUserId: nodeConfig?.approverUserId as string | undefined,
+              approverRole: nodeConfig?.approverRole as string | undefined,
+              requestPayload: nodeConfig?.requestPayload as Record<string, unknown> | undefined,
+              timeoutMs: nodeConfig?.timeoutMs as number | undefined,
+            });
+          } catch (approvalErr) {
+            const errMsg = approvalErr instanceof Error ? approvalErr.message : String(approvalErr);
+            console.error(
+              `[friday] requestNodeApproval failed for run=${runId} node=${attempt.nodeId}: ${errMsg}`,
+            );
+            await deps.publishEvent?.("workflow.approval.error", {
+              runId,
+              nodeId: attempt.nodeId,
+              attemptId: attempt.id,
+              error: errMsg,
+            });
+          }
+        }
+
+        deps.db.withWriteTransaction((db) => {
+          deps.runRepo.updateRunStatus(db, runId, "paused", deps.nowIso());
+        });
+
+        return { nodeId: attempt.nodeId, status: "paused" };
+      }
+
+      // ── Distributed dispatch: route to satellite if available ──
+      if (distributedDispatcher) {
+        const dispatchResult = await distributedDispatcher.dispatchNode({
+          runId,
+          workflowId: runEntity.workflowId,
+          workflowVersionId: runEntity.workflowVersionId,
+          nodeId: attempt.nodeId,
+          attemptId: attempt.attemptId,
+          attempt: attempt.attempt,
+          node,
+          inputData: (attempt.input as Record<string, unknown>) ?? {},
+          expressionContext: buildExpressionContext(runEntity, nodeContexts),
+          idempotencyKey: attempt.idempotencyKey,
+        });
+
+        if (dispatchResult.kind === "satellite_dispatched") {
+          deps.db.withWriteTransaction((db) => {
+            deps.nodeRepo.updateNodeAttempt(db, attempt.id, {
+              status: "running",
+              satelliteId: dispatchResult.satelliteId,
+              leaseOwner: dispatchResult.leaseOwner,
+              leaseExpiresAt: dispatchResult.leaseExpiresAt,
+              startedAt: deps.nowIso(),
+              nowIso: deps.nowIso(),
+            });
+          });
+
+          await deps.publishEvent?.("workflow.node.started", {
+            runId,
+            nodeId: attempt.nodeId,
+            attempt: attempt.attempt,
+            satelliteId: dispatchResult.satelliteId,
+          });
+
+          return { nodeId: attempt.nodeId, status: "dispatched", satelliteId: dispatchResult.satelliteId };
+        }
+
+        if (dispatchResult.kind === "blocked") {
+          deps.db.withWriteTransaction((db) => {
+            deps.nodeRepo.updateNodeAttempt(db, attempt.id, {
+              status: "blocked_offline",
+              satelliteId: dispatchResult.satelliteId,
+              error: {
+                code: dispatchResult.code,
+                message: dispatchResult.message,
+                retryable: dispatchResult.retryable,
+                details: dispatchResult.details,
+              },
+              nowIso: deps.nowIso(),
+            });
+          });
+
+          await deps.publishEvent?.("workflow.node.blocked_offline", {
+            runId,
+            nodeId: attempt.nodeId,
+            attempt: attempt.attempt,
+            satelliteId: dispatchResult.satelliteId,
+            since: deps.nowIso(),
+          });
+
+          return {
+            nodeId: attempt.nodeId,
+            status: "blocked",
+            satelliteId: dispatchResult.satelliteId,
+            error: { code: dispatchResult.code, message: dispatchResult.message },
+          };
+        }
+      }
+
+      // ── Local execution: acquire lease and run node on hub ──
+      const leaseExpiresAt = new Date(Date.now() + LEASE_TTL_MS).toISOString();
+      const leaseAcquired = deps.db.withWriteTransaction((db) =>
+        deps.nodeRepo.acquireLease(db, attempt.id, "hub", leaseExpiresAt, deps.nowIso()),
+      );
+      if (!leaseAcquired) {
+        return { nodeId: attempt.nodeId, status: "skipped" };
+      }
+
+      const timeoutMs = node.timeoutMs ?? 300_000;
+      let nodeTimeoutHandle: ReturnType<typeof setTimeout> | undefined;
+      const result = await Promise.race([
+        deps.nodeExecutor.executeNode({
+          runId,
+          workflowId: runEntity.workflowId,
+          nodeId: attempt.nodeId,
+          attemptId: attempt.attemptId,
+          node,
+          inputData: (attempt.input as Record<string, unknown>) ?? {},
+          expressionContext: buildExpressionContext(runEntity, nodeContexts),
+          signal: runSignal,
+        }),
+        new Promise<never>((_, reject) => {
+          nodeTimeoutHandle = setTimeout(
+            () => reject(new Error("NODE_TIMEOUT")),
+            timeoutMs,
+          );
+        }),
+      ]);
+      if (nodeTimeoutHandle !== undefined) clearTimeout(nodeTimeoutHandle);
+
+      deps.db.withWriteTransaction((db) => {
+        deps.nodeRepo.updateNodeAttempt(db, attempt.id, {
+          status: "completed",
+          output: result.output,
+          finishedAt: deps.nowIso(),
+          nowIso: deps.nowIso(),
+        });
+      });
+
+      await notifyNodeAttemptResultSafe({
+        runId,
+        workflowId: runEntity.workflowId,
+        nodeId: attempt.nodeId,
+        attempt: attempt.attempt,
+        status: "completed",
+      });
+
+      if (result.output != null) {
+        deps.artifactWriter.writeJsonArtifact(runId, attempt.nodeId, result.output);
+      }
+
+      return { nodeId: attempt.nodeId, status: "completed", output: result.output };
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      const errorCode = errorMessage.startsWith("NODE_")
+        ? errorMessage.split(":")[0]!
+        : "NODE_EXECUTION_FAILED";
+
+      const errorObj = {
+        code: errorCode,
+        message: errorMessage,
+        retryable: true,
+      } as const;
+
+      const failureStatus = await persistNodeFailure({
+        runId,
+        workflowId: runEntity.workflowId,
+        attempt,
+        node: plan.nodeMap.get(attempt.nodeId)!,
+        error: errorObj,
+      });
+
+      return { nodeId: attempt.nodeId, status: failureStatus, error: errorObj };
+    }
+  }
+
+  // ─── Extracted from executeRun: process batch results and apply failure policy ───
+
+  async function applyBatchResults(
+    runId: UUID,
+    results: PromiseSettledResult<NodeExecutionOutcome>[],
+    plan: FridayWorkflowExecutionPlan,
+    runEntity: FridayWorkflowRunEntity,
+    nodeStatuses: Map<string, NodeAttemptStatus>,
+    nodeContexts: Map<string, NodeContextEntry>,
+  ): Promise<{ aborted: boolean; paused: boolean; blocked: boolean }> {
+    let hasFailure = false;
+    let hasPause = false;
+    let hasBlocked = false;
+
+    for (const result of results) {
+      if (result.status === "rejected") continue;
+      const { value } = result;
+
+      if (value.status === "completed") {
+        nodeStatuses.set(value.nodeId, "completed");
+        if ("output" in value && value.output != null) {
+          const outputObj =
+            typeof value.output === "object" && !Array.isArray(value.output)
+              ? (value.output as Record<string, unknown>)
+              : { value: value.output };
+          nodeContexts.set(value.nodeId, { output: outputObj, status: "completed" });
+        }
+      } else if (value.status === "failed") {
+        nodeStatuses.set(value.nodeId, "failed");
+        if ("error" in value && value.error != null) {
+          const errObj = value.error as { code: string; message: string };
+          nodeContexts.set(value.nodeId, {
+            output: { status: "failed" },
+            status: "failed",
+            error: { code: errObj.code, message: errObj.message },
+          });
+        }
+        hasFailure = true;
+      } else if (value.status === "retrying") {
+        nodeStatuses.delete(value.nodeId);
+      } else if (value.status === "paused") {
+        nodeStatuses.set(value.nodeId, "blocked_offline");
+        hasPause = true;
+      } else if (value.status === "dispatched") {
+        nodeStatuses.set(value.nodeId, "running");
+      } else if (value.status === "blocked") {
+        nodeStatuses.set(value.nodeId, "blocked_offline");
+        hasBlocked = true;
+      }
+    }
+
+    // Apply failure policy
+    if (hasFailure) {
+      const policy = plan.failurePolicy;
+      switch (policy.onFailure) {
+        case "fail_fast": {
+          deps.db.withWriteTransaction((db) => {
+            deps.nodeRepo.cancelAllPendingNodes(db, runId, deps.nowIso());
+            deps.runRepo.finalizeRun(db, runId, "failed", deps.nowIso(), {
+              code: "WORKFLOW_FAILED",
+              message: "Workflow failed due to fail_fast policy",
+            });
+          });
+          const counts = deps.db.withReadConnection((db) =>
+            deps.nodeRepo.countByStatus(db, runId),
+          );
+          await notifyRunCompleted({
+            runId,
+            workflowId: runEntity.workflowId,
+            workflowVersionId: runEntity.workflowVersionId,
+            status: "failed",
+            plan,
+            failedNodes: counts.failed,
+            completedNodes: counts.completed,
+            cancelledNodes: counts.cancelled,
+          });
+          return { aborted: true, paused: false, blocked: false };
+        }
+
+        case "continue_on_error":
+          break;
+
+        case "pause_for_approval":
+          deps.db.withWriteTransaction((db) => {
+            deps.runRepo.updateRunStatus(db, runId, "paused", deps.nowIso());
+          });
+          return { aborted: false, paused: true, blocked: false };
+
+        case "fallback_step":
+          if (policy.fallbackStepId) {
+            nodeStatuses.delete(policy.fallbackStepId);
+          }
+          break;
+
+        case "compensate":
+          deps.db.withWriteTransaction((db) => {
+            deps.runRepo.updateRunStatus(db, runId, "compensating", deps.nowIso());
+          });
+          return { aborted: false, paused: true, blocked: false };
+      }
+    }
+
+    if (hasPause) {
+      return { aborted: false, paused: true, blocked: false };
+    }
+
+    if (hasBlocked) {
+      deps.db.withWriteTransaction((db) => {
+        deps.runRepo.updateRunStatus(db, runId, "paused", deps.nowIso());
+      });
+      await deps.publishEvent?.("workflow.run.paused", {
+        runId,
+        reason: "satellite_blocked_offline",
+      });
+      return { aborted: false, paused: false, blocked: true };
+    }
+
+    return { aborted: false, paused: false, blocked: false };
+  }
+
+  // ─── Extracted from executeRun: determine final run status after loop exit ───
+
+  async function finalizeRunStatus(
+    runId: UUID,
+    plan: FridayWorkflowExecutionPlan,
+    aborted: boolean,
+  ): Promise<void> {
+    if (!aborted) {
+      const runEntity = deps.db.withReadConnection((db) =>
+        deps.runRepo.getRunById(db, runId),
+      )!;
+
+      if (runEntity.status === "running") {
+        const counts = deps.db.withReadConnection((db) =>
+          deps.nodeRepo.countByStatus(db, runId),
+        );
+
+        if (counts.running > 0 || counts.queued > 0 || counts.retrying > 0) {
+          return;
+        }
+
+        if (counts.blocked_offline > 0) {
+          deps.db.withWriteTransaction((db) => {
+            deps.runRepo.updateRunStatus(db, runId, "paused", deps.nowIso());
+          });
+          await deps.publishEvent?.("workflow.run.paused", {
+            runId,
+            reason: "satellite_blocked_offline",
+          });
+          return;
+        }
+
+        const finalStatus: WorkflowRunStatus =
+          counts.failed > 0 ? "failed" : "completed";
+
+        deps.db.withWriteTransaction((db) => {
+          const failure =
+            finalStatus === "failed"
+              ? {
+                  code: "WORKFLOW_NODES_FAILED",
+                  message: `${counts.failed} node(s) failed`,
+                }
+              : undefined;
+          deps.runRepo.finalizeRun(db, runId, finalStatus, deps.nowIso(), failure);
+        });
+
+        await notifyRunCompleted({
+          runId,
+          workflowId: runEntity.workflowId,
+          workflowVersionId: runEntity.workflowVersionId,
+          status: finalStatus,
+          plan,
+          failedNodes: counts.failed,
+          completedNodes: counts.completed,
+          cancelledNodes: counts.cancelled,
+        });
+      }
+    }
+
+    const finalRun = deps.db.withReadConnection((db) =>
+      deps.runRepo.getRunById(db, runId),
+    );
+    if (finalRun?.status === "completed" || finalRun?.status === "failed" || finalRun?.status === "cancelled") {
+      activePlans.delete(runId);
+      activeAbortControllers.delete(runId);
+      await deps.publishEvent?.("workflow.run.finished", { runId });
+    }
+  }
+
+  // ─── Core workflow execution loop ───
+
   async function executeRun(plan: FridayWorkflowExecutionPlan): Promise<void> {
     const runId = plan.runId;
 
@@ -507,7 +1021,6 @@ export function createFridayWorkflowExecutionService(
     const nodeStatuses = new Map<string, NodeAttemptStatus>();
     deps.db.withReadConnection((db) => {
       const allNodes = deps.nodeRepo.listNodesByRun(db, runId);
-      // Use latest attempt per node
       const latestAttempts = new Map<string, FridayWorkflowRunNodeEntity>();
       for (const n of allNodes) {
         const existing = latestAttempts.get(n.nodeId);
@@ -547,42 +1060,7 @@ export function createFridayWorkflowExecutionService(
       const { readyNodes, deadEndedNodes } = schedulingResult;
 
       if (deadEndedNodes.length > 0) {
-        deps.db.withWriteTransaction((db) => {
-          for (const nodeId of deadEndedNodes) {
-            const currentStatus = nodeStatuses.get(nodeId);
-            if (currentStatus) {
-              continue;
-            }
-
-            const latestAttempt = deps.nodeRepo.getLatestAttempt(db, runId, nodeId);
-            if (latestAttempt) {
-              nodeStatuses.set(nodeId, latestAttempt.status);
-              continue;
-            }
-
-            const attemptId = deps.idGenerator();
-            const entity: FridayWorkflowRunNodeEntity = {
-              id: deps.idGenerator(),
-              runId,
-              nodeId,
-              attempt: 1,
-              attemptId,
-              status: "cancelled",
-              idempotencyKey: deps.retryManager.generateIdempotencyKey(
-                runId,
-                nodeId,
-                1,
-              ),
-              input: exprContext as unknown as JsonValue,
-              finishedAt: deps.nowIso(),
-              createdAt: deps.nowIso(),
-              updatedAt: deps.nowIso(),
-            };
-
-            deps.nodeRepo.insertNodeAttempt(db, entity);
-            nodeStatuses.set(nodeId, "cancelled");
-          }
-        });
+        cancelDeadEndedNodes(runId, deadEndedNodes, nodeStatuses, exprContext);
       }
 
       if (readyNodes.length === 0) {
@@ -592,490 +1070,27 @@ export function createFridayWorkflowExecutionService(
         continue;
       }
 
-      // Create node attempt records (or reuse existing retrying attempts)
-      const attempts: FridayWorkflowRunNodeEntity[] = [];
-      deps.db.withWriteTransaction((db) => {
-        for (const nodeId of readyNodes) {
-          // Check if this node already has a retrying attempt (from retryRun)
-          const currentNodeStatus = nodeStatuses.get(nodeId);
-          if (currentNodeStatus === "retrying") {
-            const existingAttempt = deps.db.withReadConnection((rdb) =>
-              deps.nodeRepo.getLatestAttempt(rdb, runId, nodeId),
-            );
-            if (existingAttempt && existingAttempt.status === "retrying") {
-              attempts.push(existingAttempt);
-              continue;
-            }
-          }
-
-          const latestAttempt = deps.db.withReadConnection((rdb) =>
-            deps.nodeRepo.getLatestAttempt(rdb, runId, nodeId),
-          );
-          const actualAttempt = latestAttempt
-            ? latestAttempt.attempt + 1
-            : 1;
-
-          const attemptId = deps.idGenerator();
-          const idempotencyKey = deps.retryManager.generateIdempotencyKey(
-            runId,
-            nodeId,
-            actualAttempt,
-          );
-
-          const entity: FridayWorkflowRunNodeEntity = {
-            id: deps.idGenerator(),
-            runId,
-            nodeId,
-            attempt: actualAttempt,
-            attemptId,
-            status: "queued",
-            idempotencyKey,
-            // SAFETY: exprContext is a Record-based expression context, runtime-compatible with JsonValue
-            input: exprContext as unknown as JsonValue,
-            createdAt: deps.nowIso(),
-            updatedAt: deps.nowIso(),
-          };
-
-          deps.nodeRepo.insertNodeAttempt(db, entity);
-          attempts.push(entity);
-        }
-      });
+      const attempts = prepareNodeAttempts(runId, readyNodes, nodeStatuses, exprContext);
 
       // Execute batch
       const results = await Promise.allSettled(
-        attempts.map(async (attempt) => {
-          try {
-            const node = plan.nodeMap.get(attempt.nodeId)!;
-
-            // Check for approval nodes — these block until explicit decision
-            if (node.type === "approval") {
-              // P2-WF: Use injected clock instead of Date.now() for testable lease TTL
-              const leaseExpiresAt = new Date(new Date(deps.nowIso()).getTime() + LEASE_TTL_MS).toISOString();
-              const leaseAcquired = deps.db.withWriteTransaction((db) =>
-                deps.nodeRepo.acquireLease(
-                  db,
-                  attempt.id,
-                  "hub",
-                  leaseExpiresAt,
-                  deps.nowIso(),
-                ),
-              );
-
-              if (!leaseAcquired) {
-                return { nodeId: attempt.nodeId, status: "skipped" as const };
-              }
-
-              deps.db.withWriteTransaction((db) => {
-                deps.nodeRepo.updateNodeAttempt(db, attempt.id, {
-                  status: "blocked_offline",
-                  nowIso: deps.nowIso(),
-                });
-              });
-
-              if (deps.requestNodeApproval) {
-                const nodeConfig = node.config as Record<string, unknown> | undefined;
-                try {
-                  await deps.requestNodeApproval({
-                    workflowId: runEntity.workflowId,
-                    workflowVersionId: runEntity.workflowVersionId,
-                    runId,
-                    runNodeAttemptId: attempt.id,
-                    nodeId: attempt.nodeId,
-                    approverUserId: nodeConfig?.approverUserId as string | undefined,
-                    approverRole: nodeConfig?.approverRole as string | undefined,
-                    requestPayload: nodeConfig?.requestPayload as Record<string, unknown> | undefined,
-                    timeoutMs: nodeConfig?.timeoutMs as number | undefined,
-                  });
-                } catch (approvalErr) {
-                  const errMsg = approvalErr instanceof Error ? approvalErr.message : String(approvalErr);
-                  console.error(
-                    `[friday] requestNodeApproval failed for run=${runId} node=${attempt.nodeId}: ${errMsg}`,
-                  );
-                  await deps.publishEvent?.("workflow.approval.error", {
-                    runId,
-                    nodeId: attempt.nodeId,
-                    attemptId: attempt.id,
-                    error: errMsg,
-                  });
-                }
-              }
-
-              deps.db.withWriteTransaction((db) => {
-                deps.runRepo.updateRunStatus(db, runId, "paused", deps.nowIso());
-              });
-
-              return {
-                nodeId: attempt.nodeId,
-                status: "paused" as const,
-              };
-            }
-
-            if (distributedDispatcher) {
-              const dispatchResult = await distributedDispatcher.dispatchNode({
-                runId,
-                workflowId: runEntity.workflowId,
-                workflowVersionId: runEntity.workflowVersionId,
-                nodeId: attempt.nodeId,
-                attemptId: attempt.attemptId,
-                attempt: attempt.attempt,
-                node,
-                inputData: (attempt.input as Record<string, unknown>) ?? {},
-                expressionContext: buildExpressionContext(
-                  runEntity,
-                  nodeContexts,
-                ),
-                idempotencyKey: attempt.idempotencyKey,
-              });
-
-              if (dispatchResult.kind === "satellite_dispatched") {
-                deps.db.withWriteTransaction((db) => {
-                  deps.nodeRepo.updateNodeAttempt(db, attempt.id, {
-                    status: "running",
-                    satelliteId: dispatchResult.satelliteId,
-                    leaseOwner: dispatchResult.leaseOwner,
-                    leaseExpiresAt: dispatchResult.leaseExpiresAt,
-                    startedAt: deps.nowIso(),
-                    nowIso: deps.nowIso(),
-                  });
-                });
-
-                await deps.publishEvent?.("workflow.node.started", {
-                  runId,
-                  nodeId: attempt.nodeId,
-                  attempt: attempt.attempt,
-                  satelliteId: dispatchResult.satelliteId,
-                });
-
-                return {
-                  nodeId: attempt.nodeId,
-                  status: "dispatched" as const,
-                  satelliteId: dispatchResult.satelliteId,
-                };
-              }
-
-              if (dispatchResult.kind === "blocked") {
-                deps.db.withWriteTransaction((db) => {
-                  deps.nodeRepo.updateNodeAttempt(db, attempt.id, {
-                    status: "blocked_offline",
-                    satelliteId: dispatchResult.satelliteId,
-                    error: {
-                      code: dispatchResult.code,
-                      message: dispatchResult.message,
-                      retryable: dispatchResult.retryable,
-                      details: dispatchResult.details,
-                    },
-                    nowIso: deps.nowIso(),
-                  });
-                });
-
-                await deps.publishEvent?.("workflow.node.blocked_offline", {
-                  runId,
-                  nodeId: attempt.nodeId,
-                  attempt: attempt.attempt,
-                  satelliteId: dispatchResult.satelliteId,
-                  since: deps.nowIso(),
-                });
-
-                return {
-                  nodeId: attempt.nodeId,
-                  status: "blocked" as const,
-                  satelliteId: dispatchResult.satelliteId,
-                  error: {
-                    code: dispatchResult.code,
-                    message: dispatchResult.message,
-                  },
-                };
-              }
-            }
-
-            const leaseExpiresAt = new Date(Date.now() + LEASE_TTL_MS).toISOString();
-            const leaseAcquired = deps.db.withWriteTransaction((db) =>
-              deps.nodeRepo.acquireLease(
-                db,
-                attempt.id,
-                "hub",
-                leaseExpiresAt,
-                deps.nowIso(),
-              ),
-            );
-
-            if (!leaseAcquired) {
-              return { nodeId: attempt.nodeId, status: "skipped" as const };
-            }
-
-            const timeoutMs = node.timeoutMs ?? 300_000;
-            // P2-WF-003: Store timeout handle for cleanup on success
-            let nodeTimeoutHandle: ReturnType<typeof setTimeout> | undefined;
-            const result = await Promise.race([
-              deps.nodeExecutor.executeNode({
-                runId,
-                workflowId: runEntity.workflowId,
-                nodeId: attempt.nodeId,
-                attemptId: attempt.attemptId,
-                node,
-                inputData: (attempt.input as Record<string, unknown>) ?? {},
-                expressionContext: buildExpressionContext(
-                  runEntity,
-                  nodeContexts,
-                ),
-                signal: runSignal,
-              }),
-              new Promise<never>((_, reject) => {
-                nodeTimeoutHandle = setTimeout(
-                  () => reject(new Error("NODE_TIMEOUT")),
-                  timeoutMs,
-                );
-              }),
-            ]);
-            if (nodeTimeoutHandle !== undefined) clearTimeout(nodeTimeoutHandle);
-
-            deps.db.withWriteTransaction((db) => {
-              deps.nodeRepo.updateNodeAttempt(db, attempt.id, {
-                status: "completed",
-                output: result.output,
-                finishedAt: deps.nowIso(),
-                nowIso: deps.nowIso(),
-              });
-            });
-
-            await notifyNodeAttemptResultSafe({
-              runId,
-              workflowId: runEntity.workflowId,
-              nodeId: attempt.nodeId,
-              attempt: attempt.attempt,
-              status: "completed",
-            });
-
-            if (result.output != null) {
-              deps.artifactWriter.writeJsonArtifact(
-                runId,
-                attempt.nodeId,
-                result.output,
-              );
-            }
-
-            return {
-              nodeId: attempt.nodeId,
-              status: "completed" as const,
-              output: result.output,
-            };
-          } catch (err) {
-            const errorMessage =
-              err instanceof Error ? err.message : String(err);
-            const errorCode = errorMessage.startsWith("NODE_")
-              ? errorMessage.split(":")[0]!
-              : "NODE_EXECUTION_FAILED";
-
-            const errorObj = {
-              code: errorCode,
-              message: errorMessage,
-              retryable: true,
-            } as const;
-
-            const failureStatus = await persistNodeFailure({
-              runId,
-              workflowId: runEntity.workflowId,
-              attempt,
-              node: plan.nodeMap.get(attempt.nodeId)!,
-              error: errorObj,
-            });
-
-            return {
-              nodeId: attempt.nodeId,
-              status: failureStatus,
-              error: errorObj,
-            };
-          }
-        }),
+        attempts.map((attempt) =>
+          executeSingleNode(runId, attempt, plan, runEntity, nodeContexts, runSignal),
+        ),
       );
 
-      // Process results and update statuses
-      let hasFailure = false;
-      let hasPause = false;
-      let hasBlocked = false;
-
-      for (const result of results) {
-        if (result.status === "rejected") continue;
-        const { value } = result;
-
-        if (value.status === "completed") {
-          nodeStatuses.set(value.nodeId, "completed");
-          if ("output" in value && value.output != null) {
-            const outputObj =
-              typeof value.output === "object" && !Array.isArray(value.output)
-                ? (value.output as Record<string, unknown>)
-                : { value: value.output };
-            nodeContexts.set(value.nodeId, { output: outputObj, status: "completed" });
-          }
-        } else if (value.status === "failed") {
-          nodeStatuses.set(value.nodeId, "failed");
-          if ("error" in value && value.error != null) {
-            const errObj = value.error as { code: string; message: string };
-            nodeContexts.set(value.nodeId, {
-              output: { status: "failed" },
-              status: "failed",
-              error: { code: errObj.code, message: errObj.message },
-            });
-          }
-          hasFailure = true;
-        } else if (value.status === "retrying") {
-          // Don't set status — let next iteration pick it up
-          // Remove from nodeStatuses so it can be retried
-          nodeStatuses.delete(value.nodeId);
-        } else if (value.status === "paused") {
-          nodeStatuses.set(value.nodeId, "blocked_offline");
-          hasPause = true;
-        } else if (value.status === "dispatched") {
-          nodeStatuses.set(value.nodeId, "running");
-        } else if (value.status === "blocked") {
-          nodeStatuses.set(value.nodeId, "blocked_offline");
-          hasBlocked = true;
-        }
-      }
-      // Apply failure policy
-      if (hasFailure) {
-        const policy = plan.failurePolicy;
-        switch (policy.onFailure) {
-          case "fail_fast":
-            aborted = true;
-            deps.db.withWriteTransaction((db) => {
-              deps.nodeRepo.cancelAllPendingNodes(db, runId, deps.nowIso());
-              deps.runRepo.finalizeRun(db, runId, "failed", deps.nowIso(), {
-                code: "WORKFLOW_FAILED",
-                message: "Workflow failed due to fail_fast policy",
-              });
-            });
-            {
-              const counts = deps.db.withReadConnection((db) =>
-                deps.nodeRepo.countByStatus(db, runId),
-              );
-              await notifyRunCompleted({
-                runId,
-                workflowId: runEntity.workflowId,
-                workflowVersionId: runEntity.workflowVersionId,
-                status: "failed",
-                plan,
-                failedNodes: counts.failed,
-                completedNodes: counts.completed,
-                cancelledNodes: counts.cancelled,
-              });
-            }
-            return;
-
-          case "continue_on_error":
-            // Continue, failed nodes are terminal
-            break;
-
-          case "pause_for_approval":
-            deps.db.withWriteTransaction((db) => {
-              deps.runRepo.updateRunStatus(db, runId, "paused", deps.nowIso());
-            });
-            return;
-
-          case "fallback_step":
-            // Add fallback step to ready set if available
-            if (policy.fallbackStepId) {
-              nodeStatuses.delete(policy.fallbackStepId);
-            }
-            break;
-
-          case "compensate":
-            deps.db.withWriteTransaction((db) => {
-              deps.runRepo.updateRunStatus(
-                db,
-                runId,
-                "compensating",
-                deps.nowIso(),
-              );
-            });
-            return;
-        }
-      }
-
-      if (hasPause) {
+      // Process results and apply failure policy
+      const outcome = await applyBatchResults(runId, results, plan, runEntity, nodeStatuses, nodeContexts);
+      if (outcome.aborted) {
+        aborted = true;
         return;
       }
-
-      if (hasBlocked) {
-        deps.db.withWriteTransaction((db) => {
-          deps.runRepo.updateRunStatus(db, runId, "paused", deps.nowIso());
-        });
-        await deps.publishEvent?.("workflow.run.paused", {
-          runId,
-          reason: "satellite_blocked_offline",
-        });
+      if (outcome.paused || outcome.blocked) {
         return;
       }
     }
 
-    // Determine final status
-    if (!aborted) {
-      runEntity = deps.db.withReadConnection((db) =>
-        deps.runRepo.getRunById(db, runId),
-      )!;
-
-      if (runEntity.status === "running") {
-        // Check if any nodes failed
-        const counts = deps.db.withReadConnection((db) =>
-          deps.nodeRepo.countByStatus(db, runId),
-        );
-
-        if (counts.running > 0 || counts.queued > 0 || counts.retrying > 0) {
-          return;
-        }
-
-        if (counts.blocked_offline > 0) {
-          deps.db.withWriteTransaction((db) => {
-            deps.runRepo.updateRunStatus(db, runId, "paused", deps.nowIso());
-          });
-          await deps.publishEvent?.("workflow.run.paused", {
-            runId,
-            reason: "satellite_blocked_offline",
-          });
-          return;
-        }
-
-        const finalStatus: WorkflowRunStatus =
-          counts.failed > 0 ? "failed" : "completed";
-
-        deps.db.withWriteTransaction((db) => {
-          const failure =
-            finalStatus === "failed"
-              ? {
-                  code: "WORKFLOW_NODES_FAILED",
-                  message: `${counts.failed} node(s) failed`,
-                }
-              : undefined;
-          deps.runRepo.finalizeRun(
-            db,
-            runId,
-            finalStatus,
-            deps.nowIso(),
-            failure,
-          );
-        });
-
-        await notifyRunCompleted({
-          runId,
-          workflowId: runEntity.workflowId,
-          workflowVersionId: runEntity.workflowVersionId,
-          status: finalStatus,
-          plan,
-          failedNodes: counts.failed,
-          completedNodes: counts.completed,
-          cancelledNodes: counts.cancelled,
-        });
-      }
-    }
-
-    const finalRun = deps.db.withReadConnection((db) =>
-      deps.runRepo.getRunById(db, runId),
-    );
-    if (finalRun?.status === "completed" || finalRun?.status === "failed" || finalRun?.status === "cancelled") {
-      activePlans.delete(runId);
-      activeAbortControllers.delete(runId);
-      await deps.publishEvent?.("workflow.run.finished", { runId });
-    }
+    await finalizeRunStatus(runId, plan, aborted);
   }
 
   return {

--- a/src/xhs/friday-xhs-pages.ts
+++ b/src/xhs/friday-xhs-pages.ts
@@ -162,8 +162,8 @@ export function createXhsPageInteractions(deps: CreateXhsPageInteractionsDeps): 
     }
     await xhsSleep();
 
-    // Take QR code screenshot
-    fs.mkdirSync(artifactDir, { recursive: true });
+    // Take QR code screenshot — mkdir with validated artifact dir
+    fs.mkdirSync(artifactDir, { recursive: true }); // eslint-disable-line security/detect-non-literal-fs-filename -- artifactDir is internal config, not user input
     let safeSessionId: string;
     try {
       safeSessionId = sanitizeArtifactPathSegment(sessionId);
@@ -173,7 +173,7 @@ export function createXhsPageInteractions(deps: CreateXhsPageInteractionsDeps): 
     }
     const qrPath = path.join(artifactDir, `xhs-qr-${safeSessionId}-${Date.now()}.png`);
     const screenshotBuffer = await page.screenshot({ type: "png" });
-    fs.writeFileSync(qrPath, screenshotBuffer);
+    fs.writeFileSync(qrPath, screenshotBuffer); // eslint-disable-line security/detect-non-literal-fs-filename -- path built from sanitized segments
 
     // Poll for login completion
     const startTime = Date.now();

--- a/test/unit/channels/friday-channel-input-sanitizer.test.ts
+++ b/test/unit/channels/friday-channel-input-sanitizer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { sanitizeChannelInput } from "#channels";
+import { sanitizeChannelInput, FRIDAY_MAX_CHANNEL_INPUT_LENGTH } from "#channels";
 
 describe("sanitizeChannelInput", () => {
   it("trims whitespace", () => {
@@ -38,5 +38,28 @@ describe("sanitizeChannelInput", () => {
 
   it("preserves Unicode text", () => {
     expect(sanitizeChannelInput("你好世界")).toBe("你好世界");
+  });
+
+  it("truncates input exceeding max length", () => {
+    const oversized = "a".repeat(FRIDAY_MAX_CHANNEL_INPUT_LENGTH + 1000);
+    const result = sanitizeChannelInput(oversized);
+    expect(result.length).toBeLessThanOrEqual(FRIDAY_MAX_CHANNEL_INPUT_LENGTH);
+  });
+
+  it("preserves input within max length", () => {
+    const withinLimit = "hello world";
+    expect(sanitizeChannelInput(withinLimit)).toBe("hello world");
+  });
+
+  it("applies NFC normalization", () => {
+    // é composed (e + combining acute) vs precomposed
+    const decomposed = "caf\u0065\u0301"; // e + combining accent
+    const result = sanitizeChannelInput(decomposed);
+    expect(result).toBe("café");
+  });
+
+  it("exports FRIDAY_MAX_CHANNEL_INPUT_LENGTH constant", () => {
+    expect(typeof FRIDAY_MAX_CHANNEL_INPUT_LENGTH).toBe("number");
+    expect(FRIDAY_MAX_CHANNEL_INPUT_LENGTH).toBeGreaterThan(0);
   });
 });

--- a/test/unit/deeplink/friday-deeplink-validator.test.ts
+++ b/test/unit/deeplink/friday-deeplink-validator.test.ts
@@ -107,6 +107,47 @@ describe("validateFridayDeepLink", () => {
     });
   });
 
+  describe("SSRF protection — private URL detection", () => {
+    const privateUrls = [
+      "http://127.0.0.1:8080/api",
+      "http://10.0.0.1/internal",
+      "http://192.168.1.100:11434/v1",
+      "http://172.16.0.1/admin",
+      "http://172.31.255.255/admin",
+      "http://localhost:3000/skill",
+      "http://[::1]:8080/api",
+      "http://0.0.0.0:3000/probe",
+      "http://169.254.169.254/metadata",
+    ];
+
+    for (const url of privateUrls) {
+      it(`detects private URL: ${url}`, () => {
+        const result = validateFridayDeepLink(makePayload({
+          type: "skill-source",
+          skillSource: { url },
+        }));
+        expect(result.checks.some((c) => c.level === "warning" && c.summary.toLowerCase().includes("private"))).toBe(true);
+      });
+    }
+
+    it("allows public URLs", () => {
+      const result = validateFridayDeepLink(makePayload({
+        type: "skill-source",
+        skillSource: { url: "https://github.com/user/repo" },
+      }));
+      expect(result.checks.every((c) => !c.summary.toLowerCase().includes("private"))).toBe(true);
+    });
+
+    it("treats unparseable URLs as private (fail-closed)", () => {
+      const result = validateFridayDeepLink(makePayload({
+        type: "skill-source",
+        skillSource: { url: "not-a-url" },
+      }));
+      // Should either block or warn
+      expect(result.checks.some((c) => c.level === "warning" || c.level === "blocking")).toBe(true);
+    });
+  });
+
   describe("integrity hash", () => {
     it("reports advisory when valid SHA-256 provided", () => {
       const result = validateFridayDeepLink(makePayload({

--- a/test/unit/sessions/services/friday-session-key.test.ts
+++ b/test/unit/sessions/services/friday-session-key.test.ts
@@ -163,6 +163,29 @@ describe("FridaySessionKey", () => {
         FRIDAY_SESSION_ERROR_CODES.INVALID_KEY,
       );
     });
+
+    it("rejects deeply nested subagent keys exceeding max depth", () => {
+      // Build a key with 12 levels of subagent nesting (max is 10)
+      let key = "discord:default:chat";
+      for (let i = 0; i < 12; i++) {
+        key = `subagent:${key}:task-${i}`;
+      }
+      expectSessionError(
+        () => parseFridaySessionKey(key),
+        FRIDAY_SESSION_ERROR_CODES.INVALID_KEY,
+      );
+    });
+
+    it("accepts subagent keys at max allowed depth", () => {
+      // Build a key with exactly 10 levels (should pass)
+      let key = "discord:default:chat";
+      for (let i = 0; i < 10; i++) {
+        key = `subagent:${key}:task-${i}`;
+      }
+      const parsed = parseFridaySessionKey(key);
+      expect(parsed.kind).toBe("subagent");
+      expect(parsed.channel).toBe("discord");
+    });
   });
 
   // ─── validateFridaySessionKey ───

--- a/test/unit/workflows/friday-workflow-dag-scheduler.test.ts
+++ b/test/unit/workflows/friday-workflow-dag-scheduler.test.ts
@@ -223,7 +223,7 @@ describe("FridayWorkflowDagScheduler", () => {
     expect(result.deadEndedNodes).toContain("B");
   });
 
-  it("warns when condition evaluation fails and treats the edge as enabled (fail-open)", () => {
+  it("warns when condition evaluation fails and treats the edge as disabled (fail-closed)", () => {
     const graph = makeGraph(
       [{ id: "A" }, { id: "B" }],
       [
@@ -250,9 +250,9 @@ describe("FridayWorkflowDagScheduler", () => {
     );
 
     expect(warnSpy).toHaveBeenCalledTimes(1);
-    // P2-WF-001: Changed from fail-disabled to fail-open — B should now be ready
-    expect(result.readyNodes).toContain("B");
-    expect(result.deadEndedNodes).not.toContain("B");
+    // Fail-closed: expression errors block the edge to prevent unintended execution
+    expect(result.readyNodes).not.toContain("B");
+    expect(result.deadEndedNodes).toContain("B");
   });
 
   it("entry nodes computation", () => {

--- a/ui/src/components/chat/chat-input.tsx
+++ b/ui/src/components/chat/chat-input.tsx
@@ -13,6 +13,8 @@ interface ChatInputProps {
   onValueChange?: (value: string) => void;
 }
 
+const CHAT_INPUT_MAX_LENGTH = 50_000;
+
 export function ChatInput({
   onSend,
   disabled = false,
@@ -83,6 +85,7 @@ export function ChatInput({
             "Tell Friday what you want to get done or describe the task directly…",
           )}
           disabled={disabled}
+          maxLength={CHAT_INPUT_MAX_LENGTH}
           rows={1}
           className="min-h-[32px] flex-1 resize-none bg-transparent text-sm leading-6 text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-faint)] focus:outline-none disabled:opacity-50"
         />

--- a/ui/src/components/core/budget-indicator.tsx
+++ b/ui/src/components/core/budget-indicator.tsx
@@ -1,4 +1,6 @@
 import { useBudgetStatus } from "@/hooks/use-budget-status";
+import { localize } from "@/lib/i18n/localized-text";
+import { useAppLocale } from "@/providers/locale-provider";
 
 const TONE_CLASSES = {
   neutral: "text-[color:var(--color-text-secondary)]",
@@ -8,19 +10,21 @@ const TONE_CLASSES = {
 
 export function BudgetIndicator() {
   const budget = useBudgetStatus();
+  const { locale } = useAppLocale();
 
   if (budget.loading || budget.limitUsd === null) {
     return null;
   }
 
+  const usedLabel = localize(locale, "已用", "Used");
   const label = budget.percentUsed !== null
-    ? `已用 $${budget.spentUsd.toFixed(2)} / $${budget.limitUsd.toFixed(2)} (${budget.percentUsed.toFixed(0)}%)`
-    : `已用 $${budget.spentUsd.toFixed(2)} / spent`;
+    ? `${usedLabel} $${budget.spentUsd.toFixed(2)} / $${budget.limitUsd.toFixed(2)} (${budget.percentUsed.toFixed(0)}%)`
+    : `${usedLabel} $${budget.spentUsd.toFixed(2)}`;
 
   return (
     <div
       className={`flex min-h-[32px] items-center gap-1.5 rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] px-3 py-1 text-xs font-medium shadow-[var(--shadow-floating)] ${TONE_CLASSES[budget.tone]}`}
-      title={`月度预算 / Monthly budget: ${label}`}
+      title={localize(locale, `月度预算: ${label}`, `Monthly budget: ${label}`)}
     >
       {budget.tone === "critical" && (
         <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-[color:var(--color-text-primary)]" />

--- a/ui/src/components/core/contextual-help.tsx
+++ b/ui/src/components/core/contextual-help.tsx
@@ -18,7 +18,7 @@ export function ContextualHelp(props: { text: string; locale: AppLocale; classNa
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [open]);
 
-  if (props.locale !== "zh") return null;
+  if (!props.text) return null;
 
   return (
     <span ref={ref} className={cn("relative inline-flex", props.className)}>
@@ -26,7 +26,7 @@ export function ContextualHelp(props: { text: string; locale: AppLocale; classNa
         type="button"
         onClick={() => setOpen((v) => !v)}
         className="inline-flex items-center justify-center rounded-full p-0.5 text-[color:var(--color-text-faint)] transition hover:text-[color:var(--color-text-secondary)]"
-        aria-label="帮助"
+        aria-label={props.locale === "zh" ? "帮助" : "Help"}
       >
         <HelpCircle className="h-3.5 w-3.5" />
       </button>

--- a/ui/src/components/core/primitives.tsx
+++ b/ui/src/components/core/primitives.tsx
@@ -1,4 +1,4 @@
-import type { ButtonHTMLAttributes, ReactNode } from "react";
+import { type ButtonHTMLAttributes, type ReactNode, useState } from "react";
 import { cn } from "@/lib/utils/cn";
 
 export function ShellCard(props: {
@@ -34,9 +34,9 @@ export function StatusPill(props: {
     <span
       className={cn(
         "inline-flex min-h-[32px] items-center rounded-full border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] transition-colors",
-        props.tone === "success" && "border-emerald-200 bg-emerald-50 text-emerald-700",
-        props.tone === "warning" && "border-amber-200 bg-amber-50 text-amber-700",
-        props.tone === "danger" && "border-red-200 bg-red-50 text-red-700",
+        props.tone === "success" && "border-[color:var(--color-border-success)] bg-[color:var(--color-bg-success-subtle)] text-[color:var(--color-text-success)]",
+        props.tone === "warning" && "border-[color:var(--color-border-warning)] bg-[color:var(--color-bg-warning-subtle)] text-[color:var(--color-text-warning)]",
+        props.tone === "danger" && "border-[color:var(--color-border-danger)] bg-[color:var(--color-bg-danger-subtle)] text-[color:var(--color-text-danger)]",
         (!props.tone || props.tone === "neutral") && "border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-subtle)] text-[color:var(--color-text-secondary)]",
         props.className,
       )}
@@ -148,5 +148,64 @@ export function ThinkingDots() {
       <span className="thinking-dot" />
       <span className="thinking-dot" />
     </span>
+  );
+}
+
+/* ── Confirm Dialog ── */
+
+export function ConfirmDialog(props: {
+  open: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+  title: string;
+  description?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  tone?: "danger" | "primary";
+  loading?: boolean;
+}) {
+  if (!props.open) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center" role="dialog" aria-modal="true" aria-label={props.title}>
+      <div className="fixed inset-0 bg-black/30 backdrop-blur-sm" onClick={props.onCancel} />
+      <div className="relative z-10 mx-4 w-full max-w-sm rounded-[28px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-elevated)] p-6 shadow-[var(--shadow-card-strong)]">
+        <h3 className="text-base font-semibold text-[color:var(--color-text-primary)]">{props.title}</h3>
+        {props.description && (
+          <p className="mt-2 text-sm leading-6 text-[color:var(--color-text-secondary)]">{props.description}</p>
+        )}
+        <div className="mt-5 flex justify-end gap-2">
+          <ActionButton tone="secondary" onClick={props.onCancel} disabled={props.loading}>
+            {props.cancelLabel ?? "Cancel"}
+          </ActionButton>
+          <ActionButton tone={props.tone ?? "danger"} onClick={props.onConfirm} disabled={props.loading}>
+            {props.confirmLabel ?? "Confirm"}
+          </ActionButton>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ── Empty State ── */
+
+export function EmptyState(props: {
+  title: string;
+  description?: string;
+  action?: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={cn("flex flex-col items-center justify-center py-12 text-center", props.className)}>
+      <div className="mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-[color:var(--color-bg-subtle)]">
+        <svg className="h-5 w-5 text-[color:var(--color-text-faint)]" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.5}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M20.25 7.5l-.625 10.632a2.25 2.25 0 01-2.247 2.118H6.622a2.25 2.25 0 01-2.247-2.118L3.75 7.5m6 4.125l2.25 2.25m0 0l2.25-2.25M12 13.875V7.5m0 0H9m3 0h3" />
+        </svg>
+      </div>
+      <h3 className="text-sm font-medium text-[color:var(--color-text-primary)]">{props.title}</h3>
+      {props.description && (
+        <p className="mt-1 max-w-xs text-xs leading-5 text-[color:var(--color-text-tertiary)]">{props.description}</p>
+      )}
+      {props.action && <div className="mt-4">{props.action}</div>}
+    </div>
   );
 }

--- a/ui/src/components/deeplink/deeplink-preview-dialog.tsx
+++ b/ui/src/components/deeplink/deeplink-preview-dialog.tsx
@@ -36,11 +36,11 @@ interface DeepLinkApplyResponse {
 function checkLevelBadge(level: string) {
   switch (level) {
     case "blocking":
-      return <span className="rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700 dark:bg-red-900/30 dark:text-red-400">Blocking</span>;
+      return <span className="rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700 ">Blocking</span>;
     case "warning":
-      return <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">Warning</span>;
+      return <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700 ">Warning</span>;
     default:
-      return <span className="rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-600 dark:bg-blue-900/30 dark:text-blue-400">Advisory</span>;
+      return <span className="rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-600 ">Advisory</span>;
   }
 }
 
@@ -80,7 +80,7 @@ export function DeepLinkPreviewDialog(props: { onClose: () => void; onApplied?: 
       >
         <h2 className="text-lg font-semibold text-[color:var(--color-text-primary)]">Import from URL</h2>
         <p className="mt-1 text-sm text-[color:var(--color-text-secondary)]">
-          Paste a <code className="rounded bg-zinc-100 px-1 dark:bg-zinc-800">friday://</code> deep link or a JSON payload to preview and import.
+          Paste a <code className="rounded bg-zinc-100 px-1 ">friday://</code> deep link or a JSON payload to preview and import.
         </p>
 
         <textarea
@@ -92,7 +92,7 @@ export function DeepLinkPreviewDialog(props: { onClose: () => void; onApplied?: 
         />
 
         {previewMutation.error ? (
-          <p className="mt-2 text-xs text-red-600 dark:text-red-400">
+          <p className="mt-2 text-xs text-red-600 ">
             {previewMutation.error instanceof Error ? previewMutation.error.message : "Preview failed"}
           </p>
         ) : null}
@@ -114,11 +114,11 @@ export function DeepLinkPreviewDialog(props: { onClose: () => void; onApplied?: 
             <div className="flex items-center gap-2">
               <span className="text-sm font-medium text-[color:var(--color-text-primary)]">{preview.payload.label}</span>
               {preview.verdict === "ready" ? (
-                <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400">Ready</span>
+                <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700 ">Ready</span>
               ) : preview.verdict === "needs_review" ? (
-                <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">Needs Review</span>
+                <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700 ">Needs Review</span>
               ) : (
-                <span className="rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700 dark:bg-red-900/30 dark:text-red-400">Blocked</span>
+                <span className="rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700 ">Blocked</span>
               )}
             </div>
 
@@ -157,7 +157,7 @@ export function DeepLinkPreviewDialog(props: { onClose: () => void; onApplied?: 
             </div>
 
             {applyMutation.error ? (
-              <p className="text-xs text-red-600 dark:text-red-400">
+              <p className="text-xs text-red-600 ">
                 {applyMutation.error instanceof Error ? applyMutation.error.message : "Import failed"}
               </p>
             ) : null}

--- a/ui/src/components/usage/usage-charts.tsx
+++ b/ui/src/components/usage/usage-charts.tsx
@@ -6,7 +6,7 @@
 export function PercentBar({ value, max, color }: { value: number; max: number; color: string }) {
   const pct = max > 0 ? Math.min((value / max) * 100, 100) : 0;
   return (
-    <div className="h-3 w-full rounded-full bg-zinc-100 dark:bg-zinc-800">
+    <div className="h-3 w-full rounded-full bg-[color:var(--color-bg-subtle)]">
       <div
         className="h-3 rounded-full transition-all duration-300"
         style={{ width: `${String(pct)}%`, backgroundColor: color }}
@@ -18,13 +18,13 @@ export function PercentBar({ value, max, color }: { value: number; max: number; 
 export function StatusBadge({ status }: { status: string }) {
   switch (status) {
     case "healthy":
-      return <span className="inline-flex items-center rounded-full bg-emerald-50 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400">Healthy</span>;
+      return <span className="inline-flex items-center rounded-full bg-[color:var(--color-bg-success-subtle)] px-2 py-0.5 text-xs font-medium text-[color:var(--color-text-success)]">Healthy</span>;
     case "degraded":
-      return <span className="inline-flex items-center rounded-full bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">Degraded</span>;
+      return <span className="inline-flex items-center rounded-full bg-[color:var(--color-bg-warning-subtle)] px-2 py-0.5 text-xs font-medium text-[color:var(--color-text-warning)]">Degraded</span>;
     case "error":
     case "down":
-      return <span className="inline-flex items-center rounded-full bg-red-50 px-2 py-0.5 text-xs font-medium text-red-700 dark:bg-red-900/30 dark:text-red-400">Error</span>;
+      return <span className="inline-flex items-center rounded-full bg-[color:var(--color-bg-danger-subtle)] px-2 py-0.5 text-xs font-medium text-[color:var(--color-text-danger)]">Error</span>;
     default:
-      return <span className="inline-flex items-center rounded-full bg-zinc-100 px-2 py-0.5 text-xs font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">{status}</span>;
+      return <span className="inline-flex items-center rounded-full bg-[color:var(--color-bg-subtle)] px-2 py-0.5 text-xs font-medium text-[color:var(--color-text-secondary)]">{status}</span>;
   }
 }

--- a/ui/src/lib/api/learning.ts
+++ b/ui/src/lib/api/learning.ts
@@ -38,4 +38,12 @@ export const learningApi = {
       },
     );
   },
+
+  async approveAction(actionId: string, reason?: string): Promise<void> {
+    await apiClient.post(`/v1/auto-fix/actions/${encodeURIComponent(actionId)}/approve`, reason ? { reason } : {});
+  },
+
+  async denyAction(actionId: string, reason?: string): Promise<void> {
+    await apiClient.post(`/v1/auto-fix/actions/${encodeURIComponent(actionId)}/deny`, reason ? { reason } : {});
+  },
 };

--- a/ui/src/routes/assistant-inbox-page.tsx
+++ b/ui/src/routes/assistant-inbox-page.tsx
@@ -1,8 +1,9 @@
-import { useMemo } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowRight, CheckCircle2, RefreshCcw, ShieldAlert, Sparkles } from "lucide-react";
 import { useLocation, useSearchParams } from "react-router-dom";
-import { ActionButton, ShellCard, StatusPill } from "@/components/core/primitives";
+import { ActionButton, ConfirmDialog, ShellCard, StatusPill } from "@/components/core/primitives";
+import { learningApi } from "@/lib/api/learning";
 import { LearningInsightCard } from "@/components/core/learning-insight-card";
 import { CrossBorderAssistantHandoffCard } from "@/components/packs/cross-border-assistant-handoff-card";
 import { PackAssistantHandoffCard } from "@/components/packs/pack-assistant-handoff-card";
@@ -70,6 +71,22 @@ export function AssistantInboxPage() {
     const target = document.getElementById(sectionId);
     target?.scrollIntoView({ behavior: "smooth", block: "start" });
   };
+
+  const queryClient = useQueryClient();
+  const [confirmApproval, setConfirmApproval] = useState<{ actionId: string; title: string; mode: "approve" | "deny" } | null>(null);
+  const approvalMutation = useMutation({
+    mutationFn: async ({ actionId, mode }: { actionId: string; mode: "approve" | "deny" }) => {
+      if (mode === "approve") {
+        await learningApi.approveAction(actionId);
+      } else {
+        await learningApi.denyAction(actionId);
+      }
+    },
+    onSuccess: () => {
+      setConfirmApproval(null);
+      void queryClient.invalidateQueries({ queryKey: ["uix", "assistant-inbox"] });
+    },
+  });
 
   return (
     <div className="space-y-5 pb-4">
@@ -149,6 +166,26 @@ export function AssistantInboxPage() {
                     <StatusPill tone="warning">{localize(locale, "待确认", "Needs Review")}</StatusPill>
                   </div>
                   <p className="mt-2 text-xs leading-5 text-[color:var(--color-text-secondary)]">{action.summary}</p>
+                  {action.actionId && (
+                    <div className="mt-3 flex gap-2">
+                      <ActionButton
+                        tone="primary"
+                        onClick={() => setConfirmApproval({ actionId: action.actionId!, title: action.title, mode: "approve" })}
+                        disabled={approvalMutation.isPending}
+                        className="!min-h-[36px] !px-3 !text-xs"
+                      >
+                        {localize(locale, "批准", "Approve")}
+                      </ActionButton>
+                      <ActionButton
+                        tone="danger"
+                        onClick={() => setConfirmApproval({ actionId: action.actionId!, title: action.title, mode: "deny" })}
+                        disabled={approvalMutation.isPending}
+                        className="!min-h-[36px] !px-3 !text-xs"
+                      >
+                        {localize(locale, "拒绝", "Reject")}
+                      </ActionButton>
+                    </div>
+                  )}
                 </div>
               ))}
             </div>
@@ -303,6 +340,25 @@ export function AssistantInboxPage() {
           <ArrowRight className="ml-2 h-4 w-4" aria-hidden="true" />
         </ActionButton>
       </div>
+      <ConfirmDialog
+        open={confirmApproval !== null}
+        title={confirmApproval?.mode === "approve"
+          ? localize(locale, "确认批准", "Confirm Approval")
+          : localize(locale, "确认拒绝", "Confirm Rejection")}
+        description={confirmApproval
+          ? localize(locale, `确定要${confirmApproval.mode === "approve" ? "批准" : "拒绝"}"${confirmApproval.title}"吗？`, `Are you sure you want to ${confirmApproval.mode} "${confirmApproval.title}"?`)
+          : ""}
+        confirmLabel={confirmApproval?.mode === "approve" ? localize(locale, "批准", "Approve") : localize(locale, "拒绝", "Reject")}
+        cancelLabel={localize(locale, "取消", "Cancel")}
+        tone={confirmApproval?.mode === "approve" ? "primary" : "danger"}
+        loading={approvalMutation.isPending}
+        onConfirm={() => {
+          if (confirmApproval) {
+            approvalMutation.mutate({ actionId: confirmApproval.actionId, mode: confirmApproval.mode });
+          }
+        }}
+        onCancel={() => setConfirmApproval(null)}
+      />
     </div>
   );
 }

--- a/ui/src/routes/fleet-page.tsx
+++ b/ui/src/routes/fleet-page.tsx
@@ -1,9 +1,9 @@
 import type { ReactNode } from "react";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Cpu, HeartPulse, Link2, RadioTower, ShieldCheck, Workflow } from "lucide-react";
 import { Link, useSearchParams } from "react-router-dom";
-import { ShellCard, SkeletonCard, SkeletonList, StatusPill } from "@/components/core/primitives";
+import { ActionButton, ConfirmDialog, ShellCard, SkeletonCard, SkeletonList, StatusPill } from "@/components/core/primitives";
 import { HelpTooltip } from "@/components/core/help-tooltip";
 import { localize, type AppLocale } from "@/lib/i18n/localized-text";
 import { useAppLocale } from "@/providers/locale-provider";
@@ -79,6 +79,21 @@ export function FleetPage() {
   });
 
   const satellites = satellitesQuery.data?.items ?? [];
+
+  const pairingQuery = useQuery({
+    queryKey: ["fleet", "pairing-requests"],
+    queryFn: () => fleetApi.listPairingRequests(),
+    refetchInterval: 10_000,
+  });
+  const pendingPairings = useMemo(() => pairingQuery.data ?? [], [pairingQuery.data]);
+  const [pairingToApprove, setPairingToApprove] = useState<string | null>(null);
+  const approvePairingMutation = useMutation({
+    mutationFn: (satelliteId: string) => fleetApi.approvePairing(satelliteId),
+    onSuccess: () => {
+      setPairingToApprove(null);
+      void queryClient.invalidateQueries({ queryKey: ["fleet"] });
+    },
+  });
   const loopRunsQuery = useQuery({
     queryKey: ["fleet", "loop-runs"],
     queryFn: () => systemApi.listAgentLoopRuns({ limit: 12 }),
@@ -222,6 +237,22 @@ export function FleetPage() {
         </ShellCard>
 
         <ShellCard eyebrow={localize(locale, "卫星节点", "Satellites")} title={<>{localize(locale, "选择一个", "Choose a ")} <HelpTooltip term="satellite" /> {localize(locale, "查看或恢复", "to inspect or recover")}</>}>
+          {pendingPairings.length > 0 && (
+            <div className="mb-4 space-y-2">
+              <p className="text-xs font-semibold uppercase tracking-widest text-[color:var(--color-text-tertiary)]">{localize(locale, "待配对", "Pending Pairing")}</p>
+              {pendingPairings.map((req) => (
+                <div key={req.satelliteId} className="flex items-center justify-between gap-3 rounded-2xl border border-dashed border-[color:var(--color-accent-soft)] bg-[color:var(--color-accent-muted)] px-4 py-3">
+                  <div>
+                    <p className="text-sm font-medium text-[color:var(--color-text-primary)]">{req.displayName ?? req.satelliteId}</p>
+                    <p className="text-xs text-[color:var(--color-text-tertiary)]">{localize(locale, "等待批准配对", "Waiting for pairing approval")}</p>
+                  </div>
+                  <ActionButton className="!min-h-[36px] !px-3 !text-xs" onClick={() => setPairingToApprove(req.satelliteId)} disabled={approvePairingMutation.isPending}>
+                    {localize(locale, "批准配对", "Approve")}
+                  </ActionButton>
+                </div>
+              ))}
+            </div>
+          )}
           <div className="space-y-3">
             {satellites.map((satellite) => (
               <button
@@ -509,6 +540,17 @@ export function FleetPage() {
           )}
         </ShellCard>
       </div>
+      <ConfirmDialog
+        open={pairingToApprove !== null}
+        title={localize(locale, "确认配对卫星", "Confirm Satellite Pairing")}
+        description={localize(locale, "批准后该节点将加入集群并可接收任务。", "Once approved, this satellite joins the fleet and can receive dispatched work.")}
+        confirmLabel={localize(locale, "批准", "Approve")}
+        cancelLabel={localize(locale, "取消", "Cancel")}
+        tone="primary"
+        loading={approvePairingMutation.isPending}
+        onConfirm={() => { if (pairingToApprove) approvePairingMutation.mutate(pairingToApprove); }}
+        onCancel={() => setPairingToApprove(null)}
+      />
     </div>
   );
 }

--- a/ui/src/routes/memory-page.tsx
+++ b/ui/src/routes/memory-page.tsx
@@ -3,7 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Brain, Plus, Search, Tag, Trash2 } from "lucide-react";
 import { SkeletonList } from "@/components/core/primitives";
 import { toast } from "sonner";
-import { ActionButton, ShellCard, StatusPill } from "@/components/core/primitives";
+import { ActionButton, ConfirmDialog, ShellCard, StatusPill } from "@/components/core/primitives";
 import { memoryApi } from "@/lib/api/memory";
 import { localize } from "@/lib/i18n/localized-text";
 import { useAppLocale } from "@/providers/locale-provider";
@@ -73,6 +73,7 @@ export function MemoryPage() {
   });
 
   const [showAddForm, setShowAddForm] = useState(false);
+  const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
 
   const handleSearch = () => {
     setActiveSearch(searchQuery.trim());
@@ -206,7 +207,7 @@ export function MemoryPage() {
                   </div>
                   <button
                     type="button"
-                    onClick={() => deleteMutation.mutate(item.id)}
+                    onClick={() => setDeleteConfirmId(item.id)}
                     disabled={deleteMutation.isPending}
                     aria-label={localize(locale, "删除此记忆", "Delete this memory")}
                     className="shrink-0 rounded-xl p-2 text-[color:var(--color-text-faint)] transition-colors hover:bg-[color:var(--color-bg-contrast)] hover:text-[color:var(--color-text-primary)]"
@@ -237,6 +238,22 @@ export function MemoryPage() {
           ))}
         </div>
       )}
+      <ConfirmDialog
+        open={deleteConfirmId !== null}
+        title={localize(locale, "确认删除记忆", "Delete Memory")}
+        description={localize(locale, "此操作不可撤销。", "This action cannot be undone.")}
+        confirmLabel={localize(locale, "删除", "Delete")}
+        cancelLabel={localize(locale, "取消", "Cancel")}
+        tone="danger"
+        loading={deleteMutation.isPending}
+        onConfirm={() => {
+          if (deleteConfirmId) {
+            deleteMutation.mutate(deleteConfirmId);
+            setDeleteConfirmId(null);
+          }
+        }}
+        onCancel={() => setDeleteConfirmId(null)}
+      />
     </div>
   );
 }

--- a/ui/src/routes/onboarding-page.tsx
+++ b/ui/src/routes/onboarding-page.tsx
@@ -262,9 +262,9 @@ export function OnboardingPage() {
             </div>
             <div className="mt-5 flex items-center justify-between gap-3">
               <p className="text-sm text-[color:var(--color-text-secondary)]">
-                {locale === "zh"
-                  ? `已选择 ${selectedPacks.length} / 3`
-                  : `${selectedPacks.length} / 3 selected`}
+                {selectedPacks.length < 3
+                  ? localize(locale, `请选择 3 个场景包 (已选 ${selectedPacks.length})`, `Select 3 packs to continue (${selectedPacks.length} selected)`)
+                  : localize(locale, `已选择 ${selectedPacks.length} / 3`, `${selectedPacks.length} / 3 selected`)}
               </p>
               <div className="flex gap-2">
                 <ActionButton tone="secondary" onClick={() => setStep("profile")}>

--- a/ui/src/routes/setup-page.tsx
+++ b/ui/src/routes/setup-page.tsx
@@ -559,7 +559,7 @@ export function SetupPage() {
                 </ActionButton>
                 <ActionButton
                   onClick={() => saveProviderMutation.mutate()}
-                  disabled={!providerBaseUrl.trim() || providerModels.length === 0}
+                  disabled={!providerBaseUrl.trim() || providerModels.length === 0 || saveProviderMutation.isPending}
                 >
                   Save Provider
                 </ActionButton>

--- a/ui/src/routes/skills-page.tsx
+++ b/ui/src/routes/skills-page.tsx
@@ -4,7 +4,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { BadgeCheck, Download, Link2, Package, RefreshCcw, ShieldCheck, Trash2 } from "lucide-react";
 import { DeepLinkPreviewDialog } from "@/components/deeplink/deeplink-preview-dialog";
 import { toast } from "sonner";
-import { ActionButton, ShellCard, SkeletonList, StatusPill } from "@/components/core/primitives";
+import { ActionButton, ConfirmDialog, EmptyState, ShellCard, SkeletonCard, SkeletonList, StatusPill } from "@/components/core/primitives";
 import { HelpTooltip } from "@/components/core/help-tooltip";
 import { localize, type AppLocale } from "@/lib/i18n/localized-text";
 import { useAppLocale } from "@/providers/locale-provider";
@@ -127,6 +127,7 @@ export function SkillsPage() {
   const [selectedSkillId, setSelectedSkillId] = useState<string | null>(null);
   const [recentGeneratorSessionId, setRecentGeneratorSessionId] = useState<string | null>(null);
   const [showImportDialog, setShowImportDialog] = useState(false);
+  const [deleteConfirmSkillId, setDeleteConfirmSkillId] = useState<string | null>(null);
   const requestedSkillId = searchParams.get("skillId");
   const requestedFocus = searchParams.get("focus");
   const focus: FridaySkillFocus =
@@ -655,7 +656,7 @@ export function SkillsPage() {
                   {!detail.starter && (detail.installedVersion || detail.registryLoaded) ? (
                     <ActionButton
                       tone="danger"
-                      onClick={() => void deleteMutation.mutateAsync(detail.skillId)}
+                      onClick={() => setDeleteConfirmSkillId(detail.skillId)}
                       disabled={deleteMutation.isPending}
                     >
                       <Trash2 className="mr-2 h-4 w-4" />
@@ -843,6 +844,21 @@ export function SkillsPage() {
           </div>
         </ShellCard>
       </div>
+      <ConfirmDialog
+        open={deleteConfirmSkillId !== null}
+        title={localize(locale, "确认删除技能", "Remove Skill")}
+        description={localize(locale, "此操作不可撤销。技能将从本地注册中移除。", "This action cannot be undone. The skill will be removed from the local registry.")}
+        confirmLabel={localize(locale, "删除", "Remove")}
+        cancelLabel={localize(locale, "取消", "Cancel")}
+        tone="danger"
+        loading={deleteMutation.isPending}
+        onConfirm={() => {
+          if (deleteConfirmSkillId) {
+            void deleteMutation.mutateAsync(deleteConfirmSkillId).then(() => setDeleteConfirmSkillId(null));
+          }
+        }}
+        onCancel={() => setDeleteConfirmSkillId(null)}
+      />
     </div>
   );
 }

--- a/ui/src/routes/usage-page.tsx
+++ b/ui/src/routes/usage-page.tsx
@@ -154,7 +154,7 @@ export function UsagePage() {
           <SkeletonCard lines={1} />
         </div>
       ) : isError ? (
-        <div className="rounded-xl border border-red-200 bg-red-50 p-8 text-center dark:border-red-900/50 dark:bg-red-900/20">
+        <div className="rounded-xl border border-[color:var(--color-border-danger)] bg-[color:var(--color-bg-danger-subtle)] p-8 text-center">
           <p className="text-sm font-medium status-error">{localize(locale, "加载用量数据失败", "Failed to load usage data")}</p>
           <p className="mt-1 text-xs text-[color:var(--color-text-tertiary)]">{localize(locale, "提供商健康信息暂时不可用。", "Provider health information is temporarily unavailable.")}</p>
         </div>
@@ -165,25 +165,25 @@ export function UsagePage() {
             <h2 className="text-sm font-medium text-[color:var(--color-text-primary)]">
               {localize(locale, "Token 用量估算", "Token Usage Estimate")}
             </h2>
-            <p className="mt-1 text-xs text-amber-600 dark:text-amber-400">
+            <p className="mt-1 text-xs text-[color:var(--color-text-warning)]">
               {localize(locale, "Token 数按每次成功请求约 800 个估算（输入/输出比 35/65）。实际用量因模型和提示长度而异。", "Tokens are estimated at ~800 per successful request with a 35/65 input/output split. Actual usage varies by model and prompt length.")}
             </p>
             <div className="mt-4 grid grid-cols-3 gap-4">
-              <div className="rounded-lg bg-zinc-50 p-3 dark:bg-zinc-800/50">
+              <div className="rounded-lg bg-[color:var(--color-bg-subtle)] p-3">
                 <p className="text-xs text-[color:var(--color-text-secondary)]">{localize(locale, "总 Token", "Total Tokens")}</p>
                 <p className="mt-1 text-lg font-semibold text-[color:var(--color-text-primary)]">
                   {formatNumber(estimatedTotalTokens)}
                 </p>
               </div>
-              <div className="rounded-lg bg-zinc-50 p-3 dark:bg-zinc-800/50">
+              <div className="rounded-lg bg-[color:var(--color-bg-subtle)] p-3">
                 <p className="text-xs text-[color:var(--color-text-secondary)]">{localize(locale, "输入 Token", "Input Tokens")}</p>
-                <p className="mt-1 text-lg font-semibold text-indigo-600 dark:text-indigo-400">
+                <p className="mt-1 text-lg font-semibold text-[color:var(--color-accent)]">
                   {formatNumber(estimatedInputTokens)}
                 </p>
               </div>
-              <div className="rounded-lg bg-zinc-50 p-3 dark:bg-zinc-800/50">
+              <div className="rounded-lg bg-[color:var(--color-bg-subtle)] p-3">
                 <p className="text-xs text-[color:var(--color-text-secondary)]">{localize(locale, "输出 Token", "Output Tokens")}</p>
-                <p className="mt-1 text-lg font-semibold text-violet-600 dark:text-violet-400">
+                <p className="mt-1 text-lg font-semibold text-[color:var(--color-accent)]">
                   {formatNumber(estimatedOutputTokens)}
                 </p>
               </div>
@@ -263,21 +263,21 @@ export function UsagePage() {
               {localize(locale, "错误率与回退", "Error Rate & Fallbacks")}
             </h2>
             <div className="mt-4 grid grid-cols-3 gap-4">
-              <div className="rounded-lg bg-zinc-50 p-3 dark:bg-zinc-800/50">
+              <div className="rounded-lg bg-[color:var(--color-bg-subtle)] p-3">
                 <p className="text-xs text-[color:var(--color-text-secondary)]">{localize(locale, "总请求数", "Total Requests")}</p>
                 <p className="mt-1 text-lg font-semibold text-[color:var(--color-text-primary)]">
                   {formatNumber(totalRequests)}
                 </p>
               </div>
-              <div className="rounded-lg bg-zinc-50 p-3 dark:bg-zinc-800/50">
+              <div className="rounded-lg bg-[color:var(--color-bg-subtle)] p-3">
                 <p className="text-xs text-[color:var(--color-text-secondary)]">{localize(locale, "错误率", "Error Rate")}</p>
-                <p className={`mt-1 text-lg font-semibold ${Number(errorRate) > 5 ? "text-red-600 dark:text-red-400" : "text-emerald-600 dark:text-emerald-400"}`}>
+                <p className={`mt-1 text-lg font-semibold ${Number(errorRate) > 5 ? "text-[color:var(--color-text-danger)]" : "text-[color:var(--color-text-success)]"}`}>
                   {errorRate}%
                 </p>
               </div>
-              <div className="rounded-lg bg-zinc-50 p-3 dark:bg-zinc-800/50">
+              <div className="rounded-lg bg-[color:var(--color-bg-subtle)] p-3">
                 <p className="text-xs text-[color:var(--color-text-secondary)]">Fallback Count</p>
-                <p className="mt-1 text-lg font-semibold text-amber-600 dark:text-amber-400">
+                <p className="mt-1 text-lg font-semibold text-[color:var(--color-text-warning)]">
                   {formatNumber(totalErrors)}
                 </p>
               </div>

--- a/ui/src/styles/globals.css
+++ b/ui/src/styles/globals.css
@@ -32,6 +32,17 @@
   --color-info: #5E6AD2;
   --color-live: #34C759;
 
+  /* Status subtle backgrounds and text (for StatusPill, cards) */
+  --color-bg-success-subtle: #dcfce7;
+  --color-bg-warning-subtle: #fef9c3;
+  --color-bg-danger-subtle: #fee2e2;
+  --color-text-success: #15803d;
+  --color-text-warning: #92400e;
+  --color-text-danger: #dc2626;
+  --color-border-success: #bbf7d0;
+  --color-border-warning: #fde68a;
+  --color-border-danger: #fecaca;
+
   /* Skeleton loading (warm-tinted to match beige background) */
   --color-skeleton-base: #ede5da;
   --color-skeleton-shimmer: rgba(255, 255, 255, 0.4);


### PR DESCRIPTION
## Summary

Comprehensive pre-release audit for Friday v0.5.0 covering security hardening, UI/UX completeness, and code quality.

### Security fixes (2 commits)
- WebSocket buffer 4MB cap (DoS prevention)
- Session key recursive depth limit (stack overflow prevention)
- Agent runtime timer/listener leak fix
- Master key cache TTL on file-read path
- Master key file permissions auto-remediation (chmod 0600)
- Channel input 50K char limit + Unicode NFC normalization
- Realtime cursor secret: crypto.randomBytes replacing predictable date-based secret
- Deeplink SSRF protection: URL parser rewrite covering IPv6, 0.0.0.0, link-local ranges
- Desktop app identifier regex tightened (reject newlines/tabs)
- Workflow DAG edge condition fail-open → fail-closed
- Error diagnosis lesson-disabled logic fix
- Auto-fix risk assessment threshold fix (Math.ceil)

### UI/UX fixes (2 commits)
- Assistant inbox: approve/reject buttons with confirmation dialog
- Fleet: satellite pairing request approval entry
- Skills/Memory: delete confirmation dialogs
- Chat input: 50K character maxLength
- Budget indicator: localized for en/zh
- Contextual help: enabled for all locales (was Chinese-only)
- Onboarding: explicit "Select 3 packs" guidance
- Setup: double-submit prevention
- StatusPill: migrated to CSS variable design tokens
- Removed 27 dark: class residuals
- Added 9 status-subtle CSS variables

### Tests (1 commit)
- +17 new tests: session key depth, channel sanitizer, SSRF protection (9 private IP ranges)
- Total: 9986 → 10003, all passing

### Refactor (1 commit)
- executeRun() decomposed from 519 lines / complexity 49 into 6 focused functions (~80 lines each)
- Zero logic changes, 45 targeted tests pass with zero regression

## Test plan
- [x] `npm run typecheck` — 0 errors
- [x] `npm run build` — API + UI success
- [x] `npm test` — 10003 passed, 0 failed
- [x] `npm run check:all` — all quality gates pass
- [x] Real server startup test — 68 skills loaded, 17+ API endpoints verified
- [x] SSRF protection verified with 9 private IP ranges
- [x] Authentication verified (401 for unauthenticated/invalid tokens)

https://claude.ai/code/session_01KSh6st9ZtA3Mwsvdhbc7Gg