### PR TITLE
fix(ui/plugins): truth-label trust-on-install (B2 / FRI-AUD-004)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,22 @@ and this project follows Semantic Versioning.
 
 ## [Unreleased]
 
-## [1.0.2] — Public Install Audit Hotfix — 2026-05-26
+## [1.0.2] — Post-Release Hardening Wave — 2026-05-26
 
-`1.0.2` is a security/hygiene patch on top of `1.0.1`. It does not change
-the `1.0.1` release claim (public v1 local candidate, npm/source-only,
-`dogfood_partial_pass`, nine `proof_pending` headlines carried forward,
-Slack HTTP / QQ / desktop / Homebrew / notarized macOS / mobile / "all
-integrations live" exclusions). Public install behavior changes ONLY in
-that `npm install @thesongzhu/friday@1.0.2 && npm audit --omit=dev` now
+`1.0.2` accumulates the post-release hardening queue from
+`/Users/jarvis/Desktop/Friday-post-release-hardening-plan-20260526` on
+top of `1.0.1`. It does not change the `1.0.1` release claim (public v1
+local candidate, npm/source-only, `dogfood_partial_pass`, nine
+`proof_pending` headlines carried forward, Slack HTTP / QQ / desktop /
+Homebrew / notarized macOS / mobile / "all integrations live"
+exclusions). Public install behavior changes ONLY in that
+`npm install @thesongzhu/friday@1.0.2 && npm audit --omit=dev` now
 reports `0` vulnerabilities, down from `3 high` on `1.0.1`.
 
 ### Changed
 
-- Lark/Feishu long-connection (WebSocket) event subscription is now
-  served by a native client under `src/channels/lark/internal/`
+- **B0.5** Lark/Feishu long-connection (WebSocket) event subscription is
+  now served by a native client under `src/channels/lark/internal/`
   (`lark-ws-client.ts`, `lark-ws-frame.ts`, `lark-event-dispatcher.ts`,
   `lark-domain.ts`, `lark-logger.ts`) instead of via
   `@larksuiteoapi/node-sdk`. The native client vendor-adapts the MIT-
@@ -32,6 +34,18 @@ reports `0` vulnerabilities, down from `3 high` on `1.0.1`.
   and status semantics; downstream `parseMessageEventBase` and
   `parseCardApprovalActionEvent` consume the same flattened envelope
   the SDK was producing.
+- **B2 / FRI-AUD-004** Plugins page (`ui/src/routes/plugins-page.tsx`)
+  no longer renders trust-on-install as cryptographic "signature
+  verified". The badge now uses a `pluginTrustLabel` helper that maps
+  `signatureVerified=false` → "unsigned or unverified",
+  `signatureVerified=true && trustMode="trust_on_install"` → "locally
+  trusted (trust-on-install)", and
+  `signatureVerified=true && trustMode="signed"` → "signature
+  proof_pending (no trusted keyring)". Tone is always `neutral` for v1
+  because no path produces a cryptographically verified marketplace
+  signature yet. PR #308 already added the runtime advisory + JSDoc
+  truth-label; this slice closes the user-facing UI overclaim. No
+  runtime behavior change to plugin install/enable/disable.
 
 ### Removed
 

--- a/test/unit/ui/plugin-signature-truth-labels.test.ts
+++ b/test/unit/ui/plugin-signature-truth-labels.test.ts
@@ -1,0 +1,68 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+/**
+ * B2 / FRI-AUD-004 regression guard: trust-on-install must never render
+ * as cryptographic "signature verified" in the plugins page.
+ *
+ * The plugin signature verifier at
+ * `src/plugins/security/friday-plugin-signature-verifier.ts` does NOT
+ * actually verify Ed25519 marketplace signatures (no trusted-keyring
+ * infrastructure exists in this release). It only computes SHA-256
+ * fingerprints + records user approval for local trust-on-install.
+ *
+ * Per POST_RELEASE_DEFAULT_DECISIONS.md B2, the UI must render:
+ *   - signatureVerified=false → "unsigned or unverified"
+ *   - signatureVerified=true && trustMode="trust_on_install" → "locally trusted"
+ *   - signatureVerified=true && trustMode="signed" → "signature proof_pending"
+ *
+ * Tone never returns "success" (green) for the v1 release.
+ */
+
+const PLUGINS_PAGE_PATH = "ui/src/routes/plugins-page.tsx" as const;
+
+describe("plugin signature truth labels (B2 / FRI-AUD-004)", () => {
+  const source = readFileSync(PLUGINS_PAGE_PATH, "utf8");
+
+  it("does not render trust-on-install as cryptographic 'signature verified'", () => {
+    // The previous overclaim — UI rendered "signature verified" / "签名已验证"
+    // whenever signatureVerified=true, even though trust-on-install never
+    // produces a cryptographically verified marketplace signature.
+    expect(source).not.toContain('"签名已验证"');
+    expect(source).not.toContain('"signature verified"');
+    expect(source).not.toContain("plugin.signatureVerified ?");
+    // The old success-tone pairing for the signature badge MUST be gone.
+    expect(source).not.toMatch(/tone=\{plugin\.signatureVerified \? "success" : "neutral"\}/);
+  });
+
+  it("uses a truth-labeled helper to render the trust badge", () => {
+    // The new helper centralizes the rule (single source of truth).
+    expect(source).toContain("function pluginTrustLabel(plugin: FridayPluginEntity, locale: AppLocale)");
+    // The badge must always be neutral-toned — no path produces success for v1.
+    expect(source).toMatch(/<StatusPill tone="neutral">\s*\{pluginTrustLabel\(plugin, locale\)\}\s*<\/StatusPill>/);
+  });
+
+  it("labels trust-on-install as locally trusted", () => {
+    expect(source).toContain('"本地信任（trust-on-install）"');
+    expect(source).toContain('"locally trusted (trust-on-install)"');
+    expect(source).toContain('plugin.trustMode === "trust_on_install"');
+  });
+
+  it("labels signed-but-no-keyring as signature proof_pending", () => {
+    expect(source).toContain('"签名待验证（暂无可信密钥环）"');
+    expect(source).toContain('"signature proof_pending (no trusted keyring)"');
+  });
+
+  it("preserves the unsigned-or-unverified label for signatureVerified=false", () => {
+    expect(source).toContain('"未验证签名"');
+    expect(source).toContain('"unsigned or unverified"');
+    expect(source).toContain("!plugin.signatureVerified");
+  });
+
+  it("anchors the helper to the audit finding via comment", () => {
+    // Make the why discoverable for future readers and grep tools.
+    expect(source).toContain("B2 / FRI-AUD-004 truth-label");
+    expect(source).toContain("trust-on-install must never render as a");
+    expect(source).toContain("POST_RELEASE_DEFAULT_DECISIONS.md B2");
+  });
+});

--- a/ui/src/routes/plugins-page.tsx
+++ b/ui/src/routes/plugins-page.tsx
@@ -5,7 +5,7 @@ import { toast } from "sonner";
 import { ActionButton, ConfirmDialog, EmptyState, FieldLabel, ShellCard, SkeletonCard, StatusPill } from "@/components/core/primitives";
 import { healthApi } from "@/lib/api/health";
 import { pluginsApi, type FridayPluginEntity, type FridayPluginLifecycleEvidence } from "@/lib/api/plugins";
-import { localize } from "@/lib/i18n/localized-text";
+import { localize, type AppLocale } from "@/lib/i18n/localized-text";
 import { useAppLocale } from "@/providers/locale-provider";
 
 function formatTimestamp(value?: string | null): string {
@@ -53,6 +53,35 @@ function lifecycleTone(plugin: FridayPluginEntity): "neutral" | "success" | "war
   return "neutral";
 }
 
+/**
+ * B2 / FRI-AUD-004 truth-label: trust-on-install must never render as a
+ * cryptographically verified marketplace signature. Marketplace Ed25519
+ * verification is not wired (no
+ * trusted-keyring infrastructure exists in this release); the verifier only
+ * computes SHA-256 fingerprints + user-approval for local trust-on-install
+ * (see src/plugins/security/friday-plugin-signature-verifier.ts).
+ *
+ * Rules per POST_RELEASE_DEFAULT_DECISIONS.md B2:
+ *   - signatureVerified=false → "unsigned or unverified" (neutral)
+ *   - signatureVerified=true && trustMode="trust_on_install" →
+ *     "locally trusted (trust-on-install)" (neutral — NOT success/green)
+ *   - signatureVerified=true && trustMode="signed" →
+ *     "signature proof_pending (no trusted keyring)" (neutral — until real
+ *     marketplace keyring lands)
+ *
+ * Tone never returns "success" for the v1 release because no path produces
+ * a cryptographically verified marketplace signature yet.
+ */
+function pluginTrustLabel(plugin: FridayPluginEntity, locale: AppLocale): string {
+  if (!plugin.signatureVerified) {
+    return localize(locale, "未验证签名", "unsigned or unverified");
+  }
+  if (plugin.trustMode === "trust_on_install") {
+    return localize(locale, "本地信任（trust-on-install）", "locally trusted (trust-on-install)");
+  }
+  return localize(locale, "签名待验证（暂无可信密钥环）", "signature proof_pending (no trusted keyring)");
+}
+
 function PluginInventoryCard(props: {
   plugin: FridayPluginEntity;
   lifecycleEvidence?: FridayPluginLifecycleEvidence;
@@ -78,8 +107,8 @@ function PluginInventoryCard(props: {
           <div className="flex flex-wrap items-center gap-2">
             <p className="text-base font-semibold text-[color:var(--color-text-primary)]">{plugin.name}</p>
             <StatusPill tone={pluginTone(plugin.status)}>{plugin.status}</StatusPill>
-            <StatusPill tone={plugin.signatureVerified ? "success" : "neutral"}>
-              {plugin.signatureVerified ? localize(locale, "签名已验证", "signature verified") : localize(locale, "未验证签名", "unsigned or unverified")}
+            <StatusPill tone="neutral">
+              {pluginTrustLabel(plugin, locale)}
             </StatusPill>
             <StatusPill tone={lifecycleTone(plugin)}>
               {lifecycleLabel}


### PR DESCRIPTION
## Summary

Closes the user-facing half of FRI-AUD-004: the plugins page rendered trust-on-install as `"signature verified"` even though the verifier only computes SHA-256 fingerprints + user approval (no Ed25519 marketplace verification, no trusted-keyring infrastructure in this release).

PR #308 (B1 Slice 6) added the runtime advisory + JSDoc truth-label. This slice closes the **UI** overclaim by replacing the `signatureVerified ? "signature verified" : "unsigned"` ternary with a `pluginTrustLabel(plugin, locale)` helper that maps `trustMode` to truthful labels per `POST_RELEASE_DEFAULT_DECISIONS.md` B2.

3 files, +124 / −13 LOC.

## What changed

**`ui/src/routes/plugins-page.tsx`**

- Adds `pluginTrustLabel(plugin: FridayPluginEntity, locale: AppLocale)` helper (with an anchored comment referencing B2 / FRI-AUD-004 + the verifier source + the default-decisions rule).
- Replaces the `<StatusPill tone={plugin.signatureVerified ? "success" : "neutral"}>` + ternary text with `<StatusPill tone="neutral">{pluginTrustLabel(plugin, locale)}</StatusPill>`.
- Imports `AppLocale` type alongside `localize`.

Label mapping (per `POST_RELEASE_DEFAULT_DECISIONS.md` B2):

| `signatureVerified` | `trustMode` | Label |
| --- | --- | --- |
| `false` | (any) | "unsigned or unverified" / "未验证签名" |
| `true` | `"trust_on_install"` | "locally trusted (trust-on-install)" / "本地信任（trust-on-install）" |
| `true` | `"signed"` | "signature proof_pending (no trusted keyring)" / "签名待验证（暂无可信密钥环）" |

Tone is **always** `neutral` for v1 — no path produces a cryptographically verified marketplace signature yet. When real Ed25519 keyring verification lands, the helper can return `"success"` for that lane.

**`test/unit/ui/plugin-signature-truth-labels.test.ts`** (new)

6 source-content regression tests (matching Friday's existing UI-test convention in `setup-provider-regressions.test.ts`):

1. The old "signature verified" / "签名已验证" labels are absent.
2. The old `tone={plugin.signatureVerified ? "success" : "neutral"}` pattern is absent.
3. The new helper exists and the badge uses neutral tone with the helper output.
4. The trust-on-install branch renders the locally-trusted label and gates on `plugin.trustMode === "trust_on_install"`.
5. The signed-but-no-keyring branch renders the proof_pending label.
6. The helper carries an anchored comment referencing the audit finding + default-decisions rule.

**`CHANGELOG.md` `[1.0.2]`**

- Renamed header from "Public Install Audit Hotfix" → "Post-Release Hardening Wave" to reflect that the post-release queue accumulates here.
- Added a B2 entry under `### Changed` describing this slice. B0.5 entry preserved.

## What this does NOT change

- The runtime path for plugin install / enable / disable / uninstall.
- The verifier (`friday-plugin-signature-verifier.ts`).
- The `FridayPluginSignature` type, `signatureVerified` field on the entity, or `trustMode` enum.
- Marketplace keyring infrastructure (still does not exist — labeled `signature_proof_pending`).
- Any other public release claim (`1.0.1` boundaries preserved).

## Local verification

- `npm run typecheck` — 0 errors
- `npx vitest run test/unit/ui/plugin-signature-truth-labels.test.ts` — 6/6 PASS
- `npx vitest run test/unit/ui/` (blast radius) — 200/200 PASS (42 test files)
- `git diff --check` — clean
- `detect-secrets-hook --baseline .secrets.baseline …` — clean
- ESLint warnings on the touched files are pre-existing project-wide "no matching configuration" notes for `ui/src/**` + `test/unit/ui/**` directories; 0 ESLint errors

## Real path execution

The new helper is exercised in source via the regression tests (Friday's UI testing convention). A full real-browser rendering of the badge happens during interactive use; the existing `friday-plugin-lifecycle-evidence-harness.test.ts` and `friday-plugin-routes.test.ts` exercise the backend install/trust path that produces the `signatureVerified` + `trustMode` fields the UI consumes.

## Refs

- `Friday-capability-wiring-audit-20260525-1813/USER_FACING_TRUTH_GAPS.csv` row FRI-AUD-004
- `Friday-post-release-hardening-plan-20260526/POST_RELEASE_DEFAULT_DECISIONS.md` § B2
- `Friday-post-release-hardening-plan-20260526/BATCH_SPECS.md` § B2 Spec — Plugin Signature Verification
- PR #308 — B1 Slice 6 (runtime advisory + JSDoc, prior incremental work)

## Test plan

- [ ] All branch-protected required checks green on PR head
- [ ] No regression in `friday-plugin-routes.test.ts` / lifecycle harness
- [ ] Operator authorizes merge (squash, normal path, no `--admin`)
- [ ] B0.5 + B2 ship together in the next operator-driven `1.0.2` publish (R5 same-SHA RGG + R6 release.yml)
