### PR TITLE
fix(phase24f): accept Discord bot mention around Reflex commands

### DIFF
--- a/scripts/ops/phase24f-discord-workflow-candidate-listener.mjs
+++ b/scripts/ops/phase24f-discord-workflow-candidate-listener.mjs
@@ -18,6 +18,7 @@ import {
   createDiscordRestService,
   createFridayDiscordChannel,
   normalizeDiscordMessageCreate,
+  stripDiscordBotMention,
 } from "#channels";
 import { createFridayHub } from "#hub";
 
@@ -134,8 +135,11 @@ function inspectDiscordPayload(payload, config, receivedAtMs = Date.now()) {
   const authorBotFalse = payload?.author?.bot !== true;
   const senderMatched = payload?.author?.id === config.setupUserId;
   const channelMatched = payload?.channel_id === config.channelId;
-  const containsRejectCommand = content.startsWith("reject reflex");
-  const containsApproveCommand = content.startsWith("approve reflex");
+  const commandContent = config.requireMention
+    ? stripDiscordBotMention(content, config.botUserId)
+    : content;
+  const containsRejectCommand = commandContent.startsWith("reject reflex");
+  const containsApproveCommand = commandContent.startsWith("approve reflex");
   const containsRejectNonce = content.includes(config.rejectNonce);
   let normalized = null;
   if (payload?.id && payload?.author) {
@@ -220,19 +224,21 @@ function recordDiscordMessageCreate(report, observedEventsByMessageId, payload, 
   return inspection;
 }
 
-function createInstrumentedDiscordGatewayService(config, report, observedEventsByMessageId) {
+function createInstrumentedDiscordGatewayService(config, report, observedEventsByMessageId, persistReport) {
   const gateway = createDiscordGatewayService();
   return {
     async connect(token, intents, onEvent, onStatusChange) {
       await gateway.connect(token, intents, (event) => {
         if (event?.t === "MESSAGE_CREATE") {
           recordDiscordMessageCreate(report, observedEventsByMessageId, event.d, config);
+          void persistReport("discord_message_create").catch(() => {});
         }
         onEvent(event);
       }, (status) => {
         const connected = status === "connected" || gateway.isConnected();
         report.criteria.gatewayConnected = connected;
         report.diagnostics.discordHubAdapter.gatewayConnected = connected;
+        void persistReport("discord_gateway_status").catch(() => {});
         if (onStatusChange) onStatusChange(status);
       });
       report.criteria.gatewayConnected = gateway.isConnected();
@@ -347,10 +353,23 @@ async function writeReport(report, token) {
   await fs.writeFile(report.reportPath, serialized, "utf8");
 }
 
+function createReportPersister(report, token) {
+  let writeChain = Promise.resolve();
+  return (reason) => {
+    report.diagnostics.lastReportUpdateReason = reason;
+    report.diagnostics.lastReportUpdatedAt = new Date().toISOString();
+    writeChain = writeChain
+      .catch(() => {})
+      .then(() => writeReport(report, token));
+    return writeChain;
+  };
+}
+
 async function main() {
   const config = readEnvConfig();
   const reportPath = resolveReportPath();
   const report = initialReport(config, reportPath);
+  const persistReport = createReportPersister(report, config.botToken);
   let hub;
   let server;
   let stateDir = "";
@@ -380,7 +399,7 @@ async function main() {
       channels: { enabled: false, instances: [] },
     });
 
-    const instrumentedGateway = createInstrumentedDiscordGatewayService(config, report, observedEventsByMessageId);
+    const instrumentedGateway = createInstrumentedDiscordGatewayService(config, report, observedEventsByMessageId, persistReport);
     const discordPlugin = createFridayDiscordChannel({
       gateway: instrumentedGateway,
       rest: createDiscordRestService(),
@@ -443,7 +462,7 @@ async function main() {
     report.approveFlow.candidateIdTail = tail(approveCandidateId);
     installWorkflowApprovalStub(hub, harnessConfig, generatorSessionId, approvedSlot);
 
-    await writeReport(report, config.botToken);
+    await persistReport("listener_ready");
 
     const rejectText = buildRejectOperatorMessage(rejectCandidateId, config);
     const approveText = buildApproveOperatorMessage(approveCandidateId, config);
@@ -478,6 +497,7 @@ async function main() {
     report.criteria.requireMentionSatisfied = !config.requireMention || Boolean(
       [...observedEventsByMessageId.values()].find((entry) => entry?.inspection?.mentionMatched),
     );
+    await persistReport("reject_flow_verified");
 
     if (!report.criteria.rejectCandidateStatusRejected || !report.criteria.rejectDidNotSaveWorkflow) {
       report.status = "failed";

--- a/src/channels/discord/friday-discord-channel.ts
+++ b/src/channels/discord/friday-discord-channel.ts
@@ -94,6 +94,10 @@ export function normalizeDiscordMessageCreate(
     if (!mentioned) return null;
   }
 
+  const content = requireMention && botUserId
+    ? stripDiscordBotMention(payload.content, botUserId)
+    : payload.content;
+
   const isDm = !payload.guild_id;
   const images: string[] = [];
   if (payload.attachments) {
@@ -117,13 +121,26 @@ export function normalizeDiscordMessageCreate(
     senderName: payload.author.username,
     chatId: payload.channel_id,
     chatType: isDm ? "direct" : "group",
-    text: payload.content,
+    text: content,
     images: images.length > 0 ? images : undefined,
     replyTo: payload.message_reference?.message_id,
     threadId,
     timestamp: new Date(payload.timestamp).getTime(),
     raw: payload,
   };
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function stripDiscordBotMention(content: string, botUserId: string): string {
+  const escapedBotUserId = escapeRegExp(botUserId);
+  const mention = `<@!?${escapedBotUserId}>`;
+  return content
+    .replace(new RegExp(`^(?:\\s*${mention}\\s*)+`, "u"), "")
+    .replace(new RegExp(`(?:\\s*${mention}\\s*)+$`, "u"), "")
+    .trim();
 }
 
 // ─── Factory ───

--- a/src/channels/discord/index.ts
+++ b/src/channels/discord/index.ts
@@ -1,4 +1,4 @@
-export { createFridayDiscordChannel, normalizeDiscordMessageCreate } from "./friday-discord-channel.js";
+export { createFridayDiscordChannel, normalizeDiscordMessageCreate, stripDiscordBotMention } from "./friday-discord-channel.js";
 export type { DiscordChannelDeps } from "./friday-discord-channel.js";
 export { FridayDiscordChannelConfigSchema } from "./discord-config.schema.js";
 export type { FridayDiscordChannelConfig } from "./discord-config.schema.js";

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -127,7 +127,7 @@ export { createLarkWebhookRelayService, validateLarkWebhookSignature } from "./l
 export type { LarkWebhookRelayService, LarkWebhookRelayResult } from "./lark/lark-webhook-relay.js";
 
 // Discord
-export { createFridayDiscordChannel, normalizeDiscordMessageCreate } from "./discord/friday-discord-channel.js";
+export { createFridayDiscordChannel, normalizeDiscordMessageCreate, stripDiscordBotMention } from "./discord/friday-discord-channel.js";
 export type { DiscordChannelDeps } from "./discord/friday-discord-channel.js";
 export { FridayDiscordChannelConfigSchema } from "./discord/discord-config.schema.js";
 export type { FridayDiscordChannelConfig } from "./discord/discord-config.schema.js";

--- a/test/unit/channels/discord/friday-discord-channel.test.ts
+++ b/test/unit/channels/discord/friday-discord-channel.test.ts
@@ -227,6 +227,21 @@ describe("FridayDiscordChannel", () => {
       expect(result).not.toBeNull();
     });
 
+    it("strips required bot mentions at command boundaries", () => {
+      const payload: DiscordMessageCreatePayload = {
+        id: "msg-1",
+        channel_id: "ch-1",
+        guild_id: "g-1",
+        author: { id: "user-1", username: "User", bot: false },
+        content: "<@bot-id-1> approve reflex candidate-1 <@bot-id-1>",
+        timestamp: "2026-02-21T12:00:00.000Z",
+        mentions: [{ id: "bot-id-1" }],
+      };
+
+      const result = normalizeDiscordMessageCreate(payload, true, "bot-id-1");
+      expect(result?.text).toBe("approve reflex candidate-1");
+    });
+
     it("extracts image attachments", () => {
       const payload: DiscordMessageCreatePayload = {
         id: "img-msg",

--- a/test/unit/scripts/ops/phase24f-discord-workflow-candidate.test.ts
+++ b/test/unit/scripts/ops/phase24f-discord-workflow-candidate.test.ts
@@ -142,6 +142,43 @@ describe("phase24f Discord workflow-candidate listener exports", () => {
     expect(listener.inspectDiscordPayload(messagePayload({ mentions: [] }), config).rawTargetMatched).toBe(false);
   });
 
+  it("diagnoses approve commands that miss the required bot mention", async () => {
+    const listener = await loadListener();
+    const config = baseConfig();
+    const inspection = listener.inspectDiscordPayload(
+      messagePayload({
+        content: "approve reflex phase24f-approve-run-123",
+        mentions: [],
+      }),
+      config,
+      Date.parse("2026-05-28T00:00:02Z"),
+    );
+
+    expect(inspection.containsApproveCommand).toBe(true);
+    expect(inspection.mentionMatched).toBe(false);
+    expect(inspection.normalizerAccepted).toBe(false);
+    expect(inspection.rawTargetMatched).toBe(false);
+  });
+
+  it("accepts approve commands when the required bot mention is placed first", async () => {
+    const listener = await loadListener();
+    const config = baseConfig();
+    const inspection = listener.inspectDiscordPayload(
+      messagePayload({
+        content: "<@bot-1> approve reflex phase24f-approve-run-123",
+        mentions: [{ id: "bot-1" }],
+      }),
+      config,
+      Date.parse("2026-05-28T00:00:02Z"),
+    );
+
+    expect(inspection.containsApproveCommand).toBe(true);
+    expect(inspection.mentionMatched).toBe(true);
+    expect(inspection.normalizerAccepted).toBe(true);
+    expect(inspection.normalized).toMatchObject({ text: "approve reflex phase24f-approve-run-123" });
+    expect(inspection.rawTargetMatched).toBe(true);
+  });
+
   it("initialReport carries the Phase24F schema and seeds artifactHasNoToken false", async () => {
     const listener = await loadListener();
     const report = listener.initialReport(baseConfig(), "/tmp/phase24f.json");


### PR DESCRIPTION
## Summary
- Strip the configured Discord bot mention from the beginning or end of normalized Discord text after requireMention has already matched.
- Update Phase24F diagnostics so prefix/suffix mention commands are recognized as approve/reject attempts.
- Persist Phase24F proof artifacts at READY, gateway/message events, and after reject verification so cancelled/blocked runs keep useful diagnostics.

## Verification
- npm test -- test/unit/scripts/ops/phase24f-discord-workflow-candidate.test.ts test/unit/channels/discord/friday-discord-channel.test.ts
- npm run build:api
- npm run lint -- --quiet
- npm run check:secret-patterns
- npm run check:proof:no-mock-leaks
- git diff --check

## Live failure diagnosis
Run 26554132477 reached ordinary agent routing after the approve message, producing `No model routing configured` instead of the Reflex ack/error prefix. With `FRIDAY_DISCORD_REQUIRE_MENTION=true`, that means the message likely passed mention filtering but the command parser did not see `approve reflex` at the start of normalized text. This patch keeps the mention requirement but makes common Discord mention placement (`@bot approve reflex ...` or `approve reflex ... @bot`) route to Reflex.