### PR TITLE
feat(skills): add social import candidate staging route

### DIFF
--- a/package.json
+++ b/package.json
@@ -239,6 +239,7 @@
     "#skills": "./dist/skills/index.js",
     "#skills/converter": "./dist/skills/converter/index.js",
     "#skills/generator": "./dist/skills/generator/index.js",
+    "#skills/social-import": "./dist/skills/social-import/index.js",
     "#state": "./dist/state/index.js",
     "#memory": "./dist/memory/index.js",
     "#sessions": "./dist/sessions/index.js",

--- a/src/api/http/routes/friday-social-import-routes.ts
+++ b/src/api/http/routes/friday-social-import-routes.ts
@@ -1,0 +1,253 @@
+/**
+ * Phase 02b — Social Import HTTP route.
+ *
+ * Exposes a single public route for the partial Phase 02b slice:
+ *   POST /v1/skills/social-import (operationId: skills.social.import)
+ *
+ * The route is always registered. When bootstrap could not enable the
+ * social-import service (XHS deps absent), or when the api-runtime cannot
+ * inject the converter service / canonical mutation gate (test fixture etc.),
+ * the deps fields are null and the handler returns
+ * `503 SOCIAL_IMPORT_DISABLED` with a structured `disabledReason` that never
+ * echoes env values, cookies, session strings, or credentials.
+ *
+ * Closure scope is intentionally PARTIAL — see plan + service module.
+ *
+ * @module api/http/routes/friday-social-import-routes
+ */
+
+import { FridayDomainError } from "#errors";
+import type { FridayRouteDefinition } from "../../model/friday-api-common.types.js";
+
+import type {
+  FridaySocialImportRequest,
+  FridaySocialImportService,
+  FridaySocialImportSuccessResponse,
+} from "#skills/social-import";
+import { FRIDAY_SOCIAL_IMPORT_DEFAULT_NEXT_STEPS } from "#skills/social-import";
+import {
+  createFridaySkillStageMutatingActionRequest,
+  type FridaySkillConverterService,
+} from "#skills/converter";
+import {
+  type FridayCanonicalApprovalResolution,
+  type FridayMutatingActionGate,
+} from "../../../security/friday-mutating-action-gate.js";
+
+// ─── Deps ───
+
+export interface FridaySocialImportRoutesDeps {
+  /** Active social-import service when enabled; null when disabled. */
+  readonly service: FridaySocialImportService | null;
+  /**
+   * Structured short reason from bootstrap explaining why social-import is
+   * disabled. Must never include env values, cookies, session strings, or
+   * partial credentials.
+   */
+  readonly disabledReason: string | null;
+}
+
+// ─── Internal route-side deps wired by createFridayApiRuntime ───
+
+export interface FridaySocialImportRoutesRegistrationDeps extends FridaySocialImportRoutesDeps {
+  /** Converter service used to stage the candidate after gate approval. */
+  readonly converterService: FridaySkillConverterService | null;
+  /** Canonical mutation gate used to evaluate the stage-candidate request. */
+  readonly canonicalMutationGate: FridayMutatingActionGate | null;
+}
+
+// ─── Defaults ───
+
+const DEFAULT_DISABLED_MESSAGE =
+  "Social-import is disabled in this runtime; XHS browser deps, the converter service, or the canonical mutation gate are unavailable.";
+const SURFACE = "api:/v1/skills/social-import";
+
+// ─── Factory ───
+
+export function createFridaySocialImportRoutes(
+  deps: FridaySocialImportRoutesRegistrationDeps,
+): FridayRouteDefinition<unknown, unknown, unknown, unknown>[] {
+  function disabledMessage(): string {
+    return deps.disabledReason && deps.disabledReason.trim().length > 0
+      ? deps.disabledReason
+      : DEFAULT_DISABLED_MESSAGE;
+  }
+
+  function throwDisabled(): never {
+    throw new FridayDomainError(
+      "SOCIAL_IMPORT_DISABLED",
+      disabledMessage(),
+      { httpStatus: 503 },
+    );
+  }
+
+  return [
+    {
+      operationId: "skills.social.import",
+      method: "POST",
+      path: "/v1/skills/social-import",
+      auth: { public: true },
+      async handler(ctx): Promise<FridaySocialImportSuccessResponse> {
+        if (!deps.service || !deps.converterService || !deps.canonicalMutationGate) {
+          throwDisabled();
+        }
+        const request = parseSocialImportBody(ctx.body);
+        const actorPrincipalId = ctx.principal?.principalId ?? "public:default";
+        const actorPrincipalKind = ctx.principal?.principalType ?? "api";
+
+        // 1. Pre-staging: URL allowlist, session check, real-browser
+        //    extraction, source provenance, social-aware planDigest.
+        const context = await deps.service.prepareStageContext({
+          request,
+          actorPrincipalId,
+          actorPrincipalKind,
+          surface: SURFACE,
+        });
+
+        // 2. Build the canonical stage-candidate mutation request and
+        //    evaluate the gate. The caller's `canonicalApproval` resolution
+        //    must clear the gate; otherwise the gate returns
+        //    `requires_approval` and we throw 403 with the standard shape.
+        const stageRequest = createFridaySkillStageMutatingActionRequest({
+          source: context.source,
+          formatHint: "code-repo",
+          actor: {
+            kind: actorPrincipalKind,
+            id: actorPrincipalId,
+            principalId: actorPrincipalId,
+          },
+          surface: SURFACE,
+          idempotencyKey: request.idempotencyKey,
+          planDigest: context.planDigest,
+          canonicalApproval: request.canonicalApproval,
+        });
+        const gateResult = deps.canonicalMutationGate.evaluate(stageRequest);
+        if (gateResult.decision !== "allow" || !gateResult.ticket) {
+          const code =
+            gateResult.decision === "requires_approval"
+              ? "CANONICAL_APPROVAL_REQUIRED"
+              : "CANONICAL_APPROVAL_DENIED";
+          const message =
+            gateResult.decision === "requires_approval"
+              ? "Social-import candidate staging requires canonical approval before any candidate is written."
+              : `Social-import candidate staging was blocked by the canonical approval gate: ${gateResult.reason}`;
+          throw new FridayDomainError(code, message, {
+            httpStatus: 403,
+            details: {
+              canonicalGate: gateResult.evidenceRecord,
+              planDigest: context.planDigest,
+              redactedSocialUri: context.redactedSocialUri,
+              redactedTargetUri: context.redactedTargetUri,
+              socialDomain: "xiaohongshu.com" as const,
+              extraction: context.extraction,
+            },
+          });
+        }
+        const ticket = gateResult.ticket;
+
+        // 3. Stage the candidate through the existing converter service. The
+        //    converter handles validation, file writes, redacted source
+        //    provenance, and the candidate approval proof.
+        const importResult = await deps.converterService.import({
+          source: context.source,
+          formatHint: "code-repo",
+          canonicalApprovalTicket: ticket,
+        });
+        const candidate = importResult.candidates[0];
+        if (!candidate) {
+          throw new FridayDomainError(
+            "SOCIAL_IMPORT_CANDIDATE_MISSING",
+            "Converter import did not produce a candidate; the slice cannot complete.",
+            { httpStatus: 500 },
+          );
+        }
+
+        // 4. Build the response. NextSteps lists the existing routes the user
+        //    (or operator) drives separately to finish the module_01 loop —
+        //    autonomy shadow / canary / promote / verify. The slice does NOT
+        //    call those routes itself; it also does NOT emit a learning
+        //    event (Stage 2 option 4b).
+        return {
+          ok: true,
+          candidateId: candidate.candidateId,
+          skillId: candidate.skillId,
+          socialDomain: "xiaohongshu.com",
+          redactedSocialUri: context.redactedSocialUri,
+          redactedTargetUri: context.redactedTargetUri,
+          sourceProvenanceDigest: context.sourceProvenanceDigest,
+          extraction: context.extraction,
+          ticketId: ticket.ticketId,
+          planDigest: context.planDigest,
+          stagedAt: candidate.stagedAt,
+          nextSteps: [...FRIDAY_SOCIAL_IMPORT_DEFAULT_NEXT_STEPS],
+        };
+      },
+    },
+  ];
+}
+
+// ─── Body parsing ───
+
+function parseSocialImportBody(raw: unknown): FridaySocialImportRequest {
+  if (raw === null || raw === undefined || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new FridayDomainError(
+      "VALIDATION_ERROR",
+      "Request body must be a JSON object.",
+      { httpStatus: 400 },
+    );
+  }
+  const obj = raw as Record<string, unknown>;
+  const socialUrl = obj.socialUrl;
+  if (typeof socialUrl !== "string" || socialUrl.trim().length === 0) {
+    throw new FridayDomainError(
+      "VALIDATION_ERROR",
+      "`socialUrl` is required and must be a non-empty string.",
+      { httpStatus: 400 },
+    );
+  }
+  const targetGithubRepoUrl = obj.targetGithubRepoUrl;
+  if (typeof targetGithubRepoUrl !== "string" || targetGithubRepoUrl.trim().length === 0) {
+    throw new FridayDomainError(
+      "VALIDATION_ERROR",
+      "`targetGithubRepoUrl` is required and must be a non-empty string.",
+      { httpStatus: 400 },
+    );
+  }
+  const out: { -readonly [K in keyof FridaySocialImportRequest]?: FridaySocialImportRequest[K] } = {
+    socialUrl,
+    targetGithubRepoUrl,
+  };
+  if (obj.sessionId !== undefined) {
+    if (typeof obj.sessionId !== "string" || obj.sessionId.trim().length === 0) {
+      throw new FridayDomainError(
+        "VALIDATION_ERROR",
+        "`sessionId` must be a non-empty string when provided.",
+        { httpStatus: 400 },
+      );
+    }
+    out.sessionId = obj.sessionId;
+  }
+  if (obj.idempotencyKey !== undefined) {
+    if (typeof obj.idempotencyKey !== "string") {
+      throw new FridayDomainError(
+        "VALIDATION_ERROR",
+        "`idempotencyKey` must be a string when provided.",
+        { httpStatus: 400 },
+      );
+    }
+    out.idempotencyKey = obj.idempotencyKey;
+  }
+  if (obj.canonicalApproval !== undefined) {
+    if (typeof obj.canonicalApproval !== "object" || obj.canonicalApproval === null) {
+      throw new FridayDomainError(
+        "VALIDATION_ERROR",
+        "`canonicalApproval` must be an object when provided.",
+        { httpStatus: 400 },
+      );
+    }
+    out.canonicalApproval = obj.canonicalApproval as FridayCanonicalApprovalResolution;
+  }
+  // The route DOES NOT accept a `userId` field from the body. The actor
+  // principal is read from `ctx.principal.principalId` in the handler.
+  return out as FridaySocialImportRequest;
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -138,6 +138,8 @@ export type {
   FridayMediaUnderstandingAnalyzeRequestAttachment,
   FridayMediaUnderstandingAnalyzeResponse,
 } from "./http/routes/friday-media-understanding-routes.js";
+export { createFridaySocialImportRoutes } from "./http/routes/friday-social-import-routes.js";
+export type { FridaySocialImportRoutesDeps } from "./http/routes/friday-social-import-routes.js";
 export { createFridayAuthRoutes } from "./http/routes/friday-auth-routes.js";
 export { createFridayRealtimeRoutes } from "./http/routes/friday-realtime-routes.js";
 export { createFridayFleetRoutes } from "./http/routes/friday-fleet-routes.js";

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -69,6 +69,10 @@ import {
   createFridayMediaUnderstandingRoutes,
   type FridayMediaUnderstandingRoutesDeps,
 } from "../http/routes/friday-media-understanding-routes.js";
+import {
+  createFridaySocialImportRoutes,
+  type FridaySocialImportRoutesDeps,
+} from "../http/routes/friday-social-import-routes.js";
 import { createFridaySkillGeneratorRoutes } from "../http/routes/friday-skill-generator-routes.js";
 import { createFridayDiagnosisRoutes } from "../http/routes/friday-diagnosis-routes.js";
 import { createFridayAutoFixRoutes } from "../http/routes/friday-auto-fix-routes.js";
@@ -2495,6 +2499,31 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
     doctorProvider: mediaUnderstandingDeps.doctorProvider,
     disabledReason: mediaUnderstandingDeps.disabledReason,
     nowIso: deps.nowIso,
+  })) {
+    routes.register(route);
+  }
+
+  // Register Phase 02b social-import route.
+  //
+  // The route is always registered; the disabled state is represented inside
+  // the handler via null `service` / `converterService` / `canonicalMutationGate`
+  // plus a structured `disabledReason`. When deps.socialImport is undefined
+  // (e.g. test fixtures or runtimes that do not opt in to XHS browser deps)
+  // we coalesce to an honest-disabled shape so disabled deployments return
+  // `503 SOCIAL_IMPORT_DISABLED`, never 404. The converter service and the
+  // canonical mutation gate are injected by the api-runtime so the route can
+  // build the stage-candidate mutation request and stage the candidate
+  // through the existing converter path after gate approval.
+  const socialImportDeps: FridaySocialImportRoutesDeps =
+    deps.socialImport ?? {
+      service: null,
+      disabledReason: "social import deps not provided",
+    };
+  for (const route of createFridaySocialImportRoutes({
+    service: socialImportDeps.service,
+    disabledReason: socialImportDeps.disabledReason,
+    converterService: deps.converterService ?? null,
+    canonicalMutationGate: socialImportDeps.service ? canonicalMutationGate : null,
   })) {
     routes.register(route);
   }

