### PR TITLE
B4 Slice 11: truth-label RunbookRegistry/Executor orphan (proof_pending)

### DIFF
--- a/src/observability/engine/runbook-automation.ts
+++ b/src/observability/engine/runbook-automation.ts
@@ -4,6 +4,23 @@
  * Provides a lightweight in-memory registry and executor for automating
  * operational runbooks when alert events escalate.
  *
+ * **B4 truth-labeling note (proof_pending; NOT wired into production):**
+ * `RunbookRegistry`, `RunbookExecutor`, `RunbookDefinition`,
+ * `RunbookExecutionContext`, and `RunbookExecutionResult` are exported
+ * via the parent barrel but have ZERO production import sites as of
+ * the B4 capability inventory. The observability `createService` path
+ * constructs the alert evaluation scheduler WITHOUT a runbook registry
+ * — escalating alerts notify destinations (Slack/SMTP) but do not
+ * trigger any automated runbook. Only the existing scheduler unit
+ * test (`friday-alert-evaluation-scheduler.test.ts`) and this
+ * module's own tests instantiate the registry.
+ *
+ * The exports are preserved via the parent barrel so a future
+ * "wire-runbook-automation-into-alert-engine" slice can hook them in
+ * without a contract break. A one-time `console.info` advisory fires
+ * at first `RunbookRegistry` construction so anyone wiring it in
+ * production sees the proof_pending state in logs.
+ *
  * @module observability/engine
  */
 
@@ -59,10 +76,25 @@ export interface RunbookExecutionResult {
   readonly errorMessage?: string;
 }
 
+let runbookRegistryAdvisoryEmitted = false;
+
+/** Warn-once advisory at first RunbookRegistry construction. See file header. */
+function emitRunbookRegistryAdvisoryOnce(): void {
+  if (runbookRegistryAdvisoryEmitted) return;
+  runbookRegistryAdvisoryEmitted = true;
+  console.info(
+    "[friday][observability][runbook-automation] advisory: RunbookRegistry is constructed but has zero production import sites as of the B4 capability inventory; the observability alert evaluation scheduler runs WITHOUT runbook automation. Wiring runbook escalation is proof_pending — see file header.",
+  );
+}
+
 /** Registry of runbooks keyed by rule. */
 export class RunbookRegistry {
   private readonly runbooks = new Map<UUID, RunbookDefinition>();
   private readonly runbookIdsByRule = new Map<UUID, Set<UUID>>();
+
+  constructor() {
+    emitRunbookRegistryAdvisoryOnce();
+  }
 
   /** Register or replace a runbook definition. */
   registerRunbook(runbook: RunbookDefinition): void {

--- a/test/unit/observability/engine/runbook-automation.test.ts
+++ b/test/unit/observability/engine/runbook-automation.test.ts
@@ -169,3 +169,26 @@ describe("RunbookExecutor", () => {
     expect(executor.getExecutionHistory()).toHaveLength(0);
   });
 });
+
+describe("RunbookRegistry — B4 truth-labeling", () => {
+  it("emits a one-time advisory naming the proof_pending state on first construction", () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    try {
+      new RunbookRegistry();
+      new RunbookRegistry();
+      new RunbookRegistry();
+
+      const advisoryCalls = infoSpy.mock.calls.filter((call) =>
+        typeof call[0] === "string" && (call[0] as string).includes("[friday][observability][runbook-automation]"),
+      );
+      expect(advisoryCalls.length).toBeLessThanOrEqual(1);
+      if (advisoryCalls.length === 1) {
+        const message = advisoryCalls[0]![0] as string;
+        expect(message).toContain("zero production import sites");
+        expect(message).toContain("proof_pending");
+      }
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

B4 Slice 11 — **final rank-4 candidate.**

`RunbookRegistry`, `RunbookExecutor`, `RunbookDefinition`, `RunbookExecutionContext`, `RunbookExecutionResult` are exported via the parent barrel but have **zero production import sites** as of the B4 capability inventory. The observability `createService` path constructs the alert evaluation scheduler WITHOUT a runbook registry — escalating alerts notify destinations (Slack/SMTP) but do not trigger any automated runbook.

Per the locked default rule (truth-label over remove), the exports are preserved.

## What changed (2 files, +55/-0)

**`src/observability/engine/runbook-automation.ts`**
- File header rewritten as B4 truth-labeling block.
- New `emitRunbookRegistryAdvisoryOnce` warn-once helper.
- `RunbookRegistry` constructor calls it at first construction.

**`test/unit/observability/engine/runbook-automation.test.ts`**
- New describe block "RunbookRegistry — B4 truth-labeling" with 1 test asserting advisory fires at most once per process AND message names zero-production-import-sites + proof_pending.

## Test plan

- [x] Focused: 6/6 runbook-automation tests (existing 5 + 1 new)
- [x] Blast-radius: 304/304 across `test/unit/observability/` + `test/contracts/`
- [x] tsc clean
- [x] git diff --check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)