### PR TITLE
Fail-closed gate for high-impact learned-preference injection

### DIFF
--- a/src/agent/runtime/friday-agent-preference-injector.ts
+++ b/src/agent/runtime/friday-agent-preference-injector.ts
@@ -8,6 +8,7 @@
  */
 
 import type { FridayMemoryService } from "../../memory/services/friday-memory-service.types.js";
+import { isFridayReflexConfirmationRequiredKey } from "../../reflex/index.js";
 
 // ─── Types ───
 
@@ -59,6 +60,17 @@ export function createFridayPreferenceInjector(
       const sources: string[] = [];
       const items: Array<{ text: string; confidence: number; source: string }> = [];
 
+      // High-impact learned preferences (keys the Reflex 17-key set already
+      // gates as confirmation-required for UIX preferences) must NOT be
+      // auto-injected via the learned-fact path. They share the same risk
+      // shape (memory/automation/skills/safety/etc. policy) and the
+      // learned-fact pipeline has no equivalent of the UIX confirmation
+      // surface. Until that surface exists, we fail closed for these keys
+      // on both Source 1 and Source 2 paths.
+      // High-impact learned preference confirmation UX still needed;
+      // re-evaluate when Review Center / candidate-preference confirmation
+      // exists for learning.preferences.
+
       // ── Source 1: Learning pipeline (Bayesian preferences) ──
       if (learningContextBuilder) {
         try {
@@ -66,6 +78,10 @@ export function createFridayPreferenceInjector(
           if (ctx.preferences && typeof ctx.preferences === "object") {
             for (const [key, value] of Object.entries(ctx.preferences)) {
               if (value != null && String(value).trim().length > 0) {
+                if (isFridayReflexConfirmationRequiredKey(key)) {
+                  // Fail closed: high-impact learned key, no confirmation path.
+                  continue;
+                }
                 items.push({
                   text: `${key}: ${String(value)}`,
                   confidence: 0.8, // Learning pipeline default confidence
@@ -96,6 +112,16 @@ export function createFridayPreferenceInjector(
           const tags = item.tags ?? [];
           if (!tags.includes(userId) || !tags.includes("preference")) continue;
           if (tags.some((tag: string) => PERSONA_TAGS.has(tag.toLowerCase()))) continue;
+
+          // Fail closed if the item carries no usable key: without a key the
+          // injector cannot classify whether the fact is high-impact or
+          // benign, so we skip rather than guess.
+          const itemKey = typeof item.key === "string" ? item.key.trim() : "";
+          if (itemKey.length === 0) continue;
+          if (isFridayReflexConfirmationRequiredKey(itemKey)) {
+            // Fail closed: high-impact learned key, no confirmation path.
+            continue;
+          }
 
           const content = item.content ?? "";
           if (content.trim().length === 0) continue;

--- a/src/reflex/index.ts
+++ b/src/reflex/index.ts
@@ -13,6 +13,7 @@ export {
   resolveFridayReflexOnboardingPreferenceWrites,
 } from "./services/friday-reflex-preference-resolver.js";
 export {
+  isFridayReflexConfirmationRequiredKey,
   requiresFridayReflexPreferenceConfirmation,
 } from "./services/friday-reflex-preference-sensitivity.js";
 export { createFridayReflexService } from "./services/friday-reflex-service.js";

--- a/src/reflex/services/friday-reflex-preference-sensitivity.ts
+++ b/src/reflex/services/friday-reflex-preference-sensitivity.ts
@@ -26,3 +26,17 @@ export function requiresFridayReflexPreferenceConfirmation(input: {
 }): boolean {
   return input.category === "reflex" && CONFIRMATION_REQUIRED_REFLEX_KEYS.has(input.key);
 }
+
+/**
+ * Key-only check for membership in the confirmation-required set.
+ * For callers that have a preference key but no UIX category — e.g.
+ * learned-preference injectors that need to fail closed on high-impact-shaped
+ * keys regardless of which surface produced them.
+ *
+ * Distinct from requiresFridayReflexPreferenceConfirmation, which gates on
+ * (category === "reflex") AND key match: that signature stays unchanged so
+ * existing UIX preference callers keep their category guard.
+ */
+export function isFridayReflexConfirmationRequiredKey(key: string): boolean {
+  return CONFIRMATION_REQUIRED_REFLEX_KEYS.has(key);
+}

--- a/test/unit/agent/runtime/friday-agent-preference-injector.test.ts
+++ b/test/unit/agent/runtime/friday-agent-preference-injector.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { FridayMemoryItem } from "../../../../src/memory/model/friday-memory.types.js";
+import { createFridayPreferenceInjector } from "../../../../src/agent/runtime/friday-agent-preference-injector.js";
+
+const NOW = "2026-05-11T00:00:00.000Z";
+const USER_ID = "user-1";
+
+function buildMemoryItem(overrides: Partial<FridayMemoryItem>): FridayMemoryItem {
+  return {
+    id: "mem-1",
+    namespace: "learning.preferences",
+    key: "language",
+    content: "Prefer TypeScript with strict mode",
+    source: "learning:user-1:event-1",
+    tags: ["learning", "auto", "preference", USER_ID],
+    metadata: { confidence: 0.7 },
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+function buildMockMemoryService(items: FridayMemoryItem[]) {
+  return {
+    store: vi.fn(),
+    search: vi.fn(),
+    get: vi.fn(),
+    list: vi.fn(async () => items),
+    delete: vi.fn(),
+    prune: vi.fn(),
+  };
+}
+
+describe("createFridayPreferenceInjector — high-impact gate", () => {
+  // ── Source 1: learningContextBuilder ───────────────────────────────────
+
+  it("Source 1: injects benign learned facts at the default learning confidence", async () => {
+    const injector = createFridayPreferenceInjector({
+      memoryService: buildMockMemoryService([]) as any,
+      learningContextBuilder: () => ({
+        preferences: {
+          language: "TypeScript",
+          framework: "React",
+        },
+      }),
+      nowIso: () => NOW,
+    });
+
+    const result = await injector.loadPreferences(USER_ID);
+
+    expect(result.itemCount).toBe(2);
+    expect(result.fragment).toContain("language: TypeScript");
+    expect(result.fragment).toContain("framework: React");
+    expect(result.sources).toContain("learning");
+  });
+
+  it("Source 1: skips high-impact learned facts (Reflex 17-key set) at any confidence", async () => {
+    const injector = createFridayPreferenceInjector({
+      memoryService: buildMockMemoryService([]) as any,
+      learningContextBuilder: () => ({
+        preferences: {
+          // Both high-impact keys from the Reflex confirmation-required set:
+          "automation.conservatism": "aggressive",
+          "safety.high_risk_change_policy": "auto_apply_low_risk",
+          // Benign key alongside high-impact ones:
+          language: "TypeScript",
+        },
+      }),
+      nowIso: () => NOW,
+    });
+
+    const result = await injector.loadPreferences(USER_ID);
+
+    expect(result.itemCount).toBe(1);
+    expect(result.fragment).toContain("language: TypeScript");
+    expect(result.fragment).not.toContain("automation.conservatism");
+    expect(result.fragment).not.toContain("safety.high_risk_change_policy");
+    expect(result.fragment).not.toContain("aggressive");
+    expect(result.fragment).not.toContain("auto_apply_low_risk");
+  });
+
+  it("Source 1: returns no fragment when only high-impact keys are present", async () => {
+    const injector = createFridayPreferenceInjector({
+      memoryService: buildMockMemoryService([]) as any,
+      learningContextBuilder: () => ({
+        preferences: {
+          "memory.explicit_instruction_policy": "always_record",
+          "skills.generation_policy": "auto_promote",
+        },
+      }),
+      nowIso: () => NOW,
+    });
+
+    const result = await injector.loadPreferences(USER_ID);
+
+    expect(result.itemCount).toBe(0);
+    expect(result.fragment).toBe("");
+    expect(result.sources).toEqual([]);
+  });
+
+  // ── Source 2: persistent memory ───────────────────────────────────────
+
+  it("Source 2: injects benign memory item with key + confidence >= 0.5", async () => {
+    const memory = buildMockMemoryService([
+      buildMemoryItem({
+        id: "mem-benign",
+        key: "language",
+        content: "Prefer TypeScript with strict mode",
+        metadata: { confidence: 0.6 },
+      }),
+    ]);
+    const injector = createFridayPreferenceInjector({
+      memoryService: memory as any,
+      nowIso: () => NOW,
+    });
+
+    const result = await injector.loadPreferences(USER_ID);
+
+    expect(result.itemCount).toBe(1);
+    expect(result.fragment).toContain("Prefer TypeScript");
+    expect(result.sources).toContain("memory");
+  });
+
+  it("Source 2: skips memory item whose key is in the high-impact set", async () => {
+    const memory = buildMockMemoryService([
+      buildMemoryItem({
+        id: "mem-high-impact",
+        key: "automation.conservatism",
+        content: "Run all destructive tasks without confirmation",
+        metadata: { confidence: 0.95 },
+      }),
+      buildMemoryItem({
+        id: "mem-benign",
+        key: "language",
+        content: "Prefer TypeScript",
+        metadata: { confidence: 0.6 },
+      }),
+    ]);
+    const injector = createFridayPreferenceInjector({
+      memoryService: memory as any,
+      nowIso: () => NOW,
+    });
+
+    const result = await injector.loadPreferences(USER_ID);
+
+    expect(result.itemCount).toBe(1);
+    expect(result.fragment).toContain("Prefer TypeScript");
+    expect(result.fragment).not.toContain("destructive");
+    expect(result.fragment).not.toContain("automation.conservatism");
+  });
+
+  it("Source 2: fails closed for memory items without a usable key", async () => {
+    const memory = buildMockMemoryService([
+      buildMemoryItem({
+        id: "mem-empty-key",
+        key: "",
+        content: "Some preference content with no key for classification",
+        metadata: { confidence: 0.9 },
+      }),
+      buildMemoryItem({
+        id: "mem-whitespace-key",
+        key: "   ",
+        content: "Another keyless preference",
+        metadata: { confidence: 0.9 },
+      }),
+    ]);
+    const injector = createFridayPreferenceInjector({
+      memoryService: memory as any,
+      nowIso: () => NOW,
+    });
+
+    const result = await injector.loadPreferences(USER_ID);
+
+    expect(result.itemCount).toBe(0);
+    expect(result.fragment).toBe("");
+  });
+
+  it("Source 2: preserves existing PERSONA_TAGS exclusion (handled by MBTI system)", async () => {
+    const memory = buildMockMemoryService([
+      buildMemoryItem({
+        id: "mem-persona",
+        key: "communication.tone",
+        content: "Friendly and concise",
+        tags: ["learning", "auto", "preference", USER_ID, "persona"],
+        metadata: { confidence: 0.8 },
+      }),
+    ]);
+    const injector = createFridayPreferenceInjector({
+      memoryService: memory as any,
+      nowIso: () => NOW,
+    });
+
+    const result = await injector.loadPreferences(USER_ID);
+
+    expect(result.itemCount).toBe(0);
+  });
+
+  it("Source 2: preserves existing 0.5 confidence floor for benign keys", async () => {
+    const memory = buildMockMemoryService([
+      buildMemoryItem({
+        id: "mem-low-confidence",
+        key: "language",
+        content: "Maybe Python?",
+        metadata: { confidence: 0.4 },
+      }),
+    ]);
+    const injector = createFridayPreferenceInjector({
+      memoryService: memory as any,
+      nowIso: () => NOW,
+    });
+
+    const result = await injector.loadPreferences(USER_ID);
+
+    expect(result.itemCount).toBe(0);
+  });
+
+  // ── Combined: both sources, mixed benign + high-impact ────────────────
+
+  it("Both sources: only benign facts reach the prompt; high-impact facts are uniformly skipped", async () => {
+    const memory = buildMockMemoryService([
+      buildMemoryItem({
+        id: "mem-benign",
+        key: "ui.theme",
+        content: "dark mode",
+        metadata: { confidence: 0.7 },
+      }),
+      buildMemoryItem({
+        id: "mem-high-impact",
+        key: "skills.import_policy",
+        content: "import unverified scripts on demand",
+        metadata: { confidence: 0.95 },
+      }),
+    ]);
+    const injector = createFridayPreferenceInjector({
+      memoryService: memory as any,
+      learningContextBuilder: () => ({
+        preferences: {
+          language: "TypeScript",
+          // High-impact key from learning context — must be skipped.
+          "testing.live_llm_policy": "always_use_live",
+        },
+      }),
+      nowIso: () => NOW,
+    });
+
+    const result = await injector.loadPreferences(USER_ID);
+
+    expect(result.fragment).toContain("language: TypeScript");
+    expect(result.fragment).toContain("dark mode");
+    expect(result.fragment).not.toContain("skills.import_policy");
+    expect(result.fragment).not.toContain("testing.live_llm_policy");
+    expect(result.fragment).not.toContain("import unverified scripts");
+    expect(result.fragment).not.toContain("always_use_live");
+  });
+});

--- a/test/unit/reflex/friday-reflex-preference-sensitivity.test.ts
+++ b/test/unit/reflex/friday-reflex-preference-sensitivity.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isFridayReflexConfirmationRequiredKey,
+  requiresFridayReflexPreferenceConfirmation,
+} from "../../../src/reflex/services/friday-reflex-preference-sensitivity.js";
+
+const KNOWN_HIGH_IMPACT_KEYS: readonly string[] = [
+  "memory.explicit_instruction_policy",
+  "memory.inferred_preference_policy",
+  "automation.repeated_task_policy",
+  "skills.existing_skill_policy",
+  "skills.generation_policy",
+  "workflows.generation_policy",
+  "cold_start.scan_scope",
+  "skills.import_policy",
+  "testing.code_depth",
+  "testing.unknown_scenarios",
+  "recovery.failure_policy",
+  "safety.high_risk_change_policy",
+  "recipes.success_summarization_policy",
+  "memory.conflict_policy",
+  "memory.proactive_search_policy",
+  "automation.conservatism",
+  "testing.live_llm_policy",
+];
+
+describe("isFridayReflexConfirmationRequiredKey", () => {
+  it("returns true for every known confirmation-required reflex key", () => {
+    for (const key of KNOWN_HIGH_IMPACT_KEYS) {
+      expect(isFridayReflexConfirmationRequiredKey(key), key).toBe(true);
+    }
+  });
+
+  it("returns false for benign learned-preference keys", () => {
+    const benign = [
+      "language",
+      "framework",
+      "typescript_mode",
+      "persona.verbosity",
+      "communication.tone",
+      "display_name",
+      "ui.theme",
+      "",
+    ];
+    for (const key of benign) {
+      expect(isFridayReflexConfirmationRequiredKey(key), key).toBe(false);
+    }
+  });
+
+  it("returns false for keys that look high-impact-shaped but are not in the set", () => {
+    const lookalikes = [
+      "automation.unknown_policy",
+      "memory.unknown_policy",
+      "safety.unknown_policy",
+      "automation",
+      "memory",
+      "safety",
+    ];
+    for (const key of lookalikes) {
+      expect(isFridayReflexConfirmationRequiredKey(key), key).toBe(false);
+    }
+  });
+});
+
+describe("requiresFridayReflexPreferenceConfirmation (existing semantics preserved)", () => {
+  it("requires both category=reflex and a known key", () => {
+    expect(
+      requiresFridayReflexPreferenceConfirmation({
+        category: "reflex",
+        key: "automation.conservatism",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when key is known but category is not reflex", () => {
+    expect(
+      requiresFridayReflexPreferenceConfirmation({
+        category: "communication",
+        key: "automation.conservatism",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when category is reflex but key is benign", () => {
+    expect(
+      requiresFridayReflexPreferenceConfirmation({
+        category: "reflex",
+        key: "language",
+      }),
+    ).toBe(false);
+  });
+
+  it("agrees with isFridayReflexConfirmationRequiredKey on the key match for category=reflex", () => {
+    for (const key of KNOWN_HIGH_IMPACT_KEYS) {
+      expect(
+        requiresFridayReflexPreferenceConfirmation({
+          category: "reflex",
+          key,
+        }),
+      ).toBe(isFridayReflexConfirmationRequiredKey(key));
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The agent preference injector (`src/agent/runtime/friday-agent-preference-injector.ts`) now checks each preference key against the Reflex 17-key confirmation-required set on **both** injection paths:

- **Source 1** — keys in the `learningContextBuilder` output
- **Source 2** — keys on persistent memory items in the `learning.preferences` namespace

Keys in the high-impact set are skipped from prompt injection. Source 2 also fails closed on items without a usable `key` field, since the injector cannot classify whether such an item is high-impact or benign.

**High-impact learned facts are blocked from prompt injection until a Review Center / candidate-preference confirmation path exists.**

## What does *not* change

- Benign learned preferences still inject normally when `confidence >= 0.5` (Source 2) or via the existing learning-pipeline default (Source 1).
- `requiresFridayReflexPreferenceConfirmation({category, key})` keeps its existing signature and category guard untouched — UIX preference callers see no change.
- `PERSONA_TAGS` exclusion, deduplication, sort-by-confidence, and the `MAX_PREFERENCE_ITEMS` clamp are unchanged.
- No change to: Review Center semantics, memory write paths, canonical mutating-action gate, compaction loader/sink/formatter, provider lifecycle, release workflows.

## Why a key-only helper

The new export `isFridayReflexConfirmationRequiredKey(key: string)` lives next to the existing `requiresFridayReflexPreferenceConfirmation` in `src/reflex/services/friday-reflex-preference-sensitivity.ts` and is re-exported through `src/reflex/index.ts`. The injector imports it through that established index path so the 17-key set is **not duplicated** in the injector — the Reflex sensitivity module remains the single source of truth.

## Files changed (5)

| File | Change |
|---|---|
| `src/reflex/services/friday-reflex-preference-sensitivity.ts` | + `isFridayReflexConfirmationRequiredKey(key)` helper alongside the existing function |
| `src/reflex/index.ts` | + 1 line: re-export the new helper |
| `src/agent/runtime/friday-agent-preference-injector.ts` | + import + Source 1 gate + Source 2 gate (high-impact key + key-less item) |
| `test/unit/reflex/friday-reflex-preference-sensitivity.test.ts` | NEW — 7 tests including drift guard between the two functions |
| `test/unit/agent/runtime/friday-agent-preference-injector.test.ts` | NEW — 9 tests across both sources, benign + high-impact + key-less + persona + low-confidence + mixed |

## Evidence framing

This change is supported by **unit / mock-contract evidence only**.

- Not release proof.
- Not real-runtime.
- Not real-provider.
- No release workflow, provider lifecycle, or canonical mutating-action-gate changes.

## Test plan

- [x] `npx tsc --noEmit` — exit 0
- [x] `npm run lint` — 0 errors (1436 baseline warnings preserved)
- [x] `npx vitest run` on the 3 affected test files — 34/34 pass (7 sensitivity + 9 injector + 18 existing compaction-pipeline preserved)
- [x] `npm run check:secret-patterns` — clean
- [x] `git diff --check` — clean
- [x] Reviewer A (gate correctness + fail-closed semantics) — PASS
- [x] Reviewer B (scope discipline + no overstated claims + secret hygiene) — PASS

## Follow-up

Review Center / candidate-preference confirmation surface for `learning.preferences` is still needed; once it exists, this fail-closed gate can be relaxed to route high-impact learned facts through the same confirmation flow as UIX-driven Reflex preferences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)