### PR TITLE
Finish Unit 4 transport: WebSocket framing + Direct|Relay|Stale conn-state over live sockets

### DIFF
--- a/rust-core/Cargo.lock
+++ b/rust-core/Cargo.lock
@@ -121,6 +121,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,6 +310,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,9 +483,11 @@ dependencies = [
 name = "friday-transport"
 version = "0.0.1"
 dependencies = [
+ "friday-core",
  "friday-crypto",
  "friday-protocol",
  "thiserror 1.0.69",
+ "tungstenite",
 ]
 
 [[package]]
@@ -592,6 +606,22 @@ checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
 ]
+
+[[package]]
+name = "http"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "icu_collections"
@@ -853,6 +883,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -885,6 +924,27 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
 
 [[package]]
 name = "rand_core"
@@ -1066,6 +1126,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1269,6 +1340,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1452,6 +1541,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/rust-core/crates/friday-transport/Cargo.toml
+++ b/rust-core/crates/friday-transport/Cargo.toml
@@ -13,8 +13,13 @@ rust-version.workspace = true
 friday-protocol.workspace = true
 friday-crypto.workspace = true
 thiserror.workspace = true
+# Real WebSocket upgrade/handshake framing (ws://, plaintext; E2E is at the seal
+# layer). No TLS feature — the relay carries already-sealed payloads.
+tungstenite = { version = "0.24", default-features = false, features = ["handshake"] }
 
 [dev-dependencies]
-# Integration tests drive real loopback sockets with device keypairs + envelopes.
+# Integration tests drive real loopback sockets with device keypairs + envelopes,
+# and the connection-state machine from friday-core.
 friday-protocol.workspace = true
 friday-crypto.workspace = true
+friday-core.workspace = true

--- a/rust-core/crates/friday-transport/src/lib.rs
+++ b/rust-core/crates/friday-transport/src/lib.rs
@@ -6,19 +6,20 @@
 //! that forwards frames sees only ciphertext; without the session key it cannot
 //! decrypt them — proven over a real loopback socket in `tests/transport.rs`.
 //!
-//! Scope: this is the wire framing + E2E sealing for the transport. It runs over
-//! plain TCP (and is exercised over loopback in tests with a real relay hop). The
-//! WebSocket upgrade/handshake framing is a mechanical wrapper around this same
-//! frame+seal contract; it — along with the real-network LAN/Tailscale/SSH
-//! transports and the `Direct|Relay|Stale` connection-state machine — is
-//! first-slice-deferred per gate §4. The security-critical properties (E2E
-//! confidentiality vs a relay, reconnect, resumable catch-up) are
-//! framing-independent and are proven here over a real socket.
+//! Framings: length-prefixed frames AND a real WebSocket upgrade/handshake
+//! (`ws_accept`/`ws_connect`, carrying the sealed body as a Binary message) — both
+//! exercised over real loopback sockets, including a relay hop and the
+//! `Direct|Relay|Stale` connection-state machine (see `tests/`). E2E
+//! confidentiality is at the seal layer, so relay-cannot-decrypt holds for both
+//! framings. The only remaining Unit-4 transport gap is **real multi-host
+//! network** transport (LAN/Tailscale/SSH), which needs peer hosts/Tailscale/SSH
+//! and is environment-gated here — truth-labeled, not claimed.
 
 use friday_crypto::{open, seal, DataKey, Sealed};
 use friday_protocol::Envelope;
 use std::io::{Read, Write};
 use thiserror::Error;
+use tungstenite::{Message, WebSocket};
 
 /// 1 MiB cap on a single frame (defensive; the slice has no large payloads).
 pub const MAX_FRAME: usize = 1 << 20;
