### PR TITLE
audit C: run-level workflow completion-verification enforcement + durable persistence (Stage 1 + 2B)

### DIFF
--- a/context/MEMORY.md
+++ b/context/MEMORY.md
@@ -18,4 +18,4 @@
 - Tool call summary (`src/agent/services/friday-tool-call-summary.ts`) captures privacy-safe tool execution metadata (arg keys only, no values) for observability and world model training data.
 - Warn-once pattern is used across 7+ modules (hub-bootstrap, auth, memory, system, http-server, workspace-context, unix-socket-bridge) to deduplicate runtime warnings without losing critical signals.
 - OpenAI Responses API (`openai-responses`) streaming is now supported alongside `openai-completions` in the agent LLM client.
-- Database migration count: 88 (latest: v088-auto-fix-rollback-receipt).
+- Database migration count: 89 (latest: v089-workflow-completion-verification).

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -3531,6 +3531,14 @@ export async function createFridayHub(
       // repository or pretending unknown runs were healthy.
       getWorkflowRunEvidenceStatus: (runId) =>
         workflowRuntime.evidence.getRunEvidenceStatus(runId),
+      // Audit C: bridge the runtime's ORTHOGONAL run-level
+      // completion-verification truth (a side-effect node lacking
+      // deterministic evidence → `proof_pending`). verifyClaim refuses a proof
+      // claim backed by a non-verified run for a reason DISTINCT from
+      // persistence durability. Wiring it here makes the run-level enforcement
+      // live in production (the verifier is fail-closed once wired).
+      getWorkflowRunCompletionVerification: (runId) =>
+        workflowRuntime.evidence.getRunCompletionVerification(runId),
     });
     return { service, disabledReason: null };
   })();

--- a/src/state/sqlite/migrations/index.ts
+++ b/src/state/sqlite/migrations/index.ts
@@ -87,6 +87,7 @@ import { V085_TASK_WORKFLOW_CHANNEL_COMMANDS_MIGRATION } from "./v085-task-workf
 import { V086_WORKFLOW_EVIDENCE_FAIL_CLOSED_MIGRATION } from "./v086-workflow-evidence-fail-closed.js";
 import { V087_ROLLBACK_MATRIX_CLOSEOUT_RECEIPT_MIGRATION } from "./v087-rollback-matrix-closeout-receipt.js";
 import { V088_AUTO_FIX_ROLLBACK_RECEIPT_MIGRATION } from "./v088-auto-fix-rollback-receipt.js";
+import { V089_WORKFLOW_COMPLETION_VERIFICATION_MIGRATION } from "./v089-workflow-completion-verification.js";
 
 /**
  * Ordered migration list, always ascending by version.
@@ -180,6 +181,7 @@ export const FRIDAY_SQLITE_MIGRATIONS: readonly FridaySqliteMigration[] = [
   V086_WORKFLOW_EVIDENCE_FAIL_CLOSED_MIGRATION,
   V087_ROLLBACK_MATRIX_CLOSEOUT_RECEIPT_MIGRATION,
   V088_AUTO_FIX_ROLLBACK_RECEIPT_MIGRATION,
+  V089_WORKFLOW_COMPLETION_VERIFICATION_MIGRATION,
 ];
 
 export { V003_PROVIDER_USAGE_COST_ROUTING_MIGRATION };

--- a/src/state/sqlite/migrations/v089-workflow-completion-verification.ts
+++ b/src/state/sqlite/migrations/v089-workflow-completion-verification.ts
@@ -1,0 +1,35 @@
+import { computeFridayMigrationChecksum } from "./friday-migration.types.js";
+import type { FridaySqliteMigration } from "./friday-migration.types.js";
+
+export const V089_WORKFLOW_COMPLETION_VERIFICATION_SQL = `
+-- V089: Audit C Stage 2(B) — durable workflow run completion-verification label.
+--
+-- Stage 1 (PR #398) tracks a RUN-LEVEL completion-verification truth (the worst
+-- node label observed: verified / model_assessed_unverified / proof_pending /
+-- recovery_needed / blocked) ORTHOGONAL to evidence-persistence health
+-- (evidenceStatus). That aggregate was process-lifetime in-memory only, so a
+-- side-effect run that settled \`proof_pending\` would read \`verified\` after a
+-- hub restart (unknown -> verified default) — the same amnesia evidenceStatus
+-- historically had. This persists the label so the truth survives restarts.
+--
+--   * workflow_runs.completion_verification — nullable TEXT; NULL means "no
+--     non-verified node was ever recorded" (a clean verified run). A
+--     non-verified run persists its worst label here. Legacy rows stay NULL
+--     and rehydrate as verified, which is correct for runs that predate the
+--     column. This does NOT change whether a node ran, only the orthogonal
+--     completion-verification truth; the verifier reads it fail-closed.
+
+ALTER TABLE workflow_runs
+  ADD COLUMN completion_verification TEXT;
+`;
+
+const V089_CHECKSUM = computeFridayMigrationChecksum(
+  V089_WORKFLOW_COMPLETION_VERIFICATION_SQL,
+);
+
+export const V089_WORKFLOW_COMPLETION_VERIFICATION_MIGRATION: FridaySqliteMigration = {
+  version: 89,
+  name: "v089-workflow-completion-verification",
+  sql: V089_WORKFLOW_COMPLETION_VERIFICATION_SQL,
+  checksum: V089_CHECKSUM,
+};

--- a/src/task-workflows/friday-task-workflow-service.ts
+++ b/src/task-workflows/friday-task-workflow-service.ts
@@ -96,6 +96,7 @@ import type {
   FridayTaskWorkflowSupervisorMode,
   FridayTaskWorkflowSupervisorOverview,
   FridayTaskWorkflowVerifyClaimInput,
+  FridayTaskWorkflowWorkflowRunCompletionVerification,
   FridayTaskWorkflowWorkflowRunEvidenceStatus,
 } from "./friday-task-workflow.types.js";
 
@@ -149,6 +150,28 @@ export interface CreateFridayTaskWorkflowServiceDeps {
   readonly getWorkflowRunEvidenceStatus?: (
     runId: string,
   ) => FridayTaskWorkflowWorkflowRunEvidenceStatus | null;
+  /**
+   * Audit C: workflow run completion-verification lookup, ORTHOGONAL to
+   * `getWorkflowRunEvidenceStatus`. Returns the upstream run's
+   * completion-verification truth (or `null` when the run id cannot be
+   * resolved). The hub wires this to the workflow runtime's
+   * `evidence.getRunCompletionVerification`; tests inject a deterministic
+   * fake. FAIL-CLOSED and SYMMETRIC with the evidence-status lookup: a claim
+   * holding a `workflow_run_evidence` ref cannot reach verified unless this
+   * lookup is wired AND every referenced run is `verified`. `verifyClaim`
+   * refuses a non-`verified` run (a side-effect node lacking deterministic
+   * evidence → `proof_pending`) — and equally refuses when the lookup is
+   * absent (never-silent) — with an error code DISTINCT from the persistence
+   * path. Losing the hub wiring therefore becomes a LOUD refuse in production,
+   * never a silent non-enforcement. The check runs AFTER the persistence check
+   * so a missing-persistence-lookup refusal preserves its existing error code.
+   * (The wired runtime aggregate is process-lifetime in-memory — see
+   * `getRunCompletionVerification`; persisting the label is Stage 2, matching
+   * `evidenceStatus`.)
+   */
+  readonly getWorkflowRunCompletionVerification?: (
+    runId: string,
+  ) => FridayTaskWorkflowWorkflowRunCompletionVerification | null;
 }
 
 export interface FridayTaskWorkflowService {
@@ -773,6 +796,10 @@ export function createFridayTaskWorkflowService(
       );
     }
     assertWorkflowRunEvidenceRefsAvailable(claim.id, attachedRefs);
+    // Audit C: AFTER the persistence boundary (so a missing-persistence-lookup
+    // refusal keeps its existing code), refuse a non-verified upstream run
+    // completion as a DISTINCT reason from persistence durability.
+    assertWorkflowRunCompletionVerified(claim.id, attachedRefs);
     let resolvedVerifierLaneId: string | null = null;
     if (input.verifierLaneId !== undefined) {
       if (
@@ -1074,6 +1101,74 @@ export function createFridayTaskWorkflowService(
         details: {
           claimId,
           offending,
+        },
+      },
+    );
+  }
+
+  /**
+   * Audit C: refuse verified status when any workflow_run_evidence ref's
+   * source run is not a clean `verified` completion (a side-effect node lacked
+   * deterministic evidence → `proof_pending`, or the run did not terminally
+   * complete). ORTHOGONAL to evidence-persistence durability — this is a
+   * DISTINCT refusal (`TASK_WORKFLOW_CLAIM_WORKFLOW_RUN_COMPLETION_UNVERIFIED`),
+   * never "persistence degraded". Runs AFTER
+   * `assertWorkflowRunEvidenceRefsAvailable` so the persistence boundary keeps
+   * its own error code.
+   *
+   * FAIL-CLOSED and never-silent, symmetric with
+   * `assertWorkflowRunEvidenceRefsAvailable`: a `workflow_run_evidence`-backed
+   * claim cannot reach verified unless the completion lookup is wired (an
+   * absent lookup is itself a refusal — so losing the hub wiring is a LOUD
+   * refuse, not silent non-enforcement) AND every referenced run resolves to
+   * `verified` (an unknown lookup result is also a refusal). Claims without a
+   * `workflow_run_evidence` ref are unaffected.
+   */
+  function assertWorkflowRunCompletionVerified(
+    claimId: string,
+    attachedRefs: readonly FridayTaskWorkflowEvidenceRefRecord[],
+  ): void {
+    const workflowRunEvidenceRefs = attachedRefs.filter(
+      (ref) => ref.refSource === "workflow_run_evidence",
+    );
+    if (workflowRunEvidenceRefs.length === 0) return;
+    if (!deps.getWorkflowRunCompletionVerification) {
+      throw new FridayDomainError(
+        "TASK_WORKFLOW_CLAIM_WORKFLOW_RUN_COMPLETION_UNVERIFIED",
+        `claim "${claimId}" cannot reach verified: no workflow_run completion-verification lookup is wired into the task workflow service, so the upstream run's completion truth cannot be confirmed.`,
+        {
+          httpStatus: 409,
+          details: {
+            claimId,
+            offendingRefIds: workflowRunEvidenceRefs.map((r) => r.id),
+            missingLookup: true,
+          },
+        },
+      );
+    }
+    const offending: Array<{ refId: string; runId: string; completion: string }> = [];
+    for (const ref of workflowRunEvidenceRefs) {
+      const completion = deps.getWorkflowRunCompletionVerification(ref.refId);
+      if (completion === null || completion === undefined) {
+        offending.push({ refId: ref.id, runId: ref.refId, completion: "unknown" });
+        continue;
+      }
+      if (completion !== "verified") {
+        offending.push({ refId: ref.id, runId: ref.refId, completion });
+      }
+    }
+    if (offending.length === 0) return;
+    throw new FridayDomainError(
+      "TASK_WORKFLOW_CLAIM_WORKFLOW_RUN_COMPLETION_UNVERIFIED",
+      `claim "${claimId}" cannot reach verified: workflow_run_evidence ref(s) reference run(s) whose completion is not verified (e.g. a side-effect node lacked deterministic evidence): ${offending
+        .map((entry) => `${entry.refId}->${entry.runId}(${entry.completion})`)
+        .join(", ")}. This refusal is distinct from evidence persistence durability.`,
+      {
+        httpStatus: 409,
+        details: {
+          claimId,
+          offending,
+          completionUnverified: true,
         },
       },
     );

--- a/src/task-workflows/friday-task-workflow.types.ts
+++ b/src/task-workflows/friday-task-workflow.types.ts
@@ -191,6 +191,23 @@ export type FridayTaskWorkflowWorkflowRunEvidenceStatus =
   | "unavailable";
 
 /**
+ * Audit C: completion-verification truth of an upstream workflow run,
+ * ORTHOGONAL to its evidence-persistence durability above. Mirrors the
+ * workflow runtime's `FridayNodeCompletionVerification` (kept as a local
+ * string union so the task-workflow layer does not depend on the workflows
+ * module). Only `verified` can back a proof claim; any other value means the
+ * run was not a clean/verified completion (e.g. a side-effect node lacked
+ * deterministic evidence → `proof_pending`) and `verifyClaim` refuses it for
+ * a reason DISTINCT from persistence durability.
+ */
+export type FridayTaskWorkflowWorkflowRunCompletionVerification =
+  | "verified"
+  | "model_assessed_unverified"
+  | "proof_pending"
+  | "recovery_needed"
+  | "blocked";
+
+/**
  * Phase 14.5D module_28d: deterministic per-operation rollback class
  * surfaced on the task-workflow closeout receipt.
  *

--- a/src/workflows/engine/friday-workflow-node-executor.ts
+++ b/src/workflows/engine/friday-workflow-node-executor.ts
@@ -5,6 +5,7 @@ import type {
   FridayExpressionEvaluator,
 } from "../model/friday-workflow-expression.types.js";
 import type { JsonValue, UUID } from "../model/friday-workflow.types.js";
+import type { FridayNodeCompletionVerification } from "../runtime/friday-workflow-node-acceptance.js";
 
 // ─── I/O types ───
 
@@ -27,6 +28,16 @@ export interface FridayNodeExecutionOutput {
     checksum?: string;
     metadata?: Record<string, unknown>;
   }>;
+  /**
+   * Orthogonal completion-verification truth label (audit C, Stage 1), set by
+   * the pipeline node executor from the node's declared capability. A
+   * side-effect node without deterministic evidence is `proof_pending` (NOT a
+   * clean/verified completion); informational nodes are `verified` (pure
+   * compute) or `model_assessed_unverified` (model-driven). Absent = unknown
+   * (legacy); release proof / UI must not treat unknown or non-`verified` as
+   * verified. Does not affect whether the node ran.
+   */
+  completionVerification?: FridayNodeCompletionVerification;
 }
 
 // ─── Interface ───

