### PR TITLE
B1 Slice 11: truth-label slack+http as unsupported (mode-conditional)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -341,7 +341,7 @@
         "filename": "src/api/http/routes/friday-setup-routes.ts",
         "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
         "is_verified": false,
-        "line_number": 2080
+        "line_number": 2082
       }
     ],
     "src/media-understanding/friday-media-doctor.ts": [
@@ -1124,5 +1124,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-24T15:40:30Z"
+  "generated_at": "2026-05-24T20:51:27Z"
 }

--- a/src/api/http/routes/friday-setup-routes.ts
+++ b/src/api/http/routes/friday-setup-routes.ts
@@ -26,8 +26,10 @@ import {
   FRIDAY_CHANNEL_SECRET_SCOPE,
   FRIDAY_SUPPORTED_CHANNEL_KINDS,
   FRIDAY_UNSUPPORTED_CHANNEL_KINDS,
+  FRIDAY_UNSUPPORTED_CHANNEL_MODES,
   getFridayChannelSecretFieldDescriptors,
   isFridayChannelKindSupported,
+  isFridayChannelModeSupported,
   parseFridayChannelsConfig,
   parseFridayChannelSecretRef,
 } from "#channels";
@@ -2458,6 +2460,20 @@ export function createFridaySetupRoutes(
         const kind = body.kind as FridaySupportedChannelKind;
         const config = normalizeSetupChannelConfig(kind, { ...(body.config ?? {}) } as Record<string, unknown>);
 
+        // B1 unsupported-channel-mode boundary: refuse kind+mode combinations
+        // labeled unsupported (currently slack+http — the listener is an
+        // unwired stub). See FRIDAY_UNSUPPORTED_CHANNEL_MODES in
+        // friday-channel-config.ts. Check after normalize so the inspected
+        // `mode` field reflects schema defaults rather than raw request input.
+        const candidateMode = typeof config.mode === "string" ? config.mode : undefined;
+        if (!isFridayChannelModeSupported(kind, candidateMode)) {
+          throw new FridayDomainError(
+            "CHANNEL_MODE_UNSUPPORTED",
+            `Channel kind "${kind}" with mode "${candidateMode}" is currently unsupported. See product release notes for status.`,
+            { httpStatus: 409, details: { kind, mode: candidateMode, status: "unsupported" } },
+          );
+        }
+
         if (kind === "lark" || kind === "feishu") {
           return testLarkLikeChannelConnection(kind, config);
         }
@@ -2525,6 +2541,21 @@ export function createFridaySetupRoutes(
           const kind = ch.kind as FridaySupportedChannelKind;
           const slot = nextChannelSlot(kind);
           const config = normalizeSetupChannelConfig(kind, { ...(ch.config ?? {}) } as Record<string, unknown>);
+
+          // B1 unsupported-channel-mode boundary: refuse to save channels with
+          // an unsupported kind+mode combination (currently slack+http — the
+          // listener is an unwired stub). See FRIDAY_UNSUPPORTED_CHANNEL_MODES.
+          // Check after normalize so the inspected `mode` reflects schema
+          // defaults rather than raw request input.
+          const candidateMode = typeof config.mode === "string" ? config.mode : undefined;
+          if (!isFridayChannelModeSupported(kind, candidateMode)) {
+            throw new FridayDomainError(
+              "CHANNEL_MODE_UNSUPPORTED",
+              `Channel kind "${kind}" with mode "${candidateMode}" is currently unsupported. See product release notes for status.`,
+              { httpStatus: 409, details: { kind, mode: candidateMode, status: "unsupported" } },
+            );
+          }
+
           if (kind === "telegram") {
             applyTelegramVerificationToConfig(config, ch.enabled);
           }

--- a/src/channels/friday-channel-config.ts
+++ b/src/channels/friday-channel-config.ts
@@ -68,6 +68,44 @@ export function isFridayChannelKindSupported(kind: string): boolean {
     && !UNSUPPORTED_CHANNEL_KIND_SET.has(kind);
 }
 
+/**
+ * Channel kind+mode combinations that are recognized by the schema but MUST
+ * NOT be activated at runtime because the listener is not actually wired.
+ *
+ * B1 / AUTO_DECISION_POLICY ("prefer truthful unsupported over pretending"):
+ * Slack `mode: "http"` is an unwired stub — `createSlackHttpEventService`'s
+ * `start()` just flips an internal flag without binding an HTTP server, and
+ * `verifySlackSignature` has zero callers. A user who configures slack-http
+ * would see no inbound messages at all (no listener) while the channel reports
+ * `httpListening: true`. Truth-label this as unsupported until the listener
+ * AND signature verifier (including timestamp freshness) are wired together
+ * and proven end-to-end.
+ *
+ * Slack `mode: "socket"` is fully functional and remains supported.
+ */
+export const FRIDAY_UNSUPPORTED_CHANNEL_MODES: Readonly<
+  Partial<Record<FridaySupportedChannelKind, readonly string[]>>
+> = {
+  slack: ["http"],
+} as const;
+
+/**
+ * Returns `true` if the channel kind/mode combination is supported at runtime.
+ *
+ * `mode` may be undefined (caller hasn't normalized it yet). When undefined,
+ * the combination is considered supported — the channel schema's default mode
+ * is the supported path.
+ */
+export function isFridayChannelModeSupported(
+  kind: string,
+  mode: string | undefined,
+): boolean {
+  if (mode === undefined) return true;
+  const unsupportedModes = FRIDAY_UNSUPPORTED_CHANNEL_MODES[kind as FridaySupportedChannelKind];
+  if (!unsupportedModes) return true;
+  return !unsupportedModes.includes(mode);
+}
+
 export const FridayChannelInstanceConfigSchema = z.discriminatedUnion("kind", [
   FridayQqChannelConfigSchema,
   FridayLarkChannelConfigSchema,

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -59,6 +59,7 @@ export type {
 export {
   FRIDAY_SUPPORTED_CHANNEL_KINDS,
   FRIDAY_UNSUPPORTED_CHANNEL_KINDS,
+  FRIDAY_UNSUPPORTED_CHANNEL_MODES,
   FridayQqChannelConfigSchema,
   FridayLarkChannelConfigSchema,
   FridayChannelInstanceConfigSchema,
@@ -66,6 +67,7 @@ export {
   parseFridayChannelsConfig,
   buildDefaultChannelsConfig,
   isFridayChannelKindSupported,
+  isFridayChannelModeSupported,
 } from "./friday-channel-config.js";
 
 // ─── Security / Capability Matrix ───

--- a/test/unit/api/http/routes/friday-setup-routes.test.ts
+++ b/test/unit/api/http/routes/friday-setup-routes.test.ts
@@ -451,4 +451,130 @@ describe("createFridaySetupRoutes — B0 Slice A3 bootstrap boundary", () => {
     expect(activateSavedChannels).not.toHaveBeenCalled();
     expect(onChannelsSaved).not.toHaveBeenCalled();
   });
+
+  // ─── B1 Slice 11: Slack HTTP mode labeled unsupported ───
+  //
+  // AUTO_DECISION_POLICY ("prefer truthful unsupported over pretending"):
+  // Slack HTTP mode is an unwired stub — createSlackHttpEventService.start()
+  // flips an internal flag without binding an HTTP server, and
+  // verifySlackSignature has zero callers. A user configuring slack+http would
+  // see no inbound messages at all. Truth-label this mode as unsupported until
+  // the listener AND signature verifier (including timestamp freshness) are
+  // wired together and proven end-to-end. Slack socket mode remains supported.
+
+  it("B1: setup.channels.test refuses kind='slack' + mode='http' with CHANNEL_MODE_UNSUPPORTED 409", async () => {
+    const { deps, writeTxn } = makeDeps({ setupCompletedAt: null });
+    const route = findMutatingRoute(createFridaySetupRoutes(deps), "setup.channels.test");
+
+    await expect(
+      route.handler(
+        makeCtx({
+          ip: "127.0.0.1",
+          body: {
+            kind: "slack",
+            config: {
+              botToken: "xoxb-stub",
+              mode: "http",
+              signingSecret: "stub-secret", // pragma: allowlist secret
+            },
+          },
+        }),
+      ),
+    ).rejects.toMatchObject({
+      code: "CHANNEL_MODE_UNSUPPORTED",
+      httpStatus: 409,
+      details: { kind: "slack", mode: "http", status: "unsupported" },
+    });
+
+    // Verifier-side proof: no credential validation, no test connection, no DB write.
+    expect(writeTxn).not.toHaveBeenCalled();
+  });
+
+  it("B1: setup.channels.test accepts kind='slack' + mode='socket' (regression: socket mode still works)", async () => {
+    const { deps } = makeDeps({ setupCompletedAt: null });
+    const route = findMutatingRoute(createFridaySetupRoutes(deps), "setup.channels.test");
+
+    const result = await route.handler(
+      makeCtx({
+        ip: "127.0.0.1",
+        body: {
+          kind: "slack",
+          config: { botToken: "xoxb-stub", mode: "socket", appToken: "xapp-stub" },
+        },
+      }),
+    );
+
+    expect(result).toMatchObject({ kind: "slack", validated: true });
+  });
+
+  it("B1: setup.channels.save refuses any channels[].kind='slack' + mode='http' with CHANNEL_MODE_UNSUPPORTED 409", async () => {
+    const { deps, writeTxn, activateSavedChannels, onChannelsSaved } = makeDeps({ setupCompletedAt: null });
+    const route = findMutatingRoute(createFridaySetupRoutes(deps), "setup.channels.save");
+
+    await expect(
+      route.handler(
+        makeCtx({
+          ip: "127.0.0.1",
+          body: {
+            controlConfirmed: true,
+            channels: [
+              {
+                kind: "slack",
+                enabled: true,
+                config: {
+                  botToken: "xoxb-stub",
+                  mode: "http",
+                  signingSecret: "stub-secret", // pragma: allowlist secret
+                },
+              },
+            ],
+          },
+        }),
+      ),
+    ).rejects.toMatchObject({
+      code: "CHANNEL_MODE_UNSUPPORTED",
+      httpStatus: 409,
+      details: { kind: "slack", mode: "http", status: "unsupported" },
+    });
+
+    // Verifier-side proof: no channel persisted, no activation, no callback fired.
+    expect(writeTxn).not.toHaveBeenCalled();
+    expect(activateSavedChannels).not.toHaveBeenCalled();
+    expect(onChannelsSaved).not.toHaveBeenCalled();
+  });
+
+  it("B1: setup.channels.save order-independent: slack+http after disabled discord still gets CHANNEL_MODE_UNSUPPORTED", async () => {
+    const { deps, writeTxn, activateSavedChannels, onChannelsSaved } = makeDeps({ setupCompletedAt: null });
+    const route = findMutatingRoute(createFridaySetupRoutes(deps), "setup.channels.save");
+
+    await expect(
+      route.handler(
+        makeCtx({
+          ip: "127.0.0.1",
+          body: {
+            controlConfirmed: true,
+            channels: [
+              { kind: "discord", enabled: false, config: {} },
+              {
+                kind: "slack",
+                enabled: true,
+                config: {
+                  botToken: "xoxb-stub",
+                  mode: "http",
+                  signingSecret: "stub-secret", // pragma: allowlist secret
+                },
+              },
+            ],
+          },
+        }),
+      ),
+    ).rejects.toMatchObject({
+      code: "CHANNEL_MODE_UNSUPPORTED",
+      httpStatus: 409,
+    });
+
+    expect(writeTxn).not.toHaveBeenCalled();
+    expect(activateSavedChannels).not.toHaveBeenCalled();
+    expect(onChannelsSaved).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

B1 medium-severity sweep, slice 11. AUTO_DECISION_POLICY (\"prefer truthful unsupported over pretending\") applied to the Slack HTTP-mode capability.

The audit framed this as \"verifySlackSignature missing timestamp validation\" (HIGH). Closer reading shows the framing misses the bigger truth: `verifySlackSignature` has **zero production callers**, and `createSlackHttpEventService.start()` just flips an internal flag without binding an HTTP server. A user who configures slack+http would see no inbound messages while the channel reports `httpListening: true`.

Truth-label `slack` + `mode: \"http\"` as unsupported until the listener AND signature verifier (incl. timestamp freshness) are wired together and proven end-to-end. Slack `mode: \"socket\"` is fully functional and remains supported.

## What changed (4 source/test files + secrets-baseline line-shift refresh)

**`src/channels/friday-channel-config.ts`**
- New `FRIDAY_UNSUPPORTED_CHANNEL_MODES`: `{ slack: [\"http\"] }` (mode-conditional analog of `FRIDAY_UNSUPPORTED_CHANNEL_KINDS`).
- New `isFridayChannelModeSupported(kind, mode)`: returns false only for combinations in the map; returns true for undefined mode (schema default is supported).
- 12-line docstring documents the unwired-stub rationale.

**`src/channels/index.ts`**
- Barrel re-exports the new constant + helper.

**`src/api/http/routes/friday-setup-routes.ts`**
- Parallel boundary check at both `setup.channels.test` and `setup.channels.save`, **after normalize** (so the inspected `mode` reflects schema defaults rather than raw request input) and **before any secret-write or persistence**.
- Throws `CHANNEL_MODE_UNSUPPORTED` 409 with `details: { kind, mode, status: \"unsupported\" }`. Position-independent: loop iterates per-channel, so slack+http rejected wherever it sits in the array.

**`test/unit/api/http/routes/friday-setup-routes.test.ts`**
- 4 new tests:
  1. test refuses slack+mode=http
  2. test accepts slack+mode=socket (regression — socket mode still works)
  3. save refuses any channels[].slack+mode=http
  4. save order-independent: slack+http after disabled discord still 409
- All 4 verifier-side: `writeTxn` / `activateSavedChannels` / `onChannelsSaved` not called on rejection.

**`.secrets.baseline`**
- Line-shift refresh (2080 → 2082 for the existing test-fixture allowlist marker in friday-setup-routes.ts).

## What this slice does NOT do

- Does NOT touch `verifySlackSignature` (the function has zero production callers; modifying it would be the fake-proof pattern — when a future slice wires the listener, that slice will fix the verifier with proof from the wired route).
- Does NOT add `\"slack\"` to `FRIDAY_UNSUPPORTED_CHANNEL_KINDS` (would kill the working socket mode).
- Does NOT remove the slack-http schema branch (mode is a literal in the Zod union; removing it would break unrelated paths and violate HR11 backward-compat).

## Test plan

- [x] Focused: 36/36 setup-routes tests (existing 32 + 4 new)
- [x] Blast-radius: 1445/1445 across `test/unit/channels/` + `test/unit/api/http/` + `test/contracts/`
- [x] tsc clean
- [x] eslint 0 errors (14 pre-existing unrelated warnings)
- [x] secret scan clean post baseline line-shift refresh
- [x] git diff --check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)