### PR TITLE
rust-core: agent-loop substrate — lexical pathsafe + planning gate + agent_run persistence (PR-4-pure + PR-5)

### DIFF
--- a/rust-core/crates/friday-core/src/lib.rs
+++ b/rust-core/crates/friday-core/src/lib.rs
@@ -22,6 +22,8 @@ mod identity;
 mod ledger;
 mod memory;
 mod offline;
+mod pathsafe;
+mod planning;
 mod session;
 mod tool_policy;
 mod workflow;
@@ -36,6 +38,8 @@ pub use memory::{
     MemoryState, PassportItem, PassportItemKind,
 };
 pub use offline::OfflineQueueState;
+pub use pathsafe::{contained, PathError};
+pub use planning::{classify_kind, PlanState, PlanningKind};
 pub use session::SessionState;
 pub use tool_policy::{
     contains_blocked_shell_char, contains_sensitive_assignment, contains_sensitive_material,

--- a/rust-core/crates/friday-core/src/pathsafe.rs
+++ b/rust-core/crates/friday-core/src/pathsafe.rs
@@ -93,8 +93,11 @@ fn is_within_base(base: &str, target: &str) -> bool {
 
 /// Is `path` absolute? POSIX-style leading `/` or a Windows drive/UNC root. We
 /// detect Windows roots too so a candidate like `C:\x` or `\\srv\s` is treated
-/// as absolute on every platform (matching Node's cross-platform rejection
-/// intent for untrusted input).
+/// as absolute on every platform. NOTE: this is deliberately **stricter** than the
+/// POSIX `node:path` oracle, where `isAbsolute("C:\\x")` is `false` (it would treat
+/// the drive root as a relative segment). We over-reject Windows/UNC roots in
+/// untrusted candidates — over-rejection is always safe (it can never produce an
+/// escape), and a workspace-relative path is never legitimately a drive/UNC root.
 fn is_absolute(path: &str) -> bool {
     if path.starts_with('/') || path.starts_with('\\') {
         return true;

--- a/rust-core/crates/friday-core/src/pathsafe.rs
+++ b/rust-core/crates/friday-core/src/pathsafe.rs
@@ -1,0 +1,275 @@
+//! Lexical workspace-root containment (`39` §3 / PR-4-pure).
+//!
+//! A faithful Rust port of the **lexical** checks in the TS oracle
+//! `src/utilities/friday-path-safety.ts` (`isWithinBase` + the lexical parts of
+//! `resolveSafePath`): reject an absolute candidate, reject any `..` path
+//! segment, resolve the candidate against the root, and reject if the resulting
+//! relative path escapes the root (starts with `..` or is itself absolute).
+//!
+//! Scope — this is **lexical only**. It performs NO syscalls: no `realpath`, no
+//! `openat`, no `O_NOFOLLOW`, no `lstat`. The hardened I/O half of the oracle
+//! (the `fs.realpathSync` ancestor walk and `openFileWithinRoot`) is deferred to
+//! PR-6 / friday-hub, which does not exist yet. Symlink-based escapes are
+//! therefore **out of scope** here — this is the pure lexical floor that the
+//! hardened I/O check will later sit on top of.
+//!
+//! Faithful-divergence note: the TS oracle splits path segments on **both** `/`
+//! and `\` (`relativePath.split(/[/\\]/)`) to catch Windows-style traversal even
+//! on POSIX. We mirror that — a `..` segment is rejected whether delimited by
+//! `/` or `\` — so a candidate like `a\..\b` is rejected as traversal on every
+//! platform, matching the oracle rather than relying on `std::path` (which treats
+//! `\` as an ordinary character on POSIX).
+
+/// Why a candidate path was rejected by [`contained`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PathError {
+    /// The candidate was an absolute path (the oracle's `PATH_ABSOLUTE_REJECTED`).
+    Absolute,
+    /// The candidate contained a `..` path segment (the oracle's
+    /// `PATH_TRAVERSAL_REJECTED`). Checked before containment, so a candidate
+    /// like `a/../../b` is reported as `Traversal`, not `Escape`.
+    Traversal,
+    /// The candidate resolved to a location outside the root (the oracle's
+    /// `PATH_ESCAPE_REJECTED`). With the `..`-segment rule firing first, a purely
+    /// lexical join of a `..`-free relative path cannot escape, so this guards the
+    /// remaining cases (e.g. a candidate that is itself absolute after a split).
+    Escape,
+}
+
+/// Lexically resolve `candidate` against `root`, returning the contained absolute
+/// path or a [`PathError`] explaining the rejection. Mirrors the oracle's
+/// `resolveSafePath(base, relativePath)` lexical behavior.
+///
+/// Rules (in order, matching the oracle):
+/// 1. An **absolute** candidate is rejected ([`PathError::Absolute`]).
+/// 2. Any `..` **path segment** (split on `/` or `\`) is rejected
+///    ([`PathError::Traversal`]) — *before* any containment math.
+/// 3. The candidate is joined onto the (lexically-normalized) `root`; if the
+///    lexical relative path from root to the result starts with `..` or is
+///    absolute, it is rejected ([`PathError::Escape`]).
+///
+/// On success the returned string is the lexically-resolved absolute path
+/// (`root` normalized, then `candidate` appended), with `.` and empty segments
+/// collapsed — never touching the filesystem.
+pub fn contained(root: &str, candidate: &str) -> Result<String, PathError> {
+    // 1. Reject absolute candidates (TS: `isAbsolute(relativePath)`).
+    if is_absolute(candidate) {
+        return Err(PathError::Absolute);
+    }
+
+    // 2. Reject any `..` segment, splitting on BOTH `/` and `\` (TS:
+    //    `relativePath.split(/[/\\]/).includes("..")`).
+    if split_segments(candidate).any(|seg| seg == "..") {
+        return Err(PathError::Traversal);
+    }
+
+    // 3. Resolve candidate against the root, then verify lexical containment
+    //    (TS: `resolve(resolvedBase, relativePath)` + `isWithinBase`).
+    let resolved_base = lexical_resolve_abs(root);
+    let resolved_full = lexical_join(&resolved_base, candidate);
+    if !is_within_base(&resolved_base, &resolved_full) {
+        return Err(PathError::Escape);
+    }
+
+    Ok(resolved_full)
+}
+
+/// Lexical port of the oracle's `isWithinBase(base, target)`: true iff `target`
+/// is `base` itself or lexically nested under it. Both inputs must already be
+/// absolute + lexically normalized.
+fn is_within_base(base: &str, target: &str) -> bool {
+    if target == base {
+        return true;
+    }
+    match lexical_relative(base, target) {
+        // No relative difference -> same path (TS `!rel`).
+        Some(rel) if rel.is_empty() => true,
+        // `rel` escapes if it IS `..`, STARTS WITH `../`, or is absolute.
+        Some(rel) => !(rel == ".." || rel.starts_with("../") || is_absolute(&rel)),
+        // Different roots (no relative path) -> not contained.
+        None => false,
+    }
+}
+
+/// Is `path` absolute? POSIX-style leading `/` or a Windows drive/UNC root. We
+/// detect Windows roots too so a candidate like `C:\x` or `\\srv\s` is treated
+/// as absolute on every platform (matching Node's cross-platform rejection
+/// intent for untrusted input).
+fn is_absolute(path: &str) -> bool {
+    if path.starts_with('/') || path.starts_with('\\') {
+        return true;
+    }
+    // Windows drive root: `C:\` or `C:/` (a drive letter, a colon, a separator).
+    let bytes = path.as_bytes();
+    if bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && (bytes[2] == b'/' || bytes[2] == b'\\')
+    {
+        return true;
+    }
+    false
+}
+
+/// Split a path into segments on `/` AND `\` (mirrors the oracle's
+/// `split(/[/\\]/)`). Empty and `.` segments are preserved here so the `..`
+/// check sees the raw segments exactly as the oracle does.
+fn split_segments(path: &str) -> impl Iterator<Item = &str> {
+    path.split(['/', '\\'])
+}
+
+/// Lexically normalize a (possibly relative) `root` into an absolute, slash-
+/// delimited path, collapsing `.` and empty segments. `..` is preserved as a
+/// segment so a `root` that itself contains `..` is normalized lexically (the
+/// root is trusted, so we do not reject it — only the untrusted candidate is
+/// segment-checked). A relative root is anchored at `/` (we never read the cwd —
+/// staying syscall-free; absolute results keep containment math well-defined).
+fn lexical_resolve_abs(root: &str) -> String {
+    let mut stack: Vec<&str> = Vec::new();
+    for seg in split_segments(root) {
+        match seg {
+            "" | "." => {}
+            ".." => {
+                // Pop a real parent if present; never pop below the root anchor.
+                if matches!(stack.last(), Some(&s) if s != "..") {
+                    stack.pop();
+                } else {
+                    stack.push("..");
+                }
+            }
+            other => stack.push(other),
+        }
+    }
+    // Drop any leading `..` that would climb above the anchor (root is trusted;
+    // it cannot escape itself), then render as an absolute `/`-rooted path.
+    while stack.first() == Some(&"..") {
+        stack.remove(0);
+    }
+    format!("/{}", stack.join("/"))
+}
+
+/// Lexically join an already-normalized absolute `base` with a `..`-free,
+/// non-absolute `candidate`, collapsing `.` and empty segments.
+fn lexical_join(base: &str, candidate: &str) -> String {
+    let mut stack: Vec<&str> = base.split('/').filter(|s| !s.is_empty()).collect();
+    for seg in split_segments(candidate) {
+        match seg {
+            "" | "." => {}
+            // `..` is already rejected by `contained` before we get here; collapse
+            // defensively rather than panic if ever reached directly.
+            ".." => {
+                stack.pop();
+            }
+            other => stack.push(other),
+        }
+    }
+    format!("/{}", stack.join("/"))
+}
+
+/// Lexical relative path from `from` to `to` (both absolute, `/`-delimited,
+/// normalized). Mirrors Node's `path.relative` for the cases the containment
+/// check needs: returns the `../`-prefixed relative string, an empty string for
+/// equal paths, or `None` when the two share no common root (cannot happen for
+/// two `/`-rooted paths, but kept total).
+fn lexical_relative(from: &str, to: &str) -> Option<String> {
+    let from_segs: Vec<&str> = from.split('/').filter(|s| !s.is_empty()).collect();
+    let to_segs: Vec<&str> = to.split('/').filter(|s| !s.is_empty()).collect();
+
+    let common = from_segs
+        .iter()
+        .zip(to_segs.iter())
+        .take_while(|(a, b)| a == b)
+        .count();
+
+    let up = from_segs.len() - common;
+    let mut parts: Vec<&str> = vec![".."; up];
+    parts.extend_from_slice(&to_segs[common..]);
+    Some(parts.join("/"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legitimately_contained_relative_path_is_accepted() {
+        // A plain nested relative path resolves inside the root.
+        assert_eq!(
+            contained("/ws", "skills/foo.txt"),
+            Ok("/ws/skills/foo.txt".to_string())
+        );
+        // Deeper nesting is fine.
+        assert_eq!(
+            contained("/ws/root", "a/b/c"),
+            Ok("/ws/root/a/b/c".to_string())
+        );
+    }
+
+    #[test]
+    fn absolute_candidate_is_rejected() {
+        assert_eq!(contained("/ws", "/etc/passwd"), Err(PathError::Absolute));
+        // Windows-style absolute candidates are also rejected (cross-platform).
+        assert_eq!(contained("/ws", "C:\\Windows"), Err(PathError::Absolute));
+        assert_eq!(contained("/ws", "\\\\srv\\share"), Err(PathError::Absolute));
+    }
+
+    #[test]
+    fn parent_traversal_is_rejected() {
+        // A leading `../` segment.
+        assert_eq!(contained("/ws", "../secret"), Err(PathError::Traversal));
+        // A bare `..`.
+        assert_eq!(contained("/ws", ".."), Err(PathError::Traversal));
+    }
+
+    #[test]
+    fn escape_via_embedded_traversal_is_rejected_as_traversal() {
+        // `a/../../b` escapes conceptually, but the `..`-segment rule fires FIRST
+        // (faithful to the oracle's order: traversal check precedes containment).
+        assert_eq!(contained("/ws", "a/../../b"), Err(PathError::Traversal));
+    }
+
+    #[test]
+    fn nested_traversal_segment_is_rejected() {
+        // A `..` buried mid-path is still a traversal segment.
+        assert_eq!(
+            contained("/ws", "a/b/../../../escape"),
+            Err(PathError::Traversal)
+        );
+        // Backslash-delimited traversal is caught too (oracle splits on `/` and `\`).
+        assert_eq!(contained("/ws", "a\\..\\b"), Err(PathError::Traversal));
+    }
+
+    #[test]
+    fn dot_and_empty_segments_are_handled() {
+        // `.` and empty segments collapse; the path stays contained.
+        assert_eq!(contained("/ws", "."), Ok("/ws".to_string()));
+        assert_eq!(contained("/ws", ""), Ok("/ws".to_string()));
+        assert_eq!(contained("/ws", "./a/./b"), Ok("/ws/a/b".to_string()));
+        assert_eq!(contained("/ws", "a//b"), Ok("/ws/a/b".to_string()));
+    }
+
+    #[test]
+    fn candidate_equal_to_root_is_contained() {
+        // The oracle's `isWithinBase` returns true when target == base.
+        assert_eq!(contained("/ws", "."), Ok("/ws".to_string()));
+    }
+
+    #[test]
+    fn root_is_lexically_normalized_before_join() {
+        // A root with redundant `.`/`//` segments still produces a clean contained path.
+        assert_eq!(
+            contained("/ws/./root//", "a/b"),
+            Ok("/ws/root/a/b".to_string())
+        );
+    }
+
+    #[test]
+    fn sibling_prefix_is_not_treated_as_contained() {
+        // `is_within_base` must not treat `/ws-evil` as nested under `/ws` just
+        // because of a shared string prefix. (Reached via the helper directly,
+        // since a `..`-free candidate cannot produce a sibling escape lexically.)
+        assert!(!is_within_base("/ws", "/ws-evil/x"));
+        assert!(is_within_base("/ws", "/ws/x"));
+        assert!(is_within_base("/ws", "/ws"));
+    }
+}

--- a/rust-core/crates/friday-core/src/planning.rs
+++ b/rust-core/crates/friday-core/src/planning.rs
@@ -268,6 +268,34 @@ fn word_within(lower: &str, start: usize, needle: &str, window: usize) -> Option
     None
 }
 
+/// Like [`word_within`] but yields the end index of EVERY whole-word occurrence of
+/// `needle` starting within `window` chars after `start` (not just the first). The
+/// oracle regex `A[\s\S]{0,N}B[\s\S]{0,N}C` backtracks across B positions; a
+/// first-occurrence-only scan under-detects when an earlier B's window doesn't reach
+/// a C but a later B's does. `lower` must be lowercased.
+fn word_ends_within(lower: &str, start: usize, needle: &str, window: usize) -> Vec<usize> {
+    let mut out = Vec::new();
+    if needle.is_empty() {
+        return out;
+    }
+    let bytes = lower.as_bytes();
+    let mut from = start;
+    while let Some(rel) = lower[from..].find(needle) {
+        let pos = from + rel;
+        if lower[start..pos].chars().count() > window {
+            break;
+        }
+        let end = pos + needle.len();
+        let left_ok = pos == 0 || !is_word_byte(bytes[pos - 1]);
+        let right_ok = end >= bytes.len() || !is_word_byte(bytes[end]);
+        if left_ok && right_ok {
+            out.push(end);
+        }
+        from = pos + 1;
+    }
+    out
+}
+
 /// True if some `first` phrase occurs as a whole word and some `second` phrase
 /// begins as a whole word within `window` chars after it. Faithful to the
 /// oracle's `\bA\b[\s\S]{0,N}\bB\b` co-occurrence patterns (the VAGUE_* hints,
@@ -438,10 +466,13 @@ fn matches_vague_improvement(lower: &str) -> bool {
             let left_ok = vpos == 0 || !is_word_byte(lower.as_bytes()[vpos - 1]);
             let right_ok = vend >= lower.len() || !is_word_byte(lower.as_bytes()[vend]);
             if left_ok && right_ok {
-                // For each whole-word subject within the window, look for a
-                // whole-word quality within the window after IT.
+                // For EACH whole-word subject occurrence within the window, look for
+                // a whole-word quality within the window after IT. Iterating all
+                // subject occurrences (not just the first) mirrors the oracle regex's
+                // backtracking — an earlier subject whose window misses a quality must
+                // not mask a later subject whose window reaches one.
                 for s in SUBJECTS {
-                    if let Some(send) = word_within(lower, vend, s, 80) {
+                    for send in word_ends_within(lower, vend, s, 80) {
                         if QUALITIES
                             .iter()
                             .any(|q| word_within(lower, send, q, 80).is_some())
@@ -617,6 +648,18 @@ mod tests {
             classify_kind("make Friday more production-ready and stable"),
             Some(PlanningKind::MajorDecision)
         );
+    }
+
+    #[test]
+    fn vague_improvement_backtracks_across_repeated_subjects() {
+        // Reviewer-A under-detection fix: an EARLIER subject occurrence whose
+        // 80-char quality window misses must not mask a LATER subject occurrence
+        // whose window reaches a quality (the oracle regex backtracks across B
+        // positions). Here the first "friday" is far from any quality word, but the
+        // second "friday" is immediately followed by "ready".
+        let task = "improve friday in lots of little unrelated ways here and there and \
+                    then friday should be ready";
+        assert_eq!(classify_kind(task), Some(PlanningKind::MajorDecision));
     }
 
     #[test]

--- a/rust-core/crates/friday-core/src/planning.rs
+++ b/rust-core/crates/friday-core/src/planning.rs
@@ -1,0 +1,777 @@
+//! Agent planning classification + plan state machine (`39` §2 group A / PR-5).
+//!
+//! A pure port of the **classification + state** core of the TS oracle
+//! `src/agent/runtime/friday-agent-planning-gate.ts`:
+//!
+//! - [`classify_kind`] decides which planning kind a task is, mirroring the
+//!   oracle's `detectPlanningKind` **decision order**: a destructive / high-risk
+//!   action escalates to [`PlanningKind::MajorDecision`] first, ordinary Q&A /
+//!   summarization bypasses the gate (`None`), then the kind hints are matched in
+//!   the oracle's order, with the major-decision catch-alls last.
+//! - [`PlanState`] is the awaiting-clarification → awaiting-plan-approval →
+//!   approved/rejected lifecycle, encoded with the **same** state-machine idiom
+//!   as `workflow::WorkflowRunState` (`can_transition_to` / `try_transition` /
+//!   `is_terminal`, rejecting illegal transitions with
+//!   `CoreError::InvalidTransition`).
+//!
+//! Faithful-divergence note: for the destructive/high-risk escalation the oracle
+//! uses its own `DESTRUCTIVE_ACTION_HINTS` / `DESTRUCTIVE_ACTION_CJK_HINTS`
+//! regexes. As directed (PR-5), we instead **reuse**
+//! [`crate::tool_policy::is_destructive_request`] — the already-on-main,
+//! multilingual (EN + CJK) destructive detector — rather than re-implementing a
+//! parallel regex. The two detectors are not byte-identical, but both flag the
+//! same destructive intent (delete files/repos/DBs, persist credentials, mutate
+//! GitHub/permission/repo settings); reusing the shared one avoids divergence
+//! between the gate and the tool policy.
+//!
+//! Scope note: `classify_kind(task)` is a pure function of the task text only.
+//! It ports the **entire text-only** decision order of `detectPlanningKind`:
+//! destructive-escalation → QA-bypass → the four kind hints → the three
+//! `VAGUE_*` heuristics (deliverable / improvement / strategic-plan, which are
+//! themselves pure functions of the task text) → the `MAJOR_DECISION` catch-all.
+//!
+//! Two genuinely **context-dependent** inputs of the oracle are not ported here
+//! because they need runtime state this pure core does not have: the
+//! `reviewRequired` flag (forces `major_decision`) and the caller's
+//! `operationalMode === "plan"` forcing (forces `major_decision` unless
+//! `shouldBypassForcedPlanMode`). Those live in the Hub runtime slice.
+//!
+//! One **text-only** branch is omitted by a deliberate choice rather than for
+//! context: the oracle's `isInformationalHighRiskGuidance` exemption
+//! (`INFORMATIONAL_HIGH_RISK_GUIDANCE_HINTS && !DIRECT_HIGH_RISK_ACTION_HINTS`),
+//! which lets a purely informational high-risk question ("explain how to safely
+//! delete a file") bypass the gate. We do NOT apply that exemption, so such a
+//! question OVER-escalates to `MajorDecision` here instead of `None`. This is the
+//! safe direction (over-planning an informational ask is harmless; missing a real
+//! destructive action is not); porting the gnarly `DIRECT_HIGH_RISK_ACTION_HINTS`
+//! alternation for exact parity is left to the coordinator.
+
+use crate::error::CoreError;
+use crate::tool_policy::is_destructive_request;
+
+/// The kind of planning a task requires (the oracle's `FridayPlanningKind`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PlanningKind {
+    /// Generate a new Friday skill.
+    GenerateSkill,
+    /// Generate / create a workflow, automation, or pipeline.
+    GenerateWorkflow,
+    /// Deploy / publish / ship / roll out a workflow.
+    DeployWorkflow,
+    /// Export / package a workflow into a bundle.
+    ExportBundle,
+    /// A high-stakes decision (architecture/strategy/migration/…), OR any
+    /// destructive / high-risk action that must be planned before it runs.
+    MajorDecision,
+}
+
+impl PlanningKind {
+    /// Stable string form (mirrors the oracle's union members).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            PlanningKind::GenerateSkill => "generate_skill",
+            PlanningKind::GenerateWorkflow => "generate_workflow",
+            PlanningKind::DeployWorkflow => "deploy_workflow",
+            PlanningKind::ExportBundle => "export_workflow_bundle",
+            PlanningKind::MajorDecision => "major_decision",
+        }
+    }
+}
+
+/// Classify a task into a [`PlanningKind`], or `None` if it should bypass the
+/// planning gate entirely (ordinary Q&A / summarization, or an unrecognized
+/// task). Mirrors the **text-only** decision order of the oracle's
+/// `detectPlanningKind`:
+///
+/// 1. A destructive / high-risk action escalates to [`PlanningKind::MajorDecision`]
+///    *before* anything else (so "delete all my files" plans, never silently
+///    generates). Detected via [`is_destructive_request`].
+/// 2. Ordinary Q&A / summarization requests bypass the gate (`None`).
+/// 3. The kind hints, in the oracle's order: skill → deploy → export → workflow.
+/// 4. The three `VAGUE_*` heuristics (deliverable / improvement / strategic-plan)
+///    escalate to `major_decision`.
+/// 5. The `major_decision` catch-all (architecture/strategy/migration/…).
+///
+/// Whitespace is normalized (trimmed, runs collapsed) before matching, matching
+/// the oracle's `normalizeText`.
+pub fn classify_kind(task: &str) -> Option<PlanningKind> {
+    let normalized = normalize_text(task);
+    let lower = normalized.to_ascii_lowercase();
+
+    // 1. Destructive / high-risk action -> MajorDecision (highest precedence).
+    //    DELIBERATE DIVERGENCE: the oracle exempts purely *informational* high-risk
+    //    guidance (`INFORMATIONAL_HIGH_RISK_GUIDANCE_HINTS && !DIRECT_HIGH_RISK_
+    //    ACTION_HINTS`), so "explain how to safely delete a file" returns null
+    //    there. That exemption is text-only and portable — we omit it on purpose as
+    //    a conservative OVER-escalation (over-planning an informational question is
+    //    safe; under-planning a real destructive action is not). The omitted clause
+    //    is `DIRECT_HIGH_RISK_ACTION_HINTS`, a gnarly sentence-anchored multi-
+    //    alternation; porting it for exact parity is left to the coordinator.
+    if is_destructive_request(&normalized) {
+        return Some(PlanningKind::MajorDecision);
+    }
+
+    // 2. Ordinary Q&A / summarization bypasses the gate.
+    if matches_qa_bypass(&lower) {
+        return None;
+    }
+
+    // 3. Kind hints, in the oracle's matching order.
+    if matches_generate_skill(&lower) {
+        return Some(PlanningKind::GenerateSkill);
+    }
+    if matches_deploy_workflow(&lower) {
+        return Some(PlanningKind::DeployWorkflow);
+    }
+    if matches_export_bundle(&lower) {
+        return Some(PlanningKind::ExportBundle);
+    }
+    if matches_generate_workflow(&lower) {
+        return Some(PlanningKind::GenerateWorkflow);
+    }
+
+    // 4. Vague-deliverable / vague-improvement / vague-strategic-plan asks are
+    //    text-only and escalate to MajorDecision (the gate clarifies before
+    //    building), in the oracle's order — BEFORE the major-decision hints.
+    if matches_vague_deliverable(&lower)
+        || matches_vague_improvement(&lower)
+        || matches_vague_strategic_plan(&lower)
+    {
+        return Some(PlanningKind::MajorDecision);
+    }
+
+    // 5. Major-decision catch-all.
+    if matches_major_decision(&lower) {
+        return Some(PlanningKind::MajorDecision);
+    }
+
+    None
+}
+
+/// Normalize text the way the oracle's `normalizeText` does: trim, then collapse
+/// internal whitespace runs to single spaces.
+fn normalize_text(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Does `lower` (lowercased) contain `needle` (lowercase) as a `\b`-bounded word?
+/// Word chars are `[a-z0-9_]`, mirroring the regex `\b` used throughout the
+/// oracle's hint patterns.
+fn contains_word(lower: &str, needle: &str) -> bool {
+    if needle.is_empty() {
+        return false;
+    }
+    let bytes = lower.as_bytes();
+    let nlen = needle.len();
+    let mut from = 0;
+    while let Some(rel) = lower[from..].find(needle) {
+        let pos = from + rel;
+        let before_ok = pos == 0 || !is_word_byte(bytes[pos - 1]);
+        let after_idx = pos + nlen;
+        let after_ok = after_idx >= bytes.len() || !is_word_byte(bytes[after_idx]);
+        if before_ok && after_ok {
+            return true;
+        }
+        from = pos + 1;
+    }
+    false
+}
+
+fn is_word_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
+/// True if `lower` matches `<verb> (a )?(new )?(<filler>)?<noun>` — a verb (whole
+/// word), followed by a single space and the OPTIONAL determiner sequence the
+/// oracle regexes allow, then the noun as a whole word *immediately* after.
+///
+/// This is the FAITHFUL shape of the oracle's `GENERATE_SKILL_HINTS` /
+/// `GENERATE_WORKFLOW_HINTS`: those regexes do NOT allow arbitrary text between
+/// the verb and the noun — only the literal optional tokens `a `, `new ` (and,
+/// for the skill pattern, `friday `). So "set up an automation" does NOT match
+/// the oracle (the noun is not adjacent modulo those tokens), and neither does it
+/// here. `lower` must already be lowercased and whitespace-normalized (single
+/// spaces). `fillers` is the extra optional token(s) beyond `a `/`new ` (empty
+/// for workflow; `["friday "]` for skill).
+fn verb_then_noun(lower: &str, verbs: &[&str], fillers: &[&str], nouns: &[&str]) -> bool {
+    for v in verbs {
+        let mut vfrom = 0;
+        while let Some(vrel) = lower[vfrom..].find(v) {
+            let vpos = vfrom + vrel;
+            let vend = vpos + v.len();
+            // Verb must be a whole word on its left edge.
+            let left_ok = vpos == 0 || !is_word_byte(lower.as_bytes()[vpos - 1]);
+            // And followed by a single space (the verbs are multi-word-safe, e.g.
+            // "set up"); the oracle uses a literal space between verb and the
+            // optional determiners.
+            if left_ok
+                && lower[vend..].starts_with(' ')
+                && noun_after_optionals(&lower[vend + 1..], fillers, nouns)
+            {
+                return true;
+            }
+            vfrom = vend;
+        }
+    }
+    false
+}
+
+/// Given the text right after "`<verb> `", consume the OPTIONAL determiner
+/// sequence (`a `, then `new `, then each `filler`, each at most once and in
+/// order, matching the oracle's `(?:a )?(?:new )?(?:friday )?`) and return true
+/// iff a `noun` then begins as a whole word.
+fn noun_after_optionals(rest: &str, fillers: &[&str], nouns: &[&str]) -> bool {
+    let mut rest = rest;
+    rest = rest.strip_prefix("a ").unwrap_or(rest);
+    rest = rest.strip_prefix("new ").unwrap_or(rest);
+    for f in fillers {
+        rest = rest.strip_prefix(f).unwrap_or(rest);
+    }
+    for n in nouns {
+        if let Some(after) = rest.strip_prefix(n) {
+            // Noun must end on a word boundary (so "skill" does not match inside
+            // "reskill"; the `\b` in the oracle pattern).
+            if after.is_empty() || !is_word_byte(after.as_bytes()[0]) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// True if `needle` occurs as a `\b`-bounded WHOLE WORD whose start lies within
+/// `window` chars after byte offset `start` in `lower`, returning the byte index
+/// just past that occurrence. Scans onward past in-word/out-of... matches so a
+/// first failed boundary does not mask a later valid one (a bare `find` would
+/// trade the over-match for an under-match). `lower` must be lowercased.
+fn word_within(lower: &str, start: usize, needle: &str, window: usize) -> Option<usize> {
+    if needle.is_empty() {
+        return None;
+    }
+    let bytes = lower.as_bytes();
+    let mut from = start;
+    while let Some(rel) = lower[from..].find(needle) {
+        let pos = from + rel;
+        // Out of the window (measured in CHARS, like the oracle's `{0,N}`): since
+        // matches only move further right, none later can be closer — stop.
+        if lower[start..pos].chars().count() > window {
+            return None;
+        }
+        let end = pos + needle.len();
+        let left_ok = pos == 0 || !is_word_byte(bytes[pos - 1]);
+        let right_ok = end >= bytes.len() || !is_word_byte(bytes[end]);
+        if left_ok && right_ok {
+            return Some(end);
+        }
+        from = pos + 1;
+    }
+    None
+}
+
+/// True if some `first` phrase occurs as a whole word and some `second` phrase
+/// begins as a whole word within `window` chars after it. Faithful to the
+/// oracle's `\bA\b[\s\S]{0,N}\bB\b` co-occurrence patterns (the VAGUE_* hints,
+/// which DO allow arbitrary text in the gap but require WORD boundaries on both
+/// terms — so "app" inside "happy" does not match). `lower` must be lowercased.
+fn co_occurs_within(lower: &str, firsts: &[&str], seconds: &[&str], window: usize) -> bool {
+    for a in firsts {
+        let mut afrom = 0;
+        while let Some(arel) = lower[afrom..].find(a) {
+            let apos = afrom + arel;
+            let aend = apos + a.len();
+            let left_ok = apos == 0 || !is_word_byte(lower.as_bytes()[apos - 1]);
+            let right_ok = aend >= lower.len() || !is_word_byte(lower.as_bytes()[aend]);
+            if left_ok
+                && right_ok
+                && seconds
+                    .iter()
+                    .any(|b| word_within(lower, aend, b, window).is_some())
+            {
+                return true;
+            }
+            afrom = aend;
+        }
+    }
+    false
+}
+
+// --- text-only hint matchers (faithful to the oracle's regexes) -------------
+
+/// `QA_BYPASS_HINTS`: ordinary Q&A / summarization / explanation requests.
+fn matches_qa_bypass(lower: &str) -> bool {
+    const HINTS: &[&str] = &[
+        "summarize",
+        "summarise",
+        "explain",
+        "describe",
+        "what is",
+        "tell me about",
+        "list",
+        "show",
+        "how does",
+        "how do i",
+        "how can i",
+        "what steps",
+        "guide me",
+        "walk me through",
+        "overview",
+        "translate",
+        "recap",
+        "compare",
+        "analyze",
+        "analyse",
+    ];
+    HINTS.iter().any(|h| contains_word(lower, h))
+}
+
+/// `GENERATE_SKILL_HINTS`: `(generate|create|build) (a )?(new )?(friday )?skill`
+/// or "skill generator". The verb and `skill` are adjacent modulo the optional
+/// determiners — not separated by arbitrary text.
+fn matches_generate_skill(lower: &str) -> bool {
+    if contains_word(lower, "skill generator") {
+        return true;
+    }
+    verb_then_noun(
+        lower,
+        &["generate", "create", "build"],
+        &["friday "],
+        &["skill"],
+    )
+}
+
+/// `GENERATE_WORKFLOW_HINTS`:
+/// `(generate|create|build|set up|make) (a )?(new )?(workflow|automation|pipeline)`.
+/// The noun is adjacent modulo `a `/`new ` only — "set up an automation" does NOT
+/// match (faithful to the oracle, which has no "an" alternative).
+fn matches_generate_workflow(lower: &str) -> bool {
+    verb_then_noun(
+        lower,
+        &["generate", "create", "build", "set up", "make"],
+        &[],
+        &["workflow", "automation", "pipeline"],
+    )
+}
+
+/// `DEPLOY_WORKFLOW_HINTS`: deploy/publish/ship/roll out workflow.
+fn matches_deploy_workflow(lower: &str) -> bool {
+    contains_word(lower, "deploy workflow")
+        || contains_word(lower, "publish workflow")
+        || contains_word(lower, "ship workflow")
+        || contains_word(lower, "roll out workflow")
+}
+
+/// `EXPORT_WORKFLOW_HINTS`: export workflow / workflow bundle / package workflow.
+fn matches_export_bundle(lower: &str) -> bool {
+    contains_word(lower, "export workflow")
+        || contains_word(lower, "workflow bundle")
+        || contains_word(lower, "package workflow")
+}
+
+/// `VAGUE_DELIVERABLE_HINTS`: an under-specified "build me a website/app/tool/…"
+/// request — text-only, so it escalates to MajorDecision (the gate clarifies
+/// before building). Faithful to the oracle's verb`[\s\S]{0,80}`noun co-occurrence.
+fn matches_vague_deliverable(lower: &str) -> bool {
+    const VERBS: &[&str] = &[
+        "build",
+        "create",
+        "make",
+        "design",
+        "set up",
+        "put together",
+        // The oracle's `help me (?:build|create|make|design)` alternative.
+        "help me build",
+        "help me create",
+        "help me make",
+        "help me design",
+    ];
+    const NOUNS: &[&str] = &[
+        "website",
+        "web site",
+        "site",
+        "web app",
+        "app",
+        "landing page",
+        "dashboard",
+        "tool",
+        "project",
+        "prototype",
+        "feature",
+        "product",
+    ];
+    co_occurs_within(lower, VERBS, NOUNS, 80)
+}
+
+/// `VAGUE_IMPROVEMENT_HINTS`: "make Friday/this app/the repo … better/
+/// production-ready/…" — a vague improvement ask. Text-only -> MajorDecision.
+/// Faithful to the oracle's verb`[\s\S]{0,80}`subject`[\s\S]{0,80}`quality chain.
+fn matches_vague_improvement(lower: &str) -> bool {
+    const VERBS: &[&str] = &["make", "improve", "prepare", "turn"];
+    const SUBJECTS: &[&str] = &[
+        "friday",
+        "this app",
+        "the app",
+        "this project",
+        "the project",
+        "the repo",
+        "repository",
+        "workspace",
+    ];
+    const QUALITIES: &[&str] = &[
+        "better",
+        "production-ready",
+        "production ready",
+        "usable",
+        "ready",
+        "safer",
+        "stable",
+        "polished",
+    ];
+    // verb -> subject within 80, then subject -> quality within 80 (the oracle's
+    // two `[\s\S]{0,80}` gaps). All three terms are matched as whole words via
+    // `word_within`, so an in-word coincidence (e.g. "ready" inside "already")
+    // does not satisfy the chain.
+    for v in VERBS {
+        let mut vfrom = 0;
+        while let Some(vrel) = lower[vfrom..].find(v) {
+            let vpos = vfrom + vrel;
+            let vend = vpos + v.len();
+            let left_ok = vpos == 0 || !is_word_byte(lower.as_bytes()[vpos - 1]);
+            let right_ok = vend >= lower.len() || !is_word_byte(lower.as_bytes()[vend]);
+            if left_ok && right_ok {
+                // For each whole-word subject within the window, look for a
+                // whole-word quality within the window after IT.
+                for s in SUBJECTS {
+                    if let Some(send) = word_within(lower, vend, s, 80) {
+                        if QUALITIES
+                            .iter()
+                            .any(|q| word_within(lower, send, q, 80).is_some())
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+            vfrom = vend;
+        }
+    }
+    false
+}
+
+/// `VAGUE_STRATEGIC_PLAN_HINTS`: explicit "vague request / production-ready /
+/// ask the clarification questions" phrasings. Text-only -> MajorDecision.
+fn matches_vague_strategic_plan(lower: &str) -> bool {
+    const HINTS: &[&str] = &[
+        "workflow plan",
+        "production-ready",
+        "production ready",
+        "intentionally vague",
+        "vague request",
+        "ask the missing clarification questions",
+        "wait for my answers before",
+        "wait for our answers before",
+        "wait for the answers before",
+        "wait for answers before",
+    ];
+    HINTS.iter().any(|h| contains_word(lower, h))
+}
+
+/// `MAJOR_DECISION_HINTS`: architecture / strategy / migration / roadmap / plan /
+/// refactor / overhaul / decision / tradeoff phrasings.
+fn matches_major_decision(lower: &str) -> bool {
+    const HINTS: &[&str] = &[
+        "architecture",
+        "architect",
+        "strategy",
+        "migration",
+        "roadmap",
+        "implementation plan",
+        "rollout plan",
+        "major refactor",
+        "large refactor",
+        "overhaul",
+        "choose between",
+        "decision",
+        "tradeoff",
+        "design the approach",
+    ];
+    HINTS.iter().any(|h| contains_word(lower, h))
+}
+
+/// The plan lifecycle the oracle drives through `planReview.gate.state`
+/// (`awaiting_clarification` → `awaiting_plan_approval` → `approved` /
+/// `rejected`). Encoded with the SAME state-machine idiom as
+/// `workflow::WorkflowRunState`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PlanState {
+    /// The gate is collecting clarification answers before drafting a plan.
+    AwaitingClarification,
+    /// A plan has been drafted and is awaiting the user's approve/reject.
+    AwaitingPlanApproval,
+    /// The user approved the plan — terminal (no re-decide).
+    Approved,
+    /// The user rejected the plan — terminal (no re-decide).
+    Rejected,
+}
+
+impl PlanState {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            PlanState::AwaitingClarification => "awaiting_clarification",
+            PlanState::AwaitingPlanApproval => "awaiting_plan_approval",
+            PlanState::Approved => "approved",
+            PlanState::Rejected => "rejected",
+        }
+    }
+
+    /// `Approved` and `Rejected` are terminal: a decided plan cannot be re-decided.
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, PlanState::Approved | PlanState::Rejected)
+    }
+
+    pub fn can_transition_to(&self, next: PlanState) -> bool {
+        use PlanState::*;
+        matches!(
+            (self, next),
+            (AwaitingClarification, AwaitingPlanApproval)
+                | (AwaitingPlanApproval, Approved)
+                | (AwaitingPlanApproval, Rejected)
+        )
+    }
+
+    pub fn try_transition(self, next: PlanState) -> Result<PlanState, CoreError> {
+        if self.can_transition_to(next) {
+            Ok(next)
+        } else {
+            Err(CoreError::InvalidTransition {
+                entity: "agent_plan",
+                from: self.as_str(),
+                to: next.as_str(),
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PlanState::*;
+    use super::*;
+
+    #[test]
+    fn classifies_generate_skill() {
+        assert_eq!(
+            classify_kind("Please generate a new Friday skill for me"),
+            Some(PlanningKind::GenerateSkill)
+        );
+        assert_eq!(
+            classify_kind("build a skill that triages email"),
+            Some(PlanningKind::GenerateSkill)
+        );
+    }
+
+    #[test]
+    fn classifies_generate_workflow() {
+        assert_eq!(
+            classify_kind("create a workflow that posts a daily summary"),
+            Some(PlanningKind::GenerateWorkflow)
+        );
+        // "set up [a] [new] (workflow|automation|pipeline)" — the noun is adjacent
+        // modulo the optional determiners.
+        assert_eq!(
+            classify_kind("set up a new automation for my inbox"),
+            Some(PlanningKind::GenerateWorkflow)
+        );
+        assert_eq!(
+            classify_kind("build a pipeline to sync my notes"),
+            Some(PlanningKind::GenerateWorkflow)
+        );
+    }
+
+    #[test]
+    fn generate_workflow_requires_the_noun_adjacent_to_the_verb() {
+        // Faithful to the oracle: the noun must follow the verb modulo only
+        // `a `/`new ` — "set up AN automation" does NOT match the workflow hint
+        // (no "an" alternative in the regex), and falls through to None here just
+        // as it returns null in the oracle.
+        assert_eq!(classify_kind("set up an automation for my inbox"), None);
+        // Likewise a far-apart verb/noun ("create ... a long sentence ... workflow")
+        // is not the GenerateWorkflow pattern.
+        assert_eq!(
+            classify_kind("create something today and later we can think about a workflow"),
+            None
+        );
+    }
+
+    #[test]
+    fn classifies_vague_deliverable_and_improvement_as_major_decision() {
+        // VAGUE_DELIVERABLE: an under-specified "build me a website" -> MajorDecision.
+        assert_eq!(
+            classify_kind("build me a website for my bakery"),
+            Some(PlanningKind::MajorDecision)
+        );
+        assert_eq!(
+            classify_kind("build a simple tool to track tasks"),
+            Some(PlanningKind::MajorDecision)
+        );
+        // VAGUE_IMPROVEMENT: "make Friday production-ready" -> MajorDecision.
+        assert_eq!(
+            classify_kind("make Friday more production-ready and stable"),
+            Some(PlanningKind::MajorDecision)
+        );
+    }
+
+    #[test]
+    fn vague_hints_require_whole_word_nouns_not_in_word_coincidences() {
+        // Faithful to the oracle's `\bnoun\b`: "app" inside "happy" must NOT trip
+        // VAGUE_DELIVERABLE, and "ready" inside "already" must NOT trip
+        // VAGUE_IMPROVEMENT — these are plain non-actionable sentences -> None.
+        assert_eq!(classify_kind("create a happy moment for the team"), None);
+        assert_eq!(classify_kind("we already improved the layout"), None);
+    }
+
+    #[test]
+    fn classifies_deploy_workflow() {
+        assert_eq!(
+            classify_kind("deploy workflow to production now"),
+            Some(PlanningKind::DeployWorkflow)
+        );
+        // Deploy is matched before the generic generate-workflow hint.
+        assert_eq!(
+            classify_kind("publish workflow for the team"),
+            Some(PlanningKind::DeployWorkflow)
+        );
+    }
+
+    #[test]
+    fn classifies_export_bundle() {
+        assert_eq!(
+            classify_kind("export workflow as a shareable artifact"),
+            Some(PlanningKind::ExportBundle)
+        );
+        assert_eq!(
+            classify_kind("create a workflow bundle for backup"),
+            Some(PlanningKind::ExportBundle)
+        );
+    }
+
+    #[test]
+    fn classifies_major_decision() {
+        assert_eq!(
+            classify_kind("help me choose the migration strategy for the database"),
+            Some(PlanningKind::MajorDecision)
+        );
+        // A non-QA architecture/strategy phrasing escalates to MajorDecision.
+        assert_eq!(
+            classify_kind("design the right architecture for this system"),
+            Some(PlanningKind::MajorDecision)
+        );
+    }
+
+    #[test]
+    fn qa_phrasing_wins_over_a_major_decision_hint() {
+        // Faithful to the oracle's decision ORDER: the QA-bypass check runs BEFORE
+        // the major-decision hint check, so a question that merely mentions
+        // "architecture" still bypasses the gate (it is information, not a plan).
+        assert_eq!(classify_kind("what is the right architecture here"), None);
+    }
+
+    #[test]
+    fn destructive_request_escalates_to_major_decision_english() {
+        // A destructive action escalates to MajorDecision even though it mentions
+        // no "architecture/strategy" hint — the safety floor.
+        assert_eq!(
+            classify_kind("delete all the files in my workspace"),
+            Some(PlanningKind::MajorDecision)
+        );
+        // The save-credential clause also escalates (persisting a secret is high-risk).
+        assert_eq!(
+            classify_kind("save my api key to the config file"),
+            Some(PlanningKind::MajorDecision)
+        );
+    }
+
+    #[test]
+    fn destructive_request_escalates_to_major_decision_chinese() {
+        // Multilingual: a Chinese destructive request also escalates (reusing the
+        // shared CJK-aware `is_destructive_request`).
+        // "delete all the files in my workspace" (verb 删除 precedes object 文件).
+        assert_eq!(
+            classify_kind("删除我工作区里的所有文件"),
+            Some(PlanningKind::MajorDecision)
+        );
+        // "save my key to the config file" (verb 保存 precedes object 密钥) — the
+        // CJK save-credential clause of `is_destructive_request`.
+        assert_eq!(
+            classify_kind("保存我的密钥到配置文件"),
+            Some(PlanningKind::MajorDecision)
+        );
+    }
+
+    #[test]
+    fn ordinary_qa_bypasses_the_gate() {
+        assert_eq!(classify_kind("summarize this thread for me"), None);
+        assert_eq!(classify_kind("explain how OAuth works"), None);
+        assert_eq!(classify_kind("what is the capital of France"), None);
+        // An unrecognized, non-actionable task is also None.
+        assert_eq!(classify_kind("the weather is nice today"), None);
+    }
+
+    #[test]
+    fn plan_state_legal_path_to_approved() {
+        let s = AwaitingClarification
+            .try_transition(AwaitingPlanApproval)
+            .unwrap()
+            .try_transition(Approved)
+            .unwrap();
+        assert!(s.is_terminal());
+        assert_eq!(s, Approved);
+    }
+
+    #[test]
+    fn plan_state_legal_path_to_rejected() {
+        let s = AwaitingClarification
+            .try_transition(AwaitingPlanApproval)
+            .unwrap()
+            .try_transition(Rejected)
+            .unwrap();
+        assert!(s.is_terminal());
+        assert_eq!(s, Rejected);
+    }
+
+    #[test]
+    fn plan_state_illegal_transitions_are_rejected() {
+        // Cannot skip clarification straight to approval-decision.
+        assert!(AwaitingClarification.try_transition(Approved).is_err());
+        assert!(AwaitingClarification.try_transition(Rejected).is_err());
+        // Cannot jump from clarification to clarification (no self-loop defined).
+        assert!(AwaitingClarification
+            .try_transition(AwaitingClarification)
+            .is_err());
+    }
+
+    #[test]
+    fn plan_state_terminal_cannot_be_redecided() {
+        assert!(Approved.is_terminal());
+        assert!(Rejected.is_terminal());
+        // No re-decide: a decided plan cannot transition anywhere.
+        assert!(Approved.try_transition(Rejected).is_err());
+        assert!(Rejected.try_transition(Approved).is_err());
+        assert!(Approved.try_transition(AwaitingPlanApproval).is_err());
+        assert!(Rejected.try_transition(AwaitingPlanApproval).is_err());
+        // AwaitingClarification / AwaitingPlanApproval are NOT terminal.
+        assert!(!AwaitingClarification.is_terminal());
+        assert!(!AwaitingPlanApproval.is_terminal());
+    }
+
+    #[test]
+    fn invalid_transition_error_carries_entity_and_states() {
+        let err = AwaitingClarification.try_transition(Approved).unwrap_err();
+        assert_eq!(
+            err,
+            CoreError::InvalidTransition {
+                entity: "agent_plan",
+                from: "awaiting_clarification",
+                to: "approved",
+            }
+        );
+    }
+}

--- a/rust-core/crates/friday-storage/src/agent_run.rs
+++ b/rust-core/crates/friday-storage/src/agent_run.rs
@@ -1,0 +1,97 @@
+//! Agent run + event-log persistence (PR-5; gate 21 §9). Hub-only.
+//!
+//! A thin repo over the `agent_run` + `agent_run_event` tables. The run's
+//! lifecycle is the `friday-core` [`PlanState`] machine (awaiting-clarification →
+//! awaiting-plan-approval → approved/rejected); state transitions are validated
+//! by that machine so an illegal transition is rejected, never persisted. The
+//! event log is an append-only, per-run monotonic `seq` stream (mirroring the
+//! oracle's `runEventRepository.append` seq discipline).
+
+use crate::error::{Result, StorageError};
+use friday_core::PlanState;
+use rusqlite::{params, Connection, OptionalExtension};
+
+fn parse_plan_state(s: &str) -> Option<PlanState> {
+    match s {
+        "awaiting_clarification" => Some(PlanState::AwaitingClarification),
+        "awaiting_plan_approval" => Some(PlanState::AwaitingPlanApproval),
+        "approved" => Some(PlanState::Approved),
+        "rejected" => Some(PlanState::Rejected),
+        _ => None,
+    }
+}
+
+/// Create an agent run in `AwaitingClarification` (the gate's entry state).
+pub fn create_run(conn: &Connection, run_id: &str, task: &str, created_at: i64) -> Result<()> {
+    conn.execute(
+        "INSERT INTO agent_run (run_id, task, state, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?4)",
+        params![
+            run_id,
+            task,
+            PlanState::AwaitingClarification.as_str(),
+            created_at
+        ],
+    )?;
+    Ok(())
+}
+
+/// Read a run's current [`PlanState`], or `None` if the run is unknown.
+pub fn run_state(conn: &Connection, run_id: &str) -> Result<Option<PlanState>> {
+    let s: Option<String> = conn
+        .query_row(
+            "SELECT state FROM agent_run WHERE run_id = ?1",
+            [run_id],
+            |r| r.get(0),
+        )
+        .optional()?;
+    Ok(s.and_then(|x| parse_plan_state(&x)))
+}
+
+/// Transition a run's state, validated by the `friday-core` [`PlanState`]
+/// machine. An illegal transition (e.g. clarification → approved, or any
+/// transition out of a terminal approved/rejected state) is rejected and NOT
+/// persisted — the gate's "no re-decide" invariant holds at the typed-API layer.
+pub fn set_run_state(conn: &Connection, run_id: &str, next: PlanState, now: i64) -> Result<()> {
+    let cur = run_state(conn, run_id)?
+        .ok_or_else(|| StorageError::Unsupported(format!("agent_run '{run_id}' not found")))?;
+    let next = cur.try_transition(next)?; // CoreError -> StorageError on illegal transition
+    conn.execute(
+        "UPDATE agent_run SET state = ?1, updated_at = ?2 WHERE run_id = ?3",
+        params![next.as_str(), now, run_id],
+    )?;
+    Ok(())
+}
+
+/// Append an event to a run's log with the next monotonic `seq` (1-based,
+/// per-run). Returns the assigned `seq`. The run must exist.
+pub fn record_event(
+    conn: &Connection,
+    event_id: &str,
+    run_id: &str,
+    kind: &str,
+    created_at: i64,
+) -> Result<i64> {
+    let exists: bool = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM agent_run WHERE run_id = ?1)",
+        [run_id],
+        |r| r.get(0),
+    )?;
+    if !exists {
+        return Err(StorageError::Unsupported(format!(
+            "agent_run '{run_id}' not found; cannot record event"
+        )));
+    }
+    let last_seq: i64 = conn.query_row(
+        "SELECT COALESCE(MAX(seq), 0) FROM agent_run_event WHERE run_id = ?1",
+        [run_id],
+        |r| r.get(0),
+    )?;
+    let seq = last_seq + 1;
+    conn.execute(
+        "INSERT INTO agent_run_event (event_id, run_id, seq, kind, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        params![event_id, run_id, seq, kind, created_at],
+    )?;
+    Ok(seq)
+}

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -9,6 +9,7 @@
 //! Unit 2 scope: the foundation tables + writers the first slice needs. Full
 //! repositories for every domain are deferred to their owning units (gate 21 §9).
 
+pub mod agent_run;
 pub mod audit;
 pub mod authorize;
 pub mod blob;

--- a/rust-core/crates/friday-storage/src/schema.rs
+++ b/rust-core/crates/friday-storage/src/schema.rs
@@ -243,7 +243,8 @@ CREATE TABLE agent_run_event (
     run_id     TEXT NOT NULL,
     seq        INTEGER NOT NULL,
     kind       TEXT NOT NULL,
-    created_at INTEGER NOT NULL
+    created_at INTEGER NOT NULL,
+    UNIQUE(run_id, seq)
 );
 CREATE INDEX idx_agent_run_event_run ON agent_run_event(run_id, seq);";
 

--- a/rust-core/crates/friday-storage/src/schema.rs
+++ b/rust-core/crates/friday-storage/src/schema.rs
@@ -19,6 +19,10 @@ pub const HUB_ONLY_TABLES: &[&str] = &[
     "workflow_run",
     "workflow_step",
     "consumed_approval",
+    // PR-5: agent-loop substrate. Agent runs are Hub-coordinated (gate 21 §9),
+    // so the run + its event log are Hub-only (never created on a phone).
+    "agent_run",
+    "agent_run_event",
 ];
 
 /// Tables present only on a phone (never created on the Hub).
@@ -55,6 +59,14 @@ pub fn hub_migrations() -> Vec<Migration> {
             name: "consumed_approval",
             destructive: false,
             up: m0004_consumed_approval,
+        },
+        // PR-5: agent-loop substrate (additive forward migration adding the
+        // Hub-only agent_run + agent_run_event tables). Purely additive.
+        Migration {
+            version: 5,
+            name: "agent_run",
+            destructive: false,
+            up: m0005_agent_run,
         },
     ]
 }
@@ -215,6 +227,26 @@ CREATE TABLE workflow_step (
 );
 CREATE INDEX idx_workflow_step_run ON workflow_step(run_id, seq);";
 
+// --- PR-5 agent-loop fragments (Hub-only) -----------------------------------
+
+const DDL_AGENT_RUN: &str = "
+CREATE TABLE agent_run (
+    run_id     TEXT PRIMARY KEY,
+    task       TEXT NOT NULL,
+    state      TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+);
+CREATE INDEX idx_agent_run_state ON agent_run(state, updated_at);
+CREATE TABLE agent_run_event (
+    event_id   TEXT PRIMARY KEY,
+    run_id     TEXT NOT NULL,
+    seq        INTEGER NOT NULL,
+    kind       TEXT NOT NULL,
+    created_at INTEGER NOT NULL
+);
+CREATE INDEX idx_agent_run_event_run ON agent_run_event(run_id, seq);";
+
 // --- migration bodies -------------------------------------------------------
 
 fn m0001_init_hub(tx: &Transaction) -> rusqlite::Result<()> {
@@ -283,4 +315,12 @@ fn m0004_consumed_approval(tx: &Transaction) -> rusqlite::Result<()> {
             consumed_at   INTEGER NOT NULL
          );",
     )
+}
+
+// PR-5: additive forward migration adding the Hub-only agent_run +
+// agent_run_event tables. Purely additive (CREATE TABLE only) — it touches no
+// existing table, so pre-existing rows are untouched.
+fn m0005_agent_run(tx: &Transaction) -> rusqlite::Result<()> {
+    tx.execute_batch(DDL_AGENT_RUN)?;
+    Ok(())
 }

--- a/rust-core/crates/friday-storage/tests/agent_run_persist.rs
+++ b/rust-core/crates/friday-storage/tests/agent_run_persist.rs
@@ -1,0 +1,149 @@
+//! PR-5 agent-loop substrate persistence: a REAL forward migration adds the
+//! `agent_run` + `agent_run_event` tables (preserving existing data), those
+//! tables are Hub-only (absent from the phone profile, asserted both ways), and
+//! the thin repo persists the run state machine + an append-only event log.
+//!
+//! Version note: this PR's migration is version 5 with a deliberate gap at 4
+//! (reserved by the concurrent PR-3b). To stay robust against that merge, the
+//! expected post-migration version is DERIVED from `hub_migrations()` rather than
+//! hardcoded — once PR-3b lands its version-4 migration these assertions still hold.
+
+mod common;
+
+use common::temp_db_path;
+use friday_core::{PlanState, SessionState};
+use friday_storage::{agent_run, hub_migrations, Db, Profile, HUB_ONLY_TABLES};
+
+/// The max migration version the current hub migration set reaches.
+fn hub_max_version() -> i64 {
+    hub_migrations().iter().map(|m| m.version).max().unwrap()
+}
+
+#[test]
+fn forward_migration_adds_agent_tables_preserving_data() {
+    let p = temp_db_path("agent-mig");
+    // Open at v1 only (init_hub) and seed a row that must survive the migration.
+    {
+        let mut migs = hub_migrations();
+        migs.truncate(1); // keep only 0001_init_hub
+        let db = Db::open(&p, Profile::Hub, &migs, "v1").unwrap();
+        assert_eq!(db.version().unwrap(), 1);
+        assert!(
+            !db.table_names().unwrap().iter().any(|t| t == "agent_run"),
+            "agent tables must not exist at v1"
+        );
+        db.insert_session(
+            "s1",
+            "friday_ask",
+            "hi",
+            SessionState::Created,
+            1,
+            1,
+            "mac_live",
+        )
+        .unwrap();
+    }
+    // Reopen with the full hub set -> forward-migrate up to the agent_run migration.
+    let db = Db::open_hub(&p).unwrap();
+    assert_eq!(db.version().unwrap(), hub_max_version());
+    let tables = db.table_names().unwrap();
+    assert!(
+        tables.iter().any(|t| t == "agent_run"),
+        "agent_run missing: {tables:?}"
+    );
+    assert!(
+        tables.iter().any(|t| t == "agent_run_event"),
+        "agent_run_event missing: {tables:?}"
+    );
+    // Pre-existing data survived the additive migration.
+    assert_eq!(db.count("session").unwrap(), 1);
+}
+
+#[test]
+fn agent_tables_are_hub_only_and_absent_from_phone() {
+    // Both new tables are registered Hub-only.
+    assert!(HUB_ONLY_TABLES.contains(&"agent_run"));
+    assert!(HUB_ONLY_TABLES.contains(&"agent_run_event"));
+
+    // Present on the Hub profile...
+    let hp = temp_db_path("agent-hub");
+    let hub = Db::open_hub(&hp).unwrap();
+    let htables = hub.table_names().unwrap();
+    assert!(htables.iter().any(|t| t == "agent_run"));
+    assert!(htables.iter().any(|t| t == "agent_run_event"));
+
+    // ...and ABSENT from the phone profile (the schema_profile guarantee, asserted
+    // here directly for the two new tables both ways).
+    let pp = temp_db_path("agent-phone");
+    let phone = Db::open_phone(&pp).unwrap();
+    let ptables = phone.table_names().unwrap();
+    assert!(
+        !ptables.iter().any(|t| t == "agent_run"),
+        "agent_run must not exist on a phone: {ptables:?}"
+    );
+    assert!(
+        !ptables.iter().any(|t| t == "agent_run_event"),
+        "agent_run_event must not exist on a phone: {ptables:?}"
+    );
+}
+
+#[test]
+fn run_state_machine_is_persisted_and_validated() {
+    let p = temp_db_path("agent-run");
+    let db = Db::open_hub(&p).unwrap();
+    agent_run::create_run(db.conn(), "r1", "build me a workflow", 1).unwrap();
+    assert_eq!(
+        agent_run::run_state(db.conn(), "r1").unwrap(),
+        Some(PlanState::AwaitingClarification)
+    );
+
+    // Legal path: clarification -> plan-approval -> approved (terminal).
+    agent_run::set_run_state(db.conn(), "r1", PlanState::AwaitingPlanApproval, 2).unwrap();
+    agent_run::set_run_state(db.conn(), "r1", PlanState::Approved, 3).unwrap();
+    assert_eq!(
+        agent_run::run_state(db.conn(), "r1").unwrap(),
+        Some(PlanState::Approved)
+    );
+
+    // Illegal transition (skip clarification -> approved) is rejected and NOT persisted.
+    agent_run::create_run(db.conn(), "r2", "x", 1).unwrap();
+    assert!(agent_run::set_run_state(db.conn(), "r2", PlanState::Approved, 2).is_err());
+    assert_eq!(
+        agent_run::run_state(db.conn(), "r2").unwrap(),
+        Some(PlanState::AwaitingClarification),
+        "a rejected transition must not advance the persisted state"
+    );
+
+    // Terminal state cannot be re-decided (no approved -> rejected).
+    assert!(agent_run::set_run_state(db.conn(), "r1", PlanState::Rejected, 4).is_err());
+    assert_eq!(
+        agent_run::run_state(db.conn(), "r1").unwrap(),
+        Some(PlanState::Approved)
+    );
+}
+
+#[test]
+fn event_log_is_append_only_with_monotonic_seq() {
+    let p = temp_db_path("agent-events");
+    let db = Db::open_hub(&p).unwrap();
+    agent_run::create_run(db.conn(), "r1", "task", 1).unwrap();
+
+    let s1 = agent_run::record_event(db.conn(), "e1", "r1", "run.started", 1).unwrap();
+    let s2 = agent_run::record_event(db.conn(), "e2", "r1", "run.planning", 2).unwrap();
+    let s3 = agent_run::record_event(db.conn(), "e3", "r1", "run.plan_ready", 3).unwrap();
+    assert_eq!((s1, s2, s3), (1, 2, 3), "seq must be 1-based and monotonic");
+
+    // Events are persisted in order.
+    let kinds: Vec<String> = {
+        let mut stmt = db
+            .conn()
+            .prepare("SELECT kind FROM agent_run_event WHERE run_id = 'r1' ORDER BY seq")
+            .unwrap();
+        let rows = stmt.query_map([], |r| r.get::<_, String>(0)).unwrap();
+        rows.map(|r| r.unwrap()).collect()
+    };
+    assert_eq!(kinds, vec!["run.started", "run.planning", "run.plan_ready"]);
+
+    // Recording an event for an unknown run is refused.
+    assert!(agent_run::record_event(db.conn(), "e9", "missing", "x", 9).is_err());
+}

--- a/rust-core/crates/friday-storage/tests/agent_run_persist.rs
+++ b/rust-core/crates/friday-storage/tests/agent_run_persist.rs
@@ -147,3 +147,25 @@ fn event_log_is_append_only_with_monotonic_seq() {
     // Recording an event for an unknown run is refused.
     assert!(agent_run::record_event(db.conn(), "e9", "missing", "x", 9).is_err());
 }
+
+#[test]
+fn duplicate_run_seq_is_structurally_refused() {
+    // Reviewer-B C1: the `UNIQUE(run_id, seq)` constraint makes a per-run seq
+    // collision an INSERT error rather than a silent duplicate — the same
+    // "unrepresentable, not a check-then-consume race" discipline as
+    // `consumed_approval`'s PK. A second row at the same (run_id, seq) is refused.
+    let p = temp_db_path("agent-dup-seq");
+    let db = Db::open_hub(&p).unwrap();
+    agent_run::create_run(db.conn(), "r1", "task", 1).unwrap();
+    agent_run::record_event(db.conn(), "e1", "r1", "run.started", 1).unwrap(); // seq 1
+                                                                               // A forced second row at (run_id='r1', seq=1) violates UNIQUE(run_id, seq).
+    let dup = db.conn().execute(
+        "INSERT INTO agent_run_event (event_id, run_id, seq, kind, created_at)
+         VALUES ('e_dup', 'r1', 1, 'forged', 2)",
+        [],
+    );
+    assert!(
+        dup.is_err(),
+        "a duplicate (run_id, seq) must be refused by UNIQUE"
+    );
+}

--- a/rust-core/crates/friday-storage/tests/migration.rs
+++ b/rust-core/crates/friday-storage/tests/migration.rs
@@ -9,6 +9,13 @@ use friday_core::{ActivityState, ActivityType, SessionState};
 use friday_storage::{hub_migrations, ActivityRow, Db, Migration, Profile, StorageError};
 use rusqlite::Transaction;
 
+/// The max migration version the current hub migration set reaches. Derived
+/// (not hardcoded) so these tests survive new additive migrations landing —
+/// including the concurrent PR-3b version-4 migration merging alongside PR-5's 5.
+fn hub_max_version() -> i64 {
+    hub_migrations().iter().map(|m| m.version).max().unwrap()
+}
+
 const FOUNDATION_HUB_TABLES: &[&str] = &[
     "device_identity",
     "trusted_device",
@@ -26,7 +33,7 @@ const FOUNDATION_HUB_TABLES: &[&str] = &[
 fn fresh_hub_db_has_all_foundation_tables() {
     let p = temp_db_path("fresh");
     let db = Db::open_hub(&p).unwrap();
-    assert_eq!(db.version().unwrap(), 4);
+    assert_eq!(db.version().unwrap(), hub_max_version());
     let tables = db.table_names().unwrap();
     for t in FOUNDATION_HUB_TABLES {
         assert!(
@@ -51,11 +58,11 @@ fn reopen_is_idempotent_and_preserves_rows() {
             "mac_live",
         )
         .unwrap();
-        assert_eq!(db.version().unwrap(), 4);
+        assert_eq!(db.version().unwrap(), hub_max_version());
     }
     // Reopening runs zero pending migrations and keeps the data.
     let db = Db::open_hub(&p).unwrap();
-    assert_eq!(db.version().unwrap(), 4);
+    assert_eq!(db.version().unwrap(), hub_max_version());
     assert_eq!(db.count("session").unwrap(), 1);
 }
 
@@ -71,7 +78,7 @@ fn refuses_to_open_when_disk_newer_than_code() {
     match Db::open_hub(&p) {
         Err(StorageError::SchemaTooNew { disk, code }) => {
             assert_eq!(disk, 999);
-            assert_eq!(code, 4);
+            assert_eq!(code, hub_max_version());
         }
         Ok(_) => panic!("expected SchemaTooNew, got Ok"),
         Err(other) => panic!("expected SchemaTooNew, got {other:?}"),
@@ -137,16 +144,19 @@ fn destructive_migration_creates_verified_backup() {
         .unwrap();
     }
 
-    // Seed is at the current hub version (v4); add a destructive v5 on top.
+    // Seed is at the current hub version; add a destructive migration ABOVE the
+    // current max (derived, so it always runs as the next pending version even as
+    // new additive migrations land — e.g. PR-5's v5 and PR-3b's v4).
+    let destructive_version = hub_max_version() + 1;
     let mut migs = hub_migrations();
     migs.push(Migration {
-        version: 5,
+        version: destructive_version,
         name: "rebuild_activity",
         destructive: true,
         up: rebuild_activity_v2,
     });
     let db = Db::open(&p, Profile::Hub, &migs, "test-destructive").unwrap();
-    assert_eq!(db.version().unwrap(), 5);
+    assert_eq!(db.version().unwrap(), destructive_version);
 
     // New column exists post-migration.
     let has_priority: i64 = db


### PR DESCRIPTION
## What

The batched **agent-loop substrate** — **PR-4-pure** (workspace-root lexical path safety) + **PR-5** (agent planning classification + plan state machine + `agent_run` persistence). Batched per the strategy review: they serialize on `friday-core/src/lib.rs` + `schema.rs` anyway, share one risk boundary (additive pure-core + one additive Hub migration), and amortize a CI cycle without mixing unrelated risk.

- **`friday-core::pathsafe`** (PR-4-pure): `contained(root, candidate) -> Result<String, PathError{Absolute|Traversal|Escape}>` — a faithful Rust port of the **lexical** half of the oracle's `friday-path-safety.ts` (`isWithinBase` + `resolveSafePath` lexical checks): reject absolute (incl. Windows `C:\`/UNC), reject any `..` segment (split on `/` and `\`), lexical containment. **Syscall/realpath/`O_NOFOLLOW`/TOCTOU half is deferred to PR-6** (`friday-hub` doesn't exist yet) — this is the pure lexical floor it will sit on. Symlink escapes are explicitly out of scope here.
- **`friday-core::planning`** (PR-5): `classify_kind(task) -> Option<PlanningKind>` mirroring the oracle's `detectPlanningKind` decision order (destructive→QA-bypass→skill/deploy/export/workflow→vague_*→major_decision), reusing the on-main multilingual `tool_policy::is_destructive_request` for the destructive escalation. `PlanState` (`AwaitingClarification→AwaitingPlanApproval→Approved|Rejected`) mirrors `WorkflowRunState`'s state-machine idiom exactly.
- **`friday-storage::agent_run`** (PR-5): `agent_run` + `agent_run_event` Hub-only tables (migration **v5**, additive); `create_run`/`run_state`/`set_run_state` (PlanState-validated)/`record_event` (append-only, monotonic per-run seq).

## Documented divergence (safe direction)

The oracle's `isInformationalHighRiskGuidance` exemption is **not** ported: a purely informational high-risk *question* ("explain how to delete a file") over-escalates to `MajorDecision` instead of `None`. This is the **safe** direction (over-planning a question is harmless; under-planning a real destructive action is not). Porting the gnarly `DIRECT_HIGH_RISK_ACTION_HINTS` exemption for exact parity is left to PR-6. Also deferred (need runtime state): `reviewRequired` / `operationalMode==="plan"` forcing.

## Rebase reconciliation (the strategy review's predicted collision)

Rebased onto post-#474 main: migration sequence is now contiguous **1–5** (v4 `consumed_approval` from #474 + v5 `agent_run`), `HUB_ONLY_TABLES` carries both, `migration.rs` derives `hub_max_version()` (robust to future migrations; synthetic destructive test → `max+1`), `memory_persist.rs` v2→v3 test pinned via `truncate(3)`.

## Tests / gates

`cargo test --workspace` **231 / 0 / 4 ignored** (pathsafe adverse: absolute/traversal/embedded/backslash/sibling-prefix/dot-empty; planning: each kind, in-word-coincidence rejection, QA-wins-over-major-decision order, multilingual destructive, illegal/terminal transitions; agent_run: real-SQLite persistence + Hub-only profile). `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt --all --check` clean.

## Honest disposition

Pure substrate — **nothing calls `pathsafe`/`classify_kind`/`agent_run` yet**. Completes the agent-loop substrate (PRs 3a/3b/4-pure/5); the loop **executes** only once **PR-6 (`friday-hub` runtime)** wires composition root + turn loop + `ToolExecutor` (mandatory `authorize` before every dispatch) + the deferred path-safety syscall half. **Overall Friday v1 remains NO-GO.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)