### PR TITLE
Bridge skill generator approvals to candidates

### DIFF
--- a/src/agent/tools/friday-agent-skill-generator-tool.ts
+++ b/src/agent/tools/friday-agent-skill-generator-tool.ts
@@ -55,7 +55,7 @@ export function createFridayAgentSkillGeneratorTool(
       "start (begin a generation session with a goal), " +
       "turn (submit a follow-up message to an active session), " +
       "generate (generate the skill draft from the conversation), " +
-      "approve (approve and save the generated skill), " +
+      "approve (stage the generated skill as a lifecycle candidate; requires canonical approval support), " +
       "cancel (cancel an active session), " +
       "status (check session status and draft).",
     parameters: {
@@ -182,6 +182,8 @@ export function createFridayAgentSkillGeneratorTool(
               approved: true,
               skillId: result.skillId,
               skillDir: result.skillDir,
+              candidateId: result.candidateId,
+              candidateDir: result.candidateDir,
               savedFiles: result.savedFiles,
               registryRefreshed: result.registryRefreshed,
               promotionStage: result.promotionStage,
@@ -190,9 +192,10 @@ export function createFridayAgentSkillGeneratorTool(
               requiredInputs,
               exampleRunInput,
               nextRecommendedAction: {
-                tool: "skill_run",
+                tool: "autonomy_skill_lifecycle",
                 skillId: result.skillId,
-                input: exampleRunInput,
+                candidateId: result.candidateId,
+                action: "shadow_then_canary_then_promote",
               },
             });
           }

--- a/src/api/http/routes/friday-skill-generator-routes.ts
+++ b/src/api/http/routes/friday-skill-generator-routes.ts
@@ -6,7 +6,10 @@ import type { FridayRouteDefinition } from "../../model/friday-api-common.types.
 import { FridayDomainError } from "#errors";
 import type { FridayProviderTenantContext } from "#providers";
 
-import type { FridaySkillGeneratorService } from "#skills/generator";
+import {
+  createFridaySkillGeneratorStageMutatingActionRequest,
+  type FridaySkillGeneratorService,
+} from "#skills/generator";
 import type { FridaySkillRegistry } from "#skills";
 import type { FridaySkillUiSchemaV1 } from "#skills/generator";
 import {
@@ -26,6 +29,13 @@ import {
 import type { FridaySelfHealingApiService } from "#learning";
 import type { FridayObservabilityApiService } from "../../../observability/services/friday-observability-api-service.js";
 import { extractFridaySkillGenerationContract } from "../../../skills/generator/services/friday-skill-generator-contract.js";
+import type { FridayAuthPrincipal } from "../../model/friday-api-auth.types.js";
+import type {
+  FridayCanonicalApprovalResolution,
+  FridayMutatingActionActor,
+  FridayMutatingActionGate,
+  FridayMutatingActionTicket,
+} from "../../../security/friday-mutating-action-gate.js";
 
 import type {
   FridayApproveResponse,
@@ -70,6 +80,34 @@ function buildTenantContext(principal: unknown, fallbackUserId: string, fallback
     userId,
     channelKind: fallbackChannel,
   };
+}
+
+function createActorFromPrincipal(
+  principal: FridayAuthPrincipal | null,
+  fallbackId: string,
+): FridayMutatingActionActor {
+  if (!principal) {
+    return {
+      kind: "api",
+      id: fallbackId,
+      principalId: fallbackId,
+    };
+  }
+  return {
+    kind: principal.principalType,
+    id: principal.principalId,
+    principalId: principal.principalId,
+  };
+}
+
+function readCanonicalApproval(value: unknown): FridayCanonicalApprovalResolution | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as FridayCanonicalApprovalResolution;
+  }
+  throw new FridayDomainError("VALIDATION_ERROR", "canonicalApproval must be an object", { httpStatus: 400 });
 }
 
 // ─── Validation helpers ───
@@ -162,6 +200,87 @@ function validateGenerateBody(
   }
 }
 
