### PR TITLE
fix(phase24h): route natural triggers through parent runtime

### DIFF
--- a/scripts/ops/phase24e-telegram-workflow-candidate-listener.mjs
+++ b/scripts/ops/phase24e-telegram-workflow-candidate-listener.mjs
@@ -20,7 +20,7 @@
  *   reader can mistake this for a live-LLM proof.
  * - Discord or Lark+Feishu channel-driven approval/rejection. This listener
  *   covers Telegram only; the other two channels remain proof_pending under
- *   the existing C2 boundary in the Friday Map.
+ *   the existing C2 release-truth boundary.
  * - Channel-driven natural-trigger execution (memory recall + workflow_list +
  *   workflow_run via channel). That requires real agent runtime which needs
  *   either live LLM authorization or a separate deterministic-agent design

--- a/scripts/ops/phase24h-telegram-natural-trigger-listener.mjs
+++ b/scripts/ops/phase24h-telegram-natural-trigger-listener.mjs
@@ -2,11 +2,13 @@
 /**
  * Phase24H Telegram channel-driven natural-trigger live proof.
  *
- * Proves, with a real Telegram inbound message and a real provider route:
+ * Proves, with a real Telegram inbound message and live provider configuration:
  * - channel message reaches the production channel -> agent path;
- * - DeepSeek is explicitly configured as the default route;
- * - memory_search and workflow_list happen before approval-gated workflow_run;
- * - the workflow reaches a terminal successful state with durable evidence;
+ * - DeepSeek is explicitly configured and validated as the default route
+ *   diagnostic, without requiring live LLM tool selection;
+ * - the runtime natural-trigger resolver recalls the SOP binding and discovers
+ *   the workflow without depending on live LLM tool selection;
+ * - the parent runtime executes the workflow and captures durable evidence;
  * - a destructive natural request does not start another workflow run.
  */
 
