### PR TITLE
B2 Slice 1: hanging-fetch timeout for slack alert-webhook dispatch (504)

### DIFF
--- a/src/observability/services/friday-observability-api-service.ts
+++ b/src/observability/services/friday-observability-api-service.ts
@@ -307,7 +307,20 @@ export interface CreateFridayObservabilityApiServiceDeps {
   browserDiagnosticsProvider?: () => FridayObservabilityBrowserRuntimeSummary | undefined;
   heartbeatStateGetter?: () => { lastRunAt: string | null; result: string; intervalMs: number | null; nextRunAt: string | null } | null;
   heartbeatTrigger?: () => unknown | Promise<unknown>;
+  /**
+   * Per-attempt timeout (ms) for outbound Slack alert-webhook dispatch.
+   *
+   * B2 hanging-fetch boundary: without this, `deliverToDestination` could hang
+   * indefinitely against an unresponsive Slack endpoint, blocking the per-
+   * dedupeKey retry loop forever. Default 10s matches the project convention
+   * for short-lived webhook calls (see `src/studio/friday-studio-service.ts`
+   * and `src/providers/oauth/friday-anthropic-oauth.ts`).
+   */
+  webhookTimeoutMs?: number;
 }
+
+/** Default per-attempt timeout for the slack-webhook fetch. */
+const FRIDAY_DEFAULT_WEBHOOK_TIMEOUT_MS = 10_000;
 
 export const FRIDAY_BUILT_IN_SELF_HEALING_ALERT_RULE_ID = "builtin-self-healing-repeat-failures";
 const BUILT_IN_ALERT_DISPATCH_FAILURE_RULE_ID = "builtin-alert-dispatch-failures";
@@ -1495,14 +1508,33 @@ export function createFridayObservabilityApiService(
         if (!webhookUrl) {
           throw new FridayDomainError("NOT_FOUND", `Missing Slack webhook secret for ${destination.id}`, { httpStatus: 404 });
         }
-        const response = await fetch(webhookUrl, {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({
-            text: `${subject}\n${body}`,
-            channel: destination.config.channel,
-          }),
-        });
+        const webhookTimeoutMs = deps.webhookTimeoutMs ?? FRIDAY_DEFAULT_WEBHOOK_TIMEOUT_MS;
+        let response: Response;
+        try {
+          response = await fetch(webhookUrl, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              text: `${subject}\n${body}`,
+              channel: destination.config.channel,
+            }),
+            signal: AbortSignal.timeout(webhookTimeoutMs),
+          });
+        } catch (fetchError) {
+          // B2 hanging-fetch boundary: translate AbortSignal.timeout AbortError
+          // into a domain-typed 504 so the failure is recoverable (clear error,
+          // no hang) and the retry loop at the call site can advance per-
+          // attempt. Other fetch failures (DNS, refused) propagate via the
+          // outer catch with their original message.
+          if (fetchError instanceof Error && (fetchError.name === "TimeoutError" || fetchError.name === "AbortError")) {
+            throw new FridayDomainError(
+              "OBSERVABILITY_WEBHOOK_TIMEOUT",
+              `Slack webhook timed out after ${webhookTimeoutMs}ms`,
+              { httpStatus: 504, retryable: true, details: { destinationId: destination.id, timeoutMs: webhookTimeoutMs } },
+            );
+          }
+          throw fetchError;
+        }
         if (!response.ok) {
           throw new FridayDomainError("INTERNAL_ERROR", `Slack webhook responded with ${response.status}`, { httpStatus: 500 });
         }

