### PR TITLE
fix(phase24e): extend operator-message window to 30 min total

### DIFF
--- a/.github/workflows/real-green-gate.yml
+++ b/.github/workflows/real-green-gate.yml
@@ -266,14 +266,14 @@ jobs:
   phase24e-telegram-workflow-candidate:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.phase24e_telegram_workflow_candidate == true }}
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 45
     environment: phase-24-live-channels
     env:
       FRIDAY_TELEGRAM_BOT_TOKEN: ${{ secrets.FRIDAY_TELEGRAM_BOT_TOKEN }}
       FRIDAY_TELEGRAM_CHAT_ID: ${{ secrets.FRIDAY_TELEGRAM_CHAT_ID || vars.FRIDAY_TELEGRAM_CHAT_ID }}
       FRIDAY_TELEGRAM_ALLOWED_USER_ID: ${{ secrets.FRIDAY_TELEGRAM_ALLOWED_USER_ID || vars.FRIDAY_TELEGRAM_ALLOWED_USER_ID }}
       FRIDAY_TELEGRAM_MODE: ${{ secrets.FRIDAY_TELEGRAM_MODE || vars.FRIDAY_TELEGRAM_MODE }}
-      PHASE24E_TELEGRAM_LISTENER_TIMEOUT_MS: "720000"
+      PHASE24E_TELEGRAM_LISTENER_TIMEOUT_MS: "1800000"
       PHASE24E_TELEGRAM_POLLING_TIMEOUT_SEC: "5"
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Summary

The first Phase24E live dispatch on \`33ee3ee8\` (run \`26540963806\`) blocked at \`PHASE24E_WAITING_FOR_REJECT_ACK\` because the listener's per-flow timeout is \`max(60_000, timeoutMs/2)\`. With \`PHASE24E_TELEGRAM_LISTENER_TIMEOUT_MS=720000\` (12 min total) that's only 6 minutes per message — too tight for a real operator coordinating across two acks (reject, then approve after the reject ack arrives).

Bump:
- \`PHASE24E_TELEGRAM_LISTENER_TIMEOUT_MS\`: 720000 (12 min) → 1800000 (30 min). Per-flow window goes from 6 min to 15 min.
- Job-level \`timeout-minutes\`: 25 → 45 to match.

No listener code change. No claim widening. The listener still fails closed on missing operator messages, just with comfortable slack.

## Diagnostic from the first run

\`phase24e-telegram-workflow-candidate-26540963806\` artifact:
- \`status=blocked\`, \`blocker=PHASE24E_WAITING_FOR_REJECT_ACK\`
- \`criteria.pollingConnected=true\`, \`fridayHubChannelConnected=true\`, \`channelAllowListEnforced=true\`, \`rejectCandidateSeeded=true\`
- Listener printed \`PHASE24E_TELEGRAM_LISTENER_READY\` at T+85s, ack timeout at T+360s
- The fix commit \`dd582370\` for Reviewer A's blocking findings on PR #365 was confirmed working: the DB-direct candidate read and the allowlist summary check both pass at runtime.

## Test plan

- [x] YAML parses
- [x] Diff is exactly two integer-edit changes in one file
- [ ] PR CI: build, test, security, contracts, agent-parity, ssd-lint, alignment-guard, migrations, secrets, quality-gate
- [ ] PR Real Green Gate green (phase24b/c/d/e skipped on push)
- [ ] Post-merge main CI/RGG green
- [ ] Post-merge \`workflow_dispatch\` with operator nonces → validator \`valid:true blockerClass:none expected_sha:<merge-sha>\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)