### PR TITLE
feat(storage): memory recall data layer — content + principal + same-principal recall (PROOF-MEMORY-001 step 1)

### DIFF
--- a/rust-core/crates/friday-storage/src/memory.rs
+++ b/rust-core/crates/friday-storage/src/memory.rs
@@ -228,8 +228,8 @@ pub fn auto_usable(conn: &Connection) -> Result<Vec<MemoryRow>> {
 ///   never returned. Cross-principal recall is structurally impossible here.
 /// - **Confirmed only** (`07` §9): a `Candidate`/`Rejected`/inferred item is never
 ///   recalled as fact.
-/// - **Content-bearing only**: a row with `NULL content` has nothing to inject and
-///   is skipped (fail-closed).
+/// - **Content-bearing only**: a row with `NULL` or empty (`''`) content has
+///   nothing to inject and is skipped (fail-closed).
 ///
 /// A blank/empty `principal_id` argument returns an EMPTY set WITHOUT querying —
 /// an anonymous/owner-less caller recalls nothing (it must not match `''` rows or
@@ -242,7 +242,7 @@ pub fn recall_confirmed(conn: &Connection, principal_id: &str) -> Result<Vec<Mem
     }
     let mut stmt = conn.prepare(&format!(
         "SELECT {SELECT_COLS} FROM memory_item
-         WHERE state = ?1 AND principal_id = ?2 AND content IS NOT NULL
+         WHERE state = ?1 AND principal_id = ?2 AND content IS NOT NULL AND content != ''
          ORDER BY confirmed_at DESC, created_at DESC, memory_id"
     ))?;
     let rows = stmt.query_map(
@@ -254,10 +254,12 @@ pub fn recall_confirmed(conn: &Connection, principal_id: &str) -> Result<Vec<Mem
         let row = r?;
         out.push(row);
     }
-    // Defense-in-depth: every returned row is a durable, content-bearing fact owned
-    // by exactly the requested principal (the SQL enforces it; assert it too).
+    // Defense-in-depth: every returned row is a durable, AUTO-USABLE, content-bearing
+    // fact owned by exactly the requested principal (the SQL enforces it; assert the
+    // full trust invariant too — same shape `auto_usable` asserts, plus ownership).
     debug_assert!(out.iter().all(|m| m.state.is_durable()
-        && m.content.is_some()
+        && m.confidence.auto_usable()
+        && m.content.as_deref().is_some_and(|c| !c.is_empty())
         && m.principal_id.as_deref() == Some(principal_id)));
     Ok(out)
 }