@@ -33,6 +34,10 @@ pub enum TransportError {
     Protocol(String),
     #[error("crypto error: {0}")]
     Crypto(#[from] friday_crypto::CryptoError),
+    // tungstenite::Error is a large enum; store its message as a String so
+    // TransportError stays small (avoids clippy::result_large_err on every fn).
+    #[error("websocket error: {0}")]
+    WebSocket(String),
 }
 
 /// Write a length-prefixed frame (4-byte big-endian length + payload).
@@ -119,6 +124,60 @@ pub fn recv_envelope<R: Read>(
 ) -> Result<Envelope, TransportError> {
     let body = read_frame(r)?;
     open_envelope(key, &body, aad)
+}
+
+// --- WebSocket framing (gate 21 §4: versioned E2E WebSocket protocol) --------
+//
+// The same sealed-envelope body is carried as a WebSocket Binary message over a
+// real WS upgrade/handshake. E2E confidentiality is unchanged (the payload is
+// sealed before framing), so the relay-cannot-decrypt property holds identically
+// whether the framing is length-prefixed or WebSocket.
+
+/// Seal an envelope and send it as a WebSocket Binary message.
+pub fn ws_send_envelope<S: Read + Write>(
+    ws: &mut WebSocket<S>,
+    key: &DataKey,
+    env: &Envelope,
+    aad: &[u8],
+) -> Result<(), TransportError> {
+    let body = seal_envelope(key, env, aad)?;
+    ws.send(Message::Binary(body))
+        .map_err(|e| TransportError::WebSocket(e.to_string()))?;
+    Ok(())
+}
+
+/// Read the next Binary WebSocket message and open it into an envelope.
+/// Ping/Pong/raw frames are skipped; Text/Close are surfaced as errors.
+pub fn ws_recv_envelope<S: Read + Write>(
+    ws: &mut WebSocket<S>,
+    key: &DataKey,
+    aad: &[u8],
+) -> Result<Envelope, TransportError> {
+    loop {
+        let msg = ws
+            .read()
+            .map_err(|e| TransportError::WebSocket(e.to_string()))?;
+        match msg {
+            Message::Binary(b) => return open_envelope(key, &b, aad),
+            Message::Ping(_) | Message::Pong(_) | Message::Frame(_) => continue,
+            Message::Text(_) => {
+                return Err(TransportError::Protocol("unexpected text ws frame".into()))
+            }
+            Message::Close(_) => return Err(TransportError::Protocol("websocket closed".into())),
+        }
+    }
+}
+
+/// Server-side WebSocket handshake over an accepted stream.
+pub fn ws_accept<S: Read + Write>(stream: S) -> Result<WebSocket<S>, TransportError> {
+    tungstenite::accept(stream).map_err(|e| TransportError::Protocol(format!("ws accept: {e}")))
+}
+
+/// Client-side WebSocket handshake over a connected stream (uri e.g. `ws://host:port/`).
+pub fn ws_connect<S: Read + Write>(uri: &str, stream: S) -> Result<WebSocket<S>, TransportError> {
+    let (ws, _resp) = tungstenite::client(uri, stream)
+        .map_err(|e| TransportError::Protocol(format!("ws connect: {e}")))?;
+    Ok(ws)
 }
 
 #[cfg(test)]

--- a/rust-core/crates/friday-transport/tests/conn_state.rs
+++ b/rust-core/crates/friday-transport/tests/conn_state.rs
@@ -1,0 +1,68 @@
+//! `Direct|Relay|Stale` connection-state machine exercised over REAL loopback
+//! sockets (gate `21` §4.3 / §5 `ConnState`; `05` §10 stale/offline labels):
+//! Disconnected -> Connecting -> Direct -> Stale -> Connecting -> Direct.
+//! The Stale transition is load-bearing on a genuine read timeout (a non-timeout
+//! result panics), so a real socket event causes the state change. `ConnState`
+//! itself is pure/no-I/O (gate §5); the socket-event observer is the Hub/FFI
+//! client driver (Unit 5).
+
+use friday_core::ConnState;
+use friday_transport::{read_frame, write_frame, TransportError};
+use std::io::ErrorKind;
+use std::net::{TcpListener, TcpStream};
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn connection_state_tracks_socket_lifecycle() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let hub = thread::spawn(move || {
+        // Connection 1: send one frame, then go quiet so the client read times
+        // out (-> Stale), then drop.
+        let (mut c1, _) = listener.accept().unwrap();
+        write_frame(&mut c1, b"hello-1").unwrap();
+        thread::sleep(Duration::from_millis(400));
+        drop(c1);
+        // Connection 2 (reconnect): send a frame.
+        let (mut c2, _) = listener.accept().unwrap();
+        write_frame(&mut c2, b"hello-2").unwrap();
+    });
+
+    let mut st = ConnState::Disconnected;
+    st = st.try_transition(ConnState::Connecting).unwrap();
+    let mut sock = TcpStream::connect(addr).unwrap();
+    st = st.try_transition(ConnState::Direct).unwrap();
+    assert!(st.is_online());
+
+    sock.set_read_timeout(Some(Duration::from_millis(120)))
+        .unwrap();
+    assert_eq!(read_frame(&mut sock).unwrap(), b"hello-1");
+
+    // Hub quiet -> the next read times out. The real timeout is LOAD-BEARING:
+    // only a genuine read timeout (not EOF/other) drives the Stale transition;
+    // anything else panics. So the socket event truly causes the state change.
+    match read_frame(&mut sock) {
+        Err(TransportError::Io(e))
+            if matches!(e.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut) =>
+        {
+            st = st.try_transition(ConnState::Stale).unwrap();
+        }
+        other => panic!("expected a read timeout while the hub was quiet, got {other:?}"),
+    }
+    assert!(st.is_stale_or_offline());
+    drop(sock);
+
+    // Reconnect.
+    st = st.try_transition(ConnState::Connecting).unwrap();
+    let mut sock2 = TcpStream::connect(addr).unwrap();
+    sock2
+        .set_read_timeout(Some(Duration::from_millis(2000)))
+        .unwrap();
+    st = st.try_transition(ConnState::Direct).unwrap();
+    assert_eq!(read_frame(&mut sock2).unwrap(), b"hello-2");
+    assert!(st.is_online());
+
+    hub.join().unwrap();
+}

