### PR TITLE
fix(api): reserve idempotency key in-flight to close the agent-run create race (D)

### DIFF
--- a/src/api/http/friday-http-server.ts
+++ b/src/api/http/friday-http-server.ts
@@ -74,6 +74,10 @@ interface FridayHttpIdempotencyEntry {
   operationId: string;
   principalId: string;
   payloadHash: string;
+  // "in_flight" = a request with this key is currently executing (reservation set before the
+  // handler runs, so concurrent same-key requests are rejected instead of double-executing).
+  // "completed" = the handler finished and `data` holds the replayable response.
+  status: "in_flight" | "completed";
   data: unknown;
   expiresAtMs: number;
 }
@@ -516,6 +520,10 @@ export function createFridayHttpServer(deps: FridayHttpServerDeps): FridayHttpSe
     const rawMethod = (req.method ?? "GET").toUpperCase();
     const isHead = rawMethod === "HEAD";
 
+    // Declared outside the request try so the catch block can release an in-flight idempotency
+    // reservation if the handler throws.
+    let idempotencyStoreKey: string | undefined;
+
     try {
       // Handle CORS preflight (before casting to FridayHttpMethod)
       if (rawMethod === "OPTIONS" && origin && isOriginAllowed(origin, corsOrigins)) {
@@ -785,7 +793,6 @@ export function createFridayHttpServer(deps: FridayHttpServerDeps): FridayHttpSe
         if (rateLimitResult.headers) Object.assign(middlewareHeaders, rateLimitResult.headers);
       }
 
-      let idempotencyStoreKey: string | undefined;
       const idempotencyKey = method === "GET" ? undefined : readIdempotencyKeyHeader(ctx.headers);
       if (idempotencyKey) {
         pruneExpiredIdempotencyEntries(Date.now());
@@ -813,6 +820,24 @@ export function createFridayHttpServer(deps: FridayHttpServerDeps): FridayHttpSe
             return;
           }
 
+          // A matching-payload request with this key is still executing (reservation set below
+          // before the handler runs). Reject the concurrent duplicate instead of running the
+          // handler a second time — closing the check-then-set race where two same-key requests
+          // both miss the store and both execute. Retryable: the caller can retry once the
+          // in-flight request completes and a replayable entry exists.
+          if (existing.status === "in_flight") {
+            sendJsonWithHeaders(res, 409, {
+              ok: false,
+              error: {
+                code: "SECURITY_IDEMPOTENCY_IN_PROGRESS",
+                message: `Idempotency-Key '${idempotencyKey}' is already being processed for operation '${route.operationId}'.`,
+                retryable: true,
+              },
+              requestId,
+            }, { ...corsHeaders, ...middlewareHeaders }, isHead);
+            return;
+          }
+
           const replayBody = JSON.stringify({
             ok: true,
             data: existing.data,
@@ -834,6 +859,17 @@ export function createFridayHttpServer(deps: FridayHttpServerDeps): FridayHttpSe
           }
           return;
         }
+
+        // Reserve the key BEFORE running the handler so a concurrent same-key request sees
+        // `in_flight` and is rejected above, rather than both requests executing the handler.
+        idempotencyStore.set(idempotencyStoreKey, {
+          operationId: route.operationId,
+          principalId,
+          payloadHash,
+          status: "in_flight",
+          data: undefined,
+          expiresAtMs: Date.now() + FRIDAY_IDEMPOTENCY_TTL_MS,
+        });
       }
 
       // Inject raw response reference for SSE streaming routes
@@ -842,10 +878,18 @@ export function createFridayHttpServer(deps: FridayHttpServerDeps): FridayHttpSe
       // Call handler
       const result = await route.handler(ctx);
 
