### PR TITLE
Phase 18B - CLAW-004 CLI run false-success guard

### DIFF
--- a/src/cli/friday-cli.ts
+++ b/src/cli/friday-cli.ts
@@ -1471,6 +1471,23 @@ function printCliSkillRunResult(
   }
 }
 
+function isCliSkillRunSuccessful(result: FridayCliSkillRunResult): boolean {
+  return result.status === "completed";
+}
+
+function markCliSkillRunFailure(
+  logger: Pick<typeof console, "log" | "error">,
+  result: FridayCliSkillRunResult,
+  setExitCode: (code: number) => void,
+): void {
+  if (isCliSkillRunSuccessful(result)) {
+    return;
+  }
+
+  logger.error(`Error: skill run ${result.runId} ended with status "${result.status}".`);
+  setExitCode(1);
+}
+
 async function runCliSkillRemotely(params: {
   parsed: ParsedArgs;
   baseUrl: string;
@@ -1558,6 +1575,7 @@ export async function runCliSkillCommand(
       fetchFn: deps.fetchFn ?? fetch,
     });
     printCliSkillRunResult(logger, result);
+    markCliSkillRunFailure(logger, result, setExitCode);
     return;
   }
 
@@ -1576,6 +1594,7 @@ export async function runCliSkillCommand(
 
   const result = await handle.result;
   printCliSkillRunResult(logger, result);
+  markCliSkillRunFailure(logger, result, setExitCode);
 
   await hub.stop();
 }

--- a/src/providers/cli/friday-provider-cli-backend.ts
+++ b/src/providers/cli/friday-provider-cli-backend.ts
@@ -238,7 +238,7 @@ function parseClaudeStatus(stdout: string): Pick<FridayCliSessionStatus, "logged
 
 // Exported for focused unit testing of the negative-auth-status parse boundary
 // (Phase 18B CLAW-003). The negative substrings overlap the positive ones
