### PR TITLE
Native Android emulator shell rendering the all-Rust core via UniFFI (Unit 5c)

### DIFF
--- a/apps/friday-android/.gitignore
+++ b/apps/friday-android/.gitignore
@@ -1,0 +1,11 @@
+# Build artifacts + generated/cross-compiled inputs.
+.gradle/
+.build/
+build/
+local.properties
+*.png
+# Generated UniFFI bindings + cross-compiled .so + staged JNA resource are
+# produced by build-emu.sh.
+app/src/main/kotlin/uniffi/
+app/src/main/jniLibs/
+app/src/main/resources/

--- a/apps/friday-android/README.md
+++ b/apps/friday-android/README.md
@@ -1,0 +1,45 @@
+# Friday — native Android shell (Unit 5c, emulator)
+
+A minimal Activity that renders values computed by the **all-Rust core**
+(`friday-ffi`) through the generated **UniFFI Kotlin** bindings — the Android
+mirror of `apps/friday-ios`. It proves the Kotlin ↔ Rust bridge runs on the
+Android emulator: connection-state projection + protocol schema
+version/negotiation, all from Rust.
+
+**Emulator-level** proof only. Physical-device proof and Play Store release
+remain operator-gated. Overall Friday v1 is **NO-GO**.
+
+## Build + screenshot (emulator)
+
+```sh
+apps/friday-android/build-emu.sh   # -> .build/friday-android-emu.png
+```
+
+The script: cross-compiles `libfriday_ffi.so` for `aarch64-linux-android` via the
+NDK clang, generates the Kotlin bindings, stages them + the `.so`, assembles the
+debug APK (Gradle + AGP), then `adb install` / `am start` / `screencap` on the
+running emulator.
+
+## Toolchain notes (important)
+- **Rust cross-compile** uses the rustup **stable** toolchain (it has the Android
+  std), with the NDK clang as the C compiler/linker for the bundled SQLite. brew
+  rust 1.95.0 lacks the std and shadows it, so the script puts the stable
+  toolchain bin first on `PATH` (same fix as iOS, goal file 33).
+- **AGP 9** has built-in Kotlin — no separate Kotlin Gradle plugin is applied.
+- **JNA on Android**: use `net.java.dev.jna:jna:5.18.1@aar`. Older 5.14 tried to
+  load `libjnidispatch.so` from a classpath *resource* (`com/sun/jna/
+  android-aarch64/...`), which AGP won't package (`.so` are jniLibs), throwing
+  `UnsatisfiedLinkError ... not found in resource path`. 5.16+ loads it on Android
+  via `System.loadLibrary` from the bundled jniLib. The app sets
+  `jna.library.path` to the native-lib dir (+ `useLegacyPackaging=true`) so
+  `libfriday_ffi.so` is found on disk.
+
+## Trust boundary
+`friday-ffi` excludes the Hub-only, provider-secret-bearing crates
+(`friday-deepseek`, `friday-providers`) on the Android targets too, so "no
+provider secret on the phone" is a compile-time property (`friday-arch-tests`).
+
+## Not built in CI
+The emulator build needs the Android SDK/NDK + a running emulator, so
+`build-emu.sh` is a local proof, not a CI step. CI builds/tests the Rust
+workspace (host) as usual.

