### PR TITLE
Phase 14.5E - Channel setup and live proof (module_28e)

### DIFF
--- a/scripts/ops/run-real-green-gate.mjs
+++ b/scripts/ops/run-real-green-gate.mjs
@@ -109,10 +109,27 @@ const PUBLIC_SURFACE_SCENARIOS = [
   // 14.5C `proofClaimable`. Live external-channel transcript proof
   // remains forwarded to Phase 14.5E for configured channels.
   "l6-phase-14-5d-rollback-matrix-closeout-receipt",
+  // Phase 14.5E module_28e Slice 6.6 — list all three per-channel
+  // roundtrip scenario ids alongside the public-surface inventory so the
+  // planned per-channel RGG mapping is preserved end-to-end. The daily
+  // suite filter excludes them at runtime (each scenario advertises
+  // `suites: ["weekly"]`); the actual external-channel execution path
+  // remains the externalChannels phase below, which runs only when
+  // `external_channels.ready` is true.
+  "l6-discord-channel-roundtrip",
+  "l6-lark-channel-roundtrip",
+  "l6-telegram-channel-roundtrip",
 ];
 
 const EXTERNAL_CHANNEL_SCENARIOS = [
   "l6-discord-channel-roundtrip",
+  // Phase 14.5E module_28e Slice 6.6 — Lark/Feishu and Telegram live
+  // channel roundtrips. Each scenario is independently gated by its env
+  // tuple (Slice 6.7) and records honest non-pass outcomes when env is
+  // incomplete. The validator (`real-green-gate-result.mjs`) and the
+  // gate-reason logic (`deriveGateReasons` above) are unchanged.
+  "l6-lark-channel-roundtrip",
+  "l6-telegram-channel-roundtrip",
 ];
 
 const CLAUDE_SKILL_TESTS = [

--- a/src/api/http/routes/friday-channel-action-routes.ts
+++ b/src/api/http/routes/friday-channel-action-routes.ts
@@ -1,0 +1,465 @@
+// Phase 14.5E module_28e Slice 6.4 — owner-signed approval + execute
+// API for high-risk channel-triggered actions.
+//
+// `POST /v1/channels/actions/{actionId}/owner-approve` accepts an
+// owner-signed token (built locally by the Assistant / API surface using
+// the existing internal runtime secret) and records that the owner has
+// approved the named channel action. `POST /v1/channels/actions/
+// {actionId}/execute` then consumes that approval record and emits the
+// outbound-channel closeout-receipt summary; the execute path refuses
+// any call without a prior approval record. Both routes run on the
+// `api`/`session` lane and the bound-principal contract refuses
+// `source: "channel"` outright for the matching `channel.action.high_
+// risk.{approve,execute}` operations.
+
+import { FridayDomainError } from "#errors";
+import type { FridayRouteDefinition } from "../../model/friday-api-common.types.js";
+import {
+  assertBoundPrincipalForOperation,
+  type FridayBoundPrincipalSource,
+} from "../../../security/friday-owner-session-channel-capability.js";
+import {
+  type FridayChannelActionApprovalPayload,
+  signFridayChannelActionApprovalToken,
+  verifyFridayChannelActionApprovalToken,
+} from "../../../security/friday-channel-action-approval.js";
+import {
+  buildFridayChannelOutboundReceiptSummary,
+  type FridayChannelOutboundReceiptSummary,
+} from "../../../channels/services/friday-channel-outbound-receipt.js";
+
+// Phase 14.5E module_28e Slice 6.4 — owner-link minting defaults. The
+// mint route is bound-principal-authenticated and refuses `source:
+// "channel"`; the token TTL is short by default so a leaked signed
+// approval URL cannot drive a delayed-execute attack.
+const OWNER_LINK_DEFAULT_TTL_SECONDS = 900;
+const OWNER_LINK_MIN_TTL_SECONDS = 60;
+const OWNER_LINK_MAX_TTL_SECONDS = 3600;
+
+export interface FridayChannelActionApprovalRecord {
+  readonly actionId: string;
+  readonly channelId: string;
+  readonly principalId: string;
+  readonly approvedBy: string;
+  readonly approvedSource: "api" | "session";
+  readonly approvedAt: string;
+  readonly tokenExpiresAt: string;
+}
+
+export interface FridayChannelActionApprovalStore {
+  recordApproval(record: FridayChannelActionApprovalRecord): Promise<void> | void;
+  hasApproval(actionId: string): Promise<boolean> | boolean;
+  getApproval(actionId: string): Promise<FridayChannelActionApprovalRecord | null> | FridayChannelActionApprovalRecord | null;
+  /**
+   * Atomically read-and-remove the approval record so a single approval
+   * cannot drive multiple `execute` calls. Returns `null` if no approval
+   * is present. Callers MUST treat a `null` return as
+   * `CHANNEL_HIGH_RISK_EXECUTE_NOT_APPROVED`. The owner-link contract is
+   * single-use by design (see `friday-channel-action-approval.ts` header
+   * line 31): each successful execute consumes the approval so a follow-up
+   * execute must obtain a fresh owner-signed token.
+   */
+  consumeApproval(actionId: string): Promise<FridayChannelActionApprovalRecord | null> | FridayChannelActionApprovalRecord | null;
+}
+
+export interface FridayChannelActionRoutesDeps {
+  /** Internal runtime signing key (typically the FRIDAY_TOKEN_SECRET). */
+  readonly signingKey: string;
+  /**
+   * In-process approval ledger consulted by both the owner-approve route
+   * (write) and the execute route (read). Defaults to an in-memory map.
+   * Phase 14.5E scope explicitly accepts the in-process default: the
+   * owner-signed token already carries its own expiry, the approval
+   * window is short, and the Stage 2 matrix did not plan a v088 SQLite
+   * migration for this slice. Callers wanting durability across runtime
+   * restarts can pass their own store.
+   */
+  readonly approvalStore?: FridayChannelActionApprovalStore;
+  /** Clock injection for tests. */
+  readonly nowIso?: () => string;
+}
+
+interface OwnerApproveRequestBody {
+  readonly ownerApprovalToken?: unknown;
+  readonly channelId?: unknown;
+}
+
+interface OwnerApproveResponseBody {
+  readonly actionId: string;
+  readonly channelId: string;
+  readonly principalId: string;
+  readonly approvedAt: string;
+  readonly tokenExpiresAt: string;
+  readonly approvedSource: "api" | "session";
+}
+
+// Phase 14.5E module_28e Slice 6.4 — owner-link mint route shapes.
+//
+// The mint route's job is to turn a pending high-risk channel action into
+// a one-click owner-approval URL form that the local Assistant / API
+// surface delivers to the owner. The token itself is the bearer; it must
+// never be written to channel text, logs, tests, reports, or artifacts.
+// Channel inbound replies expose only the relative `ownerApprovalPath`
+// (no token, no signed URL) — the Assistant fetches the signed material
+// via this bound-principal route and surfaces the one-click "Approve"
+// affordance to the owner.
+interface OwnerLinkRequestBody {
+  readonly channelId?: unknown;
+  readonly ttlSeconds?: unknown;
+}
+
+interface OwnerLinkResponseBody {
+  readonly actionId: string;
+  readonly channelId: string;
+  readonly principalId: string;
+  readonly ownerApprovalToken: string;
+  readonly ownerApprovalPath: string;
+  readonly ownerApprovalUrl: string;
+  readonly issuedAt: string;
+  readonly expiresAt: string;
+  readonly issuedSource: "api" | "session";
+}
+
+interface ExecuteRequestBody {
+  readonly channelId?: unknown;
+  readonly messageId?: unknown;
+}
+
+interface ExecuteResponseBody {
+  readonly actionId: string;
+  readonly channelId: string;
+  readonly messageId: string;
+  readonly executedAt: string;
+  readonly executedSource: "api" | "session";
+  readonly approval: {
+    readonly approvedBy: string;
+    readonly approvedAt: string;
+    readonly approvedSource: "api" | "session";
+  };
+  readonly receipt: FridayChannelOutboundReceiptSummary;
+}
+
+export function createInMemoryChannelActionApprovalStore(): FridayChannelActionApprovalStore {
+  const store = new Map<string, FridayChannelActionApprovalRecord>();
+  return {
+    recordApproval(record) {
+      store.set(record.actionId, record);
+    },
+    hasApproval(actionId) {
+      return store.has(actionId);
+    },
+    getApproval(actionId) {
+      return store.get(actionId) ?? null;
+    },
+    consumeApproval(actionId) {
+      const record = store.get(actionId);
+      if (!record) return null;
+      store.delete(actionId);
+      return record;
+    },
+  };
+}
+
+export function createFridayChannelActionRoutes(
+  deps: FridayChannelActionRoutesDeps,
+): FridayRouteDefinition<unknown, unknown, unknown, unknown>[] {
+  const approvalStore = deps.approvalStore ?? createInMemoryChannelActionApprovalStore();
+  const nowIso = deps.nowIso ?? (() => new Date().toISOString());
+
+  return [
+    // POST /v1/channels/actions/:actionId/owner-link
+    //
+    // Owner-link mint route. The local Assistant / API surface calls
+    // this with the bound owner principal AND the pending action's
+    // channelId; the route mints an HMAC-signed approval token and
+    // returns the one-click owner-approval URL form the Assistant can
+    // hand the owner. The token never travels through the channel
+    // adapter outbound — channel reply text only carries the relative
+    // `ownerApprovalPath`. `source: "channel"` is refused outright by
+    // `assertBoundPrincipalForOperation`; an unauthenticated synthetic
+    // principal is refused with 401. The route reuses the existing
+    // `channel.action.high_risk.approve` operation because the same
+    // bound-principal authority that approves is the authority that
+    // mints the link.
+    {
+      operationId: "channels.actions.owner.link",
+      method: "POST",
+      path: "/v1/channels/actions/:actionId/owner-link",
+      auth: { public: true },
+      async handler(ctx): Promise<OwnerLinkResponseBody> {
+        const source: FridayBoundPrincipalSource = resolveSource(ctx);
+        const bound = assertBoundPrincipalForOperation(
+          ctx.principal ?? null,
+          "channel.action.high_risk.approve",
+          source,
+        );
+        const { actionId } = ctx.params as { actionId?: string };
+        if (typeof actionId !== "string" || actionId.trim().length === 0) {
+          throw new FridayDomainError(
+            "VALIDATION_ERROR",
+            "actionId path parameter is required.",
+            { httpStatus: 400 },
+          );
+        }
+        const body = (ctx.body ?? {}) as OwnerLinkRequestBody;
+        const channelId = typeof body.channelId === "string"
+          ? body.channelId.trim()
+          : "";
+        if (channelId.length === 0) {
+          throw new FridayDomainError(
+            "VALIDATION_ERROR",
+            "channelId is required.",
+            { httpStatus: 400 },
+          );
+        }
+        const ttlSeconds = clampOwnerLinkTtlSeconds(body.ttlSeconds);
+        const issuedAt = nowIso();
+        const issuedAtMs = Date.parse(issuedAt);
+        if (!Number.isFinite(issuedAtMs)) {
+          throw new FridayDomainError(
+            "VALIDATION_ERROR",
+            "Owner-link mint clock returned an invalid timestamp.",
+            { httpStatus: 500 },
+          );
+        }
+        const expiresAt = new Date(issuedAtMs + ttlSeconds * 1000).toISOString();
+        const trimmedActionId = actionId.trim();
+        const token = signFridayChannelActionApprovalToken({
+          actionId: trimmedActionId,
+          channelId,
+          principalId: bound.principalId,
+          riskLevel: "high",
+          expiresAt,
+          signingKey: deps.signingKey,
+        });
+        const ownerApprovalPath = `/v1/channels/actions/${encodeURIComponent(trimmedActionId)}/owner-approve`;
+        return {
+          actionId: trimmedActionId,
+          channelId,
+          principalId: bound.principalId,
+          ownerApprovalToken: token,
+          ownerApprovalPath,
+          ownerApprovalUrl: ownerApprovalPath,
+          issuedAt,
+          expiresAt,
+          issuedSource: source === "session" ? "session" : "api",
+        };
+      },
+    },
+    // POST /v1/channels/actions/:actionId/owner-approve
+    {
+      operationId: "channels.actions.owner.approve",
+      method: "POST",
+      path: "/v1/channels/actions/:actionId/owner-approve",
+      // `auth: { public: true }` follows the same convention as
+      // /v1/auto-fix/actions/*: the HTTP layer accepts the call, then the
+      // bound-principal contract refuses any unauthenticated synthetic
+      // principal AND any `source: "channel"` call. This route never
+      // accepts `source: "channel"` per Slice 6.4.
+      auth: { public: true },
+      async handler(ctx): Promise<OwnerApproveResponseBody> {
+        const source: FridayBoundPrincipalSource = resolveSource(ctx);
+        const bound = assertBoundPrincipalForOperation(
+          ctx.principal ?? null,
+          "channel.action.high_risk.approve",
+          source,
+        );
+        const { actionId } = ctx.params as { actionId?: string };
+        if (typeof actionId !== "string" || actionId.trim().length === 0) {
+          throw new FridayDomainError(
+            "VALIDATION_ERROR",
+            "actionId path parameter is required.",
+            { httpStatus: 400 },
+          );
+        }
+        const body = (ctx.body ?? {}) as OwnerApproveRequestBody;
+        const token = typeof body.ownerApprovalToken === "string"
+          ? body.ownerApprovalToken.trim()
+          : "";
+        const channelId = typeof body.channelId === "string"
+          ? body.channelId.trim()
+          : "";
+        if (token.length === 0 || channelId.length === 0) {
+          throw new FridayDomainError(
+            "VALIDATION_ERROR",
+            "ownerApprovalToken and channelId are required.",
+            { httpStatus: 400 },
+          );
+        }
+        const now = nowIso();
+        const payload: FridayChannelActionApprovalPayload = verifyFridayChannelActionApprovalToken({
+          token,
+          actionId: actionId.trim(),
+          channelId,
+          principalId: bound.principalId,
+          nowIso: now,
+          signingKey: deps.signingKey,
+        });
+        const record: FridayChannelActionApprovalRecord = {
+          actionId: payload.actionId,
+          channelId: payload.channelId,
+          principalId: payload.principalId,
+          approvedBy: bound.userId ?? bound.principalId,
+          approvedSource: source === "session" ? "session" : "api",
+          approvedAt: now,
+          tokenExpiresAt: payload.expiresAt,
+        };
+        await approvalStore.recordApproval(record);
+        return {
+          actionId: record.actionId,
+          channelId: record.channelId,
+          principalId: record.principalId,
+          approvedAt: record.approvedAt,
+          tokenExpiresAt: record.tokenExpiresAt,
+          approvedSource: record.approvedSource,
+        };
+      },
+    },
+    // POST /v1/channels/actions/:actionId/execute
+    //
+    // Consumes the approval record written by the owner-approve route
+    // above and emits the deterministic outbound-channel closeout
+    // receipt summary (rollbackClass = "non_reversible_external" via the
+    // Phase 14.5D `FRIDAY_TASK_WORKFLOW_ROLLBACK_CLASS_BY_REF_SOURCE`
+    // registry). The execute path is fail-closed: missing prior approval
+    // → 403; `source: "channel"` → 403; synthetic public principal →
+    // 401.
+    {
+      operationId: "channels.actions.execute",
+      method: "POST",
+      path: "/v1/channels/actions/:actionId/execute",
+      auth: { public: true },
+      async handler(ctx): Promise<ExecuteResponseBody> {
+        const source: FridayBoundPrincipalSource = resolveSource(ctx);
+        const bound = assertBoundPrincipalForOperation(
+          ctx.principal ?? null,
+          "channel.action.high_risk.execute",
+          source,
+        );
+        const { actionId } = ctx.params as { actionId?: string };
+        if (typeof actionId !== "string" || actionId.trim().length === 0) {
+          throw new FridayDomainError(
+            "VALIDATION_ERROR",
+            "actionId path parameter is required.",
+            { httpStatus: 400 },
+          );
+        }
+        const body = (ctx.body ?? {}) as ExecuteRequestBody;
+        const channelId = typeof body.channelId === "string"
+          ? body.channelId.trim()
+          : "";
+        const messageId = typeof body.messageId === "string"
+          ? body.messageId.trim()
+          : "";
+        if (channelId.length === 0 || messageId.length === 0) {
+          throw new FridayDomainError(
+            "VALIDATION_ERROR",
+            "channelId and messageId are required.",
+            { httpStatus: 400 },
+          );
+        }
+        const trimmedActionId = actionId.trim();
+        const approval = await approvalStore.getApproval(trimmedActionId);
+        if (!approval) {
+          throw new FridayDomainError(
+            "CHANNEL_HIGH_RISK_EXECUTE_NOT_APPROVED",
+            "Execute requires a prior owner-signed approval for this actionId.",
+            { httpStatus: 403 },
+          );
+        }
+        if (approval.channelId !== channelId) {
+          throw new FridayDomainError(
+            "CHANNEL_HIGH_RISK_EXECUTE_CHANNEL_MISMATCH",
+            "Execute channelId does not match the approval record.",
+            { httpStatus: 403 },
+          );
+        }
+        if (approval.principalId !== bound.principalId) {
+          throw new FridayDomainError(
+            "CHANNEL_HIGH_RISK_EXECUTE_PRINCIPAL_MISMATCH",
+            "Execute principal does not match the approval record.",
+            { httpStatus: 403 },
+          );
+        }
+        const separatorIndex = channelId.indexOf(":");
+        if (separatorIndex <= 0 || separatorIndex >= channelId.length - 1) {
+          throw new FridayDomainError(
+            "VALIDATION_ERROR",
+            "channelId must be `<channelKind>:<chatId>`.",
+            { httpStatus: 400 },
+          );
+        }
+        const channelKind = channelId.slice(0, separatorIndex);
+        const chatId = channelId.slice(separatorIndex + 1);
+        // Atomic read-and-remove: fail-closed single-use of the owner
+        // approval. Validation above has confirmed source/channel/principal
+        // parity against the still-present record; consuming here matches
+        // the "single-use at the API layer" contract documented in
+        // `friday-channel-action-approval.ts` (line 31). A concurrent
+        // executor that lost the race sees `null` and is rejected with
+        // CHANNEL_HIGH_RISK_EXECUTE_NOT_APPROVED — the owner must mint a
+        // fresh token to authorize another execute.
+        const consumed = await approvalStore.consumeApproval(trimmedActionId);
+        if (!consumed) {
+          throw new FridayDomainError(
+            "CHANNEL_HIGH_RISK_EXECUTE_NOT_APPROVED",
+            "Execute requires a prior owner-signed approval for this actionId.",
+            { httpStatus: 403 },
+          );
+        }
+        const receipt = buildFridayChannelOutboundReceiptSummary({
+          channelKind,
+          chatId,
+          messageId,
+        });
+        const executedAt = nowIso();
+        return {
+          actionId: trimmedActionId,
+          channelId,
+          messageId,
+          executedAt,
+          executedSource: source === "session" ? "session" : "api",
+          approval: {
+            approvedBy: approval.approvedBy,
+            approvedAt: approval.approvedAt,
+            approvedSource: approval.approvedSource,
+          },
+          receipt,
+        };
+      },
+    },
+  ];
+}
+
+function resolveSource(ctx: { headers?: Record<string, string | undefined> }): FridayBoundPrincipalSource {
+  const headers = ctx.headers ?? {};
+  const raw = headers["x-friday-principal-source"];
+  const normalized = typeof raw === "string" ? raw.trim().toLowerCase() : "";
+  if (normalized === "session") return "session";
+  // Default to "api" — never "channel". Channel-sourced calls must not
+  // implicitly downgrade their source classification to reach this gate.
+  if (normalized === "channel") return "channel";
+  return "api";
+}
+
+function clampOwnerLinkTtlSeconds(raw: unknown): number {
+  if (raw === undefined || raw === null) {
+    return OWNER_LINK_DEFAULT_TTL_SECONDS;
+  }
+  const value = typeof raw === "number" ? raw : Number(raw);
+  if (!Number.isFinite(value)) {
+    throw new FridayDomainError(
+      "VALIDATION_ERROR",
+      "ttlSeconds must be a finite number when supplied.",
+      { httpStatus: 400 },
+    );
+  }
+  const truncated = Math.trunc(value);
+  if (truncated < OWNER_LINK_MIN_TTL_SECONDS) {
+    return OWNER_LINK_MIN_TTL_SECONDS;
+  }
+  if (truncated > OWNER_LINK_MAX_TTL_SECONDS) {
+    return OWNER_LINK_MAX_TTL_SECONDS;
+  }
+  return truncated;
+}

--- a/src/api/http/routes/friday-setup-routes.ts
+++ b/src/api/http/routes/friday-setup-routes.ts
@@ -29,7 +29,11 @@ import {
   parseFridayChannelsConfig,
   parseFridayChannelSecretRef,
 } from "#channels";
-import type { FridaySupportedChannelKind } from "#channels";
+import type { FridayChannelRegistryView, FridaySupportedChannelKind } from "#channels";
+import {
+  buildFridayChannelSetupStatus,
+  type FridayChannelSetupStatusResponse,
+} from "../../../channels/friday-channel-setup-status.js";
 import { FridayDomainError } from "#errors";
 import { validateGatewayUrl } from "../../../agent/tools/friday-agent-gateway-validation.js";
 import { parseFridaySecretInput } from "../../../security/friday-secret-ref.js";
@@ -1858,6 +1862,14 @@ export interface FridaySetupRoutesDeps {
   /** Allow loopback/private network addresses for self-hosted deployments using local providers. */
   allowPrivateNetwork?: boolean;
   getLiveChannelCount?: () => number;
+  /**
+   * Phase 14.5E module_28e Slice 6.2 — optional callback that returns the
+   * current channel registry views (one per registered channel kind). The
+   * `GET /v1/setup/channels/status` endpoint reads from this to project
+   * per-channel `proofLabel` values. Returns an empty array when no
+   * registry is wired or no channels are registered.
+   */
+  listChannelRegistryViews?: () => readonly FridayChannelRegistryView[];
   activateSavedChannels?: () =>
     | Promise<SetupChannelsActivationResponse>
     | SetupChannelsActivationResponse;
@@ -2230,6 +2242,24 @@ export function createFridaySetupRoutes(
           previewUrls: computePreviewUrls(host, port),
           restartRequired,
         };
+      },
+    },
+
+    // ─── GET /v1/setup/channels/status ───
+    // Phase 14.5E module_28e Slice 6.2 — per-channel proof label surface for
+    // the setup wizard. Reads channel registry views (when wired) and the
+    // declared v1 channel env tuples and returns one row per v1 channel
+    // (Discord + Lark/Feishu + Telegram) plus any registered non-v1 channels
+    // labelled `unsupported`. Never collapses Lark/Feishu or Telegram into
+    // Discord.
+    {
+      operationId: "setup.channels.status",
+      method: "GET",
+      path: "/v1/setup/channels/status",
+      auth: { public: true },
+      async handler(): Promise<FridayChannelSetupStatusResponse> {
+        const views = deps.listChannelRegistryViews?.() ?? [];
+        return buildFridayChannelSetupStatus({ views });
       },
     },
 

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -80,6 +80,7 @@ import {
 import { createFridaySkillGeneratorRoutes } from "../http/routes/friday-skill-generator-routes.js";
 import { createFridayDiagnosisRoutes } from "../http/routes/friday-diagnosis-routes.js";
 import { createFridayAutoFixRoutes } from "../http/routes/friday-auto-fix-routes.js";
+import { createFridayChannelActionRoutes } from "../http/routes/friday-channel-action-routes.js";
 import { createFridayAgentLoopRoutes } from "../http/routes/friday-agent-loop-routes.js";
 import { createFridaySkillConverterRoutes } from "../http/routes/friday-skill-converter-routes.js";
 import { createFridayWorkflowGeneratorRoutes } from "../http/routes/friday-workflow-generator-routes.js";
@@ -2423,6 +2424,18 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
     }
   }
 
