### PR TITLE
Phase 21E: Memory preference truth

### DIFF
--- a/docs/current-source-of-truth.md
+++ b/docs/current-source-of-truth.md
@@ -219,8 +219,10 @@ This document is the current architecture reference for steady-state Friday runt
 - Learned preference facts use a Bayesian-inspired confidence model with decay, conflict penalty, and evidence boost.
 - The self-learning context enrichment service is wired through hub bootstrap and becomes available after self-learning runtime creation.
 - Communication style affects wording, progress updates, failure phrasing, and clarification style only. It must not weaken approval gates, rollback rules, or destructive-action safeguards.
+- Raw learned facts are not blanket prompt injection. `createFridayPreferenceInjector` exists as a bounded injector utility and test target, but current hub prompt wiring uses the communication prompt builder plus persisted Reflex/User Constitution preference fragments instead of silently injecting raw learned facts.
+- High-impact execution, testing, security, memory-policy, workflow, skill, and User Constitution preferences must be confirmed through Review Center before they become persisted Reflex preferences that can enter the relevant prompt boundary.
 - Guided wizard contexts in `/assistant` are persisted in SQLite (`uix_guided_contexts`) and can be resumed after service restart. Onboarding session progress is also persisted in SQLite (`uix_onboarding_sessions`) and restored on boot.
-- Learned preference facts are now user-visible through `/v1/uix/learned-facts` and the current Home/Settings UI surfaces. Direct editing of learned preference facts is not yet part of the current UI surface.
+- Learned preference facts are user-visible through `/v1/uix/learned-facts`; the Settings UI renders explicit trust, memory, evidence, context-use, prompt-injection, review, and revocation boundaries. UIX learned-fact routes, memory search/list routes, and agent memory search metadata also return those boundary labels. The Assets surface can list and delete learned facts as learned knowledge, but it does not render the full boundary summary. Learned facts remain separate from explicit Memory and from confirmed Reflex preferences.
 
 ## Runtime admin and security surfaces
 

--- a/src/agent/tools/friday-agent-memory-tools.ts
+++ b/src/agent/tools/friday-agent-memory-tools.ts
@@ -626,6 +626,9 @@ function createMemorySearchTool(
                 memoryBoundary: r.item.metadata.memoryBoundary,
                 evidenceBoundary: r.item.metadata.evidenceBoundary,
                 contextUseBoundary: r.item.metadata.contextUseBoundary,
+                promptInjectionBoundary: r.item.metadata.promptInjectionBoundary,
+                reviewBoundary: r.item.metadata.reviewBoundary,
+                revocationBoundary: r.item.metadata.revocationBoundary,
               }
               : {}),
           },

--- a/src/api/http/routes/friday-uix-routes.ts
+++ b/src/api/http/routes/friday-uix-routes.ts
@@ -26,6 +26,9 @@ import {
   FRIDAY_LEARNED_FACT_CONTEXT_USE_BOUNDARY,
   FRIDAY_LEARNED_FACT_EVIDENCE_BOUNDARY,
   FRIDAY_LEARNED_FACT_MEMORY_BOUNDARY,
+  FRIDAY_LEARNED_FACT_PROMPT_INJECTION_BOUNDARY,
+  FRIDAY_LEARNED_FACT_REVIEW_BOUNDARY,
+  FRIDAY_LEARNED_FACT_REVOCATION_BOUNDARY,
   FRIDAY_LEARNED_FACT_TRUST_LEVEL,
 } from "../../../learning/services/friday-learned-fact-memory-view.js";
 
@@ -138,6 +141,9 @@ function enrichLearnedFactBoundary<T extends {
     memoryBoundary: string;
     evidenceBoundary: string;
     contextUseBoundary: string;
+    promptInjectionBoundary: string;
+    reviewBoundary: string;
+    revocationBoundary: string;
   };
 } {
   return {
@@ -147,6 +153,9 @@ function enrichLearnedFactBoundary<T extends {
       memoryBoundary: FRIDAY_LEARNED_FACT_MEMORY_BOUNDARY,
       evidenceBoundary: FRIDAY_LEARNED_FACT_EVIDENCE_BOUNDARY,
       contextUseBoundary: FRIDAY_LEARNED_FACT_CONTEXT_USE_BOUNDARY,
+      promptInjectionBoundary: FRIDAY_LEARNED_FACT_PROMPT_INJECTION_BOUNDARY,
+      reviewBoundary: FRIDAY_LEARNED_FACT_REVIEW_BOUNDARY,
+      revocationBoundary: FRIDAY_LEARNED_FACT_REVOCATION_BOUNDARY,
     },
   };
 }

