### PR TITLE
Port audited fixes from dirty closure worktree

### DIFF
--- a/docs/reports/repo/FRIDAY_DIRTY_WORKTREE_MIGRATION_LEDGER_2026-04-17.md
+++ b/docs/reports/repo/FRIDAY_DIRTY_WORKTREE_MIGRATION_LEDGER_2026-04-17.md
@@ -1,0 +1,47 @@
+# Friday Dirty Worktree Migration Ledger (2026-04-17)
+
+## Baseline
+
+- Clean implementation tree: `/Users/jarvis/Projects/Friday-final-closure-audit`
+- Branch: `codex/final-closure-audit`
+- Baseline commit: `origin/main@116ed08`
+- Source input tree: `/Users/jarvis/Projects/Friday`
+
+## Classification Rules
+
+- `forward-port`: isolated fix or feature slice that is coherent on its own, has clear regression coverage, and does not drag in generated noise or unfinished autonomy rewrites.
+- `rebuild-cleanly`: directionally useful, but coupled to broader unfinished deep-chain work, stale proof lanes, or large runtime behavior rewrites that must be redone from the clean tree.
+- `discard`: generated output, temporary artifact, stale report noise, or low-signal drift not fit for migration.
+
+## Migration Ledger
+
+| Area | Source paths | Classification | Migration mode | Notes |
+| --- | --- | --- | --- | --- |
+| Release-proof mainline already merged | release-proof browser lane, `friday-real-journeys`, audit sync from PR #137 | already in `main` | none | Baseline already includes the real-browser release-proof cutover. |
+| Local-only commit `117eb62` | `test/e2e/live/_helpers/api.ts`, `validation/real-world/lib/executors.mjs` | rebuild-cleanly | conditional | Do not carry automatically. Only reapply if new branch CI reproduces the same secret false-positive. |
+| Session/principal alignment | `src/api/http/routes/friday-session-routes.ts`, `src/api/runtime/friday-api-runtime.ts`, `test/unit/api/http/routes/friday-session-routes.test.ts` | forward-port | manual port | Small runtime/API fix that preserves session user/account context without forcing default account/user overwrites. |
+| Self-healing lesson/plan fixes | `src/api/http/routes/friday-self-healing-route-mappers.ts`, `src/learning/services/friday-auto-fix-plan-service.ts`, `src/learning/services/friday-error-diagnosis-service.ts`, `src/learning/services/friday-self-healing-api-service.ts`, matching unit tests | forward-port | manual port | Coherent slice: disable-skill remediation for skills lifecycle failures, disabled-lesson filtering, matched-lesson summary fix. |
+| Workflow generator maintenance target | `src/api/http/routes/friday-workflow-generator-routes.ts`, `src/api/model/friday-api-workflow.types.ts`, `src/workflows/generator/**`, matching unit tests | forward-port | manual port | Existing-workflow maintenance support is isolated enough to port with unit coverage. Live proof remains a separate later lane. |
+| Skill generator approval evidence gating | `src/skills/generator/services/friday-skill-generator-service.ts`, matching unit tests | forward-port | manual port | Good standalone validation hardening: require explicit self-test evidence before approve/save. |
+| Converter file-vs-directory guards | `src/skills/converter/converters/friday-n8n-node-converter.ts`, `src/skills/converter/converters/friday-openai-gpt-action-converter.ts`, matching unit tests | forward-port | manual port | Tight bug fix; prevents reading directories as files. |
+| Memory file sync warning noise | `src/memory/sync/friday-memory-file-sync-service.ts`, matching unit tests | forward-port | manual port | Small correctness fix for bracket-prefixed plain text. |
+| OpenAI responses content mapping | `src/agent/runtime/friday-agent-llm-client.ts` | forward-port | manual port | Isolated protocol fix; keep separate from broader runtime rewrites. |
+| Preference injector compaction leakage | `src/agent/runtime/friday-agent-preference-injector.ts` | forward-port | manual port | Small correctness fix: avoid treating compaction memory as global user preference. |
+| Autonomous engine file-state inspection and restart work | `src/agent/autonomous/**`, `test/e2e/live/friday-autonomous-restart.e2e.test.ts`, helper `test/e2e/live/_helpers/autonomous.ts` | rebuild-cleanly | defer | Large runtime behavior rewrite plus stale multi-provider proof lane. Rework later from clean tree. |
+| Runtime exact-literal/subagent auto-recovery logic | `src/agent/runtime/friday-agent-runtime.ts`, related tests | rebuild-cleanly | defer | Coupled to subagent behavior changes and exact-output enforcement. Too large to trust as a blind port. |
+| Subagent orchestration rewrite | `src/agent/subagent/**`, `src/agent/tools/friday-agent-subagent-tools.ts`, `src/agent/tools/friday-agent-tool-registry.ts`, `src/hub/friday-hub-bootstrap.ts`, `docs/SUBAGENT-DESIGN.md`, related tests, `test/e2e/live/friday-subagent-live.e2e.test.ts` | rebuild-cleanly | defer | Broad semantic change with stale OpenAI live proof references; redo after clean runtime review. |
+| Generator maintenance live suites | `test/e2e/live/friday-generator-maintenance-live.e2e.test.ts`, `test/e2e/live/friday-workflow-generator-maintenance-live.e2e.test.ts` | rebuild-cleanly | defer | Tests still use `LIVE_PROVIDER_KIND` multi-lane helpers; keep out until Anthropic-only deep-proof lane is rebuilt. |
+| Learning / compaction live suite | `test/e2e/live/friday-learning-live.e2e.test.ts` | rebuild-cleanly | defer | Uses stale multi-provider lane; later clean rebuild needed for true Anthropic-only deep proof. |
+| Self-healing live suite | `test/e2e/live/friday-self-healing-live.e2e.test.ts` | rebuild-cleanly | defer | Same issue as above plus broader bundled-skill setup. |
+| Playbook upgrade boundary live suite | `test/e2e/live/friday-playbook-upgrade-boundary-live.e2e.test.ts` | rebuild-cleanly | defer | Valuable later, but not part of safe immediate migration. |
+| Dirty doc drift extensions | `docs/reports/repo/FRIDAY_DOC_DRIFT_LIST_2026-04-17.md` additions about subagent/generator live proof | discard | drop | References stale OpenAI live-lane evidence and not yet-clean deep-proof status. |
+| Managed skill mutations | `managed-skills/shell-skill-current-datetime/**`, `managed-skills/live-maint-*`, `managed-skills/datetime-*`, `managed-skills/real-e2e-import-test` | discard | drop | Generated or temporary artifacts. Do not migrate. |
+| Ops real-green-gate artifacts | `docs/reports/ops/real-green-gate/**` | discard | drop | Runtime artifact output, not source. |
+
+## Immediate Execution Order
+
+1. Port the isolated `forward-port` fixes only.
+2. Run targeted unit/regression coverage for each migrated slice.
+3. Commit migrated slices in narrow logical batches.
+4. Push and let CI decide whether `117eb62` needs a clean reapplication.
+5. Treat all `rebuild-cleanly` items as follow-up implementation work, not part of this migration batch.

--- a/src/agent/runtime/friday-agent-llm-client.ts
+++ b/src/agent/runtime/friday-agent-llm-client.ts
@@ -327,7 +327,9 @@ async function* handleOllamaStream(
     { role: "system", content: params.systemPrompt },
     ...params.messages.map((m) => ({
       role: m.role,
-      content: typeof m.content === "string" ? m.content : mapContentBlocksForOpenAI(m.content),
+      content: api === "openai-responses"
+        ? mapContentBlocksForOpenAIResponses(m.role, m.content)
+        : (typeof m.content === "string" ? m.content : mapContentBlocksForOpenAI(m.content)),
     })),
   ];
 
@@ -462,7 +464,9 @@ async function* handleOpenAIStream(
     url = `${base}/v1/responses`;
     const input: Array<Record<string, unknown>> = messages.map((m) => ({
       role: m.role,
-      content: m.content,
+      content: m.role === "system"
+        ? mapContentBlocksForOpenAIResponses("system", typeof m.content === "string" ? m.content : JSON.stringify(m.content))
+        : m.content,
     }));
     body = {
       model: params.model,
@@ -567,6 +571,33 @@ function mapContentBlocksForOpenAI(
       return { type: "image_url", image_url: { url } };
     }
     return { type: "text", text: JSON.stringify(block) };
+  });
+}
+
+function mapContentBlocksForOpenAIResponses(
+  role: string,
+  content: string | FridayAgentContentBlock[],
+): Array<Record<string, unknown>> {
+  const textBlockType = role === "assistant" ? "output_text" : "input_text";
+
+  if (typeof content === "string") {
+    return [{ type: textBlockType, text: content }];
+  }
+
+  return content.map((block) => {
+    if (block.type === "text") {
+      return { type: textBlockType, text: block.text };
+    }
+    if (block.type === "image") {
+      if (role === "assistant") {
+        return { type: "output_text", text: JSON.stringify(block) };
+      }
+      const imageUrl = block.source.type === "url"
+        ? block.source.url
+        : `data:${block.source.media_type};base64,${block.source.data}`;
+      return { type: "input_image", image_url: imageUrl };
+    }
+    return { type: textBlockType, text: JSON.stringify(block) };
   });
 }
 

