### PR TITLE
P4-G1.3: authorize-release-actor in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,121 @@ permissions:
   actions: read
 
 jobs:
+  authorize-release-actor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      GH_TOKEN: ${{ github.token }}
+      ACTOR: ${{ github.actor }}
+      REPOSITORY: ${{ github.repository }}
+      REF_TYPE: ${{ github.ref_type }}
+      REF_NAME: ${{ github.ref_name }}
+      EVENT_NAME: ${{ github.event_name }}
+      DISPATCH_TAG: ${{ github.event.inputs.tag }}
+
+    steps:
+      - name: Checkout (full history for ancestry check)
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Authorize actor by permission tier
+        run: |
+          set -euo pipefail
+          # Mirrors the cloud-e2e.yml authorize-live-run permission tier
+          # check (same admin|maintain|write set per d-G1.3.2). This is the
+          # FIRST gate of the release workflow; nothing else runs until this
+          # passes.
+          permission="$(gh api "repos/${REPOSITORY}/collaborators/${ACTOR}/permission" --jq '.permission')"
+          case "${permission}" in
+            admin|maintain|write)
+              echo "Actor ${ACTOR} authorized with ${permission} permission."
+              ;;
+            *)
+              echo "::error::Actor ${ACTOR} has '${permission}' permission. Release authorization requires admin, maintain, or write."
+              exit 1
+              ;;
+          esac
+
+      - name: Validate trigger and ref
+        run: |
+          set -euo pipefail
+          # Per d-G1.3.1 the gate behaves differently per trigger:
+          #  - push-tag: workflow trigger filter already restricts to v*; the
+          #    ancestry check below validates the tag points at a main-history
+          #    commit. No further ref check needed here.
+          #  - workflow_dispatch: must originate from main (per d-G1.3.3) so
+          #    operators cannot bypass branch protection by dispatching from
+          #    a feature branch and supplying an arbitrary tag input.
+          case "${EVENT_NAME}" in
+            push)
+              if [ "${REF_TYPE}" != "tag" ]; then
+                echo "::error::push trigger expected ref_type=tag, got ref_type=${REF_TYPE} ref_name=${REF_NAME}."
+                exit 1
+              fi
+              echo "Push-tag trigger: tag=${REF_NAME}"
+              ;;
+            workflow_dispatch)
+              if [ "${REF_TYPE}" != "branch" ] || [ "${REF_NAME}" != "main" ]; then
+                echo "::error::Manual release dispatch must be run from the main branch (got ref_type=${REF_TYPE} ref_name=${REF_NAME}). To release from a tag, push the tag and let the push-tag trigger fire."
+                exit 1
+              fi
+              if [ -z "${DISPATCH_TAG}" ]; then
+                echo "::error::workflow_dispatch requires the 'tag' input."
+                exit 1
+              fi
+              echo "Dispatch trigger: tag=${DISPATCH_TAG} from ref_type=${REF_TYPE} ref_name=${REF_NAME}"
+              ;;
+            *)
+              echo "::error::Unsupported trigger '${EVENT_NAME}' for release.yml; only push-tag and workflow_dispatch are allowed."
+              exit 1
+              ;;
+          esac
+
+      - name: Ancestry check — tag commit must be reachable from origin/main
+        run: |
+          set -euo pipefail
+          # Per d-G1.3.1 the ancestor check is the load-bearing rule: actor
+          # tier alone is insufficient because a write actor could otherwise
+          # `git tag v* <some-non-main-sha>` and bypass branch protection.
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            TAG_NAME="${DISPATCH_TAG}"
+          else
+            TAG_NAME="${REF_NAME}"
+          fi
+
+          # ^{commit} forces resolution to the underlying commit object even
+          # when TAG_NAME points to an annotated tag. Same convention used by
+          # public-preflight's tag_sha resolution (P4-G1.2).
+          TAG_SHA="$(git rev-parse "${TAG_NAME}^{commit}")"
+          echo "Tag ${TAG_NAME} resolves to commit ${TAG_SHA}"
+
+          # Explicit fetch of origin/main + tags as defense-in-depth even
+          # though `fetch-depth: 0` above already pulled full history. Keeps
+          # the ancestor check unambiguous if actions/checkout ever changes
+          # its default ref-pruning behavior.
+          git fetch --no-tags origin "+refs/heads/main:refs/remotes/origin/main"
+          git fetch --tags --force origin
+
+          if ! git merge-base --is-ancestor "${TAG_SHA}" "origin/main"; then
+            echo "::error::Tag ${TAG_NAME} (commit ${TAG_SHA}) is NOT an ancestor of origin/main."
+            echo "::error::Releases must be cut from commits that have already been merged into main via the protected merge path. If this is a hotfix on an unmerged branch, merge to main first or coordinate with maintainers to extend this gate before re-attempting the release."
+            exit 1
+          fi
+          echo "Tag commit ${TAG_SHA} is reachable from origin/main."
+
+      - name: Authorization summary
+        run: |
+          set -euo pipefail
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            TAG_NAME="${DISPATCH_TAG}"
+          else
+            TAG_NAME="${REF_NAME}"
+          fi
+          echo "Release authorized: actor=${ACTOR} trigger=${EVENT_NAME} tag=${TAG_NAME}"
+
   public-preflight:
+    needs: authorize-release-actor
     runs-on: ubuntu-latest
     timeout-minutes: 20
     outputs:


### PR DESCRIPTION
## Summary

