### PR TITLE
[codex] Close B4 runtime reliability routes

### DIFF
--- a/src/api/realtime/friday-execution-control-event-emitter.ts
+++ b/src/api/realtime/friday-execution-control-event-emitter.ts
@@ -21,6 +21,9 @@ import type { FridayRealtimeEventBus } from "./friday-realtime-event-bus.types.j
 import type { FridayAuditRecord } from "../../security/friday-audit-log.js";
 import { redactEventPayload } from "./friday-event-payload-redactor.js";
 
+const DEFAULT_EMITTED_EVENTS_LIMIT = 1_000;
+const DEFAULT_AUDIT_SINK_FAILURES_LIMIT = 100;
+
 // ─── Execution-control event name subset ───
 
 export type FridayExecutionControlEventName =
@@ -103,19 +106,52 @@ function buildAuditRecord(
       payload.executionId ?? payload.resultId ?? payload.entryId ??
       payload.contextId ?? payload.candidateId ?? payload.playbookId) as string | undefined,
     requestId: correlationId,
-    result: action.includes("failed") || action.includes("exhausted") ? "failure" : "success",
+    result: isFailureAuditEvent(event, action) ? "failure" : "success",
     caller: "execution-control-event-emitter",
     details: redactEventPayload(payload) as Record<string, unknown>,
   };
 }
 
+function isFailureAuditEvent(event: FridayExecutionControlEventName, action: string): boolean {
+  return action.includes("failed") || action.includes("exhausted") || event === "retry.dlq.enqueued";
+}
+
+function pushBounded<T>(items: T[], item: T, limit: number): void {
+  items.push(item);
+  while (items.length > limit) {
+    items.shift();
+  }
+}
+
+function clampPositiveInteger(value: number | undefined, fallback: number): number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+function auditSinkErrorMessage(err: unknown): string {
+  const raw = err instanceof Error ? err.message : String(err);
+  return raw
+    .replace(/\b(sk-|key-|pk-|rk-|xai-|gsk_|aip-|whsk-|sess-|ssm-)[A-Za-z0-9_-]{8,}\b/g, "[REDACTED]")
+    .replace(/\b[A-Za-z0-9/+]{40,}={0,2}\b/g, "[REDACTED]");
+}
+
 // ─── Deps ───
+
+export interface FridayExecutionControlAuditSinkFailure {
+  event: FridayExecutionControlEventName;
+  streamId: string;
+  emittedAt: string;
+  message: string;
+}
 
 export interface CreateExecutionControlEventEmitterDeps {
   eventBus: FridayRealtimeEventBus;
   nowIso: () => string;
   /** Optional audit sink — receives forensic records for persistence. */
   auditSink?: (record: FridayAuditRecord) => void;
+  /** Maximum in-memory envelopes retained for inspection. */
+  maxEmittedEvents?: number;
+  /** Maximum audit-sink failures retained for inspection. */
+  maxAuditSinkFailures?: number;
 }
 
 // ─── Public interface ───
@@ -135,6 +171,11 @@ export interface FridayExecutionControlEventEmitter {
    * List all events emitted during this emitter's lifetime (useful for testing).
    */
   readonly emittedEvents: ReadonlyArray<FridayRealtimeEventEnvelope>;
+
+  /**
+   * List recent audit-sink failures without breaking event emission.
+   */
+  readonly auditSinkFailures: ReadonlyArray<FridayExecutionControlAuditSinkFailure>;
 }
 
 // ─── Factory ───
