### PR TITLE
Fix UI 404 for npm-installed users

### DIFF
--- a/scripts/ci/install-smoke.mjs
+++ b/scripts/ci/install-smoke.mjs
@@ -10,7 +10,10 @@
  *   4. Start the server with isolated state
  *   5. Poll GET /v1/health until success
  *   6. POST /v1/auth/login with { "local": true }
- *   7. Send SIGINT, verify clean shutdown
+ *   7. GET / — verifies the UI bundle is served from the install location
+ *      (regression guard: the CLI must resolve dist/ui relative to the
+ *      installed module, not relative to process.cwd())
+ *   8. Send SIGINT, verify clean shutdown
  */
 
 import { execSync, spawn } from "node:child_process";
@@ -238,8 +241,28 @@ async function run() {
     fail(`Login request failed: ${err.message}`);
   }
 
-  // ── Step 7: Clean shutdown via SIGINT ──
-  console.log("7. Sending SIGINT for clean shutdown…");
+  // ── Step 7: GET / — UI bundle served from install location ──
+  console.log("7. Verifying GET / serves the bundled UI…");
+  try {
+    const rootRes = await fetch(`http://127.0.0.1:${port}/`);
+    if (rootRes.status !== 200) {
+      fail(`GET / returned status ${rootRes.status} (expected 200)`);
+    }
+    const rootBody = await rootRes.text();
+    const looksLikeHtml =
+      /<!doctype html/i.test(rootBody) || /<html[\s>]/i.test(rootBody);
+    if (!looksLikeHtml) {
+      fail(
+        `GET / did not return HTML. First 200 chars: ${rootBody.slice(0, 200)}`,
+      );
+    }
+    console.log("   → UI bundle served ✓");
+  } catch (err) {
+    fail(`GET / failed: ${err.message}`);
+  }
+
+  // ── Step 8: Clean shutdown via SIGINT ──
+  console.log("8. Sending SIGINT for clean shutdown…");
   serverProc.kill("SIGINT");
 
   const shutdownDeadline = Date.now() + 10_000;

--- a/src/cli/friday-cli-run-loop.ts
+++ b/src/cli/friday-cli-run-loop.ts
@@ -6,10 +6,29 @@
  */
 
 import { exec } from "node:child_process";
-import { resolve } from "node:path";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import type { FridayHub } from "#hub";
 import { createFridayHttpServer } from "../api/http/friday-http-server.js";
 import type { FridayHttpTrustProxyMode } from "../api/http/friday-http-client-ip.js";
+
+// Resolve the UI bundle shipped alongside this CLI module.
+// After build, this file lives at dist/cli/friday-cli-run-loop.js, so dist/ui
+// is a sibling: `../ui` relative to __dirname. This lets `npm install -g`
+// users run `friday start` from any directory without setting
+// FRIDAY_UI_DIST_DIR. As a secondary fallback for local dev where a user
+// runs an unbuilt module directly, also accept `process.cwd()/dist/ui`.
+function resolveBundledUiStaticDir(): string {
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const bundled = resolve(here, "../ui");
+    if (existsSync(bundled)) return bundled;
+  } catch {
+    // fall through to cwd-based fallback
+  }
+  return resolve(process.cwd(), "dist/ui");
+}
 
 // ─── Types ───
 
@@ -20,7 +39,7 @@ export interface FridayCliRunLoopDeps {
   corsOrigins?: string[];
   logRequests?: boolean;
   trustProxyMode?: FridayHttpTrustProxyMode;
-  /** Directory containing static UI assets. Default: dist/ui relative to cwd. */
+  /** Directory containing static UI assets. Default: dist/ui bundled alongside this module. */
   uiStaticDir?: string;
   /** Override process.exit for testing. Defaults to process.exit. */
   exit?: (code: number) => void;
@@ -31,7 +50,7 @@ export interface FridayCliRunLoopDeps {
 export function runFridayCliLoop(deps: FridayCliRunLoopDeps): Promise<void> {
   const { hub, port, host, corsOrigins, logRequests, exit = (code: number) => process.exit(code) } = deps;
   const listenHost = host ?? "127.0.0.1";
-  const uiStaticDir = deps.uiStaticDir ?? resolve(process.cwd(), "dist/ui");
+  const uiStaticDir = deps.uiStaticDir ?? resolveBundledUiStaticDir();
 
   const httpServer = createFridayHttpServer({
     routes: hub.apiRuntime.routes,


### PR DESCRIPTION
## Summary

- Real users running `npm install -g @thesongzhu/friday && friday start` from any directory hit **404 on GET /** because the UI static dir was resolved against `process.cwd()` instead of the installed module's own location. [src/cli/friday-cli-run-loop.ts](src/cli/friday-cli-run-loop.ts) now resolves `dist/ui` via `import.meta.url`, so the UI bundle is always found next to the CLI module — regardless of where the user runs `friday start` from.
- [scripts/ci/install-smoke.mjs](scripts/ci/install-smoke.mjs) gains a regression guard: after `npm pack` + install into a fresh temp dir, it requires `GET /` to return 200 HTML. In-repo unit tests can't catch this class of bug (cwd happens to be correct in dev), so the guard runs against the real tarball.

## Why

Without this fix, every first-time user from npm sees a blank page / 404 the moment they open the browser — setup wizard never loads. The cwd-based default worked for contributors running from the repo root but silently failed for the primary distribution path.

## Test plan

- [x] `node scripts/ci/install-smoke.mjs` passes end-to-end (pack → install in /tmp → health → login → GET / returns HTML → SIGINT clean exit)
- [x] Manually verified: clean `npm install` into a fresh `/tmp` dir, `cd ~`, `friday start` — GET / returns 200 with the UI bundle (previously 404)
- [x] Full UI wizard walked end-to-end in browser against a real OpenAI key: provider configured + validated, webchat channel enabled, agent chat round-trip succeeded
- [x] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)