### PR TITLE
feat(skills): add upgrade analysis lifecycle gate

### DIFF
--- a/src/api/http/routes/friday-skill-routes.ts
+++ b/src/api/http/routes/friday-skill-routes.ts
@@ -23,6 +23,7 @@ import type {
   FridaySkillLifecycleService,
   FridaySkillRegistry,
 } from "#skills";
+import type { FridaySkillUpgradeAnalysisService } from "../../../skills/services/friday-skill-upgrade-analysis-service.js";
 import { FridayDomainError } from "#errors";
 import { resolveSafeInstallDir } from "#utilities";
 import { throwFridayCapabilityDisabled } from "./friday-capability-disabled.js";
@@ -44,6 +45,7 @@ export interface FridaySkillRoutesDeps {
 	  getSkillLifecycleStatus?: (skillId: string) => string | null | undefined;
 	  canonicalMutationGate?: FridayMutatingActionGate;
 	  registerRetiredLegacySkillMutationRoutes?: boolean;
+	  upgradeAnalysis?: FridaySkillUpgradeAnalysisService;
 	}
 
 function createFridaySkillContentUpdateMutatingActionRequest(input: {
@@ -669,6 +671,115 @@ export function createFridaySkillRoutes(
         return { updated: true, skillId, skill };
       },
     });
+  }
+
+  // ── Skill upgrade analysis + decision (Phase 06) ──
+  if (deps.upgradeAnalysis) {
+    routes.push(
+      {
+        operationId: "skills.upgrade.analyze",
+        method: "POST",
+        path: "/v1/skills/:skillId/upgrade/analyze",
+        auth: { public: true },
+        async handler(ctx) {
+          const skillId = String((ctx.params as Record<string, unknown>).skillId ?? "");
+          const body = asRecord(ctx.body);
+          const candidateId = asOptionalString(body.candidateId, "candidateId");
+          if (!candidateId) {
+            throw new FridayDomainError("VALIDATION_ERROR", '"candidateId" is required', {
+              httpStatus: 400,
+            });
+          }
+          const analysis = deps.upgradeAnalysis!.analyze({ skillId, candidateId });
+          return { analysis };
+        },
+      },
+      {
+        operationId: "skills.upgrade.decide",
+        method: "POST",
+        path: "/v1/skills/:skillId/upgrade/decide",
+        auth: { public: true },
+        async handler(ctx) {
+          const skillId = String((ctx.params as Record<string, unknown>).skillId ?? "");
+          const body = asRecord(ctx.body);
+          const candidateId = asOptionalString(body.candidateId, "candidateId");
+          if (!candidateId) {
+            throw new FridayDomainError("VALIDATION_ERROR", '"candidateId" is required', {
+              httpStatus: 400,
+            });
+          }
+          const decision = asOptionalString(body.decision, "decision");
+          if (decision !== "replace" && decision !== "keep") {
+            throw new FridayDomainError("VALIDATION_ERROR", '"decision" must be "replace" or "keep"', {
+              httpStatus: 400,
+            });
+          }
+
+          const analysis = deps.upgradeAnalysis!.analyze({ skillId, candidateId });
+
+          const ticket = assertCanonicalApproval({
+            deps,
+            request: {
+              action: "skills.upgrade.decide",
+              actor: createActorFromPrincipal(ctx.principal, "skill-upgrade-operator"),
+              surface: "api:/v1/skills/:skillId/upgrade/decide",
+              resource: {
+                type: "skill_upgrade",
+                id: skillId,
+                digest: hashStableJson({
+                  skillId,
+                  candidateId,
+                  decision,
+                  analysisDigest: analysis.analysisDigest,
+                  recommendation: analysis.recommendation,
+                  regressionVerdict: analysis.regressionProof.overallVerdict,
+                }),
+                attributes: {
+                  skillId,
+                  candidateId,
+                  analysisDigest: analysis.analysisDigest,
+                },
+              },
+              mutating: true,
+              risk: "high",
+              parameters: {
+                skillId,
+                candidateId,
+                decision,
+                analysisDigest: analysis.analysisDigest,
+                recommendation: analysis.recommendation,
+                regressionVerdict: analysis.regressionProof.overallVerdict,
+              },
+              idempotencyKey: asOptionalString(body.idempotencyKey, "idempotencyKey"),
+              localClaims: [
+                {
+                  guardId: "skill_upgrade_decision_guard",
+                  decision: "requires_approval",
+                  risk: "high",
+                  reason: "skill_upgrade_decision_requires_canonical_approval",
+                },
+              ],
+            },
+            canonicalApproval: readCanonicalApproval(body.canonicalApproval),
+            requiredCode: "SKILL_UPGRADE_DECIDE_APPROVAL_REQUIRED",
+            deniedCode: "SKILL_UPGRADE_DECIDE_APPROVAL_DENIED",
+            unavailableCode: "SKILL_UPGRADE_DECIDE_GATE_UNAVAILABLE",
+            requiredMessage: "Skill upgrade decisions require canonical approval before mutation.",
+            deniedMessage: "Skill upgrade decision was blocked by the canonical approval gate",
+            unavailableMessage: "Skill upgrade decisions require the canonical approval gate.",
+          });
+
+          const record = deps.upgradeAnalysis!.applyDecision({
+            skillId,
+            candidateId,
+            decision,
+            analysisDigest: analysis.analysisDigest,
+            ticket,
+          });
+          return { record };
+        },
+      },
+    );
   }
 
   // ── Skill execution dispatch (POST /v1/skills/:skillId/run) ──

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -157,6 +157,7 @@ import { createFridayAutonomyUpgradePlannerService } from "../../autonomy/servic
 import { createFridayAutonomyUpgradeStatusService } from "../../autonomy/services/friday-autonomy-upgrade-status-service.js";
 import { createFridayWorkflowUpgradeLifecycleService } from "../../autonomy/services/friday-workflow-upgrade-lifecycle-service.js";
 import { createFridaySkillUpgradeLifecycleService } from "../../autonomy/services/friday-skill-upgrade-lifecycle-service.js";
+import { createFridaySkillUpgradeAnalysisService } from "../../skills/services/friday-skill-upgrade-analysis-service.js";
 import { createFridayProviderProfileUpgradeLifecycleService } from "../../autonomy/services/friday-provider-profile-upgrade-lifecycle-service.js";
 import {
   createFridayPluginLifecycleMutatingActionRequest,
@@ -897,6 +898,16 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
       ? () => deps.skillRegistry!.refresh()
       : undefined,
     updateSkillStatus: deps.updateSkillStatus,
+  });
+  const upgradeAnalysis = createFridaySkillUpgradeAnalysisService({
+    db: deps.db,
+    nowIso: deps.nowIso,
+    skillRepo,
+    workflowRepo,
+    workspaceDir: stateDir,
+    resolveCandidate: deps.converterService
+      ? (input) => deps.converterService!.getCandidate(input)
+      : undefined,
   });
   const getSkillLifecycleDetail = (skillId: string): FridaySkillLifecycleDetail | null => {
     const lifecycleDetail = deps.skillLifecycle?.getSkill(skillId);
@@ -2558,6 +2569,7 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
 	      getSkillLifecycleStatus: (skillId) => skillRepo.getSkillById(deps.db.writer, skillId)?.status,
 	      canonicalMutationGate,
 	      registerRetiredLegacySkillMutationRoutes: !deps.skillLifecycle && skillLifecycleActionsAvailable,
+	      upgradeAnalysis,
 	    })) {
       routes.register(route);
     }

--- a/src/skills/index.ts
+++ b/src/skills/index.ts
@@ -235,6 +235,20 @@ export {
   type CreateFridaySkillLifecycleServiceDeps,
 } from "./services/friday-skill-lifecycle-service.js";
 
+export {
+  createFridaySkillUpgradeAnalysisService,
+  type FridaySkillUpgradeAnalysisService,
+  type FridaySkillUpgradeAnalysis,
+  type FridaySkillUpgradeDecisionRecord,
+  type FridaySkillManifestComparisonReport,
+  type FridaySkillBreakingChange,
+  type FridaySkillAffectedWorkflow,
+  type FridaySkillAffectedWorkflowNodeDetail,
+  type FridaySkillWorkflowRegressionProof,
+  type FridaySkillWorkflowRegressionEntry,
+  type CreateFridaySkillUpgradeAnalysisServiceDeps,
+} from "./services/friday-skill-upgrade-analysis-service.js";
+
 // Generator (re-export key types for convenience; full module at #skills/generator)
 export type { FridaySkillGeneratorService } from "./generator/services/friday-skill-generator-service.types.js";
 

