### PR TITLE
rust-core: workflow run-completion gate (a run can't be Done with an unverified side-effect step)

### DIFF
--- a/rust-core/crates/friday-core/src/lib.rs
+++ b/rust-core/crates/friday-core/src/lib.rs
@@ -34,5 +34,6 @@ pub use memory::{
 pub use offline::OfflineQueueState;
 pub use session::SessionState;
 pub use workflow::{
-    aggregate_needs_me, resolve_step_completion, NeedsMeItem, StepStatus, WorkflowRunState,
+    aggregate_needs_me, resolve_step_completion, run_is_complete, NeedsMeItem, StepStatus,
+    StepView, WorkflowRunState,
 };

--- a/rust-core/crates/friday-core/src/workflow.rs
+++ b/rust-core/crates/friday-core/src/workflow.rs
@@ -146,6 +146,15 @@ pub struct StepView {
 /// engine has otherwise finished it — the engine, not this predicate, decides
 /// when all *work* is done. This predicate answers exactly one question: "is it
 /// safe to call this run complete given its side effects?"
+///
+/// CAUTION — this is a **safety floor, not a readiness signal**. It is `true`
+/// whenever every *side-effect* step is `Verified`, even if a non-side-effect
+/// step is still `Pending`/`Running`. Use it ONLY as a guard ("refuse `Done`
+/// when `!run_is_complete`"), never as the completion trigger: a future engine
+/// that does `if run_is_complete(steps) { mark_done() }` would mark a run `Done`
+/// with unfinished analysis work. The engine must separately confirm all steps
+/// (side-effect *and* pure) are finished before driving the run to `Done`; this
+/// function only forbids the unsafe case.
 pub fn run_is_complete(steps: &[StepView]) -> bool {
     steps
         .iter()

--- a/rust-core/crates/friday-core/src/workflow.rs
+++ b/rust-core/crates/friday-core/src/workflow.rs
@@ -122,6 +122,37 @@ pub fn resolve_step_completion(
     }
 }
 
+/// A read-only projection of a workflow step for the run-completion gate: the
+/// only two facts the gate needs are whether the step has an external side effect
+/// and its current verification status. (`08` §6, `10` §6, `32` deferral.)
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct StepView {
+    pub has_side_effect: bool,
+    pub status: StepStatus,
+}
+
+/// The run-completion gate (`08` §6 / `10` §6; closes the `32` deferral).
+///
+/// A run is complete **only** when every side-effect step is `Verified`. The
+/// per-step evidence-gating invariant (`resolve_step_completion`) guarantees a
+/// side-effect step reaches `Verified` only with deterministic evidence; this
+/// function lifts that invariant from the step to the **run**: a run with a
+/// `ProofPending` (evidence not yet arrived) **or** `Failed` side-effect step is
+/// NOT complete — the `Failed` case must route the run to `Failed`, never `Done`.
+///
+/// Non-side-effect steps do not gate completion here: they may legitimately
+/// complete on a model result (`resolve_step_completion(false, ..)`), and a run
+/// can be `Done` while a non-side-effect step is still in flight only if the
+/// engine has otherwise finished it — the engine, not this predicate, decides
+/// when all *work* is done. This predicate answers exactly one question: "is it
+/// safe to call this run complete given its side effects?"
+pub fn run_is_complete(steps: &[StepView]) -> bool {
+    steps
+        .iter()
+        .filter(|s| s.has_side_effect)
+        .all(|s| s.status == StepStatus::Verified)
+}
+
 /// A cross-source action item the user must act on (`08` §2). Needs-Me preserves
 /// the underlying provider detail; missing detail must be truth-labeled, not
 /// silently dropped (so `reason`/`destination` are always carried).
@@ -201,6 +232,46 @@ mod tests {
             resolve_step_completion(false, false, false),
             StepStatus::Running
         );
+    }
+
+    #[test]
+    fn run_completion_gate_requires_every_side_effect_verified() {
+        let se = |status| StepView {
+            has_side_effect: true,
+            status,
+        };
+        let pure = |status| StepView {
+            has_side_effect: false,
+            status,
+        };
+
+        // All side-effect steps Verified -> complete (non-side-effect steps don't gate).
+        assert!(run_is_complete(&[
+            se(StepStatus::Verified),
+            se(StepStatus::Verified),
+            pure(StepStatus::Verified),
+        ]));
+        // A run with no steps at all is trivially complete (no side effect to verify).
+        assert!(run_is_complete(&[]));
+        // A run whose only steps have no side effect is complete regardless of their status.
+        assert!(run_is_complete(&[
+            pure(StepStatus::Running),
+            pure(StepStatus::Pending)
+        ]));
+
+        // A ProofPending side-effect step (evidence not yet arrived) blocks completion.
+        assert!(!run_is_complete(&[
+            se(StepStatus::Verified),
+            se(StepStatus::ProofPending),
+        ]));
+        // A Failed side-effect step blocks completion (the run must go Failed, not Done).
+        assert!(!run_is_complete(&[
+            se(StepStatus::Verified),
+            se(StepStatus::Failed),
+        ]));
+        // Pending/Running side-effect steps also block completion.
+        assert!(!run_is_complete(&[se(StepStatus::Pending)]));
+        assert!(!run_is_complete(&[se(StepStatus::Running)]));
     }
 
     #[test]

--- a/rust-core/crates/friday-storage/src/workflow.rs
+++ b/rust-core/crates/friday-storage/src/workflow.rs
@@ -6,7 +6,9 @@
 //! never marks it verified (`08` §6 / `10` §6).
 
 use crate::error::{Result, StorageError};
-use friday_core::{resolve_step_completion, StepStatus, WorkflowRunState};
+use friday_core::{
+    resolve_step_completion, run_is_complete, StepStatus, StepView, WorkflowRunState,
+};
 use rusqlite::{params, Connection, OptionalExtension};
 
 fn parse_run_state(s: &str) -> WorkflowRunState {
@@ -50,8 +52,34 @@ pub fn run_state(conn: &Connection, run_id: &str) -> Result<Option<WorkflowRunSt
     Ok(s.map(|x| parse_run_state(&x)))
 }
 
+/// Load every step of a run as a `StepView` (side-effect flag + status). This is
+/// the input to the run-completion gate; it is the single read used by
+/// `set_run_state` to decide whether a `-> Done` transition is allowed.
+fn step_views(conn: &Connection, run_id: &str) -> Result<Vec<StepView>> {
+    let mut stmt = conn.prepare(
+        "SELECT has_side_effect, status FROM workflow_step WHERE run_id = ?1 ORDER BY seq",
+    )?;
+    let rows = stmt.query_map([run_id], |r| {
+        Ok(StepView {
+            has_side_effect: r.get::<_, i64>(0)? != 0,
+            status: parse_step_status(&r.get::<_, String>(1)?),
+        })
+    })?;
+    rows.collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(StorageError::from)
+}
+
 /// Transition a run's state, validated by the `friday-core` state machine
 /// (an invalid transition is rejected).
+///
+/// Beyond the per-run state-machine check, a transition **to `Done`** is gated by
+/// `run_is_complete` (`08` §6 / `10` §6 / `32` deferral): a run cannot be reported
+/// `Done` while any side-effect step is still `ProofPending` (evidence not yet
+/// arrived) or `Failed`. Because this is the single write API for run state, a
+/// `Done` run with an unverified side-effect step is **unrepresentable through the
+/// API** — not merely discouraged (the Unit-9 divergent-pair resolution discipline).
+/// A run whose side-effect step has `Failed` must be transitioned to `Failed`, not
+/// forced `Done`.
 pub fn set_run_state(
     conn: &Connection,
     run_id: &str,
@@ -61,6 +89,18 @@ pub fn set_run_state(
     let cur = run_state(conn, run_id)?
         .ok_or_else(|| StorageError::Unsupported(format!("workflow_run '{run_id}' not found")))?;
     let next = cur.try_transition(next)?; // CoreError -> StorageError
+
+    // Run-completion gate: refuse `-> Done` while a side-effect step is unverified.
+    if next == WorkflowRunState::Done {
+        let steps = step_views(conn, run_id)?;
+        if !run_is_complete(&steps) {
+            return Err(StorageError::Unsupported(format!(
+                "workflow_run '{run_id}' cannot be marked Done: a side-effect step is not Verified \
+                 (proof_pending or failed). Attach evidence to verify it, or transition the run to Failed."
+            )));
+        }
+    }
+
     conn.execute(
         "UPDATE workflow_run SET state = ?1, updated_at = ?2 WHERE run_id = ?3",
         params![next.as_str(), now, run_id],

--- a/rust-core/crates/friday-storage/tests/workflow_persist.rs
+++ b/rust-core/crates/friday-storage/tests/workflow_persist.rs
@@ -71,6 +71,103 @@ fn run_state_machine_is_persisted_and_validated() {
 }
 
 #[test]
+fn run_cannot_be_done_while_a_side_effect_step_is_proof_pending() {
+    // The file-32 deferral, closed: persistence + per-step gating alone let a run
+    // reach Done with an unverified side-effect step. This is the discriminating
+    // test — "the transition is allowed" is NOT proof; we prove the unverified-step
+    // run is refused, and that attaching evidence then unblocks it.
+    let p = temp_db_path("wf-run-gate");
+    let db = Db::open_hub(&p).unwrap();
+    workflow::create_run(db.conn(), "r1", "QA", 1).unwrap();
+    workflow::set_run_state(db.conn(), "r1", WorkflowRunState::Running, 2).unwrap();
+
+    // A side-effect step left ProofPending (model claimed done, no evidence).
+    workflow::add_step(db.conn(), "st1", "r1", 1, true, 1).unwrap();
+    assert_eq!(
+        workflow::complete_step(db.conn(), "st1", None, true, 3).unwrap(),
+        StepStatus::ProofPending
+    );
+
+    // -> Done is REFUSED while the side-effect step is unverified.
+    assert!(
+        workflow::set_run_state(db.conn(), "r1", WorkflowRunState::Done, 4).is_err(),
+        "a run with a ProofPending side-effect step must not be marked Done"
+    );
+    // The run did not silently advance — it is still Running.
+    assert_eq!(
+        workflow::run_state(db.conn(), "r1").unwrap(),
+        Some(WorkflowRunState::Running)
+    );
+
+    // Evidence arrives -> the step verifies -> the SAME -> Done transition is now allowed.
+    assert_eq!(
+        workflow::complete_step(db.conn(), "st1", Some("evidence://receipt"), false, 5).unwrap(),
+        StepStatus::Verified
+    );
+    workflow::set_run_state(db.conn(), "r1", WorkflowRunState::Done, 6).unwrap();
+    assert_eq!(
+        workflow::run_state(db.conn(), "r1").unwrap(),
+        Some(WorkflowRunState::Done)
+    );
+}
+
+#[test]
+fn run_with_all_side_effects_verified_can_be_done_even_with_an_incomplete_pure_step() {
+    // Non-side-effect steps do not gate run completion (they complete on a model
+    // result; the engine, not this gate, decides when their work is done).
+    let p = temp_db_path("wf-run-gate-pure");
+    let db = Db::open_hub(&p).unwrap();
+    workflow::create_run(db.conn(), "r1", "QA", 1).unwrap();
+    workflow::set_run_state(db.conn(), "r1", WorkflowRunState::Running, 2).unwrap();
+
+    workflow::add_step(db.conn(), "se", "r1", 1, true, 1).unwrap();
+    workflow::complete_step(db.conn(), "se", Some("evidence://ok"), false, 3).unwrap();
+    // A pure (no-side-effect) step that is still Pending must NOT block Done.
+    workflow::add_step(db.conn(), "pure", "r1", 2, false, 1).unwrap();
+
+    workflow::set_run_state(db.conn(), "r1", WorkflowRunState::Done, 4).unwrap();
+    assert_eq!(
+        workflow::run_state(db.conn(), "r1").unwrap(),
+        Some(WorkflowRunState::Done)
+    );
+}
+
+#[test]
+fn failed_side_effect_step_blocks_done_through_the_single_write_api() {
+    // A `Failed` side-effect step must also block `-> Done` (the run must go to
+    // Failed, not Done). No public API yet produces a Failed step (that lands with
+    // the engine slice), so we inject the failed status directly via raw SQL — the
+    // gate must already defend against it. Scope of the "unrepresentable" claim: the
+    // only *typed repo API* that sets run state is `set_run_state`, and it is gated;
+    // `create_run` only ever writes `Pending`. Raw `Db::conn()` access (used here to
+    // inject the otherwise-unreachable Failed step) is deliberately out of scope —
+    // the guarantee holds at the typed-API layer, not against arbitrary raw SQL.
+    let p = temp_db_path("wf-run-gate-failed");
+    let db = Db::open_hub(&p).unwrap();
+    workflow::create_run(db.conn(), "r1", "QA", 1).unwrap();
+    workflow::set_run_state(db.conn(), "r1", WorkflowRunState::Running, 2).unwrap();
+    workflow::add_step(db.conn(), "st1", "r1", 1, true, 1).unwrap();
+    // Inject a Failed side-effect step state directly (no fail-step API yet).
+    db.conn()
+        .execute(
+            "UPDATE workflow_step SET status = 'failed' WHERE step_id = 'st1'",
+            [],
+        )
+        .unwrap();
+
+    assert!(
+        workflow::set_run_state(db.conn(), "r1", WorkflowRunState::Done, 3).is_err(),
+        "a run with a Failed side-effect step must not be marked Done"
+    );
+    // But the run CAN legitimately transition to Failed.
+    workflow::set_run_state(db.conn(), "r1", WorkflowRunState::Failed, 4).unwrap();
+    assert_eq!(
+        workflow::run_state(db.conn(), "r1").unwrap(),
+        Some(WorkflowRunState::Failed)
+    );
+}
+
+#[test]
 fn evidence_gated_step_completion_is_persisted() {
     let p = temp_db_path("wf-step");
     let db = Db::open_hub(&p).unwrap();


### PR DESCRIPTION
## What

Closes the **file-32 deferral**. Before this, `friday-storage::workflow::set_run_state` validated only the run's *own* state-machine transition, so a run could reach `Done` while a side-effect step was still `ProofPending` — violating the `08` §6 / `10` §6 invariant (*a run is not complete until its side-effect steps are verified*).

This is **PR-1 of the agent-loop NO-GO cluster repair backlog** (goal file `39` §5/§6). It is the smallest tractable, offline-testable, real slice.

## Change

- **`friday-core::workflow::run_is_complete(&[StepView]) -> bool`** (pure, no I/O) + `StepView { has_side_effect, status }`. Rule: every side-effect step must be `Verified`; a `ProofPending` **or** `Failed` side-effect step blocks `Done` (the `Failed` case routes the run to `Failed`, never `Done`). Non-side-effect steps do not gate.
- **`friday-storage::workflow::set_run_state`**: on `next == Done`, load the run's `StepView`s and refuse the transition (`StorageError`) if `!run_is_complete`. Core transition validation stays; this is the aggregate guard on top. `set_run_state` is the only *typed* run-state writer (and `create_run` only writes `Pending`), so `Done`-with-an-unverified-side-effect-step is **unrepresentable through the typed repo API**.

## Tests (real)

- **`friday-core`** unit `run_completion_gate_requires_every_side_effect_verified`: all-verified→true; ProofPending side-effect→false; Failed side-effect→false; empty / pure-only→true. (**32 passed**)
- **`friday-storage`** integration (real SQLite):
  - `run_cannot_be_done_while_a_side_effect_step_is_proof_pending` — the **discriminating** file-32 test: `→Done` errors, run stays `Running`; attach evidence → step `Verified` → the *same* `→Done` now succeeds.
  - `failed_side_effect_step_blocks_done_through_the_single_write_api` — `Failed` side-effect step blocks `Done`; run can still go `Failed`.
  - `run_with_all_side_effects_verified_can_be_done_even_with_an_incomplete_pure_step` — a still-`Pending` non-side-effect step does not block. (**7 passed**)
- `cargo fmt` + `clippy -D warnings` clean; `cargo test --workspace` = **157 passed / 0 failed / 4 ignored** (live smokes).

## Honest disposition

Moves `workflow_runtime_run_step_acceptance` (file 36) from **"NO-GO (no completion gate)"** to **"run-completion gate wired; full execution/acceptance/evidence ENGINE still NO-GO."** **Not a cat-8 PASS.** The run-driving engine, LLM turn loop, tool dispatch, and the dangerous-action/path-safety/plan-machine gates (file 39 PRs 2–6, the `friday-hub` runtime) remain backlog. Overall Friday v1 stays NO-GO.

Reviewed: Reviewer A (coverage) PASS; Reviewer B (adversarial) CONCERNS → both text-only findings fixed (test comment scoped to the typed API; delivery-status labeling corrected). A future multi-connection TOCTOU hardening (atomic `UPDATE … WHERE NOT EXISTS`) is captured for the `friday-hub` engine slice; not applicable to today's single-`Connection` design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)