### PR TITLE
Render the Needs-Me Activity inbox from Rust in both native shells (Unit 8/9 UI)

### DIFF
--- a/apps/friday-android/app/src/main/kotlin/com/friday/shell/MainActivity.kt
+++ b/apps/friday-android/app/src/main/kotlin/com/friday/shell/MainActivity.kt
@@ -16,15 +16,16 @@ import uniffi.friday_ffi.connectionIsStaleOrOffline
 import uniffi.friday_ffi.initialConnectionState
 import uniffi.friday_ffi.negotiateSchemaVersion
 import uniffi.friday_ffi.protocolSchemaVersion
+import uniffi.friday_ffi.sampleActivityInbox
 
 class MainActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // JNA on Android loads its own jnidispatch from a CLASSPATH RESOURCE
-        // (com/sun/jna/android-aarch64/libjnidispatch.so — staged by build-emu.sh).
-        // Our Rust lib (libfriday_ffi.so) is a jniLib, extracted on disk via
-        // useLegacyPackaging; point JNA's library search at that dir to find it.
+        // JNA (5.18.1@aar) loads its jnidispatch on Android via System.loadLibrary
+        // from the bundled jniLib. Our Rust lib (libfriday_ffi.so) is also a jniLib,
+        // extracted on disk via useLegacyPackaging; point JNA's library search at
+        // that dir so it is found.
         System.setProperty("jna.library.path", applicationInfo.nativeLibraryDir)
 
         // Every value below comes from the Rust core via UniFFI — not hardcoded.
@@ -36,6 +37,8 @@ class MainActivity : Activity() {
         val negotiated = negotiateSchemaVersion(
             1.toUShort(), 3.toUShort(), 2.toUShort(), 5.toUShort()
         )
+        // Urgency-first Needs-Me inbox, built + sorted by Rust (08 §1/§2).
+        val inbox = sampleActivityInbox()
 
         // (The app identity "FridayShell" is shown in the action bar; the body is
         // exactly the values the all-Rust core computes, so the rendered screen
@@ -46,6 +49,12 @@ class MainActivity : Activity() {
             appendLine("stale/offline? ${if (stale) "yes" else "no"}")
             appendLine("schema ver:   $schemaVersion")
             appendLine("negotiated:   ${negotiated?.toString() ?: "incompatible"}")
+            appendLine()
+            appendLine("Needs Me (${inbox.size}, sample):")
+            for (item in inbox) {
+                appendLine("  p${item.priority} [${item.source}] ${item.reason}")
+                appendLine("      → ${item.destination}")
+            }
             appendLine()
             append("rendered from Rust ✓")
         }

--- a/apps/friday-ios/Sources/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayApp.swift
@@ -1,10 +1,11 @@
-// Friday — Unit 5b native iOS shell (simulator proof).
+// Friday — native iOS shell (simulator proof).
 //
 // A minimal SwiftUI app whose entire content is computed by the ALL-RUST core
-// through the generated UniFFI Swift bindings (friday_ffi). It shows the
-// connection-state projection and the protocol schema version/negotiation —
-// proving the Swift <-> Rust bridge runs on the iOS simulator. No model call,
-// no provider secret on the phone (friday-ffi excludes the Hub-only crates).
+// through the generated UniFFI Swift bindings (friday_ffi): the connection-state
+// projection, the protocol schema version/negotiation, and the urgency-first
+// "Needs Me" Activity inbox — proving the Swift <-> Rust bridge runs on the iOS
+// simulator. No model call, no provider secret on the phone (friday-ffi excludes
+// the Hub-only crates).
 
 import SwiftUI
 
@@ -15,28 +16,44 @@ struct ContentView: View {
     // 1..3 vs 2..5 -> highest common = 3 (never silently downgrades).
     private let negotiated = negotiateSchemaVersion(
         localMin: 1, localMax: 3, remoteMin: 2, remoteMax: 5)
+    // Urgency-first Needs-Me inbox, built + sorted by Rust (08 §1/§2).
+    private let inbox = sampleActivityInbox()
 
     var body: some View {
-        VStack(spacing: 14) {
-            Text("Friday")
-                .font(.largeTitle).bold()
-            Text("All-Rust core via UniFFI")
-                .font(.subheadline).foregroundStyle(.secondary)
+        ScrollView {
+            VStack(spacing: 14) {
+                Text("Friday")
+                    .font(.largeTitle).bold()
+                Text("All-Rust core via UniFFI")
+                    .font(.subheadline).foregroundStyle(.secondary)
 
-            Divider()
+                Divider()
 
-            row("connection", String(describing: state))
-            row("online?", connectionIsOnline(state: state) ? "yes" : "no")
-            row("stale/offline?", connectionIsStaleOrOffline(state: state) ? "yes" : "no")
-            row("schema version", "\(schemaVersion)")
-            row("negotiated (1–3 vs 2–5)", negotiated.map { "\($0)" } ?? "incompatible")
+                row("connection", String(describing: state))
+                row("online?", connectionIsOnline(state: state) ? "yes" : "no")
+                row("stale/offline?", connectionIsStaleOrOffline(state: state) ? "yes" : "no")
+                row("schema version", "\(schemaVersion)")
+                row("negotiated (1–3 vs 2–5)", negotiated.map { "\($0)" } ?? "incompatible")
 
-            Divider()
-            Text("rendered from Rust ✓")
-                .font(.footnote).foregroundStyle(.green)
+                Divider()
+
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack {
+                        Text("Needs Me").font(.headline)
+                        Spacer()
+                        Text("\(inbox.count)").foregroundStyle(.secondary)
+                    }
+                    Text("sample — live Activity store pending")
+                        .font(.caption2).foregroundStyle(.secondary)
+                }
+                ForEach(inbox, id: \.id) { needsMeRow($0) }
+
+                Divider()
+                Text("rendered from Rust ✓")
+                    .font(.footnote).foregroundStyle(.green)
+            }
+            .padding(28)
         }
-        .padding(28)
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color(white: 0.98))
     }
 
@@ -45,6 +62,22 @@ struct ContentView: View {
             Text(label).foregroundStyle(.secondary)
             Spacer()
             Text(value).bold().monospaced()
+        }
+    }
+
+    // One Needs-Me item: source tag, reason + destination, urgency. Detail is
+    // carried, never dropped (08 §2).
+    private func needsMeRow(_ item: NeedsMeItemFfi) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            Text(item.source.uppercased())
+                .font(.caption2).bold().foregroundStyle(.secondary)
+                .frame(width: 72, alignment: .leading)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(item.reason)
+                Text(item.destination).font(.caption2).foregroundStyle(.secondary)
+            }
+            Spacer()
+            Text("p\(item.priority)").font(.caption).monospaced()
         }
     }
 }

