### PR TITLE
B5-fix-1: provider doctor remediation hint in Settings

### DIFF
--- a/test/unit/ui/provider-doctor-diagnostics.test.ts
+++ b/test/unit/ui/provider-doctor-diagnostics.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  classifyFridayProviderDoctorRemediation,
+  type FridayProviderDoctorRemediationInput,
+  type FridayProviderDoctorRemediationVerdict,
+} from "@/lib/providers/provider-doctor-diagnostics";
+
+const VERDICT_TOKENS: ReadonlyArray<FridayProviderDoctorRemediationVerdict> = [
+  "healthy",
+  "provider_disabled",
+  "cli_problem",
+  "oauth_reauth_required",
+  "credential_problem",
+  "payment_required",
+  "connectivity_problem",
+  "model_problem",
+  "unverified_or_unknown",
+  "out_of_scope_health",
+];
+
+function healthy(overrides: Partial<FridayProviderDoctorRemediationInput> = {}): FridayProviderDoctorRemediationInput {
+  return {
+    enabled: true,
+    validationStatus: "ok",
+    backendHealth: "healthy",
+    authHealth: "healthy",
+    routingEligible: true,
+    reasons: [],
+    ...overrides,
+  };
+}
+
+describe("classifyFridayProviderDoctorRemediation", () => {
+  it("returns healthy when validation is ok, both health channels are healthy, and there are no reasons", () => {
+    expect(classifyFridayProviderDoctorRemediation(healthy())).toBe("healthy");
+  });
+
+  it("returns provider_disabled when enabled=false (overrides any other failure signal)", () => {
+    expect(
+      classifyFridayProviderDoctorRemediation(healthy({
+        enabled: false,
+        validationStatus: "failed",
+        validationErrorCode: "PROVIDER_AUTH_INVALID",
+      })),
+    ).toBe("provider_disabled");
+  });
+
+  it("returns provider_disabled when reasons include provider_disabled even if enabled flag is missing", () => {
+    expect(
+      classifyFridayProviderDoctorRemediation({
+        reasons: ["provider_disabled"],
+      }),
+    ).toBe("provider_disabled");
+  });
+
+  it("returns cli_problem for cli_session_unhealthy reason", () => {
+    expect(
+      classifyFridayProviderDoctorRemediation(healthy({
+        validationStatus: "failed",
+        reasons: ["cli_session_unhealthy"],
+      })),
+    ).toBe("cli_problem");
+  });
+
+  it("returns cli_problem for cli_config_missing reason", () => {
+    expect(
+      classifyFridayProviderDoctorRemediation(healthy({
+        validationStatus: "failed",
+        reasons: ["cli_config_missing"],
+      })),
+    ).toBe("cli_problem");
+  });
+
+  it("returns oauth_reauth_required for oauth_requires_token_manager_check reason", () => {
+    expect(
+      classifyFridayProviderDoctorRemediation(healthy({
+        validationStatus: "failed",
+        reasons: ["oauth_requires_token_manager_check"],
+      })),
+    ).toBe("oauth_reauth_required");
+  });
+
+  it("returns credential_problem for PROVIDER_AUTH_INVALID errorCode", () => {
+    expect(
+      classifyFridayProviderDoctorRemediation(healthy({
+        validationStatus: "failed",
+        validationErrorCode: "PROVIDER_AUTH_INVALID",
+      })),
+    ).toBe("credential_problem");
+  });
+
+  it("returns credential_problem for PROVIDER_ENV_VAR_MISSING errorCode", () => {
+    expect(
+      classifyFridayProviderDoctorRemediation(healthy({
+        validationStatus: "failed",
+        validationErrorCode: "PROVIDER_ENV_VAR_MISSING",
+      })),
+    ).toBe("credential_problem");
+  });
+
+  it("returns credential_problem when reasons include credential_missing", () => {
+    expect(
+      classifyFridayProviderDoctorRemediation(healthy({
+        validationStatus: "failed",
+        reasons: ["credential_missing"],
+      })),
+    ).toBe("credential_problem");
+  });
+
+  it("returns payment_required for PROVIDER_PAYMENT_REQUIRED errorCode", () => {
+    expect(
+      classifyFridayProviderDoctorRemediation(healthy({
+        validationStatus: "failed",
+        validationErrorCode: "PROVIDER_PAYMENT_REQUIRED",
+      })),
+    ).toBe("payment_required");
+  });
+
+  it("returns connectivity_problem for PROVIDER_UNREACHABLE errorCode", () => {
+    expect(
+      classifyFridayProviderDoctorRemediation(healthy({
+        validationStatus: "failed",
+        validationErrorCode: "PROVIDER_UNREACHABLE",
+      })),
+    ).toBe("connectivity_problem");
+  });
+
+  it("returns model_problem for PROVIDER_MODEL_UNAVAILABLE errorCode", () => {
+    expect(
+      classifyFridayProviderDoctorRemediation(healthy({
+        validationStatus: "failed",
+        validationErrorCode: "PROVIDER_MODEL_UNAVAILABLE",
+      })),
+    ).toBe("model_problem");
+  });
+
+  it("returns model_problem when reasons include no_supported_models", () => {
+    expect(
+      classifyFridayProviderDoctorRemediation(healthy({
+        validationStatus: "failed",
+        reasons: ["no_supported_models"],
+      })),
+    ).toBe("model_problem");
+  });
+
+  it("returns unverified_or_unknown when validationStatus is never", () => {
+    expect(
+      classifyFridayProviderDoctorRemediation(healthy({
+        validationStatus: "never",
+      })),
+    ).toBe("unverified_or_unknown");
+  });
+
+  it("returns unverified_or_unknown when reasons include validation_unverified", () => {
+    expect(
+      classifyFridayProviderDoctorRemediation(healthy({
+        validationStatus: "failed",
+        reasons: ["validation_unverified"],
+      })),
+    ).toBe("unverified_or_unknown");
+  });
+
+  it("returns unverified_or_unknown for PROVIDER_UNKNOWN_ERROR errorCode", () => {
+    expect(
+      classifyFridayProviderDoctorRemediation(healthy({
+        validationStatus: "failed",
+        validationErrorCode: "PROVIDER_UNKNOWN_ERROR",
+      })),
+    ).toBe("unverified_or_unknown");
+  });
+
+  it("returns out_of_scope_health when health channels are degraded with no specific reason matched", () => {
+    expect(
+      classifyFridayProviderDoctorRemediation({
+        enabled: true,
+        validationStatus: "ok",
+        backendHealth: "degraded",
+        authHealth: "healthy",
+        reasons: [],
+      }),
+    ).toBe("out_of_scope_health");
+  });
+
+  it("priority: provider_disabled wins over credential_problem", () => {
+    expect(
+      classifyFridayProviderDoctorRemediation({
+        enabled: false,
+        validationStatus: "failed",
+        validationErrorCode: "PROVIDER_AUTH_INVALID",
+        reasons: ["credential_missing"],
+      }),
+    ).toBe("provider_disabled");
+  });
+
+  it("priority: cli_problem wins over credential_problem when both signals present", () => {
+    expect(
+      classifyFridayProviderDoctorRemediation(healthy({
+        validationStatus: "failed",
+        validationErrorCode: "PROVIDER_AUTH_INVALID",
+        reasons: ["cli_session_unhealthy"],
+      })),
+    ).toBe("cli_problem");
+  });
+
+  it("priority: oauth_reauth_required wins over credential_problem when both signals present", () => {
+    expect(
+      classifyFridayProviderDoctorRemediation(healthy({
+        validationStatus: "failed",
+        validationErrorCode: "PROVIDER_AUTH_INVALID",
+        reasons: ["oauth_requires_token_manager_check"],
+      })),
+    ).toBe("oauth_reauth_required");
+  });
+
+  it("ignores any unknown free-text fields on the input (errorMessage cannot leak into the verdict)", () => {
+    // Cast through a wider type to simulate a careless caller passing the raw
+    // FridayProviderValidationState (which carries errorMessage). The helper's
+    // declared input does not include errorMessage; this test pins the
+    // structural boundary so a future refactor cannot regress it.
+    const careless = {
+      enabled: true,
+      validationStatus: "failed",
+      validationErrorCode: "PROVIDER_AUTH_INVALID",
+      reasons: [],
+      errorMessage: "validator-detail-must-not-leak-via-classifier",
+    } as unknown as FridayProviderDoctorRemediationInput;
+
+    const verdict = classifyFridayProviderDoctorRemediation(careless);
+
+    expect(verdict).toBe("credential_problem");
+    expect(VERDICT_TOKENS).toContain(verdict);
+    expect(verdict).not.toContain("validator-detail-must-not-leak-via-classifier");
+    expect(verdict).not.toContain("ignored");
+  });
+
+  it("returns a verdict that is always one of the declared union tokens", () => {
+    // Sweep a few mixed inputs and assert every output is in the declared union.
+    const inputs: FridayProviderDoctorRemediationInput[] = [
+      {},
+      { enabled: true },
+      { enabled: false },
+      { validationStatus: "ok", backendHealth: "healthy", authHealth: "healthy" },
+      { validationStatus: "failed", validationErrorCode: "PROVIDER_PAYMENT_REQUIRED" },
+      { reasons: ["cli_session_unhealthy", "credential_missing"] },
+      { backendHealth: "missing", authHealth: "status_unknown" },
+    ];
+    for (const input of inputs) {
+      const verdict = classifyFridayProviderDoctorRemediation(input);
+      expect(VERDICT_TOKENS).toContain(verdict);
+    }
+  });
+});

