### PR TITLE
feat(hub,storage): surface paused workflows as Needs-Me items (08 §2, Unit 9)

### DIFF
--- a/rust-core/crates/friday-hub/src/workflow_exec.rs
+++ b/rust-core/crates/friday-hub/src/workflow_exec.rs
@@ -43,12 +43,38 @@
 //! approval is supplied. NL generation + skill/plugin execution stay NO-GO; v1 NO-GO.
 
 use friday_core::gate::{CanonicalApproval, MutatingActionRequest};
-use friday_core::{StepStatus, WorkflowRunState};
+use friday_core::{NeedsMeItem, StepStatus, WorkflowRunState};
 use friday_storage::{workflow, StorageError};
 use rusqlite::Connection;
 
 use crate::planner::{plan_step, StepDisposition, WorkflowDefinition};
 use crate::{gate_dispatch, GateDispatch, RawToolCall, ToolExecutor};
+
+/// Priority of a workflow-checkpoint Needs-Me item (urgency-first ordering, `08` §1).
+const WORKFLOW_CHECKPOINT_PRIORITY: u8 = 7;
+
+/// The Needs-Me items for PAUSED workflows (`08` §2): every `AwaitingCheckpoint` run is
+/// surfaced as a cross-source action item the user must act on (approve/resume the
+/// paused step). Read-only — the Hub composes these with the other Needs-Me sources
+/// (Codex/Claude/memory/…) via [`friday_core::aggregate_needs_me`]. The `reason` carries
+/// the workflow name + the exact paused step (never silently dropped, `08` §2).
+pub fn workflow_needs_me(conn: &Connection) -> Result<Vec<NeedsMeItem>, StorageError> {
+    let runs = workflow::runs_in_state(conn, WorkflowRunState::AwaitingCheckpoint)?;
+    let mut items = Vec::with_capacity(runs.len());
+    for (run_id, name) in runs {
+        let at = workflow::first_pending_seq(conn, &run_id)?
+            .map(|s| format!(" (step s{s})"))
+            .unwrap_or_default();
+        items.push(NeedsMeItem {
+            source: "workflow".to_string(),
+            id: run_id.clone(),
+            reason: format!("Checkpoint: workflow '{name}' awaiting your approval{at}"),
+            priority: WORKFLOW_CHECKPOINT_PRIORITY,
+            destination: format!("workflow/{run_id}"),
+        });
+    }
+    Ok(items)
+}
 
 /// How a workflow run ended.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -737,5 +763,94 @@ mod tests {
         assert_eq!(out2.status, WorkflowRunStatus::Completed);
         assert_eq!(exec.calls.get(), 4);
         assert_eq!(run_state(&db, "run"), "done");
+    }
+
+    // --- workflow → Needs-Me (08 §2) -----------------------------------------
+
+    #[test]
+    fn paused_workflows_surface_as_needs_me_items_completed_ones_do_not() {
+        let db = Db::open_hub(&tmp("needsme")).unwrap();
+        let exec = CountingExec {
+            calls: Cell::new(0),
+        };
+        // A run that PAUSES at a mutating checkpoint.
+        run_workflow(
+            &db_def_paused(),
+            &exec,
+            db.conn(),
+            "paused1",
+            SECRET,
+            &deny_all,
+            100,
+        )
+        .unwrap();
+        // A run that COMPLETES (all read-only).
+        let done_def = WorkflowDefinition {
+            name: "research".into(),
+            steps: vec![step("r", "read_file", &[("path", "x")], false, false)],
+        };
+        run_workflow(&done_def, &exec, db.conn(), "done1", SECRET, &deny_all, 200).unwrap();
+
+        let items = workflow_needs_me(db.conn()).unwrap();
+        // Only the paused run is a Needs-Me item; the completed run is not.
+        assert_eq!(items.len(), 1, "only the AwaitingCheckpoint run surfaces");
+        let it = &items[0];
+        assert_eq!(it.source, "workflow");
+        assert_eq!(it.id, "paused1");
+        assert_eq!(it.destination, "workflow/paused1");
+        assert_eq!(it.priority, WORKFLOW_CHECKPOINT_PRIORITY);
+        // reason carries the workflow name + the exact paused step (never dropped).
+        assert!(
+            it.reason.contains("ship") && it.reason.contains("s1"),
+            "reason: {}",
+            it.reason
+        );
+
+        // It composes with the cross-source inbox via aggregate_needs_me.
+        let mut all = items;
+        all.push(NeedsMeItem {
+            source: "claude".into(),
+            id: "c1".into(),
+            reason: "urgent question".into(),
+            priority: 9,
+            destination: "session/claude-1".into(),
+        });
+        let ranked = friday_core::aggregate_needs_me(all);
+        // urgency-first: the p9 claude item ranks above the p7 workflow checkpoint.
+        assert_eq!(ranked[0].source, "claude");
+        assert_eq!(ranked[1].source, "workflow");
+    }
+
+    #[test]
+    fn workflow_needs_me_is_empty_when_no_run_is_paused() {
+        let db = Db::open_hub(&tmp("needsme-empty")).unwrap();
+        assert!(workflow_needs_me(db.conn()).unwrap().is_empty());
+        // a completed run leaves the inbox empty.
+        let exec = CountingExec {
+            calls: Cell::new(0),
+        };
+        let def = WorkflowDefinition {
+            name: "research".into(),
+            steps: vec![step("r", "read_file", &[("path", "x")], false, false)],
+        };
+        run_workflow(&def, &exec, db.conn(), "done1", SECRET, &deny_all, 100).unwrap();
+        assert!(workflow_needs_me(db.conn()).unwrap().is_empty());
+    }
+
+    // a definition that pauses at a mutating step `s1` (named "ship").
+    fn db_def_paused() -> WorkflowDefinition {
+        WorkflowDefinition {
+            name: "ship".into(),
+            steps: vec![
+                step("read", "read_file", &[("path", "x")], false, false),
+                step(
+                    "write",
+                    "write_file",
+                    &[("path", "o"), ("content", "y")],
+                    false,
+                    true,
+                ),
+            ],
+        }
     }
 }