--- a/rust-core/crates/friday-ffi/src/lib.rs
+++ b/rust-core/crates/friday-ffi/src/lib.rs
@@ -13,7 +13,7 @@
 //! depend on `friday-deepseek` or a Hub crate, so "no provider secret on phone"
 //! is a compile-time property (gate `21` §1/§3), asserted by `friday-arch-tests`.
 
-use friday_core::ConnState;
+use friday_core::{ConnState, NeedsMeItem};
 
 uniffi::setup_scaffolding!();
 
@@ -97,6 +97,90 @@ pub fn negotiate_schema_version(
     .ok()
 }
 
+/// A cross-source "Needs Me" action item for the Activity inbox (`08` §1/§2),
+/// projected for native UI. Carries the provider detail (reason/destination) so
+/// nothing is silently dropped.
+#[derive(Debug, Clone, PartialEq, Eq, uniffi::Record)]
+pub struct NeedsMeItemFfi {
+    pub source: String,
+    pub id: String,
+    pub reason: String,
+    /// Higher = more urgent.
+    pub priority: u8,
+    pub destination: String,
+}
+
+impl From<NeedsMeItem> for NeedsMeItemFfi {
+    fn from(i: NeedsMeItem) -> Self {
+        NeedsMeItemFfi {
+            source: i.source,
+            id: i.id,
+            reason: i.reason,
+            priority: i.priority,
+            destination: i.destination,
+        }
+    }
+}
+
+impl From<NeedsMeItemFfi> for NeedsMeItem {
+    fn from(i: NeedsMeItemFfi) -> Self {
+        NeedsMeItem {
+            source: i.source,
+            id: i.id,
+            reason: i.reason,
+            priority: i.priority,
+            destination: i.destination,
+        }
+    }
+}
+
+/// Aggregate Needs-Me items urgency-first (highest priority first, stable within
+/// equal priority), via the `friday-core` logic. Exposed to native UI (`08` §1).
+#[uniffi::export]
+pub fn aggregate_needs_me(items: Vec<NeedsMeItemFfi>) -> Vec<NeedsMeItemFfi> {
+    friday_core::aggregate_needs_me(items.into_iter().map(Into::into).collect())
+        .into_iter()
+        .map(Into::into)
+        .collect()
+}
+
+/// A representative Needs-Me inbox, built and aggregated in Rust — a UI fixture
+/// so the native shells can render the prioritized Activity list before the
+/// persisted Activity store (Unit 9) is wired to the phone. NOT live data.
+#[uniffi::export]
+pub fn sample_activity_inbox() -> Vec<NeedsMeItemFfi> {
+    aggregate_needs_me(vec![
+        NeedsMeItemFfi {
+            source: "claude".into(),
+            id: "c1".into(),
+            reason: "Question: which API key to use?".into(),
+            priority: 9,
+            destination: "session/claude-1".into(),
+        },
+        NeedsMeItemFfi {
+            source: "codex".into(),
+            id: "x1".into(),
+            reason: "Approve: run DB migration".into(),
+            priority: 7,
+            destination: "session/codex-1".into(),
+        },
+        NeedsMeItemFfi {
+            source: "workflow".into(),
+            id: "w1".into(),
+            reason: "Checkpoint: confirm deploy".into(),
+            priority: 7,
+            destination: "wf/deploy".into(),
+        },
+        NeedsMeItemFfi {
+            source: "memory".into(),
+            id: "m1".into(),
+            reason: "Review: 2 new memory candidates".into(),
+            priority: 3,
+            destination: "memory/review".into(),
+        },
+    ])
+}
+
 // --- internal (non-FFI) helpers retained for the phone-side runtime/tests ---
 
 /// Open a phone-profile database. The phone schema omits the Hub-only
