### PR TITLE
B1 Slice 8 — require human confirmation for high-risk desktop actions

### DIFF
--- a/src/desktop/engine/permission-guard.ts
+++ b/src/desktop/engine/permission-guard.ts
@@ -318,8 +318,17 @@ function buildRulesEngineContext(
   };
 }
 
+// B1 medium-severity sweep — match the locked product direction
+// (GLOBAL_DECISIONS_LOCKED.md): "high-risk work requires approval; dangerous
+// or non-reversible work fails closed." Before this fix, confirmation only
+// fired for `"critical"` — but `DEFAULT_RISK_MAP` never assigns `"critical"`
+// to any default action (max default is `"high"` for close_app / file_operation),
+// so the human-confirmation Layer 3 was effectively unreachable through default
+// risk levels and only fired when a policy explicitly set `riskLevel: "critical"`.
+// Now `"high"` AND `"critical"` both require confirmation; `"none"` / `"low"`
+// / `"medium"` proceed without prompting.
 function riskRequiresConfirmation(riskLevel: FridayDesktopRiskLevel): boolean {
-  return riskLevel === "critical";
+  return riskLevel === "high" || riskLevel === "critical";
 }
 
 function assertNever(value: never): never {

--- a/test/unit/desktop/engine/action-executor.test.ts
+++ b/test/unit/desktop/engine/action-executor.test.ts
@@ -140,12 +140,13 @@ function makeMockAdapter(options: MockAdapterOptions = {}): FridayDesktopAdapter
   };
 }
 
-function makeGuard(): PermissionGuard {
+function makeGuard(overrides: { promptResolver?: Parameters<typeof createPermissionGuard>[0]["promptResolver"] } = {}): PermissionGuard {
   return createPermissionGuard({
     generateId: () => `id-${++idCounter}`,
     nowIso: () => NOW,
     permissionPromptTimeoutMs: 5000,
     principalId: "user-1",
+    ...overrides,
   });
 }
 
@@ -304,6 +305,14 @@ describe("ActionExecutor", () => {
           },
         });
         const constrainedExecutor = makeExecutor({ sandboxAllowedRoots: [tempRoot] });
+        // B1 medium-severity sweep: file_operation defaults to "high" risk in
+        // DEFAULT_RISK_MAP, and "high" now requires confirmation per the
+        // locked product direction ("high-risk work requires approval"). Use a
+        // guard with an approving prompt resolver to keep this test focused on
+        // sandbox behavior rather than confirmation behavior.
+        const approvingGuard = makeGuard({
+          promptResolver: async () => ({ decision: "approved" as const }),
+        });
         const result = await constrainedExecutor.execute(
           {
             type: "file_operation",
@@ -311,7 +320,7 @@ describe("ActionExecutor", () => {
             path: path.join(tempRoot, "inside.txt"),
           },
           sandboxAwareAdapter,
-          guard,
+          approvingGuard,
           inspector,
           { actionId: "inside-path" },
         );

--- a/test/unit/desktop/engine/permission-guard.test.ts
+++ b/test/unit/desktop/engine/permission-guard.test.ts
@@ -574,4 +574,103 @@ describe("PermissionGuard", () => {
       expect(guardWithResolver.getDecisions()).toHaveLength(1);
     });
   });
