### PR TITLE
chore(release): add public source hygiene gate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,7 +48,7 @@
 # FRIDAY_DESKTOP_PRINCIPAL_ID=friday-desktop
 # Comma-separated absolute roots for desktop file operations.
 # Default when unset: workspace root.
-# FRIDAY_DESKTOP_SANDBOX_ALLOWED_ROOTS=/Users/you/Projects/Friday
+# FRIDAY_DESKTOP_SANDBOX_ALLOWED_ROOTS=/Users/example/Projects/Friday
 
 # Channel bridge config as JSON.
 # Use env refs (`$VAR_NAME`) or `secret://channel/...` for secret fields.
@@ -73,7 +73,7 @@
 FRIDAY_ENABLE_HSTS=true
 
 # Optional MCP server bridge.
-# FRIDAY_MCP_SERVERS=[{"id":"filesystem","command":"npx","args":["-y","@modelcontextprotocol/server-filesystem","/Users/you/Projects/Friday"],"cwd":"/Users/you/Projects/Friday","timeoutMs":20000}]
+# FRIDAY_MCP_SERVERS=[{"id":"filesystem","command":"npx","args":["-y","@modelcontextprotocol/server-filesystem","/Users/example/Projects/Friday"],"cwd":"/Users/example/Projects/Friday","timeoutMs":20000}]
 
 # Node environment. Set to "production" for production deployments.
 # NODE_ENV=development

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,36 @@ friday-static*.html linguist-generated=true
 qa-report.html linguist-generated=true
 polish-report.html linguist-generated=true
 screenshots/qa/*.html linguist-generated=true
+
+# Public source archive hygiene. These files remain available in the
+# development repository, but should not ship in GitHub source downloads.
+AGENTS.md export-ignore
+context/AGENTS.md export-ignore
+.secrets.baseline export-ignore
+AUDIT-REPORT.md export-ignore
+OVERNIGHT-TASK-SUMMARY.csv export-ignore
+qa-report.html export-ignore
+docs/archive export-ignore
+docs/archive/** export-ignore
+docs/audit export-ignore
+docs/audit/** export-ignore
+docs/task export-ignore
+docs/task/** export-ignore
+docs/reports/benchmark export-ignore
+docs/reports/benchmark/** export-ignore
+reports export-ignore
+reports/** export-ignore
+test export-ignore
+test/** export-ignore
+tests export-ignore
+tests/** export-ignore
+tests-overnight export-ignore
+tests-overnight/** export-ignore
+
+# Guard against accidentally exporting local control packages or audit inputs.
+*Friday-real-user-dogfood* export-ignore
+*Friday-release-closure* export-ignore
+*Friday-global-execution* export-ignore
+"*Friday Map*" export-ignore
+*Finding* export-ignore
+*finding/_master* export-ignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,11 +9,11 @@ resume. Do not rely on session memory, handoff summaries, screenshots, or anothe
 agent's report as a substitute for fresh reads.
 
 The repo-external master prompt pointer at
-`/Users/jarvis/Desktop/READ/friday_master_workflow_prompt.md` is non-canonical
+`/Users/example/Desktop/READ/friday_master_workflow_prompt.md` is non-canonical
 operator context. Desktop-root governance files such as
-`/Users/jarvis/Desktop/friday_master_workflow_prompt.md`,
-`/Users/jarvis/Desktop/AGENTS.md`, and
-`/Users/jarvis/Desktop/friday_AGENTS.md` are retired routes. If any
+`/Users/example/Desktop/friday_master_workflow_prompt.md`,
+`/Users/example/Desktop/AGENTS.md`, and
+`/Users/example/Desktop/friday_AGENTS.md` are retired routes. If any
 repo-external prompt, snapshot, screenshot, or handoff conflicts with this file,
 follow this file and stop before changing governance behavior.
 
@@ -39,7 +39,7 @@ Never claim a fresh full-repo line-by-line reread unless it actually happened in
 These rules merge:
 
 - Friday workspace rules formerly carried in `context/AGENTS.md`, now incorporated here.
-- Repo-external operator pointers under `/Users/jarvis/Desktop/READ/`, read only when a route-map or governance task calls for them.
+- Repo-external operator pointers under `/Users/example/Desktop/READ/`, read only when a route-map or governance task calls for them.
 - The user's hard rules in this thread.
 - The Karpathy-inspired guideline repo `https://github.com/forrestchang/andrej-karpathy-skills`, read at commit `2c606141936f1eeef17fa3043a72095b4765b9c2`.
 - The Matt Pocock skills repo `https://github.com/mattpocock/skills`, read at commit `9fecab929abb904c68ce3366a1781df31ab22832`, absorbed as workflow principles only.
@@ -346,7 +346,7 @@ current `context/AGENTS.md` file is a non-canonical pointer only.
 - Prefer existing Friday skills/workflows before creating new ones.
 - Keep destructive or high-risk actions approval-gated and summarize evidence before execution.
 - When docs conflict, prefer `docs/current-source-of-truth.md` and current runtime behavior.
-- The master prompt pointer at `/Users/jarvis/Desktop/READ/friday_master_workflow_prompt.md` is repo-external local operator context; it is not release proof and is not visible to GitHub reviewers from the repo alone. Governance / hard-rule changes must land in repo-tracked docs for durable audit visibility. `context/AGENTS.md` is non-canonical and should remain a pointer to this file, not a duplicate rule source.
+- The master prompt pointer at `/Users/example/Desktop/READ/friday_master_workflow_prompt.md` is repo-external local operator context; it is not release proof and is not visible to GitHub reviewers from the repo alone. Governance / hard-rule changes must land in repo-tracked docs for durable audit visibility. `context/AGENTS.md` is non-canonical and should remain a pointer to this file, not a duplicate rule source.
 
 ## Karpathy Guideline Mapping For Friday
 

--- a/context/AGENTS.md
+++ b/context/AGENTS.md
@@ -5,7 +5,7 @@ in the repo-root `AGENTS.md` file of the current checkout.
 
 Before acting from this nested context, read the repo-root `AGENTS.md`, the
 current route map under
-`/Users/jarvis/Desktop/friday_vertical_closure_phases_2026-05-12/phase_folders/CURRENT_ROUTE_MAP.md`,
+`/Users/example/Desktop/friday_vertical_closure_phases_2026-05-12/phase_folders/CURRENT_ROUTE_MAP.md`,
 and the fresh git state. If this pointer or any copied context conflicts with the
 repo-root `AGENTS.md`, follow the repo-root file and stop before changing
 governance behavior.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -188,7 +188,7 @@ Fix from source:
 
 ```bash
 npm run build
-FRIDAY_UI_DIST_DIR=/Users/you/Projects/Friday/dist/ui NODE_ENV=development friday start --host 127.0.0.1 --port 3141
+FRIDAY_UI_DIST_DIR=/Users/example/Projects/Friday/dist/ui NODE_ENV=development friday start --host 127.0.0.1 --port 3141
 ```
 
 Open:

--- a/docs/architecture/friday-memory-and-state-protection.md
+++ b/docs/architecture/friday-memory-and-state-protection.md
@@ -14,23 +14,23 @@
 
 仓库内：
 
-- `/Users/wenxindou/Desktop/Friday/.friday`
-- `/Users/wenxindou/Desktop/Friday/memory`
-- `/Users/wenxindou/Desktop/Friday/context`
-- `/Users/wenxindou/Desktop/Friday/artifacts`
+- `/Users/example/Desktop/Friday/.friday`
+- `/Users/example/Desktop/Friday/memory`
+- `/Users/example/Desktop/Friday/context`
+- `/Users/example/Desktop/Friday/artifacts`
 
 用户级 runtime：
 
-- `/Users/wenxindou/.friday`
+- `/Users/example/.friday`
 
 平台 state：
 
-- `/Users/wenxindou/Library/Application Support/Friday/state`
-- SQLite DB：`/Users/wenxindou/Library/Application Support/Friday/state/friday.db`
+- `/Users/example/Library/Application Support/Friday/state`
+- SQLite DB：`/Users/example/Library/Application Support/Friday/state/friday.db`
 
 State resolver 规则来自：
 
-- `/Users/wenxindou/Desktop/Friday/src/state/paths/friday-state-dir-resolver.ts`
+- `/Users/example/Desktop/Friday/src/state/paths/friday-state-dir-resolver.ts`
 
 优先级：
 
@@ -43,15 +43,15 @@ State resolver 规则来自：
 
 备份目录：
 
-- `/Users/wenxindou/Desktop/Friday/.phase1-backups/20260503-122916`
+- `/Users/example/Desktop/Friday/.phase1-backups/20260503-122916`
 
 清单：
 
-- `/Users/wenxindou/Desktop/Friday/.phase1-backups/20260503-122916/manifest.md`
+- `/Users/example/Desktop/Friday/.phase1-backups/20260503-122916/manifest.md`
 
 SQLite 在线备份：
 
-- `/Users/wenxindou/Desktop/Friday/.phase1-backups/20260503-122916/platform-state-sqlite-backup/friday.db`
+- `/Users/example/Desktop/Friday/.phase1-backups/20260503-122916/platform-state-sqlite-backup/friday.db`
 - `PRAGMA integrity_check`：`ok`
 
 安全处理：

--- a/docs/architecture/friday-module-map.md
+++ b/docs/architecture/friday-module-map.md
@@ -6,17 +6,17 @@
 
 Friday 是一个本地优先、可自托管的全栈 Agent OS：
 
-- CLI / runtime：`/Users/wenxindou/Desktop/Friday/src/cli/friday-cli.ts`
-- Hub composition root：`/Users/wenxindou/Desktop/Friday/src/hub/friday-hub-bootstrap.ts`
-- HTTP/API：`/Users/wenxindou/Desktop/Friday/src/api`
-- UI：`/Users/wenxindou/Desktop/Friday/ui/src`
-- State/SQLite：`/Users/wenxindou/Desktop/Friday/src/state`
-- Agent runtime/tools：`/Users/wenxindou/Desktop/Friday/src/agent`
-- Skills：`/Users/wenxindou/Desktop/Friday/src/skills`、`/Users/wenxindou/Desktop/Friday/skills`、`/Users/wenxindou/Desktop/Friday/managed-skills`
-- Workflows：`/Users/wenxindou/Desktop/Friday/src/workflows`
-- Memory：`/Users/wenxindou/Desktop/Friday/src/memory`
-- Providers：`/Users/wenxindou/Desktop/Friday/src/providers`
-- Channels：`/Users/wenxindou/Desktop/Friday/src/channels`
+- CLI / runtime：`/Users/example/Desktop/Friday/src/cli/friday-cli.ts`
+- Hub composition root：`/Users/example/Desktop/Friday/src/hub/friday-hub-bootstrap.ts`
+- HTTP/API：`/Users/example/Desktop/Friday/src/api`
+- UI：`/Users/example/Desktop/Friday/ui/src`
+- State/SQLite：`/Users/example/Desktop/Friday/src/state`
+- Agent runtime/tools：`/Users/example/Desktop/Friday/src/agent`
+- Skills：`/Users/example/Desktop/Friday/src/skills`、`/Users/example/Desktop/Friday/skills`、`/Users/example/Desktop/Friday/managed-skills`
+- Workflows：`/Users/example/Desktop/Friday/src/workflows`
+- Memory：`/Users/example/Desktop/Friday/src/memory`
+- Providers：`/Users/example/Desktop/Friday/src/providers`
+- Channels：`/Users/example/Desktop/Friday/src/channels`
 
 ## 当前执行流
 
@@ -31,17 +31,17 @@ Friday 是一个本地优先、可自托管的全栈 Agent OS：
 
 | 模块 | 主要路径 | 当前边界评价 | Phase 1 判断 |
 | --- | --- | --- | --- |
-| Hub | `/Users/wenxindou/Desktop/Friday/src/hub/friday-hub-bootstrap.ts` | 过大，承担总装配和大量业务判断 | Phase 2/3 应优先收敛为模块注册器 |
-| Agent | `/Users/wenxindou/Desktop/Friday/src/agent/runtime/friday-agent-runtime.ts` | 过大，混合 prompt、tool loop、memory、guard、输出校验 | 先补 characterization，再拆内部策略 |
-| API | `/Users/wenxindou/Desktop/Friday/src/api/runtime/friday-api-runtime.ts` | route 文件较模块化，runtime 注册器过大 | 引入 feature route installer |
-| State | `/Users/wenxindou/Desktop/Friday/src/state` | 边界较清晰，migration 纪律好 | 保持为 core platform |
-| Memory | `/Users/wenxindou/Desktop/Friday/src/memory` | core service 较清楚，session/orchestrator 耦合较深 | 保护数据优先，后续拆 policy |
-| Skills | `/Users/wenxindou/Desktop/Friday/src/skills` | 已接近插件/乐高式 | 可作为未来模块化模板 |
-| Workflows | `/Users/wenxindou/Desktop/Friday/src/workflows` | 领域边界清楚但 runtime/execution 较大 | 适合拆 node executor/run lifecycle |
-| Providers | `/Users/wenxindou/Desktop/Friday/src/providers/services/friday-provider-service.ts` | 过大，混合 secret/OAuth/doctor/routing/usage | 优先拆分 |
-| Channels | `/Users/wenxindou/Desktop/Friday/src/channels` | adapter 模式不错，但 readiness 不均 | 增加 live/stub/experimental 标记 |
-| UI | `/Users/wenxindou/Desktop/Friday/ui/src` | API client 较集中，但 types/setup page 偏大 | 拆页面 panels，建立 contract 生成 |
-| Config | `/Users/wenxindou/Desktop/Friday/src/config` + scattered env | schema 很小，env 读取分散 | 建议统一 `FridayRuntimeConfig` |
+| Hub | `/Users/example/Desktop/Friday/src/hub/friday-hub-bootstrap.ts` | 过大，承担总装配和大量业务判断 | Phase 2/3 应优先收敛为模块注册器 |
+| Agent | `/Users/example/Desktop/Friday/src/agent/runtime/friday-agent-runtime.ts` | 过大，混合 prompt、tool loop、memory、guard、输出校验 | 先补 characterization，再拆内部策略 |
+| API | `/Users/example/Desktop/Friday/src/api/runtime/friday-api-runtime.ts` | route 文件较模块化，runtime 注册器过大 | 引入 feature route installer |
+| State | `/Users/example/Desktop/Friday/src/state` | 边界较清晰，migration 纪律好 | 保持为 core platform |
+| Memory | `/Users/example/Desktop/Friday/src/memory` | core service 较清楚，session/orchestrator 耦合较深 | 保护数据优先，后续拆 policy |
+| Skills | `/Users/example/Desktop/Friday/src/skills` | 已接近插件/乐高式 | 可作为未来模块化模板 |
+| Workflows | `/Users/example/Desktop/Friday/src/workflows` | 领域边界清楚但 runtime/execution 较大 | 适合拆 node executor/run lifecycle |
+| Providers | `/Users/example/Desktop/Friday/src/providers/services/friday-provider-service.ts` | 过大，混合 secret/OAuth/doctor/routing/usage | 优先拆分 |
+| Channels | `/Users/example/Desktop/Friday/src/channels` | adapter 模式不错，但 readiness 不均 | 增加 live/stub/experimental 标记 |
+| UI | `/Users/example/Desktop/Friday/ui/src` | API client 较集中，但 types/setup page 偏大 | 拆页面 panels，建立 contract 生成 |
+| Config | `/Users/example/Desktop/Friday/src/config` + scattered env | schema 很小，env 读取分散 | 建议统一 `FridayRuntimeConfig` |
 
 ## 依赖方向现状
 

--- a/docs/architecture/friday-phase1-baseline.md
+++ b/docs/architecture/friday-phase1-baseline.md
@@ -12,19 +12,19 @@ Phase 1 已按“先备份、再固定测试、再真实闭环、最后文档化
 
 执行前已创建备份副本：
 
-- 备份目录：`/Users/wenxindou/Desktop/Friday/.phase1-backups/20260503-122916`
-- 清单文件：`/Users/wenxindou/Desktop/Friday/.phase1-backups/20260503-122916/manifest.md`
+- 备份目录：`/Users/example/Desktop/Friday/.phase1-backups/20260503-122916`
+- 清单文件：`/Users/example/Desktop/Friday/.phase1-backups/20260503-122916/manifest.md`
 - SQLite 在线备份 integrity check：`ok`
 - 备份目录已加入本地 `.git/info/exclude`，避免 token、DB、runtime 备份被误提交；未修改仓库 `.gitignore`。
 
 已备份范围：
 
-- `/Users/wenxindou/Desktop/Friday/.friday`：1620 files，198M，含 SQLite 和 memory/context/state 指示文件
-- `/Users/wenxindou/Desktop/Friday/memory`：1 file，4.0K
-- `/Users/wenxindou/Desktop/Friday/context`：5 files，20K
-- `/Users/wenxindou/Desktop/Friday/artifacts`：41 files，160K
-- `/Users/wenxindou/.friday`：9 files，100K
-- `/Users/wenxindou/Library/Application Support/Friday/state`：5 files，7.5M，含 `friday.db`
+- `/Users/example/Desktop/Friday/.friday`：1620 files，198M，含 SQLite 和 memory/context/state 指示文件
+- `/Users/example/Desktop/Friday/memory`：1 file，4.0K
+- `/Users/example/Desktop/Friday/context`：5 files，20K
+- `/Users/example/Desktop/Friday/artifacts`：41 files，160K
+- `/Users/example/.friday`：9 files，100K
+- `/Users/example/Library/Application Support/Friday/state`：5 files，7.5M，含 `friday.db`
 
 ## 固定命令基线
 
@@ -42,7 +42,7 @@ Phase 1 已按“先备份、再固定测试、再真实闭环、最后文档化
 
 最初失败集中在：
 
-- `/Users/wenxindou/Desktop/Friday/test/integration/system/friday-system-companion-release.integration.test.ts`
+- `/Users/example/Desktop/Friday/test/integration/system/friday-system-companion-release.integration.test.ts`
 
 失败用例：
 
@@ -53,7 +53,7 @@ Phase 1 已按“先备份、再固定测试、再真实闭环、最后文档化
 直接错误：
 
 ```text
-[friday-companion-release] timed out waiting for release lock at /Users/wenxindou/Desktop/Friday/.friday/locks/macos-release.lock
+[friday-companion-release] timed out waiting for release lock at /Users/example/Desktop/Friday/.friday/locks/macos-release.lock
 ```
 
 修复方式：只修改上述集成测试文件，为 release 用例提供隔离的 release lock、隔离的 macOS release 输出、隔离的 release record 输出，以及进程组级超时清理；release workflow 用例中的 source artifact 扫描也指向隔离 runtime，避免测试产物重新进入主仓库 manifest 扫描路径。独立 source distribution 用例仍验证默认真实输出行为。

--- a/docs/architecture/friday-risk-register.md
+++ b/docs/architecture/friday-risk-register.md
@@ -6,7 +6,7 @@
 
 ### Release workflow 测试隔离曾阻塞完整门禁
 
-- 文件：`/Users/wenxindou/Desktop/Friday/test/integration/system/friday-system-companion-release.integration.test.ts`
+- 文件：`/Users/example/Desktop/Friday/test/integration/system/friday-system-companion-release.integration.test.ts`
 - 问题：初次 Phase 1 全量 `npm test` 中，3 个 macOS companion release workflow 测试失败；首个用例 180s 超时，后续并发 release 等待 `.friday/locks/macos-release.lock` 超时。
 - 当前状态：已修复并验证，完整 `npm test` 当前通过。
 - 风险：release workflow 仍是 slow/packaging gate，如果后续移除隔离锁、隔离输出或进程组超时清理，完整质量门禁可能再次不稳定。
@@ -14,21 +14,21 @@
 
 ### Hub composition root 过大
 
-- 文件：`/Users/wenxindou/Desktop/Friday/src/hub/friday-hub-bootstrap.ts`
+- 文件：`/Users/example/Desktop/Friday/src/hub/friday-hub-bootstrap.ts`
 - 问题：hub 同时装配 provider、skills、memory、workflow、agent、channels、plugins、scheduler、observability、system、uix。
 - 风险：任何 feature 改造都容易牵动启动流程。
 - 建议：先引入 feature installer/registration 文档和边界检查，再小步拆装配逻辑。
 
 ### Agent runtime 过大
 
-- 文件：`/Users/wenxindou/Desktop/Friday/src/agent/runtime/friday-agent-runtime.ts`
+- 文件：`/Users/example/Desktop/Friday/src/agent/runtime/friday-agent-runtime.ts`
 - 问题：同一文件混合 LLM loop、tool execution、memory policy、safety guard、artifact truth、输出修复。
 - 风险：重构 agent 时最容易破坏行为。
 - 建议：先补 characterization tests，再拆纯策略模块。
 
 ### Memory/state 是硬约束
 
-- 路径：`/Users/wenxindou/Library/Application Support/Friday/state/friday.db`、`/Users/wenxindou/Desktop/Friday/.friday`、`/Users/wenxindou/Desktop/Friday/context`
+- 路径：`/Users/example/Library/Application Support/Friday/state/friday.db`、`/Users/example/Desktop/Friday/.friday`、`/Users/example/Desktop/Friday/context`
 - 问题：Phase 1 已备份，但尚未做恢复演练。
 - 风险：任何 schema/memory policy 改造都可能破坏长期记忆。
 - 建议：Phase 2 不改 memory schema；先做 restore rehearsal 文档和只读校验。
@@ -37,31 +37,31 @@
 
 ### API runtime 注册器过大
 
-- 文件：`/Users/wenxindou/Desktop/Friday/src/api/runtime/friday-api-runtime.ts`
+- 文件：`/Users/example/Desktop/Friday/src/api/runtime/friday-api-runtime.ts`
 - 问题：大量 routes 和 feature dependencies 在一个 runtime 中拼装。
 - 风险：API surface 增长后 route ownership 难追踪。
 - 建议：按 feature route installer 分组，但保持 URL contracts 不变。
 
 ### Provider service 职责过多
 
-- 文件：`/Users/wenxindou/Desktop/Friday/src/providers/services/friday-provider-service.ts`
+- 文件：`/Users/example/Desktop/Friday/src/providers/services/friday-provider-service.ts`
 - 问题：secret、OAuth、doctor、routing、usage、cost、validation 交织。
 - 风险：setup/provider 修复容易影响 runtime routing。
 - 建议：优先拆 doctor、secrets/OAuth、routing、usage accounting。
 
 ### UI/API type drift
 
-- 文件：`/Users/wenxindou/Desktop/Friday/ui/src/lib/api/types.ts`
-- 文件：`/Users/wenxindou/Desktop/Friday/packages/friday-operator-client/src/system-types.ts`
+- 文件：`/Users/example/Desktop/Friday/ui/src/lib/api/types.ts`
+- 文件：`/Users/example/Desktop/Friday/packages/friday-operator-client/src/system-types.ts`
 - 问题：UI/operator client types 与 backend API model 手工同步。
 - 风险：接口变更时 UI 能编译但运行时错。
 - 建议：引入 API contract 生成或共享 schema。
 
 ### Config/env 分散
 
-- 文件：`/Users/wenxindou/Desktop/Friday/.env.example`
-- 文件：`/Users/wenxindou/Desktop/Friday/src/cli/friday-cli.ts`
-- 文件：`/Users/wenxindou/Desktop/Friday/src/hub/friday-hub-bootstrap.ts`
+- 文件：`/Users/example/Desktop/Friday/.env.example`
+- 文件：`/Users/example/Desktop/Friday/src/cli/friday-cli.ts`
+- 文件：`/Users/example/Desktop/Friday/src/hub/friday-hub-bootstrap.ts`
 - 问题：大量 `FRIDAY_*` env 不由统一 runtime config 管理。
 - 风险：本机、私服、云服务行为难比较。
 - 建议：集中解析为 `FridayRuntimeConfig`，模块只接收解析后的配置。
@@ -70,14 +70,14 @@
 
 ### Integrations readiness 不一致
 
-- 路径：`/Users/wenxindou/Desktop/Friday/src/channels`
+- 路径：`/Users/example/Desktop/Friday/src/channels`
 - 问题：部分 channel 是 live adapter，部分是 stub/partial/compat。
 - 风险：用户和维护者容易误判“支持”等于“生产可用”。
 - 建议：建立 live/stub/experimental/compat readiness matrix，并在 UI/API 文档中展示。
 
 ### Release artifacts 和测试输出较重
 
-- 路径：`/Users/wenxindou/Desktop/Friday/dist/releases`
+- 路径：`/Users/example/Desktop/Friday/dist/releases`
 - 问题：`npm test` 中 release workflow 会生成/打包 source 和 macOS artifacts，耗时高；本机 `dist/ui/assets` 还存在大量 `* 2.*` 重复 ignored 构建产物，会拖慢 source pack。
 - 风险：完整质量门禁耗时偏高，后续容易被开发者绕过。
 - 建议：release 测试继续隔离输出目录；后续如需清理 `dist/`，应单独确认，因为 Phase 1 不删除运行产物。

--- a/docs/architecture/friday-test-baseline.md
+++ b/docs/architecture/friday-test-baseline.md
@@ -41,7 +41,7 @@ Duration    167.23s
 
 历史失败文件：
 
-- `/Users/wenxindou/Desktop/Friday/test/integration/system/friday-system-companion-release.integration.test.ts`
+- `/Users/example/Desktop/Friday/test/integration/system/friday-system-companion-release.integration.test.ts`
 
 历史失败类型：
 

--- a/docs/audit/00_AUDIT_BASELINE.md
+++ b/docs/audit/00_AUDIT_BASELINE.md
@@ -1,7 +1,7 @@
 # Phase 0 - Audit Baseline
 
 Date: 2026-04-30 / post-PR #171 follow-up
-Repository root: `/Users/wenxindou/Desktop/Friday`
+Repository root: `/Users/example/Desktop/Friday`
 Branch: `codex/audit-followup-production-verification`
 Base commit: `e244899a`
 

--- a/docs/audit/13_CURRENT_REAL_WORLD_SMOKE_RERUN.md
+++ b/docs/audit/13_CURRENT_REAL_WORLD_SMOKE_RERUN.md
@@ -73,7 +73,7 @@ Report paths:
 Runtime truth:
 
 - Base URL: `http://127.0.0.1:62550`
-- Original state copied from `/Users/wenxindou/Library/Application Support/Friday/state`; original state was not modified.
+- Original state copied from `/Users/example/Library/Application Support/Friday/state`; original state was not modified.
 - Auth source: `local_passphrase_login`
 - Setup status: `needsSetup=false`
 - Setup/profile truth mismatch: `false`

--- a/docs/audit/CAPABILITY_PROOF_MATRIX_2026-05-11_POST_203.md
+++ b/docs/audit/CAPABILITY_PROOF_MATRIX_2026-05-11_POST_203.md
@@ -119,7 +119,7 @@ Row: not a capability surface; this is a test-harness hygiene observation that a
 
 | Field | Value |
 |---|---|
-| Hygiene observation | `test/e2e/live/friday-self-healing-live.e2e.test.ts:37` declares `BUNDLED_SKILLS_DIR = path.join(process.cwd(), "skills")`. `/Users/jarvis/Projects/Friday/skills/` contains 177 git-tracked files; `.gitignore` does not exclude `skills/`. The drift `it` writes a broken manifest at line ~1007 **before** entering the `try` block at line ~1010. If the test process is killed between line 1007 and line 1010 (timeout, SIGTERM, or `env.hub!.skills.refresh()` hangs), the bundled production directory is left with a tampered manifest and no restoration, plus a leftover `e2e-skill-drift-<timestamp>` subdir under `<repo>/skills/`. |
+| Hygiene observation | `test/e2e/live/friday-self-healing-live.e2e.test.ts:37` declares `BUNDLED_SKILLS_DIR = path.join(process.cwd(), "skills")`. `/Users/example/Projects/Friday/skills/` contains 177 git-tracked files; `.gitignore` does not exclude `skills/`. The drift `it` writes a broken manifest at line ~1007 **before** entering the `try` block at line ~1010. If the test process is killed between line 1007 and line 1010 (timeout, SIGTERM, or `env.hub!.skills.refresh()` hangs), the bundled production directory is left with a tampered manifest and no restoration, plus a leftover `e2e-skill-drift-<timestamp>` subdir under `<repo>/skills/`. |
 | Risk classification | Test hygiene / workspace pollution; not release-proof eligible at any tier; independent of F-017 wiring. |
 | Reference | [Finding F-020 in `10_FINDINGS_REGISTER.md`](10_FINDINGS_REGISTER.md). |
 | Release-proof claim | None. |
@@ -190,6 +190,6 @@ Plus:
 - `gh run view 25698110492 --json …` (post-merge main CI run; 10/10 jobs `success`).
 - `git ls-files skills/ | wc -l` = 177 (tracked production starter skills).
 - `grep -nE "^skills\|/skills" .gitignore` returns zero matches.
-- `find /Users/jarvis/Projects/Friday -name "*2026-05-01T21-2*"` returns zero matches (F-007 report files not present in current workspace).
+- `find /Users/example/Projects/Friday -name "*2026-05-01T21-2*"` returns zero matches (F-007 report files not present in current workspace).
 
 This refresh is **not** a full repo line-by-line audit. The rows enumerated in §3.A–§3.E were re-verified at file:line evidence depth; predecessor rows §3.1–§3.8 not listed in §3.A–§3.E were not re-verified by this slice and inherit their tier from `CAPABILITY_PROOF_MATRIX_2026-05-11.md` (anchor `edaadf7a`).

--- a/docs/audit/CAPABILITY_PROOF_MATRIX_2026-05-11_POST_208.md
+++ b/docs/audit/CAPABILITY_PROOF_MATRIX_2026-05-11_POST_208.md
@@ -157,8 +157,8 @@ This refresh was assembled from:
 - `test/e2e/live/friday-self-healing-live.e2e.test.ts` at `origin/main@ce27d96f`.
 - `test/e2e/live/friday-autonomous-restart.e2e.test.ts` at `origin/main@ce27d96f`.
 - `/tmp/friday-deepseek-queue-20260511/`.
-- `/Users/jarvis/.zsh_history` (redacted command-history check; no test output there).
-- `/Users/jarvis/.claude/projects/-Users-jarvis-Projects-Friday/c417ec56-46b8-409e-81c3-9164de83bfe6.jsonl` (local transcript evidence for DeepSeek #1/#6).
+- `/Users/example/.zsh_history` (redacted command-history check; no test output there).
+- `/Users/example/.claude/projects/-Users-jarvis-Projects-Friday/c417ec56-46b8-409e-81c3-9164de83bfe6.jsonl` (local transcript evidence for DeepSeek #1/#6).
 - GitHub Actions logs for PR #200/#201 test jobs, which showed the relevant live tests skipped in CI.
 
 This refresh is intentionally narrow. Rows from the predecessor matrices that are not mentioned here retain their previous classification until a future full matrix pass re-verifies them.

--- a/docs/audit/CAPABILITY_PROOF_MATRIX_2026-05-17_POST_243.md
+++ b/docs/audit/CAPABILITY_PROOF_MATRIX_2026-05-17_POST_243.md
@@ -3,7 +3,7 @@
 This file is a dated post-#243 ledger refresh for current `origin/main`.
 It supersedes [`CAPABILITY_PROOF_MATRIX_2026-05-12_POST_216.md`](CAPABILITY_PROOF_MATRIX_2026-05-12_POST_216.md) for current-state reading, but does not rewrite earlier historical snapshots.
 
-This is not a full repo line-by-line audit and it is not product release proof. It is a Phase 15 docs-truth reconciliation snapshot built from the per-phase completion reports under `/Users/jarvis/Desktop/friday_vertical_closure_phase_reports_2026-05-12/` and the live source under `src/`. The authoritative product surface remains [`../current-source-of-truth.md`](../current-source-of-truth.md) and the authoritative evidence taxonomy remains [`../release-evidence-policy.md`](../release-evidence-policy.md).
+This is not a full repo line-by-line audit and it is not product release proof. It is a Phase 15 docs-truth reconciliation snapshot built from the per-phase completion reports under `/Users/example/Desktop/friday_vertical_closure_phase_reports_2026-05-12/` and the live source under `src/`. The authoritative product surface remains [`../current-source-of-truth.md`](../current-source-of-truth.md) and the authoritative evidence taxonomy remains [`../release-evidence-policy.md`](../release-evidence-policy.md).
 
 ## 1. Snapshot anchor
 
@@ -71,7 +71,7 @@ This snapshot does not say:
 This refresh was assembled from:
 
 - `git log --oneline --max-count=20 origin/main` at SHA `42fac20fa5f5bfd33e23addc400d9fb98bb35ee8`.
-- Per-phase completion reports under `/Users/jarvis/Desktop/friday_vertical_closure_phase_reports_2026-05-12/`.
+- Per-phase completion reports under `/Users/example/Desktop/friday_vertical_closure_phase_reports_2026-05-12/`.
 - `REPORTS_INDEX.csv` rows for `phase_02a`, `phase_02b`, `phase_03`, `phase_04`, `phase_05`, `phase_06`, `phase_07`, `phase_08`, `phase_09`, `phase_10`, `phase_11`, `phase_12`, `phase_13`, `phase_13_5`, `phase_13_6`, `phase_14`, `phase_14_5`, `phase_15`, `phase_16`, `phase_17`.
 - Current source references for `src/packaging/persistence/friday-package-sqlite-store.ts`, `src/security/multi-tenant/persistence/friday-multi-tenant-sqlite-store.ts`, `src/media-understanding/providers/friday-openai-vision-provider.ts`, and the related env gates in `src/hub/friday-hub-bootstrap.ts`.
 - [`./10_FINDINGS_REGISTER.md`](10_FINDINGS_REGISTER.md).

--- a/docs/audit/CAPABILITY_PROOF_MATRIX_2026-05-19_POST_267.md
+++ b/docs/audit/CAPABILITY_PROOF_MATRIX_2026-05-19_POST_267.md
@@ -3,7 +3,7 @@
 This file is a dated post-#267 ledger refresh for current `origin/main`.
 It supersedes [`CAPABILITY_PROOF_MATRIX_2026-05-17_POST_243.md`](CAPABILITY_PROOF_MATRIX_2026-05-17_POST_243.md) for public v1 local claim reading, but does not rewrite earlier historical snapshots.
 
-This is not a full repo line-by-line audit and it is not product release proof by itself. It is a Phase 19 release-proof-debt reconciliation snapshot built from the Phase 18B-H issue ledgers under `/Users/jarvis/Desktop/READ/friday-conveyor-handoffs/issue-ledger/`, the Phase 18A completion report, the public v1 workflow package under `/Users/jarvis/Desktop/friday_public_v1_workflow_2026-05-18/`, and the live source under `docs/` and `validation/real-world/`. The authoritative product surface remains [`../current-source-of-truth.md`](../current-source-of-truth.md) and the authoritative evidence taxonomy remains [`../release-evidence-policy.md`](../release-evidence-policy.md).
+This is not a full repo line-by-line audit and it is not product release proof by itself. It is a Phase 19 release-proof-debt reconciliation snapshot built from the Phase 18B-H issue ledgers under `/Users/example/Desktop/READ/friday-conveyor-handoffs/issue-ledger/`, the Phase 18A completion report, the public v1 workflow package under `/Users/example/Desktop/friday_public_v1_workflow_2026-05-18/`, and the live source under `docs/` and `validation/real-world/`. The authoritative product surface remains [`../current-source-of-truth.md`](../current-source-of-truth.md) and the authoritative evidence taxonomy remains [`../release-evidence-policy.md`](../release-evidence-policy.md).
 
 ## 1. Snapshot Anchor
 
@@ -63,15 +63,15 @@ Phase 18A-H PR-head RGG artifacts provide merge-hygiene and same-SHA proof for t
 This refresh was assembled from:
 
 - `git log --oneline --max-count=30 origin/main` at SHA `be7d31d4b8651c41494770e8e562cd2bd35c20d8`.
-- `/Users/jarvis/Desktop/friday_public_v1_workflow_2026-05-18/PUBLIC_V1_OFFICIAL_PHASE_MAP.md`.
-- `/Users/jarvis/Desktop/friday_public_v1_workflow_2026-05-18/PUBLIC_V1_PHASE_ISSUE_MAP.csv`.
-- `/Users/jarvis/Desktop/READ/friday-conveyor-handoffs/issue-ledger/phase_18b_safety_false_success_secret_data_loss_closure.json`.
-- `/Users/jarvis/Desktop/READ/friday-conveyor-handoffs/issue-ledger/phase_18c_setup_first_run_ux.json`.
-- `/Users/jarvis/Desktop/READ/friday-conveyor-handoffs/issue-ledger/phase_18d_skeptical_mode_user_constitution.json`.
-- `/Users/jarvis/Desktop/READ/friday-conveyor-handoffs/issue-ledger/phase_18e_frugal_mode_productization.json`.
-- `/Users/jarvis/Desktop/READ/friday-conveyor-handoffs/issue-ledger/phase_18f_api_ui_sdk_contract_reconciliation.json`.
-- `/Users/jarvis/Desktop/READ/friday-conveyor-handoffs/issue-ledger/phase_18g_desktop_system_boundary.json`.
-- `/Users/jarvis/Desktop/READ/friday-conveyor-handoffs/issue-ledger/phase_18h_product_truth_package_hygiene.json`.
+- `/Users/example/Desktop/friday_public_v1_workflow_2026-05-18/PUBLIC_V1_OFFICIAL_PHASE_MAP.md`.
+- `/Users/example/Desktop/friday_public_v1_workflow_2026-05-18/PUBLIC_V1_PHASE_ISSUE_MAP.csv`.
+- `/Users/example/Desktop/READ/friday-conveyor-handoffs/issue-ledger/phase_18b_safety_false_success_secret_data_loss_closure.json`.
+- `/Users/example/Desktop/READ/friday-conveyor-handoffs/issue-ledger/phase_18c_setup_first_run_ux.json`.
+- `/Users/example/Desktop/READ/friday-conveyor-handoffs/issue-ledger/phase_18d_skeptical_mode_user_constitution.json`.
+- `/Users/example/Desktop/READ/friday-conveyor-handoffs/issue-ledger/phase_18e_frugal_mode_productization.json`.
+- `/Users/example/Desktop/READ/friday-conveyor-handoffs/issue-ledger/phase_18f_api_ui_sdk_contract_reconciliation.json`.
+- `/Users/example/Desktop/READ/friday-conveyor-handoffs/issue-ledger/phase_18g_desktop_system_boundary.json`.
+- `/Users/example/Desktop/READ/friday-conveyor-handoffs/issue-ledger/phase_18h_product_truth_package_hygiene.json`.
 - [`./10_FINDINGS_REGISTER.md`](10_FINDINGS_REGISTER.md).
 - [`../current-source-of-truth.md`](../current-source-of-truth.md).
 - [`../release-evidence-policy.md`](../release-evidence-policy.md).

--- a/docs/audits/b0-slice-a-ui-e2e-triage-2026-05-23.md
+++ b/docs/audits/b0-slice-a-ui-e2e-triage-2026-05-23.md
@@ -2,7 +2,7 @@
 
 Generated: 2026-05-23
 Slice: `B0_security_approval_secrets_system_boundary` Slice A (public-mutation gate)
-Worktree: `/Users/jarvis/Projects/Friday-b0-public-mutation-gate`
+Worktree: `/Users/example/Projects/Friday-b0-public-mutation-gate`
 Base SHA: `dd3686c9600a55b602f4b2fc611f58e13844272d`
 
 ## Context

--- a/docs/open-source-release-review.md
+++ b/docs/open-source-release-review.md
@@ -101,11 +101,29 @@ Historical reports may remain for audit history, but current docs must point
 users to `docs/current-source-of-truth.md`, `docs/release-evidence-policy.md`,
 and `docs/public-v1-local-candidate.md` when facts conflict.
 
+## Public Download Hygiene
+
+The npm package is the installable runtime artifact. The GitHub source archive
+is the public source download. Both surfaces must stay free of private local
+paths, local state, internal operator control folders, and real secrets.
+
+The development repository may retain tests and historical public audit context
+for maintainers. Files that are useful for development but noisy or internal for
+end-user downloads are excluded from GitHub source archives with
+`.gitattributes export-ignore`.
+
+Internal release truth-map folders, dogfood reports, release-closure control
+packages, local evidence, and operator handoffs are not release artifacts. Channel
+features remain bounded by identity, permission, approval, evidence, and
+rollback gates; the public v1 local candidate does not claim unrestricted
+channel control or all capabilities live.
+
 ## Final Checks
 
 Before presenting the repository as a public v1 local candidate, run:
 
 ```bash
+npm run check:public-source-hygiene
 npm run check:secret-patterns
 npm run audit:release-truth
 npm run release:check

--- a/docs/public-v1-local-candidate.md
+++ b/docs/public-v1-local-candidate.md
@@ -45,7 +45,7 @@ optional external claims that were explicitly out of scope.
 
 ## Not Claimed
 
-- channel control or PR #244 channel live proof
+- unrestricted channel control or PR #244 channel live proof
 - Alibaba/Tencent/Volcengine cloud live certification
 - external OTEL/Grafana export
 - Slack/SMTP external alert dispatch as release-complete
@@ -57,6 +57,20 @@ optional external claims that were explicitly out of scope.
 - Phase 18A live UI/LLM acknowledgement plus SSE tail, while it remains
   `blocked_by_env`
 - release-complete-all
+
+## Public Download Hygiene
+
+Public release surfaces are split intentionally:
+
+- npm package: the installable runtime artifact.
+- GitHub source archive: the clean public source download.
+- development repository: source, tests, and public docs for maintainers.
+
+None of these surfaces should contain private local paths, local state, Desktop
+operator control packages, release truth-map artifacts, dogfood/release-closure
+folders, or real secrets. Development-only tests and historical audit files can remain in
+the repository, but are excluded from GitHub source archives when they are not
+needed for end-user download.
 
 ## Proof Rules
 

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "check:architecture-boundaries": "node scripts/quality/check-architecture-boundaries.mjs",
     "check:security-doctor": "node scripts/ops/check-friday-security-doctor.mjs",
     "check:secret-patterns": "node scripts/quality/check-provider-key-patterns.mjs",
+    "check:public-source-hygiene": "node scripts/quality/check-public-source-hygiene.mjs",
     "check:audit-integrity": "node scripts/ops/check-friday-audit-integrity.mjs",
     "setup:hooks": "bash scripts/setup-hooks.sh",
     "ops:converge-runtime": "bash scripts/ops/friday-converge-runtime.sh",

--- a/scripts/quality/check-public-source-hygiene.mjs
+++ b/scripts/quality/check-public-source-hygiene.mjs
@@ -1,0 +1,274 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const args = process.argv.slice(2);
+const pathIndex = args.indexOf("--path");
+const scanPath = pathIndex >= 0 ? path.resolve(args[pathIndex + 1] ?? "") : null;
+const root = scanPath ?? process.cwd();
+const repoMode = scanPath === null;
+
+const TEXT_EXTENSIONS = new Set([
+  ".cjs", ".css", ".csv", ".cts", ".d.ts", ".html", ".js", ".json", ".jsx",
+  ".mjs", ".md", ".mts", ".sh", ".sql", ".svg", ".ts", ".tsx", ".txt",
+  ".yaml", ".yml", "",
+]);
+
+const ALLOWLIST_HINTS = [
+  "$FRIDAY_",
+  "allowlist secret",
+  "deliberately",
+  "expired-token",
+  "fake",
+  "fixture",
+  "intentionally",
+  "not-real",
+  "placeholder",
+  "sk-ant-test",
+  "sk-bad",
+  "sk-compatible-test",
+  "sk-real-key-123",
+  "sk-secret-api-key",
+  "sk-test",
+  "ghp_1234567890",
+  "stub",
+  "test-token",
+  "xoxb-stub",
+];
+
+const CONTENT_PATTERNS = [
+  { name: "private path /Users/jarvis", regex: /\/Users\/jarvis\b/g },
+  { name: "private path /Users/wenxindou", regex: /\/Users\/wenxindou\b/g },
+  { name: "private path /Users/you", regex: /\/Users\/you\b/g },
+  { name: "Friday Map control path", regex: /Friday Map(?!s)/g },
+  { name: "dogfood control package", regex: /Friday-real-user-dogfood/g },
+  { name: "release closure package", regex: /Friday-release-closure/g },
+  { name: "global execution package", regex: /Friday-global-execution/g },
+  { name: "finding master package", regex: /finding\/_master|Finding\/_master/g },
+  { name: "GitHub token", regex: /\bghp_[A-Za-z0-9_]{20,}\b/g },
+  { name: "npm token", regex: /\bnpm_[A-Za-z0-9]{20,}\b/g },
+  { name: "Slack token", regex: /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g },
+  { name: "Telegram bot token", regex: /\b\d{8,12}:[A-Za-z0-9_-]{30,}\b/g },
+  {
+    name: "live-looking provider key",
+    regex: /\bsk-(?:proj|svcacct)-[A-Za-z0-9_-]{16,}\b|\bsk-[A-Za-z0-9_-]{32,}\b/g,
+  },
+  {
+    name: "literal Lark secret value",
+    regex: /\bFRIDAY_LARK_APP_SECRET\s*[:=]\s*["'](?!\$FRIDAY_|<|fake|stub|test)[^"']{12,}["']/g,
+  },
+  {
+    name: "literal bot token value",
+    regex: /\bFRIDAY_(?:DISCORD|TELEGRAM)_BOT_TOKEN\s*[:=]\s*["'](?!\$FRIDAY_|<|fake|stub|test)[^"']{12,}["']/g,
+  },
+];
+
+const FORBIDDEN_PATH_PATTERNS = [
+  { name: "non-example env file", regex: /(^|\/)\.env($|\.(?!example$))/ },
+  { name: "local Friday state directory", regex: /(^|\/)\.friday\// },
+  { name: "database artifact", regex: /\.(?:db|sqlite)(?:$|-)|\.(?:db|sqlite)-(?:wal|shm)$/ },
+  { name: "log artifact", regex: /\.log$/ },
+  { name: "Desktop dogfood package", regex: /Friday-real-user-dogfood/ },
+  { name: "Desktop release package", regex: /Friday-release-closure/ },
+  { name: "Desktop global execution package", regex: /Friday-global-execution/ },
+  { name: "Friday Map package", regex: /Friday Map/ },
+  { name: "finding master package", regex: /finding\/_master|Finding\/_master/ },
+];
+
+const ARCHIVE_EXCLUDED_PATTERNS = [
+  /^AGENTS\.md$/,
+  /^context\/AGENTS\.md$/,
+  /^\.secrets\.baseline$/,
+  /^AUDIT-REPORT\.md$/,
+  /^OVERNIGHT-TASK-SUMMARY\.csv$/,
+  /^qa-report\.html$/,
+  /^docs\/archive(?:\/|$)/,
+  /^docs\/audit(?:\/|$)/,
+  /^docs\/task(?:\/|$)/,
+  /^docs\/reports\/benchmark(?:\/|$)/,
+  /^reports(?:\/|$)/,
+  /^test(?:\/|$)/,
+  /^tests(?:\/|$)/,
+  /^tests-overnight(?:\/|$)/,
+];
+
+const findings = [];
+const stats = {
+  trackedFiles: 0,
+  packFiles: 0,
+  archiveFiles: 0,
+  scannedContentFiles: 0,
+};
+
+function run(command, argsList, options = {}) {
+  return execFileSync(command, argsList, {
+    cwd: root,
+    encoding: options.encoding ?? "utf8",
+    stdio: options.stdio ?? ["ignore", "pipe", "pipe"],
+    ...options,
+  });
+}
+
+function addFinding(scope, filePath, message, detail = "") {
+  findings.push({ scope, path: filePath, message, detail });
+}
+
+function normalizePath(filePath) {
+  return filePath.split(path.sep).join("/");
+}
+
+function isAllowlistedLine(line) {
+  const normalized = line.toLowerCase();
+  return ALLOWLIST_HINTS.some((hint) => normalized.includes(hint.toLowerCase()));
+}
+
+function looksText(buffer, filePath) {
+  const ext = path.extname(filePath);
+  if (!TEXT_EXTENSIONS.has(ext)) return false;
+  if (buffer.includes(0)) return false;
+  return true;
+}
+
+function scanContentFile(scope, relativePath, absolutePath) {
+  if (relativePath === ".gitattributes") return;
+
+  let buffer;
+  try {
+    buffer = fs.readFileSync(absolutePath);
+  } catch {
+    return;
+  }
+  if (!looksText(buffer, relativePath)) return;
+
+  stats.scannedContentFiles += 1;
+  const text = buffer.toString("utf8");
+  const lines = text.split(/\r?\n/);
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+    const line = lines[lineIndex];
+    if (relativePath === "scripts/quality/check-public-source-hygiene.mjs" && /regex:\s*\//.test(line)) {
+      continue;
+    }
+    if (isAllowlistedLine(line)) continue;
+    for (const pattern of CONTENT_PATTERNS) {
+      pattern.regex.lastIndex = 0;
+      if (pattern.regex.test(line)) {
+        addFinding(scope, `${relativePath}:${lineIndex + 1}`, pattern.name, line.trim().slice(0, 220));
+      }
+    }
+  }
+}
+
+function checkPathList(scope, files) {
+  for (const filePath of files) {
+    for (const pattern of FORBIDDEN_PATH_PATTERNS) {
+      if (pattern.regex.test(filePath)) {
+        addFinding(scope, filePath, pattern.name);
+      }
+    }
+  }
+}
+
+function trackedFiles() {
+  const raw = run("git", ["ls-files", "-z"]);
+  return raw.split("\0").filter(Boolean);
+}
+
+function walk(dirPath, prefix = "") {
+  const entries = fs.readdirSync(dirPath, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    if (entry.name === ".git" || entry.name === "node_modules") continue;
+    const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name;
+    const fullPath = path.join(dirPath, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walk(fullPath, relativePath));
+      continue;
+    }
+    files.push(relativePath);
+  }
+  return files;
+}
+
+function scanFiles(scope, files, baseDir = root) {
+  checkPathList(scope, files);
+  for (const filePath of files) {
+    scanContentFile(scope, filePath, path.join(baseDir, filePath));
+  }
+}
+
+function checkTrackedFiles() {
+  const files = trackedFiles();
+  stats.trackedFiles = files.length;
+  scanFiles("tracked", files);
+}
+
+function checkNpmPack() {
+  const raw = run("npm", ["pack", "--dry-run", "--json", "--ignore-scripts"]);
+  const pack = JSON.parse(raw)[0];
+  const files = pack?.files?.map((file) => file.path) ?? [];
+  stats.packFiles = files.length;
+  checkPathList("npm-pack", files);
+  for (const filePath of files) {
+    scanContentFile("npm-pack", filePath, path.join(root, filePath));
+  }
+}
+
+function checkGitArchive() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "friday-source-hygiene-"));
+  const tarPath = path.join(tmpDir, "source.tar");
+  run("git", ["archive", "--format=tar", "--worktree-attributes", "-o", tarPath, "HEAD"], {
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  const listRaw = execFileSync("tar", ["-tf", tarPath], { encoding: "utf8" });
+  const files = listRaw.split(/\r?\n/).filter(Boolean).map((file) => file.replace(/\/$/, ""));
+  stats.archiveFiles = files.length;
+
+  for (const filePath of files) {
+    for (const pattern of ARCHIVE_EXCLUDED_PATTERNS) {
+      if (pattern.test(filePath)) {
+        addFinding("git-archive-list", filePath, "export-ignore did not exclude expected internal file");
+      }
+    }
+  }
+  checkPathList("git-archive-list", files);
+
+  const extractDir = path.join(tmpDir, "extract");
+  fs.mkdirSync(extractDir);
+  execFileSync("tar", ["-xf", tarPath, "-C", extractDir], { stdio: ["ignore", "ignore", "pipe"] });
+  scanFiles("git-archive-content", walk(extractDir), extractDir);
+}
+
+function checkExternalPath() {
+  if (!fs.existsSync(root)) {
+    console.error(`Path does not exist: ${root}`);
+    process.exit(1);
+  }
+  const files = walk(root);
+  scanFiles("path", files, root);
+}
+
+if (repoMode) {
+  checkTrackedFiles();
+  checkNpmPack();
+  checkGitArchive();
+} else {
+  checkExternalPath();
+}
+
+if (findings.length > 0) {
+  console.error("Public source hygiene check failed:");
+  for (const finding of findings.slice(0, 120)) {
+    const detail = finding.detail ? `\n    ${finding.detail}` : "";
+    console.error(`- [${finding.scope}] ${finding.path}: ${finding.message}${detail}`);
+  }
+  if (findings.length > 120) {
+    console.error(`... and ${findings.length - 120} more finding(s)`);
+  }
+  process.exit(1);
+}
+
+console.log("Public source hygiene check passed.");
+console.log(JSON.stringify(stats, null, 2));

--- a/test/unit/agent/tools/friday-agent-desktop-tool.test.ts
+++ b/test/unit/agent/tools/friday-agent-desktop-tool.test.ts
@@ -622,7 +622,7 @@ describe("createFridayAgentDesktopTool", () => {
       const legitimatePaths = [
         "/tmp/notes.txt",
         "/home/jarvis/project/file.md",
-        "/Users/jarvis/Desktop/document.pdf",
+        "/Users/example/Desktop/document.pdf",
         "C:\\Users\\Jarvis\\Documents\\file.txt",
         "subdir/file.txt", // relative
       ];

--- a/test/unit/skills/converter/discovery/friday-discovery-integration.test.ts
+++ b/test/unit/skills/converter/discovery/friday-discovery-integration.test.ts
@@ -154,8 +154,8 @@ describe("FridayDiscoveryIntegrationConverter", () => {
     });
 
     it("rejects direct payloads with path-like program or skill identifiers", async () => {
-      const badProgramId = makePayload({ programId: "/Users/jarvis/Applications/TestApp.app" });
-      const badSkillId = makePayload({ skillId: "discovery-/Users/jarvis/Applications/TestApp.app" });
+      const badProgramId = makePayload({ programId: "/Users/example/Applications/TestApp.app" });
+      const badSkillId = makePayload({ skillId: "discovery-/Users/example/Applications/TestApp.app" });
       const badShellId = makePayload({ programId: "testapp'; rm -rf / #" });
 
       await expect(converter.detect({ contentBase64: encodePayload(badProgramId) }))
@@ -169,7 +169,7 @@ describe("FridayDiscoveryIntegrationConverter", () => {
     });
 
     it("rejects direct payloads with raw path-like integration paths", async () => {
-      const bad = makePayload({ integrationPath: "/Users/jarvis/secret/integration" as never });
+      const bad = makePayload({ integrationPath: "/Users/example/secret/integration" as never });
 
       await expect(converter.detect({ contentBase64: encodePayload(bad) }))
         .resolves.toBeNull();
@@ -258,8 +258,8 @@ describe("buildDiscoveryIntegrationSource", () => {
 
   it("does not include raw executable paths or path-like program ids in the payload", () => {
     const program = makeProgram({
-      id: "/Users/jarvis/Applications/TestApp.app",
-      executablePath: "/Users/jarvis/secret/path/bin",
+      id: "/Users/example/Applications/TestApp.app",
+      executablePath: "/Users/example/secret/path/bin",
     });
     const recommendation = makeRecommendation();
     const result = buildDiscoveryIntegrationSource({ program, recommendation });
@@ -268,7 +268,7 @@ describe("buildDiscoveryIntegrationSource", () => {
       Buffer.from(result.source.contentBase64!, "base64").toString("utf8"),
     );
     const serialized = JSON.stringify(decoded);
-    expect(serialized).not.toContain("/Users/jarvis");
+    expect(serialized).not.toContain("/Users/example");
     expect(serialized).not.toContain("secret/path");
     expect(decoded.programId).toMatch(/^local-[a-f0-9]{16}$/);
     expect(decoded.skillId).toMatch(/^discovery-local-[a-f0-9]{16}$/);
@@ -426,8 +426,8 @@ describe("createFridayDiscoveryIntegrationRoutes", () => {
 
   it("redacts path-like program ids from canonical approval error details", async () => {
     const program = makeProgram({
-      id: "/Users/jarvis/Applications/TestApp.app",
-      executablePath: "/Users/jarvis/secret/bin/app",
+      id: "/Users/example/Applications/TestApp.app",
+      executablePath: "/Users/example/secret/bin/app",
     });
     const recommendation = makeRecommendation({ programId: program.id });
     const deps: FridayDiscoveryIntegrationRoutesDeps = {
@@ -453,7 +453,7 @@ describe("createFridayDiscoveryIntegrationRoutes", () => {
       }),
     });
     const details = (thrown as { details?: unknown }).details;
-    expect(JSON.stringify(details)).not.toContain("/Users/jarvis");
+    expect(JSON.stringify(details)).not.toContain("/Users/example");
     expect(JSON.stringify(details)).not.toContain("secret/bin");
   });
 
@@ -519,8 +519,8 @@ describe("createFridayDiscoveryIntegrationRoutes", () => {
     const gate = makeGate();
     const converterService = makeConverterService();
     const program = makeProgram({
-      id: "/Users/jarvis/Applications/TestApp.app",
-      executablePath: "/Users/jarvis/secret/bin/app",
+      id: "/Users/example/Applications/TestApp.app",
+      executablePath: "/Users/example/secret/bin/app",
     });
     const recommendation = makeRecommendation({ programId: program.id });
 
@@ -563,12 +563,12 @@ describe("createFridayDiscoveryIntegrationRoutes", () => {
     );
 
     const result = await route.handler(makeCtx({
-      programId: "/Users/jarvis/Applications/TestApp.app",
+      programId: "/Users/example/Applications/TestApp.app",
       canonicalApproval: approval,
     }));
 
     const serialized = JSON.stringify(result);
-    expect(serialized).not.toContain("/Users/jarvis");
+    expect(serialized).not.toContain("/Users/example");
     expect(serialized).not.toContain("secret/bin");
     expect(serialized).toContain("local-");
   });


### PR DESCRIPTION
## Summary

Adds a public-source hygiene gate for Friday release/download surfaces. This keeps runtime behavior unchanged while making the public source archive and npm package safer to inspect/download.

Changes:
- Add `npm run check:public-source-hygiene` to scan tracked files, npm pack output, and GitHub source archives for private local paths, Desktop control package names, local state artifacts, database/log files, and live-looking token/key patterns.
- Add `.gitattributes export-ignore` exclusions for internal agent governance files, historical audit/report folders, tests, and local control-package folder names so GitHub source downloads stay clean.
- Redact private absolute paths in docs/tests to `/Users/example`.
- Tighten public v1 docs so the release claim remains source/npm local-candidate only, not unrestricted channel control or all-live capability proof.

## Validation

- `npm run check:public-source-hygiene`
- manual `git archive --worktree-attributes HEAD` exclusion check + extracted archive `--path` hygiene scan
- `npm run release:check`
- `npm run check:secret-patterns`
- `npm audit --omit=dev --audit-level=moderate`
- `npx vitest run test/unit/agent/tools/friday-agent-desktop-tool.test.ts test/unit/skills/converter/discovery/friday-discovery-integration.test.ts test/e2e/ui/friday-starter-skills-closeout.test.ts test/unit/skills/runtime/friday-wave23-starter-skills.test.ts test/unit/scripts/ops/write-friday-release-manifest-source-only.test.ts`

## Notes

This PR does not remove development files from the repository history or clone workflow. It ensures public download/release surfaces are clean and gives future releases a repeatable gate.