### PR TITLE
fix(ui/settings): surface per-provider capability-lane advisories (B7 / FRI-AUD-012/013/014/017)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,27 @@ reports `0` vulnerabilities, down from `3 high` on `1.0.1`.
   directive. The dedup helper's file-header JSDoc + one-time
   module-level advisory log updated to reflect the new advisory-wired
   state.
+- **B7 / FRI-AUD-012/013/014/017** Settings page now surfaces per-
+  provider per-capability lane-failure advisories inline in each
+  provider card after a `Run capability doctor` probe. Previously the
+  probe's `capabilityResults` were only summarized as a toast count
+  ("N probes checked") and the per-lane status messages were thrown
+  away. The new render groups the latest results by `providerId` in a
+  React state map and shows a `data-testid="provider-capability-lane-
+  advisory"` block listing the capabilities whose `status !==
+  "verified"` (so `failed`, `unsupported`, or `declared-only` lanes
+  surface; `verified` lanes do not). Backend doctor-probe already
+  returned the lane-specific truth-labels for the audit's named
+  failures (Ollama embeddings "not wired", Codex subscription "has no
+  embeddings", Google Generative AI runtime "does not yet execute",
+  media-understanding env-gate 503); this slice stops the UI from
+  hiding them behind a count. The advisory copy explicitly disclaims
+  global provider-availability (`"this advisory is per-lane truth-
+  label, not a provider-global availability claim"`). No new backend
+  route, no snapshot model restructure, no change to the existing
+  `enabled / disabled` global provider pill. A full capability-health
+  dashboard remains carry-forward per the 2026-05-26 operator
+  directive.
 - **B9 / FRI-AUD-021** Renamed `createStubConfigManager` →
   `createPersistentConfigManager` in `src/hub/bootstrap/hub-helpers.ts`
   (+ re-export in `src/hub/bootstrap/index.ts` + call site in

--- a/test/unit/ui/provider-capability-lane-truth-label.test.ts
+++ b/test/unit/ui/provider-capability-lane-truth-label.test.ts
@@ -1,0 +1,112 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+/**
+ * B7 / FRI-AUD-012 / FRI-AUD-013 / FRI-AUD-014 / FRI-AUD-017 regression
+ * guard for the minimal UI lane-failure inline notice.
+ *
+ * Operator directive (2026-05-26 Option B): surface the latest
+ * Run-capability-doctor probe's per-provider per-capability failure
+ * advisories inline in the provider settings card.
+ *
+ *  - Backend doctor-probe already returns lane-specific truth-labels
+ *    (Ollama embeddings "not wired", Codex subscription "has no
+ *    embeddings", Google Generative AI runtime "does not yet execute",
+ *    media-understanding env-gate 503). Verified at
+ *    `src/providers/services/friday-provider-service.ts:1705` /
+ *    `:1825` / `:1855` and `src/api/http/routes/friday-media-
+ *    understanding-routes.ts:80`.
+ *  - The settings page already calls `providersApi.runCapabilityDoctor()`
+ *    but previously only surfaced a count toast — the per-provider
+ *    per-capability results were thrown away.
+ *  - This slice captures those results into a per-provider state map
+ *    and renders failures inline. NO new backend route, NO snapshot
+ *    model restructure, NO change to the global provider "enabled" pill.
+ *  - A full capability-health dashboard remains carry-forward.
+ */
+
+const SETTINGS_PAGE_PATH = "ui/src/routes/settings-page.tsx" as const;
+const PROVIDER_SERVICE_PATH = "src/providers/services/friday-provider-service.ts" as const;
+
+describe("provider capability-lane truth-label surface (B7 / FRI-AUD-012/013/014/017)", () => {
+  const settingsSource = readFileSync(SETTINGS_PAGE_PATH, "utf8");
+  const providerServiceSource = readFileSync(PROVIDER_SERVICE_PATH, "utf8");
+
+  it("Test 1: backend doctor-probe still returns lane-specific reasons for the audit's named failures", () => {
+    // FRI-AUD-012 Ollama embeddings
+    expect(providerServiceSource).toContain(
+      'Ollama embeddings are not wired into Friday\'s production BYOK embedding client yet.',
+    );
+    // FRI-AUD-014 Codex subscription embeddings
+    expect(providerServiceSource).toContain(
+      "OpenAI Codex subscription transport is a Responses runtime path; Friday does not route embeddings through it.",
+    );
+    // FRI-AUD-013 Google Generative AI
+    expect(providerServiceSource).toContain(
+      "Google Generative AI validation exists, but Friday's production LLM runtime does not yet execute this provider API.",
+    );
+  });
+
+  it("Test 2: settings page captures per-provider lane results from the capability-doctor mutation", () => {
+    expect(settingsSource).toContain("capabilityLaneResultsByProvider");
+    expect(settingsSource).toContain("setCapabilityLaneResultsByProvider");
+    // Must group by providerId (not flat-store) so each card can render its own slice.
+    expect(settingsSource).toContain("for (const r of result.capabilityResults)");
+    expect(settingsSource).toContain("if (!grouped[r.providerId])");
+    expect(settingsSource).toContain('grouped[r.providerId]!.push({');
+  });
+
+  it("Test 3: provider card renders the lane advisory only for lanes whose status !== 'verified'", () => {
+    expect(settingsSource).toMatch(
+      /const laneAdvisories = \(capabilityLaneResultsByProvider\[provider\.id\] \?\? \[\]\)\s*\.filter\(\(r\) => r\.status !== "verified"\);/,
+    );
+    // Bail-out path: zero non-verified lanes → no advisory rendered.
+    expect(settingsSource).toContain("if (laneAdvisories.length === 0) return null;");
+    // Render shape: per-capability list with status pill + message.
+    expect(settingsSource).toContain('data-testid="provider-capability-lane-advisory"');
+    expect(settingsSource).toContain('Capability-lane advisory (B7 / FRI-AUD-012/013/014/017)');
+    expect(settingsSource).toContain('能力 lane 提示（B7 / FRI-AUD-012/013/014/017）');
+  });
+
+  it("Test 4: advisory copy is explicit per-lane truth-label, NOT a global provider-availability claim", () => {
+    // The advisory footnote must explicitly disclaim global provider availability.
+    expect(settingsSource).toContain(
+      "this advisory is per-lane truth-label, not a provider-global availability claim",
+    );
+    expect(settingsSource).toContain(
+      "此提示仅为 per-lane 真相披露，并不代表 provider 整体不可用",
+    );
+    // The advisory references the "Run capability doctor" probe so users know
+    // it's stale if they haven't probed recently.
+    expect(settingsSource).toContain("'Run capability doctor' probe");
+  });
+
+  it("Test 5: global provider pill semantics are unchanged (still 'enabled' / 'disabled')", () => {
+    // The existing pill is driven by provider.enabled. The B7 slice must
+    // NOT introduce a separate global "all lanes live" claim. Asserting
+    // both that the existing pill is still in place AND that no new
+    // 'all-lanes-live' / 'fully-verified' badge has been added.
+    expect(settingsSource).toContain(
+      '<StatusPill tone={provider.enabled ? "success" : "neutral"}>',
+    );
+    expect(settingsSource).toContain('{provider.enabled ? "enabled" : "disabled"}');
+    expect(settingsSource).not.toContain("all lanes live");
+    expect(settingsSource).not.toContain("all-lanes-live");
+    expect(settingsSource).not.toContain("fully verified across all capabilities");
+  });
+
+  it("Test 6: anchored to the audit findings via comment", () => {
+    expect(settingsSource).toContain("B7 / FRI-AUD-012/013/014/017 minimal UI lane-truth surface");
+    // Tolerate `// ` line continuation between adjacent comment lines.
+    expect(settingsSource).toMatch(/Backend doctor-probe\s+\/\/\s+already returns lane-specific truth-labels/);
+    expect(settingsSource).toContain("full capability-health dashboard");
+    expect(settingsSource).toContain("carry-forward");
+  });
+
+  it("Test 7: no new backend aggregation route was added (constraint preservation)", () => {
+    // Asserting absence of the routes the user explicitly said NOT to add.
+    expect(settingsSource).not.toContain("/v1/providers/capability-health");
+    expect(settingsSource).not.toContain("/v1/providers/lane-health");
+    expect(settingsSource).not.toContain("capabilityHealthSnapshot");
+  });
+});

--- a/ui/src/routes/settings-page.tsx
+++ b/ui/src/routes/settings-page.tsx
@@ -17,7 +17,7 @@ import { ChannelConfigForm } from "@/components/core/channel-config-form";
 import { DiscoveryPanel } from "@/components/core/discovery-panel";
 import { CHANNEL_META } from "@/lib/channels/channel-meta";
 import type { ChannelKind } from "@/lib/setup/types";
-import { type FridayModelRoutingConfig, type FridayProviderKind, type FridayProviderProfile, type FridayRuntimeCapabilityState, ApiError } from "@/lib/api/types";
+import { type FridayModelRoutingConfig, type FridayProviderKind, type FridayProviderProfile, type FridayRuntimeCapabilityId, type FridayRuntimeCapabilityState, ApiError } from "@/lib/api/types";
 import { assistantDiagnosticsApi } from "@/lib/api/assistant-diagnostics";
 import { channelsApi } from "@/lib/api/channels";
 import { healthApi } from "@/lib/api/health";
@@ -704,6 +704,27 @@ export function SettingsPage() {
     },
   });
 
