### PR TITLE
Document workflow reread and reviewer-source rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,8 @@ Before any code, test, config, docs, workflow, skill, memory, provider, UI, syst
 6. Read the relevant Friday source, tests, audit notes, route/runtime wiring, state model, approval boundary, memory boundary, and evidence path.
 7. If using an external guideline or repo, read the actual source before merging it into Friday behavior.
 
+These required reads are per-turn and per-subphase, not one-time session setup. After every new user message, interruption, context compaction, branch switch, or resume, reread the required files and current git state before acting. Do not rely on session memory, previous summaries, or another agent's report as a substitute.
+
 Never claim a fresh full-repo line-by-line reread unless it actually happened in the current session.
 
 ## Current Guideline Inputs
@@ -27,6 +29,7 @@ These rules merge:
 - The Friday master workflow prompt at `/Users/jarvis/Desktop/friday_master_workflow_prompt.md`.
 - The user's hard rules in this thread.
 - The Karpathy-inspired guideline repo `https://github.com/forrestchang/andrej-karpathy-skills`, read at commit `2c606141936f1eeef17fa3043a72095b4765b9c2`.
+- The Matt Pocock skills repo `https://github.com/mattpocock/skills`, read at commit `9fecab929abb904c68ce3366a1781df31ab22832`, absorbed into `/Users/jarvis/Desktop/friday_master_workflow_prompt.md` section 23 as workflow principles only.
 
 The external guideline principles are applied as behavior rules, not copied as a new architecture:
 
@@ -34,6 +37,7 @@ The external guideline principles are applied as behavior rules, not copied as a
 - Keep the solution simple.
 - Make surgical changes.
 - Define verifiable success criteria and loop until verified.
+- Use staged audit, plan, implementation, verification, reviewer, and CI workflows with two isolated reviewers for meaningful changes.
 
 ## Execution Style Rules
 
@@ -156,6 +160,7 @@ Before staging any meaningful change:
 - Run secret scan when keys or secret-like context were involved.
 - Inspect `git status --short --branch`.
 - Use two isolated read-only reviewers for meaningful subphases.
+- For meaningful code review, design-doc auditing, cross-file consistency checks, release/security review, or open-ended reviewer passes, use isolated `general-purpose` reviewers. Do not use Explore-style agents for review; Explore is only acceptable for narrow file, symbol, or location lookup.
 - If either reviewer fails, fix only the blocker inside approved scope, then rerun verification and reviewers.
 
 ## Infrastructure Uncertainty Protocol


### PR DESCRIPTION
## Summary

Doc-only update to `AGENTS.md`. Persists four standing workflow rules into the repo so future Claude/Codex sessions see them without needing them re-explained in each thread. Mirrors and complements the master prompt `§23` content.

## What changed

Only `AGENTS.md` (+5 lines, 0 deletions, 4 small hunks):

1. **Per-turn / per-subphase reread requirement** (`Required Sources To Read Before Work`, line 20)
   - Required reads are not a one-time session setup
   - After every new user message, interruption, context compaction, branch switch, or resume, reread the required files and current git state
   - Session memory, previous summaries, and another agent's report are NOT substitutes
   - Compatible with the existing line 22 rule "Never claim a fresh full-repo line-by-line reread unless it actually happened" (different topic — reading discipline vs claim discipline)

2. **Matt Pocock skills repo source citation** (`Current Guideline Inputs`, line 32)
   - Repo at `https://github.com/mattpocock/skills`, read at commit `9fecab929abb904c68ce3366a1781df31ab22832`
   - Absorbed into `/Users/jarvis/Desktop/friday_master_workflow_prompt.md` section 23 as workflow principles only
   - **Not installed into Friday**. Mirrors §23.6 hard rule "`mattpocock/skills` is read for principle absorption only; it must not be installed into the Friday repo"

3. **Staged audit / plan / implementation / verification / reviewer / CI workflow principle** (external-guideline mapping, line 40)
   - Reinforces existing two-isolated-reviewers requirement at line 162

