### PR TITLE
rust-core: canonical-approval crypto binding + single-use replay (agent-loop PR-3b)

### DIFF
--- a/rust-core/crates/friday-core/src/gate.rs
+++ b/rust-core/crates/friday-core/src/gate.rs
@@ -192,7 +192,10 @@ pub fn canonical_action_bytes(request: &MutatingActionRequest) -> Vec<u8> {
         }
     }
     out.push(request.mutating as u8);
-    put_str(&mut out, request.risk.map(|r| r.as_str()).unwrap_or("none"));
+    // Bind the DERIVED effective risk (incl. local-claim escalation), not the raw
+    // declared risk — so an approval is scoped to the effective risk assessment and a
+    // request a guard later escalates no longer digest-matches (faithful to the oracle).
+    put_str(&mut out, derive_risk(request).as_str());
     put_opt_str(&mut out, &request.parameters);
     put_opt_str(&mut out, &request.plan_digest);
     put_opt_str(&mut out, &request.idempotency_key);
@@ -427,6 +430,17 @@ mod tests {
         let mut e = c.clone();
         e.idempotency_key = Some("k1".into());
         assert_ne!(canonical_action_bytes(&c), canonical_action_bytes(&e));
+        // The DERIVED effective risk is bound: a risk-escalating local claim changes
+        // the digest, so an approval can't survive a later guard escalation.
+        let mut f = req("inspect", ActorKind::Owner, false); // non-mutating -> ReadOnly base
+        let base_bytes = canonical_action_bytes(&f);
+        f.local_claims.push(LocalClaim {
+            guard_id: "risk".into(),
+            decision: GateDecision::Allow,
+            risk: Some(Risk::High),
+            reason: None,
+        });
+        assert_ne!(base_bytes, canonical_action_bytes(&f));
     }
 
     #[test]

--- a/rust-core/crates/friday-core/src/gate.rs
+++ b/rust-core/crates/friday-core/src/gate.rs
@@ -64,8 +64,22 @@ pub struct LocalClaim {
     pub reason: Option<String>,
 }
 
+/// The resource an action targets. Bound into the action digest so an approval
+/// authorizes the action on THIS resource, not the same verb on another.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Resource {
+    pub resource_type: String,
+    pub id: Option<String>,
+    pub digest: Option<String>,
+}
+
 /// A request to perform a (possibly mutating) action (TS `FridayMutatingActionRequest`,
 /// minus the `canonicalApproval` field — see the module-level fail-closed note).
