### PR TITLE
feat: beginner-friendly learning UX + glossary + risk tooltips

### DIFF
--- a/ui/src/components/core/app-error-boundary.tsx
+++ b/ui/src/components/core/app-error-boundary.tsx
@@ -35,18 +35,19 @@ export class AppErrorBoundary extends Component<AppErrorBoundaryProps, AppErrorB
               Friday
             </p>
             <h1 className="mt-2 text-2xl font-semibold tracking-tight text-[color:var(--color-text-primary)]">
-              Something went wrong
+              {document.documentElement.getAttribute("data-locale") === "zh" ? "出了点问题" : "Oops, something went wrong"}
             </h1>
             <p className="mt-3 text-sm leading-6 text-[color:var(--color-text-secondary)]">
-              Friday hit a client-side error before the current page finished rendering. Reload once. If it happens again,
-              export the local diagnostics buffer and inspect the last route transition or API error.
+              {document.documentElement.getAttribute("data-locale") === "zh"
+                ? "Friday 遇到了一个意外错误。请刷新页面重试。如果问题持续出现，请联系支持。"
+                : "Friday encountered an unexpected error. Please refresh the page to try again. If the problem persists, contact support."}
             </p>
             <button
               type="button"
               onClick={() => window.location.reload()}
               className="mt-5 inline-flex min-h-[44px] items-center rounded-full bg-[color:var(--color-text-primary)] px-4 text-sm font-medium text-[color:var(--color-bg-base)]"
             >
-              Reload
+              {document.documentElement.getAttribute("data-locale") === "zh" ? "刷新页面" : "Reload"}
             </button>
           </div>
         </div>

--- a/ui/src/components/core/learning-insight-card.tsx
+++ b/ui/src/components/core/learning-insight-card.tsx
@@ -80,18 +80,42 @@ export function LearningInsightCard() {
 
       {hasActivity ? (
         <>
+          {/* Human-friendly summary sentence — primary message */}
+          <p className="text-sm text-[color:var(--color-text-primary)] mb-3">
+            {overview.coverage.patterns > 0 &&
+              localize(
+                locale,
+                `Friday 已了解你的 ${String(overview.coverage.patterns)} 个工作习惯`,
+                `Friday has learned ${String(overview.coverage.patterns)} of your work habits`,
+              )}
+            {overview.coverage.patterns > 0 && overview.coverage.autoFixActions > 0 &&
+              localize(
+                locale,
+                `，并自动修复了 ${String(overview.coverage.autoFixActions)} 个问题`,
+                `, and auto-fixed ${String(overview.coverage.autoFixActions)} issues`,
+              )}
+            {overview.coverage.patterns > 0 && overview.coverage.autoFixActions === 0 && overview.coverage.lessons > 0 &&
+              localize(
+                locale,
+                `，从过去的经验中学到了 ${String(overview.coverage.lessons)} 条教训`,
+                `, and learned ${String(overview.coverage.lessons)} lessons from past experience`,
+              )}
+            {overview.coverage.patterns > 0 ? "." : ""}
+          </p>
+
+          {/* Stat tiles — secondary, muted */}
           <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
             {stats.map((stat) => (
               <button
                 key={stat.label}
                 type="button"
                 onClick={() => navigate("/settings#learning")}
-                className={`flex items-center gap-2.5 rounded-xl ${stat.bg} px-3 py-2.5 text-left transition hover:opacity-80`}
+                className={`flex items-center gap-2 rounded-xl ${stat.bg} px-2.5 py-2 text-left transition hover:opacity-80`}
               >
-                <stat.icon className={`h-4 w-4 shrink-0 ${stat.tone}`} aria-hidden="true" />
+                <stat.icon className={`h-3.5 w-3.5 shrink-0 ${stat.tone} opacity-60`} aria-hidden="true" />
                 <div>
-                  <p className="text-lg font-semibold leading-none text-[color:var(--color-text-primary)]">{stat.value}</p>
-                  <p className="mt-0.5 text-[11px] text-[color:var(--color-text-secondary)]">{stat.label}</p>
+                  <p className="text-sm font-medium leading-none text-[color:var(--color-text-secondary)]">{stat.value}</p>
+                  <p className="mt-0.5 text-[10px] text-[color:var(--color-text-faint)]">{stat.label}</p>
                 </div>
               </button>
             ))}
@@ -126,12 +150,23 @@ export function LearningInsightCard() {
               <p className="text-xs text-amber-700">
                 {localize(
                   locale,
-                  `${String(overview.rollbackHotspots.length)} 个热点问题频繁回滚 — Friday 正在学习更好的修复方案。`,
-                  `${String(overview.rollbackHotspots.length)} hotspot(s) with frequent rollbacks — Friday is learning better fixes.`,
+                  `Friday 在 ${String(overview.rollbackHotspots.length)} 个地方尝试修复后发现效果不好，已自动撤销并在学习更好的方案。`,
+                  `Friday tried fixes in ${String(overview.rollbackHotspots.length)} areas but rolled them back — it's learning better approaches.`,
                 )}
               </p>
             </div>
           )}
+
+          {/* Manage link */}
+          <div className="mt-3 flex justify-end">
+            <button
+              type="button"
+              onClick={() => navigate("/settings#learning")}
+              className="text-xs text-[color:var(--color-text-faint)] hover:text-[color:var(--color-text-secondary)] transition-colors"
+            >
+              {localize(locale, "管理 →", "Manage →")}
+            </button>
+          </div>
         </>
       ) : (
         <p className="text-sm text-[color:var(--color-text-secondary)]">

--- a/ui/src/lib/help/glossary.ts
+++ b/ui/src/lib/help/glossary.ts
@@ -55,7 +55,31 @@ export const FRIDAY_GLOSSARY: Record<string, GlossaryEntry> = {
   },
   pattern: {
     term: "Pattern",
-    definition: "A recurring behavior that Friday has learned from past episodes — like common tool sequences or frequent failure modes.",
+    definition: "A work habit Friday noticed from your interactions.",
+  },
+  confidence: {
+    term: "Confidence",
+    definition: "How sure Friday is about a learned preference. Higher = more reliable.",
+  },
+  rollback: {
+    term: "Rollback",
+    definition: "When Friday undoes an action that didn't work as expected.",
+  },
+  hotspot: {
+    term: "Hotspot",
+    definition: "A problem area where fixes often fail and need to be retried.",
+  },
+  lesson: {
+    term: "Lesson",
+    definition: "Something Friday learned from a past mistake — it won't repeat the same error.",
+  },
+  evidence: {
+    term: "Evidence",
+    definition: "The number of times Friday has observed this preference.",
+  },
+  "auto-fix": {
+    term: "Auto-fix",
+    definition: "Friday automatically fixes a detected problem without asking you first.",
   },
 };
 

--- a/ui/src/routes/agent-page.tsx
+++ b/ui/src/routes/agent-page.tsx
@@ -197,6 +197,16 @@ const RISK_BADGE: Record<
   blocked:     { tone: "danger",  en: "BLOCKED",     zh: "禁止" },
 };
 
