### PR TITLE
fix(ops): authenticate phase24 trusted-inbound listeners before reading the session API

### DIFF
--- a/scripts/ops/lib/phase24-local-auth.mjs
+++ b/scripts/ops/lib/phase24-local-auth.mjs
@@ -1,0 +1,77 @@
+// Phase24 trusted-inbound listeners boot a DISPOSABLE in-process Friday hub and read
+// its session API to verify the inbound user-message mirror. The session read endpoints
+// (`sessions.list` / `sessions.messages.list`) require a bound owner/session/channel
+// principal (error `OWNER_SESSION_CHANNEL_PRINCIPAL_REQUIRED`) — a security boundary we
+// MUST NOT weaken or bypass. This helper authenticates as a legitimate local principal
+// via the standard bootstrap-local-passphrase + login flow and returns a short-lived
+// Bearer token for the disposable instance.
+//
+// SECURITY: the returned token must NEVER be logged or written into a proof artifact.
+// Callers keep it in a local variable and pass it only as the Authorization header.
+
+const DEFAULT_LOCAL_PASSPHRASE = "phase24-trusted-inbound-proof-local-passphrase";
+
+async function readJsonBody(response) {
+  if (!response) return null;
+  const text = await response.text().catch(() => "");
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function unwrapEnvelope(body) {
+  if (body && typeof body === "object" && body.ok === true && Object.hasOwn(body, "data")) {
+    return body.data;
+  }
+  return body;
+}
+
+/**
+ * Acquire a Bearer access token for the disposable listener hub via the standard
+ * bootstrap-local-passphrase + login flow. Throws a descriptive error if no token is
+ * issued, so the listener records an honest blocker instead of silently falling back to
+ * an (now-rejected) authless read. NEVER logs the token.
+ *
+ * @param {string} baseUrl - e.g. http://127.0.0.1:<port>
+ * @param {{ passphrase?: string }} [options]
+ * @returns {Promise<string>} the Bearer access token
+ */
+export async function acquireLocalBearerToken(baseUrl, options = {}) {
+  const passphrase = options.passphrase
+    ?? (process.env.FRIDAY_PHASE24_LOCAL_PASSPHRASE?.trim() || DEFAULT_LOCAL_PASSPHRASE);
+
+  const statusBody = unwrapEnvelope(
+    await readJsonBody(await fetch(`${baseUrl}/v1/auth/bootstrap/status`).catch(() => null)),
+  );
+  const bootstrapRequired = Boolean(
+    statusBody && typeof statusBody === "object" && statusBody.bootstrapRequired,
+  );
+  if (bootstrapRequired) {
+    await fetch(`${baseUrl}/v1/auth/bootstrap/local-passphrase`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ passphrase }),
+    }).catch(() => undefined);
+  }
+
+  const loginBody = unwrapEnvelope(
+    await readJsonBody(await fetch(`${baseUrl}/v1/auth/login`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ localPassphrase: passphrase }),
+    }).catch(() => null)),
+  );
+
+  const token = loginBody && typeof loginBody === "object" && typeof loginBody.accessToken === "string"
+    ? loginBody.accessToken
+    : null;
+  if (!token) {
+    throw new Error(
+      "phase24 local auth failed: /v1/auth/login did not issue an accessToken via the bootstrap-local-passphrase + login flow.",
+    );
+  }
+  return token;
+}

--- a/scripts/ops/phase24b-discord-trusted-inbound-listener.mjs
+++ b/scripts/ops/phase24b-discord-trusted-inbound-listener.mjs
@@ -17,6 +17,7 @@ import {
   containsTokenMaterial as containsTokenMaterialShared,
   scrub as scrubShared,
 } from "./lib/token-redaction.mjs";
