### PR TITLE
fix(ui): restore real login for RGG probes

### DIFF
--- a/test/unit/ui/auth-storage-security.test.ts
+++ b/test/unit/ui/auth-storage-security.test.ts
@@ -4,19 +4,35 @@ import { authStorage } from "../../../ui/src/lib/storage/auth-storage";
 
 describe("authStorage", () => {
   beforeEach(() => {
-    const storage = new Map<string, string>();
+    const local = new Map<string, string>();
+    const session = new Map<string, string>();
     Object.defineProperty(globalThis, "localStorage", {
       configurable: true,
       value: {
-        getItem: (key: string) => storage.get(key) ?? null,
+        getItem: (key: string) => local.get(key) ?? null,
         setItem: (key: string, value: string) => {
-          storage.set(key, value);
+          local.set(key, value);
         },
         removeItem: (key: string) => {
-          storage.delete(key);
+          local.delete(key);
         },
         clear: () => {
-          storage.clear();
+          local.clear();
+        },
+      },
+    });
+    Object.defineProperty(globalThis, "sessionStorage", {
+      configurable: true,
+      value: {
+        getItem: (key: string) => session.get(key) ?? null,
+        setItem: (key: string, value: string) => {
+          session.set(key, value);
+        },
+        removeItem: (key: string) => {
+          session.delete(key);
+        },
+        clear: () => {
+          session.clear();
         },
       },
     });
@@ -25,6 +41,7 @@ describe("authStorage", () => {
   afterEach(() => {
     authStorage.clear();
     localStorage.clear();
+    sessionStorage.clear();
   });
 
   it("keeps new access and refresh tokens out of localStorage", () => {
@@ -34,6 +51,27 @@ describe("authStorage", () => {
     expect(authStorage.getRefreshToken()).toBe("refresh-token");
     expect(localStorage.getItem("friday.auth.accessToken")).toBeNull();
     expect(localStorage.getItem("friday.auth.refreshToken")).toBeNull();
+    expect(sessionStorage.getItem("friday.auth.sessionAccessToken")).toBeNull();
+  });
+
+  it("persists only the short-lived access token in sessionStorage when an expiry is supplied", () => {
+    authStorage.setTokens("access-token", "refresh-token", 60);
+
+    expect(authStorage.getAccessToken()).toBe("access-token");
+    expect(authStorage.getRefreshToken()).toBe("refresh-token");
+    expect(localStorage.getItem("friday.auth.accessToken")).toBeNull();
+    expect(localStorage.getItem("friday.auth.refreshToken")).toBeNull();
+    expect(sessionStorage.getItem("friday.auth.sessionAccessToken")).toBe("access-token");
+    expect(sessionStorage.getItem("friday.auth.refreshToken")).toBeNull();
+  });
+
+  it("does not persist refresh tokens in sessionStorage", () => {
+    authStorage.setTokens("access-token", "refresh-token", 60);
+    authStorage.clear();
+
+    expect(sessionStorage.getItem("friday.auth.sessionAccessToken")).toBeNull();
+    expect(sessionStorage.getItem("friday.auth.sessionAccessTokenExpiresAt")).toBeNull();
+    expect(sessionStorage.getItem("friday.auth.refreshToken")).toBeNull();
   });
 
   it("migrates legacy localStorage tokens into memory and clears them", () => {

--- a/test/unit/ui/local-bootstrap-auth-gate.test.ts
+++ b/test/unit/ui/local-bootstrap-auth-gate.test.ts
@@ -2,10 +2,12 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 describe("local bootstrap auth gate", () => {
-  it("routes first-run auth failures into local session recovery instead of passphrase setup", () => {
+  it("routes completed-bootstrap auth failures into real local login instead of seeding browser storage", () => {
     const routerSource = readFileSync("ui/src/router.tsx", "utf8");
 
     expect(routerSource).toContain("getBootstrapStatus");
+    expect(routerSource).toContain("LoginPage");
+    expect(routerSource).toContain("/login?next=");
     expect(routerSource).toContain("LocalSessionUnavailableGate");
     expect(routerSource).toContain("bootstrapStatusQuery.isError");
     expect(routerSource).toContain("正在连接本机 Friday");
@@ -20,6 +22,12 @@ describe("local bootstrap auth gate", () => {
     expect(routerSource).not.toContain("Backend said:");
     expect(routerSource).not.toContain("Local session not connected");
     expect(routerSource).not.toContain("No authentication method provided");
+
+    const loginSource = readFileSync("ui/src/routes/login-page.tsx", "utf8");
+    expect(loginSource).toContain("login({ localPassphrase: trimmed })");
+    expect(loginSource).toContain('id="login-local-passphrase"');
+    expect(loginSource).toContain("Continue locally");
+    expect(loginSource).not.toContain("localStorage.setItem");
   });
 
   it("restores a stored token without attempting local auto-login", () => {

--- a/ui/src/lib/api/auth.ts
+++ b/ui/src/lib/api/auth.ts
@@ -18,7 +18,7 @@ export async function login(input: LoginInput): Promise<LoginResponse> {
     input,
   );
 
-  authStorage.setTokens(data.accessToken, data.refreshToken);
+  authStorage.setTokens(data.accessToken, data.refreshToken, data.expiresInSec);
   authStorage.setUser(data.user);
 
   return data;

--- a/ui/src/lib/api/client.ts
+++ b/ui/src/lib/api/client.ts
@@ -61,7 +61,7 @@ async function doRefresh(): Promise<void> {
     throw new AuthExpiredError();
   }
 
-  authStorage.setTokens(envelope.data.accessToken, envelope.data.refreshToken);
+  authStorage.setTokens(envelope.data.accessToken, envelope.data.refreshToken, envelope.data.expiresInSec);
 }
 
 async function refreshSession(): Promise<void> {

--- a/ui/src/lib/storage/auth-storage.ts
+++ b/ui/src/lib/storage/auth-storage.ts
@@ -4,10 +4,20 @@ const KEYS = {
   accessToken: "friday.auth.accessToken",
   refreshToken: "friday.auth.refreshToken",
   user: "friday.auth.user",
+  sessionAccessToken: "friday.auth.sessionAccessToken",
+  sessionAccessTokenExpiresAt: "friday.auth.sessionAccessTokenExpiresAt",
 } as const;
 
 let inMemoryAccessToken: string | null = null;
 let inMemoryRefreshToken: string | null = null;
+
+function getSessionStorage(): Storage | null {
+  try {
+    return typeof sessionStorage === "undefined" ? null : sessionStorage;
+  } catch {
+    return null;
+  }
+}
 
 function readAndClearLegacyToken(key: string): string | null {
   const token = localStorage.getItem(key);
@@ -17,9 +27,43 @@ function readAndClearLegacyToken(key: string): string | null {
   return token;
 }
 
+function readSessionAccessToken(): string | null {
+  const storage = getSessionStorage();
+  if (!storage) return null;
+  const token = storage.getItem(KEYS.sessionAccessToken);
+  const expiresAtRaw = storage.getItem(KEYS.sessionAccessTokenExpiresAt);
+  const expiresAtMs = expiresAtRaw ? Number.parseInt(expiresAtRaw, 10) : 0;
+  if (!token || !Number.isFinite(expiresAtMs) || expiresAtMs <= Date.now()) {
+    storage.removeItem(KEYS.sessionAccessToken);
+    storage.removeItem(KEYS.sessionAccessTokenExpiresAt);
+    return null;
+  }
+  return token;
+}
+
+function writeSessionAccessToken(accessToken: string, expiresInSec?: number): void {
+  const storage = getSessionStorage();
+  if (!storage) return;
+  const ttlSec = typeof expiresInSec === "number" ? expiresInSec : 0;
+  if (!Number.isFinite(ttlSec) || ttlSec <= 0) {
+    storage.removeItem(KEYS.sessionAccessToken);
+    storage.removeItem(KEYS.sessionAccessTokenExpiresAt);
+    return;
+  }
+  const expiresAtMs = Date.now() + Math.max(1, Math.floor(ttlSec - 5)) * 1000;
+  storage.setItem(KEYS.sessionAccessToken, accessToken);
+  storage.setItem(KEYS.sessionAccessTokenExpiresAt, String(expiresAtMs));
+}
+
+function clearSessionAccessToken(): void {
+  const storage = getSessionStorage();
+  storage?.removeItem(KEYS.sessionAccessToken);
+  storage?.removeItem(KEYS.sessionAccessTokenExpiresAt);
+}
+
 export const authStorage = {
   getAccessToken(): string | null {
-    inMemoryAccessToken ??= readAndClearLegacyToken(KEYS.accessToken);
+    inMemoryAccessToken ??= readAndClearLegacyToken(KEYS.accessToken) ?? readSessionAccessToken();
     return inMemoryAccessToken;
   },
 
@@ -38,11 +82,12 @@ export const authStorage = {
     }
   },
 
-  setTokens(accessToken: string, refreshToken: string): void {
+  setTokens(accessToken: string, refreshToken: string, expiresInSec?: number): void {
     inMemoryAccessToken = accessToken;
     inMemoryRefreshToken = refreshToken;
     localStorage.removeItem(KEYS.accessToken);
     localStorage.removeItem(KEYS.refreshToken);
+    writeSessionAccessToken(accessToken, expiresInSec);
   },
 
   setUser(user: FridayUser): void {
@@ -55,5 +100,6 @@ export const authStorage = {
     localStorage.removeItem(KEYS.accessToken);
     localStorage.removeItem(KEYS.refreshToken);
     localStorage.removeItem(KEYS.user);
+    clearSessionAccessToken();
   },
 };

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -24,6 +24,7 @@ const AutomationsPage = lazy(async () => import("@/routes/automations-page").the
 const FleetPage = lazy(async () => import("@/routes/fleet-page").then((module) => ({ default: module.FleetPage })));
 const GuidedFlowPage = lazy(async () => import("@/routes/guided-flow-page").then((module) => ({ default: module.GuidedFlowPage })));
 const HomePage = lazy(async () => import("@/routes/home-page").then((module) => ({ default: module.HomePage })));
+const LoginPage = lazy(async () => import("@/routes/login-page").then((module) => ({ default: module.LoginPage })));
 const ObservabilityPage = lazy(async () => import("@/routes/observability-page").then((module) => ({ default: module.ObservabilityPage })));
 const OnboardingPage = lazy(async () => import("@/routes/onboarding-page").then((module) => ({ default: module.OnboardingPage })));
 const PacksPage = lazy(async () => import("@/routes/packs-page").then((module) => ({ default: module.PacksPage })));
@@ -203,6 +204,7 @@ function LocalSessionUnavailableGate(props: { error?: unknown; onRetry: () => vo
 
 function RequireAuth({ children }: { children: ReactNode }) {
   const { authError, isAuthenticated, isLoading, retryLocalSession } = useAuth();
+  const location = useLocation();
   const bootstrapStatusQuery = useQuery({
     queryKey: ["auth", "bootstrap", "status"],
     queryFn: getBootstrapStatus,
@@ -249,14 +251,8 @@ function RequireAuth({ children }: { children: ReactNode }) {
         />
       );
     }
-    return (
-      <LocalSessionUnavailableGate
-        error={authError}
-        onRetry={() => {
-          void retryLocalSession();
-        }}
-      />
-    );
+    const nextPath = `${location.pathname}${location.search}${location.hash}`;
+    return <Navigate to={`/login?next=${encodeURIComponent(nextPath)}`} replace />;
   }
 
   return <>{children}</>;
@@ -337,7 +333,14 @@ function RouteErrorBoundary() {
 export const router = createBrowserRouter([
   {
     path: "/login",
-    element: <Navigate to="/home" replace />,
+    element: (
+      <RouteSuspense
+        title={localizedText("加载登录", "Loading login")}
+        detail={localizedText("Friday 正在准备本机解锁。", "Friday is preparing local unlock.")}
+      >
+        <LoginPage />
+      </RouteSuspense>
+    ),
   },
   {
     path: "/",

--- a/ui/src/routes/login-page.tsx
+++ b/ui/src/routes/login-page.tsx
@@ -1,0 +1,95 @@
+import { FormEvent, useMemo, useState } from "react";
+import { Navigate, useNavigate, useSearchParams } from "react-router-dom";
+import { KeyRound } from "lucide-react";
+import { ActionButton } from "@/components/core/primitives";
+import { useAuth } from "@/hooks/use-auth";
+import { localize } from "@/lib/i18n/localized-text";
+import { useAppLocale } from "@/providers/locale-provider";
+
+function resolveNextPath(value: string | null): string {
+  if (!value || !value.startsWith("/") || value.startsWith("//")) {
+    return "/home";
+  }
+  return value;
+}
+
+export function LoginPage() {
+  const { locale } = useAppLocale();
+  const { isAuthenticated, login } = useAuth();
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const nextPath = useMemo(() => resolveNextPath(searchParams.get("next")), [searchParams]);
+  const [localPassphrase, setLocalPassphrase] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  if (isAuthenticated) {
+    return <Navigate to={nextPath} replace />;
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const trimmed = localPassphrase.trim();
+    if (!trimmed) {
+      setError(localize(locale, "请输入本地口令。", "Enter the local passphrase."));
+      return;
+    }
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      await login({ localPassphrase: trimmed });
+      navigate(nextPath, { replace: true });
+    } catch {
+      setError(localize(locale, "本地口令未通过。", "The local passphrase was not accepted."));
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <main className="min-h-screen bg-[color:var(--color-bg-base)] px-6 py-10 text-[color:var(--color-text-primary)]">
+      <div className="mx-auto flex min-h-[calc(100vh-5rem)] w-full max-w-[420px] flex-col justify-center">
+        <div className="mb-8 flex items-center gap-3">
+          <span
+            aria-hidden="true"
+            className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-[color:var(--color-accent-muted)] text-[color:var(--color-accent)]"
+          >
+            <KeyRound className="h-5 w-5" />
+          </span>
+          <div>
+            <p className="agent-eyebrow">Friday</p>
+            <h1 className="text-2xl font-semibold text-[color:var(--color-text-primary)]">
+              {localize(locale, "解锁本机 Friday", "Unlock local Friday")}
+            </h1>
+          </div>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <label className="flex flex-col gap-2 text-sm font-medium text-[color:var(--color-text-primary)]">
+            {localize(locale, "本地口令", "Local passphrase")}
+            <input
+              id="login-local-passphrase"
+              type="password"
+              autoComplete="current-password"
+              value={localPassphrase}
+              onChange={(event) => setLocalPassphrase(event.target.value)}
+              className="min-h-[46px] rounded-xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] px-3 text-base outline-none transition focus:border-[color:var(--color-accent)] focus:ring-2 focus:ring-[color:var(--color-accent-muted)]"
+            />
+          </label>
+
+          {error ? (
+            <p role="alert" className="text-sm text-[color:var(--color-text-danger)]">
+              {error}
+            </p>
+          ) : null}
+
+          <ActionButton type="submit" className="w-full" disabled={isSubmitting}>
+            {isSubmitting
+              ? localize(locale, "正在继续", "Continuing")
+              : localize(locale, "继续本机模式", "Continue locally")}
+          </ActionButton>
+        </form>
+      </div>
+    </main>
+  );
+}

--- a/validation/real-world/lib/executors.mjs
+++ b/validation/real-world/lib/executors.mjs
@@ -607,12 +607,32 @@ async function completeUiLoginIfNeeded({ page, client, execution, artifact, time
     return;
   }
   const requestedPath = getUrlPath(execution.path);
+  const loginTimeoutMs = Math.max(timeoutMs, 90_000);
+  const waitForLoginExit = () => page.waitForFunction(
+    () => new URL(window.location.href).pathname !== "/login",
+    undefined,
+    { timeout: loginTimeoutMs },
+  );
+  const waitForLoginResponse = () => page.waitForResponse(
+    (response) => {
+      try {
+        const url = new URL(response.url());
+        return url.pathname === "/v1/auth/login";
+      } catch {
+        return false;
+      }
+    },
+    { timeout: loginTimeoutMs },
+  );
   if (typeof client?.localPassphrase === "string" && client.localPassphrase.trim().length > 0) {
     await page.locator("#login-local-passphrase").fill(client.localPassphrase.trim());
-    await Promise.all([
-      page.waitForURL((url) => !isLoginPath(url.toString()), { timeout: timeoutMs }),
-      page.getByRole("button", { name: /continue locally/i }).click(),
-    ]);
+    const loginResponsePromise = waitForLoginResponse();
+    await page.getByRole("button", { name: /continue locally/i }).click();
+    const loginResponse = await loginResponsePromise;
+    if (!loginResponse.ok()) {
+      throw new Error(`Real browser local-passphrase login failed with HTTP ${String(loginResponse.status())}`);
+    }
+    await waitForLoginExit();
     artifact.observedEvidence.push(`completed real browser local-passphrase login for ${requestedPath}`);
     return;
   }
@@ -622,10 +642,13 @@ async function completeUiLoginIfNeeded({ page, client, execution, artifact, time
   ) {
     await page.locator("#login-email").fill(client.email.trim());
     await page.locator("#login-password").fill(client.password.trim());
-    await Promise.all([
-      page.waitForURL((url) => !isLoginPath(url.toString()), { timeout: timeoutMs }),
-      page.getByRole("button", { name: /sign in/i }).click(),
-    ]);
+    const loginResponsePromise = waitForLoginResponse();
+    await page.getByRole("button", { name: /sign in/i }).click();
+    const loginResponse = await loginResponsePromise;
+    if (!loginResponse.ok()) {
+      throw new Error(`Real browser email/password login failed with HTTP ${String(loginResponse.status())}`);
+    }
+    await waitForLoginExit();
     artifact.observedEvidence.push(`completed real browser email/password login for ${requestedPath}`);
     return;
   }


### PR DESCRIPTION
## Summary
- add a real `/login` route for completed-bootstrap local Friday sessions instead of redirecting `/login` back to `/home`
- redirect protected unauthenticated UI routes to `/login?next=...`, then perform a real `/v1/auth/login` local-passphrase request
- persist only the short-lived access token in `sessionStorage` for browser reload recovery; refresh token remains memory-only and no access/refresh token is written to `localStorage`
- make RGG browser login wait for the actual `/v1/auth/login` response and fail immediately on non-2xx responses such as `429`

## Root Cause
PR #332 correctly removed mock `localStorage.setItem(...)` token seeding from validation proofs, but Friday did not yet have a real `/login` page. The Real Green Gate browser helper can only complete real login if it reaches `/login`, so public-surface UI probes landed on protected pages without a valid UI session and reported `ui_loading` failures.

## Verification
- `npx vitest run test/unit/ui/auth-storage-security.test.ts test/unit/ui/local-bootstrap-auth-gate.test.ts` — 8 passed
- `npm run typecheck:src` — pass
- `npm run check:proof:no-mock-leaks` — pass, no mock contamination markers across 41 proof inputs
- `npm run build` — pass
- `npm run release:verify:repo` — pass, including 11,947 unit/integration tests and install smoke
- `npm audit --omit=dev --audit-level=moderate` — 0 vulnerabilities
- targeted original red public-surface scenarios against a real local Friday runtime — 24/24 artifacts passed (`docs/reports/ops/real-world-validation/2026-05-25T07-10-17-294Z-a2ieiu`)
- self-hosted RGG publicSurface phase — 36/36 passed (`/tmp/friday-rgg-auth-fix-self-hosted-realpath-20260525002049/suites/public-surface/summary.json`)

## Notes
Local self-hosted full RGG still cannot be used as the final provider/channel proof on this machine because this shell lacks the remote CI's fallback provider and external-channel readiness secrets. The relevant previously-red publicSurface lane is green locally; remote RGG should be the authoritative same-SHA proof for provider lanes.