--- a/apps/friday-android/app/build.gradle.kts
+++ b/apps/friday-android/app/build.gradle.kts
@@ -1,0 +1,48 @@
+plugins {
+    // AGP 9 compiles Kotlin via built-in support; no separate Kotlin plugin.
+    id("com.android.application")
+}
+
+android {
+    namespace = "com.friday.shell"
+    compileSdk = 36
+
+    defaultConfig {
+        applicationId = "com.friday.shell"
+        minSdk = 24
+        targetSdk = 36
+        versionCode = 1
+        versionName = "0.0.1"
+    }
+
+    buildTypes {
+        getByName("debug") {
+            isMinifyEnabled = false
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    // Extract the bundled .so files to the on-disk nativeLibraryDir (modern AGP
+    // defaults to false, leaving them inside the APK). JNA loads its jnidispatch
+    // from a real file via jna.boot.library.path, so it must exist on disk.
+    packaging {
+        jniLibs {
+            useLegacyPackaging = true
+        }
+    }
+    // The generated UniFFI Kotlin bindings (src/main/kotlin/uniffi/...) and the
+    // cross-compiled .so (src/main/jniLibs/<abi>/) are placed by build-emu.sh —
+    // both AGP default source locations, both gitignored build artifacts.
+}
+
+dependencies {
+    // UniFFI's generated Kotlin uses JNA. The @aar ships the Android
+    // libjnidispatch.so as a jniLib; JNA 5.16+ loads it on Android via
+    // System.loadLibrary (older 5.14 insisted on a classpath resource that AGP
+    // refuses to package, throwing "not found in resource path").
+    implementation("net.java.dev.jna:jna:5.18.1@aar")
+}

--- a/apps/friday-android/app/src/main/AndroidManifest.xml
+++ b/apps/friday-android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application
+        android:label="FridayShell"
+        android:allowBackup="false">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/apps/friday-android/app/src/main/kotlin/com/friday/shell/MainActivity.kt
+++ b/apps/friday-android/app/src/main/kotlin/com/friday/shell/MainActivity.kt
@@ -1,0 +1,63 @@
+// Friday — Unit 5c native Android shell (emulator proof).
+//
+// A minimal Activity whose entire screen is computed by the ALL-RUST core through
+// the generated UniFFI Kotlin bindings (uniffi.friday_ffi). It mirrors the iOS
+// shell: connection-state projection + protocol schema version/negotiation,
+// proving the Kotlin <-> Rust bridge runs on the Android emulator. No model call,
+// no provider secret on the phone (friday-ffi excludes the Hub-only crates).
+
+package com.friday.shell
+
+import android.app.Activity
+import android.os.Bundle
+import android.widget.TextView
+import uniffi.friday_ffi.connectionIsOnline
+import uniffi.friday_ffi.connectionIsStaleOrOffline
+import uniffi.friday_ffi.initialConnectionState
+import uniffi.friday_ffi.negotiateSchemaVersion
+import uniffi.friday_ffi.protocolSchemaVersion
+
+class MainActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // JNA on Android loads its own jnidispatch from a CLASSPATH RESOURCE
+        // (com/sun/jna/android-aarch64/libjnidispatch.so — staged by build-emu.sh).
+        // Our Rust lib (libfriday_ffi.so) is a jniLib, extracted on disk via
+        // useLegacyPackaging; point JNA's library search at that dir to find it.
+        System.setProperty("jna.library.path", applicationInfo.nativeLibraryDir)
+
+        // Every value below comes from the Rust core via UniFFI — not hardcoded.
+        val state = initialConnectionState()
+        val online = connectionIsOnline(state)
+        val stale = connectionIsStaleOrOffline(state)
+        val schemaVersion = protocolSchemaVersion()
+        // 1..3 vs 2..5 -> highest common = 3 (never silently downgrades).
+        val negotiated = negotiateSchemaVersion(
+            1.toUShort(), 3.toUShort(), 2.toUShort(), 5.toUShort()
+        )
+
+        // (The app identity "FridayShell" is shown in the action bar; the body is
+        // exactly the values the all-Rust core computes, so the rendered screen
+        // matches this source line-for-line.)
+        val body = buildString {
+            appendLine("connection:   ${state.name.lowercase()}")
+            appendLine("online?       ${if (online) "yes" else "no"}")
+            appendLine("stale/offline? ${if (stale) "yes" else "no"}")
+            appendLine("schema ver:   $schemaVersion")
+            appendLine("negotiated:   ${negotiated?.toString() ?: "incompatible"}")
+            appendLine()
+            append("rendered from Rust ✓")
+        }
+
+        val tv = TextView(this).apply {
+            text = body
+            textSize = 20f
+            // API 36 enforces edge-to-edge, so the content view draws behind the
+            // status + action bars; pad the top enough to clear them so every
+            // value is visible (this is a minimal proof shell, not production UI).
+            setPadding(56, 320, 56, 56)
+        }
+        setContentView(tv)
+    }
+}