+
+  // ─── B1 medium-severity sweep: "high"-risk also requires confirmation ───
+  //
+  // GLOBAL_DECISIONS_LOCKED.md: "Autonomy is risk-tiered: low-risk work can
+  // run proactively; medium-risk work plans or asks; high-risk work requires
+  // approval; dangerous or non-reversible work fails closed." Before the fix,
+  // confirmation only fired for `riskLevel === "critical"` — but
+  // `DEFAULT_RISK_MAP` never assigns "critical" to any action (close_app and
+  // file_operation top out at "high"), so the human-confirmation Layer 3 was
+  // unreachable for default-risk actions. Now both "high" AND "critical"
+  // trigger confirmation.
+
+  describe('B1: "high"-risk actions also require confirmation', () => {
+    it("denies a policy-set 'high'-risk action when no prompt resolver is configured", async () => {
+      const adapter = makeMockAdapter();
+      const policy = makePolicy([
+        { actionType: "click", appFilter: "*", decision: "allow", riskLevel: "high" },
+      ]);
+      guard.loadPolicies([policy]);
+
+      const result = await guard.check({ type: "click" }, adapter);
+      expect(result.allowed).toBe(false);
+      expect(result.denialCode).toBe("DESKTOP_PERMISSION_DENIED_USER");
+      expect(result.prompt).toBeDefined();
+    });
+
+    it("allows a policy-set 'high'-risk action when the prompt resolver approves", async () => {
+      const guardWithResolver = createPermissionGuard(makeConfig({
+        promptResolver: async () => ({ decision: "approved" as const, rationale: "User approved" }),
+      }));
+      const adapter = makeMockAdapter();
+      const policy = makePolicy([
+        { actionType: "click", appFilter: "*", decision: "allow", riskLevel: "high" },
+      ]);
+      guardWithResolver.loadPolicies([policy]);
+
+      const result = await guardWithResolver.check({ type: "click" }, adapter);
+      expect(result.allowed).toBe(true);
+      expect(result.decision?.decision).toBe("approved");
+    });
+
+    it("default 'close_app' action triggers confirmation (DEFAULT_RISK_MAP[close_app]='high')", async () => {
+      const guardWithResolver = createPermissionGuard(makeConfig({
+        promptResolver: async () => ({ decision: "approved" as const }),
+      }));
+      const adapter = makeMockAdapter();
+      // No policy loaded — falls back to DEFAULT_RISK_MAP["close_app"] === "high"
+      const result = await guardWithResolver.check(
+        { type: "close_app", appIdentifier: "com.example.app" } as never,
+        adapter,
+      );
+      // Confirmation was requested AND approved => allowed
+      expect(result.decision).toBeDefined();
+      expect(result.decision!.decision).toBe("approved");
+    });
+
+    it("default 'file_operation' action triggers confirmation (DEFAULT_RISK_MAP[file_operation]='high')", async () => {
+      const guardWithResolver = createPermissionGuard(makeConfig({
+        promptResolver: async () => ({ decision: "approved" as const }),
+      }));
+      const adapter = makeMockAdapter();
+      const result = await guardWithResolver.check(
+        {
+          type: "file_operation",
+          operation: "read",
+          filePath: "/tmp/test.txt",
+        } as never,
+        adapter,
+      );
+      expect(result.decision).toBeDefined();
+      expect(result.decision!.decision).toBe("approved");
+    });
+
+    it("regression: 'medium'-risk policy does NOT trigger confirmation", async () => {
+      const adapter = makeMockAdapter();
+      const policy = makePolicy([
+        { actionType: "click", appFilter: "*", decision: "allow", riskLevel: "medium" },
+      ]);
+      guard.loadPolicies([policy]);
+
+      const result = await guard.check({ type: "click" }, adapter);
+      // Medium proceeds without prompting; either allowed or denied by policy,
+      // but never asks the user.
+      expect(result.prompt).toBeUndefined();
+      expect(result.decision).toBeUndefined();
+    });
+
+    it("regression: 'low'-risk policy does NOT trigger confirmation", async () => {
+      const adapter = makeMockAdapter();
+      const policy = makePolicy([
+        { actionType: "click", appFilter: "*", decision: "allow", riskLevel: "low" },
+      ]);
+      guard.loadPolicies([policy]);
+
+      const result = await guard.check({ type: "click" }, adapter);
+      expect(result.prompt).toBeUndefined();
+      expect(result.decision).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

**B1 Slice 8 (medium-severity sweep, item 2)** — Real safety-boundary fix. The desktop permission-guard's Layer 3 human-confirmation gate was effectively unreachable for default-risk actions because `riskRequiresConfirmation` only returned true for `"critical"`, but `DEFAULT_RISK_MAP` never assigns `"critical"` (the highest default is `"high"` for `close_app` and `file_operation`). Per GLOBAL_DECISIONS_LOCKED.md the locked product direction is "**high-risk work requires approval**; dangerous or non-reversible work fails closed."

This slice makes `riskRequiresConfirmation` fire for `"high"` AND `"critical"`. Default close_app + file_operation now correctly trigger confirmation; medium / low / none proceed without prompting (unchanged).

## What changed (3 files, +120/-3)

| File | Change |
|---|---|
| `src/desktop/engine/permission-guard.ts` | `riskRequiresConfirmation` returns true for `"high" \|\| "critical"` (was `=== "critical"` only) + 10-line docstring |
| `test/unit/desktop/engine/permission-guard.test.ts` | 6 new tests: high+resolver approve/deny/default-close_app/default-file_operation + medium/low regression |
| `test/unit/desktop/engine/action-executor.test.ts` | Sandbox-allow test now uses a guard with an approving prompt resolver (file_operation defaults to "high" and now triggers confirmation; test focus stays on sandbox enforcement) |

## Behavior change

Deliberate. The locked spec says high-risk work requires approval. Existing call sites that relied on the broken bypass (no confirmation for high risk) will now surface `DESKTOP_PERMISSION_DENIED_USER` unless they wire a prompt resolver. Policy rules can downgrade specific actions if needed.

## Test plan

- [x] Focused: 27/27 permission-guard tests (existing 21 + 6 new)
- [x] Blast-radius: 250/250 across `test/unit/desktop/` + `test/contracts/`
- [x] tsc clean; eslint 0 errors; secret scan clean; `git diff --check` clean
- [ ] PR-head CI green
- [ ] Same-SHA real-green-gate green
- [ ] Normal squash-merge

## Closes

B1 medium-severity audit finding: `riskRequiresConfirmation only returns true when computedRisk === 'critical'. DEFAULT_RISK_MAP NEVER returns 'critical' for any action ...`.