### PR TITLE
Fail close workflow evidence export mutation

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -718,6 +718,19 @@
       "next_action": "Replace fail-closed response with a Rust-owned workflow resume/control entrypoint when available."
     },
     {
+      "id": "workflow_runs_evidence_export",
+      "route": {
+        "method": "POST",
+        "path": "/v1/workflow-runs/:runId/evidence/exports",
+        "operationId": "runs.evidence.export"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/runtime/friday-api-runtime.ts wires default/live runs.evidence.export to TS_RUNTIME_WORKFLOW_RUN_EVIDENCE_EXPORT_RETIRED before resolving TypeScript workflow run evidence state or calling workflowRuntime.evidence.exportRunEvidence; the legacy TS evidence export path is reachable only through explicit allowTestOnlyWorkflowRunExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned workflow run evidence export entrypoint when available."
+    },
+    {
       "id": "workflow_runs_get_compat",
       "route": {
         "method": "GET",

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -1037,6 +1037,19 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
       },
     );
   };
+  const throwRetiredWorkflowRunEvidenceExport = (): never => {
+    throw new FridayDomainError(
+      "TS_RUNTIME_WORKFLOW_RUN_EVIDENCE_EXPORT_RETIRED",
+      "Workflow run evidence export mutation is fail-closed while evidence-export ownership is being moved out of TypeScript.",
+      {
+        httpStatus: 503,
+        details: {
+          classification: "fail_closed",
+          replacement: "rust_owned_workflow_run_evidence_export_entrypoint_required",
+        },
+      },
+    );
+  };
 
   const requireWorkflowBuilderOperator = (
     principal: FridayAuthPrincipal | null,
@@ -2260,6 +2273,12 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
       };
     },
     exportRunEvidence: (runId, input, principal) => {
+      if (deps.allowTestOnlyWorkflowRunExecution !== true) {
+        void runId;
+        void input;
+        void principal;
+        throwRetiredWorkflowRunEvidenceExport();
+      }
       resolveAuthorizedRunForEvidence(runId, principal);
       return workflowRuntime.evidence.exportRunEvidence(
         runId,

--- a/src/api/runtime/friday-api-runtime.types.ts
+++ b/src/api/runtime/friday-api-runtime.types.ts
@@ -194,8 +194,9 @@ export interface CreateFridayApiRuntimeDeps {
   /**
    * Test-oracle only: allows legacy TypeScript workflow run execution/control
    * in isolated mock/unit validation. Production/runtime callers must leave
-   * this unset so workflow run start, cancel, retry, and resume stay
-   * fail-closed until Rust owns workflow execution truth.
+   * this unset so workflow run start, cancel, retry, resume, and evidence
+   * export mutation stay fail-closed until Rust owns workflow execution and
+   * evidence-export truth.
    */
   allowTestOnlyWorkflowRunExecution?: boolean;
   /**

--- a/test/unit/api/runtime/friday-api-runtime-run-evidence-access.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-run-evidence-access.test.ts
@@ -49,7 +49,9 @@ function makeProviderService(): FridayProviderService {
   } as FridayProviderService;
 }
 
-function makeDeps(): CreateFridayApiRuntimeDeps {
+function makeDeps(options: { allowTestOnlyWorkflowRunExecution?: boolean } = {
+  allowTestOnlyWorkflowRunExecution: true,
+}): CreateFridayApiRuntimeDeps {
   return {
     db: createTestDb(),
     idGenerator: createTestIdGenerator(),
@@ -59,7 +61,9 @@ function makeDeps(): CreateFridayApiRuntimeDeps {
     computeChecksum: (content: string) => createHash("sha256").update(content).digest("hex"),
     resolveSkill: () => ({ id: "test-skill" }),
     invokeSkill: async () => ({ ok: true }),
-    allowTestOnlyWorkflowRunExecution: true,
+    ...(options.allowTestOnlyWorkflowRunExecution === true
+      ? { allowTestOnlyWorkflowRunExecution: true }
+      : {}),
   };
 }
 
@@ -85,6 +89,41 @@ function makeMinimalGraph(
 }
 
 describe("API runtime run evidence access control", () => {
+  it("keeps workflow evidence export mutation fail-closed outside test-oracle wiring", async () => {
+    const deps = makeDeps({ allowTestOnlyWorkflowRunExecution: false });
+    const runtime = createFridayApiRuntime(deps);
+    const route = runtime.routes.getRoutes().find((candidate) => candidate.operationId === "runs.evidence.export");
+    expect(route).toBeDefined();
+
+    await expect(route!.handler({
+      params: { runId: "run-retired" },
+      query: {},
+      body: {},
+      headers: {},
+      principal: {
+        principalType: "user",
+        principalId: "tenant-owner",
+        userId: "test-user",
+        role: "operator",
+        scopes: ["workflow.write", "workflow.read"],
+        tokenId: "token-owner",
+        tokenKind: "access",
+        issuedAt: NOW,
+      },
+      requestId: "req-retired-export",
+      receivedAt: NOW,
+    } as never)).rejects.toMatchObject({
+      code: "TS_RUNTIME_WORKFLOW_RUN_EVIDENCE_EXPORT_RETIRED",
+      httpStatus: 503,
+      details: {
+        classification: "fail_closed",
+        replacement: "rust_owned_workflow_run_evidence_export_entrypoint_required",
+      },
+    });
+
+    deps.db.close();
+  });
+
   it("blocks non-owner principal from run metadata route as well", async () => {
     const deps = makeDeps();
     const runtime = createFridayApiRuntime(deps);


### PR DESCRIPTION
## Summary

- fail-close the default/live `POST /v1/workflow-runs/:runId/evidence/exports` runtime mutation with `TS_RUNTIME_WORKFLOW_RUN_EVIDENCE_EXPORT_RETIRED`
- keep legacy TypeScript evidence export reachable only through the explicit test-oracle `allowTestOnlyWorkflowRunExecution` path
- classify the exact workflow evidence export mutation surface as `fail_closed`, reducing TS runtime blockers and clearing the `workflow_runtime_blockers` family

## Verification

- `npx vitest run test/unit/api/runtime/friday-api-runtime-run-evidence-access.test.ts test/unit/api/http/routes/friday-workflow-run-routes.test.ts test/unit/quality/ts-runtime-retirement-gate.test.ts`
- `npm run check:ts-runtime-retirement`
- `npm run build`
- `npm run lint` (0 errors; existing warnings only)
- `npm run check:secret-patterns`
- `detect-secrets-hook --baseline .secrets.baseline $(git ls-files)`
- `git diff --check`

## Safety

- Default machine DB mutation: none; verification used repo-local/in-memory test paths.
- Pet/design-gallery files touched: no.
- No provider-native sync, release, App Store/TestFlight/signing, or Friday v1 GO claim.
