### PR TITLE
feat(hub,ffi): runtime bridge and native ask contract

### DIFF
--- a/rust-core/crates/friday-ffi/src/lib.rs
+++ b/rust-core/crates/friday-ffi/src/lib.rs
@@ -4,8 +4,10 @@
 //! and generates idiomatic Swift + Kotlin bindings from one Rust definition
 //! (`cargo run -p friday-ffi --bin uniffi-bindgen -- generate --library <cdylib>
 //! --language swift|kotlin`). The exposed ops are pure, FFI-safe projections of
-//! the slice's connection-state + protocol version-negotiation logic; the
-//! model-calling `ask_friday` streaming op and the native app shells land with
+//! the slice's connection-state + protocol version-negotiation logic, plus the
+//! native-facing `ask_friday` CLIENT ACTION contract (build the request envelope +
+//! parse the Hub's refs-only response). The model call itself is Hub-owned (never on
+//! the phone); the streaming-answer projection and the native app shells land with
 //! the Unit-5 native build (operator-gated tooling).
 //!
 //! Trust boundary: this is the phone-side library. It links `friday-core`,
@@ -530,6 +532,219 @@ fn load_token_usage(db_path: &str) -> friday_storage::Result<Vec<TokenUsageFfi>>
         .collect())
 }
 
+// =====================================================================================
+// Phase 3 (goal file 92 §Phase 3): the native-facing `ask_friday` CLIENT ACTION contract.
+//
+// This is a CLIENT ACTION to the Hub — a `friday_protocol::AskFridayRequest` the native
+// shell seals + sends — NOT a phone-side provider adapter. The phone BUILDS the request and
+// PARSES the Hub's refs-only response; it never links `friday-deepseek`/`friday-providers`/
+// `friday-fs`, never holds a provider credential, and never sees the raw answer text
+// (enforced at compile time by `friday-arch-tests::dep_boundary`). All wire (de)serialization
+// stays inside `friday-protocol` (`Envelope::encode`/`decode`) — this crate adds no serde.
+// =====================================================================================
+
+/// A built, wire-ready Ask-Friday client action (the "action" struct of the slice).
+/// `ok=false` carries a secret-safe `error` (an encode failure is surfaced, never a panic
+/// across the FFI). `client_msg_id` is the idempotency key — it IS the envelope `msg_id`
+/// the Hub correlates the response to; resend the SAME id to retry an ask. NOTE: end-to-end
+/// replay-dedup is **not yet enforced Hub-side** (the Phase-1 serve-loop routes by kind and
+/// keeps no seen-id set); this contract only EXPOSES the key the Hub would dedup on.
+/// `wire_json` is the PLAINTEXT envelope JSON the native transport seals + sends — it carries
+/// only the prompt (no credential, no provider material).
+#[derive(Debug, Clone, PartialEq, Eq, uniffi::Record)]
+pub struct AskRequestFfi {
+    pub ok: bool,
+    pub error: String,
+    pub client_msg_id: String,
+    pub wire_json: String,
+}
+
+/// Build the `ask_friday` client action: a schema-stamped `AskFridayRequest` envelope.
+/// Idempotency is the caller's `client_msg_id` (reuse it verbatim to retry safely). The
+/// model call happens Hub-side; this only produces the request the phone sends.
+#[uniffi::export]
+pub fn build_ask_friday_request(
+    client_msg_id: String,
+    prompt: String,
+    sent_at: i64,
+) -> AskRequestFfi {
+    let env = friday_protocol::Envelope::new(
+        client_msg_id.clone(),
+        sent_at,
+        friday_protocol::Message::AskFridayRequest { prompt },
+    );
+    match env.encode() {
+        Ok(wire_json) => AskRequestFfi {
+            ok: true,
+            error: String::new(),
+            client_msg_id,
+            wire_json,
+        },
+        Err(e) => AskRequestFfi {
+            ok: false,
+            error: e.to_string(),
+            client_msg_id,
+            wire_json: String::new(),
+        },
+    }
+}
+
+/// What the Hub said back, projected SAFELY for the native UI (the slice's "result/snapshot"
+/// types). Exactly one variant per response frame. NONE carries the raw answer text, usage
+/// cost detail, provider account id, auth material, or private reasoning — the Hub keeps
+/// those; the phone gets refs + truth labels. Consistent with the Phase-1 serve-loop's
+/// refs-only projection: the answer body is followed via `result_link`, never inlined here.
+#[derive(Debug, Clone, PartialEq, Eq, uniffi::Enum)]
+pub enum AskResponseFfi {
+    /// Hub health snapshot: online + capabilities + supported schema range. No model call.
+    Status {
+        online: bool,
+        capabilities: Vec<String>,
+        min_version: u16,
+        max_version: u16,
+    },
+    /// Terminal ask frame — REFS ONLY: a `ledger_id` + a `result_link` (`friday://activity/...`),
+    /// NOT the answer. `correlation_id` matches the `client_msg_id` the phone sent (empty if none).
+    AskResult {
+        ledger_id: String,
+        result_link: String,
+        correlation_id: String,
+    },
+    /// Token/model ledger row projection (safe cost-view fields only; no host/key/cost-secret).
+    /// `fallback` is ALWAYS surfaced — a fallback is never hidden (`02` §13).
+    LedgerRef {
+        ledger_id: String,
+        provider_kind: String,
+        model: String,
+        total_tokens: i64,
+        fallback: bool,
+    },
+    /// Activity receipt/status ref — id + type + state, NO body.
+    ActivityRef {
+        activity_id: String,
+        item_type: String,
+        state: String,
+    },
+    /// Ack of a queued offline action on reconnect. NOT completion (an ack is not a result).
+    OfflineAck { acked_msg_id: String },
+    /// An explicit, surfaced Hub error (e.g. `PROVIDER_UNAVAILABLE`) — never a silent fallback.
+    Error { code: String, message: String },
+    /// A well-formed envelope whose message kind is NOT part of the ask_friday slice (a
+    /// Provider Workspace frame, a streamed `AskFridayStream` chunk, pairing, …). It is
+    /// truth-labeled by `kind`, never silently dropped or mis-rendered as a result. The
+    /// chunk/payload of such a frame is NOT projected (no raw answer reaches the phone here).
+    Unsupported { kind: String },
+    /// The bytes did not decode as a protocol envelope (structural error only — no secret).
+    Undecodable { error: String },
+}
+
+/// Parse a Hub→phone response envelope (the plaintext the native transport just opened) into
+/// the safe [`AskResponseFfi`] projection. Decoding stays in `friday-protocol`; an undecodable
+/// or out-of-slice frame is truth-labeled, never silently treated as a completed result.
+#[uniffi::export]
+pub fn parse_hub_response(wire_json: String) -> AskResponseFfi {
+    use friday_protocol::Message;
+    let env = match friday_protocol::Envelope::decode(&wire_json) {
+        Ok(e) => e,
+        Err(e) => {
+            return AskResponseFfi::Undecodable {
+                error: e.to_string(),
+            }
+        }
+    };
+    let correlation_id = env.correlation_id.unwrap_or_default();
+    match env.message {
+        Message::HubStatus {
+            online,
+            capabilities,
+            min_version,
+            max_version,
+        } => AskResponseFfi::Status {
+            online,
+            capabilities,
+            min_version,
+            max_version,
+        },
+        Message::AskFridayResult {
+            ledger_id,
+            result_link,
+        } => AskResponseFfi::AskResult {
+            ledger_id,
+            result_link: result_link.unwrap_or_default(),
+            correlation_id,
+        },
+        // Drop `base_url_host` (Hub-side trust/infra detail) — the cost view needs only these,
+        // matching `phone_token_usage`/`TokenUsageFfi`.
+        Message::LedgerEntry {
+            ledger_id,
+            provider_kind,
+            model,
+            total_tokens,
+            fallback,
+            ..
+        } => AskResponseFfi::LedgerRef {
+            ledger_id,
+            provider_kind,
+            model,
+            total_tokens,
+            fallback,
+        },
+        Message::ActivityItem {
+            activity_id,
+            item_type,
+            state,
+        } => AskResponseFfi::ActivityRef {
+            activity_id,
+            item_type,
+            state,
+        },
+        Message::OfflineQueueAck { acked_msg_id } => AskResponseFfi::OfflineAck { acked_msg_id },
+        Message::Error { code, message } => AskResponseFfi::Error {
+            code: error_code_str(code).to_string(),
+            message,
+        },
+        other => AskResponseFfi::Unsupported {
+            kind: message_kind_name(&other).to_string(),
+        },
+    }
+}
+
+/// The wire (`SCREAMING_SNAKE_CASE`) name of an error code — surfaced, never hidden.
+fn error_code_str(code: friday_protocol::ErrorCode) -> &'static str {
+    use friday_protocol::ErrorCode as E;
+    match code {
+        E::PairingDenied => "PAIRING_DENIED",
+        E::DeviceRevoked => "DEVICE_REVOKED",
+        E::SchemaVersionUnsupported => "SCHEMA_VERSION_UNSUPPORTED",
+        E::HubOffline => "HUB_OFFLINE",
+        E::ProviderUnavailable => "PROVIDER_UNAVAILABLE",
+        E::RateLimited => "RATE_LIMITED",
+        E::IdempotencyReplay => "IDEMPOTENCY_REPLAY",
+        E::Internal => "INTERNAL",
+    }
+}
+
+/// Truth label for an out-of-slice message kind. The exhaustive match is intentional: a new
+/// protocol message variant forces this to be updated (it cannot drift to a silent "other").
+fn message_kind_name(m: &friday_protocol::Message) -> &'static str {
+    use friday_protocol::Message as M;
+    match m {
+        M::Pair { .. } => "Pair",
+        M::PairAck { .. } => "PairAck",
+        M::HubStatus { .. } => "HubStatus",
+        M::AskFridayRequest { .. } => "AskFridayRequest",
+        M::AskFridayStream { .. } => "AskFridayStream",
+        M::AskFridayResult { .. } => "AskFridayResult",
+        M::LedgerEntry { .. } => "LedgerEntry",
+        M::ActivityItem { .. } => "ActivityItem",
+        M::OfflineQueueAck { .. } => "OfflineQueueAck",
+        M::ProviderWorkspaceSnapshot { .. } => "ProviderWorkspaceSnapshot",
+        M::ProviderWorkspaceActionRequest { .. } => "ProviderWorkspaceActionRequest",
+        M::ProviderWorkspaceActionResult { .. } => "ProviderWorkspaceActionResult",
+        M::Error { .. } => "Error",
+    }
+}
+
 // --- internal (non-FFI) helpers retained for the phone-side runtime/tests ---
 
 /// Open a phone-profile database. The phone schema omits the Hub-only
