### PR TITLE
chore(hub): rename createStubConfigManager → createPersistentConfigManager (B9 / FRI-AUD-021)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,20 @@ reports `0` vulnerabilities, down from `3 high` on `1.0.1`.
   directive. The dedup helper's file-header JSDoc + one-time
   module-level advisory log updated to reflect the new advisory-wired
   state.
+- **B9 / FRI-AUD-021** Renamed `createStubConfigManager` →
+  `createPersistentConfigManager` in `src/hub/bootstrap/hub-helpers.ts`
+  (+ re-export in `src/hub/bootstrap/index.ts` + call site in
+  `src/hub/friday-hub-bootstrap.ts`). The "stub" name was stale: the
+  implementation actually persists config snapshots + revisions in
+  SQLite via `hub_settings` and the `/v1/config/*` HTTP routes are
+  wired into the API runtime. The hub-bootstrap comment block was
+  updated to drop the stale "intentionally stubbed for v0.4.x" and
+  "Config mutations via API silently no-ops" wording and to explicitly
+  distinguish the now-truthfully-named persistent configManager from
+  the still-partial-stub `createStubMemoryState` (which has 4 real
+  methods + 4 no-op methods with zero production consumers; interface
+  narrowing is a carry-forward code-hygiene item documented in
+  `B5_B6_B8_VERIFIED.md` § "FRI-AUD-022"). No runtime behavior change.
 
 ### Removed
 

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -858,7 +858,17 @@ function mapConfigValidationError(error: unknown): {
   }];
 }
 
