### PR TITLE
Fail close workflow bundle import and redact workflow catalog/builder reads

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -1101,6 +1101,91 @@
       "next_action": "Replace fail-closed response with a Rust-owned workflow deployment entrypoint when available."
     },
     {
+      "id": "workflows_bundles_import",
+      "route": {
+        "method": "POST",
+        "path": "/v1/workflows/:workflowId/import",
+        "operationId": "workflows.bundles.import"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-workflow-builder-routes.ts wires default/live workflows.bundles.import to TS_RUNTIME_WORKFLOW_BUNDLE_IMPORT_RETIRED before principal authority checks or calling the TypeScript importWorkflowBundle service; legacy behavior is reachable only through explicit allowTestOnlyWorkflowBundleImportExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned workflow bundle import entrypoint when available."
+    },
+    {
+      "id": "workflows_list_compat",
+      "route": {
+        "method": "GET",
+        "path": "/v1/workflows",
+        "operationId": "workflows.list"
+      },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Keep workflow catalog list as a bounded redacted compatibility projection while TypeScript workflow catalog mutations are fail-closed or moved to Rust-owned product truth. src/api/runtime/friday-api-runtime.ts maps each workflow through sanitizePublicWorkflowEntity, which drops ownerUserId, lastVerifiedProviderModel, lastVerifiedRuntimeVersion, shadowVersionId, and deletedBy; this read owns no product truth and cannot create, update, publish, or mark workflow completion.",
+      "next_action": "Replace this compatibility read with a Rust-owned redacted workflow catalog projection when available."
+    },
+    {
+      "id": "workflows_get_compat",
+      "route": {
+        "method": "GET",
+        "path": "/v1/workflows/:workflowId",
+        "operationId": "workflows.get"
+      },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Keep workflow detail read as a bounded redacted compatibility projection. src/api/runtime/friday-api-runtime.ts maps the workflow through sanitizePublicWorkflowEntity and each version through sanitizePublicWorkflowVersion, which redacts the raw graphJson (commands/secrets) to a bounded shape summary and drops createdByUserId; this read owns no product truth.",
+      "next_action": "Replace this compatibility read with a Rust-owned redacted workflow detail projection when available."
+    },
+    {
+      "id": "workflows_list_versions_compat",
+      "route": {
+        "method": "GET",
+        "path": "/v1/workflows/:workflowId/versions",
+        "operationId": "workflows.list.versions"
+      },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Keep workflow version list as a bounded redacted compatibility projection. src/api/runtime/friday-api-runtime.ts maps each version through sanitizePublicWorkflowVersion, which redacts the raw graphJson to a bounded shape summary and drops createdByUserId; this read owns no product truth.",
+      "next_action": "Replace this compatibility read with a Rust-owned redacted workflow version projection when available."
+    },
+    {
+      "id": "workflow_versions_get_compat",
+      "route": {
+        "method": "GET",
+        "path": "/v1/workflow-versions/:versionId",
+        "operationId": "workflow.versions.get"
+      },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Keep workflow version detail read as a bounded redacted compatibility projection. src/api/runtime/friday-api-runtime.ts maps the version through sanitizePublicWorkflowVersion, which redacts the raw graphJson to a bounded shape summary and drops createdByUserId; this read owns no product truth.",
+      "next_action": "Replace this compatibility read with a Rust-owned redacted workflow version projection when available."
+    },
+    {
+      "id": "workflows_overview_compat",
+      "route": {
+        "method": "GET",
+        "path": "/v1/workflows/:workflowId/overview",
+        "operationId": "workflows.overview"
+      },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Keep workflow overview as a bounded redacted compatibility projection. src/api/runtime/friday-api-runtime.ts wraps the product service with sanitizePublicWorkflowOverview, which redacts workflow/version/draft graph and spec config, run trigger payloads/context/failure detail, node-timeline messages, and evidence export artifact ids/paths, and drops owner/creator user ids; this read owns no product truth and cannot mark workflow completion.",
+      "next_action": "Replace this compatibility read with a Rust-owned redacted workflow overview projection when available."
+    },
+    {
+      "id": "workflows_visualization_compat",
+      "route": {
+        "method": "GET",
+        "path": "/v1/workflows/:workflowId/visualization",
+        "operationId": "workflows.visualization"
+      },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Keep workflow visualization as a bounded redacted compatibility projection. src/api/runtime/friday-api-runtime.ts wraps the product service with sanitizePublicWorkflowVisualization, which redacts raw spec step args/test cases and version graphJson, run trigger payloads/context/failure detail, node-timeline messages, and evidence export artifact ids/paths while keeping pure canvas layout; this read owns no product truth and cannot mark workflow completion.",
+      "next_action": "Replace this compatibility read with a Rust-owned redacted workflow visualization projection when available."
+    },
+    {
       "id": "autofix_run_ready",
       "route": {
         "method": "POST",

--- a/src/api/http/routes/friday-workflow-builder-routes.ts
+++ b/src/api/http/routes/friday-workflow-builder-routes.ts
@@ -1,3 +1,4 @@
+import { FridayDomainError } from "#errors";
 import type {
   FridayAuthPrincipal,
   FridayPaginationQuery,
@@ -120,6 +121,33 @@ export interface FridayWorkflowBuilderRoutesDeps {
     input: FridayReleaseWorkflowLockRequest,
     principal: FridayAuthPrincipal | null,
   ) => FridayReleaseWorkflowLockResponse;
+  /**
+   * Test-oracle only: allows the legacy TypeScript workflow bundle import
+   * mutation in isolated route/runtime validation. Default/live runtime must
+   * leave bundle import fail-closed until Rust owns workflow bundle import
+   * truth.
+   */
+  allowTestOnlyWorkflowBundleImportExecution?: boolean;
+}
+
+function throwRetiredWorkflowBundleImport(): never {
+  throw new FridayDomainError(
+    "TS_RUNTIME_WORKFLOW_BUNDLE_IMPORT_RETIRED",
+    "TypeScript workflow bundle import is retired in default/live runtime; use the Rust-owned workflow bundle import entrypoint.",
+    {
+      httpStatus: 503,
+      details: {
+        classification: "fail_closed",
+        replacement: "rust_owned_workflow_bundle_import_entrypoint_required",
+      },
+    },
+  );
+}
+
+function assertWorkflowBundleImportTestOracleAllowed(deps: FridayWorkflowBuilderRoutesDeps): void {
+  if (deps.allowTestOnlyWorkflowBundleImportExecution !== true) {
+    throwRetiredWorkflowBundleImport();
+  }
 }
 
 export function createFridayWorkflowBuilderRoutes(
@@ -173,6 +201,7 @@ export function createFridayWorkflowBuilderRoutes(
       path: "/v1/workflows/:workflowId/import",
       auth: { public: true },
       async handler(ctx) {
+        assertWorkflowBundleImportTestOracleAllowed(deps);
         assertWorkflowBuilderWritePrincipal(ctx.principal ?? null, "workflow.bundle.import");
         const { workflowId } = ctx.params as { workflowId: UUID };
         return deps.importWorkflowBundle(workflowId, ctx.body as FridayImportWorkflowBundleRequest);

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -27,6 +27,8 @@ import {
   listFridayStableWorkflowTemplates,
 } from "#workflows";
 import type {
+  FridayWorkflowDraftEntity,
+  FridayWorkflowEntity,
   FridayWorkflowEvidenceEvent,
   FridayWorkflowPlaybookEvidenceTrace,
   FridayWorkflowRetryEvidenceTrace,
@@ -35,6 +37,8 @@ import type {
   FridayWorkflowRunEvidenceExportRecord,
   FridayWorkflowRunEvidenceResponse,
   FridayWorkflowRunNodeEntity,
+  FridayWorkflowSpecV1,
+  FridayWorkflowVersionEntity,
   JsonObject,
 } from "#workflows";
 
@@ -203,6 +207,8 @@ import type { FridayRole } from "../model/friday-api-auth.types.js";
 import type {
   FridayGetRunEvidenceQuery,
   FridayRunTimelineEntry,
+  FridayWorkflowOverview,
+  FridayWorkflowVisualization,
 } from "../model/friday-api-workflow.types.js";
 import { createFridayDeepLinkApplyService } from "./friday-deep-link-apply-service.js";
 import { installFridayApiRuntimeBaseRoutes } from "./friday-api-runtime-base-routes.js";
@@ -385,6 +391,172 @@ function sanitizePublicWorkflowEvidenceExportRecord(
   return {
     export: sanitizePublicWorkflowEvidenceExport(record.export),
     evidence: sanitizePublicWorkflowEvidence(record.evidence),
+  };
+}
+
+// ─── Workflow catalog/builder compatibility read projections ───
+//
+// These bounded redacted projections back the `compat_shim` classification for
+// the workflow catalog/builder read surfaces (`workflows.list`, `workflows.get`,
+// `workflows.list.versions`, `workflow.versions.get`, `workflows.overview`,
+// `workflows.visualization`). They are not authoritative: the authoritative
+// workflow graph/version/draft truth must move to a Rust-owned entrypoint. Each
+// projection drops private user ids, provider/runtime model fields, and raw
+// graph/spec config (which can carry commands or secrets), so the compatibility
+// read cannot leak `requiredLeakControls` data.
+
+function sanitizePublicWorkflowEntity(workflow: FridayWorkflowEntity): FridayWorkflowEntity {
+  return {
+    id: workflow.id,
+    slug: workflow.slug,
+    name: workflow.name,
+    description: workflow.description,
+    tags: workflow.tags,
+    latestVersionNumber: workflow.latestVersionNumber,
+    publishedVersionNumber: workflow.publishedVersionNumber,
+    isArchived: workflow.isArchived,
+    revision: workflow.revision,
+    etag: workflow.etag,
+    lastVerifiedAt: workflow.lastVerifiedAt,
+    compatibilityStatus: workflow.compatibilityStatus,
+    promotionChannel: workflow.promotionChannel,
+    canaryStats: workflow.canaryStats,
+    createdAt: workflow.createdAt,
+    updatedAt: workflow.updatedAt,
+    deletedAt: workflow.deletedAt,
+  };
+}
+
+function sanitizePublicWorkflowVersion(version: FridayWorkflowVersionEntity): FridayWorkflowVersionEntity {
+  return {
+    id: version.id,
+    workflowId: version.workflowId,
+    versionNumber: version.versionNumber,
+    checksum: version.checksum,
+    graphJson: {
+      redacted: true,
+      shape: summarizePublicJsonShape(version.graphJson),
+    },
+    isPublished: version.isPublished,
+    changeNote: version.changeNote,
+    createdAt: version.createdAt,
+    updatedAt: version.updatedAt,
+  };
+}
+
+function sanitizePublicWorkflowSpec(spec: FridayWorkflowSpecV1): FridayWorkflowSpecV1 {
+  return {
+    schemaVersion: spec.schemaVersion,
+    workflowId: spec.workflowId,
+    name: spec.name,
+    description: spec.description,
+    startStepId: spec.startStepId,
+    trigger: spec.trigger,
+    inputs: spec.inputs.map((input) => ({
+      key: input.key,
+      type: input.type,
+      required: input.required,
+    })),
+    steps: spec.steps.map((step) => ({
+      id: step.id,
+      type: step.type,
+      ref: step.ref,
+      condition: step.condition,
+      timeoutSec: step.timeoutSec,
+      retry: step.retry,
+    })),
+    edges: spec.edges.map((edge) => ({
+      from: edge.from,
+      to: edge.to,
+      when: edge.when,
+    })),
+    outputs: spec.outputs.map((output) => ({
+      key: output.key,
+      fromStep: output.fromStep,
+      path: output.path,
+    })),
+    errorPolicy: spec.errorPolicy,
+    tests: [],
+  };
+}
+
+function sanitizePublicWorkflowDraft(draft: FridayWorkflowDraftEntity): FridayWorkflowDraftEntity {
+  return {
+    draftId: draft.draftId,
+    workflowId: draft.workflowId,
+    title: draft.title,
+    status: draft.status,
+    revision: draft.revision,
+    baseWorkflowVersionId: draft.baseWorkflowVersionId,
+    spec: sanitizePublicWorkflowSpec(draft.spec),
+    visual: draft.visual,
+    createdAt: draft.createdAt,
+    updatedAt: draft.updatedAt,
+    publishedVersionId: draft.publishedVersionId,
+    autosave: draft.autosave,
+    sourceReview: draft.sourceReview
+      ? {
+        source: draft.sourceReview.source,
+        importedAt: draft.sourceReview.importedAt,
+        requiresReviewBeforePublish: draft.sourceReview.requiresReviewBeforePublish,
+      }
+      : undefined,
+  };
+}
+
+function sanitizePublicWorkflowNodeTimeline(
+  timeline: FridayWorkflowOverview["latestRunNodeTimeline"],
+): FridayWorkflowOverview["latestRunNodeTimeline"] {
+  return timeline.map((entry) => ({
+    nodeId: entry.nodeId,
+    attempt: entry.attempt,
+    status: entry.status,
+    finishedAt: entry.finishedAt,
+    message: entry.message !== undefined ? "redacted" : undefined,
+  }));
+}
+
+function sanitizePublicWorkflowOverview(overview: FridayWorkflowOverview): FridayWorkflowOverview {
+  return {
+    workflow: sanitizePublicWorkflowEntity(overview.workflow),
+    latestVersion: overview.latestVersion
+      ? sanitizePublicWorkflowVersion(overview.latestVersion)
+      : undefined,
+    publishedVersion: overview.publishedVersion
+      ? sanitizePublicWorkflowVersion(overview.publishedVersion)
+      : undefined,
+    drafts: overview.drafts.map(sanitizePublicWorkflowDraft),
+    latestDraft: overview.latestDraft
+      ? sanitizePublicWorkflowDraft(overview.latestDraft)
+      : undefined,
+    recentRuns: overview.recentRuns.map(sanitizePublicWorkflowRun),
+    latestRun: overview.latestRun ? sanitizePublicWorkflowRun(overview.latestRun) : undefined,
+    latestRunNodeTimeline: sanitizePublicWorkflowNodeTimeline(overview.latestRunNodeTimeline),
+    latestEvidenceExports: overview.latestEvidenceExports.map(sanitizePublicWorkflowEvidenceExport),
+    versionHistory: overview.versionHistory.map(sanitizePublicWorkflowVersion),
+  };
+}
+
+function sanitizePublicWorkflowVisualization(
+  visualization: FridayWorkflowVisualization,
+): FridayWorkflowVisualization {
+  return {
+    workflow: sanitizePublicWorkflowEntity(visualization.workflow),
+    targetKind: visualization.targetKind,
+    draft: visualization.draft ? sanitizePublicWorkflowDraft(visualization.draft) : undefined,
+    version: visualization.version
+      ? sanitizePublicWorkflowVersion(visualization.version)
+      : undefined,
+    spec: sanitizePublicWorkflowSpec(visualization.spec),
+    visual: visualization.visual,
+    latestRun: visualization.latestRun
+      ? sanitizePublicWorkflowRun(visualization.latestRun)
+      : undefined,
+    recentRuns: visualization.recentRuns.map(sanitizePublicWorkflowRun),
+    nodeTimeline: sanitizePublicWorkflowNodeTimeline(visualization.nodeTimeline),
+    latestEvidenceExports: visualization.latestEvidenceExports.map(
+      sanitizePublicWorkflowEvidenceExport,
+    ),
   };
 }
 
@@ -1883,7 +2055,7 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
         cursor: query.cursor,
         limit: query.limit,
       });
-      return { items: workflows };
+      return { items: workflows.map(sanitizePublicWorkflowEntity) };
     },
     createWorkflow: (input) => {
       return workflowRuntime.crud.createWorkflowWithVersion(
@@ -1908,7 +2080,13 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
       }
       const publishedVersion =
         workflowRuntime.crud.getPublishedVersion(workflowId) ?? undefined;
-      return { workflow, latestVersion, publishedVersion };
+      return {
+        workflow: sanitizePublicWorkflowEntity(workflow),
+        latestVersion: sanitizePublicWorkflowVersion(latestVersion),
+        publishedVersion: publishedVersion
+          ? sanitizePublicWorkflowVersion(publishedVersion)
+          : undefined,
+      };
     },
     updateWorkflow: (workflowId, input) => {
       const updateInput = {
@@ -1941,7 +2119,7 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
         workflowId,
         query.limit,
       );
-      return { items: versions };
+      return { items: versions.map(sanitizePublicWorkflowVersion) };
     },
     getVersion: (versionId) => {
       const version = workflowRuntime.crud.getVersion(versionId);
@@ -1950,7 +2128,7 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
           httpStatus: 404,
         });
       }
-      return { version };
+      return { version: sanitizePublicWorkflowVersion(version) };
     },
   })) {
     routes.register(route);
@@ -2017,6 +2195,7 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
   }
 
   for (const route of createFridayWorkflowBuilderRoutes({
+    allowTestOnlyWorkflowBundleImportExecution: deps.allowTestOnlyWorkflowBundleImportExecution,
     createDraft: (workflowId, input) => {
       const draft = builderRuntime.drafts.createDraft({
         workflowId,
@@ -2169,7 +2348,13 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
   }
 
   for (const route of createFridayWorkflowProductRoutes({
-    service: workflowProductService,
+    service: {
+      ...workflowProductService,
+      getOverview: (input) =>
+        sanitizePublicWorkflowOverview(workflowProductService.getOverview(input)),
+      getVisualization: (input) =>
+        sanitizePublicWorkflowVisualization(workflowProductService.getVisualization(input)),
+    },
     allowTestOnlyWorkflowDeployExecution: deps.allowTestOnlyWorkflowDeployExecution,
   })) {
     routes.register(route);

--- a/src/api/runtime/friday-api-runtime.types.ts
+++ b/src/api/runtime/friday-api-runtime.types.ts
@@ -241,6 +241,13 @@ export interface CreateFridayApiRuntimeDeps {
    * truth.
    */
   allowTestOnlyWorkflowDeployExecution?: boolean;
+  /**
+   * Test-oracle only: allows the legacy TypeScript workflow bundle import
+   * mutation in isolated mock/unit validation. Production/runtime callers must
+   * leave this unset so `POST /v1/workflows/:workflowId/import` stays
+   * fail-closed until Rust owns workflow bundle import truth.
+   */
+  allowTestOnlyWorkflowBundleImportExecution?: boolean;
   /** Optional: user/project prompt-guidance provider for fallback workflow runtime creation. */
   userRulesContextProvider?: CreateFridayWorkflowRuntimeDeps["userRulesContextProvider"];
   /** Optional: reuse hub's session service instead of creating a new one. */

--- a/test/unit/api/http/routes/friday-workflow-builder-routes.test.ts
+++ b/test/unit/api/http/routes/friday-workflow-builder-routes.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   createFridayWorkflowBuilderRoutes,
   createFridayWorkflowBuilderTemplateRoutes,
@@ -72,6 +72,10 @@ describe("FridayWorkflowBuilderRoutes", () => {
     acquireLock: () => ({ acquired: true }),
     renewLock: () => ({ lock: null }),
     releaseLock: () => ({ released: true as const }),
+    // Opt isolated builder route tests into the legacy import oracle so the
+    // shared `routes` fixture still exercises the principal-authority path.
+    // Default/live runtime leaves this unset (proven below).
+    allowTestOnlyWorkflowBundleImportExecution: true,
   };
   const stubTemplateDeps: FridayWorkflowBuilderTemplateRoutesDeps = {
     listTemplates: () => ({ items: [] }),
@@ -178,5 +182,29 @@ describe("FridayWorkflowBuilderRoutes", () => {
     await expect(route.handler(makeCtx({ body: { title: "Draft" } }))).resolves.toEqual({
       draft: stubDraft,
     });
+  });
+
+  it("fail-closes workflows.bundles.import by default and never calls importWorkflowBundle", async () => {
+    const importSpy = vi.fn(() => ({ result: {} as never }));
+    const failClosedRoutes = createFridayWorkflowBuilderRoutes({
+      ...stubDeps,
+      allowTestOnlyWorkflowBundleImportExecution: false,
+      importWorkflowBundle: importSpy,
+    });
+    const route = failClosedRoutes.find((r) => r.operationId === "workflows.bundles.import")!;
+
+    // Guard fires before the principal check, so even a bound workflow writer
+    // is fail-closed in default/live runtime.
+    await expect(
+      route.handler(makeCtx({ body: { bundle: { schemaVersion: "1.0" } } })),
+    ).rejects.toMatchObject({
+      code: "TS_RUNTIME_WORKFLOW_BUNDLE_IMPORT_RETIRED",
+      httpStatus: 503,
+      details: {
+        classification: "fail_closed",
+        replacement: "rust_owned_workflow_bundle_import_entrypoint_required",
+      },
+    });
+    expect(importSpy).not.toHaveBeenCalled();
   });
 });

--- a/test/unit/api/runtime/friday-api-runtime-workflow-catalog-retirement.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-workflow-catalog-retirement.test.ts
@@ -1,0 +1,360 @@
+import { createHash } from "node:crypto";
+
+import { describe, expect, it } from "vitest";
+import { createFridayApiRuntime } from "#api";
+import type { CreateFridayApiRuntimeDeps, FridayAuthPrincipal } from "#api";
+import type { FridayProviderService } from "#providers";
+import type { FridayCompiledWorkflowGraphV2 } from "#workflows";
+import { createTestDb, createTestIdGenerator } from "../../../helpers/friday-test-db.helper.js";
+import {
+  createTestSpec,
+  createTestVisual,
+} from "../../workflows/builder/_helpers/create-test-spec.helper.js";
+
+const NOW = "2026-06-05T00:00:00.000Z";
+
+// Unique markers seeded as raw private/command/secret data so the assertions
+// can prove the redacted compatibility projections never surface them.
+const GRAPH_API_KEY_SECRET = "GRAPH_NODE_API_KEY_SECRET_MARKER"; // pragma: allowlist secret -- test marker, not a real secret
+const GRAPH_COMMAND_SECRET = "rm -rf /tmp/GRAPH_RAW_COMMAND_SECRET_MARKER"; // pragma: allowlist secret -- test marker, not a real secret
+const RUN_TRIGGER_SECRET = "RUN_TRIGGER_PAYLOAD_SECRET_MARKER"; // pragma: allowlist secret -- test marker, not a real secret
+const DRAFT_ARG_SECRET = "DRAFT_STEP_ARG_SECRET_MARKER"; // pragma: allowlist secret -- test marker, not a real secret
+const DRAFT_INPUT_SECRET = "DRAFT_INPUT_DEFAULT_SECRET_MARKER"; // pragma: allowlist secret -- test marker, not a real secret
+const DRAFT_TEST_SECRET = "DRAFT_TEST_CASE_SECRET_MARKER"; // pragma: allowlist secret -- test marker, not a real secret
+const DRAFT_OWNER_SECRET = "draft-owner-user-id-secret-marker"; // pragma: allowlist secret -- test marker, not a real secret
+const DRAFT_SOURCE_URL_SECRET = "https://private-source.example/DRAFT_SOURCE_URL_SECRET_MARKER"; // pragma: allowlist secret -- test marker, not a real secret
+
+function makeProviderService(): FridayProviderService {
+  return {
+    listProviders: async () => [],
+    getProvider: async () => null,
+    createProvider: async () => {
+      throw new Error("not-implemented");
+    },
+    updateProvider: async () => {
+      throw new Error("not-implemented");
+    },
+    deleteProvider: async () => undefined,
+    validateProvider: async () => ({ status: "ok", checkedAt: NOW }),
+    getRoutingConfig: async () => ({ defaultProviderId: "test", fallbackProviderIds: [] }),
+    setRoutingConfig: async (input) => input,
+    resolveRoute: async () => ({
+      provider: {
+        id: "test-provider",
+        kind: "openai",
+        name: "Test Provider",
+        baseUrl: "https://example.test",
+        enabled: true,
+        config: {
+          api: "openai-completions",
+          authMode: "api-key",
+          keySource: { kind: "env-ref", envVar: "OPENAI_API_KEY" },
+          supportedModels: ["gpt-4o-mini"],
+          validation: { status: "ok", checkedAt: NOW },
+        },
+        createdAt: NOW,
+        updatedAt: NOW,
+      },
+      model: "gpt-4o-mini",
+    }),
+    runWithFallback: async () => {
+      throw new Error("not-implemented");
+    },
+  } as FridayProviderService;
+}
+
+function makeDeps(overrides: Partial<CreateFridayApiRuntimeDeps> = {}): CreateFridayApiRuntimeDeps {
+  return {
+    db: createTestDb(),
+    idGenerator: createTestIdGenerator(),
+    nowIso: () => NOW,
+    providerService: makeProviderService(),
+    tokenSecret: "unit-test-token-key", // pragma: allowlist secret
+    computeChecksum: (content: string) => createHash("sha256").update(content).digest("hex"),
+    resolveSkill: () => ({ id: "test-skill" }),
+    invokeSkill: async () => ({ ok: true }),
+    ...overrides,
+  };
+}
+
+// Minimal valid compiled graph whose single node carries raw command/secret
+// data in its `config`. The product service synthesizes spec step `args` from
+// node `config`, so this also exercises spec-arg redaction in visualization.
+function makeGraphWithSecretConfig(workflowId: string): FridayCompiledWorkflowGraphV2 {
+  return {
+    schemaVersion: "2.0",
+    workflowId,
+    workflowVersionId: "placeholder",
+    sourceSpecSchemaVersion: "1.0",
+    graph: {
+      nodes: [
+        {
+          id: "trigger",
+          type: "trigger",
+          label: "Trigger",
+          config: {
+            apiKey: GRAPH_API_KEY_SECRET,
+            command: GRAPH_COMMAND_SECRET,
+          },
+        },
+      ],
+      edges: [],
+    },
+    failurePolicy: { onFailure: "fail_fast", notifyUser: false },
+    tests: [],
+    checksum: "placeholder",
+  };
+}
+
+const ownerPrincipal: FridayAuthPrincipal = {
+  principalType: "user",
+  principalId: "tenant-owner",
+  userId: "test-user",
+  role: "operator",
+  scopes: ["workflow.write", "workflow.read"],
+  tokenId: "token-owner",
+  tokenKind: "access",
+  issuedAt: NOW,
+};
+
+function invoker(runtime: ReturnType<typeof createFridayApiRuntime>) {
+  return (operationId: string, overrides: Record<string, unknown> = {}) => {
+    const route = runtime.routes.getRoutes().find((candidate) => candidate.operationId === operationId);
+    expect(route, `route ${operationId} should be registered`).toBeDefined();
+    return route!.handler({
+      params: {},
+      query: {},
+      body: null,
+      headers: {},
+      principal: ownerPrincipal,
+      requestId: `req-${operationId}`,
+      receivedAt: NOW,
+      ...overrides,
+    } as never);
+  };
+}
+
+describe("API runtime workflow catalog/builder retirement", () => {
+  it("fail-closes workflows.bundles.import by default and not when the test oracle is set", async () => {
+    const failClosedDeps = makeDeps();
+    const failClosedRuntime = createFridayApiRuntime(failClosedDeps);
+    const invokeFailClosed = invoker(failClosedRuntime);
+
+    await expect(
+      invokeFailClosed("workflows.bundles.import", {
+        params: { workflowId: "wf-import" },
+        body: { bundle: { schemaVersion: "1.0" } },
+      }),
+    ).rejects.toMatchObject({
+      code: "TS_RUNTIME_WORKFLOW_BUNDLE_IMPORT_RETIRED",
+      httpStatus: 503,
+      details: {
+        classification: "fail_closed",
+        replacement: "rust_owned_workflow_bundle_import_entrypoint_required",
+      },
+    });
+    failClosedDeps.db.close();
+
+    // With the explicit isolated test oracle, the retirement guard no longer
+    // fires (the call proceeds into validation/import and fails for a different
+    // reason or succeeds), proving the flag is the only thing gating it.
+    const oracleDeps = makeDeps({ allowTestOnlyWorkflowBundleImportExecution: true });
+    const oracleRuntime = createFridayApiRuntime(oracleDeps);
+    const invokeOracle = invoker(oracleRuntime);
+    let oracleError: { code?: string } | undefined;
+    try {
+      await invokeOracle("workflows.bundles.import", {
+        params: { workflowId: "wf-import" },
+        body: { bundle: { schemaVersion: "1.0" } },
+      });
+    } catch (error) {
+      oracleError = error as { code?: string };
+    }
+    expect(oracleError?.code).not.toBe("TS_RUNTIME_WORKFLOW_BUNDLE_IMPORT_RETIRED");
+    oracleDeps.db.close();
+  });
+
+  it("redacts workflow catalog list/get/version reads", async () => {
+    const deps = makeDeps();
+    const runtime = createFridayApiRuntime(deps);
+    const invoke = invoker(runtime);
+
+    const workflow = runtime.workflowCrud.createWorkflow({
+      slug: "redacted-catalog-read",
+      name: "Redacted Catalog Read",
+    });
+    const version = runtime.workflowCrud.createVersion(
+      workflow.id,
+      makeGraphWithSecretConfig(workflow.id),
+    );
+
+    const listRead = (await invoke("workflows.list", {})) as {
+      items: Array<Record<string, unknown>>;
+    };
+    // The allowlist-built projection never carries these private/runtime fields.
+    for (const item of listRead.items) {
+      expect(item.ownerUserId).toBeUndefined();
+      expect(item.lastVerifiedProviderModel).toBeUndefined();
+      expect(item.lastVerifiedRuntimeVersion).toBeUndefined();
+      expect(item.deletedBy).toBeUndefined();
+      expect(item.shadowVersionId).toBeUndefined();
+    }
+
+    const getRead = (await invoke("workflows.get", {
+      params: { workflowId: workflow.id },
+    })) as {
+      workflow: Record<string, unknown>;
+      latestVersion: Record<string, unknown>;
+    };
+    expect(getRead.workflow.ownerUserId).toBeUndefined();
+    expect(getRead.latestVersion.createdByUserId).toBeUndefined();
+    expect(getRead.latestVersion.graphJson).toMatchObject({ redacted: true });
+    expect(JSON.stringify(getRead)).not.toContain(GRAPH_API_KEY_SECRET);
+    expect(JSON.stringify(getRead)).not.toContain(GRAPH_COMMAND_SECRET);
+    expect(JSON.stringify(getRead)).not.toContain("token-owner");
+
+    const versionsRead = (await invoke("workflows.list.versions", {
+      params: { workflowId: workflow.id },
+    })) as { items: Array<Record<string, unknown>> };
+    expect(versionsRead.items.length).toBeGreaterThan(0);
+    for (const item of versionsRead.items) {
+      expect(item.createdByUserId).toBeUndefined();
+      expect(item.graphJson).toMatchObject({ redacted: true });
+    }
+    expect(JSON.stringify(versionsRead)).not.toContain(GRAPH_API_KEY_SECRET);
+    expect(JSON.stringify(versionsRead)).not.toContain(GRAPH_COMMAND_SECRET);
+
+    const versionRead = (await invoke("workflow.versions.get", {
+      params: { versionId: version.id },
+    })) as { version: Record<string, unknown> };
+    expect(versionRead.version.createdByUserId).toBeUndefined();
+    expect(versionRead.version.graphJson).toMatchObject({ redacted: true });
+    expect(JSON.stringify(versionRead)).not.toContain(GRAPH_API_KEY_SECRET);
+    expect(JSON.stringify(versionRead)).not.toContain(GRAPH_COMMAND_SECRET);
+
+    deps.db.close();
+  });
+
+  it("redacts workflow overview and visualization while keeping pure canvas layout", async () => {
+    const deps = makeDeps({ allowTestOnlyWorkflowRunExecution: true });
+    const runtime = createFridayApiRuntime(deps);
+    const invoke = invoker(runtime);
+
+    const workflow = runtime.workflowCrud.createWorkflow({
+      slug: "redacted-product-read",
+      name: "Redacted Product Read",
+    });
+    const version = runtime.workflowCrud.createVersion(
+      workflow.id,
+      makeGraphWithSecretConfig(workflow.id),
+    );
+
+    // Seed a draft carrying raw spec args, an input default, a test case, an
+    // owner user id, and a private source URL.
+    const draft = runtime.draftService.createDraft({
+      workflowId: workflow.id,
+      title: "Secret Draft",
+      ownerUserId: DRAFT_OWNER_SECRET,
+      spec: createTestSpec({
+        workflowId: workflow.id,
+        steps: [
+          { id: "step-1", type: "skill_call", ref: "test-skill", args: { token: DRAFT_ARG_SECRET } },
+        ],
+        inputs: [{ key: "k", type: "string", required: false, defaultValue: DRAFT_INPUT_SECRET }],
+        tests: [{ name: "t", inputs: { x: DRAFT_TEST_SECRET }, assertions: [] }],
+      }),
+      visual: createTestVisual(workflow.id),
+      sourceReview: {
+        source: "bundle_import",
+        sourceUrl: DRAFT_SOURCE_URL_SECRET,
+        importedAt: NOW,
+        requiresReviewBeforePublish: true,
+      },
+    });
+
+    // Seed a run carrying a raw trigger payload.
+    await invoke("runs.start", {
+      body: {
+        workflowId: workflow.id,
+        workflowVersionId: version.id,
+        triggerType: "manual",
+        triggerPayload: { secret: RUN_TRIGGER_SECRET },
+        dryRun: true,
+      },
+    });
+
+    const overview = (await invoke("workflows.overview", {
+      params: { workflowId: workflow.id },
+    })) as { overview: Record<string, unknown> };
+    const overviewBody = overview.overview;
+    const overviewJson = JSON.stringify(overview);
+
+    const drafts = overviewBody.drafts as Array<Record<string, unknown>>;
+    expect(drafts.length).toBeGreaterThan(0);
+    for (const draft of drafts) {
+      expect(draft.ownerUserId).toBeUndefined();
+      const spec = draft.spec as { steps: Array<Record<string, unknown>> };
+      for (const step of spec.steps) {
+        expect(step.args).toBeUndefined();
+      }
+      const sourceReview = draft.sourceReview as Record<string, unknown> | undefined;
+      if (sourceReview) {
+        expect(sourceReview.sourceUrl).toBeUndefined();
+      }
+    }
+    const latestVersion = overviewBody.latestVersion as Record<string, unknown> | undefined;
+    expect(latestVersion?.graphJson).toMatchObject({ redacted: true });
+    for (const run of overviewBody.recentRuns as Array<Record<string, unknown>>) {
+      expect(run.triggerPayload).toBeUndefined();
+      expect(run.context).toBeUndefined();
+      expect(run.startedByUserId).toBeUndefined();
+    }
+    expect(overviewJson).not.toContain(GRAPH_API_KEY_SECRET);
+    expect(overviewJson).not.toContain(GRAPH_COMMAND_SECRET);
+    expect(overviewJson).not.toContain(RUN_TRIGGER_SECRET);
+    expect(overviewJson).not.toContain(DRAFT_ARG_SECRET);
+    expect(overviewJson).not.toContain(DRAFT_INPUT_SECRET);
+    expect(overviewJson).not.toContain(DRAFT_TEST_SECRET);
+    expect(overviewJson).not.toContain(DRAFT_OWNER_SECRET);
+    expect(overviewJson).not.toContain(DRAFT_SOURCE_URL_SECRET);
+
+    // Version-target visualization: proves version graphJson redaction and that
+    // pure canvas layout is preserved (not over-redacted).
+    const visualization = (await invoke("workflows.visualization", {
+      params: { workflowId: workflow.id },
+    })) as { visualization: Record<string, unknown> };
+    const vizBody = visualization.visualization;
+    const vizJson = JSON.stringify(visualization);
+
+    const vizVersion = vizBody.version as Record<string, unknown> | undefined;
+    if (vizVersion) {
+      expect(vizVersion.graphJson).toMatchObject({ redacted: true });
+    }
+    // The visual graph has no command/secret-bearing config, so it stays
+    // available for the UI.
+    const vizVisual = vizBody.visual as { nodes?: unknown[] };
+    expect(Array.isArray(vizVisual.nodes)).toBe(true);
+    expect(vizJson).not.toContain(GRAPH_API_KEY_SECRET);
+    expect(vizJson).not.toContain(GRAPH_COMMAND_SECRET);
+
+    // Draft-target visualization: the synthesized/draft spec has a real step
+    // whose raw args carry a secret, so the spec-args redaction is load-bearing
+    // here (not a vacuous empty-step loop).
+    const draftViz = (await invoke("workflows.visualization", {
+      params: { workflowId: workflow.id },
+      query: { draftId: draft.draftId },
+    })) as { visualization: Record<string, unknown> };
+    const draftVizSpec = draftViz.visualization.spec as { steps: Array<Record<string, unknown>> };
+    expect(draftVizSpec.steps.length).toBeGreaterThan(0);
+    for (const step of draftVizSpec.steps) {
+      expect(step.args).toBeUndefined();
+    }
+    const draftVizJson = JSON.stringify(draftViz);
+    expect(draftVizJson).not.toContain(DRAFT_ARG_SECRET);
+    expect(draftVizJson).not.toContain(DRAFT_INPUT_SECRET);
+    expect(draftVizJson).not.toContain(DRAFT_TEST_SECRET);
+    expect(draftVizJson).not.toContain(DRAFT_OWNER_SECRET);
+
+    deps.db.close();
+  });
+});


### PR DESCRIPTION
## Scope — TS runtime retirement: `workflow_catalog_and_builder_runtime_blockers` family (7 routes)

Closes the last small workflow blocker family (adjacent to PR #540), leaving only `desktop_runtime_blockers` and `general_runtime_blocker_inventory`.

### fail_closed (1)
- `POST /v1/workflows/:workflowId/import` (`workflows.bundles.import`) now returns `503 TS_RUNTIME_WORKFLOW_BUNDLE_IMPORT_RETIRED` in default/live runtime, **before** the write-principal check or calling TypeScript `importWorkflowBundle`. Legacy behavior is reachable only through the explicit isolated `allowTestOnlyWorkflowBundleImportExecution` test-oracle flag (mirrors the PR #540 catalog-mutation pattern).

### compat_shim — bounded, redacted reads (6)
- `GET /v1/workflows` · `GET /v1/workflows/:workflowId` · `GET /v1/workflows/:workflowId/versions` · `GET /v1/workflow-versions/:versionId` · `GET /v1/workflows/:workflowId/overview` · `GET /v1/workflows/:workflowId/visualization`
- New allowlist-built runtime sanitizers (`sanitizePublicWorkflowEntity/Version/Spec/Draft/Overview/Visualization`) redact every dangerous field:
  - raw `graphJson` (compiled graph — can carry commands/secrets) → bounded shape summary
  - raw spec `steps[].args`, `tests`, `inputs[].defaultValue` dropped
  - `ownerUserId`, `createdByUserId`, provider/runtime model fields, `shadowVersionId`, `deletedBy` dropped
  - embedded run `triggerPayload`/`context`/`failure.details`/`startedByUserId` redacted (reuses existing `sanitizePublicWorkflowRun`)
  - node-timeline `message` → `"redacted"`; evidence-export artifact id/`file://` path redacted; draft `sourceReview.sourceUrl` dropped
  - **pure canvas layout** (`FridayWorkflowVisualGraphV1`: viewport/node positions/edge geometry — no config) is preserved, not over-redacted.

These reads own no product truth and cannot create/update/publish/mark-complete a workflow.

## Proof
- Redaction proven through the **real `createFridayApiRuntime` wiring** (not mock-injected): `test/unit/api/runtime/friday-api-runtime-workflow-catalog-retirement.test.ts` seeds raw secret markers in graph config, spec args, run trigger payload, draft owner/sourceUrl, and asserts they are absent from all 6 read projections; default/live import fail-closes (503) and never calls `importWorkflowBundle`.
- Two read-only reviewers (general-purpose) PASS; their actionable test-strength findings (vacuous viz spec-args loop) were fixed by adding a draft-target visualization assertion.

## Verification (local)
- `npm run check:ts-runtime-retirement`: passed — 584 routes; `ts_runtime_blocker` 194→**187**, `fail_closed` 50→**51**, `compat_shim` 231→**237**; family removed from blocker list.
- `npm run build`: passed (no type errors).
- `FRIDAY_E2E_CORE=1 npm test`: passed — 926 files / 12607 tests, no type errors.
- `npm run lint`: 0 errors.
- `npm run check:secret-patterns`, `detect-secrets-hook --baseline .secrets.baseline`, `git diff --check`: passed.

## Safety
- No fake Rust delegation, no hidden fallback, no weakened tests/gates.
- No default-DB mutation; no pet/design-gallery files touched.
- No `provider_native_synced` / Friday v1 GO claim. TS runtime retirement remains incomplete (desktop + general inventory families remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)