-// ("not logged in" contains "logged in"; "unauthenticated" contains
+// ("not logged in" contains "logged in"; negative authenticated forms contain
 // "authenticated"), so the negative branch must be evaluated first.
 export function parseCodexStatus(stdout: string, stderr: string): Pick<FridayCliSessionStatus, "loggedIn" | "message"> {
   const text = `${stdout}\n${stderr}`.trim();
@@ -250,6 +250,7 @@ export function parseCodexStatus(stdout: string, stderr: string): Pick<FridayCli
     lowered.includes("not logged in") ||
     lowered.includes("logged out") ||
     lowered.includes("unauthenticated") ||
+    lowered.includes("not authenticated") ||
     lowered.includes("login required") ||
     lowered.includes("not signed in") ||
     lowered.includes("signed out")

--- a/test/unit/cli/friday-cli.test.ts
+++ b/test/unit/cli/friday-cli.test.ts
@@ -661,6 +661,49 @@ describe("runCliSkillCommand", () => {
     expect(logs.some((line) => line.includes("remote ok"))).toBe(true);
   });
 
+  it("sets a nonzero exit code when a remote skill run reports failed", async () => {
+    const parsed = parseArgs(argv("run", "demo-skill"));
+    const logs: string[] = [];
+    let exitCode: number | undefined;
+
+    const fetchFn: typeof fetch = async () => new Response(JSON.stringify({
+      ok: true,
+      data: {
+        runId: "run-remote-failed",
+        status: "failed",
+        durationMs: 13,
+        output: { code: "SKILL_FAILED" },
+        stderr: "remote failed",
+      },
+    }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+
+    await runCliSkillCommand(parsed, {
+      env: {
+        FRIDAY_HUB_URL: "https://hub.example.test",
+        FRIDAY_ACCESS_TOKEN: "secret-token",
+      },
+      createHub: async () => {
+        throw new Error("createHub should not be called for remote execution");
+      },
+      fetchFn,
+      logger: {
+        log: (...args: unknown[]) => logs.push(args.map((value) => String(value)).join(" ")),
+        error: (...args: unknown[]) => logs.push(args.map((value) => String(value)).join(" ")),
+      },
+      setExitCode: (code) => {
+        exitCode = code;
+      },
+    });
+
+    expect(exitCode).toBe(1);
+    expect(logs.some((line) => line.includes("Run run-remote-failed — failed (13ms)"))).toBe(true);
+    expect(logs.some((line) => line.includes("remote failed"))).toBe(true);
+    expect(logs.some((line) => line.includes("ended with status \"failed\""))).toBe(true);
+  });
+
   it("falls back to an embedded hub when no remote hub env is configured", async () => {
     const parsed = parseArgs(argv("run", "demo-skill"));
     const logs: string[] = [];
@@ -708,6 +751,55 @@ describe("runCliSkillCommand", () => {
     expect(executeCount).toBe(1);
     expect(stopCount).toBe(1);
     expect(logs.some((line) => line.includes("Run run-local-1 — completed (9ms)"))).toBe(true);
+  });
+
+  it("sets a nonzero exit code when an embedded skill run reports failed", async () => {
+    const parsed = parseArgs(argv("run", "demo-skill"));
+    const logs: string[] = [];
+    let exitCode: number | undefined;
+    let stopCount = 0;
+
+    const localHub = {
+      start: async () => {},
+      stop: async () => {
+        stopCount += 1;
+      },
+      executor: {
+        execute() {
+          return {
+            result: Promise.resolve({
+              runId: "run-local-failed",
+              status: "failed",
+              durationMs: 7,
+              output: { code: "SKILL_FAILED" },
+              stdout: "",
+              stderr: "local failed",
+            }),
+          };
+        },
+      },
+    };
+
+    await runCliSkillCommand(parsed, {
+      env: {},
+      createHub: (async () => localHub) as FridayCliRunCommandDeps["createHub"],
+      fetchFn: async () => {
+        throw new Error("fetch should not be called for local execution");
+      },
+      logger: {
+        log: (...args: unknown[]) => logs.push(args.map((value) => String(value)).join(" ")),
+        error: (...args: unknown[]) => logs.push(args.map((value) => String(value)).join(" ")),
+      },
+      setExitCode: (code) => {
+        exitCode = code;
+      },
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stopCount).toBe(1);
+    expect(logs.some((line) => line.includes("Run run-local-failed — failed (7ms)"))).toBe(true);
+    expect(logs.some((line) => line.includes("local failed"))).toBe(true);
+    expect(logs.some((line) => line.includes("ended with status \"failed\""))).toBe(true);
   });
 
   it("fails fast when only one remote-hub env var is configured", async () => {

--- a/test/unit/providers/cli/friday-provider-cli-backend.test.ts
+++ b/test/unit/providers/cli/friday-provider-cli-backend.test.ts
@@ -49,6 +49,12 @@ describe("friday-provider-cli-backend", () => {
       });
     });
 
+    it("treats 'Not authenticated' as loggedIn=false", () => {
+      expect(parseCodexStatus("Not authenticated. Run `codex login`.", "")).toEqual({
+        loggedIn: false,
+      });
+    });
+
     it("treats 'Login required' as loggedIn=false", () => {
       expect(parseCodexStatus("Login required", "")).toEqual({ loggedIn: false });
     });


### PR DESCRIPTION
## Scope
Phase 18B partial slice only: `CLAW-004`.

This PR is not Phase 18B closure. It does not close all 29 Phase 18B issues and must not advance Phase 18C by itself.

## Problem
`friday run` could print a failed skill run result while leaving the CLI exit code successful.

Plain-language example: if a skill returns status `failed`, a shell script or operator could still see the command as green.

## What changed
- Added a shared CLI result status check that treats only `completed` as success.
- Applied that check to both remote hub and embedded hub `friday run` paths after printing the run result.
- Added focused tests for remote failed runs and embedded failed runs.
- Preserved the prior CLAW-003 reviewer-blocker fix so `Not authenticated` is parsed as `loggedIn=false`.

## Verification run locally for head `b0e7954e35dc12a48bcab07066a380c7bed86f94`
- `npm test -- --run test/unit/cli/friday-cli.test.ts test/unit/providers/cli/friday-provider-cli-backend.test.ts test/unit/security/friday-owner-session-channel-capability.test.ts test/unit/cli/friday-cli-tui-auth.test.ts`: PASS, 4 files / 142 tests.
- `npm run typecheck`: PASS.
- `npm run check:secret-patterns`: PASS, no provider/API key shaped secrets found.
- `git diff --check origin/main...HEAD`: PASS.
- `npx eslint <touched/relevant files>`: exit 0; 0 errors, warnings only from existing source patterns plus test-file ignore-pattern notices.

## Reviewers
- Reviewer A: PASS, checked factual correctness, paths, cleanup, missed entrypoints, and scope accounting.
- Reviewer B: PASS, checked regression risk, no overclaim, no fake proof, no secret leakage, no test weakening, no scope creep, and auto-merge/proof boundaries.

## Prior Phase 18B context
PR #248 is already merged at merge commit `76d27719a00554d60ef54fb26b01e04cc09a77a9` and covered only `CLAW-013`, `CLAW-003`, and `CLAW-044`.

This PR covers `CLAW-004` only. The issue ledger still records Phase 18B as open with remaining issues outside this slice.

## Auto-merge gate
Auto-merge is allowed only after:
- required CI checks pass for this PR head SHA,
- same-SHA RGG artifact is downloaded/read and reports `status=passed`, scenarios nonzero, all scenarios passing, blockers empty,
- two isolated reviewers are recorded as passed,
- PR-side owner-bypass checklist/comment is present if needed because live branch protection has `enforce_admins.enabled=false`,
- merge result is fetched and ledger/cursor are updated.
