### PR TITLE
test(closure): decouple deterministic repo-health backstop from the live deep-proof lane

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "test:e2e:closure:cloud": "node scripts/e2e/run-friday-closure.mjs --cloud-only",
     "test:e2e:external-closure": "node scripts/e2e/run-friday-external-closure.mjs",
     "test:e2e:voice:live": "FRIDAY_E2E_LIVE_VOICE=1 vitest run test/e2e/live/friday-execution-voice-live.e2e.test.ts",
+    "test:deep-proof:live": "vitest run test/e2e/live test/e2e/friday-llm-e2e.test.ts test/e2e/friday-real-scenarios-e2e.test.ts",
     "verify:repo-ready": "npm run release:verify:repo",
     "verify:product-local": "npm run test:e2e:closure",
     "verify:cloud-smoke": "npm run test:e2e:closure:cloud",

--- a/scripts/e2e/friday-closure-lib.mjs
+++ b/scripts/e2e/friday-closure-lib.mjs
@@ -219,13 +219,22 @@ export function resolveClosureVerdict(entries) {
   };
 }
 
+function entryId(entry) {
+  return String(entry?.id ?? entry?.stage ?? "");
+}
+
 export function resolveReadinessReport(entries, mode = "local") {
-  const localEntries = entries.filter(
-    (entry) => String(entry?.id ?? entry?.stage ?? "").startsWith("local."),
+  const localEntries = entries.filter((entry) => entryId(entry).startsWith("local."));
+  // The live deep-proof lane (`local.deep-proof.*`) is a live-LLM/provider signal and
+  // is inherently nondeterministic. It is reported on its own readiness tier and still
+  // counts toward `overall` (so a real failure is never hidden), but it is excluded from
+  // the deterministic `productReadyLocal` so live-lane flake cannot randomly pollute the
+  // deterministic local product verdict.
+  const deepProofEntries = localEntries.filter((entry) => entryId(entry).startsWith("local.deep-proof."));
+  const deterministicLocalEntries = localEntries.filter(
+    (entry) => !entryId(entry).startsWith("local.deep-proof."),
   );
-  const cloudEntries = entries.filter(
-    (entry) => String(entry?.id ?? entry?.stage ?? "").startsWith("cloud."),
-  );
+  const cloudEntries = entries.filter((entry) => entryId(entry).startsWith("cloud."));
   const repoBackstopEntry = entries.find((entry) => entry?.id === "local.backstop.release-verify");
   const overall = resolveClosureVerdict(entries).verdict;
 
@@ -234,7 +243,11 @@ export function resolveReadinessReport(entries, mode = "local") {
     repoReady: repoBackstopEntry
       ? readinessVerdictFromEntries([repoBackstopEntry])
       : FRIDAY_READINESS_VERDICTS.NOT_RUN,
-    productReadyLocal: readinessVerdictFromEntries(localEntries),
+    productReadyLocal: readinessVerdictFromEntries(deterministicLocalEntries),
+    liveDeepProofReady:
+      deepProofEntries.length > 0
+        ? readinessVerdictFromEntries(deepProofEntries)
+        : FRIDAY_READINESS_VERDICTS.NOT_RUN,
     cloudReady: readinessVerdictFromEntries(cloudEntries),
     overall,
   };

--- a/scripts/e2e/run-friday-closure.mjs
+++ b/scripts/e2e/run-friday-closure.mjs
@@ -30,6 +30,26 @@ const CLOUD_ONLY = process.argv.includes("--cloud-only");
 const CLOUD_CLOSURE_ENABLED = process.env.FRIDAY_E2E_CLOUD_ENABLED === "1";
 const SKIP_INSTALL = process.argv.includes("--skip-install") || process.env.FRIDAY_CLOSURE_SKIP_INSTALL === "1";
 const SKIP_BACKSTOP = process.argv.includes("--skip-backstop") || process.env.FRIDAY_CLOSURE_SKIP_BACKSTOP === "1";
+// Deep-proof gate flags (mirror of test/e2e/live/_helpers/deep-proof-env.ts). The
+// release-verify backstop must run with the gate CLOSED so its `npm test` exercises
+// only the deterministic repo-health lane (matches CI, which sets no live flags); the
+// live deep-proof suite is run as a SEPARATE, independently-reported required step so a
+// real live failure is never hidden but live-LLM/provider flake never randomly pollutes
+// the deterministic repo-health verdict.
+const DEEP_PROOF_LANE_FLAGS = [
+  "FRIDAY_E2E_LIVE_ANTHROPIC",
+  "FRIDAY_E2E_LIVE_DEEPSEEK",
+  "FRIDAY_E2E_LIVE_OPENAI",
+  "FRIDAY_E2E_LIVE_OLLAMA",
+];
+// Closing the gate only requires neutralizing the lane flags (readFlag === "1").
+const DEEP_PROOF_GATE_CLOSED_ENV = Object.freeze(
+  Object.fromEntries(DEEP_PROOF_LANE_FLAGS.map((flag) => [flag, ""])),
+);
+// The gate is "open" iff exactly one lane flag is set — same single-lane rule the
+// deep-proof helper enforces. Only then is a live deep-proof run meaningful.
+const DEEP_PROOF_GATE_OPEN =
+  DEEP_PROOF_LANE_FLAGS.filter((flag) => process.env[flag] === "1").length === 1;
 const LOCAL_PASSPHRASE = process.env.FRIDAY_TEST_LOCAL_PASSPHRASE
   ?? process.env.FRIDAY_LOCAL_PASSPHRASE
   ?? "friday-closure-passphrase-123";
@@ -565,6 +585,9 @@ function formatReadinessReport(readiness) {
     if (readiness.repoReady !== "NOT_RUN") {
       lines.push(`Repo Ready: ${readiness.repoReady}`);
     }
+    if (readiness.liveDeepProofReady && readiness.liveDeepProofReady !== "NOT_RUN") {
+      lines.push(`Live Deep-Proof: ${readiness.liveDeepProofReady}`);
+    }
     return lines.join("\n");
   }
 
@@ -575,6 +598,9 @@ function formatReadinessReport(readiness) {
 
   lines.push(`Repo Ready: ${readiness.repoReady}`);
   lines.push(`Product Ready (Local): ${readiness.productReadyLocal}`);
+  if (readiness.liveDeepProofReady && readiness.liveDeepProofReady !== "NOT_RUN") {
+    lines.push(`Live Deep-Proof: ${readiness.liveDeepProofReady}`);
+  }
   lines.push(`Cloud Ready: ${readiness.cloudReady}`);
   lines.push(`Overall: ${readiness.overall}`);
   return lines.join("\n");
@@ -2702,7 +2728,7 @@ async function runLocalStage(ledger) {
       await runStep(ledger, {
         id: "local.backstop.release-verify",
         stage: `${stage}.backstop`,
-        description: "Run npm run release:verify:repo as a closure backstop",
+        description: "Run npm run release:verify:repo as a deterministic repo-health backstop (deep-proof gate closed)",
       }, async () => {
         const result = await runCommand({
           id: "local.backstop.release-verify",
@@ -2710,6 +2736,11 @@ async function runLocalStage(ledger) {
           description: "npm run release:verify:repo",
           command: "npm",
           args: ["run", "release:verify:repo"],
+          // Close the deep-proof gate so `npm test` inside release:verify:repo runs
+          // the deterministic repo-health lane only and skips the live deep-proof
+          // suite — this is what makes the backstop deterministic (matches CI) and
+          // stops live-lane load from flaking unrelated unit tests under concurrency.
+          env: DEEP_PROOF_GATE_CLOSED_ENV,
           logPath: path.join(ledger.paths.logs, "local-backstop-release-verify.log"),
           timeoutMs: 1_800_000,
         });
@@ -2718,6 +2749,37 @@ async function runLocalStage(ledger) {
         }
         return { evidence: { logPath: result.logPath } };
       });
+
+      // Separate, independently-reported live deep-proof lane. Runs only when the
+      // deep-proof gate is open (keyed closure). It exercises exactly the live suite
+      // the backstop used to conflate, in isolation (less concurrency pressure), and is
+      // a REQUIRED signal — a real failure still makes `overall` NO-GO — but it is
+      // reported on its own `Live Deep-Proof` readiness tier so its live-LLM/provider
+      // nondeterminism does not pollute the deterministic repo-health verdict.
+      if (DEEP_PROOF_GATE_OPEN) {
+        await runStep(ledger, {
+          id: "local.deep-proof.live",
+          stage: `${stage}.deep-proof`,
+          description: "Run the live deep-proof e2e suite (gate open) as a separate live-provider signal",
+        }, async () => {
+          const result = await runCommand({
+            id: "local.deep-proof.live",
+            stage: `${stage}.deep-proof`,
+            description: "npm run test:deep-proof:live",
+            command: "npm",
+            args: ["run", "test:deep-proof:live"],
+            logPath: path.join(ledger.paths.logs, "local-deep-proof-live.log"),
+            timeoutMs: 1_800_000,
+          });
+          if (result.code !== 0) {
+            throw new Error(`live deep-proof suite failed with code ${String(result.code)}`);
+          }
+          return {
+            evidence: { logPath: result.logPath },
+            details: { classification: "live-provider" },
+          };
+        });
+      }
     }
   } finally {
     const cleanupErrors = await cleanupRegistry.run();

--- a/test/unit/e2e/friday-closure-lib.test.ts
+++ b/test/unit/e2e/friday-closure-lib.test.ts
@@ -113,6 +113,7 @@ describe("friday closure lib", () => {
       mode: "local",
       repoReady: FRIDAY_READINESS_VERDICTS.GO,
       productReadyLocal: FRIDAY_READINESS_VERDICTS.GO,
+      liveDeepProofReady: FRIDAY_READINESS_VERDICTS.NOT_RUN,
       cloudReady: FRIDAY_READINESS_VERDICTS.NOT_RUN,
       overall: "GO",
     });
@@ -129,6 +130,7 @@ describe("friday closure lib", () => {
       mode: "all",
       repoReady: FRIDAY_READINESS_VERDICTS.GO,
       productReadyLocal: FRIDAY_READINESS_VERDICTS.GO,
+      liveDeepProofReady: FRIDAY_READINESS_VERDICTS.NOT_RUN,
       cloudReady: FRIDAY_READINESS_VERDICTS.NO_GO,
       overall: "NO-GO",
     });
@@ -151,8 +153,46 @@ describe("friday closure lib", () => {
       mode: "local",
       repoReady: FRIDAY_READINESS_VERDICTS.GO,
       productReadyLocal: FRIDAY_READINESS_VERDICTS.NO_GO,
+      liveDeepProofReady: FRIDAY_READINESS_VERDICTS.NOT_RUN,
       cloudReady: FRIDAY_READINESS_VERDICTS.NOT_RUN,
       overall: "NO-GO",
+    });
+  });
+
+  it("decouples the live deep-proof lane from the deterministic local product verdict", () => {
+    // A live deep-proof FAIL must NOT pollute repoReady or the deterministic
+    // productReadyLocal, but MUST surface on its own tier and still drive overall NO-GO
+    // (never hidden).
+    const readiness = resolveReadinessReport([
+      { id: "local.backstop.release-verify", status: FRIDAY_CLOSURE_STATUSES.PASS },
+      { id: "local.workflows.generator", status: FRIDAY_CLOSURE_STATUSES.PASS },
+      { id: "local.deep-proof.live", status: FRIDAY_CLOSURE_STATUSES.FAIL },
+    ], "local");
+
+    expect(readiness).toEqual({
+      mode: "local",
+      repoReady: FRIDAY_READINESS_VERDICTS.GO,
+      productReadyLocal: FRIDAY_READINESS_VERDICTS.GO,
+      liveDeepProofReady: FRIDAY_READINESS_VERDICTS.NO_GO,
+      cloudReady: FRIDAY_READINESS_VERDICTS.NOT_RUN,
+      overall: "NO-GO",
+    });
+  });
+
+  it("reports Live Deep-Proof GO and overall GO when the live lane and repo-health both pass", () => {
+    const readiness = resolveReadinessReport([
+      { id: "local.backstop.release-verify", status: FRIDAY_CLOSURE_STATUSES.PASS },
+      { id: "local.workflows.generator", status: FRIDAY_CLOSURE_STATUSES.PASS },
+      { id: "local.deep-proof.live", status: FRIDAY_CLOSURE_STATUSES.PASS },
+    ], "local");
+
+    expect(readiness).toEqual({
+      mode: "local",
+      repoReady: FRIDAY_READINESS_VERDICTS.GO,
+      productReadyLocal: FRIDAY_READINESS_VERDICTS.GO,
+      liveDeepProofReady: FRIDAY_READINESS_VERDICTS.GO,
+      cloudReady: FRIDAY_READINESS_VERDICTS.NOT_RUN,
+      overall: "GO",
     });
   });
 


### PR DESCRIPTION
## Root cause
The closure `local.backstop.release-verify` step ran `npm run release:verify:repo` inheriting `process.env`. In a keyed closure that env carries `FRIDAY_E2E_LIVE_DEEPSEEK=1` + a provider key, so the deep-proof gate auto-opened **inside** `release:verify:repo`'s `npm test` and the live deep-proof suite ran *as part of* the deterministic repo-health backstop. That conflation made `local.backstop.release-verify` (and thus **Repo Ready**) flake on live-LLM/provider nondeterminism — and the live-lane load even flaked unrelated **unit** tests under concurrency (a different test each run; all green in isolation). CI repo-health on the same SHA is green (CI sets no live flags).

## Fix (honesty improvement — no signal weakened or hidden)
- Run the release-verify backstop with the deep-proof gate **CLOSED** (neutralize the `FRIDAY_E2E_LIVE_*` lane flags) so its `npm test` exercises the deterministic repo-health lane only — matching CI.
- Add a separate **REQUIRED** `local.deep-proof.live` step (only when the gate is open) that runs exactly the live suite in isolation via a new `test:deep-proof:live` script. A real failure still drives `overall` NO-GO — nothing is hidden.
- Report the live lane on its own **`Live Deep-Proof`** readiness tier and exclude `local.deep-proof.*` from the deterministic `productReadyLocal`, so live-lane flake can no longer randomly pollute the deterministic verdict.

No gate weakened, no test skipped, no live failure masked.

## Tests
`test/unit/e2e/friday-closure-lib.test.ts`: repo-health GO + live deep-proof FAIL ⇒ `repoReady=GO`, `productReadyLocal=GO`, `liveDeepProofReady=NO-GO`, `overall=NO-GO` (not hidden); and the all-pass case. `test:deep-proof:live` filter verified to resolve the 22 live files (skipped gate-closed). Scope: `scripts/e2e/` + `package.json` — **test/release-readiness harness only; no shipped runtime change**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)