### PR TITLE
fix(hub/desktop): fail-closed policy + permission decision routes (B3 / FRI-AUD-005)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,20 @@ reports `0` vulnerabilities, down from `3 high` on `1.0.1`.
   signature yet. PR #308 already added the runtime advisory + JSDoc
   truth-label; this slice closes the user-facing UI overclaim. No
   runtime behavior change to plugin install/enable/disable.
+- **B3 / FRI-AUD-005** Desktop policy + permission decision routes
+  (`/v1/desktop/policies/*`, `/v1/desktop/permissions/respond`,
+  `/v1/desktop/permissions/decisions`) now fail closed with typed 503
+  errors (`DESKTOP_POLICY_NOT_PERSISTED` /
+  `DESKTOP_PERMISSION_DECISION_NOT_PERSISTED`) when invoked. The
+  previous hub-bootstrap dep wiring echoed requests back with synthetic
+  ids and returned empty/null reads, which let synthetic responses look
+  enforced even though no durable storage / evaluator / audit / rollback
+  wiring exists. Routes stay registered for contract stability so the
+  OpenAPI surface and `friday-http-route-contract` are unchanged.
+  `desktop.permissions.list` (real OS capability check via
+  `desktopSessionManager.checkPermissions`) is preserved as live. No
+  desktop risk-tier changes; no UI consumer of the policy routes
+  existed under `ui/`, so no user-facing flow regresses.
 
 ### Removed
 

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -451,6 +451,35 @@ import type {
 
 // ─── Constants ───
 
+/**
+ * B3 / FRI-AUD-005 fail-closed error builders for desktop policy + permission
+ * decision deps. Desktop policy persistence is `proof_pending` in this
+ * release (no durable storage, no policy evaluator, no audit/rollback wiring).
+ * Routes stay registered for contract stability but live calls must surface a
+ * typed 503 so callers (UI/agents) can render the truthful state instead of
+ * accepting a synthetic-echo response as enforced.
+ *
+ * See POST_RELEASE_DEFAULT_DECISIONS.md B3:
+ *   "Desktop policy routes must either persist/enforce real policy with audit
+ *    and rollback, or be hidden/gated/labeled proof_pending. Synthetic IDs,
+ *    echoed policy, empty reads, or no-op permissions must not look enforced."
+ */
+function createDesktopPolicyNotPersistedError(operation: string): FridayDomainError {
+  return new FridayDomainError(
+    "DESKTOP_POLICY_NOT_PERSISTED",
+    `Desktop policy "${operation}" is proof_pending in this release: no durable storage, evaluator, or audit/rollback wiring exists. Routes remain registered for contract stability but no policy is persisted or enforced. See release notes.`,
+    { httpStatus: 503, details: { operation, status: "proof_pending" } },
+  );
+}
+
+function createDesktopPermissionDecisionNotPersistedError(operation: string): FridayDomainError {
+  return new FridayDomainError(
+    "DESKTOP_PERMISSION_DECISION_NOT_PERSISTED",
+    `Desktop permission decision "${operation}" is proof_pending in this release: prompt decisions are not durably stored and a decisions log is not yet wired. permissions.list (OS capability check) remains live. See release notes.`,
+    { httpStatus: 503, details: { operation, status: "proof_pending" } },
+  );
+}
+
 /** Default server version reported by the API runtime. */
 const FRIDAY_HUB_DEFAULT_SERVER_VERSION = FRIDAY_VERSION;
 const FRIDAY_AGENT_ROUTE_DEFAULT_MODEL = "default";
@@ -6351,18 +6380,33 @@ export async function createFridayHub(
         delete(recordingId, _req) { desktopSessionManager!.deleteRecording(recordingId); return { deleted: true } as never; },
       },
       policies: {
-        create(req) { return { policy: req, policyId: idGenerator() } as never; },
-        get(_policyId) { return { policy: null } as never; },
-        list(_query) { return { policies: [] } as never; },
-        update(_policyId, req) { return { policy: req } as never; },
-        delete(_policyId, _req) { return { deleted: true } as never; },
-        addRule(_policyId, req) { return { rule: req } as never; },
-        removeRule(_policyId, _ruleId, _req) { return { removed: true } as never; },
+        // B3 / FRI-AUD-005 fail-closed: desktop policy persistence is
+        // proof_pending in this release. Previous implementations of these
+        // deps echoed the request back with a synthetic id and returned
+        // empty/null reads, which let synthetic responses look enforced.
+        // Per POST_RELEASE_DEFAULT_DECISIONS.md B3 ("Desktop policy routes
+        // must either persist/enforce real policy with audit and rollback,
+        // or be hidden/gated/labeled proof_pending"), routes stay
+        // registered for contract stability (FridayCreateDesktopPolicyRequest
+        // / FridayUpdateDesktopPolicyRequest types remain unchanged) but
+        // call sites get a typed 503 they can render truthfully.
+        create(_req): never { throw createDesktopPolicyNotPersistedError("create"); },
+        get(_policyId): never { throw createDesktopPolicyNotPersistedError("get"); },
+        list(_query): never { throw createDesktopPolicyNotPersistedError("list"); },
+        update(_policyId, _req): never { throw createDesktopPolicyNotPersistedError("update"); },
+        delete(_policyId, _req): never { throw createDesktopPolicyNotPersistedError("delete"); },
+        addRule(_policyId, _req): never { throw createDesktopPolicyNotPersistedError("addRule"); },
+        removeRule(_policyId, _ruleId, _req): never { throw createDesktopPolicyNotPersistedError("removeRule"); },
       },
       permissions: {
+        // permissions.list reads real OS permissions via the session manager —
+        // this is a true read (no persistence required). Kept as real.
         async list() { const perms = await desktopSessionManager!.checkPermissions(); return { permissions: [...perms] } as never; },
-        respond(_promptId, req) { return { decision: (req as unknown as Record<string, unknown>).decision } as never; },
-        listDecisions(_query) { return { decisions: [] } as never; },
+        // B3 / FRI-AUD-005 fail-closed: the previous implementations echoed
+        // the decision and returned an always-empty decision log without
+        // persisting anything. Synthetic responses must not look enforced.
+        respond(_promptId, _req): never { throw createDesktopPermissionDecisionNotPersistedError("respond"); },
+        listDecisions(_query): never { throw createDesktopPermissionDecisionNotPersistedError("listDecisions"); },
       },
       platform: {
         async get() {

--- a/test/unit/hub/bootstrap/desktop-policy-fail-closed.test.ts
+++ b/test/unit/hub/bootstrap/desktop-policy-fail-closed.test.ts
@@ -1,0 +1,106 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+/**
+ * B3 / FRI-AUD-005 regression guard.
+ *
+ * Pre-fix state at origin/main < 2026-05-26:
+ *   - hub bootstrap wired `desktopRouteDeps.policies.*` as synthetic-echo
+ *     lambdas that returned `{ policy: req, policyId: idGenerator() }`,
+ *     `{ policy: null }`, `{ policies: [] }`, `{ deleted: true }`, etc.
+ *   - `permissions.respond` echoed the decision; `permissions.listDecisions`
+ *     always returned an empty array.
+ *   - No persistence, no evaluator, no audit/rollback — yet API responses
+ *     looked enforced.
+ *
+ * Post-fix invariant (per POST_RELEASE_DEFAULT_DECISIONS.md B3):
+ *   - All 7 `policies.*` methods throw `DESKTOP_POLICY_NOT_PERSISTED` 503.
+ *   - `permissions.respond` + `permissions.listDecisions` throw
+ *     `DESKTOP_PERMISSION_DECISION_NOT_PERSISTED` 503.
+ *   - `permissions.list` (real OS capability read) is preserved as live.
+ *   - Routes stay registered for contract stability — `friday-desktop-routes.ts`
+ *     is not modified.
+ */
+
+const HUB_PATH = "src/hub/friday-hub-bootstrap.ts" as const;
+const ROUTES_PATH = "src/api/http/routes/friday-desktop-routes.ts" as const;
+
+describe("desktop policy + permission decision fail-closed (B3 / FRI-AUD-005)", () => {
+  const hubSource = readFileSync(HUB_PATH, "utf8");
+  const routesSource = readFileSync(ROUTES_PATH, "utf8");
+
+  it("removes the synthetic-echo policy deps", () => {
+    // Old patterns must be gone from the desktopRouteDeps.policies block.
+    expect(hubSource).not.toContain("{ policy: req, policyId: idGenerator() }");
+    expect(hubSource).not.toContain("{ policy: null } as never");
+    expect(hubSource).not.toContain("{ policies: [] } as never");
+    expect(hubSource).not.toContain("{ rule: req } as never");
+    expect(hubSource).not.toContain("{ removed: true } as never");
+    // `{ deleted: true }` survives in the recordings block (real delete on the
+    // session manager); only the policy-delete synthetic version is gone.
+    // Tight regex check: the policies.delete arrow with the synthetic echo
+    // pattern is gone.
+    expect(hubSource).not.toMatch(
+      /delete\(_policyId, _req\)\s*\{\s*return\s*\{\s*deleted:\s*true\s*\}\s*as\s*never;\s*\}/,
+    );
+  });
+
+  it("removes the synthetic-echo permission decision deps", () => {
+    expect(hubSource).not.toContain('return { decision: (req as unknown as Record<string, unknown>).decision } as never');
+    expect(hubSource).not.toContain("{ decisions: [] } as never");
+  });
+
+  it("introduces typed proof_pending error builders", () => {
+    expect(hubSource).toContain("function createDesktopPolicyNotPersistedError(operation: string): FridayDomainError");
+    expect(hubSource).toContain("function createDesktopPermissionDecisionNotPersistedError(operation: string): FridayDomainError");
+    expect(hubSource).toContain('"DESKTOP_POLICY_NOT_PERSISTED"');
+    expect(hubSource).toContain('"DESKTOP_PERMISSION_DECISION_NOT_PERSISTED"');
+    expect(hubSource).toContain("httpStatus: 503");
+    expect(hubSource).toContain('status: "proof_pending"');
+  });
+
+  it("wires all 7 desktop policy dep methods to throw the proof_pending error", () => {
+    const policyDepThrowPattern = /throw createDesktopPolicyNotPersistedError\("(create|get|list|update|delete|addRule|removeRule)"\)/g;
+    const matches = hubSource.match(policyDepThrowPattern) ?? [];
+    expect(matches).toHaveLength(7);
+  });
+
+  it("wires the synthetic permission-decision deps to throw the proof_pending error", () => {
+    expect(hubSource).toContain('throw createDesktopPermissionDecisionNotPersistedError("respond")');
+    expect(hubSource).toContain('throw createDesktopPermissionDecisionNotPersistedError("listDecisions")');
+  });
+
+  it("preserves permissions.list (real OS capability check) as live", () => {
+    expect(hubSource).toContain("async list() { const perms = await desktopSessionManager!.checkPermissions(); return { permissions: [...perms] }");
+  });
+
+  it("does not modify the route surface (contract stability)", () => {
+    // All 7 policy routes + 3 permission routes remain registered with the
+    // same operationIds. The fix is in the dep wiring layer only.
+    for (const op of [
+      "desktop.policies.create",
+      "desktop.policies.list",
+      "desktop.policies.get",
+      "desktop.policies.update",
+      "desktop.policies.delete",
+      "desktop.policies.rules.create",
+      "desktop.permissions.list",
+      "desktop.permissions.respond",
+      "desktop.permissions.decisions.list",
+    ]) {
+      // Some operationIds use a slightly different name; we just check that
+      // policies + permissions sections are present in the routes file.
+    }
+    expect(routesSource).toContain('"desktop.policies.create"');
+    expect(routesSource).toContain('"desktop.policies.list"');
+    expect(routesSource).toContain('"desktop.policies.get"');
+    expect(routesSource).toContain('"desktop.policies.update"');
+    expect(routesSource).toContain('"desktop.policies.delete"');
+    expect(routesSource).toContain('"desktop.policies.rules.create"');
+  });
+
+  it("anchors the helpers to the audit finding via comment", () => {
+    expect(hubSource).toContain("B3 / FRI-AUD-005 fail-closed");
+    expect(hubSource).toContain("POST_RELEASE_DEFAULT_DECISIONS.md B3");
+  });
+});


### PR DESCRIPTION
## Summary

Closes FRI-AUD-005: hub-bootstrap desktop policy + permission decision dep wiring was synthetic-echo. Routes accepted requests and returned `{ policy: req, policyId: <fresh> }`, `{ policies: [] }`, `{ deleted: true }`, etc., even though no durable storage, evaluator, audit log, or rollback wiring exists. API responses looked enforced; nothing was persisted.

Per `POST_RELEASE_DEFAULT_DECISIONS.md` B3, the deps now fail closed with typed 503 errors:

- `DESKTOP_POLICY_NOT_PERSISTED` on all 7 `policies.{create,get,list,update,delete,addRule,removeRule}`
- `DESKTOP_PERMISSION_DECISION_NOT_PERSISTED` on `permissions.respond` + `permissions.listDecisions`

Both errors include `details: { operation, status: "proof_pending" }`.

3 files, +173 / −9 LOC. No risk-tier change. No route surface change (OpenAPI / `friday-http-route-contract` unchanged).

## Preserved as live

- `permissions.list` — real OS capability check via `desktopSessionManager.checkPermissions`.
- `actions` / `recordings` / `platform` / `elements` deps — all back real `desktopSessionManager` methods.
- All 7 policy routes + 3 permission routes stay registered (contract stability for future implementations of real persistence).

## What changed

**`src/hub/friday-hub-bootstrap.ts`**

- Adds two module-level error builders `createDesktopPolicyNotPersistedError(operation)` and `createDesktopPermissionDecisionNotPersistedError(operation)` near the constants block, each with an anchored comment referencing B3 / FRI-AUD-005 + POST_RELEASE_DEFAULT_DECISIONS B3.
- Replaces the 7 synthetic-echo `policies.*` arrows and the 2 synthetic permission-decision arrows in the `desktopRouteDeps` block with `: never { throw createDesktop...Error("<op>"); }`.

**`test/unit/hub/bootstrap/desktop-policy-fail-closed.test.ts`** (new)

8 source-content regression tests:

1. Synthetic-echo `policies` patterns are absent (`{ policy: req, policyId: idGenerator() }`, `{ policy: null }`, `{ policies: [] }`, `{ rule: req }`, `{ removed: true }`, and the specific `delete(_policyId, _req) { return { deleted: true } }` arrow).
2. Synthetic-echo `permissions.respond` + `permissions.listDecisions` arrows are absent.
3. The new typed error builders exist with the expected code + status + httpStatus 503.
4. All 7 `policies.*` methods throw the policy error (regex matches exactly 7 throws).
5. Both synthetic `permissions.*` deps throw the permission-decision error.
6. `permissions.list` (real OS check) is preserved.
7. The route surface (`friday-desktop-routes.ts`) is unchanged — all `desktop.policies.*` operationIds still registered.
8. The helpers carry anchored audit-finding comments for future readers.

**`CHANGELOG.md` `[1.0.2]`**

Adds a B3 entry under `### Changed` documenting the fail-closed behavior and the explicit "preserved as live" surfaces. B0.5 + B2 entries unchanged.

## What this does NOT change

- Desktop risk-tier semantics (per the `POST_RELEASE_DEFAULT_DECISIONS.md` B3 stop boundary "Do not change desktop risk tiers without user approval").
- Real persistence / evaluator / audit / rollback — those remain `proof_pending`; this PR is the explicit truth-label step before any future implementation work.
- Public release claim — `1.0.1` boundaries preserved; 9 `proof_pending` headlines carried forward.
- Any UI consumer (`git grep "/v1/desktop/policies" ui/` returns empty).

## Local verification

- `npm run typecheck` — 0 errors
- `npx vitest run test/unit/hub/bootstrap/desktop-policy-fail-closed.test.ts` — 8/8 PASS
- `npx vitest run test/unit/hub test/unit/api/http/routes/friday-desktop-routes.test.ts` (blast radius) — 160/160 PASS (13 test files)
- `git diff --check` — clean
- `detect-secrets-hook --baseline .secrets.baseline …` — clean

## Real path execution

The route-layer test at `test/unit/api/http/routes/friday-desktop-routes.test.ts` uses mocked `deps.policies.*` and verifies argument forwarding. After this PR the production wiring of those deps throws the typed 503, so a live call to e.g. `POST /v1/desktop/policies` returns the `DESKTOP_POLICY_NOT_PERSISTED` error code with `httpStatus: 503` and `details.status: "proof_pending"`. The route handler does not catch — it lets the typed error propagate to the HTTP error mapper, matching the existing `HEARTBEAT_UNAVAILABLE 503` / `PLUGIN_NOT_IMPLEMENTED 501` pattern at lines 5538 / 5443–5446 of the same file.

## Test plan

- [ ] All branch-protected required checks green on PR head
- [ ] No regression in `test/unit/hub/` or `friday-desktop-routes.test.ts`
- [ ] Operator authorizes merge (squash, normal path, no `--admin`)
- [ ] B0.5 + B2 + B3 ship together in the next operator-driven `1.0.2` publish

## Refs

- `Friday-capability-wiring-audit-20260525-1813/USER_FACING_TRUTH_GAPS.csv` row FRI-AUD-005
- `Friday-post-release-hardening-plan-20260526/POST_RELEASE_DEFAULT_DECISIONS.md` § B3
- `Friday-post-release-hardening-plan-20260526/BATCH_SPECS.md` § B3 Spec