-export function createStubConfigManager(
+/**
+ * B9 / FRI-AUD-021 truth-label rename (2026-05-26): renamed from the prior
+ * misleading "stub" name. This implementation actually persists config
+ * snapshots + revisions in SQLite (via `stateRuntime.sqlite.withWrite-
+ * Transaction` against the `hub_settings` table) and the `/v1/config/*`
+ * HTTP routes are wired into the API runtime. Mutations are NOT no-ops.
+ * The truthful "Persistent" name matches runtime behavior so future
+ * inventories + grep readers do not confuse this with the still-partially-
+ * stub `createStubMemoryState`.
+ */
+export function createPersistentConfigManager(
   config: { stateDir?: string; workspaceRoot?: string; skillDirs: string[] },
   stateRuntime: FridayStateRuntime,
 ): FridayHubConfigManagerService {

--- a/src/hub/bootstrap/index.ts
+++ b/src/hub/bootstrap/index.ts
@@ -29,8 +29,8 @@ export {
   resolveChannelInitConfigWithSecretPolicy,
   // Token secret resolution
   resolveTokenSecret,
-  // Stub services
-  createStubConfigManager,
+  // Hub adapter services
+  createPersistentConfigManager,
   createFridayHubAutoFixExecutionSupport,
   createStubMemoryState,
 } from "./hub-helpers.js";

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -372,7 +372,7 @@ import {
   canResolveFridayChannelApprovalFromMessage,
   createFridayChannelToolApprovalShortId,
   createFridayHubAutoFixExecutionSupport,
-  createStubConfigManager,
+  createPersistentConfigManager,
   createStubMemoryState,
   evaluateFridayChannelApprovalExpiry,
   loadChannelsConfigFromSetupState,
@@ -1038,11 +1038,22 @@ export async function createFridayHub(
     }
   }
 
-  // 2. Create stub services for standalone operation.
-  // P2: configManager and memoryState are intentionally stubbed for v0.4.x standalone mode.
-  // Full implementations with persistence are planned for the multi-node milestone.
-  // Config mutations via API are silently no-ops; use env vars and friday.config.yaml instead.
-  const configManager = createStubConfigManager({ ...config, workspaceRoot }, stateRuntime);
+  // 2. Create hub adapter services for standalone operation.
+  //
+  // B9 / FRI-AUD-021 truth-label (2026-05-26):
+  //   - configManager (now `createPersistentConfigManager`) persists
+  //     snapshots/revisions in SQLite via `hub_settings`; `/v1/config/*`
+  //     HTTP routes are wired into the API runtime; mutations are NOT
+  //     silently dropped.
+  //   - memoryState (`createStubMemoryState`) remains partial-stub: 4 of
+  //     its 10 interface methods (skill statuses + audit log) are real and
+  //     production-used; the 4 session/memory-item methods remain no-ops
+  //     and currently have ZERO production consumers (interface narrowing
+  //     is a carry-forward code-hygiene item; see B5_B6_B8_VERIFIED.md
+  //     §"FRI-AUD-022").
+  // Use env vars and `friday.config.yaml` for first-boot configuration;
+  // `/v1/config/*` for live mutations.
+  const configManager = createPersistentConfigManager({ ...config, workspaceRoot }, stateRuntime);
   const auditLogPath = resolveFridayAuditLogPath(stateRuntime.stateDir);
   const memoryState = createStubMemoryState(auditLogPath);
 

--- a/test/unit/hub/bootstrap/config-manager-truth-label.test.ts
+++ b/test/unit/hub/bootstrap/config-manager-truth-label.test.ts
@@ -1,0 +1,75 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+/**
+ * B9 / FRI-AUD-021 regression guard.
+ *
+ * Pre-fix state at origin/main < 2026-05-26: the hub bootstrap comment at
+ * `src/hub/friday-hub-bootstrap.ts:1042` claimed both `configManager` and
+ * `memoryState` were "intentionally stubbed for v0.4.x standalone mode" and
+ * that "Config mutations via API are silently no-ops". The configManager
+ * portion of this comment was stale — the underlying `createStubConfigManager`
+ * (`src/hub/bootstrap/hub-helpers.ts:861`) actually persists snapshots +
+ * revisions in SQLite (`hub_settings` table) and `/v1/config/*` HTTP routes
+ * are wired into the API runtime.
+ *
+ * Post-fix invariant:
+ *   - `createStubConfigManager` is renamed to `createPersistentConfigManager`
+ *     wherever it is exported / imported / called.
+ *   - The misleading "Config mutations via API are silently no-ops" wording
+ *     is removed from the bootstrap comment.
+ *   - The bootstrap comment explicitly distinguishes the persistent
+ *     configManager from the still-partial-stub memoryState (which has 4
+ *     real methods + 4 no-op methods with zero production consumers).
+ *   - The audit-finding anchor (`B9 / FRI-AUD-021`) is present in both the
+ *     factory JSDoc + the bootstrap comment for future readers.
+ */
+
+const HUB_BOOTSTRAP_PATH = "src/hub/friday-hub-bootstrap.ts" as const;
+const HUB_HELPERS_PATH = "src/hub/bootstrap/hub-helpers.ts" as const;
+const BOOTSTRAP_INDEX_PATH = "src/hub/bootstrap/index.ts" as const;
+
+describe("configManager rename + stale-comment fix (B9 / FRI-AUD-021)", () => {
+  const bootstrapSource = readFileSync(HUB_BOOTSTRAP_PATH, "utf8");
+  const helpersSource = readFileSync(HUB_HELPERS_PATH, "utf8");
+  const indexSource = readFileSync(BOOTSTRAP_INDEX_PATH, "utf8");
+
+  it("removes the stale 'createStubConfigManager' identifier from all hub bootstrap files", () => {
+    expect(bootstrapSource).not.toContain("createStubConfigManager");
+    expect(helpersSource).not.toContain("createStubConfigManager");
+    expect(indexSource).not.toContain("createStubConfigManager");
+  });
+
+  it("introduces the truth-labeled 'createPersistentConfigManager' identifier", () => {
+    expect(helpersSource).toContain("export function createPersistentConfigManager(");
+    expect(indexSource).toContain("createPersistentConfigManager,");
+    expect(bootstrapSource).toContain("createPersistentConfigManager,");
+    expect(bootstrapSource).toContain("createPersistentConfigManager({ ...config, workspaceRoot }, stateRuntime)");
+  });
+
+  it("removes the stale 'Config mutations via API are silently no-ops' wording", () => {
+    expect(bootstrapSource).not.toContain("Config mutations via API are silently no-ops");
+    expect(bootstrapSource).not.toContain("intentionally stubbed for v0.4.x");
+  });
+
+  it("anchors the rename + comment fix to the audit finding", () => {
+    expect(helpersSource).toContain("B9 / FRI-AUD-021 truth-label rename");
+    expect(bootstrapSource).toContain("B9 / FRI-AUD-021 truth-label");
+  });
+
+  it("explicitly distinguishes the persistent configManager from the still-partial-stub memoryState", () => {
+    // Use regex with `\s+` to tolerate the line-wrapped multi-line comment.
+    expect(bootstrapSource).toMatch(/persists\s+\/\/\s+snapshots\/revisions in SQLite/);
+    expect(bootstrapSource).toContain("/v1/config/*");
+    expect(bootstrapSource).toContain("HTTP routes are wired");
+    expect(bootstrapSource).toContain("partial-stub");
+    expect(bootstrapSource).toContain("ZERO production consumers");
+    expect(bootstrapSource).toContain("B5_B6_B8_VERIFIED.md");
+  });
+
+  it("preserves the existing `createStubMemoryState` factory (truthfully named: partial-stub)", () => {
+    expect(helpersSource).toContain("export function createStubMemoryState(auditLogPath?: string)");
+    expect(bootstrapSource).toContain("createStubMemoryState,");
+    expect(bootstrapSource).toContain("createStubMemoryState(auditLogPath)");
+  });
+});

--- a/test/unit/hub/bootstrap/hub-helpers.test.ts
+++ b/test/unit/hub/bootstrap/hub-helpers.test.ts
@@ -10,7 +10,7 @@ import type { FridayHubConfigManagerService } from "../../../../src/hub/services
 import { initializeFridayState } from "#state";
 import {
   createFridayHubAutoFixExecutionSupport,
-  createStubConfigManager,
+  createPersistentConfigManager,
   createStubMemoryState,
 } from "../../../../src/hub/bootstrap/index.js";
 import {
@@ -427,7 +427,7 @@ describe("createFridayHubAutoFixExecutionSupport", () => {
   });
 });
 
-describe("createStubConfigManager", () => {
+describe("createPersistentConfigManager", () => {
   it("hydrates currentConfig with the actual runtime state dir and launch cwd", async () => {
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "friday-audit-state-"));
     const stateRuntime = initializeFridayState({
@@ -438,7 +438,7 @@ describe("createStubConfigManager", () => {
     });
 
     try {
-      const manager = createStubConfigManager(
+      const manager = createPersistentConfigManager(
         {
           skillDirs: ["skills", "managed-skills"],
         },


### PR DESCRIPTION
## Summary

Closes FRI-AUD-021. Renames `createStubConfigManager` → `createPersistentConfigManager` and updates the stale hub-bootstrap comment that claimed config mutations were silently no-ops. The factory has actually been doing real SQLite persistence (via `hub_settings`) all along — the "stub" name + comment were left over from an earlier v0.4.x assumption.

6 files, +122 / −12 LOC. No runtime behavior change. No widening of the `1.0.1` release claim.

## What changed

**`src/hub/bootstrap/hub-helpers.ts`** — factory rename + new JSDoc anchored to B9 / FRI-AUD-021.

**`src/hub/bootstrap/index.ts`** — re-export name update; section header renamed `"Stub services"` → `"Hub adapter services"`.

**`src/hub/friday-hub-bootstrap.ts`** — import + call-site update + bootstrap comment block rewritten to drop the stale `"intentionally stubbed for v0.4.x"` and `"Config mutations via API silently no-ops"` lines and to explicitly distinguish the persistent configManager from the still-partial-stub `createStubMemoryState`. The memoryState partial-stub status (4 real methods + 4 no-op methods with zero production consumers) points to `HANDOFFS/B5_B6_B8_VERIFIED.md` §"FRI-AUD-022" for the carry-forward interface-narrowing item.

**`test/unit/hub/bootstrap/config-manager-truth-label.test.ts`** (new — 6 source-content tests):

1. Stale `createStubConfigManager` identifier is gone from all 3 hub bootstrap files.
2. Truth-labeled `createPersistentConfigManager` identifier present at definition + re-export + import + call site.
3. Stale `"Config mutations via API are silently no-ops"` + `"intentionally stubbed for v0.4.x"` wording removed.
4. Audit-finding anchor (`B9 / FRI-AUD-021`) present in both factory JSDoc + bootstrap comment.
5. Bootstrap comment explicitly distinguishes persistent configManager from partial-stub memoryState (with pointer to carry-forward handoff).
6. `createStubMemoryState` factory preserved (truthfully named — partial stub).

**`test/unit/hub/bootstrap/hub-helpers.test.ts`** — existing test updated: `describe("createStubConfigManager", ...)` → `describe("createPersistentConfigManager", ...)`; import + call site renamed. Same 1 test, same assertions (existing test exercises real SQLite hydration of `currentConfig` — its passing now is the runtime proof that the rename did not regress behavior).

**`CHANGELOG.md` `[1.0.2]`** — B9 entry added under `### Changed`. B0.5/B2/B3/B4 entries unchanged.

## What this does NOT change

- Runtime behavior of any config read/write/patch/apply operation.
- The `FridayHubConfigManagerService` interface or any consuming surface.
- `createStubMemoryState` factory or its interface (carry-forward item per `HANDOFFS/B5_B6_B8_VERIFIED.md`).
- The 1.0.1 release claim, the 9 `proof_pending` headlines, or the Slack HTTP / QQ / desktop / Homebrew / macOS / mobile / "all integrations live" exclusions.
- The `/v1/config/*` HTTP route surface or contract.

## Local verification

- `npm run typecheck` — 0 errors
- `npx vitest run test/unit/hub/bootstrap/config-manager-truth-label.test.ts` — 6/6 PASS (new)
- `npx vitest run test/unit/hub` (blast radius) — **127/127 PASS** (13 test files)
- `git diff --check` — clean
- `detect-secrets-hook --baseline .secrets.baseline …` — clean

## Real path execution

The pre-existing `createPersistentConfigManager` test at `test/unit/hub/bootstrap/hub-helpers.test.ts:430` ("hydrates currentConfig with the actual runtime state dir and launch cwd") instantiates the renamed factory against a real on-disk SQLite state runtime, calls the factory's read methods, and asserts the hydrated `currentConfig.stateDir` + `currentConfig.workspaceDir` match the runtime state. Its passing after the rename is the runtime proof that the change is mechanical and does not regress SQLite persistence semantics.

## Test plan

- [ ] All branch-protected required checks green on PR head
- [ ] No regression in `test/unit/hub/`
- [ ] Operator authorizes merge (squash, normal path, no `--admin`)
- [ ] B0.5 + B2 + B3 + B4 + B9 ship together in the next operator-driven `1.0.2` publish

## Refs

- `Friday-capability-wiring-audit-20260525-1813/USER_FACING_TRUTH_GAPS.csv` row FRI-AUD-021
- `Friday-post-release-hardening-plan-20260526/BATCH_SPECS.md` § B9 Spec
- `Friday-post-release-hardening-plan-20260526/HANDOFFS/B5_B6_B8_VERIFIED.md` § "FRI-AUD-022" carry-forward note
