### PR TITLE
feat(core,ffi): Context Passport redacted projection (secret never leaves Hub)

### DIFF
--- a/rust-core/crates/friday-core/src/lib.rs
+++ b/rust-core/crates/friday-core/src/lib.rs
@@ -34,8 +34,9 @@ pub use error::CoreError;
 pub use identity::{DeviceIdentity, DeviceRole};
 pub use ledger::{LedgerEntry, ProviderKind};
 pub use memory::{
-    decide_candidate, gate_transfer, resolve_conflict, Confidence, ConflictResolution, MemoryScope,
-    MemoryState, PassportItem, PassportItemKind,
+    decide_candidate, gate_transfer, redact_passport_for_projection, resolve_conflict, Confidence,
+    ConflictResolution, MemoryScope, MemoryState, PassportItem, PassportItemKind,
+    RedactedPassportItem,
 };
 pub use offline::OfflineQueueState;
 pub use pathsafe::{contained, PathError};

--- a/rust-core/crates/friday-core/src/memory.rs
+++ b/rust-core/crates/friday-core/src/memory.rs
@@ -410,16 +410,27 @@ mod tests {
 
     #[test]
     fn redact_projection_never_leaks_secret_label_and_marks_non_transferable() {
+        // Sentinels are intentionally NOT secret-shaped (no `sk-`/`eyJ`/`API_KEY=`) so they
+        // don't trip the repo secrets-scanner — and using a non-`sk-` value makes the test
+        // STRONGER: it proves redaction is unconditional on content, not keyed to a prefix.
         let items = vec![
             item(PassportItemKind::MemorySnippet, "prefers rust", false),
             item(PassportItemKind::Summary, "weekly plan", false),
             item(
                 PassportItemKind::ProviderSecret,
-                "DEEPSEEK_API_KEY=sk-LEAK",
+                "deepseek provider material FIXTURE-PROVIDER-AAA",
                 true,
             ),
-            item(PassportItemKind::RawToken, "Bearer eyJLEAK", false),
-            item(PassportItemKind::File, "confidential.txt", true), // sensitive non-secret
+            item(
+                PassportItemKind::RawToken,
+                "phone session blob FIXTURE-TOKEN-BBB",
+                false,
+            ),
+            item(
+                PassportItemKind::File,
+                "confidential FIXTURE-FILE-CCC",
+                true,
+            ), // sensitive non-secret
         ];
         let proj = redact_passport_for_projection(&items);
 
@@ -438,19 +449,20 @@ mod tests {
         assert_eq!(proj[4].label, "[redacted: sensitive]");
         assert!(proj[4].transferable && proj[4].redacted);
 
-        // ADVERSE: the projection's labels NEVER contain the raw secret material.
+        // ADVERSE: the projection's labels NEVER contain the original redacted material.
         for r in &proj {
-            assert!(
-                !r.label.contains("sk-LEAK"),
-                "secret value leaked: {}",
-                r.label
-            );
-            assert!(!r.label.contains("eyJLEAK"), "token leaked: {}", r.label);
-            assert!(
-                !r.label.contains("DEEPSEEK_API_KEY"),
-                "secret label leaked: {}",
-                r.label
-            );
+            for leaked in [
+                "FIXTURE-PROVIDER-AAA",
+                "FIXTURE-TOKEN-BBB",
+                "FIXTURE-FILE-CCC",
+            ] {
+                assert!(
+                    !r.label.contains(leaked),
+                    "redacted material leaked: {} in {}",
+                    leaked,
+                    r.label
+                );
+            }
         }
     }
 
@@ -480,14 +492,14 @@ mod tests {
             ),
             (PassportItemKind::RawToken, "[redacted: raw token]"),
         ] {
-            let careless = vec![item(kind, "DEEPSEEK_API_KEY=sk-LEAK", false)]; // sensitive=false
+            let careless = vec![item(kind, "provider material FIXTURE-CARELESS-DDD", false)]; // sensitive=false
             let proj = redact_passport_for_projection(&careless);
             assert_eq!(proj[0].label, marker, "{kind:?} must redact by kind");
             assert!(
                 proj[0].redacted && !proj[0].transferable,
                 "{kind:?} must be redacted + non-transferable regardless of sensitive flag"
             );
-            assert!(!proj[0].label.contains("sk-LEAK"));
+            assert!(!proj[0].label.contains("FIXTURE-CARELESS-DDD"));
         }
     }
 }

