### PR TITLE
Fail close workflow generator session runtime surfaces

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -945,6 +945,97 @@
       "next_action": "Replace fail-closed response with a Rust-owned skill generator cancellation entrypoint when available."
     },
     {
+      "id": "workflows_generator_sessions_create",
+      "route": {
+        "method": "POST",
+        "path": "/v1/workflows/generator/sessions",
+        "operationId": "workflows.generator.sessions.create"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-workflow-generator-routes.ts wires default/live workflow generator session routes to TS_RUNTIME_WORKFLOW_GENERATOR_RETIRED before invoking the TypeScript workflowGenerator service; legacy generator behavior is reachable only through explicit allowTestOnlyWorkflowGeneratorExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned workflow generator entrypoint when available."
+    },
+    {
+      "id": "workflows_generator_sessions_get",
+      "route": {
+        "method": "GET",
+        "path": "/v1/workflows/generator/sessions/:sessionId",
+        "operationId": "workflows.generator.sessions.get"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-workflow-generator-routes.ts wires default/live workflow generator session reads to TS_RUNTIME_WORKFLOW_GENERATOR_RETIRED before reading TypeScript generator session state; legacy generator reads are reachable only through explicit allowTestOnlyWorkflowGeneratorExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned redacted workflow generator session projection when available."
+    },
+    {
+      "id": "workflows_generator_sessions_messages_create",
+      "route": {
+        "method": "POST",
+        "path": "/v1/workflows/generator/sessions/:sessionId/messages",
+        "operationId": "workflows.generator.sessions.messages.create"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-workflow-generator-routes.ts wires default/live workflow generator message submission to TS_RUNTIME_WORKFLOW_GENERATOR_RETIRED before invoking the TypeScript workflowGenerator service; legacy generator behavior is reachable only through explicit allowTestOnlyWorkflowGeneratorExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned workflow generator turn entrypoint when available."
+    },
+    {
+      "id": "workflows_generator_sessions_generate",
+      "route": {
+        "method": "POST",
+        "path": "/v1/workflows/generator/sessions/:sessionId/generate",
+        "operationId": "workflows.generator.sessions.generate"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-workflow-generator-routes.ts wires default/live workflow draft generation to TS_RUNTIME_WORKFLOW_GENERATOR_RETIRED before invoking the TypeScript workflowGenerator service; legacy generator behavior is reachable only through explicit allowTestOnlyWorkflowGeneratorExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned workflow draft generation entrypoint when available."
+    },
+    {
+      "id": "workflows_generator_sessions_evidence_get",
+      "route": {
+        "method": "GET",
+        "path": "/v1/workflows/generator/sessions/:sessionId/evidence",
+        "operationId": "workflows.generator.sessions.evidence.get"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-workflow-generator-routes.ts wires default/live workflow generator evidence reads to TS_RUNTIME_WORKFLOW_GENERATOR_RETIRED before reading TypeScript generator evidence state; legacy generator evidence reads are reachable only through explicit allowTestOnlyWorkflowGeneratorExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned redacted workflow generator evidence projection when available."
+    },
+    {
+      "id": "workflows_generator_sessions_approve",
+      "route": {
+        "method": "POST",
+        "path": "/v1/workflows/generator/sessions/:sessionId/approve",
+        "operationId": "workflows.generator.sessions.approve"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-workflow-generator-routes.ts wires default/live generated workflow approval to TS_RUNTIME_WORKFLOW_GENERATOR_RETIRED before reading evidence, publishing through TypeScript Workflow CRUD, or recording observability; legacy generator approval is reachable only through explicit allowTestOnlyWorkflowGeneratorExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned generated workflow approval entrypoint when available."
+    },
+    {
+      "id": "workflows_generator_sessions_cancel",
+      "route": {
+        "method": "DELETE",
+        "path": "/v1/workflows/generator/sessions/:sessionId",
+        "operationId": "workflows.generator.sessions.cancel"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-workflow-generator-routes.ts wires default/live workflow generator cancellation to TS_RUNTIME_WORKFLOW_GENERATOR_RETIRED before invoking the TypeScript workflowGenerator service; legacy generator cancellation is reachable only through explicit allowTestOnlyWorkflowGeneratorExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned workflow generator cancellation entrypoint when available."
+    },
+    {
       "id": "autofix_run_ready",
       "route": {
         "method": "POST",

--- a/src/api/http/routes/friday-workflow-generator-routes.ts
+++ b/src/api/http/routes/friday-workflow-generator-routes.ts
@@ -32,6 +32,26 @@ const WORKFLOW_GENERATOR_PUBLICATION_BOUNDARY: FridayWorkflowGeneratorPublicatio
 export interface FridayWorkflowGeneratorRoutesDeps {
   workflowGenerator: FridayWorkflowGeneratorService;
   observability?: FridayObservabilityApiService;
+  /**
+   * Test-oracle only: allows legacy TypeScript workflow generator sessions in
+   * isolated validation. Default/live runtime must leave generator sessions
+   * fail-closed until Rust owns workflow generator truth.
+   */
+  allowTestOnlyWorkflowGeneratorExecution?: boolean;
+}
+
+function throwRetiredWorkflowGeneratorExecution(): never {
+  throw new FridayDomainError(
+    "TS_RUNTIME_WORKFLOW_GENERATOR_RETIRED",
+    "TypeScript workflow generator sessions are retired in default/live runtime; use the Rust-owned workflow generator entrypoint.",
+    {
+      httpStatus: 503,
+      details: {
+        classification: "fail_closed",
+        replacement: "rust_owned_workflow_generator_entrypoint_required",
+      },
+    },
+  );
 }
 
 function buildTenantContext(principal: unknown, fallbackUserId: string, fallbackChannel: string): FridayProviderTenantContext {
@@ -250,6 +270,12 @@ export function createFridayWorkflowGeneratorRoutes(
     }
   }
 
+  function assertWorkflowGeneratorTestOracleAllowed(): void {
+    if (deps.allowTestOnlyWorkflowGeneratorExecution !== true) {
+      throwRetiredWorkflowGeneratorExecution();
+    }
+  }
+
   return [
     // 1. Create session
     {
@@ -259,6 +285,7 @@ export function createFridayWorkflowGeneratorRoutes(
       auth: { public: true },
       rateLimitPolicyId: "generator.write",
       async handler(ctx): Promise<FridayWorkflowGeneratorStartSessionResponse> {
+        assertWorkflowGeneratorTestOracleAllowed();
         const bound = assertWorkflowGeneratorPrincipal(ctx.principal ?? null, "workflow.generator.session.create");
         validateCreateSessionBody(ctx.body);
         const body = ctx.body;
@@ -303,6 +330,7 @@ export function createFridayWorkflowGeneratorRoutes(
       path: "/v1/workflows/generator/sessions/:sessionId",
       auth: { public: true },
       async handler(ctx): Promise<FridayWorkflowGeneratorGetSessionResponse> {
+        assertWorkflowGeneratorTestOracleAllowed();
         const { sessionId } = ctx.params as { sessionId: string };
         const result = await workflowGenerator.getSession(sessionId);
         if (!result) {
@@ -324,6 +352,7 @@ export function createFridayWorkflowGeneratorRoutes(
       auth: { public: true },
       rateLimitPolicyId: "generator.llm",
       async handler(ctx): Promise<FridayWorkflowGeneratorSubmitMessageResponse> {
+        assertWorkflowGeneratorTestOracleAllowed();
         const { sessionId } = ctx.params as { sessionId: string };
         const bound = assertWorkflowGeneratorPrincipal(ctx.principal ?? null, "workflow.generator.message.create");
         await assertSessionOwner(sessionId, bound);
@@ -352,6 +381,7 @@ export function createFridayWorkflowGeneratorRoutes(
       auth: { public: true },
       rateLimitPolicyId: "generator.llm",
       async handler(ctx): Promise<FridayWorkflowGeneratorGenerateResponse> {
+        assertWorkflowGeneratorTestOracleAllowed();
         const { sessionId } = ctx.params as { sessionId: string };
         const bound = assertWorkflowGeneratorPrincipal(ctx.principal ?? null, "workflow.generator.generate");
         await assertSessionOwner(sessionId, bound);
@@ -407,6 +437,7 @@ export function createFridayWorkflowGeneratorRoutes(
       path: "/v1/workflows/generator/sessions/:sessionId/evidence",
       auth: { public: true },
       async handler(ctx): Promise<FridayWorkflowGeneratorEvidenceResponse> {
+        assertWorkflowGeneratorTestOracleAllowed();
         const { sessionId } = ctx.params as { sessionId: string };
         const evidence = await buildEvidence(sessionId);
         return { evidence };
@@ -421,6 +452,7 @@ export function createFridayWorkflowGeneratorRoutes(
       auth: { public: true },
       rateLimitPolicyId: "workflow.publish",
       async handler(ctx): Promise<FridayWorkflowGeneratorApproveResponse> {
+        assertWorkflowGeneratorTestOracleAllowed();
         const { sessionId } = ctx.params as { sessionId: string };
         const bound = assertWorkflowGeneratorPrincipal(ctx.principal ?? null, "workflow.generator.approve");
         await assertSessionOwner(sessionId, bound);
@@ -477,6 +509,7 @@ export function createFridayWorkflowGeneratorRoutes(
       path: "/v1/workflows/generator/sessions/:sessionId",
       auth: { public: true },
       async handler(ctx): Promise<FridayWorkflowGeneratorCancelResponse> {
+        assertWorkflowGeneratorTestOracleAllowed();
         const { sessionId } = ctx.params as { sessionId: string };
         const bound = assertWorkflowGeneratorPrincipal(ctx.principal ?? null, "workflow.generator.cancel");
         await assertSessionOwner(sessionId, bound);

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -3058,6 +3058,7 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
   if (deps.workflowGenerator) {
     for (const route of createFridayWorkflowGeneratorRoutes({
       workflowGenerator: deps.workflowGenerator,
+      allowTestOnlyWorkflowGeneratorExecution: deps.allowTestOnlyWorkflowGeneratorExecution,
     })) {
       routes.register(route);
     }

--- a/src/api/runtime/friday-api-runtime.types.ts
+++ b/src/api/runtime/friday-api-runtime.types.ts
@@ -220,6 +220,13 @@ export interface CreateFridayApiRuntimeDeps {
    * cancel routes remain fail-closed until Rust owns generator truth.
    */
   allowTestOnlySkillGeneratorExecution?: boolean;
+  /**
+   * Test-oracle only: allows legacy TypeScript workflow generator sessions in
+   * isolated mock/unit validation. Production/runtime callers must leave this
+   * unset so workflow generator session routes remain fail-closed until Rust
+   * owns generator truth.
+   */
+  allowTestOnlyWorkflowGeneratorExecution?: boolean;
   /** Optional: user/project prompt-guidance provider for fallback workflow runtime creation. */
   userRulesContextProvider?: CreateFridayWorkflowRuntimeDeps["userRulesContextProvider"];
   /** Optional: reuse hub's session service instead of creating a new one. */

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -1856,6 +1856,8 @@ export interface FridayHubConfig {
   allowTestOnlySkillVerifyExecution?: boolean;
   /** Test-oracle only; production hub creation must leave skill generator sessions fail-closed. */
   allowTestOnlySkillGeneratorExecution?: boolean;
+  /** Test-oracle only; production hub creation must leave workflow generator sessions fail-closed. */
+  allowTestOnlyWorkflowGeneratorExecution?: boolean;
   /** Test-oracle only; production hub creation must leave auto-fix execution fail-closed. */
   allowTestOnlyAutoFixExecution?: boolean;
   /** Test-oracle only; production hub creation must leave desktop action execution fail-closed. */

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -6898,6 +6898,7 @@ export async function createFridayHub(
     allowTestOnlySkillRunExecution: config.allowTestOnlySkillRunExecution,
     allowTestOnlySkillVerifyExecution: config.allowTestOnlySkillVerifyExecution,
     allowTestOnlySkillGeneratorExecution: config.allowTestOnlySkillGeneratorExecution,
+    allowTestOnlyWorkflowGeneratorExecution: config.allowTestOnlyWorkflowGeneratorExecution,
     agentRuntime,
     allowTestOnlyAgentRunStartExecution: config.allowTestOnlyAgentRunStartExecution,
     allowTestOnlyAgentRunControlExecution: config.allowTestOnlyAgentRunControlExecution,

--- a/test/e2e/api/_helpers/friday-api-test-server.helper.ts
+++ b/test/e2e/api/_helpers/friday-api-test-server.helper.ts
@@ -155,6 +155,12 @@ export interface CreateFridayApiTestEnvOptions {
    */
   allowTestOnlySkillGeneratorExecution?: boolean;
   /**
+   * Test-oracle opt-in for legacy TS workflow generator sessions. Default/live
+   * runtime leaves generator session routes fail-closed while Rust ownership
+   * lands.
+   */
+  allowTestOnlyWorkflowGeneratorExecution?: boolean;
+  /**
    * Test-oracle opt-in for legacy TS auto-fix execution. Default/live runtime
    * leaves auto-fix run/execute/rollback surfaces fail-closed while Rust ownership lands.
    */
@@ -267,6 +273,7 @@ export async function createFridayApiTestEnv(
     allowTestOnlySkillRunExecution: options.allowTestOnlySkillRunExecution ?? true,
     allowTestOnlySkillVerifyExecution: options.allowTestOnlySkillVerifyExecution ?? true,
     allowTestOnlySkillGeneratorExecution: options.allowTestOnlySkillGeneratorExecution ?? true,
+    allowTestOnlyWorkflowGeneratorExecution: options.allowTestOnlyWorkflowGeneratorExecution ?? true,
     computeChecksum: (content: string) =>
       crypto.createHash("sha256").update(content).digest("hex"),
     resolveSkill: options.resolveSkill ?? ((_skillId: string) => ({ id: _skillId })),

--- a/test/e2e/friday-full-e2e.test.ts
+++ b/test/e2e/friday-full-e2e.test.ts
@@ -124,6 +124,7 @@ describe.skipIf(!CORE_E2E_ENABLED)("Friday Full E2E — Batch 1 (A–F)", () => 
       logRequests: false,
       allowTestOnlyWorkflowRunExecution: true,
       allowTestOnlySkillGeneratorExecution: true,
+      allowTestOnlyWorkflowGeneratorExecution: true,
     });
     await hub.start();
 

--- a/test/e2e/mock/_helpers/mock-env.ts
+++ b/test/e2e/mock/_helpers/mock-env.ts
@@ -336,6 +336,8 @@ export async function createMockHubEnv(opts?: {
   allowTestOnlySkillVerifyExecution?: boolean;
   /** Test-oracle opt-in for legacy TS skill generator sessions; set false to prove default fail-closed behavior. */
   allowTestOnlySkillGeneratorExecution?: boolean;
+  /** Test-oracle opt-in for legacy TS workflow generator sessions; set false to prove default fail-closed behavior. */
+  allowTestOnlyWorkflowGeneratorExecution?: boolean;
   /** Test-oracle opt-in for legacy TS agent-run execution; set false to prove default fail-closed behavior. */
   allowTestOnlyAgentRunStartExecution?: boolean;
   /** Test-oracle opt-in for legacy TS agent-run controls; set false to prove default fail-closed behavior. */
@@ -385,6 +387,7 @@ export async function createMockHubEnv(opts?: {
       allowTestOnlySkillRunExecution: opts?.allowTestOnlySkillRunExecution ?? true,
       allowTestOnlySkillVerifyExecution: opts?.allowTestOnlySkillVerifyExecution ?? true,
       allowTestOnlySkillGeneratorExecution: opts?.allowTestOnlySkillGeneratorExecution ?? true,
+      allowTestOnlyWorkflowGeneratorExecution: opts?.allowTestOnlyWorkflowGeneratorExecution ?? true,
       allowTestOnlyAgentRunStartExecution: opts?.allowTestOnlyAgentRunStartExecution ?? true,
       allowTestOnlyAgentRunControlExecution: opts?.allowTestOnlyAgentRunControlExecution ?? true,
       // Allow private-network targets so mock E2E tests don't require DNS resolution

--- a/test/unit/api/http/routes/friday-workflow-generator-routes.test.ts
+++ b/test/unit/api/http/routes/friday-workflow-generator-routes.test.ts
@@ -134,6 +134,31 @@ describe("FridayWorkflowGeneratorRoutes", () => {
   const service = makeMockService();
   const routes = createFridayWorkflowGeneratorRoutes({
     workflowGenerator: service,
+    allowTestOnlyWorkflowGeneratorExecution: true,
+  });
+
+  it("fail-closes workflow generator sessions by default without invoking the TypeScript generator", async () => {
+    const localService = makeMockService();
+    const localRoutes = createFridayWorkflowGeneratorRoutes({
+      workflowGenerator: localService,
+    });
+    const createRoute = localRoutes.find((r) => r.operationId === "workflows.generator.sessions.create")!;
+
+    await expect(
+      createRoute.handler(
+        makeCtx({
+          body: { goal: "Build workflow", userId: "u-1", channel: "test" },
+        }) as never,
+      ),
+    ).rejects.toMatchObject({
+      code: "TS_RUNTIME_WORKFLOW_GENERATOR_RETIRED",
+      httpStatus: 503,
+      details: {
+        classification: "fail_closed",
+        replacement: "rust_owned_workflow_generator_entrypoint_required",
+      },
+    });
+    expect(localService.startSession).not.toHaveBeenCalled();
   });
 
   it("creates exactly 7 routes", () => {
@@ -210,7 +235,10 @@ describe("FridayWorkflowGeneratorRoutes", () => {
     ["workflows.generator.sessions.cancel", { params: { sessionId: "s-1" }, body: {} }],
   ])("%s rejects synthetic public principals from generator mutations", async (operationId, ctxOverrides) => {
     const localService = makeMockService();
-    const localRoutes = createFridayWorkflowGeneratorRoutes({ workflowGenerator: localService });
+    const localRoutes = createFridayWorkflowGeneratorRoutes({
+      workflowGenerator: localService,
+      allowTestOnlyWorkflowGeneratorExecution: true,
+    });
     const route = localRoutes.find((r) => r.operationId === operationId)!;
     await expect(
       route.handler(makeCtx({


### PR DESCRIPTION
## Summary

- Fail-close the default/live workflow generator session HTTP surfaces before they can execute the retired TS workflow generator service.
- Preserve legacy workflow generator execution only behind the explicit `allowTestOnlyWorkflowGeneratorExecution` test-oracle opt-in used by focused tests and isolated e2e helpers.
- Update the TS runtime retirement manifest so the 7 workflow generator session surfaces move from `ts_runtime_blocker` to `fail_closed`.

## Safe batch rationale

This PR intentionally batches one same-family slice: workflow generator session routes in `friday-workflow-generator-routes.ts`, all with the same runtime behavior, same adapter flag, and same manifest classification. It does not combine unrelated desktop/provider/release/pet/design surfaces.

## Verification

- `jq empty docs/ops/ts-runtime-retirement-manifest.json && npx vitest run test/unit/api/http/routes/friday-workflow-generator-routes.test.ts test/unit/api/runtime/friday-api-runtime-workflow-generator-registration.test.ts test/unit/quality/ts-runtime-retirement-gate.test.ts`
- `npm run check:ts-runtime-retirement`
  - 584 routes
  - 199 `ts_runtime_blocker`
  - 45 `fail_closed`
  - 231 `compat_shim`
- `npx vitest run test/unit/api/http/routes/friday-api-audit-fixes.test.ts test/e2e/friday-full-e2e.test.ts test/e2e/friday-real-scenarios-e2e.test.ts`
- `FRIDAY_E2E_CORE=1 npx vitest run test/e2e/friday-full-e2e.test.ts test/e2e/friday-real-scenarios-e2e.test.ts`
- `npm run build`
- `git diff --check`
- `npm run check:secret-patterns`
- `npm run lint` passed with existing warnings and 0 errors
- `detect-secrets-hook --baseline .secrets.baseline $(git ls-files)`
- `FRIDAY_E2E_CORE=1 npm test`
- `npm run test:e2e:ui`

## Guardrails

- No default machine DB mutation.
- No pet/design-gallery edits.
- No fake Rust delegation, fixture fallback, mock closure, or synthetic proof.
- No `provider_native_synced` claim.
- Not Friday v1 GO.
- Not provider-native/remote proof.
- Not release/App Store/TestFlight/signing.