### PR TITLE
Render the Memory Review from Rust in both native shells (Unit 10 UI)

### DIFF
--- a/apps/friday-android/app/src/main/kotlin/com/friday/shell/MainActivity.kt
+++ b/apps/friday-android/app/src/main/kotlin/com/friday/shell/MainActivity.kt
@@ -17,6 +17,7 @@ import uniffi.friday_ffi.initialConnectionState
 import uniffi.friday_ffi.negotiateSchemaVersion
 import uniffi.friday_ffi.protocolSchemaVersion
 import uniffi.friday_ffi.sampleActivityInbox
+import uniffi.friday_ffi.sampleMemoryReview
 
 class MainActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -39,6 +40,8 @@ class MainActivity : Activity() {
         )
         // Urgency-first Needs-Me inbox, built + sorted by Rust (08 §1/§2).
         val inbox = sampleActivityInbox()
+        // Memory candidates awaiting the user's review (07 §6/§7).
+        val memReview = sampleMemoryReview()
 
         // (The app identity "FridayShell" is shown in the action bar; the body is
         // exactly the values the all-Rust core computes, so the rendered screen
@@ -54,6 +57,12 @@ class MainActivity : Activity() {
             for (item in inbox) {
                 appendLine("  p${item.priority} [${item.source}] ${item.reason}")
                 appendLine("      → ${item.destination}")
+            }
+            appendLine()
+            appendLine("Memory Review (${memReview.size}, sample):")
+            appendLine("  awaiting confirm/reject — never auto-saved")
+            for (m in memReview) {
+                appendLine("  [${m.scope}] ${m.preview} (${m.confidence})")
             }
             appendLine()
             append("rendered from Rust ✓")

--- a/apps/friday-android/app/src/main/kotlin/com/friday/shell/MainActivity.kt
+++ b/apps/friday-android/app/src/main/kotlin/com/friday/shell/MainActivity.kt
@@ -62,7 +62,10 @@ class MainActivity : Activity() {
             appendLine("Memory Review (${memReview.size}, sample):")
             appendLine("  awaiting confirm/reject — never auto-saved")
             for (m in memReview) {
-                appendLine("  [${m.scope}] ${m.preview} (${m.confidence})")
+                // Show confidence AND lifecycle state (parity with iOS); state is
+                // the field the no-silent-write story turns on (07 §6/§7).
+                appendLine("  [${m.scope}] ${m.preview}")
+                appendLine("      ${m.confidence} · ${m.state.name.lowercase()}")
             }
             appendLine()
             append("rendered from Rust ✓")

--- a/apps/friday-ios/Sources/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayApp.swift
@@ -18,6 +18,8 @@ struct ContentView: View {
         localMin: 1, localMax: 3, remoteMin: 2, remoteMax: 5)
     // Urgency-first Needs-Me inbox, built + sorted by Rust (08 §1/§2).
     private let inbox = sampleActivityInbox()
+    // Memory candidates awaiting the user's review (07 §6/§7).
+    private let memReview = sampleMemoryReview()
 
     var body: some View {
         ScrollView {
@@ -49,6 +51,19 @@ struct ContentView: View {
                 ForEach(inbox, id: \.id) { needsMeRow($0) }
 
                 Divider()
+
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack {
+                        Text("Memory Review").font(.headline)
+                        Spacer()
+                        Text("\(memReview.count)").foregroundStyle(.secondary)
+                    }
+                    Text("sample — awaiting confirm/reject, never auto-saved")
+                        .font(.caption2).foregroundStyle(.secondary)
+                }
+                ForEach(memReview, id: \.memoryId) { memoryRow($0) }
+
+                Divider()
                 Text("rendered from Rust ✓")
                     .font(.footnote).foregroundStyle(.green)
             }
@@ -78,6 +93,22 @@ struct ContentView: View {
             }
             Spacer()
             Text("p\(item.priority)").font(.caption).monospaced()
+        }
+    }
+
+    // One memory candidate: scope tag, preview, and its confidence + lifecycle
+    // state. A candidate is never auto-confirmed (07 §6/§7).
+    private func memoryRow(_ m: MemoryCandidateFfi) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            Text(m.scope.uppercased())
+                .font(.caption2).bold().foregroundStyle(.secondary)
+                .frame(width: 72, alignment: .leading)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(m.preview)
+                Text("\(m.confidence) · \(String(describing: m.state).lowercased())")
+                    .font(.caption2).foregroundStyle(.secondary)
+            }
+            Spacer()
         }
     }
 }

