### PR TITLE
Fail close deterministic-pipeline runtime surfaces

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -1621,6 +1621,240 @@
       "executes_product_logic": false,
       "proof": "Default/live hub wiring (src/hub/friday-hub-bootstrap.ts desktopRouteDeps.permissions.listDecisions) throws DESKTOP_PERMISSION_DECISION_NOT_PERSISTED (503, status proof_pending) before any read; no decisions log is wired so there is no redactable projection. test/unit/hub/bootstrap/desktop-policy-fail-closed.test.ts is a source-wiring regression guard that asserts these throwing deps remain present (it checks bootstrap source text, not runtime 503 behavior).",
       "next_action": "Replace the proof_pending fail-closed response with a Rust-owned desktop permission decision log projection when available."
+    },
+    {
+      "id": "rules_bundles_create",
+      "route": {
+        "method": "POST",
+        "path": "/v1/rules/bundles",
+        "operationId": "rules.bundles.create"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-deterministic-pipeline-routes.ts wires default/live rules.bundles.create to TS_RUNTIME_RULES_PIPELINE_RETIRED after request validation and before calling the TypeScript rule bundle create service; legacy behavior is reachable only through explicit allowTestOnlyRulesPipelineExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned deterministic rules evaluation/authoring entrypoint when available."
+    },
+    {
+      "id": "rules_bundles_update",
+      "route": {
+        "method": "PATCH",
+        "path": "/v1/rules/bundles/:bundleId",
+        "operationId": "rules.bundles.update"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-deterministic-pipeline-routes.ts wires default/live rules.bundles.update to TS_RUNTIME_RULES_PIPELINE_RETIRED after request validation and before calling the TypeScript rule bundle update service; legacy behavior is reachable only through explicit allowTestOnlyRulesPipelineExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned deterministic rules evaluation/authoring entrypoint when available."
+    },
+    {
+      "id": "rules_evaluate",
+      "route": {
+        "method": "POST",
+        "path": "/v1/rules/evaluate",
+        "operationId": "rules.evaluate"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-deterministic-pipeline-routes.ts wires default/live rules.evaluate to TS_RUNTIME_RULES_PIPELINE_RETIRED after request validation and before calling the TypeScript rule evaluation engine service; legacy behavior is reachable only through explicit allowTestOnlyRulesPipelineExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned deterministic rules evaluation/authoring entrypoint when available."
+    },
+    {
+      "id": "rules_simulate",
+      "route": {
+        "method": "POST",
+        "path": "/v1/rules/simulate",
+        "operationId": "rules.simulate"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-deterministic-pipeline-routes.ts wires default/live rules.simulate to TS_RUNTIME_RULES_PIPELINE_RETIRED after request validation and before calling the TypeScript rule simulation engine service; legacy behavior is reachable only through explicit allowTestOnlyRulesPipelineExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned deterministic rules evaluation/authoring entrypoint when available."
+    },
+    {
+      "id": "node_runner_execute",
+      "route": {
+        "method": "POST",
+        "path": "/v1/node-runner/execute",
+        "operationId": "node.runner.execute"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-deterministic-pipeline-routes.ts wires default/live node.runner.execute to TS_RUNTIME_NODE_RUNNER_EXECUTION_RETIRED after request validation and before calling the TypeScript node execution (adapter side effects) service; legacy behavior is reachable only through explicit allowTestOnlyNodeRunnerExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned deterministic node-runner execution entrypoint when available."
+    },
+    {
+      "id": "acceptance_run",
+      "route": {
+        "method": "POST",
+        "path": "/v1/acceptance/run",
+        "operationId": "acceptance.run"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-deterministic-pipeline-routes.ts wires default/live acceptance.run to TS_RUNTIME_ACCEPTANCE_PIPELINE_RETIRED after request validation and before calling the TypeScript acceptance check execution service; legacy behavior is reachable only through explicit allowTestOnlyAcceptancePipelineExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned deterministic acceptance entrypoint when available."
+    },
+    {
+      "id": "acceptance_tests_create",
+      "route": {
+        "method": "POST",
+        "path": "/v1/acceptance/tests",
+        "operationId": "acceptance.tests.create"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-deterministic-pipeline-routes.ts wires default/live acceptance.tests.create to TS_RUNTIME_ACCEPTANCE_PIPELINE_RETIRED after request validation and before calling the TypeScript acceptance test create service; legacy behavior is reachable only through explicit allowTestOnlyAcceptancePipelineExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned deterministic acceptance entrypoint when available."
+    },
+    {
+      "id": "acceptance_tests_update",
+      "route": {
+        "method": "PUT",
+        "path": "/v1/acceptance/tests/:testId",
+        "operationId": "acceptance.tests.update"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-deterministic-pipeline-routes.ts wires default/live acceptance.tests.update to TS_RUNTIME_ACCEPTANCE_PIPELINE_RETIRED after request validation and before calling the TypeScript acceptance test update service; legacy behavior is reachable only through explicit allowTestOnlyAcceptancePipelineExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned deterministic acceptance entrypoint when available."
+    },
+    {
+      "id": "acceptance_tests_delete",
+      "route": {
+        "method": "DELETE",
+        "path": "/v1/acceptance/tests/:testId",
+        "operationId": "acceptance.tests.delete"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-deterministic-pipeline-routes.ts wires default/live acceptance.tests.delete to TS_RUNTIME_ACCEPTANCE_PIPELINE_RETIRED after request validation and before calling the TypeScript acceptance test delete service; legacy behavior is reachable only through explicit allowTestOnlyAcceptancePipelineExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned deterministic acceptance entrypoint when available."
+    },
+    {
+      "id": "retry_policies_create",
+      "route": {
+        "method": "POST",
+        "path": "/v1/retry/policies",
+        "operationId": "retry.policies.create"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-deterministic-pipeline-routes.ts wires default/live retry.policies.create to TS_RUNTIME_RETRY_PIPELINE_RETIRED after request validation and before calling the TypeScript retry policy create service; legacy behavior is reachable only through explicit allowTestOnlyRetryPipelineExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned deterministic retry entrypoint when available."
+    },
+    {
+      "id": "retry_policies_update",
+      "route": {
+        "method": "PUT",
+        "path": "/v1/retry/policies/:policyId",
+        "operationId": "retry.policies.update"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-deterministic-pipeline-routes.ts wires default/live retry.policies.update to TS_RUNTIME_RETRY_PIPELINE_RETIRED after request validation and before calling the TypeScript retry policy update service; legacy behavior is reachable only through explicit allowTestOnlyRetryPipelineExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned deterministic retry entrypoint when available."
+    },
+    {
+      "id": "retry_policies_delete",
+      "route": {
+        "method": "DELETE",
+        "path": "/v1/retry/policies/:policyId",
+        "operationId": "retry.policies.delete"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-deterministic-pipeline-routes.ts wires default/live retry.policies.delete to TS_RUNTIME_RETRY_PIPELINE_RETIRED after request validation and before calling the TypeScript retry policy delete service; legacy behavior is reachable only through explicit allowTestOnlyRetryPipelineExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned deterministic retry entrypoint when available."
+    },
+    {
+      "id": "retry_classify",
+      "route": {
+        "method": "POST",
+        "path": "/v1/retry/classify",
+        "operationId": "retry.classify"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-deterministic-pipeline-routes.ts wires default/live retry.classify to TS_RUNTIME_RETRY_PIPELINE_RETIRED after request validation and before calling the TypeScript retry failure classification engine service; legacy behavior is reachable only through explicit allowTestOnlyRetryPipelineExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned deterministic retry entrypoint when available."
+    },
+    {
+      "id": "retry_decide",
+      "route": {
+        "method": "POST",
+        "path": "/v1/retry/decide",
+        "operationId": "retry.decide"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-deterministic-pipeline-routes.ts wires default/live retry.decide to TS_RUNTIME_RETRY_PIPELINE_RETIRED after request validation and before calling the TypeScript retry decision engine service; legacy behavior is reachable only through explicit allowTestOnlyRetryPipelineExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned deterministic retry entrypoint when available."
+    },
+    {
+      "id": "retry_escalations_acknowledge",
+      "route": {
+        "method": "POST",
+        "path": "/v1/retry/escalations/:escalationId/acknowledge",
+        "operationId": "retry.escalations.acknowledge"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-deterministic-pipeline-routes.ts wires default/live retry.escalations.acknowledge to TS_RUNTIME_RETRY_PIPELINE_RETIRED after request validation and before calling the TypeScript retry escalation acknowledge state write service; legacy behavior is reachable only through explicit allowTestOnlyRetryPipelineExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned deterministic retry entrypoint when available."
+    },
+    {
+      "id": "playbook_select",
+      "route": {
+        "method": "POST",
+        "path": "/v1/playbooks/select",
+        "operationId": "playbook.select"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-deterministic-pipeline-routes.ts wires default/live playbook.select to TS_RUNTIME_PLAYBOOK_PIPELINE_RETIRED after request validation and before calling the TypeScript playbook selection engine service; legacy behavior is reachable only through explicit allowTestOnlyPlaybookPipelineExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned deterministic playbook entrypoint when available."
+    },
+    {
+      "id": "playbook_candidates_promote",
+      "route": {
+        "method": "POST",
+        "path": "/v1/playbooks/candidates/:candidateId/promote",
+        "operationId": "playbook.candidates.promote"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-deterministic-pipeline-routes.ts wires default/live playbook.candidates.promote to TS_RUNTIME_PLAYBOOK_PIPELINE_RETIRED after request validation and before calling the TypeScript playbook candidate promotion service; legacy behavior is reachable only through explicit allowTestOnlyPlaybookPipelineExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned deterministic playbook entrypoint when available."
+    },
+    {
+      "id": "playbook_rollback",
+      "route": {
+        "method": "POST",
+        "path": "/v1/playbooks/:playbookId/rollback",
+        "operationId": "playbook.rollback"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-deterministic-pipeline-routes.ts wires default/live playbook.rollback to TS_RUNTIME_PLAYBOOK_PIPELINE_RETIRED after request validation and before calling the TypeScript playbook version rollback service; legacy behavior is reachable only through explicit allowTestOnlyPlaybookPipelineExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned deterministic playbook entrypoint when available."
     }
   ]
 }

--- a/src/api/http/routes/friday-deterministic-pipeline-routes.ts
+++ b/src/api/http/routes/friday-deterministic-pipeline-routes.ts
@@ -80,6 +80,95 @@ export interface FridayDeterministicPipelineRoutesDeps {
     rollbackPlaybook: (playbookId: string, body: unknown) => Promise<unknown>;
     getScoreHistory: (playbookId: string, query: Record<string, unknown>) => unknown;
   };
+
+  // ─ Test-oracle flags ─
+  // Each flag opts isolated tests into the legacy TypeScript pipeline behavior
+  // for one sub-family. Default/live runtime must leave them unset so the
+  // deterministic-pipeline mutation/engine surfaces stay fail-closed until Rust
+  // owns the corresponding entrypoints.
+  allowTestOnlyRulesPipelineExecution?: boolean;
+  allowTestOnlyNodeRunnerExecution?: boolean;
+  allowTestOnlyAcceptancePipelineExecution?: boolean;
+  allowTestOnlyRetryPipelineExecution?: boolean;
+  allowTestOnlyPlaybookPipelineExecution?: boolean;
+}
+
+// ─── Retirement helpers ───
+//
+// The deterministic-pipeline mutation and engine-execution surfaces (rule
+// bundle create/update + evaluate/simulate, node-runner execute, acceptance
+// run + test create/update/delete, retry policy create/update/delete +
+// classify/decide/escalation acknowledge, playbook select/promote/rollback)
+// run TypeScript product logic or write state. They fail-close by default/live
+// until Rust owns the corresponding entrypoints; legacy behavior is reachable
+// only through the explicit per-sub-family test-oracle flags above.
+
+function throwRetiredDeterministicPipeline(
+  code: string,
+  label: string,
+  replacement: string,
+): never {
+  throw new FridayDomainError(
+    code,
+    `${label} is fail-closed in default/live runtime; use the Rust-owned ${replacement} entrypoint.`,
+    {
+      httpStatus: 503,
+      details: {
+        classification: "fail_closed",
+        replacement: `rust_owned_${replacement}_entrypoint_required`,
+      },
+    },
+  );
+}
+
+function assertRulesPipelineTestOracleAllowed(deps: FridayDeterministicPipelineRoutesDeps): void {
+  if (deps.allowTestOnlyRulesPipelineExecution !== true) {
+    throwRetiredDeterministicPipeline(
+      "TS_RUNTIME_RULES_PIPELINE_RETIRED",
+      "TypeScript rules pipeline execution",
+      "deterministic_rules_pipeline",
+    );
+  }
+}
+
+function assertNodeRunnerTestOracleAllowed(deps: FridayDeterministicPipelineRoutesDeps): void {
+  if (deps.allowTestOnlyNodeRunnerExecution !== true) {
+    throwRetiredDeterministicPipeline(
+      "TS_RUNTIME_NODE_RUNNER_EXECUTION_RETIRED",
+      "TypeScript node-runner execution",
+      "deterministic_node_runner",
+    );
+  }
+}
+
+function assertAcceptancePipelineTestOracleAllowed(deps: FridayDeterministicPipelineRoutesDeps): void {
+  if (deps.allowTestOnlyAcceptancePipelineExecution !== true) {
+    throwRetiredDeterministicPipeline(
+      "TS_RUNTIME_ACCEPTANCE_PIPELINE_RETIRED",
+      "TypeScript acceptance pipeline execution",
+      "deterministic_acceptance_pipeline",
+    );
+  }
+}
+
+function assertRetryPipelineTestOracleAllowed(deps: FridayDeterministicPipelineRoutesDeps): void {
+  if (deps.allowTestOnlyRetryPipelineExecution !== true) {
+    throwRetiredDeterministicPipeline(
+      "TS_RUNTIME_RETRY_PIPELINE_RETIRED",
+      "TypeScript retry pipeline execution",
+      "deterministic_retry_pipeline",
+    );
+  }
+}
+
+function assertPlaybookPipelineTestOracleAllowed(deps: FridayDeterministicPipelineRoutesDeps): void {
+  if (deps.allowTestOnlyPlaybookPipelineExecution !== true) {
+    throwRetiredDeterministicPipeline(
+      "TS_RUNTIME_PLAYBOOK_PIPELINE_RETIRED",
+      "TypeScript playbook pipeline execution",
+      "deterministic_playbook_pipeline",
+    );
+  }
 }
 
 // ─── Route Factory ───
@@ -127,6 +216,7 @@ export function createFridayDeterministicPipelineRoutes(
             { httpStatus: 400 },
           );
         }
+        assertRulesPipelineTestOracleAllowed(deps);
         return deps.rules.createBundle(body);
       },
     },
@@ -145,6 +235,7 @@ export function createFridayDeterministicPipelineRoutes(
             { httpStatus: 400 },
           );
         }
+        assertRulesPipelineTestOracleAllowed(deps);
         return deps.rules.updateBundle(bundleId, body);
       },
     },
@@ -184,6 +275,7 @@ export function createFridayDeterministicPipelineRoutes(
             { httpStatus: 400 },
           );
         }
+        assertRulesPipelineTestOracleAllowed(deps);
         return deps.rules.evaluateRules(body);
       },
     },
@@ -202,6 +294,7 @@ export function createFridayDeterministicPipelineRoutes(
             { httpStatus: 400 },
           );
         }
+        assertRulesPipelineTestOracleAllowed(deps);
         return deps.rules.simulateRules(body);
       },
     },
@@ -245,6 +338,7 @@ export function createFridayDeterministicPipelineRoutes(
             { httpStatus: 400 },
           );
         }
+        assertNodeRunnerTestOracleAllowed(deps);
         return deps.nodeRunner.executeNode(body);
       },
     },
