### PR TITLE
R1: npm/source-only release mode + Lark/Feishu channel proof harness

### DIFF
--- a/.github/workflows/real-green-gate.yml
+++ b/.github/workflows/real-green-gate.yml
@@ -13,6 +13,11 @@ on:
         required: false
         type: boolean
         default: false
+      phase24d_lark_feishu_trusted_inbound:
+        description: "Run the manual Phase24D Lark/Feishu trusted-user inbound listener."
+        required: false
+        type: boolean
+        default: false
   push:
     branches:
       - main
@@ -209,3 +214,46 @@ jobs:
         with:
           name: phase24c-telegram-trusted-inbound-${{ github.run_id }}
           path: ${{ runner.temp }}/phase24c-telegram-trusted-inbound
+
+  phase24d-lark-feishu-trusted-inbound:
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.phase24d_lark_feishu_trusted_inbound == true }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: phase-24-live-channels
+    env:
+      FRIDAY_LARK_APP_ID: ${{ secrets.FRIDAY_LARK_APP_ID || vars.FRIDAY_LARK_APP_ID }}
+      FRIDAY_LARK_APP_SECRET: ${{ secrets.FRIDAY_LARK_APP_SECRET }}
+      FRIDAY_LARK_CHAT_ID: ${{ secrets.FRIDAY_LARK_CHAT_ID || vars.FRIDAY_LARK_CHAT_ID }}
+      FRIDAY_LARK_GROUP_CHAT_ID: ${{ secrets.FRIDAY_LARK_GROUP_CHAT_ID || vars.FRIDAY_LARK_GROUP_CHAT_ID }}
+      FRIDAY_LARK_ALLOWED_USER_ID: ${{ secrets.FRIDAY_LARK_ALLOWED_USER_ID || vars.FRIDAY_LARK_ALLOWED_USER_ID }}
+      FRIDAY_LARK_USE_FEISHU: ${{ secrets.FRIDAY_LARK_USE_FEISHU || vars.FRIDAY_LARK_USE_FEISHU }}
+      FRIDAY_LARK_RECEIVE_MODE: ${{ secrets.FRIDAY_LARK_RECEIVE_MODE || vars.FRIDAY_LARK_RECEIVE_MODE }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+      FRIDAY_DEEPSEEK_API_KEY: ${{ secrets.FRIDAY_DEEPSEEK_API_KEY }}
+      PHASE24D_LARK_FEISHU_LISTENER_TIMEOUT_MS: "480000"
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build API
+        run: npm run build:api
+
+      - name: Wait for trusted Lark/Feishu user-origin message
+        run: PHASE24D_REPORT_ROOT="$RUNNER_TEMP/phase24d-lark-feishu-trusted-inbound" npm run ops:phase24d:lark-feishu-trusted-inbound
+
+      - name: Upload Phase24D Lark/Feishu trusted inbound artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: phase24d-lark-feishu-trusted-inbound-${{ github.run_id }}
+          path: ${{ runner.temp }}/phase24d-lark-feishu-trusted-inbound

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,14 @@ on:
         description: "Existing tag to release (for example: v0.3.1)"
         required: true
         type: string
+      release_mode:
+        description: "Release mode: 'source-only' (npm + source tarball; no macOS build) or 'source-and-macos' (also produce notarized DMG / Homebrew cask). Push-tag triggers always behave as 'source-only'."
+        required: false
+        type: choice
+        default: "source-only"
+        options:
+          - source-only
+          - source-and-macos
 
 permissions:
   contents: write
@@ -137,6 +145,7 @@ jobs:
     outputs:
       tag_name: ${{ steps.resolve_tag.outputs.tag_name }}
       tag_sha: ${{ steps.resolve_tag_sha.outputs.tag_sha }}
+      release_mode: ${{ steps.resolve_release_mode.outputs.release_mode }}
 
     steps:
       - name: Checkout
@@ -163,6 +172,34 @@ jobs:
             echo "::error::Tag must match v<semver> (for example: v0.3.1)"
             exit 1
           fi
+
+      - name: Resolve release mode
+        id: resolve_release_mode
+        run: |
+          set -euo pipefail
+          # Push-tag triggers (e.g. `git push origin v1.0.1`) always behave as
+          # source-only because there is no UI to choose otherwise and the
+          # default v1.0.1 release boundary forbids claiming notarized macOS
+          # / Homebrew distribution. Manual workflow_dispatch honors the
+          # operator's input (default: source-only).
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            MODE="${{ github.event.inputs.release_mode }}"
+            if [ -z "${MODE}" ]; then
+              MODE="source-only"
+            fi
+          else
+            MODE="source-only"
+          fi
+          case "${MODE}" in
+            source-only|source-and-macos)
+              echo "release_mode=${MODE}" >> "${GITHUB_OUTPUT}"
+              echo "Release mode: ${MODE}"
+              ;;
+            *)
+              echo "::error::Unknown release_mode '${MODE}'. Allowed: source-only, source-and-macos."
+              exit 1
+              ;;
+          esac
 
       - name: Resolve tag SHA
         id: resolve_tag_sha
@@ -195,6 +232,7 @@ jobs:
       - name: Public release preflight
         env:
           FRIDAY_RELEASE_TAG: ${{ env.TAG_NAME }}
+          FRIDAY_RELEASE_MODE: ${{ steps.resolve_release_mode.outputs.release_mode }}
           FRIDAY_MACOS_CODESIGN_IDENTITY: ${{ vars.FRIDAY_MACOS_CODESIGN_IDENTITY }}
           FRIDAY_MACOS_NOTARY_PROFILE: ${{ vars.FRIDAY_MACOS_NOTARY_PROFILE }}
           FRIDAY_MACOS_SPARKLE_PRIVATE_KEY: ${{ secrets.FRIDAY_MACOS_SPARKLE_PRIVATE_KEY }}
@@ -236,6 +274,7 @@ jobs:
     timeout-minutes: 90
     outputs:
       tag_name: ${{ needs.public-preflight.outputs.tag_name }}
+      release_mode: ${{ needs.public-preflight.outputs.release_mode }}
 
     steps:
       - name: Checkout
@@ -326,6 +365,60 @@ jobs:
           # prints its own structured rejection JSON to stdout on failure.
           node scripts/ops/validate-real-green-gate-result.mjs --path "${ARTIFACT_PATH}" --expected-sha "${TAG_SHA}"
 
