### PR TITLE
fix(agent,memory): destructive shell flags require approval + PII redaction of metadata/tags (ANNEX B6)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -603,7 +603,7 @@
         "filename": "test/unit/agent/runtime/friday-agent-tool-risk.test.ts",
         "hashed_secret": "d14babe099a92466c4efa49400806772a6c097cd",
         "is_verified": false,
-        "line_number": 162
+        "line_number": 185
       }
     ],
     "test/unit/api/auth/friday-auth-middleware.test.ts": [
@@ -1124,5 +1124,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-28T23:15:45Z"
+  "generated_at": "2026-05-29T00:26:37Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -603,7 +603,7 @@
         "filename": "test/unit/agent/runtime/friday-agent-tool-risk.test.ts",
         "hashed_secret": "d14babe099a92466c4efa49400806772a6c097cd",
         "is_verified": false,
-        "line_number": 185
+        "line_number": 201
       }
     ],
     "test/unit/api/auth/friday-auth-middleware.test.ts": [
@@ -1124,5 +1124,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-29T00:26:37Z"
+  "generated_at": "2026-05-29T00:48:14Z"
 }

--- a/src/agent/runtime/friday-agent-tool-risk.ts
+++ b/src/agent/runtime/friday-agent-tool-risk.ts
@@ -72,6 +72,13 @@ export function classifyShellRisk(command: string): FridayShellRiskClassificatio
     return { level: "destructive", reason: `${program} is a destructive command`, program };
   }
 
+  // Destructive FLAGS on otherwise-safe programs (git reset --hard, git clean -fdx,
+  // find . -delete) — classification must key on flags, not just the program name.
+  const dangerousFlagReason = detectDangerousShellFlagReason(program, parts);
+  if (dangerousFlagReason) {
+    return { level: "destructive", reason: dangerousFlagReason, program };
+  }
+
   // Protected artifact + destructive keyword
   const touchesProtected = listPotentialFilePaths(trimmed)
     .some((fp) => requiresApprovalForProtectedArtifactPath(fp));
@@ -134,6 +141,36 @@ function listPotentialFilePaths(text: string): string[] {
   return [...new Set(text.match(/\b[\w./-]+\.[A-Za-z0-9]+\b/g) ?? [])];
 }
 
+/**
+ * Detect destructive FLAG combinations on programs that are otherwise allow-listed as
+ * "safe" by name (e.g. git, find). Classification by program name alone let irreversible
+ * operations like `git reset --hard`, `git clean -fdx`, and `find . -delete` slip through
+ * without approval; this closes that flag-vs-program gap. Returns an approval reason string
+ * when a dangerous flag combination is present, else null.
+ */
+function detectDangerousShellFlagReason(program: string, parts: readonly string[]): string | null {
+  if (program === "git") {
+    const sub = parts[1]?.toLowerCase() ?? "";
+    const rest = parts.slice(2);
+    const hasForce = rest.some((a) => a === "-f" || a === "--force");
+    if (sub === "reset" && rest.some((a) => a === "--hard")) {
+      return "`git reset --hard` irreversibly discards uncommitted changes and requires explicit approval in the current run context.";
+    }
+    if (sub === "clean" && rest.some((a) => /^-[a-z]*f[a-z]*$/i.test(a) || a === "--force")) {
+      return "`git clean -f…` permanently deletes untracked files and requires explicit approval in the current run context.";
+    }
+    if ((sub === "checkout" || sub === "restore" || sub === "switch") && (hasForce || rest.some((a) => a === "--hard"))) {
+      return `\`git ${sub} --force\` discards local changes and requires explicit approval in the current run context.`;
+    }
+  }
+  if (program === "find") {
+    if (parts.slice(1).some((a) => a === "-delete")) {
+      return "`find … -delete` permanently removes matched files and requires explicit approval in the current run context.";
+    }
+  }
+  return null;
+}
+
 function readToolAction(args: Record<string, unknown>): string {
   return typeof args.action === "string" ? args.action.trim().toLowerCase() : "";
 }