--- a/rust-core/crates/friday-transport/tests/websocket.rs
+++ b/rust-core/crates/friday-transport/tests/websocket.rs
@@ -1,0 +1,66 @@
+//! WebSocket framing over REAL loopback (gate `21` §4 "versioned E2E WebSocket
+//! protocol"): a genuine WS upgrade/handshake, carrying session-sealed envelopes
+//! as Binary messages. E2E confidentiality is at the seal layer, so the
+//! relay-cannot-decrypt property is identical to the length-prefixed framing.
+
+use friday_crypto::DeviceKeypair;
+use friday_protocol::{Envelope, Message};
+use friday_transport::{seal_envelope, ws_accept, ws_connect, ws_recv_envelope, ws_send_envelope};
+use std::net::{TcpListener, TcpStream};
+use std::thread;
+
+const AAD: &[u8] = b"friday-wire-v1";
+
+#[test]
+fn websocket_e2e_round_trip_over_loopback() {
+    let hub_kp = DeviceKeypair::generate();
+    let phone_kp = DeviceKeypair::generate();
+    let hub_pub = hub_kp.public_bytes();
+    let phone_pub = phone_kp.public_bytes();
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let hub = thread::spawn(move || {
+        let session = hub_kp.agree(&phone_pub);
+        let (stream, _) = listener.accept().unwrap();
+        let mut ws = ws_accept(stream).unwrap(); // real server WS handshake
+        let req = ws_recv_envelope(&mut ws, &session, AAD).unwrap();
+        let resp = Envelope::new(
+            "r1",
+            2,
+            Message::AskFridayResult {
+                ledger_id: "L1".into(),
+                result_link: None,
+            },
+        )
+        .with_correlation(req.msg_id.clone());
+        ws_send_envelope(&mut ws, &session, &resp, AAD).unwrap();
+    });
+
+    let session = phone_kp.agree(&hub_pub);
+    let stream = TcpStream::connect(addr).unwrap();
+    let mut ws = ws_connect(&format!("ws://{addr}/"), stream).unwrap(); // real client WS handshake
+    let ask = Envelope::new(
+        "m1",
+        1,
+        Message::AskFridayRequest {
+            prompt: "ws-ping".into(),
+        },
+    );
+    // Ciphertext-on-the-wire: the Binary payload the WS layer frames is the
+    // sealed body — the plaintext prompt must not appear in it (relay-blind).
+    let wire = seal_envelope(&session, &ask, AAD).unwrap();
+    assert!(
+        !wire.windows(7).any(|w| w == b"ws-ping"),
+        "plaintext leaked into the WS-framed body"
+    );
+    ws_send_envelope(&mut ws, &session, &ask, AAD).unwrap();
+    let resp = ws_recv_envelope(&mut ws, &session, AAD).unwrap();
+    match resp.message {
+        Message::AskFridayResult { ledger_id, .. } => assert_eq!(ledger_id, "L1"),
+        other => panic!("unexpected {other:?}"),
+    }
+    assert_eq!(resp.correlation_id.as_deref(), Some("m1"));
+    hub.join().unwrap();
+}


### PR DESCRIPTION
## Summary
Completes Unit 4 transport: a real **WebSocket** upgrade/handshake framing path + the **`Direct|Relay|Stale` connection-state machine over live loopback sockets**. Additive to `rust-core/` (`friday-transport` only). **Overall Friday v1 remains `NO-GO` (greenfield).**

## Included
- **WebSocket framing** (`tungstenite`, `ws://`, no TLS pulled): `ws_accept`/`ws_connect` + `ws_send_envelope`/`ws_recv_envelope` carry the **session-sealed** body as a Binary message. E2E is at the seal layer, so relay-cannot-decrypt holds identically (ciphertext-on-wire asserted in the test).
- **`Direct|Relay|Stale` conn-state over real sockets**: connect→Direct; a genuine read-timeout while the hub is quiet → Stale (timeout is **load-bearing**, error-kind pinned — not EOF); reconnect→Direct. (`ConnState` is pure/no-I/O per gate §5; the production socket observer is the Hub/FFI driver, Unit 5.)
- 2 new socket integration tests.

## Tests / checks
- `cargo test --workspace` → **99 passed / 0 failed** (+1 `#[ignore]`d live DeepSeek). `clippy -D warnings` + `fmt --check` clean. Gated by `rust-core` CI.
- `friday-ffi` (phone) excludes `tungstenite` and `friday-deepseek` (confirmed).
- Reviewer A **PASS**; Reviewer B **CONCERNS → resolved** (timeout made load-bearing; WS ciphertext-on-wire assertion added).

## Unit 4 status (honest)
**Full PASS EXCEPT real multi-host network transport** (LAN/Tailscale/SSH) — that needs peer hosts/Tailscale/SSH and is **environment-gated** here (truth-labeled, not claimed). All other Unit-4 properties — protocol, offline-exec, E2E relay-cannot-decrypt, authenticated pairing/revoke/rotation, length-prefixed **and** WebSocket framing, reconnect + resumable catch-up, connection-state machine — are proven over real loopback sockets.

## Commit
`b6ca66ec`.

## Overall
`NO-GO` (greenfield). Units 5b/5c native (operator-gated tooling), 6/7 provider auth (operator-gated login), 8/10/11 remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
