### PR TITLE
refactor(self-heal): dedupe E3 durable persistence — single path via createDurableMemoryState

### DIFF
--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -1177,33 +1177,12 @@ export function createFridayHubAutoFixExecutionSupport(deps: {
   workflowRuntime?: FridayWorkflowRuntime;
   skillGenerator?: FridaySkillGeneratorService;
   nowIso: () => string;
-  // Durable skill-lifecycle persistence (optional). `persistSkillLifecycleStatus` returns true
-  // only when the skill exists in the durable skills store (installed/converter skills); for
-  // built-in / registry-only skills it returns false (no write). `getPersistedSkillLifecycleStatus`
-  // returns undefined for a not-in-store skill. Used to (a) durably persist a self-heal disable of
-  // a currently-'installed' skill so it survives restart, and (b) restore the plan-captured prior
-  // status on a regenerate_skill rollback — never to promote a 'not_installed' candidate.
-  persistSkillLifecycleStatus?: (skillId: string, status: SkillLifecycleStatus) => boolean;
-  getPersistedSkillLifecycleStatus?: (skillId: string) => SkillLifecycleStatus | undefined;
 }): FridayHubAutoFixExecutionSupport {
   // P2-07: External-state remediation must be backed by hub-level services.
   // The execution service fails closed for these kinds unless an executor is
   // injected here.
   const stepExecutors: Partial<Record<FridayAutoFixStepKind, StepExecutor>> = {};
   const stepVerifiers: Partial<Record<FridayAutoFixStepKind, StepVerifier>> = {};
-
-  // Durable-aware skill-status read: prefer the durable store (authoritative + survives restart)
-  // when the skill exists there; otherwise fall back to the in-memory stub so built-in /
-  // registry-only skills report an honest (non-durable) result.
-  const resolveSkillLifecycleStatus = async (
-    skillId: string,
-  ): Promise<SkillLifecycleStatus | undefined> => {
-    const durable = deps.getPersistedSkillLifecycleStatus?.(skillId);
-    if (durable !== undefined) {
-      return durable;
-    }
-    return (await deps.memoryState.listSkillStatuses())[skillId];
-  };
 
   const readPayloadRecord = (payload: unknown): Record<string, unknown> | null =>
     typeof payload === "object" && payload !== null && !Array.isArray(payload)
@@ -1290,21 +1269,14 @@ export function createFridayHubAutoFixExecutionSupport(deps: {
         ? `auto-fix rollback @ ${nowIso}`
         : `auto-fix disable_skill @ ${nowIso}`,
     );
-    // Durably persist ONLY a disable of a currently-'installed' skill, so the disable survives a
-    // hub restart without clobbering a converter-managed 'not_installed' candidate or any other
-    // non-installed lifecycle state. The revert path stays in-memory only — the planner emits no
-    // disable_skill rollback, and re-promotion is the converter's job, so self-heal never writes a
-    // durable 'installed'.
-    let durablyPersisted = false;
-    if (!revert && deps.getPersistedSkillLifecycleStatus?.(step.target) === "installed") {
-      durablyPersisted = deps.persistSkillLifecycleStatus?.(step.target, "disabled") ?? false;
-    }
+    // Durable persistence is provided by createDurableMemoryState (audit E3, PR #406): the
+    // updateSkillStatus wrapper above persists to the skills table for in-store skills. No
+    // second persist path here.
     if (payload) {
       payload._skillDisabled = !revert;
       payload._skillStatusAfter = nextStatus;
       payload._skillStatusTarget = step.target;
       payload._skillStatusAt = nowIso;
-      payload._skillStatusDurable = durablyPersisted;
     }
     return true;
   };
@@ -1313,9 +1285,9 @@ export function createFridayHubAutoFixExecutionSupport(deps: {
     if (!step.target) {
       return false;
     }
-    // Durable-aware so a disabled installed-skill verifies after a restart (fresh in-memory state).
-    const want = isRevertPayload(step.payload) ? "installed" : "disabled";
-    return (await resolveSkillLifecycleStatus(step.target)) === want;
+    const revert = isRevertPayload(step.payload);
+    const statuses = await deps.memoryState.listSkillStatuses();
+    return statuses[step.target] === (revert ? "installed" : "disabled");
   };
 
   stepExecutors.apply_config_patch = async (step) => {
@@ -1683,22 +1655,21 @@ export function createFridayHubAutoFixExecutionSupport(deps: {
 
       const revert = isRevertPayload(step.payload);
       if (revert) {
-        // Restore the prior status captured at plan-build time (never default-enable). A
+        // Restore the prior status captured at plan-build time (never default-enable): a
         // 'not_installed' candidate is restored to 'not_installed', never promoted to 'installed';
-        // absent capture falls back to the safe 'disabled' (not an enable).
+        // absent capture falls back to the safe 'disabled' (not an enable). The write is persisted
+        // durably by createDurableMemoryState's updateSkillStatus wrapper (audit E3, PR #406).
         const restore = (readString(payload, "restoreStatus") as SkillLifecycleStatus | undefined) ?? "disabled";
         await deps.memoryState.updateSkillStatus(
           skillId,
           restore,
           `auto-fix rollback regenerate_skill @ ${deps.nowIso()}`,
         );
-        const durablyPersisted = deps.persistSkillLifecycleStatus?.(skillId, restore) ?? false;
         if (payload) {
           payload._skillRegenerated = true;
           payload._regenerateRolledBack = true;
           payload._regeneratedAt = deps.nowIso();
           payload._skillStatusAfter = restore;
-          payload._skillStatusDurable = durablyPersisted;
         }
         return true;
       }
@@ -1742,9 +1713,11 @@ export function createFridayHubAutoFixExecutionSupport(deps: {
         return false;
       }
       if (isRevertPayload(step.payload)) {
-        // Verify the captured prior status was restored (durable-aware so it reflects a restart).
+        // Verify the captured prior status was restored (in-process; the write is persisted
+        // durably by createDurableMemoryState).
         const restore = (readString(payload, "restoreStatus") as SkillLifecycleStatus | undefined) ?? "disabled";
-        return (await resolveSkillLifecycleStatus(skillId)) === restore;
+        const statuses = await deps.memoryState.listSkillStatuses();
+        return statuses[skillId] === restore;
       }
       const statuses = await deps.memoryState.listSkillStatuses();
       return payload?._skillRegenerated === true && statuses[skillId] === "installed";

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -4016,21 +4016,8 @@ export async function createFridayHub(
     workflowRuntime,
     skillGenerator,
     nowIso,
-    // Durably persist a self-heal disable of a currently-installed skill (survives restart) and
-    // restore a regenerate_skill rollback's captured prior status. Persists only for skills already
-    // in the durable store (getSkillById existence check) — built-in/registry-only skills are not
-    // upserted, so a 'not_installed' candidate is never promoted.
-    persistSkillLifecycleStatus: (skillId, status) => {
-      let persisted = false;
-      stateRuntime.sqlite.withWriteTransaction((db) => {
-        if (converterSkillRepo.getSkillById(db, skillId)) {
-          converterSkillRepo.updateLifecycleStatus(db, skillId, status, nowIso());
-          persisted = true;
-        }
-      });
-      return persisted;
-    },
-    getPersistedSkillLifecycleStatus,
+    // Durable persistence of self-heal skill-status is provided by createDurableMemoryState
+    // (audit E3, PR #406) via its updateSkillStatus wrapper — no second persist path is wired here.
   });
 
   const selfLearningRuntime = createFridaySelfLearningRuntime({

--- a/test/unit/hub/bootstrap/hub-helpers.test.ts
+++ b/test/unit/hub/bootstrap/hub-helpers.test.ts
@@ -4,7 +4,9 @@ import * as path from "node:path";
 
 import { describe, expect, it } from "vitest";
 import type { FridaySkillRegistry, SkillLifecycleStatus } from "#skills";
+import { createFridaySkillRepository } from "#skills";
 import type { FridaySkillGeneratorService } from "#skills/generator";
+import { createTestDb } from "../../../helpers/friday-test-db.helper.js";
 import type { FridayProviderService } from "#providers";
 import type { FridayWorkflowRuntime } from "#workflows";
 import type { FridayHubConfigManagerService } from "../../../../src/hub/services/friday-hub-config-manager.types.js";
@@ -14,6 +16,7 @@ import {
   createPersistentConfigManager,
   createStubMemoryState,
 } from "../../../../src/hub/bootstrap/index.js";
+import { createDurableMemoryState } from "../../../../src/hub/bootstrap/hub-helpers.js";
 import {
   buildFridayChannelDeliveryFailureText,
   buildFridayChannelMessageTooLongText,
@@ -262,7 +265,13 @@ describe("createFridayHubAutoFixExecutionSupport", () => {
     });
   });
 
-  // ── self-heal skill-status durable persistence: capture-and-restore (residual E) ──
+  // ── self-heal skill-status durable persistence (residual E) ──
+  // Durable persistence is provided by createDurableMemoryState (audit E3, PR #406): its
+  // updateSkillStatus wrapper persists explicit transitions to the skills table (the source the
+  // workflow-exec safety gate reads). These tests verify self-heal writes the RIGHT status through
+  // that single wrapper — the regenerate_skill rollback restores the plan-captured prior status
+  // (capture-restore), never a default-enable and never promoting a not_installed candidate.
+  // (createDurableMemoryState's persistence itself is covered by friday-durable-memory-state.test.ts.)
   function makeRegistryWith(ids: readonly string[]): FridaySkillRegistry {
     const set = new Set(ids);
     return {
@@ -278,113 +287,107 @@ describe("createFridayHubAutoFixExecutionSupport", () => {
       close: async () => {},
     };
   }
-
-  // Simulated durable skills store: persist only succeeds for ids already present (mirrors the
-  // bootstrap's getSkillById existence check) — absent ids get NO write. Survives a "restart"
-  // (we discard memoryState but keep this map).
-  function makeDurableStore(seed: Record<string, SkillLifecycleStatus>) {
-    const store = new Map<string, SkillLifecycleStatus>(Object.entries(seed));
-    return {
-      store,
-      persistSkillLifecycleStatus: (skillId: string, status: SkillLifecycleStatus): boolean => {
-        if (!store.has(skillId)) return false;
-        store.set(skillId, status);
-        return true;
-      },
-      getPersistedSkillLifecycleStatus: (skillId: string): SkillLifecycleStatus | undefined => store.get(skillId),
-    };
-  }
-
   const skillGenStub = {
     startSession: async () => ({ session: { sessionId: "sess-1" } }),
     generateDraft: async () => ({ manifest: { name: "Skill X" } }),
     approveAndSave: async () => ({ candidateId: "cand-1" }),
   } as unknown as FridaySkillGeneratorService;
+  const E3_NOW = "2026-03-13T10:00:00.000Z";
+  const seedSkill = (
+    db: ReturnType<typeof createTestDb>,
+    repo: ReturnType<typeof createFridaySkillRepository>,
+    id: string,
+    status: SkillLifecycleStatus,
+  ) =>
+    db.withWriteTransaction((conn) =>
+      repo.upsertSkillFromCatalog(conn, { id, name: id, source: "local", origin: "workspace", status, nowIso: E3_NOW }),
+    );
+  const tableStatus = (
+    db: ReturnType<typeof createTestDb>,
+    repo: ReturnType<typeof createFridaySkillRepository>,
+    id: string,
+  ) => db.withReadConnection((conn) => repo.getSkillById(conn, id)?.status);
 
-  it("disable persists 'disabled' durably for an installed skill and survives a restart", async () => {
-    const durable = makeDurableStore({ "skill-x": "installed" });
-    const support = createFridayHubAutoFixExecutionSupport({
-      registry: makeRegistryWith(["skill-x"]),
-      memoryState: createStubMemoryState(),
-      nowIso: () => "2026-03-13T10:00:00.000Z",
-      ...durable,
-    });
-    const step = { stepId: "s1", kind: "disable_skill" as const, target: "skill-x", payload: {} as Record<string, unknown>, verify: { method: "error_absent" as const, timeoutMs: 5000 } };
-    await expect(support.stepExecutors.disable_skill?.(step)).resolves.toBe(true);
-    expect(durable.store.get("skill-x")).toBe("disabled");
-    expect(step.payload._skillStatusDurable).toBe(true);
-    // RESTART: fresh memoryState, same durable store → still disabled.
-    const afterRestart = createFridayHubAutoFixExecutionSupport({
-      registry: makeRegistryWith(["skill-x"]),
-      memoryState: createStubMemoryState(),
-      nowIso: () => "2026-03-13T11:00:00.000Z",
-      ...durable,
-    });
-    await expect(afterRestart.stepVerifiers.disable_skill?.(step)).resolves.toBe(true);
-    expect(durable.getPersistedSkillLifecycleStatus("skill-x")).toBe("disabled");
+  it("self-heal disable persists 'disabled' durably via the createDurableMemoryState wrapper (single path)", async () => {
+    const db = createTestDb();
+    try {
+      const repo = createFridaySkillRepository();
+      seedSkill(db, repo, "skill-x", "installed");
+      const support = createFridayHubAutoFixExecutionSupport({
+        registry: makeRegistryWith(["skill-x"]),
+        memoryState: createDurableMemoryState({ db, skillRepository: repo, nowIso: () => E3_NOW }),
+        nowIso: () => E3_NOW,
+      });
+      const step = { stepId: "d1", kind: "disable_skill" as const, target: "skill-x", payload: {} as Record<string, unknown>, verify: { method: "error_absent" as const, timeoutMs: 5000 } };
+      await expect(support.stepExecutors.disable_skill?.(step)).resolves.toBe(true);
+      expect(tableStatus(db, repo, "skill-x")).toBe("disabled"); // durable via the #406 wrapper
+      // No second persist path: the executor no longer accepts a persist dep, so there is exactly
+      // one durable write (the wrapper) and no _skillStatusDurable flag on the payload.
+      expect(step.payload).not.toHaveProperty("_skillStatusDurable");
+    } finally {
+      db.close();
+    }
   });
 
-  it("disable does NOT clobber a not_installed candidate (only installed skills are durably disabled)", async () => {
-    const durable = makeDurableStore({ "skill-cand": "not_installed" });
-    const memoryState = createStubMemoryState();
-    const support = createFridayHubAutoFixExecutionSupport({
-      registry: makeRegistryWith(["skill-cand"]),
-      memoryState,
-      nowIso: () => "2026-03-13T10:00:00.000Z",
-      ...durable,
-    });
-    const step = { stepId: "s2", kind: "disable_skill" as const, target: "skill-cand", payload: {} as Record<string, unknown>, verify: { method: "error_absent" as const, timeoutMs: 5000 } };
-    await expect(support.stepExecutors.disable_skill?.(step)).resolves.toBe(true);
-    // durable candidate status is UNTOUCHED (no promotion, no clobber); only in-memory reflects disable
-    expect(durable.store.get("skill-cand")).toBe("not_installed");
-    expect(step.payload._skillStatusDurable).toBe(false);
-    expect((await memoryState.listSkillStatuses())["skill-cand"]).toBe("disabled");
+  it("regenerate rollback restores the plan-captured prior status durably (installed/not_installed), never default-enable", async () => {
+    const db = createTestDb();
+    try {
+      const repo = createFridaySkillRepository();
+      seedSkill(db, repo, "skill-x", "installed");
+      seedSkill(db, repo, "skill-c", "not_installed");
+      const support = createFridayHubAutoFixExecutionSupport({
+        registry: makeRegistryWith(["skill-x", "skill-c"]),
+        memoryState: createDurableMemoryState({ db, skillRepository: repo, nowIso: () => E3_NOW }),
+        nowIso: () => E3_NOW,
+        skillGenerator: skillGenStub,
+      });
+      const rev = (id: string, restoreStatus: string) => ({ stepId: "r-" + id, kind: "regenerate_skill" as const, target: id, payload: { revert: true, skillId: id, restoreStatus } as Record<string, unknown>, verify: { method: "skill_registry_available" as const, timeoutMs: 5000 } });
+      await expect(support.stepExecutors.regenerate_skill?.(rev("skill-x", "installed"))).resolves.toBe(true);
+      expect(tableStatus(db, repo, "skill-x")).toBe("installed"); // restored installed
+      await expect(support.stepExecutors.regenerate_skill?.(rev("skill-c", "not_installed"))).resolves.toBe(true);
+      expect(tableStatus(db, repo, "skill-c")).toBe("not_installed"); // restored candidate, NOT promoted
+    } finally {
+      db.close();
+    }
   });
 
-  it("regenerate rollback restores the plan-captured prior status (installed / not_installed), never default-enable", async () => {
-    // prior was installed → rollback restores installed
-    const dInstalled = makeDurableStore({ "skill-x": "installed" });
-    const s1 = createFridayHubAutoFixExecutionSupport({
-      registry: makeRegistryWith(["skill-x"]), memoryState: createStubMemoryState(),
-      nowIso: () => "2026-03-13T10:00:00.000Z", skillGenerator: skillGenStub, ...dInstalled,
-    });
-    const revInstalled = { stepId: "r1", kind: "regenerate_skill" as const, target: "skill-x", payload: { revert: true, skillId: "skill-x", restoreStatus: "installed" } as Record<string, unknown>, verify: { method: "skill_registry_available" as const, timeoutMs: 5000 } };
-    await expect(s1.stepExecutors.regenerate_skill?.(revInstalled)).resolves.toBe(true);
-    await expect(s1.stepVerifiers.regenerate_skill?.(revInstalled)).resolves.toBe(true);
-    expect(dInstalled.store.get("skill-x")).toBe("installed");
-
-    // prior was not_installed (candidate) → rollback restores not_installed (NO promotion)
-    const dCand = makeDurableStore({ "skill-c": "not_installed" });
-    const s2 = createFridayHubAutoFixExecutionSupport({
-      registry: makeRegistryWith(["skill-c"]), memoryState: createStubMemoryState(),
-      nowIso: () => "2026-03-13T10:00:00.000Z", skillGenerator: skillGenStub, ...dCand,
-    });
-    const revCand = { stepId: "r2", kind: "regenerate_skill" as const, target: "skill-c", payload: { revert: true, skillId: "skill-c", restoreStatus: "not_installed" } as Record<string, unknown>, verify: { method: "skill_registry_available" as const, timeoutMs: 5000 } };
-    await expect(s2.stepExecutors.regenerate_skill?.(revCand)).resolves.toBe(true);
-    expect(dCand.store.get("skill-c")).toBe("not_installed");
-  });
-
-  it("false-positive regenerate rollback does NOT re-enable a skill that was already disabled", async () => {
-    const durable = makeDurableStore({ "skill-x": "disabled" }); // prior captured status = disabled
-    const support = createFridayHubAutoFixExecutionSupport({
-      registry: makeRegistryWith(["skill-x"]), memoryState: createStubMemoryState(),
-      nowIso: () => "2026-03-13T10:00:00.000Z", skillGenerator: skillGenStub, ...durable,
-    });
-    const step = { stepId: "r3", kind: "regenerate_skill" as const, target: "skill-x", payload: { revert: true, skillId: "skill-x", restoreStatus: "disabled" } as Record<string, unknown>, verify: { method: "skill_registry_available" as const, timeoutMs: 5000 } };
-    await expect(support.stepExecutors.regenerate_skill?.(step)).resolves.toBe(true);
-    expect(durable.store.get("skill-x")).toBe("disabled"); // stayed disabled, not enabled
-    await expect(support.stepVerifiers.regenerate_skill?.(step)).resolves.toBe(true);
+  it("false-positive regenerate rollback keeps an already-disabled skill disabled (durable), never re-enabled", async () => {
+    const db = createTestDb();
+    try {
+      const repo = createFridaySkillRepository();
+      seedSkill(db, repo, "skill-x", "installed");
+      const support = createFridayHubAutoFixExecutionSupport({
+        registry: makeRegistryWith(["skill-x"]),
+        memoryState: createDurableMemoryState({ db, skillRepository: repo, nowIso: () => E3_NOW }),
+        nowIso: () => E3_NOW,
+        skillGenerator: skillGenStub,
+      });
+      // captured prior status was 'disabled' (a false-positive regenerate on an already-disabled skill)
+      const step = { stepId: "r-fp", kind: "regenerate_skill" as const, target: "skill-x", payload: { revert: true, skillId: "skill-x", restoreStatus: "disabled" } as Record<string, unknown>, verify: { method: "skill_registry_available" as const, timeoutMs: 5000 } };
+      await expect(support.stepExecutors.regenerate_skill?.(step)).resolves.toBe(true);
+      expect(tableStatus(db, repo, "skill-x")).toBe("disabled"); // stayed disabled, not re-enabled
+    } finally {
+      db.close();
+    }
   });
 
   it("regenerate rollback with no captured restoreStatus falls back to the safe 'disabled' (never enable)", async () => {
-    const durable = makeDurableStore({ "skill-x": "installed" });
-    const support = createFridayHubAutoFixExecutionSupport({
-      registry: makeRegistryWith(["skill-x"]), memoryState: createStubMemoryState(),
-      nowIso: () => "2026-03-13T10:00:00.000Z", skillGenerator: skillGenStub, ...durable,
-    });
-    const step = { stepId: "r4", kind: "regenerate_skill" as const, target: "skill-x", payload: { revert: true, skillId: "skill-x" } as Record<string, unknown>, verify: { method: "skill_registry_available" as const, timeoutMs: 5000 } };
-    await expect(support.stepExecutors.regenerate_skill?.(step)).resolves.toBe(true);
-    expect(durable.store.get("skill-x")).toBe("disabled"); // safe default, not enabled
+    const db = createTestDb();
+    try {
+      const repo = createFridaySkillRepository();
+      seedSkill(db, repo, "skill-x", "installed");
+      const support = createFridayHubAutoFixExecutionSupport({
+        registry: makeRegistryWith(["skill-x"]),
+        memoryState: createDurableMemoryState({ db, skillRepository: repo, nowIso: () => E3_NOW }),
+        nowIso: () => E3_NOW,
+        skillGenerator: skillGenStub,
+      });
+      const step = { stepId: "r-none", kind: "regenerate_skill" as const, target: "skill-x", payload: { revert: true, skillId: "skill-x" } as Record<string, unknown>, verify: { method: "skill_registry_available" as const, timeoutMs: 5000 } };
+      await expect(support.stepExecutors.regenerate_skill?.(step)).resolves.toBe(true);
+      expect(tableStatus(db, repo, "skill-x")).toBe("disabled"); // safe default, not enabled
+    } finally {
+      db.close();
+    }
   });
 
   it("Phase 14.5B module_28b: apply_config_patch is fail-closed when no real patch payload is provided", async () => {


### PR DESCRIPTION
## Summary

PR #409 (this session) re-implemented self-heal **E3 durable persistence** in parallel with the already-merged **#406** (`createDurableMemoryState`), producing a redundant second persist path. This cleanup removes the duplication and keeps only #409's genuine increment.

**Removed (redundant with #406):**
- `persistSkillLifecycleStatus` / `getPersistedSkillLifecycleStatus` deps on `createFridayHubAutoFixExecutionSupport`
- the `resolveSkillLifecycleStatus` helper
- the **ineffective** disable "only-when-installed" guard (#406's wrapper persists regardless)
- the bootstrap wiring of those deps

Durable persistence is now **solely** #406's `createDurableMemoryState.updateSkillStatus` wrapper — a **single** durable write path.

**Kept (the genuine increment):**
- The `regenerate_skill` **rollback restores the plan-captured prior status** (`restoreStatus`) instead of a blind `disabled` — written through the same wrapper, so it persists durably with **no second path**. Never default-enables; never promotes a `not_installed` candidate.
- The plan-service `restoreStatus` capture (plan-build time) + runtime threading — unchanged.

## Proof (lint 0 errors)

`hub-helpers.test.ts` integration tests over the real `createDurableMemoryState` (test DB + `createFridaySkillRepository`):
1. **#406 persistence works**: self-heal disable → durable `skills.status = disabled` (single path; payload has **no** `_skillStatusDurable` flag → no second write).
2. **regenerate rollback restores prior durably**: `installed`→`installed`, `not_installed`→`not_installed` (**no promotion**).
3. **no wrong promotion / false-positive**: rollback of a regenerate on an already-`disabled` skill stays `disabled`; no-capture falls back to safe `disabled`.

Regression: #406 `friday-durable-memory-state.test.ts` still green (persistence intact); `friday-auto-fix-plan-service.test.ts` `restoreStatus`-capture test green; auto-fix execution/rollback suites green. `build:api`, secret scans, detect-secrets baseline, `git diff --check` clean.

## Scope

3 files (hub-helpers, bootstrap, hub-helpers test). No migration, no new planner rollback, no change to #406, no unrelated lifecycle change. No npm publish/tag/release/secrets/settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)