### PR TITLE
B1 Slice 6 — truth-label plugin signature as advisory-only / proof_pending

### DIFF
--- a/src/plugins/model/friday-plugin.types.ts
+++ b/src/plugins/model/friday-plugin.types.ts
@@ -180,6 +180,24 @@ export interface FridayPluginPermissionPolicy {
 }
 
 // ─── Signature Types ───
+//
+// B1 truth-labeling: this signature shape is **advisory-only / proof_pending**
+// in the current build. The plugin install path
+// (src/plugins/services/friday-plugin-service.ts:280-313) DOES NOT verify
+// `signature.value` against `signature.keyId` using ed25519 or any other
+// algorithm — it always falls through to `evaluateLocalTrustOnInstall(...)`
+// which is a user-approval / fingerprint-based trust-on-install model, not
+// cryptographic signature verification.
+//
+// Adding real signature verification requires:
+//   - a trusted-publisher keyring (key distribution policy, revocation list)
+//   - ed25519 verify over canonicalized manifest+package bytes
+//   - clear errors when the key is unknown / revoked / signature invalid
+//
+// Until those land, callers that present a `signature` field on the
+// manifest get NO cryptographic guarantee beyond what trust-on-install
+// already provides. Per AUTO_DECISION_POLICY ("prefer truthful unsupported"),
+// publishers should treat this field as advisory metadata only.
 
 export interface FridayPluginSignature {
   algorithm: "ed25519";

--- a/src/plugins/services/friday-plugin-service.ts
+++ b/src/plugins/services/friday-plugin-service.ts
@@ -277,9 +277,27 @@ export function createFridayPluginService(
         );
       }
 
+      // B1 truth-labeling: even when `manifest.signature` is present
+      // (ed25519 keyId+value), the install path below DOES NOT verify it
+      // cryptographically. The downstream `evaluateLocalTrustOnInstall` is a
+      // user-approval / fingerprint trust-on-install model. The
+      // `trustMode = "signed"` literal in this declaration is reserved for a
+      // future signature-verifying path; the runtime here always falls into
+      // the trust-on-install branch. Advise operators once at install time so
+      // they don't interpret a manifest with a signature field as evidence
+      // of cryptographic provenance.
+      if (manifest.signature) {
+        console.info(
+          `[friday][plugins] Plugin "${manifest.id}" manifest declares an ed25519 signature (keyId=${JSON.stringify(manifest.signature.keyId)}), but signature verification is proof_pending in this build — installation will fall back to trust-on-install (user-approval + fingerprint). See FridayPluginSignature docstring for the B1 follow-up that adds real verification.`,
+        );
+      }
       let trustMode: "signed" | "trust_on_install" = "trust_on_install";
       let signatureVerified = false;
       let trustedFingerprint: string | undefined;
+      // B1 truth-labeling: these signature-result fields exist in the entity
+      // schema for forward-compat with a future signature-verifying path. They
+      // stay undefined under the current trust-on-install model — see the
+      // advisory log above and FridayPluginSignature docstring.
       let signatureAlgorithm: string | undefined;
       let signatureKeyId: string | undefined;
       let signatureValue: string | undefined;

--- a/test/unit/plugins/services/friday-plugin-service.test.ts
+++ b/test/unit/plugins/services/friday-plugin-service.test.ts
@@ -554,4 +554,96 @@ describe("FridayPluginService", () => {
     expect(service.getPlugin("friday.test.base")).toBeNull();
   });
 
