### PR TITLE
B2 Slice 2: hanging-fetch timeout for SMTP alert dispatch (504)

### DIFF
--- a/src/observability/services/friday-observability-api-service.ts
+++ b/src/observability/services/friday-observability-api-service.ts
@@ -317,10 +317,22 @@ export interface CreateFridayObservabilityApiServiceDeps {
    * and `src/providers/oauth/friday-anthropic-oauth.ts`).
    */
   webhookTimeoutMs?: number;
+  /**
+   * Per-attempt timeout (ms) for outbound SMTP alert-email dispatch.
+   *
+   * B2 hanging-fetch boundary (sibling to webhookTimeoutMs): without this,
+   * `sendSmtpMail` could hang indefinitely against an unresponsive SMTP
+   * endpoint — either during TCP/TLS connect or while waiting for any
+   * `readResponse` between commands. Default 10s matches the webhook timeout.
+   */
+  smtpTimeoutMs?: number;
 }
 
 /** Default per-attempt timeout for the slack-webhook fetch. */
 const FRIDAY_DEFAULT_WEBHOOK_TIMEOUT_MS = 10_000;
+
+/** Default per-attempt timeout for SMTP socket operations. */
+const FRIDAY_DEFAULT_SMTP_TIMEOUT_MS = 10_000;
 
 export const FRIDAY_BUILT_IN_SELF_HEALING_ALERT_RULE_ID = "builtin-self-healing-repeat-failures";
 const BUILT_IN_ALERT_DISPATCH_FAILURE_RULE_ID = "builtin-alert-dispatch-failures";
@@ -657,9 +669,24 @@ async function sendSmtpMail(input: {
   recipients: string[];
   subject: string;
   body: string;
+  /** Hard inactivity / connect deadline. Each read or connect attempt must
+   *  complete within this many milliseconds, or the socket is destroyed and
+   *  the operation rejects with a clear timeout error. */
+  timeoutMs: number;
 }): Promise<void> {
   const socket = await new Promise<net.Socket | tls.TLSSocket>((resolve, reject) => {
-    const onError = (error: Error) => reject(error);
+    let settled = false;
+    const onError = (error: Error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(connectTimer);
+      reject(error);
+    };
+    const connectTimer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      reject(new Error(`SMTP connection to ${input.host}:${input.port} timed out after ${input.timeoutMs}ms`));
+    }, input.timeoutMs);
     if (input.secure) {
       const connection = tls.connect(
         {
@@ -667,13 +694,32 @@ async function sendSmtpMail(input: {
           port: input.port,
           servername: input.host,
         },
-        () => resolve(connection),
+        () => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(connectTimer);
+          resolve(connection);
+        },
       );
       connection.once("error", onError);
       return;
     }
-    const connection = net.connect({ host: input.host, port: input.port }, () => resolve(connection));
+    const connection = net.connect({ host: input.host, port: input.port }, () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(connectTimer);
+      resolve(connection);
+    });
     connection.once("error", onError);
+  });
+
+  // B2 hanging-fetch boundary: per-operation inactivity timeout. If any
+  // subsequent readResponse waits longer than `timeoutMs` for the next byte,
+  // node emits 'timeout'; destroy the socket so the pending readResponse
+  // rejects via its 'error' listener with a clear timeout message.
+  socket.setTimeout(input.timeoutMs);
+  socket.on("timeout", () => {
+    socket.destroy(new Error(`SMTP server at ${input.host}:${input.port} inactive for ${input.timeoutMs}ms`));
   });
 
   let buffer = "";
