### PR TITLE
ci(telegram): Rust getUpdates live-proof harness (channels track listen mode)

### DIFF
--- a/.github/workflows/telegram-live-proof.yml
+++ b/.github/workflows/telegram-live-proof.yml
@@ -39,3 +39,32 @@ jobs:
           if [ -n "$url" ]; then echo "webhook.set=true (delivery=webhook; getUpdates polling would 409 — do NOT poll without deleting it)"; else echo "webhook.set=false (delivery=polling-available)"; fi
           echo "webhook.pending_update_count=$(echo "$wh" | jq -r '.result.pending_update_count')"
           echo "OK: read-only credential probe complete (no side effects, no token printed)."
+
+  listen:
+    if: ${{ inputs.mode == 'listen' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    environment: phase-24-live-channels
+    defaults:
+      run:
+        working-directory: rust-core
+    env:
+      FRIDAY_TELEGRAM_BOT_TOKEN: ${{ secrets.FRIDAY_TELEGRAM_BOT_TOKEN }}
+      FRIDAY_TELEGRAM_ALLOWED_USER_ID: ${{ secrets.FRIDAY_TELEGRAM_ALLOWED_USER_ID || vars.FRIDAY_TELEGRAM_ALLOWED_USER_ID }}
+      # ~8 min listen window — the trusted user must DM the bot within it.
+      TELEGRAM_LISTEN_SECONDS: "480"
+      TELEGRAM_PROOF_OUT: ${{ github.workspace }}/telegram_live_proof.json
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - name: Toolchain
+        run: rustup show && cargo --version
+      - name: Live proof — real Telegram message through the Rust channels pipeline
+        run: cargo test -p friday-hub --test telegram_live -- --ignored --nocapture
+      - name: Upload live-proof evidence (redacted; no token)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: telegram-live-proof-${{ github.run_id }}
+          path: ${{ github.workspace }}/telegram_live_proof.json
+          if-no-files-found: warn

--- a/rust-core/Cargo.lock
+++ b/rust-core/Cargo.lock
@@ -489,6 +489,7 @@ dependencies = [
  "regex",
  "rusqlite",
  "serde_json",
+ "ureq",
 ]
 
 [[package]]

--- a/rust-core/crates/friday-hub/Cargo.toml
+++ b/rust-core/crates/friday-hub/Cargo.toml
@@ -29,3 +29,10 @@ serde_json.workspace = true
 # recalls). Pure computation, no I/O. NOT depended on by friday-ffi (phone).
 regex.workspace = true
 
+[dev-dependencies]
+# TEST-ONLY HTTP client for the LIVE Telegram channels proof (tests/telegram_live.rs,
+# `#[ignore]`d, run only in the phase-24-live-channels CI env). dev-dependencies are NOT
+# part of the production dependency graph (friday-arch-tests scans dependencies /
+# build-dependencies only) and never reach the phone (friday-ffi).
+ureq = { version = "2", features = ["json"] }
+

--- a/rust-core/crates/friday-hub/tests/telegram_live.rs
+++ b/rust-core/crates/friday-hub/tests/telegram_live.rs
@@ -1,0 +1,177 @@
+//! LIVE Telegram inbound proof for the Rust channels track (UNW-013). `#[ignore]`d —
+//! run ONLY in CI (the `phase-24-live-channels` environment) via `--ignored`. It polls
+//! `getUpdates` for one real message from the trusted user and drives it through the REAL
+//! channels pipeline: `register`/`provision_channel_auth` (A-PR1/A-PR2) → `resolve_and_verify`
+//! (bearer + allowlist, A-PR2) → `redact_inbound` (A-PR3) — proving the Rust channels code
+//! against real Telegram input (real sender id, real message text, real CJK/PII).
+//!
+//! HONEST SCOPE: in polling mode the wire AUTH is the bot token (only the holder can poll)
+//! plus the sender allowlist. Telegram does not deliver the webhook bearer over
+//! `getUpdates`, so the bearer presented to `resolve_and_verify` here is a synthetic
+//! per-channel secret we provision (the bearer LOGIC is exercised against the real sender
+//! id and the negatives; Telegram's real `secret_token` delivery is a webhook-mode
+//! concern, not exercised here).
+//!
+//! SECURITY: the bot token comes ONLY from `FRIDAY_TELEGRAM_BOT_TOKEN` (env) and is never
+//! logged or written. The evidence artifact contains only redacted text + the PII kinds.
+
+use friday_crypto::InMemorySecureStore;
+use friday_hub::channels::{
+    provision_channel_auth, redact_inbound, resolve_and_verify, InboundRejection,
+};
+use friday_storage::channel::{get_channel, ChannelKind};
+use friday_storage::Db;
+use std::time::{Duration, Instant};
+
+fn url(token: &str, method: &str) -> String {
+    format!("https://api.telegram.org/bot{token}/{method}")
+}
+
+fn tmp_db() -> String {
+    std::env::temp_dir()
+        .join(format!("friday-tg-live-{}.sqlite", std::process::id()))
+        .to_string_lossy()
+        .into_owned()
+}
+
+#[test]
+#[ignore = "live: needs FRIDAY_TELEGRAM_BOT_TOKEN + a real message from the trusted user during the window"]
+fn telegram_inbound_through_rust_channels_pipeline() {
+    let token = std::env::var("FRIDAY_TELEGRAM_BOT_TOKEN").unwrap_or_default();
+    if token.trim().is_empty() {
+        eprintln!("SKIP: FRIDAY_TELEGRAM_BOT_TOKEN not set (run only in the live-channels CI env)");
+        return;
+    }
+    let allowed = std::env::var("FRIDAY_TELEGRAM_ALLOWED_USER_ID").unwrap_or_default();
+    assert!(
+        !allowed.trim().is_empty(),
+        "FRIDAY_TELEGRAM_ALLOWED_USER_ID must be set for the live proof"
+    );
+    let window_secs: u64 = std::env::var("TELEGRAM_LISTEN_SECONDS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(300);
+
+    // 1) getMe — prove the token is live + capture the bot identity.
+    let me: serde_json::Value = ureq::get(&url(&token, "getMe"))
+        .timeout(Duration::from_secs(15))
+        .call()
+        .expect("getMe call failed")
+        .into_json()
+        .expect("getMe json");
+    assert_eq!(me["ok"], serde_json::json!(true), "getMe not ok");
+    let bot_id = me["result"]["id"].as_i64().expect("bot id");
+    let bot_username = me["result"]["username"].as_str().unwrap_or("?").to_string();
+    eprintln!("bot=@{bot_username} (id={bot_id}); waiting up to {window_secs}s for a DM from trusted user {allowed} — SEND ONE NOW");
+
+    // 2) getUpdates long-poll until a text message from the allowed user (or timeout).
+    let deadline = Instant::now() + Duration::from_secs(window_secs);
+    let mut offset: i64 = 0;
+    let mut found: Option<(String, String)> = None; // (from_id, text)
+    'poll: while Instant::now() < deadline {
+        let u = format!(
+            "{}?timeout=20&offset={}&allowed_updates=%5B%22message%22%5D",
+            url(&token, "getUpdates"),
+            offset
+        );
+        let resp: serde_json::Value = match ureq::get(&u).timeout(Duration::from_secs(30)).call() {
+            Ok(r) => r.into_json().expect("getUpdates json"),
+            Err(e) => {
+                eprintln!("getUpdates transient error (retrying): {e}");
+                std::thread::sleep(Duration::from_secs(2));
+                continue;
+            }
+        };
+        assert_eq!(
+            resp["ok"],
+            serde_json::json!(true),
+            "getUpdates not ok (a webhook may be set — polling 409s until it is deleted): {resp}"
+        );
+        for upd in resp["result"].as_array().cloned().unwrap_or_default() {
+            offset = upd["update_id"].as_i64().unwrap_or(offset) + 1;
+            let from_id = upd["message"]["from"]["id"]
+                .as_i64()
+                .map(|i| i.to_string())
+                .unwrap_or_default();
+            let text = upd["message"]["text"].as_str();
+            if from_id == allowed {
+                if let Some(t) = text {
+                    found = Some((from_id, t.to_string()));
+                    break 'poll;
+                }
+            } else if !from_id.is_empty() {
+                eprintln!("ignoring message from non-allowlisted user {from_id}");
+            }
+        }
+    }
+    let (from_id, text) =
+        found.expect("timed out: no text message from the trusted user within the window");
+
+    // 3) Drive the REAL channels pipeline with the real sender id + text.
+    let db = Db::open_hub(&tmp_db()).expect("open hub db");
+    let mut store = InMemorySecureStore::new();
+    let channel_id = format!("telegram:{bot_id}");
+    // Synthetic per-channel secret (polling carries no webhook bearer); >= 16 bytes.
+    let secret: &[u8] = b"friday-live-proof-inbound-material-01"; // pragma: allowlist secret
+    let bearer = provision_channel_auth(
+        &mut store,
+        db.conn(),
+        &channel_id,
+        ChannelKind::Telegram,
+        "owner",
+        std::slice::from_ref(&from_id),
+        secret,
+        0,
+    )
+    .expect("provision_channel_auth");
+    let binding = get_channel(db.conn(), &channel_id)
+        .expect("get_channel")
+        .expect("binding exists");
+
+    // Positive: correct bearer + allowlisted REAL sender authenticates.
+    let verified = resolve_and_verify(&store, &binding, &bearer, &from_id)
+        .expect("auth chain must accept the correct bearer for the allowlisted real sender");
+    assert_eq!(verified.bound_principal_id, "owner");
+    // Negative: a forged bearer is rejected (constant-time HMAC fails closed).
+    assert_eq!(
+        resolve_and_verify(&store, &binding, "deadbeef", &from_id),
+        Err(InboundRejection::BadBearer)
+    );
+    // Negative: a non-allowlisted sender is rejected even with the correct bearer.
+    assert_eq!(
+        resolve_and_verify(&store, &binding, &bearer, "999999999"),
+        Err(InboundRejection::SenderNotAllowed)
+    );
+
+    // 4) Redact the REAL message body (A-PR3).
+    let redacted = redact_inbound(verified, text.clone());
+    assert_eq!(redacted.bound_principal_id, "owner");
+    // The redacted text must not echo any redaction-marker-free raw PII (sanity: the
+    // markers, if any, prove redaction ran; the raw values are gone by construction).
+    eprintln!(
+        "LIVE PROOF OK: bot=@{bot_username} sender={from_id} allowlisted; bearer-auth pass + forged/non-allowlisted rejected; pii_redacted={:?}",
+        redacted.pii_redacted
+    );
+
+    // 5) Evidence artifact — redacted text + kinds only (no token, no raw PII).
+    let evidence = serde_json::json!({
+        "proof": "telegram_inbound_through_rust_channels_pipeline",
+        "bot_username": bot_username,
+        "bot_id": bot_id,
+        "channel_id": channel_id,
+        "sender_id": from_id,
+        "sender_allowlisted": true,
+        "bound_principal_id": "owner",
+        "bearer_auth_accepted_correct": true,
+        "forged_bearer_rejected": true,
+        "non_allowlisted_sender_rejected": true,
+        "pii_kinds_redacted": format!("{:?}", redacted.pii_redacted),
+        "redacted_text": redacted.text,
+        "raw_text_chars": text.chars().count(),
+    });
+    let out = std::env::var("TELEGRAM_PROOF_OUT")
+        .unwrap_or_else(|_| "telegram_live_proof.json".to_string());
+    std::fs::write(&out, serde_json::to_string_pretty(&evidence).unwrap())
+        .expect("write evidence artifact");
+    eprintln!("evidence written to {out}");
+}


### PR DESCRIPTION
Builds on #512 (read-only probe, which confirmed token live, bot `@P24_21bot`, **polling available** — no webhook). Adds the `listen` mode: a Rust `getUpdates` harness that drives a **real** Telegram message through the **real** channels pipeline.

### `tests/telegram_live.rs` (`#[ignore]`d, friday-hub)
- `getMe` (token live + identity) → long-poll `getUpdates` for one text message from `FRIDAY_TELEGRAM_ALLOWED_USER_ID`.
- Real pipeline on the real sender id + text: `provision_channel_auth` (A-PR1/A-PR2) → `resolve_and_verify` (A-PR2) with **positive** (correct bearer + allowlisted real sender), **forged-bearer rejected**, **non-allowlisted-sender rejected** → `redact_inbound` (A-PR3).
- Writes a **redacted** evidence artifact (no token, no raw PII; PII kinds + redacted text only).
- Skips gracefully without the token (so `cargo test --workspace` stays green locally/CI).

### Honesty / safety
- Polling-mode wire auth = bot token (only the holder can poll) + sender allowlist. Telegram does **not** deliver the webhook `secret_token` over `getUpdates`, so the bearer presented to `resolve_and_verify` is a **synthetic** per-channel secret we provision — the bearer **logic** is exercised against the real sender + the negatives; real webhook bearer delivery is webhook-mode (not exercised).
- `ureq` is a **dev-dependency** only — not in the production dep graph (`friday-arch-tests` scans `dependencies`/`build-dependencies`), never reaches the phone (`friday-ffi`).
- Token only from the `phase-24-live-channels` env secret; never logged.

### Run
Must be on `main` to be dispatchable. The live run (`mode=listen`) needs the trusted user to **DM `@P24_21bot` once during the ~8-min window**.

friday-hub workspace green, clippy `-D warnings` clean, detect-secrets 0. **v1 NO-GO.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)