--- a/rust-core/crates/friday-ffi/src/lib.rs
+++ b/rust-core/crates/friday-ffi/src/lib.rs
@@ -13,7 +13,7 @@
 //! depend on `friday-deepseek` or a Hub crate, so "no provider secret on phone"
 //! is a compile-time property (gate `21` §1/§3), asserted by `friday-arch-tests`.
 
-use friday_core::{ConnState, NeedsMeItem};
+use friday_core::{ConnState, MemoryState, NeedsMeItem};
 
 uniffi::setup_scaffolding!();
 
@@ -181,6 +181,83 @@ pub fn sample_activity_inbox() -> Vec<NeedsMeItemFfi> {
     ])
 }
 
+/// Lifecycle of a long-term memory item, projected for UI (`07` §6/§7).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
+pub enum MemoryStateFfi {
+    Candidate,
+    Confirmed,
+    Rejected,
+}
+
+impl From<MemoryState> for MemoryStateFfi {
+    fn from(s: MemoryState) -> Self {
+        match s {
+            MemoryState::Candidate => MemoryStateFfi::Candidate,
+            MemoryState::Confirmed => MemoryStateFfi::Confirmed,
+            MemoryState::Rejected => MemoryStateFfi::Rejected,
+        }
+    }
+}
+
+impl MemoryStateFfi {
+    fn to_core(self) -> MemoryState {
+        match self {
+            MemoryStateFfi::Candidate => MemoryState::Candidate,
+            MemoryStateFfi::Confirmed => MemoryState::Confirmed,
+            MemoryStateFfi::Rejected => MemoryState::Rejected,
+        }
+    }
+}
+
+/// A memory candidate awaiting the user's review (`07` §7), projected for UI.
+#[derive(Debug, Clone, PartialEq, Eq, uniffi::Record)]
+pub struct MemoryCandidateFfi {
+    pub memory_id: String,
+    pub scope: String,
+    /// A short human-readable preview of the candidate content.
+    pub preview: String,
+    pub confidence: String,
+    pub state: MemoryStateFfi,
+}
+
+/// Apply the user's review decision to a memory candidate, via the `friday-core`
+/// invariant: a candidate becomes `Confirmed` ONLY on an explicit yes; an explicit
+/// no rejects it; **no decision leaves it a candidate (never silently written)**
+/// (`07` §6/§7). Exposed so the native Memory Review UI surfaces the real logic.
+#[uniffi::export]
+pub fn decide_candidate(state: MemoryStateFfi, user_confirmed: Option<bool>) -> MemoryStateFfi {
+    friday_core::decide_candidate(state.to_core(), user_confirmed).into()
+}
+
+/// A representative Memory Review queue — pending candidates awaiting an explicit
+/// confirm/reject. A Rust-built UI fixture (the persisted phone memory store is
+/// deferred); every item is a `Candidate` (nothing is auto-confirmed). NOT live data.
+#[uniffi::export]
+pub fn sample_memory_review() -> Vec<MemoryCandidateFfi> {
+    let candidate = |id: &str, scope: &str, preview: &str, confidence: &str| MemoryCandidateFfi {
+        memory_id: id.into(),
+        scope: scope.into(),
+        preview: preview.into(),
+        confidence: confidence.into(),
+        state: MemoryStateFfi::Candidate,
+    };
+    vec![
+        candidate("mc1", "global", "Prefers Rust for new services", "inferred"),
+        candidate(
+            "mc2",
+            "project",
+            "Deploy target is the Pixel_8 emulator",
+            "candidate",
+        ),
+        candidate(
+            "mc3",
+            "session",
+            "Working on the Friday mobile rewrite",
+            "high_confidence_context",
+        ),
+    ]
+}
+
 // --- internal (non-FFI) helpers retained for the phone-side runtime/tests ---
 
 /// Open a phone-profile database. The phone schema omits the Hub-only
