### PR TITLE
fix(autonomous): anchor autonomous engine file verifier to hub workspace root

### DIFF
--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -7647,6 +7647,13 @@ export async function createFridayHub(
 
     const autonomousRepo = createFridayAutonomousRepository();
     autonomousEngine = createFridayAutonomousEngine({
+      // Anchor the autonomous engine's deterministic file verifier to the same
+      // workspace root the agent write/edit tools use (createFridayAgentToolRegistry
+      // workdir above). Without this the engine fell back to process.cwd() and
+      // rejected files the agent legitimately wrote under the hub workspace as
+      // "Path is outside the autonomous workspace root", breaking autonomous
+      // file ops (self-repair, office-task writes) and the restart-resume proof.
+      workspaceRoot,
       agentRuntime: {
         executeRun: (params) =>
           agentRuntime.executeRun({


### PR DESCRIPTION
## Problem

The autonomous engine's deterministic file verifier resolves its containment root from `deps.workspaceRoot ?? process.cwd()` (`src/agent/autonomous/friday-autonomous-engine.ts:326`, enforced at `:781` via `isPathInsideRoot`). Hub bootstrap (`src/hub/friday-hub-bootstrap.ts`) never passed `workspaceRoot` into `createFridayAutonomousEngine(...)`, so the verifier silently anchored to `process.cwd()` — while the agent `write`/`edit` tools use the hub workspace root (`createFridayAgentToolRegistry({ workdir: workspaceRoot })`).

Result: files the agent legitimately wrote under the hub workspace were rejected by the verifier as **"Path is outside the autonomous workspace root"**, so autonomous file goals could never reach verified completion whenever the workspace root differs from `process.cwd()` (isolated state dirs, real deployments, the restart-resume proof).

## Fix

Pass the already-resolved hub `workspaceRoot` into the engine deps, so the verifier enforces the **same** containment root as the write/edit tools. The `isPathInsideRoot` boundary itself is unchanged — only *which* root is enforced is corrected (consistent with #412's read/write workspace-anchoring intent).

## Evidence

- **Before:** `test/e2e/live/friday-autonomous-restart.e2e.test.ts` failed on the live DeepSeek lane — write tool reported `Wrote 39 bytes ...` (success) but verification reported `exists:false, error:"Path is outside the autonomous workspace root"`. Surfaced by the local closure `release:verify:repo` backstop.
- **After:** the same test passes on the live DeepSeek lane (4 tests, planning-interruption resume reaches verified completion).
- `typecheck:src` clean; lint adds no new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)