### PR TITLE
[codex] fix inferred preference confirmation gate

### DIFF
--- a/docs/current-source-of-truth.md
+++ b/docs/current-source-of-truth.md
@@ -221,7 +221,7 @@ This document is the current architecture reference for steady-state Friday runt
 - The communication style resolution priority cascade is: explicit preferences > learned preferences > system defaults.
 - The communication prompt fragment is injected into the agent's effective system prompt at runtime. Enrichment failure is non-fatal and must not kill the agent run.
 - The communication prompt builder reads both explicit preferences and learned preferences from the self-learning context builder.
-- Learned preference facts use a Bayesian-inspired confidence model with decay, conflict penalty, and evidence boost.
+- Learned preference facts use a Bayesian-inspired confidence model with decay, conflict penalty, and evidence boost. Low-confidence inferred preferences are kept below the active context threshold until an explicit/high-confidence preference or correction confirms them; repeated low-confidence observations alone must not make a learned preference affect behavior.
 - The self-learning context enrichment service is wired through hub bootstrap and becomes available after self-learning runtime creation.
 - Communication style affects wording, progress updates, failure phrasing, and clarification style only. It must not weaken approval gates, rollback rules, or destructive-action safeguards.
 - Raw learned facts are not blanket prompt injection. `createFridayPreferenceInjector` exists as a bounded injector utility and test target, but current hub prompt wiring uses the communication prompt builder plus persisted Reflex/User Constitution preference fragments instead of silently injecting raw learned facts.

--- a/src/learning/services/friday-preference-extraction-service.ts
+++ b/src/learning/services/friday-preference-extraction-service.ts
@@ -23,6 +23,18 @@ function normalizeKey(field: string): string {
     .replace(/^_|_$/g, "");
 }
 
