### PR TITLE
Align channel-adapter live test with canonical lifecycle (DeepSeek preflight)

### DIFF
--- a/test/e2e/live/friday-self-upgrade-channel-adapter-live.e2e.test.ts
+++ b/test/e2e/live/friday-self-upgrade-channel-adapter-live.e2e.test.ts
@@ -6,6 +6,14 @@ import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import {
+  createFridayChannelAdapterLifecycleMutatingActionRequest,
+} from "../../../src/autonomy/services/friday-channel-adapter-upgrade-lifecycle-service.js";
+import {
+  createFridayMutatingActionDigest,
+  signFridayCanonicalApproval,
+  type FridayCanonicalApprovalResolution,
+} from "../../../src/security/friday-mutating-action-gate.js";
+import {
   cleanupFridayDeepProofHubEnv,
   createFridayDeepProofHubEnv,
   FRIDAY_DEEP_PROOF_GATED,
@@ -13,6 +21,11 @@ import {
   FRIDAY_DEEP_PROOF_PROVIDER_LABEL,
   type RealHubEnv,
 } from "./_helpers/deep-proof-env.js";
+
+const CHANNEL_ADAPTER_LIFECYCLE_PLAN_DIGEST = "channel-adapter-live-proof-plan";
+const CHANNEL_ADAPTER_LIFECYCLE_SIGNING_MATERIAL =
+  "channel-adapter-live-proof-signing-material"; // pragma: allowlist secret
+const LOCAL_LIVE_PRINCIPAL_ID = "admin-001";
 
 interface RuntimeVersionEnvelope {
   ok: boolean;
@@ -370,6 +383,44 @@ async function getChannel(env: RealHubEnv, channelKind: string): Promise<Channel
   return json.data.channel;
 }
 
+function makeChannelAdapterLifecycleApproval(input: {
+  action: "shadow" | "canary" | "promote" | "rollback";
+  channelKind: string;
+  shadowVersionId?: string;
+  runtimeVersion: string;
+  providerModel: string;
+}): FridayCanonicalApprovalResolution {
+  const rollback = input.action === "rollback"
+    ? {
+      planned: true,
+      planDigest: CHANNEL_ADAPTER_LIFECYCLE_PLAN_DIGEST,
+      actions: ["channel_adapters.lifecycle.promote"],
+    }
+    : undefined;
+  const request = createFridayChannelAdapterLifecycleMutatingActionRequest({
+    action: input.action,
+    channelKind: input.channelKind,
+    shadowVersionId: input.shadowVersionId,
+    runtimeVersion: input.runtimeVersion,
+    providerModel: input.providerModel,
+    actor: {
+      kind: "user",
+      id: LOCAL_LIVE_PRINCIPAL_ID,
+      principalId: LOCAL_LIVE_PRINCIPAL_ID,
+    },
+    surface: `api:/v1/autonomy/channels/${input.action}`,
+    planDigest: CHANNEL_ADAPTER_LIFECYCLE_PLAN_DIGEST,
+    rollback,
+  });
+  return signFridayCanonicalApproval({
+    decision: "approved",
+    approvalId: `channel-adapter-live-${input.action}`,
+    decidedByPrincipalId: LOCAL_LIVE_PRINCIPAL_ID,
+    actionDigest: createFridayMutatingActionDigest(request),
+    expiresAt: "2027-05-07T00:00:00.000Z",
+  }, CHANNEL_ADAPTER_LIFECYCLE_SIGNING_MATERIAL);
+}
+
 describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)(`Friday Channel Adapter Self Upgrade Live (${FRIDAY_DEEP_PROOF_PROVIDER_LABEL})`, () => {
   let env: RealHubEnv;
   const inboundMessages: Array<{ text: string; senderId: string }> = [];
@@ -377,6 +428,7 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)(`Friday Channel Adapter Self Upgrade L
   beforeAll(async () => {
     env = await createFridayDeepProofHubEnv({
       hubConfig: {
+        tokenSecret: CHANNEL_ADAPTER_LIFECYCLE_SIGNING_MATERIAL,
         channels: {
           enabled: true,
           instances: [
@@ -465,6 +517,14 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)(`Friday Channel Adapter Self Upgrade L
           shadowVersionId: firstShadowId,
           runtimeVersion,
           providerModel: FRIDAY_DEEP_PROOF_MODEL,
+          planDigest: CHANNEL_ADAPTER_LIFECYCLE_PLAN_DIGEST,
+          canonicalApproval: makeChannelAdapterLifecycleApproval({
+            action: "shadow",
+            channelKind: "webchat",
+            shadowVersionId: firstShadowId,
+            runtimeVersion,
+            providerModel: FRIDAY_DEEP_PROOF_MODEL,
+          }),
         }),
       });
       const shadowJson = await shadowRes.json() as ChannelActionEnvelope;