@@ -288,6 +382,7 @@ export function createFridayDeterministicPipelineRoutes(
             { httpStatus: 400 },
           );
         }
+        assertAcceptancePipelineTestOracleAllowed(deps);
         return deps.acceptance.runChecks(body);
       },
     },
@@ -359,6 +454,7 @@ export function createFridayDeterministicPipelineRoutes(
             { httpStatus: 400 },
           );
         }
+        assertAcceptancePipelineTestOracleAllowed(deps);
         return deps.acceptance.createTest(body);
       },
     },
@@ -378,6 +474,7 @@ export function createFridayDeterministicPipelineRoutes(
           );
         }
         const { testId } = ctx.params as { testId: string };
+        assertAcceptancePipelineTestOracleAllowed(deps);
         return deps.acceptance.updateTest(testId, body);
       },
     },
@@ -397,6 +494,7 @@ export function createFridayDeterministicPipelineRoutes(
           );
         }
         const { testId } = ctx.params as { testId: string };
+        assertAcceptancePipelineTestOracleAllowed(deps);
         return deps.acceptance.deleteTest(testId, body);
       },
     },
@@ -468,6 +566,7 @@ export function createFridayDeterministicPipelineRoutes(
             { httpStatus: 400 },
           );
         }
+        assertRetryPipelineTestOracleAllowed(deps);
         return deps.retry.createPolicy(body);
       },
     },
