### PR TITLE
fix: provider/settings truth + setup-safety closure (no hidden OpenAI, fail-closed channels/MCP, truthful setup)

### DIFF
--- a/.github/workflows/real-green-gate.yml
+++ b/.github/workflows/real-green-gate.yml
@@ -91,7 +91,10 @@ jobs:
       FRIDAY_LARK_RECEIVE_MODE: ${{ secrets.FRIDAY_LARK_RECEIVE_MODE || vars.FRIDAY_LARK_RECEIVE_MODE }}
       FRIDAY_LARK_APPROVAL_MODE: ${{ secrets.FRIDAY_LARK_APPROVAL_MODE || vars.FRIDAY_LARK_APPROVAL_MODE }}
       FRIDAY_LARK_GROUP_APPROVAL: ${{ secrets.FRIDAY_LARK_GROUP_APPROVAL || vars.FRIDAY_LARK_GROUP_APPROVAL }}
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      # Default RGG proof is DeepSeek-only. No OpenAI key is injected on this job,
+      # and the self-hosted runtime pins explicit DeepSeek routing, so the default
+      # workflow_dispatch never attempts OpenAI (locked proof/OpenAI policy).
+      # OpenAI is exercised only by the explicitly gated c3c4 / c45 lanes below.
       DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
       FRIDAY_DEEPSEEK_API_KEY: ${{ secrets.FRIDAY_DEEPSEEK_API_KEY }}
       FRIDAY_REAL_GREEN_GATE_LIVE_PROVIDER_MODE: ${{ github.event_name == 'workflow_dispatch' && 'full' || 'economy' }}
@@ -175,7 +178,7 @@ jobs:
       FRIDAY_DISCORD_CHANNEL_ID: ${{ secrets.FRIDAY_DISCORD_CHANNEL_ID || vars.FRIDAY_DISCORD_CHANNEL_ID }}
       FRIDAY_DISCORD_BOT_USER_ID: ${{ secrets.FRIDAY_DISCORD_BOT_USER_ID || vars.FRIDAY_DISCORD_BOT_USER_ID }}
       FRIDAY_DISCORD_REQUIRE_MENTION: ${{ secrets.FRIDAY_DISCORD_REQUIRE_MENTION || vars.FRIDAY_DISCORD_REQUIRE_MENTION }}
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      # Channel listener lane — DeepSeek only, no OpenAI key (locked proof policy).
       DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
       FRIDAY_DEEPSEEK_API_KEY: ${{ secrets.FRIDAY_DEEPSEEK_API_KEY }}
       PHASE24B_DISCORD_LISTENER_TIMEOUT_MS: "480000"
@@ -338,7 +341,7 @@ jobs:
       FRIDAY_TELEGRAM_CHAT_ID: ${{ secrets.FRIDAY_TELEGRAM_CHAT_ID || vars.FRIDAY_TELEGRAM_CHAT_ID }}
       FRIDAY_TELEGRAM_ALLOWED_USER_ID: ${{ secrets.FRIDAY_TELEGRAM_ALLOWED_USER_ID || vars.FRIDAY_TELEGRAM_ALLOWED_USER_ID }}
       FRIDAY_TELEGRAM_MODE: ${{ secrets.FRIDAY_TELEGRAM_MODE || vars.FRIDAY_TELEGRAM_MODE }}
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      # Channel listener lane — DeepSeek only, no OpenAI key (locked proof policy).
       DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
       FRIDAY_DEEPSEEK_API_KEY: ${{ secrets.FRIDAY_DEEPSEEK_API_KEY }}
       PHASE24C_TELEGRAM_LISTENER_TIMEOUT_MS: "480000"
@@ -382,7 +385,7 @@ jobs:
       FRIDAY_LARK_ALLOWED_USER_ID: ${{ secrets.FRIDAY_LARK_ALLOWED_USER_ID || vars.FRIDAY_LARK_ALLOWED_USER_ID }}
       FRIDAY_LARK_USE_FEISHU: ${{ secrets.FRIDAY_LARK_USE_FEISHU || vars.FRIDAY_LARK_USE_FEISHU }}
       FRIDAY_LARK_RECEIVE_MODE: ${{ secrets.FRIDAY_LARK_RECEIVE_MODE || vars.FRIDAY_LARK_RECEIVE_MODE }}
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      # Channel listener lane — DeepSeek only, no OpenAI key (locked proof policy).
       DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
       FRIDAY_DEEPSEEK_API_KEY: ${{ secrets.FRIDAY_DEEPSEEK_API_KEY }}
       PHASE24D_LARK_FEISHU_LISTENER_TIMEOUT_MS: "480000"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -341,7 +341,7 @@
         "filename": "src/api/http/routes/friday-setup-routes.ts",
         "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
         "is_verified": false,
-        "line_number": 2082
+        "line_number": 2096
       }
     ],
     "src/media-understanding/friday-media-doctor.ts": [
@@ -562,14 +562,14 @@
         "filename": "test/e2e/setup-wizard.e2e.test.ts",
         "hashed_secret": "9d6c140e80814290940bd258644431f5d4255fd4",
         "is_verified": false,
-        "line_number": 1456
+        "line_number": 1486
       },
       {
         "type": "Secret Keyword",
         "filename": "test/e2e/setup-wizard.e2e.test.ts",
         "hashed_secret": "1800af6e29fca70d9b324a27c567a5403d655429",
         "is_verified": false,
-        "line_number": 1478
+        "line_number": 1508
       }
     ],
     "test/integration/providers/friday-provider-service-lifecycle.test.ts": [
@@ -1124,5 +1124,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-27T17:29:06Z"
+  "generated_at": "2026-05-28T21:39:56Z"
 }

