### PR TITLE
Native iOS simulator shell rendering the all-Rust core via UniFFI (Unit 5b)

### DIFF
--- a/apps/friday-ios/.gitignore
+++ b/apps/friday-ios/.gitignore
@@ -1,0 +1,3 @@
+# Local build artifacts (staticlib, generated bindings, .app bundle, screenshots).
+.build/
+*.png

--- a/apps/friday-ios/Info.plist
+++ b/apps/friday-ios/Info.plist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleExecutable</key>
+    <string>FridayShell</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.friday.shell</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>FridayShell</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.0.1</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSRequiresIPhoneOS</key>
+    <true/>
+    <key>MinimumOSVersion</key>
+    <string>17.0</string>
+    <key>UIDeviceFamily</key>
+    <array>
+        <integer>1</integer>
+    </array>
+    <key>UILaunchScreen</key>
+    <dict/>
+    <key>CFBundleSupportedPlatforms</key>
+    <array>
+        <string>iPhoneSimulator</string>
+    </array>
+    <key>DTPlatformName</key>
+    <string>iphonesimulator</string>
+</dict>
+</plist>

--- a/apps/friday-ios/README.md
+++ b/apps/friday-ios/README.md
@@ -1,0 +1,42 @@
+# Friday — native iOS shell (Unit 5b, simulator)
+
+A minimal SwiftUI app that renders values computed by the **all-Rust core**
+(`friday-ffi`) through the generated **UniFFI Swift bindings**. It is the
+first native iOS proof that the Swift ↔ Rust bridge runs on-device(sim):
+connection-state projection + protocol schema version/negotiation, all from Rust.
+
+This is **simulator-level** proof only. Physical-device proof and App Store
+release remain operator-gated. Overall Friday v1 is **NO-GO**.
+
+## Build + screenshot (simulator)
+
+```sh
+apps/friday-ios/build-sim.sh   # -> .build/friday-ios-sim.png
+```
+
+The script: cross-compiles the `aarch64-apple-ios-sim` staticlib, generates the
+Swift bindings, compiles `Sources/FridayApp.swift` + the bindings with `swiftc`
+against the simulator SDK (linking `libfriday_ffi.a`), assembles `FridayShell.app`,
+then installs/launches/screenshots it on a booted simulator.
+
+### Toolchain note (important)
+iOS cross-compile needs the **rustup stable** toolchain (it has the iOS std),
+but a Homebrew `rust` 1.95.0 can shadow it on `PATH`. The script puts the
+toolchain's own bin dir first:
+
+```sh
+PATH="$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH" cargo build ...
+```
+
+`rust-toolchain.toml` (pinned 1.95.0) is intentionally left untouched so CI stays
+reproducible; only the local iOS build overrides the toolchain via `PATH`.
+
+## Trust boundary
+`friday-ffi` is the phone-side library; its dependency graph **excludes**
+`friday-deepseek` and `friday-providers` (Hub-only, provider-secret-bearing), so
+"no provider secret on the phone" is a compile-time property asserted by
+`friday-arch-tests`. This app links only `friday-ffi`.
+
+## Not built in CI
+The simulator build needs Xcode + the iOS toolchain, so `build-sim.sh` is a local
+proof, not a CI step. CI builds/tests the Rust workspace (host) as usual.

--- a/apps/friday-ios/Sources/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayApp.swift
@@ -1,0 +1,57 @@
+// Friday — Unit 5b native iOS shell (simulator proof).
+//
+// A minimal SwiftUI app whose entire content is computed by the ALL-RUST core
+// through the generated UniFFI Swift bindings (friday_ffi). It shows the
+// connection-state projection and the protocol schema version/negotiation —
+// proving the Swift <-> Rust bridge runs on the iOS simulator. No model call,
+// no provider secret on the phone (friday-ffi excludes the Hub-only crates).
+
+import SwiftUI
+
+struct ContentView: View {
+    // Every value below comes from the Rust core via UniFFI — not hardcoded in Swift.
+    private let state = initialConnectionState()
+    private let schemaVersion = protocolSchemaVersion()
+    // 1..3 vs 2..5 -> highest common = 3 (never silently downgrades).
+    private let negotiated = negotiateSchemaVersion(
+        localMin: 1, localMax: 3, remoteMin: 2, remoteMax: 5)
+
+    var body: some View {
+        VStack(spacing: 14) {
+            Text("Friday")
+                .font(.largeTitle).bold()
+            Text("All-Rust core via UniFFI")
+                .font(.subheadline).foregroundStyle(.secondary)
+
+            Divider()
+
+            row("connection", String(describing: state))
+            row("online?", connectionIsOnline(state: state) ? "yes" : "no")
+            row("stale/offline?", connectionIsStaleOrOffline(state: state) ? "yes" : "no")
+            row("schema version", "\(schemaVersion)")
+            row("negotiated (1–3 vs 2–5)", negotiated.map { "\($0)" } ?? "incompatible")
+
+            Divider()
+            Text("rendered from Rust ✓")
+                .font(.footnote).foregroundStyle(.green)
+        }
+        .padding(28)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(white: 0.98))
+    }
+
+    private func row(_ label: String, _ value: String) -> some View {
+        HStack {
+            Text(label).foregroundStyle(.secondary)
+            Spacer()
+            Text(value).bold().monospaced()
+        }
+    }
+}
+
+@main
+struct FridayApp: App {
+    var body: some Scene {
+        WindowGroup { ContentView() }
+    }
+}

