### PR TITLE
B1 Slice 3 — generator validator refuses runtime kinds without safety scans

### DIFF
--- a/src/skills/generator/validation/friday-generated-skill-safety-validator.ts
+++ b/src/skills/generator/validation/friday-generated-skill-safety-validator.ts
@@ -179,6 +179,29 @@ function extractShellCommands(content: string): string[] {
   return commands;
 }
 
+// ─── Generator-supported runtime kinds ───
+//
+// B1 truth-labeling: `validateGeneratedCode` only implements runtime-specific
+// safety scans for `node` (UNSUPPORTED_RUNTIME_HELPER_IMPORTS,
+// UNSUPPORTED_RUNTIME_HELPER_CALLS, DANGEROUS_NODE_IMPORTS) and `shell`
+// (shebang enforcement, DANGEROUS_SHELL_PATTERNS, SHELL_COMMAND_ALLOWLIST).
+//
+// The manifest schema (`friday-skill-manifest.schema.ts:50`) accepts five
+// runtime kinds: builtin, node, python, shell, remote-http. Skills with runtime
+// `python` or `remote-http` would currently pass validation WITHOUT any
+// runtime-specific scan because the language detector returns "unknown" for
+// .py / etc, and the node/shell branches do not fire. `builtin` is never a
+// generation target (the hub ships its own builtin skills).
+//
+// Per AUTO_DECISION_POLICY ("prefer truthful unsupported over pretending"),
+// the generator refuses to validate (and therefore refuses to ship) skills
+// whose runtime is not in the safety-scan set. Adding `python` here requires
+// python-specific safety scans (dangerous imports, exec/eval/os.system,
+// subprocess.Popen with shell=True, etc.) — that is a separate slice.
+// Adding `remote-http` requires URL/auth/CORS validation — also a separate
+// slice. `builtin` would require schema changes upstream.
+const GENERATOR_SUPPORTED_RUNTIME_KINDS: ReadonlyArray<SkillManifestV2["runtime"]["kind"]> = ["node", "shell"];
+
 // ─── Main validation function ───
 
 export function validateGeneratedCode(
@@ -187,6 +210,22 @@ export function validateGeneratedCode(
 ): FridayGeneratedSkillValidationIssue[] {
   const issues: FridayGeneratedSkillValidationIssue[] = [];
   const runtimeKind = manifest.runtime.kind;
+
+  // B1 truth-labeling: refuse runtime kinds that have no runtime-specific
+  // safety scans implemented. Without this gate, a generated python skill
+  // would pass validation despite the language-specific safety checks never
+  // running. This is fail-closed against silent unsupported generation.
+  if (!GENERATOR_SUPPORTED_RUNTIME_KINDS.includes(runtimeKind)) {
+    issues.push({
+      code: "RUNTIME_KIND_NOT_GENERATABLE",
+      severity: "error",
+      message: `Generator does not yet support runtime kind "${runtimeKind}" — runtime-specific safety scans are not implemented for this runtime. Supported runtimes: ${GENERATOR_SUPPORTED_RUNTIME_KINDS.join(", ")}.`,
+    });
+    // Fall through to also run per-file checks (count, size, path traversal,
+    // entrypoint existence). Those scans are runtime-agnostic and still useful
+    // when a file list is present, but the RUNTIME_KIND_NOT_GENERATABLE error
+    // alone is sufficient to fail-close generation.
+  }
 
   // File count check
   if (files.length > MAX_FILE_COUNT) {

--- a/test/unit/skills/generator/validation/friday-generated-skill-safety-validator.test.ts
+++ b/test/unit/skills/generator/validation/friday-generated-skill-safety-validator.test.ts
@@ -328,4 +328,110 @@ describe("validateGeneratedCode", () => {
     // Should not detect shell patterns because runtime.kind is "node"
     expect(issues.some((i) => i.code === "DANGEROUS_SHELL_PATTERN")).toBe(false);
   });
+
+  // ─── B1 truth-labeling: refuse runtime kinds without safety scans ───
+
+  it("B1: refuses runtime.kind='python' with RUNTIME_KIND_NOT_GENERATABLE", () => {
+    const manifest = makeManifest({
+      runtime: {
+        kind: "python",
+        entrypoint: "main.py",
+        minHubVersion: "0.1.0",
+        apiVersion: "1",
+        timeoutMsDefault: 30000,
+      },
+    });
+    const issues = validateGeneratedCode(
+      [
+        makeFile({
+          path: "main.py",
+          language: "python",
+          content: "def execute(input):\n    return {}\n",
+        }),
+      ],
+      manifest,
+    );
+    const runtimeIssue = issues.find((i) => i.code === "RUNTIME_KIND_NOT_GENERATABLE");
+    expect(runtimeIssue).toBeDefined();
+    expect(runtimeIssue?.severity).toBe("error");
+    expect(runtimeIssue?.message).toContain("python");
+    expect(runtimeIssue?.message).toContain("node, shell");
+  });
+
+  it("B1: refuses runtime.kind='remote-http' with RUNTIME_KIND_NOT_GENERATABLE", () => {
+    const manifest = makeManifest({
+      runtime: {
+        kind: "remote-http",
+        entrypoint: "config.json",
+        minHubVersion: "0.1.0",
+        apiVersion: "1",
+        timeoutMsDefault: 30000,
+      },
+    });
+    const issues = validateGeneratedCode(
+      [makeFile({ path: "config.json", language: "json", content: '{"url":"https://example.com"}' })],
+      manifest,
+    );
+    expect(issues.some((i) => i.code === "RUNTIME_KIND_NOT_GENERATABLE" && i.severity === "error")).toBe(true);
+  });
+
+  it("B1: refuses runtime.kind='builtin' with RUNTIME_KIND_NOT_GENERATABLE", () => {
+    // 'builtin' is reserved for hub-shipped skills; the generator should not
+    // emit drafts for this kind.
+    const manifest = makeManifest({
+      runtime: {
+        kind: "builtin",
+        entrypoint: "builtin.json",
+        minHubVersion: "0.1.0",
+        apiVersion: "1",
+        timeoutMsDefault: 30000,
+      },
+    });
+    const issues = validateGeneratedCode(
+      [makeFile({ path: "builtin.json", language: "json", content: "{}" })],
+      manifest,
+    );
+    expect(issues.some((i) => i.code === "RUNTIME_KIND_NOT_GENERATABLE" && i.severity === "error")).toBe(true);
+  });
+
+  it("B1: still emits RUNTIME_KIND_NOT_GENERATABLE even when other validation issues are present (no error suppression)", () => {
+    const manifest = makeManifest({
+      runtime: {
+        kind: "python",
+        entrypoint: "main.py",
+        minHubVersion: "0.1.0",
+        apiVersion: "1",
+        timeoutMsDefault: 30000,
+      },
+    });
+    // Provide files that ALSO trigger PATH_TRAVERSAL — both issues should appear.
+    const issues = validateGeneratedCode(
+      [makeFile({ path: "../escape.py", language: "python", content: "" })],
+      manifest,
+    );
+    expect(issues.some((i) => i.code === "RUNTIME_KIND_NOT_GENERATABLE")).toBe(true);
+    expect(issues.some((i) => i.code === "PATH_TRAVERSAL")).toBe(true);
+  });
+
+  it("B1: does NOT emit RUNTIME_KIND_NOT_GENERATABLE for runtime.kind='node' (regression)", () => {
+    const issues = validateGeneratedCode([makeFile()], makeManifest());
+    expect(issues.some((i) => i.code === "RUNTIME_KIND_NOT_GENERATABLE")).toBe(false);
+  });
+
+  it("B1: does NOT emit RUNTIME_KIND_NOT_GENERATABLE for runtime.kind='shell' (regression)", () => {
+    const manifest = makeManifest({
+      runtime: {
+        kind: "shell",
+        entrypoint: "run.sh",
+        minHubVersion: "0.1.0",
+        apiVersion: "1",
+        timeoutMsDefault: 30000,
+      },
+    });
+    const issues = validateGeneratedCode(
+      [makeFile({ path: "run.sh", language: "bash", content: '#!/usr/bin/env bash\necho "{}"' })],
+      manifest,
+    );
+    expect(issues.some((i) => i.code === "RUNTIME_KIND_NOT_GENERATABLE")).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

**B1 Slice 3 — generator validator truth-labeling.** Closes a silent-bypass gap in `validateGeneratedCode`: skills with `runtime.kind` set to `python`, `remote-http`, or `builtin` would pass validation WITHOUT any runtime-specific safety scan because the language detector returns "unknown" for .py / etc. and the node/shell branches do not fire.

Per AUTO_DECISION_POLICY "prefer truthful unsupported over pretending", the validator now emits a severity:"error" `RUNTIME_KIND_NOT_GENERATABLE` issue when `manifest.runtime.kind` is not in `GENERATOR_SUPPORTED_RUNTIME_KINDS = ["node", "shell"]`.

## What changed (2 files, +145/-0)

| File | Change |
|---|---|
| `src/skills/generator/validation/friday-generated-skill-safety-validator.ts` | 20-line docstring + type-locked `GENERATOR_SUPPORTED_RUNTIME_KINDS` const + new gate as the first check inside `validateGeneratedCode` |
| `test/unit/skills/generator/validation/friday-generated-skill-safety-validator.test.ts` | 6 new tests: python/remote-http/builtin rejection + double-issue (no error suppression) + node/shell regression |

## What this slice does NOT do

- Does NOT implement python safety scans (next slice). Adding python to the supported set requires python-specific scans (dangerous imports, exec/eval/os.system, subprocess.Popen with shell=True, etc.).
- Does NOT implement remote-http URL/auth/CORS validation.
- Does NOT touch `builtin` (reserved for hub-shipped skills, never a generation target).

## Test plan

- [x] `tsc --noEmit -p .` clean; `eslint` 0 errors
- [x] Focused: 28/28 validator tests (+6)
- [x] Blast-radius: 936 tests across `test/unit/skills/` + contracts
- [x] `check:security-doctor` + `check:architecture-boundaries` PASS
- [x] Secret scan + `git diff --check` clean
- [x] Two isolated reviewers PASS (A: 7/7 security; B: 8/8 regression/no-overclaim/etc.)
- [ ] PR-head CI green
- [ ] Same-SHA real-green-gate green
- [ ] Normal squash-merge

## Closes

The B1 generator-validator coverage-gap entry from `HANDOFFS/20260524-1230-B1-session-pause-with-options.md` (option 2).