### PR TITLE
Fail close skill generator runtime surfaces

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -729,7 +729,7 @@
         "filename": "test/unit/api/http/routes/friday-api-audit-fixes.test.ts",
         "hashed_secret": "065c5c297f3c4990036a488c5b6c2a73075d439b",
         "is_verified": false,
-        "line_number": 475
+        "line_number": 481
       }
     ],
     "test/unit/api/http/routes/friday-auth-routes.test.ts": [
@@ -1124,5 +1124,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-05T01:44:19Z"
+  "generated_at": "2026-06-05T18:31:11Z"
 }

--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -828,6 +828,123 @@
       "next_action": "Replace fail-closed response with a Rust-owned skill execution entrypoint when available."
     },
     {
+      "id": "skills_verify",
+      "route": {
+        "method": "POST",
+        "path": "/v1/skills/:skillId/verify",
+        "operationId": "skills.verify"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-skill-routes.ts wires default/live skills.verify to TS_RUNTIME_SKILL_VERIFY_RETIRED before calling the TypeScript lifecycle.verifySkill service; the legacy TS verification path is reachable only through explicit allowTestOnlySkillVerifyExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned skill verification entrypoint when available."
+    },
+    {
+      "id": "skills_generator_sessions_create",
+      "route": {
+        "method": "POST",
+        "path": "/v1/skills/generator/sessions",
+        "operationId": "skills.generator.sessions.create"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-skill-generator-routes.ts wires default/live skill generator session routes to TS_RUNTIME_SKILL_GENERATOR_RETIRED before invoking the TypeScript skillGenerator service; legacy generator behavior is reachable only through explicit allowTestOnlySkillGeneratorExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned skill generator entrypoint when available."
+    },
+    {
+      "id": "skills_generator_sessions_get",
+      "route": {
+        "method": "GET",
+        "path": "/v1/skills/generator/sessions/:sessionId",
+        "operationId": "skills.generator.sessions.get"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-skill-generator-routes.ts wires default/live skill generator session routes to TS_RUNTIME_SKILL_GENERATOR_RETIRED before reading TypeScript generator session state; legacy generator reads are reachable only through explicit allowTestOnlySkillGeneratorExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned redacted skill generator session projection when available."
+    },
+    {
+      "id": "skills_generator_sessions_messages_create",
+      "route": {
+        "method": "POST",
+        "path": "/v1/skills/generator/sessions/:sessionId/messages",
+        "operationId": "skills.generator.sessions.messages.create"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-skill-generator-routes.ts wires default/live skill generator message submission to TS_RUNTIME_SKILL_GENERATOR_RETIRED before invoking the TypeScript skillGenerator service; legacy generator behavior is reachable only through explicit allowTestOnlySkillGeneratorExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned skill generator turn entrypoint when available."
+    },
+    {
+      "id": "skills_generator_sessions_generate",
+      "route": {
+        "method": "POST",
+        "path": "/v1/skills/generator/sessions/:sessionId/generate",
+        "operationId": "skills.generator.sessions.generate"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-skill-generator-routes.ts wires default/live skill draft generation to TS_RUNTIME_SKILL_GENERATOR_RETIRED before invoking the TypeScript skillGenerator service; legacy generator behavior is reachable only through explicit allowTestOnlySkillGeneratorExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned skill draft generation entrypoint when available."
+    },
+    {
+      "id": "skills_generator_sessions_test",
+      "route": {
+        "method": "POST",
+        "path": "/v1/skills/generator/sessions/:sessionId/test",
+        "operationId": "skills.generator.sessions.test"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-skill-generator-routes.ts wires default/live skill draft self-test to TS_RUNTIME_SKILL_GENERATOR_RETIRED before writing temp files or executing the TypeScript draft test path; legacy self-test behavior is reachable only through explicit allowTestOnlySkillGeneratorExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned skill draft validation/test entrypoint when available."
+    },
+    {
+      "id": "skills_generator_sessions_evidence_get",
+      "route": {
+        "method": "GET",
+        "path": "/v1/skills/generator/sessions/:sessionId/evidence",
+        "operationId": "skills.generator.sessions.evidence.get"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-skill-generator-routes.ts wires default/live skill generator evidence reads to TS_RUNTIME_SKILL_GENERATOR_RETIRED before reading TypeScript generator evidence state; legacy generator evidence reads are reachable only through explicit allowTestOnlySkillGeneratorExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned redacted skill generator evidence projection when available."
+    },
+    {
+      "id": "skills_generator_sessions_approve",
+      "route": {
+        "method": "POST",
+        "path": "/v1/skills/generator/sessions/:sessionId/approve",
+        "operationId": "skills.generator.sessions.approve"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-skill-generator-routes.ts wires default/live generated skill approval to TS_RUNTIME_SKILL_GENERATOR_RETIRED before evaluating TypeScript candidate approval or staging a candidate; legacy generator approval is reachable only through explicit allowTestOnlySkillGeneratorExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned generated skill candidate approval entrypoint when available."
+    },
+    {
+      "id": "skills_generator_sessions_cancel",
+      "route": {
+        "method": "DELETE",
+        "path": "/v1/skills/generator/sessions/:sessionId",
+        "operationId": "skills.generator.sessions.cancel"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-skill-generator-routes.ts wires default/live skill generator cancellation to TS_RUNTIME_SKILL_GENERATOR_RETIRED before invoking the TypeScript skillGenerator service; legacy generator cancellation is reachable only through explicit allowTestOnlySkillGeneratorExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned skill generator cancellation entrypoint when available."
+    },
+    {
       "id": "autofix_run_ready",
       "route": {
         "method": "POST",

--- a/src/api/http/routes/friday-skill-generator-routes.ts
+++ b/src/api/http/routes/friday-skill-generator-routes.ts
@@ -290,6 +290,21 @@ export interface FridaySkillGeneratorRoutesDeps {
   selfHealing?: FridaySelfHealingApiService;
   observability?: FridayObservabilityApiService;
   canonicalMutationGate?: FridayMutatingActionGate;
+  allowTestOnlySkillGeneratorExecution?: boolean;
+}
+
+function throwRetiredSkillGeneratorExecution(): never {
+  throw new FridayDomainError(
+    "TS_RUNTIME_SKILL_GENERATOR_RETIRED",
+    "Skill generator execution is fail-closed while generator ownership is being moved out of TypeScript.",
+    {
+      httpStatus: 503,
+      details: {
+        classification: "fail_closed",
+        replacement: "rust_owned_skill_generator_entrypoint_required",
+      },
+    },
+  );
 }
 
 const GENERATED_SKILL_HUB_VERSION = "1.0.0";
@@ -558,6 +573,12 @@ async function executeDraftFromTempDir(
 export function createFridaySkillGeneratorRoutes(
   deps: FridaySkillGeneratorRoutesDeps,
 ): FridayRouteDefinition<unknown, unknown, unknown, unknown>[] {
+  function assertSkillGeneratorTestOracleAllowed(): void {
+    if (deps.allowTestOnlySkillGeneratorExecution !== true) {
+      throwRetiredSkillGeneratorExecution();
+    }
+  }
+
   async function reportGenerationFailure(input: {
     sessionId: string;
     userId: string;
@@ -816,6 +837,7 @@ export function createFridaySkillGeneratorRoutes(
       auth: { public: true },
       rateLimitPolicyId: "skill_generator.write",
       async handler(ctx): Promise<FridayStartSessionResponse> {
+        assertSkillGeneratorTestOracleAllowed();
         validateStartSessionBody(ctx.body);
         const body = ctx.body;
         const principalUserId = requireUserId(ctx.principal);
@@ -858,6 +880,7 @@ export function createFridaySkillGeneratorRoutes(
       path: "/v1/skills/generator/sessions/:sessionId",
       auth: { public: true },
       async handler(ctx): Promise<FridayGetSessionResponse> {
+        assertSkillGeneratorTestOracleAllowed();
         const { sessionId } = ctx.params as { sessionId: string };
         const result = await deps.skillGenerator.getSession(sessionId);
         if (!result) {
@@ -879,6 +902,7 @@ export function createFridaySkillGeneratorRoutes(
       auth: { public: true },
       rateLimitPolicyId: "skill_generator.llm",
       async handler(ctx): Promise<FridaySubmitTurnResponse> {
+        assertSkillGeneratorTestOracleAllowed();
         const { sessionId } = ctx.params as { sessionId: string };
         validateSubmitTurnBody(ctx.body);
         const body = ctx.body;
@@ -905,6 +929,7 @@ export function createFridaySkillGeneratorRoutes(
       auth: { public: true },
       rateLimitPolicyId: "skill_generator.llm",
       async handler(ctx): Promise<FridayGenerateResponse> {
+        assertSkillGeneratorTestOracleAllowed();
         const { sessionId } = ctx.params as { sessionId: string };
         validateGenerateBody(ctx.body);
         const body = (ctx.body ?? {}) as { requestedModel?: string };
@@ -946,6 +971,7 @@ export function createFridaySkillGeneratorRoutes(
       auth: { public: true },
       rateLimitPolicyId: "skill_generator.write",
       async handler(ctx): Promise<FridaySkillGeneratorTestResponse> {
+        assertSkillGeneratorTestOracleAllowed();
         const { sessionId } = ctx.params as { sessionId: string };
         const session = await deps.skillGenerator.getSession(sessionId);
         if (!session) {
@@ -984,6 +1010,7 @@ export function createFridaySkillGeneratorRoutes(
       path: "/v1/skills/generator/sessions/:sessionId/evidence",
       auth: { public: true },
       async handler(ctx): Promise<FridaySkillGeneratorEvidenceResponse> {
+        assertSkillGeneratorTestOracleAllowed();
         const { sessionId } = ctx.params as { sessionId: string };
         const evidence = await buildEvidence(sessionId);
         return { evidence };
@@ -1005,6 +1032,7 @@ export function createFridaySkillGeneratorRoutes(
       auth: { public: true, allowUnauthenticatedMutation: true },
       rateLimitPolicyId: "skill_generator.write",
       async handler(ctx): Promise<FridayApproveResponse> {
+        assertSkillGeneratorTestOracleAllowed();
         const { sessionId } = ctx.params as { sessionId: string };
         validateApproveBody(ctx.body);
         const body = ctx.body ?? {};
@@ -1080,6 +1108,7 @@ export function createFridaySkillGeneratorRoutes(
       path: "/v1/skills/generator/sessions/:sessionId",
       auth: { public: true },
       async handler(ctx): Promise<FridayCancelSessionResponse> {
+        assertSkillGeneratorTestOracleAllowed();
         const { sessionId } = ctx.params as { sessionId: string };
         await deps.skillGenerator.cancelSession(sessionId);
         return { cancelled: true };

--- a/src/api/http/routes/friday-skill-routes.ts
+++ b/src/api/http/routes/friday-skill-routes.ts
@@ -42,6 +42,7 @@ export interface FridaySkillRoutesDeps {
 	  lifecycle?: FridaySkillLifecycleService;
 	  skillExecutor?: FridaySkillExecutor;
 	  allowTestOnlySkillRunExecution?: boolean;
+	  allowTestOnlySkillVerifyExecution?: boolean;
 	  managedSkillsDir?: string;
 	  getSkillLifecycleStatus?: (skillId: string) => string | null | undefined;
 	  canonicalMutationGate?: FridayMutatingActionGate;
@@ -58,6 +59,20 @@ function throwRetiredSkillRunExecution(): never {
       details: {
         classification: "fail_closed",
         replacement: "rust_owned_skill_run_entrypoint_required",
+      },
+    },
+  );
+}
+
+function throwRetiredSkillVerifyExecution(): never {
+  throw new FridayDomainError(
+    "TS_RUNTIME_SKILL_VERIFY_RETIRED",
+    "Skill verification is fail-closed while verification ownership is being moved out of TypeScript.",
+    {
+      httpStatus: 503,
+      details: {
+        classification: "fail_closed",
+        replacement: "rust_owned_skill_verification_entrypoint_required",
       },
     },
   );
@@ -565,6 +580,9 @@ export function createFridaySkillRoutes(
         path: "/v1/skills/:skillId/verify",
         auth: { public: true },
         async handler(ctx) {
+          if (deps.allowTestOnlySkillVerifyExecution !== true) {
+            throwRetiredSkillVerifyExecution();
+          }
           const skillId = String((ctx.params as Record<string, unknown>).skillId ?? "");
           const evidence = await deps.lifecycle!.verifySkill({
             skillId,

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -3006,6 +3006,7 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
       lifecycle: deps.skillLifecycle,
       skillExecutor: deps.skillExecutor,
       allowTestOnlySkillRunExecution: deps.allowTestOnlySkillRunExecution,
+      allowTestOnlySkillVerifyExecution: deps.allowTestOnlySkillVerifyExecution,
 	      managedSkillsDir: deps.managedSkillsDir,
 	      getSkillLifecycleStatus: (skillId) => skillRepo.getSkillById(deps.db.writer, skillId)?.status,
 	      canonicalMutationGate,
@@ -3024,6 +3025,7 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
       selfHealing: deps.diagnosis?.service,
       observability: deps.observabilityService,
       canonicalMutationGate,
+      allowTestOnlySkillGeneratorExecution: deps.allowTestOnlySkillGeneratorExecution,
     })) {
       routes.register(route);
     }

--- a/src/api/runtime/friday-api-runtime.types.ts
+++ b/src/api/runtime/friday-api-runtime.types.ts
@@ -206,6 +206,20 @@ export interface CreateFridayApiRuntimeDeps {
    * execution truth.
    */
   allowTestOnlySkillRunExecution?: boolean;
+  /**
+   * Test-oracle only: allows legacy TypeScript skill verification in isolated
+   * mock/unit validation. Production/runtime callers must leave this unset so
+   * POST /v1/skills/:skillId/verify remains fail-closed until Rust owns skill
+   * verification truth.
+   */
+  allowTestOnlySkillVerifyExecution?: boolean;
+  /**
+   * Test-oracle only: allows legacy TypeScript skill generator sessions in
+   * isolated mock/unit validation. Production/runtime callers must leave this
+   * unset so skill generator session create/read/message/generate/test/approve/
+   * cancel routes remain fail-closed until Rust owns generator truth.
+   */
+  allowTestOnlySkillGeneratorExecution?: boolean;
   /** Optional: user/project prompt-guidance provider for fallback workflow runtime creation. */
   userRulesContextProvider?: CreateFridayWorkflowRuntimeDeps["userRulesContextProvider"];
   /** Optional: reuse hub's session service instead of creating a new one. */

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -1852,6 +1852,10 @@ export interface FridayHubConfig {
   allowTestOnlyWorkflowRunExecution?: boolean;
   /** Test-oracle only; production hub creation must leave skill run execution fail-closed. */
   allowTestOnlySkillRunExecution?: boolean;
+  /** Test-oracle only; production hub creation must leave skill verification fail-closed. */
+  allowTestOnlySkillVerifyExecution?: boolean;
+  /** Test-oracle only; production hub creation must leave skill generator sessions fail-closed. */
+  allowTestOnlySkillGeneratorExecution?: boolean;
   /** Test-oracle only; production hub creation must leave auto-fix execution fail-closed. */
   allowTestOnlyAutoFixExecution?: boolean;
   /** Test-oracle only; production hub creation must leave desktop action execution fail-closed. */

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -6896,6 +6896,8 @@ export async function createFridayHub(
     invokeSkill: invokeSkillForWorkflow,
     allowTestOnlyWorkflowRunExecution: config.allowTestOnlyWorkflowRunExecution,
     allowTestOnlySkillRunExecution: config.allowTestOnlySkillRunExecution,
+    allowTestOnlySkillVerifyExecution: config.allowTestOnlySkillVerifyExecution,
+    allowTestOnlySkillGeneratorExecution: config.allowTestOnlySkillGeneratorExecution,
     agentRuntime,
     allowTestOnlyAgentRunStartExecution: config.allowTestOnlyAgentRunStartExecution,
     allowTestOnlyAgentRunControlExecution: config.allowTestOnlyAgentRunControlExecution,

--- a/test/e2e/api/_helpers/friday-api-test-server.helper.ts
+++ b/test/e2e/api/_helpers/friday-api-test-server.helper.ts
@@ -144,6 +144,17 @@ export interface CreateFridayApiTestEnvOptions {
    */
   allowTestOnlySkillRunExecution?: boolean;
   /**
+   * Test-oracle opt-in for legacy TS skill verification. Default/live runtime
+   * leaves skill verification fail-closed while Rust ownership lands.
+   */
+  allowTestOnlySkillVerifyExecution?: boolean;
+  /**
+   * Test-oracle opt-in for legacy TS skill generator sessions. Default/live
+   * runtime leaves generator session routes fail-closed while Rust ownership
+   * lands.
+   */
+  allowTestOnlySkillGeneratorExecution?: boolean;
+  /**
    * Test-oracle opt-in for legacy TS auto-fix execution. Default/live runtime
    * leaves auto-fix run/execute/rollback surfaces fail-closed while Rust ownership lands.
    */
@@ -254,6 +265,8 @@ export async function createFridayApiTestEnv(
     channels: options.channels,
     allowTestOnlyWorkflowRunExecution: options.allowTestOnlyWorkflowRunExecution ?? true,
     allowTestOnlySkillRunExecution: options.allowTestOnlySkillRunExecution ?? true,
+    allowTestOnlySkillVerifyExecution: options.allowTestOnlySkillVerifyExecution ?? true,
+    allowTestOnlySkillGeneratorExecution: options.allowTestOnlySkillGeneratorExecution ?? true,
     computeChecksum: (content: string) =>
       crypto.createHash("sha256").update(content).digest("hex"),
     resolveSkill: options.resolveSkill ?? ((_skillId: string) => ({ id: _skillId })),

--- a/test/e2e/friday-full-e2e.test.ts
+++ b/test/e2e/friday-full-e2e.test.ts
@@ -123,6 +123,7 @@ describe.skipIf(!CORE_E2E_ENABLED)("Friday Full E2E — Batch 1 (A–F)", () => 
       port: 0,
       logRequests: false,
       allowTestOnlyWorkflowRunExecution: true,
+      allowTestOnlySkillGeneratorExecution: true,
     });
     await hub.start();
 

--- a/test/e2e/mock/_helpers/mock-env.ts
+++ b/test/e2e/mock/_helpers/mock-env.ts
@@ -332,6 +332,10 @@ export async function createMockHubEnv(opts?: {
   allowTestOnlyWorkflowRunExecution?: boolean;
   /** Test-oracle opt-in for legacy TS skill-run execution; set false to prove default fail-closed behavior. */
   allowTestOnlySkillRunExecution?: boolean;
+  /** Test-oracle opt-in for legacy TS skill verification; set false to prove default fail-closed behavior. */
+  allowTestOnlySkillVerifyExecution?: boolean;
+  /** Test-oracle opt-in for legacy TS skill generator sessions; set false to prove default fail-closed behavior. */
+  allowTestOnlySkillGeneratorExecution?: boolean;
   /** Test-oracle opt-in for legacy TS agent-run execution; set false to prove default fail-closed behavior. */
   allowTestOnlyAgentRunStartExecution?: boolean;
   /** Test-oracle opt-in for legacy TS agent-run controls; set false to prove default fail-closed behavior. */
@@ -379,6 +383,8 @@ export async function createMockHubEnv(opts?: {
       tokenSecret: MOCK_E2E_TOKEN_SECRET,
       allowTestOnlyWorkflowRunExecution: opts?.allowTestOnlyWorkflowRunExecution ?? true,
       allowTestOnlySkillRunExecution: opts?.allowTestOnlySkillRunExecution ?? true,
+      allowTestOnlySkillVerifyExecution: opts?.allowTestOnlySkillVerifyExecution ?? true,
+      allowTestOnlySkillGeneratorExecution: opts?.allowTestOnlySkillGeneratorExecution ?? true,
       allowTestOnlyAgentRunStartExecution: opts?.allowTestOnlyAgentRunStartExecution ?? true,
       allowTestOnlyAgentRunControlExecution: opts?.allowTestOnlyAgentRunControlExecution ?? true,
       // Allow private-network targets so mock E2E tests don't require DNS resolution

--- a/test/unit/api/http/routes/friday-api-audit-fixes.test.ts
+++ b/test/unit/api/http/routes/friday-api-audit-fixes.test.ts
@@ -421,26 +421,32 @@ describe("SGEN-003: Skill generator rejects non-object generate body", () => {
     stopWatching: vi.fn(async () => undefined),
     close: vi.fn(async () => undefined),
   };
+  function createGeneratorOracleRoutes() {
+    return createFridaySkillGeneratorRoutes({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      skillGenerator: skillGen as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      registry: registry as any,
+      allowTestOnlySkillGeneratorExecution: true,
+    });
+  }
 
   it("rejects string body", async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const routes = createFridaySkillGeneratorRoutes({ skillGenerator: skillGen as any, registry: registry as any });
+    const routes = createGeneratorOracleRoutes();
     const route = routes.find((r) => r.operationId === "skills.generator.sessions.generate")!;
     const ctx = makeCtx({ params: { sessionId: "sess-1" }, body: "not-an-object" });
     await expect(route.handler(ctx)).rejects.toThrow("plain object");
   });
 
   it("rejects array body", async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const routes = createFridaySkillGeneratorRoutes({ skillGenerator: skillGen as any, registry: registry as any });
+    const routes = createGeneratorOracleRoutes();
     const route = routes.find((r) => r.operationId === "skills.generator.sessions.generate")!;
     const ctx = makeCtx({ params: { sessionId: "sess-1" }, body: [1, 2, 3] });
     await expect(route.handler(ctx)).rejects.toThrow("plain object");
   });
 
   it("accepts null body (no options)", async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const routes = createFridaySkillGeneratorRoutes({ skillGenerator: skillGen as any, registry: registry as any });
+    const routes = createGeneratorOracleRoutes();
     const route = routes.find((r) => r.operationId === "skills.generator.sessions.generate")!;
     const ctx = makeCtx({ params: { sessionId: "sess-1" }, body: null });
     const result = await route.handler(ctx);

--- a/test/unit/api/http/routes/friday-skill-generator-routes.test.ts
+++ b/test/unit/api/http/routes/friday-skill-generator-routes.test.ts
@@ -260,9 +260,34 @@ describe("FridaySkillGeneratorRoutes", () => {
       skillGenerator: generatorService,
       registry,
       canonicalMutationGate,
+      allowTestOnlySkillGeneratorExecution: true,
     });
     return { routes, generatorService, registry };
   }
+
+  it("fail-closes skill generator sessions by default without invoking the TypeScript generator", async () => {
+    const generatorService = makeMockGeneratorService();
+    const routes = createFridaySkillGeneratorRoutes({
+      skillGenerator: generatorService,
+      registry: makeMockRegistry(),
+    });
+    const route = routes.find((r) => r.operationId === "skills.generator.sessions.create")!;
+
+    await expect(
+      route.handler(makeCtx({
+        body: { goal: "Build a timer", userId: "user-1", channel: "discord" },
+        principal: { userId: "user-1", principalId: "user-1", tenantId: "tenant-1" },
+      })),
+    ).rejects.toMatchObject({
+      code: "TS_RUNTIME_SKILL_GENERATOR_RETIRED",
+      httpStatus: 503,
+      details: {
+        classification: "fail_closed",
+        replacement: "rust_owned_skill_generator_entrypoint_required",
+      },
+    });
+    expect(generatorService.startSession).not.toHaveBeenCalled();
+  });
 
   function withCanonicalApproval(body: {
     idempotencyKey?: string;
@@ -773,6 +798,7 @@ describe("FridaySkillGeneratorRoutes", () => {
         const routes = createFridaySkillGeneratorRoutes({
           skillGenerator: generatorService,
           registry: makeMockRegistry(),
+          allowTestOnlySkillGeneratorExecution: true,
         });
         const route = routes.find(
           (r) => r.operationId === "skills.generator.sessions.test",
@@ -843,6 +869,7 @@ describe("FridaySkillGeneratorRoutes", () => {
         const routes = createFridaySkillGeneratorRoutes({
           skillGenerator: generatorService,
           registry: makeMockRegistry(),
+          allowTestOnlySkillGeneratorExecution: true,
         });
         const route = routes.find(
           (r) => r.operationId === "skills.generator.sessions.test",

--- a/test/unit/api/http/routes/friday-skill-routes.test.ts
+++ b/test/unit/api/http/routes/friday-skill-routes.test.ts
@@ -304,7 +304,7 @@ describe("createFridaySkillRoutes", () => {
 	    ).rejects.toMatchObject({ code: "SKILL_LEGACY_LIFECYCLE_ROUTE_RETIRED" });
 	  });
 
-	  it("blocks legacy install/update/delete for managed external skills while keeping read verification routes active", async () => {
+	  it("blocks legacy install/update/delete and skill verification by default while keeping manifest validation active", async () => {
     const lifecycle = makeLifecycle();
     const routes = createFridaySkillRoutes({
       skillRegistry: { list: () => [] } as never,
@@ -323,17 +323,39 @@ describe("createFridaySkillRoutes", () => {
       .rejects.toMatchObject({ code: "SKILL_LEGACY_LIFECYCLE_ROUTE_RETIRED" });
     await expect(remove.handler(makeCtx({ params: { skillId: "skill.alpha" } })))
       .rejects.toMatchObject({ code: "SKILL_LEGACY_LIFECYCLE_ROUTE_RETIRED" });
-    await verify.handler(makeCtx({ params: { skillId: "skill.alpha" } }));
+    await expect(verify.handler(makeCtx({ params: { skillId: "skill.alpha" } })))
+      .rejects.toMatchObject({
+        code: "TS_RUNTIME_SKILL_VERIFY_RETIRED",
+        httpStatus: 503,
+        details: {
+          classification: "fail_closed",
+          replacement: "rust_owned_skill_verification_entrypoint_required",
+        },
+      });
     await validate.handler(makeCtx({ body: { manifest: { id: "skill.alpha" } } }));
 
     expect(lifecycle.install).not.toHaveBeenCalled();
     expect(lifecycle.update).not.toHaveBeenCalled();
     expect(lifecycle.deleteSkill).not.toHaveBeenCalled();
+    expect(lifecycle.verifySkill).not.toHaveBeenCalled();
+    expect(lifecycle.validateManifest).toHaveBeenCalledWith({ id: "skill.alpha" });
+  });
+
+  it("allows legacy skill verification only when the test oracle opts in", async () => {
+    const lifecycle = makeLifecycle();
+    const routes = createFridaySkillRoutes({
+      skillRegistry: { list: () => [] } as never,
+      lifecycle: lifecycle as never,
+      allowTestOnlySkillVerifyExecution: true,
+    });
+
+    const verify = routes.find((item) => item.operationId === "skills.verify")!;
+    await verify.handler(makeCtx({ params: { skillId: "skill.alpha" } }));
+
     expect(lifecycle.verifySkill).toHaveBeenCalledWith({
       skillId: "skill.alpha",
       userId: "user-1",
     });
-    expect(lifecycle.validateManifest).toHaveBeenCalledWith({ id: "skill.alpha" });
   });
 
   it("requires canonical approval before non-managed lifecycle update/delete", async () => {

--- a/test/unit/hub/friday-hub-bootstrap.test.ts
+++ b/test/unit/hub/friday-hub-bootstrap.test.ts
@@ -385,7 +385,7 @@ describe("createFridayHub", () => {
   });
 
   it("wires canonical skill lifecycle routes into the API runtime", async () => {
-    hub = await createIsolatedHub();
+    hub = await createIsolatedHub({ allowTestOnlySkillVerifyExecution: true });
     const routes = hub.apiRuntime.routes.getRoutes();
     const operationIds = routes.map((route) => route.operationId);
 


### PR DESCRIPTION
## Summary
- fail-close default/live `skills.verify` before TypeScript lifecycle verification executes
- fail-close default/live skill generator session create/read/message/generate/test/evidence/approve/cancel routes before TypeScript generator services execute
- keep legacy TypeScript skill verification/generator behavior available only through explicit test-oracle opt-ins in isolated test helpers
- update the TS runtime retirement manifest so the skill runtime blocker family clears honestly

## CI repair
- initial PR #538 CI failed only in `test` because two legacy tests still expected default/live skill verify/generator paths to execute TypeScript behavior
- fixed by explicitly opting those isolated tests into `allowTestOnlySkillVerifyExecution` / `allowTestOnlySkillGeneratorExecution`; default/live runtime remains fail-closed

## Verification
- `jq empty docs/ops/ts-runtime-retirement-manifest.json && npm run check:ts-runtime-retirement` passed: 584 routes, 206 `ts_runtime_blocker`, 38 `fail_closed`, 231 `compat_shim`; `skill_runtime_blockers` cleared
- `npx vitest run test/unit/api/http/routes/friday-skill-routes.test.ts test/unit/api/http/routes/friday-skill-generator-routes.test.ts test/unit/quality/ts-runtime-retirement-gate.test.ts` passed, 53 tests
- `npx vitest run test/e2e/api/friday-api-skills-routes.test.ts test/e2e/api/friday-api-skill-upgrade-lifecycle-live.test.ts test/e2e/mock/friday-mock-validation-chains.e2e.test.ts` passed, 30 tests
- `FRIDAY_E2E_CORE=1 npx vitest run test/e2e/friday-real-scenarios-e2e.test.ts test/e2e/friday-full-e2e.test.ts` passed, 158 tests passed and 33 skipped
- `npx vitest run test/unit/hub/friday-hub-bootstrap.test.ts test/unit/api/http/routes/friday-api-audit-fixes.test.ts` passed, 58 tests
- `FRIDAY_E2E_CORE=1 npm test` passed: 925 files passed, 12600 tests passed, no type errors
- `npm run test:e2e:ui` passed: 13 files passed, 28 tests passed and 2 skipped
- `npm run build` passed
- `npm run lint` passed with existing warnings, 0 errors
- `npm run check:secret-patterns` passed
- `detect-secrets-hook --baseline .secrets.baseline $(git ls-files)` passed
- `git diff --check` passed

## Guardrails
- no default machine DB mutation
- no pet/design-gallery edits
- no provider_native_synced claim
- not Friday v1 GO
- not provider-native/remote proof
- not release/App Store/TestFlight/signing
- no fake Rust delegation or mock closure