--- a/src/agent/runtime/friday-agent-llm-client.ts
+++ b/src/agent/runtime/friday-agent-llm-client.ts
@@ -327,9 +327,7 @@ async function* handleOllamaStream(
     { role: "system", content: params.systemPrompt },
     ...params.messages.map((m) => ({
       role: m.role,
-      content: api === "openai-responses"
-        ? mapContentBlocksForOpenAIResponses(m.role, m.content)
-        : (typeof m.content === "string" ? m.content : mapContentBlocksForOpenAI(m.content)),
+      content: typeof m.content === "string" ? m.content : mapContentBlocksForOpenAI(m.content),
     })),
   ];
 

--- a/src/agent/runtime/friday-agent-preference-injector.ts
+++ b/src/agent/runtime/friday-agent-preference-injector.ts
@@ -80,24 +80,21 @@ export function createFridayPreferenceInjector(
         }
       }
 
-      // ── Source 2: Persistent memory (preference-type items) ──
+      // ── Source 2: Persistent memory (true preference items only) ──
+      // Do NOT read compaction.* here. Compaction memory is session-scoped
+      // operational context, not a user preference. Injecting it globally
+      // leaks one session's retained facts into unrelated sessions.
       try {
         const memoryItems = await memoryService.list({
-          namespace: [
-            "compaction.decisions",
-            "compaction.todos",
-            "compaction.failures",
-            "compaction.files",
-            "compaction.questions",
-            "compaction.summary",
-          ],
-          tagsAny: ["compaction", "auto"],
+          namespace: ["learning.preferences"],
+          tagsAny: [userId],
           limit: 20,
         });
 
         for (const item of memoryItems) {
           // Skip items with persona-related tags (handled by MBTI system)
           const tags = item.tags ?? [];
+          if (!tags.includes(userId) || !tags.includes("preference")) continue;
           if (tags.some((tag: string) => PERSONA_TAGS.has(tag.toLowerCase()))) continue;
 
           const content = item.content ?? "";

--- a/src/api/http/routes/friday-self-healing-route-mappers.ts
+++ b/src/api/http/routes/friday-self-healing-route-mappers.ts
@@ -24,7 +24,7 @@ function readMatchedLessonIds(details: FridayIncidentDiagnosisDetails): string[]
   if (matchedLessonIds.length > 0) {
     return matchedLessonIds;
   }
-  return details.lesson ? [details.lesson.id] : [];
+  return details.diagnosis == null && details.lesson ? [details.lesson.id] : [];
 }
 
 export function toFridayDiagnosisSummary(

--- a/src/api/http/routes/friday-session-routes.ts
+++ b/src/api/http/routes/friday-session-routes.ts
@@ -1,8 +1,8 @@
 import { FridayDomainError } from "#errors";
 import {
+  FRIDAY_SESSION_DEFAULT_ACCOUNT_ID,
   FRIDAY_SESSION_ERROR_CODES,
   FRIDAY_SESSION_MEMORY_EXTRACTION_ERROR_CODES,
-  FRIDAY_SESSION_DEFAULT_ACCOUNT_ID,
 } from "#sessions";
 
 import type { FridayRouteDefinition } from "../../model/friday-api-common.types.js";

--- a/src/api/http/routes/friday-session-routes.ts
+++ b/src/api/http/routes/friday-session-routes.ts
@@ -2,6 +2,7 @@ import { FridayDomainError } from "#errors";
 import {
   FRIDAY_SESSION_ERROR_CODES,
   FRIDAY_SESSION_MEMORY_EXTRACTION_ERROR_CODES,
+  FRIDAY_SESSION_DEFAULT_ACCOUNT_ID,
 } from "#sessions";
 
 import type { FridayRouteDefinition } from "../../model/friday-api-common.types.js";
@@ -147,9 +148,29 @@ async function alignSessionWithPrincipalContext(
   if (!tenantContext) {
     return;
   }
+  const existingSession = await sessionService.getSession(sessionKey).catch(() => null);
+  const normalizedExistingAccountId =
+    typeof existingSession?.accountId === "string" && existingSession.accountId.trim().length > 0
+      ? existingSession.accountId.trim()
+      : undefined;
+  const normalizedExistingUserId =
+    typeof existingSession?.userId === "string" && existingSession.userId.trim().length > 0
+      ? existingSession.userId.trim()
+      : undefined;
+
+  const nextAccountId =
+    !normalizedExistingAccountId || normalizedExistingAccountId === FRIDAY_SESSION_DEFAULT_ACCOUNT_ID
+      ? tenantContext.hubId
+      : undefined;
+  const nextUserId = normalizedExistingUserId ? undefined : tenantContext.userId;
+
+  if (!nextAccountId && !nextUserId) {
+    return;
+  }
+
   await sessionService.alignSessionContext(sessionKey, {
-    accountId: tenantContext.hubId,
-    userId: tenantContext.userId,
+    ...(nextAccountId ? { accountId: nextAccountId } : {}),
+    ...(nextUserId ? { userId: nextUserId } : {}),
   });
 }
 
@@ -766,6 +787,22 @@ export function createFridaySessionRoutes(
           );
         }
 
+        const existingSession = await deps.sessionService.getOrCreateSession(key).catch(() => null);
+        const principalTenantContext = ctx.principal ? buildTenantContext(ctx.principal) : undefined;
+        const tenantContext: FridayProviderTenantContext | undefined = existingSession
+          ? (() => {
+            const hubId = existingSession.accountId?.trim() || principalTenantContext?.hubId?.trim();
+            if (!hubId) {
+              return undefined;
+            }
+            const userId = existingSession.userId?.trim() || principalTenantContext?.userId?.trim();
+            return {
+              hubId,
+              ...(userId ? { userId } : {}),
+            };
+          })()
+          : principalTenantContext;
+
         const run = await deps.runSession({
           sessionKey: key,
           task,
@@ -780,7 +817,7 @@ export function createFridaySessionRoutes(
             ? {
               principalId: ctx.principal.principalId,
               scopes: ctx.principal.scopes,
-              tenantContext: buildTenantContext(ctx.principal),
+              tenantContext,
             }
             : {}),
         });

--- a/src/api/http/routes/friday-workflow-generator-routes.ts
+++ b/src/api/http/routes/friday-workflow-generator-routes.ts
@@ -44,7 +44,7 @@ function buildTenantContext(principal: unknown, fallbackUserId: string, fallback
 
 function validateCreateSessionBody(
   body: unknown,
-): asserts body is { goal: string; requestedModel?: string; userId: string; channel: string } {
+): asserts body is { goal: string; requestedModel?: string; userId: string; channel: string; targetWorkflowId?: string } {
   if (body == null || typeof body !== "object") {
     throw new FridayDomainError(
       "VALIDATION_ERROR",
@@ -66,6 +66,9 @@ function validateCreateSessionBody(
   }
   if (b.requestedModel !== undefined && typeof b.requestedModel !== "string") {
     errors.push("requestedModel must be a string when provided");
+  }
+  if (b.targetWorkflowId !== undefined && typeof b.targetWorkflowId !== "string") {
+    errors.push("targetWorkflowId must be a string when provided");
   }
 
   if (errors.length > 0) {
@@ -209,6 +212,7 @@ export function createFridayWorkflowGeneratorRoutes(
           requestedModel: body.requestedModel,
           userId: body.userId,
           channel: body.channel,
+          targetWorkflowId: body.targetWorkflowId,
           tenantContext: buildTenantContext(ctx.principal, body.userId, body.channel),
         });
         if (isFailureMode(result.mode)) {

--- a/src/api/model/friday-api-workflow.types.ts
+++ b/src/api/model/friday-api-workflow.types.ts
@@ -398,6 +398,7 @@ export interface FridayWorkflowGeneratorCreateSessionRequest {
   requestedModel?: string;
   userId: string;
   channel: string;
+  targetWorkflowId?: UUID;
 }
 
 export interface FridayWorkflowGeneratorSubmitMessageRequest {

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -248,9 +248,9 @@ function resolveRunTenantContext(input: {
     return undefined;
   }
 
+  const sessionUserId = input.session?.userId?.trim() ?? undefined;
   const explicitUserId = input.tenantContext?.userId?.trim();
   const principalId = input.principalId?.trim();
-  const sessionUserId = input.session?.userId?.trim() ?? undefined;
   const explicitChannelKind = input.tenantContext?.channelKind?.trim();
   const sessionChannelKind = input.session?.channel?.trim();
 
@@ -259,8 +259,8 @@ function resolveRunTenantContext(input: {
     ...(explicitChannelKind || sessionChannelKind
       ? { channelKind: explicitChannelKind ?? sessionChannelKind }
       : {}),
-    ...(explicitUserId || principalId || sessionUserId
-      ? { userId: explicitUserId ?? principalId ?? sessionUserId }
+    ...(sessionUserId || explicitUserId || principalId
+      ? { userId: sessionUserId ?? explicitUserId ?? principalId }
       : {}),
   };
 }
@@ -1917,9 +1917,19 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
         sessionRecord = await sessionService.getOrCreateSession(input.sessionKey).catch(() => null);
       }
       if (sessionRecord && input.tenantContext && (input.tenantContext.hubId || input.tenantContext.userId)) {
+        const sessionUserId =
+          typeof sessionRecord.userId === "string" && sessionRecord.userId.trim().length > 0
+            ? sessionRecord.userId.trim()
+            : undefined;
+        const nextUserId =
+          sessionUserId === undefined
+            && typeof input.tenantContext.userId === "string"
+            && input.tenantContext.userId.trim().length > 0
+              ? input.tenantContext.userId.trim()
+              : undefined;
         sessionRecord = await sessionService.alignSessionContext(sessionRecord.key, {
           ...(input.tenantContext.hubId ? { accountId: input.tenantContext.hubId } : {}),
-          ...(input.tenantContext.userId ? { userId: input.tenantContext.userId } : {}),
+          ...(nextUserId ? { userId: nextUserId } : {}),
         }).catch(() => sessionRecord);
       }
       if (packId && sessionRecord) {

--- a/src/learning/services/friday-auto-fix-plan-service.ts
+++ b/src/learning/services/friday-auto-fix-plan-service.ts
@@ -27,6 +27,36 @@ const CATEGORY_STEP_MAP: Record<FridayErrorIncidentEntity["category"], FridayAut
   workflow: "retry_node",
 };
 
+function deriveAutoFixStepKind(
+  incident: FridayErrorIncidentEntity,
+): FridayAutoFixStepKind {
+  const source = typeof incident.context.source === "string"
+    ? incident.context.source
+    : undefined;
+  const skillId = typeof incident.context.skillId === "string"
+    ? incident.context.skillId.trim()
+    : "";
+  if (source === "skills_lifecycle" && skillId.length > 0) {
+    return "disable_skill";
+  }
+  return CATEGORY_STEP_MAP[incident.category];
+}
+
+function deriveAutoFixTarget(
+  incident: FridayErrorIncidentEntity,
+  stepKind: FridayAutoFixStepKind,
+): string {
+  if (stepKind === "disable_skill") {
+    const skillId = typeof incident.context.skillId === "string"
+      ? incident.context.skillId.trim()
+      : "";
+    if (skillId.length > 0) {
+      return skillId;
+    }
+  }
+  return incident.runId ?? incident.nodeId ?? incident.category;
+}
+
 export function createFridayAutoFixPlanService(
   deps: CreateAutoFixPlanServiceDeps,
 ): FridayAutoFixPlanService {
@@ -34,6 +64,8 @@ export function createFridayAutoFixPlanService(
     buildPlans(input) {
       const { incident, diagnosis, matchedLessons, recurrenceCount } = input;
       const plans: FridayAutoFixPlan[] = [];
+      const stepKind = deriveAutoFixStepKind(incident);
+      const target = deriveAutoFixTarget(incident, stepKind);
       const fallbackProviderIds = Array.isArray(incident.context.fallbackProviderIds)
         ? incident.context.fallbackProviderIds.filter(
             (providerId): providerId is string => typeof providerId === "string" && providerId.trim().length > 0,
@@ -64,7 +96,6 @@ export function createFridayAutoFixPlanService(
 
       if (matchedLessons.length === 0) {
         // No lessons: generate a single retry-based plan
-        const stepKind = CATEGORY_STEP_MAP[incident.category];
         const plan: FridayAutoFixPlan = {
           title: `Auto-fix: retry ${incident.category}`,
           summary: `Retry the failed ${incident.category} operation`,
@@ -72,7 +103,7 @@ export function createFridayAutoFixPlanService(
             {
               stepId: deps.idGenerator(),
               kind: stepKind,
-              target: incident.runId ?? incident.nodeId ?? incident.category,
+              target,
               payload: {
                 ...basePayload,
               },
@@ -102,7 +133,7 @@ export function createFridayAutoFixPlanService(
                 {
                   stepId: deps.idGenerator(),
                   kind: stepKind,
-                  target: incident.runId ?? incident.nodeId ?? incident.category,
+                  target,
                   payload: {
                     revert: true,
                     ...(stepKind === "switch_model_fallback"
@@ -144,7 +175,6 @@ export function createFridayAutoFixPlanService(
       }
 
       for (const lesson of matchedLessons) {
-        const stepKind = CATEGORY_STEP_MAP[incident.category];
         const plan: FridayAutoFixPlan = {
           title: `Auto-fix: ${lesson.title}`,
           summary: lesson.fix,
@@ -152,7 +182,7 @@ export function createFridayAutoFixPlanService(
             {
               stepId: deps.idGenerator(),
               kind: stepKind,
-              target: incident.runId ?? incident.nodeId ?? incident.category,
+              target,
               payload: {
                 ...basePayload,
                 lessonId: lesson.id,
@@ -185,7 +215,7 @@ export function createFridayAutoFixPlanService(
                 {
                   stepId: deps.idGenerator(),
                   kind: stepKind,
-                  target: incident.runId ?? incident.nodeId ?? incident.category,
+                  target,
                   payload: {
                     revert: true,
                     ...(stepKind === "switch_model_fallback"

--- a/src/learning/services/friday-error-diagnosis-service.ts
+++ b/src/learning/services/friday-error-diagnosis-service.ts
@@ -69,6 +69,36 @@ function isStructuredInternalRuntimeFailure(
     && typeof incident.nodeId === "string" && incident.nodeId.trim().length > 0;
 }
 
+function derivePlanStepKind(
+  incident: FridayErrorIncidentEntity,
+): FridayAutoFixPlan["steps"][number]["kind"] {
+  const source = typeof incident.context.source === "string"
+    ? incident.context.source
+    : undefined;
+  const skillId = typeof incident.context.skillId === "string"
+    ? incident.context.skillId.trim()
+    : "";
+  if (source === "skills_lifecycle" && skillId.length > 0) {
+    return "disable_skill";
+  }
+  return mapCategoryToStepKind(incident.category);
+}
+
+function derivePlanTarget(
+  incident: FridayErrorIncidentEntity,
+  stepKind: FridayAutoFixPlan["steps"][number]["kind"],
+): string {
+  if (stepKind === "disable_skill") {
+    const skillId = typeof incident.context.skillId === "string"
+      ? incident.context.skillId.trim()
+      : "";
+    if (skillId.length > 0) {
+      return skillId;
+    }
+  }
+  return incident.runId ?? incident.nodeId ?? incident.category;
+}
+
 export function createFridayErrorDiagnosisService(
   deps: CreateErrorDiagnosisServiceDeps,
 ): FridayErrorDiagnosisService {
@@ -198,8 +228,8 @@ export function createFridayErrorDiagnosisService(
       const TIER_1_KINDS = new Set(["apply_config_patch", "grant_permission"]);
 
       for (const l of matchedLessons) {
-        const planStepKind = mapCategoryToStepKind(incident.category);
-        const target = incident.nodeId ?? incident.category;
+        const planStepKind = derivePlanStepKind(incident);
+        const target = derivePlanTarget(incident, planStepKind);
         const plan: FridayAutoFixPlan = {
           title: `Auto-fix: ${l.title}`,
           summary: l.fix,

--- a/src/learning/services/friday-self-healing-api-service.ts
+++ b/src/learning/services/friday-self-healing-api-service.ts
@@ -454,6 +454,31 @@ function countRowsIfTableExists(
 export function createFridaySelfHealingApiService(
   deps: CreateFridaySelfHealingApiServiceDeps,
 ): FridaySelfHealingApiService {
+  const isLessonDisabledForUser = (
+    db: Database.Database,
+    userId: string,
+    lessonId: string,
+  ): boolean => {
+    if (!deps.factRepo) {
+      return false;
+    }
+    const disabledFact = deps.factRepo.getByUserAndKey(db, userId, `lesson_disabled:${lessonId}`);
+    const factValue = readObject(disabledFact?.value);
+    return disabledFact != null && isTruthyFlag(factValue?.disabled ?? true);
+  };
+
+  const getActiveLessonForFingerprint = (
+    db: Database.Database,
+    userId: string,
+    fingerprint: string,
+  ): FridayLearnedLessonEntity | null => {
+    const lesson = deps.lessonRepo.getByFingerprint(db, fingerprint);
+    if (!lesson) {
+      return null;
+    }
+    return isLessonDisabledForUser(db, userId, lesson.id) ? null : lesson;
+  };
+
   const buildActionDetails = (
     action: FridayAutoFixActionEntity,
   ): FridaySelfHealingActionDetails => {
@@ -466,9 +491,13 @@ export function createFridaySelfHealingApiService(
     const approval = deps.db.withReadConnection((db) =>
       deps.approvalRepo.getByActionId(db, action.actionId),
     );
-    const lesson = deps.db.withReadConnection((db) =>
-      deps.lessonRepo.getByFingerprint(db, action.plan.evidence.fingerprint),
-    );
+    const lesson = incident
+      ? deps.db.withReadConnection((db) =>
+        getActiveLessonForFingerprint(db, incident.userId, action.plan.evidence.fingerprint),
+      )
+      : deps.db.withReadConnection((db) =>
+        deps.lessonRepo.getByFingerprint(db, action.plan.evidence.fingerprint),
+      );
     const risk = incident
       ? deps.riskService.assess({
         incident,
@@ -553,7 +582,7 @@ export function createFridaySelfHealingApiService(
       deps.diagnosisRepo.getLatestByIncidentId(db, incident.incidentId),
     );
     const lesson = deps.db.withReadConnection((db) =>
-      deps.lessonRepo.getByFingerprint(db, incident.signature),
+      getActiveLessonForFingerprint(db, incident.userId, incident.signature),
     );
     const recurrenceCount = deps.db.withReadConnection((db) =>
       deps.incidentRepo.findRecentBySignature(db, incident.userId, incident.signature, 50).length,

--- a/src/memory/sync/friday-memory-file-sync-service.ts
+++ b/src/memory/sync/friday-memory-file-sync-service.ts
@@ -698,12 +698,12 @@ function looksLikeJsonValue(value: string): boolean {
   const trimmed = value.trim();
   if (!trimmed) return false;
   if (trimmed === "true" || trimmed === "false" || trimmed === "null") return true;
+  if (trimmed[0] === "{") {
+    return /^\{\s*(?:"|\})/u.test(trimmed);
+  }
+  if (trimmed[0] === "[") {
+    return /^\[\s*(?:\]|\{|\[|"|-?\d|true\b|false\b|null\b)/u.test(trimmed);
+  }
   const first = trimmed[0];
-  return (
-    first === "{" ||
-    first === "[" ||
-    first === '"' ||
-    first === "-" ||
-    (first >= "0" && first <= "9")
-  );
+  return first === '"' || first === "-" || (first >= "0" && first <= "9");
 }

--- a/src/skills/converter/converters/friday-n8n-node-converter.ts
+++ b/src/skills/converter/converters/friday-n8n-node-converter.ts
@@ -9,7 +9,7 @@
  *   - Complex n8n credential UX mapped to env/input secrets.
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { basename, join } from "node:path";
 import { FridayDomainError } from "#errors";
 
@@ -238,10 +238,12 @@ function tryReadAsFile(filePath: string): string | null {
     if (!existsSync(filePath)) {
       return null;
     }
-    const stat = readFileSync(filePath, "utf-8");
-    return stat;
+    if (!statSync(filePath).isFile()) {
+      return null;
+    }
+    return readFileSync(filePath, "utf-8");
   } catch (err) {
-      console.warn("[friday][n8n-node-converter] operation failed:", err instanceof Error ? err.message : String(err));
+    console.warn("[friday][n8n-node-converter] operation failed:", err instanceof Error ? err.message : String(err));
     return null;
   }
 }

--- a/src/skills/converter/converters/friday-openai-gpt-action-converter.ts
+++ b/src/skills/converter/converters/friday-openai-gpt-action-converter.ts
@@ -10,7 +10,7 @@
  *   - Auth mapping: API key → secret, Bearer → secret, OAuth2 → warning
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { basename, join } from "node:path";
 import YAML from "yaml";
 import { FridayDomainError } from "#errors";
@@ -258,10 +258,12 @@ function resolveSourceContent(source: FridaySkillConversionSource): string | nul
   // Try reading directly as a file
   if (existsSync(source.uri)) {
     try {
-      return readFileSync(source.uri, "utf-8");
+      if (statSync(source.uri).isFile()) {
+        return readFileSync(source.uri, "utf-8");
+      }
     } catch (err) {
-    console.warn("[friday][openai-gpt-action-converter] operation failed:", err instanceof Error ? err.message : String(err));
-      // Not a file, try directory
+      console.warn("[friday][openai-gpt-action-converter] operation failed:", err instanceof Error ? err.message : String(err));
+      // Stat failure on the source path; continue to candidate file probing.
     }
 
     // Try common OpenAPI file names in directory

--- a/src/skills/generator/services/friday-skill-generator-service.ts
+++ b/src/skills/generator/services/friday-skill-generator-service.ts
@@ -754,14 +754,7 @@ export function createFridaySkillGeneratorService(
     spec: Record<string, unknown> | null,
     contract: FridaySkillGenerationContract,
   ): FridayHarnessDeliveryContractV1 {
-    const evidenceRequirements: FridayHarnessDeliveryContractV1["evidenceRequirements"] = [
-      "generator_validation",
-      "skill_self_test",
-      "skill_verification",
-    ];
-    if (spec && skillSpecRequiresBrowserQa(spec)) {
-      evidenceRequirements.push("browser_qa");
-    }
+    const evidenceRequirements = buildSkillEvidenceRequirements(spec);
     return {
       artifactId: session.deliveryContractId ?? deps.idGenerator(),
       version: 1,
@@ -796,6 +789,52 @@ export function createFridaySkillGeneratorService(
       blockedBy: [...session.openQuestions],
       createdAt: deps.nowIso(),
       updatedAt: deps.nowIso(),
+    };
+  }
+
+  function buildSkillEvidenceRequirements(
+    spec: Record<string, unknown> | null,
+  ): FridayHarnessDeliveryContractV1["evidenceRequirements"] {
+    const evidenceRequirements: FridayHarnessDeliveryContractV1["evidenceRequirements"] = [
+      "generator_validation",
+      "skill_self_test",
+      "skill_verification",
+    ];
+    if (spec && skillSpecRequiresBrowserQa(spec)) {
+      evidenceRequirements.push("browser_qa");
+    }
+    return evidenceRequirements;
+  }
+
+  async function collectDraftEvidenceStatus(input: {
+    session: FridaySkillGenerationSession;
+    draft: FridayGeneratedSkillDraft;
+    evidenceRequirements: FridayHarnessDeliveryContractV1["evidenceRequirements"];
+  }): Promise<{
+    missingEvidenceReasons: string[];
+    stagedVerification: { packageLoaded: boolean; packageValidated: boolean; error?: string };
+  }> {
+    const missingEvidenceReasons: string[] = [];
+    if (input.evidenceRequirements.includes("skill_self_test") && !input.session.explicitTest) {
+      missingEvidenceReasons.push("Explicit self-test has not been run yet.");
+    }
+    if (input.evidenceRequirements.includes("browser_qa")) {
+      missingEvidenceReasons.push("Required browser QA evidence has not been attached.");
+    }
+
+    const stagedVerification = await runStagedDraftVerification(input.session.sessionId, input.draft);
+    if (!stagedVerification.packageLoaded && !stagedVerification.error) {
+      missingEvidenceReasons.push("Staged verification could not produce a package load result.");
+    }
+    if (!stagedVerification.packageValidated) {
+      missingEvidenceReasons.push(
+        stagedVerification.error ?? "Staged verification did not validate the draft package.",
+      );
+    }
+
+    return {
+      missingEvidenceReasons,
+      stagedVerification,
     };
   }
 
@@ -938,18 +977,11 @@ export function createFridaySkillGeneratorService(
 
     let qaVerdict: FridayHarnessQaVerdictV1 | null = null;
     if (draft && deliveryContract) {
-      const missingEvidenceReasons: string[] = [];
-      if (deliveryContract.evidenceRequirements.includes("skill_self_test") && !session.explicitTest) {
-        missingEvidenceReasons.push("Explicit self-test has not been run yet.");
-      }
-      if (deliveryContract.evidenceRequirements.includes("browser_qa")) {
-        missingEvidenceReasons.push("Required browser QA evidence has not been attached.");
-      }
-
-      const stagedVerification = await runStagedDraftVerification(session.sessionId, draft);
-      if (!stagedVerification.packageLoaded && !stagedVerification.error) {
-        missingEvidenceReasons.push("Staged verification could not produce a package load result.");
-      }
+      const { missingEvidenceReasons, stagedVerification } = await collectDraftEvidenceStatus({
+        session,
+        draft,
+        evidenceRequirements: deliveryContract.evidenceRequirements,
+      });
 
       qaVerdict = await harness.evaluateQaVerdict({
         existingQaVerdictId: session.qaVerdictId,
@@ -1917,6 +1949,20 @@ export function createFridaySkillGeneratorService(
 
       const syncedReview = await syncSkillHarness(session, draft);
       persistSession(syncedReview.session);
+
+      const spec = parseCurrentSpec(session);
+      const { missingEvidenceReasons } = await collectDraftEvidenceStatus({
+        session,
+        draft,
+        evidenceRequirements: buildSkillEvidenceRequirements(spec),
+      });
+      if (missingEvidenceReasons.length > 0) {
+        throw new FridayDomainError(
+          "VALIDATION_ERROR",
+          missingEvidenceReasons.join("; "),
+          { httpStatus: 422 },
+        );
+      }
 
       if (harness.enabled && syncedReview.qaVerdict?.verdict !== "pass") {
         throw new FridayDomainError(

--- a/src/workflows/generator/model/friday-workflow-generator.types.ts
+++ b/src/workflows/generator/model/friday-workflow-generator.types.ts
@@ -7,6 +7,7 @@ import type {
   FridayWorkflowSpecTrigger,
   FridayWorkflowSpecV1,
   FridayWorkflowVisualGraphV1,
+  UUID,
   WorkflowFailurePolicyV2,
 } from "#workflows";
 import type {
@@ -30,6 +31,17 @@ export type FridayWorkflowGeneratorSessionStatus =
   | "terminal_failed"
   | "cancelled";
 
+export interface FridayWorkflowGenerationMaintenanceTarget {
+  workflowId: UUID;
+  slug: string;
+  currentSpecWorkflowId?: string;
+  currentName: string;
+  currentDescription?: string;
+  publishedVersionId?: UUID;
+  publishedVersionNumber?: number;
+  publishedSpec?: FridayWorkflowSpecV1;
+}
+
 // ─── Session entity ───
 
 export interface FridayWorkflowGenerationSession {
@@ -45,6 +57,7 @@ export interface FridayWorkflowGenerationSession {
   draftWorkflowId?: string;
   workflowId?: string;
   workflowVersionId?: string;
+  maintenanceTarget?: FridayWorkflowGenerationMaintenanceTarget;
   harnessStage?: FridayTemplateHarnessStage;
   planningSpecId?: string;
   deliveryContractId?: string;
@@ -72,6 +85,7 @@ export interface FridayStartWorkflowGenerationRequest {
   userId: string;
   channel: string;
   tenantContext?: FridayProviderTenantContext;
+  targetWorkflowId?: UUID;
 }
 
 export interface FridayWorkflowGenerationTurnRequest {

--- a/src/workflows/generator/prompts/friday-workflow-generator-prompts.ts
+++ b/src/workflows/generator/prompts/friday-workflow-generator-prompts.ts
@@ -1,5 +1,6 @@
 import type { FridayWorkflowSpecTestCase, FridayWorkflowSpecV1 } from "#workflows";
 import type {
+  FridayWorkflowGenerationMaintenanceTarget,
   FridayWorkflowGenerationRequirements,
   FridayWorkflowGenerationTurn,
   FridayWorkflowGeneratorSkillContext,
@@ -20,6 +21,7 @@ export function buildWorkflowRequirementsPrompt(
   openQuestions: string[],
   availableSkills: FridayWorkflowGeneratorSkillContext[],
   recentTurns: FridayWorkflowGenerationTurn[],
+  maintenanceTarget?: FridayWorkflowGenerationMaintenanceTarget,
 ): FridayWorkflowGeneratorPrompt {
   const turnBlock = recentTurns
     .map((t) => `[${t.role}]: ${t.content}`)
@@ -31,6 +33,18 @@ export function buildWorkflowRequirementsPrompt(
       : "(none)";
 
   const summaryBlock = requirementsSummary || "(empty)";
+  const maintenanceBlock = maintenanceTarget
+    ? `\n\nExisting workflow maintenance target:
+- This is an in-place update to an existing workflow record.
+- Existing workflow db id: ${maintenanceTarget.workflowId}
+- Existing workflow slug: ${maintenanceTarget.slug}
+- Existing workflow name: ${maintenanceTarget.currentName}
+- Existing published version: ${maintenanceTarget.publishedVersionNumber ?? "(unknown)"}
+- Existing workflow spec id: ${maintenanceTarget.currentSpecWorkflowId ?? "(unknown)"}
+- Existing workflow description: ${maintenanceTarget.currentDescription ?? "(none)"}
+- Existing published spec snapshot:
+${maintenanceTarget.publishedSpec ? JSON.stringify(maintenanceTarget.publishedSpec, null, 2) : "(unavailable)"}`
+    : "";
 
   const skillsJson = JSON.stringify(
     availableSkills.map((s) => ({
@@ -54,7 +68,8 @@ Rules:
 2. Do not invent skill IDs; use only provided available skills.
 3. If information is complete, set state="ready_for_generation".
 4. If critical data is missing, set state="needs_clarification".
-5. Return strict JSON only.
+5. When an existing workflow maintenance target is provided, treat the current workflow as the base state and focus on the requested change rather than rebuilding requirements from scratch.
+6. Return strict JSON only.
 
 Response JSON:
 {
@@ -91,7 +106,7 @@ Available skills (id, name, description, IO):
 ${skillsJson}
 
 Recent conversation:
-${turnBlock}`;
+${turnBlock}${maintenanceBlock}`;
 
   return { system, user };
 }
@@ -102,6 +117,7 @@ export function buildWorkflowSpecPrompt(
   requirements: FridayWorkflowGenerationRequirements,
   availableSkills: FridayWorkflowGeneratorSkillContext[],
   repairContext?: { errors: string; attempt: number },
+  maintenanceTarget?: FridayWorkflowGenerationMaintenanceTarget,
 ): FridayWorkflowGeneratorPrompt {
   const requirementsJson = JSON.stringify(requirements, null, 2);
 
@@ -119,6 +135,21 @@ export function buildWorkflowSpecPrompt(
 
   const repairBlock = repairContext
     ? `\n\nPrevious attempt (${repairContext.attempt}) had errors:\n${repairContext.errors}\nFix these issues.`
+    : "";
+  const maintenanceRuleBlock = maintenanceTarget
+    ? `\n13. This is an in-place update to workflow db id "${maintenanceTarget.workflowId}".\n14. Preserve workflowId exactly as "${maintenanceTarget.currentSpecWorkflowId ?? maintenanceTarget.slug}".\n15. Use the existing workflow snapshot as the baseline and only adapt it to satisfy the updated request.`
+    : "";
+  const maintenanceUserBlock = maintenanceTarget
+    ? `\n\nExisting workflow target:
+${JSON.stringify({
+  workflowId: maintenanceTarget.workflowId,
+  slug: maintenanceTarget.slug,
+  currentName: maintenanceTarget.currentName,
+  currentDescription: maintenanceTarget.currentDescription,
+  publishedVersionNumber: maintenanceTarget.publishedVersionNumber,
+  currentSpecWorkflowId: maintenanceTarget.currentSpecWorkflowId,
+  publishedSpec: maintenanceTarget.publishedSpec,
+}, null, 2)}`
     : "";
 
   const system = `You generate a valid FridayWorkflowSpecV1 JSON object.
@@ -138,7 +169,7 @@ Rules:
 9. outputs[].fromStep must reference an existing step.
 10. tests must be [] (generated separately in next stage).
 11. Keep graph acyclic and connected from startStepId.
-12. Return a complete FridayWorkflowSpecV1 object only.
+12. Return a complete FridayWorkflowSpecV1 object only.${maintenanceRuleBlock}
 
 Target shape:
 {
@@ -176,7 +207,7 @@ Example output (simple action workflow):
 ${requirementsJson}
 
 Available skills:
-${skillsJson}${repairBlock}`;
+${skillsJson}${maintenanceUserBlock}${repairBlock}`;
 
   return { system, user };
 }

--- a/src/workflows/generator/services/friday-workflow-generator-service.ts
+++ b/src/workflows/generator/services/friday-workflow-generator-service.ts
@@ -27,6 +27,7 @@ import type {
   FridayGeneratedWorkflowValidationIssue,
   FridayGeneratedWorkflowValidationReport,
   FridayStartWorkflowGenerationRequest,
+  FridayWorkflowGenerationMaintenanceTarget,
   FridayWorkflowGenerationRequirements,
   FridayWorkflowGenerationSession,
   FridayWorkflowGenerationTurn,
@@ -410,6 +411,41 @@ export function createFridayWorkflowGeneratorService(
       return null;
     }
     return null;
+  }
+
+  function loadMaintenanceTarget(
+    workflowId: string,
+  ): FridayWorkflowGenerationMaintenanceTarget {
+    const workflow = deps.workflowCrud.getWorkflow(workflowId);
+    if (!workflow) {
+      throw new FridayDomainError(
+        "WORKFLOW_NOT_FOUND",
+        `Workflow not found: ${workflowId}`,
+        { httpStatus: 404 },
+      );
+    }
+
+    const publishedVersion =
+      deps.workflowCrud.getPublishedVersion(workflowId)
+      ?? deps.workflowCrud.listVersions(workflowId, 1)[0]
+      ?? null;
+
+    const publishedSpec = publishedVersion
+      ? deps.db.withReadConnection((reader) =>
+        specVersionRepo.getByVersionId(reader, publishedVersion.id)?.spec ?? null,
+      )
+      : null;
+
+    return {
+      workflowId: workflow.id,
+      slug: workflow.slug,
+      currentSpecWorkflowId: publishedSpec?.workflowId,
+      currentName: workflow.name,
+      currentDescription: workflow.description,
+      publishedVersionId: publishedVersion?.id,
+      publishedVersionNumber: publishedVersion?.versionNumber,
+      publishedSpec: publishedSpec ?? undefined,
+    };
   }
 
   function extractStringArray(
@@ -858,6 +894,7 @@ export function createFridayWorkflowGeneratorService(
       session.openQuestions,
       availableSkills,
       recentTurns,
+      session.maintenanceTarget,
     );
     const result = await llm.infer<WorkflowRequirementsAnalyzerResponse>({
       prompt,
@@ -874,7 +911,12 @@ export function createFridayWorkflowGeneratorService(
     availableSkills: FridayWorkflowGeneratorSkillContext[],
     requestedModel?: string,
   ): Promise<FridayWorkflowSpecV1> {
-    const prompt = buildWorkflowSpecPrompt(requirements, availableSkills, requirements._repairContext);
+    const prompt = buildWorkflowSpecPrompt(
+      requirements,
+      availableSkills,
+      requirements._repairContext,
+      session.maintenanceTarget,
+    );
     const result = await llm.infer<FridayWorkflowSpecV1>({
       prompt,
       requestedModel,
@@ -1134,6 +1176,9 @@ export function createFridayWorkflowGeneratorService(
     ): Promise<FridayWorkflowGenerationTurnResponse> {
       const now = deps.nowIso();
       const sessionId = deps.idGenerator();
+      const maintenanceTarget = input.targetWorkflowId
+        ? loadMaintenanceTarget(input.targetWorkflowId)
+        : undefined;
 
       const session: FridayWorkflowGenerationSession = {
         sessionId,
@@ -1144,7 +1189,12 @@ export function createFridayWorkflowGeneratorService(
         goal: input.goal,
         requirementsSummary: "",
         openQuestions: [],
-        decisions: [],
+        decisions: maintenanceTarget
+          ? [`Updating existing workflow ${maintenanceTarget.slug} (${maintenanceTarget.workflowId})`]
+          : [],
+        workflowId: maintenanceTarget?.workflowId,
+        workflowVersionId: maintenanceTarget?.publishedVersionId,
+        maintenanceTarget,
         createdAt: now,
         updatedAt: now,
       };
@@ -1506,17 +1556,25 @@ export function createFridayWorkflowGeneratorService(
         );
       }
 
-      // Derive unique slug
-      const slug = makeUniqueSlug(draft.spec.name || draft.spec.workflowId);
+      const targetWorkflowId = syncedReview.session.maintenanceTarget?.workflowId ?? syncedReview.session.workflowId;
+      const existingWorkflow = targetWorkflowId
+        ? deps.workflowCrud.getWorkflow(targetWorkflowId)
+        : null;
 
-      // Create workflow
-      const workflow = deps.workflowCrud.createWorkflow({
-        slug,
-        name: draft.spec.name,
-        description: draft.spec.description,
-      });
+      const workflow = existingWorkflow
+        ? deps.workflowCrud.updateWorkflow({
+          workflowId: existingWorkflow.id,
+          expectedRevision: existingWorkflow.revision,
+          etag: existingWorkflow.etag,
+          name: draft.spec.name,
+          description: draft.spec.description,
+        })
+        : deps.workflowCrud.createWorkflow({
+          slug: makeUniqueSlug(draft.spec.name || draft.spec.workflowId),
+          name: draft.spec.name,
+          description: draft.spec.description,
+        });
 
-      // Create version
       const version = deps.workflowCrud.createVersion(
         workflow.id,
         draft.compiledGraph,

--- a/test/e2e/api/friday-api-self-healing-routes.test.ts
+++ b/test/e2e/api/friday-api-self-healing-routes.test.ts
@@ -161,7 +161,7 @@ describe("API — Self-healing and assistant routes", () => {
       };
     };
     expect(resolved.data.incident.status).toBe("resolved");
-    expect(resolved.data.summary.matchedLessonIds.length).toBeGreaterThan(0);
+    expect(resolved.data.summary.matchedLessonIds).toEqual([]);
     const lessonCount = env.db.withReadConnection((db) => {
       const row = db.prepare(
         "SELECT COUNT(*) AS count FROM learned_lessons",

--- a/test/unit/agent/runtime/friday-agent-compaction-pipeline.test.ts
+++ b/test/unit/agent/runtime/friday-agent-compaction-pipeline.test.ts
@@ -549,10 +549,10 @@ describe("Compaction Pipeline Integration", () => {
         get: vi.fn(),
         list: vi.fn(async () => [
           {
-            id: "pref-1", namespace: "compaction.decisions", key: "d1",
+            id: "pref-1", namespace: "learning.preferences", key: "d1",
             content: "Prefer deploying to AWS ECS",
-            source: "compaction:s1:r1",
-            tags: ["compaction", "auto"],
+            source: "learning:user-1:event-1",
+            tags: ["learning", "auto", "preference", "user-1"],
             metadata: { confidence: 0.7 },
             createdAt: NOW, updatedAt: NOW,
           } as FridayMemoryItem,
@@ -610,10 +610,10 @@ describe("Compaction Pipeline Integration", () => {
         get: vi.fn(),
         list: vi.fn(async () => [
           {
-            id: "pref-dup", namespace: "compaction.decisions", key: "d1",
+            id: "pref-dup", namespace: "learning.preferences", key: "d1",
             content: "TypeScript strict mode preferred",
-            source: "compaction:s1:r1",
-            tags: ["compaction", "auto"],
+            source: "learning:user-1:event-1",
+            tags: ["learning", "auto", "preference", "user-1"],
             metadata: { confidence: 0.9 },
             createdAt: NOW, updatedAt: NOW,
           } as FridayMemoryItem,
@@ -638,6 +638,37 @@ describe("Compaction Pipeline Integration", () => {
       // "TypeScript strict mode preferred" vs "typescript_mode: strict mode preferred"
       // They share high overlap, so one should be removed
       expect(result.itemCount).toBeLessThanOrEqual(2);
+    });
+
+    it("ignores compaction memory so session summaries do not leak into preferences", async () => {
+      const mockMemoryService = {
+        store: vi.fn(),
+        search: vi.fn(),
+        get: vi.fn(),
+        list: vi.fn(async () => [
+          {
+            id: "compaction-1", namespace: "compaction.summary", key: "summary-1",
+            content: "Canonical evidence path /tmp/leak.txt",
+            source: "compaction:session-1:run-1",
+            tags: ["compaction", "auto", "session-1"],
+            metadata: { confidence: 0.9 },
+            createdAt: NOW, updatedAt: NOW,
+          } as FridayMemoryItem,
+        ]),
+        delete: vi.fn(),
+        prune: vi.fn(),
+      };
+
+      const injector = createFridayPreferenceInjector({
+        memoryService: mockMemoryService as any,
+        nowIso: testNowIso,
+      });
+
+      const result = await injector.loadPreferences("user-1");
+
+      expect(result.fragment).toBe("");
+      expect(result.itemCount).toBe(0);
+      expect(result.sources).toEqual([]);
     });
   });
 
@@ -749,7 +780,7 @@ describe("Compaction Pipeline Integration", () => {
         expect(verification.entityRecall).toBeLessThanOrEqual(1);
       }
 
-      // ── Step 7: Verify preference injector can read the stored items ──
+      // ── Step 7: Verify preference injector does NOT treat compaction items as preferences ──
       const injector = createFridayPreferenceInjector({
         memoryService: mockMemoryService as any,
         nowIso: testNowIso,
@@ -757,13 +788,8 @@ describe("Compaction Pipeline Integration", () => {
 
       const prefResult = await injector.loadPreferences("user-e2e");
 
-      // The injector should find and format the compaction items
-      // (it queries compaction.decisions and compaction.todos namespaces)
-      // Since our mock returns all storedItems, it should find some
-      if (storedItems.some((i) => i.namespace === "compaction.decisions" || i.namespace === "compaction.todos")) {
-        expect(prefResult.itemCount).toBeGreaterThan(0);
-        expect(prefResult.fragment).toContain("[Learned Preferences]");
-      }
+      expect(prefResult.itemCount).toBe(0);
+      expect(prefResult.fragment).toBe("");
     });
   });
 

--- a/test/unit/api/http/routes/friday-self-healing-route-mappers.test.ts
+++ b/test/unit/api/http/routes/friday-self-healing-route-mappers.test.ts
@@ -146,8 +146,9 @@ describe("friday-self-healing-route-mappers", () => {
       expect(summary.matchedLessonIds).toEqual([]);
     });
 
-    it("extracts matchedLessonIds from lesson when diagnosis has none", () => {
+    it("extracts matchedLessonIds from lesson only when diagnosis is absent", () => {
       const details = makeIncidentDetails({
+        diagnosis: null,
         lesson: {
           id: "lesson-001",
           fingerprint: "sig-abc",
@@ -162,6 +163,37 @@ describe("friday-self-healing-route-mappers", () => {
       });
       const summary = toFridayDiagnosisSummary(details);
       expect(summary.matchedLessonIds).toEqual(["lesson-001"]);
+    });
+
+    it("does not reintroduce lesson ids when diagnosis explicitly matched none", () => {
+      const details = makeIncidentDetails({
+        diagnosis: {
+          id: "diag-004",
+          incidentId: "inc-001",
+          errorFingerprint: "sig-abc",
+          confidence: 0.5,
+          diagnosis: {
+            summary: "Lesson was disabled",
+            matchedLessonIds: [],
+          },
+          createdAt: NOW,
+          updatedAt: NOW,
+        },
+        lesson: {
+          id: "lesson-001",
+          fingerprint: "sig-abc",
+          title: "Lesson learned",
+          cause: "timeout",
+          fix: "increase timeout",
+          mitigation: {},
+          sourceIncidentId: "inc-001",
+          createdAt: NOW,
+          updatedAt: NOW,
+        },
+      });
+
+      const summary = toFridayDiagnosisSummary(details);
+      expect(summary.matchedLessonIds).toEqual([]);
     });
   });
 

--- a/test/unit/api/http/routes/friday-session-routes.test.ts
+++ b/test/unit/api/http/routes/friday-session-routes.test.ts
@@ -61,7 +61,7 @@ function createMockService(): FridaySessionService {
   return {
     createSession: vi.fn(),
     listSessions: vi.fn(),
-    getSession: vi.fn(),
+    getSession: vi.fn().mockResolvedValue(null),
     getOrCreateSession: vi.fn().mockResolvedValue(makeMockSession()),
     alignSessionContext: vi.fn(),
     addMessage: vi.fn(),
@@ -951,11 +951,57 @@ describe("FridaySessionRoutes", () => {
       expect(runSession).toHaveBeenCalledWith(
         expect.objectContaining({
           tenantContext: {
-            hubId: "tenant-acme",
+            hubId: "default",
             userId: "user-1",
           },
         }),
       );
+    });
+
+    it("does not overwrite an explicit session user/account with authenticated principal context", async () => {
+      const svc = createMockService();
+      const existingSession = makeMockSession({
+        key: "web:tenant-custom:user-custom",
+        channel: "web",
+        accountId: "tenant-custom",
+        chatId: "seed-chat",
+        userId: "user-custom",
+      });
+      vi.mocked(svc.getOrCreateSession).mockResolvedValue(existingSession);
+      vi.mocked(svc.getSession).mockResolvedValue(existingSession);
+      vi.mocked(svc.addMessage).mockResolvedValue(makeMockMessage({
+        sessionKey: existingSession.key,
+        content: "hello",
+        contentText: "hello",
+      }));
+
+      const routes = createFridaySessionRoutes({ sessionService: svc });
+      const route = routes.find((r) => r.operationId === "sessions.messages.create")!;
+
+      await route.handler(
+        makeMockCtx({
+          params: { sessionKey: existingSession.key },
+          body: { role: "user", content: "hello" },
+          principal: {
+            principalType: "user",
+            principalId: "principal-1",
+            tenantId: "tenant-admin",
+            userId: "admin-001",
+            role: "owner",
+            scopes: ["session.write"],
+            tokenId: "token-1",
+            tokenKind: "access",
+            issuedAt: "2026-01-01T00:00:00.000Z",
+            expiresAt: "2026-01-01T01:00:00.000Z",
+          },
+        }) as never,
+      );
+
+      expect(svc.alignSessionContext).not.toHaveBeenCalled();
+      expect(svc.addMessage).toHaveBeenCalledWith(existingSession.key, {
+        role: "user",
+        content: "hello",
+      });
     });
 
     it("validates timeoutMs in run body", async () => {

--- a/test/unit/learning/services/friday-auto-fix-plan-service.test.ts
+++ b/test/unit/learning/services/friday-auto-fix-plan-service.test.ts
@@ -138,6 +138,29 @@ describe("FridayAutoFixPlanService", () => {
     expect(plans[0]!.steps[0]!.kind).toBe("trim_payload");
   });
 
+  it("maps skills_lifecycle failures to disable_skill using the skill id as target", () => {
+    const skillIncident = {
+      ...baseIncident,
+      category: "workflow" as const,
+      context: {
+        source: "skills_lifecycle",
+        skillId: "extract-action-items",
+        stage: "verify",
+      },
+    };
+
+    const plans = service.buildPlans({
+      incident: skillIncident,
+      diagnosis: baseDiagnosis,
+      matchedLessons: [],
+      recurrenceCount: 1,
+    });
+
+    expect(plans).toHaveLength(1);
+    expect(plans[0]!.steps[0]!.kind).toBe("disable_skill");
+    expect(plans[0]!.steps[0]!.target).toBe("extract-action-items");
+  });
+
   it("includes evidence metadata in plans", () => {
     const plans = service.buildPlans({
       incident: baseIncident,

--- a/test/unit/learning/services/friday-error-diagnosis-service.test.ts
+++ b/test/unit/learning/services/friday-error-diagnosis-service.test.ts
@@ -278,6 +278,40 @@ describe("FridayErrorDiagnosisService", () => {
     expect(result.autoFixEligible).toBe(true);
   });
 
+  it("builds disable_skill candidate plans for skills_lifecycle verification failures", () => {
+    const lessonRepo = createFridayLearnedLessonRepository();
+    lessonRepo.upsertByFingerprint(db.writer, {
+      id: "lesson-skill-001",
+      fingerprint: "sig-skill-verify",
+      title: "Disable incompatible skill",
+      cause: "Verification failed after contract drift",
+      fix: "Disable the broken skill until repaired",
+      nowIso: NOW,
+    });
+
+    const skillLifecycleIncident: FridayErrorIncidentEntity = {
+      ...baseIncident,
+      incidentId: "inc-skill-lifecycle",
+      category: "workflow",
+      severity: "medium",
+      signature: "sig-skill-verify",
+      context: {
+        source: "skills_lifecycle",
+        skillId: "extract-action-items",
+        stage: "verify",
+      },
+    };
+    const incidentRepo = createFridayErrorIncidentRepository();
+    incidentRepo.insert(db.writer, skillLifecycleIncident);
+
+    const result = service.diagnose({ incident: skillLifecycleIncident, nowIso: NOW });
+
+    expect(result.autoFixEligible).toBe(true);
+    expect(result.candidatePlans).toHaveLength(1);
+    expect(result.candidatePlans[0]!.steps[0]!.kind).toBe("disable_skill");
+    expect(result.candidatePlans[0]!.steps[0]!.target).toBe("extract-action-items");
+  });
+
   it("preserves workflow run context in lesson-backed retry plans", () => {
     db.writer.prepare(
       `INSERT INTO workflows (

--- a/test/unit/memory/sync/friday-memory-file-sync-service.test.ts
+++ b/test/unit/memory/sync/friday-memory-file-sync-service.test.ts
@@ -148,6 +148,48 @@ describe("FridayMemoryFileSyncService", () => {
     );
   });
 
+  it("does not warn for bracket-prefixed plain text session content", async () => {
+    db.withWriteTransaction((conn) => {
+      conn.prepare(
+        `INSERT INTO sessions (id, session_key, channel, chat_kind, status, agent_id, metadata_json, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).run("sess-bracket", "test:session:bracket", "cli", "dm", "active", "agent-1", "{}", "2025-01-01T00:00:00Z", "2025-01-01T00:00:00Z");
+      conn.prepare(
+        `INSERT INTO session_messages (id, session_id, session_key, role, content_json, content_text, sequence, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).run(
+        "msg-bracket",
+        "sess-bracket",
+        "test:session:bracket",
+        "assistant",
+        "[topic_block] canonical evidence path remains /tmp/proof.txt",
+        null,
+        1,
+        "2025-01-01T00:00:00Z",
+        "2025-01-01T00:00:00Z",
+      );
+    });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const repo = createFridayMemoryFileSyncRepository({ db });
+    const service = createFridayMemoryFileSyncService({
+      repository: repo,
+      stateDir: tmpDir,
+    });
+
+    await service.syncNow({ force: true });
+
+    const filePath = sessionKeyExportPath(tmpDir, "test:session:bracket");
+    const content = await fs.readFile(filePath, "utf8");
+    const first = JSON.parse(content.trim().split("\n")[0]!);
+    expect(first.content).toBe("[topic_block] canonical evidence path remains /tmp/proof.txt");
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      "[friday][memory-file-sync] try-parse-json:",
+      expect.any(String),
+    );
+  });
+
   it("warns only for malformed JSON-looking session content and preserves the raw payload", async () => {
     db.withWriteTransaction((conn) => {
       conn.prepare(

--- a/test/unit/skills/generator/services/friday-skill-generator-service.test.ts
+++ b/test/unit/skills/generator/services/friday-skill-generator-service.test.ts
@@ -1055,6 +1055,55 @@ describe("FridaySkillGeneratorService", () => {
       }
     });
 
+    it("blocks approval when explicit self-test evidence is missing", async () => {
+      const analyzerResponse = {
+        state: "needs_clarification",
+        questions: ["What?"],
+        spec: {
+          goal: "Echo",
+          inputs: [{ key: "query", type: "string", required: true, label: "Query" }],
+          outputs: [{ key: "result", type: "string", description: "Result" }],
+          runtimeKind: "shell",
+        },
+      };
+      const manifest = makeManifest({
+        runtime: {
+          kind: "shell",
+          entrypoint: "run.sh",
+          minHubVersion: "0.1.0",
+          apiVersion: "1",
+          timeoutMsDefault: 30000,
+        },
+      });
+      const files: FridayGeneratedSkillFile[] = [
+        {
+          path: "run.sh",
+          language: "bash",
+          executable: true,
+          content: "#!/usr/bin/env bash\ncat <<'EOF'\n{\"result\":\"ok\"}\nEOF\n",
+        },
+      ];
+      const uiSchema = makeUiSchema();
+
+      mockFetchForLlm([analyzerResponse, manifest, files, uiSchema]);
+
+      try {
+        const startResult = await service.startSession({
+          goal: "Echo shell skill",
+          userId: "user-1",
+          channel: "discord",
+        });
+
+        await service.generateDraft(startResult.session.sessionId);
+
+        await expect(
+          service.approveAndSave(startResult.session.sessionId),
+        ).rejects.toThrow("Explicit self-test has not been run yet.");
+      } finally {
+        restoreFetch();
+      }
+    });
+
     it("promotes generated drafts to stabilized manifests with evidence", async () => {
       const analyzerResponse = {
         state: "needs_clarification",
@@ -1095,6 +1144,20 @@ describe("FridaySkillGeneratorService", () => {
         });
 
         await service.generateDraft(startResult.session.sessionId);
+        await service.recordExplicitTestResult(startResult.session.sessionId, {
+          ok: true,
+          executable: true,
+          issues: [],
+          durationMs: 25,
+          testedAt: NOW,
+          behavioralCheck: {
+            attempted: true,
+            satisfied: true,
+            expectedMarkers: ["ok"],
+            matchedMarkers: ["ok"],
+            runStatus: "completed",
+          },
+        });
         const result = await service.approveAndSave(startResult.session.sessionId);
 
         expect(result.promotionStage).toBe("stabilized");

--- a/test/unit/workflows/generator/services/friday-workflow-generator-service.test.ts
+++ b/test/unit/workflows/generator/services/friday-workflow-generator-service.test.ts
@@ -186,8 +186,23 @@ function makeMockWorkflowCrud(): FridayWorkflowCrudService {
     getWorkflow: vi.fn(() => null),
     getWorkflowBySlug: vi.fn(() => null),
     listWorkflows: vi.fn(() => []),
-    updateWorkflow: vi.fn(() => ({} as never)),
+    updateWorkflow: vi.fn((input) => ({
+      id: input.workflowId,
+      slug: "existing-workflow",
+      name: input.name ?? "Existing Workflow",
+      description: input.description,
+      tags: ["existing"],
+      latestVersionNumber: 1,
+      publishedVersionNumber: 1,
+      isArchived: false,
+      revision: input.expectedRevision + 1,
+      etag: "etag-updated",
+      createdAt: NOW,
+      updatedAt: NOW,
+    })),
+    updateWorkflowWithGraph: vi.fn(() => ({} as never)),
     archiveWorkflow: vi.fn(),
+    createWorkflowWithVersion: vi.fn(() => ({} as never)),
     createVersion: vi.fn(() => ({
       id: "wv-1",
       workflowId: "wf-1",
@@ -597,6 +612,104 @@ describe("FridayWorkflowGeneratorService", () => {
       await expect(
         service.approveAndSave(startResult.session.sessionId),
       ).rejects.toThrow("Cannot approve session");
+    });
+
+    it("updates an existing workflow in place when targetWorkflowId is provided", async () => {
+      const existingSpec = {
+        ...makeSpecResponse(),
+        workflowId: "existing-workflow-spec",
+        name: "Existing Workflow",
+      };
+      const existingVersion = {
+        id: "wv-existing-1",
+        workflowId: "wf-existing",
+        versionNumber: 1,
+        checksum: "checksum-existing-1",
+        graphJson: {},
+        isPublished: true,
+        createdAt: NOW,
+        updatedAt: NOW,
+      };
+
+      vi.mocked(deps.workflowCrud.getWorkflow).mockImplementation((workflowId: string) => {
+        if (workflowId !== "wf-existing") {
+          return null;
+        }
+        return {
+          id: "wf-existing",
+          slug: "existing-workflow",
+          name: "Existing Workflow",
+          description: "Original description",
+          tags: ["existing"],
+          latestVersionNumber: 1,
+          publishedVersionNumber: 1,
+          isArchived: false,
+          revision: 7,
+          etag: "etag-existing",
+          createdAt: NOW,
+          updatedAt: NOW,
+        };
+      });
+      vi.mocked(deps.workflowCrud.getPublishedVersion).mockReturnValue(existingVersion);
+      vi.mocked(deps.workflowCrud.createVersion).mockReturnValue({
+        id: "wv-existing-2",
+        workflowId: "wf-existing",
+        versionNumber: 2,
+        checksum: "checksum-existing-2",
+        graphJson: {},
+        isPublished: false,
+        createdAt: NOW,
+        updatedAt: NOW,
+      });
+      vi.mocked(deps.workflowCrud.publishVersion).mockReturnValue({
+        id: "wv-existing-2",
+        workflowId: "wf-existing",
+        versionNumber: 2,
+        checksum: "checksum-existing-2",
+        graphJson: {},
+        isPublished: true,
+        createdAt: NOW,
+        updatedAt: NOW,
+      });
+
+      mockFetchForLlm([
+        makeRequirementsResponse("ready_for_generation"),
+        {
+          ...existingSpec,
+          description: "Updated description",
+          tests: [],
+        },
+        makeVisualResponse(),
+        makeTestsResponse(),
+      ]);
+
+      const startResult = await service.startSession({
+        goal: "Update the existing workflow to improve the description.",
+        userId: "u-1",
+        channel: "test",
+        targetWorkflowId: "wf-existing",
+      });
+
+      expect(startResult.session.workflowId).toBe("wf-existing");
+      expect(startResult.session.workflowVersionId).toBe("wv-existing-1");
+      expect(startResult.session.maintenanceTarget?.publishedVersionNumber).toBe(1);
+
+      const approveResult = await service.approveAndSave(startResult.session.sessionId);
+
+      expect(approveResult.workflowId).toBe("wf-existing");
+      expect(approveResult.workflowVersionId).toBe("wv-existing-2");
+      expect(approveResult.versionNumber).toBe(2);
+
+      expect(deps.workflowCrud.createWorkflow).not.toHaveBeenCalled();
+      expect(deps.workflowCrud.updateWorkflow).toHaveBeenCalledWith({
+        workflowId: "wf-existing",
+        expectedRevision: 7,
+        etag: "etag-existing",
+        name: "Existing Workflow",
+        description: "Updated description",
+      });
+      expect(deps.workflowCrud.createVersion).toHaveBeenCalled();
+      expect(deps.workflowCrud.publishVersion).toHaveBeenCalledWith("wf-existing", 2);
     });
   });
 


### PR DESCRIPTION
## Summary
- port the audited runtime/converter/memory sync fixes into a clean worktree branch
- preserve explicit session identity and self-healing lesson state during migration
- port workflow and skill generator maintenance/evidence gating fixes

## Validation
- `npx vitest run test/unit/agent/runtime/friday-agent-compaction-pipeline.test.ts test/unit/memory/sync/friday-memory-file-sync-service.test.ts test/unit/api/http/routes/friday-session-routes.test.ts test/unit/api/http/routes/friday-self-healing-route-mappers.test.ts test/unit/learning/services/friday-auto-fix-plan-service.test.ts test/unit/learning/services/friday-error-diagnosis-service.test.ts test/unit/workflows/generator/services/friday-workflow-generator-service.test.ts test/unit/skills/generator/services/friday-skill-generator-service.test.ts test/unit/skills/converter/friday-n8n-node-converter.test.ts test/unit/skills/converter/friday-openai-gpt-action-converter.test.ts`