### PR TITLE
feat(provider): provider timeline reconnect wire contract

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -305,7 +305,7 @@
         "filename": "rust-core/crates/friday-protocol/src/lib.rs",
         "hashed_secret": "187d0c692ee306ab675fb8fa24dc3cd506cefc28",
         "is_verified": false,
-        "line_number": 896
+        "line_number": 1019
       }
     ],
     "scripts/e2e-workflow-generator.sh": [
@@ -1133,5 +1133,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-29T03:25:46Z"
+  "generated_at": "2026-06-04T05:51:03Z"
 }

--- a/rust-core/crates/friday-ffi/src/lib.rs
+++ b/rust-core/crates/friday-ffi/src/lib.rs
@@ -741,6 +741,7 @@ fn message_kind_name(m: &friday_protocol::Message) -> &'static str {
         M::ProviderWorkspaceSnapshot { .. } => "ProviderWorkspaceSnapshot",
         M::ProviderWorkspaceActionRequest { .. } => "ProviderWorkspaceActionRequest",
         M::ProviderWorkspaceActionResult { .. } => "ProviderWorkspaceActionResult",
+        M::ProviderTimelineReconnect { .. } => "ProviderTimelineReconnect",
         M::Error { .. } => "Error",
     }
 }

--- a/rust-core/crates/friday-hub/src/provider_timeline.rs
+++ b/rust-core/crates/friday-hub/src/provider_timeline.rs
@@ -14,7 +14,10 @@
 //! - Events carry only refs (`body_ref`/`provider_event_id`), never raw transcript text.
 //! - Pure logic, no I/O; per-session isolation means one noisy stream cannot stall another.
 
-use friday_protocol::{IdempotencyTracker, Seen};
+use friday_protocol::{
+    IdempotencyTracker, Message, ProviderTimelineEventWire, ProviderTimelinePendingWire,
+    ProviderTimelineReconnectWire, Seen,
+};
 use std::collections::BTreeMap;
 
 /// A Friday-canonical timeline event (file 83 §ProviderTimelineEvent), metadata-only.
@@ -90,6 +93,24 @@ impl PendingState {
                 | (FailedRetryable, FailedTerminal)
                 | (FailedRetryable, Cancelled)
         )
+    }
+
+    /// The snake_case wire label. `sent_to_hub`/`accepted_by_hub` are Hub-ack states, NOT
+    /// completion — only `provider_completed` is both a real completion and terminal.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            PendingState::Draft => "draft",
+            PendingState::PendingLocal => "pending_local",
+            PendingState::SentToHub => "sent_to_hub",
+            PendingState::AcceptedByHub => "accepted_by_hub",
+            PendingState::RoutedToProvider => "routed_to_provider",
+            PendingState::WaitingProvider => "waiting_provider",
+            PendingState::ProviderCompleted => "provider_completed",
+            PendingState::Blocked => "blocked",
+            PendingState::FailedRetryable => "failed_retryable",
+            PendingState::FailedTerminal => "failed_terminal",
+            PendingState::Cancelled => "cancelled",
+        }
     }
 }
 
@@ -312,9 +333,88 @@ impl ProviderTimeline {
     }
 }
 