--- a/test/unit/observability/services/friday-observability-api-service.test.ts
+++ b/test/unit/observability/services/friday-observability-api-service.test.ts
@@ -38,6 +38,7 @@ describe("createFridayObservabilityApiService", () => {
 
   function createService(options?: {
     browserDiagnosticsProvider?: Parameters<typeof createFridayObservabilityApiService>[0]["browserDiagnosticsProvider"];
+    webhookTimeoutMs?: number;
   }) {
     const db = createTestDb();
     allocatedDbs.push(db);
@@ -46,6 +47,7 @@ describe("createFridayObservabilityApiService", () => {
       idGenerator: createTestIdGenerator(),
       nowIso: () => NOW,
       browserDiagnosticsProvider: options?.browserDiagnosticsProvider,
+      webhookTimeoutMs: options?.webhookTimeoutMs,
     });
   }
 
@@ -587,6 +589,80 @@ describe("createFridayObservabilityApiService", () => {
       expect(receivedBodies.length).toBeGreaterThanOrEqual(1);
       expect(receivedBodies[0]).toContain("Repeated self-healing failures");
     } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+    }
+  });
+
+  // B2 hanging-fetch boundary: a Slack webhook server that accepts the
+  // connection but never responds must NOT block the dispatch loop forever.
+  // The per-attempt timeout must fire and surface as a failed attempt with a
+  // clear timeout error message; the audit row must record `outcome: failure`.
+  it("B2 hanging-fetch: slack-webhook dispatch fails fast when the endpoint never responds", async () => {
+    // Server accepts the TCP connection but never writes any HTTP response.
+    const heldSockets: net.Socket[] = [];
+    const server = http.createServer((req) => {
+      heldSockets.push(req.socket);
+      req.on("data", () => { /* swallow */ });
+      // Intentionally never call res.end() / res.writeHead().
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Expected a bound HTTP server address");
+    }
+
+    try {
+      // 60ms keeps the test fast (3 attempts × 60ms ≈ 180ms + 25 + 50ms
+      // exponential backoff between retries = ~255ms) while still well above
+      // typical CI scheduler jitter.
+      const service = createService({ webhookTimeoutMs: 60 });
+      const destination = await service.routes.alertDestinations.create({
+        type: "slack",
+        name: "Hanging Slack",
+        webhookUrl: `http://127.0.0.1:${address.port}/slack-webhook`,
+        channel: "#ops",
+      });
+
+      service.recordSelfHealingProcessResults({
+        results: [
+          {
+            incidentsCreated: [
+              { incidentId: "hang-a", userId: "user-1", category: "workflow", severity: "high", signature: "fail-a", status: "open", createdAt: NOW },
+              { incidentId: "hang-b", userId: "user-1", category: "workflow", severity: "high", signature: "fail-b", status: "open", createdAt: NOW },
+              { incidentId: "hang-c", userId: "user-1", category: "workflow", severity: "high", signature: "fail-c", status: "open", createdAt: NOW },
+            ],
+            diagnosisCreated: [],
+          },
+        ],
+      });
+      await service.drainAuditWrites();
+
+      const alert = service.routes.alerts.list({}).items[0];
+      expect(alert).toBeDefined();
+
+      const dispatchStart = Date.now();
+      const response = await service.routes.alerts.testDispatch(alert!.id, {
+        destinationId: destination.destination.id,
+      });
+      const dispatchDuration = Date.now() - dispatchStart;
+
+      // Fail-fast proof: 3 attempts each ~60ms + ~75ms total exponential
+      // backoff. Cap at 5s so the test catches a real hang, not jitter.
+      expect(dispatchDuration).toBeLessThan(5_000);
+
+      // 3 attempts in the retry loop; all must have failed with the timeout
+      // error message. The attempt-status check implicitly proves the failure
+      // path completed without further hang — the catch block's awaited
+      // `appendDispatchAudit` must have returned for the result to be visible.
+      expect(response.attempts.length).toBeGreaterThanOrEqual(1);
+      for (const attempt of response.attempts) {
+        expect(attempt.status).toBe("failed");
+        expect(attempt.errorMessage).toMatch(/timed out after 60ms/i);
+      }
+    } finally {
+      for (const socket of heldSockets) {
+        socket.destroy();
+      }
       await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
     }
   });


### PR DESCRIPTION
## Summary

B2 first slice — close a real B2 hanging-fetch boundary in the observability alert-dispatch pipeline.

`deliverToDestination` at `friday-observability-api-service.ts:1498` called `fetch(webhookUrl)` with no timeout. If a Slack endpoint accepts the TCP connection but never writes an HTTP response, the call hangs indefinitely. Because the per-dedupeKey retry loop at line 1606 calls `deliverToDestination` in series for up to 3 attempts, a single unresponsive Slack endpoint **blocks the entire alert-dispatch pipeline forever**.

## What changed (2 files, +116/-8)

**`src/observability/services/friday-observability-api-service.ts`**
- New `webhookTimeoutMs?: number` dep with `FRIDAY_DEFAULT_WEBHOOK_TIMEOUT_MS = 10_000`. Convention matches `studio/friday-studio-service.ts` (12s) and `providers/oauth/friday-anthropic-oauth.ts` (15s); 10s is conservative for Slack which normally responds in <1s.
- `fetch(webhookUrl, { ..., signal: AbortSignal.timeout(timeoutMs) })`.
- Catch the timeout (AbortError / TimeoutError name) and re-throw as `FridayDomainError(\"OBSERVABILITY_WEBHOOK_TIMEOUT\", ..., { httpStatus: 504, retryable: true, details: { destinationId, timeoutMs } })` so the failure is recoverable (clear error, no hang) and the existing retry loop can advance per-attempt instead of blocking on the first one. Non-timeout fetch errors (DNS, connection refused) propagate via the outer catch with their original message.

**`test/unit/observability/services/friday-observability-api-service.test.ts`**
- `createService` test helper accepts optional `webhookTimeoutMs`.
- 1 new test \"B2 hanging-fetch: slack-webhook dispatch fails fast when the endpoint never responds\": stands up an HTTP server that accepts the connection and never calls `res.end()`, runs `testDispatch` with `webhookTimeoutMs: 60`, asserts total dispatch duration <5s, asserts every retry attempt is `failed` with message matching `/timed out after 60ms/i`.

## What this slice does NOT do

- Does NOT add a fetch timeout to SMTP (`sendSmtpMail` at line 637) — that branch has its own native socket pattern; carry-forward as a sibling B2 finding.
- Does NOT add SSRF / URL validation on `webhookUrl` — admin-supplied configuration only; out of scope here. Could be a separate B0-shaped follow-up.
- Does NOT modify the 3-attempt retry loop or its 25ms→50ms backoff.

## Test plan

- [x] Focused: 18/18 observability-api-service tests (existing 17 + 1 new)
- [x] Blast-radius: 301/301 across `test/unit/observability/` + `test/contracts/`
- [x] tsc clean
- [x] eslint 0 errors (6 pre-existing unrelated warnings)
- [x] secret scan clean
- [x] git diff --check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)