--- a/rust-core/crates/friday-core/src/memory.rs
+++ b/rust-core/crates/friday-core/src/memory.rs
@@ -468,4 +468,26 @@ mod tests {
         assert!(redact_passport_for_projection(&ok)[0].transferable);
         assert!(gate_transfer(&ok, false).is_ok());
     }
+
+    #[test]
+    fn redact_by_kind_not_by_sensitive_flag_for_secrets() {
+        // The invariant that matters: a secret/token kind is redacted + non-transferable EVEN IF
+        // the caller forgot to mark it `sensitive` — redaction keys off the KIND, never the flag.
+        for (kind, marker) in [
+            (
+                PassportItemKind::ProviderSecret,
+                "[redacted: provider secret]",
+            ),
+            (PassportItemKind::RawToken, "[redacted: raw token]"),
+        ] {
+            let careless = vec![item(kind, "DEEPSEEK_API_KEY=sk-LEAK", false)]; // sensitive=false
+            let proj = redact_passport_for_projection(&careless);
+            assert_eq!(proj[0].label, marker, "{kind:?} must redact by kind");
+            assert!(
+                proj[0].redacted && !proj[0].transferable,
+                "{kind:?} must be redacted + non-transferable regardless of sensitive flag"
+            );
+            assert!(!proj[0].label.contains("sk-LEAK"));
+        }
+    }
 }

--- a/rust-core/crates/friday-core/src/memory.rs
+++ b/rust-core/crates/friday-core/src/memory.rs
@@ -182,6 +182,55 @@ pub fn gate_transfer(
     Ok(items.iter().filter(|i| i.included).collect())
 }
 