+///
+/// `resource` / `parameters` / `idempotency_key` / `plan_digest` are bound into the
+/// action digest (`canonical_action_bytes`): they distinguish one authorized action
+/// from another, so a canonical approval (PR-3b) is bound to the exact action — the
+/// same verb on a different resource produces a different digest and is not authorized.
 #[derive(Clone, Debug)]
 pub struct MutatingActionRequest {
     pub action: String,
@@ -74,6 +88,12 @@ pub struct MutatingActionRequest {
     pub mutating: bool,
     pub risk: Option<Risk>,
     pub local_claims: Vec<LocalClaim>,
+    pub resource: Option<Resource>,
+    /// Caller-supplied canonical serialization of the action parameters (opaque to
+    /// the gate; bound into the digest). The caller is responsible for determinism.
+    pub parameters: Option<String>,
+    pub idempotency_key: Option<String>,
+    pub plan_digest: Option<String>,
 }
 
 /// The gate's evidence record — a **decision-core subset** of the TS
@@ -90,6 +110,127 @@ pub struct GateEvidenceRecord {
     pub risk: Risk,
     pub approval_required: bool,
     pub denied_by: Option<String>,
+}
+
+/// The owner's decision on a canonical approval (TS `FridayCanonicalApprovalDecision`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ApprovalDecision {
+    Approved,
+    Denied,
+}
+
+/// A canonical approval resolution (TS `FridayCanonicalApprovalResolution`) — pure
+/// data. PR-3a's pure `evaluate` never reads it (fail-closed); the verified
+/// approval→Allow upgrade lives in `friday-storage::authorize_mutating_action`
+/// (PR-3b), which composes this with `friday-crypto` (digest/signature) and the
+/// single-use replay store.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CanonicalApproval {
+    pub decision: ApprovalDecision,
+    pub approval_id: String,
+    /// Hex SHA-256 of the request's `canonical_action_bytes` at issue time. Must
+    /// match the live request's digest or the approval does not apply to this action.
+    pub action_digest: String,
+    /// Epoch ms after which the approval is expired. `None` is rejected (an approval
+    /// MUST carry an expiry — fail-closed).
+    pub expires_at: Option<i64>,
+    /// Must be `"friday_canonical_gate"` for a valid approval.
+    pub issuer: Option<String>,
+    /// Hex HMAC-SHA256 over `canonical_approval_signature_bytes`.
+    pub signature: Option<String>,
+}
+
+/// The canonical gate issuer string a valid approval must carry.
+pub const CANONICAL_GATE_ISSUER: &str = "friday_canonical_gate";
+
+// --- deterministic, collision-resistant serialization (pure; no crypto) ------
+
+fn put_bytes(out: &mut Vec<u8>, field: &[u8]) {
+    // fixed-width length prefix so concatenation is unambiguous.
+    out.extend_from_slice(&(field.len() as u64).to_le_bytes());
+    out.extend_from_slice(field);
+}
+
+fn put_str(out: &mut Vec<u8>, s: &str) {
+    put_bytes(out, s.as_bytes());
+}
+
+fn put_opt_str(out: &mut Vec<u8>, s: &Option<String>) {
+    // presence tag so `None` != `Some("")`.
+    match s {
+        None => out.push(0u8),
+        Some(v) => {
+            out.push(1u8);
+            put_str(out, v);
+        }
+    }
+}
+
+/// Deterministic, length-prefixed byte serialization of the request fields that
+/// distinguish one authorized action from another. `friday-crypto::action_digest`
+/// hashes these bytes; an approval binds to the resulting digest. This is
+/// Rust-internal (it need not match the TS hex) but MUST bind every distinguishing
+/// field — incl. `resource`/`parameters`/`idempotency_key`/`plan_digest` — so the
+/// same verb on a different resource yields a different digest.
+pub fn canonical_action_bytes(request: &MutatingActionRequest) -> Vec<u8> {
+    let mut out = Vec::new();
+    put_bytes(&mut out, b"friday.mutating_action.v1");
+    put_str(&mut out, &request.action);
+    // actor
+    put_str(&mut out, request.actor.kind.as_str());
+    put_str(&mut out, &request.actor.id);
+    put_opt_str(&mut out, &request.actor.principal_id);
+    put_str(&mut out, &request.surface);
+    // resource (presence-tagged)
+    match &request.resource {
+        None => out.push(0u8),
+        Some(r) => {
+            out.push(1u8);
+            put_str(&mut out, &r.resource_type);
+            put_opt_str(&mut out, &r.id);
+            put_opt_str(&mut out, &r.digest);
+        }
+    }
+    out.push(request.mutating as u8);
+    put_str(&mut out, request.risk.map(|r| r.as_str()).unwrap_or("none"));
+    put_opt_str(&mut out, &request.parameters);
+    put_opt_str(&mut out, &request.plan_digest);
+    put_opt_str(&mut out, &request.idempotency_key);
+    out
+}
+
+/// Deterministic byte serialization of the approval fields that are SIGNED (all
+/// fields except the signature itself). `friday-crypto::{sign,verify}_approval`
+/// HMACs these bytes.
+pub fn canonical_approval_signature_bytes(approval: &CanonicalApproval) -> Vec<u8> {
+    let mut out = Vec::new();
+    put_bytes(&mut out, b"friday.canonical_approval.v1");
+    out.push(match approval.decision {
+        ApprovalDecision::Approved => 1u8,
+        ApprovalDecision::Denied => 0u8,
+    });
+    put_str(&mut out, &approval.approval_id);
+    put_str(&mut out, &approval.action_digest);
+    match approval.expires_at {
+        None => out.push(0u8),
+        Some(v) => {
+            out.push(1u8);
+            out.extend_from_slice(&v.to_le_bytes());
+        }
+    }
+    put_opt_str(&mut out, &approval.issuer);
+    out
+}
+
+impl ActorKind {
+    fn as_str(&self) -> &'static str {
+        match self {
+            ActorKind::Owner => "owner",
+            ActorKind::Agent => "agent",
+            ActorKind::Api => "api",
+            ActorKind::Channel => "channel",
+        }
+    }
 }
 
 /// Reserved approval actions an `Agent` actor may never self-execute (TS
@@ -247,7 +388,45 @@ mod tests {
             mutating,
             risk: None,
             local_claims: vec![],
+            resource: None,
+            parameters: None,
+            idempotency_key: None,
+            plan_digest: None,
         }
+    }
+
+    #[test]
+    fn canonical_action_bytes_binds_distinguishing_fields() {
+        // The same verb/actor/surface but a DIFFERENT resource MUST yield different
+        // bytes (so a different digest, so an approval cannot cross-authorize).
+        let mut a = req("delete_file", ActorKind::Owner, true);
+        a.resource = Some(Resource {
+            resource_type: "file".into(),
+            id: Some("/data/a.txt".into()),
+            digest: None,
+        });
+        let mut b = req("delete_file", ActorKind::Owner, true);
+        b.resource = Some(Resource {
+            resource_type: "file".into(),
+            id: Some("/data/b.txt".into()),
+            digest: None,
+        });
+        assert_ne!(canonical_action_bytes(&a), canonical_action_bytes(&b));
+        // Identical requests -> identical bytes (deterministic).
+        assert_eq!(
+            canonical_action_bytes(&a),
+            canonical_action_bytes(&a.clone())
+        );
+        // None resource != Some(empty-ish) — presence tag prevents collision.
+        let c = req("delete_file", ActorKind::Owner, true);
+        assert_ne!(canonical_action_bytes(&a), canonical_action_bytes(&c));
+        // parameters / idempotency_key also distinguish.
+        let mut d = c.clone();
+        d.parameters = Some("force=true".into());
+        assert_ne!(canonical_action_bytes(&c), canonical_action_bytes(&d));
+        let mut e = c.clone();
+        e.idempotency_key = Some("k1".into());
+        assert_ne!(canonical_action_bytes(&c), canonical_action_bytes(&e));
     }
 
     #[test]

