### PR TITLE
B0 Slice A4 — system.remote.* WebAuthn challenge-issuance + sessionId-bearer carve-outs

### DIFF
--- a/src/api/http/routes/friday-system-routes.ts
+++ b/src/api/http/routes/friday-system-routes.ts
@@ -328,7 +328,16 @@ export function createFridaySystemRoutes(
       operationId: "system.remote.auth.register.options",
       method: "POST",
       path: "/v1/system/remote/auth/register/options",
-      auth: { public: true },
+      // B0 Slice A4 carve-out: WebAuthn registration challenge issuance is
+      // pre-auth by protocol design — the device has no bearer yet. The challenge
+      // itself is the trust handle for the downstream .register.verify step
+      // (already carved out in Slice A): server-issued challengeId, device-bound
+      // via the supplied deviceId, single-use (consumed in .verify), time-limited
+      // via challengeTtlMs. No persistent credential or session is granted by
+      // this endpoint. Negative test:
+      // test/unit/api/http/routes/friday-system-routes.test.ts
+      // ("A4 register.options: missing deviceId rejects before challenge issued").
+      auth: { public: true, allowUnauthenticatedMutation: true },
       async handler(ctx) {
         const body = ctx.body as FridayBeginSystemRemotePasskeyRegistrationRequest;
         requireString(body, "deviceId");
@@ -364,7 +373,13 @@ export function createFridaySystemRoutes(
       operationId: "system.remote.auth.assert.options",
       method: "POST",
       path: "/v1/system/remote/auth/assert/options",
-      auth: { public: true },
+      // B0 Slice A4 carve-out: WebAuthn assertion challenge issuance is pre-auth
+      // by protocol design — same rationale as register.options. Single-use,
+      // server-bound, device-bound, time-limited challenge consumed by the
+      // already-carved-out .assert.verify route. Negative test:
+      // test/unit/api/http/routes/friday-system-routes.test.ts
+      // ("A4 assert.options: missing deviceId rejects before challenge issued").
+      auth: { public: true, allowUnauthenticatedMutation: true },
       async handler(ctx) {
         const body = ctx.body as FridayBeginSystemRemotePasskeyAssertionRequest;
         requireString(body, "deviceId");
@@ -437,7 +452,20 @@ export function createFridaySystemRoutes(
       operationId: "system.remote.sessions.heartbeat",
       method: "POST",
       path: "/v1/system/remote/sessions/:sessionId/heartbeat",
-      auth: { public: true },
+      // B0 Slice A4 carve-out: the remote-session id minted by the carved-out
+      // `sessions.create` (which itself verifies the one-time assertionToken from
+      // a prior verifyAssertion step) is the trust handle here. The sessionId is
+      // a high-entropy server-issued UUIDv4, bound to a specific device row, and
+      // its lifecycle is owned by the server. Trust is verified by
+      // `deps.remote.heartbeatSession` → `systemService.touchRemoteSession`
+      // (`src/system/engine/friday-system-service.ts:1746-1794`): on unknown
+      // sessionId the lookup returns null before any write; on an inactive
+      // session the existing row is returned without touch; on a revoked device
+      // the session is auto-closed instead of touched. Negative test:
+      // test/unit/api/http/routes/friday-system-routes.test.ts
+      // ("A4 sessions.heartbeat: unknown sessionId is verified by deps.remote
+      //  and does not mutate state").
+      auth: { public: true, allowUnauthenticatedMutation: true },
       async handler(ctx) {
         const { sessionId } = ctx.params as { sessionId: string };
         const body = ctx.body as FridayHeartbeatSystemRemoteSessionRequest;
@@ -452,7 +480,16 @@ export function createFridaySystemRoutes(
       operationId: "system.remote.sessions.delete",
       method: "DELETE",
       path: "/v1/system/remote/sessions/:sessionId",
-      auth: { public: true },
+      // B0 Slice A4 carve-out: same sessionId-bearer rationale as
+      // sessions.heartbeat above. `deps.remote.closeSession` ultimately calls
+      // `repository.closeRemoteSession(db, id, ...)` which targets the row by id
+      // — an unknown id affects zero rows. The handler returns
+      // `{ closed: <bool>, sessionId }` truthfully reflecting whether a row was
+      // closed; no other session state is mutated. Negative test:
+      // test/unit/api/http/routes/friday-system-routes.test.ts
+      // ("A4 sessions.delete: unknown sessionId yields closed=false without
+      //  side effect on other sessions").
+      auth: { public: true, allowUnauthenticatedMutation: true },
       async handler(ctx) {
         const { sessionId } = ctx.params as { sessionId: string };
         return deps.remote.closeSession(sessionId);

--- a/test/unit/api/http/routes/friday-system-routes.test.ts
+++ b/test/unit/api/http/routes/friday-system-routes.test.ts
@@ -118,15 +118,27 @@ describe("createFridaySystemRoutes", () => {
   it("returns authenticated system route definitions", () => {
     const routes = createFridaySystemRoutes(makeDeps());
     expect(routes.length).toBeGreaterThan(0);
-    // Three pre-auth carve-outs require allowUnauthenticatedMutation:true
-    // because their handler delegates to a WebAuthn / one-time-token verifier
-    // that fails closed without a side effect when the input is bad. All other
-    // routes remain {public:true} only and rely on the server-level
-    // public-mutation gate.
+    // Pre-auth carve-outs require allowUnauthenticatedMutation:true. Slice A
+    // (PR #298) carved out the three .verify / sessions.create routes whose
+    // handlers consume a one-time WebAuthn challenge or assertion token. B0
+    // Slice A4 adds four more: the .options challenge issuance pair (challenge
+    // is single-use, server-bound, device-bound, time-limited; downstream
+    // .verify is the trust handle), and the sessions.heartbeat / sessions.delete
+    // pair (sessionId is a high-entropy server-issued UUID bearer, verified by
+    // the underlying remote-session service before any mutation). All other
+    // routes remain {public:true} only and rely on the Slice A server-level
+    // public-mutation gate; device-management routes intentionally stay
+    // default-blocked because their handlers have no in-process verifier.
     const carveOutOps = new Set([
+      // Slice A:
       "system.remote.auth.register.verify",
       "system.remote.auth.assert.verify",
       "system.remote.sessions.create",
+      // Slice A4:
+      "system.remote.auth.register.options",
+      "system.remote.auth.assert.options",
+      "system.remote.sessions.heartbeat",
+      "system.remote.sessions.delete",
     ]);
     for (const route of routes) {
       expect(route.path).toMatch(/^\/v1\/system\//);
@@ -555,5 +567,185 @@ describe("createFridaySystemRoutes", () => {
     // No downstream heartbeat or close on rejected open.
     expect(deps.remote.heartbeatSession).not.toHaveBeenCalled();
     expect(deps.remote.closeSession).not.toHaveBeenCalled();
+  });
+
+  // ─── B0 Slice A4: WebAuthn challenge-issuance + session-bearer carve-outs ───
+
+  it("A4: register.options + assert.options + sessions.heartbeat + sessions.delete declare the carve-out flag; devices.* routes do NOT", () => {
+    const routes = createFridaySystemRoutes(makeDeps());
+    const flagged = new Map<string, boolean>();
+    for (const r of routes) {
+      if (typeof r.auth === "object" && r.auth.public === true) {
+        flagged.set(
+          r.operationId,
+          (r.auth as { allowUnauthenticatedMutation?: true }).allowUnauthenticatedMutation === true,
+        );
+      }
+    }
+
+    // A4 carve-outs (this slice):
+    expect(flagged.get("system.remote.auth.register.options")).toBe(true);
+    expect(flagged.get("system.remote.auth.assert.options")).toBe(true);
+    expect(flagged.get("system.remote.sessions.heartbeat")).toBe(true);
+    expect(flagged.get("system.remote.sessions.delete")).toBe(true);
+
+    // Already carved out in Slice A (re-verified, not duplicated):
+    expect(flagged.get("system.remote.auth.register.verify")).toBe(true);
+    expect(flagged.get("system.remote.auth.assert.verify")).toBe(true);
+    expect(flagged.get("system.remote.sessions.create")).toBe(true);
+
+    // Default-blocked by Slice A's gate (NO carve-out — device-management requires
+    // an authenticated bound principal; no pre-auth use case):
+    expect(flagged.get("system.remote.devices.register")).toBe(false);
+    expect(flagged.get("system.remote.devices.delete")).toBe(false);
+    expect(flagged.get("system.remote.devices.passkey.delete")).toBe(false);
+  });
+
+  it("A4 register.options: missing deviceId rejects before challenge issued", async () => {
+    const deps = makeDeps();
+    const routes = createFridaySystemRoutes(deps);
+    const route = findRoute(routes, "system.remote.auth.register.options");
+
+    await expect(
+      route.handler(
+        makeCtx({
+          body: { idempotencyKey: "reg-options-1" }, // deviceId omitted
+          principal: null, // synthetic-public principal (reaches the handler via carve-out)
+        }),
+      ),
+    ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+
+    // Verifier-side proof: no challenge issued, no other passkey state changed.
+    expect(deps.remoteAuth.beginRegistration).not.toHaveBeenCalled();
+    expect(deps.remoteAuth.verifyRegistration).not.toHaveBeenCalled();
+    expect(deps.remoteAuth.beginAssertion).not.toHaveBeenCalled();
+    expect(deps.remoteAuth.verifyAssertion).not.toHaveBeenCalled();
+  });
+
+  it("A4 assert.options: missing deviceId rejects before challenge issued", async () => {
+    const deps = makeDeps();
+    const routes = createFridaySystemRoutes(deps);
+    const route = findRoute(routes, "system.remote.auth.assert.options");
+
+    await expect(
+      route.handler(
+        makeCtx({
+          body: { idempotencyKey: "assert-options-1" }, // deviceId omitted
+          principal: null,
+        }),
+      ),
+    ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+
+    expect(deps.remoteAuth.beginAssertion).not.toHaveBeenCalled();
+    expect(deps.remoteAuth.verifyAssertion).not.toHaveBeenCalled();
+    expect(deps.remoteAuth.beginRegistration).not.toHaveBeenCalled();
+    expect(deps.remoteAuth.verifyRegistration).not.toHaveBeenCalled();
+  });
+
+  it("A4 sessions.heartbeat: unknown sessionId is verified by deps.remote and does not mutate other sessions", async () => {
+    // Simulate the underlying behavior of `systemService.touchRemoteSession`:
+    // an unknown sessionId returns null without any write
+    // (`src/system/engine/friday-system-service.ts:1746-1755`).
+    const deps = makeDeps({
+      remote: {
+        list: vi.fn(),
+        register: vi.fn(),
+        revoke: vi.fn(),
+        clearPasskey: vi.fn(),
+        listSessions: vi.fn(),
+        openSession: vi.fn(),
+        heartbeatSession: vi.fn().mockResolvedValue({ session: null }),
+        closeSession: vi.fn(),
+      },
+    });
+    const routes = createFridaySystemRoutes(deps);
+    const route = findRoute(routes, "system.remote.sessions.heartbeat");
+
+    const result = await route.handler(
+      makeCtx({
+        params: { sessionId: "00000000-0000-4000-8000-000000000000" }, // forged but well-formed UUID
+        body: { idempotencyKey: "hb-1" },
+        principal: null, // synthetic-public reaches handler via carve-out
+      }),
+    );
+
+    // Handler returns the verifier's null verdict truthfully; no other session
+    // is touched, no session is closed, no device is registered.
+    expect(result).toEqual({ session: null });
+    expect(deps.remote.heartbeatSession).toHaveBeenCalledTimes(1);
+    expect(deps.remote.heartbeatSession).toHaveBeenCalledWith(
+      "00000000-0000-4000-8000-000000000000",
+      expect.objectContaining({ idempotencyKey: "hb-1" }),
+      expect.any(Object),
+    );
+    expect(deps.remote.closeSession).not.toHaveBeenCalled();
+    expect(deps.remote.openSession).not.toHaveBeenCalled();
+    expect(deps.remote.register).not.toHaveBeenCalled();
+    expect(deps.remote.revoke).not.toHaveBeenCalled();
+  });
+
+  it("A4 sessions.delete: unknown sessionId yields closed=false without side effect on other sessions", async () => {
+    // Underlying `repository.closeRemoteSession` targets the row by id; an
+    // unknown id affects 0 rows. The handler returns the truthful boolean.
+    const deps = makeDeps({
+      remote: {
+        list: vi.fn(),
+        register: vi.fn(),
+        revoke: vi.fn(),
+        clearPasskey: vi.fn(),
+        listSessions: vi.fn(),
+        openSession: vi.fn(),
+        heartbeatSession: vi.fn(),
+        closeSession: vi.fn().mockResolvedValue({
+          closed: false,
+          sessionId: "00000000-0000-4000-8000-000000000001",
+        }),
+      },
+    });
+    const routes = createFridaySystemRoutes(deps);
+    const route = findRoute(routes, "system.remote.sessions.delete");
+
+    const result = await route.handler(
+      makeCtx({
+        params: { sessionId: "00000000-0000-4000-8000-000000000001" },
+        principal: null,
+      }),
+    );
+
+    expect(result).toEqual({ closed: false, sessionId: "00000000-0000-4000-8000-000000000001" });
+    expect(deps.remote.closeSession).toHaveBeenCalledTimes(1);
+    expect(deps.remote.heartbeatSession).not.toHaveBeenCalled();
+    expect(deps.remote.openSession).not.toHaveBeenCalled();
+    expect(deps.remote.register).not.toHaveBeenCalled();
+    expect(deps.remote.revoke).not.toHaveBeenCalled();
+  });
+
+  it("A4 regression: authenticated principal can still call all 4 system.remote.* routes the slice carved out (register.options + assert.options + sessions.heartbeat + sessions.delete)", async () => {
+    // Sanity-check that A4 did not break the authenticated admin flow that was
+    // already working under Slice A. The makeCtx default principal is an
+    // authenticated admin.
+    const deps = makeDeps();
+    const routes = createFridaySystemRoutes(deps);
+
+    await findRoute(routes, "system.remote.auth.register.options").handler(
+      makeCtx({ body: { deviceId: "device-1", idempotencyKey: "reg-opt-key" } }),
+    );
+    await findRoute(routes, "system.remote.auth.assert.options").handler(
+      makeCtx({ body: { deviceId: "device-1", idempotencyKey: "assert-opt-key" } }),
+    );
+    await findRoute(routes, "system.remote.sessions.heartbeat").handler(
+      makeCtx({
+        params: { sessionId: "remote-session-1" },
+        body: { idempotencyKey: "hb-key" },
+      }),
+    );
+    await findRoute(routes, "system.remote.sessions.delete").handler(
+      makeCtx({ params: { sessionId: "remote-session-1" } }),
+    );
+
+    expect(deps.remoteAuth.beginRegistration).toHaveBeenCalledTimes(1);
+    expect(deps.remoteAuth.beginAssertion).toHaveBeenCalledTimes(1);
+    expect(deps.remote.heartbeatSession).toHaveBeenCalledTimes(1);
+    expect(deps.remote.closeSession).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

**B0 Slice A4 — system.remote.* WebAuthn boundary.** Per-route classification of the 7 routes the audit flagged in PR #298 (`docs/audits/b0-slice-a-ui-e2e-triage-2026-05-23.md:78-92`), executed per the user's ABA12 approval to "start A4 as its own B0 slice after A3 lands … design per-route verifier/negative tests … prove no public/default principal write bypass".

| Route | Action | Verifier |
|---|---|---|
| `system.remote.auth.register.options` | **carve out** | challenge-issuance: server-issued challengeId, device-bound, single-use, time-limited; consumed by Slice A's `.register.verify` |
| `system.remote.auth.assert.options` | **carve out** | same challenge-issuance rationale; consumed by Slice A's `.assert.verify` |
| `system.remote.sessions.heartbeat` | **carve out** | sessionId-bearer (high-entropy UUIDv4 minted by Slice A's `sessions.create`); `touchRemoteSession` returns `null` BEFORE any write on unknown id |
| `system.remote.sessions.delete` | **carve out** | sessionId-bearer; `repository.closeRemoteSession` UPDATE-by-id affects 0 rows on unknown id |
| `system.remote.devices.register` | stay default-blocked | no in-handler verifier; needs authenticated admin |
| `system.remote.devices.delete` | stay default-blocked | same |
| `system.remote.devices.passkey.delete` | stay default-blocked | same |

Carve-out flag delta vs `origin/main`: **+4**, all in `src/api/http/routes/friday-system-routes.ts`. No other route family widened.

## What changed (2 files, +238/-9)

- `src/api/http/routes/friday-system-routes.ts` — `allowUnauthenticatedMutation: true` + per-route verifier doc-comment for the 4 carve-outs (lines 331-340, 376-382, 455-468, 483-492). Handler bodies unchanged.
- `test/unit/api/http/routes/friday-system-routes.test.ts` — 5 new A4 tests + strengthened the existing inventory check at line 117 to enforce both presence (on the 4 carve-outs) and absence (on the 3 device-management routes).

## Test plan

- [x] `tsc --noEmit -p .` clean
- [x] `eslint` on touched scope — 0 errors, 5 pre-existing warnings
- [x] Focused: `vitest run` on system-routes unit + route-contract snapshot — 29/29 pass
- [x] Blast-radius: full `vitest run test/unit/api/` — 1507/1507 pass (vs 1499 pre-A4)
- [x] `npm run check:security-doctor` PASS
- [x] `npm run check:architecture-boundaries` PASS (no immutable-core file touched)
- [x] `npm run check:secret-patterns` clean
- [x] `git diff --check` clean
- [x] Two isolated reviewers PASS:
  - Reviewer A (`REVIEWER_PROMPTS/security_reviewer.md`) — 7/7 checks PASS; verifier file:line cited for each carve-out; one comment overstating rate-limit defense fixed before commit
  - Reviewer B (regression/no-overclaim/no-fake-proof/no-secret-leak/no-test-weakening/no-scope-creep/no-boundary-creep/dirty-file) — 8/8 checks PASS; verified inventory test strengthening, contract snapshot stability, no Tier-2 regression (transitive via Slice A's gate test)
- [ ] PR-head CI green for all required checks
- [ ] Same-SHA real-green-gate green
- [ ] Normal squash-merge when all gates pass

## What this slice does NOT do

- Does **not** widen any other route family. The flag delta vs `origin/main` is exactly +4.
- Does **not** introduce a loopback-as-identity pattern. A3's bootstrap-boundary remains scoped to setup routes only.
- Does **not** carve out the 3 device-management routes — they require an authenticated admin principal and stay default-blocked.
- Does **not** verify the underlying verifier cryptography. The slice proves the route-level wiring delegates correctly. The unknown-id branches of `touchRemoteSession` (line 1755) and `repository.closeRemoteSession` (UPDATE-by-id 0-row affect) are verified by source citation in the carve-out comments; a service-level negative test would close the mock-only gap in a follow-up (Reviewer A non-blocking concern).

## Closes

B0 batch's last system.remote.* follow-up. After A4 lands, B0 carries forward only: A2 already verified moot; A1-A5 + this slice fully address the 348 mutating-route audit. B0 closure handoff next.