### PR TITLE
B1 Slice 1 — label QQ unsupported at setup-route boundary

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -341,7 +341,7 @@
         "filename": "src/api/http/routes/friday-setup-routes.ts",
         "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
         "is_verified": false,
-        "line_number": 2078
+        "line_number": 2080
       }
     ],
     "src/media-understanding/friday-media-doctor.ts": [
@@ -1124,5 +1124,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-24T10:46:20Z"
+  "generated_at": "2026-05-24T15:40:30Z"
 }

--- a/src/api/http/routes/friday-setup-routes.ts
+++ b/src/api/http/routes/friday-setup-routes.ts
@@ -25,7 +25,9 @@ import {
   buildFridayChannelSecretRefKey,
   FRIDAY_CHANNEL_SECRET_SCOPE,
   FRIDAY_SUPPORTED_CHANNEL_KINDS,
+  FRIDAY_UNSUPPORTED_CHANNEL_KINDS,
   getFridayChannelSecretFieldDescriptors,
+  isFridayChannelKindSupported,
   parseFridayChannelsConfig,
   parseFridayChannelSecretRef,
 } from "#channels";
@@ -2437,6 +2439,18 @@ export function createFridaySetupRoutes(
         if (!VALID_CHANNEL_KINDS.has(body.kind)) {
           throw new FridayDomainError("VALIDATION_ERROR", `Invalid channel kind: ${String(body.kind)}`, { httpStatus: 400 });
         }
+        // B1 unsupported-channel boundary: refuse channel kinds labeled
+        // unsupported (currently QQ — see FRIDAY_UNSUPPORTED_CHANNEL_KINDS in
+        // friday-channel-config.ts and GLOBAL_DECISIONS_LOCKED.md "QQ is
+        // unsupported/proof_pending unless fixed and proven"). Test before
+        // running any credential validation.
+        if (!isFridayChannelKindSupported(body.kind)) {
+          throw new FridayDomainError(
+            "CHANNEL_KIND_UNSUPPORTED",
+            `Channel kind "${body.kind}" is currently unsupported. See product release notes for status.`,
+            { httpStatus: 409, details: { kind: body.kind, status: "unsupported" } },
+          );
+        }
         if (body.config !== null && body.config !== undefined && (typeof body.config !== "object" || Array.isArray(body.config))) {
           throw new FridayDomainError("VALIDATION_ERROR", `config must be an object for channel ${body.kind}`, { httpStatus: 400 });
         }
@@ -2490,6 +2504,16 @@ export function createFridaySetupRoutes(
           }
           if (typeof ch.kind !== "string" || !VALID_CHANNEL_KINDS.has(ch.kind)) {
             throw new FridayDomainError("VALIDATION_ERROR", `Invalid channel kind: ${String(ch.kind)}`, { httpStatus: 400 });
+          }
+          // B1 unsupported-channel boundary: refuse to save channels of
+          // unsupported kind (currently QQ). The schema still accepts the
+          // shape for backward-compat, but the runtime rejects activation.
+          if (!isFridayChannelKindSupported(ch.kind)) {
+            throw new FridayDomainError(
+              "CHANNEL_KIND_UNSUPPORTED",
+              `Channel kind "${ch.kind}" is currently unsupported. See product release notes for status.`,
+              { httpStatus: 409, details: { kind: ch.kind, status: "unsupported" } },
+            );
           }
           if (typeof ch.enabled !== "boolean") {
             throw new FridayDomainError("VALIDATION_ERROR", `enabled must be a boolean for channel ${ch.kind}`, { httpStatus: 400 });

--- a/src/channels/friday-channel-config.ts
+++ b/src/channels/friday-channel-config.ts
@@ -39,6 +39,35 @@ export const FRIDAY_SUPPORTED_CHANNEL_KINDS = [
 
 export type FridaySupportedChannelKind = (typeof FRIDAY_SUPPORTED_CHANNEL_KINDS)[number];
 
+/**
+ * Channel kinds that are recognized by the type system (still appear in
+ * `FRIDAY_SUPPORTED_CHANNEL_KINDS` for backward-compat schema validation) but
+ * MUST NOT be activated at runtime.
+ *
+ * B1 / GLOBAL_DECISIONS_LOCKED.md: "QQ is unsupported/proof_pending unless
+ * fixed and proven." QQ inbound is currently silently dropped by the channel
+ * registry's lifecycle/start arbitration (see `friday-channel-registry.ts`
+ * `buildStartPromise`). Until that root cause is fixed and end-to-end inbound
+ * delivery is proved, QQ must be labeled `unsupported` at every user-facing
+ * boundary: setup config validation, channel-registry activation, agent
+ * routing, UI.
+ *
+ * Adding a kind here does NOT delete its schema or types — the underlying
+ * source files remain so a future "support QQ" slice can re-enable cleanly
+ * once the lifecycle bug is fixed and live proof exists.
+ */
+export const FRIDAY_UNSUPPORTED_CHANNEL_KINDS: readonly FridaySupportedChannelKind[] = ["qq"] as const;
+
+const UNSUPPORTED_CHANNEL_KIND_SET = new Set<string>(FRIDAY_UNSUPPORTED_CHANNEL_KINDS);
+
+/**
+ * Returns `true` if the channel kind is recognized AND not labeled unsupported.
+ */
+export function isFridayChannelKindSupported(kind: string): boolean {
+  return (FRIDAY_SUPPORTED_CHANNEL_KINDS as readonly string[]).includes(kind)
+    && !UNSUPPORTED_CHANNEL_KIND_SET.has(kind);
+}
+
 export const FridayChannelInstanceConfigSchema = z.discriminatedUnion("kind", [
   FridayQqChannelConfigSchema,
   FridayLarkChannelConfigSchema,

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -58,12 +58,14 @@ export type {
 
 export {
   FRIDAY_SUPPORTED_CHANNEL_KINDS,
+  FRIDAY_UNSUPPORTED_CHANNEL_KINDS,
   FridayQqChannelConfigSchema,
   FridayLarkChannelConfigSchema,
   FridayChannelInstanceConfigSchema,
   FridayChannelsConfigSchema,
   parseFridayChannelsConfig,
   buildDefaultChannelsConfig,
+  isFridayChannelKindSupported,
 } from "./friday-channel-config.js";
 
 // ─── Security / Capability Matrix ───

--- a/test/unit/api/http/routes/friday-setup-routes.test.ts
+++ b/test/unit/api/http/routes/friday-setup-routes.test.ts
@@ -349,7 +349,7 @@ describe("createFridaySetupRoutes — B0 Slice A3 bootstrap boundary", () => {
       route.handler(
         makeCtx({
           ip: "127.0.0.1",
-          body: { kind: "qq", config: { appId: "test", appSecret: "test" } },
+          body: { kind: "qq", config: { appId: "test", appSecret: "test" } }, // pragma: allowlist secret
         }),
       ),
     ).rejects.toMatchObject({
@@ -372,7 +372,7 @@ describe("createFridaySetupRoutes — B0 Slice A3 bootstrap boundary", () => {
           body: {
             controlConfirmed: true,
             channels: [
-              { kind: "qq", enabled: true, config: { appId: "a", appSecret: "s" } },
+              { kind: "qq", enabled: true, config: { appId: "a", appSecret: "s" } }, // pragma: allowlist secret
             ],
           },
         }),
@@ -405,7 +405,7 @@ describe("createFridaySetupRoutes — B0 Slice A3 bootstrap boundary", () => {
           body: {
             controlConfirmed: true,
             channels: [
-              { kind: "qq", enabled: true, config: { appId: "a", appSecret: "s" } },
+              { kind: "qq", enabled: true, config: { appId: "a", appSecret: "s" } }, // pragma: allowlist secret
               { kind: "discord", enabled: false, config: {} },
               { kind: "telegram", enabled: false, config: {} },
             ],
@@ -437,7 +437,7 @@ describe("createFridaySetupRoutes — B0 Slice A3 bootstrap boundary", () => {
             controlConfirmed: true,
             channels: [
               { kind: "discord", enabled: false, config: {} },
-              { kind: "qq", enabled: true, config: { appId: "a", appSecret: "s" } },
+              { kind: "qq", enabled: true, config: { appId: "a", appSecret: "s" } }, // pragma: allowlist secret
             ],
           },
         }),

--- a/test/unit/api/http/routes/friday-setup-routes.test.ts
+++ b/test/unit/api/http/routes/friday-setup-routes.test.ts
@@ -331,4 +331,124 @@ describe("createFridaySetupRoutes — B0 Slice A3 bootstrap boundary", () => {
     });
     expect(writeTxn).not.toHaveBeenCalled();
   });
+
+  // ─── B1 Slice 1: QQ channel labeled unsupported ───
+  //
+  // GLOBAL_DECISIONS_LOCKED.md: "QQ is unsupported/proof_pending unless fixed
+  // and proven." QQ inbound is currently silently dropped by the channel
+  // registry's lifecycle/start arbitration. Until that root cause is fixed and
+  // end-to-end inbound delivery is proved, setup must refuse to test or save
+  // QQ channels. The schema still recognizes `kind: "qq"` for backward-compat,
+  // but the user-facing boundary fails closed with CHANNEL_KIND_UNSUPPORTED.
+
+  it("B1: setup.channels.test refuses kind='qq' with CHANNEL_KIND_UNSUPPORTED 409 (labeled unsupported)", async () => {
+    const { deps, writeTxn } = makeDeps({ setupCompletedAt: null });
+    const route = findMutatingRoute(createFridaySetupRoutes(deps), "setup.channels.test");
+
+    await expect(
+      route.handler(
+        makeCtx({
+          ip: "127.0.0.1",
+          body: { kind: "qq", config: { appId: "test", appSecret: "test" } },
+        }),
+      ),
+    ).rejects.toMatchObject({
+      code: "CHANNEL_KIND_UNSUPPORTED",
+      httpStatus: 409,
+    });
+
+    // Verifier-side proof: no credential validation, no test connection, no DB write.
+    expect(writeTxn).not.toHaveBeenCalled();
+  });
+
+  it("B1: setup.channels.save refuses any channels[].kind='qq' with CHANNEL_KIND_UNSUPPORTED 409", async () => {
+    const { deps, writeTxn, activateSavedChannels, onChannelsSaved } = makeDeps({ setupCompletedAt: null });
+    const route = findMutatingRoute(createFridaySetupRoutes(deps), "setup.channels.save");
+
+    await expect(
+      route.handler(
+        makeCtx({
+          ip: "127.0.0.1",
+          body: {
+            controlConfirmed: true,
+            channels: [
+              { kind: "qq", enabled: true, config: { appId: "a", appSecret: "s" } },
+            ],
+          },
+        }),
+      ),
+    ).rejects.toMatchObject({
+      code: "CHANNEL_KIND_UNSUPPORTED",
+      httpStatus: 409,
+    });
+
+    // Verifier-side proof: no channel persisted, no activation, no callback fired.
+    expect(writeTxn).not.toHaveBeenCalled();
+    expect(activateSavedChannels).not.toHaveBeenCalled();
+    expect(onChannelsSaved).not.toHaveBeenCalled();
+  });
+
+  it("B1: setup.channels.save fails on QQ before checking other per-channel verification (no partial persistence)", async () => {
+    // Defense-in-depth: when QQ appears in the channel batch, the unsupported
+    // check fires per-iteration and the loop throws before any subsequent
+    // channel's verification or any DB write begins. Position QQ FIRST in the
+    // list so this test isolates the unsupported-check; A subsequent test
+    // case proves the order-independence by re-running with QQ later (under
+    // disabled flags on others so we don't fight per-channel verification).
+    const { deps, writeTxn, activateSavedChannels, onChannelsSaved } = makeDeps({ setupCompletedAt: null });
+    const route = findMutatingRoute(createFridaySetupRoutes(deps), "setup.channels.save");
+
+    await expect(
+      route.handler(
+        makeCtx({
+          ip: "127.0.0.1",
+          body: {
+            controlConfirmed: true,
+            channels: [
+              { kind: "qq", enabled: true, config: { appId: "a", appSecret: "s" } },
+              { kind: "discord", enabled: false, config: {} },
+              { kind: "telegram", enabled: false, config: {} },
+            ],
+          },
+        }),
+      ),
+    ).rejects.toMatchObject({
+      code: "CHANNEL_KIND_UNSUPPORTED",
+      httpStatus: 409,
+    });
+
+    expect(writeTxn).not.toHaveBeenCalled();
+    expect(activateSavedChannels).not.toHaveBeenCalled();
+    expect(onChannelsSaved).not.toHaveBeenCalled();
+  });
+
+  it("B1: setup.channels.save still rejects QQ when QQ appears AFTER a supported disabled channel (order-independent)", async () => {
+    // Supplementary case: when QQ is in a mid-list position, the unsupported
+    // check still fires (validation loop iterates from index 0 forward and
+    // throws on first unsupported entry).
+    const { deps, writeTxn, activateSavedChannels, onChannelsSaved } = makeDeps({ setupCompletedAt: null });
+    const route = findMutatingRoute(createFridaySetupRoutes(deps), "setup.channels.save");
+
+    await expect(
+      route.handler(
+        makeCtx({
+          ip: "127.0.0.1",
+          body: {
+            controlConfirmed: true,
+            channels: [
+              { kind: "discord", enabled: false, config: {} },
+              { kind: "qq", enabled: true, config: { appId: "a", appSecret: "s" } },
+            ],
+          },
+        }),
+      ),
+    ).rejects.toMatchObject({
+      code: "CHANNEL_KIND_UNSUPPORTED",
+      httpStatus: 409,
+    });
+
+    expect(writeTxn).not.toHaveBeenCalled();
+    expect(activateSavedChannels).not.toHaveBeenCalled();
+    expect(onChannelsSaved).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

**B1 Slice 1 — QQ unsupported labeling.** Implements `GLOBAL_DECISIONS_LOCKED.md`: "QQ is unsupported/proof_pending unless fixed and proven." Per the user's ABA12 (HANDOFFS/20260524-1210-B1-entry-aba12-stop.md option 1), this slice labels QQ as unsupported at the user-facing setup-route boundary; the channel-registry connect-vs-start root-cause fix is the next slice.

Why this is the right user-facing boundary: `setup.channels.save` is the only legitimate path that persists an `enabled: true` channel instance to `friday_setup_state.channels_json`. Without that persisted entry, the registry never gets a QQ instance to activate. The setup-route gate is the necessary user-visible truth-labeling.

## What changed (4 files, +175/-0)

| File | Change |
|---|---|
| `src/channels/friday-channel-config.ts` | Adds `FRIDAY_UNSUPPORTED_CHANNEL_KINDS = ["qq"]` + `isFridayChannelKindSupported(kind)` predicate (does not delete the QQ schema — HR11) |
| `src/channels/index.ts` | Re-exports the new const + predicate |
| `src/api/http/routes/friday-setup-routes.ts` | `setup.channels.test` + `setup.channels.save` throw `CHANNEL_KIND_UNSUPPORTED` (409) BEFORE any normalize/test/secret-write/DB-write/activation |
| `test/unit/api/http/routes/friday-setup-routes.test.ts` | 4 new tests covering both routes + order-independence + spy assertions on writeTxn / activateSavedChannels / onChannelsSaved |

## What this slice does NOT do

- Does NOT block QQ at the channel-registry `register()` path. The next slice fixes that.
- Does NOT block QQ at agent-routing. The QQ cases in `friday-deterministic-dispatch.ts:676,726` are setup-hint strings only.
- Does NOT delete the QQ schema files or remove `"qq"` from `FRIDAY_SUPPORTED_CHANNEL_KINDS`. Backward-compat preserved per HR11.
- Does NOT touch `FridayChannelInstanceConfigSchema` (the discriminated union still includes `FridayQqChannelConfigSchema`).

## Test plan

- [x] `tsc --noEmit -p .` clean
- [x] `eslint` on touched scope — 0 errors
- [x] Focused: `vitest run` on friday-setup-routes unit — 32/32 (+4 from this slice)
- [x] Blast-radius: full `vitest run test/unit/api/` + contracts — 1525 + 67 PASS (+4 vs pre-slice)
- [x] `npm run check:security-doctor` PASS
- [x] `npm run check:architecture-boundaries` PASS
- [x] `npm run check:secret-patterns` clean
- [x] `git diff --check` clean
- [x] Two isolated reviewers PASS:
  - Reviewer A (`REVIEWER_PROMPTS/security_reviewer.md`) — 7/7 checks PASS with verifier file:line cites for both routes; confirmed line-ordering safety (check fires before any side effect)
  - Reviewer B (regression / no-overclaim / no-fake-proof / no-secret-leak / no-test-weakening / no-scope-creep / no-boundary-creep / dirty-file) — 8/8 PASS; confirmed no impact on channel-registry/agent-routing tests, no help-text creep, no schema deletion
- [ ] PR-head CI green for all required checks
- [ ] Same-SHA real-green-gate green
- [ ] Normal squash-merge when all gates pass

## Closes

User-visible "QQ unsupported" labeling per locked decision. Channel-registry root-cause fix is the immediate follow-up slice (B1 Slice 2).