### PR TITLE
Classify agent loop reads as compat

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -469,6 +469,18 @@
       "next_action": "Replace fail-closed response with a Rust-owned agent tool rejection/control entrypoint when available."
     },
     {
+      "id": "agent_loop_expertmode_get_compat",
+      "route": {
+        "method": "GET",
+        "path": "/v1/agent-loop/expert-mode",
+        "operationId": "agent.loop.expertmode.get"
+      },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Keep agent-loop expert-mode status as a bounded compatibility read while policy mutation is fail-closed or moved to Rust-owned product truth. This read does not update policy, run controls, or mark loop completion.",
+      "next_action": "Replace this compatibility read with a Rust-owned redacted agent-loop expert-mode projection when available."
+    },
+    {
       "id": "agent_loop_expertmode_update",
       "route": {
         "method": "PUT",
@@ -482,6 +494,18 @@
       "next_action": "Replace fail-closed response with a Rust-owned agent-loop expert-mode policy entrypoint when available."
     },
     {
+      "id": "agent_loop_policy_get_compat",
+      "route": {
+        "method": "GET",
+        "path": "/v1/agent-loop/policy",
+        "operationId": "agent.loop.policy.get"
+      },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Keep agent-loop policy as a bounded compatibility read while policy mutation is fail-closed or moved to Rust-owned product truth. This read does not update policy, run controls, or mark loop completion.",
+      "next_action": "Replace this compatibility read with a Rust-owned redacted agent-loop policy projection when available."
+    },
+    {
       "id": "agent_loop_policy_update",
       "route": {
         "method": "PUT",
@@ -493,6 +517,54 @@
       "executes_product_logic": false,
       "proof": "src/api/http/routes/friday-agent-loop-routes.ts wires default/live agent.loop.policy.update to TS_RUNTIME_AGENT_LOOP_POLICY_MUTATIONS_RETIRED after user-principal validation and before mutating TypeScript agent-loop policy; legacy TS mutation is reachable only through explicit allowTestOnlyAgentLoopPolicyMutation test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned agent-loop policy entrypoint when available."
+    },
+    {
+      "id": "agent_loop_runs_list_compat",
+      "route": {
+        "method": "GET",
+        "path": "/v1/agent-loop/runs",
+        "operationId": "agent.loop.runs.list"
+      },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Keep agent-loop run list as a bounded compatibility read while run controls are fail-closed or moved to Rust-owned product truth. This read does not pause, resume, cancel, execute, or mark loop completion.",
+      "next_action": "Replace this compatibility read with a Rust-owned redacted agent-loop run-list projection when available."
+    },
+    {
+      "id": "agent_loop_runs_get_compat",
+      "route": {
+        "method": "GET",
+        "path": "/v1/agent-loop/runs/:loopRunId",
+        "operationId": "agent.loop.runs.get"
+      },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Keep agent-loop run detail as a bounded compatibility read while run controls are fail-closed or moved to Rust-owned product truth. This read does not pause, resume, cancel, execute, or mark loop completion.",
+      "next_action": "Replace this compatibility read with a Rust-owned redacted agent-loop run-detail projection when available."
+    },
+    {
+      "id": "agent_loop_expertruns_list_compat",
+      "route": {
+        "method": "GET",
+        "path": "/v1/agent-loop/expert-runs",
+        "operationId": "agent.loop.expertruns.list"
+      },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Keep expert agent-loop run list as a bounded compatibility read while run controls are fail-closed or moved to Rust-owned product truth. This read does not pause, resume, cancel, execute, or mark loop completion.",
+      "next_action": "Replace this compatibility read with a Rust-owned redacted expert agent-loop run-list projection when available."
+    },
+    {
+      "id": "agent_loop_expertruns_get_compat",
+      "route": {
+        "method": "GET",
+        "path": "/v1/agent-loop/expert-runs/:loopRunId",
+        "operationId": "agent.loop.expertruns.get"
+      },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Keep expert agent-loop run detail as a bounded compatibility read while run controls are fail-closed or moved to Rust-owned product truth. This read does not pause, resume, cancel, execute, or mark loop completion.",
+      "next_action": "Replace this compatibility read with a Rust-owned redacted expert agent-loop run-detail projection when available."
     },
     {
       "id": "agent_loop_runs_pause",

--- a/test/unit/api/http/routes/friday-agent-loop-routes.test.ts
+++ b/test/unit/api/http/routes/friday-agent-loop-routes.test.ts
@@ -276,6 +276,57 @@ describe("FridayAgentLoopRoutes", () => {
     expect(service.updateExpertMode).not.toHaveBeenCalled();
   });
 
+  it("keeps agent-loop compatibility reads bounded and free of mutation/control calls", async () => {
+    const service = makeService();
+    const routes = createFridayAgentLoopRoutes({ service });
+    const scenarios = [
+      {
+        operationId: "agent.loop.expertmode.get",
+        ctx: makeCtx(),
+        expectedRead: service.getExpertMode,
+      },
+      {
+        operationId: "agent.loop.policy.get",
+        ctx: makeCtx(),
+        expectedRead: service.getPolicy,
+      },
+      {
+        operationId: "agent.loop.runs.list",
+        ctx: makeCtx({ query: { limit: "2" } }),
+        expectedRead: service.listRuns,
+      },
+      {
+        operationId: "agent.loop.expertruns.list",
+        ctx: makeCtx({ query: { limit: "2" } }),
+        expectedRead: service.listExpertRuns,
+      },
+      {
+        operationId: "agent.loop.runs.get",
+        ctx: makeCtx({ params: { loopRunId: "loop-run-1" } }),
+        expectedRead: service.getRun,
+      },
+      {
+        operationId: "agent.loop.expertruns.get",
+        ctx: makeCtx({ params: { loopRunId: "loop-run-1" } }),
+        expectedRead: service.getExpertRun,
+      },
+    ] as const;
+
+    for (const scenario of scenarios) {
+      const route = routes.find((entry) => entry.operationId === scenario.operationId)!;
+      await route.handler(scenario.ctx);
+      expect(scenario.expectedRead).toHaveBeenCalled();
+    }
+
+    expect(service.updatePolicy).not.toHaveBeenCalled();
+    expect(service.updateExpertMode).not.toHaveBeenCalled();
+    expect(service.pauseRun).not.toHaveBeenCalled();
+    expect(service.resumeRun).not.toHaveBeenCalled();
+    expect(service.cancelRun).not.toHaveBeenCalled();
+    expect(service.handleProcessResults).not.toHaveBeenCalled();
+    expect(service.syncAction).not.toHaveBeenCalled();
+  });
+
   it("fail-closes default agent-loop policy mutations before calling TypeScript services", async () => {
     const service = makeService();
     const routes = createFridayAgentLoopRoutes({ service });


### PR DESCRIPTION
## Summary
- Classify the six agent-loop GET surfaces as bounded compatibility reads.
- Keep agent-loop policy mutations and run controls fail-closed under their existing retirement errors.
- Add route tests proving the read surfaces call only read services and do not invoke policy mutation, run controls, process handling, or sync actions.

## Retirement Gate
- Before slice: 584 routes, 234 `ts_runtime_blocker`, 28 `fail_closed`, 213 `compat_shim`.
- After slice locally: 584 routes, 228 `ts_runtime_blocker`, 28 `fail_closed`, 219 `compat_shim`.
- `agent_loop_runtime_blockers` leaves the remaining blocker family list.

## Verification
- `npx vitest run test/unit/api/http/routes/friday-agent-loop-routes.test.ts`
- `npm run check:ts-runtime-retirement`
- `git diff --check`
- `npm run build`
- `npm run check:secret-patterns`
- `detect-secrets-hook --baseline .secrets.baseline $(git ls-files)`

## Safety
- Default machine DB mutation: none.
- Pet/design-gallery files touched: no.
- No runtime behavior mutation beyond manifest classification/test proof.
- No fake projection, mock closure, provider-native synced claim, or strict closure claim.