### PR TITLE
rust-core: agent-loop minor cleanups (discovery-not-billed test, OnceLock registry, FFI no-op NIT)

### DIFF
--- a/rust-core/crates/friday-ffi/src/lib.rs
+++ b/rust-core/crates/friday-ffi/src/lib.rs
@@ -355,7 +355,9 @@ fn activity_items(db: &friday_storage::Db) -> friday_storage::Result<Vec<Activit
 
 /// Interactive WRITE path: mark an activity item `Done` in the phone's own SQLite
 /// store and return the updated list. A real persisted state change (the UI's
-/// "mark done" action), not UI-only state. Unknown ids are a no-op (still `ok`).
+/// "mark done" action), not UI-only state. An UNKNOWN id is surfaced as `ok=false`
+/// with an error — no longer a silent success (file-37 red-team NIT #4). The struct
+/// shape is unchanged, so callers that already branch on `ok` need no change.
 #[uniffi::export]
 pub fn mark_activity_done(db_path: String, activity_id: String, now: i64) -> PhoneActivityFfi {
     match mark_and_list(&db_path, &activity_id, now) {
@@ -378,7 +380,13 @@ fn mark_and_list(
     now: i64,
 ) -> friday_storage::Result<Vec<ActivityItemFfi>> {
     let db = friday_storage::Db::open_phone(db_path)?;
-    db.mark_activity_done(activity_id, now)?;
+    // Surface an unknown id instead of silently succeeding: `mark_activity_done`
+    // returns false when no row matched (file-37 NIT #4).
+    if !db.mark_activity_done(activity_id, now)? {
+        return Err(friday_storage::StorageError::NotFound(format!(
+            "activity_id {activity_id}"
+        )));
+    }
     activity_items(&db)
 }
 
@@ -588,6 +596,35 @@ mod tests {
                 .state,
             "done"
         );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn ffi_mark_unknown_activity_id_surfaces_not_found() {
+        // file-37 NIT #4: marking an id that does not exist is no longer a silent
+        // success — it surfaces ok=false + an error. (Same struct shape, so a caller
+        // that branches on `ok` needs no change.)
+        let path =
+            std::env::temp_dir().join(format!("friday-ffi-markunknown-{}.db", std::process::id()));
+        let p = path.to_string_lossy().to_string();
+        let _ = std::fs::remove_file(&path);
+
+        let seeded = phone_activity_demo(p.clone());
+        assert!(seeded.ok);
+
+        let r = mark_activity_done(p.clone(), "does-not-exist".into(), 100);
+        assert!(!r.ok, "unknown id must not silently succeed");
+        assert!(
+            r.error.contains("does-not-exist"),
+            "the error names the missing id, got {:?}",
+            r.error
+        );
+        assert!(r.items.is_empty());
+
+        // A KNOWN id still succeeds (the fix did not break the happy path).
+        let ok = mark_activity_done(p.clone(), "a3".into(), 100);
+        assert!(ok.ok && ok.error.is_empty());
 
         let _ = std::fs::remove_file(&path);
     }

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -192,10 +192,21 @@ impl<T: friday_deepseek::Transport> AgentLlmClient for DeepSeekAgentLlmClient<T>
     }
 }
 
+/// The process-wide DEFAULT (built-in) tool registry, built once and reused. The free
+/// `trusted_classify`/`build_tool_prompt` chokepoints call this on every turn; caching
+/// avoids rebuilding the `BTreeMap` + its ~10 `String`s per call (the UNW-002 reviewer
+/// perf NIT). The registry is immutable after init, so a shared `&'static` is safe; a
+/// CUSTOM registry (tool packs) is still constructed per-caller via [`ToolRegistry::default`]
+/// + [`ToolRegistry::register`].
+fn default_registry() -> &'static ToolRegistry {
+    static DEFAULT: std::sync::OnceLock<ToolRegistry> = std::sync::OnceLock::new();
+    DEFAULT.get_or_init(ToolRegistry::default)
+}
+
 /// Build the tool-call prompt for the DEFAULT (built-in) tool registry. (For a custom
 /// tool set — tool packs / skills, UNW-002 — use [`build_tool_prompt_with`].)
 pub fn build_tool_prompt(task: &str) -> String {
-    build_tool_prompt_with(task, &ToolRegistry::default())
+    build_tool_prompt_with(task, default_registry())
 }
 
 /// Build the tool-call prompt: the `registry`'s tool menu (so the advertised tools and
@@ -518,7 +529,7 @@ pub fn trusted_classify(
     action: &str,
     params: &[(String, String)],
 ) -> Result<Classified, ToolError> {
-    ToolRegistry::default().classify(action, params)
+    default_registry().classify(action, params)
 }
 
 /// Build the canonical [`MutatingActionRequest`] for a raw tool call. Deterministic:
