### PR TITLE
Fail close desktop action execution routes

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -464,11 +464,24 @@
         "path": "/v1/desktop/actions/execute",
         "operationId": "desktop.actions.execute"
       },
-      "classification": "ts_runtime_blocker",
+      "classification": "fail_closed",
       "user_triggerable": true,
-      "owner": "ts-runtime-retirement",
-      "blocker": "Desktop action execution remains TypeScript-owned.",
-      "next_action": "Route desktop execution through Rust-owned action authority or fail-close action execution."
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-desktop-routes.ts wires default/live desktop.actions.execute to TS_RUNTIME_DESKTOP_ACTION_EXECUTION_RETIRED after request validation and before calling the TypeScript desktop action service; legacy TS execution is reachable only through explicit allowTestOnlyDesktopActionExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned desktop action execution entrypoint when available."
+    },
+    {
+      "id": "desktop_actions_batch",
+      "route": {
+        "method": "POST",
+        "path": "/v1/desktop/actions/batch",
+        "operationId": "desktop.actions.batch"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-desktop-routes.ts wires default/live desktop.actions.batch to TS_RUNTIME_DESKTOP_ACTION_EXECUTION_RETIRED after request validation and before calling the TypeScript desktop batch action service; legacy TS execution is reachable only through explicit allowTestOnlyDesktopActionExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned desktop batch action execution entrypoint when available."
     }
   ]
 }

