### PR TITLE
Fail close agent loop run controls

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -354,6 +354,45 @@
       "next_action": "Replace fail-closed response with a Rust-owned automation execution/control entrypoint when available."
     },
     {
+      "id": "agent_loop_runs_pause",
+      "route": {
+        "method": "POST",
+        "path": "/v1/agent-loop/runs/:loopRunId/pause",
+        "operationId": "agent.loop.runs.pause"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-agent-loop-routes.ts wires default/live agent.loop.runs.pause to TS_RUNTIME_AGENT_LOOP_CONTROLS_RETIRED after user-principal validation and before calling the TypeScript agent loop service; legacy TS pause is reachable only through explicit allowTestOnlyAgentLoopRunControlExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned agent-loop pause/control entrypoint when available."
+    },
+    {
+      "id": "agent_loop_runs_resume",
+      "route": {
+        "method": "POST",
+        "path": "/v1/agent-loop/runs/:loopRunId/resume",
+        "operationId": "agent.loop.runs.resume"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-agent-loop-routes.ts wires default/live agent.loop.runs.resume to TS_RUNTIME_AGENT_LOOP_CONTROLS_RETIRED after user-principal validation and before calling the TypeScript agent loop service; legacy TS resume is reachable only through explicit allowTestOnlyAgentLoopRunControlExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned agent-loop resume/control entrypoint when available."
+    },
+    {
+      "id": "agent_loop_runs_cancel",
+      "route": {
+        "method": "POST",
+        "path": "/v1/agent-loop/runs/:loopRunId/cancel",
+        "operationId": "agent.loop.runs.cancel"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-agent-loop-routes.ts wires default/live agent.loop.runs.cancel to TS_RUNTIME_AGENT_LOOP_CONTROLS_RETIRED after user-principal validation and before calling the TypeScript agent loop service; legacy TS cancel is reachable only through explicit allowTestOnlyAgentLoopRunControlExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned agent-loop cancel/control entrypoint when available."
+    },
+    {
       "id": "workflow_runs_start",
       "route": {
         "method": "POST",

--- a/src/api/http/routes/friday-agent-loop-routes.ts
+++ b/src/api/http/routes/friday-agent-loop-routes.ts
@@ -27,6 +27,21 @@ import {
 
 export interface FridayAgentLoopRoutesDeps {
   service: FridayAgentLoopService;
+  allowTestOnlyAgentLoopRunControlExecution?: boolean;
+}
+
+function throwRetiredAgentLoopRunControl(): never {
+  throw new FridayDomainError(
+    "TS_RUNTIME_AGENT_LOOP_CONTROLS_RETIRED",
+    "Agent loop run controls are fail-closed while runtime ownership is being moved out of TypeScript.",
+    {
+      httpStatus: 503,
+      details: {
+        classification: "fail_closed",
+        replacement: "rust_owned_agent_loop_control_entrypoint_required",
+      },
+    },
+  );
 }
 
 function requireUserId(principal: FridayAuthPrincipal | null): string {
@@ -205,6 +220,9 @@ export function createFridayAgentLoopRoutes(
       async handler(ctx): Promise<FridayAgentLoopRunControlResponse> {
         requireUserId(ctx.principal);
         const { loopRunId } = ctx.params as { loopRunId: string };
+        if (deps.allowTestOnlyAgentLoopRunControlExecution !== true) {
+          throwRetiredAgentLoopRunControl();
+        }
         return {
           run: toRunRecord(deps.service.pauseRun({ loopRunId })),
         };
@@ -218,6 +236,9 @@ export function createFridayAgentLoopRoutes(
       async handler(ctx): Promise<FridayAgentLoopRunControlResponse> {
         requireUserId(ctx.principal);
         const { loopRunId } = ctx.params as { loopRunId: string };
+        if (deps.allowTestOnlyAgentLoopRunControlExecution !== true) {
+          throwRetiredAgentLoopRunControl();
+        }
         return {
           run: toRunRecord(await deps.service.resumeRun({ loopRunId })),
         };
@@ -231,6 +252,9 @@ export function createFridayAgentLoopRoutes(
       async handler(ctx): Promise<FridayAgentLoopRunControlResponse> {
         requireUserId(ctx.principal);
         const { loopRunId } = ctx.params as { loopRunId: string };
+        if (deps.allowTestOnlyAgentLoopRunControlExecution !== true) {
+          throwRetiredAgentLoopRunControl();
+        }
         return {
           run: toRunRecord(deps.service.cancelRun({ loopRunId })),
         };

--- a/test/unit/api/http/routes/friday-agent-loop-routes.test.ts
+++ b/test/unit/api/http/routes/friday-agent-loop-routes.test.ts
@@ -329,4 +329,41 @@ describe("FridayAgentLoopRoutes", () => {
     });
     expect(service.updatePolicy).not.toHaveBeenCalled();
   });
+
+  it("fail-closes default agent-loop run controls before calling TypeScript services", async () => {
+    const service = makeService();
+    const routes = createFridayAgentLoopRoutes({ service });
+    const controlRoutes = [
+      ["agent.loop.runs.pause", service.pauseRun],
+      ["agent.loop.runs.resume", service.resumeRun],
+      ["agent.loop.runs.cancel", service.cancelRun],
+    ] as const;
+
+    for (const [operationId, serviceCall] of controlRoutes) {
+      const route = routes.find((entry) => entry.operationId === operationId)!;
+      await expect(
+        route.handler(makeCtx({ params: { loopRunId: "loop-run-1" } })),
+      ).rejects.toMatchObject({
+        code: "TS_RUNTIME_AGENT_LOOP_CONTROLS_RETIRED",
+        httpStatus: 503,
+      });
+      expect(serviceCall).not.toHaveBeenCalled();
+    }
+  });
+
+  it("allows legacy agent-loop run controls only through explicit test-only oracle wiring", async () => {
+    const service = makeService();
+    const routes = createFridayAgentLoopRoutes({
+      service,
+      allowTestOnlyAgentLoopRunControlExecution: true,
+    });
+    const route = routes.find((entry) => entry.operationId === "agent.loop.runs.pause")!;
+
+    const result = await route.handler(makeCtx({ params: { loopRunId: "loop-run-1" } })) as {
+      run: { run: { loopRunId: string } };
+    };
+
+    expect(service.pauseRun).toHaveBeenCalledWith({ loopRunId: "loop-run-1" });
+    expect(result.run.run.loopRunId).toBe("loop-run-1");
+  });
 });


### PR DESCRIPTION
## Summary

Retire default/live TypeScript-owned agent-loop run control routes by fail-closing these surfaces until Rust-owned agent-loop control entrypoints exist:

- `POST /v1/agent-loop/runs/:loopRunId/pause`
- `POST /v1/agent-loop/runs/:loopRunId/resume`
- `POST /v1/agent-loop/runs/:loopRunId/cancel`

The routes still validate the user-scoped principal, then return `TS_RUNTIME_AGENT_LOOP_CONTROLS_RETIRED` before calling the TypeScript agent loop service. Legacy TypeScript control behavior remains reachable only through explicit test-oracle wiring via `allowTestOnlyAgentLoopRunControlExecution`.

## Safety

- No default machine DB mutation.
- No pet/design-gallery edits.
- No fake/mock/synthetic proof or closure claim.
- No provider-native synced claim.

## Verification

- `npx vitest run test/unit/api/http/routes/friday-agent-loop-routes.test.ts`
- `npm run check:ts-runtime-retirement` -> 584 routes, 250 `ts_runtime_blocker`, 17 `fail_closed`
- `npm run build`
- `npx vitest run test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts test/unit/hub/friday-hub-bootstrap.test.ts test/unit/operator-client/friday-operator-client.test.ts`
- `npm run check:secret-patterns`
- `detect-secrets-hook --baseline .secrets.baseline $(git ls-files)`
- `git diff --check`