### PR TITLE
feat(hub): workflow resume-after-approval (operator-authorized) — gate-bounded, no re-execution

### DIFF
--- a/rust-core/crates/friday-hub/src/workflow_exec.rs
+++ b/rust-core/crates/friday-hub/src/workflow_exec.rs
@@ -655,6 +655,46 @@ mod tests {
     }
 
     #[test]
+    fn resume_of_a_sensitive_read_executes_on_resume_alone_no_crypto_approval() {
+        // Locks the documented authorization asymmetry: a sensitive READ checkpoints at
+        // the planner, but on RESUME it is gate-Allowed (a read needs no approval) — the
+        // resume_workflow call IS the human authorization. Even with deny-all (no minted
+        // approval), the resumed read executes. (A mutating step would still need a crypto
+        // approval — proven by resume_without_a_valid_approval_re_pauses.)
+        let db = Db::open_hub(&tmp("resume-sensread")).unwrap();
+        let exec = CountingExec {
+            calls: Cell::new(0),
+        };
+        let def = WorkflowDefinition {
+            name: "audit".into(),
+            steps: vec![step(
+                "read_secret",
+                "read_file",
+                &[("path", "id_rsa")],
+                false,
+                false,
+            )],
+        };
+        // Pause at the sensitive read; the executor is NOT called.
+        let paused = run_workflow(&def, &exec, db.conn(), "r1", SECRET, &deny_all, 100).unwrap();
+        assert!(matches!(
+            paused.status,
+            WorkflowRunStatus::AwaitingCheckpoint { .. }
+        ));
+        assert_eq!(exec.calls.get(), 0);
+        // Resume with NO crypto approval (deny-all) → the read executes (resume is the
+        // authorization for a read) → run reaches Done.
+        let out = resume_workflow(&def, &exec, db.conn(), "r1", SECRET, &deny_all, 200).unwrap();
+        assert_eq!(out.status, WorkflowRunStatus::Completed);
+        assert_eq!(
+            exec.calls.get(),
+            1,
+            "the sensitive read executes on resume alone"
+        );
+        assert_eq!(run_state(&db, "r1"), "done");
+    }
+
+    #[test]
     fn resume_advances_to_the_next_checkpoint() {
         let db = Db::open_hub(&tmp("resume-next")).unwrap();
         let exec = CountingExec {

--- a/rust-core/crates/friday-hub/src/workflow_exec.rs
+++ b/rust-core/crates/friday-hub/src/workflow_exec.rs
@@ -5,7 +5,8 @@
 //! (`08` §4): it AUTO-ADVANCES the planner-`AutoAdvance` (read-only, gate-safe) steps
 //! and PAUSES at the first step the planner marks a checkpoint (mutating / high-risk /
 //! template-policy / unclassifiable) — that step is registered but NOT executed; the
-//! run goes `AwaitingCheckpoint` (resumable; resume is a documented follow-up).
+//! run goes `AwaitingCheckpoint`. [`resume_workflow`] resumes such a run after the owner
+//! approves the paused step (executes it THROUGH THE GATE, then continues).
 //!
 //! ## Security spine (all reused, single-sourced — no new authorization path)
 //! - Every executed step goes through [`crate::gate_dispatch`] — the SAME
@@ -29,14 +30,20 @@
 //!   (`08` §6 / #471): the run cannot reach `Done` while a side-effect step is
 //!   unverified, and an executed step is completed WITH its tool receipt as evidence.
 //! - Single-shot: `run_workflow` creates the run; re-invoking with the same `run_id`
-//!   fails closed at `create_run` (dup PK) — no double-dispatch. Resume = deferred.
+//!   fails closed at `create_run` (dup PK) — no double-dispatch. RESUME after approval
+//!   is [`resume_workflow`]: it only re-enters an `AwaitingCheckpoint` run, starts at the
+//!   paused (`Pending`) step (already-`Verified` steps are never re-executed), and the
+//!   GATE still authorizes — a mutating step executes ONLY with a valid approval, else
+//!   it re-pauses (no unapproved mutating execution).
 //!
 //! HONEST SCOPE: this advances `workflow_runtime_run_step_acceptance` toward wired
-//! (read-only auto-advance + checkpoint-pause + evidence-gated completion). The full
-//! engine (resume after approval, NL generation, skills) stays NO-GO; v1 NO-GO.
+//! (read-only auto-advance + checkpoint-pause + evidence-gated completion + gated
+//! resume). The resume MECHANISM is built, but the LIVE owner-approval leg is not wired
+//! (operator/Computer-Use-gated), so a mutating resume re-pauses in v1 unless a real
+//! approval is supplied. NL generation + skill/plugin execution stay NO-GO; v1 NO-GO.
 
 use friday_core::gate::{CanonicalApproval, MutatingActionRequest};
-use friday_core::WorkflowRunState;
+use friday_core::{StepStatus, WorkflowRunState};
 use friday_storage::{workflow, StorageError};
 use rusqlite::Connection;
 
@@ -62,10 +69,8 @@ pub struct WorkflowOutcome {
     pub executed_steps: usize,
 }
 
-/// Drive a workflow definition: auto-advance gate-safe steps, pause at the first
-/// checkpoint. Creates the run (single-shot), records each step, and routes every
-/// executed step through the shared [`gate_dispatch`]. See the module docs for the
-/// security spine.
+/// Drive a workflow definition from the start: auto-advance gate-safe steps, pause at
+/// the first checkpoint. Creates the run (single-shot), then [`advance_from`] step 0.
 #[allow(clippy::too_many_arguments)]
 pub fn run_workflow(
     def: &WorkflowDefinition,
@@ -79,9 +84,134 @@ pub fn run_workflow(
     // Single-shot: a duplicate run_id fails closed here (no double-dispatch on re-invoke).
     workflow::create_run(conn, run_id, &def.name, now_ms)?;
     workflow::set_run_state(conn, run_id, WorkflowRunState::Running, now_ms)?;
+    advance_from(def, 0, executor, conn, run_id, secret, approve, 0, now_ms)
+}
 
-    let mut executed_steps = 0usize;
-    for (seq, step) in def.steps.iter().enumerate() {
+/// Resume an `AwaitingCheckpoint` run after the owner approved the paused step
+/// (operator-authorized). Validates the run is paused, finds the paused step, sets the
+/// run Running, force-dispatches the paused step THROUGH THE GATE, then continues
+/// auto-advancing to the next checkpoint / `Done`.
+///
+/// Resuming is the HUMAN checkpoint, but the GATE is still the authorization: a mutating
+/// paused step is executed ONLY if `approve` returns a valid `CanonicalApproval` for it
+/// (else it RE-pauses, never executes unapproved); a sensitive-read paused step is
+/// gate-`Allow`ed (a read needs no approval — resuming is the human decision to proceed).
+/// Already-Verified earlier steps are NEVER re-executed (resume starts at the paused
+/// step). Resuming a run that is NOT `AwaitingCheckpoint` is a fail-closed error.
+///
+/// HONEST SCOPE: this is the resume MECHANISM. In v1 `approve` is deny-all (no live
+/// owner-approval leg is wired — that leg is operator/Computer-Use-gated), so a mutating
+/// resume re-pauses unless a real approval is supplied; tests use a minted approval.
+#[allow(clippy::too_many_arguments)]
+pub fn resume_workflow(
+    def: &WorkflowDefinition,
+    executor: &dyn ToolExecutor,
+    conn: &Connection,
+    run_id: &str,
+    secret: &[u8],
+    approve: &dyn Fn(&MutatingActionRequest) -> Option<CanonicalApproval>,
+    now_ms: i64,
+) -> Result<WorkflowOutcome, StorageError> {
+    let state = workflow::run_state(conn, run_id)?
+        .ok_or_else(|| StorageError::Unsupported(format!("workflow_run '{run_id}' not found")))?;
+    if state != WorkflowRunState::AwaitingCheckpoint {
+        return Err(StorageError::Unsupported(format!(
+            "cannot resume workflow_run '{run_id}': state is {} (only an AwaitingCheckpoint run is resumable)",
+            state.as_str()
+        )));
+    }
+    let paused_seq = find_paused_seq(conn, run_id, def.steps.len())?;
+    let step = &def.steps[paused_seq];
+    let step_id = format!("{run_id}:s{paused_seq}");
+    // Back to Running (a valid SM transition from AwaitingCheckpoint).
+    workflow::set_run_state(conn, run_id, WorkflowRunState::Running, now_ms)?;
+    // Force-dispatch the paused step through the gate. The owner approved by resuming,
+    // but the GATE is the authorization — a mutating step needs `approve` to grant a
+    // valid approval; otherwise it RE-pauses (never executes unapproved).
+    let raw = RawToolCall {
+        action: step.action.clone(),
+        params: step.params.clone(),
+    };
+    match gate_dispatch(conn, executor, &raw, secret, approve, now_ms)? {
+        GateDispatch::Executed(receipt) => {
+            workflow::complete_step(conn, &step_id, Some(&receipt.summary), true, now_ms)?;
+        }
+        GateDispatch::RequiresApproval => {
+            // No valid approval on resume → re-pause; the step does NOT execute.
+            workflow::set_run_state(conn, run_id, WorkflowRunState::AwaitingCheckpoint, now_ms)?;
+            return Ok(WorkflowOutcome {
+                status: WorkflowRunStatus::AwaitingCheckpoint {
+                    step_id,
+                    reason: "gate_requires_approval (resume without a valid approval)".to_string(),
+                },
+                executed_steps: 0,
+            });
+        }
+        GateDispatch::Denied(reason) => {
+            workflow::set_run_state(conn, run_id, WorkflowRunState::Failed, now_ms)?;
+            return Ok(WorkflowOutcome {
+                status: WorkflowRunStatus::Failed {
+                    step_id,
+                    reason: format!("denied:{reason}"),
+                },
+                executed_steps: 0,
+            });
+        }
+        GateDispatch::ExecError(e) => {
+            workflow::complete_step(conn, &step_id, None, false, now_ms)?;
+            workflow::set_run_state(conn, run_id, WorkflowRunState::Failed, now_ms)?;
+            return Ok(WorkflowOutcome {
+                status: WorkflowRunStatus::Failed {
+                    step_id,
+                    reason: format!("exec_error:{e}"),
+                },
+                executed_steps: 0,
+            });
+        }
+        GateDispatch::Unregistered(action) => {
+            workflow::set_run_state(conn, run_id, WorkflowRunState::Failed, now_ms)?;
+            return Ok(WorkflowOutcome {
+                status: WorkflowRunStatus::Failed {
+                    step_id,
+                    reason: format!("unregistered:{action}"),
+                },
+                executed_steps: 0,
+            });
+        }
+    }
+    // Paused step executed → continue auto-advancing the rest (count seeded at 1).
+    advance_from(
+        def,
+        paused_seq + 1,
+        executor,
+        conn,
+        run_id,
+        secret,
+        approve,
+        1,
+        now_ms,
+    )
+}
+
+/// The SHARED per-step advance loop (used by [`run_workflow`] from 0 and
+/// [`resume_workflow`] from the step after the resumed one): for each step in
+/// `[start_seq, len)` plan→auto-advance-through-the-gate or pause at the first
+/// checkpoint; fail on a denied/errored dispatch; reach `Done` when all are verified.
+/// `executed` seeds the running count.
+#[allow(clippy::too_many_arguments)]
+fn advance_from(
+    def: &WorkflowDefinition,
+    start_seq: usize,
+    executor: &dyn ToolExecutor,
+    conn: &Connection,
+    run_id: &str,
+    secret: &[u8],
+    approve: &dyn Fn(&MutatingActionRequest) -> Option<CanonicalApproval>,
+    mut executed: usize,
+    now_ms: i64,
+) -> Result<WorkflowOutcome, StorageError> {
+    for seq in start_seq..def.steps.len() {
+        let step = &def.steps[seq];
         let step_id = format!("{run_id}:s{seq}");
         match plan_step(step) {
             // Checkpoint: register the step (a side-effect step needing evidence) but do
@@ -99,7 +229,7 @@ pub fn run_workflow(
                         step_id,
                         reason: reason.as_str().to_string(),
                     },
-                    executed_steps,
+                    executed_steps: executed,
                 });
             }
             // Auto-advance: register, then dispatch through the gate (the authorization).
@@ -126,10 +256,9 @@ pub fn run_workflow(
                             true,
                             now_ms,
                         )?;
-                        executed_steps += 1;
+                        executed += 1;
                     }
                     GateDispatch::ExecError(e) => {
-                        // Gate-Allowed but the tool failed: no evidence → not verified; run Failed.
                         workflow::complete_step(conn, &step_id, None, false, now_ms)?;
                         workflow::set_run_state(conn, run_id, WorkflowRunState::Failed, now_ms)?;
                         return Ok(WorkflowOutcome {
@@ -137,7 +266,7 @@ pub fn run_workflow(
                                 step_id,
                                 reason: format!("exec_error:{e}"),
                             },
-                            executed_steps,
+                            executed_steps: executed,
                         });
                     }
                     // The gate BACKSTOP: an auto-advanced step the gate escalates is paused,
@@ -154,7 +283,7 @@ pub fn run_workflow(
                                 step_id,
                                 reason: "gate_requires_approval".to_string(),
                             },
-                            executed_steps,
+                            executed_steps: executed,
                         });
                     }
                     GateDispatch::Denied(reason) => {
@@ -164,7 +293,7 @@ pub fn run_workflow(
                                 step_id,
                                 reason: format!("denied:{reason}"),
                             },
-                            executed_steps,
+                            executed_steps: executed,
                         });
                     }
                     GateDispatch::Unregistered(action) => {
@@ -176,7 +305,7 @@ pub fn run_workflow(
                                 step_id,
                                 reason: format!("unregistered:{action}"),
                             },
-                            executed_steps,
+                            executed_steps: executed,
                         });
                     }
                 }
