### PR TITLE
fix(annex-b6): match abbreviated git destructive flags in shell-risk gate

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -603,7 +603,7 @@
         "filename": "test/unit/agent/runtime/friday-agent-tool-risk.test.ts",
         "hashed_secret": "d14babe099a92466c4efa49400806772a6c097cd",
         "is_verified": false,
-        "line_number": 316
+        "line_number": 339
       }
     ],
     "test/unit/api/auth/friday-auth-middleware.test.ts": [
@@ -1124,5 +1124,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-29T02:50:13Z"
+  "generated_at": "2026-05-29T03:25:46Z"
 }

--- a/src/agent/runtime/friday-agent-tool-risk.ts
+++ b/src/agent/runtime/friday-agent-tool-risk.ts
@@ -341,18 +341,29 @@ function gitSubcommandStart(parts: readonly string[]): number {
   return -1;
 }
 
+// git's option parser accepts any unambiguous prefix of a long flag (verified vs git 2.39:
+// `git reset --har`/`--ha` resolve to `--hard`; `git clean --for`/`--f` resolve to `--force`),
+// so destructive flags must be matched by prefix — an exact-string match lets an abbreviated
+// form slip through the gate. A token matches when it is a `--`-prefixed prefix of the full
+// flag name (length ≥ 3, i.e. at least `--x`); this never matches a divergent flag such as
+// `--soft`, `--mixed`, or `--help`.
+function matchesLongFlag(token: string, fullFlag: string): boolean {
+  return token.length >= 3 && token.startsWith("--") && fullFlag.startsWith(token);
+}
+
 // Precise per-subcommand check: given a known subcommand and the tokens that follow it,
