### PR TITLE
fix: harden channel persona and release UI

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,37 @@
+Friday Third-Party Notices
+
+Friday is licensed under GPL-3.0-only. This NOTICE preserves upstream
+attribution for third-party source, compatibility logic, or reference material
+that has been adapted into, retained by, or used to maintain compatibility in
+this repository.
+
+OpenClaw / Clawdbot
+-------------------
+
+Some Friday components and historical reference materials were adapted from,
+ported from, or designed for compatibility with OpenClaw / Clawdbot behavior,
+including legacy SKILL.md compatibility, agent runtime references, scheduler
+guard behavior, and benchmark/adoption materials.
+
+Original copyright and license notice:
+
+MIT License
+
+Copyright (c) 2025 Peter Steinberger
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -166,3 +166,7 @@ Friday is open-source software under the license in [LICENSE](LICENSE). Before p
 <p align="center">
   <sub>Built to grow with you, without losing the boundary.</sub>
 </p>
+
+## Third-Party Notices
+
+Friday includes compatibility and adaptation work for third-party agent ecosystem formats and behavior. See [NOTICE](NOTICE) for preserved upstream copyright and license notices.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -166,3 +166,7 @@ Friday 是开源软件，许可证以 [LICENSE](LICENSE) 为准。公开发布�
 <p align="center">
   <sub>持续成长，但不丢边界。</sub>
 </p>
+
+## 第三方声明
+
+Friday 包含面向第三方 Agent 生态格式和行为的兼容与适配工作。上游版权和许可声明见 [NOTICE](NOTICE)。

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "!dist/**/*.js.map",
     "!dist/**/*.d.ts.map",
     "README.md",
+    "NOTICE",
     "LICENSE"
   ],
   "bin": {

--- a/src/api/http/routes/friday-channel-routes.ts
+++ b/src/api/http/routes/friday-channel-routes.ts
@@ -4,6 +4,8 @@ import type { FridayRouteDefinition } from "../../model/friday-api-common.types.
 
 export interface FridayChannelRoutesDeps {
   registry: FridayChannelRegistry;
+  /** Channel kinds supported by the runtime even when no instance is currently enabled. */
+  supportedKinds?: readonly string[];
   nowIso?: () => string;
   persistPersona?: (kind: string, config: FridayChannelPersonaConfig | null) => void | Promise<void>;
 }
@@ -69,6 +71,21 @@ function requireRegisteredChannel(
   }
 }
 
