### PR TITLE
Fail close workflow run controls

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -86,8 +86,8 @@
       "classification": "ts_runtime_blocker",
       "user_triggerable": true,
       "owner": "ts-runtime-retirement",
-      "blocker": "Workflow run routes still wire TypeScript workflow runtime execution.",
-      "next_action": "Delegate POST /v1/workflow-runs and run controls to Rust-owned workflow execution or fail-close them with an operator-visible retirement label."
+      "blocker": "Workflow run routes still expose TypeScript-owned run reads, evidence export, and evidence download behavior.",
+      "next_action": "Continue splitting remaining workflow run surfaces into Rust delegation, bounded compatibility reads, fail-closed controls, or owned blockers before claiming TS retirement."
     },
     {
       "id": "workflow_catalog_and_builder_runtime_blockers",
@@ -360,11 +360,50 @@
         "path": "/v1/workflow-runs",
         "operationId": "runs.start"
       },
-      "classification": "ts_runtime_blocker",
+      "classification": "fail_closed",
       "user_triggerable": true,
-      "owner": "ts-runtime-retirement",
-      "blocker": "Starts workflow runtime through TypeScript execution service.",
-      "next_action": "Redirect run creation/execution truth to Rust-owned workflow entrypoint or fail-close the route."
+      "executes_product_logic": false,
+      "proof": "src/api/runtime/friday-api-runtime.ts wires default/live runs.start to TS_RUNTIME_WORKFLOW_RUNS_RETIRED before building run security context or calling TypeScript workflowRuntime.execution.startRun; the legacy TS workflow run path is reachable only through explicit allowTestOnlyWorkflowRunExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned workflow run entrypoint when available."
+    },
+    {
+      "id": "workflow_runs_cancel",
+      "route": {
+        "method": "POST",
+        "path": "/v1/workflow-runs/:runId/cancel",
+        "operationId": "runs.cancel"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/runtime/friday-api-runtime.ts wires default/live runs.cancel to TS_RUNTIME_WORKFLOW_RUNS_RETIRED before resolving TypeScript workflow run state or calling workflowRuntime.execution.cancelRun; the legacy TS control path is reachable only through explicit allowTestOnlyWorkflowRunExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned workflow run control entrypoint when available."
+    },
+    {
+      "id": "workflow_runs_retry",
+      "route": {
+        "method": "POST",
+        "path": "/v1/workflow-runs/:runId/retry",
+        "operationId": "runs.retry"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/runtime/friday-api-runtime.ts wires default/live runs.retry to TS_RUNTIME_WORKFLOW_RUNS_RETIRED before resolving TypeScript workflow run state, enumerating nodes, or calling workflowRuntime.execution.retryRun; the legacy TS control path is reachable only through explicit allowTestOnlyWorkflowRunExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned workflow retry/control entrypoint when available."
+    },
+    {
+      "id": "workflow_runs_resume",
+      "route": {
+        "method": "POST",
+        "path": "/v1/workflow-runs/:runId/resume",
+        "operationId": "workflows.runs.resume"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/runtime/friday-api-runtime.ts wires default/live workflows.runs.resume to TS_RUNTIME_WORKFLOW_RUNS_RETIRED before resolving TypeScript workflow run state or calling workflowRuntime.execution.resumeRun; the legacy TS control path is reachable only through explicit allowTestOnlyWorkflowRunExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned workflow resume/control entrypoint when available."
     },
     {
       "id": "skills_run",

--- a/scripts/ops/run-real-green-gate.mjs
+++ b/scripts/ops/run-real-green-gate.mjs
@@ -131,6 +131,10 @@ const AGENT_RUN_START_DEPENDENT_SCENARIOS = [
   "l3-channel-origin-unified-task-state-contract",
 ];
 
+const WORKFLOW_RUN_START_DEPENDENT_SCENARIOS = [
+  "l5-workflow-approval-roundtrip",
+];
+
 const CLAUDE_SKILL_TESTS = [
   "test/unit/skills/registry/friday-skill-discovery.test.ts",
   "test/unit/skills/manifest/friday-skill-package-loader.test.ts",
@@ -249,6 +253,26 @@ export function resolveRetiredAgentRunScenarioExclusions(repoRoot) {
   return AGENT_RUN_START_DEPENDENT_SCENARIOS.map((scenarioId) => ({
     scenarioId,
     reason: "POST /v1/agent/runs is classified fail_closed in the TS runtime retirement manifest.",
+  }));
+}
+
+export function isWorkflowRunStartFailClosed(manifest) {
+  const surfaces = Array.isArray(manifest?.surfaces) ? manifest.surfaces : [];
+  return surfaces.some((surface) =>
+    surface?.id === "workflow_runs_start"
+    && surface?.classification === "fail_closed"
+    && surface?.executes_product_logic === false
+  );
+}
+
+export function resolveRetiredWorkflowRunScenarioExclusions(repoRoot) {
+  const manifest = readJsonFile(path.join(repoRoot, "docs", "ops", "ts-runtime-retirement-manifest.json"));
+  if (!isWorkflowRunStartFailClosed(manifest)) {
+    return [];
+  }
+  return WORKFLOW_RUN_START_DEPENDENT_SCENARIOS.map((scenarioId) => ({
+    scenarioId,
+    reason: "POST /v1/workflow-runs is classified fail_closed in the TS runtime retirement manifest.",
   }));
 }
 
@@ -501,6 +525,7 @@ function deriveGateReasons({
   branchConformance,
   skillConformance,
   retiredAgentRunScenarioExclusions,
+  retiredWorkflowRunScenarioExclusions,
   error,
 }) {
   const reasons = [];
@@ -572,6 +597,7 @@ export function buildSummary({
   branchConformance,
   skillConformance,
   retiredAgentRunScenarioExclusions,
+  retiredWorkflowRunScenarioExclusions,
   error,
 }) {
   const summary = {
@@ -591,6 +617,7 @@ export function buildSummary({
     branchConformance: branchConformance ?? null,
     skillConformance: skillConformance ?? null,
     retiredAgentRunScenarioExclusions: retiredAgentRunScenarioExclusions ?? [],
+    retiredWorkflowRunScenarioExclusions: retiredWorkflowRunScenarioExclusions ?? [],
     error: error ?? null,
   };
   summary.gate = {
@@ -625,7 +652,11 @@ async function main() {
   const liveProviderMode = normalizeLiveProviderMode(options.liveProviderMode);
   const excludeProviderScenarios = shouldExcludeProviderScenarios(liveProviderMode);
   const retiredAgentRunScenarioExclusions = resolveRetiredAgentRunScenarioExclusions(repoRoot);
-  const excludedScenarioIds = retiredAgentRunScenarioExclusions.map((entry) => entry.scenarioId);
+  const retiredWorkflowRunScenarioExclusions = resolveRetiredWorkflowRunScenarioExclusions(repoRoot);
+  const excludedScenarioIds = [
+    ...retiredAgentRunScenarioExclusions,
+    ...retiredWorkflowRunScenarioExclusions,
+  ].map((entry) => entry.scenarioId);
   const runId = createRunId();
   const reportRoot = options.reportRoot
     ?? path.join(repoRoot, "docs", "reports", "ops", "real-green-gate", runId);
@@ -827,6 +858,7 @@ async function main() {
       branchConformance,
       skillConformance,
       retiredAgentRunScenarioExclusions,
+      retiredWorkflowRunScenarioExclusions,
       error: terminalError,
     });
     flushTerminalArtifacts(reportRoot, summary);

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -839,6 +839,19 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
   ) => {
     return resolveAuthorizedRun(runId, principal, { evidence: true });
   };
+  const throwRetiredWorkflowRunExecution = (): never => {
+    throw new FridayDomainError(
+      "TS_RUNTIME_WORKFLOW_RUNS_RETIRED",
+      "Workflow run execution and controls are fail-closed while runtime ownership is being moved out of TypeScript.",
+      {
+        httpStatus: 503,
+        details: {
+          classification: "fail_closed",
+          replacement: "rust_owned_workflow_run_entrypoint_required",
+        },
+      },
+    );
+  };
 
   const requireWorkflowBuilderOperator = (
     principal: FridayAuthPrincipal | null,
@@ -1965,6 +1978,11 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
   // Register run routes (real service wiring)
   for (const route of createFridayWorkflowRunRoutes({
     startRun: async (input, principal) => {
+      if (deps.allowTestOnlyWorkflowRunExecution !== true) {
+        void input;
+        void principal;
+        throwRetiredWorkflowRunExecution();
+      }
       const runSecurityContext = principal
         ? {
           security: {
@@ -2086,6 +2104,12 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
       });
     },
     cancelRun: async (runId, input, principal) => {
+      if (deps.allowTestOnlyWorkflowRunExecution !== true) {
+        void runId;
+        void input;
+        void principal;
+        throwRetiredWorkflowRunExecution();
+      }
       resolveAuthorizedRun(runId, principal);
       const run = await workflowRuntime.execution.cancelRun(
         runId,
@@ -2094,6 +2118,12 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
       return { run };
     },
     retryRun: async (runId, input = {}, principal) => {
+      if (deps.allowTestOnlyWorkflowRunExecution !== true) {
+        void runId;
+        void input;
+        void principal;
+        throwRetiredWorkflowRunExecution();
+      }
       resolveAuthorizedRun(runId, principal);
       const latestAttempts = new Map<string, { nodeId: string; status: string; attempt: number }>();
       for (const node of workflowRuntime.execution.getRunNodes(runId)) {
@@ -2120,6 +2150,11 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
       return { run, retriedNodes };
     },
     resumeRun: async (runId, principal) => {
+      if (deps.allowTestOnlyWorkflowRunExecution !== true) {
+        void runId;
+        void principal;
+        throwRetiredWorkflowRunExecution();
+      }
       resolveAuthorizedRun(runId, principal);
       const run = await workflowRuntime.execution.resumeRun(runId);
       return { run };

--- a/src/api/runtime/friday-api-runtime.types.ts
+++ b/src/api/runtime/friday-api-runtime.types.ts
@@ -191,6 +191,13 @@ export interface CreateFridayApiRuntimeDeps {
   ) => Promise<unknown>;
   /** Optional: pass the hub's workflow runtime to avoid creating a duplicate. */
   workflowRuntime?: FridayWorkflowRuntime;
+  /**
+   * Test-oracle only: allows legacy TypeScript workflow run execution/control
+   * in isolated mock/unit validation. Production/runtime callers must leave
+   * this unset so workflow run start, cancel, retry, and resume stay
+   * fail-closed until Rust owns workflow execution truth.
+   */
+  allowTestOnlyWorkflowRunExecution?: boolean;
   /** Optional: user/project prompt-guidance provider for fallback workflow runtime creation. */
   userRulesContextProvider?: CreateFridayWorkflowRuntimeDeps["userRulesContextProvider"];
   /** Optional: reuse hub's session service instead of creating a new one. */

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -1848,6 +1848,8 @@ export interface FridayHubConfig {
   channels?: Record<string, unknown>;
   /** Optional SSRF guard policy (e.g. `{ allowPrivateNetwork: true }` for test environments). */
   ssrfPolicy?: FridaySsrfPolicy;
+  /** Test-oracle only; production hub creation must leave workflow run execution fail-closed. */
+  allowTestOnlyWorkflowRunExecution?: boolean;
   /** Test-oracle only; production hub creation must leave POST /v1/agent/runs fail-closed. */
   allowTestOnlyAgentRunStartExecution?: boolean;
   /** Test-oracle only; production hub creation must leave agent run controls fail-closed. */

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -6889,6 +6889,7 @@ export async function createFridayHub(
       return skill ?? null;
     },
     invokeSkill: invokeSkillForWorkflow,
+    allowTestOnlyWorkflowRunExecution: config.allowTestOnlyWorkflowRunExecution,
     agentRuntime,
     allowTestOnlyAgentRunStartExecution: config.allowTestOnlyAgentRunStartExecution,
     allowTestOnlyAgentRunControlExecution: config.allowTestOnlyAgentRunControlExecution,

--- a/test/e2e/api/_helpers/friday-api-test-server.helper.ts
+++ b/test/e2e/api/_helpers/friday-api-test-server.helper.ts
@@ -133,6 +133,11 @@ export interface CreateFridayApiTestEnvOptions {
   enableDefaultMemoryService?: boolean;
   enableSelfHealing?: boolean;
   channels?: FridayChannelRoutesDeps;
+  /**
+   * Test-oracle opt-in for legacy TS workflow-run execution. Default/live runtime
+   * leaves workflow start/control surfaces fail-closed while Rust ownership lands.
+   */
+  allowTestOnlyWorkflowRunExecution?: boolean;
   resolveSkill?: (skillId: string) => unknown | null;
   invokeSkill?: (
     skillId: string,
@@ -232,6 +237,7 @@ export async function createFridayApiTestEnv(
     pluginService: options.pluginService,
     pluginManifestLoader: options.pluginManifestLoader,
     channels: options.channels,
+    allowTestOnlyWorkflowRunExecution: options.allowTestOnlyWorkflowRunExecution ?? true,
     computeChecksum: (content: string) =>
       crypto.createHash("sha256").update(content).digest("hex"),
     resolveSkill: options.resolveSkill ?? ((_skillId: string) => ({ id: _skillId })),

--- a/test/e2e/friday-full-e2e.test.ts
+++ b/test/e2e/friday-full-e2e.test.ts
@@ -122,6 +122,7 @@ describe.skipIf(!CORE_E2E_ENABLED)("Friday Full E2E — Batch 1 (A–F)", () => 
       skillDirs: [],
       port: 0,
       logRequests: false,
+      allowTestOnlyWorkflowRunExecution: true,
     });
     await hub.start();
 

--- a/test/e2e/friday-real-scenarios-e2e.test.ts
+++ b/test/e2e/friday-real-scenarios-e2e.test.ts
@@ -139,6 +139,7 @@ describe.skipIf(!CORE_E2E_ENABLED)("Friday Real Scenarios E2E (NON-LLM)", () => 
       port: 0,
       logRequests: false,
       tokenSecret: TEST_TOKEN_SECRET,
+      allowTestOnlyWorkflowRunExecution: true,
     });
     await hub.start();
 
@@ -1660,6 +1661,7 @@ describe.skipIf(!ANTHROPIC_E2E_ENABLED || !HAS_LLM_CREDENTIAL)(
         skillDirs: [],
         port: 0,
         logRequests: false,
+        allowTestOnlyWorkflowRunExecution: true,
       });
       await hub.start();
 

--- a/test/e2e/mock/_helpers/mock-env.ts
+++ b/test/e2e/mock/_helpers/mock-env.ts
@@ -328,6 +328,8 @@ export async function createMockHubEnv(opts?: {
   ssrfPolicy?: { allowPrivateNetwork?: boolean; hostnameAllowlist?: string[] };
   /** Enable the canonical mutating-action gate for this mock hub. */
   canonicalGate?: boolean;
+  /** Test-oracle opt-in for legacy TS workflow-run execution; set false to prove default fail-closed behavior. */
+  allowTestOnlyWorkflowRunExecution?: boolean;
   /** Test-oracle opt-in for legacy TS agent-run execution; set false to prove default fail-closed behavior. */
   allowTestOnlyAgentRunStartExecution?: boolean;
   /** Test-oracle opt-in for legacy TS agent-run controls; set false to prove default fail-closed behavior. */
@@ -373,6 +375,7 @@ export async function createMockHubEnv(opts?: {
       logRequests: false,
       channels: opts?.channels,
       tokenSecret: MOCK_E2E_TOKEN_SECRET,
+      allowTestOnlyWorkflowRunExecution: opts?.allowTestOnlyWorkflowRunExecution ?? true,
       allowTestOnlyAgentRunStartExecution: opts?.allowTestOnlyAgentRunStartExecution ?? true,
       allowTestOnlyAgentRunControlExecution: opts?.allowTestOnlyAgentRunControlExecution ?? true,
       // Allow private-network targets so mock E2E tests don't require DNS resolution

--- a/test/e2e/ui/_helpers/browser-env.ts
+++ b/test/e2e/ui/_helpers/browser-env.ts
@@ -39,6 +39,10 @@ export interface FridayRealBrowserE2eEnv {
   cleanup(): Promise<void>;
 }
 
+export interface FridayRealBrowserE2eEnvOptions {
+  allowTestOnlyWorkflowRunExecution?: boolean;
+}
+
 function resolveUiStaticDir(): string {
   const uiStaticDir = path.resolve(process.cwd(), "dist/ui");
   const indexPath = path.join(uiStaticDir, "index.html");
@@ -50,12 +54,18 @@ function resolveUiStaticDir(): string {
   return uiStaticDir;
 }
 
-export async function createFridayRealBrowserE2eEnv(): Promise<FridayRealBrowserE2eEnv> {
+export async function createFridayRealBrowserE2eEnv(
+  options: FridayRealBrowserE2eEnvOptions = {},
+): Promise<FridayRealBrowserE2eEnv> {
   const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "friday-real-browser-e2e-"));
   let runtime: RealHubEnv;
+  const hubConfig = {
+    allowTestOnlyWorkflowRunExecution: options.allowTestOnlyWorkflowRunExecution,
+  };
   try {
     runtime = await createRealHubEnvFromStateDir(stateDir, {
       uiStaticDir: resolveUiStaticDir(),
+      hubConfig,
     });
   } catch (error) {
     fs.rmSync(stateDir, { recursive: true, force: true });
@@ -139,6 +149,7 @@ export async function createFridayRealBrowserE2eEnv(): Promise<FridayRealBrowser
       await shutdownRealHubEnv(runtime, { removeStateDir: false });
       runtime = await createRealHubEnvFromStateDir(stateDirToPreserve, {
         uiStaticDir,
+        hubConfig,
       });
     },
     async cleanup() {

--- a/test/e2e/ui/friday-reflex-review-center-real-browser.e2e.test.ts
+++ b/test/e2e/ui/friday-reflex-review-center-real-browser.e2e.test.ts
@@ -667,7 +667,7 @@ describe.skipIf(!CHROMIUM_AVAILABLE)("Friday Reflex Review Center real-browser f
   });
 
   it("approves a workflow candidate in the real Review Center UI and runs the published workflow", { timeout: 180_000 }, async () => {
-    env = await createFridayRealBrowserE2eEnv();
+    env = await createFridayRealBrowserE2eEnv({ allowTestOnlyWorkflowRunExecution: true });
     await completeSetup(env);
     const userId = await readUserId(env);
 
@@ -805,7 +805,7 @@ describe.skipIf(!CHROMIUM_AVAILABLE)("Friday Reflex Review Center real-browser f
   });
 
   it("keeps a Review Center approved workflow executable after a hub restart", { timeout: 180_000 }, async () => {
-    env = await createFridayRealBrowserE2eEnv();
+    env = await createFridayRealBrowserE2eEnv({ allowTestOnlyWorkflowRunExecution: true });
     await completeSetup(env);
     const userId = await readUserId(env);
 

--- a/test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts
@@ -24,6 +24,7 @@ import type { FridayAgentEventEmitter, FridayAgentRuntime } from "#agent";
 import type { FridayProviderService } from "#providers";
 import type { FridayProviderProfile } from "#providers";
 import type { FridaySqliteLayer } from "#state";
+import type { FridayWorkflowRuntime } from "#workflows";
 import { signFridayCanonicalApproval } from "../../../../src/security/friday-mutating-action-gate.js";
 import { createTestDb } from "../../../helpers/friday-test-db.helper.js";
 
@@ -175,6 +176,50 @@ function seedAgentRun(
       NOW,
     );
   });
+}
+
+function makeWorkflowRuntimeSpies(): {
+  workflowRuntime: FridayWorkflowRuntime;
+  execution: {
+    startRun: ReturnType<typeof vi.fn>;
+    getRun: ReturnType<typeof vi.fn>;
+    cancelRun: ReturnType<typeof vi.fn>;
+    retryRun: ReturnType<typeof vi.fn>;
+    resumeRun: ReturnType<typeof vi.fn>;
+  };
+} {
+  const run = {
+    id: "workflow-run-1",
+    workflowId: "workflow-1",
+    workflowVersionId: "version-1",
+    status: "running",
+    triggerType: "manual",
+    startedAt: NOW,
+    startedByUserId: "user-1",
+  };
+  const execution = {
+    startRun: vi.fn(async () => run),
+    getRun: vi.fn(() => run),
+    getRunNodes: vi.fn(() => []),
+    cancelRun: vi.fn(async () => ({ ...run, status: "cancelled" })),
+    retryRun: vi.fn(async () => ({ ...run, status: "running" })),
+    resumeRun: vi.fn(async () => ({ ...run, status: "running" })),
+  };
+  const workflowRuntime = {
+    execution,
+    evidence: {
+      getRunEvidenceStatus: vi.fn(() => ({ state: "not_required" })),
+      getRunEvidence: vi.fn(),
+      listRunEvidenceExports: vi.fn(() => []),
+      exportRunEvidence: vi.fn(),
+      getRunEvidenceExport: vi.fn(() => null),
+      downloadRunEvidenceExport: vi.fn(() => null),
+    },
+    crud: {},
+    approval: {},
+    triggers: {},
+  } as unknown as FridayWorkflowRuntime;
+  return { workflowRuntime, execution };
 }
 
 describe("API Runtime — Extended Route Registration", () => {
@@ -428,6 +473,75 @@ describe("API Runtime — Extended Route Registration", () => {
     expect((thrown as FridayDomainError).httpStatus).toBe(503);
     expect(executeRun).not.toHaveBeenCalled();
   });
+
+  it("fail-closes live workflow run start wiring without executing the TypeScript workflow runtime", async () => {
+    const { workflowRuntime, execution } = makeWorkflowRuntimeSpies();
+    const runtime = createFridayApiRuntime({
+      ...makeBaseDeps(),
+      workflowRuntime,
+    });
+    const route = runtime.routes.getRoutes().find((r) => r.operationId === "runs.start");
+    expect(route).toBeDefined();
+
+    let thrown: unknown = null;
+    try {
+      await route!.handler({
+        requestId: "req-workflow-run-retired",
+        receivedAt: NOW,
+        params: {},
+        query: {},
+        body: { workflowId: "workflow-1" },
+        headers: {},
+        principal: makePrincipal({ role: "admin", scopes: ["workflow.write"] }),
+      });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(FridayDomainError);
+    expect((thrown as FridayDomainError).code).toBe("TS_RUNTIME_WORKFLOW_RUNS_RETIRED");
+    expect((thrown as FridayDomainError).httpStatus).toBe(503);
+    expect(execution.startRun).not.toHaveBeenCalled();
+    expect(execution.getRun).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["runs.cancel", { reason: "operator requested" }, "cancelRun"],
+    ["runs.retry", { nodeIds: ["node-1"] }, "retryRun"],
+    ["workflows.runs.resume", {}, "resumeRun"],
+  ] as const)(
+    "fail-closes live workflow control wiring for %s without TypeScript execution",
+    async (operationId, body, methodName) => {
+      const { workflowRuntime, execution } = makeWorkflowRuntimeSpies();
+      const runtime = createFridayApiRuntime({
+        ...makeBaseDeps(),
+        workflowRuntime,
+      });
+      const route = runtime.routes.getRoutes().find((r) => r.operationId === operationId);
+      expect(route).toBeDefined();
+
+      let thrown: unknown = null;
+      try {
+        await route!.handler({
+          requestId: `req-${operationId}-retired`,
+          receivedAt: NOW,
+          params: { runId: "workflow-run-1" },
+          query: {},
+          body,
+          headers: {},
+          principal: makePrincipal({ role: "admin", scopes: ["workflow.write"] }),
+        });
+      } catch (err) {
+        thrown = err;
+      }
+
+      expect(thrown).toBeInstanceOf(FridayDomainError);
+      expect((thrown as FridayDomainError).code).toBe("TS_RUNTIME_WORKFLOW_RUNS_RETIRED");
+      expect((thrown as FridayDomainError).httpStatus).toBe(503);
+      expect(execution.getRun).not.toHaveBeenCalled();
+      expect(execution[methodName]).not.toHaveBeenCalled();
+    },
+  );
 
   it("registers skills.social.import in disabled state when deps.socialImport is omitted", async () => {
     const runtime = createFridayApiRuntime(makeBaseDeps());

--- a/test/unit/api/runtime/friday-api-runtime-run-evidence-access.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-run-evidence-access.test.ts
@@ -58,6 +58,7 @@ function makeDeps(): CreateFridayApiRuntimeDeps {
     computeChecksum: (content: string) => createHash("sha256").update(content).digest("hex"),
     resolveSkill: () => ({ id: "test-skill" }),
     invokeSkill: async () => ({ ok: true }),
+    allowTestOnlyWorkflowRunExecution: true,
   };
 }
 

--- a/test/unit/ops/run-real-green-gate.test.ts
+++ b/test/unit/ops/run-real-green-gate.test.ts
@@ -4,9 +4,11 @@ import { describe, expect, it } from "vitest";
 import {
   buildSummary,
   isAgentRunStartFailClosed,
+  isWorkflowRunStartFailClosed,
   normalizeLiveProviderMode,
   resolveGateSuiteReportRoot,
   resolveRetiredAgentRunScenarioExclusions,
+  resolveRetiredWorkflowRunScenarioExclusions,
   shouldExcludeProviderScenarios,
   summarizeRun,
 } from "../../../scripts/ops/run-real-green-gate.mjs";
@@ -79,7 +81,37 @@ describe("run-real-green-gate helpers", () => {
     ]);
   });
 
-  it("preserves retired agent-run scenario exclusions in the terminal summary", () => {
+  it("detects fail-closed workflow run start retirement from the manifest", () => {
+    expect(isWorkflowRunStartFailClosed({
+      surfaces: [
+        {
+          id: "workflow_runs_start",
+          classification: "fail_closed",
+          executes_product_logic: false,
+        },
+      ],
+    })).toBe(true);
+    expect(isWorkflowRunStartFailClosed({
+      surfaces: [
+        {
+          id: "workflow_runs_start",
+          classification: "ts_runtime_blocker",
+          executes_product_logic: true,
+        },
+      ],
+    })).toBe(false);
+  });
+
+  it("excludes workflow-run-start-dependent RGG scenarios while the route is fail-closed", () => {
+    expect(resolveRetiredWorkflowRunScenarioExclusions(process.cwd())).toEqual([
+      {
+        scenarioId: "l5-workflow-approval-roundtrip",
+        reason: "POST /v1/workflow-runs is classified fail_closed in the TS runtime retirement manifest.",
+      },
+    ]);
+  });
+
+  it("preserves retired runtime scenario exclusions in the terminal summary", () => {
     const summary = buildSummary({
       runId: "run-1",
       repoRoot: "/tmp/friday",
@@ -114,12 +146,24 @@ describe("run-real-green-gate helpers", () => {
           reason: "POST /v1/agent/runs is classified fail_closed in the TS runtime retirement manifest.",
         },
       ],
+      retiredWorkflowRunScenarioExclusions: [
+        {
+          scenarioId: "l5-workflow-approval-roundtrip",
+          reason: "POST /v1/workflow-runs is classified fail_closed in the TS runtime retirement manifest.",
+        },
+      ],
     });
 
     expect(summary.retiredAgentRunScenarioExclusions).toEqual([
       {
         scenarioId: "l3-channel-origin-unified-task-state-contract",
         reason: "POST /v1/agent/runs is classified fail_closed in the TS runtime retirement manifest.",
+      },
+    ]);
+    expect(summary.retiredWorkflowRunScenarioExclusions).toEqual([
+      {
+        scenarioId: "l5-workflow-approval-roundtrip",
+        reason: "POST /v1/workflow-runs is classified fail_closed in the TS runtime retirement manifest.",
       },
     ]);
     expect(summary.gate).toEqual({


### PR DESCRIPTION
## Summary
- fail-close default/live workflow run start, cancel, retry, and resume wiring with `TS_RUNTIME_WORKFLOW_RUNS_RETIRED`
- keep legacy TypeScript workflow execution reachable only through explicit test-oracle opt-in for isolated validation
- update the TS runtime retirement manifest and route registration coverage for the new fail-closed surfaces
- explicitly opt full E2E and Review Center workflow-oracle fixtures into legacy workflow execution so CI validates old behavior without weakening live defaults
- record workflow-run-dependent Real Green Gate scenarios as retirement exclusions while `/v1/workflow-runs` is classified fail-closed

## Verification
- `npx vitest run test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts`
- `npx vitest run test/unit/api/http/routes/friday-workflow-run-routes.test.ts test/unit/api/runtime/friday-api-runtime-run-evidence-access.test.ts test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts`
- `npx vitest run test/e2e/api/friday-api-workflows-routes.test.ts test/e2e/api/friday-api-workflow-retry-user-visible-receipt.e2e.test.ts`
- `FRIDAY_E2E_CORE=1 npx vitest run test/e2e/friday-real-scenarios-e2e.test.ts test/e2e/friday-full-e2e.test.ts`
- `npx vitest run test/e2e/ui/friday-reflex-review-center-real-browser.e2e.test.ts`
- `npx vitest run test/unit/ops/run-real-green-gate.test.ts`
- `npm run check:ts-runtime-retirement`
- `npm run build`
- `npm run check:secret-patterns`
- `detect-secrets-hook --baseline .secrets.baseline $(git ls-files)`
- `git diff --check`

Default machine DB mutation: none; tests use isolated temp/in-memory state.
Pet/design-gallery files touched: no.
Provider-native synced claim: no.