### PR TITLE
Interactive write path: mark an activity done, persisted to phone SQLite (both shells)

### DIFF
--- a/apps/friday-android/app/src/main/kotlin/com/friday/shell/MainActivity.kt
+++ b/apps/friday-android/app/src/main/kotlin/com/friday/shell/MainActivity.kt
@@ -1,19 +1,23 @@
-// Friday — Unit 5c native Android shell (emulator proof).
+// Friday — native Android shell (emulator proof).
 //
-// A minimal Activity whose entire screen is computed by the ALL-RUST core through
-// the generated UniFFI Kotlin bindings (uniffi.friday_ffi). It mirrors the iOS
-// shell: connection-state projection + protocol schema version/negotiation,
-// proving the Kotlin <-> Rust bridge runs on the Android emulator. No model call,
-// no provider secret on the phone (friday-ffi excludes the Hub-only crates).
+// A minimal Activity whose screen is computed by the ALL-RUST core through the
+// generated UniFFI Kotlin bindings (uniffi.friday_ffi): connection/protocol
+// state, the sample Needs-Me + Memory-Review surfaces, and a LIVE activity list
+// read from the phone's own SQLite store — plus a real WRITE path ("mark done")
+// that persists to that store. No model call, no provider secret on the phone.
 
 package com.friday.shell
 
 import android.app.Activity
 import android.os.Bundle
+import android.widget.Button
+import android.widget.LinearLayout
+import android.widget.ScrollView
 import android.widget.TextView
 import uniffi.friday_ffi.connectionIsOnline
 import uniffi.friday_ffi.connectionIsStaleOrOffline
 import uniffi.friday_ffi.initialConnectionState
+import uniffi.friday_ffi.markActivityDone
 import uniffi.friday_ffi.negotiateSchemaVersion
 import uniffi.friday_ffi.phoneActivityDemo
 import uniffi.friday_ffi.protocolSchemaVersion
