### PR TITLE
fix(learning): keep inferred preferences inactive until confirmed

### DIFF
--- a/docs/current-source-of-truth.md
+++ b/docs/current-source-of-truth.md
@@ -221,7 +221,7 @@ This document is the current architecture reference for steady-state Friday runt
 - The communication style resolution priority cascade is: explicit preferences > learned preferences > system defaults.
 - The communication prompt fragment is injected into the agent's effective system prompt at runtime. Enrichment failure is non-fatal and must not kill the agent run.
 - The communication prompt builder reads both explicit preferences and learned preferences from the self-learning context builder.
-- Learned preference facts use a Bayesian-inspired confidence model with decay, conflict penalty, and evidence boost.
+- Learned preference facts use a Bayesian-inspired confidence model with decay, conflict penalty, and evidence boost. Low-confidence inferred preferences are kept below the active context threshold until an explicit/high-confidence preference or correction confirms them; repeated low-confidence observations alone must not make a learned preference affect behavior.
 - The self-learning context enrichment service is wired through hub bootstrap and becomes available after self-learning runtime creation.
 - Communication style affects wording, progress updates, failure phrasing, and clarification style only. It must not weaken approval gates, rollback rules, or destructive-action safeguards.
 - Raw learned facts are not blanket prompt injection. `createFridayPreferenceInjector` exists as a bounded injector utility and test target, but current hub prompt wiring uses the communication prompt builder plus persisted Reflex/User Constitution preference fragments instead of silently injecting raw learned facts.

--- a/src/learning/services/friday-preference-fact-service.ts
+++ b/src/learning/services/friday-preference-fact-service.ts
@@ -48,6 +48,10 @@ export interface CreatePreferenceFactServiceDeps {
 const FIRST_INFERRED_PREFERENCE_CONFIDENCE_CAP = 0.55;
 const EXPLICIT_PREFERENCE_CONFIDENCE_FLOOR = 0.8;
 
+function isUnconfirmedInferredPreference(signal: FridayExtractedSignal): boolean {
+  return signal.kind === "preference" && signal.confidence < EXPLICIT_PREFERENCE_CONFIDENCE_FLOOR;
+}
+
 /**
  * Recompute confidence using the scoring model from the plan:
  *   existingDecayed = existingConfidence * exp(-ln(2) * daysSinceLastConfirmed / halfLifeDays)
@@ -123,9 +127,7 @@ export function createFridayPreferenceFactService(
             nowIso,
             halfLifeDays,
           );
-          const gatedConfidence = !existing
-            && signal.kind === "preference"
-            && signal.confidence < EXPLICIT_PREFERENCE_CONFIDENCE_FLOOR
+          const gatedConfidence = isUnconfirmedInferredPreference(signal)
             ? Math.min(newConfidence, FIRST_INFERRED_PREFERENCE_CONFIDENCE_CAP)
             : newConfidence;
 

--- a/test/unit/learning/services/friday-learning-context-enrichment-service.test.ts
+++ b/test/unit/learning/services/friday-learning-context-enrichment-service.test.ts
@@ -162,7 +162,7 @@ describe("FridayLearningContextEnrichmentService", () => {
     expect(ctx.appliedFacts).toEqual([]);
   });
 
-  it("buildContext includes repeated inferred preferences after corroborating evidence", () => {
+  it("buildContext excludes repeated inferred preferences until explicit confirmation", () => {
     const factRepo = createFridayPreferenceFactRepository();
     const factService = createFridayPreferenceFactService({
       db,
@@ -201,9 +201,8 @@ describe("FridayLearningContextEnrichmentService", () => {
       nowIso: NOW,
     });
 
-    expect(ctx.preferences).toHaveProperty("persona.verbosity", "concise");
-    expect(ctx.appliedFacts[0]!.key).toBe("persona.verbosity");
-    expect(ctx.appliedFacts[0]!.confidence).toBeGreaterThanOrEqual(0.60);
+    expect(ctx.preferences).not.toHaveProperty("persona.verbosity");
+    expect(ctx.appliedFacts).toEqual([]);
   });
 
   it("enrichSkillPayload adds __fridayLearning envelope", () => {

--- a/test/unit/learning/services/friday-preference-fact-service.test.ts
+++ b/test/unit/learning/services/friday-preference-fact-service.test.ts
@@ -187,7 +187,7 @@ describe("FridayPreferenceFactService", () => {
     expect(active).toHaveLength(0);
   });
 
-  it("promotes repeated inferred preferences into active context", () => {
+  it("keeps repeated inferred preferences below active context until explicit confirmation", () => {
     service.applySignals({
       event: makeEvent({ eventId: "evt-001", kind: "user_message" }),
       signals: [makeSignal({ kind: "preference", key: "persona.verbosity", value: "concise", confidence: 0.65 })],
@@ -210,16 +210,14 @@ describe("FridayPreferenceFactService", () => {
 
     expect(updated).toHaveLength(1);
     expect(updated[0]!.evidenceCount).toBe(2);
-    expect(updated[0]!.confidence).toBeGreaterThanOrEqual(0.60);
+    expect(updated[0]!.confidence).toBeLessThan(0.60);
 
     const active = service.listActiveFacts({
       userId: "test-user",
       minConfidence: 0.60,
       limit: 100,
     });
-    expect(active).toHaveLength(1);
-    expect(active[0]!.key).toBe("persona.verbosity");
-    expect(active[0]!.value).toBe("concise");
+    expect(active).toHaveLength(0);
   });
 
   it("downgrades conflicting inferred preferences back below active context threshold", () => {


### PR DESCRIPTION
## Summary
- cap low-confidence inferred preference signals below the active learning-context threshold even after repeated observations
- keep explicit/high-confidence preferences and corrections eligible for active context
- update focused tests and current source-of-truth wording

## Evidence
- Evidence bundle: /tmp/friday-self-iteration-20260531-evidence/
- npm run build:api: pass
- npx vitest run focused learning/memory/autonomy/discovery suite: 229 tests passed
- npx vitest run focused API/session/self-healing/reflex suite: 30 tests passed
- DeepSeek-only direct probe passed with OpenAI env unset
- selected live DeepSeek Friday learning test passed
- npm run check:secret-patterns: pass

## Audit Verdict
Honest NO-GO for broad self-iteration/continuous-learning claims. This PR mitigates the unconfirmed inferred-preference active-context bug only; it does not implement a full suggestion/approval queue, public-web recommendations, or the 24-36h pressure lane.