### PR TITLE
fix(agent): unwrap command wrappers + gate shell -c in shell-risk gate (ANNEX B6 follow-up)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -603,7 +603,7 @@
         "filename": "test/unit/agent/runtime/friday-agent-tool-risk.test.ts",
         "hashed_secret": "d14babe099a92466c4efa49400806772a6c097cd",
         "is_verified": false,
-        "line_number": 251
+        "line_number": 304
       }
     ],
     "test/unit/api/auth/friday-auth-middleware.test.ts": [
@@ -1124,5 +1124,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-29T02:06:35Z"
+  "generated_at": "2026-05-29T02:29:48Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -603,7 +603,7 @@
         "filename": "test/unit/agent/runtime/friday-agent-tool-risk.test.ts",
         "hashed_secret": "d14babe099a92466c4efa49400806772a6c097cd",
         "is_verified": false,
-        "line_number": 304
+        "line_number": 316
       }
     ],
     "test/unit/api/auth/friday-auth-middleware.test.ts": [
@@ -1124,5 +1124,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-29T02:29:48Z"
+  "generated_at": "2026-05-29T02:50:13Z"
 }

--- a/src/agent/runtime/friday-agent-tool-risk.ts
+++ b/src/agent/runtime/friday-agent-tool-risk.ts
@@ -56,6 +56,125 @@ function normalizeProgramName(token: string | undefined): string {
   return normalized.split("/").at(-1)?.toLowerCase() ?? "";
 }
 
