### PR TITLE
P4-G1.2: live-proof-gate in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  actions: read
 
 jobs:
   public-preflight:
@@ -21,6 +22,7 @@ jobs:
     timeout-minutes: 20
     outputs:
       tag_name: ${{ steps.resolve_tag.outputs.tag_name }}
+      tag_sha: ${{ steps.resolve_tag_sha.outputs.tag_sha }}
 
     steps:
       - name: Checkout
@@ -47,6 +49,18 @@ jobs:
             echo "::error::Tag must match v<semver> (for example: v0.3.1)"
             exit 1
           fi
+
+      - name: Resolve tag SHA
+        id: resolve_tag_sha
+        run: |
+          set -euo pipefail
+          # ^{commit} forces resolution to the underlying commit object even
+          # when TAG_NAME points to an annotated tag object. The downstream
+          # live-proof-gate uses this SHA to find the Real Green Gate run for
+          # this exact commit (P4-G1.1 strict same-SHA validator contract).
+          TAG_SHA="$(git rev-parse "${TAG_NAME}^{commit}")"
+          echo "tag_sha=${TAG_SHA}" >> "${GITHUB_OUTPUT}"
+          echo "Resolved ${TAG_NAME} to commit ${TAG_SHA}"
 
       - name: Setup Node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -132,8 +146,76 @@ jobs:
       - name: Final closeout
         run: npm run closeout:final
 