@@ -139,5 +223,51 @@ mod tests {
         assert_eq!(protocol_schema_version(), 1);
         assert_eq!(negotiate_schema_version(1, 3, 2, 5), Some(3));
         assert_eq!(negotiate_schema_version(1, 1, 2, 4), None);
+    }
+
+    #[test]
+    fn ffi_needs_me_aggregation_is_urgency_first_and_stable() {
+        let item = |src: &str, id: &str, p: u8| NeedsMeItemFfi {
+            source: src.into(),
+            id: id.into(),
+            reason: String::new(),
+            priority: p,
+            destination: String::new(),
+        };
+        let sorted = aggregate_needs_me(vec![
+            item("a", "1", 5),
+            item("b", "2", 9),
+            item("c", "3", 5),
+        ]);
+        assert_eq!(sorted[0].id, "2"); // priority 9 first
+                                       // equal priority (5) keeps arrival order: 1 before 3
+        assert_eq!(sorted[1].id, "1");
+        assert_eq!(sorted[2].id, "3");
+    }
+
+    #[test]
+    fn ffi_needs_me_item_round_trips_losslessly() {
+        let ffi = NeedsMeItemFfi {
+            source: "claude".into(),
+            id: "c1".into(),
+            reason: "a question".into(),
+            priority: 7,
+            destination: "session/x".into(),
+        };
+        let core: NeedsMeItem = ffi.clone().into();
+        let back: NeedsMeItemFfi = core.into();
+        assert_eq!(ffi, back); // every field survives both conversions
+    }
+
+    #[test]
+    fn ffi_sample_inbox_is_nonempty_and_urgency_ordered() {
+        let inbox = sample_activity_inbox();
+        assert!(!inbox.is_empty());
+        for w in inbox.windows(2) {
+            assert!(w[0].priority >= w[1].priority, "must be urgency-first");
+        }
+        assert_eq!(inbox[0].source, "claude"); // highest priority (9)
+                                               // detail is carried, never dropped.
+        assert!(!inbox[0].reason.is_empty() && !inbox[0].destination.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
Turns the iOS + Android shells from static projections into a real **Activity inbox** computed by the all-Rust core: an urgency-first "Needs Me" list. The ordering (incl. the stable tie-break) is computed in `friday-core`, not the UI. **Simulator/emulator-level**; the persisted Activity store + interactive actions are **deferred** (the inbox data is a clearly-labeled Rust fixture). Physical-device + release remain operator-gated. Overall Friday v1 stays **NO-GO**.

## What's in this slice
- **`friday-ffi`** — exposes the Needs-Me surface (pure logic, no DB): `NeedsMeItemFfi` (`uniffi::Record`, carries `source/id/reason/priority/destination` so detail is never dropped, `08` §2); `aggregate_needs_me(Vec)->Vec` composing `friday_core::aggregate_needs_me` (urgency-first, **stable** within equal priority); and `sample_activity_inbox()` — a Rust-built+sorted **fixture**, labeled NOT live data both in code and **on-screen**. **+3 FFI tests** (urgency + stable tie-break, sample ordering, lossless `From` round-trip).
- **iOS** (`FridayApp.swift`) + **Android** (`MainActivity.kt`) — render the inbox as a prioritized **"Needs Me (N, sample)"** list. Both show, urgency-ordered by Rust:
  `p9 [claude] which API key? → session/claude-1` · `p7 [codex] run DB migration → session/codex-1` · `p7 [workflow] confirm deploy → wf/deploy` · `p3 [memory] 2 memory candidates → memory/review`
  (codex before workflow at equal p7 = the stable tie-break). Verified live on the iOS simulator + Pixel_8 emulator — screenshots match source line-for-line.
- Fixed a stale JNA comment in `MainActivity` (now describes 5.18.1 / `System.loadLibrary`).

## Review
Adversarial **4-lens** review (FFI-correctness/no-overclaim, both-UIs-render-Rust, host-CI/trust-boundary, correctness/hygiene): **all PASS, zero confirmed findings**. The on-screen "sample" honesty label + Android `destination` parity + the round-trip test address the review NITs.

## Tests / gates
- `cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean.
- `cargo test --workspace` = **137 passed / 0 failed / 4 ignored**.
- Trust boundary unchanged (`cargo tree -p friday-ffi` excludes `friday-deepseek`/`friday-providers`; `friday-arch-tests` pass). No new dependency. `apps/` not in CI; no build artifacts committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)