@@ -185,6 +222,11 @@ export function getApprovalRequiredReasonForExecCommand(command: string): string
 
   if (DESTRUCTIVE_PROGRAMS.has(program)) {
     return "Deleting files from the shell is destructive and requires explicit approval in the current run context.";
+  }
+
+  const dangerousFlagReason = detectDangerousShellFlagReason(program, parts);
+  if (dangerousFlagReason) {
+    return dangerousFlagReason;
   }
 
   if (SENSITIVE_ASSIGNMENT_RE.test(trimmed)) {

--- a/src/agent/runtime/friday-agent-tool-risk.ts
+++ b/src/agent/runtime/friday-agent-tool-risk.ts
@@ -141,17 +141,41 @@ function listPotentialFilePaths(text: string): string[] {
   return [...new Set(text.match(/\b[\w./-]+\.[A-Za-z0-9]+\b/g) ?? [])];
 }
 
+// git global options that precede the subcommand; the value-taking ones (given without `=`)
+// also consume the following token. Used to locate the real subcommand for forms like
+// `git -C /repo reset --hard` or `git --no-pager clean -fdx`.
+const GIT_GLOBAL_OPTS_WITH_VALUE = new Set([
+  "-C", "-c", "--git-dir", "--work-tree", "--namespace", "--exec-path", "--super-prefix",
+]);
+
+function gitSubcommandStart(parts: readonly string[]): number {
+  let i = 1;
+  while (i < parts.length) {
+    const tok = parts[i]!;
+    if (!tok.startsWith("-")) return i; // first non-option token is the subcommand
+    // `--opt=value` is a single token; `-C <v>` / `--git-dir <v>` consume the next token too.
+    i += GIT_GLOBAL_OPTS_WITH_VALUE.has(tok) ? 2 : 1;
+  }
+  return -1;
+}
+
 /**
  * Detect destructive FLAG combinations on programs that are otherwise allow-listed as
  * "safe" by name (e.g. git, find). Classification by program name alone let irreversible
  * operations like `git reset --hard`, `git clean -fdx`, and `find . -delete` slip through
- * without approval; this closes that flag-vs-program gap. Returns an approval reason string
- * when a dangerous flag combination is present, else null.
+ * without approval; this closes that flag-vs-program gap. Leading git global options
+ * (`git -C <path> …`, `git --no-pager …`) are skipped so the subcommand is found regardless
+ * of the invocation form. Returns an approval reason string when a dangerous flag combination
+ * is present, else null.
  */
 function detectDangerousShellFlagReason(program: string, parts: readonly string[]): string | null {
   if (program === "git") {
-    const sub = parts[1]?.toLowerCase() ?? "";
-    const rest = parts.slice(2);
+    const subIdx = gitSubcommandStart(parts);
+    if (subIdx === -1) {
+      return null;
+    }
+    const sub = parts[subIdx]?.toLowerCase() ?? "";
+    const rest = parts.slice(subIdx + 1);
     const hasForce = rest.some((a) => a === "-f" || a === "--force");
     if (sub === "reset" && rest.some((a) => a === "--hard")) {
       return "`git reset --hard` irreversibly discards uncommitted changes and requires explicit approval in the current run context.";

--- a/src/memory/guard/model/friday-memory-guard.types.ts
+++ b/src/memory/guard/model/friday-memory-guard.types.ts
@@ -124,6 +124,13 @@ export interface FridayMemoryGuardQuotaRepository {
 
 export interface FridayMemoryGuardPiiGuard {
   scanAndTransform(content: string): FridayMemoryGuardPiiScanResult;
+  /**
+   * Recursively redact PII in the string leaves of an arbitrary structured value
+   * (memory metadata objects, tag arrays). Returns the redacted value (or the original
+   * when not in redact mode) plus the PII-type tags discovered, so callers can scan
+   * metadata/tags the same way `scanAndTransform` scans content.
+   */
+  redactDeep(value: unknown): { value: unknown; tagsToAdd: string[] };
 }
 
 export interface FridayMemoryGuardOutputFilter {

--- a/src/memory/guard/services/friday-memory-guard-service.ts
+++ b/src/memory/guard/services/friday-memory-guard-service.ts
@@ -505,23 +505,34 @@ export function createFridayMemoryGuardService(
         const contentBytes = byteLength(content);
         checkQuotaAndPrune(resolution.effectiveNamespace, contentBytes);
 
-        // 5. PII policy — scan/redact content AND caller-supplied metadata + tags (the
-        // metadata/tags reach the store via the HTTP route, so they must be covered too).
+        // 5. PII policy — scan/redact content AND caller-supplied metadata, and drop tags that
+        // themselves contain PII (metadata + tags reach the store via the HTTP route, so they
+        // must be covered too). Metadata values are free-form, so PII is redacted in place; a
+        // tag is a constrained-charset label, so a "[EMAIL]"-style redaction marker would be an
+        // invalid tag — instead a PII-bearing tag is dropped and its pii.* type tag surfaced.
         const piiResult = piiGuard.scanAndTransform(content);
         const metadataRedaction = piiGuard.redactDeep(metadata?.metadata);
-        const tagRedaction = piiGuard.redactDeep(metadata?.tags ?? []);
         const redactedMetadata = metadataRedaction.value as Record<string, unknown> | undefined;
-        const redactedTags = tagRedaction.value as string[];
+
+        const originalTags = metadata?.tags ?? [];
+        const tagPiiTypeTags = new Set<string>();
+        const cleanTags: string[] = [];
+        for (const tag of originalTags) {
+          const tagScan = piiGuard.scanAndTransform(tag);
+          if (tagScan.matches.length > 0) {
+            // Drop the PII-bearing tag (no PII at rest in tags); surface its pii.* type tags.
+            tagScan.tagsToAdd.forEach((t) => tagPiiTypeTags.add(t));
+          } else {
+            cleanTags.push(tag);
+          }
+        }
+
         const piiPresent =
           piiResult.matches.length > 0
           || metadataRedaction.tagsToAdd.length > 0
-          || tagRedaction.tagsToAdd.length > 0;
+          || tagPiiTypeTags.size > 0;
         const allPiiTags = [
-          ...new Set([
-            ...piiResult.tagsToAdd,
-            ...metadataRedaction.tagsToAdd,
-            ...tagRedaction.tagsToAdd,
-          ]),
+          ...new Set([...piiResult.tagsToAdd, ...metadataRedaction.tagsToAdd, ...tagPiiTypeTags]),
         ];
         // PII_MODE is compile-time "tag" by default, but test the variable as a runtime
         // string to support re-configuration without code changes.
@@ -533,15 +544,15 @@ export function createFridayMemoryGuardService(
           );
         }
 
-        // Merge PII tags (redacted tag strings + the discovered pii.* type tags)
-        const mergedTags = [...redactedTags, ...allPiiTags.filter((t) => !redactedTags.includes(t))];
+        // Merge surviving clean tags with discovered pii.* type tags (all charset-valid).
+        const mergedTags = [...cleanTags, ...allPiiTags.filter((t) => !cleanTags.includes(t))];
 
         // Re-validate tag limits after PII merge (PII tags could push over count limits)
         if (mergedTags.length > 0) {
           validateTags(mergedTags);
         }
 
-        // 6. Delegate to core — store redacted content, redacted metadata, redacted+tagged tags
+        // 6. Delegate to core — store redacted content, redacted metadata, PII-stripped tags
         const item = await core.store(resolution.effectiveNamespace, piiResult.transformedContent, {
           ...metadata,
           ...(metadata?.metadata !== undefined ? { metadata: redactedMetadata } : {}),

--- a/src/memory/guard/services/friday-memory-guard-service.ts
+++ b/src/memory/guard/services/friday-memory-guard-service.ts
@@ -505,30 +505,46 @@ export function createFridayMemoryGuardService(
         const contentBytes = byteLength(content);
         checkQuotaAndPrune(resolution.effectiveNamespace, contentBytes);
 
-        // 5. PII policy
+        // 5. PII policy — scan/redact content AND caller-supplied metadata + tags (the
+        // metadata/tags reach the store via the HTTP route, so they must be covered too).
         const piiResult = piiGuard.scanAndTransform(content);
+        const metadataRedaction = piiGuard.redactDeep(metadata?.metadata);
+        const tagRedaction = piiGuard.redactDeep(metadata?.tags ?? []);
+        const redactedMetadata = metadataRedaction.value as Record<string, unknown> | undefined;
+        const redactedTags = tagRedaction.value as string[];
+        const piiPresent =
+          piiResult.matches.length > 0
+          || metadataRedaction.tagsToAdd.length > 0
+          || tagRedaction.tagsToAdd.length > 0;
+        const allPiiTags = [
+          ...new Set([
+            ...piiResult.tagsToAdd,
+            ...metadataRedaction.tagsToAdd,
+            ...tagRedaction.tagsToAdd,
+          ]),
+        ];
         // PII_MODE is compile-time "tag" by default, but test the variable as a runtime
         // string to support re-configuration without code changes.
-        if (piiResult.matches.length > 0 && (FRIDAY_MEMORY_GUARD_PII_MODE as string) === "block") {
+        if (piiPresent && (FRIDAY_MEMORY_GUARD_PII_MODE as string) === "block") {
           throw new FridayDomainError(
             FRIDAY_MEMORY_GUARD_ERROR_CODES.PII_BLOCKED,
-            `content contains PII: ${piiResult.distinctTypes.join(", ")}`,
+            `content/metadata/tags contain PII: ${[...new Set([...piiResult.distinctTypes, ...allPiiTags.map((t) => t.split(".").at(-1) ?? t)])].join(", ")}`,
             { httpStatus: 400 },
           );
         }
 
-        // Merge PII tags
-        const existingTags = metadata?.tags ?? [];
-        const mergedTags = [...existingTags, ...piiResult.tagsToAdd.filter((t) => !existingTags.includes(t))];
+        // Merge PII tags (redacted tag strings + the discovered pii.* type tags)
+        const mergedTags = [...redactedTags, ...allPiiTags.filter((t) => !redactedTags.includes(t))];
 
         // Re-validate tag limits after PII merge (PII tags could push over count limits)
         if (mergedTags.length > 0) {
           validateTags(mergedTags);
         }
 
-        // 6. Delegate to core
+        // 6. Delegate to core — store redacted content, redacted metadata, redacted+tagged tags
         const item = await core.store(resolution.effectiveNamespace, piiResult.transformedContent, {
           ...metadata,
+          ...(metadata?.metadata !== undefined ? { metadata: redactedMetadata } : {}),
           tags: mergedTags.length > 0 ? mergedTags : metadata?.tags,
         });
 

--- a/src/memory/guard/services/friday-memory-output-filter.ts
+++ b/src/memory/guard/services/friday-memory-output-filter.ts
@@ -19,13 +19,15 @@ function redactAndTruncate(value: string, maxChars: number): string {
   return truncateString(piiRedactor.scanAndTransform(value).transformedContent, maxChars);
 }
 
-// Redact PII from the metadata object and tag array on read-back (defense in depth: items
-// stored before metadata/tag redaction existed must not leak PII when returned).
+// Strip PII from metadata + tags on read-back (defense in depth: items stored before
+// metadata/tag PII handling existed must not leak PII when returned). Metadata values are
+// free-form, so PII is redacted in place; a tag whose content is PII is dropped (a
+// "[EMAIL]"-style marker would not be a valid tag), mirroring the store path.
 function redactMetadata(metadata: Record<string, unknown>): Record<string, unknown> {
   return piiRedactor.redactDeep(metadata).value as Record<string, unknown>;
 }
-function redactTags(tags: string[]): string[] {
-  return piiRedactor.redactDeep(tags).value as string[];
+function dropPiiTags(tags: string[]): string[] {
+  return tags.filter((tag) => piiRedactor.scanAndTransform(tag).matches.length === 0);
 }
 
 export function createFridayMemoryOutputFilter(): FridayMemoryGuardOutputFilter {
@@ -35,7 +37,7 @@ export function createFridayMemoryOutputFilter(): FridayMemoryGuardOutputFilter 
         ...item,
         content: redactAndTruncate(item.content, FRIDAY_MEMORY_GUARD_MAX_RESULT_CONTENT_CHARS),
         metadata: redactMetadata(item.metadata),
-        tags: redactTags(item.tags),
+        tags: dropPiiTags(item.tags),
       };
     },
 
@@ -47,7 +49,7 @@ export function createFridayMemoryOutputFilter(): FridayMemoryGuardOutputFilter 
           ...result.item,
           content: redactAndTruncate(result.item.content, FRIDAY_MEMORY_GUARD_MAX_RESULT_CONTENT_CHARS),
           metadata: redactMetadata(result.item.metadata),
-          tags: redactTags(result.item.tags),
+          tags: dropPiiTags(result.item.tags),
         },
         snippet: redactAndTruncate(result.snippet, FRIDAY_MEMORY_GUARD_MAX_RESULT_SNIPPET_CHARS),
       }));

--- a/src/memory/guard/services/friday-memory-output-filter.ts
+++ b/src/memory/guard/services/friday-memory-output-filter.ts
@@ -19,12 +19,23 @@ function redactAndTruncate(value: string, maxChars: number): string {
   return truncateString(piiRedactor.scanAndTransform(value).transformedContent, maxChars);
 }
 
+// Redact PII from the metadata object and tag array on read-back (defense in depth: items
+// stored before metadata/tag redaction existed must not leak PII when returned).
+function redactMetadata(metadata: Record<string, unknown>): Record<string, unknown> {
+  return piiRedactor.redactDeep(metadata).value as Record<string, unknown>;
+}
+function redactTags(tags: string[]): string[] {
+  return piiRedactor.redactDeep(tags).value as string[];
+}
+
 export function createFridayMemoryOutputFilter(): FridayMemoryGuardOutputFilter {
   return {
     filterItem(item: FridayMemoryItem): FridayMemoryItem {
       return {
         ...item,
         content: redactAndTruncate(item.content, FRIDAY_MEMORY_GUARD_MAX_RESULT_CONTENT_CHARS),
+        metadata: redactMetadata(item.metadata),
+        tags: redactTags(item.tags),
       };
     },
 
@@ -35,6 +46,8 @@ export function createFridayMemoryOutputFilter(): FridayMemoryGuardOutputFilter 
         item: {
           ...result.item,
           content: redactAndTruncate(result.item.content, FRIDAY_MEMORY_GUARD_MAX_RESULT_CONTENT_CHARS),
+          metadata: redactMetadata(result.item.metadata),
+          tags: redactTags(result.item.tags),
         },
         snippet: redactAndTruncate(result.snippet, FRIDAY_MEMORY_GUARD_MAX_RESULT_SNIPPET_CHARS),
       }));

--- a/src/memory/guard/services/friday-memory-pii-guard.ts
+++ b/src/memory/guard/services/friday-memory-pii-guard.ts
@@ -131,5 +131,35 @@ export function createFridayMemoryPiiGuard(
         tagsToAdd,
       };
     },
+
+    redactDeep(value: unknown): { value: unknown; tagsToAdd: string[] } {
+      const tagSet = new Set<string>();
+      const MAX_DEPTH = 6;
+
+      const walk = (v: unknown, depth: number): unknown => {
+        if (depth > MAX_DEPTH) return v;
+        if (typeof v === "string") {
+          const matches = findMatches(v);
+          if (matches.length === 0) return v;
+          for (const m of matches) {
+            tagSet.add(`${FRIDAY_MEMORY_GUARD_PII_TAG_PREFIX}.${m.type}`);
+          }
+          return effectiveMode === "redact" ? redactContent(v, matches) : v;
+        }
+        if (Array.isArray(v)) {
+          return v.map((entry) => walk(entry, depth + 1));
+        }
+        if (v && typeof v === "object") {
+          const out: Record<string, unknown> = {};
+          for (const [k, entry] of Object.entries(v as Record<string, unknown>)) {
+            out[k] = walk(entry, depth + 1);
+          }
+          return out;
+        }
+        return v;
+      };
+
+      return { value: walk(value, 0), tagsToAdd: [...tagSet] };
+    },
   };
 }

--- a/test/unit/agent/runtime/friday-agent-tool-risk.test.ts
+++ b/test/unit/agent/runtime/friday-agent-tool-risk.test.ts
@@ -83,6 +83,21 @@ describe("friday-agent-tool-risk", () => {
       const result = classifyShellRisk("python delete database.dump");
       expect(result.level).toBe("destructive");
     });
+
+    it("classifies destructive FLAGS on otherwise-safe programs as destructive", () => {
+      expect(classifyShellRisk("git reset --hard")).toMatchObject({ level: "destructive", program: "git" });
+      expect(classifyShellRisk("git reset --hard origin/main")).toMatchObject({ level: "destructive", program: "git" });
+      expect(classifyShellRisk("git clean -fdx")).toMatchObject({ level: "destructive", program: "git" });
+      expect(classifyShellRisk("git checkout --force main")).toMatchObject({ level: "destructive", program: "git" });
+      expect(classifyShellRisk("find . -delete")).toMatchObject({ level: "destructive", program: "find" });
+    });
+
+    it("keeps benign git/find invocations safe (no flag false-positives)", () => {
+      expect(classifyShellRisk("git status")).toMatchObject({ level: "safe", program: "git" });
+      expect(classifyShellRisk("git reset HEAD file.txt")).toMatchObject({ level: "safe", program: "git" });
+      expect(classifyShellRisk("git clean -n")).toMatchObject({ level: "safe", program: "git" });
+      expect(classifyShellRisk("find . -name pattern")).toMatchObject({ level: "safe", program: "find" });
+    });
   });
 
   // ─── getApprovalRequiredReasonForExecCommand ───
