### PR TITLE
fix(autonomy): recheck live capability matrix on acquisition approval

### DIFF
--- a/src/autonomy/services/friday-capability-acquisition-service.ts
+++ b/src/autonomy/services/friday-capability-acquisition-service.ts
@@ -143,14 +143,25 @@ export function createFridayCapabilityAcquisitionService(
     if (current.status === "cancelled") {
       return current;
     }
+
+    const liveMatrix = await resolveMatrix(false);
+    const liveItemByCapability = new Map(liveMatrix.items.map((item) => [item.capability, item]));
+
     if (current.humanBlockers.length > 0) {
-      const blocked = {
-        ...current,
-        status: "human_blocked" as const,
-        updatedAt: nowIso(),
-      };
-      saveRun(blocked);
-      return blocked;
+      const unresolvedBlockers = collectHumanBlockers(
+        current.candidates,
+        current.requiredCapabilities.filter((cap) => liveItemByCapability.get(cap)?.state !== "available"),
+      );
+      if (unresolvedBlockers.length > 0) {
+        const blocked = {
+          ...current,
+          status: "human_blocked" as const,
+          humanBlockers: unresolvedBlockers,
+          updatedAt: nowIso(),
+        };
+        saveRun(blocked);
+        return blocked;
+      }
     }
 
     const verifiedAt = nowIso();
@@ -175,16 +186,25 @@ export function createFridayCapabilityAcquisitionService(
         });
         continue;
       }
+      const liveItem = liveItemByCapability.get(capability);
       const passed = candidate.sourceType === "available_runtime"
         || candidate.sourceType === "skill_generator"
         || candidate.sourceType === "workflow_generator"
-        || candidate.sourceType === "builtin_catalog";
+        || candidate.sourceType === "builtin_catalog"
+        || liveItem?.state === "available";
+      const liveVerified = passed
+        && candidate.sourceType !== "available_runtime"
+        && candidate.sourceType !== "skill_generator"
+        && candidate.sourceType !== "workflow_generator"
+        && candidate.sourceType !== "builtin_catalog";
       verificationResults.push({
         candidateId: candidate.id,
         capability,
         status: passed ? "passed" : "blocked",
         evidence: passed
-          ? `Sandbox/doctor dry-run accepted ${candidate.label}; runtime registration may proceed.`
+          ? liveVerified
+            ? `Live runtime capability matrix confirms ${capability} is available after external setup; doctor state verified at runtime.`
+            : `Sandbox/doctor dry-run accepted ${candidate.label}; runtime registration may proceed.`
           : `${candidate.label} still requires external setup or installation evidence before registration.`,
         verifiedAt,
         ...(passed ? {} : { blocker: "External setup/install must complete and pass doctor verification." }),
@@ -195,9 +215,11 @@ export function createFridayCapabilityAcquisitionService(
           sourceCandidateId: candidate.id,
           registeredAt: verifiedAt,
           state: "available",
-          note: candidate.sourceType === "available_runtime"
-            ? "Already present in runtime capability matrix."
-            : "Generated/local candidate passed the sandbox gate and can be routed.",
+          note: liveVerified
+            ? "External setup completed; live capability matrix confirms availability via runtime doctor."
+            : candidate.sourceType === "available_runtime"
+              ? "Already present in runtime capability matrix."
+              : "Generated/local candidate passed the sandbox gate and can be routed.",
         });
       }
     }

--- a/test/unit/autonomy/friday-controlled-autonomy-services.test.ts
+++ b/test/unit/autonomy/friday-controlled-autonomy-services.test.ts
@@ -63,6 +63,69 @@ describe("controlled autonomy closed loops", () => {
     expect(approved.registeredCapabilities.some((item) => item.capability === "ocr")).toBe(false);
   });
 