+const SENSITIVE_PREFERENCE_PATTERN =
+  /\b(password|passcode|secret|api[\s_]*key|token|ssn|social[\s_]+security|credit[\s_]+card|bank[\s_]+account|routing[\s_]+number|passport|driver'?s[\s_]+license|medical|medication|diagnosis|diabetes|cancer|hiv|financial|religion|political)\b|密码|口令|密钥|令牌|身份证|护照|银行卡|信用卡|病历|诊断|宗教|政治/u;
+
+function isSensitiveLearnedPreference(key: string, value: unknown): boolean {
+  const valueText = typeof value === "string"
+    ? value
+    : value === undefined || value === null
+      ? ""
+      : JSON.stringify(value);
+  return SENSITIVE_PREFERENCE_PATTERN.test(`${key} ${valueText}`);
+}
+
 function readCorrectionPayload(payload: Record<string, unknown>): {
   correctedField?: string;
   newValue?: unknown;
@@ -195,7 +207,9 @@ export function createFridayPreferenceExtractionService(
           const { correctedField, newValue } = readCorrectionPayload(event.payload);
           if (correctedField && newValue !== undefined) {
             const key = `pref:${normalizeKey(correctedField)}`;
-            signals.push(makeSignal("correction", key, newValue, 1.0));
+            if (!isSensitiveLearnedPreference(key, newValue)) {
+              signals.push(makeSignal("correction", key, newValue, 1.0));
+            }
           }
           break;
         }
@@ -209,9 +223,11 @@ export function createFridayPreferenceExtractionService(
               if (match) {
                 const key = rule.keyExtractor(match);
                 const value = rule.valueExtractor(match);
-                signals.push(
-                  makeSignal("preference", key, value, rule.confidence),
-                );
+                if (!isSensitiveLearnedPreference(key, value)) {
+                  signals.push(
+                    makeSignal("preference", key, value, rule.confidence),
+                  );
+                }
                 matched = true;
                 break; // first match wins
               }
@@ -223,9 +239,11 @@ export function createFridayPreferenceExtractionService(
                 if (match) {
                   const key = rule.keyExtractor(match);
                   const value = rule.valueExtractor(match);
-                  signals.push(
-                    makeSignal("preference", key, value, rule.confidence),
-                  );
+                  if (!isSensitiveLearnedPreference(key, value)) {
+                    signals.push(
+                      makeSignal("preference", key, value, rule.confidence),
+                    );
+                  }
                   break;
                 }
               }

--- a/src/learning/services/friday-preference-fact-service.ts
+++ b/src/learning/services/friday-preference-fact-service.ts
@@ -48,6 +48,10 @@ export interface CreatePreferenceFactServiceDeps {
 const FIRST_INFERRED_PREFERENCE_CONFIDENCE_CAP = 0.55;
 const EXPLICIT_PREFERENCE_CONFIDENCE_FLOOR = 0.8;
 
+function isUnconfirmedInferredPreference(signal: FridayExtractedSignal): boolean {
+  return signal.kind === "preference" && signal.confidence < EXPLICIT_PREFERENCE_CONFIDENCE_FLOOR;
+}
+
 /**
  * Recompute confidence using the scoring model from the plan:
  *   existingDecayed = existingConfidence * exp(-ln(2) * daysSinceLastConfirmed / halfLifeDays)
@@ -123,9 +127,7 @@ export function createFridayPreferenceFactService(
             nowIso,
             halfLifeDays,
           );
-          const gatedConfidence = !existing
-            && signal.kind === "preference"
-            && signal.confidence < EXPLICIT_PREFERENCE_CONFIDENCE_FLOOR
+          const gatedConfidence = isUnconfirmedInferredPreference(signal)
             ? Math.min(newConfidence, FIRST_INFERRED_PREFERENCE_CONFIDENCE_CAP)
             : newConfidence;
 

--- a/test/unit/learning/runtime/friday-self-learning-runtime.test.ts
+++ b/test/unit/learning/runtime/friday-self-learning-runtime.test.ts
@@ -198,7 +198,7 @@ describe("FridaySelfLearningRuntime", () => {
     expect(ctx.preferences).toHaveProperty("pref:display_name", "Captain");
   });
 
-  it("pipeline end-to-end: inferred persona preference requires repeated evidence before context use", () => {
+  it("pipeline end-to-end: inferred persona preference stays inactive until explicit confirmation", () => {
     const first = runtime.pipeline.processEvent({
       eventId: "evt-001",
       ts: NOW,
@@ -224,11 +224,11 @@ describe("FridaySelfLearningRuntime", () => {
     });
 
     expect(second.factsUpdated).toHaveLength(1);
-    expect(second.factsUpdated[0]!.confidence).toBeGreaterThanOrEqual(0.60);
+    expect(second.factsUpdated[0]!.confidence).toBeLessThan(0.60);
     expect(runtime.context.buildContext({
       userId: "test-user",
       nowIso: NOW,
-    }).preferences).toHaveProperty("persona.verbosity", "concise");
+    }).preferences).not.toHaveProperty("persona.verbosity");
   });
 
   it("pipeline end-to-end: error → incident → diagnosis (Phase 7: no lesson at ingestion)", () => {

--- a/test/unit/learning/runtime/friday-self-learning-runtime.test.ts
+++ b/test/unit/learning/runtime/friday-self-learning-runtime.test.ts
@@ -198,6 +198,31 @@ describe("FridaySelfLearningRuntime", () => {
     expect(ctx.preferences).toHaveProperty("pref:display_name", "Captain");
   });
 
+  it("pipeline end-to-end: sensitive preferences are not persisted automatically", () => {
+    const fromMessage = runtime.pipeline.processEvent({
+      eventId: "evt-sensitive-001",
+      ts: NOW,
+      userId: "test-user",
+      kind: "user_message",
+      payload: { text: "always use hunter2 for password" },
+    });
+    const fromCorrection = runtime.pipeline.processEvent({
+      eventId: "evt-sensitive-002",
+      ts: NOW,
+      userId: "test-user",
+      kind: "user_correction",
+      payload: { correctedField: "medical diagnosis", newValue: "diabetes" },
+    });
+
+    expect(fromMessage.factsUpdated).toEqual([]);
+    expect(fromCorrection.factsUpdated).toEqual([]);
+    expect(runtime.facts.listActiveFacts({
+      userId: "test-user",
+      minConfidence: 0,
+      limit: 100,
+    })).toEqual([]);
+  });
+
   it("pipeline end-to-end: inferred persona preference stays inactive until explicit confirmation", () => {
     const first = runtime.pipeline.processEvent({
       eventId: "evt-001",

--- a/test/unit/learning/services/friday-learning-context-enrichment-service.test.ts
+++ b/test/unit/learning/services/friday-learning-context-enrichment-service.test.ts
@@ -162,7 +162,7 @@ describe("FridayLearningContextEnrichmentService", () => {
     expect(ctx.appliedFacts).toEqual([]);
   });
 
-  it("buildContext includes repeated inferred preferences after corroborating evidence", () => {
+  it("buildContext excludes repeated inferred preferences until explicit confirmation", () => {
     const factRepo = createFridayPreferenceFactRepository();
     const factService = createFridayPreferenceFactService({
       db,
@@ -201,9 +201,8 @@ describe("FridayLearningContextEnrichmentService", () => {
       nowIso: NOW,
     });
 
-    expect(ctx.preferences).toHaveProperty("persona.verbosity", "concise");
-    expect(ctx.appliedFacts[0]!.key).toBe("persona.verbosity");
-    expect(ctx.appliedFacts[0]!.confidence).toBeGreaterThanOrEqual(0.60);
+    expect(ctx.preferences).not.toHaveProperty("persona.verbosity");
+    expect(ctx.appliedFacts).toEqual([]);
   });
 
   it("enrichSkillPayload adds __fridayLearning envelope", () => {

--- a/test/unit/learning/services/friday-preference-extraction-service.test.ts
+++ b/test/unit/learning/services/friday-preference-extraction-service.test.ts
@@ -66,6 +66,23 @@ describe("FridayPreferenceExtractionService", () => {
       expect(signals[0]!.value).toBe("TypeScript");
     });
 
+    it("does not extract sensitive correction facts", () => {
+      const sensitivePayloads = [
+        { correctedField: "password", newValue: "hunter2" },
+        { correctedField: "medical diagnosis", newValue: "diabetes" },
+        { field: "credit card", value: "4111111111111111" },
+      ];
+      for (const [index, payload] of sensitivePayloads.entries()) {
+        const event = makeEvent({
+          eventId: `evt-sensitive-${String(index)}`,
+          kind: "user_correction",
+          payload,
+        });
+
+        expect(service.extract(event)).toHaveLength(0);
+      }
+    });
+
     it("returns empty for missing correctedField", () => {
       const event = makeEvent({
         kind: "user_correction",
@@ -139,6 +156,23 @@ describe("FridayPreferenceExtractionService", () => {
       expect(signals[0]!.kind).toBe("preference");
       expect(signals[0]!.key).toBe("pref:display_name");
       expect(signals[0]!.value).toBe("测试名");
+    });
+
+    it("does not extract sensitive user-message preferences", () => {
+      for (const text of [
+        "always use hunter2 for password",
+        "I prefer insulin for medication",
+        "call me my-secret-token",
+        "以后叫我 密码123",
+      ]) {
+        const event = makeEvent({
+          eventId: `evt-sensitive-${text.length}`,
+          kind: "user_message",
+          payload: { text },
+        });
+
+        expect(service.extract(event)).toHaveLength(0);
+      }
     });
 
     it("returns empty for no matching pattern", () => {

--- a/test/unit/learning/services/friday-preference-fact-service.test.ts
+++ b/test/unit/learning/services/friday-preference-fact-service.test.ts
@@ -187,7 +187,7 @@ describe("FridayPreferenceFactService", () => {
     expect(active).toHaveLength(0);
   });
 
-  it("promotes repeated inferred preferences into active context", () => {
+  it("keeps repeated inferred preferences below active context until explicit confirmation", () => {
     service.applySignals({
       event: makeEvent({ eventId: "evt-001", kind: "user_message" }),
       signals: [makeSignal({ kind: "preference", key: "persona.verbosity", value: "concise", confidence: 0.65 })],
@@ -210,16 +210,14 @@ describe("FridayPreferenceFactService", () => {
 
     expect(updated).toHaveLength(1);
     expect(updated[0]!.evidenceCount).toBe(2);
-    expect(updated[0]!.confidence).toBeGreaterThanOrEqual(0.60);
+    expect(updated[0]!.confidence).toBeLessThan(0.60);
 
     const active = service.listActiveFacts({
       userId: "test-user",
       minConfidence: 0.60,
       limit: 100,
     });
-    expect(active).toHaveLength(1);
-    expect(active[0]!.key).toBe("persona.verbosity");
-    expect(active[0]!.value).toBe("concise");
+    expect(active).toHaveLength(0);
   });
 
   it("downgrades conflicting inferred preferences back below active context threshold", () => {


### PR DESCRIPTION
## What changed

- Keeps low-confidence inferred preference signals below the active learning-context threshold on every observation, not only the first observation.
- Blocks automatic extraction of sensitive learned-preference candidates from correction and user-message preference patterns before persistence.
- Updates learning/context/runtime tests so repeated inferred persona preferences remain inactive until explicit or high-confidence confirmation, and password/token/payment/medical examples are not auto-learned.
- Updates the current source-of-truth doc to state the confirmation boundary clearly.

## Why

The self-iteration audit found two learning-policy mismatches:

- Repeated inferred preferences could accumulate enough confidence to affect later behavior without user confirmation.
- Broad preference extraction rules could auto-persist sensitive preference-like content from messages or corrections.

The locked learning direction requires suggestion-first behavior and sensitive/private/high-risk learned facts to default to not auto-learned.

## Evidence

Local isolated evidence directory: `/tmp/friday-self-iteration-20260531-evidence/`

Key receipts:
- `SYSTEM-MAP.md`
- `preflight.md`
- `preflight-api-summary.json`
- `deepseek-direct-probe-summary.json`
- `PREFS-MEMORY-LIFECYCLE.md`
- `preference-lifecycle-summary.json` (50 preference/fact ops, 30 corrections, 10 revokes, 5 restart persistence checks, 5 cross-user isolation checks)
- `COVERAGE-MATRIX.md`
- `REDTEAM.md`
- `personalization-behavior-summary.json` (15 DeepSeek-backed personalized tasks, 15 measurable A/B differences, 5 corrected-vs-stale checks)
- `ALLOWED-CLAIMS.md`
- `FORBIDDEN-CLAIMS.md`

## Validation

- `npx vitest run test/unit/learning/services/friday-preference-extraction-service.test.ts test/unit/learning/runtime/friday-self-learning-runtime.test.ts test/unit/learning/services/friday-preference-fact-service.test.ts test/unit/learning/services/friday-learning-context-enrichment-service.test.ts` - 77 passed
- `npx vitest run test/unit/learning test/unit/agent/runtime/friday-agent-learning-bridge.test.ts test/unit/agent/runtime/friday-agent-preference-injector.test.ts test/unit/api/http/routes/friday-uix-routes.test.ts test/unit/memory/services/friday-memory-service.test.ts` - 373 passed
- `npx vitest run --project default test/e2e/live/friday-self-iteration-preflight-wrapper.test.ts` - 1 passed (temporary wrapper removed)
- `npx vitest run --project default test/e2e/live/friday-self-iteration-lifecycle-wrapper.test.ts` - 1 passed (temporary wrapper removed)
- `npm run typecheck` - passed
- `npm run check:secret-patterns` - passed
- `git diff --check` - passed
- Live DeepSeek personalization harness - 1 passed (temporary wrapper removed)
- Evidence/state secret scan - passed, no matches
- `npm run lint` - exit 0, existing warning baseline only
- GitHub CI run `26707230779` - passed on head `aef388d3360883f64a5b00ebda595106dd113215`
- GitHub RGG run `26707230047` - passed on head `aef388d3360883f64a5b00ebda595106dd113215`

## Audit status

This PR fixes two real self-iteration learning blockers. It does not claim full self-iteration GO: public web recommendations, long-run pressure, live browser UI walkthrough, and full red-team remain pending/proof_pending beyond the narrower local/direct evidence recorded in the audit artifacts.
