### PR TITLE
refactor(api): extract base route installer

### DIFF
--- a/src/api/runtime/friday-api-runtime-base-routes.ts
+++ b/src/api/runtime/friday-api-runtime-base-routes.ts
@@ -1,0 +1,97 @@
+import type { FridayFleetDashboardService } from "../fleet/friday-fleet-dashboard-service.types.js";
+import type { FridayHttpRouteRegistry } from "../http/friday-http-route-registry.js";
+import { createFridayHealthRoutes } from "../http/routes/friday-health-routes.js";
+import { createFridayTuiRoutes } from "../http/routes/friday-tui-routes.js";
+import type { CreateFridayApiRuntimeDeps } from "./friday-api-runtime.types.js";
+
+type FridayApiRuntimeBaseRouteDeps = Pick<
+  CreateFridayApiRuntimeDeps,
+  | "channelWebhooks"
+  | "db"
+  | "enabledChannelKinds"
+  | "mcpServer"
+  | "packaging"
+  | "pluginRuntimeMode"
+  | "searchHealth"
+  | "supportedChannelKinds"
+  | "systemHealth"
+  | "capabilitySnapshotGetter"
+>;
+
+export interface InstallFridayApiRuntimeBaseRoutesInput {
+  routes: FridayHttpRouteRegistry;
+  deps: FridayApiRuntimeBaseRouteDeps;
+  fleet: FridayFleetDashboardService;
+  serverVersion: string;
+}
+
+export function installFridayApiRuntimeBaseRoutes(input: InstallFridayApiRuntimeBaseRoutesInput): void {
+  const { deps, fleet, routes, serverVersion } = input;
+
+  // Health routes must stay first: liveness endpoints are public and used by probes.
+  for (const route of createFridayHealthRoutes({
+    version: serverVersion,
+    getCapabilities: async () => {
+      const searchHealth = typeof deps.searchHealth === "function"
+        ? await Promise.resolve(deps.searchHealth())
+        : deps.searchHealth;
+      const systemHealth = typeof deps.systemHealth === "function"
+        ? await Promise.resolve(deps.systemHealth())
+        : deps.systemHealth;
+      const enabledChannelKinds = typeof deps.enabledChannelKinds === "function"
+        ? await Promise.resolve(deps.enabledChannelKinds())
+        : deps.enabledChannelKinds;
+
+      let runtimeSnapshot: Awaited<ReturnType<NonNullable<typeof deps.capabilitySnapshotGetter>>> | undefined;
+      if (deps.capabilitySnapshotGetter) {
+        try {
+          runtimeSnapshot = await Promise.resolve(deps.capabilitySnapshotGetter({ readOnly: false }));
+        } catch {
+          runtimeSnapshot = undefined;
+        }
+      }
+
+      return {
+        schemaVersion: "1.0" as const,
+        plugins: {
+          runtimeMode: deps.pluginRuntimeMode ?? "stub",
+        },
+        channels: {
+          supportedKinds: deps.supportedChannelKinds ?? [],
+          enabledKinds: enabledChannelKinds ?? [],
+          webhookEndpoints: {
+            line: deps.channelWebhooks?.lineWebhookRelay?.isListening() === true,
+            whatsapp: deps.channelWebhooks?.whatsappWebhookRelay?.isListening() === true,
+            lark: deps.channelWebhooks?.larkWebhookRelay?.isListening() === true,
+          },
+        },
+        mcp: {
+          enabled: deps.mcpServer !== undefined,
+        },
+        packaging: {
+          enabled: deps.packaging !== undefined,
+        },
+        search: searchHealth ?? {
+          provider: "duckduckgo_html",
+          latestness: "unverified" as const,
+        },
+        ...(runtimeSnapshot?.runtime ? { runtime: runtimeSnapshot.runtime } : {}),
+        system: systemHealth ?? {
+          enabled: false,
+          remoteMode: "unavailable" as const,
+          companionReadiness: "unavailable" as const,
+        },
+      };
+    },
+  })) {
+    routes.register(route);
+  }
+
+  for (const route of createFridayTuiRoutes({
+    db: deps.db,
+    version: serverVersion,
+    fleetService: fleet,
+  })) {
+    routes.register(route);
+  }
+}

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -137,8 +137,6 @@ import { createFridayImmediateRunPersistence } from "#engine";
 import type { FridayEngineRunResult } from "#engine";
 import type { CreateFridayEngineTurnPreparerDeps } from "#engine";
 import type { CreateFridayEngineRunExecutorDeps } from "#engine";
-import { createFridayHealthRoutes } from "../http/routes/friday-health-routes.js";
-import { createFridayTuiRoutes } from "../http/routes/friday-tui-routes.js";
 import { createFridayApiTokenRepository } from "../persistence/friday-api-token-repository.js";
 import { createFridayProviderProfileRepository } from "#providers";
 import { createFridaySkillRepository, type FridaySkillLifecycleDetail } from "#skills";
