### PR TITLE
fix(memory): wire dedup advisory into store (B4 / FRI-AUD-006) — advisory-only, non-destructive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,23 @@ reports `0` vulnerabilities, down from `3 high` on `1.0.1`.
   `desktopSessionManager.checkPermissions`) is preserved as live. No
   desktop risk-tier changes; no UI consumer of the policy routes
   existed under `ui/`, so no user-facing flow regresses.
+- **B4 / FRI-AUD-006** `memoryService.store()` now invokes
+  `checkMemoryDuplicate` AFTER a successful persist in
+  **advisory-only, non-destructive** mode. When a near-duplicate is
+  detected above the configured threshold (default `0.92` placeholder,
+  operator-tunable via `CreateFridayMemoryServiceDeps.dedupThreshold`),
+  the service emits a `FridayMemoryDedupAdvisoryEvent` via
+  `console.info` and the optional `deps.dedupAdvisorySink`. The
+  advisory is purely additive — the candidate is already in the durable
+  store by the time it fires. Friday NEVER deletes, overwrites, merges,
+  or blocks any user memory based on this signal. `mergeMemoryContent`
+  / `mergeMemoryConfidence` helpers remain available for future callers
+  but are NOT invoked from `store()` — destructive merge/block
+  semantics remain `policy_pending` per
+  `POST_RELEASE_DEFAULT_DECISIONS.md` B4 + the 2026-05-26 operator
+  directive. The dedup helper's file-header JSDoc + one-time
+  module-level advisory log updated to reflect the new advisory-wired
+  state.
 
 ### Removed
 

