### PR TITLE
Align MCP self-upgrade live test with canonical lifecycle

### DIFF
--- a/test/e2e/live/friday-self-upgrade-mcp-server-live.e2e.test.ts
+++ b/test/e2e/live/friday-self-upgrade-mcp-server-live.e2e.test.ts
@@ -4,6 +4,14 @@ import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import {
+  createFridayMcpServerLifecycleMutatingActionRequest,
+} from "../../../src/autonomy/services/friday-mcp-server-upgrade-lifecycle-service.js";
+import {
+  createFridayMutatingActionDigest,
+  signFridayCanonicalApproval,
+  type FridayCanonicalApprovalResolution,
+} from "../../../src/security/friday-mutating-action-gate.js";
+import {
   cleanupFridayDeepProofHubEnv,
   createFridayDeepProofHubEnv,
   FRIDAY_DEEP_PROOF_GATED,
@@ -11,6 +19,11 @@ import {
   FRIDAY_DEEP_PROOF_PROVIDER_LABEL,
   type RealHubEnv,
 } from "./_helpers/deep-proof-env.js";
+
+const MCP_LIFECYCLE_PLAN_DIGEST = "mcp-server-live-proof-plan";
+const MCP_LIFECYCLE_SIGNING_MATERIAL =
+  "mcp-server-live-proof-signing-material"; // pragma: allowlist secret
+const LOCAL_LIVE_PRINCIPAL_ID = "admin-001";
 
 interface RuntimeVersionEnvelope {
   ok: boolean;
@@ -189,6 +202,40 @@ async function getUpgradeStatus(env: RealHubEnv, serverId: string): Promise<Upgr
   return json.data.items[0]!;
 }
 
+function makeMcpLifecycleApproval(input: {
+  action: "shadow" | "canary" | "promote" | "rollback";
+  serverId: string;
+  shadowVersionId?: string;
+  runtimeVersion: string;
+  providerModel: string;
+}): FridayCanonicalApprovalResolution {
+  const rollback = input.action === "rollback"
+    ? { planned: true, planDigest: MCP_LIFECYCLE_PLAN_DIGEST, actions: ["mcp_servers.lifecycle.promote"] }
+    : undefined;
+  const request = createFridayMcpServerLifecycleMutatingActionRequest({
+    action: input.action,
+    serverId: input.serverId,
+    shadowVersionId: input.shadowVersionId,
+    runtimeVersion: input.runtimeVersion,
+    providerModel: input.providerModel,
+    actor: {
+      kind: "user",
+      id: LOCAL_LIVE_PRINCIPAL_ID,
+      principalId: LOCAL_LIVE_PRINCIPAL_ID,
+    },
+    surface: `api:/v1/autonomy/mcp-servers/${input.action}`,
+    planDigest: MCP_LIFECYCLE_PLAN_DIGEST,
+    rollback,
+  });
+  return signFridayCanonicalApproval({
+    decision: "approved",
+    approvalId: `mcp-server-live-${input.action}`,
+    decidedByPrincipalId: LOCAL_LIVE_PRINCIPAL_ID,
+    actionDigest: createFridayMutatingActionDigest(request),
+    expiresAt: "2027-05-07T00:00:00.000Z",
+  }, MCP_LIFECYCLE_SIGNING_MATERIAL);
+}
+
 describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)(`Friday MCP Server Self Upgrade Live (${FRIDAY_DEEP_PROOF_PROVIDER_LABEL})`, () => {
   let env: RealHubEnv;
   let previousMcpServers: string | undefined;
@@ -207,7 +254,11 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)(`Friday MCP Server Self Upgrade Live (
         args: ["-e", buildStdioServerScript()],
       },
     ]);
-    env = await createFridayDeepProofHubEnv();
+    env = await createFridayDeepProofHubEnv({
+      hubConfig: {
+        tokenSecret: MCP_LIFECYCLE_SIGNING_MATERIAL,
+      },
+    });
   }, 120_000);
 
   afterAll(async () => {
@@ -273,6 +324,14 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)(`Friday MCP Server Self Upgrade Live (
           shadowVersionId: firstShadowId,
           runtimeVersion,
           providerModel: FRIDAY_DEEP_PROOF_MODEL,
+          planDigest: MCP_LIFECYCLE_PLAN_DIGEST,
+          canonicalApproval: makeMcpLifecycleApproval({
+            action: "shadow",
+            serverId,
+            shadowVersionId: firstShadowId,
+            runtimeVersion,
+            providerModel: FRIDAY_DEEP_PROOF_MODEL,
+          }),
         }),
       });
       const shadowJson = await shadowRes.json() as McpActionEnvelope;
