### PR TITLE
fix(api): receipt truth — completed-with-failed-tools must not be verified_receipt (D1)

### DIFF
--- a/src/api/http/routes/friday-agent-routes.ts
+++ b/src/api/http/routes/friday-agent-routes.ts
@@ -22,6 +22,7 @@ import type {
   FridayAgentRunStatus,
   FridayAgentRuntimeResult,
   FridayAgentTaskProfileInput,
+  FridayAgentToolCallRecord,
 } from "#agent";
 import { buildFridayAgentReplayableEvidenceReceipt, buildFridayAgentUnifiedTaskState } from "#agent";
 import type { FridayProviderTenantContext } from "#providers";
@@ -179,6 +180,52 @@ function sanitizeUserVisibleRun(run: FridayAgentRunRecord): FridayAgentRunRecord
   };
 }
 
+// D1 fix: reconstruct tool-call outcomes from the durable event stream so the
+// API-rebuilt receipt counts real tool failures. Without this, toolCalls was never
+// passed to the receipt builder, so countToolCalls(undefined).failed was always 0 and
+// every completed run with an artifactDir was misclassified as `verified_receipt` —
+// disagreeing with the on-disk receipt (which was built WITH the real tool calls).
+// Each terminal `agent.run.tool_end` event carries `isError`; a tool_start without a
+// matching tool_end is treated as a failure (it did not complete).
+function collectToolCallRecordsFromEvents(
+  auditEvents: FridayAgentRunEventRecord[],
+): FridayAgentToolCallRecord[] {
+  const startById = new Map<string, FridayAgentRunEventRecord>();
+  const endById = new Map<string, FridayAgentRunEventRecord>();
+  for (const event of auditEvents) {
+    const payload = asRecord(event.payload);
+    const toolCallId = readStringField(payload, "toolCallId");
+    if (!toolCallId) continue;
+    if (event.eventName === "agent.run.tool_start") {
+      startById.set(toolCallId, event);
+    } else if (event.eventName === "agent.run.tool_end") {
+      endById.set(toolCallId, event);
+    }
+  }
+  const toolCallIds = new Set<string>([...startById.keys(), ...endById.keys()]);
+  const records: FridayAgentToolCallRecord[] = [];
+  for (const toolCallId of toolCallIds) {
+    const startEvent = startById.get(toolCallId);
+    const endEvent = endById.get(toolCallId);
+    const endPayload = asRecord(endEvent?.payload);
+    const startPayload = asRecord(startEvent?.payload);
+    // No tool_end => the call never completed => treat as an error outcome.
+    const isError = endEvent ? endPayload?.isError === true : true;
+    const durationMs = typeof endPayload?.durationMs === "number" ? endPayload.durationMs : 0;
+    records.push({
+      toolCallId,
+      toolName: readStringField(endPayload, "toolName")
+        ?? readStringField(startPayload, "toolName")
+        ?? "unknown",
+      args: {},
+      result: { content: "", isError },
+      durationMs,
+      startedAt: (startEvent ?? endEvent)?.emittedAt ?? "",
+    });
+  }
+  return records;
+}
+
 function buildReplayableEvidenceReceiptForRun(
   run: FridayAgentRunRecord,
   auditEvents: FridayAgentRunEventRecord[],
@@ -196,6 +243,7 @@ function buildReplayableEvidenceReceiptForRun(
     usageOutput: run.usageOutput,
     costUsd: run.costUsd ?? run.actualExecution?.totalCostUsd,
     artifactDir: run.artifactDir,
+    toolCalls: collectToolCallRecordsFromEvents(auditEvents),
     testResults: run.testResults,
     artifacts: run.artifacts,
     auditEventCount: auditEvents.length,

--- a/test/unit/api/http/routes/friday-agent-routes.test.ts
+++ b/test/unit/api/http/routes/friday-agent-routes.test.ts
@@ -1014,6 +1014,69 @@ describe("FridayAgentRoutes", () => {
     expect(result.replayReceipt.proofBoundary).toContain("not release proof");
   });
 
+  // D1 regression: a completed run whose audit events include a FAILED tool call must NOT be
+  // reported as verified_receipt by the API-rebuilt receipt. Before the fix, the route never
+  // passed toolCalls into the receipt builder, so failed tool calls were uncounted and every
+  // completed+artifactDir run was misclassified verified_receipt — disagreeing with the on-disk
+  // receipt that DID count the failures (live defect on run f1de7c3f).
+  it("does not report verified_receipt for a completed run with a failed tool call (D1)", async () => {
+    stubDeps.getRun = vi.fn().mockReturnValue(createStubRun({
+      status: "completed",
+      completedAt: "2026-01-01T00:00:05.000Z",
+      artifactDir: "/tmp/friday/run-1",
+    }));
+    stubDeps.listRunEvents = vi.fn().mockReturnValue([
+      {
+        eventId: "evt-1",
+        runId: "run-1",
+        seq: 1,
+        eventName: "agent.run.tool_start",
+        payload: { runId: "run-1", toolCallId: "call-1", toolName: "read" },
+        emittedAt: "2026-01-01T00:00:01.000Z",
+        createdAt: "2026-01-01T00:00:01.000Z",
+      },
+      {
+        eventId: "evt-2",
+        runId: "run-1",
+        seq: 2,
+        eventName: "agent.run.tool_end",
+        payload: { runId: "run-1", toolCallId: "call-1", toolName: "read", isError: true },
+        emittedAt: "2026-01-01T00:00:02.000Z",
+        createdAt: "2026-01-01T00:00:02.000Z",
+      },
+      {
+        eventId: "evt-3",
+        runId: "run-1",
+        seq: 3,
+        eventName: "agent.run.completed",
+        payload: { runId: "run-1" },
+        emittedAt: "2026-01-01T00:00:05.000Z",
+        createdAt: "2026-01-01T00:00:05.000Z",
+      },
+    ]);
+
+    const routes = createFridayAgentRoutes(stubDeps);
+    const route = routes.find((r) => r.operationId === "agent.runs.audit")!;
+    const result = await route.handler({
+      body: null,
+      params: { runId: "run-1" },
+      query: {},
+      headers: {},
+      principal: null,
+      requestId: "req-1",
+      receivedAt: "2026-01-01T00:00:06.000Z",
+    }) as {
+      unifiedTaskState: { state: string; evidence: { receiptStatus?: string } };
+      replayReceipt: { receiptStatus: string; blockers: string[] };
+    };
+
+    expect(result.replayReceipt.receiptStatus).toBe("blocked_or_failed");
+    expect(result.replayReceipt.blockers).toContain("1 tool call(s) reported an error.");
+    expect(result.unifiedTaskState.state).not.toBe("verified_receipt");
+    expect(result.unifiedTaskState.state).toBe("blocked_recoverable");
+    expect(result.unifiedTaskState.evidence.receiptStatus).toBe("blocked_or_failed");
+  });
+
   it("GET /v1/agent/runs/:runId/audit includes unified task state without raw tool approval params", async () => {
     stubDeps.getRun = vi.fn().mockReturnValue(createStubRun({ status: "executing" }));
     stubDeps.listRunEvents = vi.fn().mockReturnValue([


### PR DESCRIPTION
## Problem (live-stress defect D1)
The agent API rebuilt the evidence receipt from run events but never passed `toolCalls` into `buildFridayAgentReplayableEvidenceReceipt`, so `countToolCalls(undefined).failed` was always 0 and **every completed run with an artifactDir was classified `verified_receipt`** — disagreeing with the persisted on-disk receipt that counts real tool failures.

Reproduced live: run `f1de7c3f-bcc7-4a37-83ba-4d766ef8c336` reported `unifiedTaskState=verified_receipt` via `GET /v1/agent/runs/:id` while its on-disk `evidence-receipt.json` was `blocked_or_failed` with "18 tool call(s) reported an error." A UI/automation consuming the API task-state would read SUCCESS for a run that failed.

## Fix
Reconstruct tool-call outcomes from `agent.run.tool_start`/`agent.run.tool_end` events (isError from the tool_end payload; a tool_start with no tool_end counts as a failure) and feed them to the receipt builder, so the API `receiptStatus` and the on-disk receipt agree. A completed run with any failed tool now surfaces `blocked_recoverable`/`blocked_or_failed` on the API surface, matching disk.

## Proof
- New regression test `does not report verified_receipt for a completed run with a failed tool call (D1)` — **fails before** this change (`expected 'verified_receipt' to be 'blocked_or_failed'`), passes after.
- Full agent-routes suite: **73 passed** (72 prior + 1 new), no regression.
- `tsc --noEmit`: clean for the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)