### PR TITLE
Fix Windows skill generator route tests

### DIFF
--- a/src/skills/executor/friday-shell-executor.ts
+++ b/src/skills/executor/friday-shell-executor.ts
@@ -1,4 +1,5 @@
-import { spawn } from "node:child_process";
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { extname } from "node:path";
 import type {
   FridayShellExecutor,
   FridayShellRunOptions,
@@ -8,6 +9,7 @@ import type {
 const DEFAULT_TIMEOUT_MS = 30_000;
 const TERMINATION_GRACE_MS = 500;
 const DEFAULT_MAX_OUTPUT_BYTES = 1_048_576;
+const WINDOWS_SHELL_SCRIPT_EXTENSIONS = new Set([".bash", ".sh"]);
 const SAFE_PARENT_ENV_KEYS = [
   "PATH",
   "HOME",
@@ -37,6 +39,20 @@ function buildChildEnv(overrides?: Record<string, string>): NodeJS.ProcessEnv {
     }
   }
   return overrides ? { ...env, ...overrides } : env;
+}
+
+function resolveSpawnSpec(command: string, args: string[] = []): { command: string; args: string[] } {
+  if (
+    process.platform === "win32"
+    && WINDOWS_SHELL_SCRIPT_EXTENSIONS.has(extname(command).toLowerCase())
+  ) {
+    return {
+      command: "bash",
+      args: [command, ...args],
+    };
+  }
+
+  return { command, args };
 }
 
 function createBoundedOutputCollector(streamName: "stdout" | "stderr", maxBytes: number = DEFAULT_MAX_OUTPUT_BYTES) {
@@ -86,12 +102,27 @@ export function createFridayShellExecutor(): FridayShellExecutor {
         let settled = false;
         let terminationFallbackTimer: NodeJS.Timeout | null = null;
 
-        const child = spawn(options.command, options.args ?? [], {
-          cwd: options.cwd,
-          env: buildChildEnv(options.env),
-          stdio: ["pipe", "pipe", "pipe"],
-          detached: true,
-        });
+        const spawnSpec = resolveSpawnSpec(options.command, options.args ?? []);
+        let child: ChildProcessWithoutNullStreams;
+        try {
+          child = spawn(spawnSpec.command, spawnSpec.args, {
+            cwd: options.cwd,
+            env: buildChildEnv(options.env),
+            stdio: ["pipe", "pipe", "pipe"],
+            detached: true,
+          });
+        } catch (err) {
+          stderr.append(err instanceof Error ? err.message : String(err));
+          resolve({
+            exitCode: 1,
+            stdout: stdout.toString(),
+            stderr: stderr.toString(),
+            timedOut: false,
+            cancelled: false,
+            durationMs: Date.now() - startMs,
+          });
+          return;
+        }
 
         const killProcessGroup = () => {
           try {

--- a/test/unit/api/http/routes/friday-skill-generator-routes.test.ts
+++ b/test/unit/api/http/routes/friday-skill-generator-routes.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { createFridaySkillGeneratorRoutes } from "#api";
 import {
   createFridaySkillGeneratorStageMutatingActionRequest,
@@ -722,16 +724,11 @@ describe("FridaySkillGeneratorRoutes", () => {
 
     it("runs python draft self-tests through the configured interpreter", async () => {
       const fs = await import("node:fs/promises");
-      const tempDir = await fs.mkdtemp("/tmp/friday-generator-python-");
+      const tempDir = await fs.mkdtemp(join(tmpdir(), "friday-generator-python-"));
       const previousPythonBin = process.env[FRIDAY_SKILL_PYTHON_BIN_ENV];
 
       try {
-        await fs.writeFile(
-          `${tempDir}/python-shim`,
-          "#!/bin/sh\nprintf '{\"result\":\"OK-MARKER\"}'\n",
-          { mode: 0o755 },
-        );
-        process.env[FRIDAY_SKILL_PYTHON_BIN_ENV] = `${tempDir}/python-shim`;
+        process.env[FRIDAY_SKILL_PYTHON_BIN_ENV] = process.execPath;
 
         const generatorService = makeMockGeneratorService();
         generatorService.getSession = vi.fn(async (sessionId: string) => {
@@ -764,7 +761,7 @@ describe("FridaySkillGeneratorRoutes", () => {
                   path: "index.py",
                   language: "python" as const,
                   executable: false,
-                  content: "print('unused by shim')\n",
+                  content: "process.stdout.write('{\"result\":\"OK-MARKER\"}')\n",
                 },
               ],
             },


### PR DESCRIPTION
## Summary
- Fixes the current Nightly Heavy CI Windows `HTTP route tests` failure on main (`959cf5eb`).
- Runs `.sh`/`.bash` shell skill entrypoints through `bash` on Windows inside the shared shell executor, covering both generator draft self-tests and the main skill runtime executor.
- Replaces the hardcoded `/tmp` python test fixture with `os.tmpdir()` and a cross-platform configured-interpreter shim.

## Scope
- Touched files only:
  - `src/skills/executor/friday-shell-executor.ts`
  - `test/unit/api/http/routes/friday-skill-generator-routes.test.ts`
- No RGG workflow changes in this PR.
- No release-proof claim. No provider secret use. No test skip or assertion weakening.

## Verification
- `npx vitest run test/unit/skills/executor/friday-shell-executor.test.ts test/unit/api/http/routes/friday-skill-generator-routes.test.ts --reporter=verbose` — 38/38 passed.
- `npx tsc --noEmit` — passed.
- `npm run lint` — 0 errors; existing warnings only.
- `npm run check:secret-patterns` — no provider/API key shaped secrets found.
- `git diff --check` — clean.

## Reviewers
- Reviewer A: PASS. Confirmed the Windows `spawn EFTYPE` root cause and `/tmp` root cause; confirmed shared shell executor covers generator draft self-test and main skill executor.
- Reviewer B: PASS. Confirmed no fake proof, no secret leak, no test weakening, and no scope creep.

## Notes
- Final proof for the Windows runner requires CI on this PR. This PR is draft and is not approved for merge by this description.
