### PR TITLE
Classify agent run reads as redacted compat

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -417,6 +417,66 @@
       "next_action": "Replace this compatibility read with a Rust-owned redacted automation detail projection when available."
     },
     {
+      "id": "agent_runs_list_compat",
+      "route": {
+        "method": "GET",
+        "path": "/v1/agent/runs",
+        "operationId": "agent.runs.list"
+      },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Keep agent run list as a bounded redacted compatibility projection while TypeScript agent execution and controls are fail-closed or moved to Rust-owned product truth. This read filters internal/subagent runs, caps list size, redacts private paths/provider ids/raw commands, and does not execute tools or mark completion.",
+      "next_action": "Replace this compatibility read with a Rust-owned redacted agent run projection when available."
+    },
+    {
+      "id": "agent_runs_summary_compat",
+      "route": {
+        "method": "GET",
+        "path": "/v1/agent/runs/summary",
+        "operationId": "agent.runs.summary"
+      },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Keep agent run summary as a bounded aggregate compatibility projection while TypeScript agent execution and controls are fail-closed or moved to Rust-owned product truth. This aggregate filters internal/subagent runs, caps sampled rows, and does not execute tools or mark completion.",
+      "next_action": "Replace this compatibility aggregate with a Rust-owned agent run summary projection when available."
+    },
+    {
+      "id": "agent_runs_get_compat",
+      "route": {
+        "method": "GET",
+        "path": "/v1/agent/runs/:runId",
+        "operationId": "agent.runs.get"
+      },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Keep agent run detail as a redacted compatibility projection while TypeScript agent execution and controls are fail-closed or moved to Rust-owned product truth. This read hides internal/subagent runs, redacts private paths/provider ids/raw commands, and does not execute tools or mark completion.",
+      "next_action": "Replace this compatibility detail with a Rust-owned redacted agent run projection when available."
+    },
+    {
+      "id": "agent_runs_audit_compat",
+      "route": {
+        "method": "GET",
+        "path": "/v1/agent/runs/:runId/audit",
+        "operationId": "agent.runs.audit"
+      },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Keep agent run audit as a redacted proof-ref compatibility projection while TypeScript agent execution and controls are fail-closed or moved to Rust-owned product truth. This read exposes sanitized event metadata, decision pointers, and path-redacted replay refs only; it does not execute tools or mark completion.",
+      "next_action": "Replace this compatibility audit projection with a Rust-owned redacted run audit projection when available."
+    },
+    {
+      "id": "agent_runs_events_compat",
+      "route": {
+        "method": "GET",
+        "path": "/v1/agent/runs/:runId/events",
+        "operationId": "agent.runs.events"
+      },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Keep agent run event stream as a redacted compatibility projection while TypeScript agent execution and controls are fail-closed or moved to Rust-owned product truth. This stream sanitizes replay/live payloads, redacts private paths/provider ids/raw commands, and does not execute tools or mark completion.",
+      "next_action": "Replace this compatibility event stream with a Rust-owned bounded event/timeline projection when available."
+    },
+    {
       "id": "agent_runs_approve_plan",
       "route": {
         "method": "POST",

--- a/src/api/http/routes/friday-agent-routes.ts
+++ b/src/api/http/routes/friday-agent-routes.ts
@@ -17,6 +17,7 @@ import type {
   FridayAgentEventMap,
   FridayAgentEventName,
   FridayAgentExecutionContext,
+  FridayAgentReplayableEvidenceReceipt,
   FridayAgentRunConstraints,
   FridayAgentRunRecord,
   FridayAgentRunStatus,
@@ -180,6 +181,99 @@ function sanitizeUserVisibleRun(run: FridayAgentRunRecord): FridayAgentRunRecord
   };
 }
 
+function sanitizePlanReviewForPublicRead(
+  planReview: FridayAgentRunRecord["planReview"],
+): FridayAgentRunRecord["planReview"] | undefined {
+  if (!planReview) {
+    return undefined;
+  }
+  return {
+    plan: {
+      task: planReview.plan.task,
+      stepCount: planReview.plan.stepCount,
+      description: planReview.plan.description,
+    },
+    ...(planReview.gate
+      ? {
+        gate: {
+          kind: planReview.gate.kind,
+          state: planReview.gate.state,
+          ...(Array.isArray(planReview.gate.clarificationQuestions)
+            ? { clarificationQuestions: planReview.gate.clarificationQuestions.map(() => "[redacted]") }
+            : {}),
+          ...(planReview.gate.planSummary ? { planSummary: "[redacted]" } : {}),
+          ...(planReview.gate.approvalUpdatedAt ? { approvalUpdatedAt: planReview.gate.approvalUpdatedAt } : {}),
+        },
+      }
+      : {}),
+    ...(planReview.decision
+      ? {
+        decision: {
+          approved: planReview.decision.approved,
+          mode: planReview.decision.mode,
+          reviewedAt: planReview.decision.reviewedAt,
+        },
+      }
+      : {}),
+  };
+}
+
+function sanitizePublicAgentRunRecord(run: FridayAgentRunRecord): FridayAgentRunRecord {
+  const sanitized = sanitizeUserVisibleRun(run);
+  return {
+    id: sanitized.id,
+    task: sanitized.task,
+    status: sanitized.status,
+    sessionKey: sanitized.sessionKey,
+    attempt: sanitized.attempt,
+    maxAttempts: sanitized.maxAttempts,
+    createdAt: sanitized.createdAt,
+    ...(sanitized.startedAt ? { startedAt: sanitized.startedAt } : {}),
+    ...(sanitized.completedAt ? { completedAt: sanitized.completedAt } : {}),
+    ...(typeof sanitized.durationMs === "number" ? { durationMs: sanitized.durationMs } : {}),
+    ...(typeof sanitized.usageInput === "number" ? { usageInput: sanitized.usageInput } : {}),
+    ...(typeof sanitized.usageOutput === "number" ? { usageOutput: sanitized.usageOutput } : {}),
+    ...(typeof sanitized.costUsd === "number" ? { costUsd: sanitized.costUsd } : {}),
+    ...(sanitized.errorCode ? { errorCode: sanitized.errorCode } : {}),
+    ...(sanitized.errorMessage ? { errorMessage: sanitized.errorMessage } : {}),
+    ...(sanitized.responseText ? { responseText: sanitized.responseText } : {}),
+    ...(sanitized.summary ? { summary: sanitized.summary } : {}),
+    ...(sanitized.planReview ? { planReview: sanitizePlanReviewForPublicRead(sanitized.planReview) } : {}),
+    ...(sanitized.constraints
+      ? {
+        constraints: {
+          ...(typeof sanitized.constraints.readOnly === "boolean" ? { readOnly: sanitized.constraints.readOnly } : {}),
+          ...(sanitized.constraints.operationalMode ? { operationalMode: sanitized.constraints.operationalMode } : {}),
+          ...(sanitized.constraints.dataSensitivity ? { dataSensitivity: sanitized.constraints.dataSensitivity } : {}),
+          ...(typeof sanitized.constraints.localOnly === "boolean" ? { localOnly: sanitized.constraints.localOnly } : {}),
+          ...(typeof sanitized.constraints.noEgress === "boolean" ? { noEgress: sanitized.constraints.noEgress } : {}),
+        },
+      }
+      : {}),
+    ...(sanitized.taskProfile
+      ? {
+        taskProfile: {
+          id: sanitized.taskProfile.id,
+          label: sanitized.taskProfile.label,
+          description: sanitized.taskProfile.description,
+          reasoningEffort: sanitized.taskProfile.reasoningEffort,
+          ...(typeof sanitized.taskProfile.temperature === "number" ? { temperature: sanitized.taskProfile.temperature } : {}),
+        },
+      }
+      : {}),
+    ...(sanitized.metadata?.surface
+      ? {
+        metadata: {
+          surface: sanitized.metadata.surface,
+        },
+      }
+      : {}),
+    ...(sanitized.health ? { health: sanitized.health } : {}),
+    ...(sanitized.contextSummary ? { contextSummary: sanitized.contextSummary } : {}),
+    ...(typeof sanitized.rollbackAvailable === "boolean" ? { rollbackAvailable: sanitized.rollbackAvailable } : {}),
+  };
+}
+
 // D1 fix: reconstruct tool-call outcomes from the durable event stream so the
 // API-rebuilt receipt counts real tool failures. Without this, toolCalls was never
 // passed to the receipt builder, so countToolCalls(undefined).failed was always 0 and
@@ -256,18 +350,39 @@ function buildReplayableEvidenceReceiptForRun(
   });
 }
 
