### PR TITLE
Stabilize Friday memory recall and starter skill flows

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,10 +91,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -419,7 +415,7 @@
         "filename": "src/api/http/routes/friday-setup-routes.ts",
         "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
         "is_verified": false,
-        "line_number": 482
+        "line_number": 493
       }
     ],
     "src/observability/model/friday-observability.types.ts": [
@@ -1175,5 +1171,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-22T00:53:40Z"
+  "generated_at": "2026-04-22T20:51:23Z"
 }

--- a/src/agent/runtime/friday-agent-runtime.ts
+++ b/src/agent/runtime/friday-agent-runtime.ts
@@ -2057,14 +2057,25 @@ export function createFridayAgentRuntime(
               toolCalls: allToolCalls,
               disabledToolNames,
             })) {
-              if (!hasSuccessfulMemorySearchEvidence(allToolCalls)) {
+              const requestedFields = getRequestedMemoryRecallFields(params.task);
+              const resolvedFields = new Set(
+                collectMemoryRecallExpectations({
+                  task: params.task,
+                  toolCalls: allToolCalls,
+                }).map((expectation) => expectation.field),
+              );
+              const fallbackSearchFields = !hasSuccessfulMemorySearchEvidence(allToolCalls)
+                ? requestedFields
+                : requestedFields.filter((field) => !resolvedFields.has(field));
+
+              for (const field of fallbackSearchFields) {
                 const fallbackMemorySearchRecord = await executeToolCall({
                   toolUse: {
                     type: "tool_use",
                     id: `auto-memory-recall-${idGenerator()}`,
                     name: "memory_search",
                     input: {
-                      query: "user name",
+                      query: memoryRecallFieldQuery(field),
                       namespace: "user",
                       limit: 1,
                     },
@@ -2088,6 +2099,15 @@ export function createFridayAgentRuntime(
                   emitRunEvent: (name, payload) => handleTrackedEvent(name, payload),
                 });
                 allToolCalls.push(fallbackMemorySearchRecord);
+              }
+
+              const fallbackResponse = buildDeterministicMemoryRecallFallbackResponse({
+                task: params.task,
+                toolCalls: allToolCalls,
+              });
+              if (fallbackResponse) {
+                responseText = fallbackResponse;
+                break;
               }
 
               const fallbackValues = latestMemorySearchResultContents(allToolCalls);
@@ -4640,9 +4660,10 @@ function taskRequiresMemorySearch(task: string): boolean {
   }
   return (
     /\buse memory[_ ]search\b/.test(normalized)
+    || /\bwhat(?:'s| is)\s+my\s+(?:codename|code phrase|passphrase|preferred name)\b/.test(normalized)
     || /\bwhat should you call me\b/.test(normalized)
     || /\bwhat should i call you\b/.test(normalized)
-    || /\bwhat (?:do )?i (?:like|prefer)\b/.test(normalized)
+    || /\bwhat(?:\s+\S+){0,6}\s+(?:do\s+)?i\s+(?:like|prefer)\b/.test(normalized)
     || /\b(?:my|user)\s+(?:preferred|stored)\s+(?:name|preference|preferences)\b/.test(normalized)
     || /\b(?:do you remember|what do you remember|recall|stored fact|stored facts|previous conversation|past decision|past decisions)\b/.test(normalized)
   );
@@ -4659,6 +4680,47 @@ function taskRequestsDirectNameRecall(task: string): boolean {
     || /\bwhat (?:name|nickname) (?:should|do) you (?:use|call me with)\b/.test(normalized)
     || /(怎么称呼我|该怎么叫我|应该怎么称呼我|应该叫我什么|你该怎么称呼我|你应该怎么叫我|怎么称呼您|该怎么叫您|应该怎么称呼您|应该叫您什么)/u.test(task)
   );
+}
+
+function taskRequestsCodenameRecall(task: string): boolean {
+  const normalized = task.trim().toLowerCase();
+  if (normalized.length === 0) {
+    return false;
+  }
+  return (
+    /\b(?:what(?:'s| is)?|which|tell me|remind me|do you remember)\b(?:\s+\S+){0,8}\s+\b(?:codename|code phrase|passphrase)\b/.test(normalized)
+    || /\b(?:codename|code phrase|passphrase)\b(?:\s+\S+){0,8}\s+\b(?:what(?:'s| is)?|was|again|remember)\b/.test(normalized)
+    || /(?:什么|啥).*(?:代号|口令|暗号)/u.test(task)
+    || /(?:代号|口令|暗号).*(?:是什么|是啥|告诉我|还记得|再说一遍|叫什么)/u.test(task)
+  );
+}
+
+function taskRequestsReleaseNoteStyleRecall(task: string): boolean {
+  const normalized = task.trim().toLowerCase();
+  if (normalized.length === 0) {
+    return false;
+  }
+  return (
+    /\b(?:what(?:'s| is)?|which|tell me|remind me|do you remember)\b(?:\s+\S+){0,10}\s+\brelease(?:[- ]note)? style\b/.test(normalized)
+    || /\b(?:what(?:'s| is)?|which|tell me|remind me|do you remember)\b(?:\s+\S+){0,10}\s+\brelease notes?\b/.test(normalized)
+    || /\brelease(?:[- ]note)? style\b(?:\s+\S+){0,8}\s+\b(?:what(?:'s| is)?|again|remember)\b/.test(normalized)
+    || /(?:什么|怎样).*(?:发布说明|release[- ]note|release note).*(?:风格|偏好)/iu.test(task)
+    || /(?:发布说明|release[- ]note|release note).*(?:风格|偏好).*(?:是什么|怎样|告诉我|还记得)/iu.test(task)
+  );
+}
+
+function getRequestedMemoryRecallFields(task: string): FridayMemoryRecallExpectation["field"][] {
+  const fields: FridayMemoryRecallExpectation["field"][] = [];
+  if (taskRequestsDirectNameRecall(task)) {
+    fields.push("preferred_name");
+  }
+  if (taskRequestsCodenameRecall(task)) {
+    fields.push("codename");
+  }
+  if (taskRequestsReleaseNoteStyleRecall(task)) {
+    fields.push("release_note_style");
+  }
+  return fields;
 }
 
 function responseClaimsStoredFactMissing(responseText: string): boolean {
@@ -4706,6 +4768,123 @@ function latestMemorySearchResultContents(toolCalls: FridayAgentToolCallRecord[]
     .filter((content) => content.length > 0);
 }
 
+interface FridayMemoryRecallExpectation {
+  field: "codename" | "release_note_style" | "preferred_name";
+  query: string;
+  value: string;
+  content: string;
+}
+
+function normalizeMemoryRecallValue(raw: string): string {
+  return raw.trim().replace(/^["'“”]+|["'“”.]+$/gu, "");
+}
+
+function extractMemoryRecallValue(field: FridayMemoryRecallExpectation["field"], content: string): string | undefined {
+  if (field === "codename") {
+    const match = content.match(/\b(?:codename|code phrase|passphrase)\s+is\s+["'“”]?([^"'“”.\n]+)["'“”]?/i);
+    return match?.[1] ? normalizeMemoryRecallValue(match[1]) : undefined;
+  }
+  if (field === "preferred_name") {
+    const match = content.match(/\b(?:preferred name|name)\s+is\s+["'“”]?([^"'“”.\n]+)["'“”]?/i);
+    return match?.[1] ? normalizeMemoryRecallValue(match[1]) : undefined;
+  }
+  const releaseStyleMatch = content.match(
+    /\b(?:prefers?|likes?|wants?)\s+(?:a\s+release-note style\s+that\s+)?(.+?)(?:[.]\s*|$)/i,
+  );
+  if (releaseStyleMatch?.[1]) {
+    return normalizeMemoryRecallValue(releaseStyleMatch[1]);
+  }
+  const genericMatch = content.match(/\brelease[- ]note style(?: is|:)?\s+(.+?)(?:[.]\s*|$)/i);
+  return genericMatch?.[1] ? normalizeMemoryRecallValue(genericMatch[1]) : undefined;
+}
+
+function collectMemoryRecallExpectations(params: {
+  task: string;
+  toolCalls: FridayAgentToolCallRecord[];
+}): FridayMemoryRecallExpectation[] {
+  const requestedFields = getRequestedMemoryRecallFields(params.task);
+  if (requestedFields.length === 0) {
+    return [];
+  }
+  const expectations = new Map<FridayMemoryRecallExpectation["field"], FridayMemoryRecallExpectation>();
+
+  const trySetExpectation = (
+    field: FridayMemoryRecallExpectation["field"],
+    query: string,
+    content: string,
+    allowWholeContentFallback = false,
+  ): void => {
+    if (expectations.has(field) || content.length === 0) {
+      return;
+    }
+    const value = extractMemoryRecallValue(field, content);
+    if (!value && !allowWholeContentFallback) {
+      return;
+    }
+    expectations.set(field, {
+      field,
+      query,
+      value: value ?? content,
+      content,
+    });
+  };
+
+  for (const toolCall of params.toolCalls) {
+    if (toolCall.toolName !== "memory_search" || toolCall.result.isError) {
+      continue;
+    }
+    const query = typeof toolCall.args.query === "string" ? toolCall.args.query.trim() : "";
+    if (query.length === 0) {
+      continue;
+    }
+
+    const results = parseMemorySearchResults(toolCall);
+    for (const result of results) {
+      const content = typeof result.content === "string" ? result.content.trim() : "";
+      for (const field of requestedFields) {
+        trySetExpectation(field, query, content);
+      }
+    }
+
+    const [topResult] = results;
+    const topContent = typeof topResult?.content === "string" ? topResult.content.trim() : "";
+    if (topContent.length === 0) {
+      continue;
+    }
+
+    const queryRequestsCodename = taskRequestsCodenameRecall(query) || /\b(?:codename|code phrase|passphrase)\b/i.test(query);
+    const queryRequestsReleaseStyle = /\b(?:release[- ]note style|release notes?)\b/i.test(query);
+    const queryRequestsPreferredName = taskRequestsDirectNameRecall(query) || /\b(?:name|preferred name|user name)\b/i.test(query);
+
+    if (
+      requestedFields.includes("codename")
+      && queryRequestsCodename
+      && !queryRequestsReleaseStyle
+      && !queryRequestsPreferredName
+    ) {
+      trySetExpectation("codename", query, topContent, true);
+    }
+    if (
+      requestedFields.includes("release_note_style")
+      && queryRequestsReleaseStyle
+      && !queryRequestsCodename
+      && !queryRequestsPreferredName
+    ) {
+      trySetExpectation("release_note_style", query, topContent, true);
+    }
+    if (
+      requestedFields.includes("preferred_name")
+      && queryRequestsPreferredName
+      && !queryRequestsCodename
+      && !queryRequestsReleaseStyle
+    ) {
+      trySetExpectation("preferred_name", query, topContent, true);
+    }
+  }
+
+  return [...expectations.values()];
+}
+
 function responseMatchesAnyMemoryRecallValue(
   responseText: string,
   expectedValues: string[],
@@ -4717,32 +4896,113 @@ function responseMatchesAnyMemoryRecallValue(
   return expectedValues.some((value) => normalizedResponse.includes(value.trim().toLowerCase()));
 }
 
+function memoryRecallFieldQuery(field: FridayMemoryRecallExpectation["field"]): string {
+  switch (field) {
+    case "preferred_name":
+      return "user name";
+    case "codename":
+      return "codename";
+    case "release_note_style":
+      return "release-note style";
+  }
+}
+
+function buildDeterministicMemoryRecallFallbackResponse(params: {
+  task: string;
+  toolCalls: FridayAgentToolCallRecord[];
+}): string | undefined {
+  const requestedFields = getRequestedMemoryRecallFields(params.task);
+  if (requestedFields.length === 0) {
+    return undefined;
+  }
+
+  const expectationMap = new Map(
+    collectMemoryRecallExpectations(params).map((expectation) => [expectation.field, expectation.value] as const),
+  );
+
+  if (requestedFields.length === 1 && requestedFields[0] === "preferred_name") {
+    return expectationMap.get("preferred_name");
+  }
+
+  const clauses: string[] = [];
+  if (requestedFields.includes("preferred_name")) {
+    const preferredName = expectationMap.get("preferred_name");
+    if (preferredName) {
+      clauses.push(`Your preferred name is ${preferredName}`);
+    }
+  }
+  if (requestedFields.includes("codename")) {
+    const codename = expectationMap.get("codename");
+    if (codename) {
+      clauses.push(`Your codename is ${codename}`);
+    }
+  }
+  if (requestedFields.includes("release_note_style")) {
+    const releaseStyle = expectationMap.get("release_note_style");
+    if (releaseStyle) {
+      clauses.push(`you prefer ${releaseStyle}`);
+    }
+  }
+
+  if (clauses.length === 0) {
+    return undefined;
+  }
+  if (clauses.length === 1) {
+    return `${clauses[0]}.`;
+  }
+  return `${clauses.slice(0, -1).join(", ")}, and ${clauses[clauses.length - 1]}.`;
+}
+
+function responseClaimsNewMemoryPersistence(responseText: string): boolean {
+  const normalized = responseText.trim().toLowerCase();
+  if (normalized.length === 0) {
+    return false;
+  }
+  return /\b(?:i have saved|i've saved|i saved|i recorded|saved your|recorded your)\b/.test(normalized)
+    || /(已保存|已经保存|我保存了|我记住了|我已经记住)/u.test(responseText);
+}
+
 function evaluateMemoryRecallAnswerAlignment(params: {
   task: string;
   responseText: string;
   toolCalls: FridayAgentToolCallRecord[];
 }): { retryPrompt?: string } {
-  if (!taskRequestsDirectNameRecall(params.task)) {
+  const requestedFields = getRequestedMemoryRecallFields(params.task);
+  if (requestedFields.length === 0) {
     return {};
   }
-  const expectedValues = latestMemorySearchResultContents(params.toolCalls);
-  if (expectedValues.length === 0) {
+  if (!hasSuccessfulMemorySearchEvidence(params.toolCalls)) {
+    return {};
+  }
+  const expectations = collectMemoryRecallExpectations(params);
+  const expectedFields = new Set(expectations.map((expectation) => expectation.field));
+  const missingRequestedFields = requestedFields.filter((field) => !expectedFields.has(field));
+  if (expectations.length === 0 && missingRequestedFields.length === 0) {
+    return {};
+  }
+  const missingExpectations = expectations.filter((expectation) =>
+    !responseMatchesAnyMemoryRecallValue(params.responseText, [expectation.value, expectation.content]),
+  );
+  const claimsNewPersistence = responseClaimsNewMemoryPersistence(params.responseText);
+  if (missingExpectations.length === 0 && missingRequestedFields.length === 0 && !claimsNewPersistence) {
     return {};
   }
 
-  if (responseMatchesAnyMemoryRecallValue(params.responseText, expectedValues)) {
-    return {};
-  }
-
-  const primaryExpectedValue = expectedValues[0];
   return {
     retryPrompt: [
-      "System verification: memory_search already returned a stored preferred name for this user, but your answer did not use it.",
+      "System verification: memory_search already returned stored user facts for this task, but your answer did not use the top result for every requested field.",
       `Current task: ${params.task.trim()}`,
-      `Stored preferred name from memory_search: ${primaryExpectedValue}`,
-      "Reply with that stored name directly.",
-      "Do not say the name is unknown or ask the user again unless the tool result was empty.",
-      "If the user asked for only the name, return only the name.",
+      ...missingRequestedFields.map((field) =>
+        `Requested ${field.replace(/_/g, " ")} is still missing. Rerun memory_search with a field-specific query for that field before answering.`,
+      ),
+      ...missingExpectations.map((expectation) =>
+        `Stored ${expectation.field.replace(/_/g, " ")} from memory_search: ${expectation.value}`,
+      ),
+      "Reply using those stored values directly.",
+      "Prefer the top memory_search result for the current session when multiple memories conflict.",
+      "This is a recall task, not a new save task.",
+      "Do not call feedback or memory_store, and do not say you saved or recorded anything new.",
+      "Do not say the value is unknown and do not ask the user again unless the tool result was empty.",
     ].join(" "),
   };
 }
@@ -4754,7 +5014,12 @@ function shouldAttemptDeterministicMemoryRecallFallback(params: {
   toolCalls: FridayAgentToolCallRecord[];
   disabledToolNames?: ReadonlySet<string>;
 }): boolean {
-  if (!taskRequestsDirectNameRecall(params.task)) {
+  const requestedFields = getRequestedMemoryRecallFields(params.task);
+  const expectations = collectMemoryRecallExpectations({
+    task: params.task,
+    toolCalls: params.toolCalls,
+  });
+  if (expectations.length === 0 && requestedFields.length === 0) {
     return false;
   }
   if (!params.toolMap.has("memory_search")) {
@@ -4764,9 +5029,15 @@ function shouldAttemptDeterministicMemoryRecallFallback(params: {
     return false;
   }
 
-  const expectedValues = latestMemorySearchResultContents(params.toolCalls);
-  if (expectedValues.length > 0) {
-    return !responseMatchesAnyMemoryRecallValue(params.responseText, expectedValues);
+  const expectedFields = new Set(expectations.map((expectation) => expectation.field));
+  if (requestedFields.some((field) => !expectedFields.has(field))) {
+    return true;
+  }
+
+  if (expectations.length > 0) {
+    return expectations.some((expectation) =>
+      !responseMatchesAnyMemoryRecallValue(params.responseText, [expectation.value, expectation.content]),
+    );
   }
 
   return true;

--- a/src/agent/runtime/friday-agent-system-prompt-builder.ts
+++ b/src/agent/runtime/friday-agent-system-prompt-builder.ts
@@ -220,7 +220,7 @@ export function buildFridayAgentSystemPrompt(
     "- Never say you cannot do something that your currently registered tools support.\n" +
     "- If a capability is not available in this deployment, explain that clearly and suggest the closest available alternative.\n" +
     "- When asked about your current deployment capabilities, use capabilities before answering. Use the prompt for model/version framing, not for guessing runtime state.\n" +
-    "- Use the feedback tool when a user corrects you or states a preference.\n" +
+    "- Use the feedback tool only when the current user message explicitly corrects you or explicitly states a preference. Never infer or synthesize a new preference from a question.\n" +
     "- Before answering questions that reference previous conversations, user preferences, or stored facts, proactively search memory with memory_search. If relevant memories exist, incorporate them into your response.\n" +
     "- When a request matches an available starter skill, prefer that existing skill over generating or importing a new one.\n" +
     (enforceStarterSkillRouting

--- a/src/agent/tools/friday-agent-feedback-tool.ts
+++ b/src/agent/tools/friday-agent-feedback-tool.ts
@@ -17,9 +17,79 @@ export interface CreateFridayAgentFeedbackToolDeps {
 // ─── Factory ───
 
 const VALID_KINDS = ["correction", "preference", "positive_feedback"] as const;
+const FEEDBACK_VALUE_STOPWORDS = new Set([
+  "a",
+  "an",
+  "and",
+  "be",
+  "for",
+  "i",
+  "is",
+  "me",
+  "my",
+  "of",
+  "please",
+  "the",
+  "to",
+  "use",
+]);
+const EXPLICIT_FEEDBACK_STATEMENT_PATTERNS = [
+  /\b(?:i|we)\s+(?:prefer|like|want|need|usually use|would like)\b/i,
+  /\b(?:call me|refer to me as|my codename is|my name is)\b/i,
+  /\b(?:that(?:'s| is)\s+wrong|incorrect|actually|instead|use .* instead)\b/i,
+  /(我更喜欢|我希望|我想要|请叫我|称呼我为|我的代号是|这是错的|应该改成)/u,
+] as const;
+const FEEDBACK_QUESTION_PATTERNS = [
+  /^\s*(?:what|which|who|can|could|would|do|did|does|is|are)\b/i,
+  /^\s*(?:什么|哪个|谁|可以|能不能|是否|是不是)/u,
+] as const;
 
 function normalizeFeedbackField(field: string): string {
   return field.trim().toLowerCase().replace(/[\s-]+/g, "_");
+}
+
+function tokenizeFeedbackValue(raw: string): string[] {
+  return raw
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .split(/\s+/)
+    .map((token) => token.trim())
+    .filter((token) => token.length > 1 && !FEEDBACK_VALUE_STOPWORDS.has(token));
+}
+
+function taskPromptExplicitlyStatesFeedback(taskPrompt?: string): boolean {
+  if (!taskPrompt || taskPrompt.trim().length === 0) {
+    return false;
+  }
+  if (EXPLICIT_FEEDBACK_STATEMENT_PATTERNS.some((pattern) => pattern.test(taskPrompt))) {
+    return true;
+  }
+  return false;
+}
+
+function taskPromptLooksLikeQuestion(taskPrompt?: string): boolean {
+  if (!taskPrompt || taskPrompt.trim().length === 0) {
+    return false;
+  }
+  return FEEDBACK_QUESTION_PATTERNS.some((pattern) => pattern.test(taskPrompt))
+    || taskPrompt.includes("?");
+}
+
+function taskPromptSupportsFeedbackValue(taskPrompt: string | undefined, value: string): boolean {
+  if (!taskPrompt || taskPrompt.trim().length === 0) {
+    return false;
+  }
+  const promptLower = taskPrompt.toLowerCase();
+  const normalizedValue = value.trim().toLowerCase();
+  if (normalizedValue.length >= 3 && promptLower.includes(normalizedValue)) {
+    return true;
+  }
+  const valueTokens = tokenizeFeedbackValue(value);
+  if (valueTokens.length === 0) {
+    return false;
+  }
+  const matchedTokenCount = valueTokens.filter((token) => promptLower.includes(token)).length;
+  return matchedTokenCount >= Math.min(2, valueTokens.length);
 }
 
 function extractExplicitDisplayName(taskPrompt?: string): string | null {
@@ -86,6 +156,7 @@ export function createFridayAgentFeedbackTool(
         ? extractExplicitDisplayName(executionContext?.taskPrompt)
         : null;
       const value = exactDisplayName ?? rawValue;
+      const taskPrompt = executionContext?.taskPrompt;
 
       // Use per-run principal if injected by the runtime, otherwise fall back to default.
       const userId =
@@ -95,6 +166,16 @@ export function createFridayAgentFeedbackTool(
 
       if (!(VALID_KINDS as readonly string[]).includes(kind)) {
         return textResult(`Invalid feedback kind "${kind}". Must be one of: ${VALID_KINDS.join(", ")}`);
+      }
+
+      const explicitFeedbackStatement = taskPromptExplicitlyStatesFeedback(taskPrompt);
+      const questionLikePrompt = taskPromptLooksLikeQuestion(taskPrompt);
+      const valueSupportedByPrompt = taskPromptSupportsFeedbackValue(taskPrompt, value);
+
+      if (!explicitFeedbackStatement || questionLikePrompt || !valueSupportedByPrompt) {
+        return textResult(
+          "Feedback not recorded because the current user message does not explicitly state that correction or preference.",
+        );
       }
 
       learningEventWriter([

--- a/src/agent/tools/friday-agent-memory-tools.ts
+++ b/src/agent/tools/friday-agent-memory-tools.ts
@@ -1,5 +1,6 @@
 import type { FridayAgentToolDefinition, FridayAgentToolResult } from "../model/friday-agent.types.js";
 import type { FridayMemoryService } from "#memory";
+import type { FridayMemoryItem, FridayMemorySearchResult } from "#memory";
 import type { FridayLearningEventAppendInput } from "#ledger";
 import {
   errorResult,
@@ -19,6 +20,7 @@ export interface CreateFridayAgentMemoryToolsDeps {
   learningEventWriter?: (events: FridayLearningEventAppendInput[]) => void;
   idGenerator?: () => string;
   nowIso?: () => string;
+  resolveSessionMemoryNamespace?: (sessionKey: string) => Promise<string | undefined>;
   /**
    * Optional session or run identifier used to scope the memory namespace.
    * When provided, the default namespace "agent" becomes "agent:<sessionId>"
@@ -52,11 +54,23 @@ function normalizeMemoryNamespace(raw: string): string {
     return trimmed;
   }
   const normalized = trimmed.toLowerCase().replace(/[\s_]+/g, "-");
+  if (
+    normalized === "default"
+    || normalized === "user"
+    || normalized === "preference"
+    || normalized === "system"
+    || normalized === "agent"
+  ) {
+    return normalized;
+  }
   if (normalized === "user-preference" || normalized === "user-preferences" || normalized === "preferences") {
     return "preference";
   }
   if (normalized === "users") {
     return "user";
+  }
+  if (normalized === "memory" || normalized === "memories") {
+    return "default";
   }
   return trimmed;
 }
@@ -80,6 +94,152 @@ function sanitizeExpiresAt(raw: string | undefined, nowIso?: () => string): stri
   return raw;
 }
 
+const MEMORY_SEARCH_STOPWORDS = new Set([
+  "a",
+  "an",
+  "and",
+  "answer",
+  "do",
+  "i",
+  "in",
+  "is",
+  "me",
+  "my",
+  "of",
+  "one",
+  "please",
+  "sentence",
+  "the",
+  "to",
+  "what",
+]);
+
+const EXPLICIT_USER_FACT_STATEMENT_PATTERNS: ReadonlyArray<RegExp> = [
+  /\b(?:my codename is|my code phrase is|my passphrase is|my preferred name is|my name is)\b/i,
+  /\b(?:i prefer|i like|i want|i need|call me|refer to me as)\b/i,
+  /(我的代号是|我的口令是|我的名字是|我更喜欢|我喜欢|我想要|请叫我|称呼我为)/u,
+];
+
+function tokenizeMemorySearchText(raw: string): string[] {
+  return raw
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .split(/\s+/)
+    .map((token) => token.trim())
+    .filter((token) => token.length > 1 && !MEMORY_SEARCH_STOPWORDS.has(token));
+}
+
+function normalizeMemoryContentKey(raw: string): string {
+  return raw.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+function itemBelongsToSession(item: FridayMemoryItem, sessionId: string | undefined): boolean {
+  if (!sessionId) {
+    return false;
+  }
+  const sessionTag = `session:${sessionId}`;
+  return item.source === sessionTag || item.tags.includes(sessionTag);
+}
+
+function compareIsoTimestampsDescending(left: string, right: string): number {
+  const leftMs = Date.parse(left);
+  const rightMs = Date.parse(right);
+  if (!Number.isFinite(leftMs) && !Number.isFinite(rightMs)) {
+    return 0;
+  }
+  if (!Number.isFinite(leftMs)) {
+    return 1;
+  }
+  if (!Number.isFinite(rightMs)) {
+    return -1;
+  }
+  return rightMs - leftMs;
+}
+
+function shouldPreferMemoryCandidate(
+  next: FridayMemorySearchResult,
+  current: FridayMemorySearchResult,
+  sessionId: string | undefined,
+): boolean {
+  if (next.score !== current.score) {
+    return next.score > current.score;
+  }
+  const nextFromSession = itemBelongsToSession(next.item, sessionId);
+  const currentFromSession = itemBelongsToSession(current.item, sessionId);
+  if (nextFromSession !== currentFromSession) {
+    return nextFromSession;
+  }
+  return compareIsoTimestampsDescending(next.item.updatedAt, current.item.updatedAt) < 0;
+}
+
+function applyMemoryCandidateScoreAdjustments(
+  result: FridayMemorySearchResult,
+  sessionId: string | undefined,
+): FridayMemorySearchResult {
+  let score = result.score;
+  if (memoryContentLooksLikeUnknownPlaceholder(result.item.content)) {
+    score -= 1.5;
+  }
+  if (itemBelongsToSession(result.item, sessionId)) {
+    score += 0.1;
+  }
+  return {
+    ...result,
+    score,
+  };
+}
+
+async function buildSessionLexicalCandidates(params: {
+  deps: CreateFridayAgentMemoryToolsDeps;
+  sessionId: string;
+  namespace: string;
+  query: string;
+  limit: number;
+}): Promise<FridayMemorySearchResult[]> {
+  const queryTokens = tokenizeMemorySearchText(params.query);
+  if (queryTokens.length === 0) {
+    return [];
+  }
+
+  const items = await params.deps.memoryService.list({
+    namespace: params.namespace,
+    limit: Math.max(params.limit * 8, 50),
+  });
+
+  const ranked: FridayMemorySearchResult[] = [];
+  for (const item of items) {
+    const haystack = [
+      item.content,
+      item.tags.join(" "),
+      item.source,
+    ].join(" ").toLowerCase();
+    const overlapCount = queryTokens.filter((token) => haystack.includes(token)).length;
+    const fromCurrentSession = itemBelongsToSession(item, params.sessionId);
+    if (!fromCurrentSession && overlapCount === 0) {
+      continue;
+    }
+    const overlapScore = overlapCount / queryTokens.length;
+    const sessionBoost = fromCurrentSession ? 0.85 : 0;
+    ranked.push({
+      item,
+      score: 0.2 + overlapScore + sessionBoost,
+      ftsScore: 0,
+      semanticScore: 0,
+      matchedBy: ["substring"],
+      snippet: item.content.slice(0, 200),
+    });
+  }
+
+  ranked.sort((left, right) => {
+    if (left.score !== right.score) {
+      return right.score - left.score;
+    }
+    return compareIsoTimestampsDescending(left.item.updatedAt, right.item.updatedAt);
+  });
+
+  return ranked.slice(0, Math.max(params.limit * 2, params.limit));
+}
+
 function readExplicitNamespace(args: Record<string, unknown>): string | undefined {
   const rawNamespace = readStringParam(args, "namespace");
   if (!rawNamespace) {
@@ -89,13 +249,29 @@ function readExplicitNamespace(args: Record<string, unknown>): string | undefine
   return normalized.trim().length > 0 ? normalized : undefined;
 }
 
+function namespaceShouldOverlaySessionMemory(namespace: string | undefined): boolean {
+  if (!namespace) {
+    return false;
+  }
+  const normalized = normalizeMemoryNamespace(namespace);
+  return normalized === "user"
+    || normalized === "preference"
+    || normalized === "default"
+    || normalized === "system";
+}
+
 function resolveSessionIdFromArgs(
   args: Record<string, unknown>,
   fallback: string | undefined,
+  signal: AbortSignal,
 ): string | undefined {
   const fromRuntime = args["__sessionId"];
   if (typeof fromRuntime === "string" && fromRuntime.trim().length > 0) {
     return fromRuntime;
+  }
+  const contextSessionKey = getFridayAgentToolExecutionContext(signal)?.sessionKey?.trim();
+  if (contextSessionKey && contextSessionKey.length > 0) {
+    return contextSessionKey;
   }
   return fallback;
 }
@@ -111,6 +287,28 @@ function shouldIncludeLearnedFacts(namespace: string | undefined): boolean {
     || normalized === "agent";
 }
 
+function taskPromptLooksLikeQuestion(taskPrompt: string | undefined): boolean {
+  if (!taskPrompt || taskPrompt.trim().length === 0) {
+    return false;
+  }
+  return /^\s*(?:what|which|who|can|could|would|do|did|does|is|are)\b/i.test(taskPrompt)
+    || /^\s*(?:什么|哪个|谁|可以|能不能|是否|是不是)/u.test(taskPrompt)
+    || taskPrompt.includes("?");
+}
+
+function taskPromptExplicitlyStatesUserFact(taskPrompt: string | undefined): boolean {
+  if (!taskPrompt || taskPrompt.trim().length === 0) {
+    return false;
+  }
+  return EXPLICIT_USER_FACT_STATEMENT_PATTERNS.some((pattern) => pattern.test(taskPrompt));
+}
+
+function memoryContentLooksLikeUnknownPlaceholder(content: string): boolean {
+  return /\b(?:unknown|not specified|unspecified|not provided|currently unknown)\b/i.test(content)
+    || /\b(?:not defined|undefined|user-defined)\b/i.test(content)
+    || /(未知|未提供|未说明|不清楚)/u.test(content);
+}
+
 function resolvePrincipalId(
   args: Record<string, unknown>,
   signal: AbortSignal,
@@ -122,6 +320,28 @@ function resolvePrincipalId(
   const context = getFridayAgentToolExecutionContext(signal);
   const principalId = context?.principalId?.trim();
   return principalId && principalId.length > 0 ? principalId : undefined;
+}
+
+async function resolveImplicitSessionNamespace(params: {
+  deps: CreateFridayAgentMemoryToolsDeps;
+  explicitNamespace: string | undefined;
+  sessionId: string | undefined;
+}): Promise<string | undefined> {
+  if (
+    (params.explicitNamespace && !namespaceShouldOverlaySessionMemory(params.explicitNamespace))
+    || !params.sessionId
+    || !params.deps.resolveSessionMemoryNamespace
+  ) {
+    return undefined;
+  }
+  try {
+    const namespace = await params.deps.resolveSessionMemoryNamespace(params.sessionId);
+    return typeof namespace === "string" && namespace.trim().length > 0
+      ? namespace.trim()
+      : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function extractStoredPreferenceValue(input: {
@@ -238,23 +458,82 @@ function createMemorySearchTool(
       args: Record<string, unknown>,
       signal: AbortSignal,
     ): Promise<FridayAgentToolResult> {
-      const sessionId = resolveSessionIdFromArgs(args, deps.sessionId);
+      const sessionId = resolveSessionIdFromArgs(args, deps.sessionId, signal);
       const principalId = resolvePrincipalId(args, signal);
       const query = readStringParam(args, "query", { required: true });
       const explicitNamespace = readExplicitNamespace(args);
+      const implicitSessionNamespace = await resolveImplicitSessionNamespace({
+        deps,
+        explicitNamespace,
+        sessionId,
+      });
       const limit = readNumberParam(args, "limit", { integer: true }) ?? 10;
+      const scopedNamespace =
+        explicitNamespace && implicitSessionNamespace && namespaceShouldOverlaySessionMemory(explicitNamespace)
+          ? [explicitNamespace, implicitSessionNamespace]
+          : explicitNamespace ?? implicitSessionNamespace;
 
       try {
-        const results = await deps.memoryService.search(query, {
-          namespace: explicitNamespace,
-          limit,
-        });
+        const scopedResults = scopedNamespace
+          ? await deps.memoryService.search(query, {
+            namespace: scopedNamespace,
+            limit,
+          })
+          : [];
+        const shouldUseSessionFallback =
+          Boolean(implicitSessionNamespace && sessionId)
+          && (
+            !explicitNamespace
+            || namespaceShouldOverlaySessionMemory(explicitNamespace)
+            || scopedResults.length === 0
+          );
+        const sessionLexicalCandidates =
+          shouldUseSessionFallback && implicitSessionNamespace && sessionId
+            ? await buildSessionLexicalCandidates({
+              deps,
+              sessionId,
+              namespace: implicitSessionNamespace,
+              query,
+              limit,
+            })
+            : [];
+        const fallbackResults = explicitNamespace
+          ? scopedResults.length > 0
+            ? scopedResults
+            : await deps.memoryService.search(query, {
+              ...(implicitSessionNamespace ? { namespace: implicitSessionNamespace } : {}),
+              limit: Math.max(limit * 2, limit),
+            })
+          : await deps.memoryService.search(query, {
+            limit: implicitSessionNamespace ? Math.max(limit * 2, limit) : limit,
+          });
+        const dedupedResults = (() => {
+          const merged = [...scopedResults, ...sessionLexicalCandidates, ...fallbackResults];
+          const seen = new Set<string>();
+          const itemsByContent = new Map<string, FridayMemorySearchResult>();
+          for (const result of merged) {
+            if (seen.has(result.item.id)) {
+              continue;
+            }
+            seen.add(result.item.id);
+            const boostedResult = scopedResults.some((candidate) => candidate.item.id === result.item.id)
+              ? { ...result, score: result.score + 1 }
+              : result;
+            const adjustedResult = applyMemoryCandidateScoreAdjustments(boostedResult, sessionId);
+            const contentKey = normalizeMemoryContentKey(boostedResult.item.content);
+            const existing = itemsByContent.get(contentKey);
+            if (!existing || shouldPreferMemoryCandidate(adjustedResult, existing, sessionId)) {
+              itemsByContent.set(contentKey, adjustedResult);
+            }
+          }
+          return [...itemsByContent.values()];
+        })();
         const learnedResults = principalId && deps.listLearnedFacts && shouldIncludeLearnedFacts(explicitNamespace)
           ? deps.listLearnedFacts({ userId: principalId, limit })
             .filter((fact) => matchesLearnedFactQuery(fact, query))
             .map((fact) => toLearnedFactSearchResult(fact, query))
           : [];
-        const combined = [...results, ...learnedResults]
+        const combined = [...dedupedResults, ...learnedResults]
           .sort((a, b) => b.score - a.score)
           .slice(0, limit);
 
@@ -305,7 +584,7 @@ function createMemoryStoreTool(
       args: Record<string, unknown>,
       signal: AbortSignal,
     ): Promise<FridayAgentToolResult> {
-      const sessionId = resolveSessionIdFromArgs(args, deps.sessionId);
+      const sessionId = resolveSessionIdFromArgs(args, deps.sessionId, signal);
       const content = readStringParam(args, "content", { required: true });
       const explicitNamespace = readExplicitNamespace(args);
       const namespace = explicitNamespace ?? scopedNamespace("agent", sessionId);
@@ -316,6 +595,32 @@ function createMemoryStoreTool(
         Array.isArray(rawTags)
           ? rawTags.filter((t): t is string => typeof t === "string")
           : [];
+      const executionContext = getFridayAgentToolExecutionContext(signal);
+
+      const storingUserFacingMemory =
+        namespace === "default"
+        || namespace === "user"
+        || namespace === "preference"
+        || tags.some((tag) => normalizePreferenceTag(tag) === "preference");
+
+      if (
+        storingUserFacingMemory
+        && !taskPromptExplicitlyStatesUserFact(executionContext?.taskPrompt)
+      ) {
+        return errorResult(
+          "Memory store rejected: do not persist user memory unless the current user message explicitly states that fact or preference.",
+        );
+      }
+
+      if (
+        storingUserFacingMemory
+        && taskPromptLooksLikeQuestion(executionContext?.taskPrompt)
+        && memoryContentLooksLikeUnknownPlaceholder(content)
+      ) {
+        return errorResult(
+          "Memory store rejected: do not persist unknown placeholder facts for user memory from a question-only prompt.",
+        );
+      }
 
       try {
         // source is always "agent" to label the origin of stored items

--- a/src/agent/tools/friday-agent-tool-registry.ts
+++ b/src/agent/tools/friday-agent-tool-registry.ts
@@ -180,6 +180,9 @@ export function createFridayAgentToolRegistry(
         learningEventWriter: options.learningEventWriter,
         idGenerator: options.idGenerator,
         nowIso: options.nowIso,
+        resolveSessionMemoryNamespace: options.sessionService
+          ? async (sessionKey) => options.sessionService?.getSessionMemoryNamespace(sessionKey)
+          : undefined,
       }),
     );
   }

--- a/src/api/http/routes/friday-setup-routes.ts
+++ b/src/api/http/routes/friday-setup-routes.ts
@@ -220,7 +220,7 @@ async function fetchOpenAiModels(baseUrl: string, apiKey: string, ssrf?: { allow
   );
 
   // Preferred order
-  const preferred = ["gpt-4o", "gpt-4o-mini", "gpt-4-turbo", "o4-mini", "o3-mini", "o1-mini"];
+  const preferred = ["gpt-4o-mini", "gpt-4o", "gpt-4-turbo", "o4-mini", "o3-mini", "o1-mini"];
   const defaultModel = preferred.find((m) => chatModels.includes(m));
 
   chatModels.sort((a, b) => {
@@ -372,6 +372,7 @@ export interface FridaySetupRoutesDeps {
   runningPort: number;
   /** Allow loopback/private network addresses for self-hosted deployments using local providers. */
   allowPrivateNetwork?: boolean;
+  getLiveChannelCount?: () => number;
 }
 
 // ─── Factory ───
@@ -414,7 +415,7 @@ export function createFridaySetupRoutes(
         const providers = await deps.providerService.listProviders();
         const skills = deps.skillRegistry.list();
 
-        const channelCount = (() => {
+        const persistedChannelCount = (() => {
           try {
             const parsed = JSON.parse(state.channels_json);
             if (!Array.isArray(parsed)) return 0;
@@ -424,10 +425,20 @@ export function createFridaySetupRoutes(
               (entry as { enabled?: unknown }).enabled === true,
             ).length;
           } catch (err) {
-    console.warn("[friday][setup-routes] operation failed:", err instanceof Error ? err.message : String(err));
+            console.warn("[friday][setup-routes] operation failed:", err instanceof Error ? err.message : String(err));
             return 0;
           }
         })();
+        const liveChannelCount = (() => {
+          try {
+            const count = deps.getLiveChannelCount?.();
+            return Number.isFinite(count) ? Math.max(0, Number(count)) : 0;
+          } catch (err) {
+            console.warn("[friday][setup-routes] operation failed:", err instanceof Error ? err.message : String(err));
+            return 0;
+          }
+        })();
+        const channelCount = Math.max(persistedChannelCount, liveChannelCount);
 
         const host = deps.runningHost ?? state.network_host;
         const port = deps.runningPort ?? state.network_port;

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -2067,6 +2067,7 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
       runningHost: deps.serverHost ?? "127.0.0.1",
       runningPort: deps.serverPort ?? 3141,
       allowPrivateNetwork: deps.allowPrivateNetwork,
+      getLiveChannelCount: () => deps.channels?.registry.listViews().length ?? 0,
     })) {
       routes.register(route);
     }

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -50,9 +50,10 @@ import {
   decryptSecret,
   getFridayProviderPreset,
   getMasterKey,
+  normalizeFridayProviderSupportedModels,
   resolveFridayRoutingStabilityWarning,
 } from "#providers";
-import type { FridayEncryptedEnvelope, FridayProviderApi, FridayProviderKind, FridayProviderService } from "#providers";
+import type { FridayEncryptedEnvelope, FridayProviderApi, FridayProviderKind, FridayProviderProfile, FridayProviderService } from "#providers";
 import { createFridayProviderContextCompactor, createFridayProviderContextPruner, createFridayProviderTokenEstimator } from "#providers";
 import { FridaySkillRegistryImpl, safeParseFridaySkillManifestV2 } from "#skills";
 import { createFridaySkillExecutor } from "#skills";
@@ -418,10 +419,11 @@ const ENV_PROVIDER_MAP: ReadonlyArray<{
   envVar: string;
   kind: FridayProviderKind;
   defaultModel: string;
+  supportedModels?: string[];
 }> = [
   { envVar: "FRIDAY_ANTHROPIC_API_KEY", kind: "anthropic", defaultModel: "claude-sonnet-4-20250514" },
   { envVar: "ANTHROPIC_API_KEY", kind: "anthropic", defaultModel: "claude-sonnet-4-20250514" },
-  { envVar: "OPENAI_API_KEY", kind: "openai", defaultModel: "gpt-4o" },
+  { envVar: "OPENAI_API_KEY", kind: "openai", defaultModel: "gpt-4o-mini", supportedModels: ["gpt-4o-mini", "gpt-4o"] },
   { envVar: "GOOGLE_API_KEY", kind: "google", defaultModel: "gemini-2.0-flash" },
   { envVar: "OPENROUTER_API_KEY", kind: "openrouter", defaultModel: "anthropic/claude-sonnet-4" },
   { envVar: "GROQ_API_KEY", kind: "groq", defaultModel: "llama-3.3-70b-versatile" },
@@ -431,6 +433,59 @@ const ENV_PROVIDER_MAP: ReadonlyArray<{
 
 /** Routing priority: anthropic first, then openai, then detection order. */
 const ROUTING_PRIORITY: readonly FridayProviderKind[] = ["anthropic", "openai"];
+const STABLE_OPENAI_DEFAULT_MODEL = "gpt-4o-mini";
+const STABLE_OPENAI_SUPPORTED_MODELS = [STABLE_OPENAI_DEFAULT_MODEL, "gpt-4o"] as const;
+
+function isLegacyAutoDetectedOpenAiProvider(provider: FridayProviderProfile): boolean {
+  if (provider.kind !== "openai") {
+    return false;
+  }
+  if (provider.name !== "openai (auto-detected)") {
+    return false;
+  }
+  if (provider.config.keySource.kind !== "env-ref" || provider.config.keySource.envVar !== "OPENAI_API_KEY") {
+    return false;
+  }
+
+  const supportedModels = normalizeFridayProviderSupportedModels(provider.config.supportedModels);
+  return provider.defaultModel === "gpt-4o" && supportedModels.length === 1 && supportedModels[0] === "gpt-4o";
+}
+
+async function repairLegacyAutoDetectedOpenAiProviders(
+  providerService: FridayProviderService,
+): Promise<string[]> {
+  const [providers, routing] = await Promise.all([
+    providerService.listProviders(),
+    providerService.getRoutingConfig(),
+  ]);
+  const legacyProviders = providers.filter(isLegacyAutoDetectedOpenAiProvider);
+
+  if (legacyProviders.length === 0) {
+    return [];
+  }
+
+  const repairedProviderIds: string[] = [];
+  for (const provider of legacyProviders) {
+    await providerService.updateProvider(provider.id, {
+      supportedModels: [...STABLE_OPENAI_SUPPORTED_MODELS],
+      defaultModel: STABLE_OPENAI_DEFAULT_MODEL,
+      validateOnSave: false,
+    });
+    repairedProviderIds.push(provider.id);
+  }
+
+  if (
+    repairedProviderIds.includes(routing.defaultProviderId) &&
+    routing.defaultModel === "gpt-4o"
+  ) {
+    await providerService.setRoutingConfig({
+      ...routing,
+      defaultModel: STABLE_OPENAI_DEFAULT_MODEL,
+    });
+  }
+
+  return repairedProviderIds;
+}
 
 async function autoDetectProvidersFromEnv(
   providerService: FridayProviderService,
@@ -460,7 +515,7 @@ async function autoDetectProvidersFromEnv(
         api: preset.api,
         authMode: preset.authMode,
         apiKey: `$${entry.envVar}`,
-        supportedModels: [entry.defaultModel],
+        supportedModels: entry.supportedModels ?? [entry.defaultModel],
         defaultModel: entry.defaultModel,
         validateOnSave: false,
       });
@@ -6072,6 +6127,12 @@ export async function createFridayHub(
         if (autoDetected.length > 0) {
           console.log(
             `[friday] Auto-detected ${String(autoDetected.length)} provider(s) from environment: ${autoDetected.map((p) => p.kind).join(", ")}`,
+          );
+        }
+        const repairedLegacyProviders = await repairLegacyAutoDetectedOpenAiProviders(providerService);
+        if (repairedLegacyProviders.length > 0) {
+          console.log(
+            `[friday] Repaired ${String(repairedLegacyProviders.length)} legacy auto-detected OpenAI provider(s) to ${STABLE_OPENAI_DEFAULT_MODEL}.`,
           );
         }
       }

--- a/src/providers/model/friday-provider-templates.ts
+++ b/src/providers/model/friday-provider-templates.ts
@@ -28,9 +28,9 @@ const TEMPLATE_META: Partial<Record<FridayProviderKind, FridayProviderTemplateMe
     tier: "official",
     status: "ready",
     modelDefaults: {
-      recommended: "gpt-4o",
-      fallback: "gpt-4o-mini",
-      examples: ["gpt-4o", "gpt-4o-mini", "o4-mini"],
+      recommended: "gpt-4o-mini",
+      fallback: "gpt-4o",
+      examples: ["gpt-4o-mini", "gpt-4o", "o4-mini"],
     },
     reasoningHints: [
       "Use the recommended fallback model when latency or budget matters.",

--- a/src/sessions/services/friday-session-memory-extraction-llm-client.ts
+++ b/src/sessions/services/friday-session-memory-extraction-llm-client.ts
@@ -48,6 +48,8 @@ Rules:
 - Use "kind" to classify: "fact", "decision", "preference", or "action_item".
 - Reference the source message IDs that contributed to each item.
 - Content should be concise but complete enough to be useful without the original conversation.
+- Preserve the exact user-stated value for names, codenames, passphrases, labels, and stylistic preferences when those specifics matter.
+- Do not generalize a concrete preference into a broader summary. For example, if the user specifies a release-note style, keep that wording instead of replacing it with something vague like "concise release notes."
 - Do not extract trivial greetings, acknowledgments, or filler.
 - If there is nothing meaningful to extract, return an empty items array.
 

--- a/src/skills/converter/discovery/friday-local-skill-scanner.ts
+++ b/src/skills/converter/discovery/friday-local-skill-scanner.ts
@@ -8,7 +8,7 @@
  */
 
 import { createHash } from "node:crypto";
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, extname, join, resolve } from "node:path";
 
@@ -43,6 +43,19 @@ function titleCase(raw: string): string {
 
 function makeId(absolutePath: string): string {
   return createHash("sha256").update(absolutePath).digest("hex").slice(0, 16);
+}
+
+function canonicalPath(path: string): string {
+  const resolved = (() => {
+    try {
+      return realpathSync.native(path);
+    } catch {
+      return resolve(path);
+    }
+  })();
+  return process.platform === "darwin" || process.platform === "win32"
+    ? resolved.toLowerCase()
+    : resolved;
 }
 
 function extractDescriptionMd(content: string): string {
@@ -112,6 +125,7 @@ function scanFlatDir(
     const fullPath = join(resolved, entry);
     const stat = safeStat(fullPath);
     if (!stat?.isFile) continue;
+    if (stat.size <= 0) continue;
 
     const content = safeReadText(fullPath);
     if (jsonRequiredKeys && !jsonHasKeys(content, jsonRequiredKeys)) continue;
@@ -140,6 +154,9 @@ function scanSkillSubdirs(
   parentDir: string,
   tool: LocalSkillSourceTool,
   converterHint: string,
+  options?: {
+    sourcePathMode?: "skill-file" | "directory";
+  },
 ): LocalSkillScanItem[] {
   const items: LocalSkillScanItem[] = [];
   const resolved = resolve(parentDir);
@@ -160,10 +177,10 @@ function scanSkillSubdirs(
       const description = extractDescriptionMd(content);
 
       items.push({
-        id: makeId(skillPath),
+        id: makeId(options?.sourcePathMode === "directory" ? subdirPath : skillPath),
         name: titleCase(subdir),
         sourceTool: tool,
-        sourcePath: skillPath,
+        sourcePath: options?.sourcePathMode === "directory" ? subdirPath : skillPath,
         description,
         convertible: true,
         converterHint,
@@ -183,11 +200,13 @@ function scanSkillSubdirs(
 function scanProjectSkills(projectsDir: string): LocalSkillScanItem[] {
   const items: LocalSkillScanItem[] = [];
   if (!existsSync(projectsDir)) return items;
+  const currentWorkspace = canonicalPath(process.cwd());
 
   for (const project of safeReadDir(projectsDir)) {
     const projectPath = join(projectsDir, project);
     const projectStat = safeStat(projectPath);
     if (!projectStat?.isDir) continue;
+    if (canonicalPath(projectPath) === currentWorkspace) continue;
 
     // Check <project>/skills/
     items.push(...scanSkillSubdirs(join(projectPath, "skills"), "openclaw", "clawdbot-skill-md"));
@@ -199,7 +218,7 @@ function scanProjectSkills(projectsDir: string): LocalSkillScanItem[] {
     items.push(...scanSkillSubdirs(join(projectPath, "extensions"), "openclaw", "clawdbot-skill-md"));
 
     // Check <project>/managed-skills/
-    items.push(...scanSkillSubdirs(join(projectPath, "managed-skills"), "friday", "friday-package"));
+    items.push(...scanSkillSubdirs(join(projectPath, "managed-skills"), "friday", "friday-package", { sourcePathMode: "directory" }));
   }
   return items;
 }
@@ -259,19 +278,16 @@ export function scanLocalSkills(): LocalSkillScanResult {
   }
 
   // ── 6. Current working directory skills ──
-  const cwdSkills = scanSkillSubdirs(join(cwd, "skills"), "friday", "friday-package");
+  const cwdSkills = scanSkillSubdirs(join(cwd, "skills"), "openclaw", "clawdbot-skill-md");
   if (cwdSkills.length > 0) directoriesScanned.push(join(cwd, "skills"));
   allItems.push(...cwdSkills);
-
-  const cwdManagedSkills = scanSkillSubdirs(join(cwd, "managed-skills"), "friday", "friday-package");
-  if (cwdManagedSkills.length > 0) directoriesScanned.push(join(cwd, "managed-skills"));
-  allItems.push(...cwdManagedSkills);
 
   // ── Dedup by sourcePath ──
   const seen = new Set<string>();
   const dedupedItems = allItems.filter((item) => {
-    if (seen.has(item.sourcePath)) return false;
-    seen.add(item.sourcePath);
+    const dedupeKey = canonicalPath(item.sourcePath);
+    if (seen.has(dedupeKey)) return false;
+    seen.add(dedupeKey);
     return true;
   });
 

--- a/test/e2e/mock/_helpers/mock-env.ts
+++ b/test/e2e/mock/_helpers/mock-env.ts
@@ -268,13 +268,17 @@ export async function createMockHubEnv(opts?: {
   const stateDir = fs.mkdtempSync(
     path.join(os.tmpdir(), "friday-mock-e2e-"),
   );
+  const defaultSkillDirs = [
+    path.resolve(process.cwd(), "skills"),
+    path.join(stateDir, "managed-skills"),
+  ];
 
   // 2. Create hub
   let hub;
   try {
     hub = await createFridayHub({
       stateDir,
-      skillDirs: opts?.skillDirs ?? [],
+      skillDirs: opts?.skillDirs ?? defaultSkillDirs,
       port: 0,
       logRequests: false,
       channels: opts?.channels,

--- a/test/unit/agent/runtime/friday-agent-runtime.test.ts
+++ b/test/unit/agent/runtime/friday-agent-runtime.test.ts
@@ -2516,6 +2516,103 @@ describe("FridayAgentRuntime", () => {
     expect(result.response).toBe("Captain Friday");
   });
 
+  it("fills missing memory-recall fields with field-specific fallback searches before answering", async () => {
+    const memorySearchSpy = vi.fn();
+    const combinedMemorySearchTool: FridayAgentToolDefinition = {
+      name: "memory_search",
+      description: "Mock multi-field memory search tool",
+      parameters: {
+        properties: {
+          query: { type: "string" },
+          namespace: { type: "string" },
+          limit: { type: "number" },
+        },
+        required: ["query"],
+      },
+      async execute(args) {
+        memorySearchSpy(args);
+        const query = typeof args.query === "string" ? args.query : "";
+        if (query === "codename and release-note style") {
+          return {
+            content: JSON.stringify([
+              {
+                content: "User prefers release notes with verdict first and exactly two short bullets.",
+                score: 1.2,
+                metadata: { id: "pref-1", namespace: "user" },
+              },
+            ]),
+          };
+        }
+        if (query === "codename") {
+          return {
+            content: JSON.stringify([
+              {
+                content: "User's codename is cedar-bridge-42.",
+                score: 1.1,
+                metadata: { id: "code-1", namespace: "user" },
+              },
+            ]),
+          };
+        }
+        if (query === "release-note style") {
+          return {
+            content: JSON.stringify([
+              {
+                content: "User prefers release notes with verdict first and exactly two short bullets.",
+                score: 1.2,
+                metadata: { id: "pref-1", namespace: "user" },
+              },
+            ]),
+          };
+        }
+        return { content: "[]" };
+      },
+    };
+
+    const llmClient = createMockLlmClient([
+      [
+        {
+          type: "tool_use",
+          id: "call-1",
+          name: "memory_search",
+          input: { query: "codename and release-note style", limit: 5 },
+        },
+        { type: "message_end", stopReason: "tool_use", inputTokens: 10, outputTokens: 5 },
+      ],
+      [
+        { type: "text_delta", text: "You prefer release notes with verdict first and exactly two short bullets." },
+        { type: "message_end", stopReason: "end_turn", inputTokens: 8, outputTokens: 6 },
+      ],
+      [
+        { type: "message_end", stopReason: "end_turn", inputTokens: 1, outputTokens: 0 },
+      ],
+    ]);
+
+    const runtime = createFridayAgentRuntime({
+      db,
+      llmClient,
+      model: "test-model",
+      providerId: "test-provider",
+      systemPrompt: "You are a test agent.",
+      tools: [combinedMemorySearchTool],
+      eventEmitter: createFridayAgentEventEmitter(),
+      idGenerator,
+      nowIso: () => NOW,
+    });
+
+    const result = await runtime.executeRun({
+      task: "What is my codename and what release-note style do I prefer? Answer in one concise sentence.",
+    });
+
+    expect(result.status).toBe("completed");
+    expect(memorySearchSpy).toHaveBeenCalledTimes(2);
+    expect(memorySearchSpy.mock.calls[0]?.[0]).toMatchObject({ query: "codename and release-note style" });
+    expect(memorySearchSpy.mock.calls[1]?.[0]).toMatchObject({ query: "codename", namespace: "user", limit: 1 });
+    expect(result.response).toBe(
+      "Your codename is cedar-bridge-42, and you prefer release notes with verdict first and exactly two short bullets.",
+    );
+  });
+
   it("blocks app-launch tool calls for desktop content inspection tasks and retries with read-only evidence", async () => {
     const systemSpy = vi.fn();
     const llmClient = createMockLlmClient([

--- a/test/unit/agent/tools/friday-agent-feedback-tool.test.ts
+++ b/test/unit/agent/tools/friday-agent-feedback-tool.test.ts
@@ -38,7 +38,7 @@ describe("FridayAgentFeedbackTool", () => {
 
     const result = await tool.execute(
       { kind: "correction", field: "tone", value: "more formal", context: "was too casual" },
-      signal(),
+      signalWithTaskPrompt("That's wrong. Use a more formal tone instead; it was too casual."),
     );
 
     expect(learningEventWriter).toHaveBeenCalledOnce();
@@ -61,7 +61,7 @@ describe("FridayAgentFeedbackTool", () => {
 
     await tool.execute(
       { kind: "preference", field: "language", value: "Chinese" },
-      signal(),
+      signalWithTaskPrompt("I prefer Chinese for future replies."),
     );
 
     const event = written[0]![0]!;

--- a/test/unit/agent/tools/friday-agent-generator-tools.test.ts
+++ b/test/unit/agent/tools/friday-agent-generator-tools.test.ts
@@ -9,7 +9,7 @@ import type { FridayWorkflowGeneratorService } from "../../../../src/workflows/g
 
 describe("normalizeAgentRequestedModel", () => {
   it("maps provider-kind aliases to concrete default models", () => {
-    expect(normalizeAgentRequestedModel("openai")).toBe("gpt-4o");
+    expect(normalizeAgentRequestedModel("openai")).toBe("gpt-4o-mini");
     expect(normalizeAgentRequestedModel("anthropic")).toBe("claude-sonnet-4-20250514");
     expect(normalizeAgentRequestedModel("anthropic-messages")).toBe("claude-sonnet-4-20250514");
     expect(normalizeAgentRequestedModel("default")).toBeUndefined();
@@ -131,7 +131,7 @@ describe("generator tools", () => {
 
     expect(generatorService.startSession).toHaveBeenCalledWith(
       expect.objectContaining({
-        requestedModel: "gpt-4o",
+        requestedModel: "gpt-4o-mini",
       }),
     );
   });

--- a/ui/src/components/console/shell/right-rail-slots/packs.tsx
+++ b/ui/src/components/console/shell/right-rail-slots/packs.tsx
@@ -1,12 +1,11 @@
 import { NavLink } from "react-router-dom";
-import { ChevronRight, Globe2, Layers, Package } from "lucide-react";
+import { ChevronRight, Layers, Package, Sparkles } from "lucide-react";
 import { localize } from "@/lib/i18n/localized-text";
 import { useAppLocale } from "@/providers/locale-provider";
 
 /**
- * Right-rail preset for `/packs`. Phase 1 surfaces the cross-border quickstart
- * plus deep links into the wider pack library; Phase 2 swaps the static rows
- * for a `usePackInstallations()` query when available.
+ * Right-rail preset for `/packs`. Keep this aligned with the user-created-task
+ * flow instead of re-surfacing hidden built-in packs.
  */
 export function PacksRightRailSlot() {
   const { locale } = useAppLocale();
@@ -18,34 +17,34 @@ export function PacksRightRailSlot() {
           className="text-[10px] font-semibold uppercase tracking-[0.16em]"
           style={{ color: "var(--ink-300)" }}
         >
-          {localize(locale, "引导包", "Pack library")}
+          {localize(locale, "用户任务", "User tasks")}
         </p>
         <h3
           className="mt-1 text-sm font-semibold"
           style={{ color: "var(--ink-900)", fontFamily: "var(--font-serif-sc)" }}
         >
-          {localize(locale, "按行业启动 Friday", "Launch by industry")}
+          {localize(locale, "把自创任务接成真实动作", "Turn custom tasks into live actions")}
         </h3>
       </header>
 
       <ul className="flex flex-col gap-2">
         <PackRow
-          to="/packs/cross-border/setup"
-          Icon={Globe2}
-          title={localize(locale, "跨境经营引导包", "Cross-border operating pack")}
-          hint={localize(locale, "零售 / 品牌 / 小卖家分流", "Retail · brand · seller flows")}
-        />
-        <PackRow
           to="/packs"
           Icon={Package}
-          title={localize(locale, "全部引导包", "All packs")}
-          hint={localize(locale, "浏览行业与任务模板", "Browse industry & task templates")}
+          title={localize(locale, "创建或整理任务", "Create or organize tasks")}
+          hint={localize(locale, "只显示你自己的任务定义", "Only show your own task definitions")}
+        />
+        <PackRow
+          to="/chat"
+          Icon={Sparkles}
+          title={localize(locale, "去聊天启动", "Launch from chat")}
+          hint={localize(locale, "直接把当前任务接到真实会话和 run", "Connect the task straight into a live session and run")}
         />
         <PackRow
           to="/skills"
           Icon={Layers}
           title={localize(locale, "相关技能", "Related skills")}
-          hint={localize(locale, "查看 Pack 绑定的技能", "Skills bundled with packs")}
+          hint={localize(locale, "查看任务现在能调用哪些能力", "See which capabilities your tasks can call right now")}
         />
       </ul>
     </div>
@@ -54,7 +53,7 @@ export function PacksRightRailSlot() {
 
 function PackRow(props: {
   to: string;
-  Icon: typeof Globe2;
+  Icon: typeof Package;
   title: string;
   hint: string;
 }) {

--- a/ui/src/components/core/skill-scanner-panel.tsx
+++ b/ui/src/components/core/skill-scanner-panel.tsx
@@ -26,7 +26,7 @@ const TOP_N = 20;
 const SOURCE_FILTERS = [
   { key: "all", zh: "全部", en: "All" },
   { key: "claude-code", zh: "Claude Code", en: "Claude Code" },
-  { key: "clawdbot", zh: "OpenClaw", en: "OpenClaw" },
+  { key: "openclaw", zh: "OpenClaw", en: "OpenClaw" },
   { key: "codex", zh: "Codex", en: "Codex" },
   { key: "friday", zh: "Friday", en: "Friday" },
 ] as const;
@@ -39,7 +39,7 @@ function sourceToolTone(tool: LocalSkillSourceTool): "neutral" | "success" | "wa
     case "cursor": return "neutral";
     case "n8n": return "warning";
     case "codex": return "success";
-    case "clawdbot": return "neutral";
+    case "openclaw": return "neutral";
     case "friday": return "success";
     default: return "neutral";
   }
@@ -51,7 +51,7 @@ function sourceToolLabel(tool: LocalSkillSourceTool): string {
     case "cursor": return "Cursor";
     case "n8n": return "n8n";
     case "codex": return "Codex";
-    case "clawdbot": return "ClawdBot";
+    case "openclaw": return "OpenClaw";
     case "friday": return "Friday";
     default: return "Unknown";
   }
@@ -186,16 +186,17 @@ export function SkillScannerPanel({ open, onClose }: SkillScannerPanelProps) {
   }, []);
 
   const toggleAllLocal = useCallback(() => {
+    const selectableIds = scanItems.filter((item) => item.convertible).map((item) => item.id);
     setSelectedLocalIds((prev) => {
-      if (prev.size === scanItems.length) return new Set();
-      return new Set(scanItems.map((i) => i.id));
+      if (prev.size === selectableIds.length && selectableIds.length > 0) return new Set();
+      return new Set(selectableIds);
     });
   }, [scanItems]);
 
   function handleImport() {
     if (activeTab !== "local") return;
     const items = scanItems
-      .filter((i) => selectedLocalIds.has(i.id))
+      .filter((i) => selectedLocalIds.has(i.id) && i.convertible)
       .map((i) => ({ sourcePath: i.sourcePath, formatHint: i.converterHint }));
     if (items.length === 0) return;
     importMutation.mutate(items);
@@ -274,7 +275,7 @@ export function SkillScannerPanel({ open, onClose }: SkillScannerPanelProps) {
             <label className="flex items-center gap-2 text-sm text-[color:var(--color-text-secondary)]">
               <input
                 type="checkbox"
-                checked={selectedLocalIds.size === scanItems.length && scanItems.length > 0}
+                checked={selectedLocalIds.size === scanItems.filter((item) => item.convertible).length && scanItems.some((item) => item.convertible)}
                 onChange={toggleAllLocal}
                 className="h-4 w-4 rounded border-[color:var(--color-border-soft)] accent-[color:var(--color-accent)]"
               />
@@ -286,11 +287,16 @@ export function SkillScannerPanel({ open, onClose }: SkillScannerPanelProps) {
               {visibleLocalItems.map((item) => (
                 <label
                   key={item.id}
-                  className="flex cursor-pointer items-start gap-3 rounded-xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] p-3 transition hover:border-[color:var(--color-border-strong)]"
+                  className={`flex items-start gap-3 rounded-xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] p-3 transition ${
+                    item.convertible
+                      ? "cursor-pointer hover:border-[color:var(--color-border-strong)]"
+                      : "cursor-not-allowed opacity-65"
+                  }`}
                 >
                   <input
                     type="checkbox"
                     checked={selectedLocalIds.has(item.id)}
+                    disabled={!item.convertible}
                     onChange={() => toggleLocalItem(item.id)}
                     className="mt-0.5 h-4 w-4 shrink-0 rounded border-[color:var(--color-border-soft)] accent-[color:var(--color-accent)]"
                   />
@@ -304,7 +310,9 @@ export function SkillScannerPanel({ open, onClose }: SkillScannerPanelProps) {
                       </StatusPill>
                     </div>
                     <p className="mt-0.5 line-clamp-1 text-xs text-[color:var(--color-text-tertiary)]">
-                      {item.description}
+                      {item.description || (item.convertible
+                        ? localize(locale, "可导入到 Friday。", "Can be imported into Friday.")
+                        : localize(locale, "这个条目已经在当前 Friday 工作区里，不需要再次导入。", "This entry already belongs to the current Friday workspace and does not need to be imported again."))}
                     </p>
                   </div>
                   <span className="shrink-0 text-xs text-[color:var(--color-text-tertiary)]">

--- a/ui/src/lib/api/scan-migrate.ts
+++ b/ui/src/lib/api/scan-migrate.ts
@@ -2,7 +2,7 @@ import { apiClient } from "./client";
 
 // ─── Types ───
 
-export type LocalSkillSourceTool = "claude-code" | "cursor" | "n8n" | "codex" | "clawdbot" | "friday" | "unknown";
+export type LocalSkillSourceTool = "claude-code" | "cursor" | "n8n" | "codex" | "openclaw" | "friday" | "unknown";
 
 export interface LocalSkillScanItem {
   id: string;

--- a/ui/src/lib/routes/agent-os-nav.ts
+++ b/ui/src/lib/routes/agent-os-nav.ts
@@ -22,7 +22,7 @@ export const AGENT_OS_NAV_PRIMARY: AgentOsNavItem[] = [
   {
     label: localizedText("行业与任务", "Industry & Tasks"),
     path: "/packs",
-    description: localizedText("浏览 Friday 自带的行业包和任务入口，并决定哪些加入首页。", "Browse built-in industry packs and task entries, then decide what appears on home."),
+    description: localizedText("管理你自创的任务定义，并把真实运行入口固定到首页。", "Manage your custom task definitions and pin live execution entry points back to home."),
   },
   {
     label: localizedText("助手", "Assistant"),

--- a/ui/src/routes/home-page.tsx
+++ b/ui/src/routes/home-page.tsx
@@ -30,7 +30,7 @@ import { recordPageVisit } from "@/lib/home/intent-engine";
 import { localize } from "@/lib/i18n/localized-text";
 import { findPackRuns } from "@/lib/packs/pack-assistant-receipt";
 import { buildPackAssistantHref, buildPackChatHref, buildPackFlowHref } from "@/lib/packs/pack-links";
-import { getAllPacks, getPackById } from "@/lib/packs/pack-registry";
+import { buildCustomPackId, getPackById } from "@/lib/packs/pack-registry";
 import {
   describeRunHealth,
   displayRunPreview,
@@ -357,10 +357,24 @@ export function HomePage() {
     },
   ];
 
+  const userCreatedPacks = useMemo(
+    () => customPackInputs
+      .map((input, index) => {
+        const packId = buildCustomPackId(input, index);
+        return getPackById(packId, customPackInputs);
+      })
+      .filter((pack): pack is NonNullable<ReturnType<typeof getPackById>> => Boolean(pack)),
+    [customPackInputs],
+  );
   const pinnedPacks = pinnedPackIds
     .map((packId) => getPackById(packId, customPackInputs))
-    .filter((pack): pack is NonNullable<ReturnType<typeof getPackById>> => Boolean(pack));
-  const recommendedPacks = getAllPacks(customPackInputs)
+    .filter((pack): pack is NonNullable<ReturnType<typeof getPackById>> => {
+      if (!pack) {
+        return false;
+      }
+      return !pack.builtIn;
+    });
+  const recommendedPacks = userCreatedPacks
     .filter((pack) => !pinnedPackIds.includes(pack.id))
     .slice(0, 3);
   const selectedPack = selectedPackId ? getPackById(selectedPackId, customPackInputs) ?? null : null;
@@ -741,33 +755,48 @@ export function HomePage() {
         <div className="flex items-center justify-between gap-3">
           <div>
             <h3 className="text-2xl font-semibold text-[color:var(--color-text-primary)]" style={{ fontFamily: "var(--font-serif)" }}>
-              {localize(locale, "继续推进的行业与任务", "Packs to keep moving")}
+              {localize(locale, "继续推进的自创任务", "User Tasks to Keep Moving")}
             </h3>
             <p className="mt-1 text-sm text-[color:var(--color-text-secondary)]">
-              {localize(locale, "行业包还在，只是从首页主位退到控制台底部。动态链路没有丢。", "The packs still exist; they just moved out of the top slot. The live wiring stays intact.")}
+              {localize(locale, "首页这里只保留你自己创建的任务，不再把官方行业包重新露出来。真实运行链路保持不变。", "Home only keeps the tasks you created. Built-in packs stay hidden here while the live run wiring remains intact.")}
             </p>
           </div>
           <ActionButton tone="secondary" onClick={() => navigate("/packs")}>
             <Pin className="mr-2 h-4 w-4" />
-            {localize(locale, "管理首页入口", "Manage home packs")}
+            {localize(locale, "管理任务库", "Manage task library")}
           </ActionButton>
         </div>
 
         {pinnedPacks.length === 0 ? (
-          <ShellCard title={localize(locale, "先固定几个入口", "Pin a few entries first")}>
-            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-              {recommendedPacks.map((pack) => (
-                <PackCard
-                  key={pack.id}
-                  pack={pack}
-                  compact
-                  note={pack.productCopy ? localize(locale, pack.productCopy.resultSummary.zh, pack.productCopy.resultSummary.en) : undefined}
-                  onOpen={() => setSelectedPackId(pack.id)}
-                  onPin={() => pinPack(pack.id)}
-                />
-              ))}
-            </div>
-          </ShellCard>
+          recommendedPacks.length === 0 ? (
+            <ShellCard title={localize(locale, "还没有自创任务", "No user-created tasks yet")}>
+              <div className="space-y-3">
+                <p className="text-sm text-[color:var(--color-text-secondary)]">
+                  {localize(locale, "先去“行业与任务”页创建你的第一个任务，再把它固定回首页。", "Create your first task from the Packs page, then pin it back to home.")}
+                </p>
+                <div>
+                  <ActionButton tone="secondary" onClick={() => navigate("/packs")}>
+                    {localize(locale, "去创建任务", "Create a task")}
+                  </ActionButton>
+                </div>
+              </div>
+            </ShellCard>
+          ) : (
+            <ShellCard title={localize(locale, "先固定几个入口", "Pin a few entries first")}>
+              <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                {recommendedPacks.map((pack) => (
+                  <PackCard
+                    key={pack.id}
+                    pack={pack}
+                    compact
+                    note={pack.productCopy ? localize(locale, pack.productCopy.resultSummary.zh, pack.productCopy.resultSummary.en) : undefined}
+                    onOpen={() => setSelectedPackId(pack.id)}
+                    onPin={() => pinPack(pack.id)}
+                  />
+                ))}
+              </div>
+            </ShellCard>
+          )
         ) : (
           <div className={cn("grid gap-4 md:grid-cols-2", locale === "zh" && "xl:grid-cols-3")}>
             {pinnedPacks.map((pack) => {

--- a/ui/src/routes/setup-page.tsx
+++ b/ui/src/routes/setup-page.tsx
@@ -11,7 +11,7 @@ import { systemApi } from "@/lib/api/system";
 import { discoveryApi } from "@/lib/api/discovery";
 import type { DiscoveredProgram, IntegrationRecommendation } from "@/lib/api/discovery";
 import { scanMigrateApi } from "@/lib/api/scan-migrate";
-import type { LocalSkillScanItem } from "@/lib/api/scan-migrate";
+import type { BatchImportResult, LocalSkillScanItem } from "@/lib/api/scan-migrate";
 import { getIntegrationDescription } from "@/lib/discovery/integration-descriptions";
 import {
   FRIDAY_ASSISTANT_STARTER_TASKS,
@@ -178,6 +178,7 @@ export function SetupPage() {
   const [skillScanError, setSkillScanError] = useState<string | null>(null);
   const [selectedSkillPaths, setSelectedSkillPaths] = useState<Set<string>>(new Set());
   const [skillImporting, setSkillImporting] = useState(false);
+  const [skillImportResult, setSkillImportResult] = useState<BatchImportResult | null>(null);
   // ── Existing queries ──
 
   const { data: setupStatus } = useQuery({
@@ -477,12 +478,11 @@ export function SetupPage() {
 
       try {
         const result = await scanMigrateApi.scanLocal();
-        const sorted = [...result.items].sort(
-          (a, b) => new Date(b.modifiedAt).getTime() - new Date(a.modifiedAt).getTime(),
-        );
+        const sorted = [...result.items]
+          .filter((item) => item.convertible && item.sourceTool !== "friday")
+          .sort((a, b) => new Date(b.modifiedAt).getTime() - new Date(a.modifiedAt).getTime());
         setSkillScanItems(sorted.slice(0, 10));
-        // Pre-select all convertible items
-        setSelectedSkillPaths(new Set(sorted.slice(0, 10).filter((i) => i.convertible).map((i) => i.sourcePath)));
+        setSelectedSkillPaths(new Set(sorted.slice(0, 10).map((i) => i.sourcePath)));
         setSkillScanDone(true);
       } catch (error) {
         setSkillScanItems([]);
@@ -504,9 +504,11 @@ export function SetupPage() {
   async function handleSkillImport() {
     if (selectedSkillPaths.size === 0) return;
     setSkillImporting(true);
+    setSkillImportResult(null);
     try {
       const items = Array.from(selectedSkillPaths).map((sourcePath) => ({ sourcePath }));
       const result = await scanMigrateApi.importBatch(items);
+      setSkillImportResult(result);
       toast.success(
         localize(
           locale,
@@ -1072,6 +1074,23 @@ export function SetupPage() {
                           ? localize(locale, "导入中...", "Importing...")
                           : localize(locale, `导入选中 (${selectedSkillPaths.size})`, `Import Selected (${selectedSkillPaths.size})`)}
                       </ActionButton>
+                    </div>
+                  )}
+                  {(skillImportResult?.failedCount ?? 0) > 0 && (
+                    <div className="mt-4 space-y-2">
+                      {skillImportResult!.results.filter((entry) => !entry.success).map((entry) => (
+                        <div
+                          key={entry.sourcePath}
+                          className="rounded-2xl border border-[color:var(--color-border-strong)] bg-[color:var(--color-bg-contrast)] px-4 py-3 text-left"
+                        >
+                          <p className="text-sm font-medium text-[color:var(--color-text-primary)]">
+                            {entry.sourcePath.split("/").at(-2) ?? entry.sourcePath}
+                          </p>
+                          <p className="mt-1 text-xs leading-5 text-[color:var(--color-text-secondary)]">
+                            {entry.error ?? localize(locale, "导入失败，但后端没有返回更具体的原因。", "Import failed, but the backend did not return a more specific reason.")}
+                          </p>
+                        </div>
+                      ))}
                     </div>
                   )}
                 </>


### PR DESCRIPTION
## Summary
- stabilize Friday memory recall and explicit feedback persistence so recall questions retry only on real memory-search evidence
- tighten setup/home/custom-task skill wiring and provider defaults without reintroducing old built-in pack surfaces
- isolate mock hub browser E2E skill discovery from local managed-skill residue so bundled starter-skill tests run against the intended packaged skills

## Verification
- `npm test`
- `npm run release:verify:repo`

## Notes
- excludes generated runtime state and temporary managed-skill/report artifacts from the commit scope so this PR only carries product code and test fixes