--- a/rust-core/crates/friday-storage/src/memory.rs
+++ b/rust-core/crates/friday-storage/src/memory.rs
@@ -23,6 +23,15 @@ pub struct MemoryRow {
     pub memory_id: String,
     pub scope: MemoryScope,
     pub content_ref: Option<String>,
+    /// Inline recallable text (the marker a recall injects). `None` for pre-recall
+    /// rows — such a row is never recallable (nothing to inject).
+    pub content: Option<String>,
+    /// Owning principal. The same-principal-only recall keys on this; `None` is an
+    /// unowned row that NO principal recalls (fail-closed, `07` §9 / `02` §7).
+    pub principal_id: Option<String>,
+    /// PII/secret-bearing marker. A recalled `sensitive` item routes through the
+    /// Context Passport gate (`07` §10) — under deny-all approval it is not injected.
+    pub sensitive: bool,
     pub confidence: Confidence,
     pub state: MemoryState,
     pub created_at: i64,
@@ -65,10 +74,15 @@ fn row_from(r: &rusqlite::Row) -> rusqlite::Result<MemoryRow> {
     // default (Candidate — not durable, not auto-usable), never error the read path.
     let confidence: Option<String> = r.get("confidence")?;
     let state: String = r.get("state")?;
+    // `sensitive` is INTEGER NOT NULL DEFAULT 0; read non-zero as true.
+    let sensitive: i64 = r.get("sensitive")?;
     Ok(MemoryRow {
         memory_id: r.get("memory_id")?,
         scope: parse_scope(&scope),
         content_ref: r.get("content_ref")?,
+        content: r.get("content")?,
+        principal_id: r.get("principal_id")?,
+        sensitive: sensitive != 0,
         confidence: parse_confidence(confidence.as_deref().unwrap_or("")),
         state: parse_state(&state),
         created_at: r.get("created_at")?,
@@ -76,30 +90,48 @@ fn row_from(r: &rusqlite::Row) -> rusqlite::Result<MemoryRow> {
     })
 }
 
-const SELECT_COLS: &str =
-    "memory_id, scope, content_ref, confidence, state, created_at, confirmed_at";
+const SELECT_COLS: &str = "memory_id, scope, content_ref, content, principal_id, sensitive, \
+     confidence, state, created_at, confirmed_at";
+
+/// A freshly-extracted memory candidate to persist. Carries the recall fields
+/// (`content`, `principal_id`, `sensitive`) alongside the v1 fields so the save
+/// path captures everything a later recall needs — there is no second "make it
+/// recallable" write that could be forgotten.
+#[derive(Clone, Debug)]
+pub struct NewMemoryCandidate<'a> {
+    pub memory_id: &'a str,
+    pub scope: MemoryScope,
+    /// Opaque pointer to external content (legacy v1 field; may be `None`).
+    pub content_ref: Option<&'a str>,
+    /// Inline recallable text. A candidate with `None` content is never recallable.
+    pub content: Option<&'a str>,
+    /// Owning principal (the same-principal-only recall keys on this).
+    pub principal_id: Option<&'a str>,
+    /// PII/secret-bearing — a recalled sensitive item routes through the Passport gate.
+    pub sensitive: bool,
+    pub created_at: i64,
+}
 
 /// Record a freshly-extracted memory candidate. NEVER durable: `state=Candidate`,
 /// `confidence=Candidate`, `confirmed_at=NULL`. Nothing here makes it a fact
-/// (`07` §6/§7 — no silent long-term write).
-pub fn record_candidate(
-    conn: &Connection,
-    memory_id: &str,
-    scope: MemoryScope,
-    content_ref: Option<&str>,
-    created_at: i64,
-) -> Result<()> {
+/// (`07` §6/§7 — no silent long-term write); recall still requires explicit
+/// confirmation (`state=Confirmed`) AND a matching principal.
+pub fn record_candidate(conn: &Connection, c: &NewMemoryCandidate) -> Result<()> {
     conn.execute(
         "INSERT INTO memory_item
-            (memory_id, scope, content_ref, confidence, state, created_at, confirmed_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, NULL)",
+            (memory_id, scope, content_ref, content, principal_id, sensitive,
+             confidence, state, created_at, confirmed_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, NULL)",
         params![
-            memory_id,
-            scope.as_str(),
-            content_ref,
+            c.memory_id,
+            c.scope.as_str(),
+            c.content_ref,
+            c.content,
+            c.principal_id,
+            c.sensitive as i64,
             Confidence::Candidate.as_str(),
             MemoryState::Candidate.as_str(),
-            created_at
+            c.created_at
         ],
     )?;
     Ok(())
@@ -173,7 +205,9 @@ pub fn pending_review(conn: &Connection) -> Result<Vec<MemoryRow>> {
 }
 
 /// Durable, auto-usable long-term memory: only `Confirmed` items (`07` §9,
-/// `02` §12). A candidate or rejected item is never returned here.
+/// `02` §12). A candidate or rejected item is never returned here. This is the
+/// PRINCIPAL-AGNOSTIC view (all owners) — for recall-into-an-answer use
+/// [`recall_confirmed`], which additionally enforces the same-principal boundary.
 pub fn auto_usable(conn: &Connection) -> Result<Vec<MemoryRow>> {
     let rows = select_by_state(conn, MemoryState::Confirmed)?;
     // Defense-in-depth: the state filter already restricts to Confirmed, but assert
@@ -182,6 +216,50 @@ pub fn auto_usable(conn: &Connection) -> Result<Vec<MemoryRow>> {
         .iter()
         .all(|m| m.state.is_durable() && m.confidence.auto_usable()));
     Ok(rows)
+}
+
+/// The recall set for one principal: the `Confirmed`, `content`-bearing memory
+/// OWNED BY `principal_id`, most-recently-confirmed first. This is the data-layer
+/// half of the save→recall loop (PROOF-MEMORY-001) and enforces every hard
+/// boundary at the SQL layer so a non-eligible row never even leaves the DB:
+///
+/// - **Same-principal only** (`07` §9 / `02` §7): `principal_id = ?1` exact match.
+///   A row owned by another principal — or an unowned (`NULL` principal) row — is
+///   never returned. Cross-principal recall is structurally impossible here.
+/// - **Confirmed only** (`07` §9): a `Candidate`/`Rejected`/inferred item is never
+///   recalled as fact.
+/// - **Content-bearing only**: a row with `NULL content` has nothing to inject and
+///   is skipped (fail-closed).
+///
+/// A blank/empty `principal_id` argument returns an EMPTY set WITHOUT querying —
+/// an anonymous/owner-less caller recalls nothing (it must not match `''` rows or
+/// act as a wildcard). `sensitive` rows ARE returned (the Context Passport gate,
+/// not this query, decides whether a sensitive item is actually injected).
+pub fn recall_confirmed(conn: &Connection, principal_id: &str) -> Result<Vec<MemoryRow>> {
+    // Fail-closed on a missing principal: no wildcard, no '' match — recall nothing.
+    if principal_id.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut stmt = conn.prepare(&format!(
+        "SELECT {SELECT_COLS} FROM memory_item
+         WHERE state = ?1 AND principal_id = ?2 AND content IS NOT NULL
+         ORDER BY confirmed_at DESC, created_at DESC, memory_id"
+    ))?;
+    let rows = stmt.query_map(
+        params![MemoryState::Confirmed.as_str(), principal_id],
+        row_from,
+    )?;
+    let mut out = Vec::new();
+    for r in rows {
+        let row = r?;
+        out.push(row);
+    }
+    // Defense-in-depth: every returned row is a durable, content-bearing fact owned
+    // by exactly the requested principal (the SQL enforces it; assert it too).
+    debug_assert!(out.iter().all(|m| m.state.is_durable()
+        && m.content.is_some()
+        && m.principal_id.as_deref() == Some(principal_id)));
+    Ok(out)
 }
 
 // --- helpers ---------------------------------------------------------------

--- a/rust-core/crates/friday-storage/src/schema.rs
+++ b/rust-core/crates/friday-storage/src/schema.rs
@@ -68,6 +68,19 @@ pub fn hub_migrations() -> Vec<Migration> {
             destructive: false,
             up: m0005_agent_run,
         },
+        // Memory recall (PROOF-MEMORY-001): additive fields that make a confirmed
+        // memory RECALLABLE — the inline `content` (the text a recall injects), the
+        // owning `principal_id` (the axis the cross-principal-no-recall invariant
+        // keys on), and a `sensitive` flag (so a recalled item routes through the
+        // Context Passport gate). Purely additive; pre-existing rows get NULL
+        // content / NULL principal / sensitive=0 and are therefore NOT recallable
+        // (fail-closed: no captured content + no owner ⇒ never injected).
+        Migration {
+            version: 6,
+            name: "memory_recall_fields",
+            destructive: false,
+            up: m0006_memory_recall_fields,
+        },
     ]
 }
 
@@ -324,4 +337,19 @@ fn m0004_consumed_approval(tx: &Transaction) -> rusqlite::Result<()> {
 fn m0005_agent_run(tx: &Transaction) -> rusqlite::Result<()> {
     tx.execute_batch(DDL_AGENT_RUN)?;
     Ok(())
+}
+
+// Additive recall fields on `memory_item` (PROOF-MEMORY-001). `content` is the
+// inline recallable text (the marker a recall injects); `principal_id` is the
+// owner the same-principal-only recall keys on; `sensitive` (0/1) routes a
+// recalled item through the Context Passport gate. Pre-existing rows backfill to
+// NULL/NULL/0 — not recallable (no content, no owner) — which is the fail-closed
+// default. An index on (principal_id, state) keeps the recall query cheap.
+fn m0006_memory_recall_fields(tx: &Transaction) -> rusqlite::Result<()> {
+    tx.execute_batch(
+        "ALTER TABLE memory_item ADD COLUMN content TEXT;
+         ALTER TABLE memory_item ADD COLUMN principal_id TEXT;
+         ALTER TABLE memory_item ADD COLUMN sensitive INTEGER NOT NULL DEFAULT 0;
+         CREATE INDEX idx_memory_principal_state ON memory_item(principal_id, state);",
+    )
 }

--- a/rust-core/crates/friday-storage/tests/memory_persist.rs
+++ b/rust-core/crates/friday-storage/tests/memory_persist.rs
@@ -536,16 +536,27 @@ fn recall_excludes_unconfirmed_unowned_and_contentless() {
     )
     .unwrap();
     memory::confirm(db.conn(), "unowned", 21).unwrap();
-    // (4) a genuinely-recallable control row.
-    memory::record_candidate(db.conn(), &owned_cand("ok", "real fact", "alice", false, 4)).unwrap();
-    memory::confirm(db.conn(), "ok", 22).unwrap();
+    // (4) alice's explicitly-REJECTED memory — a terminal non-fact, never recalled.
+    memory::record_candidate(
+        db.conn(),
+        &owned_cand("rejected", "rejected fact", "alice", false, 4),
+    )
+    .unwrap();
+    memory::reject(db.conn(), "rejected", 22).unwrap();
+    // (5) alice's confirmed but EMPTY-STRING content — still nothing to inject.
+    memory::record_candidate(db.conn(), &owned_cand("empty", "", "alice", false, 5)).unwrap();
+    memory::confirm(db.conn(), "empty", 23).unwrap();
+    // (6) a genuinely-recallable control row.
+    memory::record_candidate(db.conn(), &owned_cand("ok", "real fact", "alice", false, 6)).unwrap();
+    memory::confirm(db.conn(), "ok", 24).unwrap();
 
     let recalled: Vec<String> = memory::recall_confirmed(db.conn(), "alice")
         .unwrap()
         .into_iter()
         .map(|m| m.memory_id)
         .collect();
-    // Only the control row recalls; the candidate, content-less, and unowned rows do not.
+    // ONLY the control row recalls; the candidate, content-less, unowned, rejected,
+    // and empty-content rows are all excluded.
     assert_eq!(recalled, vec!["ok".to_string()]);
 }
 

--- a/rust-core/crates/friday-storage/tests/memory_persist.rs
+++ b/rust-core/crates/friday-storage/tests/memory_persist.rs
@@ -10,6 +10,46 @@ mod common;
 use common::temp_db_path;
 use friday_core::{Confidence, MemoryScope, MemoryState};
 use friday_storage::{hub_migrations, memory, Db, Profile};
+use memory::NewMemoryCandidate;
+
+/// A bare candidate (no recall content/principal) — for the trust-lifecycle tests
+/// that exercise the state machine, where ownership/content are irrelevant.
+fn cand<'a>(
+    memory_id: &'a str,
+    scope: MemoryScope,
+    content_ref: Option<&'a str>,
+    created_at: i64,
+) -> NewMemoryCandidate<'a> {
+    NewMemoryCandidate {
+        memory_id,
+        scope,
+        content_ref,
+        content: None,
+        principal_id: None,
+        sensitive: false,
+        created_at,
+    }
+}
+
+/// A recallable candidate: carries inline `content` + an owning `principal_id`
+/// (the fields a recall needs). Used by the recall/cross-principal tests.
+fn owned_cand<'a>(
+    memory_id: &'a str,
+    content: &'a str,
+    principal_id: &'a str,
+    sensitive: bool,
+    created_at: i64,
+) -> NewMemoryCandidate<'a> {
+    NewMemoryCandidate {
+        memory_id,
+        scope: MemoryScope::Global,
+        content_ref: None,
+        content: Some(content),
+        principal_id: Some(principal_id),
+        sensitive,
+        created_at,
+    }
+}
 
 /// Insert a memory_item directly at the PRE-migration (v2) schema, which has no
 /// `state` column. `confirmed_at` is the authoritative pre-migration "confirmed"