--- a/ui/src/lib/providers/provider-doctor-diagnostics.ts
+++ b/ui/src/lib/providers/provider-doctor-diagnostics.ts
@@ -1,0 +1,109 @@
+/**
+ * Provider doctor diagnostics — pure classifier from health-snapshot + persisted
+ * validation state to a stable remediation verdict token.
+ *
+ * The classifier consumes only stable enums, booleans, and known reason-code
+ * strings. It does not accept `errorMessage` (or any free-text field) on its
+ * input, and it never returns one. Surfaces (Settings, Setup wizard, etc.) map
+ * the verdict to localized copy themselves; that keeps i18n out of pure logic
+ * and preserves the secret-discipline boundary established in PR #185
+ * (validator free-text belongs in the agent doctor action, not in the general
+ * provider view).
+ */
+
+export type FridayProviderDoctorRemediationVerdict =
+  | "healthy"
+  | "provider_disabled"
+  | "cli_problem"
+  | "oauth_reauth_required"
+  | "credential_problem"
+  | "payment_required"
+  | "connectivity_problem"
+  | "model_problem"
+  | "unverified_or_unknown"
+  | "out_of_scope_health";
+
+export interface FridayProviderDoctorRemediationInput {
+  enabled?: boolean;
+  validationStatus?: string;
+  validationErrorCode?: string;
+  reasons?: ReadonlyArray<string>;
+  backendHealth?: string;
+  authHealth?: string;
+  routingEligible?: boolean;
+}
+
+/**
+ * Classify a provider's doctor / health snapshot into a stable remediation
+ * verdict. Priority order (most-actionable wins on conflict):
+ *
+ *   1. provider_disabled       — provider toggled off (admin can't fix anything else first)
+ *   2. cli_problem             — auxiliary CLI auth/session must be repaired first
+ *   3. oauth_reauth_required   — OAuth token manager check pending
+ *   4. credential_problem      — common BYOK key/env-var issue
+ *   5. payment_required        — key valid, account state needs attention (neutral copy at the surface)
+ *   6. connectivity_problem    — provider unreachable
+ *   7. model_problem           — model unavailable or supported-model list empty
+ *   8. healthy                 — all green
+ *   9. unverified_or_unknown   — never validated, validation_unverified, or PROVIDER_UNKNOWN_ERROR
+ *  10. out_of_scope_health     — backend/auth degraded with no specific reason matched
+ */
+export function classifyFridayProviderDoctorRemediation(
+  input: FridayProviderDoctorRemediationInput,
+): FridayProviderDoctorRemediationVerdict {
+  const reasons = input.reasons ?? [];
+  const reasonSet = new Set(reasons);
+
+  if (input.enabled === false || reasonSet.has("provider_disabled")) {
+    return "provider_disabled";
+  }
+
+  if (reasonSet.has("cli_session_unhealthy") || reasonSet.has("cli_config_missing")) {
+    return "cli_problem";
+  }
+
+  if (reasonSet.has("oauth_requires_token_manager_check")) {
+    return "oauth_reauth_required";
+  }
+
+  if (
+    input.validationErrorCode === "PROVIDER_AUTH_INVALID"
+    || input.validationErrorCode === "PROVIDER_ENV_VAR_MISSING"
+    || reasonSet.has("credential_missing")
+  ) {
+    return "credential_problem";
+  }
+
+  if (input.validationErrorCode === "PROVIDER_PAYMENT_REQUIRED") {
+    return "payment_required";
+  }
+
+  if (input.validationErrorCode === "PROVIDER_UNREACHABLE") {
+    return "connectivity_problem";
+  }
+
+  if (
+    input.validationErrorCode === "PROVIDER_MODEL_UNAVAILABLE"
+    || reasonSet.has("no_supported_models")
+  ) {
+    return "model_problem";
+  }
+
+  const validationOk = input.validationStatus === "ok";
+  const backendOk = input.backendHealth === undefined || input.backendHealth === "healthy";
+  const authOk = input.authHealth === undefined || input.authHealth === "healthy";
+
+  if (validationOk && backendOk && authOk && reasons.length === 0) {
+    return "healthy";
+  }
+
+  if (
+    input.validationStatus === "never"
+    || reasonSet.has("validation_unverified")
+    || input.validationErrorCode === "PROVIDER_UNKNOWN_ERROR"
+  ) {
+    return "unverified_or_unknown";
+  }
+
+  return "out_of_scope_health";
+}

