### PR TITLE
feat(hub): planner checkpoints sensitive-resource reads (#389/#494 floor) — closes the #505 gap

### DIFF
--- a/rust-core/crates/friday-hub/src/planner.rs
+++ b/rust-core/crates/friday-hub/src/planner.rs
@@ -139,7 +139,12 @@ pub fn plan_step(step: &WorkflowStep) -> StepDisposition {
     // Sensitive-resource floor (`#389`/`#494`): even a read of a token/secret/key/.pem
     // resource checkpoints — not template-overridable. The classifier already extracted
     // the resource from a path/target/file param; we screen it with the same detector
-    // the read-side gate uses. (Closes the #505 gap for the workflow path.)
+    // the read-side gate uses. (Closes the #505 gap for the workflow path.) NOTE the
+    // floor fires only when a resource is extracted, which `classify` does solely from
+    // params named `path`/`target`/`file` (the same extraction the approval-digest
+    // scoping uses) — the built-in read tools all use `path`, but a future custom
+    // tool-pack read tool naming its target differently would need that extraction
+    // extended to stay screened here.
     if classified
         .resource()
         .is_some_and(friday_core::gate::is_sensitive_resource)

--- a/rust-core/crates/friday-hub/src/planner.rs
+++ b/rust-core/crates/friday-hub/src/planner.rs
@@ -28,12 +28,12 @@
 //! execution, never remove it), and a plan `AutoAdvance` must never be treated as a
 //! grant that lets the executor skip the gate.
 //!
-//! NOTE (honest gap, not a claim): the mutating-action gate does NOT run the
-//! read-side sensitive-resource check (`evaluate_sensitive_read`, `#389`) — that gate
-//! is not yet wired into the live dispatch path (the `#494` enforcement gap). So a
-//! read-only step that reads a *sensitive* resource is NOT screened by `#389` here; it
-//! auto-advances. The read result stays Hub-side (any EXTERNAL transfer is separately
-//! Context-Passport-gated). Wiring `#389` into dispatch is a separate unit.
+//! Sensitive resources (`#389`/`#494`): the planner screens the classifier's extracted
+//! resource with `is_sensitive_resource`, so even a READ of a sensitive resource
+//! (token/secret/key/.pem/…) checkpoints (`CheckpointReason::SensitiveResource`) rather
+//! than auto-advancing. This closes the read-side gap at the planner for the workflow
+//! path. (The broader model-driven `run_loop` dispatch still does not run the read-side
+//! gate — that remains the `#494` enforcement gap for that path, a separate unit.)
 //!
 //! ## Anti-speculation
 //! The definition models ONLY what the planner consumes: steps + each step's
@@ -79,6 +79,10 @@ pub enum CheckpointReason {
     Mutating,
     /// The action's risk is `>= High` (destructive / high-risk) — the gate floor.
     HighRisk,
+    /// The action touches a SENSITIVE resource (token/secret/key/.pem/…) — even a
+    /// read of a sensitive resource checkpoints (`#389`/`#494` applied at the planner;
+    /// the gate floor, not template-overridable).
+    SensitiveResource,
     /// Gate-safe, but the template's checkpoint policy requires a checkpoint (NARROW).
     TemplatePolicy,
     /// Unregistered/unclassifiable action — fail-closed (never auto-advance unknown).
@@ -90,6 +94,7 @@ impl CheckpointReason {
         match self {
             CheckpointReason::Mutating => "mutating action (gate floor)",
             CheckpointReason::HighRisk => "high-risk action (gate floor)",
+            CheckpointReason::SensitiveResource => "sensitive resource access (gate floor)",
             CheckpointReason::TemplatePolicy => "template checkpoint policy",
             CheckpointReason::Unclassifiable => "unclassifiable/unregistered action (fail-closed)",
         }
@@ -115,9 +120,10 @@ impl StepDisposition {
 /// Decide a single step's disposition, anchored to the trusted classifier.
 ///
 /// Order matters and encodes the floor: classify FIRST (the gate's verdict), and a
-/// mutating or `>= High` action checkpoints unconditionally — the template flag is
-/// consulted ONLY after the gate has cleared the step, so it can add but never
-/// remove a checkpoint. An unregistered action is a fail-closed checkpoint.
+/// mutating action, a `>= High`-risk action, or a SENSITIVE-resource access
+/// checkpoints unconditionally — the template flag is consulted ONLY after these
+/// floors clear, so it can add but never remove a checkpoint. An unregistered action
+/// is a fail-closed checkpoint.
 pub fn plan_step(step: &WorkflowStep) -> StepDisposition {
     let classified = match trusted_classify(&step.action, &step.params) {
         Ok(c) => c,
@@ -130,7 +136,17 @@ pub fn plan_step(step: &WorkflowStep) -> StepDisposition {
     if matches!(classified.risk(), Some(r) if r >= Risk::High) {
         return StepDisposition::Checkpoint(CheckpointReason::HighRisk);
     }
-    // Gate-safe (read-only, below High). The template may NARROW only.
+    // Sensitive-resource floor (`#389`/`#494`): even a read of a token/secret/key/.pem
+    // resource checkpoints — not template-overridable. The classifier already extracted
+    // the resource from a path/target/file param; we screen it with the same detector
+    // the read-side gate uses. (Closes the #505 gap for the workflow path.)
+    if classified
+        .resource()
+        .is_some_and(friday_core::gate::is_sensitive_resource)
+    {
+        return StepDisposition::Checkpoint(CheckpointReason::SensitiveResource);
+    }
+    // Gate-safe (read-only, below High, non-sensitive). The template may NARROW only.
     if step.force_checkpoint {
         return StepDisposition::Checkpoint(CheckpointReason::TemplatePolicy);
     }
@@ -213,6 +229,35 @@ mod tests {
             false,
         ));
         assert!(d.is_checkpoint());
+    }
+
+    #[test]
+    fn read_of_a_sensitive_resource_checkpoints_not_auto_advance() {
+        // Even a READ-ONLY step checkpoints when its resource is sensitive (#389/#494):
+        // a workflow must not silently auto-read a secret/key/.pem.
+        for path in [
+            "secrets.pem",
+            "id_rsa",
+            "api_token.txt",
+            "service.credential",
+        ] {
+            let d = plan_step(&step("s", "read_file", &[("path", path)], false));
+            assert_eq!(
+                d,
+                StepDisposition::Checkpoint(CheckpointReason::SensitiveResource),
+                "reading {path} must checkpoint"
+            );
+        }
+        // a non-sensitive read still auto-advances.
+        assert_eq!(
+            plan_step(&step("s", "read_file", &[("path", "notes.txt")], false)),
+            StepDisposition::AutoAdvance
+        );
+        // a read with NO resource param (e.g. search) is not sensitive → auto-advance.
+        assert_eq!(
+            plan_step(&step("s", "search", &[("query", "TODO")], false)),
+            StepDisposition::AutoAdvance
+        );
     }
 
     #[test]

--- a/rust-core/crates/friday-hub/src/workflow_exec.rs
+++ b/rust-core/crates/friday-hub/src/workflow_exec.rs
@@ -19,13 +19,12 @@
 //!   checkpoint), so it structurally cannot smuggle a skill/plugin invocation — this
 //!   engine runs registered built-in tools only (`FsToolExecutor`), the line the
 //!   operator drew (workflow-exec authorized; skill/plugin-exec NOT).
-//! - HONEST GAP: `gate_dispatch` runs the MUTATING-action gate (`authorize_mutating_action`
-//!   → `gate::evaluate`), which does NOT run the read-side sensitive-resource check
-//!   (`evaluate_sensitive_read`, `#389` — not yet wired into the live dispatch path,
-//!   the `#494` enforcement gap). So a read-only step reading a *sensitive* resource
-//!   auto-advances WITHOUT a `#389` checkpoint. The read result stays Hub-side; any
-//!   external transfer is separately Context-Passport-gated. Wiring `#389` into
-//!   dispatch (so a sensitive read also checkpoints) is a separate unit.
+//! - Sensitive reads checkpoint (`#389`/`#494`): the planner screens each step's
+//!   resource, so a read of a token/secret/key/.pem resource is a
+//!   `CheckpointReason::SensitiveResource` checkpoint — it PAUSES, never auto-advances.
+//!   (The narrower remaining `#494` gap is the model-driven `run_loop` dispatch, which
+//!   does not run the read-side gate — a separate unit; it does not affect this
+//!   definition-driven engine, whose every step is planner-screened first.)
 //! - Run-state moves only through `set_run_state`'s SM guard + run-completion gate
 //!   (`08` §6 / #471): the run cannot reach `Done` while a side-effect step is
 //!   unverified, and an executed step is completed WITH its tool receipt as evidence.
@@ -323,6 +322,39 @@ mod tests {
             exec.calls.get(),
             1,
             "executor must NOT run the mutating checkpoint step"
+        );
+        assert_eq!(run_state(&db, "r1"), "awaiting_checkpoint");
+    }
+
+    #[test]
+    fn sensitive_resource_read_pauses_and_is_not_executed() {
+        // A read of a sensitive resource checkpoints (the planner SensitiveResource floor):
+        // the workflow pauses and the executor is NEVER called for it.
+        let db = Db::open_hub(&tmp("sensread")).unwrap();
+        let exec = CountingExec {
+            calls: Cell::new(0),
+        };
+        let def = WorkflowDefinition {
+            name: "audit".into(),
+            steps: vec![step(
+                "read_secret",
+                "read_file",
+                &[("path", "id_rsa")],
+                false,
+                false,
+            )],
+        };
+        let out = run_workflow(&def, &exec, db.conn(), "r1", SECRET, &deny_all, 100).unwrap();
+        match out.status {
+            WorkflowRunStatus::AwaitingCheckpoint { reason, .. } => {
+                assert!(reason.contains("sensitive resource"), "reason: {reason}");
+            }
+            other => panic!("expected AwaitingCheckpoint, got {other:?}"),
+        }
+        assert_eq!(
+            exec.calls.get(),
+            0,
+            "a sensitive read must NOT auto-execute"
         );
         assert_eq!(run_state(&db, "r1"), "awaiting_checkpoint");
     }


### PR DESCRIPTION
## Closes the #505-documented sensitive-read gap (planner path)

#505 documented a gap: a read-only workflow step reading a **sensitive** resource (secret/key/`.pem`/token) auto-advanced without a #389 checkpoint. This closes it **at the planner** — purely additive safety (adds a checkpoint, executes nothing new, needs no new authorization).

### `planner::plan_step`
A new gate-floor check after mutating/high-risk: if the classifier's extracted resource is **`is_sensitive_resource`** (the SAME #494 detector the read-side gate uses), the step is **`Checkpoint(SensitiveResource)`**, not `AutoAdvance`. Not template-overridable (a floor, like mutating/high-risk). The resource was already extracted by `trusted_classify` from the `path`/`target`/`file` param, so **no new input**. A non-sensitive read still auto-advances; a step with no resource param is not sensitive.

### Effect
The workflow EXECUTION engine now **pauses at a read of a sensitive resource** (the executor is never called for it) — closing the documented gap for the definition-driven path. (The narrower #494 gap remains the **model-driven `run_loop`** dispatch, a separate unit; it doesn't affect this engine, where every step is planner-screened first.)

### Tests
planner +1 (`secrets.pem`/`id_rsa`/`api_token`/`credential` → checkpoint; non-sensitive read + no-resource step → auto-advance); workflow_exec +1 (sensitive read pauses, executor-call-count == 0). Workspace **399**, clippy `-D warnings` clean, fmt clean, arch-tests green. Overall **v1: NO-GO**.