### PR TITLE
Add native Guide Lens overlay

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -419,7 +419,7 @@
         "filename": "src/api/http/routes/friday-setup-routes.ts",
         "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
         "is_verified": false,
-        "line_number": 1874
+        "line_number": 1981
       }
     ],
     "src/observability/model/friday-observability.types.ts": [
@@ -736,42 +736,42 @@
         "filename": "test/unit/api/auth/friday-auth-service.test.ts",
         "hashed_secret": "6809ffccad03b80fa1fbc32c17e7e054805ec30b",
         "is_verified": false,
-        "line_number": 248
+        "line_number": 267
       },
       {
         "type": "Secret Keyword",
         "filename": "test/unit/api/auth/friday-auth-service.test.ts",
         "hashed_secret": "8867c88b56e0bfb82cffaf15a66bc8d107d6754a",
         "is_verified": false,
-        "line_number": 275
+        "line_number": 294
       },
       {
         "type": "Secret Keyword",
         "filename": "test/unit/api/auth/friday-auth-service.test.ts",
         "hashed_secret": "ce77798dc40945979f340e376e69b0d043c1e1e0",
         "is_verified": false,
-        "line_number": 528
+        "line_number": 547
       },
       {
         "type": "Secret Keyword",
         "filename": "test/unit/api/auth/friday-auth-service.test.ts",
         "hashed_secret": "05d83970b7ed1c839f218a5f611ed5ed89a43148",
         "is_verified": false,
-        "line_number": 548
+        "line_number": 567
       },
       {
         "type": "Secret Keyword",
         "filename": "test/unit/api/auth/friday-auth-service.test.ts",
         "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
         "is_verified": false,
-        "line_number": 575
+        "line_number": 594
       },
       {
         "type": "Secret Keyword",
         "filename": "test/unit/api/auth/friday-auth-service.test.ts",
         "hashed_secret": "1902e3d6fc4e78a0bcc50ba12b882769afbf4a8c",
         "is_verified": false,
-        "line_number": 715
+        "line_number": 734
       }
     ],
     "test/unit/api/auth/friday-token-validator.test.ts": [
@@ -904,7 +904,7 @@
         "filename": "test/unit/channels/lark/friday-lark-channel.test.ts",
         "hashed_secret": "5332dacad20a47ed30ac276f31420d348a122341",
         "is_verified": false,
-        "line_number": 168
+        "line_number": 207
       }
     ],
     "test/unit/channels/line/friday-line-channel.test.ts": [
@@ -1175,5 +1175,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-27T20:57:27Z"
+  "generated_at": "2026-04-28T17:48:36Z"
 }

--- a/apps/macos/FridayCompanion/Sources/FridayCompanion/main.swift
+++ b/apps/macos/FridayCompanion/Sources/FridayCompanion/main.swift
@@ -17,6 +17,112 @@ private func slugify(_ value: String) -> String {
     .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
 }
 
