### PR TITLE
Fix provider routing and session isolation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -1000,21 +1004,21 @@
         "filename": "test/unit/providers/services/friday-provider-service.test.ts",
         "hashed_secret": "e5dee5d8a3b145b7ad98c144117ec048267d081e",
         "is_verified": false,
-        "line_number": 2002
+        "line_number": 2099
       },
       {
         "type": "Secret Keyword",
         "filename": "test/unit/providers/services/friday-provider-service.test.ts",
         "hashed_secret": "75edc4331554c94b0129b60f3d1af4eba2c43728",
         "is_verified": false,
-        "line_number": 2237
+        "line_number": 2334
       },
       {
         "type": "Secret Keyword",
         "filename": "test/unit/providers/services/friday-provider-service.test.ts",
         "hashed_secret": "21dc1586ee0cca57be27bf18763edad10fe73015",
         "is_verified": false,
-        "line_number": 2256
+        "line_number": 2353
       }
     ],
     "test/unit/rules/engine/context-redactor.test.ts": [
@@ -1171,5 +1175,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-22T20:51:23Z"
+  "generated_at": "2026-04-23T05:40:45Z"
 }

--- a/src/api/http/routes/friday-provider-routes.ts
+++ b/src/api/http/routes/friday-provider-routes.ts
@@ -185,6 +185,9 @@ function validateRoutingBody(body: unknown): asserts body is FridaySetRoutingCon
   if (b.defaultModel !== undefined && typeof b.defaultModel !== "string") {
     errors.push("defaultModel must be a string when provided");
   }
+  if (b.enforceRequestedModel !== undefined && typeof b.enforceRequestedModel !== "boolean") {
+    errors.push("enforceRequestedModel must be a boolean when provided");
+  }
 
   if (errors.length > 0) {
     throw new FridayDomainError("VALIDATION_ERROR", `Invalid request body: ${errors.join("; ")}`, { httpStatus: 400 });

--- a/src/api/http/routes/friday-provider-usage-routes.ts
+++ b/src/api/http/routes/friday-provider-usage-routes.ts
@@ -34,6 +34,18 @@ function validateBudgetBody(body: unknown): asserts body is FridaySetBudgetConfi
   }
 }
 
