### PR TITLE
Close remaining desktop runtime blockers (full desktop family retirement)

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -1454,6 +1454,173 @@
       "executes_product_logic": false,
       "proof": "src/api/http/routes/friday-desktop-routes.ts wires default/live desktop.elements.search to TS_RUNTIME_DESKTOP_ELEMENT_INSPECTION_RETIRED after request validation and before calling the TypeScript desktop adapter, which actively queries the live desktop accessibility tree and returns raw element name/value/window title/accessibility attributes; legacy TS execution is reachable only through explicit allowTestOnlyDesktopElementInspectionExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned desktop element search entrypoint when available."
+    },
+    {
+      "id": "desktop_recordings_list",
+      "route": {
+        "method": "GET",
+        "path": "/v1/desktop/recordings",
+        "operationId": "desktop.recordings.list"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-desktop-routes.ts wires default/live desktop.recordings.list to TS_RUNTIME_DESKTOP_RECORDING_RETIRED before reading the TypeScript recording store, whose recordings carry user-authored names, descriptions, tags, parameter maps, and creator ids; the recording write/replay/step surfaces are already fail-closed, so the read is retired with them rather than projected. Legacy TS reads are reachable only through explicit allowTestOnlyDesktopRecordingExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned redacted desktop recording projection when available."
+    },
+    {
+      "id": "desktop_recordings_get",
+      "route": {
+        "method": "GET",
+        "path": "/v1/desktop/recordings/:recordingId",
+        "operationId": "desktop.recordings.get"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-desktop-routes.ts wires default/live desktop.recordings.get to TS_RUNTIME_DESKTOP_RECORDING_RETIRED before reading the TypeScript recording store, whose recording carries user-authored name/description/tags, a parameter map, and a creator id; the recording write/replay/step surfaces are already fail-closed, so the read is retired with them rather than projected. Legacy TS reads are reachable only through explicit allowTestOnlyDesktopRecordingExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned redacted desktop recording projection when available."
+    },
+    {
+      "id": "desktop_platform_get_compat",
+      "route": {
+        "method": "GET",
+        "path": "/v1/desktop/platform",
+        "operationId": "desktop.platform.get"
+      },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Keep desktop platform discovery as a bounded compatibility read. The default/live hub wiring (src/hub/friday-hub-bootstrap.ts desktopRouteDeps.platform.get) returns only the detected platform name and a connected boolean; it owns no product truth, performs no desktop action, and exposes no raw OS version, status message, or private path.",
+      "next_action": "Replace this compatibility read with a Rust-owned desktop platform capability projection when available."
+    },
+    {
+      "id": "desktop_permissions_list_compat",
+      "route": {
+        "method": "GET",
+        "path": "/v1/desktop/permissions",
+        "operationId": "desktop.permissions.list"
+      },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Keep desktop OS permission status as a bounded compatibility read. The default/live hub wiring (src/hub/friday-hub-bootstrap.ts desktopRouteDeps.permissions.list) performs a real OS capability check and returns only FridayDesktopPermissionDto entries (permission type, status, platform, static grant instructions, checkedAt) with no forbidden fields; it owns no product truth, grants nothing, and persists no decision.",
+      "next_action": "Replace this compatibility read with a Rust-owned desktop permission status projection when available."
+    },
+    {
+      "id": "desktop_policies_create",
+      "route": {
+        "method": "POST",
+        "path": "/v1/desktop/policies",
+        "operationId": "desktop.policies.create"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "Default/live hub wiring (src/hub/friday-hub-bootstrap.ts desktopRouteDeps.policies.create) throws DESKTOP_POLICY_NOT_PERSISTED (503, status proof_pending) before any policy product logic, persistence, or enforcement; no durable storage/evaluator/audit exists. test/unit/hub/bootstrap/desktop-policy-fail-closed.test.ts is a source-wiring regression guard that asserts these throwing deps remain present (it checks bootstrap source text, not runtime 503 behavior). The route owns no policy truth.",
+      "next_action": "Replace the proof_pending fail-closed response with a Rust-owned desktop policy create/persist/enforce entrypoint when available."
+    },
+    {
+      "id": "desktop_policies_get",
+      "route": {
+        "method": "GET",
+        "path": "/v1/desktop/policies/:policyId",
+        "operationId": "desktop.policies.get"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "Default/live hub wiring (src/hub/friday-hub-bootstrap.ts desktopRouteDeps.policies.get) throws DESKTOP_POLICY_NOT_PERSISTED (503, status proof_pending) before any policy read; no durable policy store exists so there is no redactable projection. test/unit/hub/bootstrap/desktop-policy-fail-closed.test.ts is a source-wiring regression guard that asserts these throwing deps remain present (it checks bootstrap source text, not runtime 503 behavior).",
+      "next_action": "Replace the proof_pending fail-closed response with a Rust-owned desktop policy read projection when available."
+    },
+    {
+      "id": "desktop_policies_list",
+      "route": {
+        "method": "GET",
+        "path": "/v1/desktop/policies",
+        "operationId": "desktop.policies.list"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "Default/live hub wiring (src/hub/friday-hub-bootstrap.ts desktopRouteDeps.policies.list) throws DESKTOP_POLICY_NOT_PERSISTED (503, status proof_pending) before any policy read; no durable policy store exists so there is no redactable projection. test/unit/hub/bootstrap/desktop-policy-fail-closed.test.ts is a source-wiring regression guard that asserts these throwing deps remain present (it checks bootstrap source text, not runtime 503 behavior).",
+      "next_action": "Replace the proof_pending fail-closed response with a Rust-owned desktop policy list projection when available."
+    },
+    {
+      "id": "desktop_policies_update",
+      "route": {
+        "method": "PATCH",
+        "path": "/v1/desktop/policies/:policyId",
+        "operationId": "desktop.policies.update"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "Default/live hub wiring (src/hub/friday-hub-bootstrap.ts desktopRouteDeps.policies.update) throws DESKTOP_POLICY_NOT_PERSISTED (503, status proof_pending) before any policy mutation; no durable storage/evaluator/audit exists. test/unit/hub/bootstrap/desktop-policy-fail-closed.test.ts is a source-wiring regression guard that asserts these throwing deps remain present (it checks bootstrap source text, not runtime 503 behavior).",
+      "next_action": "Replace the proof_pending fail-closed response with a Rust-owned desktop policy update/persist/enforce entrypoint when available."
+    },
+    {
+      "id": "desktop_policies_delete",
+      "route": {
+        "method": "DELETE",
+        "path": "/v1/desktop/policies/:policyId",
+        "operationId": "desktop.policies.delete"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "Default/live hub wiring (src/hub/friday-hub-bootstrap.ts desktopRouteDeps.policies.delete) throws DESKTOP_POLICY_NOT_PERSISTED (503, status proof_pending) before any policy mutation. test/unit/hub/bootstrap/desktop-policy-fail-closed.test.ts is a source-wiring regression guard that asserts these throwing deps remain present (it checks bootstrap source text, not runtime 503 behavior).",
+      "next_action": "Replace the proof_pending fail-closed response with a Rust-owned desktop policy delete entrypoint when available."
+    },
+    {
+      "id": "desktop_policies_rules_create",
+      "route": {
+        "method": "POST",
+        "path": "/v1/desktop/policies/:policyId/rules",
+        "operationId": "desktop.policies.rules.create"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "Default/live hub wiring (src/hub/friday-hub-bootstrap.ts desktopRouteDeps.policies.addRule) throws DESKTOP_POLICY_NOT_PERSISTED (503, status proof_pending) before any policy rule mutation. test/unit/hub/bootstrap/desktop-policy-fail-closed.test.ts is a source-wiring regression guard that asserts these throwing deps remain present (it checks bootstrap source text, not runtime 503 behavior).",
+      "next_action": "Replace the proof_pending fail-closed response with a Rust-owned desktop policy rule create entrypoint when available."
+    },
+    {
+      "id": "desktop_policies_rules_delete",
+      "route": {
+        "method": "DELETE",
+        "path": "/v1/desktop/policies/:policyId/rules/:ruleId",
+        "operationId": "desktop.policies.rules.delete"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "Default/live hub wiring (src/hub/friday-hub-bootstrap.ts desktopRouteDeps.policies.removeRule) throws DESKTOP_POLICY_NOT_PERSISTED (503, status proof_pending) before any policy rule mutation. test/unit/hub/bootstrap/desktop-policy-fail-closed.test.ts is a source-wiring regression guard that asserts these throwing deps remain present (it checks bootstrap source text, not runtime 503 behavior).",
+      "next_action": "Replace the proof_pending fail-closed response with a Rust-owned desktop policy rule delete entrypoint when available."
+    },
+    {
+      "id": "desktop_permissions_respond",
+      "route": {
+        "method": "POST",
+        "path": "/v1/desktop/permissions/prompts/:promptId/respond",
+        "operationId": "desktop.permissions.respond"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "Default/live hub wiring (src/hub/friday-hub-bootstrap.ts desktopRouteDeps.permissions.respond) throws DESKTOP_PERMISSION_DECISION_NOT_PERSISTED (503, status proof_pending) before any permission decision is recorded or enforced; prompt decisions are not durably stored. test/unit/hub/bootstrap/desktop-policy-fail-closed.test.ts is a source-wiring regression guard that asserts these throwing deps remain present (it checks bootstrap source text, not runtime 503 behavior).",
+      "next_action": "Replace the proof_pending fail-closed response with a Rust-owned desktop permission decision entrypoint when available."
+    },
+    {
+      "id": "desktop_permissions_decisions_list",
+      "route": {
+        "method": "GET",
+        "path": "/v1/desktop/permissions/decisions",
+        "operationId": "desktop.permissions.decisions.list"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "Default/live hub wiring (src/hub/friday-hub-bootstrap.ts desktopRouteDeps.permissions.listDecisions) throws DESKTOP_PERMISSION_DECISION_NOT_PERSISTED (503, status proof_pending) before any read; no decisions log is wired so there is no redactable projection. test/unit/hub/bootstrap/desktop-policy-fail-closed.test.ts is a source-wiring regression guard that asserts these throwing deps remain present (it checks bootstrap source text, not runtime 503 behavior).",
+      "next_action": "Replace the proof_pending fail-closed response with a Rust-owned desktop permission decision log projection when available."
     }
   ]
 }

--- a/src/api/http/routes/friday-desktop-routes.ts
+++ b/src/api/http/routes/friday-desktop-routes.ts
@@ -299,6 +299,9 @@ export function createFridayDesktopRoutes(
       path: "/v1/desktop/recordings",
       auth: { public: true },
       async handler(ctx) {
+        if (deps.allowTestOnlyDesktopRecordingExecution !== true) {
+          throwRetiredDesktopRecording();
+        }
         return deps.recordings.list(ctx.query as FridayListDesktopRecordingsQuery);
       },
     },
@@ -309,6 +312,9 @@ export function createFridayDesktopRoutes(
       auth: { public: true },
       async handler(ctx) {
         const { recordingId } = ctx.params as { recordingId: string };
+        if (deps.allowTestOnlyDesktopRecordingExecution !== true) {
+          throwRetiredDesktopRecording();
+        }
         return deps.recordings.get(recordingId);
       },
     },

--- a/test/unit/api/http/routes/friday-desktop-routes.test.ts
+++ b/test/unit/api/http/routes/friday-desktop-routes.test.ts
@@ -226,7 +226,7 @@ describe("createFridayDesktopRoutes", () => {
     });
 
     it("lists recordings", async () => {
-      const deps = makeDeps();
+      const deps = makeDeps({ allowTestOnlyDesktopRecordingExecution: true });
       const routes = createFridayDesktopRoutes(deps);
       const route = findRoute(routes, "desktop.recordings.list");
       expect(route.method).toBe("GET");
@@ -236,12 +236,27 @@ describe("createFridayDesktopRoutes", () => {
     });
 
     it("gets a recording by ID", async () => {
-      const deps = makeDeps();
+      const deps = makeDeps({ allowTestOnlyDesktopRecordingExecution: true });
       const routes = createFridayDesktopRoutes(deps);
       const route = findRoute(routes, "desktop.recordings.get");
 
       await route.handler(makeCtx({ params: { recordingId: "rec-1" } }));
       expect(deps.recordings.get).toHaveBeenCalledWith("rec-1");
+    });
+
+    it("fail-closes desktop recording reads (list/get) by default without invoking TypeScript services", async () => {
+      const deps = makeDeps();
+      const routes = createFridayDesktopRoutes(deps);
+
+      await expect(
+        findRoute(routes, "desktop.recordings.list").handler(makeCtx({ query: {} })),
+      ).rejects.toMatchObject({ code: "TS_RUNTIME_DESKTOP_RECORDING_RETIRED", httpStatus: 503 });
+      await expect(
+        findRoute(routes, "desktop.recordings.get").handler(makeCtx({ params: { recordingId: "rec-1" } })),
+      ).rejects.toMatchObject({ code: "TS_RUNTIME_DESKTOP_RECORDING_RETIRED", httpStatus: 503 });
+
+      expect(deps.recordings.list).not.toHaveBeenCalled();
+      expect(deps.recordings.get).not.toHaveBeenCalled();
     });
 
     it("stops a recording", async () => {


### PR DESCRIPTION
## Scope — TS runtime retirement: desktop family (PR 2 of 2 — closes the family)

Finishes retiring the desktop route family — the final **13 of 24** `desktop_runtime_blockers`. After this PR the `desktop_runtime_blockers` family is fully classified and drops out of the gate's blocker list; only `general_runtime_blocker_inventory` remains.

### fail_closed via NEW route guard (2)
- `GET /v1/desktop/recordings` (list) and `GET /v1/desktop/recordings/:recordingId` (get) → 503 `TS_RUNTIME_DESKTOP_RECORDING_RETIRED` before reading the TS recording store (recordings carry user-authored name/description/tags, a parameter map, and a creator id). The recording write/replay/step surfaces were already fail-closed in PR1, so the reads are retired with them rather than redacted. Reuses the existing `allowTestOnlyDesktopRecordingExecution` flag.

### compat_shim — bounded benign live capability reads, manifest-only (2)
- `GET /v1/desktop/platform` — default/live hub wiring returns only `{ platform, connected }` (no raw OS version/path/status).
- `GET /v1/desktop/permissions` — returns only benign `FridayDesktopPermissionDto` entries (permission type, status, platform, static grant instructions, checkedAt); no forbidden fields. This benign live OS-capability read is deliberately preserved.

### fail_closed — already 503 via hub B3 deps guard, manifest-only (9)
- 7 × `desktop.policies.*` + `desktop.permissions.respond` + `desktop.permissions.decisions.list`. In default/live, the hub bootstrap deps unconditionally throw `DESKTOP_POLICY_NOT_PERSISTED` / `DESKTOP_PERMISSION_DECISION_NOT_PERSISTED` (503, `proof_pending`) before any product logic/persistence — no durable store exists. This **respects the intentional B3 proof_pending design** (keeps its error code) and records it in the manifest rather than overriding it with a route guard.

## Verification (local)
- `npm run check:ts-runtime-retirement`: passed — 584 routes; `ts_runtime_blocker` 176→**163**, `fail_closed` 62→**73**, `compat_shim` 237→**239** (purely additive manifest change). `desktop_runtime_blockers` **removed** from blockerFamilies.
- `npm run build`: passed (no type errors).
- `npx vitest run test/unit/api/http/routes/friday-desktop-routes.test.ts`: 44 passed — recordings-read tests preserve their dep-invoked assertions behind the flag; a new "fail-closes by default" test asserts 503 + `not.toHaveBeenCalled()`.
- `test/unit/hub/bootstrap/desktop-policy-fail-closed.test.ts`, gate test, route-contract snapshot: passed.
- `FRIDAY_E2E_CORE=1 npm test`: passed — 926 files / 12611 tests, no type errors.
- `npm run lint`: 0 errors. `check:secret-patterns`, `detect-secrets`, `git diff --check`: passed.
- Two read-only reviewers (general-purpose): both **PASS**. They verified against HEAD source that the 9 B3 deps unconditionally throw 503 in default/live, that `platform.get`/`permissions.list` are genuinely benign, and that the recordings-read fail-close is correct. Non-blocking caveats recorded: the B3 fail-close has a source-text regression guard (not behavioral) — the manifest proof wording was made precise to reflect this; the 9 B3 closures are non-local (route + bootstrap) and compat_shim benignity is verified by review, not gate-enforced.

## Safety
- No fake Rust delegation, no hidden fallback, no weakened tests/gates. New oracle flag set nowhere in `src/` (default/live = fail-closed). B3 intentional design respected (not overridden).
- No default-DB mutation; no pet/design-gallery files touched; no live desktop action performed.
- No `provider_native_synced` / Friday v1 GO claim. TS runtime retirement remains incomplete (`general_runtime_blocker_inventory`, 163 routes, remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)