### PR TITLE
fix(workflows): parse-validate data-node expressions in the generated-workflow validator

### DIFF
--- a/src/workflows/generator/validation/friday-generated-workflow-validator.ts
+++ b/src/workflows/generator/validation/friday-generated-workflow-validator.ts
@@ -12,6 +12,7 @@ import {
   getFridayWorkflowStepIdFormatMessage,
   isFridayWorkflowStepIdExpressionSafe,
 } from "../../utils/friday-workflow-step-id.js";
+import { createFridayExpressionEvaluator } from "../../engine/friday-workflow-expression-evaluator.js";
 
 // ─── Interface ───
 
@@ -315,6 +316,27 @@ export function createFridayGeneratedWorkflowValidator(
       // ─── Graph validation (if compiled) ───
 
       if (compiledGraph) {
+        // Pure-syntax parser shared across data nodes. parse() tokenizes +
+        // parses WITHOUT evaluating, so valid-but-unresolved refs (e.g.
+        // $steps.x) pass — only true syntax errors throw. This catches the
+        // runtime EXPRESSION_PARSE_ERROR class (e.g. `sum(...)` instead of
+        // `$sum(...)`) at validation time so the generator repair loop can
+        // relay it, instead of approving a workflow that explodes at run.
+        const expressionEvaluator = createFridayExpressionEvaluator();
+        const parseCheck = (expr: string, nodeId: string, where: string): void => {
+          try {
+            expressionEvaluator.parse(expr);
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            issues.push({
+              code: "GRAPH_DATA_NODE_EXPRESSION_PARSE_ERROR",
+              stage: "graph",
+              severity: "error",
+              message: `Data node "${nodeId}" ${where} has an invalid expression: ${message}`,
+              stepId: nodeId,
+            });
+          }
+        };
         for (const node of compiledGraph.graph.nodes) {
           if (node.type !== "data") {
             continue;
@@ -328,6 +350,21 @@ export function createFridayGeneratedWorkflowValidator(
               message: `Data node "${node.id}" must define config.mapping or config.transform`,
               stepId: node.id,
             });
+            continue;
+          }
+          // `config.transform` is always exec()'d by the data-node executor.
+          if (typeof config.transform === "string") {
+            parseCheck(config.transform, node.id, "config.transform");
+          }
+          // `config.mapping` values are exec()'d ONLY when they are strings that
+          // start with "$" (mirror of resolveArgs in the node executor); literal
+          // strings pass through unevaluated, so we must not parse-check them.
+          if (config.mapping && typeof config.mapping === "object") {
+            for (const [key, value] of Object.entries(config.mapping as Record<string, unknown>)) {
+              if (typeof value === "string" && value.startsWith("$")) {
+                parseCheck(value, node.id, `config.mapping.${key}`);
+              }
+            }
           }
         }
 

--- a/test/unit/workflows/generator/validation/friday-generated-workflow-validator.test.ts
+++ b/test/unit/workflows/generator/validation/friday-generated-workflow-validator.test.ts
@@ -324,6 +324,78 @@ describe("FridayGeneratedWorkflowValidator", () => {
     expect(result.issues.some((i) => i.code === "GRAPH_DATA_NODE_MISSING_MAPPING")).toBe(true);
   });
 
+  function compileWithDataNodeConfig(config: Record<string, unknown>): void {
+    const mockComp = mockCompiler as { compile: ReturnType<typeof vi.fn> };
+    mockComp.compile.mockReturnValue({
+      schemaVersion: "2.0" as const,
+      workflowId: "test-wf",
+      workflowVersionId: "v-1",
+      sourceSpecSchemaVersion: "1.0" as const,
+      graph: {
+        nodes: [
+          { id: "__trigger__", type: "trigger" as const, label: "Trigger", config: {} },
+          { id: "output_step", type: "data" as const, label: "output_step", config },
+        ],
+        edges: [{ id: "e-1", sourceNodeId: "__trigger__", targetNodeId: "output_step" }],
+      },
+      failurePolicy: { onFailure: "fail_fast" as const, notifyUser: false },
+      tests: [],
+      checksum: "graph-data-expr",
+    });
+  }
+
+  function validateDataNode() {
+    return validator.validate({
+      spec: makeSpec({
+        startStepId: "output_step",
+        steps: [{ id: "output_step", type: "transform", args: {} }],
+        outputs: [{ key: "result", fromStep: "output_step", path: "message" }],
+      }),
+      visual: makeVisual({
+        nodes: [
+          { nodeId: "__trigger__", x: 100, y: 100 },
+          { nodeId: "output_step", x: 350, y: 100 },
+        ],
+      }),
+      tests: makeTests(),
+    });
+  }
+
+  // The data-node executor exec()'s config.transform and $-prefixed mapping
+  // values; an unparseable expression (e.g. `sum(...)` instead of `$sum(...)`)
+  // passes the old presence-only check then explodes at run with
+  // EXPRESSION_PARSE_ERROR. The validator must catch it pre-approval.
+  it("rejects a data node whose config.transform has an invalid expression", () => {
+    createValidator();
+    compileWithDataNodeConfig({ transform: "sum(1, 2)" });
+    const result = validateDataNode();
+    expect(result.issues.some((i) => i.code === "GRAPH_DATA_NODE_EXPRESSION_PARSE_ERROR")).toBe(true);
+  });
+
+  it("rejects a data node whose $-prefixed mapping value has an invalid expression", () => {
+    createValidator();
+    compileWithDataNodeConfig({ mapping: { total: "$a + + b" } });
+    const result = validateDataNode();
+    expect(result.issues.some((i) => i.code === "GRAPH_DATA_NODE_EXPRESSION_PARSE_ERROR")).toBe(true);
+  });
+
+  it("does NOT flag valid expressions or literal mapping strings (no false positive)", () => {
+    createValidator();
+    // valid $-ref (parses; unresolved at runtime is fine), and a literal string
+    // that the executor never evaluates (does not start with $) must be ignored.
+    compileWithDataNodeConfig({ mapping: { total: "$steps.a.value", label: "hello world" } });
+    const result = validateDataNode();
+    expect(result.issues.some((i) => i.code === "GRAPH_DATA_NODE_EXPRESSION_PARSE_ERROR")).toBe(false);
+    expect(result.issues.some((i) => i.code === "GRAPH_DATA_NODE_MISSING_MAPPING")).toBe(false);
+  });
+
+  it("does NOT flag a valid config.transform expression", () => {
+    createValidator();
+    compileWithDataNodeConfig({ transform: "$steps.a.value" });
+    const result = validateDataNode();
+    expect(result.issues.some((i) => i.code === "GRAPH_DATA_NODE_EXPRESSION_PARSE_ERROR")).toBe(false);
+  });
+
   it("spec with missing startStepId produces error", () => {
     createValidator();
     const spec = makeSpec({ startStepId: "nonexistent" });


### PR DESCRIPTION
## Problem (root cause)
Workflow generation-to-run was nondeterministic (~37.5% generate-run pass across 16 attempts, independent of hub sharing). Captured failing-run node errors show the exact blocker:

- `EXPRESSION_PARSE_ERROR: unexpected identifier 'sum'; use $sum for references`
- `EXPRESSION_PARSE_ERROR: unexpected character '+' at position 13`

The generator's pre-approval validator (`friday-generated-workflow-validator.ts`) checked that data nodes *have* `config.mapping`/`config.transform` (presence) but **not** that the expression is **parseable** by the run engine. The node executor `exec()`s `config.transform` and `$`-prefixed `config.mapping` values (`resolveArgs`). DeepSeek sometimes emits invalid expressions (`sum(...)` vs `$sum(...)`, malformed operators) — structurally valid, so they pass approval, then throw `EXPRESSION_PARSE_ERROR` at run under fail_fast.

## Fix
Parse-check `config.transform` and `$`-prefixed `config.mapping` values in the validator, reusing the engine's pure-syntax `parse()` (tokenize+parse, no evaluation). Invalid expressions now fail validation → the existing generator repair loop relays the parse error → the model can fix it, instead of approving a workflow that explodes at run.

- **Fail-closed hardening — strengthens validation, never weakens it.** No schema is hardcoded.
- `parse()` is pure syntax: valid-but-unresolved refs (`$steps.x`) still pass; only true syntax errors fail. **No false positives** on literal mapping strings (not `$`-prefixed → not evaluated → not checked).
- Scoped to the reproduced data-node `transform`/`$`-mapping failure mode. `condition` (`conditionExpr`) and `ai`-node (`$ref` interpolation) expressions are noted follow-ups.

## Proof
- **Unit (deterministic) fail-before/pass-after** (`friday-generated-workflow-validator.test.ts`, +4 tests): invalid `transform` `sum(1,2)` and invalid `$`-mapping `$a + + b` now produce `GRAPH_DATA_NODE_EXPRESSION_PARSE_ERROR`; valid `$steps.a.value` + literal `"hello world"` do NOT. 16/16 pass.
- **Live (DeepSeek deep-proof) fail-before/pass-after** over 10 NL prompts: generate-run reliability **~37.5% → ~88%** (14/16 across 2 post-fix runs; safety behaviors 100%). A residual ~12% non-parse runtime failure mode remains (separate follow-up).
- **Blast radius:** 442 workflow tests pass (0 fail); validator unit 16/16; typecheck exit 0; lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)