### PR TITLE
fix(phase24h): preserve natural trigger routing

### DIFF
--- a/src/reflex/services/friday-reflex-explicit-preference-parser.ts
+++ b/src/reflex/services/friday-reflex-explicit-preference-parser.ts
@@ -48,7 +48,7 @@ const EXPLICIT_PREFERENCE_RULES: readonly ExplicitPreferenceRule[] = [
     write: { category: "reflex", key: "workflows.generation_policy", value: "do_not_suggest" },
   },
   {
-    pattern: /(以后|以后都|今后|默认).*(workflow|工作流).*(草稿|候选|审核)|(workflow).*(draft|review candidate|approval)/iu,
+    pattern: /(以后|以后都|今后|默认).*(workflow|工作流).*(草稿|候选|审核)|(always|from now on|default).*(workflow).*(draft|review candidate|approval)/iu,
     write: { category: "reflex", key: "workflows.generation_policy", value: "draft_workflow" },
   },
   {
@@ -56,7 +56,7 @@ const EXPLICIT_PREFERENCE_RULES: readonly ExplicitPreferenceRule[] = [
     write: { category: "reflex", key: "skills.generation_policy", value: "suggest_only" },
   },
   {
-    pattern: /(以后|以后都|今后|默认).*(skill|技能|能力包).*(草稿|候选|审核)|(skill).*(draft|review candidate|approval)/iu,
+    pattern: /(以后|以后都|今后|默认).*(skill|技能|能力包).*(草稿|候选|审核)|(always|from now on|default).*(skill).*(draft|review candidate|approval)/iu,
     write: { category: "reflex", key: "skills.generation_policy", value: "draft_for_approval" },
   },
   {

--- a/test/unit/reflex/friday-reflex-service.test.ts
+++ b/test/unit/reflex/friday-reflex-service.test.ts
@@ -91,6 +91,9 @@ describe("Friday Reflex onboarding registry", () => {
       { category: "reflex", key: "constitution.challenge_policy", value: "challenge_risky_or_inconsistent" },
       { category: "reflex", key: "constitution.plain_language_policy", value: "plain_language_for_decisions" },
     ]);
+    expect(parseFridayReflexExplicitPreferenceMessage(
+      "Phase24H natural trigger phase24h-positive-run-12345-abcdef12: use my saved SOP PHASE24H_SOP_NATURAL_TRIGGER to run the approved Phase24H followup automation. Use memory first, list the published workflow tagged phase24h-natural-trigger, request approval if needed, then after the workflow result is available reply with PHASE24H_WORKFLOW_EXECUTED.",
+    )).toEqual([]);
     expect(parseFridayReflexExplicitPreferenceMessage("不要记住这个")).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- tighten Reflex explicit preference parsing so one-shot workflow approval tasks are not captured as durable workflow-generation preferences
- add regression coverage for the Phase24H Telegram natural-trigger prompt

## Verification
- npx vitest run test/unit/reflex/friday-reflex-service.test.ts test/unit/scripts/ops/phase24h-telegram-natural-trigger.test.ts
- npm run build:api
- npm run --silent check:secret-patterns
- git diff --check
- node --check scripts/ops/phase24h-telegram-natural-trigger-listener.mjs