### PR TITLE
Workflow persistence + forward migration v1->v2 (Unit 9 persistence slice)

### DIFF
--- a/rust-core/crates/friday-core/src/workflow.rs
+++ b/rust-core/crates/friday-core/src/workflow.rs
@@ -90,6 +90,12 @@ impl StepStatus {
     pub fn is_complete(&self) -> bool {
         matches!(self, StepStatus::Verified)
     }
+
+    /// A terminal step cannot be re-completed. `ProofPending` is **not** terminal
+    /// — its deterministic evidence may still arrive and verify it later.
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, StepStatus::Verified | StepStatus::Failed)
+    }
 }
 
 /// Resolve a step's completion status.
@@ -172,6 +178,17 @@ mod tests {
             resolve_step_completion(true, true, false),
             StepStatus::Verified
         );
+    }
+
+    #[test]
+    fn step_terminality_lets_proof_pending_verify_later() {
+        // ProofPending is NOT terminal: late-arriving evidence can still verify it.
+        assert!(!StepStatus::ProofPending.is_terminal());
+        assert!(!StepStatus::Pending.is_terminal());
+        assert!(!StepStatus::Running.is_terminal());
+        // Verified/Failed are terminal (no re-completion / no downgrade).
+        assert!(StepStatus::Verified.is_terminal());
+        assert!(StepStatus::Failed.is_terminal());
     }
 
     #[test]

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -16,6 +16,7 @@ mod migrate;
 pub mod offline;
 pub mod pairing;
 mod schema;
