### PR TITLE
[codex] Fail close agent run controls

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -64,8 +64,8 @@
       "classification": "ts_runtime_blocker",
       "user_triggerable": true,
       "owner": "ts-runtime-retirement",
-      "blocker": "Agent routes still call TypeScript runtime dependencies for starting, cancelling, rolling back, approval, and automation execution.",
-      "next_action": "Retire POST /v1/agent/runs first by delegating execution truth to a Rust-owned entrypoint or leaving the route fail-closed until Rust ownership exists."
+      "blocker": "Agent routes still call TypeScript runtime dependencies for approval, automation asset CRUD, and other remaining agent runtime behavior.",
+      "next_action": "Continue splitting remaining agent route surfaces into Rust delegation, explicit fail-closed controls, compatibility shims, or owned blockers before claiming TS retirement."
     },
     {
       "id": "agent_loop_runtime_blockers",
@@ -313,6 +313,45 @@
       "executes_product_logic": false,
       "proof": "src/api/runtime/friday-api-runtime.ts wires default/live agent.runs.start to TS_RUNTIME_AGENT_RUNS_RETIRED before idempotency replay, state mutation, provider validation, or agent runtime execution; the legacy TS path is reachable only through explicit allowTestOnlyAgentRunStartExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned agent run entrypoint when available."
+    },
+    {
+      "id": "agent_runs_cancel",
+      "route": {
+        "method": "POST",
+        "path": "/v1/agent/runs/:runId/cancel",
+        "operationId": "agent.runs.cancel"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/runtime/friday-api-runtime.ts wires default/live agent.runs.cancel to TS_RUNTIME_AGENT_RUN_CONTROLS_RETIRED before aborting TypeScript run controllers; the legacy TS cancel path is reachable only through explicit allowTestOnlyAgentRunControlExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned agent run control entrypoint when available."
+    },
+    {
+      "id": "agent_runs_rollback",
+      "route": {
+        "method": "POST",
+        "path": "/v1/agent/runs/:runId/rollback",
+        "operationId": "agent.runs.rollback"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/runtime/friday-api-runtime.ts wires default/live agent.runs.rollback to TS_RUNTIME_AGENT_RUN_CONTROLS_RETIRED before calling TypeScript rollbackRun; the legacy TS rollback path is reachable only through explicit allowTestOnlyAgentRunControlExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned agent rollback/control entrypoint when available."
+    },
+    {
+      "id": "agent_automations_run",
+      "route": {
+        "method": "POST",
+        "path": "/v1/agent/automations/:automationId/run",
+        "operationId": "agent.automations.run"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/runtime/friday-api-runtime.ts wires default/live agent.automations.run to TS_RUNTIME_AGENT_RUN_CONTROLS_RETIRED before invoking the TypeScript automation run service; the legacy TS automation-run path is reachable only through explicit allowTestOnlyAgentRunControlExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned automation execution/control entrypoint when available."
     },
     {
       "id": "workflow_runs_start",

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -3223,6 +3223,19 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
   let agentAutomationService: FridayAgentAutomationService | undefined;
   if (deps.agentRuntime && deps.agentEventEmitter && agentRepo && agentRunEventRepo) {
     const agentAbortControllers = new Map<string, AbortController>();
+    const throwRetiredAgentRunControl = (): never => {
+      throw new FridayDomainError(
+        "TS_RUNTIME_AGENT_RUN_CONTROLS_RETIRED",
+        "Agent run controls are fail-closed while runtime control ownership is being moved out of TypeScript.",
+        {
+          httpStatus: 503,
+          details: {
+            classification: "fail_closed",
+            replacement: "rust_owned_agent_run_control_entrypoint_required",
+          },
+        },
+      );
+    };
     const replayAgentRunResult = (run: FridayAgentRunRecord): FridayAgentRuntimeResult => ({
       runId: run.id,
       status: run.status,
@@ -3344,6 +3357,13 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
       resolveSourceSessionKey: (sourceRunId) =>
         deps.db.withReadConnection((db) => agentRepo.getById(db, sourceRunId)?.sessionKey ?? null),
     });
+    const routeAutomationService: FridayAgentAutomationService =
+      deps.allowTestOnlyAgentRunControlExecution === true
+        ? agentAutomationService
+        : {
+          ...agentAutomationService,
+          run: async () => throwRetiredAgentRunControl(),
+        };
 
     for (const route of createFridayAgentRoutes({
       validateRequestedRoute: async (providerId, model, tenantContext) => {
@@ -3369,6 +3389,10 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
         );
       },
       cancelRun: (runId) => {
+        if (deps.allowTestOnlyAgentRunControlExecution !== true) {
+          void runId;
+          throwRetiredAgentRunControl();
+        }
         const controller = agentAbortControllers.get(runId);
         if (controller) {
           controller.abort(new Error("Cancelled via API"));
@@ -3441,11 +3465,15 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
         ? (runId, toolCallId, approved, options) =>
           deps.resolveToolApproval!(runId, toolCallId, approved, options)
         : (/* _runId, _toolCallId, _approved, _reason */) => ({ resolved: false }),
-      rollbackRun: deps.agentRuntime
-        ? (runId) => deps.agentRuntime!.rollbackRun(runId)
-        : undefined,
+      rollbackRun: (runId) => {
+        if (deps.allowTestOnlyAgentRunControlExecution !== true) {
+          void runId;
+          throwRetiredAgentRunControl();
+        }
+        return deps.agentRuntime!.rollbackRun?.(runId) ?? null;
+      },
       eventEmitter: deps.agentEventEmitter,
-      automationService: agentAutomationService,
+      automationService: routeAutomationService,
     })) {
       routes.register(route);
     }

--- a/src/api/runtime/friday-api-runtime.types.ts
+++ b/src/api/runtime/friday-api-runtime.types.ts
@@ -203,6 +203,13 @@ export interface CreateFridayApiRuntimeDeps {
    * POST /v1/agent/runs remains fail-closed until Rust owns execution.
    */
   allowTestOnlyAgentRunStartExecution?: boolean;
+  /**
+   * Test-oracle only: allows legacy TypeScript agent run controls in isolated
+   * mock/unit validation. Production/runtime callers must leave this unset so
+   * agent cancel, rollback, and automation-run controls stay fail-closed until
+   * Rust owns execution/control truth.
+   */
+  allowTestOnlyAgentRunControlExecution?: boolean;
   /** Optional: Reflex service for deterministic preference writes before agent runs. */
   reflexService?: FridayReflexService;
   /** Optional deterministic runtime capability getter used by context evidence selection. */

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -1850,6 +1850,8 @@ export interface FridayHubConfig {
   ssrfPolicy?: FridaySsrfPolicy;
   /** Test-oracle only; production hub creation must leave POST /v1/agent/runs fail-closed. */
   allowTestOnlyAgentRunStartExecution?: boolean;
+  /** Test-oracle only; production hub creation must leave agent run controls fail-closed. */
+  allowTestOnlyAgentRunControlExecution?: boolean;
 }
 
 // ─── Resolved Hub Config ───

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -6891,6 +6891,7 @@ export async function createFridayHub(
     invokeSkill: invokeSkillForWorkflow,
     agentRuntime,
     allowTestOnlyAgentRunStartExecution: config.allowTestOnlyAgentRunStartExecution,
+    allowTestOnlyAgentRunControlExecution: config.allowTestOnlyAgentRunControlExecution,
     reflexService,
     agentEventEmitter,
     resolveToolApproval,

--- a/test/e2e/mock/_helpers/mock-env.ts
+++ b/test/e2e/mock/_helpers/mock-env.ts
@@ -330,6 +330,8 @@ export async function createMockHubEnv(opts?: {
   canonicalGate?: boolean;
   /** Test-oracle opt-in for legacy TS agent-run execution; set false to prove default fail-closed behavior. */
   allowTestOnlyAgentRunStartExecution?: boolean;
+  /** Test-oracle opt-in for legacy TS agent-run controls; set false to prove default fail-closed behavior. */
+  allowTestOnlyAgentRunControlExecution?: boolean;
 }): Promise<MockHubEnv> {
   // Reset deterministic counters
   resetMockCounters();
@@ -372,6 +374,7 @@ export async function createMockHubEnv(opts?: {
       channels: opts?.channels,
       tokenSecret: MOCK_E2E_TOKEN_SECRET,
       allowTestOnlyAgentRunStartExecution: opts?.allowTestOnlyAgentRunStartExecution ?? true,
+      allowTestOnlyAgentRunControlExecution: opts?.allowTestOnlyAgentRunControlExecution ?? true,
       // Allow private-network targets so mock E2E tests don't require DNS resolution
       ssrfPolicy: opts?.ssrfPolicy ?? { allowPrivateNetwork: true },
     });

--- a/test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts
@@ -152,6 +152,31 @@ function makePrincipal(overrides: Partial<FridayAuthPrincipal> = {}): FridayAuth
   };
 }
 
+function seedAgentRun(
+  db: FridaySqliteLayer,
+  input: {
+    id: string;
+    status?: string;
+    sessionKey?: string;
+    task?: string;
+  },
+): void {
+  db.withWriteTransaction((writer) => {
+    writer.prepare(
+      `INSERT INTO friday_agent_runs (
+        id, task, status, session_key, attempt, max_attempts, created_at,
+        constraints_json, metadata_json
+      ) VALUES (?, ?, ?, ?, 0, 1, ?, '{}', '{}')`,
+    ).run(
+      input.id,
+      input.task ?? "Seeded test run",
+      input.status ?? "executing",
+      input.sessionKey ?? "agent:run:seeded",
+      NOW,
+    );
+  });
+}
+
 describe("API Runtime — Extended Route Registration", () => {
   afterEach(() => {
     while (allocatedDbs.length > 0) {
@@ -268,6 +293,138 @@ describe("API Runtime — Extended Route Registration", () => {
 
     expect(thrown).toBeInstanceOf(FridayDomainError);
     expect((thrown as FridayDomainError).code).toBe("TS_RUNTIME_AGENT_RUNS_RETIRED");
+    expect((thrown as FridayDomainError).httpStatus).toBe(503);
+    expect(executeRun).not.toHaveBeenCalled();
+  });
+
+  it("fail-closes live agent run cancel wiring without aborting TypeScript controllers", async () => {
+    const deps = makeBaseDeps();
+    seedAgentRun(deps.db, { id: "run-control-retired-cancel", status: "executing" });
+    const executeRun = vi.fn<FridayAgentRuntime["executeRun"]>();
+    const rollbackRun = vi.fn<FridayAgentRuntime["rollbackRun"]>();
+    const runtime = createFridayApiRuntime({
+      ...deps,
+      agentRuntime: {
+        executeRun,
+        rollbackRun,
+        registerTool: vi.fn(),
+        resumeStaleRunsOnBoot: vi.fn(() => 0),
+        hasRollbackCheckpoint: vi.fn(() => false),
+      } as unknown as FridayAgentRuntime,
+      agentEventEmitter: {
+        on: vi.fn(),
+        off: vi.fn(),
+        emit: vi.fn(),
+      } satisfies FridayAgentEventEmitter,
+    });
+    const route = runtime.routes.getRoutes().find((r) => r.operationId === "agent.runs.cancel");
+    expect(route).toBeDefined();
+
+    let thrown: unknown = null;
+    try {
+      await route!.handler({
+        requestId: "req-agent-run-cancel-retired",
+        receivedAt: NOW,
+        params: { runId: "run-control-retired-cancel" },
+        query: {},
+        body: {},
+        headers: {},
+        principal: makePrincipal({ role: "admin", scopes: ["agent.run"] }),
+      });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(FridayDomainError);
+    expect((thrown as FridayDomainError).code).toBe("TS_RUNTIME_AGENT_RUN_CONTROLS_RETIRED");
+    expect((thrown as FridayDomainError).httpStatus).toBe(503);
+    expect(executeRun).not.toHaveBeenCalled();
+    expect(rollbackRun).not.toHaveBeenCalled();
+  });
+
+  it("fail-closes live agent run rollback wiring without calling TypeScript rollback", async () => {
+    const deps = makeBaseDeps();
+    seedAgentRun(deps.db, { id: "run-control-retired-rollback", status: "completed" });
+    const rollbackRun = vi.fn<FridayAgentRuntime["rollbackRun"]>(() => ({
+      restoredCount: 1,
+      errors: [],
+    }));
+    const runtime = createFridayApiRuntime({
+      ...deps,
+      agentRuntime: {
+        executeRun: vi.fn(),
+        rollbackRun,
+        registerTool: vi.fn(),
+        resumeStaleRunsOnBoot: vi.fn(() => 0),
+        hasRollbackCheckpoint: vi.fn(() => true),
+      } as unknown as FridayAgentRuntime,
+      agentEventEmitter: {
+        on: vi.fn(),
+        off: vi.fn(),
+        emit: vi.fn(),
+      } satisfies FridayAgentEventEmitter,
+    });
+    const route = runtime.routes.getRoutes().find((r) => r.operationId === "agent.runs.rollback");
+    expect(route).toBeDefined();
+
+    let thrown: unknown = null;
+    try {
+      await route!.handler({
+        requestId: "req-agent-run-rollback-retired",
+        receivedAt: NOW,
+        params: { runId: "run-control-retired-rollback" },
+        query: {},
+        body: {},
+        headers: {},
+        principal: makePrincipal({ role: "admin", scopes: ["agent.run"] }),
+      });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(FridayDomainError);
+    expect((thrown as FridayDomainError).code).toBe("TS_RUNTIME_AGENT_RUN_CONTROLS_RETIRED");
+    expect((thrown as FridayDomainError).httpStatus).toBe(503);
+    expect(rollbackRun).not.toHaveBeenCalled();
+  });
+
+  it("fail-closes live agent automation run wiring before TypeScript automation execution", async () => {
+    const executeRun = vi.fn<FridayAgentRuntime["executeRun"]>();
+    const runtime = createFridayApiRuntime({
+      ...makeBaseDeps(),
+      agentRuntime: {
+        executeRun,
+        rollbackRun: vi.fn(),
+        registerTool: vi.fn(),
+        resumeStaleRunsOnBoot: vi.fn(() => 0),
+        hasRollbackCheckpoint: vi.fn(() => false),
+      } as unknown as FridayAgentRuntime,
+      agentEventEmitter: {
+        on: vi.fn(),
+        off: vi.fn(),
+        emit: vi.fn(),
+      } satisfies FridayAgentEventEmitter,
+    });
+    const route = runtime.routes.getRoutes().find((r) => r.operationId === "agent.automations.run");
+    expect(route).toBeDefined();
+
+    let thrown: unknown = null;
+    try {
+      await route!.handler({
+        requestId: "req-agent-automation-run-retired",
+        receivedAt: NOW,
+        params: { automationId: "automation-does-not-matter" },
+        query: {},
+        body: {},
+        headers: {},
+        principal: makePrincipal({ role: "admin", scopes: ["agent.run"] }),
+      });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(FridayDomainError);
+    expect((thrown as FridayDomainError).code).toBe("TS_RUNTIME_AGENT_RUN_CONTROLS_RETIRED");
     expect((thrown as FridayDomainError).httpStatus).toBe(503);
     expect(executeRun).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

Retires the next agent run control slice from TypeScript-owned runtime behavior by fail-closing default/live wiring for:

- `POST /v1/agent/runs/:runId/cancel`
- `POST /v1/agent/runs/:runId/rollback`
- `POST /v1/agent/automations/:automationId/run`

The legacy TypeScript control paths are still available only as an explicit isolated test-oracle opt-in via `allowTestOnlyAgentRunControlExecution`, mirroring the existing agent run start retirement guard.

## Why

After #523, `POST /v1/agent/runs` was fail-closed, but agent run controls could still enter TypeScript-owned runtime control behavior. This keeps moving Phase 2 of TS runtime retirement without faking Rust delegation or weakening route coverage.

## Verification

- `npx vitest run test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts`
- `npm run check:ts-runtime-retirement`
- `npx vitest run test/unit/api/http/routes/friday-agent-routes.test.ts test/unit/api/runtime/friday-api-runtime-deterministic-dispatch.test.ts test/unit/api/runtime/friday-api-runtime-planning-gate.test.ts test/unit/api/runtime/friday-api-runtime-session-registration.test.ts`
- `npm run build`
- `npm run check:secret-patterns`
- `npx vitest run test/unit/ops/run-real-green-gate.test.ts`
- `npx vitest run test/adversarial/agent-desktop-unavailable-resilience.test.ts`
- `detect-secrets-hook --baseline .secrets.baseline $(git ls-files)`
- `git diff --check`

## Safety notes

- No default machine DB mutation; tests use in-memory DBs.
- No pet/design-gallery edits.
- No provider_native_synced claim.
- TS retirement remains incomplete; remaining blockers stay recorded in the manifest/result handoff.