### PR TITLE
feat(hub): UNW-011 single canonical retry classifier (workflow/skills substrate, step 5)

### DIFF
--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -64,6 +64,11 @@ pub mod setup;
 /// semantic/embedding recall (greenfield NO-GO — not claimed).
 pub mod cognition;
 
+/// Step-5 (workflow/skills substrate) — UNW-011: the single canonical retry
+/// classifier (Retryable vs Terminal) over the real provider/route error types.
+/// No silent fallback (a retry is the SAME route, never a reroute); bounded.
+pub mod retry;
+
 use friday_core::gate::{
     canonical_action_bytes, canonical_approval_signature_bytes, ActorKind, ApprovalDecision,
     CanonicalApproval, GateDecision, MutatingActionRequest, CANONICAL_GATE_ISSUER,

--- a/rust-core/crates/friday-hub/src/retry.rs
+++ b/rust-core/crates/friday-hub/src/retry.rs
@@ -1,0 +1,146 @@
+//! UNW-011 — the SINGLE canonical retry classifier (workflow/skills substrate).
+//!
+//! For a failed provider/route operation it decides ONE thing: is the failure
+//! transient (**Retryable** — the SAME route may be retried, bounded) or
+//! **Terminal** (surface it; do not retry)? There is exactly ONE disposition
+//! taxonomy ([`RetryDisposition`]) classified from the REAL error types
+//! ([`friday_deepseek::DeepSeekError`] / [`crate::routing::RoutedLoopError`]) — no
+//! parallel taxonomy.
+//!
+//! ## No silent fallback (UNW-003, do not regress)
+//! `Retryable` means "retry the SAME provider/route", NEVER "try a different
+//! provider". This module exposes NO API that returns an alternate provider, so
+//! classification cannot become a reroute by construction. In particular
+//! [`RouteError::RequestedProviderUnavailable`] — the explicit no-fallback path —
+//! is **Terminal**: a specifically-requested-but-unavailable provider is surfaced,
+//! never silently retried into a different one.
+//!
+//! ## Bounded
+//! [`should_retry`] caps retries at `max_attempts` even for a `Retryable` failure,
+//! so a persistently-transient provider cannot drive an unbounded retry / runaway
+//! spend. This is the classifier + bound only; wiring it into an execution retry
+//! loop is part of the (deferred) workflow EXECUTION engine.
+
+use crate::routing::RoutedLoopError;
+use friday_deepseek::DeepSeekError;
+
+/// What to do with a failed provider/route operation. The only two honest answers:
+/// retry the same route (transient), or stop and surface (everything else).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RetryDisposition {
+    /// Transient — the SAME route may be retried (bounded by [`should_retry`]).
+    /// NEVER a reroute to a different provider.
+    Retryable,
+    /// Do not retry — surface the failure (auth / credential / protocol / no-model /
+    /// selection / wiring / storage). Retrying cannot fix it, and must not fall back.
+    Terminal,
+}
+
+impl RetryDisposition {
+    pub fn is_retryable(self) -> bool {
+        matches!(self, RetryDisposition::Retryable)
+    }
+
+    /// Classify a DeepSeek provider error. ONLY a transient
+    /// [`DeepSeekError::ProviderUnavailable`] (network / 5xx / rate-limit) is
+    /// `Retryable`; credential / auth / bad-response / no-models / core errors are
+    /// `Terminal` — retrying cannot fix them, and (per the crate's own variant docs)
+    /// none of them is ever a fallback trigger.
+    pub fn classify_deepseek(err: &DeepSeekError) -> Self {
+        match err {
+            DeepSeekError::ProviderUnavailable(_) => RetryDisposition::Retryable,
+            DeepSeekError::CredentialMissing
+            | DeepSeekError::Auth(_)
+            | DeepSeekError::BadResponse(_)
+            | DeepSeekError::NoModels
+            | DeepSeekError::Core(_) => RetryDisposition::Terminal,
+        }
+    }
+
+    /// Classify a routed-loop error. All variants are `Terminal`:
+    /// - [`RoutedLoopError::Route`] is a SELECTION failure (no route / requested
+    ///   provider unavailable) — the no-fallback path; never retried into another.
+    /// - [`RoutedLoopError::NoClientForProvider`] is a deployment-wiring gap — a
+    ///   retry cannot conjure a client (fail-closed, no reroute).
+    /// - [`RoutedLoopError::Storage`] is a Hub-internal write failure — surfaced,
+    ///   not blindly retried.
+    pub fn classify_routed(err: &RoutedLoopError) -> Self {
+        match err {
+            RoutedLoopError::Route(_)
+            | RoutedLoopError::NoClientForProvider(_)
+            | RoutedLoopError::Storage(_) => RetryDisposition::Terminal,
+        }
+    }
+}
+
+/// Whether to retry, given the disposition, attempts ALREADY made, and a cap.
+/// Bounded: a `Retryable` failure is retried only while `attempts_made <
+/// max_attempts`; a `Terminal` failure is NEVER retried. `max_attempts == 0` ⇒
+/// never retry (degenerate bound). The decision is "retry the SAME route" — there
+/// is no reroute here.
+pub fn should_retry(disposition: RetryDisposition, attempts_made: u32, max_attempts: u32) -> bool {
+    disposition.is_retryable() && attempts_made < max_attempts
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::routing::RouteError;
+
+    #[test]
+    fn only_provider_unavailable_is_retryable() {
+        assert_eq!(
+            RetryDisposition::classify_deepseek(&DeepSeekError::ProviderUnavailable("503".into())),
+            RetryDisposition::Retryable
+        );
+        // Everything else is Terminal — retrying cannot fix it.
+        for terminal in [
+            DeepSeekError::CredentialMissing,
+            DeepSeekError::Auth(401),
+            DeepSeekError::BadResponse("garbage".into()),
+            DeepSeekError::NoModels,
+        ] {
+            assert_eq!(
+                RetryDisposition::classify_deepseek(&terminal),
+                RetryDisposition::Terminal,
+                "{terminal:?} must be terminal"
+            );
+        }
+    }
+
+    #[test]
+    fn routed_errors_are_all_terminal_no_fallback() {
+        // The no-fallback path: a requested-but-unavailable provider is surfaced,
+        // NEVER retried into a different provider.
+        assert_eq!(
+            RetryDisposition::classify_routed(&RoutedLoopError::Route(
+                RouteError::RequestedProviderUnavailable("codex".into())
+            )),
+            RetryDisposition::Terminal
+        );
+        assert_eq!(
+            RetryDisposition::classify_routed(&RoutedLoopError::Route(RouteError::EmptyRegistry)),
+            RetryDisposition::Terminal
+        );
+        assert_eq!(
+            RetryDisposition::classify_routed(&RoutedLoopError::NoClientForProvider(
+                "deepseek".into()
+            )),
+            RetryDisposition::Terminal
+        );
+    }
+
+    #[test]
+    fn should_retry_is_bounded_and_terminal_never_retries() {
+        // Retryable: retried only under the cap.
+        assert!(should_retry(RetryDisposition::Retryable, 0, 3));
+        assert!(should_retry(RetryDisposition::Retryable, 2, 3));
+        assert!(!should_retry(RetryDisposition::Retryable, 3, 3)); // bounded
+        assert!(!should_retry(RetryDisposition::Retryable, 9, 3));
+        // max_attempts == 0 ⇒ never retry.
+        assert!(!should_retry(RetryDisposition::Retryable, 0, 0));
+        // Terminal: never retried, at any attempt count.
+        assert!(!should_retry(RetryDisposition::Terminal, 0, 3));
+        assert!(!should_retry(RetryDisposition::Terminal, 1, 99));
+    }
+}