@@ -849,5 +1064,185 @@ mod tests {
                 );
             }
         }
+    }
+
+    // --- Phase 3: native-facing ask_friday CLIENT ACTION contract ---
+
+    #[test]
+    fn ffi_ask_friday_request_builds_a_decodable_envelope_and_exposes_idempotency_key() {
+        let r = build_ask_friday_request("cmsg-1".into(), "hello friday".into(), 7);
+        assert!(r.ok, "build failed: {}", r.error);
+        assert_eq!(r.client_msg_id, "cmsg-1");
+        // The wire decodes back to exactly the request the phone meant to send (round-trip).
+        let env = friday_protocol::Envelope::decode(&r.wire_json).unwrap();
+        assert_eq!(env.msg_id, "cmsg-1"); // idempotency key == client_msg_id
+        assert_eq!(env.schema_version, friday_protocol::CURRENT_SCHEMA_VERSION);
+        match env.message {
+            friday_protocol::Message::AskFridayRequest { prompt } => {
+                assert_eq!(prompt, "hello friday")
+            }
+            other => panic!("expected AskFridayRequest, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ffi_ask_friday_idempotency_key_is_stable_across_retries() {
+        // Idempotency contract: a retry reuses the SAME client_msg_id, so the envelope msg_id
+        // (the dedup key) is identical even when sent_at differs. End-to-end dedup is NOT yet
+        // enforced Hub-side — this only proves the key the Hub WOULD dedup on is stable.
+        let a = build_ask_friday_request("retry-7".into(), "do x".into(), 100);
+        let b = build_ask_friday_request("retry-7".into(), "do x".into(), 999);
+        let ea = friday_protocol::Envelope::decode(&a.wire_json).unwrap();
+        let eb = friday_protocol::Envelope::decode(&b.wire_json).unwrap();
+        assert_eq!(
+            ea.msg_id, eb.msg_id,
+            "the idempotency key must be stable across retries"
+        );
+        assert_ne!(
+            ea.sent_at, eb.sent_at,
+            "sent_at may differ; the dedup key does not"
+        );
+    }
+
+    #[test]
+    fn ffi_parse_hub_response_projects_safely_and_truth_labels() {
+        use friday_protocol::{Envelope, ErrorCode, Message};
+
+        // AskResult → refs only; correlation preserved; the struct has no answer-body field.
+        let result = Envelope::new(
+            "r1",
+            1,
+            Message::AskFridayResult {
+                ledger_id: "ask-1".into(),
+                result_link: Some("friday://activity/ask-1:activity".into()),
+            },
+        )
+        .with_correlation("cmsg-1");
+        match parse_hub_response(result.encode().unwrap()) {
+            AskResponseFfi::AskResult {
+                ledger_id,
+                result_link,
+                correlation_id,
+            } => {
+                assert_eq!(ledger_id, "ask-1");
+                assert_eq!(result_link, "friday://activity/ask-1:activity");
+                assert_eq!(correlation_id, "cmsg-1");
+            }
+            other => panic!("expected AskResult, got {other:?}"),
+        }
+
+        // Status snapshot — no model call implied.
+        let status = Envelope::new(
+            "s1",
+            0,
+            Message::HubStatus {
+                online: true,
+                capabilities: vec!["ask_friday".into()],
+                min_version: 1,
+                max_version: 3,
+            },
+        );
+        assert!(matches!(
+            parse_hub_response(status.encode().unwrap()),
+            AskResponseFfi::Status { online: true, .. }
+        ));
+
+        // Error is surfaced (never a silent fallback) with the SCREAMING_SNAKE code.
+        let err = Envelope::new(
+            "e1",
+            0,
+            Message::Error {
+                code: ErrorCode::ProviderUnavailable,
+                message: "ask route unavailable".into(),
+            },
+        );
+        match parse_hub_response(err.encode().unwrap()) {
+            AskResponseFfi::Error { code, message } => {
+                assert_eq!(code, "PROVIDER_UNAVAILABLE");
+                assert!(message.contains("unavailable"));
+            }
+            other => panic!("expected Error, got {other:?}"),
+        }
+
+        // A LedgerEntry projects the cost-view fields only (base_url_host dropped).
+        let ledger = Envelope::new(
+            "l1",
+            0,
+            Message::LedgerEntry {
+                ledger_id: "ask-1".into(),
+                provider_kind: "deepseek".into(),
+                model: "deepseek-v4-flash".into(),
+                base_url_host: "api.deepseek.example".into(),
+                total_tokens: 19,
+                fallback: false,
+            },
+        );
+        match parse_hub_response(ledger.encode().unwrap()) {
+            AskResponseFfi::LedgerRef {
+                provider_kind,
+                total_tokens,
+                fallback,
+                ..
+            } => {
+                assert_eq!(provider_kind, "deepseek");
+                assert_eq!(total_tokens, 19);
+                assert!(!fallback);
+            }
+            other => panic!("expected LedgerRef, got {other:?}"),
+        }
+
+        // OfflineQueueAck is NOT completion → its own label, never AskResult.
+        let ack = Envelope::new(
+            "o1",
+            0,
+            Message::OfflineQueueAck {
+                acked_msg_id: "q1".into(),
+            },
+        );
+        assert!(matches!(
+            parse_hub_response(ack.encode().unwrap()),
+            AskResponseFfi::OfflineAck { .. }
+        ));
+
+        // An out-of-slice kind (a streamed chunk) is truth-labeled Unsupported, NOT a result.
+        let stream = Envelope::new(
+            "st1",
+            0,
+            Message::AskFridayStream {
+                seq: 0,
+                chunk: "later".into(),
+            },
+        );
+        match parse_hub_response(stream.encode().unwrap()) {
+            AskResponseFfi::Unsupported { kind } => assert_eq!(kind, "AskFridayStream"),
+            other => panic!("expected Unsupported, got {other:?}"),
+        }
+
+        // Undecodable garbage → structural error, never a result.
+        assert!(matches!(
+            parse_hub_response("not a protocol envelope".into()),
+            AskResponseFfi::Undecodable { .. }
+        ));
+    }
+
+    #[test]
+    fn ffi_parse_hub_response_never_surfaces_raw_answer_text() {
+        // ADVERSE: even if a (wrong) Hub stuffed answer text into a streamed chunk, the phone
+        // projection never carries it — the chunk kind is Unsupported and its content is NOT
+        // projected into any FFI field (consistent with the Phase-1 refs-only stance).
+        use friday_protocol::{Envelope, Message};
+        let stream = Envelope::new(
+            "st1",
+            0,
+            Message::AskFridayStream {
+                seq: 1,
+                chunk: "SECRET-ANSWER-TEXT".into(),
+            },
+        );
+        let projected = parse_hub_response(stream.encode().unwrap());
+        assert!(
+            !format!("{projected:?}").contains("SECRET-ANSWER-TEXT"),
+            "raw answer leaked into the projection"
+        );
     }
 }

--- a/rust-core/crates/friday-hub/src/conn_truth.rs
+++ b/rust-core/crates/friday-hub/src/conn_truth.rs
@@ -1,0 +1,298 @@
+//! Phase-2 runtime truth — connection / offline / reconnect honesty (goal file 92 §Phase 2).
+//!
+//! Makes offline/stale truth a RUNTIME contract, not UI copy. Builds on the existing
+//! `friday_core::ConnState` (transport state machine) and `friday_storage::offline` (the
+//! confirmed-action queue whose `execute_once` already enforces ack≠completion and
+//! fail-closed-on-invalid-approval). This module adds:
+//! - a TIME-DRIVEN stale evaluator (the missing piece over `ConnState`);
+//! - a single honest [`PresentationTruth`] label so a queued/acked/stale/offline state can
+//!   never be rendered as completed or fresh-connected;
+//! - an offline DRAIN that routes through the EXISTING gate/dispatch path only — it never
+//!   creates a new dispatch path and never executes an unauthorized action.
+//!
+//! Reconnect/no-full-reload is the provider-timeline delta/snapshot contract
+//! (`crate::provider_timeline`); zero-model-call on connect/status/refresh/reconnect is the
+//! Phase-1 serve-loop (`crate::hub_server`). This module does not add any model call.
+
+use friday_core::{ConnState, OfflineQueueState};
+use friday_storage::offline::{execute_once, ExecOutcome};
+use friday_storage::{Db, StorageError};
+
+/// Time-driven stale evaluation. An ONLINE link (`Direct`/`Relay`) whose last observation
+/// is older than `stale_after_ms` is reported `Stale` (the UI must show stale/offline
+/// truth). Any non-online state is returned unchanged — `Stale` stays `Stale` and
+/// `Disconnected` stays offline until a FRESH observation recovers it. This never
+/// fabricates an online state from time alone (no "connected" without proof).
+pub fn evaluate_stale(
+    current: ConnState,
+    last_seen_ms: i64,
+    now_ms: i64,
+    stale_after_ms: i64,
+) -> ConnState {
+    match current {
+        ConnState::Direct | ConnState::Relay
+            if now_ms.saturating_sub(last_seen_ms) > stale_after_ms =>
+        {
+            ConnState::Stale
+        }
+        other => other,
+    }
+}
+
+/// The single client-facing truth label. Deriving it is the only sanctioned way to label
+/// a connection/action — a queued/acked/stale/offline state can never become
+/// `Connected`/`Executed` here.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PresentationTruth {
+    Connected,
+    Reconnecting,
+    Stale,
+    Offline,
+    Queued,
+    Executed,
+    Failed,
+}
+
+impl PresentationTruth {
+    /// Label for the CONNECTION row from the (already time-evaluated) transport state.
+    pub fn for_connection(conn: ConnState) -> Self {
+        match conn {
+            ConnState::Direct | ConnState::Relay => PresentationTruth::Connected,
+            ConnState::Connecting => PresentationTruth::Reconnecting,
+            ConnState::Stale => PresentationTruth::Stale,
+            ConnState::Disconnected => PresentationTruth::Offline,
+        }
+    }
+
+    /// Label for an OFFLINE ACTION row. `Acked` is "the Hub saw it" — NOT completion — so
+    /// both `Queued` and `Acked` render as `Queued`; only `Executed` is completion.
+    pub fn for_offline_action(state: OfflineQueueState) -> Self {
+        match state {
+            OfflineQueueState::Queued | OfflineQueueState::Acked => PresentationTruth::Queued,
+            OfflineQueueState::Executed => PresentationTruth::Executed,
+            OfflineQueueState::Failed => PresentationTruth::Failed,
+        }
+    }
+
+    /// Only `Executed` implies the action actually completed.
+    pub fn implies_completion(self) -> bool {
+        matches!(self, PresentationTruth::Executed)
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            PresentationTruth::Connected => "connected",
+            PresentationTruth::Reconnecting => "reconnecting",
+            PresentationTruth::Stale => "stale",
+            PresentationTruth::Offline => "offline",
+            PresentationTruth::Queued => "queued",
+            PresentationTruth::Executed => "executed",
+            PresentationTruth::Failed => "failed",
+        }
+    }
+}
+
+/// Drain ONE already-confirmed offline action through the EXISTING gate/dispatch path.
+///
+/// This adds NO new dispatch path: it computes whether the stored authorization still
+/// holds (`gate_check`, e.g. the existing approval verify) and delegates to
+/// [`friday_storage::offline::execute_once`], which (a) refuses anything not `Acked` (an
+/// ack is not completion), (b) fails closed to `Failed` if the authorization is invalid
+/// (no run), and (c) is idempotent. An unauthorized or un-acked action is never executed;
+/// it stays `Queued`/`Failed` with an exact reason.
+pub fn drain_one<G, E>(
+    db: &mut Db,
+    queue_id: &str,
+    now_ms: i64,
+    gate_check: G,
+    exec: E,
+) -> Result<ExecOutcome, StorageError>
+where
+    G: FnOnce() -> bool,
+    E: FnOnce() -> Result<String, String>,
+{
+    let approval_valid = gate_check();
+    execute_once(db.conn_mut(), queue_id, approval_valid, now_ms, exec)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use friday_storage::offline::{ack, enqueue, get_state};
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static C: AtomicU64 = AtomicU64::new(0);
+    fn tmp() -> String {
+        std::env::temp_dir()
+            .join(format!(
+                "friday-conntruth-{}-{}.sqlite",
+                std::process::id(),
+                C.fetch_add(1, Ordering::Relaxed)
+            ))
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    #[test]
+    fn online_link_goes_stale_after_threshold_and_stays_until_fresh_observation() {
+        // Fresh online → stays online.
+        assert_eq!(
+            evaluate_stale(ConnState::Direct, 1000, 1500, 1000),
+            ConnState::Direct
+        );
+        // Stale by time → Stale.
+        assert_eq!(
+            evaluate_stale(ConnState::Direct, 1000, 2500, 1000),
+            ConnState::Stale
+        );
+        assert_eq!(
+            evaluate_stale(ConnState::Relay, 0, 5000, 1000),
+            ConnState::Stale
+        );
+        // Already stale / disconnected: time never fabricates "online".
+        assert_eq!(
+            evaluate_stale(ConnState::Stale, 0, 0, 1000),
+            ConnState::Stale
+        );
+        assert_eq!(
+            evaluate_stale(ConnState::Disconnected, 0, 0, 1000),
+            ConnState::Disconnected
+        );
+    }
+
+    #[test]
+    fn presentation_never_labels_stale_as_connected_or_queued_as_completed() {
+        assert_eq!(
+            PresentationTruth::for_connection(ConnState::Direct),
+            PresentationTruth::Connected
+        );
+        assert_eq!(
+            PresentationTruth::for_connection(ConnState::Stale),
+            PresentationTruth::Stale
+        );
+        assert_eq!(
+            PresentationTruth::for_connection(ConnState::Disconnected),
+            PresentationTruth::Offline
+        );
+        assert_eq!(
+            PresentationTruth::for_connection(ConnState::Connecting),
+            PresentationTruth::Reconnecting
+        );
+        // ack is NOT completion.
+        assert_eq!(
+            PresentationTruth::for_offline_action(OfflineQueueState::Acked),
+            PresentationTruth::Queued
+        );
+        assert_eq!(
+            PresentationTruth::for_offline_action(OfflineQueueState::Queued),
+            PresentationTruth::Queued
+        );
+        assert_eq!(
+            PresentationTruth::for_offline_action(OfflineQueueState::Executed),
+            PresentationTruth::Executed
+        );
+        // Only Executed implies completion.
+        for s in [
+            OfflineQueueState::Queued,
+            OfflineQueueState::Acked,
+            OfflineQueueState::Failed,
+        ] {
+            assert!(!PresentationTruth::for_offline_action(s).implies_completion());
+        }
+        assert!(
+            PresentationTruth::for_offline_action(OfflineQueueState::Executed).implies_completion()
+        );
+        assert!(!PresentationTruth::Stale.implies_completion());
+    }
+
+    #[test]
+    fn queued_is_not_executed_and_ack_is_not_completion() {
+        let db = Db::open_phone(&tmp()).unwrap();
+        enqueue(
+            db.conn(),
+            "q1",
+            "send_message",
+            "m1",
+            None,
+            Some("approval-1"),
+            1,
+        )
+        .unwrap();
+        assert_eq!(
+            get_state(db.conn(), "q1").unwrap(),
+            Some(OfflineQueueState::Queued)
+        );
+        // A Queued (un-acked) action cannot be drained — ack is not completion.
+        let mut db = db;
+        let err = drain_one(&mut db, "q1", 2, || true, || Ok("ran".into()));
+        assert!(
+            err.is_err(),
+            "draining an un-acked action must fail (ack is not completion)"
+        );
+        assert_eq!(
+            get_state(db.conn(), "q1").unwrap(),
+            Some(OfflineQueueState::Queued)
+        );
+    }
+
+    #[test]
+    fn drain_without_valid_authorization_fails_closed_and_does_not_run() {
+        let mut db = Db::open_phone(&tmp()).unwrap();
+        enqueue(
+            db.conn(),
+            "q1",
+            "send_message",
+            "m1",
+            None,
+            Some("approval-1"),
+            1,
+        )
+        .unwrap();
+        ack(db.conn(), "q1").unwrap();
+        // gate_check = false → execute_once fails closed to Failed, exec never runs.
+        let mut ran = false;
+        let outcome = drain_one(
+            &mut db,
+            "q1",
+            2,
+            || false,
+            || {
+                ran = true;
+                Ok("should-not-run".into())
+            },
+        )
+        .unwrap();
+        assert_eq!(outcome, ExecOutcome::ApprovalInvalid);
+        assert!(!ran, "unauthorized drain must NOT run the side effect");
+        assert_eq!(
+            get_state(db.conn(), "q1").unwrap(),
+            Some(OfflineQueueState::Failed)
+        );
+    }
+
+    #[test]
+    fn authorized_drain_executes_once_through_the_existing_path_and_is_idempotent() {
+        let mut db = Db::open_phone(&tmp()).unwrap();
+        enqueue(
+            db.conn(),
+            "q1",
+            "send_message",
+            "m1",
+            None,
+            Some("approval-1"),
+            1,
+        )
+        .unwrap();
+        ack(db.conn(), "q1").unwrap();
+        let outcome =
+            drain_one(&mut db, "q1", 2, || true, || Ok("execution-proof".into())).unwrap();
+        assert_eq!(outcome, ExecOutcome::Executed);
+        assert_eq!(
+            get_state(db.conn(), "q1").unwrap(),
+            Some(OfflineQueueState::Executed)
+        );
+        // Idempotent: a second drain is a no-op (already executed).
+        let again = drain_one(&mut db, "q1", 3, || true, || Ok("again".into())).unwrap();
+        assert_eq!(again, ExecOutcome::AlreadyExecuted);
+    }
+}

--- a/rust-core/crates/friday-hub/src/hub_server.rs
+++ b/rust-core/crates/friday-hub/src/hub_server.rs
@@ -1,0 +1,478 @@
+//! Phase-1 runtime bridge — headless Hub serve-loop (goal file 92 §Phase 1).
+//!
+//! Composes existing Rust mechanisms into a local **headless** Hub runtime that a future
+//! mobile/desktop UI can consume over the proven E2E-sealed WebSocket transport. It serves
+//! a TRUSTED session (the per-session [`DataKey`] is established out of band by pairing;
+//! a client without it cannot produce valid sealed envelopes → fail-closed) and handles a
+//! STREAM of messages per connection (beyond a single `accept_one`).
+//!
+//! Call discipline (the load-bearing invariant): the non-model operations
+//! (connect / status / refresh / list / reconnect) are **pure Hub reads and produce ZERO
+//! provider/model calls**. ONLY [`Message::AskFridayRequest`] reaches the Hub-owned
+//! DeepSeek route — via [`crate::record_friday_ask`], which is the single atomic
+//! ask→token_ledger+Activity(AskReceipt)+audit coupling. There is **no fallback** to
+//! Codex/Claude/OpenAI/local/mock: a route failure is surfaced as an exact blocker.
+//!
+//! Safe outbound projection: an ask returns only **refs** ([`Message::AskFridayResult`]
+//! = `ledger_id` + a `result_link`) — never the raw answer text, provider account ids,
+//! auth material, raw private reasoning, cwd, or external urls on the wire. The answer +
+//! usage live Hub-side in the token_ledger / Activity receipt. No UI code here.
+
+use friday_deepseek::{DeepSeekClient, Transport};
+use friday_protocol::{Envelope, ErrorCode, Message, SUPPORTED};
+use friday_storage::Db;
+use friday_transport::{ws_recv_envelope, ws_send_envelope, TransportError, WireWebSocket};
+use std::io::{Read, Write};
+
+use crate::{record_friday_ask, RecordAskError};
+
+/// A headless Hub runtime serving one or more trusted client sessions. Generic over the
+/// DeepSeek [`Transport`] so tests inject a scripted mock and a live build uses
+/// `DeepSeekClient::from_env()` (Hub-only credential).
+pub struct HubServer<T: Transport> {
+    db: Db,
+    deepseek: DeepSeekClient<T>,
+    capabilities: Vec<String>,
+    max_tokens: u32,
+    /// Monotonic per-ask id source (a fresh ledger_id per ask — reuse fails CLOSED on the
+    /// token_ledger PK).
+    next_ask: u64,
+}
+
+impl<T: Transport> HubServer<T> {
+    pub fn new(
+        db: Db,
+        deepseek: DeepSeekClient<T>,
+        capabilities: Vec<String>,
+        max_tokens: u32,
+    ) -> Self {
+        Self {
+            db,
+            deepseek,
+            capabilities,
+            max_tokens,
+            next_ask: 0,
+        }
+    }
+
+    /// Borrow the Db (e.g. to inspect ledger/activity Hub-side).
+    pub fn db(&self) -> &Db {
+        &self.db
+    }
+
+    /// Dispatch ONE client envelope to a response. `now_ms` is supplied by the caller's
+    /// clock (deterministic in tests). Non-model messages never touch the DeepSeek client.
+    pub fn dispatch(&mut self, env: Envelope, now_ms: i64) -> Envelope {
+        let corr = env.msg_id.clone();
+        match env.message {
+            // Pure Hub read — NO provider/model call.
+            Message::HubStatus { .. } => self.status(&corr).with_correlation(corr),
+            // The ONLY model path: Hub-owned DeepSeek route + ledger/audit/activity.
+            Message::AskFridayRequest { prompt } => {
+                self.ask(&corr, &prompt, now_ms).with_correlation(corr)
+            }
+            // The pairing channel established the session; a Pair here is out of place.
+            Message::Pair { .. } => Self::error(
+                &corr,
+                now_ms,
+                ErrorCode::Internal,
+                "already on a trusted session; pairing is the connect step",
+            ),
+            _ => Self::error(
+                &corr,
+                now_ms,
+                ErrorCode::Internal,
+                "unsupported runtime-bridge message",
+            ),
+        }
+    }
+
+    fn status(&self, msg_id: &str) -> Envelope {
+        Envelope::new(
+            format!("{msg_id}-status"),
+            0,
+            Message::HubStatus {
+                online: true,
+                capabilities: self.capabilities.clone(),
+                min_version: SUPPORTED.min,
+                max_version: SUPPORTED.max,
+            },
+        )
+    }
+
+    fn ask(&mut self, msg_id: &str, prompt: &str, now_ms: i64) -> Envelope {
+        self.next_ask += 1;
+        let ledger_id = format!("ask-{msg_id}-{}", self.next_ask);
+        let activity_id = format!("{ledger_id}:activity");
+        let session_id = "friday-hub-session";
+        match record_friday_ask(
+            &mut self.db,
+            &self.deepseek,
+            &ledger_id,
+            session_id,
+            &activity_id,
+            prompt,
+            self.max_tokens,
+            now_ms,
+        ) {
+            // Safe projection: refs ONLY. The answer text + usage stay Hub-side in the
+            // token_ledger / Activity(AskReceipt) row, never on the wire.
+            Ok(_outcome) => Envelope::new(
+                format!("{msg_id}-result"),
+                now_ms,
+                Message::AskFridayResult {
+                    ledger_id: ledger_id.clone(),
+                    result_link: Some(format!("friday://activity/{activity_id}")),
+                },
+            ),
+            // Route failure → exact blocker, NO fallback, NO half-billed row (record_friday_ask
+            // persists nothing on a Route error).
+            Err(RecordAskError::Route(_)) => Self::error(
+                msg_id,
+                now_ms,
+                ErrorCode::ProviderUnavailable,
+                "ask route unavailable (Hub-owned DeepSeek; no fallback)",
+            ),
+            Err(RecordAskError::Storage(_)) => Self::error(
+                msg_id,
+                now_ms,
+                ErrorCode::Internal,
+                "ask ledger write failed (rolled back)",
+            ),
+        }
+    }
+
+    fn error(msg_id: &str, now_ms: i64, code: ErrorCode, message: &str) -> Envelope {
+        Envelope::new(
+            format!("{msg_id}-error"),
+            now_ms,
+            Message::Error {
+                code,
+                message: message.to_string(),
+            },
+        )
+        .with_correlation(msg_id.to_string())
+    }
+
+    /// Serve a STREAM of sealed messages over ONE established session until the client
+    /// disconnects (or sends an envelope that fails to open — fail-closed, no dispatch).
+    /// `clock` supplies `now_ms` per message. Returns when the connection ends.
+    pub fn serve_connection<S: Read + Write>(
+        &mut self,
+        ws: &mut WireWebSocket<S>,
+        session_key: &friday_crypto::DataKey,
+        aad: &[u8],
+        clock: &mut dyn FnMut() -> i64,
+    ) -> Result<(), TransportError> {
+        loop {
+            let env = match ws_recv_envelope(ws, session_key, aad) {
+                Ok(e) => e,
+                // EOF / disconnect / unauthenticated-or-tampered seal → end the session.
+                Err(_) => return Ok(()),
+            };
+            let response = self.dispatch(env, clock());
+            ws_send_envelope(ws, session_key, &response, aad)?;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use friday_crypto::DeviceKeypair;
+    use friday_deepseek::{DeepSeekError, Transport};
+    use friday_transport::{ws_accept, ws_connect, ws_recv_envelope, ws_send_envelope};
+    use serde_json::{json, Value};
+    use std::net::{TcpListener, TcpStream};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use std::thread;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    const AAD: &[u8] = b"friday-runtime-bridge-v1";
+
+    fn tmp_db() -> String {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir()
+            .join(format!(
+                "friday-hubserver-{}-{}.sqlite",
+                std::process::id(),
+                nanos
+            ))
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    /// Scripted DeepSeek transport: returns canned models + chat, and counts EVERY
+    /// transport call via a shared atomic so a test can prove "zero provider calls" on the
+    /// non-model ops.
+    struct CountingMock {
+        calls: Arc<AtomicUsize>,
+    }
+    impl Transport for CountingMock {
+        fn get_json(&self, _url: &str, _bearer: &str) -> Result<Value, DeepSeekError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(json!({"object":"list","data":[
+                {"id":"deepseek-v4-flash","object":"model","owned_by":"deepseek"}
+            ]}))
+        }
+        fn post_json(
+            &self,
+            _url: &str,
+            _bearer: &str,
+            _body: &Value,
+        ) -> Result<Value, DeepSeekError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(json!({
+                "model":"deepseek-v4-flash",
+                "choices":[{"index":0,"message":{"role":"assistant","content":"SECRET-ANSWER-TEXT"},"finish_reason":"stop"}],
+                "usage":{"prompt_tokens":11,"completion_tokens":8,"total_tokens":19}
+            }))
+        }
+    }
+
+    fn server(calls: Arc<AtomicUsize>, db_path: &str) -> HubServer<CountingMock> {
+        let db = Db::open_hub(db_path).unwrap();
+        let client =
+            DeepSeekClient::with_transport(CountingMock { calls }, "test-key-not-real".to_string()); // pragma: allowlist secret
+        HubServer::new(db, client, vec!["ask_friday".into(), "status".into()], 256)
+    }
+
+    /// Headless e2e over real loopback TCP + the sealed WS transport + a mock DeepSeek:
+    /// connect → status (no model call) → ask (one model call → ledger/activity/audit) →
+    /// reconnect → status (still no extra model call). Proves the call discipline + safe
+    /// projection end to end.
+    #[test]
+    fn headless_e2e_status_is_pure_ask_routes_to_deepseek_with_safe_projection() {
+        let db_path = tmp_db();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let hub_kp = DeviceKeypair::generate();
+        let phone_kp = DeviceKeypair::generate();
+        let hub_pub = hub_kp.public_bytes();
+        let phone_pub = phone_kp.public_bytes();
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server_calls = calls.clone();
+        let server_db = db_path.clone();
+        let srv = thread::spawn(move || {
+            let session = hub_kp.agree(&phone_pub);
+            let mut hub = server(server_calls, &server_db);
+            // Serve TWO connections (the second = reconnect).
+            for _ in 0..2 {
+                let (stream, _) = listener.accept().unwrap();
+                let mut ws = ws_accept(stream).unwrap();
+                let mut clock = || 1000i64;
+                hub.serve_connection(&mut ws, &session, AAD, &mut clock)
+                    .unwrap();
+            }
+        });
+
+        let session = phone_kp.agree(&hub_pub);
+
+        // --- connection 1: status (pure) then ask (model) ---
+        {
+            let stream = TcpStream::connect(addr).unwrap();
+            let mut ws = ws_connect(&format!("ws://{addr}/"), stream).unwrap();
+
+            // status → pure, zero provider calls so far
+            let status_req = Envelope::new(
+                "c1-status",
+                1,
+                Message::HubStatus {
+                    online: false,
+                    capabilities: vec![],
+                    min_version: SUPPORTED.min,
+                    max_version: SUPPORTED.max,
+                },
+            );
+            ws_send_envelope(&mut ws, &session, &status_req, AAD).unwrap();
+            let status_resp = ws_recv_envelope(&mut ws, &session, AAD).unwrap();
+            assert!(matches!(
+                status_resp.message,
+                Message::HubStatus { online: true, .. }
+            ));
+            assert_eq!(
+                calls.load(Ordering::SeqCst),
+                0,
+                "status must make ZERO provider calls"
+            );
+
+            // ask → routes to DeepSeek; result is refs-only (no raw answer on the wire)
+            let ask_req = Envelope::new(
+                "c1-ask",
+                2,
+                Message::AskFridayRequest {
+                    prompt: "hello friday".into(),
+                },
+            );
+            ws_send_envelope(&mut ws, &session, &ask_req, AAD).unwrap();
+            let ask_resp = ws_recv_envelope(&mut ws, &session, AAD).unwrap();
+            match &ask_resp.message {
+                Message::AskFridayResult {
+                    ledger_id,
+                    result_link,
+                } => {
+                    assert!(ledger_id.starts_with("ask-"));
+                    assert!(result_link
+                        .as_deref()
+                        .unwrap()
+                        .starts_with("friday://activity/"));
+                }
+                other => panic!("expected AskFridayResult, got {other:?}"),
+            }
+            // SAFE PROJECTION: the raw answer text must NOT appear anywhere in the wire response.
+            assert!(
+                !format!("{ask_resp:?}").contains("SECRET-ANSWER-TEXT"),
+                "raw answer leaked to the wire"
+            );
+            assert!(
+                calls.load(Ordering::SeqCst) >= 1,
+                "ask must reach the DeepSeek route"
+            );
+        } // client 1 disconnects → serve_connection returns
+
+        let calls_after_ask = calls.load(Ordering::SeqCst);
+
+        // --- connection 2: reconnect + status → still no extra provider call ---
+        {
+            let stream = TcpStream::connect(addr).unwrap();
+            let mut ws = ws_connect(&format!("ws://{addr}/"), stream).unwrap();
+            let status_req = Envelope::new(
+                "c2-status",
+                3,
+                Message::HubStatus {
+                    online: false,
+                    capabilities: vec![],
+                    min_version: SUPPORTED.min,
+                    max_version: SUPPORTED.max,
+                },
+            );
+            ws_send_envelope(&mut ws, &session, &status_req, AAD).unwrap();
+            let resp = ws_recv_envelope(&mut ws, &session, AAD).unwrap();
+            assert!(matches!(
+                resp.message,
+                Message::HubStatus { online: true, .. }
+            ));
+        }
+        srv.join().unwrap();
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            calls_after_ask,
+            "reconnect/status must make NO extra provider call"
+        );
+
+        // Hub-side: exactly one ask → one token_ledger row + one AskReceipt activity + audit.
+        let db = Db::open_hub(&db_path).unwrap();
+        assert_eq!(db.count("token_ledger").unwrap(), 1);
+        assert_eq!(db.count("activity_item").unwrap(), 1);
+        assert!(db.count("audit_ledger").unwrap() >= 1);
+    }
+
+    #[test]
+    fn unauthenticated_session_key_serves_nothing() {
+        // A client with the WRONG session key cannot produce a sealed envelope the Hub can
+        // open → serve_connection ends without dispatching (fail-closed).
+        let db_path = tmp_db();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let hub_kp = DeviceKeypair::generate();
+        let phone_kp = DeviceKeypair::generate();
+        let attacker_kp = DeviceKeypair::generate();
+        let hub_pub = hub_kp.public_bytes();
+        let phone_pub = phone_kp.public_bytes();
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server_calls = calls.clone();
+        let server_db = db_path.clone();
+        let srv = thread::spawn(move || {
+            let session = hub_kp.agree(&phone_pub); // Hub's real session
+            let mut hub = server(server_calls, &server_db);
+            let (stream, _) = listener.accept().unwrap();
+            let mut ws = ws_accept(stream).unwrap();
+            let mut clock = || 1000i64;
+            hub.serve_connection(&mut ws, &session, AAD, &mut clock)
+                .unwrap();
+        });
+
+        // Attacker uses a key the Hub does not share.
+        let wrong = attacker_kp.agree(&hub_pub);
+        let stream = TcpStream::connect(addr).unwrap();
+        let mut ws = ws_connect(&format!("ws://{addr}/"), stream).unwrap();
+        let ask = Envelope::new(
+            "x-ask",
+            1,
+            Message::AskFridayRequest {
+                prompt: "exfiltrate".into(),
+            },
+        );
+        // The send may encode, but the Hub cannot open it → no dispatch, no model call.
+        let _ = ws_send_envelope(&mut ws, &wrong, &ask, AAD);
+        drop(ws);
+        srv.join().unwrap();
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            0,
+            "no provider call for an unauthenticated session"
+        );
+        let db = Db::open_hub(&db_path).unwrap();
+        assert_eq!(db.count("token_ledger").unwrap(), 0);
+    }
+
+    /// LIVE Phase-1 DeepSeek proof (`#[ignore]`d) — the ONE authorized live model call.
+    /// Run with the Hub credential exported, e.g.:
+    ///   set -a; . /private/tmp/friday-closure-20260530/.deepseek-env; set +a
+    ///   cargo test -p friday-hub --test ... -- --ignored   (here: in-crate, via --ignored)
+    /// Missing credential → graceful skip recorded as an EXACT blocker (never faked).
+    #[test]
+    #[ignore = "live: needs FRIDAY_DEEPSEEK_API_KEY (Hub-only); one authorized DeepSeek ask"]
+    fn live_ask_friday_routes_through_deepseek_and_ledgers() {
+        if std::env::var(friday_deepseek::ENV_KEY)
+            .map(|k| k.trim().is_empty())
+            .unwrap_or(true)
+        {
+            eprintln!(
+                "SKIP/BLOCKER: {} not set — DeepSeek live proof not run (no fake success)",
+                friday_deepseek::ENV_KEY
+            );
+            return;
+        }
+        let db_path = tmp_db();
+        let client = DeepSeekClient::from_env().expect("live DeepSeek client");
+        let mut hub = HubServer::new(
+            Db::open_hub(&db_path).unwrap(),
+            client,
+            vec!["ask_friday".into()],
+            64,
+        );
+        let resp = hub.dispatch(
+            Envelope::new(
+                "live-1",
+                1,
+                Message::AskFridayRequest {
+                    prompt: "Reply with the single word: OK".into(),
+                },
+            ),
+            1_700_000_000_000,
+        );
+        match resp.message {
+            Message::AskFridayResult { ledger_id, .. } => {
+                eprintln!("LIVE ask ok: ledger {ledger_id}")
+            }
+            Message::Error { code, message } => {
+                panic!("BLOCKER (no fake): live ask errored: {code:?} {message}")
+            }
+            other => panic!("unexpected {other:?}"),
+        }
+        let db = Db::open_hub(&db_path).unwrap();
+        assert_eq!(
+            db.count("token_ledger").unwrap(),
+            1,
+            "live ask must write exactly one ledger row"
+        );
+        assert_eq!(db.count("activity_item").unwrap(), 1);
+    }
+}

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -61,6 +61,13 @@ pub mod channels;
 /// outbound projection is refs-only. No UI.
 pub mod hub_server;
 
