### PR TITLE
fix(hub): persist skill repair evidence markers

### DIFF
--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -1227,18 +1227,27 @@ export function createFridayHubAutoFixExecutionSupport(deps: {
       return false;
     }
 
+    const payload = readPayloadRecord(step.payload);
     const revert = isRevertPayload(step.payload);
     if (!revert && !deps.registry.get(step.target)) {
       return false;
     }
 
+    const nextStatus = revert ? "installed" : "disabled";
+    const nowIso = deps.nowIso();
     await deps.memoryState.updateSkillStatus(
       step.target,
-      revert ? "installed" : "disabled",
+      nextStatus,
       revert
-        ? `auto-fix rollback @ ${deps.nowIso()}`
-        : `auto-fix disable_skill @ ${deps.nowIso()}`,
+        ? `auto-fix rollback @ ${nowIso}`
+        : `auto-fix disable_skill @ ${nowIso}`,
     );
+    if (payload) {
+      payload._skillDisabled = !revert;
+      payload._skillStatusAfter = nextStatus;
+      payload._skillStatusTarget = step.target;
+      payload._skillStatusAt = nowIso;
+    }
     return true;
   };
 

--- a/test/unit/hub/bootstrap/hub-helpers.test.ts
+++ b/test/unit/hub/bootstrap/hub-helpers.test.ts
@@ -224,6 +224,12 @@ describe("createFridayHubAutoFixExecutionSupport", () => {
 
     const statuses = await memoryState.listSkillStatuses();
     expect(statuses["skill-x"]).toBe("disabled");
+    expect(step.payload).toMatchObject({
+      _skillDisabled: true,
+      _skillStatusAfter: "disabled",
+      _skillStatusTarget: "skill-x",
+      _skillStatusAt: "2026-03-13T10:00:00.000Z",
+    });
   });
 
   it("revert payload restores the installed state", async () => {
@@ -247,6 +253,12 @@ describe("createFridayHubAutoFixExecutionSupport", () => {
 
     const statuses = await memoryState.listSkillStatuses();
     expect(statuses["skill-x"]).toBe("installed");
+    expect(step.payload).toMatchObject({
+      _skillDisabled: false,
+      _skillStatusAfter: "installed",
+      _skillStatusTarget: "skill-x",
+      _skillStatusAt: "2026-03-13T10:00:00.000Z",
+    });
   });
 
   it("Phase 14.5B module_28b: apply_config_patch is fail-closed when no real patch payload is provided", async () => {


### PR DESCRIPTION
## Summary

- persist `disable_skill` execution evidence markers on the auto-fix payload (`_skillDisabled`, `_skillStatusAfter`, `_skillStatusTarget`, `_skillStatusAt`)
- align rollback payload evidence with the restored installed state
- add unit coverage for both disable and rollback marker persistence

## Why

The DP-02 deterministic skill-drift proof found a real cross-layer gap: Friday could apply a `disable_skill` repair and update the skill status, but the self-healing receipt still classified the result as `diagnostic_only` because the executor did not write the evidence marker consumed by the self-healing acceptance layer.

This keeps the safety gates unchanged: unauthenticated execute remains denied, pre-approval execution remains denied, and approved execution can now produce a truthful `verified_repair` receipt when the skill is actually disabled.

## Local verification

- `npx vitest run --project default test/unit/hub/bootstrap/hub-helpers.test.ts -t "disables a skill and verifies the disabled state|revert payload restores the installed state"`
- `npm run build:api`
- `npx vitest run --project default test/unit/hub/bootstrap/hub-helpers.test.ts test/unit/learning/services/friday-auto-fix-execution-service.test.ts test/e2e/api/friday-api-auto-fix-doctor.acceptance.test.ts`
- isolated runtime proof: skill drift -> incident -> planned action -> unauth execute 401 -> pre-approval execute 403/no mutation -> approval -> agent-loop execution -> `verified_repair` -> skill disabled
- `npm test` (PASS: 882 files / 12052 tests / 0 type errors)

## Evidence artifacts

- `/Users/jarvis/Desktop/Friday-global-state-review-20260526/DETERMINISTIC_SELF_HEALING_SKILL_DRIFT_PROOF_20260527.md`
- `/Users/jarvis/Desktop/Friday-global-state-review-20260526/DP02_LOCAL_FIX_PR_HANDOFF_20260527.md`