+// Inline env-assignment token (`FOO=bar cmd`), leading on a command or after `env`'s options.
+const INLINE_ENV_ASSIGNMENT_RE = /^[A-Za-z_][A-Za-z0-9_]*=/;
+
+// Shells/interpreters that execute an opaque code string passed via a flag. The string cannot
+// be statically decomposed (quoting / nesting), so the presence of the code flag forces
+// approval rather than an unsound parse. (Metacharacter-bearing strings are already blocked
+// upstream by BLOCKED_SHELL_PATTERNS; this catches the plain `sh -c "rm -rf /data"` form.)
+const SHELL_PROGRAMS = new Set(["sh", "bash", "zsh", "dash", "ksh", "ash", "csh", "tcsh"]);
+const SHELL_CODE_FLAG_RE = /^-[a-z]*c$/i; // -c and clustered forms like -lc / -ic
+
+// Transparent command wrappers that exec a child process — the wrapped command is what the
+// risk gate must actually classify. For each, `value` = options consuming a following token
+// (space-form); `flag` = value-less options. Any UNRECOGNIZED leading dash-option fails safe to
+// "requires approval" so an unmodeled value-option cannot shift the wrapped command out of view
+// (same fail-safe philosophy as the git global-option parse).
+const COMMAND_WRAPPER_OPTS: Record<string, { value: ReadonlySet<string>; flag: ReadonlySet<string> }> = {
+  env: {
+    value: new Set(["-u", "--unset", "-C", "--chdir", "-S", "--split-string"]),
+    flag: new Set(["-i", "--ignore-environment", "-", "-0", "--null", "-v", "--debug"]),
+  },
+  sudo: {
+    value: new Set([
+      "-u", "--user", "-g", "--group", "-C", "--close-from", "-h", "--host", "-p", "--prompt",
+      "-r", "--role", "-t", "--type", "-U", "--other-user", "-D", "--chdir", "-R", "--chroot",
+    ]),
+    flag: new Set([
+      "-A", "--askpass", "-b", "--background", "-E", "--preserve-env", "-H", "--set-home",
+      "-i", "--login", "-K", "--remove-timestamp", "-k", "--reset-timestamp", "-l", "--list",
+      "-n", "--non-interactive", "-P", "--preserve-groups", "-S", "--stdin", "-s", "--shell",
+      "-V", "--version", "-v", "--validate",
+    ]),
+  },
+  doas: { value: new Set(["-u", "-C"]), flag: new Set(["-L", "-n", "-s"]) },
+  command: { value: new Set([]), flag: new Set(["-p", "-v", "-V"]) },
+  nice: { value: new Set(["-n", "--adjustment"]), flag: new Set([]) },
+  nohup: { value: new Set([]), flag: new Set([]) },
+  setsid: { value: new Set([]), flag: new Set(["-c", "--ctty", "-f", "--fork", "-w", "--wait"]) },
+  timeout: {
+    value: new Set(["-s", "--signal", "-k", "--kill-after"]),
+    flag: new Set(["--preserve-status", "--foreground", "-v", "--verbose", "-f"]),
+  },
+  xargs: {
+    value: new Set([
+      "-I", "--replace", "-i", "-n", "--max-args", "-P", "--max-procs", "-d", "--delimiter",
+      "-E", "-e", "--eof", "-L", "--max-lines", "-l", "-s", "--max-chars", "-a", "--arg-file",
+    ]),
+    flag: new Set(["-0", "--null", "-p", "--interactive", "-r", "--no-run-if-empty", "-t", "--verbose", "-x", "--exit"]),
+  },
+  time: {
+    value: new Set(["-o", "--output", "-f", "--format"]),
+    flag: new Set(["-p", "-v", "--verbose", "-a", "--append"]),
+  },
+};
+
+interface UnwrappedCommand {
+  /** Set when the wrapper form itself requires approval (shell `-c`, or an unparseable wrapper). */
+  approve?: string;
+  /** The innermost command tokens to risk-classify (the original tokens if there was no wrapper). */
+  inner: string[];
+}
+
+// Strip transparent command wrappers (`env`/`sudo`/`nice`/`timeout`/`xargs`/…) and inline
+// env-assignment prefixes so the INNERMOST command is what gets risk-classified, and force
+// approval when a shell/interpreter is handed an opaque code string. Recognized wrapper options
+// are skipped precisely; an unrecognized option (which might hide the wrapped command) forces
+// approval rather than a guess. Recurses (with a depth guard) so nested forms like
+// `sudo env rm -rf` and `sudo bash -c …` resolve to their effective risk.
+function unwrapCommand(parts: readonly string[]): UnwrappedCommand {
+  let toks: string[] = parts.slice();
+  for (let depth = 0; depth < 6 && toks.length > 0; depth++) {
+    let s = 0;
+    while (s < toks.length && INLINE_ENV_ASSIGNMENT_RE.test(toks[s]!)) s += 1;
+    if (s > 0) {
+      toks = toks.slice(s);
+      if (toks.length === 0) break;
+    }
+
+    const prog = normalizeProgramName(toks[0]);
+
+    if (SHELL_PROGRAMS.has(prog) && toks.slice(1).some((t) => SHELL_CODE_FLAG_RE.test(t))) {
+      return {
+        approve: `\`${prog} -c …\` executes an opaque command string that cannot be inspected and requires explicit approval in the current run context.`,
+        inner: toks,
+      };
+    }
+
+    // `command -v`/`-V` is a lookup (it does NOT exec the named program) → not a wrapper here.
+    if (prog === "command" && toks.slice(1).some((t) => t === "-v" || t === "-V")) break;
+
+    const spec = COMMAND_WRAPPER_OPTS[prog];
+    if (!spec) break; // not a transparent wrapper → this is the effective command
+
+    let i = 1;
+    while (i < toks.length) {
+      const opt = toks[i]!;
+      if (!opt.startsWith("-")) break; // reached operands / the wrapped command
+      if (opt === "--") { i += 1; break; } // explicit end of options
+      if (opt.includes("=")) { i += 1; continue; } // --opt=value
+      if (prog === "nice" && /^-\d+$/.test(opt)) { i += 1; continue; } // `nice -10` adjustment
+      if (spec.value.has(opt)) { i += 2; continue; }
+      if (spec.flag.has(opt)) { i += 1; continue; }
+      return {
+        approve: `\`${prog}\` was invoked with an unrecognized option, so the wrapped command cannot be verified; requires explicit approval in the current run context.`,
+        inner: toks,
+      };
+    }
+    if (prog === "env") {
+      while (i < toks.length && INLINE_ENV_ASSIGNMENT_RE.test(toks[i]!)) i += 1;
+    }
+    if (prog === "timeout" && i < toks.length && !toks[i]!.startsWith("-")) {
+      i += 1; // positional DURATION precedes the wrapped command
+    }
+
+    if (i >= toks.length) return { inner: toks }; // wrapper with no wrapped command (e.g. `sudo -l`)
+    toks = toks.slice(i);
+  }
+  return { inner: toks };
+}
+
 /**
  * Classify the risk level of a shell command.
  */
