### PR TITLE
fix(self-heal): persist explicit skill lifecycle transitions durably (audit E3)

### DIFF
--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -43,7 +43,7 @@ import type { FridayHubConfigManagerService, FridaySkillRegistrySettings } from 
 import type { FridayDiscoveredSkillRecord, FridayHubMemoryStateService } from "../services/friday-hub-memory-state.types.js";
 import { appendFridayAuditLog } from "../services/friday-hub-audit-log-writer.js";
 import type { FridayStateRuntime } from "#state";
-import type { FridaySkillExecutor, FridaySkillRegistry, SkillLifecycleStatus } from "#skills";
+import type { FridaySkillExecutor, FridaySkillRegistry, FridaySkillRepository, SkillLifecycleStatus } from "#skills";
 import type { FridaySkillSecurityProfile } from "#skills";
 import type { FridaySkillGeneratorService } from "#skills/generator";
 import type { FridaySkillConverterService } from "#skills/converter";
@@ -1745,6 +1745,51 @@ export function createStubMemoryState(auditLogPath?: string): FridayHubMemorySta
     }),
     getMemoryItems: async () => [],
     putMemoryItem: async () => {},
+  };
+}
+
+/**
+ * Audit E (E3): durable memory-state whose EXPLICIT skill-lifecycle transitions
+ * (install / disable / enable / regenerate / error / not_installed via
+ * `updateSkillStatus`) are persisted to the durable `skills` table, so a
+ * self-heal disable (or any explicit transition) SURVIVES a hub restart. The
+ * workflow-execution safety gate (`getPersistedSkillLifecycleStatus`) reads the
+ * `skills` table, so persisting the explicit transition there is what makes the
+ * gate keep blocking a disabled skill after restart.
+ *
+ * DELIBERATELY NARROW — only `updateSkillStatus` is made durable:
+ *   - `upsertDiscoveredSkills` (registry discovery snapshot) and
+ *     `listSkillStatuses` stay IN-MEMORY (delegated to the stub). Discovery
+ *     must NOT write the table, or its auto-installed `installed` would CLOBBER
+ *     the converter's `not_installed` for an unpromoted candidate and defeat
+ *     the execution gate. Keeping discovery in-memory preserves the converter's
+ *     persisted lifecycle status as the source of truth.
+ *   - The durable write is best-effort: `updateLifecycleStatus` is an UPDATE,
+ *     so it persists only for skills that already have a `skills` row (the
+ *     converter-imported / promoted skills the gate actually governs). A
+ *     bundled skill that has no `skills` row is not gated by the table and
+ *     auto-reinstalls on discovery by design — its in-memory status is
+ *     unchanged from before (no regression).
+ */
+export function createDurableMemoryState(deps: {
+  db: FridaySqliteLayer;
+  skillRepository: FridaySkillRepository;
+  nowIso: () => string;
+  auditLogPath?: string;
+}): FridayHubMemoryStateService {
+  const base = createStubMemoryState(deps.auditLogPath);
+  return {
+    ...base,
+    updateSkillStatus: async (skillId: string, status: SkillLifecycleStatus, reason?: string) => {
+      // Keep the in-memory view (read by in-flight self-heal verifiers) current.
+      await base.updateSkillStatus(skillId, status, reason);
+      // Persist the explicit transition to the durable `skills` table (what the
+      // execution safety gate reads). Best-effort: a missing row (bundled skill
+      // not catalog-written) UPDATEs zero rows and is left to in-memory only.
+      deps.db.withWriteTransaction((conn) =>
+        deps.skillRepository.updateLifecycleStatus(conn, skillId, status, deps.nowIso()),
+      );
+    },
   };
 }
 

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -369,6 +369,7 @@ import {
   buildFridayChannelDeliveryFailureText,
   buildFridayChannelMessageTooLongText,
   canResolveFridayChannelApprovalFromMessage,
+  createDurableMemoryState,
   createFridayChannelToolApprovalShortId,
   createFridayHubAutoFixExecutionSupport,
   createPersistentConfigManager,
@@ -1069,17 +1070,27 @@ export async function createFridayHub(
   //     snapshots/revisions in SQLite via `hub_settings`; `/v1/config/*`
   //     HTTP routes are wired into the API runtime; mutations are NOT
   //     silently dropped.
-  //   - memoryState (`createStubMemoryState`) remains partial-stub: 4 of
-  //     its 10 interface methods (skill statuses + audit log) are real and
-  //     production-used; the 4 session/memory-item methods remain no-ops
-  //     and currently have ZERO production consumers (interface narrowing
-  //     is a carry-forward code-hygiene item; see B5_B6_B8_VERIFIED.md
+  //   - memoryState (`createDurableMemoryState`, audit E3): EXPLICIT skill
+  //     lifecycle transitions (`updateSkillStatus`: install / disable /
+  //     enable / regenerate / not_installed) are now PERSISTED to the `skills`
+  //     table, so a self-heal disable survives a hub restart and the execution
+  //     safety gate (which reads that table) keeps blocking it. Discovery
+  //     (`upsertDiscoveredSkills`) + `listSkillStatuses` stay in-memory ON
+  //     PURPOSE — discovery must not write the table or its auto-installed
+  //     status would clobber the converter's `not_installed`. Audit-log writes
+  //     to disk; the 4 session/memory-item methods remain no-ops and have
+  //     ZERO production consumers (carry-forward; see B5_B6_B8_VERIFIED.md
   //     §"FRI-AUD-022").
   // Use env vars and `friday.config.yaml` for first-boot configuration;
   // `/v1/config/*` for live mutations.
   const configManager = createPersistentConfigManager({ ...config, workspaceRoot }, stateRuntime);
   const auditLogPath = resolveFridayAuditLogPath(stateRuntime.stateDir);
-  const memoryState = createStubMemoryState(auditLogPath);
+  const memoryState = createDurableMemoryState({
+    db: stateRuntime.sqlite,
+    skillRepository: createFridaySkillRepository(),
+    nowIso: () => new Date().toISOString(),
+    auditLogPath,
+  });
 
   // 3. Create skill registry
   const registry = new FridaySkillRegistryImpl({

--- a/test/unit/hub/bootstrap/config-manager-truth-label.test.ts
+++ b/test/unit/hub/bootstrap/config-manager-truth-label.test.ts
@@ -19,8 +19,10 @@ import { describe, expect, it } from "vitest";
  *   - The misleading "Config mutations via API are silently no-ops" wording
  *     is removed from the bootstrap comment.
  *   - The bootstrap comment explicitly distinguishes the persistent
- *     configManager from the still-partial-stub memoryState (which has 4
- *     real methods + 4 no-op methods with zero production consumers).
+ *     configManager from the memoryState. (Audit E3 update: memoryState's
+ *     EXPLICIT skill lifecycle transitions are now DURABLE —
+ *     `createDurableMemoryState` persists `updateSkillStatus` to the `skills`
+ *     table; discovery + session/memory-item methods stay in-memory.)
  *   - The audit-finding anchor (`B9 / FRI-AUD-021`) is present in both the
  *     factory JSDoc + the bootstrap comment for future readers.
  */
@@ -57,19 +59,26 @@ describe("configManager rename + stale-comment fix (B9 / FRI-AUD-021)", () => {
     expect(bootstrapSource).toContain("B9 / FRI-AUD-021 truth-label");
   });
 
-  it("explicitly distinguishes the persistent configManager from the still-partial-stub memoryState", () => {
+  it("explicitly distinguishes the persistent configManager from the (durable-explicit-transition) memoryState", () => {
     // Use regex with `\s+` to tolerate the line-wrapped multi-line comment.
     expect(bootstrapSource).toMatch(/persists\s+\/\/\s+snapshots\/revisions in SQLite/);
     expect(bootstrapSource).toContain("/v1/config/*");
     expect(bootstrapSource).toContain("HTTP routes are wired");
-    expect(bootstrapSource).toContain("partial-stub");
+    // Audit E3: explicit skill lifecycle transitions are now PERSISTED to the
+    // skills table; only the session/memory-item methods remain no-ops.
+    expect(bootstrapSource).toContain("audit E3");
+    expect(bootstrapSource).toContain("PERSISTED to the `skills`");
     expect(bootstrapSource).toContain("ZERO production consumers");
     expect(bootstrapSource).toContain("B5_B6_B8_VERIFIED.md");
   });
 
-  it("preserves the existing `createStubMemoryState` factory (truthfully named: partial-stub)", () => {
+  it("wires the durable memoryState in bootstrap while preserving the `createStubMemoryState` factory", () => {
+    // The stub factory remains exported (used by tests + as the durable base).
     expect(helpersSource).toContain("export function createStubMemoryState(auditLogPath?: string)");
-    expect(bootstrapSource).toContain("createStubMemoryState,");
-    expect(bootstrapSource).toContain("createStubMemoryState(auditLogPath)");
+    // Audit E3: bootstrap uses the durable variant; only updateSkillStatus is durable.
+    expect(helpersSource).toContain("export function createDurableMemoryState(");
+    expect(bootstrapSource).toContain("createDurableMemoryState,");
+    expect(bootstrapSource).toContain("createDurableMemoryState({");
+    expect(bootstrapSource).not.toContain("createStubMemoryState(auditLogPath)");
   });
 });

--- a/test/unit/hub/bootstrap/friday-durable-memory-state.test.ts
+++ b/test/unit/hub/bootstrap/friday-durable-memory-state.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { createFridaySkillRepository } from "#skills";
+import { createDurableMemoryState, createStubMemoryState } from "../../../../src/hub/bootstrap/hub-helpers.js";
+import { createTestDb } from "../../../helpers/friday-test-db.helper.js";
+
+// Audit E3: EXPLICIT skill lifecycle transitions (via updateSkillStatus) must be
+// DURABLE in the `skills` table — which the workflow-execution safety gate reads
+// — so a self-heal disable survives a hub restart and keeps blocking. The fix is
+// deliberately NARROW: only updateSkillStatus is durable; discovery
+// (upsertDiscoveredSkills) stays in-memory so it can NOT clobber the converter's
+// `not_installed` (which would defeat the safety gate).
+
+const NOW = "2026-05-29T00:00:00.000Z";
+
+function seedInstalled(db: ReturnType<typeof createTestDb>, repo: ReturnType<typeof createFridaySkillRepository>, id: string): void {
+  db.withWriteTransaction((conn) =>
+    repo.upsertSkillFromCatalog(conn, {
+      id, name: id, source: "local", origin: "workspace", status: "installed", nowIso: NOW,
+    }),
+  );
+}
+function tableStatus(db: ReturnType<typeof createTestDb>, repo: ReturnType<typeof createFridaySkillRepository>, id: string): string | undefined {
+  return db.withReadConnection((conn) => repo.getSkillById(conn, id)?.status);
+}
+
+describe("createDurableMemoryState — explicit-transition durability (audit E3)", () => {
+  it("disable → restart → STILL disabled (persisted to the skills table the exec gate reads)", async () => {
+    const db = createTestDb();
+    try {
+      const repo = createFridaySkillRepository();
+      seedInstalled(db, repo, "skill-x");
+      const mem = createDurableMemoryState({ db, skillRepository: repo, nowIso: () => NOW });
+      await mem.updateSkillStatus("skill-x", "disabled", "self-heal disable");
+      // Durable: the skills table (exec-gate source) now says disabled.
+      expect(tableStatus(db, repo, "skill-x")).toBe("disabled");
+      // In-memory verifier view is also current (self-heal verifier reads this).
+      expect((await mem.listSkillStatuses())["skill-x"]).toBe("disabled");
+
+      // RESTART: a fresh durable memoryState (empty in-memory) still sees the
+      // durable table status — the disable is NOT lost.
+      const afterRestart = createDurableMemoryState({ db, skillRepository: repo, nowIso: () => NOW });
+      expect(tableStatus(db, repo, "skill-x")).toBe("disabled");
+      // (in-memory listSkillStatuses is empty after restart; the durable truth
+      //  lives in the table, which is exactly what the exec gate reads.)
+      expect((await afterRestart.listSkillStatuses())["skill-x"]).toBeUndefined();
+    } finally {
+      db.close();
+    }
+  });
+
+  it("re-enable → restart → enabled (durable in the skills table)", async () => {
+    const db = createTestDb();
+    try {
+      const repo = createFridaySkillRepository();
+      seedInstalled(db, repo, "skill-y");
+      const mem = createDurableMemoryState({ db, skillRepository: repo, nowIso: () => NOW });
+      await mem.updateSkillStatus("skill-y", "disabled");
+      expect(tableStatus(db, repo, "skill-y")).toBe("disabled");
+      await mem.updateSkillStatus("skill-y", "installed"); // explicit re-enable
+      expect(tableStatus(db, repo, "skill-y")).toBe("installed");
+      // Restart: still installed.
+      createDurableMemoryState({ db, skillRepository: repo, nowIso: () => NOW });
+      expect(tableStatus(db, repo, "skill-y")).toBe("installed");
+    } finally {
+      db.close();
+    }
+  });
+
+  it("ANTI-CLOBBER: registry discovery does NOT overwrite the converter's not_installed", async () => {
+    const db = createTestDb();
+    try {
+      const repo = createFridaySkillRepository();
+      // Converter staged an unpromoted candidate as not_installed (blocks exec).
+      db.withWriteTransaction((conn) =>
+        repo.upsertSkillFromCatalog(conn, {
+          id: "skill-z", name: "skill-z", source: "local", origin: "managed", status: "not_installed", nowIso: NOW,
+        }),
+      );
+      const mem = createDurableMemoryState({ db, skillRepository: repo, nowIso: () => NOW });
+      // Registry discovery computes "installed" (e.g. bundled auto-install) and
+      // snapshots it — this MUST stay in-memory and NOT touch the table.
+      await mem.upsertDiscoveredSkills([
+        { id: "skill-z", name: "skill-z", source: "local", origin: "bundled", status: "installed", manifest: {} as never },
+      ]);
+      // The converter's not_installed in the table is preserved → exec gate still blocks.
+      expect(tableStatus(db, repo, "skill-z")).toBe("not_installed");
+    } finally {
+      db.close();
+    }
+  });
+
+  it("the durable variant does NOT make listSkillStatuses durable (discovery stays in-memory)", async () => {
+    const db = createTestDb();
+    try {
+      const repo = createFridaySkillRepository();
+      const mem = createDurableMemoryState({ db, skillRepository: repo, nowIso: () => NOW });
+      await mem.upsertDiscoveredSkills([
+        { id: "skill-w", name: "skill-w", source: "local", origin: "bundled", status: "installed", manifest: {} as never },
+      ]);
+      // In-memory snapshot present this process...
+      expect((await mem.listSkillStatuses())["skill-w"]).toBe("installed");
+      // ...but NOT written to the durable table (no clobber surface).
+      expect(tableStatus(db, repo, "skill-w")).toBeUndefined();
+      // Contrast: the stub behaves the same in-memory.
+      const stub = createStubMemoryState();
+      expect((await stub.listSkillStatuses())["skill-w"]).toBeUndefined();
+    } finally {
+      db.close();
+    }
+  });
+});


### PR DESCRIPTION
## Audit E3 — durable explicit skill lifecycle transitions

**Gap:** self-heal `disable`/`regenerate` (and other explicit transitions) wrote skill status only to the in-memory `memoryState` stub → **reset on hub restart**. A skill disabled for failing came back after a restart, and the workflow-execution safety gate (which reads the durable `skills` table via `getPersistedSkillLifecycleStatus`) no longer blocked it.

**Fix (narrow + safe; no migration — existing `skills.status` column):**
- `createDurableMemoryState` overrides **only** `updateSkillStatus` (the explicit lifecycle-transition method) to also persist via `skillRepository.updateLifecycleStatus` to the `skills` table — exactly what the exec safety gate reads. A self-heal disable now survives restart and keeps blocking.
- `upsertDiscoveredSkills` (registry discovery snapshot) + `listSkillStatuses` **stay in-memory on purpose**: discovery must NOT write the table or its auto-installed `installed` would **clobber** the converter's `not_installed` for an unpromoted candidate and defeat the gate.
- Best-effort UPDATE: persists for skills with a `skills` row (converter-imported/promoted — the ones the gate governs); a bundled skill with no row auto-reinstalls on discovery by design (no regression).

**Why not the whole memoryState:** an earlier attempt routed all of memoryState (incl. discovery) to the table and clobbered `not_installed`, defeating the safety gate. This version is deliberately narrow.

**Regression tests** (`friday-durable-memory-state.test.ts`): disable→restart→still disabled; re-enable→restart→enabled; **anti-clobber** (discovery doesn't overwrite converter `not_installed`); discovery stays in-memory. The integration test `blocks workflow skill execution when persisted lifecycle status is unavailable` still passes (gate intact).

Full suite GREEN (12244 passed / 0 failed); lint 0 errors; typecheck clean.

## E batch
- E1 deferred (dead path), **E2 #405** (phantom flag truth), **E3 this PR**, E4 not-a-defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)