### PR TITLE
fix(agent): identify path-qualified programs by basename in shell-risk gate (ANNEX B6 follow-up)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -603,7 +603,7 @@
         "filename": "test/unit/agent/runtime/friday-agent-tool-risk.test.ts",
         "hashed_secret": "d14babe099a92466c4efa49400806772a6c097cd",
         "is_verified": false,
-        "line_number": 227
+        "line_number": 251
       }
     ],
     "test/unit/api/auth/friday-auth-middleware.test.ts": [
@@ -1124,5 +1124,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-29T01:42:24Z"
+  "generated_at": "2026-05-29T02:06:35Z"
 }

--- a/src/agent/runtime/friday-agent-tool-risk.ts
+++ b/src/agent/runtime/friday-agent-tool-risk.ts
@@ -46,6 +46,16 @@ const BLOCKED_SHELL_PATTERNS = [
   /[\u0000-\u001f\u007f-\u009f]/,   // control characters
 ];
 
+// Normalize a program token to its bare, lowercased basename so a path-qualified invocation
+// (`/usr/bin/git`, `./scripts/rm`, `"git"`) is identified the same as the bare program name.
+// Mirrors the exec tool's `commandBaseName` so the approval gate and the spawn path agree on
+// program identity — otherwise a path prefix silently defeats every program-keyed check
+// (DESTRUCTIVE_PROGRAMS, SAFE_PROGRAMS, and the dangerous-flag gate).
+function normalizeProgramName(token: string | undefined): string {
+  const normalized = (token ?? "").replace(/^["']+|["']+$/g, "").replace(/\\/g, "/");
+  return normalized.split("/").at(-1)?.toLowerCase() ?? "";
+}
+
 /**
  * Classify the risk level of a shell command.
  */
@@ -63,7 +73,7 @@ export function classifyShellRisk(command: string): FridayShellRiskClassificatio
   }
 
   const parts = trimmed.split(/\s+/);
-  const program = parts[0]?.toLowerCase() ?? "";
+  const program = normalizeProgramName(parts[0]);
 
   // Destructive programs always require approval
   // Also match mkfs.* variants (mkfs.ext4, mkfs.xfs, etc.)
@@ -289,7 +299,7 @@ export function getApprovalRequiredReasonForExecCommand(command: string): string
   }
 
   const parts = trimmed.split(/\s+/);
-  const program = parts[0]?.toLowerCase() ?? "";
+  const program = normalizeProgramName(parts[0]);
   const lowerCommand = trimmed.toLowerCase();
   const touchesProtectedArtifact = listPotentialFilePaths(trimmed)
     .some((filePath) => requiresApprovalForProtectedArtifactPath(filePath));

--- a/test/unit/agent/runtime/friday-agent-tool-risk.test.ts
+++ b/test/unit/agent/runtime/friday-agent-tool-risk.test.ts
@@ -134,6 +134,20 @@ describe("friday-agent-tool-risk", () => {
       expect(classifyShellRisk("git clean -n")).toMatchObject({ level: "safe", program: "git" });
       expect(classifyShellRisk("find . -name pattern")).toMatchObject({ level: "safe", program: "find" });
     });
+
+    it("identifies path-qualified programs by basename (no path-prefix bypass)", () => {
+      // A path prefix must not defeat program identification — these used to classify as
+      // guarded/safe because parts[0] was not basename-normalized.
+      expect(classifyShellRisk("/usr/bin/git reset --hard")).toMatchObject({ level: "destructive", program: "git" });
+      expect(classifyShellRisk("/bin/git clean -fdx")).toMatchObject({ level: "destructive", program: "git" });
+      expect(classifyShellRisk("/usr/bin/find . -delete")).toMatchObject({ level: "destructive", program: "find" });
+      expect(classifyShellRisk("/bin/rm -rf /data")).toMatchObject({ level: "destructive", program: "rm" });
+      expect(classifyShellRisk("/sbin/mkfs.ext4 /dev/sda1")).toMatchObject({ level: "destructive", program: "mkfs.ext4" });
+      expect(classifyShellRisk("./scripts/rm something")).toMatchObject({ level: "destructive", program: "rm" });
+      // ...but a path-qualified SAFE program stays safe (no over-block).
+      expect(classifyShellRisk("/usr/bin/git status")).toMatchObject({ level: "safe", program: "git" });
+      expect(classifyShellRisk("/bin/ls -la")).toMatchObject({ level: "safe", program: "ls" });
+    });
   });
 
   // ─── getApprovalRequiredReasonForExecCommand ───