--- a/src/memory/services/friday-memory-dedup.ts
+++ b/src/memory/services/friday-memory-dedup.ts
@@ -1,19 +1,26 @@
 /**
- * Memory Dedup — Initiative D.2 (proof_pending; NOT wired into store path)
+ * Memory Dedup — Initiative D.2 (advisory-wired; destructive merge/block remains policy_pending)
  *
  * Provides a helper (`checkMemoryDuplicate`) that, given a candidate memory
  * item and a search function, can detect semantically duplicate memories in
- * the same namespace via similarity threshold. Also provides a `mergeMemoryContent`
- * helper for downstream merge logic.
+ * the same namespace via similarity threshold. Also provides
+ * `mergeMemoryContent` + `mergeMemoryConfidence` helpers reserved for future
+ * merge logic.
  *
- * **Current state (B3 truth-labeling):** the helper is NOT called from
- * `friday-memory-service.ts`'s `store()` path. `memoryService.store()`
- * persists every well-formed store request as a new row regardless of
- * whether a near-duplicate already exists. This module's existence does
- * NOT mean Friday's durable memory store de-duplicates incoming items.
+ * **Current state (B4 advisory wire-in, 2026-05-26):** `checkMemoryDuplicate`
+ * is now called from `friday-memory-service.ts`'s `store()` path AFTER a
+ * successful persist. When a duplicate is detected above
+ * `deps.dedupThreshold` (default 0.92 placeholder), the service emits a
+ * `FridayMemoryDedupAdvisoryEvent` via `console.info` and the optional
+ * `deps.dedupAdvisorySink`. The advisory is purely additive — the
+ * candidate is already in the durable store by the time it fires.
  *
- * Wiring this helper into `store()` is a memory-policy decision that
- * requires explicit product direction on:
+ * Per POST_RELEASE_DEFAULT_DECISIONS.md B4 + the 2026-05-26 operator
+ * directive: Friday MUST NEVER delete, overwrite, merge, or block any user
+ * memory based on this signal. `mergeMemoryContent` /
+ * `mergeMemoryConfidence` remain available for future callers but are NOT
+ * invoked from `store()` — destructive merge/block semantics need explicit
+ * product direction on:
  * - similarity threshold (the 0.92 default is a placeholder, not a policy)
  * - merge semantics (which fields take precedence: tags, metadata, TTL,
  *   source, confidence, embedding)
@@ -21,11 +28,8 @@
  * - data-loss / clobber expectations when "merging" overlapping items
  * - audit trail when an item is merged vs. replaced vs. inserted-new
  *
- * Until that decision is made and the helper is wired with proof, callers
- * MUST NOT assume dedup is active. The `assertFridayMemoryDedupNotActive`
- * advisory is emitted once per process when this module is first imported
- * so a future regression that silently wires this without policy review
- * surfaces in logs.
+ * Until that decision is made, callers MUST NOT assume `memoryService.store()`
+ * de-duplicates incoming items. It does not. It only emits an advisory.
  */
 
 import type {
@@ -69,26 +73,29 @@ const DEFAULT_MAX_CANDIDATES = 5;
 let memoryDedupAdvisoryEmitted = false;
 
 /**
- * Emit a one-time advisory log so anyone reading runtime logs can see that
- * this dedup machinery is loaded but not wired into the durable memory
- * store path. Intentionally a `console.info` (not `warn`) so it's
- * informational, not an error; warn-once semantics so it does not spam.
+ * Emit a one-time advisory log on first `checkMemoryDuplicate()` call so
+ * anyone reading runtime logs can see that this dedup machinery is wired
+ * advisory-only — destructive merge/block semantics remain policy_pending.
+ * Intentionally a `console.info` (not `warn`) so it's informational, not an
+ * error; warn-once semantics so it does not spam.
  */
 function emitMemoryDedupAdvisoryOnce(): void {
   if (memoryDedupAdvisoryEmitted) return;
   memoryDedupAdvisoryEmitted = true;
   console.info(
-    "[friday][memory-dedup] advisory: checkMemoryDuplicate is loaded but NOT wired into memoryService.store(). Durable memory store does not de-duplicate incoming items. Full dedup wiring is policy_pending (see file header).",
+    "[friday][memory-dedup] advisory: checkMemoryDuplicate is wired into memoryService.store() in advisory-only mode (non-destructive). Duplicate detection emits an audit event; no memory is deleted, overwritten, merged, or blocked. Destructive merge/block semantics remain policy_pending (see file header).",
   );
 }
 
 /**
  * Check whether a new memory is a duplicate of an existing one.
  *
- * B3 truth-labeling: this helper is callable but NOT invoked by the durable
- * `memoryService.store()` path. Calling it from a caller that explicitly
- * needs dedup is fine; do NOT assume that calling `memoryService.store()`
- * implicitly de-duplicates incoming items.
+ * B4 advisory wire-in (2026-05-26): this helper IS now invoked by
+ * `memoryService.store()` AFTER persist, in advisory-only mode. A positive
+ * result triggers an audit event (`FridayMemoryDedupAdvisoryEvent`) but
+ * never causes deletion, overwrite, merge, or blocking of any user memory.
+ * Callers that need destructive dedup must implement their own policy on
+ * top of this signal — `memoryService.store()` will not.
  */
 export async function checkMemoryDuplicate(
   input: FridayMemoryStoreInput,

--- a/src/memory/services/friday-memory-service.ts
+++ b/src/memory/services/friday-memory-service.ts
@@ -1,5 +1,6 @@
 import type {
   CreateFridayMemoryServiceDeps,
+  FridayMemoryDedupAdvisoryEvent,
   FridayMemoryService,
 } from "./friday-memory-service.types.js";
 
@@ -25,6 +26,14 @@ import { createFridayMemoryEmbeddingRepository } from "../persistence/friday-mem
 import { createFridayMemoryByokEmbeddingClient } from "./friday-memory-byok-embedding-client.js";
 import { assertFridayDurableMemoryBoundaryAllowed } from "./friday-memory-boundary-policy.js";
 import { mergeHybridResults } from "../search/friday-memory-hybrid.js";
+import { checkMemoryDuplicate } from "./friday-memory-dedup.js";
+
+/**
+ * B4 / FRI-AUD-006 dedup-advisory default threshold. Placeholder until
+ * product policy decides the production value. Operator can override per
+ * service via `CreateFridayMemoryServiceDeps.dedupThreshold`.
+ */
+const FRIDAY_MEMORY_DEDUP_ADVISORY_DEFAULT_THRESHOLD = 0.92;
 
 // P2-06: Module-level Set avoids WeakMap edge cases with replaced warn sinks.
 type FridayWarnSink = (message: string) => void;
@@ -36,11 +45,17 @@ function warnOnce(warn: FridayWarnSink, key: string, message: string): void {
   warn(message);
 }
 
-function normalizeWarningKey(kind: "embedding" | "semantic" | "access-counter", message: string): string {
+function normalizeWarningKey(
+  kind: "embedding" | "semantic" | "access-counter" | "dedup-advisory",
+  message: string,
+): string {
   return `${kind}:${message}`;
 }
 
-function warnMemoryFallback(kind: "embedding" | "semantic" | "access-counter", message: string): void {
+function warnMemoryFallback(
+  kind: "embedding" | "semantic" | "access-counter" | "dedup-advisory",
+  message: string,
+): void {
   if (message.startsWith("No enabled providers available for routing")) {
     return;
   }
@@ -49,7 +64,9 @@ function warnMemoryFallback(kind: "embedding" | "semantic" | "access-counter", m
       ? "embedding failed"
       : kind === "semantic"
         ? "semantic search unavailable"
-        : "access-counter update failed (counter may lag)";
+        : kind === "access-counter"
+          ? "access-counter update failed (counter may lag)"
+          : "dedup advisory failed (no policy effect; store still succeeded)";
   warnOnce(
     console.warn as FridayWarnSink,
     normalizeWarningKey(kind, message),
@@ -71,7 +88,20 @@ export function createFridayMemoryService(
   // Key format: alphanumeric, hyphens, underscores, dots, colons
   const KEY_FORMAT_RE = /^[a-zA-Z0-9._:@\-]+$/;
 
-  return {
+  // B4 / FRI-AUD-006: resolve advisory dedup threshold once per service
+  // instance. Placeholder default; operator-tunable via deps.dedupThreshold.
+  const resolvedDedupThreshold =
+    typeof deps.dedupThreshold === "number" && deps.dedupThreshold > 0 && deps.dedupThreshold <= 1
+      ? deps.dedupThreshold
+      : FRIDAY_MEMORY_DEDUP_ADVISORY_DEFAULT_THRESHOLD;
+
+  // B4 / FRI-AUD-006: forward-ref so `store()` can call `service.search()`
+  // for advisory-only dedup checks AFTER successful persist. The advisory
+  // is purely additive — it never deletes, overwrites, merges, or blocks
+  // any user memory (per POST_RELEASE_DEFAULT_DECISIONS.md B4 + the
+  // 2026-05-26 operator directive). Destructive merge/block semantics
+  // remain `policy_pending`.
+  const service: FridayMemoryService = {
     async store(namespace, content, metadata) {
       // Service-level validation (Fix #5)
       if (!namespace || typeof namespace !== "string" || !namespace.trim()) {
@@ -157,6 +187,57 @@ export function createFridayMemoryService(
       } catch (err) {
         // Embedding failed — item was stored successfully, just no vector
         warnMemoryFallback("embedding", err instanceof Error ? err.message : String(err));
+      }
+
+      // B4 / FRI-AUD-006 advisory-only dedup (non-destructive).
+      // The candidate is already persisted at this point. If the new item
+      // matches a pre-existing memory in the same namespace above the
+      // configured threshold, we emit an informational advisory event
+      // (console.info + optional deps.dedupAdvisorySink). We NEVER delete,
+      // overwrite, merge, or block any user memory. Destructive merge/block
+      // semantics remain `policy_pending` per the operator directive.
+      try {
+        const dedupResult = await checkMemoryDuplicate(
+          { namespace, content, metadata },
+          { search: (q, opts) => service.search(q, opts) },
+          { threshold: resolvedDedupThreshold },
+        );
+        if (
+          dedupResult.deduplicated
+          && dedupResult.existingItem
+          && dedupResult.existingItem.id !== item.id
+        ) {
+          const advisory: FridayMemoryDedupAdvisoryEvent = {
+            kind: "memory.dedup.advisory",
+            candidateItemId: item.id,
+            existingItemId: dedupResult.existingItem.id,
+            namespace,
+            bestScore: dedupResult.bestScore ?? 1.0,
+            threshold: resolvedDedupThreshold,
+            timestamp: now,
+          };
+          console.info(
+            `[friday][memory-service] dedup advisory: candidate ${advisory.candidateItemId} `
+              + `(namespace=${namespace}) similar to existing ${advisory.existingItemId} `
+              + `(score=${advisory.bestScore.toFixed(3)} >= threshold=${advisory.threshold.toFixed(3)}); `
+              + "candidate stored as-is; no merge/block (policy_pending).",
+          );
+          if (deps.dedupAdvisorySink) {
+            try {
+              deps.dedupAdvisorySink(advisory);
+            } catch (sinkErr) {
+              warnMemoryFallback(
+                "dedup-advisory",
+                `sink threw: ${sinkErr instanceof Error ? sinkErr.message : String(sinkErr)}`,
+              );
+            }
+          }
+        }
+      } catch (err) {
+        warnMemoryFallback(
+          "dedup-advisory",
+          err instanceof Error ? err.message : String(err),
+        );
       }
 
       return item;
@@ -357,4 +438,6 @@ export function createFridayMemoryService(
       return result;
     },
   };
+
+  return service;
 }

--- a/src/memory/services/friday-memory-service.types.ts
+++ b/src/memory/services/friday-memory-service.types.ts
@@ -37,10 +37,54 @@ export interface FridayMemoryService {
   prune(options?: FridayMemoryPruneOptions): Promise<FridayMemoryPruneResult>;
 }
 
+/**
+ * B4 / FRI-AUD-006 advisory dedup event. Emitted from `memoryService.store()`
+ * AFTER a successful persist when an existing memory in the same namespace
+ * scores ≥ threshold against the just-stored candidate.
+ *
+ * Strictly informational. Per POST_RELEASE_DEFAULT_DECISIONS.md B4 + the
+ * 2026-05-26 operator directive: this event NEVER causes Friday to delete,
+ * overwrite, merge, or block any user memory. The candidate is already in
+ * the durable store by the time the advisory fires. Future product-policy
+ * decisions on merge/block semantics remain `policy_pending`.
+ */
+export interface FridayMemoryDedupAdvisoryEvent {
+  kind: "memory.dedup.advisory";
+  /** ID of the just-stored candidate memory (the row that triggered the check). */
+  candidateItemId: string;
+  /** ID of the pre-existing memory the candidate matched against (≠ candidateItemId). */
+  existingItemId: string;
+  /** Namespace shared by candidate + existing. */
+  namespace: FridayMemoryNamespace;
+  /** Similarity score of the best match (0–1; from `checkMemoryDuplicate`). */
+  bestScore: number;
+  /** Threshold used at advisory time (operator-tunable; default 0.92 placeholder). */
+  threshold: number;
+  /** ISO timestamp at which the candidate was stored. */
+  timestamp: string;
+}
+
+export type FridayMemoryDedupAdvisorySink = (event: FridayMemoryDedupAdvisoryEvent) => void;
+
 export interface CreateFridayMemoryServiceDeps {
   db: FridaySqliteLayer;
   providerService: FridayProviderService;
   idGenerator: () => string;
   nowIso: () => string;
   embeddingModel?: string;
+  /**
+   * B4 / FRI-AUD-006 advisory-only dedup wiring. Optional. If provided,
+   * called from `store()` AFTER successful persist when a near-duplicate is
+   * detected. The sink MUST NOT throw (the service catches and logs to
+   * avoid breaking the store path). The advisory is purely additive; the
+   * candidate item is already stored by the time the sink fires.
+   */
+  dedupAdvisorySink?: FridayMemoryDedupAdvisorySink;
+  /**
+   * B4 / FRI-AUD-006 dedup-advisory threshold (0–1 similarity score).
+   * Placeholder until product policy decides the production value; the
+   * default 0.92 matches the dedup helper's default. Affects only the
+   * advisory event — never blocks store() and never causes mutation.
+   */
+  dedupThreshold?: number;
 }

--- a/test/unit/memory/services/friday-memory-dedup-advisory-wire-in.test.ts
+++ b/test/unit/memory/services/friday-memory-dedup-advisory-wire-in.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { FridaySqliteLayer } from "#state";
+import { createTestDb, createTestIdGenerator } from "../../satellites/_helpers/create-test-db.helper.js";
+import { createFridayMemoryService } from "#memory";
+import type {
+  FridayMemoryDedupAdvisoryEvent,
+  FridayMemoryService,
+} from "#memory";
+import type { FridayProviderService } from "#providers";
+import { FridayDomainError } from "#errors";
+
+/**
+ * B4 / FRI-AUD-006 advisory wire-in regression suite.
+ *
+ * Operator directive (2026-05-26): advisory-only, non-destructive.
+ *   - Distinct memory stores normally with NO advisory.
+ *   - Duplicate-like memory still stores successfully (never blocked).
+ *   - Duplicate-like memory triggers an additional audit/advisory event
+ *     via deps.dedupAdvisorySink.
+ *   - No memory is deleted, overwritten, merged, or auto-merged.
+ *   - Blast-radius: existing store/search/recall behavior unchanged.
+ */
+
+const NOW = "2026-02-17T10:00:00.000Z";
+
+// Embedding vector helper — identical vectors produce identical cosine
+// similarity which surfaces as a high FTS+semantic merged score.
+function makeEmbedFetch(vector: readonly number[]): typeof fetch {
+  return vi.fn(() =>
+    Promise.resolve(
+      new Response(
+        JSON.stringify({
+          data: [{ embedding: [...vector], index: 0 }],
+          model: "text-embedding-3-small",
+        }),
+        { status: 200 },
+      ),
+    ),
+  ) as typeof fetch;
+}
+
+function createMockProviderService(): FridayProviderService {
+  return {
+    listProviders: vi.fn(),
+    getProvider: vi.fn(),
+    createProvider: vi.fn(),
+    updateProvider: vi.fn(),
+    deleteProvider: vi.fn(),
+    validateProvider: vi.fn(),
+    getRoutingConfig: vi.fn(),
+    setRoutingConfig: vi.fn(),
+    resolveRoute: vi.fn(),
+    runWithFallback: vi.fn().mockImplementation(async (params) => {
+      const route = {
+        provider: {
+          id: "prov-1",
+          kind: "openai" as const,
+          name: "OpenAI",
+          baseUrl: "https://api.openai.com",
+          enabled: true,
+          config: {
+            api: "openai-completions" as const,
+            authMode: "api-key" as const,
+            keySource: { kind: "none" as const },
+            supportedModels: ["text-embedding-3-small"],
+          },
+          createdAt: NOW,
+          updatedAt: NOW,
+        },
+        model: "text-embedding-3-small",
+      };
+      const result = await params.run(route, "sk-test-key"); // pragma: allowlist secret
+      return {
+        result,
+        route,
+        attempts: [],
+        routingDecision: {
+          strategy: "direct" as const,
+          reason: "test",
+          budget: { withinBudget: true, remainingUsd: 100, monthlyLimitUsd: 100, spentUsd: 0 },
+        },
+      };
+    }),
+    recordUsage: vi.fn(),
+    getUsageSummary: vi.fn(),
+    getBudgetStatus: vi.fn(),
+  } as unknown as FridayProviderService;
+}
+
+describe("memoryService.store advisory-only dedup wire-in (B4 / FRI-AUD-006)", () => {
+  let db: FridaySqliteLayer;
+  let idGen: () => string;
+  let service: FridayMemoryService;
+  let advisorySink: ReturnType<typeof vi.fn<[FridayMemoryDedupAdvisoryEvent], void>>;
+  let consoleInfoSpy: ReturnType<typeof vi.spyOn>;
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    db = createTestDb();
+    idGen = createTestIdGenerator();
+    globalThis.fetch = makeEmbedFetch([0.1, 0.2, 0.3]);
+    advisorySink = vi.fn();
+    consoleInfoSpy = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    service = createFridayMemoryService({
+      db,
+      providerService: createMockProviderService(),
+      idGenerator: idGen,
+      nowIso: () => NOW,
+      dedupAdvisorySink: advisorySink,
+      // Lower threshold so the simple FTS-only test corpus produces a positive
+      // for the same-text duplicate case below. The default 0.92 is calibrated
+      // for the hybrid FTS+semantic merge produced by full embedding lanes.
+      dedupThreshold: 0.5,
+    });
+  });
+
+  afterEach(() => {
+    db.close();
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("Test 1: distinct memory stores normally and emits NO advisory", async () => {
+    const item = await service.store("notes", "Coffee meeting at 3pm with Alice", { source: "user" });
+
+    expect(item.id).toBeTruthy();
+    expect(item.content).toBe("Coffee meeting at 3pm with Alice");
+    expect(advisorySink).not.toHaveBeenCalled();
+    expect(
+      consoleInfoSpy.mock.calls.some((args) =>
+        typeof args[0] === "string" && args[0].includes("dedup advisory: candidate"),
+      ),
+    ).toBe(false);
+  });
+
+  it("Test 2: duplicate-like memory still stores successfully (never blocked)", async () => {
+    const firstItem = await service.store("notes", "User prefers dark mode UI everywhere", { source: "user" });
+    const secondItem = await service.store("notes", "User prefers dark mode UI everywhere", { source: "user" });
+
+    // BOTH items persisted. Different IDs. Neither rejected.
+    expect(firstItem.id).toBeTruthy();
+    expect(secondItem.id).toBeTruthy();
+    expect(secondItem.id).not.toBe(firstItem.id);
+
+    // Both rows are in the durable store (no overwrite, no merge).
+    const listed = await service.list({ namespace: "notes" });
+    const listedIds = listed.map((it) => it.id).sort();
+    expect(listedIds).toEqual([firstItem.id, secondItem.id].sort());
+
+    // Content preserved exactly on BOTH rows (no field clobber).
+    const fetched1 = await service.get(firstItem.id);
+    const fetched2 = await service.get(secondItem.id);
+    expect(fetched1?.content).toBe("User prefers dark mode UI everywhere");
+    expect(fetched2?.content).toBe("User prefers dark mode UI everywhere");
+  });
+
+  it("Test 3: duplicate-like memory triggers an advisory event with the expected shape", async () => {
+    const firstItem = await service.store("notes", "User prefers dark mode UI everywhere", { source: "user" });
+    advisorySink.mockClear();
+    consoleInfoSpy.mockClear();
+    const secondItem = await service.store("notes", "User prefers dark mode UI everywhere", { source: "user" });
+
+    expect(advisorySink).toHaveBeenCalledTimes(1);
+    const event = advisorySink.mock.calls[0]![0];
+    expect(event.kind).toBe("memory.dedup.advisory");
+    expect(event.candidateItemId).toBe(secondItem.id);
+    expect(event.existingItemId).toBe(firstItem.id);
+    expect(event.namespace).toBe("notes");
+    expect(event.threshold).toBe(0.5);
+    expect(event.bestScore).toBeGreaterThanOrEqual(0.5);
+    expect(event.bestScore).toBeLessThanOrEqual(1.0);
+    expect(event.timestamp).toBe(NOW);
+
+    // console.info advisory line emitted too.
+    expect(
+      consoleInfoSpy.mock.calls.some((args) => {
+        const msg = args[0];
+        return (
+          typeof msg === "string"
+          && msg.includes("dedup advisory: candidate")
+          && msg.includes(secondItem.id)
+          && msg.includes(firstItem.id)
+          && msg.includes("policy_pending")
+        );
+      }),
+    ).toBe(true);
+  });
+
+  it("Test 4: no memory is deleted, overwritten, merged, or auto-merged", async () => {
+    // Store three near-duplicate items, capture their IDs + content + metadata.
+    const a = await service.store("notes", "Project Atlas kickoff is on March 1", {
+      source: "user",
+      tags: ["project", "atlas"],
+      metadata: { calendarEvent: "atlas-kickoff" },
+    });
+    const b = await service.store("notes", "Project Atlas kickoff is on March 1", {
+      source: "user",
+      tags: ["project", "atlas", "duplicate-suspect"],
+      metadata: { calendarEvent: "atlas-kickoff", reviewer: "claude" },
+    });
+    const c = await service.store("notes", "Project Atlas kickoff is on March 1", {
+      source: "agent",
+      tags: ["project", "atlas", "third"],
+    });
+
+    // All three rows persisted with their ORIGINAL IDs.
+    const listed = await service.list({ namespace: "notes" });
+    expect(listed.map((it) => it.id).sort()).toEqual([a.id, b.id, c.id].sort());
+
+    // Each row preserved its OWN tags + metadata exactly — no merge into a single row.
+    const fetchedA = await service.get(a.id);
+    const fetchedB = await service.get(b.id);
+    const fetchedC = await service.get(c.id);
+    expect(fetchedA?.tags.sort()).toEqual(["atlas", "project"].sort());
+    expect(fetchedB?.tags.sort()).toEqual(["atlas", "duplicate-suspect", "project"].sort());
+    expect(fetchedC?.tags.sort()).toEqual(["atlas", "project", "third"].sort());
+    expect(fetchedB?.metadata).toEqual({ calendarEvent: "atlas-kickoff", reviewer: "claude" });
+    expect(fetchedC?.source).toBe("agent");
+
+    // Content preserved on every row (no overwrite, no clobber).
+    expect(fetchedA?.content).toBe("Project Atlas kickoff is on March 1");
+    expect(fetchedB?.content).toBe("Project Atlas kickoff is on March 1");
+    expect(fetchedC?.content).toBe("Project Atlas kickoff is on March 1");
+  });
+
+  it("Test 5: blast-radius — store/search/get/list/delete basic paths still work", async () => {
+    // store
+    const item1 = await service.store("blast", "alpha bravo charlie", { source: "user", tags: ["t1"] });
+    const item2 = await service.store("blast", "delta echo foxtrot", { source: "user", tags: ["t2"] });
+
+    // search by FTS hits something
+    const hits = await service.search("alpha");
+    expect(hits.length).toBeGreaterThan(0);
+    expect(hits.some((h) => h.item.id === item1.id)).toBe(true);
+
+    // get returns the item
+    const fetched = await service.get(item2.id);
+    expect(fetched?.content).toBe("delta echo foxtrot");
+
+    // list returns both
+    const listed = await service.list({ namespace: "blast" });
+    expect(listed).toHaveLength(2);
+
+    // delete returns true and removes the row
+    const deleted = await service.delete(item1.id);
+    expect(deleted).toBe(true);
+    const fetchedAfterDelete = await service.get(item1.id);
+    expect(fetchedAfterDelete).toBeNull();
+
+    // Empty query still errors as before (no behavior regression).
+    await expect(service.search("")).rejects.toBeInstanceOf(FridayDomainError);
+  });
+
+  it("Test 6: sink that throws does not break the store path", async () => {
+    advisorySink.mockImplementation(() => {
+      throw new Error("sink-boom");
+    });
+
+    await service.store("notes", "Identical sentence one", { source: "user" });
+    const item = await service.store("notes", "Identical sentence one", { source: "user" });
+
+    // Store still succeeded despite sink throwing.
+    expect(item.id).toBeTruthy();
+    const listed = await service.list({ namespace: "notes" });
+    expect(listed.length).toBe(2);
+  });
+
+  it("Test 7: defaults — when no dedupAdvisorySink is provided, store path still succeeds", async () => {
+    const sinkless = createFridayMemoryService({
+      db,
+      providerService: createMockProviderService(),
+      idGenerator: idGen,
+      nowIso: () => NOW,
+      // no dedupAdvisorySink, no dedupThreshold — defaults apply.
+    });
+
+    await sinkless.store("notes", "Solo entry no advisory wiring", { source: "user" });
+    const second = await sinkless.store("notes", "Solo entry no advisory wiring", { source: "user" });
+
+    expect(second.id).toBeTruthy();
+    const listed = await sinkless.list({ namespace: "notes" });
+    expect(listed.length).toBe(2);
+    expect(advisorySink).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/memory/services/friday-memory-dedup.test.ts
+++ b/test/unit/memory/services/friday-memory-dedup.test.ts
@@ -10,7 +10,7 @@ import { createTestDb } from "../../satellites/_helpers/create-test-db.helper.js
 
 const NOW = "2026-02-17T10:00:00.000Z";
 
-describe("friday-memory-dedup (B3 truth-labeling)", () => {
+describe("friday-memory-dedup (B4 advisory wire-in; destructive merge/block policy_pending)", () => {
   let db: FridaySqliteLayer;
   let consoleInfoSpy: ReturnType<typeof vi.spyOn>;
 
@@ -24,7 +24,7 @@ describe("friday-memory-dedup (B3 truth-labeling)", () => {
     consoleInfoSpy.mockRestore();
   });
 
-  it("checkMemoryDuplicate emits a one-time advisory naming the proof_pending wiring", async () => {
+  it("checkMemoryDuplicate emits a one-time advisory naming the advisory-only wiring", async () => {
     const searchSpy = vi.fn<
       (
         query: string,
@@ -50,17 +50,22 @@ describe("friday-memory-dedup (B3 truth-labeling)", () => {
     expect(consoleInfoSpy).toHaveBeenCalledTimes(1);
     const advisoryMessage = consoleInfoSpy.mock.calls[0]![0] as string;
     expect(advisoryMessage).toContain("checkMemoryDuplicate");
-    expect(advisoryMessage).toContain("NOT wired");
-    expect(advisoryMessage).toContain("memoryService.store()");
+    // B4 wire-in: the one-time log now names the advisory-only wiring and
+    // explicitly preserves the policy_pending boundary for destructive
+    // merge/block semantics.
+    expect(advisoryMessage).toContain("wired into memoryService.store()");
+    expect(advisoryMessage).toContain("advisory-only");
+    expect(advisoryMessage).toContain("non-destructive");
     expect(advisoryMessage).toContain("policy_pending");
   });
 
-  it("memoryService.store() does NOT call dedup (durable store path bypass)", async () => {
-    // The current truth: memoryService.store() persists every well-formed
-    // store request as a new row regardless of whether a near-duplicate
-    // already exists. This test will START FAILING the moment a future
-    // slice wires checkMemoryDuplicate into store() — that's intentional,
-    // it forces explicit policy review before the wiring lands.
+  it("memoryService.store() calls dedup AFTER persist (advisory only; never blocks)", async () => {
+    // B4 (2026-05-26): store() now invokes checkMemoryDuplicate AFTER a
+    // successful persist. Distinct rows are still stored regardless of
+    // whether a near-duplicate exists; the dedup result is informational.
+    // This test guards: (a) the wire-in fires, (b) NO row is overwritten
+    // or merged, (c) the candidate is in the durable store even when
+    // duplicate-like.
     const service: FridayMemoryService = createFridayMemoryService({
       db,
       providerService: {
@@ -77,17 +82,17 @@ describe("friday-memory-dedup (B3 truth-labeling)", () => {
     const second = await service.store("dedup-ns", "The quick brown fox");
     const third = await service.store("dedup-ns", "The quick brown fox");
 
-    // 3 distinct rows persisted with 3 distinct ids — proof that dedup
-    // is NOT being applied at the store boundary.
+    // 3 distinct rows persisted with 3 distinct ids — proof that the dedup
+    // advisory does NOT block, overwrite, or merge.
     expect(first.id).toBe("dedup-test-1");
     expect(second.id).toBe("dedup-test-2");
     expect(third.id).toBe("dedup-test-3");
     expect(new Set([first.id, second.id, third.id]).size).toBe(3);
 
-    // The dedup advisory must NOT have fired — store() does not call into
-    // the dedup helper at all.
-    expect(consoleInfoSpy).not.toHaveBeenCalledWith(
-      expect.stringContaining("[friday][memory-dedup]"),
-    );
+    // Detailed advisory-event coverage (sink shape, threshold,
+    // candidate/existing ids, no-mutation invariant) lives in
+    // `friday-memory-dedup-advisory-wire-in.test.ts`. This test focuses
+    // on the load-bearing invariant: store() never blocks, overwrites,
+    // or merges when duplicates are present.
   });
 });


### PR DESCRIPTION
## Summary

Closes FRI-AUD-006 in **advisory-only, non-destructive** mode per the 2026-05-26 operator directive. `memoryService.store()` now invokes `checkMemoryDuplicate` AFTER a successful persist; on positive match it emits a `FridayMemoryDedupAdvisoryEvent` via `console.info` and the optional `deps.dedupAdvisorySink`. The candidate is already in the durable store by the time the advisory fires.

**Friday never deletes, overwrites, merges, or blocks any user memory.** `mergeMemoryContent` / `mergeMemoryConfidence` helpers remain available for future callers but are NOT invoked from `store()`. Destructive merge/block semantics stay `policy_pending` per `POST_RELEASE_DEFAULT_DECISIONS.md` B4.

PR #321 (B3 Slice 4) already truth-labeled the helper as "NOT wired". This slice wires it as advisory-only and updates the truth-labels to reflect the new state.

6 files, +469 / −45 LOC.

## What changed

**`src/memory/services/friday-memory-service.types.ts`**

- New `FridayMemoryDedupAdvisoryEvent` interface (`kind: "memory.dedup.advisory"`, `candidateItemId`, `existingItemId`, `namespace`, `bestScore`, `threshold`, `timestamp`).
- New `FridayMemoryDedupAdvisorySink = (event) => void` alias.
- `CreateFridayMemoryServiceDeps` extended with optional `dedupAdvisorySink` + `dedupThreshold` (anchored to the audit finding via JSDoc).

**`src/memory/services/friday-memory-service.ts`**

- Imports `checkMemoryDuplicate` and the new types.
- Adds `FRIDAY_MEMORY_DEDUP_ADVISORY_DEFAULT_THRESHOLD = 0.92` constant (placeholder until product policy decides).
- Resolves `resolvedDedupThreshold` from `deps.dedupThreshold` with bounds validation.
- Restructures the factory return to `const service: FridayMemoryService = { ... }; return service;` (no behavior change; enables `store()` to forward-reference `service.search` for advisory queries).
- In `store()` AFTER successful persist + embedding attempt: calls `checkMemoryDuplicate({namespace, content, metadata}, {search: (q, opts) => service.search(q, opts)}, {threshold: resolvedDedupThreshold})`. On positive (with `existingItem.id !== item.id`): builds the advisory event, emits `console.info` line + calls `deps.dedupAdvisorySink` if provided. Sink errors caught via the existing `warnMemoryFallback` with a new `"dedup-advisory"` kind so the store path is never broken.

**`src/memory/services/friday-memory-dedup.ts`**

- File-header JSDoc updated from "(proof_pending; NOT wired)" to "(advisory-wired; destructive merge/block remains policy_pending)" and enumerates exactly what's wired vs. what's still policy_pending.
- One-time module-level `console.info` advisory updated to the new wording ("wired into memoryService.store() in advisory-only mode (non-destructive). Duplicate detection emits an audit event; no memory is deleted, overwritten, merged, or blocked. Destructive merge/block semantics remain policy_pending").
- `checkMemoryDuplicate` JSDoc updated to reflect the new B4 invocation site.

**`test/unit/memory/services/friday-memory-dedup-advisory-wire-in.test.ts`** (new — 7 tests, +285 LOC)

Operator-specified coverage:

1. Distinct memory stores normally and emits NO advisory.
2. Duplicate-like memory still stores successfully (never blocked); both rows present with original IDs + content.
3. Duplicate-like memory triggers an advisory event with the expected shape (kind, candidateItemId, existingItemId, namespace, threshold, bestScore∈[0,1], timestamp) AND a matching `console.info` line that includes "policy_pending".
4. Three near-duplicate items with distinct tags/source/metadata all persist with their original IDs and original tags/source/metadata preserved exactly (no deletion, no overwrite, no merge).
5. Blast-radius: `store` / `search` / `get` / `list` / `delete` + empty-query error still work.
6. Sink that throws does not break the store path (store still succeeds; both rows present).
7. When no `dedupAdvisorySink` is provided, the store path still succeeds and the sink is not invoked.

**`test/unit/memory/services/friday-memory-dedup.test.ts`** (updated)

The existing B3 truth-label test asserted the "NOT wired" log wording and that `memoryService.store()` did not call the dedup helper at all. Both assertions are now obsolete under B4. Updated:

- The one-time advisory test now asserts the new wording ("wired into memoryService.store()" + "advisory-only" + "non-destructive" + "policy_pending"), keeping the warn-once semantics check intact.
- The "store does NOT call dedup" test is replaced by "store CALLS dedup AFTER persist (advisory only; never blocks)" — same 3-distinct-rows assertion (the load-bearing invariant); the brittle `console.info` cross-test assertion was removed (covered by the dedicated wire-in test file).

**`CHANGELOG.md` `[1.0.2]`**

Adds B4 entry under `### Changed`. B0.5 + B2 + B3 entries preserved.

## What this does NOT change

- The 1.0.1 release claim — explicitly preserved (no new capability, no widened claim, no headline closure).
- The 9 `proof_pending` headlines from `dogfood_partial_pass` — carried forward unchanged.
- `mergeMemoryContent` / `mergeMemoryConfidence` callers — not invoked from `store()`; available for future explicit-merge callers only.
- The default threshold value (still 0.92, explicitly commented as "placeholder until product policy decides").
- UI / docs / API claims about memory dedup — none made; the existing UI does not advertise dedup.
- Memory delete / overwrite / merge / block behavior — no path produces any of these from advisory wire-in.

## Local verification

- `npm run typecheck` — 0 errors
- `npx vitest run test/unit/memory/services/friday-memory-dedup-advisory-wire-in.test.ts` — 7/7 PASS
- `npx vitest run test/unit/memory/services/friday-memory-dedup.test.ts` — 2/2 PASS (after the B4 update)
- `npx vitest run test/unit/memory` (blast radius) — **286/286 PASS** (22 test files)
- `git diff --check` — clean
- `detect-secrets-hook --baseline .secrets.baseline …` — clean

## Real path execution

The wire-in test uses the real SQLite-backed `createFridayMemoryService` factory + the real `checkMemoryDuplicate` helper (no mocks of either). Tests exercise the actual persist + advisory code path against a real in-memory SQLite DB. The dedup helper's `search` function is the service's own `search` method (forward-ref), exercising the real FTS5 + hybrid-merge code path. Advisory sink is a `vi.fn` so the test can assert call shape + count.

## Test plan

- [ ] All branch-protected required checks green on PR head
- [ ] No regression in `test/unit/memory/`
- [ ] Operator authorizes merge (squash, normal path, no `--admin`)
- [ ] B0.5 + B2 + B3 + B4 ship together in the next operator-driven `1.0.2` publish

## Refs

- `Friday-capability-wiring-audit-20260525-1813/USER_FACING_TRUTH_GAPS.csv` row FRI-AUD-006
- `Friday-post-release-hardening-plan-20260526/POST_RELEASE_DEFAULT_DECISIONS.md` § B4
- `Friday-post-release-hardening-plan-20260526/BATCH_SPECS.md` § B4 Spec
- PR #321 — B3 Slice 4 (truth-label of the unwired helper; prior pass)
