### PR TITLE
B3 Slice 1: hanging-fetch timeouts for LLM extraction + BYOK embedding (504)

### DIFF
--- a/src/memory/services/friday-memory-byok-embedding-client.ts
+++ b/src/memory/services/friday-memory-byok-embedding-client.ts
@@ -18,7 +18,20 @@ export interface FridayMemoryEmbeddingResponse {
 export interface CreateFridayMemoryByokEmbeddingClientDeps {
   providerService: FridayProviderService;
   embeddingModel?: string;
+  /**
+   * Per-attempt timeout (ms) for the outbound BYOK embedding fetch.
+   *
+   * B3 hanging-fetch boundary: without this, a hung embedding endpoint
+   * blocks every memory store/search/dedup operation that needs an
+   * embedding, propagating the hang up the cognition stack. Default 30s
+   * matches the typical embedding-call upper bound (shorter than full
+   * LLM completions because embeddings should be fast).
+   */
+  fetchTimeoutMs?: number;
 }
+
+/** Default per-attempt timeout for the BYOK embedding fetch. */
+const FRIDAY_DEFAULT_MEMORY_EMBEDDING_TIMEOUT_MS = 30_000;
 
 // ─── Supported API embedding endpoints ───
 
@@ -105,14 +118,32 @@ export function createFridayMemoryByokEmbeddingClient(
 
           const model = deps.embeddingModel ?? FRIDAY_MEMORY_DEFAULT_EMBEDDING_MODEL;
 
-          const response = await fetch(url, {
-            method: "POST",
-            headers,
-            body: JSON.stringify({
-              input: text,
-              model,
-            }),
-          });
+          const fetchTimeoutMs = deps.fetchTimeoutMs ?? FRIDAY_DEFAULT_MEMORY_EMBEDDING_TIMEOUT_MS;
+          let response: Response;
+          try {
+            response = await fetch(url, {
+              method: "POST",
+              headers,
+              body: JSON.stringify({
+                input: text,
+                model,
+              }),
+              signal: AbortSignal.timeout(fetchTimeoutMs),
+            });
+          } catch (fetchError) {
+            // B3 hanging-fetch boundary: translate AbortSignal.timeout into
+            // the existing EMBEDDING_UNAVAILABLE shape so the upstream
+            // fallback chain can advance instead of blocking the memory
+            // store/search/dedup pipeline indefinitely.
+            if (fetchError instanceof Error && (fetchError.name === "TimeoutError" || fetchError.name === "AbortError")) {
+              throw new FridayDomainError(
+                FRIDAY_MEMORY_ERROR_CODES.EMBEDDING_UNAVAILABLE,
+                `Embedding request timed out after ${fetchTimeoutMs}ms`,
+                { httpStatus: 504, retryable: true, details: { timeoutMs: fetchTimeoutMs } },
+              );
+            }
+            throw fetchError;
+          }
 
           if (!response.ok) {
             const body = await response.text().catch(() => "");

--- a/src/sessions/services/friday-session-memory-extraction-llm-client.ts
+++ b/src/sessions/services/friday-session-memory-extraction-llm-client.ts
@@ -25,7 +25,19 @@ import type { FridaySessionMessageRecord } from "../model/friday-session.types.j
 
 export interface CreateFridaySessionMemoryExtractionLlmClientDeps {
   providerService: FridayProviderService;
+  /**
+   * Per-attempt timeout (ms) for the outbound LLM extraction fetch.
+   *
+   * B3 hanging-fetch boundary: without this, a hung provider blocks the
+   * memory-extraction batch queue indefinitely. Default 60s matches typical
+   * upper bounds for LLM completion latency; longer than the slack/SMTP
+   * webhook defaults because LLM calls legitimately take longer.
+   */
+  fetchTimeoutMs?: number;
 }
+
+/** Default per-attempt timeout for the LLM extraction fetch. */
+const FRIDAY_DEFAULT_MEMORY_EXTRACTION_TIMEOUT_MS = 60_000;
 
 // ─── Client interface ───
 
@@ -378,11 +390,29 @@ export function createFridaySessionMemoryExtractionLlmClient(
             provider.config.authMode,
           );
 
-          const response = await fetch(url, {
-            method: "POST",
-            headers,
-            body: JSON.stringify(body),
-          });
+          const fetchTimeoutMs = deps.fetchTimeoutMs ?? FRIDAY_DEFAULT_MEMORY_EXTRACTION_TIMEOUT_MS;
+          let response: Response;
+          try {
+            response = await fetch(url, {
+              method: "POST",
+              headers,
+              body: JSON.stringify(body),
+              signal: AbortSignal.timeout(fetchTimeoutMs),
+            });
+          } catch (fetchError) {
+            // B3 hanging-fetch boundary: translate AbortSignal.timeout
+            // AbortError/TimeoutError into the existing PROVIDER_ERROR shape
+            // so the upstream fallback chain can advance to the next provider
+            // instead of blocking on a hung endpoint indefinitely.
+            if (fetchError instanceof Error && (fetchError.name === "TimeoutError" || fetchError.name === "AbortError")) {
+              throw new FridayDomainError(
+                FRIDAY_SESSION_MEMORY_EXTRACTION_ERROR_CODES.PROVIDER_ERROR,
+                `Provider ${provider.name} extraction timed out after ${fetchTimeoutMs}ms`,
+                { httpStatus: 504, retryable: true, details: { providerId: provider.id, timeoutMs: fetchTimeoutMs } },
+              );
+            }
+            throw fetchError;
+          }
 
           if (!response.ok) {
             const errorText = await response.text();

--- a/test/unit/memory/services/friday-memory-byok-embedding-client.test.ts
+++ b/test/unit/memory/services/friday-memory-byok-embedding-client.test.ts
@@ -171,4 +171,56 @@ describe("FridayMemoryByokEmbeddingClient", () => {
 
     await expect(client.embed("Hello")).rejects.toThrow(FridayDomainError);
   });
+
+  // ─── B3 hanging-fetch boundary ───
+
+  it("B3 hanging-fetch: embedding fetch aborts via AbortSignal.timeout and surfaces EMBEDDING_UNAVAILABLE 504", async () => {
+    const route = makeRoute("openai-completions");
+
+    // Mock fetch to honor the AbortSignal — when it fires, throw the
+    // TimeoutError shape that AbortSignal.timeout actually produces.
+    globalThis.fetch = vi.fn((_url: RequestInfo | URL, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal;
+        if (signal?.aborted) {
+          const err = new Error("The operation was aborted due to timeout");
+          err.name = "TimeoutError";
+          reject(err);
+          return;
+        }
+        signal?.addEventListener("abort", () => {
+          const err = new Error("The operation was aborted due to timeout");
+          err.name = "TimeoutError";
+          reject(err);
+        });
+        // Otherwise hang forever — the timeout must be what unblocks the test.
+      });
+    }) as typeof fetch;
+
+    const providerService: FridayProviderService = {
+      runWithFallback: vi.fn().mockImplementation(async (params) => {
+        const result = await params.run(route, "sk-test");
+        return {
+          result,
+          route,
+          attempts: [],
+          routingDecision: {
+            strategy: "direct",
+            reason: "test",
+            budget: { withinBudget: true, remainingUsd: 100, monthlyLimitUsd: 100, spentUsd: 0 },
+          },
+        };
+      }),
+    } as unknown as FridayProviderService;
+
+    client = createFridayMemoryByokEmbeddingClient({ providerService, fetchTimeoutMs: 60 });
+
+    const start = Date.now();
+    await expect(client.embed("Hello")).rejects.toMatchObject({
+      code: FRIDAY_MEMORY_ERROR_CODES.EMBEDDING_UNAVAILABLE,
+      httpStatus: 504,
+    });
+    const duration = Date.now() - start;
+    expect(duration).toBeLessThan(5_000); // fail-fast proof
+  });
 });