--- a/src/api/http/routes/friday-desktop-routes.ts
+++ b/src/api/http/routes/friday-desktop-routes.ts
@@ -62,6 +62,7 @@ import type { UUID } from "../../../desktop/model/friday-desktop.types.js";
 // ─── Service Dependencies ───
 
 export interface FridayDesktopRoutesDeps {
+  allowTestOnlyDesktopActionExecution?: boolean;
   actions: {
     execute(req: FridayExecuteDesktopActionRequest): Promise<FridayExecuteDesktopActionResponse>;
     batch(req: FridayBatchDesktopActionsRequest): Promise<FridayBatchDesktopActionsResponse>;
@@ -126,6 +127,20 @@ function requireEtag(body: unknown): void {
   requireString(body, "etag");
 }
 
+function throwRetiredDesktopActionExecution(): never {
+  throw new FridayDomainError(
+    "TS_RUNTIME_DESKTOP_ACTION_EXECUTION_RETIRED",
+    "Desktop action execution is fail-closed while runtime ownership is being moved out of TypeScript.",
+    {
+      httpStatus: 503,
+      details: {
+        classification: "fail_closed",
+        replacement: "rust_owned_desktop_action_execution_entrypoint_required",
+      },
+    },
+  );
+}
+
 // ─── Factory ───
 
 export function createFridayDesktopRoutes(
@@ -145,6 +160,9 @@ export function createFridayDesktopRoutes(
         const body = ctx.body as FridayExecuteDesktopActionRequest;
         requirePresent(body, "action");
         requireIdempotencyKey(body);
+        if (deps.allowTestOnlyDesktopActionExecution !== true) {
+          throwRetiredDesktopActionExecution();
+        }
         return deps.actions.execute(body);
       },
     },
@@ -159,6 +177,9 @@ export function createFridayDesktopRoutes(
           throw new FridayDomainError("VALIDATION_ERROR", "actions array is required");
         }
         requireIdempotencyKey(body);
+        if (deps.allowTestOnlyDesktopActionExecution !== true) {
+          throwRetiredDesktopActionExecution();
+        }
         return deps.actions.batch(body);
       },
     },

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -1854,6 +1854,8 @@ export interface FridayHubConfig {
   allowTestOnlySkillRunExecution?: boolean;
   /** Test-oracle only; production hub creation must leave auto-fix execution fail-closed. */
   allowTestOnlyAutoFixExecution?: boolean;
+  /** Test-oracle only; production hub creation must leave desktop action execution fail-closed. */
+  allowTestOnlyDesktopActionExecution?: boolean;
   /** Test-oracle only; production hub creation must leave POST /v1/agent/runs fail-closed. */
   allowTestOnlyAgentRunStartExecution?: boolean;
   /** Test-oracle only; production hub creation must leave agent run controls fail-closed. */

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -6531,6 +6531,7 @@ export async function createFridayHub(
   // ── Desktop route deps (opt-in, wired from desktopSessionManager) ──
   const desktopRouteDeps: Parameters<typeof createFridayApiRuntime>[0]["desktop"] = desktopSessionManager
     ? {
+      allowTestOnlyDesktopActionExecution: config.allowTestOnlyDesktopActionExecution,
       actions: {
         async execute(req) { return desktopSessionManager!.executeAction(req.action as never) as never; },
         async batch(req) {

--- a/test/unit/api/http/routes/friday-desktop-routes.test.ts
+++ b/test/unit/api/http/routes/friday-desktop-routes.test.ts
@@ -94,8 +94,30 @@ describe("createFridayDesktopRoutes", () => {
   // ─── Actions ───
 
   describe("actions", () => {
-    it("executes an action", async () => {
+    it("fail-closes desktop action execution routes by default without invoking TypeScript services", async () => {
       const deps = makeDeps();
+      const routes = createFridayDesktopRoutes(deps);
+      const executeRoute = findRoute(routes, "desktop.actions.execute");
+      const batchRoute = findRoute(routes, "desktop.actions.batch");
+
+      await expect(
+        executeRoute.handler(makeCtx({ body: { action: { type: "click" }, idempotencyKey: "k-retired-1" } })),
+      ).rejects.toMatchObject({ code: "TS_RUNTIME_DESKTOP_ACTION_EXECUTION_RETIRED" });
+      await expect(
+        batchRoute.handler(makeCtx({
+          body: {
+            actions: [{ clientId: "c1", action: { type: "click" } }],
+            idempotencyKey: "k-retired-2",
+          },
+        })),
+      ).rejects.toMatchObject({ code: "TS_RUNTIME_DESKTOP_ACTION_EXECUTION_RETIRED" });
+
+      expect(deps.actions.execute).not.toHaveBeenCalled();
+      expect(deps.actions.batch).not.toHaveBeenCalled();
+    });
+
+    it("executes an action", async () => {
+      const deps = makeDeps({ allowTestOnlyDesktopActionExecution: true });
       const routes = createFridayDesktopRoutes(deps);
       const route = findRoute(routes, "desktop.actions.execute");
       expect(route.method).toBe("POST");
@@ -122,7 +144,7 @@ describe("createFridayDesktopRoutes", () => {
     });
 
     it("batches actions", async () => {
-      const deps = makeDeps();
+      const deps = makeDeps({ allowTestOnlyDesktopActionExecution: true });
       const routes = createFridayDesktopRoutes(deps);
       const route = findRoute(routes, "desktop.actions.batch");
       expect(route.method).toBe("POST");


### PR DESCRIPTION
## Summary

Retire default/live TypeScript-owned desktop action HTTP execution by fail-closing these surfaces until Rust-owned desktop action execution entrypoints exist:

- `POST /v1/desktop/actions/execute`
- `POST /v1/desktop/actions/batch`

`batch` is included because hub wiring loops through the same TypeScript desktop session manager and otherwise remains an execution bypass.

Legacy TypeScript desktop action execution remains reachable only through explicit test-oracle wiring via `allowTestOnlyDesktopActionExecution`; default/live hub wiring leaves it unset.

## Safety

- No default machine DB mutation.
- No pet/design-gallery edits.
- No fake/mock/synthetic proof or closure claim.
- No provider-native synced claim.

## Verification

- `npx vitest run test/unit/api/http/routes/friday-desktop-routes.test.ts`
- `npm run check:ts-runtime-retirement` -> 584 routes, 253 `ts_runtime_blocker`, 14 `fail_closed`
- `npm run build`
- `npx vitest run test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts test/unit/validation/real-world-executors.test.ts test/unit/hub/bootstrap/desktop-policy-fail-closed.test.ts`
- `npm run check:secret-patterns`
- `detect-secrets-hook --baseline .secrets.baseline $(git ls-files)`
- `git diff --check`