### PR TITLE
[codex] Close memory cognition v1 proof

### DIFF
--- a/src/api/http/routes/friday-memory-routes.ts
+++ b/src/api/http/routes/friday-memory-routes.ts
@@ -140,6 +140,19 @@ function validateSearchBody(body: unknown): asserts body is FridayMemorySearchRe
   if (b.boostByConfidence !== undefined && typeof b.boostByConfidence !== "boolean") {
     throw new FridayDomainError("VALIDATION_ERROR", "boostByConfidence must be a boolean", { httpStatus: 400 });
   }
+  if (b.boostByAccess !== undefined && typeof b.boostByAccess !== "boolean") {
+    throw new FridayDomainError("VALIDATION_ERROR", "boostByAccess must be a boolean", { httpStatus: 400 });
+  }
+  if (b.applyRetentionDecay !== undefined && typeof b.applyRetentionDecay !== "boolean") {
+    throw new FridayDomainError("VALIDATION_ERROR", "applyRetentionDecay must be a boolean", { httpStatus: 400 });
+  }
+  if (b.retentionHalfLifeDays !== undefined) {
+    const retentionHalfLifeDays = Number(b.retentionHalfLifeDays);
+    if (!Number.isFinite(retentionHalfLifeDays) || retentionHalfLifeDays <= 0) {
+      throw new FridayDomainError("VALIDATION_ERROR", "retentionHalfLifeDays must be a positive number", { httpStatus: 400 });
+    }
+    b.retentionHalfLifeDays = retentionHalfLifeDays;
+  }
 }
 
 function validateStoreNumericFields(body: unknown): void {
@@ -496,6 +509,9 @@ export function createFridayMemoryRoutes(
           weights: body.weights,
           memoryType: body.memoryType,
           boostByConfidence: body.boostByConfidence,
+          boostByAccess: body.boostByAccess,
+          applyRetentionDecay: body.applyRetentionDecay,
+          retentionHalfLifeDays: body.retentionHalfLifeDays,
         });
         const learnedItems = deps.listLearnedFacts && shouldIncludeLearnedFacts({
           namespace: body.namespace,

--- a/src/api/model/friday-api-memory.types.ts
+++ b/src/api/model/friday-api-memory.types.ts
@@ -24,6 +24,9 @@ export interface FridayMemorySearchRequest {
   weights?: { fts: number; semantic: number };
   memoryType?: FridayMemoryType | FridayMemoryType[];
   boostByConfidence?: boolean;
+  boostByAccess?: boolean;
+  applyRetentionDecay?: boolean;
+  retentionHalfLifeDays?: number;
 }
 export interface FridayMemorySearchResponse {
   items: FridayMemorySearchResult[];

--- a/src/memory/guard/friday-memory-guard.constants.ts
+++ b/src/memory/guard/friday-memory-guard.constants.ts
@@ -47,7 +47,7 @@ export const FRIDAY_MEMORY_GUARD_SCOPE_PREFIX_MAX_NAMESPACES = 1_000;
 
 // ─── PII policy (compile-time configurable) ───
 
-export const FRIDAY_MEMORY_GUARD_PII_MODE = "tag" as const; // "block" | "redact" | "tag"
+export const FRIDAY_MEMORY_GUARD_PII_MODE = "redact" as const; // "block" | "redact" | "tag"
 export const FRIDAY_MEMORY_GUARD_PII_TAG_PREFIX = "pii";
 export const FRIDAY_MEMORY_GUARD_EMAIL_REGEX = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
 export const FRIDAY_MEMORY_GUARD_US_PHONE_REGEX = /\b(?:\+1[-.\s]?)?(?:\(?[2-9]\d{2}\)?[-.\s]?)?[2-9]\d{2}[-.\s]?\d{4}\b/g;

--- a/src/memory/guard/services/friday-memory-output-filter.ts
+++ b/src/memory/guard/services/friday-memory-output-filter.ts
@@ -1,5 +1,6 @@
 import type { FridayMemoryItem, FridayMemorySearchResult } from "../../model/friday-memory.types.js";
 import type { FridayMemoryGuardOutputFilter } from "../model/friday-memory-guard.types.js";
+import { createFridayMemoryPiiGuard } from "./friday-memory-pii-guard.js";
 
 import {
   FRIDAY_MEMORY_GUARD_MAX_RESULT_CONTENT_CHARS,
@@ -7,9 +8,15 @@ import {
   FRIDAY_MEMORY_GUARD_MAX_SEARCH_RESULTS,
 } from "../friday-memory-guard.constants.js";
 
+const piiRedactor = createFridayMemoryPiiGuard("redact");
+
 function truncateString(value: string, maxChars: number): string {
   if (value.length <= maxChars) return value;
   return value.slice(0, maxChars);
+}
+
+function redactAndTruncate(value: string, maxChars: number): string {
+  return truncateString(piiRedactor.scanAndTransform(value).transformedContent, maxChars);
 }
 
 export function createFridayMemoryOutputFilter(): FridayMemoryGuardOutputFilter {
@@ -17,7 +24,7 @@ export function createFridayMemoryOutputFilter(): FridayMemoryGuardOutputFilter 
     filterItem(item: FridayMemoryItem): FridayMemoryItem {
       return {
         ...item,
-        content: truncateString(item.content, FRIDAY_MEMORY_GUARD_MAX_RESULT_CONTENT_CHARS),
+        content: redactAndTruncate(item.content, FRIDAY_MEMORY_GUARD_MAX_RESULT_CONTENT_CHARS),
       };
     },
 
@@ -27,9 +34,9 @@ export function createFridayMemoryOutputFilter(): FridayMemoryGuardOutputFilter 
         ...result,
         item: {
           ...result.item,
-          content: truncateString(result.item.content, FRIDAY_MEMORY_GUARD_MAX_RESULT_CONTENT_CHARS),
+          content: redactAndTruncate(result.item.content, FRIDAY_MEMORY_GUARD_MAX_RESULT_CONTENT_CHARS),
         },
-        snippet: truncateString(result.snippet, FRIDAY_MEMORY_GUARD_MAX_RESULT_SNIPPET_CHARS),
+        snippet: redactAndTruncate(result.snippet, FRIDAY_MEMORY_GUARD_MAX_RESULT_SNIPPET_CHARS),
       }));
     },
   };