+  // B7 / FRI-AUD-012/013/014/017 minimal UI lane-truth surface: after the
+  // operator runs a capability doctor probe, surface per-provider per-lane
+  // failure advisories in the provider settings card. Backend doctor-probe
+  // already returns lane-specific truth-labels (Ollama embeddings not wired,
+  // Codex subscription has no embeddings, Google Generative AI runtime not
+  // wired, etc.) — we just stop throwing that data away in favor of a
+  // toast count. The global provider pill semantics are unchanged. The
+  // advisory only appears for lanes whose status !== "verified".
+  // Per the 2026-05-26 operator directive: full capability-health dashboard
+  // remains carry-forward; this slice does NOT add a new backend route or
+  // restructure the snapshot model.
+  type ProviderLaneAdvisory = {
+    capability: FridayRuntimeCapabilityId;
+    status: "verified" | "declared" | "failed" | "unsupported";
+    message: string;
+    checkedAt: string;
+  };
+  const [capabilityLaneResultsByProvider, setCapabilityLaneResultsByProvider] = useState<
+    Record<string, ProviderLaneAdvisory[]>
+  >({});
+
   const capabilityDoctorMutation = useMutation({
     mutationFn: () => providersApi.runCapabilityDoctor(),
     onSuccess: async (result) => {
@@ -712,6 +733,20 @@ export function SettingsPage() {
         `能力检查完成：${result.providerValidations.length} 个提供方、${result.capabilityResults.length} 项能力已检查`,
         `Capability doctor completed: ${result.providerValidations.length} provider(s), ${result.capabilityResults.length} capability probe(s) checked`,
       ));
+      // B7 capture: group per-provider so the provider card can render
+      // lane-specific advisories. Replace any prior result for a probed
+      // provider; leave unprobed providers' prior results untouched.
+      const grouped: Record<string, ProviderLaneAdvisory[]> = {};
+      for (const r of result.capabilityResults) {
+        if (!grouped[r.providerId]) grouped[r.providerId] = [];
+        grouped[r.providerId]!.push({
+          capability: r.capability,
+          status: r.status,
+          message: r.message,
+          checkedAt: r.checkedAt,
+        });
+      }
+      setCapabilityLaneResultsByProvider((prev) => ({ ...prev, ...grouped }));
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ["settings", "health"] }),
         queryClient.invalidateQueries({ queryKey: ["settings", "providers"] }),
