### PR TITLE
B1 Slice 7 — close long-form-flag bypass of rm -rf shell-safety scanner

### DIFF
--- a/src/skills/safety/friday-shell-safety-scanner.ts
+++ b/src/skills/safety/friday-shell-safety-scanner.ts
@@ -45,6 +45,27 @@ const BLOCKING_PATTERNS: ReadonlyArray<PatternRule> = [
     regex: /\brm\s+-[a-zA-Z]*r[a-zA-Z]*f[a-zA-Z]*\s+~(?:\/|\s|$|;)/,
     summary: "Recursive force-delete from home directory",
   },
+  // B1 medium-severity sweep — close long-form-flag bypass of rm -rf.
+  // The short-form patterns above match `-r` / `-f` / `-rf` / `-rR`, but a
+  // crafty author could write `rm --recursive --force /` and avoid every
+  // existing pattern. These two patterns match any `rm` invocation where a
+  // `--recursive` (long-form) flag appears anywhere in the flag list and the
+  // target is `/` or `~`. The intervening `[^\n;]*?` allows arbitrary
+  // additional flags (e.g. `--force`, `--no-preserve-root`, `-v`) between
+  // `--recursive` and the path. We anchor on `--recursive` only (not also
+  // `--force`) because `rm --recursive /` is already destructive on its own.
+  {
+    id: "rm-recursive-longform-root",
+    level: "blocking",
+    regex: /\brm\s+(?:[^\n;]*?\s+)?--recursive(?:\s+[^\n;]*?)?\s+\/(?:\s|$|;)/,
+    summary: "Recursive delete from root filesystem (long-form --recursive)",
+  },
+  {
+    id: "rm-recursive-longform-home",
+    level: "blocking",
+    regex: /\brm\s+(?:[^\n;]*?\s+)?--recursive(?:\s+[^\n;]*?)?\s+~(?:\/|\s|$|;)/,
+    summary: "Recursive delete from home directory (long-form --recursive)",
+  },
   {
     id: "chmod-777",
     level: "blocking",

--- a/test/unit/skills/safety/friday-shell-safety-scanner.test.ts
+++ b/test/unit/skills/safety/friday-shell-safety-scanner.test.ts
@@ -63,6 +63,60 @@ describe("scanShellScript", () => {
     expect(rmHome).toBeDefined();
   });
 
+  // ─── B1: long-form-flag bypass for rm -rf ───
+
+  it("B1: detects 'rm --recursive --force /' (long-form bypass) as blocking", () => {
+    const script = "rm --recursive --force /";
+    const result = scanShellScript(script);
+
+    expect(result.verdict).toBe("dangerous");
+    const blocking = result.findings.filter((f) => f.level === "blocking");
+    expect(blocking.some((f) => f.id === "rm-recursive-longform-root")).toBe(true);
+  });
+
+  it("B1: detects 'rm --recursive /' (no force flag, still recursive to root) as blocking", () => {
+    const script = "rm --recursive /";
+    const result = scanShellScript(script);
+
+    expect(result.verdict).toBe("dangerous");
+    expect(result.findings.some((f) => f.id === "rm-recursive-longform-root")).toBe(true);
+  });
+
+  it("B1: detects 'rm --recursive ~/' (long-form home) as blocking", () => {
+    const script = "rm --recursive ~/";
+    const result = scanShellScript(script);
+
+    expect(result.verdict).toBe("dangerous");
+    expect(result.findings.some((f) => f.id === "rm-recursive-longform-home")).toBe(true);
+  });
+
+  it("B1: detects 'rm --force --recursive /' (flag order swapped) as blocking", () => {
+    const script = "rm --force --recursive /";
+    const result = scanShellScript(script);
+
+    expect(result.verdict).toBe("dangerous");
+    expect(result.findings.some((f) => f.id === "rm-recursive-longform-root")).toBe(true);
+  });
+
+  it("B1: detects 'rm -v --recursive --no-preserve-root /' (extra flags between) as blocking", () => {
+    const script = "rm -v --recursive --no-preserve-root /";
+    const result = scanShellScript(script);
+
+    expect(result.verdict).toBe("dangerous");
+    expect(result.findings.some((f) => f.id === "rm-recursive-longform-root")).toBe(true);
+  });
+
+  it("B1: does NOT falsely match 'rm --recursive ./local/safe' (not root or home)", () => {
+    const script = "rm --recursive ./local/safe";
+    const result = scanShellScript(script);
+
+    // The script should not trigger the long-form patterns because target is not / or ~
+    const matched = result.findings.filter(
+      (f) => f.id === "rm-recursive-longform-root" || f.id === "rm-recursive-longform-home",
+    );
+    expect(matched).toHaveLength(0);
+  });
+
   // ─── Blocking: sudo ───
 
   it("detects sudo apt install as blocking", () => {


### PR DESCRIPTION
## Summary

**B1 Slice 7 (medium-severity sweep)** — Closes a real security gap in the shell-safety scanner.

Previously, `BLOCKING_PATTERNS` in `friday-shell-safety-scanner.ts` matched only short-form flags (`-r` / `-f` / `-rf` / `-rR`) for the rm-rf detection. A crafty author could bypass every existing pattern with `rm --recursive --force /` (long-form flags). The audit flagged this as a medium-severity finding.

This slice adds 2 new blocking patterns:
- `rm-recursive-longform-root` — matches `rm` with `--recursive` flag and target `/`
- `rm-recursive-longform-home` — matches `rm` with `--recursive` flag and target `~`

Each pattern allows arbitrary intervening flags (e.g. `--force`, `--no-preserve-root`, `-v`), so all common bypass variations are caught. The patterns anchor on `--recursive` only — `--force` alone on a directory fails without recursion, so `--recursive` is the necessary and sufficient marker.

## What changed (2 files, +75/-0)

| File | Change |
|---|---|
| `src/skills/safety/friday-shell-safety-scanner.ts` | 2 new BLOCKING_PATTERNS entries (long-form `--recursive` to `/` or `~`) |
| `test/unit/skills/safety/friday-shell-safety-scanner.test.ts` | 6 new tests covering bypass variations + 1 negative (no false-positive on local paths) |

## Test plan

- [x] Focused: 34/34 scanner tests (existing 29 + 6 new)
- [x] Blast-radius: 951/951 across `test/unit/skills/` + `test/contracts/`
- [x] tsc clean; eslint 0 errors; secret scan clean; `git diff --check` clean
- [ ] PR-head CI green
- [ ] Same-SHA real-green-gate green
- [ ] Normal squash-merge

## Companion slices

- B1 Slice 5 (PR #307, merged `75d9e9c1`) hardened the path-resolution for the SCAN INVOCATION (`verifySkill` → `resolveSafeInstallDir`).
- This slice hardens the SCANNER ITSELF so malicious scripts with long-form rm-rf flags are correctly flagged.

## Closes

The B1 medium-severity finding: `shell-safety-scanner BLOCKING_PATTERNS for rm-rf use short-form flags only`.