### PR TITLE
fix(providers): mark unpriced models in usage ledger so silent cost_usd=0 is not mistaken for free (D)

### DIFF
--- a/src/providers/services/friday-provider-service.ts
+++ b/src/providers/services/friday-provider-service.ts
@@ -3453,6 +3453,21 @@ export function createFridayProviderService(
             + "recording providerKind=\"unknown\" (no provider attribution).",
         );
       }
+      // D (ledger truth): record whether pricing was actually RESOLVED for the
+      // attributed (providerKind, model). An unrecognized model resolves to
+      // qualityTier "unknown" with a 0 rate (friday-provider-pricing-catalog
+      // fallback), which is otherwise indistinguishable from a genuinely-free
+      // model (e.g. local ollama, tier "cheap" @ $0). Without this marker an
+      // unpriced paid model silently under-reports cost as $0. We persist an
+      // explicit boolean computed from the SAME single-source pricing catalog,
+      // consistent with the record's stored providerKind: if the provider could
+      // not be attributed (providerKind "unknown") pricing is unresolved by
+      // definition — a conservative fail-closed signal. NOTE: this means
+      // "pricing resolvable for the attributed provider/model", NOT a guarantee
+      // that the stored costUsd was itself computed from this exact resolution.
+      const pricingResolved =
+        providerKind !== "unknown"
+        && pricingCatalog.getPricing(providerKind, input.model).qualityTier !== "unknown";
       const now = deps.nowIso();
       const usageDay = now.slice(0, 10);
       const usageMonth = now.slice(0, 7);
@@ -3475,7 +3490,9 @@ export function createFridayProviderService(
         totalTokens: input.usage.total,
         costUsd: input.costUsd,
         currency: "USD",
-        metadata: input.metadata ?? {},
+        // Computed marker goes LAST so a caller-supplied metadata.pricingResolved
+        // cannot spoof the ledger's truth signal.
+        metadata: { ...(input.metadata ?? {}), pricingResolved },
         createdAt: now,
       };
 

--- a/test/unit/providers/services/friday-provider-service.test.ts
+++ b/test/unit/providers/services/friday-provider-service.test.ts
@@ -3370,4 +3370,138 @@ describe("FridayProviderService", () => {
       }
     });
   });
+
+  // D (ledger truth): an unrecognized model resolves to a 0 rate (pricing
+  // catalog fallback, qualityTier "unknown"), which silently looks identical to
+  // a genuinely-free model. recordUsage now persists metadata.pricingResolved so
+  // the usage ledger can tell "unpriced ⇒ cost under-reported" apart from "free".
+  // These tests round-trip through the REAL usageRepo.insert and read the marker
+  // back with json_extract — proving it is persisted AND queryable, not just
+  // present on the in-memory record object.
+  describe("recordUsage pricing-resolution truth marker (D)", () => {
+    function readUsageRow(model: string) {
+      return db.withReadConnection((conn) =>
+        conn.prepare(
+          `SELECT json_extract(metadata_json, '$.pricingResolved') AS resolved,
+                  provider_kind AS kind,
+                  cost_usd AS cost
+             FROM llm_usage_records
+            WHERE model = ?
+            ORDER BY created_at DESC
+            LIMIT 1`,
+        ).get(model) as { resolved: number | null; kind: string; cost: number } | undefined,
+      );
+    }
+
+    async function createOpenAiProvider(): Promise<string> {
+      await service.createProvider({
+        kind: "openai",
+        name: "OpenAI",
+        baseUrl: "https://api.openai.com",
+        authMode: "api-key",
+        api: "openai-completions",
+        apiKey: "test-pricing-key", // pragma: allowlist secret
+        supportedModels: ["gpt-4o"],
+        defaultModel: "gpt-4o",
+        validateOnSave: false,
+      });
+      return "test-id-0001";
+    }
+
+    it("marks a catalog-priced model pricingResolved=true (queryable via json_extract)", async () => {
+      const providerId = await createOpenAiProvider();
+      await service.recordUsage({
+        providerId,
+        providerApi: "openai-completions",
+        model: "gpt-4o",
+        routeStrategy: "configured",
+        taskComplexity: "medium",
+        usage: { input: 1000, output: 500, cacheRead: 0, cacheWrite: 0, total: 1500 },
+        costUsd: 0.05,
+      });
+
+      const row = readUsageRow("gpt-4o");
+      expect(row?.resolved).toBe(1);
+    });
+
+    it("marks an UNPRICED model pricingResolved=false so silent cost_usd=0 is not mistaken for free (the D defect)", async () => {
+      const providerId = await createOpenAiProvider();
+      await service.recordUsage({
+        providerId,
+        providerApi: "openai-completions",
+        // No catalog pattern is a substring of this name ⇒ getPricing falls back
+        // to qualityTier "unknown" ⇒ cost_usd computes to 0 at the call site.
+        model: "experimental-unpriced-model-zzz",
+        routeStrategy: "configured",
+        taskComplexity: "medium",
+        usage: { input: 1000, output: 500, cacheRead: 0, cacheWrite: 0, total: 1500 },
+        costUsd: 0,
+      });
+
+      const row = readUsageRow("experimental-unpriced-model-zzz");
+      expect(row?.cost).toBe(0);
+      expect(row?.resolved).toBe(0);
+    });
+
+    it("distinguishes a genuinely-free model (ollama @ $0, catalog-resolved) from an unpriced one", async () => {
+      await service.createProvider({
+        kind: "ollama",
+        name: "Ollama",
+        baseUrl: "http://127.0.0.1:11434",
+        authMode: "api-key",
+        api: "ollama",
+        apiKey: "unused-local-key", // pragma: allowlist secret
+        supportedModels: ["llama3"],
+        defaultModel: "llama3",
+        validateOnSave: false,
+      });
+
+      await service.recordUsage({
+        providerId: "test-id-0001",
+        providerApi: "ollama",
+        model: "llama3",
+        routeStrategy: "configured",
+        taskComplexity: "simple",
+        usage: { input: 1000, output: 500, cacheRead: 0, cacheWrite: 0, total: 1500 },
+        costUsd: 0,
+      });
+
+      const row = readUsageRow("llama3");
+      expect(row?.cost).toBe(0); // same zero cost as the unpriced case above ...
+      expect(row?.resolved).toBe(1); // ... but truthfully marked resolved (genuinely free)
+    });
+
+    it("fails closed: provider profile gone ⇒ providerKind unknown ⇒ pricingResolved=false", async () => {
+      await service.recordUsage({
+        providerId: "does-not-exist",
+        providerApi: "openai-completions",
+        model: "gpt-4o",
+        routeStrategy: "configured",
+        taskComplexity: "medium",
+        usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, total: 2 },
+        costUsd: 0.01,
+      });
+
+      const row = readUsageRow("gpt-4o");
+      expect(row?.kind).toBe("unknown");
+      expect(row?.resolved).toBe(0);
+    });
+
+    it("cannot be spoofed: a caller-supplied metadata.pricingResolved is overridden by the computed truth", async () => {
+      const providerId = await createOpenAiProvider();
+      await service.recordUsage({
+        providerId,
+        providerApi: "openai-completions",
+        model: "experimental-unpriced-model-zzz",
+        routeStrategy: "configured",
+        taskComplexity: "medium",
+        usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, total: 2 },
+        costUsd: 0,
+        metadata: { pricingResolved: true, source: "spoof-attempt" },
+      });
+
+      const row = readUsageRow("experimental-unpriced-model-zzz");
+      expect(row?.resolved).toBe(0); // computed false wins over the caller's true
+    });
+  });
 });