--- a/test/unit/sessions/services/friday-session-memory-extraction-llm-client.test.ts
+++ b/test/unit/sessions/services/friday-session-memory-extraction-llm-client.test.ts
@@ -1,8 +1,12 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   _validateLlmResponse,
   _parseJsonFromText,
+  createFridaySessionMemoryExtractionLlmClient,
 } from "../../../../src/sessions/services/friday-session-memory-extraction-llm-client.js";
+import type { FridayProviderService } from "#providers";
+import type { FridayResolvedProviderRoute } from "#providers";
+import { FRIDAY_SESSION_MEMORY_EXTRACTION_ERROR_CODES } from "../../../../src/sessions/friday-session-memory-extraction.constants.js";
 
 describe("FridaySessionMemoryExtractionLlmClient", () => {
   describe("parseJsonFromText", () => {
@@ -159,6 +163,99 @@ describe("FridaySessionMemoryExtractionLlmClient", () => {
       );
 
       expect(result.items[0].tags).toEqual(["valid", "ok"]);
+    });
+  });
+
+  // ─── B3 hanging-fetch boundary ───
+
+  describe("B3 hanging-fetch: extractMemoryItems aborts on timeout", () => {
+    const originalFetch = globalThis.fetch;
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+      vi.restoreAllMocks();
+    });
+
+    it("aborts a hung extraction fetch via AbortSignal.timeout and surfaces PROVIDER_ERROR 504", async () => {
+      const NOW = "2026-02-17T10:00:00.000Z";
+      const route: FridayResolvedProviderRoute = {
+        provider: {
+          id: "prov-1",
+          kind: "openai",
+          name: "OpenAI",
+          baseUrl: "https://api.openai.com",
+          enabled: true,
+          config: {
+            api: "openai-chat-completions" as FridayResolvedProviderRoute["provider"]["config"]["api"],
+            authMode: "api-key",
+            keySource: { kind: "none" },
+            supportedModels: ["gpt-4o-mini"],
+            taskProfiles: {
+              "memory-extraction": {
+                model: "gpt-4o-mini",
+                temperature: 0,
+              },
+            },
+          },
+          createdAt: NOW,
+          updatedAt: NOW,
+        } as unknown as FridayResolvedProviderRoute["provider"],
+        model: "gpt-4o-mini",
+      };
+
+      // Mock fetch to hang until the AbortSignal fires.
+      globalThis.fetch = vi.fn((_url: RequestInfo | URL, init?: RequestInit) => {
+        return new Promise<Response>((_resolve, reject) => {
+          const signal = init?.signal;
+          if (signal?.aborted) {
+            const err = new Error("The operation was aborted due to timeout");
+            err.name = "TimeoutError";
+            reject(err);
+            return;
+          }
+          signal?.addEventListener("abort", () => {
+            const err = new Error("The operation was aborted due to timeout");
+            err.name = "TimeoutError";
+            reject(err);
+          });
+        });
+      }) as typeof fetch;
+
+      const providerService: FridayProviderService = {
+        runWithFallback: vi.fn().mockImplementation(async (params) => {
+          const result = await params.run(route, "sk-test");
+          return {
+            result,
+            route,
+            attempts: [],
+            routingDecision: {
+              strategy: "direct",
+              reason: "test",
+              budget: { withinBudget: true, remainingUsd: 100, monthlyLimitUsd: 100, spentUsd: 0 },
+            },
+          };
+        }),
+      } as unknown as FridayProviderService;
+
+      const client = createFridaySessionMemoryExtractionLlmClient({
+        providerService,
+        fetchTimeoutMs: 60,
+      });
+
+      const start = Date.now();
+      await expect(
+        client.extractMemoryItems(
+          [
+            { id: "msg-1", sessionId: "sess-1", role: "user", content: "Test", createdAt: NOW } as never,
+          ],
+          5,
+          { tenantId: "tenant-1", userId: "user-1" } as never,
+        ),
+      ).rejects.toMatchObject({
+        code: FRIDAY_SESSION_MEMORY_EXTRACTION_ERROR_CODES.PROVIDER_ERROR,
+        httpStatus: 504,
+      });
+      const duration = Date.now() - start;
+      expect(duration).toBeLessThan(5_000); // fail-fast proof
     });
   });
 });


