### PR TITLE
fix(ui): truthful Desktop Recording copy — stop naming a non-existent Friday Recorder app (audit E4)

### DIFF
--- a/test/unit/ui/skill-import-desktop-recording-copy-truth.test.ts
+++ b/test/unit/ui/skill-import-desktop-recording-copy-truth.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "..", "..", "..");
+const wizardSrc = readFileSync(
+  resolve(repoRoot, "ui/src/components/core/skill-import-wizard.tsx"),
+  "utf8",
+);
+
+// Audit E4 (capability-truthfulness): the skill-import "Desktop Recording" wizard must NOT tell
+// users to install/launch a "Friday Recorder" app — no such app ships (apps/macos/FridayCompanion
+// is a notification/hotkey companion, not a recorder). The copy must honestly state that desktop
+// screen-recording capture is not bundled with Friday. This is a doc/copy truth-label only.
+describe("skill-import 'Desktop Recording' copy truthfulness (audit E4)", () => {
+  it("does not name a non-existent 'Friday Recorder' app or instruct installing/launching one", () => {
+    expect(wizardSrc).not.toContain("Friday Recorder");
+    expect(wizardSrc).not.toContain("install and launch");
+    expect(wizardSrc).not.toContain("安装并启动");
+  });
+
+  it("honestly states desktop screen recording is not bundled (en + zh)", () => {
+    expect(wizardSrc).toContain("isn't bundled with Friday");
+    expect(wizardSrc).toContain("未内置桌面录屏");
+  });
+});

--- a/ui/src/components/core/skill-import-wizard.tsx
+++ b/ui/src/components/core/skill-import-wizard.tsx
@@ -224,8 +224,8 @@ export function SkillImportWizard({ open, onClose }: SkillImportWizardProps) {
           <p className="text-sm text-[color:var(--color-text-secondary)]">
             {localize(
               locale,
-              "桌面录制需要配套的桌面应用程序。请先安装并启动 Friday Recorder，然后在此导入录制文件。",
-              "Desktop recording requires the companion desktop app. Please install and launch Friday Recorder first, then import the recording file here.",
+              "Friday 未内置桌面录屏功能，也不提供配套录制应用。请使用任意录屏工具录制，然后导入录制文件（如支持）。",
+              "Desktop screen recording isn't bundled with Friday — no companion recorder app is shipped. Record with any screen recorder, then import the resulting recording file (where supported).",
             )}
           </p>
         ) : (


### PR DESCRIPTION
## Summary

Audit **E4** (capability-truthfulness) — the lone open non-operator truthfulness defect. The skill-import **"Desktop Recording"** wizard instructed users to "install and launch **Friday Recorder**", an app that **does not ship** (`apps/macos/FridayCompanion` is a notification/hotkey companion, not a recorder).

**Doc/copy truth-label only** — no recorder implementation, no fake app/integration, no runtime-capability / secrets / settings / release change.

- `ui/src/components/core/skill-import-wizard.tsx`: replace the false instruction (en + zh) with honest copy — desktop screen recording **isn't bundled** with Friday and no companion recorder app is shipped; record with any screen recorder, then import the resulting file (where supported).
- Adds `test/unit/ui/skill-import-desktop-recording-copy-truth.test.ts` — a source-content honesty test asserting the copy no longer contains "Friday Recorder" / "install and launch" / "安装并启动", and does state it isn't bundled (en + zh). Matches the established residual-E source-content proof style.

## Proof (lint 0 errors)

- New test: **2 pass, Type Errors none**.
- `tsc -p ui/tsconfig.json --noEmit`: clean. `npm run lint`: 0 errors. `check:secret-patterns`: clean. detect-secrets baseline: clean. `git diff --check`: clean.

## Scope

2 files (1 UI copy line-pair + 1 source-content test). No migration, no logic change, no runtime/secrets/settings/release. With this merged, audit E4 is closed (multi-tenant/media/packaging were already audited truthful).

🤖 Generated with [Claude Code](https://claude.com/claude-code)