### PR TITLE
fix(pr384): close reviewer-b safety proof gaps

### DIFF
--- a/scripts/ops/lib/real-green-gate-result.mjs
+++ b/scripts/ops/lib/real-green-gate-result.mjs
@@ -112,6 +112,19 @@ function normalizeStringList(value) {
     .slice();
 }
 
+function hasExplicitFallbackProofSignal(summary) {
+  const candidates = [
+    summary?.providerFallbackProof,
+    summary?.fallbackProviderProof,
+    summary?.gate?.providerFallbackProof,
+    summary?.gate?.fallbackProviderProof,
+  ];
+  if (candidates.some((candidate) => candidate?.passed === true || candidate?.status === "passed")) {
+    return true;
+  }
+  return SUITE_KEYS.some((key) => safeNumber(summary?.[key]?.fallbackProviderAttemptCount) > 0);
+}
+
 /**
  * Truthfully scope what the provider lanes proved. A run with only one eligible
  * provider proves the single-provider DEFAULT lane only — it does NOT prove
@@ -123,10 +136,13 @@ function deriveProviderLaneScope(summary) {
   const lanes = envTruth.providerLanes ?? {};
   const requirements = envTruth.providerLaneRequirements ?? {};
   if (lanes.fallback) {
+    const fallbackProven = hasExplicitFallbackProofSignal(summary);
     return {
       scope: "default_and_fallback",
-      fallback_resilience_proven: true,
-      note: "Default and fallback provider lanes were resolved and exercised.",
+      fallback_resilience_proven: fallbackProven,
+      note: fallbackProven
+        ? "Default and fallback provider lanes were resolved and explicit fallback proof signals were observed."
+        : "Default and fallback provider lanes were resolved, but this artifact does NOT prove fallback resilience without an explicit fallback proof signal.",
     };
   }
   if (requirements.fallbackRequired === false) {

--- a/scripts/ops/run-real-green-gate.mjs
+++ b/scripts/ops/run-real-green-gate.mjs
@@ -385,6 +385,9 @@ function renderMarkdown(summary) {
     `- Default lane: ${summary.preflight?.envTruth?.providerLanes?.default?.model ?? "missing"}`,
     `- Fallback lane: ${summary.preflight?.envTruth?.providerLanes?.fallback?.model ?? "missing"}`,
     `- Fallback required: ${String(summary.preflight?.envTruth?.providerLaneRequirements?.fallbackRequired !== false)} (source: ${summary.preflight?.envTruth?.providerLaneRequirements?.source ?? "n/a"})`,
+    ...(summary.preflight?.envTruth?.providerLanes?.fallback
+      ? ["- Provider-lane scope: fallback lane resolved; fallback resilience is NOT claimed unless a separate explicit fallback proof signal is present."]
+      : []),
     ...(summary.preflight?.envTruth?.providerLaneRequirements?.fallbackRequired === false && !summary.preflight?.envTruth?.providerLanes?.fallback
       ? ["- Provider-lane scope: single eligible provider — proves the single-provider DEFAULT lane ONLY; does NOT prove fallback resilience (see explicit gated C3/C4 lane)."]
       : []),

--- a/src/agent/mcp/friday-mcp-adapter.ts
+++ b/src/agent/mcp/friday-mcp-adapter.ts
@@ -77,6 +77,8 @@ export const FRIDAY_MCP_ADAPTER_ERROR_CODES = {
   TRANSPORT_ERROR: "MCP_TRANSPORT_ERROR",
   REQUEST_FAILED: "MCP_REQUEST_FAILED",
   POLICY_TOOL_FORBIDDEN: "MCP_POLICY_TOOL_FORBIDDEN",
+  POLICY_RESOURCE_FORBIDDEN: "MCP_POLICY_RESOURCE_FORBIDDEN",
+  POLICY_PROMPT_FORBIDDEN: "MCP_POLICY_PROMPT_FORBIDDEN",
   POLICY_RATE_LIMITED: "MCP_POLICY_RATE_LIMITED",
 } as const;
 
@@ -540,11 +542,12 @@ export function createFridayMcpAdapter(
           },
         });
 
+        const filtered = applyResourceAllowlist(server.policy, resources);
         markServerState(server.id, "loaded", {
-          resourceCount: resources.length,
+          resourceCount: filtered.length,
           lastLoadedAt: new Date().toISOString(),
         });
-        collected.push(...resources);
+        collected.push(...filtered);
       }
 
       return collected;
@@ -556,6 +559,7 @@ export function createFridayMcpAdapter(
       const correlationId = nextCorrelationId(server.id, "resources.read");
 
       markServerState(server.id, "discoverable");
+      enforceResourceAllowlist(server, input.uri, routeId, correlationId);
       const cached = requestDedup.get<FridayMcpReadResourceResult>(
         server.id,
         "resources/read",
@@ -643,11 +647,12 @@ export function createFridayMcpAdapter(
           },
         });
 
+        const filtered = applyPromptAllowlist(server.policy, prompts);
         markServerState(server.id, "loaded", {
-          promptCount: prompts.length,
+          promptCount: filtered.length,
           lastLoadedAt: new Date().toISOString(),
         });
-        collected.push(...prompts);
+        collected.push(...filtered);
       }
 
       return collected;
@@ -659,6 +664,7 @@ export function createFridayMcpAdapter(
       const correlationId = nextCorrelationId(server.id, `prompts.get.${input.name}`);
 
       markServerState(server.id, "discoverable");
+      enforcePromptAllowlist(server, input.name, routeId, correlationId);
       const dedupArgs = {
         name: input.name,
         ...(input.args ?? {}),
@@ -782,9 +788,23 @@ function normalizeServerPolicy(policy: FridayMcpServerPolicy | undefined): Frida
   if (!policy) return undefined;
 
   const allowAllTools = policy.allowAllTools === true;
+  const allowAllResources = policy.allowAllResources === true;
+  const allowAllPrompts = policy.allowAllPrompts === true;
 
   const toolAllowlist = Array.isArray(policy.toolAllowlist)
     ? policy.toolAllowlist
+      .filter((value): value is string => typeof value === "string")
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0)
+    : undefined;
+  const resourceAllowlist = Array.isArray(policy.resourceAllowlist)
+    ? policy.resourceAllowlist
+      .filter((value): value is string => typeof value === "string")
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0)
+    : undefined;
+  const promptAllowlist = Array.isArray(policy.promptAllowlist)
+    ? policy.promptAllowlist
       .filter((value): value is string => typeof value === "string")
       .map((value) => value.trim())
       .filter((value) => value.length > 0)
@@ -796,13 +816,25 @@ function normalizeServerPolicy(policy: FridayMcpServerPolicy | undefined): Frida
     ? { maxCalls, windowMs }
     : undefined;
 
-  if ((!toolAllowlist || toolAllowlist.length === 0) && !rateLimit && !allowAllTools) {
+  if (
+    (!toolAllowlist || toolAllowlist.length === 0)
+    && (!resourceAllowlist || resourceAllowlist.length === 0)
+    && (!promptAllowlist || promptAllowlist.length === 0)
+    && !rateLimit
+    && !allowAllTools
+    && !allowAllResources
+    && !allowAllPrompts
+  ) {
     return undefined;
   }
 
   return {
     ...(toolAllowlist && toolAllowlist.length > 0 ? { toolAllowlist } : {}),
     ...(allowAllTools ? { allowAllTools: true } : {}),
+    ...(resourceAllowlist && resourceAllowlist.length > 0 ? { resourceAllowlist } : {}),
+    ...(allowAllResources ? { allowAllResources: true } : {}),
+    ...(promptAllowlist && promptAllowlist.length > 0 ? { promptAllowlist } : {}),
+    ...(allowAllPrompts ? { allowAllPrompts: true } : {}),
     ...(rateLimit ? { rateLimit } : {}),
   };
 }
@@ -818,10 +850,26 @@ function parseServerPolicy(
   }
 
   const allowAllTools = policyRow.allowAllTools === true || row.allowAllTools === true;
+  const allowAllResources = policyRow.allowAllResources === true || row.allowAllResources === true;
+  const allowAllPrompts = policyRow.allowAllPrompts === true || row.allowAllPrompts === true;
 
   const allowlistRaw = policyRow.toolAllowlist ?? row.allowTools;
   const toolAllowlist = Array.isArray(allowlistRaw)
     ? allowlistRaw
+      .filter((value): value is string => typeof value === "string")
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0)
+    : undefined;
+  const resourcesRaw = policyRow.resourceAllowlist ?? row.allowResources;
+  const resourceAllowlist = Array.isArray(resourcesRaw)
+    ? resourcesRaw
+      .filter((value): value is string => typeof value === "string")
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0)
+    : undefined;
+  const promptsRaw = policyRow.promptAllowlist ?? row.allowPrompts;
+  const promptAllowlist = Array.isArray(promptsRaw)
+    ? promptsRaw
       .filter((value): value is string => typeof value === "string")
       .map((value) => value.trim())
       .filter((value) => value.length > 0)
@@ -844,13 +892,25 @@ function parseServerPolicy(
     }
   }
 
-  if ((!toolAllowlist || toolAllowlist.length === 0) && !rateLimit && !allowAllTools) {
+  if (
+    (!toolAllowlist || toolAllowlist.length === 0)
+    && (!resourceAllowlist || resourceAllowlist.length === 0)
+    && (!promptAllowlist || promptAllowlist.length === 0)
+    && !rateLimit
+    && !allowAllTools
+    && !allowAllResources
+    && !allowAllPrompts
+  ) {
     return undefined;
   }
 
   return {
     ...(toolAllowlist && toolAllowlist.length > 0 ? { toolAllowlist } : {}),
     ...(allowAllTools ? { allowAllTools: true } : {}),
+    ...(resourceAllowlist && resourceAllowlist.length > 0 ? { resourceAllowlist } : {}),
+    ...(allowAllResources ? { allowAllResources: true } : {}),
+    ...(promptAllowlist && promptAllowlist.length > 0 ? { promptAllowlist } : {}),
+    ...(allowAllPrompts ? { allowAllPrompts: true } : {}),
     ...(rateLimit ? { rateLimit } : {}),
   };
 }
@@ -978,6 +1038,88 @@ function applyToolAllowlist(
     return tools;
   }
   // Fail closed: no allowlist and no opt-in exposes nothing.
+  return [];
+}
+
+function enforceResourceAllowlist(
+  server: FridayMcpServerConfig,
+  uri: string,
+  routeId: string,
+  correlationId: string,
+): void {
+  const allowlist = server.policy?.resourceAllowlist;
+  if (allowlist && allowlist.length > 0) {
+    if (allowlist.includes(uri)) return;
+  } else if (server.policy?.allowAllResources === true) {
+    return;
+  }
+
+  throw createFridayMcpAdapterError({
+    code: FRIDAY_MCP_ADAPTER_ERROR_CODES.POLICY_RESOURCE_FORBIDDEN,
+    message: `MCP resource '${uri}' is not allowed on server '${server.id}'`,
+    routeId,
+    correlationId,
+    details: {
+      serverId: server.id,
+      uri,
+      allowlist: allowlist ?? [],
+      allowAllResources: server.policy?.allowAllResources === true,
+    },
+  });
+}
+
+function applyResourceAllowlist(
+  policy: FridayMcpServerPolicy | undefined,
+  resources: FridayMcpResourceDescriptor[],
+): FridayMcpResourceDescriptor[] {
+  const allowlist = policy?.resourceAllowlist;
+  if (allowlist && allowlist.length > 0) {
+    return resources.filter((resource) => allowlist.includes(resource.uri));
+  }
+  if (policy?.allowAllResources === true) {
+    return resources;
+  }
+  return [];
+}
+
+function enforcePromptAllowlist(
+  server: FridayMcpServerConfig,
+  name: string,
+  routeId: string,
+  correlationId: string,
+): void {
+  const allowlist = server.policy?.promptAllowlist;
+  if (allowlist && allowlist.length > 0) {
+    if (allowlist.includes(name)) return;
+  } else if (server.policy?.allowAllPrompts === true) {
+    return;
+  }
+
+  throw createFridayMcpAdapterError({
+    code: FRIDAY_MCP_ADAPTER_ERROR_CODES.POLICY_PROMPT_FORBIDDEN,
+    message: `MCP prompt '${name}' is not allowed on server '${server.id}'`,
+    routeId,
+    correlationId,
+    details: {
+      serverId: server.id,
+      promptName: name,
+      allowlist: allowlist ?? [],
+      allowAllPrompts: server.policy?.allowAllPrompts === true,
+    },
+  });
+}
+
+function applyPromptAllowlist(
+  policy: FridayMcpServerPolicy | undefined,
+  prompts: FridayMcpPromptDescriptor[],
+): FridayMcpPromptDescriptor[] {
+  const allowlist = policy?.promptAllowlist;
+  if (allowlist && allowlist.length > 0) {
+    return prompts.filter((prompt) => allowlist.includes(prompt.name));
+  }
+  if (policy?.allowAllPrompts === true) {
+    return prompts;
+  }
   return [];
 }
 

--- a/src/agent/mcp/friday-mcp-adapter.types.ts
+++ b/src/agent/mcp/friday-mcp-adapter.types.ts
@@ -15,6 +15,18 @@ export interface FridayMcpServerPolicy {
    * callable. Set this only when you deliberately trust the server fully.
    */
   allowAllTools?: boolean;
