### PR TITLE
Memory persistence + backfilling migration v2->v3 (Unit 10 persistence slice)

### DIFF
--- a/rust-core/crates/friday-core/src/memory.rs
+++ b/rust-core/crates/friday-core/src/memory.rs
@@ -22,6 +22,16 @@ pub enum MemoryScope {
     Session,
 }
 
+impl MemoryScope {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            MemoryScope::Global => "global",
+            MemoryScope::Project => "project",
+            MemoryScope::Session => "session",
+        }
+    }
+}
+
 /// Confidence tier (`07` §9 / `02` §12).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Confidence {
@@ -40,6 +50,15 @@ impl Confidence {
             Confidence::Confirmed | Confidence::HighConfidenceContext
         )
     }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Confidence::Confirmed => "confirmed",
+            Confidence::HighConfidenceContext => "high_confidence_context",
+            Confidence::Inferred => "inferred",
+            Confidence::Candidate => "candidate",
+        }
+    }
 }
 
 /// Lifecycle of a long-term memory item.
@@ -54,6 +73,21 @@ impl MemoryState {
     /// Durable (usable as long-term fact) only when `Confirmed`.
     pub fn is_durable(&self) -> bool {
         matches!(self, MemoryState::Confirmed)
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            MemoryState::Candidate => "candidate",
+            MemoryState::Confirmed => "confirmed",
+            MemoryState::Rejected => "rejected",
+        }
+    }
+
+    /// A terminal lifecycle state. A `Confirmed` or `Rejected` item is not a
+    /// pending candidate and is not re-decidable (no silent re-write / no
+    /// downgrade); only a `Candidate` is awaiting the user's decision.
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, MemoryState::Confirmed | MemoryState::Rejected)
     }
 }
 
@@ -255,6 +289,36 @@ mod tests {
         assert_ne!(MemoryScope::Global, MemoryScope::Project);
         assert_ne!(MemoryScope::Project, MemoryScope::Session);
         assert_ne!(MemoryScope::Global, MemoryScope::Session);
+    }
+
+    #[test]
+    fn memory_state_terminality_matches_durability_semantics() {
+        // A Candidate is awaiting the user's decision -> NOT terminal, re-decidable.
+        assert!(!MemoryState::Candidate.is_terminal());
+        // Confirmed/Rejected are terminal: no silent re-write, no downgrade.
+        assert!(MemoryState::Confirmed.is_terminal());
+        assert!(MemoryState::Rejected.is_terminal());
+        // Only Confirmed is durable; a terminal Rejected is NOT durable.
+        assert!(MemoryState::Confirmed.is_durable());
+        assert!(!MemoryState::Rejected.is_durable());
+    }
+
+    #[test]
+    fn enum_wire_strings_are_stable_and_distinct() {
+        // These strings are persisted; they must be stable + mutually distinct.
+        assert_eq!(MemoryScope::Global.as_str(), "global");
+        assert_eq!(MemoryState::Candidate.as_str(), "candidate");
+        assert_eq!(Confidence::Confirmed.as_str(), "confirmed");
+        // A confirmed Confidence and a confirmed MemoryState share the wire token
+        // (same lifecycle point) — intended, the repo keeps them consistent.
+        assert_eq!(
+            Confidence::Confirmed.as_str(),
+            MemoryState::Confirmed.as_str()
+        );
+        assert_ne!(
+            Confidence::Inferred.as_str(),
+            Confidence::Candidate.as_str()
+        );
     }
 
     #[test]

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -12,6 +12,7 @@
 pub mod audit;
 pub mod blob;
 mod error;
+pub mod memory;
 mod migrate;
 pub mod offline;
 pub mod pairing;

