### PR TITLE
Lock token-safety / no-hidden-model-call invariants (+8 tests)

### DIFF
--- a/rust-core/Cargo.lock
+++ b/rust-core/Cargo.lock
@@ -472,6 +472,7 @@ dependencies = [
 name = "friday-providers"
 version = "0.0.1"
 dependencies = [
+ "friday-storage",
  "thiserror 1.0.69",
 ]
 

--- a/rust-core/crates/friday-core/tests/ledger_token_safety.rs
+++ b/rust-core/crates/friday-core/tests/ledger_token_safety.rs
@@ -1,0 +1,102 @@
+//! Token-safety regression locks for `LedgerEntry` construction
+//! (goal `07` token-trust, `10` §4, `02` §13).
+//!
+//! These tests pin the invariant that token totals are computed from the parts
+//! by `LedgerEntry::new` (never trusted from a caller) and that out-of-range
+//! inputs are rejected rather than silently truncated/wrapped. The inline
+//! `src/ledger.rs` tests already cover the happy sum, a prompt-negative reject,
+//! and the `friday_route` fallback-false hard-wire; these close the remaining
+//! adverse-input cases (completion-negative, both-negative, i64 overflow) via
+//! the PUBLIC crate API only.
+
+use friday_core::{CoreError, LedgerEntry, ProviderKind};
+
+/// Construct a non-Friday-route entry through the public `new`, varying only the
+/// token counts so each test isolates the validation it exercises.
+fn entry(prompt: i64, completion: i64) -> Result<LedgerEntry, CoreError> {
+    LedgerEntry::new(
+        "l1",
+        "s1",
+        "a1",
+        ProviderKind::DeepSeek,
+        "deepseek-v4-flash",
+        "api.deepseek.com",
+        prompt,
+        completion,
+        None,
+        false,
+        None,
+        1000,
+    )
+}
+
+#[test]
+fn total_tokens_is_recomputed_not_caller_supplied() {
+    // `new` takes no `total_tokens` argument; the only way to get a total is the
+    // computed `prompt + completion`, so a caller cannot inject a total that
+    // disagrees with the parts (token-trust: the ledger total is authoritative).
+    let e = entry(123, 456).unwrap();
+    assert_eq!(e.total_tokens, 579);
+    assert_eq!(e.total_tokens, e.prompt_tokens + e.completion_tokens);
+}
+
+#[test]
+fn negative_completion_tokens_rejected() {
+    // The inline module covers a negative PROMPT; this covers the other arm so
+    // neither field can smuggle a negative count into the ledger.
+    let err = entry(8, -1).unwrap_err();
+    assert!(matches!(err, CoreError::InvalidLedger(_)));
+}
+
+#[test]
+fn both_negative_tokens_rejected() {
+    let err = entry(-5, -7).unwrap_err();
+    assert!(matches!(err, CoreError::InvalidLedger(_)));
+}
+
+#[test]
+fn token_total_overflow_is_rejected_not_wrapped() {
+    // prompt + completion would overflow i64. A checked add must surface an
+    // error rather than wrap to a negative/garbage total (which would corrupt
+    // every downstream cost/usage projection).
+    let err = entry(i64::MAX, 1).unwrap_err();
+    assert!(matches!(err, CoreError::InvalidLedger(_)));
+
+    // The boundary itself (sum == i64::MAX) is valid and computes exactly.
+    let ok = entry(i64::MAX - 1, 1).unwrap();
+    assert_eq!(ok.total_tokens, i64::MAX);
+}
+
+#[test]
+fn friday_route_also_recomputes_total_and_rejects_overflow() {
+    // The Friday-route convenience constructor delegates to `new`, so it inherits
+    // the same recompute + overflow guard (and never accepts a caller total).
+    let ok = LedgerEntry::friday_route(
+        "l2",
+        "s1",
+        "a1",
+        "deepseek-v4-flash",
+        100,
+        50,
+        None,
+        None,
+        1,
+    )
+    .unwrap();
+    assert_eq!(ok.total_tokens, 150);
+    assert!(!ok.fallback);
+
+    let err = LedgerEntry::friday_route(
+        "l3",
+        "s1",
+        "a1",
+        "deepseek-v4-flash",
+        i64::MAX,
+        1,
+        None,
+        None,
+        1,
+    )
+    .unwrap_err();
+    assert!(matches!(err, CoreError::InvalidLedger(_)));
+}

--- a/rust-core/crates/friday-providers/Cargo.toml
+++ b/rust-core/crates/friday-providers/Cargo.toml
@@ -13,3 +13,14 @@ rust-version.workspace = true
 # by friday-arch-tests.
 [dependencies]
 thiserror.workspace = true
+
+[dev-dependencies]
+# Token-safety regression lock only: a provider SEND returns reply text and must
+# NOT implicitly write a token_ledger row. The test opens a real Hub/Phone DB and
+# asserts the row count is unchanged across a send. This is a DEV-dependency, so
+# it does NOT enter the normal/build dependency graph the friday-ffi phone-
+# boundary arch test inspects (that test parses [dependencies]/[build-dependencies]
+# only), and friday-storage does not depend on friday-providers (no cycle). This
+# mirrors the friday-deepseek crate, which already dev-depends on friday-storage
+# for its end-to-end ledger proof.
+friday-storage.workspace = true

--- a/rust-core/crates/friday-providers/tests/session_no_ledger.rs
+++ b/rust-core/crates/friday-providers/tests/session_no_ledger.rs
@@ -1,0 +1,126 @@
+//! Token-safety regression lock: a provider SEND returns reply text ONLY and
+//! does NOT implicitly write a `token_ledger` row (goal `07` token-trust,
+//! `10` §4, `02` §13).
+//!
+//! KNOWN GAP (intentional, documented here): the `friday-providers` send path
+//! (Codex/Claude CLI sessions) currently performs NO token accounting at all —
+//! it has no storage handle and cannot ledger usage, because the provider CLIs
+//! do not surface per-call token usage the way the DeepSeek route does. So real
+//! provider-send token accounting is a KNOWN GAP deferred to a later Unit, NOT
+//! upheld here. What IS locked by this test is the safety direction of that gap:
+//! a send must never SILENTLY write a (wrong/zero) ledger row behind the
+//! operator's back. We prove it by opening a real Hub and Phone DB, sending via
+//! the real `send_to_provider` entry point with a `MockSession`, and asserting
+//! the `token_ledger` row count is unchanged. (Contrast: the DeepSeek route in
+//! `friday-deepseek` is the path that DOES ledger usage, with `fallback = false`.)
+
+use friday_providers::{
+    send_to_provider, MockSession, ProbeOutput, Provider, ProviderError, ProviderProbe,
+};
+use friday_storage::Db;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// A probe stub that reports a provider as installed + authenticated, so the
+/// send actually reaches the runner (we are testing the post-auth send path).
+struct AuthedProbe;
+impl ProviderProbe for AuthedProbe {
+    fn status(&self, provider: Provider) -> Result<ProbeOutput, ProviderError> {
+        // Output that `parse_status` reads as authenticated for either provider.
+        let stdout = match provider {
+            Provider::Codex => "Logged in using ChatGPT".to_string(),
+            Provider::Claude => "{\"loggedIn\": true}".to_string(),
+        };
+        Ok(ProbeOutput {
+            stdout,
+            stderr: String::new(),
+        })
+    }
+}
+
+/// A fresh on-disk SQLite path (a real file is needed so migrations run).
+fn temp_db_path(tag: &str) -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let mut dir = std::env::temp_dir();
+    dir.push(format!(
+        "friday-providers-noledger-{tag}-{}-{nanos}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir.push("db.sqlite");
+    dir.to_string_lossy().to_string()
+}
+
+#[test]
+fn provider_send_does_not_write_a_token_ledger_row_hub() {
+    let db = Db::open_hub(&temp_db_path("hub")).unwrap();
+    assert_eq!(
+        db.count("token_ledger").unwrap(),
+        0,
+        "freshly migrated hub db starts with an empty token_ledger"
+    );
+
+    // A successful, authorized send through the REAL entry point.
+    let runner = MockSession::new(Ok("from-codex".into()), Ok("from-claude".into()));
+    let out = send_to_provider(&AuthedProbe, &runner, Provider::Claude, "hi").unwrap();
+    assert_eq!(out.text, "from-claude", "send returns the reply text only");
+
+    // The send touched the runner exactly once and wrote NO ledger row: provider
+    // session control does not (and must not silently) perform token accounting.
+    assert_eq!(runner.calls(), vec![Provider::Claude]);
+    assert_eq!(
+        db.count("token_ledger").unwrap(),
+        0,
+        "a provider send must not implicitly write a token_ledger row"
+    );
+}
+
+#[test]
+fn provider_send_does_not_write_a_token_ledger_row_phone() {
+    // Same invariant on the phone profile (where token_ledger also exists).
+    let db = Db::open_phone(&temp_db_path("phone")).unwrap();
+    assert_eq!(db.count("token_ledger").unwrap(), 0);
+
+    let runner = MockSession::new(Ok("from-codex".into()), Ok("from-claude".into()));
+    let out = send_to_provider(&AuthedProbe, &runner, Provider::Codex, "hi").unwrap();
+    assert_eq!(out.text, "from-codex");
+
+    assert_eq!(runner.calls(), vec![Provider::Codex]);
+    assert_eq!(
+        db.count("token_ledger").unwrap(),
+        0,
+        "a provider send must not implicitly write a token_ledger row"
+    );
+}
+
+#[test]
+fn refused_unauthenticated_send_also_writes_no_ledger_row() {
+    // Adverse path: an unauthenticated send is refused before the runner is even
+    // called — and naturally writes nothing. Locks that the refusal path, too,
+    // has zero ledger side effect.
+    struct Unauthed;
+    impl ProviderProbe for Unauthed {
+        fn status(&self, provider: Provider) -> Result<ProbeOutput, ProviderError> {
+            let stdout = match provider {
+                Provider::Codex => "Not logged in".to_string(),
+                Provider::Claude => "{\"loggedIn\": false}".to_string(),
+            };
+            Ok(ProbeOutput {
+                stdout,
+                stderr: String::new(),
+            })
+        }
+    }
+
+    let db = Db::open_hub(&temp_db_path("refused")).unwrap();
+    let runner = MockSession::new(Ok("x".into()), Ok("y".into()));
+    let r = send_to_provider(&Unauthed, &runner, Provider::Claude, "hi");
+    assert!(matches!(r, Err(ProviderError::NotAuthenticated("claude"))));
+    assert!(
+        runner.calls().is_empty(),
+        "refused send never reaches the runner"
+    );
+    assert_eq!(db.count("token_ledger").unwrap(), 0);
+}


### PR DESCRIPTION
## Summary
Regression tests that lock the token-safety / no-hidden-model-call invariants the merged code already upholds (goal 07 token-trust, 10 §4, 02 §13). Test-only (+ one disclosed dev-dep). No production behavior change.

## Tests added (all real, all pass)
- **`friday-core/tests/ledger_token_safety.rs`** — `total_tokens` is recomputed (never caller-supplied), negative prompt **and** completion rejected, overflow rejected (not wrapped), `friday_route` inherits the recompute + overflow guard.
- **`friday-providers/tests/session_no_ledger.rs`** — a provider session send writes **no** `token_ledger` row (Hub + Phone profiles), and a refused unauthenticated send also has zero ledger side-effect.

## Already-upheld invariants (named, covered by existing tests)
- `friday_route` hard-wires `fallback=false`; missing/invalid credential → error, not fallback; no silent provider substitution on a failed DeepSeek call; `record_model_call` is atomic (all-or-nothing).

## Honest GAP (reported, not faked)
The `friday-providers` CLI session-send path performs **no token accounting** (no storage handle; the Codex/Claude CLIs don't surface per-call usage like the DeepSeek route does). Real provider-send token accounting is a **known gap deferred to a later Unit**. The `session_no_ledger` test is therefore a **regression lock on the safe direction** (a send must never *silently* write a wrong/zero ledger row), not proof of send-path accounting. Documented in the test header + commit.

## Disclosed manifest touch
Added `friday-storage` as a **dev-dependency** of `friday-providers` (so invariant 5 can open a real DB). Dev-deps are excluded from the `friday-arch-tests` phone-boundary parse; `friday-arch-tests` still passes; mirrors `friday-deepseek`'s existing precedent.

## Gates
`cargo test --workspace` = **153 passed / 0 failed / 4 ignored**; `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt --all -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)