+  resourceAllowlist?: string[];
+  /**
+   * Explicit high-risk opt-in to expose/read EVERY resource an external MCP
+   * server advertises. Default (false/unset) FAILS CLOSED.
+   */
+  allowAllResources?: boolean;
+  promptAllowlist?: string[];
+  /**
+   * Explicit high-risk opt-in to expose/get EVERY prompt an external MCP server
+   * advertises. Default (false/unset) FAILS CLOSED.
+   */
+  allowAllPrompts?: boolean;
   rateLimit?: FridayMcpServerRateLimitPolicy;
 }
 
@@ -123,6 +135,8 @@ export type FridayMcpErrorCode =
   | "REQUEST_FAILED"
   | "REQUEST_TIMEOUT"
   | "POLICY_TOOL_FORBIDDEN"
+  | "POLICY_RESOURCE_FORBIDDEN"
+  | "POLICY_PROMPT_FORBIDDEN"
   | "POLICY_RATE_LIMITED"
   | "DEDUP_CACHE_HIT";
 

--- a/src/channels/friday-channel-registry.ts
+++ b/src/channels/friday-channel-registry.ts
@@ -18,6 +18,7 @@ import type {
   FridayChannelSendOptions,
 } from "./friday-channel.types.js";
 import { formatFridayChannelOutboundSendOptions } from "./friday-channel-outbound-formatting.js";