### PR DESCRIPTION
## Summary

B3 first slice — closes two real hanging-fetch boundaries in the memory cognition stack. Mirrors the B2 slack-webhook / SMTP pattern.

Before this slice:
- `friday-session-memory-extraction-llm-client.ts:381` issued `fetch(url, { method: \"POST\", ... })` with no AbortSignal. A hung provider blocked the memory-extraction batch queue indefinitely.
- `friday-memory-byok-embedding-client.ts:108` issued the embedding POST with no AbortController either. A hung embedding endpoint blocked every memory store / search / dedup operation that needed an embedding.

## What changed (4 files, +224/-14)

**`src/sessions/services/friday-session-memory-extraction-llm-client.ts`**
- New `fetchTimeoutMs?: number` dep with `FRIDAY_DEFAULT_MEMORY_EXTRACTION_TIMEOUT_MS = 60_000`. 60s matches typical LLM completion upper bounds — longer than the slack/SMTP defaults because LLM calls legitimately take longer.
- `fetch(url, { ..., signal: AbortSignal.timeout(timeoutMs) })`.
- Catch AbortError/TimeoutError and re-throw as `FridayDomainError(PROVIDER_ERROR, \"extraction timed out after Xms\", { httpStatus: 504, retryable: true })` so the upstream fallback chain in `providerService.runWithFallback` can advance to the next provider instead of blocking on a hung endpoint.