+/// A phone-safe, REDACTED projection of a Context Passport item (`07` §10). The Hub holds the
+/// real passport; this is what may be PROJECTED to the phone/UI (the "Checklist Sheet"). A
+/// never-transferable kind (`ProviderSecret`/`RawToken`) or any `sensitive` item has its `label`
+/// replaced with a generic redaction marker — the secret label/value NEVER leaves the Hub — and
+/// a never-transferable item is `transferable: false`. A reader sees THAT a secret is in context
+/// (so automation stays visible) but not WHAT it is.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RedactedPassportItem {
+    pub kind: PassportItemKind,
+    pub label: String,
+    pub included: bool,
+    pub transferable: bool,
+    pub redacted: bool,
+}
+
+fn redacted_label(kind: PassportItemKind) -> &'static str {
+    match kind {
+        PassportItemKind::ProviderSecret => "[redacted: provider secret]",
+        PassportItemKind::RawToken => "[redacted: raw token]",
+        _ => "[redacted: sensitive]",
+    }
+}
+
+/// Project passport items into their phone-safe redacted form. The redaction boundary: a
+/// never-transferable (secret/token) kind OR a `sensitive` item has its real label replaced by a
+/// generic marker (the secret never projects); `transferable` is `false` for never-transferable
+/// kinds (consistent with [`gate_transfer`]). Non-sensitive ordinary items project their real
+/// label. This is the SOLE projection used to surface the passport off the Hub.
+pub fn redact_passport_for_projection(items: &[PassportItem]) -> Vec<RedactedPassportItem> {
+    items
+        .iter()
+        .map(|it| {
+            let never = it.kind.is_never_transferable();
+            let redact = never || it.sensitive;
+            RedactedPassportItem {
+                kind: it.kind,
+                label: if redact {
+                    redacted_label(it.kind).to_string()
+                } else {
+                    it.label.clone()
+                },
+                included: it.included,
+                transferable: !never,
+                redacted: redact,
+            }
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -348,5 +397,75 @@ mod tests {
                 "{kind:?} must block even when approved=true"
             );
         }
+    }
+
+    fn item(kind: PassportItemKind, label: &str, sensitive: bool) -> PassportItem {
+        PassportItem {
+            kind,
+            label: label.to_string(),
+            included: true,
+            sensitive,
+        }
+    }
+
+    #[test]
+    fn redact_projection_never_leaks_secret_label_and_marks_non_transferable() {
+        let items = vec![
+            item(PassportItemKind::MemorySnippet, "prefers rust", false),
+            item(PassportItemKind::Summary, "weekly plan", false),
+            item(
+                PassportItemKind::ProviderSecret,
+                "DEEPSEEK_API_KEY=sk-LEAK",
+                true,
+            ),
+            item(PassportItemKind::RawToken, "Bearer eyJLEAK", false),
+            item(PassportItemKind::File, "confidential.txt", true), // sensitive non-secret
+        ];
+        let proj = redact_passport_for_projection(&items);
+
+        // ordinary non-sensitive items project their REAL label, transferable, not redacted.
+        assert_eq!(proj[0].label, "prefers rust");
+        assert!(proj[0].transferable && !proj[0].redacted);
+        assert_eq!(proj[1].label, "weekly plan");
+
+        // never-transferable kinds: label redacted + transferable=false + redacted=true.
+        assert_eq!(proj[2].label, "[redacted: provider secret]");
+        assert!(!proj[2].transferable && proj[2].redacted);
+        assert_eq!(proj[3].label, "[redacted: raw token]");
+        assert!(!proj[3].transferable && proj[3].redacted);
+
+        // sensitive non-secret: label redacted + redacted=true, but still transferable (w/ approval).
+        assert_eq!(proj[4].label, "[redacted: sensitive]");
+        assert!(proj[4].transferable && proj[4].redacted);
+
+        // ADVERSE: the projection's labels NEVER contain the raw secret material.
+        for r in &proj {
+            assert!(
+                !r.label.contains("sk-LEAK"),
+                "secret value leaked: {}",
+                r.label
+            );
+            assert!(!r.label.contains("eyJLEAK"), "token leaked: {}", r.label);
+            assert!(
+                !r.label.contains("DEEPSEEK_API_KEY"),
+                "secret label leaked: {}",
+                r.label
+            );
+        }
+    }
+
+    #[test]
+    fn redact_projection_transferable_matches_gate_transfer() {
+        // a never-transferable kind is non-transferable in BOTH the projection and gate_transfer.
+        let secret = vec![item(PassportItemKind::ProviderSecret, "k", true)];
+        assert!(!redact_passport_for_projection(&secret)[0].transferable);
+        assert!(matches!(
+            gate_transfer(&secret, true),
+            Err(CoreError::BlockedTransfer(_))
+        ));
+        // an ordinary item is transferable in both.
+        let ok = vec![item(PassportItemKind::MemorySnippet, "x", false)];
+        assert!(redact_passport_for_projection(&ok)[0].transferable);
+        assert!(gate_transfer(&ok, false).is_ok());
     }
 }

--- a/rust-core/crates/friday-ffi/src/lib.rs
+++ b/rust-core/crates/friday-ffi/src/lib.rs
@@ -279,7 +279,7 @@ fn passport_kind_str(kind: friday_core::PassportItemKind) -> String {
         K::File => "file",
         K::Screenshot => "screenshot",
         K::Attachment => "attachment",
-        K::ProviderSecret => "provider_secret",
+        K::ProviderSecret => "provider_secret", // pragma: allowlist secret (kind tag, not a secret)
         K::RawToken => "raw_token",
     }
     .to_string()
@@ -312,16 +312,18 @@ pub fn sample_context_passport() -> Vec<PassportItemFfi> {
             false,
         ),
         mk(PassportItemKind::File, "design-notes.md", true, false),
-        // a secret in context: projected redacted + non-transferable (value never leaves the Hub)
+        // a secret in context: projected redacted + non-transferable (value never leaves the Hub).
+        // Fixture values are intentionally NOT secret-shaped (no `sk-`/`eyJ`/`API_KEY=`) so the
+        // repo secrets-scanner stays clean; redaction is by KIND, so the value is irrelevant.
         mk(
             PassportItemKind::ProviderSecret,
-            "DEEPSEEK_API_KEY=sk-SECRETVALUE",
+            "deepseek provider material FIXTURE-PROVIDER-VALUE",
             true,
             true,
         ),
         mk(
             PassportItemKind::RawToken,
-            "Bearer eyJSECRETTOKEN",
+            "phone session blob FIXTURE-TOKEN-VALUE",
             false,
             true,
         ),
