### PR TITLE
fix(truth): correct phantom FRIDAY_NODES_ENABLED flag (audit E2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -137,6 +137,8 @@ FRIDAY_ENABLE_HSTS=true
 # FRIDAY_TTS_PROVIDER=
 # FRIDAY_TTS_API_KEY=
 
-# ─── Nodes / IoT ───
-# Enable device/node control tool.
-# FRIDAY_NODES_ENABLED=false
+# ─── Nodes / IoT (paired satellites) ───
+# The node/device-control agent tool is ALWAYS registered; it operates on the
+# satellites you have paired and returns "satellite not found" when none are.
+# There is no enable flag — `FRIDAY_NODES_ENABLED` was never read by the
+# runtime (phantom var, removed from this example). Pair a satellite to use it.

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -7762,8 +7762,10 @@ export async function createFridayHub(
   // Stub services waste tokens: LLM tries to use the tool, gets an error, retries.
   // Skip registration entirely when no provider is available.
 
-  // 5. nodes — only register when nodes service is available (via FRIDAY_NODES_ENABLED).
-  // Same principle: don't register tools that can't work.
+  // 5. nodes — the satellite node/device-control tool is ALWAYS registered;
+  // it operates on paired satellites and returns "satellite not found" when
+  // none are paired. (There is no FRIDAY_NODES_ENABLED gate — that env var is
+  // not read by the runtime; the earlier comment naming it was inaccurate.)
   {
     const encodeNodeControlPayload = (payload: unknown): string =>
       Buffer.from(JSON.stringify(payload), "utf8").toString("base64");


### PR DESCRIPTION
## Audit E2 — phantom env-var truth fix (doc/comment only, no behavior change)

`FRIDAY_NODES_ENABLED` was advertised in `.env.example` and named in a bootstrap comment as the gate for the node/device-control tool, but `process.env.FRIDAY_NODES_ENABLED` is **never read** by the runtime. The satellite node/device-control tool is in fact **always registered** (`friday-hub-bootstrap.ts` ~7838) and operates on paired satellites (returns "satellite not found" when none are paired).

- `.env.example`: replace the phantom `FRIDAY_NODES_ENABLED=false` with an accurate note.
- bootstrap comment: correct the inaccurate "only register … via FRIDAY_NODES_ENABLED" wording.

No code/logic change. Lint clean.

## E batch context
- **E1** (preference-injector dead path): deferred/classified (your call).
- **E2** (this PR): phantom flag truth fix.
- **E3** (self-heal skill-status durability): **STOPPED & reported** — making skill-status durable conflicts with the converter's lifecycle-status writes to the shared `skills` table (registry-discovery `installed` would clobber the converter's `not_installed`, defeating the workflow-execution safety block for an unpromoted candidate). Needs a lifecycle-design decision before implementing.
- **E4** (multi-tenant/media/packaging default-off): not a defect — honestly disclosed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)