--- a/src/api/runtime/friday-api-runtime.types.ts
+++ b/src/api/runtime/friday-api-runtime.types.ts
@@ -28,6 +28,7 @@ import type {
 } from "../../autonomy/index.js";
 import type { FridayProviderService } from "#providers";
 import type { FridayMediaUnderstandingRoutesDeps } from "../http/routes/friday-media-understanding-routes.js";
+import type { FridaySocialImportRoutesDeps } from "../http/routes/friday-social-import-routes.js";
 import type { FridayMemoryGuardServiceFactory, FridayMemoryService } from "#memory";
 import type { FridaySessionMemoryExtractionService, FridaySessionService } from "#sessions";
 import type {
@@ -268,6 +269,19 @@ export interface CreateFridayApiRuntimeDeps {
    * credential.
    */
   mediaUnderstanding?: FridayMediaUnderstandingRoutesDeps;
+  /**
+   * Phase 02b social-import route surface.
+   *
+   * Optional. The route is always registered regardless of whether this slot
+   * is supplied — `createFridayApiRuntime` coalesces a missing/undefined
+   * value to an honest-disabled deps shape so disabled deployments return
+   * `503 SOCIAL_IMPORT_DISABLED` (never 404). When supplied, the hub
+   * bootstrap sets non-null `service` only when XHS browser deps, the
+   * converter service, and the canonical mutation gate are all available;
+   * otherwise the field is null with a structured `disabledReason` that
+   * never echoes cookies, session strings, env values, or credentials.
+   */
+  socialImport?: FridaySocialImportRoutesDeps;
   /** Optional: search capability metadata surfaced by /v1/health. */
   searchHealth?: {
     provider: string;

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -115,6 +115,7 @@ import {
   createFridayOpenAiVisionProvider,
   DEFAULT_OPENAI_VISION_MODEL,
 } from "#media-understanding";
+import { createFridaySocialImportService } from "#skills/social-import";
 import { parseFridaySecretInput, resolveFridaySecretInput } from "../security/friday-secret-ref.js";
 import type { FridayChannelPersonaConfig, FridayGuideLensRoutesDeps, FridaySystemRoutesDeps } from "#api";
 import type { FridayPackagingRoutesDeps } from "../api/http/routes/friday-packaging-routes.js";
@@ -3335,6 +3336,33 @@ export async function createFridayHub(
     );
   }
 
+  // ── Phase 02b Social Import (partial slice) ──
+  // The social-import service exposes the partial first-half of module_01:
+  // XHS real-browser extraction + provenance + social-aware planDigest. The
+  // route itself drives the canonical mutation gate and the converter import
+  // for candidate staging. Autonomy shadow/canary/promote/rollback + verify
+  // + learning emit remain operator-driven via existing routes.
+  const socialImportService =
+    xhsPageInteractions !== undefined && xhsSessionManager !== undefined
+      ? createFridaySocialImportService({
+          xhsPageInteractions,
+          xhsSessionManager,
+        })
+      : null;
+  const socialImportDeps: NonNullable<
+    Parameters<typeof createFridayApiRuntime>[0]["socialImport"]
+  > = socialImportService
+    ? { service: socialImportService, disabledReason: null }
+    : {
+        service: null,
+        disabledReason: "XHS browser deps not initialised in this runtime",
+      };
+  if (socialImportDeps.service === null) {
+    console.warn(
+      `[friday][W-SOCIAL-IMPORT-001] Social-import disabled: ${socialImportDeps.disabledReason}; POST /v1/skills/social-import will return 503 SOCIAL_IMPORT_DISABLED`,
+    );
+  }
+
   // ── Link Understanding pipeline ──
   // Wire the full auto-detect-links service for session message enrichment.
   {
@@ -6315,6 +6343,7 @@ export async function createFridayHub(
     multiTenantSecurity: multiTenantSecurityDeps,
     desktop: desktopRouteDeps,
     mediaUnderstanding: mediaUnderstandingDeps,
+    socialImport: socialImportDeps,
   });
 
   if (reflexService) {

--- a/src/skills/social-import/friday-social-import-service.ts
+++ b/src/skills/social-import/friday-social-import-service.ts
@@ -1,0 +1,292 @@
+/**
+ * Phase 02b — Social Import orchestrator service (pre-staging only).
+ *
+ * The service handles the parts of the partial slice that DO NOT need access
+ * to the api-runtime-internal canonical mutation gate or converter service:
+ *
+ *   1. URL allowlist enforcement (socialUrl host + targetGithubRepoUrl host).
+ *   2. XHS session validity check via the existing session manager.
+ *   3. Real-browser comment extraction via the existing `extractComments`
+ *      primitive (read-only; records count + field names only, never values).
+ *   4. Source provenance + redacted URIs via the existing converter helpers.
+ *   5. Social-aware `planDigest` derived from the redacted-URI plan body.
+ *
+ * The route handler is responsible for calling the canonical mutation gate
+ * and the converter service `import(...)` (with the returned ticket) — see
+ * `src/api/http/routes/friday-social-import-routes.ts`. The slice does NOT
+ * call autonomy shadow/canary/promote/rollback, does NOT call the installer,
+ * does NOT call doctor verify, and does NOT emit a learning event.
+ */
+
+import { FridayDomainError } from "#errors";
+import {
+  createFridaySkillCandidateSourceProvenance,
+  redactFridaySkillCandidateSourceUri,
+  type FridaySkillConversionSource,
+} from "#skills/converter";
+import {
+  createFridayMutatingActionDigest,
+  type FridayMutatingActionRequest,
+} from "../../security/friday-mutating-action-gate.js";
+import type {
+  XhsPageInteractions,
+  XhsSessionManager,
+} from "#xhs";
+
+import {
+  FRIDAY_SOCIAL_IMPORT_ACCEPTED_HOSTS,
+  FRIDAY_SOCIAL_IMPORT_PLAN_VERSION,
+  type FridaySocialImportExtractionShape,
+  type FridaySocialImportPlanDigestInput,
+  type FridaySocialImportRequest,
+  type FridaySocialImportService,
+  type FridaySocialImportStageContext,
+} from "./friday-social-import.types.js";
+
+// ─── Constants ───
+
+const DEFAULT_SESSION_ID = "xhs-default";
+const XHS_COMMENT_FIELDS_PRESENT = ["author", "content", "likes"] as const;
+
+// ─── Dependencies ───
+
+export interface CreateFridaySocialImportServiceDeps {
+  readonly xhsPageInteractions: XhsPageInteractions;
+  readonly xhsSessionManager: XhsSessionManager;
+}
+
+// ─── Factory ───
+
+export function createFridaySocialImportService(
+  deps: CreateFridaySocialImportServiceDeps,
+): FridaySocialImportService {
+  return {
+    async prepareStageContext(input) {
+      const { request, actorPrincipalId, actorPrincipalKind, surface } = input;
+      const sessionId = request.sessionId ?? DEFAULT_SESSION_ID;
+
+      // Step 1: URL allowlist enforcement.
+      assertSocialUrlAllowed(request.socialUrl);
+      assertTargetGithubUrlAllowed(request.targetGithubRepoUrl);
+
+      // Step 2: XHS session validity.
+      if (!deps.xhsSessionManager.isSessionValid(sessionId)) {
+        throw new FridayDomainError(
+          "SOCIAL_IMPORT_QR_LOGIN_REQUIRED",
+          "XHS session is not valid; complete QR login via the existing `xhs.login` agent-tool action and retry.",
+          {
+            httpStatus: 503,
+            details: {
+              blockedBy: "xhs.qr_login",
+              remediation: "agent_tool:xhs.login",
+              sessionId,
+            },
+          },
+        );
+      }
+
+      // Step 3: Real-browser extraction proof — read-only comment extraction.
+      // Only count + field names are recorded, never values.
+      const extractionStart = Date.now();
+      let commentCount = 0;
+      try {
+        const comments = await deps.xhsPageInteractions.extractComments(
+          sessionId,
+          request.socialUrl,
+        );
+        commentCount = Array.isArray(comments) ? comments.length : 0;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        throw new FridayDomainError(
+          "SOCIAL_IMPORT_EXTRACTION_FAILED",
+          `XHS extraction failed: ${redactErrorMessage(message, request)}`,
+          {
+            httpStatus: 502,
+            details: { sessionId },
+          },
+        );
+      }
+      const extractionDurationMs = Math.max(0, Date.now() - extractionStart);
+      const extraction: FridaySocialImportExtractionShape = {
+        socialDomain: "xiaohongshu.com",
+        fieldsPresent: [...XHS_COMMENT_FIELDS_PRESENT],
+        commentCount,
+        extractionDurationMs,
+      };
+
+      // Step 4: Source provenance + redacted URIs.
+      const source: FridaySkillConversionSource = {
+        uri: request.targetGithubRepoUrl,
+        formatHint: "code-repo",
+      };
+      const sourceProvenance = createFridaySkillCandidateSourceProvenance(source);
+      const redactedSocialUri = redactFridaySkillCandidateSourceUri(
+        request.socialUrl,
+      );
+      const redactedTargetUri = redactFridaySkillCandidateSourceUri(
+        request.targetGithubRepoUrl,
+      );
+
+      // Step 5: Social-aware planDigest. The digest input contains ONLY
+      // redacted URIs and provenance digests — never raw URLs, never
+      // extracted text values. extractionDurationMs is excluded to keep the
+      // digest deterministic across runs; the response still carries the
+      // real duration as proof of navigation.
+      const planDigestInput: FridaySocialImportPlanDigestInput = {
+        planVersion: FRIDAY_SOCIAL_IMPORT_PLAN_VERSION,
+        socialDomain: "xiaohongshu.com",
+        redactedSocialUri,
+        redactedTargetUri,
+        sourceProvenanceDigest: sourceProvenance.sourceDigest,
+        extraction: {
+          ...extraction,
+          extractionDurationMs: 0,
+        },
+      };
+      const planDigestRequest: FridayMutatingActionRequest = {
+        action: "skills.import.stage_candidate.social",
+        actor: {
+          kind: actorPrincipalKind,
+          id: actorPrincipalId,
+          principalId: actorPrincipalId,
+        },
+        surface,
+        resource: {
+          type: "external_skill_candidate_social_plan",
+          digest: stablePlanDigestResourceFingerprint(planDigestInput),
+        },
+        mutating: false,
+        parameters: planDigestInput as unknown as Record<string, unknown>,
+      };
+      const planDigest = createFridayMutatingActionDigest(planDigestRequest);
+
+      return {
+        request,
+        sessionId,
+        source,
+        sourceProvenanceDigest: sourceProvenance.sourceDigest,
+        redactedSocialUri,
+        redactedTargetUri,
+        extraction,
+        planDigest,
+      };
+    },
+  };
+}
+
+// ─── URL validation ───
+
+function assertSocialUrlAllowed(socialUrl: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(socialUrl);
+  } catch {
+    throw new FridayDomainError(
+      "VALIDATION_ERROR",
+      "socialUrl must be a valid URL.",
+      { httpStatus: 400 },
+    );
+  }
+  if (parsed.protocol !== "https:") {
+    throw new FridayDomainError(
+      "VALIDATION_ERROR",
+      "socialUrl must use the https:// scheme.",
+      { httpStatus: 400 },
+    );
+  }
+  const host = parsed.hostname.toLowerCase();
+  if (!FRIDAY_SOCIAL_IMPORT_ACCEPTED_HOSTS.includes(host as never)) {
+    throw new FridayDomainError(
+      "VALIDATION_ERROR",
+      `socialUrl host must be one of: ${FRIDAY_SOCIAL_IMPORT_ACCEPTED_HOSTS.join(", ")}.`,
+      { httpStatus: 400 },
+    );
+  }
+}
+
+function assertTargetGithubUrlAllowed(targetUrl: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(targetUrl);
+  } catch {
+    throw new FridayDomainError(
+      "VALIDATION_ERROR",
+      "targetGithubRepoUrl must be a valid URL.",
+      { httpStatus: 400 },
+    );
+  }
+  if (parsed.protocol !== "https:") {
+    throw new FridayDomainError(
+      "VALIDATION_ERROR",
+      "targetGithubRepoUrl must use the https:// scheme.",
+      { httpStatus: 400 },
+    );
+  }
+  if (parsed.hostname.toLowerCase() !== "github.com") {
+    throw new FridayDomainError(
+      "VALIDATION_ERROR",
+      "targetGithubRepoUrl host must be github.com.",
+      { httpStatus: 400 },
+    );
+  }
+  // Path must shape like /<owner>/<repo>[/...]. We accept additional path
+  // segments (release tag, subpath) since the existing code-repo converter
+  // handles them; only reject obviously malformed shapes here.
+  const segments = parsed.pathname.split("/").filter((s) => s.length > 0);
+  if (segments.length < 2) {
+    throw new FridayDomainError(
+      "VALIDATION_ERROR",
+      "targetGithubRepoUrl path must be `/owner/repo` at minimum.",
+      { httpStatus: 400 },
+    );
+  }
+}
+
+// ─── Helpers ───
+
+function redactErrorMessage(
+  message: string,
+  request: FridaySocialImportRequest,
+): string {
+  // Strip raw URLs from any nested error message before surfacing to the
+  // route response. Keeps the message useful for debugging while preventing
+  // raw-URL leakage into logs / responses.
+  let out = message;
+  if (request.socialUrl.length > 0) {
+    out = out.split(request.socialUrl).join("<redacted-social-uri>");
+  }
+  if (request.targetGithubRepoUrl.length > 0) {
+    out = out.split(request.targetGithubRepoUrl).join("<redacted-target-uri>");
+  }
+  return out;
+}
+
+function stablePlanDigestResourceFingerprint(value: unknown): string {
+  // Local lightweight stable JSON fingerprint for the inner resource.digest.
+  // The authoritative cryptographic hash for the overall planDigest is
+  // createFridayMutatingActionDigest (sha256 over a stable payload).
+  const text = JSON.stringify(normalize(value));
+  let hash = 0;
+  for (let i = 0; i < text.length; i++) {
+    hash = (hash * 31 + text.charCodeAt(i)) | 0;
+  }
+  return `social-plan-fingerprint:${(hash >>> 0).toString(16).padStart(8, "0")}`;
+}
+
+function normalize(value: unknown): unknown {
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => normalize(item));
+  }
+  const record = value as Record<string, unknown>;
+  const sorted: Record<string, unknown> = {};
+  for (const key of Object.keys(record).sort()) {
+    const item = record[key];
+    if (item !== undefined) {
+      sorted[key] = normalize(item);
+    }
+  }
+  return sorted;
+}

