### PR TITLE
fix(agent): anchor write/edit relative paths at the workspace root (read/write parity)

### DIFF
--- a/src/agent/tools/friday-agent-file-tools.ts
+++ b/src/agent/tools/friday-agent-file-tools.ts
@@ -236,7 +236,7 @@ function createWriteTool(workspaceRoot: string): FridayAgentToolDefinition {
       "Automatically creates parent directories.",
     parameters: {
       properties: {
-        path: { type: "string", description: "Path to the file to write" },
+        path: { type: "string", description: "Path to the file to write. Relative paths (e.g. \"summary.json\") resolve against the workspace root; absolute paths must stay within it." },
         content: { type: "string", description: "Content to write to the file" },
       },
       required: ["path", "content"],
@@ -248,19 +248,36 @@ function createWriteTool(workspaceRoot: string): FridayAgentToolDefinition {
       const filePath = readStringParam(args, "path", { required: true });
       const content = readStringParam(args, "content", { required: true });
 
-      // Security: validate path is within workspace
-      const pathError = validateFilePath(filePath, workspaceRoot);
+      // Anchor relative paths at the workspace root (read/write parity). `read`
+      // resolves `path.resolve(workspaceRoot, filePath)`; `write`/`edit` previously
+      // passed the raw relative path to validateFilePath and the write body, where
+      // it resolved against process.cwd() (the hub launch dir, outside the
+      // workspace). A bare name like "summary.json" was then rejected as "outside
+      // the allowed workspace root", forcing the agent to retry with an absolute
+      // path and recording a FAILED tool call. Resolve once and use the absolute
+      // target everywhere below (validation AND the dirname/basename write body —
+      // otherwise validation would pass but path.dirname("summary.json")==="."
+      // would write into the CWD, a worse silent bug).
+      if (hasTraversalSegments(filePath)) {
+        return errorResult(`Path "${filePath}" contains "." or ".." segments which are not allowed.`);
+      }
+      const resolvedTarget = path.isAbsolute(filePath)
+        ? filePath
+        : path.resolve(workspaceRoot, filePath);
+
+      // Security: validate the anchored target is within the workspace
+      const pathError = validateFilePath(resolvedTarget, workspaceRoot);
       if (pathError) {
         return errorResult(pathError);
       }
 
-      const approvalReason = getApprovalRequiredReasonForFileMutation(filePath, [content]);
+      const approvalReason = getApprovalRequiredReasonForFileMutation(resolvedTarget, [content]);
       if (approvalReason) {
         return errorResult(`Approval required before execution. ${approvalReason}`);
       }
 
       try {
-        const dir = path.dirname(filePath);
+        const dir = path.dirname(resolvedTarget);
         await fs.mkdir(dir, { recursive: true });
 
         // Post-mkdir containment re-check: resolve the directory via realpath
@@ -280,7 +297,7 @@ function createWriteTool(workspaceRoot: string): FridayAgentToolDefinition {
         }
 
         // Write via verified fd with O_NOFOLLOW to prevent final-component symlink swap
-        const safePath = path.join(resolvedDir, path.basename(filePath));
+        const safePath = path.join(resolvedDir, path.basename(resolvedTarget));
         let fd: number | null = null;
         try {
           fd = openWritableFileNoFollow(safePath, { create: true });
@@ -303,7 +320,7 @@ function createWriteTool(workspaceRoot: string): FridayAgentToolDefinition {
           }
         }
         const bytes = Buffer.byteLength(content, "utf8");
-        return textResult(`Wrote ${String(bytes)} bytes to ${filePath}`);
+        return textResult(`Wrote ${String(bytes)} bytes to ${resolvedTarget}`);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         return errorResult(`Failed to write file: ${message}`);
@@ -322,7 +339,7 @@ function createEditTool(workspaceRoot: string): FridayAgentToolDefinition {
       "(including whitespace).",
     parameters: {
       properties: {
-        path: { type: "string", description: "Path to the file to edit" },
+        path: { type: "string", description: "Path to the file to edit. Relative paths resolve against the workspace root; absolute paths must stay within it." },
         oldText: { type: "string", description: "Exact text to find and replace" },
         newText: { type: "string", description: "New text to replace the old text with" },
       },
@@ -334,8 +351,18 @@ function createEditTool(workspaceRoot: string): FridayAgentToolDefinition {
     ): Promise<FridayAgentToolResult> {
       const filePath = readStringParam(args, "path", { required: true });
 
-      // Security: validate path is within workspace
-      const pathError = validateFilePath(filePath, workspaceRoot);
+      // Anchor relative paths at the workspace root (read/write parity) — see the
+      // write tool above for why the raw relative path resolved against process.cwd()
+      // and recorded a FAILED tool call.
+      if (hasTraversalSegments(filePath)) {
+        return errorResult(`Path "${filePath}" contains "." or ".." segments which are not allowed.`);
+      }
+      const resolvedTarget = path.isAbsolute(filePath)
+        ? filePath
+        : path.resolve(workspaceRoot, filePath);
+
+      // Security: validate the anchored target is within the workspace
+      const pathError = validateFilePath(resolvedTarget, workspaceRoot);
       if (pathError) {
         return errorResult(pathError);
       }
@@ -347,7 +374,7 @@ function createEditTool(workspaceRoot: string): FridayAgentToolDefinition {
       const oldText = args.oldText;
       const newText = typeof args.newText === "string" ? args.newText : "";
 
-      const approvalReason = getApprovalRequiredReasonForFileMutation(filePath, [oldText, newText]);
+      const approvalReason = getApprovalRequiredReasonForFileMutation(resolvedTarget, [oldText, newText]);
       if (approvalReason) {
         return errorResult(`Approval required before execution. ${approvalReason}`);
       }
@@ -360,7 +387,7 @@ function createEditTool(workspaceRoot: string): FridayAgentToolDefinition {
           console.warn("[friday][file-tools] realpath-edit-root:", err instanceof Error ? err.message : String(err));
           resolvedRoot = path.resolve(workspaceRoot);
         }
-        const resolvedFile = fsSync.realpathSync(filePath);
+        const resolvedFile = fsSync.realpathSync(resolvedTarget);
         if (!isWithinBase(resolvedRoot, resolvedFile)) {
           return errorResult(`Path "${filePath}" escapes workspace root (possible symlink).`);
         }

--- a/test/unit/agent/tools/friday-agent-file-tools.test.ts
+++ b/test/unit/agent/tools/friday-agent-file-tools.test.ts
@@ -302,4 +302,83 @@ describe("FridayAgentFileTools", () => {
     expect(tools).toHaveLength(3);
     expect(tools.map((t) => t.name)).toEqual(["read", "write", "edit"]);
   });
+
+  // ─── Relative paths anchor at the workspace root (read/write parity) ───
+  // Regression for the write/edit bug where a bare relative path (e.g.
+  // "summary.json") resolved against process.cwd() (outside the workspace) and
+  // was rejected as "outside the allowed workspace root", forcing a failed retry.
+  // `read` always anchored at the workspace root; `write`/`edit` did not.
+  describe("relative paths anchor at the workspace root", () => {
+    let cwdDir: string;
+    let origCwd: string;
+
+    beforeEach(() => {
+      origCwd = process.cwd();
+      // CWD deliberately set to a dir that is NOT the workspace root.
+      cwdDir = fs.mkdtempSync(path.join(os.tmpdir(), "friday-file-tools-cwd-"));
+      process.chdir(cwdDir);
+    });
+
+    afterEach(() => {
+      process.chdir(origCwd);
+      fs.rmSync(cwdDir, { recursive: true, force: true });
+    });
+
+    it("write resolves a bare relative path against the workspace root, not the CWD", async () => {
+      const result = await writeTool.execute(
+        { path: "summary.json", content: '{"count":12,"sum":216,"max":42}' },
+        signal(),
+      );
+
+      expect(result.isError).toBeUndefined();
+      // lands in the workspace root ...
+      expect(fs.existsSync(path.join(tmpDir, "summary.json"))).toBe(true);
+      expect(fs.readFileSync(path.join(tmpDir, "summary.json"), "utf8")).toBe(
+        '{"count":12,"sum":216,"max":42}',
+      );
+      // ... and NOT in the process CWD
+      expect(fs.existsSync(path.join(cwdDir, "summary.json"))).toBe(false);
+    });
+
+    it("write resolves a relative subdir path against the workspace root", async () => {
+      const result = await writeTool.execute(
+        { path: "out/data.json", content: "x" },
+        signal(),
+      );
+
+      expect(result.isError).toBeUndefined();
+      expect(fs.existsSync(path.join(tmpDir, "out", "data.json"))).toBe(true);
+      expect(fs.existsSync(path.join(cwdDir, "out", "data.json"))).toBe(false);
+    });
+
+    it("edit resolves a relative path against the workspace root", async () => {
+      fs.writeFileSync(path.join(tmpDir, "note.txt"), "hello world");
+
+      const result = await editTool.execute(
+        { path: "note.txt", oldText: "world", newText: "friday" },
+        signal(),
+      );
+
+      expect(result.isError).toBeUndefined();
+      expect(fs.readFileSync(path.join(tmpDir, "note.txt"), "utf8")).toBe("hello friday");
+    });
+
+    it("still rejects absolute paths outside the workspace root", async () => {
+      const outside = path.join(cwdDir, "escape.json");
+      const result = await writeTool.execute({ path: outside, content: "x" }, signal());
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("outside the allowed workspace root");
+      expect(fs.existsSync(outside)).toBe(false);
+    });
+
+    it("still rejects '..' traversal segments in a relative path", async () => {
+      const result = await writeTool.execute({ path: "../escape.json", content: "x" }, signal());
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain('"." or ".." segments');
+      expect(fs.existsSync(path.join(cwdDir, "escape.json"))).toBe(false);
+      expect(fs.existsSync(path.join(path.dirname(tmpDir), "escape.json"))).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
## What

The `read` agent tool resolves a bare/relative path against the **workspace root** (`path.resolve(workspaceRoot, filePath)`, `friday-agent-file-tools.ts:173`). But `write` and `edit` passed the **raw relative path** straight to `validateFilePath` (:252/:338) and the write body (`path.dirname(filePath)` :263, `realpathSync(filePath)` :363), where it resolved against **`process.cwd()`** — the hub's launch directory, which is *not* the workspace root (there is no `process.chdir` anywhere in `src/**`).

So a natural `write({path:"summary.json"})` resolved to `<cwd>/summary.json`, failed the containment check as **"outside the allowed workspace root"**, and the agent had to retry with an absolute path. Each such failure is recorded as a **failed tool call**, which downgrades the run's evidence receipt from `verified_receipt` to **`blocked_or_failed`** (`evidence-receipt.ts` classifyReceipt requires `countToolCalls(...).failed === 0`, with no recovery credit) — even when the task ultimately produced the correct artifact.

## Root cause (how it was found)

Empirically reproduced on a live isolated DeepSeek run under the canonical gate: `write({path:"summary.json"})` → `isError:true` `Path "summary.json" is outside the allowed workspace root "/tmp/.../workspace"`, then a successful absolute-path retry. The downstream `exec` failure seen in a CSV task (`echo $PWD && ls -la` → shell-meta rejection) was the agent *debugging this very path confusion* — fixing the write path removes the trigger.

## Fix

In `createWriteTool`/`createEditTool`: resolve relative paths against `workspaceRoot` **once** and use the absolute target **everywhere** — validation, the approval-reason check, and the `dirname`/`basename`/`realpathSync` write body. (Resolving only at validation would be a worse *silent* bug: validation passes but `path.dirname("summary.json") === "."` mkdir/writes into the CWD.) The raw-input `.`/`..` traversal rejection is preserved; absolute-outside and symlink/TOCTOU/O_NOFOLLOW protections are unchanged. `read` is untouched (it already anchors correctly). Also documents workspace-root anchoring in the `write`/`edit` `path` descriptions.

## Proof

`test/unit/agent/tools/friday-agent-file-tools.test.ts` — new "relative paths anchor at the workspace root" block runs with `process.chdir` to a dir that is **not** the workspace root and asserts write/edit of a bare relative name land in the workspace root (and **not** the CWD), plus regressions that absolute-outside and `..` traversal are still rejected.

- **Fail-before:** 3/5 new tests fail against the pre-fix tool.
- **Pass-after:** full 28-test file-tools suite green.
- **Blast radius:** `agent/tools` + `agent/runtime` suites (**1275 tests**) and file-tool adversarial suites (**84 tests**) green; `typecheck:src` clean; `eslint` **0 errors**; `git diff --check` clean.

Branch cut from current `origin/main`. This unblocks a clean `verified_receipt` for agent runs whose only "failure" was the relative-path write retry.