### PR DESCRIPTION
## What (audit D, slice-2 — usage-ledger pricing truth)

An unrecognized model resolves to the pricing-catalog **fallback** (`qualityTier: "unknown"`, all rates `0`) in `friday-provider-pricing-catalog.ts`, so its `cost_usd` computes to `0`. In the persisted usage ledger that is **indistinguishable** from a genuinely-free model (e.g. local `ollama`, tier `cheap` @ $0). A real *paid* model that Friday routes to but that is missing from the catalog therefore silently under-reports cost as `$0` with **no truth signal** — a ledger-integrity gap (goal item D: "missing provider metadata causing silent accounting gaps / provider-cost metadata remains truthful").

## Fix (minimal, single-funnel)

`recordUsage` in `friday-provider-service.ts` is the **single funnel** for all four usage-recording call sites (generator-llm inference client + two hub agent-runtime `usageRecorder`s, all via `providerService.recordUsage`). It already constructs `pricingCatalog` internally, so it re-derives the marker with **no new dependency, no `calculate()` interface change, and no caller changes**:

```ts
const pricingResolved =
  providerKind !== "unknown"
  && pricingCatalog.getPricing(providerKind, input.model).qualityTier !== "unknown";
...
metadata: { ...(input.metadata ?? {}), pricingResolved },  // computed LAST — un-spoofable
```

- Computed from the **same single-source** catalog and **consistent with the record's stored `providerKind`**.
- Spread **last** so a caller-supplied `metadata.pricingResolved` cannot spoof the ledger truth.
- Persisted via the existing `metadata_json` column, queryable with `json_extract(metadata_json,'$.pricingResolved')` (no migration).

## Honest scope (not over-claimed)

`pricingResolved` means **"pricing was resolvable for the *attributed* (providerKind, model)"** — NOT a guarantee that the stored `costUsd` was itself computed from this exact resolution. Because `recordUsage` re-derives the marker from the profile-looked-up `providerKind` (the same one it stores on the record), a profile that went away between the fire-and-forget call and the write yields `providerKind="unknown"` ⇒ `pricingResolved=false` even if the caller computed a real non-zero cost. That is a **conservative, fail-closed** false-negative, consistent with the record's own `providerKind` field.

## Proof (no mock-only)

`test/unit/providers/services/friday-provider-service.test.ts` — real `usageRepo.insert` round-trip, read back via `json_extract`. **Fail-before / pass-after** on 5 cases:
1. catalog-priced (`openai`/`gpt-4o`) ⇒ `1`
2. **unpriced model ⇒ `0` (the D defect)** — cost_usd=0 but truthfully marked unresolved
3. genuinely-free `ollama` @ $0 ⇒ `1` — same zero cost, **distinguished** from unpriced
4. profile-gone ⇒ `providerKind="unknown"` ⇒ `0` (fail-closed)
5. caller spoof (`metadata.pricingResolved:true` on an unpriced model) ⇒ overridden to `0`

Blast radius: full provider-service + `cost/` + `persistence/` suites **130 tests green**; `typecheck:src` clean; `git diff --check` clean. Branch cut from `a00136eb` (current `origin/main`).

## Merge note

A paused prior-session handoff said "operator merges D-slice-2 manually." The current goal directive is `fixed+proven+merged` and the prior session self-merged its own green PRs (#401/#403) via non-admin squash; self-merge is not in the goal's stop-boundaries. Flagging the conflict here — deferring the merge decision to operator confirmation rather than auto-merging.