### PR TITLE
Make deep-proof live tests use the selected provider lane

### DIFF
--- a/test/e2e/live/_helpers/deep-proof-env.ts
+++ b/test/e2e/live/_helpers/deep-proof-env.ts
@@ -1,19 +1,56 @@
 import {
-  ANTHROPIC_API_KEY_ENV_REF,
   cleanupRealHubEnv,
   createRealHubEnv,
   createRealHubEnvFromStateDir,
+  DEEPSEEK_API_KEY_ENV,
+  DEEPSEEK_BASE_URL,
+  FAST_MODEL,
+  OLLAMA_BASE_URL,
+  OPENAI_API_KEY_ENV,
+  OPENAI_BASE_URL,
   shutdownRealHubEnv,
+  type FridayLiveProviderKind,
   type RealHubEnv,
 } from "./real-env.js";
+import {
+  createAnthropicProvider,
+  createDeepSeekProvider,
+  createOllamaProvider,
+  createOpenAiProvider,
+  ensureAnthropicProviders,
+  ensureDeepSeekProviders,
+  ensureOllamaProviders,
+  ensureOpenAiProviders,
+} from "./api.js";
 import { liveAnthropicCredentialMessage } from "../../_helpers/live-anthropic.js";
+
+/**
+ * Deep-proof env helper: exactly-one selected live provider lane.
+ *
+ * Replaces the prior Anthropic-only contract. Tests that opt into
+ * createFridayDeepProofHubEnv() get a single-provider deterministic
+ * environment: exactly one of FRIDAY_E2E_LIVE_ANTHROPIC / DEEPSEEK / OPENAI /
+ * OLLAMA must be set, and the matching credential must be present (Ollama
+ * relies on a reachable base URL instead of a key). Other provider keys are
+ * sanitized at hub boot via real-env's withSanitizedProviderEnv.
+ *
+ * Evidence captured by a deep-proof run is lane-specific. A DeepSeek run
+ * proves DeepSeek; it does not prove Anthropic. Surfaces consuming the
+ * helper should label evidence by the active provider.
+ */
+
+const ANTHROPIC_BASE_URL_DEFAULT = "https://api.anthropic.com";
+
+export type FridayDeepProofProviderKind = FridayLiveProviderKind;
+
+export type FridayDeepProofProviderAuthLane = "api_key" | "bearer_token" | "none";
 
 export interface FridayDeepProofEnvStatus {
   gated: boolean;
-  providerAuthLane: "api_key";
+  selectedProvider: FridayDeepProofProviderKind | null;
+  providerAuthLane: FridayDeepProofProviderAuthLane | null;
   credentialEnvRef: string | null;
   usesLegacyLane: boolean;
-  usesSupplementalLane: boolean;
   blockers: string[];
 }
 
@@ -21,76 +58,212 @@ function readFlag(value: string | undefined): boolean {
   return value === "1";
 }
 
