### PR TITLE
Live token-usage / cost-transparency view from the phone ledger (02 §13)

### DIFF
--- a/apps/friday-android/app/src/main/kotlin/com/friday/shell/MainActivity.kt
+++ b/apps/friday-android/app/src/main/kotlin/com/friday/shell/MainActivity.kt
@@ -20,6 +20,7 @@ import uniffi.friday_ffi.initialConnectionState
 import uniffi.friday_ffi.markActivityDone
 import uniffi.friday_ffi.negotiateSchemaVersion
 import uniffi.friday_ffi.phoneActivityDemo
+import uniffi.friday_ffi.phoneTokenUsage
 import uniffi.friday_ffi.protocolSchemaVersion
 import uniffi.friday_ffi.sampleActivityInbox
 import uniffi.friday_ffi.sampleMemoryReview
@@ -35,7 +36,7 @@ class MainActivity : Activity() {
         // the bundled jniLib; point JNA's library search at the native-lib dir.
         System.setProperty("jna.library.path", applicationInfo.nativeLibraryDir)
 
-        val tv = TextView(this).apply { textSize = 15f }
+        val tv = TextView(this).apply { textSize = 13f }
 
         // Real WRITE path control: mark the oldest pending activity done, persist,
         // and refresh from the store.
@@ -108,6 +109,18 @@ class MainActivity : Activity() {
                 if (note.isNotEmpty()) appendLine("  $note")
             } else {
                 appendLine("Activity (live store error): ${phoneActivity.error}")
+            }
+            appendLine()
+            val tokens = phoneTokenUsage(dbPath)
+            if (tokens.ok) {
+                appendLine("Tokens / cost (${tokens.items.size}, live · phone ledger):")
+                for (t in tokens.items) {
+                    val cost = t.costEstimate?.let { "$%.4f".format(it) } ?: "—"
+                    val flag = if (t.fallback) "⚠ fallback" else "direct"
+                    appendLine("  ${t.provider}/${t.model}: ${t.totalTokens} tok · $cost · $flag")
+                }
+            } else {
+                appendLine("Tokens (live ledger error): ${tokens.error}")
             }
             appendLine()
             append("rendered from Rust ✓")

--- a/apps/friday-ios/Sources/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayApp.swift
@@ -25,6 +25,11 @@ struct ContentView: View {
     private let dbPath: String = FileManager.default
         .urls(for: .documentDirectory, in: .userDomainMask)[0]
         .appendingPathComponent("friday.db").path
+    // Token/cost usage read from the phone's own ledger (02 §13 cost transparency).
+    private let tokens: PhoneTokensFfi = {
+        let dir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        return phoneTokenUsage(dbPath: dir.appendingPathComponent("friday.db").path)
+    }()
     @State private var activity: [ActivityItemFfi] = []
     @State private var activityError: String = ""
     @State private var note: String = ""
@@ -89,6 +94,24 @@ struct ContentView: View {
                     }
                 }
                 ForEach(activity, id: \.activityId) { activityRow($0) }
+
+                Divider()
+
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack {
+                        Text("Tokens / cost").font(.headline)
+                        Spacer()
+                        Text(tokens.ok ? "\(tokens.items.count)" : "—")
+                            .foregroundStyle(.secondary)
+                    }
+                    Text("live · phone ledger · fallback always shown")
+                        .font(.caption2).foregroundStyle(.secondary)
+                }
+                if tokens.ok {
+                    ForEach(Array(tokens.items.enumerated()), id: \.offset) { _, t in tokenRow(t) }
+                } else {
+                    Text(tokens.error).font(.caption2).foregroundStyle(.red)
+                }
 
                 Divider()
                 Text("rendered from Rust ✓")
@@ -192,6 +215,22 @@ struct ContentView: View {
         }
         .buttonStyle(.plain)
         .disabled(isDone)
+    }
+
+    // One token/cost row: provider/model, total tokens, $cost, and the fallback
+    // flag (always surfaced — a fallback is never hidden, 02 §13).
+    private func tokenRow(_ t: TokenUsageFfi) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            Text(t.provider.uppercased())
+                .font(.caption2).bold().foregroundStyle(.secondary)
+                .frame(width: 72, alignment: .leading)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(t.model)
+                Text("\(t.totalTokens) tok · \(t.costEstimate.map { String(format: "$%.4f", $0) } ?? "—") · \(t.fallback ? "⚠ fallback" : "direct")")
+                    .font(.caption2).foregroundStyle(t.fallback ? .orange : .secondary)
+            }
+            Spacer()
+        }
     }
 }
 

