### PR TITLE
Make compaction context trust marker load-bearing

### DIFF
--- a/src/agent/runtime/friday-agent-compaction-context-formatter.ts
+++ b/src/agent/runtime/friday-agent-compaction-context-formatter.ts
@@ -60,6 +60,49 @@ export function groupCompactionContextReplayRecords(
 }
 
 /**
+ * Select the prompt header and boundary text for a context-replay block based
+ * on its persisted `trustLevel`. This makes `block.trustLevel` a load-bearing
+ * input to the prompt-text path rather than only a telemetry tag, so the
+ * structured marker the loader writes is actually consumed on the read side.
+ *
+ * Drift policy:
+ *  - Compile-time drift must fail. If a future change adds a value to the
+ *    `trustLevel` union without updating this switch, the `_exhaustive: never`
+ *    assignment below stops compilation.
+ *  - Runtime-invalid persisted data must NOT crash the run. If schema drift
+ *    or a forward/back-compat mismatch ever surfaces a value outside the
+ *    declared union at runtime, fall back to the unconfirmed replay
+ *    boundary — that is the safest text the model can receive.
+ */
+function selectHeaderAndBoundary(
+  trustLevel: FridayCompactionContextBlock["trustLevel"],
+  compactedAt: string,
+): { header: string; boundary: string } {
+  const unconfirmedHeader = compactedAt
+    ? `[Unconfirmed Context Replay — ${compactedAt}]`
+    : "[Unconfirmed Context Replay]";
+  const unconfirmedBoundary =
+    "Boundary: this is a compressed prior-session summary, not user-confirmed memory. Verify before high-risk or mutating action.";
+
+  switch (trustLevel) {
+    case "unconfirmed_summary":
+      return { header: unconfirmedHeader, boundary: unconfirmedBoundary };
+  }
+
+  // Compile-time exhaustive check: TypeScript narrows `trustLevel` to `never`
+  // here only when every union value is handled above. Adding a new value
+  // without a case branch breaks compilation and forces the reviewer to
+  // decide the new branch's prompt text explicitly.
+  const _exhaustive: never = trustLevel;
+  void _exhaustive;
+
+  // Runtime fail-closed fallback: persisted data may have a value outside the
+  // declared union (schema drift). Emit the unconfirmed boundary rather than
+  // throw, so the run continues with the safest possible warning to the model.
+  return { header: unconfirmedHeader, boundary: unconfirmedBoundary };
+}
+
+/**
  * Format compaction context blocks into a prompt fragment for injection
  * into the system prompt.
  */