--- a/rust-core/crates/friday-crypto/src/approval.rs
+++ b/rust-core/crates/friday-crypto/src/approval.rs
@@ -1,0 +1,143 @@
+//! Canonical-approval crypto (PR-3b of the agent-loop cluster, file 39 §2 group A):
+//! the SHA-256 **action digest** an approval binds to, plus an HMAC-SHA256 approval
+//! **signature** with constant-time verification. Mirrors `pairing.rs`'s HMAC +
+//! `verify_slice` (constant-time) pattern.
+//!
+//! No `friday-core` dependency: these operate on caller-provided canonical byte
+//! strings (`friday-core::gate::canonical_action_bytes` /
+//! `canonical_approval_signature_bytes` build them), keeping the crypto layer free
+//! of domain types and the digest/HMAC out of pure `friday-core`.
+
+use hmac::{Hmac, Mac};
+use sha2::{Digest, Sha256};
+
+type HmacSha256 = Hmac<Sha256>;
+
+const HEX: &[u8; 16] = b"0123456789abcdef";
+
+fn to_hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push(HEX[(b >> 4) as usize] as char);
+        s.push(HEX[(b & 0x0f) as usize] as char);
+    }
+    s
+}
+
+fn hex_val(c: u8) -> Option<u8> {
+    match c {
+        b'0'..=b'9' => Some(c - b'0'),
+        b'a'..=b'f' => Some(c - b'a' + 10),
+        b'A'..=b'F' => Some(c - b'A' + 10),
+        _ => None,
+    }
+}
+
+/// Decode exactly 64 hex chars (a 32-byte SHA-256/HMAC output). `None` for any other
+/// length or a non-hex char — so a malformed signature fails closed before the compare.
+fn from_hex_32(s: &str) -> Option<[u8; 32]> {
+    if s.len() != 64 {
+        return None;
+    }
+    let b = s.as_bytes();
+    let mut out = [0u8; 32];
+    for (i, slot) in out.iter_mut().enumerate() {
+        let hi = hex_val(b[2 * i])?;
+        let lo = hex_val(b[2 * i + 1])?;
+        *slot = (hi << 4) | lo;
+    }
+    Some(out)
+}
+
+/// Lowercase-hex SHA-256 of a request's canonical action bytes — the digest an
+/// approval is bound to (a different action → different bytes → different digest).
+pub fn action_digest(canonical_action_bytes: &[u8]) -> String {
+    let mut h = Sha256::new();
+    h.update(canonical_action_bytes);
+    to_hex(&h.finalize())
+}
+
+/// Lowercase-hex HMAC-SHA256 over an approval's canonical signature bytes, keyed by
+/// the gate's signing secret.
+pub fn sign_approval(signature_bytes: &[u8], secret: &[u8]) -> String {
+    let mut mac = HmacSha256::new_from_slice(secret).expect("HMAC accepts any key length");
+    mac.update(signature_bytes);
+    to_hex(&mac.finalize().into_bytes())
+}
+
+/// Constant-time verify of a hex HMAC approval signature. Returns `false` for a
+/// non-64-hex signature, a wrong secret, or tampered bytes. Fails closed.
+pub fn verify_approval_signature(
+    signature_bytes: &[u8],
+    secret: &[u8],
+    signature_hex: &str,
+) -> bool {
+    let raw = match from_hex_32(signature_hex) {
+        Some(r) => r,
+        None => return false,
+    };
+    let mut mac = HmacSha256::new_from_slice(secret).expect("HMAC accepts any key length");
+    mac.update(signature_bytes);
+    mac.verify_slice(&raw).is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn action_digest_is_deterministic_and_distinguishing() {
+        assert_eq!(action_digest(b"abc"), action_digest(b"abc"));
+        assert_ne!(action_digest(b"abc"), action_digest(b"abd"));
+        assert_eq!(action_digest(b"abc").len(), 64); // 32-byte hex
+        assert!(action_digest(b"abc").bytes().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn sign_then_verify_roundtrips() {
+        let payload = b"approval-canonical-bytes";
+        let secret = b"gate-signing-secret";
+        let sig = sign_approval(payload, secret);
+        assert_eq!(sig.len(), 64);
+        assert!(verify_approval_signature(payload, secret, &sig));
+        // Uppercase hex still verifies (normalized on decode).
+        assert!(verify_approval_signature(
+            payload,
+            secret,
+            &sig.to_uppercase()
+        ));
+    }
+
+    #[test]
+    fn wrong_secret_rejected() {
+        let payload = b"approval-canonical-bytes";
+        let sig = sign_approval(payload, b"the-real-secret");
+        assert!(!verify_approval_signature(
+            payload,
+            b"a-different-secret",
+            &sig
+        ));
+    }
+
+    #[test]
+    fn tampered_payload_rejected() {
+        let secret = b"gate-signing-secret";
+        let sig = sign_approval(b"original-payload", secret);
+        assert!(!verify_approval_signature(
+            b"tampered-payload",
+            secret,
+            &sig
+        ));
+    }
+
+    #[test]
+    fn malformed_signature_fails_closed() {
+        let payload = b"p";
+        let secret = b"s";
+        assert!(!verify_approval_signature(payload, secret, "")); // empty
+        assert!(!verify_approval_signature(payload, secret, "abcd")); // too short
+        assert!(!verify_approval_signature(payload, secret, &"z".repeat(64))); // non-hex
+        assert!(!verify_approval_signature(payload, secret, &"a".repeat(63))); // 63 chars
+        assert!(!verify_approval_signature(payload, secret, &"a".repeat(65))); // 65 chars
+    }
+}

--- a/rust-core/crates/friday-crypto/src/lib.rs
+++ b/rust-core/crates/friday-crypto/src/lib.rs
@@ -24,8 +24,10 @@ use std::collections::HashMap;
 use thiserror::Error;
 use zeroize::ZeroizeOnDrop;
 
+pub mod approval;
 pub mod pairing;
 pub mod session;
+pub use approval::{action_digest, sign_approval, verify_approval_signature};
 pub use pairing::{pairing_proof, verify_pairing_proof};
 pub use session::DeviceKeypair;
 

--- a/rust-core/crates/friday-storage/src/authorize.rs
+++ b/rust-core/crates/friday-storage/src/authorize.rs
@@ -1,0 +1,118 @@
+//! Canonical mutating-action authorization (PR-3b of the agent-loop cluster, file
+//! 39 §2 group A; UNW-001 / cat-10). Composes the three layers:
+//!   - `friday-core::gate::evaluate` — the pure decision (PR-3a);
+//!   - `friday-crypto` — SHA-256 action digest + constant-time HMAC signature verify;
+//!   - this storage layer — the single-use replay store (`consumed_approval`).
+//!
+//! Only a `RequiresApproval` base decision consults an approval; a base `Allow`
+//! (read-only) or `Deny` (reserved/local-deny) passes through untouched and never
+//! touches the replay table. The upgrade `RequiresApproval -> Allow` happens ONLY
+//! when a presented canonical approval is: digest-bound to THIS exact action,
+//! signature-valid, unexpired, and not previously spent. Fail-closed throughout —
+//! a missing/None field, a bad signature, or a stale base never yields `Allow`.
+
+use crate::error::{Result, StorageError};
+use friday_core::gate::{
+    self, ApprovalDecision, CanonicalApproval, GateDecision, GateEvidenceRecord,
+    MutatingActionRequest, CANONICAL_GATE_ISSUER,
+};
+use rusqlite::{params, Connection, Error as SqlErr, ErrorCode};
+
+/// Authorize a (possibly mutating) action. `now_ms` is the caller's clock (this
+/// layer stays pure of wall-clock). Returns the gate decision; only a valid,
+/// unspent, digest-bound, signature-valid, unexpired approval upgrades a
+/// `RequiresApproval` action to `Allow`.
+pub fn authorize_mutating_action(
+    conn: &Connection,
+    request: &MutatingActionRequest,
+    approval: Option<&CanonicalApproval>,
+    secret: &[u8],
+    now_ms: i64,
+) -> Result<GateEvidenceRecord> {
+    // Pure base decision. Allow/Deny are final and never consult an approval or the
+    // replay store; only RequiresApproval can be upgraded.
+    let base = gate::evaluate(request);
+    if base.decision != GateDecision::RequiresApproval {
+        return Ok(base);
+    }
+    let approval = match approval {
+        Some(a) => a,
+        None => return Ok(base), // no approval presented -> stays RequiresApproval
+    };
+
+    let risk = base.risk;
+    let deny = |reason: &str| GateEvidenceRecord {
+        decision: GateDecision::Deny,
+        reason: reason.to_string(),
+        risk,
+        approval_required: true,
+        denied_by: Some("canonical_gate".to_string()),
+    };
+
+    // (1) Digest binding: the approval must be for THIS exact action (same verb on a
+    // different resource/params yields a different digest).
+    let digest = friday_crypto::action_digest(&gate::canonical_action_bytes(request));
+    if approval.action_digest != digest {
+        return Ok(deny("canonical_approval_digest_mismatch"));
+    }
+    // (2) Explicit owner denial.
+    if approval.decision == ApprovalDecision::Denied {
+        return Ok(deny("canonical_approval_denied"));
+    }
+    // (3) Issuer + constant-time signature. Missing issuer/signature fails closed.
+    if approval.issuer.as_deref() != Some(CANONICAL_GATE_ISSUER) {
+        return Ok(deny("canonical_approval_bad_issuer"));
+    }
+    let sig = match &approval.signature {
+        Some(s) => s,
+        None => return Ok(deny("canonical_approval_signature_missing")),
+    };
+    let sig_bytes = gate::canonical_approval_signature_bytes(approval);
+    if !friday_crypto::verify_approval_signature(&sig_bytes, secret, sig) {
+        return Ok(deny("canonical_approval_signature_invalid"));
+    }
+    // (4) Expiry — an approval MUST carry one (fail-closed) and must be in the future.
+    let expires_at = match approval.expires_at {
+        Some(e) => e,
+        None => return Ok(deny("canonical_approval_expiration_required")),
+    };
+    if expires_at <= now_ms {
+        return Ok(deny("canonical_approval_expired"));
+    }
+
+    // (5) Single-use: INSERT-as-grant. We reach here ONLY after every crypto/expiry
+    // check passed, so a rejected approval never burns the key. The `use_key` PK turns
+    // a replay into a uniqueness violation — double-spend is unrepresentable, not a
+    // check-then-consume race.
+    let use_key = format!(
+        "{}:{}:{}:{}",
+        approval.approval_id,
+        approval.action_digest,
+        CANONICAL_GATE_ISSUER,
+        sig.to_ascii_lowercase()
+    );
+    let insert = conn.execute(
+        "INSERT INTO consumed_approval (use_key, approval_id, action_digest, consumed_at)
+         VALUES (?1, ?2, ?3, ?4)",
+        params![
+            use_key,
+            approval.approval_id,
+            approval.action_digest,
+            now_ms
+        ],
+    );
+    match insert {
+        Ok(_) => Ok(GateEvidenceRecord {
+            decision: GateDecision::Allow,
+            reason: "canonical_approval_granted".to_string(),
+            risk,
+            approval_required: true,
+            denied_by: None,
+        }),
+        // PRIMARY KEY collision == this exact approval was already spent.
+        Err(SqlErr::SqliteFailure(e, _)) if e.code == ErrorCode::ConstraintViolation => {
+            Ok(deny("canonical_approval_replay_refused"))
+        }
+        Err(e) => Err(StorageError::from(e)),
+    }
+}

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -10,6 +10,7 @@
 //! repositories for every domain are deferred to their owning units (gate 21 §9).
 
 pub mod audit;
+pub mod authorize;
 pub mod blob;
 mod error;
 pub mod memory;
@@ -19,6 +20,7 @@ pub mod pairing;
 mod schema;
 pub mod workflow;
 
+pub use authorize::authorize_mutating_action;
 pub use error::{Result, StorageError};
 pub use migrate::{
     apply_migrations, current_version, now_ms, Migration, MigrationFn, MigrationReport,

--- a/rust-core/crates/friday-storage/src/schema.rs
+++ b/rust-core/crates/friday-storage/src/schema.rs
@@ -18,6 +18,7 @@ pub const HUB_ONLY_TABLES: &[&str] = &[
     "memory_item",
     "workflow_run",
     "workflow_step",
+    "consumed_approval",
 ];
 
 /// Tables present only on a phone (never created on the Hub).
@@ -45,6 +46,15 @@ pub fn hub_migrations() -> Vec<Migration> {
             name: "memory_state",
             destructive: false,
             up: m0003_memory_state,
+        },
+        // PR-3b: single-use canonical-approval replay store (additive). The
+        // `use_key` PRIMARY KEY makes a replayed approval an INSERT uniqueness
+        // violation — double-spend is unrepresentable, not a check-then-consume race.
+        Migration {
+            version: 4,
+            name: "consumed_approval",
+            destructive: false,
+            up: m0004_consumed_approval,
         },
     ]
 }
@@ -259,5 +269,18 @@ fn m0003_memory_state(tx: &Transaction) -> rusqlite::Result<()> {
          UPDATE memory_item
             SET confidence = 'candidate'
             WHERE confirmed_at IS NULL AND (confidence IS NULL OR confidence = 'confirmed');",
+    )
+}
+
+fn m0004_consumed_approval(tx: &Transaction) -> rusqlite::Result<()> {
+    // `use_key` PRIMARY KEY: a single approval is spendable exactly once — a second
+    // grant attempt collides on the PK (INSERT-as-grant), so replay is unrepresentable.
+    tx.execute_batch(
+        "CREATE TABLE consumed_approval (
+            use_key       TEXT PRIMARY KEY,
+            approval_id   TEXT NOT NULL,
+            action_digest TEXT NOT NULL,
+            consumed_at   INTEGER NOT NULL
+         );",
     )
 }

