### PR TITLE
Retire agent automation CRUD controls

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -354,6 +354,69 @@
       "next_action": "Replace fail-closed response with a Rust-owned automation execution/control entrypoint when available."
     },
     {
+      "id": "agent_automations_create",
+      "route": {
+        "method": "POST",
+        "path": "/v1/agent/automations",
+        "operationId": "agent.automations.create"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/runtime/friday-api-runtime.ts wires default/live agent.automations.create to TS_RUNTIME_AGENT_RUN_CONTROLS_RETIRED before invoking the TypeScript automation save service; the legacy TS automation-create path is reachable only through explicit allowTestOnlyAgentRunControlExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned automation asset create entrypoint when available."
+    },
+    {
+      "id": "agent_automations_update",
+      "route": {
+        "method": "PATCH",
+        "path": "/v1/agent/automations/:automationId",
+        "operationId": "agent.automations.update"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/runtime/friday-api-runtime.ts wires default/live agent.automations.update to TS_RUNTIME_AGENT_RUN_CONTROLS_RETIRED before invoking the TypeScript automation update service; the legacy TS automation-update path is reachable only through explicit allowTestOnlyAgentRunControlExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned automation asset update entrypoint when available."
+    },
+    {
+      "id": "agent_automations_delete",
+      "route": {
+        "method": "DELETE",
+        "path": "/v1/agent/automations/:automationId",
+        "operationId": "agent.automations.delete"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/runtime/friday-api-runtime.ts wires default/live agent.automations.delete to TS_RUNTIME_AGENT_RUN_CONTROLS_RETIRED before invoking the TypeScript automation remove service; the legacy TS automation-delete path is reachable only through explicit allowTestOnlyAgentRunControlExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned automation asset delete entrypoint when available."
+    },
+    {
+      "id": "agent_automations_list_compat",
+      "route": {
+        "method": "GET",
+        "path": "/v1/agent/automations",
+        "operationId": "agent.automations.list"
+      },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Keep agent automation list as a bounded compatibility read while automation asset mutation and execution are fail-closed or moved to Rust-owned product truth. This read does not create, update, delete, run, or mark automation completion.",
+      "next_action": "Replace this compatibility read with a Rust-owned redacted automation projection when available."
+    },
+    {
+      "id": "agent_automations_get_compat",
+      "route": {
+        "method": "GET",
+        "path": "/v1/agent/automations/:automationId",
+        "operationId": "agent.automations.get"
+      },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Keep agent automation detail as a bounded compatibility read while automation asset mutation and execution are fail-closed or moved to Rust-owned product truth. This read does not create, update, delete, run, or mark automation completion.",
+      "next_action": "Replace this compatibility read with a Rust-owned redacted automation detail projection when available."
+    },
+    {
       "id": "agent_runs_approve_plan",
       "route": {
         "method": "POST",

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -3398,6 +3398,9 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
         ? agentAutomationService
         : {
           ...agentAutomationService,
+          save: () => throwRetiredAgentRunControl(),
+          update: () => throwRetiredAgentRunControl(),
+          remove: () => throwRetiredAgentRunControl(),
           run: async () => throwRetiredAgentRunControl(),
         };
 

--- a/test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts
@@ -476,6 +476,69 @@ describe("API Runtime — Extended Route Registration", () => {
 
   for (const scenario of [
     {
+      name: "create",
+      operationId: "agent.automations.create",
+      params: {},
+      body: {
+        name: "Daily digest",
+        taskTemplate: "send digest",
+      },
+    },
+    {
+      name: "update",
+      operationId: "agent.automations.update",
+      params: { automationId: "automation-does-not-matter" },
+      body: { name: "Updated digest" },
+    },
+    {
+      name: "delete",
+      operationId: "agent.automations.delete",
+      params: { automationId: "automation-does-not-matter" },
+      body: {},
+    },
+  ]) {
+    it(`fail-closes live agent automation ${scenario.name} wiring before TypeScript automation asset mutation`, async () => {
+      const runtime = createFridayApiRuntime({
+        ...makeBaseDeps(),
+        agentRuntime: {
+          executeRun: vi.fn(),
+          rollbackRun: vi.fn(),
+          registerTool: vi.fn(),
+          resumeStaleRunsOnBoot: vi.fn(() => 0),
+          hasRollbackCheckpoint: vi.fn(() => false),
+        } as unknown as FridayAgentRuntime,
+        agentEventEmitter: {
+          on: vi.fn(),
+          off: vi.fn(),
+          emit: vi.fn(),
+        } satisfies FridayAgentEventEmitter,
+      });
+      const route = runtime.routes.getRoutes().find((r) => r.operationId === scenario.operationId);
+      expect(route).toBeDefined();
+
+      let thrown: unknown = null;
+      try {
+        await route!.handler({
+          requestId: `req-agent-automation-${scenario.name}-retired`,
+          receivedAt: NOW,
+          params: scenario.params,
+          query: {},
+          body: scenario.body,
+          headers: {},
+          principal: makePrincipal({ role: "admin", scopes: ["agent.write"] }),
+        });
+      } catch (err) {
+        thrown = err;
+      }
+
+      expect(thrown).toBeInstanceOf(FridayDomainError);
+      expect((thrown as FridayDomainError).code).toBe("TS_RUNTIME_AGENT_RUN_CONTROLS_RETIRED");
+      expect((thrown as FridayDomainError).httpStatus).toBe(503);
+    });
+  }
+
+  for (const scenario of [
+    {
       name: "approve plan",
       operationId: "agent.runs.approve.plan",
       runId: "run-control-retired-approve-plan",


### PR DESCRIPTION
## Summary
- Fail-close default/live agent automation create/update/delete before they can invoke TypeScript automation asset mutation services.
- Keep legacy automation CRUD reachable only through explicit `allowTestOnlyAgentRunControlExecution` test-oracle wiring.
- Classify automation list/get as bounded compatibility reads while automation mutation/execution remains fail-closed or pending Rust ownership.

## Verification
- `npx vitest run test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts test/unit/api/http/routes/friday-agent-routes.test.ts`
- `npm run check:ts-runtime-retirement`
- `git diff --check`
- `npm run build`
- `npm run check:secret-patterns`
- `detect-secrets-hook --baseline .secrets.baseline $(git ls-files)`

## Safety
- Default machine DB mutation: none.
- Pet/design-gallery files touched: no.
- No fake projection, mock closure, provider-native synced claim, or strict closure claim.