+// --- wire projection (SMOOTH-001 continuation): refs-only, ack≠completion preserved ---
+//
+// Pure (no I/O, no model call). The timeline owns the reconnect CONTRACT; building the wire
+// here keeps that ownership in one place. EMITTING it over the serve-loop rides with the
+// native shell — this is the contract + its proof, not the serve-loop wiring (the same
+// headless boundary as the Phase-3 FFI contract shipping without a native shell).
+
+/// Project an (in-memory) [`Reconnect`] to its refs-only wire form. The mapping is total and
+/// STRUCTURAL: a [`TimelineEvent`] carries only its refs (`body_ref`/`provider_event_id`) and
+/// a [`PendingAction`]'s `state`/`terminal` preserve Hub-ack≠provider-completion — there is no
+/// wire field that can hold raw transcript text.
+pub fn reconnect_to_wire(reconnect: &Reconnect) -> ProviderTimelineReconnectWire {
+    match reconnect {
+        Reconnect::Delta {
+            from_seq,
+            to_seq,
+            from_revision,
+            to_revision,
+            events,
+            pending,
+        } => ProviderTimelineReconnectWire::Delta {
+            from_seq: *from_seq,
+            to_seq: *to_seq,
+            from_revision: *from_revision,
+            to_revision: *to_revision,
+            events: events.iter().map(event_to_wire).collect(),
+            pending: pending.iter().map(pending_to_wire).collect(),
+        },
+        Reconnect::Snapshot {
+            to_seq,
+            revision,
+            events,
+            pending,
+            reason,
+        } => ProviderTimelineReconnectWire::Snapshot {
+            to_seq: *to_seq,
+            revision: *revision,
+            events: events.iter().map(event_to_wire).collect(),
+            pending: pending.iter().map(pending_to_wire).collect(),
+            reason: (*reason).to_string(),
+        },
+    }
+}
+
+/// Wrap a reconnect projection in the protocol [`Message`] a Hub would send a reconnecting
+/// client for `friday_session_id`.
+pub fn reconnect_to_message(friday_session_id: &str, reconnect: &Reconnect) -> Message {
+    Message::ProviderTimelineReconnect {
+        friday_session_id: friday_session_id.to_string(),
+        reconnect: reconnect_to_wire(reconnect),
+    }
+}
+
+fn event_to_wire(e: &TimelineEvent) -> ProviderTimelineEventWire {
+    ProviderTimelineEventWire {
+        seq: e.seq,
+        revision: e.revision,
+        event_kind: e.event_kind.clone(),
+        actor: e.actor.clone(),
+        body_ref: e.body_ref.clone(),
+        provider_event_id: e.provider_event_id.clone(),
+    }
+}
+
+fn pending_to_wire(p: &PendingAction) -> ProviderTimelinePendingWire {
+    ProviderTimelinePendingWire {
+        request_id: p.request_id.clone(),
+        client_msg_id: p.client_msg_id.clone(),
+        action: p.action.clone(),
+        state: p.state.as_str().to_string(),
+        terminal: p.state.is_terminal(),
+        dispatch_ref: p.dispatch_ref.clone(),
+        blocker: p.blocker.clone(),
+        base_revision: p.base_revision,
+        updated_at_revision: p.updated_at_revision,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use friday_protocol::Envelope;
 
     fn seeded() -> ProviderTimeline {
         let mut t = ProviderTimeline::new("friday-session-1");
@@ -486,5 +586,88 @@ mod tests {
         let debug = format!("{ev:?}");
         assert!(debug.contains("body://ref/1"));
         // body_ref is a ref; there is no field that could carry raw transcript text.
+    }
+
+    // --- wire projection tests ---
+
+    #[test]
+    fn delta_projects_to_refs_only_wire_and_round_trips_over_the_protocol() {
+        let mut t = seeded(); // 5 events (seq 1..=5, body://1..5)
+        t.submit_pending("c1", "r1", "send_turn");
+        t.advance_pending("r1", PendingState::SentToHub, None, None)
+            .unwrap();
+        t.advance_pending("r1", PendingState::AcceptedByHub, None, None)
+            .unwrap();
+        // Reconnect from a mid cursor → DELTA (cursor retained).
+        let reconnect = t.reconnect(3, 3);
+        assert!(matches!(reconnect, Reconnect::Delta { .. }));
+
+        let wire = reconnect_to_wire(&reconnect);
+        match &wire {
+            ProviderTimelineReconnectWire::Delta {
+                events, pending, ..
+            } => {
+                // Only the missed events (seq > 3) are present, in order, with their refs.
+                assert_eq!(events.iter().map(|e| e.seq).collect::<Vec<_>>(), vec![4, 5]);
+                assert_eq!(events[0].body_ref.as_deref(), Some("body://4"));
+                // The Hub-ack pending action is projected NOT terminal (ack != completion).
+                let p = pending.iter().find(|p| p.request_id == "r1").unwrap();
+                assert_eq!(p.state, "accepted_by_hub");
+                assert!(!p.terminal);
+            }
+            other => panic!("expected Delta wire, got {other:?}"),
+        }
+
+        // Round-trips losslessly through the protocol envelope.
+        let msg = reconnect_to_message("friday-session-1", &reconnect);
+        let env = Envelope::new("ptl-1", 1, msg.clone());
+        let json = env.encode().unwrap();
+        assert!(json.contains("\"mode\":\"delta\""));
+        // STRUCTURAL ref-only: a raw transcript value never reaches the wire — the only
+        // body-bearing field is the `body_ref` ref (asserted by the absence of a sentinel
+        // we never put into a ref).
+        assert!(!json.contains("RAW-TRANSCRIPT-BODY"));
+        assert_eq!(Envelope::decode(&json).unwrap().message, msg);
+    }
+
+    #[test]
+    fn snapshot_fallback_projects_with_reason_and_round_trips() {
+        let mut t = seeded();
+        t.prune_before(4); // drop seq 1..=3 from retention
+                           // A cursor behind retention → SNAPSHOT fallback.
+        let reconnect = t.reconnect(1, 1);
+        assert!(matches!(reconnect, Reconnect::Snapshot { .. }));
+
+        let msg = reconnect_to_message("friday-session-1", &reconnect);
+        let env = Envelope::new("ptl-2", 2, msg.clone());
+        let json = env.encode().unwrap();
+        assert!(json.contains("\"mode\":\"snapshot\""));
+        assert!(json.contains("\"reason\":\"cursor_behind_retention\""));
+        assert_eq!(Envelope::decode(&json).unwrap().message, msg);
+    }
+
+    #[test]
+    fn pending_wire_preserves_ack_is_not_completion_for_every_state() {
+        // Every non-`ProviderCompleted` state projects `terminal=false` OR a terminal
+        // FAILURE/cancel — never a completion. Only `provider_completed` is a real completion.
+        let mut t = ProviderTimeline::new("s");
+        t.submit_pending("c1", "r1", "send_turn");
+        for (to, expect_terminal) in [
+            (PendingState::SentToHub, false),
+            (PendingState::AcceptedByHub, false),
+            (PendingState::RoutedToProvider, false),
+            (PendingState::WaitingProvider, false),
+            (PendingState::ProviderCompleted, true),
+        ] {
+            t.advance_pending("r1", to, None, None).unwrap();
+            let wire = pending_to_wire(t.pending("r1").unwrap());
+            assert_eq!(wire.state, to.as_str());
+            assert_eq!(wire.terminal, expect_terminal);
+            // Only provider_completed is BOTH terminal and a real completion.
+            assert_eq!(
+                wire.terminal && wire.state == "provider_completed",
+                to == PendingState::ProviderCompleted
+            );
+        }
     }
 }

--- a/rust-core/crates/friday-protocol/src/lib.rs
+++ b/rust-core/crates/friday-protocol/src/lib.rs
@@ -169,6 +169,64 @@ pub struct ProviderWorkspaceActionResultWire {
     pub dispatch_ref: Option<String>,
 }
 
+/// One provider-session timeline event on the wire (metadata-only). It carries ONLY
+/// refs (`body_ref`/`provider_event_id`) — never raw transcript text. This is a
+/// structural guarantee: there is no field on this type that can hold a transcript body.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProviderTimelineEventWire {
+    pub seq: u64,
+    pub revision: u64,
+    pub event_kind: String,
+    pub actor: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub body_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_event_id: Option<String>,
+}
+
+/// A Friday-originated pending action on the wire. `state` is the lifecycle label and
+/// `terminal` is whether that state is terminal — together they preserve the honesty
+/// invariant that a Hub ack (`sent_to_hub`/`accepted_by_hub`) is NOT a provider
+/// completion: only `provider_completed` is both terminal and a real completion.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProviderTimelinePendingWire {
+    pub request_id: String,
+    pub client_msg_id: String,
+    pub action: String,
+    pub state: String,
+    pub terminal: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dispatch_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blocker: Option<String>,
+    pub base_revision: u64,
+    pub updated_at_revision: u64,
+}
+
+/// The provider-session timeline reconnect answer on the wire: a bounded `delta` when
+/// the client's cursor is still retained, else a `snapshot` (full retained replay) when
+/// it is behind retention. Mirrors the Hub-side `ProviderTimeline::reconnect`; a UI applies
+/// a delta incrementally and replaces on a snapshot. Internally tagged by `mode`.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+pub enum ProviderTimelineReconnectWire {
+    Delta {
+        from_seq: u64,
+        to_seq: u64,
+        from_revision: u64,
+        to_revision: u64,
+        events: Vec<ProviderTimelineEventWire>,
+        pending: Vec<ProviderTimelinePendingWire>,
+    },
+    Snapshot {
+        to_seq: u64,
+        revision: u64,
+        events: Vec<ProviderTimelineEventWire>,
+        pending: Vec<ProviderTimelinePendingWire>,
+        reason: String,
+    },
+}
+
 /// Structured QR payload for Hub/device pairing. This is the JSON that can be
 /// encoded into a QR code. It contains a short-lived Friday pairing secret, but
 /// never provider OAuth/API/session material.
