### PR TITLE
Add region-limited provider section to setup wizard

### DIFF
--- a/ui/src/routes/setup-page.tsx
+++ b/ui/src/routes/setup-page.tsx
@@ -344,6 +344,7 @@ export function SetupPage() {
   const [providerRegion, setProviderRegion] = useState<"international" | "china">(
     locale === "zh" ? "china" : "international",
   );
+  const [showRegionLimitedTemplates, setShowRegionLimitedTemplates] = useState<boolean>(false);
 
   // ── Existing state (kept intact) ──
   const [acknowledgedSecurity, setAcknowledgedSecurity] = useState(false);
@@ -1743,6 +1744,53 @@ export function SetupPage() {
             );
           })}
         </div>
+
+        {/* More providers (region-limited): opposite-region templates rendered in a
+            collapsed section. Selecting an item reuses applyProviderTemplate() and the
+            existing setup save path with validateOnSave=true; the provider is never
+            marked ready/available/routing-eligible without validation passing. */}
+        {(() => {
+          const oppositeRegion: "international" | "china" = providerRegion === "china" ? "international" : "china";
+          const oppositeKinds = providerRegion === "china" ? internationalKinds : chinaKinds;
+          if (oppositeKinds.length === 0) return null;
+          return (
+            <div className="mt-3 w-full max-w-md">
+              <button
+                type="button"
+                onClick={() => setShowRegionLimitedTemplates((v) => !v)}
+                aria-expanded={showRegionLimitedTemplates}
+                className="flex w-full items-center justify-between rounded-2xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] px-4 py-2 text-sm text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)]"
+              >
+                <span>{localize(locale, "更多提供方（地区限定）", "More providers (region-limited)")}</span>
+                <span aria-hidden="true">{showRegionLimitedTemplates ? "▾" : "▸"}</span>
+              </button>
+              {showRegionLimitedTemplates ? (
+                <div className="mt-3 flex flex-wrap justify-center gap-2">
+                  {oppositeKinds.map((kind) => {
+                    const tpl = providerTemplates.find((t) => t.providerKind === kind);
+                    const label = tpl?.displayName
+                      ? (locale === "zh" ? tpl.displayName : tpl.displayName.replace(/^[^\(]+\(([^\)]+)\)$/, "$1").trim() || tpl.displayName)
+                      : titleCase(kind);
+                    return (
+                      <button
+                        key={kind}
+                        type="button"
+                        onClick={() => {
+                          setProviderRegion(oppositeRegion);
+                          applyProviderTemplate(kind);
+                        }}
+                        className="flex items-center gap-2 rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] px-5 py-2.5 text-sm font-medium text-[color:var(--color-text-secondary)] hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text-primary)]"
+                      >
+                        <span>{label}</span>
+                        <StatusPill tone="neutral">{localize(locale, "地区限定", "Region-limited")}</StatusPill>
+                      </button>
+                    );
+                  })}
+                </div>
+              ) : null}
+            </div>
+          );
+        })()}
 
         {(useMyPlanAvailable && keyConnectionAvailable) ? (
           <div className="mt-6 flex items-center justify-center gap-1 rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] p-1">


### PR DESCRIPTION
## Summary

Adds a collapsed "更多提供方（地区限定）" / "More providers (region-limited)" section to the Step 2 provider chooser in the setup wizard. Users can now discover and select opposite-region setup-ready provider templates without leaving the wizard, while every existing safety gate stays intact.

## What this PR is

- **UI-only additive change** — 1 file, +48/-0.
- **Adds a collapsed "More providers (region-limited)" setup wizard section** that surfaces opposite-region templates (per the existing `getSetupProviderKindsForRegion` filter).
- **Reuses the existing `applyProviderTemplate()` and the existing setup wizard save path.** Selecting a region-limited template calls `setProviderRegion(oppositeRegion)` then `applyProviderTemplate(kind)`; the rest of the save flow is unchanged.
- **No backend change.** `src/providers/services/friday-provider-service.ts`, `src/api/http/routes/friday-provider-routes.ts`, `src/providers/model/friday-provider-templates.ts`, `src/providers/model/friday-provider.types.ts`, `src/providers/model/friday-runtime-capabilities.ts` — all untouched.
- **No provider doctor / validation / routing-eligibility change.** `validateOnSave: true` is still the default at create time; `fridayProviderRouteSupportsCapability` still requires `validation.status === "ok"` + capability `"verified"` for routing; `assertRequestedProviderAvailable` and `buildValidatedRouteCandidates` are unchanged.
- **No "Add anyway" wording.** The user explicitly requested this restraint; intentionally absent. The section expands visibility only — never bypasses any gate.
- **No false ready/available claim.** The per-template badge uses `<StatusPill tone="neutral">` with text "地区限定" / "Region-limited"; no "ready" / "available" / "validated" / "make available" / "mark ready" label.
- **No secret / `errorMessage` echo.** The new code paths never read `validation.errorMessage`, `Error.message`, `error.message`, `JSON.stringify(error)`, or any provider/network response text.

## UX behavior

- Default collapsed; default region remains locale-derived (existing behavior).
- Toggle is `aria-expanded` aware; the chevron (▾ / ▸) is `aria-hidden="true"` (decorative).
- When `oppositeKinds.length === 0`, the section returns `null` — no empty toggle is rendered.
- Selecting a region-limited template switches `providerRegion` to that region BEFORE `applyProviderTemplate(kind)`, so the region tab and the main pill list reflect the new selection without UI/state divergence.
- Settings "Validate Now" (PR #198) remains the post-save retry path; this PR neither competes with nor duplicates that flow.

## Browser preview not run — explanation

To visually verify the new section in a browser, the following stack would be required: a local Friday hub running with state DB initialized + auth bootstrap + the setup wizard's `providersApi.listTemplates()` returning a populated list. With an empty templates list, my new `oppositeKinds.length === 0` guard returns `null` and the section does not render at all — meaning a UI-only dev server (no hub) would show nothing useful. Standing up the full hub stack just to see one collapsed toggle + badge is not practical in this session. The change is TypeScript-validated, lint-clean, and reviewer-passed; no fake browser proof.

## Evidence framing

This change is supported by **typecheck / lint / secret scan / diff-check / reviewer evidence only**.

- **Not** real-runtime.
- **Not** real-provider.
- **Not** real-browser.
- **Not** release proof.
- **No release-proof evidence contribution.** The PR #195 capability proof matrix `l1-settings-ui` / setup wizard rows remain `blocked_by_env`; this PR neither moves them nor claims to.

## Verification

- [x] `npx tsc --noEmit` — exit 0
- [x] `npm run lint` — 0 errors (1436 baseline warnings preserved)
- [x] `npm run check:secret-patterns` — clean
- [x] `git diff --check` — clean
- [x] `git diff --name-only origin/main` — exactly 1 file (`ui/src/routes/setup-page.tsx`)
- [x] Precise grep — no "Add anyway" / "add-anyway" wording in added lines
- [x] Precise grep — no `validation.errorMessage` / `Error.message` / `error.message` echo in non-comment added lines
- [x] No backend / provider service / routing / doctor / workflow / release-script / doc change

## Reviewer trail

| Reviewer | Verdict | Scope |
|---|---|---|
| A (provider lifecycle truth + false-availability risk) | `OVERALL: PASS` | Confirmed: 1-file UI scope; no backend/doctor/runtime-capabilities/routing-eligibility change; `validateOnSave: false` zero occurrences in added code; backend `createProvider` validation branch unchanged; routing gates unchanged; badge uses neutral tone with no "Add anyway" / "Make available" / "Mark ready" wording; region switch correctly happens BEFORE `applyProviderTemplate`; empty-list guard correctly returns null; zero new mutation/query/API call. |
| B (UX clarity + scope discipline + secret/error hygiene) | `OVERALL: PASS` | Confirmed: single-file scope; collapsed-by-default initial state; toggle uses `aria-expanded` with decorative `aria-hidden="true"` chevron; per-template badge text + neutral tone correct; zero "Add anyway" / "force" / "bypass" / "Make available" / "Mark ready" wording; zero `validation.errorMessage` / `Error.message` echo in added code; zero new imports (reuses `localize` / `StatusPill` / `useState` / `titleCase`); reuses existing `applyProviderTemplate` save path; empty-list returns null; comment block neutral and accurate; Tailwind class style consistent with surrounding code; new useState is adjacent to related `providerRegion` useState (locality). |

🤖 Generated with [Claude Code](https://claude.com/claude-code)