### PR TITLE
Classify workflow run reads as redacted compat

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -718,6 +718,90 @@
       "next_action": "Replace fail-closed response with a Rust-owned workflow resume/control entrypoint when available."
     },
     {
+      "id": "workflow_runs_get_compat",
+      "route": {
+        "method": "GET",
+        "path": "/v1/workflow-runs/:runId",
+        "operationId": "runs.get"
+      },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Keep workflow run detail as a bounded redacted compatibility projection while TypeScript workflow execution and controls are fail-closed or moved to Rust-owned product truth. This read omits trigger payload, principal context, satellite/user ids, correlation ids, and raw failure details; it does not start, retry, resume, cancel, export evidence, or mark completion.",
+      "next_action": "Replace this compatibility read with a Rust-owned workflow run projection when available."
+    },
+    {
+      "id": "workflow_runs_nodes_compat",
+      "route": {
+        "method": "GET",
+        "path": "/v1/workflow-runs/:runId/nodes",
+        "operationId": "runs.list.nodes"
+      },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Keep workflow run node list as a bounded redacted compatibility projection while TypeScript workflow execution and controls are fail-closed or moved to Rust-owned product truth. This read omits node input/output, idempotency keys, lease owners, satellite ids, and raw error details; it does not execute or complete workflow nodes.",
+      "next_action": "Replace this compatibility read with a Rust-owned workflow node projection when available."
+    },
+    {
+      "id": "workflow_runs_timeline_compat",
+      "route": {
+        "method": "GET",
+        "path": "/v1/workflow-runs/:runId/timeline",
+        "operationId": "runs.timeline"
+      },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Keep workflow run timeline as a bounded redacted compatibility projection while TypeScript workflow execution and controls are fail-closed or moved to Rust-owned product truth. This read preserves cursorable event metadata but replaces raw event payloads with shape summaries; it does not treat timeline reads as completion.",
+      "next_action": "Replace this compatibility read with a Rust-owned bounded timeline projection when available."
+    },
+    {
+      "id": "workflow_runs_evidence_compat",
+      "route": {
+        "method": "GET",
+        "path": "/v1/workflow-runs/:runId/evidence",
+        "operationId": "runs.evidence"
+      },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Keep workflow run evidence as a bounded redacted compatibility projection while TypeScript workflow execution and controls are fail-closed or moved to Rust-owned product truth. This read preserves proof status and summaries while redacting raw event payloads, trace messages, principal context, file paths, and private artifact ids.",
+      "next_action": "Replace this compatibility read with a Rust-owned evidence projection when available."
+    },
+    {
+      "id": "workflow_runs_evidence_exports_list_compat",
+      "route": {
+        "method": "GET",
+        "path": "/v1/workflow-runs/:runId/evidence/exports",
+        "operationId": "runs.evidence.exports.list"
+      },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Keep workflow run evidence export list as a bounded redacted compatibility projection while TypeScript workflow execution and evidence-export mutation remain blocked or separately owned. This read exposes proof refs and checksums but rewrites file URIs and private artifact ids.",
+      "next_action": "Replace this compatibility read with a Rust-owned evidence export index when available."
+    },
+    {
+      "id": "workflow_runs_evidence_exports_get_compat",
+      "route": {
+        "method": "GET",
+        "path": "/v1/workflow-runs/:runId/evidence/exports/:exportId",
+        "operationId": "runs.evidence.exports.get"
+      },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Keep workflow run evidence export detail as a bounded redacted compatibility projection while TypeScript workflow execution and evidence-export mutation remain blocked or separately owned. This read exposes proof refs and sanitized evidence but rewrites file URIs, private artifact ids, raw event payloads, and trace messages.",
+      "next_action": "Replace this compatibility read with a Rust-owned evidence export detail projection when available."
+    },
+    {
+      "id": "workflow_runs_evidence_exports_download_compat",
+      "route": {
+        "method": "GET",
+        "path": "/v1/workflow-runs/:runId/evidence/exports/:exportId/download",
+        "operationId": "runs.evidence.exports.download"
+      },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Keep workflow run evidence export download as a bounded redacted compatibility projection while TypeScript workflow execution and evidence-export mutation remain blocked or separately owned. This download serializes sanitized evidence JSON instead of raw persisted file content or private filesystem paths.",
+      "next_action": "Replace this compatibility read with a Rust-owned evidence export download projection when available."
+    },
+    {
       "id": "skills_run",
       "route": {
         "method": "POST",

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -26,7 +26,17 @@ import {
   createFridayWorkflowTriggerRepository,
   listFridayStableWorkflowTemplates,
 } from "#workflows";
-import type { JsonObject } from "#workflows";
+import type {
+  FridayWorkflowEvidenceEvent,
+  FridayWorkflowPlaybookEvidenceTrace,
+  FridayWorkflowRetryEvidenceTrace,
+  FridayWorkflowRunEntity,
+  FridayWorkflowRunEvidenceExport,
+  FridayWorkflowRunEvidenceExportRecord,
+  FridayWorkflowRunEvidenceResponse,
+  FridayWorkflowRunNodeEntity,
+  JsonObject,
+} from "#workflows";
 
 import { classifyFridayExecution } from "../../sessions/services/friday-execution-classifier.js";
 import { dispatchDeterministic } from "../../sessions/services/friday-deterministic-dispatch.js";
@@ -202,6 +212,181 @@ const DEFAULT_REFRESH_TTL = 604_800; // 7 days
 const CURRENT_EPOCH = 1;
 const SESSION_CONTEXT_HISTORY_LIMIT = 24;
 const WORKFLOW_WEBHOOK_SECRET_SCOPES = ["workflow-webhook", "workflow"] as const;
+
+function summarizePublicJsonShape(value: unknown): JsonObject {
+  if (value === null || value === undefined) {
+    return { kind: "empty" };
+  }
+  if (Array.isArray(value)) {
+    return { kind: "array", itemCount: value.length };
+  }
+  if (typeof value === "object") {
+    const keys = Object.keys(value as Record<string, unknown>).sort();
+    return {
+      kind: "object",
+      keyCount: keys.length,
+      keys: keys.slice(0, 20),
+      truncated: keys.length > 20,
+    };
+  }
+  return { kind: typeof value };
+}
+
+function sanitizePublicWorkflowRun(run: FridayWorkflowRunEntity): FridayWorkflowRunEntity {
+  return {
+    id: run.id,
+    workflowId: run.workflowId,
+    workflowVersionId: run.workflowVersionId,
+    status: run.status,
+    triggerType: run.triggerType,
+    startedAt: run.startedAt,
+    deadlineAt: run.deadlineAt,
+    pausedAt: run.pausedAt,
+    resumedAt: run.resumedAt,
+    finishedAt: run.finishedAt,
+    createdAt: run.createdAt,
+    updatedAt: run.updatedAt,
+    proofRequired: run.proofRequired,
+    evidenceStatus: run.evidenceStatus,
+    completionVerification: run.completionVerification,
+    failure: run.failure
+      ? {
+        code: run.failure.code,
+        message: "redacted",
+      }
+      : undefined,
+  };
+}
+
+function sanitizePublicWorkflowRunNode(node: FridayWorkflowRunNodeEntity): FridayWorkflowRunNodeEntity {
+  return {
+    id: node.id,
+    runId: node.runId,
+    nodeId: node.nodeId,
+    attempt: node.attempt,
+    attemptId: node.attemptId,
+    status: node.status,
+    startedAt: node.startedAt,
+    finishedAt: node.finishedAt,
+    error: node.error
+      ? {
+        code: node.error.code,
+        message: "redacted",
+        retryable: node.error.retryable,
+      }
+      : undefined,
+    idempotencyKey: "redacted",
+    createdAt: node.createdAt,
+    updatedAt: node.updatedAt,
+  };
+}
+
+function sanitizePublicWorkflowEvidenceEvent(event: FridayWorkflowEvidenceEvent): FridayWorkflowEvidenceEvent {
+  return {
+    eventId: event.eventId,
+    event: event.event,
+    module: event.module,
+    emittedAt: event.emittedAt,
+    redacted: true,
+    correlation: {
+      runId: event.correlation.runId,
+      workflowId: event.correlation.workflowId,
+      nodeId: event.correlation.nodeId,
+      attempt: event.correlation.attempt,
+    },
+    payload: {
+      redacted: true,
+      shape: summarizePublicJsonShape(event.payload),
+    },
+  };
+}
+
+function sanitizePublicWorkflowRetryTrace(
+  trace: FridayWorkflowRetryEvidenceTrace,
+): FridayWorkflowRetryEvidenceTrace {
+  return {
+    ...trace,
+    errorMessage: trace.errorMessage ? "redacted" : undefined,
+    decision: {
+      shouldRetry: trace.decision.shouldRetry,
+      delayMs: trace.decision.delayMs,
+      reason: trace.decision.reason,
+      maxAttempts: trace.decision.maxAttempts,
+      budgetExhausted: trace.decision.budgetExhausted,
+      circuitOpen: trace.decision.circuitOpen,
+      escalateToDlq: trace.decision.escalateToDlq,
+    },
+  };
+}
+
+function sanitizePublicWorkflowPlaybookTrace(
+  trace: FridayWorkflowPlaybookEvidenceTrace,
+): FridayWorkflowPlaybookEvidenceTrace {
+  return {
+    runId: trace.runId,
+    workflowId: trace.workflowId,
+    phase: trace.phase,
+    timestamp: trace.timestamp,
+    intake: trace.intake
+      ? {
+        decision: trace.intake.decision,
+        playbookId: trace.intake.playbookId ? "redacted" : null,
+        versionNumber: trace.intake.versionNumber,
+        matchScore: trace.intake.matchScore,
+        evaluatedAt: trace.intake.evaluatedAt,
+      }
+      : undefined,
+    feedback: trace.feedback
+      ? {
+        candidateId: trace.feedback.candidateId ? "redacted" : null,
+        promotedPlaybookId: trace.feedback.promotedPlaybookId ? "redacted" : null,
+        promotionDecision: trace.feedback.promotionDecision,
+        scoreRecalculated: trace.feedback.scoreRecalculated,
+        recordedAt: trace.feedback.recordedAt,
+      }
+      : undefined,
+  };
+}
+
+function sanitizePublicWorkflowEvidence(
+  evidence: FridayWorkflowRunEvidenceResponse,
+): FridayWorkflowRunEvidenceResponse {
+  return {
+    ...evidence,
+    run: evidence.run ? sanitizePublicWorkflowRun(evidence.run) : null,
+    events: evidence.events.map(sanitizePublicWorkflowEvidenceEvent),
+    playbook: {
+      traces: evidence.playbook.traces.map(sanitizePublicWorkflowPlaybookTrace),
+    },
+    acceptance: {
+      events: evidence.acceptance.events.map(sanitizePublicWorkflowEvidenceEvent),
+    },
+    retry: {
+      events: evidence.retry.events.map(sanitizePublicWorkflowEvidenceEvent),
+      traces: evidence.retry.traces.map(sanitizePublicWorkflowRetryTrace),
+    },
+  };
+}
+
+function sanitizePublicWorkflowEvidenceExport(
+  evidenceExport: FridayWorkflowRunEvidenceExport,
+): FridayWorkflowRunEvidenceExport {
+  return {
+    ...evidenceExport,
+    artifactId: "redacted",
+    uri: `friday://workflow-runs/${evidenceExport.runId}/evidence-exports/${evidenceExport.exportId}.json`,
+    filePersisted: false,
+  };
+}
+
+function sanitizePublicWorkflowEvidenceExportRecord(
+  record: FridayWorkflowRunEvidenceExportRecord,
+): FridayWorkflowRunEvidenceExportRecord {
+  return {
+    export: sanitizePublicWorkflowEvidenceExport(record.export),
+    evidence: sanitizePublicWorkflowEvidence(record.evidence),
+  };
+}
 
 function createFridayPluginReviewEnablePlanDigest(input: {
   plugin: FridayPluginEntity;
@@ -2017,10 +2202,10 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
     getRun: (runId, principal) => {
       const run = resolveAuthorizedRun(runId, principal);
       return {
-        run: {
+        run: sanitizePublicWorkflowRun({
           ...run,
           evidenceStatus: workflowRuntime.evidence.getRunEvidenceStatus(run.id),
-        },
+        }),
       };
     },
     listRunNodes: (runId, query, principal) => {
@@ -2029,7 +2214,7 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
         runId,
         query.status,
       );
-      return { items: nodes };
+      return { items: nodes.map(sanitizePublicWorkflowRunNode) };
     },
     getRunTimeline: (runId, query, principal) => {
       resolveAuthorizedRun(runId, principal);
@@ -2049,23 +2234,29 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
           nodeId: p.nodeId as string | undefined,
           attempt: p.attempt as number | undefined,
           status: p.status as FridayRunTimelineEntry["status"] | undefined,
-          payload: p,
+          payload: {
+            redacted: true,
+            shape: summarizePublicJsonShape(p),
+          },
         };
       });
       return { items };
     },
     getRunEvidence: (runId, query, principal) => {
       resolveAuthorizedRunForEvidence(runId, principal);
-      return workflowRuntime.evidence.getRunEvidence(
-        runId,
-        parseRunEvidenceQuery(query as Record<string, unknown>),
+      return sanitizePublicWorkflowEvidence(
+        workflowRuntime.evidence.getRunEvidence(
+          runId,
+          parseRunEvidenceQuery(query as Record<string, unknown>),
+        ),
       );
     },
     listRunEvidenceExports: (runId, query, principal) => {
       resolveAuthorizedRunForEvidence(runId, principal);
       const limit = readPositiveIntQuery((query as Record<string, unknown>).limit) ?? 20;
       return {
-        items: workflowRuntime.evidence.listRunEvidenceExports(runId, limit),
+        items: workflowRuntime.evidence.listRunEvidenceExports(runId, limit)
+          .map(sanitizePublicWorkflowEvidenceExport),
       };
     },
     exportRunEvidence: (runId, input, principal) => {
@@ -2083,23 +2274,24 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
           httpStatus: 404,
         });
       }