+/// Phase-2 runtime truth — connection/offline/reconnect honesty. Time-driven stale
+/// evaluator over `friday_core::ConnState`, an honest `PresentationTruth` label (queued/
+/// acked/stale never reads as completed/connected), and an offline drain that routes only
+/// through the existing `friday_storage::offline::execute_once` gate path (no new dispatch,
+/// no run without valid authorization).
+pub mod conn_truth;
+
 /// Step-3 — observability/diagnostics (small/medium truth-labeled): composes the wired
 /// substrate (token_ledger / audit chain / agent_run) into a [`diagnostics::DiagnosticsSnapshot`]
 /// with no fake-zero, same-build (anti-stale) stamping, surfaced chain integrity, and

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -54,6 +54,13 @@ pub mod capability;
 /// DECISION note (to be enforced in A-PR4 before any channel action is dispatched).
 pub mod channels;
 
+/// Phase-1 runtime bridge — headless Hub serve-loop. Composes the existing mechanisms
+/// (pairing session, DeepSeek route via `record_friday_ask`, gate/ledger/audit/activity)
+/// into a local headless runtime a future UI can consume: connect/status/refresh/list/
+/// reconnect are pure (zero model calls); only `AskFridayRequest` reaches DeepSeek; the
+/// outbound projection is refs-only. No UI.
+pub mod hub_server;
+
 /// Step-3 — observability/diagnostics (small/medium truth-labeled): composes the wired
 /// substrate (token_ledger / audit chain / agent_run) into a [`diagnostics::DiagnosticsSnapshot`]
 /// with no fake-zero, same-build (anti-stale) stamping, surfaced chain integrity, and


