### PR TITLE
fix(phase24e): delete any stale Telegram webhook before polling

### DIFF
--- a/scripts/ops/phase24e-telegram-workflow-candidate-listener.mjs
+++ b/scripts/ops/phase24e-telegram-workflow-candidate-listener.mjs
@@ -707,12 +707,13 @@ async function main() {
 
     // Defensive: clear any pre-existing Telegram webhook so polling
     // can see updates. If a previous run (or another agent / dev env)
-    // set a webhook on this bot, getUpdates polling silently returns
-    // zero updates (Telegram routes incoming events to the webhook
-    // instead). The first phase24E live dispatch on 2ca1c30b
-    // (run 26543400522) blocked with updateCount=0 for this exact
-    // reason — even though the operator did send the reject text,
-    // the polling loop saw nothing.
+    // set a webhook on this bot, getUpdates polling cannot receive
+    // updates because Telegram routes incoming events to the webhook
+    // instead. Earlier phase24E live dispatches blocked with
+    // updateCount=0 after the operator sent the reject text; clearing
+    // any stale webhook makes this known Telegram polling conflict
+    // self-recovering, while the artifact still refuses to pass unless
+    // the live inbound/ack/status criteria below are observed.
     //
     // `drop_pending_updates=false` (default) preserves whatever updates
     // Telegram queued before this dispatch started polling. Earlier the

--- a/scripts/ops/phase24e-telegram-workflow-candidate-listener.mjs
+++ b/scripts/ops/phase24e-telegram-workflow-candidate-listener.mjs
@@ -661,6 +661,50 @@ async function main() {
       },
     });
 
+    // Bot-token health check + webhook-info snapshot, both recorded
+    // to the artifact so a future "polling sees nothing" run has
+    // enough diagnostic context to root-cause in one read. Failures
+    // are non-fatal at this step (we still try to clear the webhook
+    // below); if everything is wrong, the downstream
+    // `pollingConnected` / `updateCount` criteria still gate closure.
+    await fetch(`https://api.telegram.org/bot${encodeURIComponent(config.botToken)}/getMe`, {
+      method: "GET",
+    }).then(async (response) => {
+      if (!response.ok) {
+        throw new Error(`Telegram getMe returned HTTP ${response.status}`);
+      }
+      const body = await response.json().catch(() => null);
+      if (body && body.ok === true && body.result) {
+        report.diagnostics.telegramHubAdapter.botTokenValid = true;
+        report.diagnostics.telegramHubAdapter.botUsername = body.result.username ?? null;
+        report.diagnostics.telegramHubAdapter.botIdTail = tail(body.result.id);
+        report.diagnostics.telegramHubAdapter.botCanReadAllGroupMessages = body.result.can_read_all_group_messages ?? null;
+      } else {
+        throw new Error(`Telegram getMe returned ok=false: ${body?.description ?? "unknown"}`);
+      }
+    }).catch((err) => {
+      report.diagnostics.telegramHubAdapter.botTokenValid = false;
+      report.diagnostics.telegramHubAdapter.botHealthError = safeError(err, config.botToken);
+    });
+
+    await fetch(`https://api.telegram.org/bot${encodeURIComponent(config.botToken)}/getWebhookInfo`, {
+      method: "GET",
+    }).then(async (response) => {
+      if (!response.ok) {
+        throw new Error(`Telegram getWebhookInfo returned HTTP ${response.status}`);
+      }
+      const body = await response.json().catch(() => null);
+      if (body && body.ok === true && body.result) {
+        report.diagnostics.telegramHubAdapter.webhookInfoBeforeCleanup = {
+          urlPresent: typeof body.result.url === "string" && body.result.url.length > 0,
+          pendingUpdateCount: body.result.pending_update_count ?? 0,
+          lastErrorDate: body.result.last_error_date ?? null,
+        };
+      }
+    }).catch((err) => {
+      report.diagnostics.telegramHubAdapter.webhookInfoError = safeError(err, config.botToken);
+    });
+
     // Defensive: clear any pre-existing Telegram webhook so polling
     // can see updates. If a previous run (or another agent / dev env)
     // set a webhook on this bot, getUpdates polling silently returns

--- a/scripts/ops/phase24e-telegram-workflow-candidate-listener.mjs
+++ b/scripts/ops/phase24e-telegram-workflow-candidate-listener.mjs
@@ -661,6 +661,39 @@ async function main() {
       },
     });
 