--- a/src/skills/services/friday-skill-upgrade-analysis-service.ts
+++ b/src/skills/services/friday-skill-upgrade-analysis-service.ts
@@ -1,0 +1,529 @@
+import { createHash } from "node:crypto";
+import type { FridaySqliteLayer } from "#state";
+import { FridayDomainError } from "#errors";
+import { loadFridaySkillPackage } from "../manifest/friday-skill-package-loader.js";
+import type { SkillManifestV2, SkillInvocationMode } from "../model/friday-skill-manifest-v2.types.js";
+import type { PermissionGrant } from "../model/friday-skill-permission-policy.types.js";
+import type { FridaySkillEntity } from "../model/friday-skill-catalog.types.js";
+import type { FridaySkillRepository } from "../persistence/friday-skill-repository.js";
+import type { FridayWorkflowRepository } from "../../workflows/persistence/friday-workflow-repository.js";
+import { parseGraphJson } from "../../workflows/model/friday-workflow-graph.types.js";
+import type { FridayExternalSkillCandidate } from "../converter/services/friday-skill-candidate-store.js";
+import type { FridayMutatingActionTicket } from "../../security/friday-mutating-action-gate.js";
+
+// ─── Public types ───
+
+export interface FridaySkillManifestComparisonReport {
+  inputs: {
+    added: string[];
+    removed: string[];
+    changed: string[];
+  };
+  outputs: {
+    added: string[];
+    removed: string[];
+  };
+  permissions: {
+    added: string[];
+    removed: string[];
+  };
+  triggers: {
+    intentsAdded: string[];
+    intentsRemoved: string[];
+    phrasesAdded: string[];
+    phrasesRemoved: string[];
+    channelsAdded: string[];
+    channelsRemoved: string[];
+  };
+  runtime: {
+    kindChanged: boolean;
+    entrypointChanged: boolean;
+    oldKind: string;
+    newKind: string;
+  };
+  breakingChanges: FridaySkillBreakingChange[];
+}
+
+export interface FridaySkillBreakingChange {
+  kind: "removed_required_input" | "removed_output" | "runtime_kind_change" | "workflow_mode_removed";
+  detail: string;
+}
+
+export interface FridaySkillAffectedWorkflowNodeDetail {
+  nodeId: string;
+  effectiveSkillRef: string;
+  inputMappingKeys: string[];
+}
+
+export interface FridaySkillWorkflowRegressionEntry {
+  workflowId: string;
+  workflowName: string;
+  nodes: FridaySkillAffectedWorkflowNodeDetail[];
+  verdict: "pass" | "fail";
+  failures: string[];
+}
+
+export interface FridaySkillAffectedWorkflow {
+  workflowId: string;
+  workflowName: string;
+  nodes: FridaySkillAffectedWorkflowNodeDetail[];
+}
+
+export interface FridaySkillWorkflowRegressionProof {
+  overallVerdict: "pass" | "fail" | "no_affected_workflows";
+  entries: FridaySkillWorkflowRegressionEntry[];
+}
+
+export interface FridaySkillUpgradeAnalysis {
+  skillId: string;
+  candidateId: string;
+  isDuplicate: boolean;
+  existingVersion: string | null;
+  candidateVersion: string;
+  comparisonReport: FridaySkillManifestComparisonReport | null;
+  affectedWorkflows: FridaySkillAffectedWorkflow[];
+  regressionProof: FridaySkillWorkflowRegressionProof;
+  recommendation: "replace" | "keep" | "review_required";
+  rollbackPointer: {
+    available: boolean;
+    previousVersion: string | null;
+    previousManifestDigest: string | null;
+  };
+  analysisDigest: string;
+  analyzedAt: string;
+}
+
+export interface FridaySkillUpgradeDecisionRecord {
+  decision: "replace" | "keep";
+  skillId: string;
+  candidateId: string;
+  analysisDigest: string;
+  decidedAt: string;
+  approvalProof: {
+    ticketId: string;
+    actionDigest: string;
+    action: string;
+    resource: { type: string; id: string };
+    risk: string;
+    approvedByPrincipalId: string;
+    issuedAt: string;
+  };
+}
+
+export interface FridaySkillUpgradeAnalysisService {
+  analyze(input: { skillId: string; candidateId: string }): FridaySkillUpgradeAnalysis;
+  applyDecision(input: {
+    skillId: string;
+    candidateId: string;
+    decision: "replace" | "keep";
+    analysisDigest: string;
+    ticket: FridayMutatingActionTicket;
+  }): FridaySkillUpgradeDecisionRecord;
+}
+
+// ─── Dependencies ───
+
+export interface CreateFridaySkillUpgradeAnalysisServiceDeps {
+  db: FridaySqliteLayer;
+  nowIso: () => string;
+  skillRepo: FridaySkillRepository;
+  workflowRepo: FridayWorkflowRepository;
+  workspaceDir: string;
+  resolveCandidate?: (input: { skillId: string; candidateId: string }) =>
+    FridayExternalSkillCandidate | null;
+}
+
+// ─── Factory ───
+
+export function createFridaySkillUpgradeAnalysisService(
+  deps: CreateFridaySkillUpgradeAnalysisServiceDeps,
+): FridaySkillUpgradeAnalysisService {
+  function loadCandidateManifest(
+    candidate: FridayExternalSkillCandidate,
+  ): SkillManifestV2 {
+    const loaded = loadFridaySkillPackage({
+      skillDir: candidate.filesDir,
+      workspaceDir: deps.workspaceDir,
+    });
+    if (!loaded.ok) {
+      throw new FridayDomainError(
+        "UPGRADE_CANDIDATE_MANIFEST_LOAD_FAILED",
+        `Failed to load manifest from staged candidate ${candidate.candidateId}: ${loaded.error.message}`,
+        { httpStatus: 400 },
+      );
+    }
+    return loaded.value.manifest;
+  }
+
+  function resolveAndLoadCandidate(
+    skillId: string,
+    candidateId: string,
+  ): { candidate: FridayExternalSkillCandidate; manifest: SkillManifestV2 } {
+    if (!deps.resolveCandidate) {
+      throw new FridayDomainError(
+        "UPGRADE_CANDIDATE_RESOLUTION_UNAVAILABLE",
+        "Candidate resolution is not available on this runtime",
+        { httpStatus: 503 },
+      );
+    }
+    const candidate = deps.resolveCandidate({ skillId, candidateId });
+    if (!candidate) {
+      throw new FridayDomainError(
+        "UPGRADE_CANDIDATE_NOT_FOUND",
+        `No staged candidate found for skill ${skillId} with candidateId ${candidateId}`,
+        { httpStatus: 404 },
+      );
+    }
+    const manifest = loadCandidateManifest(candidate);
+    return { candidate, manifest };
+  }
+
+  function normalizeForStableStringify(value: unknown): unknown {
+    if (value === null || typeof value === "string" || typeof value === "boolean") return value;
+    if (typeof value === "number") return Number.isFinite(value) ? value : null;
+    if (Array.isArray(value)) return value.map((item) => normalizeForStableStringify(item));
+    if (typeof value === "object") {
+      const record = value as Record<string, unknown>;
+      return Object.fromEntries(
+        Object.keys(record).sort().filter((key) => record[key] !== undefined)
+          .map((key) => [key, normalizeForStableStringify(record[key])]),
+      );
+    }
+    return null;
+  }
+
+  function stableStringify(value: unknown): string {
+    return JSON.stringify(normalizeForStableStringify(value));
+  }
+
+  function compareManifests(
+    oldManifest: SkillManifestV2,
+    newManifest: SkillManifestV2,
+  ): FridaySkillManifestComparisonReport {
+    const oldInputKeys = new Set(oldManifest.inputs.map((i) => i.key));
+    const newInputKeys = new Set(newManifest.inputs.map((i) => i.key));
+    const oldOutputKeys = new Set(oldManifest.outputs.map((o) => o.key));
+    const newOutputKeys = new Set(newManifest.outputs.map((o) => o.key));
+    const oldGrantIds = new Set((oldManifest.permissions?.grants ?? []).map((g: PermissionGrant) => g.id));
+    const newGrantIds = new Set((newManifest.permissions?.grants ?? []).map((g: PermissionGrant) => g.id));
+
+    const inputsAdded = [...newInputKeys].filter((k) => !oldInputKeys.has(k));
+    const inputsRemoved = [...oldInputKeys].filter((k) => !newInputKeys.has(k));
+    const inputsChanged: string[] = [];
+    for (const key of oldInputKeys) {
+      if (newInputKeys.has(key)) {
+        const oldInput = oldManifest.inputs.find((i) => i.key === key);
+        const newInput = newManifest.inputs.find((i) => i.key === key);
+        if (oldInput && newInput && (oldInput.type !== newInput.type || oldInput.required !== newInput.required)) {
+          inputsChanged.push(key);
+        }
+      }
+    }
+
+    const outputsAdded = [...newOutputKeys].filter((k) => !oldOutputKeys.has(k));
+    const outputsRemoved = [...oldOutputKeys].filter((k) => !newOutputKeys.has(k));
+
+    const permissionsAdded = [...newGrantIds].filter((id) => !oldGrantIds.has(id));
+    const permissionsRemoved = [...oldGrantIds].filter((id) => !newGrantIds.has(id));
+
+    const oldIntents = new Set(oldManifest.triggers?.intents ?? []);
+    const newIntents = new Set(newManifest.triggers?.intents ?? []);
+    const oldPhrases = new Set(oldManifest.triggers?.phrases ?? []);
+    const newPhrases = new Set(newManifest.triggers?.phrases ?? []);
+    const oldChannels = new Set(oldManifest.triggers?.channels ?? []);
+    const newChannels = new Set(newManifest.triggers?.channels ?? []);
+
+    const breakingChanges: FridaySkillBreakingChange[] = [];
+
+    for (const key of inputsRemoved) {
+      const oldInput = oldManifest.inputs.find((i) => i.key === key);
+      if (oldInput?.required) {
+        breakingChanges.push({
+          kind: "removed_required_input",
+          detail: `Required input "${key}" was removed`,
+        });
+      }
+    }
+    for (const key of outputsRemoved) {
+      breakingChanges.push({
+        kind: "removed_output",
+        detail: `Output "${key}" was removed`,
+      });
+    }
+
+    const kindChanged = oldManifest.runtime.kind !== newManifest.runtime.kind;
+    if (kindChanged) {
+      breakingChanges.push({
+        kind: "runtime_kind_change",
+        detail: `Runtime kind changed from "${oldManifest.runtime.kind}" to "${newManifest.runtime.kind}"`,
+      });
+    }
+
+    const oldModes = new Set<SkillInvocationMode>(oldManifest.invocation?.modes ?? []);
+    const newModes = new Set<SkillInvocationMode>(newManifest.invocation?.modes ?? []);
+    if (oldModes.has("workflow") && !newModes.has("workflow")) {
+      breakingChanges.push({
+        kind: "workflow_mode_removed",
+        detail: 'Invocation mode "workflow" was removed from the new manifest',
+      });
+    }
+
+    return {
+      inputs: { added: inputsAdded, removed: inputsRemoved, changed: inputsChanged },
+      outputs: { added: outputsAdded, removed: outputsRemoved },
+      permissions: { added: permissionsAdded, removed: permissionsRemoved },
+      triggers: {
+        intentsAdded: [...newIntents].filter((i) => !oldIntents.has(i)),
+        intentsRemoved: [...oldIntents].filter((i) => !newIntents.has(i)),
+        phrasesAdded: [...newPhrases].filter((p) => !oldPhrases.has(p)),
+        phrasesRemoved: [...oldPhrases].filter((p) => !newPhrases.has(p)),
+        channelsAdded: [...newChannels].filter((c) => !oldChannels.has(c)),
+        channelsRemoved: [...oldChannels].filter((c) => !newChannels.has(c)),
+      },
+      runtime: {
+        kindChanged,
+        entrypointChanged: oldManifest.runtime.entrypoint !== newManifest.runtime.entrypoint,
+        oldKind: oldManifest.runtime.kind,
+        newKind: newManifest.runtime.kind,
+      },
+      breakingChanges,
+    };
+  }
+
+  function findAffectedWorkflows(skillId: string): FridaySkillAffectedWorkflow[] {
+    return deps.db.withReadConnection((conn) => {
+      const workflows = deps.workflowRepo.listWorkflows(conn, { limit: 1000 });
+      const affected: FridaySkillAffectedWorkflow[] = [];
+
+      for (const wf of workflows) {
+        const version = deps.workflowRepo.getPublishedVersion(conn, wf.id)
+          ?? deps.workflowRepo.getLatestVersion(conn, wf.id);
+        if (!version) continue;
+        if (!version.graphJson) {
+          throw new FridayDomainError(
+            "UPGRADE_WORKFLOW_GRAPH_PARSE_FAILED",
+            `Cannot parse graph for workflow "${wf.name}" (${wf.id}): graphJson is missing on the selected version`,
+            { httpStatus: 422 },
+          );
+        }
+
+        let compiledGraph;
+        try {
+          compiledGraph = parseGraphJson(version.graphJson);
+        } catch (e) {
+          throw new FridayDomainError(
+            "UPGRADE_WORKFLOW_GRAPH_PARSE_FAILED",
+            `Cannot parse graph for workflow "${wf.name}" (${wf.id}): ${e instanceof Error ? e.message : String(e)}`,
+            { httpStatus: 422 },
+          );
+        }
+
+        const matchingNodes: FridaySkillAffectedWorkflowNodeDetail[] = [];
+        for (const node of compiledGraph.graph.nodes) {
+          const config = node.config as Record<string, unknown>;
+          const effectiveRef = (config.skillId ?? config.ref) as string | undefined;
+          if (effectiveRef === skillId) {
+            const inputMapping = config.inputMapping as Record<string, unknown> | undefined;
+            matchingNodes.push({
+              nodeId: node.id,
+              effectiveSkillRef: effectiveRef,
+              inputMappingKeys: inputMapping ? Object.keys(inputMapping) : [],
+            });
+          }
+        }
+        if (matchingNodes.length > 0) {
+          affected.push({ workflowId: wf.id, workflowName: wf.name, nodes: matchingNodes });
+        }
+      }
+
+      return affected;
+    });
+  }
+
+  function buildRegressionProof(
+    affectedWorkflows: FridaySkillAffectedWorkflow[],
+    newManifest: SkillManifestV2,
+  ): FridaySkillWorkflowRegressionProof {
+    if (affectedWorkflows.length === 0) {
+      return { overallVerdict: "no_affected_workflows", entries: [] };
+    }
+
+    const newModes = new Set<SkillInvocationMode>(newManifest.invocation?.modes ?? []);
+    const newInputKeys = new Set(newManifest.inputs.map((i) => i.key));
+    const entries: FridaySkillWorkflowRegressionEntry[] = [];
+
+    for (const wf of affectedWorkflows) {
+      const failures: string[] = [];
+
+      if (!newModes.has("workflow")) {
+        failures.push(
+          `Workflow "${wf.workflowName}" (${wf.workflowId}): new manifest does not include "workflow" invocation mode`,
+        );
+      }
+
+      for (const node of wf.nodes) {
+        for (const mappedKey of node.inputMappingKeys) {
+          if (!newInputKeys.has(mappedKey)) {
+            failures.push(
+              `Workflow "${wf.workflowName}" node "${node.nodeId}": inputMapping key "${mappedKey}" is not present in candidate manifest inputs`,
+            );
+          }
+        }
+      }
+
+      entries.push({
+        workflowId: wf.workflowId,
+        workflowName: wf.workflowName,
+        nodes: wf.nodes,
+        verdict: failures.length === 0 ? "pass" : "fail",
+        failures,
+      });
+    }
+
+    const overallVerdict = entries.every((e) => e.verdict === "pass") ? "pass" : "fail";
+    return { overallVerdict, entries };
+  }
+
+  function computeRecommendation(
+    comparisonReport: FridaySkillManifestComparisonReport,
+    regressionProof: FridaySkillWorkflowRegressionProof,
+  ): "replace" | "keep" | "review_required" {
+    if (regressionProof.overallVerdict === "fail") {
+      return "review_required";
+    }
+    if (comparisonReport.breakingChanges.length > 0 && regressionProof.entries.length > 0) {
+      return "review_required";
+    }
+    return "replace";
+  }
+
+  function computeAnalysisDigest(
+    analysis: Omit<FridaySkillUpgradeAnalysis, "analysisDigest">,
+    candidateManifest: SkillManifestV2,
+    existingManifest: SkillManifestV2 | null,
+  ): string {
+    const payload = {
+      skillId: analysis.skillId,
+      candidateId: analysis.candidateId,
+      isDuplicate: analysis.isDuplicate,
+      existingVersion: analysis.existingVersion,
+      candidateVersion: analysis.candidateVersion,
+      comparisonReport: analysis.comparisonReport,
+      affectedWorkflows: analysis.affectedWorkflows,
+      regressionProof: analysis.regressionProof,
+      recommendation: analysis.recommendation,
+      rollbackPointer: analysis.rollbackPointer,
+      candidateManifestDigest: manifestDigest(candidateManifest),
+      previousManifestDigest: existingManifest ? manifestDigest(existingManifest) : null,
+    };
+    return createHash("sha256").update(stableStringify(payload)).digest("hex");
+  }
+
+  function manifestDigest(manifest: SkillManifestV2): string {
+    return createHash("sha256")
+      .update(stableStringify(manifest))
+      .digest("hex");
+  }
+
+  return {
+    analyze(input) {
+      const existing = deps.db.withReadConnection((conn) =>
+        deps.skillRepo.getSkillById(conn, input.skillId),
+      );
+
+      const isDuplicate = Boolean(
+        existing && existing.installedVersion && existing.currentManifest,
+      );
+
+      const { manifest: candidateManifest } = resolveAndLoadCandidate(input.skillId, input.candidateId);
+
+      let comparisonReport: FridaySkillManifestComparisonReport | null = null;
+      if (isDuplicate && existing!.currentManifest) {
+        comparisonReport = compareManifests(existing!.currentManifest, candidateManifest);
+      }
+
+      const affectedWorkflows = findAffectedWorkflows(input.skillId);
+
+      const regressionProof = comparisonReport
+        ? buildRegressionProof(affectedWorkflows, candidateManifest)
+        : { overallVerdict: "no_affected_workflows" as const, entries: [] };
+
+      const recommendation = comparisonReport
+        ? computeRecommendation(comparisonReport, regressionProof)
+        : "replace";
+
+      const rollbackPointer = {
+        available: Boolean(existing?.installedVersion),
+        previousVersion: existing?.installedVersion ?? null,
+        previousManifestDigest: existing?.currentManifest
+          ? manifestDigest(existing.currentManifest)
+          : null,
+      };
+
+      const partial = {
+        skillId: input.skillId,
+        candidateId: input.candidateId,
+        isDuplicate,
+        existingVersion: existing?.installedVersion ?? null,
+        candidateVersion: candidateManifest.version,
+        comparisonReport,
+        affectedWorkflows,
+        regressionProof,
+        recommendation,
+        rollbackPointer,
+        analyzedAt: deps.nowIso(),
+      };
+
+      const analysisDigest = computeAnalysisDigest(partial, candidateManifest, existing?.currentManifest ?? null);
+
+      return { ...partial, analysisDigest };
+    },
+
+    applyDecision(input) {
+      const { candidate } = resolveAndLoadCandidate(input.skillId, input.candidateId);
+
+      const existing = deps.db.withReadConnection((conn) =>
+        deps.skillRepo.getSkillById(conn, input.skillId),
+      );
+      if (!existing || !existing.installedVersion) {
+        throw new FridayDomainError(
+          "UPGRADE_SKILL_NOT_INSTALLED",
+          `Skill ${input.skillId} is not installed; cannot apply upgrade decision`,
+          { httpStatus: 409 },
+        );
+      }
+
+      const currentAnalysis = this.analyze({ skillId: input.skillId, candidateId: input.candidateId });
+      if (currentAnalysis.analysisDigest !== input.analysisDigest) {
+        throw new FridayDomainError(
+          "UPGRADE_ANALYSIS_DIGEST_MISMATCH",
+          "The analysis has changed since the approval was granted; re-analyze before deciding",
+          { httpStatus: 409 },
+        );
+      }
+
+      if (input.decision === "replace") {
+        deps.db.withWriteTransaction((conn) => {
+          deps.skillRepo.updateLifecycleStatus(conn, input.skillId, "upgrade_available", deps.nowIso());
+        });
+      }
+
+      return {
+        decision: input.decision,
+        skillId: input.skillId,
+        candidateId: input.candidateId,
+        analysisDigest: input.analysisDigest,
+        decidedAt: deps.nowIso(),
+        approvalProof: {
+          ticketId: input.ticket.ticketId,
+          actionDigest: input.ticket.actionDigest,
+          action: input.ticket.action,
+          resource: { type: input.ticket.resource.type, id: input.ticket.resource.id ?? input.skillId },
+          risk: input.ticket.risk,
+          approvedByPrincipalId: input.ticket.approvedByPrincipalId,
+          issuedAt: input.ticket.issuedAt,
+        },
+      };
+    },
+  };
+}