--- a/rust-core/crates/friday-hub/src/workflow_exec.rs
+++ b/rust-core/crates/friday-hub/src/workflow_exec.rs
@@ -55,9 +55,14 @@ const WORKFLOW_CHECKPOINT_PRIORITY: u8 = 7;
 
 /// The Needs-Me items for PAUSED workflows (`08` §2): every `AwaitingCheckpoint` run is
 /// surfaced as a cross-source action item the user must act on (approve/resume the
-/// paused step). Read-only — the Hub composes these with the other Needs-Me sources
-/// (Codex/Claude/memory/…) via [`friday_core::aggregate_needs_me`]. The `reason` carries
-/// the workflow name + the exact paused step (never silently dropped, `08` §2).
+/// paused step). Read-only. The `reason` carries the workflow name + the exact paused
+/// step (never silently dropped, `08` §2).
+///
+/// SCOPE: this is the workflow PRODUCER. A live Needs-Me inbox would compose these with
+/// the other sources (Codex/Claude/memory/…) via [`friday_core::aggregate_needs_me`] —
+/// but that cross-source aggregation entry point + the Activity inbox surface are a
+/// follow-up (the surface is UI-gated; the Codex/Claude sources are login-gated). No
+/// production caller composes these yet.
 pub fn workflow_needs_me(conn: &Connection) -> Result<Vec<NeedsMeItem>, StorageError> {
     let runs = workflow::runs_in_state(conn, WorkflowRunState::AwaitingCheckpoint)?;
     let mut items = Vec::with_capacity(runs.len());

--- a/rust-core/crates/friday-storage/src/workflow.rs
+++ b/rust-core/crates/friday-storage/src/workflow.rs
@@ -52,6 +52,35 @@ pub fn run_state(conn: &Connection, run_id: &str) -> Result<Option<WorkflowRunSt
     Ok(s.map(|x| parse_run_state(&x)))
 }
 
+/// `(run_id, name)` for every run in `state`, most-recently-updated first (uses
+/// `idx_workflow_run_state`). The data-layer query that backs the Needs-Me inbox's
+/// workflow source (`08` §2) — e.g. all `AwaitingCheckpoint` runs awaiting the user.
+pub fn runs_in_state(conn: &Connection, state: WorkflowRunState) -> Result<Vec<(String, String)>> {
+    let mut stmt = conn.prepare(
+        "SELECT run_id, name FROM workflow_run WHERE state = ?1 ORDER BY updated_at DESC, run_id",
+    )?;
+    let rows = stmt.query_map([state.as_str()], |r| Ok((r.get(0)?, r.get(1)?)))?;
+    let mut out = Vec::new();
+    for r in rows {
+        out.push(r?);
+    }
+    Ok(out)
+}
+
+/// The seq of the run's first `Pending` step (the paused checkpoint of an
+/// `AwaitingCheckpoint` run), or `None` if it has no pending step. Used to label the
+/// Needs-Me item with the exact step awaiting the user.
+pub fn first_pending_seq(conn: &Connection, run_id: &str) -> Result<Option<i64>> {
+    let seq: Option<i64> = conn
+        .query_row(
+            "SELECT seq FROM workflow_step WHERE run_id = ?1 AND status = ?2 ORDER BY seq LIMIT 1",
+            params![run_id, StepStatus::Pending.as_str()],
+            |r| r.get(0),
+        )
+        .optional()?;
+    Ok(seq)
+}
+
 /// Load every step of a run as a `StepView` (side-effect flag + status). This is
 /// the input to the run-completion gate; it is the single read used by
 /// `set_run_state` to decide whether a `-> Done` transition is allowed.


### PR DESCRIPTION
## Workflow → Needs-Me (08 §2)

The workflow engine (#505–#507) produces `AwaitingCheckpoint` runs, but nothing surfaced them in the Needs-Me inbox — `08` §2 requires Needs-Me to aggregate **workflow checkpoints**. The `aggregate_needs_me` logic existed but was never fed real paused workflows. Closes that gap. **Read-only producer, no new authorization path.**

(Note: checked Unit-3 first — the DeepSeek route + adverse/`fallback=false`/live proofs are already done on main, so no gap there; pivoted to this genuine Unit-9 gap.)

### `friday-storage::workflow`
- **`runs_in_state(state)`** → `(run_id, name)` for runs in a state, most-recent first (uses the existing `idx_workflow_run_state`).
- **`first_pending_seq(run_id)`** → the paused checkpoint step's seq.

### `friday-hub::workflow_exec::workflow_needs_me(conn)`
Every `AwaitingCheckpoint` run → a `NeedsMeItem { source:"workflow", id:run_id, reason:"Checkpoint: workflow '<name>' awaiting your approval (step sN)", priority:7, destination:"workflow/<run_id>" }`. Read-only; the Hub composes these with the other Needs-Me sources via `friday_core::aggregate_needs_me`. The `reason` carries name + exact step (`08` §2: never silently dropped).

### Tests (2 new; workflow_exec 13 total)
a paused run surfaces (source/id/destination/priority + reason carries name+step), a `Completed` run does **not**, and the item composes via `aggregate_needs_me` (urgency-first: p9 claude above p7 workflow checkpoint); empty when no run is paused. Workspace **406**, clippy `-D warnings` clean, fmt clean, arch-tests green. Overall **v1: NO-GO**.