--- a/rust-core/crates/friday-storage/src/memory.rs
+++ b/rust-core/crates/friday-storage/src/memory.rs
@@ -1,0 +1,210 @@
+//! Memory-item persistence (Unit 10; gate `21` §9, `07`, `02` §11/§12). Hub-only.
+//!
+//! Composes `friday-core`'s memory-trust invariants:
+//! - **No silent long-term write** (`07` §6/§7): extraction records a *candidate*;
+//!   it becomes durable (`Confirmed`) ONLY via an explicit user decision.
+//! - **A single authoritative lifecycle column.** `state`
+//!   (candidate/confirmed/rejected) drives durability; `confidence` is written
+//!   *consistent with* `state` by the same single writer. There is **no raw
+//!   setter for `confidence`**, so a row can never carry a contradictory
+//!   `(confidence=confirmed, state=rejected)` pair — the illegal combination is
+//!   unrepresentable through this API, not merely discouraged.
+//! - **Terminal decisions are final.** A `Confirmed`/`Rejected` item is refused
+//!   re-decision (no silent re-write, no downgrade); only a `Candidate` is
+//!   awaiting the user.
+
+use crate::error::{Result, StorageError};
+use friday_core::{decide_candidate, Confidence, MemoryScope, MemoryState};
+use rusqlite::{params, Connection, OptionalExtension};
+
+/// A persisted memory item (mirrors `memory_item`).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MemoryRow {
+    pub memory_id: String,
+    pub scope: MemoryScope,
+    pub content_ref: Option<String>,
+    pub confidence: Confidence,
+    pub state: MemoryState,
+    pub created_at: i64,
+    pub confirmed_at: Option<i64>,
+}
+
+// Defensive parsers. Values are only ever written via the enum `as_str()`, so an
+// unknown token cannot arise in normal operation; when one does, fail CLOSED on
+// the load-bearing axes — never treat an unparseable row as a durable, auto-usable
+// fact (unknown confidence -> Candidate; unknown state -> Candidate; both are
+// non-durable and not auto-usable).
+fn parse_scope(s: &str) -> MemoryScope {
+    match s {
+        "global" => MemoryScope::Global,
+        "project" => MemoryScope::Project,
+        _ => MemoryScope::Session,
+    }
+}
+
+fn parse_confidence(s: &str) -> Confidence {
+    match s {
+        "confirmed" => Confidence::Confirmed,
+        "high_confidence_context" => Confidence::HighConfidenceContext,
+        "inferred" => Confidence::Inferred,
+        _ => Confidence::Candidate,
+    }
+}
+
+fn parse_state(s: &str) -> MemoryState {
+    match s {
+        "confirmed" => MemoryState::Confirmed,
+        "rejected" => MemoryState::Rejected,
+        _ => MemoryState::Candidate,
+    }
+}
+
+fn row_from(r: &rusqlite::Row) -> rusqlite::Result<MemoryRow> {
+    let scope: String = r.get("scope")?;
+    // `confidence` is nullable in the v1 DDL; a NULL must read as the fail-closed
+    // default (Candidate — not durable, not auto-usable), never error the read path.
+    let confidence: Option<String> = r.get("confidence")?;
+    let state: String = r.get("state")?;
+    Ok(MemoryRow {
+        memory_id: r.get("memory_id")?,
+        scope: parse_scope(&scope),
+        content_ref: r.get("content_ref")?,
+        confidence: parse_confidence(confidence.as_deref().unwrap_or("")),
+        state: parse_state(&state),
+        created_at: r.get("created_at")?,
+        confirmed_at: r.get("confirmed_at")?,
+    })
+}
+
+const SELECT_COLS: &str =
+    "memory_id, scope, content_ref, confidence, state, created_at, confirmed_at";
+
+/// Record a freshly-extracted memory candidate. NEVER durable: `state=Candidate`,
+/// `confidence=Candidate`, `confirmed_at=NULL`. Nothing here makes it a fact
+/// (`07` §6/§7 — no silent long-term write).
+pub fn record_candidate(
+    conn: &Connection,
+    memory_id: &str,
+    scope: MemoryScope,
+    content_ref: Option<&str>,
+    created_at: i64,
+) -> Result<()> {
+    conn.execute(
+        "INSERT INTO memory_item
+            (memory_id, scope, content_ref, confidence, state, created_at, confirmed_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, NULL)",
+        params![
+            memory_id,
+            scope.as_str(),
+            content_ref,
+            Confidence::Candidate.as_str(),
+            MemoryState::Candidate.as_str(),
+            created_at
+        ],
+    )?;
+    Ok(())
+}
+
+pub fn get(conn: &Connection, memory_id: &str) -> Result<Option<MemoryRow>> {
+    let row = conn
+        .query_row(
+            &format!("SELECT {SELECT_COLS} FROM memory_item WHERE memory_id = ?1"),
+            [memory_id],
+            row_from,
+        )
+        .optional()?;
+    Ok(row)
+}
+
+/// Apply the user's explicit decision to a pending candidate, composing
+/// `friday-core::decide_candidate`:
+/// - confirm -> durable (`state=Confirmed`, `confidence=Confirmed`, `confirmed_at`
+///   set);
+/// - reject -> `state=Rejected` (not durable; `confidence` left non-confirmed).
+///
+/// `confidence` is written CONSISTENT with `state` here — there is no path that
+/// sets `confidence` on its own, so a confirmed-confidence/non-confirmed-state
+/// row is unrepresentable. A terminal item is refused (no re-write / no
+/// downgrade). Returns the resulting state.
+pub fn decide(
+    conn: &Connection,
+    memory_id: &str,
+    user_confirmed: bool,
+    now: i64,
+) -> Result<MemoryState> {
+    let cur = current_state(conn, memory_id)?
+        .ok_or_else(|| StorageError::Unsupported(format!("memory_item '{memory_id}' not found")))?;
+    if cur.is_terminal() {
+        return Err(StorageError::Unsupported(format!(
+            "memory_item '{memory_id}' is already terminal ({}); refusing to re-decide",
+            cur.as_str()
+        )));
+    }
+    let next = decide_candidate(cur, Some(user_confirmed));
+    let (confidence, confirmed_at) = match next {
+        MemoryState::Confirmed => (Confidence::Confirmed, Some(now)),
+        // Rejected / still-Candidate are not durable: confidence stays non-confirmed.
+        MemoryState::Rejected | MemoryState::Candidate => (Confidence::Candidate, None),
+    };
+    conn.execute(
+        "UPDATE memory_item SET state = ?1, confidence = ?2, confirmed_at = ?3
+         WHERE memory_id = ?4",
+        params![next.as_str(), confidence.as_str(), confirmed_at, memory_id],
+    )?;
+    Ok(next)
+}
+
+/// Confirm a candidate (explicit user yes). Durable iff it was a pending candidate.
+pub fn confirm(conn: &Connection, memory_id: &str, now: i64) -> Result<MemoryState> {
+    decide(conn, memory_id, true, now)
+}
+
+/// Reject a candidate (explicit user no). Never durable.
+pub fn reject(conn: &Connection, memory_id: &str, now: i64) -> Result<MemoryState> {
+    decide(conn, memory_id, false, now)
+}
+
+/// Candidates awaiting the user's decision, oldest first (`07` §6/§7) — the
+/// data-layer query that **backs** the Memory Review schedule (the schedule's
+/// settings/cron/morning-card UI is deferred, `07` §7). These are surfaced for
+/// explicit confirm/reject; they are NOT auto-usable until confirmed.
+pub fn pending_review(conn: &Connection) -> Result<Vec<MemoryRow>> {
+    select_by_state(conn, MemoryState::Candidate)
+}
+
+/// Durable, auto-usable long-term memory: only `Confirmed` items (`07` §9,
+/// `02` §12). A candidate or rejected item is never returned here.
+pub fn auto_usable(conn: &Connection) -> Result<Vec<MemoryRow>> {
+    let rows = select_by_state(conn, MemoryState::Confirmed)?;
+    // Defense-in-depth: the state filter already restricts to Confirmed, but assert
+    // the friday-core trust invariant holds for every row we hand back as a fact.
+    debug_assert!(rows
+        .iter()
+        .all(|m| m.state.is_durable() && m.confidence.auto_usable()));
+    Ok(rows)
+}
+
+// --- helpers ---------------------------------------------------------------
+
+fn current_state(conn: &Connection, memory_id: &str) -> Result<Option<MemoryState>> {
+    let s: Option<String> = conn
+        .query_row(
+            "SELECT state FROM memory_item WHERE memory_id = ?1",
+            [memory_id],
+            |r| r.get(0),
+        )
+        .optional()?;
+    Ok(s.map(|x| parse_state(&x)))
+}
+
+fn select_by_state(conn: &Connection, state: MemoryState) -> Result<Vec<MemoryRow>> {
+    let mut stmt = conn.prepare(&format!(
+        "SELECT {SELECT_COLS} FROM memory_item WHERE state = ?1 ORDER BY created_at, memory_id"
+    ))?;
+    let rows = stmt.query_map([state.as_str()], row_from)?;
+    let mut out = Vec::new();
+    for r in rows {
+        out.push(r?);
+    }
+    Ok(out)
+}

