### PR TITLE
fix(self-heal): durably persist self-heal skill-status (capture-and-restore)

### DIFF
--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -1177,12 +1177,33 @@ export function createFridayHubAutoFixExecutionSupport(deps: {
   workflowRuntime?: FridayWorkflowRuntime;
   skillGenerator?: FridaySkillGeneratorService;
   nowIso: () => string;
+  // Durable skill-lifecycle persistence (optional). `persistSkillLifecycleStatus` returns true
+  // only when the skill exists in the durable skills store (installed/converter skills); for
+  // built-in / registry-only skills it returns false (no write). `getPersistedSkillLifecycleStatus`
+  // returns undefined for a not-in-store skill. Used to (a) durably persist a self-heal disable of
+  // a currently-'installed' skill so it survives restart, and (b) restore the plan-captured prior
+  // status on a regenerate_skill rollback — never to promote a 'not_installed' candidate.
+  persistSkillLifecycleStatus?: (skillId: string, status: SkillLifecycleStatus) => boolean;
+  getPersistedSkillLifecycleStatus?: (skillId: string) => SkillLifecycleStatus | undefined;
 }): FridayHubAutoFixExecutionSupport {
   // P2-07: External-state remediation must be backed by hub-level services.
   // The execution service fails closed for these kinds unless an executor is
   // injected here.
   const stepExecutors: Partial<Record<FridayAutoFixStepKind, StepExecutor>> = {};
   const stepVerifiers: Partial<Record<FridayAutoFixStepKind, StepVerifier>> = {};
+
+  // Durable-aware skill-status read: prefer the durable store (authoritative + survives restart)
+  // when the skill exists there; otherwise fall back to the in-memory stub so built-in /
+  // registry-only skills report an honest (non-durable) result.
+  const resolveSkillLifecycleStatus = async (
+    skillId: string,
+  ): Promise<SkillLifecycleStatus | undefined> => {
+    const durable = deps.getPersistedSkillLifecycleStatus?.(skillId);
+    if (durable !== undefined) {
+      return durable;
+    }
+    return (await deps.memoryState.listSkillStatuses())[skillId];
+  };
 
   const readPayloadRecord = (payload: unknown): Record<string, unknown> | null =>
     typeof payload === "object" && payload !== null && !Array.isArray(payload)
@@ -1269,11 +1290,21 @@ export function createFridayHubAutoFixExecutionSupport(deps: {
         ? `auto-fix rollback @ ${nowIso}`
         : `auto-fix disable_skill @ ${nowIso}`,
     );
+    // Durably persist ONLY a disable of a currently-'installed' skill, so the disable survives a
+    // hub restart without clobbering a converter-managed 'not_installed' candidate or any other
+    // non-installed lifecycle state. The revert path stays in-memory only — the planner emits no
+    // disable_skill rollback, and re-promotion is the converter's job, so self-heal never writes a
+    // durable 'installed'.
+    let durablyPersisted = false;
+    if (!revert && deps.getPersistedSkillLifecycleStatus?.(step.target) === "installed") {
+      durablyPersisted = deps.persistSkillLifecycleStatus?.(step.target, "disabled") ?? false;
+    }
     if (payload) {
       payload._skillDisabled = !revert;
       payload._skillStatusAfter = nextStatus;
       payload._skillStatusTarget = step.target;
       payload._skillStatusAt = nowIso;
+      payload._skillStatusDurable = durablyPersisted;
     }
     return true;
   };
@@ -1282,9 +1313,9 @@ export function createFridayHubAutoFixExecutionSupport(deps: {
     if (!step.target) {
       return false;
     }
-    const revert = isRevertPayload(step.payload);
-    const statuses = await deps.memoryState.listSkillStatuses();
-    return statuses[step.target] === (revert ? "installed" : "disabled");
+    // Durable-aware so a disabled installed-skill verifies after a restart (fresh in-memory state).
+    const want = isRevertPayload(step.payload) ? "installed" : "disabled";
+    return (await resolveSkillLifecycleStatus(step.target)) === want;
   };
 
   stepExecutors.apply_config_patch = async (step) => {
@@ -1652,15 +1683,22 @@ export function createFridayHubAutoFixExecutionSupport(deps: {
 
       const revert = isRevertPayload(step.payload);
       if (revert) {
+        // Restore the prior status captured at plan-build time (never default-enable). A
+        // 'not_installed' candidate is restored to 'not_installed', never promoted to 'installed';
+        // absent capture falls back to the safe 'disabled' (not an enable).
+        const restore = (readString(payload, "restoreStatus") as SkillLifecycleStatus | undefined) ?? "disabled";
         await deps.memoryState.updateSkillStatus(
           skillId,
-          "disabled",
+          restore,
           `auto-fix rollback regenerate_skill @ ${deps.nowIso()}`,
         );
+        const durablyPersisted = deps.persistSkillLifecycleStatus?.(skillId, restore) ?? false;
         if (payload) {
           payload._skillRegenerated = true;
           payload._regenerateRolledBack = true;
           payload._regeneratedAt = deps.nowIso();
+          payload._skillStatusAfter = restore;
+          payload._skillStatusDurable = durablyPersisted;
         }
         return true;
       }
@@ -1704,8 +1742,9 @@ export function createFridayHubAutoFixExecutionSupport(deps: {
         return false;
       }
       if (isRevertPayload(step.payload)) {
-        const statuses = await deps.memoryState.listSkillStatuses();
-        return statuses[skillId] === "disabled";
+        // Verify the captured prior status was restored (durable-aware so it reflects a restart).
+        const restore = (readString(payload, "restoreStatus") as SkillLifecycleStatus | undefined) ?? "disabled";
+        return (await resolveSkillLifecycleStatus(skillId)) === restore;
       }
       const statuses = await deps.memoryState.listSkillStatuses();
       return payload?._skillRegenerated === true && statuses[skillId] === "installed";

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -4016,6 +4016,21 @@ export async function createFridayHub(
     workflowRuntime,
     skillGenerator,
     nowIso,
+    // Durably persist a self-heal disable of a currently-installed skill (survives restart) and
+    // restore a regenerate_skill rollback's captured prior status. Persists only for skills already
+    // in the durable store (getSkillById existence check) — built-in/registry-only skills are not
+    // upserted, so a 'not_installed' candidate is never promoted.
+    persistSkillLifecycleStatus: (skillId, status) => {
+      let persisted = false;
+      stateRuntime.sqlite.withWriteTransaction((db) => {
+        if (converterSkillRepo.getSkillById(db, skillId)) {
+          converterSkillRepo.updateLifecycleStatus(db, skillId, status, nowIso());
+          persisted = true;
+        }
+      });
+      return persisted;
+    },
+    getPersistedSkillLifecycleStatus,
   });
 
   const selfLearningRuntime = createFridaySelfLearningRuntime({
@@ -4024,6 +4039,9 @@ export async function createFridayHub(
     nowIso,
     stepExecutors: hubAutoFixSupport.stepExecutors,
     stepVerifiers: hubAutoFixSupport.stepVerifiers,
+    // Lets the auto-fix planner capture the prior skill status at plan-build time for the
+    // regenerate_skill rollback (restore-not-enable).
+    getSkillLifecycleStatus: getPersistedSkillLifecycleStatus,
   });
 
   // P1-01: Assign immediately so learningContextBuilder and communicationPromptBuilder

--- a/src/learning/runtime/friday-self-learning-runtime.ts
+++ b/src/learning/runtime/friday-self-learning-runtime.ts
@@ -102,6 +102,7 @@ export function createFridaySelfLearningRuntime(
 
   const autoFixPlan = createFridayAutoFixPlanService({
     idGenerator: deps.idGenerator,
+    getSkillLifecycleStatus: deps.getSkillLifecycleStatus,
   });
 
   const autoFixRisk = createFridayAutoFixRiskAssessmentService({

--- a/src/learning/runtime/friday-self-learning-runtime.types.ts
+++ b/src/learning/runtime/friday-self-learning-runtime.types.ts
@@ -16,6 +16,7 @@ import type { FridayAutoFixRollbackService } from "../services/friday-auto-fix-r
 import type { FridayApprovalWorkflowService } from "../services/friday-approval-workflow-service.js";
 import type { FridayAutoFixDispatcherService } from "../services/friday-auto-fix-dispatcher-service.js";
 import type { FridayAutoFixStepKind } from "../model/friday-auto-fix.types.js";
+import type { SkillLifecycleStatus } from "#skills";
 
 export interface FridaySelfLearningRuntime {
   events: FridayLearningEventCollectionService;
@@ -45,4 +46,10 @@ export interface CreateFridaySelfLearningRuntimeDeps {
   stepExecutors?: Partial<Record<FridayAutoFixStepKind, StepExecutor>>;
   /** Override auto-fix step verifiers for production use. */
   stepVerifiers?: Partial<Record<FridayAutoFixStepKind, StepVerifier>>;
+  /**
+   * Reads the current durable skill lifecycle status at plan-build time, so a regenerate_skill
+   * rollback can restore the prior status instead of blindly enabling. Wired in the hub bootstrap
+   * to the durable skills store; optional elsewhere.
+   */
+  getSkillLifecycleStatus?: (skillId: string) => SkillLifecycleStatus | undefined;
 }

--- a/src/learning/services/friday-auto-fix-plan-service.ts
+++ b/src/learning/services/friday-auto-fix-plan-service.ts
@@ -5,6 +5,7 @@ import type {
   JsonObject,
 } from "../model/friday-learning.types.js";
 import type { FridayAutoFixPlan, FridayAutoFixStepKind } from "../model/friday-auto-fix.types.js";
+import type { SkillLifecycleStatus } from "#skills";
 import { buildAutoFixPlanTitle, normalizeAutoFixTitleBase } from "./friday-auto-fix-title-helpers.js";
 
 export interface FridayAutoFixPlanService {
@@ -19,6 +20,10 @@ export interface FridayAutoFixPlanService {
 export interface CreateAutoFixPlanServiceDeps {
   idGenerator: () => string;
   regenerateSkillRecurrenceThreshold?: number;
+  // Reads the current durable skill lifecycle status at PLAN-BUILD time so a regenerate_skill
+  // rollback can restore the prior status instead of blindly enabling. Optional: when absent the
+  // rollback restores the safe 'disabled' default (never a default-enable).
+  getSkillLifecycleStatus?: (skillId: string) => SkillLifecycleStatus | undefined;
 }
 
 const CATEGORY_STEP_MAP: Record<FridayErrorIncidentEntity["category"], FridayAutoFixStepKind | undefined> = {
@@ -275,6 +280,10 @@ export function createFridayAutoFixPlanService(
           ? incident.context.skillId.trim()
           : "";
         if (skillId.length > 0) {
+          // Capture the prior durable status now (plan-build time, before the forward regenerate
+          // runs) so the rollback can restore it exactly — never promoting a 'not_installed'
+          // candidate and never defaulting to enable.
+          const priorSkillLifecycleStatus = deps.getSkillLifecycleStatus?.(skillId);
           const regenPlan: FridayAutoFixPlan = {
             title: buildAutoFixPlanTitle(`Regenerate skill ${skillId}`),
             summary: `Recurrent failure (${recurrenceCount}x) for skill '${skillId}'. Generate improved replacement via skill generator, self-test, and supervised install.`,
@@ -309,6 +318,11 @@ export function createFridayAutoFixPlanService(
                     revert: true,
                     skillId,
                     ...basePayload,
+                    // Only set restoreStatus when known (payload is JSON; omit rather than store
+                    // undefined). Absent → executor falls back to the safe 'disabled', not enable.
+                    ...(priorSkillLifecycleStatus !== undefined
+                      ? { restoreStatus: priorSkillLifecycleStatus }
+                      : {}),
                   },
                 },
               ],

--- a/test/unit/hub/bootstrap/hub-helpers.test.ts
+++ b/test/unit/hub/bootstrap/hub-helpers.test.ts
@@ -3,7 +3,8 @@ import * as os from "node:os";
 import * as path from "node:path";
 
 import { describe, expect, it } from "vitest";
-import type { FridaySkillRegistry } from "#skills";
+import type { FridaySkillRegistry, SkillLifecycleStatus } from "#skills";
+import type { FridaySkillGeneratorService } from "#skills/generator";
 import type { FridayProviderService } from "#providers";
 import type { FridayWorkflowRuntime } from "#workflows";
 import type { FridayHubConfigManagerService } from "../../../../src/hub/services/friday-hub-config-manager.types.js";
@@ -259,6 +260,131 @@ describe("createFridayHubAutoFixExecutionSupport", () => {
       _skillStatusTarget: "skill-x",
       _skillStatusAt: "2026-03-13T10:00:00.000Z",
     });
+  });
+
+  // ── self-heal skill-status durable persistence: capture-and-restore (residual E) ──
+  function makeRegistryWith(ids: readonly string[]): FridaySkillRegistry {
+    const set = new Set(ids);
+    return {
+      list: () => [],
+      get: (skillId: string) => (set.has(skillId) ? ({} as ReturnType<FridaySkillRegistry["get"]>) : null),
+      resolveByIntent: () => null,
+      validateAll: () => [],
+      reload: async () => {},
+      refresh: async () => {},
+      isCompatible: () => ({ compatible: true, reasons: [] }),
+      startWatching: async () => {},
+      stopWatching: async () => {},
+      close: async () => {},
+    };
+  }
+
+  // Simulated durable skills store: persist only succeeds for ids already present (mirrors the
+  // bootstrap's getSkillById existence check) — absent ids get NO write. Survives a "restart"
+  // (we discard memoryState but keep this map).
+  function makeDurableStore(seed: Record<string, SkillLifecycleStatus>) {
+    const store = new Map<string, SkillLifecycleStatus>(Object.entries(seed));
+    return {
+      store,
+      persistSkillLifecycleStatus: (skillId: string, status: SkillLifecycleStatus): boolean => {
+        if (!store.has(skillId)) return false;
+        store.set(skillId, status);
+        return true;
+      },
+      getPersistedSkillLifecycleStatus: (skillId: string): SkillLifecycleStatus | undefined => store.get(skillId),
+    };
+  }
+
+  const skillGenStub = {
+    startSession: async () => ({ session: { sessionId: "sess-1" } }),
+    generateDraft: async () => ({ manifest: { name: "Skill X" } }),
+    approveAndSave: async () => ({ candidateId: "cand-1" }),
+  } as unknown as FridaySkillGeneratorService;
+
+  it("disable persists 'disabled' durably for an installed skill and survives a restart", async () => {
+    const durable = makeDurableStore({ "skill-x": "installed" });
+    const support = createFridayHubAutoFixExecutionSupport({
+      registry: makeRegistryWith(["skill-x"]),
+      memoryState: createStubMemoryState(),
+      nowIso: () => "2026-03-13T10:00:00.000Z",
+      ...durable,
+    });
+    const step = { stepId: "s1", kind: "disable_skill" as const, target: "skill-x", payload: {} as Record<string, unknown>, verify: { method: "error_absent" as const, timeoutMs: 5000 } };
+    await expect(support.stepExecutors.disable_skill?.(step)).resolves.toBe(true);
+    expect(durable.store.get("skill-x")).toBe("disabled");
+    expect(step.payload._skillStatusDurable).toBe(true);
+    // RESTART: fresh memoryState, same durable store → still disabled.
+    const afterRestart = createFridayHubAutoFixExecutionSupport({
+      registry: makeRegistryWith(["skill-x"]),
+      memoryState: createStubMemoryState(),
+      nowIso: () => "2026-03-13T11:00:00.000Z",
+      ...durable,
+    });
+    await expect(afterRestart.stepVerifiers.disable_skill?.(step)).resolves.toBe(true);
+    expect(durable.getPersistedSkillLifecycleStatus("skill-x")).toBe("disabled");
+  });
+
+  it("disable does NOT clobber a not_installed candidate (only installed skills are durably disabled)", async () => {
+    const durable = makeDurableStore({ "skill-cand": "not_installed" });
+    const memoryState = createStubMemoryState();
+    const support = createFridayHubAutoFixExecutionSupport({
+      registry: makeRegistryWith(["skill-cand"]),
+      memoryState,
+      nowIso: () => "2026-03-13T10:00:00.000Z",
+      ...durable,
+    });
+    const step = { stepId: "s2", kind: "disable_skill" as const, target: "skill-cand", payload: {} as Record<string, unknown>, verify: { method: "error_absent" as const, timeoutMs: 5000 } };
+    await expect(support.stepExecutors.disable_skill?.(step)).resolves.toBe(true);
+    // durable candidate status is UNTOUCHED (no promotion, no clobber); only in-memory reflects disable
+    expect(durable.store.get("skill-cand")).toBe("not_installed");
+    expect(step.payload._skillStatusDurable).toBe(false);
+    expect((await memoryState.listSkillStatuses())["skill-cand"]).toBe("disabled");
+  });
+
+  it("regenerate rollback restores the plan-captured prior status (installed / not_installed), never default-enable", async () => {
+    // prior was installed → rollback restores installed
+    const dInstalled = makeDurableStore({ "skill-x": "installed" });
+    const s1 = createFridayHubAutoFixExecutionSupport({
+      registry: makeRegistryWith(["skill-x"]), memoryState: createStubMemoryState(),
+      nowIso: () => "2026-03-13T10:00:00.000Z", skillGenerator: skillGenStub, ...dInstalled,
+    });
+    const revInstalled = { stepId: "r1", kind: "regenerate_skill" as const, target: "skill-x", payload: { revert: true, skillId: "skill-x", restoreStatus: "installed" } as Record<string, unknown>, verify: { method: "skill_registry_available" as const, timeoutMs: 5000 } };
+    await expect(s1.stepExecutors.regenerate_skill?.(revInstalled)).resolves.toBe(true);
+    await expect(s1.stepVerifiers.regenerate_skill?.(revInstalled)).resolves.toBe(true);
+    expect(dInstalled.store.get("skill-x")).toBe("installed");
+
+    // prior was not_installed (candidate) → rollback restores not_installed (NO promotion)
+    const dCand = makeDurableStore({ "skill-c": "not_installed" });
+    const s2 = createFridayHubAutoFixExecutionSupport({
+      registry: makeRegistryWith(["skill-c"]), memoryState: createStubMemoryState(),
+      nowIso: () => "2026-03-13T10:00:00.000Z", skillGenerator: skillGenStub, ...dCand,
+    });
+    const revCand = { stepId: "r2", kind: "regenerate_skill" as const, target: "skill-c", payload: { revert: true, skillId: "skill-c", restoreStatus: "not_installed" } as Record<string, unknown>, verify: { method: "skill_registry_available" as const, timeoutMs: 5000 } };
+    await expect(s2.stepExecutors.regenerate_skill?.(revCand)).resolves.toBe(true);
+    expect(dCand.store.get("skill-c")).toBe("not_installed");
+  });
+
+  it("false-positive regenerate rollback does NOT re-enable a skill that was already disabled", async () => {
+    const durable = makeDurableStore({ "skill-x": "disabled" }); // prior captured status = disabled
+    const support = createFridayHubAutoFixExecutionSupport({
+      registry: makeRegistryWith(["skill-x"]), memoryState: createStubMemoryState(),
+      nowIso: () => "2026-03-13T10:00:00.000Z", skillGenerator: skillGenStub, ...durable,
+    });
+    const step = { stepId: "r3", kind: "regenerate_skill" as const, target: "skill-x", payload: { revert: true, skillId: "skill-x", restoreStatus: "disabled" } as Record<string, unknown>, verify: { method: "skill_registry_available" as const, timeoutMs: 5000 } };
+    await expect(support.stepExecutors.regenerate_skill?.(step)).resolves.toBe(true);
+    expect(durable.store.get("skill-x")).toBe("disabled"); // stayed disabled, not enabled
+    await expect(support.stepVerifiers.regenerate_skill?.(step)).resolves.toBe(true);
+  });
+
+  it("regenerate rollback with no captured restoreStatus falls back to the safe 'disabled' (never enable)", async () => {
+    const durable = makeDurableStore({ "skill-x": "installed" });
+    const support = createFridayHubAutoFixExecutionSupport({
+      registry: makeRegistryWith(["skill-x"]), memoryState: createStubMemoryState(),
+      nowIso: () => "2026-03-13T10:00:00.000Z", skillGenerator: skillGenStub, ...durable,
+    });
+    const step = { stepId: "r4", kind: "regenerate_skill" as const, target: "skill-x", payload: { revert: true, skillId: "skill-x" } as Record<string, unknown>, verify: { method: "skill_registry_available" as const, timeoutMs: 5000 } };
+    await expect(support.stepExecutors.regenerate_skill?.(step)).resolves.toBe(true);
+    expect(durable.store.get("skill-x")).toBe("disabled"); // safe default, not enabled
   });
 
   it("Phase 14.5B module_28b: apply_config_patch is fail-closed when no real patch payload is provided", async () => {

--- a/test/unit/learning/services/friday-auto-fix-plan-service.test.ts
+++ b/test/unit/learning/services/friday-auto-fix-plan-service.test.ts
@@ -3,6 +3,7 @@ import { createTestIdGenerator } from "../../satellites/_helpers/create-test-db.
 import { createFridayAutoFixPlanService } from "#learning";
 import type { FridayAutoFixPlanService } from "#learning";
 import type { FridayErrorIncidentEntity, FridayDiagnosisRecordEntity, FridayLearnedLessonEntity } from "#learning";
+import type { SkillLifecycleStatus } from "#skills";
 
 describe("FridayAutoFixPlanService", () => {
   let service: FridayAutoFixPlanService;
@@ -64,6 +65,31 @@ describe("FridayAutoFixPlanService", () => {
     expect(plans[0]!.steps[0]!.kind).toBe("retry_node");
     expect(plans[0]!.evidence.fingerprint).toBe("sig-abc");
     expect(plans[0]!.evidence.matchedLessonIds).toEqual(["lesson-001"]);
+  });
+
+  it("captures the prior skill lifecycle status into the regenerate_skill rollback (restore-not-enable)", () => {
+    const skillIncident: FridayErrorIncidentEntity = {
+      ...baseIncident,
+      context: { source: "skills_lifecycle", skillId: "skill-x" },
+    };
+    const regenRollbackPayload = (status: SkillLifecycleStatus | undefined): Record<string, unknown> | undefined => {
+      const plans = createFridayAutoFixPlanService({
+        idGenerator: createTestIdGenerator(),
+        regenerateSkillRecurrenceThreshold: 1,
+        getSkillLifecycleStatus: () => status,
+      }).buildPlans({ incident: skillIncident, diagnosis: baseDiagnosis, matchedLessons: [], recurrenceCount: 5 });
+      return plans.find((p) => p.rollbackPlan?.steps[0]?.kind === "regenerate_skill")
+        ?.rollbackPlan?.steps[0]?.payload as Record<string, unknown> | undefined;
+    };
+
+    // prior installed -> rollback restores installed
+    expect(regenRollbackPayload("installed")).toMatchObject({ revert: true, restoreStatus: "installed" });
+    // prior not_installed candidate -> rollback restores not_installed (never promoted to installed)
+    expect(regenRollbackPayload("not_installed")).toMatchObject({ revert: true, restoreStatus: "not_installed" });
+    // unknown prior -> restoreStatus omitted (executor falls back to the safe 'disabled', not enable)
+    const unknown = regenRollbackPayload(undefined);
+    expect(unknown).toBeDefined();
+    expect(unknown).not.toHaveProperty("restoreStatus");
   });
 
   it("builds a fallback plan when no lessons match", () => {


### PR DESCRIPTION
## Summary

Residual E (self-repair safety semantics). Self-heal `disable_skill` / `regenerate_skill` wrote skill lifecycle status **only** to the process-local `createStubMemoryState` stub, so a skill that self-heal **disabled** (because it was failing/unsafe) **silently re-enabled on the next hub restart**.

Implemented as **capture-and-restore**, scope-bounded per review (no migration, no new planner rollback construction, no broad lifecycle change). An earlier blind durable-write approach was rejected because writing `installed` could promote an unpromoted `not_installed` candidate and defeat the workflow safety gate.

## Change

- **`disable_skill`**: durably persists `disabled` **only when the skill's current durable status is `installed`** (skips `not_installed` candidates / unknown / not-in-store) — survives restart without clobbering a converter-managed candidate. The revert path stays in-memory only (the planner emits no `disable_skill` rollback; re-promotion is the converter's job — self-heal never writes a durable `installed`).
- **`regenerate_skill`**: the auto-fix **planner captures the prior durable status at plan-build time** into the existing rollback payload (`restoreStatus`); the rollback **restores exactly that status** — never default-enable, never promoting a `not_installed` candidate. The normal path does not force `installed` (converter/`approveAndSave` owns promotion).
- New optional deps: `persistSkillLifecycleStatus` / `getPersistedSkillLifecycleStatus` on the auto-fix support (persist only for in-store skills via a `getSkillById` existence check), and a `getSkillLifecycleStatus` reader threaded to the planner; wired in the hub bootstrap to `converterSkillRepo`.

## Proof (local, lint 0 errors)

`test/unit/hub/bootstrap/hub-helpers.test.ts`:
1. installed → disable → **restart** (fresh memoryState) → still `disabled`.
2. `not_installed` candidate → disable → **not clobbered/promoted** (durable untouched, only in-memory reflects disable).
3. regenerate rollback restores the captured prior status (`installed` → `installed`; `not_installed` → `not_installed`, **no promotion**).
4. **false-positive** regenerate rollback keeps an already-`disabled` skill `disabled` (not enabled).
5. no captured status → falls back to safe `disabled` (never enable).

`test/unit/learning/services/friday-auto-fix-plan-service.test.ts`: planner captures `restoreStatus` (`installed`/`not_installed`; omitted when unknown).

No regression: auto-fix execution / rollback / self-healing-api / dispatcher suites (46 tests). `build:api`, `check:secret-patterns`, detect-secrets baseline, `git diff --check` all clean.

## Scope boundary

5 source + 2 test files; no migration, no schema/contract change, no `disable_skill` planner rollback added, no registry-population change. No npm publish/tag/release/secrets/settings. Standalone (does not bundle the E2 FRIDAY_NODES truth fix — already merged as #405 — or the Desktop-Recording UI copy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)