### PR TITLE
rust-core: friday-hub composition root — PR-6 tracer bullet (one composed mock-LLM turn)

### DIFF
--- a/rust-core/Cargo.lock
+++ b/rust-core/Cargo.lock
@@ -459,6 +459,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "friday-hub"
+version = "0.0.1"
+dependencies = [
+ "friday-core",
+ "friday-crypto",
+ "friday-deepseek",
+ "friday-providers",
+ "friday-storage",
+ "rusqlite",
+]
+
+[[package]]
 name = "friday-protocol"
 version = "0.0.1"
 dependencies = [

--- a/rust-core/Cargo.toml
+++ b/rust-core/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "crates/friday-storage",
     "crates/friday-deepseek",
     "crates/friday-providers",
+    "crates/friday-hub",
     "crates/friday-ffi",
     "crates/friday-arch-tests",
 ]
@@ -50,6 +51,7 @@ friday-transport = { path = "crates/friday-transport" }
 friday-storage = { path = "crates/friday-storage" }
 friday-deepseek = { path = "crates/friday-deepseek" }
 friday-providers = { path = "crates/friday-providers" }
+friday-hub = { path = "crates/friday-hub" }
 friday-ffi = { path = "crates/friday-ffi" }
 
 [profile.dev]

--- a/rust-core/crates/friday-arch-tests/tests/dep_boundary.rs
+++ b/rust-core/crates/friday-arch-tests/tests/dep_boundary.rs
@@ -109,3 +109,39 @@ fn deepseek_does_not_depend_on_ffi_either() {
         "friday-deepseek must not depend on friday-ffi; closure = {ds_closure:?}"
     );
 }
+
+#[test]
+fn hub_is_the_secret_bearing_composition_root_and_phone_is_not() {
+    // PR-6 boundary (file 52 §3 must-nail #1): the Hub runtime is where provider
+    // secrets live, so `friday-hub`'s closure INCLUDES the secret-bearing crates;
+    // `friday-ffi` (phone) must still EXCLUDE them. This is the compile-time
+    // "secrets on the Hub, never on the phone" property for the new crate.
+    let graph = internal_dep_graph(&workspace_root());
+    assert!(
+        graph.contains_key("friday-hub"),
+        "friday-hub crate not found"
+    );
+
+    let hub_closure = closure(&graph, "friday-hub");
+    for secret in ["friday-deepseek", "friday-providers"] {
+        assert!(
+            hub_closure.contains(secret),
+            "friday-hub closure must include the secret-bearing {secret}: {hub_closure:?}"
+        );
+    }
+    // The Hub composes the substrate it drives.
+    for expected in ["friday-core", "friday-crypto", "friday-storage"] {
+        assert!(
+            hub_closure.contains(expected),
+            "friday-hub closure unexpectedly missing {expected}: {hub_closure:?}"
+        );
+    }
+    // And the phone STILL cannot reach the secret crates (re-asserted with hub present).
+    let ffi_closure = closure(&graph, "friday-ffi");
+    for secret in ["friday-deepseek", "friday-providers", "friday-hub"] {
+        assert!(
+            !ffi_closure.contains(secret),
+            "PHONE SECRET LEAK: friday-ffi depends on {secret}; closure = {ffi_closure:?}"
+        );
+    }
+}

