### PR TITLE
improve(workflows/gen): output-wiring + transform-expression prompt guidance (22.5%→72.5% strict, measured)

### DIFF
--- a/src/workflows/generator/prompts/friday-workflow-generator-prompts.ts
+++ b/src/workflows/generator/prompts/friday-workflow-generator-prompts.ts
@@ -167,6 +167,20 @@ Rules:
    - references: $inputs.<key>, $steps.<stepId>.output.<key>
    - operators: == != > < >= <= && || !
 9. outputs[].fromStep must reference an existing step.
+9a. EVERY workflow MUST declare "outputs". For each value the user asked to output, add an entry
+    { "key": "<the EXACT field name the user requested>", "fromStep": "<the step that produces it>",
+    "path": "<path INTO that step's output to reach the value, or "." for the whole output>" }.
+    Do NOT wrap the result in an extra "result" key unless the user asked for one.
+9b. transform steps compute data via args. TWO forms:
+    - args.transform: "<expression>" — the WHOLE string is evaluated as a Friday expression and the
+      step's output IS that value. Use for one computed value: {"transform": "2 + 3"} outputs 5;
+      {"transform": "$inputs.a * $inputs.b"} multiplies inputs. Then map with path ".".
+    - args.mapping: { "<field>": <value> } — builds an object; each value is evaluated as an
+      expression ONLY if it is a $-reference or expression. A BARE QUOTED ARITHMETIC STRING IS A
+      LITERAL: {"sum": "2 + 3"} outputs the TEXT "2 + 3", NOT 5. So for computed fields either
+      reference inputs/steps ({"sum": "$inputs.a + $inputs.b"}) OR, for pure constants, put the
+      already-computed literal value ({"sum": 5}, {"greeting": "Hello, World"}). Never leave an
+      un-evaluated arithmetic string in a mapping.
 10. tests must be [] (generated separately in next stage).
 11. Keep graph acyclic and connected from startStepId.
 12. Return a complete FridayWorkflowSpecV1 object only.${maintenanceRuleBlock}
@@ -199,6 +213,22 @@ Example output (simple action workflow):
   "steps": [{ "id": "action-1", "type": "skill_call", "ref": "example-skill", "args": { "data": "$inputs.input_data" } }],
   "edges": [],
   "outputs": [{ "key": "result", "fromStep": "action-1", "path": "result" }],
+  "errorPolicy": { "onFailure": "fail_fast", "notifyUser": true },
+  "tests": []
+}
+
+Example output (compute a value with a transform step — note outputs maps the EXACT field name):
+{
+  "schemaVersion": "1.0",
+  "workflowId": "template-compute-sum",
+  "name": "Compute Sum",
+  "description": "Computes a + b and outputs it as sum",
+  "startStepId": "compute",
+  "trigger": { "type": "manual" },
+  "inputs": [{ "key": "a", "type": "number", "required": true }, { "key": "b", "type": "number", "required": true }],
+  "steps": [{ "id": "compute", "type": "transform", "args": { "mapping": { "sum": "$inputs.a + $inputs.b" } } }],
+  "edges": [],
+  "outputs": [{ "key": "sum", "fromStep": "compute", "path": "sum" }],
   "errorPolicy": { "onFailure": "fail_fast", "notifyUser": true },
   "tests": []
 }`;


### PR DESCRIPTION
## Draft — DO NOT auto-merge. Operator-sequence vs the R6 anchor SHA `1608d6b3`. Quality lever, not a GO-unblocker.

Recommended-first **generation-side** reliability lever for NL workflow-generation-to-runnable-output, now **measured** (prior cycle proposed but did not ship/validate). Prompt-only change.

### Measured (52-prompt live DeepSeek oracle harness, `deepseek-v4-flash`, isolated hub, exact `1608d6b3`)
| metric | baseline | rep1 | rep2 |
|---|---|---|---|
| **strict output-correctness** | **22.5%** (9/40) | **72.5%** (29/40) | **72.5%** (29/40) |
| value-present | 0.70 | 0.83 | 0.85 |
| behavioral | 10/12 | **12/12** | **12/12** |
| repair attempts | 5 | 0 | 0 |

Two reps at the same rate ⇒ a real, reproducible **+50-point** gain; dominant `output-mapping-bug` + "expression-as-string" classes eliminated.

### What changed (accurate API guidance — NOT teach-to-test)
- **9a**: every workflow declares `outputs` mapping the exact requested field name + correct `path`; no gratuitous `result` wrapper.
- **9b**: `transform` semantics explicit — `args.transform` evaluates whole-string; `args.mapping` values evaluate only when a `$`-ref/expression (bare `"2 + 3"` is a LITERAL) — use `$`-refs or the computed constant. + compute-sum example.

### Safety / regression
- Behavioral 12/12 both reps; `46-unsafe-disable` now **refuses** (vs baseline inert no-op). 770 generator+workflow unit tests pass. Prompt-only; no runtime/validator change.

### Scope limits
- Does NOT reach ≥95% — residual ~27% (`wrong-field-name`/`wrong-or-missing-value`) is small-model semantics; ≥95% needs a deterministic output-field synthesizer / stronger model (1.1).
- Raises the floor but does NOT remove the supervised/nondeterministic truth-label (PR #426). Quality improvement, not a Full-Clean-GO unblocker.

### Why draft
Advances `main` off `1608d6b3` (R6 anchor); operator-sequence vs #426/#427/R6. No publish/tag/release/gate-flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)