--- a/rust-core/crates/friday-storage/src/schema.rs
+++ b/rust-core/crates/friday-storage/src/schema.rs
@@ -38,6 +38,14 @@ pub fn hub_migrations() -> Vec<Migration> {
             destructive: false,
             up: m0002_workflow,
         },
+        // Unit 10: memory lifecycle `state` column (additive; backfills existing
+        // confirmed rows so a confirmed memory is never silently demoted).
+        Migration {
+            version: 3,
+            name: "memory_state",
+            destructive: false,
+            up: m0003_memory_state,
+        },
     ]
 }
 
@@ -225,4 +233,31 @@ fn m0001_init_phone(tx: &Transaction) -> rusqlite::Result<()> {
 fn m0002_workflow(tx: &Transaction) -> rusqlite::Result<()> {
     tx.execute_batch(DDL_WORKFLOW)?;
     Ok(())
+}
+
+// Unit 10: additive forward migration (v2 -> v3) adding the memory lifecycle
+// `state` column. SQLite `ADD COLUMN ... DEFAULT 'candidate'` sets EVERY existing
+// row to the default, so we backfill in the SAME transaction — otherwise an
+// already-confirmed memory (`confirmed_at` set) would be silently demoted to a
+// candidate (a data-correctness regression). `confirmed_at` is the authoritative
+// pre-migration signal of "the user confirmed this".
+//
+// The migration is the ONLY writer of these columns besides the typed repo, so it
+// must uphold the same `(confidence, state)` consistency the repo guarantees —
+// otherwise it could mint the very divergent pair the repo makes unrepresentable
+// (`memory_item` has existed since v1 with a nullable, repo-unenforced
+// `confidence`). So we also normalize `confidence`: a confirmed row gets
+// `confidence='confirmed'`; a non-confirmed row never keeps a `confirmed` (or
+// NULL) confidence. Post-migration: `confidence='confirmed'` IFF
+// `state='confirmed'` IFF `confirmed_at IS NOT NULL`, and `confidence` is never NULL.
+fn m0003_memory_state(tx: &Transaction) -> rusqlite::Result<()> {
+    tx.execute_batch(
+        "ALTER TABLE memory_item ADD COLUMN state TEXT NOT NULL DEFAULT 'candidate';
+         UPDATE memory_item
+            SET state = 'confirmed', confidence = 'confirmed'
+            WHERE confirmed_at IS NOT NULL;
+         UPDATE memory_item
+            SET confidence = 'candidate'
+            WHERE confirmed_at IS NULL AND (confidence IS NULL OR confidence = 'confirmed');",
+    )
 }

--- a/rust-core/crates/friday-storage/tests/memory_persist.rs
+++ b/rust-core/crates/friday-storage/tests/memory_persist.rs
@@ -1,0 +1,303 @@
+//! Unit-10 memory persistence: the forward migration that adds the `state`
+//! lifecycle column must BACKFILL (a pre-existing confirmed memory stays
+//! confirmed, never silently demoted); the single-writer repo enforces the
+//! trust invariants — no silent long-term write, only confirmed is auto-usable,
+//! a terminal decision is final, and `confidence` is always consistent with
+//! `state` (`07` §6/§7/§9, `02` §11/§12).
+
+mod common;
+
+use common::temp_db_path;
+use friday_core::{Confidence, MemoryScope, MemoryState};
+use friday_storage::{hub_migrations, memory, Db, Profile};
+
+/// Insert a memory_item directly at the PRE-migration (v2) schema, which has no
+/// `state` column. `confirmed_at` is the authoritative pre-migration "confirmed"
+/// signal that the backfill keys on. `confidence` is `Option` because the v1 DDL
+/// made it nullable and there was no repo enforcing consistency before v3.
+fn seed_v2_memory(db: &Db, id: &str, confidence: Option<&str>, confirmed_at: Option<i64>) {
+    db.conn()
+        .execute(
+            "INSERT INTO memory_item
+                (memory_id, scope, content_ref, confidence, created_at, confirmed_at)
+             VALUES (?1, 'global', ?2, ?3, 1, ?4)",
+            rusqlite::params![id, format!("ref://{id}"), confidence, confirmed_at],
+        )
+        .unwrap();
+}
+
+fn state_of(db: &Db, id: &str) -> String {
+    db.conn()
+        .query_row(
+            "SELECT state FROM memory_item WHERE memory_id = ?1",
+            [id],
+            |r| r.get(0),
+        )
+        .unwrap()
+}
+
+#[test]
+fn forward_migration_v2_to_v3_backfills_confirmed_and_defaults_candidate() {
+    let p = temp_db_path("mem-mig");
+    // Open at v2 only (no `state` column), seed a CONFIRMED row and a pending one.
+    {
+        let mut migs = hub_migrations();
+        migs.truncate(2); // [0001_init_hub, 0002_workflow] — memory_item w/o `state`
+        let db = Db::open(&p, Profile::Hub, &migs, "v2").unwrap();
+        assert_eq!(db.version().unwrap(), 2);
+        // The `state` column must not exist yet.
+        let has_state: i64 = db
+            .conn()
+            .query_row(
+                "SELECT count(*) FROM pragma_table_info('memory_item') WHERE name = 'state'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(has_state, 0, "state column must not exist at v2");
+
+        // A user-confirmed memory (confirmed_at set) and a never-confirmed one.
+        seed_v2_memory(&db, "confirmed1", Some("confirmed"), Some(42));
+        seed_v2_memory(&db, "pending1", Some("candidate"), None);
+    }
+
+    // Reopen with the full set -> forward-migrate to v3 (adds `state` + backfills).
+    let db = Db::open_hub(&p).unwrap();
+    assert_eq!(db.version().unwrap(), 3);
+
+    // THE discriminating assertion: the pre-existing confirmed memory was NOT
+    // demoted to a candidate by the column default — it is still confirmed.
+    assert_eq!(
+        state_of(&db, "confirmed1"),
+        "confirmed",
+        "a confirmed memory must survive the migration as confirmed (not demoted)"
+    );
+    // The never-confirmed row took the safe default.
+    assert_eq!(state_of(&db, "pending1"), "candidate");
+
+    // And it round-trips through the repo as a durable, auto-usable fact.
+    let confirmed = memory::get(db.conn(), "confirmed1").unwrap().unwrap();
+    assert_eq!(confirmed.state, MemoryState::Confirmed);
+    assert!(confirmed.state.is_durable());
+    let usable = memory::auto_usable(db.conn()).unwrap();
+    assert!(usable.iter().any(|m| m.memory_id == "confirmed1"));
+    assert!(!usable.iter().any(|m| m.memory_id == "pending1"));
+}
+
+#[test]
+fn forward_migration_normalizes_confidence_so_no_divergent_pair_survives() {
+    // The migration is a SECOND writer of (state, confidence); it must uphold the
+    // same consistency the repo guarantees. A pre-v3 row could carry confirmed_at
+    // with a non-confirmed/NULL confidence (no repo enforced it before v3), or a
+    // stale 'confirmed' confidence on a never-confirmed row. After migration NO
+    // divergent (confidence='confirmed' XOR state='confirmed') pair may survive.
+    let p = temp_db_path("mem-mig-confidence");
+    {
+        let mut migs = hub_migrations();
+        migs.truncate(2); // v2: memory_item without `state`
+        let db = Db::open(&p, Profile::Hub, &migs, "v2").unwrap();
+        seed_v2_memory(&db, "conf_inferred", Some("inferred"), Some(7)); // confirmed, stale conf
+        seed_v2_memory(&db, "conf_null", None, Some(8)); // confirmed, NULL conf
+        seed_v2_memory(&db, "stale_confirmed", Some("confirmed"), None); // not confirmed, stale 'confirmed'
+        seed_v2_memory(&db, "cand_null", None, None); // not confirmed, NULL conf
+    }
+    let db = Db::open_hub(&p).unwrap();
+    assert_eq!(db.version().unwrap(), 3);
+
+    // Genuinely-confirmed rows: state AND confidence both normalized to confirmed.
+    for id in ["conf_inferred", "conf_null"] {
+        let row = memory::get(db.conn(), id).unwrap().unwrap();
+        assert_eq!(row.state, MemoryState::Confirmed, "{id} state");
+        assert_eq!(row.confidence, Confidence::Confirmed, "{id} confidence");
+    }
+    // Non-confirmed rows: a stale/NULL 'confirmed' confidence is cleared, so no
+    // (confidence=confirmed, state!=confirmed) divergent pair remains.
+    for id in ["stale_confirmed", "cand_null"] {
+        let row = memory::get(db.conn(), id).unwrap().unwrap();
+        assert_eq!(row.state, MemoryState::Candidate, "{id} state");
+        assert_ne!(
+            row.confidence,
+            Confidence::Confirmed,
+            "{id} must not keep a confirmed confidence"
+        );
+    }
+
+    // auto_usable returns exactly the genuinely-confirmed rows, and its internal
+    // (confidence,state) consistency debug_assert does NOT trip (would panic here
+    // in this debug/test build if the migration had left a divergent pair).
+    let usable: Vec<String> = memory::auto_usable(db.conn())
+        .unwrap()
+        .into_iter()
+        .map(|m| m.memory_id)
+        .collect();
+    assert_eq!(usable.len(), 2);
+    assert!(usable.contains(&"conf_inferred".to_string()));
+    assert!(usable.contains(&"conf_null".to_string()));
+}
+
+#[test]
+fn unknown_state_or_confidence_tokens_read_fail_closed() {
+    let p = temp_db_path("mem-failclosed");
+    let db = Db::open_hub(&p).unwrap(); // v3
+                                        // Hand-insert a malformed row (bypasses the typed repo) with garbage tokens
+                                        // AND confirmed_at set: a defensive read must NEVER treat it as a durable fact.
+    db.conn()
+        .execute(
+            "INSERT INTO memory_item
+                (memory_id, scope, content_ref, confidence, state, created_at, confirmed_at)
+             VALUES ('bogus', 'global', NULL, 'garbage', 'garbage', 1, 99)",
+            [],
+        )
+        .unwrap();
+    let row = memory::get(db.conn(), "bogus").unwrap().unwrap();
+    assert_eq!(row.confidence, Confidence::Candidate); // unknown -> least-trusted tier
+    assert_eq!(row.state, MemoryState::Candidate);
+    assert!(!row.state.is_durable());
+    assert!(!row.confidence.auto_usable());
+    // Never surfaced as a durable, auto-usable fact despite confirmed_at being set.
+    assert!(memory::auto_usable(db.conn()).unwrap().is_empty());
+}
+
+#[test]
+fn duplicate_record_candidate_errors_no_silent_clobber() {
+    let p = temp_db_path("mem-dup");
+    let db = Db::open_hub(&p).unwrap();
+    memory::record_candidate(db.conn(), "m1", MemoryScope::Global, Some("x"), 1).unwrap();
+    memory::confirm(db.conn(), "m1", 2).unwrap();
+    // A second record_candidate for the same id must ERROR (PK violation), never
+    // silently clobber an already-confirmed memory back to a candidate.
+    assert!(memory::record_candidate(db.conn(), "m1", MemoryScope::Global, Some("y"), 3).is_err());
+    assert_eq!(state_of(&db, "m1"), "confirmed");
+}
+
+#[test]
+fn pending_review_tie_break_is_stable_by_memory_id() {
+    let p = temp_db_path("mem-tie");
+    let db = Db::open_hub(&p).unwrap();
+    // Identical created_at: the secondary memory_id sort makes order deterministic.
+    memory::record_candidate(db.conn(), "b", MemoryScope::Global, None, 5).unwrap();
+    memory::record_candidate(db.conn(), "a", MemoryScope::Global, None, 5).unwrap();
+    memory::record_candidate(db.conn(), "c", MemoryScope::Global, None, 5).unwrap();
+    let q: Vec<String> = memory::pending_review(db.conn())
+        .unwrap()
+        .into_iter()
+        .map(|m| m.memory_id)
+        .collect();
+    assert_eq!(q, vec!["a".to_string(), "b".to_string(), "c".to_string()]);
+}
+
+#[test]
+fn candidate_is_never_auto_usable_until_explicitly_confirmed() {
+    let p = temp_db_path("mem-no-silent");
+    let db = Db::open_hub(&p).unwrap();
+
+    memory::record_candidate(db.conn(), "m1", MemoryScope::Project, Some("a fact"), 10).unwrap();
+
+    // Recorded but undecided: it is a pending candidate, NOT durable, NOT usable.
+    let row = memory::get(db.conn(), "m1").unwrap().unwrap();
+    assert_eq!(row.state, MemoryState::Candidate);
+    assert_eq!(row.confidence, Confidence::Candidate);
+    assert!(!row.state.is_durable());
+    assert!(!row.confidence.auto_usable());
+    assert!(row.confirmed_at.is_none());
+    assert!(memory::auto_usable(db.conn()).unwrap().is_empty());
+    assert!(memory::pending_review(db.conn())
+        .unwrap()
+        .iter()
+        .any(|m| m.memory_id == "m1"));
+}
+
+#[test]
+fn explicit_confirm_makes_durable_with_consistent_confidence() {
+    let p = temp_db_path("mem-confirm");
+    let db = Db::open_hub(&p).unwrap();
+    memory::record_candidate(db.conn(), "m1", MemoryScope::Global, Some("fact"), 10).unwrap();
+
+    let st = memory::confirm(db.conn(), "m1", 100).unwrap();
+    assert_eq!(st, MemoryState::Confirmed);
+
+    let row = memory::get(db.conn(), "m1").unwrap().unwrap();
+    assert_eq!(row.state, MemoryState::Confirmed);
+    // confidence is written CONSISTENT with state (no divergent pair).
+    assert_eq!(row.confidence, Confidence::Confirmed);
+    assert!(row.confidence.auto_usable());
+    assert_eq!(row.confirmed_at, Some(100));
+
+    // Now usable, and no longer in the review queue.
+    assert!(memory::auto_usable(db.conn())
+        .unwrap()
+        .iter()
+        .any(|m| m.memory_id == "m1"));
+    assert!(memory::pending_review(db.conn()).unwrap().is_empty());
+}
+
+#[test]
+fn explicit_reject_is_not_durable_and_not_confirmed_confidence() {
+    let p = temp_db_path("mem-reject");
+    let db = Db::open_hub(&p).unwrap();
+    memory::record_candidate(db.conn(), "m1", MemoryScope::Session, None, 10).unwrap();
+
+    let st = memory::reject(db.conn(), "m1", 100).unwrap();
+    assert_eq!(st, MemoryState::Rejected);
+
+    let row = memory::get(db.conn(), "m1").unwrap().unwrap();
+    assert_eq!(row.state, MemoryState::Rejected);
+    assert!(!row.state.is_durable());
+    // A rejected item never carries confirmed confidence.
+    assert_ne!(row.confidence, Confidence::Confirmed);
+    assert!(!row.confidence.auto_usable());
+    assert!(row.confirmed_at.is_none());
+    assert!(memory::auto_usable(db.conn()).unwrap().is_empty());
+    assert!(memory::pending_review(db.conn()).unwrap().is_empty());
+}
+
+#[test]
+fn terminal_decision_is_final_no_rewrite_no_downgrade() {
+    let p = temp_db_path("mem-terminal");
+    let db = Db::open_hub(&p).unwrap();
+
+    // Confirmed cannot be re-decided (no downgrade to rejected).
+    memory::record_candidate(db.conn(), "c", MemoryScope::Global, Some("x"), 1).unwrap();
+    memory::confirm(db.conn(), "c", 2).unwrap();
+    assert!(memory::reject(db.conn(), "c", 3).is_err());
+    assert!(memory::confirm(db.conn(), "c", 3).is_err());
+    assert_eq!(state_of(&db, "c"), "confirmed");
+
+    // Rejected cannot be re-decided (no silent promotion to confirmed).
+    memory::record_candidate(db.conn(), "r", MemoryScope::Global, Some("y"), 1).unwrap();
+    memory::reject(db.conn(), "r", 2).unwrap();
+    assert!(memory::confirm(db.conn(), "r", 3).is_err());
+    assert_eq!(state_of(&db, "r"), "rejected");
+
+    // Deciding a non-existent item is an error, not a silent create.
+    assert!(memory::confirm(db.conn(), "ghost", 4).is_err());
+}
+
+#[test]
+fn memory_review_queue_is_oldest_first_and_only_candidates() {
+    let p = temp_db_path("mem-queue");
+    let db = Db::open_hub(&p).unwrap();
+    memory::record_candidate(db.conn(), "old", MemoryScope::Global, None, 10).unwrap();
+    memory::record_candidate(db.conn(), "mid", MemoryScope::Global, None, 20).unwrap();
+    memory::record_candidate(db.conn(), "new", MemoryScope::Global, None, 30).unwrap();
+    // Confirm the middle one -> it leaves the queue.
+    memory::confirm(db.conn(), "mid", 25).unwrap();
+
+    let queue: Vec<String> = memory::pending_review(db.conn())
+        .unwrap()
+        .into_iter()
+        .map(|m| m.memory_id)
+        .collect();
+    assert_eq!(queue, vec!["old".to_string(), "new".to_string()]);
+}
+
+#[test]
+fn memory_item_is_hub_only_absent_on_phone() {
+    let p = temp_db_path("mem-phone");
+    let db = Db::open_phone(&p).unwrap();
+    let tables = db.table_names().unwrap();
+    assert!(
+        !tables.iter().any(|t| t == "memory_item"),
+        "memory_item must never exist on a phone profile: have {tables:?}"
+    );
+}

--- a/rust-core/crates/friday-storage/tests/migration.rs
+++ b/rust-core/crates/friday-storage/tests/migration.rs
@@ -26,7 +26,7 @@ const FOUNDATION_HUB_TABLES: &[&str] = &[
 fn fresh_hub_db_has_all_foundation_tables() {
     let p = temp_db_path("fresh");
     let db = Db::open_hub(&p).unwrap();
-    assert_eq!(db.version().unwrap(), 2);
+    assert_eq!(db.version().unwrap(), 3);
     let tables = db.table_names().unwrap();
     for t in FOUNDATION_HUB_TABLES {
         assert!(
@@ -51,11 +51,11 @@ fn reopen_is_idempotent_and_preserves_rows() {
             "mac_live",
         )
         .unwrap();
-        assert_eq!(db.version().unwrap(), 2);
+        assert_eq!(db.version().unwrap(), 3);
     }
     // Reopening runs zero pending migrations and keeps the data.
     let db = Db::open_hub(&p).unwrap();
-    assert_eq!(db.version().unwrap(), 2);
+    assert_eq!(db.version().unwrap(), 3);
     assert_eq!(db.count("session").unwrap(), 1);
 }
 
@@ -71,7 +71,7 @@ fn refuses_to_open_when_disk_newer_than_code() {
     match Db::open_hub(&p) {
         Err(StorageError::SchemaTooNew { disk, code }) => {
             assert_eq!(disk, 999);
-            assert_eq!(code, 2);
+            assert_eq!(code, 3);
         }
         Ok(_) => panic!("expected SchemaTooNew, got Ok"),
         Err(other) => panic!("expected SchemaTooNew, got {other:?}"),
@@ -137,16 +137,16 @@ fn destructive_migration_creates_verified_backup() {
         .unwrap();
     }
 
-    // Seed is at the current hub version (v2); add a destructive v3 on top.
+    // Seed is at the current hub version (v3); add a destructive v4 on top.
     let mut migs = hub_migrations();
     migs.push(Migration {
-        version: 3,
+        version: 4,
         name: "rebuild_activity",
         destructive: true,
         up: rebuild_activity_v2,
     });
     let db = Db::open(&p, Profile::Hub, &migs, "test-destructive").unwrap();
-    assert_eq!(db.version().unwrap(), 3);
+    assert_eq!(db.version().unwrap(), 4);
 
     // New column exists post-migration.
     let has_priority: i64 = db

--- a/rust-core/crates/friday-storage/tests/workflow_persist.rs
+++ b/rust-core/crates/friday-storage/tests/workflow_persist.rs
@@ -35,8 +35,12 @@ fn forward_migration_v1_to_v2_adds_workflow_tables_preserving_data() {
         )
         .unwrap();
     }
-    // Reopen with the full set -> forward-migrate to v2.
-    let db = Db::open_hub(&p).unwrap();
+    // Reopen with the v2 set -> forward-migrate v1 -> v2 in isolation (truncating
+    // to 2 keeps this test pinned to the workflow migration, independent of later
+    // migrations such as 0003).
+    let mut migs2 = hub_migrations();
+    migs2.truncate(2);
+    let db = Db::open(&p, Profile::Hub, &migs2, "v2").unwrap();
     assert_eq!(db.version().unwrap(), 2);
     let tables = db.table_names().unwrap();
     assert!(tables.iter().any(|t| t == "workflow_run"));


### PR DESCRIPTION
## Summary
Hub-only **memory_item lifecycle persistence** for the all-Rust Friday Core, composing the Unit-10 *core* trust logic already on main (PR #457). Advances Unit-10 **persistence**; the Memory Review **UI** (settings/cron/morning card, `07` §7) remains deferred. Overall Friday v1 stays **NO-GO**.

## What's in this slice
- **schema `0003` — additive, backfilling forward migration (v2→v3).** Adds the lifecycle `state` column. SQLite `ADD COLUMN ... DEFAULT 'candidate'` sets every existing row to the default, so the migration **backfills in the same transaction** — an already-confirmed memory is never silently demoted. The migration is a *second writer* of `(state, confidence)`, so it upholds the same consistency the repo guarantees: a confirmed row gets `confidence='confirmed'`; a non-confirmed row never keeps a `'confirmed'`/NULL confidence. **Post-migration invariant:** `confidence='confirmed'` ⟺ `state='confirmed'` ⟺ `confirmed_at IS NOT NULL`, and `confidence` is never NULL — **no divergent pair can survive**.
- **`friday-storage::memory` repo.** A single authoritative lifecycle column (`state`). `record_candidate` (never durable) / `decide` / `confirm` / `reject` compose `friday-core::decide_candidate`. `confidence` is written **consistent with `state` by the same single writer** — there is **no raw `confidence` setter** — so a contradictory `(confidence=confirmed, state=rejected)` row is **unrepresentable through the API**. A terminal (`Confirmed`/`Rejected`) item is refused re-decision (no silent re-write / no downgrade); only a `Candidate` is awaiting the user. `row_from` reads the nullable `confidence` **fail-closed** (NULL → `Candidate`).
- **Memory Review schedule (data layer).** `pending_review()` = candidates awaiting decision, oldest first (stable by `memory_id`); `auto_usable()` returns only `Confirmed` (durable) memories.
- **`friday-core`:** `as_str()` for `MemoryScope`/`Confidence`/`MemoryState` + `MemoryState::is_terminal()`.
- **Test updates (no weakening).** `migration.rs` tracks the real v3 bump (version/code 2→3; destructive test stacked at v4); the Unit-9 `workflow_persist` v1→v2 test is pinned via `truncate(2)` so it stays isolated to the workflow migration.

## Trust boundary
`memory_item` is **Hub-only** — migration `0003` is registered only in `hub_migrations()`; phone profile never creates it (asserted directly + via `schema_profile`).

## Review
Adversarial **5-lens** review (migration-safety, trust-invariants, hub-only/secret-safety, test-weakening/overclaim, coverage) → **3 PASS / 2 CONCERNS**. The one real finding — the migration backfilled `state` but not `confidence`, a divergent-pair hole in the slice's own "unrepresentable" claim (reproducible only on hand-malformed legacy data; unreachable in greenfield) — is **closed in this PR** (migration normalizes `confidence` + nullable-read fail-closed), with discriminating tests. Added fail-closed-parser, duplicate-insert, and tie-break coverage.

## Tests / gates
- `cargo fmt --all -- --check`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo test --workspace`: **129 passed, 0 failed, 2 ignored** (the 2 ignored are the live DeepSeek-route + provider-auth smokes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)