--- a/apps/friday-ios/build-sim.sh
+++ b/apps/friday-ios/build-sim.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Unit 5b — build the Friday native iOS shell for the SIMULATOR, install it, and
+# screenshot it. Proves the SwiftUI app renders values computed by the all-Rust
+# core via the generated UniFFI Swift bindings.
+#
+# Toolchain reconciliation (see goal file 33): the stable rustup toolchain has the
+# iOS std but brew rust 1.95.0 shadows it, so we put the toolchain's own bin dir
+# FIRST on PATH (rust-toolchain.toml is left untouched for CI reproducibility).
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+RUSTCORE="$(cd "$HERE/../../rust-core" && pwd)"
+TC="$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin"
+BUILD="$HERE/.build"
+APP="$BUILD/FridayShell.app"
+SIM_TARGET="aarch64-apple-ios-sim"
+SHOT="${1:-$BUILD/friday-ios-sim.png}"
+
+rm -rf "$BUILD"; mkdir -p "$BUILD" "$BUILD/headers"
+
+echo "== 1. build sim staticlib =="
+( cd "$RUSTCORE" && PATH="$TC:$PATH" cargo build -p friday-ffi --target "$SIM_TARGET" )
+LIBDIR="$RUSTCORE/target/$SIM_TARGET/debug"
+
+echo "== 2. generate Swift bindings =="
+( cd "$RUSTCORE" && PATH="$TC:$PATH" cargo run -q -p friday-ffi --bin uniffi-bindgen -- \
+    generate --library "$LIBDIR/libfriday_ffi.dylib" --language swift --out-dir "$BUILD/bindings" )
+
+echo "== 3. assemble module headers =="
+cp "$BUILD/bindings/friday_ffiFFI.h" "$BUILD/headers/"
+# clang discovers a module via a file named `module.modulemap` on the -I path.
+cp "$BUILD/bindings/friday_ffiFFI.modulemap" "$BUILD/headers/module.modulemap"
+
+echo "== 4. compile SwiftUI app for the simulator =="
+# Apple-Silicon host only (arm64 sim slice). The Rust core is linked as the
+# STATIC archive by full path (cargo also emits a .dylib used only for bindgen;
+# `-l` would prefer that .dylib, so we pass the .a explicitly) — the resulting
+# executable is self-contained, with no dependency on a build-tree dylib path.
+SDK="$(xcrun --sdk iphonesimulator --show-sdk-path)"
+mkdir -p "$APP"
+xcrun --sdk iphonesimulator swiftc \
+    -target arm64-apple-ios17.0-simulator \
+    -sdk "$SDK" \
+    -I "$BUILD/headers" \
+    -lc++ -framework Security -framework SystemConfiguration \
+    "$HERE/Sources/FridayApp.swift" "$BUILD/bindings/friday_ffi.swift" \
+    -Xlinker "$LIBDIR/libfriday_ffi.a" \
+    -o "$APP/FridayShell"
+cp "$HERE/Info.plist" "$APP/Info.plist"
+
+echo "== 5. pick a simulator =="
+UDID="$(xcrun simctl list devices available | grep -Eo '\(([0-9A-F-]{36})\) \(Booted\)' | grep -Eo '[0-9A-F-]{36}' | head -1 || true)"
+if [ -z "$UDID" ]; then
+  UDID="$(xcrun simctl list devices available | grep -E 'iPhone' | grep -Eo '[0-9A-F-]{36}' | head -1)"
+  echo "booting $UDID"; xcrun simctl boot "$UDID" || true
+fi
+echo "using simulator $UDID"
+open -a Simulator || true
+
+echo "== 6. install + launch + screenshot =="
+xcrun simctl install "$UDID" "$APP"
+xcrun simctl launch "$UDID" com.friday.shell
+sleep 4
+xcrun simctl io "$UDID" screenshot "$SHOT"
+echo "screenshot: $SHOT"

--- a/rust-core/crates/friday-ffi/Cargo.toml
+++ b/rust-core/crates/friday-ffi/Cargo.toml
@@ -7,13 +7,16 @@ license.workspace = true
 publish = false
 rust-version.workspace = true
 