-      return record;
+      return sanitizePublicWorkflowEvidenceExportRecord(record);
     },
     downloadRunEvidenceExport: (runId, exportId, principal) => {
       resolveAuthorizedRunForEvidence(runId, principal);
-      const download = workflowRuntime.evidence.downloadRunEvidenceExport(runId, exportId);
-      if (!download) {
+      const record = workflowRuntime.evidence.getRunEvidenceExport(runId, exportId);
+      if (!record) {
         throw new FridayDomainError("WORKFLOW_RUN_EVIDENCE_EXPORT_NOT_FOUND", "Workflow run evidence export not found", {
           httpStatus: 404,
         });
       }
-      return createFridayHttpRawTextResponse(download.content, {
+      const sanitized = sanitizePublicWorkflowEvidenceExportRecord(record);
+      return createFridayHttpRawTextResponse(JSON.stringify(sanitized, null, 2), {
         contentType: "application/json; charset=utf-8",
         headers: {
           "Content-Disposition": `attachment; filename=\"workflow-run-evidence-${exportId}.json\"`,
-          ETag: `"${download.export.checksum}"`,
-          "X-Friday-Evidence-Checksum": download.export.checksum,
-          "X-Friday-Evidence-File-Persisted": download.export.filePersisted ? "true" : "false",
+          ETag: `"${sanitized.export.checksum}"`,
+          "X-Friday-Evidence-Checksum": sanitized.export.checksum,
+          "X-Friday-Evidence-File-Persisted": "false",
         },
       });
     },

--- a/test/e2e/api/friday-api-workflows-routes.test.ts
+++ b/test/e2e/api/friday-api-workflows-routes.test.ts
@@ -854,9 +854,25 @@ describe("API — Workflow routes", () => {
     );
     const downloadBody = await downloadRes.text();
     expect(downloadBody.length).toBeGreaterThan(0);
-    expect(createHash("sha256").update(downloadBody).digest("hex")).toBe(
-      getExportJson.data.export.checksum,
+    const downloadJson = JSON.parse(downloadBody) as {
+      export: {
+        exportId: string;
+        runId: string;
+        checksum: string;
+        artifactId?: string;
+        uri?: string;
+        filePersisted?: boolean;
+      };
+    };
+    expect(downloadJson.export.exportId).toBe(exportId);
+    expect(downloadJson.export.runId).toBe(runId);
+    expect(downloadJson.export.checksum).toBe(getExportJson.data.export.checksum);
+    expect(downloadJson.export.artifactId).toBe("redacted");
+    expect(downloadJson.export.uri).toBe(
+      `friday://workflow-runs/${runId}/evidence-exports/${exportId}.json`,
     );
+    expect(downloadJson.export.filePersisted).toBe(false);
+    expect(downloadBody).not.toContain("file://");
 
     const missingRes = await fetch(
       `${env.baseUrl}/v1/workflow-runs/${runId}/evidence/exports/not-found-export/download`,

--- a/test/e2e/friday-real-scenarios-e2e.test.ts
+++ b/test/e2e/friday-real-scenarios-e2e.test.ts
@@ -1328,7 +1328,7 @@ echo '{"greeting": "hello from converted skill"}'
           items: Array<{
             nodeId: string;
             status: string;
-            output: unknown;
+            output?: unknown;
           }>;
         };
       };
@@ -1338,8 +1338,7 @@ echo '{"greeting": "hello from converted skill"}'
       const condNode = nodesJson.data.items.find((n) => n.nodeId === "check_score");
       expect(condNode).toBeTruthy();
       expect(condNode!.status).toBe("completed");
-      const condOutput = condNode!.output as { result: boolean } | null;
-      expect(condOutput?.result).toBe(true);
+      expect(condNode!.output).toBeUndefined();
 
       // pass_node should have executed
       const passNode = nodesJson.data.items.find((n) => n.nodeId === "pass_node");
@@ -1400,7 +1399,7 @@ echo '{"greeting": "hello from converted skill"}'
           items: Array<{
             nodeId: string;
             status: string;
-            output: unknown;
+            output?: unknown;
           }>;
         };
       };
@@ -1410,8 +1409,7 @@ echo '{"greeting": "hello from converted skill"}'
       const condNode = nodesJson.data.items.find((n) => n.nodeId === "check_score");
       expect(condNode).toBeTruthy();
       expect(condNode!.status).toBe("completed");
-      const condOutput = condNode!.output as { result: boolean } | null;
-      expect(condOutput?.result).toBe(false);
+      expect(condNode!.output).toBeUndefined();
 
       // fail_node should have executed
       const failNode = nodesJson.data.items.find((n) => n.nodeId === "fail_node");
@@ -1620,7 +1618,7 @@ echo '{"greeting": "hello from converted skill"}'
           items: Array<{
             nodeId: string;
             status: string;
-            output: unknown;
+            output?: unknown;
           }>;
         };
       };
