### PR TITLE
Productize frugal routing modes

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -332,7 +332,7 @@
         "filename": "src/api/http/routes/friday-provider-routes.ts",
         "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
         "is_verified": false,
-        "line_number": 266
+        "line_number": 267
       }
     ],
     "src/api/http/routes/friday-setup-routes.ts": [
@@ -953,21 +953,21 @@
         "filename": "test/unit/providers/services/friday-provider-service.test.ts",
         "hashed_secret": "e5dee5d8a3b145b7ad98c144117ec048267d081e",
         "is_verified": false,
-        "line_number": 2533
+        "line_number": 2723
       },
       {
         "type": "Secret Keyword",
         "filename": "test/unit/providers/services/friday-provider-service.test.ts",
         "hashed_secret": "75edc4331554c94b0129b60f3d1af4eba2c43728",
         "is_verified": false,
-        "line_number": 2792
+        "line_number": 2982
       },
       {
         "type": "Secret Keyword",
         "filename": "test/unit/providers/services/friday-provider-service.test.ts",
         "hashed_secret": "21dc1586ee0cca57be27bf18763edad10fe73015",
         "is_verified": false,
-        "line_number": 2811
+        "line_number": 3001
       }
     ],
     "test/unit/rules/engine/context-redactor.test.ts": [
@@ -1124,5 +1124,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-19T06:10:19Z"
+  "generated_at": "2026-05-19T09:37:28Z"
 }

--- a/src/agent/tools/friday-agent-provider-tool.ts
+++ b/src/agent/tools/friday-agent-provider-tool.ts
@@ -457,11 +457,16 @@ export function createFridayAgentProviderTool(
       return errorResult(`Provider "${providerId}" not found.`);
     }
     const defaultModel = requestedDefaultModel ?? provider.defaultModel;
