### PR TITLE
fix(phase24h): use hub API memory service

### DIFF
--- a/scripts/ops/phase24h-telegram-natural-trigger-listener.mjs
+++ b/scripts/ops/phase24h-telegram-natural-trigger-listener.mjs
@@ -398,6 +398,18 @@ async function configureDeepSeek(hub, config, report) {
   return provider;
 }
 
+export function resolveHubMemoryService(hub) {
+  const memoryService = hub?.memoryService ?? hub?.apiRuntime?.memoryService;
+  if (
+    !memoryService
+    || typeof memoryService.store !== "function"
+    || typeof memoryService.get !== "function"
+  ) {
+    throw new Error("Phase24H requires a Friday memory service from hub.apiRuntime.memoryService");
+  }
+  return memoryService;
+}
+
 export function makeWorkflowGraph() {
   return {
     schemaVersion: "2.0",
@@ -431,6 +443,7 @@ export function makeWorkflowGraph() {
 async function seedMemoryAndWorkflow(hub, report, sessionKey) {
   await hub.apiRuntime.sessionService.getOrCreateSession(sessionKey);
   const sessionMemoryNamespace = await hub.apiRuntime.sessionService.getSessionMemoryNamespace(sessionKey);
+  const memoryService = resolveHubMemoryService(hub);
   const memoryContent = [
     MEMORY_MARKER,
     "Trigger phrases: approved Phase24H followup automation; Phase24H natural trigger.",
@@ -438,13 +451,13 @@ async function seedMemoryAndWorkflow(hub, report, sessionKey) {
     "Allowed operation: run the workflow only after the channel approval gate allows workflow_run.",
     "Unsafe boundary: deletion, cleanup, or workflow removal requires separate approval and must not be performed by this proof.",
   ].join("\n");
-  await hub.memoryService.store(MEMORY_NAMESPACE, memoryContent, {
+  await memoryService.store(MEMORY_NAMESPACE, memoryContent, {
     source: "phase24h-live-proof",
     tags: ["phase24h", "sop", "workflow", "natural-trigger"],
     memoryType: "procedure",
     confidence: 0.99,
   });
-  const memoryItem = await hub.memoryService.store(sessionMemoryNamespace, memoryContent, {
+  const memoryItem = await memoryService.store(sessionMemoryNamespace, memoryContent, {
     source: "phase24h-live-proof",
     tags: ["phase24h", "sop", "workflow", "natural-trigger"],
     memoryType: "procedure",
@@ -831,7 +844,8 @@ async function main() {
     report.negativeFlow.status = negativeTerminal?.status ?? null;
     report.negativeFlow.responseSnippet = negativeText.slice(0, 240);
 
-    const memoryItem = await hub.memoryService.get(seeded.memoryItemId);
+    const memoryService = resolveHubMemoryService(hub);
+    const memoryItem = await memoryService.get(seeded.memoryItemId);
     report.diagnostics.memory = {
       ...report.diagnostics.memory,
       itemIdTail: tail(seeded.memoryItemId),

--- a/test/unit/scripts/ops/phase24h-telegram-natural-trigger.test.ts
+++ b/test/unit/scripts/ops/phase24h-telegram-natural-trigger.test.ts
@@ -82,4 +82,14 @@ describe("phase24h Telegram natural-trigger listener exports", () => {
       mapping: { proofMarker: "PHASE24H_WORKFLOW_EXECUTED" },
     });
   });
+
+  it("resolves the memory service from the API runtime exposed by createFridayHub", async () => {
+    const listener = await loadListener();
+    const memoryService = {
+      store: async () => ({ id: "memory-1" }),
+      get: async () => ({ id: "memory-1" }),
+    };
+
+    expect(listener.resolveHubMemoryService({ apiRuntime: { memoryService } })).toBe(memoryService);
+  });
 });


### PR DESCRIPTION
## Summary
- resolve Phase24H live listener memory seeding through hub.apiRuntime.memoryService
- add unit coverage for the createFridayHub exposure path

## Verification
- node --check scripts/ops/phase24h-telegram-natural-trigger-listener.mjs
- npx vitest run test/unit/scripts/ops/phase24h-telegram-natural-trigger.test.ts
- npm run build:api
- npm run --silent check:secret-patterns
- git diff --check