### PR TITLE
feat: click-to-expand details + beginner UX improvements

### DIFF
--- a/ui/src/components/core/activity-timeline.tsx
+++ b/ui/src/components/core/activity-timeline.tsx
@@ -1,5 +1,5 @@
-import { useMemo } from "react";
-import { ShellCard } from "@/components/core/primitives";
+import { useMemo, useState } from "react";
+import { ShellCard, StatusPill } from "@/components/core/primitives";
 import { localize } from "@/lib/i18n/localized-text";
 import type { AgentRunRecord } from "@/lib/api/types";
 
@@ -18,8 +18,11 @@ interface TimelineEvent {
   id: string;
   type: TimelineEventType;
   title: string;
+  fullTitle: string;
   timestamp: string;
   tone: TimelineTone;
+  status: string;
+  durationMs?: number;
 }
 
 // ─── Props ───
@@ -69,8 +72,11 @@ function deriveEvents(runs: AgentRunRecord[], locale: "zh" | "en"): TimelineEven
         title: locale === "zh"
           ? `完成任务: ${taskLabel}`
           : `Completed: ${taskLabel}`,
+        fullTitle: run.task,
         timestamp: run.completedAt ?? run.startedAt,
         tone: "success",
+        status: run.status,
+        durationMs: run.durationMs,
       });
     } else if (run.status === "failed" || run.status === "failed_tests") {
       events.push({
@@ -79,8 +85,11 @@ function deriveEvents(runs: AgentRunRecord[], locale: "zh" | "en"): TimelineEven
         title: locale === "zh"
           ? `任务失败: ${taskLabel}`
           : `Failed: ${taskLabel}`,
+        fullTitle: run.task,
         timestamp: run.completedAt ?? run.startedAt,
         tone: "warning",
+        status: run.status,
+        durationMs: run.durationMs,
       });
     } else if (run.status === "cancelled") {
       events.push({
@@ -89,8 +98,11 @@ function deriveEvents(runs: AgentRunRecord[], locale: "zh" | "en"): TimelineEven
         title: locale === "zh"
           ? `已取消: ${taskLabel}`
           : `Cancelled: ${taskLabel}`,
+        fullTitle: run.task,
         timestamp: run.completedAt ?? run.startedAt,
         tone: "neutral",
+        status: run.status,
+        durationMs: run.durationMs,
       });
     } else if (ACTIVE_STATUSES.has(run.status)) {
       events.push({
@@ -99,8 +111,11 @@ function deriveEvents(runs: AgentRunRecord[], locale: "zh" | "en"): TimelineEven
         title: locale === "zh"
           ? `正在执行: ${taskLabel}`
           : `Running: ${taskLabel}`,
+        fullTitle: run.task,
         timestamp: run.startedAt,
         tone: "info",
+        status: run.status,
+        durationMs: run.durationMs,
       });
     }
   }
@@ -112,6 +127,30 @@ function deriveEvents(runs: AgentRunRecord[], locale: "zh" | "en"): TimelineEven
 
   return events.slice(0, 8);
 }
