### PR TITLE
Phase 18B - CLAW-027 pack output containment

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -128,7 +128,7 @@
     {
       "path": "detect_secrets.filters.regex.should_exclude_file",
       "pattern": [
-        "(^|/)\\.secrets\\.baseline$|(^|/)node_modules(/|$)|(^|/)dist(/|$)|(^|/)coverage(/|$)|(^|/)package-lock\\.json$|(^|/)pnpm-lock\\.yaml$|\\.snap$|(^|/)managed-skills/[^/]+/conversion\\.report\\.json$|(^|/)docs/reports/ops/.*\\.csv$|(^|/)docs/reports/ops/real-green-gate/.*\\.json$|(^|/)docs/reports/repo/FRIDAY_.*\\.json$|(^|/)audit-fix/[^/]+\\.(csv|json)$|(^|/)audit-fix/fix-phase-status/.*\\.(csv|json)$|(^|/)audit-fix/post-fix-evidence/.*\\.(json|csv|txt|png)$|(^|/)audit-fix/runtime/.*\\.(json|jsonl|txt|png|csv)$|(^|/)screenshots/.*\\.(json|png|pdf|txt|html)$|(^|/)polish-report\\.html$|(^|/)friday-static\\.prod\\.html$|(^|/)friday-static\\.html$"
+        "(^|/)node_modules(/|$)|(^|/)dist(/|$)|(^|/)coverage(/|$)|(^|/)package-lock\\.json$|(^|/)pnpm-lock\\.yaml$|\\.snap$|(^|/)managed-skills/[^/]+/conversion\\.report\\.json$|(^|/)docs/reports/ops/.*\\.csv$|(^|/)docs/reports/ops/real-green-gate/.*\\.json$|(^|/)docs/reports/repo/FRIDAY_.*\\.json$|(^|/)audit-fix/[^/]+\\.(csv|json)$|(^|/)audit-fix/fix-phase-status/.*\\.(csv|json)$|(^|/)audit-fix/post-fix-evidence/.*\\.(json|csv|txt|png)$|(^|/)audit-fix/runtime/.*\\.(json|jsonl|txt|png|csv)$|(^|/)screenshots/.*\\.(json|png|pdf|txt|html)$|(^|/)polish-report\\.html$|(^|/)friday-static\\.prod\\.html$|(^|/)friday-static\\.html$"
       ]
     }
   ],
@@ -772,7 +772,7 @@
         "filename": "test/unit/api/http/routes/friday-skill-converter-routes.test.ts",
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_verified": false,
-        "line_number": 113
+        "line_number": 115
       }
     ],
     "test/unit/api/realtime/friday-realtime-ws-gateway.test.ts": [
@@ -1124,5 +1124,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-15T07:09:45Z"
+  "generated_at": "2026-05-18T21:24:05Z"
 }

