### PR TITLE
B3 Slice 4: truth-label memory dedup helper as not wired into store path

### DIFF
--- a/src/memory/services/friday-memory-dedup.ts
+++ b/src/memory/services/friday-memory-dedup.ts
@@ -1,13 +1,31 @@
 /**
- * Memory Dedup — Initiative D.2
+ * Memory Dedup — Initiative D.2 (proof_pending; NOT wired into store path)
  *
- * Prevents storing semantically duplicate memories within the
- * same namespace. Before storing, checks for existing items
- * with high similarity and merges if found.
+ * Provides a helper (`checkMemoryDuplicate`) that, given a candidate memory
+ * item and a search function, can detect semantically duplicate memories in
+ * the same namespace via similarity threshold. Also provides a `mergeMemoryContent`
+ * helper for downstream merge logic.
  *
- * Merge strategy:
- * - If score > threshold: update existing item's content, bump confidence
- * - If score <= threshold: store as new item
+ * **Current state (B3 truth-labeling):** the helper is NOT called from
+ * `friday-memory-service.ts`'s `store()` path. `memoryService.store()`
+ * persists every well-formed store request as a new row regardless of
+ * whether a near-duplicate already exists. This module's existence does
+ * NOT mean Friday's durable memory store de-duplicates incoming items.
+ *
+ * Wiring this helper into `store()` is a memory-policy decision that
+ * requires explicit product direction on:
+ * - similarity threshold (the 0.92 default is a placeholder, not a policy)
+ * - merge semantics (which fields take precedence: tags, metadata, TTL,
+ *   source, confidence, embedding)
+ * - confidence-bump behavior
+ * - data-loss / clobber expectations when "merging" overlapping items
+ * - audit trail when an item is merged vs. replaced vs. inserted-new
+ *
+ * Until that decision is made and the helper is wired with proof, callers
+ * MUST NOT assume dedup is active. The `assertFridayMemoryDedupNotActive`
+ * advisory is emitted once per process when this module is first imported
+ * so a future regression that silently wires this without policy review
+ * surfaces in logs.
  */
 
 import type {
@@ -48,14 +66,36 @@ export interface FridayMemoryDedupDeps {
 const DEFAULT_THRESHOLD = 0.92;
 const DEFAULT_MAX_CANDIDATES = 5;
 
+let memoryDedupAdvisoryEmitted = false;
+
+/**
+ * Emit a one-time advisory log so anyone reading runtime logs can see that
+ * this dedup machinery is loaded but not wired into the durable memory
+ * store path. Intentionally a `console.info` (not `warn`) so it's
+ * informational, not an error; warn-once semantics so it does not spam.
+ */
+function emitMemoryDedupAdvisoryOnce(): void {
+  if (memoryDedupAdvisoryEmitted) return;
+  memoryDedupAdvisoryEmitted = true;
+  console.info(
+    "[friday][memory-dedup] advisory: checkMemoryDuplicate is loaded but NOT wired into memoryService.store(). Durable memory store does not de-duplicate incoming items. Full dedup wiring is policy_pending (see file header).",
+  );
+}
+
 /**
  * Check whether a new memory is a duplicate of an existing one.
+ *
+ * B3 truth-labeling: this helper is callable but NOT invoked by the durable
+ * `memoryService.store()` path. Calling it from a caller that explicitly
+ * needs dedup is fine; do NOT assume that calling `memoryService.store()`
+ * implicitly de-duplicates incoming items.
  */
 export async function checkMemoryDuplicate(
   input: FridayMemoryStoreInput,
   deps: FridayMemoryDedupDeps,
   options?: FridayMemoryDedupOptions,
 ): Promise<FridayMemoryDedupResult> {
+  emitMemoryDedupAdvisoryOnce();
   const threshold = options?.threshold ?? DEFAULT_THRESHOLD;
   const maxCandidates = options?.maxCandidates ?? DEFAULT_MAX_CANDIDATES;
 

--- a/test/unit/memory/services/friday-memory-dedup.test.ts
+++ b/test/unit/memory/services/friday-memory-dedup.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { FridaySqliteLayer } from "#state";
+import {
+  createFridayMemoryService,
+  type FridayMemoryService,
+} from "#memory";
+import type { FridayMemorySearchResult } from "#memory";
+import { checkMemoryDuplicate } from "../../../../src/memory/services/friday-memory-dedup.js";
+import { createTestDb } from "../../satellites/_helpers/create-test-db.helper.js";
+
+const NOW = "2026-02-17T10:00:00.000Z";
+
+describe("friday-memory-dedup (B3 truth-labeling)", () => {
+  let db: FridaySqliteLayer;
+  let consoleInfoSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    db = createTestDb();
+    consoleInfoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    db.close();
+    consoleInfoSpy.mockRestore();
+  });
+
+  it("checkMemoryDuplicate emits a one-time advisory naming the proof_pending wiring", async () => {
+    const searchSpy = vi.fn<
+      (
+        query: string,
+        options?: Record<string, unknown>,
+      ) => Promise<FridayMemorySearchResult[]>
+    >(async () => []);
+
+    await checkMemoryDuplicate(
+      { namespace: "ns", content: "first call" },
+      { search: searchSpy },
+    );
+    await checkMemoryDuplicate(
+      { namespace: "ns", content: "second call" },
+      { search: searchSpy },
+    );
+    await checkMemoryDuplicate(
+      { namespace: "ns", content: "third call" },
+      { search: searchSpy },
+    );
+
+    // Advisory must fire exactly once, regardless of how many times the
+    // helper is called.
+    expect(consoleInfoSpy).toHaveBeenCalledTimes(1);
+    const advisoryMessage = consoleInfoSpy.mock.calls[0]![0] as string;
+    expect(advisoryMessage).toContain("checkMemoryDuplicate");
+    expect(advisoryMessage).toContain("NOT wired");
+    expect(advisoryMessage).toContain("memoryService.store()");
+    expect(advisoryMessage).toContain("policy_pending");
+  });
+
+  it("memoryService.store() does NOT call dedup (durable store path bypass)", async () => {
+    // The current truth: memoryService.store() persists every well-formed
+    // store request as a new row regardless of whether a near-duplicate
+    // already exists. This test will START FAILING the moment a future
+    // slice wires checkMemoryDuplicate into store() — that's intentional,
+    // it forces explicit policy review before the wiring lands.
+    const service: FridayMemoryService = createFridayMemoryService({
+      db,
+      providerService: {
+        runWithFallback: vi.fn().mockRejectedValue(new Error("embedding disabled for this test")),
+      } as never,
+      idGenerator: (() => {
+        let n = 0;
+        return () => `dedup-test-${++n}`;
+      })(),
+      nowIso: () => NOW,
+    });
+
+    const first = await service.store("dedup-ns", "The quick brown fox");
+    const second = await service.store("dedup-ns", "The quick brown fox");
+    const third = await service.store("dedup-ns", "The quick brown fox");
+
+    // 3 distinct rows persisted with 3 distinct ids — proof that dedup
+    // is NOT being applied at the store boundary.
+    expect(first.id).toBe("dedup-test-1");
+    expect(second.id).toBe("dedup-test-2");
+    expect(third.id).toBe("dedup-test-3");
+    expect(new Set([first.id, second.id, third.id]).size).toBe(3);
+
+    // The dedup advisory must NOT have fired — store() does not call into
+    // the dedup helper at all.
+    expect(consoleInfoSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("[friday][memory-dedup]"),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

B3 Slice 4 — truth-label `src/memory/services/friday-memory-dedup.ts`.

The module's prior doc header overclaimed:

> \"Prevents storing semantically duplicate memories within the same namespace. Before storing, checks for existing items with high similarity and merges if found.\"

In reality the helper has **zero callers** in production — `memoryService.store()` does not call `checkMemoryDuplicate`. Friday's durable memory store does **not** de-duplicate incoming items. Per user direction: prompt/docstring/test/advisory only, no store() behavior change and no merge/ranking policy change. Full dedup wiring is explicitly policy-blocked.

## What changed (2 files, +140/-7)

**`src/memory/services/friday-memory-dedup.ts`**
- File header docstring rewritten as proof_pending: explicitly names the module's NOT-wired state, names the helpers it provides, names the policy decisions that block full wiring (threshold, merge semantics, confidence bump, tags/metadata/TTL/source merge, embedding refresh, audit trail, data-loss/clobber expectations).
- New `emitMemoryDedupAdvisoryOnce()` warn-once helper.
- `checkMemoryDuplicate()` emits the one-time advisory at first call so anyone reading runtime logs sees the dedup machinery is loaded but not wired. JSDoc reiterates not-wired state for IDE tooltips.

**`test/unit/memory/services/friday-memory-dedup.test.ts`** (new)
- Test 1: `checkMemoryDuplicate` emits a one-time advisory matching the expected proof_pending message. Three calls in a row → advisory fires exactly once.
- Test 2: `memoryService.store()` does NOT call dedup — three sequential `store(\"same-namespace\", \"The quick brown fox\")` produce three distinct rows with distinct ids, AND the dedup advisory does NOT fire from the store path. This is THE locked truth. **Will fail loudly the moment a future slice wires `checkMemoryDuplicate` into `store()`** — intentional, forces explicit policy review before that wiring lands.

## What this slice does NOT do

- Does NOT wire `checkMemoryDuplicate` into `memoryService.store()`. That crosses a new-memory-policy boundary (threshold, merge, confidence bump, field precedence, embedding refresh, audit trail).
- Does NOT change any threshold, scoring, or merge logic.
- Does NOT add a configuration toggle for dedup.

## Test plan

- [x] Focused: 2/2 new dedup tests
- [x] Blast-radius: 346/346 across `test/unit/memory/` + `test/contracts/`
- [x] tsc clean
- [x] eslint 0 errors (1 `console.info` warning matches the pre-existing pattern in `friday-skill-lifecycle-service.ts`)
- [x] secret scan clean
- [x] git diff --check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)