### PR DESCRIPTION
## Scope

This PR lands the local Rust runtime bridge slice from file `92` Phases 1-3.

It is **NOT v1 GO**, does **not** claim `provider_native_synced`, does **not** wire UI, and must **not** be merged without explicit operator approval.

## Commits

- `e6850f02` — Phase 1: headless Hub serve-loop + `AskFridayRequest` via Hub-owned DeepSeek route.
- `4d5f6c9e` — Phase 2: stale/offline/reconnect runtime truth.
- `dea379f6` — Phase 3: native-facing `ask_friday` CLIENT ACTION contract in `friday-ffi`.

## What this proves

- Hub status/connect-style reads remain pure and make zero provider/model calls.
- Only `AskFridayRequest` reaches the Hub-owned DeepSeek path via `record_friday_ask`.
- Ask result projection is refs-only (`ledger_id`, `result_link`) and does not put raw answer text on the wire.
- Stale/offline/queued/acked labels cannot be confused with completed/executed.
- Phone-side `friday-ffi` can build an ask request and parse safe Hub responses without linking provider/secret-bearing crates.

## Explicit non-claims

- No UI wiring.
- No native device proof.
- No official Codex/Claude Remote proof.
- No Hub-side replay-dedup for duplicate `client_msg_id` yet; Phase 3 exposes the idempotency key but does not prove execute-once Hub behavior.
- No streaming answer projection; streamed chunks remain truth-labeled unsupported in the native ask contract.
- No v1 GO.

