### PR TITLE
B4 Slice 3: defense-in-depth path safety for desktop file_operation

### DIFF
--- a/src/agent/tools/friday-agent-desktop-tool.ts
+++ b/src/agent/tools/friday-agent-desktop-tool.ts
@@ -64,6 +64,68 @@ const VALID_MODIFIERS = new Set<FridayDesktopModifierKey>([
   "command",
 ]);
 
+/**
+ * POSIX absolute-path prefixes that desktop file_operation MUST NOT touch
+ * at parse-time. Defense-in-depth — the action-executor's sandbox boundary
+ * is the authoritative protection. This list is intentionally conservative
+ * (only the most obviously-system locations); broader allow-listing
+ * happens via the sandbox config.
+ */
+const FRIDAY_DESKTOP_SENSITIVE_POSIX_PREFIXES: readonly string[] = [
+  "/etc/",
+  "/proc/",
+  "/sys/",
+  "/dev/",
+  "/boot/",
+  "/root/",
+];
+
+/**
+ * Windows-equivalent sensitive prefixes (lowercased for case-insensitive
+ * compare; Windows paths are normalized to lowercase before matching).
+ */
+const FRIDAY_DESKTOP_SENSITIVE_WIN32_PREFIXES: readonly string[] = [
+  "c:\\windows\\",
+  "c:\\program files\\",
+  "c:\\program files (x86)\\",
+  "c:\\programdata\\",
+];
+
+/**
+ * Parse-time fast-reject for desktop file_operation paths.
+ *
+ * Catches:
+ * - `..` directory-traversal segments (any platform)
+ * - null bytes
+ * - absolute paths under well-known OS-system locations (POSIX `/etc/`,
+ *   `/proc/`, `/sys/`, `/dev/`, `/boot/`, `/root/`; Windows `C:\Windows\`,
+ *   `C:\Program Files\`, `C:\Program Files (x86)\`, `C:\ProgramData\`)
+ *
+ * Does NOT replace the sandbox boundary at `action-executor.ts`'s
+ * `evaluateSandboxBoundary`, which is the authoritative protection.
+ */
+function isUnsafeFileOperationPath(rawPath: string): boolean {
+  if (typeof rawPath !== "string" || rawPath.length === 0) return true;
+  // Null bytes can be used to truncate paths in some downstream consumers.
+  if (rawPath.includes("\0")) return true;
+  // P1-SEC-003: directory-traversal segments (preserved).
+  if (/(?:^|[\\/])\.\.(?:[\\/]|$)/.test(rawPath)) return true;
+  // POSIX absolute path under a sensitive prefix.
+  if (rawPath.startsWith("/")) {
+    for (const prefix of FRIDAY_DESKTOP_SENSITIVE_POSIX_PREFIXES) {
+      if (rawPath === prefix.slice(0, -1) || rawPath.startsWith(prefix)) return true;
+    }
+  }
+  // Windows absolute path under a sensitive prefix (case-insensitive).
+  if (/^[a-zA-Z]:[\\/]/.test(rawPath)) {
+    const normalized = rawPath.replace(/\//g, "\\").toLowerCase();
+    for (const prefix of FRIDAY_DESKTOP_SENSITIVE_WIN32_PREFIXES) {
+      if (normalized.startsWith(prefix)) return true;
+    }
+  }
+  return false;
+}
+
 function serializeDesktopActionResult(result: FridayDesktopActionResult): Record<string, unknown> {
   return {
     actionId: result.id,
@@ -483,11 +545,30 @@ export function createFridayAgentDesktopTool(
       }
       case "file_operation": {
         const filePath = readStringParam(args, "path", { required: true });
-        // P1-SEC-003: Reject paths with directory traversal segments
-        if (/(?:^|[\\/])\.\.(?:[\\/]|$)/.test(filePath)) {
+        // B4 defense-in-depth: parse-time fast-reject for known-attack paths.
+        // The action-executor's sandbox boundary (evaluateSandboxBoundary)
+        // is the authoritative protection — it normalizes, resolves real
+        // paths via realpath, and rejects anything outside configured
+        // sandbox roots. This parse-time check is a quick reject for the
+        // most obvious attack shapes so the action never even reaches the
+        // permission-guard / sandbox layer.
+        if (isUnsafeFileOperationPath(filePath)) {
           return null;
         }
         const operation = readStringParam(args, "operation") ?? "read";
+        // For move/copy, destinationPath gets the same check at parse-time.
+        if (operation === "move" || operation === "copy") {
+          const destinationPath = readStringParam(args, "destinationPath", { required: true });
+          if (isUnsafeFileOperationPath(destinationPath)) {
+            return null;
+          }
+          return {
+            type: "file_operation",
+            operation: operation as "move" | "copy",
+            path: filePath,
+            destinationPath,
+          };
+        }
         switch (operation) {
           case "write":
             return {
@@ -495,20 +576,6 @@ export function createFridayAgentDesktopTool(
               operation: "write" as const,
               path: filePath,
               content: readStringParam(args, "content") ?? "",
-            };
-          case "move":
-            return {
-              type: "file_operation",
-              operation: "move" as const,
-              path: filePath,
-              destinationPath: readStringParam(args, "destinationPath", { required: true }),
-            };
-          case "copy":
-            return {
-              type: "file_operation",
-              operation: "copy" as const,
-              path: filePath,
-              destinationPath: readStringParam(args, "destinationPath", { required: true }),
             };
           case "delete":
             return { type: "file_operation", operation: "delete" as const, path: filePath };

--- a/test/unit/agent/tools/friday-agent-desktop-tool.test.ts
+++ b/test/unit/agent/tools/friday-agent-desktop-tool.test.ts
@@ -546,6 +546,133 @@ describe("createFridayAgentDesktopTool", () => {
       const call = (sm.executeAction as ReturnType<typeof vi.fn>).mock.calls[0][0];
       expect(call.operation).toBe("read");
     });
+
+    // ─── B4 defense-in-depth: parse-time path safety ───
+    //
+    // The action-executor sandbox is the authoritative protection. This
+    // parse-time check is a quick reject for the most obvious attack
+    // shapes. These tests lock in the parse-time rejection set so future
+    // edits don't silently widen it.
+
+    it("B4 parse-time reject: '..' traversal in path returns Invalid action", async () => {
+      const sm = createMockSessionManager();
+      const tool = createFridayAgentDesktopTool({ desktopSessionManager: sm });
+      const result = await tool.execute(
+        { action: "execute", actionType: "file_operation", path: "../etc/passwd", operation: "read" },
+        signal(),
+      );
+      expect(result.isError).toBe(true);
+      expect(sm.executeAction).not.toHaveBeenCalled();
+    });
+
+    it("B4 parse-time reject: absolute POSIX system paths under /etc/, /proc/, /sys/, /dev/, /boot/, /root/", async () => {
+      const sensitivePaths = [
+        "/etc/passwd",
+        "/etc/shadow",
+        "/proc/self/mem",
+        "/sys/firmware/dmi/tables/smbios_entry_point",
+        "/dev/sda",
+        "/boot/grub/grub.cfg",
+        "/root/.ssh/authorized_keys",
+      ];
+      for (const p of sensitivePaths) {
+        const sm = createMockSessionManager();
+        const tool = createFridayAgentDesktopTool({ desktopSessionManager: sm });
+        const result = await tool.execute(
+          { action: "execute", actionType: "file_operation", path: p, operation: "read" },
+          signal(),
+        );
+        expect(result.isError, `should reject ${p}`).toBe(true);
+        expect(sm.executeAction, `should not call executeAction for ${p}`).not.toHaveBeenCalled();
+      }
+    });
+
+    it("B4 parse-time reject: Windows system paths (case-insensitive)", async () => {
+      const sensitivePaths = [
+        "C:\\Windows\\System32\\config\\SAM",
+        "c:\\windows\\system32\\config\\sam",
+        "C:\\Program Files\\Common Files\\something.exe",
+        "C:\\Program Files (x86)\\foo\\bar.dll",
+        "C:\\ProgramData\\Microsoft\\Crypto\\RSA",
+      ];
+      for (const p of sensitivePaths) {
+        const sm = createMockSessionManager();
+        const tool = createFridayAgentDesktopTool({ desktopSessionManager: sm });
+        const result = await tool.execute(
+          { action: "execute", actionType: "file_operation", path: p, operation: "read" },
+          signal(),
+        );
+        expect(result.isError, `should reject ${p}`).toBe(true);
+        expect(sm.executeAction, `should not call executeAction for ${p}`).not.toHaveBeenCalled();
+      }
+    });
+
+    it("B4 parse-time reject: null byte in path", async () => {
+      const sm = createMockSessionManager();
+      const tool = createFridayAgentDesktopTool({ desktopSessionManager: sm });
+      const result = await tool.execute(
+        { action: "execute", actionType: "file_operation", path: "/tmp/safe\0/../etc/passwd", operation: "read" },
+        signal(),
+      );
+      expect(result.isError).toBe(true);
+      expect(sm.executeAction).not.toHaveBeenCalled();
+    });
+
+    it("B4 parse-time accepts legitimate user paths (regression — no over-blocking)", async () => {
+      const legitimatePaths = [
+        "/tmp/notes.txt",
+        "/home/jarvis/project/file.md",
+        "/Users/jarvis/Desktop/document.pdf",
+        "C:\\Users\\Jarvis\\Documents\\file.txt",
+        "subdir/file.txt", // relative
+      ];
+      for (const p of legitimatePaths) {
+        const sm = createMockSessionManager();
+        const tool = createFridayAgentDesktopTool({ desktopSessionManager: sm });
+        const result = await tool.execute(
+          { action: "execute", actionType: "file_operation", path: p, operation: "read" },
+          signal(),
+        );
+        // Should NOT be a parse-time error — the action should reach
+        // executeAction (which the mock accepts).
+        expect(result.isError, `should NOT reject legitimate path ${p}`).toBeUndefined();
+        expect(sm.executeAction, `should call executeAction for ${p}`).toHaveBeenCalled();
+      }
+    });
+
+    it("B4 parse-time reject: move destinationPath also checked", async () => {
+      const sm = createMockSessionManager();
+      const tool = createFridayAgentDesktopTool({ desktopSessionManager: sm });
+      const result = await tool.execute(
+        {
+          action: "execute",
+          actionType: "file_operation",
+          path: "/tmp/safe.txt",
+          operation: "move",
+          destinationPath: "/etc/passwd",
+        },
+        signal(),
+      );
+      expect(result.isError).toBe(true);
+      expect(sm.executeAction).not.toHaveBeenCalled();
+    });
+
+    it("B4 parse-time reject: copy destinationPath also checked", async () => {
+      const sm = createMockSessionManager();
+      const tool = createFridayAgentDesktopTool({ desktopSessionManager: sm });
+      const result = await tool.execute(
+        {
+          action: "execute",
+          actionType: "file_operation",
+          path: "/tmp/safe.txt",
+          operation: "copy",
+          destinationPath: "/proc/self/mem",
+        },
+        signal(),
+      );
+      expect(result.isError).toBe(true);
+      expect(sm.executeAction).not.toHaveBeenCalled();
+    });
   });
 
   // ─── execute: read_element ───


### PR DESCRIPTION
## Summary

B4 Slice 3 — close the audit finding that the desktop tool's parse-time path check at `friday-agent-desktop-tool.ts:487` \"ONLY catches '..' segments. It does NOT block absolute paths to sensitive system files\".

The action-executor's sandbox boundary (`evaluateSandboxBoundary` in `src/desktop/engine/action-executor.ts:313`) is the authoritative protection — it normalizes paths, resolves real paths via `realpath`, and rejects anything outside configured `sandboxAllowedRoots`. This slice adds a **defense-in-depth fast-reject at parse time** so the most obvious attack shapes don't even reach the permission-guard / sandbox layer.

## What changed (2 files, +210/-16)

**`src/agent/tools/friday-agent-desktop-tool.ts`**
- New `FRIDAY_DESKTOP_SENSITIVE_POSIX_PREFIXES` (`/etc/`, `/proc/`, `/sys/`, `/dev/`, `/boot/`, `/root/`) and `WIN32_PREFIXES` (`C:\\Windows\\`, `C:\\Program Files\\`, `C:\\Program Files (x86)\\`, `C:\\ProgramData\\`) constants.
- New `isUnsafeFileOperationPath(p)` helper: rejects empty string, null bytes, `..` directory-traversal segments, POSIX absolute paths under the sensitive prefixes, and Windows absolute paths (case-insensitive).
- `file_operation` case calls `isUnsafeFileOperationPath` for `path` before constructing the action; for `move`/`copy`, also checks `destinationPath` before constructing the action.

**`test/unit/agent/tools/friday-agent-desktop-tool.test.ts`**
- 7 new tests covering:
  1. `..` traversal still rejected (regression)
  2. POSIX sensitive-prefix list (table-driven; 7 paths)
  3. Windows sensitive-prefix list (case-insensitive; 5 paths)
  4. Null-byte rejection
  5. Legitimate paths NOT rejected (regression — no over-blocking)
  6. `move` `destinationPath` also checked
  7. `copy` `destinationPath` also checked

## What this slice does NOT do

- Does NOT replace the action-executor sandbox boundary.
- Does NOT broaden the block list to legitimate user paths (e.g. `/home/user/...`, `/Users/...`, `C:\\Users\\...` are still allowed at parse-time; the sandbox config decides per-deployment).
- Does NOT add symlink resolution at parse-time — that happens in the sandbox boundary.

## Test plan

- [x] Focused: 62/62 desktop-tool tests (existing 55 + 7 new)
- [x] Blast-radius: 953/953 across `test/unit/agent/tools/` + `test/unit/desktop/` + `test/contracts/`
- [x] tsc clean
- [x] eslint 0 errors (2 pre-existing unrelated warnings)
- [x] secret scan clean
- [x] git diff --check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)