### PR TITLE
fix(autonomous): fail closed on unverified mutating-step completion (audit A3)

### DIFF
--- a/src/agent/autonomous/friday-autonomous-engine.ts
+++ b/src/agent/autonomous/friday-autonomous-engine.ts
@@ -15,6 +15,8 @@ import * as path from "node:path";
 
 import { FridayDomainError } from "#errors";
 
+import { isMutatingToolCall } from "../runtime/friday-agent-tool-mutation.js";
+
 import type {
   CreateFridayAutonomousEngineDeps,
   FridayAutonomousActionResult,
@@ -1453,9 +1455,19 @@ export function createFridayAutonomousEngine(
     providerId: string | undefined,
     model: string | undefined,
     signal: AbortSignal,
+    stepMutated = false,
   ): Promise<FridayAutonomousStepVerificationResult> {
     if (!step.verification) {
-      // No verification defined — assume success
+      // A step that performed a real mutating side effect cannot be assumed
+      // successful without verification — fail closed (locked decision).
+      if (stepMutated) {
+        return {
+          passed: false,
+          actual: "Mutating step has no verification criteria; cannot prove the side effect succeeded (fail-closed).",
+          method: "fail_closed",
+        };
+      }
+      // No side effect recorded → benign step, assume success (no over-blocking).
       return { passed: true, actual: "No verification criteria defined" };
     }
 
@@ -1508,9 +1520,16 @@ export function createFridayAutonomousEngine(
         const jsonMatch = result.text.match(/\{[\s\S]*\}/);
         if (jsonMatch) {
           const parsed = JSON.parse(jsonMatch[0]) as { passed?: boolean; actual?: string };
+          // For a mutating step, LLM self-judgment with NO grounding observations
+          // (empty images + empty text context) is INVALID completion proof
+          // (locked decision). When real observations exist, the LLM is
+          // interpreting external state (grounded), which is allowed.
+          const ungroundedMutation = stepMutated && images.length === 0 && textContext.trim().length === 0;
           return {
-            passed: parsed.passed === true,
-            actual: parsed.actual ?? result.text,
+            passed: ungroundedMutation ? false : parsed.passed === true,
+            actual: ungroundedMutation && parsed.passed === true
+              ? `${parsed.actual ?? result.text} (LLM self-judgment without grounding observations is not valid proof for a mutating step; fail-closed.)`
+              : parsed.actual ?? result.text,
             method: "llm_vision",
           };
         }
@@ -1535,9 +1554,15 @@ export function createFridayAutonomousEngine(
       const jsonMatch = result.response.match(/\{[\s\S]*\}/);
       if (jsonMatch) {
         const parsed = JSON.parse(jsonMatch[0]) as { passed?: boolean; actual?: string };
+        // A mutating step verified only by LLM text with NO grounding
+        // observations is INVALID completion proof (locked decision); when real
+        // observations exist the LLM interprets external state (grounded → allowed).
+        const ungroundedMutation = stepMutated && images.length === 0 && textContext.trim().length === 0;
         return {
-          passed: parsed.passed === true,
-          actual: parsed.actual ?? result.response,
+          passed: ungroundedMutation ? false : parsed.passed === true,
+          actual: ungroundedMutation && parsed.passed === true
+            ? `${parsed.actual ?? result.response} (LLM self-judgment without grounding observations is not valid proof for a mutating step; fail-closed.)`
+            : parsed.actual ?? result.response,
           method: "llm_text",
         };
       }
@@ -1561,6 +1586,7 @@ export function createFridayAutonomousEngine(
     providerId: string | undefined,
     model: string | undefined,
     signal: AbortSignal,
+    stepMutated = false,
   ): Promise<{ step: FridayAutonomousStep; passed: boolean }> {
     const browserSessionId = buildAutonomousBrowserSessionId(goalId);
     updateGoal(goalId, { status: "verifying" });
@@ -1582,6 +1608,7 @@ export function createFridayAutonomousEngine(
       providerId,
       model,
       signal,
+      stepMutated,
     );
 
     emit("autonomous.verification.completed", {
@@ -1810,6 +1837,12 @@ export function createFridayAutonomousEngine(
       });
 
       // ─── Phase 2: Step-by-step execution ───
+      // Track which steps performed a successful *mutating* tool call. Such a
+      // step has produced a real side effect and therefore must not be marked
+      // completed without deterministic verification (locked decision: missing /
+      // LLM-self-judgment verification is INVALID completion proof for side
+      // effects). Mirrors the runtime side-effect gate (#388) discriminator.
+      const mutatedStepIds = new Set<string>();
       for (let si = startingStepIndex; si < stepIds.length; si++) {
         if (signal.aborted) break;
 
@@ -1887,6 +1920,11 @@ export function createFridayAutonomousEngine(
                 plannedAction: decision.action,
               });
               actionResult = await executeAction(decision, currentStep.domain, browserSessionId, timezone, principalId, tenantContext, providerId, model, signal);
+              if (actionResult.success && isMutatingToolCall(decision.action.toolName, decision.action.args ?? {})) {
+                // This step produced a real side effect — it now requires
+                // deterministic verification before it may be marked completed.
+                mutatedStepIds.add(stepId);
+              }
               if (actionResult.success && currentStep.domain === "browser") {
                 const checkpointObservations = await collectBrowserCheckpointObservations(currentStep, stepId, browserSessionId, signal);
                 if (checkpointObservations.length > 0) {
@@ -1915,6 +1953,7 @@ export function createFridayAutonomousEngine(
                   providerId,
                   model,
                   signal,
+                  mutatedStepIds.has(stepId),
                 );
                 if (verification.passed) {
                   stepCompleted = true;
@@ -1937,6 +1976,7 @@ export function createFridayAutonomousEngine(
                 providerId,
                 model,
                 signal,
+                mutatedStepIds.has(stepId),
               );
 
               if (verification.passed) {
@@ -1960,12 +2000,24 @@ export function createFridayAutonomousEngine(
                   providerId,
                   model,
                   signal,
+                  mutatedStepIds.has(stepId),
                 );
                 if (!verification.passed) {
                   stepRetries++;
                   currentStep = updateStep(stepId, { retryCount: stepRetries });
                   break;
                 }
+              } else if (mutatedStepIds.has(stepId)) {
+                // Fail closed: the model decided "complete" for a step that
+                // performed a real mutating side effect but carries NO
+                // verification criteria — not valid completion proof (locked
+                // decision). Retry instead of silently marking completed.
+                stepRetries++;
+                currentStep = updateStep(stepId, {
+                  retryCount: stepRetries,
+                  failureReason: "Mutating step marked complete without verification criteria; cannot prove the side effect succeeded (fail-closed).",
+                });
+                break;
               }
               stepCompleted = true;
               updateStep(stepId, { status: "completed", completedAt: nowIso() });
@@ -1981,7 +2033,18 @@ export function createFridayAutonomousEngine(
               const newStepIds = [...stepIds.slice(0, si + 1), ...newStepObjects.map((s) => s.id)];
               currentGoal = updateGoal(goal.id, { stepIds: newStepIds });
               stepCompleted = true;
-              updateStep(stepId, { status: "completed", completedAt: nowIso() });
+              if (mutatedStepIds.has(stepId)) {
+                // A step that performed a real mutating side effect must not be
+                // silently marked completed when replanned away without
+                // verification — record it as failed (fail-closed).
+                updateStep(stepId, {
+                  status: "failed",
+                  completedAt: nowIso(),
+                  failureReason: "Replanned away a mutating step without verifying its side effect (fail-closed).",
+                });
+              } else {
+                updateStep(stepId, { status: "completed", completedAt: nowIso() });
+              }
               break;
             }
 

--- a/src/agent/autonomous/friday-autonomous.types.ts
+++ b/src/agent/autonomous/friday-autonomous.types.ts
@@ -129,7 +129,10 @@ export type FridayAutonomousVerificationMethod =
   | "deterministic_file"
   | "deterministic_browser"
   | "llm_text"
-  | "llm_vision";
+  | "llm_vision"
+  // A mutating step with no verification criteria (or only LLM self-judgment)
+  // is failed closed — its side effect cannot be proven.
+  | "fail_closed";
 
 /** Which deterministic file-phrase family matched, when applicable. */
 export type FridayAutonomousVerificationPatternFamily =

--- a/test/unit/agent/autonomous/friday-autonomous-engine-side-effect-verification.test.ts
+++ b/test/unit/agent/autonomous/friday-autonomous-engine-side-effect-verification.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createFridayAutonomousEngine } from "../../../../src/agent/autonomous/friday-autonomous-engine.js";
+import type {
+  CreateFridayAutonomousEngineDeps,
+  FridayAutonomousGoal,
+  FridayAutonomousIteration,
+  FridayAutonomousStep,
+} from "../../../../src/agent/autonomous/friday-autonomous.types.js";
+
+// A3 regression: the autonomous engine must NOT mark a step/goal `completed`
+// when the step performed a real *mutating* side effect but the model decided
+// "complete" with NO verification criteria (locked decision: missing /
+// LLM-self-judgment verification is INVALID completion proof for side effects).
+// Mirrors the runtime side-effect gate (#388) for the autonomous surface.
+
+let counter = 0;
+const idGen = () => `id-${++counter}`;
+const nowIso = () => "2026-05-28T10:00:00Z";
+const signal = () => new AbortController().signal;
+
+function inMemoryPersistence(): NonNullable<CreateFridayAutonomousEngineDeps["persistence"]> {
+  const goals = new Map<string, FridayAutonomousGoal>();
+  const steps = new Map<string, FridayAutonomousStep>();
+  const stepsByGoal = new Map<string, FridayAutonomousStep[]>();
+  const iters = new Map<string, FridayAutonomousIteration[]>();
+  return {
+    sqlite: {
+      withWriteTransaction: <T>(fn: (db: object) => T): T => fn({}),
+      withReadConnection: <T>(fn: (db: object) => T): T => fn({}),
+    },
+    repository: {
+      createGoal: (_d: object, g: FridayAutonomousGoal) => { goals.set(g.id, g); },
+      updateGoal: (_d: object, id: string, p: Partial<FridayAutonomousGoal>) => { const c = goals.get(id); if (c) goals.set(id, { ...c, ...p }); },
+      getGoal: (_d: object, id: string) => goals.get(id) ?? null,
+      listGoals: () => [...goals.values()],
+      listActiveGoals: () => [...goals.values()].filter((g) => !["completed", "failed", "cancelled", "interrupted_nonrecoverable"].includes(g.status)),
+      createStep: (_d: object, s: FridayAutonomousStep) => { steps.set(s.id, s); stepsByGoal.set(s.goalId, [...(stepsByGoal.get(s.goalId) ?? []), s].sort((a, b) => a.index - b.index)); },
+      updateStep: (_d: object, id: string, p: Partial<FridayAutonomousStep>) => { const c = steps.get(id); if (!c) return; const u = { ...c, ...p }; steps.set(id, u); stepsByGoal.set(c.goalId, (stepsByGoal.get(c.goalId) ?? []).map((s) => s.id === id ? u : s)); },
+      getStep: (_d: object, id: string) => steps.get(id) ?? null,
+      getStepsByGoalId: (_d: object, gid: string) => [...(stepsByGoal.get(gid) ?? [])],
+      appendIteration: (_d: object, it: FridayAutonomousIteration) => { iters.set(it.goalId, [...(iters.get(it.goalId) ?? []), it]); },
+      getIterationsByGoalId: (_d: object, gid: string) => [...(iters.get(gid) ?? [])],
+    } as unknown as NonNullable<CreateFridayAutonomousEngineDeps["persistence"]>["repository"],
+  };
+}
+
+function makeDeps(executeRunImpl: ReturnType<typeof vi.fn>, toolExecutor: ReturnType<typeof vi.fn>): CreateFridayAutonomousEngineDeps {
+  return {
+    agentRuntime: { executeRun: executeRunImpl },
+    analyzeImages: vi.fn().mockResolvedValue({ text: JSON.stringify({ kind: "complete", summary: "done" }), model: "v", inputTokens: 1, outputTokens: 1 }),
+    toolExecutor,
+    idGenerator: idGen,
+    nowIso,
+    eventEmitter: { emit: vi.fn() },
+    persistence: inMemoryPersistence(),
+  } as unknown as CreateFridayAutonomousEngineDeps;
+}
+
+const plan = (step: Record<string, unknown>) => ({ runId: "r-plan", status: "completed", response: JSON.stringify([step]), usageInput: 10, usageOutput: 5 });
+const decide = (d: Record<string, unknown>) => ({ runId: "r-dec", status: "completed", response: JSON.stringify(d), usageInput: 5, usageOutput: 5 });
+
+describe("FridayAutonomousEngine side-effect verification (A3)", () => {
+  beforeEach(() => { counter = 0; });
+
+  it("FAILS a mutating step the model marks complete with NO verification", async () => {
+    const executeRun = vi.fn()
+      .mockResolvedValueOnce(plan({ instruction: "Send the confirmation email to bob@example.com", domain: "composite" }))
+      .mockResolvedValueOnce(decide({ kind: "act", action: { toolName: "message", args: { channelId: "c1", text: "confirmed" }, rationale: "send the message" } }))
+      .mockResolvedValue(decide({ kind: "complete", summary: "Email sent" }));
+    const toolExecutor = vi.fn().mockResolvedValue({ isError: false, content: "sent" }); // message = mutating, succeeds
+    const engine = createFridayAutonomousEngine(makeDeps(executeRun, toolExecutor));
+
+    const result = await engine.executeGoal({ description: "Email bob the confirmation", signal: signal() });
+    // Side effect (message) ran but there is no verification — must NOT be a clean completion.
+    expect(result.status).not.toBe("completed");
+    expect(result.status).toBe("failed");
+  });
+
+  it("COMPLETES a non-mutating (read-only) step marked complete without verification (no over-blocking)", async () => {
+    const executeRun = vi.fn()
+      .mockResolvedValueOnce(plan({ instruction: "Read the project README", domain: "composite" }))
+      .mockResolvedValueOnce(decide({ kind: "act", action: { toolName: "read", args: { path: "README.md" }, rationale: "read it" } }))
+      .mockResolvedValue(decide({ kind: "complete", summary: "Read the file" }));
+    const toolExecutor = vi.fn().mockResolvedValue({ isError: false, content: "# Readme" }); // read = read-only, not mutating
+    const engine = createFridayAutonomousEngine(makeDeps(executeRun, toolExecutor));
+
+    const result = await engine.executeGoal({ description: "Read the README", signal: signal() });
+    expect(result.status).toBe("completed");
+  });
+});


### PR DESCRIPTION
## Why
Audit **A3** (listed as a follow-up in #388/#390). The autonomous engine is a **separate completion authority** that could mark a step/goal `completed` without deterministic proof of a side effect: `verifyStep` returned `{passed:true}` when a step had no verification; `case "complete"`/`"replan"` completed unconditionally; LLM self-judgment (`llm_vision`/`llm_text`) could close a step on model say-so. Neither #388's runtime side-effect gate nor #390's durability gate is invoked by the engine.

## What
Reuse #388's discriminator — a successful **mutating** tool call (`isMutatingToolCall`), **not** instruction-text verbs — to require deterministic proof for mutating steps:
- Track per-step mutating evidence when an "act" runs a successful mutating tool.
- `verifyStep(stepMutated)`: mutating step with **no verification** → fail closed (`method:"fail_closed"`); LLM-only verification with **no grounding observations** (empty images + empty text) → fail closed. LLM judgment over **real observations** stays allowed (grounded, not self-judgment "alone").
- `case "complete"`: mutating step + no verification → fail closed (retry), not silent completion.
- `case "replan"`: mutating step replanned away without verification → recorded **failed**, not completed.
- Benign read/observe steps (no mutating evidence) unaffected — no over-blocking (mirrors #388's carve-out).

## Proof
- New `friday-autonomous-engine-side-effect-verification.test.ts`: mutating `message` + no-verification `"complete"` → **failed**; read-only step → **completed**.
- The 4 existing "falls back to LLM verification for unsupported phrasing" tests (real file written, non-standard phrasing → **grounded** LLM verify) still pass — they have real file observations, so they are not ungrounded (this caught + corrected an initial over-block; suite-as-oracle).
- Full `--project default` suite green: **12183 passed / 0 failed**; typecheck clean.

## Follow-ups
Workflow acceptance gate (C); agent-run idempotency UNIQUE + usage-ledger divergence (D — budget-throw test already covered by #391); truth labels (E).

🤖 Generated with [Claude Code](https://claude.com/claude-code)