### PR TITLE
Guard autonomous decisions from latest-news retry

### DIFF
--- a/src/agent/runtime/friday-agent-runtime.ts
+++ b/src/agent/runtime/friday-agent-runtime.ts
@@ -1173,7 +1173,8 @@ export function createFridayAgentRuntime(
         toolNames: buildVisibleToolNames(),
         toolRouting: effectiveToolRouting,
       });
-      const timeSensitiveNewsRequested = hasTimeSensitiveNewsIntent(params.task, messages);
+      const timeSensitiveNewsRequested = !isAutonomousInternalReasoningSurface(params.executionContext?.surface)
+        && hasTimeSensitiveNewsIntent(params.task, messages);
       const allToolCalls: FridayAgentToolCallRecord[] = [];
       let toolErrorRecoveryCount = 0;
       const TOOL_ERROR_RECOVERY_MAX = 2;

--- a/test/unit/agent/runtime/friday-agent-runtime.test.ts
+++ b/test/unit/agent/runtime/friday-agent-runtime.test.ts
@@ -3301,6 +3301,55 @@ describe("FridayAgentRuntime", () => {
     expect(result.response).not.toContain("I could not verify that these are the latest results");
   });
 
+  it("does not apply latest-news retry enforcement to autonomous internal decision prompts", async () => {
+    let callCount = 0;
+    const decisionJson = JSON.stringify({
+      kind: "complete",
+      summary: "{\"observedTone\":\"analytical\"}",
+    });
+    const llmClient: FridayAgentLlmClient = {
+      async *stream() {
+        callCount++;
+        yield { type: "text_delta", text: decisionJson };
+        yield { type: "message_end", stopReason: "end_turn", inputTokens: 8, outputTokens: 18 };
+      },
+    };
+
+    const runtime = createFridayAgentRuntime({
+      db,
+      llmClient,
+      model: "test-model",
+      providerId: "test-provider",
+      systemPrompt: "You are a test agent.",
+      tools: [],
+      eventEmitter: createFridayAgentEventEmitter(),
+      idGenerator,
+      nowIso: () => NOW,
+    });
+
+    const result = await runtime.executeRun({
+      task: [
+        "Current goal: Marker AUTO_PERSONA_test.",
+        "Current step: This internal control-plane task is not a news, latestness, date, search, or source-citation task.",
+        "Return JSON only.",
+      ].join("\n"),
+      constraints: {
+        readOnly: true,
+        operationalMode: "plan",
+      },
+      executionContext: {
+        surface: "autonomous_internal_decision",
+      },
+      timezone: "UTC",
+    });
+
+    expect(result.status).toBe("completed");
+    expect(callCount).toBe(1);
+    expect(result.response).toBe(decisionJson);
+    expect(result.response).not.toContain("unverified search results");
+    expect(result.response).not.toContain("I could not verify that these are the latest results");
+  });
+
   it("does not treat a plain article read as time-sensitive news", async () => {
     let callCount = 0;
     const webFetchSpy = vi.fn();


### PR DESCRIPTION
## Summary
- skip generic time-sensitive news response enforcement for autonomous_internal_* reasoning surfaces
- add a runtime regression for the Current goal / not-news internal decision prompt shape
- unblocks focused live DeepSeek autonomous personalization proof after the first run exposed the retry collision

## Verification
- npx vitest run test/unit/agent/runtime/friday-agent-runtime.test.ts -t "autonomous internal decision prompts" --reporter=verbose
- live DeepSeek: npx vitest run test/e2e/live/friday-autonomous-personalization-live.temp.test.ts --reporter=verbose
- git diff --check
- npm run check:secret-patterns
- npm run typecheck -- --pretty false

Evidence is recorded under /tmp/friday-self-iteration-20260531-evidence/AUTONOMOUS-PERSONALIZATION.md.