--- a/rust-core/crates/friday-storage/tests/authorize_gate.rs
+++ b/rust-core/crates/friday-storage/tests/authorize_gate.rs
@@ -1,0 +1,209 @@
+//! PR-3b: canonical mutating-action authorization — crypto-bound, single-use,
+//! fail-closed. Real SQLite (the v4 `consumed_approval` replay store). Proves the
+//! ONLY path to `Allow` for a mutating action is a digest-bound, signature-valid,
+//! unexpired, unspent approval — and that double-spend / tamper / expiry all Deny.
+
+mod common;
+
+use common::temp_db_path;
+use friday_core::gate::{
+    canonical_action_bytes, canonical_approval_signature_bytes, Actor, ActorKind, ApprovalDecision,
+    CanonicalApproval, GateDecision, MutatingActionRequest, Resource, CANONICAL_GATE_ISSUER,
+};
+use friday_storage::{authorize_mutating_action, Db};
+
+const SECRET: &[u8] = b"gate-signing-secret";
+const NOW: i64 = 1_000;
+const FUTURE: i64 = 2_000;
+
+fn mutating_req() -> MutatingActionRequest {
+    MutatingActionRequest {
+        action: "delete_file".to_string(),
+        actor: Actor {
+            kind: ActorKind::Owner,
+            id: "owner-1".to_string(),
+            principal_id: Some("p1".to_string()),
+        },
+        surface: "system".to_string(),
+        mutating: true,
+        risk: None,
+        local_claims: vec![],
+        resource: Some(Resource {
+            resource_type: "file".to_string(),
+            id: Some("/data/secret.db".to_string()),
+            digest: None,
+        }),
+        parameters: None,
+        idempotency_key: Some("idem-1".to_string()),
+        plan_digest: None,
+    }
+}
+
+/// A correctly-signed, digest-bound, future-dated approval for `request`.
+fn signed_approval(request: &MutatingActionRequest, expires_at: Option<i64>) -> CanonicalApproval {
+    let digest = friday_crypto::action_digest(&canonical_action_bytes(request));
+    let mut a = CanonicalApproval {
+        decision: ApprovalDecision::Approved,
+        approval_id: "ap-1".to_string(),
+        action_digest: digest,
+        expires_at,
+        issuer: Some(CANONICAL_GATE_ISSUER.to_string()),
+        signature: None,
+    };
+    a.signature = Some(friday_crypto::sign_approval(
+        &canonical_approval_signature_bytes(&a),
+        SECRET,
+    ));
+    a
+}
+
+fn consumed_count(db: &Db) -> i64 {
+    db.conn()
+        .query_row("SELECT count(*) FROM consumed_approval", [], |r| r.get(0))
+        .unwrap()
+}
+
+#[test]
+fn valid_approval_grants_then_replay_is_refused() {
+    let db = Db::open_hub(&temp_db_path("authz-grant")).unwrap();
+    let req = mutating_req();
+    let approval = signed_approval(&req, Some(FUTURE));
+
+    // First use: granted.
+    let r = authorize_mutating_action(db.conn(), &req, Some(&approval), SECRET, NOW).unwrap();
+    assert_eq!(r.decision, GateDecision::Allow);
+    assert_eq!(r.reason, "canonical_approval_granted");
+    assert_eq!(consumed_count(&db), 1);
+
+    // Second use of the SAME approval: refused (single-use, via PK collision).
+    let r2 = authorize_mutating_action(db.conn(), &req, Some(&approval), SECRET, NOW).unwrap();
+    assert_eq!(r2.decision, GateDecision::Deny);
+    assert_eq!(r2.reason, "canonical_approval_replay_refused");
+    assert_eq!(
+        consumed_count(&db),
+        1,
+        "replay must not insert a second row"
+    );
+}
+
+#[test]
+fn no_approval_stays_requires_approval_and_does_not_touch_replay_store() {
+    let db = Db::open_hub(&temp_db_path("authz-none")).unwrap();
+    let req = mutating_req();
+    let r = authorize_mutating_action(db.conn(), &req, None, SECRET, NOW).unwrap();
+    assert_eq!(r.decision, GateDecision::RequiresApproval);
+    assert_eq!(consumed_count(&db), 0);
+}
+
+#[test]
+fn digest_mismatch_is_denied() {
+    let db = Db::open_hub(&temp_db_path("authz-digest")).unwrap();
+    let req = mutating_req();
+    let mut approval = signed_approval(&req, Some(FUTURE));
+    // Re-point the approval at a DIFFERENT action (different resource) and re-sign it
+    // so the signature is valid but the digest no longer matches `req`.
+    let mut other = mutating_req();
+    other.resource = Some(Resource {
+        resource_type: "file".to_string(),
+        id: Some("/data/OTHER.db".to_string()),
+        digest: None,
+    });
+    approval.action_digest = friday_crypto::action_digest(&canonical_action_bytes(&other));
+    approval.signature = Some(friday_crypto::sign_approval(
+        &canonical_approval_signature_bytes(&approval),
+        SECRET,
+    ));
+    let r = authorize_mutating_action(db.conn(), &req, Some(&approval), SECRET, NOW).unwrap();
+    assert_eq!(r.decision, GateDecision::Deny);
+    assert_eq!(r.reason, "canonical_approval_digest_mismatch");
+    assert_eq!(consumed_count(&db), 0);
+}
+
+#[test]
+fn bad_signature_is_denied_and_does_not_burn_the_key() {
+    let db = Db::open_hub(&temp_db_path("authz-sig")).unwrap();
+    let req = mutating_req();
+    let mut approval = signed_approval(&req, Some(FUTURE));
+    let good_sig = approval.signature.clone().unwrap();
+    // Tamper the signature (flip a hex char) -> verify fails -> Deny, NO insert.
+    approval.signature = Some(format!("0{}", &good_sig[1..]));
+    let r = authorize_mutating_action(db.conn(), &req, Some(&approval), SECRET, NOW).unwrap();
+    assert_eq!(r.decision, GateDecision::Deny);
+    assert_eq!(r.reason, "canonical_approval_signature_invalid");
+    assert_eq!(
+        consumed_count(&db),
+        0,
+        "a rejected approval must not consume a key"
+    );
+
+    // The same approval, now with its VALID signature, still grants (key not burned).
+    approval.signature = Some(good_sig);
+    let r2 = authorize_mutating_action(db.conn(), &req, Some(&approval), SECRET, NOW).unwrap();
+    assert_eq!(r2.decision, GateDecision::Allow);
+}
+
+#[test]
+fn wrong_secret_is_denied() {
+    let db = Db::open_hub(&temp_db_path("authz-secret")).unwrap();
+    let req = mutating_req();
+    let approval = signed_approval(&req, Some(FUTURE)); // signed with SECRET
+    let r =
+        authorize_mutating_action(db.conn(), &req, Some(&approval), b"WRONG-secret", NOW).unwrap();
+    assert_eq!(r.decision, GateDecision::Deny);
+    assert_eq!(r.reason, "canonical_approval_signature_invalid");
+}
+
+#[test]
+fn expired_and_missing_expiry_are_denied() {
+    let db = Db::open_hub(&temp_db_path("authz-exp")).unwrap();
+    let req = mutating_req();
+    // expires_at in the past.
+    let past = signed_approval(&req, Some(500));
+    let r = authorize_mutating_action(db.conn(), &req, Some(&past), SECRET, NOW).unwrap();
+    assert_eq!(r.decision, GateDecision::Deny);
+    assert_eq!(r.reason, "canonical_approval_expired");
+    // no expiry at all -> fail-closed.
+    let none = signed_approval(&req, None);
+    let r2 = authorize_mutating_action(db.conn(), &req, Some(&none), SECRET, NOW).unwrap();
+    assert_eq!(r2.decision, GateDecision::Deny);
+    assert_eq!(r2.reason, "canonical_approval_expiration_required");
+    assert_eq!(consumed_count(&db), 0);
+}
+
+#[test]
+fn explicit_owner_denial_is_denied() {
+    let db = Db::open_hub(&temp_db_path("authz-deny")).unwrap();
+    let req = mutating_req();
+    let mut approval = signed_approval(&req, Some(FUTURE));
+    approval.decision = ApprovalDecision::Denied;
+    approval.signature = Some(friday_crypto::sign_approval(
+        &canonical_approval_signature_bytes(&approval),
+        SECRET,
+    ));
+    let r = authorize_mutating_action(db.conn(), &req, Some(&approval), SECRET, NOW).unwrap();
+    assert_eq!(r.decision, GateDecision::Deny);
+    assert_eq!(r.reason, "canonical_approval_denied");
+}
+
+#[test]
+fn base_allow_and_base_deny_bypass_approval_and_replay_store() {
+    let db = Db::open_hub(&temp_db_path("authz-base")).unwrap();
+    // Base Allow: a non-mutating, low-risk action — approval irrelevant, table untouched.
+    let mut ro = mutating_req();
+    ro.action = "read_file".to_string();
+    ro.mutating = false;
+    let r = authorize_mutating_action(db.conn(), &ro, None, SECRET, NOW).unwrap();
+    assert_eq!(r.decision, GateDecision::Allow);
+
+    // Base Deny: an agent attempting a reserved approval action — hard Deny regardless
+    // of any presented approval; never consults the replay store.
+    let mut agent = mutating_req();
+    agent.action = "approve".to_string();
+    agent.actor.kind = ActorKind::Agent;
+    let approval = signed_approval(&agent, Some(FUTURE));
+    let r2 = authorize_mutating_action(db.conn(), &agent, Some(&approval), SECRET, NOW).unwrap();
+    assert_eq!(r2.decision, GateDecision::Deny);
+    assert_eq!(r2.reason, "agent_cannot_execute_reserved_approval_action");
+
+    assert_eq!(consumed_count(&db), 0);
+}

