### PR TITLE
Fix subagent live child-run visibility assertions

### DIFF
--- a/test/e2e/live/friday-subagent-live.e2e.test.ts
+++ b/test/e2e/live/friday-subagent-live.e2e.test.ts
@@ -261,17 +261,13 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)(`Friday Subagent Live (${FRIDAY_DEEP_P
       expect(subagentGet.json.data.subagent.childRunId).toBe(subagent.childRunId);
       expect(subagentGet.json.data.subagent.outcome?.response).toContain(childAnswer);
 
-      const childRun = await apiFetch<AgentRunEnvelope>(
-        env.baseUrl,
-        env.accessToken,
-        "GET",
-        `/v1/agent/runs/${encodeURIComponent(subagent.childRunId)}`,
-      );
-      expect(childRun.status).toBe(200);
-      expect(childRun.json.ok).toBe(true);
-      expect(childRun.json.data.run.status).toBe("completed");
-      expect(childRun.json.data.run.responseText).toContain(childAnswer);
-      expect(childRun.json.data.run.task).toContain(childAnswer);
+      // Subagent child runs are intentionally hidden from the user-facing
+      // /v1/agent/runs/:id endpoint (the route filters out runs whose
+      // sessionKey starts with "subagent:" via isSubagentChildRun). Assert
+      // child-run evidence through the subagent record fields the API does
+      // expose. childRunId presence pins that the spawn produced a real run id.
+      expect(typeof subagent.childRunId).toBe("string");
+      expect(subagent.childRunId.length).toBeGreaterThan(0);
 
       const parentRun = await apiFetch<AgentRunEnvelope>(
         env.baseUrl,
@@ -343,16 +339,14 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)(`Friday Subagent Live (${FRIDAY_DEEP_P
       expect(subagent.outcome?.status).toBe("failed");
       expect((subagent.outcome?.response ?? "").trim().length).toBeGreaterThan(0);
 
-      const childRun = await apiFetch<AgentRunEnvelope>(
-        env.baseUrl,
-        env.accessToken,
-        "GET",
-        `/v1/agent/runs/${encodeURIComponent(subagent.childRunId)}`,
-      );
-      expect(childRun.status).toBe(200);
-      expect(childRun.json.ok).toBe(true);
-      expect(childRun.json.data.run.status).toBe("failed");
-      expect((childRun.json.data.run.errorMessage ?? childRun.json.data.run.responseText ?? "").trim().length).toBeGreaterThan(0);
+      // Subagent child runs are intentionally hidden from /v1/agent/runs/:id
+      // (route filters out sessionKey-starts-with-"subagent:"). Failure
+      // evidence is asserted via the subagent record's outcome fields above
+      // (status="failed", outcome.status="failed", outcome.response non-empty).
+      // Pin childRunId presence so we still verify a real child-run id was
+      // produced even though the run itself is not user-fetchable.
+      expect(typeof subagent.childRunId).toBe("string");
+      expect(subagent.childRunId.length).toBeGreaterThan(0);
 
       const parentRun = await apiFetch<AgentRunEnvelope>(
         env.baseUrl,
@@ -507,18 +501,21 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)(`Friday Subagent Live (${FRIDAY_DEEP_P
       expect(subagent.outcome?.response).toContain(marker);
       expect(subagent.outcome?.response).not.toContain("UNKNOWN");
 
-      const childRun = await apiFetch<AgentRunEnvelope>(
-        env.baseUrl,
-        env.accessToken,
-        "GET",
-        `/v1/agent/runs/${encodeURIComponent(subagent.childRunId)}`,
-      );
-      expect(childRun.status).toBe(200);
-      expect(childRun.json.ok).toBe(true);
-      expect(childRun.json.data.run.status).toBe("completed");
-      expect(childRun.json.data.run.task).not.toContain(marker);
-      expect(childRun.json.data.run.responseText).toContain(marker);
-      expect(childRun.json.data.run.responseText).not.toContain("UNKNOWN");
+      // Subagent child runs are intentionally hidden from /v1/agent/runs/:id
+      // (route filters out sessionKey-starts-with-"subagent:" via
+      // isSubagentChildRun). The fork-mode child-run evidence is preserved
+      // through the subagent record fields above:
+      //   - subagent.task does NOT contain the marker (lines pre-fetch)
+      //     pins that the secret was not leaked via task params
+      //   - subagent.outcome?.status === "completed" pins child completion
+      //   - subagent.outcome?.response contains the marker pins that the
+      //     child found the secret via inherited session context
+      //   - subagent.outcome?.response does NOT contain "UNKNOWN" pins that
+      //     the inheritance worked, the child did not have to guess
+      // Pin childRunId presence so we still verify a real child-run id was
+      // produced even though the run itself is not user-fetchable.
+      expect(typeof subagent.childRunId).toBe("string");
+      expect(subagent.childRunId.length).toBeGreaterThan(0);
     },
   );
 
@@ -567,6 +564,18 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)(`Friday Subagent Live (${FRIDAY_DEEP_P
       );
       const subagent = subagentList.json.data.items[0]!;
       expect(subagent.childSessionKey).toBeTruthy();
+      // Pin pre-restart subagent-record evidence: completed status, child run
+      // id present, outcome response carries the child answer. The polling
+      // above (items[0].status === "completed") gates on subagent status only;
+      // the outcome.response check pins the actual child answer reached the
+      // subagent record before restart. Subagent child runs are intentionally
+      // hidden from /v1/agent/runs/:id (route filters sessionKey starts-with
+      // "subagent:"), so we verify child-run evidence through these subagent
+      // fields and through the child session messages instead.
+      expect(subagent.outcome?.status).toBe("completed");
+      expect(subagent.outcome?.response).toContain(childAnswer);
+      expect(typeof subagent.childRunId).toBe("string");
+      expect(subagent.childRunId.length).toBeGreaterThan(0);
 
       const parentAuditBefore = await fetchRunAudit(env, parentRunId);
       expect(parentAuditBefore.status).toBe(200);
@@ -574,17 +583,6 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)(`Friday Subagent Live (${FRIDAY_DEEP_P
       const toolNamesBefore = extractToolNames(parentAuditBefore.json);
       expect(toolNamesBefore).toContain("spawn_subagent");
       expect(toolNamesBefore).toContain("get_subagent");
-
-      const childRunBefore = await apiFetch<AgentRunEnvelope>(
-        env.baseUrl,
-        env.accessToken,
-        "GET",
-        `/v1/agent/runs/${encodeURIComponent(subagent.childRunId)}`,
-      );
-      expect(childRunBefore.status).toBe(200);
-      expect(childRunBefore.json.ok).toBe(true);
-      expect(childRunBefore.json.data.run.status).toBe("completed");
-      expect(childRunBefore.json.data.run.responseText).toContain(childAnswer);
 
       const childSessionBefore = await listSessionMessages(env, subagent.childSessionKey!);
       expect(childSessionBefore.status).toBe(200);
@@ -632,16 +630,18 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)(`Friday Subagent Live (${FRIDAY_DEEP_P
       expect(listAfter.json.ok).toBe(true);
       expect(listAfter.json.data.items.map((item) => item.id)).toContain(subagent.id);
 
-      const childRunAfter = await apiFetch<AgentRunEnvelope>(
-        env.baseUrl,
-        env.accessToken,
-        "GET",
-        `/v1/agent/runs/${encodeURIComponent(subagent.childRunId)}`,
-      );
-      expect(childRunAfter.status).toBe(200);
-      expect(childRunAfter.json.ok).toBe(true);
-      expect(childRunAfter.json.data.run.status).toBe("completed");
-      expect(childRunAfter.json.data.run.responseText).toContain(childAnswer);
+      // Child-run evidence after restart is asserted via:
+      //  - subagentGetAfter.json.data.subagent.childRunId === subagent.childRunId
+      //    (above) pins the same child-run id survives restart
+      //  - subagentGetAfter.json.data.subagent.outcome?.response contains
+      //    childAnswer (above) pins the response is replayable from persisted
+      //    subagent state
+      //  - childSessionAfter (below) pins the child session messages survive
+      //    the runtime restart, with the assistant message containing the
+      //    expected answer.
+      // Subagent child runs are intentionally hidden from /v1/agent/runs/:id
+      // (route filters sessionKey starts-with "subagent:"), so we do not
+      // re-fetch the child run as a top-level agent run.
 
       const childSessionAfter = await listSessionMessages(env, subagent.childSessionKey!);
       expect(childSessionAfter.status).toBe(200);


### PR DESCRIPTION
## Summary

Test assumption bug. Four `it` bodies in [test/e2e/live/friday-subagent-live.e2e.test.ts](test/e2e/live/friday-subagent-live.e2e.test.ts) called `GET /v1/agent/runs/${subagent.childRunId}` and asserted `200`, but the route filter at [src/api/http/routes/friday-agent-routes.ts:100-101](src/api/http/routes/friday-agent-routes.ts:100-101) (and the `getVisibleRunOrThrow` callsite at lines 745-755) intentionally hides subagent child runs from the user-facing endpoint via `isSubagentChildRun(run)` (which returns true when `run.sessionKey.trim().startsWith("subagent:")`). The 404 is by design, not a runtime bug.

This PR fixes the test bodies to match the route's design; it does NOT change the route, the filter, or any source/runtime code.

## Why this surfaced now

The failure was first observed locally on the DeepSeek lane (3 active failures + 1 pass + 1 skipped). The skipped fork-mode body (`it.skipIf(!SUBAGENT_FORK_GATED)`) had the same latent bug — Codex review correctly flagged it. **The bug is lane-agnostic**: the 4 affected tests would have produced the same `404` on Anthropic, OpenAI, or Ollama lanes for the same reason. DeepSeek lane just happened to expose it first.

## Scope

Single file: `test/e2e/live/friday-subagent-live.e2e.test.ts`, +54 / -54 (4 broken fetch blocks replaced with shorter assertion blocks + comments).

| `it` block | Status | Treatment |
|---|---|---|
| 1 — "delegates a real child task..." (line 183) | Active | Removed broken fetch; added `subagent.childRunId` presence check; existing `subagent.outcome.status` / `outcome.response` / `task` assertions preserve the behavioral semantic |
| 2 — "keeps the parent run alive when a waited child fails" (line 292) | Active | Same pattern; existing `subagent.status` / `outcome.status` / `outcome.response` cover failure semantic |
| 3 — "does not treat a detached handoff snapshot..." (line 370) | Active | **Unchanged** — never had the broken lookup; this was the passing test |
| 4 — "forks parent session context..." (line 441) | `it.skipIf(!SUBAGENT_FORK_GATED)` | Removed broken fetch; secret-inheritance behavioral semantic preserved through `subagent.task does NOT contain marker` + `subagent.outcome.response contains marker` + `not.toContain(\"UNKNOWN\")` + `subagent.mode/inheritedMessageCount/forkedFromMessageId` already in the test body. Skip gate preserved; fork mode NOT enabled by this PR. |
| 5 — "preserves...across runtime restart" (line 525) | Active | Removed both pre-restart and post-restart broken fetches; pre-restart now explicitly asserts `subagent.outcome.status === \"completed\"` + `outcome.response` contains childAnswer; post-restart relies on existing `subagentGetAfter.subagent.childRunId` + `outcome.response` + `listAfter` + `childSessionAfter` assertions |

## Out of scope

- **No runtime/API/route changes.** `isUserVisibleAgentRun` and `isSubagentChildRun` filters are unchanged. The route's intentional hiding of subagent child runs is preserved.
- **No new public child-run endpoint added.**
- **No fork-mode enablement.** `SUBAGENT_FORK_GATED` constant and `it.skipIf` gate at line 441 are unchanged.
- **No release.yml / real-green-gate.yml / cloud-e2e.yml changes.** No release artifact produced.

## Test plan

- [x] `git diff --check` — clean
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run lint` — 0 errors (1435 baseline warnings, none in touched file)
- [x] `npx vitest run test/e2e/live/friday-subagent-live.e2e.test.ts` — parses cleanly; 5/5 skipped (gate closed in this shell)
- [x] `npm run check:secret-patterns` — clean
- [x] Cross-body sweep: `grep \"agent/runs/\\${encodeURIComponent(subagent.childRunId)}\"` returns ZERO matches in the post-edit file
- [x] Two isolated read-only reviewers — both PASS, including explicit cross-body sweep
- [ ] CI checks on this PR

## Local verification only — not release proof

The local DeepSeek lane finding that surfaced this bug is **lane-specific local real-runtime + real-provider evidence only**. It is not a release artifact. [release.yml](.github/workflows/release.yml)'s `live-proof-gate` still requires a current-same-SHA `real-green-gate-result.json` with `status: passed`, validated by [scripts/ops/validate-real-green-gate-result.mjs](scripts/ops/validate-real-green-gate-result.mjs). That requirement is unchanged.