+function requirePersonaChannelKind(
+  deps: FridayChannelRoutesDeps,
+  kind: string,
+): void {
+  if (deps.registry.describe(kind)) {
+    return;
+  }
+  if ((deps.supportedKinds ?? []).includes(kind)) {
+    return;
+  }
+  throw new FridayDomainError("CHANNEL_NOT_FOUND", `Channel "${kind}" is not registered`, {
+    httpStatus: 404,
+  });
+}
+
 export function createFridayChannelRoutes(
   deps: FridayChannelRoutesDeps,
 ): FridayRouteDefinition<unknown, unknown, unknown, unknown>[] {
@@ -112,7 +129,7 @@ export function createFridayChannelRoutes(
       auth: { public: false, anyOfScopes: ["hub.admin"] },
       async handler(ctx) {
         const kind = String((ctx.params as Record<string, unknown>).kind ?? "").trim();
-        requireRegisteredChannel(deps, kind);
+        requirePersonaChannelKind(deps, kind);
         const persona = channelPersonaStore.get(kind);
         return { kind, persona: persona ?? null };
       },
@@ -124,7 +141,7 @@ export function createFridayChannelRoutes(
       auth: { public: false, anyOfScopes: ["hub.admin"] },
       async handler(ctx) {
         const kind = String((ctx.params as Record<string, unknown>).kind ?? "").trim();
-        requireRegisteredChannel(deps, kind);
+        requirePersonaChannelKind(deps, kind);
         const body = ctx.body as Record<string, unknown> | undefined;
         if (!body || typeof body !== "object") {
           throw new FridayDomainError("VALIDATION_ERROR", "Request body is required", { httpStatus: 400 });

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -229,7 +229,7 @@ import {
   parseFridayChannelsConfig,
   resolveFridayChannelSecretPolicy,
 } from "#channels";
-import type { FridayChannelMessage, FridayChannelRegistry } from "#channels";
+import type { FridayChannelMessage, FridayChannelRegistry, FridaySupportedChannelKind } from "#channels";
 import { createFridayChannelInboundDebouncer, createFridayChannelTypingController, sanitizeChannelInput } from "#channels";
 import { createFridayChannelSlowTaskNotifier } from "../channels/friday-channel-slow-task-notifier.js";
 import { resolveFridayPublicRunUrl } from "../agent/runtime/friday-public-run-url.js";
@@ -4740,7 +4740,7 @@ export async function createFridayHub(
 
     const personas: Record<string, FridayChannelPersonaConfig> = {};
     for (const [kind, value] of Object.entries(parsed)) {
-      if (!channelRegistry.describe(kind)) {
+      if (!channelRegistry.describe(kind) && !FRIDAY_SUPPORTED_CHANNEL_KINDS.includes(kind as FridaySupportedChannelKind)) {
         continue;
       }
       if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -4834,6 +4834,7 @@ export async function createFridayHub(
     observabilityService,
     channels: {
       registry: channelRegistry,
+      supportedKinds: [...FRIDAY_SUPPORTED_CHANNEL_KINDS],
       nowIso,
       persistPersona(kind, config) {
         const personas = loadPersistedChannelPersonas();

--- a/test/unit/api/http/routes/friday-channel-routes.test.ts
+++ b/test/unit/api/http/routes/friday-channel-routes.test.ts
@@ -165,6 +165,47 @@ describe("createFridayChannelRoutes", () => {
     });
   });
 
+  it("stores persona for a supported channel kind before an instance is enabled", async () => {
+    const deps = {
+      ...createDeps(),
+      supportedKinds: ["discord"],
+    };
+    const routes = createFridayChannelRoutes(deps);
+    const updateRoute = routes.find((item) => item.operationId === "channels.persona.update");
+    const getRoute = routes.find((item) => item.operationId === "channels.persona.get");
+
+    const updateResult = await updateRoute!.handler(makeCtx({
+      params: { kind: "discord" },
+      body: {
+        persona: "Discord operator persona",
+        systemPrompt: "",
+      },
+    }) as never);
+    const getResult = await getRoute!.handler(makeCtx({ params: { kind: "discord" } }) as never);
+
+    expect(updateResult).toMatchObject({
+      kind: "discord",
+      persona: {
+        persona: "Discord operator persona",
+        systemPrompt: "",
+        updatedAt: NOW,
+      },
+    });
+    expect(getResult).toMatchObject({
+      kind: "discord",
+      persona: {
+        persona: "Discord operator persona",
+        systemPrompt: "",
+        updatedAt: NOW,
+      },
+    });
+    expect(deps.persistPersona).toHaveBeenCalledWith("discord", {
+      persona: "Discord operator persona",
+      systemPrompt: "",
+      updatedAt: NOW,
+    });
+  });
+
   it("clears a stored channel persona when both fields are empty", async () => {
     const routes = createFridayChannelRoutes(createDeps());
     const updateRoute = routes.find((item) => item.operationId === "channels.persona.update");

--- a/ui/src/components/workflows/workflow-builder-workspace.tsx
+++ b/ui/src/components/workflows/workflow-builder-workspace.tsx
@@ -1973,10 +1973,14 @@ function WorkflowBuilderEditor() {
       ghost.style.letterSpacing = "0.08em";
       ghost.style.textTransform = "uppercase";
       ghost.style.boxShadow = "0 16px 40px rgba(0,0,0,0.3)";
-      ghost.innerHTML = `
-        <div style="opacity:0.58;font-size:10px;margin-bottom:4px;">${paletteEntry?.groupLabel ?? "Workflow node"}</div>
-        <div>${paletteEntry?.label ?? type}</div>
-      `;
+      const ghostGroup = document.createElement("div");
+      ghostGroup.style.opacity = "0.58";
+      ghostGroup.style.fontSize = "10px";
+      ghostGroup.style.marginBottom = "4px";
+      ghostGroup.textContent = paletteEntry?.groupLabel ?? "Workflow node";
+      const ghostLabel = document.createElement("div");
+      ghostLabel.textContent = paletteEntry?.label ?? type;
+      ghost.append(ghostGroup, ghostLabel);
       document.body.appendChild(ghost);
       event.dataTransfer.setDragImage(ghost, 24, 18);
       window.setTimeout(() => {


### PR DESCRIPTION
## Summary
- Allow supported channel persona settings to be configured before a channel instance is enabled, preserving Discord/channel setup state.
- Replace workflow drag ghost innerHTML with DOM/textContent construction.
- Add NOTICE packaging and README references for preserved upstream attribution.

## Verification
- npm run release:verify:repo
- npm run release:verify with live local Friday + OpenAI provider env-ref
- npx vitest run test/unit/api/http/routes/friday-channel-routes.test.ts test/unit/agent/runtime/friday-agent-runtime.test.ts
- git diff --check
- detect-secrets hook with CI baseline
- real Chrome UI checks for usage route, channel outbound, and channel-to-main handoff isolation