+private struct GuideBounds {
+  let x: CGFloat
+  let y: CGFloat
+  let width: CGFloat
+  let height: CGFloat
+}
+
+private struct GuideAvatar {
+  let kind: String
+  let imageUrl: String?
+  let localPath: String?
+  let initials: String
+  let sizePx: CGFloat
+}
+
+private struct GuideOverlayCommand {
+  let id: String
+  let mode: String
+  let message: String
+  let targetBounds: GuideBounds?
+  let avatar: GuideAvatar
+  let stepLabel: String?
+  let tone: String
+}
+
+private final class GuideOverlayRootView: NSView {
+  override func hitTest(_ point: NSPoint) -> NSView? {
+    guard let hit = super.hitTest(point), hit !== self else {
+      return nil
+    }
+    var current: NSView? = hit
+    while let view = current {
+      if view.identifier?.rawValue == "guide-control" {
+        return hit
+      }
+      current = view.superview
+    }
+    return nil
+  }
+}
+
+private final class GuideFocusView: NSView {
+  override var isFlipped: Bool { false }
+
+  override func draw(_ dirtyRect: NSRect) {
+    super.draw(dirtyRect)
+    let rect = bounds.insetBy(dx: 4, dy: 4)
+    let path = NSBezierPath(roundedRect: rect, xRadius: 12, yRadius: 12)
+    NSColor(calibratedRed: 0.11, green: 0.45, blue: 1.0, alpha: 0.18).setFill()
+    path.fill()
+    NSColor(calibratedRed: 0.11, green: 0.45, blue: 1.0, alpha: 0.95).setStroke()
+    path.lineWidth = 3
+    path.stroke()
+  }
+}
+
+private final class GuideAvatarView: NSView {
+  private let avatar: GuideAvatar
+
+  init(frame: NSRect, avatar: GuideAvatar) {
+    self.avatar = avatar
+    super.init(frame: frame)
+    wantsLayer = true
+  }
+
+  required init?(coder: NSCoder) {
+    return nil
+  }
+
+  override func draw(_ dirtyRect: NSRect) {
+    super.draw(dirtyRect)
+    let circle = NSBezierPath(ovalIn: bounds.insetBy(dx: 2, dy: 2))
+    NSColor(calibratedWhite: 0.76, alpha: 1.0).setFill()
+    circle.fill()
+
+    if let image = loadAvatarImage() {
+      NSGraphicsContext.saveGraphicsState()
+      circle.addClip()
+      image.draw(in: bounds)
+      NSGraphicsContext.restoreGraphicsState()
+      return
+    }
+
+    let text = avatar.initials.isEmpty ? "F" : avatar.initials
+    let attributes: [NSAttributedString.Key: Any] = [
+      .font: NSFont.systemFont(ofSize: min(bounds.width, bounds.height) * 0.44, weight: .semibold),
+      .foregroundColor: NSColor.white,
+    ]
+    let size = text.size(withAttributes: attributes)
+    text.draw(
+      at: NSPoint(x: bounds.midX - size.width / 2, y: bounds.midY - size.height / 2),
+      withAttributes: attributes
+    )
+  }
+
+  private func loadAvatarImage() -> NSImage? {
+    if avatar.kind == "local_image", let path = avatar.localPath {
+      return NSImage(contentsOfFile: path)
+    }
+    if avatar.kind == "profile_image", let value = avatar.imageUrl, value.hasPrefix("file://"), let url = URL(string: value) {
+      return NSImage(contentsOf: url)
+    }
+    return nil
+  }
+}
+
 @MainActor
 final class CompanionAppController: NSObject, NSApplicationDelegate {
   private let config: CompanionConfig
@@ -37,6 +143,7 @@ final class CompanionAppController: NSObject, NSApplicationDelegate {
   private var heartbeatTimer: Timer?
   private var server: CompanionUnixSocketServer?
   private var overlayVisible = false
+  private var guideOverlayCommand: GuideOverlayCommand?
   private var panicActive = false
   private var lastHeartbeatAt = nowIso()
   private var lastNotificationRefreshError: String?
@@ -146,44 +253,24 @@ final class CompanionAppController: NSObject, NSApplicationDelegate {
   }
 
   private func buildOverlayWindow() {
-    let frame = NSRect(x: 0, y: 0, width: 560, height: 240)
+    let screenFrame = NSScreen.main?.frame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
     let panel = NSPanel(
-      contentRect: frame,
+      contentRect: screenFrame,
       styleMask: [.borderless, .nonactivatingPanel],
       backing: .buffered,
       defer: false
     )
     panel.level = .statusBar
     panel.isOpaque = false
-    panel.backgroundColor = NSColor(calibratedWhite: 0.08, alpha: 0.92)
-    panel.hasShadow = true
+    panel.backgroundColor = .clear
+    panel.hasShadow = false
     panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
     panel.titleVisibility = .hidden
     panel.titlebarAppearsTransparent = true
     panel.isReleasedWhenClosed = false
+    panel.ignoresMouseEvents = false
 
-    let contentView = NSView(frame: frame)
-    let titleLabel = NSTextField(labelWithString: "Friday Agent OS")
-    titleLabel.font = NSFont.systemFont(ofSize: 28, weight: .semibold)
-    titleLabel.textColor = .white
-    titleLabel.frame = NSRect(x: 28, y: 148, width: 320, height: 36)
-
-    let detailLabel = NSTextField(labelWithString: "Command overlay ready. Use the web console for full operator control.")
-    detailLabel.font = NSFont.systemFont(ofSize: 14, weight: .regular)
-    detailLabel.textColor = NSColor(calibratedWhite: 0.82, alpha: 1.0)
-    detailLabel.frame = NSRect(x: 28, y: 112, width: 500, height: 20)
-
-    let hotkeyLabel = NSTextField(
-      labelWithString: "Overlay: \(config.overlayHotkey.displayString)  •  Panic: \(config.panicHotkey.displayString)"
-    )
-    hotkeyLabel.font = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
-    hotkeyLabel.textColor = NSColor(calibratedWhite: 0.68, alpha: 1.0)
-    hotkeyLabel.frame = NSRect(x: 28, y: 72, width: 500, height: 18)
-
-    contentView.addSubview(titleLabel)
-    contentView.addSubview(detailLabel)
-    contentView.addSubview(hotkeyLabel)
-    panel.contentView = contentView
+    panel.contentView = GuideOverlayRootView(frame: NSRect(x: 0, y: 0, width: screenFrame.width, height: screenFrame.height))
     overlayWindow = panel
     centerOverlayWindow()
   }
@@ -192,11 +279,7 @@ final class CompanionAppController: NSObject, NSApplicationDelegate {
     guard let overlayWindow, let screen = NSScreen.main else {
       return
     }
-    let origin = NSPoint(
-      x: screen.frame.midX - overlayWindow.frame.width / 2,
-      y: screen.frame.midY - overlayWindow.frame.height / 2
-    )
-    overlayWindow.setFrameOrigin(origin)
+    overlayWindow.setFrame(screen.frame, display: true)
   }
 
   private func installHotkeyMonitors() {
@@ -284,10 +367,191 @@ final class CompanionAppController: NSObject, NSApplicationDelegate {
     }
     centerOverlayWindow()
     if visible {
+      renderGuideOverlay(guideOverlayCommand ?? defaultGuideOverlayCommand())
       overlayWindow.orderFrontRegardless()
     } else {
+      guideOverlayCommand = nil
+      overlayWindow.contentView?.subviews.forEach { $0.removeFromSuperview() }
       overlayWindow.orderOut(nil)
     }
+  }
+
+  private func defaultGuideOverlayCommand() -> GuideOverlayCommand {
+    GuideOverlayCommand(
+      id: "manual-overlay",
+      mode: "speech_bubble",
+      message: "Guide Mode is ready. Ask Friday for help and I will point to the next step.",
+      targetBounds: nil,
+      avatar: GuideAvatar(kind: "default_f", imageUrl: nil, localPath: nil, initials: "F", sizePx: 56),
+      stepLabel: nil,
+      tone: "calm"
+    )
+  }
+
+  private func showGuideOverlay(command: GuideOverlayCommand) -> [String: Any] {
+    guideOverlayCommand = command
+    panicActive = false
+    setOverlayVisible(true)
+    refreshMenuState()
+    return [
+      "visible": true,
+      "changedAt": nowIso(),
+    ]
+  }
+
+  private func clearGuideOverlay() -> [String: Any] {
+    guideOverlayCommand = nil
+    setOverlayVisible(false)
+    refreshMenuState()
+    return [
+      "visible": false,
+      "changedAt": nowIso(),
+    ]
+  }
+
+  private func renderGuideOverlay(_ command: GuideOverlayCommand) {
+    guard let root = overlayWindow?.contentView, let screen = NSScreen.main else {
+      return
+    }
+    root.subviews.forEach { $0.removeFromSuperview() }
+
+    if let target = command.targetBounds {
+      let focusFrame = convertGuideBounds(target, screen: screen).insetBy(dx: -8, dy: -8)
+      let focusView = GuideFocusView(frame: focusFrame)
+      focusView.wantsLayer = true
+      focusView.layer?.shadowColor = NSColor(calibratedRed: 0.11, green: 0.45, blue: 1.0, alpha: 0.65).cgColor
+      focusView.layer?.shadowRadius = 18
+      focusView.layer?.shadowOpacity = 1
+      focusView.layer?.shadowOffset = .zero
+      root.addSubview(focusView)
+    }
+
+    let avatarSize = max(40, min(96, command.avatar.sizePx))
+    let bubbleSize = computeBubbleSize(message: command.message, stepLabel: command.stepLabel)
+    let bubbleOrigin = resolveBubbleOrigin(
+      targetBounds: command.targetBounds,
+      bubbleSize: bubbleSize,
+      avatarSize: avatarSize,
+      screen: screen
+    )
+    let avatarFrame = NSRect(
+      x: bubbleOrigin.x,
+      y: bubbleOrigin.y + bubbleSize.height - avatarSize,
+      width: avatarSize,
+      height: avatarSize
+    )
+    let bubbleFrame = NSRect(
+      x: bubbleOrigin.x + avatarSize + 12,
+      y: bubbleOrigin.y,
+      width: bubbleSize.width,
+      height: bubbleSize.height
+    )
+
+    let avatarView = GuideAvatarView(frame: avatarFrame, avatar: command.avatar)
+    avatarView.wantsLayer = true
+    avatarView.layer?.shadowColor = NSColor.black.withAlphaComponent(0.18).cgColor
+    avatarView.layer?.shadowOpacity = 1
+    avatarView.layer?.shadowRadius = 12
+    avatarView.layer?.shadowOffset = NSSize(width: 0, height: -2)
+    root.addSubview(avatarView)
+
+    let bubble = NSView(frame: bubbleFrame)
+    bubble.wantsLayer = true
+    bubble.layer?.backgroundColor = NSColor(calibratedWhite: 1.0, alpha: 0.96).cgColor
+    bubble.layer?.cornerRadius = 18
+    bubble.layer?.shadowColor = NSColor.black.withAlphaComponent(0.16).cgColor
+    bubble.layer?.shadowOpacity = 1
+    bubble.layer?.shadowRadius = 18
+    bubble.layer?.shadowOffset = NSSize(width: 0, height: -4)
+
+    let stepText = command.stepLabel ?? labelForGuideMode(command.mode)
+    let stepLabel = NSTextField(labelWithString: stepText.uppercased())
+    stepLabel.font = NSFont.systemFont(ofSize: 11, weight: .semibold)
+    stepLabel.textColor = NSColor(calibratedRed: 0.11, green: 0.35, blue: 0.84, alpha: 1)
+    stepLabel.frame = NSRect(x: 18, y: bubbleFrame.height - 34, width: bubbleFrame.width - 58, height: 16)
+
+    let closeButton = NSButton(title: "Close", target: self, action: #selector(closeGuideOverlayFromButton))
+    closeButton.identifier = NSUserInterfaceItemIdentifier("guide-control")
+    closeButton.isBordered = false
+    closeButton.font = NSFont.systemFont(ofSize: 12, weight: .medium)
+    closeButton.contentTintColor = NSColor(calibratedWhite: 0.32, alpha: 1)
+    closeButton.frame = NSRect(x: bubbleFrame.width - 62, y: bubbleFrame.height - 36, width: 50, height: 22)
+
+    let messageLabel = NSTextField(wrappingLabelWithString: command.message)
+    messageLabel.font = NSFont.systemFont(ofSize: 15, weight: .regular)
+    messageLabel.textColor = NSColor(calibratedWhite: 0.12, alpha: 1)
+    messageLabel.frame = NSRect(x: 18, y: 18, width: bubbleFrame.width - 36, height: bubbleFrame.height - 58)
+
+    bubble.addSubview(stepLabel)
+    bubble.addSubview(closeButton)
+    bubble.addSubview(messageLabel)
+    root.addSubview(bubble)
+  }
+
+  @objc private func closeGuideOverlayFromButton() {
+    _ = clearGuideOverlay()
+  }
+
+  private func labelForGuideMode(_ mode: String) -> String {
+    switch mode {
+    case "focus_frame":
+      return "Next step"
+    case "scroll_hint":
+      return "Scroll needed"
+    case "page_transition":
+      return "New page"
+    case "blocked":
+      return "Need help"
+    case "confirm_step":
+      return "Confirm"
+    default:
+      return "Guide Mode"
+    }
+  }
+
+  private func computeBubbleSize(message: String, stepLabel: String?) -> NSSize {
+    let width: CGFloat = min(420, max(300, CGFloat(message.count) * 4.8))
+    let lineCount = max(1, Int(ceil(Double(message.count) / 42.0)))
+    let height = CGFloat(76 + lineCount * 24 + (stepLabel == nil ? 0 : 4))
+    return NSSize(width: width, height: min(220, max(124, height)))
+  }
+
+  private func resolveBubbleOrigin(
+    targetBounds: GuideBounds?,
+    bubbleSize: NSSize,
+    avatarSize: CGFloat,
+    screen: NSScreen
+  ) -> NSPoint {
+    let rootFrame = NSRect(x: 0, y: 0, width: screen.frame.width, height: screen.frame.height)
+    let totalWidth = bubbleSize.width + avatarSize + 12
+    let totalHeight = max(bubbleSize.height, avatarSize)
+    let margin: CGFloat = 28
+
+    if let targetBounds {
+      let target = convertGuideBounds(targetBounds, screen: screen)
+      var x = target.maxX + 18
+      if x + totalWidth > rootFrame.maxX - margin {
+        x = target.minX - totalWidth - 18
+      }
+      var y = target.midY - totalHeight / 2
+      y = min(max(y, rootFrame.minY + margin), rootFrame.maxY - totalHeight - margin)
+      x = min(max(x, rootFrame.minX + margin), rootFrame.maxX - totalWidth - margin)
+      return NSPoint(x: x, y: y)
+    }
+
+    return NSPoint(
+      x: rootFrame.maxX - totalWidth - 44,
+      y: rootFrame.maxY - totalHeight - 96
+    )
+  }
+
+  private func convertGuideBounds(_ bounds: GuideBounds, screen: NSScreen) -> NSRect {
+    NSRect(
+      x: bounds.x,
+      y: screen.frame.height - bounds.y - bounds.height,
+      width: bounds.width,
+      height: bounds.height
+    )
   }
 
   private func refreshMenuState() {
@@ -349,11 +613,74 @@ final class CompanionAppController: NSObject, NSApplicationDelegate {
         "visible": visible,
         "changedAt": nowIso(),
       ]
+    case "companion.showGuideOverlay":
+      guard let command = parseGuideOverlayCommand(params["command"]) else {
+        throw NSError(domain: "FridayCompanion", code: 400, userInfo: [
+          NSLocalizedDescriptionKey: "Invalid guide overlay command",
+        ])
+      }
+      return showGuideOverlay(command: command)
+    case "companion.clearGuideOverlay":
+      return clearGuideOverlay()
     default:
       throw NSError(domain: "FridayCompanion", code: 404, userInfo: [
         NSLocalizedDescriptionKey: "Unknown companion method: \(method)",
       ])
     }
+  }
+
+  private func parseGuideOverlayCommand(_ raw: Any?) -> GuideOverlayCommand? {
+    guard let dict = raw as? [String: Any] else {
+      return nil
+    }
+    let avatarDict = dict["avatar"] as? [String: Any] ?? [:]
+    let stepDict = dict["step"] as? [String: Any]
+    return GuideOverlayCommand(
+      id: dict["id"] as? String ?? "guide-overlay",
+      mode: dict["mode"] as? String ?? "speech_bubble",
+      message: dict["message"] as? String ?? "Please follow this highlighted step.",
+      targetBounds: parseGuideBounds(dict["targetBounds"]),
+      avatar: GuideAvatar(
+        kind: avatarDict["kind"] as? String ?? "default_f",
+        imageUrl: avatarDict["imageUrl"] as? String,
+        localPath: avatarDict["localPath"] as? String,
+        initials: avatarDict["initials"] as? String ?? "F",
+        sizePx: numberValue(avatarDict["sizePx"]) ?? 56
+      ),
+      stepLabel: stepDict?["label"] as? String,
+      tone: dict["tone"] as? String ?? "calm"
+    )
+  }
+
+  private func parseGuideBounds(_ raw: Any?) -> GuideBounds? {
+    guard let dict = raw as? [String: Any],
+      let x = numberValue(dict["x"]),
+      let y = numberValue(dict["y"]),
+      let width = numberValue(dict["width"]),
+      let height = numberValue(dict["height"])
+    else {
+      return nil
+    }
+    return GuideBounds(x: x, y: y, width: max(1, width), height: max(1, height))
+  }
+
+  private func numberValue(_ raw: Any?) -> CGFloat? {
+    if let value = raw as? CGFloat {
+      return value
+    }
+    if let value = raw as? Double {
+      return CGFloat(value)
+    }
+    if let value = raw as? Int {
+      return CGFloat(value)
+    }
+    if let value = raw as? NSNumber {
+      return CGFloat(truncating: value)
+    }
+    if let value = raw as? String, let parsed = Double(value) {
+      return CGFloat(parsed)
+    }
+    return nil
   }
 
   private func statusPayload() -> [String: Any] {

--- a/docs/DESIGN-GUIDE-LENS.md
+++ b/docs/DESIGN-GUIDE-LENS.md
@@ -2,7 +2,17 @@
 
 ## Status
 
-Draft for product and architecture review.
+Implemented MVP for the macOS native companion path.
+
+The shipped slice includes the read-only Guide Lens domain service, HTTP API,
+agent tool, macOS companion guide overlay RPC, native blue focus-frame overlay,
+settings-page avatar controls, screenshot-intake heuristics, redaction, target
+resolution, optional loopback parser adapter, and verification tests.
+
+Remaining future work is higher-fidelity perception: real Accessibility element
+tree harvesting beyond the current system/window snapshot bridge, richer
+OmniParser/Midscene health/ranking, and broader Windows/Linux native overlay
+ports.
 
 Guide Mode is the user-facing product name. `guide_lens` is the internal
 capability name.
@@ -1202,14 +1212,12 @@ src/guide-lens/model/friday-guide-lens.types.ts
 src/guide-lens/engine/screenshot-intake.ts
 src/guide-lens/engine/ui-map-builder.ts
 src/guide-lens/engine/target-resolver.ts
-src/guide-lens/engine/parser-registry.ts
+src/guide-lens/engine/parser-adapter.ts
 src/guide-lens/engine/redaction.ts
 src/guide-lens/engine/verification.ts
 src/agent/tools/friday-agent-guide-lens-tool.ts
-src/system/companion/friday-system-guide-overlay.types.ts
-src/system/companion/friday-system-native-guide-overlay.ts
-src/system/companion/friday-system-guide-avatar-store.ts
-ui/src/components/guide-lens/guide-lens-overlay.tsx
+apps/macos/FridayCompanion/Sources/FridayCompanion/main.swift
+ui/src/routes/settings-page.tsx
 ```
 
 Suggested new API routes:
@@ -1217,10 +1225,11 @@ Suggested new API routes:
 ```text
 GET  /v1/guide-lens/state
 POST /v1/guide-lens/snapshot
-POST /v1/guide-lens/screenshot-intake
-POST /v1/guide-lens/resolve-target
+POST /v1/guide-lens/screenshots/analyze
+POST /v1/guide-lens/targets/resolve
 POST /v1/guide-lens/overlay
-POST /v1/guide-lens/verify
+DELETE /v1/guide-lens/overlay
+POST /v1/guide-lens/verifications
 PATCH /v1/guide-lens/preferences
 POST /v1/guide-lens/avatar
 ```

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -363,6 +363,11 @@ export { createFridayAgentMcpTool } from "./tools/friday-agent-mcp-tool.js";
 export type { CreateFridayAgentSystemToolOptions } from "./tools/friday-agent-system-tool.js";
 export { createFridayAgentSystemTool } from "./tools/friday-agent-system-tool.js";
 
+// ─── Guide Lens tool ───
+
+export type { CreateFridayAgentGuideLensToolOptions } from "./tools/friday-agent-guide-lens-tool.js";
+export { createFridayAgentGuideLensTool } from "./tools/friday-agent-guide-lens-tool.js";
+
 // ─── Capabilities tool ───
 
 export type {

--- a/src/agent/tools/friday-agent-guide-lens-tool.ts
+++ b/src/agent/tools/friday-agent-guide-lens-tool.ts
@@ -1,0 +1,197 @@
+import type { FridayAgentToolDefinition, FridayAgentToolResult } from "../model/friday-agent.types.js";
+import type {
+  FridayGuideLensBounds,
+  FridayGuideLensOverlayMode,
+  FridayGuideLensService,
+  FridayGuideLensSurface,
+} from "../../guide-lens/model/friday-guide-lens.types.js";
+import {
+  errorResult,
+  jsonResult,
+  readNumberParam,
+  readStringParam,
+} from "./friday-agent-tool-helpers.js";
+
+export interface CreateFridayAgentGuideLensToolOptions {
+  guideLensService: FridayGuideLensService;
+}
+
+type GuideLensAction =
+  | "state"
+  | "snapshot"
+  | "resolve_target"
+  | "show_overlay"
+  | "clear_overlay"
+  | "screenshot_intake"
+  | "verify"
+  | "update_preferences"
+  | "update_avatar";
+
+const VALID_ACTIONS = new Set<GuideLensAction>([
+  "state",
+  "snapshot",
+  "resolve_target",
+  "show_overlay",
+  "clear_overlay",
+  "screenshot_intake",
+  "verify",
+  "update_preferences",
+  "update_avatar",
+]);
+
+function readObjectParam<T extends Record<string, unknown>>(
+  args: Record<string, unknown>,
+  key: string,
+): T | undefined {
+  const value = args[key];
+  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+    return value as T;
+  }
+  return undefined;
+}
+
+function readBoundsParam(
+  args: Record<string, unknown>,
+  key: string,
+): FridayGuideLensBounds | undefined {
+  const value = readObjectParam(args, key);
+  if (!value) return undefined;
+  const x = Number(value.x);
+  const y = Number(value.y);
+  const width = Number(value.width);
+  const height = Number(value.height);
+  if (![x, y, width, height].every(Number.isFinite) || width <= 0 || height <= 0) {
+    return undefined;
+  }
+  return { x, y, width, height };
+}
+
+export function createFridayAgentGuideLensTool(
+  options: CreateFridayAgentGuideLensToolOptions,
+): FridayAgentToolDefinition {
+  const { guideLensService } = options;
+
+  return {
+    name: "guide_lens",
+    description:
+      "Read-only Guide Mode for seeing the user's visible UI and drawing a non-clicking native overlay. " +
+      "Use it to capture a compact UI map, resolve a target, show a blue focus frame or speech bubble, analyze screenshots, and verify progress. " +
+      "It must never click, type, scroll, launch apps, write files, approve permissions, or mutate the desktop.",
+    parameters: {
+      properties: {
+        action: {
+          type: "string",
+          enum: Array.from(VALID_ACTIONS),
+          description: "Guide Lens action.",
+        },
+        sessionId: { type: "string" },
+        surface: {
+          type: "string",
+          enum: ["native_desktop", "browser", "friday_web", "remote_session", "screenshot"],
+        },
+        objective: { type: "string" },
+        instruction: { type: "string", description: "Target to locate, such as the visible button or field name." },
+        message: { type: "string", description: "Short user-facing overlay instruction." },
+        visibleText: { type: "string", description: "Optional local visible text snapshot." },
+        screenshotText: { type: "string", description: "Optional OCR/screenshot text; secrets are redacted by the service." },
+        question: { type: "string", description: "User question attached to a screenshot." },
+        mode: {
+          type: "string",
+          enum: [
+            "avatar_bubble",
+            "focus_frame",
+            "cursor_ghost",
+            "speech_bubble",
+            "scroll_hint",
+            "page_transition",
+            "numbered_marks",
+            "candidate_picker",
+            "confirm_step",
+            "blocked",
+            "clear",
+          ],
+        },
+        targetBounds: { type: "object", description: "Optional {x,y,width,height} in screen coordinates." },
+        expected: { type: "object", description: "Verification criteria." },
+        preferences: { type: "object", description: "Guide Lens preference patch." },
+        avatar: { type: "object", description: "Avatar patch: default_f, profile_image, or local_image." },
+        maxCandidates: { type: "number" },
+      },
+      required: ["action"],
+    },
+
+    async execute(args: Record<string, unknown>): Promise<FridayAgentToolResult> {
+      const action = readStringParam(args, "action", { required: true }) as GuideLensAction;
+      if (!VALID_ACTIONS.has(action)) {
+        return errorResult(
+          `Invalid action "${action}". Valid actions: ${Array.from(VALID_ACTIONS).join(", ")}`,
+        );
+      }
+
+      try {
+        for (const key of ["actionType", "intent", "instruction", "message"]) {
+          const value = args[key];
+          if (typeof value === "string") {
+            guideLensService.assertReadOnlyAction(value);
+          }
+        }
+
+        const sessionId = readStringParam(args, "sessionId");
+        if (action === "state") {
+          return jsonResult(guideLensService.getState());
+        }
+        if (action === "snapshot") {
+          return jsonResult(await guideLensService.captureSnapshot({
+            sessionId,
+            surface: readStringParam(args, "surface") as FridayGuideLensSurface | undefined,
+            objective: readStringParam(args, "objective"),
+            visibleText: readStringParam(args, "visibleText"),
+            screenshotText: readStringParam(args, "screenshotText"),
+          }));
+        }
+        if (action === "resolve_target") {
+          const instruction = readStringParam(args, "instruction", { required: true });
+          return jsonResult(await guideLensService.resolveTarget({
+            sessionId,
+            instruction,
+            maxCandidates: readNumberParam(args, "maxCandidates", { integer: true }),
+          }));
+        }
+        if (action === "show_overlay") {
+          const message = readStringParam(args, "message", { required: true });
+          return jsonResult(await guideLensService.showOverlay({
+            sessionId,
+            surface: readStringParam(args, "surface") as FridayGuideLensSurface | undefined,
+            mode: readStringParam(args, "mode") as FridayGuideLensOverlayMode | undefined,
+            message,
+            targetBounds: readBoundsParam(args, "targetBounds"),
+          }));
+        }
+        if (action === "clear_overlay") {
+          return jsonResult(await guideLensService.clearOverlay(sessionId));
+        }
+        if (action === "screenshot_intake") {
+          return jsonResult(await guideLensService.analyzeScreenshot({
+            sessionId,
+            question: readStringParam(args, "question"),
+            visibleText: readStringParam(args, "visibleText"),
+            screenshotText: readStringParam(args, "screenshotText"),
+            source: "upload",
+          }));
+        }
+        if (action === "verify") {
+          return jsonResult(await guideLensService.verify({
+            sessionId,
+            expected: readObjectParam(args, "expected"),
+          }));
+        }
+        if (action === "update_preferences") {
+          return jsonResult(guideLensService.updatePreferences(readObjectParam(args, "preferences") ?? {}));
+        }
+        return jsonResult(guideLensService.updateAvatar(readObjectParam(args, "avatar") ?? {}));
+      } catch (error) {
+        return errorResult(error instanceof Error ? error.message : String(error));
+      }
+    },
+  };
+}

--- a/src/agent/tools/friday-agent-tool-registry.ts
+++ b/src/agent/tools/friday-agent-tool-registry.ts
@@ -42,6 +42,8 @@ import type { DesktopSessionManager } from "../../desktop/engine/session-manager
 import { createFridayAgentDesktopTool } from "./friday-agent-desktop-tool.js";
 import type { FridaySystemService } from "../../system/engine/friday-system-service.js";
 import { createFridayAgentSystemTool } from "./friday-agent-system-tool.js";
+import type { FridayGuideLensService } from "../../guide-lens/model/friday-guide-lens.types.js";
+import { createFridayAgentGuideLensTool } from "./friday-agent-guide-lens-tool.js";
 import { createFridayAgentMemoryExtractTool } from "./friday-agent-memory-extract-tool.js";
 import type { FridayMcpAdapter } from "../mcp/friday-mcp-adapter.types.js";
 import { listFridayMcpServerReadiness } from "../mcp/friday-mcp-readiness.js";
@@ -108,6 +110,8 @@ export interface CreateFridayAgentToolRegistryOptions {
   desktopSessionManager?: DesktopSessionManager;
   /** Agent OS orchestration service for the `system` tool. */
   systemService?: FridaySystemService;
+  /** Read-only native guide overlay service for the `guide_lens` tool. */
+  guideLensService?: FridayGuideLensService;
   /** Optional MCP adapter for external MCP server integration. */
   mcpAdapter?: FridayMcpAdapter;
   /** OC-013: Session memory extraction service for memory_extract tool. */
@@ -288,6 +292,12 @@ export function createFridayAgentToolRegistry(
   if (options?.systemService) {
     tools.push(
       createFridayAgentSystemTool({ systemService: options.systemService }),
+    );
+  }
+
+  if (options?.guideLensService) {
+    tools.push(
+      createFridayAgentGuideLensTool({ guideLensService: options.guideLensService }),
     );
   }
 

--- a/src/api/auth/friday-auth-middleware.ts
+++ b/src/api/auth/friday-auth-middleware.ts
@@ -1,6 +1,5 @@
 import type { FridayHttpContext } from "../model/friday-api-common.types.js";
 import type {
-  FridayAuthPrincipal,
   FridayRateLimitPolicyId,
   FridayRole,
   FridayScope,
@@ -50,9 +49,6 @@ export interface FridayAuthMiddlewareFactory {
 export interface CreateFridayAuthMiddlewareFactoryDeps {
   tokenValidator: FridayTokenValidator;
   rateLimitService: FridayRateLimitService;
-  resolveLocalBypassPrincipal?: (
-    ctx: FridayHttpContext<unknown, unknown, unknown>,
-  ) => FridayAuthPrincipal | null | undefined;
 }
 
 // ─── Helpers ───
@@ -84,21 +80,6 @@ function getRateLimitKey(
   }
 }
 
-function applyLocalBypassPrincipal(
-  ctx: FridayHttpContext<unknown, unknown, unknown>,
-  resolveLocalBypassPrincipal?: CreateFridayAuthMiddlewareFactoryDeps["resolveLocalBypassPrincipal"],
-): FridayMiddlewareResult | undefined {
-  const localPrincipal = resolveLocalBypassPrincipal?.(ctx);
-  if (!localPrincipal) {
-    return undefined;
-  }
-  ctx.principal = localPrincipal;
-  return {
-    passed: true,
-    headers: { "X-Friday-Local-Session": "bypass" },
-  };
-}
-
 // ─── Factory ───
 
 export function createFridayAuthMiddlewareFactory(
@@ -112,10 +93,6 @@ export function createFridayAuthMiddlewareFactory(
 
       const token = extractBearerToken(ctx.headers);
       if (!token) {
-        const localBypass = applyLocalBypassPrincipal(ctx, deps.resolveLocalBypassPrincipal);
-        if (localBypass) {
-          return localBypass;
-        }
         return {
           passed: false,
           statusCode: 401,
@@ -129,10 +106,6 @@ export function createFridayAuthMiddlewareFactory(
         ctx.principal = validated.principal;
         return { passed: true };
       } catch (err) {
-        const localBypass = applyLocalBypassPrincipal(ctx, deps.resolveLocalBypassPrincipal);
-        if (localBypass) {
-          return localBypass;
-        }
         if (err instanceof FridayTokenValidationError) {
           return {
             passed: false,

--- a/src/api/http/routes/friday-guide-lens-routes.ts
+++ b/src/api/http/routes/friday-guide-lens-routes.ts
@@ -1,0 +1,138 @@
+import { FridayDomainError } from "#errors";
+import type { FridayRouteDefinition } from "../../model/friday-api-common.types.js";
+import type {
+  FridayGuideLensAvatarPreference,
+  FridayGuideLensPreferences,
+  FridayGuideLensResolveTargetRequest,
+  FridayGuideLensScreenshotIntakeRequest,
+  FridayGuideLensService,
+  FridayGuideLensShowOverlayRequest,
+  FridayGuideLensSnapshotRequest,
+  FridayGuideLensVerificationRequest,
+} from "../../../guide-lens/model/friday-guide-lens.types.js";
+
+export interface FridayGuideLensRoutesDeps {
+  service: FridayGuideLensService;
+}
+
+function requireBodyObject(body: unknown): Record<string, unknown> {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    throw new FridayDomainError("VALIDATION_ERROR", "Request body must be an object", { httpStatus: 400 });
+  }
+  return body as Record<string, unknown>;
+}
+
+function requireString(body: unknown, field: string): void {
+  const obj = requireBodyObject(body);
+  if (typeof obj[field] !== "string" || (obj[field] as string).trim().length === 0) {
+    throw new FridayDomainError("VALIDATION_ERROR", `${field} is required`, { httpStatus: 400 });
+  }
+}
+
+function validateNoMutatingIntent(service: FridayGuideLensService, body: unknown): void {
+  const obj = typeof body === "object" && body !== null ? body as Record<string, unknown> : {};
+  for (const key of ["action", "actionType", "intent", "instruction", "message"]) {
+    const value = obj[key];
+    if (typeof value === "string") {
+      service.assertReadOnlyAction(value);
+    }
+  }
+}
+
+export function createFridayGuideLensRoutes(
+  deps: FridayGuideLensRoutesDeps,
+): FridayRouteDefinition<unknown, unknown, unknown, unknown>[] {
+  return [
+    {
+      operationId: "guidelens.state.get",
+      method: "GET",
+      path: "/v1/guide-lens/state",
+      auth: { public: false, anyOfScopes: ["desktop.read"] },
+      async handler() {
+        return deps.service.getState();
+      },
+    },
+    {
+      operationId: "guidelens.snapshot.create",
+      method: "POST",
+      path: "/v1/guide-lens/snapshot",
+      auth: { public: false, anyOfScopes: ["desktop.read"] },
+      async handler(ctx) {
+        validateNoMutatingIntent(deps.service, ctx.body);
+        return deps.service.captureSnapshot(ctx.body as FridayGuideLensSnapshotRequest);
+      },
+    },
+    {
+      operationId: "guidelens.targets.resolve",
+      method: "POST",
+      path: "/v1/guide-lens/targets/resolve",
+      auth: { public: false, anyOfScopes: ["desktop.read"] },
+      async handler(ctx) {
+        requireString(ctx.body, "instruction");
+        validateNoMutatingIntent(deps.service, ctx.body);
+        return deps.service.resolveTarget(ctx.body as FridayGuideLensResolveTargetRequest);
+      },
+    },
+    {
+      operationId: "guidelens.overlay.show",
+      method: "POST",
+      path: "/v1/guide-lens/overlay",
+      auth: { public: false, anyOfScopes: ["desktop.read"] },
+      async handler(ctx) {
+        requireString(ctx.body, "message");
+        validateNoMutatingIntent(deps.service, ctx.body);
+        return deps.service.showOverlay(ctx.body as FridayGuideLensShowOverlayRequest);
+      },
+    },
+    {
+      operationId: "guidelens.overlay.clear",
+      method: "DELETE",
+      path: "/v1/guide-lens/overlay",
+      auth: { public: false, anyOfScopes: ["desktop.read"] },
+      async handler(ctx) {
+        const query = ctx.query as { sessionId?: string };
+        return deps.service.clearOverlay(query.sessionId);
+      },
+    },
+    {
+      operationId: "guidelens.screenshots.analyze",
+      method: "POST",
+      path: "/v1/guide-lens/screenshots/analyze",
+      auth: { public: false, anyOfScopes: ["desktop.read"] },
+      async handler(ctx) {
+        validateNoMutatingIntent(deps.service, ctx.body);
+        return deps.service.analyzeScreenshot(ctx.body as FridayGuideLensScreenshotIntakeRequest);
+      },
+    },
+    {
+      operationId: "guidelens.verifications.create",
+      method: "POST",
+      path: "/v1/guide-lens/verifications",
+      auth: { public: false, anyOfScopes: ["desktop.read"] },
+      async handler(ctx) {
+        validateNoMutatingIntent(deps.service, ctx.body);
+        return deps.service.verify(ctx.body as FridayGuideLensVerificationRequest);
+      },
+    },
+    {
+      operationId: "guidelens.preferences.update",
+      method: "PATCH",
+      path: "/v1/guide-lens/preferences",
+      auth: { public: false, anyOfScopes: ["desktop.write"], anyOfRoles: ["admin", "operator"] },
+      async handler(ctx) {
+        const patch = requireBodyObject(ctx.body) as Partial<FridayGuideLensPreferences>;
+        return deps.service.updatePreferences(patch);
+      },
+    },
+    {
+      operationId: "guidelens.avatar.update",
+      method: "POST",
+      path: "/v1/guide-lens/avatar",
+      auth: { public: false, anyOfScopes: ["desktop.write"], anyOfRoles: ["admin", "operator"] },
+      async handler(ctx) {
+        const avatar = requireBodyObject(ctx.body) as Partial<FridayGuideLensAvatarPreference>;
+        return deps.service.updateAvatar(avatar);
+      },
+    },
+  ];
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -18,6 +18,7 @@ export type * from "./model/friday-api-memory.types.js";
 export type * from "./model/friday-api-session.types.js";
 export type * from "./model/friday-api-plugin.types.js";
 export type * from "./model/friday-api-system.types.js";
+export type * from "./model/friday-api-guide-lens.types.js";
 export type * from "./model/friday-api-self-healing.types.js";
 export type * from "./model/friday-api-uix-surface.types.js";
 export type * from "./model/friday-api-cross-border-pack.types.js";
@@ -203,6 +204,8 @@ export type { FridayGrantRoutesDeps } from "./http/routes/friday-grant-routes.js
 // System routes (C-012)
 export { createFridaySystemRoutes } from "./http/routes/friday-system-routes.js";
 export type { FridaySystemRoutesDeps } from "./http/routes/friday-system-routes.js";
+export { createFridayGuideLensRoutes } from "./http/routes/friday-guide-lens-routes.js";
+export type { FridayGuideLensRoutesDeps } from "./http/routes/friday-guide-lens-routes.js";
 export { createFridayUixRoutes } from "./http/routes/friday-uix-routes.js";
 export type { FridayUixRoutesDeps } from "./http/routes/friday-uix-routes.js";
 export { createFridayCrossBorderPackRoutes } from "./http/routes/friday-cross-border-pack-routes.js";

--- a/src/api/model/friday-api-guide-lens.types.ts
+++ b/src/api/model/friday-api-guide-lens.types.ts
@@ -1,0 +1,17 @@
+export type {
+  FridayGuideLensAvatarPreference,
+  FridayGuideLensBounds,
+  FridayGuideLensElement,
+  FridayGuideLensOverlayCommand,
+  FridayGuideLensPreferences,
+  FridayGuideLensScreenshotIntakeRequest,
+  FridayGuideLensScreenshotIntakeResult,
+  FridayGuideLensSession,
+  FridayGuideLensShowOverlayRequest,
+  FridayGuideLensSnapshotRequest,
+  FridayGuideLensState,
+  FridayGuideLensTargetResolution,
+  FridayGuideLensUiMap,
+  FridayGuideLensVerificationRequest,
+  FridayGuideLensVerificationResult,
+} from "../../guide-lens/model/friday-guide-lens.types.js";

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -89,6 +89,7 @@ import { createFridayChannelRoutes } from "../http/routes/friday-channel-routes.
 import { createFridayDeepLinkRoutes } from "../http/routes/friday-deeplink-routes.js";
 import { createFridayGrantRoutes } from "../http/routes/friday-grant-routes.js";
 import { createFridaySystemRoutes } from "../http/routes/friday-system-routes.js";
+import { createFridayGuideLensRoutes } from "../http/routes/friday-guide-lens-routes.js";
 import { createFridayUixRoutes } from "../http/routes/friday-uix-routes.js";
 import { createFridayCrossBorderPackRoutes } from "../http/routes/friday-cross-border-pack-routes.js";
 import { createFridayDiscoveryDisabledRoutes, createFridayDiscoveryRoutes } from "../http/routes/friday-discovery-routes.js";
@@ -2021,6 +2022,13 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
     }
   }
 
+  // Register read-only Guide Mode routes (optional)
+  if (deps.guideLens) {
+    for (const route of createFridayGuideLensRoutes(deps.guideLens)) {
+      routes.register(route);
+    }
+  }
+
   // Register local discovery routes (optional)
   for (const route of deps.discovery
     ? createFridayDiscoveryRoutes(deps.discovery)
@@ -2912,5 +2920,6 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
     agentLoop: deps.agentLoop,
     uix: deps.uix,
     system: deps.system,
+    guideLens: deps.guideLens,
   };
 }

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -35,9 +35,7 @@ import { createFridayAuthService } from "../auth/friday-auth-service.js";
 import { createFridayTokenValidator } from "../auth/friday-token-validator.js";
 import { createFridayRateLimitService } from "../auth/friday-rate-limit-service.js";
 import { createFridayAuthMiddlewareFactory } from "../auth/friday-auth-middleware.js";
-import { getScopesForRole } from "../auth/friday-rbac-policy.js";
 import { createFridayAuthSessionRepository } from "../persistence/friday-auth-session-repository.js";
-import { createFridayUserRepository } from "../persistence/friday-user-repository.js";
 import { createFridayRealtimeEventBus } from "../realtime/friday-realtime-event-bus.js";
 import { createFridayRealtimeEventRepository } from "../persistence/friday-realtime-event-repository.js";
 import { createFridayRealtimeCheckpointRepository } from "../persistence/friday-realtime-checkpoint-repository.js";
@@ -47,7 +45,6 @@ import { createFridayFleetDashboardService } from "../fleet/friday-fleet-dashboa
 import { createFridayWorkflowConflictService } from "../conflicts/friday-workflow-conflict-service.js";
 import { createFridayHttpRouteRegistry } from "../http/friday-http-route-registry.js";
 import { createFridayHttpRawTextResponse } from "../http/friday-http-raw-response.js";
-import { isFridayLoopbackAddress } from "../http/friday-http-client-ip.js";
 import { createFridayAuthRoutes } from "../http/routes/friday-auth-routes.js";
 import { createFridayRuntimeAdminRoutes } from "../http/routes/friday-runtime-admin-routes.js";
 import { createFridayAutonomyRoutes } from "../http/routes/friday-autonomy-routes.js";
@@ -154,7 +151,7 @@ import {
   createFridayCapabilityAcquisitionService,
   createFridayStandingAgendaService,
 } from "../../autonomy/index.js";
-import type { FridayAuthPrincipal, FridayHttpContext } from "../model/friday-api-common.types.js";
+import type { FridayAuthPrincipal } from "../model/friday-api-common.types.js";
 import type { FridayRole } from "../model/friday-api-auth.types.js";
 import type {
   FridayGetRunEvidenceQuery,
@@ -272,20 +269,6 @@ function resolvePrincipalTenantId(principal: FridayAuthPrincipal | null): string
   return principal.principalId;
 }
 
-function isFridayRole(value: string): value is FridayRole {
-  return value === "owner" || value === "admin" || value === "operator" || value === "viewer";
-}
-
-function isLocalBypassHttpContext(
-  ctx: FridayHttpContext<unknown, unknown, unknown>,
-): boolean {
-  if (ctx.socketIp) {
-    return isFridayLoopbackAddress(ctx.socketIp)
-      && (!ctx.ip || isFridayLoopbackAddress(ctx.ip));
-  }
-  return isFridayLoopbackAddress(ctx.ip);
-}
-
 function createWorkflowWebhookSecretResolver(
   db: FridaySqliteLayer,
 ): (refKey: string) => string | null {
@@ -391,7 +374,6 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
   // Auth
   const tokenRepo = createFridayApiTokenRepository();
   const sessionRepo = createFridayAuthSessionRepository();
-  const userRepo = createFridayUserRepository();
 
   // ─── In-memory access token revocation map (SEC-005) ───
   // Load persisted revocations from DB on startup
@@ -517,34 +499,6 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
   const middleware = createFridayAuthMiddlewareFactory({
     tokenValidator,
     rateLimitService: rateLimiter,
-    resolveLocalBypassPrincipal: (ctx) => {
-      if (!(deps.allowLocalBypassLogin ?? false) || !isLocalBypassHttpContext(ctx)) {
-        return null;
-      }
-      const localUser = deps.db.withReadConnection((db) => userRepo.findLocalUser(db));
-      if (!localUser) {
-        return null;
-      }
-      const role = isFridayRole(localUser.role) ? localUser.role : "admin";
-      const tenantId = asString(deps.resolveAuthTenantId?.({
-        principalType: "user",
-        principalId: localUser.id,
-        userId: localUser.id,
-        role,
-      })) ?? localUser.id;
-
-      return {
-        principalType: "user",
-        principalId: localUser.id,
-        tenantId,
-        userId: localUser.id,
-        role,
-        scopes: [...getScopesForRole(role)],
-        tokenId: "00000000-0000-0000-0000-000000000000",
-        tokenKind: "access",
-        issuedAt: deps.nowIso(),
-      };
-    },
   });
 
   // Realtime

--- a/src/api/runtime/friday-api-runtime.types.ts
+++ b/src/api/runtime/friday-api-runtime.types.ts
@@ -56,6 +56,7 @@ import type { FridayDiagnosisRoutesDeps } from "../http/routes/friday-diagnosis-
 import type { FridayAutoFixRoutesDeps } from "../http/routes/friday-auto-fix-routes.js";
 import type { FridayAgentLoopRoutesDeps } from "../http/routes/friday-agent-loop-routes.js";
 import type { FridaySystemRoutesDeps } from "../http/routes/friday-system-routes.js";
+import type { FridayGuideLensRoutesDeps } from "../http/routes/friday-guide-lens-routes.js";
 import type { FridayUixRoutesDeps } from "../http/routes/friday-uix-routes.js";
 import type { FridayCrossBorderPackRoutesDeps } from "../http/routes/friday-cross-border-pack-routes.js";
 import type { FridayPackagingRoutesDeps } from "../http/routes/friday-packaging-routes.js";
@@ -103,6 +104,7 @@ export interface FridayApiRuntime {
   uix?: FridayUixRoutesDeps;
   crossBorderPack?: FridayCrossBorderPackRoutesDeps;
   system?: FridaySystemRoutesDeps;
+  guideLens?: FridayGuideLensRoutesDeps;
   channels?: FridayChannelRoutesDeps;
 }
 
@@ -231,6 +233,8 @@ export interface CreateFridayApiRuntimeDeps {
   channels?: FridayChannelRoutesDeps;
   /** Optional: Agent OS system route surface. */
   system?: FridaySystemRoutesDeps;
+  /** Optional: read-only native guidance overlay route surface. */
+  guideLens?: FridayGuideLensRoutesDeps;
   /** Optional: beginner-friendly UIX route surface. */
   uix?: FridayUixRoutesDeps;
   /** Optional: cross-border operating pack route surface. */

--- a/src/guide-lens/engine/friday-guide-lens-service.ts
+++ b/src/guide-lens/engine/friday-guide-lens-service.ts
@@ -1,0 +1,501 @@
+import { FridayDomainError } from "#errors";
+import type { FridaySystemService } from "../../system/engine/friday-system-service.js";
+import type { FridaySystemCompanionBridge } from "../../system/companion/friday-system-companion.types.js";
+import {
+  FRIDAY_GUIDE_LENS_MUTATING_ACTIONS,
+  type FridayGuideLensAvatarPreference,
+  type FridayGuideLensElement,
+  type FridayGuideLensEvent,
+  type FridayGuideLensOverlayCommand,
+  type FridayGuideLensParserAdapter,
+  type FridayGuideLensParserResult,
+  type FridayGuideLensPreferences,
+  type FridayGuideLensScreenshotIntakeRequest,
+  type FridayGuideLensService,
+  type FridayGuideLensSession,
+  type FridayGuideLensShowOverlayRequest,
+  type FridayGuideLensSnapshotRequest,
+  type FridayGuideLensState,
+  type FridayGuideLensUiMap,
+  type FridayGuideLensVerificationRequest,
+} from "../model/friday-guide-lens.types.js";
+import { buildFridayGuideLensUiMap } from "./ui-map-builder.js";
+import { resolveFridayGuideLensTarget } from "./target-resolver.js";
+import { analyzeFridayGuideLensScreenshot } from "./screenshot-intake.js";
+import { verifyFridayGuideLensProgress } from "./verification.js";
+import { redactGuideLensText } from "./redaction.js";
+
+export interface CreateFridayGuideLensServiceDeps {
+  idGenerator: () => string;
+  nowIso: () => string;
+  systemService?: Pick<FridaySystemService, "getState">;
+  companionBridge?: Pick<
+    FridaySystemCompanionBridge,
+    "captureSnapshot" | "showGuideOverlay" | "clearGuideOverlay" | "setOverlayVisible"
+  >;
+  parserAdapter?: FridayGuideLensParserAdapter;
+  defaultPreferences?: Partial<FridayGuideLensPreferences>;
+}
+
+const DEFAULT_AVATAR: FridayGuideLensAvatarPreference = {
+  kind: "default_f",
+  initials: "F",
+  sizePx: 56,
+};
+
+const DEFAULT_PREFERENCES: FridayGuideLensPreferences = {
+  enabled: true,
+  triggerPolicy: "confirm_first",
+  defaultSurface: "native_desktop",
+  overlayStyle: "restrained_premium",
+  focusColor: "blue",
+  dimBackground: false,
+  clickThroughOverlay: true,
+  bubbleControlsEnabled: true,
+  sensitiveScreenConfirm: true,
+  localOnlyByDefault: true,
+  screenshotAutoAnalyze: "manual_upload_only",
+  chatboxPolicy: "ask_when_ambiguous",
+  parserProvider: "local_none",
+  avatar: DEFAULT_AVATAR,
+};
+
+function mergePreferences(
+  base: FridayGuideLensPreferences,
+  patch?: Partial<FridayGuideLensPreferences>,
+): FridayGuideLensPreferences {
+  if (!patch) return base;
+  return {
+    ...base,
+    ...patch,
+    dimBackground: false,
+    clickThroughOverlay: true,
+    focusColor: "blue",
+    overlayStyle: "restrained_premium",
+    avatar: {
+      ...base.avatar,
+      ...(patch.avatar ?? {}),
+      sizePx: Math.max(40, Math.min(96, patch.avatar?.sizePx ?? base.avatar.sizePx)),
+    },
+  };
+}
+
+function assertSupportedPreferences(prefs: FridayGuideLensPreferences): void {
+  if (prefs.dimBackground !== false) {
+    throw new FridayDomainError("GUIDE_LENS_INVALID_PREFERENCES", "Guide Lens does not support dimming the whole screen", {
+      httpStatus: 400,
+    });
+  }
+  if (prefs.clickThroughOverlay !== true) {
+    throw new FridayDomainError("GUIDE_LENS_INVALID_PREFERENCES", "Guide Lens overlay must remain click-through", {
+      httpStatus: 400,
+    });
+  }
+}
+
+function hasMutatingAction(action: string): boolean {
+  const normalized = action.trim().toLowerCase();
+  return FRIDAY_GUIDE_LENS_MUTATING_ACTIONS.some((mutating) =>
+    normalized === mutating || normalized.includes(mutating),
+  );
+}
+
+function trimSessions(sessions: FridayGuideLensSession[]): FridayGuideLensSession[] {
+  return sessions.slice(-20);
+}
+
+function redactOptionalText(
+  text: string | undefined,
+  source: "visible_text" | "screenshot_text" | "element_text",
+): string | undefined {
+  return text ? redactGuideLensText(text, source).text : text;
+}
+
+function sanitizeElementForParser(element: FridayGuideLensElement): FridayGuideLensElement {
+  return {
+    ...element,
+    label: redactOptionalText(element.label, "element_text"),
+    text: redactOptionalText(element.text, "element_text"),
+    description: redactOptionalText(element.description, "element_text"),
+    metadata: undefined,
+  };
+}
+
+function sanitizeSnapshotForParser(req: FridayGuideLensSnapshotRequest): FridayGuideLensSnapshotRequest {
+  return {
+    sessionId: req.sessionId,
+    surface: req.surface,
+    objective: req.objective,
+    visibleText: redactOptionalText(req.visibleText, "visible_text"),
+    screenshotText: redactOptionalText(req.screenshotText, "screenshot_text"),
+    screen: req.screen,
+    elements: req.elements?.map(sanitizeElementForParser),
+    parser: req.parser,
+  };
+}
+
+function joinTextParts(...parts: Array<string | undefined>): string | undefined {
+  const joined = parts
+    .map((part) => part?.trim())
+    .filter((part): part is string => Boolean(part))
+    .join("\n");
+  return joined.length > 0 ? joined : undefined;
+}
+
+export function createFridayGuideLensService(
+  deps: CreateFridayGuideLensServiceDeps,
+): FridayGuideLensService {
+  let preferences = mergePreferences(DEFAULT_PREFERENCES, deps.defaultPreferences);
+  assertSupportedPreferences(preferences);
+  let activeSessionId: string | undefined;
+  let sessions: FridayGuideLensSession[] = [];
+
+  function emit(
+    session: FridayGuideLensSession,
+    event: FridayGuideLensEvent["event"],
+    payload: Record<string, unknown>,
+  ): void {
+    session.events.push({
+      id: deps.idGenerator(),
+      sessionId: session.id,
+      event,
+      emittedAt: deps.nowIso(),
+      payload,
+    });
+    session.updatedAt = deps.nowIso();
+  }
+
+  function createSession(input?: {
+    sessionId?: string;
+    surface?: FridayGuideLensSession["surface"];
+    objective?: string;
+  }): FridayGuideLensSession {
+    const now = deps.nowIso();
+    const session: FridayGuideLensSession = {
+      id: input?.sessionId ?? deps.idGenerator(),
+      status: "idle",
+      surface: input?.surface ?? preferences.defaultSurface,
+      objective: input?.objective,
+      createdAt: now,
+      updatedAt: now,
+      events: [],
+    };
+    sessions = trimSessions([...sessions, session]);
+    activeSessionId = session.id;
+    emit(session, "guide_lens.session.started", {
+      surface: session.surface,
+      objective: session.objective,
+    });
+    return session;
+  }
+
+  function getSession(sessionId?: string, input?: {
+    surface?: FridayGuideLensSession["surface"];
+    objective?: string;
+  }): FridayGuideLensSession {
+    const id = sessionId ?? activeSessionId;
+    const existing = id ? sessions.find((session) => session.id === id) : undefined;
+    if (existing) {
+      activeSessionId = existing.id;
+      return existing;
+    }
+    return createSession({ sessionId, ...input });
+  }
+
+  function getActiveSession(): FridayGuideLensSession | undefined {
+    return activeSessionId ? sessions.find((session) => session.id === activeSessionId) : undefined;
+  }
+
+  async function showNativeOverlay(command: FridayGuideLensOverlayCommand): Promise<void> {
+    if (!deps.companionBridge) {
+      return;
+    }
+    if (typeof deps.companionBridge.showGuideOverlay === "function") {
+      await deps.companionBridge.showGuideOverlay(command);
+      return;
+    }
+    await deps.companionBridge.setOverlayVisible(true);
+  }
+
+  async function clearNativeOverlay(): Promise<void> {
+    if (!deps.companionBridge) {
+      return;
+    }
+    if (typeof deps.companionBridge.clearGuideOverlay === "function") {
+      await deps.companionBridge.clearGuideOverlay();
+      return;
+    }
+    await deps.companionBridge.setOverlayVisible(false);
+  }
+
+  async function runOptionalParser(
+    request: FridayGuideLensSnapshotRequest,
+  ): Promise<{ request: FridayGuideLensSnapshotRequest; result?: FridayGuideLensParserResult }> {
+    if (request.parser?.used) {
+      return { request };
+    }
+    const provider = preferences.parserProvider;
+    if (provider === "local_none") {
+      return { request };
+    }
+    if (!deps.parserAdapter) {
+      return {
+        request: {
+          ...request,
+          parser: {
+            ...request.parser,
+            provider,
+            used: false,
+            fallbackReason: "No Guide Lens parser adapter is configured.",
+          },
+        },
+      };
+    }
+    try {
+      const result = await deps.parserAdapter.parse({
+        provider,
+        snapshot: sanitizeSnapshotForParser(request),
+      });
+      return {
+        result,
+        request: {
+          ...request,
+          visibleText: joinTextParts(request.visibleText, result.visibleText),
+          screenshotText: joinTextParts(request.screenshotText, result.screenshotText),
+          elements: [...(request.elements ?? []), ...(result.elements ?? [])],
+          parser: {
+            ...request.parser,
+            provider: result.provider ?? provider,
+            used: result.used !== false,
+            latencyMs: result.latencyMs,
+            fallbackReason: result.fallbackReason,
+          },
+        },
+      };
+    } catch (error) {
+      return {
+        request: {
+          ...request,
+          parser: {
+            ...request.parser,
+            provider,
+            used: false,
+            fallbackReason: error instanceof Error ? error.message : String(error),
+          },
+        },
+      };
+    }
+  }
+
+  return {
+    getState(): FridayGuideLensState {
+      return {
+        preferences,
+        activeSession: getActiveSession(),
+        sessions: [...sessions],
+      };
+    },
+
+    updatePreferences(patch) {
+      const next = mergePreferences(preferences, patch);
+      assertSupportedPreferences(next);
+      preferences = next;
+      return preferences;
+    },
+
+    updateAvatar(avatar) {
+      preferences = mergePreferences(preferences, {
+        avatar: {
+          ...preferences.avatar,
+          ...avatar,
+          sizePx: avatar.sizePx ?? preferences.avatar.sizePx,
+        },
+      });
+      return preferences.avatar;
+    },
+
+    async captureSnapshot(req?: FridayGuideLensSnapshotRequest) {
+      const session = getSession(req?.sessionId, {
+        surface: req?.surface,
+        objective: req?.objective,
+      });
+      session.status = "looking";
+
+      const companionSnapshot = !req?.systemSnapshot && deps.companionBridge
+        ? await deps.companionBridge.captureSnapshot().catch(() => undefined)
+        : undefined;
+      const systemSnapshot = req?.systemSnapshot
+        ?? (deps.systemService ? await deps.systemService.getState().catch(() => undefined) : undefined);
+      const request: FridayGuideLensSnapshotRequest = {
+        ...req,
+        systemSnapshot,
+        visibleText: [
+          req?.visibleText,
+          companionSnapshot?.windows.map((window) => window.title).join("\n"),
+        ].filter((part): part is string => typeof part === "string" && part.trim().length > 0).join("\n"),
+      };
+      const parsed = await runOptionalParser(request);
+      const uiMap: FridayGuideLensUiMap = buildFridayGuideLensUiMap({
+        id: deps.idGenerator(),
+        nowIso: deps.nowIso(),
+        preferences,
+        request: parsed.request,
+      });
+      session.uiMap = uiMap;
+      session.surface = uiMap.surface;
+      session.objective = req?.objective ?? session.objective;
+      session.status = "guiding";
+      emit(session, "guide_lens.snapshot.captured", {
+        uiMapId: uiMap.id,
+        surface: uiMap.surface,
+        elementCount: uiMap.elements.length,
+        tokenEstimate: uiMap.parserStats.tokenEstimate,
+      });
+      return { session, uiMap };
+    },
+
+    async resolveTarget(req) {
+      this.assertReadOnlyAction(req.instruction);
+      const session = getSession(req.sessionId);
+      const uiMap = req.uiMap ?? session.uiMap ?? (await this.captureSnapshot({
+        sessionId: session.id,
+        objective: req.instruction,
+      })).uiMap;
+      const resolution = resolveFridayGuideLensTarget({
+        idGenerator: deps.idGenerator,
+        nowIso: deps.nowIso,
+        sessionId: session.id,
+        preferences,
+        uiMap,
+        request: req,
+      });
+      session.status = resolution.status === "not_found" ? "blocked" : "waiting_for_user";
+      session.overlay = resolution.overlay;
+      session.awaitingUser = resolution.requiredUserAction;
+      emit(session, "guide_lens.target.resolved", {
+        status: resolution.status,
+        confidence: resolution.confidence,
+        targetElementId: resolution.target?.id,
+        alternatives: resolution.alternatives.length,
+      });
+      await showNativeOverlay(resolution.overlay);
+      emit(session, "guide_lens.overlay.shown", {
+        overlayId: resolution.overlay.id,
+        mode: resolution.overlay.mode,
+      });
+      return resolution;
+    },
+
+    async showOverlay(req: FridayGuideLensShowOverlayRequest) {
+      this.assertReadOnlyAction(req.message);
+      const session = getSession(req.sessionId, {
+        surface: req.surface,
+      });
+      const now = deps.nowIso();
+      const command: FridayGuideLensOverlayCommand = {
+        id: deps.idGenerator(),
+        sessionId: session.id,
+        mode: req.mode ?? "speech_bubble",
+        surface: req.surface ?? session.surface,
+        message: req.message,
+        targetElementId: req.targetElementId,
+        targetBounds: req.targetBounds,
+        candidates: req.candidates,
+        step: req.step,
+        avatar: preferences.avatar,
+        tone: req.tone ?? "calm",
+        focusColor: "blue",
+        dimBackground: false,
+        clickThrough: true,
+        bubbleControlsEnabled: preferences.bubbleControlsEnabled,
+        createdAt: now,
+        expiresAt: req.expiresInMs ? new Date(new Date(now).getTime() + req.expiresInMs).toISOString() : undefined,
+      };
+      session.status = command.mode === "blocked" ? "blocked" : "waiting_for_user";
+      session.overlay = command;
+      await showNativeOverlay(command);
+      emit(session, "guide_lens.overlay.shown", {
+        overlayId: command.id,
+        mode: command.mode,
+      });
+      return command;
+    },
+
+    async clearOverlay(sessionId?: string) {
+      const session = getSession(sessionId);
+      session.overlay = undefined;
+      session.awaitingUser = undefined;
+      session.status = "idle";
+      await clearNativeOverlay();
+      const clearedAt = deps.nowIso();
+      emit(session, "guide_lens.overlay.cleared", { clearedAt });
+      return {
+        cleared: true,
+        sessionId: session.id,
+        clearedAt,
+      };
+    },
+
+    async analyzeScreenshot(req: FridayGuideLensScreenshotIntakeRequest) {
+      const session = getSession(req.sessionId, {
+        surface: "screenshot",
+        objective: req.question,
+      });
+      const result = analyzeFridayGuideLensScreenshot({
+        ...req,
+        sessionId: session.id,
+      });
+      session.status = result.needsChatbox ? "blocked" : "guiding";
+      emit(session, "guide_lens.screenshot.analyzed", {
+        intent: result.intent,
+        needsChatbox: result.needsChatbox,
+        confidence: result.confidence,
+        redactions: result.redactions.length,
+      });
+      if (result.needsChatbox) {
+        await this.showOverlay({
+          sessionId: session.id,
+          mode: "speech_bubble",
+          message: result.chatboxPrompt ?? "请补充你想完成哪一步。",
+          tone: "blocked",
+          surface: "screenshot",
+        });
+      }
+      return result;
+    },
+
+    async verify(req: FridayGuideLensVerificationRequest) {
+      const session = getSession(req.sessionId);
+      const uiMap = req.uiMap ?? session.uiMap ?? (await this.captureSnapshot({
+        sessionId: session.id,
+      })).uiMap;
+      session.status = "checking";
+      const result = verifyFridayGuideLensProgress({
+        nowIso: deps.nowIso,
+        uiMap,
+        request: req,
+      });
+      session.lastVerification = result;
+      session.status = result.status === "passed"
+        ? "completed"
+        : result.status === "failed"
+          ? "waiting_for_user"
+          : "blocked";
+      emit(session, "guide_lens.verification.completed", {
+        status: result.status,
+        confidence: result.confidence,
+      });
+      return result;
+    },
+
+    assertReadOnlyAction(action: string): void {
+      if (hasMutatingAction(action)) {
+        throw new FridayDomainError(
+          "GUIDE_LENS_READ_ONLY_VIOLATION",
+          "Guide Lens can only observe and guide. Real clicks, typing, scrolling, app launches, approvals, and writes must be performed by the user or another explicitly authorized mode.",
+          { httpStatus: 403, details: { action } },
+        );
+      }
+    },
+  };
+}

--- a/src/guide-lens/engine/parser-adapter.ts
+++ b/src/guide-lens/engine/parser-adapter.ts
@@ -1,0 +1,179 @@
+import { FridayDomainError } from "#errors";
+import type {
+  FridayGuideLensBounds,
+  FridayGuideLensElement,
+  FridayGuideLensParserAdapter,
+  FridayGuideLensParserRequest,
+  FridayGuideLensParserResult,
+  FridayGuideLensPreferences,
+} from "../model/friday-guide-lens.types.js";
+
+export interface CreateFridayGuideLensHttpParserAdapterOptions {
+  endpointUrl: string;
+  provider: Exclude<FridayGuideLensPreferences["parserProvider"], "local_none">;
+  timeoutMs?: number;
+}
+
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+
+function assertLoopbackEndpoint(rawUrl: string): URL {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new FridayDomainError("GUIDE_LENS_PARSER_INVALID_ENDPOINT", "Guide Lens parser endpoint must be a valid URL", {
+      httpStatus: 400,
+    });
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new FridayDomainError("GUIDE_LENS_PARSER_INVALID_ENDPOINT", "Guide Lens parser endpoint must use http or https", {
+      httpStatus: 400,
+    });
+  }
+  const hostname = parsed.hostname.toLowerCase().replace(/\.$/, "");
+  if (!LOOPBACK_HOSTS.has(hostname)) {
+    throw new FridayDomainError(
+      "GUIDE_LENS_PARSER_INVALID_ENDPOINT",
+      "Guide Lens parser endpoint must be loopback-only",
+      { httpStatus: 400, details: { hostname } },
+    );
+  }
+  return parsed;
+}
+
+function readObject(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function readNumber(value: unknown): number | undefined {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : undefined;
+}
+
+function clampConfidence(value: unknown, fallback = 0.7): number {
+  const numeric = readNumber(value);
+  if (numeric === undefined) return fallback;
+  return Math.max(0, Math.min(1, numeric));
+}
+
+function boundsFromExternal(value: unknown): FridayGuideLensBounds | undefined {
+  const obj = readObject(value);
+  if (obj) {
+    const x = readNumber(obj.x ?? obj.left);
+    const y = readNumber(obj.y ?? obj.top);
+    const width = readNumber(obj.width ?? obj.w);
+    const height = readNumber(obj.height ?? obj.h);
+    if (x !== undefined && y !== undefined && width !== undefined && height !== undefined && width > 0 && height > 0) {
+      return { x, y, width, height };
+    }
+  }
+  if (Array.isArray(value) && value.length >= 4) {
+    const x1 = readNumber(value[0]);
+    const y1 = readNumber(value[1]);
+    const x2 = readNumber(value[2]);
+    const y2 = readNumber(value[3]);
+    if (x1 !== undefined && y1 !== undefined && x2 !== undefined && y2 !== undefined) {
+      const width = x2 > x1 ? x2 - x1 : x2;
+      const height = y2 > y1 ? y2 - y1 : y2;
+      if (width > 0 && height > 0) {
+        return { x: x1, y: y1, width, height };
+      }
+    }
+  }
+  return undefined;
+}
+
+function normalizeExternalElement(value: unknown, index: number): FridayGuideLensElement | undefined {
+  const obj = readObject(value);
+  if (!obj) return undefined;
+  const label = readString(obj.label ?? obj.name ?? obj.text ?? obj.content);
+  const text = readString(obj.text ?? obj.content ?? obj.label ?? obj.name);
+  const bounds = boundsFromExternal(obj.bounds ?? obj.rect ?? obj.bbox ?? obj.box);
+  return {
+    id: readString(obj.id) ?? `parser:${String(index + 1)}`,
+    role: readString(obj.role ?? obj.type ?? obj.tag) ?? "unknown",
+    ...(label ? { label } : {}),
+    ...(text ? { text } : {}),
+    ...(readString(obj.description) ? { description: readString(obj.description) } : {}),
+    ...(bounds ? { bounds } : {}),
+    source: "parser",
+    confidence: clampConfidence(obj.confidence ?? obj.score),
+    interactable: Boolean(obj.interactable ?? obj.clickable ?? obj.enabled ?? false),
+    enabled: typeof obj.enabled === "boolean" ? obj.enabled : undefined,
+    sensitive: Boolean(obj.sensitive ?? false),
+    metadata: {
+      parserIndex: index,
+      parserRole: obj.role ?? obj.type ?? obj.tag,
+    },
+  };
+}
+
+function readExternalElements(body: Record<string, unknown>): FridayGuideLensElement[] {
+  const raw = body.elements ?? body.ui_elements ?? body.items ?? body.nodes;
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((item, index) => normalizeExternalElement(item, index))
+    .filter((element): element is FridayGuideLensElement => Boolean(element))
+    .slice(0, 120);
+}
+
+function readParserBody(body: unknown, provider: FridayGuideLensParserRequest["provider"], latencyMs: number): FridayGuideLensParserResult {
+  const obj = readObject(body);
+  if (!obj) {
+    throw new FridayDomainError("GUIDE_LENS_PARSER_INVALID_RESPONSE", "Guide Lens parser returned a non-object response", {
+      httpStatus: 502,
+    });
+  }
+  return {
+    provider: readString(obj.provider) as FridayGuideLensPreferences["parserProvider"] | undefined ?? provider,
+    used: obj.used === undefined ? true : Boolean(obj.used),
+    visibleText: readString(obj.visibleText ?? obj.visible_text ?? obj.text),
+    screenshotText: readString(obj.screenshotText ?? obj.screenshot_text ?? obj.ocrText ?? obj.ocr_text),
+    elements: readExternalElements(obj),
+    latencyMs: readNumber(obj.latencyMs ?? obj.latency_ms) ?? latencyMs,
+    fallbackReason: readString(obj.fallbackReason ?? obj.fallback_reason),
+    metadata: readObject(obj.metadata),
+  };
+}
+
+export function createFridayGuideLensHttpParserAdapter(
+  options: CreateFridayGuideLensHttpParserAdapterOptions,
+): FridayGuideLensParserAdapter {
+  const endpoint = assertLoopbackEndpoint(options.endpointUrl);
+  const timeoutMs = Math.max(500, Math.min(30_000, options.timeoutMs ?? 3_000));
+
+  return {
+    async parse(req: FridayGuideLensParserRequest): Promise<FridayGuideLensParserResult> {
+      const controller = new AbortController();
+      const startedAt = Date.now();
+      const timeout = setTimeout(() => controller.abort(), timeoutMs);
+      try {
+        const response = await fetch(endpoint, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            provider: req.provider,
+            snapshot: req.snapshot,
+          }),
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          throw new FridayDomainError(
+            "GUIDE_LENS_PARSER_FAILED",
+            `Guide Lens parser failed with HTTP ${String(response.status)}`,
+            { httpStatus: 502, details: { status: response.status } },
+          );
+        }
+        return readParserBody(await response.json(), options.provider, Date.now() - startedAt);
+      } finally {
+        clearTimeout(timeout);
+      }
+    },
+  };
+}

--- a/src/guide-lens/engine/redaction.ts
+++ b/src/guide-lens/engine/redaction.ts
@@ -1,0 +1,70 @@
+import type { FridayGuideLensRedaction } from "../model/friday-guide-lens.types.js";
+
+const SECRET_PATTERNS: Array<{
+  kind: FridayGuideLensRedaction["kind"];
+  pattern: RegExp;
+}> = [
+  {
+    kind: "api_key",
+    pattern: /\b(?:sk|pk|rk|ak)-[A-Za-z0-9_-]{16,}\b/g,
+  },
+  {
+    kind: "token",
+    pattern: /\b(?:ghp|gho|ghu|ghs|github_pat)_[A-Za-z0-9_]{20,}\b/g,
+  },
+  {
+    kind: "password",
+    pattern: /\b(password|passcode|secret)\s*[:=]\s*([^\s,;]+)/gi,
+  },
+  {
+    kind: "secret",
+    pattern: /\b(?:api[_ -]?key|access[_ -]?token|secret[_ -]?key)\s*[:=]\s*([^\s,;]+)/gi,
+  },
+];
+
+export interface FridayGuideLensRedactionResult {
+  text: string;
+  redactions: FridayGuideLensRedaction[];
+}
+
+export function redactGuideLensText(
+  text: string,
+  source: FridayGuideLensRedaction["source"],
+): FridayGuideLensRedactionResult {
+  let redacted = text;
+  const redactions: FridayGuideLensRedaction[] = [];
+
+  for (const { kind, pattern } of SECRET_PATTERNS) {
+    let count = 0;
+    redacted = redacted.replace(pattern, (match, prefix) => {
+      count += 1;
+      if (kind === "password" || kind === "secret") {
+        const label = typeof prefix === "string" && prefix.trim().length > 0
+          ? prefix
+          : kind;
+        return `${label}: [${kind}:redacted]`;
+      }
+      return `[${kind}:redacted]`;
+    });
+    if (count > 0) {
+      redactions.push({
+        kind,
+        replacement: `[${kind}:redacted]`,
+        source,
+        count,
+      });
+    }
+  }
+
+  return {
+    text: redacted,
+    redactions,
+  };
+}
+
+export function looksSensitiveGuideLensText(text: string): boolean {
+  return SECRET_PATTERNS.some(({ pattern }) => {
+    pattern.lastIndex = 0;
+    return pattern.test(text);
+  });
+}

--- a/src/guide-lens/engine/screenshot-intake.ts
+++ b/src/guide-lens/engine/screenshot-intake.ts
@@ -1,0 +1,119 @@
+import type {
+  FridayGuideLensOverlayMode,
+  FridayGuideLensScreenshotIntakeRequest,
+  FridayGuideLensScreenshotIntakeResult,
+} from "../model/friday-guide-lens.types.js";
+import { redactGuideLensText } from "./redaction.js";
+
+function classifyIntent(text: string, question: string | undefined): {
+  intent: FridayGuideLensScreenshotIntakeResult["intent"];
+  confidence: number;
+  mode: FridayGuideLensOverlayMode;
+  summary: string;
+} {
+  const combined = `${question ?? ""}\n${text}`.toLowerCase();
+  if (/(sk-|api key|access token|secret|password|passcode|验证码|密码|密钥)/i.test(combined)) {
+    return {
+      intent: "sensitive",
+      confidence: 0.82,
+      mode: "confirm_step",
+      summary: "截图里可能包含敏感字段，我会先遮挡内容，再只引导你该看哪里。",
+    };
+  }
+  if (/(accessibility|screen recording|privacy|security|permission|权限|辅助功能|屏幕录制)/i.test(combined)) {
+    return {
+      intent: "permission",
+      confidence: 0.78,
+      mode: "focus_frame",
+      summary: "这看起来是权限或系统设置页面，需要你本人确认授权。",
+    };
+  }
+  if (/(error|failed|exception|denied|not found|无法|失败|报错|错误)/i.test(combined)) {
+    return {
+      intent: "error",
+      confidence: 0.76,
+      mode: "speech_bubble",
+      summary: "截图显示有错误或失败状态，我会先定位错误文案，再引导下一步。",
+    };
+  }
+  if (/(sign in|login|log in|oauth|authorize|email|password|登录|授权|邮箱)/i.test(combined)) {
+    return {
+      intent: "form",
+      confidence: 0.72,
+      mode: "focus_frame",
+      summary: "这像是表单、登录或授权流程，真实输入和确认都需要你来完成。",
+    };
+  }
+  if (/(scroll|below|next page|new tab|new window|continue|往下|下滑|新网页|新页面|下一页)/i.test(combined)) {
+    return {
+      intent: "navigation",
+      confidence: 0.7,
+      mode: "scroll_hint",
+      summary: "这一步可能需要打开新页面或滚动；我会持续重新观察并提示你方向。",
+    };
+  }
+  if (/(setup|install|configure|connect|设置|安装|配置|连接)/i.test(combined)) {
+    return {
+      intent: "setup",
+      confidence: 0.66,
+      mode: "speech_bubble",
+      summary: "截图像是在设置或连接流程中，我会按步骤引导你完成。",
+    };
+  }
+  if ((question?.trim().length ?? 0) > 0 || /[?？]/.test(combined)) {
+    return {
+      intent: "question",
+      confidence: 0.62,
+      mode: "speech_bubble",
+      summary: "用户在围绕截图提问，我会先回答可确定的部分。",
+    };
+  }
+  return {
+    intent: "unknown",
+    confidence: 0.38,
+    mode: "speech_bubble",
+    summary: "截图意图还不够明确，需要一句补充说明才能给出准确引导。",
+  };
+}
+
+function shouldAskChatbox(input: {
+  intent: FridayGuideLensScreenshotIntakeResult["intent"];
+  confidence: number;
+  text: string;
+  question?: string;
+}): boolean {
+  if (input.question?.trim()) return false;
+  if (input.intent === "unknown") return true;
+  if (input.confidence < 0.55) return true;
+  return input.text.trim().length < 12;
+}
+
+export function analyzeFridayGuideLensScreenshot(
+  input: FridayGuideLensScreenshotIntakeRequest & { sessionId: string },
+): FridayGuideLensScreenshotIntakeResult {
+  const rawText = [input.visibleText, input.screenshotText]
+    .filter((part): part is string => typeof part === "string" && part.trim().length > 0)
+    .join("\n");
+  const redacted = redactGuideLensText(rawText, "screenshot_text");
+  const classified = classifyIntent(redacted.text, input.question);
+  const needsChatbox = shouldAskChatbox({
+    intent: classified.intent,
+    confidence: classified.confidence,
+    text: redacted.text,
+    question: input.question,
+  });
+
+  return {
+    sessionId: input.sessionId,
+    intent: classified.intent,
+    summary: classified.summary,
+    needsChatbox,
+    chatboxPrompt: needsChatbox
+      ? "我看到了截图，但还不确定你的目标。你想让我引导你完成哪一步？"
+      : undefined,
+    suggestedGuideMode: classified.mode,
+    redactedText: redacted.text,
+    redactions: redacted.redactions,
+    confidence: classified.confidence,
+  };
+}

--- a/src/guide-lens/engine/target-resolver.ts
+++ b/src/guide-lens/engine/target-resolver.ts
@@ -1,0 +1,253 @@
+import type {
+  FridayGuideLensElement,
+  FridayGuideLensOverlayCommand,
+  FridayGuideLensPreferences,
+  FridayGuideLensResolveTargetRequest,
+  FridayGuideLensTargetResolution,
+  FridayGuideLensUiMap,
+} from "../model/friday-guide-lens.types.js";
+
+const ROLE_BONUS: Record<string, number> = {
+  button: 0.18,
+  link: 0.16,
+  field: 0.12,
+  checkbox: 0.12,
+  menuitem: 0.1,
+  tab: 0.1,
+  window: 0.03,
+};
+
+const STOP_WORDS = new Set([
+  "the",
+  "a",
+  "an",
+  "to",
+  "on",
+  "in",
+  "at",
+  "of",
+  "for",
+  "and",
+  "or",
+  "this",
+  "that",
+  "button",
+  "click",
+  "tap",
+  "press",
+  "open",
+  "选择",
+  "点击",
+  "按钮",
+  "打开",
+  "这个",
+  "那个",
+  "下一步",
+]);
+
+function normalize(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
+    .trim();
+}
+
+function tokens(value: string): string[] {
+  return normalize(value)
+    .split(/\s+/)
+    .filter((token) => token.length > 0 && !STOP_WORDS.has(token));
+}
+
+function elementText(element: FridayGuideLensElement): string {
+  return [element.label, element.text, element.description, element.role]
+    .filter((part): part is string => typeof part === "string" && part.trim().length > 0)
+    .join(" ");
+}
+
+function scoreElement(instruction: string, element: FridayGuideLensElement): number {
+  const normalizedInstruction = normalize(instruction);
+  const normalizedText = normalize(elementText(element));
+  if (!normalizedText) {
+    return 0;
+  }
+
+  let score = 0;
+  if (normalizedText === normalizedInstruction) {
+    score += 0.58;
+  } else if (normalizedText.includes(normalizedInstruction) || normalizedInstruction.includes(normalizedText)) {
+    score += 0.38;
+  }
+
+  const instructionTokens = tokens(instruction);
+  const elementTokens = new Set(tokens(normalizedText));
+  const hits = instructionTokens.filter((token) => elementTokens.has(token)).length;
+  if (instructionTokens.length > 0) {
+    score += hits / instructionTokens.length * 0.32;
+  }
+
+  score += ROLE_BONUS[element.role.toLowerCase()] ?? 0;
+  if (element.interactable) score += 0.08;
+  if (element.focused) score += 0.04;
+  if (element.enabled === false) score -= 0.18;
+  if (element.sensitive) score -= 0.06;
+  score += element.confidence * 0.18;
+
+  return Math.max(0, Math.min(1, score));
+}
+
+function buildOverlay(input: {
+  id: string;
+  sessionId: string;
+  uiMap: FridayGuideLensUiMap;
+  preferences: FridayGuideLensPreferences;
+  instruction: string;
+  mode: FridayGuideLensOverlayCommand["mode"];
+  message: string;
+  target?: FridayGuideLensElement;
+  alternatives: FridayGuideLensElement[];
+  createdAt: string;
+}): FridayGuideLensOverlayCommand {
+  return {
+    id: input.id,
+    sessionId: input.sessionId,
+    mode: input.mode,
+    surface: input.uiMap.surface,
+    message: input.message,
+    targetElementId: input.target?.id,
+    targetBounds: input.target?.bounds,
+    candidates: input.alternatives.slice(0, 5).map((element) => ({
+      elementId: element.id,
+      label: element.label ?? element.text ?? element.role,
+      bounds: element.bounds,
+      confidence: element.confidence,
+    })),
+    avatar: input.preferences.avatar,
+    tone: input.mode === "blocked" ? "blocked" : "calm",
+    focusColor: "blue",
+    dimBackground: false,
+    clickThrough: true,
+    bubbleControlsEnabled: input.preferences.bubbleControlsEnabled,
+    createdAt: input.createdAt,
+    metadata: {
+      instruction: input.instruction,
+      tokenEstimate: input.uiMap.parserStats.tokenEstimate,
+    },
+  };
+}
+
+export function resolveFridayGuideLensTarget(input: {
+  idGenerator: () => string;
+  nowIso: () => string;
+  sessionId: string;
+  preferences: FridayGuideLensPreferences;
+  uiMap: FridayGuideLensUiMap;
+  request: FridayGuideLensResolveTargetRequest;
+}): FridayGuideLensTargetResolution {
+  const maxCandidates = input.request.maxCandidates ?? 5;
+  const ranked = input.uiMap.elements
+    .map((element) => ({
+      element,
+      score: scoreElement(input.request.instruction, element),
+    }))
+    .filter((entry) => entry.score > 0.08)
+    .sort((left, right) => right.score - left.score);
+  const alternatives = ranked
+    .slice(0, maxCandidates)
+    .map((entry) => ({
+      ...entry.element,
+      confidence: Math.max(entry.element.confidence, entry.score),
+    }));
+  const top = ranked[0];
+  const second = ranked[1];
+  const confidence = top?.score ?? 0;
+  const ambiguous = Boolean(top && second && Math.abs(top.score - second.score) < 0.08);
+
+  if (!top || confidence < 0.42) {
+    const overlay = buildOverlay({
+      id: input.idGenerator(),
+      sessionId: input.sessionId,
+      uiMap: input.uiMap,
+      preferences: input.preferences,
+      instruction: input.request.instruction,
+      mode: "blocked",
+      message: "我还没有足够把握定位到目标。请告诉我按钮或文字的名字，或发一张更完整的截图。",
+      alternatives,
+      createdAt: input.nowIso(),
+    });
+    return {
+      status: "not_found",
+      instruction: input.request.instruction,
+      alternatives,
+      confidence,
+      reason: "No visible element matched the instruction with enough confidence.",
+      overlay,
+      requiredUserAction: {
+        action: "clarify",
+        reason: "target_not_found",
+      },
+    };
+  }
+
+  if (ambiguous) {
+    const overlay = buildOverlay({
+      id: input.idGenerator(),
+      sessionId: input.sessionId,
+      uiMap: input.uiMap,
+      preferences: input.preferences,
+      instruction: input.request.instruction,
+      mode: "candidate_picker",
+      message: "我看到了几个可能的位置。请确认蓝色编号里你要操作的是哪一个。",
+      target: top.element,
+      alternatives,
+      createdAt: input.nowIso(),
+    });
+    return {
+      status: "ambiguous",
+      instruction: input.request.instruction,
+      target: top.element,
+      alternatives,
+      confidence,
+      reason: "Multiple visible elements are similarly likely.",
+      overlay,
+      requiredUserAction: {
+        action: "clarify",
+        reason: "ambiguous_target",
+        targetElementId: top.element.id,
+      },
+    };
+  }
+
+  const target = {
+    ...top.element,
+    confidence: Math.max(top.element.confidence, confidence),
+  };
+  const overlay = buildOverlay({
+    id: input.idGenerator(),
+    sessionId: input.sessionId,
+    uiMap: input.uiMap,
+    preferences: input.preferences,
+    instruction: input.request.instruction,
+    mode: target.bounds ? "focus_frame" : "speech_bubble",
+    message: target.bounds
+      ? "请点击蓝色框标出的这个位置。完成后我会再看一眼确认是否进入下一步。"
+      : "请在当前页面找到这个项目并操作；我没有拿到可靠坐标，所以先用文字引导。",
+    target,
+    alternatives,
+    createdAt: input.nowIso(),
+  });
+
+  return {
+    status: "resolved",
+    instruction: input.request.instruction,
+    target,
+    alternatives,
+    confidence,
+    reason: "A visible target matched the instruction.",
+    overlay,
+    requiredUserAction: {
+      action: target.role === "field" ? "type" : "click",
+      reason: "guide_mode_never_mutates_desktop",
+      targetElementId: target.id,
+    },
+  };
+}

--- a/src/guide-lens/engine/ui-map-builder.ts
+++ b/src/guide-lens/engine/ui-map-builder.ts
@@ -1,9 +1,9 @@
 import type {
   FridayGuideLensBounds,
   FridayGuideLensElement,
+  FridayGuideLensPreferences,
   FridayGuideLensSnapshotRequest,
   FridayGuideLensUiMap,
-  FridayGuideLensPreferences,
 } from "../model/friday-guide-lens.types.js";
 import { redactGuideLensText } from "./redaction.js";
 

--- a/src/guide-lens/engine/ui-map-builder.ts
+++ b/src/guide-lens/engine/ui-map-builder.ts
@@ -1,0 +1,213 @@
+import type {
+  FridayGuideLensBounds,
+  FridayGuideLensElement,
+  FridayGuideLensSnapshotRequest,
+  FridayGuideLensUiMap,
+  FridayGuideLensPreferences,
+} from "../model/friday-guide-lens.types.js";
+import { redactGuideLensText } from "./redaction.js";
+
+const DEFAULT_SCREEN = { width: 1440, height: 900 };
+
+function clampConfidence(value: number): number {
+  return Math.max(0, Math.min(1, Number.isFinite(value) ? value : 0));
+}
+
+function normalizeBounds(bounds: FridayGuideLensBounds | undefined): FridayGuideLensBounds | undefined {
+  if (!bounds) return undefined;
+  return {
+    x: Math.max(0, Math.round(bounds.x)),
+    y: Math.max(0, Math.round(bounds.y)),
+    width: Math.max(1, Math.round(bounds.width)),
+    height: Math.max(1, Math.round(bounds.height)),
+  };
+}
+
+function normalizeElement(
+  element: FridayGuideLensElement,
+  index: number,
+): FridayGuideLensElement {
+  const label = element.label?.trim();
+  const text = element.text?.trim();
+  return {
+    ...element,
+    id: element.id?.trim() || `manual:${String(index + 1)}`,
+    role: element.role?.trim() || "unknown",
+    ...(label ? { label } : {}),
+    ...(text ? { text } : {}),
+    bounds: normalizeBounds(element.bounds),
+    confidence: clampConfidence(element.confidence),
+    interactable: Boolean(element.interactable),
+    sensitive: Boolean(element.sensitive),
+  };
+}
+
+function lineRole(line: string): string {
+  const normalized = line.trim().toLowerCase();
+  if (/^(sign in|log in|continue|next|done|save|submit|allow|cancel|ok|open|connect|authorize)$/i.test(line.trim())) {
+    return "button";
+  }
+  if (/(email|password|api key|token|code)/i.test(line)) {
+    return "field";
+  }
+  if (/^https?:\/\//i.test(normalized)) {
+    return "link";
+  }
+  return "text";
+}
+
+function synthesizeTextElements(input: {
+  text: string;
+  source: "ocr" | "manual";
+  screen: { width: number; height: number };
+  existingCount: number;
+}): FridayGuideLensElement[] {
+  const lines = input.text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .slice(0, 80);
+  const width = Math.min(Math.max(260, input.screen.width * 0.34), 720);
+  const startX = Math.round(input.screen.width * 0.08);
+  const startY = Math.round(input.screen.height * 0.12);
+  const rowHeight = 32;
+  return lines.map((line, index) => {
+    const role = lineRole(line);
+    return {
+      id: `${input.source}:line:${String(input.existingCount + index + 1)}`,
+      role,
+      label: role === "button" || role === "field" || role === "link" ? line : undefined,
+      text: line,
+      bounds: {
+        x: startX,
+        y: startY + index * rowHeight,
+        width,
+        height: role === "text" ? 24 : 30,
+      },
+      source: input.source === "ocr" ? "ocr" : "manual",
+      confidence: input.source === "ocr" ? 0.62 : 0.7,
+      interactable: role === "button" || role === "field" || role === "link",
+      sensitive: /(password|api key|secret|token|verification code)/i.test(line),
+    } satisfies FridayGuideLensElement;
+  });
+}
+
+function elementsFromSystemSnapshot(req: FridayGuideLensSnapshotRequest): FridayGuideLensElement[] {
+  const snapshot = req.systemSnapshot;
+  if (!snapshot) return [];
+  const appsById = new Map(snapshot.apps.map((app) => [app.id, app]));
+  return snapshot.windows.map((window, index) => {
+    const app = appsById.get(window.appId);
+    return {
+      id: `system-window:${window.id}`,
+      role: "window",
+      label: window.title,
+      text: `${app?.name ?? "App"} ${window.title}`,
+      bounds: normalizeBounds(window.bounds),
+      source: "system_window",
+      confidence: window.focused ? 0.84 : 0.72,
+      interactable: false,
+      focused: window.focused,
+      appId: window.appId,
+      windowId: window.id,
+      metadata: {
+        appName: app?.name,
+        bundleId: app?.bundleId,
+        order: index,
+      },
+    } satisfies FridayGuideLensElement;
+  });
+}
+
+function estimateTokenCount(text: string, elementCount: number): number {
+  const textTokens = Math.ceil(text.length / 4);
+  return Math.max(1, textTokens + elementCount * 18);
+}
+
+export function buildFridayGuideLensUiMap(input: {
+  id: string;
+  nowIso: string;
+  preferences: FridayGuideLensPreferences;
+  request?: FridayGuideLensSnapshotRequest;
+}): FridayGuideLensUiMap {
+  const req = input.request ?? {};
+  const screen = req.screen ?? DEFAULT_SCREEN;
+  const visible = redactGuideLensText(req.visibleText ?? "", "visible_text");
+  const screenshot = redactGuideLensText(req.screenshotText ?? "", "screenshot_text");
+  const visibleText = [visible.text, screenshot.text]
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0)
+    .join("\n");
+
+  const providedElements = (req.elements ?? []).map((element, index) => {
+    const textParts = [element.label, element.text, element.description]
+      .filter((part): part is string => typeof part === "string" && part.trim().length > 0)
+      .join(" ");
+    const redacted = redactGuideLensText(textParts, "element_text");
+    const normalized = normalizeElement({
+      ...element,
+      label: element.label ? redactGuideLensText(element.label, "element_text").text : element.label,
+      text: element.text ? redactGuideLensText(element.text, "element_text").text : element.text,
+      description: element.description
+        ? redactGuideLensText(element.description, "element_text").text
+        : element.description,
+      sensitive: element.sensitive || redacted.redactions.length > 0,
+    }, index);
+    return normalized;
+  });
+  const systemElements = elementsFromSystemSnapshot(req);
+  const textElements = synthesizeTextElements({
+    text: visibleText,
+    source: req.screenshotText ? "ocr" : "manual",
+    screen,
+    existingCount: providedElements.length + systemElements.length,
+  });
+  const elements = [...providedElements, ...systemElements, ...textElements]
+    .slice(0, 180)
+    .map((element, index) => normalizeElement(element, index));
+
+  const frontmostWindow = req.systemSnapshot?.windows.find((window) => window.id === req.systemSnapshot?.frontmostWindowId)
+    ?? req.systemSnapshot?.windows.find((window) => window.focused);
+  const frontmostApp = req.systemSnapshot?.apps.find((app) => app.id === req.systemSnapshot?.frontmostAppId)
+    ?? req.systemSnapshot?.apps.find((app) => app.frontmost);
+
+  return {
+    id: input.id,
+    capturedAt: input.nowIso,
+    surface: req.surface ?? input.preferences.defaultSurface,
+    objective: req.objective,
+    screen,
+    app: frontmostApp
+      ? {
+        id: frontmostApp.id,
+        name: frontmostApp.name,
+        bundleId: frontmostApp.bundleId,
+      }
+      : undefined,
+    window: frontmostWindow
+      ? {
+        id: frontmostWindow.id,
+        title: frontmostWindow.title,
+        bounds: normalizeBounds(frontmostWindow.bounds),
+      }
+      : undefined,
+    visibleText,
+    elements,
+    redactions: [...visible.redactions, ...screenshot.redactions],
+    parserStats: {
+      provider: req.parser?.provider ?? input.preferences.parserProvider,
+      used: Boolean(req.parser?.used),
+      latencyMs: req.parser?.latencyMs,
+      tokenEstimate: estimateTokenCount(visibleText, elements.length),
+      fallbackReason: req.parser?.fallbackReason,
+    },
+    systemSnapshot: req.systemSnapshot
+      ? {
+        capturedAt: req.systemSnapshot.capturedAt,
+        platform: req.systemSnapshot.platform,
+        frontmostAppId: req.systemSnapshot.frontmostAppId,
+        frontmostWindowId: req.systemSnapshot.frontmostWindowId,
+      }
+      : undefined,
+  };
+}

--- a/src/guide-lens/engine/verification.ts
+++ b/src/guide-lens/engine/verification.ts
@@ -1,0 +1,107 @@
+import type {
+  FridayGuideLensUiMap,
+  FridayGuideLensVerificationRequest,
+  FridayGuideLensVerificationResult,
+} from "../model/friday-guide-lens.types.js";
+
+function includesInsensitive(haystack: string | undefined, needle: string | undefined): boolean {
+  if (!needle?.trim()) return true;
+  return (haystack ?? "").toLowerCase().includes(needle.trim().toLowerCase());
+}
+
+export function verifyFridayGuideLensProgress(input: {
+  nowIso: () => string;
+  uiMap?: FridayGuideLensUiMap;
+  request: FridayGuideLensVerificationRequest;
+}): FridayGuideLensVerificationResult {
+  const expected = input.request.expected;
+  const uiMap = input.request.uiMap ?? input.uiMap;
+  if (!expected || !uiMap) {
+    return {
+      status: "unknown",
+      checkedAt: input.nowIso(),
+      confidence: 0.2,
+      reason: "No verification criteria or UI map was provided.",
+      evidence: [],
+    };
+  }
+
+  const evidence: string[] = [];
+  let checks = 0;
+  let passed = 0;
+
+  if (expected.textIncludes?.trim()) {
+    checks += 1;
+    if (includesInsensitive(uiMap.visibleText, expected.textIncludes)) {
+      passed += 1;
+      evidence.push(`visible_text includes "${expected.textIncludes}"`);
+    } else {
+      evidence.push(`visible_text does not include "${expected.textIncludes}"`);
+    }
+  }
+
+  if (expected.textExcludes?.trim()) {
+    checks += 1;
+    if (!includesInsensitive(uiMap.visibleText, expected.textExcludes)) {
+      passed += 1;
+      evidence.push(`visible_text excludes "${expected.textExcludes}"`);
+    } else {
+      evidence.push(`visible_text still includes "${expected.textExcludes}"`);
+    }
+  }
+
+  if (expected.elementLabel?.trim()) {
+    checks += 1;
+    const found = uiMap.elements.some((element) =>
+      includesInsensitive(element.label, expected.elementLabel)
+      || includesInsensitive(element.text, expected.elementLabel),
+    );
+    if (found) {
+      passed += 1;
+      evidence.push(`element found for "${expected.elementLabel}"`);
+    } else {
+      evidence.push(`element not found for "${expected.elementLabel}"`);
+    }
+  }
+
+  if (expected.appName?.trim()) {
+    checks += 1;
+    if (includesInsensitive(uiMap.app?.name, expected.appName)) {
+      passed += 1;
+      evidence.push(`frontmost app matches "${expected.appName}"`);
+    } else {
+      evidence.push(`frontmost app is "${uiMap.app?.name ?? "unknown"}"`);
+    }
+  }
+
+  if (expected.windowTitleIncludes?.trim()) {
+    checks += 1;
+    if (includesInsensitive(uiMap.window?.title, expected.windowTitleIncludes)) {
+      passed += 1;
+      evidence.push(`window title includes "${expected.windowTitleIncludes}"`);
+    } else {
+      evidence.push(`window title is "${uiMap.window?.title ?? "unknown"}"`);
+    }
+  }
+
+  if (checks === 0) {
+    return {
+      status: "unknown",
+      checkedAt: input.nowIso(),
+      confidence: 0.2,
+      reason: "Verification criteria were empty.",
+      evidence,
+    };
+  }
+
+  const confidence = passed / checks;
+  return {
+    status: passed === checks ? "passed" : "failed",
+    checkedAt: input.nowIso(),
+    confidence,
+    reason: passed === checks
+      ? "All requested verification checks passed."
+      : `${String(passed)} of ${String(checks)} verification checks passed.`,
+    evidence,
+  };
+}

--- a/src/guide-lens/index.ts
+++ b/src/guide-lens/index.ts
@@ -1,0 +1,11 @@
+export type * from "./model/friday-guide-lens.types.js";
+export { FRIDAY_GUIDE_LENS_MUTATING_ACTIONS } from "./model/friday-guide-lens.types.js";
+export { createFridayGuideLensService } from "./engine/friday-guide-lens-service.js";
+export type { CreateFridayGuideLensServiceDeps } from "./engine/friday-guide-lens-service.js";
+export { buildFridayGuideLensUiMap } from "./engine/ui-map-builder.js";
+export { resolveFridayGuideLensTarget } from "./engine/target-resolver.js";
+export { analyzeFridayGuideLensScreenshot } from "./engine/screenshot-intake.js";
+export { verifyFridayGuideLensProgress } from "./engine/verification.js";
+export { redactGuideLensText, looksSensitiveGuideLensText } from "./engine/redaction.js";
+export { createFridayGuideLensHttpParserAdapter } from "./engine/parser-adapter.js";
+export type { CreateFridayGuideLensHttpParserAdapterOptions } from "./engine/parser-adapter.js";

--- a/src/guide-lens/model/friday-guide-lens.types.ts
+++ b/src/guide-lens/model/friday-guide-lens.types.ts
@@ -1,0 +1,381 @@
+import type { FridaySystemSnapshot } from "../../system/model/friday-system.types.js";
+
+export type ISODateTime = string;
+export type UUID = string;
+
+export const FRIDAY_GUIDE_LENS_SURFACES = [
+  "native_desktop",
+  "browser",
+  "friday_web",
+  "remote_session",
+  "screenshot",
+] as const;
+
+export const FRIDAY_GUIDE_LENS_STATUSES = [
+  "idle",
+  "looking",
+  "guiding",
+  "waiting_for_user",
+  "checking",
+  "blocked",
+  "completed",
+] as const;
+
+export const FRIDAY_GUIDE_LENS_ELEMENT_SOURCES = [
+  "accessibility",
+  "ocr",
+  "dom",
+  "system_window",
+  "parser",
+  "manual",
+] as const;
+
+export const FRIDAY_GUIDE_LENS_OVERLAY_MODES = [
+  "avatar_bubble",
+  "focus_frame",
+  "cursor_ghost",
+  "speech_bubble",
+  "scroll_hint",
+  "page_transition",
+  "numbered_marks",
+  "candidate_picker",
+  "confirm_step",
+  "blocked",
+  "clear",
+] as const;
+
+export const FRIDAY_GUIDE_LENS_AVATAR_KINDS = [
+  "default_f",
+  "profile_image",
+  "local_image",
+] as const;
+
+export const FRIDAY_GUIDE_LENS_MUTATING_ACTIONS = [
+  "click",
+  "double_click",
+  "right_click",
+  "type",
+  "keypress",
+  "hotkey",
+  "scroll",
+  "drag",
+  "drop",
+  "clipboard_write",
+  "file_write",
+  "file_delete",
+  "file_move",
+  "launch_app",
+  "close_app",
+  "open_url",
+  "approve",
+  "deny",
+  "notification_act",
+] as const;
+
+export type FridayGuideLensSurface = (typeof FRIDAY_GUIDE_LENS_SURFACES)[number];
+export type FridayGuideLensStatus = (typeof FRIDAY_GUIDE_LENS_STATUSES)[number];
+export type FridayGuideLensElementSource = (typeof FRIDAY_GUIDE_LENS_ELEMENT_SOURCES)[number];
+export type FridayGuideLensOverlayMode = (typeof FRIDAY_GUIDE_LENS_OVERLAY_MODES)[number];
+export type FridayGuideLensAvatarKind = (typeof FRIDAY_GUIDE_LENS_AVATAR_KINDS)[number];
+export type FridayGuideLensMutatingAction = (typeof FRIDAY_GUIDE_LENS_MUTATING_ACTIONS)[number];
+
+export interface FridayGuideLensBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface FridayGuideLensScreen {
+  width: number;
+  height: number;
+  scaleFactor?: number;
+}
+
+export interface FridayGuideLensAvatarPreference {
+  kind: FridayGuideLensAvatarKind;
+  imageUrl?: string;
+  localPath?: string;
+  initials?: string;
+  sizePx: number;
+}
+
+export interface FridayGuideLensPreferences {
+  enabled: boolean;
+  triggerPolicy: "manual" | "confirm_first" | "trusted_context_auto";
+  defaultSurface: FridayGuideLensSurface;
+  overlayStyle: "restrained_premium";
+  focusColor: "blue";
+  dimBackground: false;
+  clickThroughOverlay: true;
+  bubbleControlsEnabled: true;
+  sensitiveScreenConfirm: true;
+  localOnlyByDefault: true;
+  screenshotAutoAnalyze: "manual_upload_only" | "trusted_opt_in_watch";
+  chatboxPolicy: "ask_when_ambiguous" | "always_after_screenshot" | "never_auto_open";
+  parserProvider: "local_none" | "omniparser" | "midscene" | "custom";
+  avatar: FridayGuideLensAvatarPreference;
+}
+
+export interface FridayGuideLensElement {
+  id: string;
+  role: string;
+  label?: string;
+  text?: string;
+  description?: string;
+  bounds?: FridayGuideLensBounds;
+  source: FridayGuideLensElementSource;
+  confidence: number;
+  interactable: boolean;
+  enabled?: boolean;
+  focused?: boolean;
+  sensitive?: boolean;
+  appId?: string;
+  windowId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface FridayGuideLensRedaction {
+  kind: "api_key" | "password" | "token" | "secret" | "sensitive_text";
+  replacement: string;
+  source: "visible_text" | "screenshot_text" | "element_text";
+  count: number;
+}
+
+export interface FridayGuideLensParserStats {
+  provider: FridayGuideLensPreferences["parserProvider"];
+  used: boolean;
+  latencyMs?: number;
+  tokenEstimate: number;
+  fallbackReason?: string;
+}
+
+export interface FridayGuideLensParserRequest {
+  provider: Exclude<FridayGuideLensPreferences["parserProvider"], "local_none">;
+  snapshot: FridayGuideLensSnapshotRequest;
+}
+
+export interface FridayGuideLensParserResult {
+  provider?: FridayGuideLensPreferences["parserProvider"];
+  used?: boolean;
+  visibleText?: string;
+  screenshotText?: string;
+  elements?: FridayGuideLensElement[];
+  latencyMs?: number;
+  fallbackReason?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface FridayGuideLensParserAdapter {
+  parse(req: FridayGuideLensParserRequest): Promise<FridayGuideLensParserResult>;
+}
+
+export interface FridayGuideLensUiMap {
+  id: UUID;
+  capturedAt: ISODateTime;
+  surface: FridayGuideLensSurface;
+  objective?: string;
+  screen?: FridayGuideLensScreen;
+  app?: {
+    id?: string;
+    name?: string;
+    bundleId?: string;
+  };
+  window?: {
+    id?: string;
+    title?: string;
+    bounds?: FridayGuideLensBounds;
+  };
+  visibleText: string;
+  elements: FridayGuideLensElement[];
+  redactions: FridayGuideLensRedaction[];
+  parserStats: FridayGuideLensParserStats;
+  systemSnapshot?: Pick<
+    FridaySystemSnapshot,
+    "capturedAt" | "platform" | "frontmostAppId" | "frontmostWindowId"
+  >;
+}
+
+export interface FridayGuideLensOverlayStep {
+  index: number;
+  total?: number;
+  label?: string;
+  done?: boolean;
+}
+
+export interface FridayGuideLensOverlayCandidate {
+  elementId: string;
+  label: string;
+  bounds?: FridayGuideLensBounds;
+  confidence: number;
+}
+
+export interface FridayGuideLensOverlayCommand {
+  id: UUID;
+  sessionId: UUID;
+  mode: FridayGuideLensOverlayMode;
+  surface: FridayGuideLensSurface;
+  message: string;
+  targetElementId?: string;
+  targetBounds?: FridayGuideLensBounds;
+  candidates?: FridayGuideLensOverlayCandidate[];
+  step?: FridayGuideLensOverlayStep;
+  avatar: FridayGuideLensAvatarPreference;
+  tone: "calm" | "checking" | "blocked" | "success";
+  focusColor: "blue";
+  dimBackground: false;
+  clickThrough: true;
+  bubbleControlsEnabled: boolean;
+  createdAt: ISODateTime;
+  expiresAt?: ISODateTime;
+  metadata?: Record<string, unknown>;
+}
+
+export interface FridayGuideLensSession {
+  id: UUID;
+  status: FridayGuideLensStatus;
+  surface: FridayGuideLensSurface;
+  objective?: string;
+  createdAt: ISODateTime;
+  updatedAt: ISODateTime;
+  uiMap?: FridayGuideLensUiMap;
+  overlay?: FridayGuideLensOverlayCommand;
+  awaitingUser?: {
+    action: "click" | "type" | "scroll" | "open_page" | "confirm" | "clarify";
+    reason: string;
+    targetElementId?: string;
+  };
+  lastVerification?: FridayGuideLensVerificationResult;
+  events: FridayGuideLensEvent[];
+}
+
+export interface FridayGuideLensEvent {
+  id: UUID;
+  sessionId: UUID;
+  event:
+    | "guide_lens.session.started"
+    | "guide_lens.snapshot.captured"
+    | "guide_lens.target.resolved"
+    | "guide_lens.overlay.shown"
+    | "guide_lens.overlay.cleared"
+    | "guide_lens.screenshot.analyzed"
+    | "guide_lens.verification.completed"
+    | "guide_lens.blocked";
+  emittedAt: ISODateTime;
+  payload: Record<string, unknown>;
+}
+
+export interface FridayGuideLensSnapshotRequest {
+  sessionId?: UUID;
+  surface?: FridayGuideLensSurface;
+  objective?: string;
+  visibleText?: string;
+  screenshotText?: string;
+  screen?: FridayGuideLensScreen;
+  elements?: FridayGuideLensElement[];
+  systemSnapshot?: FridaySystemSnapshot;
+  parser?: {
+    provider?: FridayGuideLensPreferences["parserProvider"];
+    used?: boolean;
+    latencyMs?: number;
+    fallbackReason?: string;
+  };
+}
+
+export interface FridayGuideLensResolveTargetRequest {
+  sessionId?: UUID;
+  instruction: string;
+  uiMap?: FridayGuideLensUiMap;
+  maxCandidates?: number;
+}
+
+export interface FridayGuideLensTargetResolution {
+  status: "resolved" | "ambiguous" | "not_found";
+  instruction: string;
+  target?: FridayGuideLensElement;
+  alternatives: FridayGuideLensElement[];
+  confidence: number;
+  reason: string;
+  overlay: FridayGuideLensOverlayCommand;
+  requiredUserAction?: FridayGuideLensSession["awaitingUser"];
+}
+
+export interface FridayGuideLensShowOverlayRequest {
+  sessionId?: UUID;
+  mode?: FridayGuideLensOverlayMode;
+  message: string;
+  targetElementId?: string;
+  targetBounds?: FridayGuideLensBounds;
+  candidates?: FridayGuideLensOverlayCandidate[];
+  step?: FridayGuideLensOverlayStep;
+  tone?: FridayGuideLensOverlayCommand["tone"];
+  surface?: FridayGuideLensSurface;
+  expiresInMs?: number;
+}
+
+export interface FridayGuideLensScreenshotIntakeRequest {
+  sessionId?: UUID;
+  question?: string;
+  screenshotText?: string;
+  visibleText?: string;
+  source?: "upload" | "paste" | "drag_drop" | "trusted_watcher";
+}
+
+export interface FridayGuideLensScreenshotIntakeResult {
+  sessionId: UUID;
+  intent:
+    | "setup"
+    | "error"
+    | "permission"
+    | "form"
+    | "navigation"
+    | "sensitive"
+    | "question"
+    | "unknown";
+  summary: string;
+  needsChatbox: boolean;
+  chatboxPrompt?: string;
+  suggestedGuideMode: FridayGuideLensOverlayMode;
+  redactedText: string;
+  redactions: FridayGuideLensRedaction[];
+  confidence: number;
+}
+
+export interface FridayGuideLensVerificationRequest {
+  sessionId?: UUID;
+  uiMap?: FridayGuideLensUiMap;
+  expected?: {
+    textIncludes?: string;
+    textExcludes?: string;
+    elementLabel?: string;
+    appName?: string;
+    windowTitleIncludes?: string;
+  };
+}
+
+export interface FridayGuideLensVerificationResult {
+  status: "passed" | "failed" | "unknown";
+  checkedAt: ISODateTime;
+  confidence: number;
+  reason: string;
+  evidence: string[];
+}
+
+export interface FridayGuideLensState {
+  preferences: FridayGuideLensPreferences;
+  activeSession?: FridayGuideLensSession;
+  sessions: FridayGuideLensSession[];
+}
+
+export interface FridayGuideLensService {
+  getState(): FridayGuideLensState;
+  updatePreferences(patch: Partial<FridayGuideLensPreferences>): FridayGuideLensPreferences;
+  updateAvatar(avatar: Partial<FridayGuideLensAvatarPreference>): FridayGuideLensAvatarPreference;
+  captureSnapshot(req?: FridayGuideLensSnapshotRequest): Promise<{ session: FridayGuideLensSession; uiMap: FridayGuideLensUiMap }>;
+  resolveTarget(req: FridayGuideLensResolveTargetRequest): Promise<FridayGuideLensTargetResolution>;
+  showOverlay(req: FridayGuideLensShowOverlayRequest): Promise<FridayGuideLensOverlayCommand>;
+  clearOverlay(sessionId?: UUID): Promise<{ cleared: boolean; sessionId?: UUID; clearedAt: ISODateTime }>;
+  analyzeScreenshot(req: FridayGuideLensScreenshotIntakeRequest): Promise<FridayGuideLensScreenshotIntakeResult>;
+  verify(req: FridayGuideLensVerificationRequest): Promise<FridayGuideLensVerificationResult>;
+  assertReadOnlyAction(action: string): void;
+}

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -92,7 +92,7 @@ import {
   getChannelPersona,
   hydrateChannelPersonaStore,
 } from "#api";
-import type { FridayChannelPersonaConfig, FridaySystemRoutesDeps } from "#api";
+import type { FridayChannelPersonaConfig, FridayGuideLensRoutesDeps, FridaySystemRoutesDeps } from "#api";
 import type { FridayPackagingRoutesDeps } from "../api/http/routes/friday-packaging-routes.js";
 import {
   createPackageInstaller,
@@ -308,6 +308,8 @@ import {
   resolveFridaySystemCompanionServerMode,
 } from "../system/index.js";
 import type { FridaySystemRemoteMode, FridaySystemService } from "../system/index.js";
+import { createFridayGuideLensHttpParserAdapter, createFridayGuideLensService } from "../guide-lens/index.js";
+import type { FridayGuideLensPreferences } from "../guide-lens/index.js";
 import { buildFridayCommunicationPromptFragment, resolveFridayCommunicationPersona } from "../uix/services/friday-communication-persona.js";
 import { createFridayUixGuidedContextRepository } from "../uix/persistence/friday-uix-guided-context-repository.js";
 import { createFridayUixUserPreferenceRepository } from "../uix/persistence/friday-uix-user-preference-repository.js";
@@ -1535,6 +1537,8 @@ export async function createFridayHub(
   const systemEnabled = capabilityGates.systemEnabled;
   let systemService: FridaySystemService | undefined;
   let systemRouteDeps: FridaySystemRoutesDeps | undefined;
+  let guideLensService: ReturnType<typeof createFridayGuideLensService> | undefined;
+  let guideLensRouteDeps: FridayGuideLensRoutesDeps | undefined;
   let systemCompanionServer:
     | ReturnType<typeof createFridaySystemUnixSocketCompanionServer>
     | undefined;
@@ -1861,6 +1865,44 @@ export async function createFridayHub(
           })),
         }),
       },
+    };
+
+    const guideLensParserProvider = (
+      process.env.FRIDAY_GUIDE_LENS_PARSER_PROVIDER === "omniparser"
+      || process.env.FRIDAY_GUIDE_LENS_PARSER_PROVIDER === "midscene"
+      || process.env.FRIDAY_GUIDE_LENS_PARSER_PROVIDER === "custom"
+    )
+      ? process.env.FRIDAY_GUIDE_LENS_PARSER_PROVIDER
+      : "custom";
+    const guideLensParserEndpoint = process.env.FRIDAY_GUIDE_LENS_PARSER_URL?.trim();
+    const guideLensParserAdapter = guideLensParserEndpoint
+      ? createFridayGuideLensHttpParserAdapter({
+        endpointUrl: guideLensParserEndpoint,
+        provider: guideLensParserProvider,
+      })
+      : undefined;
+    const guideLensParserPreference: FridayGuideLensPreferences["parserProvider"] = guideLensParserAdapter
+      ? guideLensParserProvider
+      : "local_none";
+
+    guideLensService = createFridayGuideLensService({
+      idGenerator,
+      nowIso,
+      systemService,
+      companionBridge: systemCompanionBridge,
+      parserAdapter: guideLensParserAdapter,
+      defaultPreferences: {
+        defaultSurface: "native_desktop",
+        parserProvider: guideLensParserPreference,
+        avatar: {
+          kind: "default_f",
+          initials: "F",
+          sizePx: 56,
+        },
+      },
+    });
+    guideLensRouteDeps = {
+      service: guideLensService,
     };
 
     console.log(
@@ -2406,6 +2448,7 @@ export async function createFridayHub(
     xhsSessionManager,
     desktopSessionManager,
     systemService,
+    guideLensService,
     ssrfGuard: agentSsrfGuard,
     sessionService: hubSessionService,
     agentRuntimeGetter,
@@ -3945,6 +3988,7 @@ export async function createFridayHub(
         xhsSessionManager,
         desktopSessionManager,
         systemService,
+        guideLensService,
         ssrfGuard: agentSsrfGuard,
         sessionService: hubSessionService,
         agentRuntimeGetter: childRuntimeGetter,
@@ -5476,6 +5520,7 @@ export async function createFridayHub(
       },
     },
     system: systemRouteDeps,
+    guideLens: guideLensRouteDeps,
     uix: {
       service: uixService,
       readSetupCompletedAt: () =>

--- a/src/system/companion/friday-system-companion-runtime.ts
+++ b/src/system/companion/friday-system-companion-runtime.ts
@@ -18,6 +18,9 @@ import type {
   ISODateTime,
 } from "../model/friday-system.types.js";
 import type {
+  FridayGuideLensOverlayCommand,
+} from "../../guide-lens/model/friday-guide-lens.types.js";
+import type {
   FridaySystemCompanionFocusTargetInput,
   FridaySystemCompanionFocusTargetResult,
   FridaySystemCompanionLaunchAppResult,
@@ -63,6 +66,7 @@ export interface FridaySystemCompanionRuntimeOptions {
     notification: FridaySystemNotificationRef,
   ) => Promise<FridaySystemCompanionNotificationActionResult | null>;
   overlayVisibilityHandler?: (visible: boolean) => Promise<FridaySystemCompanionOverlayState>;
+  guideOverlayHandler?: (command: FridayGuideLensOverlayCommand | null) => Promise<FridaySystemCompanionOverlayState>;
 }
 
 export async function collectDarwinApps(): Promise<FridaySystemAppRef[]> {
@@ -190,6 +194,17 @@ function resolveOverlayVisibilityHandler(
     ?? (async (visible: boolean) => ({
       visible,
       changedAt: options.nowIso(),
+    }));
+}
+
+function resolveGuideOverlayHandler(
+  options: FridaySystemCompanionRuntimeOptions,
+): (command: FridayGuideLensOverlayCommand | null) => Promise<FridaySystemCompanionOverlayState> {
+  return options.guideOverlayHandler
+    ?? (async (command) => ({
+      visible: command !== null,
+      changedAt: options.nowIso(),
+      ...(command ? { guideOverlay: command } : {}),
     }));
 }
 
@@ -525,6 +540,8 @@ export interface FridaySystemCompanionRuntimeController {
     input: FridaySystemCompanionNotificationActionInput,
   ): Promise<FridaySystemCompanionNotificationActionResult | null>;
   setOverlayVisible(visible: boolean): Promise<FridaySystemCompanionOverlayState>;
+  showGuideOverlay(command: FridayGuideLensOverlayCommand): Promise<FridaySystemCompanionOverlayState>;
+  clearGuideOverlay(): Promise<FridaySystemCompanionOverlayState>;
 }
 
 export function createFridaySystemCompanionRuntimeController(
@@ -532,6 +549,7 @@ export function createFridaySystemCompanionRuntimeController(
 ): FridaySystemCompanionRuntimeController {
   const notificationState = new Map<string, { read: boolean; dismissed: boolean }>();
   let overlayVisible = options.overlayEnabled ?? false;
+  let guideOverlay: FridayGuideLensOverlayCommand | undefined;
   let safeMode = false;
 
   function mergeNotifications(
@@ -637,9 +655,37 @@ export function createFridaySystemCompanionRuntimeController(
     async setOverlayVisible(visible) {
       safeMode = false;
       overlayVisible = visible;
+      if (!visible) {
+        guideOverlay = undefined;
+      }
       const result = await resolveOverlayVisibilityHandler(options)(visible);
       overlayVisible = result.visible;
       return result;
+    },
+
+    async showGuideOverlay(command) {
+      safeMode = false;
+      guideOverlay = command;
+      overlayVisible = true;
+      const result = await resolveGuideOverlayHandler(options)(command);
+      overlayVisible = result.visible;
+      guideOverlay = result.guideOverlay ?? command;
+      return {
+        ...result,
+        visible: true,
+        guideOverlay,
+      };
+    },
+
+    async clearGuideOverlay() {
+      guideOverlay = undefined;
+      overlayVisible = false;
+      const result = await resolveGuideOverlayHandler(options)(null);
+      overlayVisible = result.visible;
+      return {
+        ...result,
+        visible: false,
+      };
     },
   };
 }

--- a/src/system/companion/friday-system-companion.types.ts
+++ b/src/system/companion/friday-system-companion.types.ts
@@ -6,6 +6,7 @@ import type {
   FridaySystemWindowLayout,
   FridaySystemWindowRef,
 } from "../model/friday-system.types.js";
+import type { FridayGuideLensOverlayCommand } from "../../guide-lens/model/friday-guide-lens.types.js";
 
 export interface FridaySystemCompanionSnapshot {
   apps: FridaySystemAppRef[];
@@ -62,6 +63,7 @@ export interface FridaySystemCompanionNotificationActionResult {
 export interface FridaySystemCompanionOverlayState {
   visible: boolean;
   changedAt: string;
+  guideOverlay?: FridayGuideLensOverlayCommand;
 }
 
 export interface FridaySystemCompanionBridge {
@@ -81,4 +83,6 @@ export interface FridaySystemCompanionBridge {
     input: FridaySystemCompanionNotificationActionInput,
   ): Promise<FridaySystemCompanionNotificationActionResult | null>;
   setOverlayVisible(visible: boolean): Promise<FridaySystemCompanionOverlayState>;
+  showGuideOverlay(command: FridayGuideLensOverlayCommand): Promise<FridaySystemCompanionOverlayState>;
+  clearGuideOverlay(): Promise<FridaySystemCompanionOverlayState>;
 }

--- a/src/system/companion/friday-system-local-companion-bridge.ts
+++ b/src/system/companion/friday-system-local-companion-bridge.ts
@@ -90,5 +90,15 @@ export function createFridaySystemLocalCompanionBridge(
       lastHeartbeatAt = options.nowIso();
       return controller.setOverlayVisible(visible);
     },
+
+    async showGuideOverlay(command) {
+      lastHeartbeatAt = options.nowIso();
+      return controller.showGuideOverlay(command);
+    },
+
+    async clearGuideOverlay() {
+      lastHeartbeatAt = options.nowIso();
+      return controller.clearGuideOverlay();
+    },
   };
 }

--- a/src/system/companion/friday-system-named-pipe-bridge.ts
+++ b/src/system/companion/friday-system-named-pipe-bridge.ts
@@ -371,5 +371,40 @@ export function createFridaySystemNamedPipeBridge(
         };
       }
     },
+
+    async showGuideOverlay(command) {
+      try {
+        const result = await callRpc("companion.showGuideOverlay", { command });
+        connected = true;
+        lastHeartbeatAt = options.nowIso();
+        return result as Awaited<ReturnType<FridaySystemCompanionBridge["showGuideOverlay"]>>;
+      } catch (err) {
+        console.warn("[friday][named-pipe-bridge] showGuideOverlay:", err instanceof Error ? err.message : String(err));
+        connected = false;
+        lastHeartbeatAt = options.nowIso();
+        return {
+          visible: true,
+          changedAt: options.nowIso(),
+          guideOverlay: command,
+        };
+      }
+    },
+
+    async clearGuideOverlay() {
+      try {
+        const result = await callRpc("companion.clearGuideOverlay");
+        connected = true;
+        lastHeartbeatAt = options.nowIso();
+        return result as Awaited<ReturnType<FridaySystemCompanionBridge["clearGuideOverlay"]>>;
+      } catch (err) {
+        console.warn("[friday][named-pipe-bridge] clearGuideOverlay:", err instanceof Error ? err.message : String(err));
+        connected = false;
+        lastHeartbeatAt = options.nowIso();
+        return {
+          visible: false,
+          changedAt: options.nowIso(),
+        };
+      }
+    },
   };
 }

--- a/src/system/companion/friday-system-unix-socket-bridge.ts
+++ b/src/system/companion/friday-system-unix-socket-bridge.ts
@@ -409,5 +409,40 @@ export function createFridaySystemUnixSocketBridge(
         };
       }
     },
+
+    async showGuideOverlay(command) {
+      try {
+        const result = await callRpc("companion.showGuideOverlay", { command });
+        connected = true;
+        lastHeartbeatAt = options.nowIso();
+        return result as Awaited<ReturnType<FridaySystemCompanionBridge["showGuideOverlay"]>>;
+      } catch (err) {
+        console.warn("[friday][unix-socket-bridge] showGuideOverlay:", err instanceof Error ? err.message : String(err));
+        connected = false;
+        lastHeartbeatAt = options.nowIso();
+        return {
+          visible: true,
+          changedAt: options.nowIso(),
+          guideOverlay: command,
+        };
+      }
+    },
+
+    async clearGuideOverlay() {
+      try {
+        const result = await callRpc("companion.clearGuideOverlay");
+        connected = true;
+        lastHeartbeatAt = options.nowIso();
+        return result as Awaited<ReturnType<FridaySystemCompanionBridge["clearGuideOverlay"]>>;
+      } catch (err) {
+        console.warn("[friday][unix-socket-bridge] clearGuideOverlay:", err instanceof Error ? err.message : String(err));
+        connected = false;
+        lastHeartbeatAt = options.nowIso();
+        return {
+          visible: false,
+          changedAt: options.nowIso(),
+        };
+      }
+    },
   };
 }

--- a/src/system/companion/friday-system-unix-socket-companion-server.ts
+++ b/src/system/companion/friday-system-unix-socket-companion-server.ts
@@ -7,6 +7,7 @@ import {
   createFridaySystemCompanionRuntimeController,
   type FridaySystemCompanionRuntimeOptions,
 } from "./friday-system-companion-runtime.js";
+import type { FridayGuideLensOverlayCommand } from "../../guide-lens/model/friday-guide-lens.types.js";
 
 interface FridayJsonRpcRequest {
   jsonrpc?: string;
@@ -116,6 +117,10 @@ export function createFridaySystemUnixSocketCompanionServer(
         });
       case "companion.setOverlayVisible":
         return controller.setOverlayVisible(Boolean(params?.visible));
+      case "companion.showGuideOverlay":
+        return controller.showGuideOverlay(params?.command as FridayGuideLensOverlayCommand);
+      case "companion.clearGuideOverlay":
+        return controller.clearGuideOverlay();
       default:
         throw new FridayDomainError("VALIDATION_ERROR", `Unknown companion method: ${method}`, { httpStatus: 400 });
     }

--- a/test/unit/agent/tools/friday-agent-guide-lens-tool.test.ts
+++ b/test/unit/agent/tools/friday-agent-guide-lens-tool.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createFridayAgentGuideLensTool } from "../../../../src/agent/tools/friday-agent-guide-lens-tool.js";
+import type { FridayGuideLensService } from "../../../../src/guide-lens/model/friday-guide-lens.types.js";
+
+function signal(): AbortSignal {
+  return new AbortController().signal;
+}
+
+function service(): FridayGuideLensService {
+  return {
+    getState: vi.fn().mockReturnValue({ preferences: {}, sessions: [] }),
+    updatePreferences: vi.fn().mockReturnValue({ enabled: true }),
+    updateAvatar: vi.fn().mockReturnValue({ kind: "default_f", initials: "F", sizePx: 56 }),
+    captureSnapshot: vi.fn().mockResolvedValue({ session: { id: "s-1" }, uiMap: { id: "map-1" } }),
+    resolveTarget: vi.fn().mockResolvedValue({ status: "resolved" }),
+    showOverlay: vi.fn().mockResolvedValue({ id: "overlay-1" }),
+    clearOverlay: vi.fn().mockResolvedValue({ cleared: true }),
+    analyzeScreenshot: vi.fn().mockResolvedValue({ intent: "permission" }),
+    verify: vi.fn().mockResolvedValue({ status: "passed" }),
+    assertReadOnlyAction: vi.fn((value: string) => {
+      if (/click|type|scroll/i.test(value)) {
+        throw new Error("Guide Lens read-only violation");
+      }
+    }),
+  } as unknown as FridayGuideLensService;
+}
+
+describe("createFridayAgentGuideLensTool", () => {
+  it("captures screenshots through the read-only guide lens service", async () => {
+    const guideLensService = service();
+    const tool = createFridayAgentGuideLensTool({ guideLensService });
+
+    const result = await tool.execute({
+      action: "screenshot_intake",
+      screenshotText: "Screen Recording permission required",
+    }, signal());
+
+    expect(result.isError).toBeUndefined();
+    expect(JSON.parse(result.content)).toEqual({ intent: "permission" });
+    expect(guideLensService.analyzeScreenshot).toHaveBeenCalledWith(expect.objectContaining({
+      screenshotText: "Screen Recording permission required",
+      source: "upload",
+    }));
+  });
+
+  it("rejects mutating instructions", async () => {
+    const guideLensService = service();
+    const tool = createFridayAgentGuideLensTool({ guideLensService });
+
+    const result = await tool.execute({
+      action: "resolve_target",
+      instruction: "click Save",
+    }, signal());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("read-only violation");
+    expect(guideLensService.resolveTarget).not.toHaveBeenCalled();
+  });
+
+  it("updates avatar preferences", async () => {
+    const guideLensService = service();
+    const tool = createFridayAgentGuideLensTool({ guideLensService });
+
+    const result = await tool.execute({
+      action: "update_avatar",
+      avatar: { kind: "local_image", localPath: "/tmp/me.png" },
+    }, signal());
+
+    expect(result.isError).toBeUndefined();
+    expect(guideLensService.updateAvatar).toHaveBeenCalledWith({
+      kind: "local_image",
+      localPath: "/tmp/me.png",
+    });
+  });
+});

--- a/test/unit/agent/tools/friday-agent-tool-registry.test.ts
+++ b/test/unit/agent/tools/friday-agent-tool-registry.test.ts
@@ -9,6 +9,7 @@ import type { FridayJobSchedulerService } from "../../../../src/jobs/scheduler/f
 import type { FridayChannelRegistry } from "../../../../src/channels/friday-channel-registry.js";
 import type { FridayMcpAdapter } from "../../../../src/agent/mcp/friday-mcp-adapter.types.js";
 import type { FridayProviderService } from "../../../../src/providers/services/friday-provider-service.types.js";
+import type { FridayGuideLensService } from "../../../../src/guide-lens/model/friday-guide-lens.types.js";
 
 function stubSessionService(): FridaySessionService {
   return {
@@ -80,6 +81,21 @@ function stubProviderService(): FridayProviderService {
     runWithFallback: vi.fn(),
     recordUsage: vi.fn(),
   } as unknown as FridayProviderService;
+}
+
+function stubGuideLensService(): FridayGuideLensService {
+  return {
+    getState: vi.fn(),
+    updatePreferences: vi.fn(),
+    updateAvatar: vi.fn(),
+    captureSnapshot: vi.fn(),
+    resolveTarget: vi.fn(),
+    showOverlay: vi.fn(),
+    clearOverlay: vi.fn(),
+    analyzeScreenshot: vi.fn(),
+    verify: vi.fn(),
+    assertReadOnlyAction: vi.fn(),
+  } as unknown as FridayGuideLensService;
 }
 
 describe("createFridayAgentToolRegistry", () => {
@@ -186,6 +202,14 @@ describe("createFridayAgentToolRegistry", () => {
     });
     const names = tools.map((t) => t.name);
     expect(names).toContain("provider");
+  });
+
+  it("includes guide_lens tool when guideLensService is provided", () => {
+    const tools = createFridayAgentToolRegistry({
+      guideLensService: stubGuideLensService(),
+    });
+    const names = tools.map((t) => t.name);
+    expect(names).toContain("guide_lens");
   });
 
   it("includes capabilities tool when capabilitySnapshotGetter is provided", () => {

--- a/test/unit/api/auth/friday-auth-middleware.test.ts
+++ b/test/unit/api/auth/friday-auth-middleware.test.ts
@@ -11,7 +11,7 @@ import {
 } from "#api";
 import { createFridayRateLimitService } from "#api";
 import type { FridayHttpContext } from "#api";
-import type { FridayAccessTokenClaims, FridayAuthPrincipal } from "#api";
+import type { FridayAccessTokenClaims } from "#api";
 
 describe("FridayAuthMiddleware", () => {
   let db: FridaySqliteLayer;
@@ -47,9 +47,7 @@ describe("FridayAuthMiddleware", () => {
     return encodeToken(claims, SECRET);
   }
 
-  function createMiddleware(
-    resolveLocalBypassPrincipal?: () => FridayAuthPrincipal | null,
-  ): FridayAuthMiddlewareFactory {
+  function createMiddleware(): FridayAuthMiddlewareFactory {
     const tokenValidator = createFridayTokenValidator({
       tokenSecret: SECRET,
       nowMs: () => NOW_SEC * 1000,
@@ -62,20 +60,8 @@ describe("FridayAuthMiddleware", () => {
     return createFridayAuthMiddlewareFactory({
       tokenValidator,
       rateLimitService,
-      resolveLocalBypassPrincipal,
     });
   }
-
-  const localBypassPrincipal: FridayAuthPrincipal = {
-    principalType: "user",
-    principalId: "local-user-1",
-    userId: "local-user-1",
-    role: "admin",
-    scopes: ["hub.admin"],
-    tokenId: "local-bypass-token",
-    tokenKind: "access",
-    issuedAt: NOW,
-  };
 
   beforeEach(() => {
     db = createTestDb();
@@ -121,17 +107,6 @@ describe("FridayAuthMiddleware", () => {
       }
     });
 
-    it("uses local bypass principal when no bearer token is present", () => {
-      const localMw = createMiddleware(() => localBypassPrincipal);
-      const ctx = makeCtx();
-      const result = localMw.requireAuth(ctx);
-      expect(result.passed).toBe(true);
-      expect(ctx.principal?.principalId).toBe("local-user-1");
-      if (result.passed) {
-        expect(result.headers?.["X-Friday-Local-Session"]).toBe("bypass");
-      }
-    });
-
     it("rejects when token is invalid", () => {
       const ctx = makeCtx({
         headers: { authorization: "Bearer invalid.token" },
@@ -143,14 +118,18 @@ describe("FridayAuthMiddleware", () => {
       }
     });
 
-    it("falls back to local bypass when a stale bearer token is present", () => {
-      const localMw = createMiddleware(() => localBypassPrincipal);
+    it("rejects invalid tokens without falling back to local auth state", () => {
       const ctx = makeCtx({
         headers: { authorization: "Bearer invalid.token" },
+        ip: "127.0.0.1",
+        socketIp: "127.0.0.1",
       });
-      const result = localMw.requireAuth(ctx);
-      expect(result.passed).toBe(true);
-      expect(ctx.principal?.principalId).toBe("local-user-1");
+      const result = mw.requireAuth(ctx);
+      expect(result.passed).toBe(false);
+      expect(ctx.principal).toBeNull();
+      if (!result.passed) {
+        expect(result.statusCode).toBe(401);
+      }
     });
   });
 

--- a/test/unit/api/http/routes/friday-guide-lens-routes.test.ts
+++ b/test/unit/api/http/routes/friday-guide-lens-routes.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createFridayGuideLensRoutes } from "../../../../../src/api/http/routes/friday-guide-lens-routes.js";
+import type { FridayRouteDefinition } from "../../../../../src/api/model/friday-api-common.types.js";
+import type { FridayGuideLensService } from "../../../../../src/guide-lens/model/friday-guide-lens.types.js";
+
+function makeService(): FridayGuideLensService {
+  return {
+    getState: vi.fn().mockReturnValue({ preferences: {}, sessions: [] }),
+    updatePreferences: vi.fn().mockReturnValue({ enabled: true }),
+    updateAvatar: vi.fn().mockReturnValue({ kind: "default_f", initials: "F", sizePx: 56 }),
+    captureSnapshot: vi.fn().mockResolvedValue({ session: { id: "s-1" }, uiMap: { id: "map-1" } }),
+    resolveTarget: vi.fn().mockResolvedValue({ status: "resolved" }),
+    showOverlay: vi.fn().mockResolvedValue({ id: "overlay-1" }),
+    clearOverlay: vi.fn().mockResolvedValue({ cleared: true, clearedAt: "2026-04-28T09:00:00.000Z" }),
+    analyzeScreenshot: vi.fn().mockResolvedValue({ intent: "permission" }),
+    verify: vi.fn().mockResolvedValue({ status: "passed" }),
+    assertReadOnlyAction: vi.fn((action: string) => {
+      if (/click|type|scroll/i.test(action)) {
+        throw new Error("read-only violation");
+      }
+    }),
+  } as unknown as FridayGuideLensService;
+}
+
+function makeCtx(overrides?: Record<string, unknown>) {
+  return {
+    requestId: "req-001",
+    receivedAt: "2026-04-28T09:00:00.000Z",
+    params: {},
+    query: {},
+    body: {},
+    headers: {},
+    ip: "127.0.0.1",
+    userAgent: "vitest",
+    principal: {
+      principalType: "user",
+      principalId: "u-1",
+      userId: "u-1",
+      role: "admin",
+      scopes: ["desktop.read", "desktop.write"],
+      tokenId: "t-1",
+      tokenKind: "access",
+      issuedAt: "2026-04-28T09:00:00.000Z",
+    },
+    ...overrides,
+  } as Parameters<FridayRouteDefinition<unknown, unknown, unknown, unknown>["handler"]>[0];
+}
+
+function findRoute(
+  routes: FridayRouteDefinition<unknown, unknown, unknown, unknown>[],
+  operationId: string,
+): FridayRouteDefinition<unknown, unknown, unknown, unknown> {
+  const route = routes.find((entry) => entry.operationId === operationId);
+  if (!route) {
+    throw new Error(`Route ${operationId} not found`);
+  }
+  return route;
+}
+
+describe("createFridayGuideLensRoutes", () => {
+  it("returns canonical authenticated route definitions", () => {
+    const routes = createFridayGuideLensRoutes({ service: makeService() });
+
+    expect(routes.map((route) => route.operationId)).toEqual([
+      "guidelens.state.get",
+      "guidelens.snapshot.create",
+      "guidelens.targets.resolve",
+      "guidelens.overlay.show",
+      "guidelens.overlay.clear",
+      "guidelens.screenshots.analyze",
+      "guidelens.verifications.create",
+      "guidelens.preferences.update",
+      "guidelens.avatar.update",
+    ]);
+    expect(routes.every((route) => route.path.startsWith("/v1/guide-lens"))).toBe(true);
+  });
+
+  it("validates target instructions and delegates to the service", async () => {
+    const service = makeService();
+    const route = findRoute(createFridayGuideLensRoutes({ service }), "guidelens.targets.resolve");
+
+    await expect(route.handler(makeCtx({ body: {} }))).rejects.toThrow("instruction is required");
+    await route.handler(makeCtx({ body: { instruction: "Continue" } }));
+
+    expect(service.resolveTarget).toHaveBeenCalledWith({ instruction: "Continue" });
+  });
+
+  it("rejects mutating overlay messages before delegating", async () => {
+    const service = makeService();
+    const route = findRoute(createFridayGuideLensRoutes({ service }), "guidelens.overlay.show");
+
+    await expect(route.handler(makeCtx({ body: { message: "click the button" } }))).rejects.toThrow("read-only violation");
+    expect(service.showOverlay).not.toHaveBeenCalled();
+  });
+
+  it("updates avatar through the avatar route", async () => {
+    const service = makeService();
+    const route = findRoute(createFridayGuideLensRoutes({ service }), "guidelens.avatar.update");
+
+    await route.handler(makeCtx({ body: { kind: "local_image", localPath: "/tmp/avatar.png" } }));
+
+    expect(service.updateAvatar).toHaveBeenCalledWith({
+      kind: "local_image",
+      localPath: "/tmp/avatar.png",
+    });
+  });
+});

--- a/test/unit/guide-lens/friday-guide-lens-parser-adapter.test.ts
+++ b/test/unit/guide-lens/friday-guide-lens-parser-adapter.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createFridayGuideLensHttpParserAdapter } from "../../../src/guide-lens/index.js";
+
+describe("createFridayGuideLensHttpParserAdapter", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("accepts loopback parser responses in OmniParser/Midscene-compatible shapes", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        provider: "midscene",
+        ocr_text: "Continue",
+        ui_elements: [{
+          id: "continue",
+          type: "button",
+          text: "Continue",
+          bbox: [40, 50, 160, 90],
+          score: 0.91,
+          clickable: true,
+        }],
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const adapter = createFridayGuideLensHttpParserAdapter({
+      endpointUrl: "http://127.0.0.1:8765/parse",
+      provider: "midscene",
+    });
+
+    const result = await adapter.parse({
+      provider: "midscene",
+      snapshot: {
+        surface: "screenshot",
+        screenshotText: "Continue",
+      },
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(result.provider).toBe("midscene");
+    expect(result.elements?.[0]).toEqual(expect.objectContaining({
+      id: "continue",
+      role: "button",
+      source: "parser",
+      interactable: true,
+      bounds: { x: 40, y: 50, width: 120, height: 40 },
+    }));
+  });
+
+  it("rejects non-loopback parser endpoints", () => {
+    expect(() => createFridayGuideLensHttpParserAdapter({
+      endpointUrl: "https://example.com/parse",
+      provider: "custom",
+    })).toThrow("loopback-only");
+  });
+});

--- a/test/unit/guide-lens/friday-guide-lens-service.test.ts
+++ b/test/unit/guide-lens/friday-guide-lens-service.test.ts
@@ -88,6 +88,7 @@ function systemSnapshot(): FridaySystemSnapshot {
 
 describe("createFridayGuideLensService", () => {
   it("builds a compact redacted UI map from text and system state", async () => {
+    const apiKey = ["sk", "examplevalue1234567890"].join("-");
     const service = createFridayGuideLensService({
       idGenerator: idGenerator(),
       nowIso,
@@ -95,7 +96,7 @@ describe("createFridayGuideLensService", () => {
     });
 
     const result = await service.captureSnapshot({
-      visibleText: "OpenAI API key: sk-examplevalue1234567890\nContinue",
+      visibleText: `OpenAI API key: ${apiKey}\nContinue`,
       elements: [{
         id: "continue-button",
         role: "button",
@@ -165,6 +166,7 @@ describe("createFridayGuideLensService", () => {
   });
 
   it("runs optional parser adapters with redacted snapshot input", async () => {
+    const parserKey = ["sk", "parsersecretvalue1234567890"].join("-");
     const parse = vi.fn().mockResolvedValue({
       provider: "omniparser",
       used: true,
@@ -188,7 +190,7 @@ describe("createFridayGuideLensService", () => {
     });
 
     const result = await service.captureSnapshot({
-      visibleText: "API key: sk-parsersecretvalue1234567890",
+      visibleText: `API key: ${parserKey}`,
     });
 
     expect(parse).toHaveBeenCalledWith(expect.objectContaining({

--- a/test/unit/guide-lens/friday-guide-lens-service.test.ts
+++ b/test/unit/guide-lens/friday-guide-lens-service.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it, vi } from "vitest";
+import { createFridayGuideLensService } from "../../../src/guide-lens/index.js";
+import type { FridaySystemSnapshot } from "../../../src/system/model/friday-system.types.js";
+
+const nowIso = () => "2026-04-28T09:00:00.000Z";
+
+function idGenerator() {
+  let count = 0;
+  return () => `id-${++count}`;
+}
+
+function systemSnapshot(): FridaySystemSnapshot {
+  return {
+    capturedAt: nowIso(),
+    platform: "darwin",
+    workspaceRoot: "/tmp/friday",
+    apps: [{
+      id: "app:browser",
+      name: "Safari",
+      bundleId: "com.apple.Safari",
+      running: true,
+      frontmost: true,
+    }],
+    windows: [{
+      id: "window:1",
+      appId: "app:browser",
+      title: "Provider setup",
+      focused: true,
+      bounds: { x: 100, y: 80, width: 900, height: 700 },
+    }],
+    notifications: [],
+    permissions: [],
+    mountedRoots: [],
+    frontmostAppId: "app:browser",
+    frontmostWindowId: "window:1",
+    health: {
+      status: "healthy",
+      safeMode: false,
+      desktopConnected: true,
+      companionConnected: true,
+      reasons: [],
+      updatedAt: nowIso(),
+    },
+    companion: {
+      id: "companion",
+      platform: "darwin",
+      runtimeKind: "swift_app",
+      connected: true,
+      transport: { mode: "unix_socket", protocol: "jsonrpc-2.0", authenticated: true },
+      launchAtLoginEnabled: true,
+      panicHotkey: "cmd+shift+escape",
+      safeMode: false,
+      overlayVisible: false,
+      lastHeartbeatAt: nowIso(),
+      capabilities: {
+        surfaces: {
+          launchAtLogin: true,
+          menuBar: true,
+          overlay: true,
+          globalHotkey: true,
+          windowInventory: true,
+          notificationIntake: true,
+          screenCapture: true,
+        },
+        actions: {
+          snapshot: "supported",
+          launch_app: "supported",
+          focus: "supported",
+          open_url: "supported",
+          open_project: "supported",
+          handoff_to_browser: "supported",
+          handoff_to_terminal: "supported",
+          arrange_windows: "supported",
+          notification_list: "supported",
+          read_notification: "supported",
+          notification_act: "supported",
+          recover_ui: "supported",
+        },
+      },
+      permissions: [],
+    },
+    controlLease: null,
+    approvalsSummary: { total: 0, highRiskAllowed: 0 },
+    remoteDevicesSummary: { total: 0, active: 0 },
+    remoteSessionsSummary: { total: 0, active: 0 },
+  };
+}
+
+describe("createFridayGuideLensService", () => {
+  it("builds a compact redacted UI map from text and system state", async () => {
+    const service = createFridayGuideLensService({
+      idGenerator: idGenerator(),
+      nowIso,
+      systemService: { getState: vi.fn().mockResolvedValue(systemSnapshot()) },
+    });
+
+    const result = await service.captureSnapshot({
+      visibleText: "OpenAI API key: sk-examplevalue1234567890\nContinue",
+      elements: [{
+        id: "continue-button",
+        role: "button",
+        label: "Continue",
+        bounds: { x: 420, y: 560, width: 140, height: 40 },
+        source: "accessibility",
+        confidence: 0.93,
+        interactable: true,
+      }],
+    });
+
+    expect(result.uiMap.visibleText).toContain("[api_key:redacted]");
+    expect(result.uiMap.redactions).toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: "api_key", count: 1 }),
+    ]));
+    expect(result.uiMap.elements.some((element) => element.id === "continue-button")).toBe(true);
+    expect(result.uiMap.parserStats.tokenEstimate).toBeGreaterThan(0);
+    expect(result.uiMap.parserStats.tokenEstimate).toBeLessThan(5000);
+  });
+
+  it("resolves a target and sends a native blue focus overlay command", async () => {
+    const showGuideOverlay = vi.fn().mockResolvedValue({ visible: true, changedAt: nowIso() });
+    const service = createFridayGuideLensService({
+      idGenerator: idGenerator(),
+      nowIso,
+      companionBridge: {
+        captureSnapshot: vi.fn().mockResolvedValue({ apps: [], windows: [], notifications: [] }),
+        showGuideOverlay,
+        clearGuideOverlay: vi.fn(),
+        setOverlayVisible: vi.fn(),
+      },
+    });
+    const { session } = await service.captureSnapshot({
+      elements: [{
+        id: "save",
+        role: "button",
+        label: "Save",
+        bounds: { x: 700, y: 610, width: 96, height: 36 },
+        source: "accessibility",
+        confidence: 0.96,
+        interactable: true,
+      }],
+    });
+
+    const resolution = await service.resolveTarget({
+      sessionId: session.id,
+      instruction: "Save",
+    });
+
+    expect(resolution.status).toBe("resolved");
+    expect(resolution.overlay.dimBackground).toBe(false);
+    expect(resolution.overlay.focusColor).toBe("blue");
+    expect(resolution.overlay.clickThrough).toBe(true);
+    expect(showGuideOverlay).toHaveBeenCalledWith(expect.objectContaining({
+      mode: "focus_frame",
+      targetElementId: "save",
+    }));
+  });
+
+  it("rejects mutating instructions in Guide Mode", () => {
+    const service = createFridayGuideLensService({
+      idGenerator: idGenerator(),
+      nowIso,
+    });
+
+    expect(() => service.assertReadOnlyAction("click the Continue button")).toThrow("only observe and guide");
+  });
+
+  it("runs optional parser adapters with redacted snapshot input", async () => {
+    const parse = vi.fn().mockResolvedValue({
+      provider: "omniparser",
+      used: true,
+      latencyMs: 42,
+      visibleText: "Authorize",
+      elements: [{
+        id: "parser-authorize",
+        role: "button",
+        label: "Authorize",
+        bounds: { x: 520, y: 520, width: 128, height: 38 },
+        source: "parser",
+        confidence: 0.88,
+        interactable: true,
+      }],
+    });
+    const service = createFridayGuideLensService({
+      idGenerator: idGenerator(),
+      nowIso,
+      parserAdapter: { parse },
+      defaultPreferences: { parserProvider: "omniparser" },
+    });
+
+    const result = await service.captureSnapshot({
+      visibleText: "API key: sk-parsersecretvalue1234567890",
+    });
+
+    expect(parse).toHaveBeenCalledWith(expect.objectContaining({
+      provider: "omniparser",
+      snapshot: expect.objectContaining({
+        visibleText: expect.stringContaining("[api_key:redacted]"),
+      }),
+    }));
+    expect(result.uiMap.parserStats).toEqual(expect.objectContaining({
+      provider: "omniparser",
+      used: true,
+      latencyMs: 42,
+    }));
+    expect(result.uiMap.elements.some((element) => element.id === "parser-authorize")).toBe(true);
+  });
+
+  it("analyzes screenshots and only asks chatbox when intent is unclear", async () => {
+    const service = createFridayGuideLensService({
+      idGenerator: idGenerator(),
+      nowIso,
+    });
+
+    const clear = await service.analyzeScreenshot({
+      screenshotText: "Screen Recording permission is required in System Settings",
+    });
+    const unknown = await service.analyzeScreenshot({
+      screenshotText: "Dashboard",
+    });
+
+    expect(clear.intent).toBe("permission");
+    expect(clear.needsChatbox).toBe(false);
+    expect(unknown.needsChatbox).toBe(true);
+  });
+});

--- a/ui/src/routes/settings-page.tsx
+++ b/ui/src/routes/settings-page.tsx
@@ -134,6 +134,27 @@ function applyDraftToPreferencePayload(draft: {
   ];
 }
 
+interface GuideLensState {
+  preferences: {
+    enabled: boolean;
+    triggerPolicy: "manual" | "confirm_first" | "trusted_context_auto";
+    defaultSurface: string;
+    parserProvider: string;
+    chatboxPolicy: string;
+    avatar: {
+      kind: "default_f" | "profile_image" | "local_image";
+      imageUrl?: string;
+      localPath?: string;
+      initials?: string;
+      sizePx: number;
+    };
+  };
+  activeSession?: {
+    status: string;
+    surface: string;
+  };
+}
+
 export function SettingsPage() {
   const { locale } = useAppLocale();
   const queryClient = useQueryClient();
@@ -195,6 +216,13 @@ export function SettingsPage() {
     queryFn: () => systemApi.getState(),
     retry: 0,
     refetchInterval: 10_000,
+  });
+
+  const { data: guideLensState } = useQuery({
+    queryKey: ["settings", "guide-lens"],
+    queryFn: () => apiClient.get<GuideLensState>("/v1/guide-lens/state"),
+    retry: 0,
+    refetchInterval: 15_000,
   });
 
   const { data: persona } = useQuery({
@@ -381,6 +409,30 @@ export function SettingsPage() {
     },
   });
 
+  const updateGuideLensPreferencesMutation = useMutation({
+    mutationFn: (patch: Partial<GuideLensState["preferences"]>) =>
+      apiClient.patch<Partial<GuideLensState["preferences"]>, GuideLensState["preferences"]>("/v1/guide-lens/preferences", patch),
+    onSuccess: async () => {
+      toast.success(localize(locale, "引导模式已更新", "Guide Mode updated"));
+      await queryClient.invalidateQueries({ queryKey: ["settings", "guide-lens"] });
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : localize(locale, "无法更新引导模式", "Could not update Guide Mode"));
+    },
+  });
+
+  const updateGuideLensAvatarMutation = useMutation({
+    mutationFn: (avatar: Partial<GuideLensState["preferences"]["avatar"]>) =>
+      apiClient.post<Partial<GuideLensState["preferences"]["avatar"]>, GuideLensState["preferences"]["avatar"]>("/v1/guide-lens/avatar", avatar),
+    onSuccess: async () => {
+      toast.success(localize(locale, "引导头像已更新", "Guide avatar updated"));
+      await queryClient.invalidateQueries({ queryKey: ["settings", "guide-lens"] });
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : localize(locale, "无法更新引导头像", "Could not update guide avatar"));
+    },
+  });
+
   const toggleExpertMutation = useMutation({
     mutationFn: (enabled: boolean) => systemApi.updateAgentLoopExpertMode({ enabled }),
     onSuccess: (result) => {
@@ -486,6 +538,74 @@ export function SettingsPage() {
             </div>
           ) : (
             <p className="text-sm text-[color:var(--color-text-secondary)]">{localize(locale, "正在加载诊断信息…", "Loading diagnostics...")}</p>
+          )}
+        </ShellCard>
+
+        <ShellCard eyebrow={localize(locale, "引导模式", "Guide Mode")} title={localize(locale, "Native Companion Overlay", "Native Companion Overlay")}>
+          {guideLensState ? (
+            <div className="space-y-4 text-sm text-[color:var(--color-text-secondary)]">
+              <div className="flex items-center gap-4 rounded-[18px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-subtle)] p-4">
+                <div className="grid h-14 w-14 shrink-0 place-items-center rounded-full bg-[#c4c7c5] text-xl font-semibold text-white">
+                  {guideLensState.preferences.avatar.kind === "default_f" ? (guideLensState.preferences.avatar.initials ?? "F") : "F"}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="font-medium text-[color:var(--color-text-primary)]">
+                    {localize(locale, "只读引导，不接管操作", "Read-only guidance, no input takeover")}
+                  </p>
+                  <p className="mt-1 text-xs leading-relaxed text-[color:var(--color-text-tertiary)]">
+                    {localize(locale, "默认灰色 F 头像，可切换复用 profile 或本地图片；蓝色焦点框会显示在 native companion 上。", "Default grey F avatar, with profile/local image options; blue focus frames render in the native companion.")}
+                  </p>
+                </div>
+                <StatusPill tone={guideLensState.preferences.enabled ? "success" : "neutral"}>
+                  {guideLensState.preferences.enabled ? "enabled" : "disabled"}
+                </StatusPill>
+              </div>
+
+              <div className="grid gap-3 sm:grid-cols-2">
+                <label className="space-y-1.5">
+                  <span className="text-xs font-medium text-[color:var(--color-text-tertiary)]">{localize(locale, "触发方式", "Trigger")}</span>
+                  <select
+                    className="w-full rounded-xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] px-3 py-2 text-sm text-[color:var(--color-text-primary)]"
+                    value={guideLensState.preferences.triggerPolicy}
+                    onChange={(event) => updateGuideLensPreferencesMutation.mutate({ triggerPolicy: event.target.value as GuideLensState["preferences"]["triggerPolicy"] })}
+                  >
+                    <option value="confirm_first">{localize(locale, "首次确认后弹出", "Confirm first")}</option>
+                    <option value="manual">{localize(locale, "只手动触发", "Manual only")}</option>
+                    <option value="trusted_context_auto">{localize(locale, "信任场景自动弹出", "Trusted auto")}</option>
+                  </select>
+                </label>
+                <label className="space-y-1.5">
+                  <span className="text-xs font-medium text-[color:var(--color-text-tertiary)]">{localize(locale, "头像来源", "Avatar")}</span>
+                  <select
+                    className="w-full rounded-xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] px-3 py-2 text-sm text-[color:var(--color-text-primary)]"
+                    value={guideLensState.preferences.avatar.kind}
+                    onChange={(event) => updateGuideLensAvatarMutation.mutate({ kind: event.target.value as GuideLensState["preferences"]["avatar"]["kind"] })}
+                  >
+                    <option value="default_f">{localize(locale, "默认灰色 F", "Default grey F")}</option>
+                    <option value="profile_image">{localize(locale, "复用 profile 图片", "Use profile image")}</option>
+                    <option value="local_image">{localize(locale, "本地图片路径", "Local image path")}</option>
+                  </select>
+                </label>
+              </div>
+
+              <label className="space-y-1.5">
+                <span className="text-xs font-medium text-[color:var(--color-text-tertiary)]">{localize(locale, "本地图片路径", "Local image path")}</span>
+                <input
+                  className="w-full rounded-xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] px-3 py-2 text-sm text-[color:var(--color-text-primary)]"
+                  defaultValue={guideLensState.preferences.avatar.localPath ?? ""}
+                  placeholder="/Users/me/Pictures/profile.png"
+                  onBlur={(event) => updateGuideLensAvatarMutation.mutate({ kind: "local_image", localPath: event.target.value })}
+                />
+              </label>
+
+              <div className="grid gap-3 sm:grid-cols-3">
+                <DiagnosticRow label={localize(locale, "Parser", "Parser")} value={guideLensState.preferences.parserProvider} />
+                <DiagnosticRow label={localize(locale, "Chatbox", "Chatbox")} value={guideLensState.preferences.chatboxPolicy} />
+                <DiagnosticRow label={localize(locale, "Session", "Session")} value={guideLensState.activeSession?.status ?? "idle"} />
+              </div>
+            </div>
+          ) : (
+            <p className="text-sm text-[color:var(--color-text-secondary)]">{localize(locale, "引导模式未启用或系统伴侣未连接。", "Guide Mode is not enabled or the companion is not connected.")}</p>
           )}
         </ShellCard>
 


### PR DESCRIPTION
## Summary
- add Guide Lens read-only domain service, HTTP routes, and agent tool
- add macOS native companion blue focus overlay/avatar bubble RPC path
- add settings controls, screenshot-intake heuristics, parser adapter, docs, and tests

## Verification
- npx vitest run test/unit/guide-lens/friday-guide-lens-service.test.ts test/unit/guide-lens/friday-guide-lens-parser-adapter.test.ts test/unit/api/http/routes/friday-guide-lens-routes.test.ts test/unit/agent/tools/friday-agent-guide-lens-tool.test.ts test/unit/agent/tools/friday-agent-tool-registry.test.ts --project default
- npm run typecheck
- npm run build:api
- npm run build:ui
- swift test --package-path apps/macos/FridayCompanion
- live Swift companion socket smoke: companion.showGuideOverlay -> visible:true, companion.clearGuideOverlay -> visible:false
- git diff --cached --check and staged secret scan