@@ -1543,17 +1589,36 @@ export function createFridayObservabilityApiService(
         if (!password && destination.config.username) {
           throw new FridayDomainError("NOT_FOUND", `Missing SMTP password secret for ${destination.id}`, { httpStatus: 404 });
         }
-        await sendSmtpMail({
-          host: destination.config.smtpHost,
-          port: destination.config.smtpPort,
-          secure: destination.config.smtpSecure,
-          username: destination.config.username,
-          password: password ?? undefined,
-          fromAddress: destination.config.fromAddress,
-          recipients: destination.config.recipients,
-          subject,
-          body,
-        });
+        const smtpTimeoutMs = deps.smtpTimeoutMs ?? FRIDAY_DEFAULT_SMTP_TIMEOUT_MS;
+        try {
+          await sendSmtpMail({
+            host: destination.config.smtpHost,
+            port: destination.config.smtpPort,
+            secure: destination.config.smtpSecure,
+            username: destination.config.username,
+            password: password ?? undefined,
+            fromAddress: destination.config.fromAddress,
+            recipients: destination.config.recipients,
+            subject,
+            body,
+            timeoutMs: smtpTimeoutMs,
+          });
+        } catch (smtpError) {
+          // B2 hanging-fetch boundary: translate SMTP connect/inactivity
+          // timeout into a domain-typed 504 so the failure is recoverable
+          // and the retry loop can advance per-attempt instead of hanging.
+          // Other SMTP failures (auth refusal, recipient rejection, real
+          // network errors) propagate via the outer catch with their
+          // original message.
+          if (smtpError instanceof Error && /timed out|inactive for/i.test(smtpError.message)) {
+            throw new FridayDomainError(
+              "OBSERVABILITY_SMTP_TIMEOUT",
+              smtpError.message,
+              { httpStatus: 504, retryable: true, details: { destinationId: destination.id, timeoutMs: smtpTimeoutMs } },
+            );
+          }
+          throw smtpError;
+        }
       }
 
       incrementCounter("friday.observability.alert_dispatches.total");

