### PR TITLE
B4 Slice 8: truth-label intentional no-ops (orchestration cancelRun + CLI TUI onRealtimeEvent)

### DIFF
--- a/src/cli/friday-cli-tui.ts
+++ b/src/cli/friday-cli-tui.ts
@@ -11,6 +11,23 @@ import { createFridayTuiController } from "../tui/friday-tui-controller.js";
 import { DEFAULT_TUI_CONFIG } from "../tui/friday-tui.types.js";
 import type { FridayTuiConfig, FridayTuiEvent } from "../tui/friday-tui.types.js";
 
+// ─── B4 truth-labeling: realtime advisory ───
+
+let fridayCliTuiRealtimeAdvisoryEmitted = false;
+
+/**
+ * Emit a one-time advisory when `realtimeEnabled: true` is requested but
+ * the TUI has no actual realtime transport wired. Replaces the prior
+ * silent no-op subscription that delivered zero events.
+ */
+function emitFridayCliTuiRealtimeAdvisoryOnce(): void {
+  if (fridayCliTuiRealtimeAdvisoryEmitted) return;
+  fridayCliTuiRealtimeAdvisoryEmitted = true;
+  console.info(
+    "[friday][cli-tui] advisory: realtimeEnabled=true was set, but no realtime transport (SSE/WebSocket) is wired in the TUI as of the B4 capability inventory. onRealtimeEvent is intentionally unset; the TUI will fall back to refresh-interval polling. Wiring realtime is proof_pending.",
+  );
+}
+
 // ─── Types ───
 
 export interface FridayCliTuiOptions {
@@ -203,13 +220,21 @@ export async function runFridayCliTui(options: FridayCliTuiOptions = {}): Promis
       rl.on("line", cb);
       return () => rl.removeListener("line", cb);
     },
-    onRealtimeEvent: config.realtimeEnabled
-      ? (cb: (event: FridayTuiEvent) => void) => {
-        // Placeholder — would connect to SSE/WebSocket endpoint
-        void cb;
-        return () => {};
+    // B4 truth-labeling: when `config.realtimeEnabled` is true, the prior
+    // behavior installed a no-op `onRealtimeEvent` subscription that NEVER
+    // delivered events (the body was `void cb; return () => {}`). That hid
+    // the proof_pending state — the TUI promised realtime but no SSE/
+    // WebSocket transport is wired. We now return `undefined` either way
+    // and emit a one-time advisory when the flag is set so the operator
+    // sees the gap instead of believing realtime events are live. A
+    // future "wire-TUI-realtime-transport" slice can hook a real
+    // subscription source through this.
+    onRealtimeEvent: (() => {
+      if (config.realtimeEnabled) {
+        emitFridayCliTuiRealtimeAdvisoryOnce();
       }
-      : undefined,
+      return undefined;
+    })(),
   });
 
   // Graceful shutdown

--- a/src/engine/friday-orchestration-engine.ts
+++ b/src/engine/friday-orchestration-engine.ts
@@ -118,12 +118,29 @@ export function createFridayOrchestrationEngine(
     return executeRun(mergedInput);
   }
 
+  /**
+   * Cancel a run by `runId`.
+   *
+   * **B4 truth-labeling note (this is an intentional no-op for interface
+   * completeness):** the orchestration engine does NOT itself maintain an
+   * abort-controller registry for in-flight runs. The actual cancellation
+   * is handled upstream by:
+   * - `src/api/runtime/friday-api-runtime.ts` — request-scoped
+   *   AbortController per agent run
+   * - `src/agent/runtime/friday-agent-runtime.ts` — internal abort
+   *   propagation through tool calls
+   *
+   * Calling this method has no observable side effect on the run unless
+   * one of those upstream layers wires through. The method exists so the
+   * `FridayOrchestrationEngine` shape matches the consumer expectation
+   * (callers may check for the method's presence). A future
+   * "centralize-cancellation" slice could wire this through a registry;
+   * until then it remains a documented no-op.
+   */
   async function cancelRun(runId: string): Promise<void> {
-    // Cancel is a no-op if resume deps are absent — the caller (API runtime)
-    // manages abort controllers externally.
+    void runId;
     if (!runResume) return;
-    // The existing agent runtime abort controller mechanism handles actual
-    // cancellation; this method exists for interface completeness.
+    // No-op by design — see JSDoc above.
   }
 
   function resumeStaleRunsOnBoot(): number {

--- a/test/unit/engine/friday-orchestration-engine.test.ts
+++ b/test/unit/engine/friday-orchestration-engine.test.ts
@@ -98,4 +98,50 @@ describe("createFridayOrchestrationEngine", () => {
     );
     expect(prepareTurn).not.toHaveBeenCalled();
   });