@@ -479,7 +539,18 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)(`Friday Channel Adapter Self Upgrade L
           Authorization: `Bearer ${env.accessToken}`,
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ success: true }),
+        body: JSON.stringify({
+          runtimeVersion,
+          providerModel: FRIDAY_DEEP_PROOF_MODEL,
+          planDigest: CHANNEL_ADAPTER_LIFECYCLE_PLAN_DIGEST,
+          canonicalApproval: makeChannelAdapterLifecycleApproval({
+            action: "canary",
+            channelKind: "webchat",
+            shadowVersionId: firstShadowId,
+            runtimeVersion,
+            providerModel: FRIDAY_DEEP_PROOF_MODEL,
+          }),
+        }),
       });
       const canaryJson = await canaryRes.json() as ChannelActionEnvelope;
       expect(canaryRes.status).toBe(200);
@@ -497,6 +568,14 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)(`Friday Channel Adapter Self Upgrade L
         body: JSON.stringify({
           runtimeVersion,
           providerModel: FRIDAY_DEEP_PROOF_MODEL,
+          planDigest: CHANNEL_ADAPTER_LIFECYCLE_PLAN_DIGEST,
+          canonicalApproval: makeChannelAdapterLifecycleApproval({
+            action: "promote",
+            channelKind: "webchat",
+            shadowVersionId: firstShadowId,
+            runtimeVersion,
+            providerModel: FRIDAY_DEEP_PROOF_MODEL,
+          }),
         }),
       });
       const promoteJson = await promoteRes.json() as ChannelActionEnvelope;
@@ -512,32 +591,6 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)(`Friday Channel Adapter Self Upgrade L
       expect(rowAfterPromote?.lastVerifiedRuntimeVersion).toBe(runtimeVersion);
       expect(rowAfterPromote?.lastVerifiedProviderModel).toBe(FRIDAY_DEEP_PROOF_MODEL);
 
-      const secondShadowId = "webchat@shadow-rollback";
-      await fetch(`${env.baseUrl}/v1/autonomy/channels/webchat/shadow`, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${env.accessToken}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          shadowVersionId: secondShadowId,
-          runtimeVersion,
-          providerModel: FRIDAY_DEEP_PROOF_MODEL,
-        }),
-      });
-
-      const failingCanaryRes = await fetch(`${env.baseUrl}/v1/autonomy/channels/webchat/canary`, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${env.accessToken}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ success: false }),
-      });
-      const failingCanaryJson = await failingCanaryRes.json() as ChannelActionEnvelope;
-      expect(failingCanaryRes.status).toBe(200);
-      expect(failingCanaryJson.data.channel.canaryStats?.failureCount).toBeGreaterThanOrEqual(1);
-
       const rollbackRes = await fetch(`${env.baseUrl}/v1/autonomy/channels/webchat/rollback`, {
         method: "POST",
         headers: {
@@ -547,6 +600,15 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)(`Friday Channel Adapter Self Upgrade L
         body: JSON.stringify({
           runtimeVersion,
           providerModel: FRIDAY_DEEP_PROOF_MODEL,
+          planDigest: CHANNEL_ADAPTER_LIFECYCLE_PLAN_DIGEST,
+          reason: "live channel adapter lifecycle rollback proof",
+          canonicalApproval: makeChannelAdapterLifecycleApproval({
+            action: "rollback",
+            channelKind: "webchat",
+            shadowVersionId: firstShadowId,
+            runtimeVersion,
+            providerModel: FRIDAY_DEEP_PROOF_MODEL,
+          }),
         }),
       });
       const rollbackJson = await rollbackRes.json() as ChannelActionEnvelope;