+const RISK_HELP_TEXT: Record<
+  NonNullable<PendingToolApprovalViewModel["riskLevel"]>,
+  { en: string; zh: string }
+> = {
+  safe:        { zh: "此操作是安全的，不会修改重要数据。",         en: "This operation is safe and won't modify important data." },
+  guarded:     { zh: "此操作受保护，Friday 会小心执行。",         en: "This operation is protected. Friday will proceed carefully." },
+  destructive: { zh: "此操作会修改或删除数据，请仔细确认。",      en: "This operation may modify or delete data. Please confirm carefully." },
+  blocked:     { zh: "此操作被安全策略禁止。",                    en: "This operation is blocked by safety policy." },
+};
+
 function ApprovalCard({
   approval,
   locale,
@@ -231,6 +241,11 @@ function ApprovalCard({
           </StatusPill>
         )}
       </p>
+      {approval.riskLevel && (
+        <p className="mb-2 text-[11px] text-[color:var(--color-text-faint)]">
+          {locale === "zh" ? RISK_HELP_TEXT[approval.riskLevel].zh : RISK_HELP_TEXT[approval.riskLevel].en}
+        </p>
+      )}
       <p className="mb-3 text-xs text-[color:var(--color-text-secondary)]">{approval.reason}</p>
 
       {paramKeys.length > 0 && (


### PR DESCRIPTION
## Summary
- Learning insight card now speaks human language ("Friday 已了解你的 5 个工作习惯")
- Stats tiles demoted, summary sentence is primary message
- "管理 →" quick link to learning controls
- Rollback messages rewritten for beginners
- 6 new glossary terms: confidence, rollback, hotspot, lesson, evidence, auto-fix
- Risk level help text on approval cards (safe/guarded/destructive/blocked explained)
- Error boundary localized zh/en with beginner-friendly text

## Test plan
- [ ] Home page learning card shows human summary
- [ ] Glossary terms render in help tooltips
- [ ] Approval cards show risk explanation text
- [ ] Error boundary shows Chinese when locale is zh
- [ ] TypeScript zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)