### PR TITLE
[codex] add workflow generator persona context

### DIFF
--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -4066,14 +4066,15 @@ export async function createFridayHub(
     if (userRulesFragment) {
       fragments.push(userRulesFragment);
     }
-    if (input.userId) {
+    const userId = input.userId;
+    if (userId) {
       const explicitPreferences = stateRuntime.sqlite.withReadConnection((db) =>
         uixUserPreferenceRepository.listByPrincipal(db, {
-          principalId: input.userId!,
+          principalId: userId,
           category: "communication",
         }));
       const learnedPreferences = _learningContextRef?.buildContext({
-        userId: input.userId,
+        userId,
         nowIso: nowIso(),
       }).preferences ?? {};
       const persona = resolveFridayCommunicationPersona({
@@ -4084,7 +4085,7 @@ export async function createFridayHub(
       if (personaFragment.trim().length > 0) {
         fragments.push(personaFragment.trim());
       }
-      const reflexFragment = buildReflexPreferencePromptFragment(input.userId);
+      const reflexFragment = buildReflexPreferencePromptFragment(userId);
       if (reflexFragment) {
         fragments.push(reflexFragment);
       }

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -77,6 +77,7 @@ import type { SkillLifecycleStatus, SkillOrigin, SkillSource } from "#skills";
 import { createFridaySkillExecutor } from "#skills";
 import { createFridaySkillGeneratorService } from "#skills/generator";
 import { createFridayWorkflowGeneratorService } from "#workflows";
+import type { FridayWorkflowGeneratorService } from "#workflows";
 import {
   createDarwinProgramScanner,
   createFridayProgramDiscoveryService,
@@ -1693,21 +1694,7 @@ export async function createFridayHub(
 
   // ─── Workflow generator service ───
 
-  const workflowGenerator = createFridayWorkflowGeneratorService({
-    db: stateRuntime!.sqlite,
-    providerService,
-    workflowCrud: workflowRuntime.crud,
-    skillRegistry: registry,
-    getSkillLifecycleStatus: getPersistedSkillLifecycleStatus,
-    idGenerator,
-    nowIso,
-    computeChecksum,
-    userRulesContextProvider: (input) =>
-      buildFridayUserRulesPromptContext({
-        task: input.task,
-        surface: input.surface,
-      }),
-  });
+  let workflowGenerator: FridayWorkflowGeneratorService;
 
   // ─── Agent runtime ───
 
@@ -4066,6 +4053,56 @@ export async function createFridayHub(
     fragments.push(`Friday Reflex preferences:\n${lines.join("\n")}`);
     return fragments.join("\n\n");
   };
+  const buildWorkflowGeneratorPromptContext = async (input: {
+    task: string;
+    userId?: string;
+    channel?: string;
+  }): Promise<string | null> => {
+    const fragments: string[] = [];
+    const userRulesFragment = await buildFridayUserRulesPromptContext({
+      task: input.task,
+      surface: "workflow_generator",
+    });
+    if (userRulesFragment) {
+      fragments.push(userRulesFragment);
+    }
+    if (input.userId) {
+      const explicitPreferences = stateRuntime.sqlite.withReadConnection((db) =>
+        uixUserPreferenceRepository.listByPrincipal(db, {
+          principalId: input.userId!,
+          category: "communication",
+        }));
+      const learnedPreferences = _learningContextRef?.buildContext({
+        userId: input.userId,
+        nowIso: nowIso(),
+      }).preferences ?? {};
+      const persona = resolveFridayCommunicationPersona({
+        explicitPreferences,
+        learnedPreferences,
+      });
+      const personaFragment = buildFridayCommunicationPromptFragment(persona);
+      if (personaFragment.trim().length > 0) {
+        fragments.push(personaFragment.trim());
+      }
+      const reflexFragment = buildReflexPreferencePromptFragment(input.userId);
+      if (reflexFragment) {
+        fragments.push(reflexFragment);
+      }
+    }
+    return fragments.length > 0 ? fragments.join("\n\n") : null;
+  };
+
+  workflowGenerator = createFridayWorkflowGeneratorService({
+    db: stateRuntime!.sqlite,
+    providerService,
+    workflowCrud: workflowRuntime.crud,
+    skillRegistry: registry,
+    getSkillLifecycleStatus: getPersistedSkillLifecycleStatus,
+    idGenerator,
+    nowIso,
+    computeChecksum,
+    userRulesContextProvider: buildWorkflowGeneratorPromptContext,
+  });
 
   // ─── Tool approval gates (GAP 2) ───
   // Shared promise map for tool-level approval flow.

--- a/test/unit/workflows/generator/services/friday-workflow-generator-service.test.ts
+++ b/test/unit/workflows/generator/services/friday-workflow-generator-service.test.ts
@@ -441,6 +441,40 @@ describe("FridayWorkflowGeneratorService", () => {
       expect(readFetchSystemPrompt()).toContain("Ask before saving generated workflows.");
     });
 
+    it("injects communication preference guidance into workflow generator prompts", async () => {
+      deps.userRulesContextProvider = vi.fn().mockResolvedValue(
+        [
+          "<friday-user-project-rules>Keep durable saves behind approval.</friday-user-project-rules>",
+          "Communication persona (user-facing guidance only):",
+          "- Tone: analytical",
+          "- Verbosity: concise",
+          "- Structure: structured",
+          "- Directness: direct",
+          "- These settings affect wording, guidance, and clarification style only.",
+          "- They must not weaken approval gates, rollback rules, or destructive-action safeguards.",
+        ].join("\n"),
+      );
+      service = createFridayWorkflowGeneratorService(deps);
+      mockFetchForLlm([makeRequirementsResponse("needs_clarification")]);
+
+      await service.startSession({
+        goal: "Build a workflow",
+        userId: "u-1",
+        channel: "test",
+      });
+
+      expect(deps.userRulesContextProvider).toHaveBeenCalledWith({
+        task: "Build a workflow",
+        userId: "u-1",
+        channel: "test",
+        surface: "workflow_generator",
+      });
+      expect(readFetchSystemPrompt()).toContain("Communication persona");
+      expect(readFetchSystemPrompt()).toContain("- Tone: analytical");
+      expect(readFetchSystemPrompt()).toContain("- Verbosity: concise");
+      expect(readFetchSystemPrompt()).toContain("must not weaken approval gates");
+    });
+
     it("auto-generates draft when ready", async () => {
       mockFetchForLlm([
         makeRequirementsResponse("ready_for_generation"),


### PR DESCRIPTION
## Summary
- move workflow generator construction until shared UIX/reflex preference prompt builders are available
- inject confirmed communication persona guidance into workflow generator prompt context when a userId is present
- add focused unit coverage proving the guidance reaches the workflow generator system prompt

## Verification
- git diff --check
- npx vitest run test/unit/workflows/generator/services/friday-workflow-generator-service.test.ts
- npx vitest run test/unit/workflows/generator/services/friday-workflow-generator-service.test.ts -t "injects communication preference guidance"
- npx tsc --noEmit --pretty false
- npm run typecheck
- npm run check:secret-patterns
- npm run lint -- src/hub/friday-hub-bootstrap.ts test/unit/workflows/generator/services/friday-workflow-generator-service.test.ts (warnings only, existing repo-wide lint warnings)

## Evidence Context
Advances the Phase 3 workflow-generator personalization gap. Evidence in /tmp/friday-self-iteration-20260531-evidence/WORKFLOW-GENERATOR-PERSONALIZATION.md records a focused live DeepSeek proof that the requirements-analysis provider request includes confirmed UIX communication preferences as prompt guidance.