### PR TITLE
Fix OpenRouter provider catalog expectation

### DIFF
--- a/test/unit/providers/model/friday-provider-catalog.test.ts
+++ b/test/unit/providers/model/friday-provider-catalog.test.ts
@@ -25,9 +25,9 @@ describe("friday-provider-catalog", () => {
     expect(new Set(FRIDAY_PROVIDER_KINDS).size).toBe(FRIDAY_PROVIDER_KINDS.length);
   });
 
-  it("returns openai-compatible preset for openrouter", () => {
+  it("returns chat-completions OpenAI-compatible preset for openrouter", () => {
     const preset = getFridayProviderPreset("openrouter");
-    expect(preset.api).toBe("openai-responses");
+    expect(preset.api).toBe("openai-completions");
     expect(preset.authMode).toBe("bearer-token");
     expect(preset.baseUrl).toBe("https://openrouter.ai/api");
   });


### PR DESCRIPTION
## Summary

- Align the OpenRouter provider catalog test with the chat-completions runtime path introduced in 079f55d.
- Keep the implementation unchanged; this fixes the stale assertion that failed CI.

## Verification

- npx vitest run test/unit/providers/model/friday-provider-catalog.test.ts test/unit/providers/model/friday-provider-templates.test.ts
- npm test