### PR TITLE
Guard session memory sensitive extraction

### DIFF
--- a/src/sessions/services/friday-session-memory-extraction-llm-client.ts
+++ b/src/sessions/services/friday-session-memory-extraction-llm-client.ts
@@ -60,8 +60,9 @@ Rules:
 - Use "kind" to classify: "fact", "decision", "preference", or "action_item".
 - Reference the source message IDs that contributed to each item.
 - Content should be concise but complete enough to be useful without the original conversation.
-- Preserve the exact user-stated value for names, codenames, passphrases, labels, and stylistic preferences when those specifics matter.
+- Preserve the exact user-stated value for names, codenames, labels, and stylistic preferences when those specifics matter.
 - Do not generalize a concrete preference into a broader summary. For example, if the user specifies a release-note style, keep that wording instead of replacing it with something vague like "concise release notes."
+- Do not extract secrets, credentials, passphrases, API keys, tokens, financial identifiers, medical details, identity documents, political/religious traits, or other high-risk sensitive facts or preferences.
 - Do not extract trivial greetings, acknowledgments, or filler.
 - If there is nothing meaningful to extract, return an empty items array.
 

--- a/src/sessions/services/friday-session-memory-extraction-service.ts
+++ b/src/sessions/services/friday-session-memory-extraction-service.ts
@@ -1,5 +1,6 @@
 import { FridayDomainError } from "#errors";
 import { safeJsonParse } from "#utilities";