+function getDefaultUtcUsageRange(receivedAt: string | undefined): { from: string; to: string } {
+  const received = receivedAt ? new Date(receivedAt) : new Date();
+  const safeDate = Number.isNaN(received.getTime()) ? new Date() : received;
+  // llm_usage_records.usage_day is written from ISO UTC dates, so default
+  // queries must use the same UTC boundary or late-evening local usage disappears.
+  const to = safeDate.toISOString().slice(0, 10);
+  return {
+    from: `${to.slice(0, 7)}-01`,
+    to,
+  };
+}
+
 // ─── Factory ───
 
 export function createFridayProviderUsageRoutes(
@@ -49,9 +61,9 @@ export function createFridayProviderUsageRoutes(
       async handler(ctx): Promise<FridayGetUsageSummaryResponse> {
         const query = ctx.query as Record<string, string | undefined>;
         // DX-004: Default 'from' to start of current month, 'to' to today
-        const now = new Date();
-        const from = query.from ?? `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-01`;
-        const to = query.to ?? `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+        const defaults = getDefaultUtcUsageRange(ctx.receivedAt);
+        const from = query.from ?? defaults.from;
+        const to = query.to ?? defaults.to;
 
         if (!from || !to) {
           throw new FridayDomainError(

--- a/src/api/http/routes/friday-session-routes.ts
+++ b/src/api/http/routes/friday-session-routes.ts
@@ -301,6 +301,9 @@ function validateRunBody(body: unknown): asserts body is FridaySessionRunRequest
   if (b.task !== undefined && (typeof b.task !== "string" || b.task.trim() === "")) {
     errors.push("task must be a non-empty string when provided");
   }
+  if (b.useLastUserMessage !== undefined && typeof b.useLastUserMessage !== "boolean") {
+    errors.push("useLastUserMessage must be a boolean when provided");
+  }
   if (b.providerId !== undefined && (typeof b.providerId !== "string" || b.providerId.trim() === "")) {
     errors.push("providerId must be a non-empty string when provided");
   }
@@ -899,8 +902,9 @@ export function createFridaySessionRoutes(
         const body = (ctx.body ?? {}) as FridaySessionRunRequest;
 
         const taskFromBody = body.task?.trim();
+        const useLastUserMessage = body.useLastUserMessage === true;
         let task = taskFromBody;
-        if (!task) {
+        if (!task && useLastUserMessage) {
           const history = await deps.sessionService.getMessages(key, 200);
           const lastUserMessage = [...history]
             .reverse()
@@ -911,7 +915,9 @@ export function createFridaySessionRoutes(
         if (!task) {
           throw new FridayDomainError(
             FRIDAY_SESSION_ERROR_CODES.INVALID_INPUT,
-            "No task provided and no user message found in session history",
+            useLastUserMessage
+              ? "useLastUserMessage was true, but no user message was found in session history"
+              : "task is required unless useLastUserMessage is explicitly true",
             { httpStatus: 400 },
           );
         }

--- a/src/api/model/friday-api-provider.types.ts
+++ b/src/api/model/friday-api-provider.types.ts
@@ -62,6 +62,7 @@ export interface FridaySetRoutingConfigRequest {
   defaultProviderId: string;
   defaultModel?: string;
   fallbackProviderIds: string[];
+  enforceRequestedModel?: boolean;
 }
 
 export interface FridaySetBudgetConfigRequest {

--- a/src/api/model/friday-api-session.types.ts
+++ b/src/api/model/friday-api-session.types.ts
@@ -96,6 +96,12 @@ export interface FridaySessionMemoryNamespaceResponse {
 
 export interface FridaySessionRunRequest {
   task?: string;
+  /**
+   * Explicitly opt in to running the latest persisted user message when task is
+   * omitted. Without this flag the API rejects empty tasks to avoid accidental
+   * reuse of stale session input.
+   */
+  useLastUserMessage?: boolean;
   providerId?: string;
   model?: string;
   replyToMessageId?: string;

--- a/src/providers/cost/friday-provider-cost-router.ts
+++ b/src/providers/cost/friday-provider-cost-router.ts
@@ -6,14 +6,6 @@ import type {
 } from "../model/friday-provider-cost.types.js";
 import type { FridayProviderPricingCatalog } from "./friday-provider-pricing-catalog.js";
 
-// ─── Score weights by complexity ───
-
-const ROUTE_SCORE_WEIGHTS = {
-  simple: { cost: 1.0, quality: 0.0 },
-  medium: { cost: 0.60, quality: 0.40 },
-  complex: { cost: 0.20, quality: 0.80 },
-} as const;
-
 const QUALITY_TIER_SCORE: Record<string, number> = {
   best: 1.0,
   balanced: 0.5,
@@ -87,29 +79,15 @@ export function createFridayProviderCostRouter(deps: {
         };
       }
 
-      // Normal: score by complexity-weighted cost/quality
-      const weights = ROUTE_SCORE_WEIGHTS[complexity];
-      const scored = candidates
-        .map((candidate) => {
-          const pricing = pricingCatalog.getPricing(
-            candidate.provider.kind,
-            candidate.model,
-          );
-          // Normalize cost to 0-1 range (lower cost = higher score)
-          const costScore = 1 - Math.min(pricing.inputPer1MUsd / 20, 1);
-          const qualityScore = QUALITY_TIER_SCORE[pricing.qualityTier] ?? 0.5;
-          const total = costScore * weights.cost + qualityScore * weights.quality;
-          return { candidate, score: total };
-        })
-        .sort((a, b) => b.score - a.score);
-
+      // Normal: preserve the operator-configured order. Cost routing may only
+      // reorder when a budget policy explicitly requires a downgrade.
       return {
-        strategy: "cost_auto",
+        strategy: "configured",
         complexity,
         budgetState,
         estimatedInputTokens,
-        orderedCandidates: scored.map((s) => s.candidate),
-        reason: `Cost-aware routing (${complexity} complexity, budget OK)`,
+        orderedCandidates: candidates,
+        reason: "Budget OK — routing followed the configured provider order",
       };
     },
   };

--- a/src/providers/services/friday-provider-service.ts
+++ b/src/providers/services/friday-provider-service.ts
@@ -137,6 +137,9 @@ interface FridayHistoricalRunRouteRow {
   status: string;
   actual_execution_json: string | null;
   task_profile_json: string | null;
+  metadata_json: string | null;
+  session_user_id: string | null;
+  session_account_id: string | null;
 }
 
 interface FridayHistoricalRouteStats {
@@ -453,8 +456,9 @@ export function createFridayProviderService(
   function loadHistoricalRouteStats(input: {
     candidates: FridayResolvedProviderRoute[];
     taskProfileId?: string;
+    tenantContext?: FridayProviderTenantContext;
   }): Map<string, FridayHistoricalRouteStats> {
-    if (!input.taskProfileId) {
+    if (!input.taskProfileId || !hasHistoricalRoutingScope(input.tenantContext)) {
       return new Map();
     }
 
@@ -470,11 +474,17 @@ export function createFridayProviderService(
 
     const rows = deps.db.withReadConnection((db) =>
       db.prepare(
-        `SELECT status, actual_execution_json, task_profile_json
-         FROM friday_agent_runs
-         WHERE status IN ('completed', 'failed')
-           AND actual_execution_json IS NOT NULL
-         ORDER BY created_at DESC
+        `SELECT r.status,
+                r.actual_execution_json,
+                r.task_profile_json,
+                r.metadata_json,
+                s.user_id AS session_user_id,
+                s.account_id AS session_account_id
+         FROM friday_agent_runs r
+         LEFT JOIN sessions s ON s.session_key = r.session_key
+         WHERE r.status IN ('completed', 'failed')
+           AND r.actual_execution_json IS NOT NULL
+         ORDER BY r.created_at DESC
          LIMIT ?`,
       ).all(ROUTE_HISTORY_SAMPLE_LIMIT) as FridayHistoricalRunRouteRow[],
     );
@@ -482,6 +492,10 @@ export function createFridayProviderService(
     const stats = new Map<string, FridayHistoricalRouteStats>();
 
     for (const row of rows) {
+      if (!historicalRouteRowMatchesScope(row, input.tenantContext)) {
+        continue;
+      }
+
       const taskProfile = safeJsonParse<Record<string, unknown>>(row.task_profile_json);
       if (taskProfile?.id !== input.taskProfileId) {
         continue;
@@ -524,6 +538,48 @@ export function createFridayProviderService(
     }
 
     return stats;
+  }
+
+  function normalizeScopeSegment(value?: string | null): string | undefined {
+    const trimmed = value?.trim();
+    return trimmed && trimmed.length > 0 ? trimmed : undefined;
+  }
+
+  function hasHistoricalRoutingScope(tenantContext?: FridayProviderTenantContext): boolean {
+    return Boolean(
+      normalizeScopeSegment(tenantContext?.userId)
+      || normalizeScopeSegment(tenantContext?.hubId),
+    );
+  }
+
+  function getHistoricalRowPrincipalId(row: FridayHistoricalRunRouteRow): string | undefined {
+    const metadata = safeJsonParse<Record<string, unknown>>(row.metadata_json);
+    const apiRequest = metadata?.apiRequest;
+    if (!apiRequest || typeof apiRequest !== "object") {
+      return undefined;
+    }
+    const principalId = (apiRequest as { principalId?: unknown }).principalId;
+    return typeof principalId === "string" ? normalizeScopeSegment(principalId) : undefined;
+  }
+
+  function historicalRouteRowMatchesScope(
+    row: FridayHistoricalRunRouteRow,
+    tenantContext?: FridayProviderTenantContext,
+  ): boolean {
+    const userId = normalizeScopeSegment(tenantContext?.userId);
+    const hubId = normalizeScopeSegment(tenantContext?.hubId);
+    const rowUserId = normalizeScopeSegment(row.session_user_id);
+    const rowPrincipalId = getHistoricalRowPrincipalId(row);
+
+    if (userId) {
+      return rowUserId === userId || rowPrincipalId === userId;
+    }
+
+    if (hubId) {
+      return normalizeScopeSegment(row.session_account_id) === hubId;
+    }
+
+    return false;
   }
 
   function loadRoutePreferenceState(input: {
@@ -632,6 +688,7 @@ export function createFridayProviderService(
     requestedProviderId?: string;
     requestedModel?: string;
     userId?: string;
+    tenantContext?: FridayProviderTenantContext;
     taskProfileId?: string;
     routingContext?: {
       requiresNativeTools?: boolean;
@@ -652,6 +709,7 @@ export function createFridayProviderService(
     const historyStats = loadHistoricalRouteStats({
       candidates: input.candidates,
       taskProfileId: input.taskProfileId,
+      tenantContext: input.tenantContext,
     });
     const preferenceState = loadRoutePreferenceState({
       candidates: input.candidates,
@@ -1412,6 +1470,7 @@ export function createFridayProviderService(
         requestedProviderId: input.requestedProviderId,
         requestedModel: input.requestedModel,
         userId: input.tenantContext?.userId,
+        tenantContext: input.tenantContext,
         taskProfileId: input.routingContext?.taskProfileId,
         routingContext: input.routingContext,
         budgetLocalOnly: routingDecision.strategy === "budget_local_only" && !enforcePin && !pinnedProvider,
@@ -2051,6 +2110,7 @@ export function createFridayProviderService(
         requestedProviderId: params.requestedProviderId,
         requestedModel: params.requestedModel,
         userId: params.tenantContext?.userId,
+        tenantContext: params.tenantContext,
         taskProfileId: params.routingContext?.taskProfileId,
         routingContext: params.routingContext,
         budgetLocalOnly: routingDecision.strategy === "budget_local_only" && !enforcePin && !pinnedProvider,

--- a/test/e2e/setup-wizard.e2e.test.ts
+++ b/test/e2e/setup-wizard.e2e.test.ts
@@ -817,7 +817,7 @@ describe("Setup Wizard E2E", () => {
         {
           method: "POST",
           headers: authHeaders(accessToken),
-          body: JSON.stringify({}),
+          body: JSON.stringify({ useLastUserMessage: true }),
         },
       );
 

--- a/test/integration/agent/friday-agent-parity-acceptance.test.ts
+++ b/test/integration/agent/friday-agent-parity-acceptance.test.ts
@@ -247,7 +247,7 @@ describe("Agent parity acceptance (integration)", () => {
 
     const response = await route!.handler({
       params: { sessionKey: "discord:default:user-ctx" },
-      body: {},
+      body: { useLastUserMessage: true },
     } as never);
 
     expect(response).toMatchObject({

--- a/test/unit/api/http/routes/friday-provider-usage-routes.test.ts
+++ b/test/unit/api/http/routes/friday-provider-usage-routes.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createFridayProviderUsageRoutes } from "../../../../../src/api/http/routes/friday-provider-usage-routes.js";
+import type { FridayProviderService } from "#providers";
+
+function makeProviderService() {
+  return {
+    getUsageSummary: vi.fn(async (input) => ({
+      from: input.from,
+      to: input.to,
+      groupBy: input.groupBy,
+      rows: [],
+      totals: {
+        callCount: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+        totalTokens: 0,
+        costUsd: 0,
+      },
+    })),
+  } as unknown as FridayProviderService & {
+    getUsageSummary: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe("FridayProviderUsageRoutes", () => {
+  it("defaults usage date range to UTC to match llm_usage_records.usage_day", async () => {
+    const providerService = makeProviderService();
+    const route = createFridayProviderUsageRoutes({ providerService })
+      .find((entry) => entry.operationId === "providers.usage.get");
+
+    if (!route) {
+      throw new Error("providers.usage.get route not found");
+    }
+
+    await route.handler({
+      requestId: "req-usage",
+      // 2026-04-22 evening in US Pacific is already 2026-04-23 in UTC.
+      receivedAt: "2026-04-23T05:18:06.000Z",
+      params: {},
+      query: {},
+      body: undefined,
+      headers: {},
+      principal: null,
+    });
+
+    expect(providerService.getUsageSummary).toHaveBeenCalledWith({
+      from: "2026-04-01",
+      to: "2026-04-23",
+      groupBy: "day",
+      providerId: undefined,
+      model: undefined,
+    });
+  });
+});

--- a/test/unit/api/http/routes/friday-session-routes.test.ts
+++ b/test/unit/api/http/routes/friday-session-routes.test.ts
@@ -628,7 +628,7 @@ describe("FridaySessionRoutes", () => {
       const result = await route.handler(
         makeMockCtx({
           params: { sessionKey: "discord:default:user1" },
-          body: {},
+          body: { useLastUserMessage: true },
         }) as never,
       );
 
@@ -828,7 +828,7 @@ describe("FridaySessionRoutes", () => {
       );
     });
 
-    it("uses latest user message as task when task is omitted", async () => {
+    it("uses latest user message as task when explicitly requested", async () => {
       const svc = createMockService();
       const runSession = vi.fn().mockResolvedValue({
         runId: "run-1",
@@ -863,7 +863,7 @@ describe("FridaySessionRoutes", () => {
       const result = await route.handler(
         makeMockCtx({
           params: { sessionKey: "discord:default:user1" },
-          body: {},
+          body: { useLastUserMessage: true },
         }) as never,
       );
 
@@ -891,6 +891,27 @@ describe("FridaySessionRoutes", () => {
           { role: "assistant", content: "FRIDAY_E2E_OK" },
         ],
       });
+    });
+
+    it("rejects omitted task unless latest-message reuse is explicit", async () => {
+      const svc = createMockService();
+      const runSession = vi.fn();
+      const routes = createFridaySessionRoutes({
+        sessionService: svc,
+        runSession,
+      });
+      const route = routes.find((r) => r.operationId === "sessions.run")!;
+
+      await expect(
+        route.handler(
+          makeMockCtx({
+            params: { sessionKey: "discord:default:user1" },
+            body: {},
+          }) as never,
+        ),
+      ).rejects.toThrow("task is required unless useLastUserMessage is explicitly true");
+      expect(svc.getMessages).not.toHaveBeenCalled();
+      expect(runSession).not.toHaveBeenCalled();
     });
 
     it("marks persistTaskMessage=true when task is provided in request body", async () => {
@@ -995,7 +1016,7 @@ describe("FridaySessionRoutes", () => {
       await route.handler(
         makeMockCtx({
           params: { sessionKey: "discord:default:user1" },
-          body: {},
+          body: { useLastUserMessage: true },
           principal: {
             principalType: "user",
             principalId: "principal-1",
@@ -1043,7 +1064,7 @@ describe("FridaySessionRoutes", () => {
       await route.handler(
         makeMockCtx({
           params: { sessionKey: "discord:default:user1" },
-          body: {},
+          body: { useLastUserMessage: true },
           principal: {
             principalType: "user",
             principalId: "principal-1",

--- a/test/unit/api/runtime/friday-api-runtime-session-registration.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-session-registration.test.ts
@@ -170,7 +170,7 @@ describe("FridayApiRuntime — Session Registration", () => {
     expect(runtime.extractionService).toBeUndefined();
   });
 
-  it("avoids duplicating latest user message in history when sessions.run derives task from history", async () => {
+  it("avoids duplicating latest user message in history when sessions.run explicitly reuses history", async () => {
     const providerService = createMockProviderService();
     const executeRun = vi.fn(async () => ({
       runId: "run-1",
@@ -209,7 +209,7 @@ describe("FridayApiRuntime — Session Registration", () => {
 
     await route!.handler({
       params: { sessionKey: "discord:default:user1" },
-      body: {},
+      body: { useLastUserMessage: true },
     } as never);
 
     expect(executeRun).toHaveBeenCalledTimes(1);

--- a/test/unit/providers/api/friday-provider-routes.test.ts
+++ b/test/unit/providers/api/friday-provider-routes.test.ts
@@ -576,10 +576,32 @@ describe("FridayProviderRoutes", () => {
         defaultProviderId: "prov-001",
         defaultModel: "gpt-4o",
         fallbackProviderIds: ["prov-002"],
+        enforceRequestedModel: true,
       };
 
       const result = await setRoutingRoute.handler(makeCtx({ body }));
       expect(result).toEqual({ routing: body });
+    });
+
+    it("providers.routing.set rejects non-boolean enforceRequestedModel", async () => {
+      const mockService = makeMockService();
+      const routes = createFridayProviderRoutes({
+        providerService: mockService,
+      });
+      const setRoutingRoute = routes.find(
+        (r) => r.operationId === "providers.routing.set",
+      )!;
+
+      await expect(
+        setRoutingRoute.handler(makeCtx({
+          body: {
+            defaultProviderId: "prov-001",
+            fallbackProviderIds: [],
+            enforceRequestedModel: "yes",
+          },
+        })),
+      ).rejects.toThrow("enforceRequestedModel must be a boolean when provided");
+      expect(mockService.setRoutingConfig).not.toHaveBeenCalled();
     });
 
     it("auth.oauth.anthropic.initiate delegates to service", async () => {

--- a/test/unit/providers/services/friday-provider-service.test.ts
+++ b/test/unit/providers/services/friday-provider-service.test.ts
@@ -1543,6 +1543,61 @@ describe("FridayProviderService", () => {
       }
     });
 
+    it("preserves the configured default provider while budget is healthy", async () => {
+      process.env.OPENAI_KEY = "test-openai-key";
+      try {
+        await service.createProvider({
+          kind: "openai",
+          name: "Primary OpenAI",
+          baseUrl: "https://api.openai.com",
+          authMode: "api-key",
+          api: "openai-responses",
+          apiKey: "$OPENAI_KEY",
+          supportedModels: ["gpt-4o"],
+          defaultModel: "gpt-4o",
+          validateOnSave: false,
+        });
+        await service.createProvider({
+          kind: "openai",
+          name: "Cheaper OpenAI fallback",
+          baseUrl: "https://api.openai.com",
+          authMode: "api-key",
+          api: "openai-responses",
+          apiKey: "$OPENAI_KEY",
+          supportedModels: ["gpt-4o-mini"],
+          defaultModel: "gpt-4o-mini",
+          validateOnSave: false,
+        });
+
+        await service.setRoutingConfig({
+          defaultProviderId: "test-id-0001",
+          fallbackProviderIds: ["test-id-0002"],
+        });
+
+        const { route, routingDecision } = await service.runWithFallback({
+          routingContext: {
+            estimatedInputTokens: 4096,
+            complexity: "simple",
+          },
+          run: async (candidate) => candidate.provider.id,
+        });
+
+        expect(route.provider.id).toBe("test-id-0001");
+        expect(route.model).toBe("gpt-4o");
+        expect(routingDecision.strategy).toBe("configured");
+        expect(routingDecision.routeDecisionTrace?.selectedBeforeLearning).toMatchObject({
+          providerId: "test-id-0001",
+          model: "gpt-4o",
+        });
+        expect(routingDecision.routeDecisionTrace?.selectedAfterLearning).toMatchObject({
+          providerId: "test-id-0001",
+          model: "gpt-4o",
+        });
+      } finally {
+        delete process.env.OPENAI_KEY;
+      }
+    });
+
     it("does not let learning history override a requestedProviderId pin", async () => {
       process.env.OPENAI_KEY = "test-openai-key";
       process.env.ANTHROPIC_KEY = "test-anthropic-key";
@@ -1745,6 +1800,24 @@ describe("FridayProviderService", () => {
         });
 
         db.withWriteTransaction((conn) => {
+          const insertSession = conn.prepare(
+            `INSERT INTO sessions (
+              id, session_key, agent_id, channel, chat_kind, status,
+              metadata_json, created_at, updated_at, account_id, chat_id, user_id
+            ) VALUES (?, ?, 'agent', 'chat', 'dm', 'active', '{}', ?, ?, ?, ?, ?)`,
+          );
+          for (const sessionKey of ["sess-001", "sess-002", "sess-003"]) {
+            insertSession.run(
+              `session-${sessionKey}`,
+              sessionKey,
+              NOW,
+              NOW,
+              "tenant-review",
+              sessionKey,
+              "user-review",
+            );
+          }
+
           const insertRun = conn.prepare(
             `INSERT INTO friday_agent_runs (
               id, task, status, session_key, provider_id, model, attempt, max_attempts, created_at,
@@ -1808,6 +1881,10 @@ describe("FridayProviderService", () => {
             complexity: "medium",
             taskProfileId: "review",
           },
+          tenantContext: {
+            hubId: "tenant-review",
+            userId: "user-review",
+          },
           run: async (candidate) => candidate.provider.id,
         });
 
@@ -1816,6 +1893,10 @@ describe("FridayProviderService", () => {
         expect(routingDecision.reason).toContain("Historical route outcomes influenced candidate scoring.");
 
         const explain = await service.explainRouting({
+          tenantContext: {
+            hubId: "tenant-review",
+            userId: "user-review",
+          },
           routingContext: {
             estimatedInputTokens: 1800,
             complexity: "medium",
@@ -1831,6 +1912,22 @@ describe("FridayProviderService", () => {
           successRate: 1,
           failureRate: 0,
         });
+
+        const otherTenantRun = await service.runWithFallback({
+          routingContext: {
+            estimatedInputTokens: 1800,
+            complexity: "medium",
+            taskProfileId: "review",
+          },
+          tenantContext: {
+            hubId: "tenant-other",
+            userId: "user-other",
+          },
+          run: async (candidate) => candidate.provider.id,
+        });
+
+        expect(otherTenantRun.route.provider.id).toBe("test-id-0001");
+        expect(otherTenantRun.routingDecision.learningSignalsPresent).toBe(false);
       } finally {
         delete process.env.OPENAI_KEY;
         delete process.env.ANTHROPIC_KEY;

--- a/ui/src/hooks/use-chat-session.ts
+++ b/ui/src/hooks/use-chat-session.ts
@@ -184,13 +184,16 @@ export function useChatSession(options: UseChatSessionOptions = {}): UseChatSess
   const [messages, setMessages] = useState<ChatMessage[]>(() => loadHistory(sessionKey));
   const [currentRunId, setCurrentRunId] = useState<string | null>(null);
   const sessionKeyRef = useRef(sessionKey);
+  const currentRunSessionKeyRef = useRef<string | null>(null);
   const outputTextRef = useRef("");
 
   const syncMessagesFromServer = useCallback(async (targetSessionKey: string): Promise<boolean> => {
     try {
       const remoteMessages = await sessionsApi.listMessages(targetSessionKey, { limit: 200 });
       const mapped = mapSessionMessagesToChatMessages(remoteMessages);
-      setMessages(mapped);
+      if (sessionKeyRef.current === targetSessionKey) {
+        setMessages(mapped);
+      }
       saveHistory(targetSessionKey, mapped);
       return true;
     } catch {
@@ -218,13 +221,36 @@ export function useChatSession(options: UseChatSessionOptions = {}): UseChatSess
     }, delayMs);
   }, [syncMessagesFromServer]);
 
+  const updateSessionHistory = useCallback((
+    targetSessionKey: string,
+    updater: (messages: ChatMessage[]) => ChatMessage[],
+  ) => {
+    if (sessionKeyRef.current !== targetSessionKey) {
+      const updated = updater(loadHistory(targetSessionKey));
+      saveHistory(targetSessionKey, updated);
+      return;
+    }
+
+    setMessages((prev) => {
+      if (sessionKeyRef.current !== targetSessionKey) {
+        const updated = updater(loadHistory(targetSessionKey));
+        saveHistory(targetSessionKey, updated);
+        return prev;
+      }
+      const updated = updater(prev);
+      saveHistory(targetSessionKey, updated);
+      return updated;
+    });
+  }, []);
+
   const runEvents = useAgentRunEvents(currentRunId, {
     enabled: currentRunId !== null,
     onTerminal: (status) => {
       // Finalize the assistant message with full output text
       const finalText = outputTextRef.current;
-      setMessages((prev) => {
-        const updated = prev.map((m) =>
+      const runSessionKey = currentRunSessionKeyRef.current ?? sessionKeyRef.current;
+      updateSessionHistory(runSessionKey, (prev) =>
+        prev.map((m) =>
           m.runId === currentRunId && m.role === "assistant"
             ? {
                 ...m,
@@ -232,13 +258,12 @@ export function useChatSession(options: UseChatSessionOptions = {}): UseChatSess
                 status: (status === "completed" ? "done" : "error") as ChatMessage["status"],
               }
             : m,
-        );
-        saveHistory(sessionKeyRef.current, updated);
-        return updated;
-      });
+        ),
+      );
       outputTextRef.current = "";
+      currentRunSessionKeyRef.current = null;
       setCurrentRunId(null);
-      scheduleSyncFromServer(sessionKeyRef.current);
+      scheduleSyncFromServer(runSessionKey);
     },
   });
 
@@ -261,6 +286,7 @@ export function useChatSession(options: UseChatSessionOptions = {}): UseChatSess
   ) => {
     const trimmed = text.trim();
     if (!trimmed) return;
+    const activeSessionKey = sessionKeyRef.current;
 
     // Add user message
     const userMsg: ChatMessage = {
@@ -271,14 +297,10 @@ export function useChatSession(options: UseChatSessionOptions = {}): UseChatSess
       status: "done",
     };
 
-    setMessages((prev) => {
-      const updated = [...prev, userMsg];
-      saveHistory(sessionKeyRef.current, updated);
-      return updated;
-    });
+    updateSessionHistory(activeSessionKey, (prev) => [...prev, userMsg]);
 
     try {
-      await ensureRemoteSession(sessionKeyRef.current);
+      await ensureRemoteSession(activeSessionKey);
 
       // Start a new agent run
       const result = await agentApi.startRun({
@@ -286,7 +308,7 @@ export function useChatSession(options: UseChatSessionOptions = {}): UseChatSess
         taskPrompt: typeof sendOptions?.taskPrompt === "string" && sendOptions.taskPrompt.trim().length > 0
           ? sendOptions.taskPrompt.trim()
           : undefined,
-        sessionKey: sessionKeyRef.current,
+        sessionKey: activeSessionKey,
         executionContext: {
           surface: "chat",
           interactive: true,
@@ -305,12 +327,8 @@ export function useChatSession(options: UseChatSessionOptions = {}): UseChatSess
           status: result.status === "completed" ? "done" : "error",
         };
 
-        setMessages((prev) => {
-          const updated = [...prev, assistantMsg];
-          saveHistory(sessionKeyRef.current, updated);
-          return updated;
-        });
-        scheduleSyncFromServer(sessionKeyRef.current);
+        updateSessionHistory(activeSessionKey, (prev) => [...prev, assistantMsg]);
+        scheduleSyncFromServer(activeSessionKey);
         sendOptions?.onAccepted?.();
         return;
       }
@@ -329,12 +347,9 @@ export function useChatSession(options: UseChatSessionOptions = {}): UseChatSess
         status: "streaming",
       };
 
-      setMessages((prev) => {
-        const updated = [...prev, assistantMsg];
-        saveHistory(sessionKeyRef.current, updated);
-        return updated;
-      });
+      updateSessionHistory(activeSessionKey, (prev) => [...prev, assistantMsg]);
 
+      currentRunSessionKeyRef.current = activeSessionKey;
       setCurrentRunId(result.runId);
       sendOptions?.onAccepted?.();
     } catch (err) {
@@ -346,18 +361,15 @@ export function useChatSession(options: UseChatSessionOptions = {}): UseChatSess
         timestamp: new Date().toISOString(),
         status: "error",
       };
-      setMessages((prev) => {
-        const updated = [...prev, errMsg];
-        saveHistory(sessionKeyRef.current, updated);
-        return updated;
-      });
+      updateSessionHistory(activeSessionKey, (prev) => [...prev, errMsg]);
     }
-  }, [ensureRemoteSession, options.packId, scheduleSyncFromServer]);
+  }, [ensureRemoteSession, options.packId, scheduleSyncFromServer, updateSessionHistory]);
 
   const clearHistory = useCallback(() => {
     const currentSessionKey = sessionKeyRef.current;
     void sessionsApi.reset(currentSessionKey).catch(() => {});
     outputTextRef.current = "";
+    currentRunSessionKeyRef.current = null;
     setCurrentRunId(null);
     setMessages([]);
     localStorage.removeItem(getHistoryStorageKey(currentSessionKey));
@@ -370,6 +382,7 @@ export function useChatSession(options: UseChatSessionOptions = {}): UseChatSess
   const startNewConversation = useCallback(() => {
     // Generate a fresh session key so the next send starts a clean server-backed session.
     outputTextRef.current = "";
+    currentRunSessionKeyRef.current = null;
     setCurrentRunId(null);
     setMessages([]);
     localStorage.removeItem(SESSION_KEY_STORAGE);

--- a/ui/src/lib/api/providers.ts
+++ b/ui/src/lib/api/providers.ts
@@ -57,6 +57,7 @@ export interface SetRoutingInput {
   defaultProviderId: string;
   defaultModel?: string;
   fallbackProviderIds: string[];
+  enforceRequestedModel?: boolean;
 }
 
 // ─── Response wrappers ───

--- a/ui/src/lib/api/types.ts
+++ b/ui/src/lib/api/types.ts
@@ -1906,6 +1906,7 @@ export interface FridayModelRoutingConfig {
   defaultProviderId: string;
   defaultModel?: string;
   fallbackProviderIds: string[];
+  enforceRequestedModel?: boolean;
 }
 
 export interface FridayOAuthLoginInitiation {

--- a/ui/src/routes/usage-page.tsx
+++ b/ui/src/routes/usage-page.tsx
@@ -1,10 +1,16 @@
 import { useQuery } from "@tanstack/react-query";
 import { apiClient } from "@/lib/api/client";
+import { providersApi } from "@/lib/api/providers";
 import { providerUsageApi } from "@/lib/api/provider-usage";
 import { SkeletonCard, StatusPill } from "@/components/core/primitives";
 import { localize } from "@/lib/i18n/localized-text";
 import { useAppLocale } from "@/providers/locale-provider";
-import type { FridayLlmBudgetStatus, FridayProviderUsageSummary } from "@/lib/api/types";
+import type {
+  FridayLlmBudgetStatus,
+  FridayModelRoutingConfig,
+  FridayProviderRoutingExplainReport,
+  FridayProviderUsageSummary,
+} from "@/lib/api/types";
 
 // ─── Types ───
 
@@ -91,6 +97,23 @@ function useProviders() {
   });
 }
 
+function useRoutingConfig() {
+  return useQuery({
+    queryKey: ["provider-routing"],
+    queryFn: async (): Promise<FridayModelRoutingConfig> => providersApi.getRouting(),
+    refetchInterval: 30_000,
+  });
+}
+
+function useRoutingExplain() {
+  return useQuery({
+    queryKey: ["provider-routing-explain", "usage-page"],
+    queryFn: async (): Promise<FridayProviderRoutingExplainReport> =>
+      providersApi.explainRouting({ estimatedInputTokens: 0, complexity: "medium" }),
+    refetchInterval: 30_000,
+  });
+}
+
 // ─── Helpers ───
 
 function formatNumber(n: number): string {
@@ -167,6 +190,8 @@ export function UsagePage() {
   const { data: usageSummary, isLoading: usageLoading, isError: usageError } = useProviderUsage();
   const { data: budgetStatus, isLoading: budgetLoading, isError: budgetError } = useBudgetStatus();
   const { data: providers = [], isLoading: providersLoading, isError: providersError } = useProviders();
+  const { data: routingConfig, isLoading: routingLoading, isError: routingConfigError } = useRoutingConfig();
+  const { data: routingExplain, isLoading: routingExplainLoading, isError: routingExplainError } = useRoutingExplain();
 
   const isLoading = healthLoading || usageLoading || budgetLoading || providersLoading;
   const isError = healthError || usageError || budgetError || providersError;
@@ -187,6 +212,14 @@ export function UsagePage() {
   // Build per-provider cost table by joining health with provider metadata.
   const providerMap = new Map(providers.map((p) => [p.id, p]));
   const healthMap = new Map(healthItems.map((item) => [item.providerId, item]));
+  const selectedRoute = routingExplain?.selected ?? routingExplain?.candidates.find((candidate) => candidate.selected);
+  const defaultProvider = routingConfig ? providerMap.get(routingConfig.defaultProviderId) : undefined;
+  const selectedProvider = selectedRoute ? providerMap.get(selectedRoute.providerId) : undefined;
+  const routeDiffersFromDefault = Boolean(
+    routingConfig
+    && selectedRoute
+    && selectedRoute.providerId !== routingConfig.defaultProviderId,
+  );
   const costRows = (usageSummary?.rows ?? []).map((row) => {
     const providerId = row.providerId ?? "";
     const meta = providerMap.get(providerId);
@@ -237,6 +270,69 @@ export function UsagePage() {
         </div>
       ) : (
         <div className="space-y-6">
+          {/* ─── Active Routing Snapshot ─── */}
+          <div className="rounded-xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] p-5">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <h2 className="text-sm font-medium text-[color:var(--color-text-primary)]">
+                  {localize(locale, "当前默认路由", "Current Default Route")}
+                </h2>
+                <p className="mt-1 text-xs text-[color:var(--color-text-secondary)]">
+                  {localize(
+                    locale,
+                    "这里是下一次未显式指定 provider/model 时的实际路由说明；下面的用量表只是历史账本，不代表下一次会用哪把 key。",
+                    "This shows the route Friday will use for the next run without an explicit provider/model. The usage table below is historical ledger data, not the next-key selector.",
+                  )}
+                </p>
+              </div>
+              {routingLoading || routingExplainLoading ? (
+                <StatusPill>{localize(locale, "检查中", "Checking")}</StatusPill>
+              ) : routeDiffersFromDefault ? (
+                <StatusPill tone="warning">{localize(locale, "路由已调整", "Route adjusted")}</StatusPill>
+              ) : selectedRoute ? (
+                <StatusPill tone="success">{localize(locale, "按默认路由", "Default route")}</StatusPill>
+              ) : (
+                <StatusPill tone="warning">{localize(locale, "不可用", "Unavailable")}</StatusPill>
+              )}
+            </div>
+
+            {routingConfigError || routingExplainError ? (
+              <p className="mt-4 rounded-lg bg-[color:var(--color-bg-warning-subtle)] p-3 text-xs text-[color:var(--color-text-secondary)]">
+                {localize(locale, "无法读取当前路由解释。请到 Providers 页面检查 provider 健康状态。", "Unable to read the current routing explanation. Check provider health on the Providers page.")}
+              </p>
+            ) : (
+              <div className="mt-4 grid gap-3 md:grid-cols-3">
+                <div className="rounded-lg bg-[color:var(--color-bg-subtle)] p-3">
+                  <p className="text-xs text-[color:var(--color-text-secondary)]">{localize(locale, "配置默认", "Configured default")}</p>
+                  <p className="mt-1 text-sm font-semibold text-[color:var(--color-text-primary)]">
+                    {defaultProvider?.name ?? routingConfig?.defaultProviderId ?? "n/a"}
+                  </p>
+                  <p className="mt-1 text-xs text-[color:var(--color-text-tertiary)]">
+                    {routingConfig?.defaultModel ?? localize(locale, "使用 provider 默认模型", "Provider default model")}
+                  </p>
+                </div>
+                <div className="rounded-lg bg-[color:var(--color-bg-subtle)] p-3">
+                  <p className="text-xs text-[color:var(--color-text-secondary)]">{localize(locale, "实际首选", "Actual first choice")}</p>
+                  <p className="mt-1 text-sm font-semibold text-[color:var(--color-text-primary)]">
+                    {selectedProvider?.name ?? selectedRoute?.providerId ?? "n/a"}
+                  </p>
+                  <p className="mt-1 text-xs text-[color:var(--color-text-tertiary)]">
+                    {selectedRoute?.model ?? "n/a"}
+                  </p>
+                </div>
+                <div className="rounded-lg bg-[color:var(--color-bg-subtle)] p-3">
+                  <p className="text-xs text-[color:var(--color-text-secondary)]">{localize(locale, "原因", "Reason")}</p>
+                  <p className="mt-1 text-sm font-semibold text-[color:var(--color-text-primary)]">
+                    {routingExplain?.reasonCode ?? "n/a"}
+                  </p>
+                  <p className="mt-1 text-xs text-[color:var(--color-text-tertiary)]">
+                    {routingExplain?.reasonText ?? localize(locale, "暂无路由说明", "No routing explanation available")}
+                  </p>
+                </div>
+              </div>
+            )}
+          </div>
+
           {/* ─── Token Usage Summary ─── */}
           <div className="rounded-xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] p-5">
             <h2 className="text-sm font-medium text-[color:var(--color-text-primary)]">


### PR DESCRIPTION
## Summary
- Preserve configured provider order while budget is healthy so default OpenAI routes are not silently reordered to cheaper fallbacks.
- Scope historical routing learning by user/hub and make session run stale-message reuse explicit.
- Keep UI chat run updates attached to the originating session and clarify Usage page current route vs historical ledger.
- Fix provider usage default date range to UTC so late-evening local OpenAI usage appears in the default report.

## Verification
- Real OpenAI smoke: route selected OpenAI/gpt-4o-mini, actualProviderKind=openai, actualProviderApi=openai-responses, fallbackAttempts=0, usage row visible with UTC default range.
- npm test -- test/unit/providers/services/friday-provider-service.test.ts test/unit/providers/api/friday-provider-routes.test.ts test/unit/api/http/routes/friday-session-routes.test.ts test/unit/ui/use-chat-session.test.ts test/unit/api/http/routes/friday-provider-usage-routes.test.ts
- npm run build
- npm run lint
- npm run test:contracts:routes
- npm run test:contracts:types
- npm run test:e2e:browser-mock-hub
- git diff --check

Note: lint exits 0 with existing warnings.