@@ -487,6 +586,7 @@ export function createFridayDeterministicPipelineRoutes(
           );
         }
         const { policyId } = ctx.params as { policyId: string };
+        assertRetryPipelineTestOracleAllowed(deps);
         return deps.retry.updatePolicy(policyId, body);
       },
     },
@@ -506,6 +606,7 @@ export function createFridayDeterministicPipelineRoutes(
           );
         }
         const { policyId } = ctx.params as { policyId: string };
+        assertRetryPipelineTestOracleAllowed(deps);
         return deps.retry.deletePolicy(policyId, body);
       },
     },
@@ -524,6 +625,7 @@ export function createFridayDeterministicPipelineRoutes(
             { httpStatus: 400 },
           );
         }
+        assertRetryPipelineTestOracleAllowed(deps);
         return deps.retry.classifyFailure(body);
       },
     },
@@ -542,6 +644,7 @@ export function createFridayDeterministicPipelineRoutes(
             { httpStatus: 400 },
           );
         }
+        assertRetryPipelineTestOracleAllowed(deps);
         return deps.retry.decideRetry(body);
       },
     },
@@ -594,6 +697,7 @@ export function createFridayDeterministicPipelineRoutes(
       auth: { public: true },
       async handler(ctx) {
         const { escalationId } = ctx.params as { escalationId: string };
+        assertRetryPipelineTestOracleAllowed(deps);
         return deps.retry.acknowledgeEscalation(escalationId, ctx.body);
       },
     },
