### PR TITLE
B1 Slice 10: RegistryVersionConflictError → FridayDomainError (fix duplicate-publish 500 → 409)

### DIFF
--- a/src/packaging/engine/registry-manager.ts
+++ b/src/packaging/engine/registry-manager.ts
@@ -8,6 +8,7 @@
  * @module packaging/engine/registry-manager
  */
 
+import { FridayDomainError } from "#errors";
 import type {
   FridayPackageEngineConfig,
   FridayPackageManifest,
@@ -16,6 +17,7 @@ import type {
   ISODateTime,
   UUID,
 } from "../model/friday-packaging.types.js";
+import { FRIDAY_PACKAGING_ERROR_CODES } from "../api/friday-packaging-api.types.js";
 import { compareSemverStr, maxSatisfying } from "./semver.js";
 
 // ─── Registry Types ───
@@ -62,14 +64,27 @@ export interface RegistryPage<T> {
   readonly nextCursor?: string;
 }
 
-/** Conflict raised when publishing an existing version with different content. */
-export class RegistryVersionConflictError extends Error {
-  readonly code: string;
+/**
+ * Conflict raised when publishing an existing version with different content.
+ *
+ * Inherits from FridayDomainError so the HTTP error mapper surfaces this as
+ * a real 409 to clients instead of falling through to a generic 500. Before
+ * this, the class extended `Error` directly and the mapper masked it as
+ * INTERNAL_ERROR — a published-twice conflict appeared as a server fault.
+ */
+export class RegistryVersionConflictError extends FridayDomainError {
+  override readonly name = "RegistryVersionConflictError";
 
   constructor(name: string, version: string, tenantId?: string) {
-    super(`Package "${name}@${version}" already exists${tenantId ? ` for tenant "${tenantId}"` : ""} with different content`);
-    this.name = "RegistryVersionConflictError";
-    this.code = "PACKAGING_VERSION_ALREADY_EXISTS";
+    super(
+      FRIDAY_PACKAGING_ERROR_CODES.VERSION_ALREADY_EXISTS,
+      `Package "${name}@${version}" already exists${tenantId ? ` for tenant "${tenantId}"` : ""} with different content`,
+      {
+        httpStatus: 409,
+        retryable: false,
+        details: tenantId !== undefined ? { name, version, tenantId } : { name, version },
+      },
+    );
   }
 }
 

--- a/test/unit/packaging/engine/registry-manager.test.ts
+++ b/test/unit/packaging/engine/registry-manager.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { createRegistryManager } from "../../../../src/packaging/engine/registry-manager.js";
+import { createRegistryManager, RegistryVersionConflictError } from "../../../../src/packaging/engine/registry-manager.js";
 import type { RegistryManager, PublishOptions } from "../../../../src/packaging/engine/registry-manager.js";
 import type {
   FridayPackageManifest,
   FridayPackageSignature,
 } from "../../../../src/packaging/model/friday-packaging.types.js";
+import { FridayDomainError } from "../../../../src/errors/friday-domain-error.js";
+import { buildErrorResponse, mapErrorToStatusCode } from "../../../../src/api/http/friday-http-error-mapper.js";
 
 // ─── Fixtures ───
 
@@ -105,6 +107,36 @@ describe("RegistryManager", () => {
       expect(() =>
         registry.publish(makePublishOptions({ archiveDigest: "sha256:other" })),
       ).toThrow(/different content/i);
+    });
+
+    it("B1 truth-labeling: duplicate-version conflict surfaces as a 409 FridayDomainError, not a 500", () => {
+      registry.publish(makePublishOptions({ tenantId: "tenant-7" }));
+      let captured: unknown;
+      try {
+        registry.publish(
+          makePublishOptions({ tenantId: "tenant-7", archiveDigest: "sha256:other" }),
+        );
+      } catch (err) {
+        captured = err;
+      }
+      expect(captured).toBeInstanceOf(RegistryVersionConflictError);
+      expect(captured).toBeInstanceOf(FridayDomainError);
+      const err = captured as RegistryVersionConflictError;
+      expect(err.code).toBe("PACKAGING_VERSION_ALREADY_EXISTS");
+      expect(err.httpStatus).toBe(409);
+      expect(err.retryable).toBe(false);
+      expect(err.details).toMatchObject({
+        name: "@friday/test-pkg",
+        version: "1.0.0",
+        tenantId: "tenant-7",
+      });
+
+      // Prove the HTTP boundary actually returns 409 — this is the user-facing fix.
+      expect(mapErrorToStatusCode(err)).toBe(409);
+      const response = buildErrorResponse(err, "req-test-1");
+      expect(response.statusCode).toBe(409);
+      expect(response.body.error.code).toBe("PACKAGING_VERSION_ALREADY_EXISTS");
+      expect(response.body.error.retryable).toBe(false);
     });
 
     it("allows same name+version for different tenants", () => {


### PR DESCRIPTION
## Summary

B1 medium-severity sweep, slice 10. **Real user-facing bug fix, not type cosmetics.**

`RegistryVersionConflictError` extended `Error` directly, so when a duplicate-version package was re-published with different content the HTTP error mapper at `src/api/http/friday-http-error-mapper.ts:96-101` classified it as a plain `Error` and returned **500 INTERNAL_ERROR** with the message masked to \"Internal Server Error\". A legitimate 409 Conflict appeared to the client as a server fault.

After this slice the same conflict surfaces as a real **409** with the original `PACKAGING_VERSION_ALREADY_EXISTS` code and the conflicting `{ name, version, tenantId }` details.

## What changed (2 files, +54/-7)

**`src/packaging/engine/registry-manager.ts`**
- `RegistryVersionConflictError` now `extends FridayDomainError`.
- Constructor passes `httpStatus: 409`, `retryable: false`, and `{ name, version, tenantId? }` details via super-options.
- Code string imported from `FRIDAY_PACKAGING_ERROR_CODES.VERSION_ALREADY_EXISTS` (single source of truth) instead of hardcoded literal.
- 6-line docstring explains the 409 fix vs. prior 500 masking.

**`test/unit/packaging/engine/registry-manager.test.ts`**
- 1 new test asserts:
  - `instanceof RegistryVersionConflictError` AND `instanceof FridayDomainError`
  - `code === \"PACKAGING_VERSION_ALREADY_EXISTS\"` preserved
  - `httpStatus === 409`, `retryable === false`, details contains name/version/tenantId
  - `mapErrorToStatusCode(err) === 409` — proves HTTP boundary
  - `buildErrorResponse(err, ...).statusCode === 409` plus body code/retryable

Existing \"throws for duplicate scoped version with different content\" test left unchanged for regression coverage.

## Why the contract is clean

- Domain code `PACKAGING_VERSION_ALREADY_EXISTS` lives in `FRIDAY_PACKAGING_ERROR_CODES` per the catalog comment (\"Domain modules may define their own codes\"). No pollution of the shared `FRIDAY_ERROR_CODES`/`HTTP_STATUS_MAP` — `httpStatus: 409` flows via super-options, matching `FridayAuthError` at `src/api/auth/friday-auth-service.ts:179`.
- No catchers compared against the old `Error` shape (grep verified).
- `src/packaging/persistence/friday-package-sqlite-store.ts:227` rethrows the same class via the same constructor signature; no caller change required.

## Test plan

- [x] Focused: 39/39 registry-manager tests
- [x] Blast-radius: 1323/1323 across test/unit/packaging/ + test/unit/api/http/ + test/unit/errors/ + test/contracts/
- [x] tsc clean
- [x] eslint 0 errors (1 pre-existing unrelated `max-lines-per-function` warning)
- [x] secret scan clean
- [x] git diff --check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)