### PR DESCRIPTION
## Goal

DeepSeek queue preflight: bring the channel-adapter live test into conformance with the current canonical channel-adapter lifecycle gate, so the DeepSeek serial queue's test #6 stops failing at the shadow endpoint with `CANONICAL_APPROVAL_REQUIRED`.

This PR was originally scoped to two independent slices (Slice 1: channel-adapter, Slice 2: generator-maintenance). Slice 2 hit the user-specified explicit STOP condition and is documented below; this PR ships Slice 1 alone.

## Current behavior (pre-change)

`test/e2e/live/friday-self-upgrade-channel-adapter-live.e2e.test.ts` fails at the first mutating endpoint on a live DeepSeek run. Three divergences from the current contract:

1. POSTs to `/shadow`, `/canary`, `/promote`, `/rollback` omit `planDigest` and `canonicalApproval`. The canonical mutating-action gate rejects with `CANONICAL_APPROVAL_REQUIRED` (HTTP 403).
2. `/canary` body sends `body: { success: true }` (and later `{ success: false }`). The route now rejects either field with `CHANNEL_ADAPTER_CANARY_RUNTIME_PROOF_REQUIRED` (HTTP 400). Canary success/failure is decided by the service's internal `runChannelCanaryProbe` (running + status=connected + health.state=connected + credentialStatus not missing/invalid + no blockedReason).
3. Second-shadow + caller-supplied failing-canary segment depends on `success: false` being honored AND would overwrite `evidence.shadow.previous` with the post-promote active snapshot, making the rollback assertions impossible.

## Expected behavior (post-change)

Test passes under DeepSeek lane (`FRIDAY_E2E_LIVE_DEEPSEEK=1`) by conforming to the canonical contract:

1. New `makeChannelAdapterLifecycleApproval` helper mirrors PR #200's MCP pattern. It builds the lifecycle mutating-action request via `createFridayChannelAdapterLifecycleMutatingActionRequest`, computes the action digest, and signs the canonical approval with a test-local HMAC secret. For `action: "rollback"`, the helper passes the rollback metadata `{ planned, planDigest, actions: ["channel_adapters.lifecycle.promote"] }` matching the service's internal request shape.
2. `hubConfig.tokenSecret` is wired to the same constant the helper signs with (existing `hubConfig.channels.*` is preserved).
3. `/canary` body sends only `runtimeVersion`, `providerModel`, `planDigest`, and `canonicalApproval`. No `success` / `evaluatedAt`.
4. Single-cycle lifecycle: shadow → canary → promote → rollback. Rollback restores pre-shadow snapshot: `promotionChannel: "rolled_back"`, `compatibilityStatus: "adaptation_required"`, `shadowVersionId: null`. These assertions match the channel-adapter service rollback semantics (NOT provider-profile / plugin `"none"`, which are different lifecycle contracts).

## Acceptance criteria

