### PR TITLE
[codex] Fix memory scoping and autofix closure

### DIFF
--- a/src/agent/tools/friday-agent-memory-tools.ts
+++ b/src/agent/tools/friday-agent-memory-tools.ts
@@ -31,21 +31,82 @@ export interface CreateFridayAgentMemoryToolsDeps {
 
 // ─── Namespace scoping ───
 
-/**
- * Returns the namespace for memory operations.
- *
- * For user-facing namespaces ("default", "user", "preference"), we do NOT
- * scope by sessionId so that memories are accessible across sessions and
- * subagents. Only internal/agent namespaces get session-scoped to prevent
- * pollution between concurrent runs.
- */
-function scopedNamespace(raw: string, sessionId: string | undefined): string {
-  const normalized = normalizeMemoryNamespace(raw);
-  // User-facing namespaces should be globally accessible, not session-scoped
-  const userFacingNamespaces = new Set(["default", "user", "preference", "system"]);
-  if (userFacingNamespaces.has(normalized)) return normalized;
-  if (!sessionId) return normalized;
-  return `${normalized}:${sessionId}`;
+const AGENT_MEMORY_BASE_NAMESPACE = "agent";
+const USER_FACING_MEMORY_NAMESPACES = new Set(["default", "user", "preference"]);
+const RESERVED_MEMORY_NAMESPACE_PREFIXES = ["system", "tenant"];
+
+function normalizeAgentMemoryScopeId(raw: string | undefined): string | undefined {
+  const trimmed = raw?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+}
+
+function normalizeAgentCustomNamespaceSegment(raw: string): string {
+  return raw
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^[.-]+|[.-]+$/g, "");
+}
+
+function resolveAgentScopedNamespace(input: {
+  scopeId: string | undefined;
+  segment?: string;
+}): string {
+  const scopeId = normalizeAgentMemoryScopeId(input.scopeId);
+  const segment = input.segment ? normalizeAgentCustomNamespaceSegment(input.segment) : "";
+  const scopeSuffix = scopeId ? `:${scopeId}` : "";
+  return segment.length > 0
+    ? `${AGENT_MEMORY_BASE_NAMESPACE}${scopeSuffix}.${segment}`
+    : `${AGENT_MEMORY_BASE_NAMESPACE}${scopeSuffix}`;
+}
+
+function isUserFacingMemoryNamespace(namespace: string | undefined): boolean {
+  return typeof namespace === "string" && USER_FACING_MEMORY_NAMESPACES.has(namespace);
+}
+
+function isReservedMemoryNamespace(namespace: string): boolean {
+  const normalized = normalizeAgentCustomNamespaceSegment(namespace);
+  return RESERVED_MEMORY_NAMESPACE_PREFIXES.some((prefix) =>
+    normalized === prefix || normalized.startsWith(`${prefix}.`) || normalized.startsWith(`${prefix}-`));
+}
+
+function resolveAgentScopedExplicitNamespace(input: {
+  explicitNamespace: string;
+  implicitSessionNamespace?: string;
+  scopeId?: string;
+}): { namespace?: string; isUserFacing: boolean; error?: string } {
+  const normalized = normalizeMemoryNamespace(input.explicitNamespace);
+  if (normalized === AGENT_MEMORY_BASE_NAMESPACE) {
+    return {
+      namespace: resolveAgentScopedNamespace({ scopeId: input.scopeId }),
+      isUserFacing: false,
+    };
+  }
+  if (isUserFacingMemoryNamespace(normalized)) {
+    return {
+      namespace: input.implicitSessionNamespace
+        ?? resolveAgentScopedNamespace({ scopeId: input.scopeId, segment: normalized }),
+      isUserFacing: true,
+    };
+  }
+  if (isReservedMemoryNamespace(normalized)) {
+    return {
+      isUserFacing: false,
+      error: `Memory namespace '${input.explicitNamespace}' is reserved and cannot be used by agent memory tools.`,
+    };
+  }
+  const segment = normalizeAgentCustomNamespaceSegment(normalized);
+  if (!segment) {
+    return {
+      isUserFacing: false,
+      error: "Memory namespace is invalid.",
+    };
+  }
+  return {
+    namespace: resolveAgentScopedNamespace({ scopeId: input.scopeId, segment }),
+    isUserFacing: false,
+  };
 }
 
 function normalizeMemoryNamespace(raw: string): string {
@@ -58,7 +119,6 @@ function normalizeMemoryNamespace(raw: string): string {
     normalized === "default"
     || normalized === "user"
     || normalized === "preference"
-    || normalized === "system"
     || normalized === "agent"
   ) {
     return normalized;
@@ -256,8 +316,7 @@ function namespaceShouldOverlaySessionMemory(namespace: string | undefined): boo
   const normalized = normalizeMemoryNamespace(namespace);
   return normalized === "user"
     || normalized === "preference"
-    || normalized === "default"
-    || normalized === "system";
+    || normalized === "default";
 }
 
 function resolveSessionIdFromArgs(
@@ -265,13 +324,13 @@ function resolveSessionIdFromArgs(
   fallback: string | undefined,
   signal: AbortSignal,
 ): string | undefined {
-  const fromRuntime = args["__sessionId"];
-  if (typeof fromRuntime === "string" && fromRuntime.trim().length > 0) {
-    return fromRuntime;
-  }
   const contextSessionKey = getFridayAgentToolExecutionContext(signal)?.sessionKey?.trim();
   if (contextSessionKey && contextSessionKey.length > 0) {
     return contextSessionKey;
+  }
+  const fromRuntime = args["__sessionId"];
+  if (typeof fromRuntime === "string" && fromRuntime.trim().length > 0) {
+    return fromRuntime;
   }
   return fallback;
 }
@@ -313,13 +372,24 @@ function resolvePrincipalId(
   args: Record<string, unknown>,
   signal: AbortSignal,
 ): string | undefined {
+  const context = getFridayAgentToolExecutionContext(signal);
+  const principalId = context?.principalId?.trim();
+  if (principalId && principalId.length > 0) {
+    return principalId;
+  }
   const fromArgs = args["__principalId"];
   if (typeof fromArgs === "string" && fromArgs.trim().length > 0) {
     return fromArgs.trim();
   }
-  const context = getFridayAgentToolExecutionContext(signal);
-  const principalId = context?.principalId?.trim();
-  return principalId && principalId.length > 0 ? principalId : undefined;
+  return undefined;
+}
+
+function resolveMemoryScopeId(input: {
+  sessionId: string | undefined;
+  principalId: string | undefined;
+}): string | undefined {
+  return normalizeAgentMemoryScopeId(input.sessionId)
+    ?? normalizeAgentMemoryScopeId(input.principalId);
 }
 
 async function resolveImplicitSessionNamespace(params: {
@@ -460,6 +530,7 @@ function createMemorySearchTool(
     ): Promise<FridayAgentToolResult> {
       const sessionId = resolveSessionIdFromArgs(args, deps.sessionId, signal);
       const principalId = resolvePrincipalId(args, signal);
+      const scopeId = resolveMemoryScopeId({ sessionId, principalId });
       const query = readStringParam(args, "query", { required: true });
       const explicitNamespace = readExplicitNamespace(args);
       const implicitSessionNamespace = await resolveImplicitSessionNamespace({
@@ -468,18 +539,25 @@ function createMemorySearchTool(
         sessionId,
       });
       const limit = readNumberParam(args, "limit", { integer: true }) ?? 10;
-      const scopedNamespace =
-        explicitNamespace && implicitSessionNamespace && namespaceShouldOverlaySessionMemory(explicitNamespace)
-          ? [explicitNamespace, implicitSessionNamespace]
-          : explicitNamespace ?? implicitSessionNamespace;
+      const agentNamespace = resolveAgentScopedNamespace({ scopeId });
+      const explicitResolution = explicitNamespace
+        ? resolveAgentScopedExplicitNamespace({
+          explicitNamespace,
+          implicitSessionNamespace,
+          scopeId,
+        })
+        : undefined;
+      if (explicitResolution?.error) {
+        return errorResult(`Memory search rejected: ${explicitResolution.error}`);
+      }
+      const scopedNamespace = explicitResolution?.namespace
+        ?? (implicitSessionNamespace ? [agentNamespace, implicitSessionNamespace] : agentNamespace);
 
       try {
-        const scopedResults = scopedNamespace
-          ? await deps.memoryService.search(query, {
-            namespace: scopedNamespace,
-            limit,
-          })
-          : [];
+        const scopedResults = await deps.memoryService.search(query, {
+          namespace: scopedNamespace,
+          limit: implicitSessionNamespace ? Math.max(limit * 2, limit) : limit,
+        });
         const shouldUseSessionFallback =
           Boolean(implicitSessionNamespace && sessionId)
           && (
@@ -497,18 +575,8 @@ function createMemorySearchTool(
               limit,
             })
             : [];
-        const fallbackResults = explicitNamespace
-          ? scopedResults.length > 0
-            ? scopedResults
-            : await deps.memoryService.search(query, {
-              ...(implicitSessionNamespace ? { namespace: implicitSessionNamespace } : {}),
-              limit: Math.max(limit * 2, limit),
-            })
-          : await deps.memoryService.search(query, {
-            limit: implicitSessionNamespace ? Math.max(limit * 2, limit) : limit,
-          });
         const dedupedResults = (() => {
-          const merged = [...scopedResults, ...sessionLexicalCandidates, ...fallbackResults];
+          const merged = [...scopedResults, ...sessionLexicalCandidates];
           const seen = new Set<string>();
           const itemsByContent = new Map<string, FridayMemorySearchResult>();
           for (const result of merged) {
@@ -585,9 +653,26 @@ function createMemoryStoreTool(
       signal: AbortSignal,
     ): Promise<FridayAgentToolResult> {
       const sessionId = resolveSessionIdFromArgs(args, deps.sessionId, signal);
+      const principalId = resolvePrincipalId(args, signal);
+      const scopeId = resolveMemoryScopeId({ sessionId, principalId });
       const content = readStringParam(args, "content", { required: true });
       const explicitNamespace = readExplicitNamespace(args);
-      const namespace = explicitNamespace ?? scopedNamespace("agent", sessionId);
+      const implicitSessionNamespace = await resolveImplicitSessionNamespace({
+        deps,
+        explicitNamespace,
+        sessionId,
+      });
+      const explicitResolution = explicitNamespace
+        ? resolveAgentScopedExplicitNamespace({
+          explicitNamespace,
+          implicitSessionNamespace,
+          scopeId,
+        })
+        : undefined;
+      if (explicitResolution?.error) {
+        return errorResult(`Memory store rejected: ${explicitResolution.error}`);
+      }
+      const namespace = explicitResolution?.namespace ?? resolveAgentScopedNamespace({ scopeId });
       const expiresAt = sanitizeExpiresAt(readStringParam(args, "expiresAt"), deps.nowIso);
 
       const rawTags = args["tags"];
@@ -598,9 +683,7 @@ function createMemoryStoreTool(
       const executionContext = getFridayAgentToolExecutionContext(signal);
 
       const storingUserFacingMemory =
-        namespace === "default"
-        || namespace === "user"
-        || namespace === "preference"
+        explicitResolution?.isUserFacing === true
         || tags.some((tag) => normalizePreferenceTag(tag) === "preference");
 
       if (

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -1040,9 +1040,9 @@ export function createFridayHubAutoFixExecutionSupport(deps: {
   workflowRuntime?: FridayWorkflowRuntime;
   nowIso: () => string;
 }): FridayHubAutoFixExecutionSupport {
-  // P2-07: Only override step kinds that need hub-level service access.
-  // All other kinds use DEFAULT_EXECUTORS from the execution service which
-  // correctly set directive markers and return true.
+  // P2-07: External-state remediation must be backed by hub-level services.
+  // The execution service fails closed for these kinds unless an executor is
+  // injected here.
   const stepExecutors: Partial<Record<FridayAutoFixStepKind, StepExecutor>> = {};
   const stepVerifiers: Partial<Record<FridayAutoFixStepKind, StepVerifier>> = {};
 

--- a/src/learning/services/friday-auto-fix-execution-service.ts
+++ b/src/learning/services/friday-auto-fix-execution-service.ts
@@ -64,91 +64,16 @@ export const AUTO_FIX_STEP_KINDS_REQUIRING_ROLLBACK_PLAN: ReadonlySet<FridayAuto
 ]);
 
 /**
- * Default executors perform real operations for each step kind.
- *
- * When hub-level services are available (skill registry, workflow runtime,
- * provider service) callers should inject richer executors via `stepExecutors`.
- * These defaults handle each kind with best-effort deterministic logic using
- * only the step payload, without requiring external service references.
+ * Default executors are intentionally limited to payload-local transforms.
+ * Steps that mutate runtime or external state must be supplied by the hub via
+ * `stepExecutors`; otherwise execution fails closed with "No executor".
  */
-export const DEFAULT_EXECUTORS: Record<FridayAutoFixStepKind, StepExecutor> = {
-  retry_node: (step) => {
-    // Retry is a signal to the pipeline to re-run the node.
-    // The executor validates that the step has a valid target.
-    if (!step.target) return false;
-    // Mark the step payload with a retry directive that the pipeline reads.
-    const payload = step.payload as Record<string, unknown> | null;
-    if (payload && typeof payload === "object") {
-      payload._retryRequested = true;
-      payload._retryAt = new Date().toISOString();
-    }
-    return true;
-  },
-
-  switch_model_fallback: (step) => {
-    // Validate step has required target info for model switching.
-    if (!step.target) return false;
-    const payload = step.payload as Record<string, unknown> | null;
-    if (payload && typeof payload === "object") {
-      payload._modelFallbackRequested = true;
-      payload._fallbackAt = new Date().toISOString();
-    }
-    return true;
-  },
-
+export const DEFAULT_EXECUTORS: Partial<Record<FridayAutoFixStepKind, StepExecutor>> = {
   trim_payload: (step) => {
-    // Payload trimming: mark step as trimmed. Actual trimming happens at
-    // the routing/executor layer when it reads this directive.
     if (!step.target) return false;
     const payload = step.payload as Record<string, unknown> | null;
     if (payload && typeof payload === "object") {
       payload._trimRequested = true;
-    }
-    return true;
-  },
-
-  apply_config_patch: (step) => {
-    // Config patches require an explicit target and non-empty payload.
-    if (!step.target) return false;
-    const payload = step.payload as Record<string, unknown> | null;
-    if (!payload || typeof payload !== "object") return false;
-    // Reject empty patches — nothing to apply.
-    const keys = Object.keys(payload).filter((k) => !k.startsWith("_"));
-    if (keys.length === 0) return false;
-    payload._configPatchApplied = true;
-    payload._appliedAt = new Date().toISOString();
-    return true;
-  },
-
-  grant_permission: (step) => {
-    // Permission grants require a target (the resource) and a payload
-    // describing the permission. Reject if either is missing.
-    if (!step.target) return false;
-    const payload = step.payload as Record<string, unknown> | null;
-    if (!payload || typeof payload !== "object") return false;
-    payload._permissionGranted = true;
-    payload._grantedAt = new Date().toISOString();
-    return true;
-  },
-
-  disable_skill: (step) => {
-    // Disable skill: requires a target identifying the skill.
-    if (!step.target) return false;
-    const payload = step.payload as Record<string, unknown> | null;
-    if (payload && typeof payload === "object") {
-      payload._skillDisabled = true;
-      payload._disabledAt = new Date().toISOString();
-    }
-    return true;
-  },
-
-  pause_workflow: (step) => {
-    // Pause workflow: requires a target identifying the workflow.
-    if (!step.target) return false;
-    const payload = step.payload as Record<string, unknown> | null;
-    if (payload && typeof payload === "object") {
-      payload._workflowPaused = true;
-      payload._pausedAt = new Date().toISOString();
     }
     return true;
   },
@@ -204,7 +129,7 @@ export const DEFAULT_VERIFIERS: Record<FridayAutoFixStepKind, StepVerifier> = {
 export function createFridayAutoFixExecutionService(
   deps: CreateAutoFixExecutionServiceDeps,
 ): FridayAutoFixExecutionService {
-  const executors = { ...DEFAULT_EXECUTORS, ...deps.stepExecutors };
+  const executors: Partial<Record<FridayAutoFixStepKind, StepExecutor>> = { ...DEFAULT_EXECUTORS, ...deps.stepExecutors };
   const verifiers = { ...DEFAULT_VERIFIERS, ...deps.stepVerifiers };
 
   function persistPlanEvidence(

--- a/src/learning/services/friday-auto-fix-plan-service.ts
+++ b/src/learning/services/friday-auto-fix-plan-service.ts
@@ -20,17 +20,19 @@ export interface CreateAutoFixPlanServiceDeps {
   idGenerator: () => string;
 }
 
-const CATEGORY_STEP_MAP: Record<FridayErrorIncidentEntity["category"], FridayAutoFixStepKind> = {
+const CATEGORY_STEP_MAP: Record<FridayErrorIncidentEntity["category"], FridayAutoFixStepKind | undefined> = {
   tool: "retry_node",
   model: "switch_model_fallback",
-  config: "apply_config_patch",
+  // Config patches require a product-specific config writer. Until a real
+  // executor is injected, fail closed rather than emitting a marker-only fix.
+  config: undefined,
   routing: "trim_payload",
   workflow: "retry_node",
 };
 
 function deriveAutoFixStepKind(
   incident: FridayErrorIncidentEntity,
-): FridayAutoFixStepKind {
+): FridayAutoFixStepKind | undefined {
   const source = typeof incident.context.source === "string"
     ? incident.context.source
     : undefined;
@@ -66,6 +68,9 @@ export function createFridayAutoFixPlanService(
       const { incident, diagnosis, matchedLessons, recurrenceCount } = input;
       const plans: FridayAutoFixPlan[] = [];
       const stepKind = deriveAutoFixStepKind(incident);
+      if (!stepKind) {
+        return plans;
+      }
       const target = deriveAutoFixTarget(incident, stepKind);
       const fallbackProviderIds = Array.isArray(incident.context.fallbackProviderIds)
         ? incident.context.fallbackProviderIds.filter(

--- a/src/learning/services/friday-error-diagnosis-service.ts
+++ b/src/learning/services/friday-error-diagnosis-service.ts
@@ -129,7 +129,7 @@ function isStructuredInternalRuntimeFailure(
 
 function derivePlanStepKind(
   incident: FridayErrorIncidentEntity,
-): FridayAutoFixPlan["steps"][number]["kind"] {
+): FridayAutoFixPlan["steps"][number]["kind"] | undefined {
   const source = typeof incident.context.source === "string"
     ? incident.context.source
     : undefined;
@@ -294,6 +294,9 @@ export function createFridayErrorDiagnosisService(
 
       for (const l of matchedLessons) {
         const planStepKind = derivePlanStepKind(incident);
+        if (!planStepKind) {
+          continue;
+        }
         const target = derivePlanTarget(incident, planStepKind);
         const plan: FridayAutoFixPlan = {
           title: buildAutoFixPlanTitle(l.title),
@@ -362,14 +365,16 @@ export function createFridayErrorDiagnosisService(
 
 function mapCategoryToStepKind(
   category: FridayErrorIncidentEntity["category"],
-): FridayAutoFixPlan["steps"][number]["kind"] {
+): FridayAutoFixPlan["steps"][number]["kind"] | undefined {
   switch (category) {
     case "tool":
       return "retry_node";
     case "model":
       return "switch_model_fallback";
     case "config":
-      return "apply_config_patch";
+      // Config patches need a concrete config writer. Do not emit
+      // marker-only remediation plans from diagnosis.
+      return undefined;
     case "routing":
       return "trim_payload";
     case "workflow":

--- a/test/unit/agent/tools/friday-agent-memory-tools.test.ts
+++ b/test/unit/agent/tools/friday-agent-memory-tools.test.ts
@@ -15,10 +15,11 @@ function signalWithPrincipal(principalId: string): AbortSignal {
 function signalWithContext(input: {
   principalId?: string;
   taskPrompt?: string;
+  sessionKey?: string;
 }): AbortSignal {
   return attachFridayAgentToolExecutionContext(new AbortController().signal, {
     runId: "run-1",
-    sessionKey: "agent:run:run-1",
+    sessionKey: input.sessionKey ?? "agent:run:run-1",
     readOnly: false,
     principalId: input.principalId,
     taskPrompt: input.taskPrompt,
@@ -112,7 +113,6 @@ describe("FridayAgentMemoryTools", () => {
       expect(parsed).toHaveLength(1);
       expect(parsed[0]).toMatchObject({
         content: "The weather in Seattle is rainy",
-        score: 0.95,
         metadata: {
           id: "item-1",
           namespace: "agent",
@@ -131,7 +131,7 @@ describe("FridayAgentMemoryTools", () => {
       );
 
       expect(svc.search).toHaveBeenCalledWith("test", {
-        namespace: "custom",
+        namespace: "agent.custom",
         limit: 5,
       });
     });
@@ -143,7 +143,7 @@ describe("FridayAgentMemoryTools", () => {
       await searchTool!.execute({ query: "test" }, signal());
 
       expect(svc.search).toHaveBeenCalledWith("test", {
-        namespace: undefined,
+        namespace: "agent",
         limit: 10,
       });
     });
@@ -219,9 +219,33 @@ describe("FridayAgentMemoryTools", () => {
       );
 
       expect(svc.search).toHaveBeenCalledWith("preferred name", {
-        namespace: "preference",
+        namespace: "agent.preference",
         limit: 5,
       });
+    });
+
+    it("never searches without a namespace", async () => {
+      const svc = mockMemoryService([]);
+      const [searchTool] = createFridayAgentMemoryTools({ memoryService: svc });
+
+      await searchTool!.execute({ query: "anything" }, signal());
+
+      const [, options] = vi.mocked(svc.search).mock.calls[0]!;
+      expect(options?.namespace).toBeDefined();
+    });
+
+    it("rejects reserved namespaces instead of searching them", async () => {
+      const svc = mockMemoryService([]);
+      const [searchTool] = createFridayAgentMemoryTools({ memoryService: svc });
+
+      const result = await searchTool!.execute(
+        { query: "secret", namespace: "tenant.default.user.other" },
+        signal(),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("reserved");
+      expect(svc.search).not.toHaveBeenCalled();
     });
 
     it("matches learned facts through token overlap when the model phrases the query differently", async () => {
@@ -313,7 +337,7 @@ describe("FridayAgentMemoryTools", () => {
         signal(),
       );
 
-      expect(svc.store).toHaveBeenCalledWith("custom-ns", "data", {
+      expect(svc.store).toHaveBeenCalledWith("agent.custom-ns", "data", {
         source: "agent",
         tags: ["tag1", "tag2"],
         expiresAt: "2026-12-31T00:00:00.000Z",
@@ -399,6 +423,21 @@ describe("FridayAgentMemoryTools", () => {
       );
     });
 
+    it("rejects reserved namespaces instead of storing to them", async () => {
+      const svc = mockMemoryService();
+      const tools = createFridayAgentMemoryTools({ memoryService: svc });
+      const storeTool = tools[1]!;
+
+      const result = await storeTool.execute(
+        { content: "secret", namespace: "system.config" },
+        signal(),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("reserved");
+      expect(svc.store).not.toHaveBeenCalled();
+    });
+
     it("returns error on store failure", async () => {
       const svc = mockMemoryService(
         undefined,
@@ -480,12 +519,12 @@ describe("FridayAgentMemoryTools", () => {
 
       expect(svc.store).toHaveBeenCalledWith("agent:session-A", "hello", expect.any(Object));
       expect(svc.search).toHaveBeenCalledWith("hello", {
-        namespace: undefined,
+        namespace: "agent:session-A",
         limit: 10,
       });
     });
 
-    it("respects explicit namespaces without remapping them to a session key", async () => {
+    it("scopes explicit agent namespace to the current session key", async () => {
       const svc = mockMemoryService();
       const [searchTool, storeTool] = createFridayAgentMemoryTools({
         memoryService: svc,
@@ -501,9 +540,9 @@ describe("FridayAgentMemoryTools", () => {
         signal(),
       );
 
-      expect(svc.store).toHaveBeenCalledWith("agent", "hello", expect.any(Object));
+      expect(svc.store).toHaveBeenCalledWith("agent:session-A", "hello", expect.any(Object));
       expect(svc.search).toHaveBeenCalledWith("hello", {
-        namespace: "agent",
+        namespace: "agent:session-A",
         limit: 10,
       });
     });
@@ -526,9 +565,78 @@ describe("FridayAgentMemoryTools", () => {
 
       expect(svc.store).toHaveBeenCalledWith("agent:session-from-runtime", "hello", expect.any(Object));
       expect(svc.search).toHaveBeenCalledWith("hello", {
-        namespace: undefined,
+        namespace: "agent:session-from-runtime",
         limit: 10,
       });
+    });
+
+    it("prefers attached execution context over internal session args", async () => {
+      const svc = mockMemoryService();
+      const [searchTool] = createFridayAgentMemoryTools({
+        memoryService: svc,
+      });
+
+      await searchTool!.execute(
+        { query: "hello", __sessionId: "attacker-session" },
+        signalWithContext({ sessionKey: "trusted-session" }),
+      );
+
+      expect(svc.search).toHaveBeenCalledWith("hello", {
+        namespace: "agent:trusted-session",
+        limit: 10,
+      });
+    });
+
+    it("prefers attached execution context over internal principal args", async () => {
+      const svc = mockMemoryService([]);
+      const observedUserIds: string[] = [];
+      const [searchTool] = createFridayAgentMemoryTools({
+        memoryService: svc,
+        listLearnedFacts: (input) => {
+          observedUserIds.push(input.userId);
+          return [{
+            key: "pref:name",
+            value: "Trusted User",
+            confidence: 0.8,
+            evidenceCount: 1,
+            lastConfirmedAt: "2026-02-19T00:00:00.000Z",
+          }];
+        },
+      });
+
+      await searchTool!.execute(
+        { query: "name", __principalId: "attacker-user" },
+        signalWithContext({ principalId: "trusted-user" }),
+      );
+
+      expect(observedUserIds).toEqual(["trusted-user"]);
+    });
+
+    it("stores user-facing aliases in the resolved session namespace", async () => {
+      const svc = mockMemoryService();
+      const [, storeTool] = createFridayAgentMemoryTools({
+        memoryService: svc,
+        resolveSessionMemoryNamespace: async () => "tenant.default.channel.webchat.user.user-1.shared",
+      });
+
+      const result = await storeTool!.execute(
+        {
+          content: "My preferred editor is Vim",
+          namespace: "preference",
+        },
+        signalWithContext({
+          principalId: "user-1",
+          sessionKey: "webchat:default:chat-1",
+          taskPrompt: "I prefer Vim.",
+        }),
+      );
+
+      expect(result.isError).toBeUndefined();
+      expect(svc.store).toHaveBeenCalledWith(
+        "tenant.default.channel.webchat.user.user-1.shared",
+        "My preferred editor is Vim",
+        expect.any(Object),
+      );
     });
   });
 });

--- a/test/unit/learning/services/friday-auto-fix-dispatcher-service.test.ts
+++ b/test/unit/learning/services/friday-auto-fix-dispatcher-service.test.ts
@@ -130,6 +130,15 @@ describe("FridayAutoFixDispatcherService", () => {
         nowIso: () => NOW,
       }),
       nowIso: () => NOW,
+      stepExecutors: {
+        retry_node: (step) => {
+          const payload = step.payload as Record<string, unknown> | null;
+          if (payload && typeof payload === "object") {
+            payload._retryRequested = true;
+          }
+          return true;
+        },
+      },
     });
     const riskService = createFridayAutoFixRiskAssessmentService({
       db,

--- a/test/unit/learning/services/friday-auto-fix-execution-service.test.ts
+++ b/test/unit/learning/services/friday-auto-fix-execution-service.test.ts
@@ -11,6 +11,7 @@ import { createFridayAutoFixLessonExtractionService } from "#learning";
 import type { FridayAutoFixExecutionService } from "#learning";
 import type { FridayAutoFixActionEntity, FridayAutoFixPlan } from "#learning";
 import type { FridayAutoFixActionRepository } from "#learning";
+import type { FridayAutoFixStepKind, StepExecutor } from "#learning";
 
 describe("FridayAutoFixExecutionService", () => {
   let db: FridaySqliteLayer;
@@ -36,6 +37,41 @@ describe("FridayAutoFixExecutionService", () => {
       recurrenceCount: 1,
     },
   };
+
+  const markerByKind: Partial<Record<FridayAutoFixStepKind, string>> = {
+    retry_node: "_retryRequested",
+    switch_model_fallback: "_modelFallbackRequested",
+    trim_payload: "_trimRequested",
+    apply_config_patch: "_configPatchApplied",
+    grant_permission: "_permissionGranted",
+    disable_skill: "_skillDisabled",
+    pause_workflow: "_workflowPaused",
+  };
+
+  const timestampMarkerByKind: Partial<Record<FridayAutoFixStepKind, string>> = {
+    retry_node: "_retryAt",
+    switch_model_fallback: "_fallbackAt",
+    apply_config_patch: "_appliedAt",
+    grant_permission: "_grantedAt",
+    disable_skill: "_disabledAt",
+    pause_workflow: "_pausedAt",
+  };
+
+  function markerExecutor(kind: FridayAutoFixStepKind): StepExecutor {
+    return (step) => {
+      if (!step.target) return false;
+      const payload = step.payload as Record<string, unknown> | null;
+      const marker = markerByKind[kind];
+      if (payload && typeof payload === "object" && marker) {
+        payload[marker] = true;
+        const timestampMarker = timestampMarkerByKind[kind];
+        if (timestampMarker) {
+          payload[timestampMarker] = NOW;
+        }
+      }
+      return true;
+    };
+  }
 
   function setupDeps() {
     const incidentRepo = createFridayErrorIncidentRepository();
@@ -83,6 +119,9 @@ describe("FridayAutoFixExecutionService", () => {
       diagnosisRepo,
       rollbackService,
       nowIso: () => NOW,
+      stepExecutors: {
+        retry_node: markerExecutor("retry_node"),
+      },
     });
 
     // Insert a planned action
@@ -161,7 +200,7 @@ describe("FridayAutoFixExecutionService", () => {
       marker: "_workflowPaused",
       timestampMarker: "_pausedAt",
     },
-  ])("executes and verifies directive-level step kind '$kind'", async ({
+  ])("executes and verifies injected step kind '$kind'", async ({
     kind,
     target,
     payload,
@@ -273,6 +312,9 @@ describe("FridayAutoFixExecutionService", () => {
         nowIso: () => NOW,
       }),
       nowIso: () => NOW,
+      stepExecutors: {
+        [kind]: markerExecutor(kind),
+      },
     });
 
     const result = await executionService.execute(actionId);
@@ -287,6 +329,95 @@ describe("FridayAutoFixExecutionService", () => {
     if (timestampMarker) {
       expect(typeof persistedPayload?.[timestampMarker]).toBe("string");
     }
+  });
+
+  it("fails closed when an external-state step has no injected executor", async () => {
+    const actionRepo = createFridayAutoFixActionRepository();
+    const incidentRepo = createFridayErrorIncidentRepository();
+    const diagnosisRepo = createFridayDiagnosisRecordRepository();
+    incidentRepo.insert(db.writer, {
+      incidentId: "inc-no-executor",
+      userId: "test-user",
+      ts: NOW,
+      category: "config",
+      severity: "medium",
+      signature: "sig-no-executor",
+      context: {},
+      autoFixEligible: true,
+      status: "open",
+      createdAt: NOW,
+      updatedAt: NOW,
+    });
+    diagnosisRepo.insert(db.writer, {
+      id: "diag-no-executor",
+      incidentId: "inc-no-executor",
+      errorFingerprint: "sig-no-executor",
+      confidence: 0.8,
+      diagnosis: { summary: "test" },
+      createdAt: NOW,
+      updatedAt: NOW,
+    });
+    const plan: FridayAutoFixPlan = {
+      title: "Auto-fix: config patch",
+      summary: "Patch config",
+      steps: [
+        {
+          stepId: "step-no-executor",
+          kind: "apply_config_patch",
+          target: "runtime-config",
+          payload: { key: "value" },
+          verify: { method: "error_absent", timeoutMs: 5000 },
+        },
+      ],
+      rollbackPlan: {
+        summary: "Rollback config patch",
+        steps: [
+          {
+            stepId: "rollback-no-executor",
+            kind: "apply_config_patch",
+            target: "runtime-config",
+            payload: { revert: true },
+          },
+        ],
+      },
+      evidence: {
+        fingerprint: "sig-no-executor",
+        matchedLessonIds: [],
+        diagnosisId: "diag-no-executor",
+        recurrenceCount: 1,
+      },
+    };
+    actionRepo.insert(db.writer, {
+      actionId: "action-no-executor",
+      incidentId: "inc-no-executor",
+      userId: "test-user",
+      riskTier: 1,
+      plan,
+      rollbackPlan: plan.rollbackPlan,
+      status: "planned",
+      outcome: null,
+      createdAt: NOW,
+      updatedAt: NOW,
+    });
+    const executionService = createFridayAutoFixExecutionService({
+      db,
+      actionRepo,
+      incidentRepo,
+      diagnosisRepo,
+      rollbackService: createFridayAutoFixRollbackService({
+        db,
+        actionRepo,
+        nowIso: () => NOW,
+      }),
+      nowIso: () => NOW,
+    });
+
+    const result = await executionService.execute("action-no-executor");
+
+    expect(result.success).toBe(false);
+    expect(result.errorMessage).toContain("has no executor");
+    expect(result.action.status).toBe("applied");
+    expect(result.action.outcome).toBe("failed");
   });
 
   it("honors injected executors and verifiers for supported kinds", async () => {
@@ -425,6 +556,9 @@ describe("FridayAutoFixExecutionService", () => {
         nowIso: () => NOW,
       }),
       nowIso: () => NOW,
+      stepExecutors: {
+        retry_node: markerExecutor("retry_node"),
+      },
     });
 
     const result = await lessonAwareService.execute("action-001");
@@ -729,6 +863,9 @@ describe("FridayAutoFixExecutionService", () => {
           nowIso: () => NOW,
         }),
         nowIso: () => NOW,
+        stepExecutors: {
+          retry_node: markerExecutor("retry_node"),
+        },
         stepVerifiers: {
           retry_node: () => false, // Verification fails
         },

--- a/test/unit/learning/services/friday-auto-fix-plan-service.test.ts
+++ b/test/unit/learning/services/friday-auto-fix-plan-service.test.ts
@@ -112,7 +112,7 @@ describe("FridayAutoFixPlanService", () => {
     });
   });
 
-  it("maps config category to apply_config_patch with rollback", () => {
+  it("does not emit marker-only plans for config incidents", () => {
     const configIncident = { ...baseIncident, category: "config" as const };
     const plans = service.buildPlans({
       incident: configIncident,
@@ -121,9 +121,7 @@ describe("FridayAutoFixPlanService", () => {
       recurrenceCount: 1,
     });
 
-    expect(plans[0]!.steps[0]!.kind).toBe("apply_config_patch");
-    expect(plans[0]!.rollbackPlan).toBeDefined();
-    expect(plans[0]!.rollbackPlan!.steps).toHaveLength(1);
+    expect(plans).toHaveLength(0);
   });
 
   it("maps routing category to trim_payload", () => {

--- a/test/unit/learning/services/friday-auto-fix-rollback-service.test.ts
+++ b/test/unit/learning/services/friday-auto-fix-rollback-service.test.ts
@@ -125,7 +125,7 @@ describe("FridayAutoFixRollbackService", () => {
     ).toBe("applied");
   });
 
-  it("falls back to default rollback executors when no hub override is provided", async () => {
+  it("fails closed when no hub executor backs a rollback step", async () => {
     const actionRepo = seedAppliedAction();
 
     const service = createFridayAutoFixRollbackService({
@@ -137,10 +137,12 @@ describe("FridayAutoFixRollbackService", () => {
 
     const result = await service.rollback("action-rb-001", "verification failed");
 
-    expect(result.rollbackSucceeded).toBe(true);
+    expect(result.success).toBe(false);
+    expect(result.rollbackSucceeded).toBe(false);
+    expect(result.errorMessage).toContain("has no executor");
     expect(
       db.withReadConnection((rdb) => actionRepo.getById(rdb, "action-rb-001"))?.status,
-    ).toBe("rolled_back");
+    ).toBe("applied");
   });
 
   it("fails closed when an explicit override removes the executor", async () => {

--- a/test/unit/learning/services/friday-error-diagnosis-service.test.ts
+++ b/test/unit/learning/services/friday-error-diagnosis-service.test.ts
@@ -221,6 +221,32 @@ describe("FridayErrorDiagnosisService", () => {
     expect(result.autoFixEligible).toBe(true);
   });
 
+  it("does not emit marker-only config candidate plans from matched lessons", () => {
+    const lessonRepo = createFridayLearnedLessonRepository();
+    const configIncident: FridayErrorIncidentEntity = {
+      ...baseIncident,
+      incidentId: "inc-config-lesson",
+      category: "config",
+      signature: "sig-config-lesson",
+      context: { key: "provider.defaultModel", error: "invalid" },
+    };
+    createFridayErrorIncidentRepository().insert(db.writer, configIncident);
+    lessonRepo.upsertByFingerprint(db.writer, {
+      id: "lesson-config-001",
+      fingerprint: "sig-config-lesson",
+      title: "Config Fix",
+      cause: "Invalid config",
+      fix: "Patch provider.defaultModel",
+      nowIso: NOW,
+    });
+
+    const result = service.diagnose({ incident: configIncident, nowIso: NOW });
+
+    expect(result.autoFixEligible).toBe(true);
+    expect(result.matchedLessons).toHaveLength(1);
+    expect(result.candidatePlans).toHaveLength(0);
+  });
+
   it("boosts structured workflow runtime failures with run and node evidence", () => {
     db.writer.prepare(
       `INSERT INTO workflows (

--- a/test/unit/learning/services/friday-self-learning-pipeline-service.test.ts
+++ b/test/unit/learning/services/friday-self-learning-pipeline-service.test.ts
@@ -845,6 +845,15 @@ describe("Approval → execution linkage", () => {
         nowIso: () => NOW,
       }),
       nowIso: () => NOW,
+      stepExecutors: {
+        disable_skill: (step) => {
+          const payload = step.payload as Record<string, unknown> | null;
+          if (payload && typeof payload === "object") {
+            payload._skillDisabled = true;
+          }
+          return true;
+        },
+      },
     });
 
     const approvalService = createFridayApprovalWorkflowService({
@@ -974,6 +983,15 @@ describe("Approval → execution linkage", () => {
         nowIso: () => NOW,
       }),
       nowIso: () => NOW,
+      stepExecutors: {
+        retry_node: (step) => {
+          const payload = step.payload as Record<string, unknown> | null;
+          if (payload && typeof payload === "object") {
+            payload._retryRequested = true;
+          }
+          return true;
+        },
+      },
     });
 
     const dispatcher = createFridayAutoFixDispatcherService({


### PR DESCRIPTION
## Summary
- Scope agent memory search/store to the active agent/session context and reject reserved system/tenant namespaces.
- Stop config incidents from generating marker-only `apply_config_patch` remediation plans.
- Make auto-fix execution fail closed for external/runtime state mutations unless the hub injects a real executor, and update rollback expectations accordingly.

## Validation
- `npm test -- test/unit/agent/tools/friday-agent-memory-tools.test.ts test/unit/learning/services/friday-auto-fix-plan-service.test.ts test/unit/learning/services/friday-error-diagnosis-service.test.ts test/unit/learning/services/friday-self-learning-pipeline-service.test.ts test/unit/learning/services/friday-auto-fix-dispatcher-service.test.ts test/unit/learning/services/friday-auto-fix-execution-service.test.ts test/unit/learning/runtime/friday-self-learning-runtime.test.ts test/unit/hub/bootstrap/hub-helpers.test.ts`
- `npm test -- test/unit/memory/guard/services/friday-memory-guard-service-namespace-isolation.test.ts test/unit/memory/guard/services/friday-memory-guard-service-validation.test.ts test/integration/sessions/friday-session-memory-extraction-integration.test.ts test/e2e/mock/friday-mock-tool-invocations.e2e.test.ts test/integration/hub/friday-hub-bootstrap-integration.test.ts test/integration/node-runner/friday-node-runner-pipeline-integration.test.ts test/integration/retry/friday-production-retry-bridge.test.ts test/integration/acceptance/friday-acceptance-gate-integration.test.ts test/integration/playbook/friday-playbook-learning-loop.test.ts`
- `npm test`