### PR TITLE
fix(api): gate skill lifecycle update/delete

### DIFF
--- a/src/api/http/routes/friday-skill-routes.ts
+++ b/src/api/http/routes/friday-skill-routes.ts
@@ -94,6 +94,60 @@ function createFridaySkillContentUpdateMutatingActionRequest(input: {
   };
 }
 
+export function createFridaySkillLifecycleRouteMutatingActionRequest(input: {
+  action: "update" | "delete";
+  skillId: string;
+  version?: string;
+  sourceId?: string;
+  targetSatelliteIds?: string[];
+  grantPermissions?: string[];
+  actor: FridayMutatingActionActor;
+  surface: string;
+  idempotencyKey?: string;
+}): FridayMutatingActionRequest {
+  const action = `skills.lifecycle.${input.action}`;
+  return {
+    action,
+    actor: input.actor,
+    surface: input.surface,
+    resource: {
+      type: "skill_lifecycle",
+      id: input.skillId,
+      digest: hashStableJson({
+        action: input.action,
+        skillId: input.skillId,
+        version: input.version,
+        sourceId: input.sourceId,
+        targetSatelliteIds: input.targetSatelliteIds,
+        grantPermissions: input.grantPermissions,
+      }),
+      attributes: {
+        skillId: input.skillId,
+        lifecycleAction: input.action,
+      },
+    },
+    mutating: true,
+    risk: "high",
+    parameters: {
+      skillId: input.skillId,
+      lifecycleAction: input.action,
+      version: input.version,
+      sourceId: input.sourceId,
+      targetSatelliteIds: input.targetSatelliteIds ?? [],
+      grantPermissions: input.grantPermissions ?? [],
+    },
+    idempotencyKey: input.idempotencyKey,
+    localClaims: [
+      {
+        guardId: "skill_lifecycle_mutation_guard",
+        decision: "requires_approval",
+        risk: "high",
+        reason: "skill_lifecycle_mutation_requires_canonical_approval",
+      },
+    ],
+  };
+}
+
 function toLegacyCompatibleListItem(item: {
   skillId: string;
   name: string;
@@ -380,13 +434,38 @@ export function createFridaySkillRoutes(
           if (isManagedExternalSkillArtifact(existing)) {
             throwLegacyExternalSkillLifecycleRequired({ skillId, operation: "update" });
           }
+          const version = asOptionalString(body.version, "version");
+          const sourceId = asOptionalString(body.sourceId, "sourceId");
+          const targetSatelliteIds = asStringArray(body.targetSatelliteIds, "targetSatelliteIds");
+          const grantPermissions = asStringArray(body.grantPermissions, "grantPermissions");
+          assertCanonicalApproval({
+            deps,
+            request: createFridaySkillLifecycleRouteMutatingActionRequest({
+              action: "update",
+              skillId,
+              version,
+              sourceId,
+              targetSatelliteIds,
+              grantPermissions,
+              actor: createActorFromPrincipal(ctx.principal, "skill-lifecycle-operator"),
+              surface: "api:/v1/skills/:skillId/update",
+              idempotencyKey: asOptionalString(body.idempotencyKey, "idempotencyKey"),
+            }),
+            canonicalApproval: readCanonicalApproval(body.canonicalApproval),
+            requiredCode: "SKILL_LIFECYCLE_UPDATE_APPROVAL_REQUIRED",
+            deniedCode: "SKILL_LIFECYCLE_UPDATE_APPROVAL_DENIED",
+            unavailableCode: "SKILL_LIFECYCLE_UPDATE_GATE_UNAVAILABLE",
+            requiredMessage: "Skill lifecycle updates require canonical approval before mutation.",
+            deniedMessage: "Skill lifecycle update was blocked by the canonical approval gate",
+            unavailableMessage: "Skill lifecycle updates require the canonical approval gate.",
+          });
           const result = await deps.lifecycle!.update({
             userId: ctx.principal?.principalId ?? "skill-operator",
             skillId,
-            version: asOptionalString(body.version, "version"),
-            sourceId: asOptionalString(body.sourceId, "sourceId"),
-            targetSatelliteIds: asStringArray(body.targetSatelliteIds, "targetSatelliteIds"),
-            grantPermissions: asStringArray(body.grantPermissions, "grantPermissions"),
+            version,
+            sourceId,
+            targetSatelliteIds,
+            grantPermissions,
           });
           return result;
         },
@@ -402,6 +481,24 @@ export function createFridaySkillRoutes(
           if (isManagedExternalSkillArtifact(existing)) {
             throwLegacyExternalSkillLifecycleRequired({ skillId, operation: "delete" });
           }
+          const body = asRecord(ctx.body);
+          assertCanonicalApproval({
+            deps,
+            request: createFridaySkillLifecycleRouteMutatingActionRequest({
+              action: "delete",
+              skillId,
+              actor: createActorFromPrincipal(ctx.principal, "skill-lifecycle-operator"),
+              surface: "api:/v1/skills/:skillId",
+              idempotencyKey: asOptionalString(body.idempotencyKey, "idempotencyKey"),
+            }),
+            canonicalApproval: readCanonicalApproval(body.canonicalApproval),
+            requiredCode: "SKILL_LIFECYCLE_DELETE_APPROVAL_REQUIRED",
+            deniedCode: "SKILL_LIFECYCLE_DELETE_APPROVAL_DENIED",
+            unavailableCode: "SKILL_LIFECYCLE_DELETE_GATE_UNAVAILABLE",
+            requiredMessage: "Skill lifecycle deletes require canonical approval before mutation.",
+            deniedMessage: "Skill lifecycle delete was blocked by the canonical approval gate",
+            unavailableMessage: "Skill lifecycle deletes require the canonical approval gate.",
+          });
           return deps.lifecycle!.deleteSkill({
             skillId,
             deletedBy: ctx.principal?.principalId ?? "skill-operator",

--- a/test/unit/api/http/routes/friday-skill-routes.test.ts
+++ b/test/unit/api/http/routes/friday-skill-routes.test.ts
@@ -4,7 +4,16 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { FridayDomainError } from "#errors";
 import { FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS_ENV } from "#skills";
-import { createFridaySkillRoutes } from "../../../../../src/api/http/routes/friday-skill-routes.js";
+import {
+  createFridaySkillLifecycleRouteMutatingActionRequest,
+  createFridaySkillRoutes,
+} from "../../../../../src/api/http/routes/friday-skill-routes.js";
+import {
+  createFridayMutatingActionDigest,
+  createFridayMutatingActionGate,
+} from "../../../../../src/security/friday-mutating-action-gate.js";
+
+const NOW = "2026-03-07T00:00:00.000Z";
 
 function makeCtx(overrides: Record<string, unknown> = {}) {
   return {
@@ -19,10 +28,10 @@ function makeCtx(overrides: Record<string, unknown> = {}) {
       scopes: ["skill.read", "skill.write", "hub.admin"],
       tokenId: "token-1",
       tokenKind: "access",
-      issuedAt: "2026-03-07T00:00:00.000Z",
+      issuedAt: NOW,
     },
     requestId: "req-1",
-    receivedAt: "2026-03-07T00:00:00.000Z",
+    receivedAt: NOW,
     ...overrides,
   } as never;
 }
@@ -125,7 +134,7 @@ function makeLifecycle() {
     deleteSkill: vi.fn(async ({ skillId }: { skillId: string }) => ({ deleted: true, skillId })),
     verifySkill: vi.fn(async (input) => ({
       skillId: input.skillId,
-      verifiedAt: "2026-03-07T00:00:00.000Z",
+      verifiedAt: NOW,
       ok: true,
       manifestVerdict: { ok: true, issues: [] },
       packageIntegrity: { available: true, ok: true },
@@ -134,6 +143,47 @@ function makeLifecycle() {
       trustSummary: { verdict: "trusted", reasons: ["ok"] },
     })),
     validateManifest: vi.fn(() => ({ ok: true, issues: [] })),
+  };
+}
+
+function makeCanonicalMutationGate() {
+  return createFridayMutatingActionGate({
+    nowIso: () => NOW,
+    ticketIdGenerator: () => "ticket-1",
+  });
+}
+
+function makeLifecycleRouteApproval(input: {
+  action: "update" | "delete";
+  skillId: string;
+  body?: Record<string, unknown>;
+}) {
+  const body = input.body ?? {};
+  const request = createFridaySkillLifecycleRouteMutatingActionRequest({
+    action: input.action,
+    skillId: input.skillId,
+    version: typeof body.version === "string" ? body.version : undefined,
+    sourceId: typeof body.sourceId === "string" ? body.sourceId : undefined,
+    targetSatelliteIds: input.action === "update"
+      ? Array.isArray(body.targetSatelliteIds) ? body.targetSatelliteIds as string[] : []
+      : undefined,
+    grantPermissions: input.action === "update"
+      ? Array.isArray(body.grantPermissions) ? body.grantPermissions as string[] : []
+      : undefined,
+    actor: {
+      kind: "user",
+      id: "user-1",
+      principalId: "user-1",
+    },
+    surface: input.action === "update" ? "api:/v1/skills/:skillId/update" : "api:/v1/skills/:skillId",
+    idempotencyKey: typeof body.idempotencyKey === "string" ? body.idempotencyKey : undefined,
+  });
+  return {
+    decision: "approved" as const,
+    approvalId: `${input.action}-approval-1`,
+    decidedByPrincipalId: "user-1",
+    actionDigest: createFridayMutatingActionDigest(request),
+    expiresAt: "2026-03-07T01:00:00.000Z",
   };
 }
 
@@ -285,7 +335,7 @@ describe("createFridaySkillRoutes", () => {
     expect(lifecycle.validateManifest).toHaveBeenCalledWith({ id: "skill.alpha" });
   });
 
-  it("keeps legacy update/delete available for non-managed skills", async () => {
+  it("requires canonical approval before non-managed lifecycle update/delete", async () => {
     const lifecycle = makeLifecycle();
     lifecycle.getSkill.mockImplementation((skillId: string) => ({
       skillId,
@@ -304,13 +354,75 @@ describe("createFridaySkillRoutes", () => {
     const routes = createFridaySkillRoutes({
       skillRegistry: { list: () => [] } as never,
       lifecycle: lifecycle as never,
+      canonicalMutationGate: makeCanonicalMutationGate(),
     });
 
     const update = routes.find((item) => item.operationId === "skills.update")!;
     const remove = routes.find((item) => item.operationId === "skills.delete")!;
 
-    await update.handler(makeCtx({ params: { skillId: "skill.alpha" }, body: { version: "1.1.0" } }));
-    await remove.handler(makeCtx({ params: { skillId: "skill.alpha" } }));
+    await expect(
+      update.handler(makeCtx({ params: { skillId: "skill.alpha" }, body: { version: "1.1.0" } })),
+    ).rejects.toMatchObject({
+      code: "SKILL_LIFECYCLE_UPDATE_APPROVAL_REQUIRED",
+      httpStatus: 403,
+    });
+    await expect(
+      remove.handler(makeCtx({ params: { skillId: "skill.alpha" } })),
+    ).rejects.toMatchObject({
+      code: "SKILL_LIFECYCLE_DELETE_APPROVAL_REQUIRED",
+      httpStatus: 403,
+    });
+
+    expect(lifecycle.update).not.toHaveBeenCalled();
+    expect(lifecycle.deleteSkill).not.toHaveBeenCalled();
+  });
+
+  it("passes canonical approval through non-managed lifecycle update/delete", async () => {
+    const lifecycle = makeLifecycle();
+    lifecycle.getSkill.mockImplementation((skillId: string) => ({
+      skillId,
+      name: "Workspace Skill",
+      source: "workspace",
+      origin: "workspace",
+      status: "installed",
+      starter: false,
+      tags: [],
+      updateAvailable: false,
+      managed: false,
+      registryLoaded: true,
+      versions: [],
+      installations: [],
+    }));
+    const routes = createFridaySkillRoutes({
+      skillRegistry: { list: () => [] } as never,
+      lifecycle: lifecycle as never,
+      canonicalMutationGate: makeCanonicalMutationGate(),
+    });
+
+    const update = routes.find((item) => item.operationId === "skills.update")!;
+    const remove = routes.find((item) => item.operationId === "skills.delete")!;
+    const updateBody = { version: "1.1.0", idempotencyKey: "update-1" };
+
+    await update.handler(makeCtx({
+      params: { skillId: "skill.alpha" },
+      body: {
+        ...updateBody,
+        canonicalApproval: makeLifecycleRouteApproval({
+          action: "update",
+          skillId: "skill.alpha",
+          body: updateBody,
+        }),
+      },
+    }));
+    await remove.handler(makeCtx({
+      params: { skillId: "skill.alpha" },
+      body: {
+        canonicalApproval: makeLifecycleRouteApproval({
+          action: "delete",
+          skillId: "skill.alpha",
+        }),
+      },
+    }));
 
     expect(lifecycle.update).toHaveBeenCalledWith(expect.objectContaining({
       skillId: "skill.alpha",


### PR DESCRIPTION
## Summary

Phase 6 of the Friday remaining-work plan: add canonical approval gates to the skill lifecycle update/delete HTTP routes before any lifecycle mutation can run.

Changed files:
- `src/api/http/routes/friday-skill-routes.ts`
- `test/unit/api/http/routes/friday-skill-routes.test.ts`

## What changed

- Added `createFridaySkillLifecycleRouteMutatingActionRequest` for route-level lifecycle `update` and `delete` mutations.
- Required canonical approval before non-managed lifecycle `skills.update` calls `deps.lifecycle.update`.
- Required canonical approval before non-managed lifecycle `skills.delete` calls `deps.lifecycle.deleteSkill`.
- Preserved the existing managed external skill retirement path: managed external install/update/delete still return `SKILL_LEGACY_LIFECYCLE_ROUTE_RETIRED` before any lifecycle mutation route is reopened.
- Added focused unit coverage for missing approval fail-closed behavior and approved update/delete behavior.

## What this does not do

- Does not wire `createFridaySkillLifecycleService` into hub/runtime.
- Does not register the currently-missing standalone lifecycle service in `createFridayApiRuntime`.
- Does not close the `/v1/skills/:skillId/verify` route-level 404 by itself.
- Does not resolve F-017 fully; it closes the approval prerequisite slice only.
- Does not touch F-019, generator/candidate-store bridge, workflows, RGG, branch protection, AGENTS.md, master prompt, or audit docs.
- Does not claim release proof.

## Verification

- `npx vitest run test/unit/api/http/routes/friday-skill-routes.test.ts --reporter=verbose` PASS: 15/15 tests.
- `npx tsc --noEmit` PASS.
- `npm run lint` PASS with 0 errors; existing repo warnings remain.
- `npm run check:secret-patterns` PASS.
- `git diff --check` PASS.
- `git diff --name-only origin/main` showed only the two approved Phase 6 files.

## Reviewers / cross-check

- Reviewer A PASS: verified fail-closed ordering, managed external retirement ordering, approved-path semantics, and no missed update/delete entrypoint in the route file.
- Reviewer B PASS: verified no fake proof, no test weakening, no scope creep, no secret leak, no automatic wiring/default-on, and no approval bypass.
- Codex cross-check PASS: confirmed no hub bootstrap / Phase 7 wiring change and diff scope limited to the two Phase 6 files.

## Honest proof framing

This is approval-boundary code/test evidence only. It is not runtime/provider proof and not same-SHA Real Green Gate release proof. Any Real Green Gate workflow success must still be checked by downloading and reading the artifact JSON; `blocked_by_env` is never pass.

## Merge status

This draft PR is not merge-approved by this body. Do not merge automatically. Stage 7 must read CI plus RGG artifact honestly, and Stage 8 must be performed only after the user merges or explicitly authorizes the allowed merge path.