@@ -1256,6 +1291,51 @@ export function SettingsPage() {
                   {healthItem?.suggestedAction ? (
                     <p className="mt-2 text-xs text-[color:var(--color-text-secondary)]">{healthItem.suggestedAction}</p>
                   ) : null}
+                  {/*
+                   * B7 / FRI-AUD-012/013/014/017 minimal lane-truth surface:
+                   * after a Run-capability-doctor probe, show per-lane
+                   * (text/embedding/vision/auth/media) advisories for THIS
+                   * provider whose status !== "verified". Hidden until the
+                   * operator runs the doctor; hidden for providers whose
+                   * every probed lane verified. Does NOT change the
+                   * "enabled" pill above.
+                   */}
+                  {(() => {
+                    const laneAdvisories = (capabilityLaneResultsByProvider[provider.id] ?? [])
+                      .filter((r) => r.status !== "verified");
+                    if (laneAdvisories.length === 0) return null;
+                    return (
+                      <div
+                        data-testid="provider-capability-lane-advisory"
+                        className="mt-3 rounded-2xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] p-3"
+                      >
+                        <p className="text-sm font-semibold text-[color:var(--color-text-primary)]">
+                          {localize(
+                            locale,
+                            "能力 lane 提示（B7 / FRI-AUD-012/013/014/017）",
+                            "Capability-lane advisory (B7 / FRI-AUD-012/013/014/017)",
+                          )}
+                        </p>
+                        <ul className="mt-2 space-y-1">
+                          {laneAdvisories.map((r) => (
+                            <li key={`${r.capability}-${r.checkedAt}`} className="flex items-start gap-2 text-xs">
+                              <StatusPill tone={r.status === "failed" ? "danger" : "warning"}>
+                                {r.capability} · {r.status}
+                              </StatusPill>
+                              <span className="text-[color:var(--color-text-secondary)]">{r.message}</span>
+                            </li>
+                          ))}
+                        </ul>
+                        <p className="mt-2 text-[10px] text-[color:var(--color-text-faint)]">
+                          {localize(
+                            locale,
+                            "来自最近一次 'Run capability doctor' 探针；其他 lane 已验证或未探测；此提示仅为 per-lane 真相披露，并不代表 provider 整体不可用。",
+                            "From the latest 'Run capability doctor' probe; other lanes verified or unprobed; this advisory is per-lane truth-label, not a provider-global availability claim.",
+                          )}
+                        </p>
+                      </div>
+                    );
+                  })()}
                   <div className="mt-3 flex flex-wrap gap-2">
                     <ActionButton
                       tone="secondary"


### PR DESCRIPTION
## Summary

Closes the user-facing half of FRI-AUD-012 / FRI-AUD-013 / FRI-AUD-014 / FRI-AUD-017. Backend doctor-probe at `src/providers/services/friday-provider-service.ts` has long returned lane-specific truth-labels (Ollama embeddings "not wired", Codex subscription "has no embeddings", Google Generative AI runtime "does not yet execute", media-understanding env-gate 503), but the settings page threw the per-lane status away and only surfaced a count toast. This slice captures the latest `runCapabilityDoctor` result per `providerId` and renders failing lanes inline in the provider settings card.

Per the 2026-05-26 operator directive (Option B):
- No new backend aggregation route.
- No restructure of the provider snapshot model.
- No change to the existing `enabled / disabled` global provider pill.
- A full capability-health dashboard remains **carry-forward**.

3 files, +214 / −1 LOC.

## What changed

**`ui/src/routes/settings-page.tsx`**

- Imported `FridayRuntimeCapabilityId` type from `@/lib/api/types`.
- Added `capabilityLaneResultsByProvider` React state — `Record<providerId, ProviderLaneAdvisory[]>`.
- Extended `capabilityDoctorMutation.onSuccess` to group `result.capabilityResults` by `providerId` and call `setCapabilityLaneResultsByProvider`.
- Added a render block inside each provider card (after the existing diagnostics row) that:
  - reads `capabilityLaneResultsByProvider[provider.id]` and filters to `status !== "verified"`;
  - bails out (returns `null`) if no failing lanes exist;
  - otherwise renders `data-testid="provider-capability-lane-advisory"` with a per-capability list (`{capability} · {status}` status pill + advisory message);
  - footnote explicitly disclaims global provider-availability: *"this advisory is per-lane truth-label, not a provider-global availability claim"* / *"此提示仅为 per-lane 真相披露，并不代表 provider 整体不可用"*.

**`test/unit/ui/provider-capability-lane-truth-label.test.ts`** (new — 7 source-content tests)

Operator-specified coverage:

1. Backend doctor-probe still returns lane-specific reasons for the audit's named failures (Ollama embeddings, Codex subscription embeddings, Google Generative AI).
2. Settings page captures per-provider lane results from the capability-doctor mutation (grouping logic + state setter present).
3. Provider card renders the lane advisory only for lanes whose status !== "verified" (filter regex + bail-out path + render shape).
4. Advisory copy is explicit per-lane truth-label, NOT a global provider-availability claim (footnote disclaimer present in both locales).
5. Global provider pill semantics unchanged (existing `enabled / disabled` pill still in place; no new "all lanes live" / "fully verified" badge added).
6. Anchored to the audit findings via comment (`B7 / FRI-AUD-012/013/014/017` + backend-probe reference + carry-forward note).
7. No new backend aggregation route added (`/v1/providers/capability-health`, `/v1/providers/lane-health`, `capabilityHealthSnapshot` all absent).

**`CHANGELOG.md` `[1.0.2]`**

Adds B7 entry under `### Changed`. B0.5/B2/B3/B4/B9 entries unchanged.

## What this does NOT change

- The 1.0.1 release claim — explicitly preserved (no new capability, no widened claim).
- The 9 `proof_pending` headlines — carried forward unchanged.
- The provider snapshot model (`ProviderTruthSnapshot`, `FridayProviderHealthSnapshotItem`).
- The `/v1/capabilities/doctor` route or its handler.
- The global "Healthy / Degraded / Offline" provider-truth pill in `ui/src/components/console/shell/provider-truth.tsx` (routing-lane health is a separate dimension from capability-lane health).
- Any backend wiring of Ollama embeddings, Codex subscription embeddings, Google Generative AI runtime, or media-understanding env-gate — those remain `proof_pending` / `setup_needed` per the existing doctor-probe truth-labels.

## Carry-forward

A full capability-health dashboard with always-on per-lane status (text/embedding/vision/auth/media) per provider, plus a backend aggregation route to fetch the latest cached results without a fresh probe round-trip, is queued for a future hardening pass with explicit product direction. The 2026-05-26 operator directive explicitly scoped this slice to minimal UI lane-truth surface.

## Local verification

- `npm run typecheck` — 0 errors
- `npx vitest run test/unit/ui/provider-capability-lane-truth-label.test.ts` — 7/7 PASS (new)
- `npx vitest run test/unit/ui` (blast radius) — **429/429 PASS** (51 test files)
- `npx vitest run test/unit/providers` (blast radius) — **332/332 PASS** (24 test files)
- `git diff --check` — clean
- `detect-secrets-hook --baseline .secrets.baseline …` — clean

## Real path execution

The new render block consumes data from the existing `POST /v1/capabilities/doctor` route's response (already wired end-to-end via `providersApi.runCapabilityDoctor()` and the existing capability-doctor mutation). The lane-specific truth-labels emitted by the backend at `friday-provider-service.ts:1705/1825/1855` are the actual messages a user will see in the new advisory block when they probe an Ollama provider (embedding lane), a Codex subscription provider (embedding lane), or a Google Generative AI provider. Source-content regression tests guard against the render block regressing into a global-availability claim.

## Test plan

- [ ] All branch-protected required checks green on PR head
- [ ] No regression in `test/unit/ui/` or `test/unit/providers/`
- [ ] Operator authorizes merge (squash, normal path, no `--admin`)
- [ ] B0.5 + B2 + B3 + B4 + B7 + B9 ship together in the next operator-driven `1.0.2` publish

## Refs

- `Friday-capability-wiring-audit-20260525-1813/USER_FACING_TRUTH_GAPS.csv` rows FRI-AUD-012 / FRI-AUD-013 / FRI-AUD-014 / FRI-AUD-017
- `Friday-post-release-hardening-plan-20260526/POST_RELEASE_DEFAULT_DECISIONS.md` § B7
- `Friday-post-release-hardening-plan-20260526/BATCH_SPECS.md` § B7 Spec
- 2026-05-26 operator AskUserQuestion directive (Option B — minimal lane-failure inline notice)
