### PR TITLE
Fail close workflow builder draft/lock/conflict runtime surfaces

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -562,14 +562,14 @@
         "filename": "test/e2e/setup-wizard.e2e.test.ts",
         "hashed_secret": "9d6c140e80814290940bd258644431f5d4255fd4",
         "is_verified": false,
-        "line_number": 1486
+        "line_number": 1487
       },
       {
         "type": "Secret Keyword",
         "filename": "test/e2e/setup-wizard.e2e.test.ts",
         "hashed_secret": "1800af6e29fca70d9b324a27c567a5403d655429",
         "is_verified": false,
-        "line_number": 1508
+        "line_number": 1509
       }
     ],
     "test/integration/providers/friday-provider-service-lifecycle.test.ts": [
@@ -1124,5 +1124,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-05T18:31:11Z"
+  "generated_at": "2026-06-06T01:51:44Z"
 }

--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -1855,6 +1855,136 @@
       "executes_product_logic": false,
       "proof": "src/api/http/routes/friday-deterministic-pipeline-routes.ts wires default/live playbook.rollback to TS_RUNTIME_PLAYBOOK_PIPELINE_RETIRED after request validation and before calling the TypeScript playbook version rollback service; legacy behavior is reachable only through explicit allowTestOnlyPlaybookPipelineExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned deterministic playbook entrypoint when available."