@@ -108,10 +123,18 @@ describe("friday-agent-tool-risk", () => {
       ).toContain("token");
     });
 
+    it("requires approval for destructive flags on otherwise-safe programs", () => {
+      expect(getApprovalRequiredReasonForExecCommand("git reset --hard")).toContain("approval");
+      expect(getApprovalRequiredReasonForExecCommand("git clean -fdx")).toContain("approval");
+      expect(getApprovalRequiredReasonForExecCommand("find . -delete")).toContain("approval");
+    });
+
     it("allows safe read-only commands", () => {
       expect(getApprovalRequiredReasonForExecCommand("ls -la")).toBeNull();
       expect(getApprovalRequiredReasonForExecCommand("cat file.txt")).toBeNull();
       expect(getApprovalRequiredReasonForExecCommand("git status")).toBeNull();
+      expect(getApprovalRequiredReasonForExecCommand("git reset HEAD file.txt")).toBeNull();
+      expect(getApprovalRequiredReasonForExecCommand("git clean -n")).toBeNull();
     });
 
     it("returns null for empty command", () => {

--- a/test/unit/agent/runtime/friday-agent-tool-risk.test.ts
+++ b/test/unit/agent/runtime/friday-agent-tool-risk.test.ts
@@ -92,6 +92,19 @@ describe("friday-agent-tool-risk", () => {
       expect(classifyShellRisk("find . -delete")).toMatchObject({ level: "destructive", program: "find" });
     });
 
+    it("detects destructive flags even behind git GLOBAL options (the common agentic form)", () => {
+      // git global options (-C <path>, -c k=v, --no-pager, --git-dir=…) shift the subcommand;
+      // these must NOT bypass the gate. (BLOCKED_SHELL_PATTERNS rejects metachars, so paths here
+      // are plain.)
+      expect(classifyShellRisk("git -C repo reset --hard")).toMatchObject({ level: "destructive", program: "git" });
+      expect(classifyShellRisk("git --no-pager clean -fdx")).toMatchObject({ level: "destructive", program: "git" });
+      expect(classifyShellRisk("git -c core.editor=vi reset --hard")).toMatchObject({ level: "destructive", program: "git" });
+      expect(classifyShellRisk("git --git-dir=somedir clean -fd")).toMatchObject({ level: "destructive", program: "git" });
+      expect(classifyShellRisk("git --work-tree wt checkout --force main")).toMatchObject({ level: "destructive", program: "git" });
+      // benign subcommand behind a global option stays safe
+      expect(classifyShellRisk("git -C repo status")).toMatchObject({ level: "safe", program: "git" });
+    });
+
     it("keeps benign git/find invocations safe (no flag false-positives)", () => {
       expect(classifyShellRisk("git status")).toMatchObject({ level: "safe", program: "git" });
       expect(classifyShellRisk("git reset HEAD file.txt")).toMatchObject({ level: "safe", program: "git" });
@@ -127,6 +140,9 @@ describe("friday-agent-tool-risk", () => {
       expect(getApprovalRequiredReasonForExecCommand("git reset --hard")).toContain("approval");
       expect(getApprovalRequiredReasonForExecCommand("git clean -fdx")).toContain("approval");
       expect(getApprovalRequiredReasonForExecCommand("find . -delete")).toContain("approval");
+      // Behind git global options (the common agentic form) must also require approval.
+      expect(getApprovalRequiredReasonForExecCommand("git -C repo reset --hard")).toContain("approval");
+      expect(getApprovalRequiredReasonForExecCommand("git --no-pager clean -fdx")).toContain("approval");
     });
 
     it("allows safe read-only commands", () => {

--- a/test/unit/memory/guard/services/_helpers/create-guard-service.helper.ts
+++ b/test/unit/memory/guard/services/_helpers/create-guard-service.helper.ts
@@ -88,6 +88,8 @@ export function createMockPiiGuard(): FridayMemoryGuardPiiGuard {
       transformedContent: "Hello world",
       tagsToAdd: [],
     }),
+    // Default: passthrough (no PII found) — returns the value unchanged with no extra tags.
+    redactDeep: vi.fn().mockImplementation((value: unknown) => ({ value, tagsToAdd: [] })),
   };
 }
 

--- a/test/unit/memory/guard/services/friday-memory-guard-service-output-filter.test.ts
+++ b/test/unit/memory/guard/services/friday-memory-guard-service-output-filter.test.ts
@@ -70,6 +70,21 @@ describe("FridayMemoryOutputFilter", () => {
     expect(filtered.content).not.toContain("123-45-6789");
   });
 
+  it("redacts PII in item metadata and drops PII-bearing tags on read-back", () => {
+    const item = makeItem({
+      metadata: { note: "reach me at owner@example.com", count: 3, nested: { ssn: "SSN 123-45-6789" } },
+      tags: ["keep-me", "123-45-6789"], // 2nd tag is an SSN-pattern (charset-valid)
+    });
+    const filtered = filter.filterItem(item);
+    const meta = filtered.metadata as { note: string; count: number; nested: { ssn: string } };
+    expect(meta.note).toContain("[EMAIL]");
+    expect(meta.note).not.toContain("owner@example.com");
+    expect(meta.nested.ssn).toContain("[SSN_US]"); // nested redaction
+    expect(meta.count).toBe(3); // non-string untouched
+    expect(filtered.tags).toContain("keep-me"); // clean tag kept
+    expect(filtered.tags).not.toContain("123-45-6789"); // PII-bearing tag dropped
+  });
+
   // ─── filterSearchResults ───
 
   it("returns results as-is when within limits", () => {

--- a/test/unit/memory/guard/services/friday-memory-guard-service-pii-policy.test.ts
+++ b/test/unit/memory/guard/services/friday-memory-guard-service-pii-policy.test.ts
@@ -34,12 +34,18 @@ describe("FridayMemoryGuardService — PII Policy", () => {
 
   it("merges PII tags with existing tags", async () => {
     const { guard, core, piiGuard } = createGuardTestSetup();
-    vi.mocked(piiGuard.scanAndTransform).mockReturnValue({
-      matches: [{ type: "email", value: "user@test.com", start: 0, end: 13 }],
-      distinctTypes: ["email"],
-      transformedContent: "user@test.com",
-      tagsToAdd: ["pii.email"],
-    });
+    // Input-aware: the email-bearing content is PII; the clean "my-tag" is not (scanAndTransform
+    // is now called per-tag as well as on content).
+    vi.mocked(piiGuard.scanAndTransform).mockImplementation((s: string) =>
+      s.includes("@")
+        ? {
+            matches: [{ type: "email", value: "user@test.com", start: 0, end: 13 }],
+            distinctTypes: ["email"],
+            transformedContent: "user@test.com",
+            tagsToAdd: ["pii.email"],
+          }
+        : { matches: [], distinctTypes: [], transformedContent: s, tagsToAdd: [] },
+    );
 
     await guard.store("test-ns", "user@test.com", { tags: ["my-tag"] });
     const callArgs = vi.mocked(core.store).mock.calls[0];
@@ -50,12 +56,16 @@ describe("FridayMemoryGuardService — PII Policy", () => {
 
   it("does not duplicate existing PII tags", async () => {
     const { guard, core, piiGuard } = createGuardTestSetup();
-    vi.mocked(piiGuard.scanAndTransform).mockReturnValue({
-      matches: [{ type: "email", value: "user@test.com", start: 0, end: 13 }],
-      distinctTypes: ["email"],
-      transformedContent: "user@test.com",
-      tagsToAdd: ["pii.email"],
-    });
+    vi.mocked(piiGuard.scanAndTransform).mockImplementation((s: string) =>
+      s.includes("@")
+        ? {
+            matches: [{ type: "email", value: "user@test.com", start: 0, end: 13 }],
+            distinctTypes: ["email"],
+            transformedContent: "user@test.com",
+            tagsToAdd: ["pii.email"],
+          }
+        : { matches: [], distinctTypes: [], transformedContent: s, tagsToAdd: [] },
+    );
 
     await guard.store("test-ns", "user@test.com", { tags: ["pii.email", "existing"] });
     const callArgs = vi.mocked(core.store).mock.calls[0];
@@ -100,5 +110,50 @@ describe("FridayMemoryGuardService — PII Policy", () => {
     const passedTags = callArgs[2]?.tags;
     expect(passedTags).toContain("pii.email");
     expect(passedTags).toContain("pii.ssn_us");
+  });
+
+  it("redacts metadata, drops PII-bearing tags, and surfaces pii.* tags on store", async () => {
+    const { guard, core, piiGuard } = createGuardTestSetup();
+    // content is clean; the SSN-pattern tag is the PII tag.
+    vi.mocked(piiGuard.scanAndTransform).mockImplementation((s: string) => {
+      const isSsnTag = s === "123-45-6789";
+      return {
+        matches: isSsnTag ? [{ type: "ssn_us" as const, value: s, start: 0, end: s.length }] : [],
+        distinctTypes: isSsnTag ? ["ssn_us" as const] : [],
+        transformedContent: s,
+        tagsToAdd: isSsnTag ? ["pii.ssn_us"] : [],
+      };
+    });
+    // redactDeep redacts email-bearing metadata string values.
+    vi.mocked(piiGuard.redactDeep).mockImplementation((value: unknown) => {
+      if (value && typeof value === "object" && !Array.isArray(value)) {
+        const out: Record<string, unknown> = {};
+        let found = false;
+        for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+          if (typeof v === "string" && v.includes("@")) {
+            out[k] = "[EMAIL]";
+            found = true;
+          } else {
+            out[k] = v;
+          }
+        }
+        return { value: out, tagsToAdd: found ? ["pii.email"] : [] };
+      }
+      return { value, tagsToAdd: [] };
+    });
+
+    await guard.store("test-ns", "clean content", {
+      metadata: { note: "ping owner@test.com" },
+      tags: ["keep-me", "123-45-6789"],
+    });
+
+    const callArgs = vi.mocked(core.store).mock.calls[0];
+    const storedMeta = callArgs[2]?.metadata as Record<string, unknown> | undefined;
+    const storedTags = callArgs[2]?.tags as string[] | undefined;
+    expect(storedMeta?.note).toBe("[EMAIL]"); // metadata redacted in place
+    expect(storedTags).toContain("keep-me"); // clean tag kept
+    expect(storedTags).not.toContain("123-45-6789"); // PII-bearing tag dropped
+    expect(storedTags).toContain("pii.ssn_us"); // tag PII type surfaced
+    expect(storedTags).toContain("pii.email"); // metadata PII type surfaced
   });
 });

--- a/test/unit/memory/guard/services/friday-memory-guard-service-validation.test.ts
+++ b/test/unit/memory/guard/services/friday-memory-guard-service-validation.test.ts
@@ -558,15 +558,21 @@ describe("FridayMemoryGuardService — CX Review Fixes", () => {
         (_, i) => `tag${i}`,
       );
 
-      vi.mocked(piiGuard.scanAndTransform).mockReturnValue({
-        matches: [
-          { type: "email", value: "a@b.com", start: 0, end: 7 },
-          { type: "phone_us", value: "555-1234", start: 10, end: 18 },
-        ],
-        distinctTypes: ["email", "phone_us"],
-        transformedContent: "a@b.com & 555-1234",
-        tagsToAdd: ["pii.email", "pii.phone-us"],
-      });
+      // Input-aware: only the email/phone-bearing content is PII; the clean tagN tags are not
+      // (scanAndTransform is now called per-tag). Content yields 2 pii.* tags → 31 + 2 = 33 > 32.
+      vi.mocked(piiGuard.scanAndTransform).mockImplementation((s: string) =>
+        s.includes("@")
+          ? {
+              matches: [
+                { type: "email", value: "a@b.com", start: 0, end: 7 },
+                { type: "phone_us", value: "555-1234", start: 10, end: 18 },
+              ],
+              distinctTypes: ["email", "phone_us"],
+              transformedContent: "a@b.com & 555-1234",
+              tagsToAdd: ["pii.email", "pii.phone-us"],
+            }
+          : { matches: [], distinctTypes: [], transformedContent: s, tagsToAdd: [] },
+      );
 
       await expect(
         guard.store("test-ns", "a@b.com & 555-1234", { tags: existingTags }),
@@ -585,12 +591,16 @@ describe("FridayMemoryGuardService — CX Review Fixes", () => {
         (_, i) => `tag${i}`,
       );
 
-      vi.mocked(piiGuard.scanAndTransform).mockReturnValue({
-        matches: [{ type: "email", value: "a@b.com", start: 0, end: 7 }],
-        distinctTypes: ["email"],
-        transformedContent: "a@b.com",
-        tagsToAdd: ["pii.email"],
-      });
+      vi.mocked(piiGuard.scanAndTransform).mockImplementation((s: string) =>
+        s.includes("@")
+          ? {
+              matches: [{ type: "email", value: "a@b.com", start: 0, end: 7 }],
+              distinctTypes: ["email"],
+              transformedContent: "a@b.com",
+              tagsToAdd: ["pii.email"],
+            }
+          : { matches: [], distinctTypes: [], transformedContent: s, tagsToAdd: [] },
+      );
 
       await guard.store("test-ns", "a@b.com", { tags: existingTags });
       expect(core.store).toHaveBeenCalled();

--- a/test/unit/memory/guard/services/friday-memory-pii-guard.test.ts
+++ b/test/unit/memory/guard/services/friday-memory-pii-guard.test.ts
@@ -160,4 +160,47 @@ describe("FridayMemoryPiiGuard", () => {
     const result = guard.scanAndTransform("Call +1-555-234-5678");
     expect(result.distinctTypes).toContain("phone_us");
   });
+
+  // ─── redactDeep (metadata + tags) ───
+
+  describe("redactDeep", () => {
+    const guard = createFridayMemoryPiiGuard("redact");
+
+    it("redacts PII in string values of a metadata object (incl nested)", () => {
+      const { value, tagsToAdd } = guard.redactDeep({
+        note: "reach me at user@example.com",
+        nested: { phone: "555-234-5678", count: 7 },
+        when: "tomorrow",
+      });
+      const meta = value as { note: string; nested: { phone: string; count: number }; when: string };
+      expect(meta.note).toContain("[EMAIL]");
+      expect(meta.note).not.toContain("user@example.com");
+      expect(meta.nested.phone).toContain("[PHONE_US]");
+      expect(meta.nested.count).toBe(7); // non-strings untouched
+      expect(meta.when).toBe("tomorrow"); // clean strings untouched
+      expect(tagsToAdd).toEqual(expect.arrayContaining(["pii.email", "pii.phone_us"]));
+    });
+
+    it("redacts PII in tag strings", () => {
+      const { value, tagsToAdd } = guard.redactDeep(["project-x", "ssn 123-45-6789"]);
+      const tags = value as string[];
+      expect(tags[0]).toBe("project-x");
+      expect(tags[1]).toContain("[SSN_US]");
+      expect(tags[1]).not.toContain("123-45-6789");
+      expect(tagsToAdd).toContain("pii.ssn_us");
+    });
+
+    it("returns clean values unchanged with no extra tags", () => {
+      const { value, tagsToAdd } = guard.redactDeep({ a: "no pii", b: [1, 2, "also clean"] });
+      expect(value).toEqual({ a: "no pii", b: [1, 2, "also clean"] });
+      expect(tagsToAdd).toHaveLength(0);
+    });
+
+    it("in tag mode, reports PII tags without altering values (non-redact)", () => {
+      const tagGuard = createFridayMemoryPiiGuard("tag");
+      const { value, tagsToAdd } = tagGuard.redactDeep({ note: "user@example.com" });
+      expect((value as { note: string }).note).toBe("user@example.com"); // not redacted in tag mode
+      expect(tagsToAdd).toContain("pii.email");
+    });
+  });
 });


### PR DESCRIPTION
Closes two ANNEX B6 P2 tightenings not covered by the parallel orchestrator's merged B6 track (#388 completion / #390 evidence-durability / self-heal-stub removal).

## Dangerous shell flags require approval
Shell risk was classified by **program name** only, so `git reset --hard`, `git clean -fdx`, `git checkout --force`, and `find . -delete` slipped through as "safe" (no approval) because `git`/`find` are name-allowlisted.
- New `detectDangerousShellFlagReason(program, parts)` flags those destructive flag combinations.
- Wired into BOTH `classifyShellRisk` (→ `destructive`) and `getApprovalRequiredReasonForExecCommand` (→ approval gate).
- Benign git/find (`git status`, `git reset HEAD`, `git clean -n`, `find . -name …`) stay `safe` (no false-positives).

## PII redaction covers content, metadata, AND tags
Previously only `content` was scanned/redacted; caller-supplied metadata + tags (reachable via the HTTP store route) passed through raw.
- New `piiGuard.redactDeep(value)` recursively redacts PII in the string leaves of metadata objects and tag arrays (depth-bounded; non-strings untouched).
- **Store path**: redacts metadata + tags, merges discovered `pii.*` tags, and block-mode now fires on metadata/tag PII too.
- **Read path** (output-filter): redacts metadata + tags on read-back (defense in depth for pre-existing items).

## Verification
- Both paths proven: dangerous-flag → destructive/approval AND benign → safe/null; redactDeep redacts email/phone/SSN in nested metadata + tags, leaves clean values + non-strings untouched, tag-vs-redact mode.
- 414 memory/tool-risk/adversarial tests pass; `tsc` clean; `git diff --check` clean; secrets baseline line-number refresh (no new secrets).

refs: B6-shell-flags, B6-pii-metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)