@@ -171,6 +169,7 @@ import type {
   FridayRunTimelineEntry,
 } from "../model/friday-api-workflow.types.js";
 import { createFridayDeepLinkApplyService } from "./friday-deep-link-apply-service.js";
+import { installFridayApiRuntimeBaseRoutes } from "./friday-api-runtime-base-routes.js";
 
 const DEFAULT_ACCESS_TTL = 3600; // 1 hour
 const DEFAULT_REFRESH_TTL = 604_800; // 7 days
@@ -1060,72 +1059,12 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
     nowIso: deps.nowIso,
   });
 
-  // Register health routes FIRST (public, no auth)
-  for (const route of createFridayHealthRoutes({
-    version: serverVersion,
-    getCapabilities: async () => {
-      const searchHealth = typeof deps.searchHealth === "function"
-        ? await Promise.resolve(deps.searchHealth())
-        : deps.searchHealth;
-      const systemHealth = typeof deps.systemHealth === "function"
-        ? await Promise.resolve(deps.systemHealth())
-        : deps.systemHealth;
-      const enabledChannelKinds = typeof deps.enabledChannelKinds === "function"
-        ? await Promise.resolve(deps.enabledChannelKinds())
-        : deps.enabledChannelKinds;
-
-      let runtimeSnapshot: Awaited<ReturnType<NonNullable<typeof deps.capabilitySnapshotGetter>>> | undefined;
-      if (deps.capabilitySnapshotGetter) {
-        try {
-          runtimeSnapshot = await Promise.resolve(deps.capabilitySnapshotGetter({ readOnly: false }));
-        } catch {
-          runtimeSnapshot = undefined;
-        }
-      }
-
-      return {
-        schemaVersion: "1.0" as const,
-        plugins: {
-          runtimeMode: deps.pluginRuntimeMode ?? "stub",
-        },
-        channels: {
-          supportedKinds: deps.supportedChannelKinds ?? [],
-          enabledKinds: enabledChannelKinds ?? [],
-          webhookEndpoints: {
-            line: deps.channelWebhooks?.lineWebhookRelay?.isListening() === true,
-            whatsapp: deps.channelWebhooks?.whatsappWebhookRelay?.isListening() === true,
-            lark: deps.channelWebhooks?.larkWebhookRelay?.isListening() === true,
-          },
-        },
-        mcp: {
-          enabled: deps.mcpServer !== undefined,
-        },
-        packaging: {
-          enabled: deps.packaging !== undefined,
-        },
-        search: searchHealth ?? {
-          provider: "duckduckgo_html",
-          latestness: "unverified" as const,
-        },
-        ...(runtimeSnapshot?.runtime ? { runtime: runtimeSnapshot.runtime } : {}),
-        system: systemHealth ?? {
-          enabled: false,
-          remoteMode: "unavailable" as const,
-          companionReadiness: "unavailable" as const,
-        },
-      };
-    },
-  })) {
-    routes.register(route);
-  }
-
-  for (const route of createFridayTuiRoutes({
-    db: deps.db,
-    version: serverVersion,
-    fleetService: fleet,
-  })) {
-    routes.register(route);
-  }
+  installFridayApiRuntimeBaseRoutes({
+    routes,
+    deps,
+    fleet,
+    serverVersion,
+  });
 
   for (const route of createFridayRuntimeAdminRoutes({
     version: {


### PR DESCRIPTION
## Summary
- Extract health/TUI base route registration from `createFridayApiRuntime` into `installFridayApiRuntimeBaseRoutes`
- Preserve health-first ordering before TUI and runtime-admin routes
- Keep route factories, auth, paths, handlers, and capability payload semantics unchanged

## Scope
- F-010 maintainability slice only
- Does not touch approval semantics, skill lifecycle behavior, providers, channels, workflows, RGG, branch protection, docs, or findings
- Does not claim full F-010 closure or release proof

## Verification
- `npx tsc --noEmit`
- `npx vitest run test/contracts/api/friday-api-route-contract.snapshot.test.ts --reporter=dot`
- `npm run check:architecture-boundaries`
- `npm run lint -- --quiet`
- `npx eslint src/api/runtime/friday-api-runtime-base-routes.ts --max-warnings=0`
- `npm run check:secret-patterns`
- explicit secret-pattern rg on touched files, including the new untracked file before staging
- `git diff --check`

## Reviewers
- Reviewer A: PASS, route ordering/path/logic preservation
- Reviewer B: PASS, no overclaim/no fake proof/no scope creep

## Proof framing
This PR is local maintainability evidence only. CI success and RGG workflow success, if present, are plumbing-tier unless the RGG artifact itself reports real passed scenarios. `blocked_by_env` is never pass and never release proof.

## Merge
Draft PR only. Do not auto-merge. Stage 7 must download/read RGG artifact and report status honestly before any user merge decision.