### PR TITLE
Exclude retired workflow-catalog-authoring scenarios from Real Green Gate

### DIFF
--- a/scripts/ops/run-real-green-gate.mjs
+++ b/scripts/ops/run-real-green-gate.mjs
@@ -135,6 +135,19 @@ const WORKFLOW_RUN_START_DEPENDENT_SCENARIOS = [
   "l5-workflow-approval-roundtrip",
 ];
 
+// Scenarios that author a workflow through the TypeScript catalog create
+// surface (POST /v1/workflows). Once workflows.create is classified
+// fail_closed in the TS runtime retirement manifest the route returns 503
+// TS_RUNTIME_WORKFLOW_CATALOG_MUTATION_RETIRED before any product logic, so
+// these scenarios cannot author a workflow and are honestly recorded as
+// excluded (not a fake pass). l3-workflow-browser-authoring clicks "Blank
+// draft" which calls workflows.create; l8-workflow-approval-soak uses the same
+// create-then-run executor as the already-excluded l5-workflow-approval-roundtrip.
+const WORKFLOW_CATALOG_AUTHORING_DEPENDENT_SCENARIOS = [
+  "l3-workflow-browser-authoring",
+  "l8-workflow-approval-soak",
+];
+
 const CLAUDE_SKILL_TESTS = [
   "test/unit/skills/registry/friday-skill-discovery.test.ts",
   "test/unit/skills/manifest/friday-skill-package-loader.test.ts",
@@ -273,6 +286,26 @@ export function resolveRetiredWorkflowRunScenarioExclusions(repoRoot) {
   return WORKFLOW_RUN_START_DEPENDENT_SCENARIOS.map((scenarioId) => ({
     scenarioId,
     reason: "POST /v1/workflow-runs is classified fail_closed in the TS runtime retirement manifest.",
+  }));
+}
+
+export function isWorkflowCatalogCreateFailClosed(manifest) {
+  const surfaces = Array.isArray(manifest?.surfaces) ? manifest.surfaces : [];
+  return surfaces.some((surface) =>
+    surface?.id === "workflows_create"
+    && surface?.classification === "fail_closed"
+    && surface?.executes_product_logic === false
+  );
+}
+
+export function resolveRetiredWorkflowCatalogScenarioExclusions(repoRoot) {
+  const manifest = readJsonFile(path.join(repoRoot, "docs", "ops", "ts-runtime-retirement-manifest.json"));
+  if (!isWorkflowCatalogCreateFailClosed(manifest)) {
+    return [];
+  }
+  return WORKFLOW_CATALOG_AUTHORING_DEPENDENT_SCENARIOS.map((scenarioId) => ({
+    scenarioId,
+    reason: "POST /v1/workflows is classified fail_closed in the TS runtime retirement manifest.",
   }));
 }
 
@@ -598,6 +631,7 @@ export function buildSummary({
   skillConformance,
   retiredAgentRunScenarioExclusions,
   retiredWorkflowRunScenarioExclusions,
+  retiredWorkflowCatalogScenarioExclusions,
   error,
 }) {
   const summary = {
@@ -618,6 +652,7 @@ export function buildSummary({
     skillConformance: skillConformance ?? null,
     retiredAgentRunScenarioExclusions: retiredAgentRunScenarioExclusions ?? [],
     retiredWorkflowRunScenarioExclusions: retiredWorkflowRunScenarioExclusions ?? [],
+    retiredWorkflowCatalogScenarioExclusions: retiredWorkflowCatalogScenarioExclusions ?? [],
     error: error ?? null,
   };
   summary.gate = {
@@ -653,9 +688,11 @@ async function main() {
   const excludeProviderScenarios = shouldExcludeProviderScenarios(liveProviderMode);
   const retiredAgentRunScenarioExclusions = resolveRetiredAgentRunScenarioExclusions(repoRoot);
   const retiredWorkflowRunScenarioExclusions = resolveRetiredWorkflowRunScenarioExclusions(repoRoot);
+  const retiredWorkflowCatalogScenarioExclusions = resolveRetiredWorkflowCatalogScenarioExclusions(repoRoot);
   const excludedScenarioIds = [
     ...retiredAgentRunScenarioExclusions,
     ...retiredWorkflowRunScenarioExclusions,
+    ...retiredWorkflowCatalogScenarioExclusions,
   ].map((entry) => entry.scenarioId);
   const runId = createRunId();
   const reportRoot = options.reportRoot
@@ -859,6 +896,7 @@ async function main() {
       skillConformance,
       retiredAgentRunScenarioExclusions,
       retiredWorkflowRunScenarioExclusions,
+      retiredWorkflowCatalogScenarioExclusions,
       error: terminalError,
     });
     flushTerminalArtifacts(reportRoot, summary);

--- a/test/unit/ops/run-real-green-gate.test.ts
+++ b/test/unit/ops/run-real-green-gate.test.ts
@@ -4,10 +4,12 @@ import { describe, expect, it } from "vitest";
 import {
   buildSummary,
   isAgentRunStartFailClosed,
+  isWorkflowCatalogCreateFailClosed,
   isWorkflowRunStartFailClosed,
   normalizeLiveProviderMode,
   resolveGateSuiteReportRoot,
   resolveRetiredAgentRunScenarioExclusions,
+  resolveRetiredWorkflowCatalogScenarioExclusions,
   resolveRetiredWorkflowRunScenarioExclusions,
   shouldExcludeProviderScenarios,
   summarizeRun,
@@ -111,6 +113,41 @@ describe("run-real-green-gate helpers", () => {
     ]);
   });
 
+  it("detects fail-closed workflow catalog create retirement from the manifest", () => {
+    expect(isWorkflowCatalogCreateFailClosed({
+      surfaces: [
+        {
+          id: "workflows_create",
+          classification: "fail_closed",
+          executes_product_logic: false,
+        },
+      ],
+    })).toBe(true);
+    expect(isWorkflowCatalogCreateFailClosed({
+      surfaces: [
+        {
+          id: "workflows_create",
+          classification: "ts_runtime_blocker",
+          executes_product_logic: true,
+        },
+      ],
+    })).toBe(false);
+    expect(isWorkflowCatalogCreateFailClosed({ surfaces: [] })).toBe(false);
+  });
+
+  it("excludes workflow-catalog-authoring-dependent RGG scenarios while workflows.create is fail-closed", () => {
+    expect(resolveRetiredWorkflowCatalogScenarioExclusions(process.cwd())).toEqual([
+      {
+        scenarioId: "l3-workflow-browser-authoring",
+        reason: "POST /v1/workflows is classified fail_closed in the TS runtime retirement manifest.",
+      },
+      {
+        scenarioId: "l8-workflow-approval-soak",
+        reason: "POST /v1/workflows is classified fail_closed in the TS runtime retirement manifest.",
+      },
+    ]);
+  });
+
   it("preserves retired runtime scenario exclusions in the terminal summary", () => {
     const summary = buildSummary({
       runId: "run-1",
@@ -152,8 +189,20 @@ describe("run-real-green-gate helpers", () => {
           reason: "POST /v1/workflow-runs is classified fail_closed in the TS runtime retirement manifest.",
         },
       ],
+      retiredWorkflowCatalogScenarioExclusions: [
+        {
+          scenarioId: "l3-workflow-browser-authoring",
+          reason: "POST /v1/workflows is classified fail_closed in the TS runtime retirement manifest.",
+        },
+      ],
     });
 
+    expect(summary.retiredWorkflowCatalogScenarioExclusions).toEqual([
+      {
+        scenarioId: "l3-workflow-browser-authoring",
+        reason: "POST /v1/workflows is classified fail_closed in the TS runtime retirement manifest.",
+      },
+    ]);
     expect(summary.retiredAgentRunScenarioExclusions).toEqual([
       {
         scenarioId: "l3-channel-origin-unified-task-state-contract",


### PR DESCRIPTION
## Why — make main's Real Green Gate green again

The **Real Green Gate (RGG)** on `main` has been **red since PR #540** fail-closed the workflow catalog write surfaces. Root cause (confirmed from the RGG run artifact + source trace):

- The public-surface scenario **`l3-workflow-browser-authoring`** (a real-browser test that clicks **"Blank draft"** at `/workflows/builder`) calls `POST /v1/workflows` (`workflows.create`).
- `workflows.create` is now classified `fail_closed` in the TS runtime retirement manifest → returns `503 TS_RUNTIME_WORKFLOW_CATALOG_MUTATION_RETIRED` **before** product logic.
- The builder canvas never renders → 120s timeout → public-surface suite fails → `gate.passed=false` (`blocked_reasons: ["public surface suite is not fully passed"]`, 58/59 scenarios passed).

Workflow catalog authoring is **genuinely retired** (TS no longer owns it; the Rust-owned authoring entrypoint is the successor goal's work), so the scenario cannot author a workflow. This is exactly the situation the existing RGG retirement-exclusion mechanism handles (it already excludes `agent_runs_start`- and `workflow_runs_start`-dependent scenarios).

## What

Mirror the existing pattern exactly:
- `isWorkflowCatalogCreateFailClosed(manifest)` — true only when the manifest surface `workflows_create` is `fail_closed` with `executes_product_logic:false`.
- `resolveRetiredWorkflowCatalogScenarioExclusions(repoRoot)` — while that holds, excludes `l3-workflow-browser-authoring` (the gate-red cause) and `l8-workflow-approval-soak` (same create-then-run executor as the already-excluded `l5-workflow-approval-roundtrip`).
- Threaded into `excludedScenarioIds` (so the scenarios are skipped at the suite level) and recorded transparently in the gate summary as `retiredWorkflowCatalogScenarioExclusions`.

**This is not a fake pass / gate-weakening:** the exclusion is *gated on the manifest classification* — if `workflows.create` is ever un-retired, the exclusion auto-disappears and the scenarios run again. The exclusion is recorded in the summary, not silently dropped. No gate reason, threshold, or existing exclusion was removed or loosened.

## Verification
- `npx vitest run test/unit/ops/run-real-green-gate.test.ts`: 10 passed, no type errors — covers the predicate (positive `fail_closed`→true; negatives `ts_runtime_blocker`/empty→false), the resolver against the **real repo manifest** (returns exactly the 2 scenarios), and summary round-trip.
- `node --check scripts/ops/run-real-green-gate.mjs`: pass. `npm run build`: pass. `npm run check:ts-runtime-retirement`: passed (163 blockers). `eslint` (changed files): 0 errors. `git diff --check`, `detect-secrets`: pass.
- Two read-only reviewers (general-purpose): both **PASS** — verified the route is genuinely fail-closed in product code, the exclusion is honest/gated/recorded, no other gate-run scenario depends on `workflows.create`, and the wiring takes effect (scenarios skipped via `validation/real-world/lib/runner.mjs`). Caveat both noted: a static review can confirm honesty but only an actual RGG run confirms green — I will verify the **post-merge RGG on main goes green**.

## Scope / safety
- Only 2 files changed (the ops gate script + its unit test); +87/−0, purely additive. No product/runtime/manifest/threshold change.
- No fake Rust delegation, no weakened gate, no secret/raw leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)