### PR TITLE
B4 Slice 9: truth-label 4 observability row types without migration tables

### DIFF
--- a/src/observability/model/friday-observability.types.ts
+++ b/src/observability/model/friday-observability.types.ts
@@ -935,7 +935,18 @@ export interface FridayAlertEvent {
 // PERSISTENCE ROW TYPES (SQLite)
 // ═══════════════════════════════════════════════════════════════════════
 
-/** SQLite row shape for the `obs_traces` table. */
+/**
+ * SQLite row shape for the `obs_traces` table.
+ *
+ * **B4 truth-labeling note (future/no_claim):** As of the B4 capability
+ * inventory there is NO migration that creates the `obs_traces` table
+ * (none of `src/state/sqlite/migrations/*.ts` declares it) and no
+ * production caller reads or writes this shape. The type is preserved
+ * for forward-compat — if a future "traces persistence" slice lands the
+ * migration and writer, callers can adopt this row shape without a type
+ * contract break. Until then, do NOT assume an `obs_traces` table
+ * exists.
+ */
 export interface FridayTraceRow {
   trace_id: string;
   name: string;
@@ -948,7 +959,13 @@ export interface FridayTraceRow {
   ended_at: string | null;
 }
 
-/** SQLite row shape for the `obs_spans` table. */
+/**
+ * SQLite row shape for the `obs_spans` table.
+ *
+ * **B4 truth-labeling note (future/no_claim):** Same status as
+ * `FridayTraceRow` — no migration declares `obs_spans`; no production
+ * caller reads/writes this shape. Preserved for forward-compat.
+ */
 export interface FridaySpanRow {
   span_id: string;
   trace_id: string;
@@ -1015,7 +1032,17 @@ export interface FridaySloDefinitionRow {
   updated_at: string;
 }
 
-/** SQLite row shape for the `obs_alert_rules` table. */
+/**
+ * SQLite row shape for the `obs_alert_rules` table.
+ *
+ * **B4 truth-labeling note (future/no_claim):** Alert RULES are
+ * currently held in-memory by `FridayAlertEngine` (see
+ * `observability/engine/alerts.ts`). No migration declares
+ * `obs_alert_rules`; no production caller persists rule definitions
+ * with this shape. The `obs_alert_channels` table DOES exist (see
+ * `FridayAlertChannelRow` below). This row type is preserved for
+ * forward-compat with a future "persistent alert rules" slice.
+ */
 export interface FridayAlertRuleRow {
   id: string;
   name: string;
@@ -1045,7 +1072,14 @@ export interface FridayAlertChannelRow {
   updated_at: string;
 }
 
-/** SQLite row shape for the `obs_alert_events` table. */
+/**
+ * SQLite row shape for the `obs_alert_events` table.
+ *
+ * **B4 truth-labeling note (future/no_claim):** Same status as
+ * `FridayAlertRuleRow` — no migration declares `obs_alert_events`; no
+ * production caller persists alert events with this shape (events are
+ * live in `FridayAlertEngine`). Preserved for forward-compat.
+ */
 export interface FridayAlertEventRow {
   id: string;
   rule_id: string;

--- a/test/integration/state/sqlite/friday-migration-chain.test.ts
+++ b/test/integration/state/sqlite/friday-migration-chain.test.ts
@@ -329,6 +329,30 @@ describe("Friday Migration Chain (V001–V024)", () => {
     expect(tableNames).toContain("obs_alert_channels");
   });
 
+  // ─── B4 truth-labeling: declared-but-not-created tables ───
+  //
+  // FridayTraceRow / FridaySpanRow / FridayAlertRuleRow / FridayAlertEventRow
+  // are declared as SQLite row shapes in `src/observability/model/friday-observability.types.ts`
+  // but the corresponding tables (`obs_traces`, `obs_spans`, `obs_alert_rules`,
+  // `obs_alert_events`) are NOT created by any migration. The row types are
+  // preserved as `future/no_claim` for forward-compat. This regression
+  // guard locks in the truth: if a future migration adds any of these
+  // tables, this test fails loudly and the row-type JSDoc must be updated
+  // to reflect the new wired state.
+
+  it("B4 truth-labeling: obs_traces / obs_spans / obs_alert_rules / obs_alert_events tables are NOT created by any migration (declared row types are future/no_claim)", () => {
+    const db = freshDb();
+    runFridayMigrations({ db, migrations: FRIDAY_SQLITE_MIGRATIONS });
+
+    const rows = db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name IN ('obs_traces', 'obs_spans', 'obs_alert_rules', 'obs_alert_events')",
+      )
+      .all() as { name: string }[];
+
+    expect(rows).toHaveLength(0);
+  });
+
   it("adds V017-V022 columns to friday_agent_runs", () => {
     const db = freshDb();
     runFridayMigrations({ db, migrations: FRIDAY_SQLITE_MIGRATIONS });


### PR DESCRIPTION
## Summary

B4 Slice 9 — close inventory rank 4 findings #1 + #2 in one bundled slice.

4 row types in `src/observability/model/friday-observability.types.ts` declare SQLite row shapes for tables (`obs_traces` / `obs_spans` / `obs_alert_rules` / `obs_alert_events`) that **no migration creates**. The audit flagged them as misleading: a reader could reasonably assume the corresponding tables exist.

Per the locked default rule (truth-label over remove unless zero contract proved), the row types are preserved with explicit JSDoc naming the `future/no_claim` state.

## What changed (2 files, +62/-4)

**`src/observability/model/friday-observability.types.ts`**
- JSDoc rewritten as B4 truth-labeling block for `FridayTraceRow`, `FridaySpanRow`, `FridayAlertRuleRow`, `FridayAlertEventRow`. Each explicitly names:
  - The missing table
  - That no production caller reads/writes the shape
  - For alert rule/event: rules are currently held in-memory by `FridayAlertEngine`; events are live in `FridayAlertEngine` (this preserves callers' ability to reason about where the live state actually lives)

**`test/integration/state/sqlite/friday-migration-chain.test.ts`**
- 1 new regression-guard test "B4 truth-labeling: obs_traces / obs_spans / obs_alert_rules / obs_alert_events tables are NOT created by any migration" — queries `sqlite_master` and asserts zero matches. **Will fail loudly if a future migration adds any of these tables** so the JSDoc must be updated to reflect the new wired state.

## What this slice does NOT do

- Does NOT remove the row types. Per the locked rule, keep + truth-label.
- Does NOT add migrations for the 4 tables.

## Test plan

- [x] Focused: 15/15 migration-chain integration tests (existing 14 + 1 new)
- [x] Blast-radius: 324/324 across `test/integration/state/` + `test/unit/observability/` + `test/contracts/`
- [x] tsc clean
- [x] git diff --check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)