+  live-proof-gate:
+    needs:
+      - public-preflight
+      - verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
+      TAG_NAME: ${{ needs.public-preflight.outputs.tag_name }}
+      TAG_SHA: ${{ needs.public-preflight.outputs.tag_sha }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.public-preflight.outputs.tag_name }}
+
+      - name: Setup Node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 22
+
+      - name: Find Real Green Gate run for tag SHA
+        id: find_run
+        run: |
+          set -euo pipefail
+          if [ -z "${TAG_SHA}" ]; then
+            echo "::error::tag_sha output from public-preflight is empty; cannot locate Real Green Gate run."
+            exit 1
+          fi
+          # Workflow file path is the source of truth (per d-G1.2.2). Pulls the
+          # workflow-specific runs endpoint, filtered to successful runs on the
+          # exact tag SHA. GitHub returns runs sorted by created_at desc, so
+          # .workflow_runs[0] is the most recent successful run.
+          RUN_ID="$(gh api -X GET "repos/${GITHUB_REPOSITORY}/actions/workflows/real-green-gate.yml/runs" -f head_sha="${TAG_SHA}" -f status=success --jq '.workflow_runs[0].id // empty')"
+          if [ -z "${RUN_ID}" ]; then
+            echo "::error::No successful Real Green Gate run found on commit ${TAG_SHA} (tag ${TAG_NAME})."
+            echo "::error::Run \"gh workflow run real-green-gate.yml -r ${TAG_NAME}\" to generate release proof on this commit, then re-run this release workflow. (P4-G1.4: no auto-trigger; no break-glass.)"
+            exit 1
+          fi
+          echo "Found Real Green Gate run ${RUN_ID} for commit ${TAG_SHA}"
+          echo "run_id=${RUN_ID}" >> "${GITHUB_OUTPUT}"
+
+      - name: Download Real Green Gate artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: real-green-gate-${{ steps.find_run.outputs.run_id }}
+          path: ./real-green-gate-download
+          run-id: ${{ steps.find_run.outputs.run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Validate Real Green Gate result
+        run: |
+          set -euo pipefail
+          ARTIFACT_PATH="./real-green-gate-download/real-green-gate-result.json"
+          if [ ! -f "${ARTIFACT_PATH}" ]; then
+            echo "::error::Expected artifact file ${ARTIFACT_PATH} is not present after download. The Real Green Gate run may have published a different artifact shape, or the artifact has expired (default GitHub Actions retention is 90 days). Re-run the Real Green Gate workflow on commit ${TAG_SHA} to regenerate."
+            exit 1
+          fi
+          # Validator is the P4-G1.1 stable-token CLI. Exit 0 only on a clean
+          # release-proof pass: status=passed AND scenarios consistent AND
+          # blocked_reasons empty AND commit_sha matches expected. The CLI
+          # prints its own structured rejection JSON to stdout on failure.
+          node scripts/ops/validate-real-green-gate-result.mjs --path "${ARTIFACT_PATH}" --expected-sha "${TAG_SHA}"
+
   source-distribution:
-    needs: verify
+    needs:
+      - verify
+      - live-proof-gate
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -168,7 +250,9 @@ jobs:
           path: dist/releases/source
 
   macos-distribution:
-    needs: verify
+    needs:
+      - verify
+      - live-proof-gate
     runs-on: macos-latest
     timeout-minutes: 45
 
@@ -217,7 +301,9 @@ jobs:
             dist/releases/homebrew
 
   publish-npm:
-    needs: verify
+    needs:
+      - verify
+      - live-proof-gate
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -271,6 +357,7 @@ jobs:
   create-release:
     needs:
       - verify
+      - live-proof-gate
       - source-distribution
       - macos-distribution
       - publish-npm


### PR DESCRIPTION
## Summary

P4-G1.2 closes the release-governance gap from the P4 audit: `release.yml` previously published artifacts after only the contract / static `closeout:final` chain in the `verify` job, with no requirement that real-runtime / real-provider / real-browser proof had ever exercised the exact commit being released. Per `docs/release-evidence-policy.md` line 36, a live lane blocked by env should never silently count as pass; this PR makes that machine-enforced at release time.

This PR uses the structured artifact + validator CLI from PR #187 (P4-G1.1, already merged into `main` as `c05111a3`).

## What changed

- **Top-level `permissions:`** add `actions: read` (kept `contents: write` + `id-token: write` exactly as before).
- **`public-preflight`**: new `tag_sha` output + new `Resolve tag SHA` step using `git rev-parse "${TAG_NAME}^{commit}"` (the `^{commit}` suffix forces resolution to the underlying commit object even when the tag is annotated). Existing `tag_name` output unchanged.
- **NEW `live-proof-gate` job** between `verify` and the publishing jobs:
  - `needs: [public-preflight, verify]`
  - `env:` sets `GH_TOKEN: ${{ github.token }}`, `TAG_NAME`, `TAG_SHA`
  - Step 1: Find Real Green Gate run via `gh api -X GET "repos/${GITHUB_REPOSITORY}/actions/workflows/real-green-gate.yml/runs" -f head_sha="${TAG_SHA}" -f status=success --jq '.workflow_runs[0].id // empty'`
  - Step 2: Cross-workflow download via `actions/download-artifact@v4` with `run-id` + `github-token`
  - Step 3: Validate via `node scripts/ops/validate-real-green-gate-result.mjs --path ./real-green-gate-download/real-green-gate-result.json --expected-sha "${TAG_SHA}"`
  - Three explicit `::error::` messages on each failure path with operator instruction (e.g., `gh workflow run real-green-gate.yml -r <tag>`)
- **Publishing jobs** `needs:` expanded to include `live-proof-gate`: `source-distribution`, `macos-distribution`, `publish-npm`, `create-release`.

## Constraints respected

- d-G1.1 strict same-SHA via `--expected-sha "${TAG_SHA}"` + `^{commit}` resolution.
- d-G1.2 workflow file path (not name); validator handles status/scenarios consistency; tier policy stays in `docs/release-evidence-policy.md`.
- d-G1.3 only `actions: read` added; existing `contents: write` and `id-token: write` preserved.
- d-G1.4 enforce-only: no auto-trigger / no self-healing rerun / no break-glass / no FAST_MODE / no shadow-warn.
- d-G1.5 no actor check on Real Green Gate runs — deferred to P4-G1.3.
- Touched ONLY `.github/workflows/release.yml`. P4-G1.1 lib / CLI / tests / `real-green-gate.yml` / `docs/audit/10_FINDINGS_REGISTER.md` / capability proof files all UNTOUCHED.
- Existing `verify` job's `closeout:final` chain preserved verbatim (the gate is additive, not replacement).
- All bash steps use `set -euo pipefail`; user-controlled values flow via `env:` block, never directly interpolated into shell bodies.

## Test plan

- [x] YAML parses cleanly (`python3 -c "yaml.safe_load(open('.github/workflows/release.yml'))"` — 7 jobs in correct order)
- [x] `git diff --check` — clean
- [x] `npm run check:secret-patterns` — clean
- [x] Two isolated read-only reviewers — PASS / PASS (closure correctness + parity; YAML safety + secret discipline + scope)
- [x] Remote `Real Green Gate` push-trigger on this branch — running on the SKIP path (no CI secrets configured for this branch); the gate logic itself isn't exercised on every push since it only runs on tag pushes / `workflow_dispatch`
- [ ] Workflow-level smoke (push a deliberately-failing throwaway tag and confirm publishing jobs are skipped) — defer until you're ready to test on a controlled tag
- [ ] Happy-path E2E (tag a commit with a successful Real Green Gate run, confirm gate passes + publish runs) — defer

## Implementation prerequisites

- PR #187 (P4-G1.1 lib + CLI) merged ✓ (`c05111a3` on main).
- `actions: read` permission addition is the only new permission.

## Out of scope (next subphases)

- **P4-G1.3** — `authorize-release-actor` job in release.yml (mirror cloud-e2e.yml's `authorize-live-run` pattern). Awaits explicit user approval after this lands.
- All Type A capability proof gaps (F-008 channels, F-009 desktop/browser, F-014 OTEL, multi-tenant E2E, packaging E2E).

🤖 Generated with [Claude Code](https://claude.com/claude-code)