### PR TITLE
Fail close agent loop policy mutations

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -354,6 +354,32 @@
       "next_action": "Replace fail-closed response with a Rust-owned automation execution/control entrypoint when available."
     },
     {
+      "id": "agent_loop_expertmode_update",
+      "route": {
+        "method": "PUT",
+        "path": "/v1/agent-loop/expert-mode",
+        "operationId": "agent.loop.expertmode.update"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-agent-loop-routes.ts wires default/live agent.loop.expertmode.update to TS_RUNTIME_AGENT_LOOP_POLICY_MUTATIONS_RETIRED after user-principal validation and before mutating TypeScript agent-loop expert-mode policy; legacy TS mutation is reachable only through explicit allowTestOnlyAgentLoopPolicyMutation test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned agent-loop expert-mode policy entrypoint when available."
+    },
+    {
+      "id": "agent_loop_policy_update",
+      "route": {
+        "method": "PUT",
+        "path": "/v1/agent-loop/policy",
+        "operationId": "agent.loop.policy.update"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-agent-loop-routes.ts wires default/live agent.loop.policy.update to TS_RUNTIME_AGENT_LOOP_POLICY_MUTATIONS_RETIRED after user-principal validation and before mutating TypeScript agent-loop policy; legacy TS mutation is reachable only through explicit allowTestOnlyAgentLoopPolicyMutation test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned agent-loop policy entrypoint when available."
+    },
+    {
       "id": "agent_loop_runs_pause",
       "route": {
         "method": "POST",

--- a/src/api/http/routes/friday-agent-loop-routes.ts
+++ b/src/api/http/routes/friday-agent-loop-routes.ts
@@ -28,6 +28,7 @@ import {
 export interface FridayAgentLoopRoutesDeps {
   service: FridayAgentLoopService;
   allowTestOnlyAgentLoopRunControlExecution?: boolean;
+  allowTestOnlyAgentLoopPolicyMutation?: boolean;
 }
 
 function throwRetiredAgentLoopRunControl(): never {
@@ -39,6 +40,20 @@ function throwRetiredAgentLoopRunControl(): never {
       details: {
         classification: "fail_closed",
         replacement: "rust_owned_agent_loop_control_entrypoint_required",
+      },
+    },
+  );
+}
+
+function throwRetiredAgentLoopPolicyMutation(): never {
+  throw new FridayDomainError(
+    "TS_RUNTIME_AGENT_LOOP_POLICY_MUTATIONS_RETIRED",
+    "Agent loop policy mutations are fail-closed while runtime ownership is being moved out of TypeScript.",
+    {
+      httpStatus: 503,
+      details: {
+        classification: "fail_closed",
+        replacement: "rust_owned_agent_loop_policy_entrypoint_required",
       },
     },
   );
@@ -100,6 +115,9 @@ export function createFridayAgentLoopRoutes(
       auth: { public: true },
       async handler(ctx): Promise<FridayUpdateAgentLoopExpertModeResponse> {
         requireUserId(ctx.principal);
+        if (deps.allowTestOnlyAgentLoopPolicyMutation !== true) {
+          throwRetiredAgentLoopPolicyMutation();
+        }
         const body = (ctx.body ?? {}) as FridayUpdateAgentLoopExpertModeRequest;
         return {
           expertMode: deps.service.updateExpertMode({
@@ -138,6 +156,9 @@ export function createFridayAgentLoopRoutes(
       auth: { public: true },
       async handler(ctx): Promise<FridayUpdateAgentLoopPolicyResponse> {
         requireUserId(ctx.principal);
+        if (deps.allowTestOnlyAgentLoopPolicyMutation !== true) {
+          throwRetiredAgentLoopPolicyMutation();
+        }
         const body = (ctx.body ?? {}) as FridayUpdateAgentLoopPolicyRequest;
         return {
           policy: deps.service.updatePolicy(body),

--- a/test/unit/api/http/routes/friday-agent-loop-routes.test.ts
+++ b/test/unit/api/http/routes/friday-agent-loop-routes.test.ts
@@ -266,16 +266,46 @@ describe("FridayAgentLoopRoutes", () => {
     ).rejects.toMatchObject({ code: "AGENT_LOOP_RUN_NOT_FOUND" });
   });
 
-  it("reads and updates expert mode", async () => {
+  it("reads expert mode without mutating TypeScript policy state", async () => {
     const service = makeService();
     const routes = createFridayAgentLoopRoutes({ service });
     const getRoute = routes.find((entry) => entry.operationId === "agent.loop.expertmode.get")!;
-    const putRoute = routes.find((entry) => entry.operationId === "agent.loop.expertmode.update")!;
 
     const getResult = await getRoute.handler(makeCtx()) as { expertMode: { enabled: boolean } };
     expect(getResult.expertMode.enabled).toBe(true);
+    expect(service.updateExpertMode).not.toHaveBeenCalled();
+  });
 
-    const putResult = await putRoute.handler(makeCtx({
+  it("fail-closes default agent-loop policy mutations before calling TypeScript services", async () => {
+    const service = makeService();
+    const routes = createFridayAgentLoopRoutes({ service });
+    const updateRoutes = [
+      ["agent.loop.expertmode.update", service.updateExpertMode, { enabled: true, probeBudget: 6 }],
+      ["agent.loop.policy.update", service.updatePolicy, { paused: true }],
+    ] as const;
+
+    for (const [operationId, serviceCall, body] of updateRoutes) {
+      const route = routes.find((entry) => entry.operationId === operationId)!;
+      await expect(
+        route.handler(makeCtx({ body })),
+      ).rejects.toMatchObject({
+        code: "TS_RUNTIME_AGENT_LOOP_POLICY_MUTATIONS_RETIRED",
+        httpStatus: 503,
+      });
+      expect(serviceCall).not.toHaveBeenCalled();
+    }
+  });
+
+  it("allows legacy agent-loop policy mutations only through explicit test-only oracle wiring", async () => {
+    const service = makeService();
+    const routes = createFridayAgentLoopRoutes({
+      service,
+      allowTestOnlyAgentLoopPolicyMutation: true,
+    });
+    const expertModeRoute = routes.find((entry) => entry.operationId === "agent.loop.expertmode.update")!;
+    const policyRoute = routes.find((entry) => entry.operationId === "agent.loop.policy.update")!;
+
+    const expertModeResult = await expertModeRoute.handler(makeCtx({
       body: {
         enabled: true,
         probeBudget: 6,
@@ -288,7 +318,14 @@ describe("FridayAgentLoopRoutes", () => {
         probeBudget: 6,
       }),
     );
-    expect(putResult.expertMode.probeBudget).toBe(4);
+    expect(expertModeResult.expertMode.probeBudget).toBe(4);
+
+    const policyResult = await policyRoute.handler(makeCtx({
+      body: { paused: true },
+    })) as { policy: { paused: boolean } };
+
+    expect(service.updatePolicy).toHaveBeenCalledWith({ paused: true });
+    expect(policyResult.policy.paused).toBe(true);
   });
 
   it("rejects synthetic public principals from expert mode routes", async () => {


### PR DESCRIPTION
## Summary

Retire default/live TypeScript-owned agent-loop policy mutation routes by fail-closing these surfaces until Rust-owned agent-loop policy entrypoints exist:

- `PUT /v1/agent-loop/expert-mode`
- `PUT /v1/agent-loop/policy`

The routes still validate a user-scoped principal, then return `TS_RUNTIME_AGENT_LOOP_POLICY_MUTATIONS_RETIRED` before calling the TypeScript agent-loop service. Legacy TypeScript mutation behavior remains reachable only through explicit test-oracle wiring via `allowTestOnlyAgentLoopPolicyMutation`.

This leaves the agent-loop read routes classified as blockers; they were not reclassified because they still read directly from the TypeScript agent-loop service and do not yet have a proven bounded/redacted Rust projection.

## Safety

- No default machine DB mutation.
- No pet/design-gallery edits.
- No fake/mock/synthetic proof or closure claim.
- No provider-native synced claim.

## Verification

- `npx vitest run test/unit/api/http/routes/friday-agent-loop-routes.test.ts`
- `npm run check:ts-runtime-retirement` -> 584 routes, 248 `ts_runtime_blocker`, 19 `fail_closed`
- `npm run build`
- `npx vitest run test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts test/unit/hub/friday-hub-bootstrap.test.ts test/unit/operator-client/friday-operator-client.test.ts`
- `npm run check:secret-patterns`
- `detect-secrets-hook --baseline .secrets.baseline $(git ls-files)`
- `git diff --check`