### PR TITLE
P4-G1.1: structured real-green-gate result artifact + validator

### DIFF
--- a/.github/workflows/real-green-gate.yml
+++ b/.github/workflows/real-green-gate.yml
@@ -49,9 +49,18 @@ jobs:
 
       - name: Record skipped live gate
         if: env.FRIDAY_BASE_URL == '' && env.FRIDAY_ACCESS_TOKEN == '' && env.FRIDAY_LOCAL_PASSPHRASE == '' && env.FRIDAY_REAL_WORLD_MINT_LOCAL_ADMIN_TOKEN == ''
+        env:
+          GITHUB_SHA: ${{ github.sha }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |
           mkdir -p "$RUNNER_TEMP/real-green-gate"
           printf '%s\n' 'Live real-world gate skipped: no Friday runtime credentials were configured in GitHub Actions secrets.' > "$RUNNER_TEMP/real-green-gate/skip.txt"
+          # P4-G1.1: also emit the structured release-proof artifact so the
+          # downstream release-time gate machine-reads status=blocked_by_env
+          # rather than inferring pass from a successful workflow status.
+          # Reuse the lib's pure builder so the schema stays single-source.
+          node -e "import('./scripts/ops/lib/real-green-gate-result.mjs').then((m) => process.stdout.write(JSON.stringify(m.buildBlockedByEnvResult({ commitSha: process.env.GITHUB_SHA || '', refName: process.env.GITHUB_REF_NAME || '', evaluatedAt: new Date().toISOString(), blockedReasons: ['env_var_missing:FRIDAY_BASE_URL_or_FRIDAY_ACCESS_TOKEN_or_FRIDAY_LOCAL_PASSPHRASE_or_FRIDAY_REAL_WORLD_MINT_LOCAL_ADMIN_TOKEN'] }), null, 2) + '\n'))" \
+            > "$RUNNER_TEMP/real-green-gate/real-green-gate-result.json"
 
       - name: Upload real green gate artifact
         if: always()

--- a/scripts/ops/lib/real-green-gate-result.mjs
+++ b/scripts/ops/lib/real-green-gate-result.mjs
@@ -1,0 +1,234 @@
+/**
+ * Real Green Gate result artifact — schema, writer helpers, and validator.
+ *
+ * P4-G1.1 introduces a structured machine-readable artifact that captures the
+ * outcome of a `npm run ops:real-green-gate` invocation (or its CI workflow
+ * skip path) so that a future release-time gate can decide ship eligibility
+ * without depending on workflow exit codes alone.
+ *
+ * Design boundaries (per docs/release-evidence-policy.md and the P4-G1 design):
+ *  - The validator never accepts `blocked_by_env`, `failed`, or `errored` as
+ *    pass. The workflow may exit success for plumbing reasons; the artifact's
+ *    `status` field tells the truth.
+ *  - There is no escape hatch / break-glass / FAST_MODE field.
+ *  - The validator does NOT enforce a specific evidence-kind policy in this
+ *    subphase; tier policy stays in docs/release-evidence-policy.md.
+ *  - Defense-in-depth: even if the writer ever marked `status: "passed"` while
+ *    `blocked_reasons` was non-empty, the validator rejects.
+ */
+
+export const REAL_GREEN_GATE_RESULT_FILENAME = "real-green-gate-result.json";
+export const REAL_GREEN_GATE_RESULT_SCHEMA_VERSION = 1;
+
+export const REAL_GREEN_GATE_RESULT_STATUSES = Object.freeze({
+  PASSED: "passed",
+  FAILED: "failed",
+  BLOCKED_BY_ENV: "blocked_by_env",
+  ERRORED: "errored",
+});
+
+const VALID_STATUS_SET = new Set(Object.values(REAL_GREEN_GATE_RESULT_STATUSES));
+
+const SUITE_KEYS = ["smoke", "dailyCore", "publicSurface"];
+
+function safeNumber(value) {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function summarizeSuiteCounts(suite) {
+  const counts = suite?.resultCounts ?? suite?.results ?? {};
+  let total = 0;
+  let passed = 0;
+  for (const [key, raw] of Object.entries(counts)) {
+    const value = safeNumber(Number(raw));
+    total += value;
+    if (key === "passed") {
+      passed += value;
+    }
+  }
+  return { total, passed };
+}
+
+function deriveScenarioCounts(summary) {
+  let scenariosTotal = 0;
+  let scenariosPassed = 0;
+  let scenariosRun = 0;
+  for (const key of SUITE_KEYS) {
+    const suite = summary?.[key];
+    if (!suite) {
+      continue;
+    }
+    const { total, passed } = summarizeSuiteCounts(suite);
+    scenariosTotal += total;
+    scenariosPassed += passed;
+    scenariosRun += total;
+  }
+  return { scenariosRun, scenariosTotal, scenariosPassed };
+}
+
+function deriveStatus(summary) {
+  if (summary?.error) {
+    return REAL_GREEN_GATE_RESULT_STATUSES.ERRORED;
+  }
+  if (summary?.gate?.passed === true) {
+    return REAL_GREEN_GATE_RESULT_STATUSES.PASSED;
+  }
+  return REAL_GREEN_GATE_RESULT_STATUSES.FAILED;
+}
+
+function deriveBlockedReasons(summary) {
+  const reasons = Array.isArray(summary?.gate?.reasons) ? summary.gate.reasons : [];
+  return reasons.filter((reason) => typeof reason === "string" && reason.length > 0);
+}
+
+function deriveEvidenceKindsObserved(summary, status) {
+  if (status !== REAL_GREEN_GATE_RESULT_STATUSES.PASSED) {
+    return [];
+  }
+  // When the gate passed end-to-end, the run-real-green-gate.mjs flow has
+  // exercised real-runtime + real-provider + real-browser tiers across the
+  // smoke / dailyCore / publicSurface suites. We only emit these tokens on
+  // status=passed; otherwise we emit an empty list so downstream readers
+  // cannot mistake partial coverage for full coverage.
+  return ["real-runtime", "real-provider", "real-browser"];
+}
+
+function normalizeStringList(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .filter((entry) => typeof entry === "string" && entry.length > 0)
+    .slice();
+}
+
+/**
+ * Build a result artifact from the run-real-green-gate.mjs summary object.
+ *
+ * @param {object} input
+ * @param {object} input.summary  The summary produced by buildSummary() inside run-real-green-gate.mjs.
+ * @param {string} input.commitSha  Full 40-char commit SHA (or "" if unknown).
+ * @param {string} input.refName  Git ref name (branch or tag).
+ * @param {string} input.evaluatedAt  ISO 8601 timestamp.
+ */
+export function buildRealGreenGateResult({ summary, commitSha, refName, evaluatedAt }) {
+  const status = deriveStatus(summary);
+  const counts = deriveScenarioCounts(summary);
+  const blockedReasons = deriveBlockedReasons(summary);
+  return {
+    schema_version: REAL_GREEN_GATE_RESULT_SCHEMA_VERSION,
+    status,
+    commit_sha: typeof commitSha === "string" ? commitSha : "",
+    ref_name: typeof refName === "string" ? refName : "",
+    evaluated_at: typeof evaluatedAt === "string" ? evaluatedAt : "",
+    evidence_kinds_observed: deriveEvidenceKindsObserved(summary, status),
+    blocked_reasons: blockedReasons,
+    scenarios_run: counts.scenariosRun,
+    scenarios_total: counts.scenariosTotal,
+    scenarios_passed: counts.scenariosPassed,
+  };
+}
+
+/**
+ * Build a result artifact for the workflow skip path (no gate execution).
+ *
+ * @param {object} input
+ * @param {string} input.commitSha
+ * @param {string} input.refName
+ * @param {string} input.evaluatedAt
+ * @param {ReadonlyArray<string>} input.blockedReasons  Stable tokens like "env_var_missing:FRIDAY_BASE_URL".
+ */
+export function buildBlockedByEnvResult({ commitSha, refName, evaluatedAt, blockedReasons }) {
+  return {
+    schema_version: REAL_GREEN_GATE_RESULT_SCHEMA_VERSION,
+    status: REAL_GREEN_GATE_RESULT_STATUSES.BLOCKED_BY_ENV,
+    commit_sha: typeof commitSha === "string" ? commitSha : "",
+    ref_name: typeof refName === "string" ? refName : "",
+    evaluated_at: typeof evaluatedAt === "string" ? evaluatedAt : "",
+    evidence_kinds_observed: [],
+    blocked_reasons: normalizeStringList(blockedReasons),
+    scenarios_run: 0,
+    scenarios_total: 0,
+    scenarios_passed: 0,
+  };
+}
+
+function isPlainObject(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Validate a parsed result object. Returns { valid, reasons }. Reasons are
+ * stable token strings; they never embed validator free-text from the input.
+ *
+ * @param {unknown} result  The parsed JSON object (NOT a file path).
+ * @param {object} [options]
+ * @param {string} [options.expectedSha]  If provided, commit_sha must match.
+ */
+export function validateRealGreenGateResult(result, options = {}) {
+  const reasons = [];
+
+  if (!isPlainObject(result)) {
+    reasons.push("not_an_object");
+    return { valid: false, reasons };
+  }
+
+  if (result.schema_version !== REAL_GREEN_GATE_RESULT_SCHEMA_VERSION) {
+    reasons.push("unsupported_schema_version");
+  }
+
+  if (typeof result.status !== "string" || !VALID_STATUS_SET.has(result.status)) {
+    reasons.push("status_invalid_or_missing");
+  } else if (result.status !== REAL_GREEN_GATE_RESULT_STATUSES.PASSED) {
+    reasons.push(`status_not_passed:${result.status}`);
+  }
+
+  if (typeof result.commit_sha !== "string" || result.commit_sha.length === 0) {
+    reasons.push("commit_sha_missing");
+  } else if (typeof options.expectedSha === "string" && options.expectedSha.length > 0) {
+    if (result.commit_sha !== options.expectedSha) {
+      reasons.push("commit_sha_mismatch");
+    }
+  }
+
+  if (typeof result.scenarios_total !== "number" || !Number.isFinite(result.scenarios_total)) {
+    reasons.push("scenarios_total_invalid");
+  }
+  if (typeof result.scenarios_passed !== "number" || !Number.isFinite(result.scenarios_passed)) {
+    reasons.push("scenarios_passed_invalid");
+  }
+  if (
+    typeof result.scenarios_total === "number"
+    && typeof result.scenarios_passed === "number"
+    && Number.isFinite(result.scenarios_total)
+    && Number.isFinite(result.scenarios_passed)
+    && result.scenarios_passed !== result.scenarios_total
+  ) {
+    reasons.push("scenarios_passed_not_equal_total");
+  }
+
+  // Defense-in-depth: status=passed must have an empty blocked_reasons.
+  // Even if a future writer were to mark status=passed alongside blockers,
+  // the validator rejects.
+  const blocked = Array.isArray(result.blocked_reasons) ? result.blocked_reasons : null;
+  if (blocked === null) {
+    reasons.push("blocked_reasons_invalid");
+  } else if (
+    result.status === REAL_GREEN_GATE_RESULT_STATUSES.PASSED
+    && blocked.length > 0
+  ) {
+    reasons.push("passed_with_blocked_reasons");
+  }
+
+  // scenarios_total must be > 0 for a credible pass; a "passed" with zero
+  // scenarios is structurally meaningless and often indicates a skipped path.
+  if (
+    result.status === REAL_GREEN_GATE_RESULT_STATUSES.PASSED
+    && typeof result.scenarios_total === "number"
+    && result.scenarios_total === 0
+  ) {
+    reasons.push("passed_with_zero_scenarios");
+  }
+
+  return { valid: reasons.length === 0, reasons };
+}

--- a/scripts/ops/lib/real-green-gate-result.mjs
+++ b/scripts/ops/lib/real-green-gate-result.mjs
@@ -157,6 +157,10 @@ function isPlainObject(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function isNonNegativeInteger(value) {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
+}
+
 /**
  * Validate a parsed result object. Returns { valid, reasons }. Reasons are
  * stable token strings; they never embed validator free-text from the input.
@@ -191,20 +195,36 @@ export function validateRealGreenGateResult(result, options = {}) {
     }
   }
 
-  if (typeof result.scenarios_total !== "number" || !Number.isFinite(result.scenarios_total)) {
+  // All three counts must be non-negative integers. Number.isFinite alone is
+  // not enough — it accepts negatives and decimals, which are structurally
+  // meaningless and would let a malformed `passed` artifact slip through
+  // (PR #187 review caught: status=passed with all counts = -1 was accepted).
+  const scenariosRunValid = isNonNegativeInteger(result.scenarios_run);
+  const scenariosTotalValid = isNonNegativeInteger(result.scenarios_total);
+  const scenariosPassedValid = isNonNegativeInteger(result.scenarios_passed);
+
+  if (!scenariosRunValid) {
+    reasons.push("scenarios_run_invalid");
+  }
+  if (!scenariosTotalValid) {
     reasons.push("scenarios_total_invalid");
   }
-  if (typeof result.scenarios_passed !== "number" || !Number.isFinite(result.scenarios_passed)) {
+  if (!scenariosPassedValid) {
     reasons.push("scenarios_passed_invalid");
   }
   if (
-    typeof result.scenarios_total === "number"
-    && typeof result.scenarios_passed === "number"
-    && Number.isFinite(result.scenarios_total)
-    && Number.isFinite(result.scenarios_passed)
+    scenariosTotalValid
+    && scenariosPassedValid
     && result.scenarios_passed !== result.scenarios_total
   ) {
     reasons.push("scenarios_passed_not_equal_total");
+  }
+  if (
+    scenariosTotalValid
+    && scenariosRunValid
+    && result.scenarios_run !== result.scenarios_total
+  ) {
+    reasons.push("scenarios_run_not_equal_total");
   }
 
   // Defense-in-depth: status=passed must have an empty blocked_reasons.
@@ -224,7 +244,7 @@ export function validateRealGreenGateResult(result, options = {}) {
   // scenarios is structurally meaningless and often indicates a skipped path.
   if (
     result.status === REAL_GREEN_GATE_RESULT_STATUSES.PASSED
-    && typeof result.scenarios_total === "number"
+    && scenariosTotalValid
     && result.scenarios_total === 0
   ) {
     reasons.push("passed_with_zero_scenarios");

--- a/scripts/ops/run-real-green-gate.mjs
+++ b/scripts/ops/run-real-green-gate.mjs
@@ -8,6 +8,10 @@ import { collectEnvironmentTruth } from "../../validation/real-world/lib/env-tru
 import { createRunId, ensureDir, writeJson, writeText } from "../../validation/real-world/lib/io.mjs";
 import { runRealWorldValidation } from "../../validation/real-world/lib/runner.mjs";
 import { checkBranchConformance } from "./check-branch-conformance.mjs";
+import {
+  REAL_GREEN_GATE_RESULT_FILENAME,
+  buildRealGreenGateResult,
+} from "./lib/real-green-gate-result.mjs";
 
 const DAILY_CORE_SCENARIOS = [
   "l0-runtime-health",
@@ -447,6 +451,19 @@ function buildSummary({
 function flushTerminalArtifacts(reportRoot, summary) {
   writeJson(path.join(reportRoot, "summary.json"), summary);
   writeText(path.join(reportRoot, "index.md"), renderMarkdown(summary));
+  const commitSha = process.env.GITHUB_SHA
+    ?? (typeof summary?.preflight?.gitHead?.stdout === "string"
+      ? summary.preflight.gitHead.stdout.trim()
+      : "");
+  const refName = process.env.GITHUB_REF_NAME
+    ?? (typeof summary?.branch === "string" ? summary.branch : "");
+  const result = buildRealGreenGateResult({
+    summary,
+    commitSha,
+    refName,
+    evaluatedAt: new Date().toISOString(),
+  });
+  writeJson(path.join(reportRoot, REAL_GREEN_GATE_RESULT_FILENAME), result);
 }
 
 async function main() {

--- a/scripts/ops/validate-real-green-gate-result.mjs
+++ b/scripts/ops/validate-real-green-gate-result.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+
+/**
+ * CLI validator for the Real Green Gate result artifact.
+ *
+ * Usage:
+ *   node scripts/ops/validate-real-green-gate-result.mjs \
+ *     --path <real-green-gate-result.json> \
+ *     [--expected-sha <40-char-hex>]
+ *
+ * Exits 0 only when the artifact validates as a clean release-proof pass.
+ * Exits 1 otherwise. Stdout always carries a JSON object describing the
+ * decision; rejection reasons are stable token strings (no validator
+ * free-text).
+ *
+ * P4-G1.1: this CLI is intentionally NOT yet invoked from any workflow.
+ * `.github/workflows/release.yml` is left untouched in this subphase. The
+ * downstream P4-G1.2 subphase will wire this CLI into a release-time gate.
+ */
+
+import { readFileSync } from "node:fs";
+import {
+  REAL_GREEN_GATE_RESULT_FILENAME,
+  validateRealGreenGateResult,
+} from "./lib/real-green-gate-result.mjs";
+
+function parseArgs(argv) {
+  const args = { path: null, expectedSha: null };
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    const next = argv[index + 1];
+    if (token === "--path" && typeof next === "string") {
+      args.path = next;
+      index += 1;
+    } else if (token === "--expected-sha" && typeof next === "string") {
+      args.expectedSha = next;
+      index += 1;
+    }
+  }
+  return args;
+}
+
+function emit(decision) {
+  process.stdout.write(`${JSON.stringify(decision, null, 2)}\n`);
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (!args.path) {
+    emit({
+      valid: false,
+      reasons: ["cli_argument_missing:path"],
+      hint: `Pass --path <path-to-${REAL_GREEN_GATE_RESULT_FILENAME}>`,
+    });
+    process.exit(1);
+  }
+
+  let raw;
+  try {
+    raw = readFileSync(args.path, "utf8");
+  } catch (err) {
+    const code = err && typeof err === "object" && "code" in err ? String(err.code) : "unknown";
+    emit({
+      valid: false,
+      reasons: [`artifact_unreadable:${code}`],
+      path: args.path,
+    });
+    process.exit(1);
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    emit({
+      valid: false,
+      reasons: ["artifact_invalid_json"],
+      path: args.path,
+    });
+    process.exit(1);
+  }
+
+  const decision = validateRealGreenGateResult(parsed, {
+    expectedSha: args.expectedSha ?? undefined,
+  });
+
+  emit({
+    valid: decision.valid,
+    reasons: decision.reasons,
+    path: args.path,
+    expected_sha: args.expectedSha ?? null,
+    observed_sha: typeof parsed?.commit_sha === "string" ? parsed.commit_sha : null,
+    observed_status: typeof parsed?.status === "string" ? parsed.status : null,
+  });
+
+  process.exit(decision.valid ? 0 : 1);
+}
+
+main();

--- a/test/unit/ops/real-green-gate-result.test.ts
+++ b/test/unit/ops/real-green-gate-result.test.ts
@@ -312,6 +312,101 @@ describe("validateRealGreenGateResult — accepts only a clean pass", () => {
     expect(decision.valid).toBe(false);
     expect(decision.reasons).toContain("passed_with_zero_scenarios");
   });
+
+  it("PR #187 review regression: rejects status=passed with all three counts = -1", () => {
+    // The exact malformed artifact that an earlier validator wrongly accepted:
+    // -1 is finite and -1 === -1, so the previous finite/equality checks were
+    // both satisfied. The non-negative-integer check now catches all three.
+    const decision = validateRealGreenGateResult(
+      validPassedResult({ scenarios_run: -1, scenarios_total: -1, scenarios_passed: -1 }),
+    );
+    expect(decision.valid).toBe(false);
+    expect(decision.reasons).toContain("scenarios_run_invalid");
+    expect(decision.reasons).toContain("scenarios_total_invalid");
+    expect(decision.reasons).toContain("scenarios_passed_invalid");
+  });
+
+  it("rejects negative scenarios_total", () => {
+    const decision = validateRealGreenGateResult(
+      validPassedResult({ scenarios_total: -1, scenarios_passed: 47, scenarios_run: 47 }),
+    );
+    expect(decision.valid).toBe(false);
+    expect(decision.reasons).toContain("scenarios_total_invalid");
+  });
+
+  it("rejects negative scenarios_passed", () => {
+    const decision = validateRealGreenGateResult(
+      validPassedResult({ scenarios_total: 47, scenarios_passed: -1, scenarios_run: 47 }),
+    );
+    expect(decision.valid).toBe(false);
+    expect(decision.reasons).toContain("scenarios_passed_invalid");
+  });
+
+  it("rejects negative scenarios_run", () => {
+    const decision = validateRealGreenGateResult(
+      validPassedResult({ scenarios_total: 47, scenarios_passed: 47, scenarios_run: -1 }),
+    );
+    expect(decision.valid).toBe(false);
+    expect(decision.reasons).toContain("scenarios_run_invalid");
+  });
+
+  it("rejects decimal scenarios_total", () => {
+    const decision = validateRealGreenGateResult(
+      validPassedResult({ scenarios_total: 47.5, scenarios_passed: 47.5, scenarios_run: 47.5 }),
+    );
+    expect(decision.valid).toBe(false);
+    expect(decision.reasons).toContain("scenarios_total_invalid");
+  });
+
+  it("rejects decimal scenarios_passed", () => {
+    const decision = validateRealGreenGateResult(
+      validPassedResult({ scenarios_total: 47, scenarios_passed: 46.5, scenarios_run: 47 }),
+    );
+    expect(decision.valid).toBe(false);
+    expect(decision.reasons).toContain("scenarios_passed_invalid");
+  });
+
+  it("rejects decimal scenarios_run", () => {
+    const decision = validateRealGreenGateResult(
+      validPassedResult({ scenarios_total: 47, scenarios_passed: 47, scenarios_run: 46.5 }),
+    );
+    expect(decision.valid).toBe(false);
+    expect(decision.reasons).toContain("scenarios_run_invalid");
+  });
+
+  it("rejects when scenarios_run !== scenarios_total even if both are valid non-negative integers", () => {
+    // status=passed implies the gate ran every expected scenario.
+    // run=5 + total=10 + passed=10 is structurally impossible (passed cannot
+    // exceed run); the validator rejects with scenarios_run_not_equal_total.
+    const decision = validateRealGreenGateResult(
+      validPassedResult({ scenarios_run: 5, scenarios_total: 10, scenarios_passed: 10 }),
+    );
+    expect(decision.valid).toBe(false);
+    expect(decision.reasons).toContain("scenarios_run_not_equal_total");
+  });
+
+  it("accepts zero as a valid non-negative integer for non-passed statuses", () => {
+    // blocked_by_env writes all three counts as 0; the integer check should
+    // accept 0 as valid, even though the artifact still gets rejected because
+    // status !== passed.
+    const decision = validateRealGreenGateResult({
+      schema_version: 1,
+      status: "blocked_by_env",
+      commit_sha: SHA_A,
+      ref_name: "main",
+      evaluated_at: "2026-05-10T07:00:00.000Z",
+      evidence_kinds_observed: [],
+      blocked_reasons: ["env_var_missing:FRIDAY_BASE_URL"],
+      scenarios_run: 0,
+      scenarios_total: 0,
+      scenarios_passed: 0,
+    });
+    expect(decision.valid).toBe(false);
+    expect(decision.reasons).toEqual(["status_not_passed:blocked_by_env"]);
+    expect(decision.reasons).not.toContain("scenarios_run_invalid");
+    expect(decision.reasons).not.toContain("scenarios_total_invalid");
+    expect(decision.reasons).not.toContain("scenarios_passed_invalid");
+  });
 });
 
 describe("validator round-trip with the writers", () => {

--- a/test/unit/ops/real-green-gate-result.test.ts
+++ b/test/unit/ops/real-green-gate-result.test.ts
@@ -1,0 +1,352 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  REAL_GREEN_GATE_RESULT_FILENAME,
+  REAL_GREEN_GATE_RESULT_SCHEMA_VERSION,
+  REAL_GREEN_GATE_RESULT_STATUSES,
+  buildBlockedByEnvResult,
+  buildRealGreenGateResult,
+  validateRealGreenGateResult,
+} from "../../../scripts/ops/lib/real-green-gate-result.mjs";
+
+const SHA_A = "a".repeat(40);
+const SHA_B = "b".repeat(40);
+
+function passingSummary() {
+  return {
+    runId: "run-id",
+    branch: "main",
+    error: null,
+    preflight: {
+      gitHead: { stdout: `${SHA_A}\n` },
+    },
+    smoke: {
+      resultCounts: { passed: 4 },
+    },
+    dailyCore: {
+      resultCounts: { passed: 14 },
+    },
+    publicSurface: {
+      resultCounts: { passed: 29 },
+    },
+    gate: {
+      passed: true,
+      reasons: [],
+    },
+  };
+}
+
+function failingSummary(reasons: string[] = ["smoke suite is not fully passed"]) {
+  return {
+    ...passingSummary(),
+    smoke: {
+      resultCounts: { passed: 3, failed: 1 },
+    },
+    gate: {
+      passed: false,
+      reasons,
+    },
+  };
+}
+
+function erroredSummary() {
+  return {
+    ...passingSummary(),
+    error: { phase: "smoke", message: "timeout" },
+    gate: {
+      passed: false,
+      reasons: ["smoke suite did not complete"],
+    },
+  };
+}
+
+describe("REAL_GREEN_GATE_RESULT constants", () => {
+  it("exposes the filename constant for the artifact path", () => {
+    expect(REAL_GREEN_GATE_RESULT_FILENAME).toBe("real-green-gate-result.json");
+  });
+
+  it("pins the schema version at 1", () => {
+    expect(REAL_GREEN_GATE_RESULT_SCHEMA_VERSION).toBe(1);
+  });
+
+  it("freezes the status enum and exposes the four canonical states", () => {
+    expect(REAL_GREEN_GATE_RESULT_STATUSES).toEqual({
+      PASSED: "passed",
+      FAILED: "failed",
+      BLOCKED_BY_ENV: "blocked_by_env",
+      ERRORED: "errored",
+    });
+    expect(Object.isFrozen(REAL_GREEN_GATE_RESULT_STATUSES)).toBe(true);
+  });
+});
+
+describe("buildRealGreenGateResult", () => {
+  it("returns status=passed with full evidence kinds when the gate passed", () => {
+    const result = buildRealGreenGateResult({
+      summary: passingSummary(),
+      commitSha: SHA_A,
+      refName: "main",
+      evaluatedAt: "2026-05-10T07:00:00.000Z",
+    });
+    expect(result).toEqual({
+      schema_version: 1,
+      status: "passed",
+      commit_sha: SHA_A,
+      ref_name: "main",
+      evaluated_at: "2026-05-10T07:00:00.000Z",
+      evidence_kinds_observed: ["real-runtime", "real-provider", "real-browser"],
+      blocked_reasons: [],
+      scenarios_run: 47,
+      scenarios_total: 47,
+      scenarios_passed: 47,
+    });
+  });
+
+  it("returns status=failed and empty evidence kinds when the gate did not pass", () => {
+    const result = buildRealGreenGateResult({
+      summary: failingSummary(),
+      commitSha: SHA_A,
+      refName: "main",
+      evaluatedAt: "2026-05-10T07:00:00.000Z",
+    });
+    expect(result.status).toBe("failed");
+    expect(result.evidence_kinds_observed).toEqual([]);
+    expect(result.blocked_reasons).toEqual(["smoke suite is not fully passed"]);
+    expect(result.scenarios_run).toBe(47);
+    expect(result.scenarios_total).toBe(47);
+    expect(result.scenarios_passed).toBe(46);
+  });
+
+  it("returns status=errored when the summary carries a terminal error", () => {
+    const result = buildRealGreenGateResult({
+      summary: erroredSummary(),
+      commitSha: SHA_A,
+      refName: "main",
+      evaluatedAt: "2026-05-10T07:00:00.000Z",
+    });
+    expect(result.status).toBe("errored");
+    expect(result.evidence_kinds_observed).toEqual([]);
+    expect(result.blocked_reasons).toContain("smoke suite did not complete");
+  });
+
+  it("coerces missing commitSha / refName / evaluatedAt to empty strings without throwing", () => {
+    const result = buildRealGreenGateResult({
+      summary: passingSummary(),
+      commitSha: undefined as unknown as string,
+      refName: undefined as unknown as string,
+      evaluatedAt: undefined as unknown as string,
+    });
+    expect(result.commit_sha).toBe("");
+    expect(result.ref_name).toBe("");
+    expect(result.evaluated_at).toBe("");
+  });
+});
+
+describe("buildBlockedByEnvResult", () => {
+  it("emits status=blocked_by_env with zero scenarios and empty evidence", () => {
+    const result = buildBlockedByEnvResult({
+      commitSha: SHA_A,
+      refName: "main",
+      evaluatedAt: "2026-05-10T07:00:00.000Z",
+      blockedReasons: ["env_var_missing:FRIDAY_BASE_URL"],
+    });
+    expect(result).toEqual({
+      schema_version: 1,
+      status: "blocked_by_env",
+      commit_sha: SHA_A,
+      ref_name: "main",
+      evaluated_at: "2026-05-10T07:00:00.000Z",
+      evidence_kinds_observed: [],
+      blocked_reasons: ["env_var_missing:FRIDAY_BASE_URL"],
+      scenarios_run: 0,
+      scenarios_total: 0,
+      scenarios_passed: 0,
+    });
+  });
+
+  it("filters out non-string blocked reasons defensively", () => {
+    const result = buildBlockedByEnvResult({
+      commitSha: SHA_A,
+      refName: "main",
+      evaluatedAt: "2026-05-10T07:00:00.000Z",
+      blockedReasons: [
+        "env_var_missing:FRIDAY_BASE_URL",
+        "",
+        null as unknown as string,
+        42 as unknown as string,
+        "env_var_missing:FRIDAY_ACCESS_TOKEN",
+      ],
+    });
+    expect(result.blocked_reasons).toEqual([
+      "env_var_missing:FRIDAY_BASE_URL",
+      "env_var_missing:FRIDAY_ACCESS_TOKEN",
+    ]);
+  });
+});
+
+describe("validateRealGreenGateResult — accepts only a clean pass", () => {
+  function validPassedResult(overrides: Record<string, unknown> = {}) {
+    return {
+      schema_version: 1,
+      status: "passed",
+      commit_sha: SHA_A,
+      ref_name: "main",
+      evaluated_at: "2026-05-10T07:00:00.000Z",
+      evidence_kinds_observed: ["real-runtime", "real-provider", "real-browser"],
+      blocked_reasons: [],
+      scenarios_run: 47,
+      scenarios_total: 47,
+      scenarios_passed: 47,
+      ...overrides,
+    };
+  }
+
+  it("accepts a well-formed passed result", () => {
+    const decision = validateRealGreenGateResult(validPassedResult());
+    expect(decision).toEqual({ valid: true, reasons: [] });
+  });
+
+  it("rejects a non-object input", () => {
+    const decision = validateRealGreenGateResult("not an object" as unknown);
+    expect(decision.valid).toBe(false);
+    expect(decision.reasons).toContain("not_an_object");
+  });
+
+  it("rejects an unsupported schema_version", () => {
+    const decision = validateRealGreenGateResult(validPassedResult({ schema_version: 2 }));
+    expect(decision.valid).toBe(false);
+    expect(decision.reasons).toContain("unsupported_schema_version");
+  });
+
+  it("rejects an unknown status string", () => {
+    const decision = validateRealGreenGateResult(validPassedResult({ status: "almost_passed" }));
+    expect(decision.valid).toBe(false);
+    expect(decision.reasons).toContain("status_invalid_or_missing");
+  });
+
+  it("rejects status=blocked_by_env even if everything else looks plausible", () => {
+    const decision = validateRealGreenGateResult({
+      schema_version: 1,
+      status: "blocked_by_env",
+      commit_sha: SHA_A,
+      ref_name: "main",
+      evaluated_at: "2026-05-10T07:00:00.000Z",
+      evidence_kinds_observed: [],
+      blocked_reasons: ["env_var_missing:FRIDAY_BASE_URL"],
+      scenarios_run: 0,
+      scenarios_total: 0,
+      scenarios_passed: 0,
+    });
+    expect(decision.valid).toBe(false);
+    expect(decision.reasons).toContain("status_not_passed:blocked_by_env");
+  });
+
+  it("rejects status=failed", () => {
+    const decision = validateRealGreenGateResult(validPassedResult({ status: "failed" }));
+    expect(decision.valid).toBe(false);
+    expect(decision.reasons).toContain("status_not_passed:failed");
+  });
+
+  it("rejects status=errored", () => {
+    const decision = validateRealGreenGateResult(validPassedResult({ status: "errored" }));
+    expect(decision.valid).toBe(false);
+    expect(decision.reasons).toContain("status_not_passed:errored");
+  });
+
+  it("rejects when commit_sha is missing", () => {
+    const decision = validateRealGreenGateResult(validPassedResult({ commit_sha: "" }));
+    expect(decision.valid).toBe(false);
+    expect(decision.reasons).toContain("commit_sha_missing");
+  });
+
+  it("rejects when expectedSha is provided and commit_sha does not match", () => {
+    const decision = validateRealGreenGateResult(validPassedResult(), { expectedSha: SHA_B });
+    expect(decision.valid).toBe(false);
+    expect(decision.reasons).toContain("commit_sha_mismatch");
+  });
+
+  it("accepts when expectedSha matches commit_sha exactly", () => {
+    const decision = validateRealGreenGateResult(validPassedResult(), { expectedSha: SHA_A });
+    expect(decision).toEqual({ valid: true, reasons: [] });
+  });
+
+  it("rejects when scenarios_passed !== scenarios_total", () => {
+    const decision = validateRealGreenGateResult(
+      validPassedResult({ scenarios_total: 47, scenarios_passed: 46 }),
+    );
+    expect(decision.valid).toBe(false);
+    expect(decision.reasons).toContain("scenarios_passed_not_equal_total");
+  });
+
+  it("rejects when scenarios_total or scenarios_passed are not finite numbers", () => {
+    const decision = validateRealGreenGateResult(
+      validPassedResult({ scenarios_total: "47" as unknown, scenarios_passed: null as unknown }),
+    );
+    expect(decision.valid).toBe(false);
+    expect(decision.reasons).toContain("scenarios_total_invalid");
+    expect(decision.reasons).toContain("scenarios_passed_invalid");
+  });
+
+  it("rejects when blocked_reasons is not an array", () => {
+    const decision = validateRealGreenGateResult(
+      validPassedResult({ blocked_reasons: null as unknown }),
+    );
+    expect(decision.valid).toBe(false);
+    expect(decision.reasons).toContain("blocked_reasons_invalid");
+  });
+
+  it("security regression: rejects status=passed when blocked_reasons is non-empty", () => {
+    // Defense-in-depth: even if a future writer marked status=passed alongside
+    // a non-empty blocked_reasons, the validator must reject.
+    const decision = validateRealGreenGateResult(
+      validPassedResult({ blocked_reasons: ["env_var_missing:FRIDAY_BASE_URL"] }),
+    );
+    expect(decision.valid).toBe(false);
+    expect(decision.reasons).toContain("passed_with_blocked_reasons");
+  });
+
+  it("rejects status=passed with zero scenarios", () => {
+    const decision = validateRealGreenGateResult(
+      validPassedResult({ scenarios_total: 0, scenarios_passed: 0, scenarios_run: 0 }),
+    );
+    expect(decision.valid).toBe(false);
+    expect(decision.reasons).toContain("passed_with_zero_scenarios");
+  });
+});
+
+describe("validator round-trip with the writers", () => {
+  it("a passed summary round-trips through builder + validator successfully", () => {
+    const built = buildRealGreenGateResult({
+      summary: passingSummary(),
+      commitSha: SHA_A,
+      refName: "main",
+      evaluatedAt: "2026-05-10T07:00:00.000Z",
+    });
+    const decision = validateRealGreenGateResult(built, { expectedSha: SHA_A });
+    expect(decision).toEqual({ valid: true, reasons: [] });
+  });
+
+  it("a blocked_by_env artifact is rejected by the validator", () => {
+    const built = buildBlockedByEnvResult({
+      commitSha: SHA_A,
+      refName: "main",
+      evaluatedAt: "2026-05-10T07:00:00.000Z",
+      blockedReasons: ["env_var_missing:FRIDAY_BASE_URL"],
+    });
+    const decision = validateRealGreenGateResult(built, { expectedSha: SHA_A });
+    expect(decision.valid).toBe(false);
+    expect(decision.reasons).toContain("status_not_passed:blocked_by_env");
+  });
+
+  it("a failing summary is rejected with a non-passed status reason", () => {
+    const built = buildRealGreenGateResult({
+      summary: failingSummary(),
+      commitSha: SHA_A,
+      refName: "main",
+      evaluatedAt: "2026-05-10T07:00:00.000Z",
+    });
+    const decision = validateRealGreenGateResult(built, { expectedSha: SHA_A });
+    expect(decision.valid).toBe(false);
+    expect(decision.reasons).toContain("status_not_passed:failed");
+  });
+});


### PR DESCRIPTION
## Summary

P4-G1.1 introduces a machine-readable JSON artifact that captures the outcome of `npm run ops:real-green-gate` (and its CI workflow skip path), plus a pure validator and CLI wrapper, so a future release-time gate (P4-G1.2 — **not in this subphase**) can decide ship eligibility from the artifact's `status` field alone, not from the workflow exit code. Per `docs/release-evidence-policy.md` line 36: a live lane blocked by env should never silently count as pass; this artifact makes that machine-explicit.

This subphase is **artifact + validator only**. `.github/workflows/release.yml` is intentionally untouched. The CLI is built but not yet invoked from any workflow. P4-G1.2 will wire the validator into a release-time gate as a separate review/approval cycle.

## Files

- `scripts/ops/lib/real-green-gate-result.mjs` — NEW pure ESM module: schema constants, `buildRealGreenGateResult()` (success/fail/error path), `buildBlockedByEnvResult()` (skip path), `validateRealGreenGateResult()` parser/validator. No I/O imports.
- `scripts/ops/validate-real-green-gate-result.mjs` — NEW thin CLI wrapper: `node scripts/ops/validate-real-green-gate-result.mjs --path <json> [--expected-sha <sha>]`. Exits 0 on clean pass, 1 otherwise.
- `test/unit/ops/real-green-gate-result.test.ts` — NEW vitest matrix (27 cases) covering each writer path, every validator rejection rule, security regression, and round-trip.
- `scripts/ops/run-real-green-gate.mjs` — MODIFY: `flushTerminalArtifacts` also writes the structured JSON.
- `.github/workflows/real-green-gate.yml` — MODIFY: skip-path step also emits the artifact via the lib's `buildBlockedByEnvResult` (single source of truth).

## Schema (snake_case per spec)

```jsonc
{
  "schema_version": 1,
  "status": "passed" | "failed" | "blocked_by_env" | "errored",
  "commit_sha": "<40-char hex or '' if unknown>",
  "ref_name": "<git ref name>",
  "evaluated_at": "<ISO 8601>",
  "evidence_kinds_observed": ["real-runtime", "real-provider", "real-browser"],
  "blocked_reasons": ["..."],
  "scenarios_run": <int>,
  "scenarios_total": <int>,
  "scenarios_passed": <int>
}
```

## Validator rejection rules

The validator rejects: `not_an_object`, `unsupported_schema_version`, `status_invalid_or_missing`, `status_not_passed:<status>` (covers blocked_by_env / failed / errored), `commit_sha_missing`, `commit_sha_mismatch` (when `expectedSha` provided), `scenarios_total_invalid`, `scenarios_passed_invalid`, `scenarios_passed_not_equal_total`, `blocked_reasons_invalid`, `passed_with_blocked_reasons` (defense-in-depth — even if a future writer marked status=passed alongside blockers, validator rejects), `passed_with_zero_scenarios`.

Per d-G1.2 the validator does NOT enforce a specific evidence-kind tier policy — that policy stays in `docs/release-evidence-policy.md`.

## Constraints respected

- d-G1.1: strict same-SHA only.
- d-G1.2: no tier-count thresholds hardcoded.
- d-G1.3: no manual override / break-glass / FAST_MODE bypass anywhere.
- d-G1.4: enforce-only; no shadow-warn; no path that turns blocked_by_env into pass.
- No `release.yml` mutation.
- No `docs/audit/10_FINDINGS_REGISTER.md` mutation.
- No capability proof work (channel/desktop/observability/multi-tenant/packaging untouched).
- Lib is pure (no `node:fs` / `node:child_process`); I/O isolated in CLI + run-real-green-gate.mjs.
- Single source of truth: workflow skip path imports the lib's `buildBlockedByEnvResult` rather than hand-rolling JSON.

## Test plan

- [x] `npm run typecheck` — pass
- [x] `npm run lint` — 0 findings on touched/new files
- [x] `npx vitest run test/unit/ops/real-green-gate-result.test.ts` — 27/27
- [x] `npm run check:secret-patterns` — clean (re-run post-stage; new files contain only synthetic SHAs)
- [x] `git diff --check` — clean
- [x] CLI smoke: rejects blocked_by_env (exit 1); accepts clean pass with matching SHA (exit 0); rejects SHA mismatch (exit 1)
- [x] Workflow inline-node smoke: produces correct JSON via lib's `buildBlockedByEnvResult`
- [x] Two isolated read-only reviewers — PASS / PASS (closure correctness + parity; regression risk + workflow YAML + secret discipline)
- [x] Remote `Real Green Gate` (push trigger) on the new branch — pass in 27s on the SKIP path (which now correctly emits `status: blocked_by_env` artifact — a future release-time gate would correctly reject it)
- [ ] P4-G1.2 release-time gate wiring — separate subphase; awaiting your approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)