### PR TITLE
fix: backfill actual route into session usage

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -374,7 +374,7 @@
         "filename": "scripts/ci/install-smoke.mjs",
         "hashed_secret": "7cfc6f6e3b1ff03a56e2ea5a163f92e95a192106",
         "is_verified": false,
-        "line_number": 147
+        "line_number": 150
       }
     ],
     "scripts/e2e-workflow-generator.sh": [
@@ -1175,5 +1175,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-23T05:40:45Z"
+  "generated_at": "2026-04-23T08:20:08Z"
 }

--- a/src/agent/persistence/friday-agent-run-repository.ts
+++ b/src/agent/persistence/friday-agent-run-repository.ts
@@ -128,6 +128,8 @@ export interface FridayAgentRunRepository {
     input: {
       id: string;
       status?: FridayAgentRunStatus;
+      providerId?: string;
+      model?: string;
       attempt?: number;
       artifacts?: FridayAgentArtifact[];
       testResults?: FridayAgentTestResult[];
@@ -224,10 +226,26 @@ export function createFridayAgentRunRepository(): FridayAgentRunRepository {
     update(db, input) {
       const sets: string[] = [];
       const params: unknown[] = [];
+      const resolvedProviderId = input.providerId
+        ?? (typeof input.actualExecution?.actualProviderId === "string"
+          ? input.actualExecution.actualProviderId
+          : undefined);
+      const resolvedModel = input.model
+        ?? (typeof input.actualExecution?.actualModel === "string"
+          ? input.actualExecution.actualModel
+          : undefined);
 
       if (input.status !== undefined) {
         sets.push("status = ?");
         params.push(input.status);
+      }
+      if (resolvedProviderId !== undefined) {
+        sets.push("provider_id = ?");
+        params.push(resolvedProviderId);
+      }
+      if (resolvedModel !== undefined) {
+        sets.push("model = ?");
+        params.push(resolvedModel);
       }
       if (input.attempt !== undefined) {
         sets.push("attempt = ?");

--- a/test/unit/agent/persistence/friday-agent-run-repository.test.ts
+++ b/test/unit/agent/persistence/friday-agent-run-repository.test.ts
@@ -293,6 +293,45 @@ describe("FridayAgentRunRepository", () => {
       );
 
       expect(updated?.actualExecution).toEqual(actualExecution);
+      expect(updated?.providerId).toBe("anthropic-1");
+      expect(updated?.model).toBe("claude-3-haiku");
+    });
+
+    it("prefers the actual route over the originally requested route for aggregation fields", () => {
+      const repo = createRepo();
+      const id = idGenerator();
+      db.withWriteTransaction((writer) =>
+        repo.create(writer, {
+          id,
+          task: "Actual route overwrite test",
+          sessionKey: "agent:run:actual-overwrite",
+          providerId: "requested-provider",
+          model: "requested-model",
+          maxAttempts: 3,
+          nowIso: NOW,
+        }),
+      );
+
+      const updated = db.withWriteTransaction((writer) =>
+        repo.update(writer, {
+          id,
+          actualExecution: {
+            actualProviderId: "actual-provider",
+            actualModel: "actual-model",
+            turns: [
+              {
+                providerId: "actual-provider",
+                model: "actual-model",
+                inputTokens: 1,
+                outputTokens: 1,
+              },
+            ],
+          },
+        }),
+      );
+
+      expect(updated?.providerId).toBe("actual-provider");
+      expect(updated?.model).toBe("actual-model");
     });
 
     it("round-trips constraints_json", () => {

--- a/test/unit/api/http/routes/friday-session-usage-routes.test.ts
+++ b/test/unit/api/http/routes/friday-session-usage-routes.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, afterEach } from "vitest";
+
+import { createFridaySessionUsageRoutes } from "../../../../../src/api/http/routes/friday-session-usage-routes.js";
+import { createFridayAgentRunRepository } from "#agent";
+import { createTestDb } from "../../../satellites/_helpers/create-test-db.helper.js";
+
+describe("FridaySessionUsageRoutes", () => {
+  const db = createTestDb();
+
+  afterEach(() => {
+    db.withWriteTransaction((writer) => {
+      writer.prepare("DELETE FROM friday_agent_runs").run();
+    });
+  });
+
+  it("aggregates usage by the actual provider route recorded after execution", async () => {
+    const repo = createFridayAgentRunRepository();
+    db.withWriteTransaction((writer) => {
+      repo.create(writer, {
+        id: "run-1",
+        task: "Route aggregation test",
+        sessionKey: "webchat:test:usage-route",
+        maxAttempts: 1,
+        nowIso: "2026-04-23T08:10:00.000Z",
+      });
+      repo.update(writer, {
+        id: "run-1",
+        status: "completed",
+        completedAt: "2026-04-23T08:10:05.000Z",
+        usageInput: 12,
+        usageOutput: 6,
+        costUsd: 0.0012,
+        actualExecution: {
+          actualProviderId: "openai-live",
+          actualModel: "gpt-4o-mini",
+          turns: [
+            {
+              providerId: "openai-live",
+              model: "gpt-4o-mini",
+              inputTokens: 12,
+              outputTokens: 6,
+              costUsd: 0.0012,
+            },
+          ],
+        },
+      });
+    });
+
+    const route = createFridaySessionUsageRoutes({ db })
+      .find((entry) => entry.operationId === "sessions.usage.get");
+
+    if (!route) {
+      throw new Error("sessions.usage.get route not found");
+    }
+
+    const result = await route.handler({
+      requestId: "req-session-usage",
+      receivedAt: "2026-04-23T08:10:06.000Z",
+      params: { sessionKey: "webchat:test:usage-route" },
+      query: {},
+      body: undefined,
+      headers: {},
+      principal: null,
+    });
+
+    expect(result).toMatchObject({
+      sessionKey: "webchat:test:usage-route",
+      totalInputTokens: 12,
+      totalOutputTokens: 6,
+      totalCostUsd: 0.0012,
+      totalRuns: 1,
+      byModel: [
+        {
+          providerId: "openai-live",
+          model: "gpt-4o-mini",
+          inputTokens: 12,
+          outputTokens: 6,
+          costUsd: 0.0012,
+          runs: 1,
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
## Summary\n- backfill provider_id/model on agent run updates from actual_execution\n- keep session usage aggregation tied to the actual provider/model route\n- add unit coverage for actual-route overwrite and session usage aggregation\n\n## Verification\n- git merge-base --is-ancestor 88e4746 HEAD\n- git diff --check 88e4746 HEAD --\n- npx vitest run test/unit/agent/persistence/friday-agent-run-repository.test.ts test/unit/api/http/routes/friday-session-usage-routes.test.ts test/unit/api/http/routes/friday-channel-routes.test.ts\n- npm run build:api\n- live local Friday on 127.0.0.1 with real OpenAI env-ref: session usage returned providerId/model and usageHasNullRoute=false\n