### PR TITLE
feat(hub): workflow execution engine — gate-mandatory, auto-advance read-only, pause at checkpoint (step 5)

### DIFF
--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -75,6 +75,12 @@ pub mod retry;
 /// narrow; unknown ⇒ fail-closed). Pure decision layer — no execution.
 pub mod planner;
 
+/// Step-5 — the workflow EXECUTION engine (operator-authorized): drives a definition
+/// semi-automatically, auto-advancing gate-safe read-only steps through the SHARED
+/// `gate_dispatch` chokepoint and pausing at the first checkpoint. Built-in tools
+/// only (no skill/plugin exec). Resume-after-approval is a deferred follow-up.
+pub mod workflow_exec;
+
 use friday_core::gate::{
     canonical_action_bytes, canonical_approval_signature_bytes, ActorKind, ApprovalDecision,
     CanonicalApproval, GateDecision, MutatingActionRequest, CANONICAL_GATE_ISSUER,
@@ -1210,6 +1216,55 @@ pub struct LoopOutcome {
     pub detail: String,
 }
 
+/// The outcome of dispatching ONE raw tool call through the gate-mandatory path.
+/// This is the SINGLE source of truth for "classify → authorize → execute ONLY on
+/// `Allow`", shared by [`run_loop`] (the model-driven agent loop) and
+/// [`workflow_exec::run_workflow`] (the definition-driven workflow engine), so the
+/// two drivers cannot drift on the security-critical dispatch. The caller records
+/// the outcome (event log / step state / history) in its own vocabulary.
+pub(crate) enum GateDispatch {
+    /// Gate `Allow`ed AND the executor ran successfully.
+    Executed(ToolReceipt),
+    /// Gate `Allow`ed but the executor returned an error (one executor call, not run).
+    ExecError(ExecError),
+    /// Gate withheld the action pending owner approval (`RequiresApproval`). Not executed.
+    RequiresApproval,
+    /// Gate `Deny`. Not executed; carries the reason.
+    Denied(String),
+    /// The action is not a registered tool — fail-closed; never executed.
+    Unregistered(String),
+}
+
+/// Classify → authorize → execute-ONLY-on-`Allow`, the gate-mandatory dispatch for a
+/// single raw tool call. The executor is invoked EXACTLY once, and ONLY on a gate
+/// `Allow`; `RequiresApproval`/`Deny`/unregistered never reach the executor. Records
+/// nothing itself (the caller does) — this is purely the security-critical decision +
+/// execution, so [`run_loop`] and [`workflow_exec::run_workflow`] share ONE copy.
+pub(crate) fn gate_dispatch(
+    conn: &Connection,
+    executor: &dyn ToolExecutor,
+    raw: &RawToolCall,
+    secret: &[u8],
+    approve: &dyn Fn(&MutatingActionRequest) -> Option<CanonicalApproval>,
+    now_ms: i64,
+) -> Result<GateDispatch, StorageError> {
+    let request = match build_request(raw) {
+        Ok(request) => request,
+        Err(ToolError::UnknownTool(action)) => return Ok(GateDispatch::Unregistered(action)),
+    };
+    let approval = approve(&request);
+    let record = authorize_mutating_action(conn, &request, approval.as_ref(), secret, now_ms)?;
+    Ok(match record.decision {
+        // Execute ONLY on Allow — the single chokepoint both drivers rely on.
+        GateDecision::Allow => match executor.execute(&raw.action, &raw.params) {
+            Ok(receipt) => GateDispatch::Executed(receipt),
+            Err(e) => GateDispatch::ExecError(e),
+        },
+        GateDecision::RequiresApproval => GateDispatch::RequiresApproval,
+        GateDecision::Deny => GateDispatch::Denied(record.reason),
+    })
+}
+
 /// Drive a MULTI-TURN agent loop: repeatedly ask the model for the next step (with
 /// conversation history), and for each proposed tool run the SAME gate-mandatory
 /// dispatch as [`run_one_turn_with_executor`] (authorize → execute only on `Allow` →
@@ -1308,9 +1363,10 @@ pub fn run_loop(
             AgentStep::Tool(raw) => raw,
         };
 
-        let request = match build_request(&raw) {
-            Ok(request) => request,
-            Err(ToolError::UnknownTool(action)) => {
+        // Gate-mandatory dispatch via the SHARED chokepoint (same as run_workflow):
+        // classify → authorize → execute ONLY on Allow. run_loop owns the recording.
+        match gate_dispatch(conn, executor, &raw, secret, approve, now_ms)? {
+            GateDispatch::Unregistered(action) => {
                 agent_run::record_event(
                     conn,
                     &ev("outcome"),
@@ -1326,14 +1382,8 @@ pub fn run_loop(
                     detail: format!("unregistered_tool:{action}"),
                 });
             }
-        };
-
-        let approval = approve(&request);
-        let record = authorize_mutating_action(conn, &request, approval.as_ref(), secret, now_ms)?;
-
-        match record.decision {
-            GateDecision::Allow => match executor.execute(&raw.action, &raw.params) {
-                Ok(receipt) => {
+            GateDispatch::Executed(receipt) => {
+                {
                     // Outcome event + hash-chained receipt in ONE tx (task #30): the
                     // event log can't get ahead of the ledger on a partial commit.
                     let tx = conn.unchecked_transaction()?;
@@ -1360,7 +1410,9 @@ pub fn run_loop(
                         outcome: format!("executed: {}", receipt.summary),
                     });
                 }
-                Err(e) => {
+            }
+            GateDispatch::ExecError(e) => {
+                {
                     // A tool error is informative, not fatal: thread it back and let the
                     // model adapt on the next turn (still bounded by max_turns). The error
                     // event + an `exec_failed` receipt are written in ONE tx so a
@@ -1389,8 +1441,8 @@ pub fn run_loop(
                         outcome: format!("exec_error: {err_text}"),
                     });
                 }
-            },
-            GateDecision::RequiresApproval => {
+            }
+            GateDispatch::RequiresApproval => {
                 agent_run::record_event(
                     conn,
                     &ev("outcome"),
@@ -1406,12 +1458,12 @@ pub fn run_loop(
                     detail: format!("requires_approval:{}", raw.action),
                 });
             }
-            GateDecision::Deny => {
+            GateDispatch::Denied(reason) => {
                 agent_run::record_event(
                     conn,
                     &ev("outcome"),
                     run_id,
-                    &format!("tool.blocked:deny:{}", record.reason),
+                    &format!("tool.blocked:deny:{reason}"),
                     now_ms,
                 )?;
                 return Ok(LoopOutcome {
@@ -1419,7 +1471,7 @@ pub fn run_loop(
                     turns: turn_index + 1,
                     executed_tools,
                     final_message: None,
-                    detail: format!("denied:{}", record.reason),
+                    detail: format!("denied:{reason}"),
                 });
             }
         }

--- a/rust-core/crates/friday-hub/src/planner.rs
+++ b/rust-core/crates/friday-hub/src/planner.rs
@@ -19,14 +19,21 @@
 //! never lower `mutating` or the risk floor (UNW-001/UNW-002 discipline).
 //!
 //! ## `AutoAdvance` is a PREVIEW, not an authorization
-//! The planner is a decision/preview layer; it does NOT authorize. When the
-//! (deferred) executor runs a step it MUST still go through the full UNW-001 gate
-//! (`authorize_mutating_action`), which additionally applies the principal/claim
-//! escalations the planner does not reproduce (e.g. sensitive-anonymous-read `#389`,
-//! `derive_risk` local-claim raises). So any planner-vs-gate divergence is
-//! fail-SAFE — the gate can only ADD approval at execution, never remove it — and a
-//! plan `AutoAdvance` must never be treated as a grant that lets the executor skip
-//! the gate.
+//! The planner is a decision/preview layer; it does NOT authorize. When the executor
+//! runs a step it MUST still go through the full UNW-001 gate
+//! (`authorize_mutating_action`), which applies the mutating-side escalations the
+//! planner does not reproduce — bound-principal (an agent cannot self-execute an
+//! approve/deny), local-guard `Deny` claims, and `derive_risk` raises. So any
+//! planner-vs-gate divergence is fail-SAFE (the gate can only ADD approval at
+//! execution, never remove it), and a plan `AutoAdvance` must never be treated as a
+//! grant that lets the executor skip the gate.
+//!
+//! NOTE (honest gap, not a claim): the mutating-action gate does NOT run the
+//! read-side sensitive-resource check (`evaluate_sensitive_read`, `#389`) — that gate
+//! is not yet wired into the live dispatch path (the `#494` enforcement gap). So a
+//! read-only step that reads a *sensitive* resource is NOT screened by `#389` here; it
+//! auto-advances. The read result stays Hub-side (any EXTERNAL transfer is separately
+//! Context-Passport-gated). Wiring `#389` into dispatch is a separate unit.
 //!
 //! ## Anti-speculation
 //! The definition models ONLY what the planner consumes: steps + each step's

--- a/rust-core/crates/friday-hub/src/workflow_exec.rs
+++ b/rust-core/crates/friday-hub/src/workflow_exec.rs
@@ -1,0 +1,375 @@
+//! Step-5 — the workflow EXECUTION engine (operator-authorized: orchestrates the
+//! already-proven BUILT-IN tools through the existing gate, NOT imported code).
+//!
+//! `run_workflow` drives a [`crate::planner::WorkflowDefinition`] semi-automatically
+//! (`08` §4): it AUTO-ADVANCES the planner-`AutoAdvance` (read-only, gate-safe) steps
+//! and PAUSES at the first step the planner marks a checkpoint (mutating / high-risk /
+//! template-policy / unclassifiable) — that step is registered but NOT executed; the
+//! run goes `AwaitingCheckpoint` (resumable; resume is a documented follow-up).
+//!
+//! ## Security spine (all reused, single-sourced — no new authorization path)
+//! - Every executed step goes through [`crate::gate_dispatch`] — the SAME
+//!   classify→authorize→execute-ONLY-on-`Allow` chokepoint `run_loop` uses. The
+//!   planner's `AutoAdvance` is a PREVIEW, never a bypass: the gate is the
+//!   authorization, so even an auto-advanced step is executed ONLY on a gate `Allow`,
+//!   and a gate `RequiresApproval`/`Deny` pauses/fails it (the backstop).
+//! - The planner only ADDS pauses: a mutating/destructive step is a checkpoint and is
+//!   never dispatched here, so this engine autonomously runs ONLY read-only steps.
+//! - A step's `action` is classified by `trusted_classify` (unknown ⇒ fail-closed
+//!   checkpoint), so it structurally cannot smuggle a skill/plugin invocation — this
+//!   engine runs registered built-in tools only (`FsToolExecutor`), the line the
+//!   operator drew (workflow-exec authorized; skill/plugin-exec NOT).
+//! - Run-state moves only through `set_run_state`'s SM guard + run-completion gate
+//!   (`08` §6 / #471): the run cannot reach `Done` while a side-effect step is
+//!   unverified, and an executed step is completed WITH its tool receipt as evidence.
+//! - Single-shot: `run_workflow` creates the run; re-invoking with the same `run_id`
+//!   fails closed at `create_run` (dup PK) — no double-dispatch. Resume = deferred.
+//!
+//! HONEST SCOPE: this advances `workflow_runtime_run_step_acceptance` toward wired
+//! (read-only auto-advance + checkpoint-pause + evidence-gated completion). The full
+//! engine (resume after approval, NL generation, skills) stays NO-GO; v1 NO-GO.
+
+use friday_core::gate::{CanonicalApproval, MutatingActionRequest};
+use friday_core::WorkflowRunState;
+use friday_storage::{workflow, StorageError};
+use rusqlite::Connection;
+
+use crate::planner::{plan_step, StepDisposition, WorkflowDefinition};
+use crate::{gate_dispatch, GateDispatch, RawToolCall, ToolExecutor};
+
+/// How a workflow run ended.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum WorkflowRunStatus {
+    /// Every step auto-advanced and the run reached `Done` (completion gate satisfied).
+    Completed,
+    /// Paused at a step that needs a user checkpoint (the step did NOT execute).
+    AwaitingCheckpoint { step_id: String, reason: String },
+    /// A dispatched step was gate-denied or errored; the run is `Failed`.
+    Failed { step_id: String, reason: String },
+}
+
+/// The outcome of a [`run_workflow`] invocation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WorkflowOutcome {
+    pub status: WorkflowRunStatus,
+    /// Steps that actually executed (gate `Allow` + executor `Ok`).
+    pub executed_steps: usize,
+}
+
+/// Drive a workflow definition: auto-advance gate-safe steps, pause at the first
+/// checkpoint. Creates the run (single-shot), records each step, and routes every
+/// executed step through the shared [`gate_dispatch`]. See the module docs for the
+/// security spine.
+#[allow(clippy::too_many_arguments)]
+pub fn run_workflow(
+    def: &WorkflowDefinition,
+    executor: &dyn ToolExecutor,
+    conn: &Connection,
+    run_id: &str,
+    secret: &[u8],
+    approve: &dyn Fn(&MutatingActionRequest) -> Option<CanonicalApproval>,
+    now_ms: i64,
+) -> Result<WorkflowOutcome, StorageError> {
+    // Single-shot: a duplicate run_id fails closed here (no double-dispatch on re-invoke).
+    workflow::create_run(conn, run_id, &def.name, now_ms)?;
+    workflow::set_run_state(conn, run_id, WorkflowRunState::Running, now_ms)?;
+
+    let mut executed_steps = 0usize;
+    for (seq, step) in def.steps.iter().enumerate() {
+        let step_id = format!("{run_id}:s{seq}");
+        match plan_step(step) {
+            // Checkpoint: register the step (a side-effect step needing evidence) but do
+            // NOT execute it; pause the run. The executor is never called for it.
+            StepDisposition::Checkpoint(reason) => {
+                workflow::add_step(conn, &step_id, run_id, seq as i64, true, now_ms)?;
+                workflow::set_run_state(
+                    conn,
+                    run_id,
+                    WorkflowRunState::AwaitingCheckpoint,
+                    now_ms,
+                )?;
+                return Ok(WorkflowOutcome {
+                    status: WorkflowRunStatus::AwaitingCheckpoint {
+                        step_id,
+                        reason: reason.as_str().to_string(),
+                    },
+                    executed_steps,
+                });
+            }
+            // Auto-advance: register, then dispatch through the gate (the authorization).
+            StepDisposition::AutoAdvance => {
+                workflow::add_step(
+                    conn,
+                    &step_id,
+                    run_id,
+                    seq as i64,
+                    step.evidence_required,
+                    now_ms,
+                )?;
+                let raw = RawToolCall {
+                    action: step.action.clone(),
+                    params: step.params.clone(),
+                };
+                match gate_dispatch(conn, executor, &raw, secret, approve, now_ms)? {
+                    GateDispatch::Executed(receipt) => {
+                        // Complete WITH the tool receipt as evidence (`08` §6).
+                        workflow::complete_step(
+                            conn,
+                            &step_id,
+                            Some(&receipt.summary),
+                            true,
+                            now_ms,
+                        )?;
+                        executed_steps += 1;
+                    }
+                    GateDispatch::ExecError(e) => {
+                        // Gate-Allowed but the tool failed: no evidence → not verified; run Failed.
+                        workflow::complete_step(conn, &step_id, None, false, now_ms)?;
+                        workflow::set_run_state(conn, run_id, WorkflowRunState::Failed, now_ms)?;
+                        return Ok(WorkflowOutcome {
+                            status: WorkflowRunStatus::Failed {
+                                step_id,
+                                reason: format!("exec_error:{e}"),
+                            },
+                            executed_steps,
+                        });
+                    }
+                    // The gate BACKSTOP: an auto-advanced step the gate escalates is paused,
+                    // never executed (the planner preview is not the authorization).
+                    GateDispatch::RequiresApproval => {
+                        workflow::set_run_state(
+                            conn,
+                            run_id,
+                            WorkflowRunState::AwaitingCheckpoint,
+                            now_ms,
+                        )?;
+                        return Ok(WorkflowOutcome {
+                            status: WorkflowRunStatus::AwaitingCheckpoint {
+                                step_id,
+                                reason: "gate_requires_approval".to_string(),
+                            },
+                            executed_steps,
+                        });
+                    }
+                    GateDispatch::Denied(reason) => {
+                        workflow::set_run_state(conn, run_id, WorkflowRunState::Failed, now_ms)?;
+                        return Ok(WorkflowOutcome {
+                            status: WorkflowRunStatus::Failed {
+                                step_id,
+                                reason: format!("denied:{reason}"),
+                            },
+                            executed_steps,
+                        });
+                    }
+                    GateDispatch::Unregistered(action) => {
+                        // Unreachable in practice (plan_step fails-closed unknown → Checkpoint
+                        // before we get here), but fail-closed here too.
+                        workflow::set_run_state(conn, run_id, WorkflowRunState::Failed, now_ms)?;
+                        return Ok(WorkflowOutcome {
+                            status: WorkflowRunStatus::Failed {
+                                step_id,
+                                reason: format!("unregistered:{action}"),
+                            },
+                            executed_steps,
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    // All steps auto-advanced. `set_run_state(Done)` enforces the completion gate
+    // (refuses Done if any side-effect step is unverified).
+    workflow::set_run_state(conn, run_id, WorkflowRunState::Done, now_ms)?;
+    Ok(WorkflowOutcome {
+        status: WorkflowRunStatus::Completed,
+        executed_steps,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ExecError, ToolReceipt};
+    use friday_storage::Db;
+    use std::cell::Cell;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static C: AtomicU64 = AtomicU64::new(0);
+    fn tmp(tag: &str) -> String {
+        std::env::temp_dir()
+            .join(format!(
+                "friday-wfexec-{}-{}-{}.sqlite",
+                std::process::id(),
+                tag,
+                C.fetch_add(1, Ordering::Relaxed)
+            ))
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    const SECRET: &[u8] = b"wf-exec-secret-0123456789abcdef";
+
+    /// Executor that records its call count and returns a receipt — so a test can prove
+    /// a checkpoint step was NEVER executed (call-count witness).
+    struct CountingExec {
+        calls: Cell<usize>,
+    }
+    impl ToolExecutor for CountingExec {
+        fn execute(
+            &self,
+            action: &str,
+            _params: &[(String, String)],
+        ) -> Result<ToolReceipt, ExecError> {
+            self.calls.set(self.calls.get() + 1);
+            Ok(ToolReceipt {
+                action: action.to_string(),
+                summary: format!("ran {action}"),
+            })
+        }
+    }
+
+    fn deny_all(_r: &MutatingActionRequest) -> Option<CanonicalApproval> {
+        None
+    }
+
+    fn step(
+        id: &str,
+        action: &str,
+        params: &[(&str, &str)],
+        force: bool,
+        evidence: bool,
+    ) -> crate::planner::WorkflowStep {
+        crate::planner::WorkflowStep {
+            id: id.to_string(),
+            action: action.to_string(),
+            params: params
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+            force_checkpoint: force,
+            evidence_required: evidence,
+        }
+    }
+
+    fn run_state(db: &Db, run_id: &str) -> String {
+        workflow::run_state(db.conn(), run_id)
+            .unwrap()
+            .unwrap()
+            .as_str()
+            .to_string()
+    }
+
+    #[test]
+    fn all_read_only_steps_auto_advance_to_completed() {
+        let db = Db::open_hub(&tmp("ro")).unwrap();
+        let exec = CountingExec {
+            calls: Cell::new(0),
+        };
+        let def = WorkflowDefinition {
+            name: "research".into(),
+            steps: vec![
+                step("a", "read_file", &[("path", "x")], false, false),
+                step("b", "search", &[("query", "TODO")], false, false),
+            ],
+        };
+        let out = run_workflow(&def, &exec, db.conn(), "r1", SECRET, &deny_all, 100).unwrap();
+        assert_eq!(out.status, WorkflowRunStatus::Completed);
+        assert_eq!(out.executed_steps, 2);
+        assert_eq!(exec.calls.get(), 2, "both read-only steps executed");
+        assert_eq!(run_state(&db, "r1"), "done");
+    }
+
+    #[test]
+    fn mutating_step_pauses_and_executor_is_never_called_for_it() {
+        // THE safety witness: a checkpoint step is registered but NOT executed.
+        let db = Db::open_hub(&tmp("pause")).unwrap();
+        let exec = CountingExec {
+            calls: Cell::new(0),
+        };
+        let def = WorkflowDefinition {
+            name: "ship".into(),
+            steps: vec![
+                step("read", "read_file", &[("path", "x")], false, false),
+                step(
+                    "write",
+                    "write_file",
+                    &[("path", "o"), ("content", "y")],
+                    false,
+                    true,
+                ),
+                step("never", "read_file", &[("path", "z")], false, false),
+            ],
+        };
+        let out = run_workflow(&def, &exec, db.conn(), "r1", SECRET, &deny_all, 100).unwrap();
+        match out.status {
+            WorkflowRunStatus::AwaitingCheckpoint { step_id, reason } => {
+                assert_eq!(step_id, "r1:s1");
+                assert!(reason.contains("mutating"));
+            }
+            other => panic!("expected AwaitingCheckpoint, got {other:?}"),
+        }
+        // Only the FIRST read-only step ran; the mutating step (and the step after it)
+        // were NOT executed.
+        assert_eq!(out.executed_steps, 1);
+        assert_eq!(
+            exec.calls.get(),
+            1,
+            "executor must NOT run the mutating checkpoint step"
+        );
+        assert_eq!(run_state(&db, "r1"), "awaiting_checkpoint");
+    }
+
+    #[test]
+    fn unknown_action_step_fails_closed_to_checkpoint_not_executed() {
+        let db = Db::open_hub(&tmp("unknown")).unwrap();
+        let exec = CountingExec {
+            calls: Cell::new(0),
+        };
+        let def = WorkflowDefinition {
+            name: "x".into(),
+            steps: vec![step("u", "frobnicate", &[], false, false)],
+        };
+        let out = run_workflow(&def, &exec, db.conn(), "r1", SECRET, &deny_all, 100).unwrap();
+        assert!(matches!(
+            out.status,
+            WorkflowRunStatus::AwaitingCheckpoint { .. }
+        ));
+        assert_eq!(exec.calls.get(), 0, "an unknown action is never executed");
+    }
+
+    #[test]
+    fn evidence_required_step_completes_with_receipt_and_run_reaches_done() {
+        // An evidence_required (side-effect) read-only step executes; its tool receipt
+        // is attached as evidence → Verified → the run-completion gate lets it reach Done.
+        let db = Db::open_hub(&tmp("evidence")).unwrap();
+        let exec = CountingExec {
+            calls: Cell::new(0),
+        };
+        let def = WorkflowDefinition {
+            name: "qa".into(),
+            steps: vec![step("e", "read_file", &[("path", "log")], false, true)],
+        };
+        let out = run_workflow(&def, &exec, db.conn(), "r1", SECRET, &deny_all, 100).unwrap();
+        assert_eq!(out.status, WorkflowRunStatus::Completed);
+        assert_eq!(run_state(&db, "r1"), "done");
+        // the step is Verified (evidence attached).
+        let status = workflow::step_status(db.conn(), "r1:s0").unwrap().unwrap();
+        assert_eq!(status.as_str(), "verified");
+    }
+
+    #[test]
+    fn re_invoking_the_same_run_id_fails_closed_single_shot() {
+        let db = Db::open_hub(&tmp("single")).unwrap();
+        let exec = CountingExec {
+            calls: Cell::new(0),
+        };
+        let def = WorkflowDefinition {
+            name: "x".into(),
+            steps: vec![step("a", "read_file", &[("path", "x")], false, false)],
+        };
+        run_workflow(&def, &exec, db.conn(), "r1", SECRET, &deny_all, 100).unwrap();
+        // re-invoking the SAME run_id is a fail-closed dup (no double-dispatch).
+        assert!(run_workflow(&def, &exec, db.conn(), "r1", SECRET, &deny_all, 200).is_err());
+    }
+}

--- a/rust-core/crates/friday-hub/src/workflow_exec.rs
+++ b/rust-core/crates/friday-hub/src/workflow_exec.rs
@@ -19,6 +19,13 @@
 //!   checkpoint), so it structurally cannot smuggle a skill/plugin invocation — this
 //!   engine runs registered built-in tools only (`FsToolExecutor`), the line the
 //!   operator drew (workflow-exec authorized; skill/plugin-exec NOT).
+//! - HONEST GAP: `gate_dispatch` runs the MUTATING-action gate (`authorize_mutating_action`
+//!   → `gate::evaluate`), which does NOT run the read-side sensitive-resource check
+//!   (`evaluate_sensitive_read`, `#389` — not yet wired into the live dispatch path,
+//!   the `#494` enforcement gap). So a read-only step reading a *sensitive* resource
+//!   auto-advances WITHOUT a `#389` checkpoint. The read result stays Hub-side; any
+//!   external transfer is separately Context-Passport-gated. Wiring `#389` into
+//!   dispatch (so a sensitive read also checkpoints) is a separate unit.
 //! - Run-state moves only through `set_run_state`'s SM guard + run-completion gate
 //!   (`08` §6 / #471): the run cannot reach `Done` while a side-effect step is
 //!   unverified, and an executed step is completed WITH its tool receipt as evidence.


### PR DESCRIPTION
## Step 5 — workflow EXECUTION engine (operator-authorized)

Operator authorized **workflow-exec** (orchestrate the already-proven built-in tools through the existing gate; **not** skill/plugin-exec). No imported code, no new authorization path.

### Shared chokepoint (advisor #3 — single source of truth)
- Extracted **`gate_dispatch`** (classify → authorize → execute **only on `Allow`**) and refactored `run_loop` to use it. **`run_loop` behavior unchanged — all 108 friday-hub tests still pass.** The model-driven loop and the definition-driven workflow now share ONE copy of the security-critical dispatch (they can't drift).

### `friday-hub::workflow_exec::run_workflow`
- Drives a `WorkflowDefinition` semi-automatically (`08` §4): auto-advances planner-`AutoAdvance` (read-only, gate-safe) steps; **pauses at the first checkpoint** (mutating/high-risk/template/unclassifiable) — that step is registered but **not executed**; run → `AwaitingCheckpoint` (resume = documented follow-up).
- Every executed step routes through `gate_dispatch`: the planner `AutoAdvance` is a **preview**, the **gate is the authorization** (executes only on `Allow`; `RequiresApproval`/`Deny` pauses/fails — the backstop). The planner only **adds** pauses, so this engine autonomously runs **only read-only** steps.
- **Built-in tools only:** a step's action goes through `trusted_classify` (unknown ⇒ fail-closed checkpoint), so it structurally cannot smuggle a skill/plugin call — the line the operator drew.
- **SM-guarded** state (`set_run_state`/`try_transition`) + **run-completion gate** (#471: no `Done` with an unverified side-effect step); an executed step completes **with its tool receipt as evidence** (`08` §6). **Single-shot:** re-invoking the same `run_id` fails closed at `create_run` (no double-dispatch); resume deferred.

### Tests (5 workflow_exec + 108 run_loop regression)
all-read-only → `Completed` (executor called N, run `Done`); **mutating step PAUSES with executor-call-count == 0** (the safety witness); unknown-action fails-closed-not-executed; `evidence_required` step verified-with-receipt → run `Done`; single-shot re-invoke fails. Workspace **397**, clippy `-D warnings` clean, fmt clean, arch-tests green.

### Honest scope
Advances `workflow_runtime_run_step_acceptance` toward wired (read-only auto-advance + checkpoint-pause + evidence-gated completion). **Resume-after-approval, NL generation, skill/plugin execution all stay NO-GO.** Overall **Friday v1: NO-GO**.