+
+  // ─── B4 truth-labeling ───
+
+  it("B4 truth-labeling: cancelRun is an intentional no-op (does not throw; does not delegate)", async () => {
+    // The orchestration engine does not maintain an abort-controller
+    // registry. cancelRun exists for interface completeness; actual
+    // cancellation is handled upstream in api-runtime / agent-runtime.
+    // Lock the no-op shape so future edits don't silently wire a fake
+    // cancellation path.
+    const agentRuntime: FridayEngineRunExecutorAgentRuntime = {
+      executeRun: vi.fn(),
+    };
+    const sessionDeps = {
+      getMessages: vi.fn(async () => []),
+      addMessage: vi.fn(async () => undefined),
+      getConversationFocus: vi.fn(async () => null),
+      setConversationFocus: vi.fn(async () => undefined),
+    };
+    const engine = createFridayOrchestrationEngine({
+      turnPreparerDeps: {
+        sessionDeps,
+        historyLimit: 24,
+        nowIso: () => "2026-05-25T00:00:00.000Z",
+        prepareTurn: vi.fn(async () => ({ historyMessages: [] } as never)),
+        buildEvidenceBlocks: () => [],
+        classifyExecution: () => ({ category: "agent_exception_path" }),
+      },
+      runExecutorDeps: {
+        agentRuntime,
+        sessionDeps,
+        nowIso: () => "2026-05-25T00:00:00.000Z",
+        persistImmediateRunResult: vi.fn(async () => undefined),
+        dispatchDeterministic: vi.fn(async () => ({ handled: false })),
+        dispatchManagedAsync: vi.fn(async () => ({ handled: false })),
+        finalizeFocus: vi.fn(() => ({ currentTask: "", updatedAt: "2026-05-25T00:00:00.000Z" })),
+        deterministicDispatchDeps: {},
+        managedAsyncDispatchDeps: {},
+        resolveIdempotencyKey: ({ runId, kind }) => `${runId}:${kind}`,
+      },
+    });
+
+    // Without runResume deps, cancelRun is a no-op AND does not throw.
+    await expect(engine.cancelRun("run-noop")).resolves.toBeUndefined();
+    // agentRuntime.executeRun must NOT have been called as a side effect.
+    expect(agentRuntime.executeRun).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

B4 Slice 8 — close inventory rank 3 findings #4 and #5 in one bundled slice. Two unrelated no-op functions both audit-flagged as misleading.

### 1. `orchestrationEngine.cancelRun`

The body was `if (!runResume) return;` plus a comment claiming the abort-controller mechanism handles cancellation. The function did nothing observable. JSDoc rewritten to explicitly state it's an intentional no-op for interface completeness; actual cancellation lives in `api-runtime` + `agent-runtime`.

### 2. `friday-cli-tui` `onRealtimeEvent`

When `realtimeEnabled: true`, the prior body was `void cb; return () => {}` — a no-op subscription that delivered zero events. Now returns `undefined` either way; when the flag is set, a one-time advisory fires so the operator sees the proof_pending state instead of believing realtime is live.

## What changed (3 files, +98/-10)

**`src/engine/friday-orchestration-engine.ts`**
- `cancelRun` rewritten with explicit no-op JSDoc naming the upstream cancellation paths.

**`src/cli/friday-cli-tui.ts`**
- New `emitFridayCliTuiRealtimeAdvisoryOnce` warn-once helper.
- `onRealtimeEvent` now returns `undefined` and emits the advisory when `realtimeEnabled` is set.

**`test/unit/engine/friday-orchestration-engine.test.ts`**
- 1 new test "B4 truth-labeling: cancelRun is an intentional no-op" locks the shape (no throw, no delegation to `agentRuntime.executeRun`).

## What this slice does NOT do

- Does NOT wire actual cancellation through `cancelRun`. Future "centralize-cancellation" slice.
- Does NOT wire SSE/WebSocket realtime transport into the TUI. Future "wire-TUI-realtime-transport" slice.

## Test plan

- [x] Focused: 2/2 orchestration-engine tests (existing 1 + 1 new)
- [x] Blast-radius: 246/246 across `test/unit/engine/` + `test/unit/cli/` + `test/contracts/`
- [x] tsc clean
- [x] secret scan clean
- [x] git diff --check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)