### PR TITLE
fix(skills): close link-to-skill lifecycle

### DIFF
--- a/src/deeplink/friday-deeplink-validator.ts
+++ b/src/deeplink/friday-deeplink-validator.ts
@@ -169,7 +169,12 @@ function validateSkillSource(
   if (!source.url) {
     checks.push({ id: "skill-url", label: "Source URL", level: "blocking", summary: "Skill source URL is required." });
   } else if (isPrivateUrl(source.url)) {
-    checks.push({ id: "skill-url-private", label: "Source URL", level: "warning", summary: "Source URL points to a private/local address." });
+    checks.push({
+      id: "skill-url-private",
+      label: "Source URL",
+      level: "blocking",
+      summary: "Source URL points to a private/local address and cannot be used for skill-source deep-link staging.",
+    });
   }
   permissions.push("Will stage an external skill candidate for review.");
   permissions.push("Skill will not be installed or made available until lifecycle validation, approval, and promotion complete.");

--- a/src/skills/converter/converters/friday-link-evidence-skill-converter.ts
+++ b/src/skills/converter/converters/friday-link-evidence-skill-converter.ts
@@ -1,0 +1,277 @@
+/**
+ * Link evidence → Friday package converter.
+ *
+ * Converts a redacted, evidence-only link summary payload into a deterministic
+ * shell skill candidate. The generated skill does not fetch the URL at run
+ * time; it carries the extracted evidence forward for review and lifecycle
+ * promotion.
+ */
+
+import { Buffer } from "node:buffer";
+
+import { FridayDomainError } from "#errors";
+
+import type {
+  FridayConvertedSkillDraft,
+  FridayConvertedSkillFile,
+  FridaySkillConversionSource,
+  FridaySkillConverter,
+  FridaySkillConverterContext,
+  FridaySkillConverterDetection,
+  FridaySkillConverterResult,
+} from "../model/friday-skill-converter.types.js";
+import type { SkillManifestV2 } from "../../model/friday-skill-manifest-v2.types.js";
+import type { FridaySkillUiSchemaV1 } from "../../generator/model/friday-skill-ui-schema.types.js";
+
+const CONVERTER_ID = "link-evidence-skill";
+const CONVERTER_DISPLAY_NAME = "Link Evidence Skill";
+const CONVERTER_PRIORITY = 95;
+export const FRIDAY_LINK_EVIDENCE_SKILL_PAYLOAD_SCHEMA = "friday.link-to-skill.candidate-source.v1";
+
+export interface FridayLinkEvidenceSkillPayload {
+  readonly $schema: typeof FRIDAY_LINK_EVIDENCE_SKILL_PAYLOAD_SCHEMA;
+  readonly sourceDigest: string;
+  readonly redactedUrl: string;
+  readonly title: string | null;
+  readonly summary: string;
+  readonly contentType: string | null;
+  readonly skillId: string;
+  readonly skillName: string;
+  readonly skillDescription: string;
+  readonly skillVersion: string;
+}
+
+export function createFridayLinkEvidenceSkillConverter(): FridaySkillConverter {
+  return {
+    id: CONVERTER_ID,
+    displayName: CONVERTER_DISPLAY_NAME,
+    priority: CONVERTER_PRIORITY,
+
+    async detect(source: FridaySkillConversionSource): Promise<FridaySkillConverterDetection | null> {
+      const payload = tryDecodePayload(source);
+      if (!payload) return null;
+      return {
+        converterId: CONVERTER_ID,
+        format: "friday-package",
+        confidence: 1.0,
+        reasons: [`contentBase64 payload matches schema ${FRIDAY_LINK_EVIDENCE_SKILL_PAYLOAD_SCHEMA}`],
+      };
+    },
+
+    async convert(
+      source: FridaySkillConversionSource,
+      ctx: FridaySkillConverterContext,
+    ): Promise<FridaySkillConverterResult> {
+      const payload = tryDecodePayload(source);
+      if (!payload) {
+        throw new FridayDomainError(
+          "VALIDATION_ERROR",
+          "Link evidence skill converter requires a valid contentBase64 payload",
+          { httpStatus: 400 },
+        );
+      }
+
+      const manifest = buildManifest(payload);
+      const uiSchema = buildUiSchema(manifest);
+      const entrypointFile = buildEntrypointFile(payload);
+      const conversionReportFile: FridayConvertedSkillFile = {
+        path: "conversion.report.json",
+        content: JSON.stringify({
+          sourceFormat: "friday-package",
+          convertedAt: ctx.nowIso(),
+          converterId: CONVERTER_ID,
+          linkEvidencePayloadSchema: FRIDAY_LINK_EVIDENCE_SKILL_PAYLOAD_SCHEMA,
+          sourceDigest: payload.sourceDigest,
+          redactedUrl: payload.redactedUrl,
+          title: payload.title,
+          contentType: payload.contentType,
+        }, null, 2),
+      };
+      const manifestFile: FridayConvertedSkillFile = {
+        path: "skill.manifest.json",
+        content: JSON.stringify(manifest, null, 2),
+      };
+      const uiSchemaFile: FridayConvertedSkillFile = {
+        path: "skill.ui.json",
+        content: JSON.stringify(uiSchema, null, 2),
+      };
+      const evidenceFile: FridayConvertedSkillFile = {
+        path: "LINK_EVIDENCE.md",
+        content: [
+          `# ${payload.skillName}`,
+          "",
+          `Source: ${payload.redactedUrl}`,
+          payload.title ? `Title: ${payload.title}` : undefined,
+          "",
+          payload.summary,
+          "",
+        ].filter((line): line is string => line !== undefined).join("\n"),
+      };
+
+      const draft: FridayConvertedSkillDraft = {
+        manifest,
+        uiSchema,
+        files: [manifestFile, uiSchemaFile, entrypointFile, evidenceFile, conversionReportFile],
+        warnings: [],
+        conversionReport: {
+          sourceFormat: "friday-package",
+          convertedAt: ctx.nowIso(),
+          converterId: CONVERTER_ID,
+        },
+      };
+
+      return {
+        converterId: CONVERTER_ID,
+        detectedFormat: "friday-package",
+        drafts: [draft],
+      };
+    },
+  };
+}
+
+function tryDecodePayload(source: FridaySkillConversionSource): FridayLinkEvidenceSkillPayload | null {
+  if (!source.contentBase64) return null;
+  try {
+    const decoded = Buffer.from(source.contentBase64, "base64").toString("utf8");
+    const parsed = JSON.parse(decoded) as Record<string, unknown>;
+    if (parsed.$schema !== FRIDAY_LINK_EVIDENCE_SKILL_PAYLOAD_SCHEMA) return null;
+    if (!isSha256Hex(parsed.sourceDigest)) return null;
+    if (!isRedactedHttpUrl(parsed.redactedUrl)) return null;
+    if (parsed.title !== null && parsed.title !== undefined && !isNonEmptyString(parsed.title)) return null;
+    if (!isNonEmptyString(parsed.summary)) return null;
+    if (parsed.contentType !== null && parsed.contentType !== undefined && typeof parsed.contentType !== "string") return null;
+    if (!isSafePayloadIdentifier(parsed.skillId)) return null;
+    if (!isNonEmptyString(parsed.skillName)) return null;
+    if (!isNonEmptyString(parsed.skillDescription)) return null;
+    if (!isSafeVersion(parsed.skillVersion)) return null;
+    return {
+      ...parsed,
+      title: parsed.title ?? null,
+      contentType: parsed.contentType ?? null,
+    } as unknown as FridayLinkEvidenceSkillPayload;
+  } catch {
+    return null;
+  }
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isSafePayloadIdentifier(value: unknown): value is string {
+  return isNonEmptyString(value) && /^[A-Za-z0-9._:-]+$/.test(value);
+}
+
+function isSafeVersion(value: unknown): value is string {
+  return isNonEmptyString(value) && /^[0-9A-Za-z._:-]+$/.test(value);
+}
+
+function isSha256Hex(value: unknown): value is string {
+  return typeof value === "string" && /^[a-f0-9]{64}$/i.test(value);
+}
+
+function isRedactedHttpUrl(value: unknown): value is string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return false;
+  }
+  try {
+    const parsed = new URL(value);
+    return (parsed.protocol === "https:" || parsed.protocol === "http:")
+      && parsed.username === ""
+      && parsed.password === "";
+  } catch {
+    return false;
+  }
+}
+
+function buildManifest(payload: FridayLinkEvidenceSkillPayload): SkillManifestV2 {
+  return {
+    schemaVersion: "2.0",
+    id: payload.skillId,
+    name: payload.skillName,
+    description: payload.skillDescription,
+    version: payload.skillVersion,
+    kind: "conversation",
+    category: "utility",
+    author: { name: "friday-link-to-skill" },
+    tags: ["link-to-skill", "evidence-derived"],
+    runtime: {
+      kind: "shell",
+      entrypoint: "run.sh",
+      minHubVersion: "1.0.0",
+      apiVersion: "1",
+      timeoutMsDefault: 5_000,
+    },
+    triggers: {
+      intents: [`link_to_skill.${payload.skillId}`],
+      phrases: [`use ${payload.skillName}`],
+      channels: ["*"],
+    },
+    invocation: {
+      userInvocable: true,
+      modelInvocable: true,
+      priority: 50,
+      modes: ["intent"],
+    },
+    requirements: { bins: [], env: [], config: [], os: ["darwin", "linux", "win32"] },
+    inputs: [],
+    outputs: [{ key: "result", type: "object", description: "Extracted link evidence result" }],
+    permissions: { grants: [], promptOn: [] },
+    schemas: { input: null, state: null, output: null },
+    flow: null,
+    executionTargets: {
+      allowedSatelliteTypes: ["desktop", "cloud-vm"],
+      requiredCapabilities: [],
+    },
+    telemetry: { events: [] },
+  };
+}
+
+function buildUiSchema(manifest: SkillManifestV2): FridaySkillUiSchemaV1 {
+  return {
+    schemaVersion: "1.0",
+    title: manifest.name,
+    description: manifest.description || undefined,
+    sections: [{ id: "main", label: "Evidence", fieldIds: [] }],
+    fields: [],
+    outputs: manifest.outputs.map((output) => ({
+      id: `output-${output.key}`,
+      outputKey: output.key,
+      label: output.description ?? output.key,
+      widget: "text",
+    })),
+    actions: [
+      { id: "run", label: "Run", style: "primary" },
+      { id: "reset", label: "Reset", style: "secondary" },
+    ],
+  };
+}
+
+function buildEntrypointFile(payload: FridayLinkEvidenceSkillPayload): FridayConvertedSkillFile {
+  const result = {
+    status: "link_evidence_ready",
+    sourceDigest: payload.sourceDigest,
+    redactedUrl: payload.redactedUrl,
+    title: payload.title,
+    summary: payload.summary,
+  };
+  const content = [
+    "#!/usr/bin/env sh",
+    `# Link evidence skill generated from ${shellCommentText(payload.redactedUrl)}`,
+    `printf '%s\\n' ${shellSingleQuote(JSON.stringify(result))}`,
+    "",
+  ].join("\n");
+  return {
+    path: "run.sh",
+    content,
+    executable: true,
+  };
+}
+
+function shellSingleQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function shellCommentText(value: string): string {
+  return value.replace(/[\r\n\0]/g, " ");
+}

--- a/src/skills/converter/converters/index.ts
+++ b/src/skills/converter/converters/index.ts
@@ -2,6 +2,7 @@ import { createFridayAdkSkillConverter } from "./friday-adk-skill-converter.js";
 import { createClawdbotSkillMdConverter } from "./friday-clawdbot-skill-md-converter.js";
 import { createFridayCodeRepoConverter } from "./friday-code-repo-converter.js";
 import { createFridayDiscoveryIntegrationConverter } from "./friday-discovery-integration-converter.js";
