### PR TITLE
B3 Slice 3: wire memory access_count/last_accessed_at on intentional search/recall

### DIFF
--- a/src/memory/persistence/friday-memory-item-repository.ts
+++ b/src/memory/persistence/friday-memory-item-repository.ts
@@ -64,6 +64,23 @@ export interface FridayMemoryItemRepository {
     db: Database.Database,
     input: FridayMemorySearchQuery & { nowIso: string; limit: number },
   ): FridayMemoryFtsHit[];
+  /**
+   * Increment access_count by 1 and set last_accessed_at = nowIso for every
+   * id in `itemIds`.
+   *
+   * B3 cognition policy (conservative): callers should invoke this ONLY when
+   * an item is actually returned through an intentional memory search/recall
+   * path used by the agent (e.g. `memoryService.search()` after merge),
+   * NOT on every raw repository read (`getById`, `list`). This makes the
+   * counter mean "served to the agent as part of recall," not "row was
+   * fetched by some internal lookup."
+   *
+   * Returns the number of rows actually updated.
+   */
+  recordAccess(
+    db: Database.Database,
+    input: { itemIds: readonly string[]; nowIso: string },
+  ): number;
 }
 
 // ─── Helpers ───
@@ -241,6 +258,20 @@ export function createFridayMemoryItemRepository(): FridayMemoryItemRepository {
     deleteById(db, id) {
       const result = db.prepare("DELETE FROM memory_items WHERE id = ?").run(id);
       return result.changes > 0;
+    },
+
+    recordAccess(db, input) {
+      if (input.itemIds.length === 0) return 0;
+      const placeholders = input.itemIds.map(() => "?").join(",");
+      const result = db
+        .prepare(
+          `UPDATE memory_items
+              SET access_count = access_count + 1,
+                  last_accessed_at = ?
+            WHERE id IN (${placeholders})`,
+        )
+        .run(input.nowIso, ...input.itemIds);
+      return result.changes;
     },
 
     prune(db, options) {

--- a/src/memory/services/friday-memory-service.ts
+++ b/src/memory/services/friday-memory-service.ts
@@ -36,15 +36,20 @@ function warnOnce(warn: FridayWarnSink, key: string, message: string): void {
   warn(message);
 }
 
-function normalizeWarningKey(kind: "embedding" | "semantic", message: string): string {
+function normalizeWarningKey(kind: "embedding" | "semantic" | "access-counter", message: string): string {
   return `${kind}:${message}`;
 }
 
-function warnMemoryFallback(kind: "embedding" | "semantic", message: string): void {
+function warnMemoryFallback(kind: "embedding" | "semantic" | "access-counter", message: string): void {
   if (message.startsWith("No enabled providers available for routing")) {
     return;
   }
-  const label = kind === "embedding" ? "embedding failed" : "semantic search unavailable";
+  const label =
+    kind === "embedding"
+      ? "embedding failed"
+      : kind === "semantic"
+        ? "semantic search unavailable"
+        : "access-counter update failed (counter may lag)";
   warnOnce(
     console.warn as FridayWarnSink,
     normalizeWarningKey(kind, message),
@@ -277,10 +282,33 @@ export function createFridayMemoryService(
         }
       }
 
+      // B3 cognition policy (conservative): record access ONLY for items that
+      // were actually returned through this intentional search path. We do not
+      // increment on raw `get()` / `list()` reads — the counter is meant to
+      // mean "served to the agent as part of recall," not "row was fetched by
+      // some internal lookup."
+      if (results.length > 0) {
+        try {
+          deps.db.withWriteTransaction((db) =>
+            itemRepo.recordAccess(db, {
+              itemIds: results.map((r) => r.item.id),
+              nowIso: now,
+            }),
+          );
+        } catch (err) {
+          // Best-effort telemetry — a failed access-counter write must NOT
+          // break the search. Log and continue with the already-merged
+          // results.
+          warnMemoryFallback("access-counter", err instanceof Error ? err.message : String(err));
+        }
+      }
+
       return results;
     },
 
     async get(itemId) {
+      // B3 cognition policy: raw `get()` does NOT increment access_count.
+      // Only intentional recall via `search()` is a counted access.
       return deps.db.withReadConnection((db) => itemRepo.getById(db, itemId));
     },
 

--- a/test/unit/memory/persistence/friday-memory-item-repository.test.ts
+++ b/test/unit/memory/persistence/friday-memory-item-repository.test.ts
@@ -508,4 +508,53 @@ describe("FridayMemoryItemRepository", () => {
     expect(hits.length).toBeGreaterThanOrEqual(1);
     expect(hits[0].itemId).toBe("legacy-1");
   });
+
+  // ─── B3 access-counter ───
+
+  describe("recordAccess (B3 conservative increment semantics)", () => {
+    it("increments access_count by 1 and sets last_accessed_at for every id", () => {
+      const itemA = makeItem({ id: "a", key: "a", accessCount: 0, lastAccessedAt: undefined });
+      const itemB = makeItem({ id: "b", key: "b", accessCount: 5, lastAccessedAt: "2026-02-10T00:00:00.000Z" });
+      const itemC = makeItem({ id: "c", key: "c", accessCount: 0 });
+      db.writer.transaction(() => {
+        repo.insert(db.writer, itemA);
+        repo.insert(db.writer, itemB);
+        repo.insert(db.writer, itemC);
+      })();
+
+      const accessedAt = "2026-02-17T11:00:00.000Z";
+      const changed = repo.recordAccess(db.writer, { itemIds: ["a", "b"], nowIso: accessedAt });
+      expect(changed).toBe(2);
+
+      const a = repo.getById(db.writer, "a")!;
+      const b = repo.getById(db.writer, "b")!;
+      const c = repo.getById(db.writer, "c")!;
+      expect(a.accessCount).toBe(1);
+      expect(a.lastAccessedAt).toBe(accessedAt);
+      expect(b.accessCount).toBe(6);
+      expect(b.lastAccessedAt).toBe(accessedAt);
+      // c was NOT in the recordAccess set — counter must stay at 0.
+      expect(c.accessCount).toBe(0);
+      expect(c.lastAccessedAt).toBeUndefined();
+    });
+
+    it("returns 0 and is a no-op when itemIds is empty", () => {
+      const item = makeItem({ accessCount: 4 });
+      db.writer.transaction(() => repo.insert(db.writer, item))();
+      const changed = repo.recordAccess(db.writer, { itemIds: [], nowIso: NOW });
+      expect(changed).toBe(0);
+      expect(repo.getById(db.writer, "item-1")!.accessCount).toBe(4);
+    });
+
+    it("multiple sequential calls accumulate the counter monotonically", () => {
+      const item = makeItem({ accessCount: 0 });
+      db.writer.transaction(() => repo.insert(db.writer, item))();
+      repo.recordAccess(db.writer, { itemIds: ["item-1"], nowIso: "2026-02-17T10:01:00.000Z" });
+      repo.recordAccess(db.writer, { itemIds: ["item-1"], nowIso: "2026-02-17T10:02:00.000Z" });
+      repo.recordAccess(db.writer, { itemIds: ["item-1"], nowIso: "2026-02-17T10:03:00.000Z" });
+      const final = repo.getById(db.writer, "item-1")!;
+      expect(final.accessCount).toBe(3);
+      expect(final.lastAccessedAt).toBe("2026-02-17T10:03:00.000Z");
+    });
+  });
 });

--- a/test/unit/memory/services/friday-memory-service.test.ts
+++ b/test/unit/memory/services/friday-memory-service.test.ts
@@ -448,4 +448,57 @@ describe("FridayMemoryService", () => {
       expect(results).toHaveLength(0);
     });
   });
