### PR TITLE
Fix Windows Python draft self-test runtime probe

### DIFF
--- a/src/skills/executor/friday-runtime-probe.ts
+++ b/src/skills/executor/friday-runtime-probe.ts
@@ -1,4 +1,6 @@
 import { spawnSync } from "node:child_process";
+import { accessSync, constants, statSync } from "node:fs";
+import { dirname, isAbsolute, normalize } from "node:path";
 
 export const FRIDAY_SKILL_PYTHON_BIN_ENV = "FRIDAY_SKILL_PYTHON_BIN";
 
@@ -7,7 +9,48 @@ function trimExecutable(value: string | undefined): string | null {
     return null;
   }
   const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : null;
+  if (!trimmed) {
+    return null;
+  }
+  if (
+    trimmed.length >= 2
+    && ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'")))
+  ) {
+    const unquoted = trimmed.slice(1, -1).trim();
+    return unquoted.length > 0 ? unquoted : null;
+  }
+  return trimmed;
+}
+
+function isPathLikeExecutable(command: string): boolean {
+  return isAbsolute(command)
+    || dirname(command) !== "."
+    || command.includes("/")
+    || command.includes("\\");
+}
+
+function probeExecutablePath(command: string): boolean {
+  const path = normalize(command);
+  let isFile = false;
+  try {
+    // The path comes from explicit local runtime configuration and is never executed here.
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    isFile = statSync(path).isFile();
+  } catch {
+    return false;
+  }
+  if (!isFile) {
+    return false;
+  }
+  if (process.platform === "win32") {
+    return true;
+  }
+  try {
+    accessSync(path, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export function probeFridayExecutable(
@@ -19,6 +62,10 @@ export function probeFridayExecutable(
     return false;
   }
 
+  if (isPathLikeExecutable(trimmed)) {
+    return probeExecutablePath(trimmed);
+  }
+
   const probe = process.platform === "win32"
     ? spawnSync("where", [trimmed], { encoding: "utf-8", env })
     : spawnSync("which", [trimmed], { encoding: "utf-8", env });
@@ -28,7 +75,7 @@ export function probeFridayExecutable(
 export function resolveFridayPythonCommand(
   env: NodeJS.ProcessEnv = process.env,
 ): string | null {
-  const explicit = trimExecutable(env[FRIDAY_SKILL_PYTHON_BIN_ENV]);
+  const explicit = trimExecutable(env.FRIDAY_SKILL_PYTHON_BIN);
   if (explicit) {
     return probeFridayExecutable(explicit, env) ? explicit : null;
   }

--- a/test/unit/skills/executor/friday-runtime-probe.test.ts
+++ b/test/unit/skills/executor/friday-runtime-probe.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  FRIDAY_SKILL_PYTHON_BIN_ENV,
+  probeFridayExecutable,
+  resolveFridayPythonCommand,
+} from "#skills";
+
+describe("Friday runtime probe", () => {
+  it("accepts an explicit executable path even when it is not discoverable on PATH", () => {
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      PATH: "",
+      [FRIDAY_SKILL_PYTHON_BIN_ENV]: process.execPath,
+    };
+
+    expect(probeFridayExecutable(process.execPath, env)).toBe(true);
+    expect(resolveFridayPythonCommand(env)).toBe(process.execPath);
+  });
+
+  it("unquotes an explicit executable path from environment configuration", () => {
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      PATH: "",
+      [FRIDAY_SKILL_PYTHON_BIN_ENV]: `"${process.execPath}"`,
+    };
+
+    expect(resolveFridayPythonCommand(env)).toBe(process.execPath);
+  });
+
+  it("does not treat a missing explicit executable path as available", () => {
+    const missingPath = join(
+      tmpdir(),
+      `friday-missing-python-${Date.now().toString()}-${Math.random().toString(36).slice(2)}`,
+    );
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      PATH: "",
+      [FRIDAY_SKILL_PYTHON_BIN_ENV]: missingPath,
+    };
+
+    expect(probeFridayExecutable(missingPath, env)).toBe(false);
+    expect(resolveFridayPythonCommand(env)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- accept explicit runtime executable paths before PATH lookup so configured interpreters work on Windows and off-PATH installs
- unquote explicit FRIDAY_SKILL_PYTHON_BIN values
- add runtime probe coverage for explicit, quoted, and missing executable paths

## Proof
- npx vitest run test/unit/api/http/routes/friday-skill-generator-routes.test.ts test/unit/skills/executor/friday-runtime-probe.test.ts test/unit/skills/executor/friday-skill-executor.test.ts test/unit/skills/executor/friday-shell-executor.test.ts
- npx vitest run test/unit/api/http
- npm run typecheck
- npm run check:secret-patterns
- npx eslint src/skills/executor/friday-runtime-probe.ts

## Notes
- npm run lint -- --max-warnings=0 ... still invokes repository-wide eslint . and fails on the existing 1511-warning baseline; direct lint of the changed source file is clean.