@@ -836,23 +838,16 @@ mod tests {
         let mem = proj.iter().find(|i| i.kind == "memory_snippet").unwrap();
         assert_eq!(mem.label, "Prefers Rust for new services");
         assert!(mem.transferable && !mem.redacted);
-        // ADVERSE: the secret VALUE/token never appears anywhere in the projected labels.
+        // ADVERSE: the secret/token VALUE never appears anywhere in the projected labels.
         for i in &proj {
-            assert!(
-                !i.label.contains("sk-SECRETVALUE"),
-                "secret leaked: {}",
-                i.label
-            );
-            assert!(
-                !i.label.contains("eyJSECRETTOKEN"),
-                "token leaked: {}",
-                i.label
-            );
-            assert!(
-                !i.label.contains("DEEPSEEK_API_KEY"),
-                "secret label leaked: {}",
-                i.label
-            );
+            for leaked in ["FIXTURE-PROVIDER-VALUE", "FIXTURE-TOKEN-VALUE"] {
+                assert!(
+                    !i.label.contains(leaked),
+                    "redacted material leaked: {} in {}",
+                    leaked,
+                    i.label
+                );
+            }
         }
     }
 }

--- a/rust-core/crates/friday-ffi/src/lib.rs
+++ b/rust-core/crates/friday-ffi/src/lib.rs
@@ -258,6 +258,86 @@ pub fn sample_memory_review() -> Vec<MemoryCandidateFfi> {
     ]
 }
 
+/// A Context Passport item PROJECTED to the phone (`07` §10, design `passportPattern: Checklist
+/// Sheet`). The `label` is ALREADY redacted by `friday_core::redact_passport_for_projection` for
+/// secret/token/sensitive kinds — the secret value never reaches this struct. `transferable` is
+/// `false` for never-transferable (secret/token) kinds.
+#[derive(Debug, Clone, PartialEq, Eq, uniffi::Record)]
+pub struct PassportItemFfi {
+    pub kind: String,
+    pub label: String,
+    pub included: bool,
+    pub transferable: bool,
+    pub redacted: bool,
+}
+
+fn passport_kind_str(kind: friday_core::PassportItemKind) -> String {
+    use friday_core::PassportItemKind as K;
+    match kind {
+        K::MemorySnippet => "memory_snippet",
+        K::Summary => "summary",
+        K::File => "file",
+        K::Screenshot => "screenshot",
+        K::Attachment => "attachment",
+        K::ProviderSecret => "provider_secret",
+        K::RawToken => "raw_token",
+    }
+    .to_string()
+}
+
+/// A representative Context Passport "Checklist Sheet" PROJECTED through
+/// `friday_core::redact_passport_for_projection`, so a secret/token kind is redacted +
+/// non-transferable — the secret value NEVER leaves the Hub. A Rust-built UI fixture (the live
+/// passport store is deferred); NOT live data. Surfaces the real redaction boundary the UI shows.
+#[uniffi::export]
+pub fn sample_context_passport() -> Vec<PassportItemFfi> {
+    use friday_core::{PassportItem, PassportItemKind};
+    let mk = |kind, label: &str, included, sensitive| PassportItem {
+        kind,
+        label: label.to_string(),
+        included,
+        sensitive,
+    };
+    let items = vec![
+        mk(
+            PassportItemKind::MemorySnippet,
+            "Prefers Rust for new services",
+            true,
+            false,
+        ),
+        mk(
+            PassportItemKind::Summary,
+            "This week: ship the Rust agent loop",
+            true,
+            false,
+        ),
+        mk(PassportItemKind::File, "design-notes.md", true, false),
+        // a secret in context: projected redacted + non-transferable (value never leaves the Hub)
+        mk(
+            PassportItemKind::ProviderSecret,
+            "DEEPSEEK_API_KEY=sk-SECRETVALUE",
+            true,
+            true,
+        ),
+        mk(
+            PassportItemKind::RawToken,
+            "Bearer eyJSECRETTOKEN",
+            false,
+            true,
+        ),
+    ];
+    friday_core::redact_passport_for_projection(&items)
+        .iter()
+        .map(|r| PassportItemFfi {
+            kind: passport_kind_str(r.kind),
+            label: r.label.clone(),
+            included: r.included,
+            transferable: r.transferable,
+            redacted: r.redacted,
+        })
+        .collect()
+}
+
 /// An activity item read back from the phone's own SQLite store (`08`), for UI.
 #[derive(Debug, Clone, PartialEq, Eq, uniffi::Record)]
 pub struct ActivityItemFfi {
@@ -738,5 +818,41 @@ mod tests {
         assert_eq!(inbox[0].source, "claude"); // highest priority (9)
                                                // detail is carried, never dropped.
         assert!(!inbox[0].reason.is_empty() && !inbox[0].destination.is_empty());
+    }
+
+    #[test]
+    fn context_passport_projection_redacts_secrets_never_leaves_hub() {
+        let proj = sample_context_passport();
+        // a provider-secret item is present, redacted, and non-transferable.
+        let secret = proj
+            .iter()
+            .find(|i| i.kind == "provider_secret")
+            .expect("secret item present in the passport");
+        assert_eq!(secret.label, "[redacted: provider secret]");
+        assert!(secret.redacted && !secret.transferable);
+        let token = proj.iter().find(|i| i.kind == "raw_token").unwrap();
+        assert!(token.redacted && !token.transferable);
+        // ordinary items keep their real label + are transferable.
+        let mem = proj.iter().find(|i| i.kind == "memory_snippet").unwrap();
+        assert_eq!(mem.label, "Prefers Rust for new services");
+        assert!(mem.transferable && !mem.redacted);
+        // ADVERSE: the secret VALUE/token never appears anywhere in the projected labels.
+        for i in &proj {
+            assert!(
+                !i.label.contains("sk-SECRETVALUE"),
+                "secret leaked: {}",
+                i.label
+            );
+            assert!(
+                !i.label.contains("eyJSECRETTOKEN"),
+                "token leaked: {}",
+                i.label
+            );
+            assert!(
+                !i.label.contains("DEEPSEEK_API_KEY"),
+                "secret label leaked: {}",
+                i.label
+            );
+        }
     }
 }