@@ -142,7 +183,10 @@ export interface FridayExecutionControlEventEmitter {
 export function createExecutionControlEventEmitter(
   deps: CreateExecutionControlEventEmitterDeps,
 ): FridayExecutionControlEventEmitter {
+  const emittedLimit = clampPositiveInteger(deps.maxEmittedEvents, DEFAULT_EMITTED_EVENTS_LIMIT);
+  const auditFailureLimit = clampPositiveInteger(deps.maxAuditSinkFailures, DEFAULT_AUDIT_SINK_FAILURES_LIMIT);
   const emitted: FridayRealtimeEventEnvelope[] = [];
+  const auditFailures: FridayExecutionControlAuditSinkFailure[] = [];
 
   return {
     emit<TEvent extends FridayExecutionControlEventName>(
@@ -164,7 +208,7 @@ export function createExecutionControlEventEmitter(
         correlationId,
       );
 
-      emitted.push(envelope as FridayRealtimeEventEnvelope);
+      pushBounded(emitted, envelope as FridayRealtimeEventEnvelope, emittedLimit);
 
       // 4. Write audit record (non-blocking, best-effort)
       if (deps.auditSink) {
@@ -177,7 +221,14 @@ export function createExecutionControlEventEmitter(
           );
           deps.auditSink(record);
         } catch (err) {
-          console.warn("[friday][execution-control-event-emitter] operation failed:", err instanceof Error ? err.message : String(err));
+          const message = auditSinkErrorMessage(err);
+          pushBounded(auditFailures, {
+            event,
+            streamId,
+            emittedAt: envelope.emittedAt,
+            message,
+          }, auditFailureLimit);
+          console.warn("[friday][execution-control-event-emitter] operation failed:", message);
           // Audit sink failure is non-fatal
         }
       }
@@ -187,6 +238,10 @@ export function createExecutionControlEventEmitter(
 
     get emittedEvents() {
       return emitted;
+    },
+
+    get auditSinkFailures() {
+      return auditFailures;
     },
   };
 }

--- a/src/api/runtime/friday-deterministic-pipeline-runtime.ts
+++ b/src/api/runtime/friday-deterministic-pipeline-runtime.ts
@@ -1708,8 +1708,6 @@ export function createFridayDeterministicPipelineRuntime(
         );
         const targetId = asString(payload.targetId) ?? `${asString(payload.workflowId) ?? "workflow"}:${asString(payload.nodeId) ?? "node"}`;
         if (decision.shouldRetry) {
-          retryCircuitBreakers.recordSuccess(targetId);
-        } else {
           retryCircuitBreakers.recordFailure(targetId);
         }
         const snapshot = retryCircuitBreakers.getSnapshot(targetId);

--- a/src/jobs/retention/friday-retention-job.ts
+++ b/src/jobs/retention/friday-retention-job.ts
@@ -34,93 +34,102 @@ export function createFridayRetentionJob(deps: CreateRetentionJobDeps): FridayRe
     run(nowIsoOverride?) {
       const nowIso = nowIsoOverride ?? deps.nowIso();
 
-      // All cleanup runs in one write transaction for atomicity
-      const result = deps.db.withWriteTransaction((db) => {
-        // 1. Mark stale pending pairing requests as expired
+      const result: FridayRetentionJobResult = {
+        markedPairingExpired: 0,
+        deletedPairingRequests: 0,
+        deletedHeartbeats: 0,
+        markedOutboxExpired: 0,
+        deletedOutboxTerminal: 0,
+        deletedLearningEvents: 0,
+        deletedSkillRuns: 0,
+        deletedAuditLogs: 0,
+        deletedAgentRuns: 0,
+        deletedLlmUsageRecords: 0,
+        deletedErrorIncidents: 0,
+      };
+
+      result.markedPairingExpired = deps.db.withWriteTransaction((db) => {
         const pairingCutoff = nowIso;
         const staleRequests = deps.pairingRequestRepo.listPendingExpiredBefore(db, pairingCutoff);
         for (const req of staleRequests) {
           deps.pairingRequestRepo.updateStatus(db, req.id, "expired", null, nowIso);
         }
-        const markedPairingExpired = staleRequests.length;
+        return staleRequests.length;
+      });
 
-        // 2. Delete old resolved pairing requests
+      result.deletedPairingRequests = deps.db.withWriteTransaction((db) => {
         const pairingDeleteCutoff = subtractDays(nowIso, policy.pairingRequestsDays);
-        const deletedPairingRequests = deps.pairingRequestRepo.deleteResolvedBefore(
+        return deps.pairingRequestRepo.deleteResolvedBefore(
           db,
           pairingDeleteCutoff,
         );
+      });
 
-        // 3. Delete old heartbeat rows
+      result.deletedHeartbeats = deps.db.withWriteTransaction((db) => {
         const heartbeatCutoff = subtractDays(nowIso, policy.heartbeatsDays);
-        const deletedHeartbeats = deps.heartbeatRepo.deleteBefore(db, heartbeatCutoff);
+        return deps.heartbeatRepo.deleteBefore(db, heartbeatCutoff);
+      });
 
-        // 4. Mark TTL-breached outbox rows as expired
-        const markedOutboxExpired = deps.outboxRepo.expireByTtl(db, nowIso);
+      result.markedOutboxExpired = deps.db.withWriteTransaction((db) =>
+        deps.outboxRepo.expireByTtl(db, nowIso),
+      );
 
-        // 5. Delete old terminal outbox rows
+      result.deletedOutboxTerminal = deps.db.withWriteTransaction((db) => {
         const outboxDeleteCutoff = subtractDays(nowIso, policy.outboxTerminalDays);
-        const deletedOutboxTerminal = deps.outboxRepo.deleteTerminalBefore(db, outboxDeleteCutoff);
+        return deps.outboxRepo.deleteTerminalBefore(db, outboxDeleteCutoff);
+      });
 
-        // 6. Delete old learning events
+      result.deletedLearningEvents = deps.db.withWriteTransaction((db) => {
         const learningCutoff = subtractDays(nowIso, policy.learningEventsDays);
-        const deletedLearningEvents = db
+        return db
           .prepare("DELETE FROM learning_events WHERE ts < ?")
           .run(learningCutoff).changes;
+      });
 
-        // 7. Delete terminal skill run snapshots
+      result.deletedSkillRuns = deps.db.withWriteTransaction((db) => {
         const skillRunCutoff = subtractDays(nowIso, policy.skillRunTerminalDays);
         let deletedSkillRuns = 0;
         for (const status of ["completed", "failed", "cancelled"]) {
-          const result = db
+          const deleteResult = db
             .prepare(
               "DELETE FROM memory_items WHERE namespace = 'skill_runs' AND tags_json LIKE ? AND updated_at < ?",
             )
             .run(`%"status:${status}"%`, skillRunCutoff);
-          deletedSkillRuns += result.changes;
+          deletedSkillRuns += deleteResult.changes;
         }
+        return deletedSkillRuns;
+      });
 
-        // 8. Delete old audit logs
+      result.deletedAuditLogs = deps.db.withWriteTransaction((db) => {
         const auditCutoff = subtractDays(nowIso, policy.auditLogsDays);
-        const deletedAuditLogs = db
+        return db
           .prepare("DELETE FROM audit_logs WHERE ts < ?")
           .run(auditCutoff).changes;
+      });
 
-        // 9. Delete old terminal agent runs (events cascade via ON DELETE CASCADE)
+      result.deletedAgentRuns = deps.db.withWriteTransaction((db) => {
         const agentRunCutoff = subtractDays(nowIso, policy.agentRunsDays);
-        const deletedAgentRuns = db
+        return db
           .prepare(
             "DELETE FROM friday_agent_runs WHERE created_at < ? AND status IN ('completed', 'failed', 'cancelled')",
           )
           .run(agentRunCutoff).changes;
+      });
 
-        // 10. Delete old LLM usage records
+      result.deletedLlmUsageRecords = deps.db.withWriteTransaction((db) => {
         const llmUsageCutoff = subtractDays(nowIso, policy.llmUsageRecordsDays);
-        const deletedLlmUsageRecords = db
+        return db
           .prepare("DELETE FROM llm_usage_records WHERE created_at < ?")
           .run(llmUsageCutoff).changes;
+      });
 
-        // 11. Delete old resolved error incidents
+      result.deletedErrorIncidents = deps.db.withWriteTransaction((db) => {
         const errorCutoff = subtractDays(nowIso, policy.errorIncidentsDays);
-        const deletedErrorIncidents = db
+        return db
           .prepare(
             "DELETE FROM error_incidents WHERE status = 'resolved' AND updated_at < ?",
           )
           .run(errorCutoff).changes;
-
-        return {
-          markedPairingExpired,
-          deletedPairingRequests,
-          deletedHeartbeats,
-          markedOutboxExpired,
-          deletedOutboxTerminal,
-          deletedLearningEvents,
-          deletedSkillRuns,
-          deletedAuditLogs,
-          deletedAgentRuns,
-          deletedLlmUsageRecords,
-          deletedErrorIncidents,
-        };
       });
 
       // Run PRAGMA optimize after cleanup to update query planner statistics

--- a/src/jobs/scheduler/friday-job-scheduler-service.ts
+++ b/src/jobs/scheduler/friday-job-scheduler-service.ts
@@ -157,6 +157,7 @@ export function createFridayJobSchedulerService(
     const timeoutMs = jobDef.timeoutMs ?? FRIDAY_SCHEDULER_DEFAULT_TIMEOUT_MS;
     const startMs = nowMs();
     const schedule = getJobSchedule(jobDef);
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
 
     repository.markRunning(jobId, nowIso());
 
@@ -164,7 +165,7 @@ export function createFridayJobSchedulerService(
       await Promise.race([
         jobDef.run(),
         new Promise<never>((_, reject) => {
-          setTimeout(() => reject(new Error("SCHEDULER_JOB_TIMEOUT")), timeoutMs);
+          timeoutHandle = setTimeout(() => reject(new Error("SCHEDULER_JOB_TIMEOUT")), timeoutMs);
         }),
       ]);
 
@@ -210,6 +211,10 @@ export function createFridayJobSchedulerService(
       // For one-shot "at" jobs: disable after max retries to prevent hot-looping
       if (schedule.kind === "at" && failures >= AT_JOB_MAX_RETRIES) {
         repository.disableJob(jobId, nowIso());
+      }
+    } finally {
+      if (timeoutHandle !== undefined) {
+        clearTimeout(timeoutHandle);
       }
     }
   }

--- a/src/playbook/engine/promoter-job.ts
+++ b/src/playbook/engine/promoter-job.ts
@@ -300,6 +300,9 @@ export function createPromoterJobRunner(deps: PromoterJobRunnerDeps): PromoterJo
           await onError?.(error);
         });
       }, intervalMs);
+      if (typeof intervalHandle.unref === "function") {
+        intervalHandle.unref();
+      }
 
       return {
         stop,

--- a/src/retry/engine/production-retry-bridge.ts
+++ b/src/retry/engine/production-retry-bridge.ts
@@ -27,9 +27,9 @@ import type { RetryBudgetInstance } from "./retry-budget.js";
  * Default retry strategies by failure category.
  * These follow the unified failure taxonomy.
  */
-export const DEFAULT_PRODUCTION_STRATEGIES: readonly FridayRetryStrategy[] = [
+export const DEFAULT_PRODUCTION_STRATEGIES: FridayRetryStrategy[] = [
   {
-    type: "exponential",
+    strategy: "exponential",
     failureCategory: "rate_limit",
     maxAttempts: 5,
     baseDelayMs: 1000,
@@ -42,7 +42,7 @@ export const DEFAULT_PRODUCTION_STRATEGIES: readonly FridayRetryStrategy[] = [
     escalationChannel: "operator",
   },
   {
-    type: "exponential",
+    strategy: "exponential",
     failureCategory: "timeout",
     maxAttempts: 2,
     baseDelayMs: 2000,
@@ -55,7 +55,7 @@ export const DEFAULT_PRODUCTION_STRATEGIES: readonly FridayRetryStrategy[] = [
     escalationChannel: "operator",
   },
   {
-    type: "exponential",
+    strategy: "exponential",
     failureCategory: "transient",
     maxAttempts: 3,
     baseDelayMs: 500,
@@ -68,7 +68,7 @@ export const DEFAULT_PRODUCTION_STRATEGIES: readonly FridayRetryStrategy[] = [
     escalationChannel: "developer",
   },
   {
-    type: "linear",
+    strategy: "linear",
     failureCategory: "resource",
     maxAttempts: 2,
     baseDelayMs: 5000,
@@ -81,7 +81,7 @@ export const DEFAULT_PRODUCTION_STRATEGIES: readonly FridayRetryStrategy[] = [
     escalationChannel: "operator",
   },
   {
-    type: "none",
+    strategy: "none",
     failureCategory: "auth",
     maxAttempts: 0,
     respectRetryAfter: false,
@@ -90,7 +90,7 @@ export const DEFAULT_PRODUCTION_STRATEGIES: readonly FridayRetryStrategy[] = [
     escalateOnExhaustion: false,
   },
   {
-    type: "none",
+    strategy: "none",
     failureCategory: "logic",
     maxAttempts: 0,
     respectRetryAfter: false,
@@ -99,7 +99,7 @@ export const DEFAULT_PRODUCTION_STRATEGIES: readonly FridayRetryStrategy[] = [
     escalateOnExhaustion: false,
   },
   {
-    type: "fixed",
+    strategy: "fixed",
     failureCategory: "unknown",
     maxAttempts: 1,
     baseDelayMs: 1000,
@@ -111,7 +111,7 @@ export const DEFAULT_PRODUCTION_STRATEGIES: readonly FridayRetryStrategy[] = [
     escalateOnExhaustion: true,
     escalationChannel: "developer",
   },
-] as unknown as FridayRetryStrategy[];
+];
 
 /**
  * Default cost budget for production retry.
@@ -176,7 +176,7 @@ export function createProductionRetryBridge(
   config: ProductionRetryBridgeConfig,
 ): ProductionRetryBridge {
   const { generateId, nowIso } = config;
-  const strategies = config.strategies ?? (DEFAULT_PRODUCTION_STRATEGIES as unknown as FridayRetryStrategy[]);
+  const strategies = config.strategies ?? DEFAULT_PRODUCTION_STRATEGIES;
   const costBudget = config.costBudget ?? DEFAULT_PRODUCTION_COST_BUDGET;
 
   // Create the failure classifier with full taxonomy

--- a/src/state/sqlite/friday-sqlite-layer.ts
+++ b/src/state/sqlite/friday-sqlite-layer.ts
@@ -64,7 +64,8 @@ export function createFridaySqliteLayer(
     reads,
 
     withWriteTransaction<T>(fn: (db: Database.Database) => T): T {
-      return writer.transaction(() => fn(writer))();
+      const transaction = writer.transaction(() => fn(writer));
+      return transaction.immediate();
     },
 
     withReadConnection<T>(fn: (db: Database.Database) => T): T {

--- a/test/integration/api/friday-execution-control-events.test.ts
+++ b/test/integration/api/friday-execution-control-events.test.ts
@@ -370,6 +370,43 @@ describe("Audit Sink Integration", () => {
     expect(record.result).toBe("failure");
   });
 
+  it("audit record marks DLQ enqueue events with failure result", () => {
+    const bus = freshBus();
+    const auditRecords: unknown[] = [];
+    const emitter = createExecutionControlEventEmitter({
+      eventBus: bus,
+      nowIso,
+      auditSink: (record) => auditRecords.push(record),
+    });
+
+    emitter.emit("retry.dlq.enqueued", {
+      entryId: "dlq-1",
+      contextId: "rc-1",
+      failureCategory: "timeout",
+      reason: "max retries exhausted",
+    });
+
+    const record = auditRecords[0] as Record<string, unknown>;
+    expect(record.result).toBe("failure");
+  });
+
+  it("keeps emittedEvents bounded to the configured inspection window", () => {
+    const bus = freshBus();
+    const emitter = createExecutionControlEventEmitter({
+      eventBus: bus,
+      nowIso,
+      maxEmittedEvents: 2,
+    });
+
+    emitter.emit("rules.bundle.created", { bundleId: "pb-1", name: "A" });
+    emitter.emit("rules.bundle.updated", { bundleId: "pb-1", fields: ["name"] });
+    emitter.emit("playbook.selected", { playbookId: "pb-1", workflowType: "etl", reason: "best" });
+
+    expect(emitter.emittedEvents).toHaveLength(2);
+    expect(emitter.emittedEvents[0].event).toBe("rules.bundle.updated");
+    expect(emitter.emittedEvents[1].event).toBe("playbook.selected");
+  });
+
   it("audit records include correlationId as requestId", () => {
     const bus = freshBus();
     const auditRecords: unknown[] = [];
@@ -403,6 +440,30 @@ describe("Audit Sink Integration", () => {
     });
 
     expect(envelope.event).toBe("rules.bundle.created");
+  });
+
+  it("surfaces audit sink failures without breaking event emission", () => {
+    const bus = freshBus();
+    const emitter = createExecutionControlEventEmitter({
+      eventBus: bus,
+      nowIso,
+      auditSink: () => { throw new Error("Audit sink crashed"); },
+      maxAuditSinkFailures: 2,
+    });
+
+    const envelope = emitter.emit("rules.bundle.created", {
+      bundleId: "pb-1",
+      name: "test",
+    });
+
+    expect(envelope.event).toBe("rules.bundle.created");
+    expect(emitter.auditSinkFailures).toHaveLength(1);
+    expect(emitter.auditSinkFailures[0]).toMatchObject({
+      event: "rules.bundle.created",
+      streamId: "rules:pb-1",
+      emittedAt: "2026-02-25T12:00:00.000Z",
+      message: "Audit sink crashed",
+    });
   });
 });
 

--- a/test/integration/retry/friday-production-retry-bridge.test.ts
+++ b/test/integration/retry/friday-production-retry-bridge.test.ts
@@ -82,6 +82,18 @@ describe("Production Retry Bridge", () => {
       expect(categories).toContain("unknown");
     });
 
+    it("uses the canonical strategy discriminator for default policies", () => {
+      const strategyKinds = DEFAULT_PRODUCTION_STRATEGIES.map((strategy) => strategy.strategy);
+      const legacyKinds = DEFAULT_PRODUCTION_STRATEGIES.map(
+        (strategy) => (strategy as unknown as Record<string, unknown>).type,
+      );
+
+      expect(strategyKinds).toContain("exponential");
+      expect(strategyKinds).toContain("linear");
+      expect(strategyKinds).toContain("fixed");
+      expect(legacyKinds.every((kind) => kind === undefined)).toBe(true);
+    });
+
     it("marks auth and logic as non-retryable (maxAttempts = 0)", () => {
       const authStrategy = DEFAULT_PRODUCTION_STRATEGIES.find(
         (s) => (s as unknown as Record<string, unknown>).failureCategory === "auth",
@@ -121,6 +133,7 @@ describe("Production Retry Bridge", () => {
 
     it("retries transient failures and succeeds on second attempt", async () => {
       const bridge = createBridge();
+      const sleep = vi.fn(async () => {});
       let attempt = 0;
       const fn = vi.fn(async () => {
         attempt++;
@@ -137,11 +150,14 @@ describe("Production Retry Bridge", () => {
         "run-1" as UUID,
         "wf-1" as UUID,
         "node-1",
-        { sleep: async () => {} }, // Skip actual delays in tests
+        { sleep }, // Skip actual delays in tests
       );
 
       expect(result).toBe("recovered");
       expect(fn).toHaveBeenCalledTimes(2);
+      expect(sleep).toHaveBeenCalledOnce();
+      expect(sleep.mock.calls[0]?.[0]).toEqual(expect.any(Number));
+      expect(sleep.mock.calls[0]?.[0]).toBeGreaterThan(0);
     });
 
     it("rejects non-retryable failures immediately", async () => {

--- a/test/unit/api/runtime/friday-deterministic-pipeline-runtime.test.ts
+++ b/test/unit/api/runtime/friday-deterministic-pipeline-runtime.test.ts
@@ -19,6 +19,7 @@ function clearRulesState(db: ReturnType<typeof createTestDb>): void {
 describe("Friday deterministic pipeline runtime wiring", () => {
   const originalPipelineMode = process.env.FRIDAY_PIPELINE_MODE;
   const originalPipelineEnable = process.env.FRIDAY_PIPELINE_ENABLE;
+  const originalRetryCircuitThreshold = process.env.FRIDAY_PIPELINE_RETRY_CIRCUIT_THRESHOLD;
 
   afterEach(() => {
     if (originalPipelineMode === undefined) {
@@ -30,6 +31,11 @@ describe("Friday deterministic pipeline runtime wiring", () => {
       delete process.env.FRIDAY_PIPELINE_ENABLE;
     } else {
       process.env.FRIDAY_PIPELINE_ENABLE = originalPipelineEnable;
+    }
+    if (originalRetryCircuitThreshold === undefined) {
+      delete process.env.FRIDAY_PIPELINE_RETRY_CIRCUIT_THRESHOLD;
+    } else {
+      process.env.FRIDAY_PIPELINE_RETRY_CIRCUIT_THRESHOLD = originalRetryCircuitThreshold;
     }
   });
 
@@ -316,6 +322,57 @@ describe("Friday deterministic pipeline runtime wiring", () => {
     expect(traces.items.length).toBeGreaterThan(0);
     expect(breakers.items.some((item) => item.targetId === "provider:openai")).toBe(true);
     expect(escalations.items.length).toBeGreaterThanOrEqual(0);
+    db.close();
+  });
+
+  it("counts retryable decideRetry failures toward the circuit breaker without treating terminal no-retry as failure", () => {
+    process.env.FRIDAY_PIPELINE_RETRY_CIRCUIT_THRESHOLD = "3";
+    const db = createTestDb();
+    const runtime = createFridayDeterministicPipelineRuntime({
+      db,
+      idGenerator: createTestIdGenerator(),
+      nowIso: () => "2026-02-27T00:00:00.000Z",
+      invokeSkill: async () => ({ ok: true }),
+    });
+
+    for (let index = 0; index < 3; index += 1) {
+      const decided = runtime.retry.decideRetry({
+        runId: `run-retry-${index}`,
+        workflowId: "wf-retry",
+        nodeId: "node-retry",
+        currentAttemptNumber: 1,
+        error: { errorCode: "ECONNRESET", errorMessage: "connection reset" },
+        targetId: "provider:retryable",
+      }) as { decision: { shouldRetry: boolean } };
+
+      expect(decided.decision.shouldRetry).toBe(true);
+    }
+
+    runtime.retry.decideRetry({
+      runId: "run-auth",
+      workflowId: "wf-auth",
+      nodeId: "node-auth",
+      currentAttemptNumber: 1,
+      error: { errorCode: "AUTH_FAILED", errorMessage: "Unauthorized" },
+      targetId: "provider:auth",
+    });
+
+    const breakers = runtime.retry.listCircuitBreakers({}) as {
+      items: Array<{ targetId: string; state: string; consecutiveFailures: number; tripCount: number }>;
+    };
+    const retryable = breakers.items.find((item) => item.targetId === "provider:retryable");
+    const terminal = breakers.items.find((item) => item.targetId === "provider:auth");
+
+    expect(retryable).toMatchObject({
+      state: "open",
+      consecutiveFailures: 3,
+      tripCount: 1,
+    });
+    expect(terminal).toMatchObject({
+      state: "closed",
+      consecutiveFailures: 0,
+      tripCount: 0,
+    });
     db.close();
   });
 

--- a/test/unit/heartbeat/friday-heartbeat-runner.test.ts
+++ b/test/unit/heartbeat/friday-heartbeat-runner.test.ts
@@ -165,6 +165,38 @@ describe("FridayHeartbeatRunner", () => {
     expect(repo.state.cooldownUntil).toBe("2026-02-23T10:02:00.000Z");
   });
 
+  it("treats unexpected non-empty non-OK output as fail-safe action-required truth", async () => {
+    const repo = createMemoryRepo();
+    const executeRun = vi.fn(async () => ({
+      runId: "run-noisy",
+      status: "completed" as const,
+      response: "diagnostic: downstream service returned 503",
+    }));
+    const onActionRequired = vi.fn();
+
+    const runner = createFridayHeartbeatRunner({
+      config: {
+        enabled: true,
+        intervalMs: 60_000,
+        cooldownMs: 120_000,
+        fallbackPrompt: "respond HEARTBEAT_OK only when no action is required",
+        sessionKey: "system:heartbeat",
+      },
+      repository: repo.repository,
+      agentRuntime: { executeRun },
+      nowIso: () => "2026-02-23T10:00:00.000Z",
+      idGenerator: () => "hb-noisy",
+      onActionRequired,
+    });
+
+    const result = await runner.runOnce();
+
+    expect(result.status).toBe("ok");
+    expect(result.actionRequired).toBe(true);
+    expect(onActionRequired).toHaveBeenCalledOnce();
+    expect(repo.state.cooldownUntil).toBe("2026-02-23T10:02:00.000Z");
+  });
+
   it("loads session history and forwards it into agent execution", async () => {
     const repo = createMemoryRepo();
     const executeRun = vi.fn(async () => ({

--- a/test/unit/jobs/retention/friday-retention-job.test.ts
+++ b/test/unit/jobs/retention/friday-retention-job.test.ts
@@ -136,6 +136,24 @@ describe("FridayRetentionJob", () => {
     expect(result.deletedHeartbeats).toBe(1);
   });
 
+  it("keeps earlier cleanup commits when a later retention step fails", () => {
+    db.writer
+      .prepare(
+        `INSERT INTO satellite_heartbeats (id, satellite_id, ts, status)
+         VALUES ('hb-old', 'sat-1', '2025-01-01T00:00:00.000Z', 'online')`,
+      )
+      .run();
+    db.writer.exec("DROP TABLE learning_events");
+
+    const job = createJob();
+
+    expect(() => job.run(NOW)).toThrow(/learning_events/i);
+    const heartbeat = db.writer
+      .prepare("SELECT id FROM satellite_heartbeats WHERE id = 'hb-old'")
+      .get();
+    expect(heartbeat).toBeUndefined();
+  });
+
   it("marks TTL-expired outbox messages", () => {
     db.withWriteTransaction((d) => {
       outboxRepo.insertMessage(d, "msg-expired", {

--- a/test/unit/jobs/scheduler/friday-job-scheduler-service.test.ts
+++ b/test/unit/jobs/scheduler/friday-job-scheduler-service.test.ts
@@ -348,6 +348,38 @@ describe("FridayJobSchedulerService", () => {
     expect(runCount).toBe(1);
   });
 
+  it("clears the per-job timeout timer after a successful run", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-24T12:00:00.000Z"));
+
+    try {
+      const repo = createFridayJobSchedulerRepository({ db });
+      let runCount = 0;
+
+      const scheduler = createFridayJobSchedulerService({
+        repository: repo,
+        jobs: [
+          {
+            id: "timer-cleanup-job",
+            intervalMs: 60_000,
+            timeoutMs: 600_000,
+            run: async () => {
+              runCount++;
+            },
+          },
+        ],
+      });
+
+      await scheduler.start();
+      await scheduler.stop();
+
+      expect(runCount).toBe(1);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   // ─── CX65: Invalid cron disables instead of hot-looping ───
 
   it("CX65: invalid cron expression disables job on seed instead of hot-looping", async () => {

--- a/test/unit/playbook/engine/promoter-job.test.ts
+++ b/test/unit/playbook/engine/promoter-job.test.ts
@@ -276,5 +276,29 @@ describe("Promoter Job Runner", () => {
       await vi.advanceTimersByTimeAsync(2_000);
       expect(getKpis).toHaveBeenCalledTimes(2);
     });
+
+    it("unrefs the interval handle when the runtime supports it", () => {
+      const unref = vi.fn();
+      const intervalHandle = { unref } as unknown as ReturnType<typeof setInterval>;
+      const setIntervalSpy = vi.spyOn(globalThis, "setInterval").mockReturnValue(intervalHandle);
+      const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval").mockImplementation(() => undefined);
+
+      try {
+        const runner = createPromoterJobRunner({
+          store,
+          promotionEngine,
+          versionManager,
+          getKpis: () => ({ reuseHitRate: 0.5, successLift: 0.3, badPromotionRollbackRate: 0.001 }),
+          nowIso: () => NOW,
+        });
+
+        const control = runner.start(1_000);
+        expect(unref).toHaveBeenCalledOnce();
+        control.stop();
+      } finally {
+        setIntervalSpy.mockRestore();
+        clearIntervalSpy.mockRestore();
+      }
+    });
   });
 });

--- a/test/unit/providers/routing/friday-provider-fallback.test.ts
+++ b/test/unit/providers/routing/friday-provider-fallback.test.ts
@@ -542,6 +542,37 @@ describe("FridayProviderFallback", () => {
       expect(fb.isInCooldown("p1")).toBe(true);
     });
 
+    it("keeps cooldown state scoped to the current fallback instance", async () => {
+      let now = Date.parse("2026-02-24T12:00:00.000Z");
+      const p1 = makeProvider("p1");
+      const p2 = makeProvider("p2");
+      const fb = createFridayProviderFallback({
+        nowMs: () => now,
+        cooldownMs: 120_000,
+      });
+
+      await fb.runWithFallback({
+        candidates: [
+          { provider: p1, model: "gpt-4o" },
+          { provider: p2, model: "gpt-4o" },
+        ],
+        run: async (route) => {
+          if (route.provider.id === "p1") throw new Error("429 rate_limit");
+          return "ok";
+        },
+      });
+
+      expect(fb.isInCooldown("p1")).toBe(true);
+
+      now += 1;
+      const restartedFallback = createFridayProviderFallback({
+        nowMs: () => now,
+        cooldownMs: 120_000,
+      });
+
+      expect(restartedFallback.isInCooldown("p1")).toBe(false);
+    });
+
     it("unknown permanent errors do not set cooldown", async () => {
       const fb = createFridayProviderFallback();
       const p1 = makeProvider("p1");

--- a/test/unit/state/sqlite/friday-sqlite-layer.test.ts
+++ b/test/unit/state/sqlite/friday-sqlite-layer.test.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import * as os from "node:os";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
 import { createFridaySqliteLayer } from "#state";
 import type { FridaySqliteLayer } from "#state";
 import { ensureFridayApiBuildForNodeWorkers } from "../../../helpers/friday-ensure-api-build.helper.js";
@@ -72,6 +73,34 @@ describe("friday-sqlite-layer", () => {
       db.prepare("SELECT v FROM kv WHERE k = ?").get("key1"),
     );
     expect(row).toBeUndefined();
+  });
+
+  it("withWriteTransaction acquires the write lock immediately", () => {
+    const dbPath = path.join(tmpDir, "immediate.db");
+    layer = createFridaySqliteLayer({
+      dbPath,
+      readPoolSize: 1,
+      pragmas: { busyTimeoutMs: 5000, synchronous: "NORMAL" },
+    });
+    layer.writer.exec("CREATE TABLE kv (k TEXT PRIMARY KEY, v TEXT)");
+
+    const competingWriter = new Database(dbPath);
+    competingWriter.pragma("busy_timeout = 0");
+
+    try {
+      expect(() => {
+        layer.withWriteTransaction(() => {
+          competingWriter.prepare("INSERT INTO kv (k, v) VALUES (?, ?)").run("other", "value");
+        });
+      }).toThrow(/database is locked|SQLITE_BUSY|busy/i);
+
+      const row = layer.withReadConnection((db) =>
+        db.prepare("SELECT v FROM kv WHERE k = ?").get("other"),
+      );
+      expect(row).toBeUndefined();
+    } finally {
+      competingWriter.close();
+    }
   });
 
   it("close() closes all connections", () => {


### PR DESCRIPTION
## B4 Runtime Reliability

Closes the approved B4 runtime-reliability slice for:
- ISSUE-013 / ISSUE-014 retry bridge and retry circuit behavior
- ISSUE-017 provider cooldown truth
- ISSUE-029 scheduler timeout cleanup
- ISSUE-030 retention transaction granularity
- ISSUE-032 heartbeat non-OK fail-safe truth
- ISSUE-033 SQLite write transaction mode
- CAND-0189 / CAND-0576 / CAND-1050

## Changes

- Corrected production retry default strategies to use the canonical `strategy` discriminator.
- Corrected deterministic retry breaker accounting so retryable failures count as failures and terminal no-retry does not inflate failure counts.
- Cleared scheduler per-job timeout handles on success/failure cleanup.
- Split retention cleanup into per-step write transactions with partial-progress proof.
- Switched SQLite write transactions to `BEGIN IMMEDIATE` through better-sqlite3 `.immediate()`.
- Added `.unref()` to promoter interval handles when supported.
- Bounded execution-control emitted event retention, classified DLQ enqueue audit records as failure, and surfaced audit-sink failures in a bounded in-memory inspection buffer.
- Added truth tests for provider cooldown restart-reset behavior and heartbeat noisy non-OK fail-safe behavior without changing those semantics.

## Verification

- `npx vitest run test/integration/retry/friday-production-retry-bridge.test.ts test/unit/api/runtime/friday-deterministic-pipeline-runtime.test.ts test/unit/jobs/scheduler/friday-job-scheduler-service.test.ts test/unit/jobs/retention/friday-retention-job.test.ts test/unit/state/sqlite/friday-sqlite-layer.test.ts test/unit/heartbeat/friday-heartbeat-runner.test.ts test/unit/providers/routing/friday-provider-fallback.test.ts test/unit/playbook/engine/promoter-job.test.ts test/integration/api/friday-execution-control-events.test.ts` - 9 files / 152 tests passed
- B4 focused vitest suite - 15 files / 287 tests passed
- `npx vitest run test/adversarial` - 14 files / 365 tests passed
- `npm run typecheck:src` - passed
- `npm run lint` - 0 errors, 1481 existing warnings
- `git diff --check` and staged `git diff --cached --check` - passed
- `npm run check:secret-patterns` - passed
- CI-equivalent `detect-secrets-hook --baseline .secrets.baseline ...` - passed

## Reviewers

- Reviewer A `019e53bd-f15e-75b3-8f48-c7432646d385`: PASS
- Reviewer B `019e53bd-f258-7b02-96e0-dde45cc925c8`: PASS

## CI / RGG / Merge

- Required CI checks passed at PR head `3ce072349172dd2aa5738aa011ff404bf4f7120d`.
- Same-SHA RGG artifact `real-green-gate-26327101588` passed with `commit_sha=3ce072349172dd2aa5738aa011ff404bf4f7120d`, `scenarios_total=94`, `scenarios_passed=94`, `blocked_reasons=[]`.
- PR #294 merged normally at `2026-05-23T09:09:57Z` as `113e2336506a1466f477b3ca26eebe10a71cca58`.
- Merge commit second parent is the PR head and PR-head-to-main tree diff is empty.
- No owner/admin bypass flag was used.

## Residual / No Overclaim

- `src/retry` still contains in-memory orchestrator/DLQ primitives, but caller mapping found no live production route beyond exports/tests; live deterministic retry breaker accounting is corrected and persisted snapshot behavior remains covered.
- Provider cooldown remains process-instance scoped and restart-reset; this is truth-tested, not changed to durable persistence.
- Heartbeat non-empty non-`HEARTBEAT_OK` output remains fail-safe action-required; this is truth-tested, not narrowed.
- `auditSinkFailures` is an in-memory bounded visibility buffer, not durable audit persistence.
