### PR TITLE
fix(agent): fail-safe git global-option parsing in shell-risk gate (ANNEX B6 follow-up)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -603,7 +603,7 @@
         "filename": "test/unit/agent/runtime/friday-agent-tool-risk.test.ts",
         "hashed_secret": "d14babe099a92466c4efa49400806772a6c097cd",
         "is_verified": false,
-        "line_number": 201
+        "line_number": 227
       }
     ],
     "test/unit/api/auth/friday-auth-middleware.test.ts": [
@@ -1124,5 +1124,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-29T00:48:14Z"
+  "generated_at": "2026-05-29T01:42:24Z"
 }

--- a/src/agent/runtime/friday-agent-tool-risk.ts
+++ b/src/agent/runtime/friday-agent-tool-risk.ts
@@ -141,22 +141,82 @@ function listPotentialFilePaths(text: string): string[] {
   return [...new Set(text.match(/\b[\w./-]+\.[A-Za-z0-9]+\b/g) ?? [])];
 }
 
-// git global options that precede the subcommand; the value-taking ones (given without `=`)
-// also consume the following token. Used to locate the real subcommand for forms like
-// `git -C /repo reset --hard` or `git --no-pager clean -fdx`.
+// git global options that precede the subcommand and, when given in their space-form
+// (without `=`), ALSO consume the following token. Used to locate the real subcommand for
+// forms like `git -C /repo reset --hard`. NOTE: this set is an optimization for the precise
+// path, not a security boundary — an option we forget to list does NOT open a bypass, because
+// `gitSubcommandStart` fails safe on anything it does not recognize (see below).
 const GIT_GLOBAL_OPTS_WITH_VALUE = new Set([
   "-C", "-c", "--git-dir", "--work-tree", "--namespace", "--exec-path", "--super-prefix",
+  // plumbing options that take a separate-token value (Reviewer-A bypass class):
+  "--config-env", "--shallow-file", "--attr-source",
 ]);