+pub mod workflow;
 
 pub use error::{Result, StorageError};
 pub use migrate::{

--- a/rust-core/crates/friday-storage/src/schema.rs
+++ b/rust-core/crates/friday-storage/src/schema.rs
@@ -10,19 +10,35 @@
 use crate::migrate::Migration;
 use rusqlite::Transaction;
 
-/// Tables present only on the Hub (never created on a phone).
-pub const HUB_ONLY_TABLES: &[&str] = &["trusted_device", "audit_ledger", "memory_item"];
+/// Tables present only on the Hub (never created on a phone). Workflow runs are
+/// Hub-coordinated (gate 21 §9 / `08`), so they are Hub-only too.
+pub const HUB_ONLY_TABLES: &[&str] = &[
+    "trusted_device",
+    "audit_ledger",
+    "memory_item",
+    "workflow_run",
+    "workflow_step",
+];
 
 /// Tables present only on a phone (never created on the Hub).
 pub const PHONE_ONLY_TABLES: &[&str] = &["offline_queue"];
 
 pub fn hub_migrations() -> Vec<Migration> {
-    vec![Migration {
-        version: 1,
-        name: "init_hub",
-        destructive: false,
-        up: m0001_init_hub,
-    }]
+    vec![
+        Migration {
+            version: 1,
+            name: "init_hub",
+            destructive: false,
+            up: m0001_init_hub,
+        },
+        // Unit 9: workflow runs + steps (additive forward migration over v1).
+        Migration {
+            version: 2,
+            name: "workflow",
+            destructive: false,
+            up: m0002_workflow,
+        },
+    ]
 }
 
 pub fn phone_migrations() -> Vec<Migration> {
@@ -158,6 +174,29 @@ CREATE TABLE offline_queue (
 );
 CREATE INDEX idx_offline_state_created ON offline_queue(state, created_at);";
 
+// --- Unit-9 workflow fragments (Hub-only) -----------------------------------
+
+const DDL_WORKFLOW: &str = "
+CREATE TABLE workflow_run (
+    run_id     TEXT PRIMARY KEY,
+    name       TEXT NOT NULL,
+    state      TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+);
+CREATE INDEX idx_workflow_run_state ON workflow_run(state, updated_at);
+CREATE TABLE workflow_step (
+    step_id         TEXT PRIMARY KEY,
+    run_id          TEXT NOT NULL,
+    seq             INTEGER NOT NULL,
+    has_side_effect INTEGER NOT NULL,
+    status          TEXT NOT NULL,
+    evidence_ref    TEXT,
+    created_at      INTEGER NOT NULL,
+    updated_at      INTEGER NOT NULL
+);
+CREATE INDEX idx_workflow_step_run ON workflow_step(run_id, seq);";
+
 // --- migration bodies -------------------------------------------------------
 
 fn m0001_init_hub(tx: &Transaction) -> rusqlite::Result<()> {
@@ -179,5 +218,11 @@ fn m0001_init_phone(tx: &Transaction) -> rusqlite::Result<()> {
     tx.execute_batch(DDL_TOKEN_LEDGER)?;
     tx.execute_batch(DDL_OFFLINE_QUEUE)?;
     tx.execute_batch(DDL_BLOB)?;
+    Ok(())
+}
+
+// Unit 9: additive forward migration (v1 -> v2) adding the Hub workflow tables.
+fn m0002_workflow(tx: &Transaction) -> rusqlite::Result<()> {
+    tx.execute_batch(DDL_WORKFLOW)?;
     Ok(())
 }

--- a/rust-core/crates/friday-storage/src/workflow.rs
+++ b/rust-core/crates/friday-storage/src/workflow.rs
@@ -1,0 +1,156 @@
+//! Workflow run + step persistence (Unit 9; gate `21` §9, `08`, `10` §6). Hub-only.
+//!
+//! Composes `friday-core`'s `WorkflowRunState` machine and the evidence-gated
+//! step-completion invariant: a side-effect step is persisted `Verified` only
+//! with deterministic evidence; otherwise `ProofPending` — a model self-claim
+//! never marks it verified (`08` §6 / `10` §6).
+
+use crate::error::{Result, StorageError};
+use friday_core::{resolve_step_completion, StepStatus, WorkflowRunState};
+use rusqlite::{params, Connection, OptionalExtension};
+
+fn parse_run_state(s: &str) -> WorkflowRunState {
+    match s {
+        "pending" => WorkflowRunState::Pending,
+        "running" => WorkflowRunState::Running,
+        "awaiting_checkpoint" => WorkflowRunState::AwaitingCheckpoint,
+        "done" => WorkflowRunState::Done,
+        _ => WorkflowRunState::Failed,
+    }
+}
+
+fn parse_step_status(s: &str) -> StepStatus {
+    match s {
+        "pending" => StepStatus::Pending,
+        "running" => StepStatus::Running,
+        "proof_pending" => StepStatus::ProofPending,
+        "verified" => StepStatus::Verified,
+        _ => StepStatus::Failed,
+    }
+}
+
+/// Create a workflow run in `Pending`.
+pub fn create_run(conn: &Connection, run_id: &str, name: &str, created_at: i64) -> Result<()> {
+    conn.execute(
+        "INSERT INTO workflow_run (run_id, name, state, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?4)",
+        params![run_id, name, WorkflowRunState::Pending.as_str(), created_at],
+    )?;
+    Ok(())
+}
+
+pub fn run_state(conn: &Connection, run_id: &str) -> Result<Option<WorkflowRunState>> {
+    let s: Option<String> = conn
+        .query_row(
+            "SELECT state FROM workflow_run WHERE run_id = ?1",
+            [run_id],
+            |r| r.get(0),
+        )
+        .optional()?;
+    Ok(s.map(|x| parse_run_state(&x)))
+}
+
+/// Transition a run's state, validated by the `friday-core` state machine
+/// (an invalid transition is rejected).
+pub fn set_run_state(
+    conn: &Connection,
+    run_id: &str,
+    next: WorkflowRunState,
+    now: i64,
+) -> Result<()> {
+    let cur = run_state(conn, run_id)?
+        .ok_or_else(|| StorageError::Unsupported(format!("workflow_run '{run_id}' not found")))?;
+    let next = cur.try_transition(next)?; // CoreError -> StorageError
+    conn.execute(
+        "UPDATE workflow_run SET state = ?1, updated_at = ?2 WHERE run_id = ?3",
+        params![next.as_str(), now, run_id],
+    )?;
+    Ok(())
+}
+
+/// Add a step (status `Pending`). `has_side_effect` decides evidence-gating.
+#[allow(clippy::too_many_arguments)]
+pub fn add_step(
+    conn: &Connection,
+    step_id: &str,
+    run_id: &str,
+    seq: i64,
+    has_side_effect: bool,
+    created_at: i64,
+) -> Result<()> {
+    conn.execute(
+        "INSERT INTO workflow_step
+            (step_id, run_id, seq, has_side_effect, status, evidence_ref, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, NULL, ?6, ?6)",
+        params![
+            step_id,
+            run_id,
+            seq,
+            has_side_effect as i64,
+            StepStatus::Pending.as_str(),
+            created_at
+        ],
+    )?;
+    Ok(())
+}
+
+pub fn step_status(conn: &Connection, step_id: &str) -> Result<Option<StepStatus>> {
+    let s: Option<String> = conn
+        .query_row(
+            "SELECT status FROM workflow_step WHERE step_id = ?1",
+            [step_id],
+            |r| r.get(0),
+        )
+        .optional()?;
+    Ok(s.map(|x| parse_step_status(&x)))
+}
+
+/// Resolve + persist a step's completion via the evidence-gating invariant. A
+/// side-effect step is persisted `Verified` only when deterministic evidence is
+/// supplied (`evidence_ref`); otherwise `ProofPending` (even if the model claimed
+/// done). Returns the persisted status.
+///
+/// Evidence presence is the presence of `evidence_ref` — there is no separate
+/// `has_evidence` flag to diverge from it, so a step can never be persisted
+/// `Verified` while carrying a NULL `evidence_ref` (the invariant is enforced by
+/// the API shape, not just by caller discipline). A step already in a terminal
+/// state (`Verified`/`Failed`) is refused — completion cannot be downgraded;
+/// `ProofPending` is non-terminal, so late-arriving evidence still verifies it.
+pub fn complete_step(
+    conn: &Connection,
+    step_id: &str,
+    evidence_ref: Option<&str>,
+    model_claimed_done: bool,
+    now: i64,
+) -> Result<StepStatus> {
+    let (has_side_effect, cur_status) = conn
+        .query_row(
+            "SELECT has_side_effect, status FROM workflow_step WHERE step_id = ?1",
+            [step_id],
+            |r| Ok((r.get::<_, i64>(0)?, r.get::<_, String>(1)?)),
+        )
+        .optional()?
+        .ok_or_else(|| StorageError::Unsupported(format!("workflow_step '{step_id}' not found")))?;
+
+    // A terminal step cannot be re-completed (no Verified -> ProofPending downgrade).
+    if parse_step_status(&cur_status).is_terminal() {
+        return Err(StorageError::Unsupported(format!(
+            "workflow_step '{step_id}' is already terminal ({cur_status}); refusing to re-complete"
+        )));
+    }
+
+    // Evidence presence IS the ref's presence: no divergent (has_evidence, ref) pair.
+    let has_evidence = evidence_ref.is_some();
+    let status = resolve_step_completion(has_side_effect != 0, has_evidence, model_claimed_done);
+    // Only attach an evidence_ref when the step is actually verified by evidence.
+    let stored_ref = if matches!(status, StepStatus::Verified) {
+        evidence_ref
+    } else {
+        None
+    };
+    conn.execute(
+        "UPDATE workflow_step SET status = ?1, evidence_ref = ?2, updated_at = ?3 WHERE step_id = ?4",
+        params![status.as_str(), stored_ref, now, step_id],
+    )?;
+    Ok(status)
+}

--- a/rust-core/crates/friday-storage/tests/migration.rs
+++ b/rust-core/crates/friday-storage/tests/migration.rs
@@ -26,7 +26,7 @@ const FOUNDATION_HUB_TABLES: &[&str] = &[
 fn fresh_hub_db_has_all_foundation_tables() {
     let p = temp_db_path("fresh");
     let db = Db::open_hub(&p).unwrap();
-    assert_eq!(db.version().unwrap(), 1);
+    assert_eq!(db.version().unwrap(), 2);
     let tables = db.table_names().unwrap();
     for t in FOUNDATION_HUB_TABLES {
         assert!(
@@ -51,11 +51,11 @@ fn reopen_is_idempotent_and_preserves_rows() {
             "mac_live",
         )
         .unwrap();
-        assert_eq!(db.version().unwrap(), 1);
+        assert_eq!(db.version().unwrap(), 2);
     }
     // Reopening runs zero pending migrations and keeps the data.
     let db = Db::open_hub(&p).unwrap();
-    assert_eq!(db.version().unwrap(), 1);
+    assert_eq!(db.version().unwrap(), 2);
     assert_eq!(db.count("session").unwrap(), 1);
 }
 
@@ -71,7 +71,7 @@ fn refuses_to_open_when_disk_newer_than_code() {
     match Db::open_hub(&p) {
         Err(StorageError::SchemaTooNew { disk, code }) => {
             assert_eq!(disk, 999);
-            assert_eq!(code, 1);
+            assert_eq!(code, 2);
         }
         Ok(_) => panic!("expected SchemaTooNew, got Ok"),
         Err(other) => panic!("expected SchemaTooNew, got {other:?}"),
@@ -137,16 +137,16 @@ fn destructive_migration_creates_verified_backup() {
         .unwrap();
     }
 
-    // v1 + destructive v2.
+    // Seed is at the current hub version (v2); add a destructive v3 on top.
     let mut migs = hub_migrations();
     migs.push(Migration {
-        version: 2,
+        version: 3,
         name: "rebuild_activity",
         destructive: true,
         up: rebuild_activity_v2,
     });
     let db = Db::open(&p, Profile::Hub, &migs, "test-destructive").unwrap();
-    assert_eq!(db.version().unwrap(), 2);
+    assert_eq!(db.version().unwrap(), 3);
 
     // New column exists post-migration.
     let has_priority: i64 = db

--- a/rust-core/crates/friday-storage/tests/workflow_persist.rs
+++ b/rust-core/crates/friday-storage/tests/workflow_persist.rs
@@ -1,0 +1,175 @@
+//! Unit-9 workflow persistence: a REAL forward migration (v1 -> v2 adds the
+//! workflow tables, preserving existing data), the run state machine persisted,
+//! and evidence-gated step completion persisted (`08` §6 / `10` §6).
+
+mod common;
+
+use common::temp_db_path;
+use friday_core::{SessionState, StepStatus, WorkflowRunState};
+use friday_storage::{hub_migrations, workflow, Db, Profile};
+
+#[test]
+fn forward_migration_v1_to_v2_adds_workflow_tables_preserving_data() {
+    let p = temp_db_path("wf-mig");
+    // Open at v1 only (init_hub), seed a row.
+    {
+        let mut migs = hub_migrations();
+        migs.truncate(1); // keep only 0001_init_hub
+        let db = Db::open(&p, Profile::Hub, &migs, "v1").unwrap();
+        assert_eq!(db.version().unwrap(), 1);
+        assert!(
+            !db.table_names()
+                .unwrap()
+                .iter()
+                .any(|t| t == "workflow_run"),
+            "workflow tables must not exist at v1"
+        );
+        db.insert_session(
+            "s1",
+            "friday_ask",
+            "hi",
+            SessionState::Created,
+            1,
+            1,
+            "mac_live",
+        )
+        .unwrap();
+    }
+    // Reopen with the full set -> forward-migrate to v2.
+    let db = Db::open_hub(&p).unwrap();
+    assert_eq!(db.version().unwrap(), 2);
+    let tables = db.table_names().unwrap();
+    assert!(tables.iter().any(|t| t == "workflow_run"));
+    assert!(tables.iter().any(|t| t == "workflow_step"));
+    // Pre-existing data survived the migration.
+    assert_eq!(db.count("session").unwrap(), 1);
+}
+
+#[test]
+fn run_state_machine_is_persisted_and_validated() {
+    let p = temp_db_path("wf-run");
+    let db = Db::open_hub(&p).unwrap();
+    workflow::create_run(db.conn(), "r1", "QA", 1).unwrap();
+    assert_eq!(
+        workflow::run_state(db.conn(), "r1").unwrap(),
+        Some(WorkflowRunState::Pending)
+    );
+    workflow::set_run_state(db.conn(), "r1", WorkflowRunState::Running, 2).unwrap();
+    workflow::set_run_state(db.conn(), "r1", WorkflowRunState::Done, 3).unwrap();
+    assert_eq!(
+        workflow::run_state(db.conn(), "r1").unwrap(),
+        Some(WorkflowRunState::Done)
+    );
+
+    // Invalid transition (Pending -> Done) is rejected by the state machine.
+    workflow::create_run(db.conn(), "r2", "x", 1).unwrap();
+    assert!(workflow::set_run_state(db.conn(), "r2", WorkflowRunState::Done, 2).is_err());
+}
+
+#[test]
+fn evidence_gated_step_completion_is_persisted() {
+    let p = temp_db_path("wf-step");
+    let db = Db::open_hub(&p).unwrap();
+    workflow::create_run(db.conn(), "r1", "QA", 1).unwrap();
+
+    // Side-effect step, NO evidence, model claims done -> ProofPending (NOT Verified).
+    workflow::add_step(db.conn(), "st1", "r1", 1, true, 1).unwrap();
+    assert_eq!(
+        workflow::complete_step(db.conn(), "st1", None, true, 2).unwrap(),
+        StepStatus::ProofPending
+    );
+    assert_eq!(
+        workflow::step_status(db.conn(), "st1").unwrap(),
+        Some(StepStatus::ProofPending)
+    );
+
+    // Side-effect step WITH evidence -> Verified.
+    workflow::add_step(db.conn(), "st2", "r1", 2, true, 1).unwrap();
+    assert_eq!(
+        workflow::complete_step(db.conn(), "st2", Some("evidence://receipt-1"), false, 3).unwrap(),
+        StepStatus::Verified
+    );
+    assert!(workflow::step_status(db.conn(), "st2")
+        .unwrap()
+        .unwrap()
+        .is_complete());
+
+    // No-side-effect step may complete on a model result.
+    workflow::add_step(db.conn(), "st3", "r1", 3, false, 1).unwrap();
+    assert_eq!(
+        workflow::complete_step(db.conn(), "st3", None, true, 4).unwrap(),
+        StepStatus::Verified
+    );
+
+    // evidence_ref is stored only for the evidence-verified step.
+    let ev2: Option<String> = db
+        .conn()
+        .query_row(
+            "SELECT evidence_ref FROM workflow_step WHERE step_id = 'st2'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(ev2.as_deref(), Some("evidence://receipt-1"));
+    let ev1: Option<String> = db
+        .conn()
+        .query_row(
+            "SELECT evidence_ref FROM workflow_step WHERE step_id = 'st1'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        ev1, None,
+        "ProofPending step must not carry an evidence_ref"
+    );
+}
+
+#[test]
+fn proof_pending_verifies_when_evidence_arrives_but_verified_cannot_downgrade() {
+    let p = temp_db_path("wf-terminal");
+    let db = Db::open_hub(&p).unwrap();
+    workflow::create_run(db.conn(), "r1", "QA", 1).unwrap();
+
+    // Side-effect step completes with no evidence yet -> ProofPending (non-terminal).
+    workflow::add_step(db.conn(), "st1", "r1", 1, true, 1).unwrap();
+    assert_eq!(
+        workflow::complete_step(db.conn(), "st1", None, true, 2).unwrap(),
+        StepStatus::ProofPending
+    );
+
+    // Evidence arrives later -> the SAME step now verifies (ProofPending is not terminal).
+    assert_eq!(
+        workflow::complete_step(db.conn(), "st1", Some("evidence://late"), false, 3).unwrap(),
+        StepStatus::Verified
+    );
+    let ev: Option<String> = db
+        .conn()
+        .query_row(
+            "SELECT evidence_ref FROM workflow_step WHERE step_id = 'st1'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(ev.as_deref(), Some("evidence://late"));
+
+    // A second completion with NO evidence must NOT downgrade a Verified step.
+    assert!(
+        workflow::complete_step(db.conn(), "st1", None, true, 4).is_err(),
+        "a terminal (Verified) step must not be re-completable"
+    );
+    assert_eq!(
+        workflow::step_status(db.conn(), "st1").unwrap(),
+        Some(StepStatus::Verified)
+    );
+    // The evidence_ref survived the rejected downgrade attempt.
+    let ev_after: Option<String> = db
+        .conn()
+        .query_row(
+            "SELECT evidence_ref FROM workflow_step WHERE step_id = 'st1'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(ev_after.as_deref(), Some("evidence://late"));
+}


### PR DESCRIPTION
## Summary
Hub-only **workflow_run / workflow_step** persistence for the all-Rust Friday Core, composing `friday-core`'s `WorkflowRunState` machine and the evidence-gated step-completion invariant. This is the persistence slice on top of the Unit-9 core logic already on main (PR #455).

Overall Friday v1 remains **NO-GO** (greenfield). This advances Unit 9 *persistence*; the workflow/activity **UI** and end-to-end NL workflow-gen→run remain deferred / proof_pending (native + model-quality), not claimed here.

## What's in this slice
- **schema `0002` — additive forward migration (v1→v2).** Adds the Hub-only `workflow_run` + `workflow_step` tables. `destructive: false`. The forward-migration test opens a DB at v1, seeds a row, reopens with the full migration set → migrates to v2, and asserts (a) the workflow tables now exist and (b) the **pre-existing row survived**. `code_max` becomes 2, so refuse-when-newer still fires.
- **`friday-storage::workflow` repo.** `create_run` / `run_state` / `set_run_state` / `add_step` / `step_status` / `complete_step`.
  - `set_run_state` is validated by `WorkflowRunState::try_transition` (an invalid transition such as Pending→Done is rejected at the state-machine layer).
  - `complete_step` composes `friday-core::resolve_step_completion`: a **side-effect** step is persisted `Verified` **only** with deterministic evidence; otherwise `ProofPending` — *even if the model claimed done*.
- **Evidence-gating made structural (reviewer-driven).** Evidence presence **is** the presence of `evidence_ref` — there is no separate `has_evidence` flag to diverge from it, so a side-effect step can **never** be persisted `Verified` with a NULL `evidence_ref`. The invariant is enforced by the API shape, not just by caller discipline.
- **No-downgrade terminal guard.** A step already `Verified`/`Failed` is refused re-completion. `ProofPending` is intentionally **non-terminal**, so late-arriving evidence still verifies it (new `StepStatus::is_terminal()`).
- **`migration.rs`** updated for the real v2 schema bump (version/code 1→2; the synthetic destructive test stacks at v3). No assertions weakened — destructive-backup guard, refuse-when-newer, and data-preservation are all still genuinely tested. Hub-only placement of the new tables is asserted both ways (present on Hub, absent on Phone) in `schema_profile`.

## Trust boundary
`workflow_run`/`workflow_step` are added to `HUB_ONLY_TABLES` — workflow runs are Hub-coordinated and never created on a phone profile.

## Tests / gates
- `cargo fmt --all -- --check`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo test --workspace`: **116 passed, 0 failed, 2 ignored** (the 2 ignored are the live DeepSeek-route and live provider-auth smokes)
- New tests: forward-migration v1→v2 (data preserved), run state machine persisted+validated, evidence-gated completion persisted, ProofPending→Verified on late evidence while Verified cannot be downgraded, `StepStatus` terminality.

## Reviewers
Reviewer A (coverage): **PASS**. Reviewer B (adversarial): **CONCERNS** on the `has_evidence`/`evidence_ref` divergent-pair representability + missing terminal guard — both fixed in this commit (structural evidence-gating + no-downgrade guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)