### PR TITLE
feat(workflows): Stage 2A — runtime-observed fs-write evidence→verified (audit C)

### DIFF
--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -1633,6 +1633,9 @@ export async function createFridayHub(
     nowIso,
     computeChecksum,
     resolveSkill: resolveWorkflowSkill,
+    // Audit C Stage 2A: anchor the filesystem-write verifier's scope containment
+    // to the same workspace root the skill registry resolves skill dirs against.
+    workspaceDir: workspaceRoot,
     invokeSkill: invokeSkillForWorkflow,
     userRulesContextProvider: (input) =>
       buildFridayUserRulesPromptContext({

--- a/src/workflows/runtime/friday-workflow-fs-write-verifier.ts
+++ b/src/workflows/runtime/friday-workflow-fs-write-verifier.ts
@@ -42,11 +42,17 @@ import { validateFridayFilesystemScope } from "../../skills/validation/friday-sk
 export const FRIDAY_FS_WRITE_TARGET_ARG_KEY = "__fridayWriteTarget";
 
 /**
- * PermissionActions that, if present, DISQUALIFY a node from being an fs-write
- * verification candidate — a write that is co-declared with send/connect/
- * capture/execute can produce side effects a runtime fs re-read cannot witness.
+ * Permission `action`s that denote a real external side effect / state mutation
+ * (mirrors the Stage-1 classifier's danger set). The ONLY one a runtime
+ * filesystem re-read can independently witness is a `filesystem` `write`; every
+ * other side-effecting grant — including `memory` `write` (a separate durable,
+ * UNwitnessed mutation, since `write` is resource-overloaded), and
+ * connect/send/capture/execute — disqualifies the node from fs-write
+ * verification. We therefore WHITELIST (candidate ⇒ every side-effecting grant
+ * is exactly `filesystem.write`), never blacklist a fixed verb set.
  */
-const DISQUALIFYING_SIDE_EFFECT_ACTIONS: ReadonlySet<string> = new Set([
+const SIDE_EFFECTING_PERMISSION_ACTIONS: ReadonlySet<string> = new Set([
+  "write",
   "connect",
   "send",
   "capture",
@@ -158,14 +164,24 @@ export function resolveFilesystemWriteTarget(
   const shape = readSkillShape(resolveSkill(skillId));
   if (!shape) return null;
 
-  const actions = shape.grants
-    .map((g) => (typeof g.action === "string" ? g.action : undefined))
-    .filter((a): a is string => typeof a === "string");
-
-  // Must declare a write, and NOTHING that a runtime fs re-read cannot witness.
-  const hasWrite = actions.includes("write");
-  if (!hasWrite) return null;
-  if (actions.some((a) => DISQUALIFYING_SIDE_EFFECT_ACTIONS.has(a))) return null;
+  // WHITELIST gate (not blacklist): a runtime fs re-read can independently witness ONLY a
+  // filesystem WRITE. So a candidate must declare a `filesystem.write` grant AND every one of
+  // its side-effecting grants must be EXACTLY `filesystem.write`. Any other side-effecting
+  // grant — `memory.write` (resource-overloaded `write`, a separate UNwitnessed durable
+  // mutation), `network.connect`, `channel.send`, `device.capture`, `shell.execute`, or any
+  // future resource×side-effect-action — disqualifies the node (it stays proof_pending).
+  // Read-only grants (filesystem.read, *.receive, memory.read, …) do NOT disqualify.
+  const sideEffectingGrants = shape.grants.filter(
+    (g) => typeof g.action === "string" && SIDE_EFFECTING_PERMISSION_ACTIONS.has(g.action),
+  );
+  const hasFilesystemWrite = sideEffectingGrants.some(
+    (g) => g.resource === "filesystem" && g.action === "write",
+  );
+  if (!hasFilesystemWrite) return null;
+  const everySideEffectIsFilesystemWrite = sideEffectingGrants.every(
+    (g) => g.resource === "filesystem" && g.action === "write",
+  );
+  if (!everySideEffectIsFilesystemWrite) return null;
 
   // skillDir is required to anchor manifest-relative scope containment.
   if (!shape.skillDir) return null;
@@ -270,7 +286,14 @@ export function resolveCanonicalTargetPath(
 export interface FridaySnapshot {
   /** Canonical absolute target path the snapshot was taken at. */
   canonicalPath: string;
-  /** Content checksum, or null if the file did not exist at snapshot time. */
+  /**
+   * Whether the target EXISTED pre-exec (independent of readability). Used to
+   * distinguish a genuinely newly-created file (`!existed` → a real delta) from
+   * an existing-but-unreadable file (`existed && checksum==null` → no provable
+   * content delta → NOT verified), so a permission flip alone can't pass.
+   */
+  existed: boolean;
+  /** Content checksum, or null if the file did not exist / was unreadable at snapshot time. */
   checksum: string | null;
 }
 
@@ -293,8 +316,12 @@ export function snapshotTarget(
     target.targetSource,
   );
   const content = io.readFile!(canonicalPath);
+  // Existence is independent of readability: a file that exists but is unreadable
+  // (content==null yet realpath resolves) must NOT later look "newly created".
+  const existed = content != null || io.realpath!(canonicalPath) != null;
   return {
     canonicalPath,
+    existed,
     checksum: content == null ? null : deps.computeChecksum(content),
   };
 }
@@ -388,12 +415,17 @@ export function verifyFsWriteEvidence(
   }
   const canonicalPath = io.realpath!(snapshot.canonicalPath) ?? snapshot.canonicalPath;
 
-  // (b) content changed OR newly created.
+  // (b) content changed OR genuinely newly created. A non-null pre-checksum requires the
+  // content to differ. A null pre-checksum is only a real delta when the file did NOT exist
+  // pre-exec; if it EXISTED but was unreadable at snapshot, we cannot prove a content delta
+  // (a mere permission/readability flip is not evidence of a write) → refuse.
   if (snapshot.checksum != null) {
     const postChecksum = deps.computeChecksum(postContent);
     if (postChecksum === snapshot.checksum) {
       return { verified: false, reason: "target-unchanged" };
     }
+  } else if (snapshot.existed) {
+    return { verified: false, reason: "target-existed-unreadable-pre-exec" };
   }
 
   // (d) target not under the evidence-export mirror (circular proof).

--- a/src/workflows/runtime/friday-workflow-fs-write-verifier.ts
+++ b/src/workflows/runtime/friday-workflow-fs-write-verifier.ts
@@ -1,0 +1,436 @@
+/**
+ * Workflow filesystem-write evidence verifier (audit C, Stage 2A).
+ *
+ * Stage 1 truth-labels every side-effect node `proof_pending` because no
+ * deterministic evidence plumbs through. Stage 2A closes the FIRST concrete
+ * side-effect class — a bounded filesystem WRITE — by re-reading the node's
+ * DECLARED write target after the skill runs and proving an independent
+ * on-disk state delta. Only then does the node's completion upgrade to
+ * `verified`; everything else (skill lied / wrote nothing / wrote elsewhere /
+ * out-of-scope / its own receipt / an evidence-export mirror) stays
+ * `proof_pending`.
+ *
+ * Scope of Stage 2A (deliberately narrow — see stage2a-plan.md):
+ *  - Candidate ONLY when the node's skill grants are write-class with NO
+ *    send/connect/capture/execute grant (a pure local file write — the only
+ *    side effect a runtime fs re-read can independently witness). A
+ *    write+send/connect/etc node is NOT a candidate and stays `proof_pending`.
+ *  - The write target is sourced ONLY from TRUSTED node/manifest inputs (a
+ *    reserved `config.args` key, or a single concrete manifest `pathPrefixes`
+ *    file) — NEVER from the (untrusted) skill output. The skill's returned
+ *    artifact URIs are used only to REFUSE a self-receipt / circular proof.
+ *  - No skill-adapter / invokeSkill / FridaySkillExecuteResult signature
+ *    change; no new persistence (verified flows through the existing
+ *    record→persist path).
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import type { FridayWorkflowNode } from "../model/friday-workflow-graph.types.js";
+import { validateFridayFilesystemScope } from "../../skills/validation/friday-skill-filesystem-scope-validator.js";
+
+/**
+ * Reserved `node.config.args` key declaring the CONCRETE filesystem path the
+ * action node's skill is expected to write. This is the minimal binding-target
+ * convention (requirement 1): it lives in the workflow node definition (trusted
+ * input), is bounded by the skill's declared `pathPrefixes` scope, and requires
+ * NO adapter contract change. The key is also passed through to the skill input
+ * (the skill executor tolerates unknown args), so a skill can read it to know
+ * exactly where to write.
+ */
+export const FRIDAY_FS_WRITE_TARGET_ARG_KEY = "__fridayWriteTarget";
+
+/**
+ * PermissionActions that, if present, DISQUALIFY a node from being an fs-write
+ * verification candidate — a write that is co-declared with send/connect/
+ * capture/execute can produce side effects a runtime fs re-read cannot witness.
+ */
+const DISQUALIFYING_SIDE_EFFECT_ACTIONS: ReadonlySet<string> = new Set([
+  "connect",
+  "send",
+  "capture",
+  "execute",
+]);
+
+export interface FridayFilesystemWriteTarget {
+  /** The action node's skill id. */
+  skillId: string;
+  /** The skill install directory (manifest-relative scope root). */
+  skillDir: string;
+  /**
+   * The declared write target, exactly as sourced from the node/manifest
+   * (relative or absolute). Containment is enforced by the verifier, never
+   * here.
+   */
+  declaredTarget: string;
+  /**
+   * Where the target was declared, which determines how a BARE-RELATIVE target
+   * resolves: a `node-arg` target (the workflow author's reserved config.args
+   * key) resolves relative to the WORKSPACE root; a `manifest-prefix` target
+   * resolves with the same skill-relative semantics `validateFridayFilesystemScope`
+   * uses. (`${workspaceDir}`-prefixed and absolute targets resolve identically
+   * for both.)
+   */
+  targetSource: "node-arg" | "manifest-prefix";
+  /**
+   * The skill's declared filesystem write scope prefixes (manifest
+   * `pathPrefixes`), used for containment + (when there is exactly one concrete
+   * prefix) as the fallback binding target.
+   */
+  writePathPrefixes: string[];
+}
+
+/** Defensive narrow of whatever `resolveSkill` returns into manifest grants + skillDir. */
+function readSkillShape(skill: unknown): {
+  grants: Array<{ resource?: unknown; action?: unknown; selectors?: unknown }>;
+  skillDir: string | null;
+} | null {
+  if (skill == null || typeof skill !== "object") return null;
+  const manifest = (skill as { manifest?: unknown }).manifest;
+  if (manifest == null || typeof manifest !== "object") return null;
+  const permissions = (manifest as { permissions?: unknown }).permissions;
+  if (permissions == null || typeof permissions !== "object") return null;
+  const rawGrants = (permissions as { grants?: unknown }).grants;
+  if (!Array.isArray(rawGrants)) return null;
+  const grants = rawGrants.filter(
+    (g): g is { resource?: unknown; action?: unknown; selectors?: unknown } =>
+      g != null && typeof g === "object",
+  );
+  const skillDirRaw = (skill as { skillDir?: unknown }).skillDir;
+  const skillDir = typeof skillDirRaw === "string" && skillDirRaw.length > 0 ? skillDirRaw : null;
+  return { grants, skillDir };
+}
+
+/** Collect filesystem.write `pathPrefixes` selectors from the grants. */
+function collectWritePathPrefixes(
+  grants: Array<{ resource?: unknown; action?: unknown; selectors?: unknown }>,
+): string[] {
+  const prefixes: string[] = [];
+  for (const grant of grants) {
+    if (grant.resource !== "filesystem" || grant.action !== "write") continue;
+    const selectors = grant.selectors;
+    if (selectors == null || typeof selectors !== "object") continue;
+    const pathPrefixes = (selectors as { pathPrefixes?: unknown }).pathPrefixes;
+    if (!Array.isArray(pathPrefixes)) continue;
+    for (const p of pathPrefixes) {
+      if (typeof p === "string" && p.length > 0) prefixes.push(p);
+    }
+  }
+  return prefixes;
+}
+
+/** Does the path prefix denote exactly one concrete file (no glob / trailing slash)? */
+function isConcreteFilePrefix(prefix: string): boolean {
+  if (prefix.includes("*")) return false;
+  if (prefix.endsWith("/")) return false;
+  return prefix.length > 0;
+}
+
+/**
+ * Resolve the BINDING filesystem-write target for an action node, sourced ONLY
+ * from trusted node/manifest inputs. Returns non-null ONLY when:
+ *  - the node is an `action` node with a resolvable skill id;
+ *  - the skill's grants contain a filesystem `write` action;
+ *  - the skill's grants contain NO disqualifying side-effect action
+ *    (send/connect/capture/execute);
+ *  - a concrete binding target is resolvable, either:
+ *      (a) the reserved `config.args.__fridayWriteTarget` key (a string), OR
+ *      (b) the manifest declares EXACTLY ONE concrete (non-glob) write
+ *          `pathPrefixes` entry.
+ *
+ * Otherwise returns null (the node is not an fs-write verification candidate
+ * and stays `proof_pending`).
+ */
+export function resolveFilesystemWriteTarget(
+  node: Pick<FridayWorkflowNode, "type" | "config">,
+  resolveSkill: (skillId: string) => unknown,
+): FridayFilesystemWriteTarget | null {
+  if (node.type !== "action") return null;
+  const cfg = (node.config ?? {}) as Record<string, unknown>;
+  const skillId = typeof cfg.skillId === "string"
+    ? cfg.skillId
+    : typeof cfg.ref === "string"
+      ? cfg.ref
+      : undefined;
+  if (!skillId) return null;
+
+  const shape = readSkillShape(resolveSkill(skillId));
+  if (!shape) return null;
+
+  const actions = shape.grants
+    .map((g) => (typeof g.action === "string" ? g.action : undefined))
+    .filter((a): a is string => typeof a === "string");
+
+  // Must declare a write, and NOTHING that a runtime fs re-read cannot witness.
+  const hasWrite = actions.includes("write");
+  if (!hasWrite) return null;
+  if (actions.some((a) => DISQUALIFYING_SIDE_EFFECT_ACTIONS.has(a))) return null;
+
+  // skillDir is required to anchor manifest-relative scope containment.
+  if (!shape.skillDir) return null;
+
+  const writePathPrefixes = collectWritePathPrefixes(shape.grants);
+
+  // (a) Reserved binding-target key in the node definition (trusted input).
+  // NOTE: this value is also passed through to the skill payload via the node
+  // executor's `resolveArgs`, which evaluates any `$`-prefixed string as a
+  // workflow expression. The binding target is therefore an ABSOLUTE path or a
+  // WORKSPACE-RELATIVE path (NOT `$`-prefixed); the verifier resolves it against
+  // the workspace root.
+  const args = (cfg.args ?? {}) as Record<string, unknown>;
+  const reservedTarget = args[FRIDAY_FS_WRITE_TARGET_ARG_KEY];
+  if (typeof reservedTarget === "string" && reservedTarget.trim().length > 0) {
+    return {
+      skillId,
+      skillDir: shape.skillDir,
+      declaredTarget: reservedTarget.trim(),
+      targetSource: "node-arg",
+      writePathPrefixes,
+    };
+  }
+
+  // (b) Manifest declares exactly one concrete (non-glob) write file. This is a
+  // manifest scope value, so it resolves with `validateFridayFilesystemScope`'s
+  // skill-relative semantics.
+  const concretePrefixes = writePathPrefixes.filter(isConcreteFilePrefix);
+  if (concretePrefixes.length === 1) {
+    return {
+      skillId,
+      skillDir: shape.skillDir,
+      declaredTarget: concretePrefixes[0]!,
+      targetSource: "manifest-prefix",
+      writePathPrefixes,
+    };
+  }
+
+  // No binding target → not a candidate (inert, stays proof_pending).
+  return null;
+}
+
+// ─── snapshot / verify ───
+
+export interface FridayFsVerifierDeps {
+  /** Reads file bytes as utf8; returns null when the path does not exist. */
+  readFile?: (absPath: string) => string | null;
+  /** Existence + canonicalization probe; returns the real absolute path or null. */
+  realpath?: (absPath: string) => string | null;
+  /** Content checksum (same impl as the runtime's computeChecksum). */
+  computeChecksum: (content: string) => string;
+}
+
+/** Default fs deps backed by node:fs (injectable for tests). */
+export function defaultFsVerifierIo(): Pick<FridayFsVerifierDeps, "readFile" | "realpath"> {
+  return {
+    readFile: (absPath) => {
+      try {
+        return fs.readFileSync(absPath, "utf8");
+      } catch {
+        return null;
+      }
+    },
+    realpath: (absPath) => {
+      try {
+        return fs.realpathSync(absPath);
+      } catch {
+        return null;
+      }
+    },
+  };
+}
+
+/**
+ * Resolve a declared target to a canonical absolute path. Uses the SAME scope
+ * semantics as `validateFridayFilesystemScope`: `${workspaceDir}` prefix and
+ * skill-relative resolution. Symlinks are canonicalized when the file exists;
+ * a not-yet-existing target resolves to its absolute (un-canonicalized) path so
+ * a newly-created file is detected post-exec.
+ */
+export function resolveCanonicalTargetPath(
+  declaredTarget: string,
+  skillDir: string,
+  workspaceDir: string,
+  realpath: (absPath: string) => string | null,
+  targetSource: FridayFilesystemWriteTarget["targetSource"] = "node-arg",
+): string {
+  // A `${workspaceDir}`-prefixed or absolute target resolves identically for
+  // either source. A BARE-RELATIVE target anchors on the WORKSPACE root for a
+  // node-author-declared `node-arg` target, and on the SKILL dir for a
+  // `manifest-prefix` target (matching `validateFridayFilesystemScope`).
+  const relativeAnchor = targetSource === "manifest-prefix" ? skillDir : workspaceDir;
+  const resolvedRaw = declaredTarget.startsWith("${workspaceDir}")
+    ? declaredTarget.replace("${workspaceDir}", workspaceDir)
+    : path.isAbsolute(declaredTarget)
+      ? declaredTarget
+      : path.join(relativeAnchor, declaredTarget);
+  const abs = path.resolve(resolvedRaw);
+  return realpath(abs) ?? abs;
+}
+
+export interface FridaySnapshot {
+  /** Canonical absolute target path the snapshot was taken at. */
+  canonicalPath: string;
+  /** Content checksum, or null if the file did not exist at snapshot time. */
+  checksum: string | null;
+}
+
+/**
+ * Pre-exec snapshot of the declared target: its canonical path + a checksum (or
+ * null when the file does not yet exist). The post-exec verify compares against
+ * this to require either a checksum change or a newly-created file.
+ */
+export function snapshotTarget(
+  target: FridayFilesystemWriteTarget,
+  workspaceDir: string,
+  deps: FridayFsVerifierDeps,
+): FridaySnapshot {
+  const io = { ...defaultFsVerifierIo(), ...deps };
+  const canonicalPath = resolveCanonicalTargetPath(
+    target.declaredTarget,
+    target.skillDir,
+    workspaceDir,
+    io.realpath!,
+    target.targetSource,
+  );
+  const content = io.readFile!(canonicalPath);
+  return {
+    canonicalPath,
+    checksum: content == null ? null : deps.computeChecksum(content),
+  };
+}
+
+export type FridayFsWriteVerifyOutcome =
+  | { verified: true }
+  | { verified: false; reason: string };
+
+export interface VerifyFsWriteEvidenceInput {
+  target: FridayFilesystemWriteTarget;
+  snapshot: FridaySnapshot;
+  /** Absolute root the evidence-export mirror lives under — a target here is REFUSED. */
+  evidenceExportRootDir: string;
+  /** The workspace root used for scope containment. */
+  workspaceDir: string;
+  /**
+   * URIs / paths the skill RETURNED as its own artifacts/receipts (untrusted).
+   * If the declared target equals any of these, the "evidence" is the skill's
+   * own self-written receipt / a returned artifact — REFUSED (circular proof).
+   */
+  returnedArtifactUris: string[];
+}
+
+/** Normalize a possibly-`file://` / relative artifact URI to a canonical absolute path. */
+function normalizeArtifactPath(
+  uri: string,
+  workspaceDir: string,
+  skillDir: string,
+  realpath: (absPath: string) => string | null,
+): string | null {
+  if (typeof uri !== "string" || uri.length === 0) return null;
+  let raw = uri;
+  if (raw.startsWith("file://")) {
+    try {
+      raw = new URL(raw).pathname;
+    } catch {
+      raw = raw.slice("file://".length);
+    }
+  } else if (/^[a-z]+:\/\//i.test(raw)) {
+    // A non-file scheme (friday://, https://, etc.) can never equal a local
+    // filesystem write target by path; skip it.
+    return null;
+  }
+  const resolvedRaw = raw.startsWith("${workspaceDir}")
+    ? raw.replace("${workspaceDir}", workspaceDir)
+    : path.isAbsolute(raw)
+      ? raw
+      : path.join(skillDir, raw);
+  const abs = path.resolve(resolvedRaw);
+  return realpath(abs) ?? abs;
+}
+
+/** Is `candidate` equal to, or nested under, `root`? (both canonical absolute) */
+function isWithin(root: string, candidate: string): boolean {
+  const rel = path.relative(root, candidate);
+  return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
+}
+
+/**
+ * Post-exec verification of a filesystem-write side effect. Returns
+ * `{ verified: true }` ONLY when ALL hold:
+ *  (a) the declared target EXISTS post-exec;
+ *  (b) its content CHANGED vs the pre-exec snapshot, OR it is NEWLY created
+ *      (snapshot checksum was null);
+ *  (c) the target is WITHIN the skill's declared write scope
+ *      (validateFridayFilesystemScope over each declared pathPrefix);
+ *  (d) the target is NOT under `evidenceExportRootDir` (no evidence-export
+ *      mirror / circular proof);
+ *  (e) the target does NOT equal any skill-RETURNED artifact URI / receipt
+ *      path (no self-receipt / circular proof).
+ *
+ * Any failure → `{ verified: false, reason }`; the caller maps this to
+ * `proof_pending`. Reads are injected for testability; the runtime supplies the
+ * real node:fs-backed deps.
+ */
+export function verifyFsWriteEvidence(
+  input: VerifyFsWriteEvidenceInput,
+  deps: FridayFsVerifierDeps,
+): FridayFsWriteVerifyOutcome {
+  const io = { ...defaultFsVerifierIo(), ...deps };
+  const { target, snapshot, evidenceExportRootDir, workspaceDir, returnedArtifactUris } = input;
+
+  // (a) target exists post-exec. Read via the snapshot path (which may be the
+  // un-canonicalized absolute path of a not-yet-created file), then canonicalize
+  // NOW that the file exists so all containment/equality comparisons below use
+  // the same realpath form `validateFridayFilesystemScope` produces (this
+  // matters on platforms where e.g. /tmp → /private/tmp).
+  const postContent = io.readFile!(snapshot.canonicalPath);
+  if (postContent == null) {
+    return { verified: false, reason: "target-missing-post-exec" };
+  }
+  const canonicalPath = io.realpath!(snapshot.canonicalPath) ?? snapshot.canonicalPath;
+
+  // (b) content changed OR newly created.
+  if (snapshot.checksum != null) {
+    const postChecksum = deps.computeChecksum(postContent);
+    if (postChecksum === snapshot.checksum) {
+      return { verified: false, reason: "target-unchanged" };
+    }
+  }
+
+  // (d) target not under the evidence-export mirror (circular proof).
+  const evidenceRootCanonical = io.realpath!(evidenceExportRootDir) ?? path.resolve(evidenceExportRootDir);
+  if (isWithin(evidenceRootCanonical, canonicalPath)) {
+    return { verified: false, reason: "target-under-evidence-export-root" };
+  }
+
+  // (e) target not equal to any skill-returned artifact URI / receipt path.
+  for (const uri of returnedArtifactUris) {
+    const artifactPath = normalizeArtifactPath(uri, workspaceDir, target.skillDir, io.realpath!);
+    if (artifactPath != null && artifactPath === canonicalPath) {
+      return { verified: false, reason: "target-equals-returned-artifact" };
+    }
+  }
+
+  // (c) target within declared write scope. With no declared prefixes there is
+  // no scope to contain the write → refuse (fail-closed). With prefixes, the
+  // target must be contained by at least one.
+  if (target.writePathPrefixes.length === 0) {
+    return { verified: false, reason: "no-declared-write-scope" };
+  }
+  const inScope = target.writePathPrefixes.some((prefix) => {
+    const result = validateFridayFilesystemScope({
+      scope: prefix,
+      skillDir: target.skillDir,
+      workspaceDir,
+    });
+    if (!result.ok || result.resolvedPath == null) return false;
+    // The declared prefix may be the file itself (concrete) or a directory the
+    // file lives under; accept the target if it equals or is nested under the
+    // resolved scope path.
+    return isWithin(result.resolvedPath, canonicalPath);
+  });
+  if (!inScope) {
+    return { verified: false, reason: "target-out-of-scope" };
+  }
+
+  return { verified: true };
+}

--- a/src/workflows/runtime/friday-workflow-runtime.ts
+++ b/src/workflows/runtime/friday-workflow-runtime.ts
@@ -87,6 +87,13 @@ import {
   type FridayNodeCompletionVerification,
   resolveNodeCompletionVerification,
 } from "./friday-workflow-node-acceptance.js";
+import {
+  type FridayFilesystemWriteTarget,
+  type FridaySnapshot,
+  resolveFilesystemWriteTarget,
+  snapshotTarget,
+  verifyFsWriteEvidence,
+} from "./friday-workflow-fs-write-verifier.js";
 import { createFridayWorkflowArtifactWriter } from "../engine/friday-workflow-artifact-writer.js";
 import { createFridayWorkflowNodeRunnerFacade } from "../engine/friday-workflow-node-runner-facade.js";
 import { createFridayWorkflowAcceptanceGate } from "../engine/friday-workflow-acceptance-gate.js";
@@ -369,6 +376,71 @@ function inferArtifactType(output: unknown): FridayAcceptanceArtifactType {
   return "json";
 }
 
+/**
+ * Audit C Stage 2A: collect every URI / path the (UNTRUSTED) node execution
+ * RESULT declares as its OWN artifact / receipt. The fs-write verifier refuses
+ * to count the declared target as `verified` if it equals any of these — that
+ * is exactly the forbidden "skill self-written receipt" / returned-artifact-URI
+ * == target circular proof (the delta would be merely the skill's own serialized
+ * output, not an independent side effect).
+ *
+ * Two formal channels are collected (NOT arbitrary output string leaves — a
+ * skill legitimately echoing the path it changed, e.g. `summary` /
+ * `details.changedPath`, must NOT trip the guard, else nothing could verify):
+ *   1. `result.artifacts[].uri` — the formal artifact channel;
+ *   2. string values under receipt/artifact-NAMED output keys (`runPath`,
+ *      `receiptPath`, `artifactPath`/`artifactUri`, `evidencePath`,
+ *      `outputPath`, `uri`, `path`) — how skills like page-benchmark-report
+ *      report the evidence file they wrote and returned as their own receipt.
+ * These are used ONLY for the refusal — never to source the re-read target.
+ */
+const RETURNED_ARTIFACT_KEYS: ReadonlySet<string> = new Set([
+  "uri",
+  "path",
+  "runpath",
+  "receiptpath",
+  "artifactpath",
+  "artifacturi",
+  "evidencepath",
+  "outputpath",
+  "reportpath",
+  "baselinepath",
+]);
+
+function collectReturnedArtifactPaths(result: unknown): string[] {
+  const uris: string[] = [];
+  const r = result as { artifacts?: unknown; output?: unknown } | null | undefined;
+  if (r && typeof r === "object") {
+    if (Array.isArray(r.artifacts)) {
+      for (const a of r.artifacts) {
+        const uri = a != null && typeof a === "object" ? (a as { uri?: unknown }).uri : undefined;
+        if (typeof uri === "string" && uri.length > 0) uris.push(uri);
+      }
+    }
+    // Walk output collecting ONLY string values under receipt/artifact-named
+    // keys (bounded depth/breadth).
+    const seen = new Set<unknown>();
+    const walk = (value: unknown, depth: number): void => {
+      if (depth > 6 || uris.length > 256) return;
+      if (value == null || typeof value !== "object" || seen.has(value)) return;
+      seen.add(value);
+      if (Array.isArray(value)) {
+        for (const item of value) walk(item, depth + 1);
+        return;
+      }
+      for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+        if (typeof v === "string" && v.length > 0 && RETURNED_ARTIFACT_KEYS.has(k.toLowerCase())) {
+          uris.push(v);
+        } else {
+          walk(v, depth + 1);
+        }
+      }
+    };
+    walk(r.output, 0);
+  }
+  return uris;
+}
+
 function normalizeAcceptanceContent(content: unknown): Record<string, unknown> {
   const base = { ...asRecord(content) };
   if (Object.keys(base).length === 0) {
@@ -421,6 +493,15 @@ export interface CreateFridayWorkflowRuntimeDeps {
   nowIso: () => string;
   computeChecksum: (content: string) => string;
   resolveSkill: (skillId: string) => unknown | null;
+  /**
+   * Workspace root used by the audit-C Stage 2A filesystem-write verifier to
+   * anchor scope containment (`${workspaceDir}` + skill-relative resolution).
+   * Wired from the hub bootstrap's `workspaceRoot` — the same root the skill
+   * registry resolves skill dirs against. Optional (defaults to `process.cwd()`)
+   * so existing callers/tests need no change; absent it only weakens fs-write
+   * containment to the process cwd, never enabling a false `verified`.
+   */
+  workspaceDir?: string;
   invokeSkill: (
     skillId: string,
     runId: string,
@@ -475,6 +556,12 @@ export function createFridayWorkflowRuntime(
   const evidenceExportRootDir = resolvedDbPath !== ":memory:"
     ? path.join(path.dirname(resolvedDbPath), "artifacts", "workflow-evidence")
     : path.join(process.cwd(), ".friday", "artifacts", "workflow-evidence");
+
+  // Audit C Stage 2A: workspace root for the filesystem-write verifier's scope
+  // containment. Defaults to the process cwd when the hub did not wire it.
+  const fsVerifierWorkspaceDir = typeof deps.workspaceDir === "string" && deps.workspaceDir.length > 0
+    ? deps.workspaceDir
+    : process.cwd();
 
   // Phase 14.5C: per-run evidence-status tracking. The legacy global
   // `evidencePersistenceAvailable` flag silently masked degraded persistence
@@ -1318,9 +1405,25 @@ export function createFridayWorkflowRuntime(
       // Applied in EVERY path — pipeline-on, output==null, and the legacy/
       // pipeline-disabled bypass — so none of them can be read as verified.
       const sideEffectClass = classifyWorkflowNodeSideEffect(input.node, deps.resolveSkill);
-      const completionVerification = resolveNodeCompletionVerification(input.node, sideEffectClass);
+      const baselineVerification = resolveNodeCompletionVerification(input.node, sideEffectClass);
+
+      // Audit C Stage 2A: is this node a filesystem-write VERIFICATION candidate
+      // — a write-class side effect (NO send/connect/capture/execute) with a
+      // resolvable binding target sourced from trusted node/manifest inputs? If
+      // so, its `proof_pending`→`verified` upgrade requires a real on-disk state
+      // delta, observed AFTER the skill runs. The Stage 1 baseline label is the
+      // worst-case (`proof_pending`); the verifier may upgrade it to `verified`.
+      const fsWriteTarget: FridayFilesystemWriteTarget | null = resolveFilesystemWriteTarget(
+        input.node,
+        deps.resolveSkill,
+      );
+
+      // The FINAL completion-verification label. For non-candidates it is the
+      // Stage 1 baseline. For candidates it starts at `proof_pending` and is only
+      // raised to `verified` after a confirmed fs delta (see below).
+      let effectiveVerification: FridayNodeCompletionVerification = baselineVerification;
       const withVerification = <T>(r: T): T => {
-        (r as { completionVerification?: FridayNodeCompletionVerification }).completionVerification = completionVerification;
+        (r as { completionVerification?: FridayNodeCompletionVerification }).completionVerification = effectiveVerification;
         return r;
       };
 
@@ -1336,15 +1439,81 @@ export function createFridayWorkflowRuntime(
       // clean/verified. It does NOT block the node from running (no
       // over-blocking) and is ORTHOGONAL to `evidenceStatus` — recording a
       // non-verified completion must NOT touch evidence-persistence health.
-      recordRunNodeCompletionVerification(input.runId, completionVerification);
+      //
+      // Stage 2A DEFER-AND-RECORD-ONCE: `recordRunNodeCompletionVerification` is
+      // monotonic-downward, so an up-front `proof_pending` record makes a later
+      // `verified` record a NO-OP. For an fs-write CANDIDATE we therefore DEFER
+      // the up-front record and record exactly once AFTER the re-read (verified
+      // when an fs delta is confirmed, else proof_pending). EVERY candidate exit
+      // path (success / catch / !pipelineEnabled) MUST record, or a
+      // candidate-only run would default-read `verified`. All non-candidate
+      // nodes keep the up-front record (unchanged Stage 1/2B behavior).
+      if (!fsWriteTarget) {
+        recordRunNodeCompletionVerification(input.runId, baselineVerification);
+      }
 
       if (!pipelineEnabled) {
         // Legacy / pipeline-disabled bypass must still be truth-labeled — a
-        // disabled pipeline is not a verified completion.
+        // disabled pipeline is not a verified completion. An fs-write candidate
+        // is NOT verified on the legacy path (no re-read happens there); record
+        // its deferred label as `proof_pending` so the run cannot read verified.
+        if (fsWriteTarget) {
+          recordRunNodeCompletionVerification(input.runId, baselineVerification);
+        }
         return withVerification(await legacyNodeExecutor.executeNode(input));
       }
+
+      // Stage 2A: snapshot the declared target BEFORE execution so the post-exec
+      // re-read can prove a checksum change or a newly-created file.
+      let fsSnapshot: FridaySnapshot | null = null;
+      if (fsWriteTarget) {
+        try {
+          fsSnapshot = snapshotTarget(
+            fsWriteTarget,
+            fsVerifierWorkspaceDir,
+            { computeChecksum: deps.computeChecksum },
+          );
+        } catch {
+          fsSnapshot = null; // unreadable pre-state → treat as "no snapshot"; verify still requires post-existence + delta.
+        }
+      }
+
       try {
         const result = withVerification(await nodeRunnerFacade.executeNode(input));
+
+        // Stage 2A: re-read the declared target and decide the candidate's
+        // single recorded label. `verified` ONLY on a confirmed in-scope,
+        // non-self-receipt, non-evidence-mirror fs delta; else `proof_pending`.
+        if (fsWriteTarget) {
+          let evidenceVerified = false;
+          if (fsSnapshot) {
+            try {
+              const outcome = verifyFsWriteEvidence(
+                {
+                  target: fsWriteTarget,
+                  snapshot: fsSnapshot,
+                  evidenceExportRootDir,
+                  workspaceDir: fsVerifierWorkspaceDir,
+                  returnedArtifactUris: collectReturnedArtifactPaths(result),
+                },
+                { computeChecksum: deps.computeChecksum },
+              );
+              evidenceVerified = outcome.verified;
+            } catch {
+              evidenceVerified = false; // any verifier error → fail closed.
+            }
+          }
+          effectiveVerification = resolveNodeCompletionVerification(
+            input.node,
+            "side_effect",
+            evidenceVerified,
+          );
+          // Stamp the now-final label on the result before it is returned, then
+          // record once. (`withVerification` reads `effectiveVerification` live,
+          // so the earlier stamp is overwritten here.)
+          (result as { completionVerification?: FridayNodeCompletionVerification }).completionVerification = effectiveVerification;
+          recordRunNodeCompletionVerification(input.runId, effectiveVerification);
+        }
 
         pipelineEventEmitter.emit(
           "pipeline.node.execution.completed",
@@ -1430,6 +1599,14 @@ export function createFridayWorkflowRuntime(
 
         return result;
       } catch (error) {
+        // Stage 2A: a candidate that threw (execution error, OR an acceptance
+        // gate failure thrown AFTER a success-path `verified` record) did NOT
+        // cleanly complete — record `proof_pending`. `record...` is
+        // monotonic-downward, so this safely downgrades any earlier `verified`
+        // and guarantees the deferred candidate is always recorded on this exit.
+        if (fsWriteTarget) {
+          recordRunNodeCompletionVerification(input.runId, "proof_pending");
+        }
         pipelineEventEmitter.emit(
           "pipeline.node.execution.completed",
           {

--- a/test/e2e/api/friday-api-workflow-completion-verification-enforcement.acceptance.test.ts
+++ b/test/e2e/api/friday-api-workflow-completion-verification-enforcement.acceptance.test.ts
@@ -20,6 +20,9 @@
  */
 
 import { createHash } from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -33,6 +36,7 @@ import {
   type FridayCompiledWorkflowGraphV2,
   type FridayWorkflowRuntime,
 } from "#workflows";
+import { FRIDAY_FS_WRITE_TARGET_ARG_KEY } from "../../../src/workflows/runtime/friday-workflow-fs-write-verifier.js";
 import type { FridaySqliteLayer } from "#state";
 
 import {
@@ -253,6 +257,180 @@ describe("Audit C part-2: workflow completion-verification run-level enforcement
       await settle(runtime, run.id);
     } finally {
       releaseGate();
+      db.close();
+    }
+  });
+});
+
+/**
+ * Audit C Stage 2A acceptance: a filesystem-WRITE run upgrades from
+ * `proof_pending` to `verified` end-to-end — a workflow node declares a binding
+ * write target, a faithful write-class skill ACTUALLY writes that file (a REAL
+ * fs delta), the runtime re-reads + checksums the declared target, the run-level
+ * completion becomes `verified`, and verifyClaim SUCCEEDS against it. The
+ * negative (skill writes nothing) stays `proof_pending` and verifyClaim is
+ * REFUSED with the distinct completion-unverified code — proving the upgrade is
+ * a real on-disk delta, never a label.
+ */
+describe("Audit C Stage 2A: filesystem-write evidence → verified, end-to-end through verifyClaim", () => {
+  let envEnable: string | undefined;
+  let envMode: string | undefined;
+  let workspaceDir: string;
+  let skillDir: string;
+
+  beforeEach(() => {
+    envEnable = process.env.FRIDAY_PIPELINE_ENABLE;
+    envMode = process.env.FRIDAY_PIPELINE_MODE;
+    process.env.FRIDAY_PIPELINE_ENABLE = "true";
+    process.env.FRIDAY_PIPELINE_MODE = "enforce";
+    workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), "s2a-e2e-ws-"));
+    skillDir = fs.mkdtempSync(path.join(os.tmpdir(), "s2a-e2e-skill-"));
+  });
+  afterEach(() => {
+    if (envEnable === undefined) delete process.env.FRIDAY_PIPELINE_ENABLE; else process.env.FRIDAY_PIPELINE_ENABLE = envEnable;
+    if (envMode === undefined) delete process.env.FRIDAY_PIPELINE_MODE; else process.env.FRIDAY_PIPELINE_MODE = envMode;
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(skillDir, { recursive: true, force: true });
+  });
+
+  // A faithful write-class skill manifest (read + write, scoped to out/, NO
+  // send/connect/capture/execute) — a valid fs-write verification candidate.
+  const WRITE_MANIFEST = {
+    permissions: {
+      grants: [
+        { resource: "filesystem", action: "read" },
+        { resource: "filesystem", action: "write", selectors: { pathPrefixes: ["${workspaceDir}/out"] } },
+      ],
+    },
+  };
+
+  function buildFsRuntime(db: FridaySqliteLayer, honest: boolean): FridayWorkflowRuntime {
+    return createFridayWorkflowRuntime({
+      db,
+      idGenerator: createTestIdGenerator(),
+      nowIso: () => NOW,
+      computeChecksum: (c) => createHash("sha256").update(c).digest("hex"),
+      workspaceDir,
+      resolveSkill: (skillId) =>
+        skillId === "fs-doc-writer" ? { id: skillId, skillDir, manifest: WRITE_MANIFEST } : null,
+      invokeSkill: async (_skillId, _runId, _nodeId, payload) => {
+        // The binding target reaches the skill as a LITERAL absolute path
+        // (it transits `resolveArgs` untouched — not `$`-prefixed).
+        const declared = String(payload[FRIDAY_FS_WRITE_TARGET_ARG_KEY] ?? "");
+        if (honest) {
+          // REAL fs delta: the skill actually writes the node-declared target.
+          fs.mkdirSync(path.dirname(declared), { recursive: true });
+          fs.writeFileSync(declared, JSON.stringify({ wrote: true }), "utf8");
+        }
+        // Untrusted output (echoing the changed path must NOT itself verify).
+        return { summary: "release docs updated", details: { changedPath: declared } };
+      },
+    });
+  }
+
+  function fsGraph(workflowId: string): FridayCompiledWorkflowGraphV2 {
+    return {
+      schemaVersion: "2.0",
+      workflowId,
+      workflowVersionId: "placeholder",
+      sourceSpecSchemaVersion: "1.0",
+      graph: {
+        nodes: [
+          { id: "trigger", type: "trigger", label: "Trigger", config: {} },
+          {
+            id: "fswrite",
+            type: "action",
+            label: "Write Doc",
+            // Binding target is an ABSOLUTE path (NOT `$`-prefixed) so it
+            // transits the node executor's `resolveArgs` untouched.
+            config: { skillId: "fs-doc-writer", args: { [FRIDAY_FS_WRITE_TARGET_ARG_KEY]: path.join(workspaceDir, "out", "RELEASE.md") } },
+          },
+        ],
+        edges: [{ id: "e1", sourceNodeId: "trigger", targetNodeId: "fswrite" }],
+      },
+      failurePolicy: { onFailure: "fail_fast", notifyUser: false },
+      tests: [],
+      checksum: "c-s2a-e2e",
+    };
+  }
+
+  function buildService(db: FridaySqliteLayer, runtime: FridayWorkflowRuntime) {
+    let nextId = 0;
+    return createFridayTaskWorkflowService({
+      db,
+      repository: createFridayTaskWorkflowRepository(),
+      idGenerator: () => {
+        nextId += 1;
+        return `tw-s2a-${String(nextId).padStart(6, "0")}`;
+      },
+      nowIso: () => NOW,
+      getWorkflowRunEvidenceStatus: (runId) => runtime.evidence.getRunEvidenceStatus(runId),
+      getWorkflowRunCompletionVerification: (runId) => runtime.evidence.getRunCompletionVerification(runId),
+    });
+  }
+
+  function verify(
+    service: ReturnType<typeof buildService>,
+    runId: string,
+    claimText: string,
+  ): { error: FridayDomainError | null; verifiedStatus?: string } {
+    const tw = service.create({
+      charter: "audit C Stage 2A fs-write verification",
+      taskKind: "general",
+      contextPackage: { allowedFiles: ["src/x.ts"], allowedTools: [], allowedApis: [], boundaryIds: ["api.task_workflows.core"] },
+    });
+    const claim = service.draftClaim(tw.id, { claimText, claimKind: "runtime_evidence" });
+    service.attachEvidenceRef(tw.id, claim.id, {
+      refKind: "workflow_run_evidence",
+      refId: runId,
+      refSource: "workflow_run_evidence",
+    });
+    try {
+      const verified = service.verifyClaim(tw.id, claim.id, { verifierVerdict: "fresh-read" });
+      return { error: null, verifiedStatus: verified.status };
+    } catch (error) {
+      return { error: error as FridayDomainError };
+    }
+  }
+
+  async function runFs(runtime: FridayWorkflowRuntime): Promise<string> {
+    const wf = runtime.crud.createWorkflow({ slug: `fs-${Math.random().toString(16).slice(2)}`, name: "fs" });
+    const v = runtime.crud.createVersion(wf.id, fsGraph(wf.id));
+    runtime.crud.publishVersion(wf.id, v.versionNumber);
+    const run = await runtime.execution.startRun({ workflowId: wf.id, workflowVersionId: v.id, triggerType: "manual" });
+    expect(await settle(runtime, run.id)).toBe("completed");
+    return run.id;
+  }
+
+  it("REAL fs delta: honest write → run completion verified → verifyClaim SUCCEEDS", async () => {
+    const db = createTestDb();
+    const runtime = buildFsRuntime(db, /* honest */ true);
+    const service = buildService(db, runtime);
+    try {
+      const runId = await runFs(runtime);
+      expect(runtime.evidence.getRunCompletionVerification(runId)).toBe("verified");
+      expect(fs.existsSync(path.join(workspaceDir, "out", "RELEASE.md"))).toBe(true);
+      const { error, verifiedStatus } = verify(service, runId, "claim backed by a real fs-write run");
+      expect(error).toBeNull();
+      expect(verifiedStatus).toBe("verified");
+    } finally {
+      db.close();
+    }
+  });
+
+  it("skill lies (writes nothing): run stays proof_pending → verifyClaim REFUSED (distinct code)", async () => {
+    const db = createTestDb();
+    const runtime = buildFsRuntime(db, /* honest */ false);
+    const service = buildService(db, runtime);
+    try {
+      const runId = await runFs(runtime);
+      expect(runtime.evidence.getRunCompletionVerification(runId)).toBe("proof_pending");
+      expect(fs.existsSync(path.join(workspaceDir, "out", "RELEASE.md"))).toBe(false);
+      const { error } = verify(service, runId, "claim backed by a skill that wrote nothing");
+      expect(error).toBeInstanceOf(FridayDomainError);
+      expect(error?.code).toBe("TASK_WORKFLOW_CLAIM_WORKFLOW_RUN_COMPLETION_UNVERIFIED");
+      expect(error?.code).not.toBe("TASK_WORKFLOW_CLAIM_WORKFLOW_RUN_EVIDENCE_UNAVAILABLE");
+    } finally {
       db.close();
     }
   });

--- a/test/unit/workflows/runtime/friday-workflow-fs-write-verifier.test.ts
+++ b/test/unit/workflows/runtime/friday-workflow-fs-write-verifier.test.ts
@@ -92,6 +92,42 @@ describe("audit C Stage 2A — resolveFilesystemWriteTarget (binding target)", (
     }
   });
 
+  it("refuses (null) when the node co-declares a NON-filesystem side-effecting grant (memory.write is UNWITNESSED)", () => {
+    // BLOCKER fix (whitelist, not blacklist): `write` is resource-overloaded. A
+    // `memory.write` is a separate durable side effect a runtime fs re-read cannot witness,
+    // so a `filesystem.write` + `memory.write` node is NOT an fs-write verification candidate
+    // — every side-effecting grant must be EXACTLY `filesystem.write`.
+    const node = actionNode({ skillId: "s", args: { [FRIDAY_FS_WRITE_TARGET_ARG_KEY]: "out/x.json" } });
+    const t = resolveFilesystemWriteTarget(
+      node,
+      skillResolver(
+        [
+          { resource: "filesystem", action: "write", selectors: { pathPrefixes: ["out"] } },
+          { resource: "memory", action: "write" },
+        ],
+        SKILL_DIR,
+      ),
+    );
+    expect(t).toBeNull();
+  });
+
+  it("still returns a target when co-declared grants are READ-ONLY (read/receive do NOT disqualify)", () => {
+    const node = actionNode({ skillId: "s", args: { [FRIDAY_FS_WRITE_TARGET_ARG_KEY]: "out/x.json" } });
+    const t = resolveFilesystemWriteTarget(
+      node,
+      skillResolver(
+        [
+          { resource: "filesystem", action: "read" },
+          { resource: "memory", action: "read" },
+          { resource: "network", action: "receive" },
+          { resource: "filesystem", action: "write", selectors: { pathPrefixes: ["out"] } },
+        ],
+        SKILL_DIR,
+      ),
+    );
+    expect(t).not.toBeNull();
+  });
+
   it("is inert (null) for a write node with no binding target (no reserved key, multiple/glob prefixes)", () => {
     const node = actionNode({ skillId: "s" });
     // glob prefix → not concrete; and no reserved key → no binding target.
@@ -211,6 +247,23 @@ describe("audit C Stage 2A — snapshotTarget + verifyFsWriteEvidence (real fs d
     );
     expect(outcome.verified).toBe(false);
     expect((outcome as { reason: string }).reason).toBe("target-missing-post-exec");
+  });
+
+  it("refuses: target EXISTED but was UNREADABLE at snapshot (no provable content delta) → proof_pending", () => {
+    // LOW-nit fix: an existing-but-unreadable file (existed=true, checksum=null) must NOT be
+    // treated as newly-created — a mere permission/readability flip is not write evidence.
+    fs.mkdirSync(path.join(workspaceDir, "out"), { recursive: true });
+    const abs = path.join(workspaceDir, "out", "report.json");
+    fs.writeFileSync(abs, "preexisting", "utf8");
+    const t = target("${workspaceDir}/out/report.json", ["${workspaceDir}/out"]);
+    // Simulate "existed but unreadable at snapshot": existed=true, checksum=null.
+    const snap = { canonicalPath: abs, existed: true, checksum: null as string | null };
+    const outcome = verifyFsWriteEvidence(
+      { target: t, snapshot: snap, evidenceExportRootDir: evidenceRoot, workspaceDir, returnedArtifactUris: [] },
+      { computeChecksum: checksum },
+    );
+    expect(outcome.verified).toBe(false);
+    expect((outcome as { reason: string }).reason).toBe("target-existed-unreadable-pre-exec");
   });
 
   it("refuses: unchanged checksum (file existed, not modified) → proof_pending", () => {

--- a/test/unit/workflows/runtime/friday-workflow-fs-write-verifier.test.ts
+++ b/test/unit/workflows/runtime/friday-workflow-fs-write-verifier.test.ts
@@ -1,0 +1,308 @@
+import { createHash } from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  FRIDAY_FS_WRITE_TARGET_ARG_KEY,
+  resolveFilesystemWriteTarget,
+  snapshotTarget,
+  verifyFsWriteEvidence,
+} from "../../../../src/workflows/runtime/friday-workflow-fs-write-verifier.js";
+import type { FridayWorkflowNode } from "../../../../src/workflows/model/friday-workflow-graph.types.js";
+
+// Audit C Stage 2A: the filesystem-write verifier upgrades a side-effect node
+// to `verified` ONLY on a real, in-scope, non-self-receipt, non-mirror on-disk
+// state delta. Every other case (skill lied / no file / unchanged / out of
+// scope / self-receipt / evidence-mirror / co-declared send-class) refuses.
+
+const checksum = (content: string): string => createHash("sha256").update(content).digest("hex");
+
+function actionNode(
+  config: Record<string, unknown>,
+): Pick<FridayWorkflowNode, "type" | "config"> {
+  return { type: "action", config } as Pick<FridayWorkflowNode, "type" | "config">;
+}
+
+/** A resolveSkill stub returning a skill with the given grants + skillDir. */
+function skillResolver(
+  grants: Array<{ resource?: string; action: string; selectors?: { pathPrefixes?: string[] } }>,
+  skillDir: string,
+): (skillId: string) => unknown {
+  return () => ({ id: "s", skillDir, manifest: { permissions: { grants } } });
+}
+
+describe("audit C Stage 2A — binding-target convention", () => {
+  it("the reserved arg key is the documented literal, and is NOT `$`-prefixed (so it is never mistaken for a workflow expression)", () => {
+    // The convention: a reserved `node.config.args.__fridayWriteTarget` key whose
+    // value is an ABSOLUTE or WORKSPACE-RELATIVE path (never `$`-prefixed) — so it
+    // transits the node executor's `resolveArgs` (which evaluates `$`-prefixed
+    // strings) UNTOUCHED, with no change to that shared resolver.
+    expect(FRIDAY_FS_WRITE_TARGET_ARG_KEY).toBe("__fridayWriteTarget");
+    expect(FRIDAY_FS_WRITE_TARGET_ARG_KEY.startsWith("$")).toBe(false);
+  });
+});
+
+describe("audit C Stage 2A — resolveFilesystemWriteTarget (binding target)", () => {
+  const SKILL_DIR = "/tmp/fake-skill-dir";
+
+  it("returns a target for a pure write-class node with the reserved config.args key", () => {
+    const node = actionNode({
+      skillId: "s",
+      args: { [FRIDAY_FS_WRITE_TARGET_ARG_KEY]: "out/report.json" },
+    });
+    const t = resolveFilesystemWriteTarget(
+      node,
+      skillResolver(
+        [{ resource: "filesystem", action: "read" }, { resource: "filesystem", action: "write", selectors: { pathPrefixes: ["out"] } }],
+        SKILL_DIR,
+      ),
+    );
+    expect(t).not.toBeNull();
+    expect(t?.declaredTarget).toBe("out/report.json");
+    expect(t?.skillDir).toBe(SKILL_DIR);
+    expect(t?.writePathPrefixes).toEqual(["out"]);
+  });
+
+  it("returns a target from a single concrete manifest pathPrefix when no reserved key", () => {
+    const node = actionNode({ skillId: "s" });
+    const t = resolveFilesystemWriteTarget(
+      node,
+      skillResolver(
+        [{ resource: "filesystem", action: "write", selectors: { pathPrefixes: ["out/report.json"] } }],
+        SKILL_DIR,
+      ),
+    );
+    expect(t?.declaredTarget).toBe("out/report.json");
+  });
+
+  it("refuses (null) when the node co-declares a send/connect/capture/execute grant", () => {
+    for (const dis of ["send", "connect", "capture", "execute"]) {
+      const node = actionNode({ skillId: "s", args: { [FRIDAY_FS_WRITE_TARGET_ARG_KEY]: "out/x.json" } });
+      const t = resolveFilesystemWriteTarget(
+        node,
+        skillResolver(
+          [{ resource: "filesystem", action: "write", selectors: { pathPrefixes: ["out"] } }, { action: dis }],
+          SKILL_DIR,
+        ),
+      );
+      expect(t).toBeNull();
+    }
+  });
+
+  it("is inert (null) for a write node with no binding target (no reserved key, multiple/glob prefixes)", () => {
+    const node = actionNode({ skillId: "s" });
+    // glob prefix → not concrete; and no reserved key → no binding target.
+    const t = resolveFilesystemWriteTarget(
+      node,
+      skillResolver([{ resource: "filesystem", action: "write", selectors: { pathPrefixes: ["out/*"] } }], SKILL_DIR),
+    );
+    expect(t).toBeNull();
+  });
+
+  it("is null for non-write nodes and non-action nodes", () => {
+    expect(
+      resolveFilesystemWriteTarget(actionNode({ skillId: "s" }), skillResolver([{ action: "read" }], SKILL_DIR)),
+    ).toBeNull();
+    expect(
+      resolveFilesystemWriteTarget(
+        { type: "data", config: {} } as Pick<FridayWorkflowNode, "type" | "config">,
+        skillResolver([{ action: "write" }], SKILL_DIR),
+      ),
+    ).toBeNull();
+  });
+
+  it("is null when the skill is unresolvable or has no skillDir", () => {
+    expect(resolveFilesystemWriteTarget(actionNode({ skillId: "s" }), () => null)).toBeNull();
+    // no skillDir on the resolved skill → cannot anchor scope → null
+    const node = actionNode({ skillId: "s", args: { [FRIDAY_FS_WRITE_TARGET_ARG_KEY]: "out/x.json" } });
+    const resolver = () => ({ id: "s", manifest: { permissions: { grants: [{ action: "write" }] } } });
+    expect(resolveFilesystemWriteTarget(node, resolver)).toBeNull();
+  });
+});
+
+describe("audit C Stage 2A — snapshotTarget + verifyFsWriteEvidence (real fs delta)", () => {
+  let workspaceDir: string;
+  let skillDir: string;
+  let evidenceRoot: string;
+
+  beforeEach(() => {
+    workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), "fs-verify-ws-"));
+    skillDir = fs.mkdtempSync(path.join(os.tmpdir(), "fs-verify-skill-"));
+    // The evidence-export mirror lives under the workspace.
+    evidenceRoot = path.join(workspaceDir, ".friday", "artifacts", "workflow-evidence");
+    fs.mkdirSync(evidenceRoot, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(skillDir, { recursive: true, force: true });
+  });
+
+  function target(declaredTarget: string, pathPrefixes: string[]) {
+    return { skillId: "s", skillDir, declaredTarget, targetSource: "node-arg" as const, writePathPrefixes: pathPrefixes };
+  }
+
+  it("verifies a newly-created in-scope file (real fs delta → verified)", () => {
+    const declared = "${workspaceDir}/out/report.json";
+    const t = target(declared, ["${workspaceDir}/out"]);
+    const snap = snapshotTarget(t, workspaceDir, { computeChecksum: checksum });
+    expect(snap.checksum).toBeNull(); // does not exist yet
+
+    // The "skill" actually writes the declared target.
+    fs.mkdirSync(path.join(workspaceDir, "out"), { recursive: true });
+    fs.writeFileSync(snap.canonicalPath, JSON.stringify({ ok: true }), "utf8");
+
+    const outcome = verifyFsWriteEvidence(
+      { target: t, snapshot: snap, evidenceExportRootDir: evidenceRoot, workspaceDir, returnedArtifactUris: [] },
+      { computeChecksum: checksum },
+    );
+    expect(outcome).toEqual({ verified: true });
+  });
+
+  it("manifest-prefix bare-relative target anchors on the SKILL dir (matches validateFridayFilesystemScope)", () => {
+    // A `manifest-prefix`-sourced bare-relative target resolves against skillDir;
+    // the manifest scope is the same bare-relative prefix, so it is in-scope.
+    const t = {
+      skillId: "s",
+      skillDir,
+      declaredTarget: "out/report.json",
+      targetSource: "manifest-prefix" as const,
+      writePathPrefixes: ["out/report.json"],
+    };
+    const snap = snapshotTarget(t, workspaceDir, { computeChecksum: checksum });
+    // Resolves under the SKILL dir, not the workspace (pre-creation the path is
+    // not yet canonicalized, so compare the resolved-but-uncanonicalized forms).
+    expect(snap.canonicalPath).toBe(path.resolve(skillDir, "out", "report.json"));
+    expect(snap.canonicalPath.startsWith(path.resolve(workspaceDir))).toBe(false);
+    fs.mkdirSync(path.join(skillDir, "out"), { recursive: true });
+    fs.writeFileSync(snap.canonicalPath, "x", "utf8");
+    const outcome = verifyFsWriteEvidence(
+      { target: t, snapshot: snap, evidenceExportRootDir: evidenceRoot, workspaceDir, returnedArtifactUris: [] },
+      { computeChecksum: checksum },
+    );
+    expect(outcome).toEqual({ verified: true });
+  });
+
+  it("verifies a changed-content in-scope file", () => {
+    fs.mkdirSync(path.join(workspaceDir, "out"), { recursive: true });
+    const abs = path.join(workspaceDir, "out", "report.json");
+    fs.writeFileSync(abs, "v1", "utf8");
+    const t = target("${workspaceDir}/out/report.json", ["${workspaceDir}/out"]);
+    const snap = snapshotTarget(t, workspaceDir, { computeChecksum: checksum });
+    expect(snap.checksum).not.toBeNull();
+    fs.writeFileSync(abs, "v2-changed", "utf8");
+    const outcome = verifyFsWriteEvidence(
+      { target: t, snapshot: snap, evidenceExportRootDir: evidenceRoot, workspaceDir, returnedArtifactUris: [] },
+      { computeChecksum: checksum },
+    );
+    expect(outcome).toEqual({ verified: true });
+  });
+
+  it("refuses: skill lied / wrote nothing (target missing post-exec) → proof_pending", () => {
+    const t = target("${workspaceDir}/out/report.json", ["${workspaceDir}/out"]);
+    const snap = snapshotTarget(t, workspaceDir, { computeChecksum: checksum });
+    // No file written.
+    const outcome = verifyFsWriteEvidence(
+      { target: t, snapshot: snap, evidenceExportRootDir: evidenceRoot, workspaceDir, returnedArtifactUris: [] },
+      { computeChecksum: checksum },
+    );
+    expect(outcome.verified).toBe(false);
+    expect((outcome as { reason: string }).reason).toBe("target-missing-post-exec");
+  });
+
+  it("refuses: unchanged checksum (file existed, not modified) → proof_pending", () => {
+    fs.mkdirSync(path.join(workspaceDir, "out"), { recursive: true });
+    const abs = path.join(workspaceDir, "out", "report.json");
+    fs.writeFileSync(abs, "same", "utf8");
+    const t = target("${workspaceDir}/out/report.json", ["${workspaceDir}/out"]);
+    const snap = snapshotTarget(t, workspaceDir, { computeChecksum: checksum });
+    // No change.
+    const outcome = verifyFsWriteEvidence(
+      { target: t, snapshot: snap, evidenceExportRootDir: evidenceRoot, workspaceDir, returnedArtifactUris: [] },
+      { computeChecksum: checksum },
+    );
+    expect((outcome as { reason: string }).reason).toBe("target-unchanged");
+  });
+
+  it("refuses: out-of-scope target (outside declared pathPrefixes) → proof_pending", () => {
+    const declared = "${workspaceDir}/escape/report.json";
+    const t = target(declared, ["${workspaceDir}/out"]); // declared write scope is out/, target is escape/
+    const snap = snapshotTarget(t, workspaceDir, { computeChecksum: checksum });
+    fs.mkdirSync(path.join(workspaceDir, "escape"), { recursive: true });
+    fs.writeFileSync(snap.canonicalPath, "x", "utf8");
+    const outcome = verifyFsWriteEvidence(
+      { target: t, snapshot: snap, evidenceExportRootDir: evidenceRoot, workspaceDir, returnedArtifactUris: [] },
+      { computeChecksum: checksum },
+    );
+    expect((outcome as { reason: string }).reason).toBe("target-out-of-scope");
+  });
+
+  it("refuses: target == a skill-returned artifact URI (self-receipt / circular) → proof_pending", () => {
+    fs.mkdirSync(path.join(workspaceDir, "out"), { recursive: true });
+    const declared = "${workspaceDir}/out/receipt.json";
+    const t = target(declared, ["${workspaceDir}/out"]);
+    const snap = snapshotTarget(t, workspaceDir, { computeChecksum: checksum });
+    fs.writeFileSync(snap.canonicalPath, "receipt", "utf8");
+    const outcome = verifyFsWriteEvidence(
+      {
+        target: t,
+        snapshot: snap,
+        evidenceExportRootDir: evidenceRoot,
+        workspaceDir,
+        // The skill returned the SAME path as its own artifact.
+        returnedArtifactUris: [snap.canonicalPath],
+      },
+      { computeChecksum: checksum },
+    );
+    expect((outcome as { reason: string }).reason).toBe("target-equals-returned-artifact");
+  });
+
+  it("refuses: target == a file:// returned artifact URI (normalized) → proof_pending", () => {
+    fs.mkdirSync(path.join(workspaceDir, "out"), { recursive: true });
+    const t = target("${workspaceDir}/out/receipt.json", ["${workspaceDir}/out"]);
+    const snap = snapshotTarget(t, workspaceDir, { computeChecksum: checksum });
+    fs.writeFileSync(snap.canonicalPath, "receipt", "utf8");
+    const outcome = verifyFsWriteEvidence(
+      {
+        target: t,
+        snapshot: snap,
+        evidenceExportRootDir: evidenceRoot,
+        workspaceDir,
+        returnedArtifactUris: [`file://${snap.canonicalPath}`],
+      },
+      { computeChecksum: checksum },
+    );
+    expect((outcome as { reason: string }).reason).toBe("target-equals-returned-artifact");
+  });
+
+  it("refuses: target under the evidence-export root (mirror / circular proof) → proof_pending", () => {
+    // Declared target is inside the evidence-export mirror dir. Scope is the
+    // mirror dir so the scope check would pass — only the mirror guard refuses.
+    const declared = path.join(evidenceRoot, "run-1", "evidence.json");
+    const t = target(declared, [evidenceRoot]);
+    const snap = snapshotTarget(t, workspaceDir, { computeChecksum: checksum });
+    fs.mkdirSync(path.dirname(snap.canonicalPath), { recursive: true });
+    fs.writeFileSync(snap.canonicalPath, "mirror", "utf8");
+    const outcome = verifyFsWriteEvidence(
+      { target: t, snapshot: snap, evidenceExportRootDir: evidenceRoot, workspaceDir, returnedArtifactUris: [] },
+      { computeChecksum: checksum },
+    );
+    expect((outcome as { reason: string }).reason).toBe("target-under-evidence-export-root");
+  });
+
+  it("refuses: no declared write scope (fail-closed) → proof_pending", () => {
+    const declared = "${workspaceDir}/out/report.json";
+    const t = target(declared, []); // no pathPrefixes
+    const snap = snapshotTarget(t, workspaceDir, { computeChecksum: checksum });
+    fs.mkdirSync(path.join(workspaceDir, "out"), { recursive: true });
+    fs.writeFileSync(snap.canonicalPath, "x", "utf8");
+    const outcome = verifyFsWriteEvidence(
+      { target: t, snapshot: snap, evidenceExportRootDir: evidenceRoot, workspaceDir, returnedArtifactUris: [] },
+      { computeChecksum: checksum },
+    );
+    expect((outcome as { reason: string }).reason).toBe("no-declared-write-scope");
+  });
+});

--- a/test/unit/workflows/runtime/friday-workflow-node-acceptance.test.ts
+++ b/test/unit/workflows/runtime/friday-workflow-node-acceptance.test.ts
@@ -4,6 +4,10 @@ import {
   resolveNodeCompletionVerification,
   isVerifiedCompletion,
 } from "../../../../src/workflows/runtime/friday-workflow-node-acceptance.js";
+import {
+  FRIDAY_FS_WRITE_TARGET_ARG_KEY,
+  resolveFilesystemWriteTarget,
+} from "../../../../src/workflows/runtime/friday-workflow-fs-write-verifier.js";
 import type { FridayWorkflowNode } from "../../../../src/workflows/model/friday-workflow-graph.types.js";
 
 // Audit C Stage 1: a side-effect node without deterministic evidence must be
@@ -76,5 +80,37 @@ describe("workflow node acceptance classifier (audit C)", () => {
     const n = node("action", { skillId: "s1" });
     const cls = classifyWorkflowNodeSideEffect(n, skillWith(["write"]));
     expect(resolveNodeCompletionVerification(n, cls, /* hasDeterministicEvidence */ true)).toBe("verified");
+  });
+});
+
+// Audit C Stage 2A: the fs-write candidate gate is a NARROWER subset of the
+// Stage 1 side-effect class — a write node co-declaring send/connect/capture/
+// execute is still side_effect (proof_pending) but is NOT an fs-write
+// verification candidate, so it can never be upgraded to verified.
+describe("audit C Stage 2A — fs-write candidate gate vs the Stage 1 classifier", () => {
+  const writeSkill = (extraActions: string[] = []) => () => ({
+    id: "s",
+    skillDir: "/tmp/skill",
+    manifest: {
+      permissions: {
+        grants: [
+          { resource: "filesystem", action: "read" },
+          { resource: "filesystem", action: "write", selectors: { pathPrefixes: ["out"] } },
+          ...extraActions.map((a) => ({ action: a })),
+        ],
+      },
+    },
+  });
+
+  it("pure write-class node with a binding target IS a candidate (verified-eligible)", () => {
+    const n = node("action", { skillId: "s", args: { [FRIDAY_FS_WRITE_TARGET_ARG_KEY]: "out/x.json" } });
+    expect(classifyWorkflowNodeSideEffect(n, writeSkill())).toBe("side_effect");
+    expect(resolveFilesystemWriteTarget(n, writeSkill())).not.toBeNull();
+  });
+
+  it("write+send node stays side_effect but is NOT a candidate (never verified)", () => {
+    const n = node("action", { skillId: "s", args: { [FRIDAY_FS_WRITE_TARGET_ARG_KEY]: "out/x.json" } });
+    expect(classifyWorkflowNodeSideEffect(n, writeSkill(["send"]))).toBe("side_effect");
+    expect(resolveFilesystemWriteTarget(n, writeSkill(["send"]))).toBeNull();
   });
 });

--- a/test/unit/workflows/runtime/friday-workflow-runtime.test.ts
+++ b/test/unit/workflows/runtime/friday-workflow-runtime.test.ts
@@ -1,4 +1,7 @@
 import { createHash } from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -9,6 +12,7 @@ import {
   type FridayWorkflowRunEvidenceStatus,
   type FridayWorkflowRuntime,
 } from "#workflows";
+import { FRIDAY_FS_WRITE_TARGET_ARG_KEY } from "../../../../src/workflows/runtime/friday-workflow-fs-write-verifier.js";
 import type { FridaySqliteLayer } from "#state";
 
 import { createTestDb, createTestIdGenerator } from "../../../helpers/friday-test-db.helper.js";
@@ -277,5 +281,236 @@ describe("Phase 14.5C module_28c — workflow runtime fail-closed evidence", () 
     );
     expect(error.code).toBe("WORKFLOW_EVIDENCE_UNAVAILABLE");
     expect(error.httpStatus).toBe(503);
+  });
+});
+
+// ─── Audit C Stage 2A: filesystem-write evidence → verified (real fs delta) ───
+
+/**
+ * End-to-end through the REAL runtime (no mock of the verifier): a workflow node
+ * declares a binding write target; a faithful write-class skill fixture ACTUALLY
+ * writes that file; the runtime re-reads + checksums the declared target and
+ * upgrades the node's deferred `proof_pending` to `verified`, which flows to the
+ * run-level `getRunCompletionVerification`. Negative cases prove the run stays
+ * `proof_pending` whenever a genuine, in-scope, non-self-receipt fs delta is
+ * absent.
+ */
+describe("audit C Stage 2A — runtime fs-write verification (real fs delta → verified)", () => {
+  let envEnable: string | undefined;
+  let envMode: string | undefined;
+  let workspaceDir: string;
+  let skillDir: string;
+
+  beforeEach(() => {
+    envEnable = process.env.FRIDAY_PIPELINE_ENABLE;
+    envMode = process.env.FRIDAY_PIPELINE_MODE;
+    process.env.FRIDAY_PIPELINE_ENABLE = "true";
+    process.env.FRIDAY_PIPELINE_MODE = "enforce";
+    workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), "s2a-rt-ws-"));
+    skillDir = fs.mkdtempSync(path.join(os.tmpdir(), "s2a-rt-skill-"));
+  });
+  afterEach(() => {
+    if (envEnable === undefined) delete process.env.FRIDAY_PIPELINE_ENABLE; else process.env.FRIDAY_PIPELINE_ENABLE = envEnable;
+    if (envMode === undefined) delete process.env.FRIDAY_PIPELINE_MODE; else process.env.FRIDAY_PIPELINE_MODE = envMode;
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(skillDir, { recursive: true, force: true });
+  });
+
+  // A faithful write-class skill manifest: read + write, scoped to `out` under
+  // the workspace, NO send/connect/capture/execute (a valid fs-write candidate).
+  const writeManifest = (extraActions: string[] = []) => ({
+    permissions: {
+      grants: [
+        { resource: "filesystem", action: "read" },
+        { resource: "filesystem", action: "write", selectors: { pathPrefixes: ["${workspaceDir}/out"] } },
+        ...extraActions.map((a) => ({ action: a })),
+      ],
+    },
+  });
+
+  type SkillSpec = {
+    manifest: ReturnType<typeof writeManifest>;
+    /** What the invocation actually does — controls the real fs delta. */
+    behavior:
+      | { kind: "write-target" } // honestly writes the declared target file
+      | { kind: "lie" } // returns a receipt but writes NOTHING
+      | { kind: "write-elsewhere"; rel: string } // writes a DIFFERENT file
+      | { kind: "self-receipt" }; // writes the target AND returns it as its own artifact uri
+  };
+
+  function buildRuntime(specs: Record<string, SkillSpec>): FridayWorkflowRuntime {
+    return createFridayWorkflowRuntime({
+      db: createTestDb(),
+      idGenerator: createTestIdGenerator(),
+      nowIso: () => NOW,
+      computeChecksum: (c) => createHash("sha256").update(c).digest("hex"),
+      workspaceDir,
+      resolveSkill: (skillId) =>
+        specs[skillId] ? { id: skillId, skillDir, manifest: specs[skillId]!.manifest } : null,
+      invokeSkill: async (skillId, _runId, _nodeId, payload) => {
+        const spec = specs[skillId];
+        if (!spec) return { ok: true };
+        // The binding target reaches the skill as a LITERAL absolute path (it
+        // transits the node executor's `resolveArgs` untouched — it is not
+        // `$`-prefixed). The skill resolves its own write location from it.
+        const declared = String(payload[FRIDAY_FS_WRITE_TARGET_ARG_KEY] ?? "");
+        const resolveDeclared = (d: string) => (path.isAbsolute(d) ? d : path.join(workspaceDir, d));
+        switch (spec.behavior.kind) {
+          case "write-target": {
+            const abs = resolveDeclared(declared);
+            fs.mkdirSync(path.dirname(abs), { recursive: true });
+            fs.writeFileSync(abs, JSON.stringify({ wrote: true, at: NOW }), "utf8");
+            return { summary: "wrote managed doc", details: { changedPath: declared } };
+          }
+          case "lie":
+            // Returns a plausible receipt but writes NOTHING.
+            return { summary: "wrote managed doc", details: { changedPath: declared, runPath: path.join(workspaceDir, "out", "receipt.json") } };
+          case "write-elsewhere": {
+            const abs = resolveDeclared(spec.behavior.rel);
+            fs.mkdirSync(path.dirname(abs), { recursive: true });
+            fs.writeFileSync(abs, "elsewhere", "utf8");
+            return { summary: "wrote elsewhere" };
+          }
+          case "self-receipt": {
+            const abs = resolveDeclared(declared);
+            fs.mkdirSync(path.dirname(abs), { recursive: true });
+            fs.writeFileSync(abs, JSON.stringify({ receipt: true }), "utf8");
+            // The skill RETURNS the declared target as its own artifact — circular.
+            return { summary: "wrote receipt", details: { runPath: abs } };
+          }
+        }
+      },
+    });
+  }
+
+  function graph(
+    workflowId: string,
+    nodes: Array<{ id: string; skillId: string; target?: string }>,
+  ): FridayCompiledWorkflowGraphV2 {
+    const actionNodes = nodes.map((n) => ({
+      id: n.id,
+      type: "action" as const,
+      label: n.id,
+      config: { skillId: n.skillId, args: n.target ? { [FRIDAY_FS_WRITE_TARGET_ARG_KEY]: n.target } : {} },
+    }));
+    const edges = actionNodes.map((n, i) => ({
+      id: `e${i}`,
+      sourceNodeId: i === 0 ? "trigger" : actionNodes[i - 1]!.id,
+      targetNodeId: n.id,
+    }));
+    return {
+      schemaVersion: "2.0",
+      workflowId,
+      workflowVersionId: "placeholder",
+      sourceSpecSchemaVersion: "1.0",
+      graph: {
+        nodes: [{ id: "trigger", type: "trigger", label: "Trigger", config: {} }, ...actionNodes],
+        edges,
+      },
+      failurePolicy: { onFailure: "fail_fast", notifyUser: false },
+      tests: [],
+      checksum: "s2a-rt",
+    };
+  }
+
+  async function runAndGetVerification(
+    runtime: FridayWorkflowRuntime,
+    nodes: Array<{ id: string; skillId: string; target?: string }>,
+  ): Promise<{ status: string; verification: string; runId: string }> {
+    const wf = runtime.crud.createWorkflow({ slug: `s2a-${Math.random().toString(16).slice(2)}`, name: "s2a" });
+    const v = runtime.crud.createVersion(wf.id, graph(wf.id, nodes));
+    runtime.crud.publishVersion(wf.id, v.versionNumber);
+    const run = await runtime.execution.startRun({ workflowId: wf.id, workflowVersionId: v.id, triggerType: "manual" });
+    const status = await waitForRunSettled(runtime, run.id);
+    return { status, verification: runtime.evidence.getRunCompletionVerification(run.id), runId: run.id };
+  }
+
+  it("POSITIVE: skill honestly writes the declared target → run completion verified", async () => {
+    const runtime = buildRuntime({ "doc-writer": { manifest: writeManifest(), behavior: { kind: "write-target" } } });
+    const r = await runAndGetVerification(runtime, [
+      { id: "act", skillId: "doc-writer", target: path.join(workspaceDir, "out", "report.json") },
+    ]);
+    expect(r.status).toBe("completed");
+    expect(r.verification).toBe("verified");
+    // Real fs delta really happened.
+    expect(fs.existsSync(path.join(workspaceDir, "out", "report.json"))).toBe(true);
+  });
+
+  it("NEGATIVE: skill lies (writes nothing) → proof_pending", async () => {
+    const runtime = buildRuntime({ "doc-writer": { manifest: writeManifest(), behavior: { kind: "lie" } } });
+    const r = await runAndGetVerification(runtime, [
+      { id: "act", skillId: "doc-writer", target: path.join(workspaceDir, "out", "report.json") },
+    ]);
+    expect(r.status).toBe("completed");
+    expect(r.verification).toBe("proof_pending");
+    expect(fs.existsSync(path.join(workspaceDir, "out", "report.json"))).toBe(false);
+  });
+
+  it("NEGATIVE: skill writes a DIFFERENT file than the declared target → proof_pending", async () => {
+    const runtime = buildRuntime({
+      "doc-writer": { manifest: writeManifest(), behavior: { kind: "write-elsewhere", rel: path.join(workspaceDir, "out", "other.json") } },
+    });
+    const r = await runAndGetVerification(runtime, [
+      { id: "act", skillId: "doc-writer", target: path.join(workspaceDir, "out", "report.json") },
+    ]);
+    expect(r.verification).toBe("proof_pending");
+  });
+
+  it("REFUSE: out-of-scope declared target (outside the manifest write scope) → proof_pending", async () => {
+    const runtime = buildRuntime({ "doc-writer": { manifest: writeManifest(), behavior: { kind: "write-target" } } });
+    const r = await runAndGetVerification(runtime, [
+      // Target is under `escape/`, NOT the declared `out/` write scope.
+      { id: "act", skillId: "doc-writer", target: path.join(workspaceDir, "escape", "report.json") },
+    ]);
+    expect(r.verification).toBe("proof_pending");
+  });
+
+  it("REFUSE: skill self-receipt (target == returned artifact uri) → proof_pending", async () => {
+    const runtime = buildRuntime({ "doc-writer": { manifest: writeManifest(), behavior: { kind: "self-receipt" } } });
+    const r = await runAndGetVerification(runtime, [
+      { id: "act", skillId: "doc-writer", target: path.join(workspaceDir, "out", "report.json") },
+    ]);
+    expect(r.verification).toBe("proof_pending");
+  });
+
+  it("NOT A CANDIDATE: write+send skill stays proof_pending (never verified)", async () => {
+    const runtime = buildRuntime({
+      "doc-sender": { manifest: writeManifest(["send"]), behavior: { kind: "write-target" } },
+    });
+    const r = await runAndGetVerification(runtime, [
+      { id: "act", skillId: "doc-sender", target: path.join(workspaceDir, "out", "report.json") },
+    ]);
+    expect(r.verification).toBe("proof_pending");
+  });
+
+  it("INERT: write skill with no declared binding target stays proof_pending", async () => {
+    const runtime = buildRuntime({ "doc-writer": { manifest: writeManifest(), behavior: { kind: "write-target" } } });
+    const r = await runAndGetVerification(runtime, [{ id: "act", skillId: "doc-writer" }]);
+    expect(r.verification).toBe("proof_pending");
+  });
+
+  it("MIXED RUN: verified fs-write + a send-class node → run aggregate proof_pending (worst-wins)", async () => {
+    const runtime = buildRuntime({
+      "doc-writer": { manifest: writeManifest(), behavior: { kind: "write-target" } },
+      "sender": { manifest: { permissions: { grants: [{ action: "send" }] } } as ReturnType<typeof writeManifest>, behavior: { kind: "lie" } },
+    });
+    const r = await runAndGetVerification(runtime, [
+      { id: "fswrite", skillId: "doc-writer", target: path.join(workspaceDir, "out", "report.json") },
+      { id: "send", skillId: "sender" },
+    ]);
+    expect(r.status).toBe("completed");
+    expect(r.verification).toBe("proof_pending");
+    // The fs-write itself really happened — the run is only proof_pending
+    // because of the co-resident send node (worst-wins), not the fs node.
+    expect(fs.existsSync(path.join(workspaceDir, "out", "report.json"))).toBe(true);
+  });
+
+  it("!pipelineEnabled: an fs-write candidate run is proof_pending (legacy path, no re-read)", async () => {
+    process.env.FRIDAY_PIPELINE_ENABLE = "false";
+    const runtime = buildRuntime({ "doc-writer": { manifest: writeManifest(), behavior: { kind: "write-target" } } });
+    const r = await runAndGetVerification(runtime, [
+      { id: "act", skillId: "doc-writer", target: path.join(workspaceDir, "out", "report.json") },
+    ]);
+    expect(r.verification).toBe("proof_pending");
   });
 });


### PR DESCRIPTION
## What
Audit-C **Stage 2A**, built on #398 (Stage 1 labeling + 2B durable persistence). Closes the first concrete side-effect class — a bounded **filesystem write** can now upgrade `proof_pending → verified`, but ONLY after the runtime **independently re-reads the node's declared write target** and proves an on-disk state delta.

## Mechanism (minimal, no broad change)
- NEW `friday-workflow-fs-write-verifier.ts`:
  - `resolveFilesystemWriteTarget` — candidate ONLY when grants are write-class with **NO** send/connect/capture/execute AND a binding target resolves.
  - `snapshotTarget` (pre-exec checksum) + `verifyFsWriteEvidence` (post-exec): exists + (changed OR newly-created) + **within declared `pathPrefixes` scope** + **NOT under `evidenceExportRootDir`** (no evidence-mirror/circular) + **NOT equal to a skill-returned artifact URI** (no self-receipt). Fail-closed: no declared scope → refuse.
- **Binding-target convention (minimal):** reserved `node.config.args` key `__fridayWriteTarget` — node-definition-sourced, non-`$`-prefixed path, bounded by the manifest's `pathPrefixes`. **No** skill-adapter / `invokeSkill` / `FridaySkillExecuteResult` / schema change.
- `friday-workflow-runtime.ts`: `workspaceDir` dep; `collectReturnedArtifactPaths` (formal `artifacts[].uri` + receipt-named keys only); **defer-and-record-once** for the fs-write candidate (the record fn is monotonic-downward + run-level + computed pre-exec, so a post-exec `verified` would be a no-op — the candidate's up-front record is deferred and recorded once after verify). All other nodes keep up-front record. catch / `!pipelineEnabled` → `proof_pending`.

## Honest scope / limitation
- send/connect/capture/execute stay `proof_pending` (never claimed verified).
- **The convention is INERT on current production write-class skills** — they self-pick their own `.friday/...` paths, so they remain `proof_pending`. Wiring a production skill to honor a node-bound target is a per-skill follow-on (not done here, to avoid a broad skill change — see PR discussion).
- The end-to-end proof uses a **faithful write-class skill fixture** that genuinely writes the declared file: real fs delta through the real runtime → `verified`; skill-lies / wrong-file / unchanged → `proof_pending`.

## Verification
- 913 (workflows + task-workflows) + 17 (new verifier unit) + 2 (e2e) green; typecheck + `diff --check` clean; no new secret findings.
- Negatives proven: skill-lies/no-file/unchanged → proof_pending; out-of-scope / self-receipt / returned-artifact==target / evidence-export-mirror → refuse; write+send not-a-candidate; mixed-run → run aggregate proof_pending (worst-wins); `!pipelineEnabled` → proof_pending.