### PR TITLE
B4 Slice 4: rename computeFingerprint → computeStableFingerprint with truthful JSDoc

### DIFF
--- a/src/playbook/engine/index.ts
+++ b/src/playbook/engine/index.ts
@@ -24,7 +24,7 @@ export {
   createLearningEngine,
   extractPattern,
   canonicalizePattern,
-  computeFingerprint,
+  computeStableFingerprint,
 } from "./learning-engine.js";
 export type { ExecutionPattern, LearningEngineDeps } from "./learning-engine.js";
 

--- a/src/playbook/engine/learning-engine.ts
+++ b/src/playbook/engine/learning-engine.ts
@@ -64,15 +64,23 @@ export function canonicalizePattern(pattern: ExecutionPattern): string {
 }
 
 /**
- * Compute a SHA-256 fingerprint of a normalized execution pattern.
- * Uses a simple but effective string hashing algorithm (FNV-1a variant)
- * since we cannot use Node crypto in pure TypeScript without external deps.
+ * Compute a stable, deterministic, NON-cryptographic fingerprint of a
+ * normalized execution pattern.
  *
- * For production use, this would use `crypto.subtle.digest('SHA-256', ...)`.
- * This implementation provides deterministic, collision-resistant hashing
- * suitable for in-memory deduplication.
+ * **B4 truth-labeling note (replaces prior "SHA-256 fingerprint" claim):**
+ * This is FNV-1a 64-bit extended to 64 hex characters via an ad-hoc
+ * mixing post-process. The 64-char hex shape resembles SHA-256 output
+ * purely for downstream type/string compatibility — it is NOT a
+ * cryptographic hash and MUST NOT be relied on for integrity, signing,
+ * adversarial-input collision resistance, or any security-bearing
+ * decision. It is suitable for in-memory deduplication of trusted
+ * pattern objects where the only concern is "same input → same string".
+ *
+ * If a cryptographic fingerprint becomes required for an integrity or
+ * signing use case, the right call is `crypto.subtle.digest('SHA-256',
+ * ...)` — and the call sites should switch to that new function.
  */