+function sanitizeReplayReceiptForPublicRead(
+  receipt: FridayAgentReplayableEvidenceReceipt,
+): FridayAgentReplayableEvidenceReceipt {
+  return {
+    ...receipt,
+    replay: {
+      auditEndpoint: receipt.replay.auditEndpoint,
+      files: receipt.replay.files.map((file) => ({
+        label: file.label,
+        kind: file.kind,
+        ...(file.kind === "audit_endpoint" && file.href ? { href: file.href } : {}),
+      })),
+    },
+    limitations: [
+      "Replay file entries are proof refs; private filesystem paths are redacted from this public API surface.",
+      ...receipt.limitations.filter((limitation) => !/file paths|tool-calls\.json/i.test(limitation)),
+    ],
+  };
+}
+
 function buildVisibleRunWithUnifiedTaskState(
   run: FridayAgentRunRecord,
   events: FridayAgentRunEventRecord[],
   issuedAt: string,
 ): FridayAgentRunWithUnifiedTaskState {
   const replayReceipt = buildReplayableEvidenceReceiptForRun(run, events, issuedAt);
+  const publicReplayReceipt = sanitizeReplayReceiptForPublicRead(replayReceipt);
   return {
-    ...sanitizeUserVisibleRun(run),
+    ...sanitizePublicAgentRunRecord(run),
     unifiedTaskState: buildFridayAgentUnifiedTaskState({
       run,
       events,
-      replayReceipt,
+      replayReceipt: publicReplayReceipt,
     }),
   };
 }