@@ -243,6 +320,40 @@ mod tests {
                                        // equal priority (5) keeps arrival order: 1 before 3
         assert_eq!(sorted[1].id, "1");
         assert_eq!(sorted[2].id, "3");
+    }
+
+    #[test]
+    fn ffi_memory_decision_never_silently_writes() {
+        // No decision -> stays a Candidate (NOT written).
+        assert_eq!(
+            decide_candidate(MemoryStateFfi::Candidate, None),
+            MemoryStateFfi::Candidate
+        );
+        // Explicit yes -> Confirmed; explicit no -> Rejected.
+        assert_eq!(
+            decide_candidate(MemoryStateFfi::Candidate, Some(true)),
+            MemoryStateFfi::Confirmed
+        );
+        assert_eq!(
+            decide_candidate(MemoryStateFfi::Candidate, Some(false)),
+            MemoryStateFfi::Rejected
+        );
+        // A terminal decision is not re-opened by a later (even contrary) signal.
+        assert_eq!(
+            decide_candidate(MemoryStateFfi::Confirmed, Some(false)),
+            MemoryStateFfi::Confirmed
+        );
+    }
+
+    #[test]
+    fn ffi_sample_memory_review_is_all_pending_candidates() {
+        let review = sample_memory_review();
+        assert!(!review.is_empty());
+        // Nothing is auto-confirmed: every item awaits the user's decision.
+        assert!(review.iter().all(|m| m.state == MemoryStateFfi::Candidate));
+        assert!(review
+            .iter()
+            .all(|m| !m.preview.is_empty() && !m.memory_id.is_empty()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Mirrors the Activity-inbox slice (#464) for the **trust-critical memory-review flow**: nothing is written to long-term memory without an **explicit** user decision (`07` §6/§7). Both shells render a "Memory Review (N, sample)" section. **Simulator/emulator-level**; the persisted phone memory store + interactive confirm/reject buttons are **deferred** (the candidates are a labeled Rust fixture). Physical-device + release remain operator-gated. Overall Friday v1 stays **NO-GO**.

## What's in this slice
- **`friday-ffi`** — exposes the memory-review surface (pure logic, no DB): `MemoryStateFfi` (`uniffi::Enum`), `MemoryCandidateFfi` (`uniffi::Record`: `memory_id/scope/preview/confidence/state`), and `decide_candidate(state, Option<bool>)` composing `friday_core::decide_candidate` — **no decision leaves a candidate a `Candidate`** (never silently written), `Some(true)→Confirmed`, `Some(false)→Rejected`, terminal states unchanged. `sample_memory_review()` is a Rust-built **fixture** of 3 pending `Candidate`s (labeled NOT live data). **+2 tests** (the no-silent-write invariant; the sample is all-`Candidate`).
- **iOS** (`FridayApp.swift`) + **Android** (`MainActivity.kt`) — render a "Memory Review (N, sample)" section with the on-screen honesty label **"awaiting confirm/reject — never auto-saved"** and each candidate's scope/preview/confidence/state. Verified live on the iOS simulator + Pixel_8 emulator — screenshots match source.

## Tests / gates
- `cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean.
- `cargo test --workspace` = **139 passed / 0 failed / 4 ignored**.
- Trust boundary unchanged (`friday-ffi` excludes `friday-deepseek`/`friday-providers`; `friday-arch-tests` pass). No new dependency. `apps/` not in CI; no build artifacts committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)