### PR TITLE
Phase 23B: Context cost evidence routing proof

### DIFF
--- a/src/agent/runtime/friday-agent-run-presentation.ts
+++ b/src/agent/runtime/friday-agent-run-presentation.ts
@@ -18,6 +18,7 @@ export interface FridayAgentRunContextSummarySnapshot {
   taskProfileId?: string;
   taskProfileLabel?: string;
   totalEstimatedChars?: number;
+  totalEstimatedInputTokens?: number;
   dominantContextKinds: string[];
   learningAdjusted: boolean;
   fallbackAttemptCount: number;
@@ -125,6 +126,7 @@ export function buildFridayAgentRunContextSummarySnapshot(
     taskProfileId: run.taskProfile?.id,
     taskProfileLabel: run.taskProfile?.label,
     totalEstimatedChars: run.contextCostSummary?.totalEstimatedChars,
+    totalEstimatedInputTokens: run.contextCostSummary?.totalEstimatedInputTokens,
     dominantContextKinds,
     learningAdjusted: run.actualExecution?.learningAdjusted === true,
     fallbackAttemptCount: run.actualExecution?.fallbackAttempts?.length ?? 0,

--- a/src/agent/runtime/friday-agent-runtime.ts
+++ b/src/agent/runtime/friday-agent-runtime.ts
@@ -143,6 +143,26 @@ function withAgentContextCostComponent(
   };
 }
 
+function buildAgentToolRoutingContextCostSummary(input: {
+  toolNames: readonly string[];
+  toolRouting: ReturnType<typeof resolveFridayAgentToolRouting>;
+}): FridayAgentContextCostSummary {
+  const estimatedChars = input.toolNames.join(",").length;
+  return withAgentContextCostComponent(undefined, {
+    kind: "tool_routing",
+    estimatedChars,
+    estimatedInputTokens: estimateAgentContextInputTokens(estimatedChars),
+    count: input.toolNames.length,
+    metadata: {
+      profile: input.toolRouting.profile,
+      selectedToolPacks: input.toolRouting.selectedToolPacks,
+      deferredToolCount: input.toolRouting.deferredToolNames.length,
+      workspaceContextPolicy: input.toolRouting.workspaceContextPolicy,
+      reason: input.toolRouting.reason,
+    },
+  });
+}
+
 function hasCjkText(text: string): boolean {
   return /[\u4e00-\u9fff]/u.test(text);
 }
@@ -1111,6 +1131,10 @@ export function createFridayAgentRuntime(
             description: tool.description.replace(/\s+/gu, " ").trim().slice(0, 180),
           }));
       };
+      latestContextCostSummary = buildAgentToolRoutingContextCostSummary({
+        toolNames: buildVisibleToolNames(),
+        toolRouting: effectiveToolRouting,
+      });
       const timeSensitiveNewsRequested = hasTimeSensitiveNewsIntent(params.task, messages);
       const allToolCalls: FridayAgentToolCallRecord[] = [];
       let toolErrorRecoveryCount = 0;
