### PR TITLE
docs(audit): defer external-env proof from local closure

### DIFF
--- a/docs/audit/NON_CLOUD_LOCAL_CLOSURE_GOAL_2026-05-11.md
+++ b/docs/audit/NON_CLOUD_LOCAL_CLOSURE_GOAL_2026-05-11.md
@@ -17,21 +17,34 @@ In scope:
 
 Out of scope for this goal:
 
+- F-008 live channel / Discord sandbox verification. The owner has not configured
+  sandbox channel credentials or recipient IDs for the current goal, so this remains
+  future external-env work and is not resolved by this local/code/ledger closure.
 - F-009 Fly app creation, cloud secrets, deployed URL, Cloud Live E2E, and cloud CORS/callback smoke.
 - F-014 OTEL/Grafana external metrics/traces/export verification.
+- RGG same-SHA release proof and the live-runtime/GitHub Actions secret setup it requires
+  (`FRIDAY_BASE_URL`, `FRIDAY_ACCESS_TOKEN`, `FRIDAY_LOCAL_PASSPHRASE`,
+  `FRIDAY_REAL_WORLD_MINT_LOCAL_ADMIN_TOKEN`). The owner has not configured these
+  runtime credentials for the current goal, so `blocked_by_env` RGG artifacts are an
+  expected out-of-scope result here, not an unresolved local/code blocker.
 - Any claim that `blocked_by_env` Real Green Gate output is a pass or release proof.
 - External launch readiness.
 - Full package distribution Phase 2 implementation or default-on package-distribution readiness. SQLite-backed package registry persistence, install/lifecycle persistence, trusted-key persistence, real signature verification through hub publish/verify, and package migration/backfill/rollback tests remain future implementation slices.
 
 ## Findings Boundary
 
+- F-008 remains `OPEN`: live channel / Discord sandbox delivery is still unverified
+  until sandbox credentials and recipient IDs are configured outside prompts/logs
+  and the channel E2E is run.
 - F-009 remains `PARTIAL`: external deployment behavior is still unknown until a real cloud deployment exists.
 - F-014 remains `OPEN`: external OTEL/Grafana export is still unverified.
-- Both findings are deferred for this non-cloud/local closure goal and must be reopened when external launch or external observability comes back into scope.
+- F-008, F-009, and F-014 are deferred for this non-cloud/local closure goal and
+  must be reopened when external channel, external launch, or external observability
+  work comes back into scope.
 - F-016 is narrowed to a packaging-honesty boundary for this goal. The current runtime may expose `/v1/packages*` only behind `FRIDAY_PACKAGING_ENABLED=true`, and that route family is still an in-memory preview with stub publish/verify behavior. This does not block the current local closure goal, but it blocks any future "package distribution ready", "default-on packaging", or "Phase 2 packaging implemented" claim.
 
 ## Proof Framing
 
-This goal can produce local/test/governance closure. It cannot produce cloud-live proof, external observability proof, or same-SHA release proof unless the required live runtime and secrets are separately configured and the relevant artifacts report `status: passed`.
+This goal can produce local/test/governance closure. It does not attempt cloud-live proof, external observability proof, or same-SHA RGG release proof. Same-SHA RGG proof remains available as a future release-gate activity only after the owner separately configures the required live runtime and GitHub Actions secrets and the relevant artifact reports `status: passed`.
 
 `blocked_by_env` is never `pass`.


### PR DESCRIPTION
## Goal

Clarify the current non-cloud/local closure boundary after the owner confirmed the live RGG runtime secrets are not configured and selected deferring F-008 from this current goal.

## Changes

- Mark F-008 live channel / Discord sandbox verification as out of the current non-cloud/local goal while keeping it `OPEN` and future external-env work.
- Mark RGG same-SHA release proof and its required live-runtime / GitHub Actions secret setup as out of the current goal.
- Preserve the hard rule that `blocked_by_env` is never pass or release proof.
- Preserve F-009 / F-014 / F-016 boundary wording.

## Out of scope

- No workflow changes.
- No RGG implementation changes.
- No GitHub Actions secrets or branch protection changes.
- No source or test changes.
- No claim that F-008, F-009, F-014, or same-SHA RGG proof is resolved.

## Verification

- `git diff --check` PASS.
- `npm run check:secret-patterns` PASS.
- Targeted secret-like scan on the touched doc returned no credential values.
- Reviewer A PASS: factual/scope/path correctness.
- Reviewer B PASS: no fake proof, no overclaim, F-008 explicitly handled.

## Evidence framing

Doc-only boundary update. Not release proof. Not same-SHA RGG proof. `blocked_by_env` remains not pass.