--- a/scripts/e2e/run-friday-external-closure.mjs
+++ b/scripts/e2e/run-friday-external-closure.mjs
@@ -464,10 +464,9 @@ async function main() {
     report.steps.externalFileSkill = { skillId: fileSkillId, status: fileRun.json.data.status };
 
     const nativeSkillDir = writeNativeSkill(sourceRoot, "external-native-echo");
-    const packPath = path.join(runRoot, "external-native-echo.friday.tgz");
     const pack = await mustOk("native skill pack", api(runtime.baseUrl, runtime.token, "POST", "/v1/skills/pack", {
       skillDir: nativeSkillDir,
-      outputFile: packPath,
+      outputFile: "external-native-echo.friday.tgz",
     }));
     const nativeImport = await mustOk("native package import", api(runtime.baseUrl, runtime.token, "POST", "/v1/skills/import", {
       source: { uri: pack.json.data.packageFile },

--- a/src/api/http/routes/friday-skill-converter-routes.ts
+++ b/src/api/http/routes/friday-skill-converter-routes.ts
@@ -9,6 +9,7 @@
 
 import type { FridayRouteDefinition } from "../../model/friday-api-common.types.js";
 import { FridayDomainError } from "#errors";
+import { basename, isAbsolute, join } from "node:path";
 import {
   createFridaySkillCandidateSourceProvenance,
   createFridaySkillStageMutatingActionRequest,
@@ -219,7 +220,7 @@ function validateImportBody(
 
 function validatePackBody(
   body: unknown,
-): asserts body is { skillDir: string; outputFile: string } {
+): asserts body is { skillDir: string; outputFile?: string } {
   if (body == null || typeof body !== "object") {
     throw new FridayDomainError(
       "VALIDATION_ERROR",
@@ -234,8 +235,8 @@ function validatePackBody(
     errors.push("skillDir is required and must be a non-empty string");
   }
 
-  if (typeof b.outputFile !== "string" || b.outputFile.trim() === "") {
-    errors.push("outputFile is required and must be a non-empty string");
+  if (b.outputFile !== undefined && (typeof b.outputFile !== "string" || b.outputFile.trim() === "")) {
+    errors.push("outputFile must be a non-empty filename when provided");
   }
 
   if (errors.length > 0) {
@@ -247,11 +248,55 @@ function validatePackBody(
   }
 }
 
+const SAFE_PACK_OUTPUT_NAME = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+
+function derivePackOutputName(skillDir: string): string {
+  const trimmedDir = skillDir.trim().replace(/[\\/]+$/, "");
+  const rawName = basename(trimmedDir) || "skill-package";
+  const safeStem = rawName
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^[._-]+|[._-]+$/g, "");
+  return `${safeStem || "skill-package"}.friday.tgz`;
+}
+
+function readContainedPackOutputName(input: { skillDir: string; outputFile?: string }): string {
+  if (input.outputFile === undefined) {
+    return derivePackOutputName(input.skillDir);
+  }
+
+  const outputName = input.outputFile.trim();
+  if (
+    outputName.includes("\0")
+    || outputName.includes("/")
+    || outputName.includes("\\")
+    || outputName.includes("..")
+    || isAbsolute(outputName)
+    || outputName === "."
+    || outputName === ".."
+  ) {
+    throw new FridayDomainError(
+      "VALIDATION_ERROR",
+      "outputFile must be a contained filename, not a filesystem path",
+      { httpStatus: 400 },
+    );
+  }
+  if (!SAFE_PACK_OUTPUT_NAME.test(outputName)) {
+    throw new FridayDomainError(
+      "VALIDATION_ERROR",
+      "outputFile must use only letters, numbers, dot, underscore, or dash and must not start with punctuation",
+      { httpStatus: 400 },
+    );
+  }
+  return outputName;
+}
+
 // ─── Dependencies ───
 
 export interface FridaySkillConverterRoutesDeps {
   converterService: FridaySkillConverterService;
   canonicalMutationGate?: FridayMutatingActionGate;
+  packOutputDir?: string;
 }
 
 function createActorFromPrincipal(
@@ -415,9 +460,17 @@ export function createFridaySkillConverterRoutes(
       async handler(ctx): Promise<FridayApiPackResponse> {
         validatePackBody(ctx.body);
         const body = ctx.body;
+        if (!deps.packOutputDir) {
+          throw new FridayDomainError(
+            "SKILL_PACK_OUTPUT_UNAVAILABLE",
+            "Skill pack output containment directory is not configured.",
+            { httpStatus: 503 },
+          );
+        }
+        const outputFile = join(deps.packOutputDir, readContainedPackOutputName(body));
         const result = await deps.converterService.pack({
           skillDir: body.skillDir,
-          outputFile: body.outputFile,
+          outputFile,
         });
         return {
           packageFile: result.packageFile,

--- a/src/api/model/friday-api-skill-converter.types.ts
+++ b/src/api/model/friday-api-skill-converter.types.ts
@@ -42,7 +42,11 @@ export interface FridayApiImportRequest {
 
 export interface FridayApiPackRequest {
   skillDir: string;
-  outputFile: string;
+  /**
+   * Optional contained package filename for API/UI callers.
+   * Filesystem paths are intentionally rejected by the HTTP route.
+   */
+  outputFile?: string;
 }
 
 // ─── Response types ───

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { join } from "node:path";
 
 import { FridayDomainError } from "#errors";
 import { createFridayMemoryGuardServiceFactory, createFridayMemoryItemRepository } from "#memory";
@@ -2671,6 +2672,7 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
     for (const route of createFridaySkillConverterRoutes({
       converterService: deps.converterService,
       canonicalMutationGate,
+      packOutputDir: join(stateDir, "artifacts", "skill-packs"),
     })) {
       routes.register(route);
     }

--- a/test/unit/api/http/routes/friday-skill-converter-routes.test.ts
+++ b/test/unit/api/http/routes/friday-skill-converter-routes.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+import { join } from "node:path";
 import { createFridaySkillConverterRoutes } from "#api";
 import { FridayDomainError } from "#errors";
 import type { FridaySkillConverterService } from "#hub";
@@ -14,6 +15,7 @@ import {
 import type { FridayApiImportRequest } from "../../../../../src/api/model/friday-api-skill-converter.types.js";
 
 const NOW = "2026-02-17T10:00:00.000Z";
+const PACK_OUTPUT_DIR = "/tmp/friday-contained-pack-output";
 const PRINCIPAL = {
   principalType: "user" as const,
   principalId: "user-1",
@@ -122,7 +124,7 @@ describe("FridaySkillConverterRoutes", () => {
       nowIso: () => NOW,
       ticketIdGenerator: () => "ticket-1",
     });
-    const routes = createFridaySkillConverterRoutes({ converterService, canonicalMutationGate });
+    const routes = createFridaySkillConverterRoutes({ converterService, canonicalMutationGate, packOutputDir: PACK_OUTPUT_DIR });
     return { routes, converterService };
   }
 
@@ -133,7 +135,7 @@ describe("FridaySkillConverterRoutes", () => {
       ticketIdGenerator: () => "signed-ticket-1",
       approvalSignatureSecret: secret,
     });
-    const routes = createFridaySkillConverterRoutes({ converterService, canonicalMutationGate });
+    const routes = createFridaySkillConverterRoutes({ converterService, canonicalMutationGate, packOutputDir: PACK_OUTPUT_DIR });
     return { routes, converterService };
   }
 
@@ -810,13 +812,16 @@ describe("FridaySkillConverterRoutes", () => {
       ).rejects.toThrow("skillDir is required");
     });
 
-    it("validates missing outputFile", async () => {
-      const { routes } = createRoutes();
+    it("accepts missing outputFile and writes to the contained pack directory", async () => {
+      const { routes, converterService } = createRoutes();
       const route = routes.find((r) => r.operationId === "skills.pack")!;
 
-      await expect(
-        route.handler(makeCtx({ body: { skillDir: "/skills/test" } })),
-      ).rejects.toThrow("outputFile is required");
+      await route.handler(makeCtx({ body: { skillDir: "/skills/test-skill" } }));
+
+      expect(converterService.pack).toHaveBeenCalledWith({
+        skillDir: "/skills/test-skill",
+        outputFile: join(PACK_OUTPUT_DIR, "test-skill.friday.tgz"),
+      });
     });
 
     it("validates empty skillDir", async () => {
@@ -830,6 +835,18 @@ describe("FridaySkillConverterRoutes", () => {
       ).rejects.toThrow("skillDir is required");
     });
 
+    it("rejects caller-selected filesystem paths for API pack output", async () => {
+      const { routes, converterService } = createRoutes();
+      const route = routes.find((r) => r.operationId === "skills.pack")!;
+
+      await expect(
+        route.handler(
+          makeCtx({ body: { skillDir: "/path/to/skill", outputFile: "/tmp/skill.friday.tgz" } }),
+        ),
+      ).rejects.toThrow("outputFile must be a contained filename");
+      expect(converterService.pack).not.toHaveBeenCalled();
+    });
+
     it("calls pack with valid body", async () => {
       const { routes, converterService } = createRoutes();
       const route = routes.find((r) => r.operationId === "skills.pack")!;
@@ -838,14 +855,14 @@ describe("FridaySkillConverterRoutes", () => {
         makeCtx({
           body: {
             skillDir: "/path/to/skill",
-            outputFile: "/tmp/skill.friday.tgz",
+            outputFile: "skill.friday.tgz",
           },
         }),
       ) as { packageFile: string; checksumSha256: string };
 
       expect(converterService.pack).toHaveBeenCalledWith({
         skillDir: "/path/to/skill",
-        outputFile: "/tmp/skill.friday.tgz",
+        outputFile: join(PACK_OUTPUT_DIR, "skill.friday.tgz"),
       });
       expect(result.packageFile).toBe("/tmp/test-skill-1.0.0.friday.tgz");
       expect(result.checksumSha256).toBe("abc123def456");

--- a/ui/src/lib/api/skills.ts
+++ b/ui/src/lib/api/skills.ts
@@ -68,7 +68,7 @@ interface ImportInput {
 
 interface PackInput {
   skillDir: string;
-  outputFile: string;
+  outputFile?: string;
 }
 
 interface SkillCatalogResponse {


### PR DESCRIPTION
## Friday Phase 18B partial slice

Issue slice: CLAW-027

This is a partial Phase 18B PR only. It must not be treated as Phase 18B closure; phase closure remains blocked until the issue ledger says all 29 required issues have terminal outcomes and the phase closure gate passes.

## Problem

`POST /v1/skills/pack` accepted caller-selected filesystem output paths. API/UI callers could direct archive writes outside a Friday-managed artifact area, while the approved product decision keeps CLI expert explicit paths available.

## Fix

- API route now accepts only an optional contained filename for `outputFile`.
- API route writes pack output under `stateDir/artifacts/skill-packs`.
- Path-like API output values are rejected before calling the converter service.
- CLI `friday pack --out` remains unchanged and continues to support explicit expert paths.
- UI API client and external closure script were aligned with the contained API contract.

## Local verification

- `node --check scripts/e2e/run-friday-external-closure.mjs`: PASS
- `npm test -- --run test/unit/api/http/routes/friday-skill-converter-routes.test.ts test/contracts/api/friday-converter-format-parity.contract.test.ts test/unit/api/http/routes/friday-api-audit-fixes.test.ts test/unit/skills/converter/friday-skill-converter-service.test.ts test/unit/skills/converter/friday-skill-package-archive.test.ts`: PASS, 111 tests, type errors 0
- `npm run typecheck`: PASS
- `npm run check:secret-patterns`: PASS
- `git diff --check`: PASS
- `npx eslint src/api/http/routes/friday-skill-converter-routes.ts src/api/model/friday-api-skill-converter.types.ts src/api/runtime/friday-api-runtime.ts scripts/e2e/run-friday-external-closure.mjs ui/src/lib/api/skills.ts test/unit/api/http/routes/friday-skill-converter-routes.test.ts`: exit 0, warnings only

## Stage 5 reviewers

- Reviewer A rerun: PASS (`019e3ced-80f0-7760-8d2b-ccaca7ecff94`)
- Reviewer B rerun: PASS (`019e3ced-812c-7743-beaa-ac86e702863d`)

## Merge gate / owner-bypass note

Auto-merge is allowed only if all required gates pass for this PR head SHA: CI required checks success, RGG same-SHA artifact status passed with scenarios nonzero/all passed/blockers empty, two isolated reviewers passed, and PR/head/ledger facts are recorded honestly.

No second write-access reviewer is available because this is a single-maintainer repository/workflow for this Friday phase.

Owner-bypass is not pre-authorized for this PR if branch protection would require it, because this slice touches a data-loss/safety boundary. If normal merge is not available after checks pass, stop and record a typed blocker instead of bypass-merging.

## Residual risk

This PR closes the API/UI output containment issue for pack archive destinations. It does not claim to solve the separate `skillDir` source-read boundary or Phase 18B closure.
