### PR TITLE
Phase 18A - Verified golden path baseline guard: CLAW-023 / CLAW-024 template fixes

### DIFF
--- a/src/workflows/builder/templates/friday-workflow-builder-builtin-templates.ts
+++ b/src/workflows/builder/templates/friday-workflow-builder-builtin-templates.ts
@@ -69,7 +69,7 @@ function createSimpleActionTemplate(): FridayWorkflowTemplateEntity {
       { key: "input_data", type: "string", required: true },
     ],
     steps: [
-      { id: "action-1", type: "skill_call", ref: "example-skill", args: { data: "$inputs.input_data" } },
+      { id: "action-1", type: "transform", args: { data: "$inputs.input_data" } },
     ],
     edges: [],
     outputs: [

--- a/src/workflows/builder/templates/friday-workflow-builder-cross-border-templates.ts
+++ b/src/workflows/builder/templates/friday-workflow-builder-cross-border-templates.ts
@@ -207,7 +207,7 @@ function buildWeeklyHotProductReviewTemplate(
     description: entry.templateDescription,
     tags: entry.tags,
     spec,
-    visual: buildVisual(workflowId, [detectStepId, scoutStepId], [`${detectStepId}:${scoutStepId}:any`]),
+    visual: buildVisual(workflowId, [detectStepId, scoutStepId], [`${detectStepId}:${scoutStepId}:success`]),
     createdAt: CREATED_AT,
     updatedAt: CREATED_AT,
   };
@@ -316,7 +316,7 @@ function buildWeeklyOperatingProfileTuneTemplate(
     visual: buildVisual(
       workflowId,
       [weeklyReviewStepId, listingAuditStepId],
-      [`${weeklyReviewStepId}:${listingAuditStepId}:any`],
+      [`${weeklyReviewStepId}:${listingAuditStepId}:success`],
     ),
     createdAt: CREATED_AT,
     updatedAt: CREATED_AT,

--- a/test/unit/workflows/builder/friday-workflow-builder-builtin-templates.test.ts
+++ b/test/unit/workflows/builder/friday-workflow-builder-builtin-templates.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from "vitest";
+import { getFridayBuiltinWorkflowTemplates } from "#workflows";
+import { listFridayCrossBorderWorkflowCatalog } from "../../../../src/packs/cross-border/friday-cross-border-workflow-catalog";
+
+describe("getFridayBuiltinWorkflowTemplates - shipping guards", () => {
+  // CLAW-023: Built-in templates must not reference unavailable runnable skills.
+  describe("CLAW-023 skill_call ref hygiene", () => {
+    it("no built-in template references the non-existent 'example-skill' placeholder", () => {
+      const templates = getFridayBuiltinWorkflowTemplates();
+      for (const template of templates) {
+        for (const step of template.spec.steps) {
+          if (step.type === "skill_call") {
+            expect(step.ref, `template ${template.templateId} step ${step.id}`).not.toBe(
+              "example-skill",
+            );
+          }
+        }
+      }
+    });
+
+    it("every skill_call step in a built-in template with a ref points at a real cross-border catalog skill id", () => {
+      const knownSkillIds = new Set<string>();
+      for (const entry of listFridayCrossBorderWorkflowCatalog()) {
+        knownSkillIds.add(entry.primarySkillId);
+        if (entry.followupSkillId) {
+          knownSkillIds.add(entry.followupSkillId);
+        }
+      }
+
+      const templates = getFridayBuiltinWorkflowTemplates();
+      for (const template of templates) {
+        for (const step of template.spec.steps) {
+          if (step.type === "skill_call" && step.ref) {
+            expect(
+              knownSkillIds.has(step.ref),
+              `template ${template.templateId} step ${step.id} references skill '${step.ref}' which is not in the cross-border catalog`,
+            ).toBe(true);
+          }
+        }
+      }
+    });
+
+    it("simple-action starter template uses a non-skill step type so it does not ship a fake skill ref", () => {
+      const templates = getFridayBuiltinWorkflowTemplates();
+      const simple = templates.find((t) => t.templateId === "builtin-simple-action");
+      expect(simple).toBeDefined();
+      const skillCalls = simple!.spec.steps.filter((step) => step.type === "skill_call");
+      expect(skillCalls).toEqual([]);
+    });
+  });
+
+  // CLAW-024: Visual edge keys must match spec edge condition; success-only spec edges
+  // must not render as ":any".
+  describe("CLAW-024 visual edge key suffix matches spec edge 'when'", () => {
+    it("for every built-in template, every visual edge whose endpoints match a spec edge uses the spec edge's 'when' value as the suffix", () => {
+      const templates = getFridayBuiltinWorkflowTemplates();
+      for (const template of templates) {
+        const specEdgeByFromTo = new Map<string, string | undefined>();
+        for (const edge of template.spec.edges) {
+          specEdgeByFromTo.set(`${edge.from}:${edge.to}`, edge.when);
+        }
+
+        for (const visualEdge of template.visual.edges) {
+          // Trigger edges have no spec counterpart; skip them.
+          if (visualEdge.edgeKey.startsWith("__trigger__:")) {
+            continue;
+          }
+          const parts = visualEdge.edgeKey.split(":");
+          expect(parts.length, `edgeKey '${visualEdge.edgeKey}' is not in from:to:when shape`).toBeGreaterThanOrEqual(3);
+          const suffix = parts[parts.length - 1]!;
+          const fromTo = parts.slice(0, -1).join(":");
+          const specWhen = specEdgeByFromTo.get(fromTo);
+          if (specWhen !== undefined) {
+            expect(
+              suffix,
+              `template ${template.templateId} visual edge '${visualEdge.edgeKey}' suffix must match spec edge 'when' value '${specWhen}'`,
+            ).toBe(specWhen);
+          }
+        }
+      }
+    });
+
+    it("weekly-hot-product-review chain template visual edge uses ':success' to match the spec success edge", () => {
+      const templates = getFridayBuiltinWorkflowTemplates();
+      const template = templates.find(
+        (t) => t.templateId === "builtin-cross-border-weekly-hot-product-review",
+      );
+      expect(template).toBeDefined();
+      const specEdge = template!.spec.edges[0]!;
+      expect(specEdge.when).toBe("success");
+      const visualEdge = template!.visual.edges.find((e) =>
+        e.edgeKey.startsWith(`${specEdge.from}:${specEdge.to}:`),
+      );
+      expect(visualEdge).toBeDefined();
+      expect(visualEdge!.edgeKey).toBe(`${specEdge.from}:${specEdge.to}:success`);
+    });
+
+    it("weekly-operating-profile-tune chain template visual edge uses ':success' to match the spec success edge", () => {
+      const templates = getFridayBuiltinWorkflowTemplates();
+      const template = templates.find(
+        (t) => t.templateId === "builtin-cross-border-weekly-operating-profile-tune",
+      );
+      expect(template).toBeDefined();
+      const specEdge = template!.spec.edges[0]!;
+      expect(specEdge.when).toBe("success");
+      const visualEdge = template!.visual.edges.find((e) =>
+        e.edgeKey.startsWith(`${specEdge.from}:${specEdge.to}:`),
+      );
+      expect(visualEdge).toBeDefined();
+      expect(visualEdge!.edgeKey).toBe(`${specEdge.from}:${specEdge.to}:success`);
+    });
+
+    it("no built-in template ships a visual edge whose suffix is ':any' while its spec edge declares a success/failure/true/false condition", () => {
+      const templates = getFridayBuiltinWorkflowTemplates();
+      for (const template of templates) {
+        const specEdgeByFromTo = new Map<string, string | undefined>();
+        for (const edge of template.spec.edges) {
+          specEdgeByFromTo.set(`${edge.from}:${edge.to}`, edge.when);
+        }
+        for (const visualEdge of template.visual.edges) {
+          if (visualEdge.edgeKey.startsWith("__trigger__:")) continue;
+          const parts = visualEdge.edgeKey.split(":");
+          const suffix = parts[parts.length - 1]!;
+          const fromTo = parts.slice(0, -1).join(":");
+          const specWhen = specEdgeByFromTo.get(fromTo);
+          if (specWhen && suffix === "any") {
+            throw new Error(
+              `template ${template.templateId} ships visual edge '${visualEdge.edgeKey}' as ':any' but spec edge declares '${specWhen}'`,
+            );
+          }
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Phase 18A vertical-slice fix landing only CLAW-023 and CLAW-024 from the
Phase 18A scope. No P0/P1 unmapped; no channel/cloud/PR-#244/release-ready
claim; no same-SHA RGG release-proof claim.

- **CLAW-023**: Simple Action built-in template no longer ships a
  `skill_call` referencing the non-existent `example-skill` placeholder.
  Step type is swapped to `transform` with the same input wiring, matching
  the Blank starter's non-runnable scaffold pattern. The
  `SKILL_REF_NOT_FOUND` / `SKILL_REF_NOT_AVAILABLE` validator at
  `src/workflows/builder/services/friday-workflow-builder-validation-service.ts:277-301`
  is unchanged, so if a user adds a `skill_call` with an unknown ref it is
  still rejected.
- **CLAW-024**: Two cross-border chain templates
  (`builtin-cross-border-weekly-hot-product-review`,
  `builtin-cross-border-weekly-operating-profile-tune`) now build visual
  edge keys with the `:success` suffix to match their spec edge
  `when: "success"`, instead of `:any`. A full sweep of
  `src/workflows/builder/templates` confirmed these were the only two
  mismatched occurrences.
- **Tests**: 7 new tests in
  `test/unit/workflows/builder/friday-workflow-builder-builtin-templates.test.ts`
  pin CLAW-023 and CLAW-024 closure (no built-in template references
  `example-skill`; every `skill_call` ref maps to a real cross-border
  catalog id; the Simple Action template uses a non-skill step type; both
  cross-border chain visual edges resolve to `:success`; no built-in
  template ships a `:any` visual suffix while its spec edge declares
  `success`/`failure`/`true`/`false`).

## Files Changed

- `src/workflows/builder/templates/friday-workflow-builder-builtin-templates.ts`
- `src/workflows/builder/templates/friday-workflow-builder-cross-border-templates.ts`
- `test/unit/workflows/builder/friday-workflow-builder-builtin-templates.test.ts` (new)

## Verification (per Phase 18A completion report)

- `npx vitest run test/unit/workflows/builder/friday-workflow-builder-builtin-templates.test.ts test/unit/workflows/builder/friday-workflow-builder-template-service.test.ts`: PASS (7 new + 20 pre-existing)
- `npx vitest run test/unit/workflows/builder/`: 133 PASS
- `npx vitest run test/unit/workflows/`: 698 PASS
- `npx tsc --noEmit`: zero errors
- `npx eslint` over the two changed src files: zero errors
- `node scripts/quality/check-provider-key-patterns.mjs`: clean
- `git diff --check`: clean

Stage 5 two isolated read-only reviewers (Reviewer A factual / Reviewer B
regression + overclaim + secret leakage + scope creep) PASS at the Stage
3-5 source/test diff, and again post-Stage-4 attempt-6 local UI proof. No
reviewer disagreement.

## Proof tier (honest)

- **Test + audit tier**: PASS (CLAW-023 and CLAW-024 closure proven by
  focused tests + repo-wide audit).
- **Local UI proof, attempt 6**: PARTIAL local contract proof. Built the
  hub via `npm run build:api` + `npm run build:ui`, ran it on port 3142
  with worktree-local `FRIDAY_STATE_DIR` and transient
  `FRIDAY_MASTER_KEY` / `FRIDAY_TOKEN_SECRET` (no writes to `~/.friday`;
  the real `~/.friday/master.key` mtime was untouched). Drove Playwright
  headless Chromium through bootstrap-status -> local-passphrase ->
  login -> setup/complete -> `/chat`; `POST /v1/agent/runs` returned 200
  with a runId; the assistant bubble rendered (graceful-degradation
  fallback); `GET /v1/sessions` returned 1 item (session persistence
  proven); `/v1/task-workflows` and `/v1/workflow-runs/:id/evidence`
  routes reachable.
- **Not observed**: a successful end-to-end LLM ack and the SSE
  `GET /v1/agent/runs/:runId/events` attach, because the
  `OPENAI_API_KEY` available in env failed OpenAI authentication
  (`validationStatus=failed`, `authHealth=degraded`); the run terminated
  at provider auth before SSE attached and the visible bubble is the
  graceful-degradation message, NOT a successful LLM ack. AGENTS.md
  forbids asking the user for provider credentials from this turn.
- **Not a release-ready claim**: this PR does not claim release-ready, does
  not claim channel control (Discord/Lark/Telegram), does not claim cloud
  live certification, does not touch PR #244, and does not claim
  same-SHA RGG release proof. Successful LLM ack + SSE remain honest
  blocked_by_env debt forwarded to a later phase decision (e.g. Phase 19
  release-proof debt).

## Public v1 non-claims preserved

- No release-ready / release-complete claim.
- No channel control or cloud live certification claim.
- No PR #244 mutation.
- No same-SHA RGG release-proof claim.
- No safety / provider / approval / memory / skill lifecycle / release-proof
  semantics changed.

## Test plan

- [ ] CI: `build`, `test`, `migrations`, `security`, `contracts`,
  `ssd-lint`, `alignment-guard`, `agent-parity`, `secrets`, `quality-gate`
  all PASS at PR head.
- [ ] Same-SHA RGG: PR-hygiene-tier only; this PR does NOT claim
  release-complete from RGG.
- [ ] Post-merge: do not wait per AGENTS.md Stage 8 rule.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>