### PR TITLE
Phase 22B: Gate vague tasks through typed clarification

### DIFF
--- a/src/agent/runtime/friday-agent-planning-gate.ts
+++ b/src/agent/runtime/friday-agent-planning-gate.ts
@@ -82,6 +82,8 @@ const GENERATE_WORKFLOW_HINTS = /\b((?:generate|create|build|set up|make) (?:a )
 const DEPLOY_WORKFLOW_HINTS = /\b(deploy workflow|publish workflow|ship workflow|roll out workflow)\b/i;
 const EXPORT_WORKFLOW_HINTS = /\b(export workflow|workflow bundle|package workflow)\b/i;
 const MAJOR_DECISION_HINTS = /\b(architecture|architect|strategy|migration|roadmap|implementation plan|rollout plan|major refactor|large refactor|overhaul|choose between|decision|tradeoff|design the approach)\b/i;
+const VAGUE_DELIVERABLE_HINTS = /\b(?:build|create|make|design|set up|put together|help me (?:build|create|make|design))\b[\s\S]{0,80}\b(?:website|web site|site|web app|app|landing page|dashboard|tool|project|prototype|feature|product)\b/i;
+const VAGUE_IMPROVEMENT_HINTS = /\b(?:make|improve|prepare|turn)\b[\s\S]{0,80}\b(?:friday|this app|the app|this project|the project|the repo|repository|workspace)\b[\s\S]{0,80}\b(?:better|production[- ]ready|usable|ready|safer|stable|polished)\b/i;
 const VAGUE_STRATEGIC_PLAN_HINTS = /\b(workflow plan|production[- ]ready|intentionally vague|vague request|ask the missing clarification questions|wait for (?:my|our|the )?answers before)\b/i;
 const CONSTRAINT_HINTS = /\b(must|should|avoid|without|constraint|permission|runtime|read.?only|safe|safely|don't|do not|cannot)\b/i;
 const DETAIL_HINTS = /\b(trigger|input|output|destination|runtime|workspace|browser|provider|channel|timeline|success|goal|constraint|notify|deploy|export)\b/i;
@@ -149,6 +151,8 @@ function detectPlanningKind(task: string, reviewRequired?: boolean): FridayPlann
   if (DEPLOY_WORKFLOW_HINTS.test(normalized)) return "deploy_workflow";
   if (EXPORT_WORKFLOW_HINTS.test(normalized)) return "export_workflow_bundle";
   if (GENERATE_WORKFLOW_HINTS.test(normalized)) return "generate_workflow";
+  if (VAGUE_DELIVERABLE_HINTS.test(normalized)) return "major_decision";
+  if (VAGUE_IMPROVEMENT_HINTS.test(normalized)) return "major_decision";
   if (VAGUE_STRATEGIC_PLAN_HINTS.test(normalized)) return "major_decision";
   if (MAJOR_DECISION_HINTS.test(normalized)) return "major_decision";
   return null;
@@ -159,6 +163,9 @@ function hasPlanningActionHint(task: string): boolean {
     || GENERATE_WORKFLOW_HINTS.test(task)
     || DEPLOY_WORKFLOW_HINTS.test(task)
     || EXPORT_WORKFLOW_HINTS.test(task)
+    || VAGUE_DELIVERABLE_HINTS.test(task)
+    || VAGUE_IMPROVEMENT_HINTS.test(task)
+    || VAGUE_STRATEGIC_PLAN_HINTS.test(task)
     || MAJOR_DECISION_HINTS.test(task);
 }
 

--- a/src/api/http/routes/friday-agent-routes.ts
+++ b/src/api/http/routes/friday-agent-routes.ts
@@ -223,6 +223,7 @@ function buildAgentRunDecisionTrace(
   const planEventNames = new Set([
     "agent.run.planning",
     "agent.run.plan_ready",
+    "agent.run.awaiting_clarification",
     "agent.run.awaiting_plan_approval",
     "agent.run.plan_approved",
     "agent.run.plan_rejected",
@@ -433,6 +434,18 @@ function sanitizeAuditEventPayload(event: FridayAgentRunEventRecord): unknown {
       ...(readStringField(payload, "planKind") ? { planKind: readStringField(payload, "planKind") } : {}),
       hasPlanMarkdown: typeof payload.planMarkdown === "string" && payload.planMarkdown.length > 0,
       hasPlanSummary: typeof payload.planSummary === "string" && payload.planSummary.length > 0,
+    };
+  }
+  if (event.eventName === "agent.run.awaiting_clarification") {
+    const questions = Array.isArray(payload.questions)
+      ? payload.questions.filter((question): question is string => typeof question === "string" && question.trim().length > 0)
+      : [];
+    return {
+      ...(readStringField(payload, "runId") ? { runId: readStringField(payload, "runId") } : {}),
+      status: "awaiting_clarification",
+      ...(readStringField(payload, "planKind") ? { planKind: readStringField(payload, "planKind") } : {}),
+      hasMessage: typeof payload.message === "string" && payload.message.length > 0,
+      questionCount: questions.length,
     };
   }
   if (event.eventName === "agent.run.awaiting_plan_approval") {
@@ -1161,6 +1174,7 @@ export function createFridayAgentRoutes(
           "agent.run.started",
           "agent.run.planning",
           "agent.run.plan_ready",
+          "agent.run.awaiting_clarification",
           "agent.run.awaiting_plan_approval",
           "agent.run.plan_approved",
           "agent.run.plan_rejected",

--- a/test/unit/agent/runtime/friday-agent-planning-gate.test.ts
+++ b/test/unit/agent/runtime/friday-agent-planning-gate.test.ts
@@ -208,6 +208,41 @@ describe("friday-agent-planning-gate", () => {
     expect(runs.get("run-vague-production-ready")?.actualExecution?.turns).toEqual([]);
   });
 
+  it("returns awaiting_clarification for ordinary vague website build requests", () => {
+    const service = createService();
+
+    const decision = service.handleTurn({
+      runId: "run-vague-website",
+      task: "Build me a small website for my side project.",
+      sessionKey: "ui:assistant:1",
+    });
+
+    expect(decision.action).toBe("return");
+    if (decision.action !== "return") {
+      throw new Error("Expected return decision");
+    }
+    expect(decision.result.status).toBe("awaiting_clarification");
+    expect(decision.pendingPlanRunId).toBe("run-vague-website");
+    expect(decision.result.response).toContain("Before I execute this major decision");
+    expect(decision.result.response).toContain("Question 1/2");
+    expect(runs.get("run-vague-website")?.status).toBe("awaiting_clarification");
+    expect(runs.get("run-vague-website")?.actualExecution?.turns).toEqual([]);
+    expect(executeRun).not.toHaveBeenCalled();
+  });
+
+  it("keeps safe website design questions out of the clarification gate", () => {
+    const service = createService();
+
+    const decision = service.handleTurn({
+      runId: "run-safe-website-question",
+      task: "Describe how to design a website navigation for beginners?",
+      sessionKey: "ui:assistant:1",
+    });
+
+    expect(decision).toEqual({ action: "pass_through" });
+    expect(runs.has("run-safe-website-question")).toBe(false);
+  });
+
   it("does not force safe Q&A through clarification when plan mode is present", () => {
     const service = createService();
 

--- a/test/unit/api/runtime/friday-api-runtime-planning-gate.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-planning-gate.test.ts
@@ -358,4 +358,69 @@ describe("FridayApiRuntime — planning gate session loop", () => {
       .map((message) => message.contentText);
     expect(assistantMessages).toContain(approved.response);
   });
+
+  it("persists vague website requests as typed awaiting clarification with audit evidence", async () => {
+    db = createTestDb();
+    const idGenerator = makeIdGenerator();
+    const eventEmitter = createFridayAgentEventEmitter();
+    const agentRuntime: FridayAgentRuntime = {
+      executeRun: vi.fn(async () => {
+        throw new Error("Vague website request should stop at the planning gate.");
+      }),
+      registerTool: vi.fn(),
+      resumeStaleRunsOnBoot: vi.fn(() => 0),
+    };
+
+    const runtime = createFridayApiRuntime({
+      db,
+      idGenerator,
+      nowIso: () => NOW,
+      providerService: makeProviderService(),
+      agentRuntime,
+      agentEventEmitter: eventEmitter,
+      tokenSecret: "test-secret-key-that-is-at-least-32-chars-long!!", // pragma: allowlist secret
+      computeChecksum: (content: string) => `checksum-${content.length}`,
+      resolveSkill: () => null,
+      invokeSkill: async () => ({}),
+    });
+
+    const startRoute = runtime.routes.getRoutes().find((route) => route.operationId === "agent.runs.start");
+    const auditRoute = runtime.routes.getRoutes().find((route) => route.operationId === "agent.runs.audit");
+    expect(startRoute).toBeDefined();
+    expect(auditRoute).toBeDefined();
+
+    const initial = await startRoute!.handler({
+      body: {
+        task: "Build me a small website for my side project.",
+        sessionKey: "ui:vague-website:test",
+      },
+      principal: makeBoundPrincipal("vague-website-user"),
+    } as never);
+
+    expect(initial.status).toBe("awaiting_clarification");
+    expect(initial.response).toContain("Question 1/2");
+    expect(agentRuntime.executeRun).not.toHaveBeenCalled();
+
+    const audit = await auditRoute!.handler({
+      params: { runId: initial.runId },
+      principal: makeBoundPrincipal("vague-website-user"),
+    } as never);
+
+    expect(audit.events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "agent.run.awaiting_clarification",
+          payload: expect.objectContaining({
+            status: "awaiting_clarification",
+            planKind: "major_decision",
+            hasMessage: true,
+            questionCount: 2,
+          }),
+        }),
+      ]),
+    );
+    expect(audit.decisionTrace.run.status).toBe("awaiting_clarification");
+    expect(audit.decisionTrace.plan.state).toBe("awaiting_clarification");
+    expect(audit.decisionTrace.plan.eventPointers.length).toBeGreaterThanOrEqual(2);
+  });
 });

--- a/test/unit/ui/assistant-view-models.test.ts
+++ b/test/unit/ui/assistant-view-models.test.ts
@@ -4,6 +4,7 @@ import {
   buildAssistantRecoveryPaths,
   buildAssistantQuickActions,
   describeIntentConfidence,
+  getNextClarificationQuestion,
   summarizeActionStatus,
   summarizeSkillEvidence,
   toneForIssue,
@@ -16,6 +17,7 @@ import type {
   FridayWorkflowOverview,
 } from "@friday-operator-client";
 import type {
+  AgentRunRecord,
   FridayFleetSatelliteCard,
   FridayPendingSatellitePairingRequest,
   SkillCatalogItem,
@@ -183,6 +185,44 @@ describe("assistant view models", () => {
     };
 
     expect(summarizeSkillEvidence(evidence)).toBe("Ready to approve and stage a candidate for lifecycle review.");
+  });
+
+  it("selects the next unanswered clarification question for active runs", () => {
+    const run = {
+      status: "awaiting_clarification",
+      planReview: {
+        plan: {
+          task: "Build me a website",
+          stepCount: 3,
+          description: "Planning gate for major decision",
+        },
+        gate: {
+          kind: "major_decision",
+          state: "awaiting_clarification",
+          clarificationQuestions: [
+            "What outcome matters most?",
+            "What constraints matter?",
+          ],
+          answers: [{ question: "What outcome matters most?", answer: "A simple portfolio." }],
+        },
+      },
+    } as Pick<AgentRunRecord, "status" | "planReview">;
+
+    expect(getNextClarificationQuestion(run)).toBe("What constraints matter?");
+    expect(getNextClarificationQuestion({
+      ...run,
+      planReview: {
+        ...run.planReview!,
+        gate: {
+          ...run.planReview!.gate!,
+          answers: [
+            { question: "What outcome matters most?", answer: "A simple portfolio." },
+            { question: "What constraints matter?", answer: "No backend." },
+          ],
+        },
+      },
+    })).toBeNull();
+    expect(getNextClarificationQuestion({ ...run, status: "awaiting_plan_approval" })).toBeNull();
   });
 
   it("prioritizes quick assistant actions for issue, workflow, fleet, and alert recovery", () => {

--- a/ui/src/lib/assistant/view-models.ts
+++ b/ui/src/lib/assistant/view-models.ts
@@ -6,6 +6,7 @@ import type {
   FridayWorkflowOverview,
 } from "@friday-operator-client";
 import type {
+  AgentRunRecord,
   FridayFleetSatelliteCard,
   FridayPendingSatellitePairingRequest,
   SkillCatalogItem,
@@ -71,6 +72,20 @@ export function summarizeSkillEvidence(evidence?: SkillGenerationEvidence | null
     return "Draft still needs to pass the explicit self-test.";
   }
   return evidence.approvalReadiness.reason;
+}
+
+export function getNextClarificationQuestion(
+  run?: Pick<AgentRunRecord, "status" | "planReview"> | null,
+): string | null {
+  if (!run || run.status !== "awaiting_clarification") {
+    return null;
+  }
+  const questions = run.planReview?.gate?.clarificationQuestions ?? [];
+  const answeredCount = run.planReview?.gate?.answers?.length ?? 0;
+  const nextQuestion = questions[answeredCount];
+  return typeof nextQuestion === "string" && nextQuestion.trim().length > 0
+    ? nextQuestion
+    : null;
 }
 
 export interface FridayAssistantQuickAction {

--- a/ui/src/routes/agent-page.tsx
+++ b/ui/src/routes/agent-page.tsx
@@ -53,6 +53,7 @@ import {
 } from "@/lib/system/view-models";
 import { buildSkillHref } from "@/lib/skills/view-models";
 import { trackStarterSkillBatch, trackStarterSkillEvent } from "@/lib/skills/starter-skill-telemetry";
+import { getNextClarificationQuestion } from "@/lib/assistant/view-models";
 import {
   describeRunHealth,
   displayRunTask,
@@ -692,6 +693,7 @@ export function AgentPage() {
     || currentRun?.planReview?.gate?.planMarkdown
     || currentRun?.planReview?.gate?.planSummary
     || "";
+  const nextClarificationQuestion = getNextClarificationQuestion(currentRun);
 
   return (
     <div className="grid gap-4 xl:grid-cols-[1.35fr_0.95fr]">
@@ -895,9 +897,9 @@ export function AgentPage() {
                   </div>
                 ) : null}
               </div>
-              {currentRun?.status === "awaiting_clarification" && currentRun.planReview?.gate?.clarificationQuestions?.length ? (
+              {nextClarificationQuestion ? (
                 <div className="mb-3 rounded-2xl border border-[color:var(--color-border-strong)] bg-[color:var(--color-bg-contrast)] p-3 text-sm text-[color:var(--color-text-primary)]">
-                  {locale === "zh" ? "等待澄清。下一个问题：" : "Waiting for clarification. Next question: "}{currentRun.planReview.gate.clarificationQuestions[0]}
+                  {locale === "zh" ? "等待澄清。下一个问题：" : "Waiting for clarification. Next question: "}{nextClarificationQuestion}
                 </div>
               ) : null}
               {currentRun?.status === "awaiting_plan_approval" && currentRun.planReview?.gate?.approvalPrompt ? (


### PR DESCRIPTION
## Summary
- Route ordinary vague website/app/improvement requests into typed `awaiting_clarification` before execution.
- Include `agent.run.awaiting_clarification` in agent audit/decision trace with sanitized payload shape.
- Show the next unanswered clarification question in the local agent UI.

## Verification
- `npm exec vitest run test/unit/agent/runtime/friday-agent-planning-gate.test.ts test/unit/api/runtime/friday-api-runtime-planning-gate.test.ts test/unit/ui/assistant-view-models.test.ts`
- `npm run typecheck`
- `npm run lint -- --quiet`
- `npm run check:secret-patterns`
- `git diff --check`

## Stage 5 Review
- Reviewer A: PASS, read-only code correctness/wiring review.
- Reviewer B: PASS, read-only regression/proof/no-overclaim review.

## Proof Boundaries
- Local runtime/API/UI unit proof only in this PR.
- No channel/cloud/OTEL/Grafana/live-provider proof claimed.
- CI and same-SHA RGG are pending and must pass before merge.
- No owner/admin bypass requested or needed.