--- a/src/skills/social-import/friday-social-import-service.ts
+++ b/src/skills/social-import/friday-social-import-service.ts
@@ -21,8 +21,8 @@
 import { FridayDomainError } from "#errors";
 import {
   createFridaySkillCandidateSourceProvenance,
-  redactFridaySkillCandidateSourceUri,
   type FridaySkillConversionSource,
+  redactFridaySkillCandidateSourceUri,
 } from "#skills/converter";
 import {
   createFridayMutatingActionDigest,

--- a/src/skills/social-import/friday-social-import.types.ts
+++ b/src/skills/social-import/friday-social-import.types.ts
@@ -1,0 +1,166 @@
+/**
+ * Phase 02b — Social link to capability loop, partial slice types.
+ *
+ * This slice covers the FIRST half of the module_01 loop:
+ *   social URL input -> real-browser XHS extraction (or honest human-blocked
+ *   record) -> entity/source mapping (user-provided target GitHub repo URL,
+ *   Mode A) -> candidate creation through the existing converter service ->
+ *   canonical approval ticket for `skills.import.stage_candidate` with social
+ *   provenance encoded in `planDigest`.
+ *
+ * The slice does NOT call the autonomy `shadow / canary / promote / verify /
+ * rollback` chain, does NOT call `FridaySkillImportInstaller`, and does NOT
+ * emit any learning event. Those transitions are driven by the user/operator
+ * through the existing `/v1/autonomy/skills/:skillId/{shadow,canary,promote,
+ * rollback}` and `/v1/skills/:skillId/verify` routes after this slice lands;
+ * the response carries a `nextSteps` array listing the exact route sequence.
+ *
+ * Redaction discipline: payloads, response bodies, candidate metadata, and the
+ * planDigest input MUST NOT contain raw social URL with query params, raw
+ * GitHub URL with credentials, cookies, session strings, or extracted post
+ * text values. Only redacted URIs (via redactFridaySkillCandidateSourceUri)
+ * and provenance digests are permitted.
+ *
+ * @module skills/social-import
+ */
+
+import type { FridayCanonicalApprovalResolution } from "../../security/friday-mutating-action-gate.js";
+import type { FridaySkillConversionSource } from "#skills/converter";
+
+// ─── Social domain allowlist ───
+
+/** Domains accepted for `socialUrl` validation (host must match exactly). */
+export const FRIDAY_SOCIAL_IMPORT_ACCEPTED_HOSTS = [
+  "www.xiaohongshu.com",
+  "xiaohongshu.com",
+  "xhslink.com",
+] as const;
+
+export type FridaySocialImportAcceptedHost =
+  (typeof FRIDAY_SOCIAL_IMPORT_ACCEPTED_HOSTS)[number];
+
+/** Plan version for the social-aware planDigest body. Bump on shape change. */
+export const FRIDAY_SOCIAL_IMPORT_PLAN_VERSION =
+  "friday.phase_02b.social-import.v1";
+
+// ─── Request / response shapes ───
+
+export interface FridaySocialImportRequest {
+  /** Public XHS post URL. Allowlist enforced at route boundary. */
+  readonly socialUrl: string;
+  /** Mode-A user-provided target GitHub repo URL. */
+  readonly targetGithubRepoUrl: string;
+  /**
+   * XHS session id used by the existing session/page primitives. Defaults to
+   * `"xhs-default"` (the same default the agent tool uses). The userId for the
+   * canonical actor is read from `ctx.principal.principalId`, not from the
+   * body.
+   */
+  readonly sessionId?: string;
+  /**
+   * Pre-approved canonical approval resolution for the candidate-staging
+   * mutation. When absent, the route returns `403 CANONICAL_APPROVAL_REQUIRED`
+   * with the approval-request shape so the caller can drive the approval flow
+   * separately and retry.
+   */
+  readonly canonicalApproval?: FridayCanonicalApprovalResolution;
+  /** Optional idempotency key threaded into the staging mutation request. */
+  readonly idempotencyKey?: string;
+}
+
+/**
+ * Extraction-shape evidence the slice records to prove real-browser navigation
+ * happened. `fieldsPresent` contains FIELD NAMES from the XHS comment shape
+ * (`["author","content","likes"]`) — NEVER any field VALUES. `commentCount`
+ * is a non-negative integer (0 is honest if the page has no comments).
+ */
+export interface FridaySocialImportExtractionShape {
+  /** Social domain (constant per slice scope). */
+  readonly socialDomain: "xiaohongshu.com";
+  /** Field names from XhsComment present in the extraction. No values. */
+  readonly fieldsPresent: readonly string[];
+  /** Count of comments returned by `extractComments(postUrl)`. May be 0. */
+  readonly commentCount: number;
+  /** Real-browser extraction wall-clock duration. Proof of navigation. */
+  readonly extractionDurationMs: number;
+}
+
+/**
+ * Body shape fed into `createFridayMutatingActionDigest` as the `planDigest`.
+ * Contains ONLY redacted URIs and provenance digests; no raw URLs, no
+ * extracted text, no cookies. Reviewer B verifies this invariant.
+ */
+export interface FridaySocialImportPlanDigestInput {
+  readonly planVersion: typeof FRIDAY_SOCIAL_IMPORT_PLAN_VERSION;
+  readonly socialDomain: "xiaohongshu.com";
+  readonly redactedSocialUri: string;
+  readonly redactedTargetUri: string;
+  readonly sourceProvenanceDigest: string;
+  readonly extraction: FridaySocialImportExtractionShape;
+}
+
+/** Success response — the candidate has been staged. */
+export interface FridaySocialImportSuccessResponse {
+  readonly ok: true;
+  readonly candidateId: string;
+  readonly skillId: string;
+  readonly socialDomain: "xiaohongshu.com";
+  readonly redactedSocialUri: string;
+  readonly redactedTargetUri: string;
+  readonly sourceProvenanceDigest: string;
+  readonly extraction: FridaySocialImportExtractionShape;
+  readonly ticketId: string;
+  readonly planDigest: string;
+  readonly stagedAt: string;
+  /**
+   * Exact route sequence the user/operator should run next to finish closing
+   * the module_01 loop. The slice itself does NOT call these routes.
+   */
+  readonly nextSteps: readonly string[];
+}
+
+// ─── Service interface ───
+
+/**
+ * Service produces the pre-staging context (URL allowlist, XHS session
+ * check, real-browser extraction proof, source provenance, social-aware
+ * planDigest). The route handler owns the canonical mutation gate call and
+ * the converter `import(...)` invocation that actually stages the candidate.
+ *
+ * Throws structured `FridayDomainError`:
+ *  - `400 VALIDATION_ERROR` for URL allowlist failures.
+ *  - `503 SOCIAL_IMPORT_QR_LOGIN_REQUIRED` for the human-blocked branch.
+ *  - `502 SOCIAL_IMPORT_EXTRACTION_FAILED` for real-browser extraction errors.
+ */
+export interface FridaySocialImportService {
+  prepareStageContext(input: {
+    request: FridaySocialImportRequest;
+    actorPrincipalId: string;
+    actorPrincipalKind: string;
+    surface: string;
+  }): Promise<FridaySocialImportStageContext>;
+}
+
+/**
+ * Pre-staging context produced by the service. The route handler folds this
+ * into the canonical mutation gate request and the converter import call.
+ */
+export interface FridaySocialImportStageContext {
+  readonly request: FridaySocialImportRequest;
+  readonly sessionId: string;
+  readonly source: FridaySkillConversionSource;
+  readonly sourceProvenanceDigest: string;
+  readonly redactedSocialUri: string;
+  readonly redactedTargetUri: string;
+  readonly extraction: FridaySocialImportExtractionShape;
+  readonly planDigest: string;
+}
+
+// ─── Default canonical next-step route sequence ───
+
+export const FRIDAY_SOCIAL_IMPORT_DEFAULT_NEXT_STEPS = [
+  "POST /v1/autonomy/skills/:skillId/shadow",
+  "POST /v1/autonomy/skills/:skillId/canary",
+  "POST /v1/autonomy/skills/:skillId/promote",
+  "POST /v1/skills/:skillId/verify",
+] as const;

--- a/src/skills/social-import/index.ts
+++ b/src/skills/social-import/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Phase 02b — Social link to capability loop, partial slice.
+ *
+ * Exports the type contract and the service factory for the partial slice.
+ * The slice itself ONLY closes the first half of the module_01 loop
+ * (extraction + entity/source mapping + candidate staging via the canonical
+ * approval gate). The autonomy shadow / canary / promote / verify chain and
+ * the learning emit remain operator-driven through existing routes.
+ */
+
+export type {
+  FridaySocialImportAcceptedHost,
+  FridaySocialImportExtractionShape,
+  FridaySocialImportPlanDigestInput,
+  FridaySocialImportRequest,
+  FridaySocialImportService,
+  FridaySocialImportStageContext,
+  FridaySocialImportSuccessResponse,
+} from "./friday-social-import.types.js";
+
+export {
+  FRIDAY_SOCIAL_IMPORT_ACCEPTED_HOSTS,
+  FRIDAY_SOCIAL_IMPORT_DEFAULT_NEXT_STEPS,
+  FRIDAY_SOCIAL_IMPORT_PLAN_VERSION,
+} from "./friday-social-import.types.js";
+
+export type { CreateFridaySocialImportServiceDeps } from "./friday-social-import-service.js";
+export { createFridaySocialImportService } from "./friday-social-import-service.js";

--- a/test/contracts/api/__snapshots__/friday-api-route-contract.snapshot.test.ts.snap
+++ b/test/contracts/api/__snapshots__/friday-api-route-contract.snapshot.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures route count to detect accidental additions/removals 1`] = `369`;
+exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures route count to detect accidental additions/removals 1`] = `370`;
 
 exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route surface as a stable contract 1`] = `
 [
@@ -1987,6 +1987,16 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   {
     "authKind": "public",
     "index": 198,
+    "method": "POST",
+    "operationId": "skills.social.import",
+    "path": "/v1/skills/social-import",
+    "rateLimitPolicyId": null,
+    "roles": [],
+    "scopes": [],
+  },
+  {
+    "authKind": "public",
+    "index": 199,
     "method": "GET",
     "operationId": "setup.status",
     "path": "/v1/setup/status",
@@ -1996,7 +2006,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 199,
+    "index": 200,
     "method": "POST",
     "operationId": "providers.detect",
     "path": "/v1/providers/detect",
@@ -2006,7 +2016,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 200,
+    "index": 201,
     "method": "GET",
     "operationId": "setup.network.get",
     "path": "/v1/setup/network",
@@ -2016,7 +2026,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 201,
+    "index": 202,
     "method": "POST",
     "operationId": "setup.network.save",
     "path": "/v1/setup/network",
@@ -2026,7 +2036,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 202,
+    "index": 203,
     "method": "POST",
     "operationId": "setup.channels.feishu.registration.begin",
     "path": "/v1/setup/channels/feishu/registration/begin",
@@ -2036,7 +2046,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 203,
+    "index": 204,
     "method": "POST",
     "operationId": "setup.channels.feishu.registration.poll",
     "path": "/v1/setup/channels/feishu/registration/poll",
@@ -2046,7 +2056,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 204,
+    "index": 205,
     "method": "POST",
     "operationId": "setup.channels.telegram.verification.begin",
     "path": "/v1/setup/channels/telegram/verification/begin",
@@ -2056,7 +2066,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 205,
+    "index": 206,
     "method": "POST",
     "operationId": "setup.channels.telegram.verification.poll",
     "path": "/v1/setup/channels/telegram/verification/poll",
@@ -2066,7 +2076,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 206,
+    "index": 207,
     "method": "POST",
     "operationId": "setup.channels.discord.verification.begin",
     "path": "/v1/setup/channels/discord/verification/begin",
@@ -2076,7 +2086,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 207,
+    "index": 208,
     "method": "POST",
     "operationId": "setup.channels.discord.verification.complete",
     "path": "/v1/setup/channels/discord/verification/complete",
@@ -2086,7 +2096,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 208,
+    "index": 209,
     "method": "POST",
     "operationId": "setup.channels.test",
     "path": "/v1/setup/channels/test",
@@ -2096,7 +2106,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 209,
+    "index": 210,
     "method": "POST",
     "operationId": "setup.channels.save",
     "path": "/v1/setup/channels",
@@ -2106,7 +2116,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 210,
+    "index": 211,
     "method": "POST",
     "operationId": "setup.complete",
     "path": "/v1/setup/complete",
@@ -2116,7 +2126,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 211,
+    "index": 212,
     "method": "GET",
     "operationId": "skills.list",
     "path": "/v1/skills",
@@ -2126,7 +2136,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 212,
+    "index": 213,
     "method": "GET",
     "operationId": "skills.catalog.list",
     "path": "/v1/skills/catalog",
@@ -2136,7 +2146,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 213,
+    "index": 214,
     "method": "GET",
     "operationId": "skills.get",
     "path": "/v1/skills/:skillId",
@@ -2146,7 +2156,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 214,
+    "index": 215,
     "method": "POST",
     "operationId": "skills.install",
     "path": "/v1/skills/install",
@@ -2156,7 +2166,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 215,
+    "index": 216,
     "method": "POST",
     "operationId": "skills.update",
     "path": "/v1/skills/:skillId/update",
@@ -2166,7 +2176,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 216,
+    "index": 217,
     "method": "DELETE",
     "operationId": "skills.delete",
     "path": "/v1/skills/:skillId",
@@ -2176,7 +2186,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 217,
+    "index": 218,
     "method": "POST",
     "operationId": "skills.manifest.validate",
     "path": "/v1/skills/validate-manifest",
@@ -2186,7 +2196,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 218,
+    "index": 219,
     "method": "POST",
     "operationId": "skills.verify",
     "path": "/v1/skills/:skillId/verify",
@@ -2196,7 +2206,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 219,
+    "index": 220,
     "method": "POST",
     "operationId": "skills.run",
     "path": "/v1/skills/:skillId/run",
@@ -2206,7 +2216,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 220,
+    "index": 221,
     "method": "POST",
     "operationId": "skills.generator.sessions.create",
     "path": "/v1/skills/generator/sessions",
@@ -2216,7 +2226,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 221,
+    "index": 222,
     "method": "GET",
     "operationId": "skills.generator.sessions.get",
     "path": "/v1/skills/generator/sessions/:sessionId",
@@ -2226,7 +2236,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 222,
+    "index": 223,
     "method": "POST",
     "operationId": "skills.generator.sessions.messages.create",
     "path": "/v1/skills/generator/sessions/:sessionId/messages",
@@ -2236,7 +2246,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 223,
+    "index": 224,
     "method": "POST",
     "operationId": "skills.generator.sessions.generate",
     "path": "/v1/skills/generator/sessions/:sessionId/generate",
@@ -2246,7 +2256,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 224,
+    "index": 225,
     "method": "POST",
     "operationId": "skills.generator.sessions.test",
     "path": "/v1/skills/generator/sessions/:sessionId/test",
@@ -2256,7 +2266,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 225,
+    "index": 226,
     "method": "GET",
     "operationId": "skills.generator.sessions.evidence.get",
     "path": "/v1/skills/generator/sessions/:sessionId/evidence",
@@ -2266,7 +2276,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 226,
+    "index": 227,
     "method": "POST",
     "operationId": "skills.generator.sessions.approve",
     "path": "/v1/skills/generator/sessions/:sessionId/approve",
@@ -2276,7 +2286,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 227,
+    "index": 228,
     "method": "DELETE",
     "operationId": "skills.generator.sessions.cancel",
     "path": "/v1/skills/generator/sessions/:sessionId",
@@ -2286,7 +2296,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 228,
+    "index": 229,
     "method": "GET",
     "operationId": "skills.ui.get",
     "path": "/v1/skills/:skillId/ui",
@@ -2296,7 +2306,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 229,
+    "index": 230,
     "method": "POST",
     "operationId": "uix.intents.resolve",
     "path": "/v1/uix/intents/resolve",
@@ -2306,7 +2316,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 230,
+    "index": 231,
     "method": "GET",
     "operationId": "uix.templates.list",
     "path": "/v1/uix/templates",
@@ -2316,7 +2326,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 231,
+    "index": 232,
     "method": "GET",
     "operationId": "uix.home.snapshot.get",
     "path": "/v1/uix/home-snapshot",
@@ -2326,7 +2336,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 232,
+    "index": 233,
     "method": "GET",
     "operationId": "uix.assistant.inbox.snapshot.get",
     "path": "/v1/uix/assistant-inbox-snapshot",
@@ -2336,7 +2346,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 233,
+    "index": 234,
     "method": "GET",
     "operationId": "uix.diagnostics.get",
     "path": "/v1/uix/diagnostics",
@@ -2346,7 +2356,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 234,
+    "index": 235,
     "method": "GET",
     "operationId": "uix.preferences.list",
     "path": "/v1/uix/preferences",
@@ -2356,7 +2366,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 235,
+    "index": 236,
     "method": "PUT",
     "operationId": "uix.preferences.update",
     "path": "/v1/uix/preferences",
@@ -2366,7 +2376,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 236,
+    "index": 237,
     "method": "DELETE",
     "operationId": "uix.preferences.delete",
     "path": "/v1/uix/preferences/:preferenceId",
@@ -2376,7 +2386,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 237,
+    "index": 238,
     "method": "GET",
     "operationId": "uix.persona.get",
     "path": "/v1/uix/persona",
@@ -2386,7 +2396,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 238,
+    "index": 239,
     "method": "PUT",
     "operationId": "uix.persona.update",
     "path": "/v1/uix/persona",
@@ -2396,7 +2406,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 239,
+    "index": 240,
     "method": "POST",
     "operationId": "uix.templates.execute",
     "path": "/v1/uix/templates/:templateId/execute",
@@ -2406,7 +2416,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 240,
+    "index": 241,
     "method": "POST",
     "operationId": "uix.wizards.start",
     "path": "/v1/uix/wizards/:wizardId/start",
@@ -2416,7 +2426,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 241,
+    "index": 242,
     "method": "POST",
     "operationId": "uix.wizards.continue",
     "path": "/v1/uix/wizards/:wizardId/continue",
@@ -2426,7 +2436,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 242,
+    "index": 243,
     "method": "GET",
     "operationId": "uix.issues.list",
     "path": "/v1/uix/issues",
@@ -2436,7 +2446,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 243,
+    "index": 244,
     "method": "GET",
     "operationId": "uix.user.profile.get",
     "path": "/v1/uix/user-profile",
@@ -2446,7 +2456,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 244,
+    "index": 245,
     "method": "PUT",
     "operationId": "uix.user.profile.update",
     "path": "/v1/uix/user-profile",
@@ -2456,7 +2466,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 245,
+    "index": 246,
     "method": "POST",
     "operationId": "uix.investigate",
     "path": "/v1/uix/investigate",
@@ -2466,7 +2476,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 246,
+    "index": 247,
     "method": "GET",
     "operationId": "uix.learnedfacts.list",
     "path": "/v1/uix/learned-facts",
@@ -2476,7 +2486,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 247,
+    "index": 248,
     "method": "DELETE",
     "operationId": "uix.learnedfacts.clear",
     "path": "/v1/uix/learned-facts",
@@ -2486,7 +2496,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 248,
+    "index": 249,
     "method": "DELETE",
     "operationId": "uix.learnedfacts.delete",
     "path": "/v1/uix/learned-facts/:factKey",
@@ -2496,7 +2506,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 249,
+    "index": 250,
     "method": "GET",
     "operationId": "packs.cross.border.profile.get",
     "path": "/v1/packs/cross-border/profile",
@@ -2506,7 +2516,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 250,
+    "index": 251,
     "method": "PUT",
     "operationId": "packs.cross.border.profile.put",
     "path": "/v1/packs/cross-border/profile",
@@ -2516,7 +2526,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 251,
+    "index": 252,
     "method": "GET",
     "operationId": "packs.cross.border.snapshot.get",
     "path": "/v1/packs/cross-border/snapshot",
@@ -2526,7 +2536,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 252,
+    "index": 253,
     "method": "POST",
     "operationId": "packs.cross.border.import.post",
     "path": "/v1/packs/cross-border/import",
@@ -2536,7 +2546,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 253,
+    "index": 254,
     "method": "POST",
     "operationId": "packs.cross.border.workflow.presets.apply",
     "path": "/v1/packs/cross-border/workflow-presets/apply",
@@ -2546,7 +2556,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 254,
+    "index": 255,
     "method": "PATCH",
     "operationId": "packs.cross.border.workflow.presets.toggle",
     "path": "/v1/packs/cross-border/workflow-presets/:workflowId",
@@ -2556,7 +2566,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 255,
+    "index": 256,
     "method": "GET",
     "operationId": "skills.converters.list",
     "path": "/v1/skills/converters",
@@ -2566,7 +2576,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 256,
+    "index": 257,
     "method": "POST",
     "operationId": "skills.convert",
     "path": "/v1/skills/convert",
@@ -2576,7 +2586,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 257,
+    "index": 258,
     "method": "POST",
     "operationId": "skills.import",
     "path": "/v1/skills/import",
@@ -2586,7 +2596,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 258,
+    "index": 259,
     "method": "POST",
     "operationId": "skills.pack",
     "path": "/v1/skills/pack",
@@ -2596,7 +2606,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 259,
+    "index": 260,
     "method": "POST",
     "operationId": "workflows.generator.sessions.create",
     "path": "/v1/workflows/generator/sessions",
@@ -2606,7 +2616,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 260,
+    "index": 261,
     "method": "GET",
     "operationId": "workflows.generator.sessions.get",
     "path": "/v1/workflows/generator/sessions/:sessionId",
@@ -2616,7 +2626,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 261,
+    "index": 262,
     "method": "POST",
     "operationId": "workflows.generator.sessions.messages.create",
     "path": "/v1/workflows/generator/sessions/:sessionId/messages",
@@ -2626,7 +2636,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 262,
+    "index": 263,
     "method": "POST",
     "operationId": "workflows.generator.sessions.generate",
     "path": "/v1/workflows/generator/sessions/:sessionId/generate",
@@ -2636,7 +2646,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 263,
+    "index": 264,
     "method": "GET",
     "operationId": "workflows.generator.sessions.evidence.get",
     "path": "/v1/workflows/generator/sessions/:sessionId/evidence",
@@ -2646,7 +2656,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 264,
+    "index": 265,
     "method": "POST",
     "operationId": "workflows.generator.sessions.approve",
     "path": "/v1/workflows/generator/sessions/:sessionId/approve",
@@ -2656,7 +2666,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 265,
+    "index": 266,
     "method": "DELETE",
     "operationId": "workflows.generator.sessions.cancel",
     "path": "/v1/workflows/generator/sessions/:sessionId",
@@ -2666,7 +2676,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 266,
+    "index": 267,
     "method": "GET",
     "operationId": "rules.bundles.list",
     "path": "/v1/rules/bundles",
@@ -2676,7 +2686,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 267,
+    "index": 268,
     "method": "GET",
     "operationId": "rules.bundles.get",
     "path": "/v1/rules/bundles/:bundleId",
@@ -2686,7 +2696,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 268,
+    "index": 269,
     "method": "POST",
     "operationId": "rules.bundles.create",
     "path": "/v1/rules/bundles",
@@ -2696,7 +2706,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 269,
+    "index": 270,
     "method": "PATCH",
     "operationId": "rules.bundles.update",
     "path": "/v1/rules/bundles/:bundleId",
@@ -2706,7 +2716,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 270,
+    "index": 271,
     "method": "GET",
     "operationId": "rules.bundles.versions.list",
     "path": "/v1/rules/bundles/:bundleId/versions",
@@ -2716,7 +2726,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 271,
+    "index": 272,
     "method": "GET",
     "operationId": "rules.list",
     "path": "/v1/rules/bundles/:bundleId/rules",
@@ -2726,7 +2736,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 272,
+    "index": 273,
     "method": "POST",
     "operationId": "rules.evaluate",
     "path": "/v1/rules/evaluate",
@@ -2736,7 +2746,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 273,
+    "index": 274,
     "method": "POST",
     "operationId": "rules.simulate",
     "path": "/v1/rules/simulate",
@@ -2746,7 +2756,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 274,
+    "index": 275,
     "method": "GET",
     "operationId": "rules.versions.list",
     "path": "/v1/rules/:ruleId/versions",
@@ -2756,7 +2766,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 275,
+    "index": 276,
     "method": "GET",
     "operationId": "rules.audit.log.list",
     "path": "/v1/rules/audit-log",
@@ -2766,7 +2776,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 276,
+    "index": 277,
     "method": "POST",
     "operationId": "node.runner.execute",
     "path": "/v1/node-runner/execute",
@@ -2776,7 +2786,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 277,
+    "index": 278,
     "method": "GET",
     "operationId": "node.runner.executions.get",
     "path": "/v1/node-runner/executions/:executionId",
@@ -2786,7 +2796,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 278,
+    "index": 279,
     "method": "GET",
     "operationId": "node.runner.executions.list",
     "path": "/v1/node-runner/executions",
@@ -2796,7 +2806,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 279,
+    "index": 280,
     "method": "POST",
     "operationId": "acceptance.run",
     "path": "/v1/acceptance/run",
@@ -2806,7 +2816,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 280,
+    "index": 281,
     "method": "GET",
     "operationId": "acceptance.results.get",
     "path": "/v1/acceptance/results/:resultId",
@@ -2816,7 +2826,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 281,
+    "index": 282,
     "method": "GET",
     "operationId": "acceptance.results.list",
     "path": "/v1/acceptance/results",
@@ -2826,7 +2836,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 282,
+    "index": 283,
     "method": "GET",
     "operationId": "acceptance.runs.get",
     "path": "/v1/acceptance/runs/:runId",
@@ -2836,7 +2846,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 283,
+    "index": 284,
     "method": "GET",
     "operationId": "acceptance.tests.list",
     "path": "/v1/acceptance/tests",
@@ -2846,7 +2856,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 284,
+    "index": 285,
     "method": "GET",
     "operationId": "acceptance.tests.get",
     "path": "/v1/acceptance/tests/:testId",
@@ -2856,7 +2866,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 285,
+    "index": 286,
     "method": "POST",
     "operationId": "acceptance.tests.create",
     "path": "/v1/acceptance/tests",
@@ -2866,7 +2876,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 286,
+    "index": 287,
     "method": "PUT",
     "operationId": "acceptance.tests.update",
     "path": "/v1/acceptance/tests/:testId",
@@ -2876,7 +2886,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 287,
+    "index": 288,
     "method": "DELETE",
     "operationId": "acceptance.tests.delete",
     "path": "/v1/acceptance/tests/:testId",
@@ -2886,7 +2896,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 288,
+    "index": 289,
     "method": "GET",
     "operationId": "acceptance.tests.versions.list",
     "path": "/v1/acceptance/tests/:testId/versions",
@@ -2896,7 +2906,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 289,
+    "index": 290,
     "method": "GET",
     "operationId": "acceptance.artifacts.history",
     "path": "/v1/acceptance/artifacts/history",
@@ -2906,7 +2916,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 290,
+    "index": 291,
     "method": "GET",
     "operationId": "retry.policies.list",
     "path": "/v1/retry/policies",
@@ -2916,7 +2926,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 291,
+    "index": 292,
     "method": "GET",
     "operationId": "retry.policies.get",
     "path": "/v1/retry/policies/:policyId",
@@ -2926,7 +2936,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 292,
+    "index": 293,
     "method": "POST",
     "operationId": "retry.policies.create",
     "path": "/v1/retry/policies",
@@ -2936,7 +2946,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 293,
+    "index": 294,
     "method": "PUT",
     "operationId": "retry.policies.update",
     "path": "/v1/retry/policies/:policyId",
@@ -2946,7 +2956,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 294,
+    "index": 295,
     "method": "DELETE",
     "operationId": "retry.policies.delete",
     "path": "/v1/retry/policies/:policyId",
@@ -2956,7 +2966,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 295,
+    "index": 296,
     "method": "POST",
     "operationId": "retry.classify",
     "path": "/v1/retry/classify",
@@ -2966,7 +2976,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 296,
+    "index": 297,
     "method": "POST",
     "operationId": "retry.decide",
     "path": "/v1/retry/decide",
@@ -2976,7 +2986,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 297,
+    "index": 298,
     "method": "GET",
     "operationId": "retry.traces.list",
     "path": "/v1/retry/traces",
@@ -2986,7 +2996,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 298,
+    "index": 299,
     "method": "GET",
     "operationId": "retry.traces.get",
     "path": "/v1/retry/traces/:traceId",
@@ -2996,7 +3006,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 299,
+    "index": 300,
     "method": "GET",
     "operationId": "retry.costs.summary",
     "path": "/v1/retry/costs",
@@ -3006,7 +3016,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 300,
+    "index": 301,
     "method": "GET",
     "operationId": "retry.escalations.list",
     "path": "/v1/retry/escalations",
@@ -3016,7 +3026,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 301,
+    "index": 302,
     "method": "POST",
     "operationId": "retry.escalations.acknowledge",
     "path": "/v1/retry/escalations/:escalationId/acknowledge",
@@ -3026,7 +3036,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 302,
+    "index": 303,
     "method": "GET",
     "operationId": "retry.circuit.breakers.list",
     "path": "/v1/retry/circuit-breakers",
@@ -3036,7 +3046,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 303,
+    "index": 304,
     "method": "GET",
     "operationId": "playbook.list",
     "path": "/v1/playbooks",
@@ -3046,7 +3056,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 304,
+    "index": 305,
     "method": "GET",
     "operationId": "playbook.get",
     "path": "/v1/playbooks/:playbookId",
@@ -3056,7 +3066,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 305,
+    "index": 306,
     "method": "POST",
     "operationId": "playbook.select",
     "path": "/v1/playbooks/select",
@@ -3066,7 +3076,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 306,
+    "index": 307,
     "method": "GET",
     "operationId": "playbook.candidates.list",
     "path": "/v1/playbooks/candidates",
@@ -3076,7 +3086,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 307,
+    "index": 308,
     "method": "POST",
     "operationId": "playbook.candidates.promote",
     "path": "/v1/playbooks/candidates/:candidateId/promote",
@@ -3086,7 +3096,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 308,
+    "index": 309,
     "method": "POST",
     "operationId": "playbook.rollback",
     "path": "/v1/playbooks/:playbookId/rollback",
@@ -3096,7 +3106,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 309,
+    "index": 310,
     "method": "GET",
     "operationId": "playbook.scores",
     "path": "/v1/playbooks/:playbookId/scores",
@@ -3106,7 +3116,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 310,
+    "index": 311,
     "method": "POST",
     "operationId": "memory.store",
     "path": "/v1/memory/store",
@@ -3116,7 +3126,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 311,
+    "index": 312,
     "method": "POST",
     "operationId": "memory.items.create",
     "path": "/v1/memory/items",
@@ -3126,7 +3136,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 312,
+    "index": 313,
     "method": "POST",
     "operationId": "memory.search",
     "path": "/v1/memory/search",
@@ -3136,7 +3146,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 313,
+    "index": 314,
     "method": "GET",
     "operationId": "memory.get",
     "path": "/v1/memory/items/:id",
@@ -3146,7 +3156,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 314,
+    "index": 315,
     "method": "GET",
     "operationId": "memory.list",
     "path": "/v1/memory/items",
@@ -3156,7 +3166,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 315,
+    "index": 316,
     "method": "DELETE",
     "operationId": "memory.delete",
     "path": "/v1/memory/items/:id",
@@ -3166,7 +3176,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 316,
+    "index": 317,
     "method": "POST",
     "operationId": "memory.prune",
     "path": "/v1/memory/prune",
@@ -3176,7 +3186,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 317,
+    "index": 318,
     "method": "GET",
     "operationId": "sessions.usage.get",
     "path": "/v1/sessions/:sessionKey/usage",
@@ -3186,7 +3196,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 318,
+    "index": 319,
     "method": "GET",
     "operationId": "sessions.usage.list",
     "path": "/v1/sessions/usage",
@@ -3196,7 +3206,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 319,
+    "index": 320,
     "method": "GET",
     "operationId": "sessions.list",
     "path": "/v1/sessions",
@@ -3206,7 +3216,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 320,
+    "index": 321,
     "method": "POST",
     "operationId": "sessions.create",
     "path": "/v1/sessions",
@@ -3216,7 +3226,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 321,
+    "index": 322,
     "method": "GET",
     "operationId": "sessions.get",
     "path": "/v1/sessions/:sessionKey",
@@ -3226,7 +3236,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 322,
+    "index": 323,
     "method": "DELETE",
     "operationId": "sessions.delete",
     "path": "/v1/sessions/:sessionKey",
@@ -3236,7 +3246,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 323,
+    "index": 324,
     "method": "POST",
     "operationId": "sessions.archive",
     "path": "/v1/sessions/:sessionKey/archive",
@@ -3246,7 +3256,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 324,
+    "index": 325,
     "method": "POST",
     "operationId": "sessions.reset",
     "path": "/v1/sessions/:sessionKey/reset",
@@ -3256,7 +3266,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 325,
+    "index": 326,
     "method": "POST",
     "operationId": "sessions.prune",
     "path": "/v1/sessions/prune",
@@ -3266,7 +3276,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 326,
+    "index": 327,
     "method": "POST",
     "operationId": "sessions.sweep",
     "path": "/v1/sessions/sweep",
@@ -3276,7 +3286,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 327,
+    "index": 328,
     "method": "POST",
     "operationId": "sessions.compact",
     "path": "/v1/sessions/:sessionKey/compact",
@@ -3286,7 +3296,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 328,
+    "index": 329,
     "method": "GET",
     "operationId": "sessions.messages.list",
     "path": "/v1/sessions/:sessionKey/messages",
@@ -3296,7 +3306,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 329,
+    "index": 330,
     "method": "GET",
     "operationId": "sessions.export",
     "path": "/v1/sessions/:sessionKey/export",
@@ -3306,7 +3316,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 330,
+    "index": 331,
     "method": "POST",
     "operationId": "sessions.messages.create",
     "path": "/v1/sessions/:sessionKey/messages",
@@ -3316,7 +3326,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 331,
+    "index": 332,
     "method": "POST",
     "operationId": "sessions.outbound.send",
     "path": "/v1/sessions/:sessionKey/outbound",
@@ -3326,7 +3336,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 332,
+    "index": 333,
     "method": "POST",
     "operationId": "sessions.run",
     "path": "/v1/sessions/:sessionKey/run",
@@ -3336,7 +3346,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 333,
+    "index": 334,
     "method": "GET",
     "operationId": "sessions.memory.namespace.get",
     "path": "/v1/sessions/:sessionKey/memory-namespace",
@@ -3346,7 +3356,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 334,
+    "index": 335,
     "method": "POST",
     "operationId": "sessions.forks.create",
     "path": "/v1/sessions/:sessionKey/fork",
@@ -3356,7 +3366,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 335,
+    "index": 336,
     "method": "GET",
     "operationId": "sessions.forks.list",
     "path": "/v1/sessions/:sessionKey/forks",
@@ -3366,7 +3376,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 336,
+    "index": 337,
     "method": "POST",
     "operationId": "sessions.forks.merge",
     "path": "/v1/sessions/:sessionKey/merge",
@@ -3376,7 +3386,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 337,
+    "index": 338,
     "method": "POST",
     "operationId": "sessions.memory.extract",
     "path": "/v1/sessions/:sessionKey/memory/extract",
@@ -3386,7 +3396,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 338,
+    "index": 339,
     "method": "POST",
     "operationId": "sessions.memory.remember",
     "path": "/v1/sessions/:sessionKey/memory/remember",
@@ -3396,7 +3406,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 339,
+    "index": 340,
     "method": "GET",
     "operationId": "sessions.memory.extraction.get",
     "path": "/v1/sessions/:sessionKey/memory/extraction",
@@ -3406,7 +3416,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 340,
+    "index": 341,
     "method": "POST",
     "operationId": "sessions.memory.extraction.retry",
     "path": "/v1/sessions/memory/extraction/retry",
@@ -3416,7 +3426,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 341,
+    "index": 342,
     "method": "GET",
     "operationId": "plugins.list",
     "path": "/v1/plugins",
@@ -3426,7 +3436,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 342,
+    "index": 343,
     "method": "GET",
     "operationId": "plugins.get",
     "path": "/v1/plugins/:id",
@@ -3436,7 +3446,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 343,
+    "index": 344,
     "method": "GET",
     "operationId": "plugins.versions.list",
     "path": "/v1/plugins/:id/versions",
@@ -3446,7 +3456,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 344,
+    "index": 345,
     "method": "POST",
     "operationId": "plugins.install",
     "path": "/v1/plugins/:id/install",
@@ -3456,7 +3466,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 345,
+    "index": 346,
     "method": "POST",
     "operationId": "plugins.enable",
     "path": "/v1/plugins/:id/enable",
@@ -3466,7 +3476,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 346,
+    "index": 347,
     "method": "POST",
     "operationId": "plugins.disable",
     "path": "/v1/plugins/:id/disable",
@@ -3476,7 +3486,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 347,
+    "index": 348,
     "method": "DELETE",
     "operationId": "plugins.uninstall",
     "path": "/v1/plugins/:id",
@@ -3486,7 +3496,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 348,
+    "index": 349,
     "method": "POST",
     "operationId": "agent.runs.start",
     "path": "/v1/agent/runs",
@@ -3496,7 +3506,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 349,
+    "index": 350,
     "method": "GET",
     "operationId": "agent.runs.list",
     "path": "/v1/agent/runs",
@@ -3506,7 +3516,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 350,
+    "index": 351,
     "method": "GET",
     "operationId": "agent.runs.summary",
     "path": "/v1/agent/runs/summary",
@@ -3516,7 +3526,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 351,
+    "index": 352,
     "method": "GET",
     "operationId": "agent.runs.get",
     "path": "/v1/agent/runs/:runId",
@@ -3526,7 +3536,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 352,
+    "index": 353,
     "method": "POST",
     "operationId": "agent.runs.cancel",
     "path": "/v1/agent/runs/:runId/cancel",
@@ -3536,7 +3546,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 353,
+    "index": 354,
     "method": "GET",
     "operationId": "agent.runs.audit",
     "path": "/v1/agent/runs/:runId/audit",
@@ -3546,7 +3556,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 354,
+    "index": 355,
     "method": "POST",
     "operationId": "agent.runs.rollback",
     "path": "/v1/agent/runs/:runId/rollback",
@@ -3556,7 +3566,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 355,
+    "index": 356,
     "method": "POST",
     "operationId": "agent.runs.approve.plan",
     "path": "/v1/agent/runs/:runId/approve-plan",
@@ -3566,7 +3576,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 356,
+    "index": 357,
     "method": "POST",
     "operationId": "agent.runs.reject.plan",
     "path": "/v1/agent/runs/:runId/reject-plan",
@@ -3576,7 +3586,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 357,
+    "index": 358,
     "method": "POST",
     "operationId": "agent.runs.approve.tool",
     "path": "/v1/agent/runs/:runId/approve-tool",
@@ -3586,7 +3596,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 358,
+    "index": 359,
     "method": "POST",
     "operationId": "agent.runs.reject.tool",
     "path": "/v1/agent/runs/:runId/reject-tool",
@@ -3596,7 +3606,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 359,
+    "index": 360,
     "method": "GET",
     "operationId": "agent.runs.events",
     "path": "/v1/agent/runs/:runId/events",
@@ -3606,7 +3616,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 360,
+    "index": 361,
     "method": "POST",
     "operationId": "agent.automations.create",
     "path": "/v1/agent/automations",
@@ -3616,7 +3626,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 361,
+    "index": 362,
     "method": "GET",
     "operationId": "agent.automations.list",
     "path": "/v1/agent/automations",
@@ -3626,7 +3636,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 362,
+    "index": 363,
     "method": "GET",
     "operationId": "agent.automations.get",
     "path": "/v1/agent/automations/:automationId",
@@ -3636,7 +3646,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 363,
+    "index": 364,
     "method": "PATCH",
     "operationId": "agent.automations.update",
     "path": "/v1/agent/automations/:automationId",
@@ -3646,7 +3656,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 364,
+    "index": 365,
     "method": "DELETE",
     "operationId": "agent.automations.delete",
     "path": "/v1/agent/automations/:automationId",
@@ -3656,7 +3666,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 365,
+    "index": 366,
     "method": "POST",
     "operationId": "agent.automations.run",
     "path": "/v1/agent/automations/:automationId/run",
@@ -3666,7 +3676,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 366,
+    "index": 367,
     "method": "GET",
     "operationId": "agent.subagents.list",
     "path": "/v1/agent/subagents",
@@ -3676,7 +3686,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 367,
+    "index": 368,
     "method": "GET",
     "operationId": "agent.subagents.get",
     "path": "/v1/agent/subagents/:subagentId",
@@ -3686,7 +3696,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 368,
+    "index": 369,
     "method": "GET",
     "operationId": "agent.runs.subagents.list",
     "path": "/v1/agent/runs/:runId/subagents",

--- a/test/unit/api/routes/friday-social-import-routes.test.ts
+++ b/test/unit/api/routes/friday-social-import-routes.test.ts
@@ -1,0 +1,448 @@
+import { describe, it, expect, vi } from "vitest";
+
+import {
+  createFridaySocialImportRoutes,
+  type FridaySocialImportRoutesRegistrationDeps,
+} from "../../../../src/api/http/routes/friday-social-import-routes.js";
+import type {
+  FridaySocialImportService,
+  FridaySocialImportStageContext,
+} from "../../../../src/skills/social-import/friday-social-import.types.js";
+import type {
+  FridaySkillConverterService,
+  FridaySkillImportOutput,
+} from "../../../../src/skills/converter/services/friday-skill-converter-service.types.js";
+import type { FridayExternalSkillCandidate } from "../../../../src/skills/converter/services/friday-skill-candidate-store.js";
+import {
+  createFridayMutatingActionGate,
+  signFridayCanonicalApproval,
+  type FridayMutatingActionGate,
+  type FridayMutatingActionGateResult,
+} from "../../../../src/security/friday-mutating-action-gate.js";
+import { FridayDomainError } from "../../../../src/errors/friday-domain-error.js";
+
+// ─── Helpers ───
+
+const NOW = "2026-05-13T00:00:00.000Z";
+const TOKEN_SECRET = "test-secret"; // pragma: allowlist secret
+
+function makeStageContext(overrides: Partial<FridaySocialImportStageContext> = {}): FridaySocialImportStageContext {
+  return {
+    request: {
+      socialUrl: "https://www.xiaohongshu.com/explore/abc",
+      targetGithubRepoUrl: "https://github.com/octocat/Hello-World",
+    },
+    sessionId: "xhs-default",
+    source: {
+      uri: "https://github.com/octocat/Hello-World",
+      formatHint: "code-repo",
+    },
+    sourceProvenanceDigest: "abcdef0123456789",
+    redactedSocialUri: "https://www.xiaohongshu.com/explore/abc",
+    redactedTargetUri: "https://github.com/octocat/Hello-World",
+    extraction: {
+      socialDomain: "xiaohongshu.com",
+      fieldsPresent: ["author", "content", "likes"],
+      commentCount: 2,
+      extractionDurationMs: 12,
+    },
+    planDigest: "test-plan-digest",
+    ...overrides,
+  };
+}
+
+function makeService(overrides: Partial<FridaySocialImportService> = {}): FridaySocialImportService {
+  return {
+    prepareStageContext: vi.fn(async () => makeStageContext()),
+    ...overrides,
+  };
+}
+
+function makeCandidate(overrides: Partial<FridayExternalSkillCandidate> = {}): FridayExternalSkillCandidate {
+  return {
+    candidateId: "Hello-World-1.0.0-abcdef",
+    shadowVersionId: "Hello-World-1.0.0-abcdef",
+    skillId: "Hello-World",
+    version: "1.0.0",
+    converterId: "code-repo",
+    detectedFormat: "code-repo",
+    sourceProvenance: {
+      sourceKind: "uri",
+      sourceDigest: "deadbeef",
+      redactedUri: "https://github.com/octocat/Hello-World",
+      formatHint: "code-repo",
+    },
+    canonicalApprovalProof: {
+      gateId: "friday_canonical_mutating_action_gate",
+      ticketId: "ticket-1",
+      actionDigest: "digest-1",
+      action: "skills.import.stage_candidate",
+      surface: "api:/v1/skills/social-import",
+      resource: {
+        type: "external_skill_candidate",
+        id: "skill-source:abcdef",
+      },
+      risk: "high",
+      approvalId: "approval-1",
+      approvedByPrincipalId: "tenant-a",
+      issuedAt: NOW,
+    },
+    candidateDir: "/tmp/test/skill-candidates/Hello-World-1.0.0-abcdef",
+    filesDir: "/tmp/test/skill-candidates/Hello-World-1.0.0-abcdef/files",
+    stagedAt: NOW,
+    validation: { ok: true, issues: [], verifiedAt: NOW },
+    ...overrides,
+  };
+}
+
+function makeConverter(overrides: Partial<FridaySkillConverterService> = {}): FridaySkillConverterService {
+  const importResult: FridaySkillImportOutput = {
+    converterId: "code-repo",
+    detectedFormat: "code-repo",
+    candidates: [makeCandidate()],
+    validation: [{ skillId: "Hello-World", ok: true, issues: [] }],
+    registryRefreshed: false,
+  };
+  return {
+    listConverters: vi.fn(() => []),
+    detect: vi.fn(),
+    convert: vi.fn(),
+    getCandidate: vi.fn(),
+    import: vi.fn(async () => importResult),
+    pack: vi.fn(),
+    ...overrides,
+  };
+}
+
+function makeGate(): FridayMutatingActionGate {
+  return createFridayMutatingActionGate({
+    nowIso: () => NOW,
+    ticketIdGenerator: () => "ticket-1",
+    approvalSignatureSecret: TOKEN_SECRET,
+    requireApprovalSignature: true,
+  });
+}
+
+function makeDeps(overrides: Partial<FridaySocialImportRoutesRegistrationDeps> = {}): FridaySocialImportRoutesRegistrationDeps {
+  return {
+    service: makeService(),
+    converterService: makeConverter(),
+    canonicalMutationGate: makeGate(),
+    disabledReason: null,
+    ...overrides,
+  };
+}
+
+function makeDisabledDeps(reason: string): FridaySocialImportRoutesRegistrationDeps {
+  return {
+    service: null,
+    converterService: null,
+    canonicalMutationGate: null,
+    disabledReason: reason,
+  };
+}
+
+function makeCtx(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    requestId: "req-1",
+    receivedAt: NOW,
+    params: {},
+    query: {},
+    body: {
+      socialUrl: "https://www.xiaohongshu.com/explore/abc",
+      targetGithubRepoUrl: "https://github.com/octocat/Hello-World",
+    },
+    headers: {},
+    principal: { principalType: "user", principalId: "tenant-a" },
+    ...overrides,
+  };
+}
+
+function findRoute(
+  routes: ReturnType<typeof createFridaySocialImportRoutes>,
+  operationId: string,
+) {
+  const route = routes.find((r) => r.operationId === operationId);
+  if (!route) throw new Error(`Route not found: ${operationId}`);
+  return route;
+}
+
+// ─── Registration contract ───
+
+describe("createFridaySocialImportRoutes — registration", () => {
+  it("always registers exactly 1 route (skills.social.import)", () => {
+    const enabled = createFridaySocialImportRoutes(makeDeps());
+    const disabled = createFridaySocialImportRoutes(makeDisabledDeps("deps absent"));
+    expect(enabled).toHaveLength(1);
+    expect(disabled).toHaveLength(1);
+  });
+
+  it("registers POST /v1/skills/social-import with public auth", () => {
+    const routes = createFridaySocialImportRoutes(makeDeps());
+    const route = findRoute(routes, "skills.social.import");
+    expect(route.method).toBe("POST");
+    expect(route.path).toBe("/v1/skills/social-import");
+    expect(route.auth).toEqual({ public: true });
+  });
+});
+
+// ─── Disabled state ───
+
+describe("createFridaySocialImportRoutes — disabled state", () => {
+  it("returns 503 SOCIAL_IMPORT_DISABLED when service is absent", async () => {
+    const deps = makeDisabledDeps("XHS browser deps not initialised in this runtime");
+    const route = findRoute(createFridaySocialImportRoutes(deps), "skills.social.import");
+    let thrown: unknown = null;
+    try {
+      await route.handler(makeCtx() as never);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(FridayDomainError);
+    expect((thrown as FridayDomainError).code).toBe("SOCIAL_IMPORT_DISABLED");
+    expect((thrown as FridayDomainError).httpStatus).toBe(503);
+    expect((thrown as FridayDomainError).message).toContain(
+      "XHS browser deps not initialised",
+    );
+  });
+
+  it("returns 503 SOCIAL_IMPORT_DISABLED when converter or gate is absent", async () => {
+    const deps: FridaySocialImportRoutesRegistrationDeps = {
+      service: makeService(),
+      converterService: null,
+      canonicalMutationGate: null,
+      disabledReason: null,
+    };
+    const route = findRoute(createFridaySocialImportRoutes(deps), "skills.social.import");
+    await expect(route.handler(makeCtx() as never)).rejects.toMatchObject({
+      code: "SOCIAL_IMPORT_DISABLED",
+      httpStatus: 503,
+    });
+  });
+});
+
+// ─── Body validation ───
+
+describe("createFridaySocialImportRoutes — body validation", () => {
+  it("rejects non-object body with 400 VALIDATION_ERROR", async () => {
+    const route = findRoute(createFridaySocialImportRoutes(makeDeps()), "skills.social.import");
+    await expect(
+      route.handler(makeCtx({ body: "not-an-object" }) as never),
+    ).rejects.toMatchObject({ code: "VALIDATION_ERROR", httpStatus: 400 });
+  });
+
+  it("rejects body missing socialUrl with 400", async () => {
+    const route = findRoute(createFridaySocialImportRoutes(makeDeps()), "skills.social.import");
+    await expect(
+      route.handler(
+        makeCtx({
+          body: { targetGithubRepoUrl: "https://github.com/octocat/Hello-World" },
+        }) as never,
+      ),
+    ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+  });
+
+  it("rejects body missing targetGithubRepoUrl with 400", async () => {
+    const route = findRoute(createFridaySocialImportRoutes(makeDeps()), "skills.social.import");
+    await expect(
+      route.handler(
+        makeCtx({
+          body: { socialUrl: "https://www.xiaohongshu.com/explore/abc" },
+        }) as never,
+      ),
+    ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+  });
+
+  it("does not accept userId from body; principal comes from ctx", async () => {
+    const service = makeService();
+    const route = findRoute(
+      createFridaySocialImportRoutes(makeDeps({ service })),
+      "skills.social.import",
+    );
+    try {
+      await route.handler(
+        makeCtx({
+          body: {
+            socialUrl: "https://www.xiaohongshu.com/explore/abc",
+            targetGithubRepoUrl: "https://github.com/octocat/Hello-World",
+            userId: "attacker-impersonating",
+          },
+        }) as never,
+      );
+    } catch {
+      // Expected — the gate will reject without canonicalApproval; we only
+      // care that the service was called with the ctx principal id.
+    }
+    expect(service.prepareStageContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorPrincipalId: "tenant-a",
+      }),
+    );
+    // Ensure the body userId was NOT used as the actor id.
+    expect(service.prepareStageContext).not.toHaveBeenCalledWith(
+      expect.objectContaining({ actorPrincipalId: "attacker-impersonating" }),
+    );
+  });
+});
+
+// ─── Approval-pending branch ───
+
+describe("createFridaySocialImportRoutes — approval-pending branch", () => {
+  it("returns 403 CANONICAL_APPROVAL_REQUIRED when canonicalApproval is absent", async () => {
+    const deps = makeDeps();
+    const route = findRoute(createFridaySocialImportRoutes(deps), "skills.social.import");
+    let thrown: unknown = null;
+    try {
+      await route.handler(makeCtx() as never);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(FridayDomainError);
+    expect((thrown as FridayDomainError).code).toBe("CANONICAL_APPROVAL_REQUIRED");
+    expect((thrown as FridayDomainError).httpStatus).toBe(403);
+    const details = (thrown as FridayDomainError).details as Record<string, unknown>;
+    expect(details.planDigest).toBeDefined();
+    expect(details.redactedSocialUri).toBeDefined();
+    expect(details.redactedTargetUri).toBeDefined();
+    expect(details.socialDomain).toBe("xiaohongshu.com");
+    expect(details.extraction).toBeDefined();
+    expect(deps.converterService?.import).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Candidate-staged branch ───
+
+describe("createFridaySocialImportRoutes — candidate-staged branch", () => {
+  async function stageCandidate(): Promise<{ result: unknown; deps: FridaySocialImportRoutesRegistrationDeps }> {
+    const deps = makeDeps();
+    const route = findRoute(createFridaySocialImportRoutes(deps), "skills.social.import");
+    // First call to extract the actionDigest from the gate-thrown 403.
+    let actionDigest = "";
+    try {
+      await route.handler(makeCtx() as never);
+    } catch (err) {
+      const details = (err as FridayDomainError).details as { canonicalGate?: { actionDigest?: string } };
+      actionDigest = details.canonicalGate?.actionDigest ?? "";
+    }
+    expect(actionDigest).toBeTruthy();
+    const canonicalApproval = signFridayCanonicalApproval(
+      {
+        decision: "approved",
+        approvalId: "approval-1",
+        decidedByPrincipalId: "tenant-a",
+        actionDigest,
+        expiresAt: "2026-05-13T01:00:00.000Z",
+      },
+      TOKEN_SECRET,
+    );
+    const result = await route.handler(
+      makeCtx({
+        body: {
+          socialUrl: "https://www.xiaohongshu.com/explore/abc",
+          targetGithubRepoUrl: "https://github.com/octocat/Hello-World",
+          canonicalApproval,
+        },
+      }) as never,
+    );
+    return { result, deps };
+  }
+
+  it("stages the candidate and returns the redacted-only response shape", async () => {
+    const { result, deps } = await stageCandidate();
+    const response = result as Record<string, unknown>;
+    expect(response.ok).toBe(true);
+    expect(response.candidateId).toBe("Hello-World-1.0.0-abcdef");
+    expect(response.skillId).toBe("Hello-World");
+    expect(response.socialDomain).toBe("xiaohongshu.com");
+    expect(typeof response.redactedSocialUri).toBe("string");
+    expect(typeof response.redactedTargetUri).toBe("string");
+    expect(typeof response.sourceProvenanceDigest).toBe("string");
+    expect(typeof response.planDigest).toBe("string");
+    expect(typeof response.ticketId).toBe("string");
+    expect(typeof response.stagedAt).toBe("string");
+    expect(response.extraction).toBeDefined();
+    expect(Array.isArray(response.nextSteps)).toBe(true);
+    // The response body must NOT contain raw URLs or a `source` field that
+    // would echo the targetGithubRepoUrl.
+    expect("source" in response).toBe(false);
+    expect("request" in response).toBe(false);
+    expect(deps.converterService?.import).toHaveBeenCalledTimes(1);
+  });
+
+  it("includes the canonical next-step route sequence", async () => {
+    const { result } = await stageCandidate();
+    const response = result as { nextSteps: string[] };
+    expect(response.nextSteps).toContain(
+      "POST /v1/autonomy/skills/:skillId/shadow",
+    );
+    expect(response.nextSteps).toContain(
+      "POST /v1/autonomy/skills/:skillId/canary",
+    );
+    expect(response.nextSteps).toContain(
+      "POST /v1/autonomy/skills/:skillId/promote",
+    );
+    expect(response.nextSteps).toContain(
+      "POST /v1/skills/:skillId/verify",
+    );
+  });
+
+  it("never echoes raw cookie/session/secret-shaped material or a source/request object", async () => {
+    const { result } = await stageCandidate();
+    const serialised = JSON.stringify(result);
+    // The redacted URIs are intentionally present (and may equal the raw
+    // input when there is no credential-shaped query string). What the
+    // response MUST NOT echo: a `source` object, a `request` mirror, a
+    // `userId` field, cookies, session-string shapes, or query-string
+    // credentials.
+    expect(serialised).not.toMatch(/"source":/);
+    expect(serialised).not.toMatch(/"request":/);
+    expect(serialised).not.toMatch(/"userId":/);
+    expect(serialised).not.toMatch(/web_session=/);
+    expect(serialised).not.toMatch(/a1=/);
+    expect(serialised).not.toMatch(/Authorization/i);
+    expect(serialised).not.toMatch(/Bearer /);
+  });
+});
+
+// ─── Denied gate ───
+
+describe("createFridaySocialImportRoutes — denied gate", () => {
+  it("returns 403 CANONICAL_APPROVAL_DENIED when gate decision is deny", async () => {
+    const denyGate: FridayMutatingActionGate = {
+      evaluate: vi.fn(
+        (): FridayMutatingActionGateResult => ({
+          decision: "deny",
+          reason: "policy_blocks_external_skill",
+          risk: "high",
+          actionDigest: "digest-1",
+          approvalRequired: true,
+          localClaims: [],
+          evidenceRecord: {
+            gateId: "friday_canonical_mutating_action_gate",
+            evaluatedAt: NOW,
+            decision: "deny",
+            reason: "policy_blocks_external_skill",
+            actionDigest: "digest-1",
+            action: "skills.import.stage_candidate",
+            actor: { kind: "user", id: "tenant-a", principalId: "tenant-a" },
+            surface: "api:/v1/skills/social-import",
+            resource: { type: "external_skill_candidate", id: "skill-source:abc" },
+            mutating: true,
+            risk: "high",
+            approvalRequired: true,
+            localClaims: [],
+          },
+        }),
+      ),
+    } as unknown as FridayMutatingActionGate;
+    const deps = makeDeps({ canonicalMutationGate: denyGate });
+    const route = findRoute(
+      createFridaySocialImportRoutes(deps),
+      "skills.social.import",
+    );
+    await expect(route.handler(makeCtx() as never)).rejects.toMatchObject({
+      code: "CANONICAL_APPROVAL_DENIED",
+      httpStatus: 403,
+    });
+  });
+});

--- a/test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts
@@ -193,6 +193,36 @@ describe("API Runtime — Extended Route Registration", () => {
     // MEDIA_UNDERSTANDING_DISABLED, never 404.
     expect(operationIds).toContain("media.understanding.doctor");
     expect(operationIds).toContain("media.understanding.analyze");
+    // Phase 02b: social-import route is ALWAYS registered even when
+    // deps.socialImport is omitted. Disabled deployments return 503
+    // SOCIAL_IMPORT_DISABLED, never 404.
+    expect(operationIds).toContain("skills.social.import");
+  });
+
+  it("registers skills.social.import in disabled state when deps.socialImport is omitted", async () => {
+    const runtime = createFridayApiRuntime(makeBaseDeps());
+    const route = runtime.routes.getRoutes().find((r) => r.operationId === "skills.social.import");
+    expect(route).toBeDefined();
+    let thrown: unknown = null;
+    try {
+      await route!.handler({
+        requestId: "req-social-import-disabled",
+        receivedAt: NOW,
+        params: {},
+        query: {},
+        body: {
+          socialUrl: "https://www.xiaohongshu.com/explore/abc",
+          targetGithubRepoUrl: "https://github.com/octocat/Hello-World",
+        },
+        headers: {},
+        principal: makePrincipal({ role: "admin", scopes: ["hub.admin"] }),
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(FridayDomainError);
+    expect((thrown as FridayDomainError).code).toBe("SOCIAL_IMPORT_DISABLED");
+    expect((thrown as FridayDomainError).httpStatus).toBe(503);
   });
 
   it("registers media-understanding routes in disabled state when deps.mediaUnderstanding is omitted", async () => {

--- a/test/unit/skills/social-import/friday-social-import-service.test.ts
+++ b/test/unit/skills/social-import/friday-social-import-service.test.ts
@@ -1,0 +1,305 @@
+import { describe, it, expect, vi } from "vitest";
+
+import {
+  createFridaySocialImportService,
+  type CreateFridaySocialImportServiceDeps,
+} from "../../../../src/skills/social-import/friday-social-import-service.js";
+import {
+  FRIDAY_SOCIAL_IMPORT_PLAN_VERSION,
+  type FridaySocialImportRequest,
+} from "../../../../src/skills/social-import/friday-social-import.types.js";
+import { FridayDomainError } from "../../../../src/errors/friday-domain-error.js";
+import type {
+  XhsComment,
+  XhsPageInteractions,
+  XhsSessionManager,
+} from "../../../../src/xhs/index.js";
+
+// ─── Helpers ───
+
+function makeSessionManager(overrides: Partial<XhsSessionManager> = {}): XhsSessionManager {
+  return {
+    saveCookies: vi.fn(),
+    loadCookies: vi.fn(),
+    isSessionValid: vi.fn(() => true),
+    getSession: vi.fn(() => undefined),
+    deleteSession: vi.fn(),
+    listSessions: vi.fn(() => []),
+    touchSession: vi.fn(),
+    ...overrides,
+  };
+}
+
+function makePageInteractions(overrides: Partial<XhsPageInteractions> = {}): XhsPageInteractions {
+  const sampleComments: XhsComment[] = [
+    { author: "alice", content: "great post", likes: "12" },
+    { author: "bob", content: "nice", likes: "3" },
+  ];
+  return {
+    login: vi.fn(),
+    search: vi.fn(),
+    createPost: vi.fn(),
+    extractComments: vi.fn(async () => sampleComments),
+    checkLoginState: vi.fn(),
+    ...overrides,
+  };
+}
+
+function makeDeps(overrides: Partial<CreateFridaySocialImportServiceDeps> = {}): CreateFridaySocialImportServiceDeps {
+  return {
+    xhsPageInteractions: makePageInteractions(),
+    xhsSessionManager: makeSessionManager(),
+    ...overrides,
+  };
+}
+
+function makeRequest(overrides: Partial<FridaySocialImportRequest> = {}): FridaySocialImportRequest {
+  return {
+    socialUrl: "https://www.xiaohongshu.com/explore/abc123",
+    targetGithubRepoUrl: "https://github.com/octocat/Hello-World",
+    ...overrides,
+  };
+}
+
+// ─── URL allowlist ───
+
+describe("createFridaySocialImportService — URL allowlist", () => {
+  it("rejects non-XHS social URL with 400 VALIDATION_ERROR", async () => {
+    const svc = createFridaySocialImportService(makeDeps());
+    await expect(
+      svc.prepareStageContext({
+        request: makeRequest({ socialUrl: "https://example.com/post/1" }),
+        actorPrincipalId: "tenant-a",
+        actorPrincipalKind: "user",
+        surface: "api:/v1/skills/social-import",
+      }),
+    ).rejects.toBeInstanceOf(FridayDomainError);
+  });
+
+  it("rejects non-https social URL", async () => {
+    const svc = createFridaySocialImportService(makeDeps());
+    await expect(
+      svc.prepareStageContext({
+        request: makeRequest({ socialUrl: "http://www.xiaohongshu.com/explore/abc" }),
+        actorPrincipalId: "tenant-a",
+        actorPrincipalKind: "user",
+        surface: "api:/v1/skills/social-import",
+      }),
+    ).rejects.toMatchObject({ code: "VALIDATION_ERROR", httpStatus: 400 });
+  });
+
+  it("rejects non-github.com target URL", async () => {
+    const svc = createFridaySocialImportService(makeDeps());
+    await expect(
+      svc.prepareStageContext({
+        request: makeRequest({
+          targetGithubRepoUrl: "https://gitlab.com/foo/bar",
+        }),
+        actorPrincipalId: "tenant-a",
+        actorPrincipalKind: "user",
+        surface: "api:/v1/skills/social-import",
+      }),
+    ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+  });
+
+  it("rejects malformed target path (missing owner/repo)", async () => {
+    const svc = createFridaySocialImportService(makeDeps());
+    await expect(
+      svc.prepareStageContext({
+        request: makeRequest({ targetGithubRepoUrl: "https://github.com/" }),
+        actorPrincipalId: "tenant-a",
+        actorPrincipalKind: "user",
+        surface: "api:/v1/skills/social-import",
+      }),
+    ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+  });
+
+  it("rejects data:, file:, javascript: schemes", async () => {
+    const svc = createFridaySocialImportService(makeDeps());
+    for (const scheme of [
+      "data:text/plain;base64,YWFh",
+      "file:///etc/passwd",
+      "javascript:alert(1)",
+    ]) {
+      await expect(
+        svc.prepareStageContext({
+          request: makeRequest({ socialUrl: scheme }),
+          actorPrincipalId: "tenant-a",
+          actorPrincipalKind: "user",
+          surface: "api:/v1/skills/social-import",
+        }),
+      ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+    }
+  });
+});
+
+// ─── Human-blocked branch ───
+
+describe("createFridaySocialImportService — human-blocked", () => {
+  it("throws 503 SOCIAL_IMPORT_QR_LOGIN_REQUIRED when session is not valid", async () => {
+    const sessionManager = makeSessionManager({
+      isSessionValid: vi.fn(() => false),
+    });
+    const pageInteractions = makePageInteractions();
+    const svc = createFridaySocialImportService({
+      xhsPageInteractions: pageInteractions,
+      xhsSessionManager: sessionManager,
+    });
+    let thrown: unknown = null;
+    try {
+      await svc.prepareStageContext({
+        request: makeRequest(),
+        actorPrincipalId: "tenant-a",
+        actorPrincipalKind: "user",
+        surface: "api:/v1/skills/social-import",
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(FridayDomainError);
+    expect((thrown as FridayDomainError).code).toBe("SOCIAL_IMPORT_QR_LOGIN_REQUIRED");
+    expect((thrown as FridayDomainError).httpStatus).toBe(503);
+    const details = (thrown as FridayDomainError).details as Record<string, unknown>;
+    expect(details.blockedBy).toBe("xhs.qr_login");
+    expect(details.remediation).toBe("agent_tool:xhs.login");
+    expect(pageInteractions.extractComments).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Successful stage context ───
+
+describe("createFridaySocialImportService — stage context", () => {
+  it("produces a deterministic planDigest for the same inputs", async () => {
+    const svc = createFridaySocialImportService(makeDeps());
+    const args = {
+      request: makeRequest(),
+      actorPrincipalId: "tenant-a",
+      actorPrincipalKind: "user",
+      surface: "api:/v1/skills/social-import",
+    } as const;
+    const a = await svc.prepareStageContext(args);
+    const b = await svc.prepareStageContext(args);
+    expect(a.planDigest).toBe(b.planDigest);
+    expect(a.planDigest.length).toBeGreaterThan(16);
+  });
+
+  it("records extraction shape with field names only, never values", async () => {
+    const svc = createFridaySocialImportService(makeDeps());
+    const ctx = await svc.prepareStageContext({
+      request: makeRequest(),
+      actorPrincipalId: "tenant-a",
+      actorPrincipalKind: "user",
+      surface: "api:/v1/skills/social-import",
+    });
+    expect(ctx.extraction.socialDomain).toBe("xiaohongshu.com");
+    expect(ctx.extraction.fieldsPresent).toEqual(["author", "content", "likes"]);
+    expect(ctx.extraction.commentCount).toBe(2);
+    expect(ctx.extraction.extractionDurationMs).toBeGreaterThanOrEqual(0);
+    // The stage context MUST NOT carry any comment author / content / likes
+    // VALUES. Stringify and search for the stub fixture values.
+    const serialised = JSON.stringify(ctx);
+    expect(serialised).not.toContain("alice");
+    expect(serialised).not.toContain("bob");
+    expect(serialised).not.toContain("great post");
+    expect(serialised).not.toContain("nice");
+  });
+
+  it("redacts query strings from social and target URIs", async () => {
+    const svc = createFridaySocialImportService(makeDeps());
+    const ctx = await svc.prepareStageContext({
+      request: makeRequest({
+        socialUrl: "https://www.xiaohongshu.com/explore/note-1?token=xyz&trace=abcdef",
+        targetGithubRepoUrl: "https://github.com/octocat/Hello-World?token=zzz",
+      }),
+      actorPrincipalId: "tenant-a",
+      actorPrincipalKind: "user",
+      surface: "api:/v1/skills/social-import",
+    });
+    // Query-string contents must be redacted (the converter helper replaces
+    // search with `?redacted=1`). Path segments are preserved per the
+    // existing redaction shape used by the converter — they are not assumed
+    // to contain secrets.
+    expect(ctx.redactedSocialUri).not.toContain("token=xyz");
+    expect(ctx.redactedSocialUri).not.toContain("trace=abcdef");
+    expect(ctx.redactedTargetUri).not.toContain("token=zzz");
+    // Response-shaped fields (the ones the route returns to the client and
+    // would emit into a learning payload) must not contain raw query values.
+    // The internal `source.uri` field is excluded because the converter
+    // service needs the raw URL to materialise the candidate; that field
+    // is never echoed to the response body by the route handler.
+    const responseShaped = {
+      redactedSocialUri: ctx.redactedSocialUri,
+      redactedTargetUri: ctx.redactedTargetUri,
+      sourceProvenanceDigest: ctx.sourceProvenanceDigest,
+      extraction: ctx.extraction,
+      planDigest: ctx.planDigest,
+    };
+    const responseFlat = JSON.stringify(responseShaped);
+    expect(responseFlat).not.toContain("token=xyz");
+    expect(responseFlat).not.toContain("token=zzz");
+    expect(responseFlat).not.toContain("trace=abcdef");
+  });
+
+  it("uses ctx.actorPrincipalId in planDigest derivation (not body)", async () => {
+    const svc = createFridaySocialImportService(makeDeps());
+    const a = await svc.prepareStageContext({
+      request: makeRequest(),
+      actorPrincipalId: "actor-1",
+      actorPrincipalKind: "user",
+      surface: "api:/v1/skills/social-import",
+    });
+    const b = await svc.prepareStageContext({
+      request: makeRequest(),
+      actorPrincipalId: "actor-2",
+      actorPrincipalKind: "user",
+      surface: "api:/v1/skills/social-import",
+    });
+    expect(a.planDigest).not.toBe(b.planDigest);
+  });
+
+  it("plan version is recorded for the slice", () => {
+    expect(FRIDAY_SOCIAL_IMPORT_PLAN_VERSION).toBe("friday.phase_02b.social-import.v1");
+  });
+
+  it("surfaces extraction failure as 502 with redacted URLs", async () => {
+    const socialUrl = "https://www.xiaohongshu.com/explore/abc123";
+    const targetGithubRepoUrl = "https://github.com/octocat/Hello-World";
+    const svc = createFridaySocialImportService(
+      makeDeps({
+        xhsPageInteractions: makePageInteractions({
+          extractComments: vi.fn(async () => {
+            throw new Error(
+              `navigation to ${socialUrl} failed for target ${targetGithubRepoUrl}`,
+            );
+          }),
+        }),
+      }),
+    );
+    let thrown: unknown = null;
+    try {
+      await svc.prepareStageContext({
+        request: makeRequest({ socialUrl, targetGithubRepoUrl }),
+        actorPrincipalId: "tenant-a",
+        actorPrincipalKind: "user",
+        surface: "api:/v1/skills/social-import",
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(FridayDomainError);
+    expect((thrown as FridayDomainError).code).toBe(
+      "SOCIAL_IMPORT_EXTRACTION_FAILED",
+    );
+    expect((thrown as FridayDomainError).httpStatus).toBe(502);
+    expect((thrown as FridayDomainError).message).not.toContain(socialUrl);
+    expect((thrown as FridayDomainError).message).not.toContain(
+      targetGithubRepoUrl,
+    );
+    expect((thrown as FridayDomainError).message).toContain(
+      "<redacted-social-uri>",
+    );
+    expect((thrown as FridayDomainError).message).toContain(
+      "<redacted-target-uri>",
+    );
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,7 @@ const pathAliases = {
   "#satellites": resolve(__dirname, "src/satellites/index.ts"),
   "#skills/converter": resolve(__dirname, "src/skills/converter/index.ts"),
   "#skills/generator": resolve(__dirname, "src/skills/generator/index.ts"),
+  "#skills/social-import": resolve(__dirname, "src/skills/social-import/index.ts"),
   "#memory": resolve(__dirname, "src/memory/index.ts"),
   "#sessions": resolve(__dirname, "src/sessions/index.ts"),
   "#skills": resolve(__dirname, "src/skills/index.ts"),


### PR DESCRIPTION
## Summary

- Adds public `POST /v1/skills/social-import` route (Phase 02b partial slice, Mode A: user-provided target GitHub repo URL)
- Performs XHS session/human-blocked check, existing `extractComments` path for real-browser provenance, redacted-URI social-aware `planDigest`, canonical approval gate evaluation, and converter candidate staging
- Always-registered pattern: returns `503 SOCIAL_IMPORT_DISABLED` when XHS browser deps are absent (never 404)
- Three handler branches: approval-pending (`403`), human-blocked (`503`), candidate-staged (`200` with `nextSteps` listing the existing autonomy + verify routes)
- Does **NOT** call `installer.installConvertedSkill`, autonomy `shadow/canary/promote/rollback`, `lifecycleService.verifySkill`, or emit learning events — full Phase 02b closure remains residual through existing autonomy lifecycle routes

## Scope

**14 files** (6 new + 8 edited):
- New: `src/skills/social-import/` module (types, service, barrel), route handler, route + service unit tests
- Edited: `package.json` + `vitest.config.ts` (alias), `src/api/index.ts` (export), `src/api/runtime/friday-api-runtime.ts` (registration), `src/api/runtime/friday-api-runtime.types.ts` (dep type), `src/hub/friday-hub-bootstrap.ts` (wiring), route-contract snapshot (370/370/0), extra-route-registration test

## Test plan

- [x] 12/12 service unit tests (URL allowlist, human-blocked, planDigest determinism, extraction shape, redaction, error redaction)
- [x] 13/13 route unit tests (registration, disabled-state, body validation, principal from ctx not body, approval-pending 403, candidate-staged 200 with real `signFridayCanonicalApproval`, denied 403, nextSteps, no source/request/userId echo)
- [x] 15/15 extra-route-registration tests (always-registered + disabled-state 503)
- [x] 6/6 route-contract snapshot (370 routes / 370 public / 0 authenticated)
- [x] Typecheck: 0 errors
- [x] `check:secret-patterns`: clean
- [x] `git diff --check origin/main`: clean
- [x] Real-runtime proof on local hub: human-blocked 503, validation 400s, redaction scan clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)