### PR TITLE
fix(hub,memory): close channel truth and memory cognition gaps

### DIFF
--- a/src/agent/tools/friday-agent-message-tool.ts
+++ b/src/agent/tools/friday-agent-message-tool.ts
@@ -23,13 +23,13 @@ export function createFridayAgentMessageTool(
   return {
     name: "message",
     description:
-      "Send a message through a channel (e.g. QQ, Lark, Discord). " +
+      "Send a message through a configured supported channel (e.g. Lark, Discord, Telegram). " +
       "Validates channel availability before sending. Returns message ID on success.",
     parameters: {
       properties: {
         channel: {
           type: "string",
-          description: "Channel kind to send through (e.g. 'qq', 'lark', 'discord').",
+          description: "Channel kind to send through (e.g. 'lark', 'discord', 'telegram').",
         },
         chatId: {
           type: "string",

--- a/src/api/http/routes/friday-memory-routes.ts
+++ b/src/api/http/routes/friday-memory-routes.ts
@@ -10,7 +10,7 @@ import type {
   FridayMemoryStoreRequest,
   FridayMemoryStoreResponse,
 } from "../../model/friday-api-memory.types.js";
-import type { FridayMemoryGuardServiceFactory, FridayMemoryItem } from "#memory";
+import type { FridayMemoryGuardServiceFactory, FridayMemoryItem, FridayMemoryType } from "#memory";
 import type { FridayLearnedFactView } from "../../../learning/services/friday-learned-fact-memory-view.js";
 import {
   FRIDAY_LEARNED_FACT_SOURCE,
@@ -41,6 +41,23 @@ export interface FridayMemoryRoutesDeps {
 
 // ─── Validation helpers ───
 
+const FRIDAY_MEMORY_TYPES: readonly FridayMemoryType[] = [
+  "fact",
+  "preference",
+  "procedure",
+  "episode",
+  "correction",
+];
+
+function isFridayMemoryType(value: unknown): value is FridayMemoryType {
+  return typeof value === "string" && FRIDAY_MEMORY_TYPES.includes(value as FridayMemoryType);
+}
+
+function isFridayMemoryTypeOrArray(value: unknown): value is FridayMemoryType | FridayMemoryType[] {
+  return isFridayMemoryType(value)
+    || (Array.isArray(value) && value.length > 0 && value.every(isFridayMemoryType));
+}
+
 function validateStoreBody(body: unknown): asserts body is FridayMemoryStoreRequest {
   if (body == null || typeof body !== "object") {
     throw new FridayDomainError("VALIDATION_ERROR", "Request body is required", { httpStatus: 400 });
@@ -53,6 +70,14 @@ function validateStoreBody(body: unknown): asserts body is FridayMemoryStoreRequ
   }
   if (typeof b.content !== "string" || !b.content) {
     errors.push("content is required and must be a non-empty string");
+  }
+  if (b.memoryType !== undefined && !isFridayMemoryType(b.memoryType)) {
+    errors.push(`memoryType must be one of: ${FRIDAY_MEMORY_TYPES.join(", ")}`);
+  }
+  if (b.confidence !== undefined) {
+    if (typeof b.confidence !== "number" || !Number.isFinite(b.confidence) || b.confidence < 0 || b.confidence > 1) {
+      errors.push("confidence must be a number between 0 and 1");
+    }
   }
 
   if (errors.length > 0) {
@@ -102,6 +127,18 @@ function validateSearchBody(body: unknown): asserts body is FridayMemorySearchRe
     }
     w.fts = fts;
     w.semantic = semantic;
+  }
+
+  if (b.memoryType !== undefined && !isFridayMemoryTypeOrArray(b.memoryType)) {
+    throw new FridayDomainError(
+      "VALIDATION_ERROR",
+      `memoryType must be one of: ${FRIDAY_MEMORY_TYPES.join(", ")} or a non-empty array of those values`,
+      { httpStatus: 400 },
+    );
+  }
+
+  if (b.boostByConfidence !== undefined && typeof b.boostByConfidence !== "boolean") {
+    throw new FridayDomainError("VALIDATION_ERROR", "boostByConfidence must be a boolean", { httpStatus: 400 });
   }
 }
 
@@ -213,6 +250,7 @@ function enforceMemoryStoreApprovalBoundary(body: FridayMemoryStoreRequest): voi
 function shouldIncludeLearnedFacts(input: {
   namespace?: string | string[];
   source?: string | string[];
+  memoryType?: FridayMemoryType | FridayMemoryType[];
 }): boolean {
   const namespaces = Array.isArray(input.namespace)
     ? input.namespace
@@ -225,6 +263,14 @@ function shouldIncludeLearnedFacts(input: {
       ? [input.source]
       : [];
   if (sources.length > 0 && !sources.includes(FRIDAY_LEARNED_FACT_SOURCE)) {
+    return false;
+  }
+  const memoryTypes = Array.isArray(input.memoryType)
+    ? input.memoryType
+    : input.memoryType
+      ? [input.memoryType]
+      : [];
+  if (memoryTypes.length > 0 && !memoryTypes.includes("preference")) {
     return false;
   }
   if (namespaces.length === 0) {
@@ -318,6 +364,8 @@ export function createFridayMemoryRoutes(
             metadata: body.metadata,
             ttlSeconds: body.ttlSeconds,
             expiresAt: body.expiresAt,
+            memoryType: body.memoryType,
+            confidence: body.confidence,
           });
           const replay = deps.findStoreReplay?.({ principalId, idempotencyKey });
           if (replay) {
@@ -347,6 +395,8 @@ export function createFridayMemoryRoutes(
           metadata: body.metadata,
           ttlSeconds: body.ttlSeconds,
           expiresAt: body.expiresAt,
+          memoryType: body.memoryType,
+          confidence: body.confidence,
         });
         return { item };
       },
@@ -385,6 +435,8 @@ export function createFridayMemoryRoutes(
             metadata: body.metadata,
             ttlSeconds: body.ttlSeconds,
             expiresAt: body.expiresAt,
+            memoryType: body.memoryType,
+            confidence: body.confidence,
           });
           const replay = deps.findStoreReplay?.({ principalId, idempotencyKey });
           if (replay) {
@@ -415,6 +467,8 @@ export function createFridayMemoryRoutes(
           metadata: body.metadata,
           ttlSeconds: body.ttlSeconds,
           expiresAt: body.expiresAt,
+          memoryType: body.memoryType,
+          confidence: body.confidence,
         });
         return { item };
       },
@@ -440,10 +494,13 @@ export function createFridayMemoryRoutes(
           limit: body.limit,
           minScore: body.minScore,
           weights: body.weights,
+          memoryType: body.memoryType,
+          boostByConfidence: body.boostByConfidence,
         });
         const learnedItems = deps.listLearnedFacts && shouldIncludeLearnedFacts({
           namespace: body.namespace,
           source: body.source,
+          memoryType: body.memoryType,
         })
           ? deps.listLearnedFacts({ userId, limit: body.limit ?? FRIDAY_MEMORY_MAX_LIMIT })
             .filter((fact) => matchesLearnedFactQuery(fact, body.query))

--- a/src/api/model/friday-api-memory.types.ts
+++ b/src/api/model/friday-api-memory.types.ts
@@ -4,6 +4,7 @@ import type {
   FridayMemoryPruneResult,
   FridayMemorySearchResult,
   FridayMemoryStoreInput,
+  FridayMemoryType,
 } from "#memory";
 
 export interface FridayMemoryStoreRequest extends FridayMemoryStoreInput {}
@@ -21,6 +22,8 @@ export interface FridayMemorySearchRequest {
   limit?: number;
   minScore?: number;
   weights?: { fts: number; semantic: number };
+  memoryType?: FridayMemoryType | FridayMemoryType[];
+  boostByConfidence?: boolean;
 }
 export interface FridayMemorySearchResponse {
   items: FridayMemorySearchResult[];

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -265,6 +265,8 @@ import {
   createWhatsappWebhookService,
   FRIDAY_CHANNEL_SECRET_SCOPE,
   FRIDAY_SUPPORTED_CHANNEL_KINDS,
+  isFridayChannelKindSupported,
+  isFridayChannelModeSupported,
   parseFridayChannelsConfig,
   resolveFridayChannelSecretPolicy,
 } from "#channels";
@@ -272,7 +274,6 @@ import type {
   FridayChannelMessage,
   FridayChannelMessageHandler,
   FridayChannelRegistry,
-  FridaySupportedChannelKind,
 } from "#channels";
 import { createFridayChannelInboundDebouncer, createFridayChannelTypingController, sanitizeChannelInput } from "#channels";
 import { createFridayChannelSlowTaskNotifier } from "../channels/friday-channel-slow-task-notifier.js";
@@ -5317,10 +5318,23 @@ export async function createFridayHub(
     const registeredKinds: string[] = [];
     const warnings: string[] = [];
     const desiredKinds = new Set<string>();
+    const isRuntimeSupportedChannel = (instance: { kind: string; mode?: unknown }): boolean => {
+      if (!isFridayChannelKindSupported(instance.kind)) return false;
+      const mode = typeof instance.mode === "string" ? instance.mode : undefined;
+      return isFridayChannelModeSupported(instance.kind, mode);
+    };
+    const warnUnsupportedChannel = (instance: { kind: string; mode?: unknown }): void => {
+      const mode = typeof instance.mode === "string" ? instance.mode : undefined;
+      const message = mode === undefined
+        ? `Channel ${instance.kind} disabled: kind is unsupported in this release.`
+        : `Channel ${instance.kind} disabled: mode ${mode} is unsupported in this release.`;
+      warnings.push(message);
+      console.warn(`[friday] ${message}`);
+    };
 
     if (parsedChannelsConfig.enabled) {
       for (const instance of parsedChannelsConfig.instances) {
-        if (instance.enabled) {
+        if (instance.enabled && isRuntimeSupportedChannel(instance)) {
           desiredKinds.add(instance.kind);
         }
       }
@@ -5340,6 +5354,11 @@ export async function createFridayHub(
 
     for (const instance of parsedChannelsConfig.instances) {
       if (!instance.enabled) continue;
+
+      if (!isRuntimeSupportedChannel(instance)) {
+        warnUnsupportedChannel(instance);
+        continue;
+      }
 
       if (options.replaceExisting && channelRegistry.get(instance.kind)) {
         await channelRegistry.unregister(instance.kind);
@@ -6450,7 +6469,7 @@ export async function createFridayHub(
 
     const personas: Record<string, FridayChannelPersonaConfig> = {};
     for (const [kind, value] of Object.entries(parsed)) {
-      if (!channelRegistry.describe(kind) && !FRIDAY_SUPPORTED_CHANNEL_KINDS.includes(kind as FridaySupportedChannelKind)) {
+      if (!channelRegistry.describe(kind) && !isFridayChannelKindSupported(kind)) {
         continue;
       }
       if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -6497,6 +6516,8 @@ export async function createFridayHub(
   hydrateChannelPersonaStore(persistedChannelPersonas);
   savePersistedChannelPersonas(persistedChannelPersonas);
 
+  const runtimeSupportedChannelKinds = FRIDAY_SUPPORTED_CHANNEL_KINDS.filter(isFridayChannelKindSupported);
+
   const apiRuntime = createFridayApiRuntime({
     db: stateRuntime!.sqlite,
     idGenerator,
@@ -6512,7 +6533,7 @@ export async function createFridayHub(
     updateSkillStatus: (skillId, status) => memoryState.updateSkillStatus(skillId, status),
     tokenSecret,
     pluginRuntimeMode,
-    supportedChannelKinds: [...FRIDAY_SUPPORTED_CHANNEL_KINDS],
+    supportedChannelKinds: [...runtimeSupportedChannelKinds],
     enabledChannelKinds: getEnabledChannelKinds,
     activateSavedChannels: activateSavedChannelsFromSetupState,
     onSetupChannelsSaved: startReflexOnboardingAfterChannelBind,
@@ -6547,7 +6568,7 @@ export async function createFridayHub(
     observabilityService,
     channels: {
       registry: channelRegistry,
-      supportedKinds: [...FRIDAY_SUPPORTED_CHANNEL_KINDS],
+      supportedKinds: [...runtimeSupportedChannelKinds],
       nowIso,
       persistPersona(kind, config) {
         const personas = loadPersistedChannelPersonas();

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -18,6 +18,7 @@ export {
 // Model types
 export type {
   FridayMemoryNamespace,
+  FridayMemoryType,
   FridayMemoryItem,
   FridayMemoryEmbedding,
   FridayMemorySearchQuery,

--- a/src/memory/persistence/friday-memory-embedding-repository.ts
+++ b/src/memory/persistence/friday-memory-embedding-repository.ts
@@ -2,8 +2,8 @@ import type Database from "better-sqlite3";
 import type {
   FridayMemoryEmbedding,
   FridayMemoryNamespace,
-  FridayMemoryType,
   FridayMemorySemanticHit,
+  FridayMemoryType,
 } from "../model/friday-memory.types.js";
 import { FridayDomainError } from "#errors";
 import { safeJsonParse } from "#utilities";

--- a/src/memory/persistence/friday-memory-embedding-repository.ts
+++ b/src/memory/persistence/friday-memory-embedding-repository.ts
@@ -2,6 +2,7 @@ import type Database from "better-sqlite3";
 import type {
   FridayMemoryEmbedding,
   FridayMemoryNamespace,
+  FridayMemoryType,
   FridayMemorySemanticHit,
 } from "../model/friday-memory.types.js";
 import { FridayDomainError } from "#errors";
@@ -39,6 +40,7 @@ export interface FridayMemoryEmbeddingRepository {
       nowIso: string;
       namespace?: FridayMemoryNamespace | FridayMemoryNamespace[];
       source?: string | string[];
+      memoryType?: FridayMemoryType | FridayMemoryType[];
       tagsAny?: string[];
       includeExpired?: boolean;
       limit: number;
@@ -86,6 +88,17 @@ function rowToEmbedding(row: EmbeddingRow): FridayMemoryEmbedding {
 function toArray(val: string | string[] | undefined): string[] | undefined {
   if (val === undefined) return undefined;
   return Array.isArray(val) ? val : [val];
+}
+
+function addInCondition(
+  conditions: string[],
+  params: unknown[],
+  column: string,
+  values: string[] | undefined,
+): void {
+  if (!values || values.length === 0) return;
+  conditions.push(`${column} IN (${values.map(() => "?").join(",")})`);
+  params.push(...values);
 }
 
 function buildTagExactConditions(tags: string[], params: unknown[]): string {
@@ -170,17 +183,9 @@ export function createFridayMemoryEmbeddingRepository(): FridayMemoryEmbeddingRe
       const conditions: string[] = ["e.model = ?"];
       const params: unknown[] = [input.model];
 
-      const namespaces = toArray(input.namespace);
-      if (namespaces && namespaces.length > 0) {
-        conditions.push(`mi.namespace IN (${namespaces.map(() => "?").join(",")})`);
-        params.push(...namespaces);
-      }
-
-      const sources = toArray(input.source);
-      if (sources && sources.length > 0) {
-        conditions.push(`mi.source IN (${sources.map(() => "?").join(",")})`);
-        params.push(...sources);
-      }
+      addInCondition(conditions, params, "mi.namespace", toArray(input.namespace));
+      addInCondition(conditions, params, "mi.source", toArray(input.source));
+      addInCondition(conditions, params, "mi.memory_type", toArray(input.memoryType));
 
       if (input.tagsAny && input.tagsAny.length > 0) {
         conditions.push(buildTagExactConditions(input.tagsAny, params));

--- a/src/memory/persistence/friday-memory-item-repository.ts
+++ b/src/memory/persistence/friday-memory-item-repository.ts
@@ -5,6 +5,7 @@ import type {
   FridayMemoryNamespace,
   FridayMemoryPruneOptions,
   FridayMemorySearchQuery,
+  FridayMemoryType,
 } from "../model/friday-memory.types.js";
 import { FridayDomainError } from "#errors";
 import { safeJsonParse } from "#utilities";
@@ -49,6 +50,7 @@ export interface FridayMemoryItemRepository {
     input?: {
       namespace?: FridayMemoryNamespace | FridayMemoryNamespace[];
       source?: string | string[];
+      memoryType?: FridayMemoryType | FridayMemoryType[];
       tagsAny?: string[];
       includeExpired?: boolean;
       limit?: number;
@@ -113,6 +115,17 @@ function rowToItem(row: MemoryItemRow): FridayMemoryItem {
 function toArray(val: string | string[] | undefined): string[] | undefined {
   if (val === undefined) return undefined;
   return Array.isArray(val) ? val : [val];
+}
+
+function addInCondition(
+  conditions: string[],
+  params: unknown[],
+  column: string,
+  values: string[] | undefined,
+): void {
+  if (!values || values.length === 0) return;
+  conditions.push(`${column} IN (${values.map(() => "?").join(",")})`);
+  params.push(...values);
 }
 
 function shouldPruneExpiredByDefault(options: FridayMemoryPruneOptions): boolean {
@@ -222,17 +235,9 @@ export function createFridayMemoryItemRepository(): FridayMemoryItemRepository {
       const conditions: string[] = [];
       const params: unknown[] = [];
 
-      const namespaces = toArray(input?.namespace);
-      if (namespaces && namespaces.length > 0) {
-        conditions.push(`namespace IN (${namespaces.map(() => "?").join(",")})`);
-        params.push(...namespaces);
-      }
-
-      const sources = toArray(input?.source);
-      if (sources && sources.length > 0) {
-        conditions.push(`source IN (${sources.map(() => "?").join(",")})`);
-        params.push(...sources);
-      }
+      addInCondition(conditions, params, "namespace", toArray(input?.namespace));
+      addInCondition(conditions, params, "source", toArray(input?.source));
+      addInCondition(conditions, params, "memory_type", toArray(input?.memoryType));
 
       if (input?.tagsAny && input.tagsAny.length > 0) {
         conditions.push(buildTagExactConditions("memory_items", input.tagsAny, "any", params));
@@ -339,18 +344,9 @@ export function createFridayMemoryItemRepository(): FridayMemoryItemRepository {
       mainParams.push(matchExpr);
 
       // Namespace filter
-      const namespaces = toArray(input.namespace);
-      if (namespaces && namespaces.length > 0) {
-        filterConditions.push(`fts.namespace IN (${namespaces.map(() => "?").join(",")})`);
-        filterParams.push(...namespaces);
-      }
-
-      // Source filter
-      const sources = toArray(input.source);
-      if (sources && sources.length > 0) {
-        filterConditions.push(`fts.source IN (${sources.map(() => "?").join(",")})`);
-        filterParams.push(...sources);
-      }
+      addInCondition(filterConditions, filterParams, "fts.namespace", toArray(input.namespace));
+      addInCondition(filterConditions, filterParams, "fts.source", toArray(input.source));
+      addInCondition(filterConditions, filterParams, "mi.memory_type", toArray(input.memoryType));
 
       // Tag filtering (Fix #1: tagsAny / tagsAll)
       if (input.tagsAny && input.tagsAny.length > 0) {

--- a/src/memory/search/friday-memory-hybrid.ts
+++ b/src/memory/search/friday-memory-hybrid.ts
@@ -17,6 +17,7 @@ export interface MergeHybridResultsInput {
   weights?: { fts: number; semantic: number };
   limit: number;
   minScore?: number;
+  boostByConfidence?: boolean;
 }
 
 /**
@@ -79,9 +80,13 @@ export function mergeHybridResults(input: MergeHybridResultsInput): FridayMemory
     const item = input.resolveItem(itemId);
     if (!item) continue;
 
+    const confidenceBoost = input.boostByConfidence && typeof item.confidence === "number"
+      ? Math.max(0, Math.min(1, item.confidence)) * 0.05
+      : 0;
+
     results.push({
       item,
-      score,
+      score: score + confidenceBoost,
       ftsScore: entry.ftsScore,
       semanticScore: entry.semanticScore,
       matchedBy: [...entry.matchedBy],

--- a/src/memory/services/friday-memory-service.ts
+++ b/src/memory/services/friday-memory-service.ts
@@ -261,6 +261,7 @@ export function createFridayMemoryService(
           text: query,
           namespace: options?.namespace,
           source: options?.source,
+          memoryType: options?.memoryType,
           tagsAny: options?.tagsAny,
           tagsAll: options?.tagsAll,
           includeExpired: options?.includeExpired,
@@ -283,6 +284,7 @@ export function createFridayMemoryService(
             nowIso: now,
             namespace: options?.namespace,
             source: options?.source,
+            memoryType: options?.memoryType,
             tagsAny: options?.tagsAny,
             includeExpired: options?.includeExpired,
             limit: FRIDAY_MEMORY_DEFAULT_CANDIDATE_LIMIT,
@@ -316,6 +318,7 @@ export function createFridayMemoryService(
         weights: options?.weights,
         limit,
         minScore: options?.minScore,
+        boostByConfidence: options?.boostByConfidence,
       });
 
       // Fallback: if FTS and semantic both returned nothing, try a namespace-filtered
@@ -329,6 +332,7 @@ export function createFridayMemoryService(
           itemRepo.list(db, {
             namespace: options.namespace,
             source: options.source,
+            memoryType: options.memoryType,
             tagsAny: options.tagsAny,
             includeExpired: options.includeExpired,
             limit: FRIDAY_MEMORY_DEFAULT_CANDIDATE_LIMIT,
@@ -353,7 +357,9 @@ export function createFridayMemoryService(
             if (options?.minScore != null && 0.1 < options.minScore) continue;
             results.push({
               item,
-              score: 0.1, // low confidence substring match
+              score: 0.1 + (options?.boostByConfidence && typeof item.confidence === "number"
+                ? Math.max(0, Math.min(1, item.confidence)) * 0.05
+                : 0), // low confidence substring match, optionally confidence-adjusted
               ftsScore: 0,
               semanticScore: 0,
               matchedBy: ["substring"],

--- a/test/unit/api/http/routes/friday-memory-routes.test.ts
+++ b/test/unit/api/http/routes/friday-memory-routes.test.ts
@@ -117,6 +117,8 @@ describe("FridayMemoryRoutes", () => {
         content: "Hello world",
         source: "agent",
         tags: ["t1"],
+        memoryType: "fact",
+        confidence: 0.85,
       },
     });
 
@@ -125,9 +127,49 @@ describe("FridayMemoryRoutes", () => {
     expect(memoryService.store).toHaveBeenCalledWith(
       "test-ns",
       "Hello world",
-      expect.objectContaining({ source: "agent", tags: ["t1"] }),
+      expect.objectContaining({
+        source: "agent",
+        tags: ["t1"],
+        memoryType: "fact",
+        confidence: 0.85,
+      }),
     );
   });
+
+  it("store handler rejects invalid memory cognition fields", async () => {
+    const route = findRoute("memory.store");
+
+    await expect(route.handler(makeCtx({
+      body: {
+        namespace: "test",
+        content: "Hello world",
+        memoryType: "mood",
+      },
+    }))).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+
+    await expect(route.handler(makeCtx({
+      body: {
+        namespace: "test",
+        content: "Hello world",
+        confidence: 1.5,
+      },
+    }))).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+  });
+
+  it.each([null, false, true, "", "0.5"])(
+    "store handler rejects non-number confidence value %j",
+    async (confidence) => {
+      const route = findRoute("memory.store");
+
+      await expect(route.handler(makeCtx({
+        body: {
+          namespace: "test",
+          content: "Hello world",
+          confidence,
+        },
+      }))).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+    },
+  );
 
   it("store handler defaults namespace to 'default' when omitted", async () => {
     const route = findRoute("memory.store");
@@ -270,10 +312,41 @@ describe("FridayMemoryRoutes", () => {
     vi.mocked(memoryService.search).mockResolvedValue([searchResult]);
 
     const route = findRoute("memory.search");
-    const ctx = makeCtx({ body: { query: "hello" } });
+    const ctx = makeCtx({
+      body: {
+        query: "hello",
+        memoryType: ["preference", "correction"],
+        boostByConfidence: true,
+      },
+    });
     const result = await route.handler(ctx) as { items: FridayMemorySearchResult[] };
     expect(result.items).toHaveLength(1);
     expect(result.items[0].score).toBe(0.9);
+    expect(memoryService.search).toHaveBeenCalledWith(
+      "hello",
+      expect.objectContaining({
+        memoryType: ["preference", "correction"],
+        boostByConfidence: true,
+      }),
+    );
+  });
+
+  it("search handler rejects invalid memory cognition filters", async () => {
+    const route = findRoute("memory.search");
+
+    await expect(route.handler(makeCtx({
+      body: {
+        query: "hello",
+        memoryType: ["preference", "unknown"],
+      },
+    }))).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+
+    await expect(route.handler(makeCtx({
+      body: {
+        query: "hello",
+        boostByConfidence: "yes",
+      },
+    }))).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
   });
 
   it("search handler validates query is required", async () => {
@@ -307,6 +380,28 @@ describe("FridayMemoryRoutes", () => {
       reviewBoundary: "not_review_center_confirmed",
       revocationBoundary: "clear_delete_or_synthetic_memory_delete",
     });
+  });
+
+  it("search handler excludes learned facts when memoryType excludes preference", async () => {
+    routes = createFridayMemoryRoutes({
+      memoryGuardFactory,
+      listLearnedFacts: () => [{
+        key: "pref:display_name",
+        value: "Captain Friday",
+        confidence: 0.8,
+        evidenceCount: 1,
+        lastConfirmedAt: NOW,
+      }],
+    });
+    const route = findRoute("memory.search");
+    const result = await route.handler(makeCtx({
+      body: {
+        query: "call me",
+        memoryType: "fact",
+      },
+    })) as { items: FridayMemorySearchResult[] };
+
+    expect(result.items.some((entry) => entry.item.source === "learned_fact")).toBe(false);
   });
 
   // ─── Get handler ───

--- a/test/unit/hub/friday-hub-bootstrap.test.ts
+++ b/test/unit/hub/friday-hub-bootstrap.test.ts
@@ -51,7 +51,9 @@ describe("createFridayHub", () => {
   let autoDetectEnvSnapshot: FridayAutoDetectProviderEnvSnapshot | null = null;
   const originalSuppression = process.env.FRIDAY_SUPPRESS_TEST_ENV_SECURITY_WARNINGS;
 
-  async function createIsolatedHub(): Promise<FridayHub> {
+  async function createIsolatedHub(
+    overrides: Partial<Parameters<typeof createFridayHub>[0]> = {},
+  ): Promise<FridayHub> {
     stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "friday-hub-bootstrap-"));
     bundledSkillsDir = path.join(stateDir, "skills-empty");
     managedSkillsDir = path.join(stateDir, "managed-skills-empty");
@@ -60,6 +62,7 @@ describe("createFridayHub", () => {
     hub = await createFridayHub({
       skillDirs: [bundledSkillsDir, managedSkillsDir],
       stateDir,
+      ...overrides,
     });
     return hub;
   }
@@ -118,6 +121,119 @@ describe("createFridayHub", () => {
     expect(hub).toBeDefined();
     expect(hub.skills).toBeDefined();
     expect(hub.executor).toBeDefined();
+  });
+
+  it("fails closed for unsupported QQ in explicit startup channel config", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      hub = await createIsolatedHub({
+        channels: {
+          enabled: true,
+          instances: [
+            {
+              kind: "qq",
+              enabled: true,
+              appId: "qq-app",
+              appSecret: "qq-secret", // pragma: allowlist secret
+            },
+          ],
+        },
+      });
+
+      expect(hub.channelRegistry.list()).not.toContain("qq");
+      expect(warnSpy.mock.calls.some(([message]) =>
+        String(message).includes("Channel qq disabled: kind is unsupported in this release."),
+      )).toBe(true);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("fails closed for unsupported slack http mode in explicit startup channel config", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      hub = await createIsolatedHub({
+        channels: {
+          enabled: true,
+          instances: [
+            {
+              kind: "slack",
+              enabled: true,
+              botToken: "xoxb-stub",
+              mode: "http",
+              signingSecret: "stub-signing-secret", // pragma: allowlist secret
+            },
+          ],
+        },
+      });
+
+      expect(hub.channelRegistry.list()).not.toContain("slack");
+      expect(warnSpy.mock.calls.some(([message]) =>
+        String(message).includes("Channel slack disabled: mode http is unsupported in this release."),
+      )).toBe(true);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("still registers supported slack socket mode from explicit startup channel config", async () => {
+    process.env.FRIDAY_TEST_SLACK_BOT_TOKEN = "xoxb-stub";
+    process.env.FRIDAY_TEST_SLACK_APP_TOKEN = "xapp-stub";
+    try {
+      hub = await createIsolatedHub({
+        channels: {
+          enabled: true,
+          instances: [
+            {
+              kind: "slack",
+              enabled: true,
+              botToken: "env:FRIDAY_TEST_SLACK_BOT_TOKEN",
+              appToken: "env:FRIDAY_TEST_SLACK_APP_TOKEN",
+              mode: "socket",
+            },
+          ],
+        },
+      });
+
+      expect(hub.channelRegistry.list()).toContain("slack");
+    } finally {
+      delete process.env.FRIDAY_TEST_SLACK_BOT_TOKEN;
+      delete process.env.FRIDAY_TEST_SLACK_APP_TOKEN;
+    }
+  });
+
+  it("does not expose unsupported QQ as a runtime-supported channel kind", async () => {
+    hub = await createIsolatedHub();
+    const routes = hub.apiRuntime.routes.getRoutes();
+    const healthRoute = routes.find((route) => route.operationId === "health.capabilities");
+    const personaRoute = routes.find((route) => route.operationId === "channels.persona.get");
+
+    const health = await healthRoute!.handler({} as never) as {
+      capabilities: { channels: { supportedKinds: string[] } };
+    };
+
+    expect(health.capabilities.channels.supportedKinds).not.toContain("qq");
+    expect(health.capabilities.channels.supportedKinds).toContain("telegram");
+
+    await expect(personaRoute!.handler({
+      requestId: "req-channel-persona-qq",
+      receivedAt: "2026-05-26T00:00:00.000Z",
+      params: { kind: "qq" },
+      query: {},
+      body: null,
+      headers: {},
+      principal: null,
+    } as never)).rejects.toMatchObject({ code: "CHANNEL_NOT_FOUND" });
+
+    await expect(personaRoute!.handler({
+      requestId: "req-channel-persona-telegram",
+      receivedAt: "2026-05-26T00:00:00.000Z",
+      params: { kind: "telegram" },
+      query: {},
+      body: null,
+      headers: {},
+      principal: null,
+    } as never)).resolves.toMatchObject({ kind: "telegram", persona: null });
   });
 
   it("starts in stopped state", async () => {

--- a/test/unit/memory/persistence/friday-memory-embedding-repository.test.ts
+++ b/test/unit/memory/persistence/friday-memory-embedding-repository.test.ts
@@ -17,11 +17,12 @@ describe("FridayMemoryEmbeddingRepository", () => {
     key?: string,
     expiresAt?: string,
     tags: string[] = [],
+    memoryType?: string,
   ) {
     db.writer
       .prepare(
-        `INSERT INTO memory_items (id, namespace, key, value_json, content_text, source, tags_json, tags_text, metadata_json, expires_at, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO memory_items (id, namespace, key, value_json, content_text, source, tags_json, tags_text, metadata_json, expires_at, created_at, updated_at, memory_type)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
       .run(
         id,
@@ -36,6 +37,7 @@ describe("FridayMemoryEmbeddingRepository", () => {
         expiresAt ?? null,
         NOW,
         NOW,
+        memoryType ?? null,
       );
   }
 
@@ -203,6 +205,27 @@ describe("FridayMemoryEmbeddingRepository", () => {
 
     expect(results).toHaveLength(1);
     expect(results[0].itemId).toBe("mi-1");
+  });
+
+  it("filters by memoryType", () => {
+    insertMemoryItem("mi-1", "test", "mi-1", undefined, [], "fact");
+    insertMemoryItem("mi-2", "test", "mi-2", undefined, [], "preference");
+
+    db.writer.transaction(() => {
+      repo.upsert(db.writer, makeEmbedding({ id: "e1", itemId: "mi-1", vector: [1.0, 0.0, 0.0] }));
+      repo.upsert(db.writer, makeEmbedding({ id: "e2", itemId: "mi-2", providerId: "prov-1", vector: [1.0, 0.0, 0.0] }));
+    })();
+
+    const results = repo.querySimilar(db.writer, {
+      queryVector: [1.0, 0.0, 0.0],
+      model: "text-embedding-3-small",
+      nowIso: NOW,
+      memoryType: "preference",
+      limit: 10,
+      candidateLimit: 100,
+    });
+
+    expect(results.map((result) => result.itemId)).toEqual(["mi-2"]);
   });
 
   it("respects candidate limit", () => {

--- a/test/unit/memory/persistence/friday-memory-item-repository.test.ts
+++ b/test/unit/memory/persistence/friday-memory-item-repository.test.ts
@@ -147,6 +147,17 @@ describe("FridayMemoryItemRepository", () => {
     expect(items[0].source).toBe("agent");
   });
 
+  it("lists items filtered by memoryType", () => {
+    db.writer.transaction(() => {
+      repo.insert(db.writer, makeItem({ id: "i1", key: "k1", memoryType: "fact" }));
+      repo.insert(db.writer, makeItem({ id: "i2", key: "k2", memoryType: "preference" }));
+      repo.insert(db.writer, makeItem({ id: "i3", key: "k3", memoryType: "correction" }));
+    })();
+
+    const items = repo.list(db.writer, { memoryType: ["preference", "correction"], nowIso: NOW });
+    expect(items.map((item) => item.id).sort()).toEqual(["i2", "i3"]);
+  });
+
   it("lists items filtered by tagsAny", () => {
     db.writer.transaction(() => {
       repo.insert(db.writer, makeItem({ id: "i1", key: "k1", tags: ["python", "ai"] }));
@@ -287,6 +298,22 @@ describe("FridayMemoryItemRepository", () => {
     });
     expect(hits).toHaveLength(1);
     expect(hits[0].itemId).toBe("i1");
+  });
+
+  it("FTS respects memoryType filter", () => {
+    db.writer.transaction(() => {
+      repo.insert(db.writer, makeItem({ id: "i1", key: "k1", content: "machine learning preference", memoryType: "preference" }));
+      repo.insert(db.writer, makeItem({ id: "i2", key: "k2", content: "machine learning fact", memoryType: "fact" }));
+    })();
+
+    const hits = repo.searchFts(db.writer, {
+      text: "machine learning",
+      memoryType: "fact",
+      nowIso: NOW,
+      limit: 10,
+    });
+    expect(hits).toHaveLength(1);
+    expect(hits[0].itemId).toBe("i2");
   });
 
   it("FTS excludes expired items", () => {

--- a/test/unit/memory/search/friday-memory-hybrid.test.ts
+++ b/test/unit/memory/search/friday-memory-hybrid.test.ts
@@ -4,7 +4,7 @@ import type { FridayMemoryItem } from "../../../../src/memory/model/friday-memor
 
 describe("mergeHybridResults", () => {
   /** Helper to build a minimal FridayMemoryItem for merge tests. */
-  function makeItem(id: string, content = `content for ${id}`): FridayMemoryItem {
+  function makeItem(id: string, content = `content for ${id}`, confidence?: number): FridayMemoryItem {
     return {
       id,
       namespace: "test",
@@ -15,6 +15,7 @@ describe("mergeHybridResults", () => {
       metadata: {},
       createdAt: "2026-01-01T00:00:00.000Z",
       updatedAt: "2026-01-01T00:00:00.000Z",
+      confidence,
     };
   }
 
@@ -97,5 +98,39 @@ describe("mergeHybridResults", () => {
 
     // Combined weighted score: 0.7 * 0.45 + 0.9 * 0.55 = 0.315 + 0.495 = 0.81
     expect(hit.score).toBeCloseTo(0.81);
+  });
+
+  it("optionally boosts ordering with bounded confidence scores", () => {
+    const items = new Map<string, FridayMemoryItem>([
+      ["low", makeItem("low", "low confidence", 0.1)],
+      ["high", makeItem("high", "high confidence", 0.9)],
+    ]);
+
+    const unboosted = mergeHybridResults({
+      ftsHits: [
+        { itemId: "low", score: 0.5, snippet: "low" },
+        { itemId: "high", score: 0.48, snippet: "high" },
+      ],
+      semanticHits: [],
+      resolveItem: (id) => items.get(id) ?? null,
+      weights: { fts: 1, semantic: 0 },
+      limit: 10,
+    });
+
+    const boosted = mergeHybridResults({
+      ftsHits: [
+        { itemId: "low", score: 0.5, snippet: "low" },
+        { itemId: "high", score: 0.48, snippet: "high" },
+      ],
+      semanticHits: [],
+      resolveItem: (id) => items.get(id) ?? null,
+      weights: { fts: 1, semantic: 0 },
+      limit: 10,
+      boostByConfidence: true,
+    });
+
+    expect(unboosted[0].item.id).toBe("low");
+    expect(boosted[0].item.id).toBe("high");
+    expect(boosted.find((entry) => entry.item.id === "high")!.score).toBeCloseTo(0.525);
   });
 });

--- a/test/unit/memory/services/friday-memory-service.test.ts
+++ b/test/unit/memory/services/friday-memory-service.test.ts
@@ -276,6 +276,48 @@ describe("FridayMemoryService", () => {
     expect(results[0].matchedBy).toContain("fts");
   });
 
+  it("filters FTS results by memoryType", async () => {
+    const failService = createMockProviderService({ embedFails: true });
+    const svc = createFridayMemoryService({
+      db,
+      providerService: failService,
+      idGenerator: idGen,
+      nowIso: () => NOW,
+    });
+
+    await svc.store("typed-ns", "alpha typed memory", { memoryType: "fact" });
+    await svc.store("typed-ns", "alpha typed memory", { memoryType: "preference" });
+
+    const results = await svc.search("alpha typed", {
+      namespace: "typed-ns",
+      memoryType: "preference",
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].item.memoryType).toBe("preference");
+  });
+
+  it("filters semantic results by memoryType", async () => {
+    await service.store("semantic-typed-ns", "The user prefers short summaries", {
+      memoryType: "preference",
+    });
+    await service.store("semantic-typed-ns", "The API endpoint returns JSON", {
+      memoryType: "fact",
+    });
+
+    // No lexical overlap with either memory; mock embeddings make semantic
+    // retrieval deterministic and the repository-level memoryType filter must
+    // exclude the fact row before scoring.
+    const results = await service.search("compressed response style", {
+      namespace: "semantic-typed-ns",
+      memoryType: "preference",
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].matchedBy).toContain("semantic");
+    expect(results[0].item.memoryType).toBe("preference");
+  });
+
   it("does not warn when search falls back to FTS because no embedding route is configured", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const svc = createFridayMemoryService({
@@ -426,6 +468,32 @@ describe("FridayMemoryService", () => {
       expect(results.length).toBeGreaterThanOrEqual(1);
       expect(results[0].item.content).toContain("configuration");
       expect(results[0].score).toBeCloseTo(0.1);
+    });
+
+    it("namespace substring fallback honors memoryType filtering", async () => {
+      const failService = createMockProviderService({ embedFails: true });
+      const svc = createFridayMemoryService({
+        db,
+        providerService: failService,
+        idGenerator: idGen,
+        nowIso: () => NOW,
+      });
+
+      await svc.store("fallback-type-ns", "server configuration details here", {
+        memoryType: "fact",
+      });
+      await svc.store("fallback-type-ns", "server configuration preference note", {
+        memoryType: "preference",
+      });
+
+      const results = await svc.search("figurat", {
+        namespace: "fallback-type-ns",
+        memoryType: "preference",
+      });
+
+      expect(results).toHaveLength(1);
+      expect(results[0].item.memoryType).toBe("preference");
+      expect(results[0].item.content).toContain("preference note");
     });
 
     it("substring fallback honors minScore cutoff", async () => {


### PR DESCRIPTION
## Summary

- fail closed for unsupported QQ and Slack HTTP startup channel configs, while preserving Slack Socket Mode
- stop exposing QQ as a runtime-supported channel kind through hub health/persona route wiring
- wire memory cognition fields through store/search: memoryType filtering, confidence persistence, and boostByConfidence ranking
- tighten memory.store confidence validation so non-number values like null/false/"0.5" reject instead of coercing

## Proof

- npx vitest run test/unit/hub/friday-hub-bootstrap.test.ts test/unit/api/http/routes/friday-memory-routes.test.ts test/unit/memory/persistence/friday-memory-embedding-repository.test.ts test/unit/memory/persistence/friday-memory-item-repository.test.ts test/unit/memory/search/friday-memory-hybrid.test.ts test/unit/memory/services/friday-memory-service.test.ts — 137 passed
- npm run typecheck — pass
- npm run build — pass
- npm run release:check — pass
- npm run check:secret-patterns — pass
- npm run check:proof:no-mock-leaks — pass
- git diff --check — pass
- npm test — 12046 passed, 252 skipped, 0 type errors
- Reviewer A: PASS
- Reviewer B: PASS

## Residual truth labels

- Slack is still represented at kind granularity in health metadata; unsupported http mode is enforced at config/startup boundaries, while socket remains supported.
- Direct non-HTTP JS callers still rely on typed inputs for confidence shape; strict runtime rejection is now proven at the public HTTP route boundary.

## Release claim

No release claim is widened. This is post-release hardening toward truthful capability state and memory cognition wiring.