@@ -73,7 +192,15 @@ export function classifyShellRisk(command: string): FridayShellRiskClassificatio
   }
 
   const parts = trimmed.split(/\s+/);
-  const program = normalizeProgramName(parts[0]);
+
+  // Unwrap transparent command wrappers (env/sudo/nice/timeout/xargs/…) so the WRAPPED command
+  // is what gets classified; a shell `-c` string or an unparseable wrapper requires approval.
+  const unwrapped = unwrapCommand(parts);
+  if (unwrapped.approve) {
+    return { level: "destructive", reason: unwrapped.approve, program: normalizeProgramName(parts[0]) };
+  }
+  const effectiveParts = unwrapped.inner;
+  const program = normalizeProgramName(effectiveParts[0]);
 
   // Destructive programs always require approval
   // Also match mkfs.* variants (mkfs.ext4, mkfs.xfs, etc.)
@@ -84,7 +211,7 @@ export function classifyShellRisk(command: string): FridayShellRiskClassificatio
 
   // Destructive FLAGS on otherwise-safe programs (git reset --hard, git clean -fdx,
   // find . -delete) — classification must key on flags, not just the program name.
-  const dangerousFlagReason = detectDangerousShellFlagReason(program, parts);
+  const dangerousFlagReason = detectDangerousShellFlagReason(program, effectiveParts);
   if (dangerousFlagReason) {
     return { level: "destructive", reason: dangerousFlagReason, program };
   }
@@ -299,7 +426,15 @@ export function getApprovalRequiredReasonForExecCommand(command: string): string
   }
 
   const parts = trimmed.split(/\s+/);
-  const program = normalizeProgramName(parts[0]);
+
+  // Unwrap transparent command wrappers so the WRAPPED command is what gates approval; a shell
+  // `-c` string or an unparseable wrapper requires approval outright.
+  const unwrapped = unwrapCommand(parts);
+  if (unwrapped.approve) {
+    return unwrapped.approve;
+  }
+  const effectiveParts = unwrapped.inner;
+  const program = normalizeProgramName(effectiveParts[0]);
   const lowerCommand = trimmed.toLowerCase();
   const touchesProtectedArtifact = listPotentialFilePaths(trimmed)
     .some((filePath) => requiresApprovalForProtectedArtifactPath(filePath));
@@ -312,7 +447,7 @@ export function getApprovalRequiredReasonForExecCommand(command: string): string
     return "Deleting files from the shell is destructive and requires explicit approval in the current run context.";
   }
 
-  const dangerousFlagReason = detectDangerousShellFlagReason(program, parts);
+  const dangerousFlagReason = detectDangerousShellFlagReason(program, effectiveParts);
   if (dangerousFlagReason) {
     return dangerousFlagReason;
   }