--- a/src/workflows/index.ts
+++ b/src/workflows/index.ts
@@ -25,6 +25,7 @@ export type {
   FridayWorkflowListInput,
   FridayWorkflowStartRunInput,
   FridayNodeOutcome,
+  FridayNodeCompletionVerification,
   RowMapper,
 } from "./model/friday-workflow.types.js";
 export type {

--- a/src/workflows/model/friday-workflow.types.ts
+++ b/src/workflows/model/friday-workflow.types.ts
@@ -192,6 +192,24 @@ export type FridayWorkflowRunEvidenceStatus =
   | "degraded"
   | "unavailable";
 
+// Audit C: orthogonal RUN/NODE completion-verification truth. This is a
+// SEPARATE axis from `FridayWorkflowRunEvidenceStatus` (evidence-persistence
+// health) — a run can have fully-available persistence yet a non-`verified`
+// completion (a side-effect node lacking deterministic evidence). Conflating
+// the two would falsely report a healthy-persistence run as "degraded". A node
+// is `verified` only when it is deterministic pure-compute or a side-effect
+// backed by deterministic evidence; model/approval nodes are
+// `model_assessed_unverified` (never release proof); a side-effect node lacking
+// evidence is `proof_pending`. `recovery_needed`/`blocked` are stronger
+// downgrades. Defined here in the model layer so both the runtime and the run
+// entity can reference it without inverted layering.
+export type FridayNodeCompletionVerification =
+  | "verified"
+  | "model_assessed_unverified"
+  | "proof_pending"
+  | "recovery_needed"
+  | "blocked";
+
 // ─── Workflow Run Entity ───
 
 export interface FridayWorkflowRunEntity {
@@ -232,6 +250,14 @@ export interface FridayWorkflowRunEntity {
    * always see the current store health.
    */
   evidenceStatus?: FridayWorkflowRunEvidenceStatus;
+  /**
+   * Audit C: orthogonal run-level completion-verification truth (the worst node
+   * label observed for the run). Populated by the runtime on read paths;
+   * NEVER conflated with `evidenceStatus`. A value other than `verified` means
+   * the run cannot be read as a clean/verified completion and is refused as
+   * proof backing by the task workflow verifier (distinct from durability).
+   */
+  completionVerification?: FridayNodeCompletionVerification;
 }
 
 // ─── Workflow Run Node Row ───

--- a/src/workflows/model/friday-workflow.types.ts
+++ b/src/workflows/model/friday-workflow.types.ts
@@ -175,6 +175,13 @@ export interface FridayWorkflowRunRow {
    * (ordinary workflow may degrade), 1 = true (must fail closed).
    */
   proof_required: number | null;
+  /**
+   * Audit C Stage 2(B): persisted run-level completion-verification label
+   * (v089). NULL = no non-verified node was ever recorded (clean verified run,
+   * incl. legacy rows). A non-verified run persists its worst label here so the
+   * truth survives a hub restart.
+   */
+  completion_verification: string | null;
 }
 
 // ─── Phase 14.5C: Workflow Run Evidence Status ───

--- a/src/workflows/persistence/friday-workflow-run-repository.ts
+++ b/src/workflows/persistence/friday-workflow-run-repository.ts
@@ -59,6 +59,19 @@ export interface FridayWorkflowRunRepository {
     context: Record<string, unknown>,
     nowIso: string,
   ): void;
+
+  /**
+   * Audit C Stage 2(B): persist the run-level completion-verification label so
+   * the orthogonal completion truth survives a hub restart (the runtime
+   * aggregate is otherwise process-lifetime in-memory). Best-effort caller:
+   * the runtime swallows a "no such column" error on legacy DBs predating
+   * v089. Only ever downgrades to a non-verified label (NULL = clean verified).
+   */
+  setCompletionVerification(
+    db: Database.Database,
+    id: UUID,
+    completionVerification: string,
+  ): void;
 }
 
 // ─── Row mapper ───
@@ -91,6 +104,10 @@ function mapRunRow(row: FridayWorkflowRunRow): FridayWorkflowRunEntity {
     createdAt: row.created_at,
     updatedAt: row.updated_at,
     proofRequired: row.proof_required === 1,
+    completionVerification:
+      (row.completion_verification ?? undefined) as
+        | FridayWorkflowRunEntity["completionVerification"]
+        | undefined,
   };
 }
 
@@ -253,6 +270,12 @@ export function createFridayWorkflowRunRepository(): FridayWorkflowRunRepository
       db.prepare(
         "UPDATE workflow_runs SET context_json = ?, updated_at = ? WHERE id = ?",
       ).run(JSON.stringify(merged), nowIso, id);
+    },
+
+    setCompletionVerification(db, id, completionVerification) {
+      db.prepare(
+        "UPDATE workflow_runs SET completion_verification = ? WHERE id = ?",
+      ).run(completionVerification, id);
     },
   };
 }

--- a/src/workflows/runtime/friday-workflow-node-acceptance.ts
+++ b/src/workflows/runtime/friday-workflow-node-acceptance.ts
@@ -24,14 +24,20 @@
  */
 
 import type { FridayWorkflowNode } from "../model/friday-workflow-graph.types.js";
+import type { FridayNodeCompletionVerification } from "../model/friday-workflow.types.js";
 
-/** Orthogonal completion-verification truth label (independent of run/node status). */
-export type FridayNodeCompletionVerification =
-  | "verified" // deterministic / pure-compute node; safe as proof
-  | "model_assessed_unverified" // informational model-driven node; NOT release proof
-  | "proof_pending" // side-effect node lacking deterministic evidence (Stage 2 upgrades)
-  | "recovery_needed"
-  | "blocked";
+/**
+ * Orthogonal completion-verification truth label (independent of run/node
+ * status AND of evidence-persistence health). Canonical definition lives in
+ * the model layer (`friday-workflow.types`); re-exported here so existing
+ * importers keep their `node-acceptance` import path. Label semantics:
+ * `verified` = deterministic pure-compute (or side-effect backed by
+ * deterministic evidence) — safe as proof; `model_assessed_unverified` =
+ * model/human-gated node — NOT release proof; `proof_pending` = side-effect
+ * node lacking deterministic evidence (Stage 2 upgrades when evidence plumbs
+ * through); `recovery_needed`/`blocked` = stronger downgrades.
+ */
+export type { FridayNodeCompletionVerification };
 
 export type FridayNodeSideEffectClass = "side_effect" | "informational";
 

