### PR TITLE
Fail close auto-fix execution routes

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -419,17 +419,43 @@
       "next_action": "Replace fail-closed response with a Rust-owned skill execution entrypoint when available."
     },
     {
+      "id": "autofix_run_ready",
+      "route": {
+        "method": "POST",
+        "path": "/v1/auto-fix/actions/run-ready",
+        "operationId": "autofix.actions.run.ready"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-auto-fix-routes.ts wires default/live autofix.actions.run.ready to TS_RUNTIME_AUTOFIX_EXECUTION_RETIRED after the bound-principal gate and before calling the TypeScript runReadyActions service; legacy TS execution is reachable only through explicit allowTestOnlyAutoFixExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned auto-fix run-ready execution entrypoint when available."
+    },
+    {
       "id": "autofix_execute",
       "route": {
         "method": "POST",
         "path": "/v1/auto-fix/actions/:actionId/execute",
         "operationId": "autofix.actions.execute"
       },
-      "classification": "ts_runtime_blocker",
+      "classification": "fail_closed",
       "user_triggerable": true,
-      "owner": "ts-runtime-retirement",
-      "blocker": "Executes auto-fix action through TypeScript service.",
-      "next_action": "Move auto-fix execute/rollback truth to Rust or fail-close execution."
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-auto-fix-routes.ts wires default/live autofix.actions.execute to TS_RUNTIME_AUTOFIX_EXECUTION_RETIRED after the bound-principal gate and before calling the TypeScript executeAction service; legacy TS execution is reachable only through explicit allowTestOnlyAutoFixExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned auto-fix execute entrypoint when available."
+    },
+    {
+      "id": "autofix_rollback",
+      "route": {
+        "method": "POST",
+        "path": "/v1/auto-fix/actions/:actionId/rollback",
+        "operationId": "autofix.actions.rollback"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-auto-fix-routes.ts wires default/live autofix.actions.rollback to TS_RUNTIME_AUTOFIX_EXECUTION_RETIRED after the bound-principal gate and before calling the TypeScript rollbackAction service; legacy TS rollback is reachable only through explicit allowTestOnlyAutoFixExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned auto-fix rollback entrypoint when available."
     },
     {
       "id": "desktop_actions_execute",

--- a/src/api/http/routes/friday-auto-fix-routes.ts
+++ b/src/api/http/routes/friday-auto-fix-routes.ts
@@ -15,6 +15,7 @@ import { toFridayFixPlanRecord } from "./friday-self-healing-route-mappers.js";
 
 export interface FridayAutoFixRoutesDeps {
   service: FridaySelfHealingApiService;
+  allowTestOnlyAutoFixExecution?: boolean;
   agentLoop?: {
     findRunByActionId(actionId: string): { loopRunId: string } | null;
   };
@@ -40,6 +41,20 @@ function requireUserId(principal: { userId?: string } | null): string {
     });
   }
   return principal.userId;
+}
+
+function throwRetiredAutoFixExecution(): never {
+  throw new FridayDomainError(
+    "TS_RUNTIME_AUTOFIX_EXECUTION_RETIRED",
+    "Auto-fix execution is fail-closed while runtime ownership is being moved out of TypeScript.",
+    {
+      httpStatus: 503,
+      details: {
+        classification: "fail_closed",
+        replacement: "rust_owned_autofix_execution_entrypoint_required",
+      },
+    },
+  );
 }
 
 function readReason(body: unknown): string | undefined {
@@ -154,6 +169,9 @@ export function createFridayAutoFixRoutes(
         // principal. One-click self-repair cannot fire from a channel/API
         // message that lacks a bound owner/session/channel principal.
         assertBoundPrincipalForOperation(ctx.principal ?? null, "autofix.actions.run.ready", "api");
+        if (deps.allowTestOnlyAutoFixExecution !== true) {
+          throwRetiredAutoFixExecution();
+        }
         const userId = requireUserId(ctx.principal);
         const body = (ctx.body ?? {}) as Record<string, unknown>;
         const run = await deps.service.runReadyActions({
@@ -252,6 +270,9 @@ export function createFridayAutoFixRoutes(
         // synthetic public principal must be refused even though it carries
         // hub.admin scope for read-only routes.
         assertBoundPrincipalForOperation(ctx.principal ?? null, "autofix.actions.execute", "api");
+        if (deps.allowTestOnlyAutoFixExecution !== true) {
+          throwRetiredAutoFixExecution();
+        }
         const userId = requireUserId(ctx.principal);
         const { actionId } = ctx.params as { actionId: string };
         const updated = await deps.service.executeAction({ actionId, userId });
@@ -277,6 +298,9 @@ export function createFridayAutoFixRoutes(
         // Phase 14.5B module_28b: rollback also mutates runtime state, so
         // the same bound-principal gate applies as execute.
         assertBoundPrincipalForOperation(ctx.principal ?? null, "autofix.actions.rollback", "api");
+        if (deps.allowTestOnlyAutoFixExecution !== true) {
+          throwRetiredAutoFixExecution();
+        }
         const userId = requireUserId(ctx.principal);
         const { actionId } = ctx.params as { actionId: string };
         const reason = readReason(ctx.body);

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -1852,6 +1852,8 @@ export interface FridayHubConfig {
   allowTestOnlyWorkflowRunExecution?: boolean;
   /** Test-oracle only; production hub creation must leave skill run execution fail-closed. */
   allowTestOnlySkillRunExecution?: boolean;
+  /** Test-oracle only; production hub creation must leave auto-fix execution fail-closed. */
+  allowTestOnlyAutoFixExecution?: boolean;
   /** Test-oracle only; production hub creation must leave POST /v1/agent/runs fail-closed. */
   allowTestOnlyAgentRunStartExecution?: boolean;
   /** Test-oracle only; production hub creation must leave agent run controls fail-closed. */

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -6711,7 +6711,11 @@ export async function createFridayHub(
     pluginManifestLoader,
     deterministicPipeline,
     diagnosis: { service: selfHealingApiService, agentLoop: agentLoopService },
-    autoFix: { service: selfHealingApiService, agentLoop: agentLoopService },
+    autoFix: {
+      service: selfHealingApiService,
+      agentLoop: agentLoopService,
+      allowTestOnlyAutoFixExecution: config.allowTestOnlyAutoFixExecution,
+    },
     agentLoop: { service: agentLoopService },
     observability: observabilityService.routes,
     observabilityService,

--- a/test/e2e/api/_helpers/friday-api-test-server.helper.ts
+++ b/test/e2e/api/_helpers/friday-api-test-server.helper.ts
@@ -143,6 +143,11 @@ export interface CreateFridayApiTestEnvOptions {
    * leaves skill run execution fail-closed while Rust ownership lands.
    */
   allowTestOnlySkillRunExecution?: boolean;
+  /**
+   * Test-oracle opt-in for legacy TS auto-fix execution. Default/live runtime
+   * leaves auto-fix run/execute/rollback surfaces fail-closed while Rust ownership lands.
+   */
+  allowTestOnlyAutoFixExecution?: boolean;
   resolveSkill?: (skillId: string) => unknown | null;
   invokeSkill?: (
     skillId: string,
@@ -237,7 +242,12 @@ export async function createFridayApiTestEnv(
     skillGenerator: options.skillGenerator,
     skillRegistry: options.skillRegistry,
     diagnosis: selfHealingService ? { service: selfHealingService } : undefined,
-    autoFix: selfHealingService ? { service: selfHealingService } : undefined,
+    autoFix: selfHealingService
+      ? {
+          service: selfHealingService,
+          allowTestOnlyAutoFixExecution: options.allowTestOnlyAutoFixExecution ?? true,
+        }
+      : undefined,
     uix: uixService ? { service: uixService } : undefined,
     pluginService: options.pluginService,
     pluginManifestLoader: options.pluginManifestLoader,

--- a/test/e2e/api/friday-api-auto-fix-doctor.acceptance.test.ts
+++ b/test/e2e/api/friday-api-auto-fix-doctor.acceptance.test.ts
@@ -363,7 +363,7 @@ describe("Phase 14.5B module_28b: one-click repair / recovery doctor acceptance"
     void diagnosisRepo;
     const configManager = makeConfigManager();
     const service = buildAcceptanceSelfHealingApiService(db, configManager);
-    const routes = createFridayAutoFixRoutes({ service });
+    const routes = createFridayAutoFixRoutes({ service, allowTestOnlyAutoFixExecution: true });
     const executeRoute = routes.find((r) => r.operationId === "autofix.actions.execute")!;
 
     const plan = buildConfigPatchPlan("verified-route", { withPatch: true });
@@ -421,7 +421,7 @@ describe("Phase 14.5B module_28b: one-click repair / recovery doctor acceptance"
     void diagnosisRepo;
     const configManager = makeConfigManager();
     const service = buildAcceptanceSelfHealingApiService(db, configManager);
-    const routes = createFridayAutoFixRoutes({ service });
+    const routes = createFridayAutoFixRoutes({ service, allowTestOnlyAutoFixExecution: true });
     const executeRoute = routes.find((r) => r.operationId === "autofix.actions.execute")!;
     const rollbackRoute = routes.find((r) => r.operationId === "autofix.actions.rollback")!;
 
@@ -504,7 +504,7 @@ describe("Phase 14.5B module_28b: one-click repair / recovery doctor acceptance"
     void diagnosisRepo;
     const configManager = makeConfigManager();
     const service = buildAcceptanceSelfHealingApiService(db, configManager);
-    const routes = createFridayAutoFixRoutes({ service });
+    const routes = createFridayAutoFixRoutes({ service, allowTestOnlyAutoFixExecution: true });
     const executeRoute = routes.find((r) => r.operationId === "autofix.actions.execute")!;
 
     const plan = buildConfigPatchPlan("diagnostic-route", { withPatch: false });

--- a/test/e2e/ui/_helpers/browser-env.ts
+++ b/test/e2e/ui/_helpers/browser-env.ts
@@ -42,6 +42,7 @@ export interface FridayRealBrowserE2eEnv {
 export interface FridayRealBrowserE2eEnvOptions {
   allowTestOnlyWorkflowRunExecution?: boolean;
   allowTestOnlySkillRunExecution?: boolean;
+  allowTestOnlyAutoFixExecution?: boolean;
 }
 
 function resolveUiStaticDir(): string {
@@ -63,6 +64,7 @@ export async function createFridayRealBrowserE2eEnv(
   const hubConfig = {
     allowTestOnlyWorkflowRunExecution: options.allowTestOnlyWorkflowRunExecution,
     allowTestOnlySkillRunExecution: options.allowTestOnlySkillRunExecution,
+    allowTestOnlyAutoFixExecution: options.allowTestOnlyAutoFixExecution,
   };
   try {
     runtime = await createRealHubEnvFromStateDir(stateDir, {

--- a/test/e2e/ui/friday-home-self-repair-real-browser.e2e.test.ts
+++ b/test/e2e/ui/friday-home-self-repair-real-browser.e2e.test.ts
@@ -328,7 +328,7 @@ describe.skipIf(!CHROMIUM_AVAILABLE)("Friday Home supervised self-repair real-br
   });
 
   it("runs and rolls back ready low-risk repair actions from Home and denies unbound repair mutations", { timeout: 180_000 }, async () => {
-    env = await createFridayRealBrowserE2eEnv();
+    env = await createFridayRealBrowserE2eEnv({ allowTestOnlyAutoFixExecution: true });
     await completeSetup(env);
     const userId = await readUserId(env);
     const actionId = seedReadyRollbackableLowRiskAutoFixAction({ env, userId });

--- a/test/unit/api/http/routes/friday-auto-fix-routes.test.ts
+++ b/test/unit/api/http/routes/friday-auto-fix-routes.test.ts
@@ -266,9 +266,37 @@ describe("FridayAutoFixRoutes", () => {
     expect(result.items[0]?.summary.loopRunId).toBe("loop-run-1");
   });
 
-  it("runs ready self-repair actions through the user-scoped all endpoint", async () => {
+  it("fail-closes auto-fix execution routes by default without invoking TypeScript services", async () => {
     const service = makeService();
     const routes = createFridayAutoFixRoutes({ service });
+    const executionRoutes = [
+      ["autofix.actions.run.ready", {}, { maxRiskTier: 1 }],
+      ["autofix.actions.execute", { actionId: "action-1" }, {}],
+      ["autofix.actions.rollback", { actionId: "action-1" }, { reason: "test rollback" }],
+    ] as const;
+
+    for (const [operationId, params, body] of executionRoutes) {
+      const route = routes.find((entry) => entry.operationId === operationId)!;
+      await expect(
+        route.handler(makeCtx({ params, body })),
+      ).rejects.toMatchObject({
+        code: "TS_RUNTIME_AUTOFIX_EXECUTION_RETIRED",
+        httpStatus: 503,
+        details: {
+          classification: "fail_closed",
+          replacement: "rust_owned_autofix_execution_entrypoint_required",
+        },
+      });
+    }
+
+    expect(service.runReadyActions).not.toHaveBeenCalled();
+    expect(service.executeAction).not.toHaveBeenCalled();
+    expect(service.rollbackAction).not.toHaveBeenCalled();
+  });
+
+  it("runs ready self-repair actions through the user-scoped all endpoint", async () => {
+    const service = makeService();
+    const routes = createFridayAutoFixRoutes({ service, allowTestOnlyAutoFixExecution: true });
     const route = routes.find((entry) => entry.operationId === "autofix.actions.run.ready")!;
 
     const result = await route.handler(
@@ -294,7 +322,10 @@ describe("FridayAutoFixRoutes", () => {
   });
 
   it("rejects unsafe maxRiskTier values for homepage self-repair", async () => {
-    const routes = createFridayAutoFixRoutes({ service: makeService() });
+    const routes = createFridayAutoFixRoutes({
+      service: makeService(),
+      allowTestOnlyAutoFixExecution: true,
+    });
     const route = routes.find((entry) => entry.operationId === "autofix.actions.run.ready")!;
 
     await expect(
@@ -323,7 +354,10 @@ describe("FridayAutoFixRoutes", () => {
   });
 
   it("requires a rollback reason", async () => {
-    const routes = createFridayAutoFixRoutes({ service: makeService() });
+    const routes = createFridayAutoFixRoutes({
+      service: makeService(),
+      allowTestOnlyAutoFixExecution: true,
+    });
     const route = routes.find((entry) => entry.operationId === "autofix.actions.rollback")!;
 
     await expect(


### PR DESCRIPTION
## Summary

Retire the TypeScript-owned auto-fix execution HTTP surfaces from default/live runtime behavior by fail-closing them until Rust-owned execution entrypoints exist:

- `POST /v1/auto-fix/actions/run-ready`
- `POST /v1/auto-fix/actions/:actionId/execute`
- `POST /v1/auto-fix/actions/:actionId/rollback`

The routes still enforce the bound-principal gate first, so synthetic public-principal mutation attempts keep returning the owner/session/channel principal refusal instead of becoming a retired-runtime 503.

Legacy TypeScript execution remains reachable only through explicit test-oracle wiring via `allowTestOnlyAutoFixExecution`; default/live hub wiring leaves it unset.

## Safety

- No default machine DB mutation; tests used in-memory/isolated state.
- No pet/design-gallery edits.
- No fake/mock/synthetic proof or closure claim.
- No provider-native synced claim.

## Verification

- `npx vitest run test/unit/api/http/routes/friday-auto-fix-routes.test.ts`
- `npx vitest run test/e2e/api/friday-api-auto-fix-doctor.acceptance.test.ts`
- `npx vitest run test/e2e/api/friday-api-phase21-cross-user-proof.test.ts`
- `npx vitest run test/e2e/ui/friday-home-self-repair-real-browser.e2e.test.ts`
- `npx vitest run test/e2e/api/friday-api-self-healing-routes.test.ts test/e2e/api/friday-api-phase21-cross-user-proof.test.ts test/unit/validation/real-world-executors.test.ts test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts`
- `npm run check:ts-runtime-retirement` -> 584 routes, 255 `ts_runtime_blocker`, 12 `fail_closed`
- `npm run build`
- `npm run check:secret-patterns`
- `detect-secrets-hook --baseline .secrets.baseline $(git ls-files)`
- `git diff --check`