-# Phone-side library. Its dependency graph deliberately EXCLUDES friday-deepseek
-# and friday-hub so "no provider secret on phone" is a compile-time property
-# (gate 21 §1/§3). Asserted by friday-arch-tests. (uniffi/protocol are phone-safe.)
+# Phone-side library. Its dependency graph deliberately EXCLUDES the Hub-only,
+# provider-secret-bearing crates friday-deepseek and friday-providers, so "no
+# provider secret on phone" is a compile-time property (gate 21 §1/§3). Asserted
+# by friday-arch-tests. (uniffi/protocol are phone-safe.)
 [lib]
 # `lib` keeps it usable by the workspace + unit tests; `cdylib` is what UniFFI
-# library-mode bindgen reads to generate Swift/Kotlin.
-crate-type = ["lib", "cdylib"]
+# library-mode bindgen reads to generate Swift/Kotlin; `staticlib` (.a) is the
+# archive the native app links (directly in apps/friday-ios for the simulator
+# build; packaged into an XCFramework for the device build — Unit 5b).
+crate-type = ["lib", "cdylib", "staticlib"]
 
 [dependencies]
 friday-core.workspace = true


### PR DESCRIPTION
## Summary
First **native iOS proof** that the Swift ↔ Rust bridge runs on the simulator: a minimal SwiftUI app whose entire content is **computed by the all-Rust core** (`friday-ffi`) through the generated UniFFI Swift bindings. **Simulator-level only** — physical-device proof and App Store release remain operator-gated. Overall Friday v1 stays **NO-GO**.

![simulator screenshot proof — rendered from Rust](https://github.com/thesongzhu/Friday/pull/new)

(Screenshot captured locally: `disconnected / no / yes / 1 / 3 / rendered from Rust ✓` — see evidence below.)

## What's in this slice
- **`friday-ffi`: add `staticlib` crate-type** (`.a`) alongside `lib`/`cdylib`. Manifest-only — host workspace build/clippy/test unchanged (**134 passed / 0 / 4**).
- **`apps/friday-ios`**: a SwiftUI app (`Sources/FridayApp.swift`) that renders, **entirely from Rust** (nothing hardcoded in Swift):
  - connection state `disconnected` (`initialConnectionState()`), `online? no` (`connectionIsOnline`), `stale/offline? yes` (`connectionIsStaleOrOffline`) — truth-labeled per `05` §10;
  - `schema version 1` (`protocolSchemaVersion()`);
  - `negotiated (1–3 vs 2–5) = 3` (`negotiateSchemaVersion`) — the **computed highest-common version**, not a constant.
  - `Info.plist`, `README.md`, `.gitignore`, and a reproducible **`build-sim.sh`**.
- **Static linking (review fix).** The Rust core is linked as the **static archive** (`.a` passed by full path; the `.dylib` cargo also emits is used only for `uniffi-bindgen`). Verified with `otool`: the `FridayShell` binary has **no `libfriday_ffi.dylib` dependency** → self-contained, not reliant on a build-tree path.
- **Toolchain reconciliation** (goal file 33): the iOS build puts the rustup **stable** toolchain bin first on `PATH` (brew rust 1.95.0 lacks the iOS std and shadows it otherwise); `rust-toolchain.toml` (pinned 1.95.0) is **left untouched** so CI stays reproducible.

## Trust boundary (verified on the phone targets, not just host)
`friday-ffi`'s dependency closure **excludes** `friday-deepseek` and `friday-providers` (Hub-only, provider-secret-bearing) on `aarch64-apple-ios` **and** `aarch64-apple-ios-sim`, not only the host — closing the target-gated-dependency blind spot. Asserted by `friday-arch-tests`. The app links only `friday-ffi` and makes no network/secret/permission calls.

## Not built in CI
`build-sim.sh` needs Xcode + the iOS toolchain, so it is a **local** proof, not a CI step (`apps/` is not a Cargo workspace member; no workflow references it). CI builds/tests the Rust workspace (host) as usual.

## Review
Adversarial **5-lens** review (bridge-authenticity, trust-boundary, host/CI-safety, build-reproducibility, swift-correctness): **trust-boundary / host-CI / swift-correctness PASS**; bridge authenticity confirmed genuine (values computed in Rust at runtime, `otool` confirms the linked core). The **one real finding** — the first cut linked the `.dylib`, making `+staticlib` inert and the "links the `.a`" claim false — is **fixed in this PR** (static archive linked; `otool`-verified) with the docs corrected.

## Evidence
`/tmp/friday-rust-mobile-rewrite-20260601-evidence/ios-shell/` — `friday-ios-sim.png` (screenshot), `ios-sim-crosscompile-20260602.txt`, generated `swift-bindings/`.

## Gates
Physical iOS device proof, release/publish, force-push, GitHub settings/secrets remain **operator-gated**. The simulator screenshot is **not** physical-device proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)