--- a/apps/friday-android/build-emu.sh
+++ b/apps/friday-android/build-emu.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Unit 5c — build the Friday native Android shell, install it on the running
+# emulator, and screenshot it. Proves the Activity renders values computed by the
+# all-Rust core via the generated UniFFI Kotlin bindings.
+#
+# Toolchain (see goal files 33/34): the iOS-style "stable rustup bin first on PATH"
+# fix (brew rust 1.95.0 lacks the mobile std and shadows it), plus the Android NDK
+# clang as the C cross-compiler / linker for the bundled-SQLite build.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+RUSTCORE="$(cd "$HERE/../../rust-core" && pwd)"
+SDK="${ANDROID_HOME:-$HOME/Library/Android/sdk}"
+NDK="$SDK/ndk/30.0.14904198"
+PB="$NDK/toolchains/llvm/prebuilt/darwin-x86_64/bin"
+TC="$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin"
+RUST_TARGET="aarch64-linux-android"   # emulator on Apple Silicon is arm64-v8a
+ABI="arm64-v8a"
+API=24
+SHOT="${1:-$HERE/.build/friday-android-emu.png}"
+
+mkdir -p "$HERE/.build"
+echo "sdk.dir=$SDK" > "$HERE/local.properties"
+
+echo "== 1. cross-compile the .so via the NDK clang =="
+( cd "$RUSTCORE" && env \
+    "CC_${RUST_TARGET}=$PB/${RUST_TARGET}${API}-clang" \
+    "CXX_${RUST_TARGET}=$PB/${RUST_TARGET}${API}-clang++" \
+    "AR_${RUST_TARGET}=$PB/llvm-ar" \
+    "CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=$PB/${RUST_TARGET}${API}-clang" \
+    "PATH=$TC:$PATH" \
+    cargo build -p friday-ffi --target "$RUST_TARGET" )
+SO="$RUSTCORE/target/$RUST_TARGET/debug/libfriday_ffi.so"
+
+echo "== 2. generate Kotlin bindings =="
+( cd "$RUSTCORE" && PATH="$TC:$PATH" cargo run -q -p friday-ffi --bin uniffi-bindgen -- \
+    generate --library "$SO" --language kotlin --out-dir "$HERE/.build/bindings" )
+
+echo "== 3. stage bindings + .so into the app =="
+rm -rf "$HERE/app/src/main/kotlin/uniffi" "$HERE/app/src/main/jniLibs" "$HERE/app/src/main/resources"
+mkdir -p "$HERE/app/src/main/kotlin" "$HERE/app/src/main/jniLibs/$ABI"
+cp -R "$HERE/.build/bindings/uniffi" "$HERE/app/src/main/kotlin/"
+cp "$SO" "$HERE/app/src/main/jniLibs/$ABI/libfriday_ffi.so"
+
+echo "== 4. assemble the debug APK =="
+( cd "$HERE" && ANDROID_HOME="$SDK" gradle :app:assembleDebug --no-daemon )
+APK="$HERE/app/build/outputs/apk/debug/app-debug.apk"
+
+echo "== 5. install + launch + screenshot on the running emulator =="
+ADB="$SDK/platform-tools/adb"
+"$ADB" install -r "$APK"
+"$ADB" shell am start -n com.friday.shell/.MainActivity
+sleep 4
+"$ADB" exec-out screencap -p > "$SHOT"
+echo "screenshot: $SHOT"

--- a/apps/friday-android/build.gradle.kts
+++ b/apps/friday-android/build.gradle.kts
@@ -1,0 +1,6 @@
+// Root build script. AGP 9.2.1 pairs with the installed Gradle 9.5.1 and
+// compileSdk 36. AGP 9 has BUILT-IN Kotlin support, so no separate Kotlin
+// plugin is applied (see apps/friday-android/README.md).
+plugins {
+    id("com.android.application") version "9.2.1" apply false
+}