+      - name: Assert RGG run was workflow_dispatch (channel phase24X jobs only run on manual dispatch)
+        env:
+          RUN_ID: ${{ steps.find_run.outputs.run_id }}
+        run: |
+          set -euo pipefail
+          EVENT="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}" --jq '.event')"
+          echo "Real Green Gate run ${RUN_ID} event=${EVENT}"
+          if [ "${EVENT}" != "workflow_dispatch" ]; then
+            echo "::error::Channel live-proof gate requires the same-SHA Real Green Gate run to have been dispatched manually with phase24b/c/d inputs set true and nonces sent. Re-run: gh workflow run real-green-gate.yml -r ${TAG_NAME} -f phase24b_discord_trusted_inbound=true -f phase24c_telegram_trusted_inbound=true -f phase24d_lark_feishu_trusted_inbound=true"
+            exit 1
+          fi
+
+      - name: Download Phase24B Discord trusted-inbound artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: phase24b-discord-trusted-inbound-${{ steps.find_run.outputs.run_id }}
+          path: ./phase24b-discord-download
+          run-id: ${{ steps.find_run.outputs.run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Download Phase24C Telegram trusted-inbound artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: phase24c-telegram-trusted-inbound-${{ steps.find_run.outputs.run_id }}
+          path: ./phase24c-telegram-download
+          run-id: ${{ steps.find_run.outputs.run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Download Phase24D Lark/Feishu trusted-inbound artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: phase24d-lark-feishu-trusted-inbound-${{ steps.find_run.outputs.run_id }}
+          path: ./phase24d-lark-feishu-download
+          run-id: ${{ steps.find_run.outputs.run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Validate channel proof artifacts
+        run: |
+          set -euo pipefail
+          DISCORD="./phase24b-discord-download/phase24b-discord-trusted-inbound-proof.json"
+          TELEGRAM="./phase24c-telegram-download/phase24c-telegram-trusted-inbound-proof.json"
+          LARK="./phase24d-lark-feishu-download/phase24d-lark-feishu-trusted-inbound-proof.json"
+          for path in "${DISCORD}" "${TELEGRAM}" "${LARK}"; do
+            if [ ! -f "${path}" ]; then
+              echo "::error::Expected channel-proof artifact ${path} is missing. Re-run real-green-gate.yml on ${TAG_SHA} with phase24b_discord_trusted_inbound, phase24c_telegram_trusted_inbound, and phase24d_lark_feishu_trusted_inbound all set true, and complete the trusted-user message probes."
+              exit 1
+            fi
+          done
+          node scripts/ops/validate-channel-proof-artifacts.mjs \
+            --discord "${DISCORD}" \
+            --telegram "${TELEGRAM}" \
+            --lark-feishu "${LARK}" \
+            --expected-sha "${TAG_SHA}"
+
   source-distribution:
     needs:
       - verify
@@ -367,6 +460,7 @@ jobs:
     needs:
       - verify
       - live-proof-gate
+    if: needs.verify.outputs.release_mode != 'source-only'
     runs-on: macos-latest
     timeout-minutes: 45
 
@@ -475,6 +569,21 @@ jobs:
       - source-distribution
       - macos-distribution
       - publish-npm
+    # `macos-distribution` skips in source-only mode. Without an explicit `if:`,
+    # GitHub Actions would cascade-skip `create-release` and the GitHub Release
+    # would never be published. Require all required deps to have succeeded,
+    # and tolerate `macos-distribution` being skipped iff release_mode is
+    # source-only. This intentionally fails closed: any other dep skipping or
+    # failing blocks the release.
+    if: |
+      always()
+      && needs.verify.result == 'success'
+      && needs.live-proof-gate.result == 'success'
+      && needs.source-distribution.result == 'success'
+      && needs.publish-npm.result == 'success'
+      && (needs.macos-distribution.result == 'success'
+          || (needs.macos-distribution.result == 'skipped'
+              && needs.verify.outputs.release_mode == 'source-only'))
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -497,6 +606,7 @@ jobs:
           path: .
 
       - name: Download macOS distribution
+        if: needs.verify.outputs.release_mode != 'source-only'
         uses: actions/download-artifact@v4
         with:
           name: friday-macos-release
@@ -506,14 +616,29 @@ jobs:
         env:
           FRIDAY_RELEASE_TAG: ${{ needs.verify.outputs.tag_name }}
           FRIDAY_RELEASE_DOWNLOAD_BASE_URL: https://github.com/${{ github.repository }}/releases/download/${{ needs.verify.outputs.tag_name }}
+          FRIDAY_RELEASE_MODE: ${{ needs.verify.outputs.release_mode }}
         run: npm run release:manifest
+
+      - name: Resolve release files
+        id: release_files
+        env:
+          RELEASE_MODE: ${{ needs.verify.outputs.release_mode }}
+        run: |
+          set -euo pipefail
+          if [ "${RELEASE_MODE}" = "source-only" ]; then
+            FILES=$'dist/releases/**/*\n'
+          else
+            FILES=$'dist/releases/**/*\ndist/macos/FridayCompanion.release.json\ndist/macos/FridayCompanion.release.md\n'
+          fi
+          {
+            echo "files<<EOF"
+            printf '%s' "${FILES}"
+            echo "EOF"
+          } >> "${GITHUB_OUTPUT}"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.verify.outputs.tag_name }}
           generate_release_notes: true
-          files: |
-            dist/releases/**/*
-            dist/macos/FridayCompanion.release.json
-            dist/macos/FridayCompanion.release.md
+          files: ${{ steps.release_files.outputs.files }}

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "ops:check-branch-conformance": "node scripts/ops/check-branch-conformance.mjs",
     "ops:phase24b:discord-trusted-inbound": "node scripts/ops/phase24b-discord-trusted-inbound-listener.mjs",
     "ops:phase24c:telegram-trusted-inbound": "node scripts/ops/phase24c-telegram-trusted-inbound-listener.mjs",
+    "ops:phase24d:lark-feishu-trusted-inbound": "node scripts/ops/phase24d-lark-feishu-trusted-inbound-listener.mjs",
     "ops:real-green-gate": "node scripts/ops/run-real-green-gate.mjs",
     "ops:harden-local-enablement": "bash scripts/ops/harden-local-enablement.sh",
     "ops:agent-adoption:doctor": "node dist/cli/friday-cli.js phases doctor",

--- a/scripts/ops/lib/token-redaction.mjs
+++ b/scripts/ops/lib/token-redaction.mjs
@@ -1,0 +1,112 @@
+/**
+ * Shared token-redaction helpers used by the Phase24 trusted inbound listeners
+ * (Discord / Telegram / Lark+Feishu). Each listener writes JSON proof artifacts
+ * that must never contain raw bot tokens or app secrets. The two primitives:
+ *
+ *   - scrub(value, token, { tokenLabel, prefixLabel })
+ *       Walks every string in `value` (via JSON.parse(JSON.stringify(...))) and
+ *       replaces:
+ *         - exact `token` occurrences with `tokenLabel`
+ *         - the first 12 chars of `token` with `prefixLabel`  (only when the
+ *           token is >12 chars; matches the original inline helpers).
+ *       Returns a deep-cloned, scrubbed copy. Non-strings pass through.
+ *
+ *   - containsTokenMaterial(serialized, token)
+ *       Returns true if the serialized text still contains the raw token or
+ *       its 12-char prefix. Used as a defense-in-depth assertion before any
+ *       artifact is written to disk.
+ *
+ * createScrubber({ token, tokenLabel, prefixLabel }) returns ergonomic
+ * pre-bound helpers so each listener can pass its own labels exactly once.
+ *
+ * Behavior parity: this module is a direct extraction of the duplicated
+ * helpers from phase24b-discord-trusted-inbound-listener.mjs and
+ * phase24c-telegram-trusted-inbound-listener.mjs. The redaction label is the
+ * only thing that becomes a parameter — the 12-char prefix logic, the
+ * empty-token short-circuit, and the deep-clone semantics are unchanged.
+ */
+
+const DEFAULT_PREFIX_CHARS = 12;
+
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.length > 0;
+}
+
+/**
+ * Deep-clone `value` and replace any occurrence of `token` (and its 12-char
+ * prefix) with redaction labels.
+ *
+ * @param {unknown} value
+ * @param {string} token
+ * @param {{ tokenLabel: string, prefixLabel: string }} labels
+ * @returns {unknown}
+ */
+export function scrub(value, token, labels) {
+  const tokenLabel = labels?.tokenLabel ?? "[REDACTED_TOKEN]";
+  const prefixLabel = labels?.prefixLabel ?? "[REDACTED_TOKEN_PREFIX]";
+  const replacer = (_key, current) => {
+    if (typeof current !== "string") return current;
+    let next = current;
+    if (isNonEmptyString(token)) {
+      next = next.split(token).join(tokenLabel);
+      if (token.length > DEFAULT_PREFIX_CHARS) {
+        next = next.split(token.slice(0, DEFAULT_PREFIX_CHARS)).join(prefixLabel);
+      }
+    }
+    return next;
+  };
+  let serialized;
+  try {
+    serialized = JSON.stringify(value, replacer);
+  } catch {
+    // Cycles or non-serializable members would otherwise propagate and leave
+    // the caller stringifying the raw error (which may itself carry secrets).
+    // Fail closed to a sentinel string instead.
+    return "[REDACTED_UNSERIALIZABLE]";
+  }
+  return JSON.parse(serialized);
+}
+
+/**
+ * Returns true if `serialized` contains `token` (or its 12-char prefix when
+ * the token is longer than 12 chars). Used as a fail-closed assertion before
+ * writing any proof artifact to disk.
+ *
+ * @param {string} serialized
+ * @param {string} token
+ * @returns {boolean}
+ */
+export function containsTokenMaterial(serialized, token) {
+  if (!isNonEmptyString(token)) return false;
+  if (typeof serialized !== "string") return false;
+  if (serialized.includes(token)) return true;
+  if (token.length > DEFAULT_PREFIX_CHARS && serialized.includes(token.slice(0, DEFAULT_PREFIX_CHARS))) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Build a pair of pre-bound helpers for a given token + label set. Listeners
+ * pass their own redaction labels exactly once at construction time:
+ *
+ *   const { scrub: scrubLocal, containsTokenMaterial: hasTokenLocal } =
+ *     createScrubber({
+ *       token: config.botToken,
+ *       tokenLabel: "[REDACTED_DISCORD_BOT_TOKEN]",
+ *       prefixLabel: "[REDACTED_DISCORD_BOT_TOKEN_PREFIX]",
+ *     });
+ *
+ * @param {{ token: string, tokenLabel: string, prefixLabel: string }} options
+ */
+export function createScrubber({ token, tokenLabel, prefixLabel }) {
+  const labels = { tokenLabel, prefixLabel };
+  return {
+    scrub(value) {
+      return scrub(value, token, labels);
+    },
+    containsTokenMaterial(serialized) {
+      return containsTokenMaterial(serialized, token);
+    },
+  };
+}

--- a/scripts/ops/phase24c-telegram-trusted-inbound-listener.mjs
+++ b/scripts/ops/phase24c-telegram-trusted-inbound-listener.mjs
@@ -14,7 +14,16 @@ import {
 } from "#channels";
 import { createFridayHub } from "#hub";
 
+import {
+  containsTokenMaterial as containsTokenMaterialShared,
+  scrub as scrubShared,
+} from "./lib/token-redaction.mjs";
+
 const PROBE_BODY_TEXT = "help me clean up old files in my workspace; ask me before doing anything";
+const TELEGRAM_REDACTION_LABELS = Object.freeze({
+  tokenLabel: "[REDACTED_TELEGRAM_BOT_TOKEN]",
+  prefixLabel: "[REDACTED_TELEGRAM_BOT_TOKEN_PREFIX]",
+});
 const DEFAULT_TIMEOUT_MS = 8 * 60 * 1000;
 const AWAITING_STATES = new Set(["awaiting_clarification", "awaiting_plan_approval"]);
 const UNIFIED_TASK_STATE_SCHEMA_VERSION = "friday.agent.unified_task_state.v1";
@@ -52,28 +61,11 @@ function tail(value) {
 }
 
 function scrub(value, token) {
-  const replacer = (_key, current) => {
-    if (typeof current !== "string") return current;
-    let next = current;
-    if (token) {
-      next = next.split(token).join("[REDACTED_TELEGRAM_BOT_TOKEN]");
-      if (token.length > 12) {
-        next = next.split(token.slice(0, 12)).join("[REDACTED_TELEGRAM_BOT_TOKEN_PREFIX]");
-      }
-    }
-    return next;
-  };
-  return JSON.parse(JSON.stringify(value, replacer));
+  return scrubShared(value, token, TELEGRAM_REDACTION_LABELS);
 }
 
 function containsTokenMaterial(serialized, token) {
-  return Boolean(
-    token
-    && (
-      serialized.includes(token)
-      || (token.length > 12 && serialized.includes(token.slice(0, 12)))
-    ),
-  );
+  return containsTokenMaterialShared(serialized, token);
 }
 
 function serializeScrubbedJson(value, token) {
@@ -283,6 +275,7 @@ function initialReport(config, reportPath) {
     completedAt: null,
     reportPath,
     environment: {
+      commit_sha: process.env.GITHUB_SHA ?? null,
       githubSha: process.env.GITHUB_SHA ?? null,
       githubRunId: process.env.GITHUB_RUN_ID ?? null,
       githubRefName: process.env.GITHUB_REF_NAME ?? null,

--- a/scripts/ops/phase24d-lark-feishu-trusted-inbound-listener.mjs
+++ b/scripts/ops/phase24d-lark-feishu-trusted-inbound-listener.mjs
@@ -6,10 +6,7 @@ import path from "node:path";
 
 import { createFridayHttpServer } from "#api";
 import {
-  createDiscordGatewayService,
-  createDiscordRestService,
-  createFridayDiscordChannel,
-  normalizeDiscordMessageCreate,
+  createFridayLarkChannel,
 } from "#channels";
 import { createFridayHub } from "#hub";
 
@@ -19,18 +16,17 @@ import {
 } from "./lib/token-redaction.mjs";
 
 const PROBE_BODY_TEXT = "help me clean up old files in my workspace; ask me before doing anything";
-const DISCORD_REDACTION_LABELS = Object.freeze({
-  tokenLabel: "[REDACTED_DISCORD_BOT_TOKEN]",
-  prefixLabel: "[REDACTED_DISCORD_BOT_TOKEN_PREFIX]",
-});
 const DEFAULT_TIMEOUT_MS = 8 * 60 * 1000;
-const DISCORD_GUILDS = 1 << 0;
-const DISCORD_GUILD_MESSAGES = 1 << 9;
-const DISCORD_DIRECT_MESSAGES = 1 << 12;
-const DISCORD_MESSAGE_CONTENT = 1 << 15;
-const REQUIRED_INTENTS = DISCORD_GUILDS | DISCORD_GUILD_MESSAGES | DISCORD_DIRECT_MESSAGES | DISCORD_MESSAGE_CONTENT;
 const AWAITING_STATES = new Set(["awaiting_clarification", "awaiting_plan_approval"]);
 const UNIFIED_TASK_STATE_SCHEMA_VERSION = "friday.agent.unified_task_state.v1";
+
+const LARK_REDACTION_LABELS = Object.freeze({
+  tokenLabel: "[REDACTED_LARK_APP_SECRET]",
+  prefixLabel: "[REDACTED_LARK_APP_SECRET_PREFIX]",
+});
+
+const FEISHU_BASE_URL = "https://open.feishu.cn";
+const LARK_BASE_URL = "https://open.larksuite.com";
 
 function envBoolean(name, fallback) {
   const raw = process.env[name]?.trim().toLowerCase();
@@ -54,11 +50,11 @@ function sanitizeNoncePart(value, fallback) {
 }
 
 function buildProbeNonce() {
-  const explicit = process.env.PHASE24B_DISCORD_PROBE_NONCE?.trim();
-  if (explicit) return sanitizeNoncePart(explicit, "phase24b-run-explicit");
+  const explicit = process.env.PHASE24D_LARK_FEISHU_PROBE_NONCE?.trim();
+  if (explicit) return sanitizeNoncePart(explicit, "phase24d-run-explicit");
   const runId = sanitizeNoncePart(process.env.GITHUB_RUN_ID, "local");
   const sha = sanitizeNoncePart((process.env.GITHUB_SHA ?? "local").slice(0, 8), "local");
-  return `phase24b-run-${runId}-${sha}`;
+  return `phase24d-run-${runId}-${sha}`;
 }
 
 function messageIncludesProbe(value, config) {
@@ -67,28 +63,62 @@ function messageIncludesProbe(value, config) {
 }
 
 function tail(value) {
-  if (typeof value !== "string" || value.length === 0) return null;
-  return value.length <= 8 ? value : value.slice(-8);
+  const text = typeof value === "number" ? String(value) : typeof value === "string" ? value : "";
+  if (text.length === 0) return null;
+  return text.length <= 8 ? text : text.slice(-8);
+}
+
+// Lark/Feishu secrets covered by every redaction step. `appSecret` is required;
+// `verificationToken` and `encryptKey` are optional per lark-config.schema.ts
+// but if present in env they must also be redacted from any serialized output.
+function collectLarkSecrets(primaryToken) {
+  const seen = new Set();
+  const tokens = [];
+  const push = (candidate) => {
+    if (typeof candidate === "string" && candidate.length > 0 && !seen.has(candidate)) {
+      seen.add(candidate);
+      tokens.push(candidate);
+    }
+  };
+  push(primaryToken);
+  push(process.env.FRIDAY_LARK_APP_SECRET?.trim());
+  push(process.env.FRIDAY_LARK_VERIFICATION_TOKEN?.trim());
+  push(process.env.FRIDAY_LARK_ENCRYPT_KEY?.trim());
+  return tokens;
 }
 
 function scrub(value, token) {
-  return scrubShared(value, token, DISCORD_REDACTION_LABELS);
+  const tokens = collectLarkSecrets(token);
+  if (tokens.length === 0) {
+    return scrubShared(value, "", LARK_REDACTION_LABELS);
+  }
+  let current = value;
+  for (const candidate of tokens) {
+    current = scrubShared(current, candidate, LARK_REDACTION_LABELS);
+  }
+  return current;
 }
 
 function containsTokenMaterial(serialized, token) {
-  return containsTokenMaterialShared(serialized, token);
+  const tokens = collectLarkSecrets(token);
+  for (const candidate of tokens) {
+    if (containsTokenMaterialShared(serialized, candidate)) return true;
+  }
+  return false;
 }
 
 function serializeScrubbedJson(value, token) {
   const serialized = `${JSON.stringify(scrub(value, token), null, 2)}\n`;
   if (containsTokenMaterial(serialized, token)) {
-    throw new Error("Refusing to write artifact because it contains the Discord bot token");
+    throw new Error("Refusing to write artifact because it contains the Lark app secret");
   }
   return serialized;
 }
 
 function safeError(error, token) {
   const raw = error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+  // scrub() folds in process.env-derived secrets, so callers in early-failure
+  // branches (where `config` is undefined) still get full redaction coverage.
   return scrub(raw, token);
 }
 
@@ -117,6 +147,16 @@ function delay(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function withTimeout(promise, ms, label) {
+  let timer;
+  return Promise.race([
+    promise,
+    new Promise((_resolve, reject) => {
+      timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+    }),
+  ]).finally(() => clearTimeout(timer));
+}
+
 async function apiFetch(baseUrl, method, pathname, body) {
   const response = await fetch(`${baseUrl}${pathname}`, {
     method,
@@ -139,41 +179,55 @@ async function apiFetch(baseUrl, method, pathname, body) {
   return json;
 }
 
-function hasMention(payload, botUserId) {
-  return Array.isArray(payload?.mentions) && payload.mentions.some((mention) => mention?.id === botUserId);
-}
+function inspectLarkFeishuEvent(rawEvent, normalized, config, receivedAtMs) {
+  const data = rawEvent && typeof rawEvent === "object" ? rawEvent : {};
+  const eventData = (data.event && typeof data.event === "object") ? data.event : data;
+  const message = (eventData.message && typeof eventData.message === "object") ? eventData.message : null;
+  const sender = (eventData.sender && typeof eventData.sender === "object") ? eventData.sender : null;
+  const senderIdRecord = sender && typeof sender.sender_id === "object" ? sender.sender_id : null;
+  const senderId = typeof senderIdRecord?.open_id === "string"
+    ? senderIdRecord.open_id
+    : (typeof senderIdRecord?.user_id === "string" ? senderIdRecord.user_id : "");
+  const chatId = typeof message?.chat_id === "string" ? message.chat_id : "";
+  const chatType = typeof message?.chat_type === "string" ? message.chat_type : null;
+  const messageId = typeof message?.message_id === "string" ? message.message_id : null;
+  const senderType = typeof sender?.sender_type === "string" ? sender.sender_type : null;
+  // Lark sender_type values: "user", "app", "anonymous", "bot". Treat anything other than "user" as bot.
+  const authorBot = senderType !== null && senderType !== "user";
+  const authorBotFalse = senderType === "user";
 
-function inspectDiscordPayload(payload, config, receivedAtMs) {
-  const content = String(payload?.content ?? "");
-  const mentionMatched = !config.requireMention || hasMention(payload, config.botUserId);
-  const authorBotFalse = payload?.author?.bot !== true;
-  const senderMatched = payload?.author?.id === config.setupUserId;
-  const channelMatched = payload?.channel_id === config.channelId;
-  const probeBodyMatched = content.includes(config.probeBodyText);
-  const nonceMatched = content.includes(config.probeNonce);
-  let normalized = null;
-  if (payload?.id && payload?.author) {
-    normalized = normalizeDiscordMessageCreate(payload, config.requireMention, config.botUserId);
-  }
+  const normalizedText = typeof normalized?.text === "string" ? normalized.text : "";
+  const probeBodyMatched = normalizedText.includes(config.probeBodyText);
+  const nonceMatched = normalizedText.includes(config.probeNonce);
+  const senderMatched = senderId.length > 0 && senderId === config.allowedUserId;
+  const chatMatched = chatId.length > 0 && chatId === config.chatId;
+  const createTime = typeof message?.create_time === "string" ? Number.parseInt(message.create_time, 10) : null;
+  const messageDateMs = Number.isFinite(createTime) ? createTime : null;
+  // Match phase24c semantics: a missing/unparseable timestamp must NOT count as fresh.
+  const freshForRun = typeof messageDateMs === "number" && messageDateMs >= config.acceptAfterMs;
+
   const rawTargetMatched = authorBotFalse
     && senderMatched
-    && channelMatched
-    && mentionMatched
+    && chatMatched
+    && freshForRun
     && probeBodyMatched
     && nonceMatched;
+
   return {
     receivedAt: new Date(receivedAtMs).toISOString(),
     receivedAtMs,
-    messageId: typeof payload?.id === "string" ? payload.id : null,
-    messageIdTail: tail(payload?.id),
-    channelIdTail: tail(payload?.channel_id),
-    guildIdTail: tail(payload?.guild_id),
-    senderIdTail: tail(payload?.author?.id),
-    authorBot: payload?.author?.bot === true,
+    messageId,
+    messageIdTail: tail(messageId),
+    chatIdTail: tail(chatId),
+    senderIdTail: tail(senderId),
+    chatType,
+    senderType,
+    messageDate: messageDateMs !== null ? new Date(messageDateMs).toISOString() : null,
+    freshForRun,
+    authorBot,
     authorBotFalse,
     senderMatched,
-    channelMatched,
-    mentionMatched,
+    chatMatched,
     probeBodyMatched,
     nonceMatched,
     fullProbeMatched: probeBodyMatched && nonceMatched,
@@ -183,18 +237,20 @@ function inspectDiscordPayload(payload, config, receivedAtMs) {
   };
 }
 
-function redactedDiscordInspection(inspection) {
+function redactedLarkFeishuInspection(inspection) {
   return {
     receivedAt: inspection.receivedAt,
     messageIdTail: inspection.messageIdTail,
-    channelIdTail: inspection.channelIdTail,
-    guildIdTail: inspection.guildIdTail,
+    chatIdTail: inspection.chatIdTail,
     senderIdTail: inspection.senderIdTail,
+    chatType: inspection.chatType,
+    senderType: inspection.senderType,
+    messageDate: inspection.messageDate,
+    freshForRun: inspection.freshForRun,
     authorBot: inspection.authorBot,
     authorBotFalse: inspection.authorBotFalse,
     senderMatched: inspection.senderMatched,
-    channelMatched: inspection.channelMatched,
-    mentionMatched: inspection.mentionMatched,
+    chatMatched: inspection.chatMatched,
     probeBodyMatched: inspection.probeBodyMatched,
     nonceMatched: inspection.nonceMatched,
     fullProbeMatched: inspection.fullProbeMatched,
@@ -203,63 +259,88 @@ function redactedDiscordInspection(inspection) {
   };
 }
 
-function recordDiscordMessageCreate(report, observedEventsByMessageId, payload, config) {
+function recordLarkFeishuEvent(report, observedEventsByMessageId, rawEvent, normalized, config) {
   const receivedAtMs = Date.now();
-  const inspection = inspectDiscordPayload(payload, config, receivedAtMs);
-  const redacted = redactedDiscordInspection(inspection);
-  const diagnostics = report.diagnostics.discordHubAdapter;
-  diagnostics.messageCreateCount += 1;
-  diagnostics.lastMessageCreate = redacted;
-  if (inspection.fullProbeMatched) diagnostics.nonceMessageCreateCount += 1;
-  if (inspection.rawTargetMatched) diagnostics.targetRawMessageCreateCount += 1;
-  if (inspection.messageId) {
+  const inspection = inspectLarkFeishuEvent(rawEvent, normalized, config, receivedAtMs);
+  const redacted = redactedLarkFeishuInspection(inspection);
+  const diagnostics = report.diagnostics.larkFeishuHubAdapter;
+  diagnostics.eventCount += 1;
+  if (inspection.messageId) diagnostics.messageEventCount += 1;
+  if (inspection.messageId && !inspection.freshForRun) diagnostics.staleMessageEventCount += 1;
+  diagnostics.lastEvent = redacted;
+  if (inspection.fullProbeMatched) diagnostics.nonceEventCount += 1;
+  if (inspection.rawTargetMatched) diagnostics.targetRawEventCount += 1;
+  if (inspection.messageId && inspection.chatMatched && inspection.freshForRun) {
     observedEventsByMessageId.set(inspection.messageId, {
-      payload,
+      rawEvent,
       normalized: inspection.normalized,
       receivedAtMs,
       inspection: redacted,
     });
   }
-  if (!inspection.rawTargetMatched) return;
+  if (!inspection.rawTargetMatched) return inspection;
 
-  report.criteria.listenerReceivedMessageCreate = true;
+  report.criteria.listenerReceivedMessageReceive = true;
   report.criteria.authorBotFalse = inspection.authorBotFalse;
-  report.criteria.authorMatchesTrustedSetupUser = inspection.senderMatched;
-  report.criteria.channelMatchesConfiguredChannel = inspection.channelMatched;
-  report.criteria.requireMentionSatisfied = inspection.mentionMatched;
+  report.criteria.senderMatchesTrustedAllowedUser = inspection.senderMatched;
+  report.criteria.chatMatchesConfiguredChat = inspection.chatMatched;
   report.criteria.nonceMatched = inspection.nonceMatched;
   report.criteria.normalizerDidNotDrop = inspection.normalizerAccepted;
-  report.observedDiscordEvent = {
-    type: "MESSAGE_CREATE",
+  report.observedLarkFeishuEvent = {
+    type: "LARK_FEISHU_MESSAGE_RECEIVE_V1",
     ...redacted,
   };
-  diagnostics.matchedMessageCreate = redacted;
+  diagnostics.matchedEvent = redacted;
+  return inspection;
 }
 
-function createInstrumentedDiscordGatewayService(config, report, observedEventsByMessageId) {
-  const gateway = createDiscordGatewayService();
-  return {
-    async connect(token, intents, onEvent, onStatusChange) {
-      await gateway.connect(token, intents, (event) => {
-        if (event?.t === "MESSAGE_CREATE") {
-          recordDiscordMessageCreate(report, observedEventsByMessageId, event.d, config);
+/**
+ * Instrument the real `createFridayLarkChannel` plugin without refactoring it.
+ * We replace `adapters.lifecycle.connect(onEvent)` with a wrapped version that:
+ *  - notes WSClient connect resolution → wsClientConnected
+ *  - records every raw event for observation
+ *  - delegates to the plugin's original inbound adapter to normalize, and
+ *    forwards the event to the original onEvent handler so hub-side
+ *    acceptance (session mirror / runs / evidence) is exercised exactly once.
+ * The plugin's own internal WSClient is the only Lark connection; we do not
+ * open a second one. This respects the "no refactor of friday-lark-channel.ts"
+ * constraint by wrapping the public adapter surface from the outside.
+ */
+function instrumentLarkFeishuPlugin(plugin, config, report, observedEventsByMessageId) {
+  const originalLifecycle = plugin.adapters.lifecycle;
+  const originalInbound = plugin.adapters.inbound;
+  if (!originalLifecycle || !originalInbound) {
+    throw new Error("createFridayLarkChannel plugin is missing required lifecycle/inbound adapters");
+  }
+  const wrappedLifecycle = {
+    async connect(onEvent) {
+      const wrappedOnEvent = (rawEvent) => {
+        let normalized = null;
+        try {
+          normalized = originalInbound.normalize(rawEvent);
+        } catch {
+          normalized = null;
         }
-        onEvent(event);
-      }, (status) => {
-        const connected = status === "connected" || gateway.isConnected();
-        report.criteria.gatewayConnected = connected;
-        report.diagnostics.discordHubAdapter.gatewayConnected = connected;
-        if (onStatusChange) onStatusChange(status);
-      });
-      report.criteria.gatewayConnected = gateway.isConnected();
-      report.diagnostics.discordHubAdapter.gatewayConnected = gateway.isConnected();
+        recordLarkFeishuEvent(report, observedEventsByMessageId, rawEvent, normalized, config);
+        onEvent(rawEvent);
+      };
+      await originalLifecycle.connect(wrappedOnEvent);
+      report.criteria.wsClientConnected = true;
+      report.diagnostics.larkFeishuHubAdapter.wsClientConnected = true;
     },
     async disconnect() {
-      await gateway.disconnect();
-      report.diagnostics.discordHubAdapter.gatewayConnected = false;
+      await originalLifecycle.disconnect();
+      report.diagnostics.larkFeishuHubAdapter.wsClientConnected = false;
     },
-    isConnected() {
-      return gateway.isConnected();
+    ...(typeof originalLifecycle.reconnect === "function"
+      ? { reconnect: () => originalLifecycle.reconnect.call(originalLifecycle) }
+      : {}),
+  };
+  return {
+    ...plugin,
+    adapters: {
+      ...plugin.adapters,
+      lifecycle: wrappedLifecycle,
     },
   };
 }
@@ -267,9 +348,9 @@ function createInstrumentedDiscordGatewayService(config, report, observedEventsB
 function initialReport(config, reportPath) {
   const startedAt = new Date().toISOString();
   return {
-    schemaVersion: "friday.phase24b.discord_trusted_inbound_proof.v1",
-    phase: "Phase24B",
-    scope: "Discord live trusted user inbound proof",
+    schemaVersion: "friday.phase24d.lark_feishu_trusted_inbound_proof.v1",
+    phase: "Phase24D",
+    scope: "Lark/Feishu live trusted user inbound proof",
     status: "running",
     blocker: null,
     startedAt,
@@ -281,29 +362,33 @@ function initialReport(config, reportPath) {
       githubRunId: process.env.GITHUB_RUN_ID ?? null,
       githubRefName: process.env.GITHUB_REF_NAME ?? null,
       timeoutMs: config.timeoutMs,
-      requireMention: config.requireMention,
-      configuredGuildIdTail: tail(config.guildId),
-      configuredChannelIdTail: tail(config.channelId),
-      configuredSetupUserIdTail: tail(config.setupUserId),
-      configuredBotUserIdTail: tail(config.botUserId),
-      discordTokenPresent: Boolean(config.botToken),
+      platformBrand: config.platformBrand,
+      platformDisplayName: config.platformDisplayName,
+      platformBaseUrl: config.platformBaseUrl,
+      useFeishu: config.useFeishu,
+      receiveMode: config.receiveMode,
+      acceptAfter: new Date(config.acceptAfterMs).toISOString(),
+      configuredChatIdTail: tail(config.chatId),
+      configuredGroupChatIdTail: tail(config.groupChatId),
+      configuredAllowedUserIdTail: tail(config.allowedUserId),
+      larkAppIdTail: tail(config.appId),
+      larkAppSecretPresent: Boolean(config.appSecret),
       probeBodyText: config.probeBodyText,
       probeNonce: config.probeNonce,
       expectedOperatorMessage: config.expectedOperatorMessage,
     },
     criteria: {
-      gatewayConnected: false,
-      listenerReceivedMessageCreate: false,
+      wsClientConnected: false,
+      listenerReceivedMessageReceive: false,
       authorBotFalse: false,
-      authorMatchesTrustedSetupUser: false,
-      channelMatchesConfiguredChannel: false,
-      requireMentionSatisfied: !config.requireMention,
+      senderMatchesTrustedAllowedUser: false,
+      chatMatchesConfiguredChat: false,
       nonceMatched: false,
       normalizerDidNotDrop: false,
-      normalizedChannelKindDiscord: false,
-      normalizedSenderMatchesTrustedSetupUser: false,
-      normalizedChatMatchesConfiguredChannel: false,
-      normalizedChatTypeGroup: false,
+      normalizedChannelKindMatchesBrand: false,
+      normalizedSenderMatchesTrustedAllowedUser: false,
+      normalizedChatMatchesConfiguredChat: false,
+      normalizedChatTypeSupported: false,
       fridayHubChannelConnected: false,
       realHubAdapterAcceptedMessage: false,
       userSessionMirrorMatched: false,
@@ -321,33 +406,39 @@ function initialReport(config, reportPath) {
       channelBoundaryNoLiveClaim: false,
       notCompleted: false,
       evidenceReceiptAvailable: false,
-      discordShortReceiptObserved: false,
+      larkFeishuShortReceiptObserved: false,
       assistantSessionReplyObserved: false,
       evidenceMatchesNonce: false,
       fullEvidenceSurfaceExported: false,
       artifactHasNoToken: false,
     },
     diagnostics: {
-      proofSource: "instrumented_hub_gateway_and_current_runner_session",
-      discordHubAdapter: {
-        gatewayConnected: false,
+      proofSource: "instrumented_hub_wsclient_adapter_and_current_runner_session",
+      platformBrand: config.platformBrand,
+      platformDisplayName: config.platformDisplayName,
+      larkFeishuHubAdapter: {
+        platformBrand: config.platformBrand,
+        wsClientConnected: false,
         realHubAdapterAcceptedMessage: false,
-        messageCreateCount: 0,
-        nonceMessageCreateCount: 0,
-        targetRawMessageCreateCount: 0,
-        lastMessageCreate: null,
-        matchedMessageCreate: null,
+        eventCount: 0,
+        messageEventCount: 0,
+        staleMessageEventCount: 0,
+        nonceEventCount: 0,
+        targetRawEventCount: 0,
+        lastEvent: null,
+        matchedEvent: null,
       },
       currentRunnerNonceCorrespondence: {
         sourceMessageIdTail: null,
         sessionMirrorMatchesNonce: false,
-        sessionMirrorSourceMessageIdMatchesGateway: false,
+        sessionMirrorSourceMessageIdMatchesWsClient: false,
         runMatchesNonce: false,
         evidenceMatchesNonce: false,
       },
       localNonCurrentRunnerAmbiguityPossible: true,
+      cleanupFailures: [],
     },
-    observedDiscordEvent: null,
+    observedLarkFeishuEvent: null,
     normalizedMessage: null,
     userSessionMirror: null,
     fridayRun: null,
@@ -377,14 +468,14 @@ async function writeEvidenceArtifact(report, token, filename, value) {
 }
 
 function resolveReportPath() {
-  const reportRoot = process.env.PHASE24B_REPORT_ROOT?.trim()
-    || (process.env.RUNNER_TEMP ? path.join(process.env.RUNNER_TEMP, "phase24b-discord-trusted-inbound") : path.join(os.tmpdir(), "phase24b-discord-trusted-inbound"));
-  return path.join(reportRoot, "phase24b-discord-trusted-inbound-proof.json");
+  const reportRoot = process.env.PHASE24D_REPORT_ROOT?.trim()
+    || (process.env.RUNNER_TEMP ? path.join(process.env.RUNNER_TEMP, "phase24d-lark-feishu-trusted-inbound") : path.join(os.tmpdir(), "phase24d-lark-feishu-trusted-inbound"));
+  return path.join(reportRoot, "phase24d-lark-feishu-trusted-inbound-proof.json");
 }
 
 async function waitForRun(baseUrl, receivedAtMs, normalizedMessage, config, timeoutMs) {
   const deadline = Date.now() + timeoutMs;
-  const sessionKey = `channel:discord:${normalizedMessage.chatId}`;
+  const sessionKey = `channel:${config.platformBrand}:${normalizedMessage.chatId}`;
   const expectedTask = normalizedMessage.text.trim();
   let lastCandidate = null;
 
@@ -411,15 +502,15 @@ async function waitForRun(baseUrl, receivedAtMs, normalizedMessage, config, time
       }
     }
 
-    await new Promise((resolve) => setTimeout(resolve, 1500));
+    await delay(1500);
   }
 
   return lastCandidate;
 }
 
-async function getSessionMessages(baseUrl, chatOrMessage) {
+async function getSessionMessages(baseUrl, chatOrMessage, config) {
   const chatId = typeof chatOrMessage === "string" ? chatOrMessage : chatOrMessage.chatId;
-  const sessionKey = `channel:discord:${chatId}`;
+  const sessionKey = `channel:${config.platformBrand}:${chatId}`;
   const encoded = encodeURIComponent(sessionKey);
   const response = await apiFetch(baseUrl, "GET", `/v1/sessions/${encoded}/messages?limit=30`).catch(() => null);
   return Array.isArray(response?.items)
@@ -432,10 +523,10 @@ async function getSessionMessages(baseUrl, chatOrMessage) {
 async function waitForUserSessionMirror(baseUrl, config, timeoutMs) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    const messages = await getSessionMessages(baseUrl, config.channelId);
+    const messages = await getSessionMessages(baseUrl, config.chatId, config);
     const mirror = messages.find((message) =>
       message?.role === "user"
-      && message?.metadata?.channelKind === "discord"
+      && message?.metadata?.channelKind === config.platformBrand
       && typeof message?.metadata?.sourceMessageId === "string"
       && messageIncludesProbe(message?.contentText, config)
     );
@@ -448,7 +539,7 @@ async function waitForUserSessionMirror(baseUrl, config, timeoutMs) {
 async function waitForAssistantSessionReply(baseUrl, normalizedMessage, config, timeoutMs) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    const messages = await getSessionMessages(baseUrl, normalizedMessage);
+    const messages = await getSessionMessages(baseUrl, normalizedMessage, config);
     const receipt = messages.find((message) =>
       message?.role === "assistant"
       && (
@@ -466,30 +557,40 @@ async function waitForAssistantSessionReply(baseUrl, normalizedMessage, config, 
 function readEnvConfig() {
   const probeNonce = buildProbeNonce();
   const probeText = `${PROBE_BODY_TEXT} ${probeNonce}`;
-  const botUserId = process.env.FRIDAY_DISCORD_BOT_USER_ID?.trim() ?? "";
+  const useFeishu = envBoolean("FRIDAY_LARK_USE_FEISHU", false);
+  const platformBrand = useFeishu ? "feishu" : "lark";
+  const platformDisplayName = useFeishu ? "Feishu" : "Lark";
+  const platformBaseUrl = useFeishu ? FEISHU_BASE_URL : LARK_BASE_URL;
+  const receiveMode = process.env.FRIDAY_LARK_RECEIVE_MODE?.trim() || "websocket";
+  const acceptAfterMs = Date.now() - 5_000;
   return {
-    botToken: process.env.FRIDAY_DISCORD_BOT_TOKEN?.trim() ?? "",
-    setupUserId: process.env.FRIDAY_DISCORD_SETUP_USER_ID?.trim() ?? "",
-    guildId: process.env.FRIDAY_DISCORD_GUILD_ID?.trim() ?? "",
-    channelId: process.env.FRIDAY_DISCORD_CHANNEL_ID?.trim() ?? "",
-    botUserId,
-    requireMention: envBoolean("FRIDAY_DISCORD_REQUIRE_MENTION", true),
-    timeoutMs: envInteger("PHASE24B_DISCORD_LISTENER_TIMEOUT_MS", DEFAULT_TIMEOUT_MS),
+    appId: process.env.FRIDAY_LARK_APP_ID?.trim() ?? "",
+    appSecret: process.env.FRIDAY_LARK_APP_SECRET?.trim() ?? "",
+    chatId: process.env.FRIDAY_LARK_CHAT_ID?.trim() ?? "",
+    groupChatId: process.env.FRIDAY_LARK_GROUP_CHAT_ID?.trim() ?? "",
+    allowedUserId: process.env.FRIDAY_LARK_ALLOWED_USER_ID?.trim() ?? "",
+    useFeishu,
+    platformBrand,
+    platformDisplayName,
+    platformBaseUrl,
+    receiveMode,
+    timeoutMs: envInteger("PHASE24D_LARK_FEISHU_LISTENER_TIMEOUT_MS", DEFAULT_TIMEOUT_MS),
+    acceptAfterMs,
     githubRunId: process.env.GITHUB_RUN_ID?.trim() || null,
     githubSha: process.env.GITHUB_SHA?.trim() || null,
     probeBodyText: PROBE_BODY_TEXT,
     probeNonce,
     probeText,
-    expectedOperatorMessage: `<@${botUserId}> ${probeText}`,
+    expectedOperatorMessage: probeText,
   };
 }
 
 function missingRequiredEnv(config) {
   return [
-    ["FRIDAY_DISCORD_BOT_TOKEN", config.botToken],
-    ["FRIDAY_DISCORD_SETUP_USER_ID", config.setupUserId],
-    ["FRIDAY_DISCORD_CHANNEL_ID", config.channelId],
-    ["FRIDAY_DISCORD_BOT_USER_ID", config.botUserId],
+    ["FRIDAY_LARK_APP_ID", config.appId],
+    ["FRIDAY_LARK_APP_SECRET", config.appSecret],
+    ["FRIDAY_LARK_CHAT_ID", config.chatId],
+    ["FRIDAY_LARK_ALLOWED_USER_ID", config.allowedUserId],
   ]
     .filter(([, value]) => !value)
     .map(([name]) => name);
@@ -521,14 +622,22 @@ async function main() {
     const missingEnv = missingRequiredEnv(config);
     if (missingEnv.length > 0) {
       report.status = "blocked";
-      report.blocker = "PHASE24B_DISCORD_ENV_EXPOSURE_BLOCKED";
+      report.blocker = "PHASE24D_LARK_FEISHU_ENV_EXPOSURE_BLOCKED";
       report.failures.push(`Missing required env: ${missingEnv.join(", ")}`);
-      await writeReport(report, config.botToken);
+      await writeReport(report, config.appSecret);
+      process.exitCode = 2;
+      return;
+    }
+    if (config.receiveMode !== "websocket") {
+      report.status = "blocked";
+      report.blocker = "PHASE24D_LARK_FEISHU_WEBSOCKET_MODE_REQUIRED";
+      report.failures.push(`Phase24D live proof requires FRIDAY_LARK_RECEIVE_MODE=websocket, got ${config.receiveMode}`);
+      await writeReport(report, config.appSecret);
       process.exitCode = 2;
       return;
     }
 
-    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "friday-phase24b-discord-"));
+    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "friday-phase24d-lark-feishu-"));
     process.env.FRIDAY_CHANNEL_DEBOUNCE_MS = process.env.FRIDAY_CHANNEL_DEBOUNCE_MS ?? "0";
     process.env.FRIDAY_CHANNEL_PROGRESS_RECEIPT_DELAY_MS = process.env.FRIDAY_CHANNEL_PROGRESS_RECEIPT_DELAY_MS ?? "0";
 
@@ -543,30 +652,25 @@ async function main() {
       },
     });
 
-    const instrumentedGateway = createInstrumentedDiscordGatewayService(config, report, observedEventsByMessageId);
-    const discordPlugin = createFridayDiscordChannel({
-      gateway: instrumentedGateway,
-      rest: createDiscordRestService(),
-    });
-    await discordPlugin.init({
-      kind: "discord",
+    const realPlugin = createFridayLarkChannel();
+    await realPlugin.init({
+      kind: config.platformBrand,
       enabled: true,
-      token: config.botToken,
-      intents: REQUIRED_INTENTS,
-      botUserId: config.botUserId,
-      allowedUsers: [config.setupUserId],
-      allowedChannels: [config.channelId],
-      requireMention: config.requireMention,
+      appId: config.appId,
+      appSecret: config.appSecret,
+      useFeishu: config.useFeishu,
+      receiveMode: "websocket",
+      allowedUsers: [config.allowedUserId],
+      allowedChats: [config.chatId],
     });
-    hub.channelRegistry.register(discordPlugin, {
-      allowedUsers: [config.setupUserId],
-      allowedChats: [config.channelId],
+    const instrumentedPlugin = instrumentLarkFeishuPlugin(realPlugin, config, report, observedEventsByMessageId);
+    hub.channelRegistry.register(instrumentedPlugin, {
+      allowedUsers: [config.allowedUserId],
+      allowedChats: [config.chatId],
     });
     await hub.start();
-    const discordView = hub.channelRegistry.describe("discord");
-    report.criteria.fridayHubChannelConnected = discordView?.status === "connected" && discordView?.running === true;
-    report.criteria.gatewayConnected = instrumentedGateway.isConnected();
-    report.diagnostics.discordHubAdapter.gatewayConnected = instrumentedGateway.isConnected();
+    const larkView = hub.channelRegistry.describe(config.platformBrand);
+    report.criteria.fridayHubChannelConnected = larkView?.status === "connected" && larkView?.running === true;
 
     const port = await findFreePort();
     server = createFridayHttpServer({
@@ -580,10 +684,10 @@ async function main() {
     await server.listen();
     const baseUrl = `http://127.0.0.1:${port}`;
 
-    await writeReport(report, config.botToken);
+    await writeReport(report, config.appSecret);
 
-    console.log("PHASE24B_DISCORD_LISTENER_READY");
-    console.log("Send this in the configured Discord channel now:");
+    console.log("PHASE24D_LARK_FEISHU_LISTENER_READY");
+    console.log(`Send this in the configured ${config.platformDisplayName} channel now:`);
     console.log(config.expectedOperatorMessage);
 
     const mirror = await waitForUserSessionMirror(baseUrl, config, config.timeoutMs);
@@ -602,12 +706,12 @@ async function main() {
 
     if (!mirror) {
       report.status = "blocked";
-      report.blocker = report.criteria.listenerReceivedMessageCreate
-        ? "PHASE24B_DISCORD_HUB_ADAPTER_DID_NOT_CREATE_NONCE_SESSION_MIRROR"
-        : "PHASE24B_WAITING_FOR_TRUSTED_USER_MESSAGE";
+      report.blocker = report.criteria.listenerReceivedMessageReceive
+        ? "PHASE24D_LARK_FEISHU_HUB_ADAPTER_DID_NOT_CREATE_NONCE_SESSION_MIRROR"
+        : "PHASE24D_WAITING_FOR_TRUSTED_USER_MESSAGE";
       report.diagnostics.localNonCurrentRunnerAmbiguityPossible = true;
       report.failures.push(`No current-runner user session mirror for nonce ${config.probeNonce} appeared within ${config.timeoutMs}ms`);
-      await writeReport(report, config.botToken);
+      await writeReport(report, config.appSecret);
       process.exitCode = 2;
       return;
     }
@@ -615,14 +719,14 @@ async function main() {
     const sourceMessageId = mirror.metadata?.sourceMessageId;
     report.diagnostics.currentRunnerNonceCorrespondence.sourceMessageIdTail = tail(sourceMessageId);
     const observed = typeof sourceMessageId === "string" ? observedEventsByMessageId.get(sourceMessageId) : null;
-    report.diagnostics.currentRunnerNonceCorrespondence.sessionMirrorSourceMessageIdMatchesGateway = Boolean(observed);
+    report.diagnostics.currentRunnerNonceCorrespondence.sessionMirrorSourceMessageIdMatchesWsClient = Boolean(observed);
 
     if (!observed) {
       report.status = "blocked";
-      report.blocker = "PHASE24B_DISCORD_CURRENT_LISTENER_SOURCE_EVENT_NOT_FOUND";
+      report.blocker = "PHASE24D_LARK_FEISHU_CURRENT_LISTENER_SOURCE_EVENT_NOT_FOUND";
       report.diagnostics.localNonCurrentRunnerAmbiguityPossible = true;
-      report.failures.push("Current runner session mirror matched the nonce, but the instrumented hub gateway did not record the same sourceMessageId");
-      await writeReport(report, config.botToken);
+      report.failures.push("Current runner session mirror matched the nonce, but the instrumented WSClient adapter did not record the same sourceMessageId");
+      await writeReport(report, config.appSecret);
       process.exitCode = 2;
       return;
     }
@@ -630,29 +734,29 @@ async function main() {
     const { normalized, receivedAtMs, inspection } = observed;
     if (!inspection?.rawTargetMatched) {
       report.status = "failed";
-      report.blocker = "PHASE24B_DISCORD_SESSION_MIRROR_SOURCE_NOT_TRUSTED_TARGET";
+      report.blocker = "PHASE24D_LARK_FEISHU_SESSION_MIRROR_SOURCE_NOT_TRUSTED_TARGET";
       report.diagnostics.localNonCurrentRunnerAmbiguityPossible = true;
-      report.failures.push("Session mirror sourceMessageId matched a gateway event, but that event did not satisfy trusted sender/channel/mention/nonce checks");
-      await writeReport(report, config.botToken);
+      report.failures.push("Session mirror sourceMessageId matched a WSClient event, but that event did not satisfy trusted sender/chat/nonce checks");
+      await writeReport(report, config.appSecret);
       process.exitCode = 1;
       return;
     }
 
     if (!normalized) {
       report.status = "failed";
-      report.blocker = "PHASE24B_DISCORD_NORMALIZER_DROPPED_TRUSTED_USER_MESSAGE";
-      report.failures.push("Discord MESSAGE_CREATE matched trusted sender/channel but Friday normalizer returned null");
-      await writeReport(report, config.botToken);
+      report.blocker = "PHASE24D_LARK_FEISHU_NORMALIZER_DROPPED_TRUSTED_USER_MESSAGE";
+      report.failures.push(`${config.platformDisplayName} message_receive matched trusted sender/chat but Friday normalizer returned null`);
+      await writeReport(report, config.appSecret);
       process.exitCode = 1;
       return;
     }
 
     report.criteria.realHubAdapterAcceptedMessage = true;
-    report.diagnostics.discordHubAdapter.realHubAdapterAcceptedMessage = true;
-    report.criteria.normalizedChannelKindDiscord = normalized.channelKind === "discord";
-    report.criteria.normalizedSenderMatchesTrustedSetupUser = normalized.senderId === config.setupUserId;
-    report.criteria.normalizedChatMatchesConfiguredChannel = normalized.chatId === config.channelId;
-    report.criteria.normalizedChatTypeGroup = normalized.chatType === "group";
+    report.diagnostics.larkFeishuHubAdapter.realHubAdapterAcceptedMessage = true;
+    report.criteria.normalizedChannelKindMatchesBrand = normalized.channelKind === config.platformBrand;
+    report.criteria.normalizedSenderMatchesTrustedAllowedUser = normalized.senderId === config.allowedUserId;
+    report.criteria.normalizedChatMatchesConfiguredChat = normalized.chatId === config.chatId;
+    report.criteria.normalizedChatTypeSupported = normalized.chatType === "direct" || normalized.chatType === "group";
     report.normalizedMessage = {
       idTail: tail(normalized.id),
       channelKind: normalized.channelKind,
@@ -665,14 +769,14 @@ async function main() {
       replyToTail: tail(normalized.replyTo),
       timestampPresent: typeof normalized.timestamp === "number",
     };
-    await writeReport(report, config.botToken);
+    await writeReport(report, config.appSecret);
 
     const run = await waitForRun(baseUrl, receivedAtMs, normalized, config, Math.min(config.timeoutMs, 180_000));
     if (!run?.id) {
       report.status = "failed";
-      report.blocker = "PHASE24B_DISCORD_SHARED_STATE_MACHINE_RUN_NOT_FOUND";
-      report.failures.push("Trusted Discord message was normalized but no matching Friday channel-origin run appeared");
-      await writeReport(report, config.botToken);
+      report.blocker = "PHASE24D_LARK_FEISHU_SHARED_STATE_MACHINE_RUN_NOT_FOUND";
+      report.failures.push(`Trusted ${config.platformDisplayName} message was normalized but no matching Friday channel-origin run appeared`);
+      await writeReport(report, config.appSecret);
       process.exitCode = 1;
       return;
     }
@@ -684,11 +788,11 @@ async function main() {
     const auditUnifiedTaskState = audit?.unifiedTaskState ?? null;
     const state = auditUnifiedTaskState?.state ?? null;
     const assistantReply = await waitForAssistantSessionReply(baseUrl, normalized, config, Math.min(config.timeoutMs, 60_000));
-    const finalSessionMessages = await getSessionMessages(baseUrl, normalized);
+    const finalSessionMessages = await getSessionMessages(baseUrl, normalized, config);
     const exportedEvidenceFiles = [
-      await writeEvidenceArtifact(report, config.botToken, "friday-agent-run-response.json", runDetails),
-      await writeEvidenceArtifact(report, config.botToken, "friday-agent-run-audit-response.json", audit),
-      await writeEvidenceArtifact(report, config.botToken, "friday-session-messages-response.json", { items: finalSessionMessages }),
+      await writeEvidenceArtifact(report, config.appSecret, "friday-agent-run-response.json", runDetails),
+      await writeEvidenceArtifact(report, config.appSecret, "friday-agent-run-audit-response.json", audit),
+      await writeEvidenceArtifact(report, config.appSecret, "friday-session-messages-response.json", { items: finalSessionMessages }),
     ];
 
     report.criteria.sharedStateMachineRunFound = true;
@@ -709,7 +813,7 @@ async function main() {
     report.criteria.notCompleted = runRecord.status !== "completed" && state !== "completed";
     report.criteria.evidenceReceiptAvailable = audit?.replayReceipt?.schemaVersion === "friday.agent.evidence_receipt.v1"
       && audit?.replayReceipt?.run?.runId === runRecord.id;
-    report.criteria.discordShortReceiptObserved = Boolean(assistantReply?.metadata?.sourceMessageId);
+    report.criteria.larkFeishuShortReceiptObserved = Boolean(assistantReply?.metadata?.sourceMessageId);
     report.criteria.assistantSessionReplyObserved = Boolean(assistantReply);
     report.criteria.evidenceMatchesNonce = messageIncludesProbe(runRecord.task, config)
       && finalSessionMessages.some((message) => message?.role === "user" && messageIncludesProbe(message?.contentText, config));
@@ -742,21 +846,20 @@ async function main() {
       assistantSessionReplyObserved: Boolean(assistantReply),
       exportedFiles: exportedEvidenceFiles,
     };
-    report.criteria.artifactHasNoToken = !containsTokenMaterial(JSON.stringify(scrub(report, config.botToken)), config.botToken);
+    report.criteria.artifactHasNoToken = !containsTokenMaterial(JSON.stringify(scrub(report, config.appSecret)), config.appSecret);
 
     const requiredCriteria = [
-      "gatewayConnected",
-      "listenerReceivedMessageCreate",
+      "wsClientConnected",
+      "listenerReceivedMessageReceive",
       "authorBotFalse",
-      "authorMatchesTrustedSetupUser",
-      "channelMatchesConfiguredChannel",
-      "requireMentionSatisfied",
+      "senderMatchesTrustedAllowedUser",
+      "chatMatchesConfiguredChat",
       "nonceMatched",
       "normalizerDidNotDrop",
-      "normalizedChannelKindDiscord",
-      "normalizedSenderMatchesTrustedSetupUser",
-      "normalizedChatMatchesConfiguredChannel",
-      "normalizedChatTypeGroup",
+      "normalizedChannelKindMatchesBrand",
+      "normalizedSenderMatchesTrustedAllowedUser",
+      "normalizedChatMatchesConfiguredChat",
+      "normalizedChatTypeSupported",
       "fridayHubChannelConnected",
       "realHubAdapterAcceptedMessage",
       "userSessionMirrorMatched",
@@ -782,23 +885,57 @@ async function main() {
     report.status = report.failures.length === 0 ? "passed" : "failed";
     if (report.status !== "passed") {
       report.blocker = report.criteria.unifiedTaskStateAwaitingHuman
-        ? "PHASE24B_DISCORD_TRUSTED_INBOUND_ACCEPTANCE_FAILED"
-        : "PHASE24B_DISCORD_SHARED_STATE_MACHINE_NOT_AWAITING_HUMAN";
+        ? "PHASE24D_LARK_FEISHU_TRUSTED_INBOUND_ACCEPTANCE_FAILED"
+        : "PHASE24D_LARK_FEISHU_SHARED_STATE_MACHINE_NOT_AWAITING_HUMAN";
     }
 
-    await writeReport(report, config.botToken);
+    await writeReport(report, config.appSecret);
     process.exitCode = report.status === "passed" ? 0 : 1;
   } catch (error) {
     report.status = "failed";
-    report.blocker = "PHASE24B_DISCORD_LISTENER_HARNESS_ERROR";
-    report.failures.push(safeError(error, config?.botToken ?? ""));
-    await writeReport(report, config?.botToken ?? "").catch(() => {});
+    report.blocker = "PHASE24D_LARK_FEISHU_LISTENER_HARNESS_ERROR";
+    report.failures.push(safeError(error, config?.appSecret ?? ""));
+    await writeReport(report, config?.appSecret ?? "").catch(() => {});
     process.exitCode = 1;
   } finally {
-    if (server) await server.close().catch(() => {});
-    if (hub) await hub.stop().catch(() => {});
-    if (stateDir) await fs.rm(stateDir, { recursive: true, force: true }).catch(() => {});
+    const cleanupFailures = [];
+    if (server) {
+      await withTimeout(server.close(), 5_000, "http_server_close").catch((error) => {
+        cleanupFailures.push(safeError(error, config?.appSecret ?? ""));
+      });
+    }
+    if (hub) {
+      await withTimeout(hub.stop(), 5_000, "hub_stop").catch((error) => {
+        cleanupFailures.push(safeError(error, config?.appSecret ?? ""));
+      });
+    }
+    if (stateDir) {
+      await withTimeout(fs.rm(stateDir, { recursive: true, force: true }), 5_000, "state_dir_cleanup").catch((error) => {
+        cleanupFailures.push(safeError(error, config?.appSecret ?? ""));
+      });
+    }
+    if (cleanupFailures.length > 0) {
+      report.diagnostics.cleanupFailures = cleanupFailures;
+      await writeReport(report, config?.appSecret ?? "").catch(() => {});
+      if (process.exitCode === 0 || process.exitCode === undefined) process.exitCode = 1;
+    }
+    if (process.env.GITHUB_ACTIONS === "true") {
+      process.exit(process.exitCode ?? 0);
+    }
   }
 }
 
-main();
+// Export hooks for unit tests (no behavior change for direct CLI invocation).
+export {
+  buildProbeNonce,
+  containsTokenMaterial,
+  initialReport,
+  missingRequiredEnv,
+  readEnvConfig,
+  resolveReportPath,
+  scrub,
+};
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/ops/run-friday-release-preflight.mjs
+++ b/scripts/ops/run-friday-release-preflight.mjs
@@ -90,11 +90,34 @@ for (const [relativePath, label] of [
   requireFile(path.join(repoRoot, relativePath), label, failures);
 }
 
-const crossPlatform = runCrossPlatformInputs(repoRoot);
-if (crossPlatform.status !== 0) {
-  // Cross-platform inputs are advisory — missing iOS/Android/Windows
-  // credentials should not block npm + source releases.
-  console.warn(`[preflight] cross-platform release inputs check returned code ${String(crossPlatform.status)} (advisory, not blocking)`);
+// R1 release-closure: `FRIDAY_RELEASE_MODE=source-only` skips the iOS/Android/
+// Windows/macOS cross-platform input check because a source/npm-only release
+// (e.g. 1.0.1) does not promise any of those distribution surfaces. The
+// default mode (unset or "source-and-macos") keeps the existing behavior.
+const releaseMode = (process.env.FRIDAY_RELEASE_MODE ?? "").trim() || "source-and-macos";
+const skipCrossPlatform = releaseMode === "source-only";
+
+let crossPlatformCheck;
+if (skipCrossPlatform) {
+  crossPlatformCheck = {
+    status: "skipped_source_only",
+    exitCode: null,
+    stdout: "",
+    stderr: "",
+  };
+} else {
+  const crossPlatform = runCrossPlatformInputs(repoRoot);
+  if (crossPlatform.status !== 0) {
+    // Cross-platform inputs are advisory — missing iOS/Android/Windows
+    // credentials should not block npm + source releases.
+    console.warn(`[preflight] cross-platform release inputs check returned code ${String(crossPlatform.status)} (advisory, not blocking)`);
+  }
+  crossPlatformCheck = {
+    status: crossPlatform.status === 0 ? "passed" : "failed",
+    exitCode: crossPlatform.status,
+    stdout: crossPlatform.stdout.trim(),
+    stderr: crossPlatform.stderr.trim(),
+  };
 }
 
 const report = {
@@ -102,15 +125,11 @@ const report = {
   repoRoot,
   tag,
   packageVersion,
+  releaseMode,
   status: failures.length === 0 ? "passed" : "failed",
   failures,
   checks: {
-    crossPlatformReleaseInputs: {
-      status: crossPlatform.status === 0 ? "passed" : "failed",
-      exitCode: crossPlatform.status,
-      stdout: crossPlatform.stdout.trim(),
-      stderr: crossPlatform.stderr.trim(),
-    },
+    crossPlatformReleaseInputs: crossPlatformCheck,
   },
 };
 
@@ -118,7 +137,9 @@ writeReport(reportPath, report);
 
 if (failures.length > 0) {
   console.error(JSON.stringify(report, null, 2));
-  process.exit(crossPlatform.status === 78 ? 78 : 1);
+  // crossPlatformCheck.exitCode is null when the check was skipped; treat
+  // that as a non-78 exit so the workflow does not see "neutral".
+  process.exit(crossPlatformCheck.exitCode === 78 ? 78 : 1);
 }
 
 console.log(JSON.stringify(report, null, 2));

--- a/scripts/ops/validate-channel-proof-artifacts.mjs
+++ b/scripts/ops/validate-channel-proof-artifacts.mjs
@@ -1,0 +1,350 @@
+#!/usr/bin/env node
+
+/**
+ * Same-SHA channel-proof artifact validator.
+ *
+ * Usage:
+ *   node scripts/ops/validate-channel-proof-artifacts.mjs \
+ *     --discord <path>|skip \
+ *     --telegram <path>|skip \
+ *     --lark-feishu <path>|skip \
+ *     [--expected-sha <40-char-hex>]
+ *
+ * For each non-skipped channel:
+ *   - loads the JSON artifact (the per-channel listener output)
+ *   - verifies schemaVersion matches the expected stable token
+ *   - verifies status === "passed"
+ *   - verifies every key in `criteria` is true (no false / pending)
+ *   - verifies `failures` is []
+ *   - verifies the corresponding `observed*Event` is non-null (live proof received)
+ *   - verifies the artifact's serialized JSON contains NO token material
+ *     (raw token, app secret, "xoxb-", "bot " or "Bearer " prefixes outside
+ *     redaction labels)
+ *   - when --expected-sha is provided, verifies environment.commit_sha
+ *     (fallback: environment.head_sha) matches
+ *
+ * Exits 0 only when every non-skipped channel is `valid: true`. Stdout always
+ * carries a structured JSON object with stable token reasons. The
+ * `blockerClass` field on each result is one of:
+ *
+ *   - artifact_missing_or_unreadable    File not found / invalid JSON / required keys absent.
+ *   - harness_reported_failure_or_blocked
+ *                                       File present + parseable but harness did not pass.
+ *   - artifact_upload_broken            Token material leaked into the artifact.
+ *   - none                              Channel validated cleanly.
+ */
+
+import { readFileSync } from "node:fs";
+
+import {
+  containsTokenMaterial as containsTokenMaterialShared,
+} from "./lib/token-redaction.mjs";
+
+const CHANNEL_DEFINITIONS = Object.freeze({
+  discord: Object.freeze({
+    flag: "--discord",
+    schemaVersion: "friday.phase24b.discord_trusted_inbound_proof.v1",
+    observedEventKey: "observedDiscordEvent",
+  }),
+  telegram: Object.freeze({
+    flag: "--telegram",
+    schemaVersion: "friday.phase24c.telegram_trusted_inbound_proof.v1",
+    observedEventKey: "observedTelegramEvent",
+  }),
+  "lark-feishu": Object.freeze({
+    flag: "--lark-feishu",
+    schemaVersion: "friday.phase24d.lark_feishu_trusted_inbound_proof.v1",
+    observedEventKey: "observedLarkFeishuEvent",
+  }),
+});
+
+const REQUIRED_TOP_LEVEL_KEYS = [
+  "schemaVersion",
+  "phase",
+  "scope",
+  "status",
+  "startedAt",
+  "completedAt",
+  "reportPath",
+  "environment",
+  "criteria",
+  "diagnostics",
+  "failures",
+];
+
+// Defense-in-depth: every channel listener writes these named criteria. The
+// generic "every criterion must be true" loop catches the `=== false` case,
+// but if a tampered artifact dropped the key entirely the loop would miss it.
+// This explicit allow-list catches that as well.
+const REQUIRED_NAMED_CRITERIA = Object.freeze(["artifactHasNoToken"]);
+
+// Conservative token-shape detectors. If any of these match outside a
+// redaction label substring, the artifact upload is broken.
+//
+// `xoxb-` is the Slack bot-token prefix (unmistakable).
+// `\b(?:Bot|Bearer)\s+\S{16,}\b` matches an Authorization-header token tail
+// (long opaque value), avoiding free-text false positives like "the bot says".
+//
+// Note: this catches *prefixed* tokens. Discord/Lark/Feishu app secrets are
+// opaque alphanumerics without a recognizable prefix — for those, every
+// listener writes a `criteria.artifactHasNoToken` boolean computed against
+// the actual secret value (see explicit assertion below) so the validator
+// catches leaks via the named criterion instead of byte-scanning.
+const TOKEN_PATTERNS = Object.freeze([
+  { kind: "substring", needle: "xoxb-", caseInsensitive: false, label: "xoxb-" },
+  { kind: "regex", regex: /\b(?:Bot|Bearer)\s+\S{16,}\b/i, label: "Bot/Bearer" },
+]);
+
+function parseArgs(argv) {
+  const args = {
+    channels: { discord: null, telegram: null, "lark-feishu": null },
+    expectedSha: null,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    const next = argv[index + 1];
+    switch (token) {
+      case "--discord":
+      case "--telegram":
+      case "--lark-feishu":
+        if (typeof next !== "string" || next.length === 0) {
+          return { args: null, error: `cli_argument_missing_value:${token}` };
+        }
+        args.channels[token.slice(2)] = next;
+        index += 1;
+        break;
+      case "--expected-sha":
+        if (typeof next !== "string" || next.length === 0) {
+          return { args: null, error: "cli_argument_missing_value:--expected-sha" };
+        }
+        args.expectedSha = next;
+        index += 1;
+        break;
+      default:
+        return { args: null, error: `cli_argument_unknown:${token}` };
+    }
+  }
+  return { args, error: null };
+}
+
+function isPlainObject(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stripRedactionLabelOccurrences(serialized) {
+  // A "[REDACTED_*]" label may legitimately contain a substring like "BOT" but
+  // never " bot ", " Bearer " or "xoxb-". Defensively remove anything bracketed
+  // by [REDACTED_...] before scanning so that the conservative substring
+  // checks have no chance of matching the labels themselves.
+  return serialized.replace(/\[REDACTED_[^\]]*\]/g, "");
+}
+
+function findResidualTokenPrefixes(serialized) {
+  const scrubbedFromLabels = stripRedactionLabelOccurrences(serialized);
+  const found = [];
+  for (const pattern of TOKEN_PATTERNS) {
+    if (pattern.kind === "substring") {
+      const haystack = pattern.caseInsensitive ? scrubbedFromLabels.toLowerCase() : scrubbedFromLabels;
+      const needleNorm = pattern.caseInsensitive ? pattern.needle.toLowerCase() : pattern.needle;
+      if (haystack.includes(needleNorm)) found.push(pattern.label);
+    } else if (pattern.kind === "regex") {
+      if (pattern.regex.test(scrubbedFromLabels)) found.push(pattern.label);
+    }
+  }
+  return found;
+}
+
+function validateChannelArtifact(channelKey, artifactPath, expectedSha) {
+  const definition = CHANNEL_DEFINITIONS[channelKey];
+  const reasons = [];
+
+  // ─── Step 1: load and parse ───
+  let raw;
+  try {
+    raw = readFileSync(artifactPath, "utf8");
+  } catch (error) {
+    const code = error && typeof error === "object" && "code" in error ? String(error.code) : "unknown";
+    return {
+      channel: channelKey,
+      valid: false,
+      blockerClass: "artifact_missing_or_unreadable",
+      reasons: [`artifact_unreadable:${code}`],
+      path: artifactPath,
+    };
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return {
+      channel: channelKey,
+      valid: false,
+      blockerClass: "artifact_missing_or_unreadable",
+      reasons: ["artifact_invalid_json"],
+      path: artifactPath,
+    };
+  }
+
+  if (!isPlainObject(parsed)) {
+    return {
+      channel: channelKey,
+      valid: false,
+      blockerClass: "artifact_missing_or_unreadable",
+      reasons: ["artifact_not_an_object"],
+      path: artifactPath,
+    };
+  }
+
+  // ─── Step 2: required keys ───
+  const missingKeys = REQUIRED_TOP_LEVEL_KEYS.filter((key) => !(key in parsed));
+  if (missingKeys.length > 0) {
+    return {
+      channel: channelKey,
+      valid: false,
+      blockerClass: "artifact_missing_or_unreadable",
+      reasons: missingKeys.map((key) => `artifact_missing_required_key:${key}`),
+      path: artifactPath,
+    };
+  }
+
+  // ─── Step 3: schemaVersion ───
+  if (parsed.schemaVersion !== definition.schemaVersion) {
+    reasons.push(`schema_version_mismatch:expected=${definition.schemaVersion}:observed=${String(parsed.schemaVersion)}`);
+  }
+
+  // ─── Step 4: status ───
+  if (parsed.status !== "passed") {
+    reasons.push(`status_not_passed:${String(parsed.status)}`);
+  }
+
+  // ─── Step 5: criteria all true ───
+  const criteria = parsed.criteria;
+  if (!isPlainObject(criteria)) {
+    reasons.push("criteria_invalid");
+  } else {
+    const criteriaFailures = Object.entries(criteria)
+      .filter(([, value]) => value !== true)
+      .map(([key]) => `criterion_not_true:${key}`);
+    reasons.push(...criteriaFailures);
+    for (const key of REQUIRED_NAMED_CRITERIA) {
+      if (!(key in criteria)) reasons.push(`criterion_missing:${key}`);
+    }
+  }
+
+  // ─── Step 6: failures must be [] ───
+  if (!Array.isArray(parsed.failures)) {
+    reasons.push("failures_not_array");
+  } else if (parsed.failures.length > 0) {
+    reasons.push(`failures_present:count=${parsed.failures.length}`);
+  }
+
+  // ─── Step 7: observed*Event must be non-null ───
+  const observedEvent = parsed[definition.observedEventKey];
+  if (observedEvent === null || observedEvent === undefined) {
+    reasons.push(`observed_event_missing:${definition.observedEventKey}`);
+  }
+
+  // ─── Step 8: token-material residue ───
+  const serialized = JSON.stringify(parsed);
+  const residualPrefixes = findResidualTokenPrefixes(serialized);
+  if (residualPrefixes.length > 0) {
+    return {
+      channel: channelKey,
+      valid: false,
+      blockerClass: "artifact_upload_broken",
+      reasons: residualPrefixes.map((prefix) => `token_material_residue:${prefix}`),
+      path: artifactPath,
+    };
+  }
+
+  // ─── Step 9: expected-sha enforcement ───
+  if (typeof expectedSha === "string" && expectedSha.length > 0) {
+    const env = isPlainObject(parsed.environment) ? parsed.environment : {};
+    const candidates = [env.commit_sha, env.head_sha].filter((value) => typeof value === "string" && value.length > 0);
+    if (candidates.length === 0) {
+      reasons.push("commit_sha_missing");
+    } else if (!candidates.includes(expectedSha)) {
+      reasons.push("commit_sha_mismatch");
+    }
+  }
+
+  if (reasons.length > 0) {
+    return {
+      channel: channelKey,
+      valid: false,
+      blockerClass: "harness_reported_failure_or_blocked",
+      reasons,
+      path: artifactPath,
+    };
+  }
+
+  return {
+    channel: channelKey,
+    valid: true,
+    blockerClass: "none",
+    reasons: [],
+    path: artifactPath,
+  };
+}
+
+/**
+ * Programmatic entry point. Returns the decision shape that the CLI emits.
+ *
+ * @param {object} args
+ * @param {{ discord: string|null, telegram: string|null, "lark-feishu": string|null }} args.channels
+ * @param {string|null} args.expectedSha
+ */
+export function validateChannelProofArtifacts(args) {
+  const results = [];
+  for (const channelKey of Object.keys(CHANNEL_DEFINITIONS)) {
+    const value = args?.channels?.[channelKey];
+    if (value === null || value === undefined || value === "skip") {
+      results.push({
+        channel: channelKey,
+        valid: true,
+        blockerClass: "none",
+        reasons: ["channel_skipped"],
+        path: null,
+        skipped: true,
+      });
+      continue;
+    }
+    results.push(validateChannelArtifact(channelKey, value, args?.expectedSha ?? null));
+  }
+  const valid = results.every((entry) => entry.valid === true);
+  return { valid, results };
+}
+
+function emit(decision) {
+  process.stdout.write(`${JSON.stringify(decision, null, 2)}\n`);
+}
+
+function main() {
+  const { args, error } = parseArgs(process.argv.slice(2));
+  if (error !== null) {
+    emit({
+      valid: false,
+      results: [
+        {
+          channel: null,
+          valid: false,
+          blockerClass: "artifact_missing_or_unreadable",
+          reasons: [error],
+        },
+      ],
+    });
+    process.exit(1);
+  }
+
+  const decision = validateChannelProofArtifacts(args);
+  emit({ ...decision, expected_sha: args.expectedSha ?? null });
+  process.exit(decision.valid ? 0 : 1);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}
+
+// Re-export the shared helper so test code can reuse the same residue check.
+export { containsTokenMaterialShared as containsTokenMaterial };

--- a/scripts/ops/write-friday-release-manifest.mjs
+++ b/scripts/ops/write-friday-release-manifest.mjs
@@ -5,6 +5,23 @@ import path from "node:path";
 
 const PLATFORM_ORDER = ["macos", "ios", "android", "windows"];
 
+const SOURCE_ONLY_RELEASE_CLAIM_BOUNDARY =
+  "This release is npm/source-only. Desktop, Homebrew, notarized macOS, mobile, "
+  + "and unproven external integrations remain outside this release claim. "
+  + "Capabilities without same-SHA live proof are labeled setup_needed, "
+  + "proof_pending, blocked_by_env, unsupported, or not_configured.";
+
+const SOURCE_ONLY_PLATFORM_OVERRIDE = Object.freeze({
+  availability: "not_in_this_release",
+  milestone: "npm_source_only_public_v1_local_candidate",
+  notes: [
+    "This platform is not part of the current npm/source-only release.",
+    "See releaseClaim.boundary for the exact boundary text.",
+  ],
+});
+
+const SOURCE_ONLY_CHANNEL_AVAILABILITY = "not_in_this_release";
+
 const PLATFORM_DEFAULTS = {
   macos: {
     availability: "release_baseline_target",
@@ -204,8 +221,19 @@ function renderMarkdown(manifest) {
     `- Version: \`${manifest.version}\``,
     `- Tag: \`${manifest.tag}\``,
     `- Download Base URL: \`${manifest.downloadBaseUrl}\``,
+    `- Release Mode: \`${manifest.releaseMode}\``,
     `- Current Milestone: \`${manifest.currentMilestone}\``,
     "",
+  ];
+  if (manifest.releaseClaim) {
+    lines.push("## Release Claim Boundary");
+    lines.push("");
+    lines.push(`- Allowed claim: ${manifest.releaseClaim.allowed}`);
+    lines.push("");
+    lines.push(`> ${manifest.releaseClaim.boundary}`);
+    lines.push("");
+  }
+  lines.push(
     "## Distribution Channels",
     "",
     "| Channel | Availability | Summary |",
@@ -220,7 +248,7 @@ function renderMarkdown(manifest) {
     ...manifest.platforms.map((platform) =>
       `| \`${platform.platform}\` | \`${platform.availability}\` | \`${platform.milestone}\` | \`${platform.nativeCompanion}\` | ${platform.artifacts.length} |`),
     "",
-  ];
+  );
 
   for (const platform of manifest.platforms) {
     lines.push(`## ${platform.platform}`);
@@ -274,6 +302,8 @@ async function main() {
   const tag = process.env.FRIDAY_RELEASE_TAG?.trim() || `v${version}`;
   const downloadBaseUrl = process.env.FRIDAY_RELEASE_DOWNLOAD_BASE_URL?.trim()
     || `https://github.com/thesongzhu/Friday/releases/download/${tag}`;
+  const releaseMode = (process.env.FRIDAY_RELEASE_MODE ?? "").trim() || "source-and-macos";
+  const sourceOnly = releaseMode === "source-only";
   const generatedAt = new Date().toISOString();
   const releasesRoot = path.join(repoRoot, "dist", "releases");
   const channelsRoot = path.join(releasesRoot, "channels");
@@ -299,10 +329,23 @@ async function main() {
   }
 
   const sourceArtifacts = sortArtifacts(artifacts.filter((artifact) => artifact.platform === "source"));
-  const macosCleanMachineEvidenceComplete = await hasCompleteMacosCleanMachineEvidence(repoRoot);
+  const macosCleanMachineEvidenceComplete = sourceOnly
+    ? false
+    : await hasCompleteMacosCleanMachineEvidence(repoRoot);
   const platformEntries = PLATFORM_ORDER.map((platform) => {
     const defaults = PLATFORM_DEFAULTS[platform];
     const platformArtifacts = sortArtifacts(artifacts.filter((artifact) => artifact.platform === platform));
+    if (sourceOnly) {
+      return {
+        platform,
+        availability: SOURCE_ONLY_PLATFORM_OVERRIDE.availability,
+        milestone: SOURCE_ONLY_PLATFORM_OVERRIDE.milestone,
+        nativeCompanion: defaults.nativeCompanion,
+        scaffolds: defaults.scaffolds,
+        notes: SOURCE_ONLY_PLATFORM_OVERRIDE.notes,
+        artifacts: platformArtifacts,
+      };
+    }
     const macosStatus = platform === "macos"
       ? resolveMacosPlatformStatus(platformArtifacts, channelMetadata, macosCleanMachineEvidenceComplete)
       : null;
@@ -317,20 +360,63 @@ async function main() {
     };
   });
 
+  const channels = sourceOnly
+    ? {
+        githubReleases: {
+          availability: channelAvailability(channelMetadata, "githubReleases", "available"),
+          summary: "Primary release entry for tagged builds and attached install assets.",
+        },
+        sparkle: {
+          availability: SOURCE_ONLY_CHANNEL_AVAILABILITY,
+          appcastUrl: null,
+          summary: "Required macOS auto-update channel for the native Agent OS baseline.",
+        },
+        homebrew: {
+          availability: SOURCE_ONLY_CHANNEL_AVAILABILITY,
+          caskTemplatePath: "packaging/homebrew/Casks/friday.rb.template",
+          tapRepo: null,
+          rawUrl: null,
+          summary: "Required macOS install and upgrade channel generated from the DMG metadata.",
+        },
+        npm: {
+          availability: channelAvailability(channelMetadata, "npm", "available"),
+          installCommand: "npm install -g @thesongzhu/friday",
+          summary: "Scoped npm package fallback while native platform installers remain phased.",
+        },
+        testflight: {
+          availability: SOURCE_ONLY_CHANNEL_AVAILABILITY,
+          summary: "Intended iOS beta distribution channel for the trusted-device remote console.",
+        },
+        playInternal: {
+          availability: SOURCE_ONLY_CHANNEL_AVAILABILITY,
+          summary: "Intended Android beta distribution channel for the trusted-device remote console.",
+        },
+      }
+    : buildChannels({
+        macosArtifacts: platformEntries[0].artifacts,
+        iosArtifacts: platformEntries[1].artifacts,
+        androidArtifacts: platformEntries[2].artifacts,
+        sourceArtifacts,
+        channelMetadata,
+      });
+
   const manifest = {
     generatedAt,
     version,
     tag,
     downloadBaseUrl,
-    currentMilestone: "macos_ios_android_windows_agent_os_rollout",
+    releaseMode,
+    currentMilestone: sourceOnly
+      ? "npm_source_only_public_v1_local_candidate"
+      : "macos_ios_android_windows_agent_os_rollout",
     longTermVision: "downloadable_cross_platform_ai_automation_employee",
-    channels: buildChannels({
-      macosArtifacts: platformEntries[0].artifacts,
-      iosArtifacts: platformEntries[1].artifacts,
-      androidArtifacts: platformEntries[2].artifacts,
-      sourceArtifacts,
-      channelMetadata,
-    }),
+    releaseClaim: sourceOnly
+      ? {
+          allowed: "public v1 local candidate, npm/source distribution",
+          boundary: SOURCE_ONLY_RELEASE_CLAIM_BOUNDARY,
+        }
+      : null,
+    channels,
     platforms: platformEntries,
     developerFallbacks: sourceArtifacts,
   };
@@ -343,7 +429,7 @@ async function main() {
   await fs.writeFile(mdPath, renderMarkdown(manifest), "utf8");
 
   const caskTemplatePath = path.join(repoRoot, "packaging", "homebrew", "Casks", "friday.rb.template");
-  if (await fileExists(caskTemplatePath)) {
+  if (!sourceOnly && await fileExists(caskTemplatePath)) {
     const macosDmg = platformEntries[0].artifacts.find((artifact) => artifact.kind === "dmg");
     if (macosDmg) {
       const template = await fs.readFile(caskTemplatePath, "utf8");

--- a/scripts/quality/release-truth-lib.mjs
+++ b/scripts/quality/release-truth-lib.mjs
@@ -46,6 +46,11 @@ export const EVIDENCE_KINDS = {
 export const DEFAULT_PROOF_INPUTS = [
   "package.json",
   "scripts/ops/run-real-green-gate.mjs",
+  "scripts/ops/lib/token-redaction.mjs",
+  "scripts/ops/phase24b-discord-trusted-inbound-listener.mjs",
+  "scripts/ops/phase24c-telegram-trusted-inbound-listener.mjs",
+  "scripts/ops/phase24d-lark-feishu-trusted-inbound-listener.mjs",
+  "scripts/ops/validate-channel-proof-artifacts.mjs",
   "validation/real-world/lib",
   "test/e2e/live",
   "test/e2e/ui/_helpers/browser-env.ts",

--- a/test/unit/scripts/ops/lib/token-redaction.test.ts
+++ b/test/unit/scripts/ops/lib/token-redaction.test.ts
@@ -1,0 +1,77 @@
+/**
+ * R1 — shared token-redaction helper used by phase24b/c/d trusted-inbound
+ * listeners and the channel-proof validator. Locks down the contract:
+ *   - exact-token replacement;
+ *   - 12-char prefix replacement when the token exceeds 12 chars;
+ *   - empty-token short-circuit;
+ *   - cyclic-object fail-closed sentinel (HR14 — secrets must never escape
+ *     through a JSON.stringify throw path).
+ */
+import { describe, it, expect } from "vitest";
+import * as path from "node:path";
+import { pathToFileURL } from "node:url";
+
+type RedactionModule = typeof import("../../../../../scripts/ops/lib/token-redaction.mjs");
+
+const scriptUrl = pathToFileURL(
+  path.resolve(__dirname, "../../../../../scripts/ops/lib/token-redaction.mjs"),
+).href;
+
+async function loadRedaction(): Promise<RedactionModule> {
+  return (await import(scriptUrl)) as RedactionModule;
+}
+
+const LABELS = Object.freeze({
+  tokenLabel: "[REDACTED_TEST_TOKEN]",
+  prefixLabel: "[REDACTED_TEST_TOKEN_PREFIX]",
+});
+
+describe("token-redaction scrub + containsTokenMaterial", () => {
+  it("replaces exact token occurrences with the token label", async () => {
+    const { scrub } = await loadRedaction();
+    const token = "supersecret-1234567890ab";
+    const result = scrub({ note: `value=${token};other=${token}` }, token, LABELS) as {
+      note: string;
+    };
+    expect(result.note).not.toContain(token);
+    expect(result.note.match(/\[REDACTED_TEST_TOKEN\]/g)?.length).toBe(2);
+  });
+
+  it("replaces the 12-char token prefix when the token is longer than 12 chars", async () => {
+    const { scrub } = await loadRedaction();
+    const token = "supersecret-1234567890ab"; // > 12 chars
+    const prefix = token.slice(0, 12);
+    const result = scrub({ note: `prefix-only=${prefix}` }, token, LABELS) as {
+      note: string;
+    };
+    expect(result.note).not.toContain(prefix);
+    expect(result.note).toContain("[REDACTED_TEST_TOKEN_PREFIX]");
+  });
+
+  it("short-circuits on empty token (no replacements, returns deep-cloned copy)", async () => {
+    const { scrub } = await loadRedaction();
+    const input = { a: "no token here", b: { c: "deep" } };
+    const result = scrub(input, "", LABELS) as typeof input;
+    expect(result).toEqual(input);
+    expect(result).not.toBe(input);
+    expect(result.b).not.toBe(input.b);
+  });
+
+  it("fails closed to a [REDACTED_UNSERIALIZABLE] sentinel when JSON.stringify throws (cycle)", async () => {
+    const { scrub } = await loadRedaction();
+    const token = "supersecret-1234567890ab";
+    const cyclic: Record<string, unknown> = { note: `value=${token}` };
+    cyclic.self = cyclic;
+    const result = scrub(cyclic, token, LABELS);
+    expect(result).toBe("[REDACTED_UNSERIALIZABLE]");
+  });
+
+  it("containsTokenMaterial detects raw token and 12-char prefix", async () => {
+    const { containsTokenMaterial } = await loadRedaction();
+    const token = "supersecret-1234567890ab";
+    expect(containsTokenMaterial(`hello ${token}`, token)).toBe(true);
+    expect(containsTokenMaterial(`hello ${token.slice(0, 12)}`, token)).toBe(true);
+    expect(containsTokenMaterial("nothing here", token)).toBe(false);
+    expect(containsTokenMaterial(`hello ${token}`, "")).toBe(false);
+  });
+});

--- a/test/unit/scripts/ops/phase24d-lark-feishu-trusted-inbound.test.ts
+++ b/test/unit/scripts/ops/phase24d-lark-feishu-trusted-inbound.test.ts
@@ -31,6 +31,12 @@ const REQUIRED_ENV = [
   "FRIDAY_LARK_ALLOWED_USER_ID",
 ];
 
+// Test fixtures only — not real credentials. Pragma needed because the
+// repo-wide detect-secrets baseline runs entropy checks on every file.
+const FAKE_PRIMARY_APP_SECRET = "primary-app-secret-abcdef1234567890"; // pragma: allowlist secret
+const FAKE_VERIFY_TOKEN = "verify-token-XYZ-1234567890"; // pragma: allowlist secret
+const FAKE_ENCRYPT_KEY = "encrypt-key-XYZ-1234567890"; // pragma: allowlist secret
+
 const SAVED_ENV: Record<string, string | undefined> = {};
 
 function snapshotEnv(keys: string[]) {
@@ -90,46 +96,44 @@ describe("phase24d listener exports", () => {
 
   it("scrub redacts FRIDAY_LARK_VERIFICATION_TOKEN and FRIDAY_LARK_ENCRYPT_KEY in addition to the primary appSecret", async () => {
     const listener = await loadListener();
-    process.env.FRIDAY_LARK_VERIFICATION_TOKEN = "verify-token-XYZ-1234567890";
-    process.env.FRIDAY_LARK_ENCRYPT_KEY = "encrypt-key-XYZ-1234567890";
-    const primary = "primary-app-secret-abcdef1234567890";
+    process.env.FRIDAY_LARK_VERIFICATION_TOKEN = FAKE_VERIFY_TOKEN;
+    process.env.FRIDAY_LARK_ENCRYPT_KEY = FAKE_ENCRYPT_KEY;
     const blob = {
-      a: `appSecret=${primary}`,
+      a: `appSecret=${FAKE_PRIMARY_APP_SECRET}`,
       b: `verifyToken=${process.env.FRIDAY_LARK_VERIFICATION_TOKEN}`,
       c: `encryptKey=${process.env.FRIDAY_LARK_ENCRYPT_KEY}`,
     };
-    const scrubbed = listener.scrub(blob, primary) as typeof blob;
-    expect(scrubbed.a).not.toContain(primary);
-    expect(scrubbed.b).not.toContain("verify-token-XYZ-1234567890");
-    expect(scrubbed.c).not.toContain("encrypt-key-XYZ-1234567890");
+    const scrubbed = listener.scrub(blob, FAKE_PRIMARY_APP_SECRET) as typeof blob;
+    expect(scrubbed.a).not.toContain(FAKE_PRIMARY_APP_SECRET);
+    expect(scrubbed.b).not.toContain(FAKE_VERIFY_TOKEN);
+    expect(scrubbed.c).not.toContain(FAKE_ENCRYPT_KEY);
   });
 
   it("scrub still redacts env-derived secrets even when called with an empty primary token (safeError early-failure path)", async () => {
     const listener = await loadListener();
-    process.env.FRIDAY_LARK_APP_SECRET = "primary-app-secret-abcdef1234567890";
-    process.env.FRIDAY_LARK_VERIFICATION_TOKEN = "verify-token-XYZ-1234567890";
+    process.env.FRIDAY_LARK_APP_SECRET = FAKE_PRIMARY_APP_SECRET;
+    process.env.FRIDAY_LARK_VERIFICATION_TOKEN = FAKE_VERIFY_TOKEN;
     const blob = {
       a: `appSecret=${process.env.FRIDAY_LARK_APP_SECRET}`,
       b: `verifyToken=${process.env.FRIDAY_LARK_VERIFICATION_TOKEN}`,
     };
     const scrubbed = listener.scrub(blob, "") as typeof blob;
-    expect(scrubbed.a).not.toContain("primary-app-secret-abcdef1234567890");
-    expect(scrubbed.b).not.toContain("verify-token-XYZ-1234567890");
+    expect(scrubbed.a).not.toContain(FAKE_PRIMARY_APP_SECRET);
+    expect(scrubbed.b).not.toContain(FAKE_VERIFY_TOKEN);
   });
 
   it("containsTokenMaterial detects any secret in the redaction set", async () => {
     const listener = await loadListener();
-    process.env.FRIDAY_LARK_VERIFICATION_TOKEN = "verify-token-XYZ-1234567890";
-    const primary = "primary-app-secret-abcdef1234567890";
-    expect(listener.containsTokenMaterial(`x=${primary}`, primary)).toBe(true);
-    expect(listener.containsTokenMaterial("x=verify-token-XYZ-1234567890", primary)).toBe(true);
-    expect(listener.containsTokenMaterial("nothing leaks here", primary)).toBe(false);
+    process.env.FRIDAY_LARK_VERIFICATION_TOKEN = FAKE_VERIFY_TOKEN;
+    expect(listener.containsTokenMaterial(`x=${FAKE_PRIMARY_APP_SECRET}`, FAKE_PRIMARY_APP_SECRET)).toBe(true);
+    expect(listener.containsTokenMaterial(`x=${FAKE_VERIFY_TOKEN}`, FAKE_PRIMARY_APP_SECRET)).toBe(true);
+    expect(listener.containsTokenMaterial("nothing leaks here", FAKE_PRIMARY_APP_SECRET)).toBe(false);
   });
 
   it("initialReport carries the schemaVersion stable token and seeds artifactHasNoToken as false (required criterion)", async () => {
     const listener = await loadListener();
     process.env.FRIDAY_LARK_APP_ID = "lark-app-id-value";
-    process.env.FRIDAY_LARK_APP_SECRET = "primary-app-secret-abcdef1234567890";
+    process.env.FRIDAY_LARK_APP_SECRET = FAKE_PRIMARY_APP_SECRET;
     process.env.FRIDAY_LARK_CHAT_ID = "lark-chat-id-value";
     process.env.FRIDAY_LARK_ALLOWED_USER_ID = "lark-allowed-user-id-value";
     const config = listener.readEnvConfig();

--- a/test/unit/scripts/ops/phase24d-lark-feishu-trusted-inbound.test.ts
+++ b/test/unit/scripts/ops/phase24d-lark-feishu-trusted-inbound.test.ts
@@ -1,0 +1,141 @@
+/**
+ * R1 — Lark/Feishu trusted-inbound harness. Locks down the exported helpers:
+ *   - missingRequiredEnv flags every empty required env var;
+ *   - buildProbeNonce sanitises run/sha into [A-Za-z0-9._-];
+ *   - scrub redacts the primary appSecret AND any
+ *     FRIDAY_LARK_VERIFICATION_TOKEN / FRIDAY_LARK_ENCRYPT_KEY present in env
+ *     (defense-in-depth so safeError still scrubs in early-failure branches
+ *     where `config` is undefined);
+ *   - containsTokenMaterial detects every secret in the redaction set;
+ *   - initialReport carries the schemaVersion stable token and seeds every
+ *     required criterion as false.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as path from "node:path";
+import { pathToFileURL } from "node:url";
+
+type ListenerModule = typeof import("../../../../scripts/ops/phase24d-lark-feishu-trusted-inbound-listener.mjs");
+
+const scriptUrl = pathToFileURL(
+  path.resolve(__dirname, "../../../../scripts/ops/phase24d-lark-feishu-trusted-inbound-listener.mjs"),
+).href;
+
+async function loadListener(): Promise<ListenerModule> {
+  return (await import(scriptUrl)) as ListenerModule;
+}
+
+const REQUIRED_ENV = [
+  "FRIDAY_LARK_APP_ID",
+  "FRIDAY_LARK_APP_SECRET",
+  "FRIDAY_LARK_CHAT_ID",
+  "FRIDAY_LARK_ALLOWED_USER_ID",
+];
+
+const SAVED_ENV: Record<string, string | undefined> = {};
+
+function snapshotEnv(keys: string[]) {
+  for (const key of keys) SAVED_ENV[key] = process.env[key];
+}
+
+function restoreEnv() {
+  for (const key of Object.keys(SAVED_ENV)) {
+    if (SAVED_ENV[key] === undefined) delete process.env[key];
+    else process.env[key] = SAVED_ENV[key];
+  }
+}
+
+describe("phase24d listener exports", () => {
+  beforeEach(() => {
+    snapshotEnv([
+      ...REQUIRED_ENV,
+      "FRIDAY_LARK_USE_FEISHU",
+      "FRIDAY_LARK_RECEIVE_MODE",
+      "FRIDAY_LARK_VERIFICATION_TOKEN",
+      "FRIDAY_LARK_ENCRYPT_KEY",
+      "FRIDAY_LARK_GROUP_CHAT_ID",
+      "PHASE24D_LARK_FEISHU_PROBE_NONCE",
+      "GITHUB_RUN_ID",
+      "GITHUB_SHA",
+    ]);
+    for (const key of REQUIRED_ENV) delete process.env[key];
+    delete process.env.FRIDAY_LARK_VERIFICATION_TOKEN;
+    delete process.env.FRIDAY_LARK_ENCRYPT_KEY;
+    delete process.env.PHASE24D_LARK_FEISHU_PROBE_NONCE;
+  });
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  it("missingRequiredEnv lists every empty required env var", async () => {
+    const listener = await loadListener();
+    process.env.FRIDAY_LARK_APP_ID = "lark-app-id-value";
+    process.env.FRIDAY_LARK_APP_SECRET = "";
+    process.env.FRIDAY_LARK_CHAT_ID = "lark-chat-id-value";
+    process.env.FRIDAY_LARK_ALLOWED_USER_ID = "";
+    const config = listener.readEnvConfig();
+    const missing = listener.missingRequiredEnv(config);
+    expect(missing).toContain("FRIDAY_LARK_APP_SECRET");
+    expect(missing).toContain("FRIDAY_LARK_ALLOWED_USER_ID");
+    expect(missing).not.toContain("FRIDAY_LARK_APP_ID");
+    expect(missing).not.toContain("FRIDAY_LARK_CHAT_ID");
+  });
+
+  it("buildProbeNonce sanitises run/sha to allowed characters", async () => {
+    const listener = await loadListener();
+    process.env.GITHUB_RUN_ID = "12345!@#$%";
+    process.env.GITHUB_SHA = "abc!@#def!@#";
+    const nonce = listener.buildProbeNonce();
+    expect(nonce).toMatch(/^phase24d-run-12345-[A-Za-z0-9._-]+$/);
+  });
+
+  it("scrub redacts FRIDAY_LARK_VERIFICATION_TOKEN and FRIDAY_LARK_ENCRYPT_KEY in addition to the primary appSecret", async () => {
+    const listener = await loadListener();
+    process.env.FRIDAY_LARK_VERIFICATION_TOKEN = "verify-token-XYZ-1234567890";
+    process.env.FRIDAY_LARK_ENCRYPT_KEY = "encrypt-key-XYZ-1234567890";
+    const primary = "primary-app-secret-abcdef1234567890";
+    const blob = {
+      a: `appSecret=${primary}`,
+      b: `verifyToken=${process.env.FRIDAY_LARK_VERIFICATION_TOKEN}`,
+      c: `encryptKey=${process.env.FRIDAY_LARK_ENCRYPT_KEY}`,
+    };
+    const scrubbed = listener.scrub(blob, primary) as typeof blob;
+    expect(scrubbed.a).not.toContain(primary);
+    expect(scrubbed.b).not.toContain("verify-token-XYZ-1234567890");
+    expect(scrubbed.c).not.toContain("encrypt-key-XYZ-1234567890");
+  });
+
+  it("scrub still redacts env-derived secrets even when called with an empty primary token (safeError early-failure path)", async () => {
+    const listener = await loadListener();
+    process.env.FRIDAY_LARK_APP_SECRET = "primary-app-secret-abcdef1234567890";
+    process.env.FRIDAY_LARK_VERIFICATION_TOKEN = "verify-token-XYZ-1234567890";
+    const blob = {
+      a: `appSecret=${process.env.FRIDAY_LARK_APP_SECRET}`,
+      b: `verifyToken=${process.env.FRIDAY_LARK_VERIFICATION_TOKEN}`,
+    };
+    const scrubbed = listener.scrub(blob, "") as typeof blob;
+    expect(scrubbed.a).not.toContain("primary-app-secret-abcdef1234567890");
+    expect(scrubbed.b).not.toContain("verify-token-XYZ-1234567890");
+  });
+
+  it("containsTokenMaterial detects any secret in the redaction set", async () => {
+    const listener = await loadListener();
+    process.env.FRIDAY_LARK_VERIFICATION_TOKEN = "verify-token-XYZ-1234567890";
+    const primary = "primary-app-secret-abcdef1234567890";
+    expect(listener.containsTokenMaterial(`x=${primary}`, primary)).toBe(true);
+    expect(listener.containsTokenMaterial("x=verify-token-XYZ-1234567890", primary)).toBe(true);
+    expect(listener.containsTokenMaterial("nothing leaks here", primary)).toBe(false);
+  });
+
+  it("initialReport carries the schemaVersion stable token and seeds artifactHasNoToken as false (required criterion)", async () => {
+    const listener = await loadListener();
+    process.env.FRIDAY_LARK_APP_ID = "lark-app-id-value";
+    process.env.FRIDAY_LARK_APP_SECRET = "primary-app-secret-abcdef1234567890";
+    process.env.FRIDAY_LARK_CHAT_ID = "lark-chat-id-value";
+    process.env.FRIDAY_LARK_ALLOWED_USER_ID = "lark-allowed-user-id-value";
+    const config = listener.readEnvConfig();
+    const report = listener.initialReport(config, "/tmp/x.json");
+    expect(report.schemaVersion).toBe("friday.phase24d.lark_feishu_trusted_inbound_proof.v1");
+    expect((report.criteria as { artifactHasNoToken: boolean }).artifactHasNoToken).toBe(false);
+    expect(report.status).toBe("running");
+  });
+});

--- a/test/unit/scripts/ops/run-friday-release-preflight-source-only.test.ts
+++ b/test/unit/scripts/ops/run-friday-release-preflight-source-only.test.ts
@@ -1,0 +1,61 @@
+/**
+ * R1 — run-friday-release-preflight source-only mode. Locks down:
+ *   - FRIDAY_RELEASE_MODE=source-only is recorded in the report;
+ *   - cross-platform release-inputs check is skipped (status=skipped_source_only)
+ *     because the npm/source release does not promise iOS/Android/Windows/macOS;
+ *   - the duplicate `checks.cross_platform_check` field is NOT emitted (drift
+ *     prevention — the canonical location is `crossPlatformReleaseInputs.status`).
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const REPO_ROOT = path.resolve(__dirname, "../../../..");
+const SCRIPT_PATH = path.join(REPO_ROOT, "scripts", "ops", "run-friday-release-preflight.mjs");
+
+let tmpDir: string;
+
+beforeAll(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "preflight-source-only-"));
+});
+
+afterAll(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+async function readReport(): Promise<Record<string, unknown>> {
+  const reportPath = path.join(tmpDir, "report.json");
+  const raw = await fs.readFile(reportPath, "utf8");
+  return JSON.parse(raw) as Record<string, unknown>;
+}
+
+describe("run-friday-release-preflight source-only mode", () => {
+  it("FRIDAY_RELEASE_MODE=source-only: report.releaseMode === 'source-only' and cross-platform check is skipped", async () => {
+    const tag = await getTagMatchingPackageVersion();
+    const result = spawnSync("node", [SCRIPT_PATH], {
+      env: {
+        ...process.env,
+        FRIDAY_RELEASE_MODE: "source-only",
+        FRIDAY_RELEASE_TAG: tag,
+        FRIDAY_RELEASE_PREFLIGHT_REPO_ROOT: REPO_ROOT,
+        FRIDAY_RELEASE_PREFLIGHT_ARTIFACT_DIR: tmpDir,
+      },
+      encoding: "utf8",
+    });
+    expect(result.status, `preflight stderr: ${result.stderr}`).toBe(0);
+    const report = await readReport();
+    expect(report.releaseMode).toBe("source-only");
+    const checks = report.checks as Record<string, unknown>;
+    expect(checks.cross_platform_check).toBeUndefined();
+    const cross = checks.crossPlatformReleaseInputs as { status: string; exitCode: unknown };
+    expect(cross.status).toBe("skipped_source_only");
+    expect(cross.exitCode).toBeNull();
+  });
+});
+
+async function getTagMatchingPackageVersion(): Promise<string> {
+  const pkg = JSON.parse(await fs.readFile(path.join(REPO_ROOT, "package.json"), "utf8"));
+  return `v${pkg.version}`;
+}

--- a/test/unit/scripts/ops/validate-channel-proof-artifacts.test.ts
+++ b/test/unit/scripts/ops/validate-channel-proof-artifacts.test.ts
@@ -1,0 +1,241 @@
+/**
+ * R1 — same-SHA channel-proof artifact validator. Locks down:
+ *   - pass on a clean fixture;
+ *   - reject status != passed;
+ *   - reject any criterion === false (generic loop);
+ *   - reject missing named criterion `artifactHasNoToken` even if loop passes;
+ *   - reject token-material residue (`xoxb-`, `Bot <opaque>`, `Bearer <opaque>`);
+ *   - tolerate free-text "the bot said" / "boto3" without false-positive;
+ *   - require expected-sha match (commit_sha primary, head_sha fallback);
+ *   - skip sentinel passes without inspecting;
+ *   - missing artifact file produces artifact_missing_or_unreadable blocker;
+ *   - invalid JSON produces artifact_missing_or_unreadable blocker;
+ *   - missing required top-level key produces artifact_missing_or_unreadable blocker.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { pathToFileURL } from "node:url";
+
+type ValidatorModule = typeof import("../../../../scripts/ops/validate-channel-proof-artifacts.mjs");
+
+const scriptUrl = pathToFileURL(
+  path.resolve(__dirname, "../../../../scripts/ops/validate-channel-proof-artifacts.mjs"),
+).href;
+
+async function loadValidator(): Promise<ValidatorModule> {
+  return (await import(scriptUrl)) as ValidatorModule;
+}
+
+const SCHEMA_DISCORD = "friday.phase24b.discord_trusted_inbound_proof.v1";
+
+function passingDiscordArtifact(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+  return {
+    schemaVersion: SCHEMA_DISCORD,
+    phase: "phase24b",
+    scope: "discord_trusted_inbound",
+    status: "passed",
+    startedAt: "2026-05-25T00:00:00Z",
+    completedAt: "2026-05-25T00:00:10Z",
+    reportPath: "/tmp/phase24b/discord.json",
+    environment: { commit_sha: "deadbeef00112233445566778899aabbccddeeff", head_sha: null },
+    criteria: {
+      wsClientConnected: true,
+      listenerReceivedMessageReceive: true,
+      authorBotFalse: true,
+      artifactHasNoToken: true,
+    },
+    diagnostics: {},
+    observedDiscordEvent: { type: "DISCORD_MESSAGE_CREATE_V1" },
+    failures: [],
+    ...overrides,
+  };
+}
+
+let tmpDir: string;
+
+beforeAll(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "validate-channel-proof-"));
+});
+
+afterAll(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+async function writeFixture(name: string, body: unknown): Promise<string> {
+  const filePath = path.join(tmpDir, name);
+  await fs.writeFile(filePath, JSON.stringify(body), "utf8");
+  return filePath;
+}
+
+describe("validateChannelProofArtifacts", () => {
+  it("passes on a clean discord fixture; matching commit_sha", async () => {
+    const { validateChannelProofArtifacts } = await loadValidator();
+    const fixturePath = await writeFixture("pass.json", passingDiscordArtifact());
+    const decision = validateChannelProofArtifacts({
+      channels: { discord: fixturePath, telegram: "skip", "lark-feishu": "skip" },
+      expectedSha: "deadbeef00112233445566778899aabbccddeeff",
+    });
+    expect(decision.valid).toBe(true);
+    const discord = decision.results.find((r) => r.channel === "discord");
+    expect(discord?.valid).toBe(true);
+    expect(discord?.blockerClass).toBe("none");
+  });
+
+  it("rejects status != passed", async () => {
+    const { validateChannelProofArtifacts } = await loadValidator();
+    const fixturePath = await writeFixture("status-not-passed.json", passingDiscordArtifact({ status: "blocked" }));
+    const decision = validateChannelProofArtifacts({
+      channels: { discord: fixturePath, telegram: "skip", "lark-feishu": "skip" },
+      expectedSha: null,
+    });
+    expect(decision.valid).toBe(false);
+    expect(decision.results[0].reasons.some((r: string) => r === "status_not_passed:blocked")).toBe(true);
+  });
+
+  it("rejects criterion === false via generic loop", async () => {
+    const { validateChannelProofArtifacts } = await loadValidator();
+    const fixturePath = await writeFixture(
+      "criterion-false.json",
+      passingDiscordArtifact({ criteria: { artifactHasNoToken: false } }),
+    );
+    const decision = validateChannelProofArtifacts({
+      channels: { discord: fixturePath, telegram: "skip", "lark-feishu": "skip" },
+      expectedSha: null,
+    });
+    expect(decision.valid).toBe(false);
+    expect(decision.results[0].reasons).toContain("criterion_not_true:artifactHasNoToken");
+  });
+
+  it("rejects missing named criterion artifactHasNoToken even if other criteria are all true", async () => {
+    const { validateChannelProofArtifacts } = await loadValidator();
+    const fixturePath = await writeFixture(
+      "criterion-missing.json",
+      passingDiscordArtifact({ criteria: { wsClientConnected: true } }),
+    );
+    const decision = validateChannelProofArtifacts({
+      channels: { discord: fixturePath, telegram: "skip", "lark-feishu": "skip" },
+      expectedSha: null,
+    });
+    expect(decision.valid).toBe(false);
+    expect(decision.results[0].reasons).toContain("criterion_missing:artifactHasNoToken");
+  });
+
+  it("rejects token residue: xoxb- prefix", async () => {
+    const { validateChannelProofArtifacts } = await loadValidator();
+    const leaked = passingDiscordArtifact({
+      diagnostics: { rawSnippet: "configured token: xoxb-FAKEEXAMPLEEXAMPLE" },
+    });
+    const fixturePath = await writeFixture("residue-xoxb.json", leaked);
+    const decision = validateChannelProofArtifacts({
+      channels: { discord: fixturePath, telegram: "skip", "lark-feishu": "skip" },
+      expectedSha: null,
+    });
+    expect(decision.valid).toBe(false);
+    expect(decision.results[0].blockerClass).toBe("artifact_upload_broken");
+  });
+
+  it("rejects token residue: Bot <opaque>", async () => {
+    const { validateChannelProofArtifacts } = await loadValidator();
+    const leaked = passingDiscordArtifact({
+      diagnostics: { authHeader: "Bot OTIxNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3.opaque.value" },
+    });
+    const fixturePath = await writeFixture("residue-bot.json", leaked);
+    const decision = validateChannelProofArtifacts({
+      channels: { discord: fixturePath, telegram: "skip", "lark-feishu": "skip" },
+      expectedSha: null,
+    });
+    expect(decision.valid).toBe(false);
+    expect(decision.results[0].blockerClass).toBe("artifact_upload_broken");
+  });
+
+  it("does NOT false-positive on the natural-language word 'bot' (no opaque token after it)", async () => {
+    const { validateChannelProofArtifacts } = await loadValidator();
+    const safe = passingDiscordArtifact({
+      diagnostics: { humanText: "the bot said hi", anotherWord: "boto3 is a lib" },
+    });
+    const fixturePath = await writeFixture("safe-text.json", safe);
+    const decision = validateChannelProofArtifacts({
+      channels: { discord: fixturePath, telegram: "skip", "lark-feishu": "skip" },
+      expectedSha: null,
+    });
+    expect(decision.valid).toBe(true);
+  });
+
+  it("falls back to head_sha when commit_sha is absent", async () => {
+    const { validateChannelProofArtifacts } = await loadValidator();
+    const fixturePath = await writeFixture(
+      "head-sha-fallback.json",
+      passingDiscordArtifact({
+        environment: { head_sha: "deadbeef00112233445566778899aabbccddeeff" },
+      }),
+    );
+    const decision = validateChannelProofArtifacts({
+      channels: { discord: fixturePath, telegram: "skip", "lark-feishu": "skip" },
+      expectedSha: "deadbeef00112233445566778899aabbccddeeff",
+    });
+    expect(decision.valid).toBe(true);
+  });
+
+  it("rejects commit_sha mismatch", async () => {
+    const { validateChannelProofArtifacts } = await loadValidator();
+    const fixturePath = await writeFixture(
+      "sha-mismatch.json",
+      passingDiscordArtifact({ environment: { commit_sha: "00000000" } }),
+    );
+    const decision = validateChannelProofArtifacts({
+      channels: { discord: fixturePath, telegram: "skip", "lark-feishu": "skip" },
+      expectedSha: "deadbeef00112233445566778899aabbccddeeff",
+    });
+    expect(decision.valid).toBe(false);
+    expect(decision.results[0].reasons).toContain("commit_sha_mismatch");
+  });
+
+  it("skip sentinel passes without inspecting any artifact", async () => {
+    const { validateChannelProofArtifacts } = await loadValidator();
+    const decision = validateChannelProofArtifacts({
+      channels: { discord: "skip", telegram: "skip", "lark-feishu": "skip" },
+      expectedSha: null,
+    });
+    expect(decision.valid).toBe(true);
+    for (const result of decision.results) {
+      expect((result as { skipped?: boolean }).skipped).toBe(true);
+    }
+  });
+
+  it("missing file produces artifact_missing_or_unreadable", async () => {
+    const { validateChannelProofArtifacts } = await loadValidator();
+    const decision = validateChannelProofArtifacts({
+      channels: { discord: path.join(tmpDir, "does-not-exist.json"), telegram: "skip", "lark-feishu": "skip" },
+      expectedSha: null,
+    });
+    expect(decision.valid).toBe(false);
+    expect(decision.results[0].blockerClass).toBe("artifact_missing_or_unreadable");
+  });
+
+  it("missing required top-level key produces artifact_missing_or_unreadable", async () => {
+    const { validateChannelProofArtifacts } = await loadValidator();
+    const fixturePath = await writeFixture("missing-key.json", { schemaVersion: SCHEMA_DISCORD });
+    const decision = validateChannelProofArtifacts({
+      channels: { discord: fixturePath, telegram: "skip", "lark-feishu": "skip" },
+      expectedSha: null,
+    });
+    expect(decision.valid).toBe(false);
+    expect(decision.results[0].blockerClass).toBe("artifact_missing_or_unreadable");
+  });
+
+  it("rejects failures array with entries even if status === passed", async () => {
+    const { validateChannelProofArtifacts } = await loadValidator();
+    const fixturePath = await writeFixture(
+      "failures-nonempty.json",
+      passingDiscordArtifact({ failures: ["unexpected"] }),
+    );
+    const decision = validateChannelProofArtifacts({
+      channels: { discord: fixturePath, telegram: "skip", "lark-feishu": "skip" },
+      expectedSha: null,
+    });
+    expect(decision.valid).toBe(false);
+    expect(decision.results[0].reasons.some((r: string) => r.startsWith("failures_present"))).toBe(true);
+  });
+});

--- a/test/unit/scripts/ops/validate-channel-proof-artifacts.test.ts
+++ b/test/unit/scripts/ops/validate-channel-proof-artifacts.test.ts
@@ -30,6 +30,11 @@ async function loadValidator(): Promise<ValidatorModule> {
 
 const SCHEMA_DISCORD = "friday.phase24b.discord_trusted_inbound_proof.v1";
 
+// Test fixture SHA only — not a real commit. Pragma needed because the
+// repo-wide detect-secrets baseline flags 40-char hex strings as
+// "Hex High Entropy String".
+const FAKE_SHA = "deadbeef00112233445566778899aabbccddeeff"; // pragma: allowlist secret
+
 function passingDiscordArtifact(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
   return {
     schemaVersion: SCHEMA_DISCORD,
@@ -39,7 +44,7 @@ function passingDiscordArtifact(overrides: Partial<Record<string, unknown>> = {}
     startedAt: "2026-05-25T00:00:00Z",
     completedAt: "2026-05-25T00:00:10Z",
     reportPath: "/tmp/phase24b/discord.json",
-    environment: { commit_sha: "deadbeef00112233445566778899aabbccddeeff", head_sha: null },
+    environment: { commit_sha: FAKE_SHA, head_sha: null },
     criteria: {
       wsClientConnected: true,
       listenerReceivedMessageReceive: true,
@@ -75,7 +80,7 @@ describe("validateChannelProofArtifacts", () => {
     const fixturePath = await writeFixture("pass.json", passingDiscordArtifact());
     const decision = validateChannelProofArtifacts({
       channels: { discord: fixturePath, telegram: "skip", "lark-feishu": "skip" },
-      expectedSha: "deadbeef00112233445566778899aabbccddeeff",
+      expectedSha: FAKE_SHA,
     });
     expect(decision.valid).toBe(true);
     const discord = decision.results.find((r) => r.channel === "discord");
@@ -168,12 +173,12 @@ describe("validateChannelProofArtifacts", () => {
     const fixturePath = await writeFixture(
       "head-sha-fallback.json",
       passingDiscordArtifact({
-        environment: { head_sha: "deadbeef00112233445566778899aabbccddeeff" },
+        environment: { head_sha: FAKE_SHA },
       }),
     );
     const decision = validateChannelProofArtifacts({
       channels: { discord: fixturePath, telegram: "skip", "lark-feishu": "skip" },
-      expectedSha: "deadbeef00112233445566778899aabbccddeeff",
+      expectedSha: FAKE_SHA,
     });
     expect(decision.valid).toBe(true);
   });
@@ -186,7 +191,7 @@ describe("validateChannelProofArtifacts", () => {
     );
     const decision = validateChannelProofArtifacts({
       channels: { discord: fixturePath, telegram: "skip", "lark-feishu": "skip" },
-      expectedSha: "deadbeef00112233445566778899aabbccddeeff",
+      expectedSha: FAKE_SHA,
     });
     expect(decision.valid).toBe(false);
     expect(decision.results[0].reasons).toContain("commit_sha_mismatch");

--- a/test/unit/scripts/ops/write-friday-release-manifest-source-only.test.ts
+++ b/test/unit/scripts/ops/write-friday-release-manifest-source-only.test.ts
@@ -1,0 +1,85 @@
+/**
+ * R1 — write-friday-release-manifest source-only mode. Locks down:
+ *   - releaseMode field is "source-only";
+ *   - currentMilestone reflects the npm/source-only public v1 local candidate;
+ *   - releaseClaim.boundary contains the RELEASE_CLAIM-mandated paragraph;
+ *   - macOS/iOS/Android/Windows platforms all show availability:
+ *     "not_in_this_release" (no inferred shipping_beta_baseline status);
+ *   - Sparkle / Homebrew / TestFlight / Play channels all show availability:
+ *     "not_in_this_release";
+ *   - Homebrew cask file is NOT emitted into dist/releases/homebrew/Casks/.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const REPO_ROOT = path.resolve(__dirname, "../../../..");
+const SCRIPT_PATH = path.join(REPO_ROOT, "scripts", "ops", "write-friday-release-manifest.mjs");
+
+let tmpRoot: string;
+
+beforeAll(async () => {
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "manifest-source-only-"));
+  // Minimal fixture mirroring the layout the manifest writer needs.
+  const packageJson = JSON.parse(await fs.readFile(path.join(REPO_ROOT, "package.json"), "utf8"));
+  await fs.mkdir(path.join(tmpRoot, "packaging", "homebrew", "Casks"), { recursive: true });
+  await fs.writeFile(path.join(tmpRoot, "package.json"), JSON.stringify({ version: packageJson.version }), "utf8");
+  await fs.writeFile(
+    path.join(tmpRoot, "packaging", "homebrew", "Casks", "friday.rb.template"),
+    "cask 'friday' do\n  version '{{VERSION}}'\n  sha256 '{{SHA256}}'\n  url '{{URL}}'\nend\n",
+    "utf8",
+  );
+});
+
+afterAll(async () => {
+  await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+describe("write-friday-release-manifest source-only mode", () => {
+  it("emits releaseMode=source-only, releaseClaim boundary, and marks all platforms/channels as not_in_this_release; no homebrew cask", async () => {
+    const result = spawnSync("node", [SCRIPT_PATH], {
+      env: {
+        ...process.env,
+        FRIDAY_RELEASE_REPO_ROOT: tmpRoot,
+        FRIDAY_RELEASE_TAG: "v1.0.1",
+        FRIDAY_RELEASE_DOWNLOAD_BASE_URL: "https://example.invalid/releases/v1.0.1",
+        FRIDAY_RELEASE_MODE: "source-only",
+      },
+      encoding: "utf8",
+    });
+    expect(result.status, `manifest stderr: ${result.stderr}`).toBe(0);
+
+    const jsonPath = path.join(tmpRoot, "dist", "releases", "Friday.release-manifest.json");
+    const mdPath = path.join(tmpRoot, "dist", "releases", "Friday.release-manifest.md");
+    const manifest = JSON.parse(await fs.readFile(jsonPath, "utf8"));
+
+    expect(manifest.releaseMode).toBe("source-only");
+    expect(manifest.currentMilestone).toBe("npm_source_only_public_v1_local_candidate");
+
+    expect(manifest.releaseClaim).toBeTruthy();
+    expect(String(manifest.releaseClaim.boundary)).toContain("This release is npm/source-only");
+    expect(String(manifest.releaseClaim.boundary)).toContain("Desktop, Homebrew, notarized macOS");
+
+    for (const platform of ["macos", "ios", "android", "windows"]) {
+      const entry = (manifest.platforms as Array<Record<string, unknown>>).find(
+        (p) => p.platform === platform,
+      );
+      expect(entry, `platform ${platform} missing from manifest`).toBeTruthy();
+      expect(entry?.availability).toBe("not_in_this_release");
+    }
+
+    for (const channel of ["sparkle", "homebrew", "testflight", "playInternal"]) {
+      const ch = (manifest.channels as Record<string, { availability: string }>)[channel];
+      expect(ch?.availability, `channel ${channel} availability`).toBe("not_in_this_release");
+    }
+
+    const homebrewCask = path.join(tmpRoot, "dist", "releases", "homebrew", "Casks", "friday.rb");
+    await expect(fs.access(homebrewCask)).rejects.toBeTruthy();
+
+    const md = await fs.readFile(mdPath, "utf8");
+    expect(md).toContain("Release Mode: `source-only`");
+    expect(md).toContain("Release Claim Boundary");
+  });
+});


### PR DESCRIPTION
## R1 — Release Closure Plan

Batch ID: `R1_release_proof_infrastructure`
Plan: `/Users/jarvis/Desktop/Friday-release-closure-plan-20260525`
Closes IDs: `R1_release_proof_infrastructure`

## Summary

Adds the release machinery required for a `1.0.1` npm/source-only public v1 local candidate, plus channel-proof gating for Discord, Telegram, and Lark/Feishu. Publish stays blocked until R5 completes same-SHA live channel proof.

## R1 Spec Coverage

| # | Requirement | Implementation |
|---|---|---|
| 1 | Source/npm-only release mode in `release.yml` | `release_mode` `workflow_dispatch` input + push-tag default; threaded through `public-preflight` → `verify` → consumers. |
| 2 | Source-only does NOT require macOS or claim desktop/Homebrew/notarized | `macos-distribution` skips; `write-friday-release-manifest` marks every platform/channel as `not_in_this_release`, emits `releaseClaim.boundary` text mandated by `RELEASE_CLAIM.md`, skips Homebrew cask. |
| 3 | Same-SHA channel proof validator (Discord + Telegram + Lark/Feishu) | `scripts/ops/validate-channel-proof-artifacts.mjs` enforces schemaVersion, `status="passed"`, every criterion true, no token residue, explicit `artifactHasNoToken` named criterion, `commit_sha`/`head_sha` match against `TAG_SHA`. |
| 4 | `phase24d_lark_feishu_trusted_inbound` job in RGG | Added to `real-green-gate.yml`; mirrors phase24c shape; only env vars the listener actually reads are exported. |
| 5 | Lark/Feishu trusted-inbound harness | `scripts/ops/phase24d-lark-feishu-trusted-inbound-listener.mjs` (941 LOC) mirrors phase24c semantics — strict `freshForRun`, fail-closed `serializeScrubbedJson` before any write. |
| 6 | Token redaction; fail if token material appears | Shared `scripts/ops/lib/token-redaction.mjs` with cyclic-throw `[REDACTED_UNSERIALIZABLE]` sentinel; phase24d `scrub`/`safeError` fold in `FRIDAY_LARK_APP_SECRET`/`VERIFICATION_TOKEN`/`ENCRYPT_KEY` from `process.env` (defense-in-depth for early-failure branches where `config` is undefined). |
| 7 | Publish blocked until R5 | `RELEASE_PUBLISH_NPM` repo var stays `false`; npm-publish step gated by it. |

## Verification

- ✅ 26 focused R1 tests pass (token-redaction, validator, phase24d harness, preflight source-only, manifest source-only); zero type errors.
- ✅ 3 existing integration tests pass (`friday-release-preflight.integration`, `friday-release-manifest.integration`).
- ✅ `npm run typecheck:src` clean.
- ✅ `npm run check:proof:no-mock-leaks` clean (46 input files, includes new phase24b/c/d listeners + validator + token-redaction lib).
- ✅ `git diff --check` clean.
- ✅ Two isolated read-only reviewers PASS after blocker fix (dangling `dist/macos/FridayCompanion.release.md` line in `release.yml` `files:` value).

## No-Fallback Compliance

Per `NO_FALLBACK_POLICY.md`:
- The source-only branches in `release.yml`, `run-friday-release-preflight.mjs`, and `write-friday-release-manifest.mjs` are spec-mandated mode toggles, NOT fallbacks: they fail closed when conditions are not satisfied, never silently degrade. `create-release.if:` requires `release_mode == 'source-only'` to tolerate a skipped `macos-distribution`.
- Token redaction fails loud (`serializeScrubbedJson` throws before any disk write if leak detected; validator residue scan + explicit `artifactHasNoToken` named-criterion fail the gate).
- No compatibility shim or alternate route around any approval/proof/lifecycle/identity gate.

## Release Claim Boundary

Per `RELEASE_CLAIM.md`, the manifest writer emits the required paragraph in source-only mode:

> This release is npm/source-only. Desktop, Homebrew, notarized macOS, mobile, and unproven external integrations remain outside this release claim. Capabilities without same-SHA live proof are labeled setup_needed, proof_pending, blocked_by_env, unsupported, or not_configured.

## Residual Risk

- R5 must still flip `RELEASE_PUBLISH_NPM=true` after same-SHA Discord/Telegram/Lark+Feishu live proof passes; not changed here.
- `FRIDAY_LARK_*` secret availability in the `phase-24-live-channels` GitHub environment is required for the phase24d job to produce live proof — `blocked_by_env` if missing, per `PROOF_STANDARD.md`. Will be classified at R5.
- `phase24b`/`phase24c` listeners gained a `commit_sha` field alongside the existing `githubSha` (both present; downstream consumers reading either name remain working). Single canonical field is a candidate cleanup for a follow-up.

## Surgical Change Notes

Per `Generic Phase/Batch` HR8/HR10: phase24b and phase24c receive a minimal edit (swap inline `scrub`/`containsTokenMaterial` for the shared `lib/token-redaction.mjs` helpers + add `commit_sha`). Both changes are direct R1 requirements (shared redaction surface for phase24d; same-SHA validator needs the commit field). No unrelated refactor or reformat.

## Test Plan

- [x] `npm run typecheck:src`
- [x] `npm run check:proof:no-mock-leaks`
- [x] Focused R1 vitest suites (26 tests)
- [x] Existing release-script integration tests (3 tests)
- [ ] PR CI (build/test/migrations/security/contracts/ssd-lint/alignment-guard/agent-parity/secrets/quality-gate)
- [ ] PR Real Green Gate on PR head SHA (workflow_dispatch with all three `phase24X_*_trusted_inbound` inputs deferred to R5 same-SHA proof)