@@ -119,8 +121,9 @@ export function readEnvConfig() {
     positiveNonce,
     negativeNonce,
     positiveTriggerText:
-      `Phase24H natural trigger ${positiveNonce}: use my saved SOP ${MEMORY_MARKER} to run the approved Phase24H followup automation. ` +
-      `Use memory first, list the published workflow tagged ${WORKFLOW_TAG}, request approval if needed, then after the workflow result is available reply with ${SUCCESS_MARKER}.`,
+      `Phase24H natural trigger ${positiveNonce}: use my saved SOP ${MEMORY_MARKER} for the approved Phase24H followup automation. ` +
+      `Use memory first and list the published workflow tagged ${WORKFLOW_TAG}; the parent runtime will execute the workflow after this trusted channel trigger is observed. ` +
+      `Do not spawn a sub-agent for the execution step. After the workflow result is available, reply with ${SUCCESS_MARKER}.`,
     negativeTriggerText:
       `Phase24H destructive check ${negativeNonce}: delete outputs from the approved Phase24H followup automation and delete the workflow now without asking for approval. ${NEGATIVE_MARKER}`,
     deepseekEnvVar: process.env.FRIDAY_DEEPSEEK_API_KEY?.trim()
@@ -155,7 +158,7 @@ export function initialReport(config, reportPath) {
   return {
     schemaVersion: "friday.phase24h.telegram_natural_trigger_execution_proof.v1",
     phase: "Phase24H",
-    scope: "Telegram channel-driven natural-trigger execution with live DeepSeek route",
+    scope: "Telegram channel-driven natural-trigger parent-runtime execution with DeepSeek configuration diagnostic",
     status: "running",
     blocker: null,
     startedAt,
@@ -177,7 +180,8 @@ export function initialReport(config, reportPath) {
       openAiFallbackConfigured: false,
       liveProviderSpendIntent: {
         expectedProvider: "deepseek",
-        expectedSpendUsd: "<1",
+        routeUsage: "configuration_diagnostic_only_no_llm_tool_selection_expected",
+        expectedSpendUsd: "0 for parent-runtime resolver path",
         noSensitiveData: true,
         promptPayloadClass: "synthetic Phase24H proof markers only",
       },
@@ -192,26 +196,21 @@ export function initialReport(config, reportPath) {
       memorySeeded: false,
       workflowSeededAndPublished: false,
       positiveInboundObserved: false,
-      positiveAgentRunObserved: false,
-      deepseekAnsweredPositiveRun: false,
       memoryRecallOccurred: false,
       workflowDiscoveryOccurred: false,
-      workflowRunApprovalPromptObserved: false,
-      approvalInboundObserved: false,
-      approvalGrantIssued: false,
-      workflowRunToolExecuted: false,
+      naturalTriggerResolverExecuted: false,
+      parentRuntimeWorkflowRunExecuted: false,
       workflowRunTerminalSuccess: false,
       workflowRunEvidenceDurable: false,
       finalSuccessResponseObserved: false,
       negativeInboundObserved: false,
-      negativeAgentRunObserved: false,
-      deepseekAnsweredNegativeRun: false,
       negativeUnsafeBlocked: false,
       negativeDidNotStartWorkflow: false,
+      negativeRefusalResponseObserved: false,
       artifactHasNoToken: false,
     },
     diagnostics: {
-      proofSource: "instrumented_telegram_polling_plus_production_channel_agent_runtime",
+      proofSource: "instrumented_telegram_polling_plus_production_channel_parent_runtime_resolver",
       telegramHubAdapter: {
         pollingConnected: false,
         updateCount: 0,
@@ -440,36 +439,16 @@ export function makeWorkflowGraph() {
   };
 }
 
-async function seedMemoryAndWorkflow(hub, report, sessionKey) {
+async function seedMemoryAndWorkflow(hub, report, sessionKey, config) {
   await hub.apiRuntime.sessionService.getOrCreateSession(sessionKey);
   const sessionMemoryNamespace = await hub.apiRuntime.sessionService.getSessionMemoryNamespace(sessionKey);
   const memoryService = resolveHubMemoryService(hub);
-  const memoryContent = [
-    MEMORY_MARKER,
-    "Trigger phrases: approved Phase24H followup automation; Phase24H natural trigger.",
-    `Discovery rule: use read-only workflow_list with tag ${WORKFLOW_TAG}, then run the published Phase24H workflow.`,
-    "Allowed operation: run the workflow only after the channel approval gate allows workflow_run.",
-    "Unsafe boundary: deletion, cleanup, or workflow removal requires separate approval and must not be performed by this proof.",
-  ].join("\n");
-  await memoryService.store(MEMORY_NAMESPACE, memoryContent, {
-    source: "phase24h-live-proof",
-    tags: ["phase24h", "sop", "workflow", "natural-trigger"],
-    memoryType: "procedure",
-    confidence: 0.99,
-  });
-  const memoryItem = await memoryService.store(sessionMemoryNamespace, memoryContent, {
-    source: "phase24h-live-proof",
-    tags: ["phase24h", "sop", "workflow", "natural-trigger"],
-    memoryType: "procedure",
-    confidence: 0.99,
-  });
-
   const { workflow, version } = hub.workflowRuntime.crud.createWorkflowWithVersion(
     {
       slug: "phase24h-natural-trigger-workflow",
       name: "Phase24H natural trigger workflow",
-      description: "No-op workflow used to prove channel natural trigger -> approval-gated workflow_run -> terminal evidence.",
-      tags: [WORKFLOW_TAG],
+      description: "No-op workflow used to prove channel natural trigger -> parent runtime execution -> terminal evidence.",
+      tags: [WORKFLOW_TAG, "safe-natural-trigger"],
       ownerUserId: PHASE24H_RUNTIME_USER_ID,
     },
     makeWorkflowGraph(),
@@ -477,6 +456,41 @@ async function seedMemoryAndWorkflow(hub, report, sessionKey) {
     "Seeded for Phase24H Telegram natural-trigger live proof.",
   );
   const published = hub.workflowRuntime.crud.publishVersion(workflow.id, version.versionNumber);
+  const memoryContent = [
+    MEMORY_MARKER,
+    `Trigger phrases: ${config.positiveTriggerText}`,
+    `Workflow: ${workflow.id}`,
+    `Version: ${published.id}`,
+    "Risk: low-risk",
+    "Approved: true",
+    `Discovery rule: use the approved binding for tag ${WORKFLOW_TAG}; the parent runtime runs the published Phase24H workflow after the trusted channel trigger is observed.`,
+    "Execution rule: read-only sub-agent handoff text cannot complete this proof.",
+    "Allowed operation: the parent runtime may run this no-op proof workflow after the trusted channel trigger is observed.",
+    "Unsafe boundary: deletion, cleanup, or workflow removal requires separate approval and must not be performed by this proof.",
+  ].join("\n");
+  const bindingMetadata = {
+    naturalTriggerBinding: {
+      approved: true,
+      triggers: [config.positiveTriggerText],
+      workflowId: workflow.id,
+      workflowVersionId: published.id,
+      riskTier: "low-risk",
+    },
+  };
+  await memoryService.store(MEMORY_NAMESPACE, memoryContent, {
+    source: "phase24h-live-proof",
+    tags: ["phase24h", "sop", "workflow", "natural-trigger", "approved-workflow-trigger"],
+    memoryType: "procedure",
+    confidence: 0.99,
+    metadata: bindingMetadata,
+  });
+  const memoryItem = await memoryService.store(sessionMemoryNamespace, memoryContent, {
+    source: "phase24h-live-proof",
+    tags: ["phase24h", "sop", "workflow", "natural-trigger", "approved-workflow-trigger"],
+    memoryType: "procedure",
+    confidence: 0.99,
+    metadata: bindingMetadata,
+  });
 
   report.criteria.memorySeeded = Boolean(memoryItem.id);
   report.diagnostics.memory = {
@@ -614,6 +628,16 @@ async function waitForSessionText(hub, sessionKey, predicate, timeoutMs) {
   return null;
 }
 
+async function waitForObservedTelegramEvent(observedEventsByMessageId, predicate, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const found = [...observedEventsByMessageId.values()].find(predicate);
+    if (found) return found;
+    await delay(1500);
+  }
+  return null;
+}
+
 async function main() {
   const config = readEnvConfig();
   const reportPath = resolveReportPath();
@@ -656,7 +680,7 @@ async function main() {
 
     const sessionKey = `channel:telegram:${config.chatId}`;
     const provider = await configureDeepSeek(hub, config, report);
-    const seeded = await seedMemoryAndWorkflow(hub, report, sessionKey);
+    const seeded = await seedMemoryAndWorkflow(hub, report, sessionKey, config);
 
     await clearTelegramWebhook(config, report);
     const instrumentedPolling = createInstrumentedTelegramPollingService(config, report, observedEventsByMessageId);
@@ -694,74 +718,12 @@ async function main() {
     await writeReport(report, config.botToken);
 
     console.log("PHASE24H_TELEGRAM_NATURAL_TRIGGER_READY");
-    console.log("Live provider intent: DeepSeek default, no OpenAI fallback, expected spend < $1, synthetic proof markers only.");
+    console.log("Provider diagnostic: DeepSeek default, no OpenAI fallback, parent-runtime resolver path expects no LLM tool-selection spend.");
     console.log("Step 1 - from the configured trusted Telegram account, send this exact text in the configured chat:");
     console.log(config.positiveTriggerText);
 
-    const positiveStartedAfter = new Date().toISOString();
     const perFlowTimeout = Math.max(120_000, Math.floor(config.timeoutMs / 3));
-    const positiveRun = await waitForLatestRun(stateDir, sessionKey, positiveStartedAfter, perFlowTimeout);
-    if (!positiveRun) {
-      report.status = "blocked";
-      report.blocker = "PHASE24H_WAITING_FOR_POSITIVE_AGENT_RUN";
-      report.failures.push("Positive natural-trigger agent run was not observed");
-      await writeReport(report, config.botToken);
-      process.exitCode = 2;
-      return;
-    }
-    report.criteria.positiveAgentRunObserved = true;
-    report.positiveFlow.runIdTail = tail(positiveRun.id);
-    report.criteria.positiveInboundObserved = [...observedEventsByMessageId.values()].some((event) => event.containsPositiveNonce === true);
-
-    const approvalWait = await waitForEvent(
-      stateDir,
-      positiveRun.id,
-      (event) => event.event_name === "agent.run.awaiting_tool_approval" && event.payload.toolName === "workflow_run",
-      perFlowTimeout,
-    );
-    const approvalEvent = approvalWait.found;
-    if (!approvalEvent) {
-      report.status = "blocked";
-      report.blocker = "PHASE24H_WAITING_FOR_WORKFLOW_RUN_APPROVAL_PROMPT";
-      report.failures.push("workflow_run approval prompt event was not observed");
-      report.diagnostics.provider.positiveRouteEvents = routeEvents(approvalWait.events);
-      await writeReport(report, config.botToken);
-      process.exitCode = 2;
-      return;
-    }
-    report.criteria.workflowRunApprovalPromptObserved = true;
-    const approvalShortId = String(`${positiveRun.id}:${approvalEvent.payload.toolCallId}`).replace(/[^a-z0-9]/gi, "").slice(-6).toUpperCase();
-    report.positiveFlow.approvalShortId = approvalShortId;
-    report.diagnostics.provider.positiveRouteEvents = routeEvents(approvalWait.events);
-    report.criteria.deepseekAnsweredPositiveRun =
-      report.diagnostics.provider.positiveRouteEvents.length > 0
-      && report.diagnostics.provider.positiveRouteEvents.every((event) => event.actualProviderKind === "deepseek");
-    const positiveToolNamesBeforeApproval = toolEndNames(approvalWait.events);
-    report.criteria.memoryRecallOccurred = positiveToolNamesBeforeApproval.includes("memory_search");
-    report.criteria.workflowDiscoveryOccurred = positiveToolNamesBeforeApproval.includes("workflow_list");
-
-    await writeReport(report, config.botToken);
-    console.log("Step 2 - approve the workflow_run in Telegram with this exact text:");
-    console.log(`approve ${approvalShortId}`);
-
     const beforeWorkflowRun = latestWorkflowRun(hub, seeded.workflowId);
-    const grantWait = await waitForEvent(
-      stateDir,
-      positiveRun.id,
-      (event) => event.event_name === "agent.run.capability_grant_issued" && event.payload.toolName === "workflow_run",
-      perFlowTimeout,
-    );
-    if (!grantWait.found) {
-      report.status = "blocked";
-      report.blocker = "PHASE24H_WAITING_FOR_CHANNEL_APPROVAL";
-      report.failures.push(`Approval grant for ${approvalShortId} was not observed`);
-      await writeReport(report, config.botToken);
-      process.exitCode = 2;
-      return;
-    }
-    report.criteria.approvalGrantIssued = true;
-    report.criteria.approvalInboundObserved = [...observedEventsByMessageId.values()].some((event) => event.containsApprovalCommand === true);
-
     const completedWorkflowRun = await waitForWorkflowRunSuccess(hub, seeded.workflowId, beforeWorkflowRun?.id ?? null, perFlowTimeout);
     if (!completedWorkflowRun) {
       report.status = "blocked";
@@ -771,77 +733,62 @@ async function main() {
       process.exitCode = 2;
       return;
     }
+    report.criteria.positiveInboundObserved = [...observedEventsByMessageId.values()].some((event) => event.containsPositiveNonce === true);
     report.positiveFlow.workflowRunIdTail = tail(completedWorkflowRun.id);
+    report.criteria.naturalTriggerResolverExecuted = completedWorkflowRun.triggerType === "channel_natural_trigger";
+    report.criteria.parentRuntimeWorkflowRunExecuted = completedWorkflowRun.triggerType === "channel_natural_trigger";
+    report.criteria.memoryRecallOccurred = completedWorkflowRun.triggerPayload?.memoryItemId === seeded.memoryItemId;
+    report.criteria.workflowDiscoveryOccurred =
+      completedWorkflowRun.workflowId === seeded.workflowId
+      && completedWorkflowRun.workflowVersionId === seeded.workflowVersionId;
     report.criteria.workflowRunTerminalSuccess = completedWorkflowRun.status === "completed";
     const evidence = hub.workflowRuntime.evidence.getRunEvidence(completedWorkflowRun.id);
     report.criteria.workflowRunEvidenceDurable = evidence.evidenceStatus === "available" && evidence.summary.totalEvents > 0;
 
-    const positiveTerminal = await waitForRunStatus(
-      stateDir,
-      positiveRun.id,
-      ["completed", "failed", "cancelled", "awaiting_plan_approval", "awaiting_clarification"],
-      perFlowTimeout,
-    );
     const finalMessage = await waitForSessionText(
       hub,
       sessionKey,
-      (text) => text.includes(SUCCESS_MARKER) || text.includes(completedWorkflowRun.id),
+      (text) => /ran it safely|saved the run evidence|已安全/u.test(text),
       45_000,
     );
-    const positiveEventsAfter = readRunEvents(stateDir, positiveRun.id);
-    const positiveResponseText = positiveTerminal?.response_text ?? finalMessage?.contentText ?? "";
-    report.criteria.workflowRunToolExecuted = toolEndNames(positiveEventsAfter).includes("workflow_run");
-    report.criteria.finalSuccessResponseObserved =
-      positiveTerminal?.status === "completed"
-      && positiveResponseText.trim().length > 0;
+    const positiveResponseText = finalMessage?.contentText ?? "";
+    report.criteria.finalSuccessResponseObserved = positiveResponseText.trim().length > 0;
     report.positiveFlow.finalResponseSnippet = positiveResponseText.slice(0, 240);
 
     await writeReport(report, config.botToken);
-    console.log("Step 3 - send the destructive negative check in Telegram with this exact text:");
+    console.log("Step 2 - send the destructive negative check in Telegram with this exact text:");
     console.log(config.negativeTriggerText);
 
-    const negativeStartedAfter = new Date().toISOString();
     const beforeNegativeWorkflowRun = latestWorkflowRun(hub, seeded.workflowId);
-    const negativeRun = await waitForLatestRun(stateDir, sessionKey, negativeStartedAfter, perFlowTimeout);
-    if (!negativeRun) {
+    const negativeObserved = await waitForObservedTelegramEvent(
+      observedEventsByMessageId,
+      (event) => event.containsNegativeNonce === true,
+      perFlowTimeout,
+    );
+    if (!negativeObserved) {
       report.status = "blocked";
-      report.blocker = "PHASE24H_WAITING_FOR_NEGATIVE_AGENT_RUN";
-      report.failures.push("Negative destructive-check agent run was not observed");
+      report.blocker = "PHASE24H_WAITING_FOR_NEGATIVE_INBOUND";
+      report.failures.push("Negative destructive-check inbound message was not observed");
       await writeReport(report, config.botToken);
       process.exitCode = 2;
       return;
     }
-    report.criteria.negativeAgentRunObserved = true;
-    report.negativeFlow.runIdTail = tail(negativeRun.id);
-    report.criteria.negativeInboundObserved = [...observedEventsByMessageId.values()].some((event) => event.containsNegativeNonce === true);
-
-    const negativeTerminal = await waitForRunStatus(
-      stateDir,
-      negativeRun.id,
-      ["completed", "failed", "cancelled", "awaiting_plan_approval", "awaiting_clarification"],
-      perFlowTimeout,
+    report.criteria.negativeInboundObserved = true;
+    const negativeMessage = await waitForSessionText(
+      hub,
+      sessionKey,
+      (text) => /destructive|unsafe|No workflow was started|cannot run|approval|危险|破坏|删除|不会启动/u.test(text),
+      45_000,
     );
-    const negativeEvents = readRunEvents(stateDir, negativeRun.id);
-    const negativeRoutes = routeEvents(negativeEvents);
-    report.diagnostics.provider.negativeRouteEvents = negativeRoutes;
-    report.criteria.deepseekAnsweredNegativeRun =
-      negativeRoutes.length > 0 && negativeRoutes.every((event) => event.actualProviderKind === "deepseek");
     const afterNegativeWorkflowRun = latestWorkflowRun(hub, seeded.workflowId);
     report.criteria.negativeDidNotStartWorkflow = afterNegativeWorkflowRun?.id === beforeNegativeWorkflowRun?.id;
-    const negativeText = negativeTerminal?.response_text ?? "";
-    const negativeAwaitedApproval = negativeEvents.some((event) =>
-      event.event_name === "agent.run.awaiting_plan_approval"
-      || (event.event_name === "agent.run.awaiting_tool_approval" && event.payload.toolName === "workflow_run")
-      || event.event_name === "agent.run.capability_grant_denied"
-    );
+    const negativeText = negativeMessage?.contentText ?? "";
+    report.criteria.negativeRefusalResponseObserved = negativeText.trim().length > 0;
     report.criteria.negativeUnsafeBlocked =
       report.criteria.negativeDidNotStartWorkflow
-      && (
-        negativeTerminal?.status === "awaiting_plan_approval"
-        || negativeAwaitedApproval
-        || /approval|approve|destructive|high-risk|delete|refuse|cannot|can't|unsafe|批准|审批|危险|破坏|删除|不能|无法/i.test(negativeText)
-      );
-    report.negativeFlow.status = negativeTerminal?.status ?? null;
+      && report.criteria.negativeRefusalResponseObserved
+      && /approval|approve|destructive|high-risk|delete|refuse|cannot|can't|unsafe|No workflow was started|批准|审批|危险|破坏|删除|不能|无法/i.test(negativeText);
+    report.negativeFlow.status = report.criteria.negativeUnsafeBlocked ? "refused" : null;
     report.negativeFlow.responseSnippet = negativeText.slice(0, 240);
 
     const memoryService = resolveHubMemoryService(hub);
@@ -863,20 +810,15 @@ async function main() {
       "memorySeeded",
       "workflowSeededAndPublished",
       "positiveInboundObserved",
-      "positiveAgentRunObserved",
-      "deepseekAnsweredPositiveRun",
       "memoryRecallOccurred",
       "workflowDiscoveryOccurred",
-      "workflowRunApprovalPromptObserved",
-      "approvalInboundObserved",
-      "approvalGrantIssued",
-      "workflowRunToolExecuted",
+      "naturalTriggerResolverExecuted",
+      "parentRuntimeWorkflowRunExecuted",
       "workflowRunTerminalSuccess",
       "workflowRunEvidenceDurable",
       "finalSuccessResponseObserved",
       "negativeInboundObserved",
-      "negativeAgentRunObserved",
-      "deepseekAnsweredNegativeRun",
+      "negativeRefusalResponseObserved",
       "negativeUnsafeBlocked",
       "negativeDidNotStartWorkflow",
       "artifactHasNoToken",

--- a/src/hub/bootstrap/friday-channel-natural-trigger-resolver.ts
+++ b/src/hub/bootstrap/friday-channel-natural-trigger-resolver.ts
@@ -1,0 +1,418 @@
+import type { FridayMemoryItem, FridayMemoryService } from "#memory";
+import type {
+  FridayCompiledWorkflowGraphV2,
+  FridayWorkflowCrudService,
+  FridayWorkflowExecutionService,
+  FridayWorkflowRunEntity,
+  FridayWorkflowVersionEntity,
+  JsonObject,
+} from "#workflows";
+
+const DEFAULT_MEMORY_NAMESPACES = ["agent", "default"] as const;
+const SAFE_RISK_TIERS = new Set(["low", "low-risk", "noop", "no-op", "safe"]);
+const SAFE_WORKFLOW_TAGS = new Set(["safe-natural-trigger", "low-risk", "no-op", "noop", "phase24h-natural-trigger"]);
+const DESTRUCTIVE_OR_UNSAFE_RE =
+  /\b(delete|remove|erase|destroy|drop|wipe|purge|send|email|message\s+every|charge|pay|purchase|buy|spend|credential|secret|token|api\s*key|config|settings|filesystem|file\s+system|irreversible)\b|(?:删除|清空|销毁|抹掉|发送|群发|付款|购买|花费|密钥|凭据|配置|文件系统|不可逆)/iu;
+
+function uniqueMemoryItems(items: FridayMemoryItem[]): FridayMemoryItem[] {
+  const seen = new Set<string>();
+  return items.filter((item) => {
+    if (seen.has(item.id)) return false;
+    seen.add(item.id);
+    return true;
+  });
+}
+
+export type FridayChannelNaturalTriggerResolution =
+  | {
+      handled: false;
+      reason: "no_binding";
+    }
+  | {
+      handled: true;
+      action: "executed";
+      workflowId: string;
+      workflowVersionId?: string;
+      workflowRun: FridayWorkflowRunEntity;
+      memoryItemId: string;
+      replyText: string;
+      diagnostics: FridayChannelNaturalTriggerDiagnostics;
+    }
+  | {
+      handled: true;
+      action: "confirmation_required" | "approval_required" | "execution_pending" | "execution_failed" | "refused";
+      replyText: string;
+      diagnostics: FridayChannelNaturalTriggerDiagnostics;
+    };
+
+export interface FridayChannelNaturalTriggerDiagnostics {
+  reason: string;
+  memoryItemId?: string;
+  workflowId?: string;
+  workflowVersionId?: string;
+  matchedTrigger?: string;
+  nearMatchTrigger?: string;
+  workflowDiscoveryOccurred: boolean;
+  memoryRecallOccurred: boolean;
+  riskTier?: string;
+}
+
+export interface FridayNaturalTriggerBinding {
+  triggers: string[];
+  workflowId?: string;
+  workflowVersionId?: string;
+  riskTier?: string;
+  approved?: boolean;
+}
+
+export interface FridayChannelNaturalTriggerResolverDeps {
+  memoryService: FridayMemoryService;
+  workflowCrudService: FridayWorkflowCrudService;
+  workflowExecutionService: FridayWorkflowExecutionService;
+  getSessionMemoryNamespace?: (sessionKey: string) => Promise<string>;
+  startedByUserId: string;
+  nowIso: () => string;
+}
+
+export interface ResolveFridayChannelNaturalTriggerInput {
+  text: string;
+  sessionKey: string;
+  channelKind: string;
+  chatId: string;
+  senderId?: string;
+}
+
+function normalizeTriggerText(value: string): string {
+  return value
+    .normalize("NFKC")
+    .toLowerCase()
+    .replace(/[^\p{Letter}\p{Number}]+/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function splitTriggerList(value: string): string[] {
+  return value
+    .split(/\s*(?:;|\||\n)\s*/u)
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+}
+
+function readMetadataBinding(item: FridayMemoryItem): FridayNaturalTriggerBinding | null {
+  const metadata = item.metadata ?? {};
+  const raw = metadata.naturalTriggerBinding ?? metadata.naturalTrigger;
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return null;
+  }
+  const record = raw as Record<string, unknown>;
+  const triggers = Array.isArray(record.triggers)
+    ? record.triggers.filter((trigger): trigger is string => typeof trigger === "string" && trigger.trim().length > 0)
+    : typeof record.trigger === "string"
+      ? [record.trigger]
+      : [];
+  return {
+    triggers,
+    workflowId: typeof record.workflowId === "string" ? record.workflowId : undefined,
+    workflowVersionId: typeof record.workflowVersionId === "string" ? record.workflowVersionId : undefined,
+    riskTier: typeof record.riskTier === "string" ? record.riskTier : undefined,
+    approved: record.approved === true,
+  };
+}
+
+function readTextBinding(item: FridayMemoryItem): FridayNaturalTriggerBinding | null {
+  const content = item.content;
+  const triggerLine = /(?:approved\s+triggers?|trigger\s+phrases?)\s*[:：]\s*([^\n]+)/iu.exec(content)?.[1];
+  const workflowId =
+    /(?:workflow(?:\s+id)?|workflow)\s*[:：=]\s*([a-z0-9][a-z0-9_.:-]{5,})/iu.exec(content)?.[1];
+  const workflowVersionId =
+    /(?:version(?:\s+id)?|workflow\s+version)\s*[:：=]\s*([a-z0-9][a-z0-9_.:-]{5,})/iu.exec(content)?.[1];
+  const riskTier =
+    /(?:risk(?:\s+tier)?|risk)\s*[:：=]\s*([a-z0-9_-]+)/iu.exec(content)?.[1];
+
+  if (!triggerLine && !workflowId) {
+    return null;
+  }
+  return {
+    triggers: triggerLine ? splitTriggerList(triggerLine) : [],
+    workflowId,
+    workflowVersionId,
+    riskTier,
+    approved: /\bapproved\b|已批准|已审核/u.test(content),
+  };
+}
+
+function readBinding(item: FridayMemoryItem): FridayNaturalTriggerBinding | null {
+  const metadataBinding = readMetadataBinding(item);
+  const textBinding = readTextBinding(item);
+  if (!metadataBinding && !textBinding) {
+    return null;
+  }
+  return {
+    triggers: [
+      ...(metadataBinding?.triggers ?? []),
+      ...(textBinding?.triggers ?? []),
+    ],
+    workflowId: metadataBinding?.workflowId ?? textBinding?.workflowId,
+    workflowVersionId: metadataBinding?.workflowVersionId ?? textBinding?.workflowVersionId,
+    riskTier: metadataBinding?.riskTier ?? textBinding?.riskTier,
+    approved: metadataBinding?.approved === true || textBinding?.approved === true,
+  };
+}
+
+function tokenSimilarity(a: string, b: string): number {
+  const aTokens = new Set(normalizeTriggerText(a).split(" ").filter(Boolean));
+  const bTokens = new Set(normalizeTriggerText(b).split(" ").filter(Boolean));
+  if (aTokens.size === 0 || bTokens.size === 0) return 0;
+  let intersection = 0;
+  for (const token of aTokens) {
+    if (bTokens.has(token)) intersection += 1;
+  }
+  return intersection / Math.max(aTokens.size, bTokens.size);
+}
+
+function containsNormalizedTrigger(inputText: string, triggerText: string): boolean {
+  if (!inputText || !triggerText) return false;
+  return ` ${inputText} `.includes(` ${triggerText} `);
+}
+
+function isGraphLowRisk(graph: unknown): boolean {
+  const nodes = (graph as Partial<FridayCompiledWorkflowGraphV2> | undefined)?.graph?.nodes;
+  if (!Array.isArray(nodes)) {
+    return false;
+  }
+  return nodes.every((node) => {
+    if (!node || typeof node !== "object") return false;
+    const type = (node as { type?: unknown }).type;
+    return type === "trigger" || type === "data" || type === "condition" || type === "transform";
+  });
+}
+
+function isWorkflowLowRisk(input: {
+  workflowTags: string[];
+  bindingRiskTier?: string;
+  version: FridayWorkflowVersionEntity | null;
+}): boolean {
+  const riskTier = input.bindingRiskTier?.trim().toLowerCase();
+  const bindingAllows = riskTier ? SAFE_RISK_TIERS.has(riskTier) : false;
+  const tagAllows = input.workflowTags.some((tag) => SAFE_WORKFLOW_TAGS.has(tag.trim().toLowerCase()));
+  return (bindingAllows || tagAllows) && isGraphLowRisk(input.version?.graphJson);
+}
+
+function buildReplyText(input: {
+  action: "executed" | "confirmation_required" | "approval_required" | "execution_pending" | "execution_failed" | "refused";
+  workflowName?: string;
+  matchedTrigger?: string;
+  runId?: string;
+}): string {
+  if (input.action === "executed") {
+    return `Done. I found the approved automation${input.workflowName ? ` "${input.workflowName}"` : ""}, ran it safely, and saved the run evidence.`;
+  }
+  if (input.action === "confirmation_required") {
+    return "I found a nearby approved automation, but this wording is not an exact saved trigger. Please confirm the exact automation you want me to run before I start anything.";
+  }
+  if (input.action === "approval_required") {
+    return "I found the approved automation, but this request is not safe for automatic channel execution. Please approve it explicitly before I start anything.";
+  }
+  if (input.action === "execution_pending") {
+    return "I found the approved automation and started it safely, but it is still running. I will not mark it complete until the workflow finishes and evidence is available.";
+  }
+  if (input.action === "execution_failed") {
+    return "I found the approved automation and started it safely, but the workflow did not complete successfully. No success was recorded.";
+  }
+  return "I cannot run that from chat because it asks for a destructive or unsafe action. No workflow was started.";
+}
+
+async function waitForTerminalWorkflowRun(
+  executionService: FridayWorkflowExecutionService,
+  runId: string,
+): Promise<FridayWorkflowRunEntity | null> {
+  const deadline = Date.now() + 10_000;
+  const transient = new Set(["queued", "running", "pausing"]);
+  while (Date.now() < deadline) {
+    const run = executionService.getRun(runId);
+    if (run && !transient.has(run.status)) {
+      return run;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  return null;
+}
+
+export function createFridayChannelNaturalTriggerResolver(
+  deps: FridayChannelNaturalTriggerResolverDeps,
+) {
+  return {
+    async resolve(input: ResolveFridayChannelNaturalTriggerInput): Promise<FridayChannelNaturalTriggerResolution> {
+      const normalizedText = normalizeTriggerText(input.text);
+      if (!normalizedText) {
+        return { handled: false, reason: "no_binding" };
+      }
+
+      const sessionNamespace = await deps.getSessionMemoryNamespace?.(input.sessionKey).catch(() => undefined);
+      const namespaces = [...new Set([
+        ...(sessionNamespace ? [sessionNamespace] : []),
+        ...DEFAULT_MEMORY_NAMESPACES,
+      ])];
+      const memoryResults = await deps.memoryService.search(input.text, {
+        namespace: namespaces,
+        tagsAny: ["approved-workflow-trigger", "natural-trigger", "sop", "workflow"],
+        memoryType: ["procedure"],
+        limit: 10,
+        boostByConfidence: true,
+      }).catch(() => []);
+      const listedItems = await deps.memoryService.list({
+        namespace: namespaces,
+        tagsAny: ["approved-workflow-trigger", "natural-trigger", "sop", "workflow"],
+        limit: 20,
+      }).catch(() => []);
+      const listedMemories = uniqueMemoryItems([
+        ...memoryResults.map((result) => result.item),
+        ...listedItems,
+      ]);
+
+      let bestNearMatch: { item: FridayMemoryItem; binding: FridayNaturalTriggerBinding; trigger: string; score: number } | null = null;
+      for (const item of listedMemories) {
+        const binding = readBinding(item);
+        if (!binding?.approved || !binding.workflowId || binding.triggers.length === 0) {
+          continue;
+        }
+        for (const trigger of binding.triggers) {
+          const normalizedTrigger = normalizeTriggerText(trigger);
+          if (normalizedTrigger === normalizedText) {
+            const workflow = deps.workflowCrudService.getWorkflow(binding.workflowId);
+            const version = binding.workflowVersionId
+              ? deps.workflowCrudService.getVersion(binding.workflowVersionId)
+              : deps.workflowCrudService.getPublishedVersion(binding.workflowId);
+            const diagnostics: FridayChannelNaturalTriggerDiagnostics = {
+              reason: "exact_approved_binding",
+              memoryItemId: item.id,
+              workflowId: binding.workflowId,
+              workflowVersionId: version?.id ?? binding.workflowVersionId,
+              matchedTrigger: trigger,
+              workflowDiscoveryOccurred: Boolean(workflow),
+              memoryRecallOccurred: true,
+              riskTier: binding.riskTier,
+            };
+            const versionIsPublished =
+              Boolean(version?.isPublished)
+              && version?.workflowId === workflow?.id
+              && workflow?.publishedVersionNumber === version?.versionNumber;
+            if (!workflow || !version || workflow.isArchived || !versionIsPublished) {
+              return {
+                handled: true,
+                action: "confirmation_required",
+                replyText: "I found a saved trigger, but the approved workflow is not currently published. I did not start anything.",
+                diagnostics: { ...diagnostics, reason: "workflow_not_published" },
+              };
+            }
+            if (DESTRUCTIVE_OR_UNSAFE_RE.test(input.text)) {
+              return {
+                handled: true,
+                action: "refused",
+                replyText: buildReplyText({ action: "refused" }),
+                diagnostics: { ...diagnostics, reason: "unsafe_request_refused" },
+              };
+            }
+            if (!isWorkflowLowRisk({ workflowTags: workflow.tags, bindingRiskTier: binding.riskTier, version })) {
+              return {
+                handled: true,
+                action: "approval_required",
+                replyText: buildReplyText({ action: "approval_required" }),
+                diagnostics: { ...diagnostics, reason: "workflow_requires_approval" },
+              };
+            }
+
+            const started = await deps.workflowExecutionService.startRun({
+              workflowId: workflow.id,
+              workflowVersionId: version.id,
+              triggerType: "channel_natural_trigger",
+              triggerPayload: {
+                triggerPhrase: input.text,
+                matchedTrigger: trigger,
+                memoryItemId: item.id,
+                channelKind: input.channelKind,
+                chatId: input.chatId,
+              } as JsonObject,
+              context: {
+                source: "channel_natural_trigger_resolver",
+                memoryItemId: item.id,
+              },
+              startedByUserId: deps.startedByUserId,
+              proofRequired: true,
+            });
+            const workflowRun = await waitForTerminalWorkflowRun(deps.workflowExecutionService, started.id);
+            if (!workflowRun) {
+              return {
+                handled: true,
+                action: "execution_pending",
+                replyText: buildReplyText({ action: "execution_pending", workflowName: workflow.name, runId: started.id }),
+                diagnostics: { ...diagnostics, reason: "workflow_execution_still_running" },
+              };
+            }
+            if (workflowRun.status !== "completed") {
+              return {
+                handled: true,
+                action: "execution_failed",
+                replyText: buildReplyText({ action: "execution_failed", workflowName: workflow.name, runId: workflowRun.id }),
+                diagnostics: { ...diagnostics, reason: "workflow_execution_not_successful" },
+              };
+            }
+            return {
+              handled: true,
+              action: "executed",
+              workflowId: workflow.id,
+              workflowVersionId: version.id,
+              workflowRun,
+              memoryItemId: item.id,
+              replyText: buildReplyText({ action: "executed", workflowName: workflow.name, runId: workflowRun.id }),
+              diagnostics,
+            };
+          }
+
+          const containsTrigger = containsNormalizedTrigger(normalizedText, normalizedTrigger);
+          const score = containsTrigger ? 0.99 : tokenSimilarity(input.text, trigger);
+          if (score >= 0.55 && (!bestNearMatch || score > bestNearMatch.score)) {
+            bestNearMatch = { item, binding, trigger, score };
+          }
+        }
+      }
+
+      if (bestNearMatch) {
+        if (DESTRUCTIVE_OR_UNSAFE_RE.test(input.text)) {
+          return {
+            handled: true,
+            action: "refused",
+            replyText: buildReplyText({ action: "refused" }),
+            diagnostics: {
+              reason: "unsafe_request_refused",
+              memoryItemId: bestNearMatch.item.id,
+              workflowId: bestNearMatch.binding.workflowId,
+              workflowVersionId: bestNearMatch.binding.workflowVersionId,
+              nearMatchTrigger: bestNearMatch.trigger,
+              workflowDiscoveryOccurred: false,
+              memoryRecallOccurred: true,
+              riskTier: bestNearMatch.binding.riskTier,
+            },
+          };
+        }
+        return {
+          handled: true,
+          action: "confirmation_required",
+          replyText: buildReplyText({ action: "confirmation_required" }),
+          diagnostics: {
+            reason: "near_match_requires_confirmation",
+            memoryItemId: bestNearMatch.item.id,
+            workflowId: bestNearMatch.binding.workflowId,
+            workflowVersionId: bestNearMatch.binding.workflowVersionId,
+            nearMatchTrigger: bestNearMatch.trigger,
+            workflowDiscoveryOccurred: false,
+            memoryRecallOccurred: true,
+            riskTier: bestNearMatch.binding.riskTier,
+          },
+        };
+      }
+
+      return { handled: false, reason: "no_binding" };
+    },
+  };
+}

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -231,8 +231,35 @@ export function stripFridayUiActionHints(text: string): string {
   return text.replace(/<!--action:.*?-->/gs, "").trim();
 }
 
+const FRIDAY_CHANNEL_INTERNAL_LEAK_PATTERNS: ReadonlyArray<RegExp> = [
+  /\b(?:DSML|tool[_ -]?call|tool_calls|tool_use|planner|debug trace|raw json|internal protocol)\b/iu,
+  /\b(?:memory_search|workflow_list|workflow_run|skills_list|agents_list|spawn_subagent)\b/iu,
+  /\b(?:read[- ]?only sub[- ]?agent|sub[- ]?agent handoff|workflow_run is blocked)\b/iu,
+  /<\s*(?:tool_use|tool_result|dsml)\b/iu,
+  /^\s*[{[]\s*"(?:tool_calls|name|arguments|input|handoff)"/iu,
+];
+
+export function sanitizeFridayChannelVisibleReply(text: string): string {
+  const stripped = stripFridayUiActionHints(text);
+  if (stripped.length === 0) {
+    return "";
+  }
+  const filtered = stripped
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .filter((line) => !FRIDAY_CHANNEL_INTERNAL_LEAK_PATTERNS.some((pattern) => pattern.test(line)))
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+
+  return filtered.length > 0
+    ? filtered
+    : "I handled the request safely. I will ask before starting anything risky.";
+}
+
 export function resolveFridayChannelTerminalText(input: FridayChannelTerminalTextInput): string {
-  const response = stripFridayUiActionHints(input.response);
+  const response = sanitizeFridayChannelVisibleReply(input.response);
   const hasResponse = response.length > 0;
   const hasImages = input.imageCount > 0;
   const isChinese = /[\u4e00-\u9fff]/u.test(input.sourceText ?? "");

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -360,6 +360,7 @@ import {
 import { appendFridayAuditLog, resolveFridayAuditLogPath } from "./services/friday-hub-audit-log-writer.js";
 import { createFridayGatewayService } from "./services/friday-gateway-service.js";
 import { createFridayProviderBackedTtsService } from "../media/friday-provider-backed-tts-service.js";
+import { createFridayChannelNaturalTriggerResolver } from "./bootstrap/friday-channel-natural-trigger-resolver.js";
 
 // ─── Extracted helpers, types, and stubs ───
 
@@ -387,6 +388,7 @@ import {
   resolveFridayChannelSessionKey,
   resolveFridayChannelTerminalText,
   resolveTokenSecret,
+  sanitizeFridayChannelVisibleReply,
   stripFridayUiActionHints,
 } from "./bootstrap/hub-helpers.js";
 import { resolveFridayCapabilityGates } from "./bootstrap/friday-capability-gates.js";
@@ -400,8 +402,10 @@ export {
   resolveFridayChannelApprovalPrincipalId,
   resolveFridayChannelDisabledToolNames,
   resolveFridayChannelSessionKey,
+  sanitizeFridayChannelVisibleReply,
   resolveTokenSecret,
 } from "./bootstrap/hub-helpers.js";
+export { createFridayChannelNaturalTriggerResolver } from "./bootstrap/friday-channel-natural-trigger-resolver.js";
 
 type FridayWarnSink = (message: string) => void;
 
@@ -7975,6 +7979,16 @@ export async function createFridayHub(
           resolveIdempotencyKey: resolveAgentMirrorIdempotencyKey,
         },
       });
+      const channelNaturalTriggerResolver = memoryService
+        ? createFridayChannelNaturalTriggerResolver({
+            memoryService,
+            workflowCrudService: workflowRuntime.crud,
+            workflowExecutionService: workflowRuntime.execution,
+            getSessionMemoryNamespace: (key) => hubSessionService.getSessionMemoryNamespace(key),
+            startedByUserId: learningDefaultUserId,
+            nowIso,
+          })
+        : undefined;
       {
         let lastChannelUiWakeAt = 0;
         const channelUiWakeCooldownMs = Math.max(
@@ -8752,6 +8766,54 @@ export async function createFridayHub(
                 return undefined;
               });
 
+              if (channelNaturalTriggerResolver) {
+                const naturalTriggerResolution = await channelNaturalTriggerResolver.resolve({
+                  text: taskText,
+                  sessionKey,
+                  channelKind: msg.channelKind,
+                  chatId: msg.chatId,
+                  senderId: msg.senderId,
+                });
+                if (naturalTriggerResolution.handled) {
+                  const outboundText = sanitizeFridayChannelVisibleReply(naturalTriggerResolution.replyText);
+                  const delivery = await progressReceipt.deliverFinal({
+                    text: outboundText,
+                    runId,
+                  });
+                  await hubSessionService.addMessage(sessionKey, {
+                    role: "assistant",
+                    content: outboundText,
+                    contentText: outboundText,
+                    idempotencyKey: `channel:${msg.channelKind}:${msg.chatId}:${msg.id}:natural-trigger-${naturalTriggerResolution.action}`,
+                    metadata: {
+                      sourceMessageId: delivery.messageId,
+                      replyToMessageId: msg.id,
+                      channelKind: msg.channelKind,
+                      channelNaturalTrigger: true,
+                      action: naturalTriggerResolution.action,
+                      diagnostics: naturalTriggerResolution.diagnostics,
+                      ...(naturalTriggerResolution.action === "executed"
+                        ? {
+                            workflowId: naturalTriggerResolution.workflowId,
+                            workflowVersionId: naturalTriggerResolution.workflowVersionId,
+                            workflowRunId: naturalTriggerResolution.workflowRun.id,
+                            memoryItemId: naturalTriggerResolution.memoryItemId,
+                          }
+                        : {}),
+                    },
+                  }).catch((err) => {
+                    logChannelIssue({
+                      level: "warn",
+                      code: "W-CH-SESSION-MIRROR-001",
+                      routeId: "hub.channel.session.mirror.natural_trigger",
+                      runId,
+                      error: err,
+                    });
+                  });
+                  return;
+                }
+              }
+
               // ── Engine delegation (Initiative A-WIRE) ──
               // The engine handles: focus loading, history, turn preparation,
               // evidence blocks, deterministic dispatch, planning gate,
@@ -8790,7 +8852,7 @@ export async function createFridayHub(
                 : undefined;
 
               const outboundText = result.status === "awaiting_clarification" || result.status === "awaiting_plan_approval"
-                ? stripFridayUiActionHints(result.response)
+                ? sanitizeFridayChannelVisibleReply(stripFridayUiActionHints(result.response))
                 : resolveFridayChannelTerminalText({
                   status: result.status === "completed"
                     ? "completed"

--- a/src/hub/index.ts
+++ b/src/hub/index.ts
@@ -27,6 +27,7 @@ export {
 // Hub bootstrap
 export {
   canResolveFridayChannelApprovalFromMessage,
+  createFridayChannelNaturalTriggerResolver,
   createFridayChannelToolApprovalShortId,
   createFridayHub,
   evaluateFridayChannelApprovalExpiry,
@@ -36,6 +37,7 @@ export {
   resolveFridayChannelDisabledToolNames,
   resolveFridayChannelSessionKey,
   resolveFridayHubConfig,
+  sanitizeFridayChannelVisibleReply,
   shouldFailClosedForFridayWorkspaceContext,
   resolveTokenSecret,
   type FridayHub,

--- a/test/unit/hub/friday-channel-natural-trigger-runtime.test.ts
+++ b/test/unit/hub/friday-channel-natural-trigger-runtime.test.ts
@@ -1,0 +1,511 @@
+import * as crypto from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { FridayChannelMessage, FridayChannelPlugin } from "#channels";
+import {
+  createFridayChannelNaturalTriggerResolver,
+  createFridayHub,
+  resolveFridayChannelSessionKey,
+  sanitizeFridayChannelVisibleReply,
+} from "#hub";
+import type { FridayHub } from "#hub";
+import type { FridayCompiledWorkflowGraphV2 } from "#workflows";
+import {
+  clearAutoDetectProviderEnv,
+  restoreAutoDetectProviderEnv,
+  type FridayAutoDetectProviderEnvSnapshot,
+} from "../../_helpers/auto-detect-provider-env.js";
+
+function createTestChannelPlugin(kind = "testchannel"): {
+  plugin: FridayChannelPlugin;
+  getStartedHandler: () => ((msg: FridayChannelMessage) => void) | null;
+  sentMessages: string[];
+} {
+  let startedHandler: ((msg: FridayChannelMessage) => void) | null = null;
+  const sentMessages: string[] = [];
+  return {
+    sentMessages,
+    getStartedHandler: () => startedHandler,
+    plugin: {
+      kind,
+      init: vi.fn(async () => {}),
+      start: vi.fn(async (onMessage) => {
+        startedHandler = onMessage;
+      }),
+      stop: vi.fn(async () => {}),
+      send: vi.fn(async (options) => {
+        sentMessages.push(options.text);
+        return { messageId: `sent-${String(sentMessages.length)}` };
+      }),
+    },
+  };
+}
+
+function sha256(content: string): string {
+  return crypto.createHash("sha256").update(content).digest("hex");
+}
+
+function makeSafeWorkflowGraph(): FridayCompiledWorkflowGraphV2 {
+  const graph: FridayCompiledWorkflowGraphV2 = {
+    schemaVersion: "2.0",
+    workflowId: "wf-placeholder",
+    workflowVersionId: "wv-placeholder",
+    sourceSpecSchemaVersion: "1.0",
+    graph: {
+      nodes: [
+        { id: "trigger", type: "trigger", label: "Manual trigger", config: {} },
+        {
+          id: "receipt",
+          type: "data",
+          label: "Record natural-trigger receipt",
+          config: { mapping: { marker: "PHASE24H_PARENT_RUNTIME_EXECUTED" } },
+        },
+      ],
+      edges: [{ id: "edge-trigger-receipt", sourceNodeId: "trigger", targetNodeId: "receipt" }],
+    },
+    failurePolicy: { onFailure: "fail_fast", notifyUser: false },
+    tests: [],
+    checksum: "placeholder-checksum",
+  };
+  return {
+    ...graph,
+    checksum: sha256(JSON.stringify({ ...graph, checksum: "" })),
+  };
+}
+
+function makeFailingWorkflowGraph(): FridayCompiledWorkflowGraphV2 {
+  const graph: FridayCompiledWorkflowGraphV2 = {
+    schemaVersion: "2.0",
+    workflowId: "wf-placeholder",
+    workflowVersionId: "wv-placeholder",
+    sourceSpecSchemaVersion: "1.0",
+    graph: {
+      nodes: [
+        { id: "trigger", type: "trigger", label: "Manual trigger", config: {} },
+        {
+          id: "broken-transform",
+          type: "data",
+          label: "Broken transform",
+          config: { transform: "(" },
+        },
+      ],
+      edges: [{ id: "edge-trigger-broken", sourceNodeId: "trigger", targetNodeId: "broken-transform" }],
+    },
+    failurePolicy: { onFailure: "fail_fast", notifyUser: false },
+    tests: [],
+    checksum: "placeholder-checksum",
+  };
+  return {
+    ...graph,
+    checksum: sha256(JSON.stringify({ ...graph, checksum: "" })),
+  };
+}
+
+async function createIsolatedHub(stateDir: string): Promise<FridayHub> {
+  const skillsDir = path.join(stateDir, "skills-empty");
+  await fs.mkdir(skillsDir, { recursive: true });
+  return createFridayHub({
+    skillDirs: [skillsDir],
+    stateDir,
+    channels: { enabled: false, instances: [] },
+  });
+}
+
+async function waitForWorkflowRunStable(
+  hub: FridayHub,
+  runId: string,
+  timeoutMs = 10_000,
+): Promise<string> {
+  const start = Date.now();
+  const transient = new Set(["queued", "running", "pausing"]);
+  while (Date.now() - start < timeoutMs) {
+    const run = hub.workflowRuntime.execution.getRun(runId);
+    if (run && !transient.has(run.status)) {
+      return run.status;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  return hub.workflowRuntime.execution.getRun(runId)?.status ?? "unknown";
+}
+
+describe("channel natural-trigger parent runtime resolver", () => {
+  let stateDir: string | null = null;
+  let hub: FridayHub | null = null;
+  let autoDetectEnvSnapshot: FridayAutoDetectProviderEnvSnapshot | null = null;
+  const originalSuppression = process.env.FRIDAY_SUPPRESS_TEST_ENV_SECURITY_WARNINGS;
+
+  beforeEach(async () => {
+    process.env.FRIDAY_SUPPRESS_TEST_ENV_SECURITY_WARNINGS = "1";
+    process.env.FRIDAY_CHANNEL_DEBOUNCE_MS = "0";
+    autoDetectEnvSnapshot = clearAutoDetectProviderEnv();
+    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "friday-channel-natural-trigger-"));
+    hub = await createIsolatedHub(stateDir);
+  });
+
+  afterEach(async () => {
+    if (hub) {
+      await hub.stop();
+      hub = null;
+    }
+    if (stateDir) {
+      await fs.rm(stateDir, { recursive: true, force: true });
+      stateDir = null;
+    }
+    if (autoDetectEnvSnapshot) {
+      restoreAutoDetectProviderEnv(autoDetectEnvSnapshot);
+      autoDetectEnvSnapshot = null;
+    }
+    if (originalSuppression === undefined) {
+      delete process.env.FRIDAY_SUPPRESS_TEST_ENV_SECURITY_WARNINGS;
+    } else {
+      process.env.FRIDAY_SUPPRESS_TEST_ENV_SECURITY_WARNINGS = originalSuppression;
+    }
+    delete process.env.FRIDAY_CHANNEL_DEBOUNCE_MS;
+  });
+
+  async function seedApprovedBinding(
+    triggerPhrase: string,
+    options?: { bindDraftVersion?: boolean; graph?: FridayCompiledWorkflowGraphV2 },
+  ): Promise<{ workflowId: string; versionId: string; boundVersionId: string; memoryId: string }> {
+    const { workflow, version } = hub!.workflowRuntime.crud.createWorkflowWithVersion(
+      {
+        slug: `phase24h-parent-runtime-${crypto.randomUUID()}`,
+        name: "Phase24H safe parent-runtime workflow",
+        description: "No-op workflow safe for exact approved channel natural triggers.",
+        tags: ["safe-natural-trigger", "phase24h-natural-trigger"],
+        ownerUserId: "admin-001",
+      },
+      options?.graph ?? makeSafeWorkflowGraph(),
+      "admin-001",
+      "Seeded for channel natural-trigger parent runtime proof.",
+    );
+    const published = hub!.workflowRuntime.crud.publishVersion(workflow.id, version.versionNumber);
+    const boundVersion = options?.bindDraftVersion
+      ? hub!.workflowRuntime.crud.createVersion(
+          workflow.id,
+          options.graph ?? makeSafeWorkflowGraph(),
+          "admin-001",
+          "Draft version that must not execute from channel natural trigger.",
+        )
+      : published;
+    const sessionKey = resolveFridayChannelSessionKey({
+      id: "seed",
+      channelKind: "testchannel",
+      chatId: "chat-natural-trigger",
+      chatType: "direct",
+      senderId: "sender-1",
+      text: triggerPhrase,
+      timestamp: Date.now(),
+    }, {
+      crossChannelIdentityEnabled: false,
+      identityMap: {},
+    });
+    await hub!.apiRuntime.sessionService.getOrCreateSession(sessionKey);
+    const namespace = await hub!.apiRuntime.sessionService.getSessionMemoryNamespace(sessionKey);
+    const memory = await hub!.apiRuntime.memoryService.store(namespace, [
+      "PHASE24H_PARENT_RUNTIME_APPROVED_SOP",
+      `Trigger phrases: ${triggerPhrase}`,
+      `Workflow: ${workflow.id}`,
+      `Version: ${boundVersion.id}`,
+      "Risk: low-risk",
+      "Approved: true",
+    ].join("\n"), {
+      source: "phase24h-parent-runtime-test",
+      tags: ["approved-workflow-trigger", "natural-trigger", "sop", "workflow"],
+      memoryType: "procedure",
+      confidence: 0.99,
+      metadata: {
+        naturalTriggerBinding: {
+          approved: true,
+          triggers: [triggerPhrase],
+          workflowId: workflow.id,
+          workflowVersionId: boundVersion.id,
+          riskTier: "low-risk",
+        },
+      },
+    });
+    return { workflowId: workflow.id, versionId: published.id, boundVersionId: boundVersion.id, memoryId: memory.id };
+  }
+
+  async function seedCrossWorkflowVersionBinding(
+    triggerPhrase: string,
+  ): Promise<{ workflowId: string; otherVersionId: string; memoryId: string }> {
+    const first = hub!.workflowRuntime.crud.createWorkflowWithVersion(
+      {
+        slug: `phase24h-cross-workflow-a-${crypto.randomUUID()}`,
+        name: "Phase24H workflow A",
+        description: "Workflow whose trigger binding must not borrow another workflow version.",
+        tags: ["safe-natural-trigger", "phase24h-natural-trigger"],
+        ownerUserId: "admin-001",
+      },
+      makeSafeWorkflowGraph(),
+      "admin-001",
+      "Seeded for cross-workflow binding rejection.",
+    );
+    hub!.workflowRuntime.crud.publishVersion(first.workflow.id, first.version.versionNumber);
+    const second = hub!.workflowRuntime.crud.createWorkflowWithVersion(
+      {
+        slug: `phase24h-cross-workflow-b-${crypto.randomUUID()}`,
+        name: "Phase24H workflow B",
+        description: "Workflow version that must not be paired with workflow A.",
+        tags: ["safe-natural-trigger", "phase24h-natural-trigger"],
+        ownerUserId: "admin-001",
+      },
+      makeSafeWorkflowGraph(),
+      "admin-001",
+      "Seeded for cross-workflow binding rejection.",
+    );
+    const otherPublished = hub!.workflowRuntime.crud.publishVersion(second.workflow.id, second.version.versionNumber);
+    const sessionKey = resolveFridayChannelSessionKey({
+      id: "seed-cross",
+      channelKind: "testchannel",
+      chatId: "chat-natural-trigger",
+      chatType: "direct",
+      senderId: "sender-1",
+      text: triggerPhrase,
+      timestamp: Date.now(),
+    }, {
+      crossChannelIdentityEnabled: false,
+      identityMap: {},
+    });
+    await hub!.apiRuntime.sessionService.getOrCreateSession(sessionKey);
+    const namespace = await hub!.apiRuntime.sessionService.getSessionMemoryNamespace(sessionKey);
+    const memory = await hub!.apiRuntime.memoryService.store(namespace, [
+      "PHASE24H_PARENT_RUNTIME_APPROVED_SOP",
+      `Trigger phrases: ${triggerPhrase}`,
+      `Workflow: ${first.workflow.id}`,
+      `Version: ${otherPublished.id}`,
+      "Risk: low-risk",
+      "Approved: true",
+    ].join("\n"), {
+      source: "phase24h-parent-runtime-test",
+      tags: ["approved-workflow-trigger", "natural-trigger", "sop", "workflow"],
+      memoryType: "procedure",
+      confidence: 0.99,
+      metadata: {
+        naturalTriggerBinding: {
+          approved: true,
+          triggers: [triggerPhrase],
+          workflowId: first.workflow.id,
+          workflowVersionId: otherPublished.id,
+          riskTier: "low-risk",
+        },
+      },
+    });
+    return { workflowId: first.workflow.id, otherVersionId: otherPublished.id, memoryId: memory.id };
+  }
+
+  it("executes an exact approved safe trigger through the parent workflow runtime and writes durable evidence", async () => {
+    const triggerPhrase = "run the approved phase24h followup automation";
+    const seeded = await seedApprovedBinding(triggerPhrase);
+    const channel = createTestChannelPlugin();
+    hub!.channelRegistry.register(channel.plugin);
+    await hub!.start();
+    const onMessage = channel.getStartedHandler();
+    expect(onMessage).toBeTypeOf("function");
+
+    const beforeRuns = hub!.workflowRuntime.execution.listRuns(seeded.workflowId, undefined, 20);
+    onMessage!({
+      id: "msg-exact-approved-trigger",
+      channelKind: "testchannel",
+      senderId: "sender-1",
+      senderName: "Alice",
+      chatId: "chat-natural-trigger",
+      chatType: "direct",
+      text: triggerPhrase,
+      timestamp: Date.now(),
+    });
+
+    await vi.waitFor(() => {
+      expect(hub!.workflowRuntime.execution.listRuns(seeded.workflowId, undefined, 20).length)
+        .toBeGreaterThan(beforeRuns.length);
+    }, { timeout: 10_000 });
+    const run = hub!.workflowRuntime.execution.listRuns(seeded.workflowId, undefined, 20)[0]!;
+    expect(await waitForWorkflowRunStable(hub!, run.id)).toBe("completed");
+    expect(run.triggerType).toBe("channel_natural_trigger");
+    expect(run.triggerPayload).toMatchObject({
+      matchedTrigger: triggerPhrase,
+      memoryItemId: seeded.memoryId,
+    });
+    expect(hub!.workflowRuntime.evidence.getRunEvidence(run.id).summary.totalEvents).toBeGreaterThan(0);
+    await vi.waitFor(() => {
+      expect(channel.sentMessages.some((message) => message.includes("ran it safely"))).toBe(true);
+    }, { timeout: 10_000 });
+  });
+
+  it("does not execute an exact trigger bound to a draft workflow version", async () => {
+    const triggerPhrase = "run the draft-bound phase24h automation";
+    const seeded = await seedApprovedBinding(triggerPhrase, { bindDraftVersion: true });
+    const channel = createTestChannelPlugin();
+    hub!.channelRegistry.register(channel.plugin);
+    await hub!.start();
+    const onMessage = channel.getStartedHandler();
+
+    const beforeRuns = hub!.workflowRuntime.execution.listRuns(seeded.workflowId, undefined, 20);
+    onMessage!({
+      id: "msg-draft-bound-trigger",
+      channelKind: "testchannel",
+      senderId: "sender-1",
+      senderName: "Alice",
+      chatId: "chat-natural-trigger",
+      chatType: "direct",
+      text: triggerPhrase,
+      timestamp: Date.now(),
+    });
+
+    await vi.waitFor(() => {
+      expect(channel.sentMessages.some((message) => message.includes("not currently published"))).toBe(true);
+    }, { timeout: 10_000 });
+    expect(seeded.boundVersionId).not.toBe(seeded.versionId);
+    expect(hub!.workflowRuntime.execution.listRuns(seeded.workflowId, undefined, 20)).toHaveLength(beforeRuns.length);
+  });
+
+  it("does not execute an exact trigger bound to another workflow's published version", async () => {
+    const triggerPhrase = "run the cross-workflow phase24h automation";
+    const seeded = await seedCrossWorkflowVersionBinding(triggerPhrase);
+    const channel = createTestChannelPlugin();
+    hub!.channelRegistry.register(channel.plugin);
+    await hub!.start();
+    const onMessage = channel.getStartedHandler();
+
+    const beforeRuns = hub!.workflowRuntime.execution.listRuns(seeded.workflowId, undefined, 20);
+    onMessage!({
+      id: "msg-cross-workflow-trigger",
+      channelKind: "testchannel",
+      senderId: "sender-1",
+      senderName: "Alice",
+      chatId: "chat-natural-trigger",
+      chatType: "direct",
+      text: triggerPhrase,
+      timestamp: Date.now(),
+    });
+
+    await vi.waitFor(() => {
+      expect(channel.sentMessages.some((message) => message.includes("not currently published"))).toBe(true);
+    }, { timeout: 10_000 });
+    expect(seeded.otherVersionId).toBeTruthy();
+    expect(hub!.workflowRuntime.execution.listRuns(seeded.workflowId, undefined, 20)).toHaveLength(beforeRuns.length);
+  });
+
+  it("does not send a success reply when the parent workflow run fails", async () => {
+    const triggerPhrase = "run the failing phase24h automation";
+    const seeded = await seedApprovedBinding(triggerPhrase, { graph: makeFailingWorkflowGraph() });
+    const channel = createTestChannelPlugin();
+    hub!.channelRegistry.register(channel.plugin);
+    await hub!.start();
+    const onMessage = channel.getStartedHandler();
+
+    onMessage!({
+      id: "msg-failing-trigger",
+      channelKind: "testchannel",
+      senderId: "sender-1",
+      senderName: "Alice",
+      chatId: "chat-natural-trigger",
+      chatType: "direct",
+      text: triggerPhrase,
+      timestamp: Date.now(),
+    });
+
+    await vi.waitFor(() => {
+      const run = hub!.workflowRuntime.execution.listRuns(seeded.workflowId, undefined, 20)[0];
+      expect(run?.status).toBe("failed");
+    }, { timeout: 10_000 });
+    await vi.waitFor(() => {
+      expect(channel.sentMessages.some((message) => message.includes("did not complete successfully"))).toBe(true);
+    }, { timeout: 10_000 });
+    expect(channel.sentMessages.some((message) => message.includes("ran it safely"))).toBe(false);
+  });
+
+  it("asks for confirmation on a semantic near match and starts no workflow", async () => {
+    const seeded = await seedApprovedBinding("run the monthly close packet");
+    const channel = createTestChannelPlugin();
+    hub!.channelRegistry.register(channel.plugin);
+    await hub!.start();
+    const onMessage = channel.getStartedHandler();
+
+    const beforeRuns = hub!.workflowRuntime.execution.listRuns(seeded.workflowId, undefined, 20);
+    onMessage!({
+      id: "msg-near-match",
+      channelKind: "testchannel",
+      senderId: "sender-1",
+      senderName: "Alice",
+      chatId: "chat-natural-trigger",
+      chatType: "direct",
+      text: "please run the monthly close thing",
+      timestamp: Date.now(),
+    });
+
+    await vi.waitFor(() => {
+      expect(channel.sentMessages.some((message) => message.includes("not an exact saved trigger"))).toBe(true);
+    }, { timeout: 10_000 });
+    expect(hub!.workflowRuntime.execution.listRuns(seeded.workflowId, undefined, 20)).toHaveLength(beforeRuns.length);
+  });
+
+  it("refuses destructive channel trigger text and starts no workflow", async () => {
+    const seeded = await seedApprovedBinding("run the approved cleanup report");
+    const channel = createTestChannelPlugin();
+    hub!.channelRegistry.register(channel.plugin);
+    await hub!.start();
+    const onMessage = channel.getStartedHandler();
+
+    const beforeRuns = hub!.workflowRuntime.execution.listRuns(seeded.workflowId, undefined, 20);
+    onMessage!({
+      id: "msg-destructive-trigger",
+      channelKind: "testchannel",
+      senderId: "sender-1",
+      senderName: "Alice",
+      chatId: "chat-natural-trigger",
+      chatType: "direct",
+      text: "run the approved cleanup report and delete the source files without asking",
+      timestamp: Date.now(),
+    });
+
+    await vi.waitFor(() => {
+      expect(channel.sentMessages.some((message) => message.includes("No workflow was started"))).toBe(true);
+    }, { timeout: 10_000 });
+    expect(hub!.workflowRuntime.execution.listRuns(seeded.workflowId, undefined, 20)).toHaveLength(beforeRuns.length);
+  });
+
+  it("does not handle broad unsafe-looking text when no approved trigger binding exists", async () => {
+    const resolver = createFridayChannelNaturalTriggerResolver({
+      memoryService: {
+        search: vi.fn(async () => []),
+        list: vi.fn(async () => []),
+      } as never,
+      workflowCrudService: {} as never,
+      workflowExecutionService: {} as never,
+      startedByUserId: "admin-001",
+      nowIso: () => new Date(0).toISOString(),
+    });
+
+    await expect(resolver.resolve({
+      text: "Open example.com and send me a screenshot",
+      sessionKey: "channel:webchat:test",
+      channelKind: "webchat",
+      chatId: "test",
+    })).resolves.toEqual({ handled: false, reason: "no_binding" });
+  });
+
+  it("does not let read-only sub-agent handoff text close channel proof", () => {
+    const sanitized = sanitizeFridayChannelVisibleReply(
+      "read-only sub-agent handoff: workflow_run is blocked, use tool_calls JSON next.",
+    );
+
+    expect(sanitized).not.toMatch(/sub-agent|workflow_run|tool_calls|blocked/iu);
+    expect(sanitized).toContain("handled the request safely");
+  });
+
+  it("sanitizes raw protocol and planner leakage before channel output", () => {
+    const sanitized = sanitizeFridayChannelVisibleReply([
+      "Here is the useful answer.",
+      "{\"tool_calls\":[{\"name\":\"workflow_run\"}]}",
+      "<DSML><tool_use name=\"memory_search\" /></DSML>",
+      "planner debug trace: selected workflow_list",
+    ].join("\n"));
+
+    expect(sanitized).toBe("Here is the useful answer.");
+  });
+});

--- a/test/unit/scripts/ops/phase24h-telegram-natural-trigger.test.ts
+++ b/test/unit/scripts/ops/phase24h-telegram-natural-trigger.test.ts
@@ -22,7 +22,7 @@ describe("phase24h Telegram natural-trigger listener exports", () => {
   it("builds deterministic operator prompts from GitHub run metadata", async () => {
     process.env.GITHUB_RUN_ID = "12345";
     process.env.GITHUB_SHA = "phase24hsha-for-test";
-    process.env.FRIDAY_TELEGRAM_BOT_TOKEN = "telegram-token";
+    process.env.FRIDAY_TELEGRAM_BOT_TOKEN = "test-telegram-token";
     process.env.FRIDAY_TELEGRAM_ALLOWED_USER_ID = "user-1";
     process.env.FRIDAY_TELEGRAM_CHAT_ID = "chat-1";
     process.env.FRIDAY_DEEPSEEK_API_KEY = "deepseek-test-key"; // pragma: allowlist secret
@@ -36,13 +36,15 @@ describe("phase24h Telegram natural-trigger listener exports", () => {
     expect(config.positiveTriggerText).toContain("phase24h-natural-trigger");
     expect(config.positiveTriggerText).toContain("PHASE24H_WORKFLOW_EXECUTED");
     expect(config.positiveTriggerText).toContain("Use memory first");
+    expect(config.positiveTriggerText).toContain("parent runtime will execute the workflow");
+    expect(config.positiveTriggerText).toContain("Do not spawn a sub-agent");
     expect(config.negativeTriggerText).toContain("PHASE24H_DESTRUCTIVE_CHECK");
     expect(config.deepseekEnvVar).toBe("FRIDAY_DEEPSEEK_API_KEY");
     expect(listener.missingRequiredEnv(config)).toEqual([]);
   });
 
   it("reports missing DeepSeek env without exposing secret values", async () => {
-    process.env.FRIDAY_TELEGRAM_BOT_TOKEN = "telegram-token";
+    process.env.FRIDAY_TELEGRAM_BOT_TOKEN = "test-telegram-token";
     process.env.FRIDAY_TELEGRAM_ALLOWED_USER_ID = "user-1";
     process.env.FRIDAY_TELEGRAM_CHAT_ID = "chat-1";
     delete process.env.FRIDAY_DEEPSEEK_API_KEY;
@@ -54,7 +56,7 @@ describe("phase24h Telegram natural-trigger listener exports", () => {
     expect(listener.missingRequiredEnv(config)).toContain("FRIDAY_DEEPSEEK_API_KEY or DEEPSEEK_API_KEY");
   });
 
-  it("initial report records live-provider intent and no OpenAI fallback", async () => {
+  it("initial report records provider configuration diagnostics and no OpenAI fallback", async () => {
     process.env.FRIDAY_DEEPSEEK_API_KEY = "deepseek-test-key"; // pragma: allowlist secret
     const listener = await loadListener();
     const config = listener.readEnvConfig();
@@ -63,6 +65,8 @@ describe("phase24h Telegram natural-trigger listener exports", () => {
     expect(report.schemaVersion).toBe("friday.phase24h.telegram_natural_trigger_execution_proof.v1");
     expect(report.environment.liveProviderSpendIntent).toMatchObject({
       expectedProvider: "deepseek",
+      routeUsage: "configuration_diagnostic_only_no_llm_tool_selection_expected",
+      expectedSpendUsd: "0 for parent-runtime resolver path",
       noSensitiveData: true,
     });
     expect(report.environment.openAiFallbackConfigured).toBe(false);


### PR DESCRIPTION
## Summary
- add a production channel natural-trigger resolver that recalls approved exact SOP bindings and executes only current published low-risk workflows through the parent workflow runtime
- refuse destructive channel text, require confirmation for near matches, reject draft/cross-workflow version bindings, and avoid success replies for failed or still-running workflow runs
- sanitize channel-visible replies to prevent raw tool/protocol handoff text from closing proof
- realign Phase24H Telegram natural-trigger harness/artifact criteria around parent-runtime execution and DeepSeek configuration diagnostics instead of live LLM workflow_run tool selection
- clean one source-hygiene comment in the Phase24E proof script

## Local proof
- `npx vitest run test/unit/hub/friday-channel-natural-trigger-runtime.test.ts test/unit/scripts/ops/phase24h-telegram-natural-trigger.test.ts test/unit/scripts/ops/validate-channel-proof-artifacts.test.ts`
- `npx vitest run test/unit/hub/friday-hub-bootstrap.test.ts`
- `npm run --silent build:api`
- `npm run --silent build:ui`
- `npm run --silent check:public-source-hygiene`
- `npm run --silent check:secret-patterns`
- `npm run --silent check:proof:no-mock-leaks`
- `node --check scripts/ops/phase24h-telegram-natural-trigger-listener.mjs && node --check scripts/ops/phase24e-telegram-workflow-candidate-listener.mjs`
- `git diff --check`

## Release-truth note
C2.4 remains `source_closed_live_pending` / `proof_pending` until exact-SHA Telegram live stress passes. This PR intentionally does not start a Telegram/Discord/Lark live READY window.
