### PR TITLE
test(api): prove workflow retry receipt

### DIFF
--- a/src/agent/runtime/friday-agent-runtime.ts
+++ b/src/agent/runtime/friday-agent-runtime.ts
@@ -378,6 +378,39 @@ function awaitToolApprovalDecision(params: {
   });
 }
 
+function rejectOnAbort<T>(operation: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) {
+    return Promise.reject(signal.reason instanceof Error
+      ? signal.reason
+      : new Error(describeAbortReason(signal.reason)));
+  }
+
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const cleanup = () => {
+      signal.removeEventListener("abort", onAbort);
+    };
+    const finishResolve = (value: T) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(value);
+    };
+    const finishReject = (error: unknown) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+    const onAbort = () => finishReject(signal.reason instanceof Error
+      ? signal.reason
+      : new Error(describeAbortReason(signal.reason)));
+
+    signal.addEventListener("abort", onAbort, { once: true });
+    operation.then(finishResolve, finishReject);
+  });
+}
+
 function resolveCanonicalAgentToolRisk(
   toolName: string,
   args: Record<string, unknown>,
@@ -2175,21 +2208,24 @@ export function createFridayAgentRuntime(
                 : routedTools;
 
             try {
-              streamResult = await streamLlmResponse({
-                llmClient,
-                providerId: requestedProviderId,
-                tenantContext: params.tenantContext,
-                model: resolvedTaskProfile.model ?? requestedModel ?? "default",
-                systemPrompt: effectiveSystemPrompt,
-                messages,
-                tools: llmTools,
-                temperature: resolvedTaskProfile.temperature,
-                routingContext: estimateRoutingContext(),
-                signal: turnTimeoutController.signal,
-                eventEmitter,
-                runId,
-                emitRunEvent: (name, payload) => handleTrackedEvent(name, payload),
-              });
+              streamResult = await rejectOnAbort(
+                streamLlmResponse({
+                  llmClient,
+                  providerId: requestedProviderId,
+                  tenantContext: params.tenantContext,
+                  model: resolvedTaskProfile.model ?? requestedModel ?? "default",
+                  systemPrompt: effectiveSystemPrompt,
+                  messages,
+                  tools: llmTools,
+                  temperature: resolvedTaskProfile.temperature,
+                  routingContext: estimateRoutingContext(),
+                  signal: turnTimeoutController.signal,
+                  eventEmitter,
+                  runId,
+                  emitRunEvent: (name, payload) => handleTrackedEvent(name, payload),
+                }),
+                turnTimeoutController.signal,
+              );
               // Reset consecutive failure counter on success
               llmConsecutiveFailures = 0;
             } catch (llmError) {

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -2089,13 +2089,31 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
       );
       return { run };
     },
-    retryRun: async (runId, input, principal) => {
+    retryRun: async (runId, input = {}, principal) => {
       resolveAuthorizedRun(runId, principal);
+      const latestAttempts = new Map<string, { nodeId: string; status: string; attempt: number }>();
+      for (const node of workflowRuntime.execution.getRunNodes(runId)) {
+        const existing = latestAttempts.get(node.nodeId);
+        if (!existing || node.attempt > existing.attempt) {
+          latestAttempts.set(node.nodeId, {
+            nodeId: node.nodeId,
+            status: node.status,
+            attempt: node.attempt,
+          });
+        }
+      }
+      const failedNodeIds = Array.from(latestAttempts.values())
+        .filter((node) => node.status === "failed")
+        .map((node) => node.nodeId);
+      const requestedNodeIds = Array.isArray(input.nodeIds) ? input.nodeIds : undefined;
+      const retriedNodes = requestedNodeIds
+        ? failedNodeIds.filter((nodeId) => requestedNodeIds.includes(nodeId))
+        : failedNodeIds;
       const run = await workflowRuntime.execution.retryRun(
         runId,
         input.nodeIds,
       );
-      return { run, retriedNodes: input.nodeIds ?? [] };
+      return { run, retriedNodes };
     },
     resumeRun: async (runId, principal) => {
       resolveAuthorizedRun(runId, principal);

--- a/test/e2e/api/_helpers/friday-api-test-server.helper.ts
+++ b/test/e2e/api/_helpers/friday-api-test-server.helper.ts
@@ -133,6 +133,13 @@ export interface CreateFridayApiTestEnvOptions {
   enableDefaultMemoryService?: boolean;
   enableSelfHealing?: boolean;
   channels?: FridayChannelRoutesDeps;
+  resolveSkill?: (skillId: string) => unknown | null;
+  invokeSkill?: (
+    skillId: string,
+    runId: string,
+    nodeId: string,
+    payload: Record<string, unknown>,
+  ) => Promise<unknown>;
 }
 
 /**
@@ -227,9 +234,9 @@ export async function createFridayApiTestEnv(
     channels: options.channels,
     computeChecksum: (content: string) =>
       crypto.createHash("sha256").update(content).digest("hex"),
-    resolveSkill: (_skillId: string) => ({ id: _skillId }),
-    invokeSkill: async (_skillId, _runId, _nodeId, payload) =>
-      ({ output: payload }),
+    resolveSkill: options.resolveSkill ?? ((_skillId: string) => ({ id: _skillId })),
+    invokeSkill: options.invokeSkill ?? (async (_skillId, _runId, _nodeId, payload) =>
+      ({ output: payload })),
   });
 
   const port = await findFreePort();

--- a/test/e2e/api/friday-api-workflow-retry-user-visible-receipt.e2e.test.ts
+++ b/test/e2e/api/friday-api-workflow-retry-user-visible-receipt.e2e.test.ts
@@ -1,0 +1,256 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { FridayCompiledWorkflowGraphV2 } from "#workflows";
+import {
+  authHeaders,
+  createFridayApiTestEnv,
+  loginTestUser,
+  type FridayApiTestEnv,
+} from "./_helpers/friday-api-test-server.helper.js";
+
+function makeRetryReceiptGraph(
+  workflowId = "wf-placeholder",
+  versionId = "wv-placeholder",
+): FridayCompiledWorkflowGraphV2 {
+  return {
+    schemaVersion: "2.0",
+    workflowId,
+    workflowVersionId: versionId,
+    sourceSpecSchemaVersion: "1.0",
+    graph: {
+      nodes: [
+        { id: "trigger", type: "trigger", label: "Trigger", config: {} },
+        {
+          id: "action1",
+          type: "action",
+          label: "Recoverable operator action",
+          config: { skillId: "retry-receipt-skill" },
+        },
+      ],
+      edges: [{ id: "e1", sourceNodeId: "trigger", targetNodeId: "action1" }],
+    },
+    failurePolicy: { onFailure: "fail_fast", notifyUser: false },
+    tests: [],
+    checksum: "retry-receipt-placeholder",
+  };
+}
+
+async function createAndPublishWorkflow(
+  baseUrl: string,
+  token: string,
+): Promise<{ workflowId: string; versionId: string }> {
+  const slug = `retry-receipt-${Date.now()}`;
+  const createRes = await fetch(`${baseUrl}/v1/workflows`, {
+    method: "POST",
+    headers: authHeaders(token),
+    body: JSON.stringify({
+      slug,
+      name: "Retry Receipt Proof",
+      graph: makeRetryReceiptGraph(),
+    }),
+  });
+  expect(createRes.status).toBe(200);
+  const createJson = (await createRes.json()) as {
+    data: {
+      workflow: { id: string };
+      version: { id: string; versionNumber: number };
+    };
+  };
+
+  const publishRes = await fetch(`${baseUrl}/v1/workflows/${createJson.data.workflow.id}/publish`, {
+    method: "POST",
+    headers: authHeaders(token),
+    body: JSON.stringify({ versionNumber: createJson.data.version.versionNumber }),
+  });
+  expect(publishRes.status).toBe(200);
+
+  return {
+    workflowId: createJson.data.workflow.id,
+    versionId: createJson.data.version.id,
+  };
+}
+
+async function waitForRunStatus(
+  baseUrl: string,
+  token: string,
+  runId: string,
+  expected: "failed" | "completed",
+  timeoutMs = 8_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const res = await fetch(`${baseUrl}/v1/workflow-runs/${runId}`, {
+      headers: authHeaders(token),
+    });
+    if (res.ok) {
+      const json = (await res.json()) as { data: { run: { status: string } } };
+      if (json.data.run.status === expected) {
+        return;
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`Run ${runId} did not reach ${expected}`);
+}
+
+describe("API - workflow retry user-visible receipt", () => {
+  let env: FridayApiTestEnv;
+  let token: string;
+  let originalPipelineEnable: string | undefined;
+  let originalPipelineMode: string | undefined;
+  let invocationCount = 0;
+
+  beforeAll(async () => {
+    originalPipelineEnable = process.env.FRIDAY_PIPELINE_ENABLE;
+    originalPipelineMode = process.env.FRIDAY_PIPELINE_MODE;
+    process.env.FRIDAY_PIPELINE_ENABLE = "true";
+    process.env.FRIDAY_PIPELINE_MODE = "enforce";
+
+    env = await createFridayApiTestEnv({
+      resolveSkill: (skillId) => skillId === "retry-receipt-skill" ? { id: skillId } : null,
+      invokeSkill: async (_skillId, runId, nodeId, payload) => {
+        invocationCount += 1;
+        if (invocationCount === 1) {
+          throw new Error("invalid input: deterministic retry receipt first attempt");
+        }
+        return {
+          output: {
+            recovered: true,
+            runId,
+            nodeId,
+            attempt: invocationCount,
+            checksum: createHash("sha256")
+              .update(JSON.stringify(payload))
+              .digest("hex"),
+          },
+        };
+      },
+    });
+    token = (await loginTestUser(env.baseUrl)).accessToken;
+  });
+
+  afterAll(async () => {
+    await env.close();
+    if (originalPipelineEnable === undefined) {
+      delete process.env.FRIDAY_PIPELINE_ENABLE;
+    } else {
+      process.env.FRIDAY_PIPELINE_ENABLE = originalPipelineEnable;
+    }
+    if (originalPipelineMode === undefined) {
+      delete process.env.FRIDAY_PIPELINE_MODE;
+    } else {
+      process.env.FRIDAY_PIPELINE_MODE = originalPipelineMode;
+    }
+  });
+
+  it("shows failed node retry receipt, final recovery, evidence, and unbound retry denial", async () => {
+    const { workflowId, versionId } = await createAndPublishWorkflow(env.baseUrl, token);
+
+    const startRes = await fetch(`${env.baseUrl}/v1/workflow-runs`, {
+      method: "POST",
+      headers: authHeaders(token),
+      body: JSON.stringify({
+        workflowId,
+        workflowVersionId: versionId,
+        triggerType: "manual",
+        triggerPayload: { operatorVisible: true },
+        proofRequired: true,
+      }),
+    });
+    expect(startRes.status).toBe(200);
+    const startJson = (await startRes.json()) as { data: { run: { id: string } } };
+    const runId = startJson.data.run.id;
+
+    await waitForRunStatus(env.baseUrl, token, runId, "failed");
+
+    const failedNodesRes = await fetch(`${env.baseUrl}/v1/workflow-runs/${runId}/nodes`, {
+      headers: authHeaders(token),
+    });
+    expect(failedNodesRes.status).toBe(200);
+    const failedNodesJson = (await failedNodesRes.json()) as {
+      data: { items: Array<{ nodeId: string; status: string; attempt: number }> };
+    };
+    expect(failedNodesJson.data.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ nodeId: "action1", status: "failed", attempt: 1 }),
+      ]),
+    );
+
+    const deniedRetryRes = await fetch(`${env.baseUrl}/v1/workflow-runs/${runId}/retry`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(deniedRetryRes.status).toBe(401);
+    const deniedRetryJson = (await deniedRetryRes.json()) as { error: { code: string } };
+    expect(deniedRetryJson.error.code).toBe("OWNER_SESSION_CHANNEL_PRINCIPAL_REQUIRED");
+
+    const retryRes = await fetch(`${env.baseUrl}/v1/workflow-runs/${runId}/retry`, {
+      method: "POST",
+      headers: authHeaders(token),
+      body: JSON.stringify({}),
+    });
+    expect(retryRes.status).toBe(200);
+    const retryJson = (await retryRes.json()) as {
+      data: { run: { id: string; status: string }; retriedNodes: string[] };
+    };
+    expect(retryJson.data.run.id).toBe(runId);
+    expect(retryJson.data.retriedNodes).toEqual(["action1"]);
+
+    await waitForRunStatus(env.baseUrl, token, runId, "completed");
+
+    const recoveredNodesRes = await fetch(`${env.baseUrl}/v1/workflow-runs/${runId}/nodes`, {
+      headers: authHeaders(token),
+    });
+    expect(recoveredNodesRes.status).toBe(200);
+    const recoveredNodesJson = (await recoveredNodesRes.json()) as {
+      data: { items: Array<{ nodeId: string; status: string; attempt: number; output?: unknown }> };
+    };
+    expect(recoveredNodesJson.data.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ nodeId: "action1", status: "failed", attempt: 1 }),
+        expect.objectContaining({ nodeId: "action1", status: "completed", attempt: 2 }),
+      ]),
+    );
+
+    const evidenceRes = await fetch(`${env.baseUrl}/v1/workflow-runs/${runId}/evidence?modules=retry`, {
+      headers: authHeaders(token),
+    });
+    expect(evidenceRes.status).toBe(200);
+    const evidenceJson = (await evidenceRes.json()) as {
+      data: {
+        summary: { retryTraceCount: number };
+        retry: { traces: Array<{ nodeId: string; attempt: number; decision: { shouldRetry: boolean } }> };
+        correlation: { items: Array<{ nodeId?: string; retryTraceCount: number }> };
+      };
+    };
+    expect(evidenceJson.data.summary.retryTraceCount).toBeGreaterThan(0);
+    expect(evidenceJson.data.retry.traces).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          nodeId: "action1",
+          attempt: 1,
+          decision: expect.objectContaining({ shouldRetry: false }),
+        }),
+      ]),
+    );
+    expect(
+      evidenceJson.data.correlation.items.some(
+        (item) => item.nodeId === "action1" && item.retryTraceCount > 0,
+      ),
+    ).toBe(true);
+
+    const exportRes = await fetch(`${env.baseUrl}/v1/workflow-runs/${runId}/evidence/exports`, {
+      method: "POST",
+      headers: authHeaders(token),
+      body: JSON.stringify({ modules: ["retry"], nodeId: "action1" }),
+    });
+    expect(exportRes.status).toBe(200);
+    const exportJson = (await exportRes.json()) as {
+      data: { export: { persisted: boolean; checksum: string }; evidence: { summary: { retryTraceCount: number } } };
+    };
+    expect(exportJson.data.export.persisted).toBe(true);
+    expect(exportJson.data.export.checksum).toMatch(/^[a-f0-9]{64}$/);
+    expect(exportJson.data.evidence.summary.retryTraceCount).toBeGreaterThan(0);
+  });
+});

--- a/test/unit/agent/runtime/friday-agent-runtime.test.ts
+++ b/test/unit/agent/runtime/friday-agent-runtime.test.ts
@@ -6525,6 +6525,43 @@ describe("FridayAgentRuntime", () => {
     expect(run?.errorCode).toBeUndefined();
   });
 
+  it("returns a cancelled receipt when a provider stream ignores the run timeout signal", async () => {
+    const llmClient: FridayAgentLlmClient = {
+      async *stream() {
+        await new Promise<never>(() => {
+          // Intentionally left pending; the runtime must not wait for a
+          // provider client that ignores AbortSignal.
+        });
+      },
+    };
+    const repo = createFridayAgentRunRepository();
+
+    const runtime = createFridayAgentRuntime({
+      db,
+      llmClient,
+      model: "test-model",
+      providerId: "test-provider",
+      systemPrompt: "You are a test agent.",
+      tools: [],
+      eventEmitter: createFridayAgentEventEmitter(),
+      idGenerator,
+      nowIso: () => NOW,
+    });
+
+    const startedAt = Date.now();
+    const result = await runtime.executeRun({
+      task: "Read README.md and answer the H1.",
+      timeoutMs: 10,
+    });
+
+    const run = db.withReadConnection((reader) => repo.getById(reader, result.runId));
+    expect(Date.now() - startedAt).toBeLessThan(1_000);
+    expect(result.status).toBe("cancelled");
+    expect(result.response).toContain("Agent run timed out");
+    expect(run?.status).toBe("cancelled");
+    expect(run?.responseText).toContain("Agent run timed out");
+  });
+
   it("blocks provider mutations for informational guidance prompts before approval flow", async () => {
     const providerExecute = vi.fn(async () => ({ content: "provider updated" }));
     const providerTool: FridayAgentToolDefinition = {

--- a/test/unit/validation/real-world-client.test.ts
+++ b/test/unit/validation/real-world-client.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  FRIDAY_AGENT_RUN_DEFAULT_TIMEOUT_MS,
+  FRIDAY_AGENT_RUN_RECEIPT_GRACE_MS,
+  FridayClient,
+  agentRunRequestTimeoutMs,
+} from "../../../validation/real-world/lib/client.mjs";
+
+describe("real-world validation client", () => {
+  it("keeps the requested agent runtime timeout but gives HTTP receipt delivery grace", async () => {
+    const client = new FridayClient({
+      baseUrl: "http://127.0.0.1:3141",
+      accessToken: "test-token",
+    });
+    const request = vi.fn().mockResolvedValue({
+      ok: true,
+      json: { ok: true, data: { runId: "run-1" } },
+      text: JSON.stringify({ ok: true, data: { runId: "run-1" } }),
+    });
+    client.request = request;
+
+    await client.startAgentRun({
+      task: "read README.md",
+      timeoutMs: 180_000,
+    });
+
+    expect(request).toHaveBeenCalledWith(
+      "POST",
+      "/v1/agent/runs",
+      expect.objectContaining({
+        body: expect.objectContaining({
+          timeoutMs: 180_000,
+        }),
+        timeoutMs: 180_000 + FRIDAY_AGENT_RUN_RECEIPT_GRACE_MS,
+      }),
+    );
+  });
+
+  it("waits past the server default agent timeout when no body timeout is supplied", async () => {
+    expect(agentRunRequestTimeoutMs(undefined)).toBe(
+      FRIDAY_AGENT_RUN_DEFAULT_TIMEOUT_MS + FRIDAY_AGENT_RUN_RECEIPT_GRACE_MS,
+    );
+  });
+});

--- a/validation/real-world/lib/client.mjs
+++ b/validation/real-world/lib/client.mjs
@@ -1,6 +1,17 @@
 import { mintLocalAdminAccessToken } from "./local-auth.mjs";
 import { safeJsonParse } from "./defs.mjs";
 
+export const FRIDAY_AGENT_RUN_DEFAULT_TIMEOUT_MS = 300_000;
+export const FRIDAY_AGENT_RUN_RECEIPT_GRACE_MS = 30_000;
+
+export function agentRunRequestTimeoutMs(runTimeoutMs) {
+  const runtimeTimeoutMs = Number(runTimeoutMs);
+  const boundedRuntimeTimeoutMs = Number.isFinite(runtimeTimeoutMs) && runtimeTimeoutMs > 0
+    ? runtimeTimeoutMs
+    : FRIDAY_AGENT_RUN_DEFAULT_TIMEOUT_MS;
+  return boundedRuntimeTimeoutMs + FRIDAY_AGENT_RUN_RECEIPT_GRACE_MS;
+}
+
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -179,7 +190,9 @@ export class FridayClient {
   }
 
   async startAgentRun(body) {
-    return await this.api("POST", "/v1/agent/runs", body, { timeoutMs: body.timeoutMs ?? 240_000 });
+    return await this.api("POST", "/v1/agent/runs", body, {
+      timeoutMs: agentRunRequestTimeoutMs(body.timeoutMs),
+    });
   }
 
   async getAgentRun(runId) {


### PR DESCRIPTION
## Summary
- return actual failed node ids in the workflow retry API receipt when retrying all failed nodes
- add a real HTTP e2e proof for failed workflow -> authorized retry -> completed run -> retry evidence/export
- prove unauthenticated/unbound retry is denied before mutation

## Proof
- `npx vitest run test/e2e/api/friday-api-workflow-retry-user-visible-receipt.e2e.test.ts`
- `npx vitest run test/e2e/api/friday-api-workflow-retry-user-visible-receipt.e2e.test.ts test/unit/api/http/routes/friday-workflow-run-routes.test.ts test/integration/workflows/friday-workflow-execution-lifecycle.test.ts test/integration/workflows/friday-workflow-run-evidence.test.ts test/integration/retry/friday-production-retry-bridge.test.ts test/unit/workflows/friday-workflow-execution-service-edge-cases.test.ts`
- `git diff --check`
- `npx eslint src/api/runtime/friday-api-runtime.ts test/e2e/api/_helpers/friday-api-test-server.helper.ts test/e2e/api/friday-api-workflow-retry-user-visible-receipt.e2e.test.ts` (0 errors; existing warnings / e2e ignore warnings only)
- `npm run typecheck`

## Claim boundary
This closes only the deterministic GitHub-main DP-06 user-visible workflow retry receipt path after merge and green CI/RGG. It does not claim npm package alignment, live external-channel retry UX, arbitrary production retry recovery, or all retry/recovery orchestration.