-export function computeFingerprint(pattern: ExecutionPattern): string {
+export function computeStableFingerprint(pattern: ExecutionPattern): string {
   const input = canonicalizePattern(pattern);
   // FNV-1a 64-bit hash (split into two 32-bit parts for JS number safety)
   let h1 = 0x811c9dc5;
@@ -144,7 +152,7 @@ export function createLearningEngine(deps: LearningEngineDeps): FridayPlaybookCa
       event: FridayPlaybookRunCompletionEvent,
     ): Promise<FridayPlaybookCandidate | null> {
       const pattern = extractPattern(event);
-      const fingerprint = computeFingerprint(pattern);
+      const fingerprint = computeStableFingerprint(pattern);
       const existing = store.getCandidateByFingerprint(fingerprint, event.workflowType);
 
       if (event.success) {

--- a/test/unit/playbook/engine/learning-engine.test.ts
+++ b/test/unit/playbook/engine/learning-engine.test.ts
@@ -4,7 +4,7 @@ import {
   createLearningEngine,
   extractPattern,
   canonicalizePattern,
-  computeFingerprint,
+  computeStableFingerprint,
 } from "../../../../src/playbook/engine/learning-engine.js";
 import type { PlaybookStore } from "../../../../src/playbook/engine/playbook-store.js";
 import type {
@@ -112,30 +112,57 @@ describe("Learning Engine", () => {
     });
   });
 
-  describe("computeFingerprint", () => {
+  describe("computeStableFingerprint", () => {
     it("produces deterministic fingerprints", () => {
       const event = makeEvent();
       const p1 = extractPattern(event);
       const p2 = extractPattern(event);
 
-      expect(computeFingerprint(p1)).toBe(computeFingerprint(p2));
+      expect(computeStableFingerprint(p1)).toBe(computeStableFingerprint(p2));
     });
 
     it("produces 64-char hex strings", () => {
       const pattern = extractPattern(makeEvent());
-      const fp = computeFingerprint(pattern);
+      const fp = computeStableFingerprint(pattern);
 
       expect(fp).toHaveLength(64);
       expect(/^[0-9a-f]{64}$/.test(fp)).toBe(true);
     });
 
     it("produces different fingerprints for different patterns", () => {
-      const fp1 = computeFingerprint(extractPattern(makeEvent()));
-      const fp2 = computeFingerprint(
+      const fp1 = computeStableFingerprint(extractPattern(makeEvent()));
+      const fp2 = computeStableFingerprint(
         extractPattern(makeEvent({ nodeSequence: [{ nodeType: "different" }] })),
       );
 
       expect(fp1).not.toBe(fp2);
+    });
+
+    it("B4 truth-labeling: NOT a SHA-256 hash (output diverges from real SHA-256 of same canonical input)", async () => {
+      // The function's 64-hex-char output shape resembles SHA-256 purely
+      // for downstream type/string compatibility. This regression guard
+      // proves it is NOT a cryptographic SHA-256: comparing the output
+      // against `crypto.subtle.digest('SHA-256', ...)` of the same
+      // canonical input must NOT match. If a future slice swaps the
+      // implementation to real SHA-256, this test will fail loudly and
+      // the docstring + function name must be updated to match.
+      const pattern = extractPattern(makeEvent());
+      const canonical = canonicalizePattern(pattern);
+      const stableFp = computeStableFingerprint(pattern);
+
+      const sha256Buf = await crypto.subtle.digest(
+        "SHA-256",
+        new TextEncoder().encode(canonical),
+      );
+      const sha256Hex = Array.from(new Uint8Array(sha256Buf))
+        .map((b) => b.toString(16).padStart(2, "0"))
+        .join("");
+
+      expect(stableFp).toHaveLength(64);
+      expect(sha256Hex).toHaveLength(64);
+      // Both are 64 hex chars. They must NOT match — proves the stable
+      // fingerprint is not a real SHA-256.
+      expect(stableFp).not.toBe(sha256Hex);
     });
   });
 
@@ -159,7 +186,7 @@ describe("Learning Engine", () => {
       );
 
       expect(canonicalizePattern(patternA)).not.toBe(canonicalizePattern(patternB));
-      expect(computeFingerprint(patternA)).not.toBe(computeFingerprint(patternB));
+      expect(computeStableFingerprint(patternA)).not.toBe(computeStableFingerprint(patternB));
     });
   });
 


### PR DESCRIPTION
## Summary

B4 Slice 4 — close inventory rank #5: `computeFingerprint` in `src/playbook/engine/learning-engine.ts:75` advertised SHA-256 64-hex-char output but implements FNV-1a 64-bit extended via ad-hoc post-processing to 64 hex chars. Anyone relying on the type / output shape could reasonably assume it was cryptographic and use it for integrity / adversarial-input dedup, where it would silently fail.

## What changed (3 files, +51/-16)

**`src/playbook/engine/learning-engine.ts`**
- Renamed `computeFingerprint` → `computeStableFingerprint`.
- JSDoc rewritten as a B4 truth-labeling block: names FNV-1a + 64-char extension explicitly; states NOT cryptographic, NOT suitable for integrity / signing / adversarial-input collision resistance; names the right call (`crypto.subtle.digest('SHA-256', ...)`) if cryptographic is ever needed.
- 1 self-call inside `createLearningEngine.processCompletedRun` updated.

**`src/playbook/engine/index.ts`**
- Barrel re-export updated to new name.

**`test/unit/playbook/engine/learning-engine.test.ts`**
- All 4 existing references updated to new name.
- 1 new test \"B4 truth-labeling: NOT a SHA-256 hash (output diverges from real SHA-256 of same canonical input)\" computes the real SHA-256 of the same canonical input via `crypto.subtle.digest` and asserts the stable-fingerprint output does NOT match. **Regression guard**: if a future slice swaps to real SHA-256, this test fails loudly and the docstring + name must be updated to match.

## What this slice does NOT do

- Does NOT change the hashing algorithm. The rename is for truthful naming, not behavior change.
- Does NOT export at the top-level `#playbook` barrel (current scope: `#playbook/engine` only).
- No external production callers existed for the old name.

## Test plan

- [x] Focused: 17/17 learning-engine tests (existing 16 + 1 new)
- [x] Blast-radius: 194/194 across `test/unit/playbook/` + `test/contracts/`
- [x] tsc clean
- [x] eslint 0 errors (2 pre-existing object-injection-sink warnings in the new test array iteration)
- [x] secret scan clean
- [x] git diff --check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)