### PR TITLE
Retire auto-fix approval controls

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -575,6 +575,68 @@
       "next_action": "Replace fail-closed response with a Rust-owned auto-fix rollback entrypoint when available."
     },
     {
+      "id": "autofix_actions_list_compat",
+      "route": {
+        "method": "GET",
+        "path": "/v1/auto-fix/actions",
+        "operationId": "autofix.actions.list"
+      },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Keep the user-scoped auto-fix action list as a bounded review/read surface while auto-fix execution and approval controls are fail-closed or moved to Rust-owned product truth. This read does not execute, approve, deny, roll back, or mark repair completion.",
+      "next_action": "Replace this compatibility read with a Rust-owned redacted auto-fix projection when available."
+    },
+    {
+      "id": "autofix_actions_get_compat",
+      "route": {
+        "method": "GET",
+        "path": "/v1/auto-fix/actions/:actionId",
+        "operationId": "autofix.actions.get"
+      },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Keep the user-scoped auto-fix action detail as a bounded review/read surface while auto-fix execution and approval controls are fail-closed or moved to Rust-owned product truth. This read does not execute, approve, deny, roll back, or mark repair completion.",
+      "next_action": "Replace this compatibility read with a Rust-owned redacted auto-fix action projection when available."
+    },
+    {
+      "id": "autofix_actions_approve",
+      "route": {
+        "method": "POST",
+        "path": "/v1/auto-fix/actions/:actionId/approve",
+        "operationId": "autofix.actions.approve"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-auto-fix-routes.ts wires default/live autofix.actions.approve to TS_RUNTIME_AUTOFIX_CONTROLS_RETIRED after the bound-principal gate and before calling the TypeScript approveAction service; legacy TS approval is reachable only through explicit allowTestOnlyAutoFixExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned auto-fix approval/control entrypoint when available."
+    },
+    {
+      "id": "autofix_actions_deny",
+      "route": {
+        "method": "POST",
+        "path": "/v1/auto-fix/actions/:actionId/deny",
+        "operationId": "autofix.actions.deny"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-auto-fix-routes.ts wires default/live autofix.actions.deny to TS_RUNTIME_AUTOFIX_CONTROLS_RETIRED after the bound-principal gate and before calling the TypeScript denyAction service; legacy TS denial is reachable only through explicit allowTestOnlyAutoFixExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned auto-fix denial/control entrypoint when available."
+    },
+    {
+      "id": "autofix_metrics_get_compat",
+      "route": {
+        "method": "GET",
+        "path": "/v1/auto-fix/metrics",
+        "operationId": "autofix.metrics.get"
+      },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Keep auto-fix metrics as a bounded compatibility read while execution and approval controls are fail-closed or moved to Rust-owned product truth. Metrics reads do not execute, approve, deny, roll back, or mark repair completion.",
+      "next_action": "Replace this compatibility read with a Rust-owned redacted auto-fix metrics projection when available."
+    },
+    {
       "id": "desktop_actions_execute",
       "route": {
         "method": "POST",

--- a/src/api/http/routes/friday-auto-fix-routes.ts
+++ b/src/api/http/routes/friday-auto-fix-routes.ts
@@ -57,6 +57,20 @@ function throwRetiredAutoFixExecution(): never {
   );
 }
 
+function throwRetiredAutoFixApprovalControl(): never {
+  throw new FridayDomainError(
+    "TS_RUNTIME_AUTOFIX_CONTROLS_RETIRED",
+    "Auto-fix approval controls are fail-closed while runtime ownership is being moved out of TypeScript.",
+    {
+      httpStatus: 503,
+      details: {
+        classification: "fail_closed",
+        replacement: "rust_owned_autofix_approval_entrypoint_required",
+      },
+    },
+  );
+}
+
 function readReason(body: unknown): string | undefined {
   if (!body || typeof body !== "object") {
     return undefined;
@@ -217,6 +231,9 @@ export function createFridayAutoFixRoutes(
         // Phase 14.5B module_28b: approval boundary must carry a bound owner
         // principal; the synthetic public principal cannot approve a repair.
         assertBoundPrincipalForOperation(ctx.principal ?? null, "autofix.actions.approve", "api");
+        if (deps.allowTestOnlyAutoFixExecution !== true) {
+          throwRetiredAutoFixApprovalControl();
+        }
         const respondedBy = requireUserId(ctx.principal);
         const { actionId } = ctx.params as { actionId: string };
         const updated = await deps.service.approveAction({
@@ -241,6 +258,9 @@ export function createFridayAutoFixRoutes(
         // Phase 14.5B module_28b: denial carries learning signals so it must
         // also be authored by a bound owner/session/channel principal.
         assertBoundPrincipalForOperation(ctx.principal ?? null, "autofix.actions.deny", "api");
+        if (deps.allowTestOnlyAutoFixExecution !== true) {
+          throwRetiredAutoFixApprovalControl();
+        }
         const respondedBy = requireUserId(ctx.principal);
         const { actionId } = ctx.params as { actionId: string };
         const updated = await deps.service.denyAction({

--- a/test/unit/api/http/routes/friday-auto-fix-routes.test.ts
+++ b/test/unit/api/http/routes/friday-auto-fix-routes.test.ts
@@ -266,11 +266,13 @@ describe("FridayAutoFixRoutes", () => {
     expect(result.items[0]?.summary.loopRunId).toBe("loop-run-1");
   });
 
-  it("fail-closes auto-fix execution routes by default without invoking TypeScript services", async () => {
+  it("fail-closes auto-fix execution and approval-control routes by default without invoking TypeScript services", async () => {
     const service = makeService();
     const routes = createFridayAutoFixRoutes({ service });
     const executionRoutes = [
       ["autofix.actions.run.ready", {}, { maxRiskTier: 1 }],
+      ["autofix.actions.approve", { actionId: "action-1" }, { reason: "Looks safe" }],
+      ["autofix.actions.deny", { actionId: "action-1" }, { reason: "Too risky" }],
       ["autofix.actions.execute", { actionId: "action-1" }, {}],
       ["autofix.actions.rollback", { actionId: "action-1" }, { reason: "test rollback" }],
     ] as const;
@@ -279,17 +281,30 @@ describe("FridayAutoFixRoutes", () => {
       const route = routes.find((entry) => entry.operationId === operationId)!;
       await expect(
         route.handler(makeCtx({ params, body })),
-      ).rejects.toMatchObject({
-        code: "TS_RUNTIME_AUTOFIX_EXECUTION_RETIRED",
-        httpStatus: 503,
-        details: {
-          classification: "fail_closed",
-          replacement: "rust_owned_autofix_execution_entrypoint_required",
-        },
-      });
+      ).rejects.toMatchObject(
+        operationId === "autofix.actions.approve" || operationId === "autofix.actions.deny"
+          ? {
+            code: "TS_RUNTIME_AUTOFIX_CONTROLS_RETIRED",
+            httpStatus: 503,
+            details: {
+              classification: "fail_closed",
+              replacement: "rust_owned_autofix_approval_entrypoint_required",
+            },
+          }
+          : {
+            code: "TS_RUNTIME_AUTOFIX_EXECUTION_RETIRED",
+            httpStatus: 503,
+            details: {
+              classification: "fail_closed",
+              replacement: "rust_owned_autofix_execution_entrypoint_required",
+            },
+          },
+      );
     }
 
     expect(service.runReadyActions).not.toHaveBeenCalled();
+    expect(service.approveAction).not.toHaveBeenCalled();
+    expect(service.denyAction).not.toHaveBeenCalled();
     expect(service.executeAction).not.toHaveBeenCalled();
     expect(service.rollbackAction).not.toHaveBeenCalled();
   });
@@ -335,7 +350,7 @@ describe("FridayAutoFixRoutes", () => {
 
   it("approves an action with the authenticated user", async () => {
     const service = makeService();
-    const routes = createFridayAutoFixRoutes({ service });
+    const routes = createFridayAutoFixRoutes({ service, allowTestOnlyAutoFixExecution: true });
     const route = routes.find((entry) => entry.operationId === "autofix.actions.approve")!;
 
     await route.handler(
@@ -367,7 +382,7 @@ describe("FridayAutoFixRoutes", () => {
 
   it("passes a structured denial reason code when provided", async () => {
     const service = makeService();
-    const routes = createFridayAutoFixRoutes({ service });
+    const routes = createFridayAutoFixRoutes({ service, allowTestOnlyAutoFixExecution: true });
     const route = routes.find((entry) => entry.operationId === "autofix.actions.deny")!;
 
     await route.handler(


### PR DESCRIPTION
## Summary
- fail-close default/live auto-fix approve and deny controls before TypeScript self-healing service calls
- keep legacy approve/deny behavior reachable only through explicit `allowTestOnlyAutoFixExecution` test-oracle wiring
- classify auto-fix list/get/metrics as bounded compatibility reads and approve/deny as `fail_closed`

## Verification
- `npx vitest run test/unit/api/http/routes/friday-auto-fix-routes.test.ts`
- `npm run check:ts-runtime-retirement`
- `git diff --check`
- `npx vitest run test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts test/e2e/api/friday-api-self-healing-routes.test.ts test/e2e/api/friday-api-auto-fix-doctor.acceptance.test.ts`
- `npm run build`
- `npm run check:secret-patterns`
- `detect-secrets-hook --baseline .secrets.baseline $(git ls-files)`

Default machine DB mutation: none. Pet/design-gallery files touched: no.