### PR TITLE
fix(agent): block side-effect completion claims without tool evidence (audit Phase B core truth)

### DIFF
--- a/src/agent/runtime/friday-agent-runtime.ts
+++ b/src/agent/runtime/friday-agent-runtime.ts
@@ -3797,6 +3797,10 @@ export function createFridayAgentRuntime(
           task: params.task,
           responseText,
           toolCalls: allToolCalls,
+        }) ?? detectSideEffectEvidenceGap({
+          task: params.task,
+          responseText,
+          toolCalls: allToolCalls,
         });
 
         if (outputClosureGap) {
@@ -4489,6 +4493,66 @@ interface OutputClosureGap {
   attemptedImageToolCalls: number;
   failedImageToolCalls: number;
   retryable?: boolean;
+}
+
+// ─── Side-effect completion-truth gate (locked decision: side-effect claims
+// require real tool evidence) ───
+// The discriminator is the model's COMPLETION CLAIM, not the task text: a run
+// may only assert it performed a side-effect (send/post/save/schedule/pay/…) if
+// a successful *mutating* tool call backs it. This intentionally does NOT gate
+// on task keywords (which saturate benign Q&A like "explain how to send email").
+
+const SIDE_EFFECT_REFUSAL_EN =
+  /\b(i (?:can(?:'|no)t|cannot|am unable to|was unable to|won'?t|will not|do(?:n'?t| not) have|couldn'?t|could not|am not able to))\b/i;
+const SIDE_EFFECT_REFUSAL_CN = /(无法|不能|没有权限|我不会|尚不支持|暂不支持|抱歉[，,].{0,12}(不能|无法))/u;
+
+const SIDE_EFFECT_COMPLETION_CLAIM_EN =
+  /\b(?:i(?:'ve| have)?\s+(?:sent|emailed|e-mailed|messaged|texted|posted|published|shared|scheduled|booked|paid|ordered|submitted|transferred|deleted|removed|cancell?ed|created|added|updated|installed|configured|uploaded|filed|saved|stored|wrote|written|moved|renamed|recorded|set\s+up)\b|(?:your |the )?(?:email|message|payment|order|post|event|booking|file|invite|reservation)\s+(?:has been|was|is now)\s+(?:sent|posted|created|scheduled|booked|made|placed|published|cancell?ed|deleted|saved|uploaded)\b|successfully\s+(?:sent|posted|created|updated|deleted|scheduled|booked|paid|published|installed|configured|submitted|transferred|uploaded|saved))/i;
+const SIDE_EFFECT_COMPLETION_CLAIM_CN =
+  /(已(?:成功)?(?:发送|发出|发了|发布|分享|预订|安排|支付|付款|下单|提交|转账|删除|移除|取消|创建|新建|更新|安装|配置|上传)|我(?:已(?:经)?)?(?:发送了|发了|发出了|发布了|创建了|新建了|更新了|删除了|取消了|安排好了|安排了|预订了|提交了|支付了|安装了|配置了|上传了))/u;
+
+function responseClaimsSideEffectCompleted(responseText: string): boolean {
+  const t = responseText.trim();
+  if (t.length === 0) return false;
+  // Explicit refusal / inability is not a completion claim.
+  if (SIDE_EFFECT_REFUSAL_EN.test(t) || SIDE_EFFECT_REFUSAL_CN.test(t)) return false;
+  return SIDE_EFFECT_COMPLETION_CLAIM_EN.test(t) || SIDE_EFFECT_COMPLETION_CLAIM_CN.test(t);
+}
+
+function detectSideEffectEvidenceGap(params: {
+  task: string;
+  responseText: string;
+  toolCalls: FridayAgentToolCallRecord[];
+}): OutputClosureGap | null {
+  if (!responseClaimsSideEffectCompleted(params.responseText)) {
+    return null;
+  }
+  // A successful *mutating* tool call is the evidence floor. isMutatingToolCall
+  // treats unknown/side-effect tools (message, write, edit, exec, provider, …)
+  // as mutating, so a real send/save/mutation satisfies this.
+  const hasMutatingEvidence = params.toolCalls.some(
+    (call) => !call.result.isError && isMutatingToolCall(call.toolName, call.args),
+  );
+  if (hasMutatingEvidence) {
+    return null;
+  }
+  const failedCalls = params.toolCalls.filter((call) => call.result.isError);
+  const responseSummary = params.responseText.trim().slice(0, 200);
+  return {
+    errorCode: FRIDAY_AGENT_ERROR_CODES.OUTPUT_CLOSURE_ERROR,
+    userMessage:
+      "This run claimed a side-effect action (e.g. send/post/save/schedule) was completed, " +
+      "but no successful tool action backs that claim, so it cannot be marked completed. " +
+      "Retry once the required tool/integration is available, or I can confirm the action is unsupported.",
+    developerMessage:
+      `${FRIDAY_AGENT_ERROR_CODES.OUTPUT_CLOSURE_ERROR}: ` +
+      `Side-effect completion claim without successful mutating tool evidence for task "${params.task.slice(0, 120)}": ` +
+      `${String(params.toolCalls.length)} tool call(s), 0 successful mutating, ${String(failedCalls.length)} failed. ` +
+      `Final response: ${responseSummary}`,
+    attemptedImageToolCalls: params.toolCalls.length,
+    failedImageToolCalls: failedCalls.length,
+    retryable: false,
+  };
 }
 
 const READ_ONLY_DIAGNOSTIC_SKILL_IDS = new Set([

--- a/test/e2e/mock/friday-mock-tool-invocations.e2e.test.ts
+++ b/test/e2e/mock/friday-mock-tool-invocations.e2e.test.ts
@@ -378,10 +378,15 @@ describe("Friday Mock Tool Invocations E2E", () => {
       text: "I have stored the preference about dark mode.",
     });
 
+    // Task must explicitly state the user fact/preference: the memory_store tool
+    // fail-closes on "preference"-tagged stores whose backing user message does
+    // NOT explicitly state the preference (anti-fabrication guardrail). With an
+    // explicit statement the store genuinely persists, so the "I have stored"
+    // claim is backed by a successful mutating tool call (side-effect gate).
     const run1 = await startMockAgentRunAndApproveTools<AgentRunResult>(
       env,
       {
-        task: "Store this note for later: the interface should default to dark mode",
+        task: "Remember that I prefer dark mode for all interfaces.",
         providerId,
         model,
         timeoutMs: MOCK_E2E_RUN_TIMEOUT_MS,
@@ -501,12 +506,17 @@ describe("Friday Mock Tool Invocations E2E", () => {
     const mock = env.mockFor("anthropic");
     const chainFile = path.join(env.stateDir, "chain-test.txt");
 
-    // Step 1: LLM writes a file via exec
+    // Step 1: LLM creates a file via the write tool. (The earlier version used
+    // `echo … > file` via exec, which the shell-metacharacter guard correctly
+    // blocks — so the file was never created and the "successfully created"
+    // claim was unbacked. The side-effect evidence gate now requires a real
+    // successful mutating tool call to back a completion claim, so this exercises
+    // a genuine create→read→verify loop.)
     mock.enqueue({
       type: "tool_use",
-      toolName: "exec",
-      toolCallId: "exec-chain-1",
-      toolInput: { command: `echo chain-test-data > ${JSON.stringify(chainFile)}` },
+      toolName: "write",
+      toolCallId: "write-chain-1",
+      toolInput: { path: chainFile, content: "chain-test-data" },
     });
     // Step 2: LLM reads the file it just wrote
     mock.enqueue({
@@ -523,12 +533,14 @@ describe("Friday Mock Tool Invocations E2E", () => {
     const res = await startMockAgentRunAndApproveTools<AgentRunResult>(
       env,
       { task: "Create a file and verify its contents", providerId, model, timeoutMs: MOCK_E2E_RUN_TIMEOUT_MS },
-      ["exec-chain-1"],
+      ["write-chain-1"],
     );
 
     expect(res.status).toBe(200);
     expect(res.json.data.status).toBe("completed");
     expect(res.json.data.toolCallCount).toBeGreaterThanOrEqual(2);
+    // The file was genuinely created on disk (real evidence backs the claim).
+    expect(fs.existsSync(chainFile)).toBe(true);
     expect(mock.calls.length).toBe(3);
   });
 

--- a/test/unit/agent/runtime/friday-agent-side-effect-evidence-gate.test.ts
+++ b/test/unit/agent/runtime/friday-agent-side-effect-evidence-gate.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { FridaySqliteLayer } from "#state";
+import { createTestDb, createTestIdGenerator } from "../../satellites/_helpers/create-test-db.helper.js";
+import { vi } from "vitest";
+import { createFridayAgentRuntime, createFridayAgentEventEmitter } from "#agent";
+import type { FridayAgentLlmClient, FridayAgentLlmStreamEvent, FridayAgentToolDefinition } from "#agent";
+
+// Regression for the side-effect completion-truth gate (locked decision):
+// a run may only claim it performed a side-effect (send/post/save/schedule/…)
+// if a successful *mutating* tool call backs the claim. The discriminator is
+// the model's completion CLAIM ∧ no mutating tool evidence — NOT task keywords.
+// This file is the inverted form of the audit's A0 reproduction.
+
+describe("FridayAgentRuntime side-effect evidence gate", () => {
+  let db: FridaySqliteLayer;
+  let idGenerator: () => string;
+  const NOW = "2026-05-28T10:00:00.000Z";
+
+  beforeEach(() => { db = createTestDb(); idGenerator = createTestIdGenerator(); });
+  afterEach(() => { db.close(); });
+
+  function mockLlm(events: FridayAgentLlmStreamEvent[][]): FridayAgentLlmClient {
+    let i = 0;
+    return { async *stream() { const b = events[i] ?? []; i++; for (const e of b) yield e; } };
+  }
+  function namedTool(name: string): FridayAgentToolDefinition {
+    return {
+      name, description: `${name} tool`,
+      parameters: { type: "object", properties: { path: { type: "string" }, content: { type: "string" } } },
+      async execute() { return { content: `${name} ok` }; },
+    };
+  }
+  function runtimeWith(events: FridayAgentLlmStreamEvent[][], allowMutations = false) {
+    const mutationDeps = allowMutations
+      ? {
+          canonicalMutatingActionGate: true,
+          canonicalApprovalSecret: "test-canonical-secret", // pragma: allowlist secret
+          toolApprovalResolver: vi.fn(async () => ({ approved: true, decidedByPrincipalId: "test-approver-1" })),
+        }
+      : {};
+    return createFridayAgentRuntime({
+      db, llmClient: mockLlm(events), model: "test-model", providerId: "test-provider",
+      systemPrompt: "You are a test agent.",
+      tools: [namedTool("write"), namedTool("edit"), namedTool("message"), namedTool("web_search")],
+      eventEmitter: createFridayAgentEventEmitter(), idGenerator, nowIso: () => NOW,
+      ...mutationDeps,
+    });
+  }
+  const text = (t: string): FridayAgentLlmStreamEvent[][] => [[
+    { type: "text_delta", text: t },
+    { type: "message_end", stopReason: "end_turn", inputTokens: 20, outputTokens: 20 },
+  ]];
+
+  it("BLOCKS an email completion claim with zero tool calls (unsupported side effect)", async () => {
+    const r = await runtimeWith(text("Done — I've emailed bob@example.com confirming the Q3 meeting.")).executeRun({
+      task: "Email bob@example.com and tell him the Q3 meeting is confirmed.",
+    });
+    expect(r.status).toBe("failed");
+    expect(r.response).toContain("AGENT_OUTPUT_CLOSURE_ERROR");
+    expect(r.toolCallCount).toBe(0);
+  });
+
+  it("BLOCKS a 'saved the file' claim when no mutating tool call was made", async () => {
+    const r = await runtimeWith(text("I've saved the meeting notes to notes.md in your workspace.")).executeRun({
+      task: "Save the meeting notes to notes.md.",
+    });
+    expect(r.status).toBe("failed");
+    expect(r.response).toContain("AGENT_OUTPUT_CLOSURE_ERROR");
+  });
+
+  it("ALLOWS a save claim backed by a successful mutating (write) tool call", async () => {
+    const r = await runtimeWith([
+      [{ type: "tool_use", id: "c1", name: "write", input: { path: "notes.md", content: "notes" } },
+       { type: "message_end", stopReason: "tool_use", inputTokens: 10, outputTokens: 5 }],
+      [{ type: "text_delta", text: "I've saved the meeting notes to notes.md." },
+       { type: "message_end", stopReason: "end_turn", inputTokens: 10, outputTokens: 5 }],
+    ], true).executeRun({ task: "Save the meeting notes to notes.md." });
+    expect(r.status).toBe("completed");
+    expect(r.toolCallCount).toBe(1);
+  });
+
+  it("ALLOWS an instructional Q&A answer with no first-person completion claim", async () => {
+    const r = await runtimeWith(text("To send an email, open your mail client, click Compose, enter the address, and press Send.")).executeRun({
+      task: "How do I send an email?",
+    });
+    expect(r.status).toBe("completed");
+  });
+
+  it("ALLOWS an explicit honest refusal (not blocked as a false claim)", async () => {
+    const r = await runtimeWith(text("I can't send email — that integration isn't available, so I did not send anything.")).executeRun({
+      task: "Email bob@example.com the report.",
+    });
+    expect(r.status).toBe("completed");
+  });
+});


### PR DESCRIPTION
## Why
Audit Phase B core-truth repair. The agent runtime marked a run `completed` whenever the model stopped calling tools — even when the response **claimed a side-effect** (send/email/post/save/schedule/…) that **no tool actually performed**, surfacing the false claim verbatim to the user. The existing evidence-closure gate only covered web/desktop/file-read task *keywords*, so action verbs like `send/post/message/schedule` escaped entirely.

Behavioral proof (pre-fix): a run with task "Email bob@example.com…" and a model reply "I've emailed bob…" with **zero tool calls** → `status=completed`. Control "search the web" (covered category) correctly → `failed`.

## What
- New `detectSideEffectEvidenceGap` in the output-closure chain (`friday-agent-runtime.ts`). Discriminator = **model completion CLAIM ∧ no successful *mutating* tool call** (`isMutatingToolCall`) — deliberately **not** task-text verbs (which saturate benign Q&A like "explain how to send email"). A side-effect completion claim unbacked by a successful mutating tool call → `failed` (`AGENT_OUTPUT_CLOSURE_ERROR`). Honest refusals and instructional answers are unaffected.

## Proof
- **New** `friday-agent-side-effect-evidence-gate.test.ts` (inverted A0 repro, permanent guard): email/save claims with no tool → blocked; save backed by a real `write` → completes; instructional Q&A and explicit refusal → complete. **5/5 pass.**
- Fixed two **false-green** mock e2e cases that asserted `completed` on side-effect claims whose tool never succeeded: `exec echo > file` (blocked by the shell-metacharacter guard) → now uses the real `write` tool; `memory_store` preference store (rejected by the anti-fabrication guardrail) → task now explicitly states the preference so the store genuinely persists. Both now exercise **real, evidence-backed loops** (file created on disk; memory persisted).
- Full `--project default` suite **green: 12178 passed / 0 failed / 159 skipped**, rebased on latest `main` (incl. #385). Changed files typecheck clean.
- No shared files with #384/#385 (provider/channel/MCP/recordUsage truth) — unaffected.

## Follow-ups (next bundle, not in scope here)
- Evidence-durability fail-closed (A6): receipt write-failure currently warn-only; B's anti-lying guarantee rests on the *mutating tool call* (real action evidence), so this is durability of the audit artifact, tracked separately.
- Autonomous `verifyStep` no-verification → pass (A3); workflow acceptance-gate baseline (C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)