+function readNonEmptyString(value: string | undefined): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function resolveAnthropicCredentialEnvRef(env: NodeJS.ProcessEnv): string | null {
+  if (readNonEmptyString(env.FRIDAY_ANTHROPIC_API_KEY)) { // pragma: allowlist secret
+    return "$FRIDAY_ANTHROPIC_API_KEY";
+  }
+  if (readNonEmptyString(env.ANTHROPIC_API_KEY)) { // pragma: allowlist secret
+    return "$ANTHROPIC_API_KEY";
+  }
+  return null;
+}
+
+function resolveDeepSeekCredentialEnvRef(env: NodeJS.ProcessEnv): string | null {
+  if (readNonEmptyString(env.FRIDAY_DEEPSEEK_API_KEY)) { // pragma: allowlist secret
+    return "$FRIDAY_DEEPSEEK_API_KEY";
+  }
+  if (readNonEmptyString(env.DEEPSEEK_API_KEY)) { // pragma: allowlist secret
+    return "$DEEPSEEK_API_KEY";
+  }
+  return null;
+}
+
+function resolveOpenAiCredentialEnvRef(env: NodeJS.ProcessEnv): string | null {
+  if (readNonEmptyString(env.OPENAI_API_KEY)) { // pragma: allowlist secret
+    return "$OPENAI_API_KEY";
+  }
+  return null;
+}
+
 export function getFridayDeepProofEnvStatus(
   env: NodeJS.ProcessEnv = process.env,
 ): FridayDeepProofEnvStatus {
-  const anthropicGate = readFlag(env.FRIDAY_E2E_LIVE_ANTHROPIC);
+  const lanes: ReadonlyArray<{ kind: FridayDeepProofProviderKind; flag: boolean }> = [
+    { kind: "anthropic", flag: readFlag(env.FRIDAY_E2E_LIVE_ANTHROPIC) },
+    { kind: "deepseek", flag: readFlag(env.FRIDAY_E2E_LIVE_DEEPSEEK) },
+    { kind: "openai", flag: readFlag(env.FRIDAY_E2E_LIVE_OPENAI) },
+    { kind: "ollama", flag: readFlag(env.FRIDAY_E2E_LIVE_OLLAMA) },
+  ];
+  const enabled = lanes.filter((lane) => lane.flag);
   const legacyLane = readFlag(env.E2E_LIVE);
-  const supplementalLane =
-    readFlag(env.FRIDAY_E2E_LIVE_OPENAI)
-    || readFlag(env.FRIDAY_E2E_LIVE_DEEPSEEK)
-    || readFlag(env.FRIDAY_E2E_LIVE_OLLAMA);
-  const credentialEnvRef =
-    typeof env.FRIDAY_ANTHROPIC_API_KEY === "string" && env.FRIDAY_ANTHROPIC_API_KEY.trim().length > 0 // pragma: allowlist secret
-      ? "$FRIDAY_ANTHROPIC_API_KEY"
-      : typeof env.ANTHROPIC_API_KEY === "string" && env.ANTHROPIC_API_KEY.trim().length > 0 // pragma: allowlist secret
-        ? "$ANTHROPIC_API_KEY"
-        : null;
-
   const blockers: string[] = [];
-  if (!anthropicGate) {
-    blockers.push("missing_anthropic_gate");
+
+  let selectedProvider: FridayDeepProofProviderKind | null = null;
+  if (enabled.length === 0) {
+    blockers.push("no_provider_lane");
+  } else if (enabled.length > 1) {
+    blockers.push("multiple_provider_lanes");
+  } else {
+    selectedProvider = enabled[0]!.kind;
   }
-  if (!credentialEnvRef) {
-    blockers.push("missing_anthropic_api_key");
-  }
+
   if (legacyLane) {
     blockers.push("legacy_live_lane_enabled");
   }
-  if (supplementalLane) {
-    blockers.push("supplemental_provider_lane_enabled");
+
+  let credentialEnvRef: string | null = null;
+  let providerAuthLane: FridayDeepProofProviderAuthLane | null = null;
+  switch (selectedProvider) {
+    case "anthropic": {
+      credentialEnvRef = resolveAnthropicCredentialEnvRef(env);
+      providerAuthLane = "api_key";
+      if (!credentialEnvRef) {
+        blockers.push("missing_key:anthropic");
+      }
+      break;
+    }
+    case "deepseek": {
+      credentialEnvRef = resolveDeepSeekCredentialEnvRef(env);
+      providerAuthLane = "bearer_token";
+      if (!credentialEnvRef) {
+        blockers.push("missing_key:deepseek");
+      }
+      break;
+    }
+    case "openai": {
+      credentialEnvRef = resolveOpenAiCredentialEnvRef(env);
+      providerAuthLane = "api_key";
+      if (!credentialEnvRef) {
+        blockers.push("missing_key:openai");
+      }
+      break;
+    }
+    case "ollama": {
+      providerAuthLane = "none";
+      // Ollama key-less; base URL reachability is checked at hub boot.
+      break;
+    }
+    case null:
+      break;
   }
 
   return {
     gated: blockers.length === 0,
-    providerAuthLane: "api_key",
+    selectedProvider,
+    providerAuthLane,
     credentialEnvRef,
     usesLegacyLane: legacyLane,
-    usesSupplementalLane: supplementalLane,
     blockers,
   };
 }
 
-export function assertFridayDeepProofAnthropicLane(
+export interface FridayDeepProofLaneSelection {
+  selectedProvider: FridayDeepProofProviderKind;
+  credentialEnvRef: string | null;
+  providerAuthLane: FridayDeepProofProviderAuthLane;
+}
+
+export function assertFridayDeepProofSingleProviderLane(
   env: NodeJS.ProcessEnv = process.env,
-): string {
+): FridayDeepProofLaneSelection {
   const status = getFridayDeepProofEnvStatus(env);
-  if (!status.gated || !status.credentialEnvRef) {
+  if (!status.gated || !status.selectedProvider || !status.providerAuthLane) {
     const parts: string[] = [];
-    if (status.blockers.includes("missing_anthropic_gate")) {
-      parts.push("set FRIDAY_E2E_LIVE_ANTHROPIC=1");
+    if (status.blockers.includes("no_provider_lane")) {
+      parts.push(
+        "set exactly one of FRIDAY_E2E_LIVE_ANTHROPIC=1 / FRIDAY_E2E_LIVE_DEEPSEEK=1 / FRIDAY_E2E_LIVE_OPENAI=1 / FRIDAY_E2E_LIVE_OLLAMA=1",
+      );
     }
-    if (status.blockers.includes("missing_anthropic_api_key")) {
-      parts.push(liveAnthropicCredentialMessage());
+    if (status.blockers.includes("multiple_provider_lanes")) {
+      parts.push(
+        "exactly one provider lane is required; multiple FRIDAY_E2E_LIVE_* flags are set",
+      );
     }
     if (status.blockers.includes("legacy_live_lane_enabled")) {
       parts.push("unset E2E_LIVE for deep proof runs");
     }
-    if (status.blockers.includes("supplemental_provider_lane_enabled")) {
-      parts.push("unset FRIDAY_E2E_LIVE_OPENAI, FRIDAY_E2E_LIVE_DEEPSEEK, and FRIDAY_E2E_LIVE_OLLAMA for deep proof runs");
+    if (status.blockers.includes("missing_key:anthropic")) {
+      parts.push(liveAnthropicCredentialMessage());
     }
-    throw new Error(`[Deep Proof] Anthropic-only lane required: ${parts.join("; ")}`);
+    if (status.blockers.includes("missing_key:deepseek")) {
+      parts.push(
+        "set FRIDAY_DEEPSEEK_API_KEY or DEEPSEEK_API_KEY for the DeepSeek deep-proof lane",
+      );
+    }
+    if (status.blockers.includes("missing_key:openai")) {
+      parts.push("set OPENAI_API_KEY for the OpenAI deep-proof lane");
+    }
+    throw new Error(
+      `[Deep Proof] Single-provider lane required: ${parts.join("; ")}`,
+    );
   }
-  return status.credentialEnvRef;
+  return {
+    selectedProvider: status.selectedProvider,
+    credentialEnvRef: status.credentialEnvRef,
+    providerAuthLane: status.providerAuthLane,
+  };
 }
 
-export const FRIDAY_DEEP_PROOF_GATED = getFridayDeepProofEnvStatus().gated;
+const INITIAL_DEEP_PROOF_STATUS = getFridayDeepProofEnvStatus();
+
+export const FRIDAY_DEEP_PROOF_GATED = INITIAL_DEEP_PROOF_STATUS.gated;
+
+/**
+ * Provider key env ref for the active deep-proof lane (e.g.
+ * "$FRIDAY_DEEPSEEK_API_KEY"). Null when the gate is closed or when the
+ * selected provider is keyless (Ollama).
+ */
+export const FRIDAY_DEEP_PROOF_PROVIDER_KEY_ENV_REF =
+  INITIAL_DEEP_PROOF_STATUS.credentialEnvRef;
+
+export function selectFridayDeepProofProviderKind(): FridayDeepProofProviderKind | null {
+  return INITIAL_DEEP_PROOF_STATUS.selectedProvider;
+}
+
+function providerLabel(kind: FridayDeepProofProviderKind | null): string {
+  switch (kind) {
+    case "anthropic":
+      return "Anthropic";
+    case "deepseek":
+      return "DeepSeek";
+    case "openai":
+      return "OpenAI";
+    case "ollama":
+      return "Ollama";
+    case null:
+    default:
+      return "no-deep-proof-provider-selected";
+  }
+}
+
+/**
+ * Human-readable label of the active deep-proof provider, used in describe
+ * blocks and diagnostic messages. Reflects the lane this run actually
+ * proves; do not generalize to other providers.
+ */
+export const FRIDAY_DEEP_PROOF_PROVIDER_LABEL = providerLabel(
+  INITIAL_DEEP_PROOF_STATUS.selectedProvider,
+);
+
+/**
+ * Default fast model for the active deep-proof lane. Pulls from real-env's
+ * FAST_MODEL which is provider-keyed and overridable via E2E_FAST_MODEL.
+ */
+export function selectFridayDeepProofModel(): string {
+  return FAST_MODEL;
+}
+
+export const FRIDAY_DEEP_PROOF_MODEL = FAST_MODEL;
 
 export async function createFridayDeepProofHubEnv(opts?: {
   uiStaticDir?: string;
   hubConfig?: Record<string, unknown>;
 }): Promise<RealHubEnv> {
-  assertFridayDeepProofAnthropicLane();
+  assertFridayDeepProofSingleProviderLane();
   const env = await createRealHubEnv(opts);
   if (!env.hub || !env.httpServer || !env.stateDir) {
     await cleanupRealHubEnv(env);
@@ -103,12 +276,202 @@ export async function createFridayDeepProofHubEnvFromStateDir(
   stateDir: string,
   opts?: { uiStaticDir?: string; hubConfig?: Record<string, unknown> },
 ): Promise<RealHubEnv> {
-  assertFridayDeepProofAnthropicLane();
+  assertFridayDeepProofSingleProviderLane();
   return createRealHubEnvFromStateDir(stateDir, opts);
+}
+
+export interface FridayDeepProofProviderCreationOptions {
+  name: string;
+  models?: ReadonlyArray<string>;
+  defaultModel?: string;
+}
+
+export interface FridayDeepProofProviderCreationResult {
+  providerId: string;
+  providerKind: FridayDeepProofProviderKind;
+  model: string;
+}
+
+/**
+ * Create a single provider on the hub matching the active deep-proof lane.
+ * Returns providerId, the active providerKind, and the model used. Tests
+ * should use the returned `model` for downstream `model:` parameters
+ * (executeGoal, providerModel:, lastVerifiedProviderModel asserts) so the
+ * fixture stays consistent with what was actually registered.
+ */
+export async function createFridayDeepProofProvider(
+  env: RealHubEnv,
+  opts: FridayDeepProofProviderCreationOptions,
+): Promise<FridayDeepProofProviderCreationResult> {
+  const lane = assertFridayDeepProofSingleProviderLane();
+  const model = opts.defaultModel ?? FAST_MODEL;
+  const models = opts.models ?? [model];
+
+  let providerId: string;
+  switch (lane.selectedProvider) {
+    case "anthropic": {
+      if (!lane.credentialEnvRef) {
+        throw new Error(liveAnthropicCredentialMessage());
+      }
+      providerId = await createAnthropicProvider(env.baseUrl, env.accessToken, {
+        name: opts.name,
+        anthropicBaseUrl: process.env.E2E_ANTHROPIC_BASE_URL ?? ANTHROPIC_BASE_URL_DEFAULT,
+        models: [...models],
+        defaultModel: model,
+        apiKeyEnvRef: lane.credentialEnvRef,
+      });
+      break;
+    }
+    case "deepseek": {
+      if (!lane.credentialEnvRef) {
+        throw new Error(
+          "[Deep Proof] DeepSeek key env ref unresolved despite gate pass",
+        );
+      }
+      providerId = await createDeepSeekProvider(env.baseUrl, env.accessToken, {
+        name: opts.name,
+        deepSeekBaseUrl: DEEPSEEK_BASE_URL,
+        models: [...models],
+        defaultModel: model,
+        apiKeyEnvRef: lane.credentialEnvRef,
+      });
+      break;
+    }
+    case "openai": {
+      if (!lane.credentialEnvRef) {
+        throw new Error(
+          "[Deep Proof] OpenAI key env ref unresolved despite gate pass",
+        );
+      }
+      providerId = await createOpenAiProvider(env.baseUrl, env.accessToken, {
+        name: opts.name,
+        openAiBaseUrl: OPENAI_BASE_URL,
+        models: [...models],
+        defaultModel: model,
+        apiKeyEnvRef: lane.credentialEnvRef,
+      });
+      break;
+    }
+    case "ollama": {
+      providerId = await createOllamaProvider(env.baseUrl, env.accessToken, {
+        name: opts.name,
+        ollamaBaseUrl: OLLAMA_BASE_URL,
+        models: [...models],
+        defaultModel: model,
+      });
+      break;
+    }
+  }
+
+  return { providerId, providerKind: lane.selectedProvider, model };
+}
+
+/**
+ * Create a fast + code provider pair on the hub for the active deep-proof
+ * lane and set routing accordingly. Mirrors api.ts ensure*Providers shape.
+ * Returns provider IDs, the active providerKind, and the model strings used.
+ */
+export interface FridayDeepProofProviderPairOptions {
+  fastModel?: string;
+  codeModel?: string;
+  apiKeyEnvRef?: string;
+  namePrefix?: string;
+}
+
+export interface FridayDeepProofProviderPairResult {
+  fastProviderId: string;
+  codeProviderId: string;
+  providerKind: FridayDeepProofProviderKind;
+  fastModel: string;
+  codeModel: string;
+}
+
+export async function ensureFridayDeepProofProviders(
+  env: RealHubEnv,
+  opts: FridayDeepProofProviderPairOptions = {},
+): Promise<FridayDeepProofProviderPairResult> {
+  const lane = assertFridayDeepProofSingleProviderLane();
+  const fastModel = opts.fastModel ?? FAST_MODEL;
+  const codeModel = opts.codeModel ?? FAST_MODEL;
+
+  switch (lane.selectedProvider) {
+    case "anthropic": {
+      const credentialEnvRef = opts.apiKeyEnvRef ?? lane.credentialEnvRef;
+      if (!credentialEnvRef) {
+        throw new Error(liveAnthropicCredentialMessage());
+      }
+      const providers = await ensureAnthropicProviders(
+        env.baseUrl,
+        env.accessToken,
+        process.env.E2E_ANTHROPIC_BASE_URL ?? ANTHROPIC_BASE_URL_DEFAULT,
+        fastModel,
+        codeModel,
+        credentialEnvRef,
+        { namePrefix: opts.namePrefix },
+      );
+      return {
+        ...providers,
+        providerKind: "anthropic",
+        fastModel,
+        codeModel,
+      };
+    }
+    case "deepseek": {
+      const credentialEnvRef = opts.apiKeyEnvRef ?? lane.credentialEnvRef ?? `$${DEEPSEEK_API_KEY_ENV}`;
+      const providers = await ensureDeepSeekProviders(
+        env.baseUrl,
+        env.accessToken,
+        DEEPSEEK_BASE_URL,
+        fastModel,
+        codeModel,
+        credentialEnvRef,
+        { namePrefix: opts.namePrefix },
+      );
+      return {
+        ...providers,
+        providerKind: "deepseek",
+        fastModel,
+        codeModel,
+      };
+    }
+    case "openai": {
+      const credentialEnvRef = opts.apiKeyEnvRef ?? lane.credentialEnvRef ?? `$${OPENAI_API_KEY_ENV}`;
+      const providers = await ensureOpenAiProviders(
+        env.baseUrl,
+        env.accessToken,
+        OPENAI_BASE_URL,
+        fastModel,
+        codeModel,
+        credentialEnvRef,
+        { namePrefix: opts.namePrefix },
+      );
+      return {
+        ...providers,
+        providerKind: "openai",
+        fastModel,
+        codeModel,
+      };
+    }
+    case "ollama": {
+      const providers = await ensureOllamaProviders(
+        env.baseUrl,
+        env.accessToken,
+        OLLAMA_BASE_URL,
+        fastModel,
+        codeModel,
+        { namePrefix: opts.namePrefix },
+      );
+      return {
+        ...providers,
+        providerKind: "ollama",
+        fastModel,
+        codeModel,
+      };
+    }
+  }
 }
 
 export {
   cleanupRealHubEnv as cleanupFridayDeepProofHubEnv,
   shutdownRealHubEnv as shutdownFridayDeepProofHubEnv,
-  ANTHROPIC_API_KEY_ENV_REF as FRIDAY_DEEP_PROOF_ANTHROPIC_API_KEY_ENV_REF,
 };

--- a/test/e2e/live/friday-autonomous-restart.e2e.test.ts
+++ b/test/e2e/live/friday-autonomous-restart.e2e.test.ts
@@ -4,8 +4,7 @@ import * as path from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import { LIVE_ANTHROPIC_MODEL, liveAnthropicCredentialMessage } from "../_helpers/live-anthropic.js";
-import { createAnthropicProvider, setModelRouting } from "./_helpers/api.js";
+import { setModelRouting } from "./_helpers/api.js";
 import {
   listAutonomousSteps,
   readAutonomousGoal,
@@ -16,13 +15,12 @@ import {
   cleanupFridayDeepProofHubEnv,
   createFridayDeepProofHubEnv,
   createFridayDeepProofHubEnvFromStateDir,
-  FRIDAY_DEEP_PROOF_ANTHROPIC_API_KEY_ENV_REF,
+  createFridayDeepProofProvider,
   FRIDAY_DEEP_PROOF_GATED,
+  FRIDAY_DEEP_PROOF_PROVIDER_LABEL,
   shutdownFridayDeepProofHubEnv,
   type RealHubEnv,
 } from "./_helpers/deep-proof-env.js";
-
-const ANTHROPIC_BASE_URL = process.env.E2E_ANTHROPIC_BASE_URL ?? "https://api.anthropic.com";
 
 function buildWorkspaceProofPath(stateDir: string, name: string): string {
   const proofDir = path.join(stateDir, ".tmp", "autonomous-live-proofs");
@@ -61,21 +59,20 @@ async function startStaticProofServer(html: string): Promise<{ url: string; clos
   };
 }
 
-async function ensureAnthropicProvider(env: RealHubEnv): Promise<string> {
-  const apiKeyEnvRef = FRIDAY_DEEP_PROOF_ANTHROPIC_API_KEY_ENV_REF
-    ?? (() => { throw new Error(liveAnthropicCredentialMessage()); })();
-  const providerId = await createAnthropicProvider(env.baseUrl, env.accessToken, {
-    name: "Anthropic Autonomous Restart Proof",
-    anthropicBaseUrl: ANTHROPIC_BASE_URL,
-    models: [LIVE_ANTHROPIC_MODEL],
-    defaultModel: LIVE_ANTHROPIC_MODEL,
-    apiKeyEnvRef,
-  });
-  await setModelRouting(env.baseUrl, env.accessToken, providerId, []);
-  return providerId;
+interface DeepProofProviderHandle {
+  providerId: string;
+  model: string;
 }
 
-describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Autonomous Restart Matrix (Anthropic API key)", () => {
+async function ensureDeepProofProvider(env: RealHubEnv): Promise<DeepProofProviderHandle> {
+  const result = await createFridayDeepProofProvider(env, {
+    name: `${FRIDAY_DEEP_PROOF_PROVIDER_LABEL} Autonomous Restart Proof`,
+  });
+  await setModelRouting(env.baseUrl, env.accessToken, result.providerId, []);
+  return { providerId: result.providerId, model: result.model };
+}
+
+describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)(`Friday Autonomous Restart Matrix (${FRIDAY_DEEP_PROOF_PROVIDER_LABEL})`, () => {
   let envsToCleanup: RealHubEnv[] = [];
 
   afterEach(async () => {
@@ -93,7 +90,7 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Autonomous Restart Matrix (Ant
     async () => {
       let env = await createFridayDeepProofHubEnv();
       envsToCleanup.push(env);
-      const providerId = await ensureAnthropicProvider(env);
+      const { providerId, model } = await ensureDeepProofProvider(env);
       const marker = `planning-content-${Date.now()}`;
       const outputPath = buildWorkspaceProofPath(env.stateDir!, `${marker}-planning-content-proof.txt`);
       const expected = `planning-content-restart-${marker}`;
@@ -102,7 +99,7 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Autonomous Restart Matrix (Ant
       const executePromise = env.hub!.autonomousEngine.executeGoal({
         description: goalDescription,
         providerId,
-        model: LIVE_ANTHROPIC_MODEL,
+        model: model,
       });
 
       const goal = await waitForAutonomousGoalByDescriptionMarker(env.stateDir!, marker, { intervalMs: 100, maxMs: 20_000 });
@@ -128,7 +125,7 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Autonomous Restart Matrix (Ant
       const resumeResult = await env.hub!.autonomousEngine.resumeGoal({
         goalId,
         providerId,
-        model: LIVE_ANTHROPIC_MODEL,
+        model: model,
       });
       if (resumeResult.status !== "completed") {
         const failureGoal = readAutonomousGoal(env.stateDir!, goalId);
@@ -184,7 +181,7 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Autonomous Restart Matrix (Ant
     async () => {
       let env = await createFridayDeepProofHubEnv();
       envsToCleanup.push(env);
-      const providerId = await ensureAnthropicProvider(env);
+      const { providerId, model } = await ensureDeepProofProvider(env);
       const marker = `planning-${Date.now()}`;
       const outputPath = buildWorkspaceProofPath(env.stateDir!, `${marker}-planning-proof.txt`);
       const expected = `planning-restart-${marker}`;
@@ -193,7 +190,7 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Autonomous Restart Matrix (Ant
       const executePromise = env.hub!.autonomousEngine.executeGoal({
         description: goalDescription,
         providerId,
-        model: LIVE_ANTHROPIC_MODEL,
+        model: model,
       });
 
       const goal = await waitForAutonomousGoalByDescriptionMarker(env.stateDir!, marker, { intervalMs: 100, maxMs: 20_000 });
@@ -219,7 +216,7 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Autonomous Restart Matrix (Ant
       const resumeResult = await env.hub!.autonomousEngine.resumeGoal({
         goalId,
         providerId,
-        model: LIVE_ANTHROPIC_MODEL,
+        model: model,
       });
       if (resumeResult.status !== "completed") {
         const failureGoal = readAutonomousGoal(env.stateDir!, goalId);
@@ -253,7 +250,7 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Autonomous Restart Matrix (Ant
     async () => {
       let env = await createFridayDeepProofHubEnv();
       envsToCleanup.push(env);
-      const providerId = await ensureAnthropicProvider(env);
+      const { providerId, model } = await ensureDeepProofProvider(env);
       const marker = `executing-${Date.now()}`;
       const outputPath = path.join(env.stateDir!, "autonomous-executing-proof.txt");
       const expected = `executing-restart-${marker}`;
@@ -261,7 +258,7 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Autonomous Restart Matrix (Ant
       const executePromise = env.hub!.autonomousEngine.executeGoal({
         description: goalDescription,
         providerId,
-        model: LIVE_ANTHROPIC_MODEL,
+        model: model,
       });
 
       const goal = await waitForAutonomousGoalByDescriptionMarker(env.stateDir!, marker, { intervalMs: 100, maxMs: 20_000 });
@@ -291,7 +288,7 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Autonomous Restart Matrix (Ant
         env.hub!.autonomousEngine.resumeGoal({
           goalId,
           providerId,
-          model: LIVE_ANTHROPIC_MODEL,
+          model: model,
         }),
       ).rejects.toThrow("cannot be resumed safely");
       expect(fs.existsSync(outputPath)).toBe(false);
@@ -318,13 +315,13 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Autonomous Restart Matrix (Ant
       let env = await createFridayDeepProofHubEnv();
       envsToCleanup.push(env);
       try {
-        const providerId = await ensureAnthropicProvider(env);
+        const { providerId, model } = await ensureDeepProofProvider(env);
         const marker = `verifying-${Date.now()}`;
         const goalDescription = `Marker ${marker}. Use only the browser tool, not any desktop tool. Open '${staticPage.url}?autonomous_marker=${encodeURIComponent(marker)}' in the browser, stay on that page, and then verify visually that the Friday login page is shown and that a local sign-in option is visible to the user.`;
         const executePromise = env.hub!.autonomousEngine.executeGoal({
           description: goalDescription,
           providerId,
-          model: LIVE_ANTHROPIC_MODEL,
+          model: model,
         });
 
         const goal = await waitForAutonomousGoalByDescriptionMarker(env.stateDir!, marker, { intervalMs: 100, maxMs: 20_000 });
@@ -360,7 +357,7 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Autonomous Restart Matrix (Ant
         const resumeResult = await env.hub!.autonomousEngine.resumeGoal({
           goalId,
           providerId,
-          model: LIVE_ANTHROPIC_MODEL,
+          model: model,
         });
         if (resumeResult.status !== "completed") {
           const failureGoal = readAutonomousGoal(env.stateDir!, goalId);

--- a/test/e2e/live/friday-generator-maintenance-live.e2e.test.ts
+++ b/test/e2e/live/friday-generator-maintenance-live.e2e.test.ts
@@ -4,17 +4,16 @@ import path from "node:path";
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
-import { LIVE_ANTHROPIC_MODEL, liveAnthropicCredentialMessage } from "../_helpers/live-anthropic.js";
-import { apiFetch, ensureAnthropicProviders } from "./_helpers/api.js";
+import { apiFetch } from "./_helpers/api.js";
 import {
   cleanupFridayDeepProofHubEnv,
   createFridayDeepProofHubEnv,
-  FRIDAY_DEEP_PROOF_ANTHROPIC_API_KEY_ENV_REF,
+  ensureFridayDeepProofProviders,
   FRIDAY_DEEP_PROOF_GATED,
+  FRIDAY_DEEP_PROOF_MODEL,
+  FRIDAY_DEEP_PROOF_PROVIDER_LABEL,
   type RealHubEnv,
 } from "./_helpers/deep-proof-env.js";
-
-const ANTHROPIC_BASE_URL = process.env.E2E_ANTHROPIC_BASE_URL ?? "https://api.anthropic.com";
 
 interface SkillGeneratorSessionEnvelope {
   ok: boolean;
@@ -283,18 +282,10 @@ function buildSkillRunInput(skillDir: string): Record<string, unknown> {
   return input;
 }
 
-async function ensureAnthropicGeneratorProviders(env: RealHubEnv): Promise<void> {
-  const apiKeyEnvRef = FRIDAY_DEEP_PROOF_ANTHROPIC_API_KEY_ENV_REF
-    ?? (() => { throw new Error(liveAnthropicCredentialMessage()); })();
-  await ensureAnthropicProviders(
-    env.baseUrl,
-    env.accessToken,
-    ANTHROPIC_BASE_URL,
-    LIVE_ANTHROPIC_MODEL,
-    LIVE_ANTHROPIC_MODEL,
-    apiKeyEnvRef,
-    { namePrefix: "Generator Maintenance Deep Proof" },
-  );
+async function ensureGeneratorMaintenanceDeepProofProviders(env: RealHubEnv): Promise<void> {
+  await ensureFridayDeepProofProviders(env, {
+    namePrefix: "Generator Maintenance Deep Proof",
+  });
 }
 
 async function getSkillDraftState(
@@ -329,7 +320,7 @@ async function createValidatedSkillDraft(
       goal,
       userId: "admin-001",
       channel: "deep-generator-maintenance",
-      requestedModel: LIVE_ANTHROPIC_MODEL,
+      requestedModel: FRIDAY_DEEP_PROOF_MODEL,
     },
     { timeoutMs: 240_000 },
   );
@@ -348,7 +339,7 @@ async function createValidatedSkillDraft(
         message:
           "Keep the implementation deterministic, shell-based, and as small as possible. " +
           "Preserve the exact requested skill id and version, and make the runtime output include the exact required marker.",
-        requestedModel: LIVE_ANTHROPIC_MODEL,
+        requestedModel: FRIDAY_DEEP_PROOF_MODEL,
       },
       { timeoutMs: 240_000 },
     );
@@ -381,7 +372,7 @@ async function createValidatedSkillDraft(
       env.accessToken,
       "POST",
       `/v1/skills/generator/sessions/${encodeURIComponent(sessionId)}/generate`,
-      { requestedModel: LIVE_ANTHROPIC_MODEL },
+      { requestedModel: FRIDAY_DEEP_PROOF_MODEL },
       { timeoutMs: 240_000 },
     );
     expect(generateRes.status).toBe(200);
@@ -415,7 +406,7 @@ async function createValidatedSkillDraft(
           message:
             `The current draft still has validation issues: ${lastIssues}. ` +
             "Fix those exact issues, keep the requested skill identity, and regenerate.",
-          requestedModel: LIVE_ANTHROPIC_MODEL,
+          requestedModel: FRIDAY_DEEP_PROOF_MODEL,
         },
         { timeoutMs: 240_000 },
       );
@@ -484,7 +475,7 @@ async function testSkillDraft(
         message:
           `The explicit self-test failed: ${lastFailure}. ` +
           "Fix the draft so the self-test passes, preserve the exact skill id/version, and regenerate.",
-        requestedModel: LIVE_ANTHROPIC_MODEL,
+        requestedModel: FRIDAY_DEEP_PROOF_MODEL,
       },
       { timeoutMs: 240_000 },
     );
@@ -496,7 +487,7 @@ async function testSkillDraft(
       env.accessToken,
       "POST",
       `/v1/skills/generator/sessions/${encodeURIComponent(sessionId)}/generate`,
-      { requestedModel: LIVE_ANTHROPIC_MODEL },
+      { requestedModel: FRIDAY_DEEP_PROOF_MODEL },
       { timeoutMs: 240_000 },
     );
     expect(generateRes.status).toBe(200);
@@ -614,13 +605,13 @@ async function getSkillUpgradeStatus(
   return response.json.data.items[0]!;
 }
 
-describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Generator Maintenance Live (Anthropic API key)", () => {
+describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)(`Friday Generator Maintenance Live (${FRIDAY_DEEP_PROOF_PROVIDER_LABEL})`, () => {
   let env: RealHubEnv;
   const generatedSkillDirs = new Set<string>();
 
   beforeAll(async () => {
     env = await createFridayDeepProofHubEnv();
-    await ensureAnthropicGeneratorProviders(env);
+    await ensureGeneratorMaintenanceDeepProofProviders(env);
   }, 120_000);
 
   afterAll(async () => {
@@ -732,7 +723,7 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Generator Maintenance Live (An
         {
           shadowVersionId: second.draft!.manifest!.version,
           runtimeVersion,
-          providerModel: LIVE_ANTHROPIC_MODEL,
+          providerModel: FRIDAY_DEEP_PROOF_MODEL,
         },
       );
       expect(shadowV2Res.status).toBe(200);
@@ -795,7 +786,7 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Generator Maintenance Live (An
         `/v1/autonomy/skills/${encodeURIComponent(skillId)}/promote`,
         {
           runtimeVersion,
-          providerModel: LIVE_ANTHROPIC_MODEL,
+          providerModel: FRIDAY_DEEP_PROOF_MODEL,
         },
       );
       expect(promoteRes.status).toBe(200);
@@ -815,7 +806,7 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Generator Maintenance Live (An
         promotionChannel: "active",
         shadowVersionId: "2.0.0",
         lastVerifiedRuntimeVersion: runtimeVersion,
-        lastVerifiedProviderModel: LIVE_ANTHROPIC_MODEL,
+        lastVerifiedProviderModel: FRIDAY_DEEP_PROOF_MODEL,
       });
       expect(JSON.parse(promotedRow!.canaryStatsJson)).toMatchObject({
         sampleSize: 1,
@@ -855,7 +846,7 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Generator Maintenance Live (An
         {
           shadowVersionId: blockedPromotion.draft!.manifest!.version,
           runtimeVersion,
-          providerModel: LIVE_ANTHROPIC_MODEL,
+          providerModel: FRIDAY_DEEP_PROOF_MODEL,
         },
       );
       expect(shadowV3Res.status).toBe(200);
@@ -892,7 +883,7 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Generator Maintenance Live (An
         `/v1/autonomy/skills/${encodeURIComponent(skillId)}/rollback`,
         {
           runtimeVersion,
-          providerModel: LIVE_ANTHROPIC_MODEL,
+          providerModel: FRIDAY_DEEP_PROOF_MODEL,
         },
       );
       expect(rollbackRes.status).toBe(200);
@@ -925,7 +916,7 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Generator Maintenance Live (An
         promotionChannel: "rolled_back",
         shadowVersionId: null,
         lastVerifiedRuntimeVersion: runtimeVersion,
-        lastVerifiedProviderModel: LIVE_ANTHROPIC_MODEL,
+        lastVerifiedProviderModel: FRIDAY_DEEP_PROOF_MODEL,
       });
       expect(JSON.parse(rolledBackRow!.canaryStatsJson)).toMatchObject({
         sampleSize: 1,

--- a/test/e2e/live/friday-self-healing-live.e2e.test.ts
+++ b/test/e2e/live/friday-self-healing-live.e2e.test.ts
@@ -5,11 +5,18 @@ import Database from "better-sqlite3";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import type { FridayCompiledWorkflowGraphV2 } from "#workflows";
-import { apiFetch, createOpenAiProvider, verifyProviderTextCapability } from "./_helpers/api.js";
+import {
+  apiFetch,
+  createDeepSeekProvider,
+  createOpenAiProvider,
+  verifyProviderTextCapability,
+} from "./_helpers/api.js";
 import { pollUntil } from "./_helpers/poll.js";
 import {
   cleanupRealHubEnv,
   createRealHubEnv,
+  DEEPSEEK_API_KEY_ENV,
+  DEEPSEEK_BASE_URL,
   E2E_GATED,
   FAST_MODEL,
   LIVE_PROVIDER_KIND,
@@ -18,7 +25,14 @@ import {
   type RealHubEnv,
 } from "./_helpers/real-env.js";
 
-const OPENAI_PROOF_GATED = E2E_GATED && LIVE_PROVIDER_KIND === "openai";
+// Mirrors the learning-live gate pattern: accept openai or deepseek as the
+// active provider lane. Self-healing logic is provider-agnostic (incident +
+// lesson + auto-fix is Friday-internal); the provider only supplies the
+// underlying LLM substrate. Active-provider evidence labelling stays honest:
+// a DeepSeek run proves DeepSeek self-healing, not OpenAI.
+const SELF_HEALING_PROOF_GATED =
+  E2E_GATED && (LIVE_PROVIDER_KIND === "openai" || LIVE_PROVIDER_KIND === "deepseek");
+const LIVE_PROVIDER_LABEL = LIVE_PROVIDER_KIND === "deepseek" ? "DeepSeek" : "OpenAI";
 const LIVE_MODEL = FAST_MODEL;
 const BUNDLED_SKILLS_DIR = path.join(process.cwd(), "skills");
 
@@ -358,21 +372,29 @@ async function readUserId(env: RealHubEnv): Promise<string> {
 }
 
 async function createProviderPair(env: RealHubEnv): Promise<{ primaryProviderId: string; secondaryProviderId: string }> {
-  const apiKeyEnvRef = `$${OPENAI_API_KEY_ENV}`;
-  const primaryProviderId = await createOpenAiProvider(env.baseUrl, env.accessToken, {
-    name: "OpenAI Primary Self-Healing (Live Proof)",
-    openAiBaseUrl: OPENAI_BASE_URL,
-    models: [LIVE_MODEL],
-    defaultModel: LIVE_MODEL,
-    apiKeyEnvRef,
-  });
-  const secondaryProviderId = await createOpenAiProvider(env.baseUrl, env.accessToken, {
-    name: "OpenAI Secondary Self-Healing (Live Proof)",
-    openAiBaseUrl: OPENAI_BASE_URL,
-    models: [LIVE_MODEL],
-    defaultModel: LIVE_MODEL,
-    apiKeyEnvRef,
-  });
+  // Branch on LIVE_PROVIDER_KIND to create the active-lane primary +
+  // secondary provider pair. Mirrors learning-live's ensureLiveLearningProvider
+  // pattern. Provider names embed LIVE_PROVIDER_LABEL so the persisted rows
+  // are diagnosable per lane.
+  const create = async (name: string): Promise<string> =>
+    LIVE_PROVIDER_KIND === "deepseek"
+      ? createDeepSeekProvider(env.baseUrl, env.accessToken, {
+          name,
+          deepSeekBaseUrl: DEEPSEEK_BASE_URL,
+          models: [LIVE_MODEL],
+          defaultModel: LIVE_MODEL,
+          apiKeyEnvRef: `$${DEEPSEEK_API_KEY_ENV}`,
+        })
+      : createOpenAiProvider(env.baseUrl, env.accessToken, {
+          name,
+          openAiBaseUrl: OPENAI_BASE_URL,
+          models: [LIVE_MODEL],
+          defaultModel: LIVE_MODEL,
+          apiKeyEnvRef: `$${OPENAI_API_KEY_ENV}`,
+        });
+
+  const primaryProviderId = await create(`${LIVE_PROVIDER_LABEL} Primary Self-Healing (Live Proof)`);
+  const secondaryProviderId = await create(`${LIVE_PROVIDER_LABEL} Secondary Self-Healing (Live Proof)`);
   await verifyProviderTextCapability(env.baseUrl, env.accessToken, primaryProviderId, LIVE_MODEL, {
     doctorProviderIds: [primaryProviderId, secondaryProviderId],
   });
@@ -622,7 +644,7 @@ async function waitForWorkflowRunStable(
   return env.hub!.workflowRuntime.execution.getRun(runId)?.status ?? "unknown";
 }
 
-describe.skipIf(!OPENAI_PROOF_GATED)("Friday Self-Healing Full Matrix (OpenAI API key)", () => {
+describe.skipIf(!SELF_HEALING_PROOF_GATED)(`Friday Self-Healing Full Matrix (${LIVE_PROVIDER_LABEL} API key)`, () => {
   let env: RealHubEnv;
   let userId: string;
   let primaryProviderId: string;

--- a/test/e2e/live/friday-self-upgrade-channel-adapter-live.e2e.test.ts
+++ b/test/e2e/live/friday-self-upgrade-channel-adapter-live.e2e.test.ts
@@ -5,11 +5,12 @@ import path from "node:path";
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
-import { LIVE_ANTHROPIC_MODEL } from "../_helpers/live-anthropic.js";
 import {
   cleanupFridayDeepProofHubEnv,
   createFridayDeepProofHubEnv,
   FRIDAY_DEEP_PROOF_GATED,
+  FRIDAY_DEEP_PROOF_MODEL,
+  FRIDAY_DEEP_PROOF_PROVIDER_LABEL,
   type RealHubEnv,
 } from "./_helpers/deep-proof-env.js";
 
@@ -369,7 +370,7 @@ async function getChannel(env: RealHubEnv, channelKind: string): Promise<Channel
   return json.data.channel;
 }
 
-describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Channel Adapter Self Upgrade Live (Anthropic API key lane)", () => {
+describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)(`Friday Channel Adapter Self Upgrade Live (${FRIDAY_DEEP_PROOF_PROVIDER_LABEL})`, () => {
   let env: RealHubEnv;
   const inboundMessages: Array<{ text: string; senderId: string }> = [];
 
@@ -463,7 +464,7 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Channel Adapter Self Upgrade L
         body: JSON.stringify({
           shadowVersionId: firstShadowId,
           runtimeVersion,
-          providerModel: LIVE_ANTHROPIC_MODEL,
+          providerModel: FRIDAY_DEEP_PROOF_MODEL,
         }),
       });
       const shadowJson = await shadowRes.json() as ChannelActionEnvelope;
@@ -495,7 +496,7 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Channel Adapter Self Upgrade L
         },
         body: JSON.stringify({
           runtimeVersion,
-          providerModel: LIVE_ANTHROPIC_MODEL,
+          providerModel: FRIDAY_DEEP_PROOF_MODEL,
         }),
       });
       const promoteJson = await promoteRes.json() as ChannelActionEnvelope;
@@ -509,7 +510,7 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Channel Adapter Self Upgrade L
       expect(rowAfterPromote?.promotionChannel).toBe("active");
       expect(rowAfterPromote?.compatibilityStatus).toBe("compatible");
       expect(rowAfterPromote?.lastVerifiedRuntimeVersion).toBe(runtimeVersion);
-      expect(rowAfterPromote?.lastVerifiedProviderModel).toBe(LIVE_ANTHROPIC_MODEL);
+      expect(rowAfterPromote?.lastVerifiedProviderModel).toBe(FRIDAY_DEEP_PROOF_MODEL);
 
       const secondShadowId = "webchat@shadow-rollback";
       await fetch(`${env.baseUrl}/v1/autonomy/channels/webchat/shadow`, {
@@ -521,7 +522,7 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Channel Adapter Self Upgrade L
         body: JSON.stringify({
           shadowVersionId: secondShadowId,
           runtimeVersion,
-          providerModel: LIVE_ANTHROPIC_MODEL,
+          providerModel: FRIDAY_DEEP_PROOF_MODEL,
         }),
       });
 
@@ -545,7 +546,7 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Channel Adapter Self Upgrade L
         },
         body: JSON.stringify({
           runtimeVersion,
-          providerModel: LIVE_ANTHROPIC_MODEL,
+          providerModel: FRIDAY_DEEP_PROOF_MODEL,
         }),
       });
       const rollbackJson = await rollbackRes.json() as ChannelActionEnvelope;

--- a/test/e2e/live/friday-self-upgrade-mcp-server-live.e2e.test.ts
+++ b/test/e2e/live/friday-self-upgrade-mcp-server-live.e2e.test.ts
@@ -3,11 +3,12 @@ import path from "node:path";
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
-import { LIVE_ANTHROPIC_MODEL } from "../_helpers/live-anthropic.js";
 import {
   cleanupFridayDeepProofHubEnv,
   createFridayDeepProofHubEnv,
   FRIDAY_DEEP_PROOF_GATED,
+  FRIDAY_DEEP_PROOF_MODEL,
+  FRIDAY_DEEP_PROOF_PROVIDER_LABEL,
   type RealHubEnv,
 } from "./_helpers/deep-proof-env.js";
 
@@ -188,7 +189,7 @@ async function getUpgradeStatus(env: RealHubEnv, serverId: string): Promise<Upgr
   return json.data.items[0]!;
 }
 
-describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday MCP Server Self Upgrade Live (Anthropic API key lane)", () => {
+describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)(`Friday MCP Server Self Upgrade Live (${FRIDAY_DEEP_PROOF_PROVIDER_LABEL})`, () => {
   let env: RealHubEnv;
   let previousMcpServers: string | undefined;
   let previousMcpServerEnabled: string | undefined;
@@ -271,7 +272,7 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday MCP Server Self Upgrade Live (
         body: JSON.stringify({
           shadowVersionId: firstShadowId,
           runtimeVersion,
-          providerModel: LIVE_ANTHROPIC_MODEL,
+          providerModel: FRIDAY_DEEP_PROOF_MODEL,
         }),
       });
       const shadowJson = await shadowRes.json() as McpActionEnvelope;
@@ -303,7 +304,7 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday MCP Server Self Upgrade Live (
         },
         body: JSON.stringify({
           runtimeVersion,
-          providerModel: LIVE_ANTHROPIC_MODEL,
+          providerModel: FRIDAY_DEEP_PROOF_MODEL,
         }),
       });
       const promoteJson = await promoteRes.json() as McpActionEnvelope;
@@ -317,7 +318,7 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday MCP Server Self Upgrade Live (
       expect(rowAfterPromote?.promotionChannel).toBe("active");
       expect(rowAfterPromote?.compatibilityStatus).toBe("compatible");
       expect(rowAfterPromote?.lastVerifiedRuntimeVersion).toBe(runtimeVersion);
-      expect(rowAfterPromote?.lastVerifiedProviderModel).toBe(LIVE_ANTHROPIC_MODEL);
+      expect(rowAfterPromote?.lastVerifiedProviderModel).toBe(FRIDAY_DEEP_PROOF_MODEL);
 
       const secondShadowId = `${serverId}@shadow-rollback`;
       await fetch(`${env.baseUrl}/v1/autonomy/mcp-servers/${encodeURIComponent(serverId)}/shadow`, {
@@ -329,7 +330,7 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday MCP Server Self Upgrade Live (
         body: JSON.stringify({
           shadowVersionId: secondShadowId,
           runtimeVersion,
-          providerModel: LIVE_ANTHROPIC_MODEL,
+          providerModel: FRIDAY_DEEP_PROOF_MODEL,
         }),
       });
 
@@ -353,7 +354,7 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday MCP Server Self Upgrade Live (
         },
         body: JSON.stringify({
           runtimeVersion,
-          providerModel: LIVE_ANTHROPIC_MODEL,
+          providerModel: FRIDAY_DEEP_PROOF_MODEL,
         }),
       });
       const rollbackJson = await rollbackRes.json() as McpActionEnvelope;

--- a/test/e2e/live/friday-self-upgrade-plugin-live.e2e.test.ts
+++ b/test/e2e/live/friday-self-upgrade-plugin-live.e2e.test.ts
@@ -5,7 +5,6 @@ import path from "node:path";
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
-import { LIVE_ANTHROPIC_MODEL } from "../_helpers/live-anthropic.js";
 import { apiFetch } from "./_helpers/api.js";
 import {
   createFridayPluginLifecycleMutatingActionRequest,
@@ -19,6 +18,8 @@ import {
   cleanupFridayDeepProofHubEnv,
   createFridayDeepProofHubEnv,
   FRIDAY_DEEP_PROOF_GATED,
+  FRIDAY_DEEP_PROOF_MODEL,
+  FRIDAY_DEEP_PROOF_PROVIDER_LABEL,
   type RealHubEnv,
 } from "./_helpers/deep-proof-env.js";
 
@@ -229,7 +230,7 @@ function makePluginLifecycleApproval(input: {
     pluginId: input.pluginId,
     shadowVersionId: input.shadowVersionId,
     runtimeVersion: input.runtimeVersion,
-    providerModel: LIVE_ANTHROPIC_MODEL,
+    providerModel: FRIDAY_DEEP_PROOF_MODEL,
     actor: {
       kind: "user",
       id: LOCAL_LIVE_PRINCIPAL_ID,
@@ -248,7 +249,7 @@ function makePluginLifecycleApproval(input: {
   }, PLUGIN_LIFECYCLE_SIGNING_MATERIAL);
 }
 
-describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Plugin Self Upgrade Live (Anthropic API key lane)", () => {
+describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)(`Friday Plugin Self Upgrade Live (${FRIDAY_DEEP_PROOF_PROVIDER_LABEL})`, () => {
   let env: RealHubEnv;
   let pluginRootDir: string;
 
@@ -317,7 +318,7 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Plugin Self Upgrade Live (Anth
         `/v1/autonomy/plugins/${encodeURIComponent(pluginId)}/review-enable`,
         {
           runtimeVersion,
-          providerModel: LIVE_ANTHROPIC_MODEL,
+          providerModel: FRIDAY_DEEP_PROOF_MODEL,
         },
       );
       expect(reviewEnableRes.status).toBe(200);
@@ -363,7 +364,7 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Plugin Self Upgrade Live (Anth
         `/v1/autonomy/plugins/${encodeURIComponent(pluginId)}/rollback`,
         {
           runtimeVersion,
-          providerModel: LIVE_ANTHROPIC_MODEL,
+          providerModel: FRIDAY_DEEP_PROOF_MODEL,
           planDigest,
           reason: "live plugin lifecycle rollback proof",
           canonicalApproval: makePluginLifecycleApproval({

--- a/test/e2e/live/friday-self-upgrade-provider-profile-live.e2e.test.ts
+++ b/test/e2e/live/friday-self-upgrade-provider-profile-live.e2e.test.ts
@@ -3,8 +3,7 @@ import path from "node:path";
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
-import { LIVE_ANTHROPIC_MODEL, liveAnthropicCredentialMessage } from "../_helpers/live-anthropic.js";
-import { apiFetch, createAnthropicProvider } from "./_helpers/api.js";
+import { apiFetch } from "./_helpers/api.js";
 import {
   createFridayProviderProfileLifecycleMutatingActionRequest,
 } from "../../../src/autonomy/services/friday-provider-profile-upgrade-lifecycle-service.js";
@@ -16,12 +15,11 @@ import {
 import {
   cleanupFridayDeepProofHubEnv,
   createFridayDeepProofHubEnv,
-  FRIDAY_DEEP_PROOF_ANTHROPIC_API_KEY_ENV_REF,
+  createFridayDeepProofProvider,
   FRIDAY_DEEP_PROOF_GATED,
+  FRIDAY_DEEP_PROOF_PROVIDER_LABEL,
   type RealHubEnv,
 } from "./_helpers/deep-proof-env.js";
-
-const ANTHROPIC_BASE_URL = process.env.E2E_ANTHROPIC_BASE_URL ?? "https://api.anthropic.com";
 const PROVIDER_LIFECYCLE_PLAN_DIGEST = "provider-profile-live-proof-plan";
 const PROVIDER_LIFECYCLE_SIGNING_MATERIAL =
   "provider-profile-live-proof-signing-material"; // pragma: allowlist secret
@@ -163,6 +161,7 @@ function makeProviderLifecycleApproval(input: {
   providerId: string;
   shadowVersionId?: string;
   runtimeVersion: string;
+  providerModel: string;
 }): FridayCanonicalApprovalResolution {
   const rollback = input.action === "rollback"
     ? { planned: true, planDigest: PROVIDER_LIFECYCLE_PLAN_DIGEST, actions: ["providers.lifecycle.promote"] }
@@ -172,7 +171,7 @@ function makeProviderLifecycleApproval(input: {
     providerId: input.providerId,
     shadowVersionId: input.shadowVersionId,
     runtimeVersion: input.runtimeVersion,
-    providerModel: LIVE_ANTHROPIC_MODEL,
+    providerModel: input.providerModel,
     actor: {
       kind: "user",
       id: LOCAL_LIVE_PRINCIPAL_ID,
@@ -216,7 +215,7 @@ async function getUpgradeStatus(env: RealHubEnv, providerId: string): Promise<Up
   return response.json.data.items[0]!;
 }
 
-describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Provider Profile Self Upgrade Live (Anthropic API key)", () => {
+describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)(`Friday Provider Profile Self Upgrade Live (${FRIDAY_DEEP_PROOF_PROVIDER_LABEL} active provider)`, () => {
   let env: RealHubEnv;
 
   beforeAll(async () => {
@@ -237,18 +236,15 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Provider Profile Self Upgrade 
     "proves provider_profile detect-adapt-replay-shadow-canary-promote-rollback with API and SQLite readback",
     { timeout: 300_000, retry: 1 },
     async () => {
-      const apiKeyEnvRef = FRIDAY_DEEP_PROOF_ANTHROPIC_API_KEY_ENV_REF
-        ?? (() => {
-          throw new Error(liveAnthropicCredentialMessage());
-        })();
       const runtimeVersion = await getRuntimeVersion(env);
-      const providerId = await createAnthropicProvider(env.baseUrl, env.accessToken, {
+      // Active-provider proof: a DeepSeek run proves DeepSeek provider-profile
+      // upgrade lifecycle, an Anthropic run proves Anthropic. Lane is fixed
+      // by the deep-proof env gate, not by this test body.
+      const providerCreation = await createFridayDeepProofProvider(env, {
         name: `Provider Self Upgrade ${Date.now().toString(36)}`,
-        anthropicBaseUrl: ANTHROPIC_BASE_URL,
-        models: [LIVE_ANTHROPIC_MODEL],
-        defaultModel: LIVE_ANTHROPIC_MODEL,
-        apiKeyEnvRef,
       });
+      const providerId = providerCreation.providerId;
+      const providerModel = providerCreation.model;
 
       const detectStatus = await getUpgradeStatus(env, providerId);
       expect(detectStatus.derivedCompatibilityStatus).toBe("adaptation_required");
@@ -283,9 +279,10 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Provider Profile Self Upgrade 
         {
           shadowVersionId: firstShadowId,
           runtimeVersion,
-          providerModel: LIVE_ANTHROPIC_MODEL,
+          providerModel,
           planDigest: PROVIDER_LIFECYCLE_PLAN_DIGEST,
           canonicalApproval: makeProviderLifecycleApproval({
+            providerModel,
             action: "shadow",
             providerId,
             shadowVersionId: firstShadowId,
@@ -306,9 +303,10 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Provider Profile Self Upgrade 
         `/v1/autonomy/providers/${encodeURIComponent(providerId)}/canary`,
         {
           runtimeVersion,
-          providerModel: LIVE_ANTHROPIC_MODEL,
+          providerModel,
           planDigest: PROVIDER_LIFECYCLE_PLAN_DIGEST,
           canonicalApproval: makeProviderLifecycleApproval({
+            providerModel,
             action: "canary",
             providerId,
             shadowVersionId: firstShadowId,
@@ -329,9 +327,10 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Provider Profile Self Upgrade 
         `/v1/autonomy/providers/${encodeURIComponent(providerId)}/promote`,
         {
           runtimeVersion,
-          providerModel: LIVE_ANTHROPIC_MODEL,
+          providerModel,
           planDigest: PROVIDER_LIFECYCLE_PLAN_DIGEST,
           canonicalApproval: makeProviderLifecycleApproval({
+            providerModel,
             action: "promote",
             providerId,
             shadowVersionId: firstShadowId,
@@ -352,10 +351,11 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Provider Profile Self Upgrade 
         `/v1/autonomy/providers/${encodeURIComponent(providerId)}/rollback`,
         {
           runtimeVersion,
-          providerModel: LIVE_ANTHROPIC_MODEL,
+          providerModel,
           planDigest: PROVIDER_LIFECYCLE_PLAN_DIGEST,
           reason: "live provider lifecycle rollback proof",
           canonicalApproval: makeProviderLifecycleApproval({
+            providerModel,
             action: "rollback",
             providerId,
             shadowVersionId: firstShadowId,

--- a/test/e2e/live/friday-self-upgrade-workflow-live.e2e.test.ts
+++ b/test/e2e/live/friday-self-upgrade-workflow-live.e2e.test.ts
@@ -3,18 +3,17 @@ import path from "node:path";
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
-import { LIVE_ANTHROPIC_MODEL, liveAnthropicCredentialMessage } from "../_helpers/live-anthropic.js";
-import { apiFetch, ensureAnthropicProviders } from "./_helpers/api.js";
+import { apiFetch } from "./_helpers/api.js";
 import { pollRunTerminal } from "./_helpers/workflow.js";
 import {
   cleanupFridayDeepProofHubEnv,
   createFridayDeepProofHubEnv,
-  FRIDAY_DEEP_PROOF_ANTHROPIC_API_KEY_ENV_REF,
+  ensureFridayDeepProofProviders,
   FRIDAY_DEEP_PROOF_GATED,
+  FRIDAY_DEEP_PROOF_MODEL,
+  FRIDAY_DEEP_PROOF_PROVIDER_LABEL,
   type RealHubEnv,
 } from "./_helpers/deep-proof-env.js";
-
-const ANTHROPIC_BASE_URL = process.env.E2E_ANTHROPIC_BASE_URL ?? "https://api.anthropic.com";
 
 interface WorkflowCreateEnvelope {
   ok: boolean;
@@ -179,20 +178,10 @@ function readWorkflowVersions(stateDir: string, workflowId: string): WorkflowVer
   }
 }
 
-async function ensureAnthropicWorkflowProviders(env: RealHubEnv): Promise<void> {
-  const apiKeyEnvRef = FRIDAY_DEEP_PROOF_ANTHROPIC_API_KEY_ENV_REF
-    ?? (() => {
-      throw new Error(liveAnthropicCredentialMessage());
-    })();
-  await ensureAnthropicProviders(
-    env.baseUrl,
-    env.accessToken,
-    ANTHROPIC_BASE_URL,
-    LIVE_ANTHROPIC_MODEL,
-    LIVE_ANTHROPIC_MODEL,
-    apiKeyEnvRef,
-    { namePrefix: "Workflow Self Upgrade Deep Proof" },
-  );
+async function ensureWorkflowDeepProofProviders(env: RealHubEnv): Promise<void> {
+  await ensureFridayDeepProofProviders(env, {
+    namePrefix: "Workflow Self Upgrade Deep Proof",
+  });
 }
 
 async function getRuntimeVersion(env: RealHubEnv): Promise<string> {
@@ -302,7 +291,7 @@ async function createUpgradeVersion(
             label: "Anthropic Upgrade Probe",
             config: {
               prompt: "Reply with the exact text: upgraded by anthropic",
-              model: LIVE_ANTHROPIC_MODEL,
+              model: FRIDAY_DEEP_PROOF_MODEL,
             },
           },
           {
@@ -414,12 +403,12 @@ async function runWorkflowVersion(
   };
 }
 
-describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Workflow Self Upgrade Live (Anthropic API key)", () => {
+describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)(`Friday Workflow Self Upgrade Live (${FRIDAY_DEEP_PROOF_PROVIDER_LABEL})`, () => {
   let env: RealHubEnv;
 
   beforeAll(async () => {
     env = await createFridayDeepProofHubEnv();
-    await ensureAnthropicWorkflowProviders(env);
+    await ensureWorkflowDeepProofProviders(env);
   }, 120_000);
 
   afterAll(async () => {
@@ -463,7 +452,7 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Workflow Self Upgrade Live (An
         {
           workflowVersionId: upgraded.versionId,
           runtimeVersion,
-          providerModel: LIVE_ANTHROPIC_MODEL,
+          providerModel: FRIDAY_DEEP_PROOF_MODEL,
         },
       );
       expect(shadowRes.status).toBe(200);
@@ -500,7 +489,7 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Workflow Self Upgrade Live (An
         {
           versionNumber: upgraded.versionNumber,
           runtimeVersion,
-          providerModel: LIVE_ANTHROPIC_MODEL,
+          providerModel: FRIDAY_DEEP_PROOF_MODEL,
         },
       );
       expect(promoteRes.status).toBe(200);
@@ -521,7 +510,7 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Workflow Self Upgrade Live (An
         {
           targetVersionNumber: 1,
           runtimeVersion,
-          providerModel: LIVE_ANTHROPIC_MODEL,
+          providerModel: FRIDAY_DEEP_PROOF_MODEL,
         },
       );
       expect(rollbackRes.status).toBe(200);

--- a/test/e2e/live/friday-subagent-live.e2e.test.ts
+++ b/test/e2e/live/friday-subagent-live.e2e.test.ts
@@ -1,21 +1,23 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
-import { LIVE_ANTHROPIC_MODEL, liveAnthropicCredentialMessage } from "../_helpers/live-anthropic.js";
-import { apiFetch, ensureAnthropicProviders } from "./_helpers/api.js";
+import { apiFetch } from "./_helpers/api.js";
 import { pollUntil } from "./_helpers/poll.js";
 import {
   cleanupFridayDeepProofHubEnv,
   createFridayDeepProofHubEnv,
   createFridayDeepProofHubEnvFromStateDir,
-  FRIDAY_DEEP_PROOF_ANTHROPIC_API_KEY_ENV_REF,
+  ensureFridayDeepProofProviders,
   FRIDAY_DEEP_PROOF_GATED,
+  FRIDAY_DEEP_PROOF_PROVIDER_LABEL,
+  selectFridayDeepProofProviderKind,
   shutdownFridayDeepProofHubEnv,
   type RealHubEnv,
 } from "./_helpers/deep-proof-env.js";
 
-const ANTHROPIC_BASE_URL = process.env.E2E_ANTHROPIC_BASE_URL ?? "https://api.anthropic.com";
 const SUBAGENT_FORK_GATED = process.env.FRIDAY_SUBAGENT_FORK_MODE_ENABLED === "true";
-const INVALID_ANTHROPIC_MODEL = "claude-invalid-subagent-live";
+// Provider-aware obviously-invalid model fixture. Stays clearly-invalid for
+// every provider lane while signalling which lane the run is exercising.
+const INVALID_LIVE_MODEL = `${selectFridayDeepProofProviderKind() ?? "no-provider"}-invalid-subagent-live`;
 
 interface StartAgentRunResponse {
   ok: boolean;
@@ -156,24 +158,20 @@ async function listSessionMessages(
   );
 }
 
-describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Subagent Live (Anthropic API key)", () => {
+describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)(`Friday Subagent Live (${FRIDAY_DEEP_PROOF_PROVIDER_LABEL})`, () => {
   let env: RealHubEnv;
   let providerId: string;
+  let liveModel: string;
 
   beforeAll(async () => {
     env = await createFridayDeepProofHubEnv();
 
-    const providers = await ensureAnthropicProviders(
-      env.baseUrl,
-      env.accessToken,
-      ANTHROPIC_BASE_URL,
-      LIVE_ANTHROPIC_MODEL,
-      LIVE_ANTHROPIC_MODEL,
-      FRIDAY_DEEP_PROOF_ANTHROPIC_API_KEY_ENV_REF ?? (() => { throw new Error(liveAnthropicCredentialMessage()); })(),
-      { namePrefix: "Subagent Live" },
-    );
+    const providers = await ensureFridayDeepProofProviders(env, {
+      namePrefix: "Subagent Live",
+    });
 
     providerId = providers.codeProviderId;
+    liveModel = providers.codeModel;
   }, 60_000);
 
   afterAll(async () => {
@@ -197,7 +195,7 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Subagent Live (Anthropic API k
         "/v1/agent/runs",
         {
           providerId,
-          model: LIVE_ANTHROPIC_MODEL,
+          model: liveModel,
           timeoutMs: 120_000,
           task: [
             "You must use spawn_subagent exactly once with wait=true because your final answer depends on the child result in this same run.",
@@ -305,11 +303,11 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Subagent Live (Anthropic API k
         "/v1/agent/runs",
         {
           providerId,
-          model: LIVE_ANTHROPIC_MODEL,
+          model: liveModel,
           timeoutMs: 120_000,
           task: [
             "You must use spawn_subagent exactly once with wait=true.",
-            `Override the child model to "${INVALID_ANTHROPIC_MODEL}" so the child fails deterministically.`,
+            `Override the child model to "${INVALID_LIVE_MODEL}" so the child fails deterministically.`,
             `The child task should attempt to return "CHILD_SHOULD_FAIL_${marker}" and nothing else.`,
             `When the child fails, do not retry and do not crash. Your final answer must be exactly "${parentAnswer}" and nothing else.`,
           ].join(" "),
@@ -341,7 +339,7 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Subagent Live (Anthropic API k
       const subagent = subagentList.json.data.items[0]!;
       expect(subagent.status).toBe("failed");
       expect(subagent.mode).toBe("fresh");
-      expect(subagent.model).toBe(INVALID_ANTHROPIC_MODEL);
+      expect(subagent.model).toBe(INVALID_LIVE_MODEL);
       expect(subagent.outcome?.status).toBe("failed");
       expect((subagent.outcome?.response ?? "").trim().length).toBeGreaterThan(0);
 
@@ -384,7 +382,7 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Subagent Live (Anthropic API k
         "/v1/agent/runs",
         {
           providerId,
-          model: LIVE_ANTHROPIC_MODEL,
+          model: liveModel,
           timeoutMs: 120_000,
           task: [
             "You must use spawn_subagent exactly once with wait=false.",
@@ -470,7 +468,7 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Subagent Live (Anthropic API k
         "/v1/agent/runs",
         {
           providerId,
-          model: LIVE_ANTHROPIC_MODEL,
+          model: liveModel,
           sessionKey,
           timeoutMs: 120_000,
           task: [
@@ -539,7 +537,7 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Subagent Live (Anthropic API k
         "/v1/agent/runs",
         {
           providerId,
-          model: LIVE_ANTHROPIC_MODEL,
+          model: liveModel,
           timeoutMs: 120_000,
           task: [
             "You must use spawn_subagent exactly once with wait=false.",

--- a/test/e2e/live/friday-workflow-generator-maintenance-live.e2e.test.ts
+++ b/test/e2e/live/friday-workflow-generator-maintenance-live.e2e.test.ts
@@ -3,19 +3,18 @@ import path from "node:path";
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
-import { LIVE_ANTHROPIC_MODEL, liveAnthropicCredentialMessage } from "../_helpers/live-anthropic.js";
-import { apiFetch, ensureAnthropicProviders } from "./_helpers/api.js";
+import { apiFetch } from "./_helpers/api.js";
 import { pollUntil } from "./_helpers/poll.js";
 import { pollRunTerminal } from "./_helpers/workflow.js";
 import {
   cleanupFridayDeepProofHubEnv,
   createFridayDeepProofHubEnv,
-  FRIDAY_DEEP_PROOF_ANTHROPIC_API_KEY_ENV_REF,
+  ensureFridayDeepProofProviders,
   FRIDAY_DEEP_PROOF_GATED,
+  FRIDAY_DEEP_PROOF_MODEL,
+  FRIDAY_DEEP_PROOF_PROVIDER_LABEL,
   type RealHubEnv,
 } from "./_helpers/deep-proof-env.js";
-
-const ANTHROPIC_BASE_URL = process.env.E2E_ANTHROPIC_BASE_URL ?? "https://api.anthropic.com";
 
 interface WorkflowCreateEnvelope {
   ok: boolean;
@@ -202,18 +201,10 @@ function decodeArtifactUri(uri: string): string {
   return Buffer.from(uri.slice(prefix.length), "base64").toString("utf8");
 }
 
-async function ensureAnthropicWorkflowProviders(env: RealHubEnv): Promise<void> {
-  const apiKeyEnvRef = FRIDAY_DEEP_PROOF_ANTHROPIC_API_KEY_ENV_REF
-    ?? (() => { throw new Error(liveAnthropicCredentialMessage()); })();
-  await ensureAnthropicProviders(
-    env.baseUrl,
-    env.accessToken,
-    ANTHROPIC_BASE_URL,
-    LIVE_ANTHROPIC_MODEL,
-    LIVE_ANTHROPIC_MODEL,
-    apiKeyEnvRef,
-    { namePrefix: "Workflow Generator Deep Proof" },
-  );
+async function ensureWorkflowGeneratorDeepProofProviders(env: RealHubEnv): Promise<void> {
+  await ensureFridayDeepProofProviders(env, {
+    namePrefix: "Workflow Generator Deep Proof",
+  });
 }
 
 async function createBaseWorkflow(
@@ -380,7 +371,7 @@ async function createValidatedWorkflowDraft(
       goal: input.goal,
       userId: "admin-001",
       channel: "deep-workflow-maintenance",
-      requestedModel: LIVE_ANTHROPIC_MODEL,
+      requestedModel: FRIDAY_DEEP_PROOF_MODEL,
       targetWorkflowId: input.targetWorkflowId,
     },
     { timeoutMs: 300_000 },
@@ -397,7 +388,7 @@ async function createValidatedWorkflowDraft(
       `/v1/workflows/generator/sessions/${encodeURIComponent(sessionId)}/messages`,
       {
         message: input.clarification,
-        requestedModel: LIVE_ANTHROPIC_MODEL,
+        requestedModel: FRIDAY_DEEP_PROOF_MODEL,
       },
       { timeoutMs: 300_000 },
     );
@@ -429,7 +420,7 @@ async function createValidatedWorkflowDraft(
       env.accessToken,
       "POST",
       `/v1/workflows/generator/sessions/${encodeURIComponent(sessionId)}/generate`,
-      { requestedModel: LIVE_ANTHROPIC_MODEL },
+      { requestedModel: FRIDAY_DEEP_PROOF_MODEL },
       { timeoutMs: 300_000 },
     );
     expect(generateRes.status).toBe(200);
@@ -462,7 +453,7 @@ async function createValidatedWorkflowDraft(
           message:
             `The previous workflow draft still has validation issues: ${lastIssues}. ` +
             "Keep the same workflow identity, fix those exact issues, and regenerate.",
-          requestedModel: LIVE_ANTHROPIC_MODEL,
+          requestedModel: FRIDAY_DEEP_PROOF_MODEL,
         },
         { timeoutMs: 300_000 },
       );
@@ -475,12 +466,12 @@ async function createValidatedWorkflowDraft(
   throw new Error(`Workflow generator draft never validated. Last issues: ${lastIssues}`);
 }
 
-describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)("Friday Workflow Generator Maintenance Live (Anthropic API key)", () => {
+describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)(`Friday Workflow Generator Maintenance Live (${FRIDAY_DEEP_PROOF_PROVIDER_LABEL})`, () => {
   let env: RealHubEnv;
 
   beforeAll(async () => {
     env = await createFridayDeepProofHubEnv();
-    await ensureAnthropicWorkflowProviders(env);
+    await ensureWorkflowGeneratorDeepProofProviders(env);
   }, 120_000);
 
   afterAll(async () => {

--- a/test/unit/e2e/friday-deep-proof-env.test.ts
+++ b/test/unit/e2e/friday-deep-proof-env.test.ts
@@ -4,7 +4,7 @@ import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 
 import {
-  assertFridayDeepProofAnthropicLane,
+  assertFridayDeepProofSingleProviderLane,
   getFridayDeepProofEnvStatus,
 } from "../../e2e/live/_helpers/deep-proof-env.js";
 
@@ -13,54 +13,166 @@ function repoPath(...segments: string[]): string {
 }
 
 describe("friday deep proof env", () => {
-  it("accepts the Anthropic API-key lane when no legacy or supplemental lanes are enabled", () => {
+  // ── Lane selection: exactly one provider lane required ─────────────────
+
+  it("rejects deep proof runs when no provider lane is selected", () => {
+    const status = getFridayDeepProofEnvStatus({});
+    expect(status.gated).toBe(false);
+    expect(status.selectedProvider).toBeNull();
+    expect(status.blockers).toContain("no_provider_lane");
+  });
+
+  it("rejects deep proof runs when multiple provider lanes are selected", () => {
     const status = getFridayDeepProofEnvStatus({
       FRIDAY_E2E_LIVE_ANTHROPIC: "1",
-      FRIDAY_ANTHROPIC_API_KEY: "test-key", // pragma: allowlist secret
+      FRIDAY_E2E_LIVE_DEEPSEEK: "1",
+      FRIDAY_ANTHROPIC_API_KEY: "anthropic-test-key", // pragma: allowlist secret
+      FRIDAY_DEEPSEEK_API_KEY: "deepseek-test-key", // pragma: allowlist secret
     });
+    expect(status.gated).toBe(false);
+    expect(status.selectedProvider).toBeNull();
+    expect(status.blockers).toContain("multiple_provider_lanes");
+  });
 
+  it("rejects deep proof runs when the legacy E2E_LIVE lane is set", () => {
+    const status = getFridayDeepProofEnvStatus({
+      FRIDAY_E2E_LIVE_ANTHROPIC: "1",
+      FRIDAY_ANTHROPIC_API_KEY: "anthropic-test-key", // pragma: allowlist secret
+      E2E_LIVE: "1",
+    });
+    expect(status.gated).toBe(false);
+    expect(status.blockers).toContain("legacy_live_lane_enabled");
+  });
+
+  // ── Per-lane acceptance + missing-key rejection ─────────────────────────
+
+  it("accepts the Anthropic lane with FRIDAY_ANTHROPIC_API_KEY", () => {
+    const status = getFridayDeepProofEnvStatus({
+      FRIDAY_E2E_LIVE_ANTHROPIC: "1",
+      FRIDAY_ANTHROPIC_API_KEY: "anthropic-test-key", // pragma: allowlist secret
+    });
     expect(status.gated).toBe(true);
+    expect(status.selectedProvider).toBe("anthropic");
     expect(status.providerAuthLane).toBe("api_key");
     expect(status.credentialEnvRef).toBe("$FRIDAY_ANTHROPIC_API_KEY");
     expect(status.blockers).toEqual([]);
   });
 
-  it("uses the legacy ANTHROPIC_API_KEY alias when the canonical env var is absent", () => {
-    const envRef = assertFridayDeepProofAnthropicLane({
-      FRIDAY_E2E_LIVE_ANTHROPIC: "1",
-      ANTHROPIC_API_KEY: "legacy-key", // pragma: allowlist secret
-    });
-
-    expect(envRef).toBe("$ANTHROPIC_API_KEY");
-  });
-
-  it("blocks deep proof runs when the legacy live lane is enabled", () => {
+  it("falls back to ANTHROPIC_API_KEY when FRIDAY_ANTHROPIC_API_KEY is absent", () => {
     const status = getFridayDeepProofEnvStatus({
       FRIDAY_E2E_LIVE_ANTHROPIC: "1",
-      FRIDAY_ANTHROPIC_API_KEY: "test-key", // pragma: allowlist secret
-      E2E_LIVE: "1",
+      ANTHROPIC_API_KEY: "anthropic-legacy-key", // pragma: allowlist secret
     });
+    expect(status.gated).toBe(true);
+    expect(status.credentialEnvRef).toBe("$ANTHROPIC_API_KEY");
+  });
 
+  it("rejects the Anthropic lane when no Anthropic key is present", () => {
+    const status = getFridayDeepProofEnvStatus({
+      FRIDAY_E2E_LIVE_ANTHROPIC: "1",
+    });
     expect(status.gated).toBe(false);
-    expect(status.blockers).toContain("legacy_live_lane_enabled");
+    expect(status.blockers).toContain("missing_key:anthropic");
   });
 
-  it("blocks deep proof runs when OpenAI or Ollama supplemental lanes are enabled", () => {
+  it("accepts the DeepSeek lane with FRIDAY_DEEPSEEK_API_KEY", () => {
     const status = getFridayDeepProofEnvStatus({
-      FRIDAY_E2E_LIVE_ANTHROPIC: "1",
-      FRIDAY_ANTHROPIC_API_KEY: "test-key", // pragma: allowlist secret
+      FRIDAY_E2E_LIVE_DEEPSEEK: "1",
+      FRIDAY_DEEPSEEK_API_KEY: "deepseek-test-key", // pragma: allowlist secret
+    });
+    expect(status.gated).toBe(true);
+    expect(status.selectedProvider).toBe("deepseek");
+    expect(status.providerAuthLane).toBe("bearer_token");
+    expect(status.credentialEnvRef).toBe("$FRIDAY_DEEPSEEK_API_KEY");
+    expect(status.blockers).toEqual([]);
+  });
+
+  it("falls back to DEEPSEEK_API_KEY when FRIDAY_DEEPSEEK_API_KEY is absent", () => {
+    const status = getFridayDeepProofEnvStatus({
+      FRIDAY_E2E_LIVE_DEEPSEEK: "1",
+      DEEPSEEK_API_KEY: "deepseek-legacy-key", // pragma: allowlist secret
+    });
+    expect(status.gated).toBe(true);
+    expect(status.credentialEnvRef).toBe("$DEEPSEEK_API_KEY");
+  });
+
+  it("rejects the DeepSeek lane when no DeepSeek key is present", () => {
+    const status = getFridayDeepProofEnvStatus({
+      FRIDAY_E2E_LIVE_DEEPSEEK: "1",
+    });
+    expect(status.gated).toBe(false);
+    expect(status.blockers).toContain("missing_key:deepseek");
+  });
+
+  it("accepts the OpenAI lane with OPENAI_API_KEY", () => {
+    const status = getFridayDeepProofEnvStatus({
+      FRIDAY_E2E_LIVE_OPENAI: "1",
+      OPENAI_API_KEY: "openai-test-key", // pragma: allowlist secret
+    });
+    expect(status.gated).toBe(true);
+    expect(status.selectedProvider).toBe("openai");
+    expect(status.providerAuthLane).toBe("api_key");
+    expect(status.credentialEnvRef).toBe("$OPENAI_API_KEY");
+    expect(status.blockers).toEqual([]);
+  });
+
+  it("rejects the OpenAI lane when no OpenAI key is present", () => {
+    const status = getFridayDeepProofEnvStatus({
       FRIDAY_E2E_LIVE_OPENAI: "1",
     });
-
     expect(status.gated).toBe(false);
-    expect(status.blockers).toContain("supplemental_provider_lane_enabled");
+    expect(status.blockers).toContain("missing_key:openai");
   });
 
-  it("rejects missing Anthropic-only configuration with an actionable error", () => {
-    expect(() => assertFridayDeepProofAnthropicLane({})).toThrowError(
-      /Anthropic-only lane required/i,
+  it("accepts the Ollama lane without any key (none auth lane)", () => {
+    const status = getFridayDeepProofEnvStatus({
+      FRIDAY_E2E_LIVE_OLLAMA: "1",
+    });
+    expect(status.gated).toBe(true);
+    expect(status.selectedProvider).toBe("ollama");
+    expect(status.providerAuthLane).toBe("none");
+    expect(status.credentialEnvRef).toBeNull();
+    expect(status.blockers).toEqual([]);
+  });
+
+  // ── assertFridayDeepProofSingleProviderLane behavior ───────────────────
+
+  it("assertFridayDeepProofSingleProviderLane returns the active lane selection on a valid env", () => {
+    const lane = assertFridayDeepProofSingleProviderLane({
+      FRIDAY_E2E_LIVE_DEEPSEEK: "1",
+      FRIDAY_DEEPSEEK_API_KEY: "deepseek-test-key", // pragma: allowlist secret
+    });
+    expect(lane.selectedProvider).toBe("deepseek");
+    expect(lane.providerAuthLane).toBe("bearer_token");
+    expect(lane.credentialEnvRef).toBe("$FRIDAY_DEEPSEEK_API_KEY");
+  });
+
+  it("assertFridayDeepProofSingleProviderLane throws an actionable error when no lane is set", () => {
+    expect(() => assertFridayDeepProofSingleProviderLane({})).toThrowError(
+      /Single-provider lane required/i,
     );
   });
+
+  it("assertFridayDeepProofSingleProviderLane throws when multiple lanes are set", () => {
+    expect(() =>
+      assertFridayDeepProofSingleProviderLane({
+        FRIDAY_E2E_LIVE_ANTHROPIC: "1",
+        FRIDAY_E2E_LIVE_OPENAI: "1",
+        FRIDAY_ANTHROPIC_API_KEY: "anthropic-test-key", // pragma: allowlist secret
+        OPENAI_API_KEY: "openai-test-key", // pragma: allowlist secret
+      }),
+    ).toThrowError(/exactly one provider lane is required/i);
+  });
+
+  it("assertFridayDeepProofSingleProviderLane throws when the selected provider is missing its key", () => {
+    expect(() =>
+      assertFridayDeepProofSingleProviderLane({
+        FRIDAY_E2E_LIVE_DEEPSEEK: "1",
+      }),
+    ).toThrowError(/DeepSeek/);
+  });
+
+  // ── Adjacent invariants preserved from prior contract ──────────────────
 
   it("keeps the canonical real-browser helper free of mock bootstrap shortcuts", () => {
     const source = fs.readFileSync(
@@ -73,14 +185,16 @@ describe("friday deep proof env", () => {
     expect(source).not.toContain("/v1/setup/complete");
   });
 
-  it("keeps the deep-proof helper free of legacy provider routing globals", () => {
+  it("keeps the deep-proof helper free of mock-hub bootstrap shortcuts and legacy E2E_LIVE acceptance", () => {
     const source = fs.readFileSync(
       repoPath("test/e2e/live/_helpers/deep-proof-env.ts"),
       "utf8",
     );
 
-    expect(source).not.toContain("LIVE_PROVIDER_KIND");
-    expect(source).not.toContain("FRIDAY_E2E_LIVE_OPENAI ===");
-    expect(source).not.toContain("FRIDAY_E2E_LIVE_OLLAMA ===");
+    // Mock bootstrap markers must never appear in the deep-proof helper.
+    expect(source).not.toContain("createMockHubEnv");
+    expect(source).not.toContain("localStorage.setItem");
+    // Legacy E2E_LIVE remains a blocker, never an accepted lane.
+    expect(source).toContain("legacy_live_lane_enabled");
   });
 });


### PR DESCRIPTION
## What this PR does

Test infrastructure refactor. Widens the deep-proof e2e helper at [test/e2e/live/_helpers/deep-proof-env.ts](test/e2e/live/_helpers/deep-proof-env.ts) from an Anthropic-only gate to an exactly-one selected live provider lane (anthropic | deepseek | openai | ollama). The 10 deep-proof consumer tests plus [friday-self-healing-live.e2e.test.ts](test/e2e/live/friday-self-healing-live.e2e.test.ts) now branch on the active lane via the helper's new exports (`createFridayDeepProofProvider`, `ensureFridayDeepProofProviders`, `FRIDAY_DEEP_PROOF_PROVIDER_LABEL`, `FRIDAY_DEEP_PROOF_MODEL`, etc.).

## What this PR explicitly does NOT do

- **It does not prove provider-universal behavior.** A run on one lane proves only that lane.
- **It does not produce release readiness or a release artifact.** No release.yml / real-green-gate.yml changes; no artifact written under `docs/reports/`.
- **It does not change the release proof contract.** [release.yml](.github/workflows/release.yml)'s `live-proof-gate` job still requires a current-same-SHA `real-green-gate-result.json` with `status: passed`, validated by [scripts/ops/validate-real-green-gate-result.mjs](scripts/ops/validate-real-green-gate-result.mjs). That requirement is unchanged.
- **It does not retire the existing single-lane deep-proof semantic.** The helper still enforces exactly-one-provider determinism (no multiple lanes, no fallback contamination, no legacy `E2E_LIVE`). Per-provider env sanitization in [real-env.ts:120-200](test/e2e/live/_helpers/real-env.ts:120-200) is unchanged.

## What this unlocks

Broader provider lane choice for the deep-proof live e2e tests. Today they all required Anthropic + an Anthropic key. After this PR, each test can be run against:
- Anthropic lane (unchanged behavior)
- DeepSeek lane (new)
- OpenAI lane (new)
- Ollama lane (new)

Each run produces lane-specific evidence. A DeepSeek run proves DeepSeek behavior on that test; it does not generalize to Anthropic / OpenAI / Ollama.

## Scope (12 files)

| File | Change |
|---|---|
| [test/e2e/live/_helpers/deep-proof-env.ts](test/e2e/live/_helpers/deep-proof-env.ts) | Full rewrite: exactly-one-provider gate; new exports for active-lane selection / provider creation / provider pair / model / label. Old Anthropic-named exports removed (clean break). |
| [test/unit/e2e/friday-deep-proof-env.test.ts](test/unit/e2e/friday-deep-proof-env.test.ts) | 18 unit cases for the new contract: zero / multiple / missing-key / legacy blockers + per-lane acceptance + assert-function happy/sad + invariants. |
| [test/e2e/live/friday-self-healing-live.e2e.test.ts](test/e2e/live/friday-self-healing-live.e2e.test.ts) | Gate widened to `openai \| deepseek` (mirrors `friday-learning-live`); provider creation branches on `LIVE_PROVIDER_KIND`. |
| 9 deep-proof consumer tests | Provider creation via helper; model strings via `FRIDAY_DEEP_PROOF_MODEL` or returned `model` field; describe block names embed `FRIDAY_DEEP_PROOF_PROVIDER_LABEL`. |

## Files explicitly NOT touched (by user instruction)

- `test/e2e/live/friday-real-journeys.e2e.test.ts` — stays Anthropic-bound. A prior partial parameterization of one assertion was reverted after Codex review flagged inconsistency with the Anthropic-hardcoded payload elsewhere in the same flow. Provider-aware migration of this file needs separate scope.
- `test/e2e/live/friday-learning-live.e2e.test.ts` — already provider-agnostic; reference pattern preserved.
- `test/e2e/live/friday-execution-voice-live.e2e.test.ts` — voice eval calibration is out of scope.
- `test/e2e/live/friday-discord-channel-live.e2e.test.ts` — channel test, no LLM provider lane.
- `test/e2e/live/friday-cloud-journeys.e2e.test.ts` — cloud-target specific; provider lane already conditional.
- `test/e2e/live/friday-reflex-live.e2e.test.ts` — uses parallel custom env contract; out of standard provider lanes.
- `release.yml`, `real-green-gate.yml`, `cloud-e2e.yml` — no workflow changes.

## Verification (local; not release proof)

| Check | Result |
|---|---|
| `npx tsc --noEmit` | 0 errors |
| `npm run lint` | 0 errors (1435 baseline warnings, none in touched files) |
| `npx vitest run test/unit/e2e/friday-deep-proof-env.test.ts` | 18/18 pass |
| `npx vitest run` (all 11 affected test files batched) | 18 pass + 21 skipped (gate-closed in this shell) + 0 failed + 0 errors |
| `npm run check:secret-patterns` | clean |
| `git diff --check` | clean |
| Two isolated read-only reviewers (gate correctness; evidence honesty + leakage + scope) | both PASS, including explicit no-partial-migration check |

## Local Phase A context (NOT release proof)

Earlier in the session, I ran two live e2e tests against the DeepSeek lane to validate the helper architecture before refactoring. Those results are local diagnostic only:
- `friday-learning-live` (DeepSeek lane) — passed 3/3 locally. **Lane-specific local real-runtime + real-provider evidence only.** Not a release.yml same-SHA Real Green Gate artifact. Must not be cited as release proof.
- `friday-execution-voice-live` (DeepSeek lane) — failed-at-content-eval. The provider-agnostic infrastructure worked (real DeepSeek call, real responses received); the evaluator's required tokens differ from DeepSeek-v4-flash output style. **This is a lane-specific failure, not a pass.** Out of scope for this PR; voice-evaluator audit is a separate item.

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 errors
- [x] `npx vitest run` on changed files — 18 PASS / 21 skip / 0 fail / 0 errors
- [x] `npm run check:secret-patterns` — clean
- [x] Two isolated reviewers — both PASS
- [ ] CI checks on this PR