### PR TITLE
docs(release-truth): sync 1.0.3 source-candidate truth through #412 + epic-6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,30 @@ and this project follows Semantic Versioning.
   source repair (PR #377), C3/C4 live-provider routing proof (PR #378), and C4.5
   direct synthetic real-user intelligence proof (PR #379). These are GitHub-main
   closures, not npm `1.0.2` package truth.
+- Source truth after PR #379 further includes the strict-repair closure batch on
+  GitHub `main` through PR #412 (final `main` SHA `f1755825`): the B6
+  dangerous-command shell-risk gate was hardened across four bypass vectors
+  (PR #396, #397, #399, #402); workflow completion-truth was closed for the
+  deterministic core — declared side-effect nodes are labeled `proof_pending`,
+  the run-level workflow-completion verifier refuses unverified run evidence, and
+  the one concrete filesystem-write side-effect class is positively upgraded to
+  `verified` by an independent on-disk re-read (PR #398, #407) — while the
+  non-filesystem side-effect classes (send / connect / capture / execute /
+  memory.write) remain `proof_pending` by design with no positive verified path
+  yet; receipt / idempotency / usage-ledger truth was closed (PR #401, #403,
+  #408); truth-label defects were corrected (PR #405, #406, #411); and the
+  `write`/`edit` agent tools were fixed to anchor relative paths at the workspace
+  root for read/write parity (PR #412). These are deterministic GitHub-main
+  closures, exact-`main` proven via same-SHA CI + Real Green Gate; they are not
+  npm `1.0.2` package truth and add no published-release claim.
+- An isolated, operator-authorized live competence proof exercised the local
+  read → DeepSeek reasoning → canonical approval-gated write → oracle-verified
+  artifact loop end-to-end on the fixed build, DeepSeek-only (no fallback
+  provider), through the real canonical approval gate, and produced a clean
+  `verified_receipt`. This is a single bounded local proof. It does not claim
+  100% all-mechanisms-live, all-integrations-live, latest-SHA live
+  external-channel delivery, or broad live-provider quality; those remain
+  deferred operator-gated proofs.
 - C2.4 remains `source_closed_live_pending` / `proof_pending` until the deferred
   exact-SHA Telegram natural-trigger stress window passes. C4.5 live external-
   channel proof, npm publish, tag, and GitHub release remain deferred operator

--- a/docs/open-source-release-review.md
+++ b/docs/open-source-release-review.md
@@ -1,6 +1,6 @@
 # Open Source Release Review
 
-Last reviewed: 2026-05-26
+Last reviewed: 2026-05-29
 
 ## Verdict
 
@@ -34,7 +34,8 @@ automatic access to systems the user has not configured.
 
 - Repository license: MIT.
 - npm package: `@thesongzhu/friday`.
-- Current published npm version: `1.0.2` (R6 published 2026-05-26T19:45Z). Repo `package.json` version: `1.0.2`. This public-install-audit hotfix replaced `@larksuiteoapi/node-sdk` — which pulled `axios ~1.13.3` with three HIGH-severity findings in the post-`1.0.1` isolated `npm audit --omit=dev` — with Friday's native Lark WebSocket client under `src/channels/lark/internal/`. Same-SHA Real Green Gate proof and Discord / Telegram / Lark+Feishu trusted-inbound artifacts passed on the `1.0.2` release SHA before publish.
+- Current published npm version: `1.0.2` (R6 published 2026-05-26T19:45Z); the npm registry latest remains `1.0.2`. Repo `package.json` version: `1.0.3` — a staged, unpublished package candidate for a future operator-authorized release, not a published version. The `1.0.2` publish was a public-install-audit hotfix that replaced `@larksuiteoapi/node-sdk` — which pulled `axios ~1.13.3` with three HIGH-severity findings in the post-`1.0.1` isolated `npm audit --omit=dev` — with Friday's native Lark WebSocket client under `src/channels/lark/internal/`. Same-SHA Real Green Gate proof and Discord / Telegram / Lark+Feishu trusted-inbound artifacts passed on the `1.0.2` release SHA before publish.
+- Source truth after `1.0.2` further includes a strict-repair closure batch on GitHub `main` through PR #412 (final SHA `f1755825`) — B6 shell-risk gate, workflow completion-truth (deterministic core / filesystem-write; other side-effect classes remain `proof_pending`), receipt/idempotency/usage-ledger truth, and truth-label corrections — plus an isolated, operator-authorized local DeepSeek competence proof with a clean `verified_receipt`. These are deterministic GitHub-main closures staged as the `1.0.3` candidate, not published-release claims; see `docs/public-v1-local-candidate.md`. A same-SHA R5 live proof on the final release SHA is still required before any `1.0.3` publish.
 - The unscoped `friday` npm package is unrelated.
 
 README, package metadata, GitHub metadata, and release docs should all use the

--- a/docs/public-v1-local-candidate.md
+++ b/docs/public-v1-local-candidate.md
@@ -1,6 +1,6 @@
 # Friday Public V1 Local Candidate
 
-Last reviewed: 2026-05-28
+Last reviewed: 2026-05-29
 
 This document summarizes the public v1 local candidate claim for the published
 `1.0.x` local-candidate line. The current public npm/source release is `1.0.2`.
@@ -120,9 +120,10 @@ The dogfood gate for `1.0.1` closed as `dogfood_partial_pass` with weighted UX
 score 7.78/10 (below the 8.0 `dogfood_pass` threshold). The published npm
 `1.0.2` package still carries the original proof-pending headlines.
 GitHub-visible source after `1.0.2` has narrowed several of them through PR
-#379 and is staged as an unpublished `1.0.3` package candidate, but those source
-changes are **not** npm package truth until a future authorized publish. Current
-source truth:
+#379 and the subsequent strict-repair closure batch (through PR #412) and is
+staged as an unpublished `1.0.3` package candidate, but those source changes are
+**not** npm package truth until a future authorized publish. Current source
+truth:
 
 1. Autonomous self-repair execute → rollback: deterministic skill-drift and
    route rollback receipt mechanics are closed on GitHub main by PR #351 and
@@ -168,6 +169,34 @@ Additional source-only closure after the nine dogfood headlines:
 - C4.5 direct synthetic real-user intelligence proof is closed on GitHub main
   by PR #379. C4.5 live external-channel proof remains deferred with the C2.4
   Telegram live stress window.
+
+Strict-repair closure batch on GitHub main (through PR #412, final source SHA
+`f1755825`), exact-`main` proven via same-SHA Real Green Gate:
+
+- B6 dangerous-command shell-risk gate hardened across four bypass vectors (PR
+  #396, #397, #399, #402).
+- Workflow completion-truth closed for the deterministic core: declared
+  side-effect nodes are labeled `proof_pending`, the run-level
+  workflow-completion verifier refuses unverified run evidence, and the
+  filesystem-write side-effect class is positively upgraded to `verified` by an
+  independent on-disk re-read (PR #398, #407). The send / connect / capture /
+  execute / memory.write side-effect classes remain `proof_pending` by design
+  with no positive verified path yet.
+- Receipt / idempotency / usage-ledger truth closed (PR #401, #403, #408).
+- Truth-label defects closed (PR #405, #406, #411).
+- `write`/`edit` agent tools fixed to anchor relative paths at the workspace root
+  for read/write parity (PR #412).
+
+These are deterministic GitHub-main closures and are not npm package truth until
+a future authorized publish.
+
+An isolated, operator-authorized live competence proof additionally exercised the
+local read → DeepSeek reasoning → canonical approval-gated write → oracle-verified
+artifact loop end-to-end on the fixed build, DeepSeek-only, through the real
+canonical approval gate, producing a clean `verified_receipt`. This is a single
+bounded local proof; it does not claim 100% all-mechanisms-live,
+all-integrations-live, latest-SHA live external-channel delivery, or broad
+live-provider quality, which remain deferred operator-gated proofs.
 
 These are truth-labeled, not silent passes. None contradict the safe claim
 above.


### PR DESCRIPTION
## What

Docs-only release-truth sync so the public docs reflect the current GitHub `main`
**1.0.3 source candidate** (`f1755825`). No code, tests, runtime, API, generated
code, branch protection, GitHub state, credentials, release-proof standards, or
governance semantics change.

### Changes
- **CHANGELOG.md** `[Unreleased]`: record the strict-repair closure batch after
  PR #379 — B6 shell-risk gate (#396/#397/#399/#402), workflow completion-truth
  (#398/#407), receipt/idempotency/usage-ledger truth (#401/#403/#408),
  truth-label corrections (#405/#406/#411), and the write/edit workspace-root fix
  (#412) — plus the isolated operator-authorized local DeepSeek competence proof
  (clean `verified_receipt`).
- **docs/public-v1-local-candidate.md**: add the strict-repair closure batch and
  the epic-6 local proof to the post-dogfood closure section; extend the
  source-narrowing line through #412; bump review date.
- **docs/open-source-release-review.md**: correct the stale repo version
  (`package.json` is `1.0.3`, a staged/unpublished candidate — npm latest remains
  `1.0.2`); add a closure pointer; bump review date.

## Truthful framing / what is NOT claimed
- npm registry latest **remains `1.0.2`**; `1.0.3` is an **unpublished** candidate.
- Workflow completion-truth is closed for the **deterministic core / filesystem-write**
  only; **send / connect / capture / execute / memory.write** side-effect classes
  remain **`proof_pending`** by design.
- The epic-6 proof is a **single bounded local** read → DeepSeek reasoning →
  canonical approval-gated write → oracle-verified-artifact loop. It does **not**
  claim 100% all-mechanisms-live, all-integrations-live, latest-SHA live
  external-channel delivery, or broad live-provider quality.
- A **same-SHA R5 live proof** on the final release SHA is still required before
  any `1.0.3` publish.
- No desktop / Homebrew / notarized-macOS / mobile distribution claim.
- **No publish, tag, GitHub release, or `RELEASE_PUBLISH_NPM` change** is included.

## Local validation
- `npm run check:public-source-hygiene` → **passed**
- `npm run check:secret-patterns` → **passed** (no key-shaped secrets)
- `npm run audit:release-truth` → exit 0, verdict `shipable with explicit de-scope`
  (auditor unauthenticated; read-only)
- `npm run release:check` → run against a local build

🤖 Generated with [Claude Code](https://claude.com/claude-code)