+import { isControlCapableChannelKind } from "./friday-channel-config.js";
 
 // ─── Types ───
 
@@ -338,7 +339,8 @@ export function createFridayChannelRegistry(options?: FridayChannelRegistryOptio
       if (entries.has(plugin.kind)) {
         throw new FridayDomainError("CONFLICT", `Channel kind "${plugin.kind}" is already registered`, { httpStatus: 409 });
       }
-      const controlCapable = registerOptions.controlCapable === true;
+      const inferredControlCapable = isControlCapableChannelKind(plugin.kind);
+      const controlCapable = inferredControlCapable || registerOptions.controlCapable === true;
       entries.set(plugin.kind, { plugin, allowlist, running: false, controlCapable });
       healthState.set(plugin.kind, { restartCount: 0 });
       // B1 channel-registry lifecycle precedence diagnostic: when a plugin

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -678,12 +678,16 @@ async function autoDetectProvidersFromEnv(
   // Set default routing if none configured — use newly detected or existing providers
   const routing = await providerService.getRoutingConfig();
   if (!routing.defaultProviderId) {
-    // Collect candidates: newly detected first, then existing enabled providers
-    const candidates = detected.length > 0
-      ? detected
-      : existing
-          .filter((p) => p.enabled)
-          .map((p) => ({ kind: p.kind as FridayProviderKind, id: p.id }));
+    // Collect candidates from both newly detected and already-persisted enabled
+    // providers. Mixed state (e.g. existing OpenAI plus newly detected DeepSeek)
+    // still means multiple provider kinds are available and must require an
+    // explicit user choice; do not silently pick the newly detected provider.
+    const candidates = [
+      ...detected,
+      ...existing
+        .filter((p) => p.enabled)
+        .map((p) => ({ kind: p.kind as FridayProviderKind, id: p.id })),
+    ];
 
     const distinctKinds = new Set(candidates.map((c) => c.kind));
 

--- a/test/contracts/agent/friday-mcp-transport-parity.contract.test.ts
+++ b/test/contracts/agent/friday-mcp-transport-parity.contract.test.ts
@@ -242,9 +242,9 @@ describe("MCP transport parity contract", () => {
           transport: "stdio",
           command: process.execPath,
           args: ["-e", buildStdioServerScript()],
-          // Opt in so transport parity is exercised; the adapter now fails
-          // closed without an allowlist or this explicit opt-in.
-          policy: { allowAllTools: true },
+          // Opt in so transport parity is exercised; the adapter fails closed
+          // per surface without an allowlist or explicit opt-in.
+          policy: { allowAllTools: true, allowAllResources: true, allowAllPrompts: true },
         },
       ],
     });
@@ -258,7 +258,7 @@ describe("MCP transport parity contract", () => {
           id: "http",
           transport: "http",
           url: PUBLIC_HTTP_MCP_TEST_URL,
-          policy: { allowAllTools: true },
+          policy: { allowAllTools: true, allowAllResources: true, allowAllPrompts: true },
         },
       ],
     });

