### PR TITLE
Phase 18B partial slices - CLAW-013, CLAW-003, CLAW-044

### DIFF
--- a/src/cli/friday-cli-tui.ts
+++ b/src/cli/friday-cli-tui.ts
@@ -30,6 +30,18 @@ interface FridayCliAuthEnvelope {
   };
 }
 
+export interface FridayCliTuiAuthCoordinatorDeps {
+  readonly apiBaseUrl: string;
+  readonly env: NodeJS.ProcessEnv;
+  readonly fetchFn?: typeof fetch;
+}
+
+export interface FridayCliTuiAuthCoordinator {
+  readonly hasConfiguredAccessToken: boolean;
+  readonly isLoopback: boolean;
+  resolveAccessToken(forceRefresh?: boolean): Promise<string | undefined>;
+}
+
 function isLoopbackBaseUrl(baseUrl: string): boolean {
   try {
     const parsed = new URL(baseUrl);
@@ -41,37 +53,39 @@ function isLoopbackBaseUrl(baseUrl: string): boolean {
   }
 }
 
-// ─── Factory ───
-
-export async function runFridayCliTui(options: FridayCliTuiOptions = {}): Promise<void> {
-  const config: FridayTuiConfig = {
-    ...DEFAULT_TUI_CONFIG,
-    ...(options.apiBaseUrl ? { apiBaseUrl: options.apiBaseUrl } : {}),
-    ...(options.refreshIntervalMs ? { refreshIntervalMs: options.refreshIntervalMs } : {}),
-    ...(options.realtimeEnabled !== undefined ? { realtimeEnabled: options.realtimeEnabled } : {}),
-  };
-  const configuredAccessToken = process.env.FRIDAY_TUI_ACCESS_TOKEN?.trim() || undefined;
-  const localPassphrase = process.env.FRIDAY_TEST_LOCAL_PASSPHRASE?.trim()
-    || process.env.FRIDAY_LOCAL_PASSPHRASE?.trim()
-    || "friday-cli-tui-passphrase-123";
-  const loopbackBaseUrl = isLoopbackBaseUrl(config.apiBaseUrl);
+export function createFridayCliTuiAuthCoordinator(
+  deps: FridayCliTuiAuthCoordinatorDeps,
+): FridayCliTuiAuthCoordinator {
+  const configuredAccessToken = deps.env.FRIDAY_TUI_ACCESS_TOKEN?.trim() || undefined;
+  const localPassphrase = deps.env.FRIDAY_TEST_LOCAL_PASSPHRASE?.trim()
+    || deps.env.FRIDAY_LOCAL_PASSPHRASE?.trim()
+    || undefined;
+  const loopback = isLoopbackBaseUrl(deps.apiBaseUrl);
+  const fetchFn = deps.fetchFn ?? fetch;
   let cachedAccessToken = configuredAccessToken;
 
   async function loginLocalPassphrase(): Promise<string> {
-    const bootstrapStatusResponse = await fetch(`${config.apiBaseUrl}/v1/auth/bootstrap/status`);
+    if (!localPassphrase) {
+      throw new FridayDomainError(
+        "TUI_AUTH_NOT_CONFIGURED",
+        "TUI first-run auth is not configured. Set FRIDAY_TUI_ACCESS_TOKEN, or FRIDAY_LOCAL_PASSPHRASE / FRIDAY_TEST_LOCAL_PASSPHRASE, before launching the TUI; no fallback credential is used.",
+        { httpStatus: 401 },
+      );
+    }
+    const bootstrapStatusResponse = await fetchFn(`${deps.apiBaseUrl}/v1/auth/bootstrap/status`);
     const bootstrapStatus = await bootstrapStatusResponse.json().catch(() => null) as {
       ok?: boolean;
       data?: { bootstrapRequired?: boolean };
     } | null;
     if (bootstrapStatusResponse.ok && bootstrapStatus?.ok === true && bootstrapStatus.data?.bootstrapRequired === true) {
-      await fetch(`${config.apiBaseUrl}/v1/auth/bootstrap/local-passphrase`, {
+      await fetchFn(`${deps.apiBaseUrl}/v1/auth/bootstrap/local-passphrase`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ localPassphrase }),
       });
     }
 
-    const response = await fetch(`${config.apiBaseUrl}/v1/auth/login`, {
+    const response = await fetchFn(`${deps.apiBaseUrl}/v1/auth/login`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ localPassphrase }),
@@ -97,11 +111,32 @@ export async function runFridayCliTui(options: FridayCliTuiOptions = {}): Promis
     if (cachedAccessToken && !forceRefresh) {
       return cachedAccessToken;
     }
-    if (!loopbackBaseUrl) {
+    if (!loopback) {
       return undefined;
     }
     return loginLocalPassphrase();
   }
+
+  return {
+    hasConfiguredAccessToken: configuredAccessToken !== undefined,
+    isLoopback: loopback,
+    resolveAccessToken,
+  };
+}
+
+// ─── Factory ───
+
+export async function runFridayCliTui(options: FridayCliTuiOptions = {}): Promise<void> {
+  const config: FridayTuiConfig = {
+    ...DEFAULT_TUI_CONFIG,
+    ...(options.apiBaseUrl ? { apiBaseUrl: options.apiBaseUrl } : {}),
+    ...(options.refreshIntervalMs ? { refreshIntervalMs: options.refreshIntervalMs } : {}),
+    ...(options.realtimeEnabled !== undefined ? { realtimeEnabled: options.realtimeEnabled } : {}),
+  };
+  const authCoordinator = createFridayCliTuiAuthCoordinator({
+    apiBaseUrl: config.apiBaseUrl,
+    env: process.env,
+  });
 
   const apiClient = createFridayTuiApiClient({
     async fetchJson<T>(url: string, init?: { method?: string; body?: string; headers?: Record<string, string> }): Promise<T> {
@@ -115,11 +150,11 @@ export async function runFridayCliTui(options: FridayCliTuiOptions = {}): Promis
           },
         });
 
-      let token = await resolveAccessToken(false);
+      let token = await authCoordinator.resolveAccessToken(false);
       let res = await doFetch(token);
 
-      if (res.status === 401 && !configuredAccessToken && loopbackBaseUrl) {
-        token = await resolveAccessToken(true);
+      if (res.status === 401 && !authCoordinator.hasConfiguredAccessToken && authCoordinator.isLoopback) {
+        token = await authCoordinator.resolveAccessToken(true);
         res = await doFetch(token);
       }
 

--- a/src/providers/cli/friday-provider-cli-backend.ts
+++ b/src/providers/cli/friday-provider-cli-backend.ts
@@ -236,17 +236,32 @@ function parseClaudeStatus(stdout: string): Pick<FridayCliSessionStatus, "logged
   }
 }
 
-function parseCodexStatus(stdout: string, stderr: string): Pick<FridayCliSessionStatus, "loggedIn" | "message"> {
+// Exported for focused unit testing of the negative-auth-status parse boundary
+// (Phase 18B CLAW-003). The negative substrings overlap the positive ones
+// ("not logged in" contains "logged in"; "unauthenticated" contains
+// "authenticated"), so the negative branch must be evaluated first.
+export function parseCodexStatus(stdout: string, stderr: string): Pick<FridayCliSessionStatus, "loggedIn" | "message"> {
   const text = `${stdout}\n${stderr}`.trim();
   if (text.length === 0) {
     return { message: "Codex CLI did not emit login status details in this environment" };
   }
   const lowered = text.toLowerCase();
-  if (lowered.includes("logged in") || lowered.includes("authenticated")) {
-    return { loggedIn: true };
-  }
-  if (lowered.includes("not logged in") || lowered.includes("login required")) {
+  if (
+    lowered.includes("not logged in") ||
+    lowered.includes("logged out") ||
+    lowered.includes("unauthenticated") ||
+    lowered.includes("login required") ||
+    lowered.includes("not signed in") ||
+    lowered.includes("signed out")
+  ) {
     return { loggedIn: false };
+  }
+  if (
+    lowered.includes("logged in") ||
+    lowered.includes("signed in") ||
+    lowered.includes("authenticated")
+  ) {
+    return { loggedIn: true };
   }
   return { message: text.slice(0, 240) };
 }

--- a/src/security/friday-owner-session-channel-capability.ts
+++ b/src/security/friday-owner-session-channel-capability.ts
@@ -119,10 +119,14 @@ export function assertBoundActorForSessionOperation(
   actorId: string | null | undefined,
   operation: FridayPublicMutationOperation,
 ): string {
+  // Phase 18B CLAW-044: trim before validating so a whitespace-only actor id
+  // (which is truthy in JavaScript) cannot pass the bound-principal gate or be
+  // propagated downstream as an audit identity.
+  const normalized = typeof actorId === "string" ? actorId.trim() : "";
   if (
-    !actorId ||
-    actorId === FRIDAY_DEFAULT_PUBLIC_HTTP_PRINCIPAL_ID ||
-    actorId === "system"
+    normalized.length === 0 ||
+    normalized === FRIDAY_DEFAULT_PUBLIC_HTTP_PRINCIPAL_ID ||
+    normalized === "system"
   ) {
     throw new FridayDomainError(
       ERROR_CODE_BOUND_PRINCIPAL_REQUIRED,
@@ -130,7 +134,7 @@ export function assertBoundActorForSessionOperation(
       { httpStatus: 401 },
     );
   }
-  return actorId;
+  return normalized;
 }
 
 export interface FridayWorkflowWebhookGateInput {

--- a/test/unit/cli/friday-cli-tui-auth.test.ts
+++ b/test/unit/cli/friday-cli-tui-auth.test.ts
@@ -1,0 +1,141 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, it, expect, vi } from "vitest";
+import { FridayDomainError } from "#errors";
+import {
+  createFridayCliTuiAuthCoordinator,
+  type FridayCliTuiAuthCoordinatorDeps,
+} from "../../../src/cli/friday-cli-tui.js";
+
+const FRIDAY_CLI_TUI_SOURCE_PATH = resolve(
+  __dirname,
+  "../../../src/cli/friday-cli-tui.ts",
+);
+
+const LOOPBACK_BASE_URL = "http://127.0.0.1:4145";
+const REMOTE_BASE_URL = "https://hub.example.com";
+
+function makeJsonResponse(body: unknown, init: { status?: number } = {}): Response {
+  const status = init.status ?? 200;
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makeDeps(
+  overrides: Partial<FridayCliTuiAuthCoordinatorDeps> & {
+    env?: NodeJS.ProcessEnv;
+  } = {},
+): FridayCliTuiAuthCoordinatorDeps {
+  return {
+    apiBaseUrl: LOOPBACK_BASE_URL,
+    env: {},
+    fetchFn: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("CLAW-013 — TUI first-run auth never uses a hard-coded fallback passphrase", () => {
+  it("source no longer contains the historical fallback literal", () => {
+    const src = readFileSync(FRIDAY_CLI_TUI_SOURCE_PATH, "utf8");
+    expect(src).not.toContain("friday-cli-tui-passphrase-123");
+  });
+
+  it("fails closed with a clear non-secret error when no env credential is configured", async () => {
+    const fetchFn = vi.fn();
+    const coordinator = createFridayCliTuiAuthCoordinator(
+      makeDeps({ env: {}, fetchFn }),
+    );
+
+    expect(coordinator.hasConfiguredAccessToken).toBe(false);
+    expect(coordinator.isLoopback).toBe(true);
+
+    await expect(coordinator.resolveAccessToken()).rejects.toBeInstanceOf(FridayDomainError);
+    await expect(coordinator.resolveAccessToken()).rejects.toMatchObject({
+      code: "TUI_AUTH_NOT_CONFIGURED",
+    });
+
+    expect(fetchFn).not.toHaveBeenCalled();
+    const errorMessage = await coordinator
+      .resolveAccessToken()
+      .catch((err: Error) => err.message);
+    expect(errorMessage).not.toContain("friday-cli-tui-passphrase-123");
+  });
+
+  it("does not invent a passphrase when no env credential is set on a remote base URL", async () => {
+    const fetchFn = vi.fn();
+    const coordinator = createFridayCliTuiAuthCoordinator(
+      makeDeps({ apiBaseUrl: REMOTE_BASE_URL, env: {}, fetchFn }),
+    );
+
+    await expect(coordinator.resolveAccessToken()).resolves.toBeUndefined();
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+});
+
+describe("CLAW-013 — explicit env credentials still flow through existing auth paths", () => {
+  it("explicit FRIDAY_TUI_ACCESS_TOKEN bypasses local passphrase login entirely", async () => {
+    const fetchFn = vi.fn();
+    const coordinator = createFridayCliTuiAuthCoordinator(
+      makeDeps({
+        env: { FRIDAY_TUI_ACCESS_TOKEN: "tok-explicit-123" },
+        fetchFn,
+      }),
+    );
+
+    expect(coordinator.hasConfiguredAccessToken).toBe(true);
+    await expect(coordinator.resolveAccessToken()).resolves.toBe("tok-explicit-123");
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("explicit FRIDAY_LOCAL_PASSPHRASE reaches bootstrap + login on a loopback base URL", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(makeJsonResponse({ ok: true, data: { bootstrapRequired: true } }))
+      .mockResolvedValueOnce(makeJsonResponse({ ok: true }))
+      .mockResolvedValueOnce(makeJsonResponse({ ok: true, data: { accessToken: "tok-from-login" } }));
+
+    const coordinator = createFridayCliTuiAuthCoordinator(
+      makeDeps({
+        env: { FRIDAY_LOCAL_PASSPHRASE: "operator-supplied-passphrase" },
+        fetchFn,
+      }),
+    );
+
+    await expect(coordinator.resolveAccessToken()).resolves.toBe("tok-from-login");
+
+    expect(fetchFn).toHaveBeenCalledTimes(3);
+    const [statusCall, bootstrapCall, loginCall] = fetchFn.mock.calls;
+    expect(statusCall[0]).toBe(`${LOOPBACK_BASE_URL}/v1/auth/bootstrap/status`);
+    expect(bootstrapCall[0]).toBe(`${LOOPBACK_BASE_URL}/v1/auth/bootstrap/local-passphrase`);
+    expect(loginCall[0]).toBe(`${LOOPBACK_BASE_URL}/v1/auth/login`);
+
+    const bootstrapBody = JSON.parse(bootstrapCall[1].body) as { localPassphrase?: string };
+    const loginBody = JSON.parse(loginCall[1].body) as { localPassphrase?: string };
+    expect(bootstrapBody.localPassphrase).toBe("operator-supplied-passphrase");
+    expect(loginBody.localPassphrase).toBe("operator-supplied-passphrase");
+  });
+
+  it("FRIDAY_TEST_LOCAL_PASSPHRASE takes precedence over FRIDAY_LOCAL_PASSPHRASE and is used at login", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(makeJsonResponse({ ok: true, data: { bootstrapRequired: false } }))
+      .mockResolvedValueOnce(makeJsonResponse({ ok: true, data: { accessToken: "tok-test-env" } }));
+
+    const coordinator = createFridayCliTuiAuthCoordinator(
+      makeDeps({
+        env: {
+          FRIDAY_TEST_LOCAL_PASSPHRASE: "test-passphrase-explicit",
+          FRIDAY_LOCAL_PASSPHRASE: "should-be-ignored",
+        },
+        fetchFn,
+      }),
+    );
+
+    await expect(coordinator.resolveAccessToken()).resolves.toBe("tok-test-env");
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    const loginBody = JSON.parse(fetchFn.mock.calls[1][1].body) as { localPassphrase?: string };
+    expect(loginBody.localPassphrase).toBe("test-passphrase-explicit");
+  });
+});

--- a/test/unit/providers/cli/friday-provider-cli-backend.test.ts
+++ b/test/unit/providers/cli/friday-provider-cli-backend.test.ts
@@ -3,6 +3,7 @@ import { chmodSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { runFridayCliBackendTextCompletion } from "#providers";
+import { parseCodexStatus } from "../../../../src/providers/cli/friday-provider-cli-backend.js";
 
 describe("friday-provider-cli-backend", () => {
   let testDir: string | undefined;
@@ -33,6 +34,51 @@ describe("friday-provider-cli-backend", () => {
 
     expect(result.length).toBeLessThan(1_100_000);
     expect(result).toContain("stdout truncated");
+  });
+
+  describe("parseCodexStatus (Phase 18B CLAW-003)", () => {
+    it("treats 'Not logged in' as loggedIn=false (does not match the positive substring)", () => {
+      expect(parseCodexStatus("Not logged in.\nRun `codex login` to authenticate.", "")).toEqual({
+        loggedIn: false,
+      });
+    });
+
+    it("treats 'Unauthenticated' as loggedIn=false (does not match the positive 'authenticated' substring)", () => {
+      expect(parseCodexStatus("", "Unauthenticated: please run codex login")).toEqual({
+        loggedIn: false,
+      });
+    });
+
+    it("treats 'Login required' as loggedIn=false", () => {
+      expect(parseCodexStatus("Login required", "")).toEqual({ loggedIn: false });
+    });
+
+    it("treats 'Logged out' as loggedIn=false", () => {
+      expect(parseCodexStatus("Logged out", "")).toEqual({ loggedIn: false });
+    });
+
+    it("treats 'Not signed in' / 'Signed out' as loggedIn=false", () => {
+      expect(parseCodexStatus("Not signed in", "")).toEqual({ loggedIn: false });
+      expect(parseCodexStatus("Signed out", "")).toEqual({ loggedIn: false });
+    });
+
+    it("recognizes 'Logged in as user@example.com' as loggedIn=true", () => {
+      expect(parseCodexStatus("Logged in as user@example.com", "")).toEqual({ loggedIn: true });
+    });
+
+    it("recognizes 'Authenticated' as loggedIn=true", () => {
+      expect(parseCodexStatus("Authenticated.", "")).toEqual({ loggedIn: true });
+    });
+
+    it("returns a message when neither side of the boundary matches", () => {
+      const result = parseCodexStatus("codex-cli 0.1.2", "");
+      expect(result.loggedIn).toBeUndefined();
+      expect(result.message).toContain("codex-cli");
+    });
+
+    it("returns the empty-output message when both streams are empty", () => {
+      expect(parseCodexStatus("", "").message).toContain("did not emit login status");
+    });
   });
 
   function writeMockCli(source: string): string {

--- a/test/unit/security/friday-owner-session-channel-capability.test.ts
+++ b/test/unit/security/friday-owner-session-channel-capability.test.ts
@@ -231,6 +231,77 @@ describe("FridayOwnerSessionChannelCapability", () => {
         assertBoundActorForSessionOperation("user-real-1", "workflow.approval.approve"),
       ).toBe("user-real-1");
     });
+
+    // Phase 18B CLAW-044: whitespace-only actor IDs were treated as bound
+    // principals because `!actorId` returns false for strings like "   ".
+    it("throws when actorId is whitespace-only (spaces)", () => {
+      let thrown: unknown;
+      try {
+        assertBoundActorForSessionOperation("   ", "workflow.approval.approve");
+      } catch (err) {
+        thrown = err;
+      }
+      expect((thrown as { code?: string }).code).toBe(
+        FRIDAY_OWNER_SESSION_CHANNEL_ERROR_CODES.BOUND_PRINCIPAL_REQUIRED,
+      );
+    });
+
+    it("throws when actorId is whitespace-only (tabs and newlines)", () => {
+      let thrown: unknown;
+      try {
+        assertBoundActorForSessionOperation("\t\n  \r", "workflow.approval.reject");
+      } catch (err) {
+        thrown = err;
+      }
+      expect((thrown as { code?: string }).code).toBe(
+        FRIDAY_OWNER_SESSION_CHANNEL_ERROR_CODES.BOUND_PRINCIPAL_REQUIRED,
+      );
+    });
+
+    it("throws when actorId is the empty string", () => {
+      let thrown: unknown;
+      try {
+        assertBoundActorForSessionOperation("", "workflow.approval.approve");
+      } catch (err) {
+        thrown = err;
+      }
+      expect((thrown as { code?: string }).code).toBe(
+        FRIDAY_OWNER_SESSION_CHANNEL_ERROR_CODES.BOUND_PRINCIPAL_REQUIRED,
+      );
+    });
+
+    it("throws when actorId is the synthetic public principal id with surrounding whitespace", () => {
+      let thrown: unknown;
+      try {
+        assertBoundActorForSessionOperation(
+          `  ${FRIDAY_DEFAULT_PUBLIC_HTTP_PRINCIPAL_ID}  `,
+          "workflow.approval.approve",
+        );
+      } catch (err) {
+        thrown = err;
+      }
+      expect((thrown as { code?: string }).code).toBe(
+        FRIDAY_OWNER_SESSION_CHANNEL_ERROR_CODES.BOUND_PRINCIPAL_REQUIRED,
+      );
+    });
+
+    it("throws when actorId is the legacy 'system' fallback with surrounding whitespace", () => {
+      let thrown: unknown;
+      try {
+        assertBoundActorForSessionOperation("  system\n", "workflow.approval.approve");
+      } catch (err) {
+        thrown = err;
+      }
+      expect((thrown as { code?: string }).code).toBe(
+        FRIDAY_OWNER_SESSION_CHANNEL_ERROR_CODES.BOUND_PRINCIPAL_REQUIRED,
+      );
+    });
+
+    it("returns a trimmed actorId when surrounded by whitespace", () => {
+      expect(
+        assertBoundActorForSessionOperation("  user-real-1\t", "workflow.approval.approve"),
+      ).toBe("user-real-1");
+    });
   });
 
   describe("describeWebhookReceiptTrust", () => {


### PR DESCRIPTION
## Scope
Phase 18B / module_31b partial slices only:

- `CLAW-013`: remove TUI hard-coded passphrase fallback.
- `CLAW-003`: prevent Codex CLI negative auth status from being parsed as logged in.
- `CLAW-044`: reject whitespace-only session actor ids at the bound-principal gate.

This PR is **not** Phase 18B closure. It does **not** close all 29 module_31b issues and must not advance Phase 18C by itself.

## What changed
- Removed the historical TUI hard-coded fallback passphrase (`friday-cli-tui-passphrase-123`) from `src/cli/friday-cli-tui.ts`'s first-run bootstrap path.
- Added a testable TUI auth coordinator and focused coverage for configured-token, configured-passphrase, test-passphrase precedence, loopback fail-closed behavior, and source literal absence.
- Exported `parseCodexStatus` for focused unit testing and changed the parser to evaluate negative auth phrases before positive substrings.
- Expanded Codex CLI status parsing for `logged out`, `unauthenticated`, `not signed in`, and `signed out` while preserving positive `logged in`, `signed in`, and `authenticated` cases.
- Trimmed actor ids before `assertBoundActorForSessionOperation` validation so whitespace-only, padded synthetic-public, and padded `system` ids fail closed; valid ids return trimmed.
- Added focused unit coverage for the CLAW-003 and CLAW-044 boundaries.

## Verification already run locally for latest head `b96ac7a97dc1b1445e773e5fd512801f5ee32c28`
- `npm ci`: PASS, matching CI install path.
- `npx vitest run --project default test/unit/providers/cli/friday-provider-cli-backend.test.ts test/unit/security/friday-owner-session-channel-capability.test.ts`: PASS, 2 files / 39 tests.
- `npm run typecheck`: PASS.
- `npm run check:secret-patterns`: PASS, no provider/API key shaped secrets found.
- `git diff --check -- <CLAW-003/044 four files>`: PASS.
- `npx eslint <CLAW-003/044 four files>`: exit 0; 0 errors, warnings only from existing source patterns plus test-file ignore-pattern notices.
- `node /Users/jarvis/.codex/friday-conveyor-bridge/certify-conveyor.mjs`: PASS, including typed partial-slice Stage 6 allowed and full Phase 18B closure blocked.

## Previous same-branch proof for `CLAW-013`
Before `CLAW-003/044` were added, PR head `3acd1eb66da36e1d34dc535d6c1d9b1a7c62bccf` had green CI and RGG. The RGG artifact reported:

- `status: passed`
- `commit_sha: 3acd1eb66da36e1d34dc535d6c1d9b1a7c62bccf`
- `scenarios_run: 82`
- `scenarios_passed: 82`
- `blocked_reasons: []`

That artifact is **not** proof for the new head `b96ac7a...`; Stage 7 must re-check CI/RGG for the new head after this push.

## Honest non-closure
The Phase 18B scope matrix has 29 issue ids. This PR currently covers three of them (`CLAW-013`, `CLAW-003`, `CLAW-044`). The issue ledger still records `phase_closure_allowed=false` and `remaining_issue_count=27` for the current `CLAW-003/044` slice.

Known still-open or decision-blocked 18B items include:

- `CLAW-002`: Codex text backend workspace-read policy, product/security decision needed.
- `CLAW-027`: skill pack output containment policy, data-loss/overwrite decision needed.
- `P1-004`: Task Workflow mutating routes public posture.
- `P0-003` / `P2-002`: F-013 / branch protection truth reconciliation.
- Remaining mapped CLAW issues: `CLAW-004`, `CLAW-005`, `CLAW-016`, `CLAW-021`, `CLAW-022`, `CLAW-025`, `CLAW-026`, `CLAW-028`, `CLAW-029`, `CLAW-030`, `CLAW-032`, `CLAW-033`, `CLAW-035`, `CLAW-036`, `CLAW-037`, `CLAW-038`, `CLAW-039`, `CLAW-040`, `CLAW-041`, `CLAW-042`, `CLAW-043`.

## Safety / approval / proof boundary statement
- No safety policy, approval semantics, memory semantics, provider/MCP/plugin/skill lifecycle semantics, release-proof standard, or default-on behavior is weakened by this PR.
- These slices tighten failure behavior: no hard-coded local auth fallback, no false logged-in status from negative Codex auth strings, and no whitespace actor id passing as a bound principal.
- This PR may be reviewed and tested as a partial slice PR. It must not be described as Phase 18B completion or public-v1 safety closure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
