### PR TITLE
B0 Slice A5 — close NEEDS_TEST carve-outs for 4 mutating routes

### DIFF
--- a/src/api/http/routes/friday-satellite-pairing-routes.ts
+++ b/src/api/http/routes/friday-satellite-pairing-routes.ts
@@ -239,11 +239,16 @@ export function createFridaySatellitePairingRoutes(
     },
 
     // ─── Handshake (public — token-based auth) ───
+    // B0 Slice A5 carve-out: handshake authenticates via the body's
+    // `token + signedChallenge + challengeNonce + clientEphemeralPublicKey`,
+    // verified by `deps.completeHandshake` before any persistent stream/epoch is
+    // returned. Negative test: see test/unit/api/routes/friday-satellite-pairing-routes.test.ts
+    // "B0 Slice A5: synthetic default-public principal cannot bypass handshake verifier".
     {
       operationId: "satellites.handshake",
       method: "POST",
       path: "/v1/satellites/:satelliteId/handshake",
-      auth: { public: true },
+      auth: { public: true, allowUnauthenticatedMutation: true },
       rateLimitPolicyId: "satellite.handshake",
       async handler(ctx: Ctx) {
         const params = ctx.params as Record<string, string>;

--- a/src/api/http/routes/friday-skill-generator-routes.ts
+++ b/src/api/http/routes/friday-skill-generator-routes.ts
@@ -991,11 +991,18 @@ export function createFridaySkillGeneratorRoutes(
     },
 
     // ─── Approve and save ───
+    // B0 Slice A5 carve-out: candidate approval is gated by
+    // `assertSkillGeneratorCandidateApproval` (canonical approval gate evaluated
+    // against the generated draft) before `deps.skillGenerator.approveAndSave` is
+    // called. Negative test: see test/unit/api/http/routes/friday-skill-generator-routes.test.ts
+    // "requires canonical approval before staging the generated skill candidate"
+    // (existing) and the new "B0 Slice A5: synthetic default-public principal
+    // cannot bypass generator candidate verifier".
     {
       operationId: "skills.generator.sessions.approve",
       method: "POST",
       path: "/v1/skills/generator/sessions/:sessionId/approve",
-      auth: { public: true },
+      auth: { public: true, allowUnauthenticatedMutation: true },
       rateLimitPolicyId: "skill_generator.write",
       async handler(ctx): Promise<FridayApproveResponse> {
         const { sessionId } = ctx.params as { sessionId: string };

--- a/src/api/http/routes/friday-skill-routes.ts
+++ b/src/api/http/routes/friday-skill-routes.ts
@@ -601,11 +601,16 @@ export function createFridaySkillRoutes(
 	  }
 
   if (deps.managedSkillsDir) {
+    // B0 Slice A5 carve-out: content updates are gated by `assertCanonicalApproval`
+    // (HMAC-signed canonical approval ticket) before any file write. The handler
+    // also rejects managed-external artifacts with SKILL_CONTENT_UPDATE_REQUIRES_LIFECYCLE
+    // before any I/O. Negative test: see test/unit/api/http/routes/friday-skill-routes.test.ts
+    // "B0 Slice A5: synthetic default-public principal cannot bypass content-update verifier".
     routes.push({
       operationId: "skills.content.update",
       method: "PATCH",
       path: "/v1/skills/:skillId/content",
-      auth: { public: true },
+      auth: { public: true, allowUnauthenticatedMutation: true },
       async handler(ctx) {
         const skillId = normalizeRouteInstallId(String((ctx.params as Record<string, unknown>).skillId ?? ""));
         const body = asRecord(ctx.body);
@@ -714,11 +719,16 @@ export function createFridaySkillRoutes(
           return { analysis };
         },
       },
+      // B0 Slice A5 carve-out: upgrade decisions are gated by `assertCanonicalApproval`
+      // (HMAC-signed canonical approval ticket bound to the analysis digest) before
+      // `deps.upgradeAnalysis.applyDecision` is called. Negative test: see
+      // test/unit/api/http/routes/friday-skill-routes.test.ts
+      // "B0 Slice A5: synthetic default-public principal cannot bypass upgrade-decide verifier".
       {
         operationId: "skills.upgrade.decide",
         method: "POST",
         path: "/v1/skills/:skillId/upgrade/decide",
-        auth: { public: true },
+        auth: { public: true, allowUnauthenticatedMutation: true },
         async handler(ctx) {
           const skillId = String((ctx.params as Record<string, unknown>).skillId ?? "");
           const body = asRecord(ctx.body);

--- a/test/unit/api/http/routes/friday-skill-generator-routes.test.ts
+++ b/test/unit/api/http/routes/friday-skill-generator-routes.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createFridaySkillGeneratorRoutes } from "#api";
+import { FRIDAY_DEFAULT_PUBLIC_HTTP_PRINCIPAL_ID } from "../../../../../src/api/http/friday-default-public-principal.js";
 import {
   createFridaySkillGeneratorStageMutatingActionRequest,
   type FridaySkillGeneratorService,
@@ -507,6 +508,32 @@ describe("FridaySkillGeneratorRoutes", () => {
           }),
         ),
       ).rejects.toThrow("requires canonical approval");
+      expect(generatorService.approveAndSave).not.toHaveBeenCalled();
+    });
+
+    it("B0 Slice A5: synthetic default-public principal cannot bypass generator candidate verifier — missing canonical approval rejects before approveAndSave", async () => {
+      const { routes, generatorService } = createRoutes();
+      const route = routes.find(
+        (r) => r.operationId === "skills.generator.sessions.approve",
+      )!;
+
+      await expect(
+        route.handler(
+          makeCtx({
+            params: { sessionId: "sess-1" },
+            principal: {
+              principalType: "user",
+              principalId: FRIDAY_DEFAULT_PUBLIC_HTTP_PRINCIPAL_ID,
+              scopes: [],
+              tokenId: "synthetic",
+              tokenKind: "access",
+              issuedAt: NOW,
+            },
+          }),
+        ),
+      ).rejects.toThrow("requires canonical approval");
+
+      // Verifier must block before any candidate is staged.
       expect(generatorService.approveAndSave).not.toHaveBeenCalled();
     });
 

--- a/test/unit/api/http/routes/friday-skill-routes.test.ts
+++ b/test/unit/api/http/routes/friday-skill-routes.test.ts
@@ -12,6 +12,7 @@ import {
   createFridayMutatingActionDigest,
   createFridayMutatingActionGate,
 } from "../../../../../src/security/friday-mutating-action-gate.js";
+import { FRIDAY_DEFAULT_PUBLIC_HTTP_PRINCIPAL_ID } from "../../../../../src/api/http/friday-default-public-principal.js";
 
 const NOW = "2026-03-07T00:00:00.000Z";
 
@@ -775,5 +776,114 @@ describe("createFridaySkillRoutes", () => {
     } finally {
       rmSync(managedSkillsDir, { recursive: true, force: true });
     }
+  });
+
+  it("B0 Slice A5: synthetic default-public principal cannot bypass content-update verifier — missing canonical approval rejects before any file write", async () => {
+    const managedSkillsDir = join(tmpdir(), `friday-skill-route-a5-content-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    const skillDir = join(managedSkillsDir, "skill.workspace");
+    mkdirSync(skillDir, { recursive: true });
+    const originalSkillMd = "# Original Workspace Skill\n";
+    const originalManifest = {
+      id: "skill.workspace",
+      name: "Original",
+      version: "1.0.0",
+      runtime: { kind: "shell" },
+    };
+    writeFileSync(join(skillDir, "SKILL.md"), originalSkillMd, "utf8");
+    writeFileSync(join(skillDir, "skill.manifest.json"), JSON.stringify(originalManifest, null, 2), "utf8");
+    try {
+      const routes = createFridaySkillRoutes({
+        managedSkillsDir,
+        skillRegistry: {
+          list: () => [],
+          // Workspace artifact (managed:false) bypasses SKILL_CONTENT_UPDATE_REQUIRES_LIFECYCLE
+          // so the canonical-approval verifier is the next gate.
+          get: vi.fn(() => ({
+            source: "workspace",
+            origin: "workspace",
+            status: "installed",
+            managed: false,
+            manifest: {
+              id: "skill.workspace",
+              name: "Original",
+              kind: "conversation",
+              runtime: { kind: "shell" },
+            },
+          })),
+        } as never,
+        canonicalMutationGate: makeCanonicalMutationGate(),
+      });
+
+      const synthethicPublicCtx = makeCtx({
+        params: { skillId: "skill.workspace" },
+        body: {
+          name: "Attacker-Renamed",
+          description: "Mutated by unauthenticated request",
+          tags: ["compromised"],
+        },
+        principal: {
+          principalId: FRIDAY_DEFAULT_PUBLIC_HTTP_PRINCIPAL_ID,
+          principalType: "user",
+          role: "viewer",
+          scopes: [],
+          tokenId: "synthetic",
+          tokenKind: "access",
+          issuedAt: NOW,
+        },
+      });
+
+      await expect(
+        routes.find((item) => item.operationId === "skills.content.update")!.handler(synthethicPublicCtx),
+      ).rejects.toMatchObject({
+        code: "SKILL_CONTENT_UPDATE_APPROVAL_REQUIRED",
+        httpStatus: 403,
+      });
+
+      // Files must be untouched: the verifier blocks before any writeFileSync runs.
+      expect(readFileSync(join(skillDir, "SKILL.md"), "utf8")).toBe(originalSkillMd);
+      expect(JSON.parse(readFileSync(join(skillDir, "skill.manifest.json"), "utf8"))).toEqual(originalManifest);
+    } finally {
+      rmSync(managedSkillsDir, { recursive: true, force: true });
+    }
+  });
+
+  it("B0 Slice A5: synthetic default-public principal cannot bypass upgrade-decide verifier — missing canonical approval rejects before applyDecision", async () => {
+    const analyze = vi.fn(() => ({
+      analysisDigest: "digest-a5-1",
+      recommendation: "replace",
+      regressionProof: { overallVerdict: "ok" },
+    }));
+    const applyDecision = vi.fn(() => ({ record: { id: "decision-1" } }));
+    const upgradeAnalysis = { analyze, applyDecision } as never;
+
+    const routes = createFridaySkillRoutes({
+      skillRegistry: { list: () => [] } as never,
+      lifecycle: makeLifecycle() as never,
+      canonicalMutationGate: makeCanonicalMutationGate(),
+      upgradeAnalysis,
+    });
+    const decide = routes.find((item) => item.operationId === "skills.upgrade.decide")!;
+
+    await expect(decide.handler(makeCtx({
+      params: { skillId: "skill.workspace" },
+      body: {
+        candidateId: "candidate-1",
+        decision: "replace",
+      },
+      principal: {
+        principalId: FRIDAY_DEFAULT_PUBLIC_HTTP_PRINCIPAL_ID,
+        principalType: "user",
+        role: "viewer",
+        scopes: [],
+        tokenId: "synthetic",
+        tokenKind: "access",
+        issuedAt: NOW,
+      },
+    }))).rejects.toMatchObject({
+      code: "SKILL_UPGRADE_DECIDE_APPROVAL_REQUIRED",
+      httpStatus: 403,
+    });
+
+    expect(applyDecision).not.toHaveBeenCalled();
   });
 });

--- a/test/unit/api/routes/friday-satellite-pairing-routes.test.ts
+++ b/test/unit/api/routes/friday-satellite-pairing-routes.test.ts
@@ -3,6 +3,7 @@ import {
   createFridaySatellitePairingRoutes,
   type FridaySatellitePairingRoutesDeps,
 } from "../../../../src/api/http/routes/friday-satellite-pairing-routes.js";
+import { FRIDAY_DEFAULT_PUBLIC_HTTP_PRINCIPAL_ID } from "../../../../src/api/http/friday-default-public-principal.js";
 
 // ─── Helpers ───
 
@@ -336,7 +337,7 @@ describe("createFridaySatellitePairingRoutes", () => {
 
       expect(route.method).toBe("POST");
       expect(route.path).toBe("/v1/satellites/:satelliteId/handshake");
-      expect(route.auth).toEqual({ public: true });
+      expect(route.auth).toEqual({ public: true, allowUnauthenticatedMutation: true });
       expect(route.rateLimitPolicyId).toBe("satellite.handshake");
 
       const result = await route.handler(makeCtx({
@@ -363,6 +364,32 @@ describe("createFridaySatellitePairingRoutes", () => {
       }) as any);
 
       expect(result).toEqual({ error: expect.objectContaining({ code: "VALIDATION_FAILED" }) });
+      expect(deps.completeHandshake).not.toHaveBeenCalled();
+    });
+
+    it("B0 Slice A5: synthetic default-public principal cannot bypass handshake verifier — bad token/signature is rejected by deps.completeHandshake with no stream issued", async () => {
+      const failingHandshake = vi.fn().mockRejectedValue(
+        new Error("SATELLITE_HANDSHAKE_INVALID_SIGNATURE"),
+      );
+      const localDeps = makeDeps({ completeHandshake: failingHandshake });
+      const routes = createFridaySatellitePairingRoutes(localDeps);
+      const route = findRoute(routes, "satellites.handshake");
+
+      // Carve-out reaches the handler under the synthetic default-public principal,
+      // but the handler's verifier (deps.completeHandshake) is the trust boundary.
+      // A bad signed challenge must be rejected and no stream/epoch may be returned.
+      await expect(route.handler(makeCtx({
+        params: { satelliteId: "sat-001" },
+        body: {
+          token: "forged-token",
+          signedChallenge: "forged-signature",
+          challengeNonce: "nonce-xyz",
+          clientEphemeralPublicKey: "client-pub-key",
+        },
+        principal: { principalId: FRIDAY_DEFAULT_PUBLIC_HTTP_PRINCIPAL_ID },
+      }) as any)).rejects.toThrow(/SATELLITE_HANDSHAKE_INVALID_SIGNATURE/);
+
+      expect(failingHandshake).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
## Summary

**B0 Slice A5 — NEEDS_TEST follow-ups (closes 4 routes deferred by PR #298).** Adds `allowUnauthenticatedMutation: true` to four routes that already had an in-handler verifier but lacked an explicit route-level negative test of that verifier's denial path. Each route's verifier is now exercised by a new negative test that proves the synthetic default-public principal cannot reach any side effect.

Aligns with locked decisions GEC-001 (root-cause grouping), GEC-005 (public/default principal cannot authorize writes), and the AUTO_DECISION_POLICY rule that pre-auth mutating routes require an explicit verifier + route-level negative test before carve-out.

## What changed (6 files, 191+/5-)

**Source (3 files, 32+/4-):**
- `src/api/http/routes/friday-satellite-pairing-routes.ts` — `satellites.handshake` carve-out + verifier/test code-comment cite (line 246-274)
- `src/api/http/routes/friday-skill-routes.ts` — `skills.content.update` (line 604-622) and `skills.upgrade.decide` (line 722-738) carve-outs + cites
- `src/api/http/routes/friday-skill-generator-routes.ts` — `skills.generator.sessions.approve` carve-out + cite (line 993-1008)

**Tests (3 files, 159+/1-):**

| Route | Verifier | Negative test (file:line) | Side-effect assertion |
|---|---|---|---|
| `satellites.handshake` | `deps.completeHandshake` (token + signedChallenge + challengeNonce + clientEphemeralPublicKey) | `test/unit/api/routes/friday-satellite-pairing-routes.test.ts:369-393` | completeHandshake mocked to reject; handler propagates; no stream/epoch returned |
| `skills.content.update` | `assertCanonicalApproval` (HMAC-signed canonical approval ticket) | `test/unit/api/http/routes/friday-skill-routes.test.ts:780-848` | SKILL.md + skill.manifest.json bytes unchanged on disk (writeFileSync never reached) |
| `skills.upgrade.decide` | `assertCanonicalApproval` (bound to analysis digest) | `test/unit/api/http/routes/friday-skill-routes.test.ts:850-888` | `upgradeAnalysis.applyDecision` not called |
| `skills.generator.sessions.approve` | `assertSkillGeneratorCandidateApproval` (canonical approval gate evaluated against generated draft) | `test/unit/api/http/routes/friday-skill-generator-routes.test.ts:513-538` | `skillGenerator.approveAndSave` not called |

## What this slice does NOT claim

- **Does not verify the verifiers themselves.** Canonical-approval HMAC verification and handshake signature math are tested at the service layer; this slice only proves the route-level wiring rejects pre-side-effect when the verifier returns `requires_approval` / `denied` / rejection.
- **Does not close audit's Slice A4** (7 `system.remote.*` WebAuthn routes). A4 requires a new boundary-design decision (device-bootstrap-token vs explicit challenge-issuance rationale) and is tracked as separate ledger debt.
- **Does not touch UI/E2E surfaces.** None of the 4 routes is exercised by the deferred UI E2E tests in Slice A2 or A3.
- **No live integration changed.** No `code_passed_live_pending` / `blocked_by_env` label change.

## Auto decisions recorded

- Branch base: latest verified `origin/main` (`6b561f9f`, post-Slice-A + post-Slice-B).
- Slice priority: chose A5 over A4 because A5 closes already-existing verifiers (proof-completion work) while A4 requires a new boundary-design decision per the audit's §"Reviewer-A flow-impact observation". A2/A3 affect UI-layer wiring and are tracked separately.
- Test-fixture principal: imported `FRIDAY_DEFAULT_PUBLIC_HTTP_PRINCIPAL_ID` rather than literal `"public:default"` to survive future renames.

## Test plan

- [x] `tsc --noEmit -p .` clean (0 errors)
- [x] `npx eslint` on touched files — 0 errors, 26 warnings all pre-existing in untouched code / test-ignored
- [x] `npx vitest run` on the 4 focused test files — 74/74 pass (incl. existing public-mutation-gate test 8/8)
- [x] `npx vitest run test/unit/api/` — full unit/api suite 1473/1473 pass (no regression)
- [x] `npx vitest run test/contracts/api/friday-api-route-contract.snapshot.test.ts` — 7/7 pass (snapshot keyed by `route.auth.public`, not full auth object; carve-out flag does not affect contract shape)
- [x] `npm run check:security-doctor` — passed
- [x] `npm run check:architecture-boundaries` — passed (no immutable-core file touched)
- [x] `npm run check:secret-patterns` — clean
- [x] `git diff --check` — clean
- [x] Two isolated read-only reviewers PASS at this PR head:
  - Reviewer A (`REVIEWER_PROMPTS/security_reviewer.md`) — PASS on all 7 checks; cited verifier file:line for each carve-out and side-effect assertions for each negative test
  - Reviewer B (regression / no-overclaim / no-fake-proof / no-secret-leak / no-test-weakening / no-scope-creep) — PASS on all 7 axes
- [ ] PR-head CI green for all required checks
- [ ] Same-SHA real-green-gate fetched + classified (DeepSeek fallback flake expected per PR #298 history; will rerun if pattern matches)
- [ ] Normal squash-merge when all gates pass