@@ -287,7 +346,18 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)(`Friday MCP Server Self Upgrade Live (
           Authorization: `Bearer ${env.accessToken}`,
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ success: true }),
+        body: JSON.stringify({
+          runtimeVersion,
+          providerModel: FRIDAY_DEEP_PROOF_MODEL,
+          planDigest: MCP_LIFECYCLE_PLAN_DIGEST,
+          canonicalApproval: makeMcpLifecycleApproval({
+            action: "canary",
+            serverId,
+            shadowVersionId: firstShadowId,
+            runtimeVersion,
+            providerModel: FRIDAY_DEEP_PROOF_MODEL,
+          }),
+        }),
       });
       const canaryJson = await canaryRes.json() as McpActionEnvelope;
       expect(canaryRes.status).toBe(200);
@@ -305,6 +375,14 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)(`Friday MCP Server Self Upgrade Live (
         body: JSON.stringify({
           runtimeVersion,
           providerModel: FRIDAY_DEEP_PROOF_MODEL,
+          planDigest: MCP_LIFECYCLE_PLAN_DIGEST,
+          canonicalApproval: makeMcpLifecycleApproval({
+            action: "promote",
+            serverId,
+            shadowVersionId: firstShadowId,
+            runtimeVersion,
+            providerModel: FRIDAY_DEEP_PROOF_MODEL,
+          }),
         }),
       });
       const promoteJson = await promoteRes.json() as McpActionEnvelope;
@@ -320,32 +398,6 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)(`Friday MCP Server Self Upgrade Live (
       expect(rowAfterPromote?.lastVerifiedRuntimeVersion).toBe(runtimeVersion);
       expect(rowAfterPromote?.lastVerifiedProviderModel).toBe(FRIDAY_DEEP_PROOF_MODEL);
 
-      const secondShadowId = `${serverId}@shadow-rollback`;
-      await fetch(`${env.baseUrl}/v1/autonomy/mcp-servers/${encodeURIComponent(serverId)}/shadow`, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${env.accessToken}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          shadowVersionId: secondShadowId,
-          runtimeVersion,
-          providerModel: FRIDAY_DEEP_PROOF_MODEL,
-        }),
-      });
-
-      const failingCanaryRes = await fetch(`${env.baseUrl}/v1/autonomy/mcp-servers/${encodeURIComponent(serverId)}/canary`, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${env.accessToken}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ success: false }),
-      });
-      const failingCanaryJson = await failingCanaryRes.json() as McpActionEnvelope;
-      expect(failingCanaryRes.status).toBe(200);
-      expect(failingCanaryJson.data.server.canaryStats?.failureCount).toBeGreaterThanOrEqual(1);
-
       const rollbackRes = await fetch(`${env.baseUrl}/v1/autonomy/mcp-servers/${encodeURIComponent(serverId)}/rollback`, {
         method: "POST",
         headers: {
@@ -355,6 +407,15 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)(`Friday MCP Server Self Upgrade Live (
         body: JSON.stringify({
           runtimeVersion,
           providerModel: FRIDAY_DEEP_PROOF_MODEL,
+          planDigest: MCP_LIFECYCLE_PLAN_DIGEST,
+          reason: "live mcp lifecycle rollback proof",
+          canonicalApproval: makeMcpLifecycleApproval({
+            action: "rollback",
+            serverId,
+            shadowVersionId: firstShadowId,
+            runtimeVersion,
+            providerModel: FRIDAY_DEEP_PROOF_MODEL,
+          }),
         }),
       });
       const rollbackJson = await rollbackRes.json() as McpActionEnvelope;


### PR DESCRIPTION
## Goal

Test-harness-only conformance to the current canonical MCP server lifecycle gate. The live smoke test should pass under the DeepSeek lane without changing product or runtime code.

## Current behavior (pre-change)

`test/e2e/live/friday-self-upgrade-mcp-server-live.e2e.test.ts` fails at the first mutating endpoint on a live DeepSeek run. Three divergences from the current contract:

1. POSTs to `/shadow`, `/canary`, `/promote`, `/rollback` omit `planDigest` and `canonicalApproval`. The canonical mutating-action gate (`src/security/friday-mutating-action-gate.ts`) rejects with `CANONICAL_APPROVAL_REQUIRED` (HTTP 403).
2. `/canary` body sends `success: true` (and later `success: false`). The route (`src/api/http/routes/friday-autonomy-routes.ts`) now rejects either field with `MCP_SERVER_CANARY_RUNTIME_PROOF_REQUIRED` (HTTP 400). Canary success/failure is decided by Friday's read-only `listTools` smoke, not by the caller.
3. Second-shadow + caller-supplied failing-canary segment depends on `success: false` being honored AND would overwrite `evidence.shadow.previous` with the post-promote active snapshot, making the rollback assertions impossible.