--- a/test/e2e/mock/friday-openclaw-parity-closure.e2e.test.ts
+++ b/test/e2e/mock/friday-openclaw-parity-closure.e2e.test.ts
@@ -1309,7 +1309,18 @@ describe("Friday OpenClaw Parity Closure E2E — Discord Mock Transport", () => 
           token: "mock-discord-token",
           requireMention: false,
         });
-        hub.channelRegistry.register(discordPlugin);
+        hub.channelRegistry.register(discordPlugin, {
+          allowedUsers: [
+            "discord-user-1",
+            "discord-user-2",
+            "discord-user-fallback",
+          ],
+          allowedChats: [
+            "discord-channel-1",
+            "discord-channel-2",
+            "discord-channel-delivery-fallback",
+          ],
+        });
       },
     });
   }, 60_000);

--- a/test/integration/hub/friday-hub-bootstrap-integration.test.ts
+++ b/test/integration/hub/friday-hub-bootstrap-integration.test.ts
@@ -2063,6 +2063,31 @@ describe("FridayHub Bootstrap Integration", () => {
     expect(routing.fallbackProviderIds).toEqual([]);
   });
 
+  it("does not auto-select a newly detected provider when an existing different kind is enabled", async () => {
+    const hub = await createIsolatedHub();
+    await hub.providerService.createProvider({
+      kind: "openai",
+      name: "Existing OpenAI",
+      baseUrl: "https://api.openai.com/v1",
+      authMode: "api-key",
+      api: "openai-responses",
+      apiKey: "$OPENAI_API_KEY",
+      supportedModels: ["gpt-4o-mini"],
+      defaultModel: "gpt-4o-mini",
+      validateOnSave: false,
+    });
+    process.env.DEEPSEEK_API_KEY = "test-deepseek-key-not-validated"; // pragma: allowlist secret
+
+    await hub.start();
+
+    const providers = await hub.providerService.listProviders();
+    expect(providers.find((p) => p.kind === "openai")).toBeDefined();
+    expect(providers.find((p) => p.kind === "deepseek")).toBeDefined();
+    const routing = await hub.providerService.getRoutingConfig();
+    expect(routing.defaultProviderId).toBe("");
+    expect(routing.fallbackProviderIds).toEqual([]);
+  });
+
   it("honors an explicit setup provider choice (FRIDAY_SETUP_DEFAULT_PROVIDER) even with multiple keys", async () => {
     // The CLI setup wizard records the user's explicit choice here; bootstrap
     // must route to it (a user choice, not a hidden auto-pick) even when other

--- a/test/unit/agent/mcp/friday-mcp-adapter-env.test.ts
+++ b/test/unit/agent/mcp/friday-mcp-adapter-env.test.ts
@@ -53,6 +53,8 @@ describe("parseFridayMcpServersFromEnv", () => {
           },
           policy: {
             toolAllowlist: ["search", "fetch"],
+            resourceAllowlist: ["friday://docs"],
+            promptAllowlist: ["summarize"],
             rateLimit: {
               maxCalls: 3,
               windowMs: 1000,
@@ -72,6 +74,8 @@ describe("parseFridayMcpServersFromEnv", () => {
         },
         policy: {
           toolAllowlist: ["search", "fetch"],
+          resourceAllowlist: ["friday://docs"],
+          promptAllowlist: ["summarize"],
           rateLimit: {
             maxCalls: 3,
             windowMs: 1000,
@@ -149,6 +153,33 @@ describe("parseFridayMcpServersFromEnv", () => {
     ]);
   });
 
+  it("parses explicit high-risk resource and prompt opt-ins separately from tools", () => {
+    const result = parseFridayMcpServersFromEnv({
+      FRIDAY_MCP_SERVERS: JSON.stringify([
+        {
+          id: "trusted-context",
+          command: "node",
+          policy: {
+            allowAllResources: true,
+            allowAllPrompts: true,
+          },
+        },
+      ]),
+    });
+
+    expect(result).toEqual([
+      {
+        id: "trusted-context",
+        transport: "stdio",
+        command: "node",
+        policy: {
+          allowAllResources: true,
+          allowAllPrompts: true,
+        },
+      },
+    ]);
+  });
+
   it("accepts legacy top-level allowTools/rateLimit policy fields", () => {
     const result = parseFridayMcpServersFromEnv({
       FRIDAY_MCP_SERVERS: JSON.stringify([
@@ -156,6 +187,8 @@ describe("parseFridayMcpServersFromEnv", () => {
           id: "legacy",
           command: "node",
           allowTools: ["search"],
+          allowResources: ["friday://status"],
+          allowPrompts: ["hello"],
           rateLimit: {
             maxCalls: 2,
             windowMs: 500,
@@ -171,6 +204,8 @@ describe("parseFridayMcpServersFromEnv", () => {
         command: "node",
         policy: {
           toolAllowlist: ["search"],
+          resourceAllowlist: ["friday://status"],
+          promptAllowlist: ["hello"],
           rateLimit: {
             maxCalls: 2,
             windowMs: 500,

--- a/test/unit/agent/mcp/friday-mcp-adapter-runtime.test.ts
+++ b/test/unit/agent/mcp/friday-mcp-adapter-runtime.test.ts
@@ -171,6 +171,128 @@ describe("createFridayMcpAdapter — runtime adversarial behavior", () => {
     ).rejects.toMatchObject({ code: "MCP_POLICY_TOOL_FORBIDDEN" });
   });
 
+  it("fails closed: resources and prompts require explicit allowlists or allowAll opt-ins", async () => {
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      const payload = JSON.parse(String(init?.body ?? "{}")) as { id?: number; method?: string };
+      if (payload.method === "initialize") {
+        return okHttpResponse(jsonRpcResponse(payload.id ?? 1, { protocolVersion: "2024-11-05" }));
+      }
+      if (payload.method === "resources/list") {
+        return okHttpResponse(jsonRpcResponse(payload.id ?? 2, {
+          resources: [{ uri: "friday://status", name: "status" }],
+        }));
+      }
+      if (payload.method === "prompts/list") {
+        return okHttpResponse(jsonRpcResponse(payload.id ?? 3, {
+          prompts: [{ name: "hello", description: "Greeting" }],
+        }));
+      }
+      if (payload.method === "resources/read") {
+        return okHttpResponse(jsonRpcResponse(payload.id ?? 4, {
+          contents: [{ type: "text", text: "secret-ish context" }],
+        }));
+      }
+      if (payload.method === "prompts/get") {
+        return okHttpResponse(jsonRpcResponse(payload.id ?? 5, {
+          messages: [{ role: "user", content: { type: "text", text: "hello" } }],
+        }));
+      }
+      return okHttpResponse("{}");
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const adapter = createFridayMcpAdapter({
+      servers: [
+        { id: "untrusted-context", transport: "http", url: "https://mcp.example.com/rpc" },
+      ],
+    });
+
+    await expect(adapter.listResources({ serverId: "untrusted-context" })).resolves.toEqual([]);
+    await expect(adapter.listPrompts({ serverId: "untrusted-context" })).resolves.toEqual([]);
+    await expect(adapter.readResource({
+      serverId: "untrusted-context",
+      uri: "friday://status",
+    })).rejects.toMatchObject({ code: FRIDAY_MCP_ADAPTER_ERROR_CODES.POLICY_RESOURCE_FORBIDDEN });
+    await expect(adapter.getPrompt({
+      serverId: "untrusted-context",
+      name: "hello",
+    })).rejects.toMatchObject({ code: FRIDAY_MCP_ADAPTER_ERROR_CODES.POLICY_PROMPT_FORBIDDEN });
+  });
+
+  it("allows only explicitly allowlisted resources and prompts", async () => {
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      const payload = JSON.parse(String(init?.body ?? "{}")) as { id?: number; method?: string; params?: Record<string, unknown> };
+      if (payload.method === "initialize") {
+        return okHttpResponse(jsonRpcResponse(payload.id ?? 1, { protocolVersion: "2024-11-05" }));
+      }
+      if (payload.method === "resources/list") {
+        return okHttpResponse(jsonRpcResponse(payload.id ?? 2, {
+          resources: [
+            { uri: "friday://allowed", name: "allowed" },
+            { uri: "friday://blocked", name: "friday://allowed" },
+          ],
+        }));
+      }
+      if (payload.method === "prompts/list") {
+        return okHttpResponse(jsonRpcResponse(payload.id ?? 3, {
+          prompts: [
+            { name: "hello", description: "Greeting" },
+            { name: "blocked", description: "Blocked" },
+          ],
+        }));
+      }
+      if (payload.method === "resources/read") {
+        return okHttpResponse(jsonRpcResponse(payload.id ?? 4, {
+          contents: [{ type: "text", text: String(payload.params?.uri ?? "") }],
+        }));
+      }
+      if (payload.method === "prompts/get") {
+        return okHttpResponse(jsonRpcResponse(payload.id ?? 5, {
+          messages: [{ role: "user", content: { type: "text", text: String(payload.params?.name ?? "") } }],
+        }));
+      }
+      return okHttpResponse("{}");
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const adapter = createFridayMcpAdapter({
+      servers: [
+        {
+          id: "allowlisted-context",
+          transport: "http",
+          url: "https://mcp.example.com/rpc",
+          policy: {
+            resourceAllowlist: ["friday://allowed"],
+            promptAllowlist: ["hello"],
+          },
+        },
+      ],
+    });
+
+    await expect(adapter.listResources({ serverId: "allowlisted-context" })).resolves.toMatchObject([
+      { uri: "friday://allowed" },
+    ]);
+    await expect(adapter.listPrompts({ serverId: "allowlisted-context" })).resolves.toMatchObject([
+      { name: "hello" },
+    ]);
+    await expect(adapter.readResource({
+      serverId: "allowlisted-context",
+      uri: "friday://allowed",
+    })).resolves.toMatchObject({ content: "friday://allowed" });
+    await expect(adapter.getPrompt({
+      serverId: "allowlisted-context",
+      name: "hello",
+    })).resolves.toMatchObject({ content: expect.stringContaining("hello") });
+    await expect(adapter.readResource({
+      serverId: "allowlisted-context",
+      uri: "friday://blocked",
+    })).rejects.toMatchObject({ code: FRIDAY_MCP_ADAPTER_ERROR_CODES.POLICY_RESOURCE_FORBIDDEN });
+    await expect(adapter.getPrompt({
+      serverId: "allowlisted-context",
+      name: "blocked",
+    })).rejects.toMatchObject({ code: FRIDAY_MCP_ADAPTER_ERROR_CODES.POLICY_PROMPT_FORBIDDEN });
+  });
+
   it("enforces local rate limit policy for repeated tool calls", async () => {
     const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
       const payload = JSON.parse(String(init?.body ?? "{}")) as {
@@ -448,6 +570,9 @@ describe("createFridayMcpAdapter — runtime adversarial behavior", () => {
           id: "dedup-http",
           transport: "http",
           url: "https://mcp.example.com/rpc",
+          policy: {
+            allowAllResources: true,
+          },
         },
       ],
     });

--- a/test/unit/channels/friday-channel-registry.test.ts
+++ b/test/unit/channels/friday-channel-registry.test.ts
@@ -117,6 +117,54 @@ describe("FridayChannelRegistry", () => {
 
       expect(registry.listViews()).toHaveLength(1);
     });
+
+    it("infers control-capable external channels at direct registration and fails closed without an allowlist", async () => {
+      let capturedHandler: ((message: FridayChannelMessage) => void) | undefined;
+      const plugin = createMockPlugin("telegram", {
+        start: vi.fn(async (onMessage) => {
+          capturedHandler = onMessage;
+        }),
+      });
+      const handler = vi.fn();
+
+      registry.register(plugin);
+      await registry.startAll(handler);
+      capturedHandler?.(createTestMessage({ channelKind: "telegram", senderId: "u-1", chatId: "c-1" }));
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it("does not allow known control-capable channels to be downgraded during direct registration", async () => {
+      let capturedHandler: ((message: FridayChannelMessage) => void) | undefined;
+      const plugin = createMockPlugin("telegram", {
+        start: vi.fn(async (onMessage) => {
+          capturedHandler = onMessage;
+        }),
+      });
+      const handler = vi.fn();
+
+      registry.register(plugin, {}, { controlCapable: false });
+      await registry.startAll(handler);
+      capturedHandler?.(createTestMessage({ channelKind: "telegram", senderId: "u-1", chatId: "c-1" }));
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it("keeps non-control direct registrations on legacy allow-when-unset behavior", async () => {
+      let capturedHandler: ((message: FridayChannelMessage) => void) | undefined;
+      const plugin = createMockPlugin("webchat", {
+        start: vi.fn(async (onMessage) => {
+          capturedHandler = onMessage;
+        }),
+      });
+      const handler = vi.fn();
+
+      registry.register(plugin);
+      await registry.startAll(handler);
+      capturedHandler?.(createTestMessage({ channelKind: "webchat", senderId: "u-1", chatId: "c-1" }));
+
+      expect(handler).toHaveBeenCalledOnce();
+    });
   });
 
   // ─── Unregistration ───
@@ -241,7 +289,7 @@ describe("FridayChannelRegistry", () => {
   describe("message routing", () => {
     it("routes messages to handler", async () => {
       const plugin = createMockPlugin("qq");
-      registry.register(plugin);
+      registry.register(plugin, { allowedUsers: ["user-1"], allowedChats: ["chat-1"] });
 
       const handler = vi.fn();
       await registry.startAll(handler);

--- a/test/unit/ops/real-green-gate-result.test.ts
+++ b/test/unit/ops/real-green-gate-result.test.ts
@@ -223,8 +223,33 @@ describe("buildRealGreenGateResult", () => {
     expect(result.provider_lane_scope.note).toMatch(/does NOT prove provider fallback resilience/i);
   });
 
-  it("scopes a two-lane run to default_and_fallback with fallback resilience proven", () => {
+  it("does not prove fallback resilience from lane presence alone", () => {
     const summary = passingSummary();
+    (summary.preflight as Record<string, unknown>).envTruth = {
+      providerLanes: {
+        default: { providerKind: "deepseek", model: "deepseek-v4-pro" },
+        fallback: { providerKind: "anthropic", model: "claude-sonnet-4" },
+      },
+      providerLaneRequirements: { fallbackRequired: true, source: "validated_alternative_available" },
+    };
+
+    const result = buildRealGreenGateResult({
+      summary,
+      commitSha: SHA_A,
+      refName: "main",
+      evaluatedAt: "2026-05-28T00:00:00.000Z",
+    });
+
+    expect(result.provider_lane_scope.scope).toBe("default_and_fallback");
+    expect(result.provider_lane_scope.fallback_resilience_proven).toBe(false);
+    expect(result.provider_lane_scope.note).toMatch(/does NOT prove fallback resilience/i);
+  });
+
+  it("marks fallback resilience proven only when an explicit fallback proof signal exists", () => {
+    const summary = {
+      ...passingSummary(),
+      providerFallbackProof: { status: "passed" },
+    };
     (summary.preflight as Record<string, unknown>).envTruth = {
       providerLanes: {
         default: { providerKind: "deepseek", model: "deepseek-v4-pro" },


### PR DESCRIPTION
## Summary

Follow-up to merged PR #384 after reviewer B found four safety/truth proof gaps that were not closed on `main`.

This PR:
- fails MCP resources/prompts closed unless explicitly allowlisted or `allowAll*` is set, including list/read/get paths
- makes known control-capable channel kinds non-downgradable at direct registration, so `telegram/discord/lark/feishu/qq/etc.` cannot be made allow-when-unset via `{ controlCapable: false }`
- includes existing enabled providers in provider auto-detect routing decisions so newly detected env providers cannot silently become the default beside an existing enabled provider of another kind
- makes RGG fallback-resilience claims require an explicit fallback proof signal, not fallback lane presence alone

## Drift Classification

- PR #384 was already squash-merged to `main` as `cc3cefc6` before reviewer-B repair landed locally.
- Classification: related drift, same safety/truth scope, no semantic conflict.
- Action: ported the reviewer-B repair onto current `origin/main=cc3cefc6` as one follow-up branch; no force-push, no GitHub settings/secrets changes, no npm publish/tag/release.

## Local Proof

Current HEAD: `97601cb309864ba0c4a02e9d3f2808172cc66b63` on top of `origin/main=cc3cefc6a02cc8648b1fec7dbe71d2f0b10f022f`.

Passed locally:
- `npm test -- --run test/unit/agent/mcp/friday-mcp-adapter-env.test.ts test/unit/agent/mcp/friday-mcp-adapter-runtime.test.ts test/contracts/agent/friday-mcp-transport-parity.contract.test.ts test/unit/channels/friday-channel-registry.test.ts test/integration/hub/friday-hub-bootstrap-integration.test.ts` — 104 passed
- `npm test -- --run test/unit/ops/real-green-gate-result.test.ts test/unit/ops/run-real-green-gate.test.ts test/unit/validation/real-world-env-truth.test.ts test/unit/ops/run-real-green-gate-self-hosted.test.ts test/unit/providers/cost/friday-provider-cost-controls.test.ts test/unit/providers/routing/friday-provider-fallback.test.ts test/integration/providers/friday-provider-service-lifecycle.test.ts` — 127 passed
- `npm test -- --run test/unit/cli/friday-cli-setup-wizard.test.ts test/e2e/setup-wizard.e2e.test.ts test/unit/ui/ui-truth-regressions.test.ts` — 38 passed, 6 skipped (existing Ollama/browser-condition skips)
- `npm run typecheck`
- `npm run build:api`
- `npm run check:secret-patterns`
- `git diff --check origin/main..HEAD`

## Read-Only Review

- Reviewer A: PASS for provider/RGG truth semantics on current-main follow-up branch.
- Reviewer B initial re-review: FAIL on control-capable channel downgrade path.
- Fix applied: known control-capable kinds now cannot be downgraded by register options; MCP resource filtering tightened to URI-only.
- Reviewer B final re-review: PASS, no blocking residual risk in scope.

## Boundaries

No live Telegram/Discord/Lark READY window, no npm publish/tag/release, no GitHub secrets/settings write, no force/admin bypass, no destructive user-data mutation, no package/default-on rollout.