--- a/src/agent/runtime/friday-agent-tool-risk.ts
+++ b/src/agent/runtime/friday-agent-tool-risk.ts
@@ -99,10 +99,15 @@ const COMMAND_WRAPPER_OPTS: Record<string, { value: ReadonlySet<string>; flag: R
   },
   xargs: {
     value: new Set([
-      "-I", "--replace", "-i", "-n", "--max-args", "-P", "--max-procs", "-d", "--delimiter",
-      "-E", "-e", "--eof", "-L", "--max-lines", "-l", "-s", "--max-chars", "-a", "--arg-file",
+      "-I", "-n", "--max-args", "-P", "--max-procs", "-d", "--delimiter",
+      "-E", "-L", "--max-lines", "-s", "--max-chars", "-a", "--arg-file",
     ]),
-    flag: new Set(["-0", "--null", "-p", "--interactive", "-r", "--no-run-if-empty", "-t", "--verbose", "-x", "--exit"]),
+    // -i/--replace, -e/--eof, -l take OPTIONAL (attached-only) arguments per getopt: a SEPARATE
+    // following token is the wrapped command, not the value, so they must be flags (skip 1).
+    flag: new Set([
+      "-0", "--null", "-p", "--interactive", "-r", "--no-run-if-empty", "-t", "--verbose", "-x", "--exit",
+      "-i", "--replace", "-e", "--eof", "-l",
+    ]),
   },
   time: {
     value: new Set(["-o", "--output", "-f", "--format"]),
@@ -125,7 +130,14 @@ interface UnwrappedCommand {
 // `sudo env rm -rf` and `sudo bash -c …` resolve to their effective risk.
 function unwrapCommand(parts: readonly string[]): UnwrappedCommand {
   let toks: string[] = parts.slice();
-  for (let depth = 0; depth < 6 && toks.length > 0; depth++) {
+  for (let depth = 0; toks.length > 0; depth++) {
+    if (depth >= 8) {
+      // pathological wrapper nesting we cannot confidently resolve → fail safe.
+      return {
+        approve: "deeply nested command wrappers cannot be verified; requires explicit approval in the current run context.",
+        inner: toks,
+      };
+    }
     let s = 0;
     while (s < toks.length && INLINE_ENV_ASSIGNMENT_RE.test(toks[s]!)) s += 1;
     if (s > 0) {
@@ -157,6 +169,9 @@ function unwrapCommand(parts: readonly string[]): UnwrappedCommand {
       if (prog === "nice" && /^-\d+$/.test(opt)) { i += 1; continue; } // `nice -10` adjustment
       if (spec.value.has(opt)) { i += 2; continue; }
       if (spec.flag.has(opt)) { i += 1; continue; }
+      // attached-value short option, e.g. `-n10` / `-sKILL` / `-uroot` (value glued to a known
+      // short value-opt) — the value is in this token, so skip just the one token.
+      if (!opt.startsWith("--") && opt.length > 2 && spec.value.has(opt.slice(0, 2))) { i += 1; continue; }
       return {
         approve: `\`${prog}\` was invoked with an unrecognized option, so the wrapped command cannot be verified; requires explicit approval in the current run context.`,
         inner: toks,

--- a/test/unit/agent/runtime/friday-agent-tool-risk.test.ts
+++ b/test/unit/agent/runtime/friday-agent-tool-risk.test.ts
@@ -166,6 +166,13 @@ describe("friday-agent-tool-risk", () => {
       expect(classifyShellRisk("time rm -rf /data")).toMatchObject({ level: "destructive", program: "rm" });
       // nested wrappers resolve to the effective risk.
       expect(classifyShellRisk("sudo env rm -rf /data")).toMatchObject({ level: "destructive", program: "rm" });
+      // xargs optional-arg options (-i/--replace/-e/-l) take attached-only values → a separate
+      // token is the wrapped command, not the value.
+      expect(classifyShellRisk("xargs -i git reset --hard")).toMatchObject({ level: "destructive", program: "git" });
+      expect(classifyShellRisk("xargs --replace rm -rf /data")).toMatchObject({ level: "destructive", program: "rm" });
+      expect(classifyShellRisk("xargs -I REPL rm")).toMatchObject({ level: "destructive", program: "rm" });
+      // attached-value short option (value glued to the flag) still finds the wrapped command.
+      expect(classifyShellRisk("nice -n10 rm -rf /data")).toMatchObject({ level: "destructive", program: "rm" });
     });
 
     it("requires approval for shell -c strings and unparseable wrappers (fail-safe)", () => {
@@ -175,6 +182,8 @@ describe("friday-agent-tool-risk", () => {
       expect(classifyShellRisk("zsh -c rm")).toMatchObject({ level: "destructive" });
       // an unrecognized wrapper option could hide the wrapped command → fail safe to approval.
       expect(classifyShellRisk("sudo --frobnicate rm -rf /data")).toMatchObject({ level: "destructive" });
+      // pathological deep wrapper nesting fails safe (cannot confidently resolve).
+      expect(classifyShellRisk(`${"env ".repeat(10)}rm -rf /data`)).toMatchObject({ level: "destructive" });
     });
 
     it("does not over-block benign wrapped commands", () => {
@@ -182,6 +191,9 @@ describe("friday-agent-tool-risk", () => {
       expect(classifyShellRisk("env VAR=v node x.js")).toMatchObject({ level: "safe", program: "node" });
       expect(classifyShellRisk("sudo git status")).toMatchObject({ level: "safe", program: "git" });
       expect(classifyShellRisk("nice -n 10 ls -la")).toMatchObject({ level: "safe", program: "ls" });
+      expect(classifyShellRisk("nice -n10 ls")).toMatchObject({ level: "safe", program: "ls" });
+      expect(classifyShellRisk("xargs -n1 echo hi")).toMatchObject({ level: "safe", program: "echo" });
+      expect(classifyShellRisk("xargs -P4 echo")).toMatchObject({ level: "safe", program: "echo" });
       expect(classifyShellRisk("env git status")).toMatchObject({ level: "safe", program: "git" });
       // `command -v rm` is a lookup, not an exec → not destructive.
       expect(classifyShellRisk("command -v rm")).toMatchObject({ level: "guarded", program: "command" });

--- a/test/unit/agent/runtime/friday-agent-tool-risk.test.ts
+++ b/test/unit/agent/runtime/friday-agent-tool-risk.test.ts
@@ -148,6 +148,44 @@ describe("friday-agent-tool-risk", () => {
       expect(classifyShellRisk("/usr/bin/git status")).toMatchObject({ level: "safe", program: "git" });
       expect(classifyShellRisk("/bin/ls -la")).toMatchObject({ level: "safe", program: "ls" });
     });
+
+    it("unwraps transparent command wrappers to classify the wrapped command (no wrapper bypass)", () => {
+      // env was in SAFE_PROGRAMS and re-execs its argument → must classify the WRAPPED command.
+      expect(classifyShellRisk("env rm -rf /data")).toMatchObject({ level: "destructive", program: "rm" });
+      expect(classifyShellRisk("env FOO=bar rm -rf /data")).toMatchObject({ level: "destructive", program: "rm" });
+      expect(classifyShellRisk("sudo rm -rf /data")).toMatchObject({ level: "destructive", program: "rm" });
+      expect(classifyShellRisk("sudo git reset --hard")).toMatchObject({ level: "destructive", program: "git" });
+      expect(classifyShellRisk("sudo -u root rm -rf /data")).toMatchObject({ level: "destructive", program: "rm" });
+      expect(classifyShellRisk("nice rm -rf /data")).toMatchObject({ level: "destructive", program: "rm" });
+      expect(classifyShellRisk("nice -n 10 rm -rf /data")).toMatchObject({ level: "destructive", program: "rm" });
+      expect(classifyShellRisk("nice -10 rm -rf /data")).toMatchObject({ level: "destructive", program: "rm" });
+      expect(classifyShellRisk("timeout 5 rm -rf /data")).toMatchObject({ level: "destructive", program: "rm" });
+      expect(classifyShellRisk("timeout -s KILL 5 git clean -fdx")).toMatchObject({ level: "destructive", program: "git" });
+      expect(classifyShellRisk("xargs rm")).toMatchObject({ level: "destructive", program: "rm" });
+      expect(classifyShellRisk("command rm -rf /data")).toMatchObject({ level: "destructive", program: "rm" });
+      expect(classifyShellRisk("time rm -rf /data")).toMatchObject({ level: "destructive", program: "rm" });
+      // nested wrappers resolve to the effective risk.
+      expect(classifyShellRisk("sudo env rm -rf /data")).toMatchObject({ level: "destructive", program: "rm" });
+    });
+
+    it("requires approval for shell -c strings and unparseable wrappers (fail-safe)", () => {
+      // a shell `-c` string is opaque (cannot be statically decomposed) → approval.
+      expect(classifyShellRisk('sh -c "rm -rf /data"')).toMatchObject({ level: "destructive" });
+      expect(classifyShellRisk('bash -c "rm -rf /data"')).toMatchObject({ level: "destructive" });
+      expect(classifyShellRisk("zsh -c rm")).toMatchObject({ level: "destructive" });
+      // an unrecognized wrapper option could hide the wrapped command → fail safe to approval.
+      expect(classifyShellRisk("sudo --frobnicate rm -rf /data")).toMatchObject({ level: "destructive" });
+    });
+
+    it("does not over-block benign wrapped commands", () => {
+      expect(classifyShellRisk("env node app.js")).toMatchObject({ level: "safe", program: "node" });
+      expect(classifyShellRisk("env VAR=v node x.js")).toMatchObject({ level: "safe", program: "node" });
+      expect(classifyShellRisk("sudo git status")).toMatchObject({ level: "safe", program: "git" });
+      expect(classifyShellRisk("nice -n 10 ls -la")).toMatchObject({ level: "safe", program: "ls" });
+      expect(classifyShellRisk("env git status")).toMatchObject({ level: "safe", program: "git" });
+      // `command -v rm` is a lookup, not an exec → not destructive.
+      expect(classifyShellRisk("command -v rm")).toMatchObject({ level: "guarded", program: "command" });
+    });
   });
 
   // ─── getApprovalRequiredReasonForExecCommand ───
@@ -192,6 +230,17 @@ describe("friday-agent-tool-risk", () => {
       expect(getApprovalRequiredReasonForExecCommand("./scripts/rm thing")).toContain("approval");
     });
 
+    it("requires approval for destructive commands behind transparent wrappers", () => {
+      expect(getApprovalRequiredReasonForExecCommand("env rm -rf /data")).toContain("approval");
+      expect(getApprovalRequiredReasonForExecCommand("sudo rm -rf /data")).toContain("approval");
+      expect(getApprovalRequiredReasonForExecCommand("sudo git reset --hard")).toContain("approval");
+      expect(getApprovalRequiredReasonForExecCommand("nice -n 10 rm -rf /data")).toContain("approval");
+      expect(getApprovalRequiredReasonForExecCommand("timeout 5 find . -delete")).toContain("approval");
+      expect(getApprovalRequiredReasonForExecCommand("xargs rm")).toContain("approval");
+      expect(getApprovalRequiredReasonForExecCommand('sh -c "rm -rf /data"')).toContain("approval");
+      expect(getApprovalRequiredReasonForExecCommand("sudo --frobnicate rm")).toContain("approval");
+    });
+
     it("allows safe read-only commands", () => {
       expect(getApprovalRequiredReasonForExecCommand("ls -la")).toBeNull();
       expect(getApprovalRequiredReasonForExecCommand("cat file.txt")).toBeNull();
@@ -201,6 +250,10 @@ describe("friday-agent-tool-risk", () => {
       // path-qualified safe programs stay safe (no over-block).
       expect(getApprovalRequiredReasonForExecCommand("/usr/bin/git status")).toBeNull();
       expect(getApprovalRequiredReasonForExecCommand("/bin/ls -la")).toBeNull();
+      // benign wrapped commands stay safe (no over-block).
+      expect(getApprovalRequiredReasonForExecCommand("env node app.js")).toBeNull();
+      expect(getApprovalRequiredReasonForExecCommand("sudo git status")).toBeNull();
+      expect(getApprovalRequiredReasonForExecCommand("command -v rm")).toBeNull();
     });
 
     it("returns null for empty command", () => {


### PR DESCRIPTION
## What
Closes the command-wrapper bypass class in the shell-approval gate (Reviewer-A finding on #397), authorized as a follow-up.

## The gap
The gate classified only the literal program at `parts[0]`, so transparent wrappers that re-exec a child slipped through under `shell:false`:

```
env rm -rf /data        # classified SAFE (env ∈ SAFE_PROGRAMS) — worst case
sudo rm -rf /data       # guarded, no approval
sudo git reset --hard   # guarded, no approval
nice -n 10 rm -rf /x    # guarded
timeout 5 find . -delete
xargs rm
time rm -rf /data
sh -c "rm -rf /data"    # no blocked metachars → guarded, ran with no approval
```

All reachable default-allow bypasses of "dangerous commands require approval".

## The fix
`unwrapCommand(parts)`:
- strips inline env-assignment prefixes (`FOO=bar cmd`) and recognized transparent wrappers (`env`, `sudo`, `doas`, `command`, `nice`, `nohup`, `setsid`, `timeout`, `xargs`, `time`);
- skips each wrapper's options **precisely** — value-opts skip 2, flags skip 1, `--opt=value` one token, `nice -10` adjustment, `timeout` positional duration;
- **re-classifies the WRAPPED command through the same gate**, recursing for nested forms (`sudo env rm -rf`, `sudo bash -c …`);
- **fail-safe** (same philosophy as the #396 git global-option parse): an UNRECOGNIZED wrapper option that could hide the wrapped command forces **approval**, not a guess;
- a shell/interpreter handed a `-c` **code string** forces approval **without parsing** the opaque string (quoting/nesting can't be statically decomposed; metachar-bearing strings are already blocked upstream);
- `command -v`/`-V` (lookup, not exec) is **not** unwrapped → stays non-destructive (no over-block).

Both `classifyShellRisk` and `getApprovalRequiredReasonForExecCommand` now analyze the unwrapped command.

## Scope / accepted boundary (please don't FAIL on this — it's intentional)
This closes **transparent wrappers + shell `-c`**. The next layer — **script-runners whose behavior lives in external files** (`npm run X`, `make target`, `go run`, `bash script.sh`) — is the **accepted denylist boundary**: the gate fundamentally cannot see what those execute, and gating all of them would require approval for all npm/make usage (too aggressive, not the goal). These are documented in CLOSURE_HANDOFF.md, not gated here. Low-reachability exotics (`flock`, `chroot`, `watch`, `stdbuf`, `ionice`, `chrt`, `taskset`) are likewise documented, not gated.

## Verification
- Focused `friday-agent-tool-risk.test.ts`: **59 pass** (wrappers destructive incl. nested + sudo-with-value-opt; shell `-c` + unparseable-wrapper → approval; benign `env node app.js`/`sudo git status`/`nice -n 10 ls`/`command -v rm` stay safe).
- Blast radius `test/unit/agent/{runtime,tools}`: **1269 pass**, no type errors.
- `git diff --check` clean; eslint 0 errors; detect-secrets line-number refresh only.

Proves both paths: unsafe (wrapped + shell-c destructive) requires approval; safe (wrapped benign + lookup) stays safe. No regression — bare-program and path-qualified behavior unchanged.