### PR TITLE
Fix provider schema errors and plan-mode chat gate

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -410,7 +410,7 @@
         "filename": "src/api/http/routes/friday-provider-routes.ts",
         "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
         "is_verified": false,
-        "line_number": 98
+        "line_number": 176
       }
     ],
     "src/api/http/routes/friday-setup-routes.ts": [
@@ -1175,5 +1175,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-23T08:20:08Z"
+  "generated_at": "2026-04-23T08:56:36Z"
 }

--- a/src/agent/runtime/friday-agent-planning-gate.ts
+++ b/src/agent/runtime/friday-agent-planning-gate.ts
@@ -6,6 +6,7 @@ import type {
   FridayAgentActualExecution,
   FridayAgentEventMap,
   FridayAgentPlanReviewPayload,
+  FridayAgentRunConstraints,
   FridayAgentRunStatus,
 } from "../model/friday-agent.types.js";
 import type { FridayAgentRunEventRepository } from "../persistence/friday-agent-run-event-repository.js";
@@ -40,7 +41,7 @@ export interface FridayAgentPlanningGateService {
     providerId?: string;
     model?: string;
     taskProfile?: FridayResolvedAgentTaskProfile;
-    constraints?: { readOnly?: boolean; operationalMode?: string };
+    constraints?: FridayAgentRunConstraints;
     reviewRequired?: boolean;
     conversationContext?: FridayAgentConversationContext;
     focusState?: {
@@ -78,6 +79,7 @@ const EXPORT_WORKFLOW_HINTS = /\b(export workflow|workflow bundle|package workfl
 const MAJOR_DECISION_HINTS = /\b(architecture|architect|strategy|migration|roadmap|implementation plan|rollout plan|major refactor|large refactor|overhaul|choose between|decision|tradeoff|design the approach)\b/i;
 const CONSTRAINT_HINTS = /\b(must|should|avoid|without|constraint|permission|runtime|read.?only|safe|safely|don't|do not|cannot)\b/i;
 const DETAIL_HINTS = /\b(trigger|input|output|destination|runtime|workspace|browser|provider|channel|timeline|success|goal|constraint|notify|deploy|export)\b/i;
+const SIMPLE_ARITHMETIC_HINTS = /^\s*(?:what\s+is\s+)?-?\d+(?:\.\d+)?\s*(?:[+\-*/xX÷]|plus|minus|times|multiplied by|divided by)\s*-?\d+(?:\.\d+)?\s*\??\s*$/i;
 
 function normalizeText(value: string): string {
   return value.trim().replace(/\s+/g, " ");
@@ -104,6 +106,22 @@ function detectPlanningKind(task: string, reviewRequired?: boolean): FridayPlann
   if (GENERATE_WORKFLOW_HINTS.test(normalized)) return "generate_workflow";
   if (MAJOR_DECISION_HINTS.test(normalized)) return "major_decision";
   return null;
+}
+
+function hasPlanningActionHint(task: string): boolean {
+  return GENERATE_SKILL_HINTS.test(task)
+    || GENERATE_WORKFLOW_HINTS.test(task)
+    || DEPLOY_WORKFLOW_HINTS.test(task)
+    || EXPORT_WORKFLOW_HINTS.test(task)
+    || MAJOR_DECISION_HINTS.test(task);
+}
+
+function shouldBypassForcedPlanMode(task: string, reviewRequired?: boolean): boolean {
+  if (reviewRequired) return false;
+  const normalized = normalizeText(task);
+  if (QA_BYPASS_HINTS.test(normalized)) return true;
+  if (SIMPLE_ARITHMETIC_HINTS.test(normalized)) return true;
+  return normalized.endsWith("?") && normalized.length <= 240 && !hasPlanningActionHint(normalized);
 }
 
 function isTaskDetailedEnough(task: string, kind: FridayPlanningKind): boolean {
@@ -308,7 +326,7 @@ export function createFridayAgentPlanningGateService(
     providerId?: string;
     model?: string;
     taskProfile?: FridayResolvedAgentTaskProfile;
-    constraints?: { readOnly?: boolean };
+    constraints?: FridayAgentRunConstraints;
     kind: FridayPlanningKind;
     status: "awaiting_clarification" | "awaiting_plan_approval";
     message: string;
@@ -612,9 +630,10 @@ export function createFridayAgentPlanningGateService(
         return { action: "pass_through", pendingPlanRunId: null };
       }
 
-      // ─── Plan mode bypass: force all tasks through the planning gate ───
+      // Plan mode gates execution/design work, but safe Q&A still belongs in the
+      // normal chat path so accidental UI/API plan constraints do not block it.
       const operationalMode = input.focusState?.operationalMode ?? input.constraints?.operationalMode;
-      const kind = operationalMode === "plan"
+      const kind = operationalMode === "plan" && !shouldBypassForcedPlanMode(input.task, input.reviewRequired)
         ? "major_decision" as FridayPlanningKind
         : detectPlanningKind(input.task, input.reviewRequired);
       if (!kind) {

--- a/src/api/http/routes/friday-provider-routes.ts
+++ b/src/api/http/routes/friday-provider-routes.ts
@@ -47,6 +47,83 @@ const VALID_KINDS = new Set<string>(FRIDAY_PROVIDER_KINDS);
 const VALID_APIS = new Set<string>(FRIDAY_PROVIDER_APIS);
 const VALID_BACKEND_KINDS = new Set<string>(FRIDAY_PROVIDER_BACKEND_KINDS);
 const VALID_AUTH_MODES = new Set(["api-key", "bearer-token", "oauth", "token", "external-session", "none"]);
+const VALID_DEPLOYMENT_KINDS = new Set(["hosted", "local", "self-hosted", "consumer-cli"]);
+const VALID_REGION_TAGS = new Set(["global", "us", "china", "local", "custom"]);
+
+const PROVIDER_CREATE_ACCEPTED_FIELDS = [
+  "kind",
+  "name",
+  "backendKind",
+  "baseUrl",
+  "authMode",
+  "api",
+  "apiKey",
+  "supportedModels",
+  "defaultModel",
+  "headers",
+  "cliConfig",
+  "deploymentKind",
+  "regionTag",
+  "enabled",
+  "validateOnSave",
+] as const;
+
+const PROVIDER_CREATE_REQUIRED_FIELDS = [
+  "kind",
+  "name",
+  "baseUrl",
+  "authMode",
+  "api",
+  "supportedModels",
+] as const;
+
+const PROVIDER_CREATE_FIELD_ALIASES = {
+  providerKind: "kind",
+  displayName: "name",
+  providerName: "name",
+  apiBaseUrl: "baseUrl",
+  baseURL: "baseUrl",
+  providerApi: "api",
+  models: "supportedModels",
+  modelIds: "supportedModels",
+  validate: "validateOnSave",
+} as const;
+
+function providerCreateSchemaDetails(): Record<string, unknown> {
+  return {
+    acceptedFields: [...PROVIDER_CREATE_ACCEPTED_FIELDS],
+    requiredFields: [...PROVIDER_CREATE_REQUIRED_FIELDS],
+    aliases: PROVIDER_CREATE_FIELD_ALIASES,
+    enums: {
+      kind: [...FRIDAY_PROVIDER_KINDS],
+      backendKind: [...FRIDAY_PROVIDER_BACKEND_KINDS],
+      authMode: [...VALID_AUTH_MODES],
+      api: [...FRIDAY_PROVIDER_APIS],
+      deploymentKind: [...VALID_DEPLOYMENT_KINDS],
+      regionTag: [...VALID_REGION_TAGS],
+    },
+    example: {
+      kind: "openai",
+      name: "OpenAI",
+      backendKind: "http",
+      baseUrl: "https://api.openai.com",
+      authMode: "api-key",
+      api: "openai-completions",
+      apiKey: "<secret>",
+      supportedModels: ["gpt-4o"],
+      defaultModel: "gpt-4o",
+      validateOnSave: true,
+    },
+  };
+}
+
+function pushProviderCreateAliasErrors(body: Record<string, unknown>, errors: string[]): void {
+  for (const [alias, canonical] of Object.entries(PROVIDER_CREATE_FIELD_ALIASES)) {
+    if (body[alias] !== undefined) {
+      errors.push(`${alias} is not accepted; use ${canonical}`);
+    }
+  }
+}
 
 function validateCliConfig(value: unknown, errors: string[]): void {
   if (value === undefined) return;
@@ -69,6 +146,7 @@ function validateCreateBody(body: unknown): asserts body is FridayCreateProvider
   }
   const b = body as Record<string, unknown>;
   const errors: string[] = [];
+  pushProviderCreateAliasErrors(b, errors);
 
   if (typeof b.kind !== "string" || !VALID_KINDS.has(b.kind)) {
     errors.push(`kind must be one of: ${[...VALID_KINDS].join(", ")}`);
@@ -110,10 +188,22 @@ function validateCreateBody(body: unknown): asserts body is FridayCreateProvider
   if (b.headers !== undefined && (b.headers == null || typeof b.headers !== "object" || Array.isArray(b.headers))) {
     errors.push("headers must be an object when provided");
   }
+  if (b.deploymentKind !== undefined && (typeof b.deploymentKind !== "string" || !VALID_DEPLOYMENT_KINDS.has(b.deploymentKind))) {
+    errors.push(`deploymentKind must be one of: ${[...VALID_DEPLOYMENT_KINDS].join(", ")}`);
+  }
+  if (b.regionTag !== undefined && (typeof b.regionTag !== "string" || !VALID_REGION_TAGS.has(b.regionTag))) {
+    errors.push(`regionTag must be one of: ${[...VALID_REGION_TAGS].join(", ")}`);
+  }
   validateCliConfig(b.cliConfig, errors);
 
   if (errors.length > 0) {
-    throw new FridayDomainError("VALIDATION_ERROR", `Invalid request body: ${errors.join("; ")}`, { httpStatus: 400 });
+    throw new FridayDomainError("VALIDATION_ERROR", `Invalid provider create request: ${errors.join("; ")}`, {
+      httpStatus: 422,
+      details: {
+        errors,
+        schema: providerCreateSchemaDetails(),
+      },
+    });
   }
 }
 

--- a/src/api/model/friday-api-agent.types.ts
+++ b/src/api/model/friday-api-agent.types.ts
@@ -1,6 +1,7 @@
 import type {
   FridayAgentContextCostSummary,
   FridayAgentExecutionContext,
+  FridayAgentRunConstraints,
   FridayAgentRunRecord,
   FridayAgentRunStatus,
   FridayAgentTaskProfileInput,
@@ -21,7 +22,7 @@ export interface FridayStartAgentRunRequest {
   timezone?: string;
   timeoutMs?: number;
   requireReview?: boolean;
-  constraints?: { readOnly?: boolean };
+  constraints?: FridayAgentRunConstraints;
   taskProfile?: FridayAgentTaskProfileInput;
   executionContext?: FridayAgentExecutionContext;
 }

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -109,6 +109,7 @@ import type {
   FridayAgentAutomationService,
   FridayAgentExecutionContext,
   FridayAgentMessage,
+  FridayAgentRunConstraints,
   FridayAgentRunRecord,
   FridayAgentRunStatus,
   FridayAgentRuntimeResult,
@@ -2351,7 +2352,7 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
       timeoutMs?: number;
       signal?: AbortSignal;
       reviewRequired?: boolean;
-      constraints?: { readOnly?: boolean };
+      constraints?: FridayAgentRunConstraints;
       principalId?: string;
       scopes?: string[];
       executionContext?: FridayAgentExecutionContext;
@@ -2537,7 +2538,7 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
       timezone?: string;
       timeoutMs?: number;
       requireReview?: boolean;
-      constraints?: { readOnly?: boolean };
+      constraints?: FridayAgentRunConstraints;
       executionContext?: FridayAgentExecutionContext;
       taskProfile?: FridayAgentTaskProfileInput;
       principalId?: string;

--- a/src/engine/friday-engine-turn-preparer.ts
+++ b/src/engine/friday-engine-turn-preparer.ts
@@ -170,7 +170,7 @@ export interface FridayTurnPreparerInput {
   runId: string;
   sessionKey?: string;
   replyToMessageId?: string;
-  constraints?: { readOnly?: boolean };
+  constraints?: FridayEngineRunInput["constraints"];
   persistTaskMessage?: boolean;
   taskAlreadyInHistory?: boolean;
   idempotencyPrefix?: string;

--- a/src/engine/friday-immediate-run-persistence.ts
+++ b/src/engine/friday-immediate-run-persistence.ts
@@ -1,4 +1,5 @@
 import type {
+  FridayAgentRunConstraints,
   FridayAgentRunEventRepository,
   FridayAgentRunRepository,
 } from "#agent";
@@ -18,7 +19,7 @@ export interface FridayImmediateRunPersistenceInput {
   sessionKey?: string;
   providerId?: string;
   model?: string;
-  constraints?: { readOnly?: boolean };
+  constraints?: FridayAgentRunConstraints;
   responseText: string;
 }
 

--- a/test/unit/agent/runtime/friday-agent-planning-gate.test.ts
+++ b/test/unit/agent/runtime/friday-agent-planning-gate.test.ts
@@ -180,6 +180,20 @@ describe("friday-agent-planning-gate", () => {
     expect(runs.get("run-new-workflow")?.actualExecution?.turns).toEqual([]);
   });
 
+  it("does not force safe Q&A through clarification when plan mode is present", () => {
+    const service = createService();
+
+    const decision = service.handleTurn({
+      runId: "run-simple-question",
+      task: "What is 2+2?",
+      sessionKey: "ui:assistant:1",
+      constraints: { readOnly: true, operationalMode: "plan" },
+    });
+
+    expect(decision).toEqual({ action: "pass_through" });
+    expect(runs.has("run-simple-question")).toBe(false);
+  });
+
   it("moves from clarification to plan approval when the user answers follow-up questions", () => {
     const service = createService();
 

--- a/test/unit/api/http/routes/friday-agent-routes.test.ts
+++ b/test/unit/api/http/routes/friday-agent-routes.test.ts
@@ -496,6 +496,44 @@ describe("FridayAgentRoutes", () => {
       );
     });
 
+    it("does not synthesize plan constraints for normal chat requests", async () => {
+      const routes = createFridayAgentRoutes(stubDeps);
+      const route = routes.find((r) => r.operationId === "agent.runs.start")!;
+      const ctx = {
+        body: {
+          task: "What is 2+2?",
+          executionContext: { surface: "chat", interactive: true },
+        },
+        params: {},
+        query: {},
+        headers: {},
+        principal: null,
+        requestId: "req-1",
+        receivedAt: "2026-01-01T00:00:00.000Z",
+      };
+      await route.handler(ctx);
+      const [input] = vi.mocked(stubDeps.startRun).mock.calls[0]!;
+      expect(input.constraints).toBeUndefined();
+    });
+
+    it("forwards explicit operationalMode constraints without making them a UI default", async () => {
+      const routes = createFridayAgentRoutes(stubDeps);
+      const route = routes.find((r) => r.operationId === "agent.runs.start")!;
+      const ctx = {
+        body: { task: "Plan this", constraints: { readOnly: true, operationalMode: "plan" } },
+        params: {},
+        query: {},
+        headers: {},
+        principal: null,
+        requestId: "req-1",
+        receivedAt: "2026-01-01T00:00:00.000Z",
+      };
+      await route.handler(ctx);
+      expect(stubDeps.startRun).toHaveBeenCalledWith(
+        expect.objectContaining({ constraints: { readOnly: true, operationalMode: "plan" } }),
+      );
+    });
+
     it("forwards timezone when provided", async () => {
       const routes = createFridayAgentRoutes(stubDeps);
       const route = routes.find((r) => r.operationId === "agent.runs.start")!;

--- a/test/unit/providers/api/friday-provider-routes.test.ts
+++ b/test/unit/providers/api/friday-provider-routes.test.ts
@@ -354,6 +354,53 @@ describe("FridayProviderRoutes", () => {
       expect(result).toHaveProperty("provider");
     });
 
+    it("providers.create returns schema details and alias hints for invalid field names", async () => {
+      const mockService = makeMockService();
+      const routes = createFridayProviderRoutes({
+        providerService: mockService,
+      });
+      const createRoute = routes.find(
+        (r) => r.operationId === "providers.create",
+      )!;
+
+      await expect(
+        createRoute.handler(makeCtx({
+          body: {
+            providerKind: "openai",
+            displayName: "Test",
+            baseUrl: "https://api.openai.com",
+            authMode: "api-key",
+            api: "openai-completions",
+            supportedModels: ["gpt-4o"],
+          },
+        })),
+      ).rejects.toMatchObject({
+        code: "VALIDATION_ERROR",
+        httpStatus: 422,
+        message: expect.stringContaining("providerKind is not accepted; use kind"),
+        details: {
+          errors: expect.arrayContaining([
+            "providerKind is not accepted; use kind",
+            "displayName is not accepted; use name",
+          ]),
+          schema: expect.objectContaining({
+            acceptedFields: expect.arrayContaining(["kind", "name", "baseUrl", "api", "supportedModels"]),
+            requiredFields: expect.arrayContaining(["kind", "name", "baseUrl", "authMode", "api", "supportedModels"]),
+            enums: expect.objectContaining({
+              kind: expect.arrayContaining(["openai"]),
+              authMode: expect.arrayContaining(["api-key"]),
+              api: expect.arrayContaining(["openai-completions"]),
+            }),
+            aliases: expect.objectContaining({
+              providerKind: "kind",
+              displayName: "name",
+            }),
+          }),
+        },
+      });
+      expect(mockService.createProvider).not.toHaveBeenCalled();
+    });
+
     it("providers.delete returns deleted true", async () => {
       const mockService = makeMockService();
       const routes = createFridayProviderRoutes({

--- a/ui/src/lib/api/types.ts
+++ b/ui/src/lib/api/types.ts
@@ -169,6 +169,7 @@ export interface AgentRunRecord {
   errorMessage?: string;
   constraints?: {
     readOnly?: boolean;
+    operationalMode?: "plan" | "execute" | "restricted";
   };
   planReview?: {
     plan: {


### PR DESCRIPTION
## Summary
- Return provider create validation as 422 with structured schema details, field enums, and alias hints for common wrong names like providerKind/displayName.
- Keep UI/default agent chat in normal mode while preserving explicit operationalMode forwarding.
- Bypass forced plan clarification for safe Q&A/arithmetic even if plan constraints are present, while keeping workflow/skill/deploy/major-decision gates intact.

## Validation
- npx vitest run test/unit/providers/api/friday-provider-routes.test.ts test/unit/api/http/routes/friday-agent-routes.test.ts test/unit/agent/runtime/friday-agent-planning-gate.test.ts
- npm run typecheck
- git diff --check
- npm run test:contracts:routes
- npx vitest run test/unit/agent/runtime/friday-agent-runtime.test.ts