### PR TITLE
fix: repair CI — sort hub bootstrap imports + regenerate secrets baseline

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -156,15 +156,6 @@
         "line_number": 68
       }
     ],
-    "docs/CX-FIX-PLAN.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": "docs/CX-FIX-PLAN.md",
-        "hashed_secret": "05c668c4033b0bbcc572d8d43f1d110ce16a9e30",
-        "is_verified": false,
-        "line_number": 1040
-      }
-    ],
     "docs/UI-WIZARD-COPY-AND-E2E-DESIGN.md": [
       {
         "type": "Secret Keyword",
@@ -181,119 +172,128 @@
         "line_number": 86
       }
     ],
-    "docs/phase2-code-review-package.md": [
+    "docs/archive/CX-FIX-PLAN.md": [
       {
         "type": "Secret Keyword",
-        "filename": "docs/phase2-code-review-package.md",
+        "filename": "docs/archive/CX-FIX-PLAN.md",
+        "hashed_secret": "05c668c4033b0bbcc572d8d43f1d110ce16a9e30",
+        "is_verified": false,
+        "line_number": 1040
+      }
+    ],
+    "docs/archive/phase2-code-review-package.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/archive/phase2-code-review-package.md",
         "hashed_secret": "6dd4cd8633fc12024ae4f042d6dff954bd56cfa2",
         "is_verified": false,
         "line_number": 3677
       },
       {
         "type": "Secret Keyword",
-        "filename": "docs/phase2-code-review-package.md",
+        "filename": "docs/archive/phase2-code-review-package.md",
         "hashed_secret": "d4e6c7f25a0c62162f040978a39848225644dbcd",
         "is_verified": false,
         "line_number": 3761
       },
       {
         "type": "Secret Keyword",
-        "filename": "docs/phase2-code-review-package.md",
+        "filename": "docs/archive/phase2-code-review-package.md",
         "hashed_secret": "c2f7ae09cb49302e2d3b498ee1e5bc40b0a95bf0",
         "is_verified": false,
         "line_number": 4569
       },
       {
         "type": "Secret Keyword",
-        "filename": "docs/phase2-code-review-package.md",
+        "filename": "docs/archive/phase2-code-review-package.md",
         "hashed_secret": "029af2308b7f5caee8c1f6ea73dd461487d3e562",
         "is_verified": false,
         "line_number": 5105
       }
     ],
