### PR TITLE
fix(self-heal): durably persist self-heal skill-status so disabled skills survive restart

### DIFF
--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -1177,12 +1177,36 @@ export function createFridayHubAutoFixExecutionSupport(deps: {
   workflowRuntime?: FridayWorkflowRuntime;
   skillGenerator?: FridaySkillGeneratorService;
   nowIso: () => string;
+  // Durable skill-lifecycle persistence (optional). When provided, self-heal status
+  // mutations (disable_skill / regenerate_skill) are persisted to the durable skills store
+  // so a disabled or re-enabled skill survives a hub restart instead of living only in the
+  // process-local memoryState stub. `persistSkillLifecycleStatus` returns true ONLY when the
+  // skill already exists in the durable store (installed/converter skills); for built-in /
+  // registry-only skills it returns false (no fake write), and the in-memory status remains
+  // the only record. `getPersistedSkillLifecycleStatus` returns undefined for a not-in-store
+  // skill so verifiers can report an honest (non-durable) result.
+  persistSkillLifecycleStatus?: (skillId: string, status: SkillLifecycleStatus) => boolean;
+  getPersistedSkillLifecycleStatus?: (skillId: string) => SkillLifecycleStatus | undefined;
 }): FridayHubAutoFixExecutionSupport {
   // P2-07: External-state remediation must be backed by hub-level services.
   // The execution service fails closed for these kinds unless an executor is
   // injected here.
   const stepExecutors: Partial<Record<FridayAutoFixStepKind, StepExecutor>> = {};
   const stepVerifiers: Partial<Record<FridayAutoFixStepKind, StepVerifier>> = {};
+
+  // Durable-aware skill-status read: prefer the durable store (authoritative + survives
+  // restart) when the skill exists there; otherwise fall back to the in-memory stub so
+  // built-in / registry-only skills report an honest (non-durable) result rather than a
+  // false "persisted" success.
+  const resolveSkillLifecycleStatus = async (
+    skillId: string,
+  ): Promise<SkillLifecycleStatus | undefined> => {
+    const durable = deps.getPersistedSkillLifecycleStatus?.(skillId);
+    if (durable !== undefined) {
+      return durable;
+    }
+    return (await deps.memoryState.listSkillStatuses())[skillId];
+  };
 
   const readPayloadRecord = (payload: unknown): Record<string, unknown> | null =>
     typeof payload === "object" && payload !== null && !Array.isArray(payload)
@@ -1269,11 +1293,15 @@ export function createFridayHubAutoFixExecutionSupport(deps: {
         ? `auto-fix rollback @ ${nowIso}`
         : `auto-fix disable_skill @ ${nowIso}`,
     );
+    // Durably persist for installed/converter skills so the status survives a hub restart;
+    // false for built-in/registry-only skills (no durable row, no fake write).
+    const durablyPersisted = deps.persistSkillLifecycleStatus?.(step.target, nextStatus) ?? false;
     if (payload) {
       payload._skillDisabled = !revert;
       payload._skillStatusAfter = nextStatus;
       payload._skillStatusTarget = step.target;
       payload._skillStatusAt = nowIso;
+      payload._skillStatusDurable = durablyPersisted;
     }
     return true;
   };
@@ -1282,9 +1310,8 @@ export function createFridayHubAutoFixExecutionSupport(deps: {
     if (!step.target) {
       return false;
     }
-    const revert = isRevertPayload(step.payload);
-    const statuses = await deps.memoryState.listSkillStatuses();
-    return statuses[step.target] === (revert ? "installed" : "disabled");
+    const want = isRevertPayload(step.payload) ? "installed" : "disabled";
+    return (await resolveSkillLifecycleStatus(step.target)) === want;
   };
 
   stepExecutors.apply_config_patch = async (step) => {
@@ -1657,10 +1684,12 @@ export function createFridayHubAutoFixExecutionSupport(deps: {
           "disabled",
           `auto-fix rollback regenerate_skill @ ${deps.nowIso()}`,
         );
+        const durablyPersisted = deps.persistSkillLifecycleStatus?.(skillId, "disabled") ?? false;
         if (payload) {
           payload._skillRegenerated = true;
           payload._regenerateRolledBack = true;
           payload._regeneratedAt = deps.nowIso();
+          payload._skillStatusDurable = durablyPersisted;
         }
         return true;
       }
@@ -1686,6 +1715,7 @@ export function createFridayHubAutoFixExecutionSupport(deps: {
         "installed",
         `auto-fix regenerate_skill @ ${deps.nowIso()}`,
       );
+      const durablyPersisted = deps.persistSkillLifecycleStatus?.(skillId, "installed") ?? false;
 
       if (payload) {
         payload._skillRegenerated = true;
@@ -1693,6 +1723,7 @@ export function createFridayHubAutoFixExecutionSupport(deps: {
         payload._regenerateSessionId = sessionId;
         payload._regenerateCandidateId = saved.candidateId;
         payload._regenerateDraftName = draft.manifest.name;
+        payload._skillStatusDurable = durablyPersisted;
       }
       return true;
     };
@@ -1704,11 +1735,10 @@ export function createFridayHubAutoFixExecutionSupport(deps: {
         return false;
       }
       if (isRevertPayload(step.payload)) {
-        const statuses = await deps.memoryState.listSkillStatuses();
-        return statuses[skillId] === "disabled";
+        return (await resolveSkillLifecycleStatus(skillId)) === "disabled";
       }
-      const statuses = await deps.memoryState.listSkillStatuses();
-      return payload?._skillRegenerated === true && statuses[skillId] === "installed";
+      return payload?._skillRegenerated === true
+        && (await resolveSkillLifecycleStatus(skillId)) === "installed";
     };
   }
 

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -4002,6 +4002,21 @@ export async function createFridayHub(
     workflowRuntime,
     skillGenerator,
     nowIso,
+    // Persist self-heal skill-status changes (disable_skill / regenerate_skill) to the durable
+    // skills store so a disabled or re-enabled skill survives a hub restart. Returns true ONLY
+    // when the skill already exists in the durable store (installed/converter skills); built-in
+    // / registry-only skills are NOT upserted (no fake write) so the caller can report honestly.
+    persistSkillLifecycleStatus: (skillId, status) => {
+      let persisted = false;
+      stateRuntime.sqlite.withWriteTransaction((db) => {
+        if (converterSkillRepo.getSkillById(db, skillId)) {
+          converterSkillRepo.updateLifecycleStatus(db, skillId, status, nowIso());
+          persisted = true;
+        }
+      });
+      return persisted;
+    },
+    getPersistedSkillLifecycleStatus,
   });
 
   const selfLearningRuntime = createFridaySelfLearningRuntime({

--- a/test/unit/hub/bootstrap/hub-helpers.test.ts
+++ b/test/unit/hub/bootstrap/hub-helpers.test.ts
@@ -3,7 +3,8 @@ import * as os from "node:os";
 import * as path from "node:path";
 
 import { describe, expect, it } from "vitest";
-import type { FridaySkillRegistry } from "#skills";
+import type { FridaySkillRegistry, SkillLifecycleStatus } from "#skills";
+import type { FridaySkillGeneratorService } from "#skills/generator";
 import type { FridayProviderService } from "#providers";
 import type { FridayWorkflowRuntime } from "#workflows";
 import type { FridayHubConfigManagerService } from "../../../../src/hub/services/friday-hub-config-manager.types.js";
@@ -259,6 +260,136 @@ describe("createFridayHubAutoFixExecutionSupport", () => {
       _skillStatusTarget: "skill-x",
       _skillStatusAt: "2026-03-13T10:00:00.000Z",
     });
+  });
+
+  // ── self-heal skill-status durable persistence (residual E) ──
+  function makeRegistryWith(ids: readonly string[]): FridaySkillRegistry {
+    const set = new Set(ids);
+    return {
+      list: () => [],
+      get: (skillId: string) =>
+        (set.has(skillId) ? ({} as ReturnType<FridaySkillRegistry["get"]>) : null),
+      resolveByIntent: () => null,
+      validateAll: () => [],
+      reload: async () => {},
+      refresh: async () => {},
+      isCompatible: () => ({ compatible: true, reasons: [] }),
+      startWatching: async () => {},
+      stopWatching: async () => {},
+      close: async () => {},
+    };
+  }
+
+  // Simulated durable skills store: persist only succeeds for ids already present (mirrors the
+  // bootstrap wiring's `getSkillById` existence check); absent ids get NO fake write. The store
+  // survives a "restart" (we discard memoryState but keep this map) so we can assert durability.
+  function makeDurableStore(seed: Record<string, SkillLifecycleStatus>) {
+    const store = new Map<string, SkillLifecycleStatus>(Object.entries(seed));
+    return {
+      store,
+      persistSkillLifecycleStatus: (skillId: string, status: SkillLifecycleStatus): boolean => {
+        if (!store.has(skillId)) {
+          return false;
+        }
+        store.set(skillId, status);
+        return true;
+      },
+      getPersistedSkillLifecycleStatus: (skillId: string): SkillLifecycleStatus | undefined =>
+        store.get(skillId),
+    };
+  }
+
+  const makeStep = (kind: "disable_skill" | "regenerate_skill", target: string, payload: Record<string, unknown>) => ({
+    stepId: `step-${target}`,
+    kind: kind as typeof kind,
+    target,
+    payload,
+    verify: { method: "error_absent" as const, timeoutMs: 5000 },
+  });
+
+  it("persists self-heal disable durably for an in-store skill and survives a restart", async () => {
+    const durable = makeDurableStore({ "skill-x": "installed" });
+    const support = createFridayHubAutoFixExecutionSupport({
+      registry: makeRegistryWith(["skill-x"]),
+      memoryState: createStubMemoryState(),
+      nowIso: () => "2026-03-13T10:00:00.000Z",
+      ...durable,
+    });
+    const step = makeStep("disable_skill", "skill-x", {});
+    await expect(support.stepExecutors.disable_skill?.(step)).resolves.toBe(true);
+    await expect(support.stepVerifiers.disable_skill?.(step)).resolves.toBe(true);
+    expect(durable.store.get("skill-x")).toBe("disabled");
+    expect((step.payload as Record<string, unknown>)._skillStatusDurable).toBe(true);
+
+    // RESTART: fresh (empty) memoryState, same durable store → still disabled.
+    const afterRestart = createFridayHubAutoFixExecutionSupport({
+      registry: makeRegistryWith(["skill-x"]),
+      memoryState: createStubMemoryState(),
+      nowIso: () => "2026-03-13T11:00:00.000Z",
+      ...durable,
+    });
+    await expect(afterRestart.stepVerifiers.disable_skill?.(step)).resolves.toBe(true);
+    expect(durable.getPersistedSkillLifecycleStatus("skill-x")).toBe("disabled");
+  });
+
+  it("regenerate/re-enable updates durable status with no stale 'disabled' after restart", async () => {
+    const durable = makeDurableStore({ "skill-x": "disabled" }); // previously self-heal-disabled
+    const skillGenerator = {
+      startSession: async () => ({ session: { sessionId: "sess-1" } }),
+      generateDraft: async () => ({ manifest: { name: "Skill X" } }),
+      approveAndSave: async () => ({ candidateId: "cand-1" }),
+    } as unknown as FridaySkillGeneratorService;
+    const support = createFridayHubAutoFixExecutionSupport({
+      registry: makeRegistryWith(["skill-x"]),
+      memoryState: createStubMemoryState(),
+      nowIso: () => "2026-03-13T10:00:00.000Z",
+      skillGenerator,
+      ...durable,
+    });
+    const step = makeStep("regenerate_skill", "skill-x", { skillId: "skill-x" });
+    await expect(support.stepExecutors.regenerate_skill?.(step)).resolves.toBe(true);
+    await expect(support.stepVerifiers.regenerate_skill?.(step)).resolves.toBe(true);
+    expect(durable.store.get("skill-x")).toBe("installed");
+    expect((step.payload as Record<string, unknown>)._skillStatusDurable).toBe(true);
+
+    // RESTART: fresh memoryState → durable still 'installed' (NOT the stale 'disabled').
+    const afterRestart = createFridayHubAutoFixExecutionSupport({
+      registry: makeRegistryWith(["skill-x"]),
+      memoryState: createStubMemoryState(),
+      nowIso: () => "2026-03-13T11:00:00.000Z",
+      skillGenerator,
+      ...durable,
+    });
+    await expect(afterRestart.stepVerifiers.regenerate_skill?.(step)).resolves.toBe(true);
+    expect(durable.getPersistedSkillLifecycleStatus("skill-x")).toBe("installed");
+  });
+
+  it("does NOT fake-persist a built-in / not-in-store skill (honest non-durable result)", async () => {
+    const durable = makeDurableStore({}); // empty → 'skill-builtin' is registry-only, not durable
+    const memoryState = createStubMemoryState();
+    const support = createFridayHubAutoFixExecutionSupport({
+      registry: makeRegistryWith(["skill-builtin"]),
+      memoryState,
+      nowIso: () => "2026-03-13T10:00:00.000Z",
+      ...durable,
+    });
+    const step = makeStep("disable_skill", "skill-builtin", {});
+    await expect(support.stepExecutors.disable_skill?.(step)).resolves.toBe(true);
+    // In-process disable applied (the only store for a built-in) ...
+    expect((await memoryState.listSkillStatuses())["skill-builtin"]).toBe("disabled");
+    // ... but NO fake durable write, and the durability signal is honest.
+    expect(durable.store.has("skill-builtin")).toBe(false);
+    expect(durable.getPersistedSkillLifecycleStatus("skill-builtin")).toBeUndefined();
+    expect((step.payload as Record<string, unknown>)._skillStatusDurable).toBe(false);
+    // After a restart (fresh memoryState, durable empty) the disable did NOT persist — the
+    // verifier honestly reports false instead of a false-green durable success.
+    const afterRestart = createFridayHubAutoFixExecutionSupport({
+      registry: makeRegistryWith(["skill-builtin"]),
+      memoryState: createStubMemoryState(),
+      nowIso: () => "2026-03-13T11:00:00.000Z",
+      ...durable,
+    });
+    await expect(afterRestart.stepVerifiers.disable_skill?.(step)).resolves.toBe(false);
   });
 
   it("Phase 14.5B module_28b: apply_config_patch is fail-closed when no real patch payload is provided", async () => {


### PR DESCRIPTION
## Summary

Residual E (self-repair safety/recovery semantics). Self-heal `disable_skill` / `regenerate_skill` wrote skill lifecycle status **only** to the process-local `createStubMemoryState` stub, so a skill that self-heal **disabled** (because it was failing/unsafe) **silently re-enabled on the next hub restart** — and a regenerated/re-enabled skill's status could likewise be lost.

This wires **both** self-heal executors to the **existing durable** skill-lifecycle store so the decision survives a restart.

## Change (scoped per approved plan)

- `createFridayHubAutoFixExecutionSupport` gains two **optional** deps: `persistSkillLifecycleStatus(id, status) -> boolean` and `getPersistedSkillLifecycleStatus(id)`.
- `disable_skill` and `regenerate_skill` executors call the durable persister after the in-memory write; the verifiers use a durable-aware read (`resolveSkillLifecycleStatus`).
- The hub bootstrap binds the persister to `converterSkillRepo` — `getSkillById` existence check, then `updateLifecycleStatus` inside `withWriteTransaction`.

**Deliberately narrow:**
- Persists **only** for skills already in the durable `skills` table (installed/converter skills). Built-in / registry-only skills are **not upserted** — `persistSkillLifecycleStatus` returns `false` (no fake write), and the verifier reports an **honest non-durable result** (falls back to in-memory) instead of false-green.
- **No migration, no schema change, no registry-population change.**

## Proof

`test/unit/hub/bootstrap/hub-helpers.test.ts` (16 pass, types clean):
- **disable → restart** (fresh empty `memoryState`, same durable store) → still `disabled`.
- **regenerate/re-enable → restart** → `installed` (no stale `disabled` — catches the counterpart-staleness trap).
- **negative**: a built-in / not-in-store target is **not** fake-persisted (`store` has no entry, `_skillStatusDurable=false`), and the verifier honestly returns `false` after restart.

No-regression: existing self-heal/auto-fix suites pass unchanged (durable hooks are optional) — `friday-auto-fix-execution-service`, `friday-auto-fix-rollback-service`, `friday-self-healing-api-service` (34 tests). `build:api`, `check:secret-patterns`, `git diff --check` clean.

## Note

For in-store skills this also makes a self-heal disable effective for the durable-read workflow/install gates **in-process** (not only after restart) — the intended safety behavior (a self-heal-disabled skill is blocked, not silently runnable).

## Scope boundary

Standalone — does not bundle the other E truth-label items (FRIDAY_NODES_ENABLED comment, Desktop-Recording UI copy). No npm publish, tag, release, secrets/settings, or migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)