+    const existingRouting = await providerService.getRoutingConfig();
 
     const routing = await providerService.setRoutingConfig({
       defaultProviderId: providerId,
       defaultModel,
       fallbackProviderIds: [],
+      ...(existingRouting.costMode ? { costMode: existingRouting.costMode } : {}),
+      ...(existingRouting.enforceRequestedModel !== undefined
+        ? { enforceRequestedModel: existingRouting.enforceRequestedModel }
+        : {}),
     });
 
     return jsonResult({

--- a/src/api/http/routes/friday-provider-routes.ts
+++ b/src/api/http/routes/friday-provider-routes.ts
@@ -63,6 +63,7 @@ const VALID_BACKEND_KINDS = new Set<string>(FRIDAY_PROVIDER_BACKEND_KINDS);
 const VALID_AUTH_MODES = new Set(["api-key", "bearer-token", "oauth", "token", "external-session", "none"]);
 const VALID_DEPLOYMENT_KINDS = new Set(["hosted", "local", "self-hosted", "consumer-cli"]);
 const VALID_REGION_TAGS = new Set(["global", "us", "china", "local", "custom"]);
+const VALID_ROUTING_COST_MODES = new Set(["frugal", "standard", "strict"]);
 const VALID_RUNTIME_CAPABILITIES = new Set<string>(FRIDAY_RUNTIME_CAPABILITY_IDS);
 
 function parseCapabilityDoctorProviderIds(body: unknown): string[] | undefined {
@@ -366,6 +367,9 @@ function validateRoutingBody(body: unknown): asserts body is FridaySetRoutingCon
   }
   if (b.defaultModel !== undefined && typeof b.defaultModel !== "string") {
     errors.push("defaultModel must be a string when provided");
+  }
+  if (b.costMode !== undefined && (typeof b.costMode !== "string" || !VALID_ROUTING_COST_MODES.has(b.costMode))) {
+    errors.push("costMode must be one of: frugal, standard, strict");
   }
   if (b.enforceRequestedModel !== undefined && typeof b.enforceRequestedModel !== "boolean") {
     errors.push("enforceRequestedModel must be a boolean when provided");

--- a/src/api/model/friday-api-provider.types.ts
+++ b/src/api/model/friday-api-provider.types.ts
@@ -67,6 +67,7 @@ export interface FridaySetRoutingConfigRequest {
   defaultProviderId: string;
   defaultModel?: string;
   fallbackProviderIds: string[];
+  costMode?: FridayModelRoutingConfig["costMode"];
   enforceRequestedModel?: boolean;
 }
 

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -1446,6 +1446,7 @@ export function createFridayHubAutoFixExecutionSupport(deps: {
           defaultProviderId: restoreProviderId,
           defaultModel: restoreModel,
           fallbackProviderIds: restoreFallbackProviderIds,
+          costMode: normalizedRouting.costMode,
           ...(restoreEnforceRequestedModel !== undefined
             ? { enforceRequestedModel: restoreEnforceRequestedModel }
             : normalizedRouting.enforceRequestedModel !== undefined
@@ -1492,6 +1493,7 @@ export function createFridayHubAutoFixExecutionSupport(deps: {
         defaultProviderId: nextProviderId,
         defaultModel: nextModel,
         fallbackProviderIds,
+        costMode: normalizedRouting.costMode,
         ...(normalizedRouting.enforceRequestedModel !== undefined
           ? { enforceRequestedModel: normalizedRouting.enforceRequestedModel }
           : {}),

--- a/src/providers/cost/friday-provider-cost-router.ts
+++ b/src/providers/cost/friday-provider-cost-router.ts
@@ -1,4 +1,5 @@
 import type { FridayResolvedProviderRoute } from "../model/friday-provider.types.js";
+import type { FridayProviderRoutingCostMode } from "../model/friday-provider.types.js";
 import type {
   FridayCostRoutingDecision,
   FridayLlmBudgetStatus,
@@ -12,6 +13,45 @@ const QUALITY_TIER_SCORE: Record<string, number> = {
   cheap: 0.1,
 };
 
+function scoreByCost(
+  candidate: FridayResolvedProviderRoute,
+  pricingCatalog: FridayProviderPricingCatalog,
+): number {
+  const pricing = pricingCatalog.getPricing(
+    candidate.provider.kind,
+    candidate.model,
+  );
+  const costScore = 1 - Math.min(pricing.inputPer1MUsd / 20, 1);
+  const qualityScore = QUALITY_TIER_SCORE[pricing.qualityTier] ?? 0.5;
+  return costScore * 0.95 + qualityScore * 0.05;
+}
+
+function scoreByBudgetDowngrade(
+  candidate: FridayResolvedProviderRoute,
+  pricingCatalog: FridayProviderPricingCatalog,
+): number {
+  const pricing = pricingCatalog.getPricing(
+    candidate.provider.kind,
+    candidate.model,
+  );
+  const costScore = 1 - Math.min(pricing.inputPer1MUsd / 20, 1);
+  const qualityScore = QUALITY_TIER_SCORE[pricing.qualityTier] ?? 0.5;
+  return costScore * 0.80 + qualityScore * 0.20;
+}
+
+function scoreByQuality(
+  candidate: FridayResolvedProviderRoute,
+  pricingCatalog: FridayProviderPricingCatalog,
+): number {
+  const pricing = pricingCatalog.getPricing(
+    candidate.provider.kind,
+    candidate.model,
+  );
+  const qualityScore = QUALITY_TIER_SCORE[pricing.qualityTier] ?? 0.5;
+  const costScore = 1 - Math.min(pricing.inputPer1MUsd / 20, 1);
+  return qualityScore * 0.85 + costScore * 0.15;
+}
+
 // ─── Interface ───
 
 export interface FridayProviderCostRouter {
@@ -20,6 +60,7 @@ export interface FridayProviderCostRouter {
     estimatedInputTokens: number;
     complexity: FridayTaskComplexity;
     budget: FridayLlmBudgetStatus;
+    costMode?: FridayProviderRoutingCostMode;
   }): FridayCostRoutingDecision;
 }
 
@@ -33,6 +74,7 @@ export function createFridayProviderCostRouter(deps: {
   return {
     planRoutes(params) {
       const { candidates, estimatedInputTokens, complexity, budget } = params;
+      const costMode = params.costMode ?? "standard";
       const budgetState = budget.state;
 
       // Over-limit: only allow free/local providers (ollama)
@@ -43,6 +85,7 @@ export function createFridayProviderCostRouter(deps: {
 
         return {
           strategy: "budget_local_only",
+          costMode,
           complexity,
           budgetState,
           estimatedInputTokens,
@@ -57,20 +100,16 @@ export function createFridayProviderCostRouter(deps: {
       if (budgetState === "near_limit") {
         const scored = candidates
           .map((candidate) => {
-            const pricing = pricingCatalog.getPricing(
-              candidate.provider.kind,
-              candidate.model,
-            );
-            // When near limit, force cost-priority scoring
-            const costScore = 1 - Math.min(pricing.inputPer1MUsd / 20, 1);
-            const qualityScore = QUALITY_TIER_SCORE[pricing.qualityTier] ?? 0.5;
-            const total = costScore * 0.80 + qualityScore * 0.20;
-            return { candidate, score: total };
+            return {
+              candidate,
+              score: scoreByBudgetDowngrade(candidate, pricingCatalog),
+            };
           })
           .sort((a, b) => b.score - a.score);
 
         return {
           strategy: "budget_downgrade",
+          costMode,
           complexity,
           budgetState,
           estimatedInputTokens,
@@ -79,10 +118,49 @@ export function createFridayProviderCostRouter(deps: {
         };
       }
 
+      if (costMode === "frugal") {
+        const scored = candidates
+          .map((candidate) => ({
+            candidate,
+            score: scoreByCost(candidate, pricingCatalog),
+          }))
+          .sort((a, b) => b.score - a.score);
+
+        return {
+          strategy: "cost_auto",
+          costMode,
+          complexity,
+          budgetState,
+          estimatedInputTokens,
+          orderedCandidates: scored.map((s) => s.candidate),
+          reason: "Frugal mode: eligible candidates re-ordered to prefer lower-cost models",
+        };
+      }
+
+      if (costMode === "strict") {
+        const scored = candidates
+          .map((candidate) => ({
+            candidate,
+            score: scoreByQuality(candidate, pricingCatalog),
+          }))
+          .sort((a, b) => b.score - a.score);
+
+        return {
+          strategy: "configured",
+          costMode,
+          complexity,
+          budgetState,
+          estimatedInputTokens,
+          orderedCandidates: scored.map((s) => s.candidate),
+          reason: "Strict mode: eligible candidates re-ordered to prefer higher-quality models",
+        };
+      }
+
       // Normal: preserve the operator-configured order. Cost routing may only
       // reorder when a budget policy explicitly requires a downgrade.
       return {
         strategy: "configured",
+        costMode,
         complexity,
         budgetState,
         estimatedInputTokens,

--- a/src/providers/model/friday-provider-cost.types.ts
+++ b/src/providers/model/friday-provider-cost.types.ts
@@ -1,6 +1,7 @@
 import type {
   FridayProviderApi,
   FridayProviderKind,
+  FridayProviderRoutingCostMode,
   FridayProviderRoutingDecisionTrace,
   FridayProviderRoutingReasonCode,
   FridayResolvedProviderRoute,
@@ -76,6 +77,7 @@ export interface FridayLlmBudgetStatus {
 
 export interface FridayCostRoutingDecision {
   strategy: FridayProviderRouteStrategy;
+  costMode?: FridayProviderRoutingCostMode;
   complexity: FridayTaskComplexity;
   budgetState: FridayBudgetState;
   estimatedInputTokens: number;

--- a/src/providers/model/friday-provider.types.ts
+++ b/src/providers/model/friday-provider.types.ts
@@ -351,9 +351,19 @@ export interface FridayModelRoutingConfig {
   defaultProviderId: string;
   defaultModel?: string;
   fallbackProviderIds: string[];
+  costMode?: FridayProviderRoutingCostMode;
   /** OC-002: When true, cost-routing cannot override the user's requested model. */
   enforceRequestedModel?: boolean;
 }
+
+export const FRIDAY_PROVIDER_ROUTING_COST_MODES = [
+  "frugal",
+  "standard",
+  "strict",
+] as const;
+
+export type FridayProviderRoutingCostMode =
+  (typeof FRIDAY_PROVIDER_ROUTING_COST_MODES)[number];
 
 function normalizeFridayStringList(input: readonly string[] | null | undefined): string[] {
   if (!Array.isArray(input)) {
@@ -404,6 +414,9 @@ export function normalizeFridayModelRoutingConfig(
     defaultProviderId,
     ...(defaultModel ? { defaultModel } : {}),
     fallbackProviderIds: normalizeFridayStringList(input?.fallbackProviderIds),
+    costMode: FRIDAY_PROVIDER_ROUTING_COST_MODES.includes(input?.costMode as FridayProviderRoutingCostMode)
+      ? (input?.costMode as FridayProviderRoutingCostMode)
+      : "standard",
     ...(input?.enforceRequestedModel !== undefined
       ? { enforceRequestedModel: Boolean(input.enforceRequestedModel) }
       : {}),
@@ -547,6 +560,8 @@ export interface FridayProviderHealthSnapshotItem {
 
 export type FridayProviderRoutingReasonCode =
   | "configured"
+  | "cost_mode_frugal"
+  | "cost_mode_strict"
   | "historical_bias"
   | "operator_override"
   | "operator_penalty"
@@ -598,6 +613,7 @@ export interface FridayProviderRoutingHistoryWindow {
 }
 
 export interface FridayProviderRoutingDecisionTrace {
+  costMode: FridayProviderRoutingCostMode;
   taskProfileId?: string;
   requiresNativeTools: boolean;
   requiredCapabilities?: FridayRuntimeCapabilityId[];
@@ -617,6 +633,7 @@ export interface FridayProviderRoutingExplainReport {
   requestedProviderId?: string;
   requestedModel?: string;
   taskProfileId?: string;
+  costMode: FridayProviderRoutingCostMode;
   requiresNativeTools: boolean;
   selectedBeforeLearning?: FridayProviderRoutingSelection;
   selectedAfterLearning?: FridayProviderRoutingSelection;

--- a/src/providers/services/friday-provider-service.ts
+++ b/src/providers/services/friday-provider-service.ts
@@ -948,6 +948,7 @@ export function createFridayProviderService(
     requestedModel?: string;
     userId?: string;
     tenantContext?: FridayProviderTenantContext;
+    costMode: FridayModelRoutingConfig["costMode"];
     taskProfileId?: string;
     routingContext?: {
       estimatedInputTokens?: number;
@@ -1129,6 +1130,10 @@ export function createFridayProviderService(
       reasonCode = "requested_provider";
     } else if (input.requestedModel) {
       reasonCode = "requested_model";
+    } else if (input.costMode === "frugal") {
+      reasonCode = "cost_mode_frugal";
+    } else if (input.costMode === "strict") {
+      reasonCode = "cost_mode_strict";
     } else if (initialStates.some((state) => state.ineligibilityReasons.length > 0)) {
       reasonCode = "backend_capability_gating";
     }
@@ -1143,6 +1148,10 @@ export function createFridayProviderService(
           return "Operator route penalties influenced candidate scoring.";
         case "historical_bias":
           return "Historical route outcomes influenced candidate scoring.";
+        case "cost_mode_frugal":
+          return "Frugal mode preferred lower-cost eligible routes without bypassing provider, capability, or safety gates.";
+        case "cost_mode_strict":
+          return "Strict mode preferred higher-quality eligible routes without bypassing provider, capability, or safety gates.";
         case "requested_provider":
           return "Routing was constrained to the explicitly requested provider.";
         case "requested_model":
@@ -1205,6 +1214,7 @@ export function createFridayProviderService(
       explain,
       selected,
       trace: {
+        costMode: input.costMode ?? "standard",
         ...(input.taskProfileId ? { taskProfileId: input.taskProfileId } : {}),
         requiresNativeTools: input.routingContext?.requiresNativeTools === true,
         ...(input.routingContext?.requiredCapabilities?.length
@@ -2659,6 +2669,7 @@ export function createFridayProviderService(
         estimatedInputTokens,
         complexity,
         budget,
+        costMode: routing.costMode,
       });
       const enforcePin = routing.enforceRequestedModel === true && !!input.requestedModel;
       const baseCandidates = (!input.requestedModel && !enforcePin && !pinnedProvider)
@@ -2670,6 +2681,7 @@ export function createFridayProviderService(
         requestedModel: input.requestedModel,
         userId: input.tenantContext?.userId,
         tenantContext: input.tenantContext,
+        costMode: routing.costMode,
         taskProfileId: input.routingContext?.taskProfileId,
         routingContext: input.routingContext,
         budgetLocalOnly: routingDecision.strategy === "budget_local_only" && !enforcePin && !pinnedProvider,
@@ -2690,6 +2702,7 @@ export function createFridayProviderService(
         ...(input.requestedProviderId ? { requestedProviderId: input.requestedProviderId } : {}),
         ...(input.requestedModel ? { requestedModel: input.requestedModel } : {}),
         ...(input.routingContext?.taskProfileId ? { taskProfileId: input.routingContext.taskProfileId } : {}),
+        costMode: traceBuilder.trace.costMode,
         requiresNativeTools,
         ...(traceBuilder.trace.selectedBeforeLearning ? { selectedBeforeLearning: traceBuilder.trace.selectedBeforeLearning } : {}),
         ...(traceBuilder.trace.selectedAfterLearning ? { selectedAfterLearning: traceBuilder.trace.selectedAfterLearning } : {}),
@@ -3162,7 +3175,11 @@ export function createFridayProviderService(
     },
 
     async setRoutingConfig(input) {
-      const validated = validateRoutingConfig(input);
+      const existingRouting = loadRoutingConfig();
+      const validated = validateRoutingConfig({
+        ...input,
+        costMode: input.costMode ?? existingRouting?.costMode,
+      });
       saveRoutingConfig(validated);
       return normalizeFridayModelRoutingConfig(validated);
     },
@@ -3345,6 +3362,7 @@ export function createFridayProviderService(
         estimatedInputTokens,
         complexity,
         budget,
+        costMode: routing.costMode,
       });
 
       // OC-002: When enforceRequestedModel is set and a specific model was
@@ -3370,6 +3388,7 @@ export function createFridayProviderService(
         requestedModel: params.requestedModel,
         userId: params.tenantContext?.userId,
         tenantContext: params.tenantContext,
+        costMode: routing.costMode,
         taskProfileId: params.routingContext?.taskProfileId,
         routingContext: params.routingContext,
         budgetLocalOnly: routingDecision.strategy === "budget_local_only" && !enforcePin && !pinnedProvider,
@@ -3408,6 +3427,7 @@ export function createFridayProviderService(
         routingDecision: {
           ...routingDecision,
           orderedCandidates: candidates,
+          costMode: traceBuilder.trace.costMode,
           reason: traceBuilder.trace.reasonText,
           reasonCode: traceBuilder.trace.reasonCode,
           learningAdjusted: traceBuilder.trace.learningAdjusted,

--- a/test/unit/agent/tools/friday-agent-provider-tool.test.ts
+++ b/test/unit/agent/tools/friday-agent-provider-tool.test.ts
@@ -209,10 +209,16 @@ describe("createFridayAgentProviderTool", () => {
     const provider = makeProvider({ id: "anthropic-oauth-1" });
     const providerService = createMockProviderService({
       getProvider: vi.fn().mockResolvedValue(provider),
+      getRoutingConfig: vi.fn().mockResolvedValue({
+        defaultProviderId: "openai-primary",
+        fallbackProviderIds: ["anthropic-oauth-1"],
+        costMode: "strict",
+      }),
       setRoutingConfig: vi.fn().mockResolvedValue({
         defaultProviderId: provider.id,
         defaultModel: provider.defaultModel,
         fallbackProviderIds: [],
+        costMode: "strict",
       }),
     });
     const tool = createFridayAgentProviderTool({ providerService });
@@ -229,8 +235,10 @@ describe("createFridayAgentProviderTool", () => {
       defaultProviderId: "anthropic-oauth-1",
       defaultModel: "claude-sonnet-4-20250514",
       fallbackProviderIds: [],
+      costMode: "strict",
     });
     expect(parsed.routing.defaultModel).toBe("claude-sonnet-4-20250514");
+    expect((parsed.routing as Record<string, unknown>).costMode).toBe("strict");
   });
 
   it("set_default returns a clear error when the provider is missing", async () => {

--- a/test/unit/hub/bootstrap/hub-helpers.test.ts
+++ b/test/unit/hub/bootstrap/hub-helpers.test.ts
@@ -88,6 +88,7 @@ describe("createFridayHubAutoFixExecutionSupport", () => {
       defaultProviderId: "provider-a",
       defaultModel: "gpt-old",
       fallbackProviderIds: ["provider-b"],
+      costMode: "strict" as const,
     };
     const providers = [
       {
@@ -400,6 +401,7 @@ describe("createFridayHubAutoFixExecutionSupport", () => {
     await expect(providerService.getRoutingConfig()).resolves.toMatchObject({
       defaultProviderId: "provider-b",
       defaultModel: "gpt-5.4",
+      costMode: "strict",
     });
   });
 

--- a/test/unit/providers/api/friday-provider-routes.test.ts
+++ b/test/unit/providers/api/friday-provider-routes.test.ts
@@ -253,6 +253,7 @@ describe("FridayProviderRoutes", () => {
       explainRouting: vi.fn(async () => ({
         requestedProviderId: "prov-001",
         requestedModel: "gpt-4o",
+        costMode: "standard" as const,
         requiresNativeTools: true,
         selectedBeforeLearning: {
           providerId: "prov-001",
@@ -954,11 +955,33 @@ describe("FridayProviderRoutes", () => {
         defaultProviderId: "prov-001",
         defaultModel: "gpt-4o",
         fallbackProviderIds: ["prov-002"],
+        costMode: "frugal" as const,
         enforceRequestedModel: true,
       };
 
       const result = await setRoutingRoute.handler(makeCtx({ body }));
       expect(result).toEqual({ routing: body });
+    });
+
+    it("providers.routing.set rejects invalid costMode", async () => {
+      const mockService = makeMockService();
+      const routes = createFridayProviderRoutes({
+        providerService: mockService,
+      });
+      const setRoutingRoute = routes.find(
+        (r) => r.operationId === "providers.routing.set",
+      )!;
+
+      await expect(
+        setRoutingRoute.handler(makeCtx({
+          body: {
+            defaultProviderId: "prov-001",
+            fallbackProviderIds: [],
+            costMode: "turbo-cheap",
+          },
+        })),
+      ).rejects.toThrow("costMode must be one of: frugal, standard, strict");
+      expect(mockService.setRoutingConfig).not.toHaveBeenCalled();
     });
 
     it("providers.routing.set requires canonical approval in gate-required profile before service mutation", async () => {

--- a/test/unit/providers/services/friday-provider-service.test.ts
+++ b/test/unit/providers/services/friday-provider-service.test.ts
@@ -767,6 +767,7 @@ describe("FridayProviderService", () => {
         defaultProviderId: "legacy-provider",
         defaultModel: "gpt-4o",
         fallbackProviderIds: [],
+        costMode: "standard",
       });
     });
 
@@ -806,6 +807,7 @@ describe("FridayProviderService", () => {
         defaultProviderId: "test-id-0001",
         defaultModel: "gpt-4o",
         fallbackProviderIds: ["test-id-0002", "test-id-0003"],
+        costMode: "standard" as const,
       };
 
       const result = await service.setRoutingConfig(input);
@@ -850,6 +852,7 @@ describe("FridayProviderService", () => {
       await service.setRoutingConfig({
         defaultProviderId: "test-id-0001",
         fallbackProviderIds: ["test-id-0002"],
+        costMode: "strict",
       });
 
       await service.setRoutingConfig({
@@ -861,6 +864,7 @@ describe("FridayProviderService", () => {
       const config = await service.getRoutingConfig();
       expect(config.defaultProviderId).toBe("test-id-0003");
       expect(config.defaultModel).toBe("claude-3");
+      expect(config.costMode).toBe("strict");
     });
 
     it("normalizes routing input when fallbackProviderIds is omitted", async () => {
@@ -884,6 +888,7 @@ describe("FridayProviderService", () => {
         defaultProviderId: "test-id-0001",
         defaultModel: "gpt-4o",
         fallbackProviderIds: [],
+        costMode: "standard",
       });
     });
 
@@ -1443,6 +1448,136 @@ describe("FridayProviderService", () => {
         eligible: false,
         ineligibilityReasons: expect.arrayContaining(["satellite_unavailable_for_local_route"]),
       });
+    });
+
+    it("frugal mode prefers lower-cost eligible routes without weakening native-tool gates", async () => {
+      const primary = await service.createProvider({
+        kind: "openai",
+        name: "OpenAI Best",
+        baseUrl: "https://api.openai.com",
+        authMode: "api-key",
+        api: "openai-completions",
+        apiKey: "test-primary-key", // pragma: allowlist secret
+        supportedModels: ["gpt-4.1"],
+        defaultModel: "gpt-4.1",
+        validateOnSave: false,
+      });
+      const cheapHttp = await service.createProvider({
+        kind: "openai",
+        name: "OpenAI Nano",
+        baseUrl: "https://api.openai.com",
+        authMode: "api-key",
+        api: "openai-completions",
+        apiKey: "test-cheap-key", // pragma: allowlist secret
+        supportedModels: ["gpt-4.1-nano"],
+        defaultModel: "gpt-4.1-nano",
+        validateOnSave: false,
+      });
+      const cheapCli = await service.createProvider({
+        kind: "openai",
+        name: "Cheap CLI",
+        baseUrl: "",
+        authMode: "external-session",
+        backendKind: "cli",
+        cliConfig: {
+          backendId: "codex-cli",
+          binaryPath: "/usr/local/bin/codex",
+        },
+        api: "openai-responses",
+        supportedModels: ["gpt-4.1-nano"],
+        defaultModel: "gpt-4.1-nano",
+        validateOnSave: false,
+      });
+      await service.setRoutingConfig({
+        defaultProviderId: primary.id,
+        fallbackProviderIds: [cheapHttp.id, cheapCli.id],
+        costMode: "frugal",
+      });
+      markProviderValidated(primary.id);
+      markProviderValidated(cheapHttp.id);
+      markProviderValidated(cheapCli.id);
+
+      const explain = await service.explainRouting({
+        routingContext: {
+          estimatedInputTokens: 1200,
+          complexity: "medium",
+        },
+      });
+
+      expect(explain.costMode).toBe("frugal");
+      expect(explain.reasonCode).toBe("cost_mode_frugal");
+      expect(explain.selected.providerId).toBe(cheapHttp.id);
+
+      const nativeToolExplain = await service.explainRouting({
+        routingContext: {
+          estimatedInputTokens: 1200,
+          complexity: "medium",
+          requiresNativeTools: true,
+        },
+      });
+
+      expect(nativeToolExplain.selected.providerId).toBe(cheapHttp.id);
+      expect(
+        nativeToolExplain.candidates.find((candidate) => candidate.providerId === cheapCli.id),
+      ).toMatchObject({
+        eligible: false,
+        ineligibilityReasons: expect.arrayContaining(["requires_native_tools"]),
+      });
+
+      const pinnedExplain = await service.explainRouting({
+        requestedProviderId: primary.id,
+        routingContext: {
+          estimatedInputTokens: 1200,
+          complexity: "medium",
+        },
+      });
+
+      expect(pinnedExplain.selected.providerId).toBe(primary.id);
+      expect(pinnedExplain.reasonCode).toBe("requested_provider");
+      expect(pinnedExplain.reason).toContain("explicitly requested provider");
+    });
+
+    it("strict mode prefers higher-quality eligible routes while preserving configured gates", async () => {
+      const cheap = await service.createProvider({
+        kind: "openai",
+        name: "OpenAI Nano",
+        baseUrl: "https://api.openai.com",
+        authMode: "api-key",
+        api: "openai-completions",
+        apiKey: "test-cheap-key", // pragma: allowlist secret
+        supportedModels: ["gpt-4.1-nano"],
+        defaultModel: "gpt-4.1-nano",
+        validateOnSave: false,
+      });
+      const best = await service.createProvider({
+        kind: "openai",
+        name: "OpenAI Best",
+        baseUrl: "https://api.openai.com",
+        authMode: "api-key",
+        api: "openai-completions",
+        apiKey: "test-best-key", // pragma: allowlist secret
+        supportedModels: ["gpt-4.1"],
+        defaultModel: "gpt-4.1",
+        validateOnSave: false,
+      });
+      await service.setRoutingConfig({
+        defaultProviderId: cheap.id,
+        fallbackProviderIds: [best.id],
+        costMode: "strict",
+      });
+      markProviderValidated(cheap.id);
+      markProviderValidated(best.id);
+
+      const explain = await service.explainRouting({
+        routingContext: {
+          estimatedInputTokens: 1200,
+          complexity: "complex",
+        },
+      });
+
+      expect(explain.costMode).toBe("strict");
+      expect(explain.reasonCode).toBe("cost_mode_strict");
+      expect(explain.selected.providerId).toBe(best.id);
     });
 
     it("honors operator-pinned routes in explainRouting", async () => {
@@ -2027,6 +2162,61 @@ describe("FridayProviderService", () => {
           providerId: "test-id-0001",
           model: "gpt-4o",
         });
+      } finally {
+        delete process.env.OPENAI_KEY;
+      }
+    });
+
+    it("uses frugal routing order on the execution path without creating new candidates", async () => {
+      process.env.OPENAI_KEY = "test-openai-key";
+      try {
+        await service.createProvider({
+          kind: "openai",
+          name: "Primary OpenAI",
+          baseUrl: "https://api.openai.com",
+          authMode: "api-key",
+          api: "openai-responses",
+          apiKey: "$OPENAI_KEY",
+          supportedModels: ["gpt-4.1"],
+          defaultModel: "gpt-4.1",
+          validateOnSave: false,
+        });
+        await service.createProvider({
+          kind: "openai",
+          name: "Cheaper OpenAI fallback",
+          baseUrl: "https://api.openai.com",
+          authMode: "api-key",
+          api: "openai-responses",
+          apiKey: "$OPENAI_KEY",
+          supportedModels: ["gpt-4.1-nano"],
+          defaultModel: "gpt-4.1-nano",
+          validateOnSave: false,
+        });
+
+        await service.setRoutingConfig({
+          defaultProviderId: "test-id-0001",
+          fallbackProviderIds: ["test-id-0002"],
+          costMode: "frugal",
+        });
+
+        const { result, route, attempts, routingDecision } = await service.runWithFallback({
+          routingContext: {
+            estimatedInputTokens: 4096,
+            complexity: "medium",
+          },
+          run: async (candidate) => candidate.provider.id,
+        });
+
+        expect(result).toBe("test-id-0002");
+        expect(route.provider.id).toBe("test-id-0002");
+        expect(route.model).toBe("gpt-4.1-nano");
+        expect(attempts).toHaveLength(0);
+        expect(routingDecision.costMode).toBe("frugal");
+        expect(routingDecision.reasonCode).toBe("cost_mode_frugal");
+        expect(routingDecision.orderedCandidates.map((candidate) => candidate.provider.id)).toEqual([
+          "test-id-0002",
+          "test-id-0001",
+        ]);
       } finally {
         delete process.env.OPENAI_KEY;
       }

--- a/ui/src/lib/api/providers.ts
+++ b/ui/src/lib/api/providers.ts
@@ -62,6 +62,7 @@ export interface SetRoutingInput {
   defaultProviderId: string;
   defaultModel?: string;
   fallbackProviderIds: string[];
+  costMode?: FridayModelRoutingConfig["costMode"];
   enforceRequestedModel?: boolean;
 }
 

--- a/ui/src/lib/api/types.ts
+++ b/ui/src/lib/api/types.ts
@@ -1959,6 +1959,7 @@ export interface FridayModelRoutingConfig {
   defaultProviderId: string;
   defaultModel?: string;
   fallbackProviderIds: string[];
+  costMode?: "frugal" | "standard" | "strict";
   enforceRequestedModel?: boolean;
 }
 
@@ -2065,6 +2066,7 @@ export interface FridayProviderRoutingExplainReport {
   requestedProviderId?: string;
   requestedModel?: string;
   taskProfileId?: string;
+  costMode: "frugal" | "standard" | "strict";
   requiresNativeTools: boolean;
   selectedBeforeLearning?: FridayProviderRoutingSelection;
   selectedAfterLearning?: FridayProviderRoutingSelection;

--- a/ui/src/routes/settings-page.tsx
+++ b/ui/src/routes/settings-page.tsx
@@ -17,7 +17,7 @@ import { ChannelConfigForm } from "@/components/core/channel-config-form";
 import { DiscoveryPanel } from "@/components/core/discovery-panel";
 import { CHANNEL_META } from "@/lib/channels/channel-meta";
 import type { ChannelKind } from "@/lib/setup/types";
-import { type FridayProviderKind, type FridayProviderProfile, type FridayRuntimeCapabilityState, ApiError } from "@/lib/api/types";
+import { type FridayModelRoutingConfig, type FridayProviderKind, type FridayProviderProfile, type FridayRuntimeCapabilityState, ApiError } from "@/lib/api/types";
 import { assistantDiagnosticsApi } from "@/lib/api/assistant-diagnostics";
 import { channelsApi } from "@/lib/api/channels";
 import { healthApi } from "@/lib/api/health";
@@ -64,6 +64,20 @@ type PendingDefaultProviderChoice = {
   providerName: string;
   defaultModel?: string;
 };
+
+type RoutingCostMode = NonNullable<FridayModelRoutingConfig["costMode"]>;
+
+const ROUTING_COST_MODE_OPTIONS: readonly RoutingCostMode[] = [
+  "frugal",
+  "standard",
+  "strict",
+];
+
+function routingCostModeLabel(mode: RoutingCostMode, locale: AppLocale): string {
+  if (mode === "frugal") return localize(locale, "省钱", "Frugal");
+  if (mode === "strict") return localize(locale, "严格", "Strict");
+  return localize(locale, "标准", "Standard");
+}
 
 function formatTimestamp(value?: string): string {
   if (!value) return "—";
@@ -456,6 +470,7 @@ export function SettingsPage() {
         defaultProviderId: providerId,
         defaultModel,
         fallbackProviderIds: (routingConfig?.fallbackProviderIds ?? []).filter((id) => id !== providerId),
+        costMode: routingConfig?.costMode ?? "standard",
         enforceRequestedModel: routingConfig?.enforceRequestedModel,
       });
       await refreshProviderQueries();
@@ -614,6 +629,29 @@ export function SettingsPage() {
     },
     onError: (error) => {
       toast.error(error instanceof Error ? error.message : localize(locale, "无法清除路由惩罚", "Could not clear route penalty"));
+    },
+  });
+
+  const routingCostModeMutation = useMutation({
+    mutationFn: (costMode: RoutingCostMode) => {
+      const defaultProviderId = routingConfig?.defaultProviderId;
+      if (!defaultProviderId) {
+        throw new Error(localize(locale, "请先配置默认模型提供方", "Configure a default model provider first"));
+      }
+      return providersApi.setRouting({
+        defaultProviderId,
+        defaultModel: routingConfig?.defaultModel,
+        fallbackProviderIds: routingConfig?.fallbackProviderIds ?? [],
+        costMode,
+        enforceRequestedModel: routingConfig?.enforceRequestedModel,
+      });
+    },
+    onSuccess: async () => {
+      toast.success(localize(locale, "路由模式已更新", "Routing mode updated"));
+      await refreshProviderQueries();
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : localize(locale, "无法更新路由模式", "Could not update routing mode"));
     },
   });
 
@@ -1222,8 +1260,37 @@ export function SettingsPage() {
         </ShellCard>
 
         <ShellCard eyebrow={localize(locale, "运维", "Operator")} title={localize(locale, "路由可解释性", "Routing Explainability")}>
-          {routingExplain ? (
-            <div className="space-y-4">
+          <div className="space-y-4">
+            <div className="rounded-[22px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-subtle)] p-4">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <p className="font-medium text-[color:var(--color-text-primary)]">{localize(locale, "模型路由模式", "Model routing mode")}</p>
+                  <p className="text-xs text-[color:var(--color-text-tertiary)]">{routingConfig?.costMode ?? routingExplain?.costMode ?? "standard"}</p>
+                </div>
+                <div className="flex items-center gap-1 rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] p-1">
+                  {ROUTING_COST_MODE_OPTIONS.map((mode) => {
+                    const active = (routingConfig?.costMode ?? "standard") === mode;
+                    return (
+                      <button
+                        key={mode}
+                        type="button"
+                        disabled={routingCostModeMutation.isPending}
+                        onClick={() => routingCostModeMutation.mutate(mode)}
+                        className={`rounded-full px-4 py-2 text-xs font-medium transition ${
+                          active
+                            ? "bg-[color:var(--color-accent)] text-white"
+                            : "text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)]"
+                        }`}
+                      >
+                        {routingCostModeLabel(mode, locale)}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            </div>
+            {routingExplain ? (
+              <>
               <div className="rounded-[22px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-subtle)] p-4">
                 <div className="flex items-center justify-between gap-3">
                   <div>
@@ -1303,10 +1370,11 @@ export function SettingsPage() {
                   </div>
                 ))}
               </div>
-            </div>
-          ) : (
-            <p className="text-sm text-[color:var(--color-text-secondary)]">{localize(locale, "路由解释预览不可用。", "Routing explain preview unavailable.")}</p>
-          )}
+              </>
+            ) : (
+              <p className="text-sm text-[color:var(--color-text-secondary)]">{localize(locale, "路由解释预览不可用。", "Routing explain preview unavailable.")}</p>
+            )}
+          </div>
         </ShellCard>
 
         <ShellCard eyebrow={localize(locale, "沟通", "Communication")} title={localize(locale, "人格", "Persona")}>

--- a/ui/src/routes/setup-page.tsx
+++ b/ui/src/routes/setup-page.tsx
@@ -23,10 +23,10 @@ import type {
   ProviderKind,
   SetupStepId,
 } from "@/lib/setup/types";
-import type { FridayProviderTemplate, FridayProviderValidationState } from "@/lib/api/types";
+import type { FridayModelRoutingConfig, FridayProviderTemplate, FridayProviderValidationState } from "@/lib/api/types";
 import { classifyFridaySaveProviderValidation } from "@/lib/setup/setup-status-diagnostics";
 import { ActionButton, ConfirmDialog, StatusPill } from "@/components/core/primitives";
-import { localize } from "@/lib/i18n/localized-text";
+import { localize, type AppLocale } from "@/lib/i18n/localized-text";
 import { useAppLocale } from "@/providers/locale-provider";
 import { CHANNEL_META } from "@/lib/channels/channel-meta";
 import type { ChannelKind } from "@/lib/setup/types";
@@ -107,6 +107,20 @@ type ProviderSetupFeedback = {
   message?: string;
   warnings: string[];
 };
+
+type RoutingCostMode = NonNullable<FridayModelRoutingConfig["costMode"]>;
+
+const ROUTING_COST_MODE_OPTIONS: readonly RoutingCostMode[] = [
+  "frugal",
+  "standard",
+  "strict",
+];
+
+function routingCostModeLabel(mode: RoutingCostMode, locale: AppLocale): string {
+  if (mode === "frugal") return localize(locale, "省钱", "Frugal");
+  if (mode === "strict") return localize(locale, "严格", "Strict");
+  return localize(locale, "标准", "Standard");
+}
 
 type OpenAICodexDeviceOAuthState = {
   status: "idle" | "starting" | "pending" | "completing" | "connected" | "error";
@@ -357,6 +371,7 @@ export function SetupPage() {
   const [providerApi, setProviderApi] = useState<ProviderApi>("openai-responses");
   const [providerAuthMode, setProviderAuthMode] = useState<AuthMode>("api-key");
   const [providerConnectionMode, setProviderConnectionMode] = useState<ProviderConnectionMode>("api-key");
+  const [providerCostMode, setProviderCostMode] = useState<RoutingCostMode>("standard");
   const [providerValidated, setProviderValidated] = useState(false);
   const [providerFeedback, setProviderFeedback] = useState<ProviderSetupFeedback>({
     status: "idle",
@@ -454,6 +469,12 @@ export function SetupPage() {
     queryFn: () => providersApi.getRouting(),
     retry: 0,
   });
+
+  useEffect(() => {
+    if (routingConfig?.costMode) {
+      setProviderCostMode(routingConfig.costMode);
+    }
+  }, [routingConfig?.costMode]);
 
   // ── Redirects ──
 
@@ -641,6 +662,8 @@ export function SetupPage() {
       defaultProviderId: provider.id,
       defaultModel: draft.defaultModel,
       fallbackProviderIds: [],
+      costMode: providerCostMode,
+      enforceRequestedModel: routingConfig?.enforceRequestedModel,
     });
 
     return { validation: response.validation };
@@ -653,6 +676,7 @@ export function SetupPage() {
         defaultProviderId: providerId,
         defaultModel,
         fallbackProviderIds: (routingConfig?.fallbackProviderIds ?? []).filter((id) => id !== providerId),
+        costMode: providerCostMode,
         enforceRequestedModel: routingConfig?.enforceRequestedModel,
       });
       await Promise.all([
@@ -1791,6 +1815,26 @@ export function SetupPage() {
             </div>
           );
         })()}
+
+        <div className="mt-6 flex items-center justify-center gap-1 rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] p-1">
+          {ROUTING_COST_MODE_OPTIONS.map((mode) => {
+            const active = providerCostMode === mode;
+            return (
+              <button
+                key={mode}
+                type="button"
+                onClick={() => setProviderCostMode(mode)}
+                className={`rounded-full px-5 py-2 text-sm font-medium transition ${
+                  active
+                    ? "bg-[color:var(--color-accent)] text-white"
+                    : "text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)]"
+                }`}
+              >
+                {routingCostModeLabel(mode, locale)}
+              </button>
+            );
+          })}
+        </div>
 
         {(useMyPlanAvailable && keyConnectionAvailable) ? (
           <div className="mt-6 flex items-center justify-center gap-1 rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] p-1">


### PR DESCRIPTION
## Phase / Slice

Phase 18E: Frugal Mode productization
Issues: P1-005, P2-008
Head SHA: 0269cecc73a2c9f385d1ee2800911200bc19f9fb
Replacement for PR #263, which was closed because GitHub did not synchronize its pull ref after the branch advanced.

## Summary

- Adds persistent `frugal` / `standard` / `strict` routing cost modes, normalizing older routing configs to `standard`.
- Makes Frugal prefer lower-cost eligible candidates and Strict prefer higher-quality eligible candidates without creating candidates or bypassing provider, capability, native-tool, approval, or safety gates.
- Surfaces routing mode controls in setup and settings while preserving existing routing fields through default-provider/setup/hub/agent-tool writers.
- Preserves over-limit local-only behavior and the previous near-limit budget downgrade weighting.
- Updates `.secrets.baseline` after CI showed line-number drift only; no new hashed secret entries were added or removed.

## Verification

- `npm test -- --run test/unit/providers/services/friday-provider-service.test.ts test/unit/providers/api/friday-provider-routes.test.ts test/unit/hub/bootstrap/hub-helpers.test.ts test/unit/agent/tools/friday-agent-provider-tool.test.ts` PASS: 4 test files, 160 tests.
- `npm run typecheck` PASS.
- `npm run build:ui` PASS.
- `npm run check:secret-patterns` PASS: no provider/API key shaped secrets found in tracked files.
- CI-equivalent `detect-secrets-hook --baseline .secrets.baseline ...` PASS after staging the baseline line-number update.
- `git diff --check` PASS.
- Targeted ESLint on touched source/test/UI files PASS with 0 errors; existing warnings only.

## Reviewer Trail

- Isolated Reviewer A: PASS after blocker fixes. Checked issue mapping, mode semantics, implementation paths, writer preservation, UI visibility, API shape, cleanup, and missed entrypoints.
- Isolated Reviewer B: PASS after blocker fixes. Checked regression risk, no overclaim, no fake proof, no secret leakage, no test weakening, no approval/safety/provider/release gate weakening, and no scope creep.
- Baseline delta reviewers for commit `0269cecc` are running; merge is blocked until both PASS.

## Owner / Merge Gate

No second write-access reviewer is available because this is a single-maintainer repository/workflow for this Friday phase.

Auto-merge is allowed only if all of the following are true before merge:

- PR head SHA matches the verified SHA.
- Required CI checks are successful for the same SHA.
- `real-green-gate-result.json` is downloaded and read for the same SHA, with `status=passed`, scenarios nonzero, all scenarios passed, and blockers empty.
- The two isolated reviewer passes above remain valid, and the baseline delta reviewers both PASS.
- No safety/security/release-governance/approval/memory/provider/MCP/plugin/skill/default-on/release-proof boundary issue remains unresolved.
- Branch protection allows a normal merge with `ownerBypassUsed=false`.

Because this slice touches provider/routing behavior, owner/admin branch-protection bypass is not authorized for this PR. If branch protection requires owner/admin bypass to merge, stop and record a typed blocker instead of merging.