### PR TITLE
Backfill related memory search results

### DIFF
--- a/src/memory/services/friday-memory-service.ts
+++ b/src/memory/services/friday-memory-service.ts
@@ -325,13 +325,13 @@ export function createFridayMemoryService(
         nowIso: now,
       });
 
-      // Fallback: if FTS and semantic both returned nothing, try a namespace-filtered
-      // substring scan so that exact-word queries still find matches when FTS tokenization
-      // misses (e.g. short or unusual tokens).
+      // Fallback/backfill: try a namespace-filtered substring scan so exact or
+      // partial topic matches can still surface related memories when FTS is
+      // too narrow and semantic search is unavailable/noisy.
       // Skip the fallback entirely when the caller demands a higher score than substring
       // matches can provide (0.1), to avoid scanning all items for results that would
       // all be filtered out anyway.
-      if (results.length === 0 && options?.namespace && !(options?.minScore != null && 0.1 < options.minScore)) {
+      if (results.length < limit && options?.namespace && !(options?.minScore != null && 0.1 < options.minScore)) {
         const allItems = deps.db.withReadConnection((db) =>
           itemRepo.list(db, {
             namespace: options.namespace,
@@ -346,9 +346,11 @@ export function createFridayMemoryService(
 
         const queryLower = query.toLowerCase();
         const queryTokens = queryLower.split(/\s+/).filter((t) => t.length > 0);
+        const existingIds = new Set(results.map((result) => result.item.id));
 
         for (const item of allItems) {
           if (results.length >= limit) break;
+          if (existingIds.has(item.id)) continue;
           const contentLower = item.content.toLowerCase();
           // Match if any query token appears as substring
           const matched = queryTokens.some((token) => contentLower.includes(token));

--- a/test/unit/memory/services/friday-memory-service.test.ts
+++ b/test/unit/memory/services/friday-memory-service.test.ts
@@ -470,6 +470,31 @@ describe("FridayMemoryService", () => {
       expect(results[0].score).toBeCloseTo(0.1);
     });
 
+    it("namespace substring backfill returns sibling facts when FTS only matches one conflict token", async () => {
+      const failService = createMockProviderService({ embedFails: true });
+      const svc = createFridayMemoryService({
+        db,
+        providerService: failService,
+        idGenerator: idGen,
+        nowIso: () => NOW,
+      });
+
+      await svc.store("conflict-ns", "The user's workshop accent color is teal");
+      await svc.store("conflict-ns", "The user's workshop accent color is navy");
+
+      const results = await svc.search("workshop accent color teal", {
+        namespace: "conflict-ns",
+        limit: 5,
+      });
+
+      const contents = results.map((result) => result.item.content).join("\n");
+      expect(contents).toContain("teal");
+      expect(contents).toContain("navy");
+      expect(results.map((result) => result.item.id)).toEqual(
+        Array.from(new Set(results.map((result) => result.item.id))),
+      );
+    });
+
     it("namespace substring fallback honors memoryType filtering", async () => {
       const failService = createMockProviderService({ embedFails: true });
       const svc = createFridayMemoryService({


### PR DESCRIPTION
## Summary
- backfill namespace-scoped substring matches when hybrid memory search has spare result capacity
- keep duplicate items out of the backfill result set
- add a regression for sibling color facts where FTS matches only one conflict token

## Verification
- npx vitest run test/unit/memory/services/friday-memory-service.test.ts
- npx vitest run test/unit/memory/services/friday-memory-service.test.ts test/unit/memory/persistence/friday-memory-item-repository.test.ts test/unit/memory/search/friday-memory-hybrid.test.ts test/unit/agent/tools/friday-agent-memory-tools.test.ts test/integration/memory/friday-agent-memory-recall-boundary.test.ts
- git diff --check
- npm run check:secret-patterns
- npm run typecheck -- --pretty false