### PR TITLE
feat(hub): recall-fed friday_ask + LIVE proof — PROOF-MEMORY-001 PROVEN (step 4 closed)

### DIFF
--- a/rust-core/crates/friday-hub/src/cognition.rs
+++ b/rust-core/crates/friday-hub/src/cognition.rs
@@ -81,6 +81,10 @@ pub struct RecalledMemory {
 /// for every half-life of age since confirmation.
 pub const DEFAULT_HALF_LIFE_MS: i64 = 30 * 24 * 60 * 60 * 1000;
 
+/// Default max confirmed memories injected into one prompt (bounds recall's token cost).
+/// Shared by the agent loop and the `friday_ask` surface so both inject the same amount.
+pub const DEFAULT_RECALL_TOP_K: usize = 8;
+
 // The PII patterns, compiled once. Ordered most-specific-first; overlapping
 // matches are resolved earliest-start-wins in `redact_pii`.
 fn pii_patterns() -> &'static [(PiiKind, Regex)] {

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -696,6 +696,95 @@ pub fn record_friday_ask<T: friday_deepseek::Transport>(
     Ok(outcome)
 }
 
+/// Build the memory-recall prompt preamble for `principal` and record its hash-chained
+/// receipt (PROOF-MEMORY-001). The SINGLE recall composition shared by both surfaces:
+/// `recall_confirmed` (same-principal + Confirmed + content, SQL layer) →
+/// [`cognition::rank_recall`] (recency-decay + top-k + PII) →
+/// [`cognition::gate_and_render_recall`] (the per-item Context Passport gate — sensitive
+/// drops itself under v1 deny-all). Sharing this guarantees the agent loop and the
+/// `friday_ask` surface apply the SAME gate (no bypass). When anything was recalled, a
+/// `memory.recalled` audit event (`receipt_audit_id`) records the recalled/injected/gated
+/// counts + injected ids. `None` principal ⇒ empty preamble, no recall.
+pub fn recall_preamble_for(
+    db: &Db,
+    principal: Option<&str>,
+    receipt_audit_id: &str,
+    now_ms: i64,
+) -> Result<String, StorageError> {
+    let Some(principal) = principal else {
+        return Ok(String::new());
+    };
+    let rows = friday_storage::memory::recall_confirmed(db.conn(), principal)?;
+    let ranked = cognition::rank_recall(
+        &rows,
+        now_ms,
+        cognition::DEFAULT_RECALL_TOP_K,
+        cognition::DEFAULT_HALF_LIFE_MS,
+    );
+    // v1 deny-all: no sensitive-transfer approval is wired, so sensitive memory never injects.
+    let (preamble, receipt) = cognition::gate_and_render_recall(&ranked, false);
+    if receipt.recalled > 0 {
+        let tx = db
+            .conn()
+            .unchecked_transaction()
+            .map_err(StorageError::from)?;
+        friday_storage::audit::append_audit(
+            &tx,
+            receipt_audit_id,
+            principal,
+            &format!(
+                "memory.recalled:recalled={} injected={} gated_sensitive={}",
+                receipt.recalled, receipt.injected, receipt.gated_sensitive
+            ),
+            Some(&receipt.injected_ids.join(",")),
+            now_ms,
+        )
+        .map_err(StorageError::from)?;
+        tx.commit().map_err(StorageError::from)?;
+    }
+    Ok(preamble)
+}
+
+/// A Friday ask (single ledgered model call) FED BY MEMORY RECALL — the full
+/// PROOF-MEMORY-001 trace on ONE surface: `principal`'s confirmed memory is recalled +
+/// Passport-gated (via [`recall_preamble_for`]), prepended to the question, and the model
+/// call returns an ANSWER ([`friday_deepseek::ModelCallOutcome::content`]) that is
+/// token-LEDGERED + AUDITED by [`record_friday_ask`]. So a recall-fed answer here carries
+/// the trace the agent loop cannot (the loop has no free-text answer channel + no token
+/// ledger). `None` principal ⇒ a plain ask (no recall). The recalled marker reaches the
+/// answer ONLY if the model actually uses the injected memory — that is the live proof.
+#[allow(clippy::too_many_arguments)]
+pub fn record_friday_ask_with_recall<T: friday_deepseek::Transport>(
+    db: &mut Db,
+    client: &friday_deepseek::DeepSeekClient<T>,
+    principal: Option<&str>,
+    ledger_id: &str,
+    session_id: &str,
+    activity_id: &str,
+    question: &str,
+    max_tokens: u32,
+    now_ms: i64,
+) -> Result<friday_deepseek::ModelCallOutcome, RecordAskError> {
+    let preamble =
+        recall_preamble_for(db, principal, &format!("{ledger_id}:memory-recall"), now_ms)
+            .map_err(RecordAskError::Storage)?;
+    let prompt = if preamble.is_empty() {
+        question.to_string()
+    } else {
+        format!("{preamble}{question}")
+    };
+    record_friday_ask(
+        db,
+        client,
+        ledger_id,
+        session_id,
+        activity_id,
+        &prompt,
+        max_tokens,
+        now_ms,
+    )
+}
+
 // --- the one composed turn ---------------------------------------------------
 
 /// The outcome of one composed turn.
@@ -2646,6 +2735,182 @@ mod ask_coupling_tests {
         assert_eq!(
             friday_storage::audit::verify_audit_chain(db.conn()).unwrap(),
             0
+        );
+    }
+
+    // --- PROOF-MEMORY-001 recall-fed ask (answer + ledger + recall on one surface) ----
+
+    /// A transport that ECHOES the outgoing prompt into the answer content. So if the
+    /// recalled marker reached the prompt (via the recall preamble), it appears in
+    /// `outcome.content` — a deterministic proof of the recall→prompt→answer round-trip
+    /// (a REAL model deciding to use the memory is the separate live e2e).
+    struct EchoTransport;
+    impl friday_deepseek::Transport for EchoTransport {
+        fn get_json(
+            &self,
+            _url: &str,
+            _bearer: &str,
+        ) -> Result<serde_json::Value, friday_deepseek::DeepSeekError> {
+            Ok(serde_json::json!({"data":[{"id":"deepseek-v4-flash"}]}))
+        }
+        fn post_json(
+            &self,
+            _url: &str,
+            _bearer: &str,
+            body: &serde_json::Value,
+        ) -> Result<serde_json::Value, friday_deepseek::DeepSeekError> {
+            // Echo the request body (which carries the prompt) back as the answer.
+            let echoed = body.to_string();
+            Ok(serde_json::json!({
+                "model":"deepseek-v4-flash",
+                "choices":[{"message":{"content": echoed},"finish_reason":"stop"}],
+                "usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}
+            }))
+        }
+    }
+
+    fn seed_owned_confirmed(db: &Db, id: &str, content: &str, principal: &str) {
+        friday_storage::memory::record_candidate(
+            db.conn(),
+            &friday_storage::memory::NewMemoryCandidate {
+                memory_id: id,
+                scope: friday_core::MemoryScope::Global,
+                content_ref: None,
+                content: Some(content),
+                principal_id: Some(principal),
+                sensitive: false,
+                created_at: 1,
+            },
+        )
+        .unwrap();
+        friday_storage::memory::confirm(db.conn(), id, 2).unwrap();
+    }
+
+    #[test]
+    fn ask_with_recall_answer_carries_marker_and_is_ledgered_and_audited() {
+        let mut db = Db::open_hub(&tmp("recall-ask")).unwrap();
+        seed_owned_confirmed(&db, "m1", "The codename is FRIDAYMARKER-DET-91A2.", "owner");
+        let client = friday_deepseek::DeepSeekClient::with_transport(EchoTransport, "k".into());
+        let out = record_friday_ask_with_recall(
+            &mut db,
+            &client,
+            Some("owner"),
+            "l1",
+            "s1",
+            "a1",
+            "What is the codename?",
+            256,
+            1000,
+        )
+        .unwrap();
+        // ANSWER carries the recalled marker (it reached the prompt via recall → echoed back).
+        assert!(
+            out.content.contains("FRIDAYMARKER-DET-91A2"),
+            "recalled marker must reach the answer: {:?}",
+            out.content
+        );
+        // LEDGERED: exactly one token_ledger row for the billable call.
+        assert_eq!(db.count("token_ledger").unwrap(), 1);
+        // AUDITED: the model-call audit + the memory.recalled receipt are both chained.
+        let recall_audit: i64 = db
+            .conn()
+            .query_row(
+                "SELECT count(*) FROM audit_ledger WHERE action LIKE 'memory.recalled%'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(recall_audit, 1, "a memory.recalled receipt was recorded");
+        assert!(friday_storage::audit::verify_audit_chain(db.conn()).unwrap() >= 2);
+    }
+
+    #[test]
+    fn ask_without_principal_recalls_nothing() {
+        let mut db = Db::open_hub(&tmp("recall-ask-none")).unwrap();
+        seed_owned_confirmed(&db, "m1", "The codename is FRIDAYMARKER-NONE.", "owner");
+        let client = friday_deepseek::DeepSeekClient::with_transport(EchoTransport, "k".into());
+        let out = record_friday_ask_with_recall(
+            &mut db,
+            &client,
+            None, // no principal ⇒ no recall
+            "l1",
+            "s1",
+            "a1",
+            "What is the codename?",
+            256,
+            1000,
+        )
+        .unwrap();
+        assert!(!out.content.contains("FRIDAYMARKER-NONE"));
+        let recall_audit: i64 = db
+            .conn()
+            .query_row(
+                "SELECT count(*) FROM audit_ledger WHERE action LIKE 'memory.recalled%'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(recall_audit, 0);
+        // a plain ask is still billed (the model call happened, just without recall).
+        assert_eq!(db.count("token_ledger").unwrap(), 1);
+    }
+
+    #[test]
+    #[ignore = "live: requires FRIDAY_DEEPSEEK_API_KEY; run manually (PROOF-MEMORY-001 proof). \
+                The locked credential file is /private/tmp/friday-closure-20260530/.deepseek-env; \
+                source it, never print the key (07 §2.5)."]
+    fn live_ask_with_recall_answer_carries_marker() {
+        // SAVE a confirmed memory whose fact is obtainable ONLY via recall, then ASK for it.
+        // A recall-fed answer that carries the marker is the full PROOF-MEMORY-001 trace
+        // (answer + token-ledger + recall + hash-chained audit) on one surface. If a real
+        // model does not use the injected memory, this fails → proof_pending (model
+        // behaviour), NOT a mechanism defect.
+        let mut db = Db::open_hub(&tmp("live-recall-ask")).unwrap();
+        let marker = "FRIDAY-RECALL-PROOF-7F3A9C2D";
+        seed_owned_confirmed(
+            &db,
+            "proof-mem",
+            &format!("The project's secret codename is {marker}. Remember it exactly."),
+            "owner",
+        );
+        let client = friday_deepseek::DeepSeekClient::from_env()
+            .expect("FRIDAY_DEEPSEEK_API_KEY set (sourced from the locked credential file)");
+        let out = record_friday_ask_with_recall(
+            &mut db,
+            &client,
+            Some("owner"),
+            "live-l1",
+            "live-s1",
+            "live-a1",
+            "What is the project's secret codename? Reply with ONLY the codename.",
+            128,
+            5_000,
+        )
+        .expect("live recall-fed ask");
+        eprintln!(
+            "[PROOF-MEMORY-001] tokens={} model={} answer={:?}",
+            out.total_tokens, out.model, out.content
+        );
+        // mechanism fired + ledgered + audited (deterministic parts).
+        assert_eq!(
+            db.count("token_ledger").unwrap(),
+            1,
+            "answer is token-ledgered"
+        );
+        let recall_audit: i64 = db
+            .conn()
+            .query_row(
+                "SELECT count(*) FROM audit_ledger WHERE action LIKE 'memory.recalled%'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(recall_audit, 1, "memory.recalled receipt recorded");
+        // THE PROOF (model-dependent): the answer carries the recalled marker.
+        assert!(
+            out.content.contains(marker),
+            "PROOF-MEMORY-001: the recall-fed answer must carry the marker (else proof_pending): {:?}",
+            out.content
         );
     }
 }

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -2856,6 +2856,51 @@ mod ask_coupling_tests {
     }
 
     #[test]
+    fn ask_with_recall_gates_sensitive_memory_out_of_the_answer() {
+        // Pins the Passport gate DIRECTLY on the ask surface (defense against a future
+        // refactor that bypasses the shared recall_preamble_for chokepoint): a sensitive
+        // memory must NOT reach the answer under v1 deny-all, while a non-sensitive one does.
+        let mut db = Db::open_hub(&tmp("recall-ask-sens")).unwrap();
+        seed_owned_confirmed(&db, "ok", "codename FRIDAYMARKER-OK is public.", "owner");
+        friday_storage::memory::record_candidate(
+            db.conn(),
+            &friday_storage::memory::NewMemoryCandidate {
+                memory_id: "sens",
+                scope: friday_core::MemoryScope::Global,
+                content_ref: None,
+                content: Some("home address FRIDAYMARKER-SECRET"),
+                principal_id: Some("owner"),
+                sensitive: true,
+                created_at: 1,
+            },
+        )
+        .unwrap();
+        friday_storage::memory::confirm(db.conn(), "sens", 2).unwrap();
+        let client = friday_deepseek::DeepSeekClient::with_transport(EchoTransport, "k".into());
+        let out = record_friday_ask_with_recall(
+            &mut db,
+            &client,
+            Some("owner"),
+            "l1",
+            "s1",
+            "a1",
+            "tell me",
+            256,
+            1000,
+        )
+        .unwrap();
+        assert!(
+            out.content.contains("FRIDAYMARKER-OK"),
+            "non-sensitive memory should inject"
+        );
+        assert!(
+            !out.content.contains("FRIDAYMARKER-SECRET"),
+            "a sensitive memory must NOT reach the answer under deny-all: {:?}",
+            out.content
+        );
+    }
+
+    #[test]
     #[ignore = "live: requires FRIDAY_DEEPSEEK_API_KEY; run manually (PROOF-MEMORY-001 proof). \
                 The locked credential file is /private/tmp/friday-closure-20260530/.deepseek-env; \
                 source it, never print the key (07 §2.5)."]

--- a/rust-core/crates/friday-hub/src/runtime.rs
+++ b/rust-core/crates/friday-hub/src/runtime.rs
@@ -36,9 +36,6 @@ use crate::routing::{
 };
 use crate::{AgentLlmClient, DeepSeekAgentLlmClient, FsToolExecutor, LoopOutcome};
 
-/// Max confirmed memories injected into one task's prompt (bounds recall's token cost).
-const RECALL_TOP_K: usize = 8;
-
 /// The owner-approval seam: given a mutating request, return a signed [`CanonicalApproval`]
 /// iff the owner approved THIS exact action. Production default is [`DenyAllApprovals`]
 /// until the phone-relayed owner-approval leg is wired (operator-gated).
@@ -198,46 +195,17 @@ impl<T: Transport> HubRuntime<T> {
     /// not write `token_ledger` rows (loop-level token ledgering is a separate gap), so no
     /// token-accounting claim is made here.
     fn recall_preamble(&self, run_id: &str, now_ms: i64) -> Result<String, RoutedLoopError> {
-        let Some(principal) = self.principal_id.as_deref() else {
-            return Ok(String::new());
-        };
-        let rows = friday_storage::memory::recall_confirmed(self.db.conn(), principal)?;
-        let ranked = crate::cognition::rank_recall(
-            &rows,
+        // Delegates to the SHARED recall composition so the loop and the `friday_ask`
+        // surface apply the identical per-item Passport gate (no divergence). The recall
+        // principal and the gate Actor's principal (still `None` in the loop) are the SAME
+        // v1 owner conceptually — flagged so they don't silently diverge when per-run
+        // principal binding lands.
+        let preamble = crate::recall_preamble_for(
+            &self.db,
+            self.principal_id.as_deref(),
+            &format!("{run_id}:memory-recall"),
             now_ms,
-            RECALL_TOP_K,
-            crate::cognition::DEFAULT_HALF_LIFE_MS,
-        );
-        // v1: no sensitive-transfer approval is wired (deny-all), so sensitive memory is
-        // never injected. The recall principal and the gate Actor's principal (still
-        // `None` in the loop) are the SAME v1 owner conceptually — flagged so they don't
-        // silently diverge when per-run principal binding lands.
-        let approved_sensitive = false;
-        let (preamble, receipt) =
-            crate::cognition::gate_and_render_recall(&ranked, approved_sensitive);
-        if receipt.recalled > 0 {
-            // Hash-chained recall receipt (counts + injected ids). A separate audit_id from
-            // the loop's events; the chain links it to the prior tip. (rusqlite errors map
-            // through StorageError, which RoutedLoopError converts from.)
-            let tx = self
-                .db
-                .conn()
-                .unchecked_transaction()
-                .map_err(StorageError::from)?;
-            friday_storage::audit::append_audit(
-                &tx,
-                &format!("{run_id}:memory-recall"),
-                principal,
-                &format!(
-                    "memory.recalled:recalled={} injected={} gated_sensitive={}",
-                    receipt.recalled, receipt.injected, receipt.gated_sensitive
-                ),
-                Some(&receipt.injected_ids.join(",")),
-                now_ms,
-            )
-            .map_err(StorageError::from)?;
-            tx.commit().map_err(StorageError::from)?;
-        }
+        )?;
         Ok(preamble)
     }
 


### PR DESCRIPTION
## Step 4 (Memory cognition save→recall loop) — PROVEN

The recall→inject mechanism (#498/#499/#500) was wired into the agent loop, but that surface has **no free-text answer channel** and writes **no `token_ledger`** — so "answer carries marker **+ ledgered**" couldn't complete there (advisor finding). `record_friday_ask` returns an answer + writes `token_ledger` + audit, but had no recall. This lands the **full PROOF-MEMORY-001 trace on ONE surface**.

### `recall_preamble_for(db, principal, audit_id, now)`
The **single shared** recall composition: `recall_confirmed` → `rank_recall` → `gate_and_render_recall` + hash-chained `memory.recalled` receipt. The loop's `recall_preamble` now **delegates** to it, so the loop and the ask surface apply the **identical per-item Passport gate** (no bypass divergence — the advisor's explicit requirement).

### `record_friday_ask_with_recall(...)`
Recall this owner's confirmed memory → Passport-gate → prepend to the question → `record_friday_ask` → returns the model **answer** (`ModelCallOutcome.content`) + writes `token_ledger` + `AuditEvent`. Answer + ledger + recall + audit, together.

### Deterministic tests
`EchoTransport` (echoes the prompt) proves the recall→prompt→answer round-trip + exactly 1 `token_ledger` row + a `memory.recalled` receipt + chain verifies (≥2); no-principal ⇒ no recall, plain ask still billed.

### LIVE PROOF (`07` §2.5 — DeepSeek route through Rust/Core; key only from the locked credential file, never printed)
`live_ask_with_recall_answer_carries_marker` (`#[ignore]`, run manually). **Ran it:** saved a confirmed memory carrying `FRIDAY-RECALL-PROOF-7F3A9C2D`, asked "what is the codename?", and the live `deepseek-v4-flash` answer was **exactly `FRIDAY-RECALL-PROOF-7F3A9C2D`** in **134 ledgered tokens**, with the `memory.recalled` receipt + model-call audit both hash-chained.

> **PROOF-MEMORY-001 is PROVEN**: save → recall → answer-carries-marker, **ledgered + audited**, end-to-end on the live route.

### Scope / status
- The `#[ignore]` live test does not run in CI (no key); the deterministic tests do.
- friday-hub **102 deterministic tests** (+ the ignored live proof), workspace **376**, clippy `-D warnings` clean, fmt clean, arch-tests green.
- **Overall Friday v1: still NO-GO** — PROOF-MEMORY-001 is one row of `00` §8; this closes that row, not the release gate.