@@ -78,8 +118,12 @@ fn forward_migration_v2_to_v3_backfills_confirmed_and_defaults_candidate() {
     );
     // The never-confirmed row took the safe default.
     assert_eq!(state_of(&db, "pending1"), "candidate");
+    drop(db);
 
-    // And it round-trips through the repo as a durable, auto-usable fact.
+    // And it round-trips through the repo as a durable, auto-usable fact. The repo
+    // targets the CURRENT schema, so read on a fully-migrated DB (the additive v4–v6
+    // migrations preserve the state/confidence the v3 backfill wrote).
+    let db = Db::open_hub(&p).unwrap();
     let confirmed = memory::get(db.conn(), "confirmed1").unwrap().unwrap();
     assert_eq!(confirmed.state, MemoryState::Confirmed);
     assert!(confirmed.state.is_durable());
@@ -105,10 +149,19 @@ fn forward_migration_normalizes_confidence_so_no_divergent_pair_survives() {
         seed_v2_memory(&db, "stale_confirmed", Some("confirmed"), None); // not confirmed, stale 'confirmed'
         seed_v2_memory(&db, "cand_null", None, None); // not confirmed, NULL conf
     }
-    let mut migs3 = hub_migrations();
-    migs3.truncate(3);
-    let db = Db::open(&p, Profile::Hub, &migs3, "v3").unwrap();
-    assert_eq!(db.version().unwrap(), 3);
+    {
+        let mut migs3 = hub_migrations();
+        migs3.truncate(3);
+        let db = Db::open(&p, Profile::Hub, &migs3, "v3").unwrap();
+        assert_eq!(
+            db.version().unwrap(),
+            3,
+            "the v3 migration under test applied"
+        );
+    }
+    // Read back via the repo on the CURRENT schema (additive v4–v6 preserve the
+    // state/confidence the v3 migration normalized).
+    let db = Db::open_hub(&p).unwrap();
 
     // Genuinely-confirmed rows: state AND confidence both normalized to confirmed.
     for id in ["conf_inferred", "conf_null"] {
@@ -168,11 +221,14 @@ fn unknown_state_or_confidence_tokens_read_fail_closed() {
 fn duplicate_record_candidate_errors_no_silent_clobber() {
     let p = temp_db_path("mem-dup");
     let db = Db::open_hub(&p).unwrap();
-    memory::record_candidate(db.conn(), "m1", MemoryScope::Global, Some("x"), 1).unwrap();
+    memory::record_candidate(db.conn(), &cand("m1", MemoryScope::Global, Some("x"), 1)).unwrap();
     memory::confirm(db.conn(), "m1", 2).unwrap();
     // A second record_candidate for the same id must ERROR (PK violation), never
     // silently clobber an already-confirmed memory back to a candidate.
-    assert!(memory::record_candidate(db.conn(), "m1", MemoryScope::Global, Some("y"), 3).is_err());
+    assert!(
+        memory::record_candidate(db.conn(), &cand("m1", MemoryScope::Global, Some("y"), 3))
+            .is_err()
+    );
     assert_eq!(state_of(&db, "m1"), "confirmed");
 }
 
@@ -181,9 +237,9 @@ fn pending_review_tie_break_is_stable_by_memory_id() {
     let p = temp_db_path("mem-tie");
     let db = Db::open_hub(&p).unwrap();
     // Identical created_at: the secondary memory_id sort makes order deterministic.
-    memory::record_candidate(db.conn(), "b", MemoryScope::Global, None, 5).unwrap();
-    memory::record_candidate(db.conn(), "a", MemoryScope::Global, None, 5).unwrap();
-    memory::record_candidate(db.conn(), "c", MemoryScope::Global, None, 5).unwrap();
+    memory::record_candidate(db.conn(), &cand("b", MemoryScope::Global, None, 5)).unwrap();
+    memory::record_candidate(db.conn(), &cand("a", MemoryScope::Global, None, 5)).unwrap();
+    memory::record_candidate(db.conn(), &cand("c", MemoryScope::Global, None, 5)).unwrap();
     let q: Vec<String> = memory::pending_review(db.conn())
         .unwrap()
         .into_iter()
@@ -197,7 +253,11 @@ fn candidate_is_never_auto_usable_until_explicitly_confirmed() {
     let p = temp_db_path("mem-no-silent");
     let db = Db::open_hub(&p).unwrap();
 
-    memory::record_candidate(db.conn(), "m1", MemoryScope::Project, Some("a fact"), 10).unwrap();
+    memory::record_candidate(
+        db.conn(),
+        &cand("m1", MemoryScope::Project, Some("a fact"), 10),
+    )
+    .unwrap();
 
     // Recorded but undecided: it is a pending candidate, NOT durable, NOT usable.
     let row = memory::get(db.conn(), "m1").unwrap().unwrap();
@@ -217,7 +277,11 @@ fn candidate_is_never_auto_usable_until_explicitly_confirmed() {
 fn explicit_confirm_makes_durable_with_consistent_confidence() {
     let p = temp_db_path("mem-confirm");
     let db = Db::open_hub(&p).unwrap();
-    memory::record_candidate(db.conn(), "m1", MemoryScope::Global, Some("fact"), 10).unwrap();
+    memory::record_candidate(
+        db.conn(),
+        &cand("m1", MemoryScope::Global, Some("fact"), 10),
+    )
+    .unwrap();
 
     let st = memory::confirm(db.conn(), "m1", 100).unwrap();
     assert_eq!(st, MemoryState::Confirmed);
@@ -241,7 +305,7 @@ fn explicit_confirm_makes_durable_with_consistent_confidence() {
 fn explicit_reject_is_not_durable_and_not_confirmed_confidence() {
     let p = temp_db_path("mem-reject");
     let db = Db::open_hub(&p).unwrap();
-    memory::record_candidate(db.conn(), "m1", MemoryScope::Session, None, 10).unwrap();
+    memory::record_candidate(db.conn(), &cand("m1", MemoryScope::Session, None, 10)).unwrap();
 
     let st = memory::reject(db.conn(), "m1", 100).unwrap();
     assert_eq!(st, MemoryState::Rejected);
@@ -263,14 +327,14 @@ fn terminal_decision_is_final_no_rewrite_no_downgrade() {
     let db = Db::open_hub(&p).unwrap();
 
     // Confirmed cannot be re-decided (no downgrade to rejected).
-    memory::record_candidate(db.conn(), "c", MemoryScope::Global, Some("x"), 1).unwrap();
+    memory::record_candidate(db.conn(), &cand("c", MemoryScope::Global, Some("x"), 1)).unwrap();
     memory::confirm(db.conn(), "c", 2).unwrap();
     assert!(memory::reject(db.conn(), "c", 3).is_err());
     assert!(memory::confirm(db.conn(), "c", 3).is_err());
     assert_eq!(state_of(&db, "c"), "confirmed");
 
     // Rejected cannot be re-decided (no silent promotion to confirmed).
-    memory::record_candidate(db.conn(), "r", MemoryScope::Global, Some("y"), 1).unwrap();
+    memory::record_candidate(db.conn(), &cand("r", MemoryScope::Global, Some("y"), 1)).unwrap();
     memory::reject(db.conn(), "r", 2).unwrap();
     assert!(memory::confirm(db.conn(), "r", 3).is_err());
     assert_eq!(state_of(&db, "r"), "rejected");
@@ -283,9 +347,9 @@ fn terminal_decision_is_final_no_rewrite_no_downgrade() {
 fn memory_review_queue_is_oldest_first_and_only_candidates() {
     let p = temp_db_path("mem-queue");
     let db = Db::open_hub(&p).unwrap();
-    memory::record_candidate(db.conn(), "old", MemoryScope::Global, None, 10).unwrap();
-    memory::record_candidate(db.conn(), "mid", MemoryScope::Global, None, 20).unwrap();
-    memory::record_candidate(db.conn(), "new", MemoryScope::Global, None, 30).unwrap();
+    memory::record_candidate(db.conn(), &cand("old", MemoryScope::Global, None, 10)).unwrap();
+    memory::record_candidate(db.conn(), &cand("mid", MemoryScope::Global, None, 20)).unwrap();
+    memory::record_candidate(db.conn(), &cand("new", MemoryScope::Global, None, 30)).unwrap();
     // Confirm the middle one -> it leaves the queue.
     memory::confirm(db.conn(), "mid", 25).unwrap();
 
@@ -306,4 +370,225 @@ fn memory_item_is_hub_only_absent_on_phone() {
         !tables.iter().any(|t| t == "memory_item"),
         "memory_item must never exist on a phone profile: have {tables:?}"
     );
+}
+
+// --- PROOF-MEMORY-001 recall (data layer) ----------------------------------
+
+/// Seed a memory_item at the PRE-recall (v5) schema, which has `state` but not the
+/// recall columns (`content`/`principal_id`/`sensitive`).
+fn seed_v5_confirmed(db: &Db, id: &str) {
+    db.conn()
+        .execute(
+            "INSERT INTO memory_item
+                (memory_id, scope, content_ref, confidence, state, created_at, confirmed_at)
+             VALUES (?1, 'global', ?2, 'confirmed', 'confirmed', 1, 42)",
+            rusqlite::params![id, format!("ref://{id}")],
+        )
+        .unwrap();
+}
+
+#[test]
+fn forward_migration_v5_to_v6_is_additive_and_old_rows_are_not_recallable() {
+    let p = temp_db_path("mem-mig-v6");
+    // Open at v5 (no recall columns) and seed a genuinely-confirmed memory.
+    {
+        let mut migs = hub_migrations();
+        migs.truncate(5);
+        let db = Db::open(&p, Profile::Hub, &migs, "v5").unwrap();
+        assert_eq!(db.version().unwrap(), 5);
+        for col in ["content", "principal_id", "sensitive"] {
+            let has: i64 = db
+                .conn()
+                .query_row(
+                    "SELECT count(*) FROM pragma_table_info('memory_item') WHERE name = ?1",
+                    [col],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(has, 0, "{col} must not exist at v5");
+        }
+        seed_v5_confirmed(&db, "legacy1");
+    }
+
+    // Forward-migrate to v6 (the migration under test).
+    let mut migs6 = hub_migrations();
+    migs6.truncate(6);
+    let db = Db::open(&p, Profile::Hub, &migs6, "v6").unwrap();
+    assert_eq!(db.version().unwrap(), 6);
+
+    // New columns + the recall index exist.
+    for col in ["content", "principal_id", "sensitive"] {
+        let has: i64 = db
+            .conn()
+            .query_row(
+                "SELECT count(*) FROM pragma_table_info('memory_item') WHERE name = ?1",
+                [col],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(has, 1, "{col} must exist at v6");
+    }
+    let has_index: i64 = db
+        .conn()
+        .query_row(
+            "SELECT count(*) FROM sqlite_master WHERE type='index' AND name='idx_memory_principal_state'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(has_index, 1);
+
+    // The pre-existing confirmed row is PRESERVED (still confirmed) but backfilled
+    // to NULL content / NULL principal / sensitive=0 — so it is NOT recallable
+    // (no captured content, no owner). Additive, fail-closed.
+    let legacy = memory::get(db.conn(), "legacy1").unwrap().unwrap();
+    assert_eq!(legacy.state, MemoryState::Confirmed);
+    assert_eq!(legacy.content, None);
+    assert_eq!(legacy.principal_id, None);
+    assert!(!legacy.sensitive);
+    // It is still in the principal-agnostic auto_usable view...
+    assert!(memory::auto_usable(db.conn())
+        .unwrap()
+        .iter()
+        .any(|m| m.memory_id == "legacy1"));
+    // ...but NO principal recalls it (unowned + no content).
+    assert!(memory::recall_confirmed(db.conn(), "alice")
+        .unwrap()
+        .is_empty());
+}
+
+#[test]
+fn recall_confirmed_returns_only_same_principal_confirmed_content() {
+    let p = temp_db_path("mem-recall-principal");
+    let db = Db::open_hub(&p).unwrap();
+    // alice's confirmed memory, and bob's confirmed memory.
+    memory::record_candidate(
+        db.conn(),
+        &owned_cand("a1", "alice likes rust", "alice", false, 1),
+    )
+    .unwrap();
+    memory::confirm(db.conn(), "a1", 10).unwrap();
+    memory::record_candidate(
+        db.conn(),
+        &owned_cand("b1", "bob likes go", "bob", false, 2),
+    )
+    .unwrap();
+    memory::confirm(db.conn(), "b1", 11).unwrap();
+
+    // alice recalls ONLY her own confirmed memory.
+    let alice = memory::recall_confirmed(db.conn(), "alice").unwrap();
+    assert_eq!(alice.len(), 1);
+    assert_eq!(alice[0].memory_id, "a1");
+    assert_eq!(alice[0].content.as_deref(), Some("alice likes rust"));
+    assert_eq!(alice[0].principal_id.as_deref(), Some("alice"));
+
+    // ADVERSE (the core security invariant): bob's memory NEVER appears for alice,
+    // and alice's NEVER appears for bob. Cross-principal recall is impossible.
+    assert!(alice.iter().all(|m| m.memory_id != "b1"));
+    let bob = memory::recall_confirmed(db.conn(), "bob").unwrap();
+    assert_eq!(bob.len(), 1);
+    assert_eq!(bob[0].memory_id, "b1");
+    assert!(bob.iter().all(|m| m.memory_id != "a1"));
+    // A third principal with no memory recalls nothing.
+    assert!(memory::recall_confirmed(db.conn(), "carol")
+        .unwrap()
+        .is_empty());
+}
+
+#[test]
+fn recall_excludes_unconfirmed_unowned_and_contentless() {
+    let p = temp_db_path("mem-recall-excludes");
+    let db = Db::open_hub(&p).unwrap();
+
+    // (1) alice's CANDIDATE (never confirmed) — must NOT recall as fact (`07` §9).
+    memory::record_candidate(
+        db.conn(),
+        &owned_cand("cand", "unconfirmed fact", "alice", false, 1),
+    )
+    .unwrap();
+    // (2) alice's confirmed but CONTENT-LESS memory — nothing to inject.
+    memory::record_candidate(
+        db.conn(),
+        &NewMemoryCandidate {
+            memory_id: "nocontent",
+            scope: MemoryScope::Global,
+            content_ref: Some("ref://x"),
+            content: None,
+            principal_id: Some("alice"),
+            sensitive: false,
+            created_at: 2,
+        },
+    )
+    .unwrap();
+    memory::confirm(db.conn(), "nocontent", 20).unwrap();
+    // (3) an UNOWNED (NULL principal) confirmed memory with content — no owner recalls it.
+    memory::record_candidate(
+        db.conn(),
+        &NewMemoryCandidate {
+            memory_id: "unowned",
+            scope: MemoryScope::Global,
+            content_ref: None,
+            content: Some("ownerless fact"),
+            principal_id: None,
+            sensitive: false,
+            created_at: 3,
+        },
+    )
+    .unwrap();
+    memory::confirm(db.conn(), "unowned", 21).unwrap();
+    // (4) a genuinely-recallable control row.
+    memory::record_candidate(db.conn(), &owned_cand("ok", "real fact", "alice", false, 4)).unwrap();
+    memory::confirm(db.conn(), "ok", 22).unwrap();
+
+    let recalled: Vec<String> = memory::recall_confirmed(db.conn(), "alice")
+        .unwrap()
+        .into_iter()
+        .map(|m| m.memory_id)
+        .collect();
+    // Only the control row recalls; the candidate, content-less, and unowned rows do not.
+    assert_eq!(recalled, vec!["ok".to_string()]);
+}
+
+#[test]
+fn recall_blank_or_empty_principal_recalls_nothing() {
+    let p = temp_db_path("mem-recall-blank");
+    let db = Db::open_hub(&p).unwrap();
+    // A confirmed memory that was (defensively) stored with an empty-string principal.
+    memory::record_candidate(db.conn(), &owned_cand("e1", "fact", "", false, 1)).unwrap();
+    memory::confirm(db.conn(), "e1", 10).unwrap();
+    memory::record_candidate(
+        db.conn(),
+        &owned_cand("a1", "alice fact", "alice", false, 2),
+    )
+    .unwrap();
+    memory::confirm(db.conn(), "a1", 11).unwrap();
+
+    // An empty / whitespace principal is fail-closed: it recalls NOTHING (no wildcard,
+    // no '' match) — it must never act as a master key over the whole store.
+    assert!(memory::recall_confirmed(db.conn(), "").unwrap().is_empty());
+    assert!(memory::recall_confirmed(db.conn(), "   ")
+        .unwrap()
+        .is_empty());
+}
+
+#[test]
+fn recall_orders_most_recently_confirmed_first_and_returns_sensitive() {
+    let p = temp_db_path("mem-recall-order");
+    let db = Db::open_hub(&p).unwrap();
+    memory::record_candidate(db.conn(), &owned_cand("old", "old fact", "alice", false, 1)).unwrap();
+    memory::confirm(db.conn(), "old", 100).unwrap();
+    memory::record_candidate(db.conn(), &owned_cand("new", "new fact", "alice", false, 2)).unwrap();
+    memory::confirm(db.conn(), "new", 200).unwrap();
+    // A sensitive (PII) confirmed memory — the recall query RETURNS it; the Context
+    // Passport gate (not this query) decides whether it is actually injected.
+    memory::record_candidate(db.conn(), &owned_cand("pii", "ssn 123", "alice", true, 3)).unwrap();
+    memory::confirm(db.conn(), "pii", 300).unwrap();
+
+    let recalled = memory::recall_confirmed(db.conn(), "alice").unwrap();
+    let ids: Vec<&str> = recalled.iter().map(|m| m.memory_id.as_str()).collect();
+    // Most-recently-confirmed first.
+    assert_eq!(ids, vec!["pii", "new", "old"]);
+    // The sensitive flag round-trips and the sensitive row IS in the recall set.
+    let pii = recalled.iter().find(|m| m.memory_id == "pii").unwrap();
+    assert!(pii.sensitive);
 }


### PR DESCRIPTION
## Step 4 (Memory cognition save→recall loop) — data-layer half

PROOF-MEMORY-001 needs `save marker → recall → answer carries marker, cross-principal must NOT recall`. The loop can't start until a confirmed memory is (a) recallable **text** and (b) owned by a **principal**. `memory_item` had neither (`content_ref` was an opaque pointer to nothing; no owner column). This PR resolves that foundation first; the cognition ranking and the loop wiring land in follow-ups.

### Migration v6 (additive, non-destructive)
- `memory_item` ADD `content TEXT` (inline recallable text), `principal_id TEXT` (owner — the axis cross-principal-no-recall keys on), `sensitive INTEGER NOT NULL DEFAULT 0` (routes a recalled item through the Context Passport gate). + index `(principal_id, state)`.
- Pre-recall rows backfill to NULL/NULL/0 → **NOT recallable** (no content, no owner). Fail-closed.

### `memory.rs`
- `MemoryRow` gains the three fields; `NewMemoryCandidate` carries them on the single save write (no separate "make recallable" write that could be forgotten).
- **`recall_confirmed(conn, principal_id)`** — the recall set for one principal. Every hard boundary enforced **at the SQL layer** so a non-eligible row never leaves the DB:
  - **Same-principal only** — `principal_id = ?` exact match; another principal's row, or an unowned (`NULL`) row, is structurally impossible to return.
  - **Confirmed only** — a candidate/inferred item is never recalled as fact (`07` §9).
  - **Content-bearing only** — `NULL content` (nothing to inject) is skipped.
  - A **blank/empty** principal recalls **nothing** (no wildcard, no `''` match — never a master key).
  - `sensitive` rows ARE returned; the Passport gate (not this query) decides injection.
- `auto_usable` stays the principal-agnostic view (admin/diagnostics).

### Tests (friday-storage, 16 memory tests)
- v5→v6 additive migration: columns + index appear, the pre-existing confirmed row is preserved but NOT recallable.
- same-principal-only + **adverse cross-principal isolation** (alice never sees bob's memory and vice-versa).
- excludes unconfirmed / unowned / content-less rows.
- blank/whitespace principal recalls nothing.
- recency ordering (most-recently-confirmed first) + sensitive flag round-trips and is returned.
- Workspace **354 passing**, clippy `--all-targets -D warnings` clean, fmt clean, `friday-arch-tests` green.

### Scope / honesty
- **Data layer only.** `recall_confirmed` has no runtime caller yet — the cognition ranking/decay/PII (friday-core) and the loop recall→Passport→inject wiring + ledger land in the next PRs.
- **PROOF-MEMORY-001 stays NO-GO / proof_pending** until the live `save→recall→answer-carries-marker` runs. Overall **Friday v1: NO-GO**.