--- a/src/learning/services/friday-learned-fact-memory-view.ts
+++ b/src/learning/services/friday-learned-fact-memory-view.ts
@@ -15,6 +15,9 @@ export const FRIDAY_LEARNED_FACT_TRUST_LEVEL = "confidence_scored_learning";
 export const FRIDAY_LEARNED_FACT_MEMORY_BOUNDARY = "separate_from_durable_memory";
 export const FRIDAY_LEARNED_FACT_EVIDENCE_BOUNDARY = "preference_fact_evidence";
 export const FRIDAY_LEARNED_FACT_CONTEXT_USE_BOUNDARY = "learning_context_service_gated";
+export const FRIDAY_LEARNED_FACT_PROMPT_INJECTION_BOUNDARY = "not_direct_prompt_injection";
+export const FRIDAY_LEARNED_FACT_REVIEW_BOUNDARY = "not_review_center_confirmed";
+export const FRIDAY_LEARNED_FACT_REVOCATION_BOUNDARY = "clear_delete_or_synthetic_memory_delete";
 
 function stringifyLearnedFactValue(value: unknown): string {
   if (typeof value === "string") {
@@ -113,6 +116,9 @@ export function toLearnedFactMemoryItem(fact: FridayLearnedFactView): FridayMemo
       memoryBoundary: FRIDAY_LEARNED_FACT_MEMORY_BOUNDARY,
       evidenceBoundary: FRIDAY_LEARNED_FACT_EVIDENCE_BOUNDARY,
       contextUseBoundary: FRIDAY_LEARNED_FACT_CONTEXT_USE_BOUNDARY,
+      promptInjectionBoundary: FRIDAY_LEARNED_FACT_PROMPT_INJECTION_BOUNDARY,
+      reviewBoundary: FRIDAY_LEARNED_FACT_REVIEW_BOUNDARY,
+      revocationBoundary: FRIDAY_LEARNED_FACT_REVOCATION_BOUNDARY,
       evidenceCount: fact.evidenceCount,
       lastConfirmedAt: fact.lastConfirmedAt,
     },

--- a/test/unit/agent/runtime/friday-agent-preference-injector.test.ts
+++ b/test/unit/agent/runtime/friday-agent-preference-injector.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 
 import type { FridayMemoryItem } from "../../../../src/memory/model/friday-memory.types.js";
@@ -33,6 +35,14 @@ function buildMockMemoryService(items: FridayMemoryItem[]) {
 }
 
 describe("createFridayPreferenceInjector — high-impact gate", () => {
+  it("keeps the learned preference injector out of production hub prompt wiring", () => {
+    const hubBootstrapSource = readFileSync(resolve(process.cwd(), "src/hub/friday-hub-bootstrap.ts"), "utf8");
+
+    expect(hubBootstrapSource).toContain("communicationPromptBuilder");
+    expect(hubBootstrapSource).toContain("buildReflexPreferencePromptFragment");
+    expect(hubBootstrapSource).not.toContain("createFridayPreferenceInjector");
+  });
+
   // ── Source 1: learningContextBuilder ───────────────────────────────────
 
   it("Source 1: injects benign learned facts at the default learning confidence", async () => {

--- a/test/unit/agent/tools/friday-agent-memory-tools.test.ts
+++ b/test/unit/agent/tools/friday-agent-memory-tools.test.ts
@@ -234,6 +234,9 @@ describe("FridayAgentMemoryTools", () => {
             memoryBoundary: "separate_from_durable_memory",
             evidenceBoundary: "preference_fact_evidence",
             contextUseBoundary: "learning_context_service_gated",
+            promptInjectionBoundary: "not_direct_prompt_injection",
+            reviewBoundary: "not_review_center_confirmed",
+            revocationBoundary: "clear_delete_or_synthetic_memory_delete",
           },
         },
       ]);

--- a/test/unit/api/http/routes/friday-memory-routes.test.ts
+++ b/test/unit/api/http/routes/friday-memory-routes.test.ts
@@ -249,6 +249,9 @@ describe("FridayMemoryRoutes", () => {
       memoryBoundary: "separate_from_durable_memory",
       evidenceBoundary: "preference_fact_evidence",
       contextUseBoundary: "learning_context_service_gated",
+      promptInjectionBoundary: "not_direct_prompt_injection",
+      reviewBoundary: "not_review_center_confirmed",
+      revocationBoundary: "clear_delete_or_synthetic_memory_delete",
     });
   });
 
@@ -329,6 +332,9 @@ describe("FridayMemoryRoutes", () => {
       memoryBoundary: "separate_from_durable_memory",
       evidenceBoundary: "preference_fact_evidence",
       contextUseBoundary: "learning_context_service_gated",
+      promptInjectionBoundary: "not_direct_prompt_injection",
+      reviewBoundary: "not_review_center_confirmed",
+      revocationBoundary: "clear_delete_or_synthetic_memory_delete",
     });
   });
 