+
+  // ─── B3 access-counter (conservative semantics) ───
+
+  describe("B3 access-counter: search increments, get/list do NOT", () => {
+    it("search() increments access_count + sets last_accessed_at only for items in the returned result set", async () => {
+      const recorded = await service.store("access-ns", "The quick brown fox jumps");
+      // Unrelated item lives in a DIFFERENT namespace so namespace-scoped search
+      // excludes it deterministically (independent of mock embedding noise).
+      const unrelated = await service.store("other-ns", "Unrelated content");
+      expect(recorded.accessCount === 0 || recorded.accessCount === undefined).toBe(true);
+
+      const results = await service.search("fox jumps", { namespace: "access-ns" });
+      const returnedIds = new Set(results.map((r) => r.item.id));
+      expect(returnedIds.has(recorded.id)).toBe(true);
+      expect(returnedIds.has(unrelated.id)).toBe(false);
+
+      const fetchedReturned = await service.get(recorded.id);
+      const fetchedUnrelated = await service.get(unrelated.id);
+
+      expect(fetchedReturned!.accessCount).toBe(1);
+      expect(fetchedReturned!.lastAccessedAt).toBeDefined();
+      // unrelated item was in a different namespace → not in result set →
+      // counter must stay 0/undef.
+      expect(fetchedUnrelated!.accessCount === 0 || fetchedUnrelated!.accessCount === undefined).toBe(true);
+      expect(fetchedUnrelated!.lastAccessedAt).toBeUndefined();
+    });
+
+    it("get() does NOT increment access_count (raw repository read)", async () => {
+      const stored = await service.store("raw-ns", "Raw read test");
+
+      // Multiple raw gets must not change the counter.
+      await service.get(stored.id);
+      await service.get(stored.id);
+      await service.get(stored.id);
+
+      const final = await service.get(stored.id);
+      // accessCount stays at the inserted value (0 / undefined).
+      expect(final!.accessCount === 0 || final!.accessCount === undefined).toBe(true);
+      expect(final!.lastAccessedAt).toBeUndefined();
+    });
+
+    it("repeated search hits accumulate the counter monotonically", async () => {
+      const stored = await service.store("monotonic-ns", "monotonic alpha beta gamma");
+
+      await service.search("monotonic", { namespace: "monotonic-ns" });
+      await service.search("monotonic", { namespace: "monotonic-ns" });
+      await service.search("monotonic", { namespace: "monotonic-ns" });
+
+      const final = await service.get(stored.id);
+      expect(final!.accessCount).toBe(3);
+      expect(final!.lastAccessedAt).toBeDefined();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

B3 Slice 3 — close the access-counter dead-write bug per the conservative cognition policy named in the user's direction:

> \"increment only when a memory item is actually returned through an intentional memory search/recall path used by the agent, not on every raw repository read.\"

Before this slice: `memory_items.access_count` was INSERTed with 0 and `last_accessed_at` was INSERTed with NULL, then both columns were read back via getById/list and surfaced through the API as if they tracked recall activity — but nothing ever incremented them. Any future ranking or recall heuristic that reads these fields was reading permanent zeros.

## What changed (4 files, +164/-3)

**`src/memory/persistence/friday-memory-item-repository.ts`**
- New `recordAccess(db, { itemIds, nowIso })` method — bulk `UPDATE memory_items SET access_count = access_count + 1, last_accessed_at = ? WHERE id IN (...)`. Returns rows updated. Empty itemIds is a no-op.
- Docstring documents the conservative-increment policy so future callers know NOT to invoke this on raw `getById`/`list` reads.

**`src/memory/services/friday-memory-service.ts`**
- After `mergeHybridResults` returns, call `recordAccess(itemIds, nowIso)` for the returned set inside a write transaction. Wrap in try/catch — a failed counter write must NOT break the search; surfaces via `warnMemoryFallback(\"access-counter\", ...)` (warn-once per message; new third-case kind added).
- `get()` does NOT call recordAccess — explicitly commented as the raw-read path that the policy reserves.

**`test/unit/memory/persistence/friday-memory-item-repository.test.ts`**
- 3 new tests: positive (increments + lastAccessedAt set for listed ids; non-listed ids untouched), no-op on empty input, monotonic accumulation across sequential calls.

**`test/unit/memory/services/friday-memory-service.test.ts`**
- 3 new tests: search() increments only returned items (different namespace ⇒ different result set proves isolation); get() does NOT increment after N raw reads; repeated search hits accumulate monotonically.

## What this slice does NOT do

- Does NOT change search ranking. Ranking still derives from `mergeHybridResults` weights/scores; access_count is recorded but not yet read by ranking.
- Does NOT cross any B3 stop condition. The policy decision (\"increment on intentional recall\") was explicitly named in the user's direction; no new memory-policy decision was made autonomously.
- Does NOT wire incrementing on `memory_search` directly (the agent tool) — `memory_search` already delegates to `memoryService.search()` so this slice covers it transitively.

## Test plan

- [x] Focused: 58/58 across both test files (existing 52 + 6 new)
- [x] Blast-radius: 344/344 across `test/unit/memory/` + `test/contracts/`
- [x] tsc clean
- [x] eslint 0 errors (4 pre-existing unrelated warnings)
- [x] secret scan clean
- [x] git diff --check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)