### PR TITLE
[codex] fix UIX persona preference key mapping

### DIFF
--- a/src/api/http/routes/friday-uix-routes.ts
+++ b/src/api/http/routes/friday-uix-routes.ts
@@ -1,6 +1,9 @@
 import { FridayDomainError } from "#errors";
 import type { FridayProviderTenantContext } from "#providers";
-import { isMbti } from "../../../uix/services/friday-communication-persona.js";
+import {
+  FRIDAY_COMMUNICATION_PREFERENCE_KEYS,
+  isMbti,
+} from "../../../uix/services/friday-communication-persona.js";
 import type { FridayUixSurfaceService } from "../../../uix/services/friday-uix-surface-service.js";
 import type { FridayRouteDefinition } from "../../model/friday-api-common.types.js";
 import type {
@@ -323,16 +326,26 @@ export function createFridayUixRoutes(
         const settings = (body?.settings ?? {}) as Record<string, unknown>;
 
         // Map persona settings to user preferences with category "communication"
-        const validKeys = new Set(["tone", "verbosity", "structure", "questionStyle", "directness", "emojiStyle", "jargonTolerance", "assumptionStyle", "confirmationStyle"]);
+        const validKeys = new Map<string, string>([
+          ["tone", FRIDAY_COMMUNICATION_PREFERENCE_KEYS.tone],
+          ["verbosity", FRIDAY_COMMUNICATION_PREFERENCE_KEYS.verbosity],
+          ["structure", FRIDAY_COMMUNICATION_PREFERENCE_KEYS.structure],
+          ["questionStyle", FRIDAY_COMMUNICATION_PREFERENCE_KEYS.questionStyle],
+          ["directness", FRIDAY_COMMUNICATION_PREFERENCE_KEYS.directness],
+          ["emojiStyle", FRIDAY_COMMUNICATION_PREFERENCE_KEYS.emojiStyle],
+          ["jargonTolerance", FRIDAY_COMMUNICATION_PREFERENCE_KEYS.jargonTolerance],
+          ["assumptionStyle", FRIDAY_COMMUNICATION_PREFERENCE_KEYS.assumptionStyle],
+          ["confirmationStyle", FRIDAY_COMMUNICATION_PREFERENCE_KEYS.confirmationStyle],
+        ]);
         const preferences: Array<{ category: "communication"; key: string; value: string }> = [];
         for (const [key, value] of Object.entries(settings)) {
           if (validKeys.has(key) && typeof value === "string" && value.trim().length > 0) {
-            preferences.push({ category: "communication", key, value: value.trim() });
+            preferences.push({ category: "communication", key: validKeys.get(key)!, value: value.trim() });
           }
         }
 
         if (preferences.length === 0) {
-          throw new FridayDomainError("VALIDATION_ERROR", "At least one valid persona setting is required. Valid keys: " + [...validKeys].join(", "), { httpStatus: 400 });
+          throw new FridayDomainError("VALIDATION_ERROR", "At least one valid persona setting is required. Valid keys: " + [...validKeys.keys()].join(", "), { httpStatus: 400 });
         }
 
         deps.service.updatePreferences({

--- a/test/e2e/mock/friday-mock-validation-chains.e2e.test.ts
+++ b/test/e2e/mock/friday-mock-validation-chains.e2e.test.ts
@@ -288,6 +288,54 @@ describe("Friday Validation Chain E2E", () => {
       expect(toneItem?.value).toBe("analytical");
     });
 
+    it("PUT persona maps UI setting keys to canonical communication preference keys", { timeout: TEST_TIMEOUT_MS }, async () => {
+      const putRes = await apiFetch<{
+        ok: boolean;
+        data: {
+          persona: {
+            settings: {
+              tone: string;
+              verbosity: string;
+              structure: string;
+              directness: string;
+            };
+          };
+        };
+        error?: { code: string; message: string };
+      }>(env.baseUrl, env.accessToken, "PUT", "/v1/uix/persona", {
+        settings: {
+          tone: "warm",
+          verbosity: "concise",
+          structure: "structured",
+          directness: "direct",
+        },
+      });
+
+      expect(putRes.status).toBe(200);
+      expect(putRes.json.ok).toBe(true);
+      expect(putRes.json.data.persona.settings).toMatchObject({
+        tone: "warm",
+        verbosity: "concise",
+        structure: "structured",
+        directness: "direct",
+      });
+
+      const getRes = await apiFetch<{
+        ok: boolean;
+        data: { items: Array<{ category: string; key: string; value: unknown }> };
+      }>(env.baseUrl, env.accessToken, "GET", "/v1/uix/preferences");
+
+      expect(getRes.status).toBe(200);
+      expect(getRes.json.data.items).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ category: "communication", key: "persona.tone", value: "warm" }),
+          expect.objectContaining({ category: "communication", key: "persona.verbosity", value: "concise" }),
+          expect.objectContaining({ category: "communication", key: "persona.structure", value: "structured" }),
+          expect.objectContaining({ category: "communication", key: "persona.directness", value: "direct" }),
+        ]),
+      );
+    });
+
     it("invalid MBTI type is rejected with 400", { timeout: TEST_TIMEOUT_MS }, async () => {
       const res = await apiFetch<{
         ok: boolean;


### PR DESCRIPTION
## Summary
- map /v1/uix/persona UI setting keys to canonical communication preference keys before persistence
- add an E2E regression proving persona update readback and canonical preference persistence

## Verification
- git diff --check
- npx vitest run test/e2e/mock/friday-mock-validation-chains.e2e.test.ts -t "PUT persona maps UI setting keys"
- npm run typecheck:src
- npm run check:secret-patterns

## Evidence Context
Found while proving live agent-route personalization. Before this fix, PUT /v1/uix/persona accepted UI-facing keys but forwarded them to validation that expects persona.* keys, causing 400 before the agent route could exercise confirmed communication preferences.