--- a/src/workflows/runtime/friday-workflow-node-acceptance.ts
+++ b/src/workflows/runtime/friday-workflow-node-acceptance.ts
@@ -1,0 +1,152 @@
+/**
+ * Workflow node acceptance classification (audit C, Stage 1).
+ *
+ * Locked product direction: a workflow node may NOT use "any non-empty output"
+ * as *verified* completion. A side-effect / external-action / mutating /
+ * user-visible-claim node that lacks deterministic evidence (a real tool
+ * receipt / state delta / provider-channel confirmation, or an explicit safe
+ * refusal) cannot be a clean (verified) completion — it is truth-labeled
+ * `proof_pending` (or `blocked`/`recovery_needed`) instead. Pure-informational /
+ * low-risk nodes may complete but are truth-labeled (`verified` for
+ * deterministic compute, `model_assessed_unverified` for model-driven nodes) and
+ * must never be treated as release proof when unverified.
+ *
+ * This is an ORTHOGONAL truth dimension layered on top of the existing run/node
+ * execution status — it does not change whether a node ran, only whether its
+ * completion is *verified*. Classification is derived from the node's declared
+ * capability (node type + skill manifest permission grants), NEVER from the
+ * node output (the untrusted artifact being gated).
+ *
+ * Stage 2 (follow-up): once the node execution result carries real tool/receipt/
+ * state-delta evidence, the gate can deterministically upgrade `proof_pending`
+ * side-effect nodes to `verified` (or down to `blocked`). Until then any
+ * side-effect node is honestly `proof_pending`.
+ */
+
+import type { FridayWorkflowNode } from "../model/friday-workflow-graph.types.js";
+
+/** Orthogonal completion-verification truth label (independent of run/node status). */
+export type FridayNodeCompletionVerification =
+  | "verified" // deterministic / pure-compute node; safe as proof
+  | "model_assessed_unverified" // informational model-driven node; NOT release proof
+  | "proof_pending" // side-effect node lacking deterministic evidence (Stage 2 upgrades)
+  | "recovery_needed"
+  | "blocked";
+
+export type FridayNodeSideEffectClass = "side_effect" | "informational";
+
+/**
+ * PermissionActions that denote a real external side effect / state mutation.
+ * Mirrors the codebase's own danger set (PermissionPromptToken:
+ * filesystem.write / network.connect / shell.execute / channel.send /
+ * device.capture). `read` / `receive` are informational.
+ */
+const SIDE_EFFECTING_PERMISSION_ACTIONS: ReadonlySet<string> = new Set([
+  "write",
+  "connect",
+  "send",
+  "capture",
+  "execute",
+]);
+
+/**
+ * Defensively extract declared permission `action`s from whatever
+ * `resolveSkill` returns. The runtime types `resolveSkill` as `unknown` (it is
+ * only contractually an existence probe), but the hub implementation returns the
+ * registered skill carrying `manifest.permissions.grants`. Any unexpected shape
+ * yields `null` so the caller fails closed (treats the node as side-effecting).
+ */
+function extractDeclaredPermissionActions(skill: unknown): string[] | null {
+  if (skill == null || typeof skill !== "object") return null;
+  const manifest = (skill as { manifest?: unknown }).manifest;
+  if (manifest == null || typeof manifest !== "object") return null;
+  const permissions = (manifest as { permissions?: unknown }).permissions;
+  if (permissions == null || typeof permissions !== "object") return null;
+
+  // Modern PermissionPolicyV2: { grants: PermissionGrant[] }
+  const grants = (permissions as { grants?: unknown }).grants;
+  if (Array.isArray(grants)) {
+    return grants
+      .map((g) => (g != null && typeof g === "object" ? (g as { action?: unknown }).action : undefined))
+      .filter((a): a is string => typeof a === "string");
+  }
+
+  // Legacy v1 shape: network/filesystem/memoryScope/tools — map to side-effect actions.
+  const legacy = permissions as {
+    network?: unknown;
+    filesystem?: unknown;
+    memoryScope?: unknown;
+    tools?: unknown;
+  };
+  const legacyActions: string[] = [];
+  if (legacy.network === true) legacyActions.push("connect");
+  if (typeof legacy.filesystem === "string" && legacy.filesystem !== "none") legacyActions.push("write");
+  if (legacy.memoryScope === "readwrite") legacyActions.push("write");
+  if (Array.isArray(legacy.tools) && legacy.tools.length > 0) legacyActions.push("execute");
+  // A legacy policy object with no side-effect signals is treated as having an
+  // empty (but present) declaration → caller fail-closes on empty grants.
+  return legacyActions;
+}
+
+/**
+ * Classify a workflow node as side-effecting vs informational from its DECLARED
+ * capability — never from its output. Fail-closed: an `action` node whose skill
+ * cannot be resolved, has no skill id, or has no declared grants is treated as
+ * side-effecting (empty grants are common and legal, so empty != safe).
+ */
+export function classifyWorkflowNodeSideEffect(
+  node: Pick<FridayWorkflowNode, "type" | "config">,
+  resolveSkill: (skillId: string) => unknown,
+): FridayNodeSideEffectClass {
+  switch (node.type) {
+    case "trigger":
+    case "condition":
+    case "data":
+      return "informational"; // pure compute / passthrough; no external action
+    case "ai":
+    case "approval":
+      return "informational"; // model/human-gated; truth-labeled, not clean-verified
+    case "action": {
+      const cfg = (node.config ?? {}) as Record<string, unknown>;
+      const skillId = typeof cfg.skillId === "string"
+        ? cfg.skillId
+        : typeof cfg.ref === "string"
+          ? cfg.ref
+          : undefined;
+      if (!skillId) return "side_effect"; // no identity → fail closed
+      const actions = extractDeclaredPermissionActions(resolveSkill(skillId));
+      if (!actions || actions.length === 0) return "side_effect"; // unresolved / empty → fail closed
+      return actions.some((a) => SIDE_EFFECTING_PERMISSION_ACTIONS.has(a))
+        ? "side_effect"
+        : "informational"; // only when every grant is read/receive
+    }
+    default:
+      return "side_effect"; // unreachable (closed enum) but fail closed
+  }
+}
+
+/**
+ * Resolve the orthogonal completion-verification label for a node, given its
+ * side-effect class and (Stage 2) whether deterministic evidence backs it.
+ * Today `hasDeterministicEvidence` is always false (no evidence plumbing), so
+ * side-effect nodes are honestly `proof_pending`.
+ */
+export function resolveNodeCompletionVerification(
+  node: Pick<FridayWorkflowNode, "type">,
+  sideEffectClass: FridayNodeSideEffectClass,
+  hasDeterministicEvidence = false,
+): FridayNodeCompletionVerification {
+  if (sideEffectClass === "side_effect") {
+    return hasDeterministicEvidence ? "verified" : "proof_pending";
+  }
+  // informational
+  if (node.type === "ai" || node.type === "approval") {
+    return "model_assessed_unverified";
+  }
+  return "verified"; // trigger / condition / data — deterministic pure compute
+}
+
+/** A completion-verification label that is safe to treat as release proof. */
+export function isVerifiedCompletion(v: FridayNodeCompletionVerification): boolean {
+  return v === "verified";
+}

--- a/src/workflows/runtime/friday-workflow-runtime.ts
+++ b/src/workflows/runtime/friday-workflow-runtime.ts
@@ -84,8 +84,8 @@ import { createFridayWorkflowRetryManager } from "../engine/friday-workflow-retr
 import { createFridayWorkflowNodeExecutor } from "../engine/friday-workflow-node-executor.js";
 import {
   classifyWorkflowNodeSideEffect,
-  resolveNodeCompletionVerification,
   type FridayNodeCompletionVerification,
+  resolveNodeCompletionVerification,
 } from "./friday-workflow-node-acceptance.js";
 import { createFridayWorkflowArtifactWriter } from "../engine/friday-workflow-artifact-writer.js";
 import { createFridayWorkflowNodeRunnerFacade } from "../engine/friday-workflow-node-runner-facade.js";

