### PR TITLE
B1 Slice 2 — harden channel-registry lifecycle precedence contract

### DIFF
--- a/src/channels/friday-channel-registry.ts
+++ b/src/channels/friday-channel-registry.ts
@@ -192,6 +192,14 @@ export function createFridayChannelRegistry(options?: FridayChannelRegistryOptio
       }
     };
 
+    // B1 channel-registry lifecycle precedence: when `adapters.lifecycle` is
+    // provided, the registry uses `lifecycle.connect()` exclusively for
+    // connection management and event wiring. `plugin.start()` is NOT called
+    // from this path even though the plugin contract requires it to exist —
+    // see the precedence note on `FridayChannelPlugin.start` in
+    // friday-channel.types.ts. Plugins that ship both MUST keep `start()` as a
+    // safe delegate (with a re-entry guard) or a no-op. A diverged `start()`
+    // would silently lose its effects under registry-managed activation.
     if (lifecycle) {
       const wrappedEventHandler = (rawEvent: unknown) => {
         if (inbound) {
@@ -300,6 +308,16 @@ export function createFridayChannelRegistry(options?: FridayChannelRegistryOptio
       }
       entries.set(plugin.kind, { plugin, allowlist, running: false });
       healthState.set(plugin.kind, { restartCount: 0 });
+      // B1 channel-registry lifecycle precedence diagnostic: when a plugin
+      // declares both adapters.lifecycle and start(), the registry will use
+      // lifecycle.connect() only. Log once at register-time so plugin authors
+      // know start() must be a safe delegate or no-op (see
+      // FridayChannelPlugin.start docstring).
+      if (plugin.adapters?.lifecycle) {
+        console.info(
+          `[friday][channel-registry] Plugin "${plugin.kind}" registered with adapters.lifecycle; registry will use lifecycle.connect() — plugin.start() will not be invoked by registry-managed activation.`,
+        );
+      }
     },
 
     async unregister(kind) {

--- a/src/channels/friday-channel.types.ts
+++ b/src/channels/friday-channel.types.ts
@@ -157,6 +157,27 @@ export interface FridayChannelPlugin {
    * Start receiving messages.
    * Opens gateway/websocket connections and begins message ingestion.
    * Calls `onMessage` for each inbound message.
+   *
+   * **Precedence with `adapters.lifecycle`** (B1 channel-registry lifecycle):
+   * When the plugin also declares `adapters.lifecycle`, the channel registry
+   * uses `adapters.lifecycle.connect()` exclusively — `start()` is NOT called
+   * from the registry path. Plugins that ship both MUST ensure `start()` is
+   * either:
+   *   - a safe delegate to `lifecycle.connect()` with a re-entry guard so a
+   *     subsequent manual `start()` call after the registry has already
+   *     connected is a no-op (see `friday-discord-channel.ts:349-357` for the
+   *     reference idiom: `start()` delegates to `lifecycleAdapter.connect`,
+   *     and the lifecycle adapter's `connect` has a "if connected, return"
+   *     guard at the top), OR
+   *   - genuinely a no-op stub for non-registry callers.
+   *
+   * A plugin that has `adapters.lifecycle` AND a `start()` that does
+   * meaningful work distinct from `lifecycle.connect()` will silently lose
+   * the `start()` behavior under registry-managed activation. The QQ channel
+   * was such a plugin (now labeled unsupported in `FRIDAY_UNSUPPORTED_CHANNEL_KINDS`)
+   * — the fix for QQ when it is re-enabled must collapse its `start()` and
+   * `lifecycle.connect()` into a single source of truth before re-listing it
+   * in `FRIDAY_SUPPORTED_CHANNEL_KINDS`.
    */
   start(onMessage: (msg: FridayChannelMessage) => void): Promise<void>;
 

--- a/test/unit/channels/friday-channel-registry.test.ts
+++ b/test/unit/channels/friday-channel-registry.test.ts
@@ -738,4 +738,87 @@ describe("FridayChannelRegistry", () => {
       await expect(registry.signalTyping("qq", "chat-1")).resolves.toBeUndefined();
     });
   });
+
+  // ─── B1 channel-registry lifecycle precedence ───
+  //
+  // When a plugin declares both `adapters.lifecycle` AND `plugin.start()`, the
+  // registry uses `lifecycle.connect()` exclusively. `plugin.start()` is NOT
+  // called by registry-managed activation. Plugins that ship both must keep
+  // `start()` as a safe delegate (with a re-entry guard) or a no-op.
+  //
+  // See:
+  //   - FridayChannelPlugin.start docstring in friday-channel.types.ts
+  //   - friday-channel-registry.ts buildStartPromise precedence comment
+  //   - HANDOFFS/20260524-1240-B1-slice1-qq-pr303-merged.md (QQ unsupported labeling)
+
+  describe("B1 lifecycle precedence: lifecycle.connect() is exclusive", () => {
+    it("calls only adapters.lifecycle.connect() — plugin.start() is NOT invoked when both exist", async () => {
+      const onConnect = vi.fn(async (_handler: (rawEvent: unknown) => void) => {});
+      const onStart = vi.fn(async (_handler: (msg: FridayChannelMessage) => void) => {});
+      const plugin = createMockPlugin("with-lifecycle", {
+        adapters: {
+          lifecycle: {
+            connect: onConnect,
+            disconnect: async () => {},
+          },
+        },
+        start: onStart,
+      });
+      registry.register(plugin);
+
+      await registry.startAll(() => {});
+
+      expect(onConnect).toHaveBeenCalledTimes(1);
+      expect(onStart).not.toHaveBeenCalled();
+    });
+
+    it("falls back to plugin.start() when no adapters.lifecycle is provided", async () => {
+      const onStart = vi.fn(async (_handler: (msg: FridayChannelMessage) => void) => {});
+      const plugin = createMockPlugin("no-lifecycle", { start: onStart });
+      // No adapters.lifecycle.
+      registry.register(plugin);
+
+      await registry.startAll(() => {});
+
+      expect(onStart).toHaveBeenCalledTimes(1);
+    });
+
+    it("emits an INFO log at register-time when a plugin declares adapters.lifecycle (advises author that start() is bypassed)", () => {
+      const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+      try {
+        const plugin = createMockPlugin("with-lifecycle-warn", {
+          adapters: {
+            lifecycle: {
+              connect: async () => {},
+              disconnect: async () => {},
+            },
+          },
+        });
+        registry.register(plugin);
+
+        expect(infoSpy).toHaveBeenCalledTimes(1);
+        const [message] = infoSpy.mock.calls[0]!;
+        expect(message).toContain("with-lifecycle-warn");
+        expect(message).toContain("lifecycle.connect()");
+        expect(message).toContain("plugin.start()");
+      } finally {
+        infoSpy.mockRestore();
+      }
+    });
+
+    it("does NOT emit the precedence INFO log when only plugin.start() is provided", () => {
+      const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+      try {
+        const plugin = createMockPlugin("legacy-start-only");
+        registry.register(plugin);
+        // No precedence advisory expected.
+        const precedenceLogs = infoSpy.mock.calls.filter(([msg]) =>
+          typeof msg === "string" && msg.includes("lifecycle.connect()"),
+        );
+        expect(precedenceLogs).toHaveLength(0);
+      } finally {
+        infoSpy.mockRestore();
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary

**B1 Slice 2 — channel-registry lifecycle precedence.** Documents + tests the existing precedence rule in the channel-registry: when a plugin declares `adapters.lifecycle`, `lifecycle.connect()` is the exclusive registry-path activation; `plugin.start()` is NOT called.

This follows B1 Slice 1 (#303, merge `d1498ffa`) which labeled QQ unsupported at the user-facing setup-route boundary. The audit's "CRITICAL CONTRACT VIOLATION" framing referenced this registry behavior, but after surveying the in-tree plugins (Discord, IRC, Line, Telegram), they all delegate `start()` to `lifecycle.connect()` with a re-entry guard. Only QQ had a divergent `start()` — and QQ is now unsupported. So the registry's behavior is correct for production plugins; this slice prevents future plugins from silently repeating QQ's mistake.

**Net: documentation + diagnostic log + tests. No runtime behavior change.**

## What changed (3 files, +122/-0)

| File | Change |
|---|---|
| `src/channels/friday-channel.types.ts` | 25-line precedence docstring on `FridayChannelPlugin.start` explaining bypass + naming Discord reference idiom |
| `src/channels/friday-channel-registry.ts` | Precedence comment block above the `if (lifecycle)` branch; one-time register-time `console.info` advisory when `adapters.lifecycle` is declared |
| `test/unit/channels/friday-channel-registry.test.ts` | 4 new tests: precedence (lifecycle wins), fallback (start wins when no lifecycle), INFO log emitted with lifecycle, INFO log NOT emitted with only start |

## What this slice does NOT do

- Does **not** change runtime behavior. `buildStartPromise` body byte-identical to origin/main.
- Does **not** make `plugin.start` optional in the type. Contract still requires it for legacy/non-registry callers.
- Does **not** enforce `FRIDAY_UNSUPPORTED_CHANNEL_KINDS` at registry `register()`. Slice 1 closed that at the user-facing setup-route boundary; registry-level defense-in-depth is a separate follow-up.
- Does **not** modify any auth/route/permission surface.

## Test plan

- [x] `tsc --noEmit -p .` clean
- [x] `eslint` on touched scope — 0 errors
- [x] Focused: `vitest run test/unit/channels/friday-channel-registry.test.ts` — 40/40 (existing 36 + 4 new); contracts 67/67
- [x] Blast-radius: `vitest run test/unit/channels/ test/unit/api/http/routes/friday-setup-routes.test.ts test/contracts/` — 471 tests + 67 contracts PASS
- [x] `npm run check:security-doctor` PASS
- [x] `npm run check:architecture-boundaries` PASS
- [x] `npm run check:secret-patterns` clean
- [x] `git diff --check` clean
- [x] Two isolated reviewers PASS:
  - Reviewer A (`REVIEWER_PROMPTS/security_reviewer.md`) — 7/7 with verifier file:line cites; confirmed buildStartPromise body unchanged, docstring accurate, no boundary widening
  - Reviewer B (regression / no-overclaim / no-fake-proof / no-secret-leak / no-test-weakening / no-scope-creep / no-boundary-creep / dirty-file) — 8/8; confirmed pure additions (122+/0-), no test weakening, no INFO log breaks any existing test
- [ ] PR-head CI green for all required checks
- [ ] Same-SHA real-green-gate green
- [ ] Normal squash-merge when all gates pass

## Closes

The B1 channel-registry lifecycle question per the user's ABA12 ("After A3 lands: start A4 as its own B0 slice... do not bundle"). The 6 critical B1 findings are now addressed: Slice 1 blocks QQ at the setup-route boundary; Slice 2 hardens the contract so any future plugin author gets a register-time advisory if they ship both `lifecycle.connect()` and a divergent `start()`.