--- a/test/unit/api/http/routes/friday-uix-routes.test.ts
+++ b/test/unit/api/http/routes/friday-uix-routes.test.ts
@@ -509,6 +509,9 @@ describe("FridayUixRoutes", () => {
       memoryBoundary: "separate_from_durable_memory",
       evidenceBoundary: "preference_fact_evidence",
       contextUseBoundary: "learning_context_service_gated",
+      promptInjectionBoundary: "not_direct_prompt_injection",
+      reviewBoundary: "not_review_center_confirmed",
+      revocationBoundary: "clear_delete_or_synthetic_memory_delete",
     });
   });
 

--- a/test/unit/ui/memory-preference-truth-entrypoints.test.ts
+++ b/test/unit/ui/memory-preference-truth-entrypoints.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "..", "..", "..");
+
+function readRepoSource(rel: string): string {
+  return readFileSync(resolve(repoRoot, rel), "utf8");
+}
+
+const SETTINGS_PAGE_SRC = readRepoSource("ui/src/routes/settings-page.tsx");
+const REFLEX_PAGE_SRC = readRepoSource("ui/src/routes/reflex-page.tsx");
+const SOURCE_OF_TRUTH_SRC = readRepoSource("docs/current-source-of-truth.md");
+
+describe("Phase 21E memory and preference truth entrypoints", () => {
+  it("shows learned-fact prompt, memory, review, and revocation boundaries in Settings", () => {
+    expect(SETTINGS_PAGE_SRC).toContain("/v1/uix/learned-facts");
+    expect(SETTINGS_PAGE_SRC).toContain("promptInjectionBoundary");
+    expect(SETTINGS_PAGE_SRC).toContain("not_direct_prompt_injection");
+    expect(SETTINGS_PAGE_SRC).toContain("reviewBoundary");
+    expect(SETTINGS_PAGE_SRC).toContain("not_review_center_confirmed");
+    expect(SETTINGS_PAGE_SRC).toContain("revocationBoundary");
+    expect(SETTINGS_PAGE_SRC).toContain("not injected into prompts as raw learned facts");
+    expect(SETTINGS_PAGE_SRC).toContain("Review Center confirmation before entering prompts as Reflex preferences");
+  });
+
+  it("labels Reflex preferences as confirmed state, not raw learned-fact prompt injection", () => {
+    expect(REFLEX_PAGE_SRC).toContain("Confirmed preferences; prompt use still follows boundaries");
+    expect(REFLEX_PAGE_SRC).toContain("not raw learned facts");
+    expect(REFLEX_PAGE_SRC).toContain("Review Center confirmation and persistence");
+    expect(REFLEX_PAGE_SRC).toContain("do not become Reflex prompt preferences before confirmation");
+  });
+
+  it("documents that the production prompt path is a non-claim for raw learned facts", () => {
+    expect(SOURCE_OF_TRUTH_SRC).toContain("Raw learned facts are not blanket prompt injection");
+    expect(SOURCE_OF_TRUTH_SRC).toContain("createFridayPreferenceInjector");
+    expect(SOURCE_OF_TRUTH_SRC).toContain("current hub prompt wiring uses the communication prompt builder");
+    expect(SOURCE_OF_TRUTH_SRC).toContain("must be confirmed through Review Center");
+  });
+});