--- a/rust-core/crates/friday-hub/src/retry.rs
+++ b/rust-core/crates/friday-hub/src/retry.rs
@@ -93,12 +93,14 @@ mod tests {
             RetryDisposition::classify_deepseek(&DeepSeekError::ProviderUnavailable("503".into())),
             RetryDisposition::Retryable
         );
-        // Everything else is Terminal — retrying cannot fix it.
+        // Everything else is Terminal — retrying cannot fix it. (All 5 non-transient
+        // variants pinned, incl. Core — exhaustive coverage of the mapping.)
         for terminal in [
             DeepSeekError::CredentialMissing,
             DeepSeekError::Auth(401),
             DeepSeekError::BadResponse("garbage".into()),
             DeepSeekError::NoModels,
+            DeepSeekError::Core(friday_core::CoreError::BlockedTransfer("x".into())),
         ] {
             assert_eq!(
                 RetryDisposition::classify_deepseek(&terminal),
@@ -125,6 +127,22 @@ mod tests {
         assert_eq!(
             RetryDisposition::classify_routed(&RoutedLoopError::NoClientForProvider(
                 "deepseek".into()
+            )),
+            RetryDisposition::Terminal
+        );
+        // The remaining two variants pinned too (no-route selection + Hub-internal storage).
+        assert_eq!(
+            RetryDisposition::classify_routed(&RoutedLoopError::Route(
+                RouteError::NoEligibleRoute {
+                    required_capabilities: vec![],
+                    model_size: None,
+                }
+            )),
+            RetryDisposition::Terminal
+        );
+        assert_eq!(
+            RetryDisposition::classify_routed(&RoutedLoopError::Storage(
+                friday_storage::StorageError::Unsupported("x".into())
             )),
             RetryDisposition::Terminal
         );


### PR DESCRIPTION
## Step 5 (workflow/skills *substrate*) — UNW-011 retry classifier

The first safe, pure substrate piece (the workflow EXECUTION engine + skill exec stay deferred per the advisor's split). `friday-hub::retry` — ONE disposition taxonomy classified from the REAL error types.

- **`RetryDisposition` = Retryable | Terminal.**
- **`classify_deepseek`** — ONLY a transient `ProviderUnavailable` (network/5xx/rate-limit) is `Retryable`; credential/auth/bad-response/no-models/core are `Terminal` (a retry can't fix them).
- **`classify_routed`** — all `RoutedLoopError` variants are `Terminal`; in particular `RouteError::RequestedProviderUnavailable` is the explicit **no-fallback** path (surfaced, never retried into a different provider) — preserves UNW-003.
- **`should_retry(disposition, attempts_made, max_attempts)`** — **bounded**: a Retryable failure retries only under the cap; Terminal never retries; `max=0` never retries (no runaway / no unbounded spend).

**No silent fallback by construction:** the module exposes no API that returns an alternate provider — `Retryable` means "retry the **same** route", so classification cannot become a reroute. One canonical classifier, not a parallel taxonomy.

### Scope / honesty
- **Classifier + bound only.** Wiring it into a retry loop is part of the deferred workflow **execution** engine; the UNW-011 contract row stays NO-GO for the engine half.
- 3 tests (per-variant disposition; no-fallback-is-terminal; bounded + terminal-never-retries). Workspace **380**, clippy `-D warnings` clean, fmt clean, arch-tests green. Overall **v1: NO-GO**.