### PR TITLE
fix(providers): ANNEX B4 — no silent routing default/refill + accurate pricing

### DIFF
--- a/src/hub/bootstrap/friday-bootstrap-auto-routing.ts
+++ b/src/hub/bootstrap/friday-bootstrap-auto-routing.ts
@@ -1,0 +1,66 @@
+import type { FridayProviderKind } from "../../providers/model/friday-provider.types.js";
+
+export interface FridayBootstrapRouteCandidate {
+  kind: FridayProviderKind;
+  id: string;
+}
+
+export interface FridayBootstrapAutoRoutingDecision {
+  defaultProviderId: string;
+  defaultModel: string;
+  fallbackProviderIds: string[];
+}
+
+/**
+ * Decide the boot-time default route from auto-detected / existing providers WITHOUT
+ * making a hidden choice on the user's behalf.
+ *
+ * Locked product decision: multiple keys/providers require explicit user choice; Friday
+ * must not silently pick a default provider or silently inject fallback providers.
+ *
+ * - Exactly one candidate: select it (single, unambiguous — preserves single-key BYOK).
+ *   No fallback providers are injected.
+ * - Two or more candidates: return `null`. Friday must NOT auto-pick a default by a hidden
+ *   priority order, nor fan out fallbacks. The user chooses explicitly; until then
+ *   `resolveRoute` surfaces `PROVIDER_NO_ROUTING`.
+ * - No candidates: `null`.
+ */
+export function resolveFridayBootstrapAutoRouting(
+  candidates: ReadonlyArray<FridayBootstrapRouteCandidate>,
+  resolveDefaultModel: (candidate: FridayBootstrapRouteCandidate) => string,
+): FridayBootstrapAutoRoutingDecision | null {
+  if (candidates.length !== 1) {
+    return null;
+  }
+
+  const sole = candidates[0]!;
+  return {
+    defaultProviderId: sole.id,
+    defaultModel: resolveDefaultModel(sole),
+    fallbackProviderIds: [],
+  };
+}
+
+/**
+ * Collect the full set of routing candidates available after env auto-detection: the
+ * UNION of providers newly detected this boot and providers already enabled in the DB,
+ * deduped by id.
+ *
+ * This count must reflect EVERY available provider, not just the freshly-detected ones.
+ * A "detected OR existing" choice would undercount on a later boot — e.g. 2 providers
+ * already configured + 1 new env key would yield a single-element detected list and
+ * silently auto-select the new provider as default among three. The union keeps the
+ * "two or more providers ⇒ explicit user choice" invariant correct across boots.
+ */
+export function collectFridayBootstrapRouteCandidates(input: {
+  detected: ReadonlyArray<FridayBootstrapRouteCandidate>;
+  existingEnabled: ReadonlyArray<FridayBootstrapRouteCandidate>;
+}): FridayBootstrapRouteCandidate[] {
+  const byId = new Map<string, FridayBootstrapRouteCandidate>();
+  for (const candidate of [...input.detected, ...input.existingEnabled]) {
+    if (!byId.has(candidate.id)) {
+      byId.set(candidate.id, candidate);
+    }
+  }
+  return [...byId.values()];
+}

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -392,6 +392,10 @@ import {
   stripFridayUiActionHints,
 } from "./bootstrap/hub-helpers.js";
 import { resolveFridayCapabilityGates } from "./bootstrap/friday-capability-gates.js";
+import {
+  collectFridayBootstrapRouteCandidates,
+  resolveFridayBootstrapAutoRouting,
+} from "./bootstrap/friday-bootstrap-auto-routing.js";
 
 // Re-export public API for backward compatibility with `#hub` barrel.
 export {
@@ -525,8 +529,6 @@ const ENV_PROVIDER_MAP: ReadonlyArray<{
   { envVar: "XAI_API_KEY", kind: "xai", defaultModel: "grok-3-mini" },
 ];
 
-/** Routing priority: anthropic first, then openai, then detection order. */
-const ROUTING_PRIORITY: readonly FridayProviderKind[] = ["anthropic", "openai"];
 const STABLE_OPENAI_DEFAULT_MODEL = "gpt-4o-mini";
 const STABLE_OPENAI_SUPPORTED_MODELS = [STABLE_OPENAI_DEFAULT_MODEL, "gpt-4o"] as const;
 const OPENAI_PROVIDER_NAME = "OpenAI Provider";
@@ -676,43 +678,42 @@ async function autoDetectProvidersFromEnv(
     }
   }
 
