### PR TITLE
[codex] land remaining lucid-swanson tail commits

### DIFF
--- a/ui/src/components/core/activity-timeline.tsx
+++ b/ui/src/components/core/activity-timeline.tsx
@@ -1,0 +1,170 @@
+import { useMemo } from "react";
+import { ShellCard } from "@/components/core/primitives";
+import { localize } from "@/lib/i18n/localized-text";
+import type { AgentRunRecord } from "@/lib/api/types";
+
+// ─── Types ───
+
+type TimelineEventType =
+  | "run_completed"
+  | "run_started"
+  | "run_failed"
+  | "run_active"
+  | "automation_triggered";
+
+type TimelineTone = "success" | "warning" | "neutral" | "info";
+
+interface TimelineEvent {
+  id: string;
+  type: TimelineEventType;
+  title: string;
+  timestamp: string;
+  tone: TimelineTone;
+}
+
+// ─── Props ───
+
+export interface ActivityTimelineProps {
+  locale: "zh" | "en";
+  runs: AgentRunRecord[];
+}
+
+// ─── Helpers ───
+
+function relativeTime(iso: string, locale: "zh" | "en"): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return locale === "zh" ? "刚刚" : "Just now";
+  if (minutes < 60)
+    return locale === "zh" ? `${minutes} 分钟前` : `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24)
+    return locale === "zh" ? `${hours} 小时前` : `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return locale === "zh" ? `${days} 天前` : `${days}d ago`;
+}
+
+const ACTIVE_STATUSES = new Set([
+  "pending",
+  "planning",
+  "awaiting_clarification",
+  "awaiting_plan_approval",
+  "awaiting_tool_approval",
+  "executing",
+  "testing",
+  "fixing",
+]);
+
+function deriveEvents(runs: AgentRunRecord[], locale: "zh" | "en"): TimelineEvent[] {
+  const events: TimelineEvent[] = [];
+
+  for (const run of runs) {
+    const taskLabel =
+      run.task.length > 48 ? `${run.task.slice(0, 48)}...` : run.task;
+
+    if (run.status === "completed") {
+      events.push({
+        id: `${run.id}-completed`,
+        type: "run_completed",
+        title: locale === "zh"
+          ? `完成任务: ${taskLabel}`
+          : `Completed: ${taskLabel}`,
+        timestamp: run.completedAt ?? run.startedAt,
+        tone: "success",
+      });
+    } else if (run.status === "failed" || run.status === "failed_tests") {
+      events.push({
+        id: `${run.id}-failed`,
+        type: "run_failed",
+        title: locale === "zh"
+          ? `任务失败: ${taskLabel}`
+          : `Failed: ${taskLabel}`,
+        timestamp: run.completedAt ?? run.startedAt,
+        tone: "warning",
+      });
+    } else if (run.status === "cancelled") {
+      events.push({
+        id: `${run.id}-cancelled`,
+        type: "run_failed",
+        title: locale === "zh"
+          ? `已取消: ${taskLabel}`
+          : `Cancelled: ${taskLabel}`,
+        timestamp: run.completedAt ?? run.startedAt,
+        tone: "neutral",
+      });
+    } else if (ACTIVE_STATUSES.has(run.status)) {
+      events.push({
+        id: `${run.id}-active`,
+        type: "run_active",
+        title: locale === "zh"
+          ? `正在执行: ${taskLabel}`
+          : `Running: ${taskLabel}`,
+        timestamp: run.startedAt,
+        tone: "info",
+      });
+    }
+  }
+
+  // Sort by most recent first
+  events.sort(
+    (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
+  );
+
+  return events.slice(0, 8);
+}
+
+// ─── Dot color map ───
+
+const DOT_COLORS: Record<TimelineTone, string> = {
+  success: "bg-[color:var(--color-text-success,#34d399)]",
+  warning: "bg-[color:var(--color-text-warning,#fbbf24)]",
+  info: "bg-[color:var(--color-accent,#60a5fa)]",
+  neutral: "bg-[color:var(--color-text-tertiary,#9ca3af)]",
+};
+
+// ─── Component ───
+
+export function ActivityTimeline({ locale, runs }: ActivityTimelineProps) {
+  const events = useMemo(() => deriveEvents(runs, locale), [runs, locale]);
+
+  return (
+    <ShellCard eyebrow={localize(locale, "活动时间线", "Activity Timeline")}>
+      {events.length === 0 ? (
+        <p className="py-4 text-center text-sm text-[color:var(--color-text-secondary)]">
+          {localize(locale, "Friday 正在待命", "Friday is standing by")}
+        </p>
+      ) : (
+        <div className="relative pl-4">
+          {/* Vertical connector line */}
+          <div
+            className="absolute left-[7px] top-[6px] w-px bg-[color:var(--color-border-soft)]"
+            style={{ height: `calc(100% - 12px)` }}
+          />
+
+          {events.map((event, index) => (
+            <div
+              key={event.id}
+              className="relative flex items-start gap-3"
+              style={{ minHeight: index < events.length - 1 ? 36 : undefined }}
+            >
+              {/* Colored dot */}
+              <div
+                className={`absolute -left-4 top-[6px] h-2 w-2 shrink-0 rounded-full ring-2 ring-[color:var(--color-bg-surface)] ${DOT_COLORS[event.tone]}`}
+              />
+
+              {/* Content */}
+              <div className="flex min-w-0 flex-1 items-baseline justify-between gap-2 pb-2">
+                <p className="min-w-0 truncate text-sm text-[color:var(--color-text-primary)]">
+                  {event.title}
+                </p>
+                <span className="shrink-0 text-[11px] text-[color:var(--color-text-tertiary)]">
+                  {relativeTime(event.timestamp, locale)}
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </ShellCard>
+  );
+}

--- a/ui/src/components/core/custom-pack-builder.tsx
+++ b/ui/src/components/core/custom-pack-builder.tsx
@@ -98,7 +98,7 @@ export function CustomPackBuilder({ open, onClose, onSaved }: CustomPackBuilderP
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
-      <div className="relative mx-4 flex max-h-[85vh] w-full max-w-lg flex-col overflow-hidden rounded-[28px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] shadow-2xl">
+      <div className="relative mx-4 flex max-h-[90vh] w-full max-w-lg flex-col overflow-hidden rounded-[28px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] shadow-2xl sm:max-h-[85vh]">
         {/* Header */}
         <div className="flex items-center justify-between border-b border-[color:var(--color-border-soft)] px-6 py-4">
           <h2 className="text-lg font-semibold text-[color:var(--color-text-primary)]">

--- a/ui/src/components/core/skill-import-wizard.tsx
+++ b/ui/src/components/core/skill-import-wizard.tsx
@@ -460,7 +460,7 @@ export function SkillImportWizard({ open, onClose }: SkillImportWizardProps) {
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
-      <div className="relative mx-4 flex max-h-[85vh] w-full max-w-2xl flex-col overflow-hidden rounded-[28px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] shadow-2xl">
+      <div className="relative mx-4 flex max-h-[90vh] w-full max-w-2xl flex-col overflow-hidden rounded-[28px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] shadow-2xl sm:max-h-[85vh]">
         {/* Header */}
         <div className="flex items-center justify-between border-b border-[color:var(--color-border-soft)] px-6 py-4">
           <h2 className="text-lg font-semibold text-[color:var(--color-text-primary)]">

--- a/ui/src/components/core/skill-scanner-panel.tsx
+++ b/ui/src/components/core/skill-scanner-panel.tsx
@@ -403,7 +403,7 @@ export function SkillScannerPanel({ open, onClose }: SkillScannerPanelProps) {
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
-      <div className="relative mx-4 flex max-h-[85vh] w-full max-w-3xl flex-col overflow-hidden rounded-[28px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] shadow-2xl">
+      <div className="relative mx-4 flex max-h-[90vh] w-full max-w-3xl flex-col overflow-hidden rounded-[28px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] shadow-2xl sm:max-h-[85vh]">
         {/* Header */}
         <div className="flex items-center justify-between border-b border-[color:var(--color-border-soft)] px-6 py-4">
           <h2 className="text-lg font-semibold text-[color:var(--color-text-primary)]">

--- a/ui/src/components/layout/app-shell.tsx
+++ b/ui/src/components/layout/app-shell.tsx
@@ -164,8 +164,8 @@ export function AppShell() {
   }, [locale]);
 
   return (
-    <div className="h-screen bg-[color:var(--color-bg-base)] text-[color:var(--color-text-primary)] lg:overflow-hidden">
-      <div className="relative flex h-full w-full pb-24 lg:pb-0">
+    <div className="min-h-screen bg-[color:var(--color-bg-base)] text-[color:var(--color-text-primary)] lg:h-screen lg:overflow-hidden">
+      <div className="relative flex min-h-screen w-full pb-24 lg:h-full lg:min-h-0 lg:pb-0">
         <aside data-testid="app-shell-rail" role="navigation" aria-label="Main navigation" className="hidden lg:block lg:w-[248px] lg:shrink-0">
           <div className="flex h-full flex-col border-r border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-chrome)] px-4 py-5 shadow-[inset_-1px_0_0_rgba(51,41,34,0.04)] backdrop-blur-md">
             <div className="border-b border-[color:var(--color-border-soft)] pb-4">

--- a/ui/src/components/layout/quick-access-bar.tsx
+++ b/ui/src/components/layout/quick-access-bar.tsx
@@ -32,14 +32,14 @@ const NAV_ICONS: Record<string, LucideIcon> = {
 
 export function QuickAccessBar(props: { items: AgentOsNavItem[]; locale: AppLocale }) {
   return (
-    <div className="mb-3 flex flex-wrap items-center gap-2">
+    <div className="mb-3 flex items-center gap-2 overflow-x-auto scrollbar-none pb-1 lg:flex-wrap lg:overflow-x-visible lg:pb-0">
       {props.items.map((item) => {
         const Icon = NAV_ICONS[item.path];
         return (
           <NavLink
             key={item.path}
             to={item.path}
-            className="inline-flex items-center gap-1.5 rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] px-3 py-1.5 text-xs font-medium text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-bg-surface-strong)] hover:text-[color:var(--color-text-primary)]"
+            className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] px-3 py-1.5 text-xs font-medium text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-bg-surface-strong)] hover:text-[color:var(--color-text-primary)]"
           >
             {Icon ? <Icon className="h-3.5 w-3.5" /> : null}
             <span>{resolveLocalizedText(item.label, props.locale)}</span>

--- a/ui/src/routes/home-page.tsx
+++ b/ui/src/routes/home-page.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowRight, CheckCircle2, Clock3, ListFilter, Pin, Plus, Sparkles } from "lucide-react";
+import { ActivityTimeline } from "@/components/core/activity-timeline";
 import { ActionButton, ShellCard, StatusPill } from "@/components/core/primitives";
 import { LearningInsightCard } from "@/components/core/learning-insight-card";
 import { computeIntentWidgetOrder, recordPageVisit } from "@/lib/home/intent-engine";
@@ -463,6 +464,8 @@ export function HomePage() {
             );
           })}
         </div>
+
+        <ActivityTimeline locale={locale} runs={recentRuns} />
       </section>
 
       <section className="space-y-3">

--- a/ui/src/styles/globals.css
+++ b/ui/src/styles/globals.css
@@ -514,6 +514,11 @@
 }
 .overflow-x-chips::-webkit-scrollbar { display: none; }
 
+.scrollbar-none {
+  scrollbar-width: none;
+}
+.scrollbar-none::-webkit-scrollbar { display: none; }
+
 /* ── Setup wizard step fade-in ── */
 .setup-step-enter {
   animation: setup-fade-in 0.5s ease-out;


### PR DESCRIPTION
This PR lands the two commits still on `claude/lucid-swanson` after #116 merged:

- c592313 feat: home page activity timeline — real-time "what Friday is doing"
- fd72079 fix: mobile responsive polish

Validation run locally in a temp clone:
- npm run typecheck
- npm run build:ui
- npx vitest run test/unit/ui/agent-os-nav.test.ts

After this merges, remote `claude/lucid-swanson` can be aligned to `main` safely.