### PR TITLE
rust-core: enforce token_ledger total + non-negativity invariant at the persistence boundary (audit 10A Q3)

### DIFF
--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -342,7 +342,51 @@ fn quote_existing_table(conn: &Connection, table: &str) -> Result<String> {
 // Free fns so the same insert logic runs against either a Connection or a
 // Transaction (Transaction derefs to Connection).
 
-fn insert_token_ledger_conn(conn: &Connection, e: &LedgerEntry) -> rusqlite::Result<()> {
+fn insert_token_ledger_conn(conn: &Connection, e: &LedgerEntry) -> Result<()> {
+    // Persistence-boundary invariant (audit 10A Q3 / finding 3c): REJECT any row whose
+    // `total_tokens` is not exactly `prompt_tokens + completion_tokens`. The
+    // `LedgerEntry` constructors already recompute the total, but the struct has `pub`
+    // fields — a struct-literal / future writer could mint a divergent row. Enforcing
+    // it HERE, at the single insert chokepoint used by both `insert_token_ledger` and
+    // `record_model_call`, makes "ledger total == prompt + completion" a property no
+    // writer can bypass, regardless of how the entry was constructed. (`fallback` is a
+    // `bool`, already constrained to {0,1} by type.)
+    //
+    // Non-negativity (Reviewer audit-10A-Q3): negative token counts sum-consistently
+    // (e.g. prompt=-100, completion=50, total=-50) and would slip past a `total==sum`
+    // check while corrupting every downstream cost/usage projection. The `LedgerEntry`
+    // constructor rejects negatives; mirror that at the persistence boundary so a
+    // struct-literal writer cannot persist a sign-garbage row either.
+    if e.prompt_tokens < 0 || e.completion_tokens < 0 {
+        return Err(StorageError::Unsupported(format!(
+            "token_ledger invariant: negative token count (prompt={}, completion={})",
+            e.prompt_tokens, e.completion_tokens
+        )));
+    }
+    let expected = e
+        .prompt_tokens
+        .checked_add(e.completion_tokens)
+        .ok_or_else(|| {
+            StorageError::Unsupported(format!(
+                "token_ledger invariant: prompt+completion overflow ({} + {})",
+                e.prompt_tokens, e.completion_tokens
+            ))
+        })?;
+    if e.total_tokens != expected {
+        return Err(StorageError::Unsupported(format!(
+            "token_ledger invariant violated: total_tokens={} != prompt+completion={}",
+            e.total_tokens, expected
+        )));
+    }
+    // A negative or non-finite cost corrupts the same downstream cost projections this
+    // boundary protects (Reviewer audit-10A-Q3 follow-up). Reject it here too.
+    if let Some(cost) = e.cost_estimate {
+        if cost < 0.0 || !cost.is_finite() {
+            return Err(StorageError::Unsupported(format!(
+                "token_ledger invariant: invalid cost_estimate ({cost})"
+            )));
+        }
+    }
     conn.execute(
         "INSERT INTO token_ledger
             (ledger_id, session_id, activity_id, provider_kind, model, base_url_host,

--- a/rust-core/crates/friday-storage/tests/token_usage.rs
+++ b/rust-core/crates/friday-storage/tests/token_usage.rs
@@ -37,3 +37,99 @@ fn list_token_usage_projects_ledger_and_surfaces_fallback() {
     assert_eq!(list[0].cost_estimate, Some(0.0021));
     assert!(!list[0].fallback); // the fallback flag is surfaced, here = false
 }
+
+#[test]
+fn insert_rejects_divergent_total_at_the_persistence_boundary() {
+    // Audit 10A Q3 / finding 3c: even a STRUCT-LITERAL writer (pub fields) cannot
+    // persist a ledger row whose total != prompt+completion. The invariant is enforced
+    // at the single insert chokepoint, regardless of how the entry was constructed.
+    let p = temp_db_path("token-invariant");
+    let db = Db::open_phone(&p).unwrap();
+
+    let divergent = LedgerEntry {
+        ledger_id: "bad".into(),
+        session_id: "s1".into(),
+        activity_id: "a1".into(),
+        provider_kind: ProviderKind::DeepSeek,
+        model: "deepseek-v4-flash".into(),
+        base_url_host: "api.deepseek.com".into(),
+        prompt_tokens: 1000,
+        completion_tokens: 500,
+        total_tokens: 999_999, // LIE: not 1500
+        cost_estimate: Some(0.01),
+        fallback: false,
+        result_link: None,
+        created_at: 1,
+    };
+    let err = db.insert_token_ledger(&divergent).unwrap_err();
+    assert!(
+        format!("{err}").contains("token_ledger invariant"),
+        "divergent total must be rejected, got: {err}"
+    );
+    assert_eq!(
+        db.count("token_ledger").unwrap(),
+        0,
+        "nothing persisted on rejection"
+    );
+
+    // A correct row (total == prompt+completion) inserts fine.
+    let ok = LedgerEntry {
+        total_tokens: 1500,
+        ..divergent
+    };
+    db.insert_token_ledger(&ok).unwrap();
+    assert_eq!(db.count("token_ledger").unwrap(), 1);
+}
+
+#[test]
+fn insert_rejects_negative_token_counts() {
+    // A sign-garbage row sums consistently (prompt=-100, completion=50, total=-50) but
+    // must NOT persist — it would corrupt every cost/usage projection. The persistence
+    // boundary rejects negatives, mirroring the constructor.
+    let p = temp_db_path("token-negative");
+    let db = Db::open_phone(&p).unwrap();
+    let neg = LedgerEntry {
+        ledger_id: "neg".into(),
+        session_id: "s1".into(),
+        activity_id: "a1".into(),
+        provider_kind: ProviderKind::DeepSeek,
+        model: "deepseek-v4-flash".into(),
+        base_url_host: "api.deepseek.com".into(),
+        prompt_tokens: -100,
+        completion_tokens: 50,
+        total_tokens: -50, // internally consistent (-100 + 50), but negative
+        cost_estimate: None,
+        fallback: false,
+        result_link: None,
+        created_at: 1,
+    };
+    let err = db.insert_token_ledger(&neg).unwrap_err();
+    assert!(
+        format!("{err}").contains("negative token count"),
+        "negative tokens must be rejected, got: {err}"
+    );
+    assert_eq!(db.count("token_ledger").unwrap(), 0);
+
+    // A negative or non-finite cost is also rejected (valid counts, garbage cost).
+    let bad_cost = LedgerEntry {
+        prompt_tokens: 100,
+        completion_tokens: 50,
+        total_tokens: 150,
+        cost_estimate: Some(-1.0),
+        ..neg
+    };
+    let err = db.insert_token_ledger(&bad_cost).unwrap_err();
+    assert!(
+        format!("{err}").contains("invalid cost_estimate"),
+        "negative cost must be rejected, got: {err}"
+    );
+    let nan_cost = LedgerEntry {
+        cost_estimate: Some(f64::NAN),
+        ..bad_cost
+    };
+    assert!(
+        db.insert_token_ledger(&nan_cost).is_err(),
+        "NaN cost must be rejected"
+    );
+    assert_eq!(db.count("token_ledger").unwrap(), 0);
+}


### PR DESCRIPTION
Closes token-safety audit (file `10A`) **Q3 / finding 3c**: `LedgerEntry` has `pub` fields, so a struct-literal / future writer could persist a row whose `total_tokens != prompt+completion` or with negative counts. The constructors recompute + reject negatives, but that is constructor-enforced, not type-enforced.

## What
`insert_token_ledger_conn` (the **single insert chokepoint** used by both `insert_token_ledger` and `record_model_call`) now REJECTS, before the INSERT:
- negative `prompt_tokens`/`completion_tokens` (a sign-garbage row like `prompt=-100,completion=50,total=-50` is internally consistent but corrupts every cost/usage projection — Reviewer-found);
- `total_tokens != prompt.checked_add(completion)` (overflow also rejected).

So "ledger total == prompt+completion AND counts non-negative" is a property **no writer can bypass**, regardless of construction. (`fallback` is a `bool`, already `{0,1}`.)

## Tests
A struct-literal divergent-total entry → rejected (nothing persisted); a negative-count entry → rejected; a correct one inserts. friday-storage suite + 287 workspace green; clippy `-D warnings` / fmt clean.

## Review
Initial reviewer: PASS on the stated invariant; CONCERNS = negative-token gap → **fixed here** (non-negativity guard + test). Disjoint from #484 (friday-hub/deepseek). Option-2 security cluster. Overall Friday v1: NO-GO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)