### PR TITLE
fix(ci): reduce DeepSeek spend on push RGG runs

### DIFF
--- a/.github/workflows/real-green-gate.yml
+++ b/.github/workflows/real-green-gate.yml
@@ -84,6 +84,7 @@ jobs:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
       FRIDAY_DEEPSEEK_API_KEY: ${{ secrets.FRIDAY_DEEPSEEK_API_KEY }}
+      FRIDAY_REAL_GREEN_GATE_LIVE_PROVIDER_MODE: ${{ github.event_name == 'workflow_dispatch' && 'full' || 'economy' }}
       FRIDAY_REAL_WORLD_CLOUD_READY: ${{ secrets.FRIDAY_REAL_WORLD_CLOUD_READY }}
       FRIDAY_REAL_WORLD_SATELLITE_READY: ${{ secrets.FRIDAY_REAL_WORLD_SATELLITE_READY }}
       FRIDAY_REAL_WORLD_MCP_READY: ${{ secrets.FRIDAY_REAL_WORLD_MCP_READY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -363,7 +363,12 @@ jobs:
           # release-proof pass: status=passed AND scenarios consistent AND
           # blocked_reasons empty AND commit_sha matches expected. The CLI
           # prints its own structured rejection JSON to stdout on failure.
-          node scripts/ops/validate-real-green-gate-result.mjs --path "${ARTIFACT_PATH}" --expected-sha "${TAG_SHA}"
+          node scripts/ops/validate-real-green-gate-result.mjs \
+            --path "${ARTIFACT_PATH}" \
+            --expected-sha "${TAG_SHA}" \
+            --required-evidence-kind real-runtime \
+            --required-evidence-kind real-provider \
+            --required-evidence-kind real-browser
 
       - name: Assert RGG run was workflow_dispatch (channel phase24X jobs only run on manual dispatch)
         env:

--- a/scripts/ops/lib/real-green-gate-result.mjs
+++ b/scripts/ops/lib/real-green-gate-result.mjs
@@ -11,8 +11,9 @@
  *    pass. The workflow may exit success for plumbing reasons; the artifact's
  *    `status` field tells the truth.
  *  - There is no escape hatch / break-glass / FAST_MODE field.
- *  - The validator does NOT enforce a specific evidence-kind policy in this
- *    subphase; tier policy stays in docs/release-evidence-policy.md.
+ *  - The validator accepts a caller-provided evidence-kind policy. Routine
+ *    push checks may validate only the structural pass, while release gates
+ *    must require the real-provider / real-browser evidence they claim.
  *  - Defense-in-depth: even if the writer ever marked `status: "passed"` while
  *    `blocked_reasons` was non-empty, the validator rejects.
  */

--- a/scripts/ops/run-real-green-gate.mjs
+++ b/scripts/ops/run-real-green-gate.mjs
@@ -14,6 +14,8 @@ import {
   buildRealGreenGateResult,
 } from "./lib/real-green-gate-result.mjs";
 
+const LIVE_PROVIDER_MODES = new Set(["full", "economy"]);
+
 const DAILY_CORE_SCENARIOS = [
   "l0-runtime-health",
   "l0-provider-lanes-ready",
@@ -149,6 +151,7 @@ function parseArgs(argv) {
     repoRoot: process.cwd(),
     mintLocalAdminToken: false,
     dailyCoreRepetitions: 1,
+    liveProviderMode: normalizeLiveProviderMode(process.env.FRIDAY_REAL_GREEN_GATE_LIVE_PROVIDER_MODE),
     validationTimeoutMs: parseOptionalInteger(process.env.FRIDAY_REAL_GREEN_GATE_VALIDATION_TIMEOUT_MS) ?? 20 * 60 * 1000,
     skillTestTimeoutMs: parseOptionalInteger(process.env.FRIDAY_REAL_GREEN_GATE_SKILL_TIMEOUT_MS) ?? 5 * 60 * 1000,
   };
@@ -180,6 +183,10 @@ function parseArgs(argv) {
         options.dailyCoreRepetitions = Number.parseInt(next, 10) || 1;
         index += 1;
         break;
+      case "--live-provider-mode":
+        options.liveProviderMode = normalizeLiveProviderMode(next);
+        index += 1;
+        break;
       case "--validation-timeout-ms":
         options.validationTimeoutMs = parseOptionalInteger(next) ?? options.validationTimeoutMs;
         index += 1;
@@ -200,6 +207,15 @@ function parseArgs(argv) {
   }
   options.branch ??= resolveCurrentBranch(options.repoRoot);
   return options;
+}
+
+export function normalizeLiveProviderMode(value) {
+  const normalized = String(value ?? "").trim().toLowerCase();
+  return LIVE_PROVIDER_MODES.has(normalized) ? normalized : "full";
+}
+
+export function shouldExcludeProviderScenarios(liveProviderMode) {
+  return normalizeLiveProviderMode(liveProviderMode) === "economy";
 }
 
 function parseBooleanFlag(value) {
@@ -347,6 +363,7 @@ function renderMarkdown(summary) {
     `- Daily core report: ${summary.dailyCore?.reportRoot ?? "n/a"}`,
     `- Public surface report: ${summary.publicSurface?.reportRoot ?? "n/a"}`,
     `- External channel report: ${summary.externalChannels?.reportRoot ?? "n/a"}`,
+    `- Live provider mode: ${summary.liveProviderMode ?? "full"}`,
     `- Branch conformance: ${summary.branchConformance?.recommendation ?? "n/a"}`,
     `- Skill conformance: ${summary.skillConformance?.ok === true ? "passed" : "failed"}`,
     `- Last completed phase: ${summary.lastCompletedPhase ?? "none"}`,
@@ -503,6 +520,7 @@ function buildSummary({
   runId,
   repoRoot,
   branch,
+  liveProviderMode,
   phaseStatus,
   preflight,
   smoke,
@@ -518,6 +536,7 @@ function buildSummary({
     generatedAt: new Date().toISOString(),
     repoRoot,
     branch,
+    liveProviderMode: normalizeLiveProviderMode(liveProviderMode),
     status: error ? "failed" : "completed",
     lastCompletedPhase: getLastCompletedPhase(phaseStatus),
     phaseStatus,
@@ -559,6 +578,8 @@ function flushTerminalArtifacts(reportRoot, summary) {
 async function main() {
   const options = parseArgs(process.argv.slice(2));
   const repoRoot = options.repoRoot;
+  const liveProviderMode = normalizeLiveProviderMode(options.liveProviderMode);
+  const excludeProviderScenarios = shouldExcludeProviderScenarios(liveProviderMode);
   const runId = createRunId();
   const reportRoot = options.reportRoot
     ?? path.join(repoRoot, "docs", "reports", "ops", "real-green-gate", runId);
@@ -637,6 +658,7 @@ async function main() {
       () => runRealWorldValidation({
         ...validationBaseOptions,
         suite: "smoke",
+        excludeProviderScenarios,
         reportRoot: resolveGateSuiteReportRoot(reportRoot, "smoke"),
       }),
       async () => {
@@ -654,6 +676,7 @@ async function main() {
         suite: "daily",
         scenarioIds: DAILY_CORE_SCENARIOS,
         repetitions: options.dailyCoreRepetitions,
+        excludeProviderScenarios,
         reportRoot: resolveGateSuiteReportRoot(reportRoot, "daily-core"),
       }),
       async () => {
@@ -671,6 +694,7 @@ async function main() {
         suite: "daily",
         scenarioIds: PUBLIC_SURFACE_SCENARIOS,
         repetitions: 1,
+        excludeProviderScenarios,
         reportRoot: resolveGateSuiteReportRoot(reportRoot, "public-surface"),
       }),
       async () => {
@@ -746,6 +770,7 @@ async function main() {
       runId,
       repoRoot,
       branch: options.branch,
+      liveProviderMode,
       phaseStatus,
       preflight,
       smoke,

--- a/scripts/ops/validate-real-green-gate-result.mjs
+++ b/scripts/ops/validate-real-green-gate-result.mjs
@@ -25,7 +25,7 @@ import {
 } from "./lib/real-green-gate-result.mjs";
 
 function parseArgs(argv) {
-  const args = { path: null, expectedSha: null };
+  const args = { path: null, expectedSha: null, requiredEvidenceKinds: [] };
   for (let index = 0; index < argv.length; index += 1) {
     const token = argv[index];
     const next = argv[index + 1];
@@ -34,6 +34,9 @@ function parseArgs(argv) {
       index += 1;
     } else if (token === "--expected-sha" && typeof next === "string") {
       args.expectedSha = next;
+      index += 1;
+    } else if (token === "--required-evidence-kind" && typeof next === "string") {
+      args.requiredEvidenceKinds.push(next);
       index += 1;
     }
   }
@@ -83,6 +86,7 @@ function main() {
 
   const decision = validateRealGreenGateResult(parsed, {
     expectedSha: args.expectedSha ?? undefined,
+    requiredEvidenceKinds: args.requiredEvidenceKinds,
   });
 
   emit({
@@ -90,6 +94,7 @@ function main() {
     reasons: decision.reasons,
     path: args.path,
     expected_sha: args.expectedSha ?? null,
+    required_evidence_kinds: args.requiredEvidenceKinds,
     observed_sha: typeof parsed?.commit_sha === "string" ? parsed.commit_sha : null,
     observed_status: typeof parsed?.status === "string" ? parsed.status : null,
   });

--- a/test/unit/ops/run-real-green-gate.test.ts
+++ b/test/unit/ops/run-real-green-gate.test.ts
@@ -1,7 +1,12 @@
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
-import { resolveGateSuiteReportRoot, summarizeRun } from "../../../scripts/ops/run-real-green-gate.mjs";
+import {
+  normalizeLiveProviderMode,
+  resolveGateSuiteReportRoot,
+  shouldExcludeProviderScenarios,
+  summarizeRun,
+} from "../../../scripts/ops/run-real-green-gate.mjs";
 
 describe("run-real-green-gate helpers", () => {
   it("preserves provider and browser attempt counters in suite summaries", () => {
@@ -25,5 +30,15 @@ describe("run-real-green-gate helpers", () => {
     expect(resolveGateSuiteReportRoot("/tmp/rgg", "public-surface")).toBe(
       join("/tmp/rgg", "suites", "public-surface"),
     );
+  });
+
+  it("defaults to full live-provider proof unless economy mode is explicit", () => {
+    expect(normalizeLiveProviderMode(undefined)).toBe("full");
+    expect(normalizeLiveProviderMode("")).toBe("full");
+    expect(normalizeLiveProviderMode("FULL")).toBe("full");
+    expect(normalizeLiveProviderMode("economy")).toBe("economy");
+    expect(normalizeLiveProviderMode("unknown")).toBe("full");
+    expect(shouldExcludeProviderScenarios("full")).toBe(false);
+    expect(shouldExcludeProviderScenarios("economy")).toBe(true);
   });
 });

--- a/test/unit/validation/real-world-runner.test.ts
+++ b/test/unit/validation/real-world-runner.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { runRealWorldValidation } from "../../../validation/real-world/lib/runner.mjs";
+
+const BASE_SCENARIO = {
+  layer: "L3",
+  productArea: "assistant behavior",
+  entrySurface: "/v1/agent/runs",
+  routeFamily: "cost control",
+  riskTier: "low",
+  suites: ["smoke"],
+  expectedEvidence: ["selected by catalog-only validation"],
+  realWorldPrompt: "Reply OK.",
+  execution: {
+    kind: "agent_run",
+  },
+};
+
+describe("real-world runner filtering", () => {
+  it("can exclude live-provider scenarios for RGG economy mode without dropping non-provider coverage", async () => {
+    const result = await runRealWorldValidation({
+      suite: "smoke",
+      catalogOnly: true,
+      excludeProviderScenarios: true,
+      catalog: [
+        {
+          ...BASE_SCENARIO,
+          id: "provider-backed",
+          providerLane: "default_only",
+        },
+        {
+          ...BASE_SCENARIO,
+          id: "non-provider",
+          providerLane: "none",
+        },
+      ],
+    });
+
+    expect(result.scenarioCount).toBe(1);
+  });
+});

--- a/validation/real-world/lib/executors.mjs
+++ b/validation/real-world/lib/executors.mjs
@@ -566,32 +566,23 @@ function scenarioTimeout(scenario, fallback) {
 let sharedUiProbeSession = null;
 
 async function getSharedUiProbeSession(uiBaseUrl) {
-  if (sharedUiProbeSession?.uiBaseUrl === uiBaseUrl) {
-    const context = await sharedUiProbeSession.browser.newContext({
-      baseURL: uiBaseUrl,
-      viewport: { width: 1440, height: 960 },
-    });
-    return {
-      ...sharedUiProbeSession,
-      context,
-    };
+  if (sharedUiProbeSession?.uiBaseUrl === uiBaseUrl && sharedUiProbeSession?.context) {
+    return sharedUiProbeSession;
   }
   if (sharedUiProbeSession?.browser) {
     await sharedUiProbeSession.browser.close().catch(() => undefined);
   }
   const browser = await chromium.launch({ headless: true });
-  sharedUiProbeSession = {
-    uiBaseUrl,
-    browser,
-  };
   const context = await browser.newContext({
     baseURL: uiBaseUrl,
     viewport: { width: 1440, height: 960 },
   });
-  return {
-    ...sharedUiProbeSession,
+  sharedUiProbeSession = {
+    uiBaseUrl,
+    browser,
     context,
   };
+  return sharedUiProbeSession;
 }
 
 export async function closeSharedUiProbeSession() {
@@ -608,6 +599,7 @@ async function completeUiLoginIfNeeded({ page, client, execution, artifact, time
   }
   const requestedPath = getUrlPath(execution.path);
   const loginTimeoutMs = Math.max(timeoutMs, 90_000);
+  const maxLoginAttempts = 4;
   const waitForLoginExit = () => page.waitForFunction(
     () => new URL(window.location.href).pathname !== "/login",
     undefined,
@@ -624,32 +616,77 @@ async function completeUiLoginIfNeeded({ page, client, execution, artifact, time
     },
     { timeout: loginTimeoutMs },
   );
-  if (typeof client?.localPassphrase === "string" && client.localPassphrase.trim().length > 0) {
-    await page.locator("#login-local-passphrase").fill(client.localPassphrase.trim());
-    const loginResponsePromise = waitForLoginResponse();
-    await page.getByRole("button", { name: /continue locally/i }).click();
-    const loginResponse = await loginResponsePromise;
-    if (!loginResponse.ok()) {
-      throw new Error(`Real browser local-passphrase login failed with HTTP ${String(loginResponse.status())}`);
+  const retryDelayFrom = async (loginResponse) => {
+    const headers = loginResponse.headers();
+    const retryAfterHeader = headers["retry-after"];
+    if (typeof retryAfterHeader === "string" && retryAfterHeader.trim().length > 0) {
+      const asSeconds = Number.parseFloat(retryAfterHeader);
+      if (Number.isFinite(asSeconds) && asSeconds > 0) {
+        return Math.ceil(asSeconds * 1_000);
+      }
+      const asDate = Date.parse(retryAfterHeader);
+      if (Number.isFinite(asDate)) {
+        return Math.max(0, asDate - Date.now());
+      }
     }
-    await waitForLoginExit();
-    artifact.observedEvidence.push(`completed real browser local-passphrase login for ${requestedPath}`);
+    try {
+      const body = await loginResponse.json();
+      const retryAfterMs = body?.error?.retryAfterMs ?? body?.retryAfterMs;
+      if (typeof retryAfterMs === "number" && Number.isFinite(retryAfterMs) && retryAfterMs > 0) {
+        return retryAfterMs;
+      }
+    } catch {
+      // Response bodies on failed login paths are best-effort diagnostic data.
+    }
+    return 15_000;
+  };
+  const runLoginWithRateLimitRetry = async ({ label, submit }) => {
+    for (let attempt = 1; attempt <= maxLoginAttempts; attempt += 1) {
+      const loginResponsePromise = waitForLoginResponse();
+      await submit();
+      const loginResponse = await loginResponsePromise;
+      if (loginResponse.ok()) {
+        await waitForLoginExit();
+        if (attempt > 1) {
+          artifact.observedEvidence.push(`${label} login recovered after ${String(attempt - 1)} rate-limit retry attempt(s)`);
+        }
+        artifact.observedEvidence.push(`completed real browser ${label} login for ${requestedPath}`);
+        return;
+      }
+      if (loginResponse.status() === 429 && attempt < maxLoginAttempts) {
+        const retryDelayMs = await retryDelayFrom(loginResponse);
+        artifact.notes = [
+          ...(artifact.notes ?? []),
+          `real browser ${label} login hit HTTP 429; waiting ${String(retryDelayMs)}ms before retry ${String(attempt + 1)}/${String(maxLoginAttempts)}`,
+        ];
+        await page.waitForTimeout(retryDelayMs);
+        continue;
+      }
+      throw new Error(`Real browser ${label} login failed with HTTP ${String(loginResponse.status())}`);
+    }
+  };
+  if (typeof client?.localPassphrase === "string" && client.localPassphrase.trim().length > 0) {
+    await runLoginWithRateLimitRetry({
+      label: "local-passphrase",
+      submit: async () => {
+        await page.locator("#login-local-passphrase").fill(client.localPassphrase.trim());
+        await page.getByRole("button", { name: /continue locally/i }).click();
+      },
+    });
     return;
   }
   if (
     typeof client?.email === "string" && client.email.trim().length > 0
     && typeof client?.password === "string" && client.password.trim().length > 0 // pragma: allowlist secret
   ) {
-    await page.locator("#login-email").fill(client.email.trim());
-    await page.locator("#login-password").fill(client.password.trim());
-    const loginResponsePromise = waitForLoginResponse();
-    await page.getByRole("button", { name: /sign in/i }).click();
-    const loginResponse = await loginResponsePromise;
-    if (!loginResponse.ok()) {
-      throw new Error(`Real browser email/password login failed with HTTP ${String(loginResponse.status())}`);
-    }
-    await waitForLoginExit();
-    artifact.observedEvidence.push(`completed real browser email/password login for ${requestedPath}`);
+    await runLoginWithRateLimitRetry({
+      label: "email/password",
+      submit: async () => {
+        await page.locator("#login-email").fill(client.email.trim());
+        await page.locator("#login-password").fill(client.password.trim());
+        await page.getByRole("button", { name: /sign in/i }).click();
+      },
+    });
     return;
   }
   throw new Error(
@@ -2183,7 +2220,6 @@ async function executeUiProbe({ artifact, client, scenario, reportRoot, uiBaseUr
     return artifact;
   } finally {
     await page?.close().catch(() => undefined);
-    await context?.close().catch(() => undefined);
   }
 }
 
@@ -2303,7 +2339,6 @@ async function executeUiAuthoring({ artifact, client, scenario, reportRoot, uiBa
     return artifact;
   } finally {
     await page?.close().catch(() => undefined);
-    await context?.close().catch(() => undefined);
   }
 }
 

--- a/validation/real-world/lib/runner.mjs
+++ b/validation/real-world/lib/runner.mjs
@@ -52,6 +52,9 @@ function matchesFilter(scenario, options) {
   if (options.tags?.length && !options.tags.some((tag) => scenario.tags?.includes(tag))) {
     return false;
   }
+  if (options.excludeProviderScenarios === true && scenario.providerLane !== "none") {
+    return false;
+  }
   return true;
 }
 


### PR DESCRIPTION
## Summary
- add `FRIDAY_REAL_GREEN_GATE_LIVE_PROVIDER_MODE` so automatic push RGG runs use `economy` mode while manual workflow_dispatch stays full proof
- exclude provider-backed real-world scenarios from economy runs without dropping non-provider runtime/browser coverage
- harden release validation to require real-runtime, real-provider, and real-browser evidence kinds so economy artifacts cannot satisfy release proof

## Root cause
DeepSeek usage on 2026-05-27 was not one runaway Friday context loop. The usage CSV shows 637 `deepseek-v4-pro` requests and ~3.3M input-cache-miss tokens. GitHub Actions shows 48 Real Green Gate runs that day; each full RGG executes roughly 13 provider calls. Push-triggered RGG was running the same live-provider proof as release/manual RGG. Provider cache hit rate stayed near zero because each run carries dynamic run/session/scenario context.

## Verification
- `npm ci`
- `npx vitest run test/unit/ops/run-real-green-gate.test.ts test/unit/ops/real-green-gate-result.test.ts test/unit/validation/real-world-runner.test.ts` (45 passed)
- `npm run validate:real-world:catalog`
- `npx eslint scripts/ops/lib/real-green-gate-result.mjs scripts/ops/run-real-green-gate.mjs scripts/ops/validate-real-green-gate-result.mjs validation/real-world/lib/runner.mjs --no-warn-ignored`
- `npm run check:secret-patterns`
- `npm run check:proof:no-mock-leaks`

## Safety
Release/same-SHA proof remains strict. The release workflow now rejects RGG artifacts missing `real-provider`, so economy push runs cannot be used as release proof.

Desktop audit note: `/Users/jarvis/Desktop/Friday-deepseek-cache-miss-audit-20260528.md`.