### PR TITLE
[codex] guard normalized driver license learning

### DIFF
--- a/src/learning/services/friday-sensitive-learning-guard.ts
+++ b/src/learning/services/friday-sensitive-learning-guard.ts
@@ -1,5 +1,5 @@
 const SENSITIVE_LEARNING_PATTERN =
-  /\b(password|passcode|secret|api[\s_-]*key|access[\s_-]*token|refresh[\s_-]*token|token|credential|private[\s_-]*key|ssn|social[\s_]+security|credit[\s_]+card|bank[\s_]+account|routing[\s_]+number|passport|driver'?s[\s_]+license|medical|medication|diagnosis|diabetes|cancer|hiv|financial|religion|political)\b|密码|口令|密钥|令牌|身份证|护照|银行卡|信用卡|病历|诊断|宗教|政治/iu;
+  /\b(password|passcode|secret|api[\s_-]*key|access[\s_-]*token|refresh[\s_-]*token|token|credential|private[\s_-]*key|ssn|social[\s_]+security|credit[\s_]+card|bank[\s_]+account|routing[\s_]+number|passport|(?:driver'?s|driver[\s_]+s)[\s_]+license|medical|medication|diagnosis|diabetes|cancer|hiv|financial|religion|political)\b|密码|口令|密钥|令牌|身份证|护照|银行卡|信用卡|病历|诊断|宗教|政治/iu;
 
 export function isFridaySensitiveLearningCandidate(...values: unknown[]): boolean {
   const text = values

--- a/test/unit/learning/services/friday-preference-extraction-service.test.ts
+++ b/test/unit/learning/services/friday-preference-extraction-service.test.ts
@@ -163,6 +163,7 @@ describe("FridayPreferenceExtractionService", () => {
         "always use hunter2 for password",
         "I prefer insulin for medication",
         "call me my-secret-token",
+        "always use driver license marker for driver's license",
         "以后叫我 密码123",
       ]) {
         const event = makeEvent({

--- a/test/unit/learning/services/friday-sensitive-learning-guard.test.ts
+++ b/test/unit/learning/services/friday-sensitive-learning-guard.test.ts
@@ -22,6 +22,7 @@ describe("Friday sensitive learning guard", () => {
     "remember my routing number preference",
     "prefer my passport identity when booking",
     "my driver's license should be in memory",
+    "my driver_s_license should be in memory",
     "tailor replies around my MEDICAL history",
     "prefer this medication schedule",
     "remember my diagnosis context",


### PR DESCRIPTION
## Summary
- Extend the shared sensitive-learning guard to catch normalized `driver_s_license` forms produced by preference key normalization.
- Add regression coverage for both the shared guard and preference extraction path.

## Verification
- `FRIDAY_PHASE2_SENSITIVE_PRIVACY_BREADTH_REPORT=/tmp/friday-self-iteration-20260531-evidence/sensitive-privacy-breadth-summary.json npx vitest run test/unit/learning/friday-sensitive-privacy-breadth.tmp.test.ts test/unit/learning/services/friday-sensitive-learning-guard.test.ts test/unit/learning/services/friday-preference-extraction-service.test.ts --reporter=verbose`
- `npx vitest run test/unit/learning/services/friday-sensitive-learning-guard.test.ts test/unit/learning/services/friday-preference-extraction-service.test.ts test/unit/agent/tools/friday-agent-memory-tools.test.ts test/unit/agent/tools/friday-agent-feedback-tool.test.ts test/unit/sessions/services/friday-session-memory-extraction-service.test.ts test/unit/memory/services/friday-episode-extractor.test.ts test/integration/sessions/friday-session-memory-extraction-integration.test.ts --reporter=verbose`
- `git diff --check`
- `npm run check:secret-patterns`
- `npm run typecheck -- --pretty false`

## Boundary
Focused local guard/caller fix only. Does not claim broad secure-storage/review-flow or third-party channel coverage.