## Expected behavior (post-change)

Test passes under DeepSeek lane (`FRIDAY_E2E_LIVE_DEEPSEEK=1`) by conforming to the canonical contract:

1. New `makeMcpLifecycleApproval` helper mirrors the sibling provider-profile and plugin live tests. It builds the lifecycle mutating-action request via `createFridayMcpServerLifecycleMutatingActionRequest` from the MCP lifecycle service, computes the action digest, and signs the canonical approval with a test-local HMAC secret. For `action: "rollback"`, the helper passes the rollback metadata `{ planned: true, planDigest, actions: ["mcp_servers.lifecycle.promote"] }` so the signed digest matches the service-built request at gate evaluation time.
2. `hubConfig.tokenSecret` is wired to the same constant the helper signs with, so the canonical gate's HMAC verification passes.
3. `/canary` body sends only `runtimeVersion`, `providerModel`, `planDigest`, and `canonicalApproval`. No `success` / `evaluatedAt`.
4. Single-cycle lifecycle: shadow → canary → promote → rollback. Rollback restores the pre-shadow snapshot per `src/autonomy/services/friday-mcp-server-upgrade-lifecycle-service.ts` rollback semantics: `promotionChannel: "rolled_back"`, `compatibilityStatus: "adaptation_required"`, `shadowVersionId: null`. These assertions match MCP service semantics (NOT provider-profile / plugin `"none"`, which are different lifecycle contracts).

## Acceptance criteria

- [x] Live smoke passes under `FRIDAY_E2E_LIVE_DEEPSEEK=1` (1/1, 373ms, no retry).
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run lint` — 0 errors. Pre-existing warnings unchanged.
- [x] `npm run check:secret-patterns` — clean.
- [x] `git diff --check` — clean.
- [x] `git diff --name-only origin/main` returns exactly one file.
- [x] Two isolated `general-purpose` reviewers PASS (lifecycle contract + scope discipline).
- [x] No product or runtime code changed.

## Out of scope

- No `src/**` changes.
- No CI / workflow / docs changes.
- No other live test changes.
- No DeepSeek 11-test queue resumption (separate decision after this PR lands).
- No friday-playbook-upgrade-boundary-live migration PR (separate, gated on full DeepSeek queue passing).
- No retroactive review of merged PRs #194-#199 (reviewer-trail audit reported separately).

## Proof tier

- **local real-runtime + real-provider DeepSeek** evidence.
- **NOT** same-SHA Real Green Gate (RGG) release proof.
- **NOT** `release.yml` `live-proof-gate` proof.
- **NOT** capability-proof-matrix release-proof contribution.

## Reviewer trail

Two isolated `general-purpose` reviewers dispatched in parallel before staging:

- **Reviewer A — canonical lifecycle correctness**: PASS on all 7 criteria. Verified canonical approval helper builds the same request the service builds at gate evaluation; rollback metadata mirrors service path; token secret wired correctly; per-endpoint fields correct; rollback assertions match MCP service semantics. Notable: confirmed `previous` snapshot is `{ "unknown", "none" }` (no detect/adapt path writes the mcp_server state row before `registerShadowVersion`), and the test assertions hold under either `{ "unknown", "none" }` or `{ "compatible", "none" }` because both ternaries short-circuit when `promotionChannel !== "active"`.
- **Reviewer B — scope discipline**: PASS on all 7 criteria. Verified file scope is exactly one file; AGENTS.md doc-only diff is stashed and NOT in this branch; no real secrets in diff (test-local HMAC material follows established sibling-test pattern with `// pragma: allowlist secret`); no `.skip` / `.only` / FAST_MODE; describe still gated on `FRIDAY_DEEP_PROOF_GATED`; assertion count went from 44 to 42 (only removed assertions were the now-impossible caller-supplied failing-canary segment).

## Test plan

- [x] `FRIDAY_E2E_LIVE_DEEPSEEK=1 npx vitest run test/e2e/live/friday-self-upgrade-mcp-server-live.e2e.test.ts` — PASS (1/1, 373ms, no retry).
- [x] No other live lanes activated (`FRIDAY_E2E_LIVE_ANTHROPIC` / `FRIDAY_E2E_LIVE_OPENAI` / `FRIDAY_E2E_LIVE_OLLAMA` unset).
- [x] No API keys, tokens, cookies, passkeys, or secret fragments in diff.
- [x] `M AGENTS.md` doc-only diff (separate work) is NOT included in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)