@@ -21,35 +25,64 @@ import uniffi.friday_ffi.sampleActivityInbox
 import uniffi.friday_ffi.sampleMemoryReview
 
 class MainActivity : Activity() {
+    private val dbPath by lazy { java.io.File(filesDir, "friday.db").absolutePath }
+    private var note: String = ""
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // JNA (5.18.1@aar) loads its jnidispatch on Android via System.loadLibrary
-        // from the bundled jniLib. Our Rust lib (libfriday_ffi.so) is also a jniLib,
-        // extracted on disk via useLegacyPackaging; point JNA's library search at
-        // that dir so it is found.
+        // JNA (5.18.1@aar) loads jnidispatch on Android via System.loadLibrary from
+        // the bundled jniLib; point JNA's library search at the native-lib dir.
         System.setProperty("jna.library.path", applicationInfo.nativeLibraryDir)
 
-        // Every value below comes from the Rust core via UniFFI — not hardcoded.
+        val tv = TextView(this).apply { textSize = 15f }
+
+        // Real WRITE path control: mark the oldest pending activity done, persist,
+        // and refresh from the store.
+        val markBtn = Button(this).apply {
+            text = "Mark oldest pending → done"
+            setOnClickListener {
+                markOldestPendingDone()
+                tv.text = render()
+            }
+        }
+
+        // On launch, perform ONE real persisted write so the screen shows a live
+        // state change through SQLite (the same write path the button uses).
+        markOldestPendingDone()
+        tv.text = render()
+
+        val column = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            // API 36 edge-to-edge: pad the top to clear the status/action bars.
+            setPadding(56, 300, 56, 56)
+            addView(markBtn)
+            addView(tv)
+        }
+        setContentView(ScrollView(this).apply { addView(column) })
+    }
+
+    /** Find the oldest still-pending activity and mark it done (a real SQLite write). */
+    private fun markOldestPendingDone() {
+        val cur = phoneActivityDemo(dbPath)
+        if (!cur.ok) return
+        val pending = cur.items.firstOrNull { it.state == "pending" } ?: return
+        val after = markActivityDone(dbPath, pending.activityId, 200L)
+        if (after.ok) note = "✓ marked “${pending.summary}” done (persisted)"
+    }
+
+    /** Build the screen text, reading the LIVE activity list fresh from the store. */
+    private fun render(): String {
         val state = initialConnectionState()
         val online = connectionIsOnline(state)
         val stale = connectionIsStaleOrOffline(state)
         val schemaVersion = protocolSchemaVersion()
-        // 1..3 vs 2..5 -> highest common = 3 (never silently downgrades).
-        val negotiated = negotiateSchemaVersion(
-            1.toUShort(), 3.toUShort(), 2.toUShort(), 5.toUShort()
-        )
-        // Urgency-first Needs-Me inbox, built + sorted by Rust (08 §1/§2).
+        val negotiated = negotiateSchemaVersion(1.toUShort(), 3.toUShort(), 2.toUShort(), 5.toUShort())
         val inbox = sampleActivityInbox()
-        // Memory candidates awaiting the user's review (07 §6/§7).
         val memReview = sampleMemoryReview()
-        // LIVE data: read back from the phone's own SQLite store (not a fixture).
-        val phoneActivity = phoneActivityDemo(java.io.File(filesDir, "friday.db").absolutePath)
+        val phoneActivity = phoneActivityDemo(dbPath)
 
-        // (The app identity "FridayShell" is shown in the action bar; the body is
-        // exactly the values the all-Rust core computes, so the rendered screen
-        // matches this source line-for-line.)
-        val body = buildString {
+        return buildString {
             appendLine("connection:   ${state.name.lowercase()}")
             appendLine("online?       ${if (online) "yes" else "no"}")
             appendLine("stale/offline? ${if (stale) "yes" else "no"}")
@@ -59,16 +92,12 @@ class MainActivity : Activity() {
             appendLine("Needs Me (${inbox.size}, sample):")
             for (item in inbox) {
                 appendLine("  p${item.priority} [${item.source}] ${item.reason}")
-                appendLine("      → ${item.destination}")
             }
             appendLine()
             appendLine("Memory Review (${memReview.size}, sample):")
             appendLine("  awaiting confirm/reject — never auto-saved")
             for (m in memReview) {
-                // Show confidence AND lifecycle state (parity with iOS); state is
-                // the field the no-silent-write story turns on (07 §6/§7).
-                appendLine("  [${m.scope}] ${m.preview}")
-                appendLine("      ${m.confidence} · ${m.state.name.lowercase()}")
+                appendLine("  [${m.scope}] ${m.preview} (${m.confidence} · ${m.state.name.lowercase()})")
             }
             appendLine()
             if (phoneActivity.ok) {
@@ -76,21 +105,12 @@ class MainActivity : Activity() {
                 for (a in phoneActivity.items) {
                     appendLine("  [${a.state}] ${a.summary} (${a.kind})")
                 }
+                if (note.isNotEmpty()) appendLine("  $note")
             } else {
                 appendLine("Activity (live store error): ${phoneActivity.error}")
             }
             appendLine()
             append("rendered from Rust ✓")
         }
-
-        val tv = TextView(this).apply {
-            text = body
-            textSize = 15f
-            // API 36 enforces edge-to-edge, so the content view draws behind the
-            // status + action bars; pad the top enough to clear them so every
-            // value is visible (this is a minimal proof shell, not production UI).
-            setPadding(56, 320, 56, 56)
-        }
-        setContentView(tv)
     }
 }

--- a/apps/friday-ios/Sources/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayApp.swift
@@ -20,11 +20,14 @@ struct ContentView: View {
     private let inbox = sampleActivityInbox()
     // Memory candidates awaiting the user's review (07 §6/§7).
     private let memReview = sampleMemoryReview()
-    // LIVE data: read back from the phone's own SQLite store (not a fixture).
-    private let phoneActivity: PhoneActivityFfi = {
-        let dir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
-        return phoneActivityDemo(dbPath: dir.appendingPathComponent("friday.db").path)
-    }()
+
+    // The phone's own SQLite file (the app sandbox). LIVE data + a real WRITE path.
+    private let dbPath: String = FileManager.default
+        .urls(for: .documentDirectory, in: .userDomainMask)[0]
+        .appendingPathComponent("friday.db").path
+    @State private var activity: [ActivityItemFfi] = []
+    @State private var activityError: String = ""
+    @State private var note: String = ""
 
     var body: some View {
         ScrollView {
@@ -74,17 +77,18 @@ struct ContentView: View {
                     HStack {
                         Text("Activity").font(.headline)
                         Spacer()
-                        Text(phoneActivity.ok ? "\(phoneActivity.items.count)" : "—")
-                            .foregroundStyle(.secondary)
+                        Text("\(activity.count)").foregroundStyle(.secondary)
                     }
-                    Text("live · phone SQLite store")
+                    Text("live · phone SQLite · tap a row to mark done")
                         .font(.caption2).foregroundStyle(.secondary)
+                    if !note.isEmpty {
+                        Text(note).font(.caption2).foregroundStyle(.green)
+                    }
+                    if !activityError.isEmpty {
+                        Text(activityError).font(.caption2).foregroundStyle(.red)
+                    }
                 }
-                if phoneActivity.ok {
-                    ForEach(phoneActivity.items, id: \.activityId) { activityRow($0) }
-                } else {
-                    Text(phoneActivity.error).font(.caption).foregroundStyle(.red)
-                }
+                ForEach(activity, id: \.activityId) { activityRow($0) }
 
                 Divider()
                 Text("rendered from Rust ✓")
@@ -93,6 +97,38 @@ struct ContentView: View {
             .padding(28)
         }
         .background(Color(white: 0.98))
+        .onAppear(perform: loadActivity)
+    }
+
+    // Load the phone store, then perform ONE real persisted write (mark the oldest
+    // pending item done) so the screen shows a live state change through SQLite.
+    // Every value comes from / goes to the real store — no UI-only mock state.
+    private func loadActivity() {
+        let loaded = phoneActivityDemo(dbPath: dbPath)
+        guard loaded.ok else {
+            activityError = loaded.error
+            return
+        }
+        if let pending = loaded.items.first(where: { $0.state == "pending" }) {
+            let after = markActivityDone(dbPath: dbPath, activityId: pending.activityId, now: 100)
+            if after.ok {
+                activity = after.items
+                note = "✓ marked “\(pending.summary)” done (persisted)"
+                return
+            }
+        }
+        activity = loaded.items
+    }
+
+    // Tapping an item marks it done via the real SQLite write path and refreshes.
+    private func markDone(_ a: ActivityItemFfi) {
+        let after = markActivityDone(dbPath: dbPath, activityId: a.activityId, now: 200)
+        if after.ok {
+            activity = after.items
+            note = "✓ marked “\(a.summary)” done (persisted)"
+        } else {
+            activityError = after.error
+        }
     }
 
     private func row(_ label: String, _ value: String) -> some View {
@@ -135,19 +171,27 @@ struct ContentView: View {
         }
     }
 
-    // One activity item read back from the phone's SQLite store: state tag,
-    // summary, and kind.
+    // One activity item from the phone's SQLite store. A non-done row is a tappable
+    // control that marks it done through the real write path; done rows are inert.
     private func activityRow(_ a: ActivityItemFfi) -> some View {
-        HStack(alignment: .top, spacing: 10) {
-            Text(a.state.uppercased())
-                .font(.caption2).bold().foregroundStyle(.secondary)
-                .frame(width: 72, alignment: .leading)
-            VStack(alignment: .leading, spacing: 2) {
-                Text(a.summary)
-                Text(a.kind).font(.caption2).foregroundStyle(.secondary)
+        let isDone = a.state == "done"
+        return Button(action: { if !isDone { markDone(a) } }) {
+            HStack(alignment: .top, spacing: 10) {
+                Text(a.state.uppercased())
+                    .font(.caption2).bold()
+                    .foregroundStyle(isDone ? Color.green : Color.secondary)
+                    .frame(width: 72, alignment: .leading)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(a.summary).foregroundStyle(.primary)
+                    Text(a.kind).font(.caption2).foregroundStyle(.secondary)
+                }
+                Spacer()
+                Image(systemName: isDone ? "checkmark.circle.fill" : "circle")
+                    .foregroundStyle(isDone ? .green : .secondary)
             }
-            Spacer()
         }
+        .buttonStyle(.plain)
+        .disabled(isDone)
     }
 }
 

--- a/rust-core/crates/friday-ffi/src/lib.rs
+++ b/rust-core/crates/friday-ffi/src/lib.rs
@@ -336,6 +336,10 @@ fn load_phone_activity(db_path: &str) -> friday_storage::Result<Vec<ActivityItem
             3,
         ))?;
     }
+    activity_items(&db)
+}
+
+fn activity_items(db: &friday_storage::Db) -> friday_storage::Result<Vec<ActivityItemFfi>> {
     Ok(db
         .list_activity()?
         .into_iter()
@@ -347,6 +351,35 @@ fn load_phone_activity(db_path: &str) -> friday_storage::Result<Vec<ActivityItem
             created_at: s.created_at,
         })
         .collect())