+import { isFridaySensitiveLearningCandidate } from "../../learning/services/friday-sensitive-learning-guard.js";
 
 import {
   FRIDAY_SESSION_MEMORY_EXTRACTION_DEFAULT_BATCH_SIZE,
@@ -14,6 +15,7 @@ import {
   FRIDAY_SESSION_MEMORY_EXTRACTION_TAG_PREFIX_KIND,
 } from "../friday-session-memory-extraction.constants.js";
 import type {
+  FridaySessionMemoryExtractionLlmItem,
   FridaySessionMemoryExtractionRunResult,
   FridaySessionMemoryExtractionStatus,
   FridaySessionMemoryExtractionTrigger,
@@ -167,6 +169,17 @@ export function createFridaySessionMemoryExtractionService(
     return { processable, alreadyExtracted };
   }
 
+  function isSensitiveExtractionItem(
+    item: FridaySessionMemoryExtractionLlmItem,
+    batch: FridaySessionMessageRecord[],
+  ): boolean {
+    const sourceTextById = new Map(batch.map((message) => [message.id, message.contentText]));
+    const sourceTexts = item.sourceMessageIds
+      .map((id) => sourceTextById.get(id))
+      .filter((text): text is string => typeof text === "string" && text.length > 0);
+    return isFridaySensitiveLearningCandidate(item.content, item.tags, sourceTexts);
+  }
+
   async function processInline(
     sessionKey: string,
     trigger: FridaySessionMemoryExtractionTrigger,
@@ -233,7 +246,9 @@ export function createFridaySessionMemoryExtractionService(
           },
         );
 
-        if (llmResponse.items.length === 0) {
+        const safeItems = llmResponse.items.filter((item) => !isSensitiveExtractionItem(item, batch));
+
+        if (safeItems.length === 0) {
           // No items — mark all as skipped
           updateMessageExtractStatus(
             batch.map((m) => m.id),
@@ -246,14 +261,14 @@ export function createFridaySessionMemoryExtractionService(
 
         // Collect which message IDs were referenced by items
         const referencedIds = new Set<string>();
-        for (const item of llmResponse.items) {
+        for (const item of safeItems) {
           for (const id of item.sourceMessageIds) {
             referencedIds.add(id);
           }
         }
 
         // Store memory items
-        for (const item of llmResponse.items) {
+        for (const item of safeItems) {
           const tags = [
             sourceTag,
             `session:${sessionKey}`,

--- a/test/integration/sessions/friday-session-memory-extraction-integration.test.ts
+++ b/test/integration/sessions/friday-session-memory-extraction-integration.test.ts
@@ -299,6 +299,77 @@ describe("Session memory extraction — integration", () => {
     expect(mockMemory.storedItems[0]!.tags).toContain("color.preference");
   });
 
+  it("filters sensitive LLM-proposed memory items before storage", async () => {
+    const session = await sessionService.createSession({
+      channel: "discord",
+      chatId: "sensitive-filter-chat-001",
+    });
+
+    await sessionService.addMessage(session.key, {
+      role: "user",
+      content: "My medical diagnosis is EXTRACT_DIAGNOSIS_SHOULD_NOT_PERSIST.",
+    });
+    await sessionService.addMessage(session.key, {
+      role: "user",
+      content: "For non-sensitive editor preferences, I prefer Helix for quick terminal edits.",
+    });
+
+    const messages = await sessionService.getMessages(session.key);
+    const sensitiveMessageId = messages[0]!.id;
+    const preferenceMessageId = messages[1]!.id;
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          choices: [
+            {
+              message: {
+                content: JSON.stringify({
+                  items: [
+                    {
+                      kind: "fact",
+                      content: "User's medical diagnosis is EXTRACT_DIAGNOSIS_SHOULD_NOT_PERSIST.",
+                      sourceMessageIds: [sensitiveMessageId],
+                      tags: ["medical"],
+                    },
+                    {
+                      kind: "preference",
+                      content: "User prefers Helix for quick terminal edits.",
+                      sourceMessageIds: [preferenceMessageId],
+                      tags: ["editor.preference"],
+                    },
+                  ],
+                }),
+              },
+            },
+          ],
+          usage: { prompt_tokens: 120, completion_tokens: 80, total_tokens: 200 },
+        }),
+      }),
+    );
+
+    const result = await extractionService.extractFromSession(session.key, {
+      trigger: "manual",
+      mode: "inline",
+    });
+
+    expect(result.processedMessageCount).toBe(2);
+    expect(result.memoryItemsCreated).toBe(1);
+    expect(result.extractedMessageCount).toBe(1);
+    expect(result.skippedMessageCount).toBe(1);
+    expect(mockMemory.storedItems).toHaveLength(1);
+    expect(mockMemory.storedItems[0]!.content).toContain("Helix");
+    expect(mockMemory.storedItems[0]!.content).not.toContain("EXTRACT_DIAGNOSIS_SHOULD_NOT_PERSIST");
+
+    const statusAfter = await extractionService.getExtractionStatus(session.key);
+    expect(statusAfter.extractedMessages).toBe(1);
+    expect(statusAfter.skippedMessages).toBe(1);
+    expect(statusAfter.failedMessages).toBe(0);
+  });
+
   // ── extraction_status_reflects_state ───────────────────────────────────
 
   it("extraction_status_reflects_state", async () => {


### PR DESCRIPTION
## Summary
- remove passphrase-preservation language from the session-memory extraction prompt
- tell the extractor not to extract secrets, credentials, medical details, financial identifiers, identity facts, political/religious traits, or other high-risk sensitive facts/preferences
- filter every model-proposed session-memory extraction item plus its referenced source message text through the shared sensitive-learning guard before storage
- add a focused integration regression proving a proposed medical diagnosis marker is skipped while a benign same-batch editor preference still persists

## Verification
- `git diff --check`
- `npm run check:secret-patterns`
- `npm run typecheck -- --pretty false`
- `npm run lint -- --quiet`
- `npx eslint src/sessions/services/friday-session-memory-extraction-llm-client.ts src/sessions/services/friday-session-memory-extraction-service.ts` (0 errors, existing warnings only)
- `npx vitest run test/integration/sessions/friday-session-memory-extraction-integration.test.ts test/unit/sessions/services/friday-session-memory-extraction-llm-client.test.ts test/unit/api/http/routes/friday-session-routes.test.ts -t "Session memory extraction|FridaySessionMemoryExtractionLlmClient|sessions.memory" --reporter=verbose`

Focused regression: 3 files passed, 36 tests passed / 63 skipped by filter, no type errors. The new test processed a sensitive medical diagnosis marker and a benign Helix editor preference in one extraction batch; only the benign item was stored.

Boundary: this is a deterministic service/integration guard with mocked extractor output, not a live DeepSeek extraction proof.