@@ -595,6 +710,30 @@ function sanitizeAuditEventPayload(event: FridayAgentRunEventRecord): unknown {
   if (!payload) {
     return event.payload;
   }
+  if (event.eventName === "agent.run.started") {
+    const contextSelection = asRecord(payload.contextSelection);
+    const selectedBlocks = Array.isArray(contextSelection?.selectedBlocks)
+      ? contextSelection.selectedBlocks
+      : [];
+    return {
+      ...(readStringField(payload, "runId") ? { runId: readStringField(payload, "runId") } : {}),
+      hasTask: typeof payload.task === "string" && payload.task.length > 0,
+      hasModel: typeof payload.model === "string" && payload.model.length > 0,
+      providerRouted: typeof payload.providerId === "string" && payload.providerId.length > 0,
+      ...(asRecord(payload.taskProfile)?.id ? { taskProfileId: readStringField(asRecord(payload.taskProfile), "id") } : {}),
+      contextSelection: {
+        selectedBlockCount: selectedBlocks.length,
+        hasSelectionReasons: Array.isArray(contextSelection?.selectionReasons) && contextSelection.selectionReasons.length > 0,
+      },
+    };
+  }
+  if (event.eventName === "agent.run.planning") {
+    return {
+      ...(readStringField(payload, "runId") ? { runId: readStringField(payload, "runId") } : {}),
+      status: "planning",
+      hasMessage: typeof payload.message === "string" && payload.message.length > 0,
+    };
+  }
   if (event.eventName === "agent.run.plan_ready") {
     return {
       ...(readStringField(payload, "runId") ? { runId: readStringField(payload, "runId") } : {}),
@@ -655,6 +794,22 @@ function sanitizeAuditEventPayload(event: FridayAgentRunEventRecord): unknown {
       ...(guardrail ? { guardrail } : {}),
     };
   }
+  if (event.eventName === "agent.run.executing") {
+    return {
+      ...(readStringField(payload, "runId") ? { runId: readStringField(payload, "runId") } : {}),
+      status: "executing",
+      ...(typeof payload.step === "number" ? { step: payload.step } : {}),
+      ...(typeof payload.totalSteps === "number" ? { totalSteps: payload.totalSteps } : {}),
+      hasDescription: typeof payload.description === "string" && payload.description.length > 0,
+    };
+  }
+  if (event.eventName === "agent.run.text_delta") {
+    return {
+      ...(readStringField(payload, "runId") ? { runId: readStringField(payload, "runId") } : {}),
+      type: "agent.run.text_delta",
+      hasDelta: typeof payload.delta === "string" && payload.delta.length > 0,
+    };
+  }
   if (
     event.eventName === "agent.run.context_replay_loaded"
     || event.eventName === "agent.run.compaction_persisted"
@@ -676,7 +831,45 @@ function sanitizeAuditEventPayload(event: FridayAgentRunEventRecord): unknown {
       ...(typeof payload.redactionCount === "number" ? { redactionCount: payload.redactionCount } : {}),
     };
   }
-  return event.payload;
+  if (
+    event.eventName === "agent.run.completed"
+    || event.eventName === "agent.run.failed"
+    || event.eventName === "agent.run.failed_tests"
+    || event.eventName === "agent.run.cancelled"
+    || event.eventName === "agent.run.degraded"
+    || event.eventName === "agent.run.mode_changed"
+    || event.eventName === "agent.run.route_selected"
+    || event.eventName === "agent.run.route_fallback"
+    || event.eventName === "agent.run.route_mismatch"
+    || event.eventName.startsWith("autonomous.")
+    || event.eventName.startsWith("agent.subagent.")
+    || event.eventName.startsWith("agent.run.capability_grant_")
+    || event.eventName === "agent.run.plan_approved"
+    || event.eventName === "agent.run.plan_rejected"
+  ) {
+    return {
+      ...(readStringField(payload, "runId") ? { runId: readStringField(payload, "runId") } : {}),
+      ...(readStringField(payload, "parentRunId") ? { parentRunId: readStringField(payload, "parentRunId") } : {}),
+      ...(readStringField(payload, "goalId") ? { goalId: readStringField(payload, "goalId") } : {}),
+      ...(readStringField(payload, "toolCallId") ? { toolCallId: readStringField(payload, "toolCallId") } : {}),
+      ...(readStringField(payload, "toolName") ? { toolName: readStringField(payload, "toolName") } : {}),
+      ...(readStringField(payload, "grantId") ? { grantId: readStringField(payload, "grantId") } : {}),
+      ...(readStringField(payload, "routeId") ? { routeId: readStringField(payload, "routeId") } : {}),
+      ...(readStringField(payload, "correlationId") ? { correlationId: readStringField(payload, "correlationId") } : {}),
+      ...(typeof payload.durationMs === "number" ? { durationMs: payload.durationMs } : {}),
+      ...(typeof payload.toolCallCount === "number" ? { toolCallCount: payload.toolCallCount } : {}),
+      ...(typeof payload.isError === "boolean" ? { isError: payload.isError } : {}),
+      hasMessage: typeof payload.message === "string" && payload.message.length > 0,
+      hasSummary: typeof payload.summary === "string" && payload.summary.length > 0,
+      hasReason: typeof payload.reason === "string" && payload.reason.length > 0,
+      hasErrorMessage: typeof payload.errorMessage === "string" && payload.errorMessage.length > 0,
+    };
+  }
+  return {
+    ...(readStringField(payload, "runId") ? { runId: readStringField(payload, "runId") } : {}),
+    redacted: true,
+    payloadKeys: Object.keys(payload).sort(),
+  };
 }
 
 // ─── Deps ───
@@ -998,7 +1191,7 @@ export function createFridayAgentRoutes(
   ): string {
     return JSON.stringify({
       type: event.eventName,
-      ...event.payload,
+      payload: sanitizeAuditEventPayload(event),
       seq: event.seq,
       emittedAt: event.emittedAt,
       replayed,
@@ -1395,10 +1588,11 @@ export function createFridayAgentRoutes(
         );
         const decisionTrace = buildAgentRunDecisionTrace(run, auditEvents);
         const replayReceipt = buildReplayableEvidenceReceiptForRun(run, auditEvents, ctx.receivedAt, decisionTrace);
+        const publicReplayReceipt = sanitizeReplayReceiptForPublicRead(replayReceipt);
         const unifiedTaskState = buildFridayAgentUnifiedTaskState({
           run,
           events: auditEvents,
-          replayReceipt,
+          replayReceipt: publicReplayReceipt,
         });
         return {
           runId,
@@ -1409,7 +1603,7 @@ export function createFridayAgentRoutes(
             payload: sanitizeAuditEventPayload(e),
           })),
           decisionTrace,
-          replayReceipt,
+          replayReceipt: publicReplayReceipt,
           unifiedTaskState,
         };
       },
@@ -1546,7 +1740,10 @@ export function createFridayAgentRoutes(
         const rawRes = (ctx as unknown as Record<string, unknown>)._raw as FridaySseResponse | undefined;
         if (!rawRes) {
           // Fallback: if no raw response, return the current run state as JSON.
-          return { run, streaming: false };
+          return {
+            run: buildVisibleRunWithUnifiedTaskState(run, deps.listRunEvents(runId), ctx.receivedAt),
+            streaming: false,
+          };
         }
 
         // Set SSE headers

--- a/test/unit/api/http/routes/friday-agent-routes.test.ts
+++ b/test/unit/api/http/routes/friday-agent-routes.test.ts
@@ -1009,8 +1009,12 @@ describe("FridayAgentRoutes", () => {
     expect(result.replayReceipt.evidence.auditEventCount).toBe(1);
     expect(result.replayReceipt.replay.auditEndpoint).toBe("/v1/agent/runs/run-1/audit");
     expect(result.replayReceipt.replay.files).toEqual(expect.arrayContaining([
-      expect.objectContaining({ kind: "evidence_receipt", path: expect.stringContaining("evidence-receipt.json") }),
+      expect.objectContaining({ kind: "evidence_receipt" }),
     ]));
+    expect(JSON.stringify(result.replayReceipt)).not.toContain("/tmp/friday");
+    for (const file of result.replayReceipt.replay.files) {
+      expect(file.path).toBeUndefined();
+    }
     expect(result.replayReceipt.proofBoundary).toContain("not release proof");
   });
 
@@ -1703,6 +1707,64 @@ describe("FridayAgentRoutes", () => {
       expect(result.items[0]?.responseText).not.toContain("sessionKey");
     });
 
+    it("redacts private run fields from list projections", async () => {
+      const run = createStubRun({
+        id: "run-private-1",
+        providerId: "provider-secret-1",
+        model: "provider-model-secret",
+        artifactDir: "/Users/jarvis/private/friday/run-private-1",
+        artifacts: [
+          { type: "response", path: "/Users/jarvis/private/friday/run-private-1/response.md" },
+        ],
+        actualExecution: {
+          requestedProviderId: "provider-secret-1",
+          actualProviderId: "provider-secret-2",
+          actualModel: "provider-model-secret",
+          turns: [
+            { providerId: "provider-secret-2", model: "provider-model-secret", inputTokens: 1, outputTokens: 1 },
+          ],
+        },
+        metadata: {
+          surface: "api",
+          apiRequest: {
+            operationId: "agent.runs.start",
+            idempotencyKey: "idem-secret",
+            payloadHash: "hash-secret",
+            receivedAt: "2026-01-01T00:00:00.000Z",
+            principalId: "principal-secret",
+          },
+        },
+      });
+      stubDeps.listRuns = vi.fn().mockReturnValue([run]);
+      const routes = createFridayAgentRoutes(stubDeps);
+      const route = routes.find((r) => r.operationId === "agent.runs.list")!;
+
+      const result = await route.handler({
+        body: null,
+        params: {},
+        query: {},
+        headers: {},
+        principal: null,
+        requestId: "req-private-list",
+        receivedAt: "2026-01-01T00:00:00.000Z",
+      });
+
+      const encoded = JSON.stringify(result);
+      expect(encoded).not.toContain("provider-secret");
+      expect(encoded).not.toContain("provider-model-secret");
+      expect(encoded).not.toContain("/Users/jarvis/private");
+      expect(encoded).not.toContain("idem-secret");
+      expect(encoded).not.toContain("principal-secret");
+      expect(result).toMatchObject({
+        items: [
+          expect.objectContaining({
+            id: "run-private-1",
+            metadata: { surface: "api" },
+          }),
+        ],
+      });
+    });
+
     it("validates limit is a positive integer", async () => {
       const routes = createFridayAgentRoutes(stubDeps);
       const route = routes.find((r) => r.operationId === "agent.runs.list")!;
@@ -1977,8 +2039,63 @@ describe("FridayAgentRoutes", () => {
         receivedAt: "2026-01-01T00:00:00.000Z",
       };
       const result = await route.handler(ctx) as { run: FridayAgentRunRecord; streaming: boolean };
-      expect(result.run).toEqual(run);
+      expect(result.run).toEqual(expect.objectContaining({
+        id: run.id,
+        status: run.status,
+      }));
       expect(result.streaming).toBe(false);
+    });
+
+    it("returns a redacted fallback JSON projection when no raw response is available", async () => {
+      const run = createStubRun({
+        status: "executing",
+        providerId: "provider-secret-1",
+        artifactDir: "/Users/jarvis/private/friday/run-1",
+        artifacts: [
+          { type: "response", path: "/Users/jarvis/private/friday/run-1/response.md" },
+        ],
+      });
+      stubDeps.getRun = vi.fn().mockReturnValue(run);
+      stubDeps.listRunEvents = vi.fn().mockReturnValue([
+        {
+          eventId: "evt-private",
+          runId: "run-1",
+          seq: 1,
+          eventName: "agent.run.tool_start",
+          payload: {
+            runId: "run-1",
+            toolCallId: "call-1",
+            toolName: "shell",
+            params: { command: "cat /Users/jarvis/private/secret.txt" },
+          },
+          emittedAt: "2026-01-01T00:00:01.000Z",
+          createdAt: "2026-01-01T00:00:01.000Z",
+        },
+      ]);
+      const routes = createFridayAgentRoutes(stubDeps);
+      const route = routes.find((r) => r.operationId === "agent.runs.events")!;
+
+      const result = await route.handler({
+        body: null,
+        params: { runId: "run-1" },
+        query: {},
+        headers: {},
+        principal: null,
+        requestId: "req-fallback-redacted",
+        receivedAt: "2026-01-01T00:00:00.000Z",
+      });
+
+      const encoded = JSON.stringify(result);
+      expect(encoded).not.toContain("provider-secret");
+      expect(encoded).not.toContain("/Users/jarvis/private");
+      expect(encoded).not.toContain("secret.txt");
+      expect(result).toMatchObject({
+        streaming: false,
+        run: expect.objectContaining({
+          id: "run-1",
+          unifiedTaskState: expect.any(Object),
+        }),
+      });
     });
 
     it("replays persisted events and closes for terminal runs with raw response", async () => {
@@ -2050,6 +2167,10 @@ describe("FridayAgentRoutes", () => {
       expect(mockRes.write).toHaveBeenCalledWith(
         expect.stringContaining('"type":"agent.run.completed"'),
       );
+      const streamOutput = mockRes.write.mock.calls.map((call) => String(call[0])).join("\n");
+      expect(streamOutput).toContain('"payload"');
+      expect(streamOutput).toContain('"hasSummary":true');
+      expect(streamOutput).not.toContain("facebook.com · visible desktop");
       expect(mockRes.end).toHaveBeenCalled();
     });
 


### PR DESCRIPTION
## Summary

- Tighten agent run public read projections so list/get/events fallback no longer expose raw persisted run fields such as provider ids, provider routing records, private artifact paths, idempotency/principal metadata, raw commands, or raw event summaries.
- Sanitize agent run SSE replay payloads and path-redact public audit replay receipts while preserving proof refs and decision/event pointers.
- Classify five agent run GET surfaces as bounded `compat_shim` reads in the TS runtime retirement manifest.

## Verification

- `npx vitest run test/unit/api/http/routes/friday-agent-routes.test.ts`
- `npx vitest run test/unit/quality/ts-runtime-retirement-gate.test.ts test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts`
- `npm run check:ts-runtime-retirement`
- `npm run build`
- `npm run check:secret-patterns`
- `detect-secrets-hook --baseline .secrets.baseline $(git ls-files)`
- `git diff --check`

## Guardrails

- No default machine DB mutation.
- No pet/design-gallery edits.
- No provider_native_synced, Friday v1 GO, release, App Store/TestFlight/signing, or provider-native remote proof claim.
- These reads do not execute tools or mark completion; remaining TS runtime blockers are still tracked by the retirement gate.