+import { acquireLocalBearerToken } from "./lib/phase24-local-auth.mjs";
 
 const PROBE_BODY_TEXT = "help me clean up old files in my workspace; ask me before doing anything";
 const DISCORD_REDACTION_LABELS = Object.freeze({
@@ -92,8 +93,20 @@ function safeError(error, token) {
   return scrub(raw, token);
 }
 
+// Bearer token for the disposable listener hub, set after bootstrap-local-passphrase +
+// login. Session/run read endpoints require a bound principal
+// (OWNER_SESSION_CHANNEL_PRINCIPAL_REQUIRED); this token is the legitimate principal.
+// SECURITY: never logged, never written to the proof artifact.
+let listenerBearerToken = null;
+
 function authlessJsonHeaders() {
   return { "Content-Type": "application/json" };
+}
+
+function authedJsonHeaders() {
+  return listenerBearerToken
+    ? { "Content-Type": "application/json", Authorization: `Bearer ${listenerBearerToken}` }
+    : { "Content-Type": "application/json" };
 }
 
 function findFreePort() {
@@ -120,7 +133,7 @@ function delay(ms) {
 async function apiFetch(baseUrl, method, pathname, body) {
   const response = await fetch(`${baseUrl}${pathname}`, {
     method,
-    headers: authlessJsonHeaders(),
+    headers: authedJsonHeaders(),
     ...(body === undefined ? {} : { body: JSON.stringify(body) }),
   });
   const text = await response.text();
@@ -579,6 +592,12 @@ async function main() {
     });
     await server.listen();
     const baseUrl = `http://127.0.0.1:${port}`;
+
+    // Session/run read endpoints require a bound principal
+    // (OWNER_SESSION_CHANNEL_PRINCIPAL_REQUIRED). Authenticate as a legitimate local
+    // principal via the standard bootstrap-local-passphrase + login flow. The token is
+    // kept local and is never logged or written to the proof artifact.
+    listenerBearerToken = await acquireLocalBearerToken(baseUrl);
 
     await writeReport(report, config.botToken);
 

--- a/scripts/ops/phase24c-telegram-trusted-inbound-listener.mjs
+++ b/scripts/ops/phase24c-telegram-trusted-inbound-listener.mjs
@@ -18,6 +18,7 @@ import {
   containsTokenMaterial as containsTokenMaterialShared,
   scrub as scrubShared,
 } from "./lib/token-redaction.mjs";
+import { acquireLocalBearerToken } from "./lib/phase24-local-auth.mjs";
 
 const PROBE_BODY_TEXT = "help me clean up old files in my workspace; ask me before doing anything";
 const TELEGRAM_REDACTION_LABELS = Object.freeze({
@@ -81,8 +82,20 @@ function safeError(error, token) {
   return scrub(raw, token);
 }
 
+// Bearer token for the disposable listener hub, set after bootstrap-local-passphrase +
+// login. Session/run read endpoints require a bound principal
+// (OWNER_SESSION_CHANNEL_PRINCIPAL_REQUIRED); this token is the legitimate principal.
+// SECURITY: never logged, never written to the proof artifact.
+let listenerBearerToken = null;
+
 function authlessJsonHeaders() {
   return { "Content-Type": "application/json" };
+}
+
+function authedJsonHeaders() {
+  return listenerBearerToken
+    ? { "Content-Type": "application/json", Authorization: `Bearer ${listenerBearerToken}` }
+    : { "Content-Type": "application/json" };
 }
 
 function findFreePort() {
@@ -119,7 +132,7 @@ function withTimeout(promise, ms, label) {
 async function apiFetch(baseUrl, method, pathname, body) {
   const response = await fetch(`${baseUrl}${pathname}`, {
     method,
-    headers: authlessJsonHeaders(),
+    headers: authedJsonHeaders(),
     ...(body === undefined ? {} : { body: JSON.stringify(body) }),
   });
   const text = await response.text();
@@ -587,6 +600,12 @@ async function main() {
     });
     await server.listen();
     const baseUrl = `http://127.0.0.1:${port}`;
+
+    // Session/run read endpoints require a bound principal
+    // (OWNER_SESSION_CHANNEL_PRINCIPAL_REQUIRED). Authenticate as a legitimate local
+    // principal via the standard bootstrap-local-passphrase + login flow. The token is
+    // kept local and is never logged or written to the proof artifact.
+    listenerBearerToken = await acquireLocalBearerToken(baseUrl);
 
     await writeReport(report, config.botToken);
 

--- a/scripts/ops/phase24d-lark-feishu-trusted-inbound-listener.mjs
+++ b/scripts/ops/phase24d-lark-feishu-trusted-inbound-listener.mjs
@@ -14,6 +14,7 @@ import {
   containsTokenMaterial as containsTokenMaterialShared,
   scrub as scrubShared,
 } from "./lib/token-redaction.mjs";
+import { acquireLocalBearerToken } from "./lib/phase24-local-auth.mjs";
 
 const PROBE_BODY_TEXT = "help me clean up old files in my workspace; ask me before doing anything";
 const DEFAULT_TIMEOUT_MS = 8 * 60 * 1000;
@@ -122,8 +123,20 @@ function safeError(error, token) {
   return scrub(raw, token);
 }
 
+// Bearer token for the disposable listener hub, set after bootstrap-local-passphrase +
+// login. Session/run read endpoints require a bound principal
+// (OWNER_SESSION_CHANNEL_PRINCIPAL_REQUIRED); this token is the legitimate principal.
+// SECURITY: never logged, never written to the proof artifact.
+let listenerBearerToken = null;
+
 function authlessJsonHeaders() {
   return { "Content-Type": "application/json" };
+}
+
+function authedJsonHeaders() {
+  return listenerBearerToken
+    ? { "Content-Type": "application/json", Authorization: `Bearer ${listenerBearerToken}` }
+    : { "Content-Type": "application/json" };
 }
 
 function findFreePort() {
@@ -164,7 +177,7 @@ function shouldForceProcessExitAfterCleanup(env = process.env) {
 async function apiFetch(baseUrl, method, pathname, body) {
   const response = await fetch(`${baseUrl}${pathname}`, {
     method,
-    headers: authlessJsonHeaders(),
+    headers: authedJsonHeaders(),
     ...(body === undefined ? {} : { body: JSON.stringify(body) }),
   });
   const text = await response.text();
@@ -687,6 +700,12 @@ async function main() {
     });
     await server.listen();
     const baseUrl = `http://127.0.0.1:${port}`;
+
+    // Session/run read endpoints require a bound principal
+    // (OWNER_SESSION_CHANNEL_PRINCIPAL_REQUIRED). Authenticate as a legitimate local
+    // principal via the standard bootstrap-local-passphrase + login flow. The token is
+    // kept local and is never logged or written to the proof artifact.
+    listenerBearerToken = await acquireLocalBearerToken(baseUrl);
 
     await writeReport(report, config.appSecret);
 

--- a/test/integration/hub/friday-phase24-trusted-inbound-session-read-auth.test.ts
+++ b/test/integration/hub/friday-phase24-trusted-inbound-session-read-auth.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import net from "node:net";
+import { createFridayHttpServer } from "#api";
+import { createFridayDiscordChannel } from "#channels";
+import { createFridayHub } from "#hub";
+import type { DiscordGatewayEvent, DiscordGatewayService } from "#channels";
+import { acquireLocalBearerToken } from "../../../scripts/ops/lib/phase24-local-auth.mjs";
+
+// Regression guard for the phase24 trusted-inbound proof harness (R5 channel proof).
+//
+// The hub writes the inbound user-message mirror correctly under
+// `channel:<brand>:<chatId>`, but the session read endpoints
+// (`sessions.list` / `sessions.messages.list`) require a bound owner/session/channel
+// principal (`OWNER_SESSION_CHANNEL_PRINCIPAL_REQUIRED`). The phase24 listeners therefore
+// MUST authenticate (via `acquireLocalBearerToken`) before reading the mirror. This test
+// proves both halves of that contract against a real hub driven by a fake gateway (no
+// real Discord / credentials / nonce):
+//   FAIL-BEFORE: an authless read is rejected with HTTP 401.
+//   PASS-AFTER:  an authenticated read returns the mirrored user message (with the
+//                nonce, sourceMessageId, and channelKind the listener verifies).
+// It does NOT weaken the auth requirement and does NOT touch the mirror producer.
+
+const CHANNEL_ID = "1476443522000486550";
+const SETUP_USER_ID = "370355408730324993";
+const BOT_USER_ID = "1507102852168814602";
+const GUILD_ID = "1476443521543180388";
+const NONCE = "phase24b-run-regression-b577f5ea";
+const PROBE_BODY = "help me clean up old files in my workspace; ask me before doing anything";
+const REQUIRED_INTENTS = (1 << 0) | (1 << 9) | (1 << 12) | (1 << 15);
+
+function findFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.listen(0, "127.0.0.1", () => {
+      const addr = srv.address();
+      if (addr && typeof addr === "object") {
+        const p = addr.port;
+        srv.close(() => resolve(p));
+      } else {
+        reject(new Error("no port"));
+      }
+    });
+  });
+}
+
+function createCapturingGateway(): DiscordGatewayService & { emit: (e: DiscordGatewayEvent) => void } {
+  let captured: ((event: DiscordGatewayEvent) => void) | null = null;
+  let connected = false;
+  return {
+    async connect(_token, _intents, onEvent, onStatusChange) {
+      captured = onEvent;
+      connected = true;
+      onStatusChange?.("connected");
+    },
+    async disconnect() {
+      connected = false;
+      captured = null;
+    },
+    isConnected() {
+      return connected;
+    },
+    emit(event: DiscordGatewayEvent) {
+      if (captured) captured(event);
+    },
+  };
+}
+
+const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe("phase24 trusted-inbound session read requires an authenticated principal", () => {
+  const cleanups: Array<() => Promise<void> | void> = [];
+  afterEach(async () => {
+    for (const c of cleanups.splice(0).reverse()) {
+      try { await c(); } catch { /* ignore */ }
+    }
+  });
+
+  it("authless read is 401; authenticated read returns the inbound user mirror", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "phase24-auth-"));
+    cleanups.push(() => fs.rmSync(stateDir, { recursive: true, force: true }));
+    process.env.FRIDAY_CHANNEL_DEBOUNCE_MS = "0";
+    process.env.FRIDAY_CHANNEL_PROGRESS_RECEIPT_DELAY_MS = "0";
+
+    const hub = await createFridayHub({
+      stateDir,
+      skillDirs: [],
+      port: 0,
+      logRequests: false,
+      channels: { enabled: false, instances: [] },
+    } as Parameters<typeof createFridayHub>[0]);
+    cleanups.push(() => hub.stop?.());
+
+    const gateway = createCapturingGateway();
+    const discordPlugin = createFridayDiscordChannel({
+      gateway,
+      rest: {
+        async sendMessage() { return { id: "stub-out-1" }; },
+        async sendTyping() { /* no-op */ },
+      },
+    });
+    await discordPlugin.init?.({
+      kind: "discord",
+      enabled: true,
+      token: "fake-token",
+      intents: REQUIRED_INTENTS,
+      botUserId: BOT_USER_ID,
+      allowedUsers: [SETUP_USER_ID],
+      allowedChannels: [CHANNEL_ID],
+      requireMention: true,
+    } as Parameters<NonNullable<typeof discordPlugin.init>>[0]);
+    hub.channelRegistry.register(discordPlugin, {
+      allowedUsers: [SETUP_USER_ID],
+      allowedChats: [CHANNEL_ID],
+    });
+    await hub.start();
+
+    const port = await findFreePort();
+    const server = createFridayHttpServer({
+      routes: hub.apiRuntime.routes,
+      wsGateway: hub.apiRuntime.wsGateway,
+      middleware: hub.apiRuntime.middleware,
+      port,
+      host: "127.0.0.1",
+      logRequests: false,
+    });
+    await server.listen();
+    cleanups.push(() => server.close?.());
+    const baseUrl = `http://127.0.0.1:${port}`;
+    const sessionKey = `channel:discord:${CHANNEL_ID}`;
+    const encoded = encodeURIComponent(sessionKey);
+
+    // Drive a synthetic trusted inbound message through the real channelMessageHandler.
+    gateway.emit({
+      op: 0,
+      t: "MESSAGE_CREATE",
+      d: {
+        id: "synthetic-msg-1",
+        channel_id: CHANNEL_ID,
+        guild_id: GUILD_ID,
+        author: { id: SETUP_USER_ID, username: "operator", bot: false },
+        content: `<@${BOT_USER_ID}> ${PROBE_BODY} ${NONCE}`,
+        timestamp: "2026-05-29T00:00:00.000Z",
+        mentions: [{ id: BOT_USER_ID }],
+      },
+    });
+
+    // ── FAIL-BEFORE: the listener's old authless read is rejected. ──
+    const authlessResp = await fetch(`${baseUrl}/v1/sessions/${encoded}/messages?limit=30`);
+    expect(authlessResp.status).toBe(401);
+    expect(await authlessResp.text()).toContain("OWNER_SESSION_CHANNEL_PRINCIPAL_REQUIRED");
+
+    // ── Authenticate exactly as the patched listeners do (shared helper). ──
+    const token = await acquireLocalBearerToken(baseUrl, { passphrase: "phase24-regression-local-passphrase" });
+    expect(typeof token).toBe("string");
+    expect(token.length).toBeGreaterThan(0);
+
+    // ── PASS-AFTER: an authenticated read returns the correctly-mirrored user message. ──
+    let mirror: Record<string, unknown> | undefined;
+    const deadline = Date.now() + 25_000;
+    while (Date.now() < deadline) {
+      const resp = await fetch(`${baseUrl}/v1/sessions/${encoded}/messages?limit=30`, {
+        headers: { Authorization: `Bearer ${token}` },
+      }).catch(() => null);
+      if (resp && resp.ok) {
+        const json: unknown = await resp.json().catch(() => null);
+        const body = (json && typeof json === "object" && "data" in (json as Record<string, unknown>))
+          ? (json as { data: unknown }).data
+          : json;
+        const items = Array.isArray((body as { items?: unknown })?.items)
+          ? (body as { items: Array<Record<string, unknown>> }).items
+          : Array.isArray(body) ? (body as Array<Record<string, unknown>>) : [];
+        mirror = items.find((m) => {
+          const meta = (m.metadata ?? {}) as Record<string, unknown>;
+          return (
+            m.role === "user"
+            && meta.channelKind === "discord"
+            && typeof meta.sourceMessageId === "string"
+            && String(m.contentText ?? "").includes(PROBE_BODY)
+            && String(m.contentText ?? "").includes(NONCE)
+          );
+        });
+        if (mirror) break;
+      }
+      await delay(500);
+    }
+
+    expect(mirror, "authenticated read should return the inbound user mirror").toBeTruthy();
+    const meta = (mirror!.metadata ?? {}) as Record<string, unknown>;
+    expect(meta.channelKind).toBe("discord");
+    expect(meta.sourceMessageId).toBe("synthetic-msg-1");
+  }, 60_000);
+});


### PR DESCRIPTION
## What

Harness-only fix so the **R5 trusted-inbound channel proof** can read the session mirror it verifies.

## Root cause (isolated local repro)

The session read endpoints (`sessions.list` / `sessions.messages.list`) now require a bound
owner/session/channel principal (`OWNER_SESSION_CHANNEL_PRINCIPAL_REQUIRED`) — a security
boundary added after the 1.0.2 R5 proof SHA (`68de607b`). The `phase24b/c/d` trusted-inbound
listeners query those endpoints **authless**, so they get **HTTP 401** and never observe the
inbound user-message mirror, even though the hub **writes it correctly** under
`channel:<brand>:<chatId>` (verified in the DB: `role=user`, `metadata.channelKind`,
`sourceMessageId`). Reproduced locally with a real hub + a driven fake gateway (no real
channel / credentials / nonce): authless GET → 401; authenticated GET → mirror present.

## Fix (harness-only)

- New shared helper `scripts/ops/lib/phase24-local-auth.mjs` — `acquireLocalBearerToken()`
  via the standard **bootstrap-local-passphrase + login** flow.
- `phase24b/c/d` listeners authenticate after the API server is up and send
  `Authorization: Bearer` on session/run reads.
- **The Bearer token is kept in a local variable — never logged, never written to a proof
  artifact.**

### What this does NOT do
- Does **not** change the channel mirror producer (`src/` untouched).
- Does **not** weaken `OWNER_SESSION_CHANNEL_PRINCIPAL_REQUIRED` or restore authless reads.
- Listeners still verify the real mirror message + nonce + `sourceMessageId` + `channelKind`
  + expected SHA.

## Regression test
`test/integration/hub/friday-phase24-trusted-inbound-session-read-auth.test.ts` — fail-before
(authless read → 401 `OWNER_SESSION_CHANNEL_PRINCIPAL_REQUIRED`) / pass-after (authenticated
read → mirrored user message). Exercises the shared auth helper against a real hub.

## Validation
Local: regression test ✅, ESLint 0 errors ✅, typecheck ✅, `check:secret-patterns` ✅,
`check:public-source-hygiene` ✅. RGG runs on `main` post-merge (this harness change cannot
affect the product RGG lane). The same-SHA **R5** re-run (operator-sent nonces) is the final
proof and is performed on the merged `main` SHA. **No publish/tag/release/`RELEASE_PUBLISH_NPM`.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
