### PR TITLE
docs(release): tighten policy surface truth labels

### DIFF
--- a/docs/ops/friday-agent-os-beta-onboarding.md
+++ b/docs/ops/friday-agent-os-beta-onboarding.md
@@ -1,6 +1,6 @@
 # Friday Agent OS Beta Onboarding
 
-Use this guide for the first external-operator setup of Friday Agent OS on a single-user Mac.
+Use this guide for the first external-operator setup of Friday Agent OS on a single-user Mac. This is beta-candidate onboarding; it does not claim public desktop, Homebrew, notarized macOS, or mobile release readiness until the required external evidence is archived.
 
 ## What you need
 
@@ -18,7 +18,7 @@ For local engineering validation:
 bash scripts/ops/release-friday-companion-app.sh
 ```
 
-For a real beta release candidate, use the notarized path described in [friday-companion-release-macos.md](./docs/ops/friday-companion-release-macos.md).
+For a real beta release candidate, use the notarized path described in [friday-companion-release-macos.md](./friday-companion-release-macos.md).
 
 Expected result:
 
@@ -28,7 +28,7 @@ Expected result:
 - `dist/releases/macos/*.dmg`
 - `dist/releases/macos/*.zip`
 - `dist/releases/Friday.release-manifest.json`
-- `dist/releases/homebrew/Casks/friday.rb`
+- `dist/releases/homebrew/Casks/friday.rb` local generated cask file; this is not Homebrew tap publication evidence
 
 ## 2. Install launchd startup
 
@@ -132,7 +132,7 @@ Before handing the setup to another external operator, confirm:
 
 - release evidence files exist in `dist/macos/`
 - packaged release artifacts exist in `dist/releases/macos/`
-- the Homebrew Cask exists in `dist/releases/homebrew/Casks/friday.rb`
+- the generated Homebrew Cask file exists locally in `dist/releases/homebrew/Casks/friday.rb`
 - launchd status is healthy
 - required macOS permissions are granted
 - passkey enrollment succeeds

--- a/docs/ops/friday-capability-matrix.md
+++ b/docs/ops/friday-capability-matrix.md
@@ -88,7 +88,7 @@ Configure it in Setup -> Capabilities -> OCR. After that I will run a sample ima
 
 ## Capability Headlines (Boundary Summary)
 
-The matrix above is the structured contract. The following three plain-language headlines summarize the current public `1.0.2` npm/source boundary and the unpublished `1.0.3` package-candidate source delta in operator-readable terms. They are the canonical wording the rest of the product surface (UI copy, release notes, docs) must align with:
+The matrix above is the structured contract. The following three plain-language headlines summarize the current public `1.0.2` npm/runtime boundary and the unpublished GitHub-main `1.0.3` package-candidate source delta in operator-readable terms. They are the canonical wording the rest of the product surface (UI copy, release notes, docs) must align with:
 
 Source-truth delta after the immutable npm `1.0.2` package: GitHub-visible main
 has subsequently closed deterministic DP-10 personal-secretary loop proof
@@ -100,9 +100,10 @@ closes Home supervised low-risk self-repair UI proof by PR #359, and closes
 user-visible workflow retry receipt/final-state proof by PR #360. Later source
 also closes C2.4 parent-runtime natural-trigger source repair by PR #377, C3/C4
 live-provider routing proof by PR #378, and C4.5 direct synthetic real-user
-intelligence proof by PR #379. Package/npm truth stays separate. Do not read
-these source closures as already published npm `1.0.2` behavior or as a
-published `1.0.3` release.
+intelligence proof by PR #379. PR #380 prepares the unpublished `1.0.3` package
+candidate on GitHub main without npm publish, tag, or GitHub release. Package/npm
+truth stays separate. Do not read these source closures as already published npm
+`1.0.2` behavior or as a published `1.0.3` release.
 
 ### What Friday Can Do Today
 

--- a/docs/ops/friday-companion-release-macos.md
+++ b/docs/ops/friday-companion-release-macos.md
@@ -1,9 +1,9 @@
 # Friday Native Companion Release Guide (macOS)
 
-Use this guide when you want to build, sign, notarize, and ship the native `FridayCompanion.app` bundle for Agent OS deployments.
+Use this guide when you want to build, sign, notarize, and prepare the native `FridayCompanion.app` bundle for Agent OS deployments. This is a release-preparation guide; public desktop, Homebrew, Sparkle, or notarized macOS release readiness requires real external credentials plus archived evidence.
 
-For a full early-user setup after release, continue with [friday-agent-os-beta-onboarding.md](./docs/ops/friday-agent-os-beta-onboarding.md).
-If signing, notarization, launchd, passkey, or socket checks fail, use [friday-agent-os-troubleshooting.md](./docs/ops/friday-agent-os-troubleshooting.md).
+For a full early-user setup after release, continue with [friday-agent-os-beta-onboarding.md](./friday-agent-os-beta-onboarding.md).
+If signing, notarization, launchd, passkey, or socket checks fail, use [friday-agent-os-troubleshooting.md](./friday-agent-os-troubleshooting.md).
 
 The repo now has two release modes:
 
@@ -37,10 +37,10 @@ The distribution layer now adds release channels on top of the existing `.app` b
    - `FRIDAY_MACOS_SPARKLE_PRIVATE_KEY`
    - `FRIDAY_MACOS_SPARKLE_PUBLIC_KEY`
    - `FRIDAY_MACOS_APPCAST_BASE_URL`
-5. For Homebrew publication:
+5. For Homebrew publication, when explicitly authorized for a release:
    - `FRIDAY_HOMEBREW_TAP_REPO`
    - `FRIDAY_HOMEBREW_TAP_GITHUB_TOKEN`
-4. Repo root available locally.
+6. Repo root available locally.
 
 ## Local Release Verification
 
@@ -66,7 +66,7 @@ This path:
 6. Writes release evidence to `dist/macos/FridayCompanion.release.json` and `dist/macos/FridayCompanion.release.md`.
 7. Stops before Gatekeeper or notarization checks, because ad-hoc signatures do not pass those checks.
 8. When Sparkle credentials are configured, also generates `dist/releases/macos/appcast.xml`.
-9. When Homebrew tap credentials are configured, also publishes the generated Cask to the tap and refreshes the manifest.
+9. When Homebrew tap credentials are configured and the release operator has explicitly authorized publication, also publishes the generated Cask to the tap and refreshes the manifest.
 
 Use this mode for local engineering acceptance and CI coverage.
 
@@ -141,7 +141,7 @@ The notarized release flow:
 8. Generates `dist/releases/Friday.release-manifest.json`, `dist/releases/Friday.release-manifest.md`, and `dist/releases/homebrew/Casks/friday.rb`.
 9. Writes release evidence to `dist/macos/FridayCompanion.release.json` and `dist/macos/FridayCompanion.release.md`.
 10. Generates `dist/releases/macos/appcast.xml` when Sparkle credentials are configured.
-11. Publishes the Homebrew cask when tap credentials are configured.
+11. Publishes the Homebrew cask only when tap credentials are configured and the release operator has explicitly authorized publication.
 
 If you need direct access to the lower-level scripts, they remain available:
 

--- a/docs/ops/friday-cross-platform-agent-os-completion-checklist.md
+++ b/docs/ops/friday-cross-platform-agent-os-completion-checklist.md
@@ -1,6 +1,6 @@
 # Friday Cross-Platform Agent OS Completion Checklist
 
-This checklist is the single completion source of truth for the current cross-platform Agent OS program.
+This checklist is the single completion source of truth for the current cross-platform Agent OS program. It tracks target beta baselines and release evidence; it is not a claim that desktop, Homebrew, iOS, Android, or Windows distribution is public-release complete.
 
 Only these status labels are allowed:
 
@@ -8,20 +8,22 @@ Only these status labels are allowed:
 - `validated but temporary`
 - `missing`
 
-## Supported Release Baselines
+## Target Release Baselines
 
 - `macOS 15+`
 - `iOS trusted-device beta`
 - `Android trusted-device beta`
 - `Windows 11`
 
-Unsupported for this milestone:
+Not targeted for this milestone:
 
 - Linux
 - iOS device-local automation
 - Android device-local automation
 
 ## Validated And Keep
+
+These are repository components or local validation surfaces to keep. They do not by themselves prove external signing, store distribution, Homebrew tap publication, or clean-machine/device release evidence.
 
 - Shared Node hub and web Operator Console
 - Stable `/v1/system/*` and `/v1/system/remote/auth/*` route families
@@ -35,6 +37,8 @@ Unsupported for this milestone:
 - macOS beta smoke and evidence-writer scripts in `scripts/ops`
 
 ## Validated But Temporary
+
+These remain transitional until the missing evidence below is archived.
 
 - Node companion daemon fallback for development
 - Source and npm install as the Windows operator fallback


### PR DESCRIPTION
## Summary
- clarify the public `1.0.2` npm/runtime boundary versus the unpublished GitHub-main `1.0.3` package candidate
- relabel cross-platform release baselines as target beta baselines, not public distribution proof
- tighten macOS beta/release docs around Homebrew tap publication, notarization, Sparkle, and external evidence requirements

## Local proof
- `git diff --check`
- `npm run audit:release-truth`
- `npm run check:closeout:truth:final`
- `npm run check:public-source-hygiene`
- `npm run check:secret-patterns`
- targeted `rg` scans for stale policy-sensitive overclaims

## Boundaries
- no live channel windows started
- no npm publish/tag/GitHub release
- no destructive memory/package/multi-tenant/keyring changes