--- a/src/memory/model/friday-memory.types.ts
+++ b/src/memory/model/friday-memory.types.ts
@@ -68,6 +68,12 @@ export interface FridayMemorySearchQuery {
   memoryType?: FridayMemoryType | FridayMemoryType[];
   /** Boost results by confidence score. Default: false. */
   boostByConfidence?: boolean;
+  /** Boost results by prior successful recall count. Default: false. */
+  boostByAccess?: boolean;
+  /** Apply non-destructive confidence decay during ranking. Default: false. */
+  applyRetentionDecay?: boolean;
+  /** Half-life in days used when applyRetentionDecay is true. */
+  retentionHalfLifeDays?: number;
 }
 
 export interface FridayMemorySearchResult {

--- a/src/memory/search/friday-memory-hybrid.ts
+++ b/src/memory/search/friday-memory-hybrid.ts
@@ -18,6 +18,48 @@ export interface MergeHybridResultsInput {
   limit: number;
   minScore?: number;
   boostByConfidence?: boolean;
+  boostByAccess?: boolean;
+  applyRetentionDecay?: boolean;
+  retentionHalfLifeDays?: number;
+  nowIso?: string;
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const DEFAULT_RETENTION_HALF_LIFE_DAYS = 180;
+const MIN_RETENTION_CONFIDENCE = 0.05;
+
+function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+
+function latestIso(left: string | undefined, right: string | undefined): string | undefined {
+  if (!left) return right;
+  if (!right) return left;
+  const leftMs = Date.parse(left);
+  const rightMs = Date.parse(right);
+  if (!Number.isFinite(leftMs)) return right;
+  if (!Number.isFinite(rightMs)) return left;
+  return rightMs > leftMs ? right : left;
+}
+
+function effectiveConfidence(item: FridayMemoryItem, input: MergeHybridResultsInput): number | undefined {
+  if (typeof item.confidence !== "number") return undefined;
+  const confidence = clamp01(item.confidence);
+  if (!input.applyRetentionDecay) return confidence;
+
+  const nowMs = Date.parse(input.nowIso ?? new Date().toISOString());
+  const anchor = latestIso(item.updatedAt, item.lastAccessedAt);
+  const anchorMs = anchor ? Date.parse(anchor) : NaN;
+  if (!Number.isFinite(nowMs) || !Number.isFinite(anchorMs) || nowMs <= anchorMs) {
+    return confidence;
+  }
+
+  const halfLifeDays = typeof input.retentionHalfLifeDays === "number" && input.retentionHalfLifeDays > 0
+    ? input.retentionHalfLifeDays
+    : DEFAULT_RETENTION_HALF_LIFE_DAYS;
+  const ageDays = (nowMs - anchorMs) / MS_PER_DAY;
+  const decayed = confidence * Math.exp(-Math.LN2 * ageDays / halfLifeDays);
+  return Math.max(MIN_RETENTION_CONFIDENCE, decayed);
 }
 
 /**
@@ -80,13 +122,17 @@ export function mergeHybridResults(input: MergeHybridResultsInput): FridayMemory
     const item = input.resolveItem(itemId);
     if (!item) continue;
 
-    const confidenceBoost = input.boostByConfidence && typeof item.confidence === "number"
-      ? Math.max(0, Math.min(1, item.confidence)) * 0.05
+    const decayedConfidence = effectiveConfidence(item, input);
+    const confidenceBoost = input.boostByConfidence && typeof decayedConfidence === "number"
+      ? decayedConfidence * 0.05
+      : 0;
+    const accessBoost = input.boostByAccess && typeof item.accessCount === "number"
+      ? Math.min(Math.max(item.accessCount, 0), 20) / 20 * 0.03
       : 0;
 
     results.push({
       item,
-      score: score + confidenceBoost,
+      score: score + confidenceBoost + accessBoost,
       ftsScore: entry.ftsScore,
       semanticScore: entry.semanticScore,
       matchedBy: [...entry.matchedBy],

--- a/src/memory/services/friday-memory-service.ts
+++ b/src/memory/services/friday-memory-service.ts
@@ -319,6 +319,10 @@ export function createFridayMemoryService(
         limit,
         minScore: options?.minScore,
         boostByConfidence: options?.boostByConfidence,
+        boostByAccess: options?.boostByAccess,
+        applyRetentionDecay: options?.applyRetentionDecay,
+        retentionHalfLifeDays: options?.retentionHalfLifeDays,
+        nowIso: now,
       });
 
       // Fallback: if FTS and semantic both returned nothing, try a namespace-filtered
@@ -359,7 +363,9 @@ export function createFridayMemoryService(
               item,
               score: 0.1 + (options?.boostByConfidence && typeof item.confidence === "number"
                 ? Math.max(0, Math.min(1, item.confidence)) * 0.05
-                : 0), // low confidence substring match, optionally confidence-adjusted
+                : 0) + (options?.boostByAccess && typeof item.accessCount === "number"
+                ? Math.min(Math.max(item.accessCount, 0), 20) / 20 * 0.03
+                : 0), // low confidence substring match, optionally confidence/access-adjusted
               ftsScore: 0,
               semanticScore: 0,
               matchedBy: ["substring"],

--- a/src/memory/sync/friday-memory-file-sync-repository.ts
+++ b/src/memory/sync/friday-memory-file-sync-repository.ts
@@ -85,7 +85,7 @@ export interface FridayMemoryFileSyncRepository {
   /** List all tracked sync state rows. */
   listAllStates(): FridayMemoryFileSyncStateRow[];
 
-  /** Upsert memory items from a parsed namespace export file. */
+  /** Non-destructively upsert memory items from a parsed namespace export file. */
   upsertMemoryItemsFromExport(
     namespace: string,
     items: Array<{
@@ -235,13 +235,6 @@ export function createFridayMemoryFileSyncRepository(deps: {
 
     upsertMemoryItemsFromExport(namespace, items) {
       return db.withWriteTransaction((conn) => {
-        // Get existing items for this namespace
-        const existingRows = conn
-          .prepare("SELECT id FROM memory_items WHERE namespace = ?")
-          .all(namespace) as Array<{ id: string }>;
-        const existingIds = new Set(existingRows.map((r) => r.id));
-
-        const importedIds = new Set<string>();
         let upserted = 0;
 
         const upsertStmt = conn.prepare(
@@ -270,21 +263,10 @@ export function createFridayMemoryFileSyncRepository(deps: {
             item.created_at,
             item.updated_at,
           );
-          importedIds.add(item.id);
           upserted++;
         }
 
-        // Delete items that exist in DB but not in the imported file
-        let deleted = 0;
-        const deleteStmt = conn.prepare("DELETE FROM memory_items WHERE id = ?");
-        for (const existingId of existingIds) {
-          if (!importedIds.has(existingId)) {
-            deleteStmt.run(existingId);
-            deleted++;
-          }
-        }
-
-        return { upserted, deleted };
+        return { upserted, deleted: 0 };
       });
     },
 

--- a/test/integration/memory/friday-memory-cognition-v1-proof.test.ts
+++ b/test/integration/memory/friday-memory-cognition-v1-proof.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createFridayMemoryRoutes } from "#api";
+import type { FridayHttpContext, FridayRouteDefinition } from "#api";
+import {
+  createFridayMemoryFileSyncRepository,
+  createFridayMemoryFileSyncService,
+  createFridayMemoryGuardServiceFactory,
+  createFridayMemoryService,
+  memoryNamespaceExportPath,
+} from "#memory";
+import type { FridayMemoryDedupAdvisoryEvent, FridayMemoryItem, FridayMemorySearchResult } from "#memory";
+import type { FridayProviderService } from "#providers";
+import { createFridaySqliteLayer } from "#state";
+
+const START = "2026-05-27T10:00:00.000Z";
+
+function createProviderWithoutEmbeddings(): FridayProviderService {
+  return {
+    listProviders: vi.fn(),
+    getProvider: vi.fn(),
+    createProvider: vi.fn(),
+    updateProvider: vi.fn(),
+    deleteProvider: vi.fn(),
+    validateProvider: vi.fn(),
+    getRoutingConfig: vi.fn(),
+    setRoutingConfig: vi.fn(),
+    resolveRoute: vi.fn(),
+    runWithFallback: vi.fn().mockRejectedValue(
+      new Error("No enabled providers available for routing: memory-cognition-v1-proof"),
+    ),
+    recordUsage: vi.fn(),
+    getUsageSummary: vi.fn(),
+    getBudgetStatus: vi.fn(),
+    setBudgetConfig: vi.fn(),
+  } as unknown as FridayProviderService;
+}
+
+function makeCtx(
+  overrides: Partial<FridayHttpContext<unknown, unknown, unknown>> = {},
+): FridayHttpContext<unknown, unknown, unknown> {
+  return {
+    requestId: "req-memory-cognition-v1",
+    receivedAt: START,
+    params: {},
+    query: {},
+    body: {},
+    headers: {},
+    principal: {
+      principalType: "user",
+      principalId: "user-1",
+      userId: "user-1",
+      role: "admin",
+      scopes: ["hub.admin", "memory.read", "memory.write"],
+      tokenId: "tok-1",
+      tokenKind: "access",
+      issuedAt: START,
+    },
+    ...overrides,
+  };
+}
+
+function findRoute(
+  routes: FridayRouteDefinition<unknown, unknown, unknown, unknown>[],
+  operationId: string,
+): FridayRouteDefinition<unknown, unknown, unknown, unknown> {
+  const route = routes.find((candidate) => candidate.operationId === operationId);
+  if (!route) throw new Error(`route not found: ${operationId}`);
+  return route;
+}
+
+describe("Memory cognition v1 proof", () => {
+  let tmpDir: string;
+  let db: ReturnType<typeof createFridaySqliteLayer>;
+  let nowIso: string;
+  let idCounter: number;
+  let dedupEvents: FridayMemoryDedupAdvisoryEvent[];
+  let routes: FridayRouteDefinition<unknown, unknown, unknown, unknown>[];
+
+  function boot(existingDbPath?: string): void {
+    db = createFridaySqliteLayer({
+      dbPath: existingDbPath ?? path.join(tmpDir, "friday-memory-proof.db"),
+      readPoolSize: 1,
+      pragmas: { busyTimeoutMs: 5000, synchronous: "NORMAL" },
+    });
+    const memoryService = createFridayMemoryService({
+      db,
+      providerService: createProviderWithoutEmbeddings(),
+      idGenerator: () => `mem-proof-${String(++idCounter).padStart(4, "0")}`,
+      nowIso: () => nowIso,
+      dedupAdvisorySink: (event) => dedupEvents.push(event),
+      dedupThreshold: 0.5,
+    });
+    const memoryGuardFactory = createFridayMemoryGuardServiceFactory({
+      core: memoryService,
+      db,
+      nowIso: () => nowIso,
+      nowMs: () => Date.parse(nowIso),
+    });
+    routes = createFridayMemoryRoutes({ memoryGuardFactory });
+  }
+
+  async function store(body: Record<string, unknown>): Promise<FridayMemoryItem> {
+    const result = await findRoute(routes, "memory.items.create").handler(makeCtx({ body })) as { item: FridayMemoryItem };
+    return result.item;
+  }
+
+  async function search(body: Record<string, unknown>): Promise<FridayMemorySearchResult[]> {
+    const result = await findRoute(routes, "memory.search").handler(makeCtx({ body })) as { items: FridayMemorySearchResult[] };
+    return result.items;
+  }
+
+  async function get(id: string): Promise<FridayMemoryItem> {
+    const result = await findRoute(routes, "memory.get").handler(makeCtx({ params: { id } })) as { item: FridayMemoryItem };
+    return result.item;
+  }
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "friday-memory-cognition-v1-"));
+    nowIso = START;
+    idCounter = 0;
+    dedupEvents = [];
+    boot();
+  });
+
+  afterEach(async () => {
+    try {
+      db.close();
+    } catch {
+      // best effort test cleanup
+    }
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("proves guarded top-k recall, confidence/access/decay ranking, PII redaction, non-destructive sync, restart recovery, and advisory-only dedup", async () => {
+    const pii = await store({
+      namespace: "cognition",
+      content: "Contact user@example.com for the concierge workflow",
+      memoryType: "fact",
+      confidence: 0.9,
+    });
+    expect(pii.content).toContain("[EMAIL]");
+    expect(pii.content).not.toContain("user@example.com");
+    expect(pii.tags).toContain("pii.email");
+
+    await store({
+      namespace: "cognition",
+      content: "alpha topk shared lower-confidence candidate",
+      memoryType: "procedure",
+      confidence: 0.2,
+    });
+    const highConfidence = await store({
+      namespace: "cognition",
+      content: "alpha topk shared higher-confidence candidate",
+      memoryType: "procedure",
+      confidence: 0.95,
+    });
+    const topK = await search({
+      namespace: "cognition",
+      query: "alpha topk shared candidate",
+      limit: 1,
+      memoryType: "procedure",
+      boostByConfidence: true,
+    });
+    expect(topK).toHaveLength(1);
+    expect(topK[0]!.item.id).toBe(highConfidence.id);
+
+    const used = await store({
+      namespace: "cognition",
+      content: "accessrank shared used candidate",
+      memoryType: "fact",
+      confidence: 0.5,
+    });
+    const fresh = await store({
+      namespace: "cognition",
+      content: "accessrank shared fresh candidate",
+      memoryType: "fact",
+      confidence: 0.5,
+    });
+    await search({ namespace: "cognition", query: "used", limit: 1 });
+    await search({ namespace: "cognition", query: "used", limit: 1 });
+    await search({ namespace: "cognition", query: "used", limit: 1 });
+    const accessRanked = await search({
+      namespace: "cognition",
+      query: "accessrank shared candidate",
+      limit: 2,
+      boostByAccess: true,
+    });
+    expect(accessRanked.map((entry) => entry.item.id)).toContain(used.id);
+    expect(accessRanked.map((entry) => entry.item.id)).toContain(fresh.id);
+    expect(accessRanked[0]!.item.id).toBe(used.id);
+    expect((await get(used.id)).accessCount).toBeGreaterThan((await get(fresh.id)).accessCount ?? 0);
+
+    nowIso = "2025-01-01T00:00:00.000Z";
+    const stale = await store({
+      namespace: "cognition",
+      content: "decayrank shared stale candidate",
+      memoryType: "fact",
+      confidence: 1,
+    });
+    nowIso = "2026-05-27T10:00:00.000Z";
+    const recent = await store({
+      namespace: "cognition",
+      content: "decayrank shared recent candidate",
+      memoryType: "fact",
+      confidence: 0.6,
+    });
+    const decayed = await search({
+      namespace: "cognition",
+      query: "decayrank shared candidate",
+      limit: 1,
+      boostByConfidence: true,
+      applyRetentionDecay: true,
+      retentionHalfLifeDays: 30,
+    });
+    expect(decayed[0]!.item.id).toBe(recent.id);
+    expect((await get(stale.id)).confidence).toBe(1);
+
+    await store({
+      namespace: "cognition",
+      content: "dedup advisory only keeps both duplicate rows",
+      key: "dedup-a",
+      memoryType: "fact",
+      confidence: 0.8,
+    });
+    await store({
+      namespace: "cognition",
+      content: "dedup advisory only keeps both duplicate rows",
+      key: "dedup-b",
+      memoryType: "fact",
+      confidence: 0.8,
+    });
+    const duplicates = await search({
+      namespace: "cognition",
+      query: "dedup advisory duplicate",
+      limit: 10,
+    });
+    expect(duplicates.filter((entry) => entry.item.content.includes("dedup advisory only")).length).toBeGreaterThanOrEqual(2);
+
+    const syncRepo = createFridayMemoryFileSyncRepository({ db });
+    const syncService = createFridayMemoryFileSyncService({
+      repository: syncRepo,
+      stateDir: tmpDir,
+      enableWatcher: false,
+      nowIso: () => nowIso,
+    });
+    const syncResult = await syncService.syncNow({ force: true });
+    expect(syncResult.errors).toHaveLength(0);
+    expect(syncResult.filesWritten).toBeGreaterThan(0);
+
+    const exportPath = memoryNamespaceExportPath(tmpDir, pii.namespace);
+    const exported = JSON.parse(await fs.readFile(exportPath, "utf8")) as {
+      items: Array<Record<string, unknown>>;
+    };
+    exported.items = exported.items.filter((item) => item.id !== fresh.id);
+    exported.items.push({
+      id: "file-added-memory",
+      key: "file-added-memory",
+      value: "file added non destructive proof",
+      contentText: "file added non destructive proof",
+      source: "file-edit",
+      tags: [],
+      metadata: {},
+      createdAt: nowIso,
+      updatedAt: nowIso,
+    });
+    await fs.writeFile(exportPath, JSON.stringify(exported, null, 2), "utf8");
+
+    const reindexResult = await syncService.reindexNow("memory_namespace", pii.namespace);
+    expect(reindexResult.errors).toHaveLength(0);
+    expect(reindexResult.filesProcessed).toBe(1);
+    expect(reindexResult.itemsDeleted).toBe(0);
+    await expect(get(fresh.id)).resolves.toMatchObject({ id: fresh.id });
+    expect(await search({
+      namespace: "cognition",
+      query: "file added non destructive proof",
+      limit: 1,
+    })).toHaveLength(1);
+
+    const dbPath = db.dbPath;
+    db.close();
+    boot(dbPath);
+
+    const afterRestart = await search({
+      namespace: "cognition",
+      query: "file added non destructive proof",
+      limit: 1,
+    });
+    expect(afterRestart).toHaveLength(1);
+    expect(afterRestart[0]!.item.content).toBe("file added non destructive proof");
+
+    const piiAfterRestart = await search({
+      namespace: "cognition",
+      query: "concierge workflow",
+      limit: 1,
+    });
+    expect(piiAfterRestart[0]!.item.content).toContain("[EMAIL]");
+    expect(piiAfterRestart[0]!.item.content).not.toContain("user@example.com");
+  });
+});

--- a/test/integration/memory/guard/friday-memory-guard-pii-namespace.test.ts
+++ b/test/integration/memory/guard/friday-memory-guard-pii-namespace.test.ts
@@ -1,51 +1,41 @@
 import { describe, it, expect, vi } from "vitest";
 import { FridayDomainError } from "#errors";
 import { FRIDAY_MEMORY_GUARD_ERROR_CODES } from "#memory";
-import { FRIDAY_MEMORY_GUARD_PII_MODE } from "#memory";
 import {
   createGuardTestSetup,
   createMockMemoryItem,
   createMockSearchResult,
 } from "../../../unit/memory/guard/services/_helpers/create-guard-service.helper.js";
 
-const PII_BLOCK_MODE_ENABLED = (FRIDAY_MEMORY_GUARD_PII_MODE as string) === "block";
-
 describe("FridayMemoryGuard — PII + Namespace + Rate Limit (Integration)", () => {
-  // ─── PII detection in tag mode (default) ───
+  // ─── PII detection in redact mode (default) ───
 
-  describe("PII detection (tag mode - default)", () => {
-    it.runIf(PII_BLOCK_MODE_ENABLED)("blocks store when PII is detected in block mode", async () => {
+  describe("PII detection (redact mode - default)", () => {
+    it("does not block store when PII can be redacted by default", async () => {
       const { guard, piiGuard } = createGuardTestSetup();
       vi.mocked(piiGuard.scanAndTransform).mockReturnValue({
         matches: [{ type: "email", value: "user@test.com", start: 0, end: 13 }],
         distinctTypes: ["email"],
-        transformedContent: "user@test.com",
+        transformedContent: "[EMAIL]",
         tagsToAdd: ["pii.email"],
       });
 
-      try {
-        await guard.store("test-ns", "user@test.com");
-        expect.fail("Expected FridayDomainError");
-      } catch (error) {
-        const domainError = error as FridayDomainError;
-        expect(domainError).toBeInstanceOf(FridayDomainError);
-        expect(domainError.code).toBe(FRIDAY_MEMORY_GUARD_ERROR_CODES.PII_BLOCKED);
-      }
+      await expect(guard.store("test-ns", "user@test.com")).resolves.toBeDefined();
     });
 
-    it("allows store with PII tags when in tag mode (default)", async () => {
+    it("redacts store content and adds PII tags by default", async () => {
       const { guard, core, piiGuard } = createGuardTestSetup();
       vi.mocked(piiGuard.scanAndTransform).mockReturnValue({
         matches: [{ type: "email", value: "user@test.com", start: 0, end: 13 }],
         distinctTypes: ["email"],
-        transformedContent: "user@test.com is the address",
+        transformedContent: "[EMAIL] is the address",
         tagsToAdd: ["pii.email"],
       });
 
       await guard.store("test-ns", "user@test.com is the address");
       expect(core.store).toHaveBeenCalledWith(
         expect.anything(),
-        "user@test.com is the address",
+        "[EMAIL] is the address",
         expect.objectContaining({ tags: ["pii.email"] }),
       );
     });

--- a/test/unit/api/http/routes/friday-memory-routes.test.ts
+++ b/test/unit/api/http/routes/friday-memory-routes.test.ts
@@ -317,6 +317,9 @@ describe("FridayMemoryRoutes", () => {
         query: "hello",
         memoryType: ["preference", "correction"],
         boostByConfidence: true,
+        boostByAccess: true,
+        applyRetentionDecay: true,
+        retentionHalfLifeDays: 30,
       },
     });
     const result = await route.handler(ctx) as { items: FridayMemorySearchResult[] };
@@ -327,6 +330,9 @@ describe("FridayMemoryRoutes", () => {
       expect.objectContaining({
         memoryType: ["preference", "correction"],
         boostByConfidence: true,
+        boostByAccess: true,
+        applyRetentionDecay: true,
+        retentionHalfLifeDays: 30,
       }),
     );
   });
@@ -345,6 +351,27 @@ describe("FridayMemoryRoutes", () => {
       body: {
         query: "hello",
         boostByConfidence: "yes",
+      },
+    }))).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+
+    await expect(route.handler(makeCtx({
+      body: {
+        query: "hello",
+        boostByAccess: "yes",
+      },
+    }))).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+
+    await expect(route.handler(makeCtx({
+      body: {
+        query: "hello",
+        applyRetentionDecay: "yes",
+      },
+    }))).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+
+    await expect(route.handler(makeCtx({
+      body: {
+        query: "hello",
+        retentionHalfLifeDays: 0,
       },
     }))).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
   });

--- a/test/unit/memory/guard/services/friday-memory-guard-service-output-filter.test.ts
+++ b/test/unit/memory/guard/services/friday-memory-guard-service-output-filter.test.ts
@@ -61,6 +61,15 @@ describe("FridayMemoryOutputFilter", () => {
     expect(filtered.tags).toEqual(["t1", "t2"]);
   });
 
+  it("redacts PII from item content before returning it", () => {
+    const item = makeItem({ content: "Email user@example.com and SSN 123-45-6789" });
+    const filtered = filter.filterItem(item);
+    expect(filtered.content).toContain("[EMAIL]");
+    expect(filtered.content).toContain("[SSN_US]");
+    expect(filtered.content).not.toContain("user@example.com");
+    expect(filtered.content).not.toContain("123-45-6789");
+  });
+
   // ─── filterSearchResults ───
 
   it("returns results as-is when within limits", () => {
@@ -90,6 +99,19 @@ describe("FridayMemoryOutputFilter", () => {
     const results = [makeSearchResult({ item: makeItem({ content: longContent }) })];
     const filtered = filter.filterSearchResults(results);
     expect(filtered[0].item.content.length).toBe(FRIDAY_MEMORY_GUARD_MAX_RESULT_CONTENT_CHARS);
+  });
+
+  it("redacts PII from search result content and snippets", () => {
+    const results = [makeSearchResult({
+      item: makeItem({ content: "Card 4111 1111 1111 1111 belongs elsewhere" }),
+      snippet: "Call 415-555-1212 about user@example.com",
+    })];
+    const filtered = filter.filterSearchResults(results);
+    expect(filtered[0].item.content).toContain("[CREDIT_CARD]");
+    expect(filtered[0].item.content).not.toContain("4111 1111 1111 1111");
+    expect(filtered[0].snippet).toContain("[PHONE_US]");
+    expect(filtered[0].snippet).toContain("[EMAIL]");
+    expect(filtered[0].snippet).not.toContain("user@example.com");
   });
 
   it("preserves score and matchedBy", () => {

--- a/test/unit/memory/search/friday-memory-hybrid.test.ts
+++ b/test/unit/memory/search/friday-memory-hybrid.test.ts
@@ -4,7 +4,12 @@ import type { FridayMemoryItem } from "../../../../src/memory/model/friday-memor
 
 describe("mergeHybridResults", () => {
   /** Helper to build a minimal FridayMemoryItem for merge tests. */
-  function makeItem(id: string, content = `content for ${id}`, confidence?: number): FridayMemoryItem {
+  function makeItem(
+    id: string,
+    content = `content for ${id}`,
+    confidence?: number,
+    overrides?: Partial<FridayMemoryItem>,
+  ): FridayMemoryItem {
     return {
       id,
       namespace: "test",
@@ -16,6 +21,7 @@ describe("mergeHybridResults", () => {
       createdAt: "2026-01-01T00:00:00.000Z",
       updatedAt: "2026-01-01T00:00:00.000Z",
       confidence,
+      ...overrides,
     };
   }
 
@@ -132,5 +138,56 @@ describe("mergeHybridResults", () => {
     expect(unboosted[0].item.id).toBe("low");
     expect(boosted[0].item.id).toBe("high");
     expect(boosted.find((entry) => entry.item.id === "high")!.score).toBeCloseTo(0.525);
+  });
+
+  it("optionally boosts ordering with bounded access count", () => {
+    const items = new Map<string, FridayMemoryItem>([
+      ["fresh", makeItem("fresh", "fresh", 0.5, { accessCount: 0 })],
+      ["used", makeItem("used", "used", 0.5, { accessCount: 20 })],
+    ]);
+
+    const boosted = mergeHybridResults({
+      ftsHits: [
+        { itemId: "fresh", score: 0.5, snippet: "fresh" },
+        { itemId: "used", score: 0.48, snippet: "used" },
+      ],
+      semanticHits: [],
+      resolveItem: (id) => items.get(id) ?? null,
+      weights: { fts: 1, semantic: 0 },
+      limit: 10,
+      boostByAccess: true,
+    });
+
+    expect(boosted[0].item.id).toBe("used");
+    expect(boosted.find((entry) => entry.item.id === "used")!.score).toBeCloseTo(0.51);
+  });
+
+  it("applies non-destructive confidence decay during ranking when requested", () => {
+    const items = new Map<string, FridayMemoryItem>([
+      ["old", makeItem("old", "old", 1.0, {
+        updatedAt: "2025-01-01T00:00:00.000Z",
+      })],
+      ["recent", makeItem("recent", "recent", 0.6, {
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      })],
+    ]);
+
+    const decayed = mergeHybridResults({
+      ftsHits: [
+        { itemId: "old", score: 0.5, snippet: "old" },
+        { itemId: "recent", score: 0.49, snippet: "recent" },
+      ],
+      semanticHits: [],
+      resolveItem: (id) => items.get(id) ?? null,
+      weights: { fts: 1, semantic: 0 },
+      limit: 10,
+      boostByConfidence: true,
+      applyRetentionDecay: true,
+      retentionHalfLifeDays: 30,
+      nowIso: "2026-01-02T00:00:00.000Z",
+    });
+
+    expect(decayed[0].item.id).toBe("recent");
+    expect(items.get("old")!.confidence).toBe(1.0);
   });
 });

--- a/test/unit/memory/sync/friday-memory-file-sync-watcher.test.ts
+++ b/test/unit/memory/sync/friday-memory-file-sync-watcher.test.ts
@@ -186,7 +186,7 @@ describe("FridayMemoryFileSyncService — Watcher & Reindex", () => {
     expect(result.filesProcessed).toBe(0);
   });
 
-  it("reindexNow handles deleted items from file", async () => {
+  it("reindexNow keeps local items when they are missing from an externally edited file", async () => {
     insertMemoryItem("item-d1", "del-ns", "key1", '{"val":1}');
     insertMemoryItem("item-d2", "del-ns", "key2", '{"val":2}');
 
@@ -210,12 +210,12 @@ describe("FridayMemoryFileSyncService — Watcher & Reindex", () => {
     // Reindex
     const result = await service.reindexNow("memory_namespace", "del-ns");
     expect(result.filesProcessed).toBe(1);
-    expect(result.itemsDeleted).toBe(1);
+    expect(result.itemsDeleted).toBe(0);
 
-    // Verify item-d2 is gone from DB
+    // External file edits are non-destructive by default: omitted local rows stay.
     const items = getMemoryItems("del-ns");
-    expect(items).toHaveLength(1);
-    expect(items[0]!.key).toBe("key1");
+    expect(items).toHaveLength(2);
+    expect(items.map((item) => item.key)).toEqual(["key1", "key2"]);
   });
 
   // ─── ReindexAll ───

--- a/ui/src/lib/api/memory.ts
+++ b/ui/src/lib/api/memory.ts
@@ -66,6 +66,9 @@ export const memoryApi = {
     weights?: { fts: number; semantic: number };
     memoryType?: FridayMemoryType | FridayMemoryType[];
     boostByConfidence?: boolean;
+    boostByAccess?: boolean;
+    applyRetentionDecay?: boolean;
+    retentionHalfLifeDays?: number;
   }): Promise<FridayMemorySearchResult[]> {
     const data = await apiClient.post<typeof input, SearchMemoryResponse>(
       "/v1/memory/search",


### PR DESCRIPTION
## What changed

Closes the Bundle D memory cognition v1 slice with real guarded memory behavior instead of report-only evidence:

- Defaults memory PII handling to redaction and also redacts stored/read search output so old rows cannot leak raw email/phone-like content on recall.
- Adds explicit memory search ranking controls for access-count boost and non-destructive retention decay, including API/UI type plumbing and route validation.
- Makes file-sync reindex non-destructive: missing rows in an edited export no longer delete local memory rows.
- Adds an end-to-end memory cognition proof covering guarded top-k recall, confidence/access/decay ranking, PII redaction, non-destructive sync, restart recovery, and destructive dedup remaining advisory-only.

## Root cause

Memory v1 had pieces of recall, guard, and sync behavior, but the closure blocker was that the release truth map needed an actually-run product loop proof for cognition behavior: safe recall ranking, PII-safe output, restart persistence, non-destructive recovery, and explicit denial of destructive merge/delete behavior. File reindex also treated omitted exported rows as deletes, which violated the local-first safety boundary for edited memory files.

## Validation

Local validation run from a clean worktree on top of `origin/main`:

- `npm ci`
- `npm test -- test/integration/memory/friday-memory-cognition-v1-proof.test.ts test/unit/memory/search/friday-memory-hybrid.test.ts test/unit/memory/guard/services/friday-memory-guard-service-output-filter.test.ts test/integration/memory/guard/friday-memory-guard-pii-namespace.test.ts test/unit/memory/sync/friday-memory-file-sync-watcher.test.ts test/unit/api/http/routes/friday-memory-routes.test.ts`
  - 6 files passed, 76 tests passed, 0 skipped
- `npm run typecheck -- --pretty false`
- `npm test -- test/unit/memory test/integration/memory test/unit/api/http/routes/friday-memory-routes.test.ts test/unit/api/runtime/friday-api-runtime-memory-registration.test.ts test/unit/api/runtime/friday-api-runtime-memory-guard-registration.test.ts test/integration/sessions/friday-session-memory-extraction-integration.test.ts test/unit/sessions test/unit/agent/tools/friday-agent-memory-tools.test.ts`
  - 46 files passed, 817 tests passed
- `npm run lint`
  - 0 errors; existing warnings only
- `npm run build:api`
- `git diff --check`
- `npm run check:secret-patterns`
- `npm test`
  - 887 files passed, 12080 tests passed, type errors: none
  - Existing global live/LLM skips remain unrelated to this Bundle D proof; the changed Bundle D path above has no skips.