### PR TITLE
Provider-session lane: Provider Workspace substrate + Codex/Claude local control (NOT v1 GO, do not merge w/o approval)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -299,6 +299,15 @@
         "line_number": 8307
       }
     ],
+    "rust-core/crates/friday-protocol/src/lib.rs": [
+      {
+        "type": "Secret Keyword",
+        "filename": "rust-core/crates/friday-protocol/src/lib.rs",
+        "hashed_secret": "187d0c692ee306ab675fb8fa24dc3cd506cefc28",
+        "is_verified": false,
+        "line_number": 896
+      }
+    ],
     "scripts/e2e-workflow-generator.sh": [
       {
         "type": "Secret Keyword",

--- a/rust-core/Cargo.lock
+++ b/rust-core/Cargo.lock
@@ -509,6 +509,8 @@ name = "friday-providers"
 version = "0.0.1"
 dependencies = [
  "friday-storage",
+ "serde",
+ "serde_json",
  "thiserror 1.0.69",
 ]
 

--- a/rust-core/Cargo.lock
+++ b/rust-core/Cargo.lock
@@ -487,6 +487,7 @@ dependencies = [
  "friday-protocol",
  "friday-providers",
  "friday-storage",
+ "friday-transport",
  "regex",
  "rusqlite",
  "serde_json",

--- a/rust-core/Cargo.lock
+++ b/rust-core/Cargo.lock
@@ -491,6 +491,7 @@ dependencies = [
  "regex",
  "rusqlite",
  "serde_json",
+ "thiserror 1.0.69",
  "ureq",
 ]
 

--- a/rust-core/Cargo.lock
+++ b/rust-core/Cargo.lock
@@ -508,6 +508,7 @@ dependencies = [
 name = "friday-providers"
 version = "0.0.1"
 dependencies = [
+ "friday-core",
  "friday-storage",
  "serde",
  "serde_json",

--- a/rust-core/Cargo.lock
+++ b/rust-core/Cargo.lock
@@ -484,6 +484,7 @@ dependencies = [
  "friday-crypto",
  "friday-deepseek",
  "friday-fs",
+ "friday-protocol",
  "friday-providers",
  "friday-storage",
  "regex",

--- a/rust-core/crates/friday-core/src/error.rs
+++ b/rust-core/crates/friday-core/src/error.rs
@@ -19,4 +19,9 @@ pub enum CoreError {
     /// sensitive item) — `07` §10 / `02` §7.
     #[error("blocked transfer: {0}")]
     BlockedTransfer(String),
+
+    /// A QR/local-host pairing payload failed validation. Pairing is the
+    /// Friday Hub/device bootstrap, not provider credential transfer.
+    #[error("invalid pairing payload: {0}")]
+    InvalidPairPayload(String),
 }

--- a/rust-core/crates/friday-core/src/lib.rs
+++ b/rust-core/crates/friday-core/src/lib.rs
@@ -22,6 +22,7 @@ mod identity;
 mod ledger;
 mod memory;
 mod offline;
+mod pairing;
 mod pathsafe;
 mod planning;
 mod provider_session;
@@ -41,6 +42,10 @@ pub use memory::{
     RedactedPassportItem,
 };
 pub use offline::OfflineQueueState;
+pub use pairing::{
+    FridayPairPayload, FridayPairProjection, PairAuthority, PairTransportHint, PairTransportKind,
+    PairingSecret, TrustedDeviceProjection, CURRENT_PAIR_PAYLOAD_VERSION,
+};
 pub use pathsafe::{contained, PathError};
 pub use planning::{classify_kind, PlanState, PlanningKind};
 pub use provider_session::{

--- a/rust-core/crates/friday-core/src/lib.rs
+++ b/rust-core/crates/friday-core/src/lib.rs
@@ -24,6 +24,7 @@ mod memory;
 mod offline;
 mod pathsafe;
 mod planning;
+mod provider_session;
 mod session;
 mod skill;
 mod tool_policy;
@@ -42,6 +43,9 @@ pub use memory::{
 pub use offline::OfflineQueueState;
 pub use pathsafe::{contained, PathError};
 pub use planning::{classify_kind, PlanState, PlanningKind};
+pub use provider_session::{
+    ProviderSessionEvent, ProviderSessionLink, ProviderSessionProjection, SyncMode, ALL_SYNC_MODES,
+};
 pub use session::SessionState;
 pub use skill::SkillState;
 pub use tool_policy::{

--- a/rust-core/crates/friday-core/src/pairing.rs
+++ b/rust-core/crates/friday-core/src/pairing.rs
@@ -391,7 +391,7 @@ mod tests {
 
     #[test]
     fn provider_credential_looking_material_is_rejected() {
-        assert!(PairingSecret::new("sk-live-provider-secret-value").is_err());
+        assert!(PairingSecret::new("sk-live-provider-secret-value").is_err()); // intentionally invalid fixture; pragma: allowlist secret
         assert!(PairTransportHint::new(
             PairTransportKind::LanWebSocket,
             "ws://127.0.0.1:4477?api_key=abc",

--- a/rust-core/crates/friday-core/src/pairing.rs
+++ b/rust-core/crates/friday-core/src/pairing.rs
@@ -1,0 +1,402 @@
+//! QR/local-host pairing contract.
+//!
+//! `PAIR-001`: the QR payload is a Friday Hub/device bootstrap. It may contain a
+//! short-lived Friday pairing secret, but it must never contain provider OAuth
+//! material, API keys, provider account ids, or provider session tokens.
+
+use crate::error::CoreError;
+use std::fmt;
+
+pub const CURRENT_PAIR_PAYLOAD_VERSION: u16 = 1;
+const MIN_PAIRING_SECRET_LEN: usize = 16;
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct PairingSecret(String);
+
+impl PairingSecret {
+    pub fn new(value: impl Into<String>) -> Result<Self, CoreError> {
+        let value = value.into();
+        if value.len() < MIN_PAIRING_SECRET_LEN {
+            return Err(CoreError::InvalidPairPayload(
+                "pairing_secret must be at least 16 bytes".into(),
+            ));
+        }
+        if contains_provider_secret_hint(&value) {
+            return Err(CoreError::InvalidPairPayload(
+                "pairing_secret looks like provider credential material".into(),
+            ));
+        }
+        Ok(Self(value))
+    }
+
+    pub fn expose_for_qr(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for PairingSecret {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("PairingSecret(<redacted>)")
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum PairTransportKind {
+    LanWebSocket,
+    Mdns,
+    ManualUrl,
+    Tailscale,
+    SshTunnel,
+    P2pRelay,
+}
+
+impl PairTransportKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            PairTransportKind::LanWebSocket => "lan_websocket",
+            PairTransportKind::Mdns => "mdns",
+            PairTransportKind::ManualUrl => "manual_url",
+            PairTransportKind::Tailscale => "tailscale",
+            PairTransportKind::SshTunnel => "ssh_tunnel",
+            PairTransportKind::P2pRelay => "p2p_relay",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "lan_websocket" => Some(Self::LanWebSocket),
+            "mdns" => Some(Self::Mdns),
+            "manual_url" => Some(Self::ManualUrl),
+            "tailscale" => Some(Self::Tailscale),
+            "ssh_tunnel" => Some(Self::SshTunnel),
+            "p2p_relay" => Some(Self::P2pRelay),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PairTransportHint {
+    pub kind: PairTransportKind,
+    pub endpoint: String,
+    pub label: String,
+}
+
+impl PairTransportHint {
+    pub fn new(
+        kind: PairTransportKind,
+        endpoint: impl Into<String>,
+        label: impl Into<String>,
+    ) -> Result<Self, CoreError> {
+        let hint = Self {
+            kind,
+            endpoint: endpoint.into(),
+            label: label.into(),
+        };
+        hint.validate()?;
+        Ok(hint)
+    }
+
+    fn validate(&self) -> Result<(), CoreError> {
+        require_non_empty(&self.endpoint, "transport_hints.endpoint")?;
+        require_non_empty(&self.label, "transport_hints.label")?;
+        if contains_provider_secret_hint(&self.endpoint)
+            || contains_provider_secret_hint(&self.label)
+        {
+            return Err(CoreError::InvalidPairPayload(
+                "transport hint contains provider credential-looking material".into(),
+            ));
+        }
+        match self.kind {
+            PairTransportKind::LanWebSocket | PairTransportKind::ManualUrl => {
+                if !self.endpoint.starts_with("ws://") && !self.endpoint.starts_with("wss://") {
+                    return Err(CoreError::InvalidPairPayload(format!(
+                        "{} endpoint must be ws:// or wss://",
+                        self.kind.as_str()
+                    )));
+                }
+            }
+            PairTransportKind::Mdns => {
+                if !self.endpoint.contains("_friday") || !self.endpoint.contains("_tcp") {
+                    return Err(CoreError::InvalidPairPayload(
+                        "mdns endpoint must identify a Friday TCP service".into(),
+                    ));
+                }
+            }
+            PairTransportKind::Tailscale => {
+                if !self.endpoint.starts_with("tailscale://") && !self.endpoint.starts_with("ws://")
+                {
+                    return Err(CoreError::InvalidPairPayload(
+                        "tailscale endpoint must be tailscale:// or ws://".into(),
+                    ));
+                }
+            }
+            PairTransportKind::SshTunnel => {
+                if !self.endpoint.starts_with("ssh://") {
+                    return Err(CoreError::InvalidPairPayload(
+                        "ssh tunnel endpoint must be ssh://".into(),
+                    ));
+                }
+            }
+            PairTransportKind::P2pRelay => {
+                if !self.endpoint.starts_with("iroh://")
+                    && !self.endpoint.starts_with("friday-p2p://")
+                {
+                    return Err(CoreError::InvalidPairPayload(
+                        "p2p relay endpoint must be iroh:// or friday-p2p://".into(),
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum PairAuthority {
+    StatusOnly,
+    Approvals,
+    SendSteer,
+    FileDiffReview,
+    AdminSetup,
+}
+
+impl PairAuthority {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            PairAuthority::StatusOnly => "status_only",
+            PairAuthority::Approvals => "approvals",
+            PairAuthority::SendSteer => "send_steer",
+            PairAuthority::FileDiffReview => "file_diff_review",
+            PairAuthority::AdminSetup => "admin_setup",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "status_only" => Some(Self::StatusOnly),
+            "approvals" => Some(Self::Approvals),
+            "send_steer" => Some(Self::SendSteer),
+            "file_diff_review" => Some(Self::FileDiffReview),
+            "admin_setup" => Some(Self::AdminSetup),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FridayPairPayload {
+    pub v: u16,
+    pub hub_id: String,
+    pub pairing_id: String,
+    pub pairing_secret: PairingSecret,
+    pub display_name: String,
+    pub transport_hints: Vec<PairTransportHint>,
+    pub expires_at: i64,
+    pub capabilities_hint: Vec<PairAuthority>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FridayPairProjection {
+    pub v: u16,
+    pub hub_id: String,
+    pub pairing_id: String,
+    pub display_name: String,
+    pub transport_labels: Vec<String>,
+    pub expires_at: i64,
+    pub capabilities_hint: Vec<PairAuthority>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TrustedDeviceProjection {
+    pub device_id: String,
+    pub label: String,
+    pub paired_at: i64,
+    pub revoked_at: Option<i64>,
+    pub key_rotated_at: Option<i64>,
+    pub pubkey_fingerprint: String,
+}
+
+impl FridayPairPayload {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        v: u16,
+        hub_id: impl Into<String>,
+        pairing_id: impl Into<String>,
+        pairing_secret: impl Into<String>,
+        display_name: impl Into<String>,
+        transport_hints: Vec<PairTransportHint>,
+        expires_at: i64,
+        capabilities_hint: Vec<PairAuthority>,
+    ) -> Result<Self, CoreError> {
+        let payload = Self {
+            v,
+            hub_id: hub_id.into(),
+            pairing_id: pairing_id.into(),
+            pairing_secret: PairingSecret::new(pairing_secret)?,
+            display_name: display_name.into(),
+            transport_hints,
+            expires_at,
+            capabilities_hint,
+        };
+        payload.validate_at(payload.expires_at - 1)?;
+        Ok(payload)
+    }
+
+    pub fn validate_at(&self, now: i64) -> Result<(), CoreError> {
+        if self.v != CURRENT_PAIR_PAYLOAD_VERSION {
+            return Err(CoreError::InvalidPairPayload(format!(
+                "unsupported version {}",
+                self.v
+            )));
+        }
+        require_non_empty(&self.hub_id, "hub_id")?;
+        require_non_empty(&self.pairing_id, "pairing_id")?;
+        require_non_empty(&self.display_name, "display_name")?;
+        if self.expires_at <= now {
+            return Err(CoreError::InvalidPairPayload(
+                "pairing payload has expired".into(),
+            ));
+        }
+        if self.transport_hints.is_empty() {
+            return Err(CoreError::InvalidPairPayload(
+                "at least one transport hint is required".into(),
+            ));
+        }
+        if self.capabilities_hint.is_empty() {
+            return Err(CoreError::InvalidPairPayload(
+                "at least one capability hint is required".into(),
+            ));
+        }
+        if contains_provider_secret_hint(&self.hub_id)
+            || contains_provider_secret_hint(&self.pairing_id)
+            || contains_provider_secret_hint(&self.display_name)
+        {
+            return Err(CoreError::InvalidPairPayload(
+                "pair payload contains provider credential-looking material".into(),
+            ));
+        }
+        for hint in &self.transport_hints {
+            hint.validate()?;
+        }
+        Ok(())
+    }
+
+    pub fn redacted_projection(&self) -> FridayPairProjection {
+        FridayPairProjection {
+            v: self.v,
+            hub_id: self.hub_id.clone(),
+            pairing_id: self.pairing_id.clone(),
+            display_name: self.display_name.clone(),
+            transport_labels: self
+                .transport_hints
+                .iter()
+                .map(|h| h.label.clone())
+                .collect(),
+            expires_at: self.expires_at,
+            capabilities_hint: self.capabilities_hint.clone(),
+        }
+    }
+}
+
+fn require_non_empty(value: &str, field: &'static str) -> Result<(), CoreError> {
+    if value.trim().is_empty() {
+        Err(CoreError::InvalidPairPayload(format!(
+            "{field} must not be empty"
+        )))
+    } else {
+        Ok(())
+    }
+}
+
+fn contains_provider_secret_hint(value: &str) -> bool {
+    let lower = value.to_ascii_lowercase();
+    lower.contains("openai_api_key")
+        || lower.contains("anthropic_api_key")
+        || lower.contains("api_key=")
+        || lower.contains("authorization:")
+        || lower.contains("bearer ")
+        || lower.contains("oauth")
+        || lower.contains("refresh_token")
+        || lower.contains("provider_token")
+        || lower.contains("provider_secret")
+        || value.contains("sk-")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_payload() -> FridayPairPayload {
+        FridayPairPayload::new(
+            CURRENT_PAIR_PAYLOAD_VERSION,
+            "hub-mac-mini",
+            "pair-1",
+            "friday-pairing-secret-32-bytes",
+            "Jarvis Mac mini",
+            vec![PairTransportHint::new(
+                PairTransportKind::LanWebSocket,
+                "ws://192.168.1.8:4477",
+                "LAN WebSocket",
+            )
+            .unwrap()],
+            2000,
+            vec![PairAuthority::StatusOnly, PairAuthority::Approvals],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn pair_payload_validates_and_projects_without_secret() {
+        let payload = sample_payload();
+        payload.validate_at(1000).unwrap();
+        let projection = format!("{:?}", payload.redacted_projection());
+        assert!(projection.contains("Jarvis Mac mini"));
+        assert!(!projection.contains(payload.pairing_secret.expose_for_qr()));
+        assert!(payload.pairing_secret.expose_for_qr().len() >= MIN_PAIRING_SECRET_LEN);
+    }
+
+    #[test]
+    fn pair_payload_debug_redacts_secret() {
+        let payload = sample_payload();
+        let debug = format!("{payload:?}");
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains(payload.pairing_secret.expose_for_qr()));
+    }
+
+    #[test]
+    fn invalid_or_expired_payloads_are_rejected() {
+        let mut payload = sample_payload();
+        assert!(payload.validate_at(payload.expires_at).is_err());
+        payload.v = 999;
+        assert!(payload.validate_at(1000).is_err());
+
+        assert!(FridayPairPayload::new(
+            CURRENT_PAIR_PAYLOAD_VERSION,
+            "hub",
+            "pair",
+            "short",
+            "Hub",
+            vec![PairTransportHint::new(
+                PairTransportKind::LanWebSocket,
+                "ws://127.0.0.1:4477",
+                "LAN"
+            )
+            .unwrap()],
+            2000,
+            vec![PairAuthority::StatusOnly],
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn provider_credential_looking_material_is_rejected() {
+        assert!(PairingSecret::new("sk-live-provider-secret-value").is_err());
+        assert!(PairTransportHint::new(
+            PairTransportKind::LanWebSocket,
+            "ws://127.0.0.1:4477?api_key=abc",
+            "LAN"
+        )
+        .is_err());
+    }
+}

--- a/rust-core/crates/friday-core/src/provider_session.rs
+++ b/rust-core/crates/friday-core/src/provider_session.rs
@@ -134,11 +134,11 @@ mod tests {
         let link = ProviderSessionLink {
             friday_session_id: "friday-s1".into(),
             provider: "codex".into(),
-            account_key_hash: "acct-hash-secret".into(),
+            account_key_hash: "acct-hash-hidden".into(), // pragma: allowlist secret
             workspace_id: "workspace-a".into(),
             cwd: Some("/Users/jarvis/private/project".into()),
-            external_session_id: Some("provider-session-secret".into()),
-            external_thread_id: Some("provider-thread-secret".into()),
+            external_session_id: Some("provider-session-hidden".into()),
+            external_thread_id: Some("provider-thread-hidden".into()),
             external_url: Some("https://provider.example/private".into()),
             sync_mode: SyncMode::ProviderAppServerLocal,
             capability_snapshot: "thread/start,turn/start".into(),
@@ -149,10 +149,10 @@ mod tests {
 
         let projection = format!("{:?}", link.redacted_projection());
         for forbidden in [
-            "acct-hash-secret",
+            "acct-hash-hidden",
             "/Users/jarvis/private/project",
-            "provider-session-secret",
-            "provider-thread-secret",
+            "provider-session-hidden",
+            "provider-thread-hidden",
             "https://provider.example/private",
         ] {
             assert!(

--- a/rust-core/crates/friday-core/src/provider_session.rs
+++ b/rust-core/crates/friday-core/src/provider_session.rs
@@ -1,0 +1,165 @@
+//! Provider session contract: sync truth labels + Hub-owned event mirror types.
+//!
+//! These are pure domain records. Provider adapters, network transports, SQL,
+//! and UI projection live in their owning crates.
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SyncMode {
+    ProviderNativeSynced,
+    ProviderAppServerLocal,
+    FridayLocalMirror,
+    ProviderNativeLinkOnly,
+    UnsupportedTruthLabeled,
+}
+
+impl SyncMode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            SyncMode::ProviderNativeSynced => "provider_native_synced",
+            SyncMode::ProviderAppServerLocal => "provider_app_server_local",
+            SyncMode::FridayLocalMirror => "friday_local_mirror",
+            SyncMode::ProviderNativeLinkOnly => "provider_native_link_only",
+            SyncMode::UnsupportedTruthLabeled => "unsupported_truth_labeled",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "provider_native_synced" => Some(SyncMode::ProviderNativeSynced),
+            "provider_app_server_local" => Some(SyncMode::ProviderAppServerLocal),
+            "friday_local_mirror" => Some(SyncMode::FridayLocalMirror),
+            "provider_native_link_only" => Some(SyncMode::ProviderNativeLinkOnly),
+            "unsupported_truth_labeled" => Some(SyncMode::UnsupportedTruthLabeled),
+            _ => None,
+        }
+    }
+}
+
+pub const ALL_SYNC_MODES: &[SyncMode] = &[
+    SyncMode::ProviderNativeSynced,
+    SyncMode::ProviderAppServerLocal,
+    SyncMode::FridayLocalMirror,
+    SyncMode::ProviderNativeLinkOnly,
+    SyncMode::UnsupportedTruthLabeled,
+];
+
+/// Hub-only provider session link. It may contain local/private identifiers and
+/// must not be projected to phone/channel surfaces directly.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProviderSessionLink {
+    pub friday_session_id: String,
+    pub provider: String,
+    pub account_key_hash: String,
+    pub workspace_id: String,
+    pub cwd: Option<String>,
+    pub external_session_id: Option<String>,
+    pub external_thread_id: Option<String>,
+    pub external_url: Option<String>,
+    pub sync_mode: SyncMode,
+    pub capability_snapshot: String,
+    pub last_provider_seen_at: Option<i64>,
+    pub last_friday_event_id: Option<String>,
+    pub truth_label: String,
+}
+
+impl ProviderSessionLink {
+    /// Redacted view safe for phone/channel UI. Raw account hashes, cwd, external
+    /// ids, and URLs stay Hub-only.
+    pub fn redacted_projection(&self) -> ProviderSessionProjection {
+        ProviderSessionProjection {
+            friday_session_id: self.friday_session_id.clone(),
+            provider: self.provider.clone(),
+            workspace_id: self.workspace_id.clone(),
+            sync_mode: self.sync_mode,
+            capability_snapshot: self.capability_snapshot.clone(),
+            last_provider_seen_at: self.last_provider_seen_at,
+            last_friday_event_id: self.last_friday_event_id.clone(),
+            truth_label: self.truth_label.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProviderSessionProjection {
+    pub friday_session_id: String,
+    pub provider: String,
+    pub workspace_id: String,
+    pub sync_mode: SyncMode,
+    pub capability_snapshot: String,
+    pub last_provider_seen_at: Option<i64>,
+    pub last_friday_event_id: Option<String>,
+    pub truth_label: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProviderSessionEvent {
+    pub friday_session_id: String,
+    pub provider_event_id: String,
+    pub provider: String,
+    pub event_kind: String,
+    pub transcript_item_kind: String,
+    pub body_ref: String,
+    pub redaction_level: String,
+    pub token_ledger_ref: Option<String>,
+    pub approval_ref: Option<String>,
+    pub audit_receipt_ref: Option<String>,
+    pub observed_at: i64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sync_modes_are_exact_file_60_values() {
+        let values: Vec<&str> = ALL_SYNC_MODES.iter().map(|mode| mode.as_str()).collect();
+        assert_eq!(
+            values,
+            vec![
+                "provider_native_synced",
+                "provider_app_server_local",
+                "friday_local_mirror",
+                "provider_native_link_only",
+                "unsupported_truth_labeled",
+            ]
+        );
+        for mode in ALL_SYNC_MODES {
+            assert_eq!(SyncMode::parse(mode.as_str()), Some(*mode));
+        }
+        assert_eq!(SyncMode::parse("native_synced"), None);
+    }
+
+    #[test]
+    fn redacted_projection_omits_hub_only_identity_and_urls() {
+        let link = ProviderSessionLink {
+            friday_session_id: "friday-s1".into(),
+            provider: "codex".into(),
+            account_key_hash: "acct-hash-secret".into(),
+            workspace_id: "workspace-a".into(),
+            cwd: Some("/Users/jarvis/private/project".into()),
+            external_session_id: Some("provider-session-secret".into()),
+            external_thread_id: Some("provider-thread-secret".into()),
+            external_url: Some("https://provider.example/private".into()),
+            sync_mode: SyncMode::ProviderAppServerLocal,
+            capability_snapshot: "thread/start,turn/start".into(),
+            last_provider_seen_at: Some(10),
+            last_friday_event_id: Some("ev-1".into()),
+            truth_label: "provider local session".into(),
+        };
+
+        let projection = format!("{:?}", link.redacted_projection());
+        for forbidden in [
+            "acct-hash-secret",
+            "/Users/jarvis/private/project",
+            "provider-session-secret",
+            "provider-thread-secret",
+            "https://provider.example/private",
+        ] {
+            assert!(
+                !projection.contains(forbidden),
+                "projection leaked Hub-only field {forbidden}: {projection}"
+            );
+        }
+        assert!(projection.contains("provider local session"));
+    }
+}

--- a/rust-core/crates/friday-ffi/src/lib.rs
+++ b/rust-core/crates/friday-ffi/src/lib.rs
@@ -569,7 +569,7 @@ mod tests {
 
     #[test]
     fn ffi_protocol_version_helpers() {
-        assert_eq!(protocol_schema_version(), 1);
+        assert_eq!(protocol_schema_version(), 2);
         assert_eq!(negotiate_schema_version(1, 3, 2, 5), Some(3));
         assert_eq!(negotiate_schema_version(1, 1, 2, 4), None);
     }

--- a/rust-core/crates/friday-ffi/src/lib.rs
+++ b/rust-core/crates/friday-ffi/src/lib.rs
@@ -569,7 +569,7 @@ mod tests {
 
     #[test]
     fn ffi_protocol_version_helpers() {
-        assert_eq!(protocol_schema_version(), 2);
+        assert_eq!(protocol_schema_version(), 3);
         assert_eq!(negotiate_schema_version(1, 3, 2, 5), Some(3));
         assert_eq!(negotiate_schema_version(1, 1, 2, 4), None);
     }

--- a/rust-core/crates/friday-hub/Cargo.toml
+++ b/rust-core/crates/friday-hub/Cargo.toml
@@ -27,6 +27,7 @@ friday-fs.workspace = true
 # The live model returns free-text content; the tool-call protocol is a JSON object
 # the Hub parses back into a RawToolCall. serde_json is the strict parser for that.
 serde_json.workspace = true
+thiserror.workspace = true
 # Memory-recall PII redaction (Hub-only — recall is Hub-side, the phone never
 # recalls). Pure computation, no I/O. NOT depended on by friday-ffi (phone).
 regex.workspace = true

--- a/rust-core/crates/friday-hub/Cargo.toml
+++ b/rust-core/crates/friday-hub/Cargo.toml
@@ -12,6 +12,7 @@ friday-core.workspace = true
 friday-crypto.workspace = true
 friday-protocol.workspace = true
 friday-storage.workspace = true
+friday-transport.workspace = true
 # The composition layer (`authorize_mutating_action`, `agent_run`) operates on a
 # `rusqlite::Connection`, so the turn-loop signatures name it directly.
 rusqlite.workspace = true

--- a/rust-core/crates/friday-hub/Cargo.toml
+++ b/rust-core/crates/friday-hub/Cargo.toml
@@ -10,6 +10,7 @@ rust-version.workspace = true
 [dependencies]
 friday-core.workspace = true
 friday-crypto.workspace = true
+friday-protocol.workspace = true
 friday-storage.workspace = true
 # The composition layer (`authorize_mutating_action`, `agent_run`) operates on a
 # `rusqlite::Connection`, so the turn-loop signatures name it directly.
@@ -35,4 +36,3 @@ regex.workspace = true
 # part of the production dependency graph (friday-arch-tests scans dependencies /
 # build-dependencies only) and never reach the phone (friday-ffi).
 ureq = { version = "2", features = ["json"] }
-

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -100,6 +100,14 @@ pub mod pair_runtime;
 /// any UI can look ready. Pure projection only; no provider/model calls.
 pub mod provider_workspace;
 
+/// PWS-004 — Provider Workspace dispatch adapter seam. Gates an action through
+/// [`provider_workspace::guard_action_request`] FIRST, then dispatches an accepted +
+/// routed action to a `ProviderDispatchAdapter`, returning dispatch_ref / truth_label /
+/// blocker. No adapter call on a non-accepted request; the capability truth_label is
+/// never upgraded by a dispatch; secrets stay Hub-side. Real Codex/Claude adapters land
+/// in CODEX-LIVE-001 / CLAUDE-MIRROR-001.
+pub mod provider_dispatch;
+
 use friday_core::gate::{
     canonical_action_bytes, canonical_approval_signature_bytes, ActorKind, ApprovalDecision,
     CanonicalApproval, GateDecision, MutatingActionRequest, CANONICAL_GATE_ISSUER,

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -89,6 +89,12 @@ pub mod planner;
 /// only (no skill/plugin exec). Resume-after-approval is a deferred follow-up.
 pub mod workflow_exec;
 
+/// PAIR-002 — Hub-side local pairing message handler. It consumes the structured
+/// QR payload from PAIR-001 and the first-slice protocol `Pair` message, writes a
+/// trusted device through the existing authenticated pairing proof, and never
+/// dispatches provider/model calls.
+pub mod pair_runtime;
+
 use friday_core::gate::{
     canonical_action_bytes, canonical_approval_signature_bytes, ActorKind, ApprovalDecision,
     CanonicalApproval, GateDecision, MutatingActionRequest, CANONICAL_GATE_ISSUER,

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -108,6 +108,13 @@ pub mod provider_workspace;
 /// in CODEX-LIVE-001 / CLAUDE-MIRROR-001.
 pub mod provider_dispatch;
 
+/// SMOOTH-001 — provider session timeline + reconnect harness. One Friday-canonical
+/// timeline per session with strictly-monotonic seq + revision-on-every-mutation, a
+/// PendingAction state machine where Hub-ack is never provider-completion, dedup by
+/// client_msg_id, and a reconnect that returns a bounded delta when the cursor is retained
+/// and a snapshot only when it is behind retention (no full-history reload by default).
+pub mod provider_timeline;
+
 use friday_core::gate::{
     canonical_action_bytes, canonical_approval_signature_bytes, ActorKind, ApprovalDecision,
     CanonicalApproval, GateDecision, MutatingActionRequest, CANONICAL_GATE_ISSUER,

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -95,6 +95,11 @@ pub mod workflow_exec;
 /// dispatches provider/model calls.
 pub mod pair_runtime;
 
+/// Provider Workspace runtime projection — maps Codex/Claude UI actions to
+/// provider capabilities, sync modes, native actions, and exact blockers before
+/// any UI can look ready. Pure projection only; no provider/model calls.
+pub mod provider_workspace;
+
 use friday_core::gate::{
     canonical_action_bytes, canonical_approval_signature_bytes, ActorKind, ApprovalDecision,
     CanonicalApproval, GateDecision, MutatingActionRequest, CANONICAL_GATE_ISSUER,

--- a/rust-core/crates/friday-hub/src/pair_runtime.rs
+++ b/rust-core/crates/friday-hub/src/pair_runtime.rs
@@ -6,8 +6,11 @@
 //! calls; scan/open/status are connection bootstrap, not Ask Friday.
 
 use friday_core::FridayPairPayload;
+use friday_crypto::DataKey;
 use friday_protocol::{Envelope, ErrorCode, Message, SUPPORTED};
 use friday_storage::Db;
+use friday_transport::{ws_recv_envelope, ws_send_envelope, TransportError, WireWebSocket};
+use std::io::{Read, Write};
 
 /// Minimal Hub pairing runtime. A future listener owns sockets/mDNS; this type
 /// owns the pairing semantics and can be tested without network or provider I/O.
@@ -81,6 +84,23 @@ impl PairingHub {
         }
     }
 
+    /// Handle exactly one E2E-sealed WebSocket pairing message and reply with a
+    /// sealed response. The socket/listener lifecycle is owned by the caller
+    /// (daemon, test, or future mobile bridge); this method binds the proven
+    /// transport framing to the pairing semantics.
+    pub fn handle_websocket_once<S: Read + Write>(
+        &self,
+        db: &mut Db,
+        ws: &mut WireWebSocket<S>,
+        session_key: &DataKey,
+        aad: &[u8],
+    ) -> Result<Envelope, TransportError> {
+        let request = ws_recv_envelope(ws, session_key, aad)?;
+        let response = self.handle_envelope(db, request);
+        ws_send_envelope(ws, session_key, &response, aad)?;
+        Ok(response)
+    }
+
     fn handle_pair(
         &self,
         db: &mut Db,
@@ -127,11 +147,18 @@ mod tests {
     use friday_core::{
         PairAuthority, PairTransportHint, PairTransportKind, CURRENT_PAIR_PAYLOAD_VERSION,
     };
-    use friday_crypto::pairing_proof;
+    use friday_crypto::{pairing_proof, DeviceKeypair};
     use friday_protocol::CURRENT_SCHEMA_VERSION;
     use friday_storage::StorageError;
+    use friday_transport::{
+        seal_envelope, ws_accept, ws_connect, ws_recv_envelope, ws_send_envelope,
+    };
+    use std::net::{TcpListener, TcpStream};
     use std::path::PathBuf;
+    use std::thread;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    const AAD: &[u8] = b"friday-pairing-ws-v1";
 
     struct TempDb(PathBuf);
 
@@ -314,5 +341,137 @@ mod tests {
             db.count("trusted_device"),
             Err(StorageError::Unsupported(_))
         ));
+    }
+
+    #[test]
+    fn websocket_pair_round_trip_over_loopback_writes_trust_no_model_rows() {
+        let tmp = TempDb::new("ws-pair");
+        let db_path = tmp.path().to_string();
+        let payload = sample_payload(2000);
+        let secret = payload.pairing_secret.expose_for_qr().as_bytes().to_vec();
+        let hub = PairingHub::new(payload, vec!["pairing".into()]);
+        let hub_kp = DeviceKeypair::generate();
+        let phone_kp = DeviceKeypair::generate();
+        let hub_pub = hub_kp.public_bytes();
+        let phone_pub = phone_kp.public_bytes();
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = thread::spawn(move || {
+            let session = hub_kp.agree(&phone_pub);
+            let mut db = Db::open_hub(&db_path).unwrap();
+            let (stream, _) = listener.accept().unwrap();
+            let mut ws = ws_accept(stream).unwrap();
+            let response = hub
+                .handle_websocket_once(&mut db, &mut ws, &session, AAD)
+                .unwrap();
+            assert_eq!(
+                response.message,
+                Message::PairAck {
+                    accepted: true,
+                    error_code: None,
+                }
+            );
+        });
+
+        let session = phone_kp.agree(&hub_pub);
+        let pubkey = vec![7u8; 32];
+        let proof = pairing_proof(&secret, &pubkey);
+        let request = Envelope::new(
+            "ws-pair-msg",
+            1000,
+            Message::Pair {
+                device_id: "ios-ws-1".into(),
+                device_pubkey: pubkey,
+                pairing_proof: proof,
+            },
+        );
+        let wire = seal_envelope(&session, &request, AAD).unwrap();
+        assert!(
+            !wire.windows(b"ios-ws-1".len()).any(|w| w == b"ios-ws-1"),
+            "device id leaked in sealed WebSocket body"
+        );
+        assert!(
+            !wire.windows(secret.len()).any(|w| w == secret.as_slice()),
+            "QR secret leaked in sealed WebSocket body"
+        );
+
+        let stream = TcpStream::connect(addr).unwrap();
+        let mut ws = ws_connect(&format!("ws://{addr}/"), stream).unwrap();
+        ws_send_envelope(&mut ws, &session, &request, AAD).unwrap();
+        let response = ws_recv_envelope(&mut ws, &session, AAD).unwrap();
+        assert_eq!(response.correlation_id.as_deref(), Some("ws-pair-msg"));
+        assert_eq!(
+            response.message,
+            Message::PairAck {
+                accepted: true,
+                error_code: None,
+            }
+        );
+        server.join().unwrap();
+
+        let db = Db::open_hub(tmp.path()).unwrap();
+        assert_eq!(db.count("trusted_device").unwrap(), 1);
+        assert_eq!(db.count("audit_ledger").unwrap(), 1);
+        assert_eq!(db.count("token_ledger").unwrap(), 0);
+        assert_eq!(db.count("activity_item").unwrap(), 0);
+    }
+
+    #[test]
+    fn websocket_ask_on_pairing_channel_is_refused_no_model_rows() {
+        let tmp = TempDb::new("ws-ask");
+        let db_path = tmp.path().to_string();
+        let hub = PairingHub::new(sample_payload(2000), vec!["pairing".into()]);
+        let hub_kp = DeviceKeypair::generate();
+        let phone_kp = DeviceKeypair::generate();
+        let hub_pub = hub_kp.public_bytes();
+        let phone_pub = phone_kp.public_bytes();
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = thread::spawn(move || {
+            let session = hub_kp.agree(&phone_pub);
+            let mut db = Db::open_hub(&db_path).unwrap();
+            let (stream, _) = listener.accept().unwrap();
+            let mut ws = ws_accept(stream).unwrap();
+            let response = hub
+                .handle_websocket_once(&mut db, &mut ws, &session, AAD)
+                .unwrap();
+            match response.message {
+                Message::Error {
+                    code: ErrorCode::ProviderUnavailable,
+                    message,
+                } => assert!(message.contains("does not dispatch")),
+                other => panic!("unexpected {other:?}"),
+            }
+        });
+
+        let session = phone_kp.agree(&hub_pub);
+        let request = Envelope::new(
+            "ws-ask",
+            1000,
+            Message::AskFridayRequest {
+                prompt: "hidden model call must not happen".into(),
+            },
+        );
+        let stream = TcpStream::connect(addr).unwrap();
+        let mut ws = ws_connect(&format!("ws://{addr}/"), stream).unwrap();
+        ws_send_envelope(&mut ws, &session, &request, AAD).unwrap();
+        let response = ws_recv_envelope(&mut ws, &session, AAD).unwrap();
+        assert_eq!(response.correlation_id.as_deref(), Some("ws-ask"));
+        match response.message {
+            Message::Error {
+                code: ErrorCode::ProviderUnavailable,
+                ..
+            } => {}
+            other => panic!("unexpected {other:?}"),
+        }
+        server.join().unwrap();
+
+        let db = Db::open_hub(tmp.path()).unwrap();
+        assert_eq!(db.count("trusted_device").unwrap(), 0);
+        assert_eq!(db.count("audit_ledger").unwrap(), 0);
+        assert_eq!(db.count("token_ledger").unwrap(), 0);
+        assert_eq!(db.count("activity_item").unwrap(), 0);
     }
 }

--- a/rust-core/crates/friday-hub/src/pair_runtime.rs
+++ b/rust-core/crates/friday-hub/src/pair_runtime.rs
@@ -9,8 +9,11 @@ use friday_core::FridayPairPayload;
 use friday_crypto::DataKey;
 use friday_protocol::{Envelope, ErrorCode, Message, SUPPORTED};
 use friday_storage::Db;
-use friday_transport::{ws_recv_envelope, ws_send_envelope, TransportError, WireWebSocket};
+use friday_transport::{
+    ws_accept, ws_recv_envelope, ws_send_envelope, TransportError, WireWebSocket,
+};
 use std::io::{Read, Write};
+use std::net::{Ipv4Addr, SocketAddr, TcpListener};
 
 /// Minimal Hub pairing runtime. A future listener owns sockets/mDNS; this type
 /// owns the pairing semantics and can be tested without network or provider I/O.
@@ -138,6 +141,46 @@ impl PairingHub {
             )
             .with_correlation(msg_id),
         }
+    }
+}
+
+/// PAIR-004 — local Hub pairing LISTENER. Binds **loopback only** (`127.0.0.1`) so the QR
+/// pairs a phone to THIS Mac's Hub and nothing routable off-box; it never exposes a
+/// provider secret. It owns the socket lifecycle; the pairing semantics + trust writes
+/// stay in [`PairingHub`]. Challenge-response is enforced downstream by
+/// `handle_websocket_once` → `handle_envelope`: only a valid `Pair` proof writes trust,
+/// and a pre-auth session/proof/model message is refused with no trust/model rows.
+pub struct PairingListener {
+    hub: PairingHub,
+    listener: TcpListener,
+}
+
+impl PairingListener {
+    /// Bind a LOOPBACK-only listener on `127.0.0.1:<port>` (`port = 0` lets the OS assign).
+    /// Binding `Ipv4Addr::LOCALHOST` (not `0.0.0.0`) is the "this Mac only" guarantee.
+    pub fn bind_loopback(hub: PairingHub, port: u16) -> std::io::Result<Self> {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, port))?;
+        Ok(Self { hub, listener })
+    }
+
+    pub fn local_addr(&self) -> std::io::Result<SocketAddr> {
+        self.listener.local_addr()
+    }
+
+    /// Accept exactly ONE connection, run the WebSocket handshake, and handle one sealed
+    /// pairing message. The E2E `session_key` is established out of band (pairing
+    /// handshake); this binds the listener to the proven pairing semantics. The challenge
+    /// (a valid `pairing_proof`) is verified before any trust/session/proof data.
+    pub fn accept_one(
+        &self,
+        db: &mut Db,
+        session_key: &DataKey,
+        aad: &[u8],
+    ) -> Result<Envelope, TransportError> {
+        let (stream, _peer) = self.listener.accept()?;
+        let mut ws = ws_accept(stream)?;
+        self.hub
+            .handle_websocket_once(db, &mut ws, session_key, aad)
     }
 }
 
@@ -473,5 +516,196 @@ mod tests {
         assert_eq!(db.count("audit_ledger").unwrap(), 0);
         assert_eq!(db.count("token_ledger").unwrap(), 0);
         assert_eq!(db.count("activity_item").unwrap(), 0);
+    }
+
+    // ---- PAIR-004 adverse suite -------------------------------------------------
+
+    /// Build a valid `Pair` message for `payload` + `device`.
+    fn pair_msg(payload: &FridayPairPayload, device_id: &str, pubkey: &[u8]) -> Message {
+        let secret = payload.pairing_secret.expose_for_qr().as_bytes().to_vec();
+        Message::Pair {
+            device_id: device_id.into(),
+            device_pubkey: pubkey.to_vec(),
+            pairing_proof: pairing_proof(&secret, pubkey),
+        }
+    }
+
+    #[test]
+    fn expired_pairing_payload_is_denied_and_writes_no_trust() {
+        let tmp = TempDb::new("expiry");
+        let mut db = Db::open_hub(tmp.path()).unwrap();
+        let payload = sample_payload(1000); // expires_at = 1000
+        let msg = pair_msg(&payload, "ios-exp", &[7u8; 32]);
+        let hub = PairingHub::new(payload, vec!["pairing".into()]);
+        // sent_at == expires_at → expired (validate_at: expires_at <= now).
+        let response = hub.handle_envelope(&mut db, Envelope::new("pair-exp", 1000, msg));
+        assert_eq!(
+            response.message,
+            Message::PairAck {
+                accepted: false,
+                error_code: Some(ErrorCode::PairingDenied),
+            }
+        );
+        assert_eq!(db.count("trusted_device").unwrap(), 0);
+        assert_eq!(db.count("audit_ledger").unwrap(), 0);
+    }
+
+    #[test]
+    fn replayed_pairing_is_denied_with_no_double_trust() {
+        let tmp = TempDb::new("replay");
+        let mut db = Db::open_hub(tmp.path()).unwrap();
+        let payload = sample_payload(5000);
+        let pubkey = [7u8; 32];
+        let first_msg = pair_msg(&payload, "ios-replay", &pubkey);
+        let replay_msg = pair_msg(&payload, "ios-replay", &pubkey); // identical proof
+        let hub = PairingHub::new(payload, vec!["pairing".into()]);
+
+        let first = hub.handle_envelope(&mut db, Envelope::new("pair-1", 1000, first_msg));
+        assert_eq!(
+            first.message,
+            Message::PairAck {
+                accepted: true,
+                error_code: None,
+            }
+        );
+        assert_eq!(db.count("trusted_device").unwrap(), 1);
+
+        // Replaying the exact captured Pair must be denied (device_id PK conflict) and
+        // must NOT create a second trust row.
+        let replay = hub.handle_envelope(&mut db, Envelope::new("pair-2", 1001, replay_msg));
+        assert_eq!(
+            replay.message,
+            Message::PairAck {
+                accepted: false,
+                error_code: Some(ErrorCode::PairingDenied),
+            }
+        );
+        assert_eq!(db.count("trusted_device").unwrap(), 1);
+    }
+
+    #[test]
+    fn revoked_device_is_no_longer_trusted() {
+        let tmp = TempDb::new("revoke");
+        let mut db = Db::open_hub(tmp.path()).unwrap();
+        let payload = sample_payload(5000);
+        let msg = pair_msg(&payload, "ios-revoke", &[7u8; 32]);
+        let hub = PairingHub::new(payload, vec!["pairing".into()]);
+        hub.handle_envelope(&mut db, Envelope::new("pair-rev", 1000, msg));
+        assert!(friday_storage::pairing::is_trusted(db.conn(), "ios-revoke").unwrap());
+
+        friday_storage::pairing::revoke_device(db.conn_mut(), "ios-revoke", 2000, "audit-revoke-1")
+            .unwrap();
+        assert!(!friday_storage::pairing::is_trusted(db.conn(), "ios-revoke").unwrap());
+    }
+
+    #[test]
+    fn first_message_before_auth_writes_no_trust_and_leaks_no_session_data() {
+        // Before any valid Pair, NO message (status / ask / unsupported) may write trust
+        // or return session/proof/transcript data — only challenge-response (a valid
+        // Pair) establishes trust.
+        let tmp = TempDb::new("preauth");
+        let mut db = Db::open_hub(tmp.path()).unwrap();
+        let hub = PairingHub::new(sample_payload(5000), vec!["pairing".into()]);
+
+        // (a) Ask before auth → refused, no model/provider call.
+        let ask = hub.handle_envelope(
+            &mut db,
+            Envelope::new(
+                "pre-ask",
+                1000,
+                Message::AskFridayRequest {
+                    prompt: "leak my history".into(),
+                },
+            ),
+        );
+        assert!(matches!(ask.message, Message::Error { .. }));
+
+        // (b) An unsupported pairing-channel message before auth → Error, not data.
+        let unsupported = hub.handle_envelope(
+            &mut db,
+            Envelope::new(
+                "pre-unsupported",
+                1000,
+                Message::PairAck {
+                    accepted: true,
+                    error_code: None,
+                },
+            ),
+        );
+        assert!(matches!(unsupported.message, Message::Error { .. }));
+
+        // (c) Status before auth is bootstrap-only: online + capabilities, NEVER a
+        // session/proof/transcript payload.
+        let status = hub.handle_envelope(&mut db, hub.status_envelope("pre-status", 1000));
+        assert!(matches!(status.message, Message::HubStatus { .. }));
+
+        // No pre-auth message wrote trust or any side-effect row.
+        assert_eq!(db.count("trusted_device").unwrap(), 0);
+        assert_eq!(db.count("audit_ledger").unwrap(), 0);
+        assert_eq!(db.count("token_ledger").unwrap(), 0);
+        assert_eq!(db.count("activity_item").unwrap(), 0);
+    }
+
+    #[test]
+    fn pairing_listener_binds_loopback_and_accepts_one_pair() {
+        let tmp = TempDb::new("listener");
+        let db_path = tmp.path().to_string();
+        let payload = sample_payload(5000);
+        let secret = payload.pairing_secret.expose_for_qr().as_bytes().to_vec();
+        let hub = PairingHub::new(payload, vec!["pairing".into()]);
+        let hub_kp = DeviceKeypair::generate();
+        let phone_kp = DeviceKeypair::generate();
+        let hub_pub = hub_kp.public_bytes();
+        let phone_pub = phone_kp.public_bytes();
+
+        let listener = PairingListener::bind_loopback(hub, 0).unwrap();
+        let addr = listener.local_addr().unwrap();
+        assert!(
+            addr.ip().is_loopback(),
+            "pairing listener must bind loopback only (this Mac)"
+        );
+
+        let server = thread::spawn(move || {
+            let session = hub_kp.agree(&phone_pub);
+            let mut db = Db::open_hub(&db_path).unwrap();
+            listener.accept_one(&mut db, &session, AAD).unwrap()
+        });
+
+        let session = phone_kp.agree(&hub_pub);
+        // The proof is over the SAME pairing secret the hub holds (captured before the
+        // payload moved into the hub).
+        let pubkey = vec![7u8; 32];
+        let request = Envelope::new(
+            "listener-pair",
+            1000,
+            Message::Pair {
+                device_id: "ios-listener".into(),
+                device_pubkey: pubkey.clone(),
+                pairing_proof: pairing_proof(&secret, &pubkey),
+            },
+        );
+
+        let stream = TcpStream::connect(addr).unwrap();
+        let mut ws = ws_connect(&format!("ws://{addr}/"), stream).unwrap();
+        ws_send_envelope(&mut ws, &session, &request, AAD).unwrap();
+        let client_resp = ws_recv_envelope(&mut ws, &session, AAD).unwrap();
+        let server_resp = server.join().unwrap();
+
+        assert_eq!(
+            server_resp.message,
+            Message::PairAck {
+                accepted: true,
+                error_code: None,
+            }
+        );
+        assert_eq!(
+            client_resp.message,
+            Message::PairAck {
+                accepted: true,
+                error_code: None,
+            }
+        );
+        let db = Db::open_hub(tmp.path()).unwrap();
+        assert_eq!(db.count("trusted_device").unwrap(), 1);
     }
 }

--- a/rust-core/crates/friday-hub/src/pair_runtime.rs
+++ b/rust-core/crates/friday-hub/src/pair_runtime.rs
@@ -148,7 +148,7 @@ mod tests {
         PairAuthority, PairTransportHint, PairTransportKind, CURRENT_PAIR_PAYLOAD_VERSION,
     };
     use friday_crypto::{pairing_proof, DeviceKeypair};
-    use friday_protocol::CURRENT_SCHEMA_VERSION;
+    use friday_protocol::SUPPORTED;
     use friday_storage::StorageError;
     use friday_transport::{
         seal_envelope, ws_accept, ws_connect, ws_recv_envelope, ws_send_envelope,
@@ -220,8 +220,8 @@ mod tests {
             } => {
                 assert!(online);
                 assert_eq!(capabilities, vec!["pairing", "provider_workspace"]);
-                assert_eq!(min_version, CURRENT_SCHEMA_VERSION);
-                assert_eq!(max_version, CURRENT_SCHEMA_VERSION);
+                assert_eq!(min_version, SUPPORTED.min);
+                assert_eq!(max_version, SUPPORTED.max);
             }
             other => panic!("unexpected {other:?}"),
         }

--- a/rust-core/crates/friday-hub/src/pair_runtime.rs
+++ b/rust-core/crates/friday-hub/src/pair_runtime.rs
@@ -1,0 +1,318 @@
+//! PAIR-002 — Hub-side QR pairing message handler.
+//!
+//! This is the runtime seam that sits behind a local WebSocket/mDNS service:
+//! it handles `Message::Pair` against a structured QR payload and writes the
+//! trusted-device/audit rows. It deliberately does **not** dispatch model/provider
+//! calls; scan/open/status are connection bootstrap, not Ask Friday.
+
+use friday_core::FridayPairPayload;
+use friday_protocol::{Envelope, ErrorCode, Message, SUPPORTED};
+use friday_storage::Db;
+
+/// Minimal Hub pairing runtime. A future listener owns sockets/mDNS; this type
+/// owns the pairing semantics and can be tested without network or provider I/O.
+#[derive(Clone, Debug)]
+pub struct PairingHub {
+    payload: FridayPairPayload,
+    capabilities: Vec<String>,
+}
+
+impl PairingHub {
+    pub fn new(payload: FridayPairPayload, capabilities: Vec<String>) -> Self {
+        Self {
+            payload,
+            capabilities,
+        }
+    }
+
+    /// Status payload shown after QR open/scan. No DB write, no provider call,
+    /// no model call.
+    pub fn status_envelope(&self, msg_id: impl Into<String>, sent_at: i64) -> Envelope {
+        Envelope::new(
+            msg_id,
+            sent_at,
+            Message::HubStatus {
+                online: true,
+                capabilities: self.capabilities.clone(),
+                min_version: SUPPORTED.min,
+                max_version: SUPPORTED.max,
+            },
+        )
+    }
+
+    /// Handle a first-slice pairing envelope. Only `Pair` writes trust state.
+    /// `AskFridayRequest` is explicitly refused here so a QR/pairing socket cannot
+    /// become a hidden model-call path.
+    pub fn handle_envelope(&self, db: &mut Db, env: Envelope) -> Envelope {
+        match env.message {
+            Message::Pair {
+                device_id,
+                device_pubkey,
+                pairing_proof,
+            } => self.handle_pair(
+                db,
+                env.msg_id,
+                env.sent_at,
+                device_id,
+                device_pubkey,
+                pairing_proof,
+            ),
+            Message::HubStatus { .. } => self
+                .status_envelope(format!("{}-status", env.msg_id), env.sent_at)
+                .with_correlation(env.msg_id),
+            Message::AskFridayRequest { .. } => Envelope::new(
+                format!("{}-refused", env.msg_id),
+                env.sent_at,
+                Message::Error {
+                    code: ErrorCode::ProviderUnavailable,
+                    message: "pairing channel does not dispatch model/provider calls".into(),
+                },
+            )
+            .with_correlation(env.msg_id),
+            _ => Envelope::new(
+                format!("{}-error", env.msg_id),
+                env.sent_at,
+                Message::Error {
+                    code: ErrorCode::Internal,
+                    message: "unsupported pairing-channel message".into(),
+                },
+            )
+            .with_correlation(env.msg_id),
+        }
+    }
+
+    fn handle_pair(
+        &self,
+        db: &mut Db,
+        msg_id: String,
+        sent_at: i64,
+        device_id: String,
+        device_pubkey: Vec<u8>,
+        pairing_proof: Vec<u8>,
+    ) -> Envelope {
+        let result = db.complete_qr_pairing(
+            &self.payload,
+            &device_id,
+            &device_pubkey,
+            &pairing_proof,
+            sent_at,
+            &format!("audit-pair-{msg_id}"),
+        );
+        match result {
+            Ok(()) => Envelope::new(
+                format!("{msg_id}-ack"),
+                sent_at,
+                Message::PairAck {
+                    accepted: true,
+                    error_code: None,
+                },
+            )
+            .with_correlation(msg_id),
+            Err(_) => Envelope::new(
+                format!("{msg_id}-denied"),
+                sent_at,
+                Message::PairAck {
+                    accepted: false,
+                    error_code: Some(ErrorCode::PairingDenied),
+                },
+            )
+            .with_correlation(msg_id),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use friday_core::{
+        PairAuthority, PairTransportHint, PairTransportKind, CURRENT_PAIR_PAYLOAD_VERSION,
+    };
+    use friday_crypto::pairing_proof;
+    use friday_protocol::CURRENT_SCHEMA_VERSION;
+    use friday_storage::StorageError;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    struct TempDb(PathBuf);
+
+    impl TempDb {
+        fn new(tag: &str) -> Self {
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            Self(std::env::temp_dir().join(format!("friday-pair-runtime-{tag}-{nanos}.sqlite")))
+        }
+
+        fn path(&self) -> &str {
+            self.0.to_str().unwrap()
+        }
+    }
+
+    impl Drop for TempDb {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.0);
+        }
+    }
+
+    fn sample_payload(expires_at: i64) -> FridayPairPayload {
+        FridayPairPayload::new(
+            CURRENT_PAIR_PAYLOAD_VERSION,
+            "hub-mac-mini",
+            "pair-1",
+            "friday-pairing-secret-32-bytes",
+            "Jarvis Mac mini",
+            vec![PairTransportHint::new(
+                PairTransportKind::LanWebSocket,
+                "ws://127.0.0.1:4477",
+                "LAN WebSocket",
+            )
+            .unwrap()],
+            expires_at,
+            vec![PairAuthority::StatusOnly, PairAuthority::Approvals],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn status_envelope_is_online_and_has_no_side_effects() {
+        let tmp = TempDb::new("status");
+        let db = Db::open_hub(tmp.path()).unwrap();
+        let hub = PairingHub::new(
+            sample_payload(2000),
+            vec!["pairing".into(), "provider_workspace".into()],
+        );
+
+        let env = hub.status_envelope("status-1", 100);
+        match env.message {
+            Message::HubStatus {
+                online,
+                capabilities,
+                min_version,
+                max_version,
+            } => {
+                assert!(online);
+                assert_eq!(capabilities, vec!["pairing", "provider_workspace"]);
+                assert_eq!(min_version, CURRENT_SCHEMA_VERSION);
+                assert_eq!(max_version, CURRENT_SCHEMA_VERSION);
+            }
+            other => panic!("unexpected {other:?}"),
+        }
+        assert_eq!(db.count("trusted_device").unwrap(), 0);
+        assert_eq!(db.count("token_ledger").unwrap(), 0);
+        assert_eq!(db.count("activity_item").unwrap(), 0);
+        assert_eq!(db.count("audit_ledger").unwrap(), 0);
+    }
+
+    #[test]
+    fn pair_message_records_trusted_device_and_no_model_call_rows() {
+        let tmp = TempDb::new("pair");
+        let mut db = Db::open_hub(tmp.path()).unwrap();
+        let payload = sample_payload(2000);
+        let secret = payload.pairing_secret.expose_for_qr().as_bytes().to_vec();
+        let hub = PairingHub::new(payload, vec!["pairing".into()]);
+        let pubkey = vec![7u8; 32];
+        let proof = pairing_proof(&secret, &pubkey);
+
+        let env = Envelope::new(
+            "pair-msg",
+            1000,
+            Message::Pair {
+                device_id: "ios-1".into(),
+                device_pubkey: pubkey,
+                pairing_proof: proof,
+            },
+        );
+        let response = hub.handle_envelope(&mut db, env);
+        assert_eq!(response.correlation_id.as_deref(), Some("pair-msg"));
+        assert_eq!(
+            response.message,
+            Message::PairAck {
+                accepted: true,
+                error_code: None
+            }
+        );
+        assert_eq!(db.count("trusted_device").unwrap(), 1);
+        assert_eq!(db.count("audit_ledger").unwrap(), 1);
+        assert_eq!(db.count("token_ledger").unwrap(), 0);
+        assert_eq!(db.count("activity_item").unwrap(), 0);
+    }
+
+    #[test]
+    fn bad_pair_and_ask_on_pairing_channel_do_not_call_model_or_write_trust() {
+        let tmp = TempDb::new("bad");
+        let mut db = Db::open_hub(tmp.path()).unwrap();
+        let hub = PairingHub::new(sample_payload(2000), vec!["pairing".into()]);
+
+        let bad_pair = Envelope::new(
+            "bad-pair",
+            1000,
+            Message::Pair {
+                device_id: "ios-1".into(),
+                device_pubkey: vec![7u8; 32],
+                pairing_proof: vec![1, 2, 3],
+            },
+        );
+        let response = hub.handle_envelope(&mut db, bad_pair);
+        assert_eq!(
+            response.message,
+            Message::PairAck {
+                accepted: false,
+                error_code: Some(ErrorCode::PairingDenied)
+            }
+        );
+
+        let ask = Envelope::new(
+            "ask-hidden",
+            1001,
+            Message::AskFridayRequest {
+                prompt: "do not run".into(),
+            },
+        );
+        let response = hub.handle_envelope(&mut db, ask);
+        match response.message {
+            Message::Error {
+                code: ErrorCode::ProviderUnavailable,
+                message,
+            } => assert!(message.contains("does not dispatch")),
+            other => panic!("unexpected {other:?}"),
+        }
+        assert_eq!(db.count("trusted_device").unwrap(), 0);
+        assert_eq!(db.count("audit_ledger").unwrap(), 0);
+        assert_eq!(db.count("token_ledger").unwrap(), 0);
+        assert_eq!(db.count("activity_item").unwrap(), 0);
+    }
+
+    #[test]
+    fn phone_db_cannot_complete_pair_message() {
+        let tmp = TempDb::new("phone");
+        let mut db = Db::open_phone(tmp.path()).unwrap();
+        let payload = sample_payload(2000);
+        let secret = payload.pairing_secret.expose_for_qr().as_bytes().to_vec();
+        let hub = PairingHub::new(payload, vec!["pairing".into()]);
+        let pubkey = vec![7u8; 32];
+        let proof = pairing_proof(&secret, &pubkey);
+
+        let env = Envelope::new(
+            "phone-pair",
+            1000,
+            Message::Pair {
+                device_id: "ios-1".into(),
+                device_pubkey: pubkey,
+                pairing_proof: proof,
+            },
+        );
+        let response = hub.handle_envelope(&mut db, env);
+        assert_eq!(
+            response.message,
+            Message::PairAck {
+                accepted: false,
+                error_code: Some(ErrorCode::PairingDenied)
+            }
+        );
+        assert!(matches!(
+            db.count("trusted_device"),
+            Err(StorageError::Unsupported(_))
+        ));
+    }
+}

--- a/rust-core/crates/friday-hub/src/provider_dispatch.rs
+++ b/rust-core/crates/friday-hub/src/provider_dispatch.rs
@@ -1,0 +1,563 @@
+//! Provider Workspace dispatch adapter SEAM (PWS-004).
+//!
+//! PWS-003 ([`crate::provider_workspace::guard_action_request`]) DECIDES
+//! accepted/routed/blocker but never dispatches. This seam wires an
+//! ACCEPTED + ROUTED action to a provider adapter and returns the
+//! `dispatch_ref` / `truth_label` / `blocker`.
+//!
+//! Invariants (file 60 §6, file 81 PWS-004, file 83):
+//! - GATE FIRST. The guard runs before the adapter is ever consulted. A blocked /
+//!   unknown / mismatched / non-routed request is returned VERBATIM with no adapter
+//!   call — so there is no hidden provider/model call on a non-accepted request.
+//! - NO TRUTH UPGRADE. The result's `truth_label` is the capability's (from the guard).
+//!   The adapter CANNOT relabel it (no `provider_native_synced` from a local dispatch);
+//!   [`DispatchOutcome`] deliberately carries no truth label.
+//! - SECRETS STAY HUB-SIDE. The adapter may run a provider CLI/app-server (in
+//!   CODEX-LIVE-001 / CLAUDE-MIRROR-001), but the [`DispatchOutcome`] / [`DispatchError`]
+//!   surfaced here must never include provider credentials, raw account ids, or raw
+//!   provider output.
+//! - NO FALLBACK. A failed dispatch returns an exact blocker; it never silently reroutes
+//!   to another provider.
+//!
+//! Sync by design — the core is blocking (ureq, no tokio). PWS-004 defines the trait +
+//! the gate-then-dispatch flow and is proven with an injected fake adapter (no real
+//! process / network in tests). The real Codex app-server and Claude mirror adapters
+//! land in CODEX-LIVE-001 / CLAUDE-MIRROR-001 as `ProviderDispatchAdapter` impls.
+
+use friday_protocol::{ProviderWorkspaceActionRequestWire, ProviderWorkspaceActionResultWire};
+use friday_providers::unified::ProviderSession;
+use thiserror::Error;
+
+use crate::provider_workspace::{guard_action_request, ProviderWorkspaceCatalog};
+
+/// What the adapter is given for an action the guard has ALREADY accepted + routed.
+/// `provider`/`action`/`capability_id` are the guard-validated strings; `truth_label` is
+/// informational only (the adapter must not change it).
+pub struct DispatchContext<'a> {
+    pub session: &'a ProviderSession,
+    pub provider: &'a str,
+    pub action: &'a str,
+    pub capability_id: &'a str,
+    pub dispatch_ref: &'a str,
+    pub truth_label: &'a str,
+    pub payload_ref: Option<&'a str>,
+}
+
+/// Coarse dispatch lifecycle. `Errored` is represented as `Err(DispatchError)`, not a
+/// status, so a failure can never be mistaken for a completion.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DispatchStatus {
+    Queued,
+    Running,
+    Completed,
+}
+
+fn dispatch_status_str(status: DispatchStatus) -> &'static str {
+    match status {
+        DispatchStatus::Queued => "dispatched_queued",
+        DispatchStatus::Running => "dispatched_running",
+        DispatchStatus::Completed => "dispatched_completed",
+    }
+}
+
+/// The result of a successful adapter dispatch. Carries NO truth label (the capability's
+/// is authoritative) and NO raw provider output/secret — only opaque refs.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DispatchOutcome {
+    pub status: DispatchStatus,
+    pub provider_event_id: Option<String>,
+    pub audit_receipt_ref: Option<String>,
+}
+
+/// Why a dispatch failed. Messages are coarse and operator-safe — never include provider
+/// stderr, credentials, account ids, or URLs.
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
+pub enum DispatchError {
+    #[error("provider adapter not ready: {0}")]
+    AdapterNotReady(String),
+    #[error("provider dispatch failed: {0}")]
+    ExecutionFailed(String),
+}
+
+/// The provider-specific dispatch seam. Implemented by the real Codex app-server / Claude
+/// mirror adapters (CODEX-LIVE-001 / CLAUDE-MIRROR-001) and by a fake adapter in tests.
+///
+/// `execute_action` is called ONLY for an action the guard already accepted + routed.
+pub trait ProviderDispatchAdapter {
+    fn execute_action(&self, ctx: &DispatchContext<'_>) -> Result<DispatchOutcome, DispatchError>;
+}
+
+/// Gate, then dispatch. The single entrypoint that wires an accepted Provider Workspace
+/// action to a provider adapter. See the module invariants.
+pub fn dispatch_provider_action(
+    catalog: &ProviderWorkspaceCatalog,
+    adapter: &dyn ProviderDispatchAdapter,
+    session: &ProviderSession,
+    request: ProviderWorkspaceActionRequestWire,
+) -> ProviderWorkspaceActionResultWire {
+    // Capture what the adapter needs before the guard consumes the request.
+    let payload_ref = request.payload_ref.clone();
+
+    // GATE FIRST — any refusal returns verbatim, adapter untouched.
+    let guard = guard_action_request(catalog, session, request);
+    if !guard.accepted || !guard.routed {
+        return guard;
+    }
+
+    // An accepted + routed guard result always carries a dispatch_ref; fail closed
+    // (no dispatch) if it somehow does not.
+    let dispatch_ref = match guard.dispatch_ref.as_deref() {
+        Some(r) => r.to_string(),
+        None => {
+            return ProviderWorkspaceActionResultWire {
+                status: "dispatch_ref_missing".to_string(),
+                blocker: Some("internal: accepted action missing dispatch_ref".to_string()),
+                dispatch_ref: None,
+                ..guard
+            };
+        }
+    };
+
+    // Dispatch. Scope the borrow of `guard` so the struct-update below can move it.
+    let outcome = {
+        let ctx = DispatchContext {
+            session,
+            provider: &guard.provider,
+            action: &guard.action,
+            capability_id: &guard.capability_id,
+            dispatch_ref: &dispatch_ref,
+            truth_label: &guard.truth_label,
+            payload_ref: payload_ref.as_deref(),
+        };
+        adapter.execute_action(&ctx)
+    };
+
+    match outcome {
+        Ok(outcome) => ProviderWorkspaceActionResultWire {
+            status: dispatch_status_str(outcome.status).to_string(),
+            blocker: None,
+            // Echo the deterministic guard dispatch_ref — the adapter cannot mint a new
+            // identity for the action.
+            dispatch_ref: Some(dispatch_ref),
+            // request_id/session/provider/action/capability_id/accepted/routed/
+            // truth_label/proof_ref are carried unchanged from the guard.
+            ..guard
+        },
+        Err(err) => ProviderWorkspaceActionResultWire {
+            status: "dispatch_failed".to_string(),
+            // STRUCTURAL no-leak: surface a FIXED operator-safe blocker per variant — the
+            // adapter's free-text detail (`{0}`, which could contain stderr / a credential
+            // / a raw url) is NEVER put on the wire. The detail stays in the `DispatchError`
+            // value for Hub-side logging/audit by the caller, not in the projection.
+            blocker: Some(wire_blocker(&err).to_string()),
+            dispatch_ref: None,
+            ..guard
+        },
+    }
+}
+
+/// The fixed, operator-safe wire blocker for a dispatch failure. Deliberately coarse and
+/// free of any adapter-supplied text so a provider secret / raw output can never reach a
+/// projected surface (file 60 §6, file 83 channel-redaction discipline).
+fn wire_blocker(err: &DispatchError) -> &'static str {
+    match err {
+        DispatchError::AdapterNotReady(_) => "provider adapter not ready",
+        DispatchError::ExecutionFailed(_) => "provider dispatch failed",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use friday_providers::unified::{
+        CapabilityStatus, FallbackStatus, PlatformProvider, ProviderCapability,
+        ProviderNativeAction, ProviderSyncMode, SessionStatus,
+    };
+    use std::cell::Cell;
+
+    fn session(provider: PlatformProvider) -> ProviderSession {
+        ProviderSession {
+            friday_session_id: format!("friday-{}", provider.as_str()),
+            provider,
+            workspace_id: "workspace-1".to_string(),
+            sync_mode: ProviderSyncMode::ProviderAppServerLocal,
+            status: SessionStatus::Idle,
+            capability_snapshot: Vec::new(),
+            active_turn_id: None,
+            last_event_seq: 0,
+            truth_label: "provider dispatch test".to_string(),
+            fallback_status: FallbackStatus::NoFallback,
+        }
+    }
+
+    fn req(
+        provider: &str,
+        friday_session_id: &str,
+        action: &str,
+        capability_id: &str,
+    ) -> ProviderWorkspaceActionRequestWire {
+        ProviderWorkspaceActionRequestWire {
+            request_id: "request-1".to_string(),
+            friday_session_id: friday_session_id.to_string(),
+            provider: provider.to_string(),
+            action: action.to_string(),
+            capability_id: capability_id.to_string(),
+            payload_ref: Some("friday://body/request/1".to_string()),
+        }
+    }
+
+    const VERIFIED_TRUTH: &str = "verified app-server list";
+
+    fn verified_catalog() -> ProviderWorkspaceCatalog {
+        let mut catalog = ProviderWorkspaceCatalog::new();
+        catalog
+            .register(
+                crate::provider_workspace::ProviderWorkspaceAction::ListSessions,
+                ProviderCapability {
+                    capability_id: "provider.codex.list_sessions".to_string(),
+                    provider: PlatformProvider::Codex,
+                    status: CapabilityStatus::Verified,
+                    sync_mode: ProviderSyncMode::ProviderAppServerLocal,
+                    truth_label: VERIFIED_TRUTH.to_string(),
+                    blocker: None,
+                    proof_ref: Some("proof-1".to_string()),
+                    native_action: Some(ProviderNativeAction::CodexAppServer {
+                        method: friday_providers::unified::CodexAppServerMethod::ThreadList,
+                        schema_ref: "schema".to_string(),
+                    }),
+                },
+            )
+            .unwrap();
+        catalog
+    }
+
+    fn unproven_catalog() -> ProviderWorkspaceCatalog {
+        let mut catalog = ProviderWorkspaceCatalog::new();
+        catalog
+            .register(
+                crate::provider_workspace::ProviderWorkspaceAction::ListSessions,
+                ProviderCapability {
+                    capability_id: "provider.codex.list_sessions".to_string(),
+                    provider: PlatformProvider::Codex,
+                    status: CapabilityStatus::ImplementedUnproven,
+                    sync_mode: ProviderSyncMode::ProviderAppServerLocal,
+                    truth_label: "codex list unproven".to_string(),
+                    blocker: Some("app-server list not yet live-proven".to_string()),
+                    proof_ref: None,
+                    native_action: None,
+                },
+            )
+            .unwrap();
+        catalog
+    }
+
+    /// A fake adapter that records calls and never spawns a real process / network.
+    enum Behavior {
+        Ok(DispatchStatus),
+        Fail(DispatchError),
+    }
+    struct FakeAdapter {
+        calls: Cell<usize>,
+        behavior: Behavior,
+    }
+    impl FakeAdapter {
+        fn with(behavior: Behavior) -> Self {
+            Self {
+                calls: Cell::new(0),
+                behavior,
+            }
+        }
+        fn ok() -> Self {
+            Self::with(Behavior::Ok(DispatchStatus::Queued))
+        }
+        fn ok_status(status: DispatchStatus) -> Self {
+            Self::with(Behavior::Ok(status))
+        }
+        fn failing() -> Self {
+            Self::with(Behavior::Fail(DispatchError::ExecutionFailed(
+                "adapter offline".to_string(),
+            )))
+        }
+        /// A failing adapter whose error string carries secret-shaped material — used to
+        /// prove the seam REDACTS it from the wire blocker (no longer a vacuous test).
+        fn failing_leaky() -> Self {
+            Self::with(Behavior::Fail(DispatchError::ExecutionFailed(
+                "token=sk-shouldNeverHappen account=acct_12345".to_string(),
+            )))
+        }
+        fn count(&self) -> usize {
+            self.calls.get()
+        }
+    }
+    impl ProviderDispatchAdapter for FakeAdapter {
+        fn execute_action(
+            &self,
+            ctx: &DispatchContext<'_>,
+        ) -> Result<DispatchOutcome, DispatchError> {
+            self.calls.set(self.calls.get() + 1);
+            // The seam must pass the deterministic guard dispatch_ref through.
+            assert!(ctx.dispatch_ref.starts_with("friday://provider-dispatch/"));
+            match &self.behavior {
+                Behavior::Ok(status) => Ok(DispatchOutcome {
+                    status: *status,
+                    provider_event_id: Some("provider-event-1".to_string()),
+                    audit_receipt_ref: Some("audit-1".to_string()),
+                }),
+                Behavior::Fail(err) => Err(err.clone()),
+            }
+        }
+    }
+
+    #[test]
+    fn unproven_action_is_not_dispatched() {
+        let adapter = FakeAdapter::ok();
+        let s = session(PlatformProvider::Codex);
+        let result = dispatch_provider_action(
+            &unproven_catalog(),
+            &adapter,
+            &s,
+            req(
+                "codex",
+                &s.friday_session_id,
+                "list_sessions",
+                "provider.codex.list_sessions",
+            ),
+        );
+        assert!(!result.accepted);
+        assert!(!result.routed);
+        assert!(result.blocker.is_some());
+        assert!(result.dispatch_ref.is_none());
+        assert_eq!(
+            adapter.count(),
+            0,
+            "a non-routed action must NOT reach the adapter"
+        );
+    }
+
+    #[test]
+    fn wrong_provider_is_refused_before_dispatch() {
+        let adapter = FakeAdapter::ok();
+        let s = session(PlatformProvider::Codex);
+        let result = dispatch_provider_action(
+            &verified_catalog(),
+            &adapter,
+            &s,
+            req(
+                "claude",
+                &s.friday_session_id,
+                "list_sessions",
+                "provider.codex.list_sessions",
+            ),
+        );
+        assert!(!result.accepted);
+        assert_eq!(result.status, "provider_mismatch");
+        assert_eq!(adapter.count(), 0);
+    }
+
+    #[test]
+    fn wrong_session_is_refused_before_dispatch() {
+        let adapter = FakeAdapter::ok();
+        let s = session(PlatformProvider::Codex);
+        let result = dispatch_provider_action(
+            &verified_catalog(),
+            &adapter,
+            &s,
+            req(
+                "codex",
+                "friday-other",
+                "list_sessions",
+                "provider.codex.list_sessions",
+            ),
+        );
+        assert!(!result.accepted);
+        assert_eq!(result.status, "session_mismatch");
+        assert_eq!(adapter.count(), 0);
+    }
+
+    #[test]
+    fn unknown_action_is_refused_before_dispatch() {
+        let adapter = FakeAdapter::ok();
+        let s = session(PlatformProvider::Codex);
+        let result = dispatch_provider_action(
+            &verified_catalog(),
+            &adapter,
+            &s,
+            req(
+                "codex",
+                &s.friday_session_id,
+                "teleport",
+                "provider.codex.teleport",
+            ),
+        );
+        assert!(!result.accepted);
+        assert_eq!(result.status, "unknown");
+        assert_eq!(adapter.count(), 0);
+    }
+
+    #[test]
+    fn missing_capability_row_is_refused_before_dispatch() {
+        let adapter = FakeAdapter::ok();
+        let s = session(PlatformProvider::Codex);
+        let result = dispatch_provider_action(
+            &ProviderWorkspaceCatalog::new(), // empty
+            &adapter,
+            &s,
+            req(
+                "codex",
+                &s.friday_session_id,
+                "list_sessions",
+                "provider.codex.list_sessions",
+            ),
+        );
+        assert!(!result.accepted);
+        assert_eq!(result.status, "missing_capability");
+        assert_eq!(adapter.count(), 0);
+    }
+
+    #[test]
+    fn verified_action_is_dispatched_with_dispatch_ref_and_preserved_truth_label() {
+        let adapter = FakeAdapter::ok();
+        let s = session(PlatformProvider::Codex);
+        let result = dispatch_provider_action(
+            &verified_catalog(),
+            &adapter,
+            &s,
+            req(
+                "codex",
+                &s.friday_session_id,
+                "list_sessions",
+                "provider.codex.list_sessions",
+            ),
+        );
+        assert!(result.accepted);
+        assert!(result.routed);
+        assert_eq!(result.status, "dispatched_queued");
+        assert!(result.blocker.is_none());
+        let dr = result
+            .dispatch_ref
+            .expect("dispatch_ref present on dispatched action");
+        assert_eq!(
+            dr,
+            "friday://provider-dispatch/codex/friday-codex/list_sessions"
+        );
+        // The truth label is the CAPABILITY's, not upgraded by the dispatch.
+        assert_eq!(result.truth_label, VERIFIED_TRUTH);
+        assert_eq!(adapter.count(), 1);
+    }
+
+    #[test]
+    fn adapter_failure_is_an_exact_blocker_not_a_completion() {
+        let adapter = FakeAdapter::failing();
+        let s = session(PlatformProvider::Codex);
+        let result = dispatch_provider_action(
+            &verified_catalog(),
+            &adapter,
+            &s,
+            req(
+                "codex",
+                &s.friday_session_id,
+                "list_sessions",
+                "provider.codex.list_sessions",
+            ),
+        );
+        // Guard accepted it, but dispatch failed — never a completion.
+        assert!(result.accepted);
+        assert!(result.routed);
+        assert_eq!(result.status, "dispatch_failed");
+        assert!(result.dispatch_ref.is_none());
+        // The wire blocker is the FIXED operator-safe string; the adapter's free-text
+        // detail ("adapter offline") is NOT surfaced on the wire.
+        assert_eq!(result.blocker.as_deref(), Some("provider dispatch failed"));
+        assert_eq!(adapter.count(), 1);
+    }
+
+    #[test]
+    fn dispatch_failure_redacts_adapter_supplied_secret_material() {
+        // Non-vacuous secret-leak proof: the adapter returns a secret-shaped error
+        // string; the seam must NOT surface any of it on the wire blocker.
+        let adapter = FakeAdapter::failing_leaky();
+        let s = session(PlatformProvider::Codex);
+        let result = dispatch_provider_action(
+            &verified_catalog(),
+            &adapter,
+            &s,
+            req(
+                "codex",
+                &s.friday_session_id,
+                "list_sessions",
+                "provider.codex.list_sessions",
+            ),
+        );
+        let blocker = result.blocker.expect("failure carries a blocker");
+        assert_eq!(blocker, "provider dispatch failed");
+        for leak in ["sk-", "token", "account", "acct_", "shouldNeverHappen"] {
+            assert!(
+                !blocker.contains(leak),
+                "adapter error text {leak:?} leaked into the wire blocker: {blocker:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn dispatch_status_running_and_completed_map_to_distinct_strings() {
+        let s = session(PlatformProvider::Codex);
+        for (status, expected) in [
+            (DispatchStatus::Running, "dispatched_running"),
+            (DispatchStatus::Completed, "dispatched_completed"),
+        ] {
+            let adapter = FakeAdapter::ok_status(status);
+            let result = dispatch_provider_action(
+                &verified_catalog(),
+                &adapter,
+                &s,
+                req(
+                    "codex",
+                    &s.friday_session_id,
+                    "list_sessions",
+                    "provider.codex.list_sessions",
+                ),
+            );
+            assert!(result.accepted);
+            assert_eq!(result.status, expected);
+            assert!(result.dispatch_ref.is_some());
+            assert_eq!(adapter.count(), 1);
+        }
+    }
+
+    #[test]
+    fn unknown_provider_and_capability_mismatch_are_refused_before_dispatch() {
+        let s = session(PlatformProvider::Codex);
+        // Unknown provider string.
+        let a1 = FakeAdapter::ok();
+        let r1 = dispatch_provider_action(
+            &verified_catalog(),
+            &a1,
+            &s,
+            req(
+                "frobnicator",
+                &s.friday_session_id,
+                "list_sessions",
+                "provider.codex.list_sessions",
+            ),
+        );
+        assert!(!r1.accepted);
+        assert_eq!(r1.status, "unknown");
+        assert_eq!(a1.count(), 0);
+        // Correct provider/action but a forged capability id.
+        let a2 = FakeAdapter::ok();
+        let r2 = dispatch_provider_action(
+            &verified_catalog(),
+            &a2,
+            &s,
+            req(
+                "codex",
+                &s.friday_session_id,
+                "list_sessions",
+                "provider.codex.WRONG_ID",
+            ),
+        );
+        assert!(!r2.accepted);
+        assert_eq!(r2.status, "capability_mismatch");
+        assert_eq!(a2.count(), 0);
+    }
+}

--- a/rust-core/crates/friday-hub/src/provider_timeline.rs
+++ b/rust-core/crates/friday-hub/src/provider_timeline.rs
@@ -1,0 +1,490 @@
+//! SMOOTH-001 — provider session timeline + reconnect harness (file 83).
+//!
+//! One Friday-canonical timeline per provider session. It assigns a strictly-monotonic
+//! per-session `seq` to every event and bumps a `revision` on EVERY mutation (including a
+//! pending-action status-only change), tracks `PendingAction`s by `client_msg_id` (deduped
+//! so a reconnect-and-resend never double-submits), and answers a reconnect with a DELTA
+//! when the client's cursor is still retained, falling back to a SNAPSHOT only when it is
+//! behind retention — so a reconnect is not a full-history reload by default.
+//!
+//! Honesty invariants (file 83):
+//! - An `OfflineQueueAck` (the Hub saw the queued message → `SentToHub`/`AcceptedByHub`) is
+//!   NEVER provider completion. The state machine makes `ProviderCompleted` reachable ONLY
+//!   through `RoutedToProvider` → `WaitingProvider`, which require Hub acceptance first.
+//! - Events carry only refs (`body_ref`/`provider_event_id`), never raw transcript text.
+//! - Pure logic, no I/O; per-session isolation means one noisy stream cannot stall another.
+
+use friday_protocol::{IdempotencyTracker, Seen};
+use std::collections::BTreeMap;
+
+/// A Friday-canonical timeline event (file 83 §ProviderTimelineEvent), metadata-only.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TimelineEvent {
+    /// Per-session, strictly monotonic from 1 (never reused, even after pruning).
+    pub seq: u64,
+    /// The timeline `revision` at which this event was appended.
+    pub revision: u64,
+    pub event_kind: String,
+    pub actor: String,
+    /// A ref to the body — never the raw transcript text.
+    pub body_ref: Option<String>,
+    pub provider_event_id: Option<String>,
+}
+
+/// The lifecycle of a Friday-originated action (file 83 §PendingAction). The happy path is
+/// a chain; terminal states may be reached from several points. `OfflineQueueAck` maps to
+/// `SentToHub`/`AcceptedByHub` and is NOT `ProviderCompleted`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PendingState {
+    Draft,
+    PendingLocal,
+    SentToHub,
+    AcceptedByHub,
+    RoutedToProvider,
+    WaitingProvider,
+    ProviderCompleted,
+    Blocked,
+    FailedRetryable,
+    FailedTerminal,
+    Cancelled,
+}
+
+impl PendingState {
+    pub fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            PendingState::ProviderCompleted
+                | PendingState::Blocked
+                | PendingState::FailedTerminal
+                | PendingState::Cancelled
+        )
+    }
+
+    /// The legal forward transitions. This is the load-bearing honesty guard:
+    /// `ProviderCompleted` is reachable ONLY from `WaitingProvider` (which requires
+    /// `RoutedToProvider` ← `AcceptedByHub` ← `SentToHub`), so an action can never be shown
+    /// "done" without real Hub acceptance + provider routing.
+    pub fn can_transition_to(self, to: PendingState) -> bool {
+        use PendingState::*;
+        matches!(
+            (self, to),
+            (Draft, PendingLocal)
+                | (PendingLocal, SentToHub)
+                | (PendingLocal, Cancelled)
+                | (SentToHub, AcceptedByHub)
+                | (SentToHub, Blocked)
+                | (SentToHub, FailedRetryable)
+                | (SentToHub, FailedTerminal)
+                | (SentToHub, Cancelled)
+                | (AcceptedByHub, RoutedToProvider)
+                | (AcceptedByHub, Blocked)
+                | (AcceptedByHub, FailedTerminal)
+                | (AcceptedByHub, Cancelled)
+                | (RoutedToProvider, WaitingProvider)
+                | (RoutedToProvider, FailedRetryable)
+                | (RoutedToProvider, FailedTerminal)
+                | (WaitingProvider, ProviderCompleted)
+                | (WaitingProvider, FailedRetryable)
+                | (WaitingProvider, FailedTerminal)
+                | (FailedRetryable, SentToHub) // retry
+                | (FailedRetryable, FailedTerminal)
+                | (FailedRetryable, Cancelled)
+        )
+    }
+}
+
+/// A Friday-originated pending action (file 83 §PendingAction).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PendingAction {
+    pub request_id: String,
+    pub client_msg_id: String,
+    pub action: String,
+    pub state: PendingState,
+    pub dispatch_ref: Option<String>,
+    pub blocker: Option<String>,
+    /// The timeline revision the action was based on when submitted.
+    pub base_revision: u64,
+    /// The timeline revision of the last state change.
+    pub updated_at_revision: u64,
+}
+
+/// The reconnect answer: a bounded DELTA when the cursor is retained, else a SNAPSHOT.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Reconnect {
+    Delta {
+        from_seq: u64,
+        to_seq: u64,
+        from_revision: u64,
+        to_revision: u64,
+        events: Vec<TimelineEvent>,
+        pending: Vec<PendingAction>,
+    },
+    Snapshot {
+        to_seq: u64,
+        revision: u64,
+        events: Vec<TimelineEvent>,
+        pending: Vec<PendingAction>,
+        reason: &'static str,
+    },
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum TimelineError {
+    /// A pending action transition that the state machine forbids.
+    IllegalTransition {
+        from: PendingState,
+        to: PendingState,
+    },
+    /// No pending action with that request id.
+    UnknownPending,
+}
+
+/// One Friday-canonical provider-session timeline.
+pub struct ProviderTimeline {
+    friday_session_id: String,
+    events: Vec<TimelineEvent>,
+    /// Next seq to assign — monotonic, never reset (survives pruning).
+    next_seq: u64,
+    /// Lowest seq still retained in `events` (events below this were pruned).
+    retained_from_seq: u64,
+    revision: u64,
+    pending: BTreeMap<String, PendingAction>, // keyed by request_id (insertion-ordered output)
+    by_client_msg: IdempotencyTracker,
+    client_to_request: BTreeMap<String, String>, // client_msg_id -> request_id (dedup)
+}
+
+impl ProviderTimeline {
+    pub fn new(friday_session_id: impl Into<String>) -> Self {
+        Self {
+            friday_session_id: friday_session_id.into(),
+            events: Vec::new(),
+            next_seq: 1,
+            retained_from_seq: 1,
+            revision: 0,
+            pending: BTreeMap::new(),
+            by_client_msg: IdempotencyTracker::new(),
+            client_to_request: BTreeMap::new(),
+        }
+    }
+
+    pub fn friday_session_id(&self) -> &str {
+        &self.friday_session_id
+    }
+    pub fn revision(&self) -> u64 {
+        self.revision
+    }
+    pub fn last_seq(&self) -> u64 {
+        self.next_seq - 1
+    }
+
+    /// Append an event; assigns the next seq and bumps revision. Returns the seq.
+    pub fn append_event(
+        &mut self,
+        event_kind: impl Into<String>,
+        actor: impl Into<String>,
+        body_ref: Option<String>,
+        provider_event_id: Option<String>,
+    ) -> u64 {
+        let seq = self.next_seq;
+        self.next_seq += 1;
+        self.revision += 1;
+        self.events.push(TimelineEvent {
+            seq,
+            revision: self.revision,
+            event_kind: event_kind.into(),
+            actor: actor.into(),
+            body_ref,
+            provider_event_id,
+        });
+        seq
+    }
+
+    /// Submit a Friday-originated pending action. Deduped by `client_msg_id`: a resend
+    /// (e.g. after reconnect) returns the EXISTING action and does not create a second one.
+    /// A freshly-submitted action starts at `PendingLocal` and bumps revision.
+    pub fn submit_pending(
+        &mut self,
+        client_msg_id: impl Into<String>,
+        request_id: impl Into<String>,
+        action: impl Into<String>,
+    ) -> &PendingAction {
+        let client_msg_id = client_msg_id.into();
+        if let Seen::Replay = self.by_client_msg.observe(&client_msg_id) {
+            let rid = self
+                .client_to_request
+                .get(&client_msg_id)
+                .expect("seen client_msg_id maps to a request");
+            return self.pending.get(rid).expect("mapped request exists");
+        }
+        let request_id = request_id.into();
+        self.revision += 1;
+        self.client_to_request
+            .insert(client_msg_id.clone(), request_id.clone());
+        let action = PendingAction {
+            request_id: request_id.clone(),
+            client_msg_id,
+            action: action.into(),
+            state: PendingState::PendingLocal,
+            dispatch_ref: None,
+            blocker: None,
+            base_revision: self.revision,
+            updated_at_revision: self.revision,
+        };
+        self.pending.entry(request_id.clone()).or_insert(action);
+        self.pending.get(&request_id).unwrap()
+    }
+
+    /// Advance a pending action to `to`, enforcing the legal state machine. A status-only
+    /// change still bumps revision (so a reconnecting client sees it).
+    pub fn advance_pending(
+        &mut self,
+        request_id: &str,
+        to: PendingState,
+        dispatch_ref: Option<String>,
+        blocker: Option<String>,
+    ) -> Result<(), TimelineError> {
+        let action = self
+            .pending
+            .get_mut(request_id)
+            .ok_or(TimelineError::UnknownPending)?;
+        if !action.state.can_transition_to(to) {
+            return Err(TimelineError::IllegalTransition {
+                from: action.state,
+                to,
+            });
+        }
+        action.state = to;
+        if dispatch_ref.is_some() {
+            action.dispatch_ref = dispatch_ref;
+        }
+        if blocker.is_some() {
+            action.blocker = blocker;
+        }
+        self.revision += 1;
+        action.updated_at_revision = self.revision;
+        Ok(())
+    }
+
+    pub fn pending(&self, request_id: &str) -> Option<&PendingAction> {
+        self.pending.get(request_id)
+    }
+
+    fn pending_snapshot(&self) -> Vec<PendingAction> {
+        self.pending.values().cloned().collect()
+    }
+
+    /// Prune events with seq below `keep_from_seq` (bounded hydration). seq assignment is
+    /// unaffected; a client whose cursor is below the new retention gets a snapshot.
+    pub fn prune_before(&mut self, keep_from_seq: u64) {
+        self.events.retain(|e| e.seq >= keep_from_seq);
+        self.retained_from_seq = self.retained_from_seq.max(keep_from_seq);
+    }
+
+    /// Answer a reconnect. If every event after `last_seen_seq` is still retained, return a
+    /// DELTA (only the missed events, in seq order); otherwise the cursor is behind
+    /// retention and we return a SNAPSHOT of what is retained.
+    pub fn reconnect(&self, last_seen_seq: u64, last_seen_revision: u64) -> Reconnect {
+        let cursor_retained = last_seen_seq + 1 >= self.retained_from_seq;
+        if cursor_retained {
+            let events: Vec<TimelineEvent> = self
+                .events
+                .iter()
+                .filter(|e| e.seq > last_seen_seq)
+                .cloned()
+                .collect();
+            Reconnect::Delta {
+                from_seq: last_seen_seq,
+                to_seq: self.last_seq(),
+                from_revision: last_seen_revision,
+                to_revision: self.revision,
+                events,
+                pending: self.pending_snapshot(),
+            }
+        } else {
+            Reconnect::Snapshot {
+                to_seq: self.last_seq(),
+                revision: self.revision,
+                events: self.events.clone(),
+                pending: self.pending_snapshot(),
+                reason: "cursor_behind_retention",
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn seeded() -> ProviderTimeline {
+        let mut t = ProviderTimeline::new("friday-session-1");
+        for i in 1..=5 {
+            t.append_event(
+                "assistant_message",
+                "provider",
+                Some(format!("body://{i}")),
+                None,
+            );
+        }
+        t
+    }
+
+    #[test]
+    fn seq_is_strictly_monotonic_and_revision_bumps_on_every_mutation() {
+        let mut t = ProviderTimeline::new("s");
+        assert_eq!(t.revision(), 0);
+        assert_eq!(t.append_event("system", "hub", None, None), 1);
+        assert_eq!(
+            t.append_event("assistant_message", "provider", None, None),
+            2
+        );
+        assert_eq!(t.last_seq(), 2);
+        assert_eq!(t.revision(), 2);
+        // A pending submit is a mutation (revision++), and a status-only advance is too.
+        t.submit_pending("c1", "r1", "send_turn");
+        assert_eq!(t.revision(), 3);
+        t.advance_pending("r1", PendingState::SentToHub, None, None)
+            .unwrap();
+        assert_eq!(t.revision(), 4);
+    }
+
+    #[test]
+    fn hub_ack_is_not_provider_completion_and_done_requires_provider_routing() {
+        let mut t = ProviderTimeline::new("s");
+        t.submit_pending("c1", "r1", "send_turn");
+        // Cannot jump straight to provider-completed from pending_local.
+        assert_eq!(
+            t.advance_pending("r1", PendingState::ProviderCompleted, None, None),
+            Err(TimelineError::IllegalTransition {
+                from: PendingState::PendingLocal,
+                to: PendingState::ProviderCompleted,
+            })
+        );
+        // Hub acceptance is not completion.
+        t.advance_pending("r1", PendingState::SentToHub, None, None)
+            .unwrap();
+        t.advance_pending("r1", PendingState::AcceptedByHub, None, None)
+            .unwrap();
+        assert!(!t.pending("r1").unwrap().state.is_terminal());
+        assert_ne!(
+            t.pending("r1").unwrap().state,
+            PendingState::ProviderCompleted
+        );
+        // Still cannot complete without routing + waiting.
+        assert!(t
+            .advance_pending("r1", PendingState::ProviderCompleted, None, None)
+            .is_err());
+        // The full legal path reaches completion.
+        t.advance_pending(
+            "r1",
+            PendingState::RoutedToProvider,
+            Some("friday://d/1".into()),
+            None,
+        )
+        .unwrap();
+        t.advance_pending("r1", PendingState::WaitingProvider, None, None)
+            .unwrap();
+        t.advance_pending("r1", PendingState::ProviderCompleted, None, None)
+            .unwrap();
+        assert_eq!(
+            t.pending("r1").unwrap().state,
+            PendingState::ProviderCompleted
+        );
+    }
+
+    #[test]
+    fn duplicate_client_msg_id_does_not_create_a_second_pending() {
+        let mut t = ProviderTimeline::new("s");
+        let first_rid = t.submit_pending("c1", "r1", "send_turn").request_id.clone();
+        let rev_after_first = t.revision();
+        // A resend with the SAME client_msg_id returns the existing action; no new pending,
+        // no extra revision bump (no double dispatch).
+        let again = t.submit_pending("c1", "r2-should-be-ignored", "send_turn");
+        assert_eq!(again.request_id, first_rid);
+        assert_eq!(t.revision(), rev_after_first);
+    }
+
+    #[test]
+    fn reconnect_delta_replays_only_missed_events_in_order() {
+        let t = seeded();
+        match t.reconnect(2, 2) {
+            Reconnect::Delta {
+                events,
+                from_seq,
+                to_seq,
+                to_revision,
+                ..
+            } => {
+                assert_eq!(from_seq, 2);
+                assert_eq!(to_seq, 5);
+                assert_eq!(to_revision, 5);
+                let seqs: Vec<u64> = events.iter().map(|e| e.seq).collect();
+                assert_eq!(seqs, vec![3, 4, 5]); // only missed, in order
+            }
+            other => panic!("expected delta, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fresh_client_gets_a_delta_of_everything_not_a_snapshot() {
+        let t = seeded();
+        match t.reconnect(0, 0) {
+            Reconnect::Delta { events, .. } => assert_eq!(events.len(), 5),
+            other => panic!("expected delta, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn old_cursor_behind_retention_triggers_snapshot_fallback() {
+        let mut t = seeded();
+        t.prune_before(3); // retain seq >= 3
+                           // A client last at seq 1 is behind retention → snapshot, not a broken delta.
+        match t.reconnect(1, 1) {
+            Reconnect::Snapshot {
+                events,
+                reason,
+                to_seq,
+                ..
+            } => {
+                assert_eq!(reason, "cursor_behind_retention");
+                assert_eq!(to_seq, 5);
+                let seqs: Vec<u64> = events.iter().map(|e| e.seq).collect();
+                assert_eq!(seqs, vec![3, 4, 5]); // retained window
+            }
+            other => panic!("expected snapshot, got {other:?}"),
+        }
+        // A client still within retention (seq 3) gets a delta.
+        assert!(matches!(t.reconnect(3, 3), Reconnect::Delta { .. }));
+    }
+
+    #[test]
+    fn two_session_timelines_are_independent() {
+        // Backpressure / isolation: appending to one session's timeline never changes
+        // another's seq or revision.
+        let mut a = ProviderTimeline::new("session-a");
+        let mut b = ProviderTimeline::new("session-b");
+        a.append_event("assistant_message", "provider", None, None);
+        a.append_event("assistant_message", "provider", None, None);
+        assert_eq!(a.last_seq(), 2);
+        assert_eq!(b.last_seq(), 0);
+        assert_eq!(b.revision(), 0);
+        b.append_event("system", "hub", None, None);
+        assert_eq!(b.last_seq(), 1);
+        assert_eq!(a.last_seq(), 2);
+    }
+
+    #[test]
+    fn events_carry_only_refs_never_raw_body() {
+        let mut t = ProviderTimeline::new("s");
+        t.append_event(
+            "assistant_message",
+            "provider",
+            Some("body://ref/1".into()),
+            Some("pe-1".into()),
+        );
+        let ev = &t.reconnect(0, 0);
+        let debug = format!("{ev:?}");
+        assert!(debug.contains("body://ref/1"));
+        // body_ref is a ref; there is no field that could carry raw transcript text.
+    }
+}

--- a/rust-core/crates/friday-hub/src/provider_workspace.rs
+++ b/rust-core/crates/friday-hub/src/provider_workspace.rs
@@ -8,6 +8,7 @@
 use std::collections::BTreeMap;
 
 use friday_protocol::{
+    ProviderWorkspaceActionRequestWire, ProviderWorkspaceActionResultWire,
     ProviderWorkspaceActionWire, ProviderWorkspaceNativeActionWire, ProviderWorkspaceNeedsMeWire,
     ProviderWorkspaceProjectionWire, ProviderWorkspaceSessionWire,
 };
@@ -31,6 +32,12 @@ pub enum ProviderWorkspaceError {
         capability_id: String,
         expected_id: String,
     },
+
+    #[error("unknown provider workspace provider: {provider}")]
+    UnknownProvider { provider: String },
+
+    #[error("unknown provider workspace action: {action}")]
+    UnknownAction { action: String },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -62,6 +69,23 @@ impl ProviderWorkspaceAction {
             ProviderWorkspaceAction::ApproveOrReject => "approve_or_reject",
             ProviderWorkspaceAction::AnswerQuestion => "answer_question",
             ProviderWorkspaceAction::OpenProviderNative => "open_provider_native",
+        }
+    }
+
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "list_sessions" => Some(ProviderWorkspaceAction::ListSessions),
+            "read_session" => Some(ProviderWorkspaceAction::ReadSession),
+            "start_session" => Some(ProviderWorkspaceAction::StartSession),
+            "resume_session" => Some(ProviderWorkspaceAction::ResumeSession),
+            "fork_session" => Some(ProviderWorkspaceAction::ForkSession),
+            "send_turn" => Some(ProviderWorkspaceAction::SendTurn),
+            "steer_turn" => Some(ProviderWorkspaceAction::SteerTurn),
+            "interrupt_turn" => Some(ProviderWorkspaceAction::InterruptTurn),
+            "approve_or_reject" => Some(ProviderWorkspaceAction::ApproveOrReject),
+            "answer_question" => Some(ProviderWorkspaceAction::AnswerQuestion),
+            "open_provider_native" => Some(ProviderWorkspaceAction::OpenProviderNative),
+            _ => None,
         }
     }
 }
@@ -169,6 +193,14 @@ impl ProviderWorkspaceCatalog {
             .map(projection_to_wire)
     }
 
+    pub fn guard_action_request(
+        &self,
+        session: &ProviderSession,
+        request: ProviderWorkspaceActionRequestWire,
+    ) -> ProviderWorkspaceActionResultWire {
+        guard_action_request(self, session, request)
+    }
+
     /// Current Friday truth-labeled provider workspace catalog. It is not a
     /// provider parity claim: unproven actions are disabled with exact blockers.
     pub fn friday_current() -> Self {
@@ -185,6 +217,124 @@ impl ProviderWorkspaceCatalog {
         }
         catalog
     }
+}
+
+pub fn guard_action_request(
+    catalog: &ProviderWorkspaceCatalog,
+    session: &ProviderSession,
+    request: ProviderWorkspaceActionRequestWire,
+) -> ProviderWorkspaceActionResultWire {
+    let provider = match parse_provider(&request.provider) {
+        Some(provider) => provider,
+        None => {
+            let blocker = format!("unknown provider '{}'", request.provider);
+            return rejected_action_result(request, "unknown", blocker);
+        }
+    };
+    if provider != session.provider {
+        return rejected_action_result(
+            request,
+            "provider_mismatch",
+            "request provider does not match session provider".to_string(),
+        );
+    }
+    if request.friday_session_id != session.friday_session_id {
+        return rejected_action_result(
+            request,
+            "session_mismatch",
+            "request session id does not match Provider Workspace session".to_string(),
+        );
+    }
+    let action = match ProviderWorkspaceAction::parse(&request.action) {
+        Some(action) => action,
+        None => {
+            let blocker = format!("unknown Provider Workspace action '{}'", request.action);
+            return rejected_action_result(request, "unknown", blocker);
+        }
+    };
+    let expected_id = capability_id(provider, action);
+    if request.capability_id != expected_id {
+        return rejected_action_result(
+            request,
+            "capability_mismatch",
+            format!("capability id must be '{expected_id}'"),
+        );
+    }
+    let Some(projected) = catalog.resolve(provider, action) else {
+        return rejected_action_result(
+            request,
+            "missing_capability",
+            "no provider capability row exists for requested action".to_string(),
+        );
+    };
+    let projected = match projected {
+        Ok(projected) => projected,
+        Err(err) => return rejected_action_result(request, "invalid_capability", err.to_string()),
+    };
+    if !projected.routed {
+        return ProviderWorkspaceActionResultWire {
+            request_id: request.request_id,
+            friday_session_id: request.friday_session_id,
+            provider: request.provider,
+            action: request.action,
+            capability_id: request.capability_id,
+            accepted: false,
+            routed: false,
+            status: capability_status_str(projected.status).to_string(),
+            truth_label: projected.truth_label,
+            blocker: projected.blocker,
+            proof_ref: projected.proof_ref,
+            dispatch_ref: None,
+        };
+    }
+    ProviderWorkspaceActionResultWire {
+        request_id: request.request_id,
+        friday_session_id: request.friday_session_id,
+        provider: request.provider,
+        action: request.action,
+        capability_id: request.capability_id,
+        accepted: true,
+        routed: true,
+        status: capability_status_str(projected.status).to_string(),
+        truth_label: projected.truth_label,
+        blocker: None,
+        proof_ref: projected.proof_ref,
+        dispatch_ref: Some(dispatch_ref(session, provider, action)),
+    }
+}
+
+fn rejected_action_result(
+    request: ProviderWorkspaceActionRequestWire,
+    status: &str,
+    blocker: String,
+) -> ProviderWorkspaceActionResultWire {
+    ProviderWorkspaceActionResultWire {
+        request_id: request.request_id,
+        friday_session_id: request.friday_session_id,
+        provider: request.provider,
+        action: request.action,
+        capability_id: request.capability_id,
+        accepted: false,
+        routed: false,
+        status: status.to_string(),
+        truth_label: "provider_workspace_action_refused_before_dispatch".to_string(),
+        blocker: Some(blocker),
+        proof_ref: None,
+        dispatch_ref: None,
+    }
+}
+
+fn dispatch_ref(
+    session: &ProviderSession,
+    provider: PlatformProvider,
+    action: ProviderWorkspaceAction,
+) -> String {
+    format!(
+        "friday://provider-dispatch/{}/{}/{}",
+        provider.as_str(),
+        session.friday_session_id,
+        action.as_str()
+    )
 }
 
 pub fn projection_to_wire(
@@ -275,6 +425,14 @@ pub const PROVIDER_WORKSPACE_ACTIONS: &[ProviderWorkspaceAction] = &[
 
 fn capability_id(provider: PlatformProvider, action: ProviderWorkspaceAction) -> String {
     format!("provider.{}.{}", provider.as_str(), action.as_str())
+}
+
+fn parse_provider(value: &str) -> Option<PlatformProvider> {
+    match value {
+        "codex" => Some(PlatformProvider::Codex),
+        "claude" => Some(PlatformProvider::Claude),
+        _ => None,
+    }
 }
 
 fn session_status_str(status: SessionStatus) -> &'static str {
@@ -808,6 +966,45 @@ mod tests {
         }
     }
 
+    fn action_request(
+        provider: &str,
+        friday_session_id: &str,
+        action: &str,
+        capability_id: &str,
+    ) -> ProviderWorkspaceActionRequestWire {
+        ProviderWorkspaceActionRequestWire {
+            request_id: "request-1".to_string(),
+            friday_session_id: friday_session_id.to_string(),
+            provider: provider.to_string(),
+            action: action.to_string(),
+            capability_id: capability_id.to_string(),
+            payload_ref: Some("friday://body/request/1".to_string()),
+        }
+    }
+
+    fn verified_list_catalog() -> ProviderWorkspaceCatalog {
+        let mut catalog = ProviderWorkspaceCatalog::new();
+        catalog
+            .register(
+                ProviderWorkspaceAction::ListSessions,
+                ProviderCapability {
+                    capability_id: "provider.codex.list_sessions".to_string(),
+                    provider: PlatformProvider::Codex,
+                    status: CapabilityStatus::Verified,
+                    sync_mode: ProviderSyncMode::ProviderAppServerLocal,
+                    truth_label: "verified app-server list".to_string(),
+                    blocker: None,
+                    proof_ref: Some("proof-1".to_string()),
+                    native_action: Some(ProviderNativeAction::CodexAppServer {
+                        method: friday_providers::unified::CodexAppServerMethod::ThreadList,
+                        schema_ref: "schema".to_string(),
+                    }),
+                },
+            )
+            .unwrap();
+        catalog
+    }
+
     #[test]
     fn current_catalog_has_no_orphan_provider_workspace_actions() {
         let catalog = ProviderWorkspaceCatalog::friday_current();
@@ -1018,7 +1215,7 @@ mod tests {
         );
         let json = env.encode().unwrap();
         assert!(json.contains("\"kind\":\"ProviderWorkspaceSnapshot\""));
-        assert!(json.contains("\"schema_version\":2"));
+        assert!(json.contains("\"schema_version\":3"));
         assert!(json.contains("\"capability_id\":\"provider.codex.send_turn\""));
         assert!(json.contains("\"provider_action\":\"codex_app_server\""));
         for forbidden in [
@@ -1037,5 +1234,124 @@ mod tests {
         }
         let decoded = Envelope::decode(&json).unwrap();
         assert_eq!(decoded, env);
+    }
+
+    #[test]
+    fn guard_refuses_unproven_codex_action_before_provider_dispatch() {
+        let catalog = ProviderWorkspaceCatalog::friday_current();
+        let result = catalog.guard_action_request(
+            &session(PlatformProvider::Codex),
+            action_request(
+                "codex",
+                "friday-codex",
+                "send_turn",
+                "provider.codex.send_turn",
+            ),
+        );
+        assert!(!result.accepted);
+        assert!(!result.routed);
+        assert_eq!(result.status, "implemented_unproven");
+        assert!(result
+            .blocker
+            .as_deref()
+            .unwrap()
+            .contains("official-history"));
+        assert!(result.dispatch_ref.is_none());
+
+        let env = Envelope::new(
+            "provider-action-result-1",
+            100,
+            Message::ProviderWorkspaceActionResult { result },
+        );
+        let json = env.encode().unwrap();
+        assert!(json.contains("\"schema_version\":3"));
+        assert!(!json.contains("sk-"));
+        assert!(!json.contains("raw user prompt"));
+        assert!(!json.contains("provider-token"));
+        assert_eq!(Envelope::decode(&json).unwrap(), env);
+    }
+
+    #[test]
+    fn guard_rejects_mismatched_or_unknown_action_requests() {
+        let catalog = ProviderWorkspaceCatalog::friday_current();
+        let session = session(PlatformProvider::Codex);
+        let cases = [
+            (
+                action_request(
+                    "claude",
+                    "friday-codex",
+                    "send_turn",
+                    "provider.claude.send_turn",
+                ),
+                "provider_mismatch",
+            ),
+            (
+                action_request(
+                    "codex",
+                    "friday-other",
+                    "send_turn",
+                    "provider.codex.send_turn",
+                ),
+                "session_mismatch",
+            ),
+            (
+                action_request(
+                    "codex",
+                    "friday-codex",
+                    "teleport",
+                    "provider.codex.teleport",
+                ),
+                "unknown",
+            ),
+            (
+                action_request(
+                    "codex",
+                    "friday-codex",
+                    "send_turn",
+                    "provider.codex.list_sessions",
+                ),
+                "capability_mismatch",
+            ),
+            (
+                action_request(
+                    "opencode",
+                    "friday-codex",
+                    "send_turn",
+                    "provider.opencode.send_turn",
+                ),
+                "unknown",
+            ),
+        ];
+        for (request, expected_status) in cases {
+            let result = catalog.guard_action_request(&session, request);
+            assert!(!result.accepted);
+            assert!(!result.routed);
+            assert_eq!(result.status, expected_status);
+            assert!(result.blocker.as_deref().is_some_and(|b| !b.is_empty()));
+            assert!(result.dispatch_ref.is_none());
+        }
+    }
+
+    #[test]
+    fn guard_accepts_only_verified_capability_with_dispatch_ref() {
+        let catalog = verified_list_catalog();
+        let result = catalog.guard_action_request(
+            &session(PlatformProvider::Codex),
+            action_request(
+                "codex",
+                "friday-codex",
+                "list_sessions",
+                "provider.codex.list_sessions",
+            ),
+        );
+        assert!(result.accepted);
+        assert!(result.routed);
+        assert_eq!(result.status, "verified");
+        assert_eq!(result.proof_ref.as_deref(), Some("proof-1"));
+        assert!(result.blocker.is_none());
+        assert_eq!(
+            result.dispatch_ref.as_deref(),
+            Some("friday://provider-dispatch/codex/friday-codex/list_sessions")
+        );
     }
 }

--- a/rust-core/crates/friday-hub/src/provider_workspace.rs
+++ b/rust-core/crates/friday-hub/src/provider_workspace.rs
@@ -7,9 +7,14 @@
 
 use std::collections::BTreeMap;
 
+use friday_protocol::{
+    ProviderWorkspaceActionWire, ProviderWorkspaceNativeActionWire, ProviderWorkspaceNeedsMeWire,
+    ProviderWorkspaceProjectionWire, ProviderWorkspaceSessionWire,
+};
 use friday_providers::unified::{
-    CapabilityStatus, NeedsMeItem, NeedsMePriority, PlatformProvider, ProviderCapability,
-    ProviderNativeAction, ProviderSession, ProviderSyncMode, SessionEvent,
+    CapabilityStatus, ClaudeRemoteControlAction, CodexAppServerMethod, FallbackStatus, NeedsMeItem,
+    NeedsMeKind, NeedsMePriority, PlatformProvider, ProviderCapability, ProviderNativeAction,
+    ProviderSession, ProviderSyncMode, SessionEvent, SessionStatus,
 };
 use thiserror::Error;
 
@@ -155,6 +160,15 @@ impl ProviderWorkspaceCatalog {
         })
     }
 
+    pub fn project_session_wire(
+        &self,
+        session: ProviderSession,
+        events: &[SessionEvent],
+    ) -> Result<ProviderWorkspaceProjectionWire, ProviderWorkspaceError> {
+        self.project_session(session, events)
+            .map(projection_to_wire)
+    }
+
     /// Current Friday truth-labeled provider workspace catalog. It is not a
     /// provider parity claim: unproven actions are disabled with exact blockers.
     pub fn friday_current() -> Self {
@@ -170,6 +184,78 @@ impl ProviderWorkspaceCatalog {
                 .expect("valid claude row");
         }
         catalog
+    }
+}
+
+pub fn projection_to_wire(
+    projection: ProviderWorkspaceProjection,
+) -> ProviderWorkspaceProjectionWire {
+    ProviderWorkspaceProjectionWire {
+        session: ProviderWorkspaceSessionWire {
+            friday_session_id: projection.session.friday_session_id,
+            provider: projection.session.provider.as_str().to_string(),
+            workspace_id: projection.session.workspace_id,
+            sync_mode: projection.session.sync_mode.as_str().to_string(),
+            status: session_status_str(projection.session.status).to_string(),
+            active_turn_id: projection.session.active_turn_id,
+            last_event_seq: projection.session.last_event_seq,
+            truth_label: projection.session.truth_label,
+            fallback_status: fallback_status_str(projection.session.fallback_status).to_string(),
+        },
+        actions: projection.actions.into_iter().map(action_to_wire).collect(),
+        needs_me: projection
+            .needs_me
+            .into_iter()
+            .map(needs_me_to_wire)
+            .collect(),
+    }
+}
+
+fn action_to_wire(action: ProviderWorkspaceActionProjection) -> ProviderWorkspaceActionWire {
+    ProviderWorkspaceActionWire {
+        provider: action.provider.as_str().to_string(),
+        action: action.action.as_str().to_string(),
+        capability_id: action.capability_id,
+        sync_mode: action.sync_mode.as_str().to_string(),
+        status: capability_status_str(action.status).to_string(),
+        truth_label: action.truth_label,
+        routed: action.routed,
+        blocker: action.blocker,
+        proof_ref: action.proof_ref,
+        native_action: action.native_action.map(native_action_to_wire),
+    }
+}
+
+fn native_action_to_wire(action: ProviderNativeAction) -> ProviderWorkspaceNativeActionWire {
+    match action {
+        ProviderNativeAction::CodexAppServer { method, schema_ref } => {
+            ProviderWorkspaceNativeActionWire::CodexAppServer {
+                method: codex_method_str(method).to_string(),
+                schema_ref,
+            }
+        }
+        ProviderNativeAction::ClaudeRemoteControl {
+            action,
+            proof_required,
+        } => ProviderWorkspaceNativeActionWire::ClaudeRemoteControl {
+            action: claude_remote_action_str(action).to_string(),
+            proof_required,
+        },
+        ProviderNativeAction::ClaudeStreamJson { event_type } => {
+            ProviderWorkspaceNativeActionWire::ClaudeStreamJson { event_type }
+        }
+    }
+}
+
+fn needs_me_to_wire(item: NeedsMeItem) -> ProviderWorkspaceNeedsMeWire {
+    ProviderWorkspaceNeedsMeWire {
+        item_id: item.item_id,
+        provider: item.provider.as_str().to_string(),
+        friday_session_id: item.friday_session_id,
+        kind: needs_me_kind_str(item.kind).to_string(),
+        priority: needs_me_priority_str(item.priority).to_string(),
+        ref_id: item.ref_id,
+        status: session_status_str(item.status).to_string(),
     }
 }
 
@@ -189,6 +275,79 @@ pub const PROVIDER_WORKSPACE_ACTIONS: &[ProviderWorkspaceAction] = &[
 
 fn capability_id(provider: PlatformProvider, action: ProviderWorkspaceAction) -> String {
     format!("provider.{}.{}", provider.as_str(), action.as_str())
+}
+
+fn session_status_str(status: SessionStatus) -> &'static str {
+    match status {
+        SessionStatus::Idle => "idle",
+        SessionStatus::Running => "running",
+        SessionStatus::AwaitingApproval => "awaiting_approval",
+        SessionStatus::AwaitingUserInput => "awaiting_user_input",
+        SessionStatus::Interrupted => "interrupted",
+        SessionStatus::Completed => "completed",
+        SessionStatus::Errored => "errored",
+        SessionStatus::Disconnected => "disconnected",
+        SessionStatus::Unknown => "unknown",
+    }
+}
+
+fn fallback_status_str(status: FallbackStatus) -> &'static str {
+    match status {
+        FallbackStatus::NoFallback => "no_fallback",
+        FallbackStatus::UnavailableNoFallback => "unavailable_no_fallback",
+        FallbackStatus::FallbackDisabled => "fallback_disabled",
+    }
+}
+
+fn capability_status_str(status: CapabilityStatus) -> &'static str {
+    match status {
+        CapabilityStatus::Verified => "verified",
+        CapabilityStatus::ImplementedUnproven => "implemented_unproven",
+        CapabilityStatus::OperatorGated => "operator_gated",
+        CapabilityStatus::ExternalBlocked => "external_blocked",
+        CapabilityStatus::Blocked => "blocked",
+        CapabilityStatus::Unsupported => "unsupported",
+    }
+}
+
+fn codex_method_str(method: CodexAppServerMethod) -> &'static str {
+    match method {
+        CodexAppServerMethod::ThreadList => "thread_list",
+        CodexAppServerMethod::ThreadRead => "thread_read",
+        CodexAppServerMethod::ThreadStart => "thread_start",
+        CodexAppServerMethod::ThreadResume => "thread_resume",
+        CodexAppServerMethod::ThreadFork => "thread_fork",
+        CodexAppServerMethod::TurnStart => "turn_start",
+        CodexAppServerMethod::TurnSteer => "turn_steer",
+        CodexAppServerMethod::TurnInterrupt => "turn_interrupt",
+        CodexAppServerMethod::ApprovalResponse => "approval_response",
+        CodexAppServerMethod::UserInputResponse => "user_input_response",
+    }
+}
+
+fn claude_remote_action_str(action: ClaudeRemoteControlAction) -> &'static str {
+    match action {
+        ClaudeRemoteControlAction::Launch => "launch",
+        ClaudeRemoteControlAction::OpenSessionUrl => "open_session_url",
+        ClaudeRemoteControlAction::ShowQr => "show_qr",
+        ClaudeRemoteControlAction::Disconnect => "disconnect",
+    }
+}
+
+fn needs_me_kind_str(kind: NeedsMeKind) -> &'static str {
+    match kind {
+        NeedsMeKind::Approval => "approval",
+        NeedsMeKind::UserQuestion => "user_question",
+    }
+}
+
+fn needs_me_priority_str(priority: NeedsMePriority) -> &'static str {
+    match priority {
+        NeedsMePriority::Low => "low",
+        NeedsMePriority::Normal => "normal",
+        NeedsMePriority::High => "high",
+        NeedsMePriority::Critical => "critical",
+    }
 }
 
 fn project_action(
@@ -594,6 +753,7 @@ fn claude_current_capabilities() -> Vec<(ProviderWorkspaceAction, ProviderCapabi
 #[cfg(test)]
 mod tests {
     use super::*;
+    use friday_protocol::{Envelope, Message};
     use friday_providers::unified::{
         ApprovalKind, ApprovalRequest, BodyRef, RedactionLevel, RiskLabel, SessionEvent,
         SessionEventKind, SessionStatus,
@@ -614,6 +774,37 @@ mod tests {
             last_event_seq: 0,
             truth_label: "provider workspace test".to_string(),
             fallback_status: friday_providers::unified::FallbackStatus::NoFallback,
+        }
+    }
+
+    fn approval_event(provider: PlatformProvider) -> SessionEvent {
+        SessionEvent {
+            event_id: "event-1".to_string(),
+            provider,
+            friday_session_id: format!("friday-{}", provider.as_str()),
+            provider_event_id: Some("provider-event-1".to_string()),
+            seq: 1,
+            kind: SessionEventKind::ApprovalRequested,
+            status: SessionStatus::AwaitingApproval,
+            transcript_item: None,
+            tool_call: None,
+            approval_request: Some(ApprovalRequest {
+                approval_ref: "approval-1".to_string(),
+                kind: ApprovalKind::CommandExecution,
+                tool_call_id: Some("tool-1".to_string()),
+                summary_ref: BodyRef {
+                    uri: "friday://body/approval/1".to_string(),
+                    redaction_level: RedactionLevel::MetadataOnly,
+                },
+                risk_label: RiskLabel::HighRisk,
+            }),
+            user_question: None,
+            file_change: None,
+            command_output: None,
+            diff_summary: None,
+            attachment: None,
+            token_ledger_ref: None,
+            audit_receipt_ref: Some("audit-1".to_string()),
         }
     }
 
@@ -777,36 +968,11 @@ mod tests {
     #[test]
     fn project_session_collects_needs_me_without_raw_provider_body() {
         let catalog = ProviderWorkspaceCatalog::friday_current();
-        let event = SessionEvent {
-            event_id: "event-1".to_string(),
-            provider: PlatformProvider::Codex,
-            friday_session_id: "friday-codex".to_string(),
-            provider_event_id: Some("provider-event-1".to_string()),
-            seq: 1,
-            kind: SessionEventKind::ApprovalRequested,
-            status: SessionStatus::AwaitingApproval,
-            transcript_item: None,
-            tool_call: None,
-            approval_request: Some(ApprovalRequest {
-                approval_ref: "approval-1".to_string(),
-                kind: ApprovalKind::CommandExecution,
-                tool_call_id: Some("tool-1".to_string()),
-                summary_ref: BodyRef {
-                    uri: "friday://body/approval/1".to_string(),
-                    redaction_level: RedactionLevel::MetadataOnly,
-                },
-                risk_label: RiskLabel::HighRisk,
-            }),
-            user_question: None,
-            file_change: None,
-            command_output: None,
-            diff_summary: None,
-            attachment: None,
-            token_ledger_ref: None,
-            audit_receipt_ref: Some("audit-1".to_string()),
-        };
         let projection = catalog
-            .project_session(session(PlatformProvider::Codex), &[event])
+            .project_session(
+                session(PlatformProvider::Codex),
+                &[approval_event(PlatformProvider::Codex)],
+            )
             .unwrap();
         assert_eq!(projection.needs_me.len(), 1);
         assert_eq!(projection.needs_me[0].ref_id, "approval-1");
@@ -814,5 +980,62 @@ mod tests {
         assert!(!debug.contains("rm -rf"));
         assert!(!debug.contains("sk-"));
         assert!(!debug.contains("provider-token"));
+    }
+
+    #[test]
+    fn project_session_wire_round_trips_as_protocol_snapshot() {
+        let catalog = ProviderWorkspaceCatalog::friday_current();
+        let projection = catalog
+            .project_session_wire(
+                session(PlatformProvider::Codex),
+                &[approval_event(PlatformProvider::Codex)],
+            )
+            .unwrap();
+        assert_eq!(projection.session.provider, "codex");
+        assert_eq!(
+            projection.session.sync_mode,
+            ProviderSyncMode::ProviderAppServerLocal.as_str()
+        );
+        assert_eq!(projection.actions.len(), PROVIDER_WORKSPACE_ACTIONS.len());
+        assert_eq!(projection.needs_me.len(), 1);
+        let send = projection
+            .actions
+            .iter()
+            .find(|action| action.action == "send_turn")
+            .expect("send_turn action present");
+        assert!(!send.routed);
+        assert_eq!(send.status, "implemented_unproven");
+        assert!(send
+            .blocker
+            .as_deref()
+            .unwrap()
+            .contains("official-history"));
+
+        let env = Envelope::new(
+            "provider-workspace-1",
+            100,
+            Message::ProviderWorkspaceSnapshot { projection },
+        );
+        let json = env.encode().unwrap();
+        assert!(json.contains("\"kind\":\"ProviderWorkspaceSnapshot\""));
+        assert!(json.contains("\"schema_version\":2"));
+        assert!(json.contains("\"capability_id\":\"provider.codex.send_turn\""));
+        assert!(json.contains("\"provider_action\":\"codex_app_server\""));
+        for forbidden in [
+            "sk-",
+            "provider-token",
+            "account-hash",
+            "/Users/jarvis/private",
+            "external-thread",
+            "https://provider.example/private",
+            "rm -rf",
+        ] {
+            assert!(
+                !json.contains(forbidden),
+                "provider workspace wire leaked {forbidden}: {json}"
+            );
+        }
+        let decoded = Envelope::decode(&json).unwrap();
+        assert_eq!(decoded, env);
     }
 }

--- a/rust-core/crates/friday-hub/src/provider_workspace.rs
+++ b/rust-core/crates/friday-hub/src/provider_workspace.rs
@@ -1,0 +1,818 @@
+//! Provider Workspace runtime projection.
+//!
+//! This is the Hub-side bridge between the provider-session contract and UI
+//! surfaces. It is deliberately pure: no provider process is started, no model
+//! call is made, and no provider credential is read. The goal is to make every
+//! Provider Workspace action capability-driven before UI wiring exists.
+
+use std::collections::BTreeMap;
+
+use friday_providers::unified::{
+    CapabilityStatus, NeedsMeItem, NeedsMePriority, PlatformProvider, ProviderCapability,
+    ProviderNativeAction, ProviderSession, ProviderSyncMode, SessionEvent,
+};
+use thiserror::Error;
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum ProviderWorkspaceError {
+    #[error("provider capability failed validation: {capability_id}")]
+    InvalidCapability { capability_id: String },
+
+    #[error("non-routable provider capability missing blocker: {capability_id}")]
+    NonRoutableCapabilityMissingBlocker { capability_id: String },
+
+    #[error("provider capability/action mismatch: {capability_id} expected {expected_id}")]
+    CapabilityActionMismatch {
+        capability_id: String,
+        expected_id: String,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ProviderWorkspaceAction {
+    ListSessions,
+    ReadSession,
+    StartSession,
+    ResumeSession,
+    ForkSession,
+    SendTurn,
+    SteerTurn,
+    InterruptTurn,
+    ApproveOrReject,
+    AnswerQuestion,
+    OpenProviderNative,
+}
+
+impl ProviderWorkspaceAction {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            ProviderWorkspaceAction::ListSessions => "list_sessions",
+            ProviderWorkspaceAction::ReadSession => "read_session",
+            ProviderWorkspaceAction::StartSession => "start_session",
+            ProviderWorkspaceAction::ResumeSession => "resume_session",
+            ProviderWorkspaceAction::ForkSession => "fork_session",
+            ProviderWorkspaceAction::SendTurn => "send_turn",
+            ProviderWorkspaceAction::SteerTurn => "steer_turn",
+            ProviderWorkspaceAction::InterruptTurn => "interrupt_turn",
+            ProviderWorkspaceAction::ApproveOrReject => "approve_or_reject",
+            ProviderWorkspaceAction::AnswerQuestion => "answer_question",
+            ProviderWorkspaceAction::OpenProviderNative => "open_provider_native",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderWorkspaceActionProjection {
+    pub provider: PlatformProvider,
+    pub action: ProviderWorkspaceAction,
+    pub capability_id: String,
+    pub sync_mode: ProviderSyncMode,
+    pub status: CapabilityStatus,
+    pub truth_label: String,
+    pub routed: bool,
+    pub blocker: Option<String>,
+    pub proof_ref: Option<String>,
+    pub native_action: Option<ProviderNativeAction>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderWorkspaceProjection {
+    pub session: ProviderSession,
+    pub actions: Vec<ProviderWorkspaceActionProjection>,
+    pub needs_me: Vec<NeedsMeItem>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ProviderWorkspaceCatalog {
+    capabilities: BTreeMap<(PlatformProvider, ProviderWorkspaceAction), ProviderCapability>,
+}
+
+impl ProviderWorkspaceCatalog {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn register(
+        &mut self,
+        action: ProviderWorkspaceAction,
+        capability: ProviderCapability,
+    ) -> Result<(), ProviderWorkspaceError> {
+        capability
+            .validate()
+            .map_err(|_| ProviderWorkspaceError::InvalidCapability {
+                capability_id: capability.capability_id.clone(),
+            })?;
+        if capability.status != CapabilityStatus::Verified && capability.blocker.is_none() {
+            return Err(
+                ProviderWorkspaceError::NonRoutableCapabilityMissingBlocker {
+                    capability_id: capability.capability_id,
+                },
+            );
+        }
+        let expected_id = capability_id(capability.provider, action);
+        if capability.capability_id != expected_id {
+            return Err(ProviderWorkspaceError::CapabilityActionMismatch {
+                capability_id: capability.capability_id,
+                expected_id,
+            });
+        }
+        self.capabilities
+            .insert((capability.provider, action), capability);
+        Ok(())
+    }
+
+    pub fn resolve(
+        &self,
+        provider: PlatformProvider,
+        action: ProviderWorkspaceAction,
+    ) -> Option<Result<ProviderWorkspaceActionProjection, ProviderWorkspaceError>> {
+        self.capabilities
+            .get(&(provider, action))
+            .map(|capability| project_action(action, capability))
+    }
+
+    pub fn project_session(
+        &self,
+        session: ProviderSession,
+        events: &[SessionEvent],
+    ) -> Result<ProviderWorkspaceProjection, ProviderWorkspaceError> {
+        let mut actions = Vec::new();
+        for action in PROVIDER_WORKSPACE_ACTIONS {
+            let Some(projected) = self.resolve(session.provider, *action) else {
+                continue;
+            };
+            actions.push(projected?);
+        }
+        let needs_me = events
+            .iter()
+            .filter(|event| event.provider == session.provider)
+            .filter_map(|event| event.needs_me(NeedsMePriority::High))
+            .collect();
+        Ok(ProviderWorkspaceProjection {
+            session,
+            actions,
+            needs_me,
+        })
+    }
+
+    /// Current Friday truth-labeled provider workspace catalog. It is not a
+    /// provider parity claim: unproven actions are disabled with exact blockers.
+    pub fn friday_current() -> Self {
+        let mut catalog = Self::new();
+        for (action, capability) in codex_current_capabilities() {
+            catalog
+                .register(action, capability)
+                .expect("valid codex row");
+        }
+        for (action, capability) in claude_current_capabilities() {
+            catalog
+                .register(action, capability)
+                .expect("valid claude row");
+        }
+        catalog
+    }
+}
+
+pub const PROVIDER_WORKSPACE_ACTIONS: &[ProviderWorkspaceAction] = &[
+    ProviderWorkspaceAction::ListSessions,
+    ProviderWorkspaceAction::ReadSession,
+    ProviderWorkspaceAction::StartSession,
+    ProviderWorkspaceAction::ResumeSession,
+    ProviderWorkspaceAction::ForkSession,
+    ProviderWorkspaceAction::SendTurn,
+    ProviderWorkspaceAction::SteerTurn,
+    ProviderWorkspaceAction::InterruptTurn,
+    ProviderWorkspaceAction::ApproveOrReject,
+    ProviderWorkspaceAction::AnswerQuestion,
+    ProviderWorkspaceAction::OpenProviderNative,
+];
+
+fn capability_id(provider: PlatformProvider, action: ProviderWorkspaceAction) -> String {
+    format!("provider.{}.{}", provider.as_str(), action.as_str())
+}
+
+fn project_action(
+    action: ProviderWorkspaceAction,
+    capability: &ProviderCapability,
+) -> Result<ProviderWorkspaceActionProjection, ProviderWorkspaceError> {
+    capability
+        .validate()
+        .map_err(|_| ProviderWorkspaceError::InvalidCapability {
+            capability_id: capability.capability_id.clone(),
+        })?;
+    let routed = capability.status == CapabilityStatus::Verified;
+    if !routed && capability.blocker.is_none() {
+        return Err(
+            ProviderWorkspaceError::NonRoutableCapabilityMissingBlocker {
+                capability_id: capability.capability_id.clone(),
+            },
+        );
+    }
+    Ok(ProviderWorkspaceActionProjection {
+        provider: capability.provider,
+        action,
+        capability_id: capability.capability_id.clone(),
+        sync_mode: capability.sync_mode,
+        status: capability.status,
+        truth_label: capability.truth_label.clone(),
+        routed,
+        blocker: capability.blocker.clone(),
+        proof_ref: capability.proof_ref.clone(),
+        native_action: capability.native_action.clone(),
+    })
+}
+
+#[derive(Debug, Clone)]
+struct CapabilitySeed {
+    provider: PlatformProvider,
+    action: ProviderWorkspaceAction,
+    status: CapabilityStatus,
+    sync_mode: ProviderSyncMode,
+    truth_label: &'static str,
+    blocker: Option<&'static str>,
+    proof_ref: Option<&'static str>,
+    native_action: Option<ProviderNativeAction>,
+}
+
+impl CapabilitySeed {
+    fn new(
+        provider: PlatformProvider,
+        action: ProviderWorkspaceAction,
+        status: CapabilityStatus,
+        sync_mode: ProviderSyncMode,
+        truth_label: &'static str,
+    ) -> Self {
+        Self {
+            provider,
+            action,
+            status,
+            sync_mode,
+            truth_label,
+            blocker: None,
+            proof_ref: None,
+            native_action: None,
+        }
+    }
+
+    fn maybe_blocker(mut self, blocker: Option<&'static str>) -> Self {
+        self.blocker = blocker;
+        self
+    }
+
+    fn maybe_proof_ref(mut self, proof_ref: Option<&'static str>) -> Self {
+        self.proof_ref = proof_ref;
+        self
+    }
+
+    fn maybe_native_action(mut self, native_action: Option<ProviderNativeAction>) -> Self {
+        self.native_action = native_action;
+        self
+    }
+
+    fn into_pair(self) -> (ProviderWorkspaceAction, ProviderCapability) {
+        (
+            self.action,
+            ProviderCapability {
+                capability_id: capability_id(self.provider, self.action),
+                provider: self.provider,
+                status: self.status,
+                sync_mode: self.sync_mode,
+                truth_label: self.truth_label.to_string(),
+                blocker: self.blocker.map(ToString::to_string),
+                proof_ref: self.proof_ref.map(ToString::to_string),
+                native_action: self.native_action,
+            },
+        )
+    }
+}
+
+macro_rules! cap {
+    (
+        $provider:expr,
+        $action:expr,
+        $status:expr,
+        $sync_mode:expr,
+        $truth_label:expr,
+        $blocker:expr,
+        $proof_ref:expr,
+        $native_action:expr $(,)?
+    ) => {
+        CapabilitySeed::new($provider, $action, $status, $sync_mode, $truth_label)
+            .maybe_blocker($blocker)
+            .maybe_proof_ref($proof_ref)
+            .maybe_native_action($native_action)
+            .into_pair()
+    };
+}
+
+fn codex_current_capabilities() -> Vec<(ProviderWorkspaceAction, ProviderCapability)> {
+    use friday_providers::unified::CodexAppServerMethod as M;
+    let blocker = "Codex app-server schema/metadata/mapping exists, but live turn lifecycle, approvals, and official-history behavior are not fully proven";
+    vec![
+        cap!(
+            PlatformProvider::Codex,
+            ProviderWorkspaceAction::ListSessions,
+            CapabilityStatus::ImplementedUnproven,
+            ProviderSyncMode::ProviderAppServerLocal,
+            "codex_app_server_local_thread_list_unproven_for_ui",
+            Some(blocker),
+            None,
+            Some(ProviderNativeAction::CodexAppServer {
+                method: M::ThreadList,
+                schema_ref: "codex-app-server-generated-schema".to_string(),
+            }),
+        ),
+        cap!(
+            PlatformProvider::Codex,
+            ProviderWorkspaceAction::ReadSession,
+            CapabilityStatus::ImplementedUnproven,
+            ProviderSyncMode::ProviderAppServerLocal,
+            "codex_app_server_local_thread_read_unproven_for_ui",
+            Some(blocker),
+            None,
+            Some(ProviderNativeAction::CodexAppServer {
+                method: M::ThreadRead,
+                schema_ref: "codex-app-server-generated-schema".to_string(),
+            }),
+        ),
+        cap!(
+            PlatformProvider::Codex,
+            ProviderWorkspaceAction::StartSession,
+            CapabilityStatus::ImplementedUnproven,
+            ProviderSyncMode::ProviderAppServerLocal,
+            "codex_app_server_local_thread_start_unproven_for_ui",
+            Some(blocker),
+            None,
+            Some(ProviderNativeAction::CodexAppServer {
+                method: M::ThreadStart,
+                schema_ref: "codex-app-server-generated-schema".to_string(),
+            }),
+        ),
+        cap!(
+            PlatformProvider::Codex,
+            ProviderWorkspaceAction::ResumeSession,
+            CapabilityStatus::ImplementedUnproven,
+            ProviderSyncMode::ProviderAppServerLocal,
+            "codex_app_server_local_thread_resume_unproven_for_ui",
+            Some(blocker),
+            None,
+            Some(ProviderNativeAction::CodexAppServer {
+                method: M::ThreadResume,
+                schema_ref: "codex-app-server-generated-schema".to_string(),
+            }),
+        ),
+        cap!(
+            PlatformProvider::Codex,
+            ProviderWorkspaceAction::ForkSession,
+            CapabilityStatus::ImplementedUnproven,
+            ProviderSyncMode::ProviderAppServerLocal,
+            "codex_app_server_local_thread_fork_unproven_for_ui",
+            Some(blocker),
+            None,
+            Some(ProviderNativeAction::CodexAppServer {
+                method: M::ThreadFork,
+                schema_ref: "codex-app-server-generated-schema".to_string(),
+            }),
+        ),
+        cap!(
+            PlatformProvider::Codex,
+            ProviderWorkspaceAction::SendTurn,
+            CapabilityStatus::ImplementedUnproven,
+            ProviderSyncMode::ProviderAppServerLocal,
+            "codex_app_server_local_turn_start_unproven_for_ui",
+            Some(blocker),
+            None,
+            Some(ProviderNativeAction::CodexAppServer {
+                method: M::TurnStart,
+                schema_ref: "codex-app-server-generated-schema".to_string(),
+            }),
+        ),
+        cap!(
+            PlatformProvider::Codex,
+            ProviderWorkspaceAction::SteerTurn,
+            CapabilityStatus::ImplementedUnproven,
+            ProviderSyncMode::ProviderAppServerLocal,
+            "codex_app_server_local_turn_steer_unproven_for_ui",
+            Some(blocker),
+            None,
+            Some(ProviderNativeAction::CodexAppServer {
+                method: M::TurnSteer,
+                schema_ref: "codex-app-server-generated-schema".to_string(),
+            }),
+        ),
+        cap!(
+            PlatformProvider::Codex,
+            ProviderWorkspaceAction::InterruptTurn,
+            CapabilityStatus::ImplementedUnproven,
+            ProviderSyncMode::ProviderAppServerLocal,
+            "codex_app_server_local_turn_interrupt_unproven_for_ui",
+            Some(blocker),
+            None,
+            Some(ProviderNativeAction::CodexAppServer {
+                method: M::TurnInterrupt,
+                schema_ref: "codex-app-server-generated-schema".to_string(),
+            }),
+        ),
+        cap!(
+            PlatformProvider::Codex,
+            ProviderWorkspaceAction::ApproveOrReject,
+            CapabilityStatus::ImplementedUnproven,
+            ProviderSyncMode::ProviderAppServerLocal,
+            "codex_app_server_local_approval_response_unproven_for_ui",
+            Some(blocker),
+            None,
+            Some(ProviderNativeAction::CodexAppServer {
+                method: M::ApprovalResponse,
+                schema_ref: "codex-app-server-generated-schema".to_string(),
+            }),
+        ),
+        cap!(
+            PlatformProvider::Codex,
+            ProviderWorkspaceAction::AnswerQuestion,
+            CapabilityStatus::ImplementedUnproven,
+            ProviderSyncMode::ProviderAppServerLocal,
+            "codex_app_server_local_user_input_response_unproven_for_ui",
+            Some(blocker),
+            None,
+            Some(ProviderNativeAction::CodexAppServer {
+                method: M::UserInputResponse,
+                schema_ref: "codex-app-server-generated-schema".to_string(),
+            }),
+        ),
+        cap!(
+            PlatformProvider::Codex,
+            ProviderWorkspaceAction::OpenProviderNative,
+            CapabilityStatus::Unsupported,
+            ProviderSyncMode::UnsupportedTruthLabeled,
+            "codex_official_same_account_native_open_unproven",
+            Some("no live proof that Friday app-server turns appear in official Codex/ChatGPT same-account history"),
+            None,
+            None,
+        ),
+    ]
+}
+
+fn claude_current_capabilities() -> Vec<(ProviderWorkspaceAction, ProviderCapability)> {
+    use friday_providers::unified::ClaudeRemoteControlAction as R;
+    let local_blocker = "Claude local mirror contract exists, but SDK/CLI session lifecycle and stream proof are not implemented";
+    vec![
+        cap!(
+            PlatformProvider::Claude,
+            ProviderWorkspaceAction::ListSessions,
+            CapabilityStatus::Blocked,
+            ProviderSyncMode::FridayLocalMirror,
+            "claude_local_mirror_list_sessions_not_built",
+            Some(local_blocker),
+            None,
+            Some(ProviderNativeAction::ClaudeStreamJson {
+                event_type: "session_list".to_string(),
+            }),
+        ),
+        cap!(
+            PlatformProvider::Claude,
+            ProviderWorkspaceAction::ReadSession,
+            CapabilityStatus::Blocked,
+            ProviderSyncMode::FridayLocalMirror,
+            "claude_local_mirror_read_session_not_built",
+            Some(local_blocker),
+            None,
+            Some(ProviderNativeAction::ClaudeStreamJson {
+                event_type: "session_read".to_string(),
+            }),
+        ),
+        cap!(
+            PlatformProvider::Claude,
+            ProviderWorkspaceAction::StartSession,
+            CapabilityStatus::Blocked,
+            ProviderSyncMode::FridayLocalMirror,
+            "claude_local_mirror_start_session_not_built",
+            Some(local_blocker),
+            None,
+            Some(ProviderNativeAction::ClaudeStreamJson {
+                event_type: "query_start".to_string(),
+            }),
+        ),
+        cap!(
+            PlatformProvider::Claude,
+            ProviderWorkspaceAction::ResumeSession,
+            CapabilityStatus::Blocked,
+            ProviderSyncMode::FridayLocalMirror,
+            "claude_local_mirror_resume_session_not_built",
+            Some(local_blocker),
+            None,
+            Some(ProviderNativeAction::ClaudeStreamJson {
+                event_type: "session_resume".to_string(),
+            }),
+        ),
+        cap!(
+            PlatformProvider::Claude,
+            ProviderWorkspaceAction::ForkSession,
+            CapabilityStatus::Blocked,
+            ProviderSyncMode::FridayLocalMirror,
+            "claude_local_mirror_fork_session_not_built",
+            Some(local_blocker),
+            None,
+            Some(ProviderNativeAction::ClaudeStreamJson {
+                event_type: "session_fork".to_string(),
+            }),
+        ),
+        cap!(
+            PlatformProvider::Claude,
+            ProviderWorkspaceAction::SendTurn,
+            CapabilityStatus::Blocked,
+            ProviderSyncMode::FridayLocalMirror,
+            "claude_local_mirror_send_turn_not_built",
+            Some(local_blocker),
+            None,
+            Some(ProviderNativeAction::ClaudeStreamJson {
+                event_type: "stream_json_input".to_string(),
+            }),
+        ),
+        cap!(
+            PlatformProvider::Claude,
+            ProviderWorkspaceAction::SteerTurn,
+            CapabilityStatus::Unsupported,
+            ProviderSyncMode::UnsupportedTruthLabeled,
+            "claude_local_mirror_steer_turn_unsupported_until_official_surface",
+            Some("no Claude local mirror steer-turn runtime owner is implemented or proven"),
+            None,
+            None,
+        ),
+        cap!(
+            PlatformProvider::Claude,
+            ProviderWorkspaceAction::InterruptTurn,
+            CapabilityStatus::Blocked,
+            ProviderSyncMode::ProviderNativeLinkOnly,
+            "claude_remote_control_interrupt_link_only_until_live_proof",
+            Some("Claude Remote Control live same-account proof is operator-gated; Friday cannot claim gate/control until observed"),
+            None,
+            Some(ProviderNativeAction::ClaudeRemoteControl {
+                action: R::Disconnect,
+                proof_required: true,
+            }),
+        ),
+        cap!(
+            PlatformProvider::Claude,
+            ProviderWorkspaceAction::ApproveOrReject,
+            CapabilityStatus::Blocked,
+            ProviderSyncMode::FridayLocalMirror,
+            "claude_local_mirror_approval_response_not_built",
+            Some(local_blocker),
+            None,
+            Some(ProviderNativeAction::ClaudeStreamJson {
+                event_type: "permission_response".to_string(),
+            }),
+        ),
+        cap!(
+            PlatformProvider::Claude,
+            ProviderWorkspaceAction::AnswerQuestion,
+            CapabilityStatus::Blocked,
+            ProviderSyncMode::FridayLocalMirror,
+            "claude_local_mirror_user_question_response_not_built",
+            Some(local_blocker),
+            None,
+            Some(ProviderNativeAction::ClaudeStreamJson {
+                event_type: "user_input_response".to_string(),
+            }),
+        ),
+        cap!(
+            PlatformProvider::Claude,
+            ProviderWorkspaceAction::OpenProviderNative,
+            CapabilityStatus::OperatorGated,
+            ProviderSyncMode::ProviderNativeLinkOnly,
+            "claude_remote_control_link_only_until_live_same_account_proof",
+            Some("operator must log in and prove Claude Remote Control URL/QR controls the same local session from Claude mobile/browser"),
+            None,
+            Some(ProviderNativeAction::ClaudeRemoteControl {
+                action: R::OpenSessionUrl,
+                proof_required: true,
+            }),
+        ),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use friday_providers::unified::{
+        ApprovalKind, ApprovalRequest, BodyRef, RedactionLevel, RiskLabel, SessionEvent,
+        SessionEventKind, SessionStatus,
+    };
+
+    fn session(provider: PlatformProvider) -> ProviderSession {
+        ProviderSession {
+            friday_session_id: format!("friday-{}", provider.as_str()),
+            provider,
+            workspace_id: "workspace-1".to_string(),
+            sync_mode: match provider {
+                PlatformProvider::Codex => ProviderSyncMode::ProviderAppServerLocal,
+                PlatformProvider::Claude => ProviderSyncMode::FridayLocalMirror,
+            },
+            status: SessionStatus::Idle,
+            capability_snapshot: Vec::new(),
+            active_turn_id: None,
+            last_event_seq: 0,
+            truth_label: "provider workspace test".to_string(),
+            fallback_status: friday_providers::unified::FallbackStatus::NoFallback,
+        }
+    }
+
+    #[test]
+    fn current_catalog_has_no_orphan_provider_workspace_actions() {
+        let catalog = ProviderWorkspaceCatalog::friday_current();
+        for provider in [PlatformProvider::Codex, PlatformProvider::Claude] {
+            for action in PROVIDER_WORKSPACE_ACTIONS {
+                let projected = catalog
+                    .resolve(provider, *action)
+                    .unwrap_or_else(|| panic!("{provider:?} {action:?} is orphaned"))
+                    .expect("projection is valid");
+                assert_eq!(projected.provider, provider);
+                assert_eq!(projected.action, *action);
+                assert!(!projected.capability_id.is_empty());
+                if !projected.routed {
+                    assert!(
+                        projected.blocker.as_deref().is_some_and(|b| !b.is_empty()),
+                        "disabled action must carry exact blocker: {provider:?} {action:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn current_codex_actions_are_local_app_server_not_official_history() {
+        let catalog = ProviderWorkspaceCatalog::friday_current();
+        let send = catalog
+            .resolve(PlatformProvider::Codex, ProviderWorkspaceAction::SendTurn)
+            .unwrap()
+            .unwrap();
+        assert!(!send.routed);
+        assert_eq!(send.status, CapabilityStatus::ImplementedUnproven);
+        assert_eq!(send.sync_mode, ProviderSyncMode::ProviderAppServerLocal);
+        assert!(send
+            .blocker
+            .as_deref()
+            .unwrap()
+            .contains("official-history"));
+
+        let native = catalog
+            .resolve(
+                PlatformProvider::Codex,
+                ProviderWorkspaceAction::OpenProviderNative,
+            )
+            .unwrap()
+            .unwrap();
+        assert_eq!(native.sync_mode, ProviderSyncMode::UnsupportedTruthLabeled);
+        assert!(!native.routed);
+    }
+
+    #[test]
+    fn claude_remote_control_is_link_only_until_live_same_account_proof() {
+        let catalog = ProviderWorkspaceCatalog::friday_current();
+        let open = catalog
+            .resolve(
+                PlatformProvider::Claude,
+                ProviderWorkspaceAction::OpenProviderNative,
+            )
+            .unwrap()
+            .unwrap();
+        assert_eq!(open.status, CapabilityStatus::OperatorGated);
+        assert_eq!(open.sync_mode, ProviderSyncMode::ProviderNativeLinkOnly);
+        assert!(!open.routed);
+        assert!(open
+            .truth_label
+            .contains("link_only_until_live_same_account_proof"));
+        assert!(matches!(
+            open.native_action,
+            Some(ProviderNativeAction::ClaudeRemoteControl { .. })
+        ));
+    }
+
+    #[test]
+    fn verified_capability_routes_only_with_proof() {
+        let mut catalog = ProviderWorkspaceCatalog::new();
+        catalog
+            .register(
+                ProviderWorkspaceAction::ListSessions,
+                ProviderCapability {
+                    capability_id: "provider.codex.list_sessions".to_string(),
+                    provider: PlatformProvider::Codex,
+                    status: CapabilityStatus::Verified,
+                    sync_mode: ProviderSyncMode::ProviderAppServerLocal,
+                    truth_label: "verified app-server list".to_string(),
+                    blocker: None,
+                    proof_ref: Some("proof-1".to_string()),
+                    native_action: Some(ProviderNativeAction::CodexAppServer {
+                        method: friday_providers::unified::CodexAppServerMethod::ThreadList,
+                        schema_ref: "schema".to_string(),
+                    }),
+                },
+            )
+            .unwrap();
+        let projected = catalog
+            .resolve(
+                PlatformProvider::Codex,
+                ProviderWorkspaceAction::ListSessions,
+            )
+            .unwrap()
+            .unwrap();
+        assert!(projected.routed);
+        assert_eq!(projected.proof_ref.as_deref(), Some("proof-1"));
+        assert!(projected.blocker.is_none());
+    }
+
+    #[test]
+    fn non_verified_capability_without_blocker_is_rejected() {
+        let mut catalog = ProviderWorkspaceCatalog::new();
+        let err = catalog
+            .register(
+                ProviderWorkspaceAction::SendTurn,
+                ProviderCapability {
+                    capability_id: "provider.codex.send_turn".to_string(),
+                    provider: PlatformProvider::Codex,
+                    status: CapabilityStatus::ImplementedUnproven,
+                    sync_mode: ProviderSyncMode::ProviderAppServerLocal,
+                    truth_label: "bad missing blocker".to_string(),
+                    blocker: None,
+                    proof_ref: None,
+                    native_action: None,
+                },
+            )
+            .unwrap_err();
+        assert_eq!(
+            err,
+            ProviderWorkspaceError::NonRoutableCapabilityMissingBlocker {
+                capability_id: "provider.codex.send_turn".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn capability_id_must_match_registered_action() {
+        let mut catalog = ProviderWorkspaceCatalog::new();
+        let err = catalog
+            .register(
+                ProviderWorkspaceAction::SendTurn,
+                ProviderCapability {
+                    capability_id: "provider.codex.list_sessions".to_string(),
+                    provider: PlatformProvider::Codex,
+                    status: CapabilityStatus::ImplementedUnproven,
+                    sync_mode: ProviderSyncMode::ProviderAppServerLocal,
+                    truth_label: "bad mismatched action".to_string(),
+                    blocker: Some("blocked but still mismatched".to_string()),
+                    proof_ref: None,
+                    native_action: None,
+                },
+            )
+            .unwrap_err();
+        assert_eq!(
+            err,
+            ProviderWorkspaceError::CapabilityActionMismatch {
+                capability_id: "provider.codex.list_sessions".to_string(),
+                expected_id: "provider.codex.send_turn".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn project_session_collects_needs_me_without_raw_provider_body() {
+        let catalog = ProviderWorkspaceCatalog::friday_current();
+        let event = SessionEvent {
+            event_id: "event-1".to_string(),
+            provider: PlatformProvider::Codex,
+            friday_session_id: "friday-codex".to_string(),
+            provider_event_id: Some("provider-event-1".to_string()),
+            seq: 1,
+            kind: SessionEventKind::ApprovalRequested,
+            status: SessionStatus::AwaitingApproval,
+            transcript_item: None,
+            tool_call: None,
+            approval_request: Some(ApprovalRequest {
+                approval_ref: "approval-1".to_string(),
+                kind: ApprovalKind::CommandExecution,
+                tool_call_id: Some("tool-1".to_string()),
+                summary_ref: BodyRef {
+                    uri: "friday://body/approval/1".to_string(),
+                    redaction_level: RedactionLevel::MetadataOnly,
+                },
+                risk_label: RiskLabel::HighRisk,
+            }),
+            user_question: None,
+            file_change: None,
+            command_output: None,
+            diff_summary: None,
+            attachment: None,
+            token_ledger_ref: None,
+            audit_receipt_ref: Some("audit-1".to_string()),
+        };
+        let projection = catalog
+            .project_session(session(PlatformProvider::Codex), &[event])
+            .unwrap();
+        assert_eq!(projection.needs_me.len(), 1);
+        assert_eq!(projection.needs_me[0].ref_id, "approval-1");
+        let debug = format!("{projection:?}");
+        assert!(!debug.contains("rm -rf"));
+        assert!(!debug.contains("sk-"));
+        assert!(!debug.contains("provider-token"));
+    }
+}

--- a/rust-core/crates/friday-protocol/src/lib.rs
+++ b/rust-core/crates/friday-protocol/src/lib.rs
@@ -224,6 +224,7 @@ pub enum ErrorCode {
 pub enum Message {
     /// phone->hub: complete QR pairing handshake (pubkey + proof; never the raw secret).
     Pair {
+        device_id: String,
         device_pubkey: Vec<u8>,
         pairing_proof: Vec<u8>,
     },
@@ -418,6 +419,7 @@ mod tests {
     fn envelope_round_trips_for_each_kind() {
         let cases = vec![
             Message::Pair {
+                device_id: "dev-1".into(),
                 device_pubkey: vec![1, 2, 3],
                 pairing_proof: vec![4, 5],
             },

--- a/rust-core/crates/friday-protocol/src/lib.rs
+++ b/rust-core/crates/friday-protocol/src/lib.rs
@@ -16,9 +16,9 @@ use std::fmt;
 use thiserror::Error;
 
 /// Highest wire schema version this build speaks.
-pub const CURRENT_SCHEMA_VERSION: u16 = 1;
+pub const CURRENT_SCHEMA_VERSION: u16 = 2;
 /// The inclusive range of versions this build supports.
-pub const SUPPORTED: VersionRange = VersionRange { min: 1, max: 1 };
+pub const SUPPORTED: VersionRange = VersionRange { min: 1, max: 2 };
 
 /// Redacted provider-session projection safe to carry to phone/channel clients.
 /// Hub-only fields such as account hashes, cwd, external URLs, provider tokens,
@@ -50,6 +50,84 @@ impl From<friday_core::ProviderSessionProjection> for ProviderSessionProjectionW
             truth_label: value.truth_label,
         }
     }
+}
+
+/// Provider Workspace session state safe for phone/desktop/channel clients.
+/// This is Friday's redacted mirror shape, not a raw provider transcript or
+/// credential-bearing session object.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ProviderWorkspaceSessionWire {
+    pub friday_session_id: String,
+    pub provider: String,
+    pub workspace_id: String,
+    pub sync_mode: String,
+    pub status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_turn_id: Option<String>,
+    pub last_event_seq: u64,
+    pub truth_label: String,
+    pub fallback_status: String,
+}
+
+/// Provider-native operation metadata safe to show to UI. This preserves the
+/// distinction between Codex app-server, Claude Remote Control, and Claude
+/// stream-json without linking phone code to provider/secret crates.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "provider_action", rename_all = "snake_case")]
+pub enum ProviderWorkspaceNativeActionWire {
+    CodexAppServer {
+        method: String,
+        schema_ref: String,
+    },
+    ClaudeRemoteControl {
+        action: String,
+        proof_required: bool,
+    },
+    ClaudeStreamJson {
+        event_type: String,
+    },
+}
+
+/// One UI action row in Provider Workspace. `routed=false` means the UI may show
+/// the action with its blocker/proof state, but must not dispatch it.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ProviderWorkspaceActionWire {
+    pub provider: String,
+    pub action: String,
+    pub capability_id: String,
+    pub sync_mode: String,
+    pub status: String,
+    pub truth_label: String,
+    pub routed: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blocker: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub proof_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub native_action: Option<ProviderWorkspaceNativeActionWire>,
+}
+
+/// Metadata-only Needs-Me row derived from provider events. Raw command bodies,
+/// transcript text, provider tokens, and provider account ids are absent.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ProviderWorkspaceNeedsMeWire {
+    pub item_id: String,
+    pub provider: String,
+    pub friday_session_id: String,
+    pub kind: String,
+    pub priority: String,
+    pub ref_id: String,
+    pub status: String,
+}
+
+/// Snapshot message body for the Provider Workspace screen. Deltas can be added
+/// later; this first wire shape gives UI clients a single canonical contract and
+/// prevents surface-specific private action ids.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ProviderWorkspaceProjectionWire {
+    pub session: ProviderWorkspaceSessionWire,
+    pub actions: Vec<ProviderWorkspaceActionWire>,
+    pub needs_me: Vec<ProviderWorkspaceNeedsMeWire>,
 }
 
 /// Structured QR payload for Hub/device pairing. This is the JSON that can be
@@ -268,6 +346,11 @@ pub enum Message {
     },
     /// hub->phone: ack of a queued offline action on reconnect. NOT completion.
     OfflineQueueAck { acked_msg_id: String },
+    /// hub->phone: redacted Provider Workspace state/action snapshot. No model
+    /// call, no provider credential, and blocked actions remain blocked.
+    ProviderWorkspaceSnapshot {
+        projection: ProviderWorkspaceProjectionWire,
+    },
     /// either: explicit error code + message.
     Error { code: ErrorCode, message: String },
 }
@@ -415,6 +498,48 @@ impl ResumableStream {
 mod tests {
     use super::*;
 
+    fn provider_workspace_snapshot() -> Message {
+        Message::ProviderWorkspaceSnapshot {
+            projection: ProviderWorkspaceProjectionWire {
+                session: ProviderWorkspaceSessionWire {
+                    friday_session_id: "friday-codex-1".into(),
+                    provider: "codex".into(),
+                    workspace_id: "workspace-1".into(),
+                    sync_mode: "provider_app_server_local".into(),
+                    status: "awaiting_approval".into(),
+                    active_turn_id: Some("turn-1".into()),
+                    last_event_seq: 7,
+                    truth_label: "codex app-server local, official history unproven".into(),
+                    fallback_status: "no_fallback".into(),
+                },
+                actions: vec![ProviderWorkspaceActionWire {
+                    provider: "codex".into(),
+                    action: "send_turn".into(),
+                    capability_id: "provider.codex.send_turn".into(),
+                    sync_mode: "provider_app_server_local".into(),
+                    status: "implemented_unproven".into(),
+                    truth_label: "codex_app_server_local_turn_start_unproven_for_ui".into(),
+                    routed: false,
+                    blocker: Some("official-history behavior is not fully proven".into()),
+                    proof_ref: None,
+                    native_action: Some(ProviderWorkspaceNativeActionWire::CodexAppServer {
+                        method: "turn_start".into(),
+                        schema_ref: "codex-app-server-generated-schema".into(),
+                    }),
+                }],
+                needs_me: vec![ProviderWorkspaceNeedsMeWire {
+                    item_id: "needs-me:friday-codex-1:approval-1".into(),
+                    provider: "codex".into(),
+                    friday_session_id: "friday-codex-1".into(),
+                    kind: "approval".into(),
+                    priority: "high".into(),
+                    ref_id: "approval-1".into(),
+                    status: "awaiting_approval".into(),
+                }],
+            },
+        }
+    }
+
     #[test]
     fn envelope_round_trips_for_each_kind() {
         let cases = vec![
@@ -442,14 +567,41 @@ mod tests {
                 code: ErrorCode::ProviderUnavailable,
                 message: "down".into(),
             },
+            provider_workspace_snapshot(),
         ];
         for msg in cases {
             let env = Envelope::new("m1", 1000, msg).with_correlation("c1");
             let json = env.encode().unwrap();
-            assert!(json.contains("\"schema_version\":1"));
+            assert!(json.contains("\"schema_version\":2"));
             let back = Envelope::decode(&json).unwrap();
             assert_eq!(back, env);
         }
+    }
+
+    #[test]
+    fn provider_workspace_snapshot_wire_is_redacted_and_truth_labeled() {
+        let env = Envelope::new("provider-workspace-1", 1000, provider_workspace_snapshot());
+        let json = env.encode().unwrap();
+        assert!(json.contains("\"kind\":\"ProviderWorkspaceSnapshot\""));
+        assert!(json.contains("\"capability_id\":\"provider.codex.send_turn\""));
+        assert!(json.contains("official-history"));
+        assert!(json.contains("\"routed\":false"));
+        assert!(json.contains("\"provider_action\":\"codex_app_server\""));
+        for forbidden in [
+            "sk-",
+            "account-hash",
+            "/Users/jarvis/private",
+            "external-thread",
+            "https://provider.example/private",
+            "raw command body",
+        ] {
+            assert!(
+                !json.contains(forbidden),
+                "provider workspace snapshot leaked {forbidden}: {json}"
+            );
+        }
+        let decoded = Envelope::decode(&json).unwrap();
+        assert_eq!(decoded, env);
     }
 
     #[test]

--- a/rust-core/crates/friday-protocol/src/lib.rs
+++ b/rust-core/crates/friday-protocol/src/lib.rs
@@ -19,6 +19,38 @@ pub const CURRENT_SCHEMA_VERSION: u16 = 1;
 /// The inclusive range of versions this build supports.
 pub const SUPPORTED: VersionRange = VersionRange { min: 1, max: 1 };
 
+/// Redacted provider-session projection safe to carry to phone/channel clients.
+/// Hub-only fields such as account hashes, cwd, external URLs, provider tokens,
+/// and raw provider ids are intentionally absent.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ProviderSessionProjectionWire {
+    pub friday_session_id: String,
+    pub provider: String,
+    pub workspace_id: String,
+    pub sync_mode: String,
+    pub capability_snapshot: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_provider_seen_at: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_friday_event_id: Option<String>,
+    pub truth_label: String,
+}
+
+impl From<friday_core::ProviderSessionProjection> for ProviderSessionProjectionWire {
+    fn from(value: friday_core::ProviderSessionProjection) -> Self {
+        Self {
+            friday_session_id: value.friday_session_id,
+            provider: value.provider,
+            workspace_id: value.workspace_id,
+            sync_mode: value.sync_mode.as_str().to_string(),
+            capability_snapshot: value.capability_snapshot,
+            last_provider_seen_at: value.last_provider_seen_at,
+            last_friday_event_id: value.last_friday_event_id,
+            truth_label: value.truth_label,
+        }
+    }
+}
+
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum ProtocolError {
     #[error("decode error: {0}")]
@@ -369,5 +401,40 @@ mod tests {
         );
         // Fully caught up -> nothing to replay.
         assert!(s.missed_since(3).is_empty());
+    }
+
+    #[test]
+    fn provider_session_projection_wire_is_redacted() {
+        let wire: ProviderSessionProjectionWire = friday_core::ProviderSessionLink {
+            friday_session_id: "friday-s1".into(),
+            provider: "codex".into(),
+            account_key_hash: "account-hash".into(),
+            workspace_id: "workspace".into(),
+            cwd: Some("/Users/jarvis/private".into()),
+            external_session_id: Some("external-session".into()),
+            external_thread_id: Some("external-thread".into()),
+            external_url: Some("https://provider.example/private".into()),
+            sync_mode: friday_core::SyncMode::ProviderAppServerLocal,
+            capability_snapshot: "thread/read".into(),
+            last_provider_seen_at: Some(1),
+            last_friday_event_id: Some("event-1".into()),
+            truth_label: "provider local session".into(),
+        }
+        .redacted_projection()
+        .into();
+        let json = serde_json::to_string(&wire).unwrap();
+        assert!(json.contains("provider_app_server_local"));
+        for forbidden in [
+            "account-hash",
+            "/Users/jarvis/private",
+            "external-session",
+            "external-thread",
+            "https://provider.example/private",
+        ] {
+            assert!(
+                !json.contains(forbidden),
+                "provider session wire projection leaked {forbidden}: {json}"
+            );
+        }
     }
 }

--- a/rust-core/crates/friday-protocol/src/lib.rs
+++ b/rust-core/crates/friday-protocol/src/lib.rs
@@ -814,7 +814,7 @@ mod tests {
         let wire: ProviderSessionProjectionWire = friday_core::ProviderSessionLink {
             friday_session_id: "friday-s1".into(),
             provider: "codex".into(),
-            account_key_hash: "account-hash".into(),
+            account_key_hash: "account-hash".into(), // pragma: allowlist secret
             workspace_id: "workspace".into(),
             cwd: Some("/Users/jarvis/private".into()),
             external_session_id: Some("external-session".into()),

--- a/rust-core/crates/friday-protocol/src/lib.rs
+++ b/rust-core/crates/friday-protocol/src/lib.rs
@@ -16,9 +16,9 @@ use std::fmt;
 use thiserror::Error;
 
 /// Highest wire schema version this build speaks.
-pub const CURRENT_SCHEMA_VERSION: u16 = 2;
+pub const CURRENT_SCHEMA_VERSION: u16 = 3;
 /// The inclusive range of versions this build supports.
-pub const SUPPORTED: VersionRange = VersionRange { min: 1, max: 2 };
+pub const SUPPORTED: VersionRange = VersionRange { min: 1, max: 3 };
 
 /// Redacted provider-session projection safe to carry to phone/channel clients.
 /// Hub-only fields such as account hashes, cwd, external URLs, provider tokens,
@@ -128,6 +128,42 @@ pub struct ProviderWorkspaceProjectionWire {
     pub session: ProviderWorkspaceSessionWire,
     pub actions: Vec<ProviderWorkspaceActionWire>,
     pub needs_me: Vec<ProviderWorkspaceNeedsMeWire>,
+}
+
+/// A UI/client request to perform one Provider Workspace action. The Hub must
+/// validate this against the capability catalog before any provider process or
+/// model call can happen.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ProviderWorkspaceActionRequestWire {
+    pub request_id: String,
+    pub friday_session_id: String,
+    pub provider: String,
+    pub action: String,
+    pub capability_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payload_ref: Option<String>,
+}
+
+/// The Hub's pre-dispatch decision for a Provider Workspace action. `accepted`
+/// means the request may enter the provider adapter. It is not a provider
+/// completion claim.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ProviderWorkspaceActionResultWire {
+    pub request_id: String,
+    pub friday_session_id: String,
+    pub provider: String,
+    pub action: String,
+    pub capability_id: String,
+    pub accepted: bool,
+    pub routed: bool,
+    pub status: String,
+    pub truth_label: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blocker: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub proof_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dispatch_ref: Option<String>,
 }
 
 /// Structured QR payload for Hub/device pairing. This is the JSON that can be
@@ -351,6 +387,15 @@ pub enum Message {
     ProviderWorkspaceSnapshot {
         projection: ProviderWorkspaceProjectionWire,
     },
+    /// phone/desktop/channel->hub: request one Provider Workspace action. The
+    /// Hub must answer with a guard result before any provider dispatch.
+    ProviderWorkspaceActionRequest {
+        request: ProviderWorkspaceActionRequestWire,
+    },
+    /// hub->client: pre-dispatch result for a Provider Workspace action request.
+    ProviderWorkspaceActionResult {
+        result: ProviderWorkspaceActionResultWire,
+    },
     /// either: explicit error code + message.
     Error { code: ErrorCode, message: String },
 }
@@ -540,6 +585,38 @@ mod tests {
         }
     }
 
+    fn provider_workspace_action_request() -> Message {
+        Message::ProviderWorkspaceActionRequest {
+            request: ProviderWorkspaceActionRequestWire {
+                request_id: "request-1".into(),
+                friday_session_id: "friday-codex-1".into(),
+                provider: "codex".into(),
+                action: "send_turn".into(),
+                capability_id: "provider.codex.send_turn".into(),
+                payload_ref: Some("friday://body/user-message/1".into()),
+            },
+        }
+    }
+
+    fn provider_workspace_action_result() -> Message {
+        Message::ProviderWorkspaceActionResult {
+            result: ProviderWorkspaceActionResultWire {
+                request_id: "request-1".into(),
+                friday_session_id: "friday-codex-1".into(),
+                provider: "codex".into(),
+                action: "send_turn".into(),
+                capability_id: "provider.codex.send_turn".into(),
+                accepted: false,
+                routed: false,
+                status: "implemented_unproven".into(),
+                truth_label: "codex_app_server_local_turn_start_unproven_for_ui".into(),
+                blocker: Some("official-history behavior is not fully proven".into()),
+                proof_ref: None,
+                dispatch_ref: None,
+            },
+        }
+    }
+
     #[test]
     fn envelope_round_trips_for_each_kind() {
         let cases = vec![
@@ -568,11 +645,13 @@ mod tests {
                 message: "down".into(),
             },
             provider_workspace_snapshot(),
+            provider_workspace_action_request(),
+            provider_workspace_action_result(),
         ];
         for msg in cases {
             let env = Envelope::new("m1", 1000, msg).with_correlation("c1");
             let json = env.encode().unwrap();
-            assert!(json.contains("\"schema_version\":2"));
+            assert!(json.contains("\"schema_version\":3"));
             let back = Envelope::decode(&json).unwrap();
             assert_eq!(back, env);
         }
@@ -602,6 +681,40 @@ mod tests {
         }
         let decoded = Envelope::decode(&json).unwrap();
         assert_eq!(decoded, env);
+    }
+
+    #[test]
+    fn provider_workspace_action_request_and_result_are_metadata_only() {
+        let request = Envelope::new(
+            "provider-action-1",
+            1000,
+            provider_workspace_action_request(),
+        );
+        let result = Envelope::new(
+            "provider-action-2",
+            1001,
+            provider_workspace_action_result(),
+        );
+        for env in [request, result] {
+            let json = env.encode().unwrap();
+            assert!(json.contains("ProviderWorkspaceAction"));
+            assert!(json.contains("\"schema_version\":3"));
+            assert!(json.contains("\"capability_id\":\"provider.codex.send_turn\""));
+            for forbidden in [
+                "raw user prompt",
+                "rm -rf",
+                "sk-",
+                "provider-token",
+                "/Users/jarvis/private",
+                "https://provider.example/private",
+            ] {
+                assert!(
+                    !json.contains(forbidden),
+                    "provider workspace action wire leaked {forbidden}: {json}"
+                );
+            }
+            assert_eq!(Envelope::decode(&json).unwrap(), env);
+        }
     }
 
     #[test]

--- a/rust-core/crates/friday-protocol/src/lib.rs
+++ b/rust-core/crates/friday-protocol/src/lib.rs
@@ -6,10 +6,13 @@
 //! catch-up logic — no networking and no encryption (the transport layer seals
 //! the serialized payload; see Unit-4 transport slice).
 //!
-//! Scope (gate §4.2): exactly the first-slice message kinds. Session-detail,
-//! attachments, workflow, and provider-adapter messages are deferred to their
-//! owning units. The actual networked WebSocket + relay + live key exchange are
-//! the Unit-4 transport sub-slice (this crate is the contract they carry).
+//! Scope (gate §4.2): the first-slice message kinds plus the Provider Workspace wire
+//! messages (session/action projection, action request/result), included as of schema
+//! v3. Session-detail, attachments, and workflow messages remain deferred to their owning
+//! units; for the provider lane, what is still deferred is NOT these wire types but the
+//! real provider ADAPTERS (live dispatch) and the operator-gated remote proof lanes. The
+//! actual networked WebSocket + relay + live key exchange are the Unit-4 transport
+//! sub-slice (this crate is the contract they carry).
 
 use serde::{Deserialize, Serialize};
 use std::fmt;

--- a/rust-core/crates/friday-protocol/src/lib.rs
+++ b/rust-core/crates/friday-protocol/src/lib.rs
@@ -12,6 +12,7 @@
 //! the Unit-4 transport sub-slice (this crate is the contract they carry).
 
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use thiserror::Error;
 
 /// Highest wire schema version this build speaks.
@@ -47,6 +48,141 @@ impl From<friday_core::ProviderSessionProjection> for ProviderSessionProjectionW
             last_provider_seen_at: value.last_provider_seen_at,
             last_friday_event_id: value.last_friday_event_id,
             truth_label: value.truth_label,
+        }
+    }
+}
+
+/// Structured QR payload for Hub/device pairing. This is the JSON that can be
+/// encoded into a QR code. It contains a short-lived Friday pairing secret, but
+/// never provider OAuth/API/session material.
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
+pub struct FridayPairPayloadWire {
+    pub v: u16,
+    pub hub_id: String,
+    pub pairing_id: String,
+    pub pairing_secret: String,
+    pub display_name: String,
+    pub transport_hints: Vec<PairTransportHintWire>,
+    pub expires_at: i64,
+    pub capabilities_hint: Vec<String>,
+}
+
+impl fmt::Debug for FridayPairPayloadWire {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FridayPairPayloadWire")
+            .field("v", &self.v)
+            .field("hub_id", &self.hub_id)
+            .field("pairing_id", &self.pairing_id)
+            .field("pairing_secret", &"<redacted>")
+            .field("display_name", &self.display_name)
+            .field("transport_hints", &self.transport_hints)
+            .field("expires_at", &self.expires_at)
+            .field("capabilities_hint", &self.capabilities_hint)
+            .finish()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct PairTransportHintWire {
+    pub kind: String,
+    pub endpoint: String,
+    pub label: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct FridayPairProjectionWire {
+    pub v: u16,
+    pub hub_id: String,
+    pub pairing_id: String,
+    pub display_name: String,
+    pub transport_labels: Vec<String>,
+    pub expires_at: i64,
+    pub capabilities_hint: Vec<String>,
+}
+
+impl FridayPairPayloadWire {
+    pub fn encode_qr_json(&self) -> Result<String, ProtocolError> {
+        serde_json::to_string(self).map_err(|e| ProtocolError::Encode(e.to_string()))
+    }
+
+    pub fn decode_qr_json(value: &str) -> Result<Self, ProtocolError> {
+        serde_json::from_str(value).map_err(|e| ProtocolError::Decode(e.to_string()))
+    }
+
+    pub fn into_core(self) -> Result<friday_core::FridayPairPayload, ProtocolError> {
+        let mut hints = Vec::with_capacity(self.transport_hints.len());
+        for hint in self.transport_hints {
+            let kind = friday_core::PairTransportKind::parse(&hint.kind).ok_or_else(|| {
+                ProtocolError::Decode(format!("unknown pair transport kind '{}'", hint.kind))
+            })?;
+            hints.push(
+                friday_core::PairTransportHint::new(kind, hint.endpoint, hint.label)
+                    .map_err(|e| ProtocolError::Decode(e.to_string()))?,
+            );
+        }
+        let mut authorities = Vec::with_capacity(self.capabilities_hint.len());
+        for authority in self.capabilities_hint {
+            authorities.push(
+                friday_core::PairAuthority::parse(&authority).ok_or_else(|| {
+                    ProtocolError::Decode(format!("unknown pair authority '{authority}'"))
+                })?,
+            );
+        }
+        friday_core::FridayPairPayload::new(
+            self.v,
+            self.hub_id,
+            self.pairing_id,
+            self.pairing_secret,
+            self.display_name,
+            hints,
+            self.expires_at,
+            authorities,
+        )
+        .map_err(|e| ProtocolError::Decode(e.to_string()))
+    }
+}
+
+impl From<&friday_core::FridayPairPayload> for FridayPairPayloadWire {
+    fn from(value: &friday_core::FridayPairPayload) -> Self {
+        Self {
+            v: value.v,
+            hub_id: value.hub_id.clone(),
+            pairing_id: value.pairing_id.clone(),
+            pairing_secret: value.pairing_secret.expose_for_qr().to_string(),
+            display_name: value.display_name.clone(),
+            transport_hints: value
+                .transport_hints
+                .iter()
+                .map(|hint| PairTransportHintWire {
+                    kind: hint.kind.as_str().to_string(),
+                    endpoint: hint.endpoint.clone(),
+                    label: hint.label.clone(),
+                })
+                .collect(),
+            expires_at: value.expires_at,
+            capabilities_hint: value
+                .capabilities_hint
+                .iter()
+                .map(|authority| authority.as_str().to_string())
+                .collect(),
+        }
+    }
+}
+
+impl From<friday_core::FridayPairProjection> for FridayPairProjectionWire {
+    fn from(value: friday_core::FridayPairProjection) -> Self {
+        Self {
+            v: value.v,
+            hub_id: value.hub_id,
+            pairing_id: value.pairing_id,
+            display_name: value.display_name,
+            transport_labels: value.transport_labels,
+            expires_at: value.expires_at,
+            capabilities_hint: value
+                .capabilities_hint
+                .iter()
+                .map(|authority| authority.as_str().to_string())
+                .collect(),
         }
     }
 }
@@ -436,5 +572,81 @@ mod tests {
                 "provider session wire projection leaked {forbidden}: {json}"
             );
         }
+    }
+
+    #[test]
+    fn friday_pair_payload_wire_round_trips_and_projection_redacts_secret() {
+        let payload = friday_core::FridayPairPayload::new(
+            friday_core::CURRENT_PAIR_PAYLOAD_VERSION,
+            "hub-mac-mini",
+            "pair-1",
+            "friday-pairing-secret-32-bytes",
+            "Jarvis Mac mini",
+            vec![friday_core::PairTransportHint::new(
+                friday_core::PairTransportKind::LanWebSocket,
+                "ws://192.168.1.8:4477",
+                "LAN WebSocket",
+            )
+            .unwrap()],
+            2000,
+            vec![
+                friday_core::PairAuthority::StatusOnly,
+                friday_core::PairAuthority::Approvals,
+            ],
+        )
+        .unwrap();
+        let wire = FridayPairPayloadWire::from(&payload);
+        let debug = format!("{wire:?}");
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains(payload.pairing_secret.expose_for_qr()));
+
+        let json = wire.encode_qr_json().unwrap();
+        assert!(
+            json.contains(payload.pairing_secret.expose_for_qr()),
+            "QR JSON must carry the Friday-scoped pairing secret"
+        );
+        let decoded = FridayPairPayloadWire::decode_qr_json(&json)
+            .unwrap()
+            .into_core()
+            .unwrap();
+        decoded.validate_at(1000).unwrap();
+
+        let projection: FridayPairProjectionWire = decoded.redacted_projection().into();
+        let projection_json = serde_json::to_string(&projection).unwrap();
+        assert!(!projection_json.contains(payload.pairing_secret.expose_for_qr()));
+        assert!(projection_json.contains("LAN WebSocket"));
+    }
+
+    #[test]
+    fn friday_pair_payload_wire_rejects_unknown_authority_and_provider_secret_hints() {
+        let raw = r#"{
+            "v":1,
+            "hub_id":"hub",
+            "pairing_id":"pair",
+            "pairing_secret":"friday-pairing-secret-32-bytes",
+            "display_name":"Hub",
+            "transport_hints":[{"kind":"lan_websocket","endpoint":"ws://127.0.0.1:4477?api_key=abc","label":"LAN"}],
+            "expires_at":2000,
+            "capabilities_hint":["status_only"]
+        }"#;
+        assert!(FridayPairPayloadWire::decode_qr_json(raw)
+            .unwrap()
+            .into_core()
+            .is_err());
+
+        let raw = r#"{
+            "v":1,
+            "hub_id":"hub",
+            "pairing_id":"pair",
+            "pairing_secret":"friday-pairing-secret-32-bytes",
+            "display_name":"Hub",
+            "transport_hints":[{"kind":"lan_websocket","endpoint":"ws://127.0.0.1:4477","label":"LAN"}],
+            "expires_at":2000,
+            "capabilities_hint":["provider_oauth_admin"]
+        }"#;
+        assert!(FridayPairPayloadWire::decode_qr_json(raw)
+            .unwrap()
+            .into_core()
+            .is_err());
     }
 }

--- a/rust-core/crates/friday-providers/Cargo.toml
+++ b/rust-core/crates/friday-providers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "friday-providers"
-description = "Friday Rust Core — Codex/Claude provider adapters (Hub-only). Unit 6/7: auth-readiness detection via official provider status commands."
+description = "Friday Rust Core — Codex/Claude provider adapters and Hub-only control-surface contracts."
 edition.workspace = true
 version.workspace = true
 license.workspace = true

--- a/rust-core/crates/friday-providers/Cargo.toml
+++ b/rust-core/crates/friday-providers/Cargo.toml
@@ -15,6 +15,7 @@ rust-version.workspace = true
 thiserror.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+friday-core.workspace = true
 
 [dev-dependencies]
 # Token-safety regression lock only: a provider SEND returns reply text and must

--- a/rust-core/crates/friday-providers/Cargo.toml
+++ b/rust-core/crates/friday-providers/Cargo.toml
@@ -13,6 +13,8 @@ rust-version.workspace = true
 # by friday-arch-tests.
 [dependencies]
 thiserror.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 
 [dev-dependencies]
 # Token-safety regression lock only: a provider SEND returns reply text and must

--- a/rust-core/crates/friday-providers/src/claude_control.rs
+++ b/rust-core/crates/friday-providers/src/claude_control.rs
@@ -8,6 +8,11 @@
 
 use friday_core::{ProviderSessionEvent, SyncMode};
 use serde_json::Value;
+use std::io::{BufRead, BufReader};
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
 use thiserror::Error;
 
 pub const CLAUDE_REMOTE_CONTROL_CANDIDATE_SYNC_MODE: &str =
@@ -21,6 +26,9 @@ pub enum ClaudeControlError {
 
     #[error("claude stream event missing required metadata: {code}")]
     MissingMetadata { code: &'static str },
+
+    #[error("claude process error: {code}")]
+    Process { code: &'static str },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -253,6 +261,129 @@ fn optional_string(value: &Value, field: &str) -> Option<String> {
         .get(field)
         .and_then(Value::as_str)
         .map(ToString::to_string)
+}
+
+/// The result of a live Claude local-mirror run (CLAUDE-MIRROR-001). Carries ONLY the
+/// metadata-only [`ProviderSessionEvent`]s the mapper produced + counts — never raw
+/// transcript text (the mapper enforces `redaction_level = metadata_only`).
+#[derive(Debug, Clone)]
+pub struct ClaudeMirrorRun {
+    pub events: Vec<ProviderSessionEvent>,
+    /// Stream-json lines the mapper did not recognize (counted, not inlined).
+    pub unmapped_count: usize,
+    pub session_id: Option<String>,
+}
+
+/// LIVE Claude LOCAL MIRROR (CLAUDE-MIRROR-001). Drives the Claude CLI's
+/// `--print --output-format stream-json` path and folds the real event stream through
+/// [`map_stream_json_to_provider_event`] into Friday-owned, metadata-only events. The
+/// lane is ALWAYS `friday_local_mirror` ([`CLAUDE_STREAM_JSON_SYNC_MODE`]) — Friday owns
+/// the transcript; this is NOT Claude Remote Control and NOT provider-native sync (those
+/// stay operator-gated). Hub-side; no provider secret is read here (the CLI uses the
+/// operator's local Claude credentials).
+pub struct LocalClaudeMirror;
+
+impl LocalClaudeMirror {
+    /// Classify the LIVE Claude CLI surface by parsing `<program> --help`. The local
+    /// stream-json mirror surface is read from the main help; remote-control is left
+    /// unproven here (operator-gated) unless its help is supplied separately.
+    pub fn capabilities(program: &str) -> Result<ClaudeHelpCapabilities, ClaudeControlError> {
+        let main_help = Self::run_help(program, &["--help"])?;
+        // Remote-control help is not sourced here; CLAUDE-MIRROR-001 proves the LOCAL
+        // mirror only. Passing the main help keeps remote-control classification honest
+        // (it stays operator-gated / unproven without a dedicated remote-control proof).
+        Ok(ClaudeHelpCapabilities::parse(&main_help, &main_help))
+    }
+
+    fn run_help(program: &str, args: &[&str]) -> Result<String, ClaudeControlError> {
+        let out = Command::new(program)
+            .args(args)
+            .stdin(Stdio::null())
+            .output()
+            .map_err(|_| ClaudeControlError::Process { code: "help-spawn" })?;
+        Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+    }
+
+    /// Run ONE `--print --output-format stream-json` turn and mirror its event stream into
+    /// metadata-only [`ProviderSessionEvent`]s. This is a real model turn (the stream-json
+    /// path inherently runs a turn); provider live sends are operator-authorized. A
+    /// `--print` run exits after the turn, so stdout EOFs naturally; a pid watchdog kills
+    /// the child if it hangs, so a blocking read can never freeze the caller.
+    pub fn mirror_stream_json(
+        program: &str,
+        prompt: &str,
+        context: &ClaudeMirrorContext,
+        observed_at: i64,
+        timeout: Duration,
+    ) -> Result<ClaudeMirrorRun, ClaudeControlError> {
+        let mut child = Command::new(program)
+            .args([
+                "-p",
+                prompt,
+                "--output-format",
+                "stream-json",
+                "--verbose",
+                "--allowedTools",
+                "",
+            ])
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|_| ClaudeControlError::Process {
+                code: "mirror-spawn",
+            })?;
+        let stdout = child.stdout.take().ok_or(ClaudeControlError::Process {
+            code: "mirror-stdout",
+        })?;
+
+        let pid = child.id();
+        let (done_tx, done_rx) = mpsc::channel::<()>();
+        let watchdog = thread::spawn(move || {
+            if done_rx.recv_timeout(timeout).is_err() {
+                let _ = Command::new("kill").arg("-9").arg(pid.to_string()).status();
+            }
+        });
+
+        let mut events = Vec::new();
+        let mut unmapped_count = 0usize;
+        let mut session_id = None;
+        let mut seq = 0u64;
+        for line in BufReader::new(stdout).lines() {
+            let line = match line {
+                Ok(l) => l,
+                Err(_) => break,
+            };
+            let trimmed = line.trim();
+            if !trimmed.starts_with('{') {
+                continue;
+            }
+            let value: Value = match serde_json::from_str(trimmed) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+            if session_id.is_none() {
+                session_id = optional_string(&value, "session_id");
+            }
+            match map_stream_json_to_provider_event(context, &value, observed_at, seq) {
+                Ok(Some(event)) => {
+                    events.push(event);
+                    seq += 1;
+                }
+                Ok(None) => {} // ping / heartbeat
+                Err(_) => unmapped_count += 1,
+            }
+        }
+
+        let _ = done_tx.send(());
+        let _ = watchdog.join();
+        let _ = child.wait();
+        Ok(ClaudeMirrorRun {
+            events,
+            unmapped_count,
+            session_id,
+        })
+    }
 }
 
 #[cfg(test)]

--- a/rust-core/crates/friday-providers/src/claude_control.rs
+++ b/rust-core/crates/friday-providers/src/claude_control.rs
@@ -1,0 +1,413 @@
+//! Claude Code control-surface contract — CLAUDE-001.
+//!
+//! This module classifies Claude control paths without starting a model turn.
+//! It separates the official Remote Control path, which can provide provider-
+//! native phone/browser continuity only after a live same-account connection is
+//! proven, from local `--print --output-format=stream-json` mirroring, which is
+//! Friday-owned history only.
+
+use friday_core::{ProviderSessionEvent, SyncMode};
+use serde_json::Value;
+use thiserror::Error;
+
+pub const CLAUDE_REMOTE_CONTROL_CANDIDATE_SYNC_MODE: &str =
+    SyncMode::ProviderNativeLinkOnly.as_str();
+pub const CLAUDE_STREAM_JSON_SYNC_MODE: &str = SyncMode::FridayLocalMirror.as_str();
+
+#[derive(Debug, Error)]
+pub enum ClaudeControlError {
+    #[error("claude control surface parse failed: {code}")]
+    Parse { code: &'static str },
+
+    #[error("claude stream event missing required metadata: {code}")]
+    MissingMetadata { code: &'static str },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClaudeHelpCapabilities {
+    pub remote_control_command: bool,
+    pub remote_control_flag: bool,
+    pub remote_control_qr: bool,
+    pub remote_control_mobile_or_browser: bool,
+    pub remote_control_spawn_worktree: bool,
+    pub remote_control_capacity: bool,
+    pub resume_flag: bool,
+    pub continue_flag: bool,
+    pub fork_session_flag: bool,
+    pub session_id_flag: bool,
+    pub stream_json_input: bool,
+    pub stream_json_output: bool,
+    pub partial_messages: bool,
+    pub hook_events: bool,
+    pub max_budget_usd: bool,
+}
+
+impl ClaudeHelpCapabilities {
+    pub fn parse(main_help: &str, remote_control_help: &str) -> Self {
+        let main = main_help.to_lowercase();
+        let remote = remote_control_help.to_lowercase();
+        Self {
+            remote_control_command: remote.contains("remote control")
+                && remote.contains("claude.ai/code"),
+            remote_control_flag: main.contains("--remote-control"),
+            remote_control_qr: remote.contains("qr code") || remote.contains("spacebar"),
+            remote_control_mobile_or_browser: remote.contains("claude mobile app")
+                && remote.contains("claude.ai/code"),
+            remote_control_spawn_worktree: remote.contains("--spawn")
+                && remote.contains("worktree"),
+            remote_control_capacity: remote.contains("--capacity"),
+            resume_flag: main.contains("--resume"),
+            continue_flag: main.contains("--continue"),
+            fork_session_flag: main.contains("--fork-session"),
+            session_id_flag: main.contains("--session-id"),
+            stream_json_input: main.contains("--input-format") && main.contains("stream-json"),
+            stream_json_output: main.contains("--output-format") && main.contains("stream-json"),
+            partial_messages: main.contains("--include-partial-messages"),
+            hook_events: main.contains("--include-hook-events"),
+            max_budget_usd: main.contains("--max-budget-usd"),
+        }
+    }
+
+    pub fn has_remote_control_surface(&self) -> bool {
+        self.remote_control_command
+            && self.remote_control_flag
+            && self.remote_control_mobile_or_browser
+    }
+
+    pub fn has_local_stream_surface(&self) -> bool {
+        self.stream_json_input
+            && self.stream_json_output
+            && self.session_id_flag
+            && self.resume_flag
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClaudeControlMode {
+    RemoteControl,
+    StreamJsonLocalMirror,
+    Unsupported,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ClaudeRemoteControlProof {
+    pub session_url_seen: bool,
+    pub qr_seen: bool,
+    pub same_account_verified: bool,
+    pub remote_surface_connected: bool,
+}
+
+impl ClaudeRemoteControlProof {
+    pub fn is_provider_native_sync_proof(self) -> bool {
+        self.session_url_seen
+            && self.qr_seen
+            && self.same_account_verified
+            && self.remote_surface_connected
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClaudeControlSurface {
+    pub mode: ClaudeControlMode,
+    pub sync_mode: SyncMode,
+    pub no_model_call: bool,
+    pub truth_label: &'static str,
+    pub requires_operator_login: bool,
+    pub requires_live_connection_proof: bool,
+}
+
+pub fn classify_remote_control_surface(
+    capabilities: &ClaudeHelpCapabilities,
+    proof: ClaudeRemoteControlProof,
+) -> ClaudeControlSurface {
+    if !capabilities.has_remote_control_surface() {
+        return ClaudeControlSurface {
+            mode: ClaudeControlMode::Unsupported,
+            sync_mode: SyncMode::UnsupportedTruthLabeled,
+            no_model_call: true,
+            truth_label: "claude_remote_control_not_available",
+            requires_operator_login: true,
+            requires_live_connection_proof: true,
+        };
+    }
+
+    let proven = proof.is_provider_native_sync_proof();
+    ClaudeControlSurface {
+        mode: ClaudeControlMode::RemoteControl,
+        sync_mode: if proven {
+            SyncMode::ProviderNativeSynced
+        } else {
+            SyncMode::ProviderNativeLinkOnly
+        },
+        no_model_call: true,
+        truth_label: if proven {
+            "claude_remote_control_provider_native_synced_live_proven"
+        } else {
+            "claude_remote_control_available_but_sync_unproven"
+        },
+        requires_operator_login: true,
+        requires_live_connection_proof: !proven,
+    }
+}
+
+pub fn classify_stream_json_surface(capabilities: &ClaudeHelpCapabilities) -> ClaudeControlSurface {
+    if !capabilities.has_local_stream_surface() {
+        return ClaudeControlSurface {
+            mode: ClaudeControlMode::Unsupported,
+            sync_mode: SyncMode::UnsupportedTruthLabeled,
+            no_model_call: true,
+            truth_label: "claude_stream_json_not_available",
+            requires_operator_login: true,
+            requires_live_connection_proof: false,
+        };
+    }
+
+    ClaudeControlSurface {
+        mode: ClaudeControlMode::StreamJsonLocalMirror,
+        sync_mode: SyncMode::FridayLocalMirror,
+        no_model_call: true,
+        truth_label: "claude_stream_json_friday_local_mirror",
+        requires_operator_login: true,
+        requires_live_connection_proof: false,
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClaudeMirrorContext {
+    pub friday_session_id: String,
+    pub provider: String,
+}
+
+impl ClaudeMirrorContext {
+    pub fn claude(friday_session_id: impl Into<String>) -> Self {
+        Self {
+            friday_session_id: friday_session_id.into(),
+            provider: "claude".to_string(),
+        }
+    }
+}
+
+pub fn map_stream_json_to_provider_event(
+    context: &ClaudeMirrorContext,
+    value: &Value,
+    observed_at: i64,
+    mirror_seq: u64,
+) -> Result<Option<ProviderSessionEvent>, ClaudeControlError> {
+    let event_type = value
+        .get("type")
+        .and_then(Value::as_str)
+        .ok_or(ClaudeControlError::MissingMetadata { code: "type" })?;
+    if matches!(event_type, "ping" | "heartbeat") {
+        return Ok(None);
+    }
+
+    let session_id = optional_string(value, "session_id")
+        .or_else(|| optional_string(value, "sessionId"))
+        .ok_or(ClaudeControlError::MissingMetadata { code: "session_id" })?;
+    let message_id = optional_string(value, "message_id")
+        .or_else(|| optional_string(value, "messageId"))
+        .or_else(|| {
+            value
+                .get("message")
+                .and_then(|message| optional_string(message, "id"))
+        })
+        .unwrap_or_else(|| "no-message".to_string());
+
+    let (event_kind, transcript_item_kind) = match event_type {
+        "system" => ("session_status", "system"),
+        "assistant" => ("assistant_message", "assistant_message"),
+        "user" => ("user_message", "user_message"),
+        "result" => ("turn_completed", "result"),
+        "tool_use" => ("tool_use", "tool"),
+        "tool_result" => ("tool_result", "tool"),
+        "permission_request" | "tool_permission_request" => ("approval_requested", "approval"),
+        _ => ("provider_event_unmapped", "provider_event"),
+    };
+
+    let approval_ref = if event_kind == "approval_requested" {
+        Some(format!("claude:{event_type}:{session_id}:{message_id}"))
+    } else {
+        None
+    };
+
+    Ok(Some(ProviderSessionEvent {
+        friday_session_id: context.friday_session_id.clone(),
+        provider_event_id: format!("claude:{event_type}:{session_id}:{message_id}:{mirror_seq}"),
+        provider: context.provider.clone(),
+        event_kind: event_kind.to_string(),
+        transcript_item_kind: transcript_item_kind.to_string(),
+        body_ref: format!(
+            "claude://stream-event/{}/{}/{}",
+            context.friday_session_id, mirror_seq, event_type
+        ),
+        redaction_level: "metadata_only".to_string(),
+        token_ledger_ref: None,
+        approval_ref,
+        audit_receipt_ref: None,
+        observed_at,
+    }))
+}
+
+fn optional_string(value: &Value, field: &str) -> Option<String> {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn fixture_capabilities() -> ClaudeHelpCapabilities {
+        ClaudeHelpCapabilities::parse(
+            r#"
+Usage: claude [options]
+  --remote-control [name]
+  -r, --resume [value]
+  -c, --continue
+  --fork-session
+  --session-id <uuid>
+  --input-format <format> "text" or "stream-json"
+  --output-format <format> "text", "json", or "stream-json"
+  --include-partial-messages
+  --include-hook-events
+  --max-budget-usd <amount>
+"#,
+            r#"
+Remote Control - Control local sessions from claude.ai/code or the Claude mobile app
+USAGE claude remote-control [options]
+  --spawn <mode> same-dir, worktree, session
+  --capacity <N>
+DESCRIPTION
+  It displays a session URL. Press spacebar to show a QR code.
+"#,
+        )
+    }
+
+    #[test]
+    fn help_parse_detects_remote_control_and_stream_json_surfaces() {
+        let caps = fixture_capabilities();
+        assert!(caps.has_remote_control_surface());
+        assert!(caps.remote_control_spawn_worktree);
+        assert!(caps.remote_control_capacity);
+        assert!(caps.has_local_stream_surface());
+        assert!(caps.partial_messages);
+        assert!(caps.hook_events);
+        assert!(caps.max_budget_usd);
+    }
+
+    #[test]
+    fn remote_control_does_not_claim_native_sync_without_live_connection_proof() {
+        let surface = classify_remote_control_surface(
+            &fixture_capabilities(),
+            ClaudeRemoteControlProof {
+                session_url_seen: true,
+                qr_seen: true,
+                same_account_verified: false,
+                remote_surface_connected: false,
+            },
+        );
+        assert_eq!(surface.mode, ClaudeControlMode::RemoteControl);
+        assert_eq!(surface.sync_mode, SyncMode::ProviderNativeLinkOnly);
+        assert_eq!(
+            surface.truth_label,
+            "claude_remote_control_available_but_sync_unproven"
+        );
+        assert!(surface.requires_live_connection_proof);
+    }
+
+    #[test]
+    fn remote_control_native_sync_requires_all_four_live_proof_bits() {
+        let surface = classify_remote_control_surface(
+            &fixture_capabilities(),
+            ClaudeRemoteControlProof {
+                session_url_seen: true,
+                qr_seen: true,
+                same_account_verified: true,
+                remote_surface_connected: true,
+            },
+        );
+        assert_eq!(surface.sync_mode, SyncMode::ProviderNativeSynced);
+        assert_eq!(
+            surface.truth_label,
+            "claude_remote_control_provider_native_synced_live_proven"
+        );
+        assert!(!surface.requires_live_connection_proof);
+    }
+
+    #[test]
+    fn stream_json_is_friday_local_mirror_not_provider_native_sync() {
+        let surface = classify_stream_json_surface(&fixture_capabilities());
+        assert_eq!(surface.mode, ClaudeControlMode::StreamJsonLocalMirror);
+        assert_eq!(surface.sync_mode, SyncMode::FridayLocalMirror);
+        assert_eq!(
+            surface.truth_label,
+            "claude_stream_json_friday_local_mirror"
+        );
+    }
+
+    #[test]
+    fn stream_json_events_map_to_metadata_only_provider_events() {
+        let context = ClaudeMirrorContext::claude("friday-session-1");
+        let value = json!({
+            "type": "assistant",
+            "session_id": "provider-session-1",
+            "message": {
+                "id": "msg-1",
+                "content": "raw Claude transcript must not be inlined"
+            }
+        });
+        let event = map_stream_json_to_provider_event(&context, &value, 42, 9)
+            .unwrap()
+            .unwrap();
+        assert_eq!(event.provider, "claude");
+        assert_eq!(event.event_kind, "assistant_message");
+        assert_eq!(event.transcript_item_kind, "assistant_message");
+        assert_eq!(event.redaction_level, "metadata_only");
+        assert_eq!(event.approval_ref, None);
+        let debug = format!("{event:?}");
+        assert!(
+            !debug.contains("raw Claude transcript"),
+            "Claude mirror event must not inline raw provider text: {debug}"
+        );
+    }
+
+    #[test]
+    fn stream_json_permission_request_maps_to_approval_ref_without_raw_tool_body() {
+        let context = ClaudeMirrorContext::claude("friday-session-1");
+        let value = json!({
+            "type": "permission_request",
+            "sessionId": "provider-session-1",
+            "messageId": "permission-1",
+            "tool_input": { "command": "rm -rf /private/project" }
+        });
+        let event = map_stream_json_to_provider_event(&context, &value, 42, 10)
+            .unwrap()
+            .unwrap();
+        assert_eq!(event.event_kind, "approval_requested");
+        assert_eq!(
+            event.approval_ref.as_deref(),
+            Some("claude:permission_request:provider-session-1:permission-1")
+        );
+        let debug = format!("{event:?}");
+        assert!(
+            !debug.contains("rm -rf"),
+            "approval mirror event must not inline raw tool body: {debug}"
+        );
+    }
+
+    #[test]
+    fn stream_json_events_missing_session_id_fail_closed() {
+        let context = ClaudeMirrorContext::claude("friday-session-1");
+        let value = json!({
+            "type": "assistant",
+            "message": { "id": "msg-1", "content": "text" }
+        });
+        assert!(matches!(
+            map_stream_json_to_provider_event(&context, &value, 42, 11),
+            Err(ClaudeControlError::MissingMetadata { code: "session_id" })
+        ));
+    }
+}

--- a/rust-core/crates/friday-providers/src/codex_appserver.rs
+++ b/rust-core/crates/friday-providers/src/codex_appserver.rs
@@ -10,6 +10,7 @@ use serde_json::{json, Value};
 use std::collections::{BTreeSet, VecDeque};
 use std::io::{BufRead, BufReader, Read, Write};
 use std::path::Path;
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 use thiserror::Error;
 
 use friday_core::ProviderSessionEvent;
@@ -252,6 +253,14 @@ pub struct JsonRpcErrorEnvelope {
 
 pub trait CodexAppServerTransport {
     fn request(&mut self, request: JsonRpcRequest) -> Result<JsonRpcResponse, CodexAppServerError>;
+
+    /// Send a fire-and-forget JSON-RPC notification (no id, no response wait). Default
+    /// no-op so in-memory / mocked transports need not implement it; the real
+    /// [`JsonLineTransport`] overrides it. Used for the post-`initialize` `initialized`
+    /// handshake the app-server expects before thread/turn calls.
+    fn notify(&mut self, _method: &str, _params: Option<Value>) -> Result<(), CodexAppServerError> {
+        Ok(())
+    }
 }
 
 pub struct JsonLineTransport<R, W> {
@@ -273,6 +282,26 @@ impl<R: Read, W: Write> JsonLineTransport<R, W> {
 }
 
 impl<R: Read, W: Write> CodexAppServerTransport for JsonLineTransport<R, W> {
+    fn notify(&mut self, method: &str, params: Option<Value>) -> Result<(), CodexAppServerError> {
+        let mut msg = serde_json::Map::new();
+        msg.insert("jsonrpc".to_string(), json!("2.0"));
+        msg.insert("method".to_string(), json!(method));
+        if let Some(p) = params {
+            msg.insert("params".to_string(), p);
+        }
+        let encoded =
+            serde_json::to_vec(&Value::Object(msg)).map_err(|_| CodexAppServerError::Protocol {
+                code: "notify-encode",
+            })?;
+        self.writer
+            .write_all(&encoded)
+            .and_then(|_| self.writer.write_all(b"\n"))
+            .and_then(|_| self.writer.flush())
+            .map_err(|_| CodexAppServerError::Transport {
+                code: "notify-write",
+            })
+    }
+
     fn request(&mut self, request: JsonRpcRequest) -> Result<JsonRpcResponse, CodexAppServerError> {
         let request_id = request.id;
         let encoded = serde_json::to_vec(&json!({
@@ -372,6 +401,13 @@ impl<T: CodexAppServerTransport> CodexAppServerClient<T> {
             platform_os: required_string(&result, "platformOs")?,
             user_agent: required_string(&result, "userAgent")?,
         })
+    }
+
+    /// Send the post-`initialize` `initialized` notification (JSON-RPC fire-and-forget).
+    /// The app-server expects it before thread/turn calls. A no-op for transports that do
+    /// not override `notify` (the in-memory test transports).
+    pub fn initialized(&mut self) -> Result<(), CodexAppServerError> {
+        self.transport.notify("initialized", None)
     }
 
     /// Non-model health probe. `thread/list` is a metadata read; it must not be
@@ -572,6 +608,64 @@ impl<T: CodexAppServerTransport> CodexAppServerClient<T> {
         response.result.ok_or(CodexAppServerError::Protocol {
             code: "missing-result",
         })
+    }
+}
+
+/// A locally-spawned `codex app-server` process speaking JSON-RPC over stdio, wrapped in a
+/// [`CodexAppServerClient`] (CODEX-LIVE-001). Hub-side only. The lane label is ALWAYS
+/// [`CODEX_APP_SERVER_SYNC_MODE`] = `provider_app_server_local` — this is Friday's LOCAL
+/// Codex control (initialize / thread list-read / turn-control), NOT official
+/// ChatGPT/Codex same-account history sync, which it must never claim. The child process
+/// is killed on drop. Spawning requires the Codex CLI installed + logged in; a failure is
+/// surfaced as an exact [`CodexAppServerError`], never faked.
+pub struct LocalCodexAppServer {
+    child: Child,
+    client: CodexAppServerClient<JsonLineTransport<ChildStdout, ChildStdin>>,
+}
+
+impl LocalCodexAppServer {
+    /// Spawn `<program> app-server` (default `program` = `"codex"`) over piped stdio.
+    pub fn spawn(program: &str) -> Result<Self, CodexAppServerError> {
+        let mut child = Command::new(program)
+            .arg("app-server")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|_| CodexAppServerError::Transport {
+                code: "app-server-spawn",
+            })?;
+        let stdin = child.stdin.take().ok_or(CodexAppServerError::Transport {
+            code: "app-server-stdin",
+        })?;
+        let stdout = child.stdout.take().ok_or(CodexAppServerError::Transport {
+            code: "app-server-stdout",
+        })?;
+        let client = CodexAppServerClient::new(JsonLineTransport::new(stdout, stdin));
+        Ok(Self { child, client })
+    }
+
+    /// The OS pid of the spawned app-server (for an external watchdog kill).
+    pub fn child_id(&self) -> u32 {
+        self.child.id()
+    }
+
+    pub fn client(
+        &mut self,
+    ) -> &mut CodexAppServerClient<JsonLineTransport<ChildStdout, ChildStdin>> {
+        &mut self.client
+    }
+
+    /// Terminate the app-server process (idempotent).
+    pub fn kill(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+impl Drop for LocalCodexAppServer {
+    fn drop(&mut self) {
+        self.kill();
     }
 }
 

--- a/rust-core/crates/friday-providers/src/codex_appserver.rs
+++ b/rust-core/crates/friday-providers/src/codex_appserver.rs
@@ -12,6 +12,8 @@ use std::io::{BufRead, BufReader, Read, Write};
 use std::path::Path;
 use thiserror::Error;
 
+use friday_core::ProviderSessionEvent;
+
 pub const CODEX_APP_SERVER_SYNC_MODE: &str = "provider_app_server_local";
 pub const CODEX_APP_SERVER_CLI_VERSION: &str = "codex-cli 0.136.0";
 
@@ -85,6 +87,58 @@ pub struct HealthSummary {
     pub initialized: InitializeSummary,
     pub thread_list: ThreadListProbe,
     pub sync_mode: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ThreadSummary {
+    pub thread_id: String,
+    pub session_id: Option<String>,
+    pub status: Option<String>,
+    pub preview: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ThreadReadSummary {
+    pub thread: ThreadSummary,
+    pub turn_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TurnSummary {
+    pub thread_id: String,
+    pub turn_id: String,
+    pub status: Option<String>,
+    pub item_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InterruptSummary {
+    pub thread_id: String,
+    pub turn_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct JsonRpcServerMessage {
+    #[serde(default)]
+    pub id: Option<Value>,
+    pub method: String,
+    #[serde(default)]
+    pub params: Value,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderMirrorContext {
+    pub friday_session_id: String,
+    pub provider: String,
+}
+
+impl ProviderMirrorContext {
+    pub fn codex(friday_session_id: impl Into<String>) -> Self {
+        Self {
+            friday_session_id: friday_session_id.into(),
+            provider: "codex".to_string(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -326,6 +380,133 @@ impl<T: CodexAppServerTransport> CodexAppServerClient<T> {
         })
     }
 
+    pub fn start_thread(
+        &mut self,
+        cwd: Option<&str>,
+        model: Option<&str>,
+    ) -> Result<ThreadSummary, CodexAppServerError> {
+        let result = self.call(
+            "thread/start",
+            json!({
+                "cwd": cwd,
+                "model": model,
+                "modelProvider": null,
+                "approvalPolicy": null,
+                "approvalsReviewer": null,
+                "sandbox": null,
+                "ephemeral": false,
+                "threadSource": null,
+                "sessionStartSource": null,
+            }),
+        )?;
+        thread_summary_from_response(&result)
+    }
+
+    pub fn resume_thread(&mut self, thread_id: &str) -> Result<ThreadSummary, CodexAppServerError> {
+        let result = self.call(
+            "thread/resume",
+            json!({
+                "threadId": thread_id,
+                "approvalPolicy": null,
+                "approvalsReviewer": null,
+            }),
+        )?;
+        thread_summary_from_response(&result)
+    }
+
+    pub fn read_thread(
+        &mut self,
+        thread_id: &str,
+        include_turns: bool,
+    ) -> Result<ThreadReadSummary, CodexAppServerError> {
+        let result = self.call(
+            "thread/read",
+            json!({
+                "threadId": thread_id,
+                "includeTurns": include_turns,
+            }),
+        )?;
+        let thread_value = result.get("thread").ok_or(CodexAppServerError::Protocol {
+            code: "thread-missing",
+        })?;
+        let turn_count = thread_value
+            .get("turns")
+            .and_then(Value::as_array)
+            .map_or(0, Vec::len);
+        Ok(ThreadReadSummary {
+            thread: thread_summary_from_thread_value(thread_value)?,
+            turn_count,
+        })
+    }
+
+    pub fn send_turn_text(
+        &mut self,
+        thread_id: &str,
+        client_user_message_id: Option<&str>,
+        text: &str,
+    ) -> Result<TurnSummary, CodexAppServerError> {
+        let result = self.call(
+            "turn/start",
+            json!({
+                "threadId": thread_id,
+                "clientUserMessageId": client_user_message_id,
+                "input": [
+                    {
+                        "type": "text",
+                        "text": text,
+                    }
+                ],
+            }),
+        )?;
+        turn_summary_from_response(thread_id, &result)
+    }
+
+    pub fn steer_turn_text(
+        &mut self,
+        thread_id: &str,
+        expected_turn_id: &str,
+        client_user_message_id: Option<&str>,
+        text: &str,
+    ) -> Result<InterruptSummary, CodexAppServerError> {
+        let result = self.call(
+            "turn/steer",
+            json!({
+                "threadId": thread_id,
+                "expectedTurnId": expected_turn_id,
+                "clientUserMessageId": client_user_message_id,
+                "input": [
+                    {
+                        "type": "text",
+                        "text": text,
+                    }
+                ],
+            }),
+        )?;
+        let turn_id = required_string(&result, "turnId")?;
+        Ok(InterruptSummary {
+            thread_id: thread_id.to_string(),
+            turn_id,
+        })
+    }
+
+    pub fn interrupt_turn(
+        &mut self,
+        thread_id: &str,
+        turn_id: &str,
+    ) -> Result<InterruptSummary, CodexAppServerError> {
+        self.call(
+            "turn/interrupt",
+            json!({
+                "threadId": thread_id,
+                "turnId": turn_id,
+            }),
+        )?;
+        Ok(InterruptSummary {
+            thread_id: thread_id.to_string(),
+            turn_id: turn_id.to_string(),
+        })
+    }
+
     fn call(&mut self, method: &str, params: Value) -> Result<Value, CodexAppServerError> {
         let id = self.next_id;
         self.next_id += 1;
@@ -351,6 +532,163 @@ fn required_string(value: &Value, field: &'static str) -> Result<String, CodexAp
         .and_then(Value::as_str)
         .map(ToString::to_string)
         .ok_or(CodexAppServerError::Protocol { code: field })
+}
+
+fn optional_string(value: &Value, field: &str) -> Option<String> {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+}
+
+fn status_string(value: &Value) -> Option<String> {
+    match value.get("status") {
+        Some(Value::String(s)) => Some(s.clone()),
+        Some(Value::Object(map)) => map
+            .get("type")
+            .and_then(Value::as_str)
+            .map(ToString::to_string),
+        _ => None,
+    }
+}
+
+fn thread_summary_from_response(value: &Value) -> Result<ThreadSummary, CodexAppServerError> {
+    let thread = value.get("thread").ok_or(CodexAppServerError::Protocol {
+        code: "thread-missing",
+    })?;
+    thread_summary_from_thread_value(thread)
+}
+
+fn thread_summary_from_thread_value(value: &Value) -> Result<ThreadSummary, CodexAppServerError> {
+    Ok(ThreadSummary {
+        thread_id: required_string(value, "id")?,
+        session_id: optional_string(value, "sessionId"),
+        status: status_string(value),
+        preview: optional_string(value, "preview"),
+    })
+}
+
+fn turn_summary_from_response(
+    thread_id: &str,
+    value: &Value,
+) -> Result<TurnSummary, CodexAppServerError> {
+    let turn = value.get("turn").ok_or(CodexAppServerError::Protocol {
+        code: "turn-missing",
+    })?;
+    Ok(TurnSummary {
+        thread_id: thread_id.to_string(),
+        turn_id: required_string(turn, "id")?,
+        status: status_string(turn),
+        item_count: turn
+            .get("items")
+            .and_then(Value::as_array)
+            .map_or(0, Vec::len),
+    })
+}
+
+pub fn map_server_message_to_provider_event(
+    context: &ProviderMirrorContext,
+    message: &JsonRpcServerMessage,
+    observed_at: i64,
+    mirror_seq: u64,
+) -> Result<Option<ProviderSessionEvent>, CodexAppServerError> {
+    let method = message.method.as_str();
+    let (event_kind, transcript_item_kind) = match method {
+        "thread/started" => ("thread_started", "thread"),
+        "thread/status/changed" => ("thread_status_changed", "thread"),
+        "thread/tokenUsage/updated" => ("token_usage_updated", "token_usage"),
+        "turn/started" => ("turn_started", "turn"),
+        "turn/completed" => ("turn_completed", "turn"),
+        "turn/diff/updated" => ("turn_diff_updated", "diff"),
+        "item/started" => ("item_started", "item"),
+        "item/completed" => ("item_completed", "item"),
+        "item/agentMessage/delta" => ("agent_message_delta", "agent_message"),
+        "item/plan/delta" => ("plan_delta", "plan"),
+        "command/exec/outputDelta" | "item/commandExecution/outputDelta" => {
+            ("command_output_delta", "command_execution")
+        }
+        "item/fileChange/outputDelta" => ("file_change_output_delta", "file_change"),
+        "item/commandExecution/requestApproval" => ("approval_requested", "approval"),
+        "item/fileChange/requestApproval" => ("approval_requested", "approval"),
+        "item/permissions/requestApproval" => ("approval_requested", "approval"),
+        "item/tool/requestUserInput" => ("user_input_requested", "user_input"),
+        "mcpServer/elicitation/request" => ("user_input_requested", "user_input"),
+        _ => ("provider_event_unmapped", "provider_event"),
+    };
+    if method == "error" {
+        return Ok(None);
+    }
+
+    let thread_id = extract_thread_id(&message.params)?;
+    let turn_id = extract_optional_string(&message.params, "turnId")
+        .or_else(|| {
+            message
+                .params
+                .get("turn")
+                .and_then(|turn| extract_optional_string(turn, "id"))
+        })
+        .unwrap_or_else(|| "no-turn".to_string());
+    let item_id = extract_optional_string(&message.params, "itemId")
+        .or_else(|| {
+            message
+                .params
+                .get("item")
+                .and_then(|item| extract_optional_string(item, "id"))
+        })
+        .unwrap_or_else(|| "no-item".to_string());
+    let approval_ref = if event_kind == "approval_requested" || event_kind == "user_input_requested"
+    {
+        Some(format!(
+            "codex:{}:{}:{}:{}:{}",
+            method,
+            thread_id,
+            turn_id,
+            item_id,
+            extract_optional_string(&message.params, "approvalId")
+                .unwrap_or_else(|| "default".to_string())
+        ))
+    } else {
+        None
+    };
+
+    Ok(Some(ProviderSessionEvent {
+        friday_session_id: context.friday_session_id.clone(),
+        provider_event_id: format!(
+            "codex:{}:{}:{}:{}:{}",
+            method, thread_id, turn_id, item_id, mirror_seq
+        ),
+        provider: context.provider.clone(),
+        event_kind: event_kind.to_string(),
+        transcript_item_kind: transcript_item_kind.to_string(),
+        body_ref: format!(
+            "codex://provider-event/{}/{}/{}",
+            context.friday_session_id,
+            mirror_seq,
+            method.replace('/', ".")
+        ),
+        redaction_level: "metadata_only".to_string(),
+        token_ledger_ref: None,
+        approval_ref,
+        audit_receipt_ref: None,
+        observed_at,
+    }))
+}
+
+fn extract_thread_id(params: &Value) -> Result<String, CodexAppServerError> {
+    extract_optional_string(params, "threadId")
+        .or_else(|| {
+            params
+                .get("thread")
+                .and_then(|thread| extract_optional_string(thread, "id"))
+        })
+        .ok_or(CodexAppServerError::Protocol { code: "thread-id" })
+}
+
+fn extract_optional_string(value: &Value, field: &str) -> Option<String> {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
 }
 
 #[derive(Debug, Default)]
@@ -528,6 +866,166 @@ mod tests {
             calls.iter().all(|c| c.method != "turn/start"),
             "PNS-002 health must not start a model turn"
         );
+    }
+
+    fn thread(id: &str, status: Value, turns: Value) -> Value {
+        json!({
+            "id": id,
+            "sessionId": "session-1",
+            "status": status,
+            "preview": "Friday test",
+            "turns": turns,
+        })
+    }
+
+    fn turn(id: &str, status: &str, items: Value) -> Value {
+        json!({
+            "id": id,
+            "status": status,
+            "items": items,
+        })
+    }
+
+    #[test]
+    fn thread_and_turn_control_methods_use_app_server_not_cli_send() {
+        let transport = MockCodexAppServerTransport::new(vec![
+            ok(json!({"thread": thread("thread-1", json!({"type":"idle"}), json!([]))})),
+            ok(
+                json!({"thread": thread("thread-1", json!({"type":"active","activeFlags":[]}), json!([]))}),
+            ),
+            ok(json!({"turn": turn("turn-1", "inProgress", json!([]))})),
+            ok(json!({"turnId": "turn-1"})),
+            ok(json!({})),
+            ok(
+                json!({"thread": thread("thread-1", json!({"type":"idle"}), json!([turn("turn-1", "completed", json!([]))]))}),
+            ),
+        ]);
+        let mut client = CodexAppServerClient::new(transport);
+        assert_eq!(
+            client
+                .start_thread(Some("/tmp/friday"), Some("gpt-5"))
+                .unwrap()
+                .thread_id,
+            "thread-1"
+        );
+        assert_eq!(
+            client.resume_thread("thread-1").unwrap().status.as_deref(),
+            Some("active")
+        );
+        let turn = client
+            .send_turn_text("thread-1", Some("client-msg-1"), "ping")
+            .unwrap();
+        assert_eq!(turn.turn_id, "turn-1");
+        assert_eq!(
+            client
+                .steer_turn_text("thread-1", "turn-1", Some("client-msg-2"), "more")
+                .unwrap()
+                .turn_id,
+            "turn-1"
+        );
+        client.interrupt_turn("thread-1", "turn-1").unwrap();
+        assert_eq!(client.read_thread("thread-1", true).unwrap().turn_count, 1);
+
+        let transport = client.into_transport();
+        let methods: Vec<&str> = transport
+            .calls()
+            .iter()
+            .map(|c| c.method.as_str())
+            .collect();
+        assert_eq!(
+            methods,
+            vec![
+                "thread/start",
+                "thread/resume",
+                "turn/start",
+                "turn/steer",
+                "turn/interrupt",
+                "thread/read",
+            ]
+        );
+        let calls = transport.calls();
+        assert_eq!(calls[0].params.get("threadSource"), Some(&Value::Null));
+        assert_eq!(
+            calls[2].params.get("input"),
+            Some(&json!([
+                {
+                    "type": "text",
+                    "text": "ping",
+                }
+            ]))
+        );
+    }
+
+    #[test]
+    fn server_notifications_map_to_friday_provider_events_without_raw_body() {
+        let context = ProviderMirrorContext::codex("friday-session-1");
+        let msg = JsonRpcServerMessage {
+            id: None,
+            method: "item/agentMessage/delta".to_string(),
+            params: json!({
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "itemId": "item-1",
+                "delta": "secret transcript text must live behind a future blob ref",
+            }),
+        };
+        let event = map_server_message_to_provider_event(&context, &msg, 123, 7)
+            .unwrap()
+            .unwrap();
+        assert_eq!(event.event_kind, "agent_message_delta");
+        assert_eq!(event.transcript_item_kind, "agent_message");
+        assert_eq!(event.redaction_level, "metadata_only");
+        assert_eq!(event.approval_ref, None);
+        let debug = format!("{event:?}");
+        assert!(
+            !debug.contains("secret transcript text"),
+            "PNS-003 mirror event must not inline raw provider text: {debug}"
+        );
+    }
+
+    #[test]
+    fn approval_requests_map_to_needs_me_ready_event_refs() {
+        let context = ProviderMirrorContext::codex("friday-session-1");
+        let msg = JsonRpcServerMessage {
+            id: Some(json!(99)),
+            method: "item/commandExecution/requestApproval".to_string(),
+            params: json!({
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "itemId": "item-approval",
+                "approvalId": "approval-1",
+                "command": "rm -rf /private/project",
+                "startedAtMs": 123000,
+            }),
+        };
+        let event = map_server_message_to_provider_event(&context, &msg, 123, 8)
+            .unwrap()
+            .unwrap();
+        assert_eq!(event.event_kind, "approval_requested");
+        assert_eq!(event.transcript_item_kind, "approval");
+        assert_eq!(
+            event.approval_ref.as_deref(),
+            Some("codex:item/commandExecution/requestApproval:thread-1:turn-1:item-approval:approval-1")
+        );
+        let debug = format!("{event:?}");
+        assert!(
+            !debug.contains("rm -rf"),
+            "approval event must not inline raw command text before a future redacted body store"
+        );
+    }
+
+    #[test]
+    fn recognized_events_missing_thread_id_fail_closed() {
+        let context = ProviderMirrorContext::codex("friday-session-1");
+        let msg = JsonRpcServerMessage {
+            id: None,
+            method: "turn/started".to_string(),
+            params: json!({"turn": turn("turn-1", "inProgress", json!([]))}),
+        };
+        assert!(matches!(
+            map_server_message_to_provider_event(&context, &msg, 123, 9),
+            Err(CodexAppServerError::Protocol { code: "thread-id" })
+        ));
     }
 
     #[test]

--- a/rust-core/crates/friday-providers/src/codex_appserver.rs
+++ b/rust-core/crates/friday-providers/src/codex_appserver.rs
@@ -1,0 +1,550 @@
+//! Codex App Server protocol harness — PNS-002.
+//!
+//! Scope: schema/method drift checks and JSON-RPC transport plumbing only. This
+//! module does not start a model turn, does not call `codex exec`, and does not
+//! claim official ChatGPT/Codex same-account history sync. It is the safe
+//! foundation for later PNS-003 thread/turn control.
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::collections::{BTreeSet, VecDeque};
+use std::io::{BufRead, BufReader, Read, Write};
+use std::path::Path;
+use thiserror::Error;
+
+pub const CODEX_APP_SERVER_SYNC_MODE: &str = "provider_app_server_local";
+pub const CODEX_APP_SERVER_CLI_VERSION: &str = "codex-cli 0.136.0";
+
+pub const REQUIRED_CLIENT_METHODS: &[&str] = &[
+    "initialize",
+    "thread/list",
+    "thread/read",
+    "thread/start",
+    "thread/resume",
+    "thread/fork",
+    "thread/archive",
+    "thread/unarchive",
+    "thread/name/set",
+    "thread/metadata/update",
+    "thread/compact/start",
+    "thread/rollback",
+    "thread/inject_items",
+    "turn/start",
+    "turn/steer",
+    "turn/interrupt",
+];
+
+pub const REQUIRED_SERVER_REQUEST_METHODS: &[&str] = &[
+    "item/commandExecution/requestApproval",
+    "item/fileChange/requestApproval",
+    "item/permissions/requestApproval",
+    "item/tool/requestUserInput",
+];
+
+pub const REQUIRED_SERVER_NOTIFICATION_METHODS: &[&str] = &[
+    "thread/started",
+    "thread/status/changed",
+    "thread/tokenUsage/updated",
+    "turn/started",
+    "turn/completed",
+    "turn/diff/updated",
+    "item/started",
+    "item/completed",
+    "item/agentMessage/delta",
+    "item/commandExecution/outputDelta",
+    "item/fileChange/outputDelta",
+];
+
+#[derive(Debug, Error)]
+pub enum CodexAppServerError {
+    #[error("codex app-server transport failed: {code}")]
+    Transport { code: &'static str },
+
+    #[error("codex app-server protocol error: {code}")]
+    Protocol { code: &'static str },
+
+    #[error("codex app-server schema drift: missing required methods")]
+    SchemaDrift,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InitializeSummary {
+    pub platform_family: String,
+    pub platform_os: String,
+    pub user_agent: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ThreadListProbe {
+    pub item_count: usize,
+    pub has_next_cursor: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HealthSummary {
+    pub initialized: InitializeSummary,
+    pub thread_list: ThreadListProbe,
+    pub sync_mode: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CodexAppServerSchemaMethods {
+    pub client_requests: BTreeSet<String>,
+    pub server_requests: BTreeSet<String>,
+    pub server_notifications: BTreeSet<String>,
+}
+
+impl CodexAppServerSchemaMethods {
+    pub fn from_generated_bundle_dir(path: impl AsRef<Path>) -> Result<Self, CodexAppServerError> {
+        let path = path.as_ref();
+        Ok(Self {
+            client_requests: extract_methods_from_schema_file(path.join("ClientRequest.json"))?,
+            server_requests: extract_methods_from_schema_file(path.join("ServerRequest.json"))?,
+            server_notifications: extract_methods_from_schema_file(
+                path.join("ServerNotification.json"),
+            )?,
+        })
+    }
+
+    pub fn assert_required_surface(&self) -> Result<(), CodexAppServerError> {
+        if has_all(&self.client_requests, REQUIRED_CLIENT_METHODS)
+            && has_all(&self.server_requests, REQUIRED_SERVER_REQUEST_METHODS)
+            && has_all(
+                &self.server_notifications,
+                REQUIRED_SERVER_NOTIFICATION_METHODS,
+            )
+        {
+            Ok(())
+        } else {
+            Err(CodexAppServerError::SchemaDrift)
+        }
+    }
+}
+
+fn has_all(actual: &BTreeSet<String>, required: &[&str]) -> bool {
+    required.iter().all(|m| actual.contains(*m))
+}
+
+fn extract_methods_from_schema_file(
+    path: impl AsRef<Path>,
+) -> Result<BTreeSet<String>, CodexAppServerError> {
+    let bytes = std::fs::read(path).map_err(|_| CodexAppServerError::Transport {
+        code: "schema-file-read",
+    })?;
+    let value: Value =
+        serde_json::from_slice(&bytes).map_err(|_| CodexAppServerError::Protocol {
+            code: "schema-json",
+        })?;
+    let mut methods = BTreeSet::new();
+    collect_method_enums(&value, &mut methods);
+    Ok(methods)
+}
+
+fn collect_method_enums(value: &Value, out: &mut BTreeSet<String>) {
+    match value {
+        Value::Object(map) => {
+            if let Some(method) = map.get("method").and_then(Value::as_object) {
+                if let Some(values) = method.get("enum").and_then(Value::as_array) {
+                    for item in values {
+                        if let Some(s) = item.as_str() {
+                            out.insert(s.to_string());
+                        }
+                    }
+                }
+            }
+            for v in map.values() {
+                collect_method_enums(v, out);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_method_enums(item, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct JsonRpcRequest {
+    pub id: u64,
+    pub method: String,
+    #[serde(default)]
+    pub params: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct JsonRpcResponse {
+    #[serde(default)]
+    pub id: Option<Value>,
+    #[serde(default)]
+    pub result: Option<Value>,
+    #[serde(default)]
+    pub error: Option<JsonRpcErrorEnvelope>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct JsonRpcErrorEnvelope {
+    pub code: i64,
+    #[serde(default)]
+    pub message: Option<String>,
+}
+
+pub trait CodexAppServerTransport {
+    fn request(&mut self, request: JsonRpcRequest) -> Result<JsonRpcResponse, CodexAppServerError>;
+}
+
+pub struct JsonLineTransport<R, W> {
+    reader: BufReader<R>,
+    writer: W,
+}
+
+impl<R: Read, W: Write> JsonLineTransport<R, W> {
+    pub fn new(reader: R, writer: W) -> Self {
+        Self {
+            reader: BufReader::new(reader),
+            writer,
+        }
+    }
+
+    pub fn into_parts(self) -> (BufReader<R>, W) {
+        (self.reader, self.writer)
+    }
+}
+
+impl<R: Read, W: Write> CodexAppServerTransport for JsonLineTransport<R, W> {
+    fn request(&mut self, request: JsonRpcRequest) -> Result<JsonRpcResponse, CodexAppServerError> {
+        let encoded = serde_json::to_vec(&request).map_err(|_| CodexAppServerError::Protocol {
+            code: "request-encode",
+        })?;
+        self.writer
+            .write_all(&encoded)
+            .and_then(|_| self.writer.write_all(b"\n"))
+            .and_then(|_| self.writer.flush())
+            .map_err(|_| CodexAppServerError::Transport {
+                code: "request-write",
+            })?;
+
+        let mut line = String::new();
+        let read =
+            self.reader
+                .read_line(&mut line)
+                .map_err(|_| CodexAppServerError::Transport {
+                    code: "response-read",
+                })?;
+        if read == 0 {
+            return Err(CodexAppServerError::Transport {
+                code: "response-eof",
+            });
+        }
+        serde_json::from_str(&line).map_err(|_| CodexAppServerError::Protocol {
+            code: "response-json",
+        })
+    }
+}
+
+pub struct CodexAppServerClient<T> {
+    transport: T,
+    next_id: u64,
+}
+
+impl<T: CodexAppServerTransport> CodexAppServerClient<T> {
+    pub fn new(transport: T) -> Self {
+        Self {
+            transport,
+            next_id: 1,
+        }
+    }
+
+    pub fn into_transport(self) -> T {
+        self.transport
+    }
+
+    pub fn initialize(
+        &mut self,
+        client_name: &str,
+        client_version: &str,
+    ) -> Result<InitializeSummary, CodexAppServerError> {
+        let result = self.call(
+            "initialize",
+            json!({
+                "clientInfo": {
+                    "name": client_name,
+                    "title": "Friday Hub",
+                    "version": client_version,
+                },
+                "capabilities": {
+                    "experimentalApi": false,
+                    "requestAttestation": false,
+                    "optOutNotificationMethods": null,
+                }
+            }),
+        )?;
+        Ok(InitializeSummary {
+            platform_family: required_string(&result, "platformFamily")?,
+            platform_os: required_string(&result, "platformOs")?,
+            user_agent: required_string(&result, "userAgent")?,
+        })
+    }
+
+    /// Non-model health probe. `thread/list` is a metadata read; it must not be
+    /// used as proof of a model send or official provider-history sync.
+    pub fn thread_list_probe(&mut self) -> Result<ThreadListProbe, CodexAppServerError> {
+        let result = self.call(
+            "thread/list",
+            json!({
+                "limit": 1,
+                "archived": false,
+                "useStateDbOnly": true,
+            }),
+        )?;
+        let item_count = result
+            .get("data")
+            .and_then(Value::as_array)
+            .ok_or(CodexAppServerError::Protocol {
+                code: "thread-list-data",
+            })?
+            .len();
+        let has_next_cursor = result.get("nextCursor").is_some_and(|v| !v.is_null());
+        Ok(ThreadListProbe {
+            item_count,
+            has_next_cursor,
+        })
+    }
+
+    pub fn health_check(
+        &mut self,
+        client_name: &str,
+        client_version: &str,
+    ) -> Result<HealthSummary, CodexAppServerError> {
+        let initialized = self.initialize(client_name, client_version)?;
+        let thread_list = self.thread_list_probe()?;
+        Ok(HealthSummary {
+            initialized,
+            thread_list,
+            sync_mode: CODEX_APP_SERVER_SYNC_MODE,
+        })
+    }
+
+    fn call(&mut self, method: &str, params: Value) -> Result<Value, CodexAppServerError> {
+        let id = self.next_id;
+        self.next_id += 1;
+        let response = self.transport.request(JsonRpcRequest {
+            id,
+            method: method.to_string(),
+            params,
+        })?;
+        if response.error.is_some() {
+            return Err(CodexAppServerError::Protocol {
+                code: "server-error",
+            });
+        }
+        response.result.ok_or(CodexAppServerError::Protocol {
+            code: "missing-result",
+        })
+    }
+}
+
+fn required_string(value: &Value, field: &'static str) -> Result<String, CodexAppServerError> {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+        .ok_or(CodexAppServerError::Protocol { code: field })
+}
+
+#[derive(Debug, Default)]
+pub struct MockCodexAppServerTransport {
+    responses: VecDeque<Result<JsonRpcResponse, CodexAppServerError>>,
+    calls: Vec<JsonRpcRequest>,
+}
+
+impl MockCodexAppServerTransport {
+    pub fn new(responses: Vec<Result<JsonRpcResponse, CodexAppServerError>>) -> Self {
+        Self {
+            responses: responses.into(),
+            calls: Vec::new(),
+        }
+    }
+
+    pub fn calls(&self) -> &[JsonRpcRequest] {
+        &self.calls
+    }
+}
+
+impl CodexAppServerTransport for MockCodexAppServerTransport {
+    fn request(&mut self, request: JsonRpcRequest) -> Result<JsonRpcResponse, CodexAppServerError> {
+        self.calls.push(request);
+        self.responses
+            .pop_front()
+            .unwrap_or(Err(CodexAppServerError::Transport { code: "mock-empty" }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn ok(result: Value) -> Result<JsonRpcResponse, CodexAppServerError> {
+        Ok(JsonRpcResponse {
+            id: Some(json!(1)),
+            result: Some(result),
+            error: None,
+        })
+    }
+
+    fn temp_schema_dir() -> std::path::PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "friday-codex-schema-fixture-{}-{nanos}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn schema_with_methods(methods: &[&str]) -> String {
+        let one_of = methods
+            .iter()
+            .map(|m| {
+                json!({
+                    "type": "object",
+                    "required": ["id", "method", "params"],
+                    "properties": {
+                        "id": { "type": "integer" },
+                        "method": { "type": "string", "enum": [m] },
+                        "params": true
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+        json!({ "oneOf": one_of }).to_string()
+    }
+
+    #[test]
+    fn required_method_surface_is_present_in_pinned_schema_fixture() {
+        let dir = temp_schema_dir();
+        std::fs::write(
+            dir.join("ClientRequest.json"),
+            schema_with_methods(REQUIRED_CLIENT_METHODS),
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("ServerRequest.json"),
+            schema_with_methods(REQUIRED_SERVER_REQUEST_METHODS),
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("ServerNotification.json"),
+            schema_with_methods(REQUIRED_SERVER_NOTIFICATION_METHODS),
+        )
+        .unwrap();
+
+        let methods = CodexAppServerSchemaMethods::from_generated_bundle_dir(&dir).unwrap();
+        methods.assert_required_surface().unwrap();
+    }
+
+    #[test]
+    fn schema_drift_missing_thread_turn_methods_fails_closed() {
+        let dir = temp_schema_dir();
+        std::fs::write(
+            dir.join("ClientRequest.json"),
+            schema_with_methods(&["initialize"]),
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("ServerRequest.json"),
+            schema_with_methods(REQUIRED_SERVER_REQUEST_METHODS),
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("ServerNotification.json"),
+            schema_with_methods(REQUIRED_SERVER_NOTIFICATION_METHODS),
+        )
+        .unwrap();
+
+        let methods = CodexAppServerSchemaMethods::from_generated_bundle_dir(&dir).unwrap();
+        assert!(matches!(
+            methods.assert_required_surface(),
+            Err(CodexAppServerError::SchemaDrift)
+        ));
+    }
+
+    #[test]
+    fn json_line_transport_writes_request_and_reads_response() {
+        let response = br#"{"id":1,"result":{"platformFamily":"unix","platformOs":"macos","userAgent":"codex-test"}}
+"#;
+        let writer = Vec::<u8>::new();
+        let mut transport = JsonLineTransport::new(&response[..], writer);
+        let out = transport
+            .request(JsonRpcRequest {
+                id: 1,
+                method: "initialize".to_string(),
+                params: json!({"clientInfo":{"name":"friday","version":"0"}}),
+            })
+            .unwrap();
+        assert!(out.error.is_none());
+        assert_eq!(
+            out.result.unwrap().get("userAgent").and_then(Value::as_str),
+            Some("codex-test")
+        );
+        let (_reader, writer) = transport.into_parts();
+        let written = String::from_utf8(writer).unwrap();
+        assert!(written.contains("\"method\":\"initialize\""));
+        assert!(written.ends_with('\n'));
+    }
+
+    #[test]
+    fn health_check_uses_initialize_then_thread_list_without_turn_start() {
+        let transport = MockCodexAppServerTransport::new(vec![
+            ok(json!({
+                "codexHome": "/tmp/codex",
+                "platformFamily": "unix",
+                "platformOs": "macos",
+                "userAgent": "codex-cli 0.136.0",
+            })),
+            ok(json!({
+                "data": [],
+                "nextCursor": null,
+                "backwardsCursor": null,
+            })),
+        ]);
+        let mut client = CodexAppServerClient::new(transport);
+        let summary = client.health_check("friday", "0.0.1").unwrap();
+        assert_eq!(summary.sync_mode, CODEX_APP_SERVER_SYNC_MODE);
+        assert_eq!(summary.initialized.platform_os, "macos");
+        assert_eq!(summary.thread_list.item_count, 0);
+
+        let transport = client.into_transport();
+        let calls = transport.calls();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].method, "initialize");
+        assert_eq!(calls[1].method, "thread/list");
+        assert!(
+            calls.iter().all(|c| c.method != "turn/start"),
+            "PNS-002 health must not start a model turn"
+        );
+    }
+
+    #[test]
+    fn protocol_error_is_label_only_and_fails_health() {
+        let transport = MockCodexAppServerTransport::new(vec![Ok(JsonRpcResponse {
+            id: Some(json!(1)),
+            result: None,
+            error: Some(JsonRpcErrorEnvelope {
+                code: -32000,
+                message: Some("raw provider text must not be surfaced".to_string()),
+            }),
+        })]);
+        let mut client = CodexAppServerClient::new(transport);
+        let err = client.health_check("friday", "0.0.1").unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "codex app-server protocol error: server-error"
+        );
+    }
+}

--- a/rust-core/crates/friday-providers/src/codex_appserver.rs
+++ b/rust-core/crates/friday-providers/src/codex_appserver.rs
@@ -83,6 +83,12 @@ pub struct ThreadListProbe {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ThreadListSummary {
+    pub threads: Vec<ThreadSummary>,
+    pub has_next_cursor: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HealthSummary {
     pub initialized: InitializeSummary,
     pub thread_list: ThreadListProbe,
@@ -268,7 +274,14 @@ impl<R: Read, W: Write> JsonLineTransport<R, W> {
 
 impl<R: Read, W: Write> CodexAppServerTransport for JsonLineTransport<R, W> {
     fn request(&mut self, request: JsonRpcRequest) -> Result<JsonRpcResponse, CodexAppServerError> {
-        let encoded = serde_json::to_vec(&request).map_err(|_| CodexAppServerError::Protocol {
+        let request_id = request.id;
+        let encoded = serde_json::to_vec(&json!({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": request.method,
+            "params": request.params,
+        }))
+        .map_err(|_| CodexAppServerError::Protocol {
             code: "request-encode",
         })?;
         self.writer
@@ -279,21 +292,41 @@ impl<R: Read, W: Write> CodexAppServerTransport for JsonLineTransport<R, W> {
                 code: "request-write",
             })?;
 
-        let mut line = String::new();
-        let read =
-            self.reader
-                .read_line(&mut line)
-                .map_err(|_| CodexAppServerError::Transport {
-                    code: "response-read",
+        loop {
+            let mut line = String::new();
+            let read =
+                self.reader
+                    .read_line(&mut line)
+                    .map_err(|_| CodexAppServerError::Transport {
+                        code: "response-read",
+                    })?;
+            if read == 0 {
+                return Err(CodexAppServerError::Transport {
+                    code: "response-eof",
+                });
+            }
+            let value: Value =
+                serde_json::from_str(&line).map_err(|_| CodexAppServerError::Protocol {
+                    code: "response-json",
                 })?;
-        if read == 0 {
-            return Err(CodexAppServerError::Transport {
-                code: "response-eof",
-            });
+            match value.get("id") {
+                Some(id) if id == &json!(request_id) => {
+                    return serde_json::from_value(value).map_err(|_| {
+                        CodexAppServerError::Protocol {
+                            code: "response-json",
+                        }
+                    });
+                }
+                Some(_) => {
+                    return Err(CodexAppServerError::Protocol {
+                        code: "interleaved-server-request",
+                    });
+                }
+                None => {
+                    continue;
+                }
+            }
         }
-        serde_json::from_str(&line).map_err(|_| CodexAppServerError::Protocol {
-            code: "response-json",
-        })
     }
 }
 
@@ -344,24 +377,40 @@ impl<T: CodexAppServerTransport> CodexAppServerClient<T> {
     /// Non-model health probe. `thread/list` is a metadata read; it must not be
     /// used as proof of a model send or official provider-history sync.
     pub fn thread_list_probe(&mut self) -> Result<ThreadListProbe, CodexAppServerError> {
+        let list = self.list_threads(1, true)?;
+        Ok(ThreadListProbe {
+            item_count: list.threads.len(),
+            has_next_cursor: list.has_next_cursor,
+        })
+    }
+
+    pub fn list_threads(
+        &mut self,
+        limit: u64,
+        use_state_db_only: bool,
+    ) -> Result<ThreadListSummary, CodexAppServerError> {
         let result = self.call(
             "thread/list",
             json!({
-                "limit": 1,
+                "limit": limit,
                 "archived": false,
-                "useStateDbOnly": true,
+                "useStateDbOnly": use_state_db_only,
             }),
         )?;
-        let item_count = result
-            .get("data")
-            .and_then(Value::as_array)
-            .ok_or(CodexAppServerError::Protocol {
-                code: "thread-list-data",
-            })?
-            .len();
+        let data =
+            result
+                .get("data")
+                .and_then(Value::as_array)
+                .ok_or(CodexAppServerError::Protocol {
+                    code: "thread-list-data",
+                })?;
+        let threads = data
+            .iter()
+            .map(thread_summary_from_thread_value)
+            .collect::<Result<Vec<_>, _>>()?;
         let has_next_cursor = result.get("nextCursor").is_some_and(|v| !v.is_null());
-        Ok(ThreadListProbe {
-            item_count,
+        Ok(ThreadListSummary {
+            threads,
             has_next_cursor,
         })
     }
@@ -832,8 +881,28 @@ mod tests {
         );
         let (_reader, writer) = transport.into_parts();
         let written = String::from_utf8(writer).unwrap();
+        assert!(written.contains("\"jsonrpc\":\"2.0\""));
         assert!(written.contains("\"method\":\"initialize\""));
         assert!(written.ends_with('\n'));
+    }
+
+    #[test]
+    fn json_line_transport_skips_notifications_until_matching_response() {
+        let response = br#"{"method":"remoteControl/status/changed","params":{"status":"disabled"}}
+{"id":1,"result":{"platformFamily":"unix","platformOs":"macos","userAgent":"codex-test"}}
+"#;
+        let mut transport = JsonLineTransport::new(&response[..], Vec::<u8>::new());
+        let out = transport
+            .request(JsonRpcRequest {
+                id: 1,
+                method: "initialize".to_string(),
+                params: json!({}),
+            })
+            .unwrap();
+        assert_eq!(
+            out.result.unwrap().get("userAgent").and_then(Value::as_str),
+            Some("codex-test")
+        );
     }
 
     #[test]
@@ -865,6 +934,27 @@ mod tests {
         assert!(
             calls.iter().all(|c| c.method != "turn/start"),
             "PNS-002 health must not start a model turn"
+        );
+    }
+
+    #[test]
+    fn list_threads_projects_thread_summaries_without_turns() {
+        let transport = MockCodexAppServerTransport::new(vec![ok(json!({
+            "data": [
+                thread("thread-1", json!({"type":"notLoaded"}), json!([])),
+            ],
+            "nextCursor": "cursor-2",
+        }))]);
+        let mut client = CodexAppServerClient::new(transport);
+        let list = client.list_threads(1, true).unwrap();
+        assert_eq!(list.threads[0].thread_id, "thread-1");
+        assert_eq!(list.threads[0].status.as_deref(), Some("notLoaded"));
+        assert!(list.has_next_cursor);
+        let transport = client.into_transport();
+        assert_eq!(transport.calls()[0].method, "thread/list");
+        assert_eq!(
+            transport.calls()[0].params.get("useStateDbOnly"),
+            Some(&json!(true))
         );
     }
 

--- a/rust-core/crates/friday-providers/src/lib.rs
+++ b/rust-core/crates/friday-providers/src/lib.rs
@@ -1,5 +1,4 @@
-//! Codex/Claude provider adapters — Unit 6/7 **auth-readiness detection**
-//! (`04` §2/§3/§4.5; `31-PROVIDER-AUTH-READINESS`).
+//! Codex/Claude provider adapters — Hub-only provider control surfaces.
 //!
 //! This is the first required provider capability: detect whether each provider
 //! CLI is installed and authenticated. It runs ONLY each provider's official,
@@ -8,10 +7,10 @@
 //! Provider credentials live in the CLIs' own Hub-side config; this crate reads
 //! only boolean auth signals and never surfaces account email/org/tokens.
 //!
-//! Scope: auth-readiness detection only. Session control (list/open/send/stop/
-//! approve), transcript streaming, and post-login Friday smoke — which DO consume
-//! the account — are later Unit 6/7 slices, not implemented here. No fallback:
-//! a failed/absent provider is truth-labeled, never substituted.
+//! Scope: auth-readiness detection, Codex app-server contract plumbing, and
+//! Claude control-surface truth labels. Live model turns and post-login Friday
+//! smoke consume the account and remain separately gated. No fallback: a failed
+//! or absent provider is truth-labeled, never substituted.
 //!
 //! Hub-only: must stay OUT of `friday-ffi`'s (phone) dependency graph
 //! (asserted by `friday-arch-tests`).
@@ -19,6 +18,7 @@
 use std::process::Command;
 use thiserror::Error;
 
+pub mod claude_control;
 pub mod codex_appserver;
 pub mod session;
 pub use session::{send_to_provider, CliSession, MockSession, SessionOutcome, SessionRunner};

--- a/rust-core/crates/friday-providers/src/lib.rs
+++ b/rust-core/crates/friday-providers/src/lib.rs
@@ -21,6 +21,7 @@ use thiserror::Error;
 pub mod claude_control;
 pub mod codex_appserver;
 pub mod session;
+pub mod unified;
 pub use session::{send_to_provider, CliSession, MockSession, SessionOutcome, SessionRunner};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/rust-core/crates/friday-providers/src/lib.rs
+++ b/rust-core/crates/friday-providers/src/lib.rs
@@ -19,6 +19,7 @@
 use std::process::Command;
 use thiserror::Error;
 
+pub mod codex_appserver;
 pub mod session;
 pub use session::{send_to_provider, CliSession, MockSession, SessionOutcome, SessionRunner};
 

--- a/rust-core/crates/friday-providers/src/unified.rs
+++ b/rust-core/crates/friday-providers/src/unified.rs
@@ -9,7 +9,7 @@ use friday_core::SyncMode;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PlatformProvider {
     Codex,

--- a/rust-core/crates/friday-providers/src/unified.rs
+++ b/rust-core/crates/friday-providers/src/unified.rs
@@ -1,0 +1,607 @@
+//! Unified provider session surface — C-PR1.
+//!
+//! These are Hub-side, metadata-first types for rendering Codex and Claude in
+//! one Provider Workspace without pretending their native controls are the same.
+//! Raw transcript text, command bodies, files, account ids, tokens, and URLs
+//! stay behind `BodyRef`/`*_ref` handles owned by the Hub event store.
+
+use friday_core::SyncMode;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PlatformProvider {
+    Codex,
+    Claude,
+}
+
+impl PlatformProvider {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            PlatformProvider::Codex => "codex",
+            PlatformProvider::Claude => "claude",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProviderSyncMode {
+    ProviderNativeSynced,
+    ProviderAppServerLocal,
+    FridayLocalMirror,
+    ProviderNativeLinkOnly,
+    UnsupportedTruthLabeled,
+}
+
+impl ProviderSyncMode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            ProviderSyncMode::ProviderNativeSynced => "provider_native_synced",
+            ProviderSyncMode::ProviderAppServerLocal => "provider_app_server_local",
+            ProviderSyncMode::FridayLocalMirror => "friday_local_mirror",
+            ProviderSyncMode::ProviderNativeLinkOnly => "provider_native_link_only",
+            ProviderSyncMode::UnsupportedTruthLabeled => "unsupported_truth_labeled",
+        }
+    }
+}
+
+impl From<SyncMode> for ProviderSyncMode {
+    fn from(value: SyncMode) -> Self {
+        match value {
+            SyncMode::ProviderNativeSynced => ProviderSyncMode::ProviderNativeSynced,
+            SyncMode::ProviderAppServerLocal => ProviderSyncMode::ProviderAppServerLocal,
+            SyncMode::FridayLocalMirror => ProviderSyncMode::FridayLocalMirror,
+            SyncMode::ProviderNativeLinkOnly => ProviderSyncMode::ProviderNativeLinkOnly,
+            SyncMode::UnsupportedTruthLabeled => ProviderSyncMode::UnsupportedTruthLabeled,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionStatus {
+    Idle,
+    Running,
+    AwaitingApproval,
+    AwaitingUserInput,
+    Interrupted,
+    Completed,
+    Errored,
+    Disconnected,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FallbackStatus {
+    NoFallback,
+    UnavailableNoFallback,
+    FallbackDisabled,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RedactionLevel {
+    MetadataOnly,
+    RedactedPreview,
+    EncryptedBody,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BodyRef {
+    pub uri: String,
+    pub redaction_level: RedactionLevel,
+}
+
+impl BodyRef {
+    pub fn metadata(uri: impl Into<String>) -> Self {
+        Self {
+            uri: uri.into(),
+            redaction_level: RedactionLevel::MetadataOnly,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProviderSession {
+    pub friday_session_id: String,
+    pub provider: PlatformProvider,
+    pub workspace_id: String,
+    pub sync_mode: ProviderSyncMode,
+    pub status: SessionStatus,
+    pub capability_snapshot: Vec<ProviderCapability>,
+    pub active_turn_id: Option<String>,
+    pub last_event_seq: u64,
+    pub truth_label: String,
+    pub fallback_status: FallbackStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionEvent {
+    pub event_id: String,
+    pub provider: PlatformProvider,
+    pub friday_session_id: String,
+    pub provider_event_id: Option<String>,
+    pub seq: u64,
+    pub kind: SessionEventKind,
+    pub status: SessionStatus,
+    pub transcript_item: Option<TranscriptItem>,
+    pub tool_call: Option<ToolCall>,
+    pub approval_request: Option<ApprovalRequest>,
+    pub user_question: Option<UserQuestion>,
+    pub file_change: Option<FileChange>,
+    pub command_output: Option<CommandOutput>,
+    pub diff_summary: Option<DiffSummary>,
+    pub attachment: Option<Attachment>,
+    pub token_ledger_ref: Option<String>,
+    pub audit_receipt_ref: Option<String>,
+}
+
+impl SessionEvent {
+    pub fn needs_me(&self, priority: NeedsMePriority) -> Option<NeedsMeItem> {
+        let (kind, ref_id) = match (&self.approval_request, &self.user_question) {
+            (Some(approval), _) => (NeedsMeKind::Approval, approval.approval_ref.clone()),
+            (None, Some(question)) => (NeedsMeKind::UserQuestion, question.question_ref.clone()),
+            (None, None) => return None,
+        };
+
+        Some(NeedsMeItem {
+            item_id: format!("needs-me:{}:{}", self.friday_session_id, ref_id),
+            provider: self.provider,
+            friday_session_id: self.friday_session_id.clone(),
+            kind,
+            priority,
+            ref_id,
+            status: self.status,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionEventKind {
+    SessionStatus,
+    UserMessage,
+    AssistantMessage,
+    ToolCall,
+    ToolResult,
+    ApprovalRequested,
+    ApprovalResolved,
+    UserQuestion,
+    FileChange,
+    CommandOutput,
+    DiffUpdated,
+    Attachment,
+    TokenUsage,
+    ProviderError,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TranscriptRole {
+    User,
+    Assistant,
+    System,
+    Tool,
+    Provider,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TranscriptItem {
+    pub item_id: String,
+    pub role: TranscriptRole,
+    pub body_ref: BodyRef,
+    pub provider_item_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolCall {
+    pub tool_call_id: String,
+    pub tool_name: String,
+    pub input_ref: BodyRef,
+    pub risk_label: RiskLabel,
+    pub approval_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RiskLabel {
+    SafeRead,
+    NeedsApproval,
+    HighRisk,
+    Blocked,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ApprovalRequest {
+    pub approval_ref: String,
+    pub kind: ApprovalKind,
+    pub tool_call_id: Option<String>,
+    pub summary_ref: BodyRef,
+    pub risk_label: RiskLabel,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ApprovalKind {
+    CommandExecution,
+    FileChange,
+    Permissions,
+    Plan,
+    McpTool,
+    ProviderNative,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UserQuestion {
+    pub question_ref: String,
+    pub prompt_ref: BodyRef,
+    pub option_count: u16,
+    pub secret_answer_allowed: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FileChange {
+    pub file_change_ref: String,
+    pub path_ref: BodyRef,
+    pub summary_ref: BodyRef,
+    pub diff_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommandOutput {
+    pub command_ref: String,
+    pub stdout_ref: Option<BodyRef>,
+    pub stderr_ref: Option<BodyRef>,
+    pub exit_code: Option<i32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DiffSummary {
+    pub diff_ref: String,
+    pub files_changed: u32,
+    pub insertions: u32,
+    pub deletions: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Attachment {
+    pub attachment_ref: String,
+    pub mime_type: String,
+    pub redaction_level: RedactionLevel,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NeedsMeItem {
+    pub item_id: String,
+    pub provider: PlatformProvider,
+    pub friday_session_id: String,
+    pub kind: NeedsMeKind,
+    pub priority: NeedsMePriority,
+    pub ref_id: String,
+    pub status: SessionStatus,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NeedsMeKind {
+    Approval,
+    UserQuestion,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NeedsMePriority {
+    Low,
+    Normal,
+    High,
+    Critical,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProviderCapability {
+    pub capability_id: String,
+    pub provider: PlatformProvider,
+    pub status: CapabilityStatus,
+    pub sync_mode: ProviderSyncMode,
+    pub truth_label: String,
+    pub blocker: Option<String>,
+    pub proof_ref: Option<String>,
+    pub native_action: Option<ProviderNativeAction>,
+}
+
+impl ProviderCapability {
+    pub fn validate(&self) -> Result<(), UnifiedSurfaceError> {
+        if self.status == CapabilityStatus::Verified && self.proof_ref.is_none() {
+            return Err(UnifiedSurfaceError::VerifiedCapabilityMissingProof);
+        }
+        if self.status == CapabilityStatus::Blocked && self.blocker.is_none() {
+            return Err(UnifiedSurfaceError::BlockedCapabilityMissingBlocker);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CapabilityStatus {
+    Verified,
+    ImplementedUnproven,
+    OperatorGated,
+    ExternalBlocked,
+    Blocked,
+    Unsupported,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "provider_action", rename_all = "snake_case")]
+pub enum ProviderNativeAction {
+    CodexAppServer {
+        method: CodexAppServerMethod,
+        schema_ref: String,
+    },
+    ClaudeRemoteControl {
+        action: ClaudeRemoteControlAction,
+        proof_required: bool,
+    },
+    ClaudeStreamJson {
+        event_type: String,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CodexAppServerMethod {
+    ThreadList,
+    ThreadRead,
+    ThreadStart,
+    ThreadResume,
+    ThreadFork,
+    TurnStart,
+    TurnSteer,
+    TurnInterrupt,
+    ApprovalResponse,
+    UserInputResponse,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClaudeRemoteControlAction {
+    Launch,
+    OpenSessionUrl,
+    ShowQr,
+    Disconnect,
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum UnifiedSurfaceError {
+    #[error("verified provider capability missing proof_ref")]
+    VerifiedCapabilityMissingProof,
+
+    #[error("blocked provider capability missing blocker")]
+    BlockedCapabilityMissingBlocker,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn approval_event() -> SessionEvent {
+        SessionEvent {
+            event_id: "evt-1".into(),
+            provider: PlatformProvider::Codex,
+            friday_session_id: "friday-session-1".into(),
+            provider_event_id: Some("codex-event-1".into()),
+            seq: 7,
+            kind: SessionEventKind::ApprovalRequested,
+            status: SessionStatus::AwaitingApproval,
+            transcript_item: Some(TranscriptItem {
+                item_id: "item-1".into(),
+                role: TranscriptRole::Tool,
+                body_ref: BodyRef::metadata("friday://body/tool-summary/1"),
+                provider_item_id: Some("provider-item-1".into()),
+            }),
+            tool_call: Some(ToolCall {
+                tool_call_id: "tool-1".into(),
+                tool_name: "shell".into(),
+                input_ref: BodyRef::metadata("friday://body/tool-input/1"),
+                risk_label: RiskLabel::HighRisk,
+                approval_ref: Some("approval-1".into()),
+            }),
+            approval_request: Some(ApprovalRequest {
+                approval_ref: "approval-1".into(),
+                kind: ApprovalKind::CommandExecution,
+                tool_call_id: Some("tool-1".into()),
+                summary_ref: BodyRef::metadata("friday://body/approval-summary/1"),
+                risk_label: RiskLabel::HighRisk,
+            }),
+            user_question: None,
+            file_change: Some(FileChange {
+                file_change_ref: "file-change-1".into(),
+                path_ref: BodyRef::metadata("friday://body/path/1"),
+                summary_ref: BodyRef::metadata("friday://body/file-summary/1"),
+                diff_ref: Some("diff-1".into()),
+            }),
+            command_output: Some(CommandOutput {
+                command_ref: "cmd-1".into(),
+                stdout_ref: Some(BodyRef::metadata("friday://body/stdout/1")),
+                stderr_ref: None,
+                exit_code: None,
+            }),
+            diff_summary: Some(DiffSummary {
+                diff_ref: "diff-1".into(),
+                files_changed: 1,
+                insertions: 4,
+                deletions: 2,
+            }),
+            attachment: None,
+            token_ledger_ref: None,
+            audit_receipt_ref: Some("audit-1".into()),
+        }
+    }
+
+    #[test]
+    fn session_event_round_trips_without_flattening_shape() {
+        let event = approval_event();
+        let encoded = serde_json::to_string(&event).expect("serialize");
+        let decoded: SessionEvent = serde_json::from_str(&encoded).expect("deserialize");
+        assert_eq!(decoded, event);
+        assert_eq!(
+            decoded.approval_request.as_ref().map(|a| a.kind),
+            Some(ApprovalKind::CommandExecution)
+        );
+        assert_eq!(
+            decoded.tool_call.as_ref().map(|t| t.risk_label),
+            Some(RiskLabel::HighRisk)
+        );
+    }
+
+    #[test]
+    fn metadata_event_does_not_expose_raw_secret_or_transcript_strings() {
+        let event = approval_event();
+        let encoded = serde_json::to_string(&event).expect("serialize");
+        let debug = format!("{event:?}");
+        for forbidden in [
+            "sk-live-secret",
+            "jarvis@example.com",
+            "org-secret",
+            "rm -rf /private/project",
+            "raw assistant transcript with private data",
+        ] {
+            assert!(!encoded.contains(forbidden), "json leaked {forbidden}");
+            assert!(!debug.contains(forbidden), "debug leaked {forbidden}");
+        }
+        assert!(encoded.contains("friday://body/tool-input/1"));
+    }
+
+    #[test]
+    fn provider_specific_native_actions_are_preserved() {
+        let codex = ProviderCapability {
+            capability_id: "provider.codex.turn.start".into(),
+            provider: PlatformProvider::Codex,
+            status: CapabilityStatus::ImplementedUnproven,
+            sync_mode: ProviderSyncMode::ProviderAppServerLocal,
+            truth_label: "codex_app_server_local_control".into(),
+            blocker: None,
+            proof_ref: None,
+            native_action: Some(ProviderNativeAction::CodexAppServer {
+                method: CodexAppServerMethod::TurnStart,
+                schema_ref: "codex-schema:0.136.0".into(),
+            }),
+        };
+        let claude = ProviderCapability {
+            capability_id: "provider.claude.remote_control.open".into(),
+            provider: PlatformProvider::Claude,
+            status: CapabilityStatus::OperatorGated,
+            sync_mode: ProviderSyncMode::ProviderNativeLinkOnly,
+            truth_label: "claude_remote_control_link_only_until_live_proof".into(),
+            blocker: Some("operator must connect same account Claude mobile/web".into()),
+            proof_ref: None,
+            native_action: Some(ProviderNativeAction::ClaudeRemoteControl {
+                action: ClaudeRemoteControlAction::OpenSessionUrl,
+                proof_required: true,
+            }),
+        };
+
+        let codex_json = serde_json::to_value(&codex).expect("codex json");
+        let claude_json = serde_json::to_value(&claude).expect("claude json");
+        assert_eq!(
+            codex_json["native_action"]["provider_action"],
+            "codex_app_server"
+        );
+        assert_eq!(
+            claude_json["native_action"]["provider_action"],
+            "claude_remote_control"
+        );
+        assert_ne!(codex_json["native_action"], claude_json["native_action"]);
+    }
+
+    #[test]
+    fn verified_capabilities_require_proof_and_blocked_require_blocker() {
+        let mut capability = ProviderCapability {
+            capability_id: "provider.codex.thread.list".into(),
+            provider: PlatformProvider::Codex,
+            status: CapabilityStatus::Verified,
+            sync_mode: ProviderSyncMode::ProviderAppServerLocal,
+            truth_label: "thread_list_verified".into(),
+            blocker: None,
+            proof_ref: None,
+            native_action: Some(ProviderNativeAction::CodexAppServer {
+                method: CodexAppServerMethod::ThreadList,
+                schema_ref: "codex-schema:0.136.0".into(),
+            }),
+        };
+        assert_eq!(
+            capability.validate(),
+            Err(UnifiedSurfaceError::VerifiedCapabilityMissingProof)
+        );
+
+        capability.proof_ref = Some("71-PNS004".into());
+        assert_eq!(capability.validate(), Ok(()));
+
+        capability.status = CapabilityStatus::Blocked;
+        capability.proof_ref = None;
+        assert_eq!(
+            capability.validate(),
+            Err(UnifiedSurfaceError::BlockedCapabilityMissingBlocker)
+        );
+        capability.blocker = Some("operator_gated".into());
+        assert_eq!(capability.validate(), Ok(()));
+    }
+
+    #[test]
+    fn needs_me_projects_approval_or_question_only() {
+        let event = approval_event();
+        let needs = event
+            .needs_me(NeedsMePriority::High)
+            .expect("approval needs me");
+        assert_eq!(needs.kind, NeedsMeKind::Approval);
+        assert_eq!(needs.ref_id, "approval-1");
+
+        let mut neutral = event;
+        neutral.approval_request = None;
+        neutral.kind = SessionEventKind::AssistantMessage;
+        assert!(neutral.needs_me(NeedsMePriority::Normal).is_none());
+    }
+
+    #[test]
+    fn sync_mode_strings_match_core_file_60_contract() {
+        for mode in [
+            SyncMode::ProviderNativeSynced,
+            SyncMode::ProviderAppServerLocal,
+            SyncMode::FridayLocalMirror,
+            SyncMode::ProviderNativeLinkOnly,
+            SyncMode::UnsupportedTruthLabeled,
+        ] {
+            let unified: ProviderSyncMode = mode.into();
+            assert_eq!(unified.as_str(), mode.as_str());
+        }
+        let encoded =
+            serde_json::to_string(&ProviderSyncMode::UnsupportedTruthLabeled).expect("serialize");
+        assert_eq!(encoded, "\"unsupported_truth_labeled\"");
+    }
+
+    #[test]
+    fn fallback_status_is_explicit_no_provider_substitution() {
+        let session = ProviderSession {
+            friday_session_id: "friday-session-1".into(),
+            provider: PlatformProvider::Claude,
+            workspace_id: "workspace-1".into(),
+            sync_mode: ProviderSyncMode::FridayLocalMirror,
+            status: SessionStatus::Disconnected,
+            capability_snapshot: Vec::new(),
+            active_turn_id: None,
+            last_event_seq: 0,
+            truth_label: "claude_unavailable_no_fallback".into(),
+            fallback_status: FallbackStatus::UnavailableNoFallback,
+        };
+
+        let encoded = serde_json::to_string(&session).expect("serialize");
+        assert!(encoded.contains("unavailable_no_fallback"));
+        assert!(!encoded.contains("deepseek"));
+        assert!(!encoded.contains("fallback_provider"));
+    }
+}

--- a/rust-core/crates/friday-providers/tests/claude_control_help_smoke.rs
+++ b/rust-core/crates/friday-providers/tests/claude_control_help_smoke.rs
@@ -1,0 +1,44 @@
+use friday_core::SyncMode;
+use friday_providers::claude_control::{
+    classify_remote_control_surface, classify_stream_json_surface, ClaudeHelpCapabilities,
+    ClaudeRemoteControlProof,
+};
+use std::process::Command;
+
+fn run_claude_help(args: &[&str]) -> String {
+    let output = Command::new("claude")
+        .args(args)
+        .output()
+        .expect("claude CLI should be installed for ignored live help smoke");
+    assert!(
+        output.status.success(),
+        "claude {:?} failed with status {:?}",
+        args,
+        output.status.code()
+    );
+    format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+#[ignore = "local CLI smoke only; reads help text and does not start a model turn"]
+fn claude_help_surfaces_parse_without_model_call() {
+    let main_help = run_claude_help(&["--help"]);
+    let remote_help = run_claude_help(&["remote-control", "--help"]);
+    let capabilities = ClaudeHelpCapabilities::parse(&main_help, &remote_help);
+
+    assert!(capabilities.has_remote_control_surface());
+    assert!(capabilities.has_local_stream_surface());
+
+    let remote =
+        classify_remote_control_surface(&capabilities, ClaudeRemoteControlProof::default());
+    assert_eq!(remote.sync_mode, SyncMode::ProviderNativeLinkOnly);
+    assert!(remote.no_model_call);
+
+    let local = classify_stream_json_surface(&capabilities);
+    assert_eq!(local.sync_mode, SyncMode::FridayLocalMirror);
+    assert!(local.no_model_call);
+}

--- a/rust-core/crates/friday-providers/tests/claude_live.rs
+++ b/rust-core/crates/friday-providers/tests/claude_live.rs
@@ -1,0 +1,117 @@
+//! LIVE Claude local-mirror smoke (CLAUDE-MIRROR-001). `#[ignore]`d — run only where the
+//! Claude CLI is installed + logged in
+//! (`cargo test -p friday-providers --test claude_live -- --ignored`).
+//!
+//! Two legs, both reusing the CLAUDE-001 contract substrate:
+//! 1. Capability classification (NO model turn): parse the live `claude --help` →
+//!    `classify_stream_json_surface` must be `friday_local_mirror`.
+//! 2. Live stream-json mirror (ONE model turn — the stream-json path inherently runs a
+//!    turn; provider live sends are operator-authorized): run
+//!    `claude -p … --output-format stream-json` and fold the REAL event stream through
+//!    `map_stream_json_to_provider_event` into metadata-only `ProviderSessionEvent`s.
+//!
+//! Truth: `friday_local_mirror` — Friday owns the transcript. This is NOT Claude Remote
+//! Control and NOT provider-native sync (those stay operator-gated). Redaction is proven
+//! by a distinctive prompt sentinel that must NEVER appear in any mirrored event. codex
+//! CLI absent → graceful SKIP; a live failure → exact blocker, never faked.
+
+use friday_core::SyncMode;
+use friday_providers::claude_control::{
+    classify_stream_json_surface, ClaudeMirrorContext, LocalClaudeMirror,
+    CLAUDE_STREAM_JSON_SYNC_MODE,
+};
+use std::time::Duration;
+
+const SENTINEL: &str = "FRIDAYMIRRORPROBE7";
+
+#[test]
+#[ignore = "live: needs Claude CLI installed + logged in (runs one authorized stream-json turn)"]
+fn claude_stream_json_local_mirror_smoke() {
+    let program = std::env::var("CLAUDE_BIN").unwrap_or_else(|_| "claude".to_string());
+
+    // Leg 1 — capability classification (no model turn).
+    let caps = match LocalClaudeMirror::capabilities(&program) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!(
+                "SKIP: could not run `{program} --help` ({e:?}) — Claude CLI not available here"
+            );
+            return;
+        }
+    };
+    assert!(
+        caps.has_local_stream_surface(),
+        "live claude --help must expose the stream-json local-mirror surface: {caps:?}"
+    );
+    let surface = classify_stream_json_surface(&caps);
+    assert_eq!(surface.sync_mode, SyncMode::FridayLocalMirror);
+    assert_eq!(
+        surface.truth_label,
+        "claude_stream_json_friday_local_mirror"
+    );
+    assert_eq!(CLAUDE_STREAM_JSON_SYNC_MODE, "friday_local_mirror");
+
+    // Leg 2 — live stream-json mirror (one authorized turn).
+    let context = ClaudeMirrorContext::claude("friday-claude-mirror-live");
+    let prompt = format!("Reply with only this exact token and nothing else: {SENTINEL}");
+    let run = LocalClaudeMirror::mirror_stream_json(
+        &program,
+        &prompt,
+        &context,
+        0,
+        Duration::from_secs(90),
+    )
+    .unwrap_or_else(|e| panic!("BLOCKER: claude stream-json mirror failed: {e:?} (claude logged in? `claude auth status`)"));
+
+    assert!(
+        !run.events.is_empty(),
+        "BLOCKER: live stream-json produced no mappable events (login/account?)"
+    );
+    assert!(
+        run.session_id.is_some(),
+        "stream-json events must carry a session_id"
+    );
+    // Every mirrored event is metadata-only, and NONE inlines the raw transcript: the
+    // model echoes the sentinel in its answer, but the metadata-only mapper must not
+    // carry it.
+    for event in &run.events {
+        assert_eq!(
+            event.redaction_level, "metadata_only",
+            "every mirrored event must be metadata_only: {event:?}"
+        );
+        assert_eq!(event.provider, "claude");
+        let debug = format!("{event:?}");
+        assert!(
+            !debug.contains(SENTINEL),
+            "raw transcript leaked into a mirrored event: {debug}"
+        );
+    }
+    let kinds: Vec<&str> = run.events.iter().map(|e| e.event_kind.as_str()).collect();
+
+    eprintln!(
+        "CLAUDE-MIRROR-001 OK: sync_mode={CLAUDE_STREAM_JSON_SYNC_MODE} events={} unmapped={} kinds={kinds:?} (Friday-owned mirror; NOT Remote Control; NOT provider-native sync)",
+        run.events.len(),
+        run.unmapped_count,
+    );
+
+    // Evidence — counts + kinds + truth labels only (no raw transcript, no account ids).
+    let evidence = serde_json::json!({
+        "proof": "claude_stream_json_local_mirror_smoke",
+        "sync_mode": CLAUDE_STREAM_JSON_SYNC_MODE,
+        "stream_json_surface_friday_local_mirror": true,
+        "has_local_stream_surface": caps.has_local_stream_surface(),
+        "remote_control_claimed": false,
+        "provider_native_synced_claimed": false,
+        "mirrored_event_count": run.events.len(),
+        "unmapped_line_count": run.unmapped_count,
+        "event_kinds": kinds,
+        "all_events_metadata_only": true,
+        "sentinel_redacted_from_all_events": true,
+        "session_id_present": run.session_id.is_some(),
+    });
+    if let Ok(out) = std::env::var("CLAUDE_PROOF_OUT") {
+        std::fs::write(&out, serde_json::to_string_pretty(&evidence).unwrap())
+            .expect("write claude live-proof evidence");
+        eprintln!("evidence written to {out}");
+    }
+}

--- a/rust-core/crates/friday-providers/tests/codex_appserver_live_schema.rs
+++ b/rust-core/crates/friday-providers/tests/codex_appserver_live_schema.rs
@@ -1,0 +1,32 @@
+//! Ignored live-ish schema drift check. This invokes only
+//! `codex app-server generate-json-schema`; it does not authenticate, start a
+//! thread, or call a model.
+
+use friday_providers::codex_appserver::CodexAppServerSchemaMethods;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[test]
+#[ignore = "local CLI check: requires codex app-server generate-json-schema"]
+fn generated_codex_appserver_schema_contains_required_surface() {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!(
+        "friday-codex-appserver-live-schema-{}-{nanos}",
+        std::process::id()
+    ));
+    let status = std::process::Command::new("codex")
+        .args([
+            "app-server",
+            "generate-json-schema",
+            "--out",
+            dir.to_string_lossy().as_ref(),
+        ])
+        .status()
+        .expect("codex app-server generate-json-schema should launch");
+    assert!(status.success());
+
+    let methods = CodexAppServerSchemaMethods::from_generated_bundle_dir(&dir).unwrap();
+    methods.assert_required_surface().unwrap();
+}

--- a/rust-core/crates/friday-providers/tests/codex_appserver_live_stdio.rs
+++ b/rust-core/crates/friday-providers/tests/codex_appserver_live_stdio.rs
@@ -1,0 +1,52 @@
+//! Ignored local app-server stdio proof. This starts a local Codex App Server
+//! child process and performs metadata-only calls: initialize, thread/list, and
+//! thread/read when a local thread exists. It must not start a model turn.
+
+use friday_providers::codex_appserver::{
+    CodexAppServerClient, JsonLineTransport, CODEX_APP_SERVER_SYNC_MODE,
+};
+use std::process::{Child, Command, Stdio};
+
+struct ChildGuard(Child);
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+#[test]
+#[ignore = "local CLI check: starts codex app-server --stdio; metadata-only, no model turn"]
+fn live_stdio_appserver_metadata_round_trip() {
+    let mut child = Command::new("codex")
+        .args(["app-server", "--stdio"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("codex app-server --stdio should launch");
+    let stdin = child.stdin.take().expect("child stdin");
+    let stdout = child.stdout.take().expect("child stdout");
+    let mut guard = ChildGuard(child);
+
+    let transport = JsonLineTransport::new(stdout, stdin);
+    let mut client = CodexAppServerClient::new(transport);
+    let health = client
+        .health_check("friday-live-stdio", "0.0.1")
+        .expect("metadata health should complete without a model turn");
+    assert_eq!(health.sync_mode, CODEX_APP_SERVER_SYNC_MODE);
+    assert!(health.initialized.user_agent.contains("friday-live-stdio"));
+
+    let threads = client
+        .list_threads(1, true)
+        .expect("thread/list should complete without a model turn");
+    if let Some(first) = threads.threads.first() {
+        let read = client
+            .read_thread(&first.thread_id, false)
+            .expect("thread/read should complete without a model turn");
+        assert_eq!(read.thread.thread_id, first.thread_id);
+    }
+
+    let _ = guard.0.kill();
+}

--- a/rust-core/crates/friday-providers/tests/codex_appserver_no_ledger.rs
+++ b/rust-core/crates/friday-providers/tests/codex_appserver_no_ledger.rs
@@ -1,0 +1,58 @@
+//! PNS-002 token-safety lock: app-server health/schema/list probes are not model
+//! turns and must not write token ledger rows.
+
+use friday_providers::codex_appserver::{
+    CodexAppServerClient, JsonRpcResponse, MockCodexAppServerTransport, CODEX_APP_SERVER_SYNC_MODE,
+};
+use friday_storage::Db;
+use serde_json::json;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn temp_db_path(tag: &str) -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let mut dir = std::env::temp_dir();
+    dir.push(format!(
+        "friday-codex-appserver-noledger-{tag}-{}-{nanos}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir.push("db.sqlite");
+    dir.to_string_lossy().to_string()
+}
+
+fn ok(
+    result: serde_json::Value,
+) -> Result<JsonRpcResponse, friday_providers::codex_appserver::CodexAppServerError> {
+    Ok(JsonRpcResponse {
+        id: Some(json!(1)),
+        result: Some(result),
+        error: None,
+    })
+}
+
+#[test]
+fn codex_appserver_health_probe_writes_no_token_ledger_rows() {
+    let db = Db::open_hub(&temp_db_path("hub")).unwrap();
+    assert_eq!(db.count("token_ledger").unwrap(), 0);
+
+    let transport = MockCodexAppServerTransport::new(vec![
+        ok(json!({
+            "codexHome": "/tmp/codex",
+            "platformFamily": "unix",
+            "platformOs": "macos",
+            "userAgent": "codex-cli 0.136.0",
+        })),
+        ok(json!({
+            "data": [],
+            "nextCursor": null,
+            "backwardsCursor": null,
+        })),
+    ]);
+    let mut client = CodexAppServerClient::new(transport);
+    let summary = client.health_check("friday", "0.0.1").unwrap();
+    assert_eq!(summary.sync_mode, CODEX_APP_SERVER_SYNC_MODE);
+    assert_eq!(db.count("token_ledger").unwrap(), 0);
+}

--- a/rust-core/crates/friday-providers/tests/codex_appserver_no_ledger.rs
+++ b/rust-core/crates/friday-providers/tests/codex_appserver_no_ledger.rs
@@ -41,7 +41,7 @@ fn link() -> ProviderSessionLink {
     ProviderSessionLink {
         friday_session_id: "friday-session-1".into(),
         provider: "codex".into(),
-        account_key_hash: "account-hash-never-project".into(),
+        account_key_hash: "account-hash-never-project".into(), // pragma: allowlist secret
         workspace_id: "workspace-alpha".into(),
         cwd: Some("/Users/jarvis/private/project".into()),
         external_session_id: Some("provider-session-id".into()),

--- a/rust-core/crates/friday-providers/tests/codex_appserver_no_ledger.rs
+++ b/rust-core/crates/friday-providers/tests/codex_appserver_no_ledger.rs
@@ -2,11 +2,15 @@
 //! turns and must not write token ledger rows.
 
 use friday_providers::codex_appserver::{
-    CodexAppServerClient, JsonRpcResponse, MockCodexAppServerTransport, CODEX_APP_SERVER_SYNC_MODE,
+    map_server_message_to_provider_event, CodexAppServerClient, JsonRpcResponse,
+    JsonRpcServerMessage, MockCodexAppServerTransport, ProviderMirrorContext,
+    CODEX_APP_SERVER_SYNC_MODE,
 };
 use friday_storage::Db;
 use serde_json::json;
 use std::time::{SystemTime, UNIX_EPOCH};
+
+use friday_core::{ProviderSessionLink, SyncMode};
 
 fn temp_db_path(tag: &str) -> String {
     let nanos = SystemTime::now()
@@ -33,6 +37,24 @@ fn ok(
     })
 }
 
+fn link() -> ProviderSessionLink {
+    ProviderSessionLink {
+        friday_session_id: "friday-session-1".into(),
+        provider: "codex".into(),
+        account_key_hash: "account-hash-never-project".into(),
+        workspace_id: "workspace-alpha".into(),
+        cwd: Some("/Users/jarvis/private/project".into()),
+        external_session_id: Some("provider-session-id".into()),
+        external_thread_id: Some("thread-1".into()),
+        external_url: None,
+        sync_mode: SyncMode::ProviderAppServerLocal,
+        capability_snapshot: "thread/start,thread/read,turn/start,turn/interrupt".into(),
+        last_provider_seen_at: Some(30),
+        last_friday_event_id: None,
+        truth_label: "Provider local session; no official app-history claim".into(),
+    }
+}
+
 #[test]
 fn codex_appserver_health_probe_writes_no_token_ledger_rows() {
     let db = Db::open_hub(&temp_db_path("hub")).unwrap();
@@ -55,4 +77,37 @@ fn codex_appserver_health_probe_writes_no_token_ledger_rows() {
     let summary = client.health_check("friday", "0.0.1").unwrap();
     assert_eq!(summary.sync_mode, CODEX_APP_SERVER_SYNC_MODE);
     assert_eq!(db.count("token_ledger").unwrap(), 0);
+}
+
+#[test]
+fn mapped_codex_events_persist_in_provider_session_mirror_without_raw_body() {
+    let db = Db::open_hub(&temp_db_path("event-mirror")).unwrap();
+    db.upsert_provider_session_link(&link()).unwrap();
+
+    let context = ProviderMirrorContext::codex("friday-session-1");
+    let msg = JsonRpcServerMessage {
+        id: None,
+        method: "item/agentMessage/delta".to_string(),
+        params: json!({
+            "threadId": "thread-1",
+            "turnId": "turn-1",
+            "itemId": "item-1",
+            "delta": "raw transcript body must not be in the event row",
+        }),
+    };
+    let event = map_server_message_to_provider_event(&context, &msg, 123, 1)
+        .unwrap()
+        .unwrap();
+    db.append_provider_session_event(&event).unwrap();
+
+    let rows = db.list_provider_session_events("friday-session-1").unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].event_kind, "agent_message_delta");
+    assert_eq!(rows[0].transcript_item_kind, "agent_message");
+    assert_eq!(rows[0].redaction_level, "metadata_only");
+    let rendered = format!("{rows:?}");
+    assert!(
+        !rendered.contains("raw transcript body"),
+        "provider_session_event rows must reference future body storage, not inline raw provider text"
+    );
 }

--- a/rust-core/crates/friday-providers/tests/codex_live.rs
+++ b/rust-core/crates/friday-providers/tests/codex_live.rs
@@ -1,0 +1,113 @@
+//! LIVE Codex app-server smoke (CODEX-LIVE-001). `#[ignore]`d — run only where the Codex
+//! CLI is installed + logged in (`cargo test -p friday-providers --test codex_live -- --ignored`).
+//!
+//! Spawns `codex app-server` over stdio and drives the REAL local lifecycle:
+//! `initialize` -> `initialized` -> `thread/list` (a metadata read — NO model turn, NO
+//! `codex exec`). It proves Friday's LOCAL Codex control lane, labeled
+//! `provider_app_server_local`; it deliberately does NOT claim official ChatGPT/Codex
+//! same-account history sync (that is the operator-gated CODEX-REMOTE-001 lane).
+//!
+//! Honesty / safety:
+//! - codex CLI absent -> graceful SKIP (not a Friday defect).
+//! - codex present but a real round trip fails (login/account) -> exact blocker surfaced,
+//!   never faked.
+//! - a pid watchdog kills the child if the lifecycle hangs, so a blocking read can never
+//!   freeze the suite.
+//! - the evidence artifact records only counts + truth labels — no thread paths/contents,
+//!   no account ids, no provider secrets.
+
+use friday_providers::codex_appserver::{LocalCodexAppServer, CODEX_APP_SERVER_SYNC_MODE};
+use std::sync::mpsc;
+use std::time::Duration;
+
+#[test]
+#[ignore = "live: needs Codex CLI installed + logged in"]
+fn codex_app_server_local_lifecycle_smoke() {
+    let program = std::env::var("CODEX_BIN").unwrap_or_else(|_| "codex".to_string());
+
+    let mut server = match LocalCodexAppServer::spawn(&program) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("SKIP: could not spawn `{program} app-server` ({e:?}) — Codex CLI not available here");
+            return;
+        }
+    };
+
+    // Watchdog: if the lifecycle hangs > 20s, kill the child by pid so the blocking read
+    // returns EOF and the call errors (never a frozen suite). Stood down on completion.
+    let pid = server.child_id();
+    let (done_tx, done_rx) = mpsc::channel::<()>();
+    let watchdog = std::thread::spawn(move || {
+        if done_rx.recv_timeout(Duration::from_secs(20)).is_err() {
+            let _ = std::process::Command::new("kill")
+                .arg("-9")
+                .arg(pid.to_string())
+                .status();
+        }
+    });
+
+    let init = server
+        .client()
+        .initialize("friday-hub-live-proof", "codex-live-001");
+    let inited = init.as_ref().ok().map(|_| server.client().initialized());
+    let list = init
+        .as_ref()
+        .ok()
+        .map(|_| server.client().thread_list_probe());
+
+    // Stand down the watchdog and reap the child.
+    let _ = done_tx.send(());
+    let _ = watchdog.join();
+    server.kill();
+
+    // initialize MUST round-trip against a logged-in app-server. A failure here is the
+    // exact (login/account/transport) blocker — surfaced, not faked.
+    let summary = init.unwrap_or_else(|e| {
+        panic!("BLOCKER: codex app-server `initialize` did not round-trip: {e:?} (codex logged in? `codex login status`)")
+    });
+    assert!(
+        !summary.platform_family.is_empty() && !summary.platform_os.is_empty(),
+        "initialize result missing platform fields: {summary:?}"
+    );
+    assert!(
+        summary.user_agent.contains("friday-hub-live-proof"),
+        "userAgent must echo the Friday client name: {:?}",
+        summary.user_agent
+    );
+
+    let inited = inited.expect("initialized handshake attempted after initialize");
+    inited.expect("initialized notification must write without error");
+
+    let probe = list
+        .expect("thread/list attempted after initialize")
+        .unwrap_or_else(|e| {
+            panic!("BLOCKER: codex app-server `thread/list` did not round-trip: {e:?}")
+        });
+
+    eprintln!(
+        "CODEX-LIVE-001 OK: sync_mode={CODEX_APP_SERVER_SYNC_MODE} platform={}/{} thread_count={} (metadata read only; no model turn; no official-history claim)",
+        summary.platform_family, summary.platform_os, probe.item_count
+    );
+
+    // Evidence — counts + truth labels only (no thread paths/contents, no account ids).
+    let evidence = serde_json::json!({
+        "proof": "codex_app_server_local_lifecycle_smoke",
+        "sync_mode": CODEX_APP_SERVER_SYNC_MODE,
+        "initialize_ok": true,
+        "platform_family": summary.platform_family,
+        "platform_os": summary.platform_os,
+        "user_agent_echoes_client": summary.user_agent.contains("friday-hub-live-proof"),
+        "initialized_ok": true,
+        "thread_list_ok": true,
+        "thread_count": probe.item_count,
+        "model_turn_started": false,
+        "official_history_claimed": false,
+    });
+    if let Ok(out) = std::env::var("CODEX_PROOF_OUT") {
+        std::fs::write(&out, serde_json::to_string_pretty(&evidence).unwrap())
+            .expect("write codex live-proof evidence");
+        eprintln!("evidence written to {out}");
+    }
+
+    assert_eq!(CODEX_APP_SERVER_SYNC_MODE, "provider_app_server_local");
+}

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -19,6 +19,7 @@ pub mod memory;
 mod migrate;
 pub mod offline;
 pub mod pairing;
+pub mod provider_session;
 mod schema;
 pub mod workflow;
 
@@ -29,7 +30,10 @@ pub use migrate::{
 };
 pub use schema::{hub_migrations, phone_migrations, HUB_ONLY_TABLES, PHONE_ONLY_TABLES};
 
-use friday_core::{ActivityState, ActivityType, DeviceIdentity, LedgerEntry, SessionState};
+use friday_core::{
+    ActivityState, ActivityType, DeviceIdentity, LedgerEntry, ProviderSessionEvent,
+    ProviderSessionLink, ProviderSessionProjection, SessionState,
+};
 use rusqlite::Connection;
 
 /// Which process this database belongs to. Determines the schema (a phone DB
@@ -217,6 +221,57 @@ impl Db {
             out.push(row?);
         }
         Ok(out)
+    }
+
+    pub fn upsert_provider_session_link(&self, link: &ProviderSessionLink) -> Result<()> {
+        if self.profile != Profile::Hub {
+            return Err(StorageError::Unsupported(
+                "provider session links are Hub-only".into(),
+            ));
+        }
+        provider_session::upsert_link(&self.conn, link)
+    }
+
+    pub fn get_provider_session_link(
+        &self,
+        friday_session_id: &str,
+    ) -> Result<Option<ProviderSessionLink>> {
+        if self.profile != Profile::Hub {
+            return Err(StorageError::Unsupported(
+                "provider session links are Hub-only".into(),
+            ));
+        }
+        provider_session::get_link(&self.conn, friday_session_id)
+    }
+
+    pub fn list_provider_session_projections(&self) -> Result<Vec<ProviderSessionProjection>> {
+        if self.profile != Profile::Hub {
+            return Err(StorageError::Unsupported(
+                "provider session projections are Hub-only".into(),
+            ));
+        }
+        provider_session::list_projections(&self.conn)
+    }
+
+    pub fn append_provider_session_event(&self, event: &ProviderSessionEvent) -> Result<()> {
+        if self.profile != Profile::Hub {
+            return Err(StorageError::Unsupported(
+                "provider session events are Hub-only".into(),
+            ));
+        }
+        provider_session::append_event(&self.conn, event)
+    }
+
+    pub fn list_provider_session_events(
+        &self,
+        friday_session_id: &str,
+    ) -> Result<Vec<ProviderSessionEvent>> {
+        if self.profile != Profile::Hub {
+            return Err(StorageError::Unsupported(
+                "provider session events are Hub-only".into(),
+            ));
+        }
+        provider_session::list_events(&self.conn, friday_session_id)
     }
 
     /// Mark an activity item `Done` (a real persisted state write). Returns

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -31,8 +31,9 @@ pub use migrate::{
 pub use schema::{hub_migrations, phone_migrations, HUB_ONLY_TABLES, PHONE_ONLY_TABLES};
 
 use friday_core::{
-    ActivityState, ActivityType, DeviceIdentity, LedgerEntry, ProviderSessionEvent,
-    ProviderSessionLink, ProviderSessionProjection, SessionState,
+    ActivityState, ActivityType, DeviceIdentity, FridayPairPayload, LedgerEntry,
+    ProviderSessionEvent, ProviderSessionLink, ProviderSessionProjection, SessionState,
+    TrustedDeviceProjection,
 };
 use rusqlite::Connection;
 
@@ -272,6 +273,41 @@ impl Db {
             ));
         }
         provider_session::list_events(&self.conn, friday_session_id)
+    }
+
+    pub fn list_trusted_device_projections(&self) -> Result<Vec<TrustedDeviceProjection>> {
+        if self.profile != Profile::Hub {
+            return Err(StorageError::Unsupported(
+                "trusted device projections are Hub-only".into(),
+            ));
+        }
+        pairing::list_trusted_device_projections(&self.conn)
+    }
+
+    pub fn complete_qr_pairing(
+        &mut self,
+        payload: &FridayPairPayload,
+        device_id: &str,
+        device_pubkey: &[u8],
+        pairing_proof: &[u8],
+        paired_at: i64,
+        audit_id: &str,
+    ) -> Result<()> {
+        if self.profile != Profile::Hub {
+            return Err(StorageError::Unsupported(
+                "QR pairing completion is Hub-only".into(),
+            ));
+        }
+        payload.validate_at(paired_at)?;
+        pairing::pair_device(
+            &mut self.conn,
+            payload.pairing_secret.expose_for_qr().as_bytes(),
+            device_id,
+            device_pubkey,
+            pairing_proof,
+            paired_at,
+            audit_id,
+        )
     }
 
     /// Mark an activity item `Done` (a real persisted state write). Returns

--- a/rust-core/crates/friday-storage/src/pairing.rs
+++ b/rust-core/crates/friday-storage/src/pairing.rs
@@ -10,8 +10,10 @@
 
 use crate::audit;
 use crate::error::{Result, StorageError};
+use friday_core::TrustedDeviceProjection;
 use friday_crypto::verify_pairing_proof;
 use rusqlite::{params, Connection, OptionalExtension};
+use sha2::{Digest, Sha256};
 
 /// Complete a QR pairing handshake. Verifies the proof binds `device_pubkey` to
 /// the out-of-band `qr_secret`; on success records the trusted device + an audit
@@ -69,6 +71,33 @@ pub fn device_pubkey(conn: &Connection, device_id: &str) -> Result<Option<Vec<u8
             |r| r.get::<_, Vec<u8>>(0),
         )
         .optional()?)
+}
+
+/// Redacted trusted-device projection for setup/trust UI. It surfaces trust
+/// state and a public-key fingerprint, never the raw public key or pairing
+/// secret.
+pub fn list_trusted_device_projections(conn: &Connection) -> Result<Vec<TrustedDeviceProjection>> {
+    let mut stmt = conn.prepare(
+        "SELECT device_id, label, paired_at, revoked_at, key_rotated_at, public_key
+         FROM trusted_device
+         ORDER BY paired_at DESC, device_id",
+    )?;
+    let rows = stmt.query_map([], |r| {
+        let public_key: Vec<u8> = r.get(5)?;
+        Ok(TrustedDeviceProjection {
+            device_id: r.get(0)?,
+            label: r.get(1)?,
+            paired_at: r.get(2)?,
+            revoked_at: r.get(3)?,
+            key_rotated_at: r.get(4)?,
+            pubkey_fingerprint: pubkey_fingerprint(&public_key),
+        })
+    })?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row?);
+    }
+    Ok(out)
 }
 
 /// Revoke a trusted device (sets `revoked_at`). A revoked device is no longer
@@ -131,4 +160,16 @@ pub fn rotate_device_key(
     )?;
     tx.commit()?;
     Ok(())
+}
+
+fn pubkey_fingerprint(public_key: &[u8]) -> String {
+    let digest = Sha256::digest(public_key);
+    let mut out = String::with_capacity(23);
+    for (idx, byte) in digest.iter().take(8).enumerate() {
+        if idx > 0 {
+            out.push(':');
+        }
+        out.push_str(&format!("{byte:02x}"));
+    }
+    out
 }

--- a/rust-core/crates/friday-storage/src/provider_session.rs
+++ b/rust-core/crates/friday-storage/src/provider_session.rs
@@ -1,0 +1,237 @@
+//! Provider session link + event mirror persistence (PNS-001). Hub-only.
+
+use crate::error::{Result, StorageError};
+use friday_core::{ProviderSessionEvent, ProviderSessionLink, ProviderSessionProjection, SyncMode};
+use rusqlite::{params, Connection, OptionalExtension};
+
+fn require_non_empty(value: &str, field: &str) -> Result<()> {
+    if value.trim().is_empty() {
+        Err(StorageError::Unsupported(format!(
+            "provider session {field} must not be empty"
+        )))
+    } else {
+        Ok(())
+    }
+}
+
+fn parse_sync_mode(value: String) -> Result<SyncMode> {
+    SyncMode::parse(&value).ok_or_else(|| {
+        StorageError::Unsupported(format!("unknown provider session sync_mode '{value}'"))
+    })
+}
+
+pub fn upsert_link(conn: &Connection, link: &ProviderSessionLink) -> Result<()> {
+    require_non_empty(&link.friday_session_id, "friday_session_id")?;
+    require_non_empty(&link.provider, "provider")?;
+    require_non_empty(&link.account_key_hash, "account_key_hash")?;
+    require_non_empty(&link.workspace_id, "workspace_id")?;
+    require_non_empty(&link.truth_label, "truth_label")?;
+
+    conn.execute(
+        "INSERT INTO provider_session_link
+            (friday_session_id, provider, account_key_hash, workspace_id, cwd,
+             external_session_id, external_thread_id, external_url, sync_mode,
+             capability_snapshot, last_provider_seen_at, last_friday_event_id, truth_label)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+         ON CONFLICT(friday_session_id) DO UPDATE SET
+            provider = excluded.provider,
+            account_key_hash = excluded.account_key_hash,
+            workspace_id = excluded.workspace_id,
+            cwd = excluded.cwd,
+            external_session_id = excluded.external_session_id,
+            external_thread_id = excluded.external_thread_id,
+            external_url = excluded.external_url,
+            sync_mode = excluded.sync_mode,
+            capability_snapshot = excluded.capability_snapshot,
+            last_provider_seen_at = excluded.last_provider_seen_at,
+            last_friday_event_id = excluded.last_friday_event_id,
+            truth_label = excluded.truth_label",
+        params![
+            link.friday_session_id,
+            link.provider,
+            link.account_key_hash,
+            link.workspace_id,
+            link.cwd,
+            link.external_session_id,
+            link.external_thread_id,
+            link.external_url,
+            link.sync_mode.as_str(),
+            link.capability_snapshot,
+            link.last_provider_seen_at,
+            link.last_friday_event_id,
+            link.truth_label,
+        ],
+    )?;
+    Ok(())
+}
+
+pub fn get_link(conn: &Connection, friday_session_id: &str) -> Result<Option<ProviderSessionLink>> {
+    conn.query_row(
+        "SELECT friday_session_id, provider, account_key_hash, workspace_id, cwd,
+                external_session_id, external_thread_id, external_url, sync_mode,
+                capability_snapshot, last_provider_seen_at, last_friday_event_id, truth_label
+         FROM provider_session_link
+         WHERE friday_session_id = ?1",
+        [friday_session_id],
+        |r| {
+            let sync_mode: String = r.get(8)?;
+            Ok((
+                r.get::<_, String>(0)?,
+                r.get::<_, String>(1)?,
+                r.get::<_, String>(2)?,
+                r.get::<_, String>(3)?,
+                r.get::<_, Option<String>>(4)?,
+                r.get::<_, Option<String>>(5)?,
+                r.get::<_, Option<String>>(6)?,
+                r.get::<_, Option<String>>(7)?,
+                sync_mode,
+                r.get::<_, String>(9)?,
+                r.get::<_, Option<i64>>(10)?,
+                r.get::<_, Option<String>>(11)?,
+                r.get::<_, String>(12)?,
+            ))
+        },
+    )
+    .optional()?
+    .map(
+        |(
+            friday_session_id,
+            provider,
+            account_key_hash,
+            workspace_id,
+            cwd,
+            external_session_id,
+            external_thread_id,
+            external_url,
+            sync_mode,
+            capability_snapshot,
+            last_provider_seen_at,
+            last_friday_event_id,
+            truth_label,
+        )| {
+            Ok(ProviderSessionLink {
+                friday_session_id,
+                provider,
+                account_key_hash,
+                workspace_id,
+                cwd,
+                external_session_id,
+                external_thread_id,
+                external_url,
+                sync_mode: parse_sync_mode(sync_mode)?,
+                capability_snapshot,
+                last_provider_seen_at,
+                last_friday_event_id,
+                truth_label,
+            })
+        },
+    )
+    .transpose()
+}
+
+pub fn list_projections(conn: &Connection) -> Result<Vec<ProviderSessionProjection>> {
+    let mut stmt = conn.prepare(
+        "SELECT friday_session_id, provider, workspace_id, sync_mode,
+                capability_snapshot, last_provider_seen_at, last_friday_event_id, truth_label
+         FROM provider_session_link
+         ORDER BY COALESCE(last_provider_seen_at, 0) DESC, friday_session_id",
+    )?;
+    let rows = stmt.query_map([], |r| {
+        let sync_mode: String = r.get(3)?;
+        Ok((
+            r.get::<_, String>(0)?,
+            r.get::<_, String>(1)?,
+            r.get::<_, String>(2)?,
+            sync_mode,
+            r.get::<_, String>(4)?,
+            r.get::<_, Option<i64>>(5)?,
+            r.get::<_, Option<String>>(6)?,
+            r.get::<_, String>(7)?,
+        ))
+    })?;
+    let mut out = Vec::new();
+    for row in rows {
+        let (
+            friday_session_id,
+            provider,
+            workspace_id,
+            sync_mode,
+            capability_snapshot,
+            last_provider_seen_at,
+            last_friday_event_id,
+            truth_label,
+        ) = row?;
+        out.push(ProviderSessionProjection {
+            friday_session_id,
+            provider,
+            workspace_id,
+            sync_mode: parse_sync_mode(sync_mode)?,
+            capability_snapshot,
+            last_provider_seen_at,
+            last_friday_event_id,
+            truth_label,
+        });
+    }
+    Ok(out)
+}
+
+pub fn append_event(conn: &Connection, event: &ProviderSessionEvent) -> Result<()> {
+    require_non_empty(&event.friday_session_id, "event.friday_session_id")?;
+    require_non_empty(&event.provider_event_id, "event.provider_event_id")?;
+    require_non_empty(&event.provider, "event.provider")?;
+    require_non_empty(&event.event_kind, "event.event_kind")?;
+    require_non_empty(&event.transcript_item_kind, "event.transcript_item_kind")?;
+    require_non_empty(&event.redaction_level, "event.redaction_level")?;
+
+    conn.execute(
+        "INSERT INTO provider_session_event
+            (friday_session_id, provider_event_id, provider, event_kind, transcript_item_kind,
+             body_ref, redaction_level, token_ledger_ref, approval_ref, audit_receipt_ref, observed_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+        params![
+            event.friday_session_id,
+            event.provider_event_id,
+            event.provider,
+            event.event_kind,
+            event.transcript_item_kind,
+            event.body_ref,
+            event.redaction_level,
+            event.token_ledger_ref,
+            event.approval_ref,
+            event.audit_receipt_ref,
+            event.observed_at,
+        ],
+    )?;
+    Ok(())
+}
+
+pub fn list_events(
+    conn: &Connection,
+    friday_session_id: &str,
+) -> Result<Vec<ProviderSessionEvent>> {
+    let mut stmt = conn.prepare(
+        "SELECT friday_session_id, provider_event_id, provider, event_kind, transcript_item_kind,
+                body_ref, redaction_level, token_ledger_ref, approval_ref, audit_receipt_ref,
+                observed_at
+         FROM provider_session_event
+         WHERE friday_session_id = ?1
+         ORDER BY observed_at, provider_event_id",
+    )?;
+    let rows = stmt.query_map([friday_session_id], |r| {
+        Ok(ProviderSessionEvent {
+            friday_session_id: r.get(0)?,
+            provider_event_id: r.get(1)?,
+            provider: r.get(2)?,
+            event_kind: r.get(3)?,
+            transcript_item_kind: r.get(4)?,
+            body_ref: r.get(5)?,
+            redaction_level: r.get(6)?,
+            token_ledger_ref: r.get(7)?,
+            approval_ref: r.get(8)?,
+            audit_receipt_ref: r.get(9)?,
+            observed_at: r.get(10)?,
+        })
+    })?;
+    rows.collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(StorageError::from)
+}

--- a/rust-core/crates/friday-storage/src/schema.rs
+++ b/rust-core/crates/friday-storage/src/schema.rs
@@ -27,6 +27,10 @@ pub const HUB_ONLY_TABLES: &[&str] = &[
     // reference (Hub-only; never on a phone). NOT a secret store — the bearer secret
     // lives in OS secure storage; the table holds only an opaque `webhook_auth_ref`.
     "channel_binding",
+    // PNS-001: provider session links + event mirror (Hub-only; may hold provider
+    // account hashes, cwd, external urls/ids — never created on a phone).
+    "provider_session_link",
+    "provider_session_event",
 ];
 
 /// Tables present only on a phone (never created on the Hub).
@@ -93,6 +97,16 @@ pub fn hub_migrations() -> Vec<Migration> {
             name: "channel_binding",
             destructive: false,
             up: m0007_channel_binding,
+        },
+        // PNS-001: Hub-only provider session links + event mirror. These rows
+        // may contain provider account hashes, cwd, and external urls/ids, so
+        // the tables are never created in the phone profile. Renumbered to v8 on the
+        // pre-PR rebase (channel_binding took v7 on main); purely additive.
+        Migration {
+            version: 8,
+            name: "provider_session_contract",
+            destructive: false,
+            up: m0008_provider_session_contract,
         },
     ]
 }
@@ -274,6 +288,51 @@ CREATE TABLE agent_run_event (
 );
 CREATE INDEX idx_agent_run_event_run ON agent_run_event(run_id, seq);";
 
+// --- PNS-001 provider-session fragments (Hub-only) --------------------------
+
+const DDL_PROVIDER_SESSION: &str = "
+CREATE TABLE provider_session_link (
+    friday_session_id     TEXT PRIMARY KEY,
+    provider              TEXT NOT NULL CHECK(length(trim(provider)) > 0),
+    account_key_hash      TEXT NOT NULL CHECK(length(trim(account_key_hash)) > 0),
+    workspace_id          TEXT NOT NULL CHECK(length(trim(workspace_id)) > 0),
+    cwd                   TEXT,
+    external_session_id   TEXT,
+    external_thread_id    TEXT,
+    external_url          TEXT,
+    sync_mode             TEXT NOT NULL CHECK(sync_mode IN (
+        'provider_native_synced',
+        'provider_app_server_local',
+        'friday_local_mirror',
+        'provider_native_link_only',
+        'unsupported_truth_labeled'
+    )),
+    capability_snapshot   TEXT NOT NULL DEFAULT '',
+    last_provider_seen_at INTEGER,
+    last_friday_event_id  TEXT,
+    truth_label           TEXT NOT NULL CHECK(length(trim(truth_label)) > 0)
+);
+CREATE INDEX idx_provider_session_provider_seen
+    ON provider_session_link(provider, last_provider_seen_at);
+
+CREATE TABLE provider_session_event (
+    friday_session_id     TEXT NOT NULL,
+    provider_event_id     TEXT NOT NULL,
+    provider              TEXT NOT NULL CHECK(length(trim(provider)) > 0),
+    event_kind            TEXT NOT NULL CHECK(length(trim(event_kind)) > 0),
+    transcript_item_kind  TEXT NOT NULL CHECK(length(trim(transcript_item_kind)) > 0),
+    body_ref              TEXT NOT NULL DEFAULT '',
+    redaction_level       TEXT NOT NULL CHECK(length(trim(redaction_level)) > 0),
+    token_ledger_ref      TEXT,
+    approval_ref          TEXT,
+    audit_receipt_ref     TEXT,
+    observed_at           INTEGER NOT NULL,
+    PRIMARY KEY(friday_session_id, provider_event_id),
+    FOREIGN KEY(friday_session_id) REFERENCES provider_session_link(friday_session_id)
+);
+CREATE INDEX idx_provider_session_event_session_seen
+    ON provider_session_event(friday_session_id, observed_at, provider_event_id);";
+
 // --- migration bodies -------------------------------------------------------
 
 fn m0001_init_hub(tx: &Transaction) -> rusqlite::Result<()> {
@@ -384,4 +443,11 @@ fn m0007_channel_binding(tx: &Transaction) -> rusqlite::Result<()> {
             created_at          INTEGER NOT NULL
         );",
     )
+}
+
+// PNS-001: Hub-only provider session links + event mirror (renumbered v7→v8 on the
+// pre-PR rebase; channel_binding took v7 on main). Purely additive.
+fn m0008_provider_session_contract(tx: &Transaction) -> rusqlite::Result<()> {
+    tx.execute_batch(DDL_PROVIDER_SESSION)?;
+    Ok(())
 }

--- a/rust-core/crates/friday-storage/tests/pairing.rs
+++ b/rust-core/crates/friday-storage/tests/pairing.rs
@@ -5,8 +5,31 @@
 mod common;
 
 use common::temp_db_path;
+use friday_core::{
+    FridayPairPayload, PairAuthority, PairTransportHint, PairTransportKind,
+    CURRENT_PAIR_PAYLOAD_VERSION,
+};
 use friday_crypto::pairing_proof;
 use friday_storage::{audit, pairing, Db, StorageError};
+
+fn sample_payload(expires_at: i64) -> FridayPairPayload {
+    FridayPairPayload::new(
+        CURRENT_PAIR_PAYLOAD_VERSION,
+        "hub-mac-mini",
+        "pair-1",
+        "friday-pairing-secret-32-bytes",
+        "Jarvis Mac mini",
+        vec![PairTransportHint::new(
+            PairTransportKind::LanWebSocket,
+            "ws://192.168.1.8:4477",
+            "LAN WebSocket",
+        )
+        .unwrap()],
+        expires_at,
+        vec![PairAuthority::StatusOnly, PairAuthority::Approvals],
+    )
+    .unwrap()
+}
 
 #[test]
 fn authenticated_pairing_records_trusted_device() {
@@ -29,6 +52,57 @@ fn authenticated_pairing_records_trusted_device() {
     assert!(pairing::is_trusted(db.conn(), "dev-1").unwrap());
     assert_eq!(db.count("trusted_device").unwrap(), 1);
     assert_eq!(audit::verify_audit_chain(db.conn()).unwrap(), 1);
+}
+
+#[test]
+fn complete_qr_pairing_uses_payload_secret_and_records_redacted_projection() {
+    let p = temp_db_path("pair-payload-ok");
+    let mut db = Db::open_hub(&p).unwrap();
+    let payload = sample_payload(200);
+    let pubkey = [9u8; 32];
+    let proof = pairing_proof(payload.pairing_secret.expose_for_qr().as_bytes(), &pubkey);
+
+    db.complete_qr_pairing(&payload, "dev-1", &pubkey, &proof, 100, "au-pair-payload")
+        .unwrap();
+
+    assert!(pairing::is_trusted(db.conn(), "dev-1").unwrap());
+    let devices = db.list_trusted_device_projections().unwrap();
+    assert_eq!(devices.len(), 1);
+    assert_eq!(devices[0].device_id, "dev-1");
+    assert_eq!(devices[0].revoked_at, None);
+    assert_eq!(devices[0].pubkey_fingerprint.matches(':').count(), 7);
+    let projection = format!("{:?}", devices[0]);
+    assert!(!projection.contains("9, 9, 9"));
+    assert_eq!(audit::verify_audit_chain(db.conn()).unwrap(), 1);
+}
+
+#[test]
+fn expired_payload_and_phone_profile_cannot_complete_qr_pairing() {
+    let p = temp_db_path("pair-payload-expired");
+    let mut db = Db::open_hub(&p).unwrap();
+    let payload = sample_payload(100);
+    let pubkey = [9u8; 32];
+    let proof = pairing_proof(payload.pairing_secret.expose_for_qr().as_bytes(), &pubkey);
+
+    assert!(db
+        .complete_qr_pairing(&payload, "dev-1", &pubkey, &proof, 100, "au-expired")
+        .is_err());
+    assert_eq!(db.count("trusted_device").unwrap(), 0);
+    assert_eq!(db.count("audit_ledger").unwrap(), 0);
+
+    let phone_path = temp_db_path("pair-payload-phone");
+    let mut phone_db = Db::open_phone(&phone_path).unwrap();
+    assert!(phone_db
+        .complete_qr_pairing(
+            &sample_payload(200),
+            "dev-1",
+            &pubkey,
+            &proof,
+            100,
+            "au-phone"
+        )
+        .is_err());
+    assert!(phone_db.list_trusted_device_projections().is_err());
 }
 
 #[test]

--- a/rust-core/crates/friday-storage/tests/provider_session.rs
+++ b/rust-core/crates/friday-storage/tests/provider_session.rs
@@ -18,7 +18,7 @@ fn link() -> ProviderSessionLink {
     ProviderSessionLink {
         friday_session_id: "friday-session-1".into(),
         provider: "codex".into(),
-        account_key_hash: "account-hash-never-project".into(),
+        account_key_hash: "account-hash-never-project".into(), // pragma: allowlist secret
         workspace_id: "workspace-alpha".into(),
         cwd: Some("/Users/jarvis/private/project".into()),
         external_session_id: Some("provider-session-id".into()),

--- a/rust-core/crates/friday-storage/tests/provider_session.rs
+++ b/rust-core/crates/friday-storage/tests/provider_session.rs
@@ -1,0 +1,161 @@
+//! PNS-001 provider-session contract persistence.
+//!
+//! Provider session links and event mirrors are Hub-only. Phone/channel surfaces
+//! only receive redacted projections: no provider secrets, account hashes, cwd,
+//! raw external ids, or provider URLs.
+
+mod common;
+
+use common::temp_db_path;
+use friday_core::{ProviderSessionEvent, ProviderSessionLink, SyncMode};
+use friday_storage::{hub_migrations, Db, Profile, StorageError, HUB_ONLY_TABLES};
+
+fn hub_max_version() -> i64 {
+    hub_migrations().iter().map(|m| m.version).max().unwrap()
+}
+
+fn link() -> ProviderSessionLink {
+    ProviderSessionLink {
+        friday_session_id: "friday-session-1".into(),
+        provider: "codex".into(),
+        account_key_hash: "account-hash-never-project".into(),
+        workspace_id: "workspace-alpha".into(),
+        cwd: Some("/Users/jarvis/private/project".into()),
+        external_session_id: Some("provider-session-id".into()),
+        external_thread_id: Some("provider-thread-id".into()),
+        external_url: Some("https://provider.example/private/thread".into()),
+        sync_mode: SyncMode::ProviderAppServerLocal,
+        capability_snapshot: "thread/start,thread/read,turn/start".into(),
+        last_provider_seen_at: Some(30),
+        last_friday_event_id: Some("friday-event-9".into()),
+        truth_label: "Provider local session; no official app-history claim".into(),
+    }
+}
+
+fn event(provider_event_id: &str, observed_at: i64) -> ProviderSessionEvent {
+    ProviderSessionEvent {
+        friday_session_id: "friday-session-1".into(),
+        provider_event_id: provider_event_id.into(),
+        provider: "codex".into(),
+        event_kind: "transcript.item".into(),
+        transcript_item_kind: "assistant_delta".into(),
+        body_ref: "blob:body".into(),
+        redaction_level: "strict".into(),
+        token_ledger_ref: Some("ledger-1".into()),
+        approval_ref: None,
+        audit_receipt_ref: Some("audit-1".into()),
+        observed_at,
+    }
+}
+
+#[test]
+fn provider_session_tables_are_hub_only_and_forward_migrated() {
+    assert!(HUB_ONLY_TABLES.contains(&"provider_session_link"));
+    assert!(HUB_ONLY_TABLES.contains(&"provider_session_event"));
+
+    let p = temp_db_path("provider-session-mig");
+    {
+        let mut migs = hub_migrations();
+        migs.truncate(1);
+        let db = Db::open(&p, Profile::Hub, &migs, "v1").unwrap();
+        assert_eq!(db.version().unwrap(), 1);
+        assert!(!db
+            .table_names()
+            .unwrap()
+            .iter()
+            .any(|t| t == "provider_session_link"));
+    }
+
+    let db = Db::open_hub(&p).unwrap();
+    assert_eq!(db.version().unwrap(), hub_max_version());
+    let tables = db.table_names().unwrap();
+    assert!(tables.iter().any(|t| t == "provider_session_link"));
+    assert!(tables.iter().any(|t| t == "provider_session_event"));
+
+    let phone_path = temp_db_path("provider-session-phone");
+    let phone = Db::open_phone(&phone_path).unwrap();
+    let phone_tables = phone.table_names().unwrap();
+    assert!(!phone_tables.iter().any(|t| t == "provider_session_link"));
+    assert!(!phone_tables.iter().any(|t| t == "provider_session_event"));
+
+    assert!(matches!(
+        phone.list_provider_session_projections(),
+        Err(StorageError::Unsupported(_))
+    ));
+}
+
+#[test]
+fn link_round_trips_and_projection_redacts_hub_only_fields() {
+    let p = temp_db_path("provider-link");
+    let db = Db::open_hub(&p).unwrap();
+    db.upsert_provider_session_link(&link()).unwrap();
+
+    let stored = db
+        .get_provider_session_link("friday-session-1")
+        .unwrap()
+        .expect("link exists");
+    assert_eq!(stored.sync_mode, SyncMode::ProviderAppServerLocal);
+    assert_eq!(
+        stored.external_url.as_deref(),
+        Some("https://provider.example/private/thread")
+    );
+
+    let projections = db.list_provider_session_projections().unwrap();
+    assert_eq!(projections.len(), 1);
+    let rendered = format!("{:?}", projections[0]);
+    for forbidden in [
+        "account-hash-never-project",
+        "/Users/jarvis/private/project",
+        "provider-session-id",
+        "provider-thread-id",
+        "https://provider.example/private/thread",
+    ] {
+        assert!(
+            !rendered.contains(forbidden),
+            "projection leaked Hub-only field {forbidden}: {rendered}"
+        );
+    }
+    assert!(rendered.contains("workspace-alpha"));
+    assert!(rendered.contains("Provider local session"));
+}
+
+#[test]
+fn invalid_sync_mode_is_structurally_rejected() {
+    let p = temp_db_path("provider-sync-mode");
+    let db = Db::open_hub(&p).unwrap();
+    let insert = db.conn().execute(
+        "INSERT INTO provider_session_link
+            (friday_session_id, provider, account_key_hash, workspace_id, sync_mode, truth_label)
+         VALUES ('s1', 'codex', 'hash', 'workspace', 'native_synced', 'bad')",
+        [],
+    );
+    assert!(insert.is_err(), "invalid sync mode must violate CHECK");
+}
+
+#[test]
+fn event_log_requires_existing_link_orders_events_and_refuses_duplicates() {
+    let p = temp_db_path("provider-events");
+    let db = Db::open_hub(&p).unwrap();
+
+    assert!(
+        db.append_provider_session_event(&event("e-missing", 1))
+            .is_err(),
+        "event mirror must require an existing provider_session_link"
+    );
+
+    db.upsert_provider_session_link(&link()).unwrap();
+    db.append_provider_session_event(&event("e2", 20)).unwrap();
+    db.append_provider_session_event(&event("e1", 10)).unwrap();
+
+    let events = db.list_provider_session_events("friday-session-1").unwrap();
+    let ids: Vec<&str> = events
+        .iter()
+        .map(|event| event.provider_event_id.as_str())
+        .collect();
+    assert_eq!(ids, vec!["e1", "e2"]);
+
+    assert!(
+        db.append_provider_session_event(&event("e1", 30)).is_err(),
+        "duplicate provider_event_id per Friday session must be refused"
+    );
+}

--- a/rust-core/crates/friday-transport/src/lib.rs
+++ b/rust-core/crates/friday-transport/src/lib.rs
@@ -21,6 +21,11 @@ use std::io::{Read, Write};
 use thiserror::Error;
 use tungstenite::{Message, WebSocket};
 
+/// Public WebSocket carrier type for crates that need to bind a domain handler
+/// to the already-tested Friday E2E WebSocket framing without depending on
+/// tungstenite directly.
+pub type WireWebSocket<S> = WebSocket<S>;
+
 /// 1 MiB cap on a single frame (defensive; the slice has no large payloads).
 pub const MAX_FRAME: usize = 1 << 20;
 


### PR DESCRIPTION
Provider-native **session-sync / Provider Workspace** substrate for the all-Rust Friday core. This is runtime scaffolding + local-control proofs — **NOT** a v1 completion.

## ⚠️ Status (read first)
- **NOT merged** — open for operator review; do not merge without explicit operator approval.
- **NOT v1 GO** — overall Friday v1 remains **NO-GO**.
- **NOT `provider_native_synced`** — no official same-account provider sync is claimed anywhere.
- Prior-agent 12-commit substrate (PWS-001/002/003, QR pairing, Codex app-server transport, Claude contract) + this session's 5 units, rebased onto latest `main`; provider migration renumbered **m0007 → m0008** so it does not collide with `main`'s `channel_binding` m0007 (channels files preserved).

## What's in it (5 autonomous units)
- **PWS-004** — Provider Workspace dispatch adapter seam (gate-then-dispatch; truth_label never upgraded by an adapter; structural secret-redaction; failure ≠ completion; no fallback).
- **CODEX-LIVE-001** — Codex app-server **local** lifecycle. Proof is **`provider_app_server_local` only**: a real `codex app-server` over stdio doing **initialize / initialized / thread-list metadata** — **no model turn**, and **no official ChatGPT/Codex history claim**.
- **CLAUDE-MIRROR-001** — Claude local mirror. Proof is **`friday_local_mirror` only** (stream-json folded into metadata-only events) — **NOT Claude Remote Control**, not provider-native sync.
- **PAIR-004** — loopback-only (`127.0.0.1`) Hub pairing listener + adverse suite (expiry / replay / revoke / first-message-before-auth + a real loopback round-trip).
- **SMOOTH-001** — provider session timeline + reconnect harness (per-session seq + revision, PendingAction state machine where Hub-ack ≠ provider-completion, client_msg_id dedup, delta/snapshot reconnect, per-session isolation).

## Remaining operator-gated lanes (NOT in this PR)
- **CODEX-REMOTE-001** (official Codex Remote Connections — ChatGPT mobile + Codex App host)
- **CLAUDE-REMOTE-001** (Claude Remote Control)
- **physical-device proof**
- **release**

## Verification (pre-PR gate)
Rebased onto latest `main`; `cargo test --workspace` → 54 test-binaries ok / 0 failed; `clippy --workspace --all-targets -D warnings` clean; `fmt --check` clean; detect-secrets scan of the lane → 0 findings. The live Codex/Claude smokes are `#[ignore]`d (run only on demand; not run in normal CI). `#514` (channels) remains parked/unmerged; no conflict with this lane.

## Evidence (goal folder)
- `84-PWS-004-DISPATCH-ADAPTER-SEAM-RESULT-20260604.md`
- `85-CODEX-LIVE-001-APP-SERVER-LOCAL-RESULT-20260604.md` (+ `EVIDENCE-CODEX-LIVE-001-...json`)
- `86-CLAUDE-MIRROR-001-LOCAL-MIRROR-RESULT-20260604.md` (+ `EVIDENCE-CLAUDE-MIRROR-001-...json`)
- `87-PAIR-004-PAIRING-LISTENER-RESULT-20260604.md`
- `88-SMOOTH-001-RECONNECT-HARNESS-RESULT-20260604.md`
- `89-PROVIDER-SESSION-PRE-PR-REBASE-GATE-EVIDENCE-20260604.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)