+  // ─── B1 truth-labeling: plugin signature is advisory-only / proof_pending ───
+  //
+  // FridayPluginManifest accepts an ed25519 signature shape, but the install
+  // path in friday-plugin-service.ts:280-313 does NOT verify it
+  // cryptographically — it always falls into `evaluateLocalTrustOnInstall`
+  // (user-approval / fingerprint trust-on-install). The slice adds:
+  //   1. A docstring on FridayPluginSignature labeling it advisory-only.
+  //   2. A one-time `console.info` advisory at install time when a manifest
+  //      declares `signature` (so the operator knows the field is not a
+  //      cryptographic guarantee).
+  //   3. Inline comments on the related declarations.
+  //
+  // These tests lock in the advisory + the unchanged trust-on-install path.
+
+  describe("B1 plugin signature truth-labeling", () => {
+    let infoSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      infoSpy.mockRestore();
+    });
+
+    it("emits a one-time INFO advisory at installPlugin when manifest declares a signature", () => {
+      const manifest = makeManifest("friday.test.signed", {
+        signature: {
+          algorithm: "ed25519",
+          keyId: "test-publisher-key-1",
+          value: "deadbeefcafef00d",
+        },
+      });
+
+      service.installPlugin({
+        manifest,
+        installPath: "/plugins/friday.test.signed",
+        source: "local",
+        userApproved: true,
+      });
+
+      const signatureAdvisories = infoSpy.mock.calls.filter(([msg]) =>
+        typeof msg === "string" && msg.includes("signature verification is proof_pending"),
+      );
+      expect(signatureAdvisories).toHaveLength(1);
+      const [message] = signatureAdvisories[0]!;
+      expect(message).toContain("friday.test.signed");
+      expect(message).toContain("test-publisher-key-1");
+      expect(message).toContain("trust-on-install");
+    });
+
+    it("does NOT emit the signature advisory when manifest has no signature field", () => {
+      const manifest = makeManifest("friday.test.unsigned"); // no signature
+
+      service.installPlugin({
+        manifest,
+        installPath: "/plugins/friday.test.unsigned",
+        source: "local",
+        userApproved: true,
+      });
+
+      const signatureAdvisories = infoSpy.mock.calls.filter(([msg]) =>
+        typeof msg === "string" && msg.includes("signature verification is proof_pending"),
+      );
+      expect(signatureAdvisories).toHaveLength(0);
+    });
+
+    it("installs the plugin under trust_on_install mode regardless of whether a signature is present (signature is not verified)", () => {
+      const manifest = makeManifest("friday.test.advisory", {
+        signature: {
+          algorithm: "ed25519",
+          keyId: "any-key-id",
+          value: "any-value",
+        },
+      });
+
+      const entity = service.installPlugin({
+        manifest,
+        installPath: "/plugins/friday.test.advisory",
+        source: "local",
+        userApproved: true,
+      });
+
+      // Truth-labeling property: regardless of whether `signature` is present
+      // and well-formed, the install path always uses `trust_on_install` —
+      // the signature field is NOT a path to a "signed" trustMode in this
+      // build. If a future slice wires real verification, that path must
+      // also flip trustMode to "signed".
+      expect(entity.trustMode).toBe("trust_on_install");
+    });
+  });
+
 });


### PR DESCRIPTION
## Summary

**B1 Slice 6 — plugin signature truth-labeling.** Closes the audit finding that `FridayPluginManifest` accepts an ed25519 `signature` field (keyId+value), but the install path in `friday-plugin-service.ts:280-313` does **not** verify the signature cryptographically — it falls back to `signatureVerifier.evaluateLocalTrustOnInstall(...)` (user-approval + fingerprint trust-on-install).

Per AUTO_DECISION_POLICY "prefer truthful unsupported over pretending":

1. JSDoc on `FridayPluginSignature` labeling it advisory-only / proof_pending + the explicit list of what real verification would require
2. One-time `console.info` advisory at `installPlugin` time when a manifest declares `signature`
3. Inline comments on the related trust-mode/algorithm/keyId/value declarations
4. 3 new tests proving advisory emission, no advisory for unsigned manifest, and `trustMode` stays `"trust_on_install"` regardless of signature presence

Same pattern as B1 Slices 2 + 4 (docs + console.info advisory + tests). No runtime behavior change.

## What changed (3 files, +128/-0)

| File | Change |
|---|---|
| `src/plugins/model/friday-plugin.types.ts` | 17-line docstring on `FridayPluginSignature` |
| `src/plugins/services/friday-plugin-service.ts` | Advisory log at `installPlugin` when `manifest.signature` is present + inline comments on related decl |
| `test/unit/plugins/services/friday-plugin-service.test.ts` | 3 new tests under "B1 plugin signature truth-labeling" |

## What this slice does NOT do

- Does **not** implement real signature verification (deferred; needs new infrastructure)
- Does **not** remove the `signature` field (HR11 — stays for future verifying path)
- Does **not** change install behavior (same `evaluateLocalTrustOnInstall` call path)

## Test plan

- [x] `tsc --noEmit -p .` clean; `eslint` 0 errors
- [x] Focused: 31/31 plugin-service tests (+3)
- [x] Blast-radius: 248/248 across `test/unit/plugins/` + `test/contracts/`
- [x] `git diff --check` clean
- [ ] PR-head CI green
- [ ] Same-SHA real-green-gate green
- [ ] Normal squash-merge

## Closes

`Plugin signature truth-label` entry from the prior B1 menu (option 1 of the latest decision).