### PR TITLE
[codex] Add TS runtime retirement manifest gate

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -1,0 +1,370 @@
+{
+  "schemaVersion": 1,
+  "kind": "friday.ts_runtime_retirement_manifest",
+  "status": "phase_1_inventory_gate_only",
+  "authority": {
+    "branch": "merged-main-post-pr-521",
+    "commit": "0fa22545",
+    "default_machine_db_mutation": "forbidden"
+  },
+  "discovery": {
+    "routeSourceDir": "src/api/http/routes",
+    "includeMethods": ["GET", "POST", "PATCH", "PUT", "DELETE"]
+  },
+  "classificationValues": [
+    "ui_shell",
+    "test_oracle",
+    "release_tooling",
+    "compat_shim",
+    "rust_delegated",
+    "operator_external_adapter",
+    "fail_closed",
+    "ts_runtime_blocker"
+  ],
+  "forbiddenCompletionSources": [
+    "provider_ack",
+    "timeline_read",
+    "process_exit",
+    "skill_run",
+    "channel_receipt"
+  ],
+  "defaultCompletionSemantics": {
+    "provider_ack": false,
+    "timeline_read": false,
+    "process_exit": false,
+    "skill_run": false,
+    "channel_receipt": false
+  },
+  "requiredLeakControls": [
+    "raw_transcripts",
+    "secrets",
+    "private_paths",
+    "provider_ids",
+    "channel_ids",
+    "raw_commands",
+    "private_reasoning"
+  ],
+  "routeFamilies": [
+    {
+      "id": "mission_spine_rust_projection",
+      "match": {
+        "sourceFile": "src/api/http/routes/friday-mission-spine-routes.ts"
+      },
+      "classification": "rust_delegated",
+      "user_triggerable": true,
+      "rust_entrypoint": "rust-core/crates/friday-hub/src/mission_workbench.rs",
+      "proof": "post-merge UI/device proof and closure status use real Rust Hub Workbench projection for mission_workbench_probe_20260605",
+      "next_action": "Keep TypeScript as a redacted HTTP adapter over Rust Mission Spine projections."
+    },
+    {
+      "id": "agent_runtime_blockers",
+      "match": {
+        "sourceFile": "src/api/http/routes/friday-agent-routes.ts"
+      },
+      "classification": "ts_runtime_blocker",
+      "user_triggerable": true,
+      "owner": "ts-runtime-retirement",
+      "blocker": "Agent routes still call TypeScript runtime dependencies for starting, cancelling, rolling back, approval, and automation execution.",
+      "next_action": "Retire POST /v1/agent/runs first by delegating execution truth to a Rust-owned entrypoint or leaving the route fail-closed until Rust ownership exists."
+    },
+    {
+      "id": "agent_loop_runtime_blockers",
+      "match": {
+        "sourceFile": "src/api/http/routes/friday-agent-loop-routes.ts"
+      },
+      "classification": "ts_runtime_blocker",
+      "user_triggerable": true,
+      "owner": "ts-runtime-retirement",
+      "blocker": "Agent loop policy and loop controls remain TypeScript-owned runtime surfaces.",
+      "next_action": "Move loop execution and run-control truth to Rust or fail-close controls that cannot complete work from TypeScript-only signals."
+    },
+    {
+      "id": "workflow_runtime_blockers",
+      "match": {
+        "sourceFile": "src/api/http/routes/friday-workflow-run-routes.ts"
+      },
+      "classification": "ts_runtime_blocker",
+      "user_triggerable": true,
+      "owner": "ts-runtime-retirement",
+      "blocker": "Workflow run routes still wire TypeScript workflow runtime execution.",
+      "next_action": "Delegate POST /v1/workflow-runs and run controls to Rust-owned workflow execution or fail-close them with an operator-visible retirement label."
+    },
+    {
+      "id": "workflow_catalog_and_builder_runtime_blockers",
+      "match": {
+        "operationIdPrefix": [
+          "workflows.",
+          "workflow.",
+          "runs.",
+          "task.workflow.",
+          "workflow.builder.",
+          "workflow.generator."
+        ]
+      },
+      "classification": "ts_runtime_blocker",
+      "user_triggerable": true,
+      "owner": "ts-runtime-retirement",
+      "blocker": "Workflow authoring, import, generator, and task-workflow controls can still shape user-triggerable runtime behavior from TypeScript.",
+      "next_action": "Classify each workflow control as Rust-delegated, fail-closed, or compatibility-only after POST /v1/workflow-runs is retired."
+    },
+    {
+      "id": "skill_runtime_blockers",
+      "match": {
+        "operationIdPrefix": [
+          "skills.run",
+          "skills.verify",
+          "skills.generator.",
+          "skills.converter."
+        ]
+      },
+      "classification": "ts_runtime_blocker",
+      "user_triggerable": true,
+      "owner": "ts-runtime-retirement",
+      "blocker": "Skill execution and generation routes still operate from TypeScript services.",
+      "next_action": "Retire POST /v1/skills/:skillId/run by routing to Rust-owned execution truth or fail-closing execution while preserving catalog/UI compatibility."
+    },
+    {
+      "id": "skill_catalog_compatibility",
+      "match": {
+        "sourceFile": "src/api/http/routes/friday-skill-routes.ts"
+      },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Keep skill catalog, install, update, delete, and manifest validation as compatibility surfaces while skill execution ownership is retired separately.",
+      "next_action": "After skill execution is retired, split remaining skill lifecycle routes into release tooling or Rust-delegated lifecycle surfaces."
+    },
+    {
+      "id": "auto_fix_runtime_blockers",
+      "match": {
+        "sourceFile": "src/api/http/routes/friday-auto-fix-routes.ts"
+      },
+      "classification": "ts_runtime_blocker",
+      "user_triggerable": true,
+      "owner": "ts-runtime-retirement",
+      "blocker": "Auto-fix execute, run-ready, and rollback routes still execute product-changing logic from TypeScript.",
+      "next_action": "Move execute/rollback truth to Rust or fail-close TypeScript execution routes with preserved review/approval reads."
+    },
+    {
+      "id": "channel_webhook_external_adapters",
+      "match": {
+        "sourceFile": "src/api/http/routes/friday-channel-webhook-routes.ts"
+      },
+      "classification": "operator_external_adapter",
+      "user_triggerable": true,
+      "trust_boundary": "External channel ingress adapter only; channel receipt is not completion.",
+      "leak_controls": {
+        "raw_private_data_allowed": false,
+        "forbidden": [
+          "raw_transcripts",
+          "secrets",
+          "private_paths",
+          "provider_ids",
+          "channel_ids",
+          "raw_commands",
+          "private_reasoning"
+        ]
+      },
+      "next_action": "Keep ingress as external adapter and move any resulting runtime execution truth into Rust-owned mission/workflow surfaces."
+    },
+    {
+      "id": "channel_management_external_adapters",
+      "match": {
+        "sourceFile": "src/api/http/routes/friday-channel-routes.ts"
+      },
+      "classification": "operator_external_adapter",
+      "user_triggerable": true,
+      "trust_boundary": "Channel configuration adapter only; channel state or receipt is not completion.",
+      "leak_controls": {
+        "raw_private_data_allowed": false,
+        "forbidden": [
+          "raw_transcripts",
+          "secrets",
+          "private_paths",
+          "provider_ids",
+          "channel_ids",
+          "raw_commands",
+          "private_reasoning"
+        ]
+      },
+      "next_action": "Retain redacted configuration adapter until channel runtime handoff is Rust-owned."
+    },
+    {
+      "id": "desktop_runtime_blockers",
+      "match": {
+        "sourceFile": "src/api/http/routes/friday-desktop-routes.ts"
+      },
+      "classification": "ts_runtime_blocker",
+      "user_triggerable": true,
+      "owner": "ts-runtime-retirement",
+      "blocker": "Desktop action, recording, replay, and permission routes remain mixed TypeScript-owned runtime surfaces.",
+      "next_action": "Retire desktop action execution and replay routes after channel runtime, preserving permission and policy routes as operator adapters."
+    },
+    {
+      "id": "provider_external_adapters",
+      "match": {
+        "sourceFile": [
+          "src/api/http/routes/friday-provider-routes.ts",
+          "src/api/http/routes/friday-provider-usage-routes.ts"
+        ]
+      },
+      "classification": "operator_external_adapter",
+      "user_triggerable": true,
+      "trust_boundary": "Provider configuration and OAuth adapter only; provider acknowledgements are not completion.",
+      "leak_controls": {
+        "raw_private_data_allowed": false,
+        "forbidden": [
+          "raw_transcripts",
+          "secrets",
+          "private_paths",
+          "provider_ids",
+          "channel_ids",
+          "raw_commands",
+          "private_reasoning"
+        ]
+      },
+      "next_action": "Keep provider-native remote proof out of scope until TS runtime blockers are retired or precisely externally blocked."
+    },
+    {
+      "id": "release_and_packaging_tooling",
+      "match": {
+        "sourceFile": [
+          "src/api/http/routes/friday-packaging-routes.ts",
+          "src/api/http/routes/friday-runtime-admin-routes.ts"
+        ]
+      },
+      "classification": "release_tooling",
+      "user_triggerable": true,
+      "migration_intent": "Release, packaging, and runtime-admin controls are not Friday v1 runtime completion truth.",
+      "next_action": "Keep out of provider-native/release claims until runtime retirement passes."
+    },
+    {
+      "id": "security_auth_setup_compatibility",
+      "match": {
+        "operationIdPrefix": [
+          "auth.",
+          "security.",
+          "setup.",
+          "grants.",
+          "secrets."
+        ]
+      },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Security, auth, setup, grant, and secret APIs remain compatibility surfaces and do not own task completion truth.",
+      "next_action": "Reclassify individual mutating security routes if they begin owning user task execution."
+    },
+    {
+      "id": "ui_control_shell",
+      "match": {
+        "operationIdPrefix": [
+          "uix.",
+          "studio.",
+          "reflex.",
+          "guidelens."
+        ]
+      },
+      "classification": "ui_shell",
+      "user_triggerable": true,
+      "migration_intent": "UI and guidance controls remain shell surfaces and must not become completion truth.",
+      "next_action": "Keep UI shell separated from Rust-owned runtime truth."
+    },
+    {
+      "id": "memory_review_only_compatibility",
+      "match": {
+        "sourceFile": "src/api/http/routes/friday-memory-routes.ts"
+      },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Memory candidates remain review-only; memory routes must not mark task completion.",
+      "next_action": "Reclassify memory writes if they become runtime completion signals."
+    },
+    {
+      "id": "general_runtime_blocker_inventory",
+      "match": {
+        "method": ["POST", "PATCH", "PUT", "DELETE"]
+      },
+      "classification": "ts_runtime_blocker",
+      "user_triggerable": true,
+      "owner": "ts-runtime-retirement",
+      "blocker": "Mutating TypeScript route is not yet proven to be UI-only, release-only, Rust-delegated, fail-closed, or an external adapter.",
+      "next_action": "Review and split into a narrower classification before claiming TS runtime retirement done."
+    },
+    {
+      "id": "read_route_compatibility_inventory",
+      "match": {
+        "method": ["GET"]
+      },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Read-only TypeScript HTTP route remains an inventory compatibility surface unless a narrower Rust-delegated or external-adapter rule applies.",
+      "next_action": "Keep read surfaces bounded/redacted and split any runtime-owner reads into explicit blockers."
+    }
+  ],
+  "surfaces": [
+    {
+      "id": "agent_runs_start",
+      "route": {
+        "method": "POST",
+        "path": "/v1/agent/runs",
+        "operationId": "agent.runs.start"
+      },
+      "classification": "ts_runtime_blocker",
+      "user_triggerable": true,
+      "owner": "ts-runtime-retirement",
+      "blocker": "Starts agent runtime through TypeScript dependencies.",
+      "next_action": "Redirect execution truth to Rust-owned agent entrypoint or return fail-closed unavailable response."
+    },
+    {
+      "id": "workflow_runs_start",
+      "route": {
+        "method": "POST",
+        "path": "/v1/workflow-runs",
+        "operationId": "runs.start"
+      },
+      "classification": "ts_runtime_blocker",
+      "user_triggerable": true,
+      "owner": "ts-runtime-retirement",
+      "blocker": "Starts workflow runtime through TypeScript execution service.",
+      "next_action": "Redirect run creation/execution truth to Rust-owned workflow entrypoint or fail-close the route."
+    },
+    {
+      "id": "skills_run",
+      "route": {
+        "method": "POST",
+        "path": "/v1/skills/:skillId/run",
+        "operationId": "skills.run"
+      },
+      "classification": "ts_runtime_blocker",
+      "user_triggerable": true,
+      "owner": "ts-runtime-retirement",
+      "blocker": "Executes skill through TypeScript skill executor.",
+      "next_action": "Replace TypeScript skill execution with Rust-owned execution truth or fail-close skill runs."
+    },
+    {
+      "id": "autofix_execute",
+      "route": {
+        "method": "POST",
+        "path": "/v1/auto-fix/actions/:actionId/execute",
+        "operationId": "autofix.actions.execute"
+      },
+      "classification": "ts_runtime_blocker",
+      "user_triggerable": true,
+      "owner": "ts-runtime-retirement",
+      "blocker": "Executes auto-fix action through TypeScript service.",
+      "next_action": "Move auto-fix execute/rollback truth to Rust or fail-close execution."
+    },
+    {
+      "id": "desktop_actions_execute",
+      "route": {
+        "method": "POST",
+        "path": "/v1/desktop/actions/execute",
+        "operationId": "desktop.actions.execute"
+      },
+      "classification": "ts_runtime_blocker",
+      "user_triggerable": true,
+      "owner": "ts-runtime-retirement",
+      "blocker": "Desktop action execution remains TypeScript-owned.",
+      "next_action": "Route desktop execution through Rust-owned action authority or fail-close action execution."
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "check:security-doctor": "node scripts/ops/check-friday-security-doctor.mjs",
     "check:secret-patterns": "node scripts/quality/check-provider-key-patterns.mjs",
     "check:public-source-hygiene": "node scripts/quality/check-public-source-hygiene.mjs",
+    "check:ts-runtime-retirement": "node scripts/quality/check-ts-runtime-retirement.mjs",
     "check:audit-integrity": "node scripts/ops/check-friday-audit-integrity.mjs",
     "setup:hooks": "bash scripts/setup-hooks.sh",
     "ops:converge-runtime": "bash scripts/ops/friday-converge-runtime.sh",

--- a/scripts/quality/check-ts-runtime-retirement.mjs
+++ b/scripts/quality/check-ts-runtime-retirement.mjs
@@ -1,0 +1,307 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ALLOWED_CLASSIFICATIONS = new Set([
+  "ui_shell",
+  "test_oracle",
+  "release_tooling",
+  "compat_shim",
+  "rust_delegated",
+  "operator_external_adapter",
+  "fail_closed",
+  "ts_runtime_blocker",
+]);
+
+const ROUTE_REGEX = /operationId:\s*"([^"]+)"[\s\S]{0,700}?method:\s*"([A-Z]+)"[\s\S]{0,700}?path:\s*"([^"]+)"/gu;
+
+export function parseArgs(argv) {
+  const args = {
+    repoRoot: process.cwd(),
+    manifestPath: "docs/ops/ts-runtime-retirement-manifest.json",
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const entry = argv[index];
+    if (entry === "--manifest") {
+      args.manifestPath = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (entry === "--repo-root") {
+      args.repoRoot = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (!entry.startsWith("--")) {
+      args.repoRoot = entry;
+    }
+  }
+
+  return args;
+}
+
+export function discoverRoutes(repoRoot, routeSourceDir) {
+  const absoluteRouteDir = path.join(repoRoot, routeSourceDir);
+  const routeFiles = walkRouteFiles(absoluteRouteDir);
+  const seen = new Set();
+  const routes = [];
+
+  for (const filePath of routeFiles) {
+    const sourceFile = path.relative(repoRoot, filePath);
+    const content = fs.readFileSync(filePath, "utf8");
+    for (const match of content.matchAll(ROUTE_REGEX)) {
+      const route = {
+        operationId: match[1],
+        method: match[2],
+        path: match[3],
+        sourceFile,
+      };
+      const key = routeKey(route);
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      routes.push(route);
+    }
+  }
+
+  return routes.sort((left, right) => routeKey(left).localeCompare(routeKey(right)));
+}
+
+export function collectTsRuntimeRetirementFailures(manifest, routes) {
+  const failures = [];
+  validateManifestBasics(manifest, failures);
+
+  const includeMethods = new Set(manifest.discovery?.includeMethods ?? []);
+  const discoveredRoutes = routes.filter((route) => includeMethods.size === 0 || includeMethods.has(route.method));
+  const exactSurfaces = manifest.surfaces ?? [];
+  const routeFamilies = manifest.routeFamilies ?? [];
+
+  for (const surface of exactSurfaces) {
+    if (!surface.route) {
+      failures.push(`surface ${surface.id ?? "<unknown>"} is missing route`);
+      continue;
+    }
+    const exists = discoveredRoutes.some((route) => routeMatchesExact(route, surface.route));
+    if (!exists) {
+      failures.push(`surface ${surface.id ?? surface.route.operationId} does not match a discovered route`);
+    }
+  }
+
+  const classified = [];
+  for (const route of discoveredRoutes) {
+    const classification = findClassificationForRoute(route, exactSurfaces, routeFamilies);
+    if (!classification) {
+      failures.push(`${routeLabel(route)} is unclassified`);
+      continue;
+    }
+    classified.push({ route, classification });
+    validateClassification(route, classification, manifest, failures);
+  }
+
+  return {
+    failures,
+    classified,
+    summary: summarizeClassifiedRoutes(classified),
+  };
+}
+
+export function findClassificationForRoute(route, exactSurfaces, routeFamilies) {
+  const exact = exactSurfaces.find((surface) => surface.route && routeMatchesExact(route, surface.route));
+  if (exact) {
+    return exact;
+  }
+  return routeFamilies.find((family) => routeMatchesRule(route, family.match ?? {}));
+}
+
+function validateManifestBasics(manifest, failures) {
+  if (manifest.schemaVersion !== 1) {
+    failures.push("manifest schemaVersion must be 1");
+  }
+  for (const value of manifest.classificationValues ?? []) {
+    if (!ALLOWED_CLASSIFICATIONS.has(value)) {
+      failures.push(`manifest contains unknown classification value ${value}`);
+    }
+  }
+  for (const required of ALLOWED_CLASSIFICATIONS) {
+    if (!(manifest.classificationValues ?? []).includes(required)) {
+      failures.push(`manifest classificationValues is missing ${required}`);
+    }
+  }
+}
+
+function validateClassification(route, classification, manifest, failures) {
+  const label = `${routeLabel(route)} via ${classification.id ?? "<unnamed>"}`;
+  if (!ALLOWED_CLASSIFICATIONS.has(classification.classification)) {
+    failures.push(`${label} has invalid classification ${classification.classification}`);
+    return;
+  }
+
+  validateCompletionSemantics(label, classification, manifest, failures);
+
+  if (classification.classification === "ts_runtime_blocker") {
+    for (const field of ["owner", "blocker", "next_action"]) {
+      if (!hasNonEmptyString(classification[field])) {
+        failures.push(`${label} is a ts_runtime_blocker without ${field}`);
+      }
+    }
+  }
+
+  if (classification.classification === "rust_delegated") {
+    for (const field of ["rust_entrypoint", "proof"]) {
+      if (!hasNonEmptyString(classification[field])) {
+        failures.push(`${label} is rust_delegated without ${field}`);
+      }
+    }
+  }
+
+  if (classification.classification === "fail_closed") {
+    if (classification.executes_product_logic !== false) {
+      failures.push(`${label} is fail_closed but does not declare executes_product_logic=false`);
+    }
+  }
+
+  if (classification.classification === "operator_external_adapter") {
+    validateLeakControls(label, classification, manifest.requiredLeakControls ?? [], failures);
+  }
+}
+
+function validateCompletionSemantics(label, classification, manifest, failures) {
+  const merged = {
+    ...(manifest.defaultCompletionSemantics ?? {}),
+    ...(classification.completion_semantics ?? {}),
+  };
+  for (const forbidden of manifest.forbiddenCompletionSources ?? []) {
+    if (merged[forbidden] !== false) {
+      failures.push(`${label} can treat ${forbidden} as completion`);
+    }
+  }
+}
+
+function validateLeakControls(label, classification, requiredLeakControls, failures) {
+  const leakControls = classification.leak_controls;
+  if (!leakControls || leakControls.raw_private_data_allowed !== false) {
+    failures.push(`${label} is operator_external_adapter without raw_private_data_allowed=false`);
+    return;
+  }
+  const forbidden = new Set(leakControls.forbidden ?? []);
+  for (const required of requiredLeakControls) {
+    if (!forbidden.has(required)) {
+      failures.push(`${label} leak controls are missing ${required}`);
+    }
+  }
+}
+
+function summarizeClassifiedRoutes(classified) {
+  const byClassification = {};
+  const blockerIds = new Set();
+  for (const { classification } of classified) {
+    byClassification[classification.classification] =
+      (byClassification[classification.classification] ?? 0) + 1;
+    if (classification.classification === "ts_runtime_blocker") {
+      blockerIds.add(classification.id);
+    }
+  }
+  return {
+    total: classified.length,
+    byClassification,
+    blockerFamilies: [...blockerIds].sort(),
+  };
+}
+
+function routeMatchesExact(route, expected) {
+  return route.method === expected.method
+    && route.path === expected.path
+    && route.operationId === expected.operationId;
+}
+
+function routeMatchesRule(route, rule) {
+  return matchStringOrArray(route.sourceFile, rule.sourceFile)
+    && matchStringOrArray(route.method, rule.method)
+    && matchStringOrArray(route.path, rule.path)
+    && matchPrefix(route.path, rule.pathPrefix)
+    && matchPrefix(route.operationId, rule.operationIdPrefix);
+}
+
+function matchStringOrArray(value, expected) {
+  if (expected === undefined) {
+    return true;
+  }
+  if (Array.isArray(expected)) {
+    return expected.includes(value);
+  }
+  return value === expected;
+}
+
+function matchPrefix(value, prefix) {
+  if (prefix === undefined) {
+    return true;
+  }
+  if (Array.isArray(prefix)) {
+    return prefix.some((entry) => value.startsWith(entry));
+  }
+  return value.startsWith(prefix);
+}
+
+function walkRouteFiles(routeDir) {
+  if (!fs.existsSync(routeDir)) {
+    return [];
+  }
+  const pending = [routeDir];
+  const files = [];
+  while (pending.length > 0) {
+    const current = pending.pop();
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const absolutePath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        pending.push(absolutePath);
+      } else if (entry.name.endsWith(".ts")) {
+        files.push(absolutePath);
+      }
+    }
+  }
+  return files;
+}
+
+function hasNonEmptyString(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function routeKey(route) {
+  return `${route.sourceFile} ${route.method} ${route.path} ${route.operationId}`;
+}
+
+function routeLabel(route) {
+  return `${route.method} ${route.path} (${route.operationId}, ${route.sourceFile})`;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const repoRoot = path.resolve(args.repoRoot);
+  const manifestPath = path.isAbsolute(args.manifestPath)
+    ? args.manifestPath
+    : path.join(repoRoot, args.manifestPath);
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  const routes = discoverRoutes(repoRoot, manifest.discovery?.routeSourceDir ?? "src/api/http/routes");
+  const result = collectTsRuntimeRetirementFailures(manifest, routes);
+  const report = {
+    generatedAt: new Date().toISOString(),
+    repoRoot,
+    manifestPath,
+    status: result.failures.length === 0 ? "passed" : "failed",
+    routeCount: routes.length,
+    summary: result.summary,
+    failures: result.failures,
+  };
+
+  console.log(JSON.stringify(report, null, 2));
+  process.exit(result.failures.length === 0 ? 0 : 1);
+}
+
+const currentFile = fileURLToPath(import.meta.url);
+if (process.argv[1] && path.resolve(process.argv[1]) === currentFile) {
+  main();
+}

--- a/test/unit/quality/ts-runtime-retirement-gate.test.ts
+++ b/test/unit/quality/ts-runtime-retirement-gate.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  collectTsRuntimeRetirementFailures,
+  findClassificationForRoute,
+} from "../../../scripts/quality/check-ts-runtime-retirement.mjs";
+
+const baseManifest = {
+  schemaVersion: 1,
+  discovery: {
+    includeMethods: ["GET", "POST"],
+  },
+  classificationValues: [
+    "ui_shell",
+    "test_oracle",
+    "release_tooling",
+    "compat_shim",
+    "rust_delegated",
+    "operator_external_adapter",
+    "fail_closed",
+    "ts_runtime_blocker",
+  ],
+  forbiddenCompletionSources: [
+    "provider_ack",
+    "timeline_read",
+    "process_exit",
+    "skill_run",
+    "channel_receipt",
+  ],
+  defaultCompletionSemantics: {
+    provider_ack: false,
+    timeline_read: false,
+    process_exit: false,
+    skill_run: false,
+    channel_receipt: false,
+  },
+  requiredLeakControls: [
+    "raw_transcripts",
+    "secrets",
+    "private_paths",
+    "provider_ids",
+    "channel_ids",
+    "raw_commands",
+    "private_reasoning",
+  ],
+  routeFamilies: [],
+  surfaces: [],
+};
+
+describe("TS runtime retirement gate", () => {
+  it("fails an unclassified user-triggerable route", () => {
+    const result = collectTsRuntimeRetirementFailures(baseManifest, [
+      {
+        method: "POST",
+        path: "/v1/agent/runs",
+        operationId: "agent.runs.start",
+        sourceFile: "src/api/http/routes/friday-agent-routes.ts",
+      },
+    ]);
+
+    expect(result.failures).toContain(
+      "POST /v1/agent/runs (agent.runs.start, src/api/http/routes/friday-agent-routes.ts) is unclassified",
+    );
+  });
+
+  it("requires blocker ownership, reason, and next action", () => {
+    const manifest = {
+      ...baseManifest,
+      routeFamilies: [
+        {
+          id: "agent_runtime",
+          match: { sourceFile: "src/api/http/routes/friday-agent-routes.ts" },
+          classification: "ts_runtime_blocker",
+          user_triggerable: true,
+          owner: "ts-runtime-retirement",
+          blocker: "TS owns agent runtime.",
+        },
+      ],
+    };
+
+    const result = collectTsRuntimeRetirementFailures(manifest, [
+      {
+        method: "POST",
+        path: "/v1/agent/runs",
+        operationId: "agent.runs.start",
+        sourceFile: "src/api/http/routes/friday-agent-routes.ts",
+      },
+    ]);
+
+    expect(result.failures).toContain(
+      "POST /v1/agent/runs (agent.runs.start, src/api/http/routes/friday-agent-routes.ts) via agent_runtime is a ts_runtime_blocker without next_action",
+    );
+  });
+
+  it("requires operator external adapters to declare private-data leak controls", () => {
+    const manifest = {
+      ...baseManifest,
+      routeFamilies: [
+        {
+          id: "channel_adapter",
+          match: { sourceFile: "src/api/http/routes/friday-channel-webhook-routes.ts" },
+          classification: "operator_external_adapter",
+          user_triggerable: true,
+          leak_controls: {
+            raw_private_data_allowed: false,
+            forbidden: ["raw_transcripts"],
+          },
+        },
+      ],
+    };
+
+    const result = collectTsRuntimeRetirementFailures(manifest, [
+      {
+        method: "POST",
+        path: "/v1/channel-webhooks/telegram",
+        operationId: "channels.webhooks.telegram",
+        sourceFile: "src/api/http/routes/friday-channel-webhook-routes.ts",
+      },
+    ]);
+
+    expect(result.failures).toContain(
+      "POST /v1/channel-webhooks/telegram (channels.webhooks.telegram, src/api/http/routes/friday-channel-webhook-routes.ts) via channel_adapter leak controls are missing secrets",
+    );
+  });
+
+  it("lets exact blocker surfaces override broader compatibility families", () => {
+    const manifest = {
+      ...baseManifest,
+      routeFamilies: [
+        {
+          id: "agent_compat",
+          match: { sourceFile: "src/api/http/routes/friday-agent-routes.ts" },
+          classification: "compat_shim",
+          user_triggerable: true,
+          migration_intent: "temporary",
+        },
+      ],
+      surfaces: [
+        {
+          id: "agent_runs_start",
+          route: {
+            method: "POST",
+            path: "/v1/agent/runs",
+            operationId: "agent.runs.start",
+          },
+          classification: "ts_runtime_blocker",
+          user_triggerable: true,
+          owner: "ts-runtime-retirement",
+          blocker: "TS starts runs.",
+          next_action: "Delegate or fail-close.",
+        },
+      ],
+    };
+
+    const classification = findClassificationForRoute(
+      {
+        method: "POST",
+        path: "/v1/agent/runs",
+        operationId: "agent.runs.start",
+        sourceFile: "src/api/http/routes/friday-agent-routes.ts",
+      },
+      manifest.surfaces,
+      manifest.routeFamilies,
+    );
+
+    expect(classification?.id).toBe("agent_runs_start");
+  });
+});


### PR DESCRIPTION
## Summary

- Add a machine-readable TS runtime retirement manifest for merged main after PR #521.
- Add a quality gate that statically discovers HTTP routes and requires exact or family classification coverage.
- Add focused unit coverage for unclassified routes, blocker metadata, external-adapter leak controls, and exact-surface override behavior.

## Scope

This is Phase 1 inventory/gate work only. It does not claim TS runtime retirement is complete, does not start provider-native remote proof, and does not claim Friday v1 GO or release readiness.

The current gate classifies 584 discovered routes and still reports 267 `ts_runtime_blocker` routes/families with owners, blocker reasons, and next actions.

## Validation

- `npm run build`
- `npm run check:secret-patterns`
- `npm run check:ts-runtime-retirement`
- `npx vitest run test/unit/quality/ts-runtime-retirement-gate.test.ts`
- `git diff --check`

## Safety Notes

- No default machine DB mutation.
- No pet/design-gallery changes.
- No provider_native_synced claim.
- Provider ack, timeline read, process exit, skill run, and channel receipt remain forbidden as completion sources in the gate.