### PR TITLE
fix: use proper import type in autonomous engine types

### DIFF
--- a/src/agent/autonomous/friday-autonomous.types.ts
+++ b/src/agent/autonomous/friday-autonomous.types.ts
@@ -544,10 +544,12 @@ export interface CreateFridayAutonomousEngineDeps {
   /** Optional SQLite persistence for goal/step/iteration state. When provided, enables write-through to survive restarts. */
   readonly persistence?: {
     readonly sqlite: {
-      withWriteTransaction<T>(fn: (db: import("better-sqlite3").Database) => T): T;
-      withReadConnection<T>(fn: (db: import("better-sqlite3").Database) => T): T;
+      withWriteTransaction<T>(fn: (db: Database.Database) => T): T;
+      withReadConnection<T>(fn: (db: Database.Database) => T): T;
     };
-    readonly repository: import("./friday-autonomous-repository.js").FridayAutonomousRepository;
+    readonly repository: FridayAutonomousRepository;
   };
 }
 import type { FridayProviderTenantContext } from "#providers";
+import type Database from "better-sqlite3";
+import type { FridayAutonomousRepository } from "./friday-autonomous-repository.js";


### PR DESCRIPTION
## Summary
Fix 3 lint errors from `@typescript-eslint/consistent-type-imports` that caused CI to fail on main (e8767be).

Replace inline `import()` type annotations with standard `import type` statements in `friday-autonomous.types.ts`.

## Test plan
- [x] `npm run lint` — 0 errors (was 3)
- [x] `npm run typecheck` — 0 errors
- [x] `npm test` — 10,045 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)