--- a/rust-core/crates/friday-ffi/src/lib.rs
+++ b/rust-core/crates/friday-ffi/src/lib.rs
@@ -382,6 +382,82 @@ fn mark_and_list(
     activity_items(&db)
 }
 
+/// A token/cost usage row for the UI (`02` §13 cost transparency). `fallback` is
+/// always shown — a fallback is never hidden.
+#[derive(Debug, Clone, PartialEq, uniffi::Record)]
+pub struct TokenUsageFfi {
+    pub provider: String,
+    pub model: String,
+    pub total_tokens: i64,
+    pub cost_estimate: Option<f64>,
+    pub fallback: bool,
+}
+
+/// Result of reading the phone-side token/cost ledger (`ok=false` -> secret-safe error).
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct PhoneTokensFfi {
+    pub ok: bool,
+    pub error: String,
+    pub items: Vec<TokenUsageFfi>,
+}
+
+/// Read the phone's own `token_ledger` (seeding a couple of DeepSeek Friday-route
+/// rows on first run) for a cost/usage view. Real on-device SQLite; the
+/// `fallback` flag is surfaced for every row (`02` §13 — never hide a fallback).
+#[uniffi::export]
+pub fn phone_token_usage(db_path: String) -> PhoneTokensFfi {
+    match load_token_usage(&db_path) {
+        Ok(items) => PhoneTokensFfi {
+            ok: true,
+            error: String::new(),
+            items,
+        },
+        Err(e) => PhoneTokensFfi {
+            ok: false,
+            error: e.to_string(),
+            items: Vec::new(),
+        },
+    }
+}
+
+fn load_token_usage(db_path: &str) -> friday_storage::Result<Vec<TokenUsageFfi>> {
+    use friday_core::{LedgerEntry, ProviderKind};
+    use friday_storage::Db;
+
+    let db = Db::open_phone(db_path)?;
+    if db.count("token_ledger")? == 0 {
+        let seed = |id: &str, model: &str, p: i64, c: i64, cost: f64, t: i64| LedgerEntry {
+            ledger_id: id.to_string(),
+            session_id: "s1".to_string(),
+            activity_id: "a1".to_string(),
+            provider_kind: ProviderKind::DeepSeek,
+            model: model.to_string(),
+            base_url_host: "api.deepseek.com".to_string(),
+            prompt_tokens: p,
+            completion_tokens: c,
+            total_tokens: p + c,
+            cost_estimate: Some(cost),
+            // DeepSeek Friday route: fallback is always false (no hidden substitute).
+            fallback: false,
+            result_link: None,
+            created_at: t,
+        };
+        db.insert_token_ledger(&seed("l1", "deepseek-v4-flash", 1200, 800, 0.0021, 1))?;
+        db.insert_token_ledger(&seed("l2", "deepseek-v4-pro", 3000, 1500, 0.0185, 2))?;
+    }
+    Ok(db
+        .list_token_usage()?
+        .into_iter()
+        .map(|u| TokenUsageFfi {
+            provider: u.provider_kind,
+            model: u.model,
+            total_tokens: u.total_tokens,
+            cost_estimate: u.cost_estimate,
+            fallback: u.fallback,
+        })
+        .collect())
+}
+
 // --- internal (non-FFI) helpers retained for the phone-side runtime/tests ---
 
 /// Open a phone-profile database. The phone schema omits the Hub-only
@@ -530,6 +606,29 @@ mod tests {
                 .state,
             "done"
         );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn ffi_phone_token_usage_seeds_lists_and_surfaces_fallback() {
+        let path =
+            std::env::temp_dir().join(format!("friday-ffi-tokens-{}.db", std::process::id()));
+        let p = path.to_string_lossy().to_string();
+        let _ = std::fs::remove_file(&path);
+
+        let r = phone_token_usage(p.clone());
+        assert!(r.ok, "open/seed failed: {}", r.error);
+        assert_eq!(r.items.len(), 2);
+        assert_eq!(r.items[0].provider, "deepseek");
+        assert_eq!(r.items[0].total_tokens, 2000); // 1200 + 800
+        assert_eq!(r.items[0].cost_estimate, Some(0.0021));
+        // The fallback flag is surfaced for every row; Friday route => false.
+        assert!(r.items.iter().all(|u| !u.fallback));
+
+        // Reopen: persisted, no re-seed.
+        let r2 = phone_token_usage(p.clone());
+        assert_eq!(r2.items.len(), 2);
 
         let _ = std::fs::remove_file(&path);
     }

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -49,6 +49,18 @@ pub struct ActivityRow {
     pub deep_link: Option<String>,
 }
 
