### PR TITLE
Phase 22D memory recall proof

### DIFF
--- a/scripts/ops/run-real-green-gate.mjs
+++ b/scripts/ops/run-real-green-gate.mjs
@@ -27,6 +27,7 @@ const DAILY_CORE_SCENARIOS = [
   "l3-long-summary-direct",
   "l3-json-extraction",
   "l3-multi-turn-memory",
+  "l3-memory-api-store-agent-recall-proof",
   "l4-file-tool-roundtrip",
   "l5-workflow-approval-roundtrip",
 ];

--- a/src/agent/tools/friday-agent-memory-tools.ts
+++ b/src/agent/tools/friday-agent-memory-tools.ts
@@ -1,5 +1,9 @@
 import type { FridayAgentToolDefinition, FridayAgentToolResult } from "../model/friday-agent.types.js";
-import type { FridayMemoryService } from "#memory";
+import type {
+  FridayMemoryGuardContext,
+  FridayMemoryGuardServiceFactory,
+  FridayMemoryService,
+} from "#memory";
 import type { FridayMemoryItem, FridayMemorySearchResult } from "#memory";
 import type { FridayLearningEventAppendInput } from "#ledger";
 import {
@@ -25,6 +29,7 @@ export interface CreateFridayAgentMemoryToolsDeps {
   idGenerator?: () => string;
   nowIso?: () => string;
   resolveSessionMemoryNamespace?: (sessionKey: string) => Promise<string | undefined>;
+  memoryGuardFactory?: FridayMemoryGuardServiceFactory;
   /**
    * Optional session or run identifier used to scope the memory namespace.
    * When provided, the default namespace "agent" becomes "agent:<sessionId>"
@@ -350,6 +355,16 @@ function shouldIncludeLearnedFacts(namespace: string | undefined): boolean {
     || normalized === "agent";
 }
 
+function shouldIncludeGuardedPrincipalMemory(namespace: string | undefined): boolean {
+  if (!namespace) {
+    return true;
+  }
+  const normalized = normalizeMemoryNamespace(namespace);
+  return normalized === "preference"
+    || normalized === "user"
+    || normalized === "default";
+}
+
 function taskPromptLooksLikeQuestion(taskPrompt: string | undefined): boolean {
   if (!taskPrompt || taskPrompt.trim().length === 0) {
     return false;
@@ -386,6 +401,28 @@ function resolvePrincipalId(
     return fromArgs.trim();
   }
   return undefined;
+}
+
+function resolvePrincipalMemoryGuardContext(input: {
+  args: Record<string, unknown>;
+  signal: AbortSignal;
+}): FridayMemoryGuardContext | undefined {
+  const executionContext = getFridayAgentToolExecutionContext(input.signal);
+  const principalId = resolvePrincipalId(input.args, input.signal);
+  const hubId = normalizeAgentMemoryScopeId(executionContext?.tenantContext?.hubId);
+  const userId = normalizeAgentMemoryScopeId(executionContext?.tenantContext?.userId)
+    ?? principalId;
+  if (!principalId || !hubId || !userId) {
+    return undefined;
+  }
+  return {
+    principalId,
+    subject: {
+      hubId,
+      userId,
+      accessLevel: "tenant",
+    },
+  };
 }
 
 function resolveMemoryScopeId(input: {
@@ -564,6 +601,15 @@ function createMemorySearchTool(
           namespace: scopedNamespace,
           limit: implicitSessionNamespace ? Math.max(limit * 2, limit) : limit,
         });
+        const memoryGuardFactory = deps.memoryGuardFactory;
+        const guardedContext = memoryGuardFactory && shouldIncludeGuardedPrincipalMemory(explicitNamespace)
+          ? resolvePrincipalMemoryGuardContext({ args, signal })
+          : undefined;
+        const guardedResults = guardedContext && memoryGuardFactory
+          ? await memoryGuardFactory.forContext(guardedContext).search(query, {
+            limit: Math.max(limit * 2, limit),
+          })
+          : [];
         const shouldUseSessionFallback =
           Boolean(implicitSessionNamespace && sessionId)
           && (
@@ -582,7 +628,10 @@ function createMemorySearchTool(
             })
             : [];
         const dedupedResults = (() => {
-          const merged = [...scopedResults, ...sessionLexicalCandidates];
+          const merged = [...scopedResults, ...guardedResults, ...sessionLexicalCandidates];
+          const directlySearchedIds = new Set(
+            [...scopedResults, ...guardedResults].map((candidate) => candidate.item.id),
+          );
           const seen = new Set<string>();
           const itemsByContent = new Map<string, FridayMemorySearchResult>();
           for (const result of merged) {
@@ -590,7 +639,7 @@ function createMemorySearchTool(
               continue;
             }
             seen.add(result.item.id);
-            const boostedResult = scopedResults.some((candidate) => candidate.item.id === result.item.id)
+            const boostedResult = directlySearchedIds.has(result.item.id)
               ? { ...result, score: result.score + 1 }
               : result;
             const adjustedResult = applyMemoryCandidateScoreAdjustments(boostedResult, sessionId);

--- a/src/agent/tools/friday-agent-memory-tools.ts
+++ b/src/agent/tools/friday-agent-memory-tools.ts
@@ -362,7 +362,8 @@ function shouldIncludeGuardedPrincipalMemory(namespace: string | undefined): boo
   const normalized = normalizeMemoryNamespace(namespace);
   return normalized === "preference"
     || normalized === "user"
-    || normalized === "default";
+    || normalized === "default"
+    || normalized === "agent";
 }
 
 function taskPromptLooksLikeQuestion(taskPrompt: string | undefined): boolean {

--- a/src/agent/tools/friday-agent-tool-registry.ts
+++ b/src/agent/tools/friday-agent-tool-registry.ts
@@ -1,6 +1,6 @@
 import type { FridaySkillExecutor, FridaySkillRegistry, SkillLifecycleStatus } from "#skills";
 import type { FridayWorkflowExecutionService } from "#workflows";
-import type { FridayMemoryService } from "#memory";
+import type { FridayMemoryGuardServiceFactory, FridayMemoryService } from "#memory";
 import type { FridayAgentToolDefinition } from "../model/friday-agent.types.js";
 import type { FridayAgentSsrfGuard } from "../security/friday-agent-ssrf-guard.js";
 import type { FridaySubagentContext, FridaySubagentRegistry } from "../subagent/friday-subagent.types.js";
@@ -74,6 +74,7 @@ export interface CreateFridayAgentToolRegistryOptions {
   getSkillLifecycleStatus?: (skillId: string) => SkillLifecycleStatus | null | undefined;
   workflowExecutionService?: FridayWorkflowExecutionService;
   memoryService?: FridayMemoryService;
+  memoryGuardFactory?: FridayMemoryGuardServiceFactory;
   listLearnedFacts?: (input: { userId: string; limit: number }) => FridayLearnedFactView[];
   learningEventWriter?: (events: FridayLearningEventAppendInput[]) => void;
   idGenerator?: () => string;
@@ -219,6 +220,7 @@ export function createFridayAgentToolRegistry(
         resolveSessionMemoryNamespace: options.sessionService
           ? async (sessionKey) => options.sessionService?.getSessionMemoryNamespace(sessionKey)
           : undefined,
+        memoryGuardFactory: options.memoryGuardFactory,
       }),
     );
   }

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -151,14 +151,14 @@ import {
   createFridayPluginSignatureVerifier,
 } from "#plugins";
 import type { FridayPluginService } from "#plugins";
-import { createFridayEpisodeExtractor, createFridayMemoryFileSyncRepository, createFridayMemoryFileSyncService, createFridayMemoryService, createFridayPatternExtractor } from "#memory";
+import { createFridayEpisodeExtractor, createFridayMemoryFileSyncRepository, createFridayMemoryFileSyncService, createFridayMemoryGuardServiceFactory, createFridayMemoryService, createFridayPatternExtractor } from "#memory";
 import {
   createFridaySessionMemoryExtractionService,
   finalizeFridayConversationFocus,
   prepareFridayConversationTurn,
 } from "#sessions";
 import type { FridayConversationBlock } from "#sessions";
-import type { FridayMemoryFileSyncService, FridayMemoryService } from "#memory";
+import type { FridayMemoryFileSyncService, FridayMemoryGuardServiceFactory, FridayMemoryService } from "#memory";
 import {
   buildFridayAgentRunContextSummarySnapshot,
   buildFridayAgentRunHealthSnapshot,
@@ -1400,6 +1400,14 @@ export async function createFridayHub(
       nowIso,
     });
   }
+  const memoryGuardFactory: FridayMemoryGuardServiceFactory | undefined = stateRuntime && memoryService
+    ? createFridayMemoryGuardServiceFactory({
+      core: memoryService,
+      db: stateRuntime.sqlite,
+      nowIso,
+      nowMs: () => new Date(nowIso()).getTime(),
+    })
+    : undefined;
 
   // ─── Workflow runtime ───
 
@@ -2772,6 +2780,7 @@ export async function createFridayHub(
     getSkillLifecycleStatus: getPersistedSkillLifecycleStatus,
     workflowExecutionService: workflowRuntime.execution,
     memoryService,
+    memoryGuardFactory,
     listLearnedFacts: (input) =>
       selfLearningRuntime.facts
         .listActiveFacts({ userId: input.userId, minConfidence: 0, limit: input.limit })
@@ -4761,6 +4770,7 @@ export async function createFridayHub(
         getSkillLifecycleStatus: getPersistedSkillLifecycleStatus,
         workflowExecutionService: workflowRuntime.execution,
         memoryService,
+        memoryGuardFactory,
         listLearnedFacts: (input) =>
           selfLearningRuntime.facts
             .listActiveFacts({ userId: input.userId, minConfidence: 0, limit: input.limit })

--- a/test/integration/memory/friday-agent-memory-recall-boundary.test.ts
+++ b/test/integration/memory/friday-agent-memory-recall-boundary.test.ts
@@ -97,7 +97,7 @@ describe("Friday agent memory recall boundary", () => {
     vi.restoreAllMocks();
   });
 
-  it("recalls current-principal API memory through the agent memory_search tool", async () => {
+  it("recalls current-principal API memory through explicit agent memory_search", async () => {
     const memoryService = createFridayMemoryService({
       db,
       providerService: createMockProviderService(),
@@ -132,7 +132,7 @@ describe("Friday agent memory recall boundary", () => {
       memoryGuardFactory,
     });
     const result = await searchTool!.execute(
-      { query: "proof run project codename", limit: 3 },
+      { query: "proof run project codename", namespace: "agent", limit: 3 },
       signalWithAdminTenant(),
     );
 

--- a/test/integration/memory/friday-agent-memory-recall-boundary.test.ts
+++ b/test/integration/memory/friday-agent-memory-recall-boundary.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createFridayAgentMemoryTools } from "#agent";
+import {
+  createFridayMemoryGuardServiceFactory,
+  createFridayMemoryService,
+} from "#memory";
+import type { FridaySqliteLayer } from "#state";
+import type { FridayProviderService } from "#providers";
+import { attachFridayAgentToolExecutionContext } from "../../../src/agent/runtime/friday-agent-tool-execution-context.js";
+import { createTestDb, createTestIdGenerator } from "../../helpers/friday-test-db.helper.js";
+
+function createMockProviderService(): FridayProviderService {
+  return {
+    listProviders: vi.fn(),
+    getProvider: vi.fn(),
+    createProvider: vi.fn(),
+    updateProvider: vi.fn(),
+    deleteProvider: vi.fn(),
+    validateProvider: vi.fn(),
+    getRoutingConfig: vi.fn(),
+    setRoutingConfig: vi.fn(),
+    resolveRoute: vi.fn(),
+    runWithFallback: vi.fn().mockImplementation(async (params) => {
+      const route = {
+        provider: {
+          id: "prov-1",
+          kind: "openai" as const,
+          name: "OpenAI",
+          baseUrl: "https://api.openai.com",
+          enabled: true,
+          config: {
+            api: "openai-completions" as const,
+            authMode: "api-key" as const,
+            keySource: { kind: "none" as const },
+            supportedModels: ["text-embedding-3-small"],
+          },
+          createdAt: "2026-05-20T18:00:00.000Z",
+          updatedAt: "2026-05-20T18:00:00.000Z",
+        },
+        model: "text-embedding-3-small",
+      };
+      const result = await params.run(route, "sk-test-key");
+      return {
+        result,
+        route,
+        attempts: [],
+        routingDecision: {
+          strategy: "direct" as const,
+          reason: "test",
+          budget: { withinBudget: true, remainingUsd: 100, monthlyLimitUsd: 100, spentUsd: 0 },
+        },
+      };
+    }),
+    recordUsage: vi.fn(),
+    getUsageSummary: vi.fn(),
+    getBudgetStatus: vi.fn(),
+    setBudgetConfig: vi.fn(),
+  } as unknown as FridayProviderService;
+}
+
+function signalWithAdminTenant(): AbortSignal {
+  return attachFridayAgentToolExecutionContext(new AbortController().signal, {
+    runId: "run-1",
+    sessionKey: "agent:run:run-1",
+    readOnly: true,
+    principalId: "admin-001",
+    tenantContext: {
+      hubId: "admin-001",
+      userId: "admin-001",
+    },
+  });
+}
+
+describe("Friday agent memory recall boundary", () => {
+  let db: FridaySqliteLayer;
+  const originalFetch = globalThis.fetch;
+  const nowIso = () => "2026-05-20T18:00:00.000Z";
+
+  beforeEach(() => {
+    db = createTestDb();
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            data: [{ embedding: [0.1, 0.2, 0.3], index: 0 }],
+            model: "text-embedding-3-small",
+          }),
+          { status: 200 },
+        ),
+      ),
+    ) as typeof fetch;
+  });
+
+  afterEach(() => {
+    db.close();
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("recalls current-principal API memory through the agent memory_search tool", async () => {
+    const memoryService = createFridayMemoryService({
+      db,
+      providerService: createMockProviderService(),
+      idGenerator: createTestIdGenerator(),
+      nowIso,
+    });
+    const memoryGuardFactory = createFridayMemoryGuardServiceFactory({
+      core: memoryService,
+      db,
+      nowIso,
+      nowMs: () => Date.parse(nowIso()),
+    });
+
+    await memoryGuardFactory.forContext({
+      principalId: "admin-001",
+      subject: {
+        hubId: "admin-001",
+        userId: "admin-001",
+        accessLevel: "tenant",
+      },
+    }).store(
+      "five-scenario-proof",
+      "For this proof run, the user's preferred project codename is BARB-phase-22d-real.",
+      {
+        source: "five-scenario-real-proof",
+        tags: ["five-scenario", "preference"],
+      },
+    );
+
+    const [searchTool] = createFridayAgentMemoryTools({
+      memoryService,
+      memoryGuardFactory,
+    });
+    const result = await searchTool!.execute(
+      { query: "proof run project codename", limit: 3 },
+      signalWithAdminTenant(),
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(JSON.parse(result.content)).toMatchObject([
+      {
+        content: "For this proof run, the user's preferred project codename is BARB-phase-22d-real.",
+        metadata: {
+          namespace: "tenant.admin-001.user.admin-001.five-scenario-proof",
+          source: "five-scenario-real-proof",
+        },
+      },
+    ]);
+  });
+});

--- a/test/unit/agent/tools/friday-agent-memory-tools.test.ts
+++ b/test/unit/agent/tools/friday-agent-memory-tools.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi } from "vitest";
 import { createFridayAgentMemoryTools } from "#agent";
-import type { FridayMemoryService } from "#memory";
+import type { FridayMemoryGuardServiceFactory, FridayMemoryService } from "#memory";
 import type { FridayMemoryItem, FridayMemorySearchResult } from "#memory";
+import type { FridayProviderTenantContext } from "#providers";
 import { attachFridayAgentToolExecutionContext } from "../../../../src/agent/runtime/friday-agent-tool-execution-context.js";
 
 function signal(): AbortSignal {
@@ -16,6 +17,7 @@ function signalWithContext(input: {
   principalId?: string;
   taskPrompt?: string;
   sessionKey?: string;
+  tenantContext?: FridayProviderTenantContext;
 }): AbortSignal {
   return attachFridayAgentToolExecutionContext(new AbortController().signal, {
     runId: "run-1",
@@ -23,6 +25,7 @@ function signalWithContext(input: {
     readOnly: false,
     principalId: input.principalId,
     taskPrompt: input.taskPrompt,
+    tenantContext: input.tenantContext,
   });
 }
 
@@ -72,6 +75,13 @@ function mockMemoryService(
     list: vi.fn().mockResolvedValue([]),
     delete: vi.fn().mockResolvedValue(false),
     prune: vi.fn().mockResolvedValue({ deletedCount: 0, deletedIds: [], dryRun: false }),
+  };
+}
+
+function mockMemoryGuardFactory(memoryService: FridayMemoryService): FridayMemoryGuardServiceFactory {
+  return {
+    forPrincipal: vi.fn().mockReturnValue(memoryService),
+    forContext: vi.fn().mockReturnValue(memoryService),
   };
 }
 
@@ -279,6 +289,78 @@ describe("FridayAgentMemoryTools", () => {
       expect(result.isError).toBe(true);
       expect(result.content).toContain("reserved");
       expect(svc.search).not.toHaveBeenCalled();
+    });
+
+    it("includes current-principal guarded API memory on default searches", async () => {
+      const svc = mockMemoryService([]);
+      const guardedSvc = mockMemoryService([
+        makeSearchResult({
+          item: makeItem({
+            id: "api-memory-1",
+            namespace: "tenant.admin-001.user.admin-001.five-scenario-proof",
+            content: "The proof run project codename is BARB-phase-22d.",
+            source: "five-scenario-real-proof",
+            tags: ["five-scenario", "preference"],
+          }),
+          score: 0.91,
+        }),
+      ]);
+      const memoryGuardFactory = mockMemoryGuardFactory(guardedSvc);
+      const [searchTool] = createFridayAgentMemoryTools({
+        memoryService: svc,
+        memoryGuardFactory,
+      });
+
+      const result = await searchTool!.execute(
+        { query: "proof run project codename", limit: 3 },
+        signalWithContext({
+          principalId: "admin-001",
+          tenantContext: { hubId: "admin-001", userId: "admin-001" },
+        }),
+      );
+
+      expect(result.isError).toBeUndefined();
+      expect(memoryGuardFactory.forContext).toHaveBeenCalledWith({
+        principalId: "admin-001",
+        subject: {
+          hubId: "admin-001",
+          userId: "admin-001",
+          accessLevel: "tenant",
+        },
+      });
+      expect(guardedSvc.search).toHaveBeenCalledWith("proof run project codename", {
+        limit: 6,
+      });
+      expect(JSON.parse(result.content)).toMatchObject([
+        {
+          content: "The proof run project codename is BARB-phase-22d.",
+          metadata: {
+            id: "api-memory-1",
+            namespace: "tenant.admin-001.user.admin-001.five-scenario-proof",
+          },
+        },
+      ]);
+    });
+
+    it("does not search guarded API memory for explicit agent namespace", async () => {
+      const svc = mockMemoryService([]);
+      const guardedSvc = mockMemoryService([makeSearchResult()]);
+      const memoryGuardFactory = mockMemoryGuardFactory(guardedSvc);
+      const [searchTool] = createFridayAgentMemoryTools({
+        memoryService: svc,
+        memoryGuardFactory,
+      });
+
+      await searchTool!.execute(
+        { query: "proof run project codename", namespace: "agent", limit: 3 },
+        signalWithContext({
+          principalId: "admin-001",
+          tenantContext: { hubId: "admin-001", userId: "admin-001" },
+        }),
+      );
+
+      expect(memoryGuardFactory.forContext).not.toHaveBeenCalled();
+      expect(guardedSvc.search).not.toHaveBeenCalled();
     });
 
     it("matches learned facts through token overlap when the model phrases the query differently", async () => {

--- a/test/unit/agent/tools/friday-agent-memory-tools.test.ts
+++ b/test/unit/agent/tools/friday-agent-memory-tools.test.ts
@@ -342,7 +342,58 @@ describe("FridayAgentMemoryTools", () => {
       ]);
     });
 
-    it("does not search guarded API memory for explicit agent namespace", async () => {
+    it("includes current-principal guarded API memory for explicit agent namespace", async () => {
+      const svc = mockMemoryService([]);
+      const guardedSvc = mockMemoryService([
+        makeSearchResult({
+          item: makeItem({
+            id: "api-memory-1",
+            namespace: "tenant.admin-001.user.admin-001.five-scenario-proof",
+            content: "The proof run project codename is BARB-phase-22d.",
+            source: "five-scenario-real-proof",
+            tags: ["five-scenario", "preference"],
+          }),
+          score: 0.91,
+        }),
+      ]);
+      const memoryGuardFactory = mockMemoryGuardFactory(guardedSvc);
+      const [searchTool] = createFridayAgentMemoryTools({
+        memoryService: svc,
+        memoryGuardFactory,
+      });
+
+      const result = await searchTool!.execute(
+        { query: "proof run project codename", namespace: "agent", limit: 3 },
+        signalWithContext({
+          principalId: "admin-001",
+          tenantContext: { hubId: "admin-001", userId: "admin-001" },
+        }),
+      );
+
+      expect(result.isError).toBeUndefined();
+      expect(memoryGuardFactory.forContext).toHaveBeenCalledWith({
+        principalId: "admin-001",
+        subject: {
+          hubId: "admin-001",
+          userId: "admin-001",
+          accessLevel: "tenant",
+        },
+      });
+      expect(guardedSvc.search).toHaveBeenCalledWith("proof run project codename", {
+        limit: 6,
+      });
+      expect(JSON.parse(result.content)).toMatchObject([
+        {
+          content: "The proof run project codename is BARB-phase-22d.",
+          metadata: {
+            id: "api-memory-1",
+            namespace: "tenant.admin-001.user.admin-001.five-scenario-proof",
+          },
+        },
+      ]);
+    });
+
+    it("does not search guarded API memory for custom agent namespaces", async () => {
       const svc = mockMemoryService([]);
       const guardedSvc = mockMemoryService([makeSearchResult()]);
       const memoryGuardFactory = mockMemoryGuardFactory(guardedSvc);
@@ -352,7 +403,7 @@ describe("FridayAgentMemoryTools", () => {
       });
 
       await searchTool!.execute(
-        { query: "proof run project codename", namespace: "agent", limit: 3 },
+        { query: "proof run project codename", namespace: "agent.custom", limit: 3 },
         signalWithContext({
           principalId: "admin-001",
           tenantContext: { hubId: "admin-001", userId: "admin-001" },

--- a/test/unit/validation/real-world-executors.test.ts
+++ b/test/unit/validation/real-world-executors.test.ts
@@ -25,13 +25,16 @@ describe("real-world executors", () => {
     responseText = "Friday",
     status = "completed",
     planReview,
+    request,
   }: {
     artifactDir?: string;
     responseText?: string;
     status?: string;
     planReview?: unknown;
+    request?: (method: string, routePath: string, options?: unknown) => Promise<unknown>;
   }) {
     return {
+      request,
       async startAgentRun() {
         return { data: { runId: "agent-run-1", toolCallCount: artifactDir ? 1 : 0 } };
       },
@@ -51,6 +54,47 @@ describe("real-world executors", () => {
             },
           },
         };
+      },
+    };
+  }
+
+  function createStatefulMemoryRecallScenario() {
+    return {
+      id: "l3-memory-api-store-agent-recall-proof",
+      entrySurface: "/v1/memory/store -> /v1/agent/runs",
+      expectedEvidence: [],
+      severityOnFailure: "P0",
+      realWorldPrompt: "Use memory_search and answer BARB.",
+      execution: {
+        kind: "agent_run",
+        setupRequests: [
+          {
+            method: "POST",
+            path: "/v1/memory/store",
+            body: {
+              namespace: "phase-22d-proof",
+              content: "codename BARB",
+            },
+            expectStatus: 200,
+            expectOkEnvelope: true,
+            jsonPathsPresent: ["data.item.id"],
+          },
+        ],
+        cleanupRequests: [
+          {
+            method: "DELETE",
+            path: "/v1/memory/items/{{setupResponses.0.json.data.item.id}}",
+            expectStatus: 200,
+            expectOkEnvelope: true,
+            jsonPathsPresent: ["data.deleted"],
+          },
+        ],
+        cleanupFailureIsFailure: true,
+        expectedOutputSubstrings: ["BARB"],
+        expectedToolNames: ["memory_search"],
+        expectedToolResultSubstrings: ["BARB"],
+        expectToolCallCountMin: 1,
+        constraints: { readOnly: true },
       },
     };
   }
@@ -261,6 +305,73 @@ describe("real-world executors", () => {
     expect(artifact.notes).toContain(
       "expected failed read tool evidence for missing workspace file docs/friday-strict-verifier-missing-proof-file.md",
     );
+  });
+
+  it("fails stateful agent scenarios when required cleanup does not satisfy expectations", async () => {
+    tempRoot = mkdtempSync(join(tmpdir(), "friday-real-world-executor-"));
+    const artifactDir = join(tempRoot, ".friday", "agent-runs", "agent-run-1");
+    mkdirSync(artifactDir, { recursive: true });
+    writeFileSync(
+      join(artifactDir, "tool-calls.json"),
+      JSON.stringify([
+        {
+          toolName: "memory_search",
+          args: { query: "codename" },
+          result: { isError: false, content: '[{"content":"codename BARB"}]' },
+        },
+      ]),
+      "utf8",
+    );
+
+    const artifact = await executeScenario({
+      runId: "validation-run-stateful-cleanup",
+      suite: "smoke",
+      scenario: createStatefulMemoryRecallScenario(),
+      lane,
+      client: createAgentScenarioClient({
+        artifactDir,
+        responseText: "BARB",
+        request: async (method, routePath) => {
+          if (method === "POST" && routePath === "/v1/memory/store") {
+            return {
+              status: 200,
+              ok: true,
+              json: { ok: true, data: { item: { id: "memory-1" } } },
+              text: "",
+              durationMs: 1,
+            };
+          }
+          return {
+            status: 500,
+            ok: false,
+            json: { ok: false, error: { code: "CLEANUP_FAILED" } },
+            text: "",
+            durationMs: 1,
+          };
+        },
+      }),
+      envTruth: {},
+      reportRoot: tempRoot,
+      uiBaseUrl: "http://127.0.0.1:3141",
+    });
+
+    expect(artifact.result).toBe("failed");
+    expect(artifact.failureClass).toBe("cleanup");
+    expect(artifact.notes).toContain(
+      "cleanup request 1 failed expectations: expected HTTP 200 but received 500; expected ok=true envelope; missing JSON path: data.deleted",
+    );
+    expect(artifact.raw.cleanupResponses).toEqual([
+      expect.objectContaining({
+        method: "DELETE",
+        path: "/v1/memory/items/memory-1",
+        status: 500,
+        expectationFailures: [
+          "expected HTTP 200 but received 500",
+          "expected ok=true envelope",
+          "missing JSON path: data.deleted",
+        ],
+      }),
+    ]);
   });
 
   describe("Phase 14.5B module_28b: auto_fix_doctor_roundtrip", () => {

--- a/validation/real-world/catalog/scenarios.mjs
+++ b/validation/real-world/catalog/scenarios.mjs
@@ -994,6 +994,60 @@ export const REAL_WORLD_SCENARIOS = [
     },
     suites: ["daily", "nightly", "weekly"],
   }),
+  agentScenario({
+    id: "l3-memory-api-store-agent-recall-proof",
+    layer: "L3",
+    productArea: "memory",
+    entrySurface: "/v1/memory/store -> /v1/agent/runs",
+    routeFamily: "memory_recall",
+    providerLane: "default_only",
+    riskTier: "high",
+    realWorldPrompt:
+      "你需要回答这个 proof run 的项目 codename。请先使用 memory_search 从 Friday 记忆中查找，不要编造。marker=phase22d-rgg-{{timestamp}}。只回答 codename。",
+    execution: {
+      setupRequests: [
+        {
+          method: "POST",
+          path: "/v1/memory/store",
+          body: {
+            namespace: "phase-22d-proof",
+            content: "For this proof run, the user's project codename is BARB-{{timestamp}}. marker=phase22d-rgg-{{timestamp}}.",
+            source: "phase-22d-real-world-validation",
+            tags: ["phase-22d", "memory-recall", "real-world-validation"],
+          },
+          expectStatus: 200,
+          expectOkEnvelope: true,
+          jsonPathsPresent: ["data.item.id", "data.item.namespace", "data.item.content"],
+        },
+      ],
+      cleanupRequests: [
+        {
+          method: "DELETE",
+          path: "/v1/memory/items/{{setupResponses.0.json.data.item.id}}",
+          expectStatus: 200,
+          expectOkEnvelope: true,
+          jsonPathsPresent: ["data.deleted"],
+        },
+      ],
+      cleanupFailureIsFailure: true,
+      constraints: { readOnly: true },
+      taskProfile: { id: "deterministic" },
+      timeoutMs: 240_000,
+      expectedOutputSubstrings: ["BARB-{{timestamp}}"],
+      expectedToolNames: ["memory_search"],
+      expectedToolResultSubstrings: ["BARB-{{timestamp}}"],
+      expectToolCallCountMin: 1,
+    },
+    oracles: {
+      behavior: {
+        expectedSubstrings: ["BARB-"],
+        forbiddenSubstrings: ["找不到", "没有找到", "无法找到", "not found", "could not find"],
+      },
+    },
+    suites: ["daily", "nightly", "weekly"],
+    severityOnFailure: "P0",
+    tags: ["phase-22d", "memory", "agent-recall", "api-memory-store"],
+  }),
   // Phase 13.5A Module 26a/26d — task-workflows read-only boundary catalog.
   //
   // Honesty note: this scenario only probes that the read-only boundary

--- a/validation/real-world/lib/executors.mjs
+++ b/validation/real-world/lib/executors.mjs
@@ -486,14 +486,17 @@ async function executeEnvTruth({ artifact, scenario, envTruth }) {
   return artifact;
 }
 
-function resolveAgentTurnPrompt({ scenario, execution, suite, attemptIndex, turn, turnIndex }) {
+function resolveAgentTurnPrompt({ scenario, execution, suite, attemptIndex, turn, turnIndex, templateContext }) {
   const applyPromptVariables = (value) => {
     if (typeof value !== "string" || value.length === 0) {
       return value;
     }
-    return value
+    const expanded = value
       .replaceAll("{{repoRoot}}", process.cwd())
       .replaceAll("{{workspaceRoot}}", process.cwd());
+    return templateContext
+      ? interpolateTemplateString(expanded, templateContext)
+      : expanded;
   };
   if (typeof turn?.prompt === "string" && turn.prompt.trim().length > 0) {
     return applyPromptVariables(turn.prompt);
@@ -584,6 +587,81 @@ async function executeHttpProbe({ artifact, client, scenario }) {
     artifact.failureClass = "http_contract";
   }
   return artifact;
+}
+
+async function executeTemplatedRequests({
+  artifact,
+  client,
+  scenario,
+  requests,
+  templateContext,
+  label,
+  throwOnExpectationFailure = true,
+}) {
+  if (!Array.isArray(requests) || requests.length === 0) {
+    return [];
+  }
+  const responses = [];
+  for (const [index, request] of requests.entries()) {
+    const requestContext = {
+      ...templateContext,
+      responses,
+    };
+    const requestPath = interpolateTemplateValue(request.path, requestContext);
+    const query = request.query
+      ? `?${new URLSearchParams(
+        Object.entries(request.query).reduce((acc, [key, value]) => {
+          acc[key] = String(interpolateTemplateValue(value, requestContext));
+          return acc;
+        }, {}),
+      ).toString()}`
+      : "";
+    const requestBody = request.body === undefined
+      ? undefined
+      : interpolateTemplateValue(request.body, requestContext);
+    const response = await client.request(request.method ?? "GET", `${requestPath}${query}`, {
+      timeoutMs: scenarioTimeout(scenario, 60_000),
+      headers: request.headers,
+      body: requestBody,
+    });
+    const record = {
+      method: request.method ?? "GET",
+      path: requestPath,
+      status: response.status,
+      ok: response.ok,
+      json: response.json ?? null,
+      text: response.text ?? null,
+      durationMs: response.durationMs,
+    };
+    artifact.observedEvidence.push(
+      `${label} ${String(index + 1)} ${record.method} ${requestPath} -> ${String(response.status)}`,
+    );
+
+    const reasons = [];
+    if (Number.isInteger(request.expectStatus) && response.status !== request.expectStatus) {
+      reasons.push(`expected HTTP ${String(request.expectStatus)} but received ${String(response.status)}`);
+    }
+    if (request.expectOkEnvelope && response.json?.ok !== true) {
+      reasons.push("expected ok=true envelope");
+    }
+    for (const path of request.jsonPathsPresent ?? []) {
+      if (resolveJsonPath(response.json, path) === undefined) {
+        reasons.push(`missing JSON path: ${path}`);
+      }
+    }
+    if (reasons.length > 0) {
+      record.expectationFailures = reasons;
+    }
+    responses.push(record);
+    if (reasons.length > 0) {
+      const message = `${label} request ${String(index + 1)} failed expectations: ${reasons.join("; ")}`;
+      if (throwOnExpectationFailure) {
+        throw new Error(message);
+      }
+      artifact.notes = [...(artifact.notes ?? []), message];
+    }
+  }
+  return responses;
 }
 
 // Phase 14.5B module_28b: live-HTTP RGG proof that all five /v1/auto-fix
@@ -1905,6 +1983,88 @@ async function executeAgentRun({ artifact, client, scenario, lane, suite, attemp
   let lastRunRecord = null;
   let lastData = null;
   let outputText = "";
+  const templateContext = {
+    scenario: {
+      id: scenario.id,
+      entrySurface: scenario.entrySurface,
+    },
+    timestamp: String(Date.now()),
+    nowIso: nowIso(),
+    attemptIndex: attemptIndex ?? 1,
+    lane: {
+      id: lane.id,
+      providerId: lane.providerId,
+      model: lane.model,
+    },
+  };
+  const setupResponses = await executeTemplatedRequests({
+    artifact,
+    client,
+    scenario,
+    requests: execution.setupRequests,
+    templateContext,
+    label: "setup",
+  });
+  const agentTemplateContext = {
+    ...templateContext,
+    setupResponses,
+  };
+  let cleanupCompleted = false;
+  const cleanupAgentRun = async () => {
+    if (cleanupCompleted) {
+      return;
+    }
+    cleanupCompleted = true;
+    try {
+      const cleanupResponses = await executeTemplatedRequests({
+        artifact,
+        client,
+        scenario,
+        requests: execution.cleanupRequests,
+        templateContext: {
+          ...agentTemplateContext,
+          turns: runTurns,
+          lastRun: lastRunRecord,
+        },
+        label: "cleanup",
+        throwOnExpectationFailure: false,
+      });
+      if (cleanupResponses.length > 0) {
+        artifact.raw = {
+          ...(artifact.raw ?? {}),
+          cleanupResponses,
+        };
+      }
+      const cleanupFailures = cleanupResponses.flatMap((response) =>
+        Array.isArray(response.expectationFailures)
+          ? response.expectationFailures
+          : [],
+      );
+      if (execution.cleanupFailureIsFailure === true && cleanupFailures.length > 0) {
+        if (!artifact.result || artifact.result === "passed") {
+          artifact.result = "failed";
+        }
+        artifact.failureClass = artifact.failureClass ?? "cleanup";
+      }
+    } catch (error) {
+      const message = `cleanup request failed: ${error instanceof Error ? error.message : String(error)}`;
+      artifact.notes = [...(artifact.notes ?? []), message];
+      if (execution.cleanupFailureIsFailure === true) {
+        if (!artifact.result || artifact.result === "passed") {
+          artifact.result = "failed";
+        }
+        artifact.failureClass = artifact.failureClass ?? "cleanup";
+        return;
+      }
+      throw error;
+    }
+  };
+  if (setupResponses.length > 0) {
+    artifact.raw = {
+      ...(artifact.raw ?? {}),
+      setupResponses,
+    };
+  }
 
   for (const [index, turn] of turns.entries()) {
     const prompt = resolveAgentTurnPrompt({
@@ -1914,18 +2074,26 @@ async function executeAgentRun({ artifact, client, scenario, lane, suite, attemp
       attemptIndex,
       turn,
       turnIndex: index,
+      templateContext: agentTemplateContext,
     });
-    const { data } = await client.startAgentRun({
-      task: prompt,
-      providerId: lane.providerId,
-      model: lane.model,
-      timeoutMs: scenarioTimeout(scenario, 180_000),
-      constraints: turn.constraints ?? execution.constraints ?? { readOnly: true },
-      taskProfile: turn.taskProfile ?? execution.taskProfile ?? { id: "deterministic" },
-      sessionKey: turn.sessionKey ?? sharedSessionKey,
-      executionContext: turn.executionContext ?? execution.executionContext,
-    });
-    const runRecord = (await client.getAgentRun(data.runId)).data.run;
+    let data;
+    let runRecord;
+    try {
+      ({ data } = await client.startAgentRun({
+        task: prompt,
+        providerId: lane.providerId,
+        model: lane.model,
+        timeoutMs: scenarioTimeout(scenario, 180_000),
+        constraints: turn.constraints ?? execution.constraints ?? { readOnly: true },
+        taskProfile: turn.taskProfile ?? execution.taskProfile ?? { id: "deterministic" },
+        sessionKey: turn.sessionKey ?? sharedSessionKey,
+        executionContext: turn.executionContext ?? execution.executionContext,
+      }));
+      runRecord = (await client.getAgentRun(data.runId)).data.run;
+    } catch (error) {
+      await cleanupAgentRun();
+      throw error;
+    }
     outputText = runRecord.responseText ?? runRecord.summary ?? data.finalResponse ?? data.response ?? "";
     const misrouteClass = detectMisroute({ scenario, outputText, run: runRecord });
 
@@ -1972,6 +2140,7 @@ async function executeAgentRun({ artifact, client, scenario, lane, suite, attemp
       artifact.result = "failed";
       artifact.failureClass = "llm_misroute";
       artifact.misrouteClass = misrouteClass;
+      await cleanupAgentRun();
       return artifact;
     }
 
@@ -2000,6 +2169,7 @@ async function executeAgentRun({ artifact, client, scenario, lane, suite, attemp
       artifact.result = ["awaiting_clarification", "awaiting_plan_approval"].includes(runRecord.status) ? "failed" : "partial";
       artifact.failureClass = runRecord.status === "failed" ? "provider_protocol" : "llm_behavior";
       artifact.notes = [...(artifact.notes ?? []), runRecord.errorMessage ?? `terminal status ${runRecord.status}`];
+      await cleanupAgentRun();
       return artifact;
     }
   }
@@ -2014,6 +2184,12 @@ async function executeAgentRun({ artifact, client, scenario, lane, suite, attemp
     runRecord: lastRunRecord,
     turns: runTurns,
     sessionKey: sharedSessionKey ?? null,
+    ...(
+      (execution.expectedToolResultSubstrings ?? []).length > 0
+      || (execution.expectedToolNames ?? []).length > 0
+        ? { agentToolCalls }
+        : {}
+    ),
   };
   artifact.observedEvidence.push(
     `provider ${lastRunRecord?.actualExecution?.actualProviderId ?? lane.providerId}`,
@@ -2029,6 +2205,43 @@ async function executeAgentRun({ artifact, client, scenario, lane, suite, attemp
     contextEstimatedInputTokens: totalContextEstimatedInputTokens,
   };
   artifact.result = "passed";
+
+  for (const expected of execution.expectedOutputSubstrings ?? []) {
+    const snippet = interpolateTemplateString(String(expected), agentTemplateContext);
+    if (!outputText.includes(snippet)) {
+      artifact.result = "failed";
+      artifact.failureClass = "llm_behavior";
+      artifact.notes = [
+        ...(artifact.notes ?? []),
+        `expected response to include ${JSON.stringify(snippet)}`,
+      ];
+    }
+  }
+
+  for (const expected of execution.expectedToolResultSubstrings ?? []) {
+    const snippet = interpolateTemplateString(String(expected), agentTemplateContext);
+    const toolEvidenceText = JSON.stringify(agentToolCalls);
+    if (!toolEvidenceText.includes(snippet)) {
+      artifact.result = "failed";
+      artifact.failureClass = "tool_bridge";
+      artifact.notes = [
+        ...(artifact.notes ?? []),
+        `expected tool evidence to include ${JSON.stringify(snippet)}`,
+      ];
+    }
+  }
+
+  for (const expectedToolName of execution.expectedToolNames ?? []) {
+    const found = agentToolCalls.some((call) => call?.toolName === expectedToolName || call?.name === expectedToolName);
+    if (!found) {
+      artifact.result = "failed";
+      artifact.failureClass = "tool_bridge";
+      artifact.notes = [
+        ...(artifact.notes ?? []),
+        `expected tool evidence for ${JSON.stringify(expectedToolName)}`,
+      ];
+    }
+  }
 
   if (typeof execution.expectWorkspaceFileTopH1 === "string" && execution.expectWorkspaceFileTopH1.trim().length > 0) {
     const relativeFilePath = execution.expectWorkspaceFileTopH1.trim();
@@ -2134,6 +2347,7 @@ async function executeAgentRun({ artifact, client, scenario, lane, suite, attemp
     artifact.failureClass = "tool_bridge";
     artifact.notes = [...(artifact.notes ?? []), `expected at least ${String(execution.expectToolCallCountMin)} tool calls`];
   }
+  await cleanupAgentRun();
   return artifact;
 }
 


### PR DESCRIPTION
## Phase 22D — Memory Recall Proof

This PR closes the Phase 22D vertical slice for API-stored memory recall through the agent loop.

### What changed

- Wires the existing Memory Guard into agent memory tools through the tool registry and hub bootstrap.
- Lets `memory_search` include current-principal guarded API memory for omitted/default/user/preference searches only.
- Keeps explicit reserved namespace searches such as `tenant.*` rejected before search dispatch.
- Adds a real SQLite/Memory Guard integration test for API-memory-shaped storage recalled through the agent `memory_search` tool.
- Adds a provider-backed RGG scenario for `/v1/memory/store -> /v1/agent/runs` recall and includes it in daily-core RGG.
- Extends the real-world agent executor with templated setup/cleanup requests, dynamic output/tool evidence assertions, and required cleanup failure handling for stateful scenarios.

### Verification run locally

- `npm exec vitest run test/unit/agent/tools/friday-agent-memory-tools.test.ts test/integration/memory/friday-agent-memory-recall-boundary.test.ts test/unit/validation/real-world-executors.test.ts test/unit/api/runtime/friday-api-runtime-memory-guard-registration.test.ts test/unit/api/runtime/friday-api-runtime-memory-registration.test.ts test/unit/api/http/routes/friday-memory-routes.test.ts test/unit/api/http/routes/friday-memory-routes-guard.test.ts test/unit/agent/runtime/friday-agent-runtime.test.ts test/unit/api/http/routes/friday-agent-routes.test.ts` — 319 tests passed.
- `npm run typecheck` — passed.
- `npm run lint -- --quiet` — passed.
- `npm run check:secret-patterns` — passed.
- `git diff --check` — passed.
- `node scripts/validation/run-real-world-validation.mjs --suite daily --scenario l3-memory-api-store-agent-recall-proof --catalog-only` — catalog import passed; generated local report directory was removed.

### Stage 5 reviewers

- Reviewer A PASS: implementation/wiring/root-cause closure and cleanup fail-closed path reviewed.
- Reviewer B PASS: safety/proof/no-overclaim/secret/test-weakening review passed after the cleanup blocker was fixed.

### Proof honesty

- Local provider-backed self-hosted scenario attempt was diagnostic only: setup memory store succeeded, but agent run was blocked by provider authentication (`PROVIDER_NO_CANDIDATES`). This is not claimed as release proof.
- Release-proof eligibility still requires PR-head same-SHA RGG: status `passed`, scenarios nonzero, all scenarios passing, blockers empty, and artifact SHA matching this PR head.
- No channel/cloud/OTEL/Grafana/release-complete-all proof is claimed.
- No owner/admin bypass is requested or required by this PR.