--- a/rust-core/crates/friday-arch-tests/tests/dep_boundary.rs
+++ b/rust-core/crates/friday-arch-tests/tests/dep_boundary.rs
@@ -37,11 +37,33 @@ fn internal_dep_graph(root: &Path) -> BTreeMap<String, BTreeSet<String>> {
         let value: toml::Value = toml::from_str(&text).unwrap();
         let name = value["package"]["name"].as_str().unwrap().to_string();
         let mut deps = BTreeSet::new();
+        // Collect friday-* deps from a dependency table, resolving the REAL crate
+        // name via the `package` field so a renamed dep
+        // (`x = { package = "friday-deepseek" }`) cannot evade the boundary check.
+        let mut scan = |tbl: &toml::value::Table| {
+            for (k, v) in tbl {
+                let dep_name = v
+                    .as_table()
+                    .and_then(|t| t.get("package"))
+                    .and_then(|p| p.as_str())
+                    .unwrap_or(k.as_str());
+                if dep_name.starts_with("friday-") {
+                    deps.insert(dep_name.to_string());
+                }
+            }
+        };
         for section in ["dependencies", "build-dependencies"] {
             if let Some(tbl) = value.get(section).and_then(|v| v.as_table()) {
-                for k in tbl.keys() {
-                    if k.starts_with("friday-") {
-                        deps.insert(k.clone());
+                scan(tbl);
+            }
+        }
+        // Also scan platform-specific [target.'cfg(...)'.dependencies] tables — a
+        // secret-bearing dep hidden behind a target cfg would otherwise be missed.
+        if let Some(targets) = value.get("target").and_then(|v| v.as_table()) {
+            for (_cfg, t) in targets {
+                for section in ["dependencies", "build-dependencies"] {
+                    if let Some(tbl) = t.get(section).and_then(|v| v.as_table()) {
+                        scan(tbl);
                     }
                 }
             }

--- a/rust-core/crates/friday-hub/Cargo.toml
+++ b/rust-core/crates/friday-hub/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "friday-hub"
+description = "Friday Hub runtime — composition root + agent turn loop (Hub-only). PR-6 tracer-bullet first slice: one composed turn through a mock LLM, proving the substrate seams snap together (classify -> gate -> authorize -> execute -> record). Not the runtime; not live."
+edition.workspace = true
+version.workspace = true
+license.workspace = true
+publish = false
+rust-version.workspace = true
+
+[dependencies]
+friday-core.workspace = true
+friday-crypto.workspace = true
+friday-storage.workspace = true
+# The composition layer (`authorize_mutating_action`, `agent_run`) operates on a
+# `rusqlite::Connection`, so the turn-loop signatures name it directly.
+rusqlite.workspace = true
+# Secret-bearing provider crates — the Hub is where provider secrets/credentials
+# live. Depending on them here (and NOT in friday-ffi) is the compile-time
+# "no secret on phone" boundary, asserted by friday-arch-tests.
+friday-deepseek.workspace = true
+friday-providers.workspace = true
+

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -24,10 +24,10 @@
 //! (with the deferred `pathsafe` syscall safe-open) call this on every dispatch.
 //!
 //! ## Why this crate carries the provider-secret dependency
-//! The Hub is where provider credentials live. `friday-hub` depends on the
-//! secret-bearing `friday-deepseek` / `friday-providers`; `friday-ffi` (phone) must
-//! NOT. That boundary is the compile-time "no secret on phone" property, asserted
-//! by `friday-arch-tests`.
+//! The Hub is where provider credentials live, so `friday-hub` depends on the
+//! provider crates `friday-deepseek` / `friday-providers` (which hold credentials);
+//! `friday-ffi` (phone) must NOT. That compile-time no-provider-key-on-phone
+//! boundary is asserted by `friday-arch-tests`.
 
 use friday_core::gate::{
     canonical_action_bytes, canonical_approval_signature_bytes, ActorKind, ApprovalDecision,
@@ -288,7 +288,7 @@ mod tests {
             .into_owned()
     }
 
-    const SECRET: &[u8] = b"hub-signing-secret";
+    const SECRET: &[u8] = b"hub-signing-secret"; // pragma: allowlist secret
 
     fn read_only_proposal() -> ToolCallProposal {
         ToolCallProposal {

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -127,6 +127,16 @@ pub fn canonical_params(pairs: &[(String, String)]) -> String {
 /// Build the canonical [`MutatingActionRequest`] for a proposal. Deterministic:
 /// the same proposal always yields byte-identical `canonical_action_bytes`, so an
 /// approval minted over this request matches when the turn re-builds it.
+///
+/// **SECURITY CONTRACT for the live slice (do NOT trust the model here).** This
+/// tracer copies `proposal.mutating` / `resource` / `params` straight from the
+/// (mock) proposal. That is safe ONLY because the proposal is a fixed test fixture.
+/// The gate keys `requires_approval` on `mutating`, so a live `AgentLlmClient` that
+/// set these fields from raw model output could let a destructive action self-declare
+/// `mutating=false` and bypass approval. The live `AgentLlmClient`/`ToolExecutor`
+/// MUST derive `mutating` (and the risk/resource classification) from a TRUSTED tool
+/// policy (e.g. `friday_core::tool_policy` / a per-tool mutating registry), never from
+/// model-asserted fields. This is a binding requirement on the deferred runtime slice.
 pub fn build_request(proposal: &ToolCallProposal) -> MutatingActionRequest {
     MutatingActionRequest {
         action: proposal.action.clone(),
@@ -193,10 +203,15 @@ pub struct TurnOutcome {
 /// `MutatingActionRequest` → `authorize_mutating_action` → (mock) execute on
 /// `Allow` → `record_event`. Every step is real substrate; only the model and the
 /// executor are mocked.
+// Consistent with `friday-storage`'s `add_step`: the turn driver legitimately
+// threads several distinct values; the live-loop slice may bundle them into a
+// `TurnContext`, but for the tracer an explicit signature is clearer.
+#[allow(clippy::too_many_arguments)]
 pub fn run_one_turn(
     client: &dyn AgentLlmClient,
     conn: &Connection,
     run_id: &str,
+    turn_index: u64,
     task: &str,
     secret: &[u8],
     approval: Option<&CanonicalApproval>,
@@ -205,11 +220,14 @@ pub fn run_one_turn(
     // 1. The model proposes a tool call.
     let proposal = client.propose_tool_call(task);
 
-    // 2. Plan classification, recorded as an event.
+    // 2. Plan classification, recorded as an event. event_id keys on the caller's
+    //    monotonic `turn_index` (NOT `now_ms`) so consecutive turns never PK-collide
+    //    on `agent_run_event.event_id` — this is what makes run_one_turn safely
+    //    loopable (a real loop increments turn_index per turn).
     let plan_kind = friday_core::classify_kind(task).map(|k| k.as_str());
     agent_run::record_event(
         conn,
-        &format!("{run_id}:{now_ms}:plan"),
+        &format!("{run_id}:t{turn_index}:plan"),
         run_id,
         &format!("plan.{}", plan_kind.unwrap_or("none")),
         now_ms,
@@ -235,7 +253,7 @@ pub fn run_one_turn(
     };
     agent_run::record_event(
         conn,
-        &format!("{run_id}:{now_ms}:outcome"),
+        &format!("{run_id}:t{turn_index}:outcome"),
         run_id,
         &outcome_kind,
         now_ms,
@@ -320,6 +338,7 @@ mod tests {
             &client,
             db.conn(),
             "r1",
+            0,
             "read the notes file",
             SECRET,
             None,
@@ -351,6 +370,7 @@ mod tests {
             &client,
             db.conn(),
             "r1",
+            0,
             "delete the old backup db",
             SECRET,
             None,
@@ -375,11 +395,12 @@ mod tests {
         let request = build_request(&proposal);
         let approval = mint_approval(&request, "ap-1", SECRET, 5000);
 
-        // Turn 1: approval valid + unspent -> Allow + executed.
+        // Turn 1 (turn_index 0): approval valid + unspent -> Allow + executed.
         let t1 = run_one_turn(
             &client,
             db.conn(),
             "r1",
+            0,
             "delete the old backup db",
             SECRET,
             Some(&approval),
@@ -389,11 +410,13 @@ mod tests {
         assert_eq!(t1.decision, GateDecision::Allow);
         assert!(t1.executed);
 
-        // Turn 2: same approval -> single-use replay refused (Deny), not executed.
+        // Turn 2 (turn_index 1): same approval -> single-use replay refused (Deny),
+        // not executed. Distinct turn_index keeps the event_ids collision-free.
         let t2 = run_one_turn(
             &client,
             db.conn(),
             "r1",
+            1,
             "delete the old backup db",
             SECRET,
             Some(&approval),
@@ -420,6 +443,7 @@ mod tests {
             &client,
             db.conn(),
             "r1",
+            0,
             "delete the old backup db",
             SECRET,
             Some(&forged),

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -1,0 +1,432 @@
+//! Friday Hub runtime — **composition root + agent turn loop** (file 39 §6 / file
+//! 52 PR-6). Hub-only.
+//!
+//! ## Scope: this is the PR-6 **tracer bullet**, not the runtime.
+//! Every agent-loop substrate mechanism was built and reviewed in ISOLATION
+//! (`planning::classify_kind`, `gate::evaluate`, `authorize_mutating_action`,
+//! `pathsafe::contained`, `run_is_complete`). The #1 remaining risk is therefore
+//! **composition** — whether the seams snap together. [`run_one_turn`] drives
+//! exactly ONE composed turn through a **mock** [`AgentLlmClient`] to surface every
+//! API-shape mismatch cheaply, before a full loop is built on possibly-wrong seams:
+//!
+//! ```text
+//! mock LLM proposes a tool call
+//!   -> planning::classify_kind(task)            (record a plan event)
+//!   -> build a canonical MutatingActionRequest  (deterministic parameters)
+//!   -> friday_storage::authorize_mutating_action (core gate + crypto + replay)
+//!   -> execute ONLY on Allow (mock executor)    (record the outcome event)
+//! ```
+//!
+//! **Honesty label (file 52 §6):** a mock-driven turn proves **composition**, NOT
+//! the product. There is no live model call, no real tool execution, no live
+//! DeepSeek evidence here. UNW-001/cat-10 (the enforced mutating-action gate) and
+//! the agent loop stay **NO-GO** until the live turn loop + a real `ToolExecutor`
+//! (with the deferred `pathsafe` syscall safe-open) call this on every dispatch.
+//!
+//! ## Why this crate carries the provider-secret dependency
+//! The Hub is where provider credentials live. `friday-hub` depends on the
+//! secret-bearing `friday-deepseek` / `friday-providers`; `friday-ffi` (phone) must
+//! NOT. That boundary is the compile-time "no secret on phone" property, asserted
+//! by `friday-arch-tests`.
+
+use friday_core::gate::{
+    canonical_action_bytes, canonical_approval_signature_bytes, ActorKind, ApprovalDecision,
+    CanonicalApproval, GateDecision, MutatingActionRequest, Resource, CANONICAL_GATE_ISSUER,
+};
+use friday_storage::{agent_run, authorize_mutating_action, StorageError};
+use rusqlite::Connection;
+
+// --- the LLM seam ------------------------------------------------------------
+
+/// A tool call the model proposes for a turn. (A real client parses this from a
+/// model response; the mock returns a canned one.)
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ToolCallProposal {
+    /// The tool/action name (e.g. `read_file`, `delete_file`).
+    pub action: String,
+    /// Whether the action mutates state (drives the gate's approval requirement).
+    pub mutating: bool,
+    /// The resource the action targets (bound into the action digest).
+    pub resource: Option<Resource>,
+    /// Tool parameters as key/value pairs; serialized deterministically into the
+    /// request's `parameters` (so the approval issuer and the live re-check agree).
+    pub params: Vec<(String, String)>,
+}
+
+/// The model-client seam (mirrors `friday-deepseek`'s `Transport` DI pattern). The
+/// turn loop dispatches through this so it is unit-testable with a mock; the live
+/// impl over `friday-deepseek` is the runtime-proven slice (not this tracer).
+pub trait AgentLlmClient {
+    fn propose_tool_call(&self, task: &str) -> ToolCallProposal;
+}
+
+/// A mock client that returns a fixed proposal — used by the tracer to prove the
+/// composition without a live model call.
+pub struct MockAgentLlmClient {
+    pub proposal: ToolCallProposal,
+}
+
+impl AgentLlmClient for MockAgentLlmClient {
+    fn propose_tool_call(&self, _task: &str) -> ToolCallProposal {
+        self.proposal.clone()
+    }
+}
+
+/// Real model-client adapter over `friday-deepseek` (establishes the secret-bearing
+/// dependency + is the home of the future live `AgentLlmClient` impl). The live
+/// model→tool-call parse is the runtime-proven slice; this tracer does not call it.
+pub struct DeepSeekAgentLlmClient<T: friday_deepseek::Transport> {
+    client: friday_deepseek::DeepSeekClient<T>,
+}
+
+impl<T: friday_deepseek::Transport> DeepSeekAgentLlmClient<T> {
+    pub fn new(client: friday_deepseek::DeepSeekClient<T>) -> Self {
+        Self { client }
+    }
+    /// Passthrough to the route's model discovery — the real `friday-deepseek` path
+    /// the live client will build on.
+    pub fn discover_models(&self) -> Result<Vec<String>, friday_deepseek::DeepSeekError> {
+        self.client.discover_models()
+    }
+}
+
+/// Provider auth-readiness, delegating to `friday-providers` (establishes that
+/// secret-bearing dependency on the Hub side). The Hub uses this to decide whether
+/// a provider route is usable before driving a turn through it.
+pub fn provider_auth<P: friday_providers::ProviderProbe>(
+    probe: &P,
+    provider: friday_providers::Provider,
+) -> friday_providers::ProviderAuthStatus {
+    friday_providers::detect(probe, provider)
+}
+
+// --- deterministic parameter serialization (advisor must-nail #2) ------------
+
+/// Deterministically serialize tool parameters: sort by (key, value), then
+/// length-prefix each pair so the encoding is order-independent AND unambiguous.
+/// The approval ISSUER and the live RE-CHECK must produce byte-identical
+/// `canonical_action_bytes`; routing both through this (never a `HashMap` iteration
+/// order) is what keeps an issued approval's digest matching at execution time.
+pub fn canonical_params(pairs: &[(String, String)]) -> String {
+    let mut sorted = pairs.to_vec();
+    sorted.sort();
+    let mut out = String::new();
+    for (k, v) in &sorted {
+        out.push_str(&k.len().to_string());
+        out.push(':');
+        out.push_str(k);
+        out.push('=');
+        out.push_str(&v.len().to_string());
+        out.push(':');
+        out.push_str(v);
+        out.push(';');
+    }
+    out
+}
+
+/// Build the canonical [`MutatingActionRequest`] for a proposal. Deterministic:
+/// the same proposal always yields byte-identical `canonical_action_bytes`, so an
+/// approval minted over this request matches when the turn re-builds it.
+pub fn build_request(proposal: &ToolCallProposal) -> MutatingActionRequest {
+    MutatingActionRequest {
+        action: proposal.action.clone(),
+        actor: friday_core::gate::Actor {
+            kind: ActorKind::Agent,
+            id: "hub-agent".to_string(),
+            principal_id: None,
+        },
+        surface: "agent".to_string(),
+        mutating: proposal.mutating,
+        risk: None,
+        local_claims: vec![],
+        resource: proposal.resource.clone(),
+        parameters: Some(canonical_params(&proposal.params)),
+        idempotency_key: None,
+        plan_digest: None,
+    }
+}
+
+// --- Hub-side approval minting (advisor must-nail #3, Hub side) --------------
+
+/// Mint a signed canonical approval for `request` (the Hub-side trust flow: the Hub
+/// holds the signing `secret` — in production `friday-crypto::SecureStore` — and,
+/// after the owner approves, mints the signed approval bound to THIS exact action).
+/// This tracer demonstrates the Hub signing seam; the phone-side owner-approval UX
+/// is out of scope here.
+pub fn mint_approval(
+    request: &MutatingActionRequest,
+    approval_id: &str,
+    secret: &[u8],
+    expires_at_ms: i64,
+) -> CanonicalApproval {
+    let digest = friday_crypto::action_digest(&canonical_action_bytes(request));
+    let mut approval = CanonicalApproval {
+        decision: ApprovalDecision::Approved,
+        approval_id: approval_id.to_string(),
+        action_digest: digest,
+        expires_at: Some(expires_at_ms),
+        issuer: Some(CANONICAL_GATE_ISSUER.to_string()),
+        signature: None,
+    };
+    approval.signature = Some(friday_crypto::sign_approval(
+        &canonical_approval_signature_bytes(&approval),
+        secret,
+    ));
+    approval
+}
+
+// --- the one composed turn ---------------------------------------------------
+
+/// The outcome of one composed turn.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TurnOutcome {
+    pub decision: GateDecision,
+    pub reason: String,
+    /// True iff the (mock) executor ran — i.e. the gate returned `Allow`.
+    pub executed: bool,
+    /// The planning classification of the task (`None` = the gate was bypassed).
+    pub plan_kind: Option<&'static str>,
+}
+
+/// Drive ONE composed agent turn over an existing run (`agent_run::create_run` the
+/// run first). Proves the seam chain: LLM proposal → `classify_kind` →
+/// `MutatingActionRequest` → `authorize_mutating_action` → (mock) execute on
+/// `Allow` → `record_event`. Every step is real substrate; only the model and the
+/// executor are mocked.
+pub fn run_one_turn(
+    client: &dyn AgentLlmClient,
+    conn: &Connection,
+    run_id: &str,
+    task: &str,
+    secret: &[u8],
+    approval: Option<&CanonicalApproval>,
+    now_ms: i64,
+) -> Result<TurnOutcome, StorageError> {
+    // 1. The model proposes a tool call.
+    let proposal = client.propose_tool_call(task);
+
+    // 2. Plan classification, recorded as an event.
+    let plan_kind = friday_core::classify_kind(task).map(|k| k.as_str());
+    agent_run::record_event(
+        conn,
+        &format!("{run_id}:{now_ms}:plan"),
+        run_id,
+        &format!("plan.{}", plan_kind.unwrap_or("none")),
+        now_ms,
+    )?;
+
+    // 3. Build the canonical request (deterministic, so a minted approval matches).
+    let request = build_request(&proposal);
+
+    // 4. Authorize — composes the pure gate decision, crypto digest/signature
+    //    verification, expiry, and the single-use replay store.
+    let record = authorize_mutating_action(conn, &request, approval, secret, now_ms)?;
+
+    // 5. Execute ONLY on Allow (mock executor); record the outcome either way.
+    let executed = matches!(record.decision, GateDecision::Allow);
+    let outcome_kind = if executed {
+        format!("tool.executed:{}", proposal.action)
+    } else {
+        format!(
+            "tool.blocked:{}:{}",
+            record.decision.as_str(),
+            record.reason
+        )
+    };
+    agent_run::record_event(
+        conn,
+        &format!("{run_id}:{now_ms}:outcome"),
+        run_id,
+        &outcome_kind,
+        now_ms,
+    )?;
+
+    Ok(TurnOutcome {
+        decision: record.decision,
+        reason: record.reason,
+        executed,
+        plan_kind,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use friday_storage::Db;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    fn temp_path(tag: &str) -> String {
+        // Unique across runs AND processes: a fixed name would let a prior run's
+        // leftover DB (with `r1` already created) collide on reopen — which is
+        // exactly what `cargo test --workspace` (a second process after a prior
+        // `-p` run) hit. pid + atomic counter make every path fresh.
+        let dir = std::env::temp_dir();
+        let pid = std::process::id();
+        let n = TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+        dir.join(format!("friday-hub-tracer-{pid}-{tag}-{n}.sqlite"))
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    const SECRET: &[u8] = b"hub-signing-secret";
+
+    fn read_only_proposal() -> ToolCallProposal {
+        ToolCallProposal {
+            action: "read_file".to_string(),
+            mutating: false,
+            resource: Some(Resource {
+                resource_type: "file".to_string(),
+                id: Some("notes.md".to_string()),
+                digest: None,
+            }),
+            params: vec![("path".to_string(), "notes.md".to_string())],
+        }
+    }
+
+    fn delete_proposal() -> ToolCallProposal {
+        ToolCallProposal {
+            action: "delete_file".to_string(),
+            mutating: true,
+            resource: Some(Resource {
+                resource_type: "file".to_string(),
+                id: Some("backups/old.db".to_string()),
+                digest: None,
+            }),
+            params: vec![("path".to_string(), "backups/old.db".to_string())],
+        }
+    }
+
+    #[test]
+    fn canonical_params_is_order_independent_and_unambiguous() {
+        let a = canonical_params(&[("b".into(), "2".into()), ("a".into(), "1".into())]);
+        let b = canonical_params(&[("a".into(), "1".into()), ("b".into(), "2".into())]);
+        assert_eq!(a, b, "param order must not change the canonical form");
+        // Length-prefix prevents the classic ab|c vs a|bc boundary collision.
+        let x = canonical_params(&[("ab".into(), "c".into())]);
+        let y = canonical_params(&[("a".into(), "bc".into())]);
+        assert_ne!(x, y);
+    }
+
+    #[test]
+    fn read_only_turn_is_allowed_and_executed() {
+        let db = Db::open_hub(&temp_path("ro")).unwrap();
+        agent_run::create_run(db.conn(), "r1", "read the notes file", 1).unwrap();
+        let client = MockAgentLlmClient {
+            proposal: read_only_proposal(),
+        };
+        let out = run_one_turn(
+            &client,
+            db.conn(),
+            "r1",
+            "read the notes file",
+            SECRET,
+            None,
+            1000,
+        )
+        .unwrap();
+        assert_eq!(out.decision, GateDecision::Allow);
+        assert!(out.executed);
+        // Two events recorded (plan + outcome), seq 1 and 2.
+        let n: i64 = db
+            .conn()
+            .query_row(
+                "SELECT count(*) FROM agent_run_event WHERE run_id='r1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(n, 2);
+    }
+
+    #[test]
+    fn mutating_turn_without_approval_requires_approval_and_does_not_execute() {
+        let db = Db::open_hub(&temp_path("noappr")).unwrap();
+        agent_run::create_run(db.conn(), "r1", "delete the old backup db", 1).unwrap();
+        let client = MockAgentLlmClient {
+            proposal: delete_proposal(),
+        };
+        let out = run_one_turn(
+            &client,
+            db.conn(),
+            "r1",
+            "delete the old backup db",
+            SECRET,
+            None,
+            1000,
+        )
+        .unwrap();
+        assert_eq!(out.decision, GateDecision::RequiresApproval);
+        assert!(!out.executed);
+        // The destructive task escalated to a plan (MajorDecision), recorded.
+        assert_eq!(out.plan_kind, Some("major_decision"));
+    }
+
+    #[test]
+    fn mutating_turn_with_hub_minted_approval_executes_then_replay_is_refused() {
+        let db = Db::open_hub(&temp_path("appr")).unwrap();
+        agent_run::create_run(db.conn(), "r1", "delete the old backup db", 1).unwrap();
+        let proposal = delete_proposal();
+        let client = MockAgentLlmClient {
+            proposal: proposal.clone(),
+        };
+        // Hub mints a signed approval bound to the EXACT request the turn will build.
+        let request = build_request(&proposal);
+        let approval = mint_approval(&request, "ap-1", SECRET, 5000);
+
+        // Turn 1: approval valid + unspent -> Allow + executed.
+        let t1 = run_one_turn(
+            &client,
+            db.conn(),
+            "r1",
+            "delete the old backup db",
+            SECRET,
+            Some(&approval),
+            1000,
+        )
+        .unwrap();
+        assert_eq!(t1.decision, GateDecision::Allow);
+        assert!(t1.executed);
+
+        // Turn 2: same approval -> single-use replay refused (Deny), not executed.
+        let t2 = run_one_turn(
+            &client,
+            db.conn(),
+            "r1",
+            "delete the old backup db",
+            SECRET,
+            Some(&approval),
+            2000,
+        )
+        .unwrap();
+        assert_eq!(t2.decision, GateDecision::Deny);
+        assert_eq!(t2.reason, "canonical_approval_replay_refused");
+        assert!(!t2.executed);
+    }
+
+    #[test]
+    fn forged_unsigned_approval_does_not_execute() {
+        // A mutating turn with an approval that has a matching digest but NO valid
+        // signature must NOT execute (fail-closed through the composed path).
+        let db = Db::open_hub(&temp_path("forge")).unwrap();
+        agent_run::create_run(db.conn(), "r1", "delete the old backup db", 1).unwrap();
+        let proposal = delete_proposal();
+        let request = build_request(&proposal);
+        let mut forged = mint_approval(&request, "ap-x", SECRET, 5000);
+        forged.signature = Some("0".repeat(64)); // wrong signature
+        let client = MockAgentLlmClient { proposal };
+        let out = run_one_turn(
+            &client,
+            db.conn(),
+            "r1",
+            "delete the old backup db",
+            SECRET,
+            Some(&forged),
+            1000,
+        )
+        .unwrap();
+        assert_eq!(out.decision, GateDecision::Deny);
+        assert!(!out.executed);
+    }
+}


### PR DESCRIPTION
## What

**PR-6 first slice (tracer bullet)** of the agent-loop cluster (spec: goal file `52`). The substrate (#471–#475) was built/reviewed in **isolation**; the #1 remaining risk is **composition**. This adds a new Hub-only `friday-hub` crate that drives **one composed turn through a mock LLM** to prove the seams snap together — before any full loop is built on them.

`run_one_turn`: model proposes a tool call → `friday_core::classify_kind` (record a plan event) → `build_request` (deterministic) → `friday_storage::authorize_mutating_action` (composes the pure gate + crypto digest/signature + single-use replay) → execute ONLY on `Allow` (mock executor) → `agent_run::record_event`.

Also: `canonical_params` (deterministic, order-independent, collision-free param serialization — used on both the approval-issue and live-re-check sides); `mint_approval` (Hub-side signing seam: Hub holds the secret, mints a signed approval bound to the exact request); `DeepSeekAgentLlmClient` + `provider_auth` (establish the secret-bearing `friday-deepseek`/`friday-providers` dependency on the Hub).

## The advisor's 3 must-nail items, built in

1. **Secret boundary** — new arch-test asserts `friday-hub` closure **includes** deepseek+providers and `friday-ffi` **still excludes** them (+ hub). `cargo tree`-confirmed at the resolved graph. (Arch-test also hardened to resist `package`-rename + target-dep evasion.)
2. **Deterministic params** — `canonical_params` is the single serializer used on both issue + re-check, so a minted approval's digest matches at execution.
3. **Signing seam** — `mint_approval` digests `canonical_action_bytes` and signs `canonical_approval_signature_bytes` (Hub trust flow).

## Review

Reviewer A (composition) **PASS** (resolver-confirmed closure). Reviewer B (adversarial) **CONCERNS → all 3 resolved**: trusted-`mutating` contract documented as a binding requirement on the live slice; arch-test hardened; `run_one_turn` made genuinely loopable via a monotonic `turn_index` (event_ids no longer depend on a unique wall-clock). B confirmed fully fail-closed: every `mutating=true` fail-open probe (no/expired/wrong-secret/digest-mismatch/denied/replayed/recased-sig approval) → not executed; no digest collision; no panic.

## Tests / gates

`cargo test --workspace` **239 / 0 / 4 ignored**; `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt --all --check` clean. friday-hub 5, arch-tests 3.

## Honest disposition

A mock-driven turn proves **composition, NOT the product**. No live model call, no real tool execution, no live DeepSeek evidence. The enforced mutating-action gate (UNW-001/cat-10) and the agent loop stay **NO-GO** until the live turn loop + a real `ToolExecutor` (with the deferred `pathsafe` syscall safe-open + the C2 detector widening) call this on every dispatch. **Overall Friday v1 remains NO-GO.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
