### PR TITLE
B1 Slice 9: truth-label win32 desktop checkPermissions as not_determined

### DIFF
--- a/src/desktop/engine/friday-desktop-adapters.ts
+++ b/src/desktop/engine/friday-desktop-adapters.ts
@@ -937,11 +937,24 @@ export async function createWin32Adapter(
       return [...WIN32_CAPABILITIES];
     },
 
+    // B1 truth-labeling: previously every win32 permission was reported as
+    // `"granted"` without any actual platform check. That's a fake-capability —
+    // the adapter has no UIAutomation/COM probe wired up yet, so the truthful
+    // state is `"not_determined"` until a real probe lands. Each permission
+    // carries an actionable instruction so an operator can verify in Windows
+    // Settings.
     async checkPermissions(): Promise<FridayDesktopPermission[]> {
       const now = config.nowIso();
-      return WIN32_PERMISSIONS.map(perm =>
-        makePermission(perm, "granted", "win32", now,
-          perm === "accessibility" ? "Windows → Settings → Accessibility → Enable UI Automation" : undefined),
+      const winInstructions: Readonly<Record<FridayDesktopOsPermissionType, string | undefined>> = {
+        accessibility: "Windows → Settings → Accessibility → Enable UI Automation",
+        automation: "Windows → Settings → Privacy & security → App permissions → Automation tools",
+        input_monitoring: "Windows → Settings → Privacy & security → Input monitoring (no per-app gate; runtime input hooks may still fail)",
+        // Permission types not used by win32 — fields kept for the Record completeness.
+        screen_recording: undefined,
+        file_access: undefined,
+      };
+      return WIN32_PERMISSIONS.map((perm) =>
+        makePermission(perm, "not_determined", "win32", now, winInstructions[perm]),
       );
     },
   };

--- a/test/unit/desktop/engine/friday-desktop-adapters.test.ts
+++ b/test/unit/desktop/engine/friday-desktop-adapters.test.ts
@@ -348,12 +348,31 @@ describe("C-001 FridayDesktopAdapters", () => {
       expect(caps).not.toContain("scripting_bridge"); // macOS only
     });
 
-    it("checks Windows permissions (generally granted)", async () => {
+    it("B1 truth-labeling: Windows permissions all report 'not_determined' until a real platform probe is wired", async () => {
+      // Previously the win32 adapter returned `"granted"` for every permission
+      // without any actual UIAutomation/COM check. Per AUTO_DECISION_POLICY
+      // ("prefer truthful unsupported over pretending"), the adapter now
+      // returns `"not_determined"` with actionable instructions until a real
+      // probe lands.
       const permissions = await adapter.checkPermissions();
       expect(permissions.length).toBe(3);
       for (const perm of permissions) {
         expect(perm.platform).toBe("win32");
-        expect(perm.status).toBe("granted");
+        expect(perm.status).toBe("not_determined");
+      }
+      // Each permission has an instruction so operators can act on the
+      // not_determined verdict.
+      for (const perm of permissions) {
+        if (perm.permissionType === "accessibility") {
+          expect(perm.grantInstructions).toBeDefined();
+          expect(perm.grantInstructions).toContain("Accessibility");
+        } else if (perm.permissionType === "automation") {
+          expect(perm.grantInstructions).toBeDefined();
+          expect(perm.grantInstructions).toContain("Automation");
+        } else if (perm.permissionType === "input_monitoring") {
+          expect(perm.grantInstructions).toBeDefined();
+          expect(perm.grantInstructions).toContain("Input monitoring");
+        }
       }
     });
 


### PR DESCRIPTION
## Summary

B1 medium-severity sweep, slice 9. Close a fake-capability in the win32 desktop adapter: `checkPermissions()` was returning `status: \"granted\"` for every permission without performing any actual UIAutomation/COM probe. Per AUTO_DECISION_POLICY (\"prefer truthful unsupported over pretending\"), the adapter now returns `\"not_determined\"` with actionable per-permission instructions until a real probe lands.

## What changed (2 files, +37/-5)

**`src/desktop/engine/friday-desktop-adapters.ts`**
- win32 `checkPermissions` returns `\"not_determined\"` for accessibility / automation / input_monitoring (was `\"granted\"`).
- Each permission has its own actionable instruction pointing at the Windows Settings UI path the operator can use.
- 6-line truth-labeling docstring naming the missing UIAutomation/COM probe.

**`test/unit/desktop/engine/friday-desktop-adapters.test.ts`**
- Updated existing test from \"Windows permissions generally granted\" to truth-labeling assertion: every win32 permission status is `\"not_determined\"` AND carries an instructional string mentioning the relevant Settings path.

## Behavior compatibility

`permission-guard.ts` only DENIES on `status === \"denied\"`. Both `\"granted\"` and `\"not_determined\"` let the action through to the next layer, so the change does **not** introduce new false-denials. UI surfaces that display the permission state will now show `\"not_determined\"` — truthful rather than overclaiming.

## What this slice does NOT do

- Does NOT change darwin (the 3 untracked permission types already returned `\"not_determined\"`; accessibility is actually probed via `systemPreferences.isTrustedAccessibilityClient`).
- Does NOT change linux (accessibility actually probed via XDG; file_access truthfully returns `\"granted\"` because POSIX file permissions exist).
- Does NOT wire a real UIAutomation/COM probe. That's a separate slice.

## Test plan

- [x] Focused: 57/57 desktop-adapter tests (`vitest run test/unit/desktop/engine/friday-desktop-adapters.test.ts`)
- [x] Blast-radius: 250/250 across `test/unit/desktop/` + `test/contracts/`
- [x] tsc clean
- [x] eslint 0 errors
- [x] secret scan clean
- [x] git diff --check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)