## Local evidence files

- `/Users/jarvis/Desktop/friday-rust-mobile-rewrite-goals-20260601/93-RUNTIME-BRIDGE-PHASE1-EVIDENCE-20260604.md`
- `/Users/jarvis/Desktop/friday-rust-mobile-rewrite-goals-20260601/94-STALE-OFFLINE-RUNTIME-TRUTH-EVIDENCE-20260604.md`
- `/Users/jarvis/Desktop/friday-rust-mobile-rewrite-goals-20260601/95-NATIVE-FACING-RUNTIME-CONTRACT-EVIDENCE-20260604.md`
- `/Users/jarvis/Desktop/friday-rust-mobile-rewrite-goals-20260601/96-POST-515-CAPABILITY-REGISTRY-AND-UX-RUNTIME-REFRESH-20260604.md`
- `/Users/jarvis/Desktop/friday-rust-mobile-rewrite-goals-20260601/100-GLOBAL-TRUTH-AND-NEXT-ORDER-20260604.md`
- `/Users/jarvis/Desktop/friday-rust-mobile-rewrite-goals-20260601/101-RUST-REWRITE-VISIBLE-TASK-BOARD-20260604.md`

## Verification already run locally

```bash
cargo test --workspace
cargo clippy --workspace --all-targets -- -D warnings
cargo fmt --all -- --check
git diff --check
detect-secrets scan crates/friday-ffi/src/lib.rs
```

Also observed:

- design source freshness is green: `node scripts/source-freshness-test.js` passes.
- final design implementation prompt gate still fails because mobile/desktop/telegram are not operator-confirmed; this PR does not attempt UI wiring.

## Remaining file-92 work after this PR

- Phase 5: Provider Workspace headless continuation.
- Phase 6: Channels headless continuation.
- Phase 7: `99-AUTOMATABLE-RUST-CLOSURE-STATUS-20260604.md`.