@@ -184,13 +313,30 @@ pub fn run_workflow(
         }
     }
 
-    // All steps auto-advanced. `set_run_state(Done)` enforces the completion gate
-    // (refuses Done if any side-effect step is unverified).
+    // All steps verified. `set_run_state(Done)` enforces the completion gate (refuses
+    // Done if any side-effect step is unverified).
     workflow::set_run_state(conn, run_id, WorkflowRunState::Done, now_ms)?;
     Ok(WorkflowOutcome {
         status: WorkflowRunStatus::Completed,
-        executed_steps,
+        executed_steps: executed,
     })
+}
+
+/// Find the paused step's seq for an `AwaitingCheckpoint` run: the first `Pending` step
+/// (earlier steps are `Verified`; the checkpoint was `add_step`ed `Pending` and not
+/// executed). Fail-closed if none is found.
+fn find_paused_seq(conn: &Connection, run_id: &str, n_steps: usize) -> Result<usize, StorageError> {
+    for seq in 0..n_steps {
+        let step_id = format!("{run_id}:s{seq}");
+        match workflow::step_status(conn, &step_id)? {
+            Some(StepStatus::Pending) => return Ok(seq),
+            Some(_) => continue, // Verified/etc. → already settled, skip
+            None => break,       // no more added steps
+        }
+    }
+    Err(StorageError::Unsupported(format!(
+        "no paused (Pending) step found for run '{run_id}'"
+    )))
 }
 
 #[cfg(test)]