--- a/scripts/ops/lib/real-green-gate-result.mjs
+++ b/scripts/ops/lib/real-green-gate-result.mjs
@@ -113,6 +113,37 @@ function normalizeStringList(value) {
 }
 
 /**
+ * Truthfully scope what the provider lanes proved. A run with only one eligible
+ * provider proves the single-provider DEFAULT lane only — it does NOT prove
+ * provider fallback resilience (that is the explicit, gated C3/C4 lane). This
+ * must never be over-claimed as a fallback/resilience proof.
+ */
+function deriveProviderLaneScope(summary) {
+  const envTruth = summary?.preflight?.envTruth ?? {};
+  const lanes = envTruth.providerLanes ?? {};
+  const requirements = envTruth.providerLaneRequirements ?? {};
+  if (lanes.fallback) {
+    return {
+      scope: "default_and_fallback",
+      fallback_resilience_proven: true,
+      note: "Default and fallback provider lanes were resolved and exercised.",
+    };
+  }
+  if (requirements.fallbackRequired === false) {
+    return {
+      scope: "single_provider_default_only",
+      fallback_resilience_proven: false,
+      note: "Only one eligible provider was available; this run proves the single-provider default lane ONLY and does NOT prove provider fallback resilience. Multi-provider/fallback resilience is the explicit gated C3/C4 provider-routing lane.",
+    };
+  }
+  return {
+    scope: "default_only",
+    fallback_resilience_proven: false,
+    note: "No fallback provider lane was exercised in this run.",
+  };
+}
+
+/**
  * Build a result artifact from the run-real-green-gate.mjs summary object.
  *
  * @param {object} input
@@ -136,6 +167,7 @@ export function buildRealGreenGateResult({ summary, commitSha, refName, evaluate
     scenarios_run: counts.scenariosRun,
     scenarios_total: counts.scenariosTotal,
     scenarios_passed: counts.scenariosPassed,
+    provider_lane_scope: deriveProviderLaneScope(summary),
   };
 }
 

--- a/scripts/ops/run-real-green-gate-self-hosted.mjs
+++ b/scripts/ops/run-real-green-gate-self-hosted.mjs
@@ -164,6 +164,56 @@ export async function completeSelfHostedSetup(baseUrl, localPassphrase) {
   }
 }
 
+/**
+ * Pin EXPLICIT DeepSeek routing for the default RGG proof.
+ *
+ * The runtime auto-registers provider profiles from env keys but, per the locked
+ * provider policy, no longer auto-selects a default when multiple kinds are
+ * present. RGG must therefore make an explicit, truthful choice rather than rely
+ * on a hidden default — and the default proof lane must never attempt OpenAI.
+ * We pick DeepSeek (Friday's primary) with NO fallback so the default proof
+ * exercises exactly one provider and OpenAI's providerAttemptCount stays 0.
+ *
+ * Returns { configured: boolean } so the caller can record the truth; if no
+ * DeepSeek provider is present, routing is left unset (action-required) and the
+ * gate reflects that honestly instead of falling back to another provider.
+ */
+export async function configureExplicitDeepSeekRouting(baseUrl, localPassphrase) {
+  const accessToken = await loginLocalPassphrase(baseUrl, localPassphrase);
+  const providersResponse = await fetch(`${baseUrl}/v1/providers`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  const providersBody = await providersResponse.json().catch(() => ({}));
+  const items = Array.isArray(providersBody?.data?.items)
+    ? providersBody.data.items
+    : Array.isArray(providersBody?.items)
+      ? providersBody.items
+      : [];
+  const deepseek = items.find(
+    (provider) => provider?.kind === "deepseek" && provider?.enabled !== false,
+  );
+  if (!deepseek?.id) {
+    return { configured: false };
+  }
+  const routingResponse = await fetch(`${baseUrl}/v1/model-routing`, {
+    method: "PUT",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      defaultProviderId: deepseek.id,
+      defaultModel: typeof deepseek.defaultModel === "string" ? deepseek.defaultModel : "deepseek-v4-pro",
+      fallbackProviderIds: [],
+    }),
+  });
+  const routingBody = await routingResponse.json().catch(() => ({}));
+  if (!routingResponse.ok || routingBody?.ok !== true) {
+    throw new Error(`Self-hosted DeepSeek routing config failed with HTTP ${String(routingResponse.status)}`);
+  }
+  return { configured: true, providerId: deepseek.id };
+}
+
 export function createRuntimeEnv(baseEnv, paths, port, localPassphrase, tokenSecret, workspaceRoot) {
   const channelsEnv = buildExplicitChannelsEnv(baseEnv);
   return {
@@ -317,6 +367,11 @@ export async function runSelfHostedRealGreenGate(options) {
     await waitForHealth(baseUrl, options.runtimeBootTimeoutMs ?? DEFAULT_RUNTIME_BOOT_TIMEOUT_MS);
     await bootstrapLocalPassphrase(baseUrl, localPassphrase);
     await completeSelfHostedSetup(baseUrl, localPassphrase);
+    const routingConfigured = await configureExplicitDeepSeekRouting(baseUrl, localPassphrase);
+    appendLogLine(
+      path.join(reportRoot, "self-hosted-runtime-meta.txt"),
+      `deepseekRoutingConfigured=${String(routingConfigured.configured)}`,
+    );
 
     const gateEnv = createGateEnv(process.env, paths, baseUrl, localPassphrase, tokenSecret, repoRoot);
     const gateArgs = [

--- a/scripts/ops/run-real-green-gate.mjs
+++ b/scripts/ops/run-real-green-gate.mjs
@@ -384,6 +384,10 @@ function renderMarkdown(summary) {
     `- Auth ok: ${String(summary.preflight?.envTruth?.auth?.ok === true)}`,
     `- Default lane: ${summary.preflight?.envTruth?.providerLanes?.default?.model ?? "missing"}`,
     `- Fallback lane: ${summary.preflight?.envTruth?.providerLanes?.fallback?.model ?? "missing"}`,
+    `- Fallback required: ${String(summary.preflight?.envTruth?.providerLaneRequirements?.fallbackRequired !== false)} (source: ${summary.preflight?.envTruth?.providerLaneRequirements?.source ?? "n/a"})`,
+    ...(summary.preflight?.envTruth?.providerLaneRequirements?.fallbackRequired === false && !summary.preflight?.envTruth?.providerLanes?.fallback
+      ? ["- Provider-lane scope: single eligible provider — proves the single-provider DEFAULT lane ONLY; does NOT prove fallback resilience (see explicit gated C3/C4 lane)."]
+      : []),
     "",
     "## Public Surface",
     "",

--- a/src/agent/mcp/friday-mcp-adapter.ts
+++ b/src/agent/mcp/friday-mcp-adapter.ts
@@ -253,6 +253,10 @@ export function parseFridayMcpServersFromEnv(
     }
 
     const transport = detectTransport(row, index, warn);
+    if (transport === null) {
+      // Unsupported transport — fail closed (detectTransport already warned).
+      continue;
+    }
     const timeoutMs = parsePositiveNumber(row.timeoutMs);
     const policy = parseServerPolicy(row, index, warn);
 
@@ -723,7 +727,17 @@ function normalizeServerConfig(server: FridayMcpServerConfig): FridayMcpServerCo
   const id = server.id.trim();
   if (!id) return null;
 
-  const transport = server.transport === "http" ? "http" : "stdio";
+  // Fail closed: only stdio/http are supported. An explicitly set but
+  // unsupported transport (e.g. "sse", "ws") must NOT be silently coerced to a
+  // local stdio child process — drop the server instead.
+  const rawTransport = server.transport === undefined || server.transport === null
+    ? "stdio"
+    : String(server.transport).trim().toLowerCase();
+  if (rawTransport !== "stdio" && rawTransport !== "http") {
+    console.warn(`[friday] WARNING: MCP server '${id}' has unsupported transport '${rawTransport}'; skipping (no stdio fallback).`);
+    return null;
+  }
+  const transport: FridayMcpTransport = rawTransport;
   const timeoutMs = parsePositiveNumber(server.timeoutMs);
   const policy = normalizeServerPolicy(server.policy);
 
@@ -767,6 +781,8 @@ function normalizeServerConfig(server: FridayMcpServerConfig): FridayMcpServerCo
 function normalizeServerPolicy(policy: FridayMcpServerPolicy | undefined): FridayMcpServerPolicy | undefined {
   if (!policy) return undefined;
 
+  const allowAllTools = policy.allowAllTools === true;
+
   const toolAllowlist = Array.isArray(policy.toolAllowlist)
     ? policy.toolAllowlist
       .filter((value): value is string => typeof value === "string")
@@ -780,12 +796,13 @@ function normalizeServerPolicy(policy: FridayMcpServerPolicy | undefined): Frida
     ? { maxCalls, windowMs }
     : undefined;
 
-  if ((!toolAllowlist || toolAllowlist.length === 0) && !rateLimit) {
+  if ((!toolAllowlist || toolAllowlist.length === 0) && !rateLimit && !allowAllTools) {
     return undefined;
   }
 
   return {
     ...(toolAllowlist && toolAllowlist.length > 0 ? { toolAllowlist } : {}),
+    ...(allowAllTools ? { allowAllTools: true } : {}),
     ...(rateLimit ? { rateLimit } : {}),
   };
 }
@@ -799,6 +816,8 @@ function parseServerPolicy(
   if (row.policy && typeof row.policy === "object" && !Array.isArray(row.policy)) {
     policyRow = row.policy as Record<string, unknown>;
   }
+
+  const allowAllTools = policyRow.allowAllTools === true || row.allowAllTools === true;
 
   const allowlistRaw = policyRow.toolAllowlist ?? row.allowTools;
   const toolAllowlist = Array.isArray(allowlistRaw)
@@ -825,12 +844,13 @@ function parseServerPolicy(
     }
   }
 
-  if ((!toolAllowlist || toolAllowlist.length === 0) && !rateLimit) {
+  if ((!toolAllowlist || toolAllowlist.length === 0) && !rateLimit && !allowAllTools) {
     return undefined;
   }
 
   return {
     ...(toolAllowlist && toolAllowlist.length > 0 ? { toolAllowlist } : {}),
+    ...(allowAllTools ? { allowAllTools: true } : {}),
     ...(rateLimit ? { rateLimit } : {}),
   };
 }
@@ -870,7 +890,7 @@ function detectTransport(
   row: Record<string, unknown>,
   index: number,
   warn: WarnLike,
-): FridayMcpTransport {
+): FridayMcpTransport | null {
   const rawTransport = typeof row.transport === "string"
     ? row.transport.trim().toLowerCase()
     : "";
@@ -886,8 +906,10 @@ function detectTransport(
     return rawTransport;
   }
 
-  warn(`[friday] WARNING: FRIDAY_MCP_SERVERS[${String(index)}] has unsupported transport '${rawTransport}', fallback to stdio.`);
-  return "stdio";
+  // Fail closed: an unsupported transport must NOT be silently coerced to a
+  // local stdio child process. Reject the entry (caller skips it).
+  warn(`[friday] WARNING: FRIDAY_MCP_SERVERS[${String(index)}] has unsupported transport '${rawTransport}'; skipping server (no stdio fallback).`);
+  return null;
 }
 
 function requireServer(
@@ -919,9 +941,16 @@ function enforceToolAllowlist(
   correlationId: string,
 ): void {
   const allowlist = server.policy?.toolAllowlist;
-  if (!allowlist || allowlist.length === 0) return;
-  if (allowlist.includes(toolName)) return;
+  if (allowlist && allowlist.length > 0) {
+    if (allowlist.includes(toolName)) return;
+  } else if (server.policy?.allowAllTools === true) {
+    // Explicit high-risk opt-in: caller deliberately trusts every tool.
+    return;
+  }
 
+  // Fail closed: an external MCP server with no toolAllowlist and no explicit
+  // allowAllTools opt-in exposes NO callable tools; and a configured allowlist
+  // denies anything not on it.
   throw createFridayMcpAdapterError({
     code: FRIDAY_MCP_ADAPTER_ERROR_CODES.POLICY_TOOL_FORBIDDEN,
     message: `MCP tool '${toolName}' is not allowed on server '${server.id}'`,
@@ -930,7 +959,8 @@ function enforceToolAllowlist(
     details: {
       serverId: server.id,
       toolName,
-      allowlist,
+      allowlist: allowlist ?? [],
+      allowAllTools: server.policy?.allowAllTools === true,
     },
   });
 }
@@ -940,10 +970,15 @@ function applyToolAllowlist(
   tools: FridayMcpToolDescriptor[],
 ): FridayMcpToolDescriptor[] {
   const allowlist = policy?.toolAllowlist;
-  if (!allowlist || allowlist.length === 0) {
+  if (allowlist && allowlist.length > 0) {
+    return tools.filter((tool) => allowlist.includes(tool.name));
+  }
+  if (policy?.allowAllTools === true) {
+    // Explicit high-risk opt-in: expose everything the server advertises.
     return tools;
   }
-  return tools.filter((tool) => allowlist.includes(tool.name));
+  // Fail closed: no allowlist and no opt-in exposes nothing.
+  return [];
 }
 
 function enforceRateLimit(

--- a/src/agent/mcp/friday-mcp-adapter.types.ts
+++ b/src/agent/mcp/friday-mcp-adapter.types.ts
@@ -8,6 +8,13 @@ export interface FridayMcpServerRateLimitPolicy {
 
 export interface FridayMcpServerPolicy {
   toolAllowlist?: string[];
+  /**
+   * Explicit high-risk opt-in to expose EVERY tool an external MCP server
+   * advertises when no `toolAllowlist` is set. Default (false/unset) FAILS
+   * CLOSED: with no allowlist and no opt-in, no external tools are exposed or
+   * callable. Set this only when you deliberately trust the server fully.
+   */
+  allowAllTools?: boolean;
   rateLimit?: FridayMcpServerRateLimitPolicy;
 }
 

--- a/src/api/http/routes/friday-setup-routes.ts
+++ b/src/api/http/routes/friday-setup-routes.ts
@@ -28,6 +28,7 @@ import {
   FRIDAY_UNSUPPORTED_CHANNEL_KINDS,
   FRIDAY_UNSUPPORTED_CHANNEL_MODES,
   getFridayChannelSecretFieldDescriptors,
+  isControlCapableChannelKind,
   isFridayChannelKindSupported,
   isFridayChannelModeSupported,
   parseFridayChannelsConfig,
@@ -1076,6 +1077,13 @@ function applyTelegramVerificationToConfig(config: Record<string, unknown>, enab
     );
   }
 
+  // Persist the verified principal as the allowlist so this control-capable
+  // channel fails closed (the verified user, not "everyone"). Mirrors the
+  // Feishu verification-apply path.
+  if (!normalizeStringList(config.allowedUsers) && session.result.userId) {
+    config.allowedUsers = [session.result.userId];
+  }
+
   delete config.setupVerificationId;
 }
 
@@ -1134,6 +1142,12 @@ function applyDiscordVerificationToConfig(config: Record<string, unknown>, enabl
 
   config.token = persistedToken;
   config.botUserId = session.botUserId;
+  // Persist the DM-verified user as the allowlist so this control-capable
+  // channel fails closed (the verified user, not "everyone"). Mirrors the
+  // Feishu verification-apply path.
+  if (!normalizeStringList(config.allowedUsers) && session.result.userId) {
+    config.allowedUsers = [session.result.userId];
+  }
   delete config.setupVerificationId;
   delete config.setupUserId;
   delete config.guildId;
@@ -2565,6 +2579,29 @@ export function createFridaySetupRoutes(
           if (kind === "feishu") {
             applyFeishuRegistrationToConfig(config, ch.enabled);
           }
+
+          // Fail closed: an enabled control-capable channel must persist a
+          // verified user/chat allowlist. A missing allowlist must NOT be
+          // treated as "allow everyone" (locked channel policy). The
+          // verification-apply above populates this for telegram/discord/feishu;
+          // any other control-capable channel must carry an explicit allowlist.
+          if (ch.enabled && isControlCapableChannelKind(kind)) {
+            const cfg = config as Record<string, unknown>;
+            const hasAllowlist = Boolean(
+              normalizeStringList(cfg.allowedUsers)
+              || normalizeStringList(cfg.allowedChats)
+              || normalizeStringList(cfg.allowedChannels)
+              || normalizeStringList(cfg.allowedGroups),
+            );
+            if (!hasAllowlist) {
+              throw new FridayDomainError(
+                "CHANNEL_ALLOWLIST_REQUIRED",
+                `Channel ${kind} requires a verified user/chat allowlist before it can be enabled (control-capable channels fail closed).`,
+                { httpStatus: 400, details: { kind, status: "allowlist_required" } },
+              );
+            }
+          }
+
           const secretFields = getFridayChannelSecretFieldDescriptors(kind, config);
 
           for (const field of secretFields) {

--- a/src/channels/friday-channel-config.ts
+++ b/src/channels/friday-channel-config.ts
@@ -69,6 +69,40 @@ export function isFridayChannelKindSupported(kind: string): boolean {
 }
 
 /**
+ * External messaging channels whose inbound messages can drive Friday to take
+ * action (i.e. "control" the agent: trigger tasks, approvals, tool calls).
+ *
+ * Locked channel policy (GLOBAL_DECISIONS_LOCKED): these MUST fail closed — a
+ * missing/empty user/chat allowlist must NOT be treated as "allow everyone".
+ * Any anonymous sender on these platforms could otherwise drive the agent.
+ *
+ * `webchat` is intentionally excluded: it is the first-party, session-
+ * authenticated Friday UI surface, not an untrusted external control channel.
+ */
+export const FRIDAY_CONTROL_CAPABLE_CHANNEL_KINDS: readonly FridaySupportedChannelKind[] = [
+  "telegram",
+  "discord",
+  "lark",
+  "feishu",
+  "whatsapp",
+  "signal",
+  "slack",
+  "irc",
+  "line",
+  "qq",
+] as const;
+
+const CONTROL_CAPABLE_CHANNEL_KIND_SET = new Set<string>(FRIDAY_CONTROL_CAPABLE_CHANNEL_KINDS);
+
+/**
+ * Returns `true` if inbound messages on this channel kind can control the agent,
+ * so the channel must fail closed without a persisted allowlist.
+ */
+export function isControlCapableChannelKind(kind: string): boolean {
+  return CONTROL_CAPABLE_CHANNEL_KIND_SET.has(kind);
+}
+
+/**
  * Channel kind+mode combinations that are recognized by the schema but MUST
  * NOT be activated at runtime because the listener is not actually wired.
  *

--- a/src/channels/friday-channel-registry.ts
+++ b/src/channels/friday-channel-registry.ts
@@ -32,6 +32,21 @@ export interface FridayChannelRegistryEntry {
   plugin: FridayChannelPlugin;
   allowlist: FridayChannelAllowlistConfig;
   running: boolean;
+  /**
+   * When true, inbound messages on this channel can drive the agent, so a
+   * missing/empty allowlist FAILS CLOSED (deny) instead of allowing everyone.
+   */
+  controlCapable: boolean;
+}
+
+export interface FridayChannelRegisterOptions {
+  /**
+   * Mark this channel as control-capable so the registry denies inbound when no
+   * allowlist is persisted. Set from `isControlCapableChannelKind(kind)` at the
+   * activation boundary. Defaults to false (legacy allow-when-unset behavior for
+   * non-control channels such as the first-party webchat surface).
+   */
+  controlCapable?: boolean;
 }
 
 export type FridayChannelCredentialStatus =
@@ -77,7 +92,11 @@ export interface FridayChannelStartSummary {
 
 export interface FridayChannelRegistry {
   /** Register a channel plugin with optional allowlist filtering. */
-  register(plugin: FridayChannelPlugin, allowlist?: FridayChannelAllowlistConfig): void;
+  register(
+    plugin: FridayChannelPlugin,
+    allowlist?: FridayChannelAllowlistConfig,
+    options?: FridayChannelRegisterOptions,
+  ): void;
 
   /** Unregister a channel plugin by kind. Stops it if running. */
   unregister(kind: string): Promise<void>;
@@ -157,14 +176,27 @@ export function createFridayChannelRegistry(options?: FridayChannelRegistryOptio
   function checkAllowlist(
     msg: FridayChannelMessage,
     allowlist: FridayChannelAllowlistConfig,
+    controlCapable: boolean,
   ): boolean {
-    if (allowlist.allowedUsers !== undefined) {
-      if (!allowlist.allowedUsers.includes(msg.senderId)) {
+    const hasUserAllowlist = allowlist.allowedUsers !== undefined;
+    const hasChatAllowlist = allowlist.allowedChats !== undefined;
+
+    // Fail closed for control-capable channels: an entirely-unset allowlist must
+    // NOT mean "allow everyone". Without a persisted allowlist there is no
+    // verified principal, so deny inbound (locked channel policy). Non-control
+    // channels (e.g. first-party webchat) keep the legacy allow-when-unset
+    // behavior. The empty-array case ([]) already denies below.
+    if (controlCapable && !hasUserAllowlist && !hasChatAllowlist) {
+      return false;
+    }
+
+    if (hasUserAllowlist) {
+      if (!allowlist.allowedUsers!.includes(msg.senderId)) {
         return false;
       }
     }
-    if (allowlist.allowedChats !== undefined) {
-      if (!allowlist.allowedChats.includes(msg.chatId)) {
+    if (hasChatAllowlist) {
+      if (!allowlist.allowedChats!.includes(msg.chatId)) {
         return false;
       }
     }
@@ -207,7 +239,7 @@ export function createFridayChannelRegistry(options?: FridayChannelRegistryOptio
             void inbound.normalizeAllAsync(rawEvent)
               .then((msgs) => {
                 for (const msg of msgs) {
-                  if (!checkAllowlist(msg, entry.allowlist)) continue;
+                  if (!checkAllowlist(msg, entry.allowlist, entry.controlCapable)) continue;
                   handler(msg);
                 }
               })
@@ -223,7 +255,7 @@ export function createFridayChannelRegistry(options?: FridayChannelRegistryOptio
             void inbound.normalizeAsync(rawEvent)
               .then((msg) => {
                 if (!msg) return;
-                if (!checkAllowlist(msg, entry.allowlist)) return;
+                if (!checkAllowlist(msg, entry.allowlist, entry.controlCapable)) return;
                 handler(msg);
               })
               .catch((err: unknown) => {
@@ -237,7 +269,7 @@ export function createFridayChannelRegistry(options?: FridayChannelRegistryOptio
           if (inbound.normalizeAll) {
             const msgs = inbound.normalizeAll(rawEvent);
             for (const msg of msgs) {
-              if (!checkAllowlist(msg, entry.allowlist)) continue;
+              if (!checkAllowlist(msg, entry.allowlist, entry.controlCapable)) continue;
               handler(msg);
             }
             return;
@@ -245,13 +277,13 @@ export function createFridayChannelRegistry(options?: FridayChannelRegistryOptio
 
           const msg = inbound.normalize(rawEvent);
           if (!msg) return;
-          if (!checkAllowlist(msg, entry.allowlist)) return;
+          if (!checkAllowlist(msg, entry.allowlist, entry.controlCapable)) return;
           handler(msg);
           return;
         }
 
         const msg = rawEvent as FridayChannelMessage;
-        if (!checkAllowlist(msg, entry.allowlist)) return;
+        if (!checkAllowlist(msg, entry.allowlist, entry.controlCapable)) return;
         handler(msg);
       };
 
@@ -259,7 +291,7 @@ export function createFridayChannelRegistry(options?: FridayChannelRegistryOptio
     }
 
     const wrappedHandler = (msg: FridayChannelMessage) => {
-      if (!checkAllowlist(msg, entry.allowlist)) return;
+      if (!checkAllowlist(msg, entry.allowlist, entry.controlCapable)) return;
       handler(msg);
     };
 
@@ -301,12 +333,13 @@ export function createFridayChannelRegistry(options?: FridayChannelRegistryOptio
   }
 
   return {
-    register(plugin, allowlist = {}) {
+    register(plugin, allowlist = {}, registerOptions = {}) {
       options?.checkMutationGrant?.("register", plugin.kind);
       if (entries.has(plugin.kind)) {
         throw new FridayDomainError("CONFLICT", `Channel kind "${plugin.kind}" is already registered`, { httpStatus: 409 });
       }
-      entries.set(plugin.kind, { plugin, allowlist, running: false });
+      const controlCapable = registerOptions.controlCapable === true;
+      entries.set(plugin.kind, { plugin, allowlist, running: false, controlCapable });
       healthState.set(plugin.kind, { restartCount: 0 });
       // B1 channel-registry lifecycle precedence diagnostic: when a plugin
       // declares both adapters.lifecycle and start(), the registry will use

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -60,6 +60,7 @@ export {
   FRIDAY_SUPPORTED_CHANNEL_KINDS,
   FRIDAY_UNSUPPORTED_CHANNEL_KINDS,
   FRIDAY_UNSUPPORTED_CHANNEL_MODES,
+  FRIDAY_CONTROL_CAPABLE_CHANNEL_KINDS,
   FridayQqChannelConfigSchema,
   FridayLarkChannelConfigSchema,
   FridayChannelInstanceConfigSchema,
@@ -68,6 +69,7 @@ export {
   buildDefaultChannelsConfig,
   isFridayChannelKindSupported,
   isFridayChannelModeSupported,
+  isControlCapableChannelKind,
 } from "./friday-channel-config.js";
 
 // ─── Security / Capability Matrix ───

--- a/src/cli/friday-cli.ts
+++ b/src/cli/friday-cli.ts
@@ -489,7 +489,7 @@ Backfill historical packContext metadata onto agent runs using strict session ev
 friday setup
 
 Interactive setup wizard — walks you through configuring:
-  1. LLM provider (Anthropic / OpenAI / Ollama)
+  1. LLM provider (Anthropic / DeepSeek / OpenAI / Ollama)
   2. API key (or skip for Ollama)
   3. Message channels (optional)
 
@@ -2341,7 +2341,7 @@ export function writeFridaySetupEnvFile(envPath: string, envLines: string[]): vo
   tightenFridaySetupEnvFilePermissions(envPath);
 }
 
-async function cmdSetup(): Promise<void> {
+export async function cmdSetup(): Promise<void> {
   const readline = await import("node:readline");
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
 
@@ -2354,13 +2354,15 @@ async function cmdSetup(): Promise<void> {
   console.log("╚══════════════════════════════════════════════════╝");
   console.log("");
 
-  // Step 1: LLM Provider
+  // Step 1: LLM Provider — present providers as explicit peer choices (no
+  // steering by omission). DeepSeek is a first-class option.
   console.log("Step 1: Choose your LLM provider");
-  console.log("  [1] Anthropic (Claude) — recommended");
-  console.log("  [2] OpenAI (GPT)");
-  console.log("  [3] Ollama (local, free, no API key needed)");
+  console.log("  [1] Anthropic (Claude)");
+  console.log("  [2] DeepSeek");
+  console.log("  [3] OpenAI (GPT)");
+  console.log("  [4] Ollama (local, free, no API key needed)");
   console.log("");
-  const providerChoice = await ask("Enter choice [1/2/3]: ");
+  const providerChoice = await ask("Enter choice [1/2/3/4]: ");
 
   let providerId: string;
   let apiKey = "";
@@ -2368,6 +2370,17 @@ async function cmdSetup(): Promise<void> {
 
   switch (providerChoice) {
     case "2":
+      providerId = "deepseek";
+      console.log("");
+      apiKey = await ask("Enter your DeepSeek API key: ");
+      if (!apiKey) {
+        console.error("API key is required for DeepSeek.");
+        rl.close();
+        process.exitCode = 1;
+        return;
+      }
+      break;
+    case "3":
       providerId = "openai";
       console.log("");
       apiKey = await ask("Enter your OpenAI API key: ");
@@ -2378,7 +2391,7 @@ async function cmdSetup(): Promise<void> {
         return;
       }
       break;
-    case "3":
+    case "4":
       providerId = "ollama";
       baseUrl = await ask("Ollama URL [http://localhost:11434]: ") || "http://localhost:11434";
       console.log("No API key needed for Ollama.");
@@ -2406,12 +2419,20 @@ async function cmdSetup(): Promise<void> {
   const envLines: string[] = [];
 
   if (apiKey) {
-    const envVarName = providerId === "openai" ? "OPENAI_API_KEY" : "FRIDAY_ANTHROPIC_API_KEY";
+    const envVarName = providerId === "openai"
+      ? "OPENAI_API_KEY"
+      : providerId === "deepseek"
+        ? "DEEPSEEK_API_KEY"
+        : "FRIDAY_ANTHROPIC_API_KEY";
     envLines.push(`${envVarName}=${apiKey}`);
   }
   if (baseUrl) {
     envLines.push(`OLLAMA_BASE_URL=${baseUrl}`);
   }
+  // Persist the user's explicit provider choice as routing intent so bootstrap
+  // routes to it as the default even when other provider keys are present in
+  // the environment (an explicit choice, never an auto-guess).
+  envLines.push(`FRIDAY_SETUP_DEFAULT_PROVIDER=${providerId}`);
 
   if (envLines.length > 0) {
     writeFridaySetupEnvFile(envPath, envLines);

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -687,11 +687,7 @@ async function autoDetectProvidersFromEnv(
 
     const distinctKinds = new Set(candidates.map((c) => c.kind));
 
-    if (candidates.length > 0 && distinctKinds.size <= 1) {
-      // Exactly one provider kind is available and the user has not chosen a
-      // route. Auto-selecting the sole available provider does not usurp a user
-      // choice, so default to it with NO auto-added fallback providers.
-      const chosen = candidates[0]!;
+    const setDefaultRoute = async (chosen: { kind: FridayProviderKind; id: string }): Promise<void> => {
       const chosenEntry = ENV_PROVIDER_MAP.find((e) => e.kind === chosen.kind);
       const defaultModel = chosenEntry?.defaultModel ?? (chosen.kind === "ollama" ? "llama3.2" : "default");
       try {
@@ -706,6 +702,24 @@ async function autoDetectProvidersFromEnv(
           err instanceof Error ? err.message : String(err),
         );
       }
+    };
+
+    // 1) Honor an explicit provider choice recorded by setup (e.g. the CLI
+    // wizard writes FRIDAY_SETUP_DEFAULT_PROVIDER). This is a user choice, so
+    // route to it even when multiple provider keys are present — it is not a
+    // hidden auto-pick.
+    const intendedKind = (process.env.FRIDAY_SETUP_DEFAULT_PROVIDER ?? "").trim().toLowerCase();
+    const intendedCandidate = intendedKind
+      ? candidates.find((c) => c.kind === intendedKind)
+      : undefined;
+
+    if (intendedCandidate) {
+      await setDefaultRoute(intendedCandidate);
+    } else if (candidates.length > 0 && distinctKinds.size <= 1) {
+      // Exactly one provider kind is available and the user has not chosen a
+      // route. Auto-selecting the sole available provider does not usurp a user
+      // choice, so default to it with NO auto-added fallback providers.
+      await setDefaultRoute(candidates[0]!);
     } else if (distinctKinds.size > 1) {
       // Multiple provider kinds are available but the user has not chosen a
       // route. Locked provider policy: never auto-pick a provider (no hidden

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -525,8 +525,6 @@ const ENV_PROVIDER_MAP: ReadonlyArray<{
   { envVar: "XAI_API_KEY", kind: "xai", defaultModel: "grok-3-mini" },
 ];
 
-/** Routing priority: anthropic first, then openai, then detection order. */
-const ROUTING_PRIORITY: readonly FridayProviderKind[] = ["anthropic", "openai"];
 const STABLE_OPENAI_DEFAULT_MODEL = "gpt-4o-mini";
 const STABLE_OPENAI_SUPPORTED_MODELS = [STABLE_OPENAI_DEFAULT_MODEL, "gpt-4o"] as const;
 const OPENAI_PROVIDER_NAME = "OpenAI Provider";
@@ -686,26 +684,20 @@ async function autoDetectProvidersFromEnv(
           .filter((p) => p.enabled)
           .map((p) => ({ kind: p.kind as FridayProviderKind, id: p.id }));
 
-    if (candidates.length > 0) {
-      // Pick best provider by priority
-      let chosen = candidates[0]!;
-      for (const priorityKind of ROUTING_PRIORITY) {
-        const match = candidates.find((d) => d.kind === priorityKind);
-        if (match) {
-          chosen = match;
-          break;
-        }
-      }
+    const distinctKinds = new Set(candidates.map((c) => c.kind));
+
+    if (candidates.length > 0 && distinctKinds.size <= 1) {
+      // Exactly one provider kind is available and the user has not chosen a
+      // route. Auto-selecting the sole available provider does not usurp a user
+      // choice, so default to it with NO auto-added fallback providers.
+      const chosen = candidates[0]!;
       const chosenEntry = ENV_PROVIDER_MAP.find((e) => e.kind === chosen.kind);
       const defaultModel = chosenEntry?.defaultModel ?? (chosen.kind === "ollama" ? "llama3.2" : "default");
       try {
         await providerService.setRoutingConfig({
           defaultProviderId: chosen.id,
           defaultModel,
-          fallbackProviderIds: candidates
-            .filter((d) => d.id !== chosen.id)
-            .slice(0, 3)
-            .map((d) => d.id),
+          fallbackProviderIds: [],
         });
       } catch (err) {
         console.warn(
@@ -713,6 +705,18 @@ async function autoDetectProvidersFromEnv(
           err instanceof Error ? err.message : String(err),
         );
       }
+    } else if (distinctKinds.size > 1) {
+      // Multiple provider kinds are available but the user has not chosen a
+      // route. Locked provider policy: never auto-pick a provider (no hidden
+      // OpenAI / DeepSeek default) and never auto-add fallback providers behind
+      // the user's back. Leave routing unset so the request-time
+      // PROVIDER_NO_ROUTING path surfaces an explicit-choice (action-required)
+      // prompt and the user makes the call.
+      console.warn(
+        `[friday] Auto-detect: ${String(distinctKinds.size)} provider kinds detected `
+          + `(${[...distinctKinds].sort().join(", ")}) but no default route is configured. `
+          + "Not auto-selecting a provider — explicit user choice required.",
+      );
     }
   }
 

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -261,6 +261,7 @@ import {
   createWhatsappWebhookService,
   FRIDAY_CHANNEL_SECRET_SCOPE,
   FRIDAY_SUPPORTED_CHANNEL_KINDS,
+  isControlCapableChannelKind,
   isFridayChannelKindSupported,
   isFridayChannelModeSupported,
   parseFridayChannelsConfig,
@@ -5415,7 +5416,22 @@ export async function createFridayHub(
         allowlistConfig.allowedChats = (instance as Record<string, unknown>).allowedChannels as string[] | undefined;
       }
 
-      channelRegistry.register(plugin, allowlistConfig);
+      // Fail closed: a control-capable external channel with no persisted
+      // user/chat allowlist must NOT be activated (a missing allowlist would
+      // otherwise accept inbound control messages from anyone). Skip activation
+      // and surface a warning instead of silently allowing all.
+      const controlCapable = isControlCapableChannelKind(instance.kind);
+      const hasAllowlist =
+        (allowlistConfig.allowedUsers?.length ?? 0) > 0
+        || (allowlistConfig.allowedChats?.length ?? 0) > 0;
+      if (controlCapable && !hasAllowlist) {
+        const message = `Channel ${instance.kind} not activated: a verified user/chat allowlist is required for control-capable channels (fail-closed).`;
+        warnings.push(message);
+        console.warn(`[friday] ${message}`);
+        continue;
+      }
+
+      channelRegistry.register(plugin, allowlistConfig, { controlCapable });
       registeredKinds.push(plugin.kind);
     }
 

--- a/src/providers/cost/friday-provider-pricing-catalog.ts
+++ b/src/providers/cost/friday-provider-pricing-catalog.ts
@@ -34,6 +34,66 @@ const DEFAULT_MODEL_PRICING: readonly FridayProviderModelPricing[] = [
     cacheReadPer1MUsd: 0.03,
     cacheWritePer1MUsd: 0.10,
   },
+  // OpenAI gpt-4o family — Friday's auto-detected OpenAI default is gpt-4o-mini
+  // (see ENV_PROVIDER_MAP). Rates per OpenAI published API pricing (2026-05).
+  {
+    providerKind: "openai",
+    modelPattern: "gpt-4o-mini",
+    qualityTier: "cheap",
+    inputPer1MUsd: 0.15,
+    outputPer1MUsd: 0.60,
+    cacheReadPer1MUsd: 0.075,
+    cacheWritePer1MUsd: 0.15,
+  },
+  {
+    providerKind: "openai",
+    modelPattern: "gpt-4o",
+    qualityTier: "best",
+    inputPer1MUsd: 2.50,
+    outputPer1MUsd: 10.00,
+    cacheReadPer1MUsd: 1.25,
+    cacheWritePer1MUsd: 2.50,
+  },
+  // DeepSeek — Friday's primary live provider. Standard (post-promo) rates per
+  // DeepSeek published API pricing (api-docs.deepseek.com, 2026-05). cacheRead =
+  // cache-hit input price. deepseek-chat / deepseek-reasoner are deprecated
+  // aliases that map to deepseek-v4-flash (non-thinking / thinking modes).
+  {
+    providerKind: "deepseek",
+    modelPattern: "deepseek-v4-pro",
+    qualityTier: "best",
+    inputPer1MUsd: 1.74,
+    outputPer1MUsd: 3.48,
+    cacheReadPer1MUsd: 0.0145,
+    cacheWritePer1MUsd: 1.74,
+  },
+  {
+    providerKind: "deepseek",
+    modelPattern: "deepseek-v4-flash",
+    qualityTier: "cheap",
+    inputPer1MUsd: 0.14,
+    outputPer1MUsd: 0.28,
+    cacheReadPer1MUsd: 0.0028,
+    cacheWritePer1MUsd: 0.14,
+  },
+  {
+    providerKind: "deepseek",
+    modelPattern: "deepseek-reasoner",
+    qualityTier: "cheap",
+    inputPer1MUsd: 0.14,
+    outputPer1MUsd: 0.28,
+    cacheReadPer1MUsd: 0.0028,
+    cacheWritePer1MUsd: 0.14,
+  },
+  {
+    providerKind: "deepseek",
+    modelPattern: "deepseek-chat",
+    qualityTier: "cheap",
+    inputPer1MUsd: 0.14,
+    outputPer1MUsd: 0.28,
+    cacheReadPer1MUsd: 0.0028,
+    cacheWritePer1MUsd: 0.14,
+  },
   {
     providerKind: "anthropic",
     modelPattern: "claude-opus",
@@ -154,13 +214,17 @@ export function createFridayProviderPricingCatalog(): FridayProviderPricingCatal
         };
       }
 
-      // Fallback: unknown model, assume balanced pricing
+      // Fallback: unrecognized model. Truth over guessing — do NOT fabricate a
+      // plausible "balanced" rate. Record zero cost with an explicit "unknown"
+      // tier; the (truthful) model name and provider kind are still recorded, so
+      // the usage artifact surfaces that this model is unpriced. Add a pricing
+      // entry above for any model Friday actually routes to.
       return {
-        inputPer1MUsd: 1.00,
-        outputPer1MUsd: 4.00,
-        cacheReadPer1MUsd: 0.10,
-        cacheWritePer1MUsd: 1.00,
-        qualityTier: "balanced",
+        inputPer1MUsd: 0,
+        outputPer1MUsd: 0,
+        cacheReadPer1MUsd: 0,
+        cacheWritePer1MUsd: 0,
+        qualityTier: "unknown",
       };
     },
   };

--- a/src/providers/model/friday-provider-cost.types.ts
+++ b/src/providers/model/friday-provider-cost.types.ts
@@ -25,7 +25,9 @@ export type FridayBudgetState = "ok" | "near_limit" | "over_limit";
 
 // ─── Model quality tier ───
 
-export type FridayModelQualityTier = "cheap" | "balanced" | "best";
+// "unknown" is used by the pricing fallback so an unpriced model is recorded as
+// an explicit unknown rather than a fabricated "balanced" rate.
+export type FridayModelQualityTier = "cheap" | "balanced" | "best" | "unknown";
 
 // ─── Normalized usage across API shapes ───
 
@@ -99,7 +101,10 @@ export interface FridayLlmUsageRecord {
   usageDay: string;
   usageMonth: string;
   providerId: string;
-  providerKind: FridayProviderKind;
+  // May be "unknown" when the provider profile was deleted/disabled between the
+  // LLM call and this (fire-and-forget) usage write. Never silently default to a
+  // real provider kind — that would record false provider attribution.
+  providerKind: FridayProviderKind | "unknown";
   providerApi: FridayProviderApi;
   model: string;
   routeStrategy: FridayProviderRouteStrategy;

--- a/src/providers/services/friday-provider-service.ts
+++ b/src/providers/services/friday-provider-service.ts
@@ -3443,7 +3443,16 @@ export function createFridayProviderService(
       const provider = deps.db.withReadConnection((db) =>
         profileRepo.getById(db, input.providerId),
       );
-      const providerKind = provider?.kind ?? "openai";
+      // Truth: never attribute usage to a real provider kind we cannot confirm.
+      // If the profile is gone (deleted/disabled between the call and this
+      // fire-and-forget write), record an explicit "unknown" kind, not OpenAI.
+      const providerKind = provider?.kind ?? "unknown";
+      if (!provider) {
+        console.warn(
+          `[friday] recordUsage: provider profile ${input.providerId} not found; `
+            + "recording providerKind=\"unknown\" (no provider attribution).",
+        );
+      }
       const now = deps.nowIso();
       const usageDay = now.slice(0, 10);
       const usageMonth = now.slice(0, 7);

--- a/src/skills/generator/llm/friday-provider-inference-client.ts
+++ b/src/skills/generator/llm/friday-provider-inference-client.ts
@@ -630,6 +630,9 @@ export function createFridayProviderInferenceClient(
           taskComplexity: complexity,
           usage: result.usage,
           costUsd: result.costUsd,
+          // Distinguish this runtime path truthfully in usage artifacts
+          // (hub-agent callers tag source="agent-runtime").
+          metadata: { source: "generator-llm" },
         }).catch(() => {
           // Usage recording is best-effort; swallow errors
         });

--- a/test/contracts/agent/friday-mcp-transport-parity.contract.test.ts
+++ b/test/contracts/agent/friday-mcp-transport-parity.contract.test.ts
@@ -242,6 +242,9 @@ describe("MCP transport parity contract", () => {
           transport: "stdio",
           command: process.execPath,
           args: ["-e", buildStdioServerScript()],
+          // Opt in so transport parity is exercised; the adapter now fails
+          // closed without an allowlist or this explicit opt-in.
+          policy: { allowAllTools: true },
         },
       ],
     });
@@ -255,6 +258,7 @@ describe("MCP transport parity contract", () => {
           id: "http",
           transport: "http",
           url: PUBLIC_HTTP_MCP_TEST_URL,
+          policy: { allowAllTools: true },
         },
       ],
     });
@@ -306,6 +310,9 @@ describe("MCP transport parity contract", () => {
           transport: "stdio",
           command: process.execPath,
           args: ["-e", buildStdioServerScript()],
+          // Opt in so transport parity is exercised; the adapter now fails
+          // closed without an allowlist or this explicit opt-in.
+          policy: { allowAllTools: true },
         },
       ],
     });
@@ -318,6 +325,7 @@ describe("MCP transport parity contract", () => {
           id: "http",
           transport: "http",
           url: PUBLIC_HTTP_MCP_TEST_URL,
+          policy: { allowAllTools: true },
         },
       ],
     });

--- a/test/e2e/setup-wizard.e2e.test.ts
+++ b/test/e2e/setup-wizard.e2e.test.ts
@@ -700,7 +700,6 @@ describe("Setup Wizard E2E", () => {
           expect(setupRow).toBeDefined();
           expect(setupRow!.channels_json).not.toContain("fake-discord-token");
           expect(setupRow!.channels_json).not.toContain(beginJson.data.verificationId);
-          expect(setupRow!.channels_json).not.toContain("10001");
           expect(setupRow!.channels_json).not.toContain("guild-1");
 
           const storedChannels = JSON.parse(setupRow!.channels_json) as Array<{
@@ -712,6 +711,11 @@ describe("Setup Wizard E2E", () => {
           const discordEntry = storedChannels.find((entry) => entry.kind === "discord");
           expect(discordEntry?.controlConfirmed).toBe(true);
           expect(typeof discordEntry?.controlConfirmedAt).toBe("string");
+          // Safer truth: the DM-verified user is persisted as the allowlist so
+          // the control-capable channel fails closed (not allow-all). The
+          // transient setupUserId is still dropped.
+          expect(discordEntry?.config?.allowedUsers).toEqual(["10001"]);
+          expect(discordEntry?.config?.setupUserId).toBeUndefined();
           expect(discordEntry?.config?.botUserId).toBe("bot-1");
           expect(typeof discordEntry?.config?.token).toBe("string");
           expect(String(discordEntry?.config?.token ?? "")).toMatch(/^secret:\/\/channel\//);
@@ -734,7 +738,7 @@ describe("Setup Wizard E2E", () => {
       }
     });
 
-    it("A8a: save Telegram channel should require private DM verification without writing allowlist", async () => {
+    it("A8a: save Telegram channel should require private DM verification and persist the verified allowlist", async () => {
       const originalFetch = globalThis.fetch;
       let getUpdatesCallCount = 0;
       let setupCode = "";
@@ -870,7 +874,10 @@ describe("Setup Wizard E2E", () => {
             config?: Record<string, unknown>;
           }>;
           const telegramEntry = storedChannels.find((entry) => entry.kind === "telegram");
-          expect(telegramEntry?.config?.allowedUsers).toBeUndefined();
+          // Safer truth: the privately-verified user is persisted as the
+          // allowlist so this control-capable channel fails closed instead of
+          // accepting inbound control messages from anyone.
+          expect(telegramEntry?.config?.allowedUsers).toEqual(["2002"]);
           expect(String(telegramEntry?.config?.botToken ?? "")).toMatch(/^secret:\/\/channel\//);
         } finally {
           db.close();
@@ -1137,6 +1144,29 @@ describe("Setup Wizard E2E", () => {
       } finally {
         globalThis.fetch = originalFetch;
       }
+    });
+
+    it("A8d: enabling a control-capable channel without an allowlist fails closed", async () => {
+      // GATE: a missing user/chat allowlist must block save for control-capable
+      // channels — it must not silently activate an allow-everyone channel.
+      const res = await fetch(`${baseUrl}/v1/setup/channels`, {
+        method: "POST",
+        headers: authHeaders(accessToken),
+        body: JSON.stringify({
+          controlConfirmed: true,
+          channels: [
+            {
+              kind: "slack",
+              enabled: true,
+              config: { botToken: "xoxb-test-token", appToken: "xapp-test-token", mode: "socket" },
+            },
+          ],
+        }),
+      });
+      expect(res.status).toBe(400);
+      const body = await res.text();
+      expect(body).toContain("allowlist");
+      expect(JSON.parse(body).ok).toBe(false);
     });
 
     it("A9: save channels with invalid kind should return 400 or 422", async () => {

--- a/test/integration/hub/friday-hub-bootstrap-integration.test.ts
+++ b/test/integration/hub/friday-hub-bootstrap-integration.test.ts
@@ -2063,6 +2063,34 @@ describe("FridayHub Bootstrap Integration", () => {
     expect(routing.fallbackProviderIds).toEqual([]);
   });
 
+  it("honors an explicit setup provider choice (FRIDAY_SETUP_DEFAULT_PROVIDER) even with multiple keys", async () => {
+    // The CLI setup wizard records the user's explicit choice here; bootstrap
+    // must route to it (a user choice, not a hidden auto-pick) even when other
+    // provider keys are present.
+    process.env.OPENAI_API_KEY = "test-openai-key-not-validated"; // pragma: allowlist secret
+    process.env.DEEPSEEK_API_KEY = "test-deepseek-key-not-validated"; // pragma: allowlist secret
+    const previousIntent = process.env.FRIDAY_SETUP_DEFAULT_PROVIDER;
+    process.env.FRIDAY_SETUP_DEFAULT_PROVIDER = "deepseek";
+    try {
+      const hub = await createIsolatedHub();
+      await hub.start();
+
+      const providers = await hub.providerService.listProviders();
+      const deepseek = providers.find((p) => p.kind === "deepseek");
+      expect(deepseek).toBeDefined();
+
+      const routing = await hub.providerService.getRoutingConfig();
+      expect(routing.defaultProviderId).toBe(deepseek!.id);
+      expect(routing.fallbackProviderIds).toEqual([]);
+    } finally {
+      if (previousIntent === undefined) {
+        delete process.env.FRIDAY_SETUP_DEFAULT_PROVIDER;
+      } else {
+        process.env.FRIDAY_SETUP_DEFAULT_PROVIDER = previousIntent;
+      }
+    }
+  });
+
   it("preserves a saved default with empty fallbacks on multi-key boot (no auto-added fallback)", async () => {
     // Gate OFF (dev) path: a user who saved {default, fallbackProviderIds: []}
     // must not have a fallback silently added when a second key appears.

--- a/test/integration/hub/friday-hub-bootstrap-integration.test.ts
+++ b/test/integration/hub/friday-hub-bootstrap-integration.test.ts
@@ -2042,4 +2042,54 @@ describe("FridayHub Bootstrap Integration", () => {
     const providers = await hub.providerService.listProviders();
     expect(providers.find((p) => p.kind === "deepseek")).toBeUndefined();
   });
+
+  it("does not auto-select a provider when multiple kinds are detected and no routing is chosen", async () => {
+    // Locked provider policy (gate OFF / dev boot): multiple LLM keys + no
+    // explicit routing must require an explicit user choice — never a hidden
+    // OpenAI / DeepSeek default and never an auto-added fallback.
+    process.env.OPENAI_API_KEY = "test-openai-key-not-validated"; // pragma: allowlist secret
+    process.env.DEEPSEEK_API_KEY = "test-deepseek-key-not-validated"; // pragma: allowlist secret
+    const hub = await createIsolatedHub();
+    await hub.start();
+
+    const providers = await hub.providerService.listProviders();
+    // Both profiles are registered so the user can choose between them.
+    expect(providers.find((p) => p.kind === "openai")).toBeDefined();
+    expect(providers.find((p) => p.kind === "deepseek")).toBeDefined();
+
+    // ...but no default route is auto-elected: this surfaces as action-required.
+    const routing = await hub.providerService.getRoutingConfig();
+    expect(routing.defaultProviderId).toBe("");
+    expect(routing.fallbackProviderIds).toEqual([]);
+  });
+
+  it("preserves a saved default with empty fallbacks on multi-key boot (no auto-added fallback)", async () => {
+    // Gate OFF (dev) path: a user who saved {default, fallbackProviderIds: []}
+    // must not have a fallback silently added when a second key appears.
+    const hub = await createIsolatedHub();
+    const primary = await hub.providerService.createProvider({
+      kind: "deepseek",
+      name: "DeepSeek Primary",
+      baseUrl: "https://api.deepseek.com",
+      authMode: "api-key",
+      api: "openai-completions",
+      apiKey: "$DEEPSEEK_API_KEY",
+      supportedModels: ["deepseek-v4-pro"],
+      defaultModel: "deepseek-v4-pro",
+      validateOnSave: false,
+    });
+    await hub.providerService.setRoutingConfig({
+      defaultProviderId: primary.id,
+      defaultModel: "deepseek-v4-pro",
+      fallbackProviderIds: [],
+    });
+    // A second provider key appears in the environment.
+    process.env.OPENAI_API_KEY = "test-openai-key-not-validated"; // pragma: allowlist secret
+
+    await hub.start();
+
+    const routing = await hub.providerService.getRoutingConfig();
+    expect(routing.defaultProviderId).toBe(primary.id);
+    expect(routing.fallbackProviderIds).toEqual([]);
+  });
 });

--- a/test/integration/providers/friday-provider-service-lifecycle.test.ts
+++ b/test/integration/providers/friday-provider-service-lifecycle.test.ts
@@ -242,4 +242,59 @@ describe("FridayProviderService Lifecycle (Integration)", () => {
       expect(fetched).toBeNull();
     });
   });
+
+  // ─── Record usage truthfully ───
+
+  describe("record usage", () => {
+    function readStoredProviderKinds(providerId: string): string[] {
+      return db.withReadConnection((conn) =>
+        conn
+          .prepare("SELECT provider_kind FROM llm_usage_records WHERE provider_id = ?")
+          .all(providerId)
+          .map((row) => (row as { provider_kind: string }).provider_kind),
+      );
+    }
+
+    it("records providerKind=\"unknown\" (never OpenAI) when the provider profile is missing", async () => {
+      await service.recordUsage({
+        providerId: "ghost-provider-id",
+        providerApi: "openai-completions",
+        model: "some-model",
+        routeStrategy: "configured",
+        taskComplexity: "simple",
+        usage: { input: 100, output: 50, cacheRead: 0, cacheWrite: 0, total: 150 },
+        costUsd: 0,
+      });
+
+      const kinds = readStoredProviderKinds("ghost-provider-id");
+      expect(kinds).toEqual(["unknown"]);
+      expect(kinds).not.toContain("openai");
+    });
+
+    it("records the real provider kind for an existing provider", async () => {
+      const provider = await service.createProvider({
+        kind: "deepseek",
+        name: "DeepSeek",
+        baseUrl: "https://api.deepseek.com",
+        authMode: "api-key",
+        api: "openai-completions",
+        apiKey: "$DEEPSEEK_API_KEY",
+        supportedModels: ["deepseek-v4-pro"],
+        defaultModel: "deepseek-v4-pro",
+        validateOnSave: false,
+      });
+
+      await service.recordUsage({
+        providerId: provider.id,
+        providerApi: "openai-completions",
+        model: "deepseek-v4-pro",
+        routeStrategy: "configured",
+        taskComplexity: "simple",
+        usage: { input: 100, output: 50, cacheRead: 0, cacheWrite: 0, total: 150 },
+        costUsd: 0.001,
+      });
+
+      expect(readStoredProviderKinds(provider.id)).toEqual(["deepseek"]);
+    });
+  });
 });

--- a/test/unit/agent/mcp/friday-mcp-adapter-env.test.ts
+++ b/test/unit/agent/mcp/friday-mcp-adapter-env.test.ts
@@ -114,6 +114,41 @@ describe("parseFridayMcpServersFromEnv", () => {
     expect(warn).toHaveBeenCalled();
   });
 
+  it("fails closed: drops entries with an unsupported transport instead of stdio fallback", () => {
+    const warn = vi.fn();
+    const result = parseFridayMcpServersFromEnv(
+      {
+        FRIDAY_MCP_SERVERS: JSON.stringify([
+          { id: "bad-sse", transport: "sse", command: "node" },
+          { id: "ok-stdio", command: "node" },
+        ]),
+      },
+      warn,
+    );
+
+    // The unsupported-transport entry is rejected, NOT silently run as stdio.
+    expect(result.map((s) => s.id)).toEqual(["ok-stdio"]);
+    expect(result.some((s) => s.id === "bad-sse")).toBe(false);
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("parses an explicit high-risk allowAllTools opt-in", () => {
+    const result = parseFridayMcpServersFromEnv({
+      FRIDAY_MCP_SERVERS: JSON.stringify([
+        { id: "trusted", command: "node", policy: { allowAllTools: true } },
+      ]),
+    });
+
+    expect(result).toEqual([
+      {
+        id: "trusted",
+        transport: "stdio",
+        command: "node",
+        policy: { allowAllTools: true },
+      },
+    ]);
+  });
+
   it("accepts legacy top-level allowTools/rateLimit policy fields", () => {
     const result = parseFridayMcpServersFromEnv({
       FRIDAY_MCP_SERVERS: JSON.stringify([

--- a/test/unit/agent/mcp/friday-mcp-adapter-runtime.test.ts
+++ b/test/unit/agent/mcp/friday-mcp-adapter-runtime.test.ts
@@ -120,6 +120,9 @@ describe("createFridayMcpAdapter — runtime adversarial behavior", () => {
           id: "lazy-http",
           transport: "http",
           url: "https://mcp.example.com/rpc",
+          // Explicit high-risk opt-in so discovered tools are exposed; without
+          // it the adapter fails closed and exposes nothing.
+          policy: { allowAllTools: true },
         },
       ],
     });
@@ -128,6 +131,44 @@ describe("createFridayMcpAdapter — runtime adversarial behavior", () => {
     await adapter.searchTools({ query: "search", serverId: "lazy-http" });
     expect(adapter.listServerStates()[0]?.state).toBe("loaded");
     expect(adapter.listServerStates()[0]?.toolCount).toBe(1);
+  });
+
+  it("fails closed: an external server with no allowlist and no opt-in exposes no tools", async () => {
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      const payload = JSON.parse(String(init?.body ?? "{}")) as { id?: number; method?: string };
+      if (payload.method === "initialize") {
+        return okHttpResponse(jsonRpcResponse(payload.id ?? 1, { protocolVersion: "2024-11-05" }));
+      }
+      if (payload.method === "tools/list") {
+        return okHttpResponse(jsonRpcResponse(payload.id ?? 2, {
+          tools: [{ name: "search", description: "Search docs", inputSchema: { type: "object" } }],
+        }));
+      }
+      if (payload.method === "tools/call") {
+        return okHttpResponse(jsonRpcResponse(payload.id ?? 3, {
+          content: [{ type: "text", text: "ok" }],
+          isError: false,
+        }));
+      }
+      return okHttpResponse("{}");
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const adapter = createFridayMcpAdapter({
+      servers: [
+        { id: "untrusted-http", transport: "http", url: "https://mcp.example.com/rpc" },
+      ],
+    });
+
+    // Discovery still works, but NO tools are exposed without an explicit
+    // allowlist or allowAllTools opt-in.
+    const tools = await adapter.listTools({ serverId: "untrusted-http" });
+    expect(tools).toEqual([]);
+
+    // Calling any tool is denied with a policy error (not silently allowed).
+    await expect(
+      adapter.callTool({ serverId: "untrusted-http", toolName: "search", args: {} }),
+    ).rejects.toMatchObject({ code: "MCP_POLICY_TOOL_FORBIDDEN" });
   });
 
   it("enforces local rate limit policy for repeated tool calls", async () => {
@@ -157,6 +198,7 @@ describe("createFridayMcpAdapter — runtime adversarial behavior", () => {
           transport: "http",
           url: "https://mcp.example.com/rpc",
           policy: {
+            allowAllTools: true,
             rateLimit: {
               maxCalls: 1,
               windowMs: 60_000,
@@ -226,6 +268,9 @@ describe("createFridayMcpAdapter — runtime adversarial behavior", () => {
           id: "unstable-http",
           transport: "http",
           url: "https://unstable.example.com/mcp",
+          // Opt in so the call reaches the transport layer (the behavior under
+          // test) rather than being blocked by the fail-closed default.
+          policy: { allowAllTools: true },
         },
       ],
     });

--- a/test/unit/channels/friday-channel-registry.test.ts
+++ b/test/unit/channels/friday-channel-registry.test.ts
@@ -294,9 +294,29 @@ describe("FridayChannelRegistry", () => {
       expect(handler).toHaveBeenCalledTimes(1);
     });
 
-    it("allows all messages when no allowlist is set", async () => {
-      const plugin = createMockPlugin("qq");
-      registry.register(plugin);
+    it("fails closed: a control-capable channel with no allowlist blocks all inbound", async () => {
+      // Locked channel policy: a missing allowlist must NOT mean "allow everyone"
+      // for control-capable channels (e.g. telegram/discord). Previously this
+      // returned true (allow-all) — that was the unsafe direction this flips.
+      const plugin = createMockPlugin("telegram");
+      registry.register(plugin, {}, { controlCapable: true });
+
+      const handler = vi.fn();
+      await registry.startAll(handler);
+
+      const startCall = (plugin.start as ReturnType<typeof vi.fn>).mock.calls[0];
+      const onMessage = startCall[0] as (msg: FridayChannelMessage) => void;
+
+      onMessage(createTestMessage());
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it("allows all messages when no allowlist is set for a NON-control channel", async () => {
+      // Scope guard: the fail-closed rule is for control-capable channels only.
+      // A non-control channel (e.g. the first-party webchat surface) keeps the
+      // legacy allow-when-unset behavior.
+      const plugin = createMockPlugin("webchat");
+      registry.register(plugin); // controlCapable defaults to false
 
       const handler = vi.fn();
       await registry.startAll(handler);

--- a/test/unit/cli/friday-cli-setup-wizard.test.ts
+++ b/test/unit/cli/friday-cli-setup-wizard.test.ts
@@ -1,0 +1,87 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Scripted answers for the mocked readline prompts. The setup wizard asks:
+//   1) provider choice  2) api key (or ollama url)  3) "Start Friday now?"
+// Answering "n" to (3) avoids spawning the real server (cmdStart).
+const hoisted = vi.hoisted(() => ({ answers: [] as string[] }));
+
+vi.mock("node:readline", () => ({
+  createInterface: () => ({
+    question: (_question: string, cb: (answer: string) => void) => {
+      cb(hoisted.answers.shift() ?? "");
+    },
+    close: () => {},
+  }),
+}));
+
+// Deep import: cmdSetup is intentionally NOT on the public #cli barrel.
+const { cmdSetup } = await import("../../../src/cli/friday-cli.js");
+
+const PROVIDER_KEYS = [
+  "OPENAI_API_KEY",
+  "DEEPSEEK_API_KEY",
+  "FRIDAY_ANTHROPIC_API_KEY",
+  "OLLAMA_BASE_URL",
+  "FRIDAY_SETUP_DEFAULT_PROVIDER",
+];
+
+describe("cmdSetup (CLI provider setup wizard)", () => {
+  let tempDir: string;
+  let envSnapshot: Map<string, string | undefined>;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "friday-cli-setup-"));
+    envSnapshot = new Map([
+      ["FRIDAY_STATE_DIR", process.env.FRIDAY_STATE_DIR],
+      ...PROVIDER_KEYS.map((k) => [k, process.env[k]] as [string, string | undefined]),
+    ]);
+    process.env.FRIDAY_STATE_DIR = tempDir;
+    for (const key of PROVIDER_KEYS) delete process.env[key];
+  });
+
+  afterEach(() => {
+    for (const [key, value] of envSnapshot) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    hoisted.answers = [];
+  });
+
+  function readEnvFile(): string {
+    return fs.readFileSync(path.join(tempDir, ".env"), "utf8");
+  }
+
+  it("offers DeepSeek as a first-class option and writes DEEPSEEK_API_KEY (no OpenAI)", async () => {
+    hoisted.answers = ["2", "sk-deepseek-test-key", "n"];
+    await cmdSetup();
+
+    const env = readEnvFile();
+    expect(env).toContain("DEEPSEEK_API_KEY=sk-deepseek-test-key");
+    expect(env).toContain("FRIDAY_SETUP_DEFAULT_PROVIDER=deepseek");
+    // Choosing DeepSeek must never write an OpenAI key.
+    expect(env).not.toContain("OPENAI_API_KEY");
+  });
+
+  it("writes OPENAI_API_KEY only when the user explicitly chooses OpenAI", async () => {
+    hoisted.answers = ["3", "sk-openai-test-key", "n"];
+    await cmdSetup();
+
+    const env = readEnvFile();
+    expect(env).toContain("OPENAI_API_KEY=sk-openai-test-key");
+    expect(env).toContain("FRIDAY_SETUP_DEFAULT_PROVIDER=openai");
+  });
+
+  it("does not write OpenAI by default (Anthropic) and records explicit intent", async () => {
+    hoisted.answers = ["1", "sk-ant-test-key", "n"];
+    await cmdSetup();
+
+    const env = readEnvFile();
+    expect(env).toContain("FRIDAY_ANTHROPIC_API_KEY=sk-ant-test-key");
+    expect(env).toContain("FRIDAY_SETUP_DEFAULT_PROVIDER=anthropic");
+    expect(env).not.toContain("OPENAI_API_KEY");
+  });
+});

--- a/test/unit/hub/friday-hub-bootstrap.test.ts
+++ b/test/unit/hub/friday-hub-bootstrap.test.ts
@@ -293,6 +293,9 @@ describe("createFridayHub", () => {
               botToken: "env:FRIDAY_TEST_SLACK_BOT_TOKEN",
               appToken: "env:FRIDAY_TEST_SLACK_APP_TOKEN",
               mode: "socket",
+              // Control-capable channels fail closed without a persisted
+              // allowlist; provide one so this asserts socket mode IS supported.
+              allowedUsers: ["U-allowed-user"],
             },
           ],
         },

--- a/test/unit/ops/real-green-gate-result.test.ts
+++ b/test/unit/ops/real-green-gate-result.test.ts
@@ -106,6 +106,11 @@ describe("buildRealGreenGateResult", () => {
       scenarios_run: 47,
       scenarios_total: 47,
       scenarios_passed: 47,
+      provider_lane_scope: {
+        scope: "default_only",
+        fallback_resilience_proven: false,
+        note: "No fallback provider lane was exercised in this run.",
+      },
     });
   });
 
@@ -192,6 +197,51 @@ describe("buildRealGreenGateResult", () => {
     expect(result.commit_sha).toBe("");
     expect(result.ref_name).toBe("");
     expect(result.evaluated_at).toBe("");
+  });
+
+  it("scopes a single-provider run to default-only and does NOT overclaim fallback resilience", () => {
+    const summary = passingSummary();
+    (summary.preflight as Record<string, unknown>).envTruth = {
+      providerLanes: {
+        default: { providerKind: "deepseek", model: "deepseek-v4-pro" },
+        fallback: null,
+      },
+      providerLaneRequirements: { fallbackRequired: false, source: "single_provider_no_fallback_required" },
+    };
+
+    const result = buildRealGreenGateResult({
+      summary,
+      commitSha: SHA_A,
+      refName: "main",
+      evaluatedAt: "2026-05-28T00:00:00.000Z",
+    });
+
+    expect(result.status).toBe(REAL_GREEN_GATE_RESULT_STATUSES.PASSED);
+    expect(result.provider_lane_scope.scope).toBe("single_provider_default_only");
+    expect(result.provider_lane_scope.fallback_resilience_proven).toBe(false);
+    expect(result.provider_lane_scope.note).toMatch(/single-provider default lane ONLY/i);
+    expect(result.provider_lane_scope.note).toMatch(/does NOT prove provider fallback resilience/i);
+  });
+
+  it("scopes a two-lane run to default_and_fallback with fallback resilience proven", () => {
+    const summary = passingSummary();
+    (summary.preflight as Record<string, unknown>).envTruth = {
+      providerLanes: {
+        default: { providerKind: "deepseek", model: "deepseek-v4-pro" },
+        fallback: { providerKind: "anthropic", model: "claude-sonnet-4" },
+      },
+      providerLaneRequirements: { fallbackRequired: true, source: "validated_alternative_available" },
+    };
+
+    const result = buildRealGreenGateResult({
+      summary,
+      commitSha: SHA_A,
+      refName: "main",
+      evaluatedAt: "2026-05-28T00:00:00.000Z",
+    });
+
+    expect(result.provider_lane_scope.scope).toBe("default_and_fallback");
+    expect(result.provider_lane_scope.fallback_resilience_proven).toBe(true);
   });
 });
 

--- a/test/unit/ops/run-real-green-gate-self-hosted.test.ts
+++ b/test/unit/ops/run-real-green-gate-self-hosted.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { REAL_GREEN_GATE_RESULT_FILENAME } from "../../../scripts/ops/lib/real-green-gate-result.mjs";
 import {
   completeSelfHostedSetup,
+  configureExplicitDeepSeekRouting,
   createGateEnv,
   createRuntimeEnv,
 } from "../../../scripts/ops/run-real-green-gate-self-hosted.mjs";
@@ -98,6 +99,88 @@ describe("run-real-green-gate-self-hosted", () => {
       completedSteps: ["welcome", "security", "network", "skills"],
       skippedSteps: ["communication", "provider", "channels"],
     });
+  });
+
+  it("pins explicit DeepSeek routing (no fallback) and never selects OpenAI for the default proof", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    vi.stubGlobal("fetch", vi.fn(async (url: string, init?: RequestInit) => {
+      calls.push({ url, init });
+      if (url.endsWith("/v1/auth/login")) {
+        return new Response(JSON.stringify({ ok: true, data: { accessToken: "tok" } }), {
+          status: 200, headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (url.endsWith("/v1/providers")) {
+        return new Response(JSON.stringify({
+          ok: true,
+          data: {
+            items: [
+              { id: "oai-1", kind: "openai", enabled: true, defaultModel: "gpt-4o-mini" },
+              { id: "ds-1", kind: "deepseek", enabled: true, defaultModel: "deepseek-v4-pro" },
+            ],
+          },
+        }), { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+      if (url.endsWith("/v1/model-routing")) {
+        return new Response(JSON.stringify({ ok: true, data: { routing: {} } }), {
+          status: 200, headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify({ ok: false }), { status: 404 });
+    }));
+
+    const result = await configureExplicitDeepSeekRouting("http://127.0.0.1:31337", "pass");
+
+    expect(result).toEqual({ configured: true, providerId: "ds-1" });
+    const routingCall = calls.find((c) => c.url.endsWith("/v1/model-routing"));
+    expect(routingCall?.init?.method).toBe("PUT");
+    const body = JSON.parse(String(routingCall?.init?.body));
+    expect(body).toEqual({
+      defaultProviderId: "ds-1",
+      defaultModel: "deepseek-v4-pro",
+      fallbackProviderIds: [],
+    });
+    // OpenAI is registered but must never be selected as default or fallback.
+    expect(body.defaultProviderId).not.toBe("oai-1");
+    expect(body.fallbackProviderIds).not.toContain("oai-1");
+  });
+
+  it("leaves routing unset (configured:false) when no DeepSeek provider is present", async () => {
+    const calls: string[] = [];
+    vi.stubGlobal("fetch", vi.fn(async (url: string) => {
+      calls.push(url);
+      if (url.endsWith("/v1/auth/login")) {
+        return new Response(JSON.stringify({ ok: true, data: { accessToken: "tok" } }), {
+          status: 200, headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (url.endsWith("/v1/providers")) {
+        return new Response(JSON.stringify({
+          ok: true,
+          data: { items: [{ id: "oai-1", kind: "openai", enabled: true }] },
+        }), { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+      return new Response(JSON.stringify({ ok: false }), { status: 404 });
+    }));
+
+    const result = await configureExplicitDeepSeekRouting("http://127.0.0.1:31337", "pass");
+
+    expect(result).toEqual({ configured: false });
+    // No routing PUT is made — action-required is surfaced honestly.
+    expect(calls.some((url) => url.endsWith("/v1/model-routing"))).toBe(false);
+  });
+
+  it("injects OPENAI_API_KEY only on the two explicitly gated OpenAI lanes", () => {
+    const workflow = readFileSync(join(process.cwd(), ".github/workflows/real-green-gate.yml"), "utf8");
+    const injections = workflow.match(/OPENAI_API_KEY: \$\{\{ secrets\.OPENAI_API_KEY \}\}/g) ?? [];
+    // Only c3c4-provider-routing-proof and c45-real-user-intelligence-proof.
+    expect(injections).toHaveLength(2);
+    // The default proof job must not carry an OpenAI key.
+    const mainJobSection = workflow.slice(
+      workflow.indexOf("real-green-gate:"),
+      workflow.indexOf("phase24b-discord-trusted-inbound:"),
+    );
+    expect(mainJobSection).not.toContain("OPENAI_API_KEY");
   });
 
   it("passes an explicit workspace root while keeping runtime state isolated", () => {

--- a/test/unit/providers/cost/friday-provider-cost-controls.test.ts
+++ b/test/unit/providers/cost/friday-provider-cost-controls.test.ts
@@ -57,10 +57,52 @@ describe("Friday provider cost controls", () => {
       expect(catalog.getPricing("openai", "gpt-4.1-mini").inputPer1MUsd).toBe(0.4);
       expect(catalog.getPricing("openai", "gpt-4.1").inputPer1MUsd).toBe(2);
       expect(catalog.getPricing("ollama", "llama3.1").inputPer1MUsd).toBe(0);
-      expect(catalog.getPricing("openai", "unknown-model")).toMatchObject({
-        inputPer1MUsd: 1,
-        outputPer1MUsd: 4,
-        qualityTier: "balanced",
+    });
+
+    it("prices the OpenAI gpt-4o models Friday auto-detects (incl gpt-4o-mini)", () => {
+      const catalog = createFridayProviderPricingCatalog();
+
+      // gpt-4o-mini is the auto-detected OpenAI default; the longest pattern wins
+      // so gpt-4o-mini does not collapse into gpt-4o.
+      expect(catalog.getPricing("openai", "gpt-4o-mini")).toMatchObject({
+        inputPer1MUsd: 0.15,
+        outputPer1MUsd: 0.6,
+        qualityTier: "cheap",
+      });
+      expect(catalog.getPricing("openai", "gpt-4o")).toMatchObject({
+        inputPer1MUsd: 2.5,
+        outputPer1MUsd: 10,
+      });
+    });
+
+    it("prices DeepSeek (Friday's primary) v4 models and legacy aliases", () => {
+      const catalog = createFridayProviderPricingCatalog();
+
+      expect(catalog.getPricing("deepseek", "deepseek-v4-pro")).toMatchObject({
+        inputPer1MUsd: 1.74,
+        outputPer1MUsd: 3.48,
+        qualityTier: "best",
+      });
+      expect(catalog.getPricing("deepseek", "deepseek-v4-flash")).toMatchObject({
+        inputPer1MUsd: 0.14,
+        outputPer1MUsd: 0.28,
+      });
+      // Deprecated aliases map to v4-flash pricing — they are still priced, not
+      // sent through the unknown fallback.
+      expect(catalog.getPricing("deepseek", "deepseek-chat").inputPer1MUsd).toBe(0.14);
+      expect(catalog.getPricing("deepseek", "deepseek-reasoner").inputPer1MUsd).toBe(0.14);
+    });
+
+    it("records an unrecognized model as explicit unknown, not a fabricated rate", () => {
+      const catalog = createFridayProviderPricingCatalog();
+
+      // Truth over guessing: no fabricated $1/$4 "balanced" estimate.
+      expect(catalog.getPricing("openai", "unknown-model")).toEqual({
+        inputPer1MUsd: 0,
+        outputPer1MUsd: 0,
+        cacheReadPer1MUsd: 0,
+        cacheWritePer1MUsd: 0,
+        qualityTier: "unknown",
       });
     });
   });

--- a/test/unit/providers/routing/friday-provider-fallback.test.ts
+++ b/test/unit/providers/routing/friday-provider-fallback.test.ts
@@ -459,6 +459,37 @@ describe("FridayProviderFallback", () => {
       ).rejects.toThrow("no candidates available");
     });
 
+    it("uses only explicit DeepSeek routing and never invokes an OpenAI provider", async () => {
+      // Unconditional proof (no live/skip gate) for locked decision #1: explicit
+      // DeepSeek routing with no fallback resolves to DeepSeek alone — an
+      // also-registered OpenAI provider must NOT be auto-injected or invoked.
+      const fb = createFridayProviderFallback();
+      const deepseek = makeProvider("ds", "deepseek", true, "deepseek-v4-pro", ["deepseek-v4-pro"]);
+      const openai = makeProvider("oai", "openai", true, "gpt-4o-mini", ["gpt-4o-mini"]);
+      const routing: FridayModelRoutingConfig = {
+        defaultProviderId: "ds",
+        fallbackProviderIds: [],
+      };
+
+      const candidates = fb.resolveCandidates({ routing, providers: [openai, deepseek] });
+      expect(candidates).toHaveLength(1);
+      expect(candidates[0].provider.kind).toBe("deepseek");
+      expect(candidates.some((c) => c.provider.kind === "openai")).toBe(false);
+
+      const invokedKinds: string[] = [];
+      const result = await fb.runWithFallback({
+        candidates,
+        run: async (route) => {
+          invokedKinds.push(route.provider.kind);
+          return `ok-${route.provider.kind}`;
+        },
+      });
+
+      expect(result.result).toBe("ok-deepseek");
+      expect(invokedKinds).toEqual(["deepseek"]);
+      expect(invokedKinds).not.toContain("openai");
+    });
+
     it("records all failed attempts in order", async () => {
       const fb = createFridayProviderFallback();
       const p1 = makeProvider("p1", "openai");

--- a/test/unit/ui/ui-truth-regressions.test.ts
+++ b/test/unit/ui/ui-truth-regressions.test.ts
@@ -8,9 +8,11 @@ import { CHANNEL_KINDS_ORDERED, CHANNEL_META } from "../../../ui/src/lib/channel
 import {
   SETUP_CHANNEL_KINDS_ORDERED,
   buildSetupCompletionStepState,
+  buildSetupCompletionTitle,
   getProviderBootstrapRecommendation,
   getSetupProviderKindsForRegion,
 } from "../../../ui/src/routes/setup-page";
+import { buildFridayReadinessSummary } from "../../../ui/src/components/setup/friday-readiness-summary";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, "../../..");
@@ -51,6 +53,40 @@ describe("ui truth regressions", () => {
 
   it("keeps setup channels limited to verified first-run control routes", () => {
     expect(SETUP_CHANNEL_KINDS_ORDERED).toEqual(["telegram", "discord", "feishu"]);
+  });
+
+  it("does not claim Friday is ready when the AI provider step was skipped", () => {
+    const skipped = buildSetupCompletionTitle("en", false);
+    // Truthful: runtime-ready, not provider-ready.
+    expect(skipped.title).toBe("Setup saved");
+    expect(skipped.title).not.toBe("Friday is Ready");
+    expect(skipped.subtitle).toMatch(/Connect an AI provider/i);
+
+    const ready = buildSetupCompletionTitle("en", true);
+    expect(ready.title).toBe("Friday is Ready");
+    expect(ready.subtitle).toBeNull();
+  });
+
+  it("buckets an unverified AI text capability as needing connection, not ready", () => {
+    const summary = buildFridayReadinessSummary(
+      {
+        capabilities: {
+          runtime: {
+            items: [
+              { capability: "text", label: "Text model", state: "needs_user_auth", sources: [], blockers: [] },
+            ],
+          },
+        },
+      } as never,
+      "en",
+    );
+    const readyBucket = summary.buckets.find((b) => b.id === "ready");
+    const connectBucket = summary.buckets.find((b) => b.id === "connect");
+    // The skipped/unverified text model must NOT appear as ready.
+    expect(readyBucket?.items ?? []).not.toContain("Text model");
+    expect(connectBucket?.items ?? []).toContain("Text model");
+    // And the subline reflects an outstanding gap rather than "all ready".
+    expect(summary.subline).toMatch(/need/i);
   });
 
   it("does not present unsupported QQ as an available shared channel", () => {

--- a/test/unit/validation/real-world-env-truth.test.ts
+++ b/test/unit/validation/real-world-env-truth.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   PHASE24_CHANNEL_ENV_REQUIREMENTS,
+  chooseFallbackLane,
   collectEnvironmentTruth,
   resolveFallbackLaneRequirement,
   resolveScenarioLanes,
@@ -95,7 +96,11 @@ function allPhase24Env(valuePrefix: string) {
 }
 
 describe("real-world env truth fallback requirements", () => {
-  it("requires a fallback lane whenever a default lane exists", () => {
+  it("does NOT require a fallback lane when only one eligible provider exists", () => {
+    // A one-provider deployment truthfully has no fallback. Requiring one (the
+    // old default_lane_requires_fallback behavior) would force re-introducing a
+    // second provider such as OpenAI just to satisfy the gate. This run proves
+    // the single-provider DEFAULT lane only — not fallback resilience.
     const providers = [
       makeProvider({ id: "default-provider", name: "Default Provider" }),
       makeProvider({
@@ -122,8 +127,8 @@ describe("real-world env truth fallback requirements", () => {
     );
 
     expect(result).toEqual({
-      fallbackRequired: true,
-      source: "default_lane_requires_fallback",
+      fallbackRequired: false,
+      source: "single_provider_no_fallback_required",
     });
   });
 
@@ -158,6 +163,48 @@ describe("real-world env truth fallback requirements", () => {
       fallbackRequired: true,
       source: "validated_alternative_available",
     });
+  });
+
+  it("never synthesizes an OpenAI fallback when OpenAI is not a registered provider", () => {
+    // Only DeepSeek + Anthropic exist (no OpenAI). The chosen fallback must be a
+    // real registered non-default provider — never a fabricated OpenAI lane.
+    const providers = [
+      makeProvider({ id: "deepseek-default", kind: "deepseek", name: "DeepSeek" }),
+      makeProvider({ id: "anthropic-alt", kind: "anthropic", name: "Anthropic Alt" }),
+    ];
+    const providerHealthById = new Map([
+      ["deepseek-default", { providerId: "deepseek-default", routingEligible: true, validationStatus: "ok" }],
+      ["anthropic-alt", { providerId: "anthropic-alt", routingEligible: true, validationStatus: "ok" }],
+    ]);
+
+    const fallback = chooseFallbackLane(
+      providers,
+      { defaultProviderId: "deepseek-default", fallbackProviderIds: [] },
+      { providerId: "deepseek-default", providerKind: "deepseek", backendKind: "http" },
+      providerHealthById,
+    );
+
+    expect(fallback).not.toBeNull();
+    expect(fallback?.providerKind).not.toBe("openai");
+    expect(fallback?.providerKind).toBe("anthropic");
+  });
+
+  it("returns no fallback lane (never an OpenAI guess) when only one provider exists", () => {
+    const providers = [
+      makeProvider({ id: "deepseek-only", kind: "deepseek", name: "DeepSeek" }),
+    ];
+    const providerHealthById = new Map([
+      ["deepseek-only", { providerId: "deepseek-only", routingEligible: true, validationStatus: "ok" }],
+    ]);
+
+    const fallback = chooseFallbackLane(
+      providers,
+      { defaultProviderId: "deepseek-only", fallbackProviderIds: [] },
+      { providerId: "deepseek-only", providerKind: "deepseek", backendKind: "http" },
+      providerHealthById,
+    );
+
+    expect(fallback).toBeNull();
   });
 });
 

--- a/ui/src/routes/setup-page.tsx
+++ b/ui/src/routes/setup-page.tsx
@@ -172,6 +172,29 @@ export function buildSetupCompletionStepState(input: SetupCompletionStepStateInp
   return { completedSteps, skippedSteps };
 }
 
+/**
+ * Truthful setup-completion headline. Distinguishes "runtime ready" from "AI
+ * provider ready": when the provider step was skipped (not validated) we must
+ * NOT claim Friday is ready — the runtime is up but no AI provider is connected
+ * yet. The per-capability readiness panel carries the detailed truth.
+ */
+export function buildSetupCompletionTitle(
+  locale: AppLocale,
+  providerValidated: boolean,
+): { title: string; subtitle: string | null } {
+  if (providerValidated) {
+    return { title: localize(locale, "Friday 已就绪", "Friday is Ready"), subtitle: null };
+  }
+  return {
+    title: localize(locale, "设置已保存", "Setup saved"),
+    subtitle: localize(
+      locale,
+      "运行环境已就绪。连接一个 AI 提供方后 Friday 才能开始工作——详情见下方。",
+      "The runtime is ready. Connect an AI provider before Friday can work — see the details below.",
+    ),
+  };
+}
+
 type FeishuRegistrationState = {
   status: "idle" | "starting" | "pending" | "success" | "failed";
   registrationId?: string;
@@ -2864,6 +2887,9 @@ export function SetupPage() {
   // ─── STEP 5 — Completion ───
 
   function renderStep5() {
+    // Truthful completion headline — does not claim "ready" if the AI provider
+    // step was skipped (runtime-ready vs provider-ready).
+    const completionTitle = buildSetupCompletionTitle(locale, providerValidated);
     // Build summary lines
     const summaryItems: string[] = [];
     if (providerValidated) {
@@ -2896,8 +2922,14 @@ export function SetupPage() {
         </div>
 
         <h1 className="text-4xl font-semibold tracking-tight text-[color:var(--color-text-primary)] sm:text-5xl">
-          {localize(locale, "Friday 已就绪", "Friday is Ready")}
+          {completionTitle.title}
         </h1>
+
+        {completionTitle.subtitle && (
+          <p className="mt-3 max-w-2xl text-base text-[color:var(--color-text-secondary)]">
+            {completionTitle.subtitle}
+          </p>
+        )}
 
         {summaryItems.length > 0 && (
           <p className="mt-4 text-lg text-[color:var(--color-text-secondary)]">

--- a/validation/real-world/lib/env-truth.mjs
+++ b/validation/real-world/lib/env-truth.mjs
@@ -227,19 +227,27 @@ export function resolveFallbackLaneRequirement(providers, routing, defaultLane, 
       || isProviderValidationEligible(provider)
     ));
   if (defaultLane && !hasValidatedAlternative) {
+    // Single eligible provider: a one-provider deployment truthfully has no
+    // fallback, so the default proof must NOT require one — and must never
+    // synthesize an absent provider (e.g. OpenAI) as a fallback. This run then
+    // verifies ONLY the single-provider default lane; it does NOT prove provider
+    // fallback resilience. Multi-provider / fallback-resilience proof is the
+    // explicit, gated C3/C4 provider-routing lane.
     return {
-      fallbackRequired: true,
-      source: "default_lane_requires_fallback",
+      fallbackRequired: false,
+      source: "single_provider_no_fallback_required",
     };
   }
 
+  // Two or more eligible providers exist with no explicit fallback configured —
+  // a fallback lane is still required so resilience is exercised.
   return {
     fallbackRequired: hasValidatedAlternative,
     source: hasValidatedAlternative ? "validated_alternative_available" : "no_validated_alternative",
   };
 }
 
-function chooseFallbackLane(providers, routing, defaultLane, providerHealthById = new Map()) {
+export function chooseFallbackLane(providers, routing, defaultLane, providerHealthById = new Map()) {
   const enabled = providers.filter((provider) => provider.enabled && provider.id !== defaultLane?.providerId);
   const preferredIds = asArray(routing?.fallbackProviderIds);
   const fromPreferred = uniqueProviders(preferredIds


### PR DESCRIPTION
## Provider / settings truth + setup-safety closure

Makes Friday follow user settings: no hidden provider choice, no hidden OpenAI usage, no unsafe allow-all channel control, no fake-ready setup state, and no compatibility fallback that changes user intent. Gate-anchored against the current code (reconciled with already-merged PR #378), not just the goal's bullets.

### Provider routing (locked decision #1)
- `autoDetectProvidersFromEnv` no longer auto-picks a provider when **multiple** provider kinds are detected with no explicit routing — it leaves routing unset so the request-time `PROVIDER_NO_ROUTING` (action-required) path engages. Single-key auto-pick is preserved (decision #1 is scoped to multiple keys).
- Removed the OpenAI-biased `ROUTING_PRIORITY` constant; no auto-added fallback providers.
- Honors an explicit setup-recorded choice (`FRIDAY_SETUP_DEFAULT_PROVIDER`) even with multiple keys — an explicit user choice, not a hidden auto-pick.

### Usage / cost truth
- `recordUsage` records `providerKind: "unknown"` (with a diagnostic) when the provider profile is missing — never silently attributes usage to OpenAI.
- Pricing catalog gains the real models Friday uses at published rates: DeepSeek `v4-pro`/`v4-flash` (+ legacy `chat`/`reasoner` aliases) and OpenAI `gpt-4o`/`gpt-4o-mini`. The generic fallback no longer fabricates `$1/$4` — unrecognized models return an explicit `unknown` (zero) rate.

### RGG / CI proof (locked decision #3)
- Default RGG proof is **DeepSeek-only**: dropped `OPENAI_API_KEY` from the main gate job and the phase24b/c/d channel-listener jobs. OpenAI is injected only on the explicitly gated `c3c4` / `c45` lanes.
- The self-hosted RGG runtime pins **explicit** DeepSeek routing (no fallback) after setup, so it does not rely on auto-pick and never attempts OpenAI by default. (`real-provider` evidence is still produced from the DeepSeek attempt; the fallback lane resolves to a non-OpenAI provider.)

### Channels — fail closed (locked decision #2)
- Control-capable external channels (telegram, discord, lark, feishu, whatsapp, signal, slack, irc, line, qq) fail closed without a persisted user/chat allowlist: the registry denies inbound, activation skips the channel, and the setup save handler rejects it (`CHANNEL_ALLOWLIST_REQUIRED`). `webchat` (first-party, session-authenticated) is intentionally excluded.
- Telegram/Discord verification now persists the verified principal as `allowedUsers` (mirrors the Feishu path).

### MCP — fail closed
- An unsupported MCP transport (e.g. `sse`) is rejected instead of silently coerced to a local stdio child process.
- An external MCP server with no `toolAllowlist` exposes **no** tools and denies calls unless an explicit, visible high-risk `allowAllTools` opt-in is set.

### Setup honesty
- The wizard completion screen no longer unconditionally claims "Friday is Ready"; when the AI provider step was skipped it says "Setup saved" with a runtime-ready-vs-provider-ready subtitle.
- CLI setup adds DeepSeek as a first-class peer option and persists the explicit provider choice.

### Media / TTS
- Confirmed already-safe (disabled-by-default + truth-labeled media understanding; OpenAI-compatible-only TTS gated behind a verified probe). No change needed.

### Tests / proof
Wrong-direction tests flipped to the safer truth (channel allow-all, telegram/discord `allowedUsers` undefined, MCP permissive default). Added gate tests for every locked decision. Local proof: full default test suite green, full typecheck (src+ui+operator-client), build (API+UI), eslint (0 errors), and all CI guard scripts (provider-reliability, architecture-boundaries, secret-patterns, public-source-hygiene, alignment, ssd, migrations, adversarial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
