### PR TITLE
fix(observability): drain background audit writes on shutdown

### DIFF
--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -8467,7 +8467,9 @@ export async function createFridayHub(
       upSince = null;
 
       // P1-SHUT-001/002/003: Stop services started during bootstrap
-      try { observabilityService?.scheduler?.stop(); } catch (err) {
+      let observabilityStopError: unknown;
+      try { await observabilityService.shutdown(); } catch (err) {
+      observabilityStopError = err;
       warnHubBootstrapOperationFailureOnce(err); /* best-effort */ }
       try { agentLearningBridge?.stop(); } catch (err) {
       warnHubBootstrapOperationFailureOnce(err); /* best-effort */ }
@@ -8508,6 +8510,9 @@ export async function createFridayHub(
       // 7. State
       stateRuntime?.close();
       hubState = "stopped";
+      if (observabilityStopError) {
+        throw observabilityStopError;
+      }
     },
 
     status(): FridayHubStatus {

--- a/src/observability/services/friday-observability-api-service.ts
+++ b/src/observability/services/friday-observability-api-service.ts
@@ -225,6 +225,8 @@ export interface FridayObservabilityApiService {
   readonly dashboard: FridayDashboardDataProvider;
   readonly scheduler: FridayAlertEvaluationScheduler;
   observeAsync<T>(input: FridayObservedOperationInput, work: () => Promise<T>): Promise<T>;
+  drainAuditWrites(): Promise<void>;
+  shutdown(): Promise<void>;
   recordSelfHealingProcessResults(input: {
     results: Array<{
       incidentsCreated: Array<{
@@ -762,6 +764,8 @@ export function createFridayObservabilityApiService(
   const dispatchHistoryByKey = new Map<string, AlertDispatchAttemptRecord>();
   const resolvedAlertIds = new Set<string>();
   const observedAgentLoopRunIds = new Set<string>();
+  const pendingAuditWrites = new Set<Promise<void>>();
+  const backgroundAuditFailures: unknown[] = [];
 
   for (const metric of COUNTER_METRICS) {
     metrics.registerCounter(metric.name, metric.module);
@@ -1244,6 +1248,32 @@ export function createFridayObservabilityApiService(
         "OBS_AUDIT_APPEND_FAILED",
         "Observability audit append failed; refusing to complete audited operation",
         { httpStatus: 503, cause: error },
+      );
+    }
+  }
+
+  function enqueueBackgroundAudit(input: Parameters<typeof appendAudit>[0]): void {
+    const pending = appendAudit(input)
+      .then(() => undefined)
+      .catch((error: unknown) => {
+        backgroundAuditFailures.push(error);
+      })
+      .finally(() => {
+        pendingAuditWrites.delete(pending);
+      });
+    pendingAuditWrites.add(pending);
+  }
+
+  async function drainAuditWrites(): Promise<void> {
+    while (pendingAuditWrites.size > 0) {
+      await Promise.allSettled([...pendingAuditWrites]);
+    }
+    if (backgroundAuditFailures.length > 0) {
+      const [firstFailure] = backgroundAuditFailures.splice(0, backgroundAuditFailures.length);
+      throw new FridayDomainError(
+        "OBS_AUDIT_BACKGROUND_APPEND_FAILED",
+        "Observability background audit append failed; lifecycle drain refused to hide the failure",
+        { httpStatus: 503, cause: firstFailure },
       );
     }
   }
@@ -2267,6 +2297,11 @@ export function createFridayObservabilityApiService(
     health,
     dashboard,
     scheduler,
+    drainAuditWrites,
+    async shutdown() {
+      scheduler.stop();
+      await drainAuditWrites();
+    },
     async observeAsync<T>(input: FridayObservedOperationInput, work: () => Promise<T>): Promise<T> {
       const startedAt = Date.now();
       const correlation = startTrace(input.module, input.operationName, {
@@ -2345,7 +2380,7 @@ export function createFridayObservabilityApiService(
             correlationId: input.correlationId ?? incident.incidentId,
           });
           endTrace(correlation, "error", incident.signature);
-          void appendAudit({
+          enqueueBackgroundAudit({
             actor: { type: "system", id: "self-healing", displayName: "Friday Self-Healing" },
             actionCategory: "create",
             action: "learning.incident.opened",
@@ -2363,8 +2398,6 @@ export function createFridayObservabilityApiService(
               userId: incident.userId,
             },
             errorMessage: incident.signature,
-          }).catch((error: unknown) => {
-            console.warn("[friday] observability audit append failed", error);
           });
         }
 
@@ -2376,7 +2409,7 @@ export function createFridayObservabilityApiService(
             confidence: diagnosis.confidence,
           });
           endTrace(correlation, "ok");
-          void appendAudit({
+          enqueueBackgroundAudit({
             actor: { type: "system", id: "self-healing", displayName: "Friday Self-Healing" },
             actionCategory: "create",
             action: "learning.diagnosis.recorded",
@@ -2392,8 +2425,6 @@ export function createFridayObservabilityApiService(
               confidence: diagnosis.confidence,
               errorFingerprint: diagnosis.errorFingerprint,
             },
-          }).catch((error: unknown) => {
-            console.warn("[friday] observability audit append failed", error);
           });
         }
       }

--- a/test/unit/observability/services/friday-observability-api-service.test.ts
+++ b/test/unit/observability/services/friday-observability-api-service.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import http from "node:http";
 import net from "node:net";
 
@@ -76,7 +76,7 @@ describe("createFridayObservabilityApiService", () => {
     expect(series.series.points.some((point) => point.value > 0)).toBe(true);
   });
 
-  it("raises a built-in alert for repeated self-healing failures", () => {
+  it("raises a built-in alert for repeated self-healing failures", async () => {
     const service = createService();
 
     service.recordSelfHealingProcessResults({
@@ -116,28 +116,114 @@ describe("createFridayObservabilityApiService", () => {
       ],
       correlationId: "corr-1",
     });
+    await service.drainAuditWrites();
 
     const alerts = service.routes.alerts.list({});
     expect(alerts.items.length).toBeGreaterThanOrEqual(1);
     expect(alerts.items[0]?.ruleId).toBe("builtin-self-healing-repeat-failures");
   });
 
+  it("drains self-healing background audit writes deterministically", async () => {
+    const service = createService();
+
+    service.recordSelfHealingProcessResults({
+      results: [
+        {
+          incidentsCreated: [
+            {
+              incidentId: "incident-drain",
+              userId: "user-1",
+              category: "workflow",
+              severity: "high",
+              signature: "drain-failure",
+              status: "open",
+              createdAt: NOW,
+            },
+          ],
+          diagnosisCreated: [
+            {
+              id: "diagnosis-drain",
+              incidentId: "incident-drain",
+              confidence: 0.92,
+              errorFingerprint: "fingerprint-drain",
+              createdAt: NOW,
+            },
+          ],
+        },
+      ],
+    });
+
+    await service.drainAuditWrites();
+
+    const audit = service.routes.audit.search({ module: "learning" });
+    expect(audit.items.map((entry) => entry.action).sort()).toEqual([
+      "learning.diagnosis.recorded",
+      "learning.incident.opened",
+    ]);
+  });
+
+  it("surfaces background audit write failures during lifecycle drain", async () => {
+    const service = createService();
+    allocatedDbs.pop()?.close();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    try {
+      service.recordSelfHealingProcessResults({
+        results: [
+          {
+            incidentsCreated: [
+              {
+                incidentId: "incident-after-close",
+                userId: "user-1",
+                category: "workflow",
+                severity: "high",
+                signature: "late-write",
+                status: "open",
+                createdAt: NOW,
+              },
+            ],
+            diagnosisCreated: [],
+          },
+        ],
+      });
+
+      await expect(service.drainAuditWrites()).rejects.toMatchObject({
+        code: "OBS_AUDIT_BACKGROUND_APPEND_FAILED",
+      });
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[friday] observability audit append failed",
+        expect.anything(),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it("fails audited rule mutations when audit persistence is unavailable", async () => {
     const service = createService();
     allocatedDbs.pop()?.close();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
 
-    await expect(
-      service.routes.alertRules.create({
-        name: "Audit must persist",
-        description: "Exercise fail-closed audit behavior",
-        severity: "critical",
-        metric: "friday.learning.failures.total",
-        operator: ">",
-        threshold: 0,
-        evaluationIntervalSec: 60,
-        channelIds: [],
-      }),
-    ).rejects.toMatchObject({ code: "OBS_AUDIT_APPEND_FAILED" });
+    try {
+      await expect(
+        service.routes.alertRules.create({
+          name: "Audit must persist",
+          description: "Exercise fail-closed audit behavior",
+          severity: "critical",
+          metric: "friday.learning.failures.total",
+          operator: ">",
+          threshold: 0,
+          evaluationIntervalSec: 60,
+          channelIds: [],
+        }),
+      ).rejects.toMatchObject({ code: "OBS_AUDIT_APPEND_FAILED" });
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[friday] observability audit append failed",
+        expect.anything(),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it("records agent-loop events into traces, audit, and metrics", async () => {
@@ -453,6 +539,7 @@ describe("createFridayObservabilityApiService", () => {
           },
         ],
       });
+      await service.drainAuditWrites();
 
       const alert = service.routes.alerts.list({}).items[0];
       expect(alert).toBeDefined();
@@ -542,6 +629,7 @@ describe("createFridayObservabilityApiService", () => {
           },
         ],
       });
+      await service.drainAuditWrites();
 
       const alert = service.routes.alerts.list({}).items[0];
       expect(alert).toBeDefined();


### PR DESCRIPTION
## Goal
Close the F-011 local audit-trail lifecycle slice by making self-healing background audit writes drainable and surfacing late-write failures before SQLite shutdown.

## Current behavior
`recordSelfHealingProcessResults()` queued audit appends as fire-and-forget promises. If the DB closed before those promises settled, tests could emit DB-closed audit append warnings without a deterministic lifecycle drain point.

## Change
- Track self-healing background audit append promises in `FridayObservabilityApiService`.
- Add `drainAuditWrites()` and `shutdown()` to stop the scheduler and drain pending audit writes.
- Surface background audit failures as `OBS_AUDIT_BACKGROUND_APPEND_FAILED`; audited foreground mutations still fail closed with `OBS_AUDIT_APPEND_FAILED`.
- Wire hub `stop()` to call observability `shutdown()` before `stateRuntime.close()`, while still continuing cleanup and rethrowing the observability stop error after local cleanup.
- Add focused tests for deterministic drain and drain-time failure surfacing.

## Out of scope
- No F-014 external observability / OTEL / Grafana work.
- No release proof or RGG change.
- No provider, approval, branch protection, workflow, or cloud scope.
- Does not mark F-011 globally resolved by itself; ledger update is a later phase after merge.

## Verification
- `npx vitest run test/unit/observability/services/friday-observability-api-service.test.ts test/unit/hub/friday-hub-bootstrap.test.ts --reporter=verbose` -> PASS, 2 files / 26 tests.
- `npx vitest run test/unit/observability/engine/audit-trail.test.ts test/unit/observability/persistence/friday-observability-audit-repository.test.ts test/unit/observability/services/friday-observability-api-service.test.ts --reporter=dot` -> PASS, 3 files / 54 tests.
- `npx tsc --noEmit` -> PASS.
- `npm run lint -- --quiet` -> PASS.
- `npm run check:secret-patterns` -> PASS.
- `git diff --check` -> PASS.

## Reviewer trail
- Reviewer A: PASS. Confirmed background audit writes are tracked/drained, hub stop calls observability shutdown before state close, existing fail-closed audited mutation remains, and only target files changed.
- Reviewer B: PASS. Confirmed no F-014/cloud/release-proof scope, no secrets, no test weakening, no hidden audit failure, and no overclaim.

## Evidence framing
Proof tier: local unit/mock-contract verification only. This is not release proof. `blocked_by_env` remains never pass. Workflow success is plumbing-tier only until artifacts are downloaded/read in Stage 7.