--- a/rust-core/crates/friday-storage/tests/memory_persist.rs
+++ b/rust-core/crates/friday-storage/tests/memory_persist.rs
@@ -61,8 +61,12 @@ fn forward_migration_v2_to_v3_backfills_confirmed_and_defaults_candidate() {
         seed_v2_memory(&db, "pending1", Some("candidate"), None);
     }
 
-    // Reopen with the full set -> forward-migrate to v3 (adds `state` + backfills).
-    let db = Db::open_hub(&p).unwrap();
+    // Reopen pinned to v3 (the migration under test) -> forward-migrate to v3 (adds
+    // `state` + backfills). Truncating keeps this test independent of later migrations
+    // (v4+), exactly like the v1->v2 workflow-persist test.
+    let mut migs3 = hub_migrations();
+    migs3.truncate(3);
+    let db = Db::open(&p, Profile::Hub, &migs3, "v3").unwrap();
     assert_eq!(db.version().unwrap(), 3);
 
     // THE discriminating assertion: the pre-existing confirmed memory was NOT
@@ -101,7 +105,9 @@ fn forward_migration_normalizes_confidence_so_no_divergent_pair_survives() {
         seed_v2_memory(&db, "stale_confirmed", Some("confirmed"), None); // not confirmed, stale 'confirmed'
         seed_v2_memory(&db, "cand_null", None, None); // not confirmed, NULL conf
     }
