### PR TITLE
Add provider validate action to settings

### DIFF
--- a/ui/src/routes/settings-page.tsx
+++ b/ui/src/routes/settings-page.tsx
@@ -17,7 +17,7 @@ import { ChannelConfigForm } from "@/components/core/channel-config-form";
 import { DiscoveryPanel } from "@/components/core/discovery-panel";
 import { CHANNEL_META } from "@/lib/channels/channel-meta";
 import type { ChannelKind } from "@/lib/setup/types";
-import type { FridayProviderKind, FridayProviderProfile, FridayRuntimeCapabilityState } from "@/lib/api/types";
+import { type FridayProviderKind, type FridayProviderProfile, type FridayRuntimeCapabilityState, ApiError } from "@/lib/api/types";
 import { assistantDiagnosticsApi } from "@/lib/api/assistant-diagnostics";
 import { channelsApi } from "@/lib/api/channels";
 import { healthApi } from "@/lib/api/health";
@@ -635,6 +635,33 @@ export function SettingsPage() {
     },
   });
 
+  const validateMutation = useMutation({
+    mutationFn: (providerId: string) => providersApi.validate(providerId),
+    onSuccess: async (validation) => {
+      // Toast outcome is driven by the returned validation.status, not by
+      // HTTP success alone. The backend returns 2xx + status="failed" when
+      // the credential resolves but the provider rejects it; that path
+      // must surface as a failure, not a success.
+      if (validation.status === "ok") {
+        toast.success(localize(locale, "验证通过", "Validation passed"));
+      } else if (validation.status === "failed") {
+        const code = validation.errorCode ?? "VALIDATION_FAILED";
+        toast.error(localize(locale, `验证失败:${code}`, `Validation failed: ${code}`));
+      } else {
+        // status === "never" or any future value: stay neutral, never imply pass.
+        toast(localize(locale, "验证已完成", "Validation complete"));
+      }
+      await refreshProviderQueries();
+    },
+    onError: (error) => {
+      // Do NOT echo error.message or validation.errorMessage — those may
+      // contain provider/network response text. Only surface the structured
+      // ApiError.code when available, otherwise a fixed generic copy.
+      const code = error instanceof ApiError ? error.code : "UNKNOWN_ERROR";
+      toast.error(localize(locale, `验证请求失败:${code}`, `Validate request failed: ${code}`));
+    },
+  });
+
   const lessonToggleMutation = useMutation({
     mutationFn: (input: { lessonId: string; enabled: boolean }) =>
       learningApi.setLessonEnabled({
@@ -1099,6 +1126,8 @@ export function SettingsPage() {
                     const remediationHint = remediationVerdict
                       ? describeFridayProviderDoctorRemediation(remediationVerdict, locale)
                       : null;
+                    const isValidatingThisProvider =
+                      validateMutation.isPending && validateMutation.variables === provider.id;
                     return (
                       <>
                   <div className="flex items-center justify-between gap-3">
@@ -1139,6 +1168,17 @@ export function SettingsPage() {
                   {healthItem?.suggestedAction ? (
                     <p className="mt-2 text-xs text-[color:var(--color-text-secondary)]">{healthItem.suggestedAction}</p>
                   ) : null}
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    <ActionButton
+                      tone="secondary"
+                      disabled={validateMutation.isPending}
+                      onClick={() => validateMutation.mutate(provider.id)}
+                    >
+                      {isValidatingThisProvider
+                        ? localize(locale, "验证中...", "Validating...")
+                        : localize(locale, "立即验证", "Validate now")}
+                    </ActionButton>
+                  </div>
                   {provider.kind === "openai-codex" && provider.config.authMode === "oauth" ? (
                     <div className="mt-3 flex flex-wrap gap-2">
                       <ActionButton


### PR DESCRIPTION
## Summary

Adds a per-provider "立即验证" / "Validate now" button to the Settings provider section. Triggers the existing `providersApi.validate(providerId)` action.

## What this PR is

- **UI-only additive change** — 1 file, +41/-1.
- **No backend behavior change.** The backend `POST /v1/providers/:providerId/validate` route (`operationId: providers.validate`), the `service.validateProvider` method, and the canonical mutation gate are all unchanged.
- **No provider doctor / routing eligibility / canonical mutation gate change.**
- Consumes the **existing** `providersApi.validate(providerId)` API client method; no new endpoint, no new request body field.

## Behavior

- **Toast result is driven by the returned `validation.status`, not HTTP success alone.** The backend returns `2xx` with `validation.status === "failed"` when the credential resolves but the provider rejects it; that path surfaces an error toast, not a success toast.
  - `status === "ok"` → `toast.success("验证通过" / "Validation passed")`
  - `status === "failed"` → `toast.error("验证失败:<errorCode>" / "Validation failed: <errorCode>")`
  - `status === "never"` or any future value → neutral `toast("验证已完成" / "Validation complete")`
- **Toast only exposes structured `errorCode` / `ApiError.code`, never provider `errorMessage` or raw `error.message`.** The `onError` path uses `error instanceof ApiError ? error.code : "UNKNOWN_ERROR"`. The failed-status branch uses `validation.errorCode ?? "VALIDATION_FAILED"`. Neither `validation.errorMessage` nor `Error.message` is referenced anywhere in the new mutation code.
- **All Validate buttons are disabled while one validation is pending.** `disabled={validateMutation.isPending}` is mutation-wide, so the user cannot start a concurrent validation that would retarget `mutation.variables` and leave the original row's request in flight without visible pending state.
- The label remains per-row: `isValidatingThisProvider = validateMutation.isPending && validateMutation.variables === provider.id` — only the actively validating row shows "验证中..." / "Validating..."; other rows show "立即验证" / "Validate now" but are disabled.
- After validation completes, the existing `refreshProviderQueries()` helper invalidates `["settings", "providers"]`, `["settings", "provider-health"]`, `["settings", "routing-config"]`, `["settings", "routing-explain"]`, and `["shell", "provider-truth"]` — the row's status pills, diagnostic grid, and remediation card re-render with the new persisted state.

## Strict scope

- 1 file: `ui/src/routes/settings-page.tsx`
- No source code change outside this UI file
- No tests (unit or e2e) added — no settings-page test infrastructure exists at the unit level; a focused e2e for one button is out of scope per agreed F5a plan
- No workflow / release script change
- No doc change
- No retroactive change to PR #195 capability proof matrix, PR #196 packaging doc, PR #197 trust marker, or any other prior PR

## Verification

**No browser preview was run; verification is `typecheck` / `lint` / `secret scan` / `diff-check` / `reviewer` only.**

Browser preview rationale: a meaningful proof would require a running Friday hub backend (with at least one configured provider) + UI dev server + admin login session + known good and known bad provider keys to exercise both success and failure toast paths. Setting that stack up just to click one button is not practical in this session, and the change is TypeScript-validated and reviewed.

- [x] `npx tsc --noEmit` — exit 0
- [x] `npm run lint` — 0 errors (1436 baseline warnings preserved)
- [x] `npm run check:secret-patterns` — clean
- [x] `git diff --check` — clean
- [x] `git diff --name-only origin/main` — exactly 1 file (`ui/src/routes/settings-page.tsx`)
- [x] No source / test / workflow / release script / doc / capability proof matrix changed

## Reviewer trail

| Round | Reviewer | Verdict | Notes |
|---|---|---|---|
| R1 | A (UI behavior + status semantics) | `OVERALL: PASS` | status-driven toast, refreshProviderQueries, per-row pending isolation, button visible for all providers, no backend creep, mutationFn signature matches API client, no confirmation dialog |
| R1 | B (secret hygiene + scope) | `OVERALL: PASS` | no `validation.errorMessage` / `error.message` echo, ApiError import correct, scope = 1 file, no release-proof tier label, no scope creep into other mutations, no e2e test added |
| R2 | targeted (pending-state UX after one-line `disabled` adjustment) | `OVERALL: PASS` | mutation-wide disabled correctly closes the concurrent-click race condition; label still uses per-row state; no other behavior change; secret hygiene preserved |

## Evidence framing

This change is supported by **UI-only / TypeScript / lint / reviewer** evidence.

- **Not** real-runtime.
- **Not** real-provider.
- **Not** release proof.
- **No release-proof evidence contribution.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)