+    },
+    {
+      "id": "workflow_builder_drafts_create",
+      "route": {
+        "method": "POST",
+        "path": "/v1/workflows/:workflowId/drafts",
+        "operationId": "drafts.create"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-workflow-builder-routes.ts wires default/live drafts.create to TS_RUNTIME_WORKFLOW_BUILDER_DRAFT_RETIRED before principal authority checks and before calling the TypeScript createDraft service; legacy behavior is reachable only through explicit allowTestOnlyWorkflowBuilderDraftExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned workflow builder draft create entrypoint when available."
+    },
+    {
+      "id": "workflow_builder_drafts_save",
+      "route": {
+        "method": "PATCH",
+        "path": "/v1/workflows/:workflowId/drafts/:draftId",
+        "operationId": "drafts.save"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-workflow-builder-routes.ts wires default/live drafts.save to TS_RUNTIME_WORKFLOW_BUILDER_DRAFT_RETIRED before principal authority checks and before calling the TypeScript saveDraft service; legacy behavior is reachable only through explicit allowTestOnlyWorkflowBuilderDraftExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned workflow builder draft save entrypoint when available."
+    },
+    {
+      "id": "workflow_builder_drafts_autosave",
+      "route": {
+        "method": "POST",
+        "path": "/v1/workflows/:workflowId/drafts/:draftId/autosave",
+        "operationId": "drafts.autosave"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-workflow-builder-routes.ts wires default/live drafts.autosave to TS_RUNTIME_WORKFLOW_BUILDER_DRAFT_RETIRED before principal authority checks and before calling the TypeScript autosaveDraft service; legacy behavior is reachable only through explicit allowTestOnlyWorkflowBuilderDraftExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned workflow builder draft autosave entrypoint when available."
+    },
+    {
+      "id": "workflow_builder_drafts_compile",
+      "route": {
+        "method": "POST",
+        "path": "/v1/workflows/:workflowId/drafts/:draftId/compile",
+        "operationId": "drafts.compile"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-workflow-builder-routes.ts wires default/live drafts.compile to TS_RUNTIME_WORKFLOW_BUILDER_DRAFT_RETIRED before principal authority checks and before calling the TypeScript compileDraft service; legacy behavior is reachable only through explicit allowTestOnlyWorkflowBuilderDraftExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned workflow builder draft compile entrypoint when available."
+    },
+    {
+      "id": "workflow_builder_drafts_publish",
+      "route": {
+        "method": "POST",
+        "path": "/v1/workflows/:workflowId/drafts/:draftId/publish",
+        "operationId": "drafts.publish"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-workflow-builder-routes.ts wires default/live drafts.publish to TS_RUNTIME_WORKFLOW_BUILDER_DRAFT_RETIRED before principal authority checks and before calling the TypeScript publishDraft service; legacy behavior is reachable only through explicit allowTestOnlyWorkflowBuilderDraftExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned workflow builder draft publish entrypoint when available."
+    },
+    {
+      "id": "workflow_builder_templates_instantiate",
+      "route": {
+        "method": "POST",
+        "path": "/v1/workflow-builder/templates/:templateId/instantiate",
+        "operationId": "templates.instantiate"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-workflow-builder-routes.ts wires default/live templates.instantiate to TS_RUNTIME_WORKFLOW_BUILDER_DRAFT_RETIRED before principal authority checks and before calling the TypeScript instantiateTemplate service; legacy behavior is reachable only through explicit allowTestOnlyWorkflowBuilderDraftExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned workflow builder template instantiate entrypoint when available."
+    },
+    {
+      "id": "workflow_locks_acquire",
+      "route": {
+        "method": "POST",
+        "path": "/v1/workflows/:workflowId/locks/acquire",
+        "operationId": "locks.acquire"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-workflow-builder-routes.ts wires default/live locks.acquire to TS_RUNTIME_WORKFLOW_BUILDER_DRAFT_RETIRED before principal authority checks and before calling the TypeScript acquireLock service; legacy behavior is reachable only through explicit allowTestOnlyWorkflowBuilderDraftExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned workflow builder lock acquire entrypoint when available."
+    },
+    {
+      "id": "workflow_locks_renew",
+      "route": {
+        "method": "POST",
+        "path": "/v1/workflows/:workflowId/locks/renew",
+        "operationId": "locks.renew"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-workflow-builder-routes.ts wires default/live locks.renew to TS_RUNTIME_WORKFLOW_BUILDER_DRAFT_RETIRED before principal authority checks and before calling the TypeScript renewLock service; legacy behavior is reachable only through explicit allowTestOnlyWorkflowBuilderDraftExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned workflow builder lock renew entrypoint when available."
+    },
+    {
+      "id": "workflow_locks_release",
+      "route": {
+        "method": "POST",
+        "path": "/v1/workflows/:workflowId/locks/release",
+        "operationId": "locks.release"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-workflow-builder-routes.ts wires default/live locks.release to TS_RUNTIME_WORKFLOW_BUILDER_DRAFT_RETIRED before principal authority checks and before calling the TypeScript releaseLock service; legacy behavior is reachable only through explicit allowTestOnlyWorkflowBuilderDraftExecution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned workflow builder lock release entrypoint when available."
+    },
+    {
+      "id": "workflow_conflicts_resolve",
+      "route": {
+        "method": "POST",
+        "path": "/v1/workflows/:workflowId/conflicts/:conflictId/resolve",
+        "operationId": "conflicts.resolve"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-workflow-conflict-routes.ts wires default/live conflicts.resolve to TS_RUNTIME_WORKFLOW_CONFLICT_RESOLVE_RETIRED before principal authority checks and before calling the TypeScript resolveConflict service; legacy behavior is reachable only through explicit allowTestOnlyWorkflowConflictResolution test-oracle wiring.",
+      "next_action": "Replace fail-closed response with a Rust-owned workflow conflict resolution entrypoint when available."
     }
   ]
 }

--- a/src/api/http/routes/friday-workflow-builder-routes.ts
+++ b/src/api/http/routes/friday-workflow-builder-routes.ts
@@ -43,6 +43,33 @@ export interface FridayWorkflowBuilderTemplateRoutesDeps {
     templateId: string,
     body: FridayInstantiateWorkflowBuilderTemplateRequest,
   ) => FridayInstantiateWorkflowBuilderTemplateResponse;
+  /**
+   * Test-oracle only: allows the legacy TypeScript workflow builder draft/lock/
+   * template-instantiate mutations in isolated route/runtime validation.
+   * Default/live runtime must leave these fail-closed until Rust owns workflow
+   * builder draft authoring truth.
+   */
+  allowTestOnlyWorkflowBuilderDraftExecution?: boolean;
+}
+
+function throwRetiredWorkflowBuilderDraft(): never {
+  throw new FridayDomainError(
+    "TS_RUNTIME_WORKFLOW_BUILDER_DRAFT_RETIRED",
+    "TypeScript workflow builder draft/lock/template authoring is retired in default/live runtime; use the Rust-owned workflow builder draft entrypoint.",
+    {
+      httpStatus: 503,
+      details: {
+        classification: "fail_closed",
+        replacement: "rust_owned_workflow_builder_draft_entrypoint_required",
+      },
+    },
+  );
+}
+
+function assertWorkflowBuilderDraftTestOracleAllowed(allow: boolean | undefined): void {
+  if (allow !== true) {
+    throwRetiredWorkflowBuilderDraft();
+  }
 }
 
 function assertWorkflowBuilderWritePrincipal(
@@ -87,6 +114,7 @@ export function createFridayWorkflowBuilderTemplateRoutes(
       path: "/v1/workflow-builder/templates/:templateId/instantiate",
       auth: { public: true },
       async handler(ctx) {
+        assertWorkflowBuilderDraftTestOracleAllowed(deps.allowTestOnlyWorkflowBuilderDraftExecution);
         assertWorkflowBuilderWritePrincipal(ctx.principal ?? null, "workflow.template.instantiate");
         const { templateId } = ctx.params as { templateId: string };
         const body = ctx.body as FridayInstantiateWorkflowBuilderTemplateRequest;
@@ -128,6 +156,13 @@ export interface FridayWorkflowBuilderRoutesDeps {
    * truth.
    */
   allowTestOnlyWorkflowBundleImportExecution?: boolean;
+  /**
+   * Test-oracle only: allows the legacy TypeScript workflow builder draft/lock
+   * mutations in isolated route/runtime validation. Default/live runtime must
+   * leave these fail-closed until Rust owns workflow builder draft authoring
+   * truth.
+   */
+  allowTestOnlyWorkflowBuilderDraftExecution?: boolean;
 }
 
 function throwRetiredWorkflowBundleImport(): never {
@@ -170,6 +205,7 @@ export function createFridayWorkflowBuilderRoutes(
       path: "/v1/workflows/:workflowId/drafts",
       auth: { public: true },
       async handler(ctx) {
+        assertWorkflowBuilderDraftTestOracleAllowed(deps.allowTestOnlyWorkflowBuilderDraftExecution);
         assertWorkflowBuilderWritePrincipal(ctx.principal ?? null, "workflow.draft.create");
         const { workflowId } = ctx.params as { workflowId: UUID };
         return deps.createDraft(workflowId, ctx.body as FridayCreateDraftRequest);
@@ -213,6 +249,7 @@ export function createFridayWorkflowBuilderRoutes(
       path: "/v1/workflows/:workflowId/drafts/:draftId",
       auth: { public: true },
       async handler(ctx) {
+        assertWorkflowBuilderDraftTestOracleAllowed(deps.allowTestOnlyWorkflowBuilderDraftExecution);
         assertWorkflowBuilderWritePrincipal(ctx.principal ?? null, "workflow.draft.save");
         const { workflowId, draftId } = ctx.params as { workflowId: UUID; draftId: UUID };
         return deps.saveDraft(workflowId, draftId, ctx.body as FridaySaveDraftRequest);
@@ -224,6 +261,7 @@ export function createFridayWorkflowBuilderRoutes(
       path: "/v1/workflows/:workflowId/drafts/:draftId/autosave",
       auth: { public: true },
       async handler(ctx) {
+        assertWorkflowBuilderDraftTestOracleAllowed(deps.allowTestOnlyWorkflowBuilderDraftExecution);
         assertWorkflowBuilderWritePrincipal(ctx.principal ?? null, "workflow.draft.autosave");
         const { workflowId, draftId } = ctx.params as { workflowId: UUID; draftId: UUID };
         return deps.autosaveDraft(workflowId, draftId, ctx.body as FridayAutosaveDraftRequest);
@@ -235,6 +273,7 @@ export function createFridayWorkflowBuilderRoutes(
       path: "/v1/workflows/:workflowId/drafts/:draftId/compile",
       auth: { public: true },
       async handler(ctx) {
+        assertWorkflowBuilderDraftTestOracleAllowed(deps.allowTestOnlyWorkflowBuilderDraftExecution);
         assertWorkflowBuilderWritePrincipal(ctx.principal ?? null, "workflow.draft.compile");
         const { workflowId, draftId } = ctx.params as { workflowId: UUID; draftId: UUID };
         return deps.compileDraft(workflowId, draftId);
@@ -247,6 +286,7 @@ export function createFridayWorkflowBuilderRoutes(
       auth: { public: true },
       rateLimitPolicyId: "workflow.publish",
       async handler(ctx) {
+        assertWorkflowBuilderDraftTestOracleAllowed(deps.allowTestOnlyWorkflowBuilderDraftExecution);
         assertWorkflowBuilderWritePrincipal(ctx.principal ?? null, "workflow.draft.publish");
         const { workflowId, draftId } = ctx.params as { workflowId: UUID; draftId: UUID };
         return deps.publishDraft(workflowId, draftId, ctx.body as FridayPublishDraftRequest);
@@ -258,6 +298,7 @@ export function createFridayWorkflowBuilderRoutes(
       path: "/v1/workflows/:workflowId/locks/acquire",
       auth: { public: true },
       async handler(ctx) {
+        assertWorkflowBuilderDraftTestOracleAllowed(deps.allowTestOnlyWorkflowBuilderDraftExecution);
         assertWorkflowBuilderWritePrincipal(ctx.principal ?? null, "workflow.lock.acquire");
         const { workflowId } = ctx.params as { workflowId: UUID };
         return deps.acquireLock(workflowId, ctx.body as FridayAcquireWorkflowLockRequest, ctx.principal);
@@ -269,6 +310,7 @@ export function createFridayWorkflowBuilderRoutes(
       path: "/v1/workflows/:workflowId/locks/renew",
       auth: { public: true },
       async handler(ctx) {
+        assertWorkflowBuilderDraftTestOracleAllowed(deps.allowTestOnlyWorkflowBuilderDraftExecution);
         assertWorkflowBuilderWritePrincipal(ctx.principal ?? null, "workflow.lock.renew");
         const { workflowId } = ctx.params as { workflowId: UUID };
         return deps.renewLock(workflowId, ctx.body as FridayRenewWorkflowLockRequest, ctx.principal);
@@ -280,6 +322,7 @@ export function createFridayWorkflowBuilderRoutes(
       path: "/v1/workflows/:workflowId/locks/release",
       auth: { public: true },
       async handler(ctx) {
+        assertWorkflowBuilderDraftTestOracleAllowed(deps.allowTestOnlyWorkflowBuilderDraftExecution);
         assertWorkflowBuilderWritePrincipal(ctx.principal ?? null, "workflow.lock.release");
         const { workflowId } = ctx.params as { workflowId: UUID };
         return deps.releaseLock(workflowId, ctx.body as FridayReleaseWorkflowLockRequest, ctx.principal);

--- a/src/api/http/routes/friday-workflow-conflict-routes.ts
+++ b/src/api/http/routes/friday-workflow-conflict-routes.ts
@@ -1,4 +1,5 @@
 import { assertBoundPrincipalAuthorityForOperation } from "../../../security/friday-owner-session-channel-capability.js";
+import { FridayDomainError } from "#errors";
 import type { FridayRouteDefinition } from "../../model/friday-api-common.types.js";
 import type { UUID } from "#workflows";
 import type {
@@ -19,6 +20,33 @@ export interface FridayWorkflowConflictRoutesDeps {
     input: FridayResolveWorkflowConflictRequest,
     userId?: UUID,
   ) => FridayResolveWorkflowConflictResponse;
+  /**
+   * Test-oracle only: allows the legacy TypeScript workflow conflict resolution
+   * mutation in isolated route/runtime validation. Default/live runtime must
+   * leave conflict resolution fail-closed until Rust owns workflow conflict
+   * resolution truth.
+   */
+  allowTestOnlyWorkflowConflictResolution?: boolean;
+}
+
+function throwRetiredWorkflowConflictResolve(): never {
+  throw new FridayDomainError(
+    "TS_RUNTIME_WORKFLOW_CONFLICT_RESOLVE_RETIRED",
+    "TypeScript workflow conflict resolution is retired in default/live runtime; use the Rust-owned workflow conflict resolution entrypoint.",
+    {
+      httpStatus: 503,
+      details: {
+        classification: "fail_closed",
+        replacement: "rust_owned_workflow_conflict_resolution_entrypoint_required",
+      },
+    },
+  );
+}
+
+function assertWorkflowConflictResolveTestOracleAllowed(deps: FridayWorkflowConflictRoutesDeps): void {
+  if (deps.allowTestOnlyWorkflowConflictResolution !== true) {
+    throwRetiredWorkflowConflictResolve();
+  }
 }
 
 export function createFridayWorkflowConflictRoutes(
@@ -42,6 +70,7 @@ export function createFridayWorkflowConflictRoutes(
       auth: { public: true },
       rateLimitPolicyId: "workflow.resolve_conflict",
       async handler(ctx) {
+        assertWorkflowConflictResolveTestOracleAllowed(deps);
         const { workflowId, conflictId } = ctx.params as { workflowId: UUID; conflictId: UUID };
         const bound = assertBoundPrincipalAuthorityForOperation(
           ctx.principal ?? null,

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -2136,6 +2136,7 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
 
   // Register builder routes (real service wiring)
   for (const route of createFridayWorkflowBuilderTemplateRoutes({
+    allowTestOnlyWorkflowBuilderDraftExecution: deps.allowTestOnlyWorkflowBuilderDraftExecution,
     listTemplates: ({ scope }) => ({
       items: builderRuntime.templates.listTemplates(
         scope === "user" || scope === "global" ? scope : undefined,
@@ -2196,6 +2197,7 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
 
   for (const route of createFridayWorkflowBuilderRoutes({
     allowTestOnlyWorkflowBundleImportExecution: deps.allowTestOnlyWorkflowBundleImportExecution,
+    allowTestOnlyWorkflowBuilderDraftExecution: deps.allowTestOnlyWorkflowBuilderDraftExecution,
     createDraft: (workflowId, input) => {
       const draft = builderRuntime.drafts.createDraft({
         workflowId,
@@ -2808,6 +2810,7 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
 
   // Register conflict routes
   for (const route of createFridayWorkflowConflictRoutes({
+    allowTestOnlyWorkflowConflictResolution: deps.allowTestOnlyWorkflowConflictResolution,
     listConflicts: (workflowId, query) => ({
       items: conflicts.listConflicts(workflowId, query.status, query.limit),
     }),

--- a/src/api/runtime/friday-api-runtime.types.ts
+++ b/src/api/runtime/friday-api-runtime.types.ts
@@ -260,6 +260,20 @@ export interface CreateFridayApiRuntimeDeps {
   allowTestOnlyAcceptancePipelineExecution?: boolean;
   allowTestOnlyRetryPipelineExecution?: boolean;
   allowTestOnlyPlaybookPipelineExecution?: boolean;
+  /**
+   * Test-oracle only: allow the legacy TypeScript workflow builder draft/lock/
+   * template-instantiate mutations in isolated mock/unit/e2e validation.
+   * Production/runtime callers must leave this unset so workflow builder draft
+   * authoring stays fail-closed until Rust owns it.
+   */
+  allowTestOnlyWorkflowBuilderDraftExecution?: boolean;
+  /**
+   * Test-oracle only: allow the legacy TypeScript workflow conflict resolution
+   * mutation in isolated mock/unit validation. Production/runtime callers must
+   * leave this unset so conflict resolution stays fail-closed until Rust owns
+   * it.
+   */
+  allowTestOnlyWorkflowConflictResolution?: boolean;
   /** Optional: user/project prompt-guidance provider for fallback workflow runtime creation. */
   userRulesContextProvider?: CreateFridayWorkflowRuntimeDeps["userRulesContextProvider"];
   /** Optional: reuse hub's session service instead of creating a new one. */

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -1862,6 +1862,8 @@ export interface FridayHubConfig {
   allowTestOnlyWorkflowCatalogMutationExecution?: boolean;
   /** Test-oracle only; production hub creation must leave workflow deploy fail-closed. */
   allowTestOnlyWorkflowDeployExecution?: boolean;
+  /** Test-oracle only; production hub creation must leave workflow builder draft/lock/template authoring fail-closed. */
+  allowTestOnlyWorkflowBuilderDraftExecution?: boolean;
   /** Test-oracle only; production hub creation must leave auto-fix execution fail-closed. */
   allowTestOnlyAutoFixExecution?: boolean;
   /** Test-oracle only; production hub creation must leave desktop action execution fail-closed. */

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -6901,6 +6901,7 @@ export async function createFridayHub(
     allowTestOnlyWorkflowGeneratorExecution: config.allowTestOnlyWorkflowGeneratorExecution,
     allowTestOnlyWorkflowCatalogMutationExecution: config.allowTestOnlyWorkflowCatalogMutationExecution,
     allowTestOnlyWorkflowDeployExecution: config.allowTestOnlyWorkflowDeployExecution,
+    allowTestOnlyWorkflowBuilderDraftExecution: config.allowTestOnlyWorkflowBuilderDraftExecution,
     agentRuntime,
     allowTestOnlyAgentRunStartExecution: config.allowTestOnlyAgentRunStartExecution,
     allowTestOnlyAgentRunControlExecution: config.allowTestOnlyAgentRunControlExecution,

--- a/test/e2e/api/_helpers/friday-api-test-server.helper.ts
+++ b/test/e2e/api/_helpers/friday-api-test-server.helper.ts
@@ -165,6 +165,7 @@ export interface CreateFridayApiTestEnvOptions {
    * runtime leaves workflow catalog writes fail-closed while Rust ownership lands.
    */
   allowTestOnlyWorkflowCatalogMutationExecution?: boolean;
+  allowTestOnlyWorkflowBuilderDraftExecution?: boolean;
   /**
    * Test-oracle opt-in for legacy TS workflow deploy execution. Default/live
    * runtime leaves workflow deploy fail-closed while Rust ownership lands.
@@ -285,6 +286,7 @@ export async function createFridayApiTestEnv(
     allowTestOnlySkillGeneratorExecution: options.allowTestOnlySkillGeneratorExecution ?? true,
     allowTestOnlyWorkflowGeneratorExecution: options.allowTestOnlyWorkflowGeneratorExecution ?? true,
     allowTestOnlyWorkflowCatalogMutationExecution: options.allowTestOnlyWorkflowCatalogMutationExecution ?? true,
+    allowTestOnlyWorkflowBuilderDraftExecution: options.allowTestOnlyWorkflowBuilderDraftExecution ?? true,
     allowTestOnlyWorkflowDeployExecution: options.allowTestOnlyWorkflowDeployExecution ?? true,
     computeChecksum: (content: string) =>
       crypto.createHash("sha256").update(content).digest("hex"),

--- a/test/e2e/friday-full-e2e.test.ts
+++ b/test/e2e/friday-full-e2e.test.ts
@@ -126,6 +126,7 @@ describe.skipIf(!CORE_E2E_ENABLED)("Friday Full E2E — Batch 1 (A–F)", () => 
       allowTestOnlySkillGeneratorExecution: true,
       allowTestOnlyWorkflowGeneratorExecution: true,
       allowTestOnlyWorkflowCatalogMutationExecution: true,
+      allowTestOnlyWorkflowBuilderDraftExecution: true,
       allowTestOnlyWorkflowDeployExecution: true,
     });
     await hub.start();

--- a/test/e2e/friday-real-scenarios-e2e.test.ts
+++ b/test/e2e/friday-real-scenarios-e2e.test.ts
@@ -141,6 +141,7 @@ describe.skipIf(!CORE_E2E_ENABLED)("Friday Real Scenarios E2E (NON-LLM)", () => 
       tokenSecret: TEST_TOKEN_SECRET,
       allowTestOnlyWorkflowRunExecution: true,
       allowTestOnlyWorkflowCatalogMutationExecution: true,
+      allowTestOnlyWorkflowBuilderDraftExecution: true,
       allowTestOnlyWorkflowDeployExecution: true,
     });
     await hub.start();
@@ -1662,6 +1663,7 @@ describe.skipIf(!ANTHROPIC_E2E_ENABLED || !HAS_LLM_CREDENTIAL)(
         logRequests: false,
         allowTestOnlyWorkflowRunExecution: true,
         allowTestOnlyWorkflowCatalogMutationExecution: true,
+        allowTestOnlyWorkflowBuilderDraftExecution: true,
         allowTestOnlyWorkflowDeployExecution: true,
       });
       await hub.start();

--- a/test/e2e/live/_helpers/real-env.ts
+++ b/test/e2e/live/_helpers/real-env.ts
@@ -316,6 +316,7 @@ async function startLocalRealHubEnv(
       skillDirs: [],
       port: 0,
       logRequests: false,
+      allowTestOnlyWorkflowBuilderDraftExecution: true,
       ...opts?.hubConfig,
     });
     await createdHub.start();

--- a/test/e2e/mock/_helpers/mock-env.ts
+++ b/test/e2e/mock/_helpers/mock-env.ts
@@ -340,6 +340,7 @@ export async function createMockHubEnv(opts?: {
   allowTestOnlyWorkflowGeneratorExecution?: boolean;
   /** Test-oracle opt-in for legacy TS workflow catalog mutations; set false to prove default fail-closed behavior. */
   allowTestOnlyWorkflowCatalogMutationExecution?: boolean;
+  allowTestOnlyWorkflowBuilderDraftExecution?: boolean;
   /** Test-oracle opt-in for legacy TS workflow deploy execution; set false to prove default fail-closed behavior. */
   allowTestOnlyWorkflowDeployExecution?: boolean;
   /** Test-oracle opt-in for legacy TS agent-run execution; set false to prove default fail-closed behavior. */
@@ -393,6 +394,7 @@ export async function createMockHubEnv(opts?: {
       allowTestOnlySkillGeneratorExecution: opts?.allowTestOnlySkillGeneratorExecution ?? true,
       allowTestOnlyWorkflowGeneratorExecution: opts?.allowTestOnlyWorkflowGeneratorExecution ?? true,
       allowTestOnlyWorkflowCatalogMutationExecution: opts?.allowTestOnlyWorkflowCatalogMutationExecution ?? true,
+      allowTestOnlyWorkflowBuilderDraftExecution: opts?.allowTestOnlyWorkflowBuilderDraftExecution ?? true,
       allowTestOnlyWorkflowDeployExecution: opts?.allowTestOnlyWorkflowDeployExecution ?? true,
       allowTestOnlyAgentRunStartExecution: opts?.allowTestOnlyAgentRunStartExecution ?? true,
       allowTestOnlyAgentRunControlExecution: opts?.allowTestOnlyAgentRunControlExecution ?? true,

--- a/test/e2e/setup-wizard.e2e.test.ts
+++ b/test/e2e/setup-wizard.e2e.test.ts
@@ -156,6 +156,7 @@ describe("Setup Wizard E2E", () => {
         port: 0,
         logRequests: false,
         tokenSecret: TEST_TOKEN_SECRET,
+        allowTestOnlyWorkflowBuilderDraftExecution: true,
       });
       await hub.start();
     } finally {

--- a/test/unit/api/http/routes/friday-workflow-builder-routes.test.ts
+++ b/test/unit/api/http/routes/friday-workflow-builder-routes.test.ts
@@ -76,11 +76,13 @@ describe("FridayWorkflowBuilderRoutes", () => {
     // shared `routes` fixture still exercises the principal-authority path.
     // Default/live runtime leaves this unset (proven below).
     allowTestOnlyWorkflowBundleImportExecution: true,
+    allowTestOnlyWorkflowBuilderDraftExecution: true,
   };
   const stubTemplateDeps: FridayWorkflowBuilderTemplateRoutesDeps = {
     listTemplates: () => ({ items: [] }),
     getTemplate: () => ({ template: {} as never }),
     instantiateTemplate: () => ({ draft: stubDraft }),
+    allowTestOnlyWorkflowBuilderDraftExecution: true,
   };
 
   const routes = createFridayWorkflowBuilderRoutes(stubDeps);
@@ -206,5 +208,41 @@ describe("FridayWorkflowBuilderRoutes", () => {
       },
     });
     expect(importSpy).not.toHaveBeenCalled();
+  });
+
+  it("fail-closes workflow builder draft/lock mutations by default", async () => {
+    const createSpy = vi.fn(() => ({ draft: stubDraft }));
+    const acquireSpy = vi.fn(() => ({ acquired: true }));
+    const failClosedRoutes = createFridayWorkflowBuilderRoutes({
+      ...stubDeps,
+      allowTestOnlyWorkflowBuilderDraftExecution: false,
+      createDraft: createSpy,
+      acquireLock: acquireSpy,
+    });
+    await expect(
+      failClosedRoutes.find((r) => r.operationId === "drafts.create")!.handler(makeCtx({ body: { title: "D" } })),
+    ).rejects.toMatchObject({
+      code: "TS_RUNTIME_WORKFLOW_BUILDER_DRAFT_RETIRED",
+      httpStatus: 503,
+      details: { classification: "fail_closed" },
+    });
+    await expect(
+      failClosedRoutes.find((r) => r.operationId === "locks.acquire")!.handler(makeCtx({ body: {} })),
+    ).rejects.toMatchObject({ code: "TS_RUNTIME_WORKFLOW_BUILDER_DRAFT_RETIRED", httpStatus: 503 });
+    expect(createSpy).not.toHaveBeenCalled();
+    expect(acquireSpy).not.toHaveBeenCalled();
+  });
+
+  it("fail-closes templates.instantiate by default", async () => {
+    const instSpy = vi.fn(() => ({ draft: stubDraft }));
+    const failClosedTemplateRoutes = createFridayWorkflowBuilderTemplateRoutes({
+      ...stubTemplateDeps,
+      allowTestOnlyWorkflowBuilderDraftExecution: false,
+      instantiateTemplate: instSpy,
+    });
+    await expect(
+      failClosedTemplateRoutes.find((r) => r.operationId === "templates.instantiate")!.handler(makeCtx({ body: {} })),
+    ).rejects.toMatchObject({ code: "TS_RUNTIME_WORKFLOW_BUILDER_DRAFT_RETIRED", httpStatus: 503 });
+    expect(instSpy).not.toHaveBeenCalled();
   });
 });

--- a/test/unit/api/http/routes/friday-workflow-conflict-routes.test.ts
+++ b/test/unit/api/http/routes/friday-workflow-conflict-routes.test.ts
@@ -45,6 +45,9 @@ describe("FridayWorkflowConflictRoutes", () => {
   const stubDeps: FridayWorkflowConflictRoutesDeps = {
     listConflicts: () => ({ items: [] }),
     resolveConflict: () => ({ conflict: stubConflict, draft: stubDraft }),
+    // Opt isolated tests into the legacy oracle so the principal-authority path
+    // is still exercised. Default/live runtime leaves this unset (proven below).
+    allowTestOnlyWorkflowConflictResolution: true,
   };
 
   const routes = createFridayWorkflowConflictRoutes(stubDeps);
@@ -83,9 +86,25 @@ describe("FridayWorkflowConflictRoutes", () => {
     const route = createFridayWorkflowConflictRoutes({
       listConflicts: () => ({ items: [] }),
       resolveConflict,
+      allowTestOnlyWorkflowConflictResolution: true,
     }).find((r) => r.operationId === "conflicts.resolve")!;
     const result = await route.handler(makeCtx());
     expect(result).toEqual({ conflict: stubConflict, draft: stubDraft });
     expect(resolveConflict).toHaveBeenCalledWith("wf-1", "conflict-1", {}, "user-1");
+  });
+
+  it("fail-closes conflicts.resolve by default and never calls resolveConflict", async () => {
+    const resolveConflict = vi.fn(() => ({ conflict: stubConflict, draft: stubDraft }));
+    const route = createFridayWorkflowConflictRoutes({
+      listConflicts: () => ({ items: [] }),
+      resolveConflict,
+      allowTestOnlyWorkflowConflictResolution: false,
+    }).find((r) => r.operationId === "conflicts.resolve")!;
+    await expect(route.handler(makeCtx())).rejects.toMatchObject({
+      code: "TS_RUNTIME_WORKFLOW_CONFLICT_RESOLVE_RETIRED",
+      httpStatus: 503,
+      details: { classification: "fail_closed" },
+    });
+    expect(resolveConflict).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Scope — TS runtime retirement: workflow authoring (completes #541)

Fail-closes the **10 remaining workflow authoring mutation routes**, finishing the workflow catalog/builder retirement started in #541. The GET reads (drafts.list/get/export, templates.list/get, conflicts.list) stay `compat_shim`, untouched.

| route(s) | error code (flag) |
|---|---|
| `drafts.create/save/autosave/compile/publish`, `templates.instantiate`, `locks.acquire/renew/release` | `TS_RUNTIME_WORKFLOW_BUILDER_DRAFT_RETIRED` (`allowTestOnlyWorkflowBuilderDraftExecution`) |
| `conflicts.resolve` | `TS_RUNTIME_WORKFLOW_CONFLICT_RESOLVE_RETIRED` (`allowTestOnlyWorkflowConflictResolution`) |

Each guard fires as the first handler statement (before the principal check — matching the #541 bundle-import sibling in the same file). `templates.instantiate` lives in a separate deps interface/factory, so the draft flag is added to **both** builder deps interfaces.

The draft flag is threaded end-to-end (route deps → `CreateFridayApiRuntimeDeps` → both registration calls → **hub config + bootstrap**) because the full-e2e/real-scenarios/setup-wizard/real-journeys draft-lifecycle suites drive drafts/locks through `createFridayHub` and must opt into the legacy oracle. The conflict flag is runtime-deps-only (no e2e/hub test resolves a conflict). Both flags are set nowhere in `src/` → default/live = fail-closed.

## Verification (local)
- `npm run check:ts-runtime-retirement`: passed — 584 routes; `ts_runtime_blocker` 145→**135**, `fail_closed` 91→**101** (manifest purely additive, 0 deletions). `general_runtime_blocker_inventory` remains.
- `npm run build`: passed (no type errors).
- `npx vitest run test/unit/api/http/routes/friday-workflow-builder-routes.test.ts test/unit/api/http/routes/friday-workflow-conflict-routes.test.ts`: 30 passed — existing auth/delegate tests preserved (stubDeps set the oracle on); new "fail-closes by default" tests assert 503 + correct code + `dep not.toHaveBeenCalled()`.
- `FRIDAY_E2E_CORE=1 npm test`: passed — 926 files, no type errors (the e2e draft/lock lifecycle suites pass via the draft oracle defaults).
- `npm run lint`: 0 errors. `check:secret-patterns`, `detect-secrets`, `git diff --check`: passed.
- Two read-only reviewers (general-purpose): both **PASS** — verified all 10 mutations guarded (incl. the dual-interface templates.instantiate), all GET reads untouched, hub threading complete, oracle flags never set truthy in `src/`, and **no new RGG exclusion needed** (the one builder scenario `l3-workflow-browser-authoring` is already excluded via `workflows.create`). Their non-blocking finding (two env-gated live suites' hubs) was fixed by adding the oracle to `setup-wizard.e2e.test.ts` and `live/_helpers/real-env.ts`.

## Safety
- No fake Rust delegation, no hidden fallback, no weakened tests/gates. Oracle flags set nowhere in `src/` (default/live = fail-closed).
- No default-DB mutation; no pet/design-gallery files touched.
- No `provider_native_synced` / Friday v1 GO claim. TS runtime retirement remains incomplete (`general_runtime_blocker_inventory`, 135 routes, remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)