### PR TITLE
Codex/Claude auth-readiness detection (Unit 6/7 foundation)

### DIFF
--- a/rust-core/Cargo.lock
+++ b/rust-core/Cargo.lock
@@ -469,6 +469,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "friday-providers"
+version = "0.0.1"
+dependencies = [
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "friday-storage"
 version = "0.0.1"
 dependencies = [

--- a/rust-core/Cargo.toml
+++ b/rust-core/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "crates/friday-transport",
     "crates/friday-storage",
     "crates/friday-deepseek",
+    "crates/friday-providers",
     "crates/friday-ffi",
     "crates/friday-arch-tests",
 ]
@@ -48,6 +49,7 @@ friday-protocol = { path = "crates/friday-protocol" }
 friday-transport = { path = "crates/friday-transport" }
 friday-storage = { path = "crates/friday-storage" }
 friday-deepseek = { path = "crates/friday-deepseek" }
+friday-providers = { path = "crates/friday-providers" }
 friday-ffi = { path = "crates/friday-ffi" }
 
 [profile.dev]

--- a/rust-core/crates/friday-arch-tests/tests/dep_boundary.rs
+++ b/rust-core/crates/friday-arch-tests/tests/dep_boundary.rs
@@ -81,10 +81,14 @@ fn ffi_dependency_closure_excludes_deepseek() {
 
     let ffi_closure = closure(&graph, "friday-ffi");
 
-    assert!(
-        !ffi_closure.contains("friday-deepseek"),
-        "PHONE SECRET LEAK: friday-ffi transitively depends on friday-deepseek; closure = {ffi_closure:?}"
-    );
+    // Hub-only, provider-secret-bearing crates must never reach the phone.
+    for hub_only in ["friday-deepseek", "friday-providers"] {
+        assert!(graph.contains_key(hub_only), "{hub_only} crate not found");
+        assert!(
+            !ffi_closure.contains(hub_only),
+            "PHONE SECRET LEAK: friday-ffi transitively depends on {hub_only}; closure = {ffi_closure:?}"
+        );
+    }
 
     // Sanity: the phone crate does link the phone-side crates it actually uses.
     for expected in ["friday-core", "friday-storage", "friday-crypto"] {

--- a/rust-core/crates/friday-providers/Cargo.toml
+++ b/rust-core/crates/friday-providers/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "friday-providers"
+description = "Friday Rust Core — Codex/Claude provider adapters (Hub-only). Unit 6/7: auth-readiness detection via official provider status commands."
+edition.workspace = true
+version.workspace = true
+license.workspace = true
+publish = false
+rust-version.workspace = true
+
+# Hub-only: runs the local Codex/Claude CLIs. Provider credentials stay in those
+# CLIs' own config on the Hub; this crate only reads auth STATUS (read-only, no
+# model call). Must stay OUT of friday-ffi's (phone) dependency graph — asserted
+# by friday-arch-tests.
+[dependencies]
+thiserror.workspace = true

--- a/rust-core/crates/friday-providers/src/lib.rs
+++ b/rust-core/crates/friday-providers/src/lib.rs
@@ -1,0 +1,254 @@
+//! Codex/Claude provider adapters — Unit 6/7 **auth-readiness detection**
+//! (`04` §2/§3/§4.5; `31-PROVIDER-AUTH-READINESS`).
+//!
+//! This is the first required provider capability: detect whether each provider
+//! CLI is installed and authenticated. It runs ONLY each provider's official,
+//! read-only **status** command (`codex login status`, `claude auth status`) —
+//! never a prompt/send — so **no model call** occurs and nothing is charged.
+//! Provider credentials live in the CLIs' own Hub-side config; this crate reads
+//! only boolean auth signals and never surfaces account email/org/tokens.
+//!
+//! Scope: auth-readiness detection only. Session control (list/open/send/stop/
+//! approve), transcript streaming, and post-login Friday smoke — which DO consume
+//! the account — are later Unit 6/7 slices, not implemented here. No fallback:
+//! a failed/absent provider is truth-labeled, never substituted.
+//!
+//! Hub-only: must stay OUT of `friday-ffi`'s (phone) dependency graph
+//! (asserted by `friday-arch-tests`).
+
+use std::process::Command;
+use thiserror::Error;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Provider {
+    Codex,
+    Claude,
+}
+
+impl Provider {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Provider::Codex => "codex",
+            Provider::Claude => "claude",
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum ProviderError {
+    #[error("provider CLI not found or not runnable: {0}")]
+    NotInstalled(String),
+}
+
+/// Output of a provider's read-only status command.
+///
+/// Secret hygiene: `stdout`/`stderr` hold the CLI's RAW status output, which can
+/// include account identifiers (e.g. claude's `authMethod`/`subscriptionType`).
+/// Callers must NOT surface these raw fields in logs/evidence/UI — go through
+/// [`parse_status`], whose [`ProviderAuthStatus`] carries only booleans + a
+/// coarse, secret-safe label.
+#[derive(Debug, Clone)]
+pub struct ProbeOutput {
+    pub stdout: String,
+    pub stderr: String,
+}
+
+/// Runs a provider's read-only auth-status command. Real impl is [`CliProbe`];
+/// tests inject a mock so parsing/no-fallback logic is provable without the CLIs.
+pub trait ProviderProbe {
+    fn status(&self, provider: Provider) -> Result<ProbeOutput, ProviderError>;
+}
+
+/// Real probe: invokes each CLI's official read-only status subcommand by
+/// ABSOLUTE path (so PATH shadowing can't pick a wrong/broken binary). It runs
+/// ONLY a status command — never a prompt/send — so no model call occurs.
+pub struct CliProbe {
+    pub codex_bin: String,
+    pub claude_bin: String,
+}
+
+impl Default for CliProbe {
+    fn default() -> Self {
+        let home = std::env::var("HOME").unwrap_or_default();
+        CliProbe {
+            codex_bin: format!("{home}/.local/bin/codex"),
+            claude_bin: format!("{home}/.local/bin/claude"),
+        }
+    }
+}
+
+impl CliProbe {
+    fn run(bin: &str, args: &[&str]) -> Result<ProbeOutput, ProviderError> {
+        match Command::new(bin).args(args).output() {
+            Ok(out) => Ok(ProbeOutput {
+                stdout: String::from_utf8_lossy(&out.stdout).to_string(),
+                stderr: String::from_utf8_lossy(&out.stderr).to_string(),
+            }),
+            Err(e) => Err(ProviderError::NotInstalled(format!("{bin}: {e}"))),
+        }
+    }
+}
+
+impl ProviderProbe for CliProbe {
+    fn status(&self, provider: Provider) -> Result<ProbeOutput, ProviderError> {
+        match provider {
+            Provider::Codex => Self::run(&self.codex_bin, &["login", "status"]),
+            Provider::Claude => Self::run(&self.claude_bin, &["auth", "status"]),
+        }
+    }
+}
+
+/// Auth-readiness for a provider. Carries booleans + a coarse, secret-safe label
+/// only — never account email/org/tokens.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderAuthStatus {
+    pub provider: Provider,
+    pub installed: bool,
+    pub authenticated: bool,
+    /// `"logged_in" | "not_logged_in" | "not_installed"`.
+    pub detail: &'static str,
+}
+
+/// Parse a provider's status output into auth-readiness. Reads only boolean
+/// signals; does NOT surface account identifiers.
+pub fn parse_status(
+    provider: Provider,
+    probe: Result<ProbeOutput, ProviderError>,
+) -> ProviderAuthStatus {
+    match probe {
+        Err(_) => ProviderAuthStatus {
+            provider,
+            installed: false,
+            authenticated: false,
+            detail: "not_installed",
+        },
+        Ok(out) => {
+            // Some CLIs print auth status to stderr (codex) and some to stdout
+            // (claude `auth status` JSON), so consider BOTH streams.
+            let hay = format!("{}\n{}", out.stdout, out.stderr).to_lowercase();
+            let authenticated = match provider {
+                // codex: "Logged in using ChatGPT" (guard against "Not logged in").
+                Provider::Codex => hay.contains("logged in") && !hay.contains("not logged in"),
+                // claude `auth status`: JSON `"loggedIn": true`.
+                Provider::Claude => {
+                    hay.contains("\"loggedin\": true") || hay.contains("loggedin: true")
+                }
+            };
+            ProviderAuthStatus {
+                provider,
+                installed: true,
+                authenticated,
+                detail: if authenticated {
+                    "logged_in"
+                } else {
+                    "not_logged_in"
+                },
+            }
+        }
+    }
+}
+
+/// Detect a provider's auth readiness (installed + authenticated) via the probe.
+pub fn detect<P: ProviderProbe>(probe: &P, provider: Provider) -> ProviderAuthStatus {
+    parse_status(provider, probe.status(provider))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    struct MockProbe {
+        out: HashMap<&'static str, Result<ProbeOutput, ()>>,
+    }
+    impl MockProbe {
+        fn new() -> Self {
+            Self {
+                out: HashMap::new(),
+            }
+        }
+        fn set(mut self, p: Provider, stdout: &str) -> Self {
+            self.out.insert(
+                p.as_str(),
+                Ok(ProbeOutput {
+                    stdout: stdout.to_string(),
+                    stderr: String::new(),
+                }),
+            );
+            self
+        }
+        fn set_streams(mut self, p: Provider, stdout: &str, stderr: &str) -> Self {
+            self.out.insert(
+                p.as_str(),
+                Ok(ProbeOutput {
+                    stdout: stdout.to_string(),
+                    stderr: stderr.to_string(),
+                }),
+            );
+            self
+        }
+        fn set_missing(mut self, p: Provider) -> Self {
+            self.out.insert(p.as_str(), Err(()));
+            self
+        }
+    }
+    impl ProviderProbe for MockProbe {
+        fn status(&self, provider: Provider) -> Result<ProbeOutput, ProviderError> {
+            match self.out.get(provider.as_str()) {
+                Some(Ok(o)) => Ok(o.clone()),
+                _ => Err(ProviderError::NotInstalled("mock".into())),
+            }
+        }
+    }
+
+    #[test]
+    fn codex_logged_in_detected() {
+        let p = MockProbe::new().set(Provider::Codex, "Logged in using ChatGPT");
+        let s = detect(&p, Provider::Codex);
+        assert!(s.installed && s.authenticated);
+        assert_eq!(s.detail, "logged_in");
+    }
+
+    #[test]
+    fn codex_logged_in_on_stderr_detected() {
+        // codex prints "Logged in using ChatGPT" to STDERR (stdout empty) — the
+        // parser must consider both streams (regression guard for the live bug).
+        let p = MockProbe::new().set_streams(Provider::Codex, "", "Logged in using ChatGPT");
+        let s = detect(&p, Provider::Codex);
+        assert!(s.installed && s.authenticated);
+        assert_eq!(s.detail, "logged_in");
+    }
+
+    #[test]
+    fn codex_not_logged_in_detected() {
+        let p = MockProbe::new().set(Provider::Codex, "Not logged in");
+        let s = detect(&p, Provider::Codex);
+        assert!(s.installed && !s.authenticated);
+        assert_eq!(s.detail, "not_logged_in");
+    }
+
+    #[test]
+    fn claude_logged_in_detected() {
+        let p = MockProbe::new().set(
+            Provider::Claude,
+            "{\n  \"loggedIn\": true,\n  \"authMethod\": \"claude.ai\"\n}",
+        );
+        let s = detect(&p, Provider::Claude);
+        assert!(s.installed && s.authenticated);
+    }
+
+    #[test]
+    fn claude_not_logged_in_detected() {
+        let p = MockProbe::new().set(Provider::Claude, "{\n  \"loggedIn\": false\n}");
+        let s = detect(&p, Provider::Claude);
+        assert!(s.installed && !s.authenticated);
+    }
+
+    #[test]
+    fn missing_cli_is_not_installed_never_a_fallback() {
+        let p = MockProbe::new().set_missing(Provider::Codex);
+        let s = detect(&p, Provider::Codex);
+        assert!(!s.installed && !s.authenticated);
+        assert_eq!(s.detail, "not_installed");
+    }
+}

--- a/rust-core/crates/friday-providers/tests/live_auth.rs
+++ b/rust-core/crates/friday-providers/tests/live_auth.rs
@@ -1,0 +1,41 @@
+//! LIVE provider auth-readiness smoke (gated `#[ignore]`; needs the Hub's
+//! authenticated codex + claude CLIs). Runs ONLY read-only status commands —
+//! no prompt/send, so no model call and no cost. Secret-safe: prints only
+//! booleans + the coarse detail label, never account identifiers. Run:
+//!   cargo test -p friday-providers --test live_auth -- --ignored --nocapture
+
+use friday_providers::{detect, CliProbe, Provider};
+
+#[test]
+#[ignore = "live: requires Hub-local authenticated codex + claude CLIs (read-only, no model call)"]
+fn live_codex_and_claude_auth_ready() {
+    let probe = CliProbe::default();
+    let codex = detect(&probe, Provider::Codex);
+    let claude = detect(&probe, Provider::Claude);
+
+    println!(
+        "[live] codex:  installed={} authenticated={} detail={}",
+        codex.installed, codex.authenticated, codex.detail
+    );
+    println!(
+        "[live] claude: installed={} authenticated={} detail={}",
+        claude.installed, claude.authenticated, claude.detail
+    );
+
+    assert!(
+        codex.installed,
+        "codex CLI must be installed (~/.local/bin/codex)"
+    );
+    assert!(
+        codex.authenticated,
+        "codex must be logged in (codex login status)"
+    );
+    assert!(
+        claude.installed,
+        "claude CLI must be installed (~/.local/bin/claude)"
+    );
+    assert!(
+        claude.authenticated,
+        "claude must be logged in (claude auth status)"
+    );
+}


### PR DESCRIPTION
## Summary
**Unit 6/7 auth-readiness detection** — a Hub-only `friday-providers` crate that detects whether Codex/Claude are installed and authenticated. Additive to `rust-core/`. **Overall Friday v1 remains `NO-GO`.**

## Included
- Detection via each provider's **official read-only status command** (`codex login status`, `claude auth status`), invoked by absolute path (no PATH shadowing). **No prompt/send → no model call, no cost.**
- `parse_status` reads only boolean auth signals + a coarse label; raw CLI output (`ProbeOutput`) is captured but never surfaced (no account email/org/tokens). **No fallback**: an absent/unauthed provider is truth-labeled (`not_installed`/`not_logged_in`), never substituted.
- `parse_status` considers **both stdout and stderr** (codex prints status to stderr — a real bug the live smoke caught; regression test added).
- Dep boundary extended: `friday-arch-tests` asserts `friday-ffi` (phone) excludes **both** `friday-deepseek` and `friday-providers`.

## Tests / checks
- 6 offline mock tests + 1 gated `#[ignore]` **live smoke** that confirms BOTH codex and claude `installed=true, authenticated=true` (read-only, secret-safe). `cargo test --workspace` → **111 passed**; `clippy -D warnings` + `fmt` clean. Gated by the `rust-core` CI job.
- Reviewer A **PASS**; Reviewer B **CLEAN** (no model-call risk, no secret leak, no fallback, no overclaim).

## Honestly deferred (NOT PASS)
- Session control (list/open/send/stop/approve), transcript streaming, **post-login Friday smoke**, and **adapter parity** — later Unit 6/7 slices (they consume the account). Mobile provider-auth UX is Unit 5.

## Commit
`8b6004d3`. **Overall: `NO-GO`.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
