### PR TITLE
fix(phase24h): seed workflow with bootstrap admin user

### DIFF
--- a/scripts/ops/phase24h-telegram-natural-trigger-listener.mjs
+++ b/scripts/ops/phase24h-telegram-natural-trigger-listener.mjs
@@ -37,7 +37,7 @@ const MEMORY_NAMESPACE = "default";
 const MEMORY_MARKER = "PHASE24H_SOP_NATURAL_TRIGGER";
 const SUCCESS_MARKER = "PHASE24H_WORKFLOW_EXECUTED";
 const NEGATIVE_MARKER = "PHASE24H_DESTRUCTIVE_CHECK";
-const USER_ID = "phase24h-telegram-user";
+export const PHASE24H_RUNTIME_USER_ID = "admin-001";
 const REDACTION_LABELS = Object.freeze({
   tokenLabel: "[REDACTED_TELEGRAM_BOT_TOKEN]",
   prefixLabel: "[REDACTED_TELEGRAM_BOT_TOKEN_PREFIX]",
@@ -470,10 +470,10 @@ async function seedMemoryAndWorkflow(hub, report, sessionKey) {
       name: "Phase24H natural trigger workflow",
       description: "No-op workflow used to prove channel natural trigger -> approval-gated workflow_run -> terminal evidence.",
       tags: [WORKFLOW_TAG],
-      ownerUserId: USER_ID,
+      ownerUserId: PHASE24H_RUNTIME_USER_ID,
     },
     makeWorkflowGraph(),
-    USER_ID,
+    PHASE24H_RUNTIME_USER_ID,
     "Seeded for Phase24H Telegram natural-trigger live proof.",
   );
   const published = hub.workflowRuntime.crud.publishVersion(workflow.id, version.versionNumber);

--- a/test/unit/scripts/ops/phase24h-telegram-natural-trigger.test.ts
+++ b/test/unit/scripts/ops/phase24h-telegram-natural-trigger.test.ts
@@ -92,4 +92,10 @@ describe("phase24h Telegram natural-trigger listener exports", () => {
 
     expect(listener.resolveHubMemoryService({ apiRuntime: { memoryService } })).toBe(memoryService);
   });
+
+  it("uses the bootstrap admin user for runtime-owned seeded workflow records", async () => {
+    const listener = await loadListener();
+
+    expect(listener.PHASE24H_RUNTIME_USER_ID).toBe("admin-001");
+  });
 });


### PR DESCRIPTION
## Summary
- use the bootstrap admin user for Phase24H seeded workflow ownership
- add unit coverage so the live harness does not regress to a nonexistent owner user

## Verification
- node --check scripts/ops/phase24h-telegram-natural-trigger-listener.mjs
- npx vitest run test/unit/scripts/ops/phase24h-telegram-natural-trigger.test.ts
- npm run build:api
- npm run --silent check:secret-patterns
- git diff --check