@@ -410,5 +556,146 @@ mod tests {
         run_workflow(&def, &exec, db.conn(), "r1", SECRET, &deny_all, 100).unwrap();
         // re-invoking the SAME run_id is a fail-closed dup (no double-dispatch).
         assert!(run_workflow(&def, &exec, db.conn(), "r1", SECRET, &deny_all, 200).is_err());
+    }
+
+    // --- resume-after-approval (operator-authorized) -------------------------
+
+    /// A minting approval policy: grants a valid, digest-bound approval for the request
+    /// (stands in for the operator-gated owner-approval leg in tests).
+    fn mint_all(r: &MutatingActionRequest) -> Option<CanonicalApproval> {
+        Some(crate::mint_approval(r, "owner", SECRET, 10_000_000))
+    }
+
+    fn read_then_write_def() -> WorkflowDefinition {
+        WorkflowDefinition {
+            name: "ship".into(),
+            steps: vec![
+                step("read", "read_file", &[("path", "x")], false, false),
+                step(
+                    "write",
+                    "write_file",
+                    &[("path", "o"), ("content", "y")],
+                    false,
+                    true,
+                ),
+            ],
+        }
+    }
+
+    #[test]
+    fn resume_executes_approved_mutating_step_and_completes_without_re_running_earlier() {
+        let db = Db::open_hub(&tmp("resume-ok")).unwrap();
+        let exec = CountingExec {
+            calls: Cell::new(0),
+        };
+        let def = read_then_write_def();
+        // Pause at the mutating write step (deny-all): read ran, write did not.
+        let paused = run_workflow(&def, &exec, db.conn(), "r1", SECRET, &deny_all, 100).unwrap();
+        assert!(matches!(
+            paused.status,
+            WorkflowRunStatus::AwaitingCheckpoint { .. }
+        ));
+        assert_eq!(exec.calls.get(), 1);
+        // Resume WITH a valid approval → the write executes (gate Allow via approval) → Done.
+        let out = resume_workflow(&def, &exec, db.conn(), "r1", SECRET, &mint_all, 200).unwrap();
+        assert_eq!(out.status, WorkflowRunStatus::Completed);
+        assert_eq!(run_state(&db, "r1"), "done");
+        // The read step was NOT re-executed — only the write ran on resume (1 → 2 total).
+        assert_eq!(exec.calls.get(), 2, "earlier verified step must not re-run");
+        // both steps verified.
+        assert_eq!(
+            workflow::step_status(db.conn(), "r1:s1")
+                .unwrap()
+                .unwrap()
+                .as_str(),
+            "verified"
+        );
+    }
+
+    #[test]
+    fn resume_without_a_valid_approval_re_pauses_and_does_not_execute() {
+        let db = Db::open_hub(&tmp("resume-deny")).unwrap();
+        let exec = CountingExec {
+            calls: Cell::new(0),
+        };
+        let def = read_then_write_def();
+        run_workflow(&def, &exec, db.conn(), "r1", SECRET, &deny_all, 100).unwrap();
+        assert_eq!(exec.calls.get(), 1);
+        // Resume with NO approval (deny-all) → the mutating step RE-pauses, never executes.
+        let out = resume_workflow(&def, &exec, db.conn(), "r1", SECRET, &deny_all, 200).unwrap();
+        assert!(matches!(
+            out.status,
+            WorkflowRunStatus::AwaitingCheckpoint { .. }
+        ));
+        assert_eq!(
+            exec.calls.get(),
+            1,
+            "unapproved mutating step must NOT execute on resume"
+        );
+        assert_eq!(run_state(&db, "r1"), "awaiting_checkpoint");
+    }
+
+    #[test]
+    fn resume_a_non_awaiting_checkpoint_run_is_fail_closed() {
+        let db = Db::open_hub(&tmp("resume-nonpaused")).unwrap();
+        let exec = CountingExec {
+            calls: Cell::new(0),
+        };
+        // an all-read-only run completes immediately (Done, not paused).
+        let def = WorkflowDefinition {
+            name: "research".into(),
+            steps: vec![step("a", "read_file", &[("path", "x")], false, false)],
+        };
+        let out = run_workflow(&def, &exec, db.conn(), "r1", SECRET, &deny_all, 100).unwrap();
+        assert_eq!(out.status, WorkflowRunStatus::Completed);
+        // resuming a Done run is fail-closed.
+        assert!(resume_workflow(&def, &exec, db.conn(), "r1", SECRET, &mint_all, 200).is_err());
+        // resuming a non-existent run is fail-closed too.
+        assert!(resume_workflow(&def, &exec, db.conn(), "ghost", SECRET, &mint_all, 200).is_err());
+    }
+
+    #[test]
+    fn resume_advances_to_the_next_checkpoint() {
+        let db = Db::open_hub(&tmp("resume-next")).unwrap();
+        let exec = CountingExec {
+            calls: Cell::new(0),
+        };
+        let def = WorkflowDefinition {
+            name: "multi".into(),
+            steps: vec![
+                step("r1", "read_file", &[("path", "a")], false, false),
+                step(
+                    "w1",
+                    "write_file",
+                    &[("path", "o1"), ("content", "y")],
+                    false,
+                    true,
+                ),
+                step("r2", "read_file", &[("path", "b")], false, false),
+                step(
+                    "w2",
+                    "write_file",
+                    &[("path", "o2"), ("content", "z")],
+                    false,
+                    true,
+                ),
+            ],
+        };
+        // pause at w1 (s1) after r1.
+        run_workflow(&def, &exec, db.conn(), "run", SECRET, &deny_all, 100).unwrap();
+        assert_eq!(exec.calls.get(), 1);
+        // resume w1 → executes w1, auto-advances r2, pauses at w2 (s3).
+        let out = resume_workflow(&def, &exec, db.conn(), "run", SECRET, &mint_all, 200).unwrap();
+        match out.status {
+            WorkflowRunStatus::AwaitingCheckpoint { step_id, .. } => assert_eq!(step_id, "run:s3"),
+            other => panic!("expected AwaitingCheckpoint at w2, got {other:?}"),
+        }
+        // r1 + w1 + r2 ran (3); w2 did not.
+        assert_eq!(exec.calls.get(), 3);
+        // resume again → w2 executes → Done.
+        let out2 = resume_workflow(&def, &exec, db.conn(), "run", SECRET, &mint_all, 300).unwrap();
+        assert_eq!(out2.status, WorkflowRunStatus::Completed);
+        assert_eq!(exec.calls.get(), 4);
+        assert_eq!(run_state(&db, "run"), "done");
     }
 }


