### PR TITLE
fix(providers): surface capability health truth

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -332,7 +332,7 @@
         "filename": "src/api/http/routes/friday-provider-routes.ts",
         "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
         "is_verified": false,
-        "line_number": 267
+        "line_number": 278
       }
     ],
     "src/api/http/routes/friday-setup-routes.ts": [
@@ -1124,5 +1124,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-24T20:51:27Z"
+  "generated_at": "2026-05-27T17:29:06Z"
 }

--- a/src/api/http/routes/friday-provider-routes.ts
+++ b/src/api/http/routes/friday-provider-routes.ts
@@ -11,6 +11,7 @@ import type {
   FridayCreateProviderRequest,
   FridayCreateProviderResponse,
   FridayDeleteProviderResponse,
+  FridayGetProviderCapabilityHealthSnapshotResponse,
   FridayGetProviderDoctorResponse,
   FridayGetProviderHealthSnapshotResponse,
   FridayGetProviderResponse,
@@ -33,7 +34,17 @@ import type {
   FridayValidateProviderResponse,
 } from "../../model/friday-api-provider.types.js";
 
-import type { FridayModelRoutingConfig, FridayProviderLane, FridayProviderService } from "#providers";
+import type {
+  FridayModelRoutingConfig,
+  FridayProviderCapabilityHealthCapabilityItem,
+  FridayProviderCapabilityHealthSnapshotSummary,
+  FridayProviderHealthSnapshotItem,
+  FridayProviderLane,
+  FridayProviderProfile,
+  FridayProviderRuntimeCapabilityDeclaration,
+  FridayProviderService,
+  FridayRuntimeCapabilityId,
+} from "#providers";
 import {
   FRIDAY_PROVIDER_APIS,
   FRIDAY_PROVIDER_BACKEND_KINDS,
@@ -577,6 +588,149 @@ export function createFridayProviderRoutes(
     return { items };
   }
 
+  function summarizeCapabilityHealth(
+    items: FridayGetProviderCapabilityHealthSnapshotResponse["items"],
+  ): FridayProviderCapabilityHealthSnapshotSummary {
+    const summary: FridayProviderCapabilityHealthSnapshotSummary = {
+      available: 0,
+      setupNeeded: 0,
+      proofPending: 0,
+      disabled: 0,
+      unsupported: 0,
+    };
+    for (const item of items) {
+      for (const capability of item.capabilities) {
+        if (capability.state === "available") summary.available += 1;
+        if (capability.state === "setup_needed") summary.setupNeeded += 1;
+        if (capability.state === "proof_pending") summary.proofPending += 1;
+        if (capability.state === "disabled") summary.disabled += 1;
+        if (capability.state === "unsupported") summary.unsupported += 1;
+      }
+    }
+    return summary;
+  }
+
+  function providerHealthCapabilityBlock(input: {
+    provider: FridayProviderProfile;
+    healthItem: FridayProviderHealthSnapshotItem | undefined;
+  }): Pick<FridayProviderCapabilityHealthCapabilityItem, "state" | "source" | "message"> | null {
+    const { provider, healthItem } = input;
+    const validationStatus = healthItem?.validationStatus ?? provider.config.validation?.status ?? "never";
+    const backendHealth = healthItem?.backendHealth ?? "status_unknown";
+    const authHealth = healthItem?.authHealth ?? "status_unknown";
+
+    if (!provider.enabled) {
+      return {
+        state: "disabled",
+        source: "provider_health_snapshot",
+        message: "Provider is disabled; enable it before this capability can be used.",
+      };
+    }
+    if (backendHealth === "unsupported" || authHealth === "unsupported") {
+      return {
+        state: "unsupported",
+        source: "provider_health_snapshot",
+        message: "Provider backend or auth mode is unsupported for this capability.",
+      };
+    }
+    if (backendHealth === "missing" || authHealth === "missing" || validationStatus === "failed") {
+      return {
+        state: "setup_needed",
+        source: "provider_health_snapshot",
+        message: provider.config.validation?.errorMessage
+          ?? "Provider setup or validation is failing; fix credentials or connection before claiming this capability.",
+      };
+    }
+    if (validationStatus !== "ok") {
+      return {
+        state: "setup_needed",
+        source: "provider_health_snapshot",
+        message: "Provider validation has not passed; validate credentials before claiming this capability.",
+      };
+    }
+    return null;
+  }
+
+  function runtimeCapabilityHealthState(
+    declaration: FridayProviderRuntimeCapabilityDeclaration,
+  ): Pick<FridayProviderCapabilityHealthCapabilityItem, "state" | "source" | "message"> {
+    if (declaration.status === "verified" && declaration.verified === true) {
+      return {
+        state: "available",
+        source: "runtime_capability_snapshot",
+        message: declaration.notes ?? "Capability is available because it passed a persisted capability doctor proof.",
+      };
+    }
+    if (declaration.status === "failed" || declaration.verified === false) {
+      return {
+        state: "setup_needed",
+        source: "runtime_capability_snapshot",
+        message: declaration.notes ?? "Capability failed its latest persisted proof; rerun setup or validation before use.",
+      };
+    }
+    return {
+      state: "proof_pending",
+      source: "declared_configuration",
+      message: declaration.notes ?? "Capability is declared but has not passed a persisted live proof yet.",
+    };
+  }
+
+  function deriveCapabilityHealthCapability(input: {
+    provider: FridayProviderProfile;
+    healthItem: FridayProviderHealthSnapshotItem | undefined;
+    declaration: FridayProviderRuntimeCapabilityDeclaration;
+  }): FridayProviderCapabilityHealthCapabilityItem {
+    const { provider, healthItem, declaration } = input;
+    const blockerCodes = Array.from(new Set(healthItem?.reasons ?? []));
+    const checkedAt = declaration.verifiedAt ?? provider.config.validation?.checkedAt;
+    const healthBlock = providerHealthCapabilityBlock({ provider, healthItem });
+    const state = healthBlock ?? runtimeCapabilityHealthState(declaration);
+    const base = {
+      capability: declaration.capability,
+      ...(declaration.model ? { model: declaration.model } : {}),
+      blockerCodes,
+      ...(checkedAt ? { checkedAt } : {}),
+      ...(declaration.verifiedAt ? { lastVerifiedAt: declaration.verifiedAt } : {}),
+    };
+    return {
+      ...base,
+      ...state,
+    };
+  }
+
+  async function listCapabilityHealthSnapshot(): Promise<FridayGetProviderCapabilityHealthSnapshotResponse> {
+    const providers = await deps.providerService.listProviders();
+    const health = await listHealthSnapshot();
+    const healthByProviderId = new Map(health.items.map((item) => [item.providerId, item]));
+    const items = providers.map((provider) => {
+      const declarations = provider.config.runtimeCapabilities?.length
+        ? provider.config.runtimeCapabilities
+        : [{
+            capability: "text" as FridayRuntimeCapabilityId,
+            ...(provider.defaultModel ?? provider.config.supportedModels[0]
+              ? { model: provider.defaultModel ?? provider.config.supportedModels[0] }
+              : {}),
+            status: "declared" as const,
+          }];
+      const healthItem = healthByProviderId.get(provider.id);
+      return {
+        providerId: provider.id,
+        providerKind: provider.kind,
+        providerName: provider.name,
+        lane: healthItem?.lane ?? (provider.enabled ? "standby" : "disabled"),
+        enabled: provider.enabled,
+        validationStatus: healthItem?.validationStatus ?? provider.config.validation?.status ?? "never",
+        capabilities: declarations.map((declaration) =>
+          deriveCapabilityHealthCapability({ provider, healthItem, declaration }),
+        ),
+      };
+    });
+    return {
+      items,
+      summary: summarizeCapabilityHealth(items),
+    };
+  }
+
   return [
     {
       operationId: "providers.templates.list",
@@ -622,6 +776,16 @@ export function createFridayProviderRoutes(
       auth: { public: true },
       async handler(): Promise<FridayGetProviderHealthSnapshotResponse> {
         return listHealthSnapshot();
+      },
+    },
+
+    {
+      operationId: "providers.capabilityHealth.list",
+      method: "GET",
+      path: "/v1/providers/capability-health",
+      auth: { public: true },
+      async handler(): Promise<FridayGetProviderCapabilityHealthSnapshotResponse> {
+        return listCapabilityHealthSnapshot();
       },
     },
 

--- a/src/api/http/routes/friday-provider-routes.ts
+++ b/src/api/http/routes/friday-provider-routes.ts
@@ -780,7 +780,7 @@ export function createFridayProviderRoutes(
     },
 
     {
-      operationId: "providers.capabilityHealth.list",
+      operationId: "providers.capability.health.list",
       method: "GET",
       path: "/v1/providers/capability-health",
       auth: { public: true },

--- a/src/api/model/friday-api-provider.types.ts
+++ b/src/api/model/friday-api-provider.types.ts
@@ -10,6 +10,8 @@ import type {
   FridayProviderAuthMode,
   FridayProviderBackendKind,
   FridayProviderCapabilityDoctorReport,
+  FridayProviderCapabilityHealthSnapshotItem,
+  FridayProviderCapabilityHealthSnapshotSummary,
   FridayProviderCliConfig,
   FridayProviderDeploymentKind,
   FridayProviderDoctorReport,
@@ -109,6 +111,11 @@ export interface FridayGetProviderResponse {
 
 export interface FridayGetProviderHealthSnapshotResponse {
   items: FridayProviderHealthSnapshotItem[];
+}
+
+export interface FridayGetProviderCapabilityHealthSnapshotResponse {
+  items: FridayProviderCapabilityHealthSnapshotItem[];
+  summary: FridayProviderCapabilityHealthSnapshotSummary;
 }
 
 export type FridayRunCapabilityDoctorResponse = FridayProviderCapabilityDoctorReport & {

--- a/src/providers/model/friday-provider.types.ts
+++ b/src/providers/model/friday-provider.types.ts
@@ -530,6 +530,47 @@ export interface FridayProviderCapabilityDoctorReport {
   capabilityResults: FridayProviderCapabilityDoctorProbeResult[];
 }
 
+export type FridayProviderCapabilityHealthState =
+  | "available"
+  | "setup_needed"
+  | "proof_pending"
+  | "disabled"
+  | "unsupported";
+
+export type FridayProviderCapabilityHealthSource =
+  | "runtime_capability_snapshot"
+  | "provider_health_snapshot"
+  | "declared_configuration";
+
+export interface FridayProviderCapabilityHealthCapabilityItem {
+  capability: FridayRuntimeCapabilityId;
+  model?: string;
+  state: FridayProviderCapabilityHealthState;
+  source: FridayProviderCapabilityHealthSource;
+  message: string;
+  blockerCodes: string[];
+  checkedAt?: string;
+  lastVerifiedAt?: string;
+}
+
+export interface FridayProviderCapabilityHealthSnapshotItem {
+  providerId: string;
+  providerKind: FridayProviderKind;
+  providerName: string;
+  lane: FridayProviderLane;
+  enabled: boolean;
+  validationStatus: FridayProviderValidationState["status"];
+  capabilities: FridayProviderCapabilityHealthCapabilityItem[];
+}
+
+export interface FridayProviderCapabilityHealthSnapshotSummary {
+  available: number;
+  setupNeeded: number;
+  proofPending: number;
+  disabled: number;
+  unsupported: number;
+}
+
 export type FridayProviderLane =
   | "primary"
   | "fallback"

--- a/test/contracts/api/__snapshots__/friday-api-route-contract.snapshot.test.ts.snap
+++ b/test/contracts/api/__snapshots__/friday-api-route-contract.snapshot.test.ts.snap
@@ -21,7 +21,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > Phase 14.5A WP-001: eve
 }
 `;
 
-exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures route count to detect accidental additions/removals 1`] = `417`;
+exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures route count to detect accidental additions/removals 1`] = `418`;
 
 exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route surface as a stable contract 1`] = `
 [
@@ -1898,6 +1898,16 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   {
     "authKind": "public",
     "index": 187,
+    "method": "GET",
+    "operationId": "providers.capability.health.list",
+    "path": "/v1/providers/capability-health",
+    "rateLimitPolicyId": null,
+    "roles": [],
+    "scopes": [],
+  },
+  {
+    "authKind": "public",
+    "index": 188,
     "method": "POST",
     "operationId": "capabilities.doctor",
     "path": "/v1/capabilities/doctor",
@@ -1907,7 +1917,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 188,
+    "index": 189,
     "method": "GET",
     "operationId": "providers.get",
     "path": "/v1/providers/:providerId",
@@ -1917,7 +1927,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 189,
+    "index": 190,
     "method": "POST",
     "operationId": "providers.create",
     "path": "/v1/providers",
@@ -1927,7 +1937,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 190,
+    "index": 191,
     "method": "PATCH",
     "operationId": "providers.update",
     "path": "/v1/providers/:providerId",
@@ -1937,7 +1947,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 191,
+    "index": 192,
     "method": "DELETE",
     "operationId": "providers.delete",
     "path": "/v1/providers/:providerId",
@@ -1947,7 +1957,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 192,
+    "index": 193,
     "method": "POST",
     "operationId": "providers.validate",
     "path": "/v1/providers/:providerId/validate",
@@ -1957,7 +1967,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 193,
+    "index": 194,
     "method": "GET",
     "operationId": "providers.doctor",
     "path": "/v1/providers/:providerId/doctor",
@@ -1967,7 +1977,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 194,
+    "index": 195,
     "method": "GET",
     "operationId": "providers.routing.explain",
     "path": "/v1/providers/routing/explain",
@@ -1977,7 +1987,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 195,
+    "index": 196,
     "method": "POST",
     "operationId": "providers.routing.pin",
     "path": "/v1/providers/routing/pin",
@@ -1987,7 +1997,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 196,
+    "index": 197,
     "method": "POST",
     "operationId": "providers.routing.penalty.clear",
     "path": "/v1/providers/routing/penalties/clear",
@@ -1997,7 +2007,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 197,
+    "index": 198,
     "method": "GET",
     "operationId": "providers.auth.profiles.list",
     "path": "/v1/providers/:providerId/auth-profiles",
@@ -2007,7 +2017,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 198,
+    "index": 199,
     "method": "POST",
     "operationId": "providers.auth.profiles.activate",
     "path": "/v1/providers/:providerId/auth-profiles/:profileKey/activate",
@@ -2017,7 +2027,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 199,
+    "index": 200,
     "method": "GET",
     "operationId": "providers.routing.get",
     "path": "/v1/model-routing",
@@ -2027,7 +2037,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 200,
+    "index": 201,
     "method": "PUT",
     "operationId": "providers.routing.set",
     "path": "/v1/model-routing",
@@ -2037,7 +2047,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 201,
+    "index": 202,
     "method": "POST",
     "operationId": "auth.oauth.anthropic.initiate",
     "path": "/v1/auth/oauth/anthropic/initiate",
@@ -2047,7 +2057,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 202,
+    "index": 203,
     "method": "POST",
     "operationId": "auth.oauth.anthropic.callback",
     "path": "/v1/auth/oauth/anthropic/callback",
@@ -2057,7 +2067,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 203,
+    "index": 204,
     "method": "POST",
     "operationId": "auth.oauth.openai.codex.device.initiate",
     "path": "/v1/auth/oauth/openai-codex/device/initiate",
@@ -2067,7 +2077,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 204,
+    "index": 205,
     "method": "POST",
     "operationId": "auth.oauth.openai.codex.device.complete",
     "path": "/v1/auth/oauth/openai-codex/device/complete",
@@ -2077,7 +2087,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 205,
+    "index": 206,
     "method": "POST",
     "operationId": "media.understanding.doctor",
     "path": "/v1/media-understanding/doctor",
@@ -2087,7 +2097,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 206,
+    "index": 207,
     "method": "POST",
     "operationId": "media.understanding.analyze",
     "path": "/v1/media-understanding/analyze",
@@ -2097,7 +2107,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 207,
+    "index": 208,
     "method": "GET",
     "operationId": "task.workflows.boundaries.list",
     "path": "/v1/task-workflows/boundaries",
@@ -2107,7 +2117,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 208,
+    "index": 209,
     "method": "GET",
     "operationId": "task.workflows.gates.list",
     "path": "/v1/task-workflows/gates",
@@ -2117,7 +2127,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 209,
+    "index": 210,
     "method": "POST",
     "operationId": "task.workflows.preview",
     "path": "/v1/task-workflows/preview",
@@ -2127,7 +2137,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 210,
+    "index": 211,
     "method": "POST",
     "operationId": "task.workflows.create",
     "path": "/v1/task-workflows",
@@ -2137,7 +2147,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 211,
+    "index": 212,
     "method": "GET",
     "operationId": "task.workflows.list",
     "path": "/v1/task-workflows",
@@ -2147,7 +2157,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 212,
+    "index": 213,
     "method": "GET",
     "operationId": "task.workflows.get",
     "path": "/v1/task-workflows/:workflowId",
@@ -2157,7 +2167,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 213,
+    "index": 214,
     "method": "POST",
     "operationId": "task.workflows.revise",
     "path": "/v1/task-workflows/:workflowId/revisions",
@@ -2167,7 +2177,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 214,
+    "index": 215,
     "method": "GET",
     "operationId": "task.workflows.revisions.list",
     "path": "/v1/task-workflows/:workflowId/revisions",
@@ -2177,7 +2187,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 215,
+    "index": 216,
     "method": "POST",
     "operationId": "task.workflows.claims.create",
     "path": "/v1/task-workflows/:workflowId/claims",
@@ -2187,7 +2197,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 216,
+    "index": 217,
     "method": "GET",
     "operationId": "task.workflows.claims.list",
     "path": "/v1/task-workflows/:workflowId/claims",
@@ -2197,7 +2207,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 217,
+    "index": 218,
     "method": "GET",
     "operationId": "task.workflows.claims.get",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId",
@@ -2207,7 +2217,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 218,
+    "index": 219,
     "method": "POST",
     "operationId": "task.workflows.claims.evidence.attach",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId/evidence-ref",
@@ -2217,7 +2227,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 219,
+    "index": 220,
     "method": "GET",
     "operationId": "task.workflows.claims.evidence.list",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId/evidence-refs",
@@ -2227,7 +2237,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 220,
+    "index": 221,
     "method": "POST",
     "operationId": "task.workflows.claims.verify",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId/verify",
@@ -2237,7 +2247,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 221,
+    "index": 222,
     "method": "POST",
     "operationId": "task.workflows.claims.block",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId/block",
@@ -2247,7 +2257,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 222,
+    "index": 223,
     "method": "POST",
     "operationId": "task.workflows.closeout",
     "path": "/v1/task-workflows/:workflowId/closeout",
@@ -2257,7 +2267,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 223,
+    "index": 224,
     "method": "POST",
     "operationId": "task.workflows.lanes.executor.open",
     "path": "/v1/task-workflows/:workflowId/lanes/executor",
@@ -2267,7 +2277,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 224,
+    "index": 225,
     "method": "POST",
     "operationId": "task.workflows.lanes.verifier.open",
     "path": "/v1/task-workflows/:workflowId/lanes/verifier",
@@ -2277,7 +2287,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 225,
+    "index": 226,
     "method": "POST",
     "operationId": "task.workflows.lanes.complete",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId/complete",
@@ -2287,7 +2297,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 226,
+    "index": 227,
     "method": "POST",
     "operationId": "task.workflows.lanes.verdict",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId/verdict",
@@ -2297,7 +2307,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 227,
+    "index": 228,
     "method": "GET",
     "operationId": "task.workflows.lanes.list",
     "path": "/v1/task-workflows/:workflowId/lanes",
@@ -2307,7 +2317,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 228,
+    "index": 229,
     "method": "GET",
     "operationId": "task.workflows.lanes.get",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId",
@@ -2317,7 +2327,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 229,
+    "index": 230,
     "method": "POST",
     "operationId": "task.workflows.lanes.cli.handoff.record",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId/cli-handoffs",
@@ -2327,7 +2337,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 230,
+    "index": 231,
     "method": "GET",
     "operationId": "task.workflows.lanes.cli.handoffs.list",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId/cli-handoffs",
@@ -2337,7 +2347,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 231,
+    "index": 232,
     "method": "GET",
     "operationId": "task.workflows.cli.handoffs.list",
     "path": "/v1/task-workflows/:workflowId/cli-handoffs",
@@ -2347,7 +2357,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 232,
+    "index": 233,
     "method": "GET",
     "operationId": "task.workflows.supervisor.read",
     "path": "/v1/task-workflows/:workflowId/supervisor",
@@ -2357,7 +2367,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 233,
+    "index": 234,
     "method": "POST",
     "operationId": "task.workflows.channel.command.issue",
     "path": "/v1/task-workflows/:workflowId/channel-commands",
@@ -2367,7 +2377,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 234,
+    "index": 235,
     "method": "GET",
     "operationId": "task.workflows.channel.command.list",
     "path": "/v1/task-workflows/:workflowId/channel-commands",
@@ -2377,7 +2387,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 235,
+    "index": 236,
     "method": "POST",
     "operationId": "task.workflows.channel.command.confirm",
     "path": "/v1/task-workflows/:workflowId/channel-commands/confirm",
@@ -2387,7 +2397,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 236,
+    "index": 237,
     "method": "GET",
     "operationId": "task.workflows.evidence.explorer.query",
     "path": "/v1/task-workflows/evidence",
@@ -2397,7 +2407,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 237,
+    "index": 238,
     "method": "GET",
     "operationId": "task.workflows.evidence.explorer.raw",
     "path": "/v1/task-workflows/evidence/:evidenceRefId/raw",
@@ -2407,7 +2417,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 238,
+    "index": 239,
     "method": "POST",
     "operationId": "skills.social.import",
     "path": "/v1/skills/social-import",
@@ -2417,7 +2427,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 239,
+    "index": 240,
     "method": "GET",
     "operationId": "setup.status",
     "path": "/v1/setup/status",
@@ -2427,7 +2437,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 240,
+    "index": 241,
     "method": "POST",
     "operationId": "providers.detect",
     "path": "/v1/providers/detect",
@@ -2437,7 +2447,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 241,
+    "index": 242,
     "method": "GET",
     "operationId": "setup.network.get",
     "path": "/v1/setup/network",
@@ -2447,7 +2457,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 242,
+    "index": 243,
     "method": "POST",
     "operationId": "setup.network.save",
     "path": "/v1/setup/network",
@@ -2457,7 +2467,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 243,
+    "index": 244,
     "method": "POST",
     "operationId": "setup.channels.feishu.registration.begin",
     "path": "/v1/setup/channels/feishu/registration/begin",
@@ -2467,7 +2477,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 244,
+    "index": 245,
     "method": "POST",
     "operationId": "setup.channels.feishu.registration.poll",
     "path": "/v1/setup/channels/feishu/registration/poll",
@@ -2477,7 +2487,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 245,
+    "index": 246,
     "method": "POST",
     "operationId": "setup.channels.telegram.verification.begin",
     "path": "/v1/setup/channels/telegram/verification/begin",
@@ -2487,7 +2497,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 246,
+    "index": 247,
     "method": "POST",
     "operationId": "setup.channels.telegram.verification.poll",
     "path": "/v1/setup/channels/telegram/verification/poll",
@@ -2497,7 +2507,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 247,
+    "index": 248,
     "method": "POST",
     "operationId": "setup.channels.discord.verification.begin",
     "path": "/v1/setup/channels/discord/verification/begin",
@@ -2507,7 +2517,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 248,
+    "index": 249,
     "method": "POST",
     "operationId": "setup.channels.discord.verification.complete",
     "path": "/v1/setup/channels/discord/verification/complete",
@@ -2517,7 +2527,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 249,
+    "index": 250,
     "method": "POST",
     "operationId": "setup.channels.test",
     "path": "/v1/setup/channels/test",
@@ -2527,7 +2537,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 250,
+    "index": 251,
     "method": "POST",
     "operationId": "setup.channels.save",
     "path": "/v1/setup/channels",
@@ -2537,7 +2547,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 251,
+    "index": 252,
     "method": "POST",
     "operationId": "setup.complete",
     "path": "/v1/setup/complete",
@@ -2547,7 +2557,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 252,
+    "index": 253,
     "method": "GET",
     "operationId": "skills.list",
     "path": "/v1/skills",
@@ -2557,7 +2567,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 253,
+    "index": 254,
     "method": "GET",
     "operationId": "skills.catalog.list",
     "path": "/v1/skills/catalog",
@@ -2567,7 +2577,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 254,
+    "index": 255,
     "method": "GET",
     "operationId": "skills.get",
     "path": "/v1/skills/:skillId",
@@ -2577,7 +2587,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 255,
+    "index": 256,
     "method": "POST",
     "operationId": "skills.install",
     "path": "/v1/skills/install",
@@ -2587,7 +2597,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 256,
+    "index": 257,
     "method": "POST",
     "operationId": "skills.update",
     "path": "/v1/skills/:skillId/update",
@@ -2597,7 +2607,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 257,
+    "index": 258,
     "method": "DELETE",
     "operationId": "skills.delete",
     "path": "/v1/skills/:skillId",
@@ -2607,7 +2617,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 258,
+    "index": 259,
     "method": "POST",
     "operationId": "skills.manifest.validate",
     "path": "/v1/skills/validate-manifest",
@@ -2617,7 +2627,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 259,
+    "index": 260,
     "method": "POST",
     "operationId": "skills.verify",
     "path": "/v1/skills/:skillId/verify",
@@ -2627,7 +2637,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 260,
+    "index": 261,
     "method": "POST",
     "operationId": "skills.upgrade.analyze",
     "path": "/v1/skills/:skillId/upgrade/analyze",
@@ -2637,7 +2647,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 261,
+    "index": 262,
     "method": "POST",
     "operationId": "skills.upgrade.decide",
     "path": "/v1/skills/:skillId/upgrade/decide",
@@ -2647,7 +2657,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 262,
+    "index": 263,
     "method": "POST",
     "operationId": "skills.run",
     "path": "/v1/skills/:skillId/run",
@@ -2657,7 +2667,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 263,
+    "index": 264,
     "method": "POST",
     "operationId": "skills.generator.sessions.create",
     "path": "/v1/skills/generator/sessions",
@@ -2667,7 +2677,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 264,
+    "index": 265,
     "method": "GET",
     "operationId": "skills.generator.sessions.get",
     "path": "/v1/skills/generator/sessions/:sessionId",
@@ -2677,7 +2687,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 265,
+    "index": 266,
     "method": "POST",
     "operationId": "skills.generator.sessions.messages.create",
     "path": "/v1/skills/generator/sessions/:sessionId/messages",
@@ -2687,7 +2697,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 266,
+    "index": 267,
     "method": "POST",
     "operationId": "skills.generator.sessions.generate",
     "path": "/v1/skills/generator/sessions/:sessionId/generate",
@@ -2697,7 +2707,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 267,
+    "index": 268,
     "method": "POST",
     "operationId": "skills.generator.sessions.test",
     "path": "/v1/skills/generator/sessions/:sessionId/test",
@@ -2707,7 +2717,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 268,
+    "index": 269,
     "method": "GET",
     "operationId": "skills.generator.sessions.evidence.get",
     "path": "/v1/skills/generator/sessions/:sessionId/evidence",
@@ -2717,7 +2727,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 269,
+    "index": 270,
     "method": "POST",
     "operationId": "skills.generator.sessions.approve",
     "path": "/v1/skills/generator/sessions/:sessionId/approve",
@@ -2727,7 +2737,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 270,
+    "index": 271,
     "method": "DELETE",
     "operationId": "skills.generator.sessions.cancel",
     "path": "/v1/skills/generator/sessions/:sessionId",
@@ -2737,7 +2747,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 271,
+    "index": 272,
     "method": "GET",
     "operationId": "skills.ui.get",
     "path": "/v1/skills/:skillId/ui",
@@ -2747,7 +2757,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 272,
+    "index": 273,
     "method": "POST",
     "operationId": "uix.intents.resolve",
     "path": "/v1/uix/intents/resolve",
@@ -2757,7 +2767,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 273,
+    "index": 274,
     "method": "GET",
     "operationId": "uix.templates.list",
     "path": "/v1/uix/templates",
@@ -2767,7 +2777,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 274,
+    "index": 275,
     "method": "GET",
     "operationId": "uix.home.snapshot.get",
     "path": "/v1/uix/home-snapshot",
@@ -2777,7 +2787,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 275,
+    "index": 276,
     "method": "GET",
     "operationId": "uix.assistant.inbox.snapshot.get",
     "path": "/v1/uix/assistant-inbox-snapshot",
@@ -2787,7 +2797,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 276,
+    "index": 277,
     "method": "GET",
     "operationId": "uix.diagnostics.get",
     "path": "/v1/uix/diagnostics",
@@ -2797,7 +2807,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 277,
+    "index": 278,
     "method": "GET",
     "operationId": "uix.preferences.list",
     "path": "/v1/uix/preferences",
@@ -2807,7 +2817,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 278,
+    "index": 279,
     "method": "PUT",
     "operationId": "uix.preferences.update",
     "path": "/v1/uix/preferences",
@@ -2817,7 +2827,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 279,
+    "index": 280,
     "method": "DELETE",
     "operationId": "uix.preferences.delete",
     "path": "/v1/uix/preferences/:preferenceId",
@@ -2827,7 +2837,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 280,
+    "index": 281,
     "method": "GET",
     "operationId": "uix.persona.get",
     "path": "/v1/uix/persona",
@@ -2837,7 +2847,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 281,
+    "index": 282,
     "method": "PUT",
     "operationId": "uix.persona.update",
     "path": "/v1/uix/persona",
@@ -2847,7 +2857,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 282,
+    "index": 283,
     "method": "POST",
     "operationId": "uix.templates.execute",
     "path": "/v1/uix/templates/:templateId/execute",
@@ -2857,7 +2867,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 283,
+    "index": 284,
     "method": "POST",
     "operationId": "uix.wizards.start",
     "path": "/v1/uix/wizards/:wizardId/start",
@@ -2867,7 +2877,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 284,
+    "index": 285,
     "method": "POST",
     "operationId": "uix.wizards.continue",
     "path": "/v1/uix/wizards/:wizardId/continue",
@@ -2877,7 +2887,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 285,
+    "index": 286,
     "method": "GET",
     "operationId": "uix.issues.list",
     "path": "/v1/uix/issues",
@@ -2887,7 +2897,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 286,
+    "index": 287,
     "method": "GET",
     "operationId": "uix.user.profile.get",
     "path": "/v1/uix/user-profile",
@@ -2897,7 +2907,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 287,
+    "index": 288,
     "method": "PUT",
     "operationId": "uix.user.profile.update",
     "path": "/v1/uix/user-profile",
@@ -2907,7 +2917,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 288,
+    "index": 289,
     "method": "POST",
     "operationId": "uix.investigate",
     "path": "/v1/uix/investigate",
@@ -2917,7 +2927,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 289,
+    "index": 290,
     "method": "GET",
     "operationId": "uix.learnedfacts.list",
     "path": "/v1/uix/learned-facts",
@@ -2927,7 +2937,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 290,
+    "index": 291,
     "method": "DELETE",
     "operationId": "uix.learnedfacts.clear",
     "path": "/v1/uix/learned-facts",
@@ -2937,7 +2947,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 291,
+    "index": 292,
     "method": "PATCH",
     "operationId": "uix.learnedfacts.update",
     "path": "/v1/uix/learned-facts/:factKey",
@@ -2947,7 +2957,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 292,
+    "index": 293,
     "method": "DELETE",
     "operationId": "uix.learnedfacts.delete",
     "path": "/v1/uix/learned-facts/:factKey",
@@ -2957,7 +2967,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 293,
+    "index": 294,
     "method": "GET",
     "operationId": "packs.cross.border.profile.get",
     "path": "/v1/packs/cross-border/profile",
@@ -2967,7 +2977,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 294,
+    "index": 295,
     "method": "PUT",
     "operationId": "packs.cross.border.profile.put",
     "path": "/v1/packs/cross-border/profile",
@@ -2977,7 +2987,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 295,
+    "index": 296,
     "method": "GET",
     "operationId": "packs.cross.border.snapshot.get",
     "path": "/v1/packs/cross-border/snapshot",
@@ -2987,7 +2997,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 296,
+    "index": 297,
     "method": "POST",
     "operationId": "packs.cross.border.import.post",
     "path": "/v1/packs/cross-border/import",
@@ -2997,7 +3007,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 297,
+    "index": 298,
     "method": "POST",
     "operationId": "packs.cross.border.workflow.presets.apply",
     "path": "/v1/packs/cross-border/workflow-presets/apply",
@@ -3007,7 +3017,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 298,
+    "index": 299,
     "method": "PATCH",
     "operationId": "packs.cross.border.workflow.presets.toggle",
     "path": "/v1/packs/cross-border/workflow-presets/:workflowId",
@@ -3017,7 +3027,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 299,
+    "index": 300,
     "method": "POST",
     "operationId": "packs.cross.border.run.evidence.capture",
     "path": "/v1/packs/cross-border/run-evidence",
@@ -3027,7 +3037,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 300,
+    "index": 301,
     "method": "PATCH",
     "operationId": "packs.cross.border.import.stale",
     "path": "/v1/packs/cross-border/imports/:importBatchId/stale",
@@ -3037,7 +3047,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 301,
+    "index": 302,
     "method": "POST",
     "operationId": "packs.cross.border.workflows.disable.all",
     "path": "/v1/packs/cross-border/workflows/disable-all",
@@ -3047,7 +3057,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 302,
+    "index": 303,
     "method": "GET",
     "operationId": "skills.converters.list",
     "path": "/v1/skills/converters",
@@ -3057,7 +3067,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 303,
+    "index": 304,
     "method": "POST",
     "operationId": "skills.convert",
     "path": "/v1/skills/convert",
@@ -3067,7 +3077,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 304,
+    "index": 305,
     "method": "POST",
     "operationId": "skills.import",
     "path": "/v1/skills/import",
@@ -3077,7 +3087,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 305,
+    "index": 306,
     "method": "POST",
     "operationId": "skills.pack",
     "path": "/v1/skills/pack",
@@ -3087,7 +3097,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 306,
+    "index": 307,
     "method": "POST",
     "operationId": "workflows.generator.sessions.create",
     "path": "/v1/workflows/generator/sessions",
@@ -3097,7 +3107,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 307,
+    "index": 308,
     "method": "GET",
     "operationId": "workflows.generator.sessions.get",
     "path": "/v1/workflows/generator/sessions/:sessionId",
@@ -3107,7 +3117,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 308,
+    "index": 309,
     "method": "POST",
     "operationId": "workflows.generator.sessions.messages.create",
     "path": "/v1/workflows/generator/sessions/:sessionId/messages",
@@ -3117,7 +3127,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 309,
+    "index": 310,
     "method": "POST",
     "operationId": "workflows.generator.sessions.generate",
     "path": "/v1/workflows/generator/sessions/:sessionId/generate",
@@ -3127,7 +3137,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 310,
+    "index": 311,
     "method": "GET",
     "operationId": "workflows.generator.sessions.evidence.get",
     "path": "/v1/workflows/generator/sessions/:sessionId/evidence",
@@ -3137,7 +3147,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 311,
+    "index": 312,
     "method": "POST",
     "operationId": "workflows.generator.sessions.approve",
     "path": "/v1/workflows/generator/sessions/:sessionId/approve",
@@ -3147,7 +3157,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 312,
+    "index": 313,
     "method": "DELETE",
     "operationId": "workflows.generator.sessions.cancel",
     "path": "/v1/workflows/generator/sessions/:sessionId",
@@ -3157,7 +3167,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 313,
+    "index": 314,
     "method": "GET",
     "operationId": "rules.bundles.list",
     "path": "/v1/rules/bundles",
@@ -3167,7 +3177,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 314,
+    "index": 315,
     "method": "GET",
     "operationId": "rules.bundles.get",
     "path": "/v1/rules/bundles/:bundleId",
@@ -3177,7 +3187,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 315,
+    "index": 316,
     "method": "POST",
     "operationId": "rules.bundles.create",
     "path": "/v1/rules/bundles",
@@ -3187,7 +3197,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 316,
+    "index": 317,
     "method": "PATCH",
     "operationId": "rules.bundles.update",
     "path": "/v1/rules/bundles/:bundleId",
@@ -3197,7 +3207,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 317,
+    "index": 318,
     "method": "GET",
     "operationId": "rules.bundles.versions.list",
     "path": "/v1/rules/bundles/:bundleId/versions",
@@ -3207,7 +3217,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 318,
+    "index": 319,
     "method": "GET",
     "operationId": "rules.list",
     "path": "/v1/rules/bundles/:bundleId/rules",
@@ -3217,7 +3227,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 319,
+    "index": 320,
     "method": "POST",
     "operationId": "rules.evaluate",
     "path": "/v1/rules/evaluate",
@@ -3227,7 +3237,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 320,
+    "index": 321,
     "method": "POST",
     "operationId": "rules.simulate",
     "path": "/v1/rules/simulate",
@@ -3237,7 +3247,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 321,
+    "index": 322,
     "method": "GET",
     "operationId": "rules.versions.list",
     "path": "/v1/rules/:ruleId/versions",
@@ -3247,7 +3257,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 322,
+    "index": 323,
     "method": "GET",
     "operationId": "rules.audit.log.list",
     "path": "/v1/rules/audit-log",
@@ -3257,7 +3267,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 323,
+    "index": 324,
     "method": "POST",
     "operationId": "node.runner.execute",
     "path": "/v1/node-runner/execute",
@@ -3267,7 +3277,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 324,
+    "index": 325,
     "method": "GET",
     "operationId": "node.runner.executions.get",
     "path": "/v1/node-runner/executions/:executionId",
@@ -3277,7 +3287,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 325,
+    "index": 326,
     "method": "GET",
     "operationId": "node.runner.executions.list",
     "path": "/v1/node-runner/executions",
@@ -3287,7 +3297,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 326,
+    "index": 327,
     "method": "POST",
     "operationId": "acceptance.run",
     "path": "/v1/acceptance/run",
@@ -3297,7 +3307,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 327,
+    "index": 328,
     "method": "GET",
     "operationId": "acceptance.results.get",
     "path": "/v1/acceptance/results/:resultId",
@@ -3307,7 +3317,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 328,
+    "index": 329,
     "method": "GET",
     "operationId": "acceptance.results.list",
     "path": "/v1/acceptance/results",
@@ -3317,7 +3327,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 329,
+    "index": 330,
     "method": "GET",
     "operationId": "acceptance.runs.get",
     "path": "/v1/acceptance/runs/:runId",
@@ -3327,7 +3337,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 330,
+    "index": 331,
     "method": "GET",
     "operationId": "acceptance.tests.list",
     "path": "/v1/acceptance/tests",
@@ -3337,7 +3347,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 331,
+    "index": 332,
     "method": "GET",
     "operationId": "acceptance.tests.get",
     "path": "/v1/acceptance/tests/:testId",
@@ -3347,7 +3357,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 332,
+    "index": 333,
     "method": "POST",
     "operationId": "acceptance.tests.create",
     "path": "/v1/acceptance/tests",
@@ -3357,7 +3367,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 333,
+    "index": 334,
     "method": "PUT",
     "operationId": "acceptance.tests.update",
     "path": "/v1/acceptance/tests/:testId",
@@ -3367,7 +3377,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 334,
+    "index": 335,
     "method": "DELETE",
     "operationId": "acceptance.tests.delete",
     "path": "/v1/acceptance/tests/:testId",
@@ -3377,7 +3387,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 335,
+    "index": 336,
     "method": "GET",
     "operationId": "acceptance.tests.versions.list",
     "path": "/v1/acceptance/tests/:testId/versions",
@@ -3387,7 +3397,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 336,
+    "index": 337,
     "method": "GET",
     "operationId": "acceptance.artifacts.history",
     "path": "/v1/acceptance/artifacts/history",
@@ -3397,7 +3407,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 337,
+    "index": 338,
     "method": "GET",
     "operationId": "retry.policies.list",
     "path": "/v1/retry/policies",
@@ -3407,7 +3417,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 338,
+    "index": 339,
     "method": "GET",
     "operationId": "retry.policies.get",
     "path": "/v1/retry/policies/:policyId",
@@ -3417,7 +3427,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 339,
+    "index": 340,
     "method": "POST",
     "operationId": "retry.policies.create",
     "path": "/v1/retry/policies",
@@ -3427,7 +3437,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 340,
+    "index": 341,
     "method": "PUT",
     "operationId": "retry.policies.update",
     "path": "/v1/retry/policies/:policyId",
@@ -3437,7 +3447,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 341,
+    "index": 342,
     "method": "DELETE",
     "operationId": "retry.policies.delete",
     "path": "/v1/retry/policies/:policyId",
@@ -3447,7 +3457,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 342,
+    "index": 343,
     "method": "POST",
     "operationId": "retry.classify",
     "path": "/v1/retry/classify",
@@ -3457,7 +3467,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 343,
+    "index": 344,
     "method": "POST",
     "operationId": "retry.decide",
     "path": "/v1/retry/decide",
@@ -3467,7 +3477,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 344,
+    "index": 345,
     "method": "GET",
     "operationId": "retry.traces.list",
     "path": "/v1/retry/traces",
@@ -3477,7 +3487,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 345,
+    "index": 346,
     "method": "GET",
     "operationId": "retry.traces.get",
     "path": "/v1/retry/traces/:traceId",
@@ -3487,7 +3497,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 346,
+    "index": 347,
     "method": "GET",
     "operationId": "retry.costs.summary",
     "path": "/v1/retry/costs",
@@ -3497,7 +3507,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 347,
+    "index": 348,
     "method": "GET",
     "operationId": "retry.escalations.list",
     "path": "/v1/retry/escalations",
@@ -3507,7 +3517,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 348,
+    "index": 349,
     "method": "POST",
     "operationId": "retry.escalations.acknowledge",
     "path": "/v1/retry/escalations/:escalationId/acknowledge",
@@ -3517,7 +3527,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 349,
+    "index": 350,
     "method": "GET",
     "operationId": "retry.circuit.breakers.list",
     "path": "/v1/retry/circuit-breakers",
@@ -3527,7 +3537,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 350,
+    "index": 351,
     "method": "GET",
     "operationId": "playbook.list",
     "path": "/v1/playbooks",
@@ -3537,7 +3547,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 351,
+    "index": 352,
     "method": "GET",
     "operationId": "playbook.get",
     "path": "/v1/playbooks/:playbookId",
@@ -3547,7 +3557,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 352,
+    "index": 353,
     "method": "POST",
     "operationId": "playbook.select",
     "path": "/v1/playbooks/select",
@@ -3557,7 +3567,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 353,
+    "index": 354,
     "method": "GET",
     "operationId": "playbook.candidates.list",
     "path": "/v1/playbooks/candidates",
@@ -3567,7 +3577,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 354,
+    "index": 355,
     "method": "POST",
     "operationId": "playbook.candidates.promote",
     "path": "/v1/playbooks/candidates/:candidateId/promote",
@@ -3577,7 +3587,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 355,
+    "index": 356,
     "method": "POST",
     "operationId": "playbook.rollback",
     "path": "/v1/playbooks/:playbookId/rollback",
@@ -3587,7 +3597,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 356,
+    "index": 357,
     "method": "GET",
     "operationId": "playbook.scores",
     "path": "/v1/playbooks/:playbookId/scores",
@@ -3597,7 +3607,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 357,
+    "index": 358,
     "method": "POST",
     "operationId": "memory.store",
     "path": "/v1/memory/store",
@@ -3607,7 +3617,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 358,
+    "index": 359,
     "method": "POST",
     "operationId": "memory.items.create",
     "path": "/v1/memory/items",
@@ -3617,7 +3627,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 359,
+    "index": 360,
     "method": "POST",
     "operationId": "memory.search",
     "path": "/v1/memory/search",
@@ -3627,7 +3637,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 360,
+    "index": 361,
     "method": "GET",
     "operationId": "memory.get",
     "path": "/v1/memory/items/:id",
@@ -3637,7 +3647,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 361,
+    "index": 362,
     "method": "GET",
     "operationId": "memory.list",
     "path": "/v1/memory/items",
@@ -3647,7 +3657,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 362,
+    "index": 363,
     "method": "DELETE",
     "operationId": "memory.delete",
     "path": "/v1/memory/items/:id",
@@ -3657,7 +3667,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 363,
+    "index": 364,
     "method": "POST",
     "operationId": "memory.prune",
     "path": "/v1/memory/prune",
@@ -3667,7 +3677,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 364,
+    "index": 365,
     "method": "GET",
     "operationId": "sessions.usage.get",
     "path": "/v1/sessions/:sessionKey/usage",
@@ -3677,7 +3687,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 365,
+    "index": 366,
     "method": "GET",
     "operationId": "sessions.usage.list",
     "path": "/v1/sessions/usage",
@@ -3687,7 +3697,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 366,
+    "index": 367,
     "method": "GET",
     "operationId": "sessions.list",
     "path": "/v1/sessions",
@@ -3697,7 +3707,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 367,
+    "index": 368,
     "method": "POST",
     "operationId": "sessions.create",
     "path": "/v1/sessions",
@@ -3707,7 +3717,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 368,
+    "index": 369,
     "method": "GET",
     "operationId": "sessions.get",
     "path": "/v1/sessions/:sessionKey",
@@ -3717,7 +3727,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 369,
+    "index": 370,
     "method": "DELETE",
     "operationId": "sessions.delete",
     "path": "/v1/sessions/:sessionKey",
@@ -3727,7 +3737,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 370,
+    "index": 371,
     "method": "POST",
     "operationId": "sessions.archive",
     "path": "/v1/sessions/:sessionKey/archive",
@@ -3737,7 +3747,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 371,
+    "index": 372,
     "method": "POST",
     "operationId": "sessions.reset",
     "path": "/v1/sessions/:sessionKey/reset",
@@ -3747,7 +3757,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 372,
+    "index": 373,
     "method": "POST",
     "operationId": "sessions.prune",
     "path": "/v1/sessions/prune",
@@ -3757,7 +3767,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 373,
+    "index": 374,
     "method": "POST",
     "operationId": "sessions.sweep",
     "path": "/v1/sessions/sweep",
@@ -3767,7 +3777,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 374,
+    "index": 375,
     "method": "POST",
     "operationId": "sessions.compact",
     "path": "/v1/sessions/:sessionKey/compact",
@@ -3777,7 +3787,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 375,
+    "index": 376,
     "method": "GET",
     "operationId": "sessions.messages.list",
     "path": "/v1/sessions/:sessionKey/messages",
@@ -3787,7 +3797,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 376,
+    "index": 377,
     "method": "GET",
     "operationId": "sessions.export",
     "path": "/v1/sessions/:sessionKey/export",
@@ -3797,7 +3807,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 377,
+    "index": 378,
     "method": "POST",
     "operationId": "sessions.messages.create",
     "path": "/v1/sessions/:sessionKey/messages",
@@ -3807,7 +3817,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 378,
+    "index": 379,
     "method": "POST",
     "operationId": "sessions.outbound.send",
     "path": "/v1/sessions/:sessionKey/outbound",
@@ -3817,7 +3827,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 379,
+    "index": 380,
     "method": "POST",
     "operationId": "sessions.run",
     "path": "/v1/sessions/:sessionKey/run",
@@ -3827,7 +3837,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 380,
+    "index": 381,
     "method": "GET",
     "operationId": "sessions.memory.namespace.get",
     "path": "/v1/sessions/:sessionKey/memory-namespace",
@@ -3837,7 +3847,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 381,
+    "index": 382,
     "method": "POST",
     "operationId": "sessions.forks.create",
     "path": "/v1/sessions/:sessionKey/fork",
@@ -3847,7 +3857,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 382,
+    "index": 383,
     "method": "GET",
     "operationId": "sessions.forks.list",
     "path": "/v1/sessions/:sessionKey/forks",
@@ -3857,7 +3867,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 383,
+    "index": 384,
     "method": "POST",
     "operationId": "sessions.forks.merge",
     "path": "/v1/sessions/:sessionKey/merge",
@@ -3867,7 +3877,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 384,
+    "index": 385,
     "method": "POST",
     "operationId": "sessions.memory.extract",
     "path": "/v1/sessions/:sessionKey/memory/extract",
@@ -3877,7 +3887,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 385,
+    "index": 386,
     "method": "POST",
     "operationId": "sessions.memory.remember",
     "path": "/v1/sessions/:sessionKey/memory/remember",
@@ -3887,7 +3897,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 386,
+    "index": 387,
     "method": "GET",
     "operationId": "sessions.memory.extraction.get",
     "path": "/v1/sessions/:sessionKey/memory/extraction",
@@ -3897,7 +3907,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 387,
+    "index": 388,
     "method": "POST",
     "operationId": "sessions.memory.extraction.retry",
     "path": "/v1/sessions/memory/extraction/retry",
@@ -3907,7 +3917,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 388,
+    "index": 389,
     "method": "GET",
     "operationId": "plugins.list",
     "path": "/v1/plugins",
@@ -3917,7 +3927,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 389,
+    "index": 390,
     "method": "GET",
     "operationId": "plugins.get",
     "path": "/v1/plugins/:id",
@@ -3927,7 +3937,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 390,
+    "index": 391,
     "method": "GET",
     "operationId": "plugins.versions.list",
     "path": "/v1/plugins/:id/versions",
@@ -3937,7 +3947,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 391,
+    "index": 392,
     "method": "POST",
     "operationId": "plugins.install",
     "path": "/v1/plugins/:id/install",
@@ -3947,7 +3957,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 392,
+    "index": 393,
     "method": "POST",
     "operationId": "plugins.enable",
     "path": "/v1/plugins/:id/enable",
@@ -3957,7 +3967,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 393,
+    "index": 394,
     "method": "POST",
     "operationId": "plugins.disable",
     "path": "/v1/plugins/:id/disable",
@@ -3967,7 +3977,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 394,
+    "index": 395,
     "method": "DELETE",
     "operationId": "plugins.uninstall",
     "path": "/v1/plugins/:id",
@@ -3977,7 +3987,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 395,
+    "index": 396,
     "method": "POST",
     "operationId": "agent.runs.start",
     "path": "/v1/agent/runs",
@@ -3987,7 +3997,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 396,
+    "index": 397,
     "method": "GET",
     "operationId": "agent.runs.list",
     "path": "/v1/agent/runs",
@@ -3997,7 +4007,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 397,
+    "index": 398,
     "method": "GET",
     "operationId": "agent.runs.summary",
     "path": "/v1/agent/runs/summary",
@@ -4007,7 +4017,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 398,
+    "index": 399,
     "method": "GET",
     "operationId": "agent.runs.get",
     "path": "/v1/agent/runs/:runId",
@@ -4017,7 +4027,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 399,
+    "index": 400,
     "method": "POST",
     "operationId": "agent.runs.cancel",
     "path": "/v1/agent/runs/:runId/cancel",
@@ -4027,7 +4037,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 400,
+    "index": 401,
     "method": "GET",
     "operationId": "agent.runs.audit",
     "path": "/v1/agent/runs/:runId/audit",
@@ -4037,7 +4047,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 401,
+    "index": 402,
     "method": "POST",
     "operationId": "agent.runs.rollback",
     "path": "/v1/agent/runs/:runId/rollback",
@@ -4047,7 +4057,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 402,
+    "index": 403,
     "method": "POST",
     "operationId": "agent.runs.approve.plan",
     "path": "/v1/agent/runs/:runId/approve-plan",
@@ -4057,7 +4067,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 403,
+    "index": 404,
     "method": "POST",
     "operationId": "agent.runs.reject.plan",
     "path": "/v1/agent/runs/:runId/reject-plan",
@@ -4067,7 +4077,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 404,
+    "index": 405,
     "method": "POST",
     "operationId": "agent.runs.approve.tool",
     "path": "/v1/agent/runs/:runId/approve-tool",
@@ -4077,7 +4087,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 405,
+    "index": 406,
     "method": "POST",
     "operationId": "agent.runs.reject.tool",
     "path": "/v1/agent/runs/:runId/reject-tool",
@@ -4087,7 +4097,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 406,
+    "index": 407,
     "method": "GET",
     "operationId": "agent.runs.events",
     "path": "/v1/agent/runs/:runId/events",
@@ -4097,7 +4107,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 407,
+    "index": 408,
     "method": "POST",
     "operationId": "agent.automations.create",
     "path": "/v1/agent/automations",
@@ -4107,7 +4117,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 408,
+    "index": 409,
     "method": "GET",
     "operationId": "agent.automations.list",
     "path": "/v1/agent/automations",
@@ -4117,7 +4127,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 409,
+    "index": 410,
     "method": "GET",
     "operationId": "agent.automations.get",
     "path": "/v1/agent/automations/:automationId",
@@ -4127,7 +4137,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 410,
+    "index": 411,
     "method": "PATCH",
     "operationId": "agent.automations.update",
     "path": "/v1/agent/automations/:automationId",
@@ -4137,7 +4147,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 411,
+    "index": 412,
     "method": "DELETE",
     "operationId": "agent.automations.delete",
     "path": "/v1/agent/automations/:automationId",
@@ -4147,7 +4157,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 412,
+    "index": 413,
     "method": "POST",
     "operationId": "agent.automations.run",
     "path": "/v1/agent/automations/:automationId/run",
@@ -4157,7 +4167,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 413,
+    "index": 414,
     "method": "GET",
     "operationId": "agent.subagents.list",
     "path": "/v1/agent/subagents",
@@ -4167,7 +4177,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 414,
+    "index": 415,
     "method": "GET",
     "operationId": "agent.subagents.get",
     "path": "/v1/agent/subagents/:subagentId",
@@ -4177,7 +4187,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 415,
+    "index": 416,
     "method": "GET",
     "operationId": "agent.runs.subagents.list",
     "path": "/v1/agent/runs/:runId/subagents",
@@ -4187,7 +4197,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 416,
+    "index": 417,
     "method": "GET",
     "operationId": "assets.inventory.list",
     "path": "/v1/assets/inventory",

--- a/test/unit/providers/api/friday-provider-routes.test.ts
+++ b/test/unit/providers/api/friday-provider-routes.test.ts
@@ -391,7 +391,7 @@ describe("FridayProviderRoutes", () => {
     const routes = createFridayProviderRoutes({
       providerService: makeMockService(),
     });
-    expect(routes).toHaveLength(22);
+    expect(routes).toHaveLength(23);
   });
 
   it("has correct operation ids", () => {
@@ -1266,6 +1266,90 @@ describe("FridayProviderRoutes", () => {
       });
     });
 
+    it("lists capability health from persisted snapshots without running live probes", async () => {
+      const mockService = makeMockService();
+      const verifiedProfile: FridayProviderProfile = {
+        ...sampleProfile,
+        config: {
+          ...sampleProfile.config,
+          runtimeCapabilities: [
+            {
+              capability: "text",
+              model: "gpt-4o",
+              status: "verified",
+              verified: true,
+              verifiedAt: NOW,
+              notes: "Capability passed a live standardized probe.",
+            },
+          ],
+        },
+      };
+      const pendingProfile: FridayProviderProfile = {
+        ...anthropicOauthProfile,
+        config: {
+          ...anthropicOauthProfile.config,
+          validation: { status: "ok", checkedAt: NOW },
+          runtimeCapabilities: [
+            {
+              capability: "vision",
+              model: "claude-sonnet-4-20250514",
+              status: "declared",
+            },
+          ],
+        },
+      };
+      const disabledProfile: FridayProviderProfile = {
+        ...openAICodexOauthProfile,
+        enabled: false,
+        config: {
+          ...openAICodexOauthProfile.config,
+          validation: { status: "never" },
+          runtimeCapabilities: [
+            {
+              capability: "text",
+              model: "gpt-5.4-mini",
+              status: "declared",
+            },
+          ],
+        },
+      };
+      mockService.listProviders = vi.fn(async () => [verifiedProfile, pendingProfile, disabledProfile]);
+      mockService.doctorProvider = vi.fn(async (providerId: string) => ({
+        providerId,
+        providerKind: providerId === "anth-001" ? "anthropic" as const : providerId === "codex-001" ? "openai-codex" as const : "openai" as const,
+        backendKind: providerId === "codex-001" ? "cli" as const : "http" as const,
+        authMode: providerId === "prov-001" ? "api-key" as const : "oauth" as const,
+        checkedAt: NOW,
+        backendHealth: "healthy" as const,
+        authHealth: providerId === "codex-001" ? "missing" as const : "healthy" as const,
+        routingEligible: providerId !== "codex-001",
+        reasons: providerId === "codex-001" ? ["validation_unverified"] : [],
+      }));
+      const routes = createFridayProviderRoutes({ providerService: mockService });
+      const route = routes.find((entry) => entry.operationId === "providers.capabilityHealth.list")!;
+
+      const result = await route.handler(makeCtx());
+      const items = (result as { items: Array<{ providerId: string; capabilities: Array<{ state: string; source: string }> }>; summary: Record<string, number> }).items;
+
+      expect(mockService.runCapabilityDoctor).not.toHaveBeenCalled();
+      expect(items.find((item) => item.providerId === "prov-001")?.capabilities[0]).toMatchObject({
+        state: "available",
+        source: "runtime_capability_snapshot",
+      });
+      expect(items.find((item) => item.providerId === "anth-001")?.capabilities[0]).toMatchObject({
+        state: "proof_pending",
+        source: "declared_configuration",
+      });
+      expect(items.find((item) => item.providerId === "codex-001")?.capabilities[0]).toMatchObject({
+        state: "disabled",
+      });
+      expect((result as { summary: { available: number; proofPending: number; disabled: number } }).summary).toMatchObject({
+        available: 1,
+        proofPending: 1,
+        disabled: 1,
+      });
+    });
+
     it("includes OAuth route operation ids", () => {
       const routes = createFridayProviderRoutes({
         providerService: makeMockService(),
@@ -1273,6 +1357,7 @@ describe("FridayProviderRoutes", () => {
       const operationIds = routes.map((r) => r.operationId);
       expect(operationIds).toContain("providers.templates.list");
       expect(operationIds).toContain("providers.health.list");
+      expect(operationIds).toContain("providers.capabilityHealth.list");
       expect(operationIds).toContain("auth.oauth.anthropic.initiate");
       expect(operationIds).toContain("auth.oauth.anthropic.callback");
       expect(operationIds).toContain("auth.oauth.openai.codex.device.initiate");

--- a/test/unit/providers/api/friday-provider-routes.test.ts
+++ b/test/unit/providers/api/friday-provider-routes.test.ts
@@ -1326,7 +1326,7 @@ describe("FridayProviderRoutes", () => {
         reasons: providerId === "codex-001" ? ["validation_unverified"] : [],
       }));
       const routes = createFridayProviderRoutes({ providerService: mockService });
-      const route = routes.find((entry) => entry.operationId === "providers.capabilityHealth.list")!;
+      const route = routes.find((entry) => entry.operationId === "providers.capability.health.list")!;
 
       const result = await route.handler(makeCtx());
       const items = (result as { items: Array<{ providerId: string; capabilities: Array<{ state: string; source: string }> }>; summary: Record<string, number> }).items;
@@ -1357,7 +1357,7 @@ describe("FridayProviderRoutes", () => {
       const operationIds = routes.map((r) => r.operationId);
       expect(operationIds).toContain("providers.templates.list");
       expect(operationIds).toContain("providers.health.list");
-      expect(operationIds).toContain("providers.capabilityHealth.list");
+      expect(operationIds).toContain("providers.capability.health.list");
       expect(operationIds).toContain("auth.oauth.anthropic.initiate");
       expect(operationIds).toContain("auth.oauth.anthropic.callback");
       expect(operationIds).toContain("auth.oauth.openai.codex.device.initiate");

--- a/test/unit/ui/provider-capability-lane-truth-label.test.ts
+++ b/test/unit/ui/provider-capability-lane-truth-label.test.ts
@@ -19,17 +19,19 @@ import { describe, expect, it } from "vitest";
  *  - The settings page already calls `providersApi.runCapabilityDoctor()`
  *    but previously only surfaced a count toast — the per-provider
  *    per-capability results were thrown away.
- *  - This slice captures those results into a per-provider state map
- *    and renders failures inline. NO new backend route, NO snapshot
- *    model restructure, NO change to the global provider "enabled" pill.
- *  - A full capability-health dashboard remains carry-forward.
+ *  - The persisted dashboard is now backed by /v1/providers/capability-health,
+ *    while the just-ran doctor result still renders inline until query
+ *    invalidation completes. The global provider "enabled" pill remains only
+ *    enabled/disabled.
  */
 
 const SETTINGS_PAGE_PATH = "ui/src/routes/settings-page.tsx" as const;
+const PROVIDERS_API_PATH = "ui/src/lib/api/providers.ts" as const;
 const PROVIDER_SERVICE_PATH = "src/providers/services/friday-provider-service.ts" as const;
 
 describe("provider capability-lane truth-label surface (B7 / FRI-AUD-012/013/014/017)", () => {
   const settingsSource = readFileSync(SETTINGS_PAGE_PATH, "utf8");
+  const providersApiSource = readFileSync(PROVIDERS_API_PATH, "utf8");
   const providerServiceSource = readFileSync(PROVIDER_SERVICE_PATH, "utf8");
 
   it("Test 1: backend doctor-probe still returns lane-specific reasons for the audit's named failures", () => {
@@ -95,18 +97,20 @@ describe("provider capability-lane truth-label surface (B7 / FRI-AUD-012/013/014
     expect(settingsSource).not.toContain("fully verified across all capabilities");
   });
 
-  it("Test 6: anchored to the audit findings via comment", () => {
+  it("Test 6: persisted capability-health dashboard uses a backend snapshot route", () => {
+    expect(providersApiSource).toContain('"/v1/providers/capability-health"');
+    expect(providersApiSource).toContain("listCapabilityHealth");
+    expect(settingsSource).toContain('queryKey: ["settings", "provider-capability-health"]');
+    expect(settingsSource).toContain('data-testid="provider-capability-health-dashboard"');
+    expect(settingsSource).toContain("labelForProviderCapabilityHealthState");
+    expect(settingsSource).toContain("setup_needed");
+    expect(settingsSource).toContain("proof_pending");
+  });
+
+  it("Test 7: anchored to the audit findings via comment", () => {
     expect(settingsSource).toContain("B7 / FRI-AUD-012/013/014/017 minimal UI lane-truth surface");
     // Tolerate `// ` line continuation between adjacent comment lines.
     expect(settingsSource).toMatch(/Backend doctor-probe\s+\/\/\s+already returns lane-specific truth-labels/);
-    expect(settingsSource).toContain("full capability-health dashboard");
-    expect(settingsSource).toContain("carry-forward");
-  });
-
-  it("Test 7: no new backend aggregation route was added (constraint preservation)", () => {
-    // Asserting absence of the routes the user explicitly said NOT to add.
-    expect(settingsSource).not.toContain("/v1/providers/capability-health");
-    expect(settingsSource).not.toContain("/v1/providers/lane-health");
-    expect(settingsSource).not.toContain("capabilityHealthSnapshot");
+    expect(settingsSource).toContain("backend-snapshot");
   });
 });

--- a/ui/src/lib/api/providers.ts
+++ b/ui/src/lib/api/providers.ts
@@ -12,6 +12,7 @@ import type {
   FridayProviderBackendKind,
   FridayProviderCliConfig,
   FridayProviderDoctorReport,
+  FridayProviderCapabilityHealthSnapshotItem,
   FridayProviderHealthSnapshotItem,
   FridayProviderRuntimeCapabilityDeclaration,
   FridayProviderRoutingExplainReport,
@@ -86,6 +87,17 @@ interface GetProviderResponse {
 
 interface GetProviderHealthSnapshotResponse {
   items: FridayProviderHealthSnapshotItem[];
+}
+
+interface GetProviderCapabilityHealthSnapshotResponse {
+  items: FridayProviderCapabilityHealthSnapshotItem[];
+  summary: {
+    available: number;
+    setupNeeded: number;
+    proofPending: number;
+    disabled: number;
+    unsupported: number;
+  };
 }
 
 interface RunCapabilityDoctorResponse {
@@ -226,6 +238,13 @@ export const providersApi = {
 
   async listHealth(): Promise<FridayProviderHealthSnapshotItem[]> {
     const data = await apiClient.get<GetProviderHealthSnapshotResponse>("/v1/providers/health");
+    return data.items;
+  },
+
+  async listCapabilityHealth(): Promise<FridayProviderCapabilityHealthSnapshotItem[]> {
+    const data = await apiClient.get<GetProviderCapabilityHealthSnapshotResponse>(
+      "/v1/providers/capability-health",
+    );
     return data.items;
   },
 

--- a/ui/src/lib/api/types.ts
+++ b/ui/src/lib/api/types.ts
@@ -2128,6 +2128,34 @@ export interface FridayProviderHealthSnapshotItem {
   suggestedAction: string;
 }
 
+export type FridayProviderCapabilityHealthState =
+  | "available"
+  | "setup_needed"
+  | "proof_pending"
+  | "disabled"
+  | "unsupported";
+
+export interface FridayProviderCapabilityHealthCapabilityItem {
+  capability: FridayRuntimeCapabilityId;
+  model?: string;
+  state: FridayProviderCapabilityHealthState;
+  source: "runtime_capability_snapshot" | "provider_health_snapshot" | "declared_configuration";
+  message: string;
+  blockerCodes: string[];
+  checkedAt?: string;
+  lastVerifiedAt?: string;
+}
+
+export interface FridayProviderCapabilityHealthSnapshotItem {
+  providerId: string;
+  providerKind: FridayProviderKind;
+  providerName: string;
+  lane: "primary" | "fallback" | "standby" | "disabled";
+  enabled: boolean;
+  validationStatus: "never" | "ok" | "failed";
+  capabilities: FridayProviderCapabilityHealthCapabilityItem[];
+}
+
 export interface FridayModelRoutingConfig {
   defaultProviderId: string;
   defaultModel?: string;

--- a/ui/src/routes/settings-page.tsx
+++ b/ui/src/routes/settings-page.tsx
@@ -17,7 +17,7 @@ import { ChannelConfigForm } from "@/components/core/channel-config-form";
 import { DiscoveryPanel } from "@/components/core/discovery-panel";
 import { CHANNEL_META } from "@/lib/channels/channel-meta";
 import type { ChannelKind } from "@/lib/setup/types";
-import { type FridayModelRoutingConfig, type FridayProviderKind, type FridayProviderProfile, type FridayRuntimeCapabilityId, type FridayRuntimeCapabilityState, ApiError } from "@/lib/api/types";
+import { type FridayModelRoutingConfig, type FridayProviderCapabilityHealthState, type FridayProviderKind, type FridayProviderProfile, type FridayRuntimeCapabilityId, type FridayRuntimeCapabilityState, ApiError } from "@/lib/api/types";
 import { assistantDiagnosticsApi } from "@/lib/api/assistant-diagnostics";
 import { channelsApi } from "@/lib/api/channels";
 import { healthApi } from "@/lib/api/health";
@@ -272,6 +272,29 @@ function toneForCapabilityState(value: FridayRuntimeCapabilityState): "neutral" 
   return "neutral";
 }
 
+function toneForProviderCapabilityHealthState(
+  value: FridayProviderCapabilityHealthState,
+): "neutral" | "success" | "warning" | "danger" {
+  if (value === "available") return "success";
+  if (value === "proof_pending" || value === "setup_needed") return "warning";
+  if (value === "disabled" || value === "unsupported") return "neutral";
+  return "neutral";
+}
+
+function labelForProviderCapabilityHealthState(
+  locale: AppLocale,
+  value: FridayProviderCapabilityHealthState,
+): string {
+  const labels: Record<FridayProviderCapabilityHealthState, string> = {
+    available: localize(locale, "可用", "available"),
+    setup_needed: localize(locale, "需配置", "setup needed"),
+    proof_pending: localize(locale, "待证明", "proof pending"),
+    disabled: localize(locale, "已停用", "disabled"),
+    unsupported: localize(locale, "不支持", "unsupported"),
+  };
+  return labels[value];
+}
+
 function labelForCapabilityState(locale: AppLocale, value: FridayRuntimeCapabilityState): string {
   const labels: Record<FridayRuntimeCapabilityState, string> = {
     available: localize(locale, "可用", "available"),
@@ -374,6 +397,13 @@ export function SettingsPage() {
   const { data: providerHealth = [] } = useQuery({
     queryKey: ["settings", "provider-health"],
     queryFn: () => providersApi.listHealth(),
+    retry: 0,
+    refetchInterval: 15_000,
+  });
+
+  const { data: providerCapabilityHealth = [] } = useQuery({
+    queryKey: ["settings", "provider-capability-health"],
+    queryFn: () => providersApi.listCapabilityHealth(),
     retry: 0,
     refetchInterval: 15_000,
   });
@@ -506,6 +536,7 @@ export function SettingsPage() {
     await Promise.all([
       queryClient.invalidateQueries({ queryKey: ["settings", "providers"] }),
       queryClient.invalidateQueries({ queryKey: ["settings", "provider-health"] }),
+      queryClient.invalidateQueries({ queryKey: ["settings", "provider-capability-health"] }),
       queryClient.invalidateQueries({ queryKey: ["settings", "routing-config"] }),
       queryClient.invalidateQueries({ queryKey: ["settings", "routing-explain"] }),
       queryClient.invalidateQueries({ queryKey: ["shell", "provider-truth"] }),
@@ -712,9 +743,9 @@ export function SettingsPage() {
   // wired, etc.) — we just stop throwing that data away in favor of a
   // toast count. The global provider pill semantics are unchanged. The
   // advisory only appears for lanes whose status !== "verified".
-  // Per the 2026-05-26 operator directive: full capability-health dashboard
-  // remains carry-forward; this slice does NOT add a new backend route or
-  // restructure the snapshot model.
+  // The persisted capability-health dashboard below is backend-snapshot
+  // driven; this transient map only keeps the latest just-ran doctor output
+  // visible before query invalidation completes.
   type ProviderLaneAdvisory = {
     capability: FridayRuntimeCapabilityId;
     status: "verified" | "declared" | "failed" | "unsupported";
@@ -751,6 +782,7 @@ export function SettingsPage() {
         queryClient.invalidateQueries({ queryKey: ["settings", "health"] }),
         queryClient.invalidateQueries({ queryKey: ["settings", "providers"] }),
         queryClient.invalidateQueries({ queryKey: ["settings", "provider-health"] }),
+        queryClient.invalidateQueries({ queryKey: ["settings", "provider-capability-health"] }),
       ]);
     },
     onError: (error) => {
@@ -1235,6 +1267,7 @@ export function SettingsPage() {
                   {(() => {
                     const template = providerTemplates.find((item) => item.providerKind === provider.kind);
                     const healthItem = providerHealth.find((item) => item.providerId === provider.id);
+                    const capabilityHealthItem = providerCapabilityHealth.find((item) => item.providerId === provider.id);
                     const remediationVerdict = healthItem
                       ? classifyFridayProviderDoctorRemediation({
                           enabled: provider.enabled,
@@ -1290,6 +1323,39 @@ export function SettingsPage() {
                   ) : null}
                   {healthItem?.suggestedAction ? (
                     <p className="mt-2 text-xs text-[color:var(--color-text-secondary)]">{healthItem.suggestedAction}</p>
+                  ) : null}
+                  {capabilityHealthItem?.capabilities.length ? (
+                    <div data-testid="provider-capability-health-dashboard" className="mt-3 rounded-2xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] p-3">
+                      <div className="flex items-center justify-between gap-3">
+                        <p className="text-sm font-semibold text-[color:var(--color-text-primary)]">
+                          {localize(locale, "能力健康", "Capability health")}
+                        </p>
+                        <StatusPill tone={toneForProviderLane(capabilityHealthItem.lane)}>
+                          {capabilityHealthItem.lane}
+                        </StatusPill>
+                      </div>
+                      <ul className="mt-2 space-y-2">
+                        {capabilityHealthItem.capabilities.map((capability) => (
+                          <li key={`${capability.capability}-${capability.model ?? "any"}`} className="text-xs">
+                            <div className="flex flex-wrap items-center gap-2">
+                              <StatusPill tone={toneForProviderCapabilityHealthState(capability.state)}>
+                                {labelForProviderCapabilityHealthState(locale, capability.state)}
+                              </StatusPill>
+                              <span className="font-medium text-[color:var(--color-text-primary)]">
+                                {capability.capability}{capability.model ? ` · ${capability.model}` : ""}
+                              </span>
+                              <span className="text-[color:var(--color-text-faint)]">{capability.source}</span>
+                            </div>
+                            <p className="mt-1 leading-5 text-[color:var(--color-text-secondary)]">{capability.message}</p>
+                            {capability.lastVerifiedAt ? (
+                              <p className="mt-1 text-[10px] text-[color:var(--color-text-faint)]">
+                                {localize(locale, "上次证明：", "Last proof: ")}{formatTimestamp(capability.lastVerifiedAt)}
+                              </p>
+                            ) : null}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
                   ) : null}
                   {/*
                    * B7 / FRI-AUD-012/013/014/017 minimal lane-truth surface:


### PR DESCRIPTION
## Summary
- add a read-only provider capability-health snapshot route backed by persisted provider health/runtime capability truth
- render the Settings provider capability-health dashboard with available/setup_needed/proof_pending/disabled/unsupported labels
- keep the just-ran capability doctor lane advisory while proving the snapshot route does not run live probes or hide spend

## Proof
- npm test -- test/unit/providers/api/friday-provider-routes.test.ts test/unit/ui/provider-capability-lane-truth-label.test.ts
- npm test -- test/unit/providers/services/friday-provider-service.test.ts test/unit/providers/api/friday-provider-routes.test.ts test/unit/ui/provider-capability-lane-truth-label.test.ts test/unit/ui/usage-page.test.ts
- npm run typecheck
- npm run build:api
- npm run build:ui
- npm run lint (0 errors, existing warnings)
- git diff --check
- secret-pattern diff scan: no real secret, only test literal api-key enum

## Boundaries
- no live provider spend or live capability probe is triggered by the new GET snapshot route
- no npm publish, GitHub settings/secrets, production credentials, or destructive data mutation