### PR TITLE
Fail-close agent run approval controls

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -354,6 +354,58 @@
       "next_action": "Replace fail-closed response with a Rust-owned automation execution/control entrypoint when available."
     },
     {
+      "id": "agent_runs_approve_plan",
+      "route": {
+        "method": "POST",
+        "path": "/v1/agent/runs/:runId/approve-plan",
+        "operationId": "agent.runs.approve.plan"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/runtime/friday-api-runtime.ts wires default/live agent.runs.approve.plan to TS_RUNTIME_AGENT_RUN_CONTROLS_RETIRED after route visibility/principal checks and before calling the TypeScript planning gate or mirroring session state; the legacy TS approval path is reachable only through explicit allowTestOnlyAgentRunControlExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned agent plan approval/control entrypoint when available."
+    },
+    {
+      "id": "agent_runs_reject_plan",
+      "route": {
+        "method": "POST",
+        "path": "/v1/agent/runs/:runId/reject-plan",
+        "operationId": "agent.runs.reject.plan"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/runtime/friday-api-runtime.ts wires default/live agent.runs.reject.plan to TS_RUNTIME_AGENT_RUN_CONTROLS_RETIRED after route visibility/principal checks and before calling the TypeScript planning gate or mirroring session state; the legacy TS rejection path is reachable only through explicit allowTestOnlyAgentRunControlExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned agent plan rejection/control entrypoint when available."
+    },
+    {
+      "id": "agent_runs_approve_tool",
+      "route": {
+        "method": "POST",
+        "path": "/v1/agent/runs/:runId/approve-tool",
+        "operationId": "agent.runs.approve.tool"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/runtime/friday-api-runtime.ts wires default/live agent.runs.approve.tool to TS_RUNTIME_AGENT_RUN_CONTROLS_RETIRED after route visibility/principal/body checks and before resolving the TypeScript tool approval gate; the legacy TS tool approval path is reachable only through explicit allowTestOnlyAgentRunControlExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned agent tool approval/control entrypoint when available."
+    },
+    {
+      "id": "agent_runs_reject_tool",
+      "route": {
+        "method": "POST",
+        "path": "/v1/agent/runs/:runId/reject-tool",
+        "operationId": "agent.runs.reject.tool"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/runtime/friday-api-runtime.ts wires default/live agent.runs.reject.tool to TS_RUNTIME_AGENT_RUN_CONTROLS_RETIRED after route visibility/principal/body checks and before resolving the TypeScript tool approval gate; the legacy TS tool rejection path is reachable only through explicit allowTestOnlyAgentRunControlExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned agent tool rejection/control entrypoint when available."
+    },
+    {
       "id": "agent_loop_expertmode_update",
       "route": {
         "method": "PUT",

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -3436,6 +3436,10 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
         }
       },
       approvePlan: async (input) => {
+        if (deps.allowTestOnlyAgentRunControlExecution !== true) {
+          void input;
+          throwRetiredAgentRunControl();
+        }
         if (!agentPlanningGate) {
           throw new FridayDomainError("AGENT_PLAN_NOT_AVAILABLE", "Planning gate is not available", { httpStatus: 501 });
         }
@@ -3472,6 +3476,10 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
         return result;
       },
       rejectPlan: async (input) => {
+        if (deps.allowTestOnlyAgentRunControlExecution !== true) {
+          void input;
+          throwRetiredAgentRunControl();
+        }
         if (!agentPlanningGate) {
           throw new FridayDomainError("AGENT_PLAN_NOT_AVAILABLE", "Planning gate is not available", { httpStatus: 501 });
         }
@@ -3497,10 +3505,18 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
         }
         return result;
       },
-      resolveToolApproval: deps.resolveToolApproval
-        ? (runId, toolCallId, approved, options) =>
-          deps.resolveToolApproval!(runId, toolCallId, approved, options)
-        : (/* _runId, _toolCallId, _approved, _reason */) => ({ resolved: false }),
+      resolveToolApproval: (runId, toolCallId, approved, options) => {
+        if (deps.allowTestOnlyAgentRunControlExecution !== true) {
+          void runId;
+          void toolCallId;
+          void approved;
+          void options;
+          throwRetiredAgentRunControl();
+        }
+        return deps.resolveToolApproval
+          ? deps.resolveToolApproval(runId, toolCallId, approved, options)
+          : { resolved: false };
+      },
       rollbackRun: (runId) => {
         if (deps.allowTestOnlyAgentRunControlExecution !== true) {
           void runId;

--- a/src/api/runtime/friday-api-runtime.types.ts
+++ b/src/api/runtime/friday-api-runtime.types.ts
@@ -220,8 +220,8 @@ export interface CreateFridayApiRuntimeDeps {
   /**
    * Test-oracle only: allows legacy TypeScript agent run controls in isolated
    * mock/unit validation. Production/runtime callers must leave this unset so
-   * agent cancel, rollback, and automation-run controls stay fail-closed until
-   * Rust owns execution/control truth.
+   * agent cancel, rollback, automation-run, plan approval, and tool approval
+   * controls stay fail-closed until Rust owns execution/control truth.
    */
   allowTestOnlyAgentRunControlExecution?: boolean;
   /** Optional: Reflex service for deterministic preference writes before agent runs. */

--- a/test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts
@@ -474,6 +474,123 @@ describe("API Runtime — Extended Route Registration", () => {
     expect(executeRun).not.toHaveBeenCalled();
   });
 
+  for (const scenario of [
+    {
+      name: "approve plan",
+      operationId: "agent.runs.approve.plan",
+      runId: "run-control-retired-approve-plan",
+      body: {},
+    },
+    {
+      name: "reject plan",
+      operationId: "agent.runs.reject.plan",
+      runId: "run-control-retired-reject-plan",
+      body: {},
+    },
+  ]) {
+    it(`fail-closes live agent run ${scenario.name} wiring before TypeScript planning control`, async () => {
+      const deps = makeBaseDeps();
+      seedAgentRun(deps.db, { id: scenario.runId, status: "awaiting_plan_approval" });
+      const executeRun = vi.fn<FridayAgentRuntime["executeRun"]>();
+      const runtime = createFridayApiRuntime({
+        ...deps,
+        agentRuntime: {
+          executeRun,
+          rollbackRun: vi.fn(),
+          registerTool: vi.fn(),
+          resumeStaleRunsOnBoot: vi.fn(() => 0),
+          hasRollbackCheckpoint: vi.fn(() => false),
+        } as unknown as FridayAgentRuntime,
+        agentEventEmitter: {
+          on: vi.fn(),
+          off: vi.fn(),
+          emit: vi.fn(),
+        } satisfies FridayAgentEventEmitter,
+      });
+      const route = runtime.routes.getRoutes().find((r) => r.operationId === scenario.operationId);
+      expect(route).toBeDefined();
+
+      let thrown: unknown = null;
+      try {
+        await route!.handler({
+          requestId: `req-${scenario.runId}`,
+          receivedAt: NOW,
+          params: { runId: scenario.runId },
+          query: {},
+          body: scenario.body,
+          headers: {},
+          principal: makePrincipal({ role: "admin", scopes: ["agent.run"] }),
+        });
+      } catch (err) {
+        thrown = err;
+      }
+
+      expect(thrown).toBeInstanceOf(FridayDomainError);
+      expect((thrown as FridayDomainError).code).toBe("TS_RUNTIME_AGENT_RUN_CONTROLS_RETIRED");
+      expect((thrown as FridayDomainError).httpStatus).toBe(503);
+      expect(executeRun).not.toHaveBeenCalled();
+    });
+  }
+
+  for (const scenario of [
+    {
+      name: "approve tool",
+      operationId: "agent.runs.approve.tool",
+      runId: "run-control-retired-approve-tool",
+      body: { toolCallId: "tool-call-1" },
+    },
+    {
+      name: "reject tool",
+      operationId: "agent.runs.reject.tool",
+      runId: "run-control-retired-reject-tool",
+      body: { toolCallId: "tool-call-1", reason: "not approved" },
+    },
+  ]) {
+    it(`fail-closes live agent run ${scenario.name} wiring before TypeScript tool approval resolution`, async () => {
+      const deps = makeBaseDeps();
+      seedAgentRun(deps.db, { id: scenario.runId, status: "awaiting_tool_approval" });
+      const resolveToolApproval = vi.fn(() => ({ resolved: true }));
+      const runtime = createFridayApiRuntime({
+        ...deps,
+        agentRuntime: {
+          executeRun: vi.fn(),
+          rollbackRun: vi.fn(),
+          registerTool: vi.fn(),
+          resumeStaleRunsOnBoot: vi.fn(() => 0),
+          hasRollbackCheckpoint: vi.fn(() => false),
+        } as unknown as FridayAgentRuntime,
+        agentEventEmitter: {
+          on: vi.fn(),
+          off: vi.fn(),
+          emit: vi.fn(),
+        } satisfies FridayAgentEventEmitter,
+        resolveToolApproval,
+      });
+      const route = runtime.routes.getRoutes().find((r) => r.operationId === scenario.operationId);
+      expect(route).toBeDefined();
+
+      let thrown: unknown = null;
+      try {
+        await route!.handler({
+          requestId: `req-${scenario.runId}`,
+          receivedAt: NOW,
+          params: { runId: scenario.runId },
+          query: {},
+          body: scenario.body,
+          headers: {},
+          principal: makePrincipal({ role: "admin", scopes: ["agent.run"] }),
+        });
+      } catch (err) {
+        thrown = err;
+      }
+
+      expect(thrown).toBeInstanceOf(FridayDomainError);
+      expect((thrown as FridayDomainError).code).toBe("TS_RUNTIME_AGENT_RUN_CONTROLS_RETIRED");
+      expect((thrown as FridayDomainError).httpStatus).toBe(503);
+      expect(resolveToolApproval).not.toHaveBeenCalled();
+    });
+  }
+
   it("fail-closes live workflow run start wiring without executing the TypeScript workflow runtime", async () => {
     const { workflowRuntime, execution } = makeWorkflowRuntimeSpies();
     const runtime = createFridayApiRuntime({

--- a/test/unit/api/runtime/friday-api-runtime-planning-gate.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-planning-gate.test.ts
@@ -315,6 +315,7 @@ describe("FridayApiRuntime — planning gate session loop", () => {
       resolveSkill: () => null,
       invokeSkill: async () => ({}),
       allowTestOnlyAgentRunStartExecution: true,
+      allowTestOnlyAgentRunControlExecution: true,
     });
     sessionServiceRef = runtime.sessionService;
 


### PR DESCRIPTION
## Summary
- fail-close default/live agent plan approval and rejection controls before TypeScript planning gate/session side effects
- fail-close default/live agent tool approval and rejection controls before TypeScript tool approval resolution
- classify the four approval/rejection routes as `fail_closed` in the TS runtime retirement manifest

## Verification
- `npx vitest run test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts`
- `npm run check:ts-runtime-retirement`
- `npx vitest run test/unit/api/http/routes/friday-agent-routes.test.ts test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts test/unit/hub/friday-hub-bootstrap.test.ts test/unit/operator-client/friday-operator-client.test.ts`
- `npm run build`
- `npm run check:secret-patterns`
- `detect-secrets-hook --baseline .secrets.baseline $(git ls-files)`
- `git diff --check`

Default machine DB mutation: none. Pet/design-gallery files touched: no.