--- a/test/unit/observability/services/friday-observability-api-service.test.ts
+++ b/test/unit/observability/services/friday-observability-api-service.test.ts
@@ -39,6 +39,7 @@ describe("createFridayObservabilityApiService", () => {
   function createService(options?: {
     browserDiagnosticsProvider?: Parameters<typeof createFridayObservabilityApiService>[0]["browserDiagnosticsProvider"];
     webhookTimeoutMs?: number;
+    smtpTimeoutMs?: number;
   }) {
     const db = createTestDb();
     allocatedDbs.push(db);
@@ -48,6 +49,7 @@ describe("createFridayObservabilityApiService", () => {
       nowIso: () => NOW,
       browserDiagnosticsProvider: options?.browserDiagnosticsProvider,
       webhookTimeoutMs: options?.webhookTimeoutMs,
+      smtpTimeoutMs: options?.smtpTimeoutMs,
     });
   }
 
@@ -754,6 +756,82 @@ describe("createFridayObservabilityApiService", () => {
       expect(conversations.join("")).toContain("RCPT TO:<ops@example.com>");
       expect(conversations.join("")).toContain("Repeated self-healing failures");
     } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+    }
+  });
+
+  // B2 hanging-fetch boundary (sibling to slack-webhook): an SMTP server that
+  // accepts the TCP connection but never writes the 220 greeting must NOT
+  // block the dispatch loop forever. Either the connect-deadline OR the
+  // post-connect per-operation timeout must fire and surface as a failed
+  // attempt with a clear timeout error message.
+  it("B2 hanging-fetch: SMTP dispatch fails fast when the endpoint never replies after connect", async () => {
+    // Server accepts connections but never writes a 220 greeting and never
+    // responds to commands. sendSmtpMail's first `readResponse("220")` is the
+    // one that hangs without a timeout — the socket inactivity timer must
+    // fire.
+    const heldSockets: net.Socket[] = [];
+    const server = net.createServer((socket) => {
+      heldSockets.push(socket);
+      // Intentionally never write anything.
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Expected a bound SMTP server address");
+    }
+
+    try {
+      // 80ms keeps the test fast (3 attempts × 80ms ≈ 240ms + ~75ms backoff
+      // ≈ 315ms total) while staying above typical CI scheduler jitter.
+      const service = createService({ smtpTimeoutMs: 80 });
+      const destination = await service.routes.alertDestinations.create({
+        type: "email",
+        name: "Hanging Email",
+        recipients: ["ops@example.com"],
+        fromAddress: "alerts@example.com",
+        smtpHost: "127.0.0.1",
+        smtpPort: address.port,
+        password: "smtp-password", // pragma: allowlist secret
+      });
+
+      service.recordSelfHealingProcessResults({
+        results: [
+          {
+            incidentsCreated: [
+              { incidentId: "smtp-hang-a", userId: "user-1", category: "workflow", severity: "high", signature: "fail-a", status: "open", createdAt: NOW },
+              { incidentId: "smtp-hang-b", userId: "user-1", category: "workflow", severity: "high", signature: "fail-b", status: "open", createdAt: NOW },
+              { incidentId: "smtp-hang-c", userId: "user-1", category: "workflow", severity: "high", signature: "fail-c", status: "open", createdAt: NOW },
+            ],
+            diagnosisCreated: [],
+          },
+        ],
+      });
+      await service.drainAuditWrites();
+
+      const alert = service.routes.alerts.list({}).items[0];
+      expect(alert).toBeDefined();
+
+      const dispatchStart = Date.now();
+      const response = await service.routes.alerts.testDispatch(alert!.id, {
+        destinationId: destination.destination.id,
+      });
+      const dispatchDuration = Date.now() - dispatchStart;
+
+      // Fail-fast proof: 3 attempts each ~80ms + ~75ms backoff. Cap at 5s so
+      // the test catches a real hang, not jitter.
+      expect(dispatchDuration).toBeLessThan(5_000);
+
+      expect(response.attempts.length).toBeGreaterThanOrEqual(1);
+      for (const attempt of response.attempts) {
+        expect(attempt.status).toBe("failed");
+        expect(attempt.errorMessage).toMatch(/timed out|inactive for/i);
+        expect(attempt.errorMessage).toMatch(/80ms/);
+      }
+    } finally {
+      for (const socket of heldSockets) {
+        socket.destroy();
+      }
       await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
     }
   });


### PR DESCRIPTION
## Summary

B2 Slice 2 — sibling to PR #314 (slack-webhook timeout). Closes the same hanging-fetch class for the SMTP branch of alert dispatch.

`sendSmtpMail` at `friday-observability-api-service.ts:650` uses native `tls.connect` / `net.connect` with no timeout, then reads SMTP responses via socket `'data'` events. If an SMTP server accepts the TCP connection but never writes the 220 greeting (or hangs mid-command), every `readResponse` hangs forever. The 3-attempt retry loop in `deliverToDestination` advances only if each attempt fails fast, so without this fix a single unresponsive SMTP endpoint **blocks the entire alert-dispatch pipeline indefinitely**.

## What changed (2 files, +157/-14)

**`src/observability/services/friday-observability-api-service.ts`**
- New `smtpTimeoutMs?: number` dep with `FRIDAY_DEFAULT_SMTP_TIMEOUT_MS = 10_000` (matches `webhookTimeoutMs`).
- New required `timeoutMs` on `sendSmtpMail` input.
- **Hard connect-deadline**: `setTimeout(timeoutMs)` around `tls.connect` / `net.connect`. Resolution / error / deadline are mutually exclusive via a `settled` flag — the promise can never resolve twice.
- **Per-operation inactivity timeout**: `socket.setTimeout(timeoutMs)` + `'timeout'` listener that destroys the socket with a clear error message. The pending `readResponse`'s existing `'error'` listener receives the error and rejects.
- `deliverToDestination` SMTP branch catches the timeout shape (`/timed out|inactive for/i`) and re-throws as `FridayDomainError(\"OBSERVABILITY_SMTP_TIMEOUT\", ..., { httpStatus: 504, retryable: true, details })`. Other SMTP failures (auth refusal, recipient rejection, real network errors) propagate with their original message.

**`test/unit/observability/services/friday-observability-api-service.test.ts`**
- `createService` accepts optional `smtpTimeoutMs`.
- 1 new test \"B2 hanging-fetch: SMTP dispatch fails fast when the endpoint never replies after connect\": stands up a `net.createServer` that accepts connections and never writes the 220 greeting. With `smtpTimeoutMs: 80`, asserts total dispatch duration <5s, every retry attempt is `failed` with message matching `/timed out|inactive for/i` and `/80ms/`.

## Test plan

- [x] Focused: 19/19 observability-api-service tests (existing 18 + 1 new)
- [x] Blast-radius: 302/302 across `test/unit/observability/` + `test/contracts/`
- [x] tsc clean
- [x] eslint 0 errors (6 pre-existing unrelated warnings)
- [x] secret scan clean
- [x] git diff --check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)