**`src/memory/services/friday-memory-byok-embedding-client.ts`**
- Same pattern: new `fetchTimeoutMs?: number` dep with `FRIDAY_DEFAULT_MEMORY_EMBEDDING_TIMEOUT_MS = 30_000`. Shorter than the LLM default because embeddings should be fast.
- `AbortSignal.timeout` on the fetch.
- Catch + re-throw as `FridayDomainError(EMBEDDING_UNAVAILABLE, ..., { httpStatus: 504, retryable: true })`.

**`test/unit/memory/services/friday-memory-byok-embedding-client.test.ts` + `test/unit/sessions/services/friday-session-memory-extraction-llm-client.test.ts`**
- 2 new tests (one per client). Each mocks `globalThis.fetch` to honor the passed AbortSignal — when aborted, rejects with a `TimeoutError` (same shape as `AbortSignal.timeout` produces). Configures the client with `fetchTimeoutMs: 60`. Asserts the call rejects with the expected `FridayDomainError` shape (504 + correct code) AND that dispatch duration <5s — fail-fast proof.

## What this slice does NOT do

- Does NOT touch any memory ranking, recall heuristic, or PII policy. This is purely a hanging-fetch safety boundary; B3's spec stop conditions (\"new memory policy\", \"destructive sync\", \"privacy conflict\", \"unproven semantic index default-on\") are not crossed.
- Does NOT wire `fetchTimeoutMs` through the hub bootstrap — callers use the default until a future configuration slice.
- Does NOT add retry logic. The existing fallback chain in `providerService.runWithFallback` already retries across providers; the timeout makes that chain advance correctly.

## Test plan

- [x] Focused: 24/24 across both client test files (existing 22 + 2 new)
- [x] Blast-radius: 742/742 across `test/unit/memory/` + `test/unit/sessions/` + `test/contracts/`
- [x] tsc clean
- [x] eslint 0 errors (4 pre-existing unrelated warnings)
- [x] secret scan clean
- [x] git diff --check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)