### PR DESCRIPTION
## Resume-after-approval (operator-authorized: "授权resume")

`friday-hub::workflow_exec::resume_workflow` re-enters an `AwaitingCheckpoint` run after the owner approves the paused step.

- **Validates** the run IS `AwaitingCheckpoint` (fail-closed error otherwise — can't resume a Done/Failed/never-existed run).
- **Finds the paused step** (first `Pending`; earlier are `Verified`) and starts THERE — already-`Verified` steps are **never re-executed** (no double-dispatch).
- Sets the run `Running` (valid SM transition) and **force-dispatches the paused step THROUGH THE GATE**. Resuming is the human checkpoint, but the **gate is still the authorization**: a mutating step executes ONLY if `approve` grants a valid, digest-bound `CanonicalApproval`; otherwise it **re-pauses** (no unapproved mutating execution). A sensitive-read paused step is gate-`Allow`ed (a read needs no approval — resuming is the decision to proceed).
- Then continues auto-advancing the rest to the next checkpoint / `Done`.

### Refactor (single source, no drift)
Extracted the shared **`advance_from(start_seq)`** loop used by both `run_workflow` (from 0) and `resume_workflow` (from paused+1). `run_workflow` behavior unchanged — its 6 existing tests pass.

### Honest scope
The resume **mechanism** is built + tested (with a minted approval). The **live owner-approval leg is NOT wired** (operator/Computer-Use-gated), so a mutating resume re-pauses in v1 unless a real approval is supplied. NL generation + skill/plugin execution stay NO-GO; **v1 NO-GO**.

### Tests (4 resume + 6 prior = 10 workflow_exec)
approved-mutating executes + completes + earlier step NOT re-run (call-count 1→2); no-approval re-pauses (call-count stays 1); non-AwaitingCheckpoint + ghost run fail-closed; resume advances to the **next** checkpoint (multi-checkpoint). Workspace **403**, clippy `-D warnings` clean, fmt clean, arch-tests green.