--- a/src/workflows/runtime/friday-workflow-runtime.ts
+++ b/src/workflows/runtime/friday-workflow-runtime.ts
@@ -535,7 +535,13 @@ export function createFridayWorkflowRuntime(
   // backing by the task workflow verifier — as a reason DISTINCT from
   // persistence durability. It NEVER downgrades `evidenceStatus`; conflating
   // the two would falsely report a healthy-persistence run as "degraded"
-  // (a reverse lie). Runtime state is the source of truth; not persisted.
+  // (a reverse lie). Stage 2(B): the worst label is ALSO persisted durably
+  // (workflow_runs.completion_verification, v089) so the truth survives a hub
+  // restart — the in-memory map is the per-process fast path; the read merges
+  // both (worst wins). NOTE: this is C ENFORCEMENT + persistence only; letting
+  // an honest side-effect node EARN `verified` from runtime-observed evidence
+  // is the separate contract-change (a) PR — until then any side-effect node
+  // stays `proof_pending` (no forgeable skill-output signal is accepted).
   const runCompletionVerificationByRunId = new Map<
     string,
     FridayNodeCompletionVerification
@@ -550,6 +556,35 @@ export function createFridayWorkflowRuntime(
     verified: 4,
   };
 
+  const isCompletionVerificationLabel = (
+    value: unknown,
+  ): value is FridayNodeCompletionVerification =>
+    typeof value === "string" && value in COMPLETION_VERIFICATION_RANK;
+
+  const worstCompletionVerification = (
+    a: FridayNodeCompletionVerification | undefined,
+    b: FridayNodeCompletionVerification | undefined,
+  ): FridayNodeCompletionVerification | undefined => {
+    if (a === undefined) return b;
+    if (b === undefined) return a;
+    return COMPLETION_VERIFICATION_RANK[a] <= COMPLETION_VERIFICATION_RANK[b] ? a : b;
+  };
+
+  // Stage 2(B): persist the run's worst label durably (best-effort). Only
+  // non-verified labels are written (NULL = clean verified default). Swallow
+  // errors (legacy DB with no v089 column, or the run row not yet inserted) —
+  // the in-memory aggregate still enforces this run for the process lifetime.
+  const persistCompletionVerification = (
+    runId: string,
+    label: FridayNodeCompletionVerification,
+  ): void => {
+    try {
+      deps.db.withWriteTransaction((db) => runRepo.setCompletionVerification(db, runId, label));
+    } catch {
+      /* legacy DB / pre-insert; in-memory aggregate remains authoritative */
+    }
+  };
+
   const recordRunNodeCompletionVerification = (
     runId: string,
     label: FridayNodeCompletionVerification,
@@ -560,13 +595,24 @@ export function createFridayWorkflowRuntime(
       || COMPLETION_VERIFICATION_RANK[label] < COMPLETION_VERIFICATION_RANK[previous]
     ) {
       runCompletionVerificationByRunId.set(runId, label);
+      if (label !== "verified") {
+        persistCompletionVerification(runId, label);
+      }
     }
   };
 
   const getRunCompletionVerification = (
     runId: string,
   ): FridayNodeCompletionVerification => {
-    const recorded = runCompletionVerificationByRunId.get(runId) ?? "verified";
+    const inMemory = runCompletionVerificationByRunId.get(runId);
+    const run = execution.getRun(runId);
+    // Stage 2(B): merge the in-memory aggregate with the persisted label
+    // (v089) — the WORST of the two — so the truth survives a hub restart
+    // (after which the in-memory map is empty but the column is not).
+    const persisted = isCompletionVerificationLabel(run?.completionVerification)
+      ? run?.completionVerification
+      : undefined;
+    const recorded = worstCompletionVerification(inMemory, persisted) ?? "verified";
     // Fail-closed for non-settled runs: a run that is not terminally
     // `completed` can NEVER be read as a clean `verified` completion — a
     // still-executing run may yet run a side-effect node, and a failed /
@@ -574,7 +620,6 @@ export function createFridayWorkflowRuntime(
     // time-of-check race at the source so the verifier observes
     // `proof_pending` rather than a premature `verified`. A recorded stronger
     // downgrade (proof_pending / recovery_needed / blocked) is preserved.
-    const run = execution.getRun(runId);
     if (run?.status === "completed") {
       return recorded;
     }

--- a/src/workflows/runtime/friday-workflow-runtime.ts
+++ b/src/workflows/runtime/friday-workflow-runtime.ts
@@ -82,6 +82,11 @@ import { createFridayWorkflowRunMachine } from "../engine/friday-workflow-run-ma
 import { createFridayWorkflowNodeMachine } from "../engine/friday-workflow-node-machine.js";
 import { createFridayWorkflowRetryManager } from "../engine/friday-workflow-retry-manager.js";
 import { createFridayWorkflowNodeExecutor } from "../engine/friday-workflow-node-executor.js";
+import {
+  classifyWorkflowNodeSideEffect,
+  resolveNodeCompletionVerification,
+  type FridayNodeCompletionVerification,
+} from "./friday-workflow-node-acceptance.js";
 import { createFridayWorkflowArtifactWriter } from "../engine/friday-workflow-artifact-writer.js";
 import { createFridayWorkflowNodeRunnerFacade } from "../engine/friday-workflow-node-runner-facade.js";
 import { createFridayWorkflowAcceptanceGate } from "../engine/friday-workflow-acceptance-gate.js";
@@ -1205,11 +1210,26 @@ export function createFridayWorkflowRuntime(
 
   const nodeExecutor = {
     async executeNode(input) {
+      // Audit C Stage 1: derive the orthogonal completion-verification label
+      // from the node's DECLARED capability (never from output). A side-effect
+      // node without deterministic evidence is `proof_pending` (not a clean /
+      // verified completion); informational nodes are verified / model_assessed.
+      // Applied in EVERY path — pipeline-on, output==null, and the legacy/
+      // pipeline-disabled bypass — so none of them can be read as verified.
+      const sideEffectClass = classifyWorkflowNodeSideEffect(input.node, deps.resolveSkill);
+      const completionVerification = resolveNodeCompletionVerification(input.node, sideEffectClass);
+      const withVerification = <T>(r: T): T => {
+        (r as { completionVerification?: FridayNodeCompletionVerification }).completionVerification = completionVerification;
+        return r;
+      };
+
       if (!pipelineEnabled) {
-        return legacyNodeExecutor.executeNode(input);
+        // Legacy / pipeline-disabled bypass must still be truth-labeled — a
+        // disabled pipeline is not a verified completion.
+        return withVerification(await legacyNodeExecutor.executeNode(input));
       }
       try {
-        const result = await nodeRunnerFacade.executeNode(input);
+        const result = withVerification(await nodeRunnerFacade.executeNode(input));
 
         pipelineEventEmitter.emit(
           "pipeline.node.execution.completed",

--- a/src/workflows/runtime/friday-workflow-runtime.ts
+++ b/src/workflows/runtime/friday-workflow-runtime.ts
@@ -525,6 +525,62 @@ export function createFridayWorkflowRuntime(
     }
   };
 
+  // Audit C part-2: RUN-LEVEL completion-verification truth, ORTHOGONAL to
+  // evidence-persistence health (`evidenceStatus`). Tracks the worst (least
+  // verified) node completion-verification label observed for the run. This is
+  // the run-level enforcement surface for the workflow-node false-completion
+  // bypasses (arbitrary non-empty baseline pass, output==null skip, and the
+  // disabled-pipeline/legacy path): a run whose aggregate is not `verified`
+  // cannot be read as a clean/verified completion and is refused as proof
+  // backing by the task workflow verifier — as a reason DISTINCT from
+  // persistence durability. It NEVER downgrades `evidenceStatus`; conflating
+  // the two would falsely report a healthy-persistence run as "degraded"
+  // (a reverse lie). Runtime state is the source of truth; not persisted.
+  const runCompletionVerificationByRunId = new Map<
+    string,
+    FridayNodeCompletionVerification
+  >();
+  // Worst-first rank: a LOWER number is a stronger (worse) downgrade. The run
+  // aggregate keeps the worst label any node reported.
+  const COMPLETION_VERIFICATION_RANK: Record<FridayNodeCompletionVerification, number> = {
+    blocked: 0,
+    recovery_needed: 1,
+    proof_pending: 2,
+    model_assessed_unverified: 3,
+    verified: 4,
+  };
+
+  const recordRunNodeCompletionVerification = (
+    runId: string,
+    label: FridayNodeCompletionVerification,
+  ): void => {
+    const previous = runCompletionVerificationByRunId.get(runId);
+    if (
+      previous === undefined
+      || COMPLETION_VERIFICATION_RANK[label] < COMPLETION_VERIFICATION_RANK[previous]
+    ) {
+      runCompletionVerificationByRunId.set(runId, label);
+    }
+  };
+
+  const getRunCompletionVerification = (
+    runId: string,
+  ): FridayNodeCompletionVerification => {
+    const recorded = runCompletionVerificationByRunId.get(runId) ?? "verified";
+    // Fail-closed for non-settled runs: a run that is not terminally
+    // `completed` can NEVER be read as a clean `verified` completion — a
+    // still-executing run may yet run a side-effect node, and a failed /
+    // cancelled run did not complete. This closes the mid-flight
+    // time-of-check race at the source so the verifier observes
+    // `proof_pending` rather than a premature `verified`. A recorded stronger
+    // downgrade (proof_pending / recovery_needed / blocked) is preserved.
+    const run = execution.getRun(runId);
+    if (run?.status === "completed") {
+      return recorded;
+    }
+    return recorded === "verified" ? "proof_pending" : recorded;
+  };
+
   const isRunProofRequired = (runId: string): boolean => {
     const cached = proofRequiredByRunId.get(runId);
     if (cached !== undefined) return cached;
@@ -1222,6 +1278,20 @@ export function createFridayWorkflowRuntime(
         (r as { completionVerification?: FridayNodeCompletionVerification }).completionVerification = completionVerification;
         return r;
       };
+
+      // Run-level enforcement (audit C part-2): record this node's
+      // completion-verification into the run-level aggregate (the worst label
+      // wins). A node that is NOT a clean `verified` completion — a side-effect
+      // node lacking deterministic evidence (`proof_pending`) or a
+      // model-assessed informational node (`model_assessed_unverified`) — makes
+      // the RUN aggregate non-`verified`, which the task workflow verifier
+      // refuses as proof backing. This closes the run-level bypasses (arbitrary
+      // non-empty baseline pass, output==null skipping the gate, and the
+      // disabled-pipeline/legacy path): none can leave the run readable as
+      // clean/verified. It does NOT block the node from running (no
+      // over-blocking) and is ORTHOGONAL to `evidenceStatus` — recording a
+      // non-verified completion must NOT touch evidence-persistence health.
+      recordRunNodeCompletionVerification(input.runId, completionVerification);
 
       if (!pipelineEnabled) {
         // Legacy / pipeline-disabled bypass must still be truth-labeled — a
@@ -2046,9 +2116,10 @@ export function createFridayWorkflowRuntime(
       });
 
     const evidenceStatus = getRunEvidenceStatus(runId);
+    const completionVerification = getRunCompletionVerification(runId);
     const rawRun = execution.getRun(runId);
     const run = rawRun
-      ? { ...rawRun, evidenceStatus }
+      ? { ...rawRun, evidenceStatus, completionVerification }
       : null;
     return {
       run,
@@ -2076,6 +2147,7 @@ export function createFridayWorkflowRuntime(
         items: correlationItems,
       },
       evidenceStatus,
+      completionVerification,
     };
   };
 
@@ -2296,6 +2368,9 @@ export function createFridayWorkflowRuntime(
     },
     getRunEvidenceStatus(runId: string): FridayWorkflowRunEvidenceStatus {
       return getRunEvidenceStatus(runId);
+    },
+    getRunCompletionVerification(runId: string): FridayNodeCompletionVerification {
+      return getRunCompletionVerification(runId);
     },
   };
 

--- a/src/workflows/runtime/friday-workflow-runtime.types.ts
+++ b/src/workflows/runtime/friday-workflow-runtime.types.ts
@@ -3,6 +3,7 @@ import type { FridayWorkflowExecutionService } from "../services/friday-workflow
 import type { FridayWorkflowTriggerService } from "../services/friday-workflow-trigger-service.js";
 import type { FridayWorkflowApprovalService } from "../services/friday-workflow-approval-service.types.js";
 import type {
+  FridayNodeCompletionVerification,
   FridayWorkflowRunEntity,
   FridayWorkflowRunEvidenceStatus,
   ISODateTime,
@@ -126,6 +127,15 @@ export interface FridayWorkflowRunEvidenceResponse {
    * receipt — `degraded` and `unavailable` block any proof claim.
    */
   evidenceStatus: FridayWorkflowRunEvidenceStatus;
+  /**
+   * Audit C: orthogonal run-level completion-verification truth (worst node
+   * label observed). SEPARATE from `evidenceStatus` — a run can be
+   * `available` (healthy persistence) yet `proof_pending` (a side-effect node
+   * lacked deterministic evidence). A non-`verified` value means the run is
+   * not a clean/verified completion and cannot back a proof claim, for a
+   * reason distinct from persistence durability.
+   */
+  completionVerification: FridayNodeCompletionVerification;
 }
 
 export interface FridayWorkflowRunEvidenceExport {
@@ -187,6 +197,16 @@ export interface FridayWorkflowEvidenceService {
    * downstream verifier — there is no fallback that masks degraded state.
    */
   getRunEvidenceStatus(runId: UUID): FridayWorkflowRunEvidenceStatus;
+  /**
+   * Audit C: deterministic per-run completion-verification truth, ORTHOGONAL
+   * to `getRunEvidenceStatus`. Returns `verified` only for a terminally
+   * `completed` run whose every node was a clean/verified completion; a
+   * side-effect node lacking deterministic evidence yields `proof_pending`,
+   * and a non-settled run is never `verified` (fail-closed against the
+   * mid-flight race). The task workflow verifier reads this to refuse a
+   * non-verified run as proof backing — never conflated with persistence.
+   */
+  getRunCompletionVerification(runId: UUID): FridayNodeCompletionVerification;
 }
 
 /**

--- a/test/e2e/api/friday-api-task-workflow-rollback-matrix.acceptance.test.ts
+++ b/test/e2e/api/friday-api-task-workflow-rollback-matrix.acceptance.test.ts
@@ -80,7 +80,14 @@ function createRuntime(db: FridaySqliteLayer): FridayWorkflowRuntime {
     idGenerator: createTestIdGenerator(),
     nowIso: () => NOW,
     computeChecksum: (content) => createHash("sha256").update(content).digest("hex"),
-    resolveSkill: () => ({ id: "rollback-matrix-skill" }),
+    // Audit C: this fixture tests ROLLBACK-CLASS disclosure (derived from the
+    // ref SOURCE type), orthogonal to completion-verification. Its placeholder
+    // action node is informational → read-only manifest → completion
+    // `verified`, so a workflow_run_evidence claim can still be verified here.
+    resolveSkill: () => ({
+      id: "rollback-matrix-skill",
+      manifest: { permissions: { grants: [{ action: "read" }] } },
+    }),
     invokeSkill: async () => ({ ok: true }),
   });
 }
@@ -215,6 +222,11 @@ describe("Phase 14.5D module_28d: rollback matrix closeout receipt acceptance", 
         nowIso: () => NOW,
         getWorkflowRunEvidenceStatus: (runId) =>
           runtime.evidence.getRunEvidenceStatus(runId),
+        // Audit C: wire the orthogonal completion lookup as the hub does
+        // (fail-closed requires it); the read-only run is `verified`, so the
+        // workflow_run_evidence claim still reaches verified here.
+        getWorkflowRunCompletionVerification: (runId) =>
+          runtime.evidence.getRunCompletionVerification(runId),
       });
       try {
         const { workflowId, versionId } = await publishWorkflowAndGetVersionId(

--- a/test/e2e/api/friday-api-workflow-completion-verification-enforcement.acceptance.test.ts
+++ b/test/e2e/api/friday-api-workflow-completion-verification-enforcement.acceptance.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Audit C part-2 acceptance test — RUN-LEVEL completion-verification
+ * enforcement, end-to-end against the real workflow runtime and the real task
+ * workflow service (no mocks of the verifier path).
+ *
+ * Proves the enforcement is real, not merely a label:
+ *  - a side-effect run (a node whose skill declares a side-effecting grant, or
+ *    whose skill cannot be resolved — fail-closed) settles `completed` with
+ *    healthy persistence (`evidenceStatus === "available"`) yet a
+ *    `proof_pending` completion, and verifyClaim REFUSES a workflow_run_evidence
+ *    ref pointing at it with the DISTINCT code
+ *    TASK_WORKFLOW_CLAIM_WORKFLOW_RUN_COMPLETION_UNVERIFIED (409) — never the
+ *    persistence code;
+ *  - a read-only (informational) run is `verified` and verifyClaim SUCCEEDS
+ *    (no over-blocking);
+ *  - the mid-flight time-of-check race is closed at the source: a run that has
+ *    not terminally `completed` reads non-verified, so verifyClaim refuses it.
+ *
+ * The lookups are wired exactly as the hub bootstrap wires them.
+ */
+
+import { createHash } from "node:crypto";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { FridayDomainError } from "../../../src/errors/friday-domain-error.js";
+import {
+  createFridayTaskWorkflowRepository,
+  createFridayTaskWorkflowService,
+} from "../../../src/task-workflows/index.js";
+import {
+  createFridayWorkflowRuntime,
+  type FridayCompiledWorkflowGraphV2,
+  type FridayWorkflowRuntime,
+} from "#workflows";
+import type { FridaySqliteLayer } from "#state";
+
+import {
+  createTestDb,
+  createTestIdGenerator,
+} from "../../helpers/friday-test-db.helper.js";
+
+const NOW = "2026-05-29T00:00:00.000Z";
+
+function waitMs(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function settle(runtime: FridayWorkflowRuntime, runId: string): Promise<string> {
+  for (let i = 0; i < 250; i += 1) {
+    const run = runtime.execution.getRun(runId);
+    if (run && ["completed", "failed", "cancelled"].includes(run.status)) return run.status;
+    await waitMs(20);
+  }
+  throw new Error(`run ${runId} did not settle`);
+}
+
+// Skill manifests keyed by id: `side-effect-skill` declares a side-effecting
+// `send` grant; `read-only-skill` declares only `read`. `invokeSkill` returns a
+// plausible non-empty output so the ONLY thing keeping the side-effect run from
+// "verified" is the declared capability, not the (untrusted) output.
+// `side-effect-skill` declares a side-effecting `send` grant; `read-only-skill`
+// and `blocking-read-skill` declare only `read` (informational). The blocking
+// skill is classified `verified`-eligible but its invocation blocks forever, so
+// the run never settles — used to prove the mid-flight fail-closed behavior.
+const MANIFESTS: Record<string, { permissions: { grants: Array<{ action: string }> } }> = {
+  "side-effect-skill": { permissions: { grants: [{ action: "send" }] } },
+  "read-only-skill": { permissions: { grants: [{ action: "read" }] } },
+  "blocking-read-skill": { permissions: { grants: [{ action: "read" }] } },
+};
+const BLOCKING_SKILL_ID = "blocking-read-skill";
+
+function graph(workflowId: string, skillId: string): FridayCompiledWorkflowGraphV2 {
+  return {
+    schemaVersion: "2.0",
+    workflowId,
+    workflowVersionId: "placeholder",
+    sourceSpecSchemaVersion: "1.0",
+    graph: {
+      nodes: [
+        { id: "trigger", type: "trigger", label: "Trigger", config: {} },
+        { id: "act", type: "action", label: "Act", config: { skillId } },
+      ],
+      edges: [{ id: "e1", sourceNodeId: "trigger", targetNodeId: "act" }],
+    },
+    failurePolicy: { onFailure: "fail_fast", notifyUser: false },
+    tests: [],
+    checksum: "c-part2-enforce",
+  };
+}
+
+function publish(runtime: FridayWorkflowRuntime, slug: string, skillId: string): { workflowId: string; versionId: string } {
+  const wf = runtime.crud.createWorkflow({ slug, name: slug });
+  const v = runtime.crud.createVersion(wf.id, graph(wf.id, skillId));
+  runtime.crud.publishVersion(wf.id, v.versionNumber);
+  return { workflowId: wf.id, versionId: v.id };
+}
+
+describe("Audit C part-2: workflow completion-verification run-level enforcement", () => {
+  let envEnable: string | undefined;
+  let envMode: string | undefined;
+  let release: (() => void) | null = null;
+
+  beforeEach(() => {
+    envEnable = process.env.FRIDAY_PIPELINE_ENABLE;
+    envMode = process.env.FRIDAY_PIPELINE_MODE;
+    process.env.FRIDAY_PIPELINE_ENABLE = "true";
+    process.env.FRIDAY_PIPELINE_MODE = "enforce";
+  });
+  afterEach(() => {
+    release?.();
+    release = null;
+    if (envEnable === undefined) delete process.env.FRIDAY_PIPELINE_ENABLE; else process.env.FRIDAY_PIPELINE_ENABLE = envEnable;
+    if (envMode === undefined) delete process.env.FRIDAY_PIPELINE_MODE; else process.env.FRIDAY_PIPELINE_MODE = envMode;
+  });
+
+  function buildRuntime(db: FridaySqliteLayer, opts?: { gate?: Promise<void> }): FridayWorkflowRuntime {
+    return createFridayWorkflowRuntime({
+      db,
+      idGenerator: createTestIdGenerator(),
+      nowIso: () => NOW,
+      computeChecksum: (c) => createHash("sha256").update(c).digest("hex"),
+      resolveSkill: (skillId) => (MANIFESTS[skillId] ? { id: skillId, manifest: MANIFESTS[skillId] } : null),
+      invokeSkill: async (skillId: string) => {
+        if (skillId === BLOCKING_SKILL_ID && opts?.gate) await opts.gate;
+        return { ok: true, sent: true };
+      },
+    });
+  }
+
+  function buildService(db: FridaySqliteLayer, runtime: FridayWorkflowRuntime) {
+    let nextId = 0;
+    return createFridayTaskWorkflowService({
+      db,
+      repository: createFridayTaskWorkflowRepository(),
+      idGenerator: () => {
+        nextId += 1;
+        return `tw-id-${String(nextId).padStart(6, "0")}`;
+      },
+      nowIso: () => NOW,
+      // Wired exactly as the hub bootstrap wires both orthogonal lookups.
+      getWorkflowRunEvidenceStatus: (runId) => runtime.evidence.getRunEvidenceStatus(runId),
+      getWorkflowRunCompletionVerification: (runId) => runtime.evidence.getRunCompletionVerification(runId),
+    });
+  }
+
+  function attachAndVerify(
+    service: ReturnType<typeof buildService>,
+    runId: string,
+    claimText: string,
+  ): { error: FridayDomainError | null; verifiedStatus?: string } {
+    const tw = service.create({
+      charter: "audit C part-2 completion enforcement",
+      taskKind: "general",
+      contextPackage: { allowedFiles: ["src/x.ts"], allowedTools: [], allowedApis: [], boundaryIds: ["api.task_workflows.core"] },
+    });
+    const claim = service.draftClaim(tw.id, { claimText, claimKind: "runtime_evidence" });
+    service.attachEvidenceRef(tw.id, claim.id, {
+      refKind: "workflow_run_evidence",
+      refId: runId,
+      refSource: "workflow_run_evidence",
+    });
+    try {
+      const verified = service.verifyClaim(tw.id, claim.id, { verifierVerdict: "fresh-read" });
+      return { error: null, verifiedStatus: verified.status };
+    } catch (error) {
+      return { error: error as FridayDomainError };
+    }
+  }
+
+  it("side-effect run: completed + evidence available + completion proof_pending; verifyClaim REFUSED with the DISTINCT code", async () => {
+    const db = createTestDb();
+    const runtime = buildRuntime(db);
+    const service = buildService(db, runtime);
+    try {
+      const { workflowId, versionId } = publish(runtime, "ce-side-effect", "side-effect-skill");
+      const run = await runtime.execution.startRun({ workflowId, workflowVersionId: versionId, triggerType: "manual" });
+      expect(await settle(runtime, run.id)).toBe("completed");
+
+      // Orthogonality: persistence healthy, completion not verified.
+      expect(runtime.evidence.getRunEvidenceStatus(run.id)).toBe("available");
+      expect(runtime.evidence.getRunCompletionVerification(run.id)).toBe("proof_pending");
+
+      const { error } = attachAndVerify(service, run.id, "claim backed by side-effect run");
+      expect(error).toBeInstanceOf(FridayDomainError);
+      expect(error?.code).toBe("TASK_WORKFLOW_CLAIM_WORKFLOW_RUN_COMPLETION_UNVERIFIED");
+      expect(error?.httpStatus).toBe(409);
+      // DISTINCT from the persistence refusal — never "persistence degraded".
+      expect(error?.code).not.toBe("TASK_WORKFLOW_CLAIM_WORKFLOW_RUN_EVIDENCE_UNAVAILABLE");
+    } finally {
+      db.close();
+    }
+  });
+
+  it("fail-closed: unresolved-skill action run is also proof_pending → verifyClaim refused", async () => {
+    const db = createTestDb();
+    const runtime = buildRuntime(db);
+    const service = buildService(db, runtime);
+    try {
+      const { workflowId, versionId } = publish(runtime, "ce-unresolved", "ghost-skill"); // not in MANIFESTS
+      const run = await runtime.execution.startRun({ workflowId, workflowVersionId: versionId, triggerType: "manual" });
+      await settle(runtime, run.id);
+      expect(runtime.evidence.getRunCompletionVerification(run.id)).toBe("proof_pending");
+      const { error } = attachAndVerify(service, run.id, "claim backed by unresolved-skill run");
+      expect(error?.code).toBe("TASK_WORKFLOW_CLAIM_WORKFLOW_RUN_COMPLETION_UNVERIFIED");
+    } finally {
+      db.close();
+    }
+  });
+
+  it("read-only run: completion verified → verifyClaim SUCCEEDS (no over-blocking)", async () => {
+    const db = createTestDb();
+    const runtime = buildRuntime(db);
+    const service = buildService(db, runtime);
+    try {
+      const { workflowId, versionId } = publish(runtime, "ce-read-only", "read-only-skill");
+      const run = await runtime.execution.startRun({ workflowId, workflowVersionId: versionId, triggerType: "manual" });
+      expect(await settle(runtime, run.id)).toBe("completed");
+      expect(runtime.evidence.getRunCompletionVerification(run.id)).toBe("verified");
+      const { error, verifiedStatus } = attachAndVerify(service, run.id, "claim backed by read-only run");
+      expect(error).toBeNull();
+      expect(verifiedStatus).toBe("verified");
+    } finally {
+      db.close();
+    }
+  });
+
+  it("mid-flight TOCTOU closed: a run that has NOT terminally completed reads non-verified → verifyClaim refused", async () => {
+    const db = createTestDb();
+    let releaseGate: () => void = () => {};
+    const gate = new Promise<void>((res) => {
+      releaseGate = res;
+    });
+    release = releaseGate; // ensure afterEach unblocks even if an assertion throws
+    const runtime = buildRuntime(db, { gate });
+    const service = buildService(db, runtime);
+    try {
+      // A read-only-classified run, but its action node blocks forever (mid-flight).
+      const { workflowId, versionId } = publish(runtime, "ce-midflight", BLOCKING_SKILL_ID);
+      const run = await runtime.execution.startRun({ workflowId, workflowVersionId: versionId, triggerType: "manual" });
+      await waitMs(80); // let the run start; the action node is now blocked, run NOT terminal.
+
+      const liveRun = runtime.execution.getRun(run.id);
+      expect(liveRun?.status).not.toBe("completed"); // genuinely mid-flight
+      // Fail-closed at the source: a non-settled run is never "verified".
+      expect(runtime.evidence.getRunCompletionVerification(run.id)).not.toBe("verified");
+
+      const { error } = attachAndVerify(service, run.id, "claim backed by still-executing run");
+      expect(error).toBeInstanceOf(FridayDomainError);
+      expect(error?.code).toBe("TASK_WORKFLOW_CLAIM_WORKFLOW_RUN_COMPLETION_UNVERIFIED");
+
+      releaseGate();
+      await settle(runtime, run.id);
+    } finally {
+      releaseGate();
+      db.close();
+    }
+  });
+});

--- a/test/e2e/api/friday-api-workflow-evidence-fail-closed.acceptance.test.ts
+++ b/test/e2e/api/friday-api-workflow-evidence-fail-closed.acceptance.test.ts
@@ -89,7 +89,15 @@ function createRuntime(db: FridaySqliteLayer): FridayWorkflowRuntime {
     idGenerator: createTestIdGenerator(),
     nowIso: () => NOW,
     computeChecksum: (content) => createHash("sha256").update(content).digest("hex"),
-    resolveSkill: () => ({ id: "evidence-fail-closed-skill" }),
+    // Audit C: this fixture exercises evidence-PERSISTENCE fail-closed; its
+    // single action node is a benign informational placeholder, so it declares
+    // a read-only manifest → completion `verified`. (Without a manifest the
+    // node would fail-closed to a side-effect `proof_pending` run, which is
+    // correct behavior but orthogonal to what THIS test asserts.)
+    resolveSkill: () => ({
+      id: "evidence-fail-closed-skill",
+      manifest: { permissions: { grants: [{ action: "read" }] } },
+    }),
     invokeSkill: async () => ({ ok: true }),
   });
 }
@@ -242,6 +250,12 @@ describe("Phase 14.5C module_28c: workflow evidence fail-closed acceptance", () 
         nowIso: () => NOW,
         getWorkflowRunEvidenceStatus: (runId) =>
           runtime.evidence.getRunEvidenceStatus(runId),
+        // Audit C: wire the orthogonal completion lookup exactly as the hub
+        // does (fail-closed requires it). The fixture's run is read-only →
+        // `verified`, so the happy path still verifies; this only adds the
+        // run-level completion gate the production service enforces.
+        getWorkflowRunCompletionVerification: (runId) =>
+          runtime.evidence.getRunCompletionVerification(runId),
       });
       try {
         const { workflowId: wfId, versionId } = await publishWorkflowAndGetVersionId(

--- a/test/unit/task-workflows/friday-task-workflow-service.test.ts
+++ b/test/unit/task-workflows/friday-task-workflow-service.test.ts
@@ -1138,6 +1138,12 @@ describe("Phase 14.5C module_28c — workflow evidence fail-closed", () => {
       },
       nowIso: () => frozenNow,
       getWorkflowRunEvidenceStatus: (runId) => statusByRunId.get(runId) ?? null,
+      // Audit C: these are persistence-fidelity tests; the orthogonal
+      // completion lookup is wired (fail-closed requires it) and returns
+      // `verified` for every run so it never interferes with the persistence
+      // assertions. Completion-specific refusals are covered by their own
+      // tests below.
+      getWorkflowRunCompletionVerification: () => "verified",
     });
   }
 
@@ -1246,6 +1252,82 @@ describe("Phase 14.5C module_28c — workflow evidence fail-closed", () => {
       verifierVerdict: "fresh-read verified",
     });
     expect(verified.status).toBe("verified");
+  });
+
+  // ── Audit C part-2: completion-verification FAIL-CLOSED guards ──
+  // These guard run-level completion enforcement the same way the persistence
+  // path is guarded, so production enforcement cannot be silently lost.
+
+  it("verifyClaim FAIL-CLOSED: refuses workflow_run_evidence ref when NO completion lookup is wired (even with persistence available)", () => {
+    // If the hub ever stops wiring getWorkflowRunCompletionVerification, a
+    // workflow_run_evidence claim must loudly refuse — never silently drop
+    // run-level completion enforcement.
+    const repository = createFridayTaskWorkflowRepository();
+    const service = createFridayTaskWorkflowService({
+      db,
+      repository,
+      idGenerator: () => {
+        nextId += 1;
+        return `id-${nextId.toString(16).padStart(8, "0")}`;
+      },
+      nowIso: () => frozenNow,
+      getWorkflowRunEvidenceStatus: () => "available", // persistence is healthy
+      // getWorkflowRunCompletionVerification intentionally omitted.
+    });
+    const workflow = service.create(makeCreateInput());
+    const claim = service.draftClaim(workflow.id, {
+      claimText: "ref backed by run with no completion lookup",
+      claimKind: "runtime_evidence",
+    });
+    service.attachEvidenceRef(workflow.id, claim.id, {
+      refKind: "workflow_run_evidence",
+      refId: "run-ok",
+      refSource: "workflow_run_evidence",
+    });
+    let err: FridayDomainError | null = null;
+    try {
+      service.verifyClaim(workflow.id, claim.id, { verifierVerdict: "fresh-read" });
+    } catch (e) {
+      err = e as FridayDomainError;
+    }
+    expect(err).toBeInstanceOf(FridayDomainError);
+    expect(err?.code).toBe("TASK_WORKFLOW_CLAIM_WORKFLOW_RUN_COMPLETION_UNVERIFIED");
+    expect((err?.details as { missingLookup?: boolean })?.missingLookup).toBe(true);
+  });
+
+  it("verifyClaim refuses workflow_run_evidence ref when source run completion is proof_pending (distinct from persistence)", () => {
+    const repository = createFridayTaskWorkflowRepository();
+    const service = createFridayTaskWorkflowService({
+      db,
+      repository,
+      idGenerator: () => {
+        nextId += 1;
+        return `id-${nextId.toString(16).padStart(8, "0")}`;
+      },
+      nowIso: () => frozenNow,
+      getWorkflowRunEvidenceStatus: () => "available", // persistence healthy
+      getWorkflowRunCompletionVerification: () => "proof_pending", // side-effect, no evidence
+    });
+    const workflow = service.create(makeCreateInput());
+    const claim = service.draftClaim(workflow.id, {
+      claimText: "ref backed by proof_pending run",
+      claimKind: "runtime_evidence",
+    });
+    service.attachEvidenceRef(workflow.id, claim.id, {
+      refKind: "workflow_run_evidence",
+      refId: "run-sideeffect",
+      refSource: "workflow_run_evidence",
+    });
+    let err: FridayDomainError | null = null;
+    try {
+      service.verifyClaim(workflow.id, claim.id, { verifierVerdict: "fresh-read" });
+    } catch (e) {
+      err = e as FridayDomainError;
+    }
+    expect(err?.code).toBe("TASK_WORKFLOW_CLAIM_WORKFLOW_RUN_COMPLETION_UNVERIFIED");
+    expect(err?.httpStatus).toBe(409);
+    // Orthogonal: NOT the persistence code, even though persistence is available.
+    expect(err?.code).not.toBe("TASK_WORKFLOW_CLAIM_WORKFLOW_RUN_EVIDENCE_UNAVAILABLE");
   });
 
   it("closeout receipt: evidenceDurability=available and proofClaimable=true on a clean run", () => {
@@ -1409,6 +1491,7 @@ describe("Phase 14.5D module_28d — closeout receipt rollback disclosure", () =
       },
       nowIso: () => frozenNow,
       getWorkflowRunEvidenceStatus: (runId) => statusByRunId.get(runId) ?? null,
+      getWorkflowRunCompletionVerification: () => "verified",
     });
     const workflow = service.create(makeCreateInput());
     const claim = service.draftClaim(workflow.id, {

--- a/test/unit/workflows/runtime/friday-workflow-acceptance-run-enforcement.test.ts
+++ b/test/unit/workflows/runtime/friday-workflow-acceptance-run-enforcement.test.ts
@@ -1,0 +1,127 @@
+import { createHash } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createFridayWorkflowRuntime,
+  type FridayCompiledWorkflowGraphV2,
+  type FridayWorkflowRuntime,
+} from "#workflows";
+import type { FridaySqliteLayer } from "#state";
+import { createTestDb, createTestIdGenerator } from "../../../helpers/friday-test-db.helper.js";
+
+// Audit C part-2: RUN-LEVEL enforcement of workflow node completion-truth.
+//
+// A side-effect node lacking deterministic evidence must make the run's
+// completion-verification aggregate non-`verified` (`proof_pending`) — so it
+// cannot be read as a clean/verified completion. This is ORTHOGONAL to the
+// evidence-persistence axis (`evidenceStatus`): a healthy-persistence run must
+// stay `evidenceStatus === "available"` while reporting `proof_pending`.
+// Conflating the two (the earlier overload) would falsely report a
+// healthy-persistence run as "degraded" — a reverse lie. The node still runs
+// (status completed); only the verified-completion truth changes. Closes the 3
+// run-level bypasses (arbitrary non-empty baseline, output==null, disabled
+// pipeline / legacy).
+
+const NOW = "2026-05-29T00:00:00.000Z";
+const waitMs = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+async function settle(runtime: FridayWorkflowRuntime, runId: string): Promise<string> {
+  for (let i = 0; i < 250; i += 1) {
+    const run = runtime.execution.getRun(runId);
+    if (run && ["completed", "failed", "cancelled"].includes(run.status)) return run.status;
+    await waitMs(20);
+  }
+  throw new Error(`run ${runId} did not settle`);
+}
+
+function graph(workflowId: string): FridayCompiledWorkflowGraphV2 {
+  return {
+    schemaVersion: "2.0", workflowId, workflowVersionId: "placeholder", sourceSpecSchemaVersion: "1.0",
+    graph: {
+      nodes: [
+        { id: "trigger", type: "trigger", label: "Trigger", config: {} },
+        { id: "act", type: "action", label: "Act", config: { skillId: "the-skill" } },
+      ],
+      edges: [{ id: "e1", sourceNodeId: "trigger", targetNodeId: "act" }],
+    },
+    failurePolicy: { onFailure: "fail_fast", notifyUser: false }, tests: [], checksum: "c-part2",
+  };
+}
+
+function runtimeWith(db: FridaySqliteLayer, grants: Array<{ action: string }>, output: unknown = { ok: true }): FridayWorkflowRuntime {
+  return createFridayWorkflowRuntime({
+    db, idGenerator: createTestIdGenerator(), nowIso: () => NOW,
+    computeChecksum: (c: string) => createHash("sha256").update(c).digest("hex"),
+    resolveSkill: () => ({ id: "the-skill", manifest: { permissions: { grants } } }),
+    invokeSkill: async () => output,
+  });
+}
+
+async function runAndGetTruth(
+  runtime: FridayWorkflowRuntime,
+): Promise<{ status: string; evidenceStatus?: string; completionVerification?: string }> {
+  const wf = runtime.crud.createWorkflow({ slug: `c2-${Math.random().toString(16).slice(2)}`, name: "C part2" });
+  const v = runtime.crud.createVersion(wf.id, graph(wf.id));
+  runtime.crud.publishVersion(wf.id, v.versionNumber);
+  const run = await runtime.execution.startRun({ workflowId: wf.id, workflowVersionId: v.id, triggerType: "manual" });
+  const status = await settle(runtime, run.id);
+  return {
+    status,
+    evidenceStatus: runtime.evidence.getRunEvidenceStatus(run.id),
+    completionVerification: runtime.evidence.getRunCompletionVerification(run.id),
+  };
+}
+
+describe("workflow acceptance run-level enforcement (audit C part-2)", () => {
+  let envEnable: string | undefined;
+  let envMode: string | undefined;
+  beforeEach(() => {
+    envEnable = process.env.FRIDAY_PIPELINE_ENABLE; envMode = process.env.FRIDAY_PIPELINE_MODE;
+    process.env.FRIDAY_PIPELINE_ENABLE = "true"; process.env.FRIDAY_PIPELINE_MODE = "enforce";
+  });
+  afterEach(() => {
+    if (envEnable === undefined) delete process.env.FRIDAY_PIPELINE_ENABLE; else process.env.FRIDAY_PIPELINE_ENABLE = envEnable;
+    if (envMode === undefined) delete process.env.FRIDAY_PIPELINE_MODE; else process.env.FRIDAY_PIPELINE_MODE = envMode;
+  });
+
+  it("ORTHOGONALITY: side-effect node (send grant) → completion proof_pending AND evidence available (no reverse lie)", async () => {
+    const db = createTestDb();
+    const r = await runAndGetTruth(runtimeWith(db, [{ action: "send" }]));
+    db.close();
+    expect(r.status).toBe("completed"); // node still ran — no over-blocking
+    expect(r.completionVerification).toBe("proof_pending"); // not a clean/verified completion
+    expect(r.evidenceStatus).toBe("available"); // persistence is HEALTHY — must NOT be downgraded
+  });
+
+  it("informational/read-only node → completion verified AND evidence available (no over-blocking)", async () => {
+    const db = createTestDb();
+    const r = await runAndGetTruth(runtimeWith(db, [{ action: "read" }]));
+    db.close();
+    expect(r.completionVerification).toBe("verified");
+    expect(r.evidenceStatus).toBe("available");
+  });
+
+  it("bypass 2: side-effect node with null output cannot stay clean — still proof_pending (output never decides truth)", async () => {
+    const db = createTestDb();
+    const r = await runAndGetTruth(runtimeWith(db, [{ action: "write" }], null));
+    db.close();
+    expect(r.completionVerification).toBe("proof_pending");
+    expect(r.evidenceStatus).toBe("available");
+  });
+
+  it("fail-closed: action node with empty grants (unknown capability) → proof_pending", async () => {
+    const db = createTestDb();
+    const r = await runAndGetTruth(runtimeWith(db, []));
+    db.close();
+    expect(r.completionVerification).toBe("proof_pending");
+    expect(r.evidenceStatus).toBe("available");
+  });
+
+  it("bypass 3: disabled pipeline (legacy) side-effect node is NOT a verified completion → proof_pending", async () => {
+    process.env.FRIDAY_PIPELINE_ENABLE = "false";
+    const db = createTestDb();
+    const r = await runAndGetTruth(runtimeWith(db, [{ action: "send" }]));
+    db.close();
+    expect(r.completionVerification).toBe("proof_pending");
+    expect(r.evidenceStatus).toBe("available");
+  });
+});

--- a/test/unit/workflows/runtime/friday-workflow-completion-verification-persistence.test.ts
+++ b/test/unit/workflows/runtime/friday-workflow-completion-verification-persistence.test.ts
@@ -1,0 +1,132 @@
+import { createHash } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createFridayWorkflowRuntime,
+  type FridayCompiledWorkflowGraphV2,
+  type FridayWorkflowRuntime,
+} from "#workflows";
+import type { FridaySqliteLayer } from "#state";
+import { createTestDb, createTestIdGenerator } from "../../../helpers/friday-test-db.helper.js";
+
+// Audit C Stage 2(B): the run-level completion-verification label is persisted
+// durably (workflow_runs.completion_verification, v089), so the truth survives
+// a hub restart. Stage 1 tracked it in-memory only, so a side-effect run that
+// settled `proof_pending` would amnesiacally read `verified` in a fresh process
+// (unknown -> verified default). This test simulates a restart by building a
+// SECOND runtime on the SAME db (fresh in-memory aggregate) and asserting the
+// persisted label is read back.
+//
+// NOTE: this proves ENFORCEMENT + PERSISTENCE only. Letting an honest
+// side-effect node EARN `verified` from runtime-observed evidence is the
+// separate contract-change (a) PR; here a side-effect node stays proof_pending.
+
+const NOW = "2026-05-29T00:00:00.000Z";
+const waitMs = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+async function settle(runtime: FridayWorkflowRuntime, runId: string): Promise<string> {
+  for (let i = 0; i < 250; i += 1) {
+    const run = runtime.execution.getRun(runId);
+    if (run && ["completed", "failed", "cancelled"].includes(run.status)) return run.status;
+    await waitMs(20);
+  }
+  throw new Error(`run ${runId} did not settle`);
+}
+
+function graph(workflowId: string): FridayCompiledWorkflowGraphV2 {
+  return {
+    schemaVersion: "2.0", workflowId, workflowVersionId: "placeholder", sourceSpecSchemaVersion: "1.0",
+    graph: {
+      nodes: [
+        { id: "trigger", type: "trigger", label: "Trigger", config: {} },
+        { id: "act", type: "action", label: "Act", config: { skillId: "the-skill" } },
+      ],
+      edges: [{ id: "e1", sourceNodeId: "trigger", targetNodeId: "act" }],
+    },
+    failurePolicy: { onFailure: "fail_fast", notifyUser: false }, tests: [], checksum: "c-stage2b",
+  };
+}
+
+function runtimeOn(db: FridaySqliteLayer, grants: Array<{ action: string }>): FridayWorkflowRuntime {
+  return createFridayWorkflowRuntime({
+    db, idGenerator: createTestIdGenerator(), nowIso: () => NOW,
+    computeChecksum: (c: string) => createHash("sha256").update(c).digest("hex"),
+    resolveSkill: () => ({ id: "the-skill", manifest: { permissions: { grants } } }),
+    invokeSkill: async () => ({ ok: true }),
+  });
+}
+
+async function runOn(runtime: FridayWorkflowRuntime): Promise<string> {
+  const wf = runtime.crud.createWorkflow({ slug: `c2b-${Math.random().toString(16).slice(2)}`, name: "C stage2b" });
+  const v = runtime.crud.createVersion(wf.id, graph(wf.id));
+  runtime.crud.publishVersion(wf.id, v.versionNumber);
+  const run = await runtime.execution.startRun({ workflowId: wf.id, workflowVersionId: v.id, triggerType: "manual" });
+  await settle(runtime, run.id);
+  return run.id;
+}
+
+describe("workflow completion-verification persistence (audit C Stage 2(B))", () => {
+  let envEnable: string | undefined;
+  let envMode: string | undefined;
+  beforeEach(() => {
+    envEnable = process.env.FRIDAY_PIPELINE_ENABLE; envMode = process.env.FRIDAY_PIPELINE_MODE;
+    process.env.FRIDAY_PIPELINE_ENABLE = "true"; process.env.FRIDAY_PIPELINE_MODE = "enforce";
+  });
+  afterEach(() => {
+    if (envEnable === undefined) delete process.env.FRIDAY_PIPELINE_ENABLE; else process.env.FRIDAY_PIPELINE_ENABLE = envEnable;
+    if (envMode === undefined) delete process.env.FRIDAY_PIPELINE_MODE; else process.env.FRIDAY_PIPELINE_MODE = envMode;
+  });
+
+  it("side-effect run: completion_verification column persists proof_pending", () => {
+    const db = createTestDb();
+    try {
+      // synchronous DDL/DML check is done via the runtime path below; here just
+      // confirm the column exists (migration applied).
+      const cols = db.withReadConnection((conn) =>
+        conn.prepare("PRAGMA table_info(workflow_runs)").all() as Array<{ name: string }>,
+      );
+      expect(cols.some((c) => c.name === "completion_verification")).toBe(true);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("RESTART: a proof_pending run is still proof_pending after a fresh runtime (no amnesia)", async () => {
+    const db = createTestDb();
+    try {
+      const first = runtimeOn(db, [{ action: "send" }]); // side-effect → proof_pending
+      const runId = await runOn(first);
+      expect(first.evidence.getRunCompletionVerification(runId)).toBe("proof_pending");
+      // Persisted to the column:
+      const persisted = db.withReadConnection((conn) =>
+        (conn.prepare("SELECT completion_verification AS c FROM workflow_runs WHERE id = ?").get(runId) as { c: string | null }).c,
+      );
+      expect(persisted).toBe("proof_pending");
+
+      // Simulate a hub restart: a brand-new runtime instance on the SAME db has
+      // an EMPTY in-memory aggregate. Without persistence it would read the
+      // amnesiac "verified"; with v089 it reads the persisted truth.
+      const afterRestart = runtimeOn(db, [{ action: "send" }]);
+      expect(afterRestart.evidence.getRunCompletionVerification(runId)).toBe("proof_pending");
+    } finally {
+      db.close();
+    }
+  });
+
+  it("RESTART: a clean verified (read-only) run reads verified after restart (NULL column → default)", async () => {
+    const db = createTestDb();
+    try {
+      const first = runtimeOn(db, [{ action: "read" }]); // informational → verified
+      const runId = await runOn(first);
+      expect(first.evidence.getRunCompletionVerification(runId)).toBe("verified");
+      const persisted = db.withReadConnection((conn) =>
+        (conn.prepare("SELECT completion_verification AS c FROM workflow_runs WHERE id = ?").get(runId) as { c: string | null }).c,
+      );
+      expect(persisted).toBeNull(); // verified is never persisted (NULL default)
+
+      const afterRestart = runtimeOn(db, [{ action: "read" }]);
+      expect(afterRestart.evidence.getRunCompletionVerification(runId)).toBe("verified");
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/test/unit/workflows/runtime/friday-workflow-node-acceptance.test.ts
+++ b/test/unit/workflows/runtime/friday-workflow-node-acceptance.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyWorkflowNodeSideEffect,
+  resolveNodeCompletionVerification,
+  isVerifiedCompletion,
+} from "../../../../src/workflows/runtime/friday-workflow-node-acceptance.js";
+import type { FridayWorkflowNode } from "../../../../src/workflows/model/friday-workflow-graph.types.js";
+
+// Audit C Stage 1: a side-effect node without deterministic evidence must be
+// truth-labeled proof_pending (NOT a clean/verified completion); classification
+// derives from declared capability (node.type + manifest grants), never output.
+
+function node(type: FridayWorkflowNode["type"], config: Record<string, unknown> = {}): Pick<FridayWorkflowNode, "type" | "config"> {
+  return { type, config } as Pick<FridayWorkflowNode, "type" | "config">;
+}
+const skillWith = (actions: string[]) => () => ({ manifest: { permissions: { grants: actions.map((a) => ({ action: a })) } } });
+const noSkill = () => null;
+
+describe("workflow node acceptance classifier (audit C)", () => {
+  it("pure-compute nodes (trigger/condition/data) are informational → verified", () => {
+    for (const t of ["trigger", "condition", "data"] as const) {
+      const cls = classifyWorkflowNodeSideEffect(node(t), noSkill);
+      expect(cls).toBe("informational");
+      expect(resolveNodeCompletionVerification(node(t), cls)).toBe("verified");
+    }
+  });
+
+  it("ai / approval nodes are informational → model_assessed_unverified (never release proof)", () => {
+    for (const t of ["ai", "approval"] as const) {
+      const cls = classifyWorkflowNodeSideEffect(node(t), noSkill);
+      const v = resolveNodeCompletionVerification(node(t), cls);
+      expect(v).toBe("model_assessed_unverified");
+      expect(isVerifiedCompletion(v)).toBe(false);
+    }
+  });
+
+  it("action node with a side-effecting grant (write/send/connect/execute/capture) → side_effect → proof_pending", () => {
+    for (const a of ["write", "send", "connect", "execute", "capture"]) {
+      const n = node("action", { skillId: "s1" });
+      const cls = classifyWorkflowNodeSideEffect(n, skillWith([a]));
+      expect(cls).toBe("side_effect");
+      const v = resolveNodeCompletionVerification(n, cls);
+      expect(v).toBe("proof_pending");
+      expect(isVerifiedCompletion(v)).toBe(false);
+    }
+  });
+
+  it("action node whose grants are all read/receive → informational → verified", () => {
+    const n = node("action", { skillId: "s1" });
+    const cls = classifyWorkflowNodeSideEffect(n, skillWith(["read", "receive"]));
+    expect(cls).toBe("informational");
+    expect(resolveNodeCompletionVerification(n, cls)).toBe("verified");
+  });
+
+  it("fail-closed: action node with empty grants → side_effect (empty != safe)", () => {
+    const n = node("action", { skillId: "s1" });
+    expect(classifyWorkflowNodeSideEffect(n, skillWith([]))).toBe("side_effect");
+  });
+
+  it("fail-closed: action node with unresolved skill or no skillId → side_effect", () => {
+    expect(classifyWorkflowNodeSideEffect(node("action", { skillId: "missing" }), noSkill)).toBe("side_effect");
+    expect(classifyWorkflowNodeSideEffect(node("action", {}), skillWith(["write"]))).toBe("side_effect");
+  });
+
+  it("supports config.ref as the skill identity", () => {
+    const n = node("action", { ref: "s2" });
+    expect(classifyWorkflowNodeSideEffect(n, skillWith(["send"]))).toBe("side_effect");
+  });
+
+  it("legacy v1 permission shape (network:true) → side_effect", () => {
+    const legacySkill = () => ({ manifest: { permissions: { network: true, filesystem: "none", memoryScope: "read", tools: [] } } });
+    expect(classifyWorkflowNodeSideEffect(node("action", { skillId: "s3" }), legacySkill)).toBe("side_effect");
+  });
+
+  it("Stage 2 forward-compat: side_effect WITH deterministic evidence → verified", () => {
+    const n = node("action", { skillId: "s1" });
+    const cls = classifyWorkflowNodeSideEffect(n, skillWith(["write"]));
+    expect(resolveNodeCompletionVerification(n, cls, /* hasDeterministicEvidence */ true)).toBe("verified");
+  });
+});

--- a/test/unit/workflows/runtime/friday-workflow-runtime.test.ts
+++ b/test/unit/workflows/runtime/friday-workflow-runtime.test.ts
@@ -69,7 +69,11 @@ function createRuntime(db: FridaySqliteLayer): FridayWorkflowRuntime {
     idGenerator: createTestIdGenerator(),
     nowIso: () => NOW,
     computeChecksum: (content: string) => createHash("sha256").update(content).digest("hex"),
-    resolveSkill: () => ({ id: "fail-closed-skill" }),
+    // Read-only (informational) skill: this suite tests evidence-PERSISTENCE
+    // fail-closed, not side-effect verification, so the action node is a benign
+    // read skill (audit C: read/receive grants → informational → verified, so the
+    // node-acceptance classifier does not downgrade these runs).
+    resolveSkill: () => ({ id: "fail-closed-skill", manifest: { permissions: { grants: [{ action: "read" }] } } }),
     invokeSkill: async () => ({ ok: true, data: ["sample"] }),
   });
 }

--- a/validation/real-world/lib/executors.mjs
+++ b/validation/real-world/lib/executors.mjs
@@ -1302,7 +1302,15 @@ async function executeWorkflowEvidenceFailClosed({ artifact, scenario }) {
     idGenerator,
     nowIso: () => WORKFLOW_EVIDENCE_FAIL_CLOSED_NOW,
     computeChecksum: (content) => crypto.createHash("sha256").update(content).digest("hex"),
-    resolveSkill: () => ({ id: "rgg-evidence-fail-closed-skill" }),
+    // Audit C: this scenario exercises evidence-PERSISTENCE fail-closed; its
+    // action node is a benign informational placeholder, so it declares a
+    // read-only manifest → completion `verified` (without one it would
+    // fail-closed to a side-effect `proof_pending` run, which is correct but
+    // orthogonal to what this scenario proves).
+    resolveSkill: () => ({
+      id: "rgg-evidence-fail-closed-skill",
+      manifest: { permissions: { grants: [{ action: "read" }] } },
+    }),
     invokeSkill: async () => ({ ok: true }),
   });
   const taskWorkflowRepository = createFridayTaskWorkflowRepository();
@@ -1313,6 +1321,11 @@ async function executeWorkflowEvidenceFailClosed({ artifact, scenario }) {
     idGenerator: () => `rgg-tw-${String(++taskWorkflowIdCounter).padStart(6, "0")}`,
     nowIso: () => WORKFLOW_EVIDENCE_FAIL_CLOSED_NOW,
     getWorkflowRunEvidenceStatus: (runId) => runtime.evidence.getRunEvidenceStatus(runId),
+    // Audit C: wire the orthogonal completion lookup exactly as the hub does
+    // (verifyClaim is fail-closed and requires it). The read-only run is
+    // `verified`, so the workflow_run_evidence claim still reaches verified.
+    getWorkflowRunCompletionVerification: (runId) =>
+      runtime.evidence.getRunCompletionVerification(runId),
   });
 
   const failures = [];
@@ -1670,7 +1683,14 @@ async function executeTaskWorkflowRollbackMatrix({ artifact, scenario }) {
     idGenerator,
     nowIso: () => TASK_WORKFLOW_ROLLBACK_MATRIX_NOW,
     computeChecksum: (content) => crypto.createHash("sha256").update(content).digest("hex"),
-    resolveSkill: () => ({ id: "rgg-rollback-matrix-skill" }),
+    // Audit C: this scenario tests ROLLBACK-CLASS disclosure (derived from the
+    // ref SOURCE type), orthogonal to completion-verification. Its placeholder
+    // action node is informational → read-only manifest → completion
+    // `verified`, so a workflow_run_evidence claim can still be verified here.
+    resolveSkill: () => ({
+      id: "rgg-rollback-matrix-skill",
+      manifest: { permissions: { grants: [{ action: "read" }] } },
+    }),
     invokeSkill: async () => ({ ok: true }),
   });
   const taskWorkflowRepository = createFridayTaskWorkflowRepository();
@@ -1681,6 +1701,11 @@ async function executeTaskWorkflowRollbackMatrix({ artifact, scenario }) {
     idGenerator: () => `rgg-tw-rb-${String(++taskWorkflowIdCounter).padStart(6, "0")}`,
     nowIso: () => TASK_WORKFLOW_ROLLBACK_MATRIX_NOW,
     getWorkflowRunEvidenceStatus: (runId) => runtime.evidence.getRunEvidenceStatus(runId),
+    // Audit C: wire the orthogonal completion lookup as the hub does
+    // (verifyClaim is fail-closed and requires it). The read-only run is
+    // `verified`, so the workflow_run_evidence claim still reaches verified.
+    getWorkflowRunCompletionVerification: (runId) =>
+      runtime.evidence.getRunCompletionVerification(runId),
   });
 
   const failures = [];


### PR DESCRIPTION
## What & why

Audit finding **C** (workflow-node false-completion): a side-effect / mutating / user-visible-claim workflow node could be read as a **verified** completion off nothing more than arbitrary non-empty output. This PR implements **actual run-level enforcement** (not mere labeling) that closes the 3 run-level bypasses:

1. arbitrary non-empty output passing the vacuous acceptance baseline,
2. `output == null` skipping the gate entirely,
3. the disabled-pipeline / legacy path being treated as verified.

## Design: a SEPARATE, orthogonal truth axis (no reverse lie)

Completion-verification is tracked as its **own** run-level axis, fully **orthogonal** to evidence-persistence health (`evidenceStatus`). An earlier attempt overloaded `evidenceStatus → "degraded"` for any non-verified node — that was a *reverse lie* (a run with perfectly healthy persistence reported as "degraded") and broke 4 e2e proof/persistence tests. That overload is reverted; the two axes never conflate.

- **Runtime** (`friday-workflow-runtime`): per-run `completionVerification` aggregate (worst node label wins); `getRunCompletionVerification` is **fail-closed for non-settled runs** (a run not terminally `completed` is never `verified` → closes the mid-flight time-of-check race at the source). Surfaced on the evidence facade and the run receipt; never touches `evidenceStatus`.
- **Classification** (Stage 1, from part-1): a node is `verified` only when it is deterministic pure-compute or read-only; `ai`/`approval` → `model_assessed_unverified`; a side-effect node lacking deterministic evidence (or with unresolvable/empty grants — fail-closed) → `proof_pending`. Derived from declared capability (node type + manifest grants), **never** from output.
- **Task-workflow verifier** (the consumer / teeth) — **FAIL-CLOSED**: `verifyClaim` refuses a `workflow_run_evidence` ref whose source run is not `verified`, with the **distinct** code `TASK_WORKFLOW_CLAIM_WORKFLOW_RUN_COMPLETION_UNVERIFIED` (409) — never the persistence code. A *missing* completion lookup is itself a refusal, so losing the hub wiring becomes a **loud refuse** in production, never silent non-enforcement. The hub bootstrap wires it.

No closeout gate is added: `attachEvidenceRef` already blocks attaching refs to verified claims, and the completion label is immutable within a process lifetime, so (unlike persistence durability) there is no post-verify drift to re-check.

## Proof

- **Full default suite green:** 12226 passed / 159 skipped / **0 failed**; typecheck clean.
- **NEW enforcement e2e** (`...completion-verification-enforcement.acceptance`): side-effect & unresolved-skill runs are refused at `verifyClaim` with the distinct code; read-only run verifies (no over-blocking); **mid-flight TOCTOU** refused.
- **NEW service unit guards:** fail-closed when the completion lookup is absent (catches hub-wiring loss); `proof_pending` run refused distinctly from persistence.
- **run-enforcement unit:** asserts orthogonality (`proof_pending` AND `evidenceStatus === "available"`) across all 3 bypasses.
- The 4 prior blast-radius e2e tests pass; genuinely-informational fixtures were given read-only manifests + the completion lookup wired exactly as the hub wires it.

## Known limitation (scoped to Stage 2)

The completion aggregate is **process-lifetime in-memory** (same as `evidenceStatus`). After a hub restart, a previously `proof_pending` *completed* run reads `verified` (unknown→verified default). This **matches `evidenceStatus`'s existing behavior and is not a regression**; persisting the label durably is **Stage 2** (which is also where deterministic side-effect evidence would upgrade `proof_pending → verified`).

## Drift

Rebased onto latest `origin/main` (includes #395). No file overlap with concurrent work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)