### PR TITLE
fix(workflows): make generated data-node transforms runnable (evaluator arithmetic + nested mapping + JSON-object normalize) — supersedes #421

### DIFF
--- a/src/workflows/engine/friday-workflow-expression-evaluator.ts
+++ b/src/workflows/engine/friday-workflow-expression-evaluator.ts
@@ -242,8 +242,13 @@ function parseExpr(tokens: Token[]): FridayExprNode {
   // not_expr = "!" not_expr | compare
   function notExpr(): FridayExprNode {
     if (peek().kind === "NOT") {
+      // checkDepth bounds the "!" recursion. Without it a long "!" chain (e.g.
+      // "!".repeat(4095)) recurses to stack-overflow within MAX_EXPR_LENGTH —
+      // a DoS the depth limit is meant to prevent (mirrors unaryMinus).
+      checkDepth();
       advance();
       const operand = notExpr();
+      depth--;
       return { kind: "unary", op: "!", operand };
     }
     return compare();
@@ -424,6 +429,14 @@ function evaluateNode(
           );
         }
         if (target == null || typeof target !== "object") {
+          return undefined;
+        }
+        // Only read OWN properties. Inherited members (valueOf, toString,
+        // hasOwnProperty, __defineGetter__, …) are not workflow data and must
+        // not be exposed — returning the inherited builtin function would leak
+        // prototype internals (e.g. into AI-node prompt interpolation). Own
+        // data reads (inputs/steps.output/env values) are unaffected.
+        if (!Object.prototype.hasOwnProperty.call(target, segment)) {
           return undefined;
         }
         target = (target as Record<string, unknown>)[segment];

--- a/src/workflows/engine/friday-workflow-expression-evaluator.ts
+++ b/src/workflows/engine/friday-workflow-expression-evaluator.ts
@@ -57,9 +57,19 @@ function tokenize(expr: string): Token[] {
       continue;
     }
 
-    // Single-char operators
+    // Single-char operators (comparison + arithmetic). "-" is always an
+    // operator token here; numeric negation is handled in the parser
+    // (unaryMinus) so subtraction `$a - $b` and negation `-5` both work.
     const ch = expr[i]!;
-    if (ch === ">" || ch === "<") {
+    if (
+      ch === ">" ||
+      ch === "<" ||
+      ch === "+" ||
+      ch === "-" ||
+      ch === "*" ||
+      ch === "/" ||
+      ch === "%"
+    ) {
       tokens.push({ kind: "OP", value: ch });
       i++;
       continue;
@@ -120,13 +130,10 @@ function tokenize(expr: string): Token[] {
       continue;
     }
 
-    // Number literal
-    if (/[0-9]/.test(ch) || (ch === "-" && i + 1 < expr.length && /[0-9]/.test(expr[i + 1]!))) {
+    // Number literal (digits only; a leading "-" is a unary/binary operator
+    // token resolved by the parser, not part of the number token).
+    if (/[0-9]/.test(ch)) {
       let num = "";
-      if (ch === "-") {
-        num += ch;
-        i++;
-      }
       while (i < expr.length && /[0-9.]/.test(expr[i]!)) {
         num += expr[i];
         i++;
@@ -242,9 +249,13 @@ function parseExpr(tokens: Token[]): FridayExprNode {
     return compare();
   }
 
-  // compare = primary ( OP primary )?
+  // compare = additive ( CMP_OP additive )?
+  // NOTE: additive/multiplicative/unaryMinus sit BELOW compare so that a pure
+  // comparison/logical expression (a workflow condition) with no arithmetic
+  // operators parses to the IDENTICAL AST as before this change — additive and
+  // multiplicative pass straight through to primary when no +,-,*,/,% appears.
   function compare(): FridayExprNode {
-    const left = primary();
+    const left = additive();
     const t = peek();
     if (
       t.kind === "OP" &&
@@ -256,7 +267,7 @@ function parseExpr(tokens: Token[]): FridayExprNode {
         t.value === "<=")
     ) {
       advance();
-      const right = primary();
+      const right = additive();
       return {
         kind: "binary",
         op: t.value as "==" | "!=" | ">" | "<" | ">=" | "<=",
@@ -265,6 +276,43 @@ function parseExpr(tokens: Token[]): FridayExprNode {
       };
     }
     return left;
+  }
+
+  // additive = multiplicative ( ("+"|"-") multiplicative )*   (left-assoc)
+  function additive(): FridayExprNode {
+    let left = multiplicative();
+    while (peek().kind === "OP" && (peek().value === "+" || peek().value === "-")) {
+      const op = advance().value as "+" | "-";
+      const right = multiplicative();
+      left = { kind: "binary", op, left, right };
+    }
+    return left;
+  }
+
+  // multiplicative = unaryMinus ( ("*"|"/"|"%") unaryMinus )*   (left-assoc)
+  function multiplicative(): FridayExprNode {
+    let left = unaryMinus();
+    while (
+      peek().kind === "OP" &&
+      (peek().value === "*" || peek().value === "/" || peek().value === "%")
+    ) {
+      const op = advance().value as "*" | "/" | "%";
+      const right = unaryMinus();
+      left = { kind: "binary", op, left, right };
+    }
+    return left;
+  }
+
+  // unaryMinus = "-" unaryMinus | primary   (numeric negation; tight binding)
+  function unaryMinus(): FridayExprNode {
+    if (peek().kind === "OP" && peek().value === "-") {
+      checkDepth();
+      advance();
+      const operand = unaryMinus();
+      depth--;
+      return { kind: "unary", op: "-", operand };
+    }
+    return primary();
   }
 
   // primary = ref | literal | "(" expr ")"
@@ -325,6 +373,24 @@ function parseExpr(tokens: Token[]): FridayExprNode {
 }
 
 // ─── Evaluator ───
+
+// Concat coercion for "+" when at least one operand is not a number.
+// Explicit + predictable: null/undefined → "" (so a missing ref in
+// `$a + " " + $b` does not emit the literal text "null"/"undefined"),
+// objects/arrays → JSON, everything else → String().
+function stringifyOperand(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  if (typeof value === "object") {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return String(value);
+    }
+  }
+  return String(value);
+}
 
 function evaluateNode(
   node: FridayExprNode,
@@ -394,12 +460,33 @@ function evaluateNode(
           return Number(left) >= Number(right);
         case "<=":
           return Number(left) <= Number(right);
+        // Arithmetic / concat. Coercion rule is explicit and documented:
+        // "+" does numeric addition only when BOTH operands are numbers,
+        // otherwise string concatenation (String(left)+String(right));
+        // "- * / %" always Number()-coerce both operands (consistent with the
+        // ordering comparison operators above).
+        case "+":
+          if (typeof left === "number" && typeof right === "number") {
+            return left + right;
+          }
+          return `${stringifyOperand(left)}${stringifyOperand(right)}`;
+        case "-":
+          return Number(left) - Number(right);
+        case "*":
+          return Number(left) * Number(right);
+        case "/":
+          return Number(left) / Number(right);
+        case "%":
+          return Number(left) % Number(right);
       }
       break;
     }
 
     case "unary": {
       const operand = evaluateNode(node.operand, ctx);
+      if (node.op === "-") {
+        return -Number(operand);
+      }
       return !operand;
     }
   }

--- a/src/workflows/engine/friday-workflow-node-executor.ts
+++ b/src/workflows/engine/friday-workflow-node-executor.ts
@@ -70,6 +70,38 @@ export interface CreateNodeExecutorDeps {
 
 // ─── Expression arg resolution ───
 
+// Resolve a single mapping/arg value. `$`-prefixed strings are evaluated as
+// expressions; arrays and PLAIN OBJECTS are resolved RECURSIVELY so a nested
+// mapping like `{ outputs: { result: "$inputs.a - $inputs.b" } }` (a shape the
+// generator legitimately emits) has its inner expressions evaluated instead of
+// passed through as the literal expression string. Prototype-polluting keys are
+// dropped (defense-in-depth; the value object is built from model output).
+const UNSAFE_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+function resolveValue(
+  value: unknown,
+  expressionContext: FridayExpressionContext,
+  evaluator: FridayExpressionEvaluator,
+): unknown {
+  if (typeof value === "string") {
+    return value.startsWith("$") ? evaluator.exec(value, expressionContext) : value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => resolveValue(item, expressionContext, evaluator));
+  }
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, inner] of Object.entries(value as Record<string, unknown>)) {
+      if (UNSAFE_KEYS.has(key)) {
+        continue;
+      }
+      out[key] = resolveValue(inner, expressionContext, evaluator);
+    }
+    return out;
+  }
+  return value;
+}
+
 function resolveArgs(
   args: Record<string, unknown>,
   expressionContext: FridayExpressionContext,
@@ -77,11 +109,10 @@ function resolveArgs(
 ): Record<string, unknown> {
   const resolved: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(args)) {
-    if (typeof value === "string" && value.startsWith("$")) {
-      resolved[key] = evaluator.exec(value, expressionContext);
-    } else {
-      resolved[key] = value;
+    if (UNSAFE_KEYS.has(key)) {
+      continue;
     }
+    resolved[key] = resolveValue(value, expressionContext, evaluator);
   }
   return resolved;
 }

--- a/src/workflows/generator/services/friday-workflow-generator-service.ts
+++ b/src/workflows/generator/services/friday-workflow-generator-service.ts
@@ -324,6 +324,27 @@ function normalizeGeneratedTests(
   return normalized.length > 0 ? normalized : buildFallbackTests(spec);
 }
 
+// Returns the parsed value iff `value` is a string that JSON-parses to a plain
+// (non-null, non-array) object; otherwise undefined. Used to rewrite a
+// JSON-object-literal `transform` string into runnable `mapping` form. Refs
+// (`$x`), arithmetic (`$a + $b`), and bare literals are not valid JSON and
+// return undefined (left as a `transform` for the expression evaluator).
+function tryParseJsonObjectTransform(value: string): Record<string, unknown> | undefined {
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("{")) {
+    return undefined;
+  }
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // Not JSON (a ref/arithmetic/expression) — leave as a transform.
+  }
+  return undefined;
+}
+
 function normalizeGeneratedSpecStep(
   step: FridayWorkflowSpecStep,
 ): FridayWorkflowSpecStep {
@@ -363,6 +384,24 @@ function normalizeGeneratedSpecStep(
   ) {
     normalizedArgs.mapping = normalizedArgs.transform;
     delete normalizedArgs.transform;
+  }
+  // A `transform` STRING that is a JSON object literal (e.g.
+  // `'{"message":"version two"}'`) is NOT executable by the data-node
+  // expression evaluator (which evaluates a single expression, not an object
+  // literal). The runnable representation is `config.mapping`, whose values go
+  // through resolveArgs (literals pass through; `$`-prefixed values are
+  // evaluated). Rewrite it to mapping form so it RUNS instead of throwing
+  // EXPRESSION_PARSE_ERROR at execution. Refs/arithmetic strings (not valid
+  // JSON) are left untouched and handled by the evaluator.
+  if (
+    typeof normalizedArgs.transform === "string" &&
+    normalizedArgs.mapping === undefined
+  ) {
+    const parsedObject = tryParseJsonObjectTransform(normalizedArgs.transform);
+    if (parsedObject !== undefined) {
+      normalizedArgs.mapping = parsedObject;
+      delete normalizedArgs.transform;
+    }
   }
 
   return {

--- a/src/workflows/generator/validation/friday-generated-workflow-validator.ts
+++ b/src/workflows/generator/validation/friday-generated-workflow-validator.ts
@@ -12,6 +12,7 @@ import {
   getFridayWorkflowStepIdFormatMessage,
   isFridayWorkflowStepIdExpressionSafe,
 } from "../../utils/friday-workflow-step-id.js";
+import { createFridayExpressionEvaluator } from "../../engine/friday-workflow-expression-evaluator.js";
 
 // ─── Interface ───
 
@@ -315,6 +316,27 @@ export function createFridayGeneratedWorkflowValidator(
       // ─── Graph validation (if compiled) ───
 
       if (compiledGraph) {
+        // Pure-syntax parser shared across data nodes. parse() tokenizes +
+        // parses WITHOUT evaluating, so valid-but-unresolved refs (e.g.
+        // $steps.x) pass — only true syntax errors throw. This catches the
+        // runtime EXPRESSION_PARSE_ERROR class (e.g. `sum(...)` instead of
+        // `$sum(...)`) at validation time so the generator repair loop can
+        // relay it, instead of approving a workflow that explodes at run.
+        const expressionEvaluator = createFridayExpressionEvaluator();
+        const parseCheck = (expr: string, nodeId: string, where: string): void => {
+          try {
+            expressionEvaluator.parse(expr);
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            issues.push({
+              code: "GRAPH_DATA_NODE_EXPRESSION_PARSE_ERROR",
+              stage: "graph",
+              severity: "error",
+              message: `Data node "${nodeId}" ${where} has an invalid expression: ${message}`,
+              stepId: nodeId,
+            });
+          }
+        };
         for (const node of compiledGraph.graph.nodes) {
           if (node.type !== "data") {
             continue;
@@ -328,6 +350,21 @@ export function createFridayGeneratedWorkflowValidator(
               message: `Data node "${node.id}" must define config.mapping or config.transform`,
               stepId: node.id,
             });
+            continue;
+          }
+          // `config.transform` is always exec()'d by the data-node executor.
+          if (typeof config.transform === "string") {
+            parseCheck(config.transform, node.id, "config.transform");
+          }
+          // `config.mapping` values are exec()'d ONLY when they are strings that
+          // start with "$" (mirror of resolveArgs in the node executor); literal
+          // strings pass through unevaluated, so we must not parse-check them.
+          if (config.mapping && typeof config.mapping === "object") {
+            for (const [key, value] of Object.entries(config.mapping as Record<string, unknown>)) {
+              if (typeof value === "string" && value.startsWith("$")) {
+                parseCheck(value, node.id, `config.mapping.${key}`);
+              }
+            }
           }
         }
 

--- a/src/workflows/model/friday-workflow-expression.types.ts
+++ b/src/workflows/model/friday-workflow-expression.types.ts
@@ -18,14 +18,32 @@ export interface FridayExprRef {
 
 export interface FridayExprBinaryOp {
   kind: "binary";
-  op: "==" | "!=" | ">" | "<" | ">=" | "<=" | "&&" | "||";
+  op:
+    | "=="
+    | "!="
+    | ">"
+    | "<"
+    | ">="
+    | "<="
+    | "&&"
+    | "||"
+    // Arithmetic / string-concat. "+" is JS-like (numeric add when both
+    // operands are numbers, else string concat); "- * / %" Number()-coerce
+    // both operands (consistent with the ordering comparison operators).
+    | "+"
+    | "-"
+    | "*"
+    | "/"
+    | "%";
   left: FridayExprNode;
   right: FridayExprNode;
 }
 
 export interface FridayExprUnaryOp {
   kind: "unary";
-  op: "!";
+  // "!" logical negation (boolean, loose precedence); "-" numeric negation
+  // (tight precedence, binds below multiplicative).
+  op: "!" | "-";
   operand: FridayExprNode;
 }
 

--- a/src/workflows/model/friday-workflow-expression.types.ts
+++ b/src/workflows/model/friday-workflow-expression.types.ts
@@ -27,9 +27,14 @@ export interface FridayExprBinaryOp {
     | "<="
     | "&&"
     | "||"
-    // Arithmetic / string-concat. "+" is JS-like (numeric add when both
-    // operands are numbers, else string concat); "- * / %" Number()-coerce
-    // both operands (consistent with the ordering comparison operators).
+    // Arithmetic / string-concat. "+" does numeric addition ONLY when BOTH
+    // operands are typeof "number"; for ANY other operand (string, null,
+    // boolean, object) it string-concatenates (so null + 5 => "5", not 5 —
+    // deliberately NOT JS "+" semantics; the rule is one clear branch). "- * /
+    // %" always Number()-coerce both operands (like the ordering comparisons).
+    // NOTE: binary "-" needs surrounding spaces ("$a - $b"); "-" is also a
+    // valid ref-name char (hyphenated step IDs like $steps.s3-csv), so "$a-$b"
+    // parses as a ref, not subtraction.
     | "+"
     | "-"
     | "*"

--- a/test/unit/workflows/friday-workflow-expression-evaluator-security.test.ts
+++ b/test/unit/workflows/friday-workflow-expression-evaluator-security.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { createFridayExpressionEvaluator } from "#workflows";
+import type { FridayExpressionContext } from "#workflows";
+
+// Adversarial-security characterization for the workflow expression evaluator
+// (extended this session with arithmetic + nested-mapping recursion). Derived
+// from a 5-agent adversarial probe: prototype-pollution, code-execution/sandbox
+// escape, ReDoS/DoS, and coercion. Locks the safety properties so a future
+// change that weakens them fails loudly.
+describe("FridayExpressionEvaluator — adversarial security", () => {
+  const evaluator = createFridayExpressionEvaluator();
+  const ctx: FridayExpressionContext = {
+    inputs: { a: 5, b: 3, name: "Ada", nested: { x: 1 }, obj: { k: 1 }, arr: [1, 2] },
+    steps: { "s3-csv": { output: { total: 9 } } },
+    env: {},
+  };
+
+  // ─── Prototype pollution / sandbox escape (READ path) ───
+  it("rejects prototype-internal ref segments at ANY position", () => {
+    expect(() => evaluator.exec("$inputs.__proto__.x", ctx)).toThrow("EXPRESSION_UNSAFE_PATH_ACCESS");
+    expect(() => evaluator.exec("$inputs.constructor", ctx)).toThrow("EXPRESSION_UNSAFE_PATH_ACCESS");
+    expect(() => evaluator.exec("$inputs.prototype", ctx)).toThrow("EXPRESSION_UNSAFE_PATH_ACCESS");
+    expect(() => evaluator.exec("$inputs.nested.constructor.constructor", ctx)).toThrow("EXPRESSION_UNSAFE_PATH_ACCESS");
+    expect(() => evaluator.exec("$steps.__proto__.x", ctx)).toThrow("EXPRESSION_UNSAFE_PATH_ACCESS");
+  });
+  it("returns undefined for non-sandbox roots (no deref, no throw)", () => {
+    expect(evaluator.exec("$__proto__.x", ctx)).toBeUndefined();
+    expect(evaluator.exec("$constructor.prototype", ctx)).toBeUndefined();
+  });
+  // Own-property hardening (this session): inherited builtins are NOT readable.
+  it("does not expose inherited Object.prototype members (own-property guard)", () => {
+    expect(evaluator.exec("$inputs.valueOf", ctx)).toBeUndefined();
+    expect(evaluator.exec("$inputs.hasOwnProperty", ctx)).toBeUndefined();
+    expect(evaluator.exec("$inputs.toString", ctx)).toBeUndefined();
+    // own data still resolves
+    expect(evaluator.exec("$inputs.nested.x", ctx)).toBe(1);
+    expect(evaluator.exec("$steps.s3-csv.output.total", ctx)).toBe(9); // hyphenated step id
+  });
+
+  // ─── Code execution / sandbox escape (no such grammar) ───
+  it("has no call / index / template / sequence / assignment / global productions", () => {
+    for (const expr of [
+      "$inputs.a()",
+      "$fn(1)",
+      '$inputs.constructor("return process")()',
+      "`${process}`",
+      "$inputs.a, $inputs.b",
+      "$inputs.a = 5",
+      "$inputs[a]",
+      "process",
+      "globalThis",
+    ]) {
+      expect(() => evaluator.parse(expr), expr).toThrow();
+    }
+  });
+
+  // ─── DoS / resource bounds ───
+  it("bounds recursion depth for ! chains (fixed), unary-minus chains, and parens", () => {
+    expect(() => evaluator.parse("!".repeat(40) + "1")).toThrow("EXPRESSION_DEPTH_EXCEEDED");
+    expect(() => evaluator.parse("-".repeat(40) + "1")).toThrow("EXPRESSION_DEPTH_EXCEEDED");
+    expect(() => evaluator.parse("(".repeat(40) + "1" + ")".repeat(40))).toThrow("EXPRESSION_DEPTH_EXCEEDED");
+  });
+  it("bounds total expression length", () => {
+    expect(() => evaluator.parse("1".repeat(4097))).toThrow("EXPRESSION_TOO_LONG");
+  });
+
+  // ─── Coercion characterization (explicit, documented rule) ───
+  it("'+' adds numbers, concats otherwise (incl. null/boolean → concat, NOT JS numeric)", () => {
+    expect(evaluator.exec("5 + 3", ctx)).toBe(8);
+    expect(evaluator.exec('"5" + "3"', ctx)).toBe("53");
+    expect(evaluator.exec("null + 5", ctx)).toBe("5"); // deliberately NOT JS (which is 5)
+    expect(evaluator.exec("true + 1", ctx)).toBe("true1");
+  });
+  it("'- * / %' Number()-coerce (so they differ from '+' on string operands)", () => {
+    expect(evaluator.exec("10 - 4", ctx)).toBe(6);
+    expect(evaluator.exec('"5" - "3"', ctx)).toBe(2);
+    expect(evaluator.exec("1 / 0", ctx)).toBe(Infinity);
+    expect(Number.isNaN(evaluator.exec("0 / 0", ctx) as number)).toBe(true);
+  });
+  it("concat uses JSON for objects/arrays and '' for null/undefined", () => {
+    expect(evaluator.exec('"" + $inputs.obj', ctx)).toBe('{"k":1}');
+    expect(evaluator.exec('"" + $inputs.arr', ctx)).toBe("[1,2]");
+    expect(evaluator.exec("$inputs.missing + ' tail'", ctx)).toBe(" tail");
+  });
+});

--- a/test/unit/workflows/friday-workflow-expression-evaluator.test.ts
+++ b/test/unit/workflows/friday-workflow-expression-evaluator.test.ts
@@ -160,4 +160,73 @@ describe("FridayExpressionEvaluator", () => {
   it("handles escaped quotes in strings", () => {
     expect(evaluator.exec('"hello \\"world\\""', ctx)).toBe('hello "world"');
   });
+
+  // ─── Arithmetic (added for workflow-gen transform reliability) ───
+
+  it("evaluates numeric addition (both operands numbers)", () => {
+    expect(evaluator.exec("2 + 3", ctx)).toBe(5);
+    expect(evaluator.exec("$inputs.count + 8", ctx)).toBe(50);
+  });
+
+  it("evaluates subtraction / multiplication / division / modulo", () => {
+    expect(evaluator.exec("10 - 4", ctx)).toBe(6);
+    expect(evaluator.exec("3 * 4", ctx)).toBe(12);
+    expect(evaluator.exec("15 / 4", ctx)).toBe(3.75);
+    expect(evaluator.exec("17 % 5", ctx)).toBe(2);
+    expect(evaluator.exec("$inputs.count * 2", ctx)).toBe(84);
+  });
+
+  it("honors arithmetic precedence and parentheses", () => {
+    expect(evaluator.exec("2 + 3 * 4", ctx)).toBe(14);
+    expect(evaluator.exec("(2 + 3) * 4", ctx)).toBe(20);
+    expect(evaluator.exec("20 - 4 - 6", ctx)).toBe(10); // left-associative
+  });
+
+  it("evaluates unary minus / negation", () => {
+    expect(evaluator.exec("-5", ctx)).toBe(-5);
+    expect(evaluator.exec("0 - $inputs.count", ctx)).toBe(-42);
+    expect(evaluator.exec("-$inputs.count", ctx)).toBe(-42);
+    expect(evaluator.exec("$inputs.count > -1", ctx)).toBe(true);
+  });
+
+  // The "+" coercion rule is EXPLICIT (advisor trap: JS "+" overload):
+  // numeric add ONLY when both operands are numbers; otherwise string concat.
+  it("'+' is numeric add for numbers but concat when a string is involved", () => {
+    expect(evaluator.exec("5 + 3", ctx)).toBe(8); // both numbers → add
+    expect(evaluator.exec('"5" + "3"', ctx)).toBe("53"); // both strings → concat
+    expect(evaluator.exec("'Hello, ' + $inputs.name", ctx)).toBe("Hello, Alice");
+    expect(evaluator.exec("$inputs.name + '!'", ctx)).toBe("Alice!");
+    expect(evaluator.exec("$inputs.name + ' is ' + $inputs.count", ctx)).toBe("Alice is 42");
+  });
+
+  it("concat treats null/undefined as empty (no literal 'null'/'undefined')", () => {
+    expect(evaluator.exec("$steps.missing.output.x + 'tail'", ctx)).toBe("tail");
+    expect(evaluator.exec("'head ' + $steps.missing.output.x", ctx)).toBe("head ");
+  });
+
+  // ─── Condition AST identity (arithmetic insertion must be transparent) ───
+
+  it("pure comparison parses to the SAME AST (no arithmetic wrapper nodes)", () => {
+    expect(evaluator.parse("$inputs.count == 42")).toEqual({
+      kind: "binary",
+      op: "==",
+      left: { kind: "ref", path: ["inputs", "count"] },
+      right: { kind: "literal", value: 42 },
+    });
+    // "!" stays looser than comparison: `!$a == $b` ⇒ `!($a == $b)`
+    expect(evaluator.parse("!$steps.check.output.valid == $steps.check.output.result")).toEqual({
+      kind: "unary",
+      op: "!",
+      operand: {
+        kind: "binary",
+        op: "==",
+        left: { kind: "ref", path: ["steps", "check", "output", "valid"] },
+        right: { kind: "ref", path: ["steps", "check", "output", "result"] },
+      },
+    });
+  });
+
+  it("arithmetic still respects max nesting depth (unary minus chain)", () => {
+    expect(() => evaluator.parse("-".repeat(40) + "5")).toThrow("EXPRESSION_DEPTH_EXCEEDED");
+  });
 });

--- a/test/unit/workflows/friday-workflow-node-executor.test.ts
+++ b/test/unit/workflows/friday-workflow-node-executor.test.ts
@@ -116,6 +116,49 @@ describe("FridayWorkflowNodeExecutor", () => {
     expect((result.output as Record<string, unknown>).name).toBe("Alice");
   });
 
+  it("evaluates NESTED mapping expressions (resolveArgs recursion) and arithmetic", async () => {
+    // Fail-before: resolveArgs only evaluated top-level "$"-strings, so a nested
+    // mapping value came back as the literal expression string. Pass-after: it
+    // recurses, and the (newly supported) arithmetic evaluates.
+    const executor = createExecutor();
+    const node: FridayWorkflowNode = {
+      id: "data-nested",
+      type: "data",
+      label: "Data",
+      config: {
+        mapping: {
+          outputs: { net: "$inputs.gross - $inputs.discount" },
+          total: "$inputs.a + $inputs.b",
+        },
+      } as Record<string, JsonValue>,
+    };
+    const ctx: FridayExpressionContext = {
+      inputs: { gross: 100, discount: 30, a: 7, b: 5 },
+      steps: {},
+    };
+    const result = await executor.executeNode(makeInput(node, ctx));
+    const out = result.output as Record<string, unknown>;
+    expect((out.outputs as Record<string, unknown>).net).toBe(70); // nested expr evaluated, not literal string
+    expect(out.total).toBe(12); // arithmetic evaluated
+  });
+
+  it("drops prototype-polluting mapping keys (resolveArgs safety)", async () => {
+    const executor = createExecutor();
+    const node: FridayWorkflowNode = {
+      id: "data-proto",
+      type: "data",
+      label: "Data",
+      config: {
+        mapping: { ["__proto__"]: { polluted: true }, safe: "$inputs.name" },
+      } as Record<string, JsonValue>,
+    };
+    const ctx: FridayExpressionContext = { inputs: { name: "ok" }, steps: {} };
+    const result = await executor.executeNode(makeInput(node, ctx));
+    const out = result.output as Record<string, unknown>;
+    expect(out.safe).toBe("ok");
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined(); // no global pollution
+  });
+
   it("executes data node with empty config as a null-output no-op", async () => {
     const executor = createExecutor();
     const node: FridayWorkflowNode = {

--- a/test/unit/workflows/generator/services/friday-workflow-generator-service.test.ts
+++ b/test/unit/workflows/generator/services/friday-workflow-generator-service.test.ts
@@ -612,7 +612,7 @@ describe("FridayWorkflowGeneratorService", () => {
       expect(compiledNode?.config).toEqual({ mapping: { message: "version two" } });
     });
 
-    it("normalizes top-level expression fields into step.args.transform before compilation", async () => {
+    it("normalizes a JSON-object expression string into runnable data-node mapping", async () => {
       mockFetchForLlm([
         makeRequirementsResponse("ready_for_generation"),
         makeTransformSpecResponseWithTopLevelExpression(),
@@ -644,13 +644,16 @@ describe("FridayWorkflowGeneratorService", () => {
 
       expect(result.mode).toBe("preview_ready");
       expect(result.draft).toBeDefined();
+      // A JSON-object expression STRING is rewritten to runnable `mapping`
+      // form (the prior `transform: '{"message":...}'` shape threw
+      // EXPRESSION_PARSE_ERROR at run; mapping literals pass through cleanly).
       expect(result.draft!.spec.steps[0]).toEqual({
         id: "output_version_two",
         type: "transform",
-        args: { transform: '{"message":"version two"}' },
+        args: { mapping: { message: "version two" } },
       });
       const compiledNode = result.draft!.compiledGraph.graph.nodes.find((node) => node.id === "output_version_two");
-      expect(compiledNode?.config).toEqual({ transform: '{"message":"version two"}' });
+      expect(compiledNode?.config).toEqual({ mapping: { message: "version two" } });
     });
 
     it("falls back to deterministic visual and tests when auxiliary LLM calls fail", async () => {

--- a/test/unit/workflows/generator/validation/friday-generated-workflow-validator.test.ts
+++ b/test/unit/workflows/generator/validation/friday-generated-workflow-validator.test.ts
@@ -324,6 +324,78 @@ describe("FridayGeneratedWorkflowValidator", () => {
     expect(result.issues.some((i) => i.code === "GRAPH_DATA_NODE_MISSING_MAPPING")).toBe(true);
   });
 
+  function compileWithDataNodeConfig(config: Record<string, unknown>): void {
+    const mockComp = mockCompiler as { compile: ReturnType<typeof vi.fn> };
+    mockComp.compile.mockReturnValue({
+      schemaVersion: "2.0" as const,
+      workflowId: "test-wf",
+      workflowVersionId: "v-1",
+      sourceSpecSchemaVersion: "1.0" as const,
+      graph: {
+        nodes: [
+          { id: "__trigger__", type: "trigger" as const, label: "Trigger", config: {} },
+          { id: "output_step", type: "data" as const, label: "output_step", config },
+        ],
+        edges: [{ id: "e-1", sourceNodeId: "__trigger__", targetNodeId: "output_step" }],
+      },
+      failurePolicy: { onFailure: "fail_fast" as const, notifyUser: false },
+      tests: [],
+      checksum: "graph-data-expr",
+    });
+  }
+
+  function validateDataNode() {
+    return validator.validate({
+      spec: makeSpec({
+        startStepId: "output_step",
+        steps: [{ id: "output_step", type: "transform", args: {} }],
+        outputs: [{ key: "result", fromStep: "output_step", path: "message" }],
+      }),
+      visual: makeVisual({
+        nodes: [
+          { nodeId: "__trigger__", x: 100, y: 100 },
+          { nodeId: "output_step", x: 350, y: 100 },
+        ],
+      }),
+      tests: makeTests(),
+    });
+  }
+
+  // The data-node executor exec()'s config.transform and $-prefixed mapping
+  // values; an unparseable expression (e.g. `sum(...)` instead of `$sum(...)`)
+  // passes the old presence-only check then explodes at run with
+  // EXPRESSION_PARSE_ERROR. The validator must catch it pre-approval.
+  it("rejects a data node whose config.transform has an invalid expression", () => {
+    createValidator();
+    compileWithDataNodeConfig({ transform: "sum(1, 2)" });
+    const result = validateDataNode();
+    expect(result.issues.some((i) => i.code === "GRAPH_DATA_NODE_EXPRESSION_PARSE_ERROR")).toBe(true);
+  });
+
+  it("rejects a data node whose $-prefixed mapping value has an invalid expression", () => {
+    createValidator();
+    compileWithDataNodeConfig({ mapping: { total: "$a + + b" } });
+    const result = validateDataNode();
+    expect(result.issues.some((i) => i.code === "GRAPH_DATA_NODE_EXPRESSION_PARSE_ERROR")).toBe(true);
+  });
+
+  it("does NOT flag valid expressions or literal mapping strings (no false positive)", () => {
+    createValidator();
+    // valid $-ref (parses; unresolved at runtime is fine), and a literal string
+    // that the executor never evaluates (does not start with $) must be ignored.
+    compileWithDataNodeConfig({ mapping: { total: "$steps.a.value", label: "hello world" } });
+    const result = validateDataNode();
+    expect(result.issues.some((i) => i.code === "GRAPH_DATA_NODE_EXPRESSION_PARSE_ERROR")).toBe(false);
+    expect(result.issues.some((i) => i.code === "GRAPH_DATA_NODE_MISSING_MAPPING")).toBe(false);
+  });
+
+  it("does NOT flag a valid config.transform expression", () => {
+    createValidator();
+    compileWithDataNodeConfig({ transform: "$steps.a.value" });
+    const result = validateDataNode();
+    expect(result.issues.some((i) => i.code === "GRAPH_DATA_NODE_EXPRESSION_PARSE_ERROR")).toBe(false);
+  });
+
   it("spec with missing startStepId produces error", () => {
     createValidator();
     const spec = makeSpec({ startStepId: "nonexistent" });


### PR DESCRIPTION
**Supersedes #421** (includes its data-node expression parse-check and fixes its false positive).

## Root cause
Workflow-generation-to-run threw `EXPRESSION_PARSE_ERROR` at run on validated drafts because the expression layer was too shallow for the transforms DeepSeek emits:
1. The evaluator was **reference-only** — `$a + $b`, `$x * 2`, unary `-` all threw.
2. The data-node executor's `resolveArgs` only evaluated **top-level** `$`-strings — a nested mapping `{outputs:{net:"$a - $b"}}` returned the literal expression string.
3. The generator normalizer left a **JSON-object STRING** transform (`'{"message":"x"}'`) as a non-runnable string `transform`.

## Fix (3 coordinated, safe-by-construction parts)
- **Evaluator**: add arithmetic (`+ - * / %`) + unary `-`, inserted BELOW `compare` so pure comparison/logical **conditions parse to identical ASTs** (proven by an AST-identity test). Explicit `+` coercion: numeric add only when both operands are numbers, else string concat (null/undefined→""). Still no JS `eval`; prototype-pollution guard + MAX length/depth intact (`checkDepth` covers the new unary recursion).
- **Executor `resolveArgs`**: recurse into nested objects/arrays (with a prototype-pollution key guard) so nested `$`-expressions evaluate.
- **Normalizer**: rewrite a JSON-object-literal string `transform` → runnable `mapping` (resolves #421's false positive that broke `friday-workflow-generator-service.test.ts`).

## Proof
- fail-before/pass-after units: evaluator **37/37** (arithmetic, concat both-ways, negative, precedence, condition-AST-identity, depth), node-executor **12/12** (nested recursion + proto safety), generator-service + validator green.
- blast-radius: **780/780** workflow + node-runner tests; typecheck clean; lint 0 errors.
- live: a runtime-input doubling produced `doubled=42` (real end-to-end computation, not a constant).

## Honest scope
This makes computed transforms **runnable** and resolves #421's false positive. It is a capability + correctness fix, **not** a reliability claim: generation-to-CORRECT-output reliability is measured separately (output-correctness oracle) and remains model-generation-quality-bounded → workflow-gen-to-run stays `proof_pending` / not-claimed for 1.0.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)