+import { createFridayLinkEvidenceSkillConverter } from "./friday-link-evidence-skill-converter.js";
 import { createFridayN8nNodeConverter } from "./friday-n8n-node-converter.js";
 import {
   createFridayOpenAiGptActionConverter,
@@ -14,6 +15,11 @@ export { createFridayAdkSkillConverter } from "./friday-adk-skill-converter.js";
 export { createClawdbotSkillMdConverter } from "./friday-clawdbot-skill-md-converter.js";
 export { createNativeSkillPackageConverter } from "./friday-native-skill-package-converter.js";
 export { createFridayDiscoveryIntegrationConverter } from "./friday-discovery-integration-converter.js";
+export {
+  createFridayLinkEvidenceSkillConverter,
+  FRIDAY_LINK_EVIDENCE_SKILL_PAYLOAD_SCHEMA,
+} from "./friday-link-evidence-skill-converter.js";
+export type { FridayLinkEvidenceSkillPayload } from "./friday-link-evidence-skill-converter.js";
 export { createFridayN8nNodeConverter } from "./friday-n8n-node-converter.js";
 export { createFridayOpenAiGptActionConverter } from "./friday-openai-gpt-action-converter.js";
 export { createFridayUndocumentedApiConverter } from "./friday-undocumented-api-converter.js";
@@ -24,6 +30,7 @@ export type { OpenAiGptActionConverterOptions } from "./friday-openai-gpt-action
 
 export const FRIDAY_DEFAULT_CONVERTER_FACTORIES = [
   createNativeSkillPackageConverter,
+  createFridayLinkEvidenceSkillConverter,
   createFridayDiscoveryIntegrationConverter,
   createFridayAdkSkillConverter,
   createClawdbotSkillMdConverter,

--- a/src/skills/converter/index.ts
+++ b/src/skills/converter/index.ts
@@ -60,6 +60,8 @@ export {
   createFridayCodeRepoConverter,
   createFridayDiscoveryIntegrationConverter,
   FRIDAY_DEFAULT_CONVERTER_FACTORIES,
+  createFridayLinkEvidenceSkillConverter,
+  FRIDAY_LINK_EVIDENCE_SKILL_PAYLOAD_SCHEMA,
   createNativeSkillPackageConverter,
   createFridayN8nNodeConverter,
   createFridayOpenAiGptActionConverter,
@@ -69,6 +71,7 @@ export {
 
 export type {
   OpenAiGptActionConverterOptions,
+  FridayLinkEvidenceSkillPayload,
 } from "./converters/index.js";
 
 export type {

--- a/src/skills/index.ts
+++ b/src/skills/index.ts
@@ -301,6 +301,20 @@ export {
 // Converter (re-export key types for convenience; full module at #skills/converter)
 export type { FridaySkillConverterService } from "./converter/services/friday-skill-converter-service.types.js";
 
+// Link-to-skill
+export {
+  buildFridayLinkToSkillCandidateSource,
+  createFridayLinkToSkillService,
+} from "./link-to-skill/index.js";
+export type {
+  CreateFridayLinkToSkillServiceDeps,
+  FridayLinkToSkillService,
+  FridayLinkToSkillSourceBuildInput,
+  FridayLinkToSkillSourceBuildResult,
+  FridayLinkToSkillStageInput,
+  FridayLinkToSkillStageResult,
+} from "./link-to-skill/index.js";
+
 // Watcher
 export { createFridaySkillWatcher } from "./registry/friday-skill-watcher.js";
 export type { FridaySkillFileChangeEvent, FridaySkillWatcher } from "./registry/friday-skill-watcher.js";

--- a/src/skills/link-to-skill/friday-link-to-skill-service.ts
+++ b/src/skills/link-to-skill/friday-link-to-skill-service.ts
@@ -1,0 +1,264 @@
+import { createHash } from "node:crypto";
+import { Buffer } from "node:buffer";
+
+import { FridayDomainError } from "#errors";
+import type {
+  FridayLinkSummary,
+  FridayLinkUnderstandingService,
+} from "#link-understanding";
+import {
+  createFridayAgentSsrfGuard,
+  FridaySsrfBlockedError,
+} from "../../agent/security/friday-agent-ssrf-guard.js";
+import type {
+  FridayCanonicalApprovalResolution,
+  FridayMutatingActionActor,
+  FridayMutatingActionGate,
+  FridayMutatingActionTicket,
+} from "../../security/friday-mutating-action-gate.js";
+import type {
+  FridaySkillConversionSource,
+  FridaySkillConverterService,
+  FridaySkillImportOutput,
+} from "../converter/index.js";
+import {
+  createFridaySkillStageMutatingActionRequest,
+  FRIDAY_LINK_EVIDENCE_SKILL_PAYLOAD_SCHEMA,
+  type FridayLinkEvidenceSkillPayload,
+  redactFridaySkillCandidateSourceUri,
+} from "../converter/index.js";
+
+export interface FridayLinkToSkillSourceBuildInput {
+  readonly evidence: FridayLinkSummary;
+  readonly skillId?: string;
+  readonly skillName?: string;
+  readonly skillDescription?: string;
+  readonly skillVersion?: string;
+}
+
+export interface FridayLinkToSkillSourceBuildResult {
+  readonly source: FridaySkillConversionSource;
+  readonly payload: FridayLinkEvidenceSkillPayload;
+}
+
+export interface FridayLinkToSkillStageInput {
+  readonly text: string;
+  readonly canonicalApprovalTicket?: FridayMutatingActionTicket;
+  readonly actor?: FridayMutatingActionActor;
+  readonly surface?: string;
+  readonly idempotencyKey?: string;
+  readonly planDigest?: string;
+  readonly canonicalApproval?: FridayCanonicalApprovalResolution;
+  readonly skillId?: string;
+  readonly skillName?: string;
+  readonly skillDescription?: string;
+  readonly skillVersion?: string;
+}
+
+export interface FridayLinkToSkillStageResult {
+  readonly evidence: FridayLinkSummary;
+  readonly source: FridaySkillConversionSource;
+  readonly importResult: FridaySkillImportOutput;
+}
+
+export interface FridayLinkToSkillService {
+  stageFromText(input: FridayLinkToSkillStageInput): Promise<FridayLinkToSkillStageResult>;
+}
+
+export interface CreateFridayLinkToSkillServiceDeps {
+  readonly linkUnderstanding: Pick<FridayLinkUnderstandingService, "processText">;
+  readonly converterService: FridaySkillConverterService;
+  readonly canonicalMutationGate?: FridayMutatingActionGate;
+}
+
+const linkToSkillSsrfGuard = createFridayAgentSsrfGuard();
+
+export function createFridayLinkToSkillService(
+  deps: CreateFridayLinkToSkillServiceDeps,
+): FridayLinkToSkillService {
+  return {
+    async stageFromText(input) {
+      const summaries = await deps.linkUnderstanding.processText(input.text);
+      const evidence = summaries[0];
+      if (!evidence) {
+        throw new FridayDomainError(
+          "LINK_TO_SKILL_NO_LINK_EVIDENCE",
+          "No fetchable link evidence was found to generate a skill candidate.",
+          { httpStatus: 422 },
+        );
+      }
+
+      const built = buildFridayLinkToSkillCandidateSource({
+        evidence,
+        skillId: input.skillId,
+        skillName: input.skillName,
+        skillDescription: input.skillDescription,
+        skillVersion: input.skillVersion,
+      });
+      const canonicalApprovalTicket = input.canonicalApprovalTicket ?? assertCanonicalStageTicket({
+        deps,
+        source: built.source,
+        actor: input.actor,
+        surface: input.surface,
+        idempotencyKey: input.idempotencyKey,
+        planDigest: input.planDigest,
+        canonicalApproval: input.canonicalApproval,
+      });
+      const importResult = await deps.converterService.import({
+        source: built.source,
+        formatHint: "auto",
+        canonicalApprovalTicket,
+      });
+
+      return {
+        evidence,
+        source: built.source,
+        importResult,
+      };
+    },
+  };
+}
+
+function assertCanonicalStageTicket(input: {
+  deps: CreateFridayLinkToSkillServiceDeps;
+  source: FridaySkillConversionSource;
+  actor?: FridayMutatingActionActor;
+  surface?: string;
+  idempotencyKey?: string;
+  planDigest?: string;
+  canonicalApproval?: FridayCanonicalApprovalResolution;
+}): FridayMutatingActionTicket {
+  if (!input.deps.canonicalMutationGate) {
+    throw new FridayDomainError(
+      "LINK_TO_SKILL_CANONICAL_GATE_UNAVAILABLE",
+      "Link-to-skill candidate generation requires the canonical approval gate.",
+      { httpStatus: 503 },
+    );
+  }
+
+  const actor = input.actor ?? {
+    kind: "api",
+    id: "api:link-to-skill",
+    principalId: "api:link-to-skill",
+  };
+  const gateResult = input.deps.canonicalMutationGate.evaluate(
+    createFridaySkillStageMutatingActionRequest({
+      source: input.source,
+      formatHint: "auto",
+      actor,
+      surface: input.surface ?? "api:link-to-skill",
+      idempotencyKey: input.idempotencyKey,
+      planDigest: input.planDigest,
+      canonicalApproval: input.canonicalApproval,
+    }),
+  );
+
+  if (gateResult.decision !== "allow" || !gateResult.ticket) {
+    throw new FridayDomainError(
+      gateResult.decision === "requires_approval"
+        ? "CANONICAL_APPROVAL_REQUIRED"
+        : "CANONICAL_APPROVAL_DENIED",
+      gateResult.decision === "requires_approval"
+        ? "Link-to-skill candidate generation requires canonical approval before any candidate is written."
+        : `Link-to-skill candidate generation was blocked by the canonical approval gate: ${gateResult.reason}`,
+      {
+        httpStatus: 403,
+        details: { canonicalGate: gateResult.evidenceRecord },
+      },
+    );
+  }
+  return gateResult.ticket;
+}
+
+export function buildFridayLinkToSkillCandidateSource(
+  input: FridayLinkToSkillSourceBuildInput,
+): FridayLinkToSkillSourceBuildResult {
+  assertPublicLinkEvidenceUrl(input.evidence.url);
+  const sourceDigest = hashString(input.evidence.url);
+  const defaultSkillId = `link-skill-${sourceDigest.slice(0, 16)}`;
+  const skillId = safePayloadIdentifier(input.skillId ?? defaultSkillId);
+  const title = cleanOptionalText(input.evidence.title, 120);
+  const skillName = cleanText(
+    input.skillName ?? title ?? `Link skill ${sourceDigest.slice(0, 8)}`,
+    96,
+  );
+  const summary = cleanText(input.evidence.summary, 2_000);
+  const skillDescription = cleanText(
+    input.skillDescription ?? `Generated from extracted link evidence: ${summary}`,
+    240,
+  );
+
+  const payload: FridayLinkEvidenceSkillPayload = {
+    $schema: FRIDAY_LINK_EVIDENCE_SKILL_PAYLOAD_SCHEMA,
+    sourceDigest,
+    redactedUrl: redactFridaySkillCandidateSourceUri(input.evidence.url),
+    title,
+    summary,
+    contentType: cleanOptionalText(input.evidence.contentType, 120),
+    skillId,
+    skillName,
+    skillDescription,
+    skillVersion: input.skillVersion ?? "1.0.0",
+  };
+
+  return {
+    source: {
+      contentBase64: Buffer.from(JSON.stringify(payload)).toString("base64"),
+      formatHint: "friday-package",
+    },
+    payload,
+  };
+}
+
+function assertPublicLinkEvidenceUrl(url: string): void {
+  try {
+    linkToSkillSsrfGuard.validate(url);
+  } catch (err) {
+    if (err instanceof FridaySsrfBlockedError) {
+      throw new FridayDomainError(
+        "LINK_TO_SKILL_URL_BLOCKED",
+        "Link-to-skill evidence URL points to a private/local address and cannot be used for skill candidate generation.",
+        { httpStatus: 422 },
+      );
+    }
+    throw err;
+  }
+}
+
+function safePayloadIdentifier(value: string): string {
+  const normalized = value.trim().toLowerCase()
+    .replace(/[^a-z0-9._:-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+  if (normalized.length === 0) {
+    throw new FridayDomainError(
+      "LINK_TO_SKILL_INVALID_SKILL_ID",
+      "Link-to-skill generated an empty skill id.",
+      { httpStatus: 422 },
+    );
+  }
+  return normalized;
+}
+
+function cleanText(value: string, maxLength: number): string {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (normalized.length === 0) {
+    throw new FridayDomainError(
+      "LINK_TO_SKILL_EMPTY_EVIDENCE",
+      "Link-to-skill evidence text is empty.",
+      { httpStatus: 422 },
+    );
+  }
+  return normalized.length <= maxLength ? normalized : `${normalized.slice(0, Math.max(0, maxLength - 3))}...`;
+}
+
+function cleanOptionalText(value: string | null, maxLength: number): string | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (normalized.length === 0) return null;
+  return normalized.length <= maxLength ? normalized : `${normalized.slice(0, Math.max(0, maxLength - 3))}...`;
+}
+
+function hashString(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}

--- a/src/skills/link-to-skill/index.ts
+++ b/src/skills/link-to-skill/index.ts
@@ -1,0 +1,13 @@
+export {
+  buildFridayLinkToSkillCandidateSource,
+  createFridayLinkToSkillService,
+} from "./friday-link-to-skill-service.js";
+
+export type {
+  CreateFridayLinkToSkillServiceDeps,
+  FridayLinkToSkillService,
+  FridayLinkToSkillSourceBuildInput,
+  FridayLinkToSkillSourceBuildResult,
+  FridayLinkToSkillStageInput,
+  FridayLinkToSkillStageResult,
+} from "./friday-link-to-skill-service.js";

--- a/test/e2e/api/friday-api-skill-upgrade-lifecycle-live.test.ts
+++ b/test/e2e/api/friday-api-skill-upgrade-lifecycle-live.test.ts
@@ -60,16 +60,31 @@ import type { FridayApiRuntime, FridayHttpServer } from "#api";
 import type { FridaySqliteLayer } from "#state";
 import { runFridayMigrations, FRIDAY_SQLITE_MIGRATIONS } from "#state";
 import { createFridayProviderService } from "#providers";
+import {
+  createFridayLinkCacheRepository,
+  createFridayLinkUnderstandingService,
+} from "#link-understanding";
 import { createFridayMutatingActionGate } from "../../../src/security/friday-mutating-action-gate.js";
 import {
+  buildFridayLinkToSkillCandidateSource,
+  createFridayLinkToSkillService,
   FridaySkillRegistryImpl,
   createFridaySkillExecutor,
   FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS_ENV,
   createFridaySkillRepository,
+  createFridaySkillRunMutatingActionRequest,
 } from "#skills";
 import type {
   FridaySkillConverterService,
   FridayExternalSkillCandidate,
+} from "#skills/converter";
+import {
+  createFridayLinkEvidenceSkillConverter,
+  createFridaySkillConverterRegistry,
+  createFridaySkillConverterService,
+  createFridaySkillImportInstaller,
+  createFridaySkillPackageArchiver,
+  createFridaySkillStageMutatingActionRequest,
 } from "#skills/converter";
 import { createFridaySkillRunStore } from "#ledger";
 import type {
@@ -97,6 +112,7 @@ const SKILL_ID = "phase14-skill-upgrade-proof";
 const RUNTIME_VERSION = "runtime-phase14";
 const PROVIDER_MODEL = "phase14-no-provider";
 const PLAN_DIGEST = "phase14-upgrade-plan-digest";
+const LINK_TO_SKILL_SOURCE_URL = "https://example.com/friday-link-skill?token=deeplink-proof-token";
 
 // ── Local helpers ─────────────────────────────────────────────────────────
 
@@ -281,28 +297,90 @@ function buildCandidate(input: {
   };
 }
 
-function createConverterServiceStub(): FridaySkillConverterService & {
-  registerCandidate(candidate: FridayExternalSkillCandidate): void;
+function createConverterServiceStub(fallback?: FridaySkillConverterService): FridaySkillConverterService & {
+  registerCandidate(candidate: FridayExternalSkillCandidate, sourceUri?: string): void;
 } {
-  const candidates = new Map<string, FridayExternalSkillCandidate>();
+  const sourceCandidates = new Map<string, FridayExternalSkillCandidate>();
+  const stagedCandidates = new Map<string, FridayExternalSkillCandidate>();
   return {
-    registerCandidate(candidate) {
-      candidates.set(`${candidate.skillId}::${candidate.candidateId}`, candidate);
+    registerCandidate(candidate, sourceUri) {
+      sourceCandidates.set(`file://${candidate.candidateId}`, candidate);
+      if (sourceUri) {
+        sourceCandidates.set(sourceUri, candidate);
+      }
     },
-    listConverters: () => [],
-    detect: async () => null,
-    convert: async () => {
+    listConverters: () => fallback?.listConverters() ?? [],
+    detect: async (source) => fallback?.detect(source) ?? null,
+    convert: async (input) => {
+      if (fallback) return fallback.convert(input);
       throw new Error("convert is not supported in the Phase 14 lifecycle proof test");
     },
     getCandidate: ({ skillId, candidateId }) =>
-      candidates.get(`${skillId}::${candidateId}`) ?? null,
-    import: async () => {
-      throw new Error("import is not supported in the Phase 14 lifecycle proof test");
+      stagedCandidates.get(`${skillId}::${candidateId}`)
+        ?? fallback?.getCandidate({ skillId, candidateId })
+        ?? null,
+    import: async (input) => {
+      const candidate = input.source.uri ? sourceCandidates.get(input.source.uri) : undefined;
+      if (!candidate && fallback) {
+        return fallback.import(input);
+      }
+      if (!candidate) {
+        throw new Error("unknown Phase 14 lifecycle proof skill source");
+      }
+      stagedCandidates.set(`${candidate.skillId}::${candidate.candidateId}`, candidate);
+      return {
+        converterId: candidate.converterId,
+        detectedFormat: candidate.detectedFormat,
+        candidates: [candidate],
+        validation: [
+          {
+            skillId: candidate.skillId,
+            ok: candidate.validation.ok,
+            issues: candidate.validation.issues,
+          },
+        ],
+        registryRefreshed: false,
+      };
     },
-    pack: async () => {
+    pack: async (input) => {
+      if (fallback) return fallback.pack(input);
       throw new Error("pack is not supported in the Phase 14 lifecycle proof test");
     },
   };
+}
+
+function createLinkEvidenceConverterService(input: {
+  db: FridaySqliteLayer;
+  workspaceDir: string;
+  managedSkillsDir: string;
+  nowIso: () => string;
+}): FridaySkillConverterService {
+  const registry = createFridaySkillConverterRegistry();
+  registry.register(createFridayLinkEvidenceSkillConverter());
+  return createFridaySkillConverterService({
+    registry,
+    installer: createFridaySkillImportInstaller(),
+    archiver: createFridaySkillPackageArchiver(),
+    context: {
+      workspaceDir: input.workspaceDir,
+      managedSkillsDir: input.managedSkillsDir,
+      nowIso: input.nowIso,
+    },
+    onSkillCandidateStaged: ({ candidate, draft }) => {
+      input.db.withWriteTransaction((conn) => {
+        createFridaySkillRepository().upsertSkillFromCatalog(conn, {
+          id: candidate.skillId,
+          name: draft.manifest.name,
+          source: "local",
+          origin: "managed",
+          latestVersion: draft.manifest.version,
+          status: "not_installed",
+          currentManifest: draft.manifest,
+          nowIso: candidate.stagedAt,
+        });
+      });
+    },
+  });
 }
 
 function createStubConfigManager(input: {
@@ -398,6 +476,8 @@ describe("Phase 14 — live HTTP skill upgrade lifecycle proof (Phase 06 debt)",
   let candidateRoot: string;
   let v1Candidate: FridayExternalSkillCandidate;
   let v2Candidate: FridayExternalSkillCandidate;
+  let overreachCandidate: FridayExternalSkillCandidate;
+  let linkCandidate: FridayExternalSkillCandidate;
   let apiRuntime: FridayApiRuntime;
   let httpServer: FridayHttpServer;
   let baseUrl: string;
@@ -424,10 +504,31 @@ describe("Phase 14 — live HTTP skill upgrade lifecycle proof (Phase 06 debt)",
 
     const v1Manifest = buildManifest("1.0.0");
     const v2Manifest = buildManifest("2.0.0");
+    const overreachManifest = buildManifest("3.0.0", {
+      permissions: {
+        grants: [
+          {
+            id: "phase14-filesystem-write-root",
+            resource: "filesystem",
+            action: "write",
+            required: true,
+            reason: "Phase 14 negative proof requests broad filesystem write access.",
+          },
+        ],
+        promptOn: [],
+      },
+    });
     const v1CandidateId = `${SKILL_ID}-v1-${Math.random().toString(36).slice(2, 10)}`;
     const v2CandidateId = `${SKILL_ID}-v2-${Math.random().toString(36).slice(2, 10)}`;
+    const overreachCandidateId = `${SKILL_ID}-overreach-${Math.random().toString(36).slice(2, 10)}`;
+    const linkCandidateId = `${SKILL_ID}-link-${Math.random().toString(36).slice(2, 10)}`;
     const v1FilesDir = writeSkillFiles(join(candidateRoot, v1CandidateId, "files"), v1Manifest);
     const v2FilesDir = writeSkillFiles(join(candidateRoot, v2CandidateId, "files"), v2Manifest);
+    const overreachFilesDir = writeSkillFiles(
+      join(candidateRoot, overreachCandidateId, "files"),
+      overreachManifest,
+    );
+    const linkFilesDir = writeSkillFiles(join(candidateRoot, linkCandidateId, "files"), v1Manifest);
     const stagedAt = new Date().toISOString();
     v1Candidate = buildCandidate({
       candidateId: v1CandidateId,
@@ -439,6 +540,33 @@ describe("Phase 14 — live HTTP skill upgrade lifecycle proof (Phase 06 debt)",
       candidateId: v2CandidateId,
       filesDir: v2FilesDir,
       manifest: v2Manifest,
+      stagedAt,
+    });
+    overreachCandidate = {
+      ...buildCandidate({
+        candidateId: overreachCandidateId,
+        filesDir: overreachFilesDir,
+        manifest: overreachManifest,
+        stagedAt,
+      }),
+      validation: {
+        ok: false,
+        verifiedAt: stagedAt,
+        issues: [
+          {
+            stage: "trust-policy",
+            severity: "error",
+            code: "PERMISSION_OVERREACH",
+            message: "Broad filesystem write access is refused for staged skill candidates.",
+            path: "permissions.grants[0]",
+          },
+        ],
+      },
+    };
+    linkCandidate = buildCandidate({
+      candidateId: linkCandidateId,
+      filesDir: linkFilesDir,
+      manifest: v1Manifest,
       stagedAt,
     });
 
@@ -455,10 +583,6 @@ describe("Phase 14 — live HTTP skill upgrade lifecycle proof (Phase 06 debt)",
       });
     });
 
-    converterService = createConverterServiceStub();
-    converterService.registerCandidate(v1Candidate);
-    converterService.registerCandidate(v2Candidate);
-
     const idCounter = { count: 0 };
     const idGenerator = () => `phase14-${String(++idCounter.count).padStart(6, "0")}`;
     const nowIsoMutable = { value: stagedAt };
@@ -467,6 +591,17 @@ describe("Phase 14 — live HTTP skill upgrade lifecycle proof (Phase 06 debt)",
       nowIsoMutable.value = new Date(current + 100).toISOString();
       return nowIsoMutable.value;
     };
+
+    converterService = createConverterServiceStub(createLinkEvidenceConverterService({
+      db,
+      workspaceDir,
+      managedSkillsDir,
+      nowIso,
+    }));
+    converterService.registerCandidate(v1Candidate);
+    converterService.registerCandidate(v2Candidate);
+    converterService.registerCandidate(overreachCandidate);
+    converterService.registerCandidate(linkCandidate, LINK_TO_SKILL_SOURCE_URL);
 
     const providerService = createFridayProviderService({
       db,
@@ -604,7 +739,139 @@ describe("Phase 14 — live HTTP skill upgrade lifecycle proof (Phase 06 debt)",
         });
       }
 
-      // 1. Shadow v1
+      function importBodyFor(candidate: FridayExternalSkillCandidate, idempotencyKey: string) {
+        return {
+          source: { uri: `file://${candidate.candidateId}`, formatHint: "friday-package" as const },
+          formatHint: "friday-package" as const,
+          target: "managed" as const,
+          replace: true,
+          refreshRegistry: false,
+          idempotencyKey,
+          planDigest: PLAN_DIGEST,
+        };
+      }
+
+      function signImportStage(
+        body: ReturnType<typeof importBodyFor>,
+        approvalId: string,
+      ) {
+        const request = createFridaySkillStageMutatingActionRequest({
+          source: body.source,
+          formatHint: body.formatHint,
+          target: body.target,
+          replace: body.replace,
+          refreshRegistry: body.refreshRegistry,
+          actor,
+          surface: "api:/v1/skills/import",
+          idempotencyKey: body.idempotencyKey,
+          planDigest: body.planDigest,
+        });
+        return signCanonicalApproval({
+          request,
+          tokenSecret: HMAC_TEST_MATERIAL,
+          approvalId,
+          decidedByPrincipalId: "phase14-user",
+          expiresAt: expiresIn(15),
+        });
+      }
+
+      function signRun(
+        input: Record<string, unknown>,
+        sessionId: string,
+        approvalId: string,
+      ) {
+        const request = createFridaySkillRunMutatingActionRequest({
+          skillId: SKILL_ID,
+          input,
+          channel: "api",
+          sessionId,
+          actor,
+          surface: "api:/v1/skills/:skillId/run",
+        });
+        return signCanonicalApproval({
+          request,
+          tokenSecret: HMAC_TEST_MATERIAL,
+          approvalId,
+          decidedByPrincipalId: "phase14-user",
+          expiresAt: expiresIn(15),
+        });
+      }
+
+      async function runSkillAndExpectVersion(
+        version: string,
+        sessionId: string,
+      ): Promise<void> {
+        const input = { query: `expect-${version}` };
+        const runRes = await callJson(
+          "POST",
+          `/v1/skills/${encodeURIComponent(SKILL_ID)}/run`,
+          {
+            input,
+            channel: "api",
+            sessionId,
+            canonicalApproval: signRun(input, sessionId, `phase14-run-${version}-${sessionId}`),
+          },
+        );
+        expect(runRes.status, JSON.stringify(runRes.json)).toBe(200);
+        const data = runRes.json.data as Record<string, unknown>;
+        expect(data.status).toBe("completed");
+        expect(String(data.stdout)).toContain(`phase14-${version}`);
+      }
+
+      // 1. Import-stage v1 through the public converter route.
+      const importV1Body = importBodyFor(v1Candidate, "phase14-import-v1");
+      const importV1Denied = await callJson("POST", "/v1/skills/import", importV1Body);
+      expect(importV1Denied.status, JSON.stringify(importV1Denied.json)).toBe(403);
+      expect(importV1Denied.json.error?.code).toBe("CANONICAL_APPROVAL_REQUIRED");
+      const importV1 = await callJson(
+        "POST",
+        "/v1/skills/import",
+        {
+          ...importV1Body,
+          canonicalApproval: signImportStage(importV1Body, "phase14-import-v1"),
+        },
+      );
+      expect(importV1.status, JSON.stringify(importV1.json)).toBe(200);
+      const importV1Candidates = (importV1.json.data as Record<string, unknown>)
+        .candidates as Array<Record<string, unknown>>;
+      expect(importV1Candidates[0]?.candidateId).toBe(v1Candidate.candidateId);
+
+      // 2. Permission-overreach candidate stages with validation evidence but
+      //    is refused before it can enter the lifecycle.
+      const overreachImportBody = importBodyFor(
+        overreachCandidate,
+        "phase14-import-overreach",
+      );
+      const importOverreach = await callJson(
+        "POST",
+        "/v1/skills/import",
+        {
+          ...overreachImportBody,
+          canonicalApproval: signImportStage(
+            overreachImportBody,
+            "phase14-import-overreach",
+          ),
+        },
+      );
+      expect(importOverreach.status, JSON.stringify(importOverreach.json)).toBe(200);
+      const overreachValidation = (importOverreach.json.data as Record<string, unknown>)
+        .validation as Array<Record<string, unknown>>;
+      expect(overreachValidation[0]?.ok).toBe(false);
+      const overreachShadow = await callJson(
+        "POST",
+        `/v1/autonomy/skills/${encodeURIComponent(SKILL_ID)}/shadow`,
+        {
+          candidateId: overreachCandidate.candidateId,
+          shadowVersionId: overreachCandidate.candidateId,
+          runtimeVersion: RUNTIME_VERSION,
+          providerModel: PROVIDER_MODEL,
+          canonicalApproval: signFor("shadow", overreachCandidate.candidateId),
+        },
+      );
+      expect(overreachShadow.status, JSON.stringify(overreachShadow.json)).toBe(422);
+      expect(overreachShadow.json.error?.code).toBe("SKILL_CANDIDATE_VALIDATION_FAILED");
+
+      // 3. Shadow v1
       const shadowV1Body = {
         candidateId: v1Candidate.candidateId,
         shadowVersionId: v1Candidate.candidateId,
@@ -612,6 +879,13 @@ describe("Phase 14 — live HTTP skill upgrade lifecycle proof (Phase 06 debt)",
         providerModel: PROVIDER_MODEL,
         canonicalApproval: signFor("shadow", v1Candidate.candidateId),
       };
+      const shadowV1Denied = await callJson(
+        "POST",
+        `/v1/autonomy/skills/${encodeURIComponent(SKILL_ID)}/shadow`,
+        { ...shadowV1Body, canonicalApproval: undefined },
+      );
+      expect(shadowV1Denied.status, JSON.stringify(shadowV1Denied.json)).toBe(403);
+      expect(shadowV1Denied.json.error?.code).toBe("CANONICAL_APPROVAL_REQUIRED");
       const shadowV1 = await callJson(
         "POST",
         `/v1/autonomy/skills/${encodeURIComponent(SKILL_ID)}/shadow`,
@@ -620,7 +894,7 @@ describe("Phase 14 — live HTTP skill upgrade lifecycle proof (Phase 06 debt)",
       expect(shadowV1.status, JSON.stringify(shadowV1.json)).toBe(200);
       expect(shadowV1.json.ok).toBe(true);
 
-      // 2. Canary v1
+      // 4. Canary v1
       const canaryV1Body = {
         candidateId: v1Candidate.candidateId,
         runtimeVersion: RUNTIME_VERSION,
@@ -634,7 +908,7 @@ describe("Phase 14 — live HTTP skill upgrade lifecycle proof (Phase 06 debt)",
       );
       expect(canaryV1.status, JSON.stringify(canaryV1.json)).toBe(200);
 
-      // 3. Promote v1
+      // 5. Promote v1
       const promoteV1Body = {
         candidateId: v1Candidate.candidateId,
         runtimeVersion: RUNTIME_VERSION,
@@ -642,6 +916,13 @@ describe("Phase 14 — live HTTP skill upgrade lifecycle proof (Phase 06 debt)",
         planDigest: PLAN_DIGEST,
         canonicalApproval: signFor("promote", v1Candidate.candidateId),
       };
+      const promoteV1Denied = await callJson(
+        "POST",
+        `/v1/autonomy/skills/${encodeURIComponent(SKILL_ID)}/promote`,
+        { ...promoteV1Body, canonicalApproval: undefined },
+      );
+      expect(promoteV1Denied.status, JSON.stringify(promoteV1Denied.json)).toBe(403);
+      expect(promoteV1Denied.json.error?.code).toBe("CANONICAL_APPROVAL_REQUIRED");
       const promoteV1 = await callJson(
         "POST",
         `/v1/autonomy/skills/${encodeURIComponent(SKILL_ID)}/promote`,
@@ -650,7 +931,16 @@ describe("Phase 14 — live HTTP skill upgrade lifecycle proof (Phase 06 debt)",
       expect(promoteV1.status, JSON.stringify(promoteV1.json)).toBe(200);
       expect(existsSync(join(managedSkillsDir, SKILL_ID, "skill.manifest.json"))).toBe(true);
 
-      // 4. Publish a workflow that references the skill so analyze sees an
+      const runV1Denied = await callJson(
+        "POST",
+        `/v1/skills/${encodeURIComponent(SKILL_ID)}/run`,
+        { input: { query: "unsigned-v1" }, channel: "api", sessionId: "phase14-run-v1-denied" },
+      );
+      expect(runV1Denied.status, JSON.stringify(runV1Denied.json)).toBe(403);
+      expect(runV1Denied.json.error?.code).toBe("SKILL_RUN_APPROVAL_REQUIRED");
+      await runSkillAndExpectVersion("1.0.0", "phase14-run-v1");
+
+      // 6. Publish a workflow that references the skill so analyze sees an
       //    affected workflow with the candidate's input mapping.
       const workflowGraphBody = {
         schemaVersion: "2.0",
@@ -697,7 +987,20 @@ describe("Phase 14 — live HTTP skill upgrade lifecycle proof (Phase 06 debt)",
       );
       expect(publishRes.status, JSON.stringify(publishRes.json)).toBe(200);
 
-      // 5. Shadow v2 (previous = v1 active)
+      // 7. Import-stage and shadow v2 (previous = v1 active)
+      const importV2Body = importBodyFor(v2Candidate, "phase14-import-v2");
+      const importV2Denied = await callJson("POST", "/v1/skills/import", importV2Body);
+      expect(importV2Denied.status, JSON.stringify(importV2Denied.json)).toBe(403);
+      expect(importV2Denied.json.error?.code).toBe("CANONICAL_APPROVAL_REQUIRED");
+      const importV2 = await callJson(
+        "POST",
+        "/v1/skills/import",
+        {
+          ...importV2Body,
+          canonicalApproval: signImportStage(importV2Body, "phase14-import-v2"),
+        },
+      );
+      expect(importV2.status, JSON.stringify(importV2.json)).toBe(200);
       const shadowV2Body = {
         candidateId: v2Candidate.candidateId,
         shadowVersionId: v2Candidate.candidateId,
@@ -712,7 +1015,7 @@ describe("Phase 14 — live HTTP skill upgrade lifecycle proof (Phase 06 debt)",
       );
       expect(shadowV2.status, JSON.stringify(shadowV2.json)).toBe(200);
 
-      // 6. Analyze v2
+      // 8. Analyze v2
       const analyzeRes = await callJson(
         "POST",
         `/v1/skills/${encodeURIComponent(SKILL_ID)}/upgrade/analyze`,
@@ -729,7 +1032,7 @@ describe("Phase 14 — live HTTP skill upgrade lifecycle proof (Phase 06 debt)",
       const regression = analysis.regressionProof as { overallVerdict: string };
       expect(["pass", "fail", "no_affected_workflows"]).toContain(regression.overallVerdict);
 
-      // 7. Decide(replace) v2
+      // 9. Decide(replace) v2
       const decideRequest = buildSkillUpgradeDecideApprovalRequest({
         skillId: SKILL_ID,
         candidateId: v2Candidate.candidateId,
@@ -763,7 +1066,7 @@ describe("Phase 14 — live HTTP skill upgrade lifecycle proof (Phase 06 debt)",
       );
       expect(skillRow?.status).toBe("upgrade_available");
 
-      // 8. Canary v2
+      // 10. Canary v2
       const canaryV2 = await callJson(
         "POST",
         `/v1/autonomy/skills/${encodeURIComponent(SKILL_ID)}/canary`,
@@ -776,7 +1079,7 @@ describe("Phase 14 — live HTTP skill upgrade lifecycle proof (Phase 06 debt)",
       );
       expect(canaryV2.status, JSON.stringify(canaryV2.json)).toBe(200);
 
-      // 9. Promote v2 → active=v2, rollbackDir=v1 backup
+      // 11. Promote v2 -> active=v2, rollbackDir=v1 backup
       const promoteV2 = await callJson(
         "POST",
         `/v1/autonomy/skills/${encodeURIComponent(SKILL_ID)}/promote`,
@@ -794,8 +1097,21 @@ describe("Phase 14 — live HTTP skill upgrade lifecycle proof (Phase 06 debt)",
       );
       expect(installedRowAfterV2?.installedVersion).toBe("2.0.0");
       expect(installedRowAfterV2?.status).toBe("installed");
+      await runSkillAndExpectVersion("2.0.0", "phase14-run-v2");
 
-      // 10. Rollback v2 → restore v1
+      // 12. Rollback v2 -> restore v1
+      const rollbackDenied = await callJson(
+        "POST",
+        `/v1/autonomy/skills/${encodeURIComponent(SKILL_ID)}/rollback`,
+        {
+          candidateId: v2Candidate.candidateId,
+          runtimeVersion: RUNTIME_VERSION,
+          providerModel: PROVIDER_MODEL,
+          planDigest: PLAN_DIGEST,
+        },
+      );
+      expect(rollbackDenied.status, JSON.stringify(rollbackDenied.json)).toBe(403);
+      expect(rollbackDenied.json.error?.code).toBe("CANONICAL_APPROVAL_REQUIRED");
       const rollbackRes = await callJson(
         "POST",
         `/v1/autonomy/skills/${encodeURIComponent(SKILL_ID)}/rollback`,
@@ -812,7 +1128,7 @@ describe("Phase 14 — live HTTP skill upgrade lifecycle proof (Phase 06 debt)",
         .evidence as Record<string, unknown>;
       expect(rollbackEvidence.stage).toBe("rolled_back");
 
-      // 11. Read raw lifecycle evidence to assert result === "restored_previous"
+      // 13. Read raw lifecycle evidence to assert result === "restored_previous"
       const evidencePath = join(
         managedSkillsDir,
         ".lifecycle",
@@ -825,12 +1141,569 @@ describe("Phase 14 — live HTTP skill upgrade lifecycle proof (Phase 06 debt)",
       };
       expect(evidenceRecord.rollback?.result).toBe("restored_previous");
 
-      // 12. Confirm lifecycle restored to installed v1
+      // 14. Confirm lifecycle restored to installed v1
       const restoredRow = db.withReadConnection((conn) =>
         createFridaySkillRepository().getSkillById(conn, SKILL_ID),
       );
       expect(restoredRow?.installedVersion).toBe("1.0.0");
       expect(restoredRow?.currentManifest?.version).toBe("1.0.0");
+      await runSkillAndExpectVersion("1.0.0", "phase14-run-v1-restored");
+    },
+  );
+
+  it(
+    "live HTTP: skill-source deeplink preview/apply stages a candidate that must pass lifecycle promotion before run",
+    { timeout: 60_000 },
+    async () => {
+      const adminToken = tokenWithScopes([
+        "hub.admin",
+        "skill.read",
+        "skill.write",
+      ]);
+      const auth = { Authorization: `Bearer ${adminToken}`, "Content-Type": "application/json" };
+      const actor = actorForTestUser();
+
+      async function callJson<T = Record<string, unknown>>(
+        method: string,
+        path: string,
+        body?: Record<string, unknown>,
+      ): Promise<{ status: number; json: { ok: boolean; data?: T; error?: { code: string; message: string; details?: unknown } } }> {
+        const res = await fetch(`${baseUrl}${path}`, {
+          method,
+          headers: auth,
+          body: body === undefined ? undefined : JSON.stringify(body),
+        });
+        const text = await res.text();
+        const parsed = text.length > 0 ? JSON.parse(text) : { ok: res.ok };
+        return { status: res.status, json: parsed };
+      }
+
+      function signFor(action: "shadow" | "canary" | "promote", candidateId: string) {
+        const request = buildSkillLifecycleApprovalRequest({
+          action,
+          skillId: SKILL_ID,
+          candidateId,
+          runtimeVersion: RUNTIME_VERSION,
+          providerModel: PROVIDER_MODEL,
+          actor,
+          planDigest: action === "shadow" || action === "canary" ? undefined : PLAN_DIGEST,
+        });
+        return signCanonicalApproval({
+          request,
+          tokenSecret: HMAC_TEST_MATERIAL,
+          approvalId: `phase14-link-${action}-${candidateId}`,
+          decidedByPrincipalId: "phase14-user",
+          expiresAt: expiresIn(15),
+        });
+      }
+
+      function signDeepLinkStage(approvalId: string) {
+        const request = createFridaySkillStageMutatingActionRequest({
+          source: { uri: LINK_TO_SKILL_SOURCE_URL },
+          formatHint: "auto",
+          actor,
+          surface: "api:/v1/deeplink/apply",
+          idempotencyKey: "phase14-link-to-skill-apply",
+          planDigest: PLAN_DIGEST,
+        });
+        return signCanonicalApproval({
+          request,
+          tokenSecret: HMAC_TEST_MATERIAL,
+          approvalId,
+          decidedByPrincipalId: "phase14-user",
+          expiresAt: expiresIn(15),
+        });
+      }
+
+      function signRun(input: Record<string, unknown>, sessionId: string) {
+        const request = createFridaySkillRunMutatingActionRequest({
+          skillId: SKILL_ID,
+          input,
+          channel: "api",
+          sessionId,
+          actor,
+          surface: "api:/v1/skills/:skillId/run",
+        });
+        return signCanonicalApproval({
+          request,
+          tokenSecret: HMAC_TEST_MATERIAL,
+          approvalId: `phase14-link-run-${sessionId}`,
+          decidedByPrincipalId: "phase14-user",
+          expiresAt: expiresIn(15),
+        });
+      }
+
+      const payload = {
+        version: 1,
+        type: "skill-source",
+        label: "Phase 14 link-to-skill proof",
+        skillSource: { url: LINK_TO_SKILL_SOURCE_URL },
+      };
+
+      const preview = await callJson<{
+        preview: {
+          verdict: string;
+          payload: { skillSource?: { url?: string } };
+          permissionSummary: string[];
+        };
+      }>("POST", "/v1/deeplink/preview", { payload });
+      expect(preview.status, JSON.stringify(preview.json)).toBe(200);
+      expect(preview.json.data?.preview.verdict).toBe("ready");
+      expect(preview.json.data?.preview.payload.skillSource?.url).toBe(
+        "https://example.com/friday-link-skill?redacted=1",
+      );
+      expect(preview.json.data?.preview.permissionSummary).toContain(
+        "Will stage an external skill candidate for review.",
+      );
+
+      const privatePayload = {
+        version: 1,
+        type: "skill-source",
+        label: "Blocked private link-to-skill proof",
+        skillSource: { url: "http://localhost:3000/private-skill?token=private-proof-token" },
+      };
+      const privatePreview = await callJson<{
+        preview: { verdict: string; checks: Array<{ id: string; level: string }> };
+      }>("POST", "/v1/deeplink/preview", { payload: privatePayload });
+      expect(privatePreview.status, JSON.stringify(privatePreview.json)).toBe(200);
+      expect(privatePreview.json.data?.preview.verdict).toBe("blocked");
+      expect(privatePreview.json.data?.preview.checks.some((check) =>
+        check.id === "skill-url-private" && check.level === "blocking"
+      )).toBe(true);
+
+      const privateApply = await callJson("POST", "/v1/deeplink/apply", {
+        payload: privatePayload,
+        confirmed: true,
+      });
+      expect(privateApply.status, JSON.stringify(privateApply.json)).toBe(422);
+      expect(privateApply.json.error?.code).toBe("VALIDATION_FAILED");
+
+      const unconfirmedApply = await callJson("POST", "/v1/deeplink/apply", {
+        payload,
+        confirmed: false,
+      });
+      expect(unconfirmedApply.status, JSON.stringify(unconfirmedApply.json)).toBe(400);
+      expect(unconfirmedApply.json.error?.code).toBe("VALIDATION_FAILED");
+
+      const unsignedApply = await callJson("POST", "/v1/deeplink/apply", {
+        payload,
+        confirmed: true,
+        idempotencyKey: "phase14-link-to-skill-apply",
+        planDigest: PLAN_DIGEST,
+      });
+      expect(unsignedApply.status, JSON.stringify(unsignedApply.json)).toBe(403);
+      expect(unsignedApply.json.error?.code).toBe("CANONICAL_APPROVAL_REQUIRED");
+
+      const signedApply = await callJson<{
+        result: { applied: boolean; resourceType: string; resourceId?: string; message: string };
+      }>("POST", "/v1/deeplink/apply", {
+        payload,
+        confirmed: true,
+        idempotencyKey: "phase14-link-to-skill-apply",
+        planDigest: PLAN_DIGEST,
+        canonicalApproval: signDeepLinkStage("phase14-link-to-skill-stage"),
+      });
+      expect(signedApply.status, JSON.stringify(signedApply.json)).toBe(200);
+      expect(signedApply.json.data?.result.applied).toBe(true);
+      expect(signedApply.json.data?.result.resourceType).toBe("skill-source");
+      expect(signedApply.json.data?.result.resourceId).toBe(linkCandidate.candidateId);
+      expect(signedApply.json.data?.result.message).toContain("staged");
+
+      const runBeforeLifecycle = await callJson("POST", `/v1/skills/${encodeURIComponent(SKILL_ID)}/run`, {
+        input: { query: "before-lifecycle" },
+        channel: "api",
+        sessionId: "phase14-link-run-before-lifecycle",
+      });
+      expect(runBeforeLifecycle.status).not.toBe(200);
+
+      const shadow = await callJson(
+        "POST",
+        `/v1/autonomy/skills/${encodeURIComponent(SKILL_ID)}/shadow`,
+        {
+          candidateId: linkCandidate.candidateId,
+          shadowVersionId: linkCandidate.candidateId,
+          runtimeVersion: RUNTIME_VERSION,
+          providerModel: PROVIDER_MODEL,
+          canonicalApproval: signFor("shadow", linkCandidate.candidateId),
+        },
+      );
+      expect(shadow.status, JSON.stringify(shadow.json)).toBe(200);
+
+      const canary = await callJson(
+        "POST",
+        `/v1/autonomy/skills/${encodeURIComponent(SKILL_ID)}/canary`,
+        {
+          candidateId: linkCandidate.candidateId,
+          runtimeVersion: RUNTIME_VERSION,
+          providerModel: PROVIDER_MODEL,
+          canonicalApproval: signFor("canary", linkCandidate.candidateId),
+        },
+      );
+      expect(canary.status, JSON.stringify(canary.json)).toBe(200);
+
+      const promote = await callJson(
+        "POST",
+        `/v1/autonomy/skills/${encodeURIComponent(SKILL_ID)}/promote`,
+        {
+          candidateId: linkCandidate.candidateId,
+          runtimeVersion: RUNTIME_VERSION,
+          providerModel: PROVIDER_MODEL,
+          planDigest: PLAN_DIGEST,
+          canonicalApproval: signFor("promote", linkCandidate.candidateId),
+        },
+      );
+      expect(promote.status, JSON.stringify(promote.json)).toBe(200);
+
+      const input = { query: "after-link-promotion" };
+      const runAfterLifecycle = await callJson<{ status: string; stdout: string }>(
+        "POST",
+        `/v1/skills/${encodeURIComponent(SKILL_ID)}/run`,
+        {
+          input,
+          channel: "api",
+          sessionId: "phase14-link-run-after-lifecycle",
+          canonicalApproval: signRun(input, "phase14-link-run-after-lifecycle"),
+        },
+      );
+      expect(runAfterLifecycle.status, JSON.stringify(runAfterLifecycle.json)).toBe(200);
+      expect(runAfterLifecycle.json.data?.status).toBe("completed");
+      expect(runAfterLifecycle.json.data?.stdout).toContain("phase14-1.0.0");
+    },
+  );
+
+  it(
+    "live HTTP: extracted link evidence candidate promotes, runs after restart, and rollback cleans the active artifact",
+    { timeout: 60_000 },
+    async () => {
+      const adminToken = tokenWithScopes([
+        "hub.admin",
+        "skill.read",
+        "skill.write",
+      ]);
+      const auth = { Authorization: `Bearer ${adminToken}`, "Content-Type": "application/json" };
+      const actor = actorForTestUser();
+      const linkSkillId = `phase14-link-evidence-${Math.random().toString(36).slice(2, 8)}`;
+      const linkUrl = "https://example.com/friday-link-evidence-skill?token=restart-cleanup-secret";
+      const stageSurface = "api:/v1/link-to-skill/stage";
+      const stageIdempotencyKey = "phase14-link-evidence-stage";
+      let fetchCount = 0;
+
+      async function callJson<T = Record<string, unknown>>(
+        method: string,
+        path: string,
+        body?: Record<string, unknown>,
+      ): Promise<{ status: number; json: { ok: boolean; data?: T; error?: { code: string; message: string; details?: unknown } } }> {
+        const res = await fetch(`${baseUrl}${path}`, {
+          method,
+          headers: auth,
+          body: body === undefined ? undefined : JSON.stringify(body),
+        });
+        const text = await res.text();
+        const parsed = text.length > 0 ? JSON.parse(text) : { ok: res.ok };
+        return { status: res.status, json: parsed };
+      }
+
+      function signStage(source: ReturnType<typeof buildFridayLinkToSkillCandidateSource>["source"]) {
+        const request = createFridaySkillStageMutatingActionRequest({
+          source,
+          formatHint: "auto",
+          actor,
+          surface: stageSurface,
+          idempotencyKey: stageIdempotencyKey,
+          planDigest: PLAN_DIGEST,
+        });
+        return signCanonicalApproval({
+          request,
+          tokenSecret: HMAC_TEST_MATERIAL,
+          approvalId: "phase14-link-evidence-stage",
+          decidedByPrincipalId: "phase14-user",
+          expiresAt: expiresIn(15),
+        });
+      }
+
+      function signFor(action: "shadow" | "canary" | "promote" | "rollback", candidateId: string) {
+        const request = buildSkillLifecycleApprovalRequest({
+          action,
+          skillId: linkSkillId,
+          candidateId,
+          runtimeVersion: RUNTIME_VERSION,
+          providerModel: PROVIDER_MODEL,
+          actor,
+          planDigest: action === "shadow" || action === "canary" ? undefined : PLAN_DIGEST,
+        });
+        return signCanonicalApproval({
+          request,
+          tokenSecret: HMAC_TEST_MATERIAL,
+          approvalId: `phase14-link-evidence-${action}-${candidateId}`,
+          decidedByPrincipalId: "phase14-user",
+          expiresAt: expiresIn(15),
+        });
+      }
+
+      function signRun(input: Record<string, unknown>, sessionId: string) {
+        const request = createFridaySkillRunMutatingActionRequest({
+          skillId: linkSkillId,
+          input,
+          channel: "api",
+          sessionId,
+          actor,
+          surface: "api:/v1/skills/:skillId/run",
+        });
+        return signCanonicalApproval({
+          request,
+          tokenSecret: HMAC_TEST_MATERIAL,
+          approvalId: `phase14-link-evidence-run-${sessionId}`,
+          decidedByPrincipalId: "phase14-user",
+          expiresAt: expiresIn(15),
+        });
+      }
+
+      async function restartHttpRuntime(): Promise<void> {
+        await httpServer.close();
+        await registry.close();
+
+        const idCounter = { count: 0 };
+        const idGenerator = () => `phase14-restart-${String(++idCounter.count).padStart(6, "0")}`;
+        const nowIsoMutable = { value: new Date().toISOString() };
+        const nowIso = () => {
+          const current = new Date(nowIsoMutable.value).getTime();
+          nowIsoMutable.value = new Date(current + 100).toISOString();
+          return nowIsoMutable.value;
+        };
+        const providerService = createFridayProviderService({
+          db,
+          idGenerator,
+          nowIso,
+        });
+        const configManager = createStubConfigManager({ workspaceDir, managedSkillsDir });
+        const memoryState = createStubMemoryState();
+        registry = new FridaySkillRegistryImpl({
+          workspaceDir,
+          hubVersion: "1.0.0",
+          supportedApiVersions: ["1"],
+          configManager,
+          memoryStateService: memoryState,
+        });
+        const persistedLinkSkill = db.withReadConnection((conn) =>
+          createFridaySkillRepository().getSkillById(conn, linkSkillId),
+        );
+        if (persistedLinkSkill?.status) {
+          await memoryState.updateSkillStatus(linkSkillId, persistedLinkSkill.status);
+        }
+        await registry.refresh();
+
+        converterService = createConverterServiceStub(createLinkEvidenceConverterService({
+          db,
+          workspaceDir,
+          managedSkillsDir,
+          nowIso,
+        }));
+        const runStore = createFridaySkillRunStore({ db });
+        const executorCanonicalGate = createFridayMutatingActionGate({
+          nowIso,
+          ticketIdGenerator: () => idGenerator(),
+          approvalSignatureSecret: HMAC_TEST_MATERIAL,
+          requireApprovalSignature: true,
+        });
+        const skillExecutor = createFridaySkillExecutor({
+          db,
+          registry,
+          runStore,
+          idGenerator,
+          nowIso,
+          canonicalMutationGate: executorCanonicalGate,
+        });
+        apiRuntime = createFridayApiRuntime({
+          db,
+          idGenerator,
+          nowIso,
+          providerService,
+          converterService,
+          skillRegistry: registry,
+          skillExecutor,
+          tokenSecret: HMAC_TEST_MATERIAL,
+          accessTokenTtlSec: ACCESS_TTL,
+          managedSkillsDir,
+          stateDir: workspaceDir,
+          computeChecksum: (content: string) =>
+            crypto.createHash("sha256").update(content).digest("hex"),
+          resolveSkill: (skillId: string) => ({ id: skillId }),
+          invokeSkill: async (_skillId, _runId, _nodeId, payload) => ({ output: payload }),
+          updateSkillStatus: async (skillId, status) => {
+            await memoryState.updateSkillStatus(skillId, status);
+          },
+        });
+        const port = await findFreePort();
+        httpServer = createFridayHttpServer({
+          routes: apiRuntime.routes,
+          wsGateway: apiRuntime.wsGateway,
+          middleware: apiRuntime.middleware,
+          port,
+          host: "127.0.0.1",
+        });
+        await httpServer.listen();
+        baseUrl = `http://127.0.0.1:${port}`;
+      }
+
+      const linkUnderstanding = createFridayLinkUnderstandingService({
+        fetchFn: async () => {
+          fetchCount += 1;
+          return {
+            statusCode: 200,
+            contentType: "text/html",
+            body: `
+              <html>
+                <head><title>Restart Link Evidence Skill</title></head>
+                <body>
+                  <main>
+                    <h1>Restart Link Evidence Skill</h1>
+                    <p>Build a Friday skill that summarizes restart-safe link evidence for the workspace.</p>
+                    <p>The deterministic proof phrase is LINK_SKILL_RESTART_READY and the skill must not fetch the source URL when it runs.</p>
+                    <p>This article text is intentionally long enough for stable extraction by the link-understanding pipeline.</p>
+                  </main>
+                </body>
+              </html>
+            `,
+          };
+        },
+        cache: createFridayLinkCacheRepository(() => new Date().toISOString()),
+        nowIso: () => new Date().toISOString(),
+      });
+      const evidence = (await linkUnderstanding.processText(`Turn this into a skill: ${linkUrl}`))[0]!;
+      expect(evidence.summary).toContain("LINK_SKILL_RESTART_READY");
+      const built = buildFridayLinkToSkillCandidateSource({
+        evidence,
+        skillId: linkSkillId,
+        skillName: "Restart Link Evidence Skill",
+      });
+      expect(JSON.stringify(built.payload)).not.toContain("restart-cleanup-secret");
+      expect(built.payload.redactedUrl).toBe(
+        "https://example.com/friday-link-evidence-skill?redacted=1",
+      );
+
+      const linkToSkill = createFridayLinkToSkillService({
+        linkUnderstanding,
+        converterService,
+        canonicalMutationGate: createFridayMutatingActionGate({
+          nowIso: () => new Date().toISOString(),
+          ticketIdGenerator: () => "phase14-link-evidence-ticket",
+          approvalSignatureSecret: HMAC_TEST_MATERIAL,
+          requireApprovalSignature: true,
+        }),
+      });
+      const staged = await linkToSkill.stageFromText({
+        text: `Turn this into a skill: ${linkUrl}`,
+        actor,
+        surface: stageSurface,
+        idempotencyKey: stageIdempotencyKey,
+        planDigest: PLAN_DIGEST,
+        canonicalApproval: signStage(built.source),
+        skillId: linkSkillId,
+        skillName: "Restart Link Evidence Skill",
+      });
+      expect(staged.importResult.converterId).toBe("link-evidence-skill");
+      const candidate = staged.importResult.candidates[0]!;
+      expect(candidate.skillId).toBe(linkSkillId);
+      expect(candidate.validation.ok).toBe(true);
+      expect(candidate.sourceProvenance.sourceKind).toBe("contentBase64");
+      expect(readFileSync(join(candidate.filesDir, "run.sh"), "utf8")).not.toContain(
+        "restart-cleanup-secret",
+      );
+
+      const runBeforeLifecycle = await callJson("POST", `/v1/skills/${encodeURIComponent(linkSkillId)}/run`, {
+        input: { query: "before-lifecycle" },
+        channel: "api",
+        sessionId: "phase14-link-evidence-before-lifecycle",
+      });
+      expect(runBeforeLifecycle.status).not.toBe(200);
+
+      for (const action of ["shadow", "canary", "promote"] as const) {
+        const res = await callJson(
+          "POST",
+          `/v1/autonomy/skills/${encodeURIComponent(linkSkillId)}/${action}`,
+          {
+            candidateId: candidate.candidateId,
+            ...(action === "shadow" ? { shadowVersionId: candidate.candidateId } : {}),
+            runtimeVersion: RUNTIME_VERSION,
+            providerModel: PROVIDER_MODEL,
+            ...(action === "promote" ? { planDigest: PLAN_DIGEST } : {}),
+            canonicalApproval: signFor(action, candidate.candidateId),
+          },
+        );
+        expect(res.status, JSON.stringify(res.json)).toBe(200);
+      }
+
+      await restartHttpRuntime();
+
+      const runInput = { query: "after-restart" };
+      const runAfterRestart = await callJson<{ status: string; stdout: string }>(
+        "POST",
+        `/v1/skills/${encodeURIComponent(linkSkillId)}/run`,
+        {
+          input: runInput,
+          channel: "api",
+          sessionId: "phase14-link-evidence-after-restart",
+          canonicalApproval: signRun(runInput, "phase14-link-evidence-after-restart"),
+        },
+      );
+      expect(runAfterRestart.status, JSON.stringify(runAfterRestart.json)).toBe(200);
+      expect(runAfterRestart.json.data?.status).toBe("completed");
+      expect(runAfterRestart.json.data?.stdout).toContain("link_evidence_ready");
+      expect(runAfterRestart.json.data?.stdout).toContain("LINK_SKILL_RESTART_READY");
+      expect(runAfterRestart.json.data?.stdout).toContain(
+        "https://example.com/friday-link-evidence-skill?redacted=1",
+      );
+      expect(runAfterRestart.json.data?.stdout).not.toContain("restart-cleanup-secret");
+      expect(fetchCount).toBeGreaterThanOrEqual(1);
+
+      const rollbackDenied = await callJson(
+        "POST",
+        `/v1/autonomy/skills/${encodeURIComponent(linkSkillId)}/rollback`,
+        {
+          candidateId: candidate.candidateId,
+          runtimeVersion: RUNTIME_VERSION,
+          providerModel: PROVIDER_MODEL,
+          planDigest: PLAN_DIGEST,
+        },
+      );
+      expect(rollbackDenied.status, JSON.stringify(rollbackDenied.json)).toBe(403);
+      expect(rollbackDenied.json.error?.code).toBe("CANONICAL_APPROVAL_REQUIRED");
+      const rollback = await callJson(
+        "POST",
+        `/v1/autonomy/skills/${encodeURIComponent(linkSkillId)}/rollback`,
+        {
+          candidateId: candidate.candidateId,
+          runtimeVersion: RUNTIME_VERSION,
+          providerModel: PROVIDER_MODEL,
+          planDigest: PLAN_DIGEST,
+          canonicalApproval: signFor("rollback", candidate.candidateId),
+        },
+      );
+      expect(rollback.status, JSON.stringify(rollback.json)).toBe(200);
+      const activeDir = join(managedSkillsDir, linkSkillId);
+      expect(existsSync(activeDir)).toBe(false);
+      const lifecycleEvidencePath = join(
+        managedSkillsDir,
+        ".lifecycle",
+        linkSkillId,
+        `${candidate.candidateId}.json`,
+      );
+      const lifecycleEvidence = JSON.parse(readFileSync(lifecycleEvidencePath, "utf8")) as {
+        rollback?: { result?: string };
+      };
+      expect(lifecycleEvidence.rollback?.result).toBe("cleared_active");
+      const rowAfterRollback = db.withReadConnection((conn) =>
+        createFridaySkillRepository().getSkillById(conn, linkSkillId),
+      );
+      expect(rowAfterRollback?.status).toBe("not_installed");
+
+      const runAfterRollback = await callJson("POST", `/v1/skills/${encodeURIComponent(linkSkillId)}/run`, {
+        input: { query: "after-rollback" },
+        channel: "api",
+        sessionId: "phase14-link-evidence-after-rollback",
+        canonicalApproval: signRun({ query: "after-rollback" }, "phase14-link-evidence-after-rollback"),
+      });
+      expect(runAfterRollback.status).not.toBe(200);
     },
   );
 });

--- a/test/e2e/ui/friday-reflex-review-center-real-browser.e2e.test.ts
+++ b/test/e2e/ui/friday-reflex-review-center-real-browser.e2e.test.ts
@@ -370,6 +370,46 @@ function seedWorkflowCandidate(input: {
   }
 }
 
+function seedSkillCandidate(input: {
+  env: FridayRealBrowserE2eEnv;
+  userId: string;
+  candidateId: string;
+  generatorSessionId: string;
+  title: string;
+}): ReflexCandidate {
+  const db = new Database(path.join(input.env.stateDir, "friday.db"));
+  try {
+    return createFridayReflexCandidateRepository().insert(db, {
+      id: input.candidateId,
+      nowIso: new Date().toISOString(),
+      userId: input.userId,
+      kind: "skill",
+      origin: "post_run",
+      status: "ready_for_review",
+      sourceRunId: `run-${input.candidateId}`,
+      sessionKey: `session-${input.candidateId}`,
+      title: input.title,
+      summary: "Review Center browser proof skill candidate",
+      payload: {
+        goal: "Create a safe deterministic skill candidate for Review Center approval proof.",
+      },
+      evidence: {
+        generatorSessionId: input.generatorSessionId,
+        mode: "test_fixture",
+        draftSkillId: `draft-${input.candidateId}`,
+        draftName: input.title,
+        validationOk: true,
+        qaVerdict: { status: "passed", source: "review-center-skill-browser-proof" },
+        harness: { status: "passed", source: "review-center-skill-browser-proof" },
+      },
+      confidence: 0.9,
+      riskTier: 3,
+    });
+  } finally {
+    db.close();
+  }
+}
+
 async function requestReviewCandidate(
   env: FridayRealBrowserE2eEnv,
   key: string,
@@ -509,6 +549,121 @@ describe.skipIf(!CHROMIUM_AVAILABLE)("Friday Reflex Review Center real-browser f
     expect(rejectedCandidates.status).toBe(200);
     expect(rejectedCandidates.json.ok).toBe(true);
     expect(rejectedCandidates.json.data.items.some((item) => item.id === rejectCandidate.id)).toBe(true);
+  });
+
+  it("approves and rejects skill candidates in the real Review Center UI without making staged skills runnable", { timeout: 180_000 }, async () => {
+    env = await createFridayRealBrowserE2eEnv();
+    await completeSetup(env);
+    const userId = await readUserId(env);
+
+    const approveAndSaveCalls: string[] = [];
+    const originalApproveAndSave = env.hub.skillGenerator.approveAndSave.bind(env.hub.skillGenerator);
+
+    try {
+      env.hub.skillGenerator.approveAndSave = async (sessionId: string) => {
+        approveAndSaveCalls.push(sessionId);
+        if (sessionId !== "skill-ui-approve-session") {
+          throw new Error(`Unexpected skill generator approval session: ${sessionId}`);
+        }
+        return {
+          sessionId,
+          skillId: "review-center-approved-skill",
+          skillDir: path.join(env!.stateDir, "generated-skills", "review-center-approved-skill"),
+          candidateId: "review-center-approved-skill-candidate",
+          candidateDir: path.join(env!.stateDir, "skill-candidates", "review-center-approved-skill-candidate"),
+          savedFiles: ["skill.manifest.json", "SKILL.md", "run.sh"],
+          registryRefreshed: false,
+          promotionStage: "candidate_staged",
+          candidateManifestTags: ["skill.lifecycle.candidate"],
+          promotedManifestTags: [],
+          evidence: {
+            packageLoaded: true,
+            packageValidated: true,
+            registryRefreshed: false,
+            candidateStaged: true,
+          },
+          harness: { status: "passed", source: "review-center-skill-browser-proof" },
+          qaVerdict: { verdict: "pass", summary: "deterministic Review Center skill proof passed" },
+        };
+      };
+
+      const approveCandidate = seedSkillCandidate({
+        env,
+        userId,
+        candidateId: "skill-ui-approve-candidate",
+        generatorSessionId: "skill-ui-approve-session",
+        title: "Approve deterministic Review Center skill",
+      });
+      const rejectCandidate = seedSkillCandidate({
+        env,
+        userId,
+        candidateId: "skill-ui-reject-candidate",
+        generatorSessionId: "skill-ui-reject-session",
+        title: "Reject deterministic Review Center skill",
+      });
+
+      pageHandle = await env.newPage();
+      await seedBrowserProfile(pageHandle);
+      await pageHandle.page.goto("/reflex", { waitUntil: "networkidle" });
+      await pageHandle.page.getByText("Friday Reflex").first().waitFor({ state: "visible", timeout: 60_000 });
+
+      await pageHandle.page.locator(`[data-testid="reflex-candidate-card-${approveCandidate.id}"]`).waitFor({
+        state: "visible",
+        timeout: 60_000,
+      });
+      await pageHandle.page.locator(`[data-testid="reflex-candidate-card-${rejectCandidate.id}"]`).waitFor({
+        state: "visible",
+        timeout: 60_000,
+      });
+
+      await pageHandle.page.locator(`[data-testid="reflex-candidate-reject-${rejectCandidate.id}"]`).click();
+      await pageHandle.page.waitForFunction(
+        (candidateId) => !document.querySelector(`[data-testid="reflex-candidate-card-${candidateId}"]`),
+        rejectCandidate.id,
+        { timeout: 20_000 },
+      );
+      expect(approveAndSaveCalls).toHaveLength(0);
+
+      await pageHandle.page.locator(`[data-testid="reflex-candidate-approve-${approveCandidate.id}"]`).click();
+      await pageHandle.page.waitForFunction(
+        (candidateId) => !document.querySelector(`[data-testid="reflex-candidate-card-${candidateId}"]`),
+        approveCandidate.id,
+        { timeout: 20_000 },
+      );
+      expect(approveAndSaveCalls).toEqual(["skill-ui-approve-session"]);
+
+      const approvedCandidates = await env.apiFetch<{ items: ReflexCandidate[] }>(
+        "GET",
+        "/v1/reflex/candidates?status=approved&kind=skill",
+      );
+      expect(approvedCandidates.status).toBe(200);
+      expect(approvedCandidates.json.ok).toBe(true);
+      const approved = approvedCandidates.json.data.items.find((item) => item.id === approveCandidate.id);
+      expect(approved?.evidence).toMatchObject({
+        savedSkillId: "review-center-approved-skill",
+        stagedCandidateId: "review-center-approved-skill-candidate",
+        registryRefreshed: false,
+        promotionStage: "candidate_staged",
+        lifecycleBoundary: "candidate_staged_not_installed_or_promoted",
+      });
+
+      const rejectedCandidates = await env.apiFetch<{ items: ReflexCandidate[] }>(
+        "GET",
+        "/v1/reflex/candidates?status=rejected&kind=skill",
+      );
+      expect(rejectedCandidates.status).toBe(200);
+      expect(rejectedCandidates.json.ok).toBe(true);
+      expect(rejectedCandidates.json.data.items.some((item) => item.id === rejectCandidate.id)).toBe(true);
+
+      const runStagedSkill = await env.apiFetch<Record<string, unknown>>(
+        "POST",
+        "/v1/skills/review-center-approved-skill/run",
+        { input: {}, channel: "api", sessionId: "review-center-staged-skill-run-denied" },
+      );
+      expect(runStagedSkill.status).not.toBe(200);
+    } finally {
+      env.hub.skillGenerator.approveAndSave = originalApproveAndSave;
+    }
   });
 
   it("approves a workflow candidate in the real Review Center UI and runs the published workflow", { timeout: 180_000 }, async () => {

--- a/test/unit/deeplink/friday-deeplink-validator.test.ts
+++ b/test/unit/deeplink/friday-deeplink-validator.test.ts
@@ -101,12 +101,13 @@ describe("validateFridayDeepLink", () => {
       expect(result.payload.skillSource?.url).toBe("https://example.com/skill-repo?redacted=1");
     });
 
-    it("warns on private URL", () => {
+    it("blocks private URL skill sources", () => {
       const result = validateFridayDeepLink(makePayload({
         type: "skill-source",
         skillSource: { url: "http://localhost:3000/skill" },
       }));
-      expect(result.verdict).toBe("needs_review");
+      expect(result.verdict).toBe("blocked");
+      expect(result.checks.some((c) => c.level === "blocking" && c.id === "skill-url-private")).toBe(true);
     });
   });
 
@@ -202,7 +203,8 @@ describe("validateFridayDeepLink", () => {
           type: "skill-source",
           skillSource: { url },
         }));
-        expect(result.checks.some((c) => c.level === "warning" && c.summary.toLowerCase().includes("private"))).toBe(true);
+        expect(result.verdict).toBe("blocked");
+        expect(result.checks.some((c) => c.id === "skill-url-private" && c.level === "blocking")).toBe(true);
       });
     }
 
@@ -219,8 +221,8 @@ describe("validateFridayDeepLink", () => {
         type: "skill-source",
         skillSource: { url: "not-a-url" },
       }));
-      // Should either block or warn
-      expect(result.checks.some((c) => c.level === "warning" || c.level === "blocking")).toBe(true);
+      expect(result.verdict).toBe("blocked");
+      expect(result.checks.some((c) => c.id === "skill-url-private" && c.level === "blocking")).toBe(true);
     });
   });
 

--- a/test/unit/skills/link-to-skill/friday-link-to-skill-service.test.ts
+++ b/test/unit/skills/link-to-skill/friday-link-to-skill-service.test.ts
@@ -1,0 +1,240 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  createFridayLinkCacheRepository,
+  createFridayLinkUnderstandingService,
+} from "#link-understanding";
+import {
+  buildFridayLinkToSkillCandidateSource,
+  createFridayLinkToSkillService,
+} from "#skills";
+import {
+  createFridayLinkEvidenceSkillConverter,
+  createFridaySkillConverterRegistry,
+  createFridaySkillConverterService,
+  createFridaySkillImportInstaller,
+  createFridaySkillPackageArchiver,
+  createFridaySkillStageMutatingActionRequest,
+} from "#skills/converter";
+import {
+  createFridayMutatingActionDigest,
+  createFridayMutatingActionGate,
+  signFridayCanonicalApproval,
+  type FridayCanonicalApprovalResolution,
+  type FridayMutatingActionActor,
+} from "../../../../src/security/friday-mutating-action-gate.js";
+
+const NOW = "2026-05-27T07:12:00.000Z";
+const APPROVAL_TEST_KEY = "link-to-skill-test-key";
+const PLAN_DIGEST = "link-to-skill-plan-digest";
+const ACTOR: FridayMutatingActionActor = {
+  kind: "user",
+  id: "link-user",
+  principalId: "link-user",
+};
+
+function makeTempDir(): string {
+  const dir = join(tmpdir(), `friday-link-to-skill-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function makeConverterService(root: string) {
+  const registry = createFridaySkillConverterRegistry();
+  registry.register(createFridayLinkEvidenceSkillConverter());
+  return createFridaySkillConverterService({
+    registry,
+    installer: createFridaySkillImportInstaller(),
+    archiver: createFridaySkillPackageArchiver(),
+    context: {
+      workspaceDir: root,
+      managedSkillsDir: join(root, "managed-skills"),
+      nowIso: () => NOW,
+    },
+  });
+}
+
+function signStageApproval(input: {
+  source: ReturnType<typeof buildFridayLinkToSkillCandidateSource>["source"];
+  idempotencyKey: string;
+}): FridayCanonicalApprovalResolution {
+  const request = createFridaySkillStageMutatingActionRequest({
+    source: input.source,
+    formatHint: "auto",
+    actor: ACTOR,
+    surface: "test:link-to-skill",
+    idempotencyKey: input.idempotencyKey,
+    planDigest: PLAN_DIGEST,
+  });
+  return signFridayCanonicalApproval({
+    decision: "approved",
+    approvalId: `approval-${input.idempotencyKey}`,
+    decidedByPrincipalId: "link-user",
+    actionDigest: createFridayMutatingActionDigest(request),
+    expiresAt: "2026-05-27T08:12:00.000Z",
+  }, APPROVAL_TEST_KEY);
+}
+
+describe("Friday link-to-skill service", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("extracts link evidence, generates a redacted skill candidate source, and stages it through the converter service", async () => {
+    const root = makeTempDir();
+    tempDirs.push(root);
+    const linkUrl = "https://example.com/skill-guide?token=super-secret-link-token";
+    const fetchFn = vi.fn(async () => ({
+      statusCode: 200,
+      contentType: "text/html",
+      body: `
+        <html>
+          <head><title>Invoice Skill Guide</title></head>
+          <body>
+            <main>
+              <h1>Invoice Skill Guide</h1>
+              <p>Build a Friday skill that summarizes invoice status for the workspace.</p>
+              <p>The deterministic proof phrase is LINK_SKILL_EVIDENCE_READY and the skill must not fetch the source URL when it runs.</p>
+              <p>This extra body text gives Readability enough article content to produce stable evidence from the HTML fixture.</p>
+            </main>
+          </body>
+        </html>
+      `,
+    }));
+    const linkUnderstanding = createFridayLinkUnderstandingService({
+      fetchFn,
+      cache: createFridayLinkCacheRepository(() => NOW),
+      nowIso: () => NOW,
+    });
+    const converterService = makeConverterService(root);
+    const gate = createFridayMutatingActionGate({
+      nowIso: () => NOW,
+      ticketIdGenerator: () => "ticket-link-to-skill",
+      approvalSignatureSecret: APPROVAL_TEST_KEY,
+      requireApprovalSignature: true,
+    });
+
+    const text = `Please turn this into a skill: ${linkUrl}`;
+    const evidence = (await linkUnderstanding.processText(text))[0]!;
+    expect(evidence.summary).toContain("LINK_SKILL_EVIDENCE_READY");
+    const built = buildFridayLinkToSkillCandidateSource({
+      evidence,
+      skillId: "invoice-link-skill",
+      skillName: "Invoice Link Skill",
+    });
+    expect(JSON.stringify(built.payload)).not.toContain("super-secret-link-token");
+    expect(built.payload.redactedUrl).toBe("https://example.com/skill-guide?redacted=1");
+
+    const service = createFridayLinkToSkillService({
+      linkUnderstanding,
+      converterService,
+      canonicalMutationGate: gate,
+    });
+    const result = await service.stageFromText({
+      text,
+      actor: ACTOR,
+      surface: "test:link-to-skill",
+      idempotencyKey: "stage-link-skill",
+      planDigest: PLAN_DIGEST,
+      canonicalApproval: signStageApproval({
+        source: built.source,
+        idempotencyKey: "stage-link-skill",
+      }),
+      skillId: "invoice-link-skill",
+      skillName: "Invoice Link Skill",
+    });
+
+    expect(result.importResult.converterId).toBe("link-evidence-skill");
+    expect(result.importResult.candidates).toHaveLength(1);
+    expect(result.importResult.validation[0]?.ok).toBe(true);
+    const candidate = result.importResult.candidates[0]!;
+    expect(candidate.skillId).toBe("invoice-link-skill");
+    expect(candidate.validation.ok).toBe(true);
+    expect(candidate.sourceProvenance.sourceKind).toBe("contentBase64");
+    expect(existsSync(join(candidate.filesDir, "run.sh"))).toBe(true);
+    const runSh = readFileSync(join(candidate.filesDir, "run.sh"), "utf8");
+    expect(runSh).toContain("LINK_SKILL_EVIDENCE_READY");
+    expect(runSh).toContain("link_evidence_ready");
+    expect(runSh).toContain("https://example.com/skill-guide?redacted=1");
+    expect(runSh).not.toContain("super-secret-link-token");
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("requires canonical approval before writing a generated link skill candidate", async () => {
+    const root = makeTempDir();
+    tempDirs.push(root);
+    const linkUnderstanding = {
+      processText: vi.fn(async () => [{
+        url: "https://example.com/approved-link-skill",
+        title: "Approval Required",
+        summary: "LINK_SKILL_APPROVAL_REQUIRED evidence.",
+        contentType: "text/html",
+        cached: false,
+        processingMs: 1,
+      }]),
+    };
+    const service = createFridayLinkToSkillService({
+      linkUnderstanding,
+      converterService: makeConverterService(root),
+      canonicalMutationGate: createFridayMutatingActionGate({
+        nowIso: () => NOW,
+        ticketIdGenerator: () => "ticket-denied",
+        approvalSignatureSecret: APPROVAL_TEST_KEY,
+        requireApprovalSignature: true,
+      }),
+    });
+
+    await expect(service.stageFromText({
+      text: "https://example.com/approved-link-skill",
+      actor: ACTOR,
+      surface: "test:link-to-skill",
+      idempotencyKey: "missing-approval",
+      planDigest: PLAN_DIGEST,
+      skillId: "approval-required-link-skill",
+    })).rejects.toMatchObject({ code: "CANONICAL_APPROVAL_REQUIRED" });
+  });
+
+  it("blocks private/local URLs before candidate generation", async () => {
+    const root = makeTempDir();
+    tempDirs.push(root);
+    const linkUnderstanding = {
+      processText: vi.fn(async () => [{
+        url: "http://127.0.0.1:3000/private-skill?token=private-token",
+        title: "Private Skill",
+        summary: "This must not become a generated skill candidate.",
+        contentType: "text/html",
+        cached: false,
+        processingMs: 1,
+      }]),
+    };
+    const converterService = makeConverterService(root);
+    const importSpy = vi.spyOn(converterService, "import");
+    const service = createFridayLinkToSkillService({
+      linkUnderstanding,
+      converterService,
+      canonicalMutationGate: createFridayMutatingActionGate({
+        nowIso: () => NOW,
+        ticketIdGenerator: () => "ticket-private",
+        approvalSignatureSecret: APPROVAL_TEST_KEY,
+        requireApprovalSignature: true,
+      }),
+    });
+
+    await expect(service.stageFromText({
+      text: "http://127.0.0.1:3000/private-skill?token=private-token",
+      actor: ACTOR,
+      surface: "test:link-to-skill",
+      idempotencyKey: "private-url",
+      planDigest: PLAN_DIGEST,
+      skillId: "private-link-skill",
+    })).rejects.toMatchObject({ code: "LINK_TO_SKILL_URL_BLOCKED" });
+    expect(importSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- stage extracted link evidence as an evidence-only skill candidate behind canonical approval
- convert link-evidence payloads into deterministic shell skills that carry redacted proof and do not refetch source URLs at run time
- block private/local skill-source links and prove Review Center skill candidate approve/reject flows

## Proof
- npm ci
- npx vitest run test/e2e/api/friday-api-skill-upgrade-lifecycle-live.test.ts
- npm run build:ui
- npx vitest run test/e2e/ui/friday-reflex-review-center-real-browser.e2e.test.ts
- npx vitest run test/unit/skills/link-to-skill/friday-link-to-skill-service.test.ts test/unit/skills/converter/discovery/friday-discovery-integration.test.ts test/unit/skills/converter/friday-skill-converter-service.test.ts test/unit/skills/converter/friday-skill-converter-registry.test.ts test/unit/link-understanding/friday-link-understanding.test.ts test/unit/deeplink/friday-deeplink-validator.test.ts
- npx vitest run test/unit/api/http/routes/friday-skill-converter-routes.test.ts test/unit/api/http/routes/friday-skill-routes.test.ts test/unit/skills/executor/friday-skill-executor.test.ts
- npm run build:api
- npm run lint
- npm run check:secret-patterns
- detect-secrets-hook on changed files
- npm test

## Safety
- no npm publish, no GitHub settings/secrets changes, no force push
- unsafe/private URL path blocks before candidate write
- candidate staging requires canonical approval instead of default-allow fallback