@@ -398,6 +456,13 @@ pub enum Message {
     /// hub->client: pre-dispatch result for a Provider Workspace action request.
     ProviderWorkspaceActionResult {
         result: ProviderWorkspaceActionResultWire,
+    },
+    /// hub->client: provider-session timeline reconnect — a bounded DELTA when the
+    /// client's cursor is retained, else a SNAPSHOT. Events carry refs only (never raw
+    /// transcript); a pending action's `state`/`terminal` preserve Hub-ack≠completion.
+    ProviderTimelineReconnect {
+        friday_session_id: String,
+        reconnect: ProviderTimelineReconnectWire,
     },
     /// either: explicit error code + message.
     Error { code: ErrorCode, message: String },
@@ -658,6 +723,64 @@ mod tests {
             let back = Envelope::decode(&json).unwrap();
             assert_eq!(back, env);
         }
+    }
+
+    #[test]
+    fn provider_timeline_reconnect_wire_round_trips_delta_and_snapshot() {
+        // DELTA: internally tagged by mode; events carry refs only; a Hub-ack pending
+        // action is NOT terminal (ack != provider completion).
+        let delta = Message::ProviderTimelineReconnect {
+            friday_session_id: "fsess-1".into(),
+            reconnect: ProviderTimelineReconnectWire::Delta {
+                from_seq: 2,
+                to_seq: 4,
+                from_revision: 5,
+                to_revision: 7,
+                events: vec![ProviderTimelineEventWire {
+                    seq: 3,
+                    revision: 6,
+                    event_kind: "provider_event".into(),
+                    actor: "provider".into(),
+                    body_ref: Some("ref://event/3".into()),
+                    provider_event_id: Some("pe-3".into()),
+                }],
+                pending: vec![ProviderTimelinePendingWire {
+                    request_id: "r1".into(),
+                    client_msg_id: "c1".into(),
+                    action: "send_turn".into(),
+                    state: "accepted_by_hub".into(),
+                    terminal: false,
+                    dispatch_ref: None,
+                    blocker: None,
+                    base_revision: 5,
+                    updated_at_revision: 6,
+                }],
+            },
+        };
+        let env = Envelope::new("ptl-delta", 1000, delta.clone());
+        let json = env.encode().unwrap();
+        assert!(json.contains("\"kind\":\"ProviderTimelineReconnect\""));
+        assert!(json.contains("\"mode\":\"delta\""));
+        assert!(json.contains("\"body_ref\":\"ref://event/3\""));
+        assert!(json.contains("\"terminal\":false")); // Hub ack is not completion
+        assert_eq!(Envelope::decode(&json).unwrap(), env);
+
+        // SNAPSHOT: carries the fallback reason; round-trips.
+        let snapshot = Message::ProviderTimelineReconnect {
+            friday_session_id: "fsess-1".into(),
+            reconnect: ProviderTimelineReconnectWire::Snapshot {
+                to_seq: 9,
+                revision: 12,
+                events: vec![],
+                pending: vec![],
+                reason: "cursor_behind_retention".into(),
+            },
+        };
+        let env = Envelope::new("ptl-snap", 1001, snapshot);
+        let json = env.encode().unwrap();
+        assert!(json.contains("\"mode\":\"snapshot\""));
+        assert!(json.contains("\"reason\":\"cursor_behind_retention\""));
+        assert_eq!(Envelope::decode(&json).unwrap(), env);
     }
 
     #[test]


### PR DESCRIPTION
Stacked on #516. Do not merge before #516 lands, and do not merge without operator approval.

Scope:
- Adds provider timeline reconnect wire projection for delta/snapshot reconnects.
- Preserves refs-only events and pending action state on the wire.
- Keeps Hub ack distinct from provider completion.
- Adds protocol round-trip coverage and FFI unsupported-message-kind handling.

Evidence:
- /Users/jarvis/Desktop/friday-rust-mobile-rewrite-goals-20260601/97-PROVIDER-WORKSPACE-HEADLESS-CONTINUATION-EVIDENCE-20260604.md
- Verified in clean worktree at commit 2d04de1e.

Verification run:
- cargo test -p friday-protocol provider_timeline
- cargo test -p friday-hub provider_timeline
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check
- git ls-files -z | xargs -0 detect-secrets-hook --baseline .secrets.baseline

Not claimed:
- Not Friday v1 GO.
- No provider_native_synced claim.
- No UI wiring.
- No live provider/model turn.
- No official Codex/Claude Remote proof.
- Not emitted by the Hub serve-loop yet and not consumed by native UI yet.

This PR proves only the Phase 5 headless provider timeline reconnect wire contract.