4. **Reviewer agent-type rule** (`Verification Protocol`, line 163)
   - For meaningful code review, design-doc auditing, cross-file consistency checks, release/security review, or open-ended reviewer passes, use isolated `general-purpose` reviewers
   - Do NOT use Explore-style agents for review; Explore is only acceptable for narrow file, symbol, or location lookup
   - Matches the Explore tool description's own exclusion list ("Do NOT use it for code review, design-doc auditing, cross-file consistency checks, or open-ended analysis")
   - **Was not previously persisted anywhere** (`rg -n "general-purpose|Explore" AGENTS.md master-prompt context/AGENTS.md` returns 0 matches in prior origin/main)

## What does NOT change

- No runtime code (`src/**`).
- No test code (`test/**`).
- No workflow files (`.github/workflows/*.yml`).
- No `docs/current-source-of-truth.md`.
- No `/Users/jarvis/Desktop/friday_master_workflow_prompt.md` (lives outside repo).
- No `.claude/settings.local.json`, `.claude/launch.json`, or any secret-bearing file.
- No release-proof tier definition, RGG validator behavior, or live-test gating.
- No reformat of unrelated existing `AGENTS.md` text.

## Verification

Run on the staging branch:

| Check | Result |
|---|---|
| `git diff --check` | clean |
| `git diff --name-only origin/main` | `AGENTS.md` (single file) |
| `git diff --cached --stat` | `1 file changed, 5 insertions(+)` |
| `rg "general-purpose\|Explore.*review" AGENTS.md` | matches line 163 (new rule) |
| `rg "per-turn\|Matt Pocock\|staged audit" AGENTS.md` | matches the 3 other dirty hunks |
| `git status --short --branch` | only the one staged file before commit, clean tree after |
| typecheck / lint / vitest | not run — `AGENTS.md` is doc-only markdown, does not participate in tsc / lint / test pipelines |
| secret scan | diff contains only plain-text rule wording + public GitHub URLs + public commit SHAs; no API keys / tokens / cookies / passkeys |

## Reviewer trail

Two isolated `general-purpose` reviewers dispatched in parallel before staging (per the new line 163 rule itself):

- **Reviewer A — content correctness**: PASS on 6/6 criteria. Verified consistency with master prompt §23 (§23.2 Stage 0-8, §23.6 hard rules) and `context/AGENTS.md`; confirmed the new rule solves the prior Explore misuse problem and matches Explore tool description; confirmed no product/runtime/test/release-semantics change; confirmed all 3 prior dirty hunks preserved.
- **Reviewer B — scope discipline / hygiene**: PASS on 8/8 criteria. Verified file scope = exactly `AGENTS.md`; no secret leak (only public URLs + public commit SHAs); no `.claude/`, `src/**`, `test/**`, `.github/**`, `docs/**`, or protected paths touched; new wording does not require impossible full-repo reread; `git diff --check` clean; no reformat of unrelated text; working tree clean.

## Evidence framing (per §23.6)

- **This PR is a doc-only workflow-rule clarification.**
- **Not release proof.** No same-SHA Real Green Gate (RGG) evidence is produced or claimed.
- **Workflow `conclusion: success` on this PR will be plumbing-tier only**, never release proof on its own.
- `blocked_by_env` (if any future RGG run on this SHA emits it) is **never** `pass`.
- No live test was run for this PR; live tests do not apply to a markdown-only change.

## Out of scope (deferred to separate work)

- `#9 friday-generator-maintenance-live.e2e.test.ts` skill-generator-vs-candidate-store lifecycle map (read-only audit).
- DeepSeek safe queue resumption excluding #9 (8-10 live tests).
- Full link-to-capability closed-loop map, including the now-confirmed `provider-template` deeplink docs-vs-runtime mismatch (`docs/current-source-of-truth.md:248` claims real import; `src/api/runtime/friday-deep-link-apply-service.ts:104-108` returns `applied: false` preview-only).
- Setup-wizard A4 brittle contract narrow fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)