### PR TITLE
Fix live chat and run continuity surfaces

### DIFF
--- a/ui/src/hooks/use-chat-session.ts
+++ b/ui/src/hooks/use-chat-session.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { agentApi } from "@/lib/api/agent";
 import { sessionsApi } from "@/lib/api/sessions";
-import type { FridaySessionMessageRecord } from "@/lib/api/types";
+import { ApiError, type FridaySessionMessageRecord } from "@/lib/api/types";
 import { useAgentRunEvents, type UseAgentRunEventsResult } from "./use-agent-run-events";
 
 // ─── Types ───
@@ -165,6 +165,10 @@ function mapSessionMessagesToChatMessages(records: FridaySessionMessageRecord[])
     }));
 }
 
+function isSessionAlreadyCreatedError(error: unknown): boolean {
+  return error instanceof ApiError && error.code === "ALREADY_EXISTS";
+}
+
 // ─── Hook ───
 
 export function useChatSession(options: UseChatSessionOptions = {}): UseChatSessionResult {
@@ -176,31 +180,27 @@ export function useChatSession(options: UseChatSessionOptions = {}): UseChatSess
 
   const syncMessagesFromServer = useCallback(async (targetSessionKey: string): Promise<boolean> => {
     try {
-      await sessionsApi.get(targetSessionKey);
       const remoteMessages = await sessionsApi.listMessages(targetSessionKey, { limit: 200 });
       const mapped = mapSessionMessagesToChatMessages(remoteMessages);
       setMessages(mapped);
       saveHistory(targetSessionKey, mapped);
       return true;
     } catch {
-      if (targetSessionKey === sessionKeyRef.current) {
-        setMessages([]);
-        saveHistory(targetSessionKey, []);
-      }
       return false;
     }
   }, []);
 
   const ensureRemoteSession = useCallback(async (targetSessionKey: string) => {
     try {
-      await sessionsApi.get(targetSessionKey);
-      return;
-    } catch {
       await sessionsApi.create({
         channel: CHAT_SESSION_CHANNEL,
         chatId: extractChatIdFromSessionKey(targetSessionKey),
         chatKind: "dm",
       });
+    } catch (error) {
+      if (!isSessionAlreadyCreatedError(error)) {
+        throw error;
+      }
     }
   }, []);
 

--- a/ui/src/hooks/use-pack-launch-actions.ts
+++ b/ui/src/hooks/use-pack-launch-actions.ts
@@ -21,6 +21,10 @@ export interface UsePackLaunchActionsOptions {
   surface: "packs" | "home" | "chat";
 }
 
+const PACK_RUN_DISCOVERY_LIMIT = 100;
+const PACK_RUN_DISCOVERY_TIMEOUT_MS = 15_000;
+const PACK_RUN_DISCOVERY_POLL_MS = 400;
+
 function createPackStartIdempotencyKey(packId: string): string {
   const normalizedPackId = encodeURIComponent(packId)
     .replace(/%/g, "_")
@@ -30,6 +34,18 @@ function createPackStartIdempotencyKey(packId: string): string {
     return `pack-start:${normalizedPackId}:${crypto.randomUUID()}`;
   }
   return `pack-start:${normalizedPackId}:${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function readPackRunId(run: AgentRunRecord, packId: string, knownRunIds: Set<string>): string | null {
+  const runPackId = run.metadata?.packContext?.packId;
+  if (runPackId !== packId || knownRunIds.has(run.id)) {
+    return null;
+  }
+  return run.id;
 }
 
 export function usePackLaunchActions(
@@ -75,6 +91,28 @@ export function usePackLaunchActions(
     },
   });
 
+  const invalidatePackQueries = useCallback(async () => {
+    await Promise.allSettled([
+      queryClient.invalidateQueries({ queryKey: ["packs", "recent-runs"] }),
+      queryClient.invalidateQueries({ queryKey: ["assistant-inbox", "snapshot"] }),
+    ]);
+  }, [queryClient]);
+
+  const waitForNewPackRunId = useCallback(async (packId: string, knownRunIds: Set<string>) => {
+    const deadline = Date.now() + PACK_RUN_DISCOVERY_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      const runs = await agentApi.listRuns({ limit: PACK_RUN_DISCOVERY_LIMIT });
+      const discoveredRunId = runs
+        .map((run) => readPackRunId(run, packId, knownRunIds))
+        .find((runId): runId is string => typeof runId === "string");
+      if (discoveredRunId) {
+        return discoveredRunId;
+      }
+      await delay(PACK_RUN_DISCOVERY_POLL_MS);
+    }
+    return null;
+  }, []);
+
   const startPackNow = useCallback(async (pack: FridayPackDefinition) => {
     if (!isCustomPackDefinition(pack)) {
       navigate(buildPackFlowHref(pack));
@@ -87,15 +125,32 @@ export function usePackLaunchActions(
 
     pendingCustomPackIdsRef.current.add(pack.id);
     try {
-      const result = await startCustomPackRun.mutateAsync({
+      const knownRunIds = new Set(
+        (await agentApi.listRuns({ limit: PACK_RUN_DISCOVERY_LIMIT }))
+          .filter((run) => run.metadata?.packContext?.packId === pack.id)
+          .map((run) => run.id),
+      );
+
+      const startRequest = startCustomPackRun.mutateAsync({
         pack,
         idempotencyKey: createPackStartIdempotencyKey(pack.id),
       });
+
+      const discoveredRunId = await waitForNewPackRunId(pack.id, knownRunIds);
+      if (discoveredRunId) {
+        await invalidatePackQueries();
+        navigate(buildAgentRunHref(discoveredRunId));
+        void startRequest.catch(() => undefined);
+        return;
+      }
+
+      const result = await startRequest;
+      await invalidatePackQueries();
       navigate(buildAgentRunHref(result.runId));
     } finally {
       pendingCustomPackIdsRef.current.delete(pack.id);
     }
-  }, [navigate, startCustomPackRun]);
+  }, [invalidatePackQueries, navigate, startCustomPackRun, waitForNewPackRunId]);
 
   const adjustPackBeforeStart = useCallback((pack: FridayPackDefinition) => {
     if (!isCustomPackDefinition(pack)) {

--- a/ui/src/routes/chat-page.tsx
+++ b/ui/src/routes/chat-page.tsx
@@ -416,19 +416,16 @@ export function ChatPage() {
         pack={selectedPack}
         onClose={() => setSelectedPackId(null)}
         onStartNow={() => {
-          setSelectedPackId(null);
           if (selectedPack) {
             void startPackNow(selectedPack);
           }
         }}
         onAdjustBeforeStart={() => {
-          setSelectedPackId(null);
           if (selectedPack) {
             adjustPackBeforeStart(selectedPack);
           }
         }}
         onOpenSkill={(skillId) => {
-          setSelectedPackId(null);
           navigate(buildSkillHref(skillId));
         }}
         onAskFriday={(prompt) => {
@@ -443,7 +440,6 @@ export function ChatPage() {
           setDraftText(prompt);
         }}
         onOpenAssistant={selectedPack ? () => {
-          setSelectedPackId(null);
           setPendingPackPath(buildPackAssistantHref(selectedPack.id));
         } : undefined}
       />

--- a/ui/src/routes/home-page.tsx
+++ b/ui/src/routes/home-page.tsx
@@ -802,25 +802,21 @@ export function HomePage() {
         continueLabel={selectedPackRunState.recentRun ? formatShortTimestamp(selectedPackRunState.recentRun.completedAt ?? selectedPackRunState.recentRun.startedAt, locale) : null}
         onClose={() => setSelectedPackId(null)}
         onOpenCurrent={selectedPackRunState.activeRun ? () => {
-          setSelectedPackId(null);
           if (selectedPack && selectedPackRunState.activeRun) {
             openCurrentPackRun(selectedPack, selectedPackRunState.activeRun);
           }
         } : undefined}
         onContinue={selectedPackRunState.recentRun ? () => {
-          setSelectedPackId(null);
           if (selectedPack) {
             continuePack(selectedPack, selectedPackRunState.recentRun);
           }
         } : undefined}
         onStartNow={() => {
-          setSelectedPackId(null);
           if (selectedPack) {
             void startPackNow(selectedPack);
           }
         }}
         onAdjustBeforeStart={() => {
-          setSelectedPackId(null);
           if (selectedPack) {
             adjustPackBeforeStart(selectedPack);
           }

--- a/ui/src/routes/packs-page.tsx
+++ b/ui/src/routes/packs-page.tsx
@@ -283,18 +283,15 @@ export function PacksPage() {
           if (!selectedPack) {
             return;
           }
-          setSelectedPackId(null);
           void startPackNow(selectedPack);
         }}
         onAdjustBeforeStart={() => {
           if (!selectedPack) {
             return;
           }
-          setSelectedPackId(null);
           adjustPackBeforeStart(selectedPack);
         }}
         onOpenSkill={(skillId) => {
-          setSelectedPackId(null);
           navigate(buildSkillHref(skillId));
         }}
         onAskFriday={(prompt) => {
@@ -304,7 +301,6 @@ export function PacksPage() {
           }
         }}
         onOpenAssistant={selectedPack ? () => {
-          setSelectedPackId(null);
           navigate(buildPackAssistantHref(selectedPack.id));
         } : undefined}
         onRemoveFromHome={selectedPack && pinnedPackIds.includes(selectedPack.id) ? () => {

--- a/ui/src/routes/workflows-page.tsx
+++ b/ui/src/routes/workflows-page.tsx
@@ -174,6 +174,31 @@ export function WorkflowsPage() {
     },
   });
 
+  const startRunMutation = useMutation({
+    mutationFn: (input: { workflowId: string; workflowVersionId?: string }) =>
+      workflowRunsApi.start({
+        workflowId: input.workflowId,
+        workflowVersionId: input.workflowVersionId,
+        triggerType: "manual",
+        triggerPayload: {},
+      }),
+    onSuccess: () => {
+      toast.success(locale === "zh" ? "工作流已启动。" : "Workflow run started.");
+      if (selectedWorkflowId) {
+        void queryClient.invalidateQueries({ queryKey: systemKeys.workflowOverview(selectedWorkflowId) });
+        void queryClient.invalidateQueries({
+          queryKey: systemKeys.workflowVisualization(
+            selectedWorkflowId,
+            overviewQuery.data?.latestDraft?.draftId ?? overviewQuery.data?.publishedVersion?.id ?? "default",
+          ),
+        });
+      }
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : (locale === "zh" ? "无法启动工作流。" : "Failed to start workflow."));
+    },
+  });
+
   const graphNodes = useMemo(() => {
     const spec = visualizationQuery.data?.spec;
     const visual = visualizationQuery.data?.visual;
@@ -205,6 +230,8 @@ export function WorkflowsPage() {
         : [],
     [overviewQuery.data, visualizationQuery.data],
   );
+
+  const runnableWorkflowVersionId = overviewQuery.data?.publishedVersion?.id ?? overviewQuery.data?.latestVersion?.id;
 
   const handleSelectWorkflow = (workflowId: string) => {
     setSelectedWorkflowId(workflowId);
@@ -297,6 +324,19 @@ export function WorkflowsPage() {
                     <ActionButton tone="secondary" onClick={handleSecondaryAction} disabled={deployMutation.isPending}>
                       <Package className="mr-2 h-4 w-4" />
                       {attentionSummary.secondaryLabel}
+                    </ActionButton>
+                  ) : null}
+                  {runnableWorkflowVersionId ? (
+                    <ActionButton
+                      tone="secondary"
+                      onClick={() => startRunMutation.mutate({
+                        workflowId: overviewQuery.data.workflow.id,
+                        workflowVersionId: runnableWorkflowVersionId,
+                      })}
+                      disabled={startRunMutation.isPending}
+                    >
+                      <PlayCircle className="mr-2 h-4 w-4" />
+                      {locale === "zh" ? "运行当前工作流" : "Run current workflow"}
                     </ActionButton>
                   ) : null}
                   <Link


### PR DESCRIPTION
## Summary
- avoid false 404/clear-history behavior while creating chat sessions
- keep pack quick sheets mounted while real launches and navigation begin
- add a real workflow run action on the workflows page
- improve custom pack run discovery so the UI navigates to the real new run as soon as it appears

## Validation
- npm run typecheck
- npm run build:ui
- curl -sS http://127.0.0.1:3251/v1/health
- manual local smoke of /chat, /home, /packs, /workflows against the live Friday server