@@ -1778,8 +1802,8 @@ export function createFridayAgentRuntime(
           ? promptBuildResult
           : promptBuildResult.prompt;
         latestContextCostSummary = typeof promptBuildResult === "string"
-          ? undefined
-          : promptBuildResult.contextCostSummary;
+          ? latestContextCostSummary
+          : promptBuildResult.contextCostSummary ?? latestContextCostSummary;
 
         let effectiveSystemPrompt = baseSystemPrompt;
         const skipSupplementalContext = toolRouting.promptProfile === "minimal";

--- a/src/agent/runtime/friday-agent-runtime.ts
+++ b/src/agent/runtime/friday-agent-runtime.ts
@@ -68,6 +68,8 @@ import type {
 import type {
   CreateFridayAgentRuntimeDeps,
   FridayAgentCompactionContextBuildResult,
+  FridayAgentContextCostComponent,
+  FridayAgentContextCostSummary,
   FridayAgentConversationContext,
   FridayAgentExecutionContext,
   FridayAgentRuntime,
@@ -124,6 +126,22 @@ const AGENT_COMPACTION_SOFT_CHAR_THRESHOLD = Math.floor(
   * AGENT_COMPACTION_APPROX_CHARS_PER_TOKEN
   * AGENT_COMPACTION_TRIGGER_RATIO,
 );
+
+function estimateAgentContextInputTokens(estimatedChars: number): number {
+  return Math.max(0, Math.ceil(Math.max(0, estimatedChars) / AGENT_COMPACTION_APPROX_CHARS_PER_TOKEN));
+}
+
+function withAgentContextCostComponent(
+  summary: FridayAgentContextCostSummary | undefined,
+  component: FridayAgentContextCostComponent,
+): FridayAgentContextCostSummary {
+  const components = [...(summary?.components ?? []), component];
+  return {
+    totalEstimatedChars: components.reduce((sum, item) => sum + item.estimatedChars, 0),
+    totalEstimatedInputTokens: components.reduce((sum, item) => sum + item.estimatedInputTokens, 0),
+    components,
+  };
+}
 
 function hasCjkText(text: string): boolean {
   return /[\u4e00-\u9fff]/u.test(text);
@@ -836,6 +854,8 @@ export function createFridayAgentRuntime(
           durationMs: input.durationMs,
           usageInput: input.usageInput,
           usageOutput: input.usageOutput,
+          ...(input.contextCostSummary ? { contextCostSummary: input.contextCostSummary } : {}),
+          ...(input.taskProfile ? { taskProfile: input.taskProfile } : {}),
           ...(input.images ? { images: input.images } : {}),
           ...(input.finalResponse ? { finalResponse: input.finalResponse } : {}),
         };
@@ -1113,7 +1133,7 @@ export function createFridayAgentRuntime(
       let latestRouteDecisionTrace: FridayAgentActualExecution["routeDecisionTrace"] | undefined;
 
       const estimateRoutingContext = (): NonNullable<FridayAgentLlmStreamParams["routingContext"]> => {
-        const estimatedChars =
+        const messageEstimatedChars =
           params.task.length
           + messages.reduce((sum, message) => {
             if (typeof message.content === "string") {
@@ -1121,13 +1141,18 @@ export function createFridayAgentRuntime(
             }
             return sum + JSON.stringify(message.content).length;
           }, 0);
+        const contextEstimatedChars = latestContextCostSummary?.totalEstimatedChars ?? 0;
+        const estimatedChars = messageEstimatedChars + contextEstimatedChars;
+        const estimatedInputTokens =
+          estimateAgentContextInputTokens(messageEstimatedChars)
+          + (latestContextCostSummary?.totalEstimatedInputTokens ?? 0);
         const complexity = resolvedTaskProfile.id === "planning" || resolvedTaskProfile.id === "review"
           ? "complex"
           : estimatedChars < 1200
             ? "simple"
             : "medium";
         return {
-          estimatedInputTokens: Math.max(1, Math.ceil(estimatedChars / 4)),
+          estimatedInputTokens: Math.max(1, estimatedInputTokens),
           complexity,
           requiresNativeTools: inferFridayTaskRequiresNativeTools({
             task: params.task,
@@ -1768,6 +1793,20 @@ export function createFridayAgentRuntime(
             if (loadedContext) {
               const fragment = loadedContext.fragment.trim();
               effectiveSystemPrompt += `\n\n${fragment}`;
+              latestContextCostSummary = withAgentContextCostComponent(latestContextCostSummary, {
+                kind: "context_replay",
+                estimatedChars: fragment.length,
+                estimatedInputTokens: estimateAgentContextInputTokens(fragment.length),
+                count: loadedContext.blockCount ?? loadedContext.sources?.length ?? 1,
+                metadata: {
+                  sourceCount: loadedContext.sources?.length ?? 0,
+                  evidenceTier: loadedContext.evidenceTier ?? "audit_replay_evidence",
+                  trustLevel: loadedContext.trustLevel ?? "unconfirmed_summary",
+                  memoryBoundary: loadedContext.memoryBoundary ?? "not_user_confirmed_memory",
+                  redactionApplied: loadedContext.redactionApplied ?? false,
+                  redactionCount: loadedContext.redactionCount ?? 0,
+                },
+              });
               handleTrackedEvent("agent.run.context_replay_loaded", {
                 runId,
                 sessionKey: loadedContext.sessionKey ?? params.sessionKey,

--- a/src/agent/runtime/friday-agent-runtime.types.ts
+++ b/src/agent/runtime/friday-agent-runtime.types.ts
@@ -149,14 +149,16 @@ export interface FridayAgentSystemPromptContext {
 }
 
 export interface FridayAgentContextCostComponent {
-  kind: "workspace_context" | "starter_skills" | "mcp" | "subagents" | "tool_routing";
+  kind: "workspace_context" | "starter_skills" | "mcp" | "subagents" | "tool_routing" | "context_replay";
   estimatedChars: number;
+  estimatedInputTokens: number;
   count?: number;
   metadata?: Record<string, unknown>;
 }
 
 export interface FridayAgentContextCostSummary {
   totalEstimatedChars: number;
+  totalEstimatedInputTokens: number;
   components: FridayAgentContextCostComponent[];
 }
 

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -3820,8 +3820,10 @@ export async function createFridayHub(
       + skill.triggerPhrases.join(", ").length
       + (skill.tags ?? []).join(", ").length,
     0);
+    const estimateContextInputTokens = (estimatedChars: number) =>
+      Math.max(0, Math.ceil(Math.max(0, estimatedChars) / 4));
     const mcpStates = mcpAdapter?.listServerStates() ?? [];
-    const components = [
+    const rawComponents = [
       workspaceContextSummary && (
         workspaceContextSummary.promptChars > 0
         || workspaceContextSummary.loadErrors.length > 0
@@ -3891,10 +3893,15 @@ export async function createFridayHub(
           }
         : null,
     ].filter((component): component is NonNullable<typeof component> => component !== null);
+    const components = rawComponents.map((component) => ({
+      ...component,
+      estimatedInputTokens: estimateContextInputTokens(component.estimatedChars),
+    }));
     return {
       prompt,
       contextCostSummary: {
         totalEstimatedChars: components.reduce((sum, component) => sum + component.estimatedChars, 0),
+        totalEstimatedInputTokens: components.reduce((sum, component) => sum + component.estimatedInputTokens, 0),
         components,
       },
     };

--- a/test/unit/agent/runtime/friday-agent-runtime-compaction-budget.test.ts
+++ b/test/unit/agent/runtime/friday-agent-runtime-compaction-budget.test.ts
@@ -7,6 +7,7 @@ import type {
   FridayAgentLlmStreamEvent,
   FridayAgentLlmStreamParams,
   FridayAgentMessage,
+  FridayAgentToolDefinition,
 } from "#agent";
 
 import { createTestDb, createTestIdGenerator } from "../../satellites/_helpers/create-test-db.helper.js";
@@ -156,5 +157,53 @@ describe("FridayAgentRuntime compaction budget", () => {
     expect(result.contextCostSummary?.totalEstimatedInputTokens).toBe(100);
     expect(persistedRun?.contextCostSummary?.totalEstimatedInputTokens).toBe(100);
     expect(routingContexts[0]?.estimatedInputTokens).toBeGreaterThan(100);
+  });
+
+  it("persists tool routing context cost evidence for delegated parent runs", async () => {
+    const webSearchTool: FridayAgentToolDefinition = {
+      name: "web_search",
+      description: "Search public web results.",
+      parameters: { type: "object", properties: {} },
+      execute: async () => ({ content: "unused" }),
+    };
+    const delegationHandler = vi.fn(async () => ({
+      delegated: true as const,
+      subagentId: "subagent-context-cost",
+      childRunId: "child-context-cost-run",
+      childSessionKey: "child-session",
+      statusSnapshot: "completed" as const,
+      outcome: {
+        status: "completed" as const,
+        response: "delegated done",
+        toolCallCount: 0,
+        durationMs: 7,
+        usageInput: 0,
+        usageOutput: 0,
+      },
+    }));
+    const runtime = createFridayAgentRuntime({
+      db,
+      llmClient: createMockLlmClient([]),
+      model: "test-model",
+      providerId: "test-provider",
+      systemPrompt: "Static parent prompt.",
+      tools: [webSearchTool],
+      eventEmitter: createFridayAgentEventEmitter(),
+      idGenerator,
+      nowIso: () => NOW,
+      delegationHandler,
+    });
+
+    const result = await runtime.executeRun({
+      task: "Search provider integration details for routing evidence.",
+      runId: "delegated-context-cost-parent",
+    });
+    const persistedRun = db.withReadConnection((reader) =>
+      createFridayAgentRunRepository().getById(reader, "delegated-context-cost-parent"));
+
+    expect(delegationHandler).toHaveBeenCalledTimes(1);
+    expect(result.status).toBe("completed");
+    expect(result.contextCostSummary?.components.some((component) => component.kind === "tool_routing")).toBe(true);
+    expect(persistedRun?.contextCostSummary?.totalEstimatedInputTokens).toBeGreaterThan(0);
   });
 });

--- a/test/unit/agent/runtime/friday-agent-runtime-compaction-budget.test.ts
+++ b/test/unit/agent/runtime/friday-agent-runtime-compaction-budget.test.ts
@@ -1,8 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { FridaySqliteLayer } from "#state";
-import { createFridayAgentEventEmitter, createFridayAgentRuntime } from "#agent";
-import type { FridayAgentLlmClient, FridayAgentLlmStreamEvent, FridayAgentMessage } from "#agent";
+import { createFridayAgentEventEmitter, createFridayAgentRunRepository, createFridayAgentRuntime } from "#agent";
+import type {
+  FridayAgentLlmClient,
+  FridayAgentLlmStreamEvent,
+  FridayAgentLlmStreamParams,
+  FridayAgentMessage,
+} from "#agent";
 
 import { createTestDb, createTestIdGenerator } from "../../satellites/_helpers/create-test-db.helper.js";
 
@@ -22,10 +27,12 @@ describe("FridayAgentRuntime compaction budget", () => {
 
   function createMockLlmClient(
     events: FridayAgentLlmStreamEvent[][],
+    onStream?: (params: FridayAgentLlmStreamParams) => void,
   ): FridayAgentLlmClient {
     let callIndex = 0;
     return {
-      async *stream() {
+      async *stream(params) {
+        onStream?.(params);
         const batch = events[callIndex] ?? [];
         callIndex++;
         for (const event of batch) {
@@ -100,5 +107,54 @@ describe("FridayAgentRuntime compaction budget", () => {
 
     expect(result.status).toBe("completed");
     expect(compactionBridge.compact).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns context cost token estimates and includes them in provider routing", async () => {
+    const routingContexts: Array<FridayAgentLlmStreamParams["routingContext"]> = [];
+    const runtime = createFridayAgentRuntime({
+      db,
+      llmClient: createMockLlmClient(
+        [
+          [
+            { type: "text_delta", text: "done" },
+            { type: "message_end", stopReason: "end_turn", inputTokens: 22, outputTokens: 4 },
+          ],
+        ],
+        (params) => routingContexts.push(params.routingContext),
+      ),
+      model: "test-model",
+      providerId: "test-provider",
+      systemPromptBuilder: () => ({
+        prompt: "You are a test agent with workspace context.",
+        contextCostSummary: {
+          totalEstimatedChars: 400,
+          totalEstimatedInputTokens: 100,
+          components: [
+            {
+              kind: "workspace_context",
+              estimatedChars: 400,
+              estimatedInputTokens: 100,
+              count: 1,
+            },
+          ],
+        },
+      }),
+      tools: [],
+      eventEmitter: createFridayAgentEventEmitter(),
+      idGenerator,
+      nowIso: () => NOW,
+    });
+
+    const result = await runtime.executeRun({
+      task: "Answer briefly.",
+      runId: "context-cost-run-1",
+    });
+    const persistedRun = db.withReadConnection((reader) =>
+      createFridayAgentRunRepository().getById(reader, "context-cost-run-1"));
+
+    expect(result.status).toBe("completed");
+    expect(result.contextCostSummary?.totalEstimatedInputTokens).toBe(100);
+    expect(persistedRun?.contextCostSummary?.totalEstimatedInputTokens).toBe(100);
+    expect(routingContexts[0]?.estimatedInputTokens).toBeGreaterThan(100);
   });
 });

--- a/test/unit/api/http/routes/friday-agent-routes.test.ts
+++ b/test/unit/api/http/routes/friday-agent-routes.test.ts
@@ -110,6 +110,47 @@ describe("FridayAgentRoutes", () => {
     expect(route!.auth).toEqual({ public: true });
   });
 
+  it("POST /v1/agent/runs returns context cost token estimates from the runtime result", async () => {
+    stubDeps.startRun = vi.fn().mockResolvedValue(createStubResult({
+      contextCostSummary: {
+        totalEstimatedChars: 480,
+        totalEstimatedInputTokens: 120,
+        components: [
+          {
+            kind: "tool_routing",
+            estimatedChars: 480,
+            estimatedInputTokens: 120,
+            count: 4,
+          },
+        ],
+      },
+    }));
+    const routes = createFridayAgentRoutes(stubDeps);
+    const route = routes.find((r) => r.operationId === "agent.runs.start")!;
+
+    const response = await route.handler({
+      body: { task: "Summarize context cost." },
+      params: {},
+      query: {},
+      headers: {},
+      principal: createStubPrincipal(),
+      requestId: "req-1",
+      receivedAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    expect(response).toMatchObject({
+      contextCostSummary: {
+        totalEstimatedInputTokens: 120,
+        components: [
+          expect.objectContaining({
+            kind: "tool_routing",
+            estimatedInputTokens: 120,
+          }),
+        ],
+      },
+    });
+  });
+
   it("POST /v1/agent/runs isolates unauthenticated public v1 runs from server-workspace tools", async () => {
     const routes = createFridayAgentRoutes(stubDeps);
     const route = routes.find((r) => r.operationId === "agent.runs.start")!;

--- a/test/unit/validation/real-world-executors.test.ts
+++ b/test/unit/validation/real-world-executors.test.ts
@@ -30,6 +30,7 @@ describe("real-world executors", () => {
     toolCallCount,
     unifiedTaskState,
     auditUnifiedTaskState,
+    contextCostSummary,
   }: {
     artifactDir?: string;
     responseText?: string;
@@ -40,6 +41,7 @@ describe("real-world executors", () => {
     toolCallCount?: number;
     unifiedTaskState?: unknown;
     auditUnifiedTaskState?: unknown;
+    contextCostSummary?: unknown;
   }) {
     return {
       request,
@@ -62,6 +64,7 @@ describe("real-world executors", () => {
                 actualModel: "test-model",
                 turns: [],
               },
+              contextCostSummary,
             },
           },
         };
@@ -228,6 +231,22 @@ describe("real-world executors", () => {
         liveChannelProof: "not_claimed",
       },
       proofBoundary: "This state is not channel live proof and still requires same-SHA Real Green Gate for release/default-on claims.",
+    };
+  }
+
+  function createContextCostEvidenceScenario() {
+    return {
+      id: "l4-context-cost-control-evidence",
+      entrySurface: "/v1/agent/runs",
+      expectedEvidence: [],
+      severityOnFailure: "P1",
+      realWorldPrompt: "Reply exactly: context cost evidence recorded.",
+      execution: {
+        kind: "agent_run",
+        expectedOutputSubstrings: ["context cost evidence recorded"],
+        expectedContextEstimatedInputTokensMin: 1,
+        constraints: { readOnly: true },
+      },
     };
   }
 
@@ -466,6 +485,56 @@ describe("real-world executors", () => {
       liveChannelProof: "not_claimed",
     });
     expect(artifact.observedEvidence).toContain("unified task live channel proof not_claimed");
+  });
+
+  it("passes context cost evidence only when the run record has nonzero estimated input tokens", async () => {
+    const artifact = await executeScenario({
+      runId: "validation-run-context-cost",
+      suite: "smoke",
+      scenario: createContextCostEvidenceScenario(),
+      lane,
+      client: createAgentScenarioClient({
+        responseText: "context cost evidence recorded",
+        contextCostSummary: {
+          totalEstimatedChars: 24,
+          totalEstimatedInputTokens: 6,
+          components: [
+            {
+              kind: "tool_routing",
+              estimatedChars: 24,
+              estimatedInputTokens: 6,
+            },
+          ],
+        },
+      }),
+      envTruth: {},
+      reportRoot: tmpdir(),
+      uiBaseUrl: "http://127.0.0.1:3141",
+    });
+
+    expect(artifact.result).toBe("passed");
+    expect(artifact.metrics?.contextEstimatedInputTokens).toBe(6);
+  });
+
+  it("fails context cost evidence when the run record lacks estimated input tokens", async () => {
+    const artifact = await executeScenario({
+      runId: "validation-run-context-cost-missing",
+      suite: "smoke",
+      scenario: createContextCostEvidenceScenario(),
+      lane,
+      client: createAgentScenarioClient({
+        responseText: "context cost evidence recorded",
+      }),
+      envTruth: {},
+      reportRoot: tmpdir(),
+      uiBaseUrl: "http://127.0.0.1:3141",
+    });
+
+    expect(artifact.result).toBe("failed");
+    expect(artifact.failureClass).toBe("tool_bridge");
+    expect(artifact.notes).toContain(
+      "expected context estimated input tokens >= 1 but got 0",
+    );
   });
 
   it("fails stateful agent scenarios when required cleanup does not satisfy expectations", async () => {

--- a/ui/src/lib/api/types.ts
+++ b/ui/src/lib/api/types.ts
@@ -101,14 +101,16 @@ export interface ResolvedAgentTaskProfile {
 }
 
 export interface AgentContextCostComponent {
-  kind: "workspace_context" | "starter_skills" | "mcp" | "subagents";
+  kind: "workspace_context" | "starter_skills" | "mcp" | "subagents" | "tool_routing" | "context_replay";
   estimatedChars: number;
+  estimatedInputTokens: number;
   count?: number;
   metadata?: Record<string, unknown>;
 }
 
 export interface AgentContextCostSummary {
   totalEstimatedChars: number;
+  totalEstimatedInputTokens: number;
   components: AgentContextCostComponent[];
 }
 
@@ -130,6 +132,7 @@ export interface AgentRunContextSummarySnapshot {
   taskProfileId?: string;
   taskProfileLabel?: string;
   totalEstimatedChars?: number;
+  totalEstimatedInputTokens?: number;
   dominantContextKinds: string[];
   learningAdjusted: boolean;
   fallbackAttemptCount: number;

--- a/validation/real-world/catalog/scenarios.mjs
+++ b/validation/real-world/catalog/scenarios.mjs
@@ -1552,8 +1552,7 @@ export const REAL_WORLD_SCENARIOS = [
     providerLane: "default_only",
     preconditions: ["auth.ready"],
     realWorldPrompt: [
-      "This is a deterministic echo probe, not a research task.",
-      "For the Friday status check, reply with exactly these four words: context cost evidence recorded",
+      "Reply exactly with this phrase: context cost evidence recorded",
     ].join(" "),
     expectedEvidence: [
       "agent run persists contextCostSummary on the run record",

--- a/validation/real-world/catalog/scenarios.mjs
+++ b/validation/real-world/catalog/scenarios.mjs
@@ -1543,6 +1543,35 @@ export const REAL_WORLD_SCENARIOS = [
       },
     },
   }),
+  agentScenario({
+    id: "l4-context-cost-control-evidence",
+    layer: "L4",
+    productArea: "providers",
+    entrySurface: "/v1/agent/runs",
+    routeFamily: "context cost control",
+    providerLane: "default_only",
+    preconditions: ["auth.ready"],
+    realWorldPrompt: [
+      "For this Friday context-cost evidence check, answer exactly: context cost evidence recorded",
+      "Do not use web search or tools.",
+    ].join(" "),
+    expectedEvidence: [
+      "agent run persists contextCostSummary on the run record",
+      "contextCostSummary reports nonzero totalEstimatedInputTokens",
+      "real-world validation fails if that token evidence is missing or zero",
+    ],
+    execution: {
+      useJudge: false,
+      expectedOutputSubstrings: ["context cost evidence recorded"],
+      expectedContextEstimatedInputTokensMin: 1,
+    },
+    oracles: {
+      behavior: {
+        minimumTextLength: 20,
+        disallowStatuses: ["awaiting_clarification", "awaiting_plan_approval"],
+      },
+    },
+  }),
   baseScenario({
     id: "l5-workflow-approval-roundtrip",
     layer: "L5",

--- a/validation/real-world/catalog/scenarios.mjs
+++ b/validation/real-world/catalog/scenarios.mjs
@@ -1552,8 +1552,8 @@ export const REAL_WORLD_SCENARIOS = [
     providerLane: "default_only",
     preconditions: ["auth.ready"],
     realWorldPrompt: [
-      "For this Friday context-cost evidence check, answer exactly: context cost evidence recorded",
-      "Do not use web search or tools.",
+      "This is a deterministic echo probe, not a research task.",
+      "For the Friday status check, reply with exactly these four words: context cost evidence recorded",
     ].join(" "),
     expectedEvidence: [
       "agent run persists contextCostSummary on the run record",

--- a/validation/real-world/lib/executors.mjs
+++ b/validation/real-world/lib/executors.mjs
@@ -2593,6 +2593,17 @@ async function executeAgentRun({ artifact, client, scenario, lane, suite, attemp
     artifact.failureClass = "tool_bridge";
     artifact.notes = [...(artifact.notes ?? []), `expected at least ${String(execution.expectToolCallCountMin)} tool calls`];
   }
+  if (
+    typeof execution.expectedContextEstimatedInputTokensMin === "number"
+    && totalContextEstimatedInputTokens < execution.expectedContextEstimatedInputTokensMin
+  ) {
+    artifact.result = "failed";
+    artifact.failureClass = "tool_bridge";
+    artifact.notes = [
+      ...(artifact.notes ?? []),
+      `expected context estimated input tokens >= ${String(execution.expectedContextEstimatedInputTokensMin)} but got ${String(totalContextEstimatedInputTokens)}`,
+    ];
+  }
   if (execution.expectReplayableEvidenceReceipt === true && lastRunRecord && lastData?.runId) {
     const receiptInspection = await inspectReplayableEvidenceReceipt({
       client,


### PR DESCRIPTION
## Phase

Phase 23B — Context Compaction / Cost Control

Scope: Friday-native context/cost evidence plumbing only. No UI rewrite, no provider credential change, no approval/memory/provider/MCP/plugin/skill lifecycle weakening, no Phase 20, no PR #244, and no channel/cloud/live-provider claim.

## Changes

- Adds `totalEstimatedInputTokens` and per-component `estimatedInputTokens` to agent context cost summaries.
- Preserves runtime `contextCostSummary` and `taskProfile` in immediate agent run results.
- Includes context cost estimates in provider routing context so cost routing sees prompt/context load, not only task text.
- Records compaction replay context as a separate `context_replay` cost component with explicit non-memory metadata.
- Adds RGG scenario `l4-context-cost-control-evidence` plus an oracle that fails when context estimated input token evidence is missing or zero.
- Updates API/UI shared types and focused tests for runtime persistence, API response, and real-world executor behavior.

## Issue Slice Record

| issue | problem | impact | why it remains / classification | fix effect | decision needed | plain-language example | evidence/test path | status |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| B2-X03 | Desktop/src mechanisms must not be copied directly. | Architecture/license/fit risk if copied blindly. | Classified as reference-only, Friday-native implementation used. | No Desktop/src code migration; only native evidence/routing concepts. | no | A good external mechanism still has to fit Friday's API/evidence chain. | `src/agent/runtime/friday-agent-runtime.ts`; `src/hub/friday-hub-bootstrap.ts` | addressed |
| F00005 | `context/AGENTS.md` is non-canonical pointer. | Agents must reload canonical rules before context work. | Verified by fresh-read; no code change required. | PR body and workflow preserve canonical AGENTS/route-map proof wording. | no | Friday proof depends on the repo rule source, not copied notes. | `context/AGENTS.md`; current route map | verified/no-code |
| F00039 | Frugal mode existed but provider runtime/product proof was incomplete. | Cost mode could undercount context and overclaim proof. | Runtime now exposes estimated context input tokens and routes with them. | Provider routing sees context load; RGG can fail if evidence is absent. | no | Friday can show that context had an estimated token cost. | `test/unit/agent/runtime/friday-agent-runtime-compaction-budget.test.ts` | addressed |
| F00057 | Reports underclaimed existing frugal/strict/budget router support. | Need current proof over stale report text. | Current source already had router; this slice adds missing evidence/proof path. | New oracle proves context-cost evidence, not just source presence. | no | Existing code is not proof until the scenario can check it. | `validation/real-world/catalog/scenarios.mjs`; `validation/real-world/lib/executors.mjs` | addressed |
| F00166 | Cost routing/context compaction/tool deferral should be exposed after gates. | Users need evidence without weakening gates. | 23A covered tool deferral; 23B covers context/cost evidence. | Adds API/runtime/evidence support without new UI route. | no | The run receipt can include estimated context cost. | `src/api/http/routes/friday-agent-routes.ts` response via focused test | addressed |
| SRC-MECH-007 | Context compression should reduce token pressure and surface cost control. | Long-task cost evidence was incomplete. | Friday already had compaction; this slice adds token attribution and replay component evidence. | Context replay is counted separately and labeled non-memory. | no | Replayed context is tracked as cost, not smuggled into memory. | `src/agent/runtime/friday-agent-runtime.ts`; `validation/real-world` oracle | addressed |

## Verification

- `npm exec vitest -- run test/unit/agent/runtime/friday-agent-runtime-compaction-budget.test.ts test/unit/api/http/routes/friday-agent-routes.test.ts test/unit/validation/real-world-executors.test.ts` — passed, 87 tests.
- Follow-up delegated-parent runtime fix: `npm exec vitest -- run test/unit/agent/runtime/friday-agent-runtime-compaction-budget.test.ts test/unit/validation/real-world-executors.test.ts test/unit/api/http/routes/friday-agent-routes.test.ts` — passed, 88 tests.
- Prompt repair verification: `npm run validate:real-world:catalog` passed; `node scripts/validation/run-real-world-validation.mjs --list-scenarios` included `l4-context-cost-control-evidence`; `npm exec vitest -- run test/unit/validation/real-world-executors.test.ts` passed, 13 tests.
- `npm run validate:real-world:catalog` — passed, catalog scenario count 29.
- `npm run typecheck` — passed.
- `npm run lint -- --quiet` — passed.
- `npm run check:secret-patterns` — passed, no provider/API key shaped secrets found.
- `npm run build:api` — passed.
- `npm run build:ui` — passed.
- `git diff --check` and `git diff --cached --check` — passed.

## Stage 5 Review

Attempted normal isolated reviewer infrastructure twice. It did not start: first attempt was rejected by tool invocation constraints; second attempt failed with `agent thread limit reached`. Per the user-approved fallback rule, this PR used Codex-only fallback review, not normal two isolated reviewers.

- Reviewer A perspective: code correctness, architecture, runtime wiring, persistence/API/UI type consistency, RGG oracle, missed entrypoints, cleanup — PASS.
- Reviewer B perspective: regression risk, safety/proof quality, no overclaim, no fake proof, no secret leakage, no test weakening, no scope creep, no approval/memory/provider/MCP/plugin/skill boundary weakening — PASS.

Residual risk: `totalEstimatedInputTokens` is an estimate derived from character counts for context evidence/routing. It is not a claim of provider-billed exact usage.

## Stage 7 Gate

Accepted same-SHA proof for PR head `9c370dedd31d861cace3588c0d6adeb351ecf52a`:

- Required PR checks: all success (`build`, `migrations`, `ssd-lint`, `alignment-guard`, `secrets`, `test`, `security`, `contracts`, `agent-parity`, `quality-gate`, `real-green-gate`).
- RGG run: `26214666799`.
- Downloaded/read artifact: `/tmp/friday-23b-rgg-26214666799-9c370ded/real-green-gate-26214666799/real-green-gate-result.json`.
- `status=passed`.
- `commit_sha=9c370dedd31d861cace3588c0d6adeb351ecf52a` matches PR head.
- `scenarios_run=91`, `scenarios_total=91`, `scenarios_passed=91`.
- `blocked_reasons=[]`.
- Smoke suite summary: 34/34 passed.
- Target scenario `l4-context-cost-control-evidence` passed with `contextEstimatedInputTokens=2049`, `toolCallCount=0`, provider `gpt-4o-mini`.

Earlier failed RGG runs were inspected and are not accepted as proof:

- `26211913336` on `a041b0e60...` failed because delegated parent runs lacked context cost evidence.
- `26212948685` on `54bdb291...` failed because the initial scenario prompt caused LLM behavior mismatch despite context token evidence being present.
- `26213859788` on `211a6070...` failed because `status check` wording triggered status/tool routing and web tool calls.
