### PR TITLE
[codex] Close B3 memory approval state boundaries

### DIFF
--- a/src/api/http/routes/friday-memory-routes.ts
+++ b/src/api/http/routes/friday-memory-routes.ts
@@ -20,6 +20,7 @@ import {
   toLearnedFactMemoryItem,
   toLearnedFactSearchResult,
 } from "../../../learning/services/friday-learned-fact-memory-view.js";
+import { isFridayReflexConfirmationRequiredKey } from "../../../reflex/services/friday-reflex-preference-sensitivity.js";
 import { FridayDomainError } from "#errors";
 import { FRIDAY_MEMORY_ERROR_CODES, FRIDAY_MEMORY_MAX_LIMIT } from "#memory";
 import {
@@ -134,6 +135,81 @@ function readPrincipalUserId(principal: unknown): string {
   return userId;
 }
 
+function readStoreMetadata(body: FridayMemoryStoreRequest): Record<string, unknown> | undefined {
+  return body.metadata && typeof body.metadata === "object" && !Array.isArray(body.metadata)
+    ? body.metadata as Record<string, unknown>
+    : undefined;
+}
+
+function readNestedRecord(record: Record<string, unknown> | undefined, key: string): Record<string, unknown> | undefined {
+  const value = record?.[key];
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function readStringValue(record: Record<string, unknown> | undefined, key: string): string | undefined {
+  const value = record?.[key];
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function readStorePreferenceKeyCandidates(body: FridayMemoryStoreRequest): string[] {
+  const metadata = readStoreMetadata(body);
+  const preference = readNestedRecord(metadata, "preference");
+  const reflex = readNestedRecord(metadata, "reflex");
+  return [
+    body.key,
+    readStringValue(metadata, "key"),
+    readStringValue(metadata, "preferenceKey"),
+    readStringValue(metadata, "reflexPreferenceKey"),
+    readStringValue(preference, "key"),
+    readStringValue(reflex, "key"),
+  ].filter((value): value is string => typeof value === "string" && value.trim().length > 0);
+}
+
+function memoryStoreLooksLikePreferenceActivation(body: FridayMemoryStoreRequest): boolean {
+  const metadata = readStoreMetadata(body);
+  const preference = readNestedRecord(metadata, "preference");
+  const reflex = readNestedRecord(metadata, "reflex");
+  if (
+    preference
+    || reflex
+    || readStringValue(metadata, "preferenceKey")
+    || readStringValue(metadata, "reflexPreferenceKey")
+  ) {
+    return true;
+  }
+  const tags = Array.isArray(body.tags)
+    ? body.tags.filter((tag): tag is string => typeof tag === "string")
+    : [];
+  const corpus = [
+    body.namespace,
+    body.source,
+    body.memoryType,
+    readStringValue(metadata, "category"),
+    readStringValue(metadata, "preferenceCategory"),
+    readStringValue(preference, "category"),
+    readStringValue(reflex, "category"),
+    ...tags,
+  ]
+    .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    .join(" ")
+    .toLowerCase();
+  return /\b(reflex|preference|preferences|user_preference|explicit_preference)\b/.test(corpus);
+}
+
+function enforceMemoryStoreApprovalBoundary(body: FridayMemoryStoreRequest): void {
+  const protectedKey = readStorePreferenceKeyCandidates(body)
+    .find((key) => isFridayReflexConfirmationRequiredKey(key));
+  if (!protectedKey) return;
+  if (!memoryStoreLooksLikePreferenceActivation(body) && body.key !== protectedKey) return;
+  throw new FridayDomainError(
+    "MEMORY_REQUIRES_REVIEW_CENTER_CONFIRMATION",
+    `High-impact preference '${protectedKey}' must be confirmed through /v1/reflex/preferences/${protectedKey} before durable activation.`,
+    { httpStatus: 409 },
+  );
+}
+
 function shouldIncludeLearnedFacts(input: {
   namespace?: string | string[];
   source?: string | string[];
@@ -228,6 +304,7 @@ export function createFridayMemoryRoutes(
         validateStoreNumericFields(rawBody);
         validateStoreBody(rawBody);
         const body = rawBody;
+        enforceMemoryStoreApprovalBoundary(body);
         const memory = deps.memoryGuardFactory.forPrincipal(ctx.principal);
         const idempotencyKey = readIdempotencyKeyHeader(ctx.headers);
         if (idempotencyKey) {
@@ -295,6 +372,7 @@ export function createFridayMemoryRoutes(
         validateStoreNumericFields(rawBody);
         validateStoreBody(rawBody);
         const body = rawBody;
+        enforceMemoryStoreApprovalBoundary(body);
         const principalId = readPrincipalUserId(ctx.principal);
         const idempotencyKey = readIdempotencyKeyHeader(ctx.headers);
         if (idempotencyKey) {

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -187,6 +187,11 @@ export function canResolveFridayChannelApprovalFromMessage(input: {
     && input.route.senderId === input.message.senderId;
 }
 
+export function createFridayChannelToolApprovalShortId(runId: string, toolCallId: string): string {
+  const source = `${runId}:${toolCallId}`.replace(/[^a-z0-9]/gi, "");
+  return (source.slice(-6) || "ACTION").toUpperCase();
+}
+
 export type FridayChannelApprovalExpiryDecision =
   | { expired: false }
   | {

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -370,6 +370,7 @@ import {
   buildFridayChannelDeliveryFailureText,
   buildFridayChannelMessageTooLongText,
   canResolveFridayChannelApprovalFromMessage,
+  createFridayChannelToolApprovalShortId,
   createFridayHubAutoFixExecutionSupport,
   createStubConfigManager,
   createStubMemoryState,
@@ -396,6 +397,7 @@ import { resolveFridayCapabilityGates } from "./bootstrap/friday-capability-gate
 // Re-export public API for backward compatibility with `#hub` barrel.
 export {
   canResolveFridayChannelApprovalFromMessage,
+  createFridayChannelToolApprovalShortId,
   evaluateFridayChannelApprovalExpiry,
   parseFridayChannelIdentityMap,
   resolveFridayChannelApprovalPrincipalId,
@@ -3926,7 +3928,6 @@ export async function createFridayHub(
     nowIso,
     stepExecutors: hubAutoFixSupport.stepExecutors,
     stepVerifiers: hubAutoFixSupport.stepVerifiers,
-    memoryWriter: memoryService,
   });
 
   // P1-01: Assign immediately so learningContextBuilder and communicationPromptBuilder
@@ -4028,6 +4029,14 @@ export async function createFridayHub(
 	    canonicalAction?: string;
 	    canonicalRisk?: string;
 	  };
+  type FridayRestartedChannelToolApproval = Omit<FridayPendingChannelToolApproval, "params" | "route">;
+  type FridayAgentRunEventSqlRow = {
+    run_id: string;
+    seq: number;
+    event_name: string;
+    payload_json: string;
+    emitted_at: string;
+  };
   const channelApprovalRoutesBySession = new Map<string, FridayChannelApprovalRoute>();
   const channelApprovalRoutesByRun = new Map<string, FridayChannelApprovalRoute>();
   const channelApprovalRoutesBySessionPrincipal = new Map<string, FridayChannelApprovalRoute>();
@@ -4045,11 +4054,6 @@ export async function createFridayHub(
 
   const channelApprovalSessionPrincipalKey = (sessionKey: string, principalId: string): string =>
     `${sessionKey}:${principalId}`;
-
-  const createChannelToolApprovalShortId = (runId: string, toolCallId: string): string => {
-    const source = `${runId}:${toolCallId}`.replace(/[^a-z0-9]/gi, "");
-    return (source.slice(-6) || "ACTION").toUpperCase();
-  };
 
   const parseChannelToolApprovalCommand = (text: string): FridayChannelToolApprovalCommand | null => {
     const trimmed = text.trim();
@@ -4139,6 +4143,73 @@ export async function createFridayHub(
   ): FridayPendingChannelToolApproval[] =>
     [...channelToolApprovalSessions.values()].filter((pending) => pending.sessionKey === sessionKey);
 
+  const listRestartedChannelToolApprovalsForSession = (
+    sessionKey: string,
+  ): FridayRestartedChannelToolApproval[] => {
+    const decisionEventNames = new Set([
+      "agent.run.capability_grant_issued",
+      "agent.run.capability_grant_denied",
+      "agent.run.capability_grant_used",
+    ]);
+    const pendingByKey = new Map<string, FridayRestartedChannelToolApproval>();
+    try {
+      const rows = stateRuntime!.sqlite.withReadConnection((db) =>
+        db.prepare(
+          `SELECT run_id, seq, event_name, payload_json, emitted_at
+             FROM friday_agent_run_events
+            WHERE event_name IN (
+              'agent.run.awaiting_tool_approval',
+              'agent.run.capability_grant_issued',
+              'agent.run.capability_grant_denied',
+              'agent.run.capability_grant_used'
+            )
+              AND json_extract(payload_json, '$.sessionKey') = ?
+            ORDER BY emitted_at ASC, seq ASC
+            LIMIT 1000`,
+        ).all(sessionKey) as FridayAgentRunEventSqlRow[],
+      );
+      for (const row of rows) {
+        const payload = safeJsonParse<Record<string, unknown>>(row.payload_json) ?? {};
+        const runId = typeof payload.runId === "string" ? payload.runId : row.run_id;
+        const toolCallId = typeof payload.toolCallId === "string" ? payload.toolCallId : undefined;
+        if (!toolCallId) continue;
+        const key = `${runId}:${toolCallId}`;
+        if (decisionEventNames.has(row.event_name)) {
+          pendingByKey.delete(key);
+          continue;
+        }
+        if (
+          row.event_name !== "agent.run.awaiting_tool_approval"
+          || payload.surface !== "channel"
+          || payload.sessionKey !== sessionKey
+        ) {
+          continue;
+        }
+        const grantId = typeof payload.grantId === "string" ? payload.grantId : undefined;
+        const toolName = typeof payload.toolName === "string" ? payload.toolName : undefined;
+        const reason = typeof payload.reason === "string" ? payload.reason : undefined;
+        const expiresAt = typeof payload.expiresAt === "string" ? payload.expiresAt : undefined;
+        if (!grantId || !toolName || !reason || !expiresAt) continue;
+        pendingByKey.set(key, {
+          runId,
+          sessionKey,
+          grantId,
+          toolCallId,
+          toolName,
+          shortId: createFridayChannelToolApprovalShortId(runId, toolCallId),
+          reason,
+          expiresAt,
+          ...(typeof payload.actionDigest === "string" ? { canonicalActionDigest: payload.actionDigest } : {}),
+          ...(typeof payload.canonicalAction === "string" ? { canonicalAction: payload.canonicalAction } : {}),
+          ...(typeof payload.riskLevel === "string" ? { canonicalRisk: payload.riskLevel } : {}),
+        });
+      }
+    } catch (err) {
+      warnHubBootstrapOnce(`[friday] channel-tool-approval-restart-scan: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    return [...pendingByKey.values()];
+  };
+
   const deleteChannelToolApprovalSessionsForRun = (runId: string, toolCallId?: string): void => {
     for (const [key, pending] of channelToolApprovalSessions) {
       if (pending.runId === runId && (!toolCallId || pending.toolCallId === toolCallId)) {
@@ -4212,7 +4283,7 @@ export async function createFridayHub(
           )
         : undefined);
     if (!route) return;
-    const shortId = createChannelToolApprovalShortId(prompt.runId, prompt.toolCallId);
+    const shortId = createFridayChannelToolApprovalShortId(prompt.runId, prompt.toolCallId);
     const approvalSessionKey = route.sessionKey;
     const pending: FridayPendingChannelToolApproval = {
       runId: prompt.runId,
@@ -8193,6 +8264,9 @@ export async function createFridayHub(
           const pendingApprovalsForCommand = approvalCommand
             ? listPendingChannelToolApprovalsForSession(sessionKey)
             : [];
+          const restartedApprovalsForCommand = approvalCommand && pendingApprovalsForCommand.length === 0
+            ? listRestartedChannelToolApprovalsForSession(sessionKey)
+            : [];
           const pendingApprovalForCommand = approvalCommand
             ? approvalCommand.shortId
               ? pendingApprovalsForCommand.find((pending) => pending.shortId === approvalCommand.shortId)
@@ -8200,9 +8274,22 @@ export async function createFridayHub(
                 ? pendingApprovalsForCommand[0]
                 : undefined
             : undefined;
+          const restartedApprovalForCommand = approvalCommand
+            ? approvalCommand.shortId
+              ? restartedApprovalsForCommand.find((pending) => pending.shortId === approvalCommand.shortId)
+              : restartedApprovalsForCommand.length === 1
+                ? restartedApprovalsForCommand[0]
+                : undefined
+            : undefined;
           const shouldRouteToolApprovalCommand = Boolean(
             approvalCommand
-            && (pendingApprovalForCommand || approvalCommand.shortId || pendingApprovalsForCommand.length > 1),
+            && (
+              pendingApprovalForCommand
+              || restartedApprovalForCommand
+              || approvalCommand.shortId
+              || pendingApprovalsForCommand.length > 1
+              || restartedApprovalsForCommand.length > 1
+            ),
           );
           const reflexCandidateCommand = text.length > 0 ? parseReflexCandidateDecisionCommand(text) : null;
           if (reflexCandidateCommand) {
@@ -8440,8 +8527,22 @@ export async function createFridayHub(
 	                      ackText = `审批 ${pendingApprovalForCommand.shortId} 已经结束，不需要重复处理。`;
 	                    }
 	                  }
-	                } else if (pendingApprovalsForCommand.length > 1 && !approvalCommand.shortId) {
-                  const ids = pendingApprovalsForCommand.map((pending) => pending.shortId).join(", ");
+	                } else if (restartedApprovalForCommand) {
+	                  const expiryDecision = evaluateFridayChannelApprovalExpiry({
+	                    expiresAt: restartedApprovalForCommand.expiresAt,
+	                    nowIso: nowIso(),
+	                  });
+	                  if (expiryDecision.expired) {
+	                    ackText = `审批 ${restartedApprovalForCommand.shortId} 已过期，请重新发起操作。`;
+	                  } else {
+	                    ackText = `审批 ${restartedApprovalForCommand.shortId} 所属运行已在重启后中断，Friday 不能继续执行旧敏感操作；请重新发起操作，我会重新请求确认。`;
+	                  }
+	                } else if ((pendingApprovalsForCommand.length + restartedApprovalsForCommand.length) > 1 && !approvalCommand.shortId) {
+                  const combinedApprovals = [
+                    ...pendingApprovalsForCommand,
+                    ...restartedApprovalsForCommand,
+                  ];
+                  const ids = combinedApprovals.map((pending) => pending.shortId).join(", ");
                   ackText = `当前有多个待审批操作：${ids}。请回复「批准 <编号>」或「拒绝 <编号>」。`;
                 } else {
                   ackText = `没有找到待审批操作 ${approvalCommand.shortId ?? ""}。`;

--- a/src/hub/index.ts
+++ b/src/hub/index.ts
@@ -27,6 +27,7 @@ export {
 // Hub bootstrap
 export {
   canResolveFridayChannelApprovalFromMessage,
+  createFridayChannelToolApprovalShortId,
   createFridayHub,
   evaluateFridayChannelApprovalExpiry,
   parseFridayChannelIdentityMap,

--- a/src/learning/runtime/friday-self-learning-runtime.ts
+++ b/src/learning/runtime/friday-self-learning-runtime.ts
@@ -179,7 +179,6 @@ export function createFridaySelfLearningRuntime(
     diagnosisService: diagnosis,
     planService: autoFixPlan,
     riskService: autoFixRisk,
-    memoryWriter: deps.memoryWriter,
     idGenerator: deps.idGenerator,
     nowIso: deps.nowIso,
   });

--- a/src/learning/runtime/friday-self-learning-runtime.types.ts
+++ b/src/learning/runtime/friday-self-learning-runtime.types.ts
@@ -45,6 +45,4 @@ export interface CreateFridaySelfLearningRuntimeDeps {
   stepExecutors?: Partial<Record<FridayAutoFixStepKind, StepExecutor>>;
   /** Override auto-fix step verifiers for production use. */
   stepVerifiers?: Partial<Record<FridayAutoFixStepKind, StepVerifier>>;
-  /** Optional memory writer for persisting learned preferences to cross-session memory. */
-  memoryWriter?: { store(namespace: string, content: string, metadata?: Record<string, unknown>): Promise<unknown> };
 }

--- a/src/learning/services/friday-self-learning-pipeline-service.ts
+++ b/src/learning/services/friday-self-learning-pipeline-service.ts
@@ -34,10 +34,6 @@ export interface FridaySelfLearningPipelineService {
   ): FridaySelfLearningProcessResult[];
 }
 
-export interface FridayLearningMemoryWriter {
-  store(namespace: string, content: string, metadata?: Record<string, unknown>): Promise<unknown>;
-}
-
 export interface CreateSelfLearningPipelineServiceDeps {
   db: FridaySqliteLayer;
   events: FridayLearningEventCollectionService;
@@ -52,8 +48,6 @@ export interface CreateSelfLearningPipelineServiceDeps {
   diagnosisService?: FridayErrorDiagnosisService;
   planService?: FridayAutoFixPlanService;
   riskService?: FridayAutoFixRiskAssessmentService;
-  /** Optional memory service for persisting extracted preferences as searchable memory items. */
-  memoryWriter?: FridayLearningMemoryWriter;
   idGenerator: () => string;
   nowIso: () => string;
 }

--- a/src/memory/services/friday-memory-boundary-policy.ts
+++ b/src/memory/services/friday-memory-boundary-policy.ts
@@ -1,0 +1,73 @@
+import { FridayDomainError } from "#errors";
+
+const LEARNED_FACT_ID_PREFIX = "learned-fact:";
+const LEARNED_FACT_SOURCE = "learned_fact";
+const LEARNED_FACT_METADATA_CLAIMS: Record<string, unknown> = {
+  learnedFact: true,
+  trustLevel: "confidence_scored_learning",
+  memoryBoundary: "separate_from_durable_memory",
+  evidenceBoundary: "preference_fact_evidence",
+  contextUseBoundary: "learning_context_service_gated",
+  promptInjectionBoundary: "not_direct_prompt_injection",
+  reviewBoundary: "not_review_center_confirmed",
+  revocationBoundary: "clear_delete_or_synthetic_memory_delete",
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasReservedLearnedFactMetadata(metadata: Record<string, unknown> | undefined): boolean {
+  if (!metadata) return false;
+  for (const [key, value] of Object.entries(LEARNED_FACT_METADATA_CLAIMS)) {
+    if (metadata[key] === value) return true;
+  }
+  return false;
+}
+
+export function assertFridayDurableMemoryBoundaryAllowed(input: {
+  id?: string;
+  source?: string;
+  key?: string;
+  tags?: string[];
+  metadata?: Record<string, unknown>;
+}): void {
+  if (input.source === LEARNED_FACT_SOURCE) {
+    throw new FridayDomainError(
+      "MEMORY_BOUNDARY_RESERVED",
+      "Durable memory writes cannot use the synthetic learned-fact source.",
+      { httpStatus: 409 },
+    );
+  }
+  if (input.id?.startsWith(LEARNED_FACT_ID_PREFIX) || input.key?.startsWith(LEARNED_FACT_ID_PREFIX)) {
+    throw new FridayDomainError(
+      "MEMORY_BOUNDARY_RESERVED",
+      "Durable memory writes cannot use synthetic learned-fact ids.",
+      { httpStatus: 409 },
+    );
+  }
+  if (input.tags?.includes("preference_fact")) {
+    throw new FridayDomainError(
+      "MEMORY_BOUNDARY_RESERVED",
+      "Durable memory writes cannot claim the preference-fact evidence boundary.",
+      { httpStatus: 409 },
+    );
+  }
+  if (hasReservedLearnedFactMetadata(input.metadata)) {
+    throw new FridayDomainError(
+      "MEMORY_BOUNDARY_RESERVED",
+      "Durable memory writes cannot claim synthetic learned-fact boundary metadata.",
+      { httpStatus: 409 },
+    );
+  }
+  const nestedBoundary = isRecord(input.metadata?.learnedFact)
+    ? input.metadata.learnedFact
+    : undefined;
+  if (hasReservedLearnedFactMetadata(nestedBoundary)) {
+    throw new FridayDomainError(
+      "MEMORY_BOUNDARY_RESERVED",
+      "Durable memory writes cannot claim synthetic learned-fact boundary metadata.",
+      { httpStatus: 409 },
+    );
+  }
+}

--- a/src/memory/services/friday-memory-service.ts
+++ b/src/memory/services/friday-memory-service.ts
@@ -23,6 +23,7 @@ import {
 import { createFridayMemoryItemRepository } from "../persistence/friday-memory-item-repository.js";
 import { createFridayMemoryEmbeddingRepository } from "../persistence/friday-memory-embedding-repository.js";
 import { createFridayMemoryByokEmbeddingClient } from "./friday-memory-byok-embedding-client.js";
+import { assertFridayDurableMemoryBoundaryAllowed } from "./friday-memory-boundary-policy.js";
 import { mergeHybridResults } from "../search/friday-memory-hybrid.js";
 
 // P2-06: Module-level Set avoids WeakMap edge cases with replaced warn sinks.
@@ -96,6 +97,12 @@ export function createFridayMemoryService(
       const tags = metadata?.tags ?? [];
       const meta = metadata?.metadata ?? {};
       const ttlSeconds = metadata?.ttlSeconds;
+      assertFridayDurableMemoryBoundaryAllowed({
+        source,
+        key,
+        tags,
+        metadata: meta,
+      });
 
       let expiresAt = metadata?.expiresAt;
       if (!expiresAt && ttlSeconds) {

--- a/src/memory/sync/friday-memory-file-sync-service.ts
+++ b/src/memory/sync/friday-memory-file-sync-service.ts
@@ -46,6 +46,7 @@ import {
   createFridayMemoryFileSyncWatcher,
   type FridayMemoryFileSyncWatcher,
 } from "./friday-memory-file-sync-watcher.js";
+import { assertFridayDurableMemoryBoundaryAllowed } from "../services/friday-memory-boundary-policy.js";
 
 // ─── Dependencies ───
 
@@ -389,6 +390,18 @@ export function createFridayMemoryFileSyncService(
 
   // ─── Reindex logic (file → DB) ───
 
+  function readExportTags(value: unknown): string[] {
+    return Array.isArray(value)
+      ? value.filter((tag): tag is string => typeof tag === "string")
+      : [];
+  }
+
+  function readExportMetadata(value: unknown): Record<string, unknown> | undefined {
+    return value && typeof value === "object" && !Array.isArray(value)
+      ? value as Record<string, unknown>
+      : undefined;
+  }
+
   async function reindexEntity(
     entityType: FridayMemorySyncEntityType,
     entityKey: string,
@@ -430,17 +443,31 @@ export function createFridayMemoryFileSyncService(
           return;
         }
 
-        const items = parsed.items.map((item: Record<string, unknown>) => ({
-          id: item.id as string,
-          key: item.key as string,
-          value_json: JSON.stringify(item.value ?? null),
-          content_text: (item.contentText as string | null) ?? null,
-          source: (item.source as string) ?? "file-import",
-          tags_json: JSON.stringify(item.tags ?? []),
-          metadata_json: JSON.stringify(item.metadata ?? null),
-          created_at: (item.createdAt as string) ?? nowIso(),
-          updated_at: (item.updatedAt as string) ?? nowIso(),
-        }));
+        const items = parsed.items.map((item: Record<string, unknown>) => {
+          const id = item.id as string;
+          const source = (item.source as string) ?? "file-import";
+          const key = item.key as string;
+          const tags = readExportTags(item.tags);
+          const metadata = readExportMetadata(item.metadata);
+          assertFridayDurableMemoryBoundaryAllowed({
+            id,
+            source,
+            key,
+            tags,
+            metadata,
+          });
+          return {
+            id,
+            key,
+            value_json: JSON.stringify(item.value ?? null),
+            content_text: (item.contentText as string | null) ?? null,
+            source,
+            tags_json: JSON.stringify(tags),
+            metadata_json: JSON.stringify(metadata ?? null),
+            created_at: (item.createdAt as string) ?? nowIso(),
+            updated_at: (item.updatedAt as string) ?? nowIso(),
+          };
+        });
 
         const { upserted, deleted } = repository.upsertMemoryItemsFromExport(entityKey, items);
         result.itemsUpserted += upserted;

--- a/test/e2e/mock/friday-mock-subagent-canonical-gate.e2e.test.ts
+++ b/test/e2e/mock/friday-mock-subagent-canonical-gate.e2e.test.ts
@@ -7,6 +7,7 @@ import {
   createMockHubEnv,
   type MockHubEnv,
 } from "./_helpers/mock-env.js";
+import { createFridayChannelToolApprovalShortId } from "#hub";
 import type {
   FridayChannelMessage,
   FridayChannelMessageHandler,
@@ -413,5 +414,65 @@ describe("Friday live-channel canonical approval adversarial E2E", () => {
     } finally {
       fs.rmSync(sentinel, { force: true });
     }
+  }, 30_000);
+
+  it("tells the original sender to reissue an approval after restart state is only durable", async () => {
+    const runId = "run-restarted-approval-1";
+    const toolCallId = "tool-restarted-approval-1";
+    const sessionKey = "channel:test-channel:group-1";
+    const shortId = createFridayChannelToolApprovalShortId(runId, toolCallId);
+    const db = new Database(path.join(env.stateDir, "friday.db"));
+    try {
+      db.prepare(
+        `INSERT INTO friday_agent_runs (id, task, status, session_key, max_attempts, created_at, started_at)
+         VALUES (?, ?, 'failed', ?, 1, ?, ?)`,
+      ).run(
+        runId,
+        "Interrupted channel approval",
+        sessionKey,
+        "2026-05-21T10:00:00.000Z",
+        "2026-05-21T10:00:00.000Z",
+      );
+      db.prepare(
+        `INSERT INTO friday_agent_run_events
+          (event_id, run_id, seq, event_name, payload_json, emitted_at, created_at)
+         VALUES (?, ?, 1, 'agent.run.awaiting_tool_approval', ?, ?, ?)`,
+      ).run(
+        "evt-restarted-approval-1",
+        runId,
+        JSON.stringify({
+          runId,
+          status: "awaiting_tool_approval",
+          grantId: `capgrant:${runId}:${toolCallId}`,
+          toolName: "exec",
+          toolCallId,
+          params: { command: "touch should-not-run" },
+          reason: "Canonical approval required for agent.tool.exec",
+          expiresAt: "2999-05-21T10:15:00.000Z",
+          riskLevel: "high",
+          sessionKey,
+          surface: "channel",
+        }),
+        "2026-05-21T10:00:01.000Z",
+        "2026-05-21T10:00:01.000Z",
+      );
+    } finally {
+      db.close();
+    }
+
+    channel.emit({
+      id: "msg-restarted-approve",
+      senderId: "user-a",
+      senderName: "User A",
+      chatId: "group-1",
+      text: `批准 ${shortId}`,
+    });
+
+    await waitFor(() =>
+      channel.sent.find((message) =>
+        message.text.includes(`审批 ${shortId} 所属运行已在重启后中断`)
+        && message.text.includes("请重新发起操作"),
+      ) ?? null,
+    );
   }, 30_000);
 });

--- a/test/unit/api/http/routes/friday-memory-routes.test.ts
+++ b/test/unit/api/http/routes/friday-memory-routes.test.ts
@@ -146,6 +146,60 @@ describe("FridayMemoryRoutes", () => {
     await expect(route.handler(ctx)).rejects.toThrow(FridayDomainError);
   });
 
+  it("store handler rejects high-impact preference activation without Review Center confirmation", async () => {
+    const route = findRoute("memory.store");
+    const ctx = makeCtx({
+      body: {
+        namespace: "preference",
+        key: "testing.live_llm_policy",
+        content: "Always use live LLMs",
+        memoryType: "preference",
+      },
+    });
+
+    await expect(route.handler(ctx)).rejects.toMatchObject({
+      code: "MEMORY_REQUIRES_REVIEW_CENTER_CONFIRMATION",
+    });
+    expect(memoryService.store).not.toHaveBeenCalled();
+  });
+
+  it("store alias rejects high-impact reflex preference metadata without durable activation", async () => {
+    const route = findRoute("memory.items.create");
+    const ctx = makeCtx({
+      body: {
+        namespace: "notes",
+        content: "Do not auto-apply high-risk changes",
+        metadata: {
+          category: "reflex",
+          key: "safety.high_risk_change_policy",
+        },
+      },
+    });
+
+    await expect(route.handler(ctx)).rejects.toMatchObject({
+      code: "MEMORY_REQUIRES_REVIEW_CENTER_CONFIRMATION",
+    });
+    expect(memoryService.store).not.toHaveBeenCalled();
+  });
+
+  it("store handler rejects preferenceKey metadata for high-impact preferences", async () => {
+    const route = findRoute("memory.store");
+    const ctx = makeCtx({
+      body: {
+        namespace: "notes",
+        content: "Prefer review candidates for inferred memory",
+        metadata: {
+          preferenceKey: "memory.inferred_preference_policy",
+        },
+      },
+    });
+
+    await expect(route.handler(ctx)).rejects.toMatchObject({
+      code: "MEMORY_REQUIRES_REVIEW_CENTER_CONFIRMATION",
+    });
+    expect(memoryService.store).not.toHaveBeenCalled();
+  });
+
   it("store handler replays an existing item when Idempotency-Key matches", async () => {
     const replayItem: FridayMemoryItem = {
       ...mockItem,

--- a/test/unit/hub/friday-hub-bootstrap-identity.test.ts
+++ b/test/unit/hub/friday-hub-bootstrap-identity.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   canResolveFridayChannelApprovalFromMessage,
+  createFridayChannelToolApprovalShortId,
   evaluateFridayChannelApprovalExpiry,
   parseFridayChannelIdentityMap,
   resolveFridayChannelApprovalPrincipalId,
@@ -141,5 +142,10 @@ describe("cross-channel identity mapping", () => {
       expiresAt: "not-a-date",
       nowIso: "2026-05-21T10:15:00.000Z",
     })).toEqual({ expired: true, reason: "approval_expiration_invalid" });
+  });
+
+  it("derives stable channel tool approval short codes from run and tool call ids", () => {
+    expect(createFridayChannelToolApprovalShortId("run-abc-123456", "tool-xyz-999999")).toBe("999999");
+    expect(createFridayChannelToolApprovalShortId("!!!", "***")).toBe("ACTION");
   });
 });

--- a/test/unit/learning/services/friday-self-learning-pipeline-service.test.ts
+++ b/test/unit/learning/services/friday-self-learning-pipeline-service.test.ts
@@ -222,51 +222,17 @@ describe("FridaySelfLearningPipelineService", () => {
     expect(result.factsUpdated[0]!.value).toBe("Python");
   });
 
-  it("does not duplicate learned preferences into exported memory", () => {
-    const memoryWriter = {
-      store: vi.fn(),
-    };
-    const ledger = createFridayLearningEventLedger({ db });
-    const factRepo = createFridayPreferenceFactRepository();
-    const incidentRepo = createFridayErrorIncidentRepository();
-    const diagnosisRepo = createFridayDiagnosisRecordRepository();
-    const lessonRepo = createFridayLearnedLessonRepository();
-    const events = createFridayLearningEventCollectionService({ ledger });
-    const extraction = createFridayPreferenceExtractionService({
-      idGenerator: idGen,
-    });
-    const facts = createFridayPreferenceFactService({
-      db,
-      factRepo,
-      idGenerator: idGen,
-      nowIso: () => NOW,
-    });
-    const lifecycle = createFridayLearningLifecycleService({
-      db,
-      factRepo,
-    });
-    const pipelineWithoutPreferenceExports = createFridaySelfLearningPipelineService({
-      db,
-      events,
-      extraction,
-      facts,
-      lifecycle,
-      incidentRepo,
-      diagnosisRepo,
-      lessonRepo,
-      memoryWriter,
-      idGenerator: idGen,
-      nowIso: () => NOW,
-    });
-
-    const result = pipelineWithoutPreferenceExports.processEvent(makeEvent({
+  it("keeps learned preferences in preference facts instead of durable memory", () => {
+    const result = pipeline.processEvent(makeEvent({
       kind: "user_message",
       payload: { text: "Call me Codex." },
     }));
 
     expect(result.factsUpdated).toHaveLength(1);
     expect(result.factsUpdated[0]!.key).toBe("pref:display_name");
-    expect(memoryWriter.store).not.toHaveBeenCalled();
+    const memoryCount = db.withReadConnection((reader) =>
+      reader.prepare("SELECT COUNT(*) as cnt FROM memory_items").get() as { cnt: number });
+    expect(memoryCount.cnt).toBe(0);
   });
 
   it("processEvent creates incidents for error signals", () => {

--- a/test/unit/memory/services/friday-memory-service.test.ts
+++ b/test/unit/memory/services/friday-memory-service.test.ts
@@ -141,6 +141,26 @@ describe("FridayMemoryService", () => {
     expect(item.expiresAt).toBeDefined();
   });
 
+  it("rejects durable writes that impersonate synthetic learned-fact memory", async () => {
+    await expect(service.store("preference", "Captain Friday", {
+      source: "learned_fact",
+    })).rejects.toMatchObject({ code: "MEMORY_BOUNDARY_RESERVED" });
+
+    await expect(service.store("preference", "Captain Friday", {
+      key: "learned-fact:pref:name",
+    })).rejects.toMatchObject({ code: "MEMORY_BOUNDARY_RESERVED" });
+
+    await expect(service.store("preference", "Captain Friday", {
+      tags: ["preference_fact"],
+    })).rejects.toMatchObject({ code: "MEMORY_BOUNDARY_RESERVED" });
+
+    await expect(service.store("preference", "Captain Friday", {
+      metadata: {
+        memoryBoundary: "separate_from_durable_memory",
+      },
+    })).rejects.toMatchObject({ code: "MEMORY_BOUNDARY_RESERVED" });
+  });
+
   it("stores successfully even when embedding fails (graceful fallback)", async () => {
     const failService = createMockProviderService({ embedFails: true });
     const svc = createFridayMemoryService({

--- a/test/unit/memory/sync/friday-memory-file-sync-watcher.test.ts
+++ b/test/unit/memory/sync/friday-memory-file-sync-watcher.test.ts
@@ -128,6 +128,45 @@ describe("FridayMemoryFileSyncService — Watcher & Reindex", () => {
     expect(items.find(i => i.key === "key2")?.value_json).toBe('{"new":"item"}');
   });
 
+  it("reindexNow rejects external imports that impersonate learned-fact synthetic ids", async () => {
+    insertMemoryItem("item-boundary-1", "boundary-ns", "key1", '{"safe":true}');
+
+    const repo = createFridayMemoryFileSyncRepository({ db });
+    const service = createFridayMemoryFileSyncService({
+      repository: repo,
+      stateDir: tmpDir,
+      enableWatcher: false,
+    });
+
+    await service.syncNow();
+
+    const filePath = memoryNamespaceExportPath(tmpDir, "boundary-ns");
+    const parsed = JSON.parse(await fs.readFile(filePath, "utf8"));
+    parsed.items.push({
+      id: "learned-fact:pref:display_name",
+      key: "ordinary-key",
+      value: { name: "Captain Friday" },
+      contentText: "Captain Friday",
+      source: "file-edit",
+      tags: [],
+      metadata: {},
+      createdAt: "2025-01-02T00:00:00Z",
+      updatedAt: "2025-01-02T00:00:00Z",
+    });
+    await fs.writeFile(filePath, JSON.stringify(parsed, null, 2), "utf8");
+
+    const result = await service.reindexNow("memory_namespace", "boundary-ns");
+    expect(result.filesProcessed).toBe(0);
+    expect(result.itemsUpserted).toBe(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]!.message).toContain("synthetic learned-fact ids");
+
+    const items = getMemoryItems("boundary-ns");
+    expect(items).toHaveLength(1);
+    expect(items[0]!.id).toBe("item-boundary-1");
+    expect(items[0]!.value_json).toBe('{"safe":true}');
+  });
+
   it("reindexNow skips when file hash matches last export", async () => {
     insertMemoryItem("item-skip", "skip-reindex-ns", "key1", '{"val":1}');
 


### PR DESCRIPTION
## Scope

Friday Global Closure B3_MEMORY_APPROVAL_STATE.

Closes formal issues: ISSUE-004, ISSUE-023, ISSUE-024, ISSUE-025.

## Changes

- Re-prompts channel tool approvals after restart instead of resolving stale durable approval state.
- Blocks high-impact reflex preference activation through direct memory store routes; callers must use the Review Center-backed reflex preference route.
- Preserves durable memory vs learned preference-fact separation in `FridayMemoryService.store` and file-sync reindex, including synthetic learned-fact ids.
- Removes the unused learning `memoryWriter` hook so learned preferences stay in preference facts rather than durable memory exports.

## Verification

- `npx vitest run test/unit/memory/sync/friday-memory-file-sync-watcher.test.ts test/unit/memory/sync/friday-memory-file-sync-service.test.ts test/unit/memory/services/friday-memory-service.test.ts` — 3 files / 54 tests passed
- B3 focused suite — 15 files / 223 tests passed
- `npx vitest run test/adversarial` — 14 files / 365 tests passed
- `npm run typecheck:src` — passed
- `npm run lint` — passed, 0 errors / 1481 existing warnings
- `git diff --check` and `git diff --cached --check` — passed
- `npm run check:secret-patterns` — passed
- CI-equivalent `detect-secrets-hook --baseline .secrets.baseline ...` from `.github/workflows/ci.yml` — passed

## Reviewers

- Reviewer A Huygens (`019e5393-66ff-7883-b5f0-6cd383f9974f`) — PASS
- Reviewer B Gibbs (`019e5393-67c7-78e0-b155-1925bdf2605f`) — PASS

Residual risk noted by both reviewers: the malicious file-sync import test exercises `reindexNow`; watcher-triggered external changes share the same `reindexEntity` path, but there is not a separate async filesystem-event malicious-import assertion.

## Release Proof

PR-head CI passed at `418939a1bf69407501e5deb25c0dd08891fff1eb`.

Same-SHA Real Green Gate artifact `real-green-gate-26326172687` passed for `418939a1bf69407501e5deb25c0dd08891fff1eb`: `status=passed`, `scenarios_total=94`, `scenarios_passed=94`, `blocked_reasons=[]`.