-// return an approval reason for a destructive flag combination, else null.
+// return an approval reason for a destructive flag combination, else null. Long destructive
+// flags are matched by prefix (see matchesLongFlag) so abbreviated forms cannot bypass.
 function gitDestructiveReason(sub: string, rest: readonly string[]): string | null {
   const s = sub.toLowerCase();
-  const hasForce = rest.some((a) => a === "-f" || a === "--force");
-  if (s === "reset" && rest.some((a) => a === "--hard")) {
+  const hasForce = rest.some((a) => a === "-f" || matchesLongFlag(a, "--force"));
+  if (s === "reset" && rest.some((a) => matchesLongFlag(a, "--hard"))) {
     return "`git reset --hard` irreversibly discards uncommitted changes and requires explicit approval in the current run context.";
   }
-  if (s === "clean" && rest.some((a) => /^-[a-z]*f[a-z]*$/i.test(a) || a === "--force")) {
+  if (s === "clean" && rest.some((a) => /^-[a-z]*f[a-z]*$/i.test(a) || matchesLongFlag(a, "--force"))) {
     return "`git clean -f…` permanently deletes untracked files and requires explicit approval in the current run context.";
   }
-  if ((s === "checkout" || s === "restore" || s === "switch") && (hasForce || rest.some((a) => a === "--hard"))) {
+  if ((s === "checkout" || s === "restore" || s === "switch") && (hasForce || rest.some((a) => matchesLongFlag(a, "--hard")))) {
     return `\`git ${s} --force\` discards local changes and requires explicit approval in the current run context.`;
   }
   return null;

--- a/test/unit/agent/runtime/friday-agent-tool-risk.test.ts
+++ b/test/unit/agent/runtime/friday-agent-tool-risk.test.ts
@@ -133,6 +133,26 @@ describe("friday-agent-tool-risk", () => {
       expect(classifyShellRisk("git reset HEAD file.txt")).toMatchObject({ level: "safe", program: "git" });
       expect(classifyShellRisk("git clean -n")).toMatchObject({ level: "safe", program: "git" });
       expect(classifyShellRisk("find . -name pattern")).toMatchObject({ level: "safe", program: "find" });
+      // prefix flag-matching must not over-block: only a prefix of `--hard` triggers reset,
+      // and `--force` (not a prefix of `--hard`) does not make a `reset`-named branch destructive.
+      expect(classifyShellRisk("git reset --soft")).toMatchObject({ level: "safe", program: "git" });
+      expect(classifyShellRisk("git reset --mixed")).toMatchObject({ level: "safe", program: "git" });
+      expect(classifyShellRisk("git push origin reset --force")).toMatchObject({ level: "safe", program: "git" });
+      expect(classifyShellRisk("git checkout -b reset")).toMatchObject({ level: "safe", program: "git" });
+    });
+
+    it("detects destructive git flags given as unambiguous abbreviations (no abbreviation bypass)", () => {
+      // git resolves unambiguous long-flag prefixes (`--har` → `--hard`, `--for` → `--force`);
+      // exact-string flag matching missed these. (verified vs git 2.39)
+      expect(classifyShellRisk("git reset --har")).toMatchObject({ level: "destructive", program: "git" });
+      expect(classifyShellRisk("git reset --ha")).toMatchObject({ level: "destructive", program: "git" });
+      expect(classifyShellRisk("git clean --for")).toMatchObject({ level: "destructive", program: "git" });
+      expect(classifyShellRisk("git clean --f")).toMatchObject({ level: "destructive", program: "git" });
+      expect(classifyShellRisk("git checkout --for main")).toMatchObject({ level: "destructive", program: "git" });
+      // combined with the leading-option and wrapper paths (must still catch the abbreviation):
+      expect(classifyShellRisk("git -C repo reset --har")).toMatchObject({ level: "destructive", program: "git" });
+      expect(classifyShellRisk("git --shallow-file snap reset --har")).toMatchObject({ level: "destructive", program: "git" });
+      expect(classifyShellRisk("sudo git reset --har")).toMatchObject({ level: "destructive", program: "git" });
     });
 
     it("identifies path-qualified programs by basename (no path-prefix bypass)", () => {
@@ -233,6 +253,9 @@ describe("friday-agent-tool-risk", () => {
       // Behind obscure / unknown global options must ALSO require approval (no default-allow).
       expect(getApprovalRequiredReasonForExecCommand("git --shallow-file snap reset --hard")).toContain("approval");
       expect(getApprovalRequiredReasonForExecCommand("git --totally-unknown-opt val reset --hard")).toContain("approval");
+      // Unambiguous flag abbreviations must also require approval (git resolves the prefix).
+      expect(getApprovalRequiredReasonForExecCommand("git reset --har")).toContain("approval");
+      expect(getApprovalRequiredReasonForExecCommand("git clean --for")).toContain("approval");
     });
 
     it("requires approval for path-qualified destructive programs (no path-prefix bypass)", () => {


### PR DESCRIPTION
## Summary

Closes the remaining ANNEX B6 git shell-risk bypass after #396 (leading global-option fail-safe scan) and #397 (path-qualified program basename): **unambiguous flag abbreviation**.

git's option parser accepts any unambiguous prefix of a long flag. Verified against git 2.39 that these execute the destructive subcommand but evaded `gitDestructiveReason`'s exact-string flag matching (`a === "--hard"` / `a === "--force"`):

| Command | git resolves to | before |
|---|---|---|
| `git reset --har` / `--ha` | `--hard` | classified **safe** (bypass) |
| `git clean --for` / `--f` | `--force` | classified **safe** (bypass) |
| `git checkout --for main` | `--force` | classified **safe** (bypass) |

`gitDestructiveReason` is the helper shared by the precise path, the #396 fail-safe unknown-leading-option scan, and the #399 command-wrapper unwrap path, so a single fix closes the abbreviation vector on **all** of them.

## Fix

Add `matchesLongFlag(token, fullFlag)` — a `--`-prefixed token of length ≥ 3 that is a prefix of the full flag — and use it for the `--hard` / `--force` checks (short `-f` and the `-fdx` clean-bundle regex are unchanged). Errs toward requiring approval, the safe direction for a destructive-command gate.

## No false positives (locked in by tests)

`--force` is **not** a prefix of `--hard`, and divergent flags never match a prefix, so these stay safe:
- `git reset --soft`, `git reset --mixed`
- `git push origin reset --force` (reset as a branch name; force-push ≠ local `reset --hard`)
- `git checkout -b reset`, `git clean -n`, `git reset HEAD file.txt`

## Proof (local, on base `dd9d4366`)

- `npm test -- --run test/unit/agent/runtime/friday-agent-tool-risk.test.ts` → **60 tests pass, Type Errors none** (adds abbreviation cases across `classifyShellRisk` + `getApprovalRequiredReasonForExecCommand`, plus the no-false-positive assertions, and confirms abbreviation is caught behind leading options / unknown options / `sudo` wrapper).
- `npm run build:api` → pass. `npm run check:secret-patterns` → clean. `git diff --check` → clean.

## Scope

One helper + the shared `gitDestructiveReason` flag checks + tests. No npm publish, tag, GitHub release, live-channel window, or secrets/settings change. With this merged + exact-main proven, the ANNEX B6 git shell-risk surface (leading-option, path-qualified, command-wrapper/`shell -c`, and abbreviation vectors) is fully closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)