### PR TITLE
ci(rgg): self-host runtime when env is absent

### DIFF
--- a/.github/workflows/real-green-gate.yml
+++ b/.github/workflows/real-green-gate.yml
@@ -43,24 +43,44 @@ jobs:
       - name: Check branch conformance
         run: node scripts/ops/check-branch-conformance.mjs --branch "${{ github.ref_name }}" --report-root "$RUNNER_TEMP/real-green-gate/branch"
 
-      - name: Run real green gate
+      - name: Run real green gate against configured runtime
         if: env.FRIDAY_BASE_URL != '' || env.FRIDAY_ACCESS_TOKEN != '' || env.FRIDAY_LOCAL_PASSPHRASE != '' || env.FRIDAY_REAL_WORLD_MINT_LOCAL_ADMIN_TOKEN != ''
         run: npm run ops:real-green-gate -- --branch "${{ github.ref_name }}" --report-root "$RUNNER_TEMP/real-green-gate"
 
-      - name: Record skipped live gate
+      - name: Run real green gate against self-hosted runtime
         if: env.FRIDAY_BASE_URL == '' && env.FRIDAY_ACCESS_TOKEN == '' && env.FRIDAY_LOCAL_PASSPHRASE == '' && env.FRIDAY_REAL_WORLD_MINT_LOCAL_ADMIN_TOKEN == ''
         env:
           GITHUB_SHA: ${{ github.sha }}
           GITHUB_REF_NAME: ${{ github.ref_name }}
+          FRIDAY_ANTHROPIC_API_KEY: ${{ secrets.FRIDAY_ANTHROPIC_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          FRIDAY_DEEPSEEK_API_KEY: ${{ secrets.FRIDAY_DEEPSEEK_API_KEY }}
         run: |
           mkdir -p "$RUNNER_TEMP/real-green-gate"
-          printf '%s\n' 'Live real-world gate skipped: no Friday runtime credentials were configured in GitHub Actions secrets.' > "$RUNNER_TEMP/real-green-gate/skip.txt"
-          # P4-G1.1: also emit the structured release-proof artifact so the
-          # downstream release-time gate machine-reads status=blocked_by_env
-          # rather than inferring pass from a successful workflow status.
-          # Reuse the lib's pure builder so the schema stays single-source.
-          node -e "import('./scripts/ops/lib/real-green-gate-result.mjs').then((m) => process.stdout.write(JSON.stringify(m.buildBlockedByEnvResult({ commitSha: process.env.GITHUB_SHA || '', refName: process.env.GITHUB_REF_NAME || '', evaluatedAt: new Date().toISOString(), blockedReasons: ['env_var_missing:FRIDAY_BASE_URL_or_FRIDAY_ACCESS_TOKEN_or_FRIDAY_LOCAL_PASSPHRASE_or_FRIDAY_REAL_WORLD_MINT_LOCAL_ADMIN_TOKEN'] }), null, 2) + '\n'))" \
-            > "$RUNNER_TEMP/real-green-gate/real-green-gate-result.json"
+          if ! npm run build; then
+            node --input-type=module <<'NODE'
+          import fs from "node:fs";
+          import path from "node:path";
+          import { buildErroredResult, REAL_GREEN_GATE_RESULT_FILENAME } from "./scripts/ops/lib/real-green-gate-result.mjs";
+
+          const reportRoot = path.join(process.env.RUNNER_TEMP ?? ".", "real-green-gate");
+          fs.mkdirSync(reportRoot, { recursive: true });
+          fs.writeFileSync(
+            path.join(reportRoot, REAL_GREEN_GATE_RESULT_FILENAME),
+            `${JSON.stringify(buildErroredResult({
+              commitSha: process.env.GITHUB_SHA ?? "",
+              refName: process.env.GITHUB_REF_NAME ?? "",
+              evaluatedAt: new Date().toISOString(),
+              blockedReasons: ["self_hosted_runtime_build_failed"],
+            }), null, 2)}\n`,
+            "utf8",
+          );
+          NODE
+            exit 1
+          fi
+          node scripts/ops/run-real-green-gate-self-hosted.mjs --branch "${{ github.ref_name }}" --report-root "$RUNNER_TEMP/real-green-gate"
 
       - name: Upload real green gate artifact
         if: always()

--- a/.github/workflows/real-green-gate.yml
+++ b/.github/workflows/real-green-gate.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
       - name: Validate catalog
         run: npm run validate:real-world:catalog
 

--- a/scripts/ops/lib/real-green-gate-result.mjs
+++ b/scripts/ops/lib/real-green-gate-result.mjs
@@ -85,12 +85,18 @@ function deriveEvidenceKindsObserved(summary, status) {
   if (status !== REAL_GREEN_GATE_RESULT_STATUSES.PASSED) {
     return [];
   }
-  // When the gate passed end-to-end, the run-real-green-gate.mjs flow has
-  // exercised real-runtime + real-provider + real-browser tiers across the
-  // smoke / dailyCore / publicSurface suites. We only emit these tokens on
-  // status=passed; otherwise we emit an empty list so downstream readers
-  // cannot mistake partial coverage for full coverage.
-  return ["real-runtime", "real-provider", "real-browser"];
+  const counts = deriveScenarioCounts(summary);
+  const observed = [];
+  if (counts.scenariosRun > 0) {
+    observed.push("real-runtime");
+  }
+  if (SUITE_KEYS.some((key) => safeNumber(summary?.[key]?.providerAttemptCount) > 0)) {
+    observed.push("real-provider");
+  }
+  if (SUITE_KEYS.some((key) => safeNumber(summary?.[key]?.browserProbeAttemptCount) > 0)) {
+    observed.push("real-browser");
+  }
+  return observed;
 }
 
 function normalizeStringList(value) {
@@ -142,6 +148,25 @@ export function buildBlockedByEnvResult({ commitSha, refName, evaluatedAt, block
   return {
     schema_version: REAL_GREEN_GATE_RESULT_SCHEMA_VERSION,
     status: REAL_GREEN_GATE_RESULT_STATUSES.BLOCKED_BY_ENV,
+    commit_sha: typeof commitSha === "string" ? commitSha : "",
+    ref_name: typeof refName === "string" ? refName : "",
+    evaluated_at: typeof evaluatedAt === "string" ? evaluatedAt : "",
+    evidence_kinds_observed: [],
+    blocked_reasons: normalizeStringList(blockedReasons),
+    scenarios_run: 0,
+    scenarios_total: 0,
+    scenarios_passed: 0,
+  };
+}
+
+/**
+ * Build a result artifact for failures that happen before the normal gate
+ * runner can emit its own summary, such as self-hosted runtime boot failure.
+ */
+export function buildErroredResult({ commitSha, refName, evaluatedAt, blockedReasons }) {
+  return {
+    schema_version: REAL_GREEN_GATE_RESULT_SCHEMA_VERSION,
+    status: REAL_GREEN_GATE_RESULT_STATUSES.ERRORED,
     commit_sha: typeof commitSha === "string" ? commitSha : "",
     ref_name: typeof refName === "string" ? refName : "",
     evaluated_at: typeof evaluatedAt === "string" ? evaluatedAt : "",

--- a/scripts/ops/run-real-green-gate-self-hosted.mjs
+++ b/scripts/ops/run-real-green-gate-self-hosted.mjs
@@ -164,10 +164,11 @@ export async function completeSelfHostedSetup(baseUrl, localPassphrase) {
   }
 }
 
-function createRuntimeEnv(baseEnv, paths, port, localPassphrase, tokenSecret) {
+export function createRuntimeEnv(baseEnv, paths, port, localPassphrase, tokenSecret, workspaceRoot) {
   return {
     ...baseEnv,
     FRIDAY_STATE_DIR: paths.stateDir,
+    FRIDAY_WORKSPACE_ROOT: workspaceRoot,
     FRIDAY_TOKEN_SECRET: tokenSecret,
     FRIDAY_LOCAL_PASSPHRASE: localPassphrase,
     FRIDAY_PORT: String(port),
@@ -180,10 +181,11 @@ function createRuntimeEnv(baseEnv, paths, port, localPassphrase, tokenSecret) {
   };
 }
 
-function createGateEnv(baseEnv, paths, baseUrl, localPassphrase, tokenSecret) {
+export function createGateEnv(baseEnv, paths, baseUrl, localPassphrase, tokenSecret, workspaceRoot) {
   return {
     ...baseEnv,
     FRIDAY_STATE_DIR: paths.stateDir,
+    FRIDAY_WORKSPACE_ROOT: workspaceRoot,
     FRIDAY_TOKEN_SECRET: tokenSecret,
     FRIDAY_BASE_URL: baseUrl,
     FRIDAY_UI_BASE_URL: baseUrl,
@@ -280,7 +282,7 @@ export async function runSelfHostedRealGreenGate(options) {
   const baseUrl = `http://${DEFAULT_HOST}:${String(port)}`;
   const localPassphrase = randomHex(24);
   const tokenSecret = randomHex(32);
-  const runtimeEnv = createRuntimeEnv(process.env, paths, port, localPassphrase, tokenSecret);
+  const runtimeEnv = createRuntimeEnv(process.env, paths, port, localPassphrase, tokenSecret, repoRoot);
   const runtime = spawnLogged(process.execPath, [
     distCli,
     "start",
@@ -302,11 +304,12 @@ export async function runSelfHostedRealGreenGate(options) {
 
   try {
     appendLogLine(path.join(reportRoot, "self-hosted-runtime-meta.txt"), `baseUrl=${baseUrl}`);
+    appendLogLine(path.join(reportRoot, "self-hosted-runtime-meta.txt"), `workspaceRoot=${repoRoot}`);
     await waitForHealth(baseUrl, options.runtimeBootTimeoutMs ?? DEFAULT_RUNTIME_BOOT_TIMEOUT_MS);
     await bootstrapLocalPassphrase(baseUrl, localPassphrase);
     await completeSelfHostedSetup(baseUrl, localPassphrase);
 
-    const gateEnv = createGateEnv(process.env, paths, baseUrl, localPassphrase, tokenSecret);
+    const gateEnv = createGateEnv(process.env, paths, baseUrl, localPassphrase, tokenSecret, repoRoot);
     const gateArgs = [
       path.join(repoRoot, "scripts", "ops", "run-real-green-gate.mjs"),
       "--repo-root",

--- a/scripts/ops/run-real-green-gate-self-hosted.mjs
+++ b/scripts/ops/run-real-green-gate-self-hosted.mjs
@@ -1,0 +1,352 @@
+#!/usr/bin/env node
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { buildErroredResult, REAL_GREEN_GATE_RESULT_FILENAME } from "./lib/real-green-gate-result.mjs";
+
+const DEFAULT_HOST = "127.0.0.1";
+const DEFAULT_RUNTIME_BOOT_TIMEOUT_MS = 90_000;
+const DEFAULT_CHILD_STOP_GRACE_MS = 5_000;
+const SELF_HOSTED_SETUP_COMPLETED_STEPS = ["welcome", "security", "network", "skills"];
+const SELF_HOSTED_SETUP_SKIPPED_STEPS = ["communication", "provider", "channels"];
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DEFAULT_REPO_ROOT = path.resolve(__dirname, "..", "..");
+
+function parseArgs(argv) {
+  const options = {
+    repoRoot: DEFAULT_REPO_ROOT,
+    reportRoot: path.join(os.tmpdir(), "real-green-gate"),
+    runtimeBootTimeoutMs: DEFAULT_RUNTIME_BOOT_TIMEOUT_MS,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+    switch (arg) {
+      case "--repo-root":
+        options.repoRoot = path.resolve(next);
+        index += 1;
+        break;
+      case "--report-root":
+        options.reportRoot = path.resolve(next);
+        index += 1;
+        break;
+      case "--branch":
+        options.branch = next;
+        index += 1;
+        break;
+      case "--runtime-boot-timeout-ms":
+        options.runtimeBootTimeoutMs = Number.parseInt(next, 10) || DEFAULT_RUNTIME_BOOT_TIMEOUT_MS;
+        index += 1;
+        break;
+      default:
+        break;
+    }
+  }
+
+  return options;
+}
+
+function ensureDir(dirPath) {
+  fs.mkdirSync(dirPath, { recursive: true });
+}
+
+function writeJson(filePath, value) {
+  ensureDir(path.dirname(filePath));
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function appendLogLine(filePath, line) {
+  ensureDir(path.dirname(filePath));
+  fs.appendFileSync(filePath, `${line}\n`, "utf8");
+}
+
+function randomHex(bytes) {
+  return crypto.randomBytes(bytes).toString("hex");
+}
+
+async function findFreePort(host = DEFAULT_HOST) {
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.listen(0, host, () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close();
+        reject(new Error("Could not determine a free TCP port"));
+        return;
+      }
+      const port = address.port;
+      server.close(() => resolve(port));
+    });
+    server.on("error", reject);
+  });
+}
+
+async function sleep(ms) {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForHealth(baseUrl, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError = null;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`${baseUrl}/v1/health`);
+      if (response.ok) {
+        return await response.json().catch(() => ({}));
+      }
+      lastError = new Error(`HTTP ${String(response.status)}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await sleep(1_000);
+  }
+  const suffix = lastError instanceof Error ? `: ${lastError.message}` : "";
+  throw new Error(`Self-hosted Friday runtime did not become healthy${suffix}`);
+}
+
+async function bootstrapLocalPassphrase(baseUrl, localPassphrase) {
+  const statusResponse = await fetch(`${baseUrl}/v1/auth/bootstrap/status`);
+  const statusBody = await statusResponse.json().catch(() => ({}));
+  if (!statusResponse.ok || statusBody?.ok !== true) {
+    throw new Error(`Local auth bootstrap status failed with HTTP ${String(statusResponse.status)}`);
+  }
+  const bootstrapRequired = Boolean(statusBody?.data?.bootstrapRequired ?? statusBody?.bootstrapRequired);
+  if (!bootstrapRequired) {
+    return;
+  }
+  const bootstrapResponse = await fetch(`${baseUrl}/v1/auth/bootstrap/local-passphrase`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ localPassphrase }),
+  });
+  const bootstrapBody = await bootstrapResponse.json().catch(() => ({}));
+  if (!bootstrapResponse.ok || bootstrapBody?.ok !== true) {
+    throw new Error(`Local auth bootstrap failed with HTTP ${String(bootstrapResponse.status)}`);
+  }
+}
+
+async function loginLocalPassphrase(baseUrl, localPassphrase) {
+  const response = await fetch(`${baseUrl}/v1/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ localPassphrase }),
+  });
+  const body = await response.json().catch(() => ({}));
+  if (!response.ok || body?.ok !== true || typeof body?.data?.accessToken !== "string") {
+    throw new Error(`Self-hosted local login failed with HTTP ${String(response.status)}`);
+  }
+  return body.data.accessToken;
+}
+
+export async function completeSelfHostedSetup(baseUrl, localPassphrase) {
+  const accessToken = await loginLocalPassphrase(baseUrl, localPassphrase);
+  const response = await fetch(`${baseUrl}/v1/setup/complete`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      completedSteps: SELF_HOSTED_SETUP_COMPLETED_STEPS,
+      skippedSteps: SELF_HOSTED_SETUP_SKIPPED_STEPS,
+    }),
+  });
+  const body = await response.json().catch(() => ({}));
+  if (!response.ok || body?.ok !== true) {
+    throw new Error(`Self-hosted setup completion failed with HTTP ${String(response.status)}`);
+  }
+}
+
+function createRuntimeEnv(baseEnv, paths, port, localPassphrase, tokenSecret) {
+  return {
+    ...baseEnv,
+    FRIDAY_STATE_DIR: paths.stateDir,
+    FRIDAY_TOKEN_SECRET: tokenSecret,
+    FRIDAY_LOCAL_PASSPHRASE: localPassphrase,
+    FRIDAY_PORT: String(port),
+    FRIDAY_HOST: DEFAULT_HOST,
+    FRIDAY_AUTO_OPEN_UI: "false",
+    FRIDAY_BROWSER_HEADLESS: "true",
+    FRIDAY_LOG_REQUESTS: "false",
+    FRIDAY_CHANNELS_JSON: baseEnv.FRIDAY_CHANNELS_JSON ?? '{"enabled":true,"instances":[]}',
+    FRIDAY_SYSTEM_ENABLED: baseEnv.FRIDAY_SYSTEM_ENABLED ?? "true",
+  };
+}
+
+function createGateEnv(baseEnv, paths, baseUrl, localPassphrase, tokenSecret) {
+  return {
+    ...baseEnv,
+    FRIDAY_STATE_DIR: paths.stateDir,
+    FRIDAY_TOKEN_SECRET: tokenSecret,
+    FRIDAY_BASE_URL: baseUrl,
+    FRIDAY_UI_BASE_URL: baseUrl,
+    FRIDAY_LOCAL_PASSPHRASE: localPassphrase,
+    FRIDAY_CHANNELS_JSON: baseEnv.FRIDAY_CHANNELS_JSON ?? '{"enabled":true,"instances":[]}',
+    FRIDAY_BROWSER_HEADLESS: "true",
+  };
+}
+
+async function stopChild(child, graceMs = DEFAULT_CHILD_STOP_GRACE_MS) {
+  if (!child || child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+  await new Promise((resolve) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (child.exitCode === null && child.signalCode === null) {
+        child.kill("SIGKILL");
+      }
+      settle();
+    }, graceMs);
+    const settle = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      child.removeListener("close", settle);
+      child.removeListener("error", settle);
+      resolve();
+    };
+    child.once("close", settle);
+    child.once("error", settle);
+    child.kill("SIGTERM");
+  });
+}
+
+function spawnLogged(command, args, { cwd, env, logPath }) {
+  ensureDir(path.dirname(logPath));
+  const stream = fs.createWriteStream(logPath, { flags: "w" });
+  const child = spawn(command, args, {
+    cwd,
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.stdout.on("data", (chunk) => stream.write(chunk));
+  child.stderr.on("data", (chunk) => stream.write(chunk));
+  child.once("close", () => stream.end());
+  child.once("error", () => stream.end());
+  return child;
+}
+
+async function runLogged(command, args, { cwd, env, logPath }) {
+  const child = spawnLogged(command, args, { cwd, env, logPath });
+  return await new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", (code, signal) => {
+      resolve({ code: code ?? 1, signal });
+    });
+  });
+}
+
+function writeEarlyErrorArtifact(reportRoot, reason) {
+  writeJson(path.join(reportRoot, REAL_GREEN_GATE_RESULT_FILENAME), buildErroredResult({
+    commitSha: process.env.GITHUB_SHA ?? "",
+    refName: process.env.GITHUB_REF_NAME ?? "",
+    evaluatedAt: new Date().toISOString(),
+    blockedReasons: [reason],
+  }));
+}
+
+export async function runSelfHostedRealGreenGate(options) {
+  const repoRoot = path.resolve(options.repoRoot ?? DEFAULT_REPO_ROOT);
+  const reportRoot = path.resolve(options.reportRoot);
+  ensureDir(reportRoot);
+
+  const distCli = path.join(repoRoot, "dist", "cli", "friday-cli.js");
+  if (!fs.existsSync(distCli)) {
+    throw new Error("dist/cli/friday-cli.js is missing; build the runtime before self-hosting RGG.");
+  }
+
+  const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), "friday-rgg-runtime-"));
+  const paths = {
+    runtimeRoot,
+    stateDir: path.join(runtimeRoot, "state"),
+    managedSkillsDir: path.join(runtimeRoot, "managed-skills"),
+    runtimeLog: path.join(reportRoot, "self-hosted-runtime.log"),
+    gateLog: path.join(reportRoot, "self-hosted-gate.log"),
+  };
+  ensureDir(paths.stateDir);
+  ensureDir(paths.managedSkillsDir);
+
+  const port = await findFreePort();
+  const baseUrl = `http://${DEFAULT_HOST}:${String(port)}`;
+  const localPassphrase = randomHex(24);
+  const tokenSecret = randomHex(32);
+  const runtimeEnv = createRuntimeEnv(process.env, paths, port, localPassphrase, tokenSecret);
+  const runtime = spawnLogged(process.execPath, [
+    distCli,
+    "start",
+    "--host",
+    DEFAULT_HOST,
+    "--port",
+    String(port),
+    "--skills-dir",
+    path.join(repoRoot, "skills"),
+    "--skills-dir",
+    paths.managedSkillsDir,
+    "--skills-dir",
+    path.join(repoRoot, "managed-skills"),
+  ], {
+    cwd: repoRoot,
+    env: runtimeEnv,
+    logPath: paths.runtimeLog,
+  });
+
+  try {
+    appendLogLine(path.join(reportRoot, "self-hosted-runtime-meta.txt"), `baseUrl=${baseUrl}`);
+    await waitForHealth(baseUrl, options.runtimeBootTimeoutMs ?? DEFAULT_RUNTIME_BOOT_TIMEOUT_MS);
+    await bootstrapLocalPassphrase(baseUrl, localPassphrase);
+    await completeSelfHostedSetup(baseUrl, localPassphrase);
+
+    const gateEnv = createGateEnv(process.env, paths, baseUrl, localPassphrase, tokenSecret);
+    const gateArgs = [
+      path.join(repoRoot, "scripts", "ops", "run-real-green-gate.mjs"),
+      "--repo-root",
+      repoRoot,
+      "--base-url",
+      baseUrl,
+      "--ui-base-url",
+      baseUrl,
+      "--report-root",
+      reportRoot,
+    ];
+    if (options.branch) {
+      gateArgs.push("--branch", options.branch);
+    }
+    const gateResult = await runLogged(process.execPath, gateArgs, {
+      cwd: repoRoot,
+      env: gateEnv,
+      logPath: paths.gateLog,
+    });
+    return gateResult;
+  } finally {
+    await stopChild(runtime);
+    fs.rmSync(runtimeRoot, { recursive: true, force: true });
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  try {
+    const result = await runSelfHostedRealGreenGate(options);
+    process.exitCode = result.code;
+  } catch (error) {
+    ensureDir(options.reportRoot);
+    const message = error instanceof Error ? error.message : String(error);
+    appendLogLine(path.join(options.reportRoot, "self-hosted-runtime-error.log"), message);
+    writeEarlyErrorArtifact(options.reportRoot, "self_hosted_runtime_error");
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}

--- a/scripts/ops/run-real-green-gate.mjs
+++ b/scripts/ops/run-real-green-gate.mjs
@@ -360,6 +360,10 @@ export function summarizeRun(run) {
   };
 }
 