--- a/src/skills/services/friday-skill-upgrade-analysis-service.ts
+++ b/src/skills/services/friday-skill-upgrade-analysis-service.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import type { FridaySqliteLayer } from "#state";
 import { FridayDomainError } from "#errors";
 import { loadFridaySkillPackage } from "../manifest/friday-skill-package-loader.js";
-import type { SkillManifestV2, SkillInvocationMode } from "../model/friday-skill-manifest-v2.types.js";
+import type { SkillInvocationMode, SkillManifestV2 } from "../model/friday-skill-manifest-v2.types.js";
 import type { PermissionGrant } from "../model/friday-skill-permission-policy.types.js";
 import type { FridaySkillEntity } from "../model/friday-skill-catalog.types.js";
 import type { FridaySkillRepository } from "../persistence/friday-skill-repository.js";

--- a/test/contracts/api/__snapshots__/friday-api-route-contract.snapshot.test.ts.snap
+++ b/test/contracts/api/__snapshots__/friday-api-route-contract.snapshot.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures route count to detect accidental additions/removals 1`] = `371`;
+exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures route count to detect accidental additions/removals 1`] = `373`;
 
 exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route surface as a stable contract 1`] = `
 [
@@ -2208,6 +2208,26 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
     "authKind": "public",
     "index": 220,
     "method": "POST",
+    "operationId": "skills.upgrade.analyze",
+    "path": "/v1/skills/:skillId/upgrade/analyze",
+    "rateLimitPolicyId": null,
+    "roles": [],
+    "scopes": [],
+  },
+  {
+    "authKind": "public",
+    "index": 221,
+    "method": "POST",
+    "operationId": "skills.upgrade.decide",
+    "path": "/v1/skills/:skillId/upgrade/decide",
+    "rateLimitPolicyId": null,
+    "roles": [],
+    "scopes": [],
+  },
+  {
+    "authKind": "public",
+    "index": 222,
+    "method": "POST",
     "operationId": "skills.run",
     "path": "/v1/skills/:skillId/run",
     "rateLimitPolicyId": null,
@@ -2216,7 +2236,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 221,
+    "index": 223,
     "method": "POST",
     "operationId": "skills.generator.sessions.create",
     "path": "/v1/skills/generator/sessions",
@@ -2226,7 +2246,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 222,
+    "index": 224,
     "method": "GET",
     "operationId": "skills.generator.sessions.get",
     "path": "/v1/skills/generator/sessions/:sessionId",
@@ -2236,7 +2256,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 223,
+    "index": 225,
     "method": "POST",
     "operationId": "skills.generator.sessions.messages.create",
     "path": "/v1/skills/generator/sessions/:sessionId/messages",
@@ -2246,7 +2266,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 224,
+    "index": 226,
     "method": "POST",
     "operationId": "skills.generator.sessions.generate",
     "path": "/v1/skills/generator/sessions/:sessionId/generate",
@@ -2256,7 +2276,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 225,
+    "index": 227,
     "method": "POST",
     "operationId": "skills.generator.sessions.test",
     "path": "/v1/skills/generator/sessions/:sessionId/test",
@@ -2266,7 +2286,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 226,
+    "index": 228,
     "method": "GET",
     "operationId": "skills.generator.sessions.evidence.get",
     "path": "/v1/skills/generator/sessions/:sessionId/evidence",
@@ -2276,7 +2296,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 227,
+    "index": 229,
     "method": "POST",
     "operationId": "skills.generator.sessions.approve",
     "path": "/v1/skills/generator/sessions/:sessionId/approve",
@@ -2286,7 +2306,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 228,
+    "index": 230,
     "method": "DELETE",
     "operationId": "skills.generator.sessions.cancel",
     "path": "/v1/skills/generator/sessions/:sessionId",
@@ -2296,7 +2316,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 229,
+    "index": 231,
     "method": "GET",
     "operationId": "skills.ui.get",
     "path": "/v1/skills/:skillId/ui",
@@ -2306,7 +2326,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 230,
+    "index": 232,
     "method": "POST",
     "operationId": "uix.intents.resolve",
     "path": "/v1/uix/intents/resolve",
@@ -2316,7 +2336,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 231,
+    "index": 233,
     "method": "GET",
     "operationId": "uix.templates.list",
     "path": "/v1/uix/templates",
@@ -2326,7 +2346,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 232,
+    "index": 234,
     "method": "GET",
     "operationId": "uix.home.snapshot.get",
     "path": "/v1/uix/home-snapshot",
@@ -2336,7 +2356,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 233,
+    "index": 235,
     "method": "GET",
     "operationId": "uix.assistant.inbox.snapshot.get",
     "path": "/v1/uix/assistant-inbox-snapshot",
@@ -2346,7 +2366,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 234,
+    "index": 236,
     "method": "GET",
     "operationId": "uix.diagnostics.get",
     "path": "/v1/uix/diagnostics",
@@ -2356,7 +2376,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 235,
+    "index": 237,
     "method": "GET",
     "operationId": "uix.preferences.list",
     "path": "/v1/uix/preferences",
@@ -2366,7 +2386,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 236,
+    "index": 238,
     "method": "PUT",
     "operationId": "uix.preferences.update",
     "path": "/v1/uix/preferences",
@@ -2376,7 +2396,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 237,
+    "index": 239,
     "method": "DELETE",
     "operationId": "uix.preferences.delete",
     "path": "/v1/uix/preferences/:preferenceId",
@@ -2386,7 +2406,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 238,
+    "index": 240,
     "method": "GET",
     "operationId": "uix.persona.get",
     "path": "/v1/uix/persona",
@@ -2396,7 +2416,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 239,
+    "index": 241,
     "method": "PUT",
     "operationId": "uix.persona.update",
     "path": "/v1/uix/persona",
@@ -2406,7 +2426,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 240,
+    "index": 242,
     "method": "POST",
     "operationId": "uix.templates.execute",
     "path": "/v1/uix/templates/:templateId/execute",
@@ -2416,7 +2436,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 241,
+    "index": 243,
     "method": "POST",
     "operationId": "uix.wizards.start",
     "path": "/v1/uix/wizards/:wizardId/start",
@@ -2426,7 +2446,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 242,
+    "index": 244,
     "method": "POST",
     "operationId": "uix.wizards.continue",
     "path": "/v1/uix/wizards/:wizardId/continue",
@@ -2436,7 +2456,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 243,
+    "index": 245,
     "method": "GET",
     "operationId": "uix.issues.list",
     "path": "/v1/uix/issues",
@@ -2446,7 +2466,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 244,
+    "index": 246,
     "method": "GET",
     "operationId": "uix.user.profile.get",
     "path": "/v1/uix/user-profile",
@@ -2456,7 +2476,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 245,
+    "index": 247,
     "method": "PUT",
     "operationId": "uix.user.profile.update",
     "path": "/v1/uix/user-profile",
@@ -2466,7 +2486,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 246,
+    "index": 248,
     "method": "POST",
     "operationId": "uix.investigate",
     "path": "/v1/uix/investigate",
@@ -2476,7 +2496,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 247,
+    "index": 249,
     "method": "GET",
     "operationId": "uix.learnedfacts.list",
     "path": "/v1/uix/learned-facts",
@@ -2486,7 +2506,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 248,
+    "index": 250,
     "method": "DELETE",
     "operationId": "uix.learnedfacts.clear",
     "path": "/v1/uix/learned-facts",
@@ -2496,7 +2516,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 249,
+    "index": 251,
     "method": "DELETE",
     "operationId": "uix.learnedfacts.delete",
     "path": "/v1/uix/learned-facts/:factKey",
@@ -2506,7 +2526,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 250,
+    "index": 252,
     "method": "GET",
     "operationId": "packs.cross.border.profile.get",
     "path": "/v1/packs/cross-border/profile",
@@ -2516,7 +2536,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 251,
+    "index": 253,
     "method": "PUT",
     "operationId": "packs.cross.border.profile.put",
     "path": "/v1/packs/cross-border/profile",
@@ -2526,7 +2546,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 252,
+    "index": 254,
     "method": "GET",
     "operationId": "packs.cross.border.snapshot.get",
     "path": "/v1/packs/cross-border/snapshot",
@@ -2536,7 +2556,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 253,
+    "index": 255,
     "method": "POST",
     "operationId": "packs.cross.border.import.post",
     "path": "/v1/packs/cross-border/import",
@@ -2546,7 +2566,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 254,
+    "index": 256,
     "method": "POST",
     "operationId": "packs.cross.border.workflow.presets.apply",
     "path": "/v1/packs/cross-border/workflow-presets/apply",
@@ -2556,7 +2576,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 255,
+    "index": 257,
     "method": "PATCH",
     "operationId": "packs.cross.border.workflow.presets.toggle",
     "path": "/v1/packs/cross-border/workflow-presets/:workflowId",
@@ -2566,7 +2586,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 256,
+    "index": 258,
     "method": "GET",
     "operationId": "skills.converters.list",
     "path": "/v1/skills/converters",
@@ -2576,7 +2596,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 257,
+    "index": 259,
     "method": "POST",
     "operationId": "skills.convert",
     "path": "/v1/skills/convert",
@@ -2586,7 +2606,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 258,
+    "index": 260,
     "method": "POST",
     "operationId": "skills.import",
     "path": "/v1/skills/import",
@@ -2596,7 +2616,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 259,
+    "index": 261,
     "method": "POST",
     "operationId": "skills.pack",
     "path": "/v1/skills/pack",
@@ -2606,7 +2626,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 260,
+    "index": 262,
     "method": "POST",
     "operationId": "workflows.generator.sessions.create",
     "path": "/v1/workflows/generator/sessions",
@@ -2616,7 +2636,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 261,
+    "index": 263,
     "method": "GET",
     "operationId": "workflows.generator.sessions.get",
     "path": "/v1/workflows/generator/sessions/:sessionId",
@@ -2626,7 +2646,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 262,
+    "index": 264,
     "method": "POST",
     "operationId": "workflows.generator.sessions.messages.create",
     "path": "/v1/workflows/generator/sessions/:sessionId/messages",
@@ -2636,7 +2656,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 263,
+    "index": 265,
     "method": "POST",
     "operationId": "workflows.generator.sessions.generate",
     "path": "/v1/workflows/generator/sessions/:sessionId/generate",
@@ -2646,7 +2666,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 264,
+    "index": 266,
     "method": "GET",
     "operationId": "workflows.generator.sessions.evidence.get",
     "path": "/v1/workflows/generator/sessions/:sessionId/evidence",
@@ -2656,7 +2676,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 265,
+    "index": 267,
     "method": "POST",
     "operationId": "workflows.generator.sessions.approve",
     "path": "/v1/workflows/generator/sessions/:sessionId/approve",
@@ -2666,7 +2686,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 266,
+    "index": 268,
     "method": "DELETE",
     "operationId": "workflows.generator.sessions.cancel",
     "path": "/v1/workflows/generator/sessions/:sessionId",
@@ -2676,7 +2696,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 267,
+    "index": 269,
     "method": "GET",
     "operationId": "rules.bundles.list",
     "path": "/v1/rules/bundles",
@@ -2686,7 +2706,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 268,
+    "index": 270,
     "method": "GET",
     "operationId": "rules.bundles.get",
     "path": "/v1/rules/bundles/:bundleId",
@@ -2696,7 +2716,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 269,
+    "index": 271,
     "method": "POST",
     "operationId": "rules.bundles.create",
     "path": "/v1/rules/bundles",
@@ -2706,7 +2726,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 270,
+    "index": 272,
     "method": "PATCH",
     "operationId": "rules.bundles.update",
     "path": "/v1/rules/bundles/:bundleId",
@@ -2716,7 +2736,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 271,
+    "index": 273,
     "method": "GET",
     "operationId": "rules.bundles.versions.list",
     "path": "/v1/rules/bundles/:bundleId/versions",
@@ -2726,7 +2746,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 272,
+    "index": 274,
     "method": "GET",
     "operationId": "rules.list",
     "path": "/v1/rules/bundles/:bundleId/rules",
@@ -2736,7 +2756,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 273,
+    "index": 275,
     "method": "POST",
     "operationId": "rules.evaluate",
     "path": "/v1/rules/evaluate",
@@ -2746,7 +2766,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 274,
+    "index": 276,
     "method": "POST",
     "operationId": "rules.simulate",
     "path": "/v1/rules/simulate",
@@ -2756,7 +2776,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 275,
+    "index": 277,
     "method": "GET",
     "operationId": "rules.versions.list",
     "path": "/v1/rules/:ruleId/versions",
@@ -2766,7 +2786,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 276,
+    "index": 278,
     "method": "GET",
     "operationId": "rules.audit.log.list",
     "path": "/v1/rules/audit-log",
@@ -2776,7 +2796,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 277,
+    "index": 279,
     "method": "POST",
     "operationId": "node.runner.execute",
     "path": "/v1/node-runner/execute",
@@ -2786,7 +2806,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 278,
+    "index": 280,
     "method": "GET",
     "operationId": "node.runner.executions.get",
     "path": "/v1/node-runner/executions/:executionId",
@@ -2796,7 +2816,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 279,
+    "index": 281,
     "method": "GET",
     "operationId": "node.runner.executions.list",
     "path": "/v1/node-runner/executions",
@@ -2806,7 +2826,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 280,
+    "index": 282,
     "method": "POST",
     "operationId": "acceptance.run",
     "path": "/v1/acceptance/run",
@@ -2816,7 +2836,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 281,
+    "index": 283,
     "method": "GET",
     "operationId": "acceptance.results.get",
     "path": "/v1/acceptance/results/:resultId",
@@ -2826,7 +2846,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 282,
+    "index": 284,
     "method": "GET",
     "operationId": "acceptance.results.list",
     "path": "/v1/acceptance/results",
@@ -2836,7 +2856,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 283,
+    "index": 285,
     "method": "GET",
     "operationId": "acceptance.runs.get",
     "path": "/v1/acceptance/runs/:runId",
@@ -2846,7 +2866,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 284,
+    "index": 286,
     "method": "GET",
     "operationId": "acceptance.tests.list",
     "path": "/v1/acceptance/tests",
@@ -2856,7 +2876,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 285,
+    "index": 287,
     "method": "GET",
     "operationId": "acceptance.tests.get",
     "path": "/v1/acceptance/tests/:testId",
@@ -2866,7 +2886,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 286,
+    "index": 288,
     "method": "POST",
     "operationId": "acceptance.tests.create",
     "path": "/v1/acceptance/tests",
@@ -2876,7 +2896,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 287,
+    "index": 289,
     "method": "PUT",
     "operationId": "acceptance.tests.update",
     "path": "/v1/acceptance/tests/:testId",
@@ -2886,7 +2906,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 288,
+    "index": 290,
     "method": "DELETE",
     "operationId": "acceptance.tests.delete",
     "path": "/v1/acceptance/tests/:testId",
@@ -2896,7 +2916,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 289,
+    "index": 291,
     "method": "GET",
     "operationId": "acceptance.tests.versions.list",
     "path": "/v1/acceptance/tests/:testId/versions",
@@ -2906,7 +2926,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 290,
+    "index": 292,
     "method": "GET",
     "operationId": "acceptance.artifacts.history",
     "path": "/v1/acceptance/artifacts/history",
@@ -2916,7 +2936,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 291,
+    "index": 293,
     "method": "GET",
     "operationId": "retry.policies.list",
     "path": "/v1/retry/policies",
@@ -2926,7 +2946,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 292,
+    "index": 294,
     "method": "GET",
     "operationId": "retry.policies.get",
     "path": "/v1/retry/policies/:policyId",
@@ -2936,7 +2956,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 293,
+    "index": 295,
     "method": "POST",
     "operationId": "retry.policies.create",
     "path": "/v1/retry/policies",
@@ -2946,7 +2966,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 294,
+    "index": 296,
     "method": "PUT",
     "operationId": "retry.policies.update",
     "path": "/v1/retry/policies/:policyId",
@@ -2956,7 +2976,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 295,
+    "index": 297,
     "method": "DELETE",
     "operationId": "retry.policies.delete",
     "path": "/v1/retry/policies/:policyId",
@@ -2966,7 +2986,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 296,
+    "index": 298,
     "method": "POST",
     "operationId": "retry.classify",
     "path": "/v1/retry/classify",
@@ -2976,7 +2996,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 297,
+    "index": 299,
     "method": "POST",
     "operationId": "retry.decide",
     "path": "/v1/retry/decide",
@@ -2986,7 +3006,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 298,
+    "index": 300,
     "method": "GET",
     "operationId": "retry.traces.list",
     "path": "/v1/retry/traces",
@@ -2996,7 +3016,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 299,
+    "index": 301,
     "method": "GET",
     "operationId": "retry.traces.get",
     "path": "/v1/retry/traces/:traceId",
@@ -3006,7 +3026,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 300,
+    "index": 302,
     "method": "GET",
     "operationId": "retry.costs.summary",
     "path": "/v1/retry/costs",
@@ -3016,7 +3036,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 301,
+    "index": 303,
     "method": "GET",
     "operationId": "retry.escalations.list",
     "path": "/v1/retry/escalations",
@@ -3026,7 +3046,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 302,
+    "index": 304,
     "method": "POST",
     "operationId": "retry.escalations.acknowledge",
     "path": "/v1/retry/escalations/:escalationId/acknowledge",
@@ -3036,7 +3056,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 303,
+    "index": 305,
     "method": "GET",
     "operationId": "retry.circuit.breakers.list",
     "path": "/v1/retry/circuit-breakers",
@@ -3046,7 +3066,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 304,
+    "index": 306,
     "method": "GET",
     "operationId": "playbook.list",
     "path": "/v1/playbooks",
@@ -3056,7 +3076,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 305,
+    "index": 307,
     "method": "GET",
     "operationId": "playbook.get",
     "path": "/v1/playbooks/:playbookId",
@@ -3066,7 +3086,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 306,
+    "index": 308,
     "method": "POST",
     "operationId": "playbook.select",
     "path": "/v1/playbooks/select",
@@ -3076,7 +3096,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 307,
+    "index": 309,
     "method": "GET",
     "operationId": "playbook.candidates.list",
     "path": "/v1/playbooks/candidates",
@@ -3086,7 +3106,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 308,
+    "index": 310,
     "method": "POST",
     "operationId": "playbook.candidates.promote",
     "path": "/v1/playbooks/candidates/:candidateId/promote",
@@ -3096,7 +3116,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 309,
+    "index": 311,
     "method": "POST",
     "operationId": "playbook.rollback",
     "path": "/v1/playbooks/:playbookId/rollback",
@@ -3106,7 +3126,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 310,
+    "index": 312,
     "method": "GET",
     "operationId": "playbook.scores",
     "path": "/v1/playbooks/:playbookId/scores",
@@ -3116,7 +3136,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 311,
+    "index": 313,
     "method": "POST",
     "operationId": "memory.store",
     "path": "/v1/memory/store",
@@ -3126,7 +3146,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 312,
+    "index": 314,
     "method": "POST",
     "operationId": "memory.items.create",
     "path": "/v1/memory/items",
@@ -3136,7 +3156,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 313,
+    "index": 315,
     "method": "POST",
     "operationId": "memory.search",
     "path": "/v1/memory/search",
@@ -3146,7 +3166,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 314,
+    "index": 316,
     "method": "GET",
     "operationId": "memory.get",
     "path": "/v1/memory/items/:id",
@@ -3156,7 +3176,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 315,
+    "index": 317,
     "method": "GET",
     "operationId": "memory.list",
     "path": "/v1/memory/items",
@@ -3166,7 +3186,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 316,
+    "index": 318,
     "method": "DELETE",
     "operationId": "memory.delete",
     "path": "/v1/memory/items/:id",
@@ -3176,7 +3196,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 317,
+    "index": 319,
     "method": "POST",
     "operationId": "memory.prune",
     "path": "/v1/memory/prune",
@@ -3186,7 +3206,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 318,
+    "index": 320,
     "method": "GET",
     "operationId": "sessions.usage.get",
     "path": "/v1/sessions/:sessionKey/usage",
@@ -3196,7 +3216,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 319,
+    "index": 321,
     "method": "GET",
     "operationId": "sessions.usage.list",
     "path": "/v1/sessions/usage",
@@ -3206,7 +3226,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 320,
+    "index": 322,
     "method": "GET",
     "operationId": "sessions.list",
     "path": "/v1/sessions",
@@ -3216,7 +3236,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 321,
+    "index": 323,
     "method": "POST",
     "operationId": "sessions.create",
     "path": "/v1/sessions",
@@ -3226,7 +3246,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 322,
+    "index": 324,
     "method": "GET",
     "operationId": "sessions.get",
     "path": "/v1/sessions/:sessionKey",
@@ -3236,7 +3256,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 323,
+    "index": 325,
     "method": "DELETE",
     "operationId": "sessions.delete",
     "path": "/v1/sessions/:sessionKey",
@@ -3246,7 +3266,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 324,
+    "index": 326,
     "method": "POST",
     "operationId": "sessions.archive",
     "path": "/v1/sessions/:sessionKey/archive",
@@ -3256,7 +3276,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 325,
+    "index": 327,
     "method": "POST",
     "operationId": "sessions.reset",
     "path": "/v1/sessions/:sessionKey/reset",
@@ -3266,7 +3286,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 326,
+    "index": 328,
     "method": "POST",
     "operationId": "sessions.prune",
     "path": "/v1/sessions/prune",
@@ -3276,7 +3296,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 327,
+    "index": 329,
     "method": "POST",
     "operationId": "sessions.sweep",
     "path": "/v1/sessions/sweep",
@@ -3286,7 +3306,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 328,
+    "index": 330,
     "method": "POST",
     "operationId": "sessions.compact",
     "path": "/v1/sessions/:sessionKey/compact",
@@ -3296,7 +3316,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 329,
+    "index": 331,
     "method": "GET",
     "operationId": "sessions.messages.list",
     "path": "/v1/sessions/:sessionKey/messages",
@@ -3306,7 +3326,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 330,
+    "index": 332,
     "method": "GET",
     "operationId": "sessions.export",
     "path": "/v1/sessions/:sessionKey/export",
@@ -3316,7 +3336,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 331,
+    "index": 333,
     "method": "POST",
     "operationId": "sessions.messages.create",
     "path": "/v1/sessions/:sessionKey/messages",
@@ -3326,7 +3346,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 332,
+    "index": 334,
     "method": "POST",
     "operationId": "sessions.outbound.send",
     "path": "/v1/sessions/:sessionKey/outbound",
@@ -3336,7 +3356,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 333,
+    "index": 335,
     "method": "POST",
     "operationId": "sessions.run",
     "path": "/v1/sessions/:sessionKey/run",
@@ -3346,7 +3366,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 334,
+    "index": 336,
     "method": "GET",
     "operationId": "sessions.memory.namespace.get",
     "path": "/v1/sessions/:sessionKey/memory-namespace",
@@ -3356,7 +3376,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 335,
+    "index": 337,
     "method": "POST",
     "operationId": "sessions.forks.create",
     "path": "/v1/sessions/:sessionKey/fork",
@@ -3366,7 +3386,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 336,
+    "index": 338,
     "method": "GET",
     "operationId": "sessions.forks.list",
     "path": "/v1/sessions/:sessionKey/forks",
@@ -3376,7 +3396,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 337,
+    "index": 339,
     "method": "POST",
     "operationId": "sessions.forks.merge",
     "path": "/v1/sessions/:sessionKey/merge",
@@ -3386,7 +3406,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 338,
+    "index": 340,
     "method": "POST",
     "operationId": "sessions.memory.extract",
     "path": "/v1/sessions/:sessionKey/memory/extract",
@@ -3396,7 +3416,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 339,
+    "index": 341,
     "method": "POST",
     "operationId": "sessions.memory.remember",
     "path": "/v1/sessions/:sessionKey/memory/remember",
@@ -3406,7 +3426,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 340,
+    "index": 342,
     "method": "GET",
     "operationId": "sessions.memory.extraction.get",
     "path": "/v1/sessions/:sessionKey/memory/extraction",
@@ -3416,7 +3436,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 341,
+    "index": 343,
     "method": "POST",
     "operationId": "sessions.memory.extraction.retry",
     "path": "/v1/sessions/memory/extraction/retry",
@@ -3426,7 +3446,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 342,
+    "index": 344,
     "method": "GET",
     "operationId": "plugins.list",
     "path": "/v1/plugins",
@@ -3436,7 +3456,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 343,
+    "index": 345,
     "method": "GET",
     "operationId": "plugins.get",
     "path": "/v1/plugins/:id",
@@ -3446,7 +3466,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 344,
+    "index": 346,
     "method": "GET",
     "operationId": "plugins.versions.list",
     "path": "/v1/plugins/:id/versions",
@@ -3456,7 +3476,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 345,
+    "index": 347,
     "method": "POST",
     "operationId": "plugins.install",
     "path": "/v1/plugins/:id/install",
@@ -3466,7 +3486,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 346,
+    "index": 348,
     "method": "POST",
     "operationId": "plugins.enable",
     "path": "/v1/plugins/:id/enable",
@@ -3476,7 +3496,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 347,
+    "index": 349,
     "method": "POST",
     "operationId": "plugins.disable",
     "path": "/v1/plugins/:id/disable",
@@ -3486,7 +3506,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 348,
+    "index": 350,
     "method": "DELETE",
     "operationId": "plugins.uninstall",
     "path": "/v1/plugins/:id",
@@ -3496,7 +3516,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 349,
+    "index": 351,
     "method": "POST",
     "operationId": "agent.runs.start",
     "path": "/v1/agent/runs",
@@ -3506,7 +3526,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 350,
+    "index": 352,
     "method": "GET",
     "operationId": "agent.runs.list",
     "path": "/v1/agent/runs",
@@ -3516,7 +3536,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 351,
+    "index": 353,
     "method": "GET",
     "operationId": "agent.runs.summary",
     "path": "/v1/agent/runs/summary",
@@ -3526,7 +3546,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 352,
+    "index": 354,
     "method": "GET",
     "operationId": "agent.runs.get",
     "path": "/v1/agent/runs/:runId",
@@ -3536,7 +3556,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 353,
+    "index": 355,
     "method": "POST",
     "operationId": "agent.runs.cancel",
     "path": "/v1/agent/runs/:runId/cancel",
@@ -3546,7 +3566,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 354,
+    "index": 356,
     "method": "GET",
     "operationId": "agent.runs.audit",
     "path": "/v1/agent/runs/:runId/audit",
@@ -3556,7 +3576,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 355,
+    "index": 357,
     "method": "POST",
     "operationId": "agent.runs.rollback",
     "path": "/v1/agent/runs/:runId/rollback",
@@ -3566,7 +3586,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 356,
+    "index": 358,
     "method": "POST",
     "operationId": "agent.runs.approve.plan",
     "path": "/v1/agent/runs/:runId/approve-plan",
@@ -3576,7 +3596,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 357,
+    "index": 359,
     "method": "POST",
     "operationId": "agent.runs.reject.plan",
     "path": "/v1/agent/runs/:runId/reject-plan",
@@ -3586,7 +3606,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 358,
+    "index": 360,
     "method": "POST",
     "operationId": "agent.runs.approve.tool",
     "path": "/v1/agent/runs/:runId/approve-tool",
@@ -3596,7 +3616,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 359,
+    "index": 361,
     "method": "POST",
     "operationId": "agent.runs.reject.tool",
     "path": "/v1/agent/runs/:runId/reject-tool",
@@ -3606,7 +3626,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 360,
+    "index": 362,
     "method": "GET",
     "operationId": "agent.runs.events",
     "path": "/v1/agent/runs/:runId/events",
@@ -3616,7 +3636,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 361,
+    "index": 363,
     "method": "POST",
     "operationId": "agent.automations.create",
     "path": "/v1/agent/automations",
@@ -3626,7 +3646,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 362,
+    "index": 364,
     "method": "GET",
     "operationId": "agent.automations.list",
     "path": "/v1/agent/automations",
@@ -3636,7 +3656,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 363,
+    "index": 365,
     "method": "GET",
     "operationId": "agent.automations.get",
     "path": "/v1/agent/automations/:automationId",
@@ -3646,7 +3666,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 364,
+    "index": 366,
     "method": "PATCH",
     "operationId": "agent.automations.update",
     "path": "/v1/agent/automations/:automationId",
@@ -3656,7 +3676,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 365,
+    "index": 367,
     "method": "DELETE",
     "operationId": "agent.automations.delete",
     "path": "/v1/agent/automations/:automationId",
@@ -3666,7 +3686,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 366,
+    "index": 368,
     "method": "POST",
     "operationId": "agent.automations.run",
     "path": "/v1/agent/automations/:automationId/run",
@@ -3676,7 +3696,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 367,
+    "index": 369,
     "method": "GET",
     "operationId": "agent.subagents.list",
     "path": "/v1/agent/subagents",
@@ -3686,7 +3706,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 368,
+    "index": 370,
     "method": "GET",
     "operationId": "agent.subagents.get",
     "path": "/v1/agent/subagents/:subagentId",
@@ -3696,7 +3716,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 369,
+    "index": 371,
     "method": "GET",
     "operationId": "agent.runs.subagents.list",
     "path": "/v1/agent/runs/:runId/subagents",
@@ -3706,7 +3726,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 370,
+    "index": 372,
     "method": "GET",
     "operationId": "assets.inventory.list",
     "path": "/v1/assets/inventory",

--- a/test/unit/skills/services/friday-skill-upgrade-analysis-service.test.ts
+++ b/test/unit/skills/services/friday-skill-upgrade-analysis-service.test.ts
@@ -1,0 +1,735 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import type { FridaySqliteLayer } from "#state";
+import type { SkillManifestV2 } from "#skills";
+import { createFridaySkillRepository } from "#skills";
+import { createFridayWorkflowRepository } from "#workflows";
+import {
+  createFridaySkillUpgradeAnalysisService,
+  type FridaySkillUpgradeAnalysisService,
+} from "../../../../src/skills/services/friday-skill-upgrade-analysis-service.js";
+import type { FridayExternalSkillCandidate } from "../../../../src/skills/converter/services/friday-skill-candidate-store.js";
+import type { FridayMutatingActionTicket } from "../../../../src/security/friday-mutating-action-gate.js";
+
+import { createTestDb } from "../../satellites/_helpers/create-test-db.helper.js";
+
+const NOW = "2026-05-13T22:00:00.000Z";
+
+function makeManifest(overrides: Partial<SkillManifestV2> = {}): SkillManifestV2 {
+  return {
+    schemaVersion: "2.0",
+    id: "skill-1",
+    name: "Skill 1",
+    description: "Upgrade analysis test fixture",
+    version: "1.0.0",
+    kind: "conversation",
+    category: "utility",
+    author: { name: "tester" },
+    tags: ["test"],
+    runtime: {
+      kind: "shell",
+      entrypoint: "run.sh",
+      minHubVersion: "1.0.0",
+      apiVersion: "1",
+      timeoutMsDefault: 30_000,
+    },
+    triggers: { intents: ["do-stuff"], phrases: ["do stuff"], channels: ["*"] },
+    invocation: {
+      userInvocable: true,
+      modelInvocable: true,
+      priority: 50,
+      modes: ["intent", "workflow"],
+    },
+    requirements: { bins: [], env: [], config: [], os: ["darwin", "linux", "win32"] },
+    inputs: [
+      { key: "query", type: "string", label: "The query", required: true },
+    ],
+    outputs: [{ key: "result", type: "string", description: "Result" }],
+    permissions: { grants: [], promptOn: [] },
+    schemas: { input: null, state: null, output: null },
+    flow: null,
+    executionTargets: {
+      allowedSatelliteTypes: ["phone", "desktop", "rpi", "cloud-vm"],
+      requiredCapabilities: [],
+    },
+    telemetry: { events: [] },
+    ...overrides,
+  };
+}
+
+function writeSkillFiles(dir: string, manifest = makeManifest()): void {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "skill.manifest.json"), JSON.stringify(manifest, null, 2), "utf8");
+  writeFileSync(join(dir, "SKILL.md"), `# ${manifest.name}\n`, "utf8");
+  writeFileSync(join(dir, "skill.ui.json"), JSON.stringify({
+    schemaVersion: "1.0",
+    title: manifest.name,
+    sections: [],
+    fields: [],
+    outputs: [],
+    actions: [],
+  }, null, 2), "utf8");
+  writeFileSync(join(dir, "run.sh"), "#!/usr/bin/env bash\necho '{\"result\":\"ok\"}'\n", {
+    encoding: "utf8",
+    mode: 0o755,
+  });
+}
+
+function makeCandidate(filesDir: string, manifest = makeManifest()): FridayExternalSkillCandidate {
+  return {
+    candidateId: "cand-v2-abc",
+    shadowVersionId: "cand-v2-abc",
+    skillId: manifest.id,
+    version: manifest.version,
+    converterId: "native-friday-package",
+    detectedFormat: "friday-package",
+    sourceProvenance: {
+      sourceKind: "uri",
+      sourceDigest: "source-digest",
+      redactedUri: "file-uri:redacted",
+      formatHint: "friday-package",
+    },
+    canonicalApprovalProof: {
+      gateId: "friday_canonical_mutating_action_gate",
+      ticketId: "stage-ticket",
+      actionDigest: "stage-digest",
+      action: "skills.import.stage_candidate",
+      surface: "test",
+      resource: { type: "external_skill_candidate", id: "candidate" },
+      risk: "high",
+      approvalId: "stage-approval",
+      approvedByPrincipalId: "tester",
+      issuedAt: NOW,
+      planDigest: "plan-digest",
+    },
+    candidateDir: join(filesDir, ".."),
+    filesDir,
+    stagedAt: NOW,
+    validation: {
+      ok: true,
+      issues: [],
+      verifiedAt: NOW,
+    },
+  };
+}
+
+function makeTicket(): FridayMutatingActionTicket {
+  return {
+    ticketId: "ticket-001",
+    actionDigest: "action-digest-001",
+    action: "skills.upgrade.decide",
+    surface: "test",
+    resource: { type: "skill_upgrade", id: "skill-1" },
+    risk: "high",
+    approvedByPrincipalId: "tester",
+    issuedAt: NOW,
+  };
+}
+
+describe("FridaySkillUpgradeAnalysisService", () => {
+  let db: FridaySqliteLayer;
+  let skillRepo: ReturnType<typeof createFridaySkillRepository>;
+  let workflowRepo: ReturnType<typeof createFridayWorkflowRepository>;
+  let tmpBase: string;
+  let service: FridaySkillUpgradeAnalysisService;
+
+  const v1Manifest = makeManifest({ version: "1.0.0" });
+  const v2Manifest = makeManifest({
+    version: "2.0.0",
+    inputs: [
+      { key: "query", type: "string", label: "The query", required: true },
+      { key: "format", type: "string", label: "Output format", required: false },
+    ],
+  });
+
+  beforeEach(() => {
+    db = createTestDb();
+    skillRepo = createFridaySkillRepository();
+    workflowRepo = createFridayWorkflowRepository({ db });
+    tmpBase = join(tmpdir(), `upgrade-analysis-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  function installV1(): void {
+    db.withWriteTransaction((conn) => {
+      skillRepo.upsertSkillFromCatalog(conn, {
+        id: "skill-1",
+        name: "Skill 1",
+        source: "managed",
+        origin: "managed",
+        latestVersion: "1.0.0",
+        status: "installed",
+        currentManifest: v1Manifest,
+        nowIso: NOW,
+      });
+      skillRepo.setInstalledVersion(conn, "skill-1", "1.0.0", v1Manifest, NOW);
+    });
+  }
+
+  function setupService(candidateManifest: SkillManifestV2 = v2Manifest): FridaySkillUpgradeAnalysisService {
+    const filesDir = join(tmpBase, "candidates", "cand-v2-abc", "files");
+    writeSkillFiles(filesDir, candidateManifest);
+    const candidate = makeCandidate(filesDir, candidateManifest);
+
+    const svc = createFridaySkillUpgradeAnalysisService({
+      db,
+      nowIso: () => NOW,
+      skillRepo,
+      workflowRepo,
+      workspaceDir: tmpBase,
+      resolveCandidate: (input) =>
+        input.candidateId === candidate.candidateId ? candidate : null,
+    });
+    service = svc;
+    return svc;
+  }
+
+  function insertWorkflowWithGraph(
+    workflowId: string,
+    workflowName: string,
+    graphJson: string,
+  ): void {
+    db.withWriteTransaction((conn) => {
+      workflowRepo.insertWorkflow(conn, workflowId, {
+        slug: workflowName.toLowerCase().replace(/\s+/g, "-"),
+        name: workflowName,
+        ownerUserId: "test-user",
+      }, "etag-1", NOW);
+      workflowRepo.insertVersion(
+        conn,
+        `${workflowId}-v1`,
+        workflowId,
+        1,
+        "checksum-1",
+        graphJson,
+        "test-user",
+        "initial",
+        NOW,
+      );
+      workflowRepo.publishVersion(conn, workflowId, `${workflowId}-v1`, NOW);
+      workflowRepo.setPublishedVersion(conn, workflowId, 1, NOW);
+    });
+  }
+
+  function insertWorkflowWithSkillNode(
+    workflowId: string,
+    workflowName: string,
+    skillId: string,
+    inputMapping?: Record<string, unknown>,
+  ): void {
+    const graphJson = JSON.stringify({
+      nodes: [
+        { id: "node-1", type: "action", config: { actionType: "skill", skillId, inputMapping } },
+      ],
+      edges: [],
+    });
+    insertWorkflowWithGraph(workflowId, workflowName, graphJson);
+  }
+
+  // ─── Test: detects duplicate when installed skill exists ───
+  it("detects duplicate when installed skill exists with same skillId", () => {
+    installV1();
+    setupService();
+    const analysis = service.analyze({ skillId: "skill-1", candidateId: "cand-v2-abc" });
+
+    expect(analysis.isDuplicate).toBe(true);
+    expect(analysis.existingVersion).toBe("1.0.0");
+    expect(analysis.candidateVersion).toBe("2.0.0");
+    expect(analysis.comparisonReport).not.toBeNull();
+    expect(analysis.analysisDigest).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  // ─── Test: no duplicate when skill has no installedVersion ───
+  it("no duplicate when skill has no installedVersion", () => {
+    db.withWriteTransaction((conn) => {
+      skillRepo.upsertSkillFromCatalog(conn, {
+        id: "skill-1",
+        name: "Skill 1",
+        source: "managed",
+        origin: "managed",
+        status: "not_installed",
+        nowIso: NOW,
+      });
+    });
+    setupService();
+    const analysis = service.analyze({ skillId: "skill-1", candidateId: "cand-v2-abc" });
+
+    expect(analysis.isDuplicate).toBe(false);
+    expect(analysis.comparisonReport).toBeNull();
+  });
+
+  // ─── Test: correct input/output/permission/trigger diffs ───
+  it("comparison report shows correct input/output diffs", () => {
+    installV1();
+    setupService();
+    const analysis = service.analyze({ skillId: "skill-1", candidateId: "cand-v2-abc" });
+
+    expect(analysis.comparisonReport!.inputs.added).toContain("format");
+    expect(analysis.comparisonReport!.inputs.removed).toEqual([]);
+  });
+
+  // ─── Test: breaking changes - removed required input ───
+  it("flags removed required input as breaking change", () => {
+    installV1();
+    const breakingV2 = makeManifest({
+      version: "2.0.0",
+      inputs: [],
+    });
+    setupService(breakingV2);
+    const analysis = service.analyze({ skillId: "skill-1", candidateId: "cand-v2-abc" });
+
+    expect(analysis.comparisonReport!.breakingChanges.length).toBeGreaterThan(0);
+    expect(analysis.comparisonReport!.breakingChanges[0].kind).toBe("removed_required_input");
+  });
+
+  // ─── Test: breaking changes - runtime kind change ───
+  it("flags runtime kind change as breaking change", () => {
+    installV1();
+    const runtimeChangeV2 = makeManifest({
+      version: "2.0.0",
+      runtime: {
+        kind: "node",
+        entrypoint: "index.js",
+        minHubVersion: "1.0.0",
+        apiVersion: "1",
+        timeoutMsDefault: 30_000,
+      },
+    });
+    setupService(runtimeChangeV2);
+    const analysis = service.analyze({ skillId: "skill-1", candidateId: "cand-v2-abc" });
+
+    expect(analysis.comparisonReport!.runtime.kindChanged).toBe(true);
+    expect(analysis.comparisonReport!.breakingChanges.some((bc) => bc.kind === "runtime_kind_change")).toBe(true);
+  });
+
+  // ─── Test: finds affected workflows ───
+  it("finds affected workflows from published graphJson", () => {
+    installV1();
+    insertWorkflowWithSkillNode("wf-1", "Test Workflow", "skill-1");
+    setupService();
+    const analysis = service.analyze({ skillId: "skill-1", candidateId: "cand-v2-abc" });
+
+    expect(analysis.affectedWorkflows.length).toBe(1);
+    expect(analysis.affectedWorkflows[0].workflowId).toBe("wf-1");
+    expect(analysis.affectedWorkflows[0].nodes.length).toBe(1);
+    expect(analysis.affectedWorkflows[0].nodes[0].nodeId).toBe("node-1");
+    expect(analysis.affectedWorkflows[0].nodes[0].effectiveSkillRef).toBe("skill-1");
+  });
+
+  // ─── Test: empty affected workflows when none reference the skill ───
+  it("empty affected workflows when none reference the skill", () => {
+    installV1();
+    insertWorkflowWithSkillNode("wf-1", "Other Workflow", "other-skill");
+    setupService();
+    const analysis = service.analyze({ skillId: "skill-1", candidateId: "cand-v2-abc" });
+
+    expect(analysis.affectedWorkflows.length).toBe(0);
+  });
+
+  // ─── Test: regression proof passes for compatible manifest ───
+  it("regression proof passes for compatible manifest", () => {
+    installV1();
+    insertWorkflowWithSkillNode("wf-1", "Test Workflow", "skill-1");
+    setupService();
+    const analysis = service.analyze({ skillId: "skill-1", candidateId: "cand-v2-abc" });
+
+    expect(analysis.regressionProof.overallVerdict).toBe("pass");
+  });
+
+  // ─── Test: regression proof fails when workflow invocation mode missing ───
+  it("regression proof fails when workflow invocation mode missing", () => {
+    installV1();
+    insertWorkflowWithSkillNode("wf-1", "Test Workflow", "skill-1");
+    const noWorkflowModeV2 = makeManifest({
+      version: "2.0.0",
+      invocation: {
+        userInvocable: true,
+        modelInvocable: true,
+        priority: 50,
+        modes: ["intent"],
+      },
+    });
+    setupService(noWorkflowModeV2);
+    const analysis = service.analyze({ skillId: "skill-1", candidateId: "cand-v2-abc" });
+
+    expect(analysis.regressionProof.overallVerdict).toBe("fail");
+    expect(analysis.regressionProof.entries[0].failures.length).toBeGreaterThan(0);
+  });
+
+  // ─── Test: recommends replace with no breaking changes ───
+  it("recommends replace with no breaking changes", () => {
+    installV1();
+    setupService();
+    const analysis = service.analyze({ skillId: "skill-1", candidateId: "cand-v2-abc" });
+
+    expect(analysis.recommendation).toBe("replace");
+  });
+
+  // ─── Test: recommends review_required with breaking changes + affected workflows ───
+  it("recommends review_required with breaking changes and affected workflows", () => {
+    installV1();
+    insertWorkflowWithSkillNode("wf-1", "Test Workflow", "skill-1");
+    const breakingV2 = makeManifest({
+      version: "2.0.0",
+      inputs: [],
+      invocation: {
+        userInvocable: true,
+        modelInvocable: true,
+        priority: 50,
+        modes: ["intent"],
+      },
+    });
+    setupService(breakingV2);
+    const analysis = service.analyze({ skillId: "skill-1", candidateId: "cand-v2-abc" });
+
+    expect(analysis.recommendation).toBe("review_required");
+  });
+
+  // ─── Test: applyDecision replace → upgrade_available ───
+  it("applyDecision replace calls updateLifecycleStatus to upgrade_available", () => {
+    installV1();
+    setupService();
+    const analysis = service.analyze({ skillId: "skill-1", candidateId: "cand-v2-abc" });
+
+    const record = service.applyDecision({
+      skillId: "skill-1",
+      candidateId: "cand-v2-abc",
+      decision: "replace",
+      analysisDigest: analysis.analysisDigest,
+      ticket: makeTicket(),
+    });
+
+    expect(record.decision).toBe("replace");
+    expect(record.analysisDigest).toBe(analysis.analysisDigest);
+    expect(record.approvalProof.ticketId).toBe("ticket-001");
+
+    const skill = db.withReadConnection((conn) => skillRepo.getSkillById(conn, "skill-1"));
+    expect(skill!.status).toBe("upgrade_available");
+  });
+
+  // ─── Test: applyDecision keep → no state change ───
+  it("applyDecision keep does not change lifecycle status", () => {
+    installV1();
+    setupService();
+    const analysis = service.analyze({ skillId: "skill-1", candidateId: "cand-v2-abc" });
+
+    const record = service.applyDecision({
+      skillId: "skill-1",
+      candidateId: "cand-v2-abc",
+      decision: "keep",
+      analysisDigest: analysis.analysisDigest,
+      ticket: makeTicket(),
+    });
+
+    expect(record.decision).toBe("keep");
+    const skill = db.withReadConnection((conn) => skillRepo.getSkillById(conn, "skill-1"));
+    expect(skill!.status).toBe("installed");
+  });
+
+  // ─── Test: applyDecision rejects invalid candidateId ───
+  it("applyDecision rejects invalid candidateId", () => {
+    installV1();
+    setupService();
+
+    expect(() =>
+      service.applyDecision({
+        skillId: "skill-1",
+        candidateId: "bogus-candidate",
+        decision: "replace",
+        analysisDigest: "any-digest",
+        ticket: makeTicket(),
+      }),
+    ).toThrow(/No staged candidate found/);
+  });
+
+  // ─── Test: applyDecision rejects stale analysisDigest ───
+  it("applyDecision rejects stale/mismatched analysisDigest", () => {
+    installV1();
+    setupService();
+    const analysis = service.analyze({ skillId: "skill-1", candidateId: "cand-v2-abc" });
+
+    expect(() =>
+      service.applyDecision({
+        skillId: "skill-1",
+        candidateId: "cand-v2-abc",
+        decision: "replace",
+        analysisDigest: "stale-digest-from-previous-analysis",
+        ticket: makeTicket(),
+      }),
+    ).toThrow(/analysis has changed since the approval/);
+
+    const skill = db.withReadConnection((conn) => skillRepo.getSkillById(conn, "skill-1"));
+    expect(skill!.status).toBe("installed");
+  });
+
+  // ─── Test: rollback pointer captures previous installedVersion ───
+  it("rollback pointer captures previous installedVersion", () => {
+    installV1();
+    setupService();
+    const analysis = service.analyze({ skillId: "skill-1", candidateId: "cand-v2-abc" });
+
+    expect(analysis.rollbackPointer.available).toBe(true);
+    expect(analysis.rollbackPointer.previousVersion).toBe("1.0.0");
+    expect(analysis.rollbackPointer.previousManifestDigest).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  // ─── Test: full scenario ───
+  it("full scenario: duplicate → compare → decide → regression → rollback", () => {
+    installV1();
+    insertWorkflowWithSkillNode("wf-1", "Automation Workflow", "skill-1");
+    setupService();
+
+    const analysis = service.analyze({ skillId: "skill-1", candidateId: "cand-v2-abc" });
+
+    expect(analysis.isDuplicate).toBe(true);
+    expect(analysis.comparisonReport).not.toBeNull();
+    expect(analysis.regressionProof.overallVerdict).toBe("pass");
+    expect(analysis.recommendation).toBe("replace");
+    expect(analysis.rollbackPointer.available).toBe(true);
+    expect(analysis.analysisDigest).toMatch(/^[a-f0-9]{64}$/);
+
+    const record = service.applyDecision({
+      skillId: "skill-1",
+      candidateId: "cand-v2-abc",
+      decision: "replace",
+      analysisDigest: analysis.analysisDigest,
+      ticket: makeTicket(),
+    });
+
+    expect(record.decision).toBe("replace");
+    expect(record.analysisDigest).toBe(analysis.analysisDigest);
+    expect(record.approvalProof.action).toBe("skills.upgrade.decide");
+    expect(record.approvalProof.approvedByPrincipalId).toBe("tester");
+
+    const skill = db.withReadConnection((conn) => skillRepo.getSkillById(conn, "skill-1"));
+    expect(skill!.status).toBe("upgrade_available");
+  });
+
+  // ─── Test: compiled graph with schemaVersion 2.0 and nested graph.nodes ───
+  it("detects affected workflows from compiled graph with nested graph.nodes", () => {
+    installV1();
+    const compiledGraph = JSON.stringify({
+      schemaVersion: "2.0",
+      workflowId: "wf-compiled",
+      workflowVersionId: "wf-compiled-v1",
+      sourceSpecSchemaVersion: "1.0",
+      graph: {
+        nodes: [
+          { id: "cnode-1", type: "action", label: "Run Skill", config: { skillId: "skill-1", inputMapping: { query: "$.trigger.query" } } },
+          { id: "cnode-2", type: "trigger", label: "Start", config: { triggerType: "webhook", method: "POST" } },
+        ],
+        edges: [{ id: "e-1", sourceNodeId: "cnode-2", targetNodeId: "cnode-1" }],
+      },
+      failurePolicy: { onFailure: "fail_fast" },
+      tests: [],
+      checksum: "abc123",
+    });
+    insertWorkflowWithGraph("wf-compiled", "Compiled Workflow", compiledGraph);
+    setupService();
+    const analysis = service.analyze({ skillId: "skill-1", candidateId: "cand-v2-abc" });
+
+    expect(analysis.affectedWorkflows.length).toBe(1);
+    expect(analysis.affectedWorkflows[0].workflowId).toBe("wf-compiled");
+    expect(analysis.affectedWorkflows[0].nodes[0].nodeId).toBe("cnode-1");
+    expect(analysis.affectedWorkflows[0].nodes[0].inputMappingKeys).toEqual(["query"]);
+  });
+
+  // ─── Test: top-level nodes graph still works ───
+  it("detects affected workflows from top-level nodes graph", () => {
+    installV1();
+    const topLevelGraph = JSON.stringify({
+      nodes: [
+        { id: "tnode-1", type: "action", config: { actionType: "skill", skillId: "skill-1" } },
+      ],
+      edges: [],
+    });
+    insertWorkflowWithGraph("wf-toplevel", "Top Level Workflow", topLevelGraph);
+    setupService();
+    const analysis = service.analyze({ skillId: "skill-1", candidateId: "cand-v2-abc" });
+
+    expect(analysis.affectedWorkflows.length).toBe(1);
+    expect(analysis.affectedWorkflows[0].nodes[0].nodeId).toBe("tnode-1");
+  });
+
+  // ─── Test: config.ref is detected as skill reference ───
+  it("detects skill reference via config.ref (fallback to skillId)", () => {
+    installV1();
+    const refGraph = JSON.stringify({
+      nodes: [
+        { id: "ref-node-1", type: "action", config: { ref: "skill-1", inputMapping: { query: "$.input.q" } } },
+      ],
+      edges: [],
+    });
+    insertWorkflowWithGraph("wf-ref", "Ref Workflow", refGraph);
+    setupService();
+    const analysis = service.analyze({ skillId: "skill-1", candidateId: "cand-v2-abc" });
+
+    expect(analysis.affectedWorkflows.length).toBe(1);
+    expect(analysis.affectedWorkflows[0].nodes[0].nodeId).toBe("ref-node-1");
+    expect(analysis.affectedWorkflows[0].nodes[0].effectiveSkillRef).toBe("skill-1");
+    expect(analysis.affectedWorkflows[0].nodes[0].inputMappingKeys).toEqual(["query"]);
+  });
+
+  // ─── Test: regression proof passes when all inputMapping keys are covered ───
+  it("regression proof passes when all inputMapping keys are covered by candidate manifest", () => {
+    installV1();
+    insertWorkflowWithSkillNode("wf-mapped", "Mapped Workflow", "skill-1", { query: "$.trigger.q" });
+    setupService();
+    const analysis = service.analyze({ skillId: "skill-1", candidateId: "cand-v2-abc" });
+
+    expect(analysis.regressionProof.overallVerdict).toBe("pass");
+    expect(analysis.affectedWorkflows[0].nodes[0].inputMappingKeys).toEqual(["query"]);
+  });
+
+  // ─── Test: regression proof fails when mapped input removed from candidate ───
+  it("regression proof fails when workflow node maps an input removed from candidate manifest", () => {
+    installV1();
+    insertWorkflowWithSkillNode("wf-broken", "Broken Mapping Workflow", "skill-1", {
+      query: "$.trigger.q",
+      obsoleteField: "$.trigger.old",
+    });
+    setupService();
+    const analysis = service.analyze({ skillId: "skill-1", candidateId: "cand-v2-abc" });
+
+    expect(analysis.regressionProof.overallVerdict).toBe("fail");
+    expect(analysis.regressionProof.entries[0].failures.some(
+      (f) => f.includes("obsoleteField") && f.includes("not present in candidate manifest inputs"),
+    )).toBe(true);
+  });
+
+  // ─── Test: non-breaking comparison changes flip analysisDigest ───
+  it("analysisDigest changes when non-breaking comparison fields change", () => {
+    installV1();
+    const v2WithGrant = makeManifest({
+      version: "2.0.0",
+      inputs: [{ key: "query", type: "string", label: "The query", required: true }],
+      permissions: { grants: [{ id: "perm-a", resource: "filesystem", action: "read", required: true, reason: "test" }], promptOn: [] },
+    });
+    const filesDir1 = join(tmpBase, "candidates", "cand-v2-abc", "files");
+    writeSkillFiles(filesDir1, v2WithGrant);
+    const cand1 = makeCandidate(filesDir1, v2WithGrant);
+    const svc1 = createFridaySkillUpgradeAnalysisService({
+      db, nowIso: () => NOW, skillRepo, workflowRepo, workspaceDir: tmpBase,
+      resolveCandidate: (input) => input.candidateId === cand1.candidateId ? cand1 : null,
+    });
+    const digest1 = svc1.analyze({ skillId: "skill-1", candidateId: "cand-v2-abc" }).analysisDigest;
+
+    const v2WithDifferentGrant = makeManifest({
+      version: "2.0.0",
+      inputs: [{ key: "query", type: "string", label: "The query", required: true }],
+      permissions: { grants: [{ id: "perm-b", resource: "network", action: "connect", required: true, reason: "test" }], promptOn: [] },
+    });
+    const filesDir2 = join(tmpBase, "candidates2", "cand-v2-abc", "files");
+    writeSkillFiles(filesDir2, v2WithDifferentGrant);
+    const cand2 = makeCandidate(filesDir2, v2WithDifferentGrant);
+    const svc2 = createFridaySkillUpgradeAnalysisService({
+      db, nowIso: () => NOW, skillRepo, workflowRepo, workspaceDir: tmpBase,
+      resolveCandidate: (input) => input.candidateId === cand2.candidateId ? { ...cand2, filesDir: filesDir2 } : null,
+    });
+    const digest2 = svc2.analyze({ skillId: "skill-1", candidateId: "cand-v2-abc" }).analysisDigest;
+
+    expect(digest1).not.toBe(digest2);
+  });
+
+  // ─── Test: same id/version but different candidate content changes analysisDigest ───
+  it("analysisDigest changes for same id/version but different candidate manifest content", () => {
+    installV1();
+    const v2a = makeManifest({
+      version: "2.0.0",
+      inputs: [{ key: "query", type: "string", label: "The query", required: true }],
+    });
+    const v2b = makeManifest({
+      version: "2.0.0",
+      inputs: [
+        { key: "query", type: "string", label: "The query", required: true },
+        { key: "extra", type: "string", label: "Extra field", required: false },
+      ],
+    });
+
+    const filesDir1 = join(tmpBase, "cand-same-ver-a", "cand-v2-abc", "files");
+    writeSkillFiles(filesDir1, v2a);
+    const cand1 = makeCandidate(filesDir1, v2a);
+    const svc1 = createFridaySkillUpgradeAnalysisService({
+      db, nowIso: () => NOW, skillRepo, workflowRepo, workspaceDir: tmpBase,
+      resolveCandidate: (input) => input.candidateId === cand1.candidateId ? cand1 : null,
+    });
+    const analysis1 = svc1.analyze({ skillId: "skill-1", candidateId: "cand-v2-abc" });
+
+    const filesDir2 = join(tmpBase, "cand-same-ver-b", "cand-v2-abc", "files");
+    writeSkillFiles(filesDir2, v2b);
+    const cand2 = makeCandidate(filesDir2, v2b);
+    const svc2 = createFridaySkillUpgradeAnalysisService({
+      db, nowIso: () => NOW, skillRepo, workflowRepo, workspaceDir: tmpBase,
+      resolveCandidate: (input) => input.candidateId === cand2.candidateId ? { ...cand2, filesDir: filesDir2 } : null,
+    });
+    const analysis2 = svc2.analyze({ skillId: "skill-1", candidateId: "cand-v2-abc" });
+
+    expect(analysis1.candidateVersion).toBe(analysis2.candidateVersion);
+    expect(analysis1.analysisDigest).not.toBe(analysis2.analysisDigest);
+  });
+
+  // ─── Test: rollback pointer digest changes when previous manifest content changes ───
+  it("rollback pointer digest changes when previous installed manifest content changes with same version", () => {
+    const v1a = makeManifest({
+      version: "1.0.0",
+      permissions: { grants: [{ id: "perm-x", resource: "filesystem", action: "read", required: true, reason: "test" }], promptOn: [] },
+    });
+    db.withWriteTransaction((conn) => {
+      skillRepo.upsertSkillFromCatalog(conn, {
+        id: "skill-1", name: "Skill 1", source: "managed", origin: "managed",
+        latestVersion: "1.0.0", status: "installed", currentManifest: v1a, nowIso: NOW,
+      });
+      skillRepo.setInstalledVersion(conn, "skill-1", "1.0.0", v1a, NOW);
+    });
+    setupService();
+    const digestA = service.analyze({ skillId: "skill-1", candidateId: "cand-v2-abc" })
+      .rollbackPointer.previousManifestDigest;
+
+    const v1b = makeManifest({
+      version: "1.0.0",
+      permissions: { grants: [{ id: "perm-y", resource: "network", action: "connect", required: true, reason: "test" }], promptOn: [] },
+    });
+    db.withWriteTransaction((conn) => {
+      skillRepo.upsertSkillFromCatalog(conn, {
+        id: "skill-1", name: "Skill 1", source: "managed", origin: "managed",
+        latestVersion: "1.0.0", status: "installed", currentManifest: v1b, nowIso: NOW,
+      });
+      skillRepo.setInstalledVersion(conn, "skill-1", "1.0.0", v1b, NOW);
+    });
+    setupService();
+    const digestB = service.analyze({ skillId: "skill-1", candidateId: "cand-v2-abc" })
+      .rollbackPointer.previousManifestDigest;
+
+    expect(digestA).toMatch(/^[a-f0-9]{64}$/);
+    expect(digestB).toMatch(/^[a-f0-9]{64}$/);
+    expect(digestA).not.toBe(digestB);
+  });
+
+  // ─── Test: malformed workflow graph fails closed ───
+  it("malformed workflow graph fails closed with thrown error, not silently skipped", () => {
+    installV1();
+    insertWorkflowWithGraph("wf-bad", "Bad Workflow", "not valid json {{{");
+    setupService();
+
+    expect(() =>
+      service.analyze({ skillId: "skill-1", candidateId: "cand-v2-abc" }),
+    ).toThrow(/Cannot parse graph/);
+  });
+
+  // ─── Test: empty graphJson on workflow version fails closed ───
+  it("empty graphJson on workflow version fails closed", () => {
+    installV1();
+    insertWorkflowWithGraph("wf-empty-graph", "Empty Graph Workflow", "");
+    setupService();
+
+    expect(() =>
+      service.analyze({ skillId: "skill-1", candidateId: "cand-v2-abc" }),
+    ).toThrow(/graphJson is missing/);
+  });
+});


### PR DESCRIPTION
## Summary

- Implement skill upgrade analysis and decision lifecycle (Phase 06)
- Detect when a staged candidate duplicates an installed skill, compare manifests, find affected workflows, prove structural regression safety
- Produce user-visible analysis with rollback pointer and require canonical approval for replace/keep decision
- New service: `createFridaySkillUpgradeAnalysisService` with `analyze()` and `applyDecision()`
- New routes: `skills.upgrade.analyze`, `skills.upgrade.decide`

## Verification status

- **Local verification**: all green
  - 27/27 unit tests passed
  - typecheck passed (3 tsconfigs)
  - contract tests passed (13/13, route snapshot 371 → 373)
  - secret-pattern scan clean
  - `git diff --check` clean
- **Local real-runtime route-handler proof**: core lifecycle **PASS**
  - Import v1 → shadow → canary → promote → publish workflow → import v2 → analyze → decide → verify `upgrade_available`
  - Full analysis assertions verified (isDuplicate, version comparison, inputs/permissions diff, affected workflows, regression proof, rollback pointer, approval proof)
- **Full HTTP proof**: NOT proven
- **Same-SHA RGG proof**: NOT proven yet
- **Release-complete**: NOT claimed
- **rollbackPointer**: proven
- **Rollback route success**: NOT proven; rollback attempt blocked by `CANONICAL_APPROVAL_DENIED / canonical_approval_digest_mismatch` (rollback approval was signed against pre-decision state; after decide mutated status to `upgrade_available`, digest no longer matched)

## Files changed

- `src/skills/services/friday-skill-upgrade-analysis-service.ts` (new)
- `test/unit/skills/services/friday-skill-upgrade-analysis-service.test.ts` (new)
- `src/api/http/routes/friday-skill-routes.ts` (modified)
- `src/api/runtime/friday-api-runtime.ts` (modified)
- `src/skills/index.ts` (modified)
- `test/contracts/api/__snapshots__/friday-api-route-contract.snapshot.test.ts.snap` (modified)

## Out of scope

- merge/absorb decisions
- UI
- new SQL migrations
- hub bootstrap changes
- promotionChannel/shadowVersionId mutation
- setUpgradeMetadata
- release-proof standard changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)