@@ -647,6 +751,7 @@ export function createFridayDeterministicPipelineRoutes(
             { httpStatus: 400 },
           );
         }
+        assertPlaybookPipelineTestOracleAllowed(deps);
         return deps.playbook.selectPlaybook(body);
       },
     },
@@ -668,6 +773,7 @@ export function createFridayDeterministicPipelineRoutes(
       auth: { public: true },
       async handler(ctx) {
         const { candidateId } = ctx.params as { candidateId: string };
+        assertPlaybookPipelineTestOracleAllowed(deps);
         return deps.playbook.promoteCandidate(candidateId, ctx.body);
       },
     },
@@ -687,6 +793,7 @@ export function createFridayDeterministicPipelineRoutes(
             { httpStatus: 400 },
           );
         }
+        assertPlaybookPipelineTestOracleAllowed(deps);
         return deps.playbook.rollbackPlaybook(playbookId, body);
       },
     },

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -3253,7 +3253,14 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
 
   // Register deterministic pipeline routes (optional — only if service is provided)
   if (deps.deterministicPipeline) {
-    for (const route of createFridayDeterministicPipelineRoutes(deps.deterministicPipeline)) {
+    for (const route of createFridayDeterministicPipelineRoutes({
+      ...deps.deterministicPipeline,
+      allowTestOnlyRulesPipelineExecution: deps.allowTestOnlyRulesPipelineExecution,
+      allowTestOnlyNodeRunnerExecution: deps.allowTestOnlyNodeRunnerExecution,
+      allowTestOnlyAcceptancePipelineExecution: deps.allowTestOnlyAcceptancePipelineExecution,
+      allowTestOnlyRetryPipelineExecution: deps.allowTestOnlyRetryPipelineExecution,
+      allowTestOnlyPlaybookPipelineExecution: deps.allowTestOnlyPlaybookPipelineExecution,
+    })) {
       routes.register(route);
     }
   }

--- a/src/api/runtime/friday-api-runtime.types.ts
+++ b/src/api/runtime/friday-api-runtime.types.ts
@@ -248,6 +248,18 @@ export interface CreateFridayApiRuntimeDeps {
    * fail-closed until Rust owns workflow bundle import truth.
    */
   allowTestOnlyWorkflowBundleImportExecution?: boolean;
+  /**
+   * Test-oracle only: allow the legacy TypeScript deterministic-pipeline
+   * surfaces (rules, node-runner, acceptance, retry, playbook) in isolated
+   * mock/unit validation. Production/runtime callers must leave these unset so
+   * the corresponding mutation/engine-execution routes stay fail-closed until
+   * Rust owns the deterministic-pipeline entrypoints.
+   */
+  allowTestOnlyRulesPipelineExecution?: boolean;
+  allowTestOnlyNodeRunnerExecution?: boolean;
+  allowTestOnlyAcceptancePipelineExecution?: boolean;
+  allowTestOnlyRetryPipelineExecution?: boolean;
+  allowTestOnlyPlaybookPipelineExecution?: boolean;
   /** Optional: user/project prompt-guidance provider for fallback workflow runtime creation. */
   userRulesContextProvider?: CreateFridayWorkflowRuntimeDeps["userRulesContextProvider"];
   /** Optional: reuse hub's session service instead of creating a new one. */

--- a/test/unit/api/http/routes/friday-deterministic-pipeline-routes.test.ts
+++ b/test/unit/api/http/routes/friday-deterministic-pipeline-routes.test.ts
@@ -33,8 +33,19 @@ function findRoute(routes: FridayRouteDefinition<unknown, unknown, unknown, unkn
   return routes.find((r) => r.operationId === operationId)!;
 }
 
-function makeDeps(): FridayDeterministicPipelineRoutesDeps {
+function makeDeps(
+  overrides?: Partial<FridayDeterministicPipelineRoutesDeps>,
+): FridayDeterministicPipelineRoutesDeps {
   return {
+    // Default isolated unit deps opt into the legacy pipeline test-oracle so the
+    // delegate/validation tests below still exercise the dep contract.
+    // Default/live runtime leaves these unset; the "fail-closes by default"
+    // tests pass them as false to prove the 503 boundary.
+    allowTestOnlyRulesPipelineExecution: true,
+    allowTestOnlyNodeRunnerExecution: true,
+    allowTestOnlyAcceptancePipelineExecution: true,
+    allowTestOnlyRetryPipelineExecution: true,
+    allowTestOnlyPlaybookPipelineExecution: true,
     rules: {
       listBundles: vi.fn().mockReturnValue({ bundles: [], total: 0 }),
       getBundle: vi.fn().mockReturnValue({ bundle: { id: "b-1" } }),
@@ -88,6 +99,7 @@ function makeDeps(): FridayDeterministicPipelineRoutesDeps {
       rollbackPlaybook: vi.fn().mockResolvedValue({ playbook: { id: "pb-1" } }),
       getScoreHistory: vi.fn().mockReturnValue({ scores: [] }),
     },
+    ...overrides,
   };
 }
 
@@ -434,6 +446,87 @@ describe("A-007 FridayDeterministicPipelineRoutes", () => {
 
       await route.handler(makeCtx({ params: { playbookId: "pb-1" } }));
       expect(deps.playbook.getScoreHistory).toHaveBeenCalledWith("pb-1", {});
+    });
+  });
+
+  describe("fail-closed by default without the test-oracle", () => {
+    it("rules pipeline mutations/engines fail-close with TS_RUNTIME_RULES_PIPELINE_RETIRED", async () => {
+      const deps = makeDeps({ allowTestOnlyRulesPipelineExecution: false });
+      const routes = createFridayDeterministicPipelineRoutes(deps);
+      await expect(findRoute(routes, "rules.bundles.create").handler(makeCtx({ body: { name: "B" } })))
+        .rejects.toMatchObject({ code: "TS_RUNTIME_RULES_PIPELINE_RETIRED", httpStatus: 503 });
+      await expect(findRoute(routes, "rules.evaluate").handler(makeCtx({ body: { bundleId: "b-1" } })))
+        .rejects.toMatchObject({ code: "TS_RUNTIME_RULES_PIPELINE_RETIRED", httpStatus: 503 });
+      await expect(findRoute(routes, "rules.simulate").handler(makeCtx({ body: { bundleId: "b-1" } })))
+        .rejects.toMatchObject({ code: "TS_RUNTIME_RULES_PIPELINE_RETIRED", httpStatus: 503 });
+      await expect(findRoute(routes, "rules.bundles.update").handler(makeCtx({ params: { bundleId: "b-1" }, body: { name: "X" } })))
+        .rejects.toMatchObject({ code: "TS_RUNTIME_RULES_PIPELINE_RETIRED", httpStatus: 503 });
+      expect(deps.rules.createBundle).not.toHaveBeenCalled();
+      expect(deps.rules.updateBundle).not.toHaveBeenCalled();
+      expect(deps.rules.evaluateRules).not.toHaveBeenCalled();
+      expect(deps.rules.simulateRules).not.toHaveBeenCalled();
+    });
+
+    it("node-runner execute fail-closes with TS_RUNTIME_NODE_RUNNER_EXECUTION_RETIRED", async () => {
+      const deps = makeDeps({ allowTestOnlyNodeRunnerExecution: false });
+      const routes = createFridayDeterministicPipelineRoutes(deps);
+      await expect(findRoute(routes, "node.runner.execute").handler(makeCtx({ body: { nodeId: "n-1" } })))
+        .rejects.toMatchObject({ code: "TS_RUNTIME_NODE_RUNNER_EXECUTION_RETIRED", httpStatus: 503 });
+      expect(deps.nodeRunner.executeNode).not.toHaveBeenCalled();
+    });
+
+    it("acceptance run + test mutations fail-close with TS_RUNTIME_ACCEPTANCE_PIPELINE_RETIRED", async () => {
+      const deps = makeDeps({ allowTestOnlyAcceptancePipelineExecution: false });
+      const routes = createFridayDeterministicPipelineRoutes(deps);
+      await expect(findRoute(routes, "acceptance.run").handler(makeCtx({ body: { artifactType: "workflow_output" } })))
+        .rejects.toMatchObject({ code: "TS_RUNTIME_ACCEPTANCE_PIPELINE_RETIRED", httpStatus: 503 });
+      await expect(findRoute(routes, "acceptance.tests.create").handler(makeCtx({ body: { name: "t", artifactType: "x" } })))
+        .rejects.toMatchObject({ code: "TS_RUNTIME_ACCEPTANCE_PIPELINE_RETIRED", httpStatus: 503 });
+      await expect(findRoute(routes, "acceptance.tests.delete").handler(makeCtx({ params: { testId: "t-1" }, body: { etag: "e" } })))
+        .rejects.toMatchObject({ code: "TS_RUNTIME_ACCEPTANCE_PIPELINE_RETIRED", httpStatus: 503 });
+      await expect(findRoute(routes, "acceptance.tests.update").handler(makeCtx({ params: { testId: "t-1" }, body: { etag: "e" } })))
+        .rejects.toMatchObject({ code: "TS_RUNTIME_ACCEPTANCE_PIPELINE_RETIRED", httpStatus: 503 });
+      expect(deps.acceptance.runChecks).not.toHaveBeenCalled();
+      expect(deps.acceptance.createTest).not.toHaveBeenCalled();
+      expect(deps.acceptance.updateTest).not.toHaveBeenCalled();
+      expect(deps.acceptance.deleteTest).not.toHaveBeenCalled();
+    });
+
+    it("retry policy mutations + engines fail-close with TS_RUNTIME_RETRY_PIPELINE_RETIRED", async () => {
+      const deps = makeDeps({ allowTestOnlyRetryPipelineExecution: false });
+      const routes = createFridayDeterministicPipelineRoutes(deps);
+      await expect(findRoute(routes, "retry.policies.create").handler(makeCtx({ body: { name: "p" } })))
+        .rejects.toMatchObject({ code: "TS_RUNTIME_RETRY_PIPELINE_RETIRED", httpStatus: 503 });
+      await expect(findRoute(routes, "retry.classify").handler(makeCtx({ body: { error: { message: "x" } } })))
+        .rejects.toMatchObject({ code: "TS_RUNTIME_RETRY_PIPELINE_RETIRED", httpStatus: 503 });
+      await expect(findRoute(routes, "retry.decide").handler(makeCtx({ body: { runId: "r", workflowId: "w", nodeId: "n" } })))
+        .rejects.toMatchObject({ code: "TS_RUNTIME_RETRY_PIPELINE_RETIRED", httpStatus: 503 });
+      await expect(findRoute(routes, "retry.escalations.acknowledge").handler(makeCtx({ params: { escalationId: "e-1" }, body: {} })))
+        .rejects.toMatchObject({ code: "TS_RUNTIME_RETRY_PIPELINE_RETIRED", httpStatus: 503 });
+      await expect(findRoute(routes, "retry.policies.update").handler(makeCtx({ params: { policyId: "p-1" }, body: { etag: "e" } })))
+        .rejects.toMatchObject({ code: "TS_RUNTIME_RETRY_PIPELINE_RETIRED", httpStatus: 503 });
+      await expect(findRoute(routes, "retry.policies.delete").handler(makeCtx({ params: { policyId: "p-1" }, body: { etag: "e" } })))
+        .rejects.toMatchObject({ code: "TS_RUNTIME_RETRY_PIPELINE_RETIRED", httpStatus: 503 });
+      expect(deps.retry.createPolicy).not.toHaveBeenCalled();
+      expect(deps.retry.updatePolicy).not.toHaveBeenCalled();
+      expect(deps.retry.deletePolicy).not.toHaveBeenCalled();
+      expect(deps.retry.classifyFailure).not.toHaveBeenCalled();
+      expect(deps.retry.decideRetry).not.toHaveBeenCalled();
+      expect(deps.retry.acknowledgeEscalation).not.toHaveBeenCalled();
+    });
+
+    it("playbook select/promote/rollback fail-close with TS_RUNTIME_PLAYBOOK_PIPELINE_RETIRED", async () => {
+      const deps = makeDeps({ allowTestOnlyPlaybookPipelineExecution: false });
+      const routes = createFridayDeterministicPipelineRoutes(deps);
+      await expect(findRoute(routes, "playbook.select").handler(makeCtx({ body: { workflowType: "wt" } })))
+        .rejects.toMatchObject({ code: "TS_RUNTIME_PLAYBOOK_PIPELINE_RETIRED", httpStatus: 503 });
+      await expect(findRoute(routes, "playbook.candidates.promote").handler(makeCtx({ params: { candidateId: "c-1" }, body: {} })))
+        .rejects.toMatchObject({ code: "TS_RUNTIME_PLAYBOOK_PIPELINE_RETIRED", httpStatus: 503 });
+      await expect(findRoute(routes, "playbook.rollback").handler(makeCtx({ params: { playbookId: "pb-1" }, body: { targetVersionNumber: 1 } })))
+        .rejects.toMatchObject({ code: "TS_RUNTIME_PLAYBOOK_PIPELINE_RETIRED", httpStatus: 503 });
+      expect(deps.playbook.selectPlaybook).not.toHaveBeenCalled();
+      expect(deps.playbook.promoteCandidate).not.toHaveBeenCalled();
+      expect(deps.playbook.rollbackPlaybook).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Scope — TS runtime retirement: `general_runtime_blocker_inventory` (deterministic-pipeline family)

Fail-closes the **18 mutation/engine-execution routes** in `friday-deterministic-pipeline-routes.ts` (every non-GET route). The 26 GET reads stay `compat_shim` and are untouched.

| sub-family | error code (flag) | routes |
|---|---|---|
| rules | `TS_RUNTIME_RULES_PIPELINE_RETIRED` (`allowTestOnlyRulesPipelineExecution`) | bundles.create, bundles.update, evaluate, simulate |
| node-runner | `TS_RUNTIME_NODE_RUNNER_EXECUTION_RETIRED` (`allowTestOnlyNodeRunnerExecution`) | execute (runs a node — adapter side effects) |
| acceptance | `TS_RUNTIME_ACCEPTANCE_PIPELINE_RETIRED` (`allowTestOnlyAcceptancePipelineExecution`) | run, tests.create/update/delete |
| retry | `TS_RUNTIME_RETRY_PIPELINE_RETIRED` (`allowTestOnlyRetryPipelineExecution`) | policies.create/update/delete, classify, decide, escalations.acknowledge |
| playbook | `TS_RUNTIME_PLAYBOOK_PIPELINE_RETIRED` (`allowTestOnlyPlaybookPipelineExecution`) | select, candidates.promote, rollback |

Each guard fires **after request validation** (so invalid bodies still 400) and **before** the TypeScript service. Legacy behavior is reachable only via the explicit per-sub-family test-oracle flags, threaded from `CreateFridayApiRuntimeDeps` into the registration spread; default/live hub wiring leaves them unset (set nowhere in `src/`).

## Verification (local)
- `npm run check:ts-runtime-retirement`: passed — 584 routes; `ts_runtime_blocker` 163→**145**, `fail_closed` 73→**91** (manifest change purely additive, 0 deletions). `general_runtime_blocker_inventory` remains.
- `npm run build`: passed (no type errors).
- `npx vitest run test/unit/api/http/routes/friday-deterministic-pipeline-routes.test.ts`: 41 passed — existing delegate/validation tests preserved (makeDeps defaults the oracle flags on); 5 new "fail-closes by default" tests set the flag false and assert 503 + correct code + `dep not.toHaveBeenCalled()` for all 18 mutations. Route-count snapshot unchanged (44 / GET 26 / POST 13 / PUT 2 / PATCH 1 / DELETE 2).
- `FRIDAY_E2E_CORE=1 npm test`: passed — 926 files / 12618 tests, no type errors.
- `npm run lint`: 0 errors. `check:secret-patterns`, `detect-secrets`, `git diff --check`: passed.
- Two read-only reviewers (general-purpose): both **PASS** — verified all 18 mutations guarded after-validation/before-dep, all 26 GETs untouched, correct flag/code mapping, manifest additive & accurate, and that **no Real Green Gate scenario exercises these routes** (no RGG exclusion needed, unlike #544).

## Safety
- No fake Rust delegation, no hidden fallback, no weakened tests/gates. Oracle flags set nowhere in `src/` (default/live = fail-closed).
- No default-DB mutation; no pet/design-gallery files touched.
- No `provider_native_synced` / Friday v1 GO claim. TS runtime retirement remains incomplete (`general_runtime_blocker_inventory`, 145 routes, remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)