--- a/ui/src/routes/settings-page.tsx
+++ b/ui/src/routes/settings-page.tsx
@@ -43,6 +43,10 @@ import {
   supportsUseMyPlan,
   type ProviderConnectionMode,
 } from "@/lib/providers/provider-connection";
+import {
+  classifyFridayProviderDoctorRemediation,
+  type FridayProviderDoctorRemediationVerdict,
+} from "@/lib/providers/provider-doctor-diagnostics";
 
 type OpenAICodexDeviceOAuthState = {
   status: "idle" | "starting" | "pending" | "completing" | "connected" | "error";
@@ -84,6 +88,97 @@ function toneForProviderLane(value: "primary" | "fallback" | "standby" | "disabl
   if (value === "primary") return "success";
   if (value === "fallback") return "warning";
   return "neutral";
+}
+
+function describeFridayProviderDoctorRemediation(
+  verdict: FridayProviderDoctorRemediationVerdict,
+  locale: AppLocale,
+): { title: string; hint: string } | null {
+  switch (verdict) {
+    case "healthy":
+      return null;
+    case "provider_disabled":
+      return {
+        title: localize(locale, "Provider 已停用", "Provider is disabled"),
+        hint: localize(locale, "启用此 provider 才能继续路由。", "Enable this provider before it can route."),
+      };
+    case "cli_problem":
+      return {
+        title: localize(locale, "CLI 会话问题", "CLI session problem"),
+        hint: localize(
+          locale,
+          "CLI 后端尚未配置或会话已过期。请重新登录或检查 CLI 配置。",
+          "The CLI backend is not configured or its session has expired. Re-login or check the CLI configuration.",
+        ),
+      };
+    case "oauth_reauth_required":
+      return {
+        title: localize(locale, "OAuth 需要重新授权", "OAuth re-authorization required"),
+        hint: localize(
+          locale,
+          "请通过 OAuth 流程重新连接此 provider。",
+          "Reconnect this provider through the OAuth flow.",
+        ),
+      };
+    case "credential_problem":
+      return {
+        title: localize(locale, "凭据问题", "Credential problem"),
+        hint: localize(
+          locale,
+          "API 密钥或环境变量似乎无效或缺失。请重新输入或设置环境变量。",
+          "The API key or environment variable appears invalid or missing. Re-enter the key or set the environment variable.",
+        ),
+      };
+    case "payment_required":
+      return {
+        title: localize(locale, "账户或验证需关注", "Account or validation needs attention"),
+        hint: localize(
+          locale,
+          "此 provider 当前不可路由。详情请通过 provider doctor 查看。",
+          "This provider is currently not routable. Check the provider doctor for details.",
+        ),
+      };
+    case "connectivity_problem":
+      return {
+        title: localize(locale, "连接问题", "Connectivity problem"),
+        hint: localize(
+          locale,
+          "无法到达此 provider。请检查 baseURL 与网络。",
+          "Cannot reach this provider. Check the baseURL and network connectivity.",
+        ),
+      };
+    case "model_problem":
+      return {
+        title: localize(locale, "模型问题", "Model problem"),
+        hint: localize(
+          locale,
+          "所选模型不可用或可用模型列表为空。请检查 model 配置。",
+          "The selected model is unavailable, or the supported-model list is empty. Check the model configuration.",
+        ),
+      };
+    case "unverified_or_unknown":
+      return {
+        title: localize(locale, "尚未验证", "Not yet verified"),
+        hint: localize(
+          locale,
+          "此 provider 还未通过 doctor 验证。请运行 validate 或 doctor。",
+          "This provider has not passed doctor validation yet. Run validate or doctor.",
+        ),
+      };
+    case "out_of_scope_health":
+      return {
+        title: localize(locale, "健康降级", "Health degraded"),
+        hint: localize(
+          locale,
+          "后端或认证状态非健康，但未匹配到具体修复项。请通过 provider doctor 进一步排查。",
+          "Backend or auth health is degraded but no specific remediation matched. Investigate via the provider doctor.",
+        ),
+      };
+    default: {
+      const exhaustive: never = verdict;
+      return exhaustive;
+    }
+  }
 }
 
 function toneForMcpState(value: "configured" | "discoverable" | "loaded" | "deferred"): "neutral" | "success" | "warning" {
@@ -990,6 +1085,20 @@ export function SettingsPage() {
                   {(() => {
                     const template = providerTemplates.find((item) => item.providerKind === provider.kind);
                     const healthItem = providerHealth.find((item) => item.providerId === provider.id);
+                    const remediationVerdict = healthItem
+                      ? classifyFridayProviderDoctorRemediation({
+                          enabled: provider.enabled,
+                          validationStatus: healthItem.validationStatus,
+                          validationErrorCode: provider.config.validation?.errorCode,
+                          reasons: healthItem.reasons,
+                          backendHealth: healthItem.backendHealth,
+                          authHealth: healthItem.authHealth,
+                          routingEligible: healthItem.routingEligible,
+                        })
+                      : undefined;
+                    const remediationHint = remediationVerdict
+                      ? describeFridayProviderDoctorRemediation(remediationVerdict, locale)
+                      : null;
                     return (
                       <>
                   <div className="flex items-center justify-between gap-3">
@@ -1008,6 +1117,12 @@ export function SettingsPage() {
                   <p className="mt-3 text-sm text-[color:var(--color-text-secondary)]">
                     {localize(locale, "默认模型：", "Default model: ")}{provider.defaultModel ?? resolveFirstSupportedModel(provider) ?? localize(locale, "未设置", "Not set")}
                   </p>
+                  {remediationHint ? (
+                    <div className="mt-3 rounded-2xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] p-3">
+                      <p className="text-sm font-semibold text-[color:var(--color-text-primary)]">{remediationHint.title}</p>
+                      <p className="mt-1 text-xs leading-5 text-[color:var(--color-text-secondary)]">{remediationHint.hint}</p>
+                    </div>
+                  ) : null}
                   {healthItem ? (
                     <div className="mt-3 grid gap-3 md:grid-cols-2">
                       <DiagnosticRow label={localize(locale, "后端健康", "Backend health")} value={healthItem.backendHealth} />


### PR DESCRIPTION
## Summary

Closes the B5 audit finding that the Settings provider detail card surfaced raw doctor diagnostic values (`backendHealth` / `authHealth` / `validationStatus` / `circuitState`) without any user-readable explanation. The B5 audit identified ~12 doctor failure shapes in production with only 1 mapped to user-readable copy (the setup wizard's post-save B4 verdict).

This subphase adds:
- A **pure classifier** `classifyFridayProviderDoctorRemediation()` in `ui/src/lib/providers/provider-doctor-diagnostics.ts` that maps a provider's already-persisted health-snapshot + validation state to one of ten stable verdict tokens.
- A **22-case unit matrix** covering each errorCode (6 enum values), each reason cluster (cli / oauth / credential_missing / no_supported_models / validation_unverified / provider_disabled), priority conflicts (disabled+credential, cli+credential, oauth+credential), the healthy path, the out-of-scope-health fallback, the unverified path, a sweep test, and a **security regression** that smuggles an `errorMessage` through a wider cast and asserts it cannot leak into the verdict.
- A **module-level `describeFridayProviderDoctorRemediation()` helper** in `ui/src/routes/settings-page.tsx` for the verdict→localized copy mapping (kept inline so i18n stays out of pure logic), and a small JSX hint banner above the existing diagnostic grid that renders only when the verdict is non-healthy.

## Constraints respected (per user contract)

- Helper input does **not** accept `errorMessage` (or any free-text field). Output is a stable union of 10 tokens. Settings copy is hardcoded by verdict via `localize()` — no runtime free-text from `provider`/`healthItem` is interpolated. Preserves the secret boundary set by PR #185.
- **No new HTTP doctor or health call.** The classifier consumes only `provider` (from `providersApi.list()`) and `healthItem` (from `providersApi.listHealth()`) already in scope.
- **No backend, routing, validation, or doctor behavior change.**
- `PROVIDER_PAYMENT_REQUIRED` is classified internally as `payment_required` for stable logic, but rendered with **neutral** copy ("Account or validation needs attention; check the provider doctor for details") — no payment-specific UX in this subphase per d-3.
- Existing raw `DiagnosticRow` grid, cooldown text, `suggestedAction` paragraph, and the openai-codex Reconnect button are **unchanged**. New hint is purely additive above the existing grid.
- `provider-truth.tsx` and `use-provider-truth.ts` **not touched** (read-only audit reference only).
- No B2 (Validate Now button), B3 (region template work), Phase 4A.7, Fresh Investigation, or P4 work in this subphase.

## Test plan

- [x] `npm run typecheck` — pass
- [x] `npm run lint` — 0 findings on touched/new files
- [x] `npx vitest run test/unit/ui/provider-doctor-diagnostics.test.ts` — 22/22
- [x] `npm run check:secret-patterns` — clean (re-run post-stage; new files contain only synthetic placeholders)
- [x] `git diff --check` — clean
- [x] Two isolated read-only reviewers — PASS / PASS (closure correctness + parity; regression risk + secret discipline)
- [x] Remote `Real Green Gate` (push trigger) — running on the branch
- [ ] Browser-mock-hub e2e against the new banner — not run; helper logic is unit-tested. Full browser proof would require dev server + a fixture provider in a non-healthy state and is deferred to a follow-up if you want a screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)