@@ -171,12 +185,22 @@ describe("friday-agent-tool-risk", () => {
       expect(getApprovalRequiredReasonForExecCommand("git --totally-unknown-opt val reset --hard")).toContain("approval");
     });
 
+    it("requires approval for path-qualified destructive programs (no path-prefix bypass)", () => {
+      expect(getApprovalRequiredReasonForExecCommand("/usr/bin/git reset --hard")).toContain("approval");
+      expect(getApprovalRequiredReasonForExecCommand("/usr/bin/find . -delete")).toContain("approval");
+      expect(getApprovalRequiredReasonForExecCommand("/bin/rm -rf /data")).toContain("approval");
+      expect(getApprovalRequiredReasonForExecCommand("./scripts/rm thing")).toContain("approval");
+    });
+
     it("allows safe read-only commands", () => {
       expect(getApprovalRequiredReasonForExecCommand("ls -la")).toBeNull();
       expect(getApprovalRequiredReasonForExecCommand("cat file.txt")).toBeNull();
       expect(getApprovalRequiredReasonForExecCommand("git status")).toBeNull();
       expect(getApprovalRequiredReasonForExecCommand("git reset HEAD file.txt")).toBeNull();
       expect(getApprovalRequiredReasonForExecCommand("git clean -n")).toBeNull();
+      // path-qualified safe programs stay safe (no over-block).
+      expect(getApprovalRequiredReasonForExecCommand("/usr/bin/git status")).toBeNull();
+      expect(getApprovalRequiredReasonForExecCommand("/bin/ls -la")).toBeNull();
     });
 
     it("returns null for empty command", () => {


### PR DESCRIPTION
## What
Closes a pre-existing default-allow bypass in the shell-approval gate, surfaced by the adversarial reviewer of #396 and authorized as a follow-up.

## The gap
The gate identified the program via `parts[0].toLowerCase()` with **no basename normalization**, so a path-qualified binary skipped every program-keyed check (`DESTRUCTIVE_PROGRAMS`, `SAFE_PROGRAMS`, and the dangerous-flag detector keyed on `program === "git"`/`"find"`):

```
/usr/bin/git reset --hard     # classified guarded, no approval (BYPASS)
/bin/git clean -fdx           # same
/usr/bin/find . -delete       # same
/bin/rm -rf /data             # same — defeats the DESTRUCTIVE_PROGRAMS rm gate
```

Verified these actually execute. This is **pre-existing on `origin/main`** (the `program === "git"` literal and `parts[0]` keying predate all recent B6 work) and is **more reachable** than the obscure plumbing options closed in #396 — an agent emitting a path-qualified binary is far more plausible. The exec tool already basename-normalizes for its path-operand checks (`commandBaseName`); the risk module did not, so the approval gate and the spawn path disagreed on program identity.

## The fix
Add `normalizeProgramName` (mirrors `commandBaseName`: strip surrounding quotes, normalize separators, take the lowercased basename) and apply it where `program` is derived in **both** `classifyShellRisk` and `getApprovalRequiredReasonForExecCommand`, **before** the existing `mkfs.ext4 → mkfs` `.`-split (so `/sbin/mkfs.ext4` → `mkfs.ext4` → `mkfs` still resolves). `gitSubcommandStart` already scans from `parts[1]`, so the path prefix on `parts[0]` no longer matters.

Result: path-qualified destructive programs require approval; path-qualified **safe** programs (`/usr/bin/git status`, `/bin/ls`) stay safe (no over-block).

## Verification
- Focused `friday-agent-tool-risk.test.ts`: **55 pass** (new probes for path-qualified git/find/rm/mkfs + `./scripts/rm` destructive, and `/usr/bin/git status` / `/bin/ls` safe).
- Blast radius `test/unit/agent/{runtime,tools}`: **1265 pass**, no type errors.
- `git diff --check` clean; eslint 0 errors; detect-secrets line-number refresh only (no new secret).

Proves both paths: unsafe (path-qualified destructive) requires approval; safe (path-qualified read-only) stays safe. No regression — bare-program behavior is unchanged (`normalizeProgramName("git") === "git"`).