- [x] Live smoke passes under `FRIDAY_E2E_LIVE_DEEPSEEK=1` (1/1, 344ms, single attempt).
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run lint` — 0 errors. Pre-existing warnings unchanged.
- [x] `npm run check:secret-patterns` — clean.
- [x] `git diff --check` — clean.
- [x] `git diff --name-only origin/main` returns exactly one file.
- [x] Two isolated `general-purpose` reviewers PASS (canonical correctness + scope discipline).
- [x] No product or runtime code changed.

## Out of scope

- No `src/**` changes.
- No CI / workflow / docs changes.
- No other live test changes (no edits to `friday-generator-maintenance-live.e2e.test.ts` — see Slice 2 STOP below).
- No DeepSeek 11-test queue resumption (separate decision after this PR lands).

## Slice 2 — STOP condition (honest blocker disclosure)

User prompt baked in an explicit STOP condition for Slice 2 (`friday-generator-maintenance-live`):

> "If candidateId is unavailable from current response shape, STOP and report before changing API/runtime."

Fresh-read confirms STOP fires:

- Skill autonomy lifecycle requires `candidateId` from the candidate store (`src/autonomy/services/friday-skill-upgrade-lifecycle-service.ts:293-311` `requireCandidate` calls `resolveCandidate({ skillId, candidateId })`).
- Candidate store is fed only by `FridaySkillCandidateStore.stage()` (`src/skills/converter/services/friday-skill-candidate-store.ts:293`).
- Grep on `src/skills/generator/` returns **0 references** to `candidateStore`, `FridayExternalSkillCandidate`, or `skill-candidate`. The only caller of `candidateStore.stage()` is `src/skills/converter/services/friday-skill-converter-service.ts:215`.
- Skill generator's `approveAndSave` (`src/skills/generator/services/friday-skill-generator-service.ts:2021+`) writes files directly to `resolveSafeInstallDir(skillsDir, skillId)` and updates session status to `approved` — never stages a candidate.
- `FridayApproveResponse` type (`src/api/model/friday-api-skill-generator.types.ts:98-107`) exposes no `candidateId`.

So `friday-generator-maintenance-live.e2e.test.ts` cannot be made canonical-compliant within test-harness-only scope. The fix requires either:
- A product/runtime change to make generator `approveAndSave` stage a candidate (out of test-harness scope), or
- A test rewrite to use `/v1/skills/import` instead of generator approve (changes test meaning — not approved here).

Per user's STOP condition: no edits attempted on `friday-generator-maintenance-live.e2e.test.ts`. Decision deferred.

## Proof tier

- **local real-runtime + real-provider DeepSeek** evidence for channel-adapter.
- **NOT** same-SHA Real Green Gate (RGG) release proof.
- **NOT** `release.yml` `live-proof-gate` proof.
- **NOT** capability-proof-matrix release-proof contribution.

## Reviewer trail

Two isolated `general-purpose` reviewers dispatched in parallel before staging:

- **Reviewer A — canonical lifecycle correctness**: PASS on all 7 criteria. Verified helper builds the same request the service builds at gate evaluation; rollback metadata mirrors service path (`actions: ["channel_adapters.lifecycle.promote"]`); tokenSecret correctly wired; per-endpoint fields correct; single-cycle rollback math confirmed (`{unknown, none}` pre-shadow snapshot → `{adaptation_required, rolled_back}` post-rollback).
- **Reviewer B — scope discipline**: PASS on all 8 criteria. Verified file scope is exactly one file; AGENTS.md doc-only diff is stashed and NOT in this branch; no real secrets in diff (test-local HMAC material follows established sibling pattern with `// pragma: allowlist secret`); no `.skip` / `.only` / FAST_MODE; describe still gated on `FRIDAY_DEEP_PROOF_GATED`; assertion count goes from 47 to 45 (only removed assertions are the now-impossible caller-supplied failing-canary segment). Confirmed Slice 2 file was NOT edited.

## Test plan

- [x] `FRIDAY_E2E_LIVE_DEEPSEEK=1 npx vitest run test/e2e/live/friday-self-upgrade-channel-adapter-live.e2e.test.ts` — PASS (1/1, 344ms, single attempt, no retry).
- [x] No other live lanes activated (`FRIDAY_E2E_LIVE_ANTHROPIC` / `FRIDAY_E2E_LIVE_OPENAI` / `FRIDAY_E2E_LIVE_OLLAMA` unset).
- [x] No API keys, tokens, cookies, passkeys, or secret fragments in diff.
- [x] `M AGENTS.md` doc-only diff (separate work) is NOT included in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)