### PR TITLE
[codex] Gate provider budget mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project follows Semantic Versioning.
 
 ## [Unreleased]
 
+- Source truth after the immutable npm `1.0.2` package now includes deterministic
+  closures for DP-10 personal-secretary loop proof (PR #352), Skill +
+  link-to-skill lifecycle proof (PR #353), repair/self-upgrade/retry-audit proof
+  (PR #354), and Memory cognition v1 proof (PR #355). These are GitHub-main
+  closures, not npm `1.0.2` package truth.
+- Provider budget configuration writes now share the protected provider mutation
+  boundary: in canonical-gate-required profiles, `PUT /v1/providers/budget`
+  requires an approved plan digest and canonical approval before changing the
+  budget setting, returns gate evidence, and strips approval control fields
+  instead of persisting them into budget config.
+- Usage & Cost source/UI proof now keeps near-limit and over-limit budget states
+  visibly distinct. This supports cost-control truth without claiming hidden
+  spend prevention beyond the configured budget/routing policy.
+- No npm publish is included in this source change. Public npm package alignment
+  still requires an explicit operator-approved future release.
+
 ## [1.0.2] — Post-Release Hardening Wave — 2026-05-26
 
 `1.0.2` accumulates the post-release hardening queue on top of `1.0.1`.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Friday is a **public v1 local candidate** distributed via **npm/source only**, n
 - Slack HTTP Events-API inbound and QQ remain **`unsupported`** in this release.
 - Real Green Gate success is counted only when the artifact is for the same SHA, has nonzero scenarios, all scenarios pass, and blockers are empty.
 - `blocked_by_env`, mock-only tests, workflow success alone, stale artifacts, and wrong-SHA artifacts are not release proof.
-- Dogfood gate for `1.0.1` closed as **`dogfood_partial_pass`** (UX 7.78/10 weighted), and the same nine `proof_pending` headlines are still carried forward in `1.0.2` (see [`docs/public-v1-local-candidate.md`](docs/public-v1-local-candidate.md)): self-repair execute→rollback end-to-end, self-upgrade actual mutation, skill install/update/delete canonical-approval workflow, end-to-end link-to-skill candidate→run, queue/retry receipt loop on retry-eligible incident, audit tamper-negative on disposable ledger, R1 Lark phase24d listener-shutdown bug, speed/cost near_limit/over_limit UI surfacing, memory per-item `confidence`/`last_accessed` surfacing.
+- Dogfood gate for `1.0.1` closed as **`dogfood_partial_pass`** (UX 7.78/10 weighted). The published npm `1.0.2` package still carries the original nine proof-pending headlines. GitHub-visible source after `1.0.2` has closed several deterministic slices, but those are not npm truth until a future authorized publish; see [`docs/public-v1-local-candidate.md`](docs/public-v1-local-candidate.md).
 
 ## The Product Loop
 

--- a/docs/ops/friday-capability-matrix.md
+++ b/docs/ops/friday-capability-matrix.md
@@ -90,6 +90,14 @@ Configure it in Setup -> Capabilities -> OCR. After that I will run a sample ima
 
 The matrix above is the structured contract. The following three plain-language headlines summarize the current public `1.0.2` npm/source boundary in operator-readable terms and are the canonical wording the rest of the product surface (UI copy, release notes, docs) must align with:
 
+Source-truth delta after the immutable npm `1.0.2` package: GitHub-visible main
+has subsequently closed deterministic DP-10 personal-secretary loop proof
+(PR #352), skill/link lifecycle proof (PR #353), repair/upgrade/retry-audit
+proof (PR #354), and Memory cognition v1 proof (PR #355). Current source also
+gates provider budget changes through canonical mutation approval in protected
+profiles and keeps package/npm truth separate. Do not read these source closures
+as already published npm `1.0.2` behavior.
+
 ### What Friday Can Do Today
 
 In `1.0.2`, Friday can run the local-first runtime described in the matrix above: configured chat and task execution, BYOK provider routing for text / vision / OCR / embeddings / web search where the lane is provider-configured and verified, PDF and file work inside scoped paths, browser/desktop control inside the operator-approved boundary, MCP server discovery against connected servers, skill and workflow lifecycle through the candidate → sandbox → approval → register → doctor-verify path, supervised self-healing with bounded auto-fix and rollback, configured trusted-channel inbound on Discord/Telegram/Lark+Feishu (proven on the `1.0.2` release SHA via same-SHA Real Green Gate channel artifacts), memory and learned-preference surfaces, and operator-visible audit/evidence/observability. "Today" means available in the released runtime; "should be able to" is not the same as "today" and stays in the matrix or roadmap.

--- a/docs/public-v1-local-candidate.md
+++ b/docs/public-v1-local-candidate.md
@@ -115,35 +115,42 @@ the release-closure plan's runtime-delta classification report.
 ## Dogfood Closure And Proof-Pending Headlines
 
 The dogfood gate for `1.0.1` closed as `dogfood_partial_pass` with weighted UX
-score 7.78/10 (below the 8.0 `dogfood_pass` threshold), and these headlines
-remain carried forward in `1.0.2`. The following
-capabilities are wired with fail-closed lifecycle gates but end-to-end execution
-is `proof_pending` and explicitly carried forward for a subsequent dogfood pass:
+score 7.78/10 (below the 8.0 `dogfood_pass` threshold). The published npm
+`1.0.2` package still carries the original proof-pending headlines. GitHub-visible
+source after `1.0.2` has narrowed several of them with PR #350 through PR #355
+and the provider/cost source slice below, but those source changes are **not**
+npm package truth until a future authorized publish. Current source truth:
 
-1. Autonomous self-repair end-to-end execute → rollback (lifecycle exists; no
-   autonomy-detected runtime incident occurred during the dogfood test instance)
-2. Autonomous self-upgrade actual mutation (lifecycle visible; no proposal
-   triggered during the test instance)
-3. Skill install / update / delete through the canonical-approval workflow
-   (gates fail-closed at `SKILL_LEGACY_LIFECYCLE_ROUTE_RETIRED`,
-   `SKILL_LIFECYCLE_UPDATE_APPROVAL_REQUIRED`,
-   `SKILL_LIFECYCLE_DELETE_APPROVAL_REQUIRED`; canonical-approval flow setup
-   remains out of scope for the current dogfood evidence)
-4. End-to-end link-to-skill candidate → tests → approval → run (scan-local
-   works; install gate prevents URL trust bypass; full end-to-end run is
-   carried forward)
-5. Queue/retry end-to-end receipt loop with a retry-eligible incident (read
-   endpoints work; no retry-eligible incident was triggered)
-6. Audit tamper-negative on a disposable test ledger (read endpoints work;
-   tamper-negative round-trip carried forward)
-7. R1 Lark phase24d listener-shutdown bug (listener writes `status=passed`
-   correctly but the WebSocket holds the event loop open; non-correctness;
-   artifact is durable; roadmap follow-up)
-8. Speed/cost end-to-end `near_limit` / `over_limit` UI surfacing (primitives
-   wired; full flow not exercised end-to-end)
-9. Memory per-item `confidence` and `last_accessed` field surfacing (ranking,
-   score, and access-count work; per-item `confidence` not yet surfaced in the
-   API shape)
+1. Autonomous self-repair execute → rollback: deterministic skill-drift and
+   route rollback receipt mechanics are closed on GitHub main by PR #351 and
+   PR #354. Live-provider and UI/channel repair dogfood remain separate.
+2. Autonomous self-upgrade actual mutation: workflow lifecycle shadow/canary/
+   promote/rollback now requires canonical mutation approval by PR #354. A
+   product-discovered live mutation remains separate.
+3. Skill install / update / delete through canonical approval: deterministic
+   import/stage, promote/run, update, rollback, and Review Center candidate
+   boundaries are closed on GitHub main by PR #353. Live external-channel and
+   npm package truth remain separate.
+4. Link-to-skill candidate → tests → approval → run: controlled link staging,
+   evidence extraction, private/local URL denial, restart run, and rollback
+   cleanup are closed on GitHub main by PR #353. Arbitrary live-web/channel
+   proof and npm package truth remain separate.
+5. Queue/retry receipt loop: deterministic retry-to-audit append is closed on
+   GitHub main by PR #354. User-visible retry final-state dogfood remains
+   separate.
+6. Audit tamper-negative: disposable retry/audit tamper detection is closed on
+   GitHub main by PR #354. Broader user-visible audit UX can be proven later.
+7. R1 Lark phase24d listener shutdown: source cleanup is closed on GitHub main
+   by PR #350. npm `1.0.2` does not contain it.
+8. Speed/cost `near_limit` / `over_limit`: current source routes expose live
+   budget/usage/provider-health data, the Usage page has explicit near-limit
+   and over-limit labels, and provider budget writes require canonical mutation
+   approval in gate-required profiles. Provider/cost dashboard polish and npm
+   package truth remain separate.
+9. Memory cognition v1: guarded recall, ranking, PII redaction, non-destructive
+   sync, restart/recovery, and duplicate-row non-merge proof are closed on
+   GitHub main by PR #355. Destructive dedup merge/block policy, live external
+   memory dogfood, and npm package truth remain separate.
 
 These are truth-labeled, not silent passes. None contradict the safe claim
 above.

--- a/src/api/http/routes/friday-provider-routes.ts
+++ b/src/api/http/routes/friday-provider-routes.ts
@@ -403,7 +403,11 @@ export function createFridayProviderSetupMutatingActionRequest(input: {
     actor: input.actor,
     surface: input.surface,
     resource: {
-      type: input.action.startsWith("providers.routing.") ? "provider_routing" : "provider_setup",
+      type: input.action.startsWith("providers.routing.")
+        ? "provider_routing"
+        : input.action.startsWith("providers.budget.")
+          ? "provider_budget"
+          : "provider_setup",
       id: input.resourceId,
       digest: hashStableJson(sanitizedParameters),
       attributes: {
@@ -421,7 +425,7 @@ export function createFridayProviderSetupMutatingActionRequest(input: {
         guardId: "provider_setup_mutation_guard",
         decision: "requires_approval",
         risk: "high",
-        reason: "provider_setup_or_routing_mutation_requires_canonical_approval",
+        reason: "provider_setup_routing_or_budget_mutation_requires_canonical_approval",
       },
     ],
   };

--- a/src/api/http/routes/friday-provider-usage-routes.ts
+++ b/src/api/http/routes/friday-provider-usage-routes.ts
@@ -1,4 +1,4 @@
-import type { FridayRouteDefinition } from "../../model/friday-api-common.types.js";
+import type { FridayAuthPrincipal, FridayRouteDefinition } from "../../model/friday-api-common.types.js";
 
 import type {
   FridayGetBudgetStatusResponse,
@@ -9,12 +9,27 @@ import type {
 
 import type { FridayProviderService } from "#providers";
 import { FridayDomainError } from "#errors";
+import {
+  type FridayCanonicalApprovalResolution,
+  type FridayMutatingActionActor,
+  type FridayMutatingActionGate,
+  type FridayMutatingActionTicket,
+} from "../../../security/friday-mutating-action-gate.js";
+import { createFridayProviderSetupMutatingActionRequest } from "./friday-provider-routes.js";
 
 // ─── Dependencies ───
 
 export interface FridayProviderUsageRoutesDeps {
   providerService: FridayProviderService;
+  canonicalMutationGate?: FridayMutatingActionGate;
+  providerMutationGateRequired?: boolean;
 }
+
+type BudgetMutationBody = FridaySetBudgetConfigRequest & {
+  planDigest?: string;
+  idempotencyKey?: string;
+  canonicalApproval?: FridayCanonicalApprovalResolution;
+};
 
 // ─── Budget validation ───
 
@@ -44,6 +59,116 @@ function getDefaultUtcUsageRange(receivedAt: string | undefined): { from: string
     from: `${to.slice(0, 7)}-01`,
     to,
   };
+}
+
+function createActorFromPrincipal(
+  principal: FridayAuthPrincipal | null,
+  fallbackId: string,
+): FridayMutatingActionActor {
+  if (!principal) {
+    return {
+      kind: "api",
+      id: fallbackId,
+      principalId: fallbackId,
+    };
+  }
+  return {
+    kind: principal.principalType,
+    id: principal.principalId,
+    principalId: principal.principalId,
+  };
+}
+
+function readCanonicalApproval(value: unknown): FridayCanonicalApprovalResolution | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as FridayCanonicalApprovalResolution;
+  }
+  throw new FridayDomainError("VALIDATION_ERROR", "canonicalApproval must be an object", { httpStatus: 400 });
+}
+
+function canonicalGateEvidence(ticket: FridayMutatingActionTicket | undefined): {
+  ticketId: string;
+  actionDigest: string;
+  approvalId: string;
+  planDigest?: string;
+} | undefined {
+  if (!ticket) {
+    return undefined;
+  }
+  return {
+    ticketId: ticket.ticketId,
+    actionDigest: ticket.actionDigest,
+    approvalId: ticket.approvalId,
+    planDigest: ticket.planDigest,
+  };
+}
+
+function withCanonicalGate<T extends object>(
+  payload: T,
+  ticket: FridayMutatingActionTicket | undefined,
+): T & { canonicalGate?: NonNullable<ReturnType<typeof canonicalGateEvidence>> } {
+  const evidence = canonicalGateEvidence(ticket);
+  return evidence ? { ...payload, canonicalGate: evidence } : payload;
+}
+
+function maybeRequireBudgetMutationTicket(input: {
+  deps: FridayProviderUsageRoutesDeps;
+  ctx: { requestId: string; principal: FridayAuthPrincipal | null };
+  body: BudgetMutationBody;
+}): FridayMutatingActionTicket | undefined {
+  if (!input.deps.providerMutationGateRequired) {
+    return undefined;
+  }
+  if (!input.deps.canonicalMutationGate) {
+    throw new FridayDomainError(
+      "PROVIDER_MUTATION_CANONICAL_GATE_UNAVAILABLE",
+      "Provider budget mutations require the canonical approval gate in this profile.",
+      { httpStatus: 503 },
+    );
+  }
+  if (!input.body.planDigest) {
+    throw new FridayDomainError(
+      "PROVIDER_MUTATION_PLAN_DIGEST_REQUIRED",
+      "Provider budget mutations require an approved plan digest in this profile.",
+      { httpStatus: 403, details: { action: "providers.budget.set", resourceId: "llm.budget.v1" } },
+    );
+  }
+
+  const parameters = { monthlyLimitUsd: input.body.monthlyLimitUsd };
+  const request = createFridayProviderSetupMutatingActionRequest({
+    action: "providers.budget.set",
+    actor: createActorFromPrincipal(input.ctx.principal, `api:${input.ctx.requestId}`),
+    surface: "api:/v1/providers/budget",
+    resourceId: "llm.budget.v1",
+    parameters,
+    planDigest: input.body.planDigest,
+    idempotencyKey: input.body.idempotencyKey,
+  });
+  const gateResult = input.deps.canonicalMutationGate.evaluate({
+    ...request,
+    canonicalApproval: readCanonicalApproval(input.body.canonicalApproval),
+  });
+  if (gateResult.decision !== "allow" || !gateResult.ticket) {
+    throw new FridayDomainError(
+      gateResult.decision === "requires_approval"
+        ? "CANONICAL_APPROVAL_REQUIRED"
+        : "CANONICAL_APPROVAL_DENIED",
+      gateResult.decision === "requires_approval"
+        ? "Provider budget mutation requires canonical approval before any budget setting is changed."
+        : `Provider budget mutation was blocked by the canonical approval gate: ${gateResult.reason}`,
+      {
+        httpStatus: 403,
+        details: {
+          canonicalGate: gateResult.evidenceRecord,
+          actionDigest: gateResult.actionDigest,
+        },
+      },
+    );
+  }
+  return gateResult.ticket;
 }
 
 // ─── Factory ───
@@ -124,9 +249,12 @@ export function createFridayProviderUsageRoutes(
       auth: { public: true },
       async handler(ctx): Promise<FridaySetBudgetConfigResponse> {
         validateBudgetBody(ctx.body);
-        const body = ctx.body;
-        const budget = await deps.providerService.setBudgetConfig(body);
-        return { budget };
+        const body = ctx.body as BudgetMutationBody;
+        const ticket = maybeRequireBudgetMutationTicket({ deps, ctx, body });
+        const budget = await deps.providerService.setBudgetConfig({
+          monthlyLimitUsd: body.monthlyLimitUsd,
+        });
+        return withCanonicalGate({ budget }, ticket);
       },
     },
   ];

--- a/src/api/model/friday-api-provider.types.ts
+++ b/src/api/model/friday-api-provider.types.ts
@@ -73,6 +73,9 @@ export interface FridaySetRoutingConfigRequest {
 
 export interface FridaySetBudgetConfigRequest {
   monthlyLimitUsd: number;
+  planDigest?: string;
+  idempotencyKey?: string;
+  canonicalApproval?: unknown;
 }
 
 export interface FridayRunCapabilityDoctorRequest {
@@ -199,6 +202,7 @@ export interface FridayGetBudgetStatusResponse {
 
 export interface FridaySetBudgetConfigResponse {
   budget: FridayLlmBudgetConfig;
+  canonicalGate?: FridayProviderCanonicalGateEvidence;
 }
 
 // ─── OAuth types ───

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -2624,6 +2624,8 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
   // stays readable without being correctness-critical for dispatch.
   for (const route of createFridayProviderUsageRoutes({
     providerService: deps.providerService,
+    canonicalMutationGate,
+    providerMutationGateRequired,
   })) {
     routes.register(route);
   }

--- a/test/unit/api/http/routes/friday-provider-usage-routes.test.ts
+++ b/test/unit/api/http/routes/friday-provider-usage-routes.test.ts
@@ -2,6 +2,16 @@ import { describe, expect, it, vi } from "vitest";
 
 import { createFridayProviderUsageRoutes } from "../../../../../src/api/http/routes/friday-provider-usage-routes.js";
 import type { FridayProviderService } from "#providers";
+import type { FridayHttpContext } from "#api";
+import { createFridayProviderSetupMutatingActionRequest } from "../../../../../src/api/http/routes/friday-provider-routes.js";
+import {
+  createFridayMutatingActionDigest,
+  createFridayMutatingActionGate,
+  type FridayCanonicalApprovalResolution,
+} from "../../../../../src/security/friday-mutating-action-gate.js";
+
+const NOW = "2026-05-27T10:15:00.000Z";
+const PLAN_DIGEST = "provider-budget-plan-1";
 
 function makeProviderService() {
   return {
@@ -20,12 +30,84 @@ function makeProviderService() {
         costUsd: 0,
       },
     })),
+    getBudgetStatus: vi.fn(async () => ({
+      month: "2026-05",
+      config: null,
+      spentUsd: 0,
+      remainingUsd: null,
+      state: "ok" as const,
+    })),
+    setBudgetConfig: vi.fn(async (input) => input),
   } as unknown as FridayProviderService & {
     getUsageSummary: ReturnType<typeof vi.fn>;
+    getBudgetStatus: ReturnType<typeof vi.fn>;
+    setBudgetConfig: ReturnType<typeof vi.fn>;
   };
 }
 
 describe("FridayProviderUsageRoutes", () => {
+  function makeCtx(overrides: Partial<FridayHttpContext<unknown, unknown, unknown>> = {}): FridayHttpContext<unknown, unknown, unknown> {
+    return {
+      requestId: "req-budget",
+      receivedAt: NOW,
+      params: {},
+      query: {},
+      body: undefined,
+      headers: {},
+      principal: null,
+      ...overrides,
+    };
+  }
+
+  function makeAdminCtx(overrides: Partial<FridayHttpContext<unknown, unknown, unknown>> = {}): FridayHttpContext<unknown, unknown, unknown> {
+    return makeCtx({
+      principal: {
+        principalType: "user",
+        principalId: "user-1",
+        userId: "user-1",
+        role: "admin",
+        scopes: ["hub.admin"],
+        tokenId: "tok-1",
+        tokenKind: "access",
+        issuedAt: NOW,
+      },
+      ...overrides,
+    });
+  }
+
+  function makeBudgetApproval(monthlyLimitUsd: number): FridayCanonicalApprovalResolution {
+    const request = createFridayProviderSetupMutatingActionRequest({
+      action: "providers.budget.set",
+      actor: {
+        kind: "user",
+        id: "user-1",
+        principalId: "user-1",
+      },
+      surface: "api:/v1/providers/budget",
+      resourceId: "llm.budget.v1",
+      parameters: { monthlyLimitUsd },
+      planDigest: PLAN_DIGEST,
+    });
+    return {
+      decision: "approved",
+      approvalId: "providers.budget.set-approval",
+      decidedByPrincipalId: "user-1",
+      actionDigest: createFridayMutatingActionDigest(request),
+      expiresAt: "2026-05-27T11:15:00.000Z",
+    };
+  }
+
+  function createBudgetRoutesWithGate(providerService: ReturnType<typeof makeProviderService>) {
+    return createFridayProviderUsageRoutes({
+      providerService,
+      providerMutationGateRequired: true,
+      canonicalMutationGate: createFridayMutatingActionGate({
+        nowIso: () => NOW,
+        ticketIdGenerator: () => "ticket-budget-1",
+      }),
+    });
+  }
+
   it("defaults usage date range to UTC to match llm_usage_records.usage_day", async () => {
     const providerService = makeProviderService();
     const route = createFridayProviderUsageRoutes({ providerService })
@@ -52,6 +134,52 @@ describe("FridayProviderUsageRoutes", () => {
       groupBy: "day",
       providerId: undefined,
       model: undefined,
+    });
+  });
+
+  it("requires canonical approval before changing provider budget in gate-required profiles", async () => {
+    const providerService = makeProviderService();
+    const route = createBudgetRoutesWithGate(providerService)
+      .find((entry) => entry.operationId === "providers.budget.set");
+
+    if (!route) {
+      throw new Error("providers.budget.set route not found");
+    }
+
+    await expect(route.handler(makeAdminCtx({
+      body: { monthlyLimitUsd: 3 },
+    }))).rejects.toMatchObject({
+      code: "PROVIDER_MUTATION_PLAN_DIGEST_REQUIRED",
+    });
+
+    expect(providerService.setBudgetConfig).not.toHaveBeenCalled();
+  });
+
+  it("accepts canonical approval and does not persist approval control fields as budget config", async () => {
+    const providerService = makeProviderService();
+    const route = createBudgetRoutesWithGate(providerService)
+      .find((entry) => entry.operationId === "providers.budget.set");
+
+    if (!route) {
+      throw new Error("providers.budget.set route not found");
+    }
+
+    const result = await route.handler(makeAdminCtx({
+      body: {
+        monthlyLimitUsd: 3,
+        planDigest: PLAN_DIGEST,
+        canonicalApproval: makeBudgetApproval(3),
+      },
+    }));
+
+    expect(providerService.setBudgetConfig).toHaveBeenCalledWith({ monthlyLimitUsd: 3 });
+    expect(result).toMatchObject({
+      budget: { monthlyLimitUsd: 3 },
+      canonicalGate: {
+        ticketId: "ticket-budget-1",
+        approvalId: "providers.budget.set-approval",
+        planDigest: PLAN_DIGEST,
+      },
     });
   });
 });

--- a/test/unit/ui/usage-page.test.ts
+++ b/test/unit/ui/usage-page.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { formatTokenSharePercent } from "../../../ui/src/routes/usage-page";
+import { budgetStatusLabel, budgetStatusTone, formatTokenSharePercent } from "../../../ui/src/routes/usage-page";
 
 describe("usage page token share formatting", () => {
   it("derives input and output percentages from recorded token totals", () => {
@@ -15,5 +15,14 @@ describe("usage page token share formatting", () => {
   it("does not leak stale placeholder percentages when totals are missing", () => {
     expect(formatTokenSharePercent(35, 0)).toBe("0%");
     expect(formatTokenSharePercent(Number.NaN, 100)).toBe("0%");
+  });
+});
+
+describe("usage page budget state surfacing", () => {
+  it("maps near-limit and over-limit budget states to visible warning/danger labels", () => {
+    expect(budgetStatusTone("near_limit")).toBe("warning");
+    expect(budgetStatusLabel("near_limit", "en")).toBe("Near limit");
+    expect(budgetStatusTone("over_limit")).toBe("danger");
+    expect(budgetStatusLabel("over_limit", "en")).toBe("Over limit");
   });
 });

--- a/ui/src/routes/usage-page.tsx
+++ b/ui/src/routes/usage-page.tsx
@@ -174,17 +174,34 @@ function providerStatusBadge(item: ProviderHealthItem, locale: import("@/lib/i18
   return <StatusPill tone="warning">{localize(locale, "需关注", "Needs attention")}</StatusPill>;
 }
 
-function budgetStatusBadge(status: FridayLlmBudgetStatus["state"], locale: import("@/lib/i18n/localized-text").AppLocale) {
+export function budgetStatusTone(status: FridayLlmBudgetStatus["state"]): "success" | "warning" | "danger" | undefined {
   switch (status) {
     case "ok":
-      return <StatusPill tone="success">{localize(locale, "预算正常", "Budget OK")}</StatusPill>;
+      return "success";
     case "near_limit":
-      return <StatusPill tone="warning">{localize(locale, "接近上限", "Near limit")}</StatusPill>;
+      return "warning";
     case "over_limit":
-      return <StatusPill tone="danger">{localize(locale, "超出上限", "Over limit")}</StatusPill>;
+      return "danger";
     default:
-      return <StatusPill>{localize(locale, "未知", "Unknown")}</StatusPill>;
+      return undefined;
   }
+}
+
+export function budgetStatusLabel(status: FridayLlmBudgetStatus["state"], locale: import("@/lib/i18n/localized-text").AppLocale): string {
+  switch (status) {
+    case "ok":
+      return localize(locale, "预算正常", "Budget OK");
+    case "near_limit":
+      return localize(locale, "接近上限", "Near limit");
+    case "over_limit":
+      return localize(locale, "超出上限", "Over limit");
+    default:
+      return localize(locale, "未知", "Unknown");
+  }
+}
+
+function budgetStatusBadge(status: FridayLlmBudgetStatus["state"], locale: import("@/lib/i18n/localized-text").AppLocale) {
+  return <StatusPill tone={budgetStatusTone(status)}>{budgetStatusLabel(status, locale)}</StatusPill>;
 }
 
 // Re-export from extracted chart module for direct use


### PR DESCRIPTION
## Summary
- Requires the canonical mutation gate for `PUT /v1/providers/budget` in gate-required profiles, with approved `providers.budget.set` evidence before budget config changes.
- Strips control fields before persistence so `planDigest`, `canonicalApproval`, and `idempotencyKey` cannot be stored as budget config.
- Exposes truthful Usage & Cost near/over-limit labels through exported view helpers and updates package/source-truth docs without claiming npm availability.

## Root cause
`PUT /v1/providers/budget` mutated provider cost policy while remaining public and outside the canonical provider mutation gate. The same endpoint also accepted approval-control fields in the request body and forwarded the whole body to budget persistence, creating approval-boundary and evidence-integrity risk.

## Proof
- `npm ci`
- `npm test -- test/unit/ui/usage-page.test.ts test/unit/api/http/routes/friday-provider-usage-routes.test.ts test/unit/providers/api/friday-provider-routes.test.ts test/unit/providers/cost/friday-provider-cost-controls.test.ts test/unit/providers/services/friday-provider-service.test.ts` (5 files, 143 tests)
- `npm run typecheck -- --pretty false`
- `npm run build:api`
- `npm run build:ui`
- `git diff --check`
- `npm run check:secret-patterns`
- `npm test -- test/unit/providers test/integration/providers test/unit/api/http/routes/friday-provider-usage-routes.test.ts test/unit/providers/api/friday-provider-routes.test.ts test/unit/ui/usage-page.test.ts test/unit/ui/provider-truth.test.ts test/unit/ui/provider-capability-lane-truth-label.test.ts test/unit/ui/provider-doctor-diagnostics.test.ts` (30 files, 382 tests)
- `npm run lint` (0 errors; existing warnings remain)
- `npm pack --dry-run --json` (dry run only; no publish)
- `npm audit --omit=dev` (0 production vulnerabilities)
- `npm test` (887 files passed, 12,084 tests passed; 21 files / 251 tests skipped; type errors 0)

## Release truth / boundaries
- No npm publish was performed or authorized. Public npm `@thesongzhu/friday@1.0.2` remains immutable/stale at gitHead `68de607b17214db0fdf400c29b8bbe0876eb21fb`.
- This PR closes only the GitHub-source provider budget mutation/evidence slice once merged. It does not claim public npm availability or live external-provider/channel proof.
- No GitHub secrets/settings, production credentials, force-push/admin bypass, or destructive user-data changes were used.