-    let db = Db::open_hub(&p).unwrap();
+    let mut migs3 = hub_migrations();
+    migs3.truncate(3);
+    let db = Db::open(&p, Profile::Hub, &migs3, "v3").unwrap();
     assert_eq!(db.version().unwrap(), 3);
 
     // Genuinely-confirmed rows: state AND confidence both normalized to confirmed.

--- a/rust-core/crates/friday-storage/tests/migration.rs
+++ b/rust-core/crates/friday-storage/tests/migration.rs
@@ -26,7 +26,7 @@ const FOUNDATION_HUB_TABLES: &[&str] = &[
 fn fresh_hub_db_has_all_foundation_tables() {
     let p = temp_db_path("fresh");
     let db = Db::open_hub(&p).unwrap();
-    assert_eq!(db.version().unwrap(), 3);
+    assert_eq!(db.version().unwrap(), 4);
     let tables = db.table_names().unwrap();
     for t in FOUNDATION_HUB_TABLES {
         assert!(
@@ -51,11 +51,11 @@ fn reopen_is_idempotent_and_preserves_rows() {
             "mac_live",
         )
         .unwrap();
-        assert_eq!(db.version().unwrap(), 3);
+        assert_eq!(db.version().unwrap(), 4);
     }
     // Reopening runs zero pending migrations and keeps the data.
     let db = Db::open_hub(&p).unwrap();
-    assert_eq!(db.version().unwrap(), 3);
+    assert_eq!(db.version().unwrap(), 4);
     assert_eq!(db.count("session").unwrap(), 1);
 }
 
@@ -71,7 +71,7 @@ fn refuses_to_open_when_disk_newer_than_code() {
     match Db::open_hub(&p) {
         Err(StorageError::SchemaTooNew { disk, code }) => {
             assert_eq!(disk, 999);
-            assert_eq!(code, 3);
+            assert_eq!(code, 4);
         }
         Ok(_) => panic!("expected SchemaTooNew, got Ok"),
         Err(other) => panic!("expected SchemaTooNew, got {other:?}"),
@@ -137,16 +137,16 @@ fn destructive_migration_creates_verified_backup() {
         .unwrap();
     }
 
-    // Seed is at the current hub version (v3); add a destructive v4 on top.
+    // Seed is at the current hub version (v4); add a destructive v5 on top.
     let mut migs = hub_migrations();
     migs.push(Migration {
-        version: 4,
+        version: 5,
         name: "rebuild_activity",
         destructive: true,
         up: rebuild_activity_v2,
     });
     let db = Db::open(&p, Profile::Hub, &migs, "test-destructive").unwrap();
-    assert_eq!(db.version().unwrap(), 4);
+    assert_eq!(db.version().unwrap(), 5);
 
     // New column exists post-migration.
     let has_priority: i64 = db


### PR DESCRIPTION
## What

**PR-3b of the agent-loop NO-GO repair backlog** (file `39` §2 group A; closes the **binding half of UNW-001 / cat-10**). Stacks on PR-3a (#473). Three layers, faithful to `friday-mutating-action-gate.ts`'s approval mechanics:

- **`friday-core::gate`** (pure, no crypto): extends `MutatingActionRequest` with `resource`/`parameters`/`idempotency_key`/`plan_digest` — the digest **must** bind every field that distinguishes one authorized action from another, else one approval cross-authorizes a different action. Adds `CanonicalApproval` + deterministic, length-prefixed, presence-tagged `canonical_action_bytes` / `canonical_approval_signature_bytes` (Rust-internal; `None != Some("")`).
- **`friday-crypto::approval`**: `action_digest` (SHA-256 hex), `sign_approval` / `verify_approval_signature` (HMAC-SHA256, **constant-time** via `verify_slice`, mirrors `pairing.rs`); a non-64-hex signature fails closed before the compare.
- **`friday-storage`**: `consumed_approval` replay table + additive migration **v4** (`use_key` PRIMARY KEY) + `authorize_mutating_action` composing core+crypto+replay.

## The two load-bearing security properties (advisor-directed)

1. **Digest binds the exact action.** `canonical_action_bytes` binds action/actor/surface/**resource**/mutating/risk/**parameters**/**plan_digest**/**idempotency_key** — the same verb on a different resource yields a different digest, so an approval can't cross-authorize. (`digest_mismatch` test proves it.)
2. **Single-use is atomic INSERT-as-grant**, not check-then-consume. The `use_key` PK turns a replay into a uniqueness violation → `Deny(replay_refused)`, so double-spend is **unrepresentable**, not a TOCTOU window. The consume happens strictly *after* digest+signature+expiry pass, so a rejected approval **never burns the key**.

Fail-closed edges: base `Allow`/`Deny` bypass the approval path and never touch the replay store; only `RequiresApproval` can be upgraded, and only by a digest-bound, signature-valid, unexpired, unspent approval. Approved-but-no-expiry → `Deny(expiration_required)`; bad/missing issuer or signature → `Deny`; wrong secret → `Deny`; absent approval → stays `RequiresApproval`. **Never `Allow` without a fully-validated, freshly-consumed approval.**

## Tests / gates

`friday-core` 63 (+`canonical_action_bytes` binds distinguishing fields), `friday-crypto` 22 (+digest deterministic/distinguishing; sign/verify roundtrip incl. uppercase-hex; wrong-secret/tampered/malformed fail closed), `friday-storage` `authorize_gate` 8 (grant-then-replay-refused, digest_mismatch, **bad_signature-does-not-burn-key**, wrong_secret, expired/expiration_required, owner_denial, base-Allow/Deny bypass). `cargo test --workspace` **201 / 0 / 4 ignored**; `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt --all --check` clean. (Version-pinning tests in `memory_persist`/`migration` made migration-count-robust: truncate-to-v3 / synthetic destructive → v5.)

## Honest disposition

This **wires the canonical-approval binding** — the gate is now buildable end-to-end (classify → evaluate → authorize). But it is enforced at runtime only once **PR-6 (`friday-hub`)** calls `authorize_mutating_action` before every tool dispatch. Nothing calls it yet; **zero runtime protection added**. UNW-001/cat-10 stays NO-GO until PR-6. **Overall Friday v1 remains NO-GO.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)