### PR TITLE
Fail close desktop live-control and sensitive-stream runtime surfaces

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -1311,6 +1311,149 @@
       "executes_product_logic": false,
       "proof": "src/api/http/routes/friday-desktop-routes.ts wires default/live desktop.actions.batch to TS_RUNTIME_DESKTOP_ACTION_EXECUTION_RETIRED after request validation and before calling the TypeScript desktop batch action service; legacy TS execution is reachable only through explicit allowTestOnlyDesktopActionExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned desktop batch action execution entrypoint when available."
+    },
+    {
+      "id": "desktop_actions_cancel",
+      "route": {
+        "method": "POST",
+        "path": "/v1/desktop/actions/:actionId/cancel",
+        "operationId": "desktop.actions.cancel"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-desktop-routes.ts wires default/live desktop.actions.cancel to TS_RUNTIME_DESKTOP_ACTION_CONTROL_RETIRED after request validation and before calling the TypeScript desktop action cancel service (which aborts an in-flight live action); legacy TS execution is reachable only through explicit allowTestOnlyDesktopActionControlExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned desktop action control entrypoint when available."
+    },
+    {
+      "id": "desktop_actions_log",
+      "route": {
+        "method": "GET",
+        "path": "/v1/desktop/actions/log",
+        "operationId": "desktop.actions.log"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-desktop-routes.ts wires default/live desktop.actions.log to TS_RUNTIME_DESKTOP_ACTION_CONTROL_RETIRED before reading the TypeScript desktop action log, whose entries carry raw action payloads (typed text, file paths/contents, clipboard, screenshots, element values) with no safe bounded projection; legacy TS reads are reachable only through explicit allowTestOnlyDesktopActionControlExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned redacted desktop action audit projection when available."
+    },
+    {
+      "id": "desktop_recordings_start",
+      "route": {
+        "method": "POST",
+        "path": "/v1/desktop/recordings",
+        "operationId": "desktop.recordings.start"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-desktop-routes.ts wires default/live desktop.recordings.start to TS_RUNTIME_DESKTOP_RECORDING_RETIRED after request validation and before calling the TypeScript desktop recording service; legacy TS execution is reachable only through explicit allowTestOnlyDesktopRecordingExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned desktop recording entrypoint when available."
+    },
+    {
+      "id": "desktop_recordings_stop",
+      "route": {
+        "method": "POST",
+        "path": "/v1/desktop/recordings/:recordingId/stop",
+        "operationId": "desktop.recordings.stop"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-desktop-routes.ts wires default/live desktop.recordings.stop to TS_RUNTIME_DESKTOP_RECORDING_RETIRED after request validation and before calling the TypeScript desktop recording service; legacy TS execution is reachable only through explicit allowTestOnlyDesktopRecordingExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned desktop recording entrypoint when available."
+    },
+    {
+      "id": "desktop_recordings_pause",
+      "route": {
+        "method": "POST",
+        "path": "/v1/desktop/recordings/:recordingId/pause",
+        "operationId": "desktop.recordings.pause"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-desktop-routes.ts wires default/live desktop.recordings.pause to TS_RUNTIME_DESKTOP_RECORDING_RETIRED after request validation and before calling the TypeScript desktop recording service; legacy TS execution is reachable only through explicit allowTestOnlyDesktopRecordingExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned desktop recording entrypoint when available."
+    },
+    {
+      "id": "desktop_recordings_resume",
+      "route": {
+        "method": "POST",
+        "path": "/v1/desktop/recordings/:recordingId/resume",
+        "operationId": "desktop.recordings.resume"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-desktop-routes.ts wires default/live desktop.recordings.resume to TS_RUNTIME_DESKTOP_RECORDING_RETIRED after request validation and before calling the TypeScript desktop recording service; legacy TS execution is reachable only through explicit allowTestOnlyDesktopRecordingExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned desktop recording entrypoint when available."
+    },
+    {
+      "id": "desktop_recordings_replay",
+      "route": {
+        "method": "POST",
+        "path": "/v1/desktop/recordings/:recordingId/replay",
+        "operationId": "desktop.recordings.replay"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-desktop-routes.ts wires default/live desktop.recordings.replay to TS_RUNTIME_DESKTOP_RECORDING_RETIRED after request validation and before calling the TypeScript desktop recording service (which re-executes recorded steps against the live desktop); legacy TS execution is reachable only through explicit allowTestOnlyDesktopRecordingExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned desktop recording replay entrypoint when available."
+    },
+    {
+      "id": "desktop_recordings_delete",
+      "route": {
+        "method": "DELETE",
+        "path": "/v1/desktop/recordings/:recordingId",
+        "operationId": "desktop.recordings.delete"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-desktop-routes.ts wires default/live desktop.recordings.delete to TS_RUNTIME_DESKTOP_RECORDING_RETIRED after request validation and before calling the TypeScript desktop recording service; legacy TS execution is reachable only through explicit allowTestOnlyDesktopRecordingExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned desktop recording entrypoint when available."
+    },
+    {
+      "id": "desktop_recordings_steps_list",
+      "route": {
+        "method": "GET",
+        "path": "/v1/desktop/recordings/:recordingId/steps",
+        "operationId": "desktop.recordings.steps.list"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-desktop-routes.ts wires default/live desktop.recordings.steps.list to TS_RUNTIME_DESKTOP_RECORDING_RETIRED before reading the TypeScript recording step stream, whose steps carry raw captured actions, element values, results, and parameter bindings (typed text, file paths, coordinates) with no safe bounded projection; legacy TS reads are reachable only through explicit allowTestOnlyDesktopRecordingExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned redacted desktop recording step projection when available."
+    },
+    {
+      "id": "desktop_elements_inspect",
+      "route": {
+        "method": "POST",
+        "path": "/v1/desktop/elements/inspect",
+        "operationId": "desktop.elements.inspect"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-desktop-routes.ts wires default/live desktop.elements.inspect to TS_RUNTIME_DESKTOP_ELEMENT_INSPECTION_RETIRED after request validation and before calling the TypeScript desktop adapter, which actively queries the live desktop accessibility tree and returns raw element name/value/window title/accessibility attributes; legacy TS execution is reachable only through explicit allowTestOnlyDesktopElementInspectionExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned desktop element inspection entrypoint when available."
+    },
+    {
+      "id": "desktop_elements_search",
+      "route": {
+        "method": "GET",
+        "path": "/v1/desktop/elements/search",
+        "operationId": "desktop.elements.search"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-desktop-routes.ts wires default/live desktop.elements.search to TS_RUNTIME_DESKTOP_ELEMENT_INSPECTION_RETIRED after request validation and before calling the TypeScript desktop adapter, which actively queries the live desktop accessibility tree and returns raw element name/value/window title/accessibility attributes; legacy TS execution is reachable only through explicit allowTestOnlyDesktopElementInspectionExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned desktop element search entrypoint when available."
     }
   ]
 }

--- a/src/api/http/routes/friday-desktop-routes.ts
+++ b/src/api/http/routes/friday-desktop-routes.ts
@@ -63,6 +63,27 @@ import type { UUID } from "../../../desktop/model/friday-desktop.types.js";
 
 export interface FridayDesktopRoutesDeps {
   allowTestOnlyDesktopActionExecution?: boolean;
+  /**
+   * Test-oracle only: allows legacy TypeScript desktop action control/audit
+   * surfaces (cancel, action log) in isolated validation. Default/live runtime
+   * must leave these unset so they stay fail-closed until Rust owns desktop
+   * action control truth.
+   */
+  allowTestOnlyDesktopActionControlExecution?: boolean;
+  /**
+   * Test-oracle only: allows legacy TypeScript desktop recording
+   * lifecycle/replay/step-stream surfaces in isolated validation. Default/live
+   * runtime must leave this unset so desktop recording stays fail-closed until
+   * Rust owns desktop recording truth.
+   */
+  allowTestOnlyDesktopRecordingExecution?: boolean;
+  /**
+   * Test-oracle only: allows legacy TypeScript live desktop element
+   * inspection/search in isolated validation. Default/live runtime must leave
+   * this unset so live desktop element queries stay fail-closed until Rust owns
+   * desktop element-inspection truth.
+   */
+  allowTestOnlyDesktopElementInspectionExecution?: boolean;
   actions: {
     execute(req: FridayExecuteDesktopActionRequest): Promise<FridayExecuteDesktopActionResponse>;
     batch(req: FridayBatchDesktopActionsRequest): Promise<FridayBatchDesktopActionsResponse>;
@@ -141,6 +162,48 @@ function throwRetiredDesktopActionExecution(): never {
   );
 }
 
+function throwRetiredDesktopActionControl(): never {
+  throw new FridayDomainError(
+    "TS_RUNTIME_DESKTOP_ACTION_CONTROL_RETIRED",
+    "Desktop action control and action-log read surfaces are fail-closed while runtime ownership is being moved out of TypeScript.",
+    {
+      httpStatus: 503,
+      details: {
+        classification: "fail_closed",
+        replacement: "rust_owned_desktop_action_control_entrypoint_required",
+      },
+    },
+  );
+}
+
+function throwRetiredDesktopRecording(): never {
+  throw new FridayDomainError(
+    "TS_RUNTIME_DESKTOP_RECORDING_RETIRED",
+    "Desktop recording lifecycle, replay, and step-stream surfaces are fail-closed while runtime ownership is being moved out of TypeScript.",
+    {
+      httpStatus: 503,
+      details: {
+        classification: "fail_closed",
+        replacement: "rust_owned_desktop_recording_entrypoint_required",
+      },
+    },
+  );
+}
+
+function throwRetiredDesktopElementInspection(): never {
+  throw new FridayDomainError(
+    "TS_RUNTIME_DESKTOP_ELEMENT_INSPECTION_RETIRED",
+    "Live desktop element inspection and search are fail-closed while runtime ownership is being moved out of TypeScript.",
+    {
+      httpStatus: 503,
+      details: {
+        classification: "fail_closed",
+        replacement: "rust_owned_desktop_element_inspection_entrypoint_required",
+      },
+    },
+  );
+}
+
 // ─── Factory ───
 
 export function createFridayDesktopRoutes(
@@ -192,6 +255,9 @@ export function createFridayDesktopRoutes(
         const { actionId } = ctx.params as { actionId: string };
         const body = ctx.body as FridayCancelDesktopActionRequest;
         requireIdempotencyKey(body);
+        if (deps.allowTestOnlyDesktopActionControlExecution !== true) {
+          throwRetiredDesktopActionControl();
+        }
         return deps.actions.cancel(actionId, body);
       },
     },
@@ -201,6 +267,9 @@ export function createFridayDesktopRoutes(
       path: "/v1/desktop/actions/log",
       auth: { public: true },
       async handler(ctx) {
+        if (deps.allowTestOnlyDesktopActionControlExecution !== true) {
+          throwRetiredDesktopActionControl();
+        }
         return deps.actions.log(ctx.query as FridayListDesktopActionLogQuery);
       },
     },
@@ -218,6 +287,9 @@ export function createFridayDesktopRoutes(
         const body = ctx.body as FridayStartDesktopRecordingRequest;
         requireString(body, "name");
         requireIdempotencyKey(body);
+        if (deps.allowTestOnlyDesktopRecordingExecution !== true) {
+          throwRetiredDesktopRecording();
+        }
         return deps.recordings.start(body);
       },
     },
@@ -249,6 +321,9 @@ export function createFridayDesktopRoutes(
         const { recordingId } = ctx.params as { recordingId: string };
         const body = ctx.body as FridayStopDesktopRecordingRequest;
         requireIdempotencyKey(body);
+        if (deps.allowTestOnlyDesktopRecordingExecution !== true) {
+          throwRetiredDesktopRecording();
+        }
         return deps.recordings.stop(recordingId, body);
       },
     },
@@ -261,6 +336,9 @@ export function createFridayDesktopRoutes(
         const { recordingId } = ctx.params as { recordingId: string };
         const body = ctx.body as FridayPauseDesktopRecordingRequest;
         requireIdempotencyKey(body);
+        if (deps.allowTestOnlyDesktopRecordingExecution !== true) {
+          throwRetiredDesktopRecording();
+        }
         return deps.recordings.pause(recordingId, body);
       },
     },
@@ -273,6 +351,9 @@ export function createFridayDesktopRoutes(
         const { recordingId } = ctx.params as { recordingId: string };
         const body = ctx.body as FridayResumeDesktopRecordingRequest;
         requireIdempotencyKey(body);
+        if (deps.allowTestOnlyDesktopRecordingExecution !== true) {
+          throwRetiredDesktopRecording();
+        }
         return deps.recordings.resume(recordingId, body);
       },
     },
@@ -283,6 +364,9 @@ export function createFridayDesktopRoutes(
       auth: { public: true },
       async handler(ctx) {
         const { recordingId } = ctx.params as { recordingId: string };
+        if (deps.allowTestOnlyDesktopRecordingExecution !== true) {
+          throwRetiredDesktopRecording();
+        }
         return deps.recordings.listSteps(recordingId, ctx.query as FridayListDesktopRecordingStepsQuery);
       },
     },
@@ -295,6 +379,9 @@ export function createFridayDesktopRoutes(
         const { recordingId } = ctx.params as { recordingId: string };
         const body = ctx.body as FridayReplayDesktopRecordingRequest;
         requireIdempotencyKey(body);
+        if (deps.allowTestOnlyDesktopRecordingExecution !== true) {
+          throwRetiredDesktopRecording();
+        }
         return deps.recordings.replay(recordingId, body);
       },
     },
@@ -307,6 +394,9 @@ export function createFridayDesktopRoutes(
         const { recordingId } = ctx.params as { recordingId: string };
         const body = ctx.body as FridayDeleteDesktopRecordingRequest;
         requireIdempotencyKey(body);
+        if (deps.allowTestOnlyDesktopRecordingExecution !== true) {
+          throwRetiredDesktopRecording();
+        }
         return deps.recordings.delete(recordingId, body);
       },
     },
@@ -459,6 +549,9 @@ export function createFridayDesktopRoutes(
       async handler(ctx) {
         const body = ctx.body as FridayInspectDesktopElementRequest;
         requirePresent(body, "selector");
+        if (deps.allowTestOnlyDesktopElementInspectionExecution !== true) {
+          throwRetiredDesktopElementInspection();
+        }
         return deps.elements.inspect(body);
       },
     },
@@ -471,6 +564,9 @@ export function createFridayDesktopRoutes(
         const query = ctx.query as FridaySearchDesktopElementsQuery;
         if (!query.query) {
           throw new FridayDomainError("VALIDATION_ERROR", "query is required");
+        }
+        if (deps.allowTestOnlyDesktopElementInspectionExecution !== true) {
+          throwRetiredDesktopElementInspection();
         }
         return deps.elements.search(query);
       },

--- a/test/unit/api/http/routes/friday-desktop-routes.test.ts
+++ b/test/unit/api/http/routes/friday-desktop-routes.test.ts
@@ -164,7 +164,7 @@ describe("createFridayDesktopRoutes", () => {
     });
 
     it("cancels an action", async () => {
-      const deps = makeDeps();
+      const deps = makeDeps({ allowTestOnlyDesktopActionControlExecution: true });
       const routes = createFridayDesktopRoutes(deps);
       const route = findRoute(routes, "desktop.actions.cancel");
       expect(route.method).toBe("POST");
@@ -176,7 +176,7 @@ describe("createFridayDesktopRoutes", () => {
     });
 
     it("lists action log", async () => {
-      const deps = makeDeps();
+      const deps = makeDeps({ allowTestOnlyDesktopActionControlExecution: true });
       const routes = createFridayDesktopRoutes(deps);
       const route = findRoute(routes, "desktop.actions.log");
       expect(route.method).toBe("GET");
@@ -185,13 +185,30 @@ describe("createFridayDesktopRoutes", () => {
       await route.handler(ctx);
       expect(deps.actions.log).toHaveBeenCalledWith(ctx.query);
     });
+
+    it("fail-closes desktop action control/log by default without invoking TypeScript services", async () => {
+      const deps = makeDeps();
+      const routes = createFridayDesktopRoutes(deps);
+      const cancelRoute = findRoute(routes, "desktop.actions.cancel");
+      const logRoute = findRoute(routes, "desktop.actions.log");
+
+      await expect(
+        cancelRoute.handler(makeCtx({ params: { actionId: "a-1" }, body: { idempotencyKey: "k-fc-cancel" } })),
+      ).rejects.toMatchObject({ code: "TS_RUNTIME_DESKTOP_ACTION_CONTROL_RETIRED", httpStatus: 503 });
+      await expect(
+        logRoute.handler(makeCtx({ query: { status: "success" } })),
+      ).rejects.toMatchObject({ code: "TS_RUNTIME_DESKTOP_ACTION_CONTROL_RETIRED", httpStatus: 503 });
+
+      expect(deps.actions.cancel).not.toHaveBeenCalled();
+      expect(deps.actions.log).not.toHaveBeenCalled();
+    });
   });
 
   // ─── Recordings ───
 
   describe("recordings", () => {
     it("starts a recording", async () => {
-      const deps = makeDeps();
+      const deps = makeDeps({ allowTestOnlyDesktopRecordingExecution: true });
       const routes = createFridayDesktopRoutes(deps);
       const route = findRoute(routes, "desktop.recordings.start");
       expect(route.method).toBe("POST");
@@ -228,7 +245,7 @@ describe("createFridayDesktopRoutes", () => {
     });
 
     it("stops a recording", async () => {
-      const deps = makeDeps();
+      const deps = makeDeps({ allowTestOnlyDesktopRecordingExecution: true });
       const routes = createFridayDesktopRoutes(deps);
       const route = findRoute(routes, "desktop.recordings.stop");
 
@@ -237,7 +254,7 @@ describe("createFridayDesktopRoutes", () => {
     });
 
     it("pauses a recording", async () => {
-      const deps = makeDeps();
+      const deps = makeDeps({ allowTestOnlyDesktopRecordingExecution: true });
       const routes = createFridayDesktopRoutes(deps);
       const route = findRoute(routes, "desktop.recordings.pause");
 
@@ -246,7 +263,7 @@ describe("createFridayDesktopRoutes", () => {
     });
 
     it("resumes a recording", async () => {
-      const deps = makeDeps();
+      const deps = makeDeps({ allowTestOnlyDesktopRecordingExecution: true });
       const routes = createFridayDesktopRoutes(deps);
       const route = findRoute(routes, "desktop.recordings.resume");
 
@@ -255,7 +272,7 @@ describe("createFridayDesktopRoutes", () => {
     });
 
     it("lists recording steps", async () => {
-      const deps = makeDeps();
+      const deps = makeDeps({ allowTestOnlyDesktopRecordingExecution: true });
       const routes = createFridayDesktopRoutes(deps);
       const route = findRoute(routes, "desktop.recordings.steps.list");
 
@@ -264,7 +281,7 @@ describe("createFridayDesktopRoutes", () => {
     });
 
     it("replays a recording", async () => {
-      const deps = makeDeps();
+      const deps = makeDeps({ allowTestOnlyDesktopRecordingExecution: true });
       const routes = createFridayDesktopRoutes(deps);
       const route = findRoute(routes, "desktop.recordings.replay");
 
@@ -276,13 +293,38 @@ describe("createFridayDesktopRoutes", () => {
     });
 
     it("deletes a recording", async () => {
-      const deps = makeDeps();
+      const deps = makeDeps({ allowTestOnlyDesktopRecordingExecution: true });
       const routes = createFridayDesktopRoutes(deps);
       const route = findRoute(routes, "desktop.recordings.delete");
       expect(route.method).toBe("DELETE");
 
       await route.handler(makeCtx({ params: { recordingId: "rec-1" }, body: { idempotencyKey: "k9" } }));
       expect(deps.recordings.delete).toHaveBeenCalledWith("rec-1", { idempotencyKey: "k9" });
+    });
+
+    it("fail-closes desktop recording lifecycle/replay/steps by default without invoking TypeScript services", async () => {
+      const deps = makeDeps();
+      const routes = createFridayDesktopRoutes(deps);
+
+      await expect(
+        findRoute(routes, "desktop.recordings.start").handler(
+          makeCtx({ body: { name: "Flow", idempotencyKey: "k-fc-start" } }),
+        ),
+      ).rejects.toMatchObject({ code: "TS_RUNTIME_DESKTOP_RECORDING_RETIRED", httpStatus: 503 });
+      await expect(
+        findRoute(routes, "desktop.recordings.replay").handler(
+          makeCtx({ params: { recordingId: "rec-1" }, body: { idempotencyKey: "k-fc-replay" } }),
+        ),
+      ).rejects.toMatchObject({ code: "TS_RUNTIME_DESKTOP_RECORDING_RETIRED", httpStatus: 503 });
+      await expect(
+        findRoute(routes, "desktop.recordings.steps.list").handler(
+          makeCtx({ params: { recordingId: "rec-1" }, query: {} }),
+        ),
+      ).rejects.toMatchObject({ code: "TS_RUNTIME_DESKTOP_RECORDING_RETIRED", httpStatus: 503 });
+
+      expect(deps.recordings.start).not.toHaveBeenCalled();
+      expect(deps.recordings.replay).not.toHaveBeenCalled();
+      expect(deps.recordings.listSteps).not.toHaveBeenCalled();
     });
   });
 
@@ -450,7 +492,7 @@ describe("createFridayDesktopRoutes", () => {
 
   describe("elements", () => {
     it("inspects an element", async () => {
-      const deps = makeDeps();
+      const deps = makeDeps({ allowTestOnlyDesktopElementInspectionExecution: true });
       const routes = createFridayDesktopRoutes(deps);
       const route = findRoute(routes, "desktop.elements.inspect");
       expect(route.method).toBe("POST");
@@ -462,7 +504,7 @@ describe("createFridayDesktopRoutes", () => {
     });
 
     it("searches elements", async () => {
-      const deps = makeDeps();
+      const deps = makeDeps({ allowTestOnlyDesktopElementInspectionExecution: true });
       const routes = createFridayDesktopRoutes(deps);
       const route = findRoute(routes, "desktop.elements.search");
       expect(route.method).toBe("GET");
@@ -476,6 +518,23 @@ describe("createFridayDesktopRoutes", () => {
       const route = findRoute(routes, "desktop.elements.search");
       const ctx = makeCtx({ query: {} });
       await expect(route.handler(ctx)).rejects.toThrow("query is required");
+    });
+
+    it("fail-closes live desktop element inspect/search by default without invoking TypeScript services", async () => {
+      const deps = makeDeps();
+      const routes = createFridayDesktopRoutes(deps);
+
+      await expect(
+        findRoute(routes, "desktop.elements.inspect").handler(
+          makeCtx({ body: { selector: { strategy: "accessibility_id", value: "btn-ok" } } }),
+        ),
+      ).rejects.toMatchObject({ code: "TS_RUNTIME_DESKTOP_ELEMENT_INSPECTION_RETIRED", httpStatus: 503 });
+      await expect(
+        findRoute(routes, "desktop.elements.search").handler(makeCtx({ query: { query: "Submit" } })),
+      ).rejects.toMatchObject({ code: "TS_RUNTIME_DESKTOP_ELEMENT_INSPECTION_RETIRED", httpStatus: 503 });
+
+      expect(deps.elements.inspect).not.toHaveBeenCalled();
+      expect(deps.elements.search).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Scope — TS runtime retirement: desktop family (PR 1 of 2)

Closes **11 of 24** `desktop_runtime_blockers` by fail-closing the unambiguous TypeScript live-control / raw-sensitive-stream surfaces, mirroring the already-merged `desktop.actions.execute`/`batch` pattern (#528).

### fail_closed (11)
| route | error | reason |
|---|---|---|
| `POST /v1/desktop/actions/:actionId/cancel` | `TS_RUNTIME_DESKTOP_ACTION_CONTROL_RETIRED` | aborts an in-flight live action |
| `GET /v1/desktop/actions/log` | same | raw action payloads (typed text, file paths/contents, clipboard, screenshots) — no safe bounded projection |
| `POST /v1/desktop/recordings` (start) | `TS_RUNTIME_DESKTOP_RECORDING_RETIRED` | recording lifecycle write |
| `POST .../stop` `.../pause` `.../resume` | same | recording lifecycle write |
| `POST .../replay` | same | re-executes recorded steps on the **live** desktop |
| `DELETE /v1/desktop/recordings/:id` | same | destructive write |
| `GET .../recordings/:id/steps` | same | raw captured actions / element values / parameter bindings (keystrokes, paths) |
| `POST /v1/desktop/elements/inspect` | `TS_RUNTIME_DESKTOP_ELEMENT_INSPECTION_RETIRED` | actively queries the live desktop accessibility tree |
| `GET /v1/desktop/elements/search` | same | actively queries the live desktop accessibility tree |

Each guard fires **after request validation** and **before** the TypeScript desktop service / live side effect. Legacy behavior is reachable only via explicit isolated test-oracle flags (`allowTestOnlyDesktopActionControlExecution`, `allowTestOnlyDesktopRecordingExecution`, `allowTestOnlyDesktopElementInspectionExecution`); default/live hub wiring leaves them unset.

### Deferred to PR2 (not in this PR)
`desktop.recordings.list/get`, `desktop.platform.get` (→ bounded redacted `compat_shim`), and `desktop.policies.*` / `desktop.permissions.*` (already 503 at the deps layer via hub bootstrap; manifest reconciliation, with `permissions.list` preserved as a benign live OS-capability read). The `desktop_runtime_blockers` family therefore remains a blocker after this PR — honest partial progress.

## Verification (local)
- `npm run check:ts-runtime-retirement`: passed — 584 routes; `ts_runtime_blocker` 187→**176**, `fail_closed` 51→**62** (+11/−11; manifest change is purely additive). Family stays in blocker list.
- `npm run build`: passed (no type errors).
- `npx vitest run test/unit/api/http/routes/friday-desktop-routes.test.ts`: 43 passed — the 11 legacy "dep invoked" assertions preserved behind the test-oracle flags, plus 3 new "fail-closes by default" tests asserting 503 + `dep not.toHaveBeenCalled()`.
- `test/unit/hub/bootstrap/desktop-policy-fail-closed.test.ts`, gate test, route-contract snapshot, runtime registration: passed.
- `FRIDAY_E2E_CORE=1 npm test`: passed — 926 files / 12610 tests, no type errors.
- `npm run lint`: 0 errors. `check:secret-patterns`, `detect-secrets`, `git diff --check`: passed.
- Two read-only reviewers (general-purpose): both PASS, zero issues.

## Safety
- No fake Rust delegation, no hidden fallback, no weakened tests/gates. New oracle flags are set nowhere in `src/` (default/live = fail-closed).
- No default-DB mutation; no pet/design-gallery files touched; no live desktop action performed (retirement removes TS's ability to perform them).
- No `provider_native_synced` / Friday v1 GO claim. TS runtime retirement remains incomplete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)