@@ -76,13 +119,8 @@ export function formatCompactionContextForPrompt(
   const parts: string[] = [];
 
   for (const block of selected) {
-    const header = block.compactedAt
-      ? `[Unconfirmed Context Replay — ${block.compactedAt}]`
-      : "[Unconfirmed Context Replay]";
-    const sectionParts: string[] = [
-      header,
-      "Boundary: this is a compressed prior-session summary, not user-confirmed memory. Verify before high-risk or mutating action.",
-    ];
+    const { header, boundary } = selectHeaderAndBoundary(block.trustLevel, block.compactedAt);
+    const sectionParts: string[] = [header, boundary];
 
     if (block.summaryText) {
       sectionParts.push(`Summary: ${block.summaryText}`);

--- a/test/unit/agent/runtime/friday-agent-compaction-pipeline.test.ts
+++ b/test/unit/agent/runtime/friday-agent-compaction-pipeline.test.ts
@@ -549,6 +549,60 @@ describe("Compaction Pipeline Integration", () => {
       const prompt = formatCompactionContextForPrompt(blocks);
       expect(prompt).toBe("");
     });
+
+    it("formats unconfirmed_summary replay blocks with the unconfirmed boundary", () => {
+      const blocks = groupCompactionContextReplayRecords([
+        makeContextReplayRecord({
+          summary: {
+            summaryText: "User worked on something.",
+            decisions: [],
+            todos: [],
+            openQuestions: [],
+            toolFailures: [],
+            fileOperations: [],
+          },
+          compactedAt: "2026-04-15T09:00:00Z",
+        }),
+      ]);
+
+      // Sanity: the only declared trustLevel value today.
+      expect(blocks[0].trustLevel).toBe("unconfirmed_summary");
+
+      const prompt = formatCompactionContextForPrompt(blocks);
+
+      expect(prompt).toContain("[Unconfirmed Context Replay — 2026-04-15T09:00:00Z]");
+      expect(prompt).toContain(
+        "Boundary: this is a compressed prior-session summary, not user-confirmed memory. Verify before high-risk or mutating action.",
+      );
+      expect(prompt).toContain("Summary: User worked on something.");
+    });
+
+    it("falls back to the unconfirmed boundary when persisted trustLevel is outside the declared union (fail-closed)", () => {
+      // Simulate runtime-only schema drift: a persisted record carries a
+      // trustLevel value that the formatter's union does not declare. The
+      // formatter must NOT throw — it must emit the safest possible warning.
+      const driftBlock = {
+        entryId: "drift-1",
+        sessionKey: "session-drift",
+        runId: "run-drift",
+        compactedAt: "2026-04-15T09:00:00Z",
+        trustLevel: "future_unknown_value",
+        source: "context_replay" as const,
+        summaryText: "Drift summary.",
+        decisions: [],
+        todos: [],
+        openQuestions: [],
+        toolFailures: [],
+        fileOperations: [],
+      } as unknown as Parameters<typeof formatCompactionContextForPrompt>[0][number];
+
+      const prompt = formatCompactionContextForPrompt([driftBlock]);
+
+      expect(prompt).toContain("[Unconfirmed Context Replay");
+      expect(prompt).toContain("not user-confirmed memory");
+      expect(prompt).toContain("Verify before high-risk or mutating action.");
+      expect(prompt).toContain("Summary: Drift summary.");
+    });
   });
 
   // ══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Phase 4A.7 Gap #1 — the persisted `trustLevel` field on context-replay blocks is now load-bearing in the prompt-text path, not just a telemetry tag.

Pre-PR: `formatCompactionContextForPrompt()` ignored `block.trustLevel` and inlined a hardcoded "Unconfirmed Context Replay" header + boundary text on every block. The structured marker was therefore dead-read on the prompt path while still being consumed by runtime telemetry events.

Post-PR: a new `selectHeaderAndBoundary(trustLevel, compactedAt)` helper explicitly switches on `block.trustLevel` and returns the prompt header + boundary strings. The formatter's main loop calls the helper instead of inlining strings.

## Evidence framing

This change is supported by **unit / mock-contract** evidence only.

- Not real-runtime.
- Not real-provider.
- Not real-browser, not cloud-live, not manual-external.
- **No release-proof evidence contribution.**

## What does NOT change

- **No runtime behavior change for current `unconfirmed_summary` blocks.** The only currently declared `trustLevel` value is `"unconfirmed_summary"`, and the helper returns header + boundary strings that are byte-identical to the pre-PR inlined text for that value.
- **Prompt text for current replay blocks remains unchanged.** All existing assertions in the formatter test suite continue to pass without modification (e.g., `prompt).toContain("[Unconfirmed Context Replay")`, `prompt).toContain("not user-confirmed memory")`).
- **No prompt-builder threading.** `src/agent/runtime/friday-agent-system-prompt-builder.ts` is untouched. The current architecture appends compaction replay text after the builder returns; this PR keeps that boundary intact.
- **No runtime / loader / sink threading.** `src/agent/runtime/friday-agent-runtime.ts`, `src/agent/runtime/friday-agent-compaction-context-loader.ts`, and `src/agent/runtime/friday-agent-compaction-context-replay-sink.ts` are untouched.
- **No telemetry contract change.** The loader still sets `trustLevel: "unconfirmed_summary"` on the load result for telemetry consumption; the helper consumes the same field but does not alter what the loader writes.

## What does change

- The formatter now consumes `block.trustLevel` on the prompt-text path.
- Future trust-level vocabulary expansion is **compile-time guarded**: `const _exhaustive: never = trustLevel` after the switch will fail TypeScript compilation if a new value is added to the `trustLevel` union without a corresponding case branch, forcing the reviewer to decide the new branch's prompt text explicitly.
- Invalid persisted `trustLevel` (e.g., schema drift surfacing a value outside the declared union at runtime) **fails closed to the unconfirmed boundary** — the helper does not throw; it returns the same unconfirmed-replay header + boundary text the switch would have returned for `"unconfirmed_summary"`. This is the safest fallback.

## Files changed (2)

| File | Change |
|---|---|
| `src/agent/runtime/friday-agent-compaction-context-formatter.ts` | +52/-7 — new `selectHeaderAndBoundary()` helper with switch + compile-time exhaustive check + runtime fail-closed fallback. Main loop refactored to call the helper. |
| `test/unit/agent/runtime/friday-agent-compaction-pipeline.test.ts` | +54/-0 — two new tests: `"formats unconfirmed_summary replay blocks with the unconfirmed boundary"` (explicit assertion of full boundary string) and `"falls back to the unconfirmed boundary when persisted trustLevel is outside the declared union (fail-closed)"` (simulates runtime drift via cast, asserts no throw + unconfirmed boundary emitted). |

Net diff: **+99/-7** across **2 files**.

## Verification

- [x] `npx tsc --noEmit` — exit 0
- [x] `npm run lint` — 0 errors (1436 baseline warnings preserved)
- [x] `npx vitest run test/unit/agent/runtime/friday-agent-compaction-pipeline.test.ts` — 20/20 pass (was 18 pre-PR; +2 new)
- [x] `npm run check:secret-patterns` — clean
- [x] `git diff --check` — clean
- [x] `git diff --name-only origin/main` — exactly 2 files
- [x] No source / test / workflow / release script change outside the 2 named files

## Reviewer trail

| Reviewer | Verdict | Scope |
|---|---|---|
| A (marker actually consumed; output remains safe; no scope creep) | `OVERALL: PASS` | Verified helper reads `block.trustLevel` (line 78), main loop calls helper (line 122), unconfirmed_summary output byte-identical to pre-PR, exhaustive check correctly wired (`const _exhaustive: never = trustLevel` after switch), runtime fail-closed fallback returns without throwing, 2-file scope confirmed via `git diff --name-only`. |
| B (regression risk; no prompt weakening; no release-proof overclaim; no scope creep) | `OVERALL: PASS` | Verified prompt text byte-identical for unconfirmed_summary, no release-proof tier label, no prompt-builder threading, no vocabulary expansion (single case only), runtime fail-closed (no `expect.toThrow`), no alarmist wording, comments don't overclaim, telemetry contract unchanged, test assertions precise (full boundary string), no real-provider/real-runtime fixtures. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)