+}
+
+/// Interactive WRITE path: mark an activity item `Done` in the phone's own SQLite
+/// store and return the updated list. A real persisted state change (the UI's
+/// "mark done" action), not UI-only state. Unknown ids are a no-op (still `ok`).
+#[uniffi::export]
+pub fn mark_activity_done(db_path: String, activity_id: String, now: i64) -> PhoneActivityFfi {
+    match mark_and_list(&db_path, &activity_id, now) {
+        Ok(items) => PhoneActivityFfi {
+            ok: true,
+            error: String::new(),
+            items,
+        },
+        Err(e) => PhoneActivityFfi {
+            ok: false,
+            error: e.to_string(),
+            items: Vec::new(),
+        },
+    }
+}
+
+fn mark_and_list(
+    db_path: &str,
+    activity_id: &str,
+    now: i64,
+) -> friday_storage::Result<Vec<ActivityItemFfi>> {
+    let db = friday_storage::Db::open_phone(db_path)?;
+    db.mark_activity_done(activity_id, now)?;
+    activity_items(&db)
 }
 
 // --- internal (non-FFI) helpers retained for the phone-side runtime/tests ---
@@ -456,6 +489,47 @@ mod tests {
         assert!(r3.ok);
         assert_eq!(r3.items.len(), 4, "the extra row must survive a fresh open");
         assert!(r3.items.iter().any(|a| a.activity_id == "extra"));
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn ffi_mark_activity_done_persists_across_reopen() {
+        let path =
+            std::env::temp_dir().join(format!("friday-ffi-markdone-{}.db", std::process::id()));
+        let p = path.to_string_lossy().to_string();
+        let _ = std::fs::remove_file(&path);
+
+        // Seed (a3 = "Queued offline" is Pending).
+        let seeded = phone_activity_demo(p.clone());
+        assert!(seeded.ok);
+        let a3 = seeded.items.iter().find(|a| a.activity_id == "a3").unwrap();
+        assert_eq!(a3.state, "pending");
+
+        // The interactive write: mark a3 done. Returns the updated list.
+        let after = mark_activity_done(p.clone(), "a3".into(), 100);
+        assert!(after.ok);
+        assert_eq!(
+            after
+                .items
+                .iter()
+                .find(|a| a.activity_id == "a3")
+                .unwrap()
+                .state,
+            "done"
+        );
+
+        // Reopen via a FRESH read path: the state change persisted on disk.
+        let reopened = phone_activity_demo(p.clone());
+        assert_eq!(
+            reopened
+                .items
+                .iter()
+                .find(|a| a.activity_id == "a3")
+                .unwrap()
+                .state,
+            "done"
+        );
 
         let _ = std::fs::remove_file(&path);
     }

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -179,6 +179,16 @@ impl Db {
         Ok(out)
     }
 
+    /// Mark an activity item `Done` (a real persisted state write). Returns
+    /// `true` if a row was updated, `false` if the id is unknown.
+    pub fn mark_activity_done(&self, activity_id: &str, now: i64) -> Result<bool> {
+        let n = self.conn.execute(
+            "UPDATE activity_item SET state = ?1, updated_at = ?2 WHERE activity_id = ?3",
+            rusqlite::params![ActivityState::Done.as_str(), now, activity_id],
+        )?;
+        Ok(n > 0)
+    }
+
     // --- writers ------------------------------------------------------------
 
     pub fn insert_device(&self, d: &DeviceIdentity) -> Result<()> {

--- a/rust-core/crates/friday-storage/tests/activity_list.rs
+++ b/rust-core/crates/friday-storage/tests/activity_list.rs
@@ -34,3 +34,29 @@ fn list_activity_returns_summaries_oldest_first() {
     assert_eq!(list[0].summary, "summary-a");
     assert_eq!(list[1].activity_id, "b");
 }
+
+#[test]
+fn mark_activity_done_persists_and_reports_unknown() {
+    let p = temp_db_path("mark-done");
+    let row = |id: &str| ActivityRow {
+        activity_id: id.into(),
+        session_id: None,
+        kind: ActivityType::AskStatus,
+        state: ActivityState::Pending,
+        summary: "s".into(),
+        created_at: 1,
+        updated_at: 1,
+        deep_link: None,
+    };
+    {
+        let db = Db::open_phone(&p).unwrap();
+        db.insert_activity(&row("a")).unwrap();
+        assert!(db.mark_activity_done("a", 5).unwrap()); // updated
+        assert!(!db.mark_activity_done("ghost", 5).unwrap()); // unknown id -> false
+    }
+    // Reopen a fresh handle: the state change survived on disk.
+    let db = Db::open_phone(&p).unwrap();
+    let list = db.list_activity().unwrap();
+    assert_eq!(list.len(), 1);
+    assert_eq!(list[0].state, "done");
+}


### PR DESCRIPTION
## Summary
Turns the phone activity list from a read-only render into a real **write surface**: tapping/marking an activity done performs a genuine `UPDATE` on the phone's own SQLite store and the change **persists**. Not UI-only mock state. Simulator/emulator-level; physical-device + release remain operator-gated. Overall Friday v1 stays **NO-GO**.

## What's in this slice
- **`friday-storage`** — `Db::mark_activity_done(activity_id, now) -> bool` (real `UPDATE`; `false` for an unknown id) + a test: mark → **reopen a fresh `Db`** → state persisted as `done`.
- **`friday-ffi`** — `mark_activity_done(db_path, activity_id, now) -> PhoneActivityFfi` (`open_phone` → `UPDATE` → updated list) + `ffi_mark_activity_done_persists_across_reopen` (seed `a3`=pending → mark done → reopen via a fresh read → `a3=="done"` — proves on-disk persistence, not UI state).
- **iOS** — stateful `ContentView`; each non-done activity row is a tappable `Button` that marks it done via the real FFI; `onAppear` performs one persisted write so the screen shows a live transition.
- **Android** — a "Mark oldest pending → done" `Button` (real control) + the same on-launch persisted write; re-renders from the store.
- **Verified live**: the Android emulator screenshot shows `a3` "Queued offline: send report" (seeded **pending**) now **`[done]`** with "✓ marked … done (persisted)". iOS renders via the same FFI (4-section ScrollView; Activity below the fold, covered by the FFI round-trip test + the Android render).

## Honest boundary
`memory_item` is **Hub-only** (never on the phone), so a phone-local "confirm/reject persists" isn't possible without sync — memory confirm/reject persistence stays proven at the **host hub-store** layer (`friday-storage::memory` tests). This slice's on-device write is `activity_item` (phone profile).

## Tests / gates
- `cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean.
- `cargo test --workspace` = **143 passed / 0 failed / 4 ignored**.
- Trust boundary unchanged (`friday-ffi` excludes `friday-deepseek`/`friday-providers`; `friday-arch-tests` pass). No new dependency. No build artifacts committed.
- Review: focused self-review for this low-risk UI wiring (per operator guidance), without skipping the persistence proof, screenshots, no-provider-on-phone check, or regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)