P4-G1.3 closes the third leg of the release-governance trilogy on `release.yml`. The two prior legs are already in `main`:
- **P4-G1.1** (PR #187, `c05111a3`): structured `real-green-gate-result.json` artifact + pure validator + CLI.
- **P4-G1.2** (PR #188, `bbfffebd`): `live-proof-gate` job that requires the artifact at release time.

Without G1.3, a write-tier actor could `git tag v* <some-non-main-sha> && git push origin v*` and trigger the entire release pipeline — bypassing branch protection on `main`. The actor-only check from cloud-e2e.yml's `authorize-live-run` is **not sufficient on its own** for `release.yml` because release.yml has BOTH `push: tags: v*` and `workflow_dispatch` triggers, and a copy-paste of cloud-e2e's `REF_TYPE != branch || REF_NAME != main` check would block all push-tag releases (push-tag has `ref_type=tag`).

This PR therefore implements **B+ancestor**: actor permission tier + trigger-aware ref check + tag commit ancestry against `origin/main`.

## What changed (1 file, +114 / 0)

`.github/workflows/release.yml`:

- **NEW `authorize-release-actor` job** — FIRST in the workflow DAG; `runs-on: ubuntu-latest`; `timeout-minutes: 5`; env block contains only public, non-secret values (no release-time secrets); steps:
  1. Checkout with `fetch-depth: 0` (needed for the ancestor check; no release-build logic).
  2. **Actor tier**: `gh api repos/${REPOSITORY}/collaborators/${ACTOR}/permission` + `case admin|maintain|write` (mirrors cloud-e2e.yml authorize-live-run verbatim per d-G1.3.2).
  3. **Trigger + ref**: `case ${EVENT_NAME}`:
     - `push` → require `REF_TYPE == tag` (workflow trigger filter `v*` already restricts; ancestor check below is the load-bearing rule).
     - `workflow_dispatch` → require `REF_TYPE == branch && REF_NAME == main` AND non-empty `DISPATCH_TAG` input (per d-G1.3.3).
     - other → reject.
  4. **Ancestor check** (the load-bearing rule per d-G1.3.1): resolve `TAG_NAME` per trigger; `git rev-parse "${TAG_NAME}^{commit}"` (the `^{commit}` suffix forces commit resolution even for annotated tags); explicit `git fetch --no-tags origin "+refs/heads/main:refs/remotes/origin/main"` and `git fetch --tags --force origin` (defense-in-depth even though `fetch-depth: 0` already pulled full history); `git merge-base --is-ancestor "${TAG_SHA}" "origin/main"`. Reject with hotfix-aware operator instruction if the tag's commit is not in main's history.
  5. Authorization summary log.
- **`public-preflight` gains `needs: authorize-release-actor`** (1 line). All other jobs (`verify`, `live-proof-gate`, `source-distribution`, `macos-distribution`, `publish-npm`, `create-release`) inherit transitively (per d-G1.3.4); their bodies are unchanged.

## Constraints respected (per d-G1.3.* contract)

- d-G1.3.1 ✓ B+ancestor: actor tier + ancestor on push-tag; actor tier + ref(branch=main) + ancestor on workflow_dispatch.
- d-G1.3.2 ✓ `admin|maintain|write` (cloud-e2e parity).
- d-G1.3.3 ✓ workflow_dispatch retained but only from main.
- d-G1.3.4 ✓ transitive needs via `public-preflight` (single-line edit).
- d-G1.3.5 ✓ no bot whitelist; no per-actor exemption.
- ✓ Touched ONLY `.github/workflows/release.yml`.
- ✓ G1.2 live-proof-gate / G1.1 validator/lib/CLI/tests / `real-green-gate.yml` / findings register / capability proof files / P5 docs all UNTOUCHED.
- ✓ authorize-release-actor is FIRST gate; runs no release secrets; no release artifact/publish steps.
- ✓ `^{commit}` suffix on `git rev-parse`; explicit `git fetch origin main` + `git fetch --tags --force origin`; `git merge-base --is-ancestor`.
- ✓ All bash uses `set -euo pipefail`; user-controlled values flow via `env:` block, never directly interpolated; quoted variable expansion.
- ✓ All failure paths use explicit `::error::` + `exit 1` with operator-actionable messages. No FAST_MODE / no break-glass / no continue-on-error / no auto-trigger.

## Test plan

- [x] YAML parses cleanly (`python3 yaml.safe_load` returns 8 jobs in correct order)
- [x] `git diff --check` clean
- [x] `npm run check:secret-patterns` clean
- [x] Two isolated read-only reviewers — PASS / PASS (closure correctness + B+ancestor logic; YAML safety + secret discipline + scope)
- [x] Remote `Real Green Gate` push-trigger on this branch — runs on the SKIP path (no CI secrets configured); the gate itself only fires on tag pushes / `workflow_dispatch` (not on regular push to a codex branch)
- [ ] Workflow-level smoke test (push a non-authorized actor / non-allowed ref / off-main-tag combo and confirm rejection) — defer until controlled test environment
- [ ] Happy-path E2E (push a valid v* tag from main with an authorized actor, confirm full pipeline runs) — defer

## Out of scope

- Type A capability proof gaps (F-008 channels, F-009 desktop/browser, F-014 OTEL, multi-tenant E2E, packaging E2E).
- Findings register update (F-015 doc-only cleanup).
- P5 docs.
- Phase 4A.7 read-path closure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)