### PR TITLE
[codex] Fix summary misroute RGG failure

### DIFF
--- a/src/agent/runtime/friday-agent-tool-routing.ts
+++ b/src/agent/runtime/friday-agent-tool-routing.ts
@@ -526,6 +526,9 @@ function classifyFridayToolRoutingProfile(input: {
   if (/\b(remember|memory|preference|preferences|recall|previously|past conversation|stored fact)\b|记住|记忆|偏好|之前|上次/u.test(text)) {
     return "memory";
   }
+  if (taskIsQaWithProvidedContext(text) && !taskLooksLikeCurrentOrExternalKnowledgeRequest(text)) {
+    return "general";
+  }
   if (/\b(browser|click|open page|navigate|login|interactive|screenshot|playwright|spa|reddit|twitter|x\.com)\b|浏览器|点击|打开网页|登录|截图/u.test(text)) {
     return "browser";
   }
@@ -571,6 +574,24 @@ function taskExplicitlyRequiresExecTool(task: string): boolean {
   return /\b(call|use)\s+the\s+`?exec`?\s+tool\b[\s\S]{0,200}\b(?:command|shell|terminal|workspace|path|file|directory|cat|find|grep|rg|sed|awk|npm|git)\b/i.test(task)
     || /\b(?:command|shell|terminal|workspace|path|file|directory|cat|find|grep|rg|sed|awk|npm|git)\b[\s\S]{0,200}\b(call|use)\s+the\s+`?exec`?\s+tool\b/i.test(task)
     || /`exec`\s+tool[\s\S]{0,200}\b(?:command|shell|terminal|workspace|path|file|directory|cat|find|grep|rg|sed|awk|npm|git)\b/i.test(task);
+}
+
+const QA_CONTEXT_VERBS =
+  /\b(summarize|summarise|explain|describe|overview|analyze|analyse|recap|compare|translate)\b/i;
+const QA_CONTEXT_VERBS_CN =
+  /(总结|概括|解释|描述|分析|对比|翻译|概述)/u;
+const EXPLICIT_EXTERNAL_ACTION =
+  /\b(open|visit|browse|go to|navigate|download|fetch from|look up on|search (?:the )?(?:web|internet|online))\b/i;
+
+function taskIsQaWithProvidedContext(task: string): boolean {
+  if (!QA_CONTEXT_VERBS.test(task) && !QA_CONTEXT_VERBS_CN.test(task)) return false;
+  if (EXPLICIT_EXTERNAL_ACTION.test(task)) return false;
+  if (/https?:\/\/\S+/i.test(task)) return false;
+  return true;
+}
+
+function taskLooksLikeCurrentOrExternalKnowledgeRequest(task: string): boolean {
+  return /\b(latest|current|today|news|source|sources|url|documentation|docs|release notes)\b|最新|今天|最近|新闻|资料|来源/u.test(task);
 }
 
 function buildToolRoutingIntentText(input: {

--- a/src/memory/guard/services/friday-memory-pii-guard.ts
+++ b/src/memory/guard/services/friday-memory-pii-guard.ts
@@ -42,6 +42,23 @@ function luhnCheck(digits: string): boolean {
   return sum % 10 === 0;
 }
 
+const CREDIT_CARD_CONTEXT_BEFORE =
+  /(?:credit\s*card|card(?:\s*number)?|cc|visa|mastercard|master\s*card|amex|american\s*express|discover|payment|billing|account)\s*(?:number|no\.?)?\s*[:#=-]?\s*$/i;
+
+const CREDIT_CARD_IDENTIFIER_PREFIX = /[A-Za-z][A-Za-z0-9]{1,31}[-_:]$/;
+const CREDIT_CARD_IDENTIFIER_SUFFIX = /^[-_:][A-Za-z][A-Za-z0-9]{1,31}/;
+
+function isCreditCardIdentifierFalsePositive(content: string, match: RegExpExecArray): boolean {
+  const before = content.slice(Math.max(0, match.index - 48), match.index);
+  if (CREDIT_CARD_CONTEXT_BEFORE.test(before)) {
+    return false;
+  }
+
+  const matched = match[0];
+  const after = content.slice(match.index + matched.length, match.index + matched.length + 48);
+  return CREDIT_CARD_IDENTIFIER_PREFIX.test(before) || CREDIT_CARD_IDENTIFIER_SUFFIX.test(after);
+}
+
 function findMatches(content: string): FridayMemoryGuardPiiMatch[] {
   const matches: FridayMemoryGuardPiiMatch[] = [];
 
@@ -55,6 +72,9 @@ function findMatches(content: string): FridayMemoryGuardPiiMatch[] {
       if (pattern.type === "credit_card") {
         const digits = match[0].replace(/[^0-9]/g, "");
         if (digits.length < 13 || digits.length > 19 || !luhnCheck(digits)) {
+          continue;
+        }
+        if (isCreditCardIdentifierFalsePositive(content, match)) {
           continue;
         }
       }

--- a/test/integration/memory/guard/friday-memory-guard-pii-namespace.test.ts
+++ b/test/integration/memory/guard/friday-memory-guard-pii-namespace.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { FridayDomainError } from "#errors";
-import { FRIDAY_MEMORY_GUARD_ERROR_CODES } from "#memory";
+import { createFridayMemoryPiiGuard, FRIDAY_MEMORY_GUARD_ERROR_CODES } from "#memory";
 import {
   createGuardTestSetup,
   createMockMemoryItem,
@@ -54,6 +54,30 @@ describe("FridayMemoryGuard — PII + Namespace + Rate Limit (Integration)", () 
         expect.anything(),
         "safe content",
         expect.anything(),
+      );
+    });
+
+    it("preserves Luhn-valid project/proof identifiers while still redacting actual cards", async () => {
+      const { guard, core, piiGuard } = createGuardTestSetup();
+      const realPiiGuard = createFridayMemoryPiiGuard("redact");
+      vi.mocked(piiGuard.scanAndTransform).mockImplementation((content) =>
+        realPiiGuard.scanAndTransform(content),
+      );
+
+      const proofContent =
+        "For this proof run, the user's project codename is BARB-1779879819520. marker=phase22d-rgg-1779879819520.";
+      await guard.store("test-ns", proofContent);
+      expect(core.store).toHaveBeenLastCalledWith(
+        expect.anything(),
+        proofContent,
+        expect.objectContaining({ tags: undefined }),
+      );
+
+      await guard.store("test-ns", "Card: 4111111111111111");
+      expect(core.store).toHaveBeenLastCalledWith(
+        expect.anything(),
+        "Card: [CREDIT_CARD]",
+        expect.objectContaining({ tags: ["pii.credit_card"] }),
       );
     });
   });

--- a/test/unit/agent/runtime/friday-agent-tool-routing.test.ts
+++ b/test/unit/agent/runtime/friday-agent-tool-routing.test.ts
@@ -71,6 +71,35 @@ describe("resolveFridayAgentToolRouting", () => {
     expect(routing.selectedToolNames).toContain("web_search");
     expect(routing.selectedToolNames).not.toContain("read");
   });
+
+  it("keeps current-knowledge summary requests on the web profile", () => {
+    const routing = resolveFridayAgentToolRouting({
+      task: "Summarize the latest TypeScript release notes and include source URLs.",
+      tools,
+    });
+
+    expect(routing.profile).toBe("web");
+    expect(routing.selectedToolPacks).toEqual(["web"]);
+    expect(routing.selectedToolNames).toContain("web_search");
+  });
+
+  it("keeps provided-context summaries out of workflow tools even when the note mentions workflow automation", () => {
+    const routing = resolveFridayAgentToolRouting({
+      task: "Summarize this note in 3 bullet points only: Friday should answer normal summaries directly and must not enter workflow generation or approval planning mode.",
+      tools: [
+        ...tools,
+        tool("workflow_generate"),
+        tool("workflow_run"),
+        tool("cron"),
+      ],
+    });
+
+    expect(routing.profile).toBe("general");
+    expect(routing.selectedToolPacks).toEqual(["general"]);
+    expect(routing.selectedToolNames).not.toContain("workflow_generate");
+    expect(routing.selectedToolNames).not.toContain("workflow_run");
+    expect(routing.selectedToolNames).not.toContain("cron");
+  });
 });
 
 describe("searchFridayDeferredTools", () => {

--- a/test/unit/memory/guard/services/friday-memory-pii-guard.test.ts
+++ b/test/unit/memory/guard/services/friday-memory-pii-guard.test.ts
@@ -47,6 +47,22 @@ describe("FridayMemoryPiiGuard", () => {
       expect(ccMatches).toHaveLength(0);
     });
 
+    it("does not redact Luhn-valid project codenames with alphabetic identifier prefixes", () => {
+      const result = guard.scanAndTransform(
+        "For this proof run, codename is BARB-1779879819520. marker=phase22d-rgg-1779879819520.",
+      );
+      expect(result.matches.filter((m) => m.type === "credit_card")).toHaveLength(0);
+      expect(result.distinctTypes).not.toContain("credit_card");
+      expect(result.transformedContent).toContain("BARB-1779879819520");
+      expect(result.transformedContent).toContain("phase22d-rgg-1779879819520");
+    });
+
+    it("still detects Luhn-valid credit cards with explicit payment context", () => {
+      const result = guard.scanAndTransform("Credit card number: 4111111111111111");
+      expect(result.matches.filter((m) => m.type === "credit_card")).toHaveLength(1);
+      expect(result.distinctTypes).toContain("credit_card");
+    });
+
     it("returns empty matches for clean content", () => {
       const result = guard.scanAndTransform("This is a safe message with no PII");
       expect(result.matches).toHaveLength(0);
@@ -81,6 +97,23 @@ describe("FridayMemoryPiiGuard", () => {
       const result = guard.scanAndTransform("Email: user@example.com");
       expect(result.transformedContent).toContain("[EMAIL]");
       expect(result.transformedContent).not.toContain("user@example.com");
+    });
+
+    it("preserves proof and project identifiers that look numeric but are not cards", () => {
+      const result = guard.scanAndTransform(
+        "For this proof run, the user's project codename is BARB-1779879819520. marker=phase22d-rgg-1779879819520.",
+      );
+      expect(result.transformedContent).toContain("BARB-1779879819520");
+      expect(result.transformedContent).toContain("marker=phase22d-rgg-1779879819520");
+      expect(result.transformedContent).not.toContain("[CREDIT_CARD]");
+      expect(result.tagsToAdd).not.toContain("pii.credit_card");
+    });
+
+    it("continues to redact standalone credit cards", () => {
+      const result = guard.scanAndTransform("Card: 4111111111111111");
+      expect(result.transformedContent).toContain("[CREDIT_CARD]");
+      expect(result.transformedContent).not.toContain("4111111111111111");
+      expect(result.tagsToAdd).toContain("pii.credit_card");
     });
 
     it("redacts SSN", () => {


### PR DESCRIPTION
## Summary
- Fixes the post-merge main RGG failure in `l3-summary-misroute-guard` by keeping provided-context summary/analysis prompts out of workflow tool routing.
- Fixes the follow-on RGG daily-core blocker where memory PII redaction treated Luhn-valid project/proof identifiers like `BARB-177...` and `phase22d-rgg-177...` as credit cards.
- Preserves safety: current/latest/source/doc requests still route to web, and real standalone credit card numbers still redact.

## Root Cause
1. The original RGG prompt was a normal provided-note summary, but its content mentioned `workflow`, `automation`, and `approval`. Tool routing matched those content words as workflow intent before recognizing the prompt as a direct summary task, exposing workflow tools and causing validation failure.
2. After that fix, RGG advanced to `l3-memory-api-store-agent-recall-proof` and exposed evidence corruption: the memory PII guard used Luhn validation alone for credit-card candidates, so ordinary alphanumeric proof/project identifiers with a hyphenated prefix could be redacted as `[CREDIT_CARD]`. That changed stored memory content and tool evidence, violating memory/evidence integrity.

## Local Proof
- `npm ci` PASS
- `npm test -- test/unit/agent/runtime/friday-agent-tool-routing.test.ts test/unit/agent/runtime/friday-agent-runtime-native-tools.test.ts` PASS
- `npm test -- test/unit/agent/runtime/friday-agent-runtime.test.ts test/unit/agent/runtime/friday-agent-runtime-native-tools.test.ts test/unit/agent/runtime/friday-agent-tool-routing.test.ts test/unit/validation/real-world-executors.test.ts` PASS
- `npm test -- test/unit/memory/guard/services/friday-memory-pii-guard.test.ts test/integration/memory/guard/friday-memory-guard-pii-namespace.test.ts` PASS
- `npm test -- test/unit/agent/runtime/friday-agent-tool-routing.test.ts test/unit/agent/runtime/friday-agent-runtime-native-tools.test.ts test/unit/validation/real-world-executors.test.ts test/integration/memory/friday-memory-cognition-v1-proof.test.ts test/unit/memory/guard/services/friday-memory-pii-guard.test.ts test/integration/memory/guard/friday-memory-guard-pii-namespace.test.ts` PASS
- `npm run typecheck -- --pretty false` PASS
- `npm run build:api` PASS
- `npm run build:ui` PASS
- `npm run lint` PASS (existing warnings, 0 errors)
- `git diff --check` PASS
- `npm run check:secret-patterns` PASS
- `npm audit --omit=dev` PASS

## Remote Proof
- PR head: `a454e86191658882adb54748438389942087384d`
- CI run `26507951965`: PASS, including build, test, contracts, security, secrets, agent-parity, quality-gate.
- RGG run `26507949836`: PASS, 94/94 scenarios, same SHA.
- RGG daily-core: 21/21 passed, no defects. `l3-memory-api-store-agent-recall-proof` passed with `memory_search` returning `BARB-1779880908123` unredacted and no `pii.credit_card` tag.
- RGG summary guard: passed with `tool_routing.profile=general`, selected pack `general`, `toolCallCount=0`.
- Phase24 external-channel jobs were skipped by workflow condition and are not claimed as live-channel proof.

## Claim Boundary
This PR repairs GitHub-source / same-SHA RGG truth only. It does not publish npm, does not claim live external-channel proof, and does not change provider-secret or production settings.