@@ -2547,6 +2558,36 @@ mod ask_coupling_tests {
         assert!(matches!(err, RecordAskError::Route(_)), "got {err}");
         // No half-billed row / orphan activity / audit on a route failure.
         assert_eq!(db.count("token_ledger").unwrap(), 0);
+        assert_eq!(db.count("activity_item").unwrap(), 0);
+        assert_eq!(
+            friday_storage::audit::verify_audit_chain(db.conn()).unwrap(),
+            0
+        );
+    }
+
+    /// Token-safety (audit 10A): model DISCOVERY (the `GET /models` round-trip) is NOT
+    /// billed. `record_friday_ask`'s one-row test proves discovery added no row *alongside*
+    /// a chat; this isolates discovery ON ITS OWN — a `discover_models()` call with NO
+    /// chat leaves the token ledger (and the whole billing surface) empty. It is unbillable
+    /// by construction: `discover_models` takes no `&Db` and never reaches
+    /// `record_model_call`, so only an actual completion (`chat`) can ever write a row.
+    #[test]
+    fn model_discovery_get_alone_is_not_billed() {
+        let db = Db::open_hub(&tmp("discover")).unwrap();
+        let client =
+            friday_deepseek::DeepSeekClient::with_transport(MockTransport::new(false), "k".into());
+        // The GET /models round-trip happens (returns the live model id)…
+        let models = client.discover_models().unwrap();
+        assert!(
+            models.iter().any(|m| m == "deepseek-v4-flash"),
+            "discovery returned the model, so the GET really ran"
+        );
+        // …yet nothing is billed: no ledger row, no activity receipt, no audit entry.
+        assert_eq!(
+            db.count("token_ledger").unwrap(),
+            0,
+            "model discovery is a free GET — it must never write a token_ledger row"
+        );
         assert_eq!(db.count("activity_item").unwrap(), 0);
         assert_eq!(
             friday_storage::audit::verify_audit_chain(db.conn()).unwrap(),

--- a/rust-core/crates/friday-storage/src/error.rs
+++ b/rust-core/crates/friday-storage/src/error.rs
@@ -23,6 +23,11 @@ pub enum StorageError {
     #[error("unsupported for this profile: {0}")]
     Unsupported(String),
 
+    /// A write/update targeted a row that does not exist (e.g. marking an unknown
+    /// activity id). Surfaced rather than treated as a silent success.
+    #[error("not found: {0}")]
+    NotFound(String),
+
     /// Pairing proof did not authenticate the device's public key against the
     /// out-of-band QR secret (gate 21 §4.2; blocks active-MITM key substitution).
     #[error("pairing denied: invalid pairing proof for device {0}")]


### PR DESCRIPTION
## What

Three small **non-UI** cleanups (operator-selected), no behavior change to any security/gate path.

### 1. Token-safety (audit 10A) — dedicated discovery-not-billed test
`model_discovery_get_alone_is_not_billed`: a `discover_models()` `GET /models` round-trip on its own leaves the token ledger / activity / audit **empty**. The `record_friday_ask` one-row test proved discovery added no row *alongside* a chat; this isolates discovery **alone**. Unbillable by construction (`discover_models` takes no `&Db`, never reaches `record_model_call`).

### 2. UNW-002 perf NIT (reviewer follow-up) — OnceLock-cached default registry
The free `trusted_classify`/`build_tool_prompt` chokepoints called `ToolRegistry::default()` (rebuilding a `BTreeMap` + ~10 `String`s) on **every turn**. Now they share an immutable `&'static` via `OnceLock`. Custom registries (tool packs) are unaffected; `default_registry() == ToolRegistry::default()` so all classification is **byte-identical** (the UNW-001/002 trust contract is untouched).

### 3. file-37 red-team NIT #4 — surface unknown activity id (no more silent success)
The FFI `mark_and_list` discarded `mark_activity_done`'s bool, so marking a **non-existent** id returned `ok=true`. It now returns `StorageError::NotFound` → `ok=false` + error. The **UniFFI struct shape is unchanged** (callers branch on `ok` exactly as before — no shell change needed), and the happy path (known id → `ok=true`) is preserved.

## file-37 scope note (honest)

Only NIT **#4** was actionable in the non-UI lane: **#3/#5 are moot** — the referenced `rust-core/EVIDENCE-LEDGER.md` no longer exists on main (removed in a later PR; no `Users/jarvis` path or stale "51 passed" remains anywhere). **#1/#2** are iOS/UI evidence items, out of the non-UI lane and design-handoff-gated.

## Tests

friday-hub **54** (+1 discovery), friday-ffi suites (+1 unknown-id), workspace **319**, `clippy -D warnings` clean, `friday-arch-tests` green. **Overall Friday v1 remains NO-GO** — these are mechanism cleanups, not product closure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)