@@ -1630,8 +1628,7 @@ echo '{"greeting": "hello from converted skill"}'
       const deployNode = json.data.items.find((n) => n.nodeId === "deploy");
       expect(deployNode).toBeTruthy();
       expect(deployNode!.status).toBe("completed");
-      const output = deployNode!.output as { deployed: boolean } | null;
-      expect(output?.deployed).toBe(true);
+      expect(deployNode!.output).toBeUndefined();
     });
   });
 });

--- a/test/unit/api/runtime/friday-api-runtime-run-evidence-access.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-run-evidence-access.test.ts
@@ -3,6 +3,7 @@ import { createHash } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import { createFridayApiRuntime } from "#api";
 import type { CreateFridayApiRuntimeDeps, FridayAuthPrincipal } from "#api";
+import type { FridayHttpRawTextResponse } from "../../../../src/api/http/friday-http-raw-response.js";
 import type { FridayProviderService } from "#providers";
 import type { FridayCompiledWorkflowGraphV2 } from "#workflows";
 import { createTestDb, createTestIdGenerator } from "../../../helpers/friday-test-db.helper.js";
@@ -516,6 +517,158 @@ describe("API runtime run evidence access control", () => {
       code: "WORKFLOW_RUN_EVIDENCE_FORBIDDEN",
       httpStatus: 403,
     });
