### PR TITLE
test(deep-proof): update self-upgrade live tests for current security/lifecycle contracts

### DIFF
--- a/test/e2e/live/friday-self-upgrade-mcp-server-live.e2e.test.ts
+++ b/test/e2e/live/friday-self-upgrade-mcp-server-live.e2e.test.ts
@@ -252,6 +252,12 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)(`Friday MCP Server Self Upgrade Live (
         transport: "stdio",
         command: process.execPath,
         args: ["-e", buildStdioServerScript()],
+        // The MCP adapter fails CLOSED on tool/resource exposure (since #384):
+        // a server with no policy exposes nothing. Drive the real approved path
+        // with a least-privilege allowlist matching exactly what this proof's
+        // synthetic server advertises and the test exercises (echo tool,
+        // friday://status resource). Not allowAllTools/allowAllResources.
+        policy: { toolAllowlist: ["echo"], resourceAllowlist: ["friday://status"] },
       },
     ]);
     env = await createFridayDeepProofHubEnv({

--- a/test/e2e/live/friday-self-upgrade-plugin-live.e2e.test.ts
+++ b/test/e2e/live/friday-self-upgrade-plugin-live.e2e.test.ts
@@ -177,8 +177,12 @@ function createPluginFixture(rootDir: string, pluginId: string): string {
   fs.writeFileSync(
     path.join(distDir, "index.mjs"),
     `import fs from "node:fs";
-const activatedPath = new URL("../activated.json", import.meta.url);
-const deactivatedPath = new URL("../deactivated.json", import.meta.url);
+// Liveness markers are written OUTSIDE the install/package tree (into the parent
+// plugin root dir) so the trust-on-install fingerprint of the install dir stays
+// intact across canary -> promote loads. From dist/, "../../" resolves to the
+// parent of the install dir.
+const activatedPath = new URL("../../${pluginId}.activated.json", import.meta.url);
+const deactivatedPath = new URL("../../${pluginId}.deactivated.json", import.meta.url);
 export async function activate(context) {
   fs.writeFileSync(activatedPath, JSON.stringify({ pluginId: context.pluginId, activated: true }));
 }
@@ -333,7 +337,10 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)(`Friday Plugin Self Upgrade Live (${FR
       expect(reviewEnableRes.json.data.evidence?.rollbackPointerAvailable).toBe(true);
       expect(reviewEnableRes.json.data.evidence?.planDigest).toBeTruthy();
 
-      const activatedMarker = path.join(installPath, "activated.json");
+      // Markers live OUTSIDE the install dir (in the parent plugin root) so the
+      // trust-on-install fingerprint of the install tree is not perturbed by the
+      // activate()/deactivate() liveness writes during canary -> promote.
+      const activatedMarker = path.join(path.dirname(installPath), `${pluginId}.activated.json`);
       expect(fs.existsSync(activatedMarker)).toBe(true);
       const activatedPayload = JSON.parse(fs.readFileSync(activatedMarker, "utf8")) as { pluginId: string };
       expect(activatedPayload.pluginId).toBe(pluginId);

--- a/test/e2e/live/friday-self-upgrade-workflow-live.e2e.test.ts
+++ b/test/e2e/live/friday-self-upgrade-workflow-live.e2e.test.ts
@@ -6,6 +6,14 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { apiFetch } from "./_helpers/api.js";
 import { pollRunTerminal } from "./_helpers/workflow.js";
 import {
+  createFridayWorkflowLifecycleMutatingActionRequest,
+} from "../../../src/autonomy/services/friday-workflow-upgrade-lifecycle-service.js";
+import {
+  createFridayMutatingActionDigest,
+  signFridayCanonicalApproval,
+  type FridayCanonicalApprovalResolution,
+} from "../../../src/security/friday-mutating-action-gate.js";
+import {
   cleanupFridayDeepProofHubEnv,
   createFridayDeepProofHubEnv,
   ensureFridayDeepProofProviders,
@@ -14,6 +22,11 @@ import {
   FRIDAY_DEEP_PROOF_PROVIDER_LABEL,
   type RealHubEnv,
 } from "./_helpers/deep-proof-env.js";
+
+const WORKFLOW_LIFECYCLE_PLAN_DIGEST = "workflow-live-proof-plan";
+const WORKFLOW_LIFECYCLE_SIGNING_MATERIAL =
+  "workflow-live-proof-signing-material"; // pragma: allowlist secret
+const LOCAL_LIVE_PRINCIPAL_ID = "admin-001";
 
 interface WorkflowCreateEnvelope {
   ok: boolean;
@@ -194,6 +207,46 @@ async function getRuntimeVersion(env: RealHubEnv): Promise<string> {
   expect(response.status).toBe(200);
   expect(response.json.ok).toBe(true);
   return response.json.data.version;
+}
+
+function makeWorkflowLifecycleApproval(input: {
+  action: "shadow" | "canary" | "promote" | "rollback";
+  workflowId: string;
+  workflowVersionId?: string;
+  versionNumber?: number;
+  targetVersionNumber?: number;
+  success?: boolean;
+  runtimeVersion: string;
+  providerModel: string;
+}): FridayCanonicalApprovalResolution {
+  const rollback = input.action === "rollback"
+    ? { planned: true, planDigest: WORKFLOW_LIFECYCLE_PLAN_DIGEST, actions: ["workflows.lifecycle.promote"] }
+    : undefined;
+  const request = createFridayWorkflowLifecycleMutatingActionRequest({
+    action: input.action,
+    workflowId: input.workflowId,
+    workflowVersionId: input.workflowVersionId,
+    versionNumber: input.versionNumber,
+    targetVersionNumber: input.targetVersionNumber,
+    success: input.success,
+    runtimeVersion: input.runtimeVersion,
+    providerModel: input.providerModel,
+    actor: {
+      kind: "user",
+      id: LOCAL_LIVE_PRINCIPAL_ID,
+      principalId: LOCAL_LIVE_PRINCIPAL_ID,
+    },
+    surface: `api:/v1/autonomy/workflows/${input.workflowId}/${input.action}`,
+    planDigest: WORKFLOW_LIFECYCLE_PLAN_DIGEST,
+    rollback,
+  });
+  return signFridayCanonicalApproval({
+    decision: "approved",
+    approvalId: `workflow-live-${input.action}`,
+    decidedByPrincipalId: LOCAL_LIVE_PRINCIPAL_ID,
+    actionDigest: createFridayMutatingActionDigest(request),
+    expiresAt: "2027-05-07T00:00:00.000Z",
+  }, WORKFLOW_LIFECYCLE_SIGNING_MATERIAL);
 }
 
 async function createBaseWorkflow(
@@ -407,7 +460,11 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)(`Friday Workflow Self Upgrade Live (${
   let env: RealHubEnv;
 
   beforeAll(async () => {
-    env = await createFridayDeepProofHubEnv();
+    env = await createFridayDeepProofHubEnv({
+      hubConfig: {
+        tokenSecret: WORKFLOW_LIFECYCLE_SIGNING_MATERIAL,
+      },
+    });
     await ensureWorkflowDeepProofProviders(env);
   }, 120_000);
 
@@ -453,6 +510,14 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)(`Friday Workflow Self Upgrade Live (${
           workflowVersionId: upgraded.versionId,
           runtimeVersion,
           providerModel: FRIDAY_DEEP_PROOF_MODEL,
+          planDigest: WORKFLOW_LIFECYCLE_PLAN_DIGEST,
+          canonicalApproval: makeWorkflowLifecycleApproval({
+            action: "shadow",
+            workflowId: baseline.workflowId,
+            workflowVersionId: upgraded.versionId,
+            runtimeVersion,
+            providerModel: FRIDAY_DEEP_PROOF_MODEL,
+          }),
         },
       );
       expect(shadowRes.status).toBe(200);
@@ -473,6 +538,16 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)(`Friday Workflow Self Upgrade Live (${
         `/v1/autonomy/workflows/${encodeURIComponent(baseline.workflowId)}/canary`,
         {
           success: true,
+          runtimeVersion,
+          providerModel: FRIDAY_DEEP_PROOF_MODEL,
+          planDigest: WORKFLOW_LIFECYCLE_PLAN_DIGEST,
+          canonicalApproval: makeWorkflowLifecycleApproval({
+            action: "canary",
+            workflowId: baseline.workflowId,
+            success: true,
+            runtimeVersion,
+            providerModel: FRIDAY_DEEP_PROOF_MODEL,
+          }),
         },
       );
       expect(canaryRes.status).toBe(200);
@@ -490,6 +565,14 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)(`Friday Workflow Self Upgrade Live (${
           versionNumber: upgraded.versionNumber,
           runtimeVersion,
           providerModel: FRIDAY_DEEP_PROOF_MODEL,
+          planDigest: WORKFLOW_LIFECYCLE_PLAN_DIGEST,
+          canonicalApproval: makeWorkflowLifecycleApproval({
+            action: "promote",
+            workflowId: baseline.workflowId,
+            versionNumber: upgraded.versionNumber,
+            runtimeVersion,
+            providerModel: FRIDAY_DEEP_PROOF_MODEL,
+          }),
         },
       );
       expect(promoteRes.status).toBe(200);
@@ -511,6 +594,14 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)(`Friday Workflow Self Upgrade Live (${
           targetVersionNumber: 1,
           runtimeVersion,
           providerModel: FRIDAY_DEEP_PROOF_MODEL,
+          planDigest: WORKFLOW_LIFECYCLE_PLAN_DIGEST,
+          canonicalApproval: makeWorkflowLifecycleApproval({
+            action: "rollback",
+            workflowId: baseline.workflowId,
+            targetVersionNumber: 1,
+            runtimeVersion,
+            providerModel: FRIDAY_DEEP_PROOF_MODEL,
+          }),
         },
       );
       expect(rollbackRes.status).toBe(200);


### PR DESCRIPTION
Repairs the 3 failing deep-proof self-upgrade live e2e tests (mcp_server / plugin / workflow). Root-caused as **test_drift** (the product is correct; the tests were stale for legitimate hardening). **Test-only — no `src/` change; no canonical-approval gate, lifecycle-promotion precondition, or trust-fingerprint boundary weakened; no assertion relaxed.** Verified green locally on the live DeepSeek deep-proof lane (all 3 pass, full shadow→canary→promote→rollback chains); fail-before was the local closure `release:verify:repo` run.

- **mcp_server** — MCP adapter fails CLOSED on tool/resource exposure since #384; the test's stdio server had no `policy` → `listTools` returned `[]`. Added least-privilege `policy:{toolAllowlist:["echo"],resourceAllowlist:["friday://status"]}` (the real approved path; not `allowAllTools`).
- **plugin** — fixture's `activate()`/`deactivate()` wrote markers INTO the install dir → trust-on-install fingerprint correctly flagged the changed tree (424). Markers moved OUTSIDE the install tree; assertions updated; fingerprint gate intact.
- **workflow** — shadow/canary/promote/rollback share the canonical-approval gate the test never satisfied (400). Drives a signed canonical approval on all four calls, mirroring the passing provider-profile/channel-adapter siblings (surface = real route form `api:/v1/autonomy/workflows/${workflowId}/${action}`).

These deep-proof tests are gated (`FRIDAY_DEEP_PROOF_GATED`) and skip in standard CI without a live key; the pass-after proof is the local deep-proof run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)