+
+function formatDuration(ms: number, locale: "zh" | "en"): string {
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return locale === "zh" ? `${seconds} 秒` : `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  if (minutes < 60) {
+    return locale === "zh"
+      ? `${minutes} 分 ${remainingSeconds} 秒`
+      : `${minutes}m ${remainingSeconds}s`;
+  }
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return locale === "zh"
+    ? `${hours} 小时 ${remainingMinutes} 分`
+    : `${hours}h ${remainingMinutes}m`;
+}
+
+const STATUS_LABELS: Record<string, { zh: string; en: string; tone: "success" | "warning" | "neutral" | "danger" }> = {
+  completed: { zh: "已完成", en: "Completed", tone: "success" },
+  failed: { zh: "失败", en: "Failed", tone: "danger" },
+  failed_tests: { zh: "测试失败", en: "Tests Failed", tone: "warning" },
+  cancelled: { zh: "已取消", en: "Cancelled", tone: "neutral" },
+};
 
 // ─── Dot color map ───
 
@@ -126,6 +165,7 @@ const DOT_COLORS: Record<TimelineTone, string> = {
 
 export function ActivityTimeline({ locale, runs }: ActivityTimelineProps) {
   const events = useMemo(() => deriveEvents(runs, locale), [runs, locale]);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
 
   return (
     <ShellCard eyebrow={localize(locale, "活动时间线", "Activity Timeline")}>
@@ -141,28 +181,66 @@ export function ActivityTimeline({ locale, runs }: ActivityTimelineProps) {
             style={{ height: `calc(100% - 12px)` }}
           />
 
-          {events.map((event, index) => (
-            <div
-              key={event.id}
-              className="relative flex items-start gap-3"
-              style={{ minHeight: index < events.length - 1 ? 36 : undefined }}
-            >
-              {/* Colored dot */}
+          {events.map((event, index) => {
+            const isExpanded = expandedId === event.id;
+            const statusMeta = STATUS_LABELS[event.status];
+            return (
               <div
-                className={`absolute -left-4 top-[6px] h-2 w-2 shrink-0 rounded-full ring-2 ring-[color:var(--color-bg-surface)] ${DOT_COLORS[event.tone]}`}
-              />
+                key={event.id}
+                className="relative"
+                style={{ minHeight: index < events.length - 1 ? 36 : undefined }}
+              >
+                {/* Colored dot */}
+                <div
+                  className={`absolute -left-4 top-[6px] h-2 w-2 shrink-0 rounded-full ring-2 ring-[color:var(--color-bg-surface)] ${DOT_COLORS[event.tone]}`}
+                />
 
-              {/* Content */}
-              <div className="flex min-w-0 flex-1 items-baseline justify-between gap-2 pb-2">
-                <p className="min-w-0 truncate text-sm text-[color:var(--color-text-primary)]">
-                  {event.title}
-                </p>
-                <span className="shrink-0 text-[11px] text-[color:var(--color-text-tertiary)]">
-                  {relativeTime(event.timestamp, locale)}
-                </span>
+                {/* Clickable content */}
+                <button
+                  type="button"
+                  onClick={() => setExpandedId(isExpanded ? null : event.id)}
+                  className="flex min-w-0 w-full items-baseline justify-between gap-2 pb-2 text-left transition-colors hover:bg-[color:var(--color-bg-hover)] rounded-lg -mx-1 px-1"
+                >
+                  <p className={`min-w-0 text-sm text-[color:var(--color-text-primary)] ${isExpanded ? "" : "truncate"}`}>
+                    {isExpanded ? event.fullTitle : event.title}
+                  </p>
+                  <span className="shrink-0 text-[11px] text-[color:var(--color-text-tertiary)]">
+                    {relativeTime(event.timestamp, locale)}
+                  </span>
+                </button>
+
+                {/* Expanded detail */}
+                {isExpanded && (
+                  <div className="ml-1 mb-2 rounded-xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-subtle)] px-3 py-2 space-y-1.5">
+                    {statusMeta && (
+                      <div className="flex items-center gap-2">
+                        <StatusPill tone={statusMeta.tone}>
+                          {locale === "zh" ? statusMeta.zh : statusMeta.en}
+                        </StatusPill>
+                        {event.durationMs != null && (
+                          <span className="text-[11px] text-[color:var(--color-text-tertiary)]">
+                            {formatDuration(event.durationMs, locale)}
+                          </span>
+                        )}
+                      </div>
+                    )}
+                    {!statusMeta && event.durationMs != null && (
+                      <p className="text-[11px] text-[color:var(--color-text-tertiary)]">
+                        {formatDuration(event.durationMs, locale)}
+                      </p>
+                    )}
+                    <a
+                      href="/sessions"
+                      onClick={(e) => { e.stopPropagation(); }}
+                      className="inline-block text-xs text-[color:var(--color-accent)] hover:underline"
+                    >
+                      {localize(locale, "查看完整会话 \u2192", "View full session \u2192")}
+                    </a>
+                  </div>
+                )}
               </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       )}
     </ShellCard>

--- a/ui/src/components/core/learning-insight-card.tsx
+++ b/ui/src/components/core/learning-insight-card.tsx
@@ -1,5 +1,6 @@
+import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { BookOpen, Brain, Shield, TrendingUp } from "lucide-react";
+import { BookOpen, Brain, ChevronDown, Shield, TrendingUp } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { learningApi } from "@/lib/api/learning";
 import { localize } from "@/lib/i18n/localized-text";
@@ -14,6 +15,7 @@ import { SkeletonLine } from "@/components/core/primitives";
 export function LearningInsightCard() {
   const { locale } = useAppLocale();
   const navigate = useNavigate();
+  const [expandedStat, setExpandedStat] = useState<string | null>(null);
   const { data: overview, isLoading } = useQuery({
     queryKey: ["learning", "overview"],
     queryFn: () => learningApi.getOverview(5),
@@ -109,17 +111,118 @@ export function LearningInsightCard() {
               <button
                 key={stat.label}
                 type="button"
-                onClick={() => navigate("/settings#learning")}
-                className={`flex items-center gap-2 rounded-xl ${stat.bg} px-2.5 py-2 text-left transition hover:opacity-80`}
+                onClick={() => setExpandedStat(expandedStat === stat.label ? null : stat.label)}
+                className={`flex items-center gap-2 rounded-xl ${stat.bg} px-2.5 py-2 text-left transition hover:opacity-80 ${expandedStat === stat.label ? "ring-1 ring-[color:var(--color-border-strong)]" : ""}`}
               >
                 <stat.icon className={`h-3.5 w-3.5 shrink-0 ${stat.tone} opacity-60`} aria-hidden="true" />
-                <div>
+                <div className="min-w-0 flex-1">
                   <p className="text-sm font-medium leading-none text-[color:var(--color-text-secondary)]">{stat.value}</p>
                   <p className="mt-0.5 text-[10px] text-[color:var(--color-text-faint)]">{stat.label}</p>
                 </div>
+                <ChevronDown className={`h-3 w-3 shrink-0 text-[color:var(--color-text-faint)] transition-transform ${expandedStat === stat.label ? "rotate-180" : ""}`} aria-hidden="true" />
               </button>
             ))}
           </div>
+
+          {/* Expanded detail section */}
+          {expandedStat && (
+            <div className="mt-3 rounded-xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-subtle)] px-3 py-3">
+              {expandedStat === localize(locale, "教训", "Lessons") && (
+                overview.lessons.length > 0 ? (
+                  <div className="space-y-2">
+                    {overview.lessons.slice(0, 3).map((item) => (
+                      <div key={item.lesson.id} className="rounded-lg bg-[color:var(--color-bg-surface)] px-3 py-2">
+                        <p className="text-xs font-medium text-[color:var(--color-text-primary)]">{item.lesson.title}</p>
+                        <p className="mt-1 text-[11px] text-[color:var(--color-text-secondary)]">
+                          {localize(locale, "原因", "Cause")}: {item.lesson.cause}
+                        </p>
+                        <p className="text-[11px] text-[color:var(--color-text-secondary)]">
+                          {localize(locale, "修复", "Fix")}: {item.lesson.fix}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-xs text-[color:var(--color-text-secondary)]">
+                    {localize(locale, "点击「管理」查看完整详情", "Click Manage for full details")}
+                  </p>
+                )
+              )}
+
+              {expandedStat === localize(locale, "模式", "Patterns") && (
+                overview.patterns.length > 0 ? (
+                  <div className="space-y-2">
+                    {overview.patterns.slice(0, 3).map((item) => (
+                      <div key={item.patternId} className="rounded-lg bg-[color:var(--color-bg-surface)] px-3 py-2">
+                        <p className="text-xs font-medium text-[color:var(--color-text-primary)]">{item.kind}</p>
+                        <p className="mt-1 text-[11px] text-[color:var(--color-text-secondary)]">{item.description}</p>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-xs text-[color:var(--color-text-secondary)]">
+                    {localize(locale, "点击「管理」查看完整详情", "Click Manage for full details")}
+                  </p>
+                )
+              )}
+
+              {expandedStat === localize(locale, "自动修复", "Auto-fixes") && (
+                overview.rejectedFixes.length > 0 || overview.coverage.autoFixActions > 0 ? (
+                  <div className="space-y-2">
+                    <p className="text-xs text-[color:var(--color-text-secondary)]">
+                      {localize(
+                        locale,
+                        `共 ${String(overview.coverage.autoFixActions)} 次自动修复`,
+                        `${String(overview.coverage.autoFixActions)} auto-fix action(s) total`,
+                      )}
+                    </p>
+                    {overview.rejectedFixes.slice(0, 3).map((item) => (
+                      <div key={item.actionId} className="rounded-lg bg-[color:var(--color-bg-surface)] px-3 py-2">
+                        <p className="text-xs font-medium text-[color:var(--color-text-primary)]">{item.title}</p>
+                        {item.reason && (
+                          <p className="mt-1 text-[11px] text-[color:var(--color-text-secondary)]">{item.reason}</p>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-xs text-[color:var(--color-text-secondary)]">
+                    {localize(locale, "点击「管理」查看完整详情", "Click Manage for full details")}
+                  </p>
+                )
+              )}
+
+              {expandedStat === localize(locale, "诊断", "Diagnoses") && (
+                overview.rollbackHotspots.length > 0 ? (
+                  <div className="space-y-2">
+                    <p className="text-xs text-[color:var(--color-text-secondary)]">
+                      {localize(
+                        locale,
+                        `共 ${String(overview.coverage.incidents)} 次诊断`,
+                        `${String(overview.coverage.incidents)} diagnosis event(s)`,
+                      )}
+                    </p>
+                    {overview.rollbackHotspots.slice(0, 3).map((item) => (
+                      <div key={item.fingerprint} className="rounded-lg bg-[color:var(--color-bg-surface)] px-3 py-2">
+                        <p className="text-xs font-medium text-[color:var(--color-text-primary)]">{item.fingerprint}</p>
+                        <p className="mt-1 text-[11px] text-[color:var(--color-text-secondary)]">
+                          {localize(
+                            locale,
+                            `回滚 ${String(item.rolledBackCount)} / 应用 ${String(item.appliedCount)} / 拒绝 ${String(item.rejectedCount)}`,
+                            `Rolled back ${String(item.rolledBackCount)} / Applied ${String(item.appliedCount)} / Rejected ${String(item.rejectedCount)}`,
+                          )}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-xs text-[color:var(--color-text-secondary)]">
+                    {localize(locale, "点击「管理」查看完整详情", "Click Manage for full details")}
+                  </p>
+                )
+              )}
+            </div>
+          )}
 
           {overview.recentRejectedFixes.length > 0 && (
             <div className="mt-3 rounded-xl bg-[color:var(--color-bg-contrast)] px-3 py-2">

--- a/ui/src/routes/home-page.tsx
+++ b/ui/src/routes/home-page.tsx
@@ -319,6 +319,9 @@ export function HomePage() {
                       <p className="text-sm text-[color:var(--color-text-secondary)]">
                         {localize(locale, "现在没有正在运行的任务。", "No task is actively running right now.")}
                       </p>
+                      <p className="text-xs text-[color:var(--color-text-tertiary)]">
+                        {localize(locale, "此处显示 Friday 当前正在执行的任务", "Shows tasks Friday is currently running")}
+                      </p>
                       <ActionButton tone="secondary" onClick={() => navigate("/chat")}>
                         <Sparkles className="mr-2 h-4 w-4" />
                         {localize(locale, "开始新任务", "Start a task")}
@@ -358,6 +361,9 @@ export function HomePage() {
                       <p className="text-sm text-[color:var(--color-text-secondary)]">
                         {localize(locale, "当前没有需要你确认的自动修复。", "There are no approvals waiting on you right now.")}
                       </p>
+                      <p className="text-xs text-[color:var(--color-text-tertiary)]">
+                        {localize(locale, "当 Friday 需要你审批时会显示在这里", "Appears when Friday needs your approval")}
+                      </p>
                       <ActionButton tone="secondary" onClick={() => navigate("/assistant")}>
                         <CheckCircle2 className="mr-2 h-4 w-4" />
                         {localize(locale, "查看助手", "Open assistant")}
@@ -389,6 +395,9 @@ export function HomePage() {
                     <div className="space-y-3">
                       <p className="text-sm text-[color:var(--color-text-secondary)]">
                         {localize(locale, "还没有固定在跑的自动化。", "No recurring automation is pinned into your flow yet.")}
+                      </p>
+                      <p className="text-xs text-[color:var(--color-text-tertiary)]">
+                        {localize(locale, "你设置的定时自动化会显示在这里", "Your scheduled automations appear here")}
                       </p>
                       <ActionButton tone="secondary" onClick={() => navigate("/automations")}>
                         <Clock3 className="mr-2 h-4 w-4" />


### PR DESCRIPTION
## Summary
- Learning card stats expand inline to show lessons/patterns/fixes details
- Activity timeline items clickable with full task text + duration + session link
- Home empty state cards explain their purpose to beginners
- Learning card human-friendly summary + risk tooltips + glossary (from PR #120)

## Test plan
- [ ] Click learning stat tile → expands to show details
- [ ] Click timeline item → expands with full info
- [ ] Empty home cards show helper text
- [ ] TypeScript zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)