--- a/ui/src/routes/reflex-page.tsx
+++ b/ui/src/routes/reflex-page.tsx
@@ -450,7 +450,7 @@ export function ReflexPage() {
         <ShellCard title={localize(locale, "显式偏好", "Explicit Preferences")}>
           <p className="text-2xl font-semibold text-[color:var(--color-text-primary)]">{String(preferences.length)}</p>
           <p className="text-sm text-[color:var(--color-text-secondary)]">
-            {localize(locale, "会进入 prompt 和 UIX 偏好面", "Available to prompts and UIX surfaces")}
+            {localize(locale, "已确认的偏好；prompt 使用仍按边界执行", "Confirmed preferences; prompt use still follows boundaries")}
           </p>
         </ShellCard>
       </div>
@@ -619,45 +619,54 @@ export function ReflexPage() {
           </ShellCard>
           <ShellCard
             eyebrow={localize(locale, "Canonical Preferences", "Canonical Preferences")}
-            title={localize(locale, "跨渠道、prompt 和 UI 使用的偏好", "Preferences shared by channels, prompts, and UI")}
+            title={localize(locale, "按边界使用的已确认偏好", "Confirmed preferences used within boundaries")}
           >
             {preferencesQuery.isLoading ? (
               <SkeletonList rows={4} />
             ) : preferences.length === 0 ? (
               <EmptyState
                 title={localize(locale, "还没有 Reflex 偏好", "No Reflex preferences yet")}
-                description={localize(locale, "完成引导或让 Friday 记录普通偏好后，这里会显示可复用设置；需要确认的设置会先进入审核候选。", "Complete onboarding or ask Friday to record ordinary preferences to populate reusable settings; settings that need confirmation appear as review candidates first.")}
+                description={localize(locale, "普通偏好写入后会显示在这里；执行、测试、安全和 User Constitution 偏好会先进入 Review Center 候选，确认前不会作为 Reflex prompt 偏好生效。", "Ordinary preferences appear here after they are saved; execution, testing, safety, and User Constitution preferences enter Review Center first and do not become Reflex prompt preferences before confirmation.")}
               />
             ) : (
-              <div className="divide-y divide-[color:var(--color-border-soft)]">
-                {preferences.map((preference) => (
-                  <div key={preference.id} className="grid gap-3 py-3 md:grid-cols-[180px_1fr_150px_112px] md:items-center">
-                    <div>
-                      <StatusPill>{preference.category}</StatusPill>
-                      <p className="mt-2 text-xs text-[color:var(--color-text-faint)]">{preference.source}</p>
-                    </div>
-                    <div className="min-w-0">
-                      <p className="text-sm font-medium text-[color:var(--color-text-primary)]">{preference.key}</p>
-                      <p className="mt-1 break-words text-sm text-[color:var(--color-text-secondary)]">
-                        {typeof preference.value === "string" ? preference.value : JSON.stringify(preference.value)}
+              <div className="space-y-3">
+                <p className="text-xs leading-5 text-[color:var(--color-text-tertiary)]">
+                  {localize(
+                    locale,
+                    "这里显示的是已保存偏好，不是 raw learned facts。高影响偏好只有在 Review Center 确认并持久化后，才会进入对应 prompt 边界。",
+                    "This list shows saved preferences, not raw learned facts. High-impact preferences enter the relevant prompt boundary only after Review Center confirmation and persistence.",
+                  )}
+                </p>
+                <div className="divide-y divide-[color:var(--color-border-soft)]">
+                  {preferences.map((preference) => (
+                    <div key={preference.id} className="grid gap-3 py-3 md:grid-cols-[180px_1fr_150px_112px] md:items-center">
+                      <div>
+                        <StatusPill>{preference.category}</StatusPill>
+                        <p className="mt-2 text-xs text-[color:var(--color-text-faint)]">{preference.source}</p>
+                      </div>
+                      <div className="min-w-0">
+                        <p className="text-sm font-medium text-[color:var(--color-text-primary)]">{preference.key}</p>
+                        <p className="mt-1 break-words text-sm text-[color:var(--color-text-secondary)]">
+                          {typeof preference.value === "string" ? preference.value : JSON.stringify(preference.value)}
+                        </p>
+                      </div>
+                      <p className="text-xs text-[color:var(--color-text-faint)] md:text-right">
+                        {formatTime(preference.updatedAt)}
                       </p>
-                    </div>
-                    <p className="text-xs text-[color:var(--color-text-faint)] md:text-right">
-                      {formatTime(preference.updatedAt)}
-                    </p>
-                    <div className="flex md:justify-end">
-                      <ActionButton
-                        tone="secondary"
-                        className="!min-h-[34px] !px-3 !text-xs"
-                        disabled={revokePreferenceMutation.isPending && busyPreferenceId === preference.id}
-                        onClick={() => revokePreferenceMutation.mutate(preference.id)}
-                      >
-                        <Trash2 className="mr-1.5 h-3.5 w-3.5" aria-hidden="true" />
+                      <div className="flex md:justify-end">
+                        <ActionButton
+                          tone="secondary"
+                          className="!min-h-[34px] !px-3 !text-xs"
+                          disabled={revokePreferenceMutation.isPending && busyPreferenceId === preference.id}
+                          onClick={() => revokePreferenceMutation.mutate(preference.id)}
+                        >
+                          <Trash2 className="mr-1.5 h-3.5 w-3.5" aria-hidden="true" />
                         {localize(locale, "撤销", "Revoke")}
                       </ActionButton>
                     </div>
                   </div>
-                ))}
+                  ))}
+                </div>
               </div>
             )}
           </ShellCard>

--- a/ui/src/routes/settings-page.tsx
+++ b/ui/src/routes/settings-page.tsx
@@ -65,6 +65,25 @@ type PendingDefaultProviderChoice = {
   defaultModel?: string;
 };
 
+type LearnedFactBoundary = {
+  trustLevel: string;
+  memoryBoundary: string;
+  evidenceBoundary: string;
+  contextUseBoundary: string;
+  promptInjectionBoundary: string;
+  reviewBoundary: string;
+  revocationBoundary: string;
+};
+
+type LearnedFact = {
+  key: string;
+  value: unknown;
+  confidence: number;
+  evidenceCount: number;
+  lastConfirmedAt: string;
+  boundary?: LearnedFactBoundary;
+};
+
 type RoutingCostMode = NonNullable<FridayModelRoutingConfig["costMode"]>;
 
 const ROUTING_COST_MODE_OPTIONS: readonly RoutingCostMode[] = [
@@ -77,6 +96,36 @@ function routingCostModeLabel(mode: RoutingCostMode, locale: AppLocale): string 
   if (mode === "frugal") return localize(locale, "省钱", "Frugal");
   if (mode === "strict") return localize(locale, "严格", "Strict");
   return localize(locale, "标准", "Standard");
+}
+
+function learnedFactBoundaryDetails(fact: LearnedFact, locale: AppLocale): Array<{ label: string; value: string }> {
+  const boundary = fact.boundary;
+  return [
+    {
+      label: localize(locale, "记忆", "Memory"),
+      value: boundary?.memoryBoundary === "separate_from_durable_memory"
+        ? localize(locale, "独立于显式 Memory", "separate from explicit Memory")
+        : boundary?.memoryBoundary ?? localize(locale, "边界未知", "boundary unknown"),
+    },
+    {
+      label: localize(locale, "Prompt", "Prompt"),
+      value: boundary?.promptInjectionBoundary === "not_direct_prompt_injection"
+        ? localize(locale, "不直接注入", "not direct injection")
+        : boundary?.promptInjectionBoundary ?? localize(locale, "边界未知", "boundary unknown"),
+    },
+    {
+      label: localize(locale, "审核", "Review"),
+      value: boundary?.reviewBoundary === "not_review_center_confirmed"
+        ? localize(locale, "未由 Review Center 确认", "not Review Center confirmed")
+        : boundary?.reviewBoundary ?? localize(locale, "边界未知", "boundary unknown"),
+    },
+    {
+      label: localize(locale, "撤销", "Revoke"),
+      value: boundary?.revocationBoundary === "clear_delete_or_synthetic_memory_delete"
+        ? localize(locale, "可清除或删除", "clear or delete available")
+        : boundary?.revocationBoundary ?? localize(locale, "边界未知", "boundary unknown"),
+    },
+  ];
 }
 
 function formatTimestamp(value?: string): string {
@@ -379,7 +428,7 @@ export function SettingsPage() {
   const { data: learnedFacts = [] } = useQuery({
     queryKey: ["settings", "learnedFacts"],
     queryFn: async () => {
-      const data = await apiClient.get<{ items: Array<{ key: string; value: unknown; confidence: number; evidenceCount: number; lastConfirmedAt: string }> }>("/v1/uix/learned-facts");
+      const data = await apiClient.get<{ items: LearnedFact[] }>("/v1/uix/learned-facts");
       return data.items;
     },
     retry: 0,
@@ -1596,34 +1645,55 @@ export function SettingsPage() {
           )}
         </ShellCard>
 
-        {learnedFacts.length > 0 ? (
-          <ShellCard eyebrow={localize(locale, "学习", "Learning")} title={localize(locale, "Friday 对你的了解", "What Friday Knows About You")}>
-            <div className="space-y-3">
+        <ShellCard eyebrow={localize(locale, "学习", "Learning")} title={localize(locale, "Friday 对你的了解", "What Friday Knows About You")}>
+          <div className="space-y-3">
+            <p className="text-sm text-[color:var(--color-text-secondary)]">
+              {localize(
+                locale,
+                "这些是 Friday 从互动中学到的置信度事实；它们独立于显式 Memory，不会作为原始 learned fact 直接注入 prompt。",
+                "These are confidence-scored facts Friday learned from interactions; they are separate from explicit Memory and are not injected into prompts as raw learned facts.",
+              )}
+            </p>
+            <p className="text-xs leading-5 text-[color:var(--color-text-tertiary)]">
+              {localize(
+                locale,
+                "只有通信 persona 或 runtime context resolver 明确使用时才会产生影响；执行、测试、安全和 User Constitution 偏好仍需要 Review Center 确认后才会作为 Reflex 偏好进入 prompt。",
+                "They can influence behavior only when a communication persona or runtime context resolver explicitly uses them; execution, testing, safety, and User Constitution preferences still need Review Center confirmation before entering prompts as Reflex preferences.",
+              )}
+            </p>
+            {learnedFacts.length === 0 ? (
               <p className="text-sm text-[color:var(--color-text-secondary)]">
-                {localize(locale, "这些是 Friday 从你的互动中学到的偏好和事实。", "These are preferences and facts Friday has learned from your interactions.")}
+                {localize(locale, "还没有 learned facts。边界仍然生效：显式 Memory、learned fact、Reflex 偏好和 User Constitution 是分开的。", "No learned facts yet. The boundary still applies: explicit Memory, learned facts, Reflex preferences, and User Constitution settings are separate.")}
               </p>
-              {learnedFacts.map((fact) => (
-                <div key={fact.key} className="rounded-[22px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-subtle)] p-4">
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="min-w-0">
-                      <div className="flex items-center gap-2">
-                        <Brain className="h-3.5 w-3.5 text-[color:var(--color-text-faint)]" />
-                        <p className="text-sm font-medium text-[color:var(--color-text-primary)]">{fact.key}</p>
-                      </div>
-                      <p className="mt-1 text-sm text-[color:var(--color-text-secondary)]">{String(fact.value)}</p>
+            ) : learnedFacts.map((fact) => (
+              <div key={fact.key} className="rounded-[22px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-subtle)] p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2">
+                      <Brain className="h-3.5 w-3.5 text-[color:var(--color-text-faint)]" />
+                      <p className="text-sm font-medium text-[color:var(--color-text-primary)]">{fact.key}</p>
                     </div>
-                    <StatusPill tone={fact.confidence >= 0.7 ? "success" : fact.confidence >= 0.4 ? "warning" : "neutral"}>
-                      {(fact.confidence * 100).toFixed(0)}%
-                    </StatusPill>
+                    <p className="mt-1 text-sm text-[color:var(--color-text-secondary)]">{String(fact.value)}</p>
                   </div>
-                  <p className="mt-2 text-xs text-[color:var(--color-text-faint)]">
-                    {String(fact.evidenceCount)} evidence · last confirmed {formatTimestamp(fact.lastConfirmedAt)}
-                  </p>
+                  <StatusPill tone={fact.confidence >= 0.7 ? "success" : fact.confidence >= 0.4 ? "warning" : "neutral"}>
+                    {(fact.confidence * 100).toFixed(0)}%
+                  </StatusPill>
                 </div>
-              ))}
-            </div>
-          </ShellCard>
-        ) : null}
+                <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                  {learnedFactBoundaryDetails(fact, locale).map((item) => (
+                    <div key={item.label} className="min-w-0 rounded-xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg)] px-3 py-2">
+                      <p className="text-[11px] uppercase text-[color:var(--color-text-faint)]">{item.label}</p>
+                      <p className="mt-1 text-xs text-[color:var(--color-text-secondary)]">{item.value}</p>
+                    </div>
+                  ))}
+                </div>
+                <p className="mt-2 text-xs text-[color:var(--color-text-faint)]">
+                  {String(fact.evidenceCount)} evidence · last confirmed {formatTimestamp(fact.lastConfirmedAt)}
+                </p>
+              </div>
+            ))}
+          </div>
+        </ShellCard>
 
         <ShellCard eyebrow={localize(locale, "运维", "Operator")} title={localize(locale, "学习控制", "Learning Controls")}>
           {learningOverview ? (


### PR DESCRIPTION
## Phase 21E - Memory / Preference Truth

### Scope
- Closes Phase 21E P21-006/P21-007 only.
- Does not reopen Phase 20, PR #244, channel/cloud, OTEL/Grafana, or release-complete-all claims.
- Does not wire `createFridayPreferenceInjector` into the production prompt path.

### Changes
- Adds explicit learned-fact boundary labels for prompt injection, Review Center confirmation, and revocation alongside existing trust/memory/evidence/context-use labels.
- Returns those boundary labels from UIX learned-fact routes, memory search/list synthetic learned-fact items, and agent memory search metadata.
- Updates Settings learned-fact UI copy to distinguish learned facts from explicit Memory and raw prompt injection.
- Updates Reflex preference copy to make saved/confirmed preferences and Review Center-gated prompt effects explicit.
- Updates `docs/current-source-of-truth.md` to document the actual production boundary: communication prompt builder + persisted Reflex/User Constitution fragments, not raw learned-fact blanket injection.
- Adds static/source tests proving the UI/doc boundary copy and no production hub wiring of the injector.

### Verification
- `npm exec vitest run test/unit/ui/memory-preference-truth-entrypoints.test.ts test/unit/api/http/routes/friday-uix-routes.test.ts test/unit/api/http/routes/friday-memory-routes.test.ts test/unit/agent/tools/friday-agent-memory-tools.test.ts test/unit/agent/runtime/friday-agent-preference-injector.test.ts test/unit/reflex/friday-reflex-service.test.ts test/unit/reflex/friday-user-constitution.test.ts test/unit/uix/services/friday-communication-persona.test.ts test/unit/agent/runtime/friday-agent-runtime.test.ts test/unit/learning/services/friday-preference-extraction-service.test.ts test/unit/learning/services/friday-preference-fact-service.test.ts` -> 11 files / 315 tests passed.
- `npm run typecheck` -> passed.
- `npm run lint -- --quiet` -> passed.
- `npm run check:secret-patterns` -> passed.
- `git diff --check` -> passed.
- `git diff --cached --check` -> passed before commit.

### Stage 5 Review
Normal isolated read-only reviewers were used; alternate local Stage 5 fallback was not used.

- Reviewer A initial pass found a real docs overclaim blocker: `docs/current-source-of-truth.md` implied Assets rendered the full learned-fact boundary summary. Fixed by narrowing the doc to state Settings renders full boundaries, UIX/memory/agent-memory return boundary metadata, and Assets only lists/deletes learned facts as learned knowledge.
- Reviewer A rerun PASS: Curie `019e433a-36c0-7471-b77d-b68cbf5b1493`.
- Reviewer B rerun PASS: Popper `019e433a-60cc-7cc1-a18b-556efafe9ca0`.

### Release Proof Status
- Local focused proof: passed.
- CI/RGG: pending Stage 7 for PR head `a13aa9a9c625c8b924a48577dd44b816628eec25`.
- RGG will count only if the artifact is for the same SHA, status is `passed`, scenarios are nonzero/all pass, and blockers are empty.

### Safety / Boundary Notes
- No owner/admin bypass requested or used.
- No secrets added; secret-pattern scan passed.
- No API state rename, migration, prompt behavior wiring, or memory schema change.
- High-impact execution/testing/security/memory/workflow/skill/User Constitution preferences remain Review Center-gated before durable Reflex prompt effect.

### Rollback
- Revert PR head `a13aa9a9c625c8b924a48577dd44b816628eec25` or the eventual merge commit if this Phase 21E truth slice needs removal.
