### PR TITLE
Wire channel handoff into main chat

### DIFF
--- a/test/unit/ui/channel-handoff.test.ts
+++ b/test/unit/ui/channel-handoff.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { FridaySessionMessageRecord, FridaySessionRecord } from "../../../ui/src/lib/api/types";
+import {
+  buildChannelChatHandoffPayload,
+  buildChannelChatHandoffTaskPrompt,
+  clearPendingChannelChatHandoff,
+  readPendingChannelChatHandoff,
+  writePendingChannelChatHandoff,
+} from "../../../ui/src/lib/chat/channel-handoff";
+
+function makeSession(overrides: Partial<FridaySessionRecord> = {}): FridaySessionRecord {
+  return {
+    id: "session-1",
+    key: "channel:discord:123",
+    channel: "discord",
+    accountId: "default",
+    chatId: "123",
+    userId: "admin-001",
+    chatKind: "dm",
+    status: "active",
+    metadata: {
+      conversationFocus: {
+        currentTopicSummary: "需要继续处理 Discord 里的经营交接",
+      },
+    },
+    contextInputTokens: 0,
+    contextOutputTokens: 0,
+    contextTotalTokens: 0,
+    messageCount: 4,
+    createdAt: "2026-04-22T23:00:00.000Z",
+    updatedAt: "2026-04-22T23:10:00.000Z",
+    lastActivityAt: "2026-04-22T23:10:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeMessage(sequence: number, role: FridaySessionMessageRecord["role"], contentText: string): FridaySessionMessageRecord {
+  return {
+    id: `message-${sequence}`,
+    sessionId: "session-1",
+    sessionKey: "channel:discord:123",
+    sequence,
+    role,
+    content: contentText,
+    contentText,
+    tokenCount: 0,
+    metadata: {},
+    memoryExtractStatus: "pending",
+    occurredAt: `2026-04-22T23:1${sequence}:00.000Z`,
+    createdAt: `2026-04-22T23:1${sequence}:00.000Z`,
+    updatedAt: `2026-04-22T23:1${sequence}:00.000Z`,
+  };
+}
+
+function installSessionStorageMock() {
+  const store = new Map<string, string>();
+  const mock = {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    clear: () => {
+      store.clear();
+    },
+  };
+  vi.stubGlobal("sessionStorage", mock);
+  return mock;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("channel chat handoff helper", () => {
+  it("builds a payload with topic summary and recent excerpts", () => {
+    const payload = buildChannelChatHandoffPayload({
+      session: makeSession(),
+      displayName: "admin-001",
+      messages: [
+        makeMessage(1, "user", "先告诉我这条 Discord 会话里最重要的经营问题"),
+        makeMessage(2, "assistant", "目前最重要的问题是客服和图片质量交接没有闭环。"),
+        makeMessage(3, "user", "那把下一步动作列出来"),
+        makeMessage(4, "assistant", "可以，先做客服归因，再做图片和详情页修订。"),
+      ],
+      nowIso: () => "2026-04-22T23:20:00.000Z",
+    });
+
+    expect(payload.sourceSessionKey).toBe("channel:discord:123");
+    expect(payload.sourceDisplayName).toBe("admin-001");
+    expect(payload.topicSummary).toContain("经营交接");
+    expect(payload.latestUserMessage).toContain("下一步动作");
+    expect(payload.latestAssistantMessage).toContain("客服归因");
+    expect(payload.excerpts).toHaveLength(4);
+  });
+
+  it("builds a task prompt that keeps isolation explicit", () => {
+    const payload = buildChannelChatHandoffPayload({
+      session: makeSession(),
+      displayName: "admin-001",
+      messages: [
+        makeMessage(1, "user", "请继续这个 Discord 对话"),
+        makeMessage(2, "assistant", "好的，我会先整理经营交接摘要。"),
+      ],
+      nowIso: () => "2026-04-22T23:20:00.000Z",
+    });
+
+    const taskPrompt = buildChannelChatHandoffTaskPrompt(payload, "把它整理成主聊天里的行动计划", "zh");
+
+    expect(taskPrompt).toContain("这不是自动合并历史");
+    expect(taskPrompt).toContain("来源渠道: discord");
+    expect(taskPrompt).not.toContain("Recent anchors");
+    expect(taskPrompt).toContain("最近锚点:");
+    expect(taskPrompt).toContain("用户在主聊天里的当前请求");
+    expect(taskPrompt).toContain("行动计划");
+  });
+
+  it("round-trips pending handoff payloads through sessionStorage", () => {
+    installSessionStorageMock();
+
+    const payload = buildChannelChatHandoffPayload({
+      session: makeSession(),
+      displayName: "admin-001",
+      messages: [makeMessage(1, "user", "hello"), makeMessage(2, "assistant", "world")],
+      nowIso: () => "2026-04-22T23:20:00.000Z",
+    });
+
+    const handoffId = writePendingChannelChatHandoff(payload);
+    expect(readPendingChannelChatHandoff(handoffId)?.sourceSessionKey).toBe("channel:discord:123");
+    clearPendingChannelChatHandoff(handoffId);
+    expect(readPendingChannelChatHandoff(handoffId)).toBeNull();
+  });
+});

--- a/ui/src/hooks/use-channel-sessions.ts
+++ b/ui/src/hooks/use-channel-sessions.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { useAuth } from "@/hooks/use-auth";
 import { channelsApi } from "@/lib/api/channels";
 import { sessionsApi } from "@/lib/api/sessions";
 import type { ChannelRegistryView, FridaySessionRecord, FridaySessionMessageRecord } from "@/lib/api/types";
@@ -6,6 +7,7 @@ import type { ChannelRegistryView, FridaySessionRecord, FridaySessionMessageReco
 // ─── Channel overview: connected channels + their sessions ───
 
 export function useChannelRegistryQuery() {
+  const { isAuthenticated, isLoading } = useAuth();
   return useQuery<ChannelRegistryView[]>({
     queryKey: ["channels", "registry"],
     queryFn: async () => {
@@ -14,19 +16,38 @@ export function useChannelRegistryQuery() {
     },
     staleTime: 10_000,
     refetchInterval: 15_000,
+    enabled: isAuthenticated && !isLoading,
   });
 }
 
-export function useChannelSessionsQuery(channel?: string) {
+export function useChannelSessionsQuery(channel?: string | string[]) {
+  const { isAuthenticated, isLoading } = useAuth();
+  const requestedKinds = Array.isArray(channel)
+    ? Array.from(new Set(channel.map((item) => item.trim()).filter((item) => item.length > 0)))
+    : typeof channel === "string" && channel.trim().length > 0
+      ? [channel.trim()]
+      : [];
+  const queryKeySuffix = requestedKinds.length === 0 ? "all" : requestedKinds.join(",");
   return useQuery<FridaySessionRecord[]>({
-    queryKey: ["channels", "sessions", channel ?? "all"],
+    queryKey: ["channels", "sessions", queryKeySuffix],
     queryFn: async () => {
-      const sessions = await sessionsApi.list({
-        channel: channel || undefined,
-        limit: 100,
-      });
+      const sessions = requestedKinds.length <= 1
+        ? await sessionsApi.list({
+          channel: requestedKinds[0],
+          limit: 100,
+        })
+        : (await Promise.all(
+          requestedKinds.map((kind) => sessionsApi.list({
+            channel: kind,
+            limit: 100,
+          })),
+        )).flat();
+      const deduped = new Map<string, FridaySessionRecord>();
+      for (const session of sessions) {
+        deduped.set(session.key, session);
+      }
       // Sort by most recent activity
-      return sessions.sort((a, b) => {
+      return Array.from(deduped.values()).sort((a, b) => {
         const aTime = a.lastActivityAt ?? a.updatedAt;
         const bTime = b.lastActivityAt ?? b.updatedAt;
         return bTime.localeCompare(aTime);
@@ -34,11 +55,12 @@ export function useChannelSessionsQuery(channel?: string) {
     },
     staleTime: 5_000,
     refetchInterval: 5_000,
-    enabled: true,
+    enabled: isAuthenticated && !isLoading,
   });
 }
 
 export function useSessionMessagesQuery(sessionKey: string | null) {
+  const { isAuthenticated, isLoading } = useAuth();
   return useQuery<FridaySessionMessageRecord[]>({
     queryKey: ["channels", "session-messages", sessionKey],
     queryFn: async () => {
@@ -47,7 +69,7 @@ export function useSessionMessagesQuery(sessionKey: string | null) {
     },
     staleTime: 3_000,
     refetchInterval: 3_000,
-    enabled: !!sessionKey,
+    enabled: isAuthenticated && !isLoading && !!sessionKey,
   });
 }
 

--- a/ui/src/hooks/use-chat-session.ts
+++ b/ui/src/hooks/use-chat-session.ts
@@ -20,7 +20,7 @@ export interface UseChatSessionResult {
   sessionKey: string;
   currentRunId: string | null;
   runEvents: UseAgentRunEventsResult;
-  sendMessage: (text: string) => Promise<void>;
+  sendMessage: (text: string, options?: { taskPrompt?: string; onAccepted?: () => void }) => Promise<void>;
   isStreaming: boolean;
   clearHistory: () => void;
   startNewConversation: () => void;
@@ -247,7 +247,10 @@ export function useChatSession(options: UseChatSessionOptions = {}): UseChatSess
 
   const isStreaming = runEvents.connectionState === "streaming" || runEvents.connectionState === "connecting";
 
-  const sendMessage = useCallback(async (text: string) => {
+  const sendMessage = useCallback(async (
+    text: string,
+    sendOptions?: { taskPrompt?: string; onAccepted?: () => void },
+  ) => {
     const trimmed = text.trim();
     if (!trimmed) return;
 
@@ -272,6 +275,9 @@ export function useChatSession(options: UseChatSessionOptions = {}): UseChatSess
       // Start a new agent run
       const result = await agentApi.startRun({
         task: trimmed,
+        taskPrompt: typeof sendOptions?.taskPrompt === "string" && sendOptions.taskPrompt.trim().length > 0
+          ? sendOptions.taskPrompt.trim()
+          : undefined,
         sessionKey: sessionKeyRef.current,
         executionContext: {
           surface: "chat",
@@ -297,6 +303,7 @@ export function useChatSession(options: UseChatSessionOptions = {}): UseChatSess
           return updated;
         });
         scheduleSyncFromServer(sessionKeyRef.current);
+        sendOptions?.onAccepted?.();
         return;
       }
 
@@ -321,6 +328,7 @@ export function useChatSession(options: UseChatSessionOptions = {}): UseChatSess
       });
 
       setCurrentRunId(result.runId);
+      sendOptions?.onAccepted?.();
     } catch (err) {
       // Add error message
       const errMsg: ChatMessage = {

--- a/ui/src/lib/chat/channel-handoff.ts
+++ b/ui/src/lib/chat/channel-handoff.ts
@@ -1,0 +1,213 @@
+import type { FridaySessionMessageRecord, FridaySessionRecord } from "@/lib/api/types";
+
+export interface FridayChannelChatHandoffExcerpt {
+  role: "user" | "assistant";
+  text: string;
+}
+
+export interface FridayChannelChatHandoffPayload {
+  id: string;
+  sourceSessionKey: string;
+  sourceChannel: string;
+  sourceDisplayName: string;
+  sourceChatId: string;
+  sourceChatKind: string;
+  sourceMessageCount: number;
+  sourceLastActivityAt?: string;
+  topicSummary?: string;
+  latestUserMessage?: string;
+  latestAssistantMessage?: string;
+  excerpts: FridayChannelChatHandoffExcerpt[];
+  createdAt: string;
+}
+
+const HANDOFF_STORAGE_PREFIX = "friday-chat-handoff:";
+const HANDOFF_LATEST_KEY = "friday-chat-handoff-latest";
+const MAX_EXCERPT_LENGTH = 220;
+const MAX_EXCERPTS = 4;
+
+function truncate(text: string, maxLength = MAX_EXCERPT_LENGTH): string {
+  const normalized = text.trim().replace(/\s+/g, " ");
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+  return `${normalized.slice(0, maxLength - 1)}…`;
+}
+
+function readTopicSummary(session: FridaySessionRecord): string | undefined {
+  const metadata = session.metadata as Record<string, unknown> | undefined;
+  const focus = metadata?.conversationFocus;
+  if (!focus || typeof focus !== "object" || Array.isArray(focus)) {
+    return undefined;
+  }
+  const candidate = (focus as Record<string, unknown>).currentTopicSummary;
+  return typeof candidate === "string" && candidate.trim().length > 0
+    ? truncate(candidate, 140)
+    : undefined;
+}
+
+function toRenderableExcerpt(record: FridaySessionMessageRecord): FridayChannelChatHandoffExcerpt | null {
+  if (record.role !== "user" && record.role !== "assistant") {
+    return null;
+  }
+  const rawText = typeof record.contentText === "string" && record.contentText.trim().length > 0
+    ? record.contentText
+    : typeof record.content === "string"
+      ? record.content
+      : "";
+  const text = truncate(rawText);
+  if (!text) {
+    return null;
+  }
+  return {
+    role: record.role,
+    text,
+  };
+}
+
+export function buildChannelChatHandoffPayload(input: {
+  session: FridaySessionRecord;
+  displayName: string;
+  messages: FridaySessionMessageRecord[];
+  nowIso?: () => string;
+}): FridayChannelChatHandoffPayload {
+  const topicSummary = readTopicSummary(input.session);
+  const excerpts = input.messages
+    .filter((record) => record.role === "user" || record.role === "assistant")
+    .sort((left, right) => left.sequence - right.sequence)
+    .slice(-MAX_EXCERPTS)
+    .map(toRenderableExcerpt)
+    .filter((excerpt): excerpt is FridayChannelChatHandoffExcerpt => Boolean(excerpt));
+
+  const latestUserMessage = [...input.messages]
+    .reverse()
+    .find((record) => record.role === "user");
+  const latestAssistantMessage = [...input.messages]
+    .reverse()
+    .find((record) => record.role === "assistant");
+
+  const createdAt = input.nowIso ? input.nowIso() : new Date().toISOString();
+  const id = `handoff-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+
+  return {
+    id,
+    sourceSessionKey: input.session.key,
+    sourceChannel: input.session.channel,
+    sourceDisplayName: input.displayName,
+    sourceChatId: input.session.chatId,
+    sourceChatKind: input.session.chatKind,
+    sourceMessageCount: input.session.messageCount,
+    sourceLastActivityAt: input.session.lastActivityAt,
+    topicSummary,
+    latestUserMessage: latestUserMessage ? truncate(latestUserMessage.contentText || String(latestUserMessage.content ?? "")) : undefined,
+    latestAssistantMessage: latestAssistantMessage ? truncate(latestAssistantMessage.contentText || String(latestAssistantMessage.content ?? "")) : undefined,
+    excerpts,
+    createdAt,
+  };
+}
+
+export function buildChannelChatHandoffTaskPrompt(
+  payload: FridayChannelChatHandoffPayload,
+  userText: string,
+  locale: "zh" | "en",
+): string {
+  const header = locale === "zh"
+    ? [
+        "你正在从一条外部渠道会话继续到 Friday 主聊天。",
+        "这不是自动合并历史。",
+        "只使用下面的摘要和锚点继续上下文，不要假装你看到了完整原始线程。",
+      ]
+    : [
+        "You are continuing from an external channel conversation into Friday main chat.",
+        "This is not an automatic history merge.",
+        "Use only the summary and anchors below; do not pretend you can see the full original thread.",
+      ];
+
+  const sourceBlock = locale === "zh"
+    ? [
+        `来源渠道: ${payload.sourceChannel}`,
+        `来源会话: ${payload.sourceDisplayName}`,
+        `来源 chatId: ${payload.sourceChatId}`,
+      ]
+    : [
+        `Source channel: ${payload.sourceChannel}`,
+        `Source conversation: ${payload.sourceDisplayName}`,
+        `Source chatId: ${payload.sourceChatId}`,
+      ];
+
+  const topicBlock = payload.topicSummary
+    ? (locale === "zh"
+      ? [`当前主题: ${payload.topicSummary}`]
+      : [`Current topic: ${payload.topicSummary}`])
+    : [];
+
+  const anchorHeader = locale === "zh" ? "最近锚点:" : "Recent anchors:";
+  const anchors = payload.excerpts.map((excerpt) => {
+    const roleLabel = excerpt.role === "user"
+      ? (locale === "zh" ? "用户" : "User")
+      : "Friday";
+    return `${roleLabel}: ${excerpt.text}`;
+  });
+
+  const latestUserBlock = payload.latestUserMessage && payload.excerpts.every((excerpt) => excerpt.text !== payload.latestUserMessage)
+    ? [locale === "zh" ? `最近用户消息: ${payload.latestUserMessage}` : `Latest user message: ${payload.latestUserMessage}`]
+    : [];
+  const latestAssistantBlock = payload.latestAssistantMessage && payload.excerpts.every((excerpt) => excerpt.text !== payload.latestAssistantMessage)
+    ? [locale === "zh" ? `最近 Friday 回复: ${payload.latestAssistantMessage}` : `Latest Friday reply: ${payload.latestAssistantMessage}`]
+    : [];
+
+  const questionLine = locale === "zh"
+    ? `用户在主聊天里的当前请求: ${userText.trim()}`
+    : `Current user request in main chat: ${userText.trim()}`;
+
+  return [
+    ...header,
+    "",
+    ...sourceBlock,
+    ...topicBlock,
+    ...latestUserBlock,
+    ...latestAssistantBlock,
+    anchors.length > 0 ? "" : undefined,
+    anchors.length > 0 ? anchorHeader : undefined,
+    ...anchors,
+    "",
+    questionLine,
+  ]
+    .filter((line): line is string => typeof line === "string")
+    .join("\n")
+    .trim();
+}
+
+export function writePendingChannelChatHandoff(payload: FridayChannelChatHandoffPayload): string {
+  sessionStorage.setItem(`${HANDOFF_STORAGE_PREFIX}${payload.id}`, JSON.stringify(payload));
+  sessionStorage.setItem(HANDOFF_LATEST_KEY, payload.id);
+  return payload.id;
+}
+
+export function readPendingChannelChatHandoff(handoffId?: string | null): FridayChannelChatHandoffPayload | null {
+  const resolvedId = handoffId ?? sessionStorage.getItem(HANDOFF_LATEST_KEY);
+  if (!resolvedId) {
+    return null;
+  }
+  const raw = sessionStorage.getItem(`${HANDOFF_STORAGE_PREFIX}${resolvedId}`);
+  if (!raw) {
+    return null;
+  }
+  try {
+    return JSON.parse(raw) as FridayChannelChatHandoffPayload;
+  } catch {
+    return null;
+  }
+}
+
+export function clearPendingChannelChatHandoff(handoffId?: string | null): void {
+  const resolvedId = handoffId ?? sessionStorage.getItem(HANDOFF_LATEST_KEY);
+  if (!resolvedId) {
+    return;
+  }
+  sessionStorage.removeItem(`${HANDOFF_STORAGE_PREFIX}${resolvedId}`);
+  const latest = sessionStorage.getItem(HANDOFF_LATEST_KEY);
+  if (latest === resolvedId) {
+    sessionStorage.removeItem(HANDOFF_LATEST_KEY);
+  }
+}

--- a/ui/src/routes/channels-page.tsx
+++ b/ui/src/routes/channels-page.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { AlertTriangle, Radio, Send, Settings2, Wifi, WifiOff, MessageSquare, ChevronRight, X, Zap } from "lucide-react";
+import { useSearchParams } from "react-router-dom";
 import { toast } from "sonner";
 import { ActionButton, StatusPill } from "@/components/core/primitives";
+import { useAppNavigate } from "@/hooks/use-app-navigate";
 import { localize } from "@/lib/i18n/localized-text";
 import { useAppLocale } from "@/providers/locale-provider";
 import { CHANNEL_META, CHANNEL_KINDS_ORDERED, getChannelDisplayName } from "@/lib/channels/channel-meta";
@@ -9,6 +11,8 @@ import type { ChannelKind } from "@/lib/setup/types";
 import type { FridaySessionRecord, FridaySessionMessageRecord, ChannelRegistryView } from "@/lib/api/types";
 import { agentApi } from "@/lib/api/agent";
 import { channelsApi } from "@/lib/api/channels";
+import { sessionsApi } from "@/lib/api/sessions";
+import { buildChannelChatHandoffPayload, writePendingChannelChatHandoff } from "@/lib/chat/channel-handoff";
 import { useAgentRunEvents } from "@/hooks/use-agent-run-events";
 import {
   useChannelRegistryQuery,
@@ -66,9 +70,11 @@ function formatTime(iso: string): string {
 
 export function ChannelsPage() {
   const { locale } = useAppLocale();
+  const navigate = useAppNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const { data: registry = [] } = useChannelRegistryQuery();
   const [filterChannel, setFilterChannel] = useState<string>("all");
-  const [selectedSessionKey, setSelectedSessionKey] = useState<string | null>(null);
+  const [selectedSessionKey, setSelectedSessionKey] = useState<string | null>(() => searchParams.get("sessionKey"));
 
   // Reply state
   const [replyText, setReplyText] = useState("");
@@ -83,10 +89,16 @@ export function ChannelsPage() {
   const [personaSaving, setPersonaSaving] = useState(false);
   const [personaChannelKind, setPersonaChannelKind] = useState<string | null>(null);
 
-  const { data: sessions = [] } = useChannelSessionsQuery(
-    filterChannel === "all" ? undefined : filterChannel,
-  );
+  const requestedSessionChannels = filterChannel === "all"
+    ? registry.map((channel) => channel.kind)
+    : filterChannel;
+  const { data: sessions = [] } = useChannelSessionsQuery(requestedSessionChannels);
   const { data: messages = [], refetch: refetchMessages } = useSessionMessagesQuery(selectedSessionKey);
+
+  useEffect(() => {
+    const sessionKey = searchParams.get("sessionKey");
+    setSelectedSessionKey(sessionKey);
+  }, [searchParams]);
 
   // Streaming response for current reply
   const runEvents = useAgentRunEvents(currentRunId, {
@@ -184,6 +196,27 @@ export function ChannelsPage() {
   const connectedChannels = registry.filter((ch) => ch.running);
   const selectedSession = sessions.find((s) => s.key === selectedSessionKey) ?? null;
 
+  async function handleContinueToMainChat() {
+    if (!selectedSession) {
+      return;
+    }
+
+    try {
+      const sourceMessages = messages.length > 0
+        ? messages
+        : await sessionsApi.listMessages(selectedSession.key, { limit: 12 });
+      const handoff = buildChannelChatHandoffPayload({
+        session: selectedSession,
+        displayName: getSessionDisplayName(selectedSession),
+        messages: sourceMessages,
+      });
+      const handoffId = writePendingChannelChatHandoff(handoff);
+      navigate(`/chat?handoff=${encodeURIComponent(handoffId)}&fresh=1`);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : localize(locale, "交接失败", "Failed to hand off"));
+    }
+  }
+
   // Only treat sessions as channel sessions when they belong to a registered channel kind.
   const channelSessions = sessions.filter((session) => registeredChannelKinds.has(getSessionChannelKind(session)));
 
@@ -232,7 +265,15 @@ export function ChannelsPage() {
       <div className="flex flex-wrap gap-2">
         <button
           type="button"
-          onClick={() => { setFilterChannel("all"); setSelectedSessionKey(null); }}
+          onClick={() => {
+            setFilterChannel("all");
+            setSelectedSessionKey(null);
+            setSearchParams((prev) => {
+              const next = new URLSearchParams(prev);
+              next.delete("sessionKey");
+              return next;
+            }, { replace: true });
+          }}
           className={`flex items-center gap-2 rounded-xl border px-3 py-1.5 text-sm font-medium transition ${
             filterChannel === "all"
               ? "border-[color:var(--color-accent)] bg-[color:var(--color-accent-soft)] text-[color:var(--color-accent)]"
@@ -338,7 +379,14 @@ export function ChannelsPage() {
                   <button
                     key={session.key}
                     type="button"
-                    onClick={() => setSelectedSessionKey(session.key)}
+                    onClick={() => {
+                      setSelectedSessionKey(session.key);
+                      setSearchParams((prev) => {
+                        const next = new URLSearchParams(prev);
+                        next.set("sessionKey", session.key);
+                        return next;
+                      }, { replace: true });
+                    }}
                     className={`flex w-full items-center gap-3 px-4 py-3 text-left transition ${
                       isActive
                         ? "bg-[color:var(--color-accent-soft)]"
@@ -415,6 +463,36 @@ export function ChannelsPage() {
                 </StatusPill>
               </div>
 
+              <div className="border-b border-[color:var(--color-border-soft)] px-5 py-3">
+                <div className="rounded-2xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-subtle)] px-4 py-3">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="min-w-0 flex-1">
+                      <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[color:var(--color-text-faint)]">
+                        {localize(locale, "渠道上下文", "Channel context")}
+                      </p>
+                      <p className="mt-1 text-sm leading-6 text-[color:var(--color-text-secondary)]">
+                        {localize(
+                          locale,
+                          `这里的回复会继续留在 ${safeChannelName(getSessionChannelKind(selectedSession), locale)}，默认不会自动并到主聊天。`,
+                          `Replies here stay in ${safeChannelName(getSessionChannelKind(selectedSession), locale)} and do not automatically merge into main chat.`,
+                        )}
+                      </p>
+                    </div>
+                    <ActionButton tone="secondary" onClick={() => void handleContinueToMainChat()}>
+                      {localize(locale, "继续到主聊天", "Continue in main chat")}
+                    </ActionButton>
+                  </div>
+                  <div className="mt-3 flex flex-wrap gap-2 text-xs text-[color:var(--color-text-secondary)]">
+                    <span className="rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] px-2.5 py-1">
+                      {localize(locale, "默认行为", "Default")}: {localize(locale, "隔离上下文", "Isolated context")}
+                    </span>
+                    <span className="rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] px-2.5 py-1">
+                      {localize(locale, "手动继续", "Manual continue")}: {localize(locale, "只带摘要", "Summary only")}
+                    </span>
+                  </div>
+                </div>
+              </div>
+
               {/* Messages */}
               <div className="flex-1 overflow-y-auto px-5 py-4">
                 {messages.length === 0 && !isStreaming ? (
@@ -488,8 +566,8 @@ export function ChannelsPage() {
                   <p className="text-[10px] text-[color:var(--color-text-faint)]">
                     {localize(
                       locale,
-                      `Friday 将通过 ${safeChannelName(getSessionChannelKind(selectedSession), locale)} 回复`,
-                      `Friday will reply via ${safeChannelName(getSessionChannelKind(selectedSession), locale)}`,
+                      `Friday 将通过 ${safeChannelName(getSessionChannelKind(selectedSession), locale)} 回复；主聊天默认不会自动合并这条线。`,
+                      `Friday replies through ${safeChannelName(getSessionChannelKind(selectedSession), locale)}; main chat does not auto-merge this thread.`,
                     )}
                   </p>
                 </div>

--- a/ui/src/routes/chat-page.tsx
+++ b/ui/src/routes/chat-page.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ArrowRight, MessageSquarePlus, Trash2 } from "lucide-react";
+import { ArrowRight, MessageSquarePlus, Trash2, X } from "lucide-react";
 import { useSearchParams } from "react-router-dom";
 import { toast } from "sonner";
 import { useChatSession } from "@/hooks/use-chat-session";
@@ -16,6 +16,12 @@ import { useHomeSurfacePreferences } from "@/hooks/use-home-surface-preferences"
 import { usePackLaunchActions } from "@/hooks/use-pack-launch-actions";
 import { useUserProfile } from "@/hooks/use-user-profile";
 import { localize } from "@/lib/i18n/localized-text";
+import {
+  buildChannelChatHandoffTaskPrompt,
+  clearPendingChannelChatHandoff,
+  readPendingChannelChatHandoff,
+  type FridayChannelChatHandoffPayload,
+} from "@/lib/chat/channel-handoff";
 import { buildPackAssistantHref } from "@/lib/packs/pack-links";
 import { getPackById } from "@/lib/packs/pack-registry";
 import { sessionsApi, type SessionUsageResponse } from "@/lib/api/sessions";
@@ -43,6 +49,7 @@ export function ChatPage() {
   const [pendingPackPath, setPendingPackPath] = useState<string | null>(null);
   const [draftText, setDraftText] = useState("");
   const [showTopFade, setShowTopFade] = useState(false);
+  const [pendingHandoff, setPendingHandoff] = useState<FridayChannelChatHandoffPayload | null>(null);
   const {
     messages,
     sessionKey,
@@ -57,6 +64,7 @@ export function ChatPage() {
   const bottomRef = useRef<HTMLDivElement>(null);
   const shouldAutoScrollRef = useRef(true);
   const lastCompletedMessageIdRef = useRef<string | null>(null);
+  const appliedFreshHandoffRef = useRef<string | null>(null);
   const [sessionUsage, setSessionUsage] = useState<SessionUsageResponse | null>(null);
   const activePack = packIdParam ? getPackById(packIdParam, customPackInputs) ?? null : null;
 
@@ -75,6 +83,25 @@ export function ChatPage() {
       return next;
     }, { replace: true });
   }, [searchParams, setSearchParams]);
+
+  useEffect(() => {
+    const handoffId = searchParams.get("handoff")?.trim();
+    if (!handoffId) {
+      setPendingHandoff(null);
+      return;
+    }
+    setPendingHandoff(readPendingChannelChatHandoff(handoffId));
+  }, [searchParams]);
+
+  useEffect(() => {
+    const handoffId = searchParams.get("handoff")?.trim();
+    const shouldFreshOpen = searchParams.get("fresh") === "1";
+    if (!handoffId || !shouldFreshOpen || appliedFreshHandoffRef.current === handoffId) {
+      return;
+    }
+    appliedFreshHandoffRef.current = handoffId;
+    startNewConversation();
+  }, [searchParams, startNewConversation]);
 
   useEffect(() => {
     if (!sessionKey) {
@@ -146,28 +173,52 @@ export function ChatPage() {
     });
   }, [messages, runEvents.progress.phase]);
 
+  const clearActiveHandoff = useCallback(() => {
+    const handoffId = pendingHandoff?.id ?? searchParams.get("handoff");
+    clearPendingChannelChatHandoff(handoffId);
+    setPendingHandoff(null);
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      next.delete("handoff");
+      next.delete("fresh");
+      return next;
+    }, { replace: true });
+  }, [pendingHandoff?.id, searchParams, setSearchParams]);
+
+  const sendFromChat = useCallback((text: string) => {
+    const taskPrompt = pendingHandoff
+      ? buildChannelChatHandoffTaskPrompt(pendingHandoff, text, locale)
+      : undefined;
+    void sendMessage(text, {
+      taskPrompt,
+      onAccepted: pendingHandoff ? clearActiveHandoff : undefined,
+    });
+  }, [clearActiveHandoff, locale, pendingHandoff, sendMessage]);
+
   const handleSend = useCallback((text: string) => {
     setDraftText("");
-    void sendMessage(text);
-  }, [sendMessage]);
+    sendFromChat(text);
+  }, [sendFromChat]);
 
   const handleRetry = useCallback((assistantMsgId: string) => {
     const idx = messages.findIndex((m) => m.id === assistantMsgId);
     if (idx < 1) return;
     for (let i = idx - 1; i >= 0; i--) {
       if (messages[i]!.role === "user") {
-        void sendMessage(messages[i]!.content);
+        sendFromChat(messages[i]!.content);
         return;
       }
     }
-  }, [messages, sendMessage]);
+  }, [messages, sendFromChat]);
 
   const handleCommand = useCallback((commandId: string) => {
     switch (commandId) {
       case "new":
+        clearActiveHandoff();
         startNewConversation();
         break;
       case "clear":
+        clearActiveHandoff();
         clearHistory();
         break;
       case "skills":
@@ -180,14 +231,14 @@ export function ChatPage() {
         navigate("/settings");
         break;
       case "help":
-        void sendMessage(
+        sendFromChat(
           locale === "zh"
             ? "请列出所有可用的斜杠命令及其用途。"
             : "Please list all available slash commands and what they do.",
         );
         break;
     }
-  }, [startNewConversation, clearHistory, navigate, sendMessage, locale]);
+  }, [clearActiveHandoff, startNewConversation, clearHistory, navigate, sendFromChat, locale]);
 
   const latestAssistantMsg = messages.length > 0
     ? messages[messages.length - 1]
@@ -249,6 +300,58 @@ export function ChatPage() {
                 "The composer stays pinned to the bottom; history only appears when you scroll up.",
               )}
           </p>
+          {pendingHandoff ? (
+            <div className="mt-3 rounded-[20px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-subtle)] px-4 py-3">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="min-w-0 flex-1">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[color:var(--color-text-faint)]">
+                    {localize(locale, "继续来源", "Continuation source")}
+                  </p>
+                  <p className="mt-1 text-sm font-semibold text-[color:var(--color-text-primary)]">
+                    {pendingHandoff.sourceChannel} · {pendingHandoff.sourceDisplayName}
+                  </p>
+                  <p className="mt-1 text-sm leading-6 text-[color:var(--color-text-secondary)]">
+                    {localize(
+                      locale,
+                      "这会打开一条新的主聊天线，只带入摘要与最近锚点，不自动合并完整渠道历史。",
+                      "This opens a fresh main-chat thread and carries over only a summary plus recent anchors, not the full channel history.",
+                    )}
+                  </p>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <ActionButton tone="secondary" onClick={() => navigate(`/channels?sessionKey=${encodeURIComponent(pendingHandoff.sourceSessionKey)}`)}>
+                    {localize(locale, "查看原会话", "Open source thread")}
+                  </ActionButton>
+                  <ActionButton tone="secondary" onClick={clearActiveHandoff}>
+                    <X className="mr-2 h-4 w-4" />
+                    {localize(locale, "关闭来源", "Dismiss source")}
+                  </ActionButton>
+                </div>
+              </div>
+              <div className="mt-3 flex flex-wrap gap-2 text-xs text-[color:var(--color-text-secondary)]">
+                {pendingHandoff.topicSummary ? (
+                  <span className="rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] px-2.5 py-1">
+                    {localize(locale, "主题", "Topic")}: {pendingHandoff.topicSummary}
+                  </span>
+                ) : null}
+                <span className="rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] px-2.5 py-1">
+                  {localize(locale, "消息", "Messages")}: {pendingHandoff.sourceMessageCount}
+                </span>
+                <span className="rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] px-2.5 py-1">
+                  {localize(locale, "默认隔离", "Isolation")}: {localize(locale, "不自动合并", "No auto merge")}
+                </span>
+              </div>
+              {pendingHandoff.latestUserMessage ? (
+                <p className="mt-3 text-sm leading-6 text-[color:var(--color-text-secondary)]">
+                  <span className="font-medium text-[color:var(--color-text-primary)]">
+                    {localize(locale, "最近用户消息", "Latest user message")}:
+                  </span>
+                  {" "}
+                  {pendingHandoff.latestUserMessage}
+                </p>
+              ) : null}
+            </div>
+          ) : null}
         </div>
 
         <div className="flex flex-wrap gap-2">
@@ -396,6 +499,20 @@ export function ChatPage() {
               >
                 {localize(locale, "去 Assistant", "Open Assistant")}
               </button>
+            </div>
+          ) : null}
+          {pendingHandoff ? (
+            <div className="mb-3 flex flex-wrap items-center gap-2 text-xs text-[color:var(--color-text-secondary)]">
+              <span className="rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] px-2.5 py-1">
+                {pendingHandoff.sourceChannel} · {pendingHandoff.sourceDisplayName}
+              </span>
+              <span>
+                {localize(
+                  locale,
+                  "首次发送会带入这条渠道会话的摘要，不会自动并入完整历史。",
+                  "The first send carries a summary of this channel thread and does not merge the full history.",
+                )}
+              </span>
             </div>
           ) : null}
 


### PR DESCRIPTION
## Summary
- Add manual channel-to-main-chat handoff with a fresh main chat thread.
- Keep channel sessions isolated by default and carry only summary/anchor context on handoff.
- Fix channels page session loading so live channel conversations are not hidden behind unrelated recent system/agent sessions.

## Validation
- `npm run typecheck`
- `npm run build:ui`
- `npx vitest run test/unit/ui/channel-handoff.test.ts`
- Manual live UI verification on `127.0.0.1:3151`: Discord registry connected, Discord sessions visible, handoff opens `/chat?handoff=...&fresh=1`, new main chat session has no copied Discord history.