+export function resolveGateSuiteReportRoot(reportRoot, suiteName) {
+  return path.join(reportRoot, "suites", suiteName);
+}
+
 function hasOnlyPassed(run) {
   if (!run) {
     return false;
@@ -549,6 +553,7 @@ async function main() {
       () => runRealWorldValidation({
         ...validationBaseOptions,
         suite: "smoke",
+        reportRoot: resolveGateSuiteReportRoot(reportRoot, "smoke"),
       }),
       async () => {
         await closeSharedUiProbeSession();
@@ -565,6 +570,7 @@ async function main() {
         suite: "daily",
         scenarioIds: DAILY_CORE_SCENARIOS,
         repetitions: options.dailyCoreRepetitions,
+        reportRoot: resolveGateSuiteReportRoot(reportRoot, "daily-core"),
       }),
       async () => {
         await closeSharedUiProbeSession();
@@ -581,6 +587,7 @@ async function main() {
         suite: "daily",
         scenarioIds: PUBLIC_SURFACE_SCENARIOS,
         repetitions: 1,
+        reportRoot: resolveGateSuiteReportRoot(reportRoot, "public-surface"),
       }),
       async () => {
         await closeSharedUiProbeSession();

--- a/scripts/ops/run-real-green-gate.mjs
+++ b/scripts/ops/run-real-green-gate.mjs
@@ -2,6 +2,7 @@
 
 import { execFileSync } from "node:child_process";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { FridayClient } from "../../validation/real-world/lib/client.mjs";
 import { closeSharedUiProbeSession } from "../../validation/real-world/lib/executors.mjs";
 import { collectEnvironmentTruth } from "../../validation/real-world/lib/env-truth.mjs";
@@ -345,7 +346,7 @@ function buildClientOptions(options) {
   };
 }
 
-function summarizeRun(run) {
+export function summarizeRun(run) {
   return {
     runId: run.runId,
     suite: run.suite,
@@ -354,6 +355,8 @@ function summarizeRun(run) {
     failureClassCounts: run.failureClassCounts ?? {},
     defectBucketCounts: run.defectBucketCounts ?? {},
     providerLanes: run.providerLanes ?? {},
+    providerAttemptCount: run.providerAttemptCount ?? 0,
+    browserProbeAttemptCount: run.browserProbeAttemptCount ?? 0,
   };
 }
 
@@ -648,7 +651,9 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  console.error(error instanceof Error ? error.stack ?? error.message : String(error));
-  process.exitCode = 1;
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.stack ?? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/src/agent/runtime/friday-agent-runtime.ts
+++ b/src/agent/runtime/friday-agent-runtime.ts
@@ -4931,6 +4931,21 @@ function taskLooksLikeExternalAction(task: string): boolean {
   return english.test(task) || chinese.test(task);
 }
 
+function taskLooksLikeLocalWorkspaceFileInspection(task: string): boolean {
+  const englishLocal =
+    /\b(local|workspace|repo|repository|project|current workspace|current repo|filesystem)\b/i;
+  const englishFileAction =
+    /\b(read|open|inspect|check|cat|show)\b[\s\S]{0,64}\b(file|files|filesystem|folder|directory|path|readme|[a-z0-9_.-]+\.[a-z0-9]+)\b/i;
+  const englishFileFirst =
+    /\b(file|files|filesystem|folder|directory|path|readme|[a-z0-9_.-]+\.[a-z0-9]+)\b[\s\S]{0,64}\b(read|open|inspect|check|cat|show)\b/i;
+  const chineseLocal = /(本地|工作区|仓库|项目|文件系统)/u;
+  const chineseFileAction = /(读取|查看|检查|打开).{0,32}(文件|目录|路径|工作区|仓库)/u;
+  return (
+    (englishLocal.test(task) && (englishFileAction.test(task) || englishFileFirst.test(task)))
+    || (chineseLocal.test(task) && chineseFileAction.test(task))
+  );
+}
+
 /**
  * Detect Q&A tasks that contain web-action keywords but are asking about
  * provided/internal content — NOT requesting an external lookup.
@@ -5120,6 +5135,7 @@ function toolCallViolatesDesktopInspectionIntent(params: {
 }
 
 function classifyEvidenceTask(task: string): "web" | "desktop" | null {
+  if (taskLooksLikeLocalWorkspaceFileInspection(task)) return "desktop";
   if (taskLooksLikeDesktopAction(task)) return "desktop";
   // Q&A tasks may contain web-action keywords ("search", "check") but are
   // asking about provided/internal content — skip evidence closure for these.
@@ -5133,15 +5149,23 @@ function buildEvidenceRetryPrompt(params: {
   toolMap: Map<string, FridayAgentToolDefinition>;
   disabledToolNames?: ReadonlySet<string>;
 }): string {
-  const category = classifyEvidenceTask(params.task.trim()) ?? "web";
+  const task = params.task.trim();
+  const localWorkspaceFileInspection = taskLooksLikeLocalWorkspaceFileInspection(task);
+  const category = classifyEvidenceTask(task) ?? "web";
   const isEnabled = (name: string) => !(params.disabledToolNames?.has(name) ?? false);
-  const preferredTools = category === "desktop"
+  const preferredTools = localWorkspaceFileInspection
+    ? ["read", "exec"]
+    : category === "desktop"
     ? ["system", "desktop", "exec", "read", "browser"]
     : ["web_fetch", "web_search", "browser"];
   const enabledPreferred = preferredTools.filter((name) => params.toolMap.has(name) && isEnabled(name));
   const toolHint = enabledPreferred.length > 0 ? enabledPreferred.join("/") : "available tools";
-  const taskLabel = category === "desktop" ? "this local desktop/device task" : "this external task";
-  const approachHint = category === "desktop"
+  const taskLabel = localWorkspaceFileInspection
+    ? "this local workspace file task"
+    : category === "desktop" ? "this local desktop/device task" : "this external task";
+  const approachHint = localWorkspaceFileInspection
+    ? "Use read for the requested workspace path; do not use web_search or web_fetch because they cannot inspect local workspace files."
+    : category === "desktop"
     ? "Start with system snapshot, then use system intents before falling back to desktop session_info or desktop screenshot for visible evidence."
     : "Use web tools to gather evidence before concluding.";
 

--- a/src/agent/runtime/friday-agent-runtime.ts
+++ b/src/agent/runtime/friday-agent-runtime.ts
@@ -4221,6 +4221,32 @@ function detectEvidenceClosureGap(params: {
   const category = classifyEvidenceTask(normalizedTask);
   if (!category) return null;
 
+  if (taskLooksLikeLocalWorkspaceFileInspection(normalizedTask)) {
+    const hasReadEvidence = hasSuccessfulLocalWorkspaceReadEvidence(normalizedTask, params.toolCalls);
+    const refusalAfterRead = hasReadEvidence && responseLooksLikeLocalFileAccessRefusal(params.responseText);
+    if (!hasReadEvidence || refusalAfterRead) {
+      const failedCalls = params.toolCalls.filter((call) => call.result.isError);
+      const latestFailure = failedCalls[failedCalls.length - 1];
+      const failureDetail = latestFailure?.result.content
+        ? latestFailure.result.content.replace(/\s+/g, " ").trim()
+        : "no successful read tool evidence for the requested workspace file";
+      return {
+        errorCode: FRIDAY_AGENT_ERROR_CODES.OUTPUT_CLOSURE_ERROR,
+        userMessage:
+          "Workspace file task could not be completed with verifiable read evidence. " +
+          "Retry after checking the requested path and file tool availability.",
+        developerMessage:
+          `${FRIDAY_AGENT_ERROR_CODES.OUTPUT_CLOSURE_ERROR}: ` +
+          `Workspace file evidence closure failed for task "${normalizedTask.slice(0, 120)}": ` +
+          `${String(params.toolCalls.length)} tool call(s), ` +
+          `${hasReadEvidence ? "successful read was followed by a file-access refusal" : "no matching successful read tool call"}. ` +
+          `Last failure: ${failureDetail}. Final response: ${params.responseText.trim().slice(0, 200)}`,
+        attemptedImageToolCalls: params.toolCalls.length,
+        failedImageToolCalls: failedCalls.length,
+      };
+    }
+  }
+
   const hasAttemptedEvidenceTool = params.toolCalls.some((call) => {
     if (category === "desktop") {
       return call.toolName === "system"
@@ -4722,6 +4748,53 @@ function hasSuccessfulToolEvidence(toolCalls: FridayAgentToolCallRecord[]): bool
   return false;
 }
 
+function extractLocalWorkspaceFileMentions(task: string): string[] {
+  const mentions = new Set<string>();
+  const fileMatches = task.match(/\b(?:[a-z0-9_.-]+\/)*[a-z0-9_.-]+\.[a-z0-9]+\b/giu) ?? [];
+  for (const match of fileMatches) {
+    mentions.add(stripTrailingPunctuation(match).toLowerCase());
+  }
+  if (mentions.size === 0 && /\breadme\b/i.test(task)) {
+    mentions.add("readme.md");
+  }
+  return [...mentions];
+}
+
+function hasSuccessfulLocalWorkspaceReadEvidence(
+  task: string,
+  toolCalls: FridayAgentToolCallRecord[],
+): boolean {
+  const requestedFiles = extractLocalWorkspaceFileMentions(task);
+  return toolCalls.some((call) => {
+    if (call.toolName !== "read" || call.result.isError) {
+      return false;
+    }
+    const rawPath = typeof call.args.path === "string" ? call.args.path.trim() : "";
+    if (rawPath.length === 0) {
+      return false;
+    }
+    if (requestedFiles.length === 0) {
+      return true;
+    }
+    const normalizedPath = rawPath.replace(/\\/g, "/").toLowerCase();
+    const pathBase = basename(normalizedPath);
+    return requestedFiles.some((requested) => {
+      if (requested.includes("/")) {
+        return normalizedPath === requested || normalizedPath.endsWith(`/${requested}`);
+      }
+      return normalizedPath === requested
+        || normalizedPath.endsWith(`/${requested}`)
+        || pathBase === requested;
+    });
+  });
+}
+
+function responseLooksLikeLocalFileAccessRefusal(responseText: string): boolean {
+  return /\b(?:cannot|can't|unable to|not able to|could not|couldn't)\s+(?:directly\s+)?(?:access|read|open)\b/i.test(responseText)
+    || /\b(?:cannot|can't|unable to|not able to|could not|couldn't)\s+(?:extract|inspect)\b/i.test(responseText)
+    || /(无法直接访问|无法访问|无法读取|不能读取|不能访问|无法打开|无法提取)/u.test(responseText);
+}
+
 function hasFeedbackPersistenceEvidence(toolCalls: FridayAgentToolCallRecord[]): boolean {
   for (const call of toolCalls) {
     if (call.result.isError) continue;
@@ -4782,11 +4855,21 @@ function shouldEnforceToolEvidenceForTask(params: {
   if (isAutonomousInternalReasoningSurface(executionSurface)) {
     return false;
   }
-  if (hasSuccessfulToolEvidence(toolCalls)) return false;
 
   const normalizedTask = task.trim();
   if (normalizedTask.length === 0) return false;
   const taskCategory = classifyEvidenceTask(normalizedTask);
+  if (taskLooksLikeLocalWorkspaceFileInspection(normalizedTask)) {
+    const hasReadEvidence = hasSuccessfulLocalWorkspaceReadEvidence(normalizedTask, toolCalls);
+    if (!hasReadEvidence) {
+      return hasEvidenceCapableTools(toolMap, disabledToolNames, "desktop");
+    }
+    if (responseLooksLikeLocalFileAccessRefusal(responseText)) {
+      return hasEvidenceCapableTools(toolMap, disabledToolNames, "desktop");
+    }
+    return false;
+  }
+  if (hasSuccessfulToolEvidence(toolCalls)) return false;
   if (toolCalls.length > 0) {
     // If a desktop route attempted tools but all failed, force one more
     // evidence-oriented retry instead of silently accepting the failure text.
@@ -4935,9 +5018,9 @@ function taskLooksLikeLocalWorkspaceFileInspection(task: string): boolean {
   const englishLocal =
     /\b(local|workspace|repo|repository|project|current workspace|current repo|filesystem)\b/i;
   const englishFileAction =
-    /\b(read|open|inspect|check|cat|show)\b[\s\S]{0,64}\b(file|files|filesystem|folder|directory|path|readme|[a-z0-9_.-]+\.[a-z0-9]+)\b/i;
+    /\b(read|open|inspect|check|cat|show)\b[\s\S]{0,64}\b(file|files|filesystem|folder|directory|path|readme|(?:[a-z0-9_.-]+\/)*[a-z0-9_.-]+\.[a-z0-9]+)\b/i;
   const englishFileFirst =
-    /\b(file|files|filesystem|folder|directory|path|readme|[a-z0-9_.-]+\.[a-z0-9]+)\b[\s\S]{0,64}\b(read|open|inspect|check|cat|show)\b/i;
+    /\b(file|files|filesystem|folder|directory|path|readme|(?:[a-z0-9_.-]+\/)*[a-z0-9_.-]+\.[a-z0-9]+)\b[\s\S]{0,64}\b(read|open|inspect|check|cat|show)\b/i;
   const chineseLocal = /(本地|工作区|仓库|项目|文件系统)/u;
   const chineseFileAction = /(读取|查看|检查|打开).{0,32}(文件|目录|路径|工作区|仓库)/u;
   return (

--- a/src/agent/runtime/friday-agent-runtime.ts
+++ b/src/agent/runtime/friday-agent-runtime.ts
@@ -2590,6 +2590,25 @@ export function createFridayAgentRuntime(
               continue;
             }
 
+            const localWorkspaceFileIntentViolation = toolCallViolatesLocalWorkspaceFileIntent({
+              task: params.task,
+              toolName: toolUse.name,
+              toolArgs: toolUse.input ?? {},
+            });
+            if (localWorkspaceFileIntentViolation) {
+              toolCallRecordsByIndex.set(toolIndex, emitImmediateToolCallResult({
+                toolUse,
+                runId,
+                nowIso,
+                emitRunEvent: (name, payload) => handleTrackedEvent(name, payload),
+                routeId: "agent.execute.tool.local_workspace_file",
+                correlationId: runId,
+                errorCode: "WRONG_TOOL_FOR_TASK",
+                message: localWorkspaceFileIntentViolation,
+              }));
+              continue;
+            }
+
             if (explicitAutonomousTask && isAutonomousTaskBypassTool(toolUse.name)) {
               toolCallRecordsByIndex.set(toolIndex, emitImmediateToolCallResult({
                 toolUse,
@@ -3919,6 +3938,59 @@ function resolveToolPathArg(input: Record<string, unknown> | undefined): string 
   return pathArg?.trim().length ? pathArg.trim() : undefined;
 }
 
+function normalizeLocalWorkspacePathForMatch(pathArg: string): string {
+  return pathArg.replace(/\\/g, "/").replace(/^\.\//, "").toLowerCase();
+}
+
+function localWorkspacePathMatchesRequested(pathArg: string, requested: string): boolean {
+  const normalizedPath = normalizeLocalWorkspacePathForMatch(pathArg);
+  const normalizedRequested = normalizeLocalWorkspacePathForMatch(requested);
+  const pathBase = basename(normalizedPath);
+  if (normalizedRequested.includes("/")) {
+    return normalizedPath === normalizedRequested || normalizedPath.endsWith(`/${normalizedRequested}`);
+  }
+  return normalizedPath === normalizedRequested
+    || normalizedPath.endsWith(`/${normalizedRequested}`)
+    || pathBase === normalizedRequested;
+}
+
+function taskExplicitlyRequiresReadToolForWorkspaceFile(task: string): boolean {
+  return taskLooksLikeLocalWorkspaceFileInspection(task)
+    && (
+      /\bcall\s+the\s+`?read`?\s+tool\b/i.test(task)
+      || /\buse\s+the\s+`?read`?\s+tool\b/i.test(task)
+      || /\buse\s+`?read`?\s+for\s+the\s+requested\s+workspace\s+path\b/i.test(task)
+      || /`read`\s+tool/u.test(task)
+    );
+}
+
+function toolCallViolatesLocalWorkspaceFileIntent(params: {
+  task: string;
+  toolName: string;
+  toolArgs: Record<string, unknown>;
+}): string | null {
+  if (!taskExplicitlyRequiresReadToolForWorkspaceFile(params.task)) {
+    return null;
+  }
+  const requestedPath = extractLocalWorkspaceFileMentions(params.task)[0];
+  const requestedLabel = requestedPath ?? "the requested workspace file";
+  if (params.toolName !== "read") {
+    return `This task explicitly requires tool 'read' for local workspace file '${requestedLabel}'. Do not use '${params.toolName}', web, browser, search, capabilities, or tool-pack detours for this workspace file. Call read with path="${requestedLabel}" next.`;
+  }
+
+  if (!requestedPath) {
+    return null;
+  }
+  const actualPath = resolveToolPathArg(params.toolArgs);
+  if (!actualPath) {
+    return `The read tool call is missing the requested local workspace path. Call read with path="${requestedLabel}".`;
+  }
+  if (!localWorkspacePathMatchesRequested(actualPath, requestedPath)) {
+    return `The read tool path '${actualPath}' does not match the requested local workspace file '${requestedLabel}'. Call read with path="${requestedLabel}".`;
+  }
+  return null;
+}
+
 function isRuntimeSkillAuthoringPath(input: Record<string, unknown> | undefined): boolean {
   const pathArg = resolveToolPathArg(input);
   if (!pathArg) return false;
@@ -4776,15 +4848,8 @@ function hasSuccessfulLocalWorkspaceReadEvidence(
     if (requestedFiles.length === 0) {
       return true;
     }
-    const normalizedPath = rawPath.replace(/\\/g, "/").toLowerCase();
-    const pathBase = basename(normalizedPath);
     return requestedFiles.some((requested) => {
-      if (requested.includes("/")) {
-        return normalizedPath === requested || normalizedPath.endsWith(`/${requested}`);
-      }
-      return normalizedPath === requested
-        || normalizedPath.endsWith(`/${requested}`)
-        || pathBase === requested;
+      return localWorkspacePathMatchesRequested(rawPath, requested);
     });
   });
 }
@@ -5234,9 +5299,15 @@ function buildEvidenceRetryPrompt(params: {
 }): string {
   const task = params.task.trim();
   const localWorkspaceFileInspection = taskLooksLikeLocalWorkspaceFileInspection(task);
+  const explicitWorkspaceReadToolTask = taskExplicitlyRequiresReadToolForWorkspaceFile(task);
+  const requestedWorkspacePath = explicitWorkspaceReadToolTask
+    ? extractLocalWorkspaceFileMentions(task)[0]
+    : undefined;
   const category = classifyEvidenceTask(task) ?? "web";
   const isEnabled = (name: string) => !(params.disabledToolNames?.has(name) ?? false);
-  const preferredTools = localWorkspaceFileInspection
+  const preferredTools = explicitWorkspaceReadToolTask
+    ? ["read"]
+    : localWorkspaceFileInspection
     ? ["read", "exec"]
     : category === "desktop"
     ? ["system", "desktop", "exec", "read", "browser"]
@@ -5246,7 +5317,9 @@ function buildEvidenceRetryPrompt(params: {
   const taskLabel = localWorkspaceFileInspection
     ? "this local workspace file task"
     : category === "desktop" ? "this local desktop/device task" : "this external task";
-  const approachHint = localWorkspaceFileInspection
+  const approachHint = explicitWorkspaceReadToolTask
+    ? `Call read with path="${requestedWorkspacePath ?? "the requested workspace path"}"; do not use web, browser, search, capabilities, or tool-pack detours because they cannot satisfy local file read evidence.`
+    : localWorkspaceFileInspection
     ? "Use read for the requested workspace path; do not use web_search or web_fetch because they cannot inspect local workspace files."
     : category === "desktop"
     ? "Start with system snapshot, then use system intents before falling back to desktop session_info or desktop screenshot for visible evidence."

--- a/src/agent/runtime/friday-agent-runtime.ts
+++ b/src/agent/runtime/friday-agent-runtime.ts
@@ -4296,12 +4296,22 @@ function detectEvidenceClosureGap(params: {
   if (taskLooksLikeLocalWorkspaceFileInspection(normalizedTask)) {
     const hasReadEvidence = hasSuccessfulLocalWorkspaceReadEvidence(normalizedTask, params.toolCalls);
     const refusalAfterRead = hasReadEvidence && responseLooksLikeLocalFileAccessRefusal(params.responseText);
-    if (!hasReadEvidence || refusalAfterRead) {
+    const missingRequestedHeading = hasReadEvidence
+      && taskRequestsTopWorkspaceHeading(normalizedTask)
+      && !hasSuccessfulLocalWorkspaceReadEvidenceWithHeading(normalizedTask, params.toolCalls);
+    if (!hasReadEvidence || refusalAfterRead || missingRequestedHeading) {
       const failedCalls = params.toolCalls.filter((call) => call.result.isError);
       const latestFailure = failedCalls[failedCalls.length - 1];
       const failureDetail = latestFailure?.result.content
         ? latestFailure.result.content.replace(/\s+/g, " ").trim()
+        : missingRequestedHeading
+        ? "read tool evidence did not include the requested top heading"
         : "no successful read tool evidence for the requested workspace file";
+      const closureReason = missingRequestedHeading
+        ? "read result did not include the requested top heading"
+        : hasReadEvidence
+        ? "successful read was followed by a file-access refusal"
+        : "no matching successful read tool call";
       return {
         errorCode: FRIDAY_AGENT_ERROR_CODES.OUTPUT_CLOSURE_ERROR,
         userMessage:
@@ -4311,7 +4321,7 @@ function detectEvidenceClosureGap(params: {
           `${FRIDAY_AGENT_ERROR_CODES.OUTPUT_CLOSURE_ERROR}: ` +
           `Workspace file evidence closure failed for task "${normalizedTask.slice(0, 120)}": ` +
           `${String(params.toolCalls.length)} tool call(s), ` +
-          `${hasReadEvidence ? "successful read was followed by a file-access refusal" : "no matching successful read tool call"}. ` +
+          `${closureReason}. ` +
           `Last failure: ${failureDetail}. Final response: ${params.responseText.trim().slice(0, 200)}`,
         attemptedImageToolCalls: params.toolCalls.length,
         failedImageToolCalls: failedCalls.length,
@@ -4854,10 +4864,39 @@ function hasSuccessfulLocalWorkspaceReadEvidence(
   });
 }
 
+function taskRequestsTopWorkspaceHeading(task: string): boolean {
+  return /\btop\s+(?:h1|heading)\b/i.test(task)
+    || /\b(?:h1|heading)\b[\s\S]{0,32}\bonly\b/i.test(task);
+}
+
+function readContentIncludesWorkspaceHeading(content: string): boolean {
+  return /(^|\n)\s*#\s+\S/u.test(content)
+    || /<h1\b[^>]*>[\s\S]*?<\/h1>/iu.test(content);
+}
+
+function hasSuccessfulLocalWorkspaceReadEvidenceWithHeading(
+  task: string,
+  toolCalls: FridayAgentToolCallRecord[],
+): boolean {
+  const requestedFiles = extractLocalWorkspaceFileMentions(task);
+  return toolCalls.some((call) => {
+    if (call.toolName !== "read" || call.result.isError) {
+      return false;
+    }
+    const rawPath = typeof call.args.path === "string" ? call.args.path.trim() : "";
+    if (rawPath.length === 0) {
+      return false;
+    }
+    const matchesRequestedPath = requestedFiles.length === 0
+      || requestedFiles.some((requested) => localWorkspacePathMatchesRequested(rawPath, requested));
+    return matchesRequestedPath && readContentIncludesWorkspaceHeading(call.result.content);
+  });
+}
+
 function responseLooksLikeLocalFileAccessRefusal(responseText: string): boolean {
   return /\b(?:cannot|can't|unable to|not able to|could not|couldn't)\s+(?:directly\s+)?(?:access|read|open)\b/i.test(responseText)
     || /\b(?:cannot|can't|unable to|not able to|could not|couldn't)\s+(?:extract|inspect)\b/i.test(responseText)
-    || /(无法直接访问|无法访问|无法读取|不能读取|不能访问|无法打开|无法提取)/u.test(responseText);
+    || /(无法直接访问|无法访问|无法读取|不能读取|不能访问|无法打开|无法提取|未能读取|没能读取|未能访问|没能访问|未能打开|没能打开|未能提取|没能提取)/u.test(responseText);
 }
 
 function hasFeedbackPersistenceEvidence(toolCalls: FridayAgentToolCallRecord[]): boolean {
@@ -4927,6 +4966,11 @@ function shouldEnforceToolEvidenceForTask(params: {
   if (taskLooksLikeLocalWorkspaceFileInspection(normalizedTask)) {
     const hasReadEvidence = hasSuccessfulLocalWorkspaceReadEvidence(normalizedTask, toolCalls);
     if (!hasReadEvidence) {
+      return hasEvidenceCapableTools(toolMap, disabledToolNames, "desktop");
+    }
+    const missingRequestedHeading = taskRequestsTopWorkspaceHeading(normalizedTask)
+      && !hasSuccessfulLocalWorkspaceReadEvidenceWithHeading(normalizedTask, toolCalls);
+    if (missingRequestedHeading) {
       return hasEvidenceCapableTools(toolMap, disabledToolNames, "desktop");
     }
     if (responseLooksLikeLocalFileAccessRefusal(responseText)) {
@@ -5317,10 +5361,19 @@ function buildEvidenceRetryPrompt(params: {
   const taskLabel = localWorkspaceFileInspection
     ? "this local workspace file task"
     : category === "desktop" ? "this local desktop/device task" : "this external task";
+  const headingRetryHint = taskRequestsTopWorkspaceHeading(task)
+    ? "If a previous read used offset/limit and did not include the H1, call read again without offset/limit or with enough lines so the read result includes the requested top H1 before answering."
+    : "";
   const approachHint = explicitWorkspaceReadToolTask
-    ? `Call read with path="${requestedWorkspacePath ?? "the requested workspace path"}"; do not use web, browser, search, capabilities, or tool-pack detours because they cannot satisfy local file read evidence.`
+    ? [
+        `Call read with path="${requestedWorkspacePath ?? "the requested workspace path"}"; do not use web, browser, search, capabilities, or tool-pack detours because they cannot satisfy local file read evidence.`,
+        headingRetryHint,
+      ].filter((part) => part.length > 0).join(" ")
     : localWorkspaceFileInspection
-    ? "Use read for the requested workspace path; do not use web_search or web_fetch because they cannot inspect local workspace files."
+    ? [
+        "Use read for the requested workspace path; do not use web_search or web_fetch because they cannot inspect local workspace files.",
+        headingRetryHint,
+      ].filter((part) => part.length > 0).join(" ")
     : category === "desktop"
     ? "Start with system snapshot, then use system intents before falling back to desktop session_info or desktop screenshot for visible evidence."
     : "Use web tools to gather evidence before concluding.";

--- a/src/agent/runtime/friday-agent-system-prompt-builder.ts
+++ b/src/agent/runtime/friday-agent-system-prompt-builder.ts
@@ -196,6 +196,7 @@ export function buildFridayAgentSystemPrompt(
     "- Capabilities/runtime questions (what Friday can do, which features are enabled/disabled, messaging/MCP/provider status): use capabilities first — never guess runtime state\n" +
     "- Status/progress questions (current task, delegated task progress, latest result, blockers): use task_status first — never fabricate progress\n" +
     "- Approval and workflow control commands (approve, reject, cancel, retry, workflow status): use the corresponding control tool directly\n" +
+    "- Local workspace files, repository paths, or filesystem reads: use read first for file contents; do not use web_search or web_fetch for workspace files\n" +
     "- Information lookup (news, facts, documentation): use web_search first, then web_fetch for specific URLs\n" +
     "- Fetch a specific URL (articles, docs, pages): use web_fetch — HTML is auto-parsed to readable text\n" +
     "- JS-heavy sites (Reddit, Twitter/X, SPA apps), interactive pages, login-required pages: use browser (snapshot action to read content)\n" +

--- a/src/agent/runtime/friday-agent-tool-routing.ts
+++ b/src/agent/runtime/friday-agent-tool-routing.ts
@@ -97,6 +97,7 @@ export function resolveFridayAgentToolRouting(input: {
   const task = input.task?.trim() ?? "";
   const availableTools = input.tools.filter((tool) => !(input.disabledToolNames?.has(tool.name) ?? false));
   const availableToolNames = new Set(availableTools.map((tool) => tool.name));
+  const explicitWorkspaceReadToolTask = taskExplicitlyRequiresWorkspaceReadTool(task);
   const profile = classifyFridayToolRoutingProfile({
     task,
     images: input.images,
@@ -122,9 +123,15 @@ export function resolveFridayAgentToolRouting(input: {
     availableTools,
     input.disabledToolNames,
   ));
+  if (explicitWorkspaceReadToolTask) {
+    selected.clear();
+    if (availableToolNames.has("read")) {
+      selected.add("read");
+    }
+  }
 
   // Preserve small custom-tool runtimes and focused tests without reopening the full production registry.
-  if (availableTools.length <= 6) {
+  if (!explicitWorkspaceReadToolTask && availableTools.length <= 6) {
     for (const tool of availableTools) {
       if (!FRIDAY_KNOWN_TOOL_NAMES.has(tool.name)) {
         selected.add(tool.name);
@@ -133,9 +140,11 @@ export function resolveFridayAgentToolRouting(input: {
   }
 
   const selectedToolNames = [...selected].filter((name) => availableToolNames.has(name));
-  const deferredToolNames = availableTools
-    .map((tool) => tool.name)
-    .filter((name) => !selected.has(name));
+  const deferredToolNames = explicitWorkspaceReadToolTask
+    ? []
+    : availableTools
+        .map((tool) => tool.name)
+        .filter((name) => !selected.has(name));
 
   return {
     profile,
@@ -272,6 +281,9 @@ function classifyFridayToolRoutingProfile(input: {
   if (/\b(skill|skills|plugin)\b|技能|插件/u.test(text)) {
     return "skill";
   }
+  if (taskExplicitlyRequiresWorkspaceReadTool(text)) {
+    return "code";
+  }
   if (/\b(latest|current|today|news|search|lookup|source|url|https?:\/\/|documentation|docs)\b|最新|今天|最近|新闻|搜索|查一下|资料|来源/u.test(text)) {
     return "web";
   }
@@ -291,6 +303,11 @@ function classifyFridayToolRoutingProfile(input: {
     return "trivial";
   }
   return "general";
+}
+
+function taskExplicitlyRequiresWorkspaceReadTool(task: string): boolean {
+  return /\b(call|use)\s+the\s+`?read`?\s+tool\b[\s\S]{0,160}\b(?:file|repo|repository|workspace|readme|(?:[a-z0-9_.-]+\/)*[a-z0-9_.-]+\.[a-z0-9]+)\b/i.test(task)
+    || /\b(?:file|repo|repository|workspace|readme|(?:[a-z0-9_.-]+\/)*[a-z0-9_.-]+\.[a-z0-9]+)\b[\s\S]{0,160}\b(call|use)\s+the\s+`?read`?\s+tool\b/i.test(task);
 }
 
 function buildToolRoutingIntentText(input: {

--- a/src/config/friday-config.types.ts
+++ b/src/config/friday-config.types.ts
@@ -40,6 +40,7 @@ export interface LoadedFridayConfig {
   exists: boolean;
   rawText?: string;
   runtimeStateDir?: string;
+  workspaceRoot?: string;
   launchCwd?: string;
 }
 

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -826,11 +826,11 @@ function mapConfigValidationError(error: unknown): {
 }
 
 export function createStubConfigManager(
-  config: { stateDir?: string; skillDirs: string[] },
+  config: { stateDir?: string; workspaceRoot?: string; skillDirs: string[] },
   stateRuntime: FridayStateRuntime,
 ): FridayHubConfigManagerService {
   const skillSettings: FridaySkillRegistrySettings = {
-    workspaceDir: config.stateDir ?? ".",
+    workspaceDir: config.workspaceRoot ?? config.stateDir ?? ".",
     bundledSkillsDir: config.skillDirs[0] ?? "skills",
     managedSkillsDir: config.skillDirs[1] ?? "managed-skills",
     extraSkillDirs: config.skillDirs.slice(2),
@@ -946,6 +946,7 @@ export function createStubConfigManager(
         exists: true,
         rawText: JSON.stringify(snapshot.config, null, 2),
         runtimeStateDir: stateRuntime.stateDir,
+        workspaceRoot: config.workspaceRoot ?? config.stateDir ?? ".",
         launchCwd: process.cwd(),
       };
     },
@@ -1609,6 +1610,7 @@ export interface FridayHubStatus {
 
 export interface FridayHubConfig {
   stateDir?: string;
+  workspaceRoot?: string;
   skillDirs: string[];
   host?: string;
   port?: number;
@@ -1627,6 +1629,7 @@ export interface FridayHubConfig {
 
 export interface FridayResolvedHubConfig {
   stateDir?: string;
+  workspaceRoot?: string;
   skillDirs: string[];
   port: number;
   tokenSecret: string;

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -712,6 +712,7 @@ export function resolveFridayHubConfig(
     3141;
 
   const stateDir = input.stateDir ?? env.FRIDAY_STATE_DIR ?? undefined;
+  const workspaceRoot = input.workspaceRoot ?? env.FRIDAY_WORKSPACE_ROOT ?? undefined;
 
   let skillDirs: string[];
   if (input.skillDirs.length > 0) {
@@ -765,6 +766,7 @@ export function resolveFridayHubConfig(
 
   return {
     stateDir,
+    workspaceRoot,
     skillDirs,
     port,
     tokenSecret,
@@ -918,6 +920,7 @@ export async function createFridayHub(
 
   // P0-001: Wrap remaining bootstrap in try/catch to ensure SQLite cleanup on partial failure
   try {
+  const workspaceRoot = config.workspaceRoot ?? process.env.FRIDAY_WORKSPACE_ROOT ?? config.stateDir ?? ".";
 
   const daemonService = createFridayLocalDaemonService({
     moduleUrl: import.meta.url,
@@ -976,13 +979,13 @@ export async function createFridayHub(
   // P2: configManager and memoryState are intentionally stubbed for v0.4.x standalone mode.
   // Full implementations with persistence are planned for the multi-node milestone.
   // Config mutations via API are silently no-ops; use env vars and friday.config.yaml instead.
-  const configManager = createStubConfigManager(config, stateRuntime);
+  const configManager = createStubConfigManager({ ...config, workspaceRoot }, stateRuntime);
   const auditLogPath = resolveFridayAuditLogPath(stateRuntime.stateDir);
   const memoryState = createStubMemoryState(auditLogPath);
 
   // 3. Create skill registry
   const registry = new FridaySkillRegistryImpl({
-    workspaceDir: config.stateDir ?? ".",
+    workspaceDir: workspaceRoot,
     hubVersion: FRIDAY_HUB_SKILL_COMPAT_VERSION,
     supportedApiVersions: ["1"],
     configManager,
@@ -1200,7 +1203,6 @@ export async function createFridayHub(
     }
     return result.output;
   };
-  const workspaceRoot = config.stateDir ?? ".";
   type FridayUserRulesPromptSurface =
     | "skill_generator"
     | "workflow_generator"

--- a/test/unit/agent/runtime/friday-agent-runtime.test.ts
+++ b/test/unit/agent/runtime/friday-agent-runtime.test.ts
@@ -2417,7 +2417,7 @@ describe("FridayAgentRuntime", () => {
         { type: "message_end", stopReason: "tool_use", inputTokens: 8, outputTokens: 6 },
       ],
       [
-        { type: "text_delta", text: "无法直接访问 README.md，因此无法提取 H1。" },
+        { type: "text_delta", text: "未能读取到 README.md 文件的内容。请确认文件存在或路径正确。" },
         { type: "message_end", stopReason: "end_turn", inputTokens: 8, outputTokens: 6 },
       ],
       [
@@ -2446,6 +2446,76 @@ describe("FridayAgentRuntime", () => {
 
       expect(result.status).toBe("completed");
       expect(result.toolCallCount).toBe(1);
+      expect(result.response).toBe("Friday");
+    } finally {
+      rmSync(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("retries top-heading workspace reads when the first read is too narrow", async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "friday-agent-runtime-read-heading-"));
+    writeFileSync(
+      join(workspaceRoot, "README.md"),
+      [
+        '<p align="right">',
+        '  <a href="README.zh-CN.md">中文</a>',
+        "</p>",
+        "",
+        '<h1 align="center">Friday</h1>',
+        "",
+        "Local fixture.",
+      ].join("\n"),
+      "utf8",
+    );
+    const llmClient = createMockLlmClient([
+      [
+        {
+          type: "tool_use",
+          id: "read-readme-narrow",
+          name: "read",
+          input: { path: "README.md", limit: 1 },
+        },
+        { type: "message_end", stopReason: "tool_use", inputTokens: 8, outputTokens: 6 },
+      ],
+      [
+        { type: "text_delta", text: 'The top H1 is <p align="right">.' },
+        { type: "message_end", stopReason: "end_turn", inputTokens: 8, outputTokens: 6 },
+      ],
+      [
+        {
+          type: "tool_use",
+          id: "read-readme-full",
+          name: "read",
+          input: { path: "README.md" },
+        },
+        { type: "message_end", stopReason: "tool_use", inputTokens: 8, outputTokens: 6 },
+      ],
+      [
+        { type: "text_delta", text: "Friday" },
+        { type: "message_end", stopReason: "end_turn", inputTokens: 8, outputTokens: 6 },
+      ],
+    ]);
+
+    const runtime = createFridayAgentRuntime({
+      db,
+      llmClient,
+      model: "test-model",
+      providerId: "test-provider",
+      systemPromptBuilder: () => "STANDARD_PROMPT",
+      tools: createFridayAgentFileTools({ workspaceRoot }),
+      eventEmitter: createFridayAgentEventEmitter(),
+      idGenerator,
+      nowIso: () => NOW,
+      workdir: workspaceRoot,
+    });
+
+    try {
+      const result = await runtime.executeRun({
+        task: "Call the read tool with path README.md from the current workspace root, then answer with the top H1 heading only.",
+      });
+
+      expect(result.status).toBe("completed");
+      expect(result.toolCallCount).toBe(2);
       expect(result.response).toBe("Friday");
     } finally {
       rmSync(workspaceRoot, { recursive: true, force: true });

--- a/test/unit/agent/runtime/friday-agent-runtime.test.ts
+++ b/test/unit/agent/runtime/friday-agent-runtime.test.ts
@@ -2021,6 +2021,284 @@ describe("FridayAgentRuntime", () => {
     expect(result.response).toContain("AGENT_OUTPUT_CLOSURE_ERROR");
   });
 
+  it("does not count request_tool_pack as local workspace file read evidence", async () => {
+    const llmClient = createMockLlmClient([
+      [
+        {
+          type: "tool_use",
+          id: "load-code-pack",
+          name: "request_tool_pack",
+          input: { pack: "code", reason: "Need local workspace file access." },
+        },
+        { type: "message_end", stopReason: "tool_use", inputTokens: 8, outputTokens: 6 },
+      ],
+      [
+        { type: "text_delta", text: "I cannot access README.md directly." },
+        { type: "message_end", stopReason: "end_turn", inputTokens: 8, outputTokens: 6 },
+      ],
+      [
+        { type: "text_delta", text: "Still unable to read README.md." },
+        { type: "message_end", stopReason: "end_turn", inputTokens: 8, outputTokens: 6 },
+      ],
+    ]);
+
+    const runtime = createFridayAgentRuntime({
+      db,
+      llmClient,
+      model: "test-model",
+      providerId: "test-provider",
+      systemPromptBuilder: () => "STANDARD_PROMPT",
+      tools: [createNamedTool("read"), createExecTool()],
+      eventEmitter: createFridayAgentEventEmitter(),
+      idGenerator,
+      nowIso: () => NOW,
+    });
+
+    const result = await runtime.executeRun({
+      task: "Call the read tool with path README.md from the current workspace root, then answer with the top H1 heading only.",
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.toolCallCount).toBe(1);
+    expect(result.response).toContain("AGENT_OUTPUT_CLOSURE_ERROR");
+  });
+
+  it("does not count web or skill-list tools as local workspace file read evidence", async () => {
+    const llmClient = createMockLlmClient([
+      [
+        {
+          type: "tool_use",
+          id: "web-fetch-readme",
+          name: "web_fetch",
+          input: { url: "https://example.com/README.md" },
+        },
+        {
+          type: "tool_use",
+          id: "list-skills",
+          name: "skills_list",
+          input: {},
+        },
+        { type: "message_end", stopReason: "tool_use", inputTokens: 8, outputTokens: 6 },
+      ],
+      [
+        { type: "text_delta", text: "I still cannot access README.md from the workspace." },
+        { type: "message_end", stopReason: "end_turn", inputTokens: 8, outputTokens: 6 },
+      ],
+      [
+        { type: "text_delta", text: "No local read evidence is available." },
+        { type: "message_end", stopReason: "end_turn", inputTokens: 8, outputTokens: 6 },
+      ],
+    ]);
+
+    const runtime = createFridayAgentRuntime({
+      db,
+      llmClient,
+      model: "test-model",
+      providerId: "test-provider",
+      systemPromptBuilder: () => "STANDARD_PROMPT",
+      tools: [createSuccessfulWebFetchTool(), createNamedTool("skills_list"), createNamedTool("read")],
+      eventEmitter: createFridayAgentEventEmitter(),
+      idGenerator,
+      nowIso: () => NOW,
+    });
+
+    const result = await runtime.executeRun({
+      task: "Call the read tool with path README.md from the current workspace root, then answer with the top H1 heading only.",
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.toolCallCount).toBe(2);
+    expect(result.response).toContain("AGENT_OUTPUT_CLOSURE_ERROR");
+  });
+
+  it("does not count capabilities as local workspace file read evidence", async () => {
+    const llmClient = createMockLlmClient([
+      [
+        {
+          type: "tool_use",
+          id: "check-capabilities",
+          name: "capabilities",
+          input: {},
+        },
+        { type: "message_end", stopReason: "tool_use", inputTokens: 8, outputTokens: 6 },
+      ],
+      [
+        { type: "text_delta", text: "Capabilities checked, but I cannot read README.md from the workspace." },
+        { type: "message_end", stopReason: "end_turn", inputTokens: 8, outputTokens: 6 },
+      ],
+      [
+        { type: "text_delta", text: "No local file read evidence is available." },
+        { type: "message_end", stopReason: "end_turn", inputTokens: 8, outputTokens: 6 },
+      ],
+    ]);
+
+    const runtime = createFridayAgentRuntime({
+      db,
+      llmClient,
+      model: "test-model",
+      providerId: "test-provider",
+      systemPromptBuilder: () => "STANDARD_PROMPT",
+      tools: [createNamedTool("capabilities"), createNamedTool("read")],
+      eventEmitter: createFridayAgentEventEmitter(),
+      idGenerator,
+      nowIso: () => NOW,
+    });
+
+    const result = await runtime.executeRun({
+      task: "Use capabilities if needed, but read README.md from the local workspace and answer with the top H1 heading only.",
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.response).toContain("AGENT_OUTPUT_CLOSURE_ERROR");
+  });
+
+  it("does not satisfy nested workspace file requests with a same-basename read", async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "friday-agent-runtime-read-path-match-"));
+    writeFileSync(join(workspaceRoot, "README.md"), "# Wrong\n", "utf8");
+    const llmClient = createMockLlmClient([
+      [
+        {
+          type: "tool_use",
+          id: "read-root-readme",
+          name: "read",
+          input: { path: "README.md" },
+        },
+        { type: "message_end", stopReason: "tool_use", inputTokens: 8, outputTokens: 6 },
+      ],
+      [
+        { type: "text_delta", text: "Wrong" },
+        { type: "message_end", stopReason: "end_turn", inputTokens: 8, outputTokens: 6 },
+      ],
+      [
+        { type: "text_delta", text: "Still no matching nested file read." },
+        { type: "message_end", stopReason: "end_turn", inputTokens: 8, outputTokens: 6 },
+      ],
+    ]);
+
+    const runtime = createFridayAgentRuntime({
+      db,
+      llmClient,
+      model: "test-model",
+      providerId: "test-provider",
+      systemPromptBuilder: () => "STANDARD_PROMPT",
+      tools: createFridayAgentFileTools({ workspaceRoot }),
+      eventEmitter: createFridayAgentEventEmitter(),
+      idGenerator,
+      nowIso: () => NOW,
+      workdir: workspaceRoot,
+    });
+
+    try {
+      const result = await runtime.executeRun({
+        task: "Call the read tool with path docs/README.md from the current workspace root, then answer with the top H1 heading only.",
+      });
+
+      expect(result.status).toBe("failed");
+      expect(result.toolCallCount).toBe(1);
+      expect(result.response).toContain("AGENT_OUTPUT_CLOSURE_ERROR");
+    } finally {
+      rmSync(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("retries local workspace file tasks until the requested file is read", async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "friday-agent-runtime-read-evidence-"));
+    writeFileSync(join(workspaceRoot, "README.md"), "# Friday\n\nLocal fixture.\n", "utf8");
+    const llmClient = createMockLlmClient([
+      [
+        { type: "text_delta", text: "I cannot access README.md directly." },
+        { type: "message_end", stopReason: "end_turn", inputTokens: 8, outputTokens: 6 },
+      ],
+      [
+        {
+          type: "tool_use",
+          id: "read-readme",
+          name: "read",
+          input: { path: "README.md" },
+        },
+        { type: "message_end", stopReason: "tool_use", inputTokens: 8, outputTokens: 6 },
+      ],
+      [
+        { type: "text_delta", text: "Friday" },
+        { type: "message_end", stopReason: "end_turn", inputTokens: 8, outputTokens: 6 },
+      ],
+    ]);
+
+    const runtime = createFridayAgentRuntime({
+      db,
+      llmClient,
+      model: "test-model",
+      providerId: "test-provider",
+      systemPromptBuilder: () => "STANDARD_PROMPT",
+      tools: createFridayAgentFileTools({ workspaceRoot }),
+      eventEmitter: createFridayAgentEventEmitter(),
+      idGenerator,
+      nowIso: () => NOW,
+      workdir: workspaceRoot,
+    });
+
+    try {
+      const result = await runtime.executeRun({
+        task: "Call the read tool with path README.md from the current workspace root, then answer with the top H1 heading only.",
+      });
+
+      expect(result.status).toBe("completed");
+      expect(result.toolCallCount).toBe(1);
+      expect(result.response).toBe("Friday");
+    } finally {
+      rmSync(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("retries local workspace file tasks when a successful read is followed by a refusal answer", async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "friday-agent-runtime-read-refusal-"));
+    writeFileSync(join(workspaceRoot, "README.md"), "# Friday\n\nLocal fixture.\n", "utf8");
+    const llmClient = createMockLlmClient([
+      [
+        {
+          type: "tool_use",
+          id: "read-readme",
+          name: "read",
+          input: { path: "README.md" },
+        },
+        { type: "message_end", stopReason: "tool_use", inputTokens: 8, outputTokens: 6 },
+      ],
+      [
+        { type: "text_delta", text: "无法直接访问 README.md，因此无法提取 H1。" },
+        { type: "message_end", stopReason: "end_turn", inputTokens: 8, outputTokens: 6 },
+      ],
+      [
+        { type: "text_delta", text: "Friday" },
+        { type: "message_end", stopReason: "end_turn", inputTokens: 8, outputTokens: 6 },
+      ],
+    ]);
+
+    const runtime = createFridayAgentRuntime({
+      db,
+      llmClient,
+      model: "test-model",
+      providerId: "test-provider",
+      systemPromptBuilder: () => "STANDARD_PROMPT",
+      tools: createFridayAgentFileTools({ workspaceRoot }),
+      eventEmitter: createFridayAgentEventEmitter(),
+      idGenerator,
+      nowIso: () => NOW,
+      workdir: workspaceRoot,
+    });
+
+    try {
+      const result = await runtime.executeRun({
+        task: "Call the read tool with path README.md from the current workspace root, then answer with the top H1 heading only.",
+      });
+
+      expect(result.status).toBe("completed");
+      expect(result.toolCallCount).toBe(1);
+      expect(result.response).toBe("Friday");
+    } finally {
+      rmSync(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
   it("re-prompts latest news answers until dates and URLs are included", async () => {
     let callCount = 0;
     const llmClient: FridayAgentLlmClient = {

--- a/test/unit/agent/runtime/friday-agent-runtime.test.ts
+++ b/test/unit/agent/runtime/friday-agent-runtime.test.ts
@@ -2111,6 +2111,117 @@ describe("FridayAgentRuntime", () => {
     expect(result.response).toContain("AGENT_OUTPUT_CLOSURE_ERROR");
   });
 
+  it("blocks non-read detours for explicit local workspace read-tool tasks", async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "friday-agent-runtime-read-detour-"));
+    writeFileSync(join(workspaceRoot, "README.md"), "# Friday\n\nLocal fixture.\n", "utf8");
+    const webFetchSpy = vi.fn();
+    const llmClient = createMockLlmClient([
+      [
+        {
+          type: "tool_use",
+          id: "web-fetch-readme",
+          name: "web_fetch",
+          input: { url: "README.md" },
+        },
+        { type: "message_end", stopReason: "tool_use", inputTokens: 8, outputTokens: 6 },
+      ],
+      [
+        {
+          type: "tool_use",
+          id: "read-readme",
+          name: "read",
+          input: { path: "README.md" },
+        },
+        { type: "message_end", stopReason: "tool_use", inputTokens: 8, outputTokens: 6 },
+      ],
+      [
+        { type: "text_delta", text: "Friday" },
+        { type: "message_end", stopReason: "end_turn", inputTokens: 8, outputTokens: 6 },
+      ],
+    ]);
+
+    const runtime = createFridayAgentRuntime({
+      db,
+      llmClient,
+      model: "test-model",
+      providerId: "test-provider",
+      systemPromptBuilder: () => "STANDARD_PROMPT",
+      tools: [createSuccessfulWebFetchTool(webFetchSpy), ...createFridayAgentFileTools({ workspaceRoot })],
+      eventEmitter: createFridayAgentEventEmitter(),
+      idGenerator,
+      nowIso: () => NOW,
+      workdir: workspaceRoot,
+    });
+
+    try {
+      const result = await runtime.executeRun({
+        task: "Call the read tool with path README.md from the current workspace root, then answer with the top H1 heading only.",
+      });
+
+      expect(result.status).toBe("completed");
+      expect(result.toolCallCount).toBe(2);
+      expect(result.response).toBe("Friday");
+      expect(webFetchSpy).not.toHaveBeenCalled();
+    } finally {
+      rmSync(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks read calls that target the wrong local workspace path", async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "friday-agent-runtime-read-wrong-path-"));
+    writeFileSync(join(workspaceRoot, "README.md"), "# Friday\n\nLocal fixture.\n", "utf8");
+    writeFileSync(join(workspaceRoot, "NOTES.md"), "# Wrong\n", "utf8");
+    const llmClient = createMockLlmClient([
+      [
+        {
+          type: "tool_use",
+          id: "read-notes",
+          name: "read",
+          input: { path: "NOTES.md" },
+        },
+        { type: "message_end", stopReason: "tool_use", inputTokens: 8, outputTokens: 6 },
+      ],
+      [
+        {
+          type: "tool_use",
+          id: "read-readme",
+          name: "read",
+          input: { path: "README.md" },
+        },
+        { type: "message_end", stopReason: "tool_use", inputTokens: 8, outputTokens: 6 },
+      ],
+      [
+        { type: "text_delta", text: "Friday" },
+        { type: "message_end", stopReason: "end_turn", inputTokens: 8, outputTokens: 6 },
+      ],
+    ]);
+
+    const runtime = createFridayAgentRuntime({
+      db,
+      llmClient,
+      model: "test-model",
+      providerId: "test-provider",
+      systemPromptBuilder: () => "STANDARD_PROMPT",
+      tools: createFridayAgentFileTools({ workspaceRoot }),
+      eventEmitter: createFridayAgentEventEmitter(),
+      idGenerator,
+      nowIso: () => NOW,
+      workdir: workspaceRoot,
+    });
+
+    try {
+      const result = await runtime.executeRun({
+        task: "Call the read tool with path README.md from the current workspace root, then answer with the top H1 heading only.",
+      });
+
+      expect(result.status).toBe("completed");
+      expect(result.toolCallCount).toBe(2);
+      expect(result.response).toBe("Friday");
+    } finally {
+      rmSync(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
   it("does not count capabilities as local workspace file read evidence", async () => {
     const llmClient = createMockLlmClient([
       [

--- a/test/unit/agent/runtime/friday-agent-runtime.test.ts
+++ b/test/unit/agent/runtime/friday-agent-runtime.test.ts
@@ -892,6 +892,48 @@ describe("FridayAgentRuntime", () => {
     expect(capturedToolNames).not.toContain("desktop");
   });
 
+  it("exposes only read for explicit workspace read-tool tasks", async () => {
+    const capturedToolNamesByTurn: string[][] = [];
+    const llmClient: FridayAgentLlmClient = {
+      async *stream(params) {
+        capturedToolNamesByTurn.push(params.tools.map((tool) => tool.name).sort());
+        yield { type: "text_delta", text: "I cannot access README.md directly." };
+        yield { type: "message_end", stopReason: "end_turn", inputTokens: 8, outputTokens: 6 };
+      },
+    };
+
+    const runtime = createFridayAgentRuntime({
+      db,
+      llmClient,
+      model: "test-model",
+      providerId: "test-provider",
+      systemPromptBuilder: () => "STANDARD_PROMPT",
+      tools: [
+        createNamedTool("read"),
+        createNamedTool("write"),
+        createNamedTool("edit"),
+        createExecTool(),
+        createSuccessfulWebSearchTool(),
+        createSuccessfulWebFetchTool(),
+        createNamedTool("skills_list"),
+        createNamedTool("capabilities"),
+      ],
+      eventEmitter: createFridayAgentEventEmitter(),
+      idGenerator,
+      nowIso: () => NOW,
+    });
+
+    const result = await runtime.executeRun({
+      task: "Call the `read` tool with path `README.md` from the current workspace root, then answer with the top H1 heading only. Do not use web search for this workspace file.",
+    });
+
+    expect(result.status).toBe("failed");
+    expect(capturedToolNamesByTurn.length).toBeGreaterThan(0);
+    for (const toolNames of capturedToolNamesByTurn) {
+      expect(toolNames).toEqual(["read"]);
+    }
+  });
+
   it("routes channel full-agent workflow follow-ups to workflow tools", async () => {
     let capturedToolNames: string[] = [];
     let capturedPromptContext: FridayAgentSystemPromptContext | undefined;

--- a/test/unit/agent/runtime/friday-agent-system-prompt-builder.test.ts
+++ b/test/unit/agent/runtime/friday-agent-system-prompt-builder.test.ts
@@ -98,6 +98,18 @@ describe("buildFridayAgentSystemPrompt", () => {
     expect(prompt).not.toContain("File read/write/edit across the entire filesystem");
   });
 
+  it("routes local workspace file reads to the read tool before web lookup", () => {
+    const prompt = buildFridayAgentSystemPrompt({
+      toolNames: ["read", "web_search", "web_fetch"],
+      modelIdentity: "test-model (provider: test)",
+      version: "0.0.0-test",
+    });
+
+    expect(prompt).toContain("Local workspace files, repository paths, or filesystem reads");
+    expect(prompt).toContain("use read first for file contents");
+    expect(prompt).toContain("do not use web_search or web_fetch for workspace files");
+  });
+
   it("documents supervised autonomy and destructive approval gates", () => {
     const prompt = buildFridayAgentSystemPrompt({
       toolNames: ["exec", "read", "write", "edit", "system"],

--- a/test/unit/agent/runtime/friday-agent-tool-routing.test.ts
+++ b/test/unit/agent/runtime/friday-agent-tool-routing.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import type { FridayAgentToolDefinition } from "../../../../src/agent/model/friday-agent.types.js";
+import { resolveFridayAgentToolRouting } from "../../../../src/agent/runtime/friday-agent-tool-routing.js";
+
+function tool(name: string): FridayAgentToolDefinition {
+  return {
+    name,
+    description: `${name} test tool`,
+    parameters: { type: "object", properties: {} },
+    execute: async () => ({ content: "ok" }),
+  };
+}
+
+const tools = [
+  "read",
+  "write",
+  "edit",
+  "exec",
+  "web_fetch",
+  "web_search",
+  "skills_list",
+  "skill_run",
+  "task_status",
+  "capabilities",
+].map(tool);
+
+describe("resolveFridayAgentToolRouting", () => {
+  it("routes explicit workspace read-tool tasks to code tools before web keyword matching", () => {
+    const routing = resolveFridayAgentToolRouting({
+      task: "Call the `read` tool with path `README.md` from the current workspace root, then answer with the top H1 heading only. Do not use web search for this workspace file.",
+      tools,
+    });
+
+    expect(routing.profile).toBe("code");
+    expect(routing.selectedToolPacks).toEqual(["code"]);
+    expect(routing.selectedToolNames).toEqual(["read"]);
+    expect(routing.deferredToolNames).toEqual([]);
+  });
+
+  it("keeps ordinary web lookup tasks on the web profile", () => {
+    const routing = resolveFridayAgentToolRouting({
+      task: "Search the latest TypeScript release notes and include source URLs.",
+      tools,
+    });
+
+    expect(routing.profile).toBe("web");
+    expect(routing.selectedToolPacks).toEqual(["web"]);
+    expect(routing.selectedToolNames).toContain("web_search");
+    expect(routing.selectedToolNames).not.toContain("read");
+  });
+});

--- a/test/unit/hub/friday-hub-bootstrap-env.test.ts
+++ b/test/unit/hub/friday-hub-bootstrap-env.test.ts
@@ -72,26 +72,6 @@ describe("resolveFridayHubConfig", () => {
     expect(resolved.stateDir).toBe("/from-env");
   });
 
-  it("keeps workspaceRoot separate from stateDir when FRIDAY_WORKSPACE_ROOT is set", () => {
-    const resolved = resolveFridayHubConfig(
-      makeConfig(),
-      {
-        FRIDAY_STATE_DIR: "/tmp/friday-state",
-        FRIDAY_WORKSPACE_ROOT: "/repo/checkout",
-      },
-    );
-    expect(resolved.stateDir).toBe("/tmp/friday-state");
-    expect(resolved.workspaceRoot).toBe("/repo/checkout");
-  });
-
-  it("uses explicit workspaceRoot over env", () => {
-    const resolved = resolveFridayHubConfig(
-      makeConfig({ workspaceRoot: "/explicit-workspace" }),
-      { FRIDAY_WORKSPACE_ROOT: "/env-workspace" },
-    );
-    expect(resolved.workspaceRoot).toBe("/explicit-workspace");
-  });
-
   // ─── Skill dirs ───
 
   it("defaults skillDirs to ['skills', 'managed-skills']", () => {
@@ -153,6 +133,26 @@ describe("resolveFridayHubConfig", () => {
     expect(resolved.tokenSecret).toBe("env-secret");
     expect(resolved.tokenSecretSource).toBe("env");
     expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("keeps workspaceRoot separate from stateDir when FRIDAY_WORKSPACE_ROOT is set", () => {
+    const resolved = resolveFridayHubConfig(
+      makeConfig(),
+      {
+        FRIDAY_STATE_DIR: "/tmp/friday-state",
+        FRIDAY_WORKSPACE_ROOT: "/repo/checkout",
+      },
+    );
+    expect(resolved.stateDir).toBe("/tmp/friday-state");
+    expect(resolved.workspaceRoot).toBe("/repo/checkout");
+  });
+
+  it("uses explicit workspaceRoot over env", () => {
+    const resolved = resolveFridayHubConfig(
+      makeConfig({ workspaceRoot: "/explicit-workspace" }),
+      { FRIDAY_WORKSPACE_ROOT: "/env-workspace" },
+    );
+    expect(resolved.workspaceRoot).toBe("/explicit-workspace");
   });
 
   it("defaults allowPrivateNetwork=false in dev mode", () => {

--- a/test/unit/hub/friday-hub-bootstrap-env.test.ts
+++ b/test/unit/hub/friday-hub-bootstrap-env.test.ts
@@ -72,6 +72,26 @@ describe("resolveFridayHubConfig", () => {
     expect(resolved.stateDir).toBe("/from-env");
   });
 
+  it("keeps workspaceRoot separate from stateDir when FRIDAY_WORKSPACE_ROOT is set", () => {
+    const resolved = resolveFridayHubConfig(
+      makeConfig(),
+      {
+        FRIDAY_STATE_DIR: "/tmp/friday-state",
+        FRIDAY_WORKSPACE_ROOT: "/repo/checkout",
+      },
+    );
+    expect(resolved.stateDir).toBe("/tmp/friday-state");
+    expect(resolved.workspaceRoot).toBe("/repo/checkout");
+  });
+
+  it("uses explicit workspaceRoot over env", () => {
+    const resolved = resolveFridayHubConfig(
+      makeConfig({ workspaceRoot: "/explicit-workspace" }),
+      { FRIDAY_WORKSPACE_ROOT: "/env-workspace" },
+    );
+    expect(resolved.workspaceRoot).toBe("/explicit-workspace");
+  });
+
   // ─── Skill dirs ───
 
   it("defaults skillDirs to ['skills', 'managed-skills']", () => {

--- a/test/unit/hub/friday-hub-runtime-identity.test.ts
+++ b/test/unit/hub/friday-hub-runtime-identity.test.ts
@@ -58,4 +58,50 @@ describe("Friday hub runtime identity", () => {
     expect(result.currentConfig.runtimeStateDir).toBe(stateDir);
     expect(result.currentConfig.launchCwd).toBe(process.cwd());
   });
+
+  it("surfaces FRIDAY_WORKSPACE_ROOT separately from FRIDAY_STATE_DIR", async () => {
+    const originalWorkspaceRoot = process.env.FRIDAY_WORKSPACE_ROOT;
+    const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "friday-runtime-workspace-"));
+    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "friday-runtime-state-"));
+    bundledSkillsDir = path.join(stateDir, "skills-empty");
+    managedSkillsDir = path.join(stateDir, "managed-skills-empty");
+    await fs.mkdir(bundledSkillsDir, { recursive: true });
+    await fs.mkdir(managedSkillsDir, { recursive: true });
+    await fs.writeFile(path.join(workspaceRoot, "README.md"), "# Friday\n", "utf8");
+
+    try {
+      process.env.FRIDAY_WORKSPACE_ROOT = workspaceRoot;
+      hub = await createFridayHub({
+        skillDirs: [bundledSkillsDir, managedSkillsDir],
+        stateDir,
+      });
+      const route = hub.apiRuntime.routes.getRoutes().find((entry) => entry.operationId === "config.get");
+      expect(route).toBeDefined();
+
+      const result = await route!.handler({
+        requestId: "req-runtime-config-workspace-root",
+        receivedAt: "2026-05-12T00:00:00.000Z",
+        params: {},
+        query: {},
+        body: null,
+        headers: {},
+        principal: { userId: "admin-001", role: "admin" } as never,
+      }) as {
+        currentConfig: {
+          runtimeStateDir?: string;
+          workspaceRoot?: string;
+        };
+      };
+
+      expect(result.currentConfig.runtimeStateDir).toBe(stateDir);
+      expect(result.currentConfig.workspaceRoot).toBe(workspaceRoot);
+    } finally {
+      if (originalWorkspaceRoot === undefined) {
+        delete process.env.FRIDAY_WORKSPACE_ROOT;
+      } else {
+        process.env.FRIDAY_WORKSPACE_ROOT = originalWorkspaceRoot;
+      }
+      await fs.rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
 });

--- a/test/unit/ops/real-green-gate-result.test.ts
+++ b/test/unit/ops/real-green-gate-result.test.ts
@@ -5,6 +5,7 @@ import {
   REAL_GREEN_GATE_RESULT_SCHEMA_VERSION,
   REAL_GREEN_GATE_RESULT_STATUSES,
   buildBlockedByEnvResult,
+  buildErroredResult,
   buildRealGreenGateResult,
   validateRealGreenGateResult,
 } from "../../../scripts/ops/lib/real-green-gate-result.mjs";
@@ -22,12 +23,18 @@ function passingSummary() {
     },
     smoke: {
       resultCounts: { passed: 4 },
+      providerAttemptCount: 0,
+      browserProbeAttemptCount: 0,
     },
     dailyCore: {
       resultCounts: { passed: 14 },
+      providerAttemptCount: 6,
+      browserProbeAttemptCount: 3,
     },
     publicSurface: {
       resultCounts: { passed: 29 },
+      providerAttemptCount: 0,
+      browserProbeAttemptCount: 18,
     },
     gate: {
       passed: true,
@@ -81,7 +88,7 @@ describe("REAL_GREEN_GATE_RESULT constants", () => {
 });
 
 describe("buildRealGreenGateResult", () => {
-  it("returns status=passed with full evidence kinds when the gate passed", () => {
+  it("returns status=passed with only observed evidence kinds when the gate passed", () => {
     const result = buildRealGreenGateResult({
       summary: passingSummary(),
       commitSha: SHA_A,
@@ -99,6 +106,28 @@ describe("buildRealGreenGateResult", () => {
       scenarios_run: 47,
       scenarios_total: 47,
       scenarios_passed: 47,
+    });
+  });
+
+  it("does not claim provider or browser evidence when passed suites did not observe those attempts", () => {
+    const summary = {
+      ...passingSummary(),
+      smoke: { resultCounts: { passed: 4 }, providerAttemptCount: 0, browserProbeAttemptCount: 0 },
+      dailyCore: { resultCounts: { passed: 3 }, providerAttemptCount: 0, browserProbeAttemptCount: 0 },
+      publicSurface: null,
+    };
+    const result = buildRealGreenGateResult({
+      summary,
+      commitSha: SHA_A,
+      refName: "main",
+      evaluatedAt: "2026-05-10T07:00:00.000Z",
+    });
+    expect(result).toMatchObject({
+      status: "passed",
+      evidence_kinds_observed: ["real-runtime"],
+      scenarios_run: 7,
+      scenarios_total: 7,
+      scenarios_passed: 7,
     });
   });
 
@@ -181,6 +210,29 @@ describe("buildBlockedByEnvResult", () => {
       "env_var_missing:FRIDAY_BASE_URL",
       "env_var_missing:FRIDAY_ACCESS_TOKEN",
     ]);
+  });
+});
+
+describe("buildErroredResult", () => {
+  it("emits status=errored with zero scenarios and empty evidence", () => {
+    const result = buildErroredResult({
+      commitSha: SHA_A,
+      refName: "main",
+      evaluatedAt: "2026-05-10T07:00:00.000Z",
+      blockedReasons: ["self_hosted_runtime_error"],
+    });
+    expect(result).toEqual({
+      schema_version: 1,
+      status: "errored",
+      commit_sha: SHA_A,
+      ref_name: "main",
+      evaluated_at: "2026-05-10T07:00:00.000Z",
+      evidence_kinds_observed: [],
+      blocked_reasons: ["self_hosted_runtime_error"],
+      scenarios_run: 0,
+      scenarios_total: 0,
+      scenarios_passed: 0,
+    });
   });
 });
 

--- a/test/unit/ops/run-real-green-gate-self-hosted.test.ts
+++ b/test/unit/ops/run-real-green-gate-self-hosted.test.ts
@@ -23,7 +23,7 @@ describe("run-real-green-gate-self-hosted", () => {
     const repoRoot = join(tempRoot, "repo-without-dist");
     const reportRoot = join(tempRoot, "report");
     const scriptPath = join(process.cwd(), "scripts/ops/run-real-green-gate-self-hosted.mjs");
-    const sha = "718c23e97222a9eb34a6bb2e8244e51fd5b04c44";
+    const sha = "test-self-hosted-rgg-sha";
 
     expect(() =>
       execFileSync(process.execPath, [

--- a/test/unit/ops/run-real-green-gate-self-hosted.test.ts
+++ b/test/unit/ops/run-real-green-gate-self-hosted.test.ts
@@ -5,7 +5,11 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { REAL_GREEN_GATE_RESULT_FILENAME } from "../../../scripts/ops/lib/real-green-gate-result.mjs";
-import { completeSelfHostedSetup } from "../../../scripts/ops/run-real-green-gate-self-hosted.mjs";
+import {
+  completeSelfHostedSetup,
+  createGateEnv,
+  createRuntimeEnv,
+} from "../../../scripts/ops/run-real-green-gate-self-hosted.mjs";
 
 describe("run-real-green-gate-self-hosted", () => {
   let tempRoot: string | null = null;
@@ -93,6 +97,36 @@ describe("run-real-green-gate-self-hosted", () => {
       completedSteps: ["welcome", "security", "network", "skills"],
       skippedSteps: ["communication", "provider", "channels"],
     });
+  });
+
+  it("passes an explicit workspace root while keeping runtime state isolated", () => {
+    const paths = {
+      stateDir: "/tmp/friday-rgg-runtime/state",
+    };
+    const workspaceRoot = "/home/runner/work/Friday/Friday";
+
+    const runtimeEnv = createRuntimeEnv(
+      {},
+      paths,
+      3141,
+      "passphrase-placeholder",
+      "token-placeholder",
+      workspaceRoot,
+    );
+    const gateEnv = createGateEnv(
+      {},
+      paths,
+      "http://127.0.0.1:3141",
+      "passphrase-placeholder",
+      "token-placeholder",
+      workspaceRoot,
+    );
+
+    expect(runtimeEnv.FRIDAY_STATE_DIR).toBe(paths.stateDir);
+    expect(runtimeEnv.FRIDAY_WORKSPACE_ROOT).toBe(workspaceRoot);
+    expect(gateEnv.FRIDAY_STATE_DIR).toBe(paths.stateDir);
+    expect(gateEnv.FRIDAY_WORKSPACE_ROOT).toBe(workspaceRoot);
+    expect(gateEnv.FRIDAY_BASE_URL).toBe("http://127.0.0.1:3141");
   });
 
   it("keeps build failure inside the self-hosted workflow step so an errored artifact is uploaded", () => {

--- a/test/unit/ops/run-real-green-gate-self-hosted.test.ts
+++ b/test/unit/ops/run-real-green-gate-self-hosted.test.ts
@@ -1,0 +1,106 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { REAL_GREEN_GATE_RESULT_FILENAME } from "../../../scripts/ops/lib/real-green-gate-result.mjs";
+import { completeSelfHostedSetup } from "../../../scripts/ops/run-real-green-gate-self-hosted.mjs";
+
+describe("run-real-green-gate-self-hosted", () => {
+  let tempRoot: string | null = null;
+
+  afterEach(() => {
+    if (tempRoot) {
+      rmSync(tempRoot, { recursive: true, force: true });
+      tempRoot = null;
+    }
+    vi.unstubAllGlobals();
+  });
+
+  it("writes an errored result artifact when the self-hosted runtime cannot start", () => {
+    tempRoot = mkdtempSync(join(tmpdir(), "friday-rgg-self-hosted-test-"));
+    const repoRoot = join(tempRoot, "repo-without-dist");
+    const reportRoot = join(tempRoot, "report");
+    const scriptPath = join(process.cwd(), "scripts/ops/run-real-green-gate-self-hosted.mjs");
+    const sha = "718c23e97222a9eb34a6bb2e8244e51fd5b04c44";
+
+    expect(() =>
+      execFileSync(process.execPath, [
+        scriptPath,
+        "--repo-root",
+        repoRoot,
+        "--report-root",
+        reportRoot,
+      ], {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          GITHUB_SHA: sha,
+          GITHUB_REF_NAME: "codex/test-self-hosted-rgg",
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      }),
+    ).toThrow();
+
+    const artifact = JSON.parse(readFileSync(join(reportRoot, REAL_GREEN_GATE_RESULT_FILENAME), "utf8"));
+    expect(artifact).toMatchObject({
+      status: "errored",
+      commit_sha: sha,
+      ref_name: "codex/test-self-hosted-rgg",
+      evidence_kinds_observed: [],
+      blocked_reasons: ["self_hosted_runtime_error"],
+      scenarios_run: 0,
+      scenarios_total: 0,
+      scenarios_passed: 0,
+    });
+    expect(readFileSync(join(reportRoot, "self-hosted-runtime-error.log"), "utf8")).toContain(
+      "dist/cli/friday-cli.js is missing",
+    );
+  });
+
+  it("logs in and completes setup before running the gate without claiming provider/channel setup", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    vi.stubGlobal("fetch", vi.fn(async (url: string, init?: RequestInit) => {
+      calls.push({ url, init });
+      if (url.endsWith("/v1/auth/login")) {
+        return new Response(JSON.stringify({
+          ok: true,
+          data: { accessToken: "test-access-token" },
+        }), { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+      if (url.endsWith("/v1/setup/complete")) {
+        return new Response(JSON.stringify({
+          ok: true,
+          data: { setupCompletedAt: "2026-05-12T00:00:00.000Z" },
+        }), { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+      return new Response(JSON.stringify({ ok: false }), { status: 404 });
+    }));
+
+    await completeSelfHostedSetup("http://127.0.0.1:31337", "local-passphrase");
+
+    expect(calls.map((call) => call.url)).toEqual([
+      "http://127.0.0.1:31337/v1/auth/login",
+      "http://127.0.0.1:31337/v1/setup/complete",
+    ]);
+    const setupCall = calls[1];
+    expect(setupCall.init?.headers).toMatchObject({
+      Authorization: "Bearer test-access-token",
+      "Content-Type": "application/json",
+    });
+    expect(JSON.parse(String(setupCall.init?.body))).toEqual({
+      completedSteps: ["welcome", "security", "network", "skills"],
+      skippedSteps: ["communication", "provider", "channels"],
+    });
+  });
+
+  it("keeps build failure inside the self-hosted workflow step so an errored artifact is uploaded", () => {
+    const workflow = readFileSync(join(process.cwd(), ".github/workflows/real-green-gate.yml"), "utf8");
+
+    expect(workflow).not.toContain("name: Build self-hosted Friday runtime");
+    expect(workflow).toContain("self_hosted_runtime_build_failed");
+    expect(workflow).toContain("buildErroredResult");
+    expect(workflow).toContain("node scripts/ops/run-real-green-gate-self-hosted.mjs");
+  });
+});

--- a/test/unit/ops/run-real-green-gate.test.ts
+++ b/test/unit/ops/run-real-green-gate.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { summarizeRun } from "../../../scripts/ops/run-real-green-gate.mjs";
+
+describe("run-real-green-gate helpers", () => {
+  it("preserves provider and browser attempt counters in suite summaries", () => {
+    expect(summarizeRun({
+      runId: "run-1",
+      suite: "daily",
+      reportRoot: "/tmp/report",
+      resultCounts: { passed: 2 },
+      failureClassCounts: {},
+      defectBucketCounts: {},
+      providerLanes: {},
+      providerAttemptCount: 2,
+      browserProbeAttemptCount: 1,
+    })).toMatchObject({
+      providerAttemptCount: 2,
+      browserProbeAttemptCount: 1,
+    });
+  });
+});

--- a/test/unit/ops/run-real-green-gate.test.ts
+++ b/test/unit/ops/run-real-green-gate.test.ts
@@ -1,6 +1,7 @@
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
-import { summarizeRun } from "../../../scripts/ops/run-real-green-gate.mjs";
+import { resolveGateSuiteReportRoot, summarizeRun } from "../../../scripts/ops/run-real-green-gate.mjs";
 
 describe("run-real-green-gate helpers", () => {
   it("preserves provider and browser attempt counters in suite summaries", () => {
@@ -18,5 +19,11 @@ describe("run-real-green-gate helpers", () => {
       providerAttemptCount: 2,
       browserProbeAttemptCount: 1,
     });
+  });
+
+  it("keeps suite detail reports inside the RGG artifact root", () => {
+    expect(resolveGateSuiteReportRoot("/tmp/rgg", "public-surface")).toBe(
+      join("/tmp/rgg", "suites", "public-surface"),
+    );
   });
 });

--- a/test/unit/validation/real-world-executors.test.ts
+++ b/test/unit/validation/real-world-executors.test.ts
@@ -1,0 +1,121 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { executeScenario } from "../../../validation/real-world/lib/executors.mjs";
+
+describe("real-world executors", () => {
+  let tempRoot: string | null = null;
+
+  afterEach(() => {
+    if (tempRoot) {
+      rmSync(tempRoot, { recursive: true, force: true });
+      tempRoot = null;
+    }
+  });
+
+  function createAgentScenarioClient({ artifactDir }: { artifactDir?: string }) {
+    return {
+      async startAgentRun() {
+        return { data: { runId: "agent-run-1", toolCallCount: artifactDir ? 1 : 0 } };
+      },
+      async getAgentRun() {
+        return {
+          data: {
+            run: {
+              status: "completed",
+              responseText: "Friday",
+              artifactDir,
+              actualExecution: {
+                actualProviderId: "test-provider",
+                actualModel: "test-model",
+                turns: [],
+              },
+            },
+          },
+        };
+      },
+    };
+  }
+
+  function createFileRoundtripScenario() {
+    return {
+      id: "l4-file-tool-roundtrip",
+      entrySurface: "/v1/agent/runs",
+      expectedEvidence: [],
+      severityOnFailure: "P1",
+      realWorldPrompt: "Call the read tool with path README.md, then answer with the top H1 heading only.",
+      execution: {
+        kind: "agent_run",
+        expectWorkspaceFileTopH1: "README.md",
+        expectToolCallCountMin: 1,
+        constraints: { readOnly: true },
+      },
+    };
+  }
+
+  const lane = {
+    laneKey: "default",
+    providerId: "test-provider",
+    model: "test-model",
+  };
+
+  it("fails file roundtrip when response has the heading but no matching read tool evidence", async () => {
+    const artifact = await executeScenario({
+      runId: "validation-run-1",
+      suite: "smoke",
+      scenario: createFileRoundtripScenario(),
+      lane,
+      client: createAgentScenarioClient({ artifactDir: undefined }),
+      envTruth: {},
+      reportRoot: tmpdir(),
+      uiBaseUrl: "http://127.0.0.1:3141",
+    });
+
+    expect(artifact.result).toBe("failed");
+    expect(artifact.failureClass).toBe("tool_bridge");
+    expect(artifact.notes).toContain(
+      'expected successful read tool evidence for README.md containing workspace top heading "Friday"',
+    );
+  });
+
+  it("passes file roundtrip only when matching read tool evidence contains the expected heading", async () => {
+    tempRoot = mkdtempSync(join(tmpdir(), "friday-real-world-executor-"));
+    const artifactDir = join(tempRoot, ".friday", "agent-runs", "agent-run-1");
+    mkdirSync(artifactDir, { recursive: true });
+    writeFileSync(
+      join(artifactDir, "tool-calls.json"),
+      JSON.stringify([
+        {
+          toolName: "read",
+          args: { path: "README.md" },
+          result: { isError: false, content: "# Friday\n\nLocal fixture.\n" },
+        },
+      ]),
+      "utf8",
+    );
+
+    const artifact = await executeScenario({
+      runId: "validation-run-1",
+      suite: "smoke",
+      scenario: createFileRoundtripScenario(),
+      lane,
+      client: createAgentScenarioClient({ artifactDir }),
+      envTruth: {},
+      reportRoot: tempRoot,
+      uiBaseUrl: "http://127.0.0.1:3141",
+    });
+
+    expect(artifact.result).toBe("passed");
+    expect(artifact.raw.toolEvidence).toEqual([
+      expect.objectContaining({
+        toolName: "read",
+        isError: false,
+        relativePath: "README.md",
+        matchesExpectedPath: true,
+        matchesExpectedHeading: true,
+      }),
+    ]);
+  });
+});

--- a/test/unit/validation/real-world-reporting.test.ts
+++ b/test/unit/validation/real-world-reporting.test.ts
@@ -1,0 +1,66 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { writeReports } from "../../../validation/real-world/lib/reporting.mjs";
+
+describe("real-world reporting", () => {
+  let tempRoot: string | null = null;
+
+  afterEach(() => {
+    if (tempRoot) {
+      rmSync(tempRoot, { recursive: true, force: true });
+      tempRoot = null;
+    }
+  });
+
+  it("summarizes provider and browser probe attempts for RGG evidence-kind derivation", () => {
+    tempRoot = mkdtempSync(join(tmpdir(), "friday-real-world-reporting-"));
+    const reportRoot = join(tempRoot, "report");
+
+    const summary = writeReports({
+      repoRoot: tempRoot,
+      reportRoot,
+      runId: "reporting-test",
+      suite: "daily",
+      scenarios: [
+        { id: "provider-scenario", layer: "L3" },
+        { id: "browser-scenario", layer: "L1" },
+      ],
+      artifacts: [
+        {
+          scenarioId: "provider-scenario",
+          lane: "default",
+          result: "passed",
+          metrics: { durationMs: 12 },
+        },
+        {
+          scenarioId: "browser-scenario",
+          lane: "none",
+          result: "passed",
+          metrics: { uiRequestCount: 3 },
+        },
+      ],
+      envTruth: {
+        baseUrl: "http://127.0.0.1:3141",
+        uiBaseUrl: "http://127.0.0.1:3141",
+        collectedAt: "2026-05-12T00:00:00.000Z",
+        publicChecks: { health: { ok: true, status: 200 } },
+        auth: { ok: true, source: "local_passphrase_login", user: { id: "user" } },
+        setupStatus: { needsSetup: false },
+        userProfile: { profileType: "local", onboardedAt: "2026-05-12T00:00:00.000Z" },
+        providerLanes: { default: { providerName: "Provider", model: "model" }, fallback: null },
+        derived: { setupUserProfileTruthMismatch: false },
+      },
+      options: {},
+    });
+
+    expect(summary.providerAttemptCount).toBe(1);
+    expect(summary.browserProbeAttemptCount).toBe(1);
+
+    const written = JSON.parse(readFileSync(join(reportRoot, "summary.json"), "utf8"));
+    expect(written.providerAttemptCount).toBe(1);
+    expect(written.browserProbeAttemptCount).toBe(1);
+  });
+});

--- a/test/unit/validation/real-world-reporting.test.ts
+++ b/test/unit/validation/real-world-reporting.test.ts
@@ -115,4 +115,67 @@ describe("real-world reporting", () => {
     expect(JSON.stringify(written)).not.toContain("runtime-access-token");
     expect(JSON.stringify(written)).not.toContain("runtime-refresh-token");
   });
+
+  it("writes sanitized tool evidence without raw file content or secrets", () => {
+    tempRoot = mkdtempSync(join(tmpdir(), "friday-real-world-reporting-"));
+    const reportRoot = join(tempRoot, "report");
+
+    writeReports({
+      repoRoot: tempRoot,
+      reportRoot,
+      runId: "reporting-tool-evidence-test",
+      suite: "smoke",
+      scenarios: [{ id: "l4-file-tool-roundtrip", layer: "L4" }],
+      artifacts: [
+        {
+          runId: "reporting-tool-evidence-test",
+          scenarioId: "l4-file-tool-roundtrip",
+          suite: "smoke",
+          lane: "default",
+          result: "passed",
+          metrics: {},
+          raw: {
+            runId: "agent-run-1",
+            toolEvidence: [
+              {
+                index: 0,
+                toolName: "read",
+                isError: false,
+                argKeys: ["path"],
+                relativePath: "README.md",
+                resultLengthChars: 36,
+                outputShape: "multiline-text",
+                matchesExpectedPath: true,
+                matchesExpectedHeading: true,
+              },
+            ],
+          },
+        },
+      ],
+      envTruth: {
+        baseUrl: "http://127.0.0.1:3141",
+        uiBaseUrl: "http://127.0.0.1:3141",
+        collectedAt: "2026-05-12T00:00:00.000Z",
+        publicChecks: { health: { ok: true, status: 200 } },
+        auth: { ok: true, source: "local_passphrase_login", user: { id: "user" } },
+        setupStatus: { needsSetup: false },
+        userProfile: { profileType: "local", onboardedAt: "2026-05-12T00:00:00.000Z" },
+        providerLanes: { default: { providerName: "Provider", model: "model" }, fallback: null },
+        derived: { setupUserProfileTruthMismatch: false },
+      },
+      options: {},
+    });
+
+    const evidencePath = join(reportRoot, "tool-evidence", "l4-file-tool-roundtrip", "agent-run-1.json");
+    const written = JSON.parse(readFileSync(evidencePath, "utf8"));
+    expect(written.evidence[0]).toMatchObject({
+      toolName: "read",
+      isError: false,
+      argKeys: ["path"],
+      relativePath: "README.md",
+      matchesExpectedHeading: true,
+    });
+    expect(JSON.stringify(written)).not.toContain("# Friday");
+    expect(JSON.stringify(written)).not.toContain("sk-");
+  });
 });

--- a/test/unit/validation/real-world-reporting.test.ts
+++ b/test/unit/validation/real-world-reporting.test.ts
@@ -94,11 +94,11 @@ describe("real-world reporting", () => {
         derived: { setupUserProfileTruthMismatch: false },
       },
       options: {
-        localPassphrase: "runtime-passphrase",
-        mintTokenSecret: "runtime-token-secret",
-        accessToken: "runtime-access-token",
+        localPassphrase: "runtime-passphrase", // pragma: allowlist secret
+        mintTokenSecret: "runtime-token-secret", // pragma: allowlist secret
+        accessToken: "runtime-access-token", // pragma: allowlist secret
         safeOption: "visible",
-        nested: { refreshToken: "runtime-refresh-token" },
+        nested: { refreshToken: "runtime-refresh-token" }, // pragma: allowlist secret
       },
     });
 

--- a/test/unit/validation/real-world-reporting.test.ts
+++ b/test/unit/validation/real-world-reporting.test.ts
@@ -63,4 +63,56 @@ describe("real-world reporting", () => {
     expect(written.providerAttemptCount).toBe(1);
     expect(written.browserProbeAttemptCount).toBe(1);
   });
+
+  it("redacts credential-shaped options from written summaries", () => {
+    tempRoot = mkdtempSync(join(tmpdir(), "friday-real-world-reporting-"));
+    const reportRoot = join(tempRoot, "report");
+
+    writeReports({
+      repoRoot: tempRoot,
+      reportRoot,
+      runId: "reporting-redaction-test",
+      suite: "daily",
+      scenarios: [{ id: "runtime-scenario", layer: "L0" }],
+      artifacts: [
+        {
+          scenarioId: "runtime-scenario",
+          lane: "none",
+          result: "passed",
+          metrics: {},
+        },
+      ],
+      envTruth: {
+        baseUrl: "http://127.0.0.1:3141",
+        uiBaseUrl: "http://127.0.0.1:3141",
+        collectedAt: "2026-05-12T00:00:00.000Z",
+        publicChecks: { health: { ok: true, status: 200 } },
+        auth: { ok: true, source: "local_passphrase_login", user: { id: "user" } },
+        setupStatus: { needsSetup: false },
+        userProfile: { profileType: "local", onboardedAt: "2026-05-12T00:00:00.000Z" },
+        providerLanes: { default: null, fallback: null },
+        derived: { setupUserProfileTruthMismatch: false },
+      },
+      options: {
+        localPassphrase: "runtime-passphrase",
+        mintTokenSecret: "runtime-token-secret",
+        accessToken: "runtime-access-token",
+        safeOption: "visible",
+        nested: { refreshToken: "runtime-refresh-token" },
+      },
+    });
+
+    const written = JSON.parse(readFileSync(join(reportRoot, "summary.json"), "utf8"));
+    expect(written.options).toMatchObject({
+      localPassphrase: "[redacted]",
+      mintTokenSecret: "[redacted]",
+      accessToken: "[redacted]",
+      safeOption: "visible",
+      nested: { refreshToken: "[redacted]" },
+    });
+    expect(JSON.stringify(written)).not.toContain("runtime-passphrase");
+    expect(JSON.stringify(written)).not.toContain("runtime-token-secret");
+    expect(JSON.stringify(written)).not.toContain("runtime-access-token");
+    expect(JSON.stringify(written)).not.toContain("runtime-refresh-token");
+  });
 });

--- a/validation/real-world/catalog/scenarios.mjs
+++ b/validation/real-world/catalog/scenarios.mjs
@@ -812,7 +812,7 @@ export const REAL_WORLD_SCENARIOS = [
     entrySurface: "/v1/agent/runs",
     routeFamily: "file tool",
     providerLane: "default_only",
-    realWorldPrompt: "Use the filesystem to read README.md from the current workspace root and answer with its top H1 heading only.",
+    realWorldPrompt: "Use the workspace file read tool to read README.md from the current workspace root and answer with its top H1 heading only. Do not use web search for this workspace file.",
     expectedEvidence: [
       "agent uses at least one tool call",
       "output reflects filesystem content rather than a guess",

--- a/validation/real-world/catalog/scenarios.mjs
+++ b/validation/real-world/catalog/scenarios.mjs
@@ -812,7 +812,7 @@ export const REAL_WORLD_SCENARIOS = [
     entrySurface: "/v1/agent/runs",
     routeFamily: "file tool",
     providerLane: "default_only",
-    realWorldPrompt: "Use the workspace file read tool to read README.md from the current workspace root and answer with its top H1 heading only. Do not use web search for this workspace file.",
+    realWorldPrompt: "Call the `read` tool with path `README.md` from the current workspace root, then answer with the top H1 heading only. Do not use web search for this workspace file.",
     expectedEvidence: [
       "agent uses at least one tool call",
       "output reflects filesystem content rather than a guess",

--- a/validation/real-world/catalog/scenarios.mjs
+++ b/validation/real-world/catalog/scenarios.mjs
@@ -830,6 +830,13 @@ export const REAL_WORLD_SCENARIOS = [
         forbiddenSubstrings: [
           "outside the allowed workspace root",
           "cannot access the file",
+          "cannot access",
+          "unable to access",
+          "unable to read",
+          "无法直接访问",
+          "无法读取",
+          "不能读取",
+          "无法访问",
         ],
       },
     },

--- a/validation/real-world/lib/executors.mjs
+++ b/validation/real-world/lib/executors.mjs
@@ -41,6 +41,75 @@ function extractTopWorkspaceHeading(markdownText) {
   return markdownHeading ? normalizeHeadingText(markdownHeading) : null;
 }
 
+async function readAgentToolCalls(runRecord) {
+  const artifactDir = typeof runRecord?.artifactDir === "string" ? runRecord.artifactDir.trim() : "";
+  if (!artifactDir) {
+    return [];
+  }
+  const toolCallsPath = path.join(artifactDir, "tool-calls.json");
+  try {
+    const raw = await fs.readFile(toolCallsPath, "utf8");
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function outputShapeForToolResult(content) {
+  if (typeof content !== "string") {
+    return typeof content;
+  }
+  const trimmed = content.trim();
+  if (trimmed.length === 0) {
+    return "empty";
+  }
+  if ((trimmed.startsWith("{") && trimmed.endsWith("}")) || (trimmed.startsWith("[") && trimmed.endsWith("]"))) {
+    return "json-like";
+  }
+  if (trimmed.includes("\n")) {
+    return "multiline-text";
+  }
+  return "text";
+}
+
+function sanitizeToolEvidence({ toolCalls, expectedHeading, expectedPath }) {
+  const expectedPathLower = typeof expectedPath === "string" ? expectedPath.toLowerCase() : "";
+  return toolCalls.map((call, index) => {
+    const argKeys = call?.args && typeof call.args === "object" ? Object.keys(call.args).sort() : [];
+    const rawPath = typeof call?.args?.path === "string" ? call.args.path : undefined;
+    const relativePath = call?.toolName === "read" && rawPath
+      ? rawPath.replace(/\\/g, "/").replace(/^\/+/, "")
+      : undefined;
+    const content = typeof call?.result?.content === "string" ? call.result.content : "";
+    const resultLengthChars = content.length;
+    const expectedHeadingHit = Boolean(
+      call?.toolName === "read"
+      && !call?.result?.isError
+      && expectedHeading
+      && content.includes(expectedHeading),
+    );
+    return {
+      index,
+      toolName: String(call?.toolName ?? "unknown"),
+      isError: Boolean(call?.result?.isError),
+      argKeys,
+      relativePath,
+      resultLengthChars,
+      outputShape: outputShapeForToolResult(content),
+      matchesExpectedPath: Boolean(
+        relativePath
+        && expectedPathLower
+        && (
+          relativePath.toLowerCase() === expectedPathLower
+          || relativePath.toLowerCase().endsWith(`/${expectedPathLower}`)
+        ),
+      ),
+      matchesExpectedHeading: expectedHeadingHit,
+    };
+  });
+}
+
 function getUrlPath(value) {
   if (typeof value !== "string" || value.length === 0) return "";
   try {
@@ -853,6 +922,8 @@ async function executeAgentRun({ artifact, client, scenario, lane, suite, attemp
     }
   }
 
+  const agentToolCalls = await readAgentToolCalls(lastRunRecord);
+
   artifact.raw = {
     ...(artifact.raw ?? {}),
     runId: lastData?.runId ?? null,
@@ -887,13 +958,33 @@ async function executeAgentRun({ artifact, client, scenario, lane, suite, attemp
         `workspace file ${relativeFilePath}`,
         `workspace top heading ${expectedHeading ?? "missing"}`,
       );
+      const toolEvidence = sanitizeToolEvidence({
+        toolCalls: agentToolCalls,
+        expectedHeading,
+        expectedPath: relativeFilePath,
+      });
+      const hasExpectedReadToolEvidence = toolEvidence.some((entry) =>
+        entry.toolName === "read"
+        && entry.isError === false
+        && entry.matchesExpectedPath === true
+        && entry.matchesExpectedHeading === true
+      );
       artifact.raw = {
         ...(artifact.raw ?? {}),
         workspaceFileOracle: {
           path: relativeFilePath,
           expectedHeading,
         },
+        toolEvidence,
       };
+      if (!hasExpectedReadToolEvidence) {
+        artifact.result = "failed";
+        artifact.failureClass = "tool_bridge";
+        artifact.notes = [
+          ...(artifact.notes ?? []),
+          `expected successful read tool evidence for ${relativeFilePath} containing workspace top heading ${JSON.stringify(expectedHeading)}`,
+        ];
+      }
       if (!expectedHeading || !normalizeHeadingText(outputText).includes(expectedHeading)) {
         artifact.result = "failed";
         artifact.failureClass = "tool_bridge";

--- a/validation/real-world/lib/executors.mjs
+++ b/validation/real-world/lib/executors.mjs
@@ -80,9 +80,38 @@ function isIgnorableUiRequestFailure(message) {
   return parsed.method === "GET" && parsed.pathname.startsWith("/v1/");
 }
 
-function isIgnorableUiConsoleError(message) {
+function parseUiResponseError(message) {
+  if (typeof message !== "string" || message.length === 0) return null;
+  const match = message.match(/^(\d{3})\s+(\S+)$/u);
+  if (!match) {
+    return null;
+  }
+  return {
+    status: Number.parseInt(match[1], 10),
+    url: match[2],
+    pathname: getUrlPath(match[2]),
+  };
+}
+
+function isIgnorableUiResponseError(message) {
+  const parsed = parseUiResponseError(message);
+  if (!parsed) {
+    return false;
+  }
+  return parsed.status === 400 && parsed.pathname === "/v1/providers/routing/explain";
+}
+
+function isIgnorableUiConsoleError(message, responseErrors = []) {
   if (typeof message !== "string" || message.length === 0) return false;
-  return /status of 401 \(Unauthorized\)/i.test(message);
+  if (/status of 401 \(Unauthorized\)/i.test(message)) {
+    return true;
+  }
+  if (/status of 400 \(Bad Request\)/i.test(message)) {
+    const hasResponseErrors = responseErrors.length > 0;
+    const allResponseErrorsIgnorable = responseErrors.every((entry) => isIgnorableUiResponseError(entry));
+    return hasResponseErrors && allResponseErrorsIgnorable;
+  }
+  return false;
 }
 
 function isRetryableUiProbeError(error) {
@@ -167,6 +196,32 @@ async function completeUiLoginIfNeeded({ page, client, execution, artifact, time
   throw new Error(
     "UI probe landed on /login but no real browser login credential was available. Provide localPassphrase or email/password for proof runs.",
   );
+}
+
+async function seedUiAuthStorageIfAvailable({ context, client, artifact }) {
+  const accessToken = typeof client?.accessToken === "string" ? client.accessToken.trim() : "";
+  const refreshToken = typeof client?.refreshToken === "string" ? client.refreshToken.trim() : "";
+  if (accessToken.length === 0) {
+    return false;
+  }
+  await context.addInitScript(
+    ({ accessToken: seededAccessToken, refreshToken: seededRefreshToken, user }) => {
+      window.localStorage.setItem("friday.auth.accessToken", seededAccessToken);
+      if (seededRefreshToken) {
+        window.localStorage.setItem("friday.auth.refreshToken", seededRefreshToken);
+      }
+      if (user) {
+        window.localStorage.setItem("friday.auth.user", JSON.stringify(user));
+      }
+    },
+    {
+      accessToken,
+      refreshToken,
+      user: client.user ?? null,
+    },
+  );
+  artifact.observedEvidence.push("seeded browser auth storage from validation login session");
+  return true;
 }
 
 async function settleAndCompleteUiLoginIfNeeded({ page, client, execution, artifact, timeoutMs }) {
@@ -438,6 +493,7 @@ async function executeUiProbe({ artifact, client, scenario, reportRoot, uiBaseUr
   const requestFailures = [];
   const reloadAbortedRequestFailures = [];
   const consoleErrors = [];
+  const responseErrors = [];
   const requestOrder = new WeakMap();
   let requestSequence = 0;
   let reloadAbortCutoff = null;
@@ -451,8 +507,11 @@ async function executeUiProbe({ artifact, client, scenario, reportRoot, uiBaseUr
     });
     const bootstrapStatus = bootstrapResponse.json?.data ?? bootstrapResponse.json ?? null;
     const authCapabilities = bootstrapStatus ?? {};
+    const hasBrowserAuthToken =
+      typeof client?.accessToken === "string" && client.accessToken.trim().length > 0;
     const hasBrowserLoginCredential =
-      (typeof client?.localPassphrase === "string" && client.localPassphrase.trim().length > 0)
+      hasBrowserAuthToken
+      || (typeof client?.localPassphrase === "string" && client.localPassphrase.trim().length > 0)
       || (
         typeof client?.email === "string" && client.email.trim().length > 0
         && typeof client?.password === "string" && client.password.trim().length > 0 // pragma: allowlist secret
@@ -476,6 +535,7 @@ async function executeUiProbe({ artifact, client, scenario, reportRoot, uiBaseUr
     }
 
     ({ context } = await getSharedUiProbeSession(uiBaseUrl));
+    await seedUiAuthStorageIfAvailable({ context, client, artifact });
     page = await context.newPage();
     page.on("request", (request) => {
       requestUrls.push(request.url());
@@ -492,6 +552,11 @@ async function executeUiProbe({ artifact, client, scenario, reportRoot, uiBaseUr
         return;
       }
       requestFailures.push(message);
+    });
+    page.on("response", (response) => {
+      if (response.status() >= 400) {
+        responseErrors.push(`${String(response.status())} ${response.url()}`);
+      }
     });
     page.on("console", (message) => {
       if (message.type() === "error") {
@@ -563,8 +628,13 @@ async function executeUiProbe({ artifact, client, scenario, reportRoot, uiBaseUr
     const requestedPath = getUrlPath(execution.path);
     const allowedFinalPathPrefixes = execution.allowedFinalPathPrefixes ?? [requestedPath];
     const significantRequestFailures = requestFailures.filter((message) => !isIgnorableUiRequestFailure(message));
-    const significantConsoleErrors = consoleErrors.filter((message) => !isIgnorableUiConsoleError(message));
-    artifact.toolErrors = [...significantRequestFailures, ...significantConsoleErrors];
+    const significantResponseErrors = responseErrors.filter((message) => !isIgnorableUiResponseError(message));
+    const significantConsoleErrors = consoleErrors.filter((message) => !isIgnorableUiConsoleError(message, responseErrors));
+    artifact.toolErrors = [
+      ...significantRequestFailures,
+      ...significantConsoleErrors,
+      ...significantResponseErrors,
+    ];
     artifact.observedEvidence.push(
       `loaded ${execution.path}`,
       `final url ${finalUrl}`,
@@ -586,6 +656,8 @@ async function executeUiProbe({ artifact, client, scenario, reportRoot, uiBaseUr
       allowedFinalPathPrefixes,
       consoleErrors,
       significantConsoleErrors,
+      responseErrors,
+      significantResponseErrors,
       requestFailures,
       reloadAbortedRequestFailures,
       significantRequestFailures,
@@ -614,13 +686,14 @@ async function executeUiProbe({ artifact, client, scenario, reportRoot, uiBaseUr
       return artifact;
     }
 
-    if (significantRequestFailures.length > 0 || significantConsoleErrors.length > 0) {
+    if (significantRequestFailures.length > 0 || significantConsoleErrors.length > 0 || significantResponseErrors.length > 0) {
       artifact.result = "partial";
       artifact.failureClass = "ui_loading";
       artifact.notes = [
         ...(artifact.notes ?? []),
         significantRequestFailures.length > 0 ? `${String(significantRequestFailures.length)} failed UI requests` : "",
         significantConsoleErrors.length > 0 ? `${String(significantConsoleErrors.length)} console errors` : "",
+        significantResponseErrors.length > 0 ? `${String(significantResponseErrors.length)} HTTP error responses` : "",
       ].filter(Boolean);
     }
     return artifact;

--- a/validation/real-world/lib/reporting.mjs
+++ b/validation/real-world/lib/reporting.mjs
@@ -107,6 +107,18 @@ function summarizeAggregates({ artifacts, grouped, envTruth }) {
   };
 }
 
+function countProviderAttempts(artifacts) {
+  return artifacts.filter((artifact) =>
+    artifact?.lane === "default" || artifact?.lane === "fallback"
+  ).length;
+}
+
+function countBrowserProbeAttempts(artifacts) {
+  return artifacts.filter((artifact) =>
+    typeof artifact?.metrics?.uiRequestCount === "number"
+  ).length;
+}
+
 function renderCoverageMatrix({ scenarios, grouped }) {
   const byKey = new Map(grouped.map((entry) => [`${entry.scenarioId}::${entry.lane}`, entry]));
   const lines = [
@@ -285,6 +297,8 @@ export function writeReports({
     groupedCount: grouped.length,
     results: resultCounts,
     resultCounts,
+    providerAttemptCount: countProviderAttempts(artifacts),
+    browserProbeAttemptCount: countBrowserProbeAttempts(artifacts),
     failureClassCounts,
     defectBucketCounts,
     baseUrl: envTruth.baseUrl,

--- a/validation/real-world/lib/reporting.mjs
+++ b/validation/real-world/lib/reporting.mjs
@@ -3,6 +3,7 @@ import { resolveLatestPointerPath, writeJson, writeText } from "./io.mjs";
 import { summarizeNumbers } from "./stats.mjs";
 
 const RESULT_ORDER = ["failed", "manual_review", "partial", "blocked", "passed"];
+const SENSITIVE_OPTION_KEY_RE = /(?:access[_-]?token|refresh[_-]?token|password|passphrase|secret|api[_-]?key|credential|authorization|cookie)/iu;
 
 function formatPercent(value) {
   if (typeof value !== "number" || !Number.isFinite(value)) return "n/a";
@@ -19,6 +20,24 @@ function countBy(values) {
     acc[value] = (acc[value] ?? 0) + 1;
     return acc;
   }, {});
+}
+
+function sanitizeReportValue(value, key = "") {
+  if (SENSITIVE_OPTION_KEY_RE.test(key)) {
+    return typeof value === "string" && value.length > 0 ? "[redacted]" : value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => sanitizeReportValue(entry));
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([entryKey, entryValue]) => [
+        entryKey,
+        sanitizeReportValue(entryValue, entryKey),
+      ]),
+    );
+  }
+  return value;
 }
 
 function worstResult(results) {
@@ -305,7 +324,7 @@ export function writeReports({
     uiBaseUrl: envTruth.uiBaseUrl,
     providerLanes: envTruth.providerLanes,
     aggregates,
-    options,
+    options: sanitizeReportValue(options),
   };
 
   writeJson(path.join(reportRoot, "summary.json"), summary);

--- a/validation/real-world/lib/reporting.mjs
+++ b/validation/real-world/lib/reporting.mjs
@@ -282,6 +282,27 @@ function renderIndex({ runId, suite, scenarios, grouped, envTruth, aggregates })
   return lines.join("\n") + "\n";
 }
 
+function writeToolEvidenceArtifacts({ reportRoot, artifacts }) {
+  for (const artifact of artifacts) {
+    const evidence = artifact?.raw?.toolEvidence;
+    if (!Array.isArray(evidence) || evidence.length === 0) {
+      continue;
+    }
+    const scenarioId = String(artifact.scenarioId ?? "unknown").replace(/[^a-zA-Z0-9_.-]/g, "-");
+    const runId = String(artifact.raw?.runId ?? artifact.runId ?? "run").replace(/[^a-zA-Z0-9_.-]/g, "-");
+    writeJson(
+      path.join(reportRoot, "tool-evidence", scenarioId, `${runId}.json`),
+      {
+        scenarioId: artifact.scenarioId,
+        suite: artifact.suite,
+        lane: artifact.lane,
+        runId: artifact.raw?.runId ?? artifact.runId ?? null,
+        evidence,
+      },
+    );
+  }
+}
+
 export function writeReports({
   repoRoot,
   reportRoot,
@@ -337,6 +358,7 @@ export function writeReports({
   writeText(path.join(reportRoot, "performance-report.md"), renderPerformanceReport({ grouped, aggregates }));
   writeText(path.join(reportRoot, "defect-ledger.md"), renderDefectLedger({ artifacts }));
   writeText(path.join(reportRoot, "index.md"), renderIndex({ runId, suite, scenarios, grouped, envTruth, aggregates }));
+  writeToolEvidenceArtifacts({ reportRoot, artifacts });
   writeJson(resolveLatestPointerPath(repoRoot), {
     runId,
     suite,


### PR DESCRIPTION
## Summary

Adds a self-hosted Real Green Gate path for GitHub Actions runs where the four Friday runtime env vars are absent:

- `FRIDAY_BASE_URL`
- `FRIDAY_ACCESS_TOKEN`
- `FRIDAY_LOCAL_PASSPHRASE`
- `FRIDAY_REAL_WORLD_MINT_LOCAL_ADMIN_TOKEN`

Instead of emitting `blocked_by_env` solely for missing runtime env, the workflow now builds Friday, starts an ephemeral localhost runtime, creates temporary local auth/state under runner temp, completes setup truth, runs the gate against the PR SHA, and uploads `real-green-gate-result.json`.

## Evidence framing

This PR does **not** claim release proof by itself.

- Workflow success is plumbing-tier only.
- `blocked_by_env`, `failed`, and `errored` are never pass.
- Same-SHA RGG proof requires downloaded artifact JSON with `status: "passed"`, nonzero scenarios, passed equals total, and empty blockers.
- Provider evidence is only reported when provider attempts are actually observed.
- Provider secrets are referenced only by GitHub Secret names; no secret values are in this PR.

## Key changes

- Preserve configured external-runtime RGG path when any runtime env var is present.
- Add self-hosted runtime path when all four runtime env vars are absent.
- Write an `errored` artifact if self-hosted build/runtime startup fails before the normal gate runner emits a summary.
- Precondition setup truth before RGG by local-passphrase bootstrap, local login, and `/v1/setup/complete`.
- Skip provider/channel setup steps in the self-hosted setup marker instead of falsely claiming they were configured.
- Derive `evidence_kinds_observed` from observed real-runtime/provider/browser counters rather than hard-coding provider/browser evidence.

## Verification

- `node --check scripts/ops/run-real-green-gate.mjs && node --check scripts/ops/run-real-green-gate-self-hosted.mjs && node --check scripts/ops/lib/real-green-gate-result.mjs` — PASS
- `npx vitest run test/unit/ops/run-real-green-gate.test.ts test/unit/ops/real-green-gate-result.test.ts test/unit/ops/run-real-green-gate-self-hosted.test.ts test/unit/e2e/friday-closure-lib.test.ts test/unit/validation/real-world-reporting.test.ts --reporter=verbose` — PASS, 5 files / 56 tests
- `npx tsc --noEmit` — PASS
- `npm run build` — PASS
- `npm run lint` — PASS with 0 errors / 1423 existing warnings
- `npm run check:secret-patterns` — PASS
- `git diff --check` — PASS
- Local self-hosted diagnostic — emitted same-SHA `status=errored` artifact, not release proof; confirmed `setupStatus.needsSetup=false` and `setupUserProfileTruthMismatch=false`; remaining blocker was provider lanes incomplete / smoke timeout.
- Tight secret grep over changed files and diagnostic artifact — no secret values found.

## Reviewer trail

- Reviewer A final: PASS, no file:line blockers.
- Reviewer B final: PASS, no file:line blockers.

## Owner-bypass checklist placeholder

⚠️ This draft PR is **not approved for merge** by this body text.

If this PR later needs the single-maintainer owner-bypass path, the per-merge approval line must be captured in a PR comment or PR body update before merge, and it must satisfy the current §23.6 / AGENTS.md owner-bypass requirements. Merge action alone is not approval.