+
+// git global options that take NO value, so the next token is still a global option or the
+// subcommand. Recognizing the common ones keeps the precise path in play; an unrecognized
+// flag simply falls through to the fail-safe scan below.
+const GIT_GLOBAL_FLAGS_NO_VALUE = new Set([
+  "--no-pager", "--paginate", "-p", "--bare", "--no-replace-objects", "--literal-pathspecs",
+  "--glob-pathspecs", "--noglob-pathspecs", "--icase-pathspecs", "--no-optional-locks",
+  "--no-lazy-fetch", "--no-advice", "--version", "--html-path", "--man-path", "--info-path",
+]);
+
+// Sentinel: a leading git global option we do NOT recognize. We cannot reliably locate the
+// subcommand by position (an unknown option might consume the next token, masquerading its
+// value as the subcommand — the exact `git --shallow-file <v> reset --hard` bypass class).
+// The caller must fail safe and scan the whole token list instead of trusting position.
+const GIT_SUBCOMMAND_UNKNOWN_OPT = -2;
 
 function gitSubcommandStart(parts: readonly string[]): number {
   let i = 1;
   while (i < parts.length) {
     const tok = parts[i]!;
     if (!tok.startsWith("-")) return i; // first non-option token is the subcommand
-    // `--opt=value` is a single token; `-C <v>` / `--git-dir <v>` consume the next token too.
-    i += GIT_GLOBAL_OPTS_WITH_VALUE.has(tok) ? 2 : 1;
+    if (tok.includes("=")) { // `--opt=value` carries its value inline — single token
+      i += 1;
+      continue;
+    }
+    if (GIT_GLOBAL_OPTS_WITH_VALUE.has(tok)) { // `-C <v>` / `--git-dir <v>` consume next token
+      i += 2;
+      continue;
+    }
+    if (GIT_GLOBAL_FLAGS_NO_VALUE.has(tok)) { // known value-less flag — skip just the flag
+      i += 1;
+      continue;
+    }
+    return GIT_SUBCOMMAND_UNKNOWN_OPT; // unrecognized global option → fail safe, do not guess
   }
   return -1;
+}
+
+// Precise per-subcommand check: given a known subcommand and the tokens that follow it,
+// return an approval reason for a destructive flag combination, else null.
+function gitDestructiveReason(sub: string, rest: readonly string[]): string | null {
+  const s = sub.toLowerCase();
+  const hasForce = rest.some((a) => a === "-f" || a === "--force");
+  if (s === "reset" && rest.some((a) => a === "--hard")) {
+    return "`git reset --hard` irreversibly discards uncommitted changes and requires explicit approval in the current run context.";
+  }
+  if (s === "clean" && rest.some((a) => /^-[a-z]*f[a-z]*$/i.test(a) || a === "--force")) {
+    return "`git clean -f…` permanently deletes untracked files and requires explicit approval in the current run context.";
+  }
+  if ((s === "checkout" || s === "restore" || s === "switch") && (hasForce || rest.some((a) => a === "--hard"))) {
+    return `\`git ${s} --force\` discards local changes and requires explicit approval in the current run context.`;
+  }
+  return null;
+}
+
+// Fail-safe scan used only when an unrecognized leading global option is present: treat each
+// token as a candidate subcommand and check the tokens after it, so a destructive combination
+// cannot hide behind an option we don't model. Because this only runs when a leading option is
+// unrecognized, it does NOT produce the `git commit -m "reset --hard"` false-positive (there the
+// subcommand `commit` is found by position and the scan is never reached).
+function gitDestructiveReasonByScan(tokens: readonly string[]): string | null {
+  for (let k = 0; k < tokens.length; k++) {
+    const reason = gitDestructiveReason(tokens[k]!, tokens.slice(k + 1));
+    if (reason) return reason;
+  }
+  return null;
 }
 
 /**
@@ -165,27 +225,21 @@ function gitSubcommandStart(parts: readonly string[]): number {
  * operations like `git reset --hard`, `git clean -fdx`, and `find . -delete` slip through
  * without approval; this closes that flag-vs-program gap. Leading git global options
  * (`git -C <path> …`, `git --no-pager …`) are skipped so the subcommand is found regardless
- * of the invocation form. Returns an approval reason string when a dangerous flag combination
- * is present, else null.
+ * of the invocation form; an UNRECOGNIZED leading option fails safe to a full-token scan so
+ * obscure plumbing options (`git --shallow-file <v> reset --hard`) cannot hide a destructive
+ * subcommand. Returns an approval reason string when a dangerous flag combination is present,
+ * else null.
  */
 function detectDangerousShellFlagReason(program: string, parts: readonly string[]): string | null {
   if (program === "git") {
     const subIdx = gitSubcommandStart(parts);
+    if (subIdx === GIT_SUBCOMMAND_UNKNOWN_OPT) {
+      return gitDestructiveReasonByScan(parts.slice(1));
+    }
     if (subIdx === -1) {
       return null;
     }
-    const sub = parts[subIdx]?.toLowerCase() ?? "";
-    const rest = parts.slice(subIdx + 1);
-    const hasForce = rest.some((a) => a === "-f" || a === "--force");
-    if (sub === "reset" && rest.some((a) => a === "--hard")) {
-      return "`git reset --hard` irreversibly discards uncommitted changes and requires explicit approval in the current run context.";
-    }
-    if (sub === "clean" && rest.some((a) => /^-[a-z]*f[a-z]*$/i.test(a) || a === "--force")) {
-      return "`git clean -f…` permanently deletes untracked files and requires explicit approval in the current run context.";
-    }
-    if ((sub === "checkout" || sub === "restore" || sub === "switch") && (hasForce || rest.some((a) => a === "--hard"))) {
-      return `\`git ${sub} --force\` discards local changes and requires explicit approval in the current run context.`;
-    }
+    return gitDestructiveReason(parts[subIdx] ?? "", parts.slice(subIdx + 1));
   }
   if (program === "find") {
     if (parts.slice(1).some((a) => a === "-delete")) {

--- a/test/unit/agent/runtime/friday-agent-tool-risk.test.ts
+++ b/test/unit/agent/runtime/friday-agent-tool-risk.test.ts
@@ -105,6 +105,29 @@ describe("friday-agent-tool-risk", () => {
       expect(classifyShellRisk("git -C repo status")).toMatchObject({ level: "safe", program: "git" });
     });
 
+    it("fails safe on UNRECOGNIZED git global options (no default-allow on unknown options)", () => {
+      // Reviewer-A bypass class: plumbing options taking a separate-token value were treated as
+      // single-token, shifting their value into the subcommand slot so `reset --hard` was never
+      // inspected. These known plumbing options must now classify destructive.
+      expect(classifyShellRisk("git --shallow-file snap reset --hard")).toMatchObject({ level: "destructive", program: "git" });
+      expect(classifyShellRisk("git --config-env k=v reset --hard")).toMatchObject({ level: "destructive", program: "git" });
+      expect(classifyShellRisk("git --attr-source tree clean -fdx")).toMatchObject({ level: "destructive", program: "git" });
+      // A genuinely unknown / future global option must NOT default-allow: the destructive
+      // subcommand behind it is still caught by the fail-safe scan (this is the core no-default-allow
+      // guarantee — not just an expanded allow-list of named options).
+      expect(classifyShellRisk("git --totally-unknown-opt val reset --hard")).toMatchObject({ level: "destructive", program: "git" });
+      // ...but an unrecognized option in front of a benign subcommand stays safe (no over-block).
+      expect(classifyShellRisk("git --shallow-file snap status")).toMatchObject({ level: "safe", program: "git" });
+      expect(classifyShellRisk("git --totally-unknown-opt val status")).toMatchObject({ level: "safe", program: "git" });
+    });
+
+    it("does not false-positive on destructive tokens inside a benign subcommand's args", () => {
+      // The fail-safe scan only runs behind an UNRECOGNIZED leading option; `commit` is found by
+      // position, so a message that merely mentions reset --hard is not treated as a reset.
+      expect(classifyShellRisk('git commit -m "reset --hard"')).toMatchObject({ level: "safe", program: "git" });
+      expect(classifyShellRisk("git --no-pager commit -m wip")).toMatchObject({ level: "safe", program: "git" });
+    });
+
     it("keeps benign git/find invocations safe (no flag false-positives)", () => {
       expect(classifyShellRisk("git status")).toMatchObject({ level: "safe", program: "git" });
       expect(classifyShellRisk("git reset HEAD file.txt")).toMatchObject({ level: "safe", program: "git" });
@@ -143,6 +166,9 @@ describe("friday-agent-tool-risk", () => {
       // Behind git global options (the common agentic form) must also require approval.
       expect(getApprovalRequiredReasonForExecCommand("git -C repo reset --hard")).toContain("approval");
       expect(getApprovalRequiredReasonForExecCommand("git --no-pager clean -fdx")).toContain("approval");
+      // Behind obscure / unknown global options must ALSO require approval (no default-allow).
+      expect(getApprovalRequiredReasonForExecCommand("git --shallow-file snap reset --hard")).toContain("approval");
+      expect(getApprovalRequiredReasonForExecCommand("git --totally-unknown-opt val reset --hard")).toContain("approval");
     });
 
     it("allows safe read-only commands", () => {


### PR DESCRIPTION
## What
Closes the residual default-allow bypass in the dangerous-shell-flag approval gate that shipped with the now-merged ANNEX B6 bundle (#395). Reviewer A flagged it on #395; the orchestrator merged #395 as-is, so this is a clean follow-up off current `main`.

## The gap
`gitSubcommandStart` located the git subcommand by skipping a fixed allow-list of global options and treating any **unlisted** leading option as single-token. Git plumbing options that take a **separate-token value** therefore shifted their value into the subcommand slot:

```
git --shallow-file snap reset --hard   # classified SAFE, no approval (BYPASS)
git --config-env  k=v   reset --hard   # same
git --attr-source tree  reset --hard   # same
```

Common forms (`-C`, `-c`, `--no-pager`, `--git-dir=`, `--work-tree`) were already covered, so reachability was low — but it was a **default-allow fallback on unknown options**, which the ANNEX repair goal explicitly forbids ("do not close with: default-allow fallback").

## The fix
`gitSubcommandStart` now fails safe:
- recognized value-options skip their value (`-C <v>` → +2);
- recognized value-less flags skip one token (`--no-pager` → +1);
- `--opt=value` is one token;
- **any UNRECOGNIZED leading option** drops to a full-token scan that detects a destructive `(subcommand, flag)` combination regardless of the options preceding it.

The named option sets are now an **optimization for the precise path, not a security boundary** — a forgotten/future option degrades to the scan, never to a bypass. This converts Reviewer A's "default-allow on unknown options" into fail-safe behavior.

No false-positive: the scan runs **only** behind an unrecognized leading option, so `git commit -m "reset --hard"` stays safe (the `commit` subcommand is found by position; the scan is never reached).

## Verification
- Focused suite `friday-agent-tool-risk.test.ts`: **53 pass** (incl. new probes for `--shallow-file`/`--config-env`/`--attr-source`, a genuinely-unknown option, no-over-block, and the commit-message false-positive guard).
- Blast radius `test/unit/agent/{runtime,tools}`: **1263 pass**, no type errors.
- `git diff --check` clean; eslint 0 errors; detect-secrets no new findings (baseline line-number refresh only).

Proves both paths: unsafe (obscure + unknown options behind `reset --hard`/`clean -fdx`) requires approval; safe (benign subcommands behind the same options, `reset HEAD file`, `clean -n`, commit messages) stays safe.