+/// A UI-facing token/cost summary (a read projection of `token_ledger`). The
+/// `fallback` flag is always surfaced — a fallback is never hidden (`02` §13).
+#[derive(Clone, Debug, PartialEq)]
+pub struct TokenUsageRow {
+    pub provider_kind: String,
+    pub model: String,
+    pub total_tokens: i64,
+    pub cost_estimate: Option<f64>,
+    pub fallback: bool,
+    pub created_at: i64,
+}
+
 /// A UI-facing activity summary (a read projection of `activity_item`).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ActivitySummary {
@@ -170,6 +182,30 @@ impl Db {
                 state: r.get(2)?,
                 summary: r.get(3)?,
                 created_at: r.get(4)?,
+            })
+        })?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
+
+    /// Token/cost usage rows (read projection of `token_ledger`), oldest-first.
+    /// Surfaces the `fallback` flag so a fallback is never hidden (`02` §13).
+    pub fn list_token_usage(&self) -> Result<Vec<TokenUsageRow>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT provider_kind, model, total_tokens, cost_estimate, fallback, created_at
+             FROM token_ledger ORDER BY created_at, ledger_id",
+        )?;
+        let rows = stmt.query_map([], |r| {
+            Ok(TokenUsageRow {
+                provider_kind: r.get(0)?,
+                model: r.get(1)?,
+                total_tokens: r.get(2)?,
+                cost_estimate: r.get(3)?,
+                fallback: r.get::<_, i64>(4)? != 0,
+                created_at: r.get(5)?,
             })
         })?;
         let mut out = Vec::new();

--- a/rust-core/crates/friday-storage/tests/token_usage.rs
+++ b/rust-core/crates/friday-storage/tests/token_usage.rs
@@ -1,0 +1,39 @@
+//! `Db::list_token_usage` read projection (used by the phone-side cost view).
+
+mod common;
+
+use common::temp_db_path;
+use friday_core::{LedgerEntry, ProviderKind};
+use friday_storage::Db;
+
+#[test]
+fn list_token_usage_projects_ledger_and_surfaces_fallback() {
+    let p = temp_db_path("token-usage");
+    let db = Db::open_phone(&p).unwrap();
+    assert!(db.list_token_usage().unwrap().is_empty());
+
+    let e = LedgerEntry {
+        ledger_id: "l1".into(),
+        session_id: "s1".into(),
+        activity_id: "a1".into(),
+        provider_kind: ProviderKind::DeepSeek,
+        model: "deepseek-v4-flash".into(),
+        base_url_host: "api.deepseek.com".into(),
+        prompt_tokens: 1200,
+        completion_tokens: 800,
+        total_tokens: 2000,
+        cost_estimate: Some(0.0021),
+        fallback: false,
+        result_link: None,
+        created_at: 1,
+    };
+    db.insert_token_ledger(&e).unwrap();
+
+    let list = db.list_token_usage().unwrap();
+    assert_eq!(list.len(), 1);
+    assert_eq!(list[0].provider_kind, "deepseek");
+    assert_eq!(list[0].model, "deepseek-v4-flash");
+    assert_eq!(list[0].total_tokens, 2000);
+    assert_eq!(list[0].cost_estimate, Some(0.0021));
+    assert!(!list[0].fallback); // the fallback flag is surfaced, here = false
+}


### PR DESCRIPTION
## Summary
A live **cost-transparency** view (`02` §13): reads the phone's own `token_ledger` (live on-device SQLite, a different domain than the activity store) and surfaces provider/model/tokens/cost with the **fallback flag always shown** — a fallback is never hidden. Simulator/emulator-level; overall Friday v1 stays **NO-GO**.

## What's in this slice
- **`friday-storage`**: `TokenUsageRow` + `Db::list_token_usage` (projection: provider/model/total_tokens/cost_estimate/fallback, oldest-first) + a test.
- **`friday-ffi`**: `TokenUsageFfi` + `PhoneTokensFfi` + `phone_token_usage(db_path)` — opens the phone `token_ledger`, seeds 2 DeepSeek Friday-route rows (`fallback=false`) on first run, lists; + a test (seed → list → reopen persisted; fallback surfaced).
- **iOS + Android**: a "Tokens / cost (live · phone ledger)" section — `provider/model · N tok · $cost · [direct | ⚠ fallback]`. Android screenshot: `deepseek-v4-flash 2000 tok $0.0021 direct`, `deepseek-v4-pro 4500 tok $0.0185 direct`.

## Tests / gates
- `cargo fmt`/`clippy -D warnings` clean; `cargo test --workspace` = **145 passed / 0 failed / 4 ignored**.
- Trust boundary unchanged (`friday-ffi` excludes `friday-deepseek`/`friday-providers`). No new dependency. No build artifacts committed.
- Review: focused self-review + host CI (read-only live view; proportional per operator guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)