### PR TITLE
fix(annex-b6): close git shell-risk leading-option and flag-abbreviation bypasses

### DIFF
--- a/src/agent/runtime/friday-agent-tool-risk.ts
+++ b/src/agent/runtime/friday-agent-tool-risk.ts
@@ -141,50 +141,64 @@ function listPotentialFilePaths(text: string): string[] {
   return [...new Set(text.match(/\b[\w./-]+\.[A-Za-z0-9]+\b/g) ?? [])];
 }
 
-// git global options that precede the subcommand; the value-taking ones (given without `=`)
-// also consume the following token. Used to locate the real subcommand for forms like
-// `git -C /repo reset --hard` or `git --no-pager clean -fdx`.
-const GIT_GLOBAL_OPTS_WITH_VALUE = new Set([
-  "-C", "-c", "--git-dir", "--work-tree", "--namespace", "--exec-path", "--super-prefix",
-]);
+// git subcommands whose destructive flag forms irreversibly discard local state.
+const GIT_DESTRUCTIVE_SUBCOMMANDS = new Set(["reset", "clean", "checkout", "restore", "switch"]);
 
-function gitSubcommandStart(parts: readonly string[]): number {
-  let i = 1;
-  while (i < parts.length) {
-    const tok = parts[i]!;
-    if (!tok.startsWith("-")) return i; // first non-option token is the subcommand
-    // `--opt=value` is a single token; `-C <v>` / `--git-dir <v>` consume the next token too.
-    i += GIT_GLOBAL_OPTS_WITH_VALUE.has(tok) ? 2 : 1;
+/**
+ * git's option parser accepts any unambiguous prefix of a long flag (verified against git
+ * 2.39: `git reset --har`/`--ha` resolve to `--hard`, `git clean --for`/`--f` resolve to
+ * `--force`). Matching destructive flags by exact string therefore lets an abbreviated form
+ * slip through the gate. Treat a token as the flag when it is a `--`-prefixed prefix of the
+ * full flag name (length ≥ 3, i.e. at least `--x`); this never matches a divergent flag such
+ * as `--soft`, `--mixed`, or `--help`.
+ */
+function matchesLongFlag(token: string, fullFlag: string): boolean {
+  return token.length >= 3 && token.startsWith("--") && fullFlag.startsWith(token);
+}
+
+function gitDestructiveReasonAt(parts: readonly string[], subIdx: number): string | null {
+  const sub = parts[subIdx]?.toLowerCase() ?? "";
+  const rest = parts.slice(subIdx + 1);
+  const hasForce = rest.some((a) => a === "-f" || matchesLongFlag(a, "--force"));
+  if (sub === "reset" && rest.some((a) => matchesLongFlag(a, "--hard"))) {
+    return "`git reset --hard` irreversibly discards uncommitted changes and requires explicit approval in the current run context.";
   }
-  return -1;
+  if (sub === "clean" && rest.some((a) => /^-[a-z]*f[a-z]*$/i.test(a) || matchesLongFlag(a, "--force"))) {
+    return "`git clean -f…` permanently deletes untracked files and requires explicit approval in the current run context.";
+  }
+  if ((sub === "checkout" || sub === "restore" || sub === "switch") && (hasForce || rest.some((a) => matchesLongFlag(a, "--hard")))) {
+    return `\`git ${sub} --force\` discards local changes and requires explicit approval in the current run context.`;
+  }
+  return null;
 }
 
 /**
  * Detect destructive FLAG combinations on programs that are otherwise allow-listed as
  * "safe" by name (e.g. git, find). Classification by program name alone let irreversible
  * operations like `git reset --hard`, `git clean -fdx`, and `find . -delete` slip through
- * without approval; this closes that flag-vs-program gap. Leading git global options
- * (`git -C <path> …`, `git --no-pager …`) are skipped so the subcommand is found regardless
- * of the invocation form. Returns an approval reason string when a dangerous flag combination
- * is present, else null.
+ * without approval; this closes that flag-vs-program gap.
+ *
+ * For git, the dangerous (subcommand, flag) pair is detected position-independently: any
+ * `reset`/`clean`/`checkout`/`restore`/`switch` keyword token followed by its destructive
+ * flag is flagged, regardless of how many leading global options precede it. This is robust
+ * to git's evolving global-option grammar — including value-taking options whose value token
+ * shifts the subcommand position (`git --config-env <k>=<v> reset --hard`, `git -C <path> …`,
+ * `git --no-pager …`) and unambiguous flag abbreviations (`--har` → `--hard`, `--for` →
+ * `--force`), both of which a position-pinned exact-match scan would miss. It errs toward
+ * requiring approval, the safe direction for a destructive-command gate; benign forms
+ * (`git reset --soft`, `git clean -n`, a branch literally named `reset` without the
+ * destructive flag) stay unflagged. Returns an approval reason string when a dangerous
+ * combination is present, else null.
  */
 function detectDangerousShellFlagReason(program: string, parts: readonly string[]): string | null {
   if (program === "git") {
-    const subIdx = gitSubcommandStart(parts);
-    if (subIdx === -1) {
-      return null;
-    }
-    const sub = parts[subIdx]?.toLowerCase() ?? "";
-    const rest = parts.slice(subIdx + 1);
-    const hasForce = rest.some((a) => a === "-f" || a === "--force");
-    if (sub === "reset" && rest.some((a) => a === "--hard")) {
-      return "`git reset --hard` irreversibly discards uncommitted changes and requires explicit approval in the current run context.";
-    }
-    if (sub === "clean" && rest.some((a) => /^-[a-z]*f[a-z]*$/i.test(a) || a === "--force")) {
-      return "`git clean -f…` permanently deletes untracked files and requires explicit approval in the current run context.";
-    }
-    if ((sub === "checkout" || sub === "restore" || sub === "switch") && (hasForce || rest.some((a) => a === "--hard"))) {
-      return `\`git ${sub} --force\` discards local changes and requires explicit approval in the current run context.`;
+    for (let i = 1; i < parts.length; i++) {
+      if (GIT_DESTRUCTIVE_SUBCOMMANDS.has(parts[i]!.toLowerCase())) {
+        const reason = gitDestructiveReasonAt(parts, i);
+        if (reason) {
+          return reason;
+        }
+      }
     }
   }
   if (program === "find") {

--- a/test/unit/agent/runtime/friday-agent-tool-risk.test.ts
+++ b/test/unit/agent/runtime/friday-agent-tool-risk.test.ts
@@ -105,11 +105,41 @@ describe("friday-agent-tool-risk", () => {
       expect(classifyShellRisk("git -C repo status")).toMatchObject({ level: "safe", program: "git" });
     });
 
+    it("detects destructive flags behind value-taking global options (leading-option bypass)", () => {
+      // A value-taking global option given in space form (`--config-env <name>=<envvar>`)
+      // shifts the subcommand position; a position-pinned scan misses it. (verified vs git 2.39)
+      expect(classifyShellRisk("git --config-env foo.bar=MYVAR reset --hard")).toMatchObject({ level: "destructive", program: "git" });
+      expect(classifyShellRisk("git --config-env=foo.bar=MYVAR reset --hard")).toMatchObject({ level: "destructive", program: "git" });
+      expect(classifyShellRisk("git --namespace ns clean -fd")).toMatchObject({ level: "destructive", program: "git" });
+      expect(classifyShellRisk("git -c a=b -c c=d reset --hard")).toMatchObject({ level: "destructive", program: "git" });
+      // `--exec-path` takes no space value (prior allowlist over-consumed it, eating the subcommand)
+      expect(classifyShellRisk("git --exec-path reset --hard")).toMatchObject({ level: "destructive", program: "git" });
+    });
+
+    it("detects destructive flags given as unambiguous abbreviations (abbreviation bypass)", () => {
+      // git resolves unambiguous long-flag prefixes (`--har` → `--hard`, `--for` → `--force`);
+      // exact-string matching missed these. (verified vs git 2.39)
+      expect(classifyShellRisk("git reset --har")).toMatchObject({ level: "destructive", program: "git" });
+      expect(classifyShellRisk("git reset --ha")).toMatchObject({ level: "destructive", program: "git" });
+      expect(classifyShellRisk("git clean --for")).toMatchObject({ level: "destructive", program: "git" });
+      expect(classifyShellRisk("git clean --f")).toMatchObject({ level: "destructive", program: "git" });
+      expect(classifyShellRisk("git checkout --for main")).toMatchObject({ level: "destructive", program: "git" });
+      // combined: leading value-option + abbreviated flag
+      expect(classifyShellRisk("git -C repo reset --har")).toMatchObject({ level: "destructive", program: "git" });
+    });
+
     it("keeps benign git/find invocations safe (no flag false-positives)", () => {
       expect(classifyShellRisk("git status")).toMatchObject({ level: "safe", program: "git" });
       expect(classifyShellRisk("git reset HEAD file.txt")).toMatchObject({ level: "safe", program: "git" });
       expect(classifyShellRisk("git clean -n")).toMatchObject({ level: "safe", program: "git" });
       expect(classifyShellRisk("find . -name pattern")).toMatchObject({ level: "safe", program: "find" });
+      // only `--hard` (or a prefix of it) makes reset destructive — soft/mixed/quiet stay safe
+      expect(classifyShellRisk("git reset --soft")).toMatchObject({ level: "safe", program: "git" });
+      expect(classifyShellRisk("git reset --mixed")).toMatchObject({ level: "safe", program: "git" });
+      // `reset` as a branch name with `--force` (force-push) is not local `reset --hard`
+      expect(classifyShellRisk("git push origin reset --force")).toMatchObject({ level: "safe", program: "git" });
+      // creating a branch literally named `reset` is not a destructive checkout
+      expect(classifyShellRisk("git checkout -b reset")).toMatchObject({ level: "safe", program: "git" });
     });
   });
 
@@ -143,6 +173,10 @@ describe("friday-agent-tool-risk", () => {
       // Behind git global options (the common agentic form) must also require approval.
       expect(getApprovalRequiredReasonForExecCommand("git -C repo reset --hard")).toContain("approval");
       expect(getApprovalRequiredReasonForExecCommand("git --no-pager clean -fdx")).toContain("approval");
+      // Leading value-taking global option (space form) and abbreviated flags must not bypass.
+      expect(getApprovalRequiredReasonForExecCommand("git --config-env foo.bar=MYVAR reset --hard")).toContain("approval");
+      expect(getApprovalRequiredReasonForExecCommand("git reset --har")).toContain("approval");
+      expect(getApprovalRequiredReasonForExecCommand("git clean --for")).toContain("approval");
     });
 
     it("allows safe read-only commands", () => {
@@ -151,6 +185,8 @@ describe("friday-agent-tool-risk", () => {
       expect(getApprovalRequiredReasonForExecCommand("git status")).toBeNull();
       expect(getApprovalRequiredReasonForExecCommand("git reset HEAD file.txt")).toBeNull();
       expect(getApprovalRequiredReasonForExecCommand("git clean -n")).toBeNull();
+      expect(getApprovalRequiredReasonForExecCommand("git reset --soft")).toBeNull();
+      expect(getApprovalRequiredReasonForExecCommand("git push origin reset --force")).toBeNull();
     });
 
     it("returns null for empty command", () => {


### PR DESCRIPTION
## Summary

Narrow follow-up to PR #395 (ANNEX B6). The destructive-git-flag classifier in `src/agent/runtime/friday-agent-tool-risk.ts` (`detectDangerousShellFlagReason`) had **two residual bypasses** that let irreversible git operations evade the approval/destructive gate:

1. **Leading value-taking global option (space form)** — the prior scan located the subcommand via a fixed allowlist of value-taking global options. A value-taking option *not* in that allowlist, given in space form, shifted the subcommand past the scan. Verified executing the subcommand against git 2.39:
   - `git --config-env <name>=<envvar> reset --hard` → ran `reset --hard`, classified **safe** (bypass).
   - The allowlist also over-consumed `--exec-path` (which takes no space value), eating the subcommand.
2. **Flag abbreviation** — git's option parser accepts any unambiguous long-flag prefix, but the classifier matched flags by exact string. Verified against git 2.39:
   - `git reset --har` / `--ha` → `--hard`; `git clean --for` / `--f` → `--force`; `git checkout --for` → `--force` — all executed the destructive op while classified **safe**.

## Fix

Replace the position-pinned allowlist scan with a **position-independent detector**: flag any `reset`/`clean`/`checkout`/`restore`/`switch` subcommand keyword token followed by its destructive flag, regardless of preceding leading options, and match long flags by **prefix** (`--har` → `--hard`, `--for` → `--force`). This is robust to git's evolving global-option grammar (no allowlist to keep in sync) and errs toward requiring approval — the safe direction for a destructive-command gate.

Benign forms stay unflagged: `git reset --soft`, `git reset --mixed`, `git clean -n`, `git reset HEAD file.txt`, a branch literally named `reset` without the destructive flag (`git push origin reset --force`, `git checkout -b reset`), and `git -C repo status`.

## Proof (local, on base `ec6a4d87`)

- `npm test -- --run test/unit/agent/runtime/friday-agent-tool-risk.test.ts` → **53 tests pass, Type Errors none** (adds both bypass-vector tests + no-false-positive assertions across `classifyShellRisk` and `getApprovalRequiredReasonForExecCommand`).
- `npm run build:api` → pass.
- `npm run check:secret-patterns` → "No provider/API key shaped secrets found in tracked files."
- `git diff --check` → clean.

## Scope

Closes the two known git shell-risk bypasses only (single function + its test file). No npm publish, tag, GitHub release, live-channel window, or secrets/settings change. After exact-main proof, the ANNEX B6 shell-risk surface can be marked fully closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)