--- a/apps/friday-android/gradle.properties
+++ b/apps/friday-android/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
+android.useAndroidX=true
+kotlin.code.style=official

--- a/apps/friday-android/settings.gradle.kts
+++ b/apps/friday-android/settings.gradle.kts
@@ -1,0 +1,15 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+rootProject.name = "friday-android"
+include(":app")


### PR DESCRIPTION
## Summary
The Android mirror of the iOS shell (#462): a minimal Activity whose content is **computed entirely by the all-Rust core** (`friday-ffi`) through the generated **UniFFI Kotlin** bindings, proven on the Pixel_8 emulator. **No Rust changes** (`friday-ffi` already emits the `cdylib`) — this slice is `apps/friday-android/` only. **Emulator-level** proof; physical-device + Play Store release remain operator-gated. Overall Friday v1 stays **NO-GO**.

## Verified live (screenshot)
On the Pixel_8 emulator (`arm64-v8a`, API 36), `FridayShell` renders — all from Rust, none hardcoded in Kotlin:
`connection: disconnected · online? no · stale/offline? yes · schema ver: 1 · negotiated: 3 · rendered from Rust ✓`
`negotiated = 3` is the **computed** highest-common version of `1–3` vs `2–5` (`negotiateSchemaVersion`), matching iOS exactly. Evidence: `/tmp/friday-rust-mobile-rewrite-20260601-evidence/android-shell/`.

## What's in this slice
- **`apps/friday-android`**: plain Activity (no Compose, to avoid the Compose/Kotlin version matrix), `Info`/manifest, and a reproducible **`build-emu.sh`** that cross-compiles → generates bindings → assembles the APK → installs/launches/screenshots.
- **Cross-compile**: `libfriday_ffi.so` for `aarch64-linux-android` via the **NDK clang** (incl. rusqlite **bundled SQLite**), using the stable-rustup-bin-first PATH (brew rust 1.95.0 lacks the Android std and shadows it; `rust-toolchain.toml` untouched for CI).
- **Build system**: Gradle 9.5.1 + **AGP 9.2.1** (built-in Kotlin — no separate Kotlin plugin), `compileSdk 36`. API 36 enforces **edge-to-edge**, so the content pads the top to clear the system bars (every value visible → the screenshot matches the source line-for-line).
- **JNA-on-Android fix**: `net.java.dev.jna:jna:5.18.1@aar`. Older 5.14 loaded `libjnidispatch.so` from a classpath *resource* (`com/sun/jna/android-aarch64/...`) that AGP won't package (`.so` are jniLibs) → `UnsatisfiedLinkError ... not found in resource path`. 5.16+ loads it via `System.loadLibrary` from the bundled jniLib; the app sets `jna.library.path` (+ `useLegacyPackaging=true`) for `libfriday_ffi.so`.

## Trust boundary (verified on the Android target)
`cargo tree -p friday-ffi --target aarch64-linux-android` excludes `friday-deepseek` + `friday-providers` (no provider secret on the phone; `friday-arch-tests`). The app declares **no permissions** (no `INTERNET`) and reaches no network/secret surface.

## Review
Adversarial 4-lens review (bridge-authenticity, trust-boundary, build-reproducibility/host-CI, Kotlin-correctness): **trust-boundary / host-CI / Kotlin-correctness PASS**; the one CONCERN — the captured screenshot didn't depict the committed Activity (edge-to-edge occluded the top lines) — is **fixed in this PR** (top padding clears the bars; screenshot regenerated to match source).

## Tests / gates
- Host workspace unaffected (no `rust-core` diff vs main): `cargo fmt`/`clippy -D warnings` clean, `cargo test --workspace` green; `apps/` is not a Cargo workspace member and no CI workflow references it.
- No build artifacts committed (`.so`/generated bindings/APK/`.build`/`jniLibs`/`*.png` all gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)