### PR TITLE
Fix autonomous planning resume file-write replay

### DIFF
--- a/src/agent/autonomous/friday-autonomous-engine.ts
+++ b/src/agent/autonomous/friday-autonomous-engine.ts
@@ -765,6 +765,8 @@ export function createFridayAutonomousEngine(
     const patterns = [
       /exact text ["']([^"']+)["']/i,
       /contains(?: the)?(?: exact)? text ["']([^"']+)["']/i,
+      /(?:with|contains)(?: the)?(?: exact)? content ["']([^"']+)["']/i,
+      /exact content ["']([^"']+)["']/i,
       /content(?:s)? (?:is|are) ["']([^"']+)["']/i,
     ];
     for (const text of texts) {

--- a/test/unit/agent/autonomous/friday-autonomous-engine.test.ts
+++ b/test/unit/agent/autonomous/friday-autonomous-engine.test.ts
@@ -1101,6 +1101,66 @@ describe("FridayAutonomousEngine", () => {
       }
     });
 
+    it("uses deterministic file-state verification for file writes phrased with exact content", async () => {
+      const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), "friday-autonomous-file-content-"));
+      const outputPath = path.join(workspaceDir, "proof.txt");
+      const expected = "deterministic autonomous content proof";
+      const runtime = {
+        executeRun: vi.fn().mockResolvedValue({
+          runId: "run-plan",
+          status: "completed",
+          response: JSON.stringify([
+            {
+              instruction: `Create the file '${outputPath}' with the exact content '${expected}'`,
+              domain: "file",
+              verification: `Verify the file '${outputPath}' exists and contains the exact content '${expected}'`,
+            },
+          ]),
+          usageInput: 20,
+          usageOutput: 10,
+        }),
+      };
+      const toolExecutor = vi.fn().mockImplementation(async (toolName: string, args: Record<string, unknown>) => {
+        if (toolName !== "write") {
+          return { content: `unexpected tool ${toolName}`, isError: true };
+        }
+        const filePath = String(args.path);
+        const content = String(args.content);
+        fs.writeFileSync(filePath, content, "utf8");
+        return { content: "write complete" };
+      });
+
+      try {
+        engine = createFridayAutonomousEngine({
+          ...deps,
+          agentRuntime: runtime,
+          toolExecutor,
+          analyzeImages: vi.fn(),
+          config: { iterationDelayMs: 0 },
+        });
+
+        const result = await engine.executeGoal({
+          description: "Create a proof file with exact content wording and verify it",
+          signal: signal(),
+        });
+
+        expect(result.status).toBe("completed");
+        expect(runtime.executeRun).toHaveBeenCalledTimes(1);
+        expect(toolExecutor).toHaveBeenCalledTimes(1);
+        expect(toolExecutor).toHaveBeenCalledWith(
+          "write",
+          {
+            path: outputPath,
+            content: expected,
+          },
+          expect.any(AbortSignal),
+        );
+        expect(fs.readFileSync(outputPath, "utf8")).toBe(expected);
+      } finally {
+        fs.rmSync(workspaceDir, { recursive: true, force: true });
+      }
+    });
+
     it("should handle aborted goals", async () => {
       const controller = new AbortController();
       controller.abort(new Error("User cancelled"));


### PR DESCRIPTION
## Summary
- fix deterministic autonomous file replay for steps phrased with exact content
- add a unit regression covering exact-content file instructions
- re-run post-merge autonomous, self-upgrade, self-healing, learning, and real-browser smokes locally

## Real proof
- `npx vitest run test/unit/agent/autonomous/friday-autonomous-engine.test.ts`
- `FRIDAY_E2E_LIVE_ANTHROPIC=1 FRIDAY_ANTHROPIC_API_KEY=*** npx vitest run test/e2e/live/friday-autonomous-restart.e2e.test.ts -t 'marks planning interruption as recoverable and resumes to verified completion'`
- `FRIDAY_E2E_LIVE_ANTHROPIC=1 FRIDAY_ANTHROPIC_API_KEY=*** npx vitest run test/e2e/live/friday-self-upgrade-workflow-live.e2e.test.ts`
- `FRIDAY_E2E_LIVE_ANTHROPIC=1 FRIDAY_ANTHROPIC_API_KEY=*** npx vitest run test/e2e/live/friday-self-healing-live.e2e.test.ts -t 'auto-applies a low-risk fallback fix, writes a lesson, and changes the next action via lesson readback'`
- `FRIDAY_E2E_LIVE_ANTHROPIC=1 FRIDAY_ANTHROPIC_API_KEY=*** npx vitest run test/e2e/live/friday-learning-live.e2e.test.ts -t 'proves compaction trigger -> writeback -> reset -> readback changes behavior over a real session'`
- `npx vitest run test/e2e/ui/friday-real-browser-onboarding.e2e.test.ts`
- `npm run build:api`