-      // If the handler already took over the response (e.g. SSE streaming), bail out
-      if (res.headersSent || res.writableEnded) return;
+      // If the handler already took over the response (e.g. SSE streaming), bail out.
+      // The handler owns the response, so there is no replayable JSON body to cache — drop the
+      // in-flight reservation so the key is not wedged until TTL.
+      if (res.headersSent || res.writableEnded) {
+        if (idempotencyStoreKey) idempotencyStore.delete(idempotencyStoreKey);
+        return;
+      }
 
       if (isFridayHttpRawTextResponse(result)) {
+        // Raw-text responses are not cached for replay (original behavior); release the
+        // reservation so a later same-key request is not rejected against a never-completed entry.
+        if (idempotencyStoreKey) idempotencyStore.delete(idempotencyStoreKey);
         const responseBody = result.body;
         const responseHeaders: Record<string, string | number> = {
           "Content-Type": result.contentType ?? "text/plain; charset=utf-8",
@@ -867,6 +911,7 @@ export function createFridayHttpServer(deps: FridayHttpServerDeps): FridayHttpSe
       assertSerializableJsonResponse(result, route.operationId);
 
       if (idempotencyStoreKey) {
+        // Upgrade the in-flight reservation to a completed, replayable entry.
         idempotencyStore.set(idempotencyStoreKey, {
           operationId: route.operationId,
           principalId: ctx.principal?.principalId ?? "anonymous",
@@ -877,6 +922,7 @@ export function createFridayHttpServer(deps: FridayHttpServerDeps): FridayHttpSe
             query,
             body,
           }),
+          status: "completed",
           data: result,
           expiresAtMs: Date.now() + FRIDAY_IDEMPOTENCY_TTL_MS,
         });
@@ -903,6 +949,9 @@ export function createFridayHttpServer(deps: FridayHttpServerDeps): FridayHttpSe
         res.end(successBody);
       }
     } catch (error: unknown) {
+      // The handler threw, so no completed entry was written. Release the in-flight reservation
+      // so this idempotency key is retryable rather than wedged in_flight until TTL.
+      if (idempotencyStoreKey) idempotencyStore.delete(idempotencyStoreKey);
       // If headers were already sent (e.g. SSE stream errored mid-flight), we cannot send JSON
       if (res.headersSent || res.writableEnded) {
         res.end();

--- a/test/unit/api/http/friday-http-server-idempotency.test.ts
+++ b/test/unit/api/http/friday-http-server-idempotency.test.ts
@@ -120,4 +120,53 @@ describe("FridayHttpServer idempotency", () => {
     expect(conflictBody.error.code).toBe("SECURITY_IDEMPOTENCY_KEY_CONFLICT");
     expect(createCount).toBe(1);
   });
+
+  it("rejects a concurrent duplicate (same key) instead of running the handler twice", async () => {
+    const routes = createFridayHttpRouteRegistry();
+    let createCount = 0;
+    routes.register({
+      operationId: "test.idempotency.create.slow",
+      method: "POST",
+      path: "/v1/test/idempotency-slow",
+      auth: { public: true, allowUnauthenticatedMutation: true },
+      async handler(ctx) {
+        createCount += 1;
+        const id = createCount;
+        // Hold the request open so a concurrent same-key request overlaps the in-flight window.
+        await new Promise((resolve) => setTimeout(resolve, 25));
+        return { id, body: ctx.body };
+      },
+    });
+
+    server = createFridayHttpServer({
+      routes,
+      wsGateway: makeStubWsGateway(),
+      middleware: makeStubMiddleware(),
+      port,
+      host: "127.0.0.1",
+    });
+    await server.listen();
+
+    const init = {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "Idempotency-Key": "race-1" },
+      body: JSON.stringify({ value: "one" }),
+    };
+
+    // Fire two identical same-key requests concurrently. The reservation is set synchronously
+    // (no await between the store .get and the in-flight .set), so exactly one runs the handler
+    // and the other is rejected in-progress. Without the reservation both miss the store and
+    // both execute (createCount === 2).
+    const [a, b] = await Promise.all([
+      fetch(`${baseUrl}/v1/test/idempotency-slow`, init),
+      fetch(`${baseUrl}/v1/test/idempotency-slow`, init),
+    ]);
+
+    expect(createCount).toBe(1);
+    const statuses = [a.status, b.status].sort((x, y) => x - y);
+    expect(statuses).toEqual([200, 409]);
+    const conflict = a.status === 409 ? a : b;
+    const conflictBody = await conflict.json() as { ok: false; error: { code: string } };
+    expect(conflictBody.error.code).toBe("SECURITY_IDEMPOTENCY_IN_PROGRESS");
+  });
 });


### PR DESCRIPTION
## Problem (epic D — idempotency race)
The HTTP idempotency layer (`src/api/http/friday-http-server.ts`) did a **non-atomic check-then-set**: it read the store (`idempotencyStore.get`) to gate the handler, but only wrote the entry **after** the handler returned. Two concurrent requests with the same `Idempotency-Key` could both miss the store and **both execute the handler** — creating duplicate agent runs. No DB unique index backstops agent-run idempotency (unique idempotency indexes exist only on `outbox_messages` and `session_messages`).

## Fix
Reserve the key with a `status: "in_flight"` entry **before** running the handler, so a concurrent same-key request is rejected with `409 SECURITY_IDEMPOTENCY_IN_PROGRESS` (retryable) instead of double-executing. On success the entry is upgraded to `status: "completed"` with the replayable response. The reservation is deleted on the three no-completion exits (handler/SSE takeover, raw-text response, and the `catch` block) so a key is never wedged until TTL.

Because the store `.get` and the reservation `.set` happen in the same synchronous tick (before any `await`), this closes the event-loop race for a single-process server. (Multi-instance/durable dedup would need a DB unique constraint — out of scope; noted as follow-up.)

## Proof
- New concurrent (`Promise.all`) duplicate-request test: **fails before** this change (handler runs twice, `createCount===2`), **passes after** (runs once, second request gets `409 IN_PROGRESS`). Existing sequential replay/conflict test unchanged.
- `vitest`: 2 passed. `tsc --noEmit`: clean for the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)