### PR TITLE
B1 Slice 4 — truth-label skills lifecycle catalog stubs as proof_pending

### DIFF
--- a/src/skills/services/friday-skill-lifecycle-service.ts
+++ b/src/skills/services/friday-skill-lifecycle-service.ts
@@ -880,6 +880,28 @@ function enrichSummary(input: {
 export function createFridaySkillLifecycleService(
   deps: CreateFridaySkillLifecycleServiceDeps,
 ): FridaySkillLifecycleService {
+  // B1 truth-labeling: this lifecycle service ships without a wired catalog
+  // backend. `getCatalogCandidates` and `getSource` below are placeholders
+  // that return empty/undefined so summaries built from persisted/registry
+  // state still render. Public `listCatalog` will return an empty result and
+  // `getSkill(...).sourceDetails` / `.catalogEntry` will be undefined regardless
+  // of which skillId is asked for. Emit a one-time INFO so operators reading
+  // diagnostics can see this is a known proof_pending feature, not data loss.
+  console.info(
+    "[friday][skill-lifecycle] Catalog backend is not wired in this build — listCatalog() returns empty and getSkill() omits sourceDetails/catalogEntry. This is proof_pending per B1; persisted + registry-based summaries remain truthful.",
+  );
+
+  /**
+   * B1 catalog stub: returns `[]` for every skillId. The lifecycle service
+   * does not currently have a catalog repository wired through
+   * `CreateFridaySkillLifecycleServiceDeps`. Until a real catalog backend
+   * lands, every catalog-derived field in summaries (`catalogEntry`,
+   * `sourceDetails`, `sourceId`, `latestVersion` derived from catalog, etc.)
+   * is unavailable. Persisted DB state + in-memory registry state still
+   * power the rest of the summary.
+   *
+   * See `listCatalog` and `getSkill` below for the public surface.
+   */
   function getCatalogCandidates(skillId: string): FridaySkillCatalogItem[] {
     void skillId;
     return [];
@@ -903,6 +925,10 @@ export function createFridaySkillLifecycleService(
     );
   }
 
+  /**
+   * B1 catalog-source stub: returns `undefined` for every sourceId. Paired
+   * with `getCatalogCandidates`; see the rationale comment on that function.
+   */
   function getSource(sourceId?: string): FridaySkillSourceEntity | undefined {
     void sourceId;
     return undefined;
@@ -1244,6 +1270,19 @@ export function createFridaySkillLifecycleService(
       return [...summaries.values()].sort((left, right) => left.name.localeCompare(right.name));
     },
 
+    /**
+     * B1 truth-labeling note: this method returns `{ items: [], total: 0 }`
+     * for ALL queries because the lifecycle service ships without a wired
+     * catalog backend (see `getCatalogCandidates` stub above and the
+     * `console.info` advisory at service-creation time). An empty result is
+     * truthful — there ARE no catalog items in this build — but operators
+     * consuming the response should not interpret it as "user has not added
+     * anything"; it means "catalog feature is proof_pending."
+     *
+     * Future: wire a real catalog repository (likely a new dep slot in
+     * `CreateFridaySkillLifecycleServiceDeps`) and update this method + the
+     * `getCatalogCandidates` stub in lock-step.
+     */
     listCatalog(query) {
       void query;
       const result: FridaySkillCatalogResult = { items: [], total: 0 };
@@ -1254,6 +1293,15 @@ export function createFridaySkillLifecycleService(
       };
     },
 
+    /**
+     * B1 truth-labeling note: `sourceDetails` and `catalogEntry` will always be
+     * `undefined` in this build because the catalog backend is not wired
+     * (see `getCatalogCandidates` / `getSource` stubs and the `console.info`
+     * advisory at service-creation time). The persisted-skill + registered-skill
+     * portions of the summary are real; only the catalog-derived enrichments
+     * are unavailable. Callers should not treat the absence of `catalogEntry`
+     * as "no source available" — it means "catalog feature is proof_pending."
+     */
     getSkill(skillId) {
       const summary = buildSummary(skillId);
       if (!summary) {

--- a/test/unit/skills/lifecycle/friday-skill-lifecycle-catalog-stub.test.ts
+++ b/test/unit/skills/lifecycle/friday-skill-lifecycle-catalog-stub.test.ts
@@ -1,0 +1,131 @@
+/**
+ * B1 catalog truth-labeling tests.
+ *
+ * The `createFridaySkillLifecycleService` factory does not currently wire a
+ * catalog backend through `CreateFridaySkillLifecycleServiceDeps`. As a result:
+ *   1. A one-time INFO log is emitted at service creation advising operators
+ *      that catalog-derived enrichments are proof_pending in this build.
+ *   2. `listCatalog(query)` returns `{ items: [], total: 0 }` for every query.
+ *   3. `getSkill(skillId)` returns a summary built from persisted + registry
+ *      state only — `sourceDetails` and `catalogEntry` are always `undefined`.
+ *
+ * These tests lock in (1) and (2) as the current truthful behavior. (3) is
+ * covered transitively by integration tests that exercise getSkill with
+ * persisted skills and confirm the summary shape; this file does not
+ * re-stub the full dep tree.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { createFridaySkillLifecycleService, type FridaySkillRegistry } from "#skills";
+
+function makeStubRegistry(): FridaySkillRegistry {
+  return {
+    register: vi.fn(),
+    unregister: vi.fn(),
+    get: vi.fn(() => undefined),
+    list: vi.fn(() => []),
+    findByIntent: vi.fn(() => undefined),
+    findByPhrase: vi.fn(() => undefined),
+    refresh: vi.fn(async () => {}),
+    listForChannel: vi.fn(() => []),
+    setUserAuthorization: vi.fn(),
+    getUserAuthorization: vi.fn(() => undefined),
+  } as unknown as FridaySkillRegistry;
+}
+
+function makeMinimalDeps() {
+  // Database stub: returns null/empty for every read; no writes expected in
+  // listCatalog or getSkill(unknown).
+  const db = {
+    withReadConnection: <T,>(fn: (handle: unknown) => T): T => fn({}),
+    withWriteTransaction: <T,>(fn: (handle: unknown) => T): T => fn({}),
+    close: () => {},
+  };
+  return {
+    db: db as never,
+    nowIso: () => "2026-05-24T13:30:00.000Z",
+    managedSkillsDir: "/tmp/friday-b1-test-skills",
+    hubVersion: "1.0.0",
+    supportedApiVersions: ["1"],
+    registry: makeStubRegistry(),
+    installations: {} as never,
+    packageInstaller: {} as never,
+    signatureVerifier: {} as never,
+    trustScoring: {} as never,
+    skillRepo: {
+      getSkillById: vi.fn(() => null),
+      listSkills: vi.fn(() => []),
+    } as never,
+    versionRepo: {
+      listVersions: vi.fn(() => []),
+    } as never,
+    installationRepo: {
+      listBySkill: vi.fn(() => []),
+    } as never,
+  };
+}
+
+describe("createFridaySkillLifecycleService — B1 catalog truth-labeling", () => {
+  let infoSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    infoSpy.mockRestore();
+  });
+
+  it("emits a one-time INFO log at service creation advising that catalog is proof_pending", () => {
+    createFridaySkillLifecycleService(makeMinimalDeps());
+
+    const catalogAdvisories = infoSpy.mock.calls.filter(([msg]) =>
+      typeof msg === "string" && msg.includes("Catalog backend is not wired"),
+    );
+    expect(catalogAdvisories).toHaveLength(1);
+    const [message] = catalogAdvisories[0]!;
+    expect(message).toContain("listCatalog()");
+    expect(message).toContain("getSkill()");
+    expect(message).toContain("proof_pending");
+  });
+
+  it("listCatalog returns {items: [], total: 0} for any query (catalog backend not wired)", () => {
+    const service = createFridaySkillLifecycleService(makeMinimalDeps());
+
+    const result = service.listCatalog({} as never);
+    expect(result.items).toEqual([]);
+    expect(result.total).toBe(0);
+  });
+
+  it("listCatalog returns empty for queries with filters too (no query parameter changes the result)", () => {
+    const service = createFridaySkillLifecycleService(makeMinimalDeps());
+
+    const result = service.listCatalog({
+      query: "starter",
+      tags: ["productivity"],
+      category: "utility",
+    } as never);
+    expect(result.items).toEqual([]);
+    expect(result.total).toBe(0);
+  });
+
+  it("getSkill returns null for an unknown skillId when neither persisted nor registered", () => {
+    const service = createFridaySkillLifecycleService(makeMinimalDeps());
+
+    const result = service.getSkill("unknown-skill-id");
+    expect(result).toBeNull();
+  });
+
+  it("creating multiple services emits one advisory per creation (no global de-dup)", () => {
+    // The advisory is per-instance — operators get one notice per process-managed
+    // service so the diagnostic is visible regardless of how many lifecycles exist.
+    createFridaySkillLifecycleService(makeMinimalDeps());
+    createFridaySkillLifecycleService(makeMinimalDeps());
+
+    const catalogAdvisories = infoSpy.mock.calls.filter(([msg]) =>
+      typeof msg === "string" && msg.includes("Catalog backend is not wired"),
+    );
+    expect(catalogAdvisories).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary

**B1 Slice 4 — skills lifecycle catalog truth-labeling.** Closes the audit finding that `getCatalogCandidates(skillId)` and `getSource(sourceId)` in `friday-skill-lifecycle-service.ts:883-909` silently return empty/undefined, leading to `lifecycle.listCatalog()` always returning `{items:[], total:0}` and `lifecycle.getSkill().sourceDetails/.catalogEntry` always being `undefined` — with no signal that the catalog backend is simply not wired in this build.

Per AUTO_DECISION_POLICY "prefer truthful unsupported over pretending":

1. One-time `console.info` advisory at service creation
2. JSDoc rationale on `getCatalogCandidates`/`getSource` internal stubs
3. JSDoc on public `listCatalog`/`getSkill` documenting the proof_pending status

5 new tests lock in the current truthful behavior.

Same pattern as Slice 2 (channel-registry lifecycle precedence): docs + diagnostic log + tests. No runtime behavior change.

## What changed (2 files, +179/-0)

| File | Change |
|---|---|
| `src/skills/services/friday-skill-lifecycle-service.ts` | +48 lines: creation-time advisory log + JSDoc on stubs + JSDoc on public methods |
| `test/unit/skills/lifecycle/friday-skill-lifecycle-catalog-stub.test.ts` (NEW) | +131 lines: 5 tests proving advisory + listCatalog returns + getSkill(unknown) returns null + multiple-service advisory |

## What this slice does NOT do

- Does NOT wire a real catalog repository (separate slice when product is ready)
- Does NOT remove the stubs or change return types (HR11)
- Does NOT add a `catalogAvailable` field to the result type (would be a contract change)

## Test plan

- [x] Focused: 5/5 new catalog-stub tests
- [x] Blast-radius: 941/941 across `test/unit/skills/` + `test/contracts/`
- [x] tsc clean; eslint 0 errors; secret scan clean; `git diff --check` clean
- [x] check:security-doctor PASS; check:architecture-boundaries PASS
- [ ] PR-head CI green
- [ ] Same-SHA real-green-gate green
- [ ] Normal squash-merge

## Closes

Skills lifecycle catalog stubs entry from `HANDOFFS/20260524-1230-B1-session-pause-with-options.md` (option 2 of latest menu).