+  it("registers external setup_recipe candidate when live matrix confirms capability is available", async () => {
+    let currentMatrix = matrixWith();
+    const mutableService = createFridayCapabilityAcquisitionService({
+      db,
+      idGenerator: createTestIdGenerator(),
+      nowIso: () => `2026-04-25T00:00:${String(++nowCounter).padStart(2, "0")}.000Z`,
+      policyService,
+      capabilitySnapshotGetter: () => ({ readOnly: false, ...emptyAgentSnapshot(), runtime: currentMatrix }),
+    });
+
+    const run = await mutableService.startRun({
+      userId: "test-user",
+      goal: "识别这张扫描件里的文字",
+      requiredCapabilities: ["text", "ocr"],
+    });
+    expect(run.status).toBe("human_blocked");
+    expect(run.humanBlockers.join("\n")).toContain("API key");
+
+    const stillBlocked = await mutableService.approveRun(run.id);
+    expect(stillBlocked.status).toBe("human_blocked");
+
+    currentMatrix = matrixWith("ocr");
+
+    const approved = await mutableService.approveRun(run.id);
+    expect(approved.status).toBe("verified");
+    expect(approved.executionSuggestion.canExecute).toBe(true);
+    expect(approved.executionSuggestion.nextAction).toBe("execute_task");
+    expect(approved.registeredCapabilities).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ capability: "ocr", state: "available" }),
+      ]),
+    );
+    const ocrVerification = approved.verificationResults.find((v) => v.capability === "ocr");
+    expect(ocrVerification?.status).toBe("passed");
+    expect(ocrVerification?.evidence).toContain("Live runtime capability matrix");
+  });
+
+  it("keeps partial blockers when only some external capabilities become available", async () => {
+    let currentMatrix = matrixWith();
+    const mutableService = createFridayCapabilityAcquisitionService({
+      db,
+      idGenerator: createTestIdGenerator(),
+      nowIso: () => `2026-04-25T00:00:${String(++nowCounter).padStart(2, "0")}.000Z`,
+      policyService,
+      capabilitySnapshotGetter: () => ({ readOnly: false, ...emptyAgentSnapshot(), runtime: currentMatrix }),
+    });
+
+    const run = await mutableService.startRun({
+      userId: "test-user",
+      goal: "识别扫描件并生成语音",
+      requiredCapabilities: ["text", "ocr", "tts"],
+    });
+    expect(run.status).toBe("human_blocked");
+    expect(run.humanBlockers.length).toBeGreaterThanOrEqual(2);
+
+    currentMatrix = matrixWith("ocr");
+
+    const partial = await mutableService.approveRun(run.id);
+    expect(partial.status).toBe("human_blocked");
+    expect(partial.humanBlockers.some((b) => b.includes("ocr"))).toBe(false);
+    expect(partial.humanBlockers.some((b) => b.includes("tts"))).toBe(true);
+  });
+
   it("requires approval before a generated custom capability can register", async () => {
     const run = await acquisitionService.startRun({
       userId: "test-user",
@@ -150,7 +213,7 @@ function emptyAgentSnapshot() {
   };
 }
 
-function matrixWith(): FridayRuntimeCapabilityMatrix {
+function matrixWith(...extraAvailable: FridayRuntimeCapabilityId[]): FridayRuntimeCapabilityMatrix {
   const available = new Set<FridayRuntimeCapabilityId>([
     "text",
     "web_search",
@@ -160,6 +223,7 @@ function matrixWith(): FridayRuntimeCapabilityMatrix {
     "pdf_parse",
     "browser",
     "skills",
+    ...extraAvailable,
   ]);
   const needsAuth = new Set<FridayRuntimeCapabilityId>(["vision", "ocr", "embedding", "tts"]);
   const buildable = new Set<FridayRuntimeCapabilityId>(["custom"]);


### PR DESCRIPTION
## Summary

- `approveRun()` in the capability acquisition service now re-resolves the live capability matrix before deciding whether human blockers are still active
- External candidates (`setup_recipe`, `repair_option`, `mcp_registry`, `github`, `npm`, `openapi`, `web_search`) can now transition to `available` when the live matrix confirms the capability is live after external human setup
- Partial blocker path refreshes only unresolved blockers; resolved capabilities are removed from the blocker list without overclaiming capability registration
- 2 new tests: full-resolution path (external candidate → human setup → approve → verified) and partial-blocker path (some resolved, some still blocked)

## Scope

**Phase 04 Option A only**: live matrix re-check in `approveRun()`.

- No skill lifecycle / install_register / shadow / promote / provider / memory semantics changed
- No route changes, no new HTTP endpoints, no database schema changes
- No AGENTS.md, stage wire, old ledger, or governance file changes
- Only 2 files modified: `src/autonomy/services/friday-capability-acquisition-service.ts` and `test/unit/autonomy/friday-controlled-autonomy-services.test.ts`

## Proof tier

- **mock-contract** (unit tests with mock DB and mock capability matrix) — regression detection only, not release proof
- **Real-runtime proof was NOT attempted** and remains `blocked_by_env` unless separately run with hub + provider credentials
- `blocked_by_env` is an honest blocked state, not pass

## Verification

- 7/7 focused vitest tests pass (5 existing + 2 new)
- `npm run typecheck`: clean across all 3 tsconfig targets
- `npm run check:secret-patterns`: clean
- `git diff --check`: clean
- Stage 5 Reviewer A PASS (factual correctness, early-return fix, no missed entrypoints)
- Stage 5 Reviewer B PASS (no overclaim, no secret leakage, no test weakening, no scope creep)

## Test plan

- [ ] CI checks pass (build, test, typecheck, lint, contracts, secrets, agent-parity, security, quality-gate)
- [ ] RGG artifact downloaded and read honestly if release proof is claimed
- [ ] Real-runtime proof: start hub, create acquisition run for vision/OCR, approve after provider setup, confirm status=verified (blocked_by_env unless separately run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)