+
+    deps.db.close();
+  });
+
+  it("redacts workflow run read, timeline, evidence export, and download projections", async () => {
+    const deps = makeDeps();
+    const runtime = createFridayApiRuntime(deps);
+
+    const workflow = runtime.workflowCrud.createWorkflow({
+      slug: "redacted-workflow-run-read-test",
+      name: "Redacted Workflow Run Read Test",
+    });
+    const version = runtime.workflowCrud.createVersion(
+      workflow.id,
+      makeMinimalGraph(workflow.id, "placeholder"),
+    );
+
+    const ownerPrincipal: FridayAuthPrincipal = {
+      principalType: "user",
+      principalId: "tenant-owner",
+      userId: "test-user",
+      role: "viewer",
+      scopes: ["workflow.write", "workflow.read"],
+      tokenId: "token-owner",
+      tokenKind: "access",
+      issuedAt: NOW,
+    };
+
+    const route = (operationId: string) => {
+      const found = runtime.routes.getRoutes().find((candidate) => candidate.operationId === operationId);
+      expect(found).toBeDefined();
+      return found!;
+    };
+    const invoke = (operationId: string, overrides: Record<string, unknown>) =>
+      route(operationId).handler({
+        params: {},
+        query: {},
+        body: null,
+        headers: {},
+        principal: ownerPrincipal,
+        requestId: `req-${operationId}`,
+        receivedAt: NOW,
+        ...overrides,
+      } as never);
+
+    const started = await invoke("runs.start", {
+      body: {
+        workflowId: workflow.id,
+        workflowVersionId: version.id,
+        triggerType: "manual",
+        triggerPayload: {
+          privateTranscript: "raw-transcript-secret",
+          providerId: "provider-secret",
+        },
+        dryRun: true,
+      },
+    }) as { run: { id: string } };
+    const runId = started.run.id;
+
+    deps.db.withWriteTransaction((db) => {
+      db.prepare(
+        `INSERT INTO realtime_events (
+           event_id, stream_id, seq, event, payload_json, emitted_at,
+           correlation_id, state_version_json, created_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).run(
+        "evt-private-timeline",
+        `run:${runId}`,
+        999,
+        "workflow.node.private",
+        JSON.stringify({
+          nodeId: "trigger",
+          attempt: 1,
+          status: "completed",
+          privateTranscript: "raw-transcript-secret",
+          filePath: "/private/tmp/friday/private-evidence.json",
+          providerId: "provider-secret",
+        }),
+        NOW,
+        "correlation-secret",
+        null,
+        NOW,
+      );
+    });
+
+    const runRead = await invoke("runs.get", {
+      params: { runId },
+    }) as { run: Record<string, unknown> };
+    expect(runRead.run.triggerPayload).toBeUndefined();
+    expect(runRead.run.context).toBeUndefined();
+    expect(runRead.run.startedByUserId).toBeUndefined();
+    expect(JSON.stringify(runRead)).not.toContain("raw-transcript-secret");
+    expect(JSON.stringify(runRead)).not.toContain("token-owner");
+
+    const nodesRead = await invoke("runs.list.nodes", {
+      params: { runId },
+    }) as { items: Array<Record<string, unknown>> };
+    for (const node of nodesRead.items) {
+      expect(node.input).toBeUndefined();
+      expect(node.output).toBeUndefined();
+      expect(node.satelliteId).toBeUndefined();
+      expect(node.leaseOwner).toBeUndefined();
+      expect(node.idempotencyKey).toBe("redacted");
+    }
+
+    const timelineRead = await invoke("runs.timeline", {
+      params: { runId },
+      query: { afterSeq: 998, limit: 5 },
+    }) as { items: Array<Record<string, unknown>> };
+    expect(timelineRead.items).toHaveLength(1);
+    expect(timelineRead.items[0]!.payload).toMatchObject({
+      redacted: true,
+      shape: {
+        kind: "object",
+      },
+    });
+    expect(JSON.stringify(timelineRead)).not.toContain("raw-transcript-secret");
+    expect(JSON.stringify(timelineRead)).not.toContain("/private/tmp/friday");
+    expect(JSON.stringify(timelineRead)).not.toContain("provider-secret");
+
+    await invoke("runs.evidence.export", {
+      params: { runId },
+      body: {},
+    });
+
+    const exportsList = await invoke("runs.evidence.exports.list", {
+      params: { runId },
+    }) as { items: Array<Record<string, unknown>> };
+    expect(exportsList.items).toHaveLength(1);
+    const exportId = exportsList.items[0]!.exportId as string;
+    expect(exportsList.items[0]!.artifactId).toBe("redacted");
+    expect(exportsList.items[0]!.uri).toBe(`friday://workflow-runs/${runId}/evidence-exports/${exportId}.json`);
+    expect(exportsList.items[0]!.filePersisted).toBe(false);
+    expect(JSON.stringify(exportsList)).not.toContain("file://");
+
+    const exportDetail = await invoke("runs.evidence.exports.get", {
+      params: { runId, exportId },
+    }) as { export: Record<string, unknown>; evidence: Record<string, unknown> };
+    expect(exportDetail.export.artifactId).toBe("redacted");
+    expect(exportDetail.export.uri).toBe(`friday://workflow-runs/${runId}/evidence-exports/${exportId}.json`);
+    expect(JSON.stringify(exportDetail)).not.toContain("file://");
+
+    const download = await invoke("runs.evidence.exports.download", {
+      params: { runId, exportId },
+    }) as FridayHttpRawTextResponse;
+    expect(download.__fridayRawTextResponse).toBe(true);
+    expect(download.headers?.["X-Friday-Evidence-File-Persisted"]).toBe("false");
+    const downloaded = JSON.parse(download.body) as Record<string, unknown>;
+    expect(JSON.stringify(downloaded)).not.toContain("file://");
+    expect(JSON.stringify(downloaded)).not.toContain("/private/tmp/friday");
+    expect(JSON.stringify(downloaded)).not.toContain("raw-transcript-secret");
+    expect((downloaded.export as Record<string, unknown>).artifactId).toBe("redacted");
 
     deps.db.close();
   });


### PR DESCRIPTION
## Summary
- add public workflow-run projection sanitizers for run, node, timeline, evidence, export, and download reads
- classify seven workflow-run GET/download surfaces as bounded redacted compat shims
- keep POST evidence export as an honest workflow_runtime_blocker; no fake Rust delegation or mock proof

## Verification
- npx vitest run test/unit/api/runtime/friday-api-runtime-run-evidence-access.test.ts test/unit/api/http/routes/friday-workflow-run-routes.test.ts
- npx vitest run test/unit/quality/ts-runtime-retirement-gate.test.ts test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts
- npm run check:ts-runtime-retirement
- npm run build
- npm run lint
- npm run check:secret-patterns
- detect-secrets-hook --baseline .secrets.baseline $(git ls-files)
- git diff --check

## Guardrails
- no default machine DB mutation
- no pet/design-gallery edits
- no provider_native_synced claim
- no strict closure or release claim
- memory candidates remain review-only