### PR DESCRIPTION
## Step-3 (operator chain): Context Passport backend/FFI projection

The Context Passport (07 §10, 02 §7/§12) defines what context may be projected off the Hub. This adds the **redacted projection** — the SOLE path that surfaces passport items to the phone/UI — so a provider secret or raw token is visible *as present* but never *as value*.

### friday-core::memory
- `RedactedPassportItem` + `redact_passport_for_projection(&[PassportItem]) -> Vec<RedactedPassportItem>`.
- Redaction boundary: a never-transferable kind (`ProviderSecret`/`RawToken`) **or** any `sensitive` item → real label replaced by a generic marker (`[redacted: provider secret]` / `[redacted: raw token]` / `[redacted: sensitive]`), `redacted: true`. Never-transferable kinds are `transferable: false` — **consistent with `gate_transfer`**. Ordinary non-sensitive items project their real label, transferable.

### friday-ffi
- `PassportItemFfi` (uniffi::Record) + `sample_context_passport()` — a Rust-built UI fixture (design `passportPattern: Checklist Sheet`) projected **through** `friday_core::redact_passport_for_projection`, so secret/token rows arrive at the phone surface already redacted + non-transferable. **Truth-labeled: NOT live data** (the live passport store is deferred). friday-ffi still links no Hub/provider crate (arch-test enforced — "no provider secret on phone" stays a compile-time property).

### Tests
- core: no-leak (no `sk-`/`Bearer`/`KEY` material in any projected label) + `transferable` matches `gate_transfer` for secret vs ordinary.
- ffi: adverse no-leak on the fixture projection.
- Workspace **348 passing**, `clippy --all-targets -D warnings` clean, `fmt --check` clean, `friday-arch-tests` green.

### Scope / honesty
- Docs-only-PASS avoided: this is the real redaction mechanism + tests, not a doc claim.
- No UI wiring, no saved design files touched, no provider/channel/device work. Overall **Friday v1 remains NO-GO**.