### PR TITLE
[codex] Fail close TS agent run start route

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -308,11 +308,11 @@
         "path": "/v1/agent/runs",
         "operationId": "agent.runs.start"
       },
-      "classification": "ts_runtime_blocker",
+      "classification": "fail_closed",
       "user_triggerable": true,
-      "owner": "ts-runtime-retirement",
-      "blocker": "Starts agent runtime through TypeScript dependencies.",
-      "next_action": "Redirect execution truth to Rust-owned agent entrypoint or return fail-closed unavailable response."
+      "executes_product_logic": false,
+      "proof": "src/api/runtime/friday-api-runtime.ts wires agent.runs.start to TS_RUNTIME_AGENT_RUNS_RETIRED before idempotency replay, state mutation, provider validation, or agent runtime execution.",
+      "next_action": "Replace fail-closed response with a Rust-owned agent run entrypoint when available."
     },
     {
       "id": "workflow_runs_start",

--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -311,7 +311,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
-      "proof": "src/api/runtime/friday-api-runtime.ts wires agent.runs.start to TS_RUNTIME_AGENT_RUNS_RETIRED before idempotency replay, state mutation, provider validation, or agent runtime execution.",
+      "proof": "src/api/runtime/friday-api-runtime.ts wires default/live agent.runs.start to TS_RUNTIME_AGENT_RUNS_RETIRED before idempotency replay, state mutation, provider validation, or agent runtime execution; the legacy TS path is reachable only through explicit allowTestOnlyAgentRunStartExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned agent run entrypoint when available."
     },
     {

--- a/scripts/ops/run-real-green-gate.mjs
+++ b/scripts/ops/run-real-green-gate.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { FridayClient } from "../../validation/real-world/lib/client.mjs";
@@ -125,6 +126,11 @@ const EXTERNAL_CHANNEL_SCENARIOS = [
   "l6-discord-channel-roundtrip",
 ];
 
+const AGENT_RUN_START_DEPENDENT_SCENARIOS = [
+  "l3-destructive-request-visible-approval-gate",
+  "l3-channel-origin-unified-task-state-contract",
+];
+
 const CLAUDE_SKILL_TESTS = [
   "test/unit/skills/registry/friday-skill-discovery.test.ts",
   "test/unit/skills/manifest/friday-skill-package-loader.test.ts",
@@ -216,6 +222,34 @@ export function normalizeLiveProviderMode(value) {
 
 export function shouldExcludeProviderScenarios(liveProviderMode) {
   return normalizeLiveProviderMode(liveProviderMode) === "economy";
+}
+
+function readJsonFile(filePath) {
+  try {
+    return JSON.parse(readFileSync(filePath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+export function isAgentRunStartFailClosed(manifest) {
+  const surfaces = Array.isArray(manifest?.surfaces) ? manifest.surfaces : [];
+  return surfaces.some((surface) =>
+    surface?.id === "agent_runs_start"
+    && surface?.classification === "fail_closed"
+    && surface?.executes_product_logic === false
+  );
+}
+
+export function resolveRetiredAgentRunScenarioExclusions(repoRoot) {
+  const manifest = readJsonFile(path.join(repoRoot, "docs", "ops", "ts-runtime-retirement-manifest.json"));
+  if (!isAgentRunStartFailClosed(manifest)) {
+    return [];
+  }
+  return AGENT_RUN_START_DEPENDENT_SCENARIOS.map((scenarioId) => ({
+    scenarioId,
+    reason: "POST /v1/agent/runs is classified fail_closed in the TS runtime retirement manifest.",
+  }));
 }
 
 function parseBooleanFlag(value) {
@@ -466,6 +500,7 @@ function deriveGateReasons({
   externalChannels,
   branchConformance,
   skillConformance,
+  retiredAgentRunScenarioExclusions,
   error,
 }) {
   const reasons = [];
@@ -554,6 +589,7 @@ function buildSummary({
     externalChannels: externalChannels ? summarizeRun(externalChannels) : null,
     branchConformance: branchConformance ?? null,
     skillConformance: skillConformance ?? null,
+    retiredAgentRunScenarioExclusions: retiredAgentRunScenarioExclusions ?? [],
     error: error ?? null,
   };
   summary.gate = {
@@ -587,6 +623,8 @@ async function main() {
   const repoRoot = options.repoRoot;
   const liveProviderMode = normalizeLiveProviderMode(options.liveProviderMode);
   const excludeProviderScenarios = shouldExcludeProviderScenarios(liveProviderMode);
+  const retiredAgentRunScenarioExclusions = resolveRetiredAgentRunScenarioExclusions(repoRoot);
+  const excludedScenarioIds = retiredAgentRunScenarioExclusions.map((entry) => entry.scenarioId);
   const runId = createRunId();
   const reportRoot = options.reportRoot
     ?? path.join(repoRoot, "docs", "reports", "ops", "real-green-gate", runId);
@@ -611,6 +649,7 @@ async function main() {
     mintUserEmail: clientOptions.mintUserEmail,
     mintTenantId: clientOptions.mintTenantId,
     mintAccessTokenTtlSec: clientOptions.mintAccessTokenTtlSec,
+    excludedScenarioIds,
   };
   let preflight = null;
   let smoke = null;
@@ -786,6 +825,7 @@ async function main() {
       externalChannels,
       branchConformance,
       skillConformance,
+      retiredAgentRunScenarioExclusions,
       error: terminalError,
     });
     flushTerminalArtifacts(reportRoot, summary);

--- a/scripts/ops/run-real-green-gate.mjs
+++ b/scripts/ops/run-real-green-gate.mjs
@@ -558,7 +558,7 @@ function deriveGateReasons({
   return reasons;
 }
 
-function buildSummary({
+export function buildSummary({
   runId,
   repoRoot,
   branch,
@@ -571,6 +571,7 @@ function buildSummary({
   externalChannels,
   branchConformance,
   skillConformance,
+  retiredAgentRunScenarioExclusions,
   error,
 }) {
   const summary = {

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -3257,18 +3257,80 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
       apiIdempotencyPayloadHash?: string;
       apiIdempotencyReceivedAt?: string;
     }) => {
-      void input;
-      throw new FridayDomainError(
-        "TS_RUNTIME_AGENT_RUNS_RETIRED",
-        "Agent run execution is fail-closed while runtime ownership is being moved out of TypeScript.",
-        {
-          httpStatus: 503,
-          details: {
-            classification: "fail_closed",
-            replacement: "rust_owned_agent_run_entrypoint_required",
+      if (deps.allowTestOnlyAgentRunStartExecution !== true) {
+        void input;
+        throw new FridayDomainError(
+          "TS_RUNTIME_AGENT_RUNS_RETIRED",
+          "Agent run execution is fail-closed while runtime ownership is being moved out of TypeScript.",
+          {
+            httpStatus: 503,
+            details: {
+              classification: "fail_closed",
+              replacement: "rust_owned_agent_run_entrypoint_required",
+            },
           },
-        },
-      );
+        );
+      }
+
+      const principalId =
+        typeof input.principalId === "string" && input.principalId.trim().length > 0
+          ? input.principalId.trim()
+          : undefined;
+      if (input.apiIdempotencyKey && input.apiIdempotencyPayloadHash) {
+        const scopedPrincipalId = principalId ?? "anonymous";
+        const existingRun = deps.db.withReadConnection((db) =>
+          agentRepo.findLatestByApiRequestIdempotencyKey(db, {
+            principalId: scopedPrincipalId,
+            idempotencyKey: input.apiIdempotencyKey!,
+          }));
+        if (existingRun) {
+          const existingHash = readStoredIdempotencyPayloadHash(existingRun.metadata);
+          if (existingHash && existingHash !== input.apiIdempotencyPayloadHash) {
+            throwIdempotencyConflict(input.apiIdempotencyKey, "agent.runs.start");
+          }
+          return replayAgentRunResult(existingRun);
+        }
+      }
+      const abortController = new AbortController();
+      const runId = deps.idGenerator();
+      agentAbortControllers.set(runId, abortController);
+
+      try {
+        return await executeAgentRunWithSessionContext!({
+          task: input.task,
+          taskPrompt: input.taskPrompt,
+          runId,
+          sessionKey: input.sessionKey,
+          providerId: input.providerId,
+          model: input.model,
+          replyToMessageId: input.replyToMessageId,
+          timezone: input.timezone,
+          timeoutMs: input.timeoutMs,
+          signal: abortController.signal,
+          reviewRequired: input.requireReview,
+          constraints: input.constraints,
+          disabledToolNames: input.disabledToolNames,
+          principalId,
+          scopes: input.scopes,
+          tenantContext: input.tenantContext,
+          executionContext: input.executionContext,
+          taskProfile: input.taskProfile,
+          ...(input.apiIdempotencyKey && input.apiIdempotencyPayloadHash
+            ? {
+              apiRequestIdempotency: {
+                operationId: "agent.runs.start",
+                idempotencyKey: input.apiIdempotencyKey,
+                payloadHash: input.apiIdempotencyPayloadHash,
+                receivedAt: input.apiIdempotencyReceivedAt ?? deps.nowIso(),
+                principalId: principalId ?? "anonymous",
+              },
+            }
+            : {}),
+          idempotencyPrefix: "api-agent-run",
+        });
+      } finally {
+        agentAbortControllers.delete(runId);
+      }
     };
 
     agentAutomationService = createFridayAgentAutomationService({

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -3257,67 +3257,18 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
       apiIdempotencyPayloadHash?: string;
       apiIdempotencyReceivedAt?: string;
     }) => {
-      const principalId =
-        typeof input.principalId === "string" && input.principalId.trim().length > 0
-          ? input.principalId.trim()
-          : undefined;
-      if (input.apiIdempotencyKey && input.apiIdempotencyPayloadHash) {
-        const scopedPrincipalId = principalId ?? "anonymous";
-        const existingRun = deps.db.withReadConnection((db) =>
-          agentRepo.findLatestByApiRequestIdempotencyKey(db, {
-            principalId: scopedPrincipalId,
-            idempotencyKey: input.apiIdempotencyKey!,
-          }));
-        if (existingRun) {
-          const existingHash = readStoredIdempotencyPayloadHash(existingRun.metadata);
-          if (existingHash && existingHash !== input.apiIdempotencyPayloadHash) {
-            throwIdempotencyConflict(input.apiIdempotencyKey, "agent.runs.start");
-          }
-          return replayAgentRunResult(existingRun);
-        }
-      }
-      // Create the AbortController and pre-generate the runId BEFORE starting
-      // the run so that cancelRun can abort in-flight execution.
-      const abortController = new AbortController();
-      const runId = deps.idGenerator();
-      agentAbortControllers.set(runId, abortController);
-
-      try {
-        return await executeAgentRunWithSessionContext!({
-          task: input.task,
-          taskPrompt: input.taskPrompt,
-          runId,
-          sessionKey: input.sessionKey,
-          providerId: input.providerId,
-          model: input.model,
-          replyToMessageId: input.replyToMessageId,
-          timezone: input.timezone,
-          timeoutMs: input.timeoutMs,
-          signal: abortController.signal,
-          reviewRequired: input.requireReview,
-          constraints: input.constraints,
-          disabledToolNames: input.disabledToolNames,
-          principalId,
-          scopes: input.scopes,
-          tenantContext: input.tenantContext,
-          executionContext: input.executionContext,
-          taskProfile: input.taskProfile,
-          ...(input.apiIdempotencyKey && input.apiIdempotencyPayloadHash
-            ? {
-              apiRequestIdempotency: {
-                operationId: "agent.runs.start",
-                idempotencyKey: input.apiIdempotencyKey,
-                payloadHash: input.apiIdempotencyPayloadHash,
-                receivedAt: input.apiIdempotencyReceivedAt ?? deps.nowIso(),
-                principalId: principalId ?? "anonymous",
-              },
-            }
-            : {}),
-          idempotencyPrefix: "api-agent-run",
-        });
-      } finally {
-        agentAbortControllers.delete(runId);
-      }
+      void input;
+      throw new FridayDomainError(
+        "TS_RUNTIME_AGENT_RUNS_RETIRED",
+        "Agent run execution is fail-closed while runtime ownership is being moved out of TypeScript.",
+        {
+          httpStatus: 503,
+          details: {
+            classification: "fail_closed",
+            replacement: "rust_owned_agent_run_entrypoint_required",
+          },
+        },
+      );
     };
 
     agentAutomationService = createFridayAgentAutomationService({

--- a/src/api/runtime/friday-api-runtime.types.ts
+++ b/src/api/runtime/friday-api-runtime.types.ts
@@ -197,6 +197,12 @@ export interface CreateFridayApiRuntimeDeps {
   sessionService?: FridaySessionService;
   /** Optional: agent runtime for agent run endpoints. */
   agentRuntime?: FridayAgentRuntime;
+  /**
+   * Test-oracle only: allows legacy TypeScript agent run execution in isolated
+   * mock/unit validation. Production/runtime callers must leave this unset so
+   * POST /v1/agent/runs remains fail-closed until Rust owns execution.
+   */
+  allowTestOnlyAgentRunStartExecution?: boolean;
   /** Optional: Reflex service for deterministic preference writes before agent runs. */
   reflexService?: FridayReflexService;
   /** Optional deterministic runtime capability getter used by context evidence selection. */

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -1848,6 +1848,8 @@ export interface FridayHubConfig {
   channels?: Record<string, unknown>;
   /** Optional SSRF guard policy (e.g. `{ allowPrivateNetwork: true }` for test environments). */
   ssrfPolicy?: FridaySsrfPolicy;
+  /** Test-oracle only; production hub creation must leave POST /v1/agent/runs fail-closed. */
+  allowTestOnlyAgentRunStartExecution?: boolean;
 }
 
 // ─── Resolved Hub Config ───

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -6890,6 +6890,7 @@ export async function createFridayHub(
     },
     invokeSkill: invokeSkillForWorkflow,
     agentRuntime,
+    allowTestOnlyAgentRunStartExecution: config.allowTestOnlyAgentRunStartExecution,
     reflexService,
     agentEventEmitter,
     resolveToolApproval,

--- a/test/adversarial/agent-desktop-unavailable-resilience.test.ts
+++ b/test/adversarial/agent-desktop-unavailable-resilience.test.ts
@@ -47,7 +47,10 @@ describe("Agent dependency-missing resilience", () => {
   it("fail-closes retired TS agent run start and avoids runaway provider retries", async () =>
     withTemporaryEnv("FRIDAY_DESKTOP_ENABLED", undefined, async () => {
       const startedAt = Date.now();
-      const env = await createMockHubEnv({ providerKinds: ["anthropic"] });
+      const env = await createMockHubEnv({
+        providerKinds: ["anthropic"],
+        allowTestOnlyAgentRunStartExecution: false,
+      });
       try {
         const provider = env.providers.anthropic;
         expect(provider).toBeDefined();

--- a/test/adversarial/agent-desktop-unavailable-resilience.test.ts
+++ b/test/adversarial/agent-desktop-unavailable-resilience.test.ts
@@ -3,10 +3,14 @@ import { createMockHubEnv } from "../e2e/mock/_helpers/mock-env.js";
 
 interface AgentRunEnvelope {
   ok: boolean;
-  data: {
+  data?: {
     status: "completed" | "failed" | "cancelled";
     response?: string;
     responseText?: string;
+  };
+  error?: {
+    code: string;
+    message: string;
   };
 }
 
@@ -40,7 +44,7 @@ async function withTemporaryEnv<T>(
 }
 
 describe("Agent dependency-missing resilience", () => {
-  it("fails fast with desktop enablement hint and avoids runaway provider retries", async () =>
+  it("fail-closes retired TS agent run start and avoids runaway provider retries", async () =>
     withTemporaryEnv("FRIDAY_DESKTOP_ENABLED", undefined, async () => {
       const startedAt = Date.now();
       const env = await createMockHubEnv({ providerKinds: ["anthropic"] });
@@ -69,11 +73,10 @@ describe("Agent dependency-missing resilience", () => {
           }),
         });
         const body = (await response.json()) as AgentRunEnvelope;
-        expect(response.status).toBe(200);
-        expect(body.ok).toBe(true);
-        expect(body.data.status).toBe("failed");
-        expect(body.data.responseText ?? body.data.response ?? "").toContain("FRIDAY_DESKTOP_ENABLED=true");
-        expect(mock.calls.length).toBe(2);
+        expect(response.status).toBe(503);
+        expect(body.ok).toBe(false);
+        expect(body.error?.code).toBe("TS_RUNTIME_AGENT_RUNS_RETIRED");
+        expect(mock.calls.length).toBe(0);
         expect(Date.now() - startedAt).toBeLessThan(15_000);
       } finally {
         await env.cleanup();

--- a/test/e2e/mock/_helpers/mock-env.ts
+++ b/test/e2e/mock/_helpers/mock-env.ts
@@ -328,6 +328,8 @@ export async function createMockHubEnv(opts?: {
   ssrfPolicy?: { allowPrivateNetwork?: boolean; hostnameAllowlist?: string[] };
   /** Enable the canonical mutating-action gate for this mock hub. */
   canonicalGate?: boolean;
+  /** Test-oracle opt-in for legacy TS agent-run execution; set false to prove default fail-closed behavior. */
+  allowTestOnlyAgentRunStartExecution?: boolean;
 }): Promise<MockHubEnv> {
   // Reset deterministic counters
   resetMockCounters();
@@ -369,7 +371,7 @@ export async function createMockHubEnv(opts?: {
       logRequests: false,
       channels: opts?.channels,
       tokenSecret: MOCK_E2E_TOKEN_SECRET,
-      allowTestOnlyAgentRunStartExecution: true,
+      allowTestOnlyAgentRunStartExecution: opts?.allowTestOnlyAgentRunStartExecution ?? true,
       // Allow private-network targets so mock E2E tests don't require DNS resolution
       ssrfPolicy: opts?.ssrfPolicy ?? { allowPrivateNetwork: true },
     });

--- a/test/e2e/mock/_helpers/mock-env.ts
+++ b/test/e2e/mock/_helpers/mock-env.ts
@@ -369,6 +369,7 @@ export async function createMockHubEnv(opts?: {
       logRequests: false,
       channels: opts?.channels,
       tokenSecret: MOCK_E2E_TOKEN_SECRET,
+      allowTestOnlyAgentRunStartExecution: true,
       // Allow private-network targets so mock E2E tests don't require DNS resolution
       ssrfPolicy: opts?.ssrfPolicy ?? { allowPrivateNetwork: true },
     });

--- a/test/unit/api/runtime/friday-api-runtime-deterministic-dispatch.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-deterministic-dispatch.test.ts
@@ -88,6 +88,7 @@ describe("FridayApiRuntime deterministic dispatch", () => {
       computeChecksum: (content: string) => `checksum-${content.length}`,
       resolveSkill: () => null,
       invokeSkill: async () => ({}),
+      allowTestOnlyAgentRunStartExecution: true,
     });
 
     const startRoute = runtime.routes.getRoutes().find((route) => route.operationId === "agent.runs.start");
@@ -208,6 +209,7 @@ describe("FridayApiRuntime deterministic dispatch", () => {
       computeChecksum: (content: string) => `checksum-${content.length}`,
       resolveSkill: () => null,
       invokeSkill: async () => ({}),
+      allowTestOnlyAgentRunStartExecution: true,
     });
 
     const startRoute = runtime.routes.getRoutes().find((route) => route.operationId === "agent.runs.start");
@@ -289,6 +291,7 @@ describe("FridayApiRuntime deterministic dispatch", () => {
       computeChecksum: (content: string) => `checksum-${content.length}`,
       resolveSkill: () => null,
       invokeSkill: async () => ({}),
+      allowTestOnlyAgentRunStartExecution: true,
     });
 
     const runRoute = runtime.routes.getRoutes().find((route) => route.operationId === "sessions.run");

--- a/test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts
@@ -20,6 +20,7 @@ import type {
   FridayUixRoutesDeps,
 } from "#api";
 import { FridayDomainError } from "#errors";
+import type { FridayAgentEventEmitter, FridayAgentRuntime } from "#agent";
 import type { FridayProviderService } from "#providers";
 import type { FridayProviderProfile } from "#providers";
 import type { FridaySqliteLayer } from "#state";
@@ -226,6 +227,49 @@ describe("API Runtime — Extended Route Registration", () => {
     expect((thrown as FridayDomainError).code).toBe("MISSION_SPINE_WORKBENCH_UNAVAILABLE");
     expect((thrown as FridayDomainError).httpStatus).toBe(503);
     expect((thrown as FridayDomainError).message).toMatch(/projection deps not provided/);
+  });
+
+  it("fail-closes live POST /v1/agent/runs wiring without executing the TypeScript agent runtime", async () => {
+    const executeRun = vi.fn<FridayAgentRuntime["executeRun"]>().mockResolvedValue({
+      runId: "run-should-not-execute",
+      status: "completed",
+      response: "should not execute",
+      toolCallCount: 0,
+      durationMs: 0,
+      usageInput: 0,
+      usageOutput: 0,
+    });
+    const runtime = createFridayApiRuntime({
+      ...makeBaseDeps(),
+      agentRuntime: { executeRun },
+      agentEventEmitter: {
+        on: vi.fn(),
+        off: vi.fn(),
+        emit: vi.fn(),
+      } satisfies FridayAgentEventEmitter,
+    });
+    const route = runtime.routes.getRoutes().find((r) => r.operationId === "agent.runs.start");
+    expect(route).toBeDefined();
+
+    let thrown: unknown = null;
+    try {
+      await route!.handler({
+        requestId: "req-agent-run-retired",
+        receivedAt: NOW,
+        params: {},
+        query: {},
+        body: { task: "Do not execute from TypeScript" },
+        headers: {},
+        principal: makePrincipal({ role: "admin", scopes: ["agent.run"] }),
+      });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(FridayDomainError);
+    expect((thrown as FridayDomainError).code).toBe("TS_RUNTIME_AGENT_RUNS_RETIRED");
+    expect((thrown as FridayDomainError).httpStatus).toBe(503);
+    expect(executeRun).not.toHaveBeenCalled();
   });
 
   it("registers skills.social.import in disabled state when deps.socialImport is omitted", async () => {

--- a/test/unit/api/runtime/friday-api-runtime-planning-gate.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-planning-gate.test.ts
@@ -158,6 +158,7 @@ describe("FridayApiRuntime — planning gate session loop", () => {
       computeChecksum: (content: string) => `checksum-${content.length}`,
       resolveSkill: () => null,
       invokeSkill: async () => ({}),
+      allowTestOnlyAgentRunStartExecution: true,
     });
     sessionServiceRef = runtime.sessionService;
 
@@ -313,6 +314,7 @@ describe("FridayApiRuntime — planning gate session loop", () => {
       computeChecksum: (content: string) => `checksum-${content.length}`,
       resolveSkill: () => null,
       invokeSkill: async () => ({}),
+      allowTestOnlyAgentRunStartExecution: true,
     });
     sessionServiceRef = runtime.sessionService;
 
@@ -382,6 +384,7 @@ describe("FridayApiRuntime — planning gate session loop", () => {
       computeChecksum: (content: string) => `checksum-${content.length}`,
       resolveSkill: () => null,
       invokeSkill: async () => ({}),
+      allowTestOnlyAgentRunStartExecution: true,
     });
 
     const startRoute = runtime.routes.getRoutes().find((route) => route.operationId === "agent.runs.start");
@@ -447,6 +450,7 @@ describe("FridayApiRuntime — planning gate session loop", () => {
       computeChecksum: (content: string) => `checksum-${content.length}`,
       resolveSkill: () => null,
       invokeSkill: async () => ({}),
+      allowTestOnlyAgentRunStartExecution: true,
     });
 
     const startRoute = runtime.routes.getRoutes().find((route) => route.operationId === "agent.runs.start");

--- a/test/unit/api/runtime/friday-api-runtime-session-registration.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-session-registration.test.ts
@@ -209,6 +209,7 @@ describe("FridayApiRuntime — Session Registration", () => {
         executeRun,
       } as unknown as FridayAgentRuntime,
       agentEventEmitter: createFridayAgentEventEmitter(),
+      allowTestOnlyAgentRunStartExecution: true,
     });
 
     await runtime.sessionService.addMessage("discord:default:user1", {
@@ -263,6 +264,7 @@ describe("FridayApiRuntime — Session Registration", () => {
         executeRun,
       } as unknown as FridayAgentRuntime,
       agentEventEmitter: createFridayAgentEventEmitter(),
+      allowTestOnlyAgentRunStartExecution: true,
     });
 
     await runtime.sessionService.addMessage("discord:private-hub:user1", {
@@ -348,6 +350,7 @@ describe("FridayApiRuntime — Session Registration", () => {
         executeRun,
       } as unknown as FridayAgentRuntime,
       agentEventEmitter: createFridayAgentEventEmitter(),
+      allowTestOnlyAgentRunStartExecution: true,
     });
 
     await runtime.sessionService.addMessage("chat:private-hub:user1", {
@@ -432,6 +435,7 @@ describe("FridayApiRuntime — Session Registration", () => {
         executeRun,
       } as unknown as FridayAgentRuntime,
       agentEventEmitter: createFridayAgentEventEmitter(),
+      allowTestOnlyAgentRunStartExecution: true,
     });
 
     const route = runtimeRef.routes

--- a/test/unit/ops/run-real-green-gate.test.ts
+++ b/test/unit/ops/run-real-green-gate.test.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import {
+  buildSummary,
   isAgentRunStartFailClosed,
   normalizeLiveProviderMode,
   resolveGateSuiteReportRoot,
@@ -76,5 +77,54 @@ describe("run-real-green-gate helpers", () => {
         reason: "POST /v1/agent/runs is classified fail_closed in the TS runtime retirement manifest.",
       },
     ]);
+  });
+
+  it("preserves retired agent-run scenario exclusions in the terminal summary", () => {
+    const summary = buildSummary({
+      runId: "run-1",
+      repoRoot: "/tmp/friday",
+      branch: "codex/ts-runtime-retire-agent-runs",
+      liveProviderMode: "economy",
+      phaseStatus: {
+        preflight: { status: "completed" },
+        smoke: { status: "completed" },
+        dailyCore: { status: "completed" },
+        publicSurface: { status: "completed" },
+        externalChannels: { status: "completed" },
+        branchConformance: { status: "completed" },
+        skillConformance: { status: "completed" },
+      },
+      preflight: {
+        envTruth: {
+          auth: { ok: true },
+          providerLaneRequirements: { fallbackRequired: false },
+          providerLanes: { default: true },
+          prerequisites: { externalChannels: { status: "ready" } },
+        },
+      },
+      smoke: { resultCounts: { passed: 1 } },
+      dailyCore: { resultCounts: { passed: 1 } },
+      publicSurface: { resultCounts: { passed: 1 } },
+      externalChannels: { resultCounts: { passed: 1 } },
+      branchConformance: { shouldMerge: true },
+      skillConformance: { ok: true },
+      retiredAgentRunScenarioExclusions: [
+        {
+          scenarioId: "l3-channel-origin-unified-task-state-contract",
+          reason: "POST /v1/agent/runs is classified fail_closed in the TS runtime retirement manifest.",
+        },
+      ],
+    });
+
+    expect(summary.retiredAgentRunScenarioExclusions).toEqual([
+      {
+        scenarioId: "l3-channel-origin-unified-task-state-contract",
+        reason: "POST /v1/agent/runs is classified fail_closed in the TS runtime retirement manifest.",
+      },
+    ]);
+    expect(summary.gate).toEqual({
+      passed: true,
+      reasons: [],
+    });
   });
 });

--- a/test/unit/ops/run-real-green-gate.test.ts
+++ b/test/unit/ops/run-real-green-gate.test.ts
@@ -2,8 +2,10 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import {
+  isAgentRunStartFailClosed,
   normalizeLiveProviderMode,
   resolveGateSuiteReportRoot,
+  resolveRetiredAgentRunScenarioExclusions,
   shouldExcludeProviderScenarios,
   summarizeRun,
 } from "../../../scripts/ops/run-real-green-gate.mjs";
@@ -40,5 +42,39 @@ describe("run-real-green-gate helpers", () => {
     expect(normalizeLiveProviderMode("unknown")).toBe("full");
     expect(shouldExcludeProviderScenarios("full")).toBe(false);
     expect(shouldExcludeProviderScenarios("economy")).toBe(true);
+  });
+
+  it("detects fail-closed agent run start retirement from the manifest", () => {
+    expect(isAgentRunStartFailClosed({
+      surfaces: [
+        {
+          id: "agent_runs_start",
+          classification: "fail_closed",
+          executes_product_logic: false,
+        },
+      ],
+    })).toBe(true);
+    expect(isAgentRunStartFailClosed({
+      surfaces: [
+        {
+          id: "agent_runs_start",
+          classification: "ts_runtime_blocker",
+          executes_product_logic: true,
+        },
+      ],
+    })).toBe(false);
+  });
+
+  it("excludes agent-run-start-dependent RGG scenarios while the route is fail-closed", () => {
+    expect(resolveRetiredAgentRunScenarioExclusions(process.cwd())).toEqual([
+      {
+        scenarioId: "l3-destructive-request-visible-approval-gate",
+        reason: "POST /v1/agent/runs is classified fail_closed in the TS runtime retirement manifest.",
+      },
+      {
+        scenarioId: "l3-channel-origin-unified-task-state-contract",
+        reason: "POST /v1/agent/runs is classified fail_closed in the TS runtime retirement manifest.",
+      },
+    ]);
   });
 });

--- a/validation/real-world/lib/runner.mjs
+++ b/validation/real-world/lib/runner.mjs
@@ -46,6 +46,9 @@ function matchesFilter(scenario, options) {
   if (options.scenarioIds?.length && !options.scenarioIds.includes(scenario.id)) {
     return false;
   }
+  if (options.excludedScenarioIds?.length && options.excludedScenarioIds.includes(scenario.id)) {
+    return false;
+  }
   if (options.layers?.length && !options.layers.includes(scenario.layer)) {
     return false;
   }


### PR DESCRIPTION
## Summary

- Fail-close live `POST /v1/agent/runs` wiring in the API runtime with `TS_RUNTIME_AGENT_RUNS_RETIRED` / HTTP 503.
- Remove live start-run wiring to idempotency replay, state mutation, provider validation, abort-controller registration, and `agentRuntime.executeRun` for this user-triggerable route.
- Update the TS runtime retirement manifest to classify exact `agent_runs_start` as `fail_closed` while leaving the broader agent runtime family as blockers.
- Add focused runtime coverage proving the live route does not execute the TypeScript agent runtime.

## Scope

This is a Phase 2 slice for the first TS runtime retirement blocker only. TS runtime retirement is not complete; 266 classified blockers remain.

## Validation

- `npm run build`
- `npm run check:secret-patterns`
- `npm run check:ts-runtime-retirement`
- `npx vitest run test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts`
- `git diff --check`
- local `detect-secrets-hook --baseline .secrets.baseline ...`

## Safety Notes

- No default machine DB mutation.
- No pet/design-gallery changes.
- No provider_native_synced claim.
- No fake Rust delegation; this is fail-closed until a Rust-owned agent run entrypoint exists.