-  // Set default routing if none configured — use newly detected or existing providers
+  // Set default routing if none configured — use newly detected or existing providers.
+  // Locked decision: multiple keys/providers require explicit user choice. Friday must not
+  // silently pick a default provider or inject fallbacks. A single available provider is
+  // unambiguous and is auto-selected (single-key BYOK still boots ready); with two or more
+  // providers we leave routing unconfigured so the user chooses explicitly (resolveRoute
+  // surfaces PROVIDER_NO_ROUTING until then).
   const routing = await providerService.getRoutingConfig();
   if (!routing.defaultProviderId) {
-    // Collect candidates: newly detected first, then existing enabled providers
-    const candidates = detected.length > 0
-      ? detected
-      : existing
-          .filter((p) => p.enabled)
-          .map((p) => ({ kind: p.kind as FridayProviderKind, id: p.id }));
+    // Candidates = the UNION of newly-detected and already-enabled providers (deduped).
+    // Using only one or the other would undercount across boots and let a later single new
+    // env key silently become the default among several configured providers.
+    const candidates = collectFridayBootstrapRouteCandidates({
+      detected,
+      existingEnabled: existing
+        .filter((p) => p.enabled)
+        .map((p) => ({ kind: p.kind as FridayProviderKind, id: p.id })),
+    });
 
-    if (candidates.length > 0) {
-      // Pick best provider by priority
-      let chosen = candidates[0]!;
-      for (const priorityKind of ROUTING_PRIORITY) {
-        const match = candidates.find((d) => d.kind === priorityKind);
-        if (match) {
-          chosen = match;
-          break;
-        }
-      }
-      const chosenEntry = ENV_PROVIDER_MAP.find((e) => e.kind === chosen.kind);
-      const defaultModel = chosenEntry?.defaultModel ?? (chosen.kind === "ollama" ? "llama3.2" : "default");
+    const decision = resolveFridayBootstrapAutoRouting(candidates, (candidate) => {
+      const entry = ENV_PROVIDER_MAP.find((e) => e.kind === candidate.kind);
+      return entry?.defaultModel ?? (candidate.kind === "ollama" ? "llama3.2" : "default");
+    });
+
+    if (decision) {
       try {
-        await providerService.setRoutingConfig({
-          defaultProviderId: chosen.id,
-          defaultModel,
-          fallbackProviderIds: candidates
-            .filter((d) => d.id !== chosen.id)
-            .slice(0, 3)
-            .map((d) => d.id),
-        });
+        await providerService.setRoutingConfig(decision);
       } catch (err) {
         console.warn(
           "[friday] Auto-detect: failed to set default routing:",
           err instanceof Error ? err.message : String(err),
         );
       }
+    } else if (candidates.length > 1) {
+      console.log(
+        `[friday] Auto-detect: ${candidates.length} providers available with no default routing — leaving routing unset so you can choose explicitly (no provider auto-selected, no fallbacks injected).`,
+      );
     }
   }
 
@@ -3329,29 +3330,11 @@ export async function createFridayHub(
     ]);
     const routingWarning = resolveFridayRoutingStabilityWarning({ routing, providers });
     if (routingWarning && providers.length > 0) {
+      // Diagnostic only: surface the missing-fallback warning to the operator. Friday must
+      // NOT silently inject fallback providers on the user's behalf — configuring fallbacks
+      // is an explicit user choice (locked decision: no hidden provider behavior, no silent
+      // refill). A user who saved an empty fallback list keeps it empty.
       warnHubBootstrapOnce(`[friday][W-PROVIDER-ROUTING-001] ${routingWarning}`);
-      // Auto-configure fallback providers if none are set
-      if (
-        !canonicalMutatingActionGateEnabled &&
-        routing.defaultProviderId &&
-        (!routing.fallbackProviderIds || routing.fallbackProviderIds.length === 0)
-      ) {
-        const validatedAlternatives = providers
-          .filter((p) => p.enabled && p.id !== routing.defaultProviderId)
-          .slice(0, 3)
-          .map((p) => p.id);
-        if (validatedAlternatives.length > 0) {
-          try {
-            await providerService.setRoutingConfig({
-              ...routing,
-              fallbackProviderIds: validatedAlternatives,
-            });
-            console.log(`[friday] Auto-configured ${validatedAlternatives.length} fallback provider(s) for routing resilience.`);
-          } catch {
-            // Non-fatal: fallback auto-config failure should not block startup.
-          }
-        }
-      }
     }
   } catch (err) {
     if (!isExpectedProviderNoRouting(err)) {

--- a/src/providers/cost/friday-provider-pricing-catalog.ts
+++ b/src/providers/cost/friday-provider-pricing-catalog.ts
@@ -34,6 +34,27 @@ const DEFAULT_MODEL_PRICING: readonly FridayProviderModelPricing[] = [
     cacheReadPer1MUsd: 0.03,
     cacheWritePer1MUsd: 0.10,
   },
+  // gpt-4o family — Friday's OPENAI_API_KEY auto-detect defaults (gpt-4o-mini default, gpt-4o
+  // supported). Source: https://openai.com/api/pricing/ (verified 2026-05-28). Without these,
+  // both env-default OpenAI models hit the generic $1/$4 fallback below.
+  {
+    providerKind: "openai",
+    modelPattern: "gpt-4o-mini",
+    qualityTier: "cheap",
+    inputPer1MUsd: 0.15,
+    outputPer1MUsd: 0.60,
+    cacheReadPer1MUsd: 0.075,
+    cacheWritePer1MUsd: 0.15,
+  },
+  {
+    providerKind: "openai",
+    modelPattern: "gpt-4o",
+    qualityTier: "best",
+    inputPer1MUsd: 2.50,
+    outputPer1MUsd: 10.00,
+    cacheReadPer1MUsd: 1.25,
+    cacheWritePer1MUsd: 2.50,
+  },
   {
     providerKind: "anthropic",
     modelPattern: "claude-opus",
@@ -87,6 +108,64 @@ const DEFAULT_MODEL_PRICING: readonly FridayProviderModelPricing[] = [
     outputPer1MUsd: 0.30,
     cacheReadPer1MUsd: 0.01,
     cacheWritePer1MUsd: 0.08,
+  },
+  // gemini-2.0-flash — Friday's GOOGLE_API_KEY auto-detect default. Source:
+  // https://ai.google.dev/gemini-api/docs/pricing (verified 2026-05-28). Note: "gemini-2.0-flash"
+  // does NOT substring-match "gemini-2.0-flash-lite", so without this entry the default model
+  // silently fell to the generic $1/$4 fallback.
+  {
+    providerKind: "google",
+    modelPattern: "gemini-2.0-flash",
+    qualityTier: "balanced",
+    inputPer1MUsd: 0.10,
+    outputPer1MUsd: 0.40,
+    cacheReadPer1MUsd: 0.025,
+    cacheWritePer1MUsd: 0.10,
+  },
+  // DeepSeek V4 — Friday's DEEPSEEK_API_KEY auto-detect defaults (deepseek-v4-pro default,
+  // deepseek-v4-flash supported) plus the deepseek-chat / deepseek-reasoner deprecation aliases
+  // (both are V4 Flash modes, priced as V4 Flash). Source: https://api-docs.deepseek.com/quick_start/pricing
+  // (verified 2026-05-28; STANDARD list prices — the 75%-off v4-pro promo expiring 2026-05-31 is
+  // intentionally NOT used so cost/budget never silently under-reports after the promo ends).
+  // Without a deepseek kind here, every DeepSeek model hit the generic $1/$4 fallback.
+  {
+    providerKind: "deepseek",
+    modelPattern: "deepseek-v4-flash",
+    qualityTier: "cheap",
+    inputPer1MUsd: 0.14,
+    outputPer1MUsd: 0.28,
+    cacheReadPer1MUsd: 0.0028,
+    cacheWritePer1MUsd: 0.14,
+  },
+  {
+    providerKind: "deepseek",
+    modelPattern: "deepseek-v4-pro",
+    qualityTier: "best",
+    inputPer1MUsd: 1.74,
+    outputPer1MUsd: 3.48,
+    cacheReadPer1MUsd: 0.0145,
+    cacheWritePer1MUsd: 1.74,
+  },
+  {
+    providerKind: "deepseek",
+    modelPattern: "deepseek-chat",
+    qualityTier: "cheap",
+    inputPer1MUsd: 0.14,
+    outputPer1MUsd: 0.28,
+    cacheReadPer1MUsd: 0.0028,
+    cacheWritePer1MUsd: 0.14,
+  },
+  {
+    // deepseek-reasoner is the V4 Flash thinking-mode alias — priced identically to
+    // deepseek-v4-flash / deepseek-chat, so it carries the same "cheap" tier to keep the
+    // cost router scoring equivalently-priced aliases of the same model equivalently.
+    providerKind: "deepseek",
+    modelPattern: "deepseek-reasoner",
+    qualityTier: "cheap",
+    inputPer1MUsd: 0.14,
+    outputPer1MUsd: 0.28,
+    cacheReadPer1MUsd: 0.0028,
+    cacheWritePer1MUsd: 0.14,
   },
   {
     providerKind: "ollama",

--- a/test/unit/hub/bootstrap/friday-bootstrap-auto-routing.test.ts
+++ b/test/unit/hub/bootstrap/friday-bootstrap-auto-routing.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  collectFridayBootstrapRouteCandidates,
+  resolveFridayBootstrapAutoRouting,
+  type FridayBootstrapRouteCandidate,
+} from "../../../../src/hub/bootstrap/friday-bootstrap-auto-routing.js";
+
+const modelFor = (c: FridayBootstrapRouteCandidate) =>
+  c.kind === "anthropic" ? "claude-sonnet-4-20250514" : c.kind === "deepseek" ? "deepseek-v4-pro" : "gpt-4o-mini";
+
+describe("resolveFridayBootstrapAutoRouting", () => {
+  it("auto-selects the sole provider with no injected fallbacks (single-key BYOK)", () => {
+    const decision = resolveFridayBootstrapAutoRouting(
+      [{ kind: "openai", id: "openai-1" }],
+      modelFor,
+    );
+    expect(decision).toEqual({
+      defaultProviderId: "openai-1",
+      defaultModel: "gpt-4o-mini",
+      fallbackProviderIds: [],
+    });
+  });
+
+  it("does NOT silently pick a default when multiple providers are available", () => {
+    const decision = resolveFridayBootstrapAutoRouting(
+      [
+        { kind: "anthropic", id: "anthropic-1" },
+        { kind: "openai", id: "openai-1" },
+        { kind: "deepseek", id: "deepseek-1" },
+      ],
+      modelFor,
+    );
+    // null => routing stays unconfigured => resolveRoute surfaces PROVIDER_NO_ROUTING =>
+    // the user must choose explicitly. No hidden default, no fallback fan-out.
+    expect(decision).toBeNull();
+  });
+
+  it("returns null when there are no candidates", () => {
+    expect(resolveFridayBootstrapAutoRouting([], modelFor)).toBeNull();
+  });
+
+  it("never injects fallback providers even in the single-provider case", () => {
+    const decision = resolveFridayBootstrapAutoRouting(
+      [{ kind: "deepseek", id: "deepseek-1" }],
+      modelFor,
+    );
+    expect(decision?.fallbackProviderIds).toEqual([]);
+  });
+});
+
+describe("collectFridayBootstrapRouteCandidates", () => {
+  it("unions newly-detected with already-enabled providers (deduped by id)", () => {
+    const candidates = collectFridayBootstrapRouteCandidates({
+      detected: [{ kind: "deepseek", id: "deepseek-1" }],
+      existingEnabled: [
+        { kind: "anthropic", id: "anthropic-1" },
+        { kind: "openai", id: "openai-1" },
+      ],
+    });
+    expect(candidates.map((c) => c.id).sort()).toEqual(["anthropic-1", "deepseek-1", "openai-1"]);
+  });
+
+  it("does not double-count a provider present in both lists", () => {
+    const candidates = collectFridayBootstrapRouteCandidates({
+      detected: [{ kind: "openai", id: "openai-1" }],
+      existingEnabled: [{ kind: "openai", id: "openai-1" }],
+    });
+    expect(candidates).toHaveLength(1);
+  });
+
+  it("second-boot regression: adding one env key to an existing multi-provider setup still requires explicit choice", () => {
+    // Two providers already configured, user adds a third via a new env key.
+    const candidates = collectFridayBootstrapRouteCandidates({
+      detected: [{ kind: "deepseek", id: "deepseek-1" }],
+      existingEnabled: [
+        { kind: "anthropic", id: "anthropic-1" },
+        { kind: "openai", id: "openai-1" },
+      ],
+    });
+    expect(candidates).toHaveLength(3);
+    // The union (3) must NOT be silently auto-selected — the newly-detected single key
+    // must not become the default among multiple configured providers.
+    expect(resolveFridayBootstrapAutoRouting(candidates, modelFor)).toBeNull();
+  });
+
+  it("preserves single-provider BYOK from either source", () => {
+    expect(
+      resolveFridayBootstrapAutoRouting(
+        collectFridayBootstrapRouteCandidates({
+          detected: [{ kind: "openai", id: "openai-1" }],
+          existingEnabled: [],
+        }),
+        modelFor,
+      )?.defaultProviderId,
+    ).toBe("openai-1");
+    expect(
+      resolveFridayBootstrapAutoRouting(
+        collectFridayBootstrapRouteCandidates({
+          detected: [],
+          existingEnabled: [{ kind: "anthropic", id: "anthropic-1" }],
+        }),
+        modelFor,
+      )?.defaultProviderId,
+    ).toBe("anthropic-1");
+  });
+});

--- a/test/unit/providers/cost/friday-provider-cost-controls.test.ts
+++ b/test/unit/providers/cost/friday-provider-cost-controls.test.ts
@@ -63,6 +63,63 @@ describe("Friday provider cost controls", () => {
         qualityTier: "balanced",
       });
     });
+
+    it("prices the env auto-detect default models accurately instead of the generic fallback", () => {
+      const catalog = createFridayProviderPricingCatalog();
+      const GENERIC_FALLBACK = { inputPer1MUsd: 1, outputPer1MUsd: 4 };
+
+      // OPENAI_API_KEY defaults: gpt-4o-mini (default) and gpt-4o (supported).
+      expect(catalog.getPricing("openai", "gpt-4o-mini")).toMatchObject({
+        inputPer1MUsd: 0.15,
+        outputPer1MUsd: 0.6,
+        cacheReadPer1MUsd: 0.075,
+      });
+      expect(catalog.getPricing("openai", "gpt-4o")).toMatchObject({
+        inputPer1MUsd: 2.5,
+        outputPer1MUsd: 10,
+        cacheReadPer1MUsd: 1.25,
+      });
+      // gpt-4o-mini must keep the more specific pattern over gpt-4o.
+      expect(catalog.getPricing("openai", "gpt-4o-mini").inputPer1MUsd).not.toBe(
+        catalog.getPricing("openai", "gpt-4o").inputPer1MUsd,
+      );
+
+      // DEEPSEEK_API_KEY defaults: deepseek-v4-pro (default) and deepseek-v4-flash (supported),
+      // plus the deepseek-chat / deepseek-reasoner deprecation aliases.
+      expect(catalog.getPricing("deepseek", "deepseek-v4-pro")).toMatchObject({
+        inputPer1MUsd: 1.74,
+        outputPer1MUsd: 3.48,
+      });
+      expect(catalog.getPricing("deepseek", "deepseek-v4-flash")).toMatchObject({
+        inputPer1MUsd: 0.14,
+        outputPer1MUsd: 0.28,
+      });
+      expect(catalog.getPricing("deepseek", "deepseek-chat").inputPer1MUsd).toBe(0.14);
+      expect(catalog.getPricing("deepseek", "deepseek-reasoner").outputPer1MUsd).toBe(0.28);
+
+      // GOOGLE_API_KEY default: gemini-2.0-flash (must not be swallowed by gemini-2.0-flash-lite).
+      expect(catalog.getPricing("google", "gemini-2.0-flash")).toMatchObject({
+        inputPer1MUsd: 0.1,
+        outputPer1MUsd: 0.4,
+      });
+      expect(catalog.getPricing("google", "gemini-2.0-flash-lite").inputPer1MUsd).toBe(0.08);
+
+      // None of the OpenAI / DeepSeek / Google env-default models may resolve to the generic
+      // $1/$4 fallback. (xai/groq/mistral/openrouter env defaults intentionally still use the
+      // generic fallback — those provider kinds have no catalog entries; documented limitation.)
+      for (const [kind, model] of [
+        ["openai", "gpt-4o-mini"],
+        ["openai", "gpt-4o"],
+        ["deepseek", "deepseek-v4-pro"],
+        ["deepseek", "deepseek-v4-flash"],
+        ["google", "gemini-2.0-flash"],
+      ] as const) {
+        const pricing = catalog.getPricing(kind, model);
+        expect({ inputPer1MUsd: pricing.inputPer1MUsd, outputPer1MUsd: pricing.outputPer1MUsd }).not.toEqual(
+          GENERIC_FALLBACK,
+        );
+      }
+    });
   });
 
   describe("cost router", () => {


### PR DESCRIPTION
## What & why
Closes the real ANNEX P1/P2 provider findings on current `origin/main`:

- **B4-pricing (P1)** — env auto-detect default models silently fell to the generic `$1/$4` balanced fallback, so cost/budget labels were inaccurate. Added accurate, officially-sourced pricing for:
  - OpenAI `gpt-4o` (2.50/1.25/10.00), `gpt-4o-mini` (0.15/0.075/0.60)
  - DeepSeek `deepseek-v4-pro` (1.74/0.0145/3.48), `deepseek-v4-flash` (0.14/0.0028/0.28) + `deepseek-chat`/`deepseek-reasoner` aliases priced as V4 Flash
  - Google `gemini-2.0-flash` (0.10/0.025/0.40)
  - **Standard list prices** (not the DeepSeek promo expiring 2026-05-31) so cost/budget never silently under-reports later. Sources + dates recorded inline in the catalog.
- **B4-fallback-injection (P1)** — removed the startup block that silently refilled an empty `fallbackProviderIds` (overrode an explicit empty choice).
- **B4-auto-select (P2)** — removed boot-time silent default-provider selection by hardcoded `ROUTING_PRIORITY`. A **single** available provider is still auto-selected (single-key BYOK boots ready); **two or more** leave routing unconfigured so the user chooses explicitly (`resolveRoute` surfaces `PROVIDER_NO_ROUTING`). Candidates are the **union** of newly-detected + already-enabled providers (deduped) so a later single new env key can't silently become default among several configured providers.

`W-PROVIDER-ROUTING-001` is kept as a diagnostic-only warning (no silent action).

## Migration invariant
Users with a **saved default / fallback list are untouched** — both removed paths only ever fired when no default was persisted / fallbacks were empty. Only new multi-provider local setups change (now require explicit choice), exactly the locked decision.

## Documented limitation (non-hidden)
`groq` / `mistral` / `xai` / `openrouter` env-default models still resolve to the generic `$1/$4` fallback — those provider kinds have zero catalog entries. Out of this bundle's scope (goal names OpenAI + DeepSeek; Google was already first-class).

## Verification
- New: `friday-bootstrap-auto-routing.test.ts` (single→select, ≥2→null, union/second-boot regression, dedup, BYOK both sources).
- New pricing assertions prove gpt-4o/gpt-4o-mini/deepseek/gemini-2.0-flash no longer hit `$1/$4`; existing fallback test preserved.
- 14 focused tests pass; `tsc` clean on changed files; `git diff --check` clean; no secrets.
- Two independent read-only reviewers PASS (correctness + regression/no-overclaim/no-scope-creep).

refs: B4-fallback-injection, B4-auto-select, B4-pricing

🤖 Generated with [Claude Code](https://claude.com/claude-code)