-    "docs/phase8-code-review-package-r2.md": [
+    "docs/archive/phase8-code-review-package-r2.md": [
       {
         "type": "Secret Keyword",
-        "filename": "docs/phase8-code-review-package-r2.md",
+        "filename": "docs/archive/phase8-code-review-package-r2.md",
         "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
         "is_verified": false,
         "line_number": 6342
       },
       {
         "type": "Secret Keyword",
-        "filename": "docs/phase8-code-review-package-r2.md",
+        "filename": "docs/archive/phase8-code-review-package-r2.md",
         "hashed_secret": "c0e8a667fc342fbab753015a44743ab36200c801",
         "is_verified": false,
         "line_number": 6555
       },
       {
         "type": "Secret Keyword",
-        "filename": "docs/phase8-code-review-package-r2.md",
+        "filename": "docs/archive/phase8-code-review-package-r2.md",
         "hashed_secret": "6809ffccad03b80fa1fbc32c17e7e054805ec30b",
         "is_verified": false,
         "line_number": 6694
       },
       {
         "type": "Secret Keyword",
-        "filename": "docs/phase8-code-review-package-r2.md",
+        "filename": "docs/archive/phase8-code-review-package-r2.md",
         "hashed_secret": "8867c88b56e0bfb82cffaf15a66bc8d107d6754a",
         "is_verified": false,
         "line_number": 6721
       },
       {
         "type": "Secret Keyword",
-        "filename": "docs/phase8-code-review-package-r2.md",
+        "filename": "docs/archive/phase8-code-review-package-r2.md",
         "hashed_secret": "d4e0e04792fd434b5dc9c4155c178f66edcf4ed3",
         "is_verified": false,
         "line_number": 6950
       },
       {
         "type": "Secret Keyword",
-        "filename": "docs/phase8-code-review-package-r2.md",
+        "filename": "docs/archive/phase8-code-review-package-r2.md",
         "hashed_secret": "3b5910f25dbc879c344ca806b582efb0da6ffa6f",
         "is_verified": false,
         "line_number": 8363
       },
       {
         "type": "Secret Keyword",
-        "filename": "docs/phase8-code-review-package-r2.md",
+        "filename": "docs/archive/phase8-code-review-package-r2.md",
         "hashed_secret": "71df888bc5fbf8e09f797e223d70eebfabada055",
         "is_verified": false,
         "line_number": 9817
       }
     ],
-    "docs/phase8-code-review-package.md": [
+    "docs/archive/phase8-code-review-package.md": [
       {
         "type": "Secret Keyword",
-        "filename": "docs/phase8-code-review-package.md",
+        "filename": "docs/archive/phase8-code-review-package.md",
         "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
         "is_verified": false,
         "line_number": 5405
       },
       {
         "type": "Secret Keyword",
-        "filename": "docs/phase8-code-review-package.md",
+        "filename": "docs/archive/phase8-code-review-package.md",
         "hashed_secret": "c0e8a667fc342fbab753015a44743ab36200c801",
         "is_verified": false,
         "line_number": 5583
       },
       {
         "type": "Secret Keyword",
-        "filename": "docs/phase8-code-review-package.md",
+        "filename": "docs/archive/phase8-code-review-package.md",
         "hashed_secret": "d4e0e04792fd434b5dc9c4155c178f66edcf4ed3",
         "is_verified": false,
         "line_number": 5920
       },
       {
         "type": "Secret Keyword",
-        "filename": "docs/phase8-code-review-package.md",
+        "filename": "docs/archive/phase8-code-review-package.md",
         "hashed_secret": "3b5910f25dbc879c344ca806b582efb0da6ffa6f",
         "is_verified": false,
         "line_number": 7306
       },
       {
         "type": "Secret Keyword",
-        "filename": "docs/phase8-code-review-package.md",
+        "filename": "docs/archive/phase8-code-review-package.md",
         "hashed_secret": "71df888bc5fbf8e09f797e223d70eebfabada055",
         "is_verified": false,
         "line_number": 8307
@@ -366,6 +366,129 @@
         "hashed_secret": "91d4005f24e76ea3d356c849d728e3a63401361f",
         "is_verified": false,
         "line_number": 1098
+      }
+    ],
+    "docs/reports/ops/real-green-gate/2026-04-13T02-13-03-023Z-mzyeag/branch/branch-conformance.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "docs/reports/ops/real-green-gate/2026-04-13T02-13-03-023Z-mzyeag/branch/branch-conformance.json",
+        "hashed_secret": "f99d9c52d3889563af532cafbcdf24b71ef69029",
+        "is_verified": false,
+        "line_number": 7
+      }
+    ],
+    "docs/reports/ops/real-green-gate/2026-04-13T02-13-03-023Z-mzyeag/preflight.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "docs/reports/ops/real-green-gate/2026-04-13T02-13-03-023Z-mzyeag/preflight.json",
+        "hashed_secret": "f99d9c52d3889563af532cafbcdf24b71ef69029",
+        "is_verified": false,
+        "line_number": 14
+      }
+    ],
+    "docs/reports/ops/real-green-gate/2026-04-13T02-13-03-023Z-mzyeag/summary.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "docs/reports/ops/real-green-gate/2026-04-13T02-13-03-023Z-mzyeag/summary.json",
+        "hashed_secret": "f99d9c52d3889563af532cafbcdf24b71ef69029",
+        "is_verified": false,
+        "line_number": 19
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/reports/ops/real-green-gate/2026-04-13T02-13-03-023Z-mzyeag/summary.json",
+        "hashed_secret": "85c30c826b12adb6c38f201042e8f35f5d512583",
+        "is_verified": false,
+        "line_number": 762
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/reports/ops/real-green-gate/2026-04-13T02-13-03-023Z-mzyeag/summary.json",
+        "hashed_secret": "e68d188e5a5f89ebc8936c7f89611ab9484fa7eb",
+        "is_verified": false,
+        "line_number": 801
+      }
+    ],
+    "docs/reports/ops/real-green-gate/2026-04-13T04-07-20-734Z-b7nrwa/branch/branch-conformance.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "docs/reports/ops/real-green-gate/2026-04-13T04-07-20-734Z-b7nrwa/branch/branch-conformance.json",
+        "hashed_secret": "f99d9c52d3889563af532cafbcdf24b71ef69029",
+        "is_verified": false,
+        "line_number": 7
+      }
+    ],
+    "docs/reports/ops/real-green-gate/2026-04-13T04-07-20-734Z-b7nrwa/preflight.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "docs/reports/ops/real-green-gate/2026-04-13T04-07-20-734Z-b7nrwa/preflight.json",
+        "hashed_secret": "f99d9c52d3889563af532cafbcdf24b71ef69029",
+        "is_verified": false,
+        "line_number": 14
+      }
+    ],
+    "docs/reports/ops/real-green-gate/2026-04-13T04-07-20-734Z-b7nrwa/summary.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "docs/reports/ops/real-green-gate/2026-04-13T04-07-20-734Z-b7nrwa/summary.json",
+        "hashed_secret": "f99d9c52d3889563af532cafbcdf24b71ef69029",
+        "is_verified": false,
+        "line_number": 19
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/reports/ops/real-green-gate/2026-04-13T04-07-20-734Z-b7nrwa/summary.json",
+        "hashed_secret": "386f11844293737f44d244d85962dc387e655ee5",
+        "is_verified": false,
+        "line_number": 762
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/reports/ops/real-green-gate/2026-04-13T04-07-20-734Z-b7nrwa/summary.json",
+        "hashed_secret": "a839fd972dec36baf279cd6837ddac8060ac837f",
+        "is_verified": false,
+        "line_number": 801
+      }
+    ],
+    "docs/reports/ops/real-green-gate/2026-04-13T05-52-33-628Z-px7748/branch/branch-conformance.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "docs/reports/ops/real-green-gate/2026-04-13T05-52-33-628Z-px7748/branch/branch-conformance.json",
+        "hashed_secret": "8101e14d8db3f337de85aef301e36fbea127c099",
+        "is_verified": false,
+        "line_number": 7
+      }
+    ],
+    "docs/reports/ops/real-green-gate/2026-04-13T05-52-33-628Z-px7748/preflight.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "docs/reports/ops/real-green-gate/2026-04-13T05-52-33-628Z-px7748/preflight.json",
+        "hashed_secret": "8101e14d8db3f337de85aef301e36fbea127c099",
+        "is_verified": false,
+        "line_number": 14
+      }
+    ],
+    "docs/reports/ops/real-green-gate/2026-04-13T05-52-33-628Z-px7748/summary.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "docs/reports/ops/real-green-gate/2026-04-13T05-52-33-628Z-px7748/summary.json",
+        "hashed_secret": "8101e14d8db3f337de85aef301e36fbea127c099",
+        "is_verified": false,
+        "line_number": 19
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/reports/ops/real-green-gate/2026-04-13T05-52-33-628Z-px7748/summary.json",
+        "hashed_secret": "131f3c64b0167003e89633737401b40daf67a465",
+        "is_verified": false,
+        "line_number": 131
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/reports/ops/real-green-gate/2026-04-13T05-52-33-628Z-px7748/summary.json",
+        "hashed_secret": "deaefedf4d300f5d4128db09245c24bae7334799",
+        "is_verified": false,
+        "line_number": 153
       }
     ],
     "scripts/ci/install-smoke.mjs": [
@@ -1175,5 +1298,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-15T07:53:49Z"
+  "generated_at": "2026-04-15T20:27:45Z"
 }

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -80,8 +80,8 @@ import { createFridayApiRuntime, createFridayDeterministicPipelineRuntime, getCh
 import type { FridaySystemRoutesDeps } from "#api";
 import type { FridayPackagingRoutesDeps } from "../api/http/routes/friday-packaging-routes.js";
 import {
-  createRegistryManager,
   createPackageInstaller,
+  createRegistryManager,
 } from "../packaging/engine/index.js";
 import {
   createFridayPackagingApiHandlers,


### PR DESCRIPTION
## Summary
- Sort import members alphabetically in `src/hub/friday-hub-bootstrap.ts` to fix `sort-imports` lint error
- Regenerate `.secrets.baseline` to cover files moved to `docs/archive/` and new report files in `docs/reports/ops/` (false-positive commit SHAs and high-entropy hex strings)

These two issues caused the CI failure on main after 809958f (#130).

## Test plan
- [x] `npm run lint` — 0 errors
- [x] `vitest run` — 10,053 tests pass, 0 failures, no type errors
- [x] `detect-secrets-hook --baseline .secrets.baseline` — no new secrets detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)