### PR TITLE
feat(hub): wire memory recall into the agent loop — gated injection + receipt (PROOF-MEMORY-001 step 3)

### DIFF
--- a/rust-core/crates/friday-hub/src/cognition.rs
+++ b/rust-core/crates/friday-hub/src/cognition.rs
@@ -34,6 +34,7 @@
 //! Redaction is defense-in-depth; the Context Passport sensitive-flag gate is the
 //! primary control and is NOT replaced by this.
 
+use friday_core::{gate_transfer, PassportItem, PassportItemKind};
 use friday_storage::memory::MemoryRow;
 use regex::Regex;
 use std::sync::OnceLock;
@@ -251,6 +252,70 @@ pub fn rank_recall(
         .collect()
 }
 
+/// Outcome of gating a recall set for injection — a hash-chainable receipt.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RecallReceipt {
+    /// Memories that passed cognition (ranked + redacted) and were CONSIDERED.
+    pub recalled: usize,
+    /// Of those, the count that cleared the Context Passport gate and were injected.
+    pub injected: usize,
+    /// Dropped by the gate (a `sensitive` memory with no transfer approval).
+    pub gated_sensitive: usize,
+    /// The `memory_id`s actually injected (the receipt's payload).
+    pub injected_ids: Vec<String>,
+}
+
+/// Build the recall preamble by applying the Context Passport gate PER ITEM — the
+/// REAL runtime control (`07` §10), not a pre-filter or a `debug_assert`. A recalled
+/// memory is injected ONLY if [`friday_core::gate_transfer`] clears it: the secret-KIND
+/// hard block AND the sensitive-needs-approval rule both run. In v1 `approved_sensitive`
+/// is `false` (no sensitive-transfer approval is wired — deny-all), so a `sensitive`
+/// memory drops itself while the rest still inject (no all-or-nothing). The injected
+/// `content` is already PII-redacted by [`rank_recall`]. Returns the preamble (empty
+/// if nothing injects) + a [`RecallReceipt`].
+pub fn gate_and_render_recall(
+    ranked: &[RecalledMemory],
+    approved_sensitive: bool,
+) -> (String, RecallReceipt) {
+    let mut lines: Vec<String> = Vec::new();
+    let mut injected_ids: Vec<String> = Vec::new();
+    let mut gated_sensitive = 0usize;
+    for m in ranked {
+        // A MemorySnippet is never a secret-KIND, so the gate fires only on the
+        // sensitive rule here — but routing through the real gate means a future
+        // secret-bearing kind is blocked by construction, not by this call site.
+        let item = PassportItem {
+            kind: PassportItemKind::MemorySnippet,
+            label: m.content.clone(),
+            included: true,
+            sensitive: m.sensitive,
+        };
+        if gate_transfer(std::slice::from_ref(&item), approved_sensitive).is_ok() {
+            lines.push(format!("- {}", m.content));
+            injected_ids.push(m.memory_id.clone());
+        } else {
+            gated_sensitive += 1;
+        }
+    }
+    let preamble = if lines.is_empty() {
+        String::new()
+    } else {
+        format!(
+            "Relevant confirmed memory for this user (use only if helpful; do not repeat verbatim):\n{}\n\n",
+            lines.join("\n")
+        )
+    };
+    (
+        preamble,
+        RecallReceipt {
+            recalled: ranked.len(),
+            injected: injected_ids.len(),
+            gated_sensitive,
+            injected_ids,
+        },
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -451,6 +516,61 @@ mod tests {
         assert!(ranked[0].sensitive);
         assert!(ranked[0].content.contains("[EMAIL]"));
         assert!(!ranked[0].content.contains("alice@example.com"));
+    }
+
+    // --- Passport-gated render ------------------------------------------------
+
+    fn recalled(id: &str, content: &str, sensitive: bool) -> RecalledMemory {
+        RecalledMemory {
+            memory_id: id.to_string(),
+            content: content.to_string(),
+            score: 1.0,
+            sensitive,
+            redacted: false,
+        }
+    }
+
+    #[test]
+    fn gate_injects_nonsensitive_and_drops_sensitive_under_deny_all() {
+        let ranked = vec![
+            recalled("a", "alice likes rust", false),
+            recalled("s", "alice home address", true), // sensitive
+            recalled("b", "alice ships fridays", false),
+        ];
+        // v1 deny-all: no sensitive-transfer approval.
+        let (preamble, receipt) = gate_and_render_recall(&ranked, false);
+        assert_eq!(receipt.recalled, 3);
+        assert_eq!(receipt.injected, 2);
+        assert_eq!(receipt.gated_sensitive, 1);
+        assert_eq!(receipt.injected_ids, vec!["a".to_string(), "b".to_string()]);
+        // the non-sensitive content is in the preamble; the sensitive content is NOT.
+        assert!(preamble.contains("alice likes rust") && preamble.contains("alice ships fridays"));
+        assert!(
+            !preamble.contains("alice home address"),
+            "a sensitive memory must NOT be injected under deny-all: {preamble:?}"
+        );
+    }
+
+    #[test]
+    fn gate_injects_sensitive_only_when_transfer_approved() {
+        let ranked = vec![recalled("s", "sensitive note", true)];
+        // approved → injected
+        let (yes, ry) = gate_and_render_recall(&ranked, true);
+        assert_eq!(ry.injected, 1);
+        assert!(yes.contains("sensitive note"));
+        // not approved → gated out, empty preamble
+        let (no, rn) = gate_and_render_recall(&ranked, false);
+        assert_eq!(rn.injected, 0);
+        assert_eq!(rn.gated_sensitive, 1);
+        assert!(no.is_empty());
+    }
+
+    #[test]
+    fn gate_empty_recall_is_empty_preamble() {
+        let (preamble, receipt) = gate_and_render_recall(&[], false);
+        assert!(preamble.is_empty());
+        assert_eq!(receipt.recalled, 0);
+        assert_eq!(receipt.injected, 0);
     }
 
     #[test]

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -1137,13 +1137,15 @@ pub fn run_loop(
     conn: &Connection,
     run_id: &str,
     task: &str,
+    recall_preamble: &str,
     secret: &[u8],
     approve: &dyn Fn(&MutatingActionRequest) -> Option<CanonicalApproval>,
     max_turns: u64,
     now_ms: i64,
 ) -> Result<LoopOutcome, StorageError> {
     // Plan classification recorded ONCE (it is a property of the task, constant across
-    // turns).
+    // turns). Uses the CLEAN `task` — the recall preamble below augments only the prompt,
+    // never the run row / classification / events.
     let plan_kind = friday_core::classify_kind(task).map(|k| k.as_str());
     agent_run::record_event(
         conn,
@@ -1153,13 +1155,26 @@ pub fn run_loop(
         now_ms,
     )?;
 
+    // The prompt the model sees = recall preamble (PROOF-MEMORY-001; already
+    // Passport-gated + PII-redacted by the caller) + the clean task. Built once
+    // (constant across turns). Empty preamble ⇒ prompt_task == task (recall disabled).
+    // NOTE this enters the agent's INSTRUCTION context — a prompt-injection-inward
+    // surface. The backstop is genuine: the UNW-001 mutating-action gate evaluates EVERY
+    // tool call regardless of prompt text, and the recalled memory is user-CONFIRMED
+    // (not raw channel text), so it is trusted context, not arbitrary injection.
+    let prompt_task = if recall_preamble.is_empty() {
+        task.to_string()
+    } else {
+        format!("{recall_preamble}{task}")
+    };
+
     let mut history: Vec<TurnTrace> = Vec::new();
     let mut executed_tools: u64 = 0;
 
     for turn_index in 0..max_turns {
         let ev = |suffix: &str| format!("{run_id}:t{turn_index}:{suffix}");
 
-        let step = match client.next_step(task, &history) {
+        let step = match client.next_step(&prompt_task, &history) {
             Ok(step) => step,
             Err(e) => {
                 agent_run::record_event(
@@ -2100,6 +2115,7 @@ mod tests {
             db.conn(),
             "r1",
             "read a then b",
+            "",
             SECRET,
             &no_approval(),
             10,
@@ -2138,6 +2154,7 @@ mod tests {
             db.conn(),
             "r1",
             "read input then write output",
+            "",
             SECRET,
             &mint_for_each(),
             10,
@@ -2169,6 +2186,7 @@ mod tests {
             db.conn(),
             "r1",
             "do the thing",
+            "",
             SECRET,
             &no_approval(),
             10,
@@ -2208,6 +2226,7 @@ mod tests {
             db.conn(),
             "r1",
             "write secret.txt",
+            "",
             SECRET,
             &no_approval(),
             10,
@@ -2243,6 +2262,7 @@ mod tests {
             db.conn(),
             "r1",
             "loop forever",
+            "",
             SECRET,
             &no_approval(),
             3,
@@ -2283,6 +2303,7 @@ mod tests {
             db.conn(),
             "r1",
             "read notes.md and tell me the tasks",
+            "",
             SECRET,
             &mint_for_each(),
             5,
@@ -2311,6 +2332,7 @@ mod tests {
             db.conn(),
             "r1",
             "do it",
+            "",
             SECRET,
             &no_approval(),
             5,
@@ -2339,6 +2361,7 @@ mod tests {
             db.conn(),
             "r1",
             "read then frobnicate",
+            "",
             SECRET,
             &no_approval(),
             5,
@@ -2368,6 +2391,7 @@ mod tests {
             db.conn(),
             "r1",
             "list then finish",
+            "",
             SECRET,
             &no_approval(),
             5,
@@ -2425,6 +2449,7 @@ mod tests {
             db.conn(),
             "r1",
             "write twice",
+            "",
             SECRET,
             &approve,
             5,

--- a/rust-core/crates/friday-hub/src/routing.rs
+++ b/rust-core/crates/friday-hub/src/routing.rs
@@ -432,6 +432,7 @@ pub fn run_routed_loop(
     conn: &Connection,
     run_id: &str,
     task: &str,
+    recall_preamble: &str,
     secret: &[u8],
     approve: &dyn Fn(&MutatingActionRequest) -> Option<CanonicalApproval>,
     max_turns: u64,
@@ -449,7 +450,16 @@ pub fn run_routed_loop(
         .ok_or_else(|| RoutedLoopError::NoClientForProvider(route.provider_id.clone()))?;
 
     let outcome = run_loop(
-        client, executor, conn, run_id, task, secret, approve, max_turns, now_ms,
+        client,
+        executor,
+        conn,
+        run_id,
+        task,
+        recall_preamble,
+        secret,
+        approve,
+        max_turns,
+        now_ms,
     )?;
     Ok((selection, outcome))
 }
@@ -842,6 +852,7 @@ mod tests {
             db.conn(),
             "run-ro",
             "read the notes",
+            "",
             b"secret-key-0123456789",
             &|_req| None,
             4,
@@ -877,6 +888,7 @@ mod tests {
             db.conn(),
             "run-mut",
             "delete the database",
+            "",
             b"secret-key-0123456789",
             &|_req| None, // owner does NOT approve
             4,
@@ -919,6 +931,7 @@ mod tests {
             db.conn(),
             "run-noclient",
             "do something",
+            "",
             b"secret-key-0123456789",
             &|_req| None,
             4,
@@ -954,6 +967,7 @@ mod tests {
             db.conn(),
             "run-pinned",
             "use codex",
+            "",
             b"secret-key-0123456789",
             &|_req| None,
             4,

--- a/rust-core/crates/friday-hub/src/runtime.rs
+++ b/rust-core/crates/friday-hub/src/runtime.rs
@@ -36,6 +36,9 @@ use crate::routing::{
 };
 use crate::{AgentLlmClient, DeepSeekAgentLlmClient, FsToolExecutor, LoopOutcome};
 
+/// Max confirmed memories injected into one task's prompt (bounds recall's token cost).
+const RECALL_TOP_K: usize = 8;
+
 /// The owner-approval seam: given a mutating request, return a signed [`CanonicalApproval`]
 /// iff the owner approved THIS exact action. Production default is [`DenyAllApprovals`]
 /// until the phone-relayed owner-approval leg is wired (operator-gated).
@@ -63,6 +66,10 @@ pub struct HubConfig {
     /// approval to verify); load-bearing once a granting policy is wired.
     pub secret: Vec<u8>,
     pub max_turns: u64,
+    /// The Hub owner whose confirmed memory may be recalled into a task's prompt
+    /// (PROOF-MEMORY-001). A Hub is single-owner in v1, so every run inherits this
+    /// principal. `None` ⇒ memory recall is DISABLED (fail-closed: no owner, no recall).
+    pub principal_id: Option<String>,
 }
 
 /// Why the live runtime failed to assemble.
@@ -94,6 +101,8 @@ pub struct HubRuntime<T: Transport> {
     secret: Vec<u8>,
     approval: Box<dyn ApprovalPolicy>,
     max_turns: u64,
+    /// Hub owner for memory recall; `None` disables recall (see [`HubConfig::principal_id`]).
+    principal_id: Option<String>,
 }
 
 impl<T: Transport> HubRuntime<T> {
@@ -116,6 +125,7 @@ impl<T: Transport> HubRuntime<T> {
             secret: config.secret,
             approval,
             max_turns: config.max_turns,
+            principal_id: config.principal_id,
         })
     }
 
@@ -146,6 +156,11 @@ impl<T: Transport> HubRuntime<T> {
         now_ms: i64,
     ) -> Result<(RoutedSelection, LoopOutcome), RoutedLoopError> {
         agent_run::create_run(self.db.conn(), run_id, task, now_ms)?;
+        // PROOF-MEMORY-001: recall this owner's confirmed memory, gate it through the
+        // Context Passport, and inject it as a prompt PREAMBLE (the run's `task` stays
+        // clean — the preamble is added only to what the model sees). `None` principal ⇒
+        // no recall. Records a hash-chained `memory.recalled` audit receipt.
+        let recall_preamble = self.recall_preamble(run_id, now_ms)?;
         // v1: a constraint-free request (selects the highest-priority dispatchable route =
         // deepseek-flash, the only live one). Deriving required capabilities / model-size
         // from the task is a later refinement; with one live provider it cannot mask a wrong
@@ -160,11 +175,70 @@ impl<T: Transport> HubRuntime<T> {
             self.db.conn(),
             run_id,
             task,
+            &recall_preamble,
             &self.secret,
             &approve,
             self.max_turns,
             now_ms,
         )
+    }
+
+    /// Build the memory-recall prompt preamble for this run and record its receipt.
+    ///
+    /// Pipeline: [`recall_confirmed`] (same-principal + Confirmed + content-bearing, SQL
+    /// layer) → [`cognition::rank_recall`] (recency-decay + top-k + PII redaction) →
+    /// [`cognition::gate_and_render_recall`] (the per-item Context Passport gate — a
+    /// `sensitive` memory drops itself under v1 deny-all). When anything was recalled, a
+    /// hash-chained `memory.recalled` audit event records the `recalled/injected/gated`
+    /// counts and the injected `memory_id`s (the recall→answer receipt; the
+    /// answer-carries-marker proof is the separate live e2e). `None` principal ⇒ empty
+    /// preamble, no recall.
+    ///
+    /// SCOPE: this records the audit RECEIPT; it does NOT ledger tokens — `run_loop` does
+    /// not write `token_ledger` rows (loop-level token ledgering is a separate gap), so no
+    /// token-accounting claim is made here.
+    fn recall_preamble(&self, run_id: &str, now_ms: i64) -> Result<String, RoutedLoopError> {
+        let Some(principal) = self.principal_id.as_deref() else {
+            return Ok(String::new());
+        };
+        let rows = friday_storage::memory::recall_confirmed(self.db.conn(), principal)?;
+        let ranked = crate::cognition::rank_recall(
+            &rows,
+            now_ms,
+            RECALL_TOP_K,
+            crate::cognition::DEFAULT_HALF_LIFE_MS,
+        );
+        // v1: no sensitive-transfer approval is wired (deny-all), so sensitive memory is
+        // never injected. The recall principal and the gate Actor's principal (still
+        // `None` in the loop) are the SAME v1 owner conceptually — flagged so they don't
+        // silently diverge when per-run principal binding lands.
+        let approved_sensitive = false;
+        let (preamble, receipt) =
+            crate::cognition::gate_and_render_recall(&ranked, approved_sensitive);
+        if receipt.recalled > 0 {
+            // Hash-chained recall receipt (counts + injected ids). A separate audit_id from
+            // the loop's events; the chain links it to the prior tip. (rusqlite errors map
+            // through StorageError, which RoutedLoopError converts from.)
+            let tx = self
+                .db
+                .conn()
+                .unchecked_transaction()
+                .map_err(StorageError::from)?;
+            friday_storage::audit::append_audit(
+                &tx,
+                &format!("{run_id}:memory-recall"),
+                principal,
+                &format!(
+                    "memory.recalled:recalled={} injected={} gated_sensitive={}",
+                    receipt.recalled, receipt.injected, receipt.gated_sensitive
+                ),
+                Some(&receipt.injected_ids.join(",")),
+                now_ms,
+            )
+            .map_err(StorageError::from)?;
+            tx.commit().map_err(StorageError::from)?;
+        }
+        Ok(preamble)
     }
 
     /// Read access to the composed DB (for evidence/inspection: agent_run events, audit chain).
@@ -321,12 +395,177 @@ mod tests {
                 workspace_root: ws.0.clone(),
                 secret: SECRET.to_vec(),
                 max_turns: 6,
+                principal_id: None, // recall disabled by default; the recall test sets it
             },
             agent,
             approval,
         )
         .unwrap();
         (rt, ws, post_calls) // TempDir guard keeps the workspace alive; counter for the no-hidden test
+    }
+
+    // ---- PROOF-MEMORY-001 recall→inject wiring -------------------------------
+
+    /// A transport that CAPTURES every outgoing chat body (so a test can assert what
+    /// the model actually receives), and finishes the loop in one turn.
+    struct CaptureTransport {
+        bodies: Rc<std::cell::RefCell<Vec<Value>>>,
+    }
+    impl Transport for CaptureTransport {
+        fn get_json(&self, _url: &str, _bearer: &str) -> Result<Value, DeepSeekError> {
+            Ok(serde_json::json!({"data":[{"id":"deepseek-v4-flash"}]}))
+        }
+        fn post_json(
+            &self,
+            _url: &str,
+            _bearer: &str,
+            body: &Value,
+        ) -> Result<Value, DeepSeekError> {
+            self.bodies.borrow_mut().push(body.clone());
+            // Finish immediately so the loop runs exactly one turn.
+            Ok(serde_json::json!({
+                "model":"deepseek-v4-flash",
+                "choices":[{"message":{"content":"{\"tool\":\"none\"}"},"finish_reason":"stop"}],
+                "usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}
+            }))
+        }
+    }
+
+    fn recall_runtime(
+        tag: &str,
+        principal: Option<&str>,
+    ) -> (
+        HubRuntime<CaptureTransport>,
+        TempDir,
+        Rc<std::cell::RefCell<Vec<Value>>>,
+    ) {
+        let ws = TempDir::new(tag);
+        let bodies = Rc::new(std::cell::RefCell::new(Vec::new()));
+        let transport = CaptureTransport {
+            bodies: bodies.clone(),
+        };
+        let client = DeepSeekClient::with_transport(transport, "k".into());
+        let agent = DeepSeekAgentLlmClient::new(client);
+        let rt = HubRuntime::new(
+            HubConfig {
+                db_path: tmp(tag),
+                workspace_root: ws.0.clone(),
+                secret: SECRET.to_vec(),
+                max_turns: 4,
+                principal_id: principal.map(|p| p.to_string()),
+            },
+            agent,
+            Box::new(DenyAllApprovals),
+        )
+        .unwrap();
+        (rt, ws, bodies)
+    }
+
+    fn seed_confirmed(
+        rt: &HubRuntime<CaptureTransport>,
+        id: &str,
+        content: &str,
+        principal: &str,
+        sensitive: bool,
+    ) {
+        let conn = rt.db().conn();
+        friday_storage::memory::record_candidate(
+            conn,
+            &friday_storage::memory::NewMemoryCandidate {
+                memory_id: id,
+                scope: friday_core::MemoryScope::Global,
+                content_ref: None,
+                content: Some(content),
+                principal_id: Some(principal),
+                sensitive,
+                created_at: 1,
+            },
+        )
+        .unwrap();
+        friday_storage::memory::confirm(conn, id, 2).unwrap();
+    }
+
+    fn body_contains(bodies: &Rc<std::cell::RefCell<Vec<Value>>>, needle: &str) -> bool {
+        bodies
+            .borrow()
+            .iter()
+            .any(|b| b.to_string().contains(needle))
+    }
+
+    fn recall_audit_count(rt: &HubRuntime<CaptureTransport>) -> i64 {
+        rt.db()
+            .conn()
+            .query_row(
+                "SELECT count(*) FROM audit_ledger WHERE action LIKE 'memory.recalled%'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap()
+    }
+
+    #[test]
+    fn recall_injects_owner_confirmed_memory_into_the_prompt_and_records_receipt() {
+        // POSITIVE recall — the test that makes the negatives below non-vacuous.
+        let (rt, _ws, bodies) = recall_runtime("recall-pos", Some("alice"));
+        seed_confirmed(&rt, "m1", "MEMMARKER-alice-prefers-rust", "alice", false);
+        rt.run_task("r-pos", "help me", 100).unwrap();
+        assert!(
+            body_contains(&bodies, "MEMMARKER-alice-prefers-rust"),
+            "alice's confirmed memory must be injected into the outgoing prompt"
+        );
+        // a hash-chained memory.recalled receipt was written.
+        assert_eq!(recall_audit_count(&rt), 1);
+        // SCOPE: this proves recall→PROMPT INJECTION, not that the model's ANSWER carries
+        // the marker (that is the separate live e2e — PROOF-MEMORY-001 stays proof_pending).
+    }
+
+    #[test]
+    fn recall_is_cross_principal_isolated_in_the_prompt() {
+        // bob's runtime, alice's memory → bob's prompt must NEVER carry it.
+        let (rt, _ws, bodies) = recall_runtime("recall-xp", Some("bob"));
+        seed_confirmed(&rt, "m1", "MEMMARKER-alice-secret-plan", "alice", false);
+        rt.run_task("r-xp", "help me", 100).unwrap();
+        assert!(
+            !body_contains(&bodies, "MEMMARKER-alice-secret-plan"),
+            "cross-principal recall leak: alice's memory reached bob's prompt"
+        );
+        // nothing was recalled for bob → no receipt.
+        assert_eq!(recall_audit_count(&rt), 0);
+    }
+
+    #[test]
+    fn recall_no_principal_injects_nothing() {
+        let (rt, _ws, bodies) = recall_runtime("recall-none", None);
+        seed_confirmed(&rt, "m1", "MEMMARKER-unowned", "alice", false);
+        rt.run_task("r-none", "help me", 100).unwrap();
+        assert!(!body_contains(&bodies, "MEMMARKER-unowned"));
+        assert_eq!(recall_audit_count(&rt), 0);
+    }
+
+    #[test]
+    fn recall_sensitive_memory_is_gated_out_under_deny_all() {
+        let (rt, _ws, bodies) = recall_runtime("recall-sens", Some("alice"));
+        seed_confirmed(&rt, "ok", "MEMMARKER-ok-nonsensitive", "alice", false);
+        seed_confirmed(&rt, "sens", "MEMMARKER-sensitive-pii", "alice", true);
+        rt.run_task("r-sens", "help me", 100).unwrap();
+        // the non-sensitive memory injects; the sensitive one is gated out (deny-all).
+        assert!(body_contains(&bodies, "MEMMARKER-ok-nonsensitive"));
+        assert!(
+            !body_contains(&bodies, "MEMMARKER-sensitive-pii"),
+            "a sensitive memory must NOT be injected under deny-all"
+        );
+        // receipt recorded recalled=2 injected=1 gated_sensitive=1.
+        let action: String = rt
+            .db()
+            .conn()
+            .query_row(
+                "SELECT action FROM audit_ledger WHERE action LIKE 'memory.recalled%'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(action.contains("recalled=2") && action.contains("injected=1"));
+        assert!(action.contains("gated_sensitive=1"));
     }
 
     // ---- routing honesty (dispatchable_routes) ------------------------------
@@ -505,6 +744,7 @@ mod tests {
             workspace_root: ws.0.clone(),
             secret: SECRET.to_vec(),
             max_turns: 5,
+            principal_id: None, // the live save→recall→answer-carries-marker e2e is a separate proof (PR4)
         })
         .expect("live runtime assembles (FRIDAY_DEEPSEEK_API_KEY set)");
         let (sel, out) = rt


### PR DESCRIPTION
## Step 4 (Memory cognition save→recall loop) — the wiring that closes the recall path

An owner's confirmed memory is now recalled, **Passport-gated**, and **injected into the task's prompt**.

### Composition (`run_task`)
- `HubConfig` gains **`principal_id`** (the Hub owner; v1 single-owner). **`None` ⇒ recall DISABLED** (fail-closed: no owner, no recall) — every pre-existing test/path is unchanged.
- `run_task` recalls ONCE per task: `recall_confirmed(principal)` [same-principal + Confirmed + content, SQL layer, #498] → `cognition::rank_recall` [recency-decay + `top_k=8` + PII redaction, #499] → `cognition::gate_and_render_recall`.

### The Passport gate is the REAL per-item runtime control (advisor finding)
`gate_and_render_recall` injects a memory **only if** `gate_transfer(&[item], approved).is_ok()` — the secret-KIND block AND the sensitive-needs-approval rule both run, **fail-closed in release** (not a pre-filter, not a `debug_assert`). v1 `approved=false` (no sensitive-transfer approval wired = deny-all), so a sensitive memory drops itself while the rest still inject (**no all-or-nothing**).

### Injection seam (no trait change)
`run_loop` keeps the **clean `task`** for `create_run`/`classify_kind`/events and builds `prompt_task = recall_preamble + task` for `client.next_step` only. `recall_preamble` threads `run_task → run_routed_loop → run_loop`. Empty preamble ⇒ `prompt_task == task`.

### Audit
A hash-chained `memory.recalled:recalled=N injected=M gated_sensitive=K` event (payload = injected `memory_id`s) is the recall receipt.

### Honest labels
- **Proves recall→PROMPT INJECTION** (capture-transport asserts the marker is in the outgoing body), **NOT** that the model's ANSWER carries the marker — that is the separate **live e2e (next)**. **PROOF-MEMORY-001 stays NO-GO / proof_pending.**
- **No token-ledger claim**: `run_loop` does NOT write `token_ledger` rows (loop-level token ledgering is a **separate gap**); only the audit receipt is recorded.
- Recalled memory enters the agent's **instruction context** (a prompt-injection-inward surface). Backstop is genuine: the UNW-001 mutating gate evaluates **every** tool call regardless of prompt text, and recalled memory is **user-confirmed** (not raw channel text). The recall principal == the gate Actor principal (still `None` in the loop) = the same v1 owner; flagged so they don't silently diverge.

### Tests
positive recall injects the marker into the captured prompt body; **cross-principal isolation** (bob never sees alice's memory); no-principal injects nothing; **sensitive memory gated out under deny-all** (receipt `recalled=2/injected=1/gated=1`); `gate_and_render_recall` unit tests. **friday-hub 100 tests, workspace 374**, clippy `-D warnings` clean, fmt clean, arch-tests green. Overall **v1: NO-GO**.