+function validateApproveBody(
+  body: unknown,
+): asserts body is {
+  idempotencyKey?: string;
+  planDigest?: string;
+  canonicalApproval?: FridayCanonicalApprovalResolution;
+} {
+  if (body == null) return;
+  if (typeof body !== "object" || Array.isArray(body)) {
+    throw new FridayDomainError(
+      "VALIDATION_ERROR",
+      "Request body must be a plain object when provided",
+      { httpStatus: 400 },
+    );
+  }
+  const b = body as Record<string, unknown>;
+  if (b.idempotencyKey !== undefined && typeof b.idempotencyKey !== "string") {
+    throw new FridayDomainError("VALIDATION_ERROR", "idempotencyKey must be a string when provided", { httpStatus: 400 });
+  }
+  if (b.planDigest !== undefined && typeof b.planDigest !== "string") {
+    throw new FridayDomainError("VALIDATION_ERROR", "planDigest must be a string when provided", { httpStatus: 400 });
+  }
+  readCanonicalApproval(b.canonicalApproval);
+}
+
+async function assertSkillGeneratorCandidateApproval(input: {
+  deps: FridaySkillGeneratorRoutesDeps;
+  principal: FridayAuthPrincipal | null;
+  requestId: string;
+  sessionId: string;
+  body: {
+    idempotencyKey?: string;
+    planDigest?: string;
+    canonicalApproval?: FridayCanonicalApprovalResolution;
+  };
+}): Promise<FridayMutatingActionTicket> {
+  if (!input.deps.canonicalMutationGate) {
+    throw new FridayDomainError(
+      "SKILL_GENERATOR_CANDIDATE_GATE_UNAVAILABLE",
+      "Generated skill approval requires the canonical approval gate before candidate staging.",
+      { httpStatus: 503 },
+    );
+  }
+  const sessionData = await input.deps.skillGenerator.getSession(input.sessionId);
+  if (!sessionData?.draft) {
+    throw new FridayDomainError(
+      "GENERATOR_DRAFT_NOT_FOUND",
+      "No draft found for session. Generate a draft first.",
+      { httpStatus: 404 },
+    );
+  }
+  const gateResult = input.deps.canonicalMutationGate.evaluate(
+    createFridaySkillGeneratorStageMutatingActionRequest({
+      session: sessionData.session,
+      draft: sessionData.draft,
+      actor: createActorFromPrincipal(input.principal, `api:${input.requestId}`),
+      surface: "api:/v1/skills/generator/sessions/:sessionId/approve",
+      idempotencyKey: input.body.idempotencyKey,
+      planDigest: input.body.planDigest,
+      canonicalApproval: input.body.canonicalApproval,
+    }),
+  );
+  if (gateResult.decision !== "allow" || !gateResult.ticket) {
+    throw new FridayDomainError(
+      gateResult.decision === "requires_approval"
+        ? "SKILL_GENERATOR_CANDIDATE_APPROVAL_REQUIRED"
+        : "SKILL_GENERATOR_CANDIDATE_APPROVAL_DENIED",
+      gateResult.decision === "requires_approval"
+        ? "Generated skill approval stages a lifecycle candidate and requires canonical approval before any candidate is written."
+        : `Generated skill candidate staging was blocked by the canonical approval gate: ${gateResult.reason}`,
+      {
+        httpStatus: 403,
+        details: {
+          canonicalGate: gateResult.evidenceRecord,
+        },
+      },
+    );
+  }
+  return gateResult.ticket;
+}
+
 // ─── Dependencies ───
 
 export interface FridaySkillGeneratorRoutesDeps {
@@ -169,6 +288,7 @@ export interface FridaySkillGeneratorRoutesDeps {
   registry: FridaySkillRegistry;
   selfHealing?: FridaySelfHealingApiService;
   observability?: FridayObservabilityApiService;
+  canonicalMutationGate?: FridayMutatingActionGate;
 }
 
 const GENERATED_SKILL_HUB_VERSION = "1.0.0";
@@ -644,18 +764,18 @@ export function createFridaySkillGeneratorRoutes(
             ? !test
               ? "Draft still needs to pass explicit self-test"
               : !test.ok
-                ? "Draft still needs to pass explicit self-test"
-                : !test.executable
-                  ? "Draft explicit self-test did not execute runtime behavior"
-                  : "Draft passed validation and explicit self-test"
+            ? "Draft still needs to pass explicit self-test"
+            : !test.executable
+              ? "Draft explicit self-test did not execute runtime behavior"
+              : "Draft passed validation and explicit self-test"
             : "Draft has validation issues that must be fixed before approval",
         }
         : savedOrApproved
           ? {
             ready: true,
             reason: result.session.status === "saved"
-              ? "Generated skill saved."
-              : "Generated skill approved and ready to save.",
+              ? "Generated skill candidate staged."
+              : "Generated skill approved and ready to stage as a candidate.",
           }
         : {
           ready: false,
@@ -678,7 +798,7 @@ export function createFridaySkillGeneratorRoutes(
       approvalReadiness,
       qaVerdict,
       harness,
-      savedSkillIdentity: result.session.draftSkillId
+      stagedCandidateIdentity: result.session.draftSkillId
         ? {
           skillId: result.session.draftSkillId,
         }
@@ -878,7 +998,18 @@ export function createFridaySkillGeneratorRoutes(
       rateLimitPolicyId: "skill_generator.write",
       async handler(ctx): Promise<FridayApproveResponse> {
         const { sessionId } = ctx.params as { sessionId: string };
-        const result = await deps.skillGenerator.approveAndSave(sessionId);
+        validateApproveBody(ctx.body);
+        const body = ctx.body ?? {};
+        const canonicalApprovalTicket = await assertSkillGeneratorCandidateApproval({
+          deps,
+          principal: ctx.principal,
+          requestId: ctx.requestId,
+          sessionId,
+          body,
+        });
+        const result = await deps.skillGenerator.approveAndSave(sessionId, {
+          canonicalApprovalTicket,
+        });
         const evidence = await buildEvidence(sessionId).catch(() => ({
           sessionId,
           validationSummary: {
@@ -894,20 +1025,22 @@ export function createFridaySkillGeneratorRoutes(
           executableTestSummary: null,
           approvalReadiness: {
             ready: true,
-            reason: "Generated skill saved.",
+            reason: "Generated skill candidate staged.",
           },
           qaVerdict: result.qaVerdict ?? null,
           harness: result.harness ?? null,
-          savedSkillIdentity: {
+          stagedCandidateIdentity: {
             skillId: result.skillId,
-            skillDir: result.skillDir,
+            candidateId: result.candidateId,
+            candidateDir: result.candidateDir,
+            filesDir: result.skillDir,
           },
         }));
         await deps.observability?.recordSkillGeneratorEvent({
           sessionId,
           userId: "operator",
           event: "draft_saved",
-          summary: `Saved generated skill ${result.skillId}`,
+          summary: `Staged generated skill candidate ${result.candidateId}`,
           ok: true,
           evidence,
         });
@@ -917,13 +1050,15 @@ export function createFridaySkillGeneratorRoutes(
             ...evidence,
             qaVerdict: result.qaVerdict ?? evidence.qaVerdict ?? null,
             harness: result.harness ?? evidence.harness ?? null,
-            savedSkillIdentity: {
+            stagedCandidateIdentity: {
               skillId: result.skillId,
-              skillDir: result.skillDir,
+              candidateId: result.candidateId,
+              candidateDir: result.candidateDir,
+              filesDir: result.skillDir,
             },
             approvalReadiness: {
               ready: true,
-              reason: "Generated skill saved.",
+              reason: "Generated skill candidate staged.",
             },
           },
         };

--- a/src/api/model/friday-api-skill-generator.types.ts
+++ b/src/api/model/friday-api-skill-generator.types.ts
@@ -80,9 +80,11 @@ export interface FridaySkillGenerationEvidence {
   };
   qaVerdict?: FridayHarnessQaVerdictV1 | null;
   harness?: FridayTemplateHarnessSummary | null;
-  savedSkillIdentity?: {
+  stagedCandidateIdentity?: {
     skillId: string;
-    skillDir?: string;
+    candidateId?: string;
+    candidateDir?: string;
+    filesDir?: string;
   };
 }
 
@@ -99,9 +101,11 @@ export interface FridayApproveResponse {
   sessionId: string;
   skillId: string;
   skillDir: string;
+  candidateId: string;
+  candidateDir: string;
   savedFiles: string[];
   registryRefreshed: boolean;
-  promotionStage: "stabilized";
+  promotionStage: "candidate_staged";
   promotedManifestTags: string[];
   evidence: FridaySkillGenerationEvidence;
 }

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -2574,6 +2574,7 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
       registry: deps.skillRegistry,
       selfHealing: deps.diagnosis?.service,
       observability: deps.observabilityService,
+      canonicalMutationGate,
     })) {
       routes.register(route);
     }

--- a/src/skills/generator/index.ts
+++ b/src/skills/generator/index.ts
@@ -75,3 +75,10 @@ export {
 export type {
   FridaySkillGenerationContract,
 } from "./services/friday-skill-generator-contract.js";
+
+export {
+  FRIDAY_SKILL_GENERATOR_CANDIDATE_CONVERTER_ID,
+  createFridayGeneratedSkillCandidateDraft,
+  createFridayGeneratedSkillCandidateSource,
+  createFridaySkillGeneratorStageMutatingActionRequest,
+} from "./services/friday-skill-generator-candidate-bridge.js";

--- a/src/skills/generator/services/friday-skill-generator-candidate-bridge.ts
+++ b/src/skills/generator/services/friday-skill-generator-candidate-bridge.ts
@@ -1,0 +1,98 @@
+import type {
+  FridayCanonicalApprovalResolution,
+  FridayMutatingActionActor,
+  FridayMutatingActionRequest,
+} from "../../../security/friday-mutating-action-gate.js";
+import {
+  createFridaySkillStageMutatingActionRequest,
+  type FridayConvertedSkillDraft,
+  type FridaySkillConversionSource,
+} from "#skills/converter";
+import type {
+  FridayGeneratedSkillDraft,
+  FridaySkillGenerationSession,
+} from "../model/friday-skill-generator.types.js";
+import type { SkillManifestV2 } from "../../model/friday-skill-manifest-v2.types.js";
+
+export const FRIDAY_SKILL_GENERATOR_CANDIDATE_CONVERTER_ID = "friday-skill-generator";
+
+export function createFridayGeneratedSkillCandidateSource(input: {
+  session: FridaySkillGenerationSession;
+  draft: FridayGeneratedSkillDraft;
+}): FridaySkillConversionSource {
+  const payload = {
+    schemaVersion: "friday.skill-generator.candidate-source.v1",
+    sessionId: input.session.sessionId,
+    userId: input.session.userId,
+    channel: input.session.channel,
+    goal: input.session.goal,
+    skillId: input.draft.manifest.id,
+    version: input.draft.manifest.version,
+    manifest: input.draft.manifest,
+    uiSchema: input.draft.uiSchema,
+    files: input.draft.files.map((file) => ({
+      path: file.path,
+      content: file.content,
+      executable: file.executable === true,
+    })),
+  };
+
+  return {
+    contentBase64: Buffer.from(JSON.stringify(payload)).toString("base64"),
+    formatHint: "friday-package",
+  };
+}
+
+export function createFridayGeneratedSkillCandidateDraft(input: {
+  manifest: SkillManifestV2;
+  draft: FridayGeneratedSkillDraft;
+  convertedAt: string;
+}): FridayConvertedSkillDraft {
+  return {
+    manifest: input.manifest,
+    uiSchema: input.draft.uiSchema,
+    files: [
+      {
+        path: "skill.manifest.json",
+        content: JSON.stringify(input.manifest, null, 2),
+      },
+      {
+        path: "skill.ui.json",
+        content: JSON.stringify(input.draft.uiSchema, null, 2),
+      },
+      ...input.draft.files.map((file) => ({
+        path: file.path,
+        content: file.content,
+        executable: file.executable === true,
+      })),
+    ],
+    warnings: [],
+    conversionReport: {
+      sourceFormat: "friday-package",
+      convertedAt: input.convertedAt,
+      converterId: FRIDAY_SKILL_GENERATOR_CANDIDATE_CONVERTER_ID,
+    },
+  };
+}
+
+export function createFridaySkillGeneratorStageMutatingActionRequest(input: {
+  session: FridaySkillGenerationSession;
+  draft: FridayGeneratedSkillDraft;
+  actor: FridayMutatingActionActor;
+  surface: string;
+  idempotencyKey?: string;
+  planDigest?: string;
+  canonicalApproval?: FridayCanonicalApprovalResolution;
+}): FridayMutatingActionRequest {
+  return createFridaySkillStageMutatingActionRequest({
+    source: createFridayGeneratedSkillCandidateSource({
+      session: input.session,
+      draft: input.draft,
+    }),
+    actor: input.actor,
+    surface: input.surface,
+    idempotencyKey: input.idempotencyKey,
+    planDigest: input.planDigest,
+    canonicalApproval: input.canonicalApproval,
+  });
+}

--- a/src/skills/generator/services/friday-skill-generator-service.ts
+++ b/src/skills/generator/services/friday-skill-generator-service.ts
@@ -3,7 +3,7 @@ import { dirname, extname, join } from "node:path";
 import { tmpdir } from "node:os";
 
 import { FridayDomainError } from "#errors";
-import { resolveSafeInstallDir, resolveSafePath, safeJsonParse } from "#utilities";
+import { resolveSafePath, safeJsonParse } from "#utilities";
 import {
   buildHarnessSchemaTest,
   createFridayTemplateHarnessService,
@@ -67,7 +67,14 @@ import { validateUiSchema } from "../validation/friday-generated-skill-ui-valida
 import { safeParseFridaySkillManifestV2 } from "../../manifest/friday-skill-manifest.schema.js";
 import { loadFridaySkillPackage } from "../../manifest/friday-skill-package-loader.js";
 import { validateFridaySkillPackage } from "../../validation/friday-skill-validation-pipeline.js";
-import { createFridaySkillRepository } from "../../persistence/friday-skill-repository.js";
+import { createFridaySkillCandidateStore } from "../../converter/services/friday-skill-candidate-store.js";
+import { createFridayMutatingActionDigest, type FridayMutatingActionTicket } from "../../../security/friday-mutating-action-gate.js";
+import {
+  createFridayGeneratedSkillCandidateDraft,
+  createFridayGeneratedSkillCandidateSource,
+  createFridaySkillGeneratorStageMutatingActionRequest,
+  FRIDAY_SKILL_GENERATOR_CANDIDATE_CONVERTER_ID,
+} from "./friday-skill-generator-candidate-bridge.js";
 
 // ─── Constants ───
 
@@ -582,7 +589,6 @@ function autoResolveSkillGeneratorClarifications(input: {
 export function createFridaySkillGeneratorService(
   deps: CreateFridaySkillGeneratorServiceDeps,
 ): FridaySkillGeneratorService {
-  const skillRepo = createFridaySkillRepository();
   const repo: FridaySkillGenerationSessionRepository =
     createFridaySkillGenerationSessionRepository({
       db: deps.db,
@@ -1166,7 +1172,7 @@ export function createFridaySkillGeneratorService(
         ?? (session.status === "needs_clarification"
           ? "Waiting for one more answer before generation can continue."
           : session.status === "saved"
-            ? "Generated skill saved."
+            ? "Generated skill candidate staged."
             : "Skill generator state recorded."),
       completedWork: [
         planningSpec.artifactId ? "Planning spec recorded." : "",
@@ -1241,6 +1247,53 @@ export function createFridaySkillGeneratorService(
       ...manifest,
       tags: [...nextTags],
     };
+  }
+
+  function assertGeneratorCandidateApproval(input: {
+    session: FridaySkillGenerationSession;
+    draft: FridayGeneratedSkillDraft;
+    canonicalApprovalTicket?: FridayMutatingActionTicket;
+  }): FridayMutatingActionTicket {
+    const ticket = input.canonicalApprovalTicket;
+    if (!ticket) {
+      throw new FridayDomainError(
+        "SKILL_GENERATOR_CANDIDATE_APPROVAL_REQUIRED",
+        "Generated skill approval now stages a lifecycle candidate and requires canonical approval.",
+        { httpStatus: 403 },
+      );
+    }
+    if (ticket.action !== "skills.import.stage_candidate" || ticket.resource.type !== "external_skill_candidate") {
+      throw new FridayDomainError(
+        "SKILL_GENERATOR_CANDIDATE_APPROVAL_INVALID",
+        "Generated skill approval ticket does not authorize external skill candidate staging.",
+        { httpStatus: 403, details: { ticketId: ticket.ticketId, action: ticket.action, resourceType: ticket.resource.type } },
+      );
+    }
+
+    const expectedRequest = createFridaySkillGeneratorStageMutatingActionRequest({
+      session: input.session,
+      draft: input.draft,
+      actor: ticket.actor,
+      surface: ticket.surface,
+      idempotencyKey: ticket.idempotencyKey,
+      planDigest: ticket.planDigest,
+    });
+    const expectedDigest = createFridayMutatingActionDigest(expectedRequest);
+    if (expectedDigest !== ticket.actionDigest) {
+      throw new FridayDomainError(
+        "SKILL_GENERATOR_CANDIDATE_APPROVAL_DIGEST_MISMATCH",
+        "Generated skill approval ticket does not match the staged candidate request.",
+        {
+          httpStatus: 403,
+          details: {
+            ticketId: ticket.ticketId,
+            expectedDigest,
+            actualDigest: ticket.actionDigest,
+          },
+        },
+      );
+    }
+    return ticket;
   }
 
   async function runRequirementsAnalyzer(
@@ -2018,7 +2071,7 @@ export function createFridaySkillGeneratorService(
       return buildHarnessSummaryFromSession(session, qaVerdict);
     },
 
-    async approveAndSave(sessionId: string) {
+    async approveAndSave(sessionId: string, input = {}) {
       const session = requireSession(sessionId);
 
       if (session.status !== "ready_for_review") {
@@ -2073,122 +2126,42 @@ export function createFridaySkillGeneratorService(
         );
       }
 
-      // Resolve skills directory
       const settings = await deps.configManager.getSkillRegistrySettings(
         ".",
       );
-      const skillsDir = settings.managedSkillsDir;
       const skillId = draft.manifest.id;
-      const finalSkillDir = resolveSafeInstallDir(skillsDir, skillId);
       const promotedManifest = withStabilizedLifecycleTags(draft.manifest);
-
-      // ── Stage: Write to temp directory first ──
-      const tempDir = join(tmpdir(), `friday-skill-${sessionId}`);
-      mkdirSync(tempDir, { recursive: true });
-
-      const savedFiles: string[] = [];
-
-      try {
-        // Write manifest
-        const manifestPath = resolveSafePath(tempDir, "skill.manifest.json");
-        mkdirSync(dirname(manifestPath), { recursive: true });
-        writeFileSync(
-          manifestPath,
-          JSON.stringify(promotedManifest, null, 2),
-          "utf-8",
-        );
-        savedFiles.push("skill.manifest.json");
-
-        // Write UI schema
-        const uiPath = resolveSafePath(tempDir, "skill.ui.json");
-        mkdirSync(dirname(uiPath), { recursive: true });
-        writeFileSync(
-          uiPath,
-          JSON.stringify(draft.uiSchema, null, 2),
-          "utf-8",
-        );
-        savedFiles.push("skill.ui.json");
-
-        // Write generated files
-        for (const file of draft.files) {
-          const filePath = resolveSafePath(tempDir, file.path);
-          mkdirSync(dirname(filePath), { recursive: true });
-          writeFileSync(filePath, file.content, "utf-8");
-          savedFiles.push(file.path);
-
-          // chmod +x shell files (.sh extension or executable metadata)
-          const ext = extname(file.path).toLowerCase();
-          if (ext === ".sh" || ext === ".bash" || file.executable) {
-            chmodSync(filePath, 0o755);
-          }
-        }
-
-        // ── Stage: Validate package in temp dir ──
-        const loadResult = loadFridaySkillPackage({
-          skillDir: tempDir,
-          workspaceDir: skillsDir,
-        });
-
-        if (!loadResult.ok) {
-          throw new FridayDomainError(
-            "VALIDATION_ERROR",
-            `Package load failed in staging directory: ${loadResult.error.message}`,
-            { httpStatus: 422 },
-          );
-        }
-
-        const packageValidation = validateFridaySkillPackage({
-          loaded: loadResult.value,
-          workspaceDir: skillsDir,
-          hubVersion: FRIDAY_HUB_COMPAT_VERSION,
-          supportedApiVersions: SUPPORTED_API_VERSIONS,
-        });
-
-        if (!packageValidation.ok) {
-          const errors = packageValidation.issues
-            .filter((i) => i.severity === "error")
-            .map((i) => i.message)
-            .join("; ");
-          throw new FridayDomainError(
-            "VALIDATION_ERROR",
-            `Package validation failed: ${errors}`,
-            { httpStatus: 422 },
-          );
-        }
-
-        // ── Stage: Move from temp to final directory ──
-        mkdirSync(finalSkillDir, { recursive: true });
-
-        // Build a set of paths that have the executable metadata flag
-        const executablePaths = new Set(
-          draft.files
-            .filter((f) => f.executable)
-            .map((f) => f.path),
-        );
-
-        // Copy files from temp to final (renameSync can fail across mounts)
-        for (const relPath of savedFiles) {
-          const src = join(tempDir, relPath);
-          const dest = resolveSafePath(finalSkillDir, relPath);
-          mkdirSync(dirname(dest), { recursive: true });
-          const content = readFileSync(src);
-          writeFileSync(dest, content);
-
-          // Preserve executable permissions — check both extension and metadata
-          const ext = extname(relPath).toLowerCase();
-          if (ext === ".sh" || ext === ".bash" || executablePaths.has(relPath)) {
-            chmodSync(dest, 0o755);
-          }
-        }
-      } finally {
-        // ── Stage: Clean up temp dir ──
-        try {
-          rmSync(tempDir, { recursive: true, force: true });
-        } catch (err) {
-      console.warn("[friday][skill-generator-service] operation failed:", err instanceof Error ? err.message : String(err));
-          // Best-effort cleanup
-        }
-      }
+      const canonicalApprovalTicket = assertGeneratorCandidateApproval({
+        session,
+        draft,
+        canonicalApprovalTicket: input.canonicalApprovalTicket,
+      });
+      const candidateStore = createFridaySkillCandidateStore({
+        context: {
+          workspaceDir: settings.workspaceDir,
+          managedSkillsDir: settings.managedSkillsDir,
+          nowIso: deps.nowIso,
+        },
+        hubVersion: FRIDAY_HUB_COMPAT_VERSION,
+        supportedApiVersions: SUPPORTED_API_VERSIONS,
+      });
+      const candidateDraft = createFridayGeneratedSkillCandidateDraft({
+        manifest: promotedManifest,
+        draft,
+        convertedAt: deps.nowIso(),
+      });
+      const candidate = await candidateStore.stage({
+        source: createFridayGeneratedSkillCandidateSource({ session, draft }),
+        converterId: FRIDAY_SKILL_GENERATOR_CANDIDATE_CONVERTER_ID,
+        detectedFormat: "friday-package",
+        draft: candidateDraft,
+        validation: {
+          ok: true,
+          issues: [],
+        },
+        canonicalApprovalTicket,
+      });
+      const savedFiles = candidateDraft.files.map((file) => file.path);
 
       // Update session status
       const approvedSession: FridaySkillGenerationSession = {
@@ -2199,13 +2172,6 @@ export function createFridaySkillGeneratorService(
       const syncedApproved = await syncSkillHarness(approvedSession);
       persistSession(syncedApproved.session);
 
-      // Update lifecycle status to "installed"
-      await deps.memoryStateService.updateSkillStatus(
-        skillId,
-        "installed",
-      );
-
-      // Save final status
       const savedSession: FridaySkillGenerationSession = {
         ...syncedApproved.session,
         status: "saved",
@@ -2214,51 +2180,24 @@ export function createFridaySkillGeneratorService(
       const syncedSaved = await syncSkillHarness(savedSession);
       persistSession(syncedSaved.session);
 
-      // Refresh the skill registry
-      let registryRefreshed = false;
-      try {
-        await deps.registry.refresh();
-        registryRefreshed = true;
-      } catch (err) {
-      console.warn("[friday][skill-generator-service] operation failed:", err instanceof Error ? err.message : String(err));
-        // Non-fatal — skill is saved but registry didn't refresh
-      }
-
-      deps.db.withWriteTransaction((conn) => {
-        skillRepo.upsertSkillFromCatalog(conn, {
-          id: skillId,
-          name: promotedManifest.name,
-          source: "local",
-          origin: "managed",
-          latestVersion: promotedManifest.version,
-          status: "installed",
-          currentManifest: promotedManifest,
-          nowIso: deps.nowIso(),
-        });
-        skillRepo.setInstalledVersion(
-          conn,
-          skillId,
-          promotedManifest.version,
-          promotedManifest,
-          deps.nowIso(),
-        );
-      });
-
       // Clean up persisted draft
       deleteDraft(sessionId);
 
       return {
         sessionId,
         skillId,
-        skillDir: finalSkillDir,
+        skillDir: candidate.filesDir,
+        candidateId: candidate.candidateId,
+        candidateDir: candidate.candidateDir,
         savedFiles,
-        registryRefreshed,
-        promotionStage: "stabilized",
+        registryRefreshed: false,
+        promotionStage: "candidate_staged",
         promotedManifestTags: promotedManifest.tags,
         evidence: {
           packageLoaded: true,
           packageValidated: true,
-          registryRefreshed,
+          registryRefreshed: false,
+          candidateStaged: true,
         },
         harness: syncedSaved.harnessSummary,
         qaVerdict: syncedReview.qaVerdict,

--- a/src/skills/generator/services/friday-skill-generator-service.types.ts
+++ b/src/skills/generator/services/friday-skill-generator-service.types.ts
@@ -3,6 +3,7 @@ import type { FridayProviderService } from "#providers";
 import type { FridaySkillRegistry } from "#skills";
 import type { FridayHubConfigManagerService, FridayHubMemoryStateService } from "#hub";
 import type { FridayHarnessQaVerdictV1, FridayTemplateHarnessSummary } from "#harness";
+import type { FridayMutatingActionTicket } from "../../../security/friday-mutating-action-gate.js";
 
 import type {
   FridayGeneratedSkillDraft,
@@ -46,18 +47,23 @@ export interface FridaySkillGeneratorService {
 
   getHarnessSummary(sessionId: string): Promise<FridayTemplateHarnessSummary | null>;
 
-  approveAndSave(sessionId: string): Promise<{
+  approveAndSave(sessionId: string, input?: {
+    canonicalApprovalTicket?: FridayMutatingActionTicket;
+  }): Promise<{
     sessionId: string;
     skillId: string;
     skillDir: string;
+    candidateId: string;
+    candidateDir: string;
     savedFiles: string[];
     registryRefreshed: boolean;
-    promotionStage: "stabilized";
+    promotionStage: "candidate_staged";
     promotedManifestTags: string[];
     evidence: {
       packageLoaded: boolean;
       packageValidated: boolean;
       registryRefreshed: boolean;
+      candidateStaged: boolean;
     };
     harness?: FridayTemplateHarnessSummary | null;
     qaVerdict?: FridayHarnessQaVerdictV1 | null;

--- a/test/contracts/api/friday-api-route-contract.snapshot.test.ts
+++ b/test/contracts/api/friday-api-route-contract.snapshot.test.ts
@@ -141,9 +141,11 @@ const stubSkillGenerator: FridaySkillGeneratorService = {
     sessionId: "stub",
     skillId: "stub",
     skillDir: "stub",
+    candidateId: "stub-candidate",
+    candidateDir: "stub-candidate-dir",
     savedFiles: [],
     registryRefreshed: false,
-    promotionStage: "stabilized" as const,
+    promotionStage: "candidate_staged" as const,
     promotedManifestTags: [],
     evidence: {
       sessionId: "stub",

--- a/test/unit/agent/tools/friday-agent-generator-tools.test.ts
+++ b/test/unit/agent/tools/friday-agent-generator-tools.test.ts
@@ -79,20 +79,9 @@ function createMockSkillGeneratorService(): FridaySkillGeneratorService {
     recordExplicitTestResult: vi.fn(),
     getQaVerdict: vi.fn(),
     getHarnessSummary: vi.fn(),
-    approveAndSave: vi.fn().mockResolvedValue({
-      sessionId: "skill-session-1",
-      skillId: "generated-skill",
-      skillDir: "/tmp/generated-skill",
-      savedFiles: ["skill.manifest.json", "index.mjs"],
-      registryRefreshed: true,
-      promotionStage: "stabilized",
-      promotedManifestTags: ["generated"],
-      evidence: {
-        packageLoaded: true,
-        packageValidated: true,
-        registryRefreshed: true,
-      },
-    }),
+    approveAndSave: vi.fn().mockRejectedValue(
+      new Error("Generated skill approval now stages a lifecycle candidate and requires canonical approval."),
+    ),
     cancelSession: vi.fn(),
   } as unknown as FridaySkillGeneratorService;
 }
@@ -153,7 +142,7 @@ describe("generator tools", () => {
     );
   });
 
-  it("returns required input hints after skill approval", async () => {
+  it("fails closed when skill approval requires canonical candidate staging approval", async () => {
     const generatorService = createMockSkillGeneratorService();
     const tool = createFridayAgentSkillGeneratorTool({ generatorService });
 
@@ -162,15 +151,9 @@ describe("generator tools", () => {
       sessionId: "skill-session-1",
     });
 
-    const parsed = JSON.parse(result.content) as Record<string, unknown>;
-    expect(parsed.requiredInputs).toEqual([
-      { key: "topic", type: "string", label: "Topic" },
-    ]);
-    expect(parsed.exampleRunInput).toEqual({ topic: "<topic>" });
-    expect(parsed.nextRecommendedAction).toEqual({
-      tool: "skill_run",
-      skillId: "generated-skill",
-      input: { topic: "<topic>" },
-    });
+    expect(generatorService.approveAndSave).toHaveBeenCalledWith("skill-session-1");
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("skill_generate approve failed");
+    expect(result.content).toContain("requires canonical approval");
   });
 });

--- a/test/unit/api/http/routes/friday-skill-generator-routes.test.ts
+++ b/test/unit/api/http/routes/friday-skill-generator-routes.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect, vi } from "vitest";
 import { createFridaySkillGeneratorRoutes } from "#api";
-import type { FridaySkillGeneratorService } from "#skills/generator";
+import {
+  createFridaySkillGeneratorStageMutatingActionRequest,
+  type FridaySkillGeneratorService,
+} from "#skills/generator";
+import {
+  createFridayMutatingActionDigest,
+  createFridayMutatingActionGate,
+} from "../../../../../src/security/friday-mutating-action-gate.js";
 import {
   FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS_ENV,
   FRIDAY_SKILL_PYTHON_BIN_ENV,
@@ -12,6 +19,14 @@ import type { SkillManifestV2 } from "#skills";
 import type { FridaySkillGenerationTurnResponse } from "#skills/generator";
 
 const NOW = "2026-02-17T10:00:00.000Z";
+const PRINCIPAL = {
+  principalType: "user" as const,
+  principalId: "user-1",
+  scopes: ["skill.write" as const],
+  tokenId: "token-1",
+  tokenKind: "access" as const,
+  issuedAt: NOW,
+};
 
 function makeCtx(
   overrides: Partial<FridayHttpContext<unknown, unknown, unknown>> = {},
@@ -164,10 +179,12 @@ function makeMockGeneratorService(): FridaySkillGeneratorService {
     approveAndSave: vi.fn(async () => ({
       sessionId: "sess-1",
       skillId: "test-skill",
-      skillDir: "/tmp/test/skills/test-skill",
+      skillDir: "/tmp/test/skill-candidates/test-skill/files",
+      candidateId: "test-skill-1.0.0-candidate",
+      candidateDir: "/tmp/test/skill-candidates/test-skill",
       savedFiles: ["skill.manifest.json", "index.mjs"],
-      registryRefreshed: true,
-      promotionStage: "stabilized" as const,
+      registryRefreshed: false,
+      promotionStage: "candidate_staged" as const,
       promotedManifestTags: ["starter.cli", "skill.stabilized"],
       evidence: {
         sessionId: "sess-1",
@@ -192,9 +209,11 @@ function makeMockGeneratorService(): FridaySkillGeneratorService {
           ready: true,
           reason: "Draft is ready",
         },
-        savedSkillIdentity: {
+        stagedCandidateIdentity: {
           skillId: "test-skill",
-          skillDir: "/tmp/test/skills/test-skill",
+          candidateId: "test-skill-1.0.0-candidate",
+          candidateDir: "/tmp/test/skill-candidates/test-skill",
+          filesDir: "/tmp/test/skill-candidates/test-skill/files",
         },
       },
     })),
@@ -229,11 +248,50 @@ describe("FridaySkillGeneratorRoutes", () => {
   function createRoutes() {
     const generatorService = makeMockGeneratorService();
     const registry = makeMockRegistry();
+    const canonicalMutationGate = createFridayMutatingActionGate({
+      nowIso: () => NOW,
+      ticketIdGenerator: () => "ticket-1",
+    });
     const routes = createFridaySkillGeneratorRoutes({
       skillGenerator: generatorService,
       registry,
+      canonicalMutationGate,
     });
     return { routes, generatorService, registry };
+  }
+
+  function withCanonicalApproval(body: {
+    idempotencyKey?: string;
+    planDigest?: string;
+  } = {}) {
+    const session = makeMockSession().session;
+    const draft = makeMockDraft();
+    const request = createFridaySkillGeneratorStageMutatingActionRequest({
+      session: {
+        ...session,
+        draftSkillId: "test-skill",
+        status: "ready_for_review",
+      },
+      draft,
+      actor: {
+        kind: PRINCIPAL.principalType,
+        id: PRINCIPAL.principalId,
+        principalId: PRINCIPAL.principalId,
+      },
+      surface: "api:/v1/skills/generator/sessions/:sessionId/approve",
+      idempotencyKey: body.idempotencyKey,
+      planDigest: body.planDigest,
+    });
+    return {
+      ...body,
+      canonicalApproval: {
+        decision: "approved" as const,
+        approvalId: "approval-1",
+        decidedByPrincipalId: PRINCIPAL.principalId,
+        actionDigest: createFridayMutatingActionDigest(request),
+        expiresAt: "2026-02-17T11:00:00.000Z",
+      },
+    };
   }
 
   it("creates 7 route definitions", () => {
@@ -432,19 +490,47 @@ describe("FridaySkillGeneratorRoutes", () => {
   });
 
   describe("POST /v1/skills/generator/sessions/:sessionId/approve", () => {
-    it("calls approveAndSave", async () => {
+    it("requires canonical approval before staging the generated skill candidate", async () => {
+      const { routes, generatorService } = createRoutes();
+      const route = routes.find(
+        (r) => r.operationId === "skills.generator.sessions.approve",
+      )!;
+
+      await expect(
+        route.handler(
+          makeCtx({
+            params: { sessionId: "sess-1" },
+            principal: PRINCIPAL,
+          }),
+        ),
+      ).rejects.toThrow("requires canonical approval");
+      expect(generatorService.approveAndSave).not.toHaveBeenCalled();
+    });
+
+    it("calls approveAndSave with a canonical candidate staging ticket", async () => {
       const { routes, generatorService } = createRoutes();
       const route = routes.find(
         (r) => r.operationId === "skills.generator.sessions.approve",
       )!;
 
       const result = await route.handler(
-        makeCtx({ params: { sessionId: "sess-1" } }),
-      ) as { skillId: string };
+        makeCtx({
+          params: { sessionId: "sess-1" },
+          principal: PRINCIPAL,
+          body: withCanonicalApproval({ idempotencyKey: "approve-1" }),
+        }),
+      ) as { skillId: string; candidateId: string };
 
-      expect(generatorService.approveAndSave).toHaveBeenCalledWith("sess-1");
+      expect(generatorService.approveAndSave).toHaveBeenCalledWith("sess-1", {
+        canonicalApprovalTicket: expect.objectContaining({
+          action: "skills.import.stage_candidate",
+          approvalId: "approval-1",
+          ticketId: "ticket-1",
+        }),
+      });
       expect(result.skillId).toBe("test-skill");
-      expect(result.promotionStage).toBe("stabilized");
+      expect(result.candidateId).toBe("test-skill-1.0.0-candidate");
+      expect(result.promotionStage).toBe("candidate_staged");
     });
   });
 

--- a/test/unit/reflex/friday-reflex-service.test.ts
+++ b/test/unit/reflex/friday-reflex-service.test.ts
@@ -406,6 +406,44 @@ describe("Friday Reflex service", () => {
     expect(approveAndSave).not.toHaveBeenCalled();
   });
 
+  it("fails closed when approving a skill candidate without canonical staging approval", async () => {
+    const approveAndSave = vi.fn(async () => {
+      throw new Error("Generated skill approval now stages a lifecycle candidate and requires canonical approval.");
+    });
+    const service = createService({
+      skillGenerator: {
+        startSession: vi.fn(),
+        submitTurn: vi.fn(),
+        getSession: vi.fn(),
+        generateDraft: vi.fn(),
+        recordExplicitTestResult: vi.fn(),
+        getQaVerdict: vi.fn(),
+        getHarnessSummary: vi.fn(),
+        approveAndSave,
+        cancelSession: vi.fn(),
+      } as never,
+    });
+    const candidate = service.createCandidate({
+      userId: "user-1",
+      kind: "skill",
+      origin: "post_run",
+      title: "Generated skill candidate",
+      summary: "A generated skill waiting for review.",
+      payload: { skillId: "generated-skill" },
+      evidence: { generatorSessionId: "skill-session-1" },
+      confidence: 0.8,
+      riskTier: 2,
+    });
+
+    const approved = await service.approveCandidate({ userId: "user-1", candidateId: candidate.id });
+
+    expect(approveAndSave).toHaveBeenCalledWith("skill-session-1");
+    expect(approved.status).toBe("failed");
+    expect(approved.evidence.error).toContain("requires canonical approval");
+    expect(approved.evidence.savedSkillId).toBeUndefined();
+    expect(approved.evidence.promotionStage).toBeUndefined();
+  });
+
   it("adds curator review metadata without approving generated candidates", async () => {
     const approveAndSave = vi.fn();
     const service = createService({

--- a/test/unit/skills/generator/services/friday-skill-generator-service.test.ts
+++ b/test/unit/skills/generator/services/friday-skill-generator-service.test.ts
@@ -1,6 +1,10 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { rmSync } from "node:fs";
 
-import { createFridaySkillGeneratorService } from "#skills/generator";
+import {
+  createFridaySkillGeneratorService,
+  createFridaySkillGeneratorStageMutatingActionRequest,
+} from "#skills/generator";
 import type { CreateFridaySkillGeneratorServiceDeps } from "#skills/generator";
 import type { FridayProviderService } from "#providers";
 import type { FridaySkillRegistry } from "#skills";
@@ -10,6 +14,10 @@ import type { FridaySqliteLayer } from "#state";
 import type { SkillManifestV2 } from "#skills";
 import type { FridaySkillUiSchemaV1 } from "#skills/generator";
 import type { FridayGeneratedSkillFile } from "#skills/generator";
+import {
+  createFridayMutatingActionDigest,
+  type FridayMutatingActionTicket,
+} from "../../../../../src/security/friday-mutating-action-gate.js";
 
 const NOW = "2026-02-17T10:00:00.000Z";
 
@@ -441,6 +449,10 @@ describe("FridaySkillGeneratorService", () => {
     service = createFridaySkillGeneratorService(deps);
   });
 
+  afterEach(() => {
+    rmSync("/tmp/test/skill-candidates", { recursive: true, force: true });
+  });
+
   function mockFetchForLlm(responses: unknown[]): void {
     let callIdx = 0;
     globalThis.fetch = vi.fn(async () => {
@@ -468,6 +480,43 @@ describe("FridaySkillGeneratorService", () => {
       messages?: Array<{ role?: string; content?: string }>;
     };
     return body.messages?.find((message) => message.role === "system")?.content ?? "";
+  }
+
+  async function makeCanonicalGeneratorCandidateTicket(sessionId: string): Promise<FridayMutatingActionTicket> {
+    const data = await service.getSession(sessionId);
+    if (!data?.draft) {
+      throw new Error(`Draft missing for ${sessionId}`);
+    }
+    const request = createFridaySkillGeneratorStageMutatingActionRequest({
+      session: data.session,
+      draft: data.draft,
+      actor: {
+        kind: "user",
+        id: data.session.userId,
+        principalId: data.session.userId,
+      },
+      surface: "unit:test",
+      idempotencyKey: `approve-${sessionId}`,
+    });
+    return {
+      ticketId: `ticket-${sessionId}`,
+      actionDigest: createFridayMutatingActionDigest(request),
+      action: request.action,
+      actor: request.actor,
+      surface: request.surface,
+      resource: request.resource,
+      risk: "high",
+      approvalId: `approval-${sessionId}`,
+      approvedByPrincipalId: data.session.userId,
+      issuedAt: NOW,
+      idempotencyKey: `approve-${sessionId}`,
+    };
+  }
+
+  async function approveWithCanonicalTicket(sessionId: string) {
+    return service.approveAndSave(sessionId, {
+      canonicalApprovalTicket: await makeCanonicalGeneratorCandidateTicket(sessionId),
+    });
   }
 
   describe("startSession", () => {
@@ -1285,7 +1334,7 @@ describe("FridaySkillGeneratorService", () => {
       }
     });
 
-    it("promotes generated drafts to stabilized manifests with evidence", async () => {
+    it("stages generated drafts as lifecycle candidates with evidence", async () => {
       const analyzerResponse = {
         state: "needs_clarification",
         questions: ["What?"],
@@ -1339,9 +1388,11 @@ describe("FridaySkillGeneratorService", () => {
             runStatus: "completed",
           },
         });
-        const result = await service.approveAndSave(startResult.session.sessionId);
+        const result = await approveWithCanonicalTicket(startResult.session.sessionId);
 
-        expect(result.promotionStage).toBe("stabilized");
+        expect(result.promotionStage).toBe("candidate_staged");
+        expect(result.candidateId).toContain("test-skill-1.0.0");
+        expect(result.registryRefreshed).toBe(false);
         expect(result.promotedManifestTags).toEqual(
           expect.arrayContaining(["generated", "skill.stabilized", "cli-backed"]),
         );
@@ -1349,8 +1400,14 @@ describe("FridaySkillGeneratorService", () => {
         expect(result.evidence).toEqual({
           packageLoaded: true,
           packageValidated: true,
-          registryRefreshed: true,
+          registryRefreshed: false,
+          candidateStaged: true,
         });
+        expect(deps.memoryStateService.updateSkillStatus).not.toHaveBeenCalledWith(
+          "test-skill",
+          "installed",
+        );
+        expect(deps.registry.refresh).not.toHaveBeenCalled();
       } finally {
         restoreFetch();
       }

--- a/test/unit/ui/skill-generator-page.test.ts
+++ b/test/unit/ui/skill-generator-page.test.ts
@@ -189,10 +189,12 @@ describe("skill generator page", () => {
     mocks.approveSession.mockResolvedValue({
       sessionId: "session-1",
       skillId: "incident-triage",
-      skillDir: "/tmp/incident-triage",
+      skillDir: "/tmp/skill-candidates/incident-triage/files",
+      candidateId: "incident-triage-1-0-0-candidate",
+      candidateDir: "/tmp/skill-candidates/incident-triage",
       savedFiles: ["skill.manifest.json", "index.ts"],
-      registryRefreshed: true,
-      promotionStage: "stabilized",
+      registryRefreshed: false,
+      promotionStage: "candidate_staged",
       promotedManifestTags: ["generated", "stabilized"],
       evidence: {
         sessionId: "session-1",
@@ -216,9 +218,11 @@ describe("skill generator page", () => {
           ready: true,
           reason: "ready",
         },
-        savedSkillIdentity: {
+        stagedCandidateIdentity: {
           skillId: "incident-triage",
-          skillDir: "/tmp/incident-triage",
+          candidateId: "incident-triage-1-0-0-candidate",
+          candidateDir: "/tmp/skill-candidates/incident-triage",
+          filesDir: "/tmp/skill-candidates/incident-triage/files",
         },
       },
     });
@@ -291,7 +295,7 @@ describe("skill generator page", () => {
     const receipt = getByTestId("skill-generator-approve-receipt");
     expect(receipt.textContent).toContain("Approve success receipt");
     expect(receipt.textContent).toContain("incident-triage");
-    expect(receipt.textContent).toContain("/tmp/incident-triage");
-    expect(receipt.textContent).toContain("stabilized");
+    expect(receipt.textContent).toContain("/tmp/skill-candidates/incident-triage/files");
+    expect(receipt.textContent).toContain("candidate_staged");
   });
 });


### PR DESCRIPTION
## Summary
- Route generated skill approval through canonical candidate staging instead of direct install/default availability.
- Require canonical approval on the HTTP approve route, pass the issued ticket into the generator service, and revalidate ticket action/resource/digest before staging.
- Return candidate metadata (`candidateId`, `candidateDir`, candidate files path) and keep registry refresh/install state false.
- Preserve Option 1 for non-HTTP entrypoints: agent/reflex direct approve paths fail closed without a canonical staging ticket, with focused tests.

## Scope
- F-019 generator-to-candidate-store bridge only.
- No F-017 lifecycle wiring changes.
- No F-020, F-008, RGG, cloud, workflow, or branch-protection changes.

## Verification
- `npx tsc --noEmit` PASS.
- Focused vitest: 4 files / 72 tests PASS.
- Related regression vitest: 5 files / 59 tests PASS.
- Touched-file ESLint: 0 errors, warnings only.
- `npx eslint . --quiet` PASS.
- `git diff --check` PASS.
- `npm run check:secret-patterns` PASS.
- Reviewer A Round 2 PASS.
- Reviewer B Round 2 PASS.

## Honest Evidence Framing
- This PR is not release proof.
- No RGG/same-SHA proof is claimed.
- Green CI, if achieved, is plumbing-tier unless the RGG artifact itself reports real scenarios passed.
- `blocked_by_env` is never pass and never release proof.

## Merge
- Draft PR only.
- Do not auto-merge.
- Do not use owner/admin bypass unless the active Friday governance rules are satisfied separately before merge.