+    // Defensive: clear any pre-existing Telegram webhook so polling
+    // can see updates. If a previous run (or another agent / dev env)
+    // set a webhook on this bot, getUpdates polling silently returns
+    // zero updates (Telegram routes incoming events to the webhook
+    // instead). The first phase24E live dispatch on 2ca1c30b
+    // (run 26543400522) blocked with updateCount=0 for this exact
+    // reason — even though the operator did send the reject text,
+    // the polling loop saw nothing.
+    //
+    // `drop_pending_updates=true` clears whatever events Telegram
+    // queued while a webhook was active, so the listener starts from
+    // a clean state and the operator's NEW messages drive the run.
+    await fetch(`https://api.telegram.org/bot${encodeURIComponent(config.botToken)}/deleteWebhook?drop_pending_updates=true`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    }).then(async (response) => {
+      if (!response.ok) {
+        const text = await response.text().catch(() => "");
+        throw new Error(`Telegram deleteWebhook returned HTTP ${response.status}${text ? ` — ${text.slice(0, 200)}` : ""}`);
+      }
+      const body = await response.json().catch(() => null);
+      if (body && body.ok !== true) {
+        throw new Error(`Telegram deleteWebhook returned ok=false: ${body.description ?? "unknown"}`);
+      }
+      report.diagnostics.telegramHubAdapter.webhookClearedBeforePolling = true;
+    }).catch((err) => {
+      // Do not fail-closed on this defensive step; record the failure
+      // and continue. If the bot really has a webhook set the
+      // downstream updateCount=0 will surface the same blocker as
+      // before, with a clearer diagnostic.
+      report.diagnostics.telegramHubAdapter.webhookCleanupError = safeError(err, config.botToken);
+    });
+
     const instrumentedPolling = createInstrumentedTelegramPollingService(config, report, observedEventsByMessageId);
     const telegramPlugin = createFridayTelegramChannel({
       polling: instrumentedPolling,

--- a/scripts/ops/phase24e-telegram-workflow-candidate-listener.mjs
+++ b/scripts/ops/phase24e-telegram-workflow-candidate-listener.mjs
@@ -714,10 +714,21 @@ async function main() {
     // reason — even though the operator did send the reject text,
     // the polling loop saw nothing.
     //
-    // `drop_pending_updates=true` clears whatever events Telegram
-    // queued while a webhook was active, so the listener starts from
-    // a clean state and the operator's NEW messages drive the run.
-    await fetch(`https://api.telegram.org/bot${encodeURIComponent(config.botToken)}/deleteWebhook?drop_pending_updates=true`, {
+    // `drop_pending_updates=false` (default) preserves whatever updates
+    // Telegram queued before this dispatch started polling. Earlier the
+    // listener used `drop_pending_updates=true` to clear noise from any
+    // webhook-era backlog, but that turned into a coordination footgun
+    // for the live operator loop: when the operator sent the prompted
+    // text just before the next dispatch's `deleteWebhook` call (or
+    // before listener boot completed), their already-queued message
+    // got dropped. By keeping pending updates the next polling cycle
+    // drains them through the normal trusted-user / allowed-chat /
+    // command-prefix filter. Stale pending events for *previous*
+    // dispatches' candidate IDs surface as "处理失败" acks (hub
+    // responds when the candidate ID is unknown), which the listener
+    // correctly does NOT accept as `已更新为 rejected` — so dropping
+    // the flag does not lower the closure bar.
+    await fetch(`https://api.telegram.org/bot${encodeURIComponent(config.botToken)}/deleteWebhook`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
     }).then(async (response) => {


### PR DESCRIPTION
## Summary

Phase24E live Telegram workflow-candidate proof still has no validated live artifact. The latest attempted dispatch (run `26545981559` on `c98aab86`) reached `PHASE24E_TELEGRAM_LISTENER_READY`, started polling, confirmed the bot token, observed no pre-cleanup webhook URL and no pending updates, then timed out with `updateCount=0` / no reject ack. Without a durable operator-send confirmation for that run, this is classified as an operator-coordination timeout, not proof of a Telegram code bug.

This PR keeps the listener defensive for a known Telegram polling conflict: before starting polling, it records bot/webhook diagnostics and POSTs `deleteWebhook` with the default `drop_pending_updates=false`. That clears any stale webhook that would prevent `getUpdates` polling from receiving updates, while preserving already-queued operator messages for the current dispatch.

## Scope

Changed file: `scripts/ops/phase24e-telegram-workflow-candidate-listener.mjs`.

The listener now records:

- bot-token health (`getMe`) without secret values
- pre-cleanup webhook info (`urlPresent`, `pendingUpdateCount`, `lastErrorDate`)
- whether `deleteWebhook` succeeded before polling

It does not relax the proof bar. The artifact still cannot validate unless live inbound reject/approve messages are observed, channel acks are delivered, candidate statuses change, approve saves through workflow CRUD, reject does not save, and `artifactHasNoToken=true`.

## Safety / Truth Boundary

- No token values are printed or stored; report serialization still scrubs and rejects token material.
- PR/push RGG phase24 live-channel jobs are expected to be skipped and are not counted as live proof.
- `workflowGeneratorApproveAndSaveStubbed=true` remains explicit; this proves channel-driven workflow-candidate approve/reject CRUD only, not live LLM generation.
- Attempt-5 remains blocked/no live proof: `PHASE24E_WAITING_FOR_REJECT_ACK`, `updateCount=0`, `rejectInboundObserved=false`, `rejectAckDelivered=false`.

## Test plan

- [x] `node --check scripts/ops/phase24e-telegram-workflow-candidate-listener.mjs`
- [x] `npm run lint -- --quiet scripts/ops/phase24e-telegram-workflow-candidate-listener.mjs`
- [x] `git diff --check`
- [x] PR CI/RGG previously green at `c98aab86`; new claim-only commit `5d18358b` requires fresh PR CI/RGG
- [ ] After merge and post-merge CI/RGG, run one merged-main `workflow_dispatch` only with operator ready to send within 3 minutes
- [ ] Validate Phase24E artifact against the merged SHA with `valid:true` and `blockerClass:none` before updating Friday Map truth