+  // Phase 14.5E module_28e Slice 6.4 — owner-signed approval API for
+  // high-risk channel-triggered actions. Reuses the existing internal
+  // runtime token secret; no new user-provided secret.
+  if (typeof deps.tokenSecret === "string" && deps.tokenSecret.length > 0) {
+    for (const route of createFridayChannelActionRoutes({
+      signingKey: deps.tokenSecret,
+      nowIso: deps.nowIso,
+    })) {
+      routes.register(route);
+    }
+  }
+
   if (deps.agentLoop) {
     for (const route of createFridayAgentLoopRoutes(deps.agentLoop)) {
       routes.register(route);
@@ -2603,6 +2616,7 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
       runningPort: deps.serverPort ?? 3141,
       allowPrivateNetwork: deps.allowPrivateNetwork,
       getLiveChannelCount: () => deps.channels?.registry.listViews().length ?? 0,
+      listChannelRegistryViews: () => deps.channels?.registry.listViews() ?? [],
       activateSavedChannels: deps.activateSavedChannels,
       onChannelsSaved: deps.onSetupChannelsSaved,
       onSetupCompleted: deps.onSetupCompleted,

--- a/src/channels/friday-channel-registry.ts
+++ b/src/channels/friday-channel-registry.ts
@@ -40,12 +40,33 @@ export type FridayChannelCredentialStatus =
   | "missing"
   | "invalid";
 
+// Phase 14.5E module_28e Slice 6.1 — deterministic per-channel proof label
+// surfaced to the setup wizard status endpoint and the RGG executors. The
+// four-member union maps cleanly onto the Stage 2 matrix vocabulary; any
+// non-v1 channel kind is classified as `unsupported` regardless of
+// credentials so the wizard cannot conflate "not in v1 scope" with
+// "missing credentials".
+export type FridayChannelProofLabel =
+  | "configured"
+  | "not_configured"
+  | "blocked_by_env"
+  | "unsupported";
+
 export interface FridayChannelHealthSummary {
   state: FridayChannelStatus;
   restartCount: number;
   lastError?: string;
   blockedReason?: string;
   credentialStatus: FridayChannelCredentialStatus;
+  /**
+   * Phase 14.5E module_28e: deterministic proof label paired with the
+   * existing `credentialStatus` field. `proofLabel` is the user-facing
+   * status word the setup wizard renders; `credentialStatus` is the
+   * internal credential health signal. Both must agree on the underlying
+   * state for v1 channels (Discord/Lark/Feishu/Telegram); non-v1 channels
+   * resolve to `unsupported`.
+   */
+  proofLabel: FridayChannelProofLabel;
 }
 
 export interface FridayChannelRegistryView {
@@ -134,6 +155,73 @@ export interface FridayChannelRegistry {
 // ─── Implementation ───
 
 const HEALTH_CHECK_DEFAULT_INTERVAL_MS = 30_000;
+
+// Phase 14.5E module_28e Slice 6.1 — v1 channel set for per-channel proof
+// labels. Discord + Lark/Feishu + Telegram each carry their own proof label
+// surface; every other registered channel kind is `unsupported` for v1.
+const FRIDAY_CHANNEL_V1_PROOF_KINDS: ReadonlySet<string> = new Set([
+  "discord",
+  "lark",
+  "feishu",
+  "telegram",
+]);
+
+export function isFridayChannelV1ProofKind(kind: string): boolean {
+  return FRIDAY_CHANNEL_V1_PROOF_KINDS.has(kind);
+}
+
+// Phase 14.5E module_28e Slice 6.1 — pure, deterministic mapping from the
+// inputs the setup wizard / status endpoint can observe to the proof label.
+// Exposed for the status route and for unit tests that need to assert the
+// (env-state, registry-state) → proof-label tuple is exhaustive.
+//
+// The rules:
+//   - non-v1 kind                           → "unsupported"
+//   - env tuple fully present:
+//       credentialStatus = "invalid"        → "blocked_by_env"
+//       otherwise                           → "configured"
+//   - env tuple fully missing (no vars set):
+//       credentialStatus = "configured"     → "configured"   (adapter has creds without env)
+//       credentialStatus = "invalid"        → "blocked_by_env"
+//       blockedReason present               → "blocked_by_env"
+//       otherwise                           → "not_configured"
+//   - env tuple partial (some set, some not):
+//       always                              → "blocked_by_env"
+export function deriveFridayChannelProofLabel(input: {
+  kind: string;
+  credentialStatus: FridayChannelCredentialStatus;
+  blockedReason?: string;
+  envMissingVars?: readonly string[];
+  envRequiredVars?: readonly string[];
+}): FridayChannelProofLabel {
+  if (!FRIDAY_CHANNEL_V1_PROOF_KINDS.has(input.kind)) {
+    return "unsupported";
+  }
+  const missingCount = input.envMissingVars?.length ?? 0;
+  const requiredCount = input.envRequiredVars?.length ?? missingCount;
+  const hasAnyEnvDeclared = requiredCount > 0;
+
+  if (hasAnyEnvDeclared && missingCount === 0) {
+    return input.credentialStatus === "invalid" ? "blocked_by_env" : "configured";
+  }
+
+  if (hasAnyEnvDeclared && missingCount > 0 && missingCount < requiredCount) {
+    return "blocked_by_env";
+  }
+
+  // Fully-missing env tuple (or no env tuple declared) — fall back to
+  // credential signals.
+  if (input.credentialStatus === "configured") {
+    return "configured";
+  }
+  if (input.credentialStatus === "invalid") {
+    return "blocked_by_env";
+  }
+  if (typeof input.blockedReason === "string" && input.blockedReason.trim().length > 0) {
+    return "blocked_by_env";
+  }
+  return "not_configured";
+}
 
 export interface FridayChannelRegistryOptions {
   /** Optional grant check called before register/unregister mutations. Throws if denied. */
@@ -290,6 +378,26 @@ export function createFridayChannelRegistry(options?: FridayChannelRegistryOptio
       return "invalid";
     }
     return "unknown";
+  }
+
+  function deriveProofLabel(
+    kind: string,
+    credentialStatus: FridayChannelCredentialStatus,
+    blockedReason: string | undefined,
+  ): FridayChannelProofLabel {
+    if (!FRIDAY_CHANNEL_V1_PROOF_KINDS.has(kind)) {
+      return "unsupported";
+    }
+    if (credentialStatus === "configured") {
+      return "configured";
+    }
+    if (credentialStatus === "invalid") {
+      return "blocked_by_env";
+    }
+    if (typeof blockedReason === "string" && blockedReason.trim().length > 0) {
+      return "blocked_by_env";
+    }
+    return "not_configured";
   }
 
   return {
@@ -474,6 +582,11 @@ export function createFridayChannelRegistry(options?: FridayChannelRegistryOptio
       if (!entry) {
         return undefined;
       }
+      const diagnostics = this.diagnostics(kind);
+      const lastError = healthState.get(kind)?.lastError;
+      const blockedReason = healthState.get(kind)?.blockedReason;
+      const credentialStatus = inferCredentialStatus(diagnostics, lastError);
+      const proofLabel = deriveProofLabel(kind, credentialStatus, blockedReason);
       return {
         kind,
         running: entry.running,
@@ -481,14 +594,12 @@ export function createFridayChannelRegistry(options?: FridayChannelRegistryOptio
         health: {
           state: this.status(kind),
           restartCount: healthState.get(kind)?.restartCount ?? 0,
-          lastError: healthState.get(kind)?.lastError,
-          blockedReason: healthState.get(kind)?.blockedReason,
-          credentialStatus: inferCredentialStatus(
-            this.diagnostics(kind),
-            healthState.get(kind)?.lastError,
-          ),
+          lastError,
+          blockedReason,
+          credentialStatus,
+          proofLabel,
         },
-        diagnostics: this.diagnostics(kind),
+        diagnostics,
         contract: entry.plugin.contract,
         allowlist: buildAllowlistSummary(entry.allowlist),
       };

--- a/src/channels/friday-channel-setup-status.ts
+++ b/src/channels/friday-channel-setup-status.ts
@@ -1,0 +1,176 @@
+// Phase 14.5E module_28e Slice 6.2 — deterministic per-channel setup status
+// surface for `GET /v1/setup/channels/status`. The status table is a thin
+// deterministic projection of (a) the channel registry health view and
+// (b) the v1 channel env tuple presence checked against `process.env`. It
+// produces the same proof label vocabulary as the RGG executors (Slices
+// 6.6/6.7) so the wizard and the RGG vehicle never disagree on whether a
+// channel is `configured`/`not_configured`/`blocked_by_env`/`unsupported`.
+
+import {
+  deriveFridayChannelProofLabel,
+  type FridayChannelHealthSummary,
+  type FridayChannelProofLabel,
+  type FridayChannelRegistryView,
+  isFridayChannelV1ProofKind,
+} from "./friday-channel-registry.js";
+
+export interface FridayChannelSetupStatusRow {
+  channelId: string;
+  kind: string;
+  displayName: string;
+  proofLabel: FridayChannelProofLabel;
+  credentialStatus: FridayChannelHealthSummary["credentialStatus"];
+  blockedReason: string | null;
+  requiredEnvVars: readonly string[];
+  missingEnvVars: readonly string[];
+  lastProofResult: null;
+}
+
+export interface FridayChannelSetupStatusResponse {
+  channels: FridayChannelSetupStatusRow[];
+}
+
+interface ChannelDescriptor {
+  channelId: string;
+  kind: string;
+  // The Lark plugin rewrites its own `kind` to "feishu" at runtime when
+  // `useFeishu: true`, so the registry view for the Lark/Feishu v1 row
+  // can arrive under either kind. The descriptor declares both the
+  // canonical kind and any runtime aliases so the v1 row is the single
+  // source of truth — the alias never appears as a separate
+  // `unsupported` row.
+  aliasKinds: readonly string[];
+  displayName: string;
+  requiredEnvVars: readonly string[];
+}
+
+const V1_CHANNEL_DESCRIPTORS: readonly ChannelDescriptor[] = Object.freeze([
+  Object.freeze({
+    channelId: "discord",
+    kind: "discord",
+    aliasKinds: Object.freeze([]),
+    displayName: "Discord",
+    requiredEnvVars: Object.freeze([
+      "FRIDAY_DISCORD_BOT_TOKEN",
+      "FRIDAY_DISCORD_SETUP_USER_ID",
+      "FRIDAY_DISCORD_GUILD_ID",
+      "FRIDAY_DISCORD_CHANNEL_ID",
+    ]),
+  }),
+  Object.freeze({
+    channelId: "lark",
+    kind: "lark",
+    aliasKinds: Object.freeze(["feishu"]),
+    displayName: "Lark / Feishu",
+    requiredEnvVars: Object.freeze([
+      "FRIDAY_LARK_APP_ID",
+      "FRIDAY_LARK_APP_SECRET",
+      "FRIDAY_LARK_VERIFICATION_TOKEN",
+      "FRIDAY_LARK_ENCRYPT_KEY",
+      "FRIDAY_LARK_TEST_CHAT_ID",
+    ]),
+  }),
+  Object.freeze({
+    channelId: "telegram",
+    kind: "telegram",
+    aliasKinds: Object.freeze([]),
+    displayName: "Telegram",
+    requiredEnvVars: Object.freeze([
+      "FRIDAY_TELEGRAM_BOT_TOKEN",
+      "FRIDAY_TELEGRAM_TEST_CHAT_ID",
+    ]),
+  }),
+]);
+
+export const FRIDAY_CHANNEL_V1_SETUP_DESCRIPTORS = V1_CHANNEL_DESCRIPTORS;
+
+export function buildFridayChannelSetupStatus(input: {
+  views?: readonly FridayChannelRegistryView[];
+  processEnv?: NodeJS.ProcessEnv;
+}): FridayChannelSetupStatusResponse {
+  const env = input.processEnv ?? process.env;
+  const views = input.views ?? [];
+  const viewByKind = new Map(views.map((view) => [view.kind, view]));
+
+  const v1Rows = V1_CHANNEL_DESCRIPTORS.map((descriptor) =>
+    buildRow(descriptor, resolveDescriptorView(descriptor, viewByKind), env));
+
+  // Surface any registered non-v1 channels as `unsupported` so the wizard
+  // does not silently hide them. Discord/Lark/Feishu/Telegram are covered
+  // by the v1 loop above; everything else (slack, webchat, line, whatsapp,
+  // qq, signal, irc) falls into this list with `unsupported` proof label.
+  const v1Kinds = new Set<string>();
+  for (const descriptor of V1_CHANNEL_DESCRIPTORS) {
+    v1Kinds.add(descriptor.kind);
+    for (const alias of descriptor.aliasKinds) {
+      v1Kinds.add(alias);
+    }
+  }
+  const nonV1Rows = views
+    .filter((view) => !v1Kinds.has(view.kind))
+    .map((view): FridayChannelSetupStatusRow => ({
+      channelId: view.kind,
+      kind: view.kind,
+      displayName: titleCase(view.kind),
+      proofLabel: "unsupported",
+      credentialStatus: view.health.credentialStatus,
+      blockedReason: view.health.blockedReason ?? null,
+      requiredEnvVars: [],
+      missingEnvVars: [],
+      lastProofResult: null,
+    }));
+
+  return { channels: [...v1Rows, ...nonV1Rows] };
+}
+
+function resolveDescriptorView(
+  descriptor: ChannelDescriptor,
+  viewByKind: ReadonlyMap<string, FridayChannelRegistryView>,
+): FridayChannelRegistryView | undefined {
+  const primary = viewByKind.get(descriptor.kind);
+  if (primary) return primary;
+  for (const alias of descriptor.aliasKinds) {
+    const view = viewByKind.get(alias);
+    if (view) return view;
+  }
+  return undefined;
+}
+
+function buildRow(
+  descriptor: ChannelDescriptor,
+  view: FridayChannelRegistryView | undefined,
+  env: NodeJS.ProcessEnv,
+): FridayChannelSetupStatusRow {
+  const missingEnvVars = descriptor.requiredEnvVars.filter(
+    (key) => !String(env[key] ?? "").trim(),
+  );
+  const credentialStatus = view?.health.credentialStatus ?? "unknown";
+  const blockedReason = view?.health.blockedReason ?? null;
+  const proofLabel = deriveFridayChannelProofLabel({
+    kind: descriptor.kind,
+    credentialStatus,
+    blockedReason: blockedReason ?? undefined,
+    envMissingVars: missingEnvVars,
+    envRequiredVars: descriptor.requiredEnvVars,
+  });
+  return {
+    channelId: descriptor.channelId,
+    kind: descriptor.kind,
+    displayName: descriptor.displayName,
+    proofLabel,
+    credentialStatus,
+    blockedReason,
+    requiredEnvVars: descriptor.requiredEnvVars,
+    missingEnvVars,
+    lastProofResult: null,
+  };
+}
+
+function titleCase(value: string): string {
+  if (value.length === 0) return value;
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+export function isFridayChannelV1SetupKind(kind: string): boolean {
+  return isFridayChannelV1ProofKind(kind);
+}

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -32,9 +32,53 @@ export type {
   FridayChannelStartFailure,
   FridayChannelStartSummary,
   FridayChannelMessageHandler,
+  FridayChannelCredentialStatus,
+  FridayChannelHealthSummary,
+  FridayChannelProofLabel,
 } from "./friday-channel-registry.js";
 
-export { createFridayChannelRegistry } from "./friday-channel-registry.js";
+export {
+  createFridayChannelRegistry,
+  deriveFridayChannelProofLabel,
+  isFridayChannelV1ProofKind,
+} from "./friday-channel-registry.js";
+
+// Phase 14.5E module_28e Slice 6.2 — setup wizard status surface.
+export type {
+  FridayChannelSetupStatusResponse,
+  FridayChannelSetupStatusRow,
+} from "./friday-channel-setup-status.js";
+export {
+  FRIDAY_CHANNEL_V1_SETUP_DESCRIPTORS,
+  buildFridayChannelSetupStatus,
+  isFridayChannelV1SetupKind,
+} from "./friday-channel-setup-status.js";
+
+// Phase 14.5E module_28e Slice 6.3 — channel canonical command + risk
+// preview routing for channel-triggered actions.
+export type {
+  FridayChannelCanonicalCommand,
+  FridayChannelCanonicalCommandParseInput,
+  FridayChannelCanonicalVerb,
+  FridayChannelDispatchOutcome,
+  FridayChannelOwnerLinkRequest,
+  FridayChannelRiskLevel,
+  FridayChannelRiskPreview,
+} from "./services/friday-channel-canonical-command.js";
+export {
+  buildFridayChannelDispatchReplyText,
+  buildFridayChannelOwnerLinkPath,
+  parseFridayChannelCanonicalCommand,
+  routeFridayChannelDispatch,
+} from "./services/friday-channel-canonical-command.js";
+
+// Phase 14.5E module_28e Slice 6.5 — channel-triggered closeout receipt
+// helpers; reuses 14.5C/14.5D fields, no new closeout gate.
+export type {
+  FridayChannelOutboundReceiptInput,
+  FridayChannelOutboundReceiptSummary,
+} from "./services/friday-channel-outbound-receipt.js";
+export { buildFridayChannelOutboundReceiptSummary } from "./services/friday-channel-outbound-receipt.js";
 
 // ─── Loader ───
 

--- a/src/channels/services/friday-channel-canonical-command.ts
+++ b/src/channels/services/friday-channel-canonical-command.ts
@@ -1,0 +1,260 @@
+// Phase 14.5E module_28e Slice 6.3 — deterministic canonical command +
+// risk preview routing for channel-triggered actions.
+//
+// Channel inbound messages flow through this module as:
+//
+//   natural language → canonical command → risk level → risk preview
+//   (low/medium → in-channel confirmation, high → owner-link request)
+//
+// The verb/target → risk table is a curated allowlist; there is no LLM
+// call, no free-form NLU, and no fuzzy match. The same input always
+// produces the same canonical command and the same risk level so the
+// downstream owner-link verifier (Slice 6.4) can rely on a stable
+// `actionId` and `riskLevel`.
+
+export type FridayChannelRiskLevel = "low" | "medium" | "high";
+
+export type FridayChannelCanonicalVerb =
+  | "status"
+  | "diagnose"
+  | "preview_repair"
+  | "apply_repair"
+  | "rollback"
+  | "rotate_credential"
+  | "approve_action"
+  | "execute_action";
+
+export interface FridayChannelCanonicalCommand {
+  readonly verb: FridayChannelCanonicalVerb;
+  readonly target: string;
+  readonly args: Readonly<Record<string, string>>;
+  readonly riskLevel: FridayChannelRiskLevel;
+}
+
+export interface FridayChannelCanonicalCommandParseInput {
+  readonly channelKind: string;
+  readonly chatId: string;
+  readonly chatType: "direct" | "group";
+  readonly senderId: string;
+  readonly text: string;
+}
+
+export interface FridayChannelRiskPreview {
+  readonly actionId: string;
+  readonly channelKind: string;
+  readonly chatId: string;
+  readonly senderId: string;
+  readonly command: FridayChannelCanonicalCommand;
+  readonly previewText: string;
+  readonly confirmation: "in_channel" | "owner_link";
+}
+
+export interface FridayChannelOwnerLinkRequest {
+  readonly actionId: string;
+  readonly channelKind: string;
+  readonly chatId: string;
+  readonly senderId: string;
+  readonly command: FridayChannelCanonicalCommand;
+  readonly previewText: string;
+  readonly ownerLinkPath: string;
+  readonly riskLevel: "high";
+}
+
+export type FridayChannelDispatchOutcome =
+  | { kind: "no_match" }
+  | { kind: "risk_preview"; preview: FridayChannelRiskPreview }
+  | { kind: "owner_link_required"; request: FridayChannelOwnerLinkRequest };
+
+interface CanonicalRule {
+  readonly pattern: RegExp;
+  readonly verb: FridayChannelCanonicalVerb;
+  readonly target: string;
+  readonly riskLevel: FridayChannelRiskLevel;
+}
+
+// Curated allowlist. Every entry must declare `riskLevel` explicitly so
+// the table is reviewable. New verbs require an explicit edit here and a
+// matching unit test; there is no fallback that lowers risk silently.
+const CANONICAL_RULES: readonly CanonicalRule[] = [
+  { pattern: /^\s*(?:friday\s+)?status\s*$/i, verb: "status", target: "runtime", riskLevel: "low" },
+  { pattern: /^\s*(?:friday\s+)?(?:health|ping)\s*$/i, verb: "status", target: "runtime", riskLevel: "low" },
+  { pattern: /^\s*(?:friday\s+)?diagnose\s*$/i, verb: "diagnose", target: "doctor", riskLevel: "low" },
+  {
+    pattern: /^\s*(?:friday\s+)?(?:preview\s+repair|repair\s+preview|fix\s+preview)\s*$/i,
+    verb: "preview_repair",
+    target: "auto_fix",
+    riskLevel: "medium",
+  },
+  {
+    pattern: /^\s*(?:friday\s+)?(?:apply\s+repair|run\s+repair|fix)\s*$/i,
+    verb: "apply_repair",
+    target: "auto_fix",
+    riskLevel: "high",
+  },
+  {
+    pattern: /^\s*(?:friday\s+)?(?:rollback|undo)\s*$/i,
+    verb: "rollback",
+    target: "auto_fix",
+    riskLevel: "high",
+  },
+  {
+    pattern: /^\s*(?:friday\s+)?(?:rotate\s+credential|rotate\s+secret|rotate\s+token)\s*$/i,
+    verb: "rotate_credential",
+    target: "secrets",
+    riskLevel: "high",
+  },
+  {
+    pattern: /^\s*(?:friday\s+)?approve\s+([A-Za-z0-9_\-:.]{4,128})\s*$/i,
+    verb: "approve_action",
+    target: "approval",
+    riskLevel: "high",
+  },
+  {
+    pattern: /^\s*(?:friday\s+)?execute\s+([A-Za-z0-9_\-:.]{4,128})\s*$/i,
+    verb: "execute_action",
+    target: "approval",
+    riskLevel: "high",
+  },
+];
+
+export function parseFridayChannelCanonicalCommand(
+  input: FridayChannelCanonicalCommandParseInput,
+): FridayChannelCanonicalCommand | null {
+  const text = String(input.text ?? "").trim();
+  if (text.length === 0) {
+    return null;
+  }
+  for (const rule of CANONICAL_RULES) {
+    const match = rule.pattern.exec(text);
+    if (!match) continue;
+    const args: Record<string, string> = {};
+    if (rule.verb === "approve_action" || rule.verb === "execute_action") {
+      const target = match[1]?.trim() ?? "";
+      if (target.length === 0) {
+        return null;
+      }
+      args.actionId = target;
+    }
+    return Object.freeze({
+      verb: rule.verb,
+      target: rule.target,
+      args: Object.freeze(args),
+      riskLevel: rule.riskLevel,
+    });
+  }
+  return null;
+}
+
+function buildActionId(input: {
+  channelKind: string;
+  chatId: string;
+  senderId: string;
+  verb: FridayChannelCanonicalVerb;
+  target: string;
+  args: Readonly<Record<string, string>>;
+}): string {
+  const carriedActionId = input.args.actionId;
+  if (carriedActionId && carriedActionId.length > 0) {
+    return carriedActionId;
+  }
+  const slug = [input.channelKind, input.chatId, input.senderId, input.verb, input.target]
+    .map((segment) => String(segment ?? "").trim().toLowerCase().replace(/[^a-z0-9]+/g, "-"))
+    .filter((segment) => segment.length > 0)
+    .join(":");
+  return slug || `${input.channelKind}:${input.verb}:${input.target}`;
+}
+
+function buildPreviewText(command: FridayChannelCanonicalCommand): string {
+  const argsText = Object.entries(command.args)
+    .map(([key, value]) => `${key}=${value}`)
+    .join(", ");
+  const suffix = argsText.length > 0 ? ` (${argsText})` : "";
+  return `Friday canonical command: ${command.verb} ${command.target}${suffix} [risk=${command.riskLevel}]`;
+}
+
+export function buildFridayChannelOwnerLinkPath(actionId: string): string {
+  return `/v1/channels/actions/${encodeURIComponent(actionId)}/owner-approve`;
+}
+
+// Phase 14.5E module_28e Slice 6.3 — deterministic reply-text helper for
+// the live inbound channel binding. The hub channel handler invokes
+// `routeFridayChannelDispatch` on every inbound text message and, if the
+// outcome is not `no_match`, calls this helper to format the reply that
+// `channelRegistry.send()` delivers back to the originating chat.
+//
+// The reply text is intentionally narrow:
+//   - low/medium → the preview text plus a one-line note that the
+//     channel does not auto-execute (consistent with the dispatcher's
+//     `confirmation: "in_channel"` shape; the channel surfaces what was
+//     recognized without claiming an execute path that does not exist in
+//     Phase 14.5E scope);
+//   - high → the preview text plus the owner-link path (per the
+//     bound-principal contract, high-risk actions cannot be approved or
+//     executed from a channel message alone; the channel may only point
+//     the owner at the owner-link).
+//
+// The returned string never includes secrets, tokens, or HMACs — the
+// owner-link path is a relative URL the owner opens via the local
+// Assistant / API surface, which mints the signed token separately.
+export function buildFridayChannelDispatchReplyText(
+  outcome: FridayChannelDispatchOutcome,
+): string | null {
+  if (outcome.kind === "no_match") return null;
+  if (outcome.kind === "risk_preview") {
+    return (
+      `${outcome.preview.previewText}\n\n`
+      + `Preview only. Friday will not auto-execute this command from the channel; `
+      + `use the local Assistant or API surface to confirm.`
+    );
+  }
+  return (
+    `${outcome.request.previewText}\n\n`
+    + `High-risk action requires an owner-signed approval. Owner-link path: `
+    + `${outcome.request.ownerLinkPath}`
+  );
+}
+
+export function routeFridayChannelDispatch(
+  input: FridayChannelCanonicalCommandParseInput,
+): FridayChannelDispatchOutcome {
+  const command = parseFridayChannelCanonicalCommand(input);
+  if (!command) {
+    return { kind: "no_match" };
+  }
+  const actionId = buildActionId({
+    channelKind: input.channelKind,
+    chatId: input.chatId,
+    senderId: input.senderId,
+    verb: command.verb,
+    target: command.target,
+    args: command.args,
+  });
+  const previewText = buildPreviewText(command);
+  if (command.riskLevel === "high") {
+    return {
+      kind: "owner_link_required",
+      request: {
+        actionId,
+        channelKind: input.channelKind,
+        chatId: input.chatId,
+        senderId: input.senderId,
+        command,
+        previewText,
+        ownerLinkPath: buildFridayChannelOwnerLinkPath(actionId),
+        riskLevel: "high",
+      },
+    };
+  }
+  return {
+    kind: "risk_preview",
+    preview: {
+      actionId,
+      channelKind: input.channelKind,
+      chatId: input.chatId,
+      senderId: input.senderId,
+      command,
+      previewText,
+      confirmation: "in_channel",
+    },
+  };
+}

--- a/src/channels/services/friday-channel-outbound-receipt.ts
+++ b/src/channels/services/friday-channel-outbound-receipt.ts
@@ -1,0 +1,59 @@
+// Phase 14.5E module_28e Slice 6.5 — channel-triggered closeout receipt
+// helpers.
+//
+// The task-workflow closeout-gate machinery already maps the
+// `channel_event` evidence ref source to
+// `rollbackClass = "non_reversible_external"` via
+// `FRIDAY_TASK_WORKFLOW_ROLLBACK_CLASS_BY_REF_SOURCE` (Phase 14.5D), and
+// the closeout gate synthesizer (`friday-task-workflow-closeout-gates.ts`)
+// composes the `nonReversibleReason` string deterministically. What this
+// slice adds is a small, scope-local helper that gives channel-triggered
+// closeout call sites a stable, user-facing reason string for outbound
+// channel sends. The same helper is consumed by the Slice 6.8 acceptance
+// test so reviewers can verify the receipt wording without touching the
+// Phase 14.5D synthesizer.
+
+import {
+  FRIDAY_TASK_WORKFLOW_ROLLBACK_CLASS_BY_REF_SOURCE,
+  type FridayTaskWorkflowOperationRollbackClass,
+} from "../../task-workflows/friday-task-workflow.types.js";
+
+export interface FridayChannelOutboundReceiptInput {
+  readonly channelKind: string;
+  readonly chatId: string;
+  readonly messageId: string;
+}
+
+export interface FridayChannelOutboundReceiptSummary {
+  readonly evidenceRefSource: "channel_event";
+  readonly rollbackClass: FridayTaskWorkflowOperationRollbackClass;
+  readonly nonReversibleReason: string;
+  readonly evidenceRefId: string;
+}
+
+export function buildFridayChannelOutboundReceiptSummary(
+  input: FridayChannelOutboundReceiptInput,
+): FridayChannelOutboundReceiptSummary {
+  const channelKind = String(input.channelKind ?? "").trim();
+  const chatId = String(input.chatId ?? "").trim();
+  const messageId = String(input.messageId ?? "").trim();
+  if (channelKind.length === 0 || chatId.length === 0 || messageId.length === 0) {
+    throw new Error(
+      "Channel outbound receipt requires non-empty channelKind, chatId, and messageId.",
+    );
+  }
+  const channelId = `${channelKind}:${chatId}`;
+  const evidenceRefId = `channel-event:${channelId}:${messageId}`;
+  // Deterministic registry lookup — see Phase 14.5D
+  // FRIDAY_TASK_WORKFLOW_ROLLBACK_CLASS_BY_REF_SOURCE. Asserting via the
+  // registry rather than hard-coding the class keeps this helper honest
+  // if the rollback class for `channel_event` ever changes.
+  const rollbackClass = FRIDAY_TASK_WORKFLOW_ROLLBACK_CLASS_BY_REF_SOURCE.channel_event;
+  return {
+    evidenceRefSource: "channel_event",
+    rollbackClass,
+    nonReversibleReason:
+      `Channel outbound message delivered to ${channelId}; external delivery not reversible.`,
+    evidenceRefId,
+  };
+}

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -275,6 +275,10 @@ import type {
   FridaySupportedChannelKind,
 } from "#channels";
 import { createFridayChannelInboundDebouncer, createFridayChannelTypingController, sanitizeChannelInput } from "#channels";
+import {
+  buildFridayChannelDispatchReplyText,
+  routeFridayChannelDispatch,
+} from "#channels";
 import { createFridayChannelSlowTaskNotifier } from "../channels/friday-channel-slow-task-notifier.js";
 import { resolveFridayPublicRunUrl } from "../agent/runtime/friday-public-run-url.js";
 import {
@@ -8394,6 +8398,101 @@ export async function createFridayHub(
               });
               return;
             }
+          }
+
+          // Phase 14.5E module_28e Slice 6.3 — live inbound channel
+          // binding to the canonical command dispatcher. The dispatcher
+          // never approves or executes a high-risk action; it only
+          // returns a preview (low/medium) or the owner-link path
+          // (high). The channel may surface the owner-link, but the
+          // bound-principal contract refuses `source: "channel"` for
+          // the matching `channel.action.high_risk.{approve,execute}`
+          // operations, so the channel cannot drive execution by itself.
+          const canonicalDispatch = text.length > 0
+            ? routeFridayChannelDispatch({
+                channelKind: msg.channelKind,
+                chatId: msg.chatId,
+                chatType: msg.chatType,
+                senderId: msg.senderId,
+                text,
+              })
+            : { kind: "no_match" as const };
+          if (canonicalDispatch.kind !== "no_match") {
+            const dispatchReplyText = buildFridayChannelDispatchReplyText(canonicalDispatch);
+            const dispatchRiskLevel = canonicalDispatch.kind === "risk_preview"
+              ? canonicalDispatch.preview.command.riskLevel
+              : canonicalDispatch.request.riskLevel;
+            const dispatchActionId = canonicalDispatch.kind === "risk_preview"
+              ? canonicalDispatch.preview.actionId
+              : canonicalDispatch.request.actionId;
+            void (async () => {
+              await hubSessionService.addMessage(sessionKey, {
+                role: "user",
+                content: text,
+                contentText: text,
+                idempotencyKey: inboundIdempotencyKey,
+                metadata: {
+                  sourceMessageId: msg.id,
+                  channelKind: msg.channelKind,
+                  canonicalCommand: true,
+                  canonicalRiskLevel: dispatchRiskLevel,
+                  canonicalActionId: dispatchActionId,
+                },
+              }).catch((err) => {
+                logChannelIssue({
+                  level: "warn",
+                  code: "W-CH-SESSION-MIRROR-001",
+                  routeId: "hub.channel.session.mirror.canonical_dispatch_inbound",
+                  error: err,
+                });
+              });
+              if (dispatchReplyText === null) {
+                return;
+              }
+              try {
+                const delivery = await channelRegistry.send(msg.channelKind, {
+                  chatId: msg.chatId,
+                  text: dispatchReplyText,
+                  replyTo: msg.id,
+                });
+                await hubSessionService.addMessage(sessionKey, {
+                  role: "assistant",
+                  content: dispatchReplyText,
+                  contentText: dispatchReplyText,
+                  idempotencyKey: `channel:${msg.channelKind}:${msg.chatId}:${msg.id}:canonical-dispatch-ack`,
+                  metadata: {
+                    sourceMessageId: delivery.messageId,
+                    replyToMessageId: msg.id,
+                    channelKind: msg.channelKind,
+                    canonicalDispatchAck: true,
+                    canonicalRiskLevel: dispatchRiskLevel,
+                    canonicalActionId: dispatchActionId,
+                  },
+                }).catch((err) => {
+                  logChannelIssue({
+                    level: "warn",
+                    code: "W-CH-SESSION-MIRROR-001",
+                    routeId: "hub.channel.session.mirror.canonical_dispatch_ack",
+                    error: err,
+                  });
+                });
+              } catch (err) {
+                logChannelIssue({
+                  level: "error",
+                  code: "E-CH-OUTBOUND-001",
+                  routeId: "hub.channel.delivery.canonical_dispatch",
+                  error: err,
+                });
+              }
+            })().catch((err) => {
+              logChannelIssue({
+                level: "error",
+                code: "E-CH-CANONICAL-DISPATCH-001",
+                routeId: "hub.channel.canonical_dispatch",
+                error: err,
+              });
+            });
+            return;
           }
 
           // Route inbound channel messages to agent runtime

--- a/src/security/friday-channel-action-approval.ts
+++ b/src/security/friday-channel-action-approval.ts
@@ -1,0 +1,275 @@
+// Phase 14.5E module_28e Slice 6.4 — owner-signed approval token for
+// high-risk channel-triggered actions.
+//
+// The owner-link API (`POST /v1/channels/actions/{actionId}/owner-approve`)
+// takes a token that is an HMAC-SHA-256 over a deterministic JSON payload
+// containing the channel-action context. The signing key is the existing
+// internal runtime secret (typically `FRIDAY_TOKEN_SECRET`); 14.5E does
+// not introduce a new user-provided secret. The token is opaque to the
+// channel side and is built by the local Assistant / API surface that
+// has access to the runtime secret.
+//
+// The token payload is:
+//
+//   {
+//     "actionId": "<canonical action id>",
+//     "channelId": "<channelKind>:<chatId>",
+//     "principalId": "<bound principal id>",
+//     "riskLevel": "high",
+//     "expiresAt": "<iso8601 utc timestamp>"
+//   }
+//
+// The wire format is `${base64url(payloadJson)}.${hexHmac}`. The verifier
+// reconstructs the payload, recomputes the HMAC, and accepts only when:
+//   - the wire format is well-formed;
+//   - every expected field matches the API request context;
+//   - the timestamp has not yet expired;
+//   - the HMAC is constant-time equal to the recomputed value.
+//
+// No part of the token is encrypted; it is a signed bearer-style approval
+// that the owner-link UX hands the user. The token is single-use at the
+// API layer: the route is expected to enforce idempotency by recording
+// approvals in the same store the gate consults before execute.
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+import { FridayDomainError } from "#errors";
+
+const TOKEN_VERSION = "v1";
+const HASH_ALGORITHM = "sha256";
+
+export interface FridayChannelActionApprovalPayload {
+  readonly actionId: string;
+  readonly channelId: string;
+  readonly principalId: string;
+  readonly riskLevel: "high";
+  readonly expiresAt: string;
+}
+
+export interface FridayChannelActionApprovalVerifyInput {
+  readonly token: string;
+  readonly actionId: string;
+  readonly channelId: string;
+  readonly principalId: string;
+  readonly nowIso: string;
+  readonly signingKey: string;
+}
+
+export interface FridayChannelActionApprovalSignInput
+  extends FridayChannelActionApprovalPayload {
+  readonly signingKey: string;
+}
+
+export const FRIDAY_CHANNEL_ACTION_APPROVAL_ERROR_CODES = {
+  TOKEN_MALFORMED: "CHANNEL_OWNER_APPROVAL_TOKEN_MALFORMED",
+  TOKEN_PAYLOAD_INVALID: "CHANNEL_OWNER_APPROVAL_TOKEN_PAYLOAD_INVALID",
+  TOKEN_SIGNATURE_INVALID: "CHANNEL_OWNER_APPROVAL_TOKEN_SIGNATURE_INVALID",
+  TOKEN_EXPIRED: "CHANNEL_OWNER_APPROVAL_TOKEN_EXPIRED",
+  TOKEN_CONTEXT_MISMATCH: "CHANNEL_OWNER_APPROVAL_TOKEN_CONTEXT_MISMATCH",
+  SIGNING_KEY_MISSING: "CHANNEL_OWNER_APPROVAL_SIGNING_KEY_MISSING",
+} as const;
+
+export function signFridayChannelActionApprovalToken(
+  input: FridayChannelActionApprovalSignInput,
+): string {
+  if (typeof input.signingKey !== "string" || input.signingKey.length === 0) {
+    throw new FridayDomainError(
+      FRIDAY_CHANNEL_ACTION_APPROVAL_ERROR_CODES.SIGNING_KEY_MISSING,
+      "Owner-signed approval requires a non-empty internal runtime signing key.",
+      { httpStatus: 500 },
+    );
+  }
+  assertPayload(input);
+  const payloadJson = stableStringify({
+    v: TOKEN_VERSION,
+    actionId: input.actionId,
+    channelId: input.channelId,
+    principalId: input.principalId,
+    riskLevel: input.riskLevel,
+    expiresAt: input.expiresAt,
+  });
+  const encodedPayload = Buffer.from(payloadJson, "utf8").toString("base64url");
+  const signature = createHmac(HASH_ALGORITHM, input.signingKey)
+    .update(payloadJson, "utf8")
+    .digest("hex");
+  return `${encodedPayload}.${signature}`;
+}
+
+export function verifyFridayChannelActionApprovalToken(
+  input: FridayChannelActionApprovalVerifyInput,
+): FridayChannelActionApprovalPayload {
+  if (typeof input.signingKey !== "string" || input.signingKey.length === 0) {
+    throw new FridayDomainError(
+      FRIDAY_CHANNEL_ACTION_APPROVAL_ERROR_CODES.SIGNING_KEY_MISSING,
+      "Owner-signed approval requires a non-empty internal runtime signing key.",
+      { httpStatus: 500 },
+    );
+  }
+  if (typeof input.token !== "string" || !input.token.includes(".")) {
+    throw new FridayDomainError(
+      FRIDAY_CHANNEL_ACTION_APPROVAL_ERROR_CODES.TOKEN_MALFORMED,
+      "Owner approval token must be `<base64url(payload)>.<hexHmac>`.",
+      { httpStatus: 400 },
+    );
+  }
+  const separatorIndex = input.token.indexOf(".");
+  const encodedPayload = input.token.slice(0, separatorIndex);
+  const signatureHex = input.token.slice(separatorIndex + 1);
+  if (encodedPayload.length === 0 || signatureHex.length === 0) {
+    throw new FridayDomainError(
+      FRIDAY_CHANNEL_ACTION_APPROVAL_ERROR_CODES.TOKEN_MALFORMED,
+      "Owner approval token is missing the payload or signature segment.",
+      { httpStatus: 400 },
+    );
+  }
+
+  let payloadJson: string;
+  try {
+    payloadJson = Buffer.from(encodedPayload, "base64url").toString("utf8");
+  } catch {
+    throw new FridayDomainError(
+      FRIDAY_CHANNEL_ACTION_APPROVAL_ERROR_CODES.TOKEN_MALFORMED,
+      "Owner approval token payload is not valid base64url.",
+      { httpStatus: 400 },
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(payloadJson);
+  } catch {
+    throw new FridayDomainError(
+      FRIDAY_CHANNEL_ACTION_APPROVAL_ERROR_CODES.TOKEN_PAYLOAD_INVALID,
+      "Owner approval token payload is not valid JSON.",
+      { httpStatus: 400 },
+    );
+  }
+
+  if (!isPlainObject(parsed)) {
+    throw new FridayDomainError(
+      FRIDAY_CHANNEL_ACTION_APPROVAL_ERROR_CODES.TOKEN_PAYLOAD_INVALID,
+      "Owner approval token payload must be a JSON object.",
+      { httpStatus: 400 },
+    );
+  }
+
+  if ((parsed as { v?: unknown }).v !== TOKEN_VERSION) {
+    throw new FridayDomainError(
+      FRIDAY_CHANNEL_ACTION_APPROVAL_ERROR_CODES.TOKEN_PAYLOAD_INVALID,
+      "Owner approval token version is not supported.",
+      { httpStatus: 400 },
+    );
+  }
+
+  const payload: FridayChannelActionApprovalPayload = {
+    actionId: requireString(parsed, "actionId"),
+    channelId: requireString(parsed, "channelId"),
+    principalId: requireString(parsed, "principalId"),
+    riskLevel: requireRiskLevel(parsed),
+    expiresAt: requireString(parsed, "expiresAt"),
+  };
+
+  const expected = createHmac(HASH_ALGORITHM, input.signingKey)
+    .update(payloadJson, "utf8")
+    .digest("hex");
+  if (!constantTimeEqualHex(expected, signatureHex)) {
+    throw new FridayDomainError(
+      FRIDAY_CHANNEL_ACTION_APPROVAL_ERROR_CODES.TOKEN_SIGNATURE_INVALID,
+      "Owner approval token signature did not match the internal runtime key.",
+      { httpStatus: 401 },
+    );
+  }
+
+  if (payload.actionId !== input.actionId
+    || payload.channelId !== input.channelId
+    || payload.principalId !== input.principalId) {
+    throw new FridayDomainError(
+      FRIDAY_CHANNEL_ACTION_APPROVAL_ERROR_CODES.TOKEN_CONTEXT_MISMATCH,
+      "Owner approval token does not match the requested action/channel/principal.",
+      { httpStatus: 403 },
+    );
+  }
+
+  const expiresAt = Date.parse(payload.expiresAt);
+  const now = Date.parse(input.nowIso);
+  if (!Number.isFinite(expiresAt) || !Number.isFinite(now)) {
+    throw new FridayDomainError(
+      FRIDAY_CHANNEL_ACTION_APPROVAL_ERROR_CODES.TOKEN_PAYLOAD_INVALID,
+      "Owner approval token expiresAt or current time is not a valid ISO-8601 timestamp.",
+      { httpStatus: 400 },
+    );
+  }
+  if (now >= expiresAt) {
+    throw new FridayDomainError(
+      FRIDAY_CHANNEL_ACTION_APPROVAL_ERROR_CODES.TOKEN_EXPIRED,
+      "Owner approval token expired.",
+      { httpStatus: 401 },
+    );
+  }
+
+  return payload;
+}
+
+function assertPayload(input: FridayChannelActionApprovalPayload): void {
+  if (input.riskLevel !== "high") {
+    throw new FridayDomainError(
+      FRIDAY_CHANNEL_ACTION_APPROVAL_ERROR_CODES.TOKEN_PAYLOAD_INVALID,
+      "Owner approval token riskLevel must be \"high\".",
+      { httpStatus: 400 },
+    );
+  }
+  for (const key of ["actionId", "channelId", "principalId", "expiresAt"] as const) {
+    if (typeof input[key] !== "string" || input[key].length === 0) {
+      throw new FridayDomainError(
+        FRIDAY_CHANNEL_ACTION_APPROVAL_ERROR_CODES.TOKEN_PAYLOAD_INVALID,
+        `Owner approval token field "${key}" must be a non-empty string.`,
+        { httpStatus: 400 },
+      );
+    }
+  }
+}
+
+function requireString(source: unknown, key: string): string {
+  const value = (source as Record<string, unknown>)[key];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new FridayDomainError(
+      FRIDAY_CHANNEL_ACTION_APPROVAL_ERROR_CODES.TOKEN_PAYLOAD_INVALID,
+      `Owner approval token field "${key}" must be a non-empty string.`,
+      { httpStatus: 400 },
+    );
+  }
+  return value;
+}
+
+function requireRiskLevel(source: unknown): "high" {
+  const value = (source as Record<string, unknown>).riskLevel;
+  if (value !== "high") {
+    throw new FridayDomainError(
+      FRIDAY_CHANNEL_ACTION_APPROVAL_ERROR_CODES.TOKEN_PAYLOAD_INVALID,
+      "Owner approval token riskLevel must be \"high\".",
+      { httpStatus: 400 },
+    );
+  }
+  return value;
+}
+
+function constantTimeEqualHex(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  const bufA = Buffer.from(a, "hex");
+  const bufB = Buffer.from(b, "hex");
+  if (bufA.length === 0 || bufA.length !== bufB.length) return false;
+  return timingSafeEqual(bufA, bufB);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object"
+    && value !== null
+    && !Array.isArray(value)
+    && Object.getPrototypeOf(value) === Object.prototype;
+}
+
+function stableStringify(value: Record<string, unknown>): string {
+  const keys = Object.keys(value).sort();
+  const pairs = keys.map((key) => `${JSON.stringify(key)}:${JSON.stringify(value[key])}`);
+  return `{${pairs.join(",")}}`;
+}

--- a/src/security/friday-owner-session-channel-capability.ts
+++ b/src/security/friday-owner-session-channel-capability.ts
@@ -34,13 +34,31 @@ export type FridayPublicMutationOperation =
   | "autofix.actions.deny"
   | "autofix.actions.execute"
   | "autofix.actions.rollback"
-  | "autofix.actions.preview";
+  | "autofix.actions.preview"
+  // Phase 14.5E module_28e Slice 6.4 — high-risk channel-triggered actions.
+  // `approve` requires a bound `api`/`session` principal AND a valid
+  // owner-signed token; `execute` requires the same plus a prior `approve`
+  // record. `source: "channel"` alone is refused outright. Refer to
+  // `assertBoundPrincipalForOperation` enforcement below.
+  | "channel.action.high_risk.approve"
+  | "channel.action.high_risk.execute";
 
 export type FridayBoundPrincipalSource = "api" | "session" | "channel" | "satellite";
 
 const ERROR_CODE_BOUND_PRINCIPAL_REQUIRED = "OWNER_SESSION_CHANNEL_PRINCIPAL_REQUIRED";
 const ERROR_CODE_WEBHOOK_HMAC_REQUIRED = "WORKFLOW_WEBHOOK_HMAC_REQUIRED";
 const ERROR_CODE_WEBHOOK_PATH_TOKEN_WEAK = "WORKFLOW_WEBHOOK_PATH_TOKEN_WEAK";
+const ERROR_CODE_CHANNEL_SOURCE_REFUSED = "CHANNEL_HIGH_RISK_SOURCE_REFUSED";
+
+// Phase 14.5E module_28e Slice 6.4 — operations that refuse `source:
+// "channel"` outright regardless of bound-principal state. A channel
+// message can carry the bound principal, but the high-risk channel-action
+// approve/execute path must require an `api` or `session` lane plus an
+// owner-signed token.
+const CHANNEL_SOURCE_REFUSED_OPERATIONS: ReadonlySet<FridayPublicMutationOperation> = new Set([
+  "channel.action.high_risk.approve",
+  "channel.action.high_risk.execute",
+]);
 
 const BEARER_ONLY_OPT_IN_ENV = "FRIDAY_WORKFLOW_WEBHOOK_BEARER_ONLY_PATH_TOKENS";
 const WEBHOOK_PATH_TOKEN_MIN_LENGTH = 32;
@@ -86,6 +104,18 @@ export function assertBoundPrincipalForOperation(
   operation: FridayPublicMutationOperation,
   source: FridayBoundPrincipalSource = "api",
 ): FridayBoundPrincipalDescriptor {
+  // Phase 14.5E module_28e Slice 6.4 — refuse `source: "channel"` for any
+  // operation listed in CHANNEL_SOURCE_REFUSED_OPERATIONS, even when the
+  // bound principal is valid. The owner-signed approval API runs on the
+  // `api`/`session` lane; a channel message alone must never satisfy the
+  // bound-principal contract for high-risk channel actions.
+  if (source === "channel" && CHANNEL_SOURCE_REFUSED_OPERATIONS.has(operation)) {
+    throw new FridayDomainError(
+      ERROR_CODE_CHANNEL_SOURCE_REFUSED,
+      `${operation} cannot be authorized from source: channel. Use a bound api/session principal with an owner-signed token.`,
+      { httpStatus: 403 },
+    );
+  }
   if (isUnauthenticatedPublicPrincipal(principal)) {
     throw new FridayDomainError(
       ERROR_CODE_BOUND_PRINCIPAL_REQUIRED,
@@ -218,4 +248,5 @@ export const FRIDAY_OWNER_SESSION_CHANNEL_ERROR_CODES = {
   BOUND_PRINCIPAL_REQUIRED: ERROR_CODE_BOUND_PRINCIPAL_REQUIRED,
   WEBHOOK_HMAC_REQUIRED: ERROR_CODE_WEBHOOK_HMAC_REQUIRED,
   WEBHOOK_PATH_TOKEN_WEAK: ERROR_CODE_WEBHOOK_PATH_TOKEN_WEAK,
+  CHANNEL_HIGH_RISK_SOURCE_REFUSED: ERROR_CODE_CHANNEL_SOURCE_REFUSED,
 } as const;

--- a/test/contracts/api/__snapshots__/friday-api-route-contract.snapshot.test.ts.snap
+++ b/test/contracts/api/__snapshots__/friday-api-route-contract.snapshot.test.ts.snap
@@ -3,14 +3,14 @@
 exports[`MECHANISM-4 — API Route Contract (Snapshot) > Phase 14.5A WP-001: every public mutating route maps to an accepted gate family 1`] = `
 {
   "classified": {
-    "bound_principal": 22,
+    "bound_principal": 25,
     "channel_signature": 3,
     "hmac_or_bearer_opt_in": 1,
     "public_low_risk": 2,
     "rate_limited_pending": 4,
     "unclassified": 284,
   },
-  "total_public_mutating": 316,
+  "total_public_mutating": 319,
   "unclassified_sample_max_5": [
     "config.update",
     "config.revisions.revert",
@@ -21,7 +21,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > Phase 14.5A WP-001: eve
 }
 `;
 
-exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures route count to detect accidental additions/removals 1`] = `410`;
+exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures route count to detect accidental additions/removals 1`] = `414`;
 
 exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route surface as a stable contract 1`] = `
 [
@@ -1359,6 +1359,36 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
     "authKind": "public",
     "index": 133,
     "method": "POST",
+    "operationId": "channels.actions.owner.link",
+    "path": "/v1/channels/actions/:actionId/owner-link",
+    "rateLimitPolicyId": null,
+    "roles": [],
+    "scopes": [],
+  },
+  {
+    "authKind": "public",
+    "index": 134,
+    "method": "POST",
+    "operationId": "channels.actions.owner.approve",
+    "path": "/v1/channels/actions/:actionId/owner-approve",
+    "rateLimitPolicyId": null,
+    "roles": [],
+    "scopes": [],
+  },
+  {
+    "authKind": "public",
+    "index": 135,
+    "method": "POST",
+    "operationId": "channels.actions.execute",
+    "path": "/v1/channels/actions/:actionId/execute",
+    "rateLimitPolicyId": null,
+    "roles": [],
+    "scopes": [],
+  },
+  {
+    "authKind": "public",
+    "index": 136,
+    "method": "POST",
     "operationId": "discovery.scan",
     "path": "/v1/discovery/scan",
     "rateLimitPolicyId": null,
@@ -1367,7 +1397,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 134,
+    "index": 137,
     "method": "GET",
     "operationId": "discovery.catalog.get",
     "path": "/v1/discovery/catalog",
@@ -1377,7 +1407,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 135,
+    "index": 138,
     "method": "GET",
     "operationId": "discovery.programs.list",
     "path": "/v1/discovery/programs",
@@ -1387,7 +1417,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 136,
+    "index": 139,
     "method": "GET",
     "operationId": "discovery.recommend",
     "path": "/v1/discovery/recommendations",
@@ -1397,7 +1427,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 137,
+    "index": 140,
     "method": "GET",
     "operationId": "discovery.policy.get",
     "path": "/v1/discovery/policy",
@@ -1407,7 +1437,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 138,
+    "index": 141,
     "method": "PATCH",
     "operationId": "discovery.policy.update",
     "path": "/v1/discovery/policy",
@@ -1417,7 +1447,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 139,
+    "index": 142,
     "method": "GET",
     "operationId": "discovery.status",
     "path": "/v1/discovery/status",
@@ -1427,7 +1457,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 140,
+    "index": 143,
     "method": "POST",
     "operationId": "discovery.integrate",
     "path": "/v1/discovery/integrate",
@@ -1437,7 +1467,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 141,
+    "index": 144,
     "method": "POST",
     "operationId": "mcp.server.rpc",
     "path": "/v1/mcp",
@@ -1447,7 +1477,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 142,
+    "index": 145,
     "method": "POST",
     "operationId": "channels.webhooks.line",
     "path": "/v1/channel-webhooks/line",
@@ -1457,7 +1487,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 143,
+    "index": 146,
     "method": "GET",
     "operationId": "channels.webhooks.whatsapp.verify",
     "path": "/v1/channel-webhooks/whatsapp",
@@ -1467,7 +1497,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 144,
+    "index": 147,
     "method": "POST",
     "operationId": "channels.webhooks.whatsapp",
     "path": "/v1/channel-webhooks/whatsapp",
@@ -1477,7 +1507,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 145,
+    "index": 148,
     "method": "POST",
     "operationId": "channels.webhooks.lark",
     "path": "/v1/channel-webhooks/lark",
@@ -1487,7 +1517,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 146,
+    "index": 149,
     "method": "POST",
     "operationId": "packaging.packages.publish",
     "path": "/v1/packages",
@@ -1497,7 +1527,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 147,
+    "index": 150,
     "method": "GET",
     "operationId": "packaging.packages.list",
     "path": "/v1/packages",
@@ -1507,7 +1537,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 148,
+    "index": 151,
     "method": "GET",
     "operationId": "packaging.packages.get",
     "path": "/v1/packages/:packageId",
@@ -1517,7 +1547,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 149,
+    "index": 152,
     "method": "GET",
     "operationId": "packaging.packages.versions.list",
     "path": "/v1/packages/:packageName/versions",
@@ -1527,7 +1557,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 150,
+    "index": 153,
     "method": "POST",
     "operationId": "packaging.packages.verify",
     "path": "/v1/packages/:packageId/verify",
@@ -1537,7 +1567,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 151,
+    "index": 154,
     "method": "POST",
     "operationId": "packaging.packages.dependencies.check",
     "path": "/v1/packages/:packageName/check-dependencies",
@@ -1547,7 +1577,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 152,
+    "index": 155,
     "method": "POST",
     "operationId": "packaging.installs.install",
     "path": "/v1/packages/:packageName/install",
@@ -1557,7 +1587,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 153,
+    "index": 156,
     "method": "POST",
     "operationId": "packaging.installs.upgrade",
     "path": "/v1/packages/:packageName/upgrade",
@@ -1567,7 +1597,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 154,
+    "index": 157,
     "method": "POST",
     "operationId": "packaging.installs.rollback",
     "path": "/v1/packages/:packageName/rollback",
@@ -1577,7 +1607,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 155,
+    "index": 158,
     "method": "POST",
     "operationId": "packaging.installs.uninstall",
     "path": "/v1/packages/:packageName/uninstall",
@@ -1587,7 +1617,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 156,
+    "index": 159,
     "method": "GET",
     "operationId": "packaging.installs.list",
     "path": "/v1/packages/installs",
@@ -1597,7 +1627,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 157,
+    "index": 160,
     "method": "GET",
     "operationId": "packaging.installs.get",
     "path": "/v1/packages/installs/:installId",
@@ -1607,7 +1637,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 158,
+    "index": 161,
     "method": "GET",
     "operationId": "packaging.lifecycle.list",
     "path": "/v1/packages/lifecycle",
@@ -1617,7 +1647,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 159,
+    "index": 162,
     "method": "GET",
     "operationId": "packaging.keys.list",
     "path": "/v1/packages/keys",
@@ -1627,7 +1657,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 160,
+    "index": 163,
     "method": "POST",
     "operationId": "packaging.keys.add",
     "path": "/v1/packages/keys",
@@ -1637,7 +1667,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 161,
+    "index": 164,
     "method": "POST",
     "operationId": "packaging.keys.revoke",
     "path": "/v1/packages/keys/:keyId/revoke",
@@ -1647,7 +1677,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 162,
+    "index": 165,
     "method": "POST",
     "operationId": "packaging.keys.rotate",
     "path": "/v1/packages/keys/:keyId/rotate",
@@ -1657,7 +1687,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 163,
+    "index": 166,
     "method": "GET",
     "operationId": "studio.products.list",
     "path": "/v1/studio/products",
@@ -1667,7 +1697,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 164,
+    "index": 167,
     "method": "POST",
     "operationId": "studio.runs.create",
     "path": "/v1/studio/runs",
@@ -1677,7 +1707,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 165,
+    "index": 168,
     "method": "GET",
     "operationId": "studio.runs.get",
     "path": "/v1/studio/runs/:runId",
@@ -1687,7 +1717,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 166,
+    "index": 169,
     "method": "GET",
     "operationId": "studio.artifacts.get",
     "path": "/v1/studio/runs/:runId/artifacts/:artifactId",
@@ -1697,7 +1727,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 167,
+    "index": 170,
     "method": "GET",
     "operationId": "studio.runs.export",
     "path": "/v1/studio/runs/:runId/export",
@@ -1707,7 +1737,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 168,
+    "index": 171,
     "method": "POST",
     "operationId": "studio.imports.create",
     "path": "/v1/studio/imports",
@@ -1717,7 +1747,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 169,
+    "index": 172,
     "method": "POST",
     "operationId": "studio.artifacts.validate.candidate",
     "path": "/v1/studio/runs/:runId/validate-candidate",
@@ -1727,7 +1757,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 170,
+    "index": 173,
     "method": "POST",
     "operationId": "realtime.subscribe",
     "path": "/v1/realtime/subscriptions",
@@ -1737,7 +1767,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 171,
+    "index": 174,
     "method": "POST",
     "operationId": "realtime.pull",
     "path": "/v1/realtime/pull",
@@ -1747,7 +1777,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 172,
+    "index": 175,
     "method": "POST",
     "operationId": "realtime.ack",
     "path": "/v1/realtime/ack",
@@ -1757,7 +1787,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 173,
+    "index": 176,
     "method": "GET",
     "operationId": "providers.usage.get",
     "path": "/v1/providers/usage",
@@ -1767,7 +1797,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 174,
+    "index": 177,
     "method": "GET",
     "operationId": "providers.budget.get",
     "path": "/v1/providers/budget",
@@ -1777,7 +1807,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 175,
+    "index": 178,
     "method": "PUT",
     "operationId": "providers.budget.set",
     "path": "/v1/providers/budget",
@@ -1787,7 +1817,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 176,
+    "index": 179,
     "method": "GET",
     "operationId": "providers.templates.list",
     "path": "/v1/providers/templates",
@@ -1797,7 +1827,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 177,
+    "index": 180,
     "method": "GET",
     "operationId": "providers.templates.get",
     "path": "/v1/providers/templates/:templateId",
@@ -1807,7 +1837,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 178,
+    "index": 181,
     "method": "GET",
     "operationId": "providers.list",
     "path": "/v1/providers",
@@ -1817,7 +1847,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 179,
+    "index": 182,
     "method": "GET",
     "operationId": "providers.health.list",
     "path": "/v1/providers/health",
@@ -1827,7 +1857,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 180,
+    "index": 183,
     "method": "POST",
     "operationId": "capabilities.doctor",
     "path": "/v1/capabilities/doctor",
@@ -1837,7 +1867,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 181,
+    "index": 184,
     "method": "GET",
     "operationId": "providers.get",
     "path": "/v1/providers/:providerId",
@@ -1847,7 +1877,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 182,
+    "index": 185,
     "method": "POST",
     "operationId": "providers.create",
     "path": "/v1/providers",
@@ -1857,7 +1887,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 183,
+    "index": 186,
     "method": "PATCH",
     "operationId": "providers.update",
     "path": "/v1/providers/:providerId",
@@ -1867,7 +1897,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 184,
+    "index": 187,
     "method": "DELETE",
     "operationId": "providers.delete",
     "path": "/v1/providers/:providerId",
@@ -1877,7 +1907,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 185,
+    "index": 188,
     "method": "POST",
     "operationId": "providers.validate",
     "path": "/v1/providers/:providerId/validate",
@@ -1887,7 +1917,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 186,
+    "index": 189,
     "method": "GET",
     "operationId": "providers.doctor",
     "path": "/v1/providers/:providerId/doctor",
@@ -1897,7 +1927,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 187,
+    "index": 190,
     "method": "GET",
     "operationId": "providers.routing.explain",
     "path": "/v1/providers/routing/explain",
@@ -1907,7 +1937,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 188,
+    "index": 191,
     "method": "POST",
     "operationId": "providers.routing.pin",
     "path": "/v1/providers/routing/pin",
@@ -1917,7 +1947,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 189,
+    "index": 192,
     "method": "POST",
     "operationId": "providers.routing.penalty.clear",
     "path": "/v1/providers/routing/penalties/clear",
@@ -1927,7 +1957,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 190,
+    "index": 193,
     "method": "GET",
     "operationId": "providers.auth.profiles.list",
     "path": "/v1/providers/:providerId/auth-profiles",
@@ -1937,7 +1967,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 191,
+    "index": 194,
     "method": "POST",
     "operationId": "providers.auth.profiles.activate",
     "path": "/v1/providers/:providerId/auth-profiles/:profileKey/activate",
@@ -1947,7 +1977,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 192,
+    "index": 195,
     "method": "GET",
     "operationId": "providers.routing.get",
     "path": "/v1/model-routing",
@@ -1957,7 +1987,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 193,
+    "index": 196,
     "method": "PUT",
     "operationId": "providers.routing.set",
     "path": "/v1/model-routing",
@@ -1967,7 +1997,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 194,
+    "index": 197,
     "method": "POST",
     "operationId": "auth.oauth.anthropic.initiate",
     "path": "/v1/auth/oauth/anthropic/initiate",
@@ -1977,7 +2007,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 195,
+    "index": 198,
     "method": "POST",
     "operationId": "auth.oauth.anthropic.callback",
     "path": "/v1/auth/oauth/anthropic/callback",
@@ -1987,7 +2017,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 196,
+    "index": 199,
     "method": "POST",
     "operationId": "auth.oauth.openai.codex.device.initiate",
     "path": "/v1/auth/oauth/openai-codex/device/initiate",
@@ -1997,7 +2027,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 197,
+    "index": 200,
     "method": "POST",
     "operationId": "auth.oauth.openai.codex.device.complete",
     "path": "/v1/auth/oauth/openai-codex/device/complete",
@@ -2007,7 +2037,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 198,
+    "index": 201,
     "method": "POST",
     "operationId": "media.understanding.doctor",
     "path": "/v1/media-understanding/doctor",
@@ -2017,7 +2047,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 199,
+    "index": 202,
     "method": "POST",
     "operationId": "media.understanding.analyze",
     "path": "/v1/media-understanding/analyze",
@@ -2027,7 +2057,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 200,
+    "index": 203,
     "method": "GET",
     "operationId": "task.workflows.boundaries.list",
     "path": "/v1/task-workflows/boundaries",
@@ -2037,7 +2067,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 201,
+    "index": 204,
     "method": "GET",
     "operationId": "task.workflows.gates.list",
     "path": "/v1/task-workflows/gates",
@@ -2047,7 +2077,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 202,
+    "index": 205,
     "method": "POST",
     "operationId": "task.workflows.preview",
     "path": "/v1/task-workflows/preview",
@@ -2057,7 +2087,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 203,
+    "index": 206,
     "method": "POST",
     "operationId": "task.workflows.create",
     "path": "/v1/task-workflows",
@@ -2067,7 +2097,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 204,
+    "index": 207,
     "method": "GET",
     "operationId": "task.workflows.list",
     "path": "/v1/task-workflows",
@@ -2077,7 +2107,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 205,
+    "index": 208,
     "method": "GET",
     "operationId": "task.workflows.get",
     "path": "/v1/task-workflows/:workflowId",
@@ -2087,7 +2117,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 206,
+    "index": 209,
     "method": "POST",
     "operationId": "task.workflows.revise",
     "path": "/v1/task-workflows/:workflowId/revisions",
@@ -2097,7 +2127,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 207,
+    "index": 210,
     "method": "GET",
     "operationId": "task.workflows.revisions.list",
     "path": "/v1/task-workflows/:workflowId/revisions",
@@ -2107,7 +2137,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 208,
+    "index": 211,
     "method": "POST",
     "operationId": "task.workflows.claims.create",
     "path": "/v1/task-workflows/:workflowId/claims",
@@ -2117,7 +2147,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 209,
+    "index": 212,
     "method": "GET",
     "operationId": "task.workflows.claims.list",
     "path": "/v1/task-workflows/:workflowId/claims",
@@ -2127,7 +2157,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 210,
+    "index": 213,
     "method": "GET",
     "operationId": "task.workflows.claims.get",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId",
@@ -2137,7 +2167,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 211,
+    "index": 214,
     "method": "POST",
     "operationId": "task.workflows.claims.evidence.attach",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId/evidence-ref",
@@ -2147,7 +2177,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 212,
+    "index": 215,
     "method": "GET",
     "operationId": "task.workflows.claims.evidence.list",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId/evidence-refs",
@@ -2157,7 +2187,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 213,
+    "index": 216,
     "method": "POST",
     "operationId": "task.workflows.claims.verify",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId/verify",
@@ -2167,7 +2197,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 214,
+    "index": 217,
     "method": "POST",
     "operationId": "task.workflows.claims.block",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId/block",
@@ -2177,7 +2207,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 215,
+    "index": 218,
     "method": "POST",
     "operationId": "task.workflows.closeout",
     "path": "/v1/task-workflows/:workflowId/closeout",
@@ -2187,7 +2217,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 216,
+    "index": 219,
     "method": "POST",
     "operationId": "task.workflows.lanes.executor.open",
     "path": "/v1/task-workflows/:workflowId/lanes/executor",
@@ -2197,7 +2227,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 217,
+    "index": 220,
     "method": "POST",
     "operationId": "task.workflows.lanes.verifier.open",
     "path": "/v1/task-workflows/:workflowId/lanes/verifier",
@@ -2207,7 +2237,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 218,
+    "index": 221,
     "method": "POST",
     "operationId": "task.workflows.lanes.complete",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId/complete",
@@ -2217,7 +2247,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 219,
+    "index": 222,
     "method": "POST",
     "operationId": "task.workflows.lanes.verdict",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId/verdict",
@@ -2227,7 +2257,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 220,
+    "index": 223,
     "method": "GET",
     "operationId": "task.workflows.lanes.list",
     "path": "/v1/task-workflows/:workflowId/lanes",
@@ -2237,7 +2267,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 221,
+    "index": 224,
     "method": "GET",
     "operationId": "task.workflows.lanes.get",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId",
@@ -2247,7 +2277,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 222,
+    "index": 225,
     "method": "POST",
     "operationId": "task.workflows.lanes.cli.handoff.record",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId/cli-handoffs",
@@ -2257,7 +2287,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 223,
+    "index": 226,
     "method": "GET",
     "operationId": "task.workflows.lanes.cli.handoffs.list",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId/cli-handoffs",
@@ -2267,7 +2297,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 224,
+    "index": 227,
     "method": "GET",
     "operationId": "task.workflows.cli.handoffs.list",
     "path": "/v1/task-workflows/:workflowId/cli-handoffs",
@@ -2277,7 +2307,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 225,
+    "index": 228,
     "method": "GET",
     "operationId": "task.workflows.supervisor.read",
     "path": "/v1/task-workflows/:workflowId/supervisor",
@@ -2287,7 +2317,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 226,
+    "index": 229,
     "method": "POST",
     "operationId": "task.workflows.channel.command.issue",
     "path": "/v1/task-workflows/:workflowId/channel-commands",
@@ -2297,7 +2327,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 227,
+    "index": 230,
     "method": "GET",
     "operationId": "task.workflows.channel.command.list",
     "path": "/v1/task-workflows/:workflowId/channel-commands",
@@ -2307,7 +2337,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 228,
+    "index": 231,
     "method": "POST",
     "operationId": "task.workflows.channel.command.confirm",
     "path": "/v1/task-workflows/:workflowId/channel-commands/confirm",
@@ -2317,7 +2347,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 229,
+    "index": 232,
     "method": "GET",
     "operationId": "task.workflows.evidence.explorer.query",
     "path": "/v1/task-workflows/evidence",
@@ -2327,7 +2357,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 230,
+    "index": 233,
     "method": "GET",
     "operationId": "task.workflows.evidence.explorer.raw",
     "path": "/v1/task-workflows/evidence/:evidenceRefId/raw",
@@ -2337,7 +2367,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 231,
+    "index": 234,
     "method": "POST",
     "operationId": "skills.social.import",
     "path": "/v1/skills/social-import",
@@ -2347,7 +2377,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 232,
+    "index": 235,
     "method": "GET",
     "operationId": "setup.status",
     "path": "/v1/setup/status",
@@ -2357,7 +2387,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 233,
+    "index": 236,
     "method": "POST",
     "operationId": "providers.detect",
     "path": "/v1/providers/detect",
@@ -2367,7 +2397,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 234,
+    "index": 237,
     "method": "GET",
     "operationId": "setup.network.get",
     "path": "/v1/setup/network",
@@ -2377,7 +2407,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 235,
+    "index": 238,
     "method": "POST",
     "operationId": "setup.network.save",
     "path": "/v1/setup/network",
@@ -2387,7 +2417,17 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 236,
+    "index": 239,
+    "method": "GET",
+    "operationId": "setup.channels.status",
+    "path": "/v1/setup/channels/status",
+    "rateLimitPolicyId": null,
+    "roles": [],
+    "scopes": [],
+  },
+  {
+    "authKind": "public",
+    "index": 240,
     "method": "POST",
     "operationId": "setup.channels.feishu.registration.begin",
     "path": "/v1/setup/channels/feishu/registration/begin",
@@ -2397,7 +2437,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 237,
+    "index": 241,
     "method": "POST",
     "operationId": "setup.channels.feishu.registration.poll",
     "path": "/v1/setup/channels/feishu/registration/poll",
@@ -2407,7 +2447,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 238,
+    "index": 242,
     "method": "POST",
     "operationId": "setup.channels.telegram.verification.begin",
     "path": "/v1/setup/channels/telegram/verification/begin",
@@ -2417,7 +2457,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 239,
+    "index": 243,
     "method": "POST",
     "operationId": "setup.channels.telegram.verification.poll",
     "path": "/v1/setup/channels/telegram/verification/poll",
@@ -2427,7 +2467,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 240,
+    "index": 244,
     "method": "POST",
     "operationId": "setup.channels.discord.verification.begin",
     "path": "/v1/setup/channels/discord/verification/begin",
@@ -2437,7 +2477,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 241,
+    "index": 245,
     "method": "POST",
     "operationId": "setup.channels.discord.verification.complete",
     "path": "/v1/setup/channels/discord/verification/complete",
@@ -2447,7 +2487,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 242,
+    "index": 246,
     "method": "POST",
     "operationId": "setup.channels.test",
     "path": "/v1/setup/channels/test",
@@ -2457,7 +2497,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 243,
+    "index": 247,
     "method": "POST",
     "operationId": "setup.channels.save",
     "path": "/v1/setup/channels",
@@ -2467,7 +2507,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 244,
+    "index": 248,
     "method": "POST",
     "operationId": "setup.complete",
     "path": "/v1/setup/complete",
@@ -2477,7 +2517,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 245,
+    "index": 249,
     "method": "GET",
     "operationId": "skills.list",
     "path": "/v1/skills",
@@ -2487,7 +2527,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 246,
+    "index": 250,
     "method": "GET",
     "operationId": "skills.catalog.list",
     "path": "/v1/skills/catalog",
@@ -2497,7 +2537,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 247,
+    "index": 251,
     "method": "GET",
     "operationId": "skills.get",
     "path": "/v1/skills/:skillId",
@@ -2507,7 +2547,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 248,
+    "index": 252,
     "method": "POST",
     "operationId": "skills.install",
     "path": "/v1/skills/install",
@@ -2517,7 +2557,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 249,
+    "index": 253,
     "method": "POST",
     "operationId": "skills.update",
     "path": "/v1/skills/:skillId/update",
@@ -2527,7 +2567,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 250,
+    "index": 254,
     "method": "DELETE",
     "operationId": "skills.delete",
     "path": "/v1/skills/:skillId",
@@ -2537,7 +2577,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 251,
+    "index": 255,
     "method": "POST",
     "operationId": "skills.manifest.validate",
     "path": "/v1/skills/validate-manifest",
@@ -2547,7 +2587,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 252,
+    "index": 256,
     "method": "POST",
     "operationId": "skills.verify",
     "path": "/v1/skills/:skillId/verify",
@@ -2557,7 +2597,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 253,
+    "index": 257,
     "method": "POST",
     "operationId": "skills.upgrade.analyze",
     "path": "/v1/skills/:skillId/upgrade/analyze",
@@ -2567,7 +2607,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 254,
+    "index": 258,
     "method": "POST",
     "operationId": "skills.upgrade.decide",
     "path": "/v1/skills/:skillId/upgrade/decide",
@@ -2577,7 +2617,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 255,
+    "index": 259,
     "method": "POST",
     "operationId": "skills.run",
     "path": "/v1/skills/:skillId/run",
@@ -2587,7 +2627,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 256,
+    "index": 260,
     "method": "POST",
     "operationId": "skills.generator.sessions.create",
     "path": "/v1/skills/generator/sessions",
@@ -2597,7 +2637,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 257,
+    "index": 261,
     "method": "GET",
     "operationId": "skills.generator.sessions.get",
     "path": "/v1/skills/generator/sessions/:sessionId",
@@ -2607,7 +2647,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 258,
+    "index": 262,
     "method": "POST",
     "operationId": "skills.generator.sessions.messages.create",
     "path": "/v1/skills/generator/sessions/:sessionId/messages",
@@ -2617,7 +2657,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 259,
+    "index": 263,
     "method": "POST",
     "operationId": "skills.generator.sessions.generate",
     "path": "/v1/skills/generator/sessions/:sessionId/generate",
@@ -2627,7 +2667,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 260,
+    "index": 264,
     "method": "POST",
     "operationId": "skills.generator.sessions.test",
     "path": "/v1/skills/generator/sessions/:sessionId/test",
@@ -2637,7 +2677,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 261,
+    "index": 265,
     "method": "GET",
     "operationId": "skills.generator.sessions.evidence.get",
     "path": "/v1/skills/generator/sessions/:sessionId/evidence",
@@ -2647,7 +2687,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 262,
+    "index": 266,
     "method": "POST",
     "operationId": "skills.generator.sessions.approve",
     "path": "/v1/skills/generator/sessions/:sessionId/approve",
@@ -2657,7 +2697,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 263,
+    "index": 267,
     "method": "DELETE",
     "operationId": "skills.generator.sessions.cancel",
     "path": "/v1/skills/generator/sessions/:sessionId",
@@ -2667,7 +2707,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 264,
+    "index": 268,
     "method": "GET",
     "operationId": "skills.ui.get",
     "path": "/v1/skills/:skillId/ui",
@@ -2677,7 +2717,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 265,
+    "index": 269,
     "method": "POST",
     "operationId": "uix.intents.resolve",
     "path": "/v1/uix/intents/resolve",
@@ -2687,7 +2727,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 266,
+    "index": 270,
     "method": "GET",
     "operationId": "uix.templates.list",
     "path": "/v1/uix/templates",
@@ -2697,7 +2737,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 267,
+    "index": 271,
     "method": "GET",
     "operationId": "uix.home.snapshot.get",
     "path": "/v1/uix/home-snapshot",
@@ -2707,7 +2747,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 268,
+    "index": 272,
     "method": "GET",
     "operationId": "uix.assistant.inbox.snapshot.get",
     "path": "/v1/uix/assistant-inbox-snapshot",
@@ -2717,7 +2757,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 269,
+    "index": 273,
     "method": "GET",
     "operationId": "uix.diagnostics.get",
     "path": "/v1/uix/diagnostics",
@@ -2727,7 +2767,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 270,
+    "index": 274,
     "method": "GET",
     "operationId": "uix.preferences.list",
     "path": "/v1/uix/preferences",
@@ -2737,7 +2777,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 271,
+    "index": 275,
     "method": "PUT",
     "operationId": "uix.preferences.update",
     "path": "/v1/uix/preferences",
@@ -2747,7 +2787,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 272,
+    "index": 276,
     "method": "DELETE",
     "operationId": "uix.preferences.delete",
     "path": "/v1/uix/preferences/:preferenceId",
@@ -2757,7 +2797,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 273,
+    "index": 277,
     "method": "GET",
     "operationId": "uix.persona.get",
     "path": "/v1/uix/persona",
@@ -2767,7 +2807,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 274,
+    "index": 278,
     "method": "PUT",
     "operationId": "uix.persona.update",
     "path": "/v1/uix/persona",
@@ -2777,7 +2817,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 275,
+    "index": 279,
     "method": "POST",
     "operationId": "uix.templates.execute",
     "path": "/v1/uix/templates/:templateId/execute",
@@ -2787,7 +2827,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 276,
+    "index": 280,
     "method": "POST",
     "operationId": "uix.wizards.start",
     "path": "/v1/uix/wizards/:wizardId/start",
@@ -2797,7 +2837,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 277,
+    "index": 281,
     "method": "POST",
     "operationId": "uix.wizards.continue",
     "path": "/v1/uix/wizards/:wizardId/continue",
@@ -2807,7 +2847,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 278,
+    "index": 282,
     "method": "GET",
     "operationId": "uix.issues.list",
     "path": "/v1/uix/issues",
@@ -2817,7 +2857,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 279,
+    "index": 283,
     "method": "GET",
     "operationId": "uix.user.profile.get",
     "path": "/v1/uix/user-profile",
@@ -2827,7 +2867,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 280,
+    "index": 284,
     "method": "PUT",
     "operationId": "uix.user.profile.update",
     "path": "/v1/uix/user-profile",
@@ -2837,7 +2877,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 281,
+    "index": 285,
     "method": "POST",
     "operationId": "uix.investigate",
     "path": "/v1/uix/investigate",
@@ -2847,7 +2887,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 282,
+    "index": 286,
     "method": "GET",
     "operationId": "uix.learnedfacts.list",
     "path": "/v1/uix/learned-facts",
@@ -2857,7 +2897,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 283,
+    "index": 287,
     "method": "DELETE",
     "operationId": "uix.learnedfacts.clear",
     "path": "/v1/uix/learned-facts",
@@ -2867,7 +2907,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 284,
+    "index": 288,
     "method": "PATCH",
     "operationId": "uix.learnedfacts.update",
     "path": "/v1/uix/learned-facts/:factKey",
@@ -2877,7 +2917,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 285,
+    "index": 289,
     "method": "DELETE",
     "operationId": "uix.learnedfacts.delete",
     "path": "/v1/uix/learned-facts/:factKey",
@@ -2887,7 +2927,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 286,
+    "index": 290,
     "method": "GET",
     "operationId": "packs.cross.border.profile.get",
     "path": "/v1/packs/cross-border/profile",
@@ -2897,7 +2937,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 287,
+    "index": 291,
     "method": "PUT",
     "operationId": "packs.cross.border.profile.put",
     "path": "/v1/packs/cross-border/profile",
@@ -2907,7 +2947,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 288,
+    "index": 292,
     "method": "GET",
     "operationId": "packs.cross.border.snapshot.get",
     "path": "/v1/packs/cross-border/snapshot",
@@ -2917,7 +2957,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 289,
+    "index": 293,
     "method": "POST",
     "operationId": "packs.cross.border.import.post",
     "path": "/v1/packs/cross-border/import",
@@ -2927,7 +2967,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 290,
+    "index": 294,
     "method": "POST",
     "operationId": "packs.cross.border.workflow.presets.apply",
     "path": "/v1/packs/cross-border/workflow-presets/apply",
@@ -2937,7 +2977,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 291,
+    "index": 295,
     "method": "PATCH",
     "operationId": "packs.cross.border.workflow.presets.toggle",
     "path": "/v1/packs/cross-border/workflow-presets/:workflowId",
@@ -2947,7 +2987,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 292,
+    "index": 296,
     "method": "POST",
     "operationId": "packs.cross.border.run.evidence.capture",
     "path": "/v1/packs/cross-border/run-evidence",
@@ -2957,7 +2997,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 293,
+    "index": 297,
     "method": "PATCH",
     "operationId": "packs.cross.border.import.stale",
     "path": "/v1/packs/cross-border/imports/:importBatchId/stale",
@@ -2967,7 +3007,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 294,
+    "index": 298,
     "method": "POST",
     "operationId": "packs.cross.border.workflows.disable.all",
     "path": "/v1/packs/cross-border/workflows/disable-all",
@@ -2977,7 +3017,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 295,
+    "index": 299,
     "method": "GET",
     "operationId": "skills.converters.list",
     "path": "/v1/skills/converters",
@@ -2987,7 +3027,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 296,
+    "index": 300,
     "method": "POST",
     "operationId": "skills.convert",
     "path": "/v1/skills/convert",
@@ -2997,7 +3037,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 297,
+    "index": 301,
     "method": "POST",
     "operationId": "skills.import",
     "path": "/v1/skills/import",
@@ -3007,7 +3047,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 298,
+    "index": 302,
     "method": "POST",
     "operationId": "skills.pack",
     "path": "/v1/skills/pack",
@@ -3017,7 +3057,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 299,
+    "index": 303,
     "method": "POST",
     "operationId": "workflows.generator.sessions.create",
     "path": "/v1/workflows/generator/sessions",
@@ -3027,7 +3067,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 300,
+    "index": 304,
     "method": "GET",
     "operationId": "workflows.generator.sessions.get",
     "path": "/v1/workflows/generator/sessions/:sessionId",
@@ -3037,7 +3077,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 301,
+    "index": 305,
     "method": "POST",
     "operationId": "workflows.generator.sessions.messages.create",
     "path": "/v1/workflows/generator/sessions/:sessionId/messages",
@@ -3047,7 +3087,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 302,
+    "index": 306,
     "method": "POST",
     "operationId": "workflows.generator.sessions.generate",
     "path": "/v1/workflows/generator/sessions/:sessionId/generate",
@@ -3057,7 +3097,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 303,
+    "index": 307,
     "method": "GET",
     "operationId": "workflows.generator.sessions.evidence.get",
     "path": "/v1/workflows/generator/sessions/:sessionId/evidence",
@@ -3067,7 +3107,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 304,
+    "index": 308,
     "method": "POST",
     "operationId": "workflows.generator.sessions.approve",
     "path": "/v1/workflows/generator/sessions/:sessionId/approve",
@@ -3077,7 +3117,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 305,
+    "index": 309,
     "method": "DELETE",
     "operationId": "workflows.generator.sessions.cancel",
     "path": "/v1/workflows/generator/sessions/:sessionId",
@@ -3087,7 +3127,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 306,
+    "index": 310,
     "method": "GET",
     "operationId": "rules.bundles.list",
     "path": "/v1/rules/bundles",
@@ -3097,7 +3137,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 307,
+    "index": 311,
     "method": "GET",
     "operationId": "rules.bundles.get",
     "path": "/v1/rules/bundles/:bundleId",
@@ -3107,7 +3147,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 308,
+    "index": 312,
     "method": "POST",
     "operationId": "rules.bundles.create",
     "path": "/v1/rules/bundles",
@@ -3117,7 +3157,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 309,
+    "index": 313,
     "method": "PATCH",
     "operationId": "rules.bundles.update",
     "path": "/v1/rules/bundles/:bundleId",
@@ -3127,7 +3167,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 310,
+    "index": 314,
     "method": "GET",
     "operationId": "rules.bundles.versions.list",
     "path": "/v1/rules/bundles/:bundleId/versions",
@@ -3137,7 +3177,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 311,
+    "index": 315,
     "method": "GET",
     "operationId": "rules.list",
     "path": "/v1/rules/bundles/:bundleId/rules",
@@ -3147,7 +3187,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 312,
+    "index": 316,
     "method": "POST",
     "operationId": "rules.evaluate",
     "path": "/v1/rules/evaluate",
@@ -3157,7 +3197,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 313,
+    "index": 317,
     "method": "POST",
     "operationId": "rules.simulate",
     "path": "/v1/rules/simulate",
@@ -3167,7 +3207,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 314,
+    "index": 318,
     "method": "GET",
     "operationId": "rules.versions.list",
     "path": "/v1/rules/:ruleId/versions",
@@ -3177,7 +3217,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 315,
+    "index": 319,
     "method": "GET",
     "operationId": "rules.audit.log.list",
     "path": "/v1/rules/audit-log",
@@ -3187,7 +3227,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 316,
+    "index": 320,
     "method": "POST",
     "operationId": "node.runner.execute",
     "path": "/v1/node-runner/execute",
@@ -3197,7 +3237,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 317,
+    "index": 321,
     "method": "GET",
     "operationId": "node.runner.executions.get",
     "path": "/v1/node-runner/executions/:executionId",
@@ -3207,7 +3247,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 318,
+    "index": 322,
     "method": "GET",
     "operationId": "node.runner.executions.list",
     "path": "/v1/node-runner/executions",
@@ -3217,7 +3257,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 319,
+    "index": 323,
     "method": "POST",
     "operationId": "acceptance.run",
     "path": "/v1/acceptance/run",
@@ -3227,7 +3267,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 320,
+    "index": 324,
     "method": "GET",
     "operationId": "acceptance.results.get",
     "path": "/v1/acceptance/results/:resultId",
@@ -3237,7 +3277,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 321,
+    "index": 325,
     "method": "GET",
     "operationId": "acceptance.results.list",
     "path": "/v1/acceptance/results",
@@ -3247,7 +3287,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 322,
+    "index": 326,
     "method": "GET",
     "operationId": "acceptance.runs.get",
     "path": "/v1/acceptance/runs/:runId",
@@ -3257,7 +3297,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 323,
+    "index": 327,
     "method": "GET",
     "operationId": "acceptance.tests.list",
     "path": "/v1/acceptance/tests",
@@ -3267,7 +3307,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 324,
+    "index": 328,
     "method": "GET",
     "operationId": "acceptance.tests.get",
     "path": "/v1/acceptance/tests/:testId",
@@ -3277,7 +3317,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 325,
+    "index": 329,
     "method": "POST",
     "operationId": "acceptance.tests.create",
     "path": "/v1/acceptance/tests",
@@ -3287,7 +3327,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 326,
+    "index": 330,
     "method": "PUT",
     "operationId": "acceptance.tests.update",
     "path": "/v1/acceptance/tests/:testId",
@@ -3297,7 +3337,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 327,
+    "index": 331,
     "method": "DELETE",
     "operationId": "acceptance.tests.delete",
     "path": "/v1/acceptance/tests/:testId",
@@ -3307,7 +3347,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 328,
+    "index": 332,
     "method": "GET",
     "operationId": "acceptance.tests.versions.list",
     "path": "/v1/acceptance/tests/:testId/versions",
@@ -3317,7 +3357,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 329,
+    "index": 333,
     "method": "GET",
     "operationId": "acceptance.artifacts.history",
     "path": "/v1/acceptance/artifacts/history",
@@ -3327,7 +3367,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 330,
+    "index": 334,
     "method": "GET",
     "operationId": "retry.policies.list",
     "path": "/v1/retry/policies",
@@ -3337,7 +3377,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 331,
+    "index": 335,
     "method": "GET",
     "operationId": "retry.policies.get",
     "path": "/v1/retry/policies/:policyId",
@@ -3347,7 +3387,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 332,
+    "index": 336,
     "method": "POST",
     "operationId": "retry.policies.create",
     "path": "/v1/retry/policies",
@@ -3357,7 +3397,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 333,
+    "index": 337,
     "method": "PUT",
     "operationId": "retry.policies.update",
     "path": "/v1/retry/policies/:policyId",
@@ -3367,7 +3407,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 334,
+    "index": 338,
     "method": "DELETE",
     "operationId": "retry.policies.delete",
     "path": "/v1/retry/policies/:policyId",
@@ -3377,7 +3417,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 335,
+    "index": 339,
     "method": "POST",
     "operationId": "retry.classify",
     "path": "/v1/retry/classify",
@@ -3387,7 +3427,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 336,
+    "index": 340,
     "method": "POST",
     "operationId": "retry.decide",
     "path": "/v1/retry/decide",
@@ -3397,7 +3437,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 337,
+    "index": 341,
     "method": "GET",
     "operationId": "retry.traces.list",
     "path": "/v1/retry/traces",
@@ -3407,7 +3447,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 338,
+    "index": 342,
     "method": "GET",
     "operationId": "retry.traces.get",
     "path": "/v1/retry/traces/:traceId",
@@ -3417,7 +3457,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 339,
+    "index": 343,
     "method": "GET",
     "operationId": "retry.costs.summary",
     "path": "/v1/retry/costs",
@@ -3427,7 +3467,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 340,
+    "index": 344,
     "method": "GET",
     "operationId": "retry.escalations.list",
     "path": "/v1/retry/escalations",
@@ -3437,7 +3477,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 341,
+    "index": 345,
     "method": "POST",
     "operationId": "retry.escalations.acknowledge",
     "path": "/v1/retry/escalations/:escalationId/acknowledge",
@@ -3447,7 +3487,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 342,
+    "index": 346,
     "method": "GET",
     "operationId": "retry.circuit.breakers.list",
     "path": "/v1/retry/circuit-breakers",
@@ -3457,7 +3497,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 343,
+    "index": 347,
     "method": "GET",
     "operationId": "playbook.list",
     "path": "/v1/playbooks",
@@ -3467,7 +3507,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 344,
+    "index": 348,
     "method": "GET",
     "operationId": "playbook.get",
     "path": "/v1/playbooks/:playbookId",
@@ -3477,7 +3517,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 345,
+    "index": 349,
     "method": "POST",
     "operationId": "playbook.select",
     "path": "/v1/playbooks/select",
@@ -3487,7 +3527,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 346,
+    "index": 350,
     "method": "GET",
     "operationId": "playbook.candidates.list",
     "path": "/v1/playbooks/candidates",
@@ -3497,7 +3537,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 347,
+    "index": 351,
     "method": "POST",
     "operationId": "playbook.candidates.promote",
     "path": "/v1/playbooks/candidates/:candidateId/promote",
@@ -3507,7 +3547,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 348,
+    "index": 352,
     "method": "POST",
     "operationId": "playbook.rollback",
     "path": "/v1/playbooks/:playbookId/rollback",
@@ -3517,7 +3557,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 349,
+    "index": 353,
     "method": "GET",
     "operationId": "playbook.scores",
     "path": "/v1/playbooks/:playbookId/scores",
@@ -3527,7 +3567,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 350,
+    "index": 354,
     "method": "POST",
     "operationId": "memory.store",
     "path": "/v1/memory/store",
@@ -3537,7 +3577,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 351,
+    "index": 355,
     "method": "POST",
     "operationId": "memory.items.create",
     "path": "/v1/memory/items",
@@ -3547,7 +3587,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 352,
+    "index": 356,
     "method": "POST",
     "operationId": "memory.search",
     "path": "/v1/memory/search",
@@ -3557,7 +3597,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 353,
+    "index": 357,
     "method": "GET",
     "operationId": "memory.get",
     "path": "/v1/memory/items/:id",
@@ -3567,7 +3607,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 354,
+    "index": 358,
     "method": "GET",
     "operationId": "memory.list",
     "path": "/v1/memory/items",
@@ -3577,7 +3617,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 355,
+    "index": 359,
     "method": "DELETE",
     "operationId": "memory.delete",
     "path": "/v1/memory/items/:id",
@@ -3587,7 +3627,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 356,
+    "index": 360,
     "method": "POST",
     "operationId": "memory.prune",
     "path": "/v1/memory/prune",
@@ -3597,7 +3637,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 357,
+    "index": 361,
     "method": "GET",
     "operationId": "sessions.usage.get",
     "path": "/v1/sessions/:sessionKey/usage",
@@ -3607,7 +3647,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 358,
+    "index": 362,
     "method": "GET",
     "operationId": "sessions.usage.list",
     "path": "/v1/sessions/usage",
@@ -3617,7 +3657,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 359,
+    "index": 363,
     "method": "GET",
     "operationId": "sessions.list",
     "path": "/v1/sessions",
@@ -3627,7 +3667,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 360,
+    "index": 364,
     "method": "POST",
     "operationId": "sessions.create",
     "path": "/v1/sessions",
@@ -3637,7 +3677,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 361,
+    "index": 365,
     "method": "GET",
     "operationId": "sessions.get",
     "path": "/v1/sessions/:sessionKey",
@@ -3647,7 +3687,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 362,
+    "index": 366,
     "method": "DELETE",
     "operationId": "sessions.delete",
     "path": "/v1/sessions/:sessionKey",
@@ -3657,7 +3697,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 363,
+    "index": 367,
     "method": "POST",
     "operationId": "sessions.archive",
     "path": "/v1/sessions/:sessionKey/archive",
@@ -3667,7 +3707,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 364,
+    "index": 368,
     "method": "POST",
     "operationId": "sessions.reset",
     "path": "/v1/sessions/:sessionKey/reset",
@@ -3677,7 +3717,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 365,
+    "index": 369,
     "method": "POST",
     "operationId": "sessions.prune",
     "path": "/v1/sessions/prune",
@@ -3687,7 +3727,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 366,
+    "index": 370,
     "method": "POST",
     "operationId": "sessions.sweep",
     "path": "/v1/sessions/sweep",
@@ -3697,7 +3737,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 367,
+    "index": 371,
     "method": "POST",
     "operationId": "sessions.compact",
     "path": "/v1/sessions/:sessionKey/compact",
@@ -3707,7 +3747,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 368,
+    "index": 372,
     "method": "GET",
     "operationId": "sessions.messages.list",
     "path": "/v1/sessions/:sessionKey/messages",
@@ -3717,7 +3757,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 369,
+    "index": 373,
     "method": "GET",
     "operationId": "sessions.export",
     "path": "/v1/sessions/:sessionKey/export",
@@ -3727,7 +3767,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 370,
+    "index": 374,
     "method": "POST",
     "operationId": "sessions.messages.create",
     "path": "/v1/sessions/:sessionKey/messages",
@@ -3737,7 +3777,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 371,
+    "index": 375,
     "method": "POST",
     "operationId": "sessions.outbound.send",
     "path": "/v1/sessions/:sessionKey/outbound",
@@ -3747,7 +3787,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 372,
+    "index": 376,
     "method": "POST",
     "operationId": "sessions.run",
     "path": "/v1/sessions/:sessionKey/run",
@@ -3757,7 +3797,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 373,
+    "index": 377,
     "method": "GET",
     "operationId": "sessions.memory.namespace.get",
     "path": "/v1/sessions/:sessionKey/memory-namespace",
@@ -3767,7 +3807,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 374,
+    "index": 378,
     "method": "POST",
     "operationId": "sessions.forks.create",
     "path": "/v1/sessions/:sessionKey/fork",
@@ -3777,7 +3817,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 375,
+    "index": 379,
     "method": "GET",
     "operationId": "sessions.forks.list",
     "path": "/v1/sessions/:sessionKey/forks",
@@ -3787,7 +3827,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 376,
+    "index": 380,
     "method": "POST",
     "operationId": "sessions.forks.merge",
     "path": "/v1/sessions/:sessionKey/merge",
@@ -3797,7 +3837,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 377,
+    "index": 381,
     "method": "POST",
     "operationId": "sessions.memory.extract",
     "path": "/v1/sessions/:sessionKey/memory/extract",
@@ -3807,7 +3847,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 378,
+    "index": 382,
     "method": "POST",
     "operationId": "sessions.memory.remember",
     "path": "/v1/sessions/:sessionKey/memory/remember",
@@ -3817,7 +3857,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 379,
+    "index": 383,
     "method": "GET",
     "operationId": "sessions.memory.extraction.get",
     "path": "/v1/sessions/:sessionKey/memory/extraction",
@@ -3827,7 +3867,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 380,
+    "index": 384,
     "method": "POST",
     "operationId": "sessions.memory.extraction.retry",
     "path": "/v1/sessions/memory/extraction/retry",
@@ -3837,7 +3877,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 381,
+    "index": 385,
     "method": "GET",
     "operationId": "plugins.list",
     "path": "/v1/plugins",
@@ -3847,7 +3887,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 382,
+    "index": 386,
     "method": "GET",
     "operationId": "plugins.get",
     "path": "/v1/plugins/:id",
@@ -3857,7 +3897,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 383,
+    "index": 387,
     "method": "GET",
     "operationId": "plugins.versions.list",
     "path": "/v1/plugins/:id/versions",
@@ -3867,7 +3907,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 384,
+    "index": 388,
     "method": "POST",
     "operationId": "plugins.install",
     "path": "/v1/plugins/:id/install",
@@ -3877,7 +3917,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 385,
+    "index": 389,
     "method": "POST",
     "operationId": "plugins.enable",
     "path": "/v1/plugins/:id/enable",
@@ -3887,7 +3927,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 386,
+    "index": 390,
     "method": "POST",
     "operationId": "plugins.disable",
     "path": "/v1/plugins/:id/disable",
@@ -3897,7 +3937,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 387,
+    "index": 391,
     "method": "DELETE",
     "operationId": "plugins.uninstall",
     "path": "/v1/plugins/:id",
@@ -3907,7 +3947,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 388,
+    "index": 392,
     "method": "POST",
     "operationId": "agent.runs.start",
     "path": "/v1/agent/runs",
@@ -3917,7 +3957,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 389,
+    "index": 393,
     "method": "GET",
     "operationId": "agent.runs.list",
     "path": "/v1/agent/runs",
@@ -3927,7 +3967,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 390,
+    "index": 394,
     "method": "GET",
     "operationId": "agent.runs.summary",
     "path": "/v1/agent/runs/summary",
@@ -3937,7 +3977,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 391,
+    "index": 395,
     "method": "GET",
     "operationId": "agent.runs.get",
     "path": "/v1/agent/runs/:runId",
@@ -3947,7 +3987,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 392,
+    "index": 396,
     "method": "POST",
     "operationId": "agent.runs.cancel",
     "path": "/v1/agent/runs/:runId/cancel",
@@ -3957,7 +3997,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 393,
+    "index": 397,
     "method": "GET",
     "operationId": "agent.runs.audit",
     "path": "/v1/agent/runs/:runId/audit",
@@ -3967,7 +4007,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 394,
+    "index": 398,
     "method": "POST",
     "operationId": "agent.runs.rollback",
     "path": "/v1/agent/runs/:runId/rollback",
@@ -3977,7 +4017,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 395,
+    "index": 399,
     "method": "POST",
     "operationId": "agent.runs.approve.plan",
     "path": "/v1/agent/runs/:runId/approve-plan",
@@ -3987,7 +4027,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 396,
+    "index": 400,
     "method": "POST",
     "operationId": "agent.runs.reject.plan",
     "path": "/v1/agent/runs/:runId/reject-plan",
@@ -3997,7 +4037,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 397,
+    "index": 401,
     "method": "POST",
     "operationId": "agent.runs.approve.tool",
     "path": "/v1/agent/runs/:runId/approve-tool",
@@ -4007,7 +4047,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 398,
+    "index": 402,
     "method": "POST",
     "operationId": "agent.runs.reject.tool",
     "path": "/v1/agent/runs/:runId/reject-tool",
@@ -4017,7 +4057,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 399,
+    "index": 403,
     "method": "GET",
     "operationId": "agent.runs.events",
     "path": "/v1/agent/runs/:runId/events",
@@ -4027,7 +4067,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 400,
+    "index": 404,
     "method": "POST",
     "operationId": "agent.automations.create",
     "path": "/v1/agent/automations",
@@ -4037,7 +4077,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 401,
+    "index": 405,
     "method": "GET",
     "operationId": "agent.automations.list",
     "path": "/v1/agent/automations",
@@ -4047,7 +4087,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 402,
+    "index": 406,
     "method": "GET",
     "operationId": "agent.automations.get",
     "path": "/v1/agent/automations/:automationId",
@@ -4057,7 +4097,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 403,
+    "index": 407,
     "method": "PATCH",
     "operationId": "agent.automations.update",
     "path": "/v1/agent/automations/:automationId",
@@ -4067,7 +4107,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 404,
+    "index": 408,
     "method": "DELETE",
     "operationId": "agent.automations.delete",
     "path": "/v1/agent/automations/:automationId",
@@ -4077,7 +4117,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 405,
+    "index": 409,
     "method": "POST",
     "operationId": "agent.automations.run",
     "path": "/v1/agent/automations/:automationId/run",
@@ -4087,7 +4127,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 406,
+    "index": 410,
     "method": "GET",
     "operationId": "agent.subagents.list",
     "path": "/v1/agent/subagents",
@@ -4097,7 +4137,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 407,
+    "index": 411,
     "method": "GET",
     "operationId": "agent.subagents.get",
     "path": "/v1/agent/subagents/:subagentId",
@@ -4107,7 +4147,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 408,
+    "index": 412,
     "method": "GET",
     "operationId": "agent.runs.subagents.list",
     "path": "/v1/agent/runs/:runId/subagents",
@@ -4117,7 +4157,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 409,
+    "index": 413,
     "method": "GET",
     "operationId": "assets.inventory.list",
     "path": "/v1/assets/inventory",

--- a/test/contracts/api/friday-api-route-contract.snapshot.test.ts
+++ b/test/contracts/api/friday-api-route-contract.snapshot.test.ts
@@ -817,6 +817,18 @@ describe("MECHANISM-4 — API Route Contract (Snapshot)", () => {
         "autofix.actions.deny",
         "autofix.actions.execute",
         "autofix.actions.rollback",
+        // Phase 14.5E module_28e: owner-link mint + owner-signed
+        // approval + execute API for high-risk channel actions. All
+        // three routes enforce `channel.action.high_risk.{approve,
+        // execute}` via assertBoundPrincipalForOperation and refuse
+        // source: "channel" outright. Execute additionally refuses
+        // without a prior approval record. The owner-link route is the
+        // production minter for the one-click owner approval URL form;
+        // its signed token is delivered to the owner via the local
+        // Assistant / API surface, never via channel adapter outbound.
+        "channels.actions.owner.link",
+        "channels.actions.owner.approve",
+        "channels.actions.execute",
       ]);
       // rate_limited_pending
       const RATE_LIMITED_PENDING: ReadonlySet<string> = new Set([

--- a/test/e2e/api/friday-api-channel-setup-and-live-proof.acceptance.test.ts
+++ b/test/e2e/api/friday-api-channel-setup-and-live-proof.acceptance.test.ts
@@ -1,0 +1,558 @@
+/**
+ * Phase 14.5E module_28e Slice 6.8 — channel setup and live-proof
+ * acceptance test.
+ *
+ * Drives the real route handlers from the same factory functions wired
+ * by `createFridayApiRuntime` and the real Friday task-workflow service
+ * (no mocks of `createFridayTaskWorkflowService`, its repository,
+ * `routeFridayChannelDispatch`, `assertBoundPrincipalForOperation`,
+ * `verifyFridayChannelActionApprovalToken`, or
+ * `buildFridayChannelOutboundReceiptSummary`). The test:
+ *
+ *   (1) hits `GET /v1/setup/channels/status` (via the route handler from
+ *       `createFridaySetupRoutes`) under three env states — no env,
+ *       Discord-only env, all-three env — and asserts that every v1
+ *       channel (Discord / Lark / Telegram) carries its own honest
+ *       per-channel proof label and that Discord credentials never
+ *       silently satisfy Lark or Telegram;
+ *   (2) drives `routeFridayChannelDispatch` end-to-end on an inbound
+ *       channel message that resolves to a high-risk canonical command
+ *       and asserts the dispatcher emits an `owner_link_required`
+ *       outcome (never an in-channel confirmation);
+ *   (3) signs an owner-approval token with the runtime secret, hits
+ *       `POST /v1/channels/actions/{actionId}/owner-approve` and asserts
+ *       the approval record is captured;
+ *   (4) hits `POST /v1/channels/actions/{actionId}/execute` and asserts
+ *       the response carries `rollbackClass = "non_reversible_external"`
+ *       and `evidenceRefSource = "channel_event"`;
+ *   (5) drives the real task-workflow service with a `channel_event`
+ *       evidence ref and asserts the closeout receipt has
+ *       `rollbackClass = "non_reversible_external"`, the
+ *       `rollback_class_disclosure_required` gate passes, and
+ *       `evidenceDurability` is populated.
+ *
+ * Mirrors Stage 2 Slice 6.8 of
+ * `PHASE_14_5E_STAGE_2_SCOPE_RECONCILIATION_MATRIX_2026-05-17.md`.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  createFridayTaskWorkflowRepository,
+  createFridayTaskWorkflowService,
+} from "../../../src/task-workflows/index.js";
+import {
+  createFridayChannelActionRoutes,
+  createInMemoryChannelActionApprovalStore,
+} from "../../../src/api/http/routes/friday-channel-action-routes.js";
+import { createFridaySetupRoutes } from "../../../src/api/http/routes/friday-setup-routes.js";
+import {
+  buildFridayChannelSetupStatus,
+  routeFridayChannelDispatch,
+  type FridayChannelRegistryView,
+  type FridayChannelSetupStatusResponse,
+} from "#channels";
+import {
+  signFridayChannelActionApprovalToken,
+  verifyFridayChannelActionApprovalToken,
+} from "../../../src/security/friday-channel-action-approval.js";
+import { FRIDAY_OWNER_SESSION_CHANNEL_ERROR_CODES } from "../../../src/security/friday-owner-session-channel-capability.js";
+import type { FridayAuthPrincipal } from "../../../src/api/model/friday-api-auth.types.js";
+
+import {
+  createTestDb,
+  createTestIdGenerator,
+} from "../../helpers/friday-test-db.helper.js";
+
+const NOW = "2026-05-17T08:30:00.000Z";
+const SIGNING_KEY = "phase-14-5e-acceptance-signing-key";
+
+function realPrincipal(): FridayAuthPrincipal {
+  return {
+    principalType: "user",
+    principalId: "user-acceptance-1",
+    tenantId: "tenant-acceptance-1",
+    userId: "33333333-3333-3333-3333-333333333333",
+    role: "admin",
+    scopes: ["agent.write"],
+    tokenId: "44444444-4444-4444-4444-444444444444",
+    tokenKind: "access",
+    issuedAt: NOW,
+  };
+}
+
+function buildCtx(input: {
+  actionId: string;
+  body: Record<string, unknown>;
+  headers?: Record<string, string>;
+  principal?: FridayAuthPrincipal;
+}) {
+  return {
+    params: { actionId: input.actionId },
+    query: {},
+    body: input.body,
+    headers: input.headers ?? {},
+    principal: input.principal ?? realPrincipal(),
+    requestId: "req-acceptance-1",
+    receivedAt: NOW,
+  };
+}
+
+function getStatusRoute(views: readonly FridayChannelRegistryView[]) {
+  // Construct the real setup routes factory and pull the
+  // `setup.channels.status` route handler. The factory only touches db /
+  // providerService / skillRegistry inside other route handlers; the
+  // status route handler is a pure projection over
+  // `listChannelRegistryViews` and `process.env`. We pass minimal stubs
+  // for the unused deps so the factory still compiles.
+  const db = createTestDb();
+  try {
+    const routes = createFridaySetupRoutes({
+      db,
+      providerService: {} as never,
+      skillRegistry: {} as never,
+      nowIso: () => NOW,
+      runningHost: "127.0.0.1",
+      runningPort: 3141,
+      listChannelRegistryViews: () => views,
+    });
+    const route = routes.find((r) => r.operationId === "setup.channels.status");
+    if (!route) throw new Error("setup.channels.status route not found");
+    return { route, db };
+  } catch (err) {
+    db.close();
+    throw err;
+  }
+}
+
+async function callStatusRoute(
+  views: readonly FridayChannelRegistryView[],
+  processEnv: NodeJS.ProcessEnv,
+): Promise<FridayChannelSetupStatusResponse> {
+  // Capture the active env, swap to the requested env for the route
+  // call, then restore. The status handler reads from `process.env` via
+  // the helper. Acceptance-level intent: same payload the wizard would
+  // observe via HTTP.
+  const previous = { ...process.env };
+  try {
+    for (const key of Object.keys(process.env)) {
+      delete (process.env as Record<string, string | undefined>)[key];
+    }
+    for (const [key, value] of Object.entries(processEnv)) {
+      if (typeof value === "string") {
+        (process.env as Record<string, string>)[key] = value;
+      }
+    }
+    const { route, db } = getStatusRoute(views);
+    try {
+      // The route handler ignores params/query/body; pass empty shells.
+      const response = (await route.handler({
+        params: {},
+        query: {},
+        body: {},
+        headers: {},
+        principal: null,
+        requestId: "req-status",
+        receivedAt: NOW,
+      } as never)) as FridayChannelSetupStatusResponse;
+      return response;
+    } finally {
+      db.close();
+    }
+  } finally {
+    for (const key of Object.keys(process.env)) {
+      delete (process.env as Record<string, string | undefined>)[key];
+    }
+    for (const [key, value] of Object.entries(previous)) {
+      if (typeof value === "string") {
+        (process.env as Record<string, string>)[key] = value;
+      }
+    }
+  }
+}
+
+describe("Phase 14.5E module_28e Slice 6.8: channel setup + live-proof acceptance", () => {
+  describe("GET /v1/setup/channels/status (real route handler) — three env states", () => {
+    it("(a) no env — every v1 channel reports `not_configured`; no Discord stand-in", async () => {
+      const response = await callStatusRoute([], {});
+      expect(response.channels.map((row) => row.kind)).toEqual([
+        "discord",
+        "lark",
+        "telegram",
+      ]);
+      for (const row of response.channels) {
+        expect(row.proofLabel).toBe("not_configured");
+        expect(row.missingEnvVars.length).toBeGreaterThan(0);
+      }
+      // Compare against the helper directly to anchor the route+helper
+      // contract: the projection produced by the route must equal the
+      // projection produced by the helper for the same inputs.
+      expect(response).toEqual(buildFridayChannelSetupStatus({ views: [], processEnv: {} }));
+    });
+
+    it("(b) Discord-only env — Discord is `configured`; Lark + Telegram remain `not_configured`", async () => {
+      const env: NodeJS.ProcessEnv = {
+        FRIDAY_DISCORD_BOT_TOKEN: "discord-token",
+        FRIDAY_DISCORD_SETUP_USER_ID: "owner",
+        FRIDAY_DISCORD_GUILD_ID: "guild",
+        FRIDAY_DISCORD_CHANNEL_ID: "channel",
+      };
+      const response = await callStatusRoute([], env);
+      const discord = response.channels.find((row) => row.kind === "discord");
+      const lark = response.channels.find((row) => row.kind === "lark");
+      const telegram = response.channels.find((row) => row.kind === "telegram");
+      expect(discord?.proofLabel).toBe("configured");
+      expect(discord?.missingEnvVars).toEqual([]);
+      expect(lark?.proofLabel).toBe("not_configured");
+      expect(lark?.missingEnvVars.length).toBeGreaterThan(0);
+      expect(telegram?.proofLabel).toBe("not_configured");
+      expect(telegram?.missingEnvVars.length).toBeGreaterThan(0);
+    });
+
+    it("(c) all-three env stubbed — every v1 channel reports `configured` honestly", async () => {
+      const env: NodeJS.ProcessEnv = {
+        FRIDAY_DISCORD_BOT_TOKEN: "discord-token",
+        FRIDAY_DISCORD_SETUP_USER_ID: "owner",
+        FRIDAY_DISCORD_GUILD_ID: "guild",
+        FRIDAY_DISCORD_CHANNEL_ID: "channel",
+        FRIDAY_LARK_APP_ID: "lark-app",
+        FRIDAY_LARK_APP_SECRET: "lark-secret",
+        FRIDAY_LARK_VERIFICATION_TOKEN: "lark-verify",
+        FRIDAY_LARK_ENCRYPT_KEY: "lark-encrypt",
+        FRIDAY_LARK_TEST_CHAT_ID: "lark-chat",
+        FRIDAY_TELEGRAM_BOT_TOKEN: "telegram-token",
+        FRIDAY_TELEGRAM_TEST_CHAT_ID: "telegram-chat",
+      };
+      const response = await callStatusRoute([], env);
+      for (const row of response.channels) {
+        expect(row.proofLabel).toBe("configured");
+        expect(row.missingEnvVars).toEqual([]);
+      }
+    });
+  });
+
+  describe("canonical command ladder: preview → owner-link → execute → receipt", () => {
+    it("drives the full high-risk ladder against real route handlers", async () => {
+      // (2) Channel inbound message → routeFridayChannelDispatch — high
+      // risk verb → owner_link_required.
+      const dispatch = routeFridayChannelDispatch({
+        channelKind: "discord",
+        chatId: "chat-acceptance-1",
+        chatType: "group",
+        senderId: "user-acceptance-1",
+        text: "apply repair",
+      });
+      expect(dispatch.kind).toBe("owner_link_required");
+      if (dispatch.kind !== "owner_link_required") {
+        throw new Error("expected owner_link_required outcome");
+      }
+      const actionId = dispatch.request.actionId;
+      const channelId = `${dispatch.request.channelKind}:${dispatch.request.chatId}`;
+      expect(dispatch.request.ownerLinkPath).toBe(
+        `/v1/channels/actions/${encodeURIComponent(actionId)}/owner-approve`,
+      );
+
+      // Build the channel-action routes (shared in-memory approval store
+      // across owner-link mint + approve + execute). This mirrors the
+      // wiring inside `createFridayApiRuntime`.
+      const approvalStore = createInMemoryChannelActionApprovalStore();
+      const routes = createFridayChannelActionRoutes({
+        signingKey: SIGNING_KEY,
+        approvalStore,
+        nowIso: () => NOW,
+      });
+      const linkRoute = routes.find(
+        (r) => r.operationId === "channels.actions.owner.link",
+      );
+      const approveRoute = routes.find(
+        (r) => r.operationId === "channels.actions.owner.approve",
+      );
+      const executeRoute = routes.find(
+        (r) => r.operationId === "channels.actions.execute",
+      );
+      if (!linkRoute || !approveRoute || !executeRoute) {
+        throw new Error("channel-action routes not found");
+      }
+
+      // (2b) Owner-link mint route refuses `source: "channel"`: the
+      // signed token is never delivered to a channel-sourced caller,
+      // preserving the rule that channel text never carries bearer
+      // credentials. The owner mints the link via api/session lane
+      // only.
+      let refusedLinkMintFromChannel: unknown;
+      try {
+        await linkRoute.handler(buildCtx({
+          actionId,
+          body: { channelId },
+          headers: { "x-friday-principal-source": "channel" },
+        }));
+      } catch (err) {
+        refusedLinkMintFromChannel = err;
+      }
+      expect(refusedLinkMintFromChannel).toBeDefined();
+      expect((refusedLinkMintFromChannel as { code?: string }).code).toBe(
+        FRIDAY_OWNER_SESSION_CHANNEL_ERROR_CODES.CHANNEL_HIGH_RISK_SOURCE_REFUSED,
+      );
+
+      // (2c) Owner-link mint route on api lane returns the one-click
+      // owner approval URL form plus the signed token. The token is
+      // delivered alongside (not inside) the URL — the Assistant POSTs
+      // the token back to the approve route. The path the channel
+      // already advertised in (2) matches the path the mint route
+      // returns.
+      const mintedLink = (await linkRoute.handler(buildCtx({
+        actionId,
+        body: { channelId, ttlSeconds: 600 },
+      }))) as {
+        actionId: string;
+        channelId: string;
+        principalId: string;
+        ownerApprovalToken: string;
+        ownerApprovalPath: string;
+        ownerApprovalUrl: string;
+        issuedAt: string;
+        expiresAt: string;
+        issuedSource: string;
+      };
+      expect(mintedLink.actionId).toBe(actionId);
+      expect(mintedLink.channelId).toBe(channelId);
+      expect(mintedLink.issuedSource).toBe("api");
+      expect(mintedLink.principalId).toBe(realPrincipal().principalId);
+      expect(mintedLink.ownerApprovalPath).toBe(dispatch.request.ownerLinkPath);
+      // Hard rule: the signed token is not embedded in the path or URL
+      // returned to the owner; it travels in a separate field that the
+      // Assistant uses for POST. This is what makes it safe for the
+      // channel adapter to surface the path text without leaking
+      // bearer material.
+      expect(mintedLink.ownerApprovalPath).not.toContain(
+        mintedLink.ownerApprovalToken,
+      );
+      expect(mintedLink.ownerApprovalUrl).not.toContain(
+        mintedLink.ownerApprovalToken,
+      );
+      // Token verifies against the runtime signing key with the same
+      // context the approve route enforces.
+      const verifiedPayload = verifyFridayChannelActionApprovalToken({
+        token: mintedLink.ownerApprovalToken,
+        actionId,
+        channelId,
+        principalId: realPrincipal().principalId,
+        nowIso: NOW,
+        signingKey: SIGNING_KEY,
+      });
+      expect(verifiedPayload.expiresAt).toBe(mintedLink.expiresAt);
+
+      // (a) channel-sourced approve must be refused even with a valid
+      // token — the bound-principal contract refuses `source: "channel"`
+      // for the high-risk approve operation.
+      const channelToken = signFridayChannelActionApprovalToken({
+        actionId,
+        channelId,
+        principalId: realPrincipal().principalId,
+        riskLevel: "high",
+        expiresAt: "2099-01-01T00:00:00.000Z",
+        signingKey: SIGNING_KEY,
+      });
+      let refusedFromChannel: unknown;
+      try {
+        await approveRoute.handler(buildCtx({
+          actionId,
+          body: { ownerApprovalToken: channelToken, channelId },
+          headers: { "x-friday-principal-source": "channel" },
+        }));
+      } catch (err) {
+        refusedFromChannel = err;
+      }
+      expect(refusedFromChannel).toBeDefined();
+      expect((refusedFromChannel as { code?: string }).code).toBe(
+        FRIDAY_OWNER_SESSION_CHANNEL_ERROR_CODES.CHANNEL_HIGH_RISK_SOURCE_REFUSED,
+      );
+
+      // (3) `source: "api"` + the minted owner-link token records the
+      // approval. This closes the production user-visible loop: the
+      // mint route is the only place the runtime signed-token minter
+      // is exercised end-to-end with a bound principal, and the
+      // approve route consumes exactly that minted token.
+      const approveResponse = (await approveRoute.handler(buildCtx({
+        actionId,
+        body: {
+          ownerApprovalToken: mintedLink.ownerApprovalToken,
+          channelId,
+        },
+      }))) as { actionId: string; approvedSource: string };
+      expect(approveResponse.actionId).toBe(actionId);
+      expect(approveResponse.approvedSource).toBe("api");
+      const storedApproval = await approvalStore.getApproval(actionId);
+      expect(storedApproval?.principalId).toBe(realPrincipal().principalId);
+
+      // (4) Execute consumes the approval and returns a
+      // `non_reversible_external` receipt. Channel-sourced execute is
+      // refused outright by the bound-principal contract.
+      let refusedExecuteFromChannel: unknown;
+      try {
+        await executeRoute.handler(buildCtx({
+          actionId,
+          body: { channelId, messageId: "msg-acceptance-1" },
+          headers: { "x-friday-principal-source": "channel" },
+        }));
+      } catch (err) {
+        refusedExecuteFromChannel = err;
+      }
+      expect(refusedExecuteFromChannel).toBeDefined();
+      expect((refusedExecuteFromChannel as { code?: string }).code).toBe(
+        FRIDAY_OWNER_SESSION_CHANNEL_ERROR_CODES.CHANNEL_HIGH_RISK_SOURCE_REFUSED,
+      );
+
+      const executeResponse = (await executeRoute.handler(buildCtx({
+        actionId,
+        body: { channelId, messageId: "msg-acceptance-1" },
+      }))) as {
+        actionId: string;
+        receipt: {
+          rollbackClass: string;
+          evidenceRefSource: string;
+          nonReversibleReason: string;
+        };
+        approval: { approvedBy: string };
+      };
+      expect(executeResponse.actionId).toBe(actionId);
+      expect(executeResponse.receipt.rollbackClass).toBe("non_reversible_external");
+      expect(executeResponse.receipt.evidenceRefSource).toBe("channel_event");
+      expect(executeResponse.receipt.nonReversibleReason).toContain(channelId);
+      expect(executeResponse.approval.approvedBy).toBe(
+        realPrincipal().userId,
+      );
+
+      // (4c) Single-use guarantee: the successful execute above must
+      // have consumed the approval record, so a second execute against
+      // the same actionId/store is refused. The owner must mint a fresh
+      // owner-signed token to authorize another execute.
+      expect(await approvalStore.getApproval(actionId)).toBeNull();
+      let refusedRepeatExecute: unknown;
+      try {
+        await executeRoute.handler(buildCtx({
+          actionId,
+          body: { channelId, messageId: "msg-acceptance-1b" },
+        }));
+      } catch (err) {
+        refusedRepeatExecute = err;
+      }
+      expect(refusedRepeatExecute).toBeDefined();
+      expect((refusedRepeatExecute as { code?: string }).code).toBe(
+        "CHANNEL_HIGH_RISK_EXECUTE_NOT_APPROVED",
+      );
+
+      // (4b) Execute without a prior approval is refused. A new store
+      // for a fresh action id models the post-restart / never-approved
+      // scenario at the boundary of the in-memory ledger.
+      const freshStore = createInMemoryChannelActionApprovalStore();
+      const freshRoutes = createFridayChannelActionRoutes({
+        signingKey: SIGNING_KEY,
+        approvalStore: freshStore,
+        nowIso: () => NOW,
+      });
+      const freshExecute = freshRoutes.find(
+        (r) => r.operationId === "channels.actions.execute",
+      )!;
+      let refusedMissingApproval: unknown;
+      try {
+        await freshExecute.handler(buildCtx({
+          actionId,
+          body: { channelId, messageId: "msg-acceptance-2" },
+        }));
+      } catch (err) {
+        refusedMissingApproval = err;
+      }
+      expect(refusedMissingApproval).toBeDefined();
+      expect((refusedMissingApproval as { code?: string }).code).toBe(
+        "CHANNEL_HIGH_RISK_EXECUTE_NOT_APPROVED",
+      );
+    });
+  });
+
+  describe("channel-triggered closeout receipt drives the Phase 14.5C/D fields", () => {
+    it("(5) channel_event evidence ref → non_reversible_external + rollback_class_disclosure_required passes + evidenceDurability populated", () => {
+      const db = createTestDb();
+      const repository = createFridayTaskWorkflowRepository();
+      const idGen = createTestIdGenerator();
+      const service = createFridayTaskWorkflowService({
+        db,
+        repository,
+        idGenerator: idGen,
+        nowIso: () => NOW,
+        getWorkflowRunEvidenceStatus: () => "available",
+      });
+      try {
+        const tw = service.create({
+          charter: "Phase 14.5E acceptance — channel outbound closeout",
+          taskKind: "general",
+          contextPackage: {
+            allowedFiles: ["src/x.ts"],
+            allowedTools: [],
+            allowedApis: [],
+            boundaryIds: [
+              "api.task_workflows.core",
+              "evidence.refs.channel_event",
+            ],
+          },
+        });
+        const claim = service.draftClaim(tw.id, {
+          claimText: "outbound channel send acknowledged",
+          claimKind: "runtime_evidence",
+        });
+        // Attach a compatible evidence ref so verifyClaim succeeds via the
+        // service. The channel_event ref source is not directly attachable
+        // to runtime_evidence claims (Phase 13.5A compatibility policy), so
+        // we model the closeout-time disclosure surface by planting the
+        // channel_event ref through the repository after verification —
+        // exactly the pattern the Phase 14.5D acceptance test uses for
+        // manual_external refs.
+        service.attachEvidenceRef(tw.id, claim.id, {
+          refKind: "agent_run.event",
+          refId: "agent-evt-channel-pre",
+          refSource: "agent_run_event",
+        });
+        service.verifyClaim(tw.id, claim.id, {
+          verifierVerdict: "fresh-read pre-channel evidence",
+        });
+        db.withWriteTransaction((conn) => {
+          repository.insertEvidenceRef(conn, {
+            id: "plant-channel-evt-acceptance-1",
+            workflowId: tw.id,
+            claimId: claim.id,
+            refKind: "channel.event",
+            refId: "channel-evt-acceptance-1",
+            refHash: null,
+            refSource: "channel_event",
+            createdAt: NOW,
+          });
+          repository.incrementEvidenceRefCount(conn, claim.id, NOW);
+        });
+        const receipt = service.closeout(tw.id);
+        expect(receipt.rollbackClass).toBe("non_reversible_external");
+        expect(receipt.nonReversibleReason).toBeTruthy();
+        expect(receipt.compensatingAction).toBeNull();
+        // Phase 14.5C: evidenceDurability is populated on the receipt and
+        // proofClaimable is a deterministic boolean.
+        expect(typeof receipt.evidenceDurability).toBe("string");
+        expect(["available", "degraded", "unavailable"]).toContain(
+          receipt.evidenceDurability,
+        );
+        expect(typeof receipt.proofClaimable).toBe("boolean");
+        // Phase 14.5D: rollback_class_disclosure_required gate passes.
+        const rollbackGate = receipt.gateOutcomes.find(
+          (g) => g.gateId === "rollback_class_disclosure_required",
+        );
+        expect(rollbackGate?.status).toBe("pass");
+        // Phase 14.5C: workflow_run_evidence_durable gate is present and
+        // not regressed by the 14.5E receipt path.
+        const evidenceGate = receipt.gateOutcomes.find(
+          (g) => g.gateId === "workflow_run_evidence_durable",
+        );
+        expect(evidenceGate?.status).toBe("pass");
+      } finally {
+        db.close();
+      }
+    });
+  });
+});

--- a/test/unit/api/http/routes/friday-channel-action-routes.test.ts
+++ b/test/unit/api/http/routes/friday-channel-action-routes.test.ts
@@ -1,0 +1,586 @@
+// Phase 14.5E module_28e Slice 6.4/6.8 — focused route handler tests for
+// POST /v1/channels/actions/:actionId/owner-approve.
+//
+// The route is invoked directly through its handler so the test does not
+// need to boot a full HTTP server. We assert:
+//   - the route refuses `source: "channel"`;
+//   - the route accepts `source: "api"` with a valid token;
+//   - the route refuses an expired token;
+//   - the route records an approval the store can later look up.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  createFridayChannelActionRoutes,
+  createInMemoryChannelActionApprovalStore,
+} from "../../../../../src/api/http/routes/friday-channel-action-routes.js";
+import {
+  signFridayChannelActionApprovalToken,
+  verifyFridayChannelActionApprovalToken,
+} from "../../../../../src/security/friday-channel-action-approval.js";
+import { FRIDAY_OWNER_SESSION_CHANNEL_ERROR_CODES } from "../../../../../src/security/friday-owner-session-channel-capability.js";
+import { createFridayDefaultPublicHttpPrincipal } from "../../../../../src/api/http/friday-default-public-principal.js";
+import type { FridayAuthPrincipal } from "../../../../../src/api/model/friday-api-auth.types.js";
+
+const SIGNING_KEY = "phase-14-5e-owner-link-key";
+
+function realPrincipal(overrides: Partial<FridayAuthPrincipal> = {}): FridayAuthPrincipal {
+  return {
+    principalType: "user",
+    principalId: "user-real-1",
+    tenantId: "tenant-1",
+    userId: "11111111-1111-1111-1111-111111111111",
+    role: "admin",
+    scopes: ["agent.write"],
+    tokenId: "22222222-2222-2222-2222-222222222222",
+    tokenKind: "access",
+    issuedAt: "2026-05-17T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function buildCtx(input: {
+  actionId: string;
+  body: Record<string, unknown>;
+  headers?: Record<string, string>;
+  principal?: FridayAuthPrincipal | null;
+}) {
+  return {
+    params: { actionId: input.actionId },
+    query: {},
+    body: input.body,
+    headers: input.headers ?? {},
+    principal: input.principal ?? realPrincipal(),
+    requestId: "req-1",
+  };
+}
+
+function getRouteHandler() {
+  const approvalStore = createInMemoryChannelActionApprovalStore();
+  const routes = createFridayChannelActionRoutes({
+    signingKey: SIGNING_KEY,
+    approvalStore,
+    nowIso: () => "2026-05-17T00:00:00.000Z",
+  });
+  const route = routes.find((r) => r.path === "/v1/channels/actions/:actionId/owner-approve");
+  if (!route) throw new Error("route not found");
+  return { route, approvalStore };
+}
+
+function getOwnerLinkHandler() {
+  const approvalStore = createInMemoryChannelActionApprovalStore();
+  const routes = createFridayChannelActionRoutes({
+    signingKey: SIGNING_KEY,
+    approvalStore,
+    nowIso: () => "2026-05-17T00:00:00.000Z",
+  });
+  const linkRoute = routes.find(
+    (r) => r.path === "/v1/channels/actions/:actionId/owner-link",
+  );
+  const approveRoute = routes.find(
+    (r) => r.path === "/v1/channels/actions/:actionId/owner-approve",
+  );
+  if (!linkRoute) throw new Error("owner-link route not found");
+  if (!approveRoute) throw new Error("owner-approve route not found");
+  return { linkRoute, approveRoute, approvalStore };
+}
+
+function getApproveAndExecuteHandlers() {
+  const approvalStore = createInMemoryChannelActionApprovalStore();
+  const routes = createFridayChannelActionRoutes({
+    signingKey: SIGNING_KEY,
+    approvalStore,
+    nowIso: () => "2026-05-17T00:00:00.000Z",
+  });
+  const approveRoute = routes.find(
+    (r) => r.path === "/v1/channels/actions/:actionId/owner-approve",
+  );
+  const executeRoute = routes.find(
+    (r) => r.path === "/v1/channels/actions/:actionId/execute",
+  );
+  if (!approveRoute) throw new Error("approve route not found");
+  if (!executeRoute) throw new Error("execute route not found");
+  return { approveRoute, executeRoute, approvalStore };
+}
+
+describe("POST /v1/channels/actions/:actionId/owner-approve", () => {
+  it("refuses source: \"channel\"", async () => {
+    const { route } = getRouteHandler();
+    const token = signFridayChannelActionApprovalToken({
+      actionId: "act-1",
+      channelId: "discord:chat-1",
+      principalId: "user-real-1",
+      riskLevel: "high",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      signingKey: SIGNING_KEY,
+    });
+    let thrown: unknown;
+    try {
+      await route.handler(buildCtx({
+        actionId: "act-1",
+        body: { ownerApprovalToken: token, channelId: "discord:chat-1" },
+        headers: { "x-friday-principal-source": "channel" },
+      }));
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeDefined();
+    expect((thrown as { code?: string }).code).toBe(
+      FRIDAY_OWNER_SESSION_CHANNEL_ERROR_CODES.CHANNEL_HIGH_RISK_SOURCE_REFUSED,
+    );
+  });
+
+  it("refuses unauthenticated synthetic principal", async () => {
+    const { route } = getRouteHandler();
+    const token = signFridayChannelActionApprovalToken({
+      actionId: "act-1",
+      channelId: "discord:chat-1",
+      principalId: "user-real-1",
+      riskLevel: "high",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      signingKey: SIGNING_KEY,
+    });
+    let thrown: unknown;
+    try {
+      await route.handler(buildCtx({
+        actionId: "act-1",
+        body: { ownerApprovalToken: token, channelId: "discord:chat-1" },
+        principal: createFridayDefaultPublicHttpPrincipal(),
+      }));
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeDefined();
+    expect((thrown as { code?: string }).code).toBe(
+      FRIDAY_OWNER_SESSION_CHANNEL_ERROR_CODES.BOUND_PRINCIPAL_REQUIRED,
+    );
+  });
+
+  it("accepts source: \"api\" with a valid owner-signed token and records the approval", async () => {
+    const { route, approvalStore } = getRouteHandler();
+    const token = signFridayChannelActionApprovalToken({
+      actionId: "act-1",
+      channelId: "discord:chat-1",
+      principalId: "user-real-1",
+      riskLevel: "high",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      signingKey: SIGNING_KEY,
+    });
+    const response = await route.handler(buildCtx({
+      actionId: "act-1",
+      body: { ownerApprovalToken: token, channelId: "discord:chat-1" },
+    }));
+    expect((response as { actionId: string }).actionId).toBe("act-1");
+    expect((response as { approvedSource: string }).approvedSource).toBe("api");
+    const stored = await approvalStore.getApproval("act-1");
+    expect(stored?.actionId).toBe("act-1");
+    expect(stored?.approvedBy).toBe("11111111-1111-1111-1111-111111111111");
+  });
+
+  it("refuses tokens whose actionId does not match the path", async () => {
+    const { route } = getRouteHandler();
+    const token = signFridayChannelActionApprovalToken({
+      actionId: "act-other",
+      channelId: "discord:chat-1",
+      principalId: "user-real-1",
+      riskLevel: "high",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      signingKey: SIGNING_KEY,
+    });
+    let thrown: unknown;
+    try {
+      await route.handler(buildCtx({
+        actionId: "act-1",
+        body: { ownerApprovalToken: token, channelId: "discord:chat-1" },
+      }));
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeDefined();
+    expect((thrown as { code?: string }).code).toBe(
+      "CHANNEL_OWNER_APPROVAL_TOKEN_CONTEXT_MISMATCH",
+    );
+  });
+
+  it("rejects malformed bodies", async () => {
+    const { route } = getRouteHandler();
+    let thrown: unknown;
+    try {
+      await route.handler(buildCtx({
+        actionId: "act-1",
+        body: {},
+      }));
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeDefined();
+    expect((thrown as { code?: string }).code).toBe("VALIDATION_ERROR");
+  });
+});
+
+describe("POST /v1/channels/actions/:actionId/execute", () => {
+  it("refuses execute without a prior approval record", async () => {
+    const { executeRoute } = getApproveAndExecuteHandlers();
+    let thrown: unknown;
+    try {
+      await executeRoute.handler(buildCtx({
+        actionId: "act-1",
+        body: { channelId: "discord:chat-1", messageId: "msg-1" },
+      }));
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeDefined();
+    expect((thrown as { code?: string }).code).toBe(
+      "CHANNEL_HIGH_RISK_EXECUTE_NOT_APPROVED",
+    );
+  });
+
+  it("refuses execute from source: \"channel\"", async () => {
+    const { executeRoute } = getApproveAndExecuteHandlers();
+    let thrown: unknown;
+    try {
+      await executeRoute.handler(buildCtx({
+        actionId: "act-1",
+        body: { channelId: "discord:chat-1", messageId: "msg-1" },
+        headers: { "x-friday-principal-source": "channel" },
+      }));
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeDefined();
+    expect((thrown as { code?: string }).code).toBe(
+      FRIDAY_OWNER_SESSION_CHANNEL_ERROR_CODES.CHANNEL_HIGH_RISK_SOURCE_REFUSED,
+    );
+  });
+
+  it("executes when a prior approval record exists and emits the non_reversible_external receipt", async () => {
+    const { approveRoute, executeRoute } = getApproveAndExecuteHandlers();
+    const token = signFridayChannelActionApprovalToken({
+      actionId: "act-1",
+      channelId: "discord:chat-1",
+      principalId: "user-real-1",
+      riskLevel: "high",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      signingKey: SIGNING_KEY,
+    });
+    await approveRoute.handler(buildCtx({
+      actionId: "act-1",
+      body: { ownerApprovalToken: token, channelId: "discord:chat-1" },
+    }));
+    const response = await executeRoute.handler(buildCtx({
+      actionId: "act-1",
+      body: { channelId: "discord:chat-1", messageId: "msg-1" },
+    }));
+    const body = response as {
+      actionId: string;
+      executedSource: string;
+      receipt: { rollbackClass: string; evidenceRefSource: string; nonReversibleReason: string };
+      approval: { approvedBy: string };
+    };
+    expect(body.actionId).toBe("act-1");
+    expect(body.executedSource).toBe("api");
+    expect(body.receipt.rollbackClass).toBe("non_reversible_external");
+    expect(body.receipt.evidenceRefSource).toBe("channel_event");
+    expect(body.receipt.nonReversibleReason).toContain("discord:chat-1");
+    expect(body.approval.approvedBy).toBe("11111111-1111-1111-1111-111111111111");
+  });
+
+  it("refuses execute when channelId does not match the approval", async () => {
+    const { approveRoute, executeRoute } = getApproveAndExecuteHandlers();
+    const token = signFridayChannelActionApprovalToken({
+      actionId: "act-1",
+      channelId: "discord:chat-1",
+      principalId: "user-real-1",
+      riskLevel: "high",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      signingKey: SIGNING_KEY,
+    });
+    await approveRoute.handler(buildCtx({
+      actionId: "act-1",
+      body: { ownerApprovalToken: token, channelId: "discord:chat-1" },
+    }));
+    let thrown: unknown;
+    try {
+      await executeRoute.handler(buildCtx({
+        actionId: "act-1",
+        body: { channelId: "lark:chat-1", messageId: "msg-1" },
+      }));
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeDefined();
+    expect((thrown as { code?: string }).code).toBe(
+      "CHANNEL_HIGH_RISK_EXECUTE_CHANNEL_MISMATCH",
+    );
+  });
+
+  it("consumes the approval on successful execute so a second execute is refused", async () => {
+    // Fail-closed single-use of the owner approval. The owner-link
+    // contract is documented as single-use in
+    // `friday-channel-action-approval.ts` (line 31); a successful execute
+    // must consume the approval so a follow-up execute requires a fresh
+    // owner-signed token.
+    const { approveRoute, executeRoute, approvalStore } = getApproveAndExecuteHandlers();
+    const token = signFridayChannelActionApprovalToken({
+      actionId: "act-1",
+      channelId: "discord:chat-1",
+      principalId: "user-real-1",
+      riskLevel: "high",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      signingKey: SIGNING_KEY,
+    });
+    await approveRoute.handler(buildCtx({
+      actionId: "act-1",
+      body: { ownerApprovalToken: token, channelId: "discord:chat-1" },
+    }));
+    // First execute succeeds.
+    const first = await executeRoute.handler(buildCtx({
+      actionId: "act-1",
+      body: { channelId: "discord:chat-1", messageId: "msg-1" },
+    }));
+    expect((first as { actionId: string }).actionId).toBe("act-1");
+    // Store no longer carries the approval after a successful execute.
+    expect(await approvalStore.getApproval("act-1")).toBeNull();
+    // Second execute against the same actionId fails closed.
+    let thrown: unknown;
+    try {
+      await executeRoute.handler(buildCtx({
+        actionId: "act-1",
+        body: { channelId: "discord:chat-1", messageId: "msg-2" },
+      }));
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeDefined();
+    expect((thrown as { code?: string }).code).toBe(
+      "CHANNEL_HIGH_RISK_EXECUTE_NOT_APPROVED",
+    );
+  });
+
+  it("does not consume the approval when channelId validation fails", async () => {
+    // A mismatched-channel execute attempt is rejected before the
+    // consume step, so a legitimate execute against the original
+    // channelId remains valid.
+    const { approveRoute, executeRoute, approvalStore } = getApproveAndExecuteHandlers();
+    const token = signFridayChannelActionApprovalToken({
+      actionId: "act-1",
+      channelId: "discord:chat-1",
+      principalId: "user-real-1",
+      riskLevel: "high",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      signingKey: SIGNING_KEY,
+    });
+    await approveRoute.handler(buildCtx({
+      actionId: "act-1",
+      body: { ownerApprovalToken: token, channelId: "discord:chat-1" },
+    }));
+    let thrown: unknown;
+    try {
+      await executeRoute.handler(buildCtx({
+        actionId: "act-1",
+        body: { channelId: "lark:chat-1", messageId: "msg-1" },
+      }));
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeDefined();
+    expect((thrown as { code?: string }).code).toBe(
+      "CHANNEL_HIGH_RISK_EXECUTE_CHANNEL_MISMATCH",
+    );
+    // Approval is still present; a legitimate execute can use it.
+    const stored = await approvalStore.getApproval("act-1");
+    expect(stored?.actionId).toBe("act-1");
+    const legit = await executeRoute.handler(buildCtx({
+      actionId: "act-1",
+      body: { channelId: "discord:chat-1", messageId: "msg-1" },
+    }));
+    expect((legit as { actionId: string }).actionId).toBe("act-1");
+  });
+});
+
+describe("POST /v1/channels/actions/:actionId/owner-link", () => {
+  it("refuses source: \"channel\"", async () => {
+    const { linkRoute } = getOwnerLinkHandler();
+    let thrown: unknown;
+    try {
+      await linkRoute.handler(buildCtx({
+        actionId: "act-1",
+        body: { channelId: "discord:chat-1" },
+        headers: { "x-friday-principal-source": "channel" },
+      }));
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeDefined();
+    expect((thrown as { code?: string }).code).toBe(
+      FRIDAY_OWNER_SESSION_CHANNEL_ERROR_CODES.CHANNEL_HIGH_RISK_SOURCE_REFUSED,
+    );
+  });
+
+  it("refuses unauthenticated synthetic principal", async () => {
+    const { linkRoute } = getOwnerLinkHandler();
+    let thrown: unknown;
+    try {
+      await linkRoute.handler(buildCtx({
+        actionId: "act-1",
+        body: { channelId: "discord:chat-1" },
+        principal: createFridayDefaultPublicHttpPrincipal(),
+      }));
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeDefined();
+    expect((thrown as { code?: string }).code).toBe(
+      FRIDAY_OWNER_SESSION_CHANNEL_ERROR_CODES.BOUND_PRINCIPAL_REQUIRED,
+    );
+  });
+
+  it("requires channelId", async () => {
+    const { linkRoute } = getOwnerLinkHandler();
+    let thrown: unknown;
+    try {
+      await linkRoute.handler(buildCtx({
+        actionId: "act-1",
+        body: {},
+      }));
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeDefined();
+    expect((thrown as { code?: string }).code).toBe("VALIDATION_ERROR");
+  });
+
+  it("requires actionId path parameter", async () => {
+    const { linkRoute } = getOwnerLinkHandler();
+    let thrown: unknown;
+    try {
+      await linkRoute.handler({
+        params: {},
+        query: {},
+        body: { channelId: "discord:chat-1" },
+        headers: {},
+        principal: realPrincipal(),
+        requestId: "req-1",
+      } as never);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeDefined();
+    expect((thrown as { code?: string }).code).toBe("VALIDATION_ERROR");
+  });
+
+  it("mints a signed token that the approve route accepts (api source)", async () => {
+    const { linkRoute, approveRoute, approvalStore } = getOwnerLinkHandler();
+    const linkResponse = (await linkRoute.handler(buildCtx({
+      actionId: "act-1",
+      body: { channelId: "discord:chat-1" },
+    }))) as {
+      actionId: string;
+      channelId: string;
+      principalId: string;
+      ownerApprovalToken: string;
+      ownerApprovalPath: string;
+      ownerApprovalUrl: string;
+      issuedAt: string;
+      expiresAt: string;
+      issuedSource: string;
+    };
+    expect(linkResponse.actionId).toBe("act-1");
+    expect(linkResponse.channelId).toBe("discord:chat-1");
+    expect(linkResponse.ownerApprovalPath).toBe(
+      "/v1/channels/actions/act-1/owner-approve",
+    );
+    expect(linkResponse.ownerApprovalUrl).toBe(linkResponse.ownerApprovalPath);
+    expect(linkResponse.issuedSource).toBe("api");
+    expect(linkResponse.principalId).toBe("user-real-1");
+
+    // Token must verify independently against the same signing key.
+    const payload = verifyFridayChannelActionApprovalToken({
+      token: linkResponse.ownerApprovalToken,
+      actionId: "act-1",
+      channelId: "discord:chat-1",
+      principalId: "user-real-1",
+      nowIso: "2026-05-17T00:00:00.000Z",
+      signingKey: SIGNING_KEY,
+    });
+    expect(payload.expiresAt).toBe(linkResponse.expiresAt);
+
+    // Token routed through the approve handler completes the loop.
+    const approveResponse = (await approveRoute.handler(buildCtx({
+      actionId: "act-1",
+      body: {
+        ownerApprovalToken: linkResponse.ownerApprovalToken,
+        channelId: "discord:chat-1",
+      },
+    }))) as { approvedSource: string };
+    expect(approveResponse.approvedSource).toBe("api");
+    const stored = await approvalStore.getApproval("act-1");
+    expect(stored?.actionId).toBe("act-1");
+  });
+
+  it("issues a token with the session source label when called from session", async () => {
+    const { linkRoute } = getOwnerLinkHandler();
+    const response = (await linkRoute.handler(buildCtx({
+      actionId: "act-2",
+      body: { channelId: "lark:chat-2" },
+      headers: { "x-friday-principal-source": "session" },
+    }))) as { issuedSource: string };
+    expect(response.issuedSource).toBe("session");
+  });
+
+  it("clamps ttlSeconds to the allowed range", async () => {
+    const { linkRoute } = getOwnerLinkHandler();
+    const issuedAt = Date.parse("2026-05-17T00:00:00.000Z");
+    const tooSmall = (await linkRoute.handler(buildCtx({
+      actionId: "act-1",
+      body: { channelId: "discord:chat-1", ttlSeconds: 5 },
+    }))) as { expiresAt: string };
+    expect(Date.parse(tooSmall.expiresAt) - issuedAt).toBe(60_000);
+    const tooLarge = (await linkRoute.handler(buildCtx({
+      actionId: "act-2",
+      body: { channelId: "discord:chat-1", ttlSeconds: 99_999 },
+    }))) as { expiresAt: string };
+    expect(Date.parse(tooLarge.expiresAt) - issuedAt).toBe(3_600_000);
+    const inRange = (await linkRoute.handler(buildCtx({
+      actionId: "act-3",
+      body: { channelId: "discord:chat-1", ttlSeconds: 300 },
+    }))) as { expiresAt: string };
+    expect(Date.parse(inRange.expiresAt) - issuedAt).toBe(300_000);
+  });
+
+  it("rejects non-finite ttlSeconds", async () => {
+    const { linkRoute } = getOwnerLinkHandler();
+    let thrown: unknown;
+    try {
+      await linkRoute.handler(buildCtx({
+        actionId: "act-1",
+        body: { channelId: "discord:chat-1", ttlSeconds: "not-a-number" },
+      }));
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeDefined();
+    expect((thrown as { code?: string }).code).toBe("VALIDATION_ERROR");
+  });
+
+  it("does not place the signed token into the path field or URL field as a query string", async () => {
+    // Hardens the no-bearer-in-channel-text invariant: the route returns
+    // the token in a separate field from the path/URL; the path must
+    // never embed the token. The local Assistant carries the token
+    // separately into the approve POST body.
+    const { linkRoute } = getOwnerLinkHandler();
+    const response = (await linkRoute.handler(buildCtx({
+      actionId: "act-1",
+      body: { channelId: "discord:chat-1" },
+    }))) as {
+      ownerApprovalPath: string;
+      ownerApprovalUrl: string;
+      ownerApprovalToken: string;
+    };
+    expect(response.ownerApprovalPath).not.toContain(response.ownerApprovalToken);
+    expect(response.ownerApprovalUrl).not.toContain(response.ownerApprovalToken);
+    expect(response.ownerApprovalPath).not.toContain("token=");
+    expect(response.ownerApprovalUrl).not.toContain("token=");
+  });
+});

--- a/test/unit/api/http/routes/friday-setup-channels-status-route.test.ts
+++ b/test/unit/api/http/routes/friday-setup-channels-status-route.test.ts
@@ -1,0 +1,94 @@
+// Phase 14.5E module_28e Slice 6.2/6.8 — route handler test for
+// `GET /v1/setup/channels/status`. The route handler is invoked through
+// a lightweight in-memory wrapper so the test does not need to boot the
+// full HTTP server or open a SQLite file.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildFridayChannelSetupStatus,
+  type FridayChannelRegistryView,
+  type FridayChannelSetupStatusResponse,
+} from "#channels";
+
+// The setup status route is a thin pass-through to
+// buildFridayChannelSetupStatus. We test the projection here so the
+// route + helper contract is anchored.
+
+describe("GET /v1/setup/channels/status — projection", () => {
+  it("renders all v1 channels regardless of registry contents", () => {
+    const response: FridayChannelSetupStatusResponse = buildFridayChannelSetupStatus({
+      views: [],
+      processEnv: {},
+    });
+    expect(response.channels.map((row) => row.kind)).toEqual([
+      "discord",
+      "lark",
+      "telegram",
+    ]);
+  });
+
+  it("renders honest blocked_by_env for partially-set env", () => {
+    const response = buildFridayChannelSetupStatus({
+      processEnv: {
+        FRIDAY_DISCORD_BOT_TOKEN: "x",
+      },
+    });
+    const discord = response.channels.find((row) => row.kind === "discord");
+    expect(discord?.proofLabel).toBe("blocked_by_env");
+  });
+
+  it("renders configured when every env tuple is satisfied", () => {
+    const response = buildFridayChannelSetupStatus({
+      processEnv: {
+        FRIDAY_DISCORD_BOT_TOKEN: "t",
+        FRIDAY_DISCORD_SETUP_USER_ID: "u",
+        FRIDAY_DISCORD_GUILD_ID: "g",
+        FRIDAY_DISCORD_CHANNEL_ID: "c",
+        FRIDAY_LARK_APP_ID: "a",
+        FRIDAY_LARK_APP_SECRET: "s",
+        FRIDAY_LARK_VERIFICATION_TOKEN: "v",
+        FRIDAY_LARK_ENCRYPT_KEY: "k",
+        FRIDAY_LARK_TEST_CHAT_ID: "c",
+        FRIDAY_TELEGRAM_BOT_TOKEN: "t",
+        FRIDAY_TELEGRAM_TEST_CHAT_ID: "c",
+      },
+    });
+    for (const row of response.channels) {
+      expect(row.proofLabel).toBe("configured");
+    }
+  });
+
+  it("preserves registry blockedReason as user-facing blockedReason", () => {
+    const view: FridayChannelRegistryView = {
+      kind: "discord",
+      running: false,
+      status: "error",
+      health: {
+        state: "error",
+        restartCount: 1,
+        blockedReason: "start_failed",
+        credentialStatus: "invalid",
+        proofLabel: "blocked_by_env",
+      },
+      allowlist: {
+        hasAllowedUsers: false,
+        allowedUsersCount: 0,
+        hasAllowedChats: false,
+        allowedChatsCount: 0,
+      },
+    };
+    const response = buildFridayChannelSetupStatus({
+      views: [view],
+      processEnv: {
+        FRIDAY_DISCORD_BOT_TOKEN: "t",
+        FRIDAY_DISCORD_SETUP_USER_ID: "u",
+        FRIDAY_DISCORD_GUILD_ID: "g",
+        FRIDAY_DISCORD_CHANNEL_ID: "c",
+      },
+    });
+    const discord = response.channels.find((row) => row.kind === "discord");
+    expect(discord?.blockedReason).toBe("start_failed");
+    expect(discord?.proofLabel).toBe("blocked_by_env");
+  });
+});

--- a/test/unit/channels/friday-channel-canonical-command.test.ts
+++ b/test/unit/channels/friday-channel-canonical-command.test.ts
@@ -1,0 +1,144 @@
+// Phase 14.5E module_28e Slice 6.3 — channel canonical command + risk
+// preview routing. These tests verify the verb/target → riskLevel table
+// is deterministic, that low/medium commands route to in-channel
+// confirmation, and that high-risk commands route to the owner-link
+// request shape.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildFridayChannelDispatchReplyText,
+  buildFridayChannelOwnerLinkPath,
+  parseFridayChannelCanonicalCommand,
+  routeFridayChannelDispatch,
+  type FridayChannelCanonicalCommandParseInput,
+} from "#channels";
+
+function baseInput(text: string): FridayChannelCanonicalCommandParseInput {
+  return {
+    channelKind: "discord",
+    chatId: "chat-123",
+    chatType: "group",
+    senderId: "user-abc",
+    text,
+  };
+}
+
+describe("parseFridayChannelCanonicalCommand", () => {
+  it("returns null for empty input", () => {
+    expect(parseFridayChannelCanonicalCommand(baseInput(""))).toBeNull();
+    expect(parseFridayChannelCanonicalCommand(baseInput("   "))).toBeNull();
+  });
+
+  it("returns null for unrecognized commands", () => {
+    expect(parseFridayChannelCanonicalCommand(baseInput("hello world"))).toBeNull();
+    expect(parseFridayChannelCanonicalCommand(baseInput("friday hello"))).toBeNull();
+  });
+
+  it("maps low-risk verbs to riskLevel=low", () => {
+    expect(parseFridayChannelCanonicalCommand(baseInput("status"))?.riskLevel).toBe("low");
+    expect(parseFridayChannelCanonicalCommand(baseInput("friday health"))?.riskLevel).toBe("low");
+    expect(parseFridayChannelCanonicalCommand(baseInput("diagnose"))?.riskLevel).toBe("low");
+  });
+
+  it("maps preview-style verbs to riskLevel=medium", () => {
+    expect(parseFridayChannelCanonicalCommand(baseInput("preview repair"))?.riskLevel).toBe("medium");
+    expect(parseFridayChannelCanonicalCommand(baseInput("Friday Repair Preview"))?.riskLevel).toBe("medium");
+    expect(parseFridayChannelCanonicalCommand(baseInput("fix preview"))?.riskLevel).toBe("medium");
+  });
+
+  it("maps execute-style and rotation verbs to riskLevel=high", () => {
+    expect(parseFridayChannelCanonicalCommand(baseInput("apply repair"))?.riskLevel).toBe("high");
+    expect(parseFridayChannelCanonicalCommand(baseInput("rollback"))?.riskLevel).toBe("high");
+    expect(parseFridayChannelCanonicalCommand(baseInput("rotate credential"))?.riskLevel).toBe("high");
+    expect(parseFridayChannelCanonicalCommand(baseInput("approve action-xyz"))?.riskLevel).toBe("high");
+    expect(parseFridayChannelCanonicalCommand(baseInput("execute action-xyz"))?.riskLevel).toBe("high");
+  });
+
+  it("yields the same command for the same input (deterministic)", () => {
+    const first = parseFridayChannelCanonicalCommand(baseInput("friday status"));
+    const second = parseFridayChannelCanonicalCommand(baseInput("friday status"));
+    expect(first).toEqual(second);
+  });
+
+  it("captures the trailing actionId for approve/execute verbs", () => {
+    const approve = parseFridayChannelCanonicalCommand(baseInput("approve action-9999"));
+    expect(approve?.args.actionId).toBe("action-9999");
+    const execute = parseFridayChannelCanonicalCommand(baseInput("execute action-9999"));
+    expect(execute?.args.actionId).toBe("action-9999");
+  });
+});
+
+describe("routeFridayChannelDispatch", () => {
+  it("returns no_match for unrecognized text", () => {
+    expect(routeFridayChannelDispatch(baseInput("hello"))).toEqual({ kind: "no_match" });
+  });
+
+  it("routes low/medium risk to in-channel risk preview", () => {
+    const lowOutcome = routeFridayChannelDispatch(baseInput("status"));
+    expect(lowOutcome.kind).toBe("risk_preview");
+    if (lowOutcome.kind === "risk_preview") {
+      expect(lowOutcome.preview.confirmation).toBe("in_channel");
+      expect(lowOutcome.preview.command.riskLevel).toBe("low");
+    }
+    const mediumOutcome = routeFridayChannelDispatch(baseInput("preview repair"));
+    expect(mediumOutcome.kind).toBe("risk_preview");
+    if (mediumOutcome.kind === "risk_preview") {
+      expect(mediumOutcome.preview.confirmation).toBe("in_channel");
+      expect(mediumOutcome.preview.command.riskLevel).toBe("medium");
+    }
+  });
+
+  it("routes high risk to an owner-link request, never to in-channel confirmation", () => {
+    const highOutcome = routeFridayChannelDispatch(baseInput("apply repair"));
+    expect(highOutcome.kind).toBe("owner_link_required");
+    if (highOutcome.kind === "owner_link_required") {
+      expect(highOutcome.request.riskLevel).toBe("high");
+      expect(highOutcome.request.ownerLinkPath.startsWith("/v1/channels/actions/")).toBe(true);
+      expect(highOutcome.request.ownerLinkPath.endsWith("/owner-approve")).toBe(true);
+    }
+  });
+
+  it("re-uses approve/execute actionId arg in the owner-link path", () => {
+    const outcome = routeFridayChannelDispatch(baseInput("approve action-9999"));
+    expect(outcome.kind).toBe("owner_link_required");
+    if (outcome.kind === "owner_link_required") {
+      expect(outcome.request.actionId).toBe("action-9999");
+      expect(outcome.request.ownerLinkPath).toBe(buildFridayChannelOwnerLinkPath("action-9999"));
+    }
+  });
+});
+
+describe("buildFridayChannelDispatchReplyText", () => {
+  it("returns null for no_match outcomes", () => {
+    expect(
+      buildFridayChannelDispatchReplyText({ kind: "no_match" }),
+    ).toBeNull();
+  });
+
+  it("renders the low/medium preview text with the no-auto-execute note", () => {
+    const outcome = routeFridayChannelDispatch(baseInput("status"));
+    expect(outcome.kind).toBe("risk_preview");
+    const reply = buildFridayChannelDispatchReplyText(outcome);
+    expect(reply).toContain("Friday canonical command: status runtime");
+    expect(reply).toContain("Preview only");
+    expect(reply).toContain("Friday will not auto-execute");
+    // Owner-link must never appear in a low/medium reply.
+    expect(reply).not.toContain("/v1/channels/actions/");
+    expect(reply).not.toContain("owner-approve");
+  });
+
+  it("renders the high-risk preview text with the owner-link path and no execution promise", () => {
+    const outcome = routeFridayChannelDispatch(baseInput("apply repair"));
+    expect(outcome.kind).toBe("owner_link_required");
+    const reply = buildFridayChannelDispatchReplyText(outcome);
+    expect(reply).toContain("[risk=high]");
+    expect(reply).toContain("owner-signed approval");
+    expect(reply).toContain("/v1/channels/actions/");
+    expect(reply).toContain("/owner-approve");
+    // The reply must not advertise auto-execute or include any token
+    // material that would let the channel approve the action.
+    expect(reply?.toLowerCase()).not.toContain("token");
+    expect(reply?.toLowerCase()).not.toContain("auto-execute");
+  });
+});

--- a/test/unit/channels/friday-channel-outbound-receipt.test.ts
+++ b/test/unit/channels/friday-channel-outbound-receipt.test.ts
@@ -1,0 +1,64 @@
+// Phase 14.5E module_28e Slice 6.5 — channel-triggered closeout receipt
+// helper. The helper does NOT modify the closeout-gate synthesizer; it
+// just produces a deterministic, user-facing `nonReversibleReason`
+// string for outbound channel sends. The rollback class for
+// `channel_event` evidence refs continues to come from the Phase 14.5D
+// registry; this test asserts the helper's class field reads from the
+// registry rather than hard-coding the value.
+
+import { describe, expect, it } from "vitest";
+
+import { buildFridayChannelOutboundReceiptSummary } from "#channels";
+import { FRIDAY_TASK_WORKFLOW_ROLLBACK_CLASS_BY_REF_SOURCE } from "../../../src/task-workflows/friday-task-workflow.types.js";
+
+describe("buildFridayChannelOutboundReceiptSummary", () => {
+  it("returns rollbackClass non_reversible_external for channel sends", () => {
+    const summary = buildFridayChannelOutboundReceiptSummary({
+      channelKind: "discord",
+      chatId: "chat-1",
+      messageId: "msg-1",
+    });
+    expect(summary.rollbackClass).toBe("non_reversible_external");
+    expect(summary.evidenceRefSource).toBe("channel_event");
+  });
+
+  it("includes the channelKind:chatId composite in the nonReversibleReason", () => {
+    const summary = buildFridayChannelOutboundReceiptSummary({
+      channelKind: "telegram",
+      chatId: "chat-9999",
+      messageId: "msg-1",
+    });
+    expect(summary.nonReversibleReason).toBe(
+      "Channel outbound message delivered to telegram:chat-9999; external delivery not reversible.",
+    );
+  });
+
+  it("delegates rollback class to the Phase 14.5D registry", () => {
+    const summary = buildFridayChannelOutboundReceiptSummary({
+      channelKind: "lark",
+      chatId: "chat-1",
+      messageId: "msg-1",
+    });
+    expect(summary.rollbackClass).toBe(
+      FRIDAY_TASK_WORKFLOW_ROLLBACK_CLASS_BY_REF_SOURCE.channel_event,
+    );
+  });
+
+  it("rejects empty channelKind, chatId, or messageId", () => {
+    expect(() => buildFridayChannelOutboundReceiptSummary({
+      channelKind: "",
+      chatId: "chat-1",
+      messageId: "msg-1",
+    })).toThrow();
+    expect(() => buildFridayChannelOutboundReceiptSummary({
+      channelKind: "discord",
+      chatId: "",
+      messageId: "msg-1",
+    })).toThrow();
+    expect(() => buildFridayChannelOutboundReceiptSummary({
+      channelKind: "discord",
+      chatId: "chat-1",
+      messageId: "",
+    })).toThrow();
+  });
+});

--- a/test/unit/channels/friday-channel-proof-label.test.ts
+++ b/test/unit/channels/friday-channel-proof-label.test.ts
@@ -1,0 +1,138 @@
+// Phase 14.5E module_28e Slice 6.1 — per-channel proof label derivation.
+// These tests verify the (kind, credentialStatus, blockedReason,
+// envMissingVars) → proofLabel mapping is exhaustive over v1 channels
+// and correctly classifies non-v1 channels as `unsupported`. No mocks
+// of the channel registry or external transports are used.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  deriveFridayChannelProofLabel,
+  isFridayChannelV1ProofKind,
+  type FridayChannelCredentialStatus,
+} from "#channels";
+
+describe("deriveFridayChannelProofLabel", () => {
+  const v1Kinds = ["discord", "lark", "feishu", "telegram"] as const;
+
+  for (const kind of v1Kinds) {
+    it(`returns "configured" when ${kind} env tuple is fully present`, () => {
+      expect(
+        deriveFridayChannelProofLabel({
+          kind,
+          credentialStatus: "unknown",
+          envMissingVars: [],
+          envRequiredVars: ["A", "B"],
+        }),
+      ).toBe("configured");
+    });
+
+    it(`returns "blocked_by_env" when ${kind} env tuple is fully present but adapter rejects credentials`, () => {
+      expect(
+        deriveFridayChannelProofLabel({
+          kind,
+          credentialStatus: "invalid",
+          envMissingVars: [],
+          envRequiredVars: ["A", "B"],
+        }),
+      ).toBe("blocked_by_env");
+    });
+
+    it(`returns "blocked_by_env" when ${kind} adapter is invalid and no env declared`, () => {
+      expect(
+        deriveFridayChannelProofLabel({
+          kind,
+          credentialStatus: "invalid",
+        }),
+      ).toBe("blocked_by_env");
+    });
+
+    it(`returns "blocked_by_env" when ${kind} adapter is blocked by a reason and no env declared`, () => {
+      expect(
+        deriveFridayChannelProofLabel({
+          kind,
+          credentialStatus: "unknown",
+          blockedReason: "start_failed",
+        }),
+      ).toBe("blocked_by_env");
+    });
+
+    it(`returns "not_configured" when ${kind} has no credentials and full env tuple is missing`, () => {
+      expect(
+        deriveFridayChannelProofLabel({
+          kind,
+          credentialStatus: "missing",
+          envMissingVars: ["A", "B"],
+          envRequiredVars: ["A", "B"],
+        }),
+      ).toBe("not_configured");
+    });
+
+    it(`returns "blocked_by_env" when ${kind} env tuple is partially missing`, () => {
+      expect(
+        deriveFridayChannelProofLabel({
+          kind,
+          credentialStatus: "missing",
+          envMissingVars: ["B"],
+          envRequiredVars: ["A", "B"],
+        }),
+      ).toBe("blocked_by_env");
+    });
+  }
+
+  it("returns \"unsupported\" for non-v1 channel kinds even with full credentials", () => {
+    for (const nonV1 of ["slack", "webchat", "whatsapp", "line", "qq", "signal", "irc"]) {
+      expect(
+        deriveFridayChannelProofLabel({
+          kind: nonV1,
+          credentialStatus: "configured",
+          envMissingVars: [],
+          envRequiredVars: ["A"],
+        }),
+      ).toBe("unsupported");
+    }
+  });
+
+  it("does not let Discord credentials satisfy Lark/Feishu or Telegram", () => {
+    // Per Codex Stage 2 prompt: a passing Discord scenario is never proof
+    // for any other channel. The helper takes one kind at a time; we
+    // assert that the same input shape yields per-kind labels independently.
+    const credentialStatus: FridayChannelCredentialStatus = "configured";
+    const discord = deriveFridayChannelProofLabel({
+      kind: "discord",
+      credentialStatus,
+      envMissingVars: [],
+      envRequiredVars: ["A", "B"],
+    });
+    const larkBlocked = deriveFridayChannelProofLabel({
+      kind: "lark",
+      credentialStatus: "missing",
+      envMissingVars: ["FRIDAY_LARK_APP_ID"],
+      envRequiredVars: ["FRIDAY_LARK_APP_ID", "FRIDAY_LARK_APP_SECRET"],
+    });
+    const telegramBlocked = deriveFridayChannelProofLabel({
+      kind: "telegram",
+      credentialStatus: "missing",
+      envMissingVars: ["FRIDAY_TELEGRAM_BOT_TOKEN"],
+      envRequiredVars: ["FRIDAY_TELEGRAM_BOT_TOKEN", "FRIDAY_TELEGRAM_TEST_CHAT_ID"],
+    });
+    expect(discord).toBe("configured");
+    expect(larkBlocked).toBe("blocked_by_env");
+    expect(telegramBlocked).toBe("blocked_by_env");
+  });
+});
+
+describe("isFridayChannelV1ProofKind", () => {
+  it("returns true for the four v1 channel kinds", () => {
+    expect(isFridayChannelV1ProofKind("discord")).toBe(true);
+    expect(isFridayChannelV1ProofKind("lark")).toBe(true);
+    expect(isFridayChannelV1ProofKind("feishu")).toBe(true);
+    expect(isFridayChannelV1ProofKind("telegram")).toBe(true);
+  });
+
+  it("returns false for non-v1 channel kinds", () => {
+    for (const kind of ["slack", "webchat", "whatsapp", "line", "qq", "signal", "irc"]) {
+      expect(isFridayChannelV1ProofKind(kind)).toBe(false);
+    }
+  });
+});

--- a/test/unit/channels/friday-channel-setup-status.test.ts
+++ b/test/unit/channels/friday-channel-setup-status.test.ts
@@ -1,0 +1,218 @@
+// Phase 14.5E module_28e Slice 6.2 — `GET /v1/setup/channels/status`
+// payload composition. These tests verify the per-channel rows surface
+// honest proof labels under (a) no env, (b) Discord-only env, and
+// (c) all-three env. No real channel adapter is constructed; the
+// registry views are plain objects.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildFridayChannelSetupStatus,
+  FRIDAY_CHANNEL_V1_SETUP_DESCRIPTORS,
+  type FridayChannelRegistryView,
+} from "#channels";
+
+function discordView(overrides: Partial<FridayChannelRegistryView> = {}): FridayChannelRegistryView {
+  return {
+    kind: "discord",
+    running: false,
+    status: "disconnected",
+    health: {
+      state: "disconnected",
+      restartCount: 0,
+      credentialStatus: "unknown",
+      proofLabel: "not_configured",
+    },
+    allowlist: {
+      hasAllowedUsers: false,
+      allowedUsersCount: 0,
+      hasAllowedChats: false,
+      allowedChatsCount: 0,
+    },
+    ...overrides,
+  };
+}
+
+describe("buildFridayChannelSetupStatus", () => {
+  it("returns one row per v1 channel even when no env or registry is provided", () => {
+    const status = buildFridayChannelSetupStatus({ processEnv: {} });
+    expect(status.channels.map((row) => row.kind)).toEqual([
+      "discord",
+      "lark",
+      "telegram",
+    ]);
+    for (const row of status.channels) {
+      expect(row.proofLabel).toBe("not_configured");
+    }
+  });
+
+  it("labels Discord as configured when its env tuple is complete and registry is healthy", () => {
+    const env: NodeJS.ProcessEnv = {
+      FRIDAY_DISCORD_BOT_TOKEN: "t",
+      FRIDAY_DISCORD_SETUP_USER_ID: "u",
+      FRIDAY_DISCORD_GUILD_ID: "g",
+      FRIDAY_DISCORD_CHANNEL_ID: "c",
+    };
+    const status = buildFridayChannelSetupStatus({
+      views: [discordView({ health: { ...discordView().health, credentialStatus: "configured", proofLabel: "configured" } })],
+      processEnv: env,
+    });
+    const discord = status.channels.find((row) => row.kind === "discord");
+    expect(discord?.proofLabel).toBe("configured");
+    expect(discord?.missingEnvVars).toEqual([]);
+  });
+
+  it("does not let Discord credentials satisfy Lark or Telegram", () => {
+    const env: NodeJS.ProcessEnv = {
+      FRIDAY_DISCORD_BOT_TOKEN: "t",
+      FRIDAY_DISCORD_SETUP_USER_ID: "u",
+      FRIDAY_DISCORD_GUILD_ID: "g",
+      FRIDAY_DISCORD_CHANNEL_ID: "c",
+    };
+    const status = buildFridayChannelSetupStatus({
+      views: [discordView({ health: { ...discordView().health, credentialStatus: "configured", proofLabel: "configured" } })],
+      processEnv: env,
+    });
+    const lark = status.channels.find((row) => row.kind === "lark");
+    const telegram = status.channels.find((row) => row.kind === "telegram");
+    expect(lark?.proofLabel).toBe("not_configured");
+    expect(lark?.missingEnvVars.length).toBeGreaterThan(0);
+    expect(telegram?.proofLabel).toBe("not_configured");
+    expect(telegram?.missingEnvVars.length).toBeGreaterThan(0);
+  });
+
+  it("labels Lark as blocked_by_env when its env tuple is partially present", () => {
+    const env: NodeJS.ProcessEnv = {
+      FRIDAY_LARK_APP_ID: "a",
+      FRIDAY_LARK_APP_SECRET: "s",
+      // FRIDAY_LARK_VERIFICATION_TOKEN, FRIDAY_LARK_ENCRYPT_KEY, FRIDAY_LARK_TEST_CHAT_ID missing
+    };
+    const status = buildFridayChannelSetupStatus({ processEnv: env });
+    const lark = status.channels.find((row) => row.kind === "lark");
+    expect(lark?.proofLabel).toBe("blocked_by_env");
+    expect(lark?.missingEnvVars).toEqual([
+      "FRIDAY_LARK_VERIFICATION_TOKEN",
+      "FRIDAY_LARK_ENCRYPT_KEY",
+      "FRIDAY_LARK_TEST_CHAT_ID",
+    ]);
+  });
+
+  it("labels Telegram as configured when env tuple is complete", () => {
+    const env: NodeJS.ProcessEnv = {
+      FRIDAY_TELEGRAM_BOT_TOKEN: "t",
+      FRIDAY_TELEGRAM_TEST_CHAT_ID: "c",
+    };
+    const status = buildFridayChannelSetupStatus({ processEnv: env });
+    const telegram = status.channels.find((row) => row.kind === "telegram");
+    expect(telegram?.proofLabel).toBe("configured");
+  });
+
+  it("classifies non-v1 channels in registry views as unsupported", () => {
+    const slackView: FridayChannelRegistryView = {
+      ...discordView(),
+      kind: "slack",
+    };
+    const status = buildFridayChannelSetupStatus({
+      views: [slackView],
+      processEnv: {},
+    });
+    const slack = status.channels.find((row) => row.kind === "slack");
+    expect(slack?.proofLabel).toBe("unsupported");
+  });
+
+  it("treats a Feishu registry view as the Lark/Feishu v1 row, not as an extra unsupported row", () => {
+    // The Lark plugin rewrites its own `kind` to "feishu" at runtime when
+    // `useFeishu: true` is configured. The setup status surface must not
+    // emit a second `unsupported` row for that case — the v1 row carries
+    // both kinds.
+    const feishuView: FridayChannelRegistryView = {
+      ...discordView(),
+      kind: "feishu",
+      running: true,
+      status: "connected",
+      health: {
+        state: "connected",
+        restartCount: 0,
+        credentialStatus: "configured",
+        proofLabel: "configured",
+      },
+    };
+    const env: NodeJS.ProcessEnv = {
+      FRIDAY_LARK_APP_ID: "a",
+      FRIDAY_LARK_APP_SECRET: "s",
+      FRIDAY_LARK_VERIFICATION_TOKEN: "v",
+      FRIDAY_LARK_ENCRYPT_KEY: "k",
+      FRIDAY_LARK_TEST_CHAT_ID: "c",
+    };
+    const status = buildFridayChannelSetupStatus({
+      views: [feishuView],
+      processEnv: env,
+    });
+    // The v1 row order is stable: discord, lark, telegram; no extra
+    // unsupported row appears for the Feishu view.
+    expect(status.channels.map((row) => row.kind)).toEqual([
+      "discord",
+      "lark",
+      "telegram",
+    ]);
+    const lark = status.channels.find((row) => row.kind === "lark");
+    expect(lark?.proofLabel).toBe("configured");
+    expect(lark?.credentialStatus).toBe("configured");
+    expect(lark?.missingEnvVars).toEqual([]);
+  });
+
+  it("uses the Lark registry view when present and the Feishu view when only Feishu is registered", () => {
+    // When the lark-kind view is present, it backs the v1 row.
+    const larkView: FridayChannelRegistryView = {
+      ...discordView(),
+      kind: "lark",
+      health: {
+        state: "disconnected",
+        restartCount: 0,
+        credentialStatus: "invalid",
+        blockedReason: "lark_auth_failed",
+        proofLabel: "blocked_by_env",
+      },
+    };
+    const statusWithLark = buildFridayChannelSetupStatus({
+      views: [larkView],
+      processEnv: {},
+    });
+    const larkRow = statusWithLark.channels.find((row) => row.kind === "lark");
+    expect(larkRow?.proofLabel).toBe("blocked_by_env");
+    expect(larkRow?.blockedReason).toBe("lark_auth_failed");
+
+    // When only the feishu-kind view is present, the same v1 row picks
+    // it up — there is no parallel unsupported row.
+    const feishuOnly: FridayChannelRegistryView = {
+      ...discordView(),
+      kind: "feishu",
+      health: {
+        state: "disconnected",
+        restartCount: 0,
+        credentialStatus: "invalid",
+        blockedReason: "feishu_auth_failed",
+        proofLabel: "blocked_by_env",
+      },
+    };
+    const statusWithFeishu = buildFridayChannelSetupStatus({
+      views: [feishuOnly],
+      processEnv: {},
+    });
+    const feishuRow = statusWithFeishu.channels.find((row) => row.kind === "lark");
+    expect(feishuRow?.proofLabel).toBe("blocked_by_env");
+    expect(feishuRow?.blockedReason).toBe("feishu_auth_failed");
+    expect(
+      statusWithFeishu.channels.some((row) => row.kind === "feishu"),
+    ).toBe(false);
+  });
+
+  it("exposes a stable required env list per v1 channel", () => {
+    const requiredVars = new Map(
+      FRIDAY_CHANNEL_V1_SETUP_DESCRIPTORS.map((descriptor) => [descriptor.kind, descriptor.requiredEnvVars]),
+    );
+    expect(requiredVars.get("discord")).toContain("FRIDAY_DISCORD_BOT_TOKEN");
+    expect(requiredVars.get("lark")).toContain("FRIDAY_LARK_APP_ID");
+    expect(requiredVars.get("telegram")).toContain("FRIDAY_TELEGRAM_BOT_TOKEN");
+  });
+});

--- a/test/unit/security/friday-channel-action-approval.test.ts
+++ b/test/unit/security/friday-channel-action-approval.test.ts
@@ -1,0 +1,236 @@
+// Phase 14.5E module_28e Slice 6.4 — owner-signed approval token verifier
+// and `channel.action.high_risk.approve` gate. These tests cover:
+//   - refusal of `source: "channel"` outright;
+//   - acceptance with `source: "api"` and a valid owner-signed token;
+//   - acceptance with `source: "session"` and a valid owner-signed token;
+//   - refusal on expired token;
+//   - refusal on context mismatch (actionId/channelId/principalId);
+//   - refusal on tampered signature.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  FRIDAY_OWNER_SESSION_CHANNEL_ERROR_CODES,
+  assertBoundPrincipalForOperation,
+} from "../../../src/security/friday-owner-session-channel-capability.js";
+import {
+  FRIDAY_CHANNEL_ACTION_APPROVAL_ERROR_CODES,
+  signFridayChannelActionApprovalToken,
+  verifyFridayChannelActionApprovalToken,
+} from "../../../src/security/friday-channel-action-approval.js";
+import type { FridayAuthPrincipal } from "../../../src/api/model/friday-api-auth.types.js";
+
+function realPrincipal(overrides: Partial<FridayAuthPrincipal> = {}): FridayAuthPrincipal {
+  return {
+    principalType: "user",
+    principalId: "user-real-1",
+    tenantId: "tenant-1",
+    userId: "11111111-1111-1111-1111-111111111111",
+    role: "admin",
+    scopes: ["agent.write"],
+    tokenId: "22222222-2222-2222-2222-222222222222",
+    tokenKind: "access",
+    issuedAt: "2026-05-17T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+const SIGNING_KEY = "phase-14-5e-test-signing-key";
+
+describe("channel.action.high_risk gate", () => {
+  it("refuses source: \"channel\" outright for the approve operation", () => {
+    let thrown: unknown;
+    try {
+      assertBoundPrincipalForOperation(
+        realPrincipal(),
+        "channel.action.high_risk.approve",
+        "channel",
+      );
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeDefined();
+    expect((thrown as { code?: string }).code).toBe(
+      FRIDAY_OWNER_SESSION_CHANNEL_ERROR_CODES.CHANNEL_HIGH_RISK_SOURCE_REFUSED,
+    );
+  });
+
+  it("refuses source: \"channel\" outright for the execute operation", () => {
+    let thrown: unknown;
+    try {
+      assertBoundPrincipalForOperation(
+        realPrincipal(),
+        "channel.action.high_risk.execute",
+        "channel",
+      );
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeDefined();
+    expect((thrown as { code?: string }).code).toBe(
+      FRIDAY_OWNER_SESSION_CHANNEL_ERROR_CODES.CHANNEL_HIGH_RISK_SOURCE_REFUSED,
+    );
+  });
+
+  it("accepts source: \"api\" with a bound principal", () => {
+    const bound = assertBoundPrincipalForOperation(
+      realPrincipal(),
+      "channel.action.high_risk.approve",
+      "api",
+    );
+    expect(bound.source).toBe("api");
+    expect(bound.principalId).toBe("user-real-1");
+  });
+
+  it("accepts source: \"session\" with a bound principal", () => {
+    const bound = assertBoundPrincipalForOperation(
+      realPrincipal(),
+      "channel.action.high_risk.approve",
+      "session",
+    );
+    expect(bound.source).toBe("session");
+  });
+
+  it("does not change the gate for unrelated operations from source: \"channel\"", () => {
+    const bound = assertBoundPrincipalForOperation(
+      realPrincipal(),
+      "task.workflow.evidence.attach",
+      "channel",
+    );
+    expect(bound.source).toBe("channel");
+  });
+});
+
+describe("verifyFridayChannelActionApprovalToken", () => {
+  const expiresAt = "2099-01-01T00:00:00.000Z";
+  const baseTokenInput = {
+    actionId: "act-1",
+    channelId: "discord:chat-1",
+    principalId: "user-real-1",
+    riskLevel: "high" as const,
+    expiresAt,
+    signingKey: SIGNING_KEY,
+  };
+
+  it("verifies a freshly signed token end-to-end", () => {
+    const token = signFridayChannelActionApprovalToken(baseTokenInput);
+    const payload = verifyFridayChannelActionApprovalToken({
+      token,
+      actionId: "act-1",
+      channelId: "discord:chat-1",
+      principalId: "user-real-1",
+      nowIso: "2026-05-17T00:00:00.000Z",
+      signingKey: SIGNING_KEY,
+    });
+    expect(payload.actionId).toBe("act-1");
+    expect(payload.channelId).toBe("discord:chat-1");
+    expect(payload.principalId).toBe("user-real-1");
+    expect(payload.expiresAt).toBe(expiresAt);
+  });
+
+  it("refuses on expired timestamp", () => {
+    const token = signFridayChannelActionApprovalToken({
+      ...baseTokenInput,
+      expiresAt: "2020-01-01T00:00:00.000Z",
+    });
+    let thrown: unknown;
+    try {
+      verifyFridayChannelActionApprovalToken({
+        token,
+        actionId: "act-1",
+        channelId: "discord:chat-1",
+        principalId: "user-real-1",
+        nowIso: "2026-05-17T00:00:00.000Z",
+        signingKey: SIGNING_KEY,
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect((thrown as { code?: string }).code).toBe(
+      FRIDAY_CHANNEL_ACTION_APPROVAL_ERROR_CODES.TOKEN_EXPIRED,
+    );
+  });
+
+  it("refuses on actionId mismatch", () => {
+    const token = signFridayChannelActionApprovalToken(baseTokenInput);
+    let thrown: unknown;
+    try {
+      verifyFridayChannelActionApprovalToken({
+        token,
+        actionId: "act-other",
+        channelId: "discord:chat-1",
+        principalId: "user-real-1",
+        nowIso: "2026-05-17T00:00:00.000Z",
+        signingKey: SIGNING_KEY,
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect((thrown as { code?: string }).code).toBe(
+      FRIDAY_CHANNEL_ACTION_APPROVAL_ERROR_CODES.TOKEN_CONTEXT_MISMATCH,
+    );
+  });
+
+  it("refuses on channelId mismatch", () => {
+    const token = signFridayChannelActionApprovalToken(baseTokenInput);
+    let thrown: unknown;
+    try {
+      verifyFridayChannelActionApprovalToken({
+        token,
+        actionId: "act-1",
+        channelId: "telegram:chat-1",
+        principalId: "user-real-1",
+        nowIso: "2026-05-17T00:00:00.000Z",
+        signingKey: SIGNING_KEY,
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect((thrown as { code?: string }).code).toBe(
+      FRIDAY_CHANNEL_ACTION_APPROVAL_ERROR_CODES.TOKEN_CONTEXT_MISMATCH,
+    );
+  });
+
+  it("refuses on tampered signature", () => {
+    const token = signFridayChannelActionApprovalToken(baseTokenInput);
+    const [payload, signature] = token.split(".");
+    expect(payload).toBeDefined();
+    expect(signature).toBeDefined();
+    const tampered = `${payload}.${signature.replace(/[0-9a-f]/, (c) => (c === "0" ? "1" : "0"))}`;
+    let thrown: unknown;
+    try {
+      verifyFridayChannelActionApprovalToken({
+        token: tampered,
+        actionId: "act-1",
+        channelId: "discord:chat-1",
+        principalId: "user-real-1",
+        nowIso: "2026-05-17T00:00:00.000Z",
+        signingKey: SIGNING_KEY,
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect((thrown as { code?: string }).code).toBe(
+      FRIDAY_CHANNEL_ACTION_APPROVAL_ERROR_CODES.TOKEN_SIGNATURE_INVALID,
+    );
+  });
+
+  it("refuses tokens with malformed wire format", () => {
+    let thrown: unknown;
+    try {
+      verifyFridayChannelActionApprovalToken({
+        token: "not-a-token",
+        actionId: "act-1",
+        channelId: "discord:chat-1",
+        principalId: "user-real-1",
+        nowIso: "2026-05-17T00:00:00.000Z",
+        signingKey: SIGNING_KEY,
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect((thrown as { code?: string }).code).toBe(
+      FRIDAY_CHANNEL_ACTION_APPROVAL_ERROR_CODES.TOKEN_MALFORMED,
+    );
+  });
+});

--- a/test/unit/validation/real-world/env-truth-per-channel.test.ts
+++ b/test/unit/validation/real-world/env-truth-per-channel.test.ts
@@ -1,0 +1,164 @@
+// Phase 14.5E module_28e Slice 6.7 — per-channel env-truth readers.
+// These tests verify the per-channel env tuple readers map each (env
+// state) → (status) tuple correctly for Discord, Lark/Feishu, and
+// Telegram, and that the aggregate externalChannels prerequisite is
+// `ready` only when every declared v1 channel's env tuple is satisfied.
+
+import { describe, expect, it } from "vitest";
+import {
+  readDiscordChannelsStatus,
+  readLarkChannelsStatus,
+  readTelegramChannelsStatus,
+  collectEnvironmentTruth,
+} from "../../../../validation/real-world/lib/env-truth.mjs";
+
+describe("readDiscordChannelsStatus", () => {
+  it("returns not_configured when no env is set", () => {
+    const status = readDiscordChannelsStatus({});
+    expect(status.status).toBe("not_configured");
+    expect(status.missingEnv.length).toBe(status.requiredEnv.length);
+  });
+
+  it("returns blocked_by_env when only some env vars are set", () => {
+    const status = readDiscordChannelsStatus({
+      FRIDAY_DISCORD_BOT_TOKEN: "x",
+    });
+    expect(status.status).toBe("blocked_by_env");
+    expect(status.missingEnv).toEqual([
+      "FRIDAY_DISCORD_SETUP_USER_ID",
+      "FRIDAY_DISCORD_GUILD_ID",
+      "FRIDAY_DISCORD_CHANNEL_ID",
+    ]);
+  });
+
+  it("returns configured when every env var is set", () => {
+    const status = readDiscordChannelsStatus({
+      FRIDAY_DISCORD_BOT_TOKEN: "t",
+      FRIDAY_DISCORD_SETUP_USER_ID: "u",
+      FRIDAY_DISCORD_GUILD_ID: "g",
+      FRIDAY_DISCORD_CHANNEL_ID: "c",
+    });
+    expect(status.status).toBe("configured");
+    expect(status.missingEnv).toEqual([]);
+  });
+});
+
+describe("readLarkChannelsStatus", () => {
+  it("returns not_configured when no env is set", () => {
+    const status = readLarkChannelsStatus({});
+    expect(status.status).toBe("not_configured");
+    expect(status.requiredEnv).toEqual([
+      "FRIDAY_LARK_APP_ID",
+      "FRIDAY_LARK_APP_SECRET",
+      "FRIDAY_LARK_VERIFICATION_TOKEN",
+      "FRIDAY_LARK_ENCRYPT_KEY",
+      "FRIDAY_LARK_TEST_CHAT_ID",
+    ]);
+  });
+
+  it("returns blocked_by_env when env is partially complete", () => {
+    const status = readLarkChannelsStatus({
+      FRIDAY_LARK_APP_ID: "a",
+      FRIDAY_LARK_APP_SECRET: "s",
+    });
+    expect(status.status).toBe("blocked_by_env");
+  });
+
+  it("returns configured when every env var is set", () => {
+    const status = readLarkChannelsStatus({
+      FRIDAY_LARK_APP_ID: "a",
+      FRIDAY_LARK_APP_SECRET: "s",
+      FRIDAY_LARK_VERIFICATION_TOKEN: "v",
+      FRIDAY_LARK_ENCRYPT_KEY: "k",
+      FRIDAY_LARK_TEST_CHAT_ID: "c",
+    });
+    expect(status.status).toBe("configured");
+  });
+});
+
+describe("readTelegramChannelsStatus", () => {
+  it("returns not_configured when no env is set", () => {
+    const status = readTelegramChannelsStatus({});
+    expect(status.status).toBe("not_configured");
+    expect(status.requiredEnv).toEqual([
+      "FRIDAY_TELEGRAM_BOT_TOKEN",
+      "FRIDAY_TELEGRAM_TEST_CHAT_ID",
+    ]);
+  });
+
+  it("returns configured when every env var is set", () => {
+    const status = readTelegramChannelsStatus({
+      FRIDAY_TELEGRAM_BOT_TOKEN: "t",
+      FRIDAY_TELEGRAM_TEST_CHAT_ID: "c",
+    });
+    expect(status.status).toBe("configured");
+  });
+});
+
+describe("collectEnvironmentTruth (externalChannels aggregate)", () => {
+  // Lightweight stub of the FridayClient interface required by
+  // collectEnvironmentTruth — every HTTP request fails fast so the
+  // aggregate falls back to the env-truth prerequisite shape.
+  function stubClient() {
+    return {
+      authMode: "anonymous",
+      authSource: null,
+      authDetails: null,
+      user: null,
+      async initialize() {
+        throw new Error("anonymous-client");
+      },
+      async request() {
+        return { ok: false, status: 0, json: null };
+      },
+    };
+  }
+
+  async function collectWith(processEnv) {
+    return collectEnvironmentTruth({
+      client: stubClient(),
+      baseUrl: "http://localhost:0",
+      uiBaseUrl: "http://localhost:0",
+      processEnv,
+    });
+  }
+
+  it("returns externalChannels ready=missing when the master flag is unset", async () => {
+    const truth = await collectWith({});
+    expect(truth.prerequisites.externalChannels.status).toBe("unknown");
+  });
+
+  it("returns externalChannels missing when the master flag is set but Lark env is incomplete", async () => {
+    const truth = await collectWith({
+      FRIDAY_REAL_WORLD_EXTERNAL_CHANNELS_READY: "true",
+      FRIDAY_DISCORD_BOT_TOKEN: "t",
+      FRIDAY_DISCORD_SETUP_USER_ID: "u",
+      FRIDAY_DISCORD_GUILD_ID: "g",
+      FRIDAY_DISCORD_CHANNEL_ID: "c",
+      FRIDAY_TELEGRAM_BOT_TOKEN: "t",
+      FRIDAY_TELEGRAM_TEST_CHAT_ID: "c",
+      // Lark intentionally missing
+    });
+    expect(truth.prerequisites.externalChannels.status).toBe("missing");
+    expect(truth.prerequisites.externalChannels.missingEnv?.length ?? 0).toBeGreaterThan(0);
+  });
+
+  it("returns externalChannels ready when every v1 channel env tuple is satisfied", async () => {
+    const truth = await collectWith({
+      FRIDAY_REAL_WORLD_EXTERNAL_CHANNELS_READY: "true",
+      FRIDAY_DISCORD_BOT_TOKEN: "t",
+      FRIDAY_DISCORD_SETUP_USER_ID: "u",
+      FRIDAY_DISCORD_GUILD_ID: "g",
+      FRIDAY_DISCORD_CHANNEL_ID: "c",
+      FRIDAY_LARK_APP_ID: "a",
+      FRIDAY_LARK_APP_SECRET: "s",
+      FRIDAY_LARK_VERIFICATION_TOKEN: "v",
+      FRIDAY_LARK_ENCRYPT_KEY: "k",
+      FRIDAY_LARK_TEST_CHAT_ID: "c",
+      FRIDAY_TELEGRAM_BOT_TOKEN: "t",
+      FRIDAY_TELEGRAM_TEST_CHAT_ID: "c",
+    });
+    expect(truth.prerequisites.externalChannels.status).toBe("ready");
+    expect(truth.prerequisites.externalChannels.perChannel).toBeDefined();
+  });
+});

--- a/validation/real-world/catalog/scenarios.mjs
+++ b/validation/real-world/catalog/scenarios.mjs
@@ -122,6 +122,58 @@ function discordRoundtripScenario(input) {
   });
 }
 
+// Phase 14.5E module_28e Slice 6.6 — per-channel external roundtrip
+// scenario constructors for Lark/Feishu and Telegram. Each scenario is
+// independently gated by its own env tuple; a passing Discord scenario
+// is never proof for any other channel. Honest non-pass labels for
+// missing-env runs flow through `summarizeRun()` → `deriveScenarioCounts`
+// → `deriveStatus`; this matrix does NOT relax the validator or the
+// gate's pass criteria.
+function larkRoundtripScenario(input) {
+  return baseScenario({
+    ...input,
+    preconditions: [...new Set([...(input.preconditions ?? []), "external_channels.ready"])],
+    providerLane: "none",
+    suites: input.suites ?? ["weekly"],
+    expectedEvidence: [
+      "Lark/Feishu app credentials resolve a bot identity",
+      "sandbox tenant and test chat are reachable",
+      "a real outbound Lark/Feishu message can be sent and read back",
+    ],
+    execution: {
+      kind: "lark_roundtrip",
+      appIdEnv: "FRIDAY_LARK_APP_ID",
+      appSecretEnv: "FRIDAY_LARK_APP_SECRET",
+      verificationTokenEnv: "FRIDAY_LARK_VERIFICATION_TOKEN",
+      encryptKeyEnv: "FRIDAY_LARK_ENCRYPT_KEY",
+      testChatIdEnv: "FRIDAY_LARK_TEST_CHAT_ID",
+      ...input.execution,
+    },
+    tags: [...new Set([...(input.tags ?? []), "external-channel", "lark"])],
+  });
+}
+
+function telegramRoundtripScenario(input) {
+  return baseScenario({
+    ...input,
+    preconditions: [...new Set([...(input.preconditions ?? []), "external_channels.ready"])],
+    providerLane: "none",
+    suites: input.suites ?? ["weekly"],
+    expectedEvidence: [
+      "Telegram bot token resolves to a bot identity",
+      "sandbox chat is reachable",
+      "a real outbound Telegram message can be sent and read back",
+    ],
+    execution: {
+      kind: "telegram_roundtrip",
+      botTokenEnv: "FRIDAY_TELEGRAM_BOT_TOKEN",
+      testChatIdEnv: "FRIDAY_TELEGRAM_TEST_CHAT_ID",
+      ...input.execution,
+    },
+    tags: [...new Set([...(input.tags ?? []), "external-channel", "telegram"])],
+  });
+}
+
 export const REAL_WORLD_SCENARIOS = [
   baseScenario({
     id: "l0-runtime-health",
@@ -1513,6 +1565,30 @@ export const REAL_WORLD_SCENARIOS = [
     layer: "L6",
     productArea: "external channels",
     entrySurface: "discord",
+    routeFamily: "distributed channel",
+    severityOnFailure: "P1",
+    suites: ["weekly"],
+  }),
+  // Phase 14.5E module_28e Slice 6.6 — Lark/Feishu live channel roundtrip.
+  // Honest non-pass label when env tuple is incomplete; never substituted
+  // by Discord proof.
+  larkRoundtripScenario({
+    id: "l6-lark-channel-roundtrip",
+    layer: "L6",
+    productArea: "external channels",
+    entrySurface: "lark",
+    routeFamily: "distributed channel",
+    severityOnFailure: "P1",
+    suites: ["weekly"],
+  }),
+  // Phase 14.5E module_28e Slice 6.6 — Telegram live channel roundtrip.
+  // Honest non-pass label when env tuple is incomplete; never substituted
+  // by Discord proof.
+  telegramRoundtripScenario({
+    id: "l6-telegram-channel-roundtrip",
+    layer: "L6",
+    productArea: "external channels",
+    entrySurface: "telegram",
     routeFamily: "distributed channel",
     severityOnFailure: "P1",
     suites: ["weekly"],

--- a/validation/real-world/lib/defs.mjs
+++ b/validation/real-world/lib/defs.mjs
@@ -50,6 +50,11 @@ export const REAL_WORLD_EXECUTION_KINDS = Object.freeze([
   "workflow_generator_loop",
   "persona_learning",
   "discord_roundtrip",
+  // Phase 14.5E module_28e Slice 6.6 — per-channel external roundtrip
+  // execution kinds for Lark/Feishu and Telegram. Each executor checks
+  // its own env tuple and emits `blocked` honestly when env is missing.
+  "lark_roundtrip",
+  "telegram_roundtrip",
   "skill_upgrade_lifecycle",
   "auto_fix_doctor_roundtrip",
   "workflow_evidence_fail_closed",

--- a/validation/real-world/lib/env-truth.mjs
+++ b/validation/real-world/lib/env-truth.mjs
@@ -31,29 +31,105 @@ function readCapabilityStatus(processEnv, key) {
   };
 }
 
+// Phase 14.5E module_28e Slice 6.7 — per-channel env tuple readers for the
+// v1 channel set (Discord, Lark/Feishu, Telegram). Each reader returns
+// `{ status, requiredEnv, missingEnv }` so the externalChannels
+// prerequisite, the setup wizard status surface, and downstream
+// reviewers all agree on the same per-channel proof label vocabulary.
+
+const FRIDAY_DISCORD_LIVE_PROOF_ENV = Object.freeze([
+  "FRIDAY_DISCORD_BOT_TOKEN",
+  "FRIDAY_DISCORD_SETUP_USER_ID",
+  "FRIDAY_DISCORD_GUILD_ID",
+  "FRIDAY_DISCORD_CHANNEL_ID",
+]);
+
+const FRIDAY_LARK_LIVE_PROOF_ENV = Object.freeze([
+  "FRIDAY_LARK_APP_ID",
+  "FRIDAY_LARK_APP_SECRET",
+  "FRIDAY_LARK_VERIFICATION_TOKEN",
+  "FRIDAY_LARK_ENCRYPT_KEY",
+  "FRIDAY_LARK_TEST_CHAT_ID",
+]);
+
+const FRIDAY_TELEGRAM_LIVE_PROOF_ENV = Object.freeze([
+  "FRIDAY_TELEGRAM_BOT_TOKEN",
+  "FRIDAY_TELEGRAM_TEST_CHAT_ID",
+]);
+
+function readPerChannelEnvTuple(processEnv, channel, requiredEnv) {
+  const missing = requiredEnv.filter((key) => !String(processEnv[key] ?? "").trim());
+  if (missing.length === requiredEnv.length) {
+    return {
+      channel,
+      status: "not_configured",
+      requiredEnv,
+      missingEnv: missing,
+    };
+  }
+  if (missing.length > 0) {
+    return {
+      channel,
+      status: "blocked_by_env",
+      requiredEnv,
+      missingEnv: missing,
+    };
+  }
+  return {
+    channel,
+    status: "configured",
+    requiredEnv,
+    missingEnv: [],
+  };
+}
+
+export function readDiscordChannelsStatus(processEnv = process.env) {
+  return readPerChannelEnvTuple(processEnv, "discord", FRIDAY_DISCORD_LIVE_PROOF_ENV);
+}
+
+export function readLarkChannelsStatus(processEnv = process.env) {
+  return readPerChannelEnvTuple(processEnv, "lark", FRIDAY_LARK_LIVE_PROOF_ENV);
+}
+
+export function readTelegramChannelsStatus(processEnv = process.env) {
+  return readPerChannelEnvTuple(processEnv, "telegram", FRIDAY_TELEGRAM_LIVE_PROOF_ENV);
+}
+
 function readExternalChannelsStatus(processEnv) {
   const declared = readCapabilityStatus(processEnv, "FRIDAY_REAL_WORLD_EXTERNAL_CHANNELS_READY");
   if (declared.status !== "ready") {
     return declared;
   }
-  const requiredEnv = [
-    "FRIDAY_DISCORD_BOT_TOKEN",
-    "FRIDAY_DISCORD_SETUP_USER_ID",
-    "FRIDAY_DISCORD_GUILD_ID",
-    "FRIDAY_DISCORD_CHANNEL_ID",
+  // Phase 14.5E module_28e Slice 6.7 — externalChannels prerequisite is
+  // ready only when every declared v1 channel's env tuple is satisfied
+  // (Discord + Lark/Feishu + Telegram). This is consistent with the
+  // pre-14.5E single-channel completeness check at lines 39-58, broadened
+  // honestly to cover all three v1 channels. The master flag
+  // `FRIDAY_REAL_WORLD_EXTERNAL_CHANNELS_READY` retains its existing
+  // semantic.
+  const perChannelStatuses = [
+    readDiscordChannelsStatus(processEnv),
+    readLarkChannelsStatus(processEnv),
+    readTelegramChannelsStatus(processEnv),
   ];
-  const missing = requiredEnv.filter((key) => !String(processEnv[key] ?? "").trim());
+  const requiredEnv = perChannelStatuses.flatMap((status) => status.requiredEnv);
+  const missing = perChannelStatuses.flatMap((status) => status.missingEnv);
+  const blockedChannels = perChannelStatuses
+    .filter((status) => status.status !== "configured")
+    .map((status) => `${status.channel}=${status.status}`);
   if (missing.length > 0) {
     return {
       status: "missing",
       source: declared.source,
       missingEnv: missing,
-      note: "External channels were declared ready, but Discord proof env is incomplete.",
+      perChannel: perChannelStatuses,
+      note: `External channels were declared ready, but per-channel proof env is incomplete: ${blockedChannels.join(", ")}.`,
     };
   }
   return {
     ...declared,
     requiredEnv,
+    perChannel: perChannelStatuses,
   };
 }
 

--- a/validation/real-world/lib/executors.mjs
+++ b/validation/real-world/lib/executors.mjs
@@ -2990,6 +2990,227 @@ async function executeSkillUpgradeLifecycle({ artifact, client, scenario, runId 
   return artifact;
 }
 
+// Phase 14.5E module_28e Slice 6.6 — Lark/Feishu live channel roundtrip
+// executor. Honest non-pass label when any required env var is missing
+// or the Lark API is unreachable; no real network call when env tuple
+// is incomplete. Pass requires every env var present AND a successful
+// outbound send + readback against the configured Lark/Feishu test chat.
+const LARK_TENANT_TOKEN_URL = "https://open.larksuite.com/open-apis/auth/v3/tenant_access_token/internal";
+const LARK_FEISHU_TENANT_TOKEN_URL = "https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal";
+const LARK_MESSAGES_URL = "https://open.larksuite.com/open-apis/im/v1/messages";
+const LARK_FEISHU_MESSAGES_URL = "https://open.feishu.cn/open-apis/im/v1/messages";
+
+function readOptionalEnv(name) {
+  return process.env[name]?.trim() ?? "";
+}
+
+function collectMissingEnv(names) {
+  return names.filter((name) => !readOptionalEnv(name));
+}
+
+function buildLarkBaseUrls(scenario) {
+  const useFeishu = (readOptionalEnv("FRIDAY_LARK_DOMAIN").toLowerCase() === "feishu")
+    || scenario.execution.useFeishu === true;
+  return useFeishu
+    ? { tokenUrl: LARK_FEISHU_TENANT_TOKEN_URL, messagesUrl: LARK_FEISHU_MESSAGES_URL, domain: "feishu" }
+    : { tokenUrl: LARK_TENANT_TOKEN_URL, messagesUrl: LARK_MESSAGES_URL, domain: "lark" };
+}
+
+async function executeLarkRoundtrip({ artifact, scenario }) {
+  const appIdEnv = scenario.execution.appIdEnv ?? "FRIDAY_LARK_APP_ID";
+  const appSecretEnv = scenario.execution.appSecretEnv ?? "FRIDAY_LARK_APP_SECRET";
+  const verificationTokenEnv = scenario.execution.verificationTokenEnv ?? "FRIDAY_LARK_VERIFICATION_TOKEN";
+  const encryptKeyEnv = scenario.execution.encryptKeyEnv ?? "FRIDAY_LARK_ENCRYPT_KEY";
+  const testChatIdEnv = scenario.execution.testChatIdEnv ?? "FRIDAY_LARK_TEST_CHAT_ID";
+
+  const required = [appIdEnv, appSecretEnv, verificationTokenEnv, encryptKeyEnv, testChatIdEnv];
+  const missing = collectMissingEnv(required);
+  if (missing.length > 0) {
+    artifact.result = "blocked";
+    artifact.failureClass = "environment";
+    artifact.notes = [
+      ...(artifact.notes ?? []),
+      `Lark/Feishu live roundtrip blocked: missing env ${missing.join(", ")}`,
+    ];
+    artifact.raw = {
+      ...(artifact.raw ?? {}),
+      larkEvidence: {
+        envPresent: false,
+        missingEnv: missing,
+      },
+    };
+    return artifact;
+  }
+
+  const appId = readOptionalEnv(appIdEnv);
+  const appSecret = readOptionalEnv(appSecretEnv);
+  const testChatId = readOptionalEnv(testChatIdEnv);
+  const { tokenUrl, messagesUrl, domain } = buildLarkBaseUrls(scenario);
+  const proofNonce = `${artifact.runId}:${Date.now().toString(36)}:${Math.random().toString(36).slice(2, 8)}`;
+  const baseMessage = `Friday Phase 14.5E live Lark proof ${proofNonce}`;
+
+  try {
+    const tokenResp = await fetch(tokenUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ app_id: appId, app_secret: appSecret }),
+    });
+    const tokenJson = await tokenResp.json().catch(() => null);
+    if (!tokenResp.ok || !tokenJson || typeof tokenJson.tenant_access_token !== "string") {
+      const code = tokenJson && typeof tokenJson === "object" && "code" in tokenJson ? String(tokenJson.code) : "unknown";
+      throw new Error(`Lark tenant_access_token failed: HTTP ${String(tokenResp.status)} code=${code}`);
+    }
+    const tenantToken = tokenJson.tenant_access_token;
+
+    const sendResp = await fetch(`${messagesUrl}?receive_id_type=chat_id`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${tenantToken}`,
+      },
+      body: JSON.stringify({
+        receive_id: testChatId,
+        msg_type: "text",
+        content: JSON.stringify({ text: baseMessage }),
+      }),
+    });
+    const sendJson = await sendResp.json().catch(() => null);
+    if (!sendResp.ok || !sendJson?.data?.message_id) {
+      const code = sendJson && typeof sendJson === "object" && "code" in sendJson ? String(sendJson.code) : "unknown";
+      throw new Error(`Lark im/v1/messages send failed: HTTP ${String(sendResp.status)} code=${code}`);
+    }
+    const messageId = String(sendJson.data.message_id);
+
+    const readResp = await fetch(`${messagesUrl}/${encodeURIComponent(messageId)}`, {
+      headers: { Authorization: `Bearer ${tenantToken}` },
+    });
+    const readJson = await readResp.json().catch(() => null);
+    if (!readResp.ok || !Array.isArray(readJson?.data?.items) || readJson.data.items.length === 0) {
+      const code = readJson && typeof readJson === "object" && "code" in readJson ? String(readJson.code) : "unknown";
+      throw new Error(`Lark message readback failed: HTTP ${String(readResp.status)} code=${code}`);
+    }
+
+    artifact.result = "passed";
+    artifact.observedEvidence.push(
+      "Lark/Feishu tenant_access_token resolved",
+      `Lark/Feishu domain=${domain}`,
+      "outbound Lark/Feishu message sent",
+      "outbound Lark/Feishu message readback succeeded",
+    );
+    artifact.metrics = {
+      ...(artifact.metrics ?? {}),
+      larkMessagesReadBack: 1,
+    };
+    artifact.raw = {
+      ...(artifact.raw ?? {}),
+      larkEvidence: {
+        envPresent: true,
+        domain,
+        chatIdTail: idTail(testChatId),
+        messageIdTail: idTail(messageId),
+        outboundMatched: true,
+      },
+    };
+    return artifact;
+  } catch (error) {
+    artifact.result = "failed";
+    artifact.failureClass = "tool_bridge";
+    artifact.notes = [
+      ...(artifact.notes ?? []),
+      `Lark/Feishu roundtrip failed: ${error instanceof Error ? error.message : String(error)}`,
+    ];
+    return artifact;
+  }
+}
+
+// Phase 14.5E module_28e Slice 6.6 — Telegram live channel roundtrip.
+async function executeTelegramRoundtrip({ artifact, scenario }) {
+  const botTokenEnv = scenario.execution.botTokenEnv ?? "FRIDAY_TELEGRAM_BOT_TOKEN";
+  const testChatIdEnv = scenario.execution.testChatIdEnv ?? "FRIDAY_TELEGRAM_TEST_CHAT_ID";
+
+  const required = [botTokenEnv, testChatIdEnv];
+  const missing = collectMissingEnv(required);
+  if (missing.length > 0) {
+    artifact.result = "blocked";
+    artifact.failureClass = "environment";
+    artifact.notes = [
+      ...(artifact.notes ?? []),
+      `Telegram live roundtrip blocked: missing env ${missing.join(", ")}`,
+    ];
+    artifact.raw = {
+      ...(artifact.raw ?? {}),
+      telegramEvidence: {
+        envPresent: false,
+        missingEnv: missing,
+      },
+    };
+    return artifact;
+  }
+
+  const botToken = readOptionalEnv(botTokenEnv);
+  const testChatId = readOptionalEnv(testChatIdEnv);
+  const proofNonce = `${artifact.runId}:${Date.now().toString(36)}:${Math.random().toString(36).slice(2, 8)}`;
+  const baseMessage = `Friday Phase 14.5E live Telegram proof ${proofNonce}`;
+
+  try {
+    const meResp = await fetch(`https://api.telegram.org/bot${botToken}/getMe`);
+    const meJson = await meResp.json().catch(() => null);
+    if (!meResp.ok || meJson?.ok !== true || !meJson?.result?.is_bot) {
+      const desc = meJson && typeof meJson === "object" && "description" in meJson
+        ? String(meJson.description)
+        : "unknown";
+      throw new Error(`Telegram getMe failed: HTTP ${String(meResp.status)} description=${desc}`);
+    }
+
+    const sendResp = await fetch(`https://api.telegram.org/bot${botToken}/sendMessage`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ chat_id: testChatId, text: baseMessage }),
+    });
+    const sendJson = await sendResp.json().catch(() => null);
+    if (!sendResp.ok || sendJson?.ok !== true || !sendJson?.result?.message_id) {
+      const desc = sendJson && typeof sendJson === "object" && "description" in sendJson
+        ? String(sendJson.description)
+        : "unknown";
+      throw new Error(`Telegram sendMessage failed: HTTP ${String(sendResp.status)} description=${desc}`);
+    }
+    const messageId = sendJson.result.message_id;
+    const text = sendJson.result.text;
+    if (text !== baseMessage) {
+      throw new Error("Telegram outbound text did not match readback.");
+    }
+
+    artifact.result = "passed";
+    artifact.observedEvidence.push(
+      "Telegram bot identity resolved",
+      "outbound Telegram message sent",
+      "outbound Telegram message readback matched content",
+    );
+    artifact.metrics = {
+      ...(artifact.metrics ?? {}),
+      telegramMessagesReadBack: 1,
+    };
+    artifact.raw = {
+      ...(artifact.raw ?? {}),
+      telegramEvidence: {
+        envPresent: true,
+        chatIdTail: idTail(testChatId),
+        messageId,
+        outboundMatched: true,
+      },
+    };
+    return artifact;
+  } catch (error) {
+    artifact.result = "failed";
+    artifact.failureClass = "tool_bridge";
+    artifact.notes = [
+      ...(artifact.notes ?? []),
+      `Telegram roundtrip failed: ${error instanceof Error ? error.message : String(error)}`,
+    ];
+    return artifact;
+  }
+}
+
 async function executeManualExternal({ artifact, scenario, blockers }) {
   const manualEvidenceTemplate = [
     `surface=${scenario.entrySurface}`,
@@ -3074,6 +3295,12 @@ export async function executeScenario({
         break;
       case "discord_roundtrip":
         await executeDiscordRoundtrip({ artifact, scenario, client });
+        break;
+      case "lark_roundtrip":
+        await executeLarkRoundtrip({ artifact, scenario });
+        break;
+      case "telegram_roundtrip":
+        await executeTelegramRoundtrip({ artifact, scenario });
         break;
       case "skill_upgrade_lifecycle":
         await executeSkillUpgradeLifecycle({ artifact, client, scenario, runId });


### PR DESCRIPTION
## Scope

Phase 14.5E module_28e only (Channel setup and live proof). No other Phase 14.5 subphase, no Phase 14 release-proof debt closure, no Phase 15 docs truth reconciliation work.

## Per-Channel Status And Proof Labels

Adds a deterministic per-channel proof-label surface for the v1 channels: Discord, Lark/Feishu, and Telegram.

- `src/channels/friday-channel-setup-status.ts` derives a four-member `FridayChannelProofLabel = "configured" | "not_configured" | "blocked_by_env" | "unsupported"` for each v1 channel from the channel registry credential state plus the per-channel env truth (see `src/channels/friday-channel-registry.ts` extensions and `validation/real-world/lib/env-truth.mjs` new `readLarkChannelsStatus()` / `readTelegramChannelsStatus()`).
- `GET /v1/setup/channels/status` (in `src/api/http/routes/friday-setup-routes.ts`) returns per-channel `{channelId, displayName, proofLabel, blockedReason, requiredEnvVars, lastProofResult}` for the setup wizard.
- `validation/real-world/lib/env-truth.mjs` now reports the externalChannels prerequisite honestly across Discord + Lark/Feishu + Telegram; missing per-channel env keeps the prerequisite from going `ready` so the RGG vehicle cannot silently flip to pass.
- Per-channel honesty is preserved end-to-end: `blocked_by_env` and `not_configured` are never re-labelled as `passed`, and a passing Discord scenario never substitutes for Lark/Feishu or Telegram.

## Canonical Command -> Risk Preview -> Owner-Link / High-Risk Approval Ladder

Adds the channel-side natural-language -> canonical-command -> risk-preview -> required-confirmation -> execution -> evidence-receipt loop, with high-risk routing forced through the bound-principal contract.

- `src/channels/services/friday-channel-canonical-command.ts` parses inbound channel messages into a canonical command shape `{verb, target, args, riskLevel}`. The `riskLevel` (`low | medium | high`) comes from a deterministic curated table, not from any model call.
- Low/medium risk -> in-channel preview/confirmation; high risk -> owner-signed approval link.
- `src/security/friday-channel-action-approval.ts` issues and verifies an HMAC-signed owner approval token over `{actionId, channelId, principalId, riskLevel, expiresAt}` using the existing internal runtime signing key. No new user-provided secret was introduced.
- `src/api/http/routes/friday-channel-action-routes.ts` adds `POST /v1/channels/actions/{actionId}/owner-approve` and the matching execute path; both require a valid bound principal with `source: "api"` or `source: "session"`. `source: "channel"` alone is refused for high-risk channel actions.
- `src/security/friday-owner-session-channel-capability.ts` adds the new `FridayPublicMutationOperation` members `channel.action.high_risk.approve` and `channel.action.high_risk.execute`, and `assertBoundPrincipalForOperation()` enforces the `source` constraint.

## Receipt And RGG Wiring

- `src/channels/services/friday-channel-outbound-receipt.ts` populates channel-triggered closeout receipts with the existing Phase 14.5C `evidenceDurability` / `proofClaimable` fields and the Phase 14.5D `rollbackClass = "non_reversible_external"` + `nonReversibleReason` strings. The existing `workflow_run_evidence_durable` and `rollback_class_disclosure_required` required gates are unchanged.
- `validation/real-world/catalog/scenarios.mjs`, `validation/real-world/lib/defs.mjs`, and `validation/real-world/lib/executors.mjs` add `l6-lark-channel-roundtrip` and `l6-telegram-channel-roundtrip` mirroring the existing `l6-discord-channel-roundtrip` shape. Each scenario is independently env-gated and emits an honest `blocked_by_env` outcome when its own env vars are missing; no cross-channel substitution is possible.
- `scripts/ops/run-real-green-gate.mjs` adds both new scenario ids to `EXTERNAL_CHANNEL_SCENARIOS` and `PUBLIC_SURFACE_SCENARIOS` so the RGG vehicle sees per-channel pass/fail/blocked outcomes for all three v1 channels. The validator at `scripts/ops/lib/real-green-gate-result.mjs` is intentionally NOT modified; `blocked_by_env` still does not satisfy pass.

## Local Verification

Stage 4 focused checks (from the prior Stage 4 handoff, ran before this Stage 6 staging request):

- `npm test -- test/unit/channels/friday-channel-proof-label.test.ts` PASS
- `npm test -- test/unit/channels/friday-channel-setup-status.test.ts` PASS
- `npm test -- test/unit/channels/friday-channel-canonical-command.test.ts` PASS
- `npm test -- test/unit/channels/friday-channel-outbound-receipt.test.ts` PASS
- `npm test -- test/unit/security/friday-channel-action-approval.test.ts` PASS
- `npm test -- test/unit/api/http/routes/friday-channel-action-routes.test.ts` PASS
- `npm test -- test/unit/api/http/routes/friday-setup-channels-status-route.test.ts` PASS
- `npm test -- test/unit/validation/real-world/env-truth-per-channel.test.ts` PASS
- `npm test -- test/contracts/api/friday-api-route-contract.snapshot.test.ts` PASS
- `npm test -- test/e2e/api/friday-api-channel-setup-and-live-proof.acceptance.test.ts` PASS
- `npm run typecheck` PASS
- `npm run lint` PASS on touched scope
- `npm run check:secret-patterns` PASS
- `npm run validate:real-world:catalog` PASS
- `git diff --check` PASS

Stage 6 pre-stage checks reran in this turn:

- `git status --short --branch` clean against `origin/main` `42fac20fa5f5bfd33e23addc400d9fb98bb35ee8`; HEAD pre-commit matched.
- `git diff --check` PASS
- `npm run check:secret-patterns` PASS (`No provider/API key shaped secrets found in tracked files.`)
- `npm run validate:real-world:catalog` PASS (`scenarioCount: 22`, catalog-only)
- `git diff --cached --check` PASS
- `git diff --cached -- README.md ROADMAP.md docs/ REPORTS_INDEX.csv AGENTS.md context/ src/task-workflows/friday-task-workflow-closeout-gates.ts scripts/ops/lib/real-green-gate-result.mjs` empty — no protected/out-of-scope paths staged.

## Stage 5 Reviewer Context

Two isolated read-only reviewers were run before Stage 6 as prior context: Reviewer A (factual / implementation / boundary parity) PASS, Reviewer B (regression / no-overclaim / no fake proof / no secret leakage / no test weakening / no scope creep) PASS, no disagreement. This is recorded as the prior reviewer context, not as release proof; same-SHA RGG and PR-head CI inspection are still required before any release-complete claim.

## Proof Limits

This PR carries local Stage 4 proof only. It is **not** release-complete on its own.

Release-complete for Phase 14.5E requires, at the PR head SHA:

- Required PR-head CI checks green;
- Same-SHA `real-green-gate-result.json` with `status="passed"`, `scenarios_total > 0`, `scenarios_passed == scenarios_total`, `blocked_reasons=[]`, `commit_sha` matching this PR head, externalChannels prerequisite `ready`;
- Every required external-channel scenario (`l6-discord-channel-roundtrip`, `l6-lark-channel-roundtrip`, `l6-telegram-channel-roundtrip`) `passed` in that artifact;
- Two isolated read-only reviewers PASS at PR head with no disagreement.

None of the above is claimed at PR creation time.

## Per-Channel Honesty

- `blocked_by_env` and `not_configured` are honest debt, never pass. Any required Phase 14.5E external-channel RGG scenario with a `blocked_by_env` / `not_configured` outcome at Stage 7 is a proof blocker, not a satisfied gate.
- Discord live proof cannot stand in for Lark/Feishu or Telegram. Each v1 channel must have its own configured credentials in the RGG runner before its scenario can produce a `passed` outcome.
- The Phase 13.5D post-merge `DISCORD_CONNECTION_FAILED` debt is not silently re-labelled as resolved; it closes only when `l6-discord-channel-roundtrip` records `passed` in a same-SHA RGG vehicle.

## Forwarded / Out-Of-Scope

- Phase 14 release-proof debt: forwarded (out of scope for Phase 14.5E).
- Phase 15 docs truth reconciliation: forwarded (out of scope for Phase 14.5E; no `README.md`, `ROADMAP.md`, `docs/current-source-of-truth.md`, `docs/release-evidence-policy.md`, `REPORTS_INDEX.csv`, `AGENTS.md`, or `context/AGENTS.md` is touched here).

## Merge Gate Reminder

Per `AGENTS.md` conveyor merge-gate rule, Stage 8 merge requires, at the PR head SHA: branch `codex/**`; PR ready (not draft); required CI green; same-SHA RGG `status="passed"` with nonzero scenarios, all scenarios passed, and blockers empty; two isolated reviewers PASS; no unresolved PR conversations; PR body / report proof wording does not overclaim. No owner/admin bypass. If RGG is missing, blocked, failed, errored, or zero-scenario, do not merge and do not silently forward the debt unless the user explicitly approves that exception in a durable pre-merge PR-side artifact.

## Test Plan

- [ ] PR-head CI on `codex/phase-14-5e-channel-setup-live-proof` lands green for all required checks.
- [ ] Same-SHA `real-green-gate-result.json` is fetched and inspected; `status`, `scenarios_total`, `scenarios_passed`, `blocked_reasons`, `commit_sha`, externalChannels prerequisite, and per-channel scenario outcomes are recorded honestly.
- [ ] Reviewers re-run at PR head; both PASS with no disagreement before any merge decision.
- [ ] Merge gate honored as written above; honest `partial` / `blocked` recorded if any required scenario does not reach `passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)