### PR TITLE
fix(task-workflows): fail-close TS task-workflow runtime mutation surfaces

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -2414,6 +2414,201 @@
       "executes_product_logic": false,
       "proof": "src/api/http/routes/friday-autonomy-routes.ts fail-closes default/live autonomy.plugins.review.enable to TS_RUNTIME_AUTONOMY_LIFECYCLE_RETIRED after principal/availability checks and before calling the TypeScript plugin review-enable lifecycle service mutation; legacy behavior is reachable only through explicit allowTestOnlyAutonomyLifecycleExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned autonomy plugin review-enable entrypoint when available."
+    },
+    {
+      "id": "task_workflows_preview",
+      "route": {
+        "method": "POST",
+        "path": "/v1/task-workflows/preview",
+        "operationId": "task.workflows.preview"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-task-workflow-routes.ts fail-closes default/live task.workflows.preview to TS_RUNTIME_TASK_WORKFLOW_RETIRED after the TASK_WORKFLOWS_DISABLED availability check and request-body validation (400) (the route is public and non-mutating, so there is no bound-principal step), and immediately before the TypeScript task-workflow preview computation; legacy behavior is reachable only through explicit allowTestOnlyTaskWorkflowExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned task-workflow execution entrypoint when available."
+    },
+    {
+      "id": "task_workflows_create",
+      "route": {
+        "method": "POST",
+        "path": "/v1/task-workflows",
+        "operationId": "task.workflows.create"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-task-workflow-routes.ts fail-closes default/live task.workflows.create to TS_RUNTIME_TASK_WORKFLOW_RETIRED after the TASK_WORKFLOWS_DISABLED availability check, the bound-principal owner/session/channel check (401), and request-body validation (400), and immediately before the TypeScript task-workflow service mutation; legacy behavior is reachable only through explicit allowTestOnlyTaskWorkflowExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned task-workflow execution entrypoint when available."
+    },
+    {
+      "id": "task_workflows_revise",
+      "route": {
+        "method": "POST",
+        "path": "/v1/task-workflows/:workflowId/revisions",
+        "operationId": "task.workflows.revise"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-task-workflow-routes.ts fail-closes default/live task.workflows.revise to TS_RUNTIME_TASK_WORKFLOW_RETIRED after the TASK_WORKFLOWS_DISABLED availability check, the bound-principal owner/session/channel check (401), and request-body validation (400), and immediately before the TypeScript task-workflow service mutation; legacy behavior is reachable only through explicit allowTestOnlyTaskWorkflowExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned task-workflow execution entrypoint when available."
+    },
+    {
+      "id": "task_workflows_closeout",
+      "route": {
+        "method": "POST",
+        "path": "/v1/task-workflows/:workflowId/closeout",
+        "operationId": "task.workflows.closeout"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-task-workflow-routes.ts fail-closes default/live task.workflows.closeout to TS_RUNTIME_TASK_WORKFLOW_RETIRED after the TASK_WORKFLOWS_DISABLED availability check and the bound-principal owner/session/channel check (401), and immediately before the TypeScript task-workflow service mutation; legacy behavior is reachable only through explicit allowTestOnlyTaskWorkflowExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned task-workflow execution entrypoint when available."
+    },
+    {
+      "id": "task_workflows_claims_create",
+      "route": {
+        "method": "POST",
+        "path": "/v1/task-workflows/:workflowId/claims",
+        "operationId": "task.workflows.claims.create"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-task-workflow-routes.ts fail-closes default/live task.workflows.claims.create to TS_RUNTIME_TASK_WORKFLOW_RETIRED after the TASK_WORKFLOWS_DISABLED availability check, the bound-principal owner/session/channel check (401), and request-body validation (400), and immediately before the TypeScript task-workflow service mutation; legacy behavior is reachable only through explicit allowTestOnlyTaskWorkflowExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned task-workflow execution entrypoint when available."
+    },
+    {
+      "id": "task_workflows_claims_block",
+      "route": {
+        "method": "POST",
+        "path": "/v1/task-workflows/:workflowId/claims/:claimId/block",
+        "operationId": "task.workflows.claims.block"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-task-workflow-routes.ts fail-closes default/live task.workflows.claims.block to TS_RUNTIME_TASK_WORKFLOW_RETIRED after the TASK_WORKFLOWS_DISABLED availability check, the bound-principal owner/session/channel check (401), and request-body validation (400), and immediately before the TypeScript task-workflow service mutation; legacy behavior is reachable only through explicit allowTestOnlyTaskWorkflowExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned task-workflow execution entrypoint when available."
+    },
+    {
+      "id": "task_workflows_claims_evidence_attach",
+      "route": {
+        "method": "POST",
+        "path": "/v1/task-workflows/:workflowId/claims/:claimId/evidence-ref",
+        "operationId": "task.workflows.claims.evidence.attach"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-task-workflow-routes.ts fail-closes default/live task.workflows.claims.evidence.attach to TS_RUNTIME_TASK_WORKFLOW_RETIRED after the TASK_WORKFLOWS_DISABLED availability check, the bound-principal owner/session/channel check (401), and request-body validation (400), and immediately before the TypeScript task-workflow service mutation; legacy behavior is reachable only through explicit allowTestOnlyTaskWorkflowExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned task-workflow execution entrypoint when available."
+    },
+    {
+      "id": "task_workflows_claims_verify",
+      "route": {
+        "method": "POST",
+        "path": "/v1/task-workflows/:workflowId/claims/:claimId/verify",
+        "operationId": "task.workflows.claims.verify"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-task-workflow-routes.ts fail-closes default/live task.workflows.claims.verify to TS_RUNTIME_TASK_WORKFLOW_RETIRED after the TASK_WORKFLOWS_DISABLED availability check, the bound-principal owner/session/channel check (401), and request-body validation (400), and immediately before the TypeScript task-workflow service mutation; legacy behavior is reachable only through explicit allowTestOnlyTaskWorkflowExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned task-workflow execution entrypoint when available."
+    },
+    {
+      "id": "task_workflows_lanes_executor_open",
+      "route": {
+        "method": "POST",
+        "path": "/v1/task-workflows/:workflowId/lanes/executor",
+        "operationId": "task.workflows.lanes.executor.open"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-task-workflow-routes.ts fail-closes default/live task.workflows.lanes.executor.open to TS_RUNTIME_TASK_WORKFLOW_RETIRED after the TASK_WORKFLOWS_DISABLED availability check, the bound-principal owner/session/channel check (401), and request-body validation (400), and immediately before the TypeScript task-workflow service mutation; legacy behavior is reachable only through explicit allowTestOnlyTaskWorkflowExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned task-workflow execution entrypoint when available."
+    },
+    {
+      "id": "task_workflows_lanes_verifier_open",
+      "route": {
+        "method": "POST",
+        "path": "/v1/task-workflows/:workflowId/lanes/verifier",
+        "operationId": "task.workflows.lanes.verifier.open"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-task-workflow-routes.ts fail-closes default/live task.workflows.lanes.verifier.open to TS_RUNTIME_TASK_WORKFLOW_RETIRED after the TASK_WORKFLOWS_DISABLED availability check, the bound-principal owner/session/channel check (401), and request-body validation (400), and immediately before the TypeScript task-workflow service mutation; legacy behavior is reachable only through explicit allowTestOnlyTaskWorkflowExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned task-workflow execution entrypoint when available."
+    },
+    {
+      "id": "task_workflows_lanes_complete",
+      "route": {
+        "method": "POST",
+        "path": "/v1/task-workflows/:workflowId/lanes/:laneId/complete",
+        "operationId": "task.workflows.lanes.complete"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-task-workflow-routes.ts fail-closes default/live task.workflows.lanes.complete to TS_RUNTIME_TASK_WORKFLOW_RETIRED after the TASK_WORKFLOWS_DISABLED availability check, the bound-principal owner/session/channel check (401), and request-body validation (400), and immediately before the TypeScript task-workflow service mutation; legacy behavior is reachable only through explicit allowTestOnlyTaskWorkflowExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned task-workflow execution entrypoint when available."
+    },
+    {
+      "id": "task_workflows_lanes_verdict",
+      "route": {
+        "method": "POST",
+        "path": "/v1/task-workflows/:workflowId/lanes/:laneId/verdict",
+        "operationId": "task.workflows.lanes.verdict"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-task-workflow-routes.ts fail-closes default/live task.workflows.lanes.verdict to TS_RUNTIME_TASK_WORKFLOW_RETIRED after the TASK_WORKFLOWS_DISABLED availability check, the bound-principal owner/session/channel check (401), and request-body validation (400), and immediately before the TypeScript task-workflow service mutation; legacy behavior is reachable only through explicit allowTestOnlyTaskWorkflowExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned task-workflow execution entrypoint when available."
+    },
+    {
+      "id": "task_workflows_lanes_cli_handoff_record",
+      "route": {
+        "method": "POST",
+        "path": "/v1/task-workflows/:workflowId/lanes/:laneId/cli-handoffs",
+        "operationId": "task.workflows.lanes.cli.handoff.record"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-task-workflow-routes.ts fail-closes default/live task.workflows.lanes.cli.handoff.record to TS_RUNTIME_TASK_WORKFLOW_RETIRED after the TASK_WORKFLOWS_DISABLED availability check, the bound-principal owner/session/channel check (401), and request-body validation (400), and immediately before the TypeScript task-workflow service mutation; legacy behavior is reachable only through explicit allowTestOnlyTaskWorkflowExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned task-workflow execution entrypoint when available."
+    },
+    {
+      "id": "task_workflows_channel_command_issue",
+      "route": {
+        "method": "POST",
+        "path": "/v1/task-workflows/:workflowId/channel-commands",
+        "operationId": "task.workflows.channel.command.issue"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-task-workflow-routes.ts fail-closes default/live task.workflows.channel.command.issue to TS_RUNTIME_TASK_WORKFLOW_RETIRED after the TASK_WORKFLOWS_DISABLED availability check, the bound-principal owner/session/channel check (401), and request-body validation (400), and immediately before the TypeScript task-workflow service mutation; legacy behavior is reachable only through explicit allowTestOnlyTaskWorkflowExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned task-workflow execution entrypoint when available."
+    },
+    {
+      "id": "task_workflows_channel_command_confirm",
+      "route": {
+        "method": "POST",
+        "path": "/v1/task-workflows/:workflowId/channel-commands/confirm",
+        "operationId": "task.workflows.channel.command.confirm"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-task-workflow-routes.ts fail-closes default/live task.workflows.channel.command.confirm to TS_RUNTIME_TASK_WORKFLOW_RETIRED after the TASK_WORKFLOWS_DISABLED availability check, the bound-principal owner/session/channel check (401), and request-body validation (400), and immediately before the TypeScript task-workflow service mutation; legacy behavior is reachable only through explicit allowTestOnlyTaskWorkflowExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned task-workflow execution entrypoint when available."
     }
   ]
 }

--- a/src/api/http/routes/friday-task-workflow-routes.ts
+++ b/src/api/http/routes/friday-task-workflow-routes.ts
@@ -60,6 +60,14 @@ export interface FridayTaskWorkflowRoutesDeps {
   /** Structured short reason from bootstrap explaining why task workflows
    *  are disabled. Must never echo secret material. */
   readonly disabledReason: string | null;
+  /**
+   * Test-oracle only: allow the legacy TypeScript task-workflow mutations
+   * (create/preview/revise/closeout, claim draft/block/evidence/verify, lane
+   * open/complete/verdict/cli-handoff, channel-command issue/confirm) in
+   * isolated mock/unit validation. Production/runtime callers must leave this
+   * unset so task-workflow execution stays fail-closed until Rust owns it.
+   */
+  readonly allowTestOnlyTaskWorkflowExecution?: boolean;
 }
 
 const DEFAULT_DISABLED_MESSAGE =
@@ -688,6 +696,43 @@ function parseEvidenceExplorerQuery(
   };
 }
 
+// ─── Retirement helpers ───
+//
+// The task-workflow mutation surfaces (create/preview/revise/closeout, claim
+// draft/block/evidence/verify, lane open/complete/verdict/cli-handoff, and
+// channel-command issue/confirm) run TypeScript product logic or write
+// task-workflow state. They fail-close by default/live until Rust owns the
+// task-workflow execution entrypoint; legacy behavior is reachable only
+// through the explicit allowTestOnlyTaskWorkflowExecution test-oracle flag.
+
+function throwRetiredTaskWorkflow(
+  code: string,
+  label: string,
+  replacement: string,
+): never {
+  throw new FridayDomainError(
+    code,
+    `${label} is fail-closed in default/live runtime; use the Rust-owned ${replacement} entrypoint.`,
+    {
+      httpStatus: 503,
+      details: {
+        classification: "fail_closed",
+        replacement: `rust_owned_${replacement}_entrypoint_required`,
+      },
+    },
+  );
+}
+
+function assertTaskWorkflowTestOracleAllowed(deps: FridayTaskWorkflowRoutesDeps): void {
+  if (deps.allowTestOnlyTaskWorkflowExecution !== true) {
+    throwRetiredTaskWorkflow(
+      "TS_RUNTIME_TASK_WORKFLOW_RETIRED",
+      "TypeScript task-workflow execution",
+      "task_workflow_execution",
+    );
+  }
+}
+
 export function createFridayTaskWorkflowRoutes(
   deps: FridayTaskWorkflowRoutesDeps,
 ): FridayRouteDefinition<unknown, unknown, unknown, unknown>[] {
@@ -718,6 +763,7 @@ export function createFridayTaskWorkflowRoutes(
       async handler(ctx) {
         const service = requireService(deps);
         const input = parseCreateBody(ctx.body);
+        assertTaskWorkflowTestOracleAllowed(deps);
         return { preview: service.preview(input) };
       },
     },
@@ -730,6 +776,7 @@ export function createFridayTaskWorkflowRoutes(
         const service = requireService(deps);
         assertTaskWorkflowMutationPrincipal(ctx.principal ?? null, "task.workflow.create");
         const input = parseCreateBody(ctx.body);
+        assertTaskWorkflowTestOracleAllowed(deps);
         return { workflow: service.create(input) };
       },
     },
@@ -769,6 +816,7 @@ export function createFridayTaskWorkflowRoutes(
         assertTaskWorkflowMutationPrincipal(ctx.principal ?? null, "task.workflow.revise");
         const { workflowId } = ctx.params as { workflowId: string };
         const input = parseReviseBody(ctx.body);
+        assertTaskWorkflowTestOracleAllowed(deps);
         return service.revise(workflowId, input);
       },
     },
@@ -793,6 +841,7 @@ export function createFridayTaskWorkflowRoutes(
         assertTaskWorkflowMutationPrincipal(ctx.principal ?? null, "task.workflow.claim.create");
         const { workflowId } = ctx.params as { workflowId: string };
         const input = parseDraftClaimBody(ctx.body);
+        assertTaskWorkflowTestOracleAllowed(deps);
         return { claim: service.draftClaim(workflowId, input) };
       },
     },
@@ -840,6 +889,7 @@ export function createFridayTaskWorkflowRoutes(
           claimId: string;
         };
         const input = parseAttachEvidenceRefBody(ctx.body);
+        assertTaskWorkflowTestOracleAllowed(deps);
         return service.attachEvidenceRef(workflowId, claimId, input);
       },
     },
@@ -870,6 +920,7 @@ export function createFridayTaskWorkflowRoutes(
           claimId: string;
         };
         const input = parseVerifyClaimBody(ctx.body);
+        assertTaskWorkflowTestOracleAllowed(deps);
         return { claim: service.verifyClaim(workflowId, claimId, input) };
       },
     },
@@ -886,6 +937,7 @@ export function createFridayTaskWorkflowRoutes(
           claimId: string;
         };
         const input = parseBlockClaimBody(ctx.body);
+        assertTaskWorkflowTestOracleAllowed(deps);
         return { claim: service.blockClaim(workflowId, claimId, input) };
       },
     },
@@ -898,6 +950,7 @@ export function createFridayTaskWorkflowRoutes(
         const service = requireService(deps);
         assertTaskWorkflowMutationPrincipal(ctx.principal ?? null, "task.workflow.closeout");
         const { workflowId } = ctx.params as { workflowId: string };
+        assertTaskWorkflowTestOracleAllowed(deps);
         return { receipt: service.closeout(workflowId) };
       },
     },
@@ -911,6 +964,7 @@ export function createFridayTaskWorkflowRoutes(
         assertTaskWorkflowMutationPrincipal(ctx.principal ?? null, "task.workflow.lane.executor.open");
         const { workflowId } = ctx.params as { workflowId: string };
         const input = parseOpenExecutorLaneBody(ctx.body);
+        assertTaskWorkflowTestOracleAllowed(deps);
         return { lane: service.openExecutorLane(workflowId, input) };
       },
     },
@@ -924,6 +978,7 @@ export function createFridayTaskWorkflowRoutes(
         assertTaskWorkflowMutationPrincipal(ctx.principal ?? null, "task.workflow.lane.verifier.open");
         const { workflowId } = ctx.params as { workflowId: string };
         const input = parseOpenVerifierLaneBody(ctx.body);
+        assertTaskWorkflowTestOracleAllowed(deps);
         return { lane: service.openVerifierLane(workflowId, input) };
       },
     },
@@ -940,6 +995,7 @@ export function createFridayTaskWorkflowRoutes(
           laneId: string;
         };
         const input = parseCompleteLaneBody(ctx.body);
+        assertTaskWorkflowTestOracleAllowed(deps);
         return { lane: service.completeLane(workflowId, laneId, input) };
       },
     },
@@ -956,6 +1012,7 @@ export function createFridayTaskWorkflowRoutes(
           laneId: string;
         };
         const input = parseSubmitVerifierVerdictBody(ctx.body);
+        assertTaskWorkflowTestOracleAllowed(deps);
         return { claim: service.submitVerifierVerdict(workflowId, laneId, input) };
       },
     },
@@ -997,6 +1054,7 @@ export function createFridayTaskWorkflowRoutes(
           laneId: string;
         };
         const input = parseRecordCliHandoffBody(ctx.body);
+        assertTaskWorkflowTestOracleAllowed(deps);
         const handoff = await service.recordCliHandoff(workflowId, laneId, input);
         return { handoff };
       },
@@ -1047,6 +1105,7 @@ export function createFridayTaskWorkflowRoutes(
         assertTaskWorkflowMutationPrincipal(ctx.principal ?? null, "task.workflow.channel.command.issue");
         const { workflowId } = ctx.params as { workflowId: string };
         const input = parseIssueChannelCommandBody(ctx.body);
+        assertTaskWorkflowTestOracleAllowed(deps);
         return service.issueChannelCommand(workflowId, input);
       },
     },
@@ -1071,6 +1130,7 @@ export function createFridayTaskWorkflowRoutes(
         assertTaskWorkflowMutationPrincipal(ctx.principal ?? null, "task.workflow.channel.command.confirm");
         const { workflowId } = ctx.params as { workflowId: string };
         const input = parseConfirmChannelCommandBody(ctx.body);
+        assertTaskWorkflowTestOracleAllowed(deps);
         return service.confirmChannelCommand(workflowId, input);
       },
     },

--- a/test/unit/api/routes/friday-task-workflow-cli-handoff-routes.test.ts
+++ b/test/unit/api/routes/friday-task-workflow-cli-handoff-routes.test.ts
@@ -179,6 +179,7 @@ describe("Phase 13.5C CLI handoff record route behavior", () => {
       | { workflowId: string; laneId: string; backendId: string }
       | null = null;
     const routes = createFridayTaskWorkflowRoutes({
+      allowTestOnlyTaskWorkflowExecution: true,
       service: makeStubService({
         recordCliHandoff: async (workflowId, laneId, input) => {
           received = {

--- a/test/unit/api/routes/friday-task-workflow-cli-lane-routes.test.ts
+++ b/test/unit/api/routes/friday-task-workflow-cli-lane-routes.test.ts
@@ -125,6 +125,7 @@ describe("Phase 13.5C laneRole='cli' route validation", () => {
     };
     let received: { laneRole?: string } = {};
     const routes = createFridayTaskWorkflowRoutes({
+      allowTestOnlyTaskWorkflowExecution: true,
       service: makeStubServiceWithLanes({
         openExecutorLane: (_workflowId, input) => {
           received = { laneRole: input.laneRole };
@@ -188,6 +189,7 @@ describe("Phase 13.5C laneRole='cli' route validation", () => {
       updatedAt: "2026-05-16T00:00:00.000Z",
     };
     const routes = createFridayTaskWorkflowRoutes({
+      allowTestOnlyTaskWorkflowExecution: true,
       service: makeStubServiceWithLanes({
         openVerifierLane: () => fakeLane,
       }),

--- a/test/unit/api/routes/friday-task-workflow-lane-routes.test.ts
+++ b/test/unit/api/routes/friday-task-workflow-lane-routes.test.ts
@@ -312,6 +312,7 @@ describe("Phase 13.5B lane route delegation to service", () => {
       updatedAt: "2026-05-15T00:00:00.000Z",
     };
     const routes = createFridayTaskWorkflowRoutes({
+      allowTestOnlyTaskWorkflowExecution: true,
       service: makeStubServiceWithLanes({
         openExecutorLane: () => fakeLane,
       }),

--- a/test/unit/api/routes/friday-task-workflow-routes.test.ts
+++ b/test/unit/api/routes/friday-task-workflow-routes.test.ts
@@ -252,6 +252,7 @@ describe("Phase 13.5A read-only catalogs", () => {
       },
     };
     const routes = createFridayTaskWorkflowRoutes({
+      allowTestOnlyTaskWorkflowExecution: true,
       service: observable,
       disabledReason: null,
     });
@@ -301,6 +302,7 @@ describe("Phase 13.5A B.2.1 route surface — refSource incompatibility error sh
 
   it("attach route surfaces TASK_WORKFLOW_EVIDENCE_REFSOURCE_INCOMPATIBLE as HTTP 400 with details", async () => {
     const routes = createFridayTaskWorkflowRoutes({
+      allowTestOnlyTaskWorkflowExecution: true,
       service: makeServiceForCompatRoute(),
       disabledReason: null,
     });
@@ -633,6 +635,7 @@ describe("Phase 14.5A WP-001: task-workflow public mutating routes require bound
 
   it("keeps preview as a non-mutating public route", async () => {
     const routes = createFridayTaskWorkflowRoutes({
+      allowTestOnlyTaskWorkflowExecution: true,
       service: makeStubService(),
       disabledReason: null,
     });
@@ -642,5 +645,78 @@ describe("Phase 14.5A WP-001: task-workflow public mutating routes require bound
       principal: syntheticPublic(),
     }) as never)) as { preview: { specHash: string } };
     expect(response.preview.specHash).toBe("stub-hash");
+  });
+});
+
+describe("TS runtime retirement — task-workflow mutations fail-close by default", () => {
+  it("fail-close with TS_RUNTIME_TASK_WORKFLOW_RETIRED (503) when the test-oracle flag is unset, even for otherwise-valid bound-principal requests", async () => {
+    // No allowTestOnlyTaskWorkflowExecution => production/runtime default.
+    const routes = createFridayTaskWorkflowRoutes({
+      service: makeStubService(),
+      disabledReason: null,
+    });
+
+    // Pattern C: public, non-mutating preview still fail-closes (after body validation).
+    await expect(
+      findRoute(routes, "task.workflows.preview").handler(
+        makeCtx({ body: { charter: "x", taskKind: "general", contextPackage: {} } }) as never,
+      ),
+    ).rejects.toMatchObject({ code: "TS_RUNTIME_TASK_WORKFLOW_RETIRED", httpStatus: 503 });
+
+    // Pattern A: principal-gated create fail-closes for a valid bound principal + valid body.
+    await expect(
+      findRoute(routes, "task.workflows.create").handler(
+        makeCtx({ body: { charter: "x", taskKind: "general", contextPackage: {} } }) as never,
+      ),
+    ).rejects.toMatchObject({ code: "TS_RUNTIME_TASK_WORKFLOW_RETIRED", httpStatus: 503 });
+
+    // Pattern A with params + body: evidence-ref attach fail-closes after validation.
+    await expect(
+      findRoute(routes, "task.workflows.claims.evidence.attach").handler(
+        makeCtx({
+          params: { workflowId: "w-1", claimId: "c-1" },
+          body: { refKind: "docs.start_here", refId: "START_HERE_PROMPT.md", refSource: "docs_intent_reference" },
+        }) as never,
+      ),
+    ).rejects.toMatchObject({ code: "TS_RUNTIME_TASK_WORKFLOW_RETIRED", httpStatus: 503 });
+
+    // Pattern B: no-body closeout fail-closes after the bound-principal check.
+    await expect(
+      findRoute(routes, "task.workflows.closeout").handler(
+        makeCtx({ params: { workflowId: "w-1" } }) as never,
+      ),
+    ).rejects.toMatchObject({ code: "TS_RUNTIME_TASK_WORKFLOW_RETIRED", httpStatus: 503 });
+  });
+
+  it("still enforces availability (503 DISABLED) and bound-principal (401) BEFORE the retirement guard", async () => {
+    // Disabled service => availability check fires first (not the retirement guard).
+    await expect(
+      findRoute(makeDisabledRoutes(), "task.workflows.create").handler(
+        makeCtx({ body: { charter: "x", taskKind: "general", contextPackage: {} } }) as never,
+      ),
+    ).rejects.toMatchObject({ code: "TASK_WORKFLOWS_DISABLED", httpStatus: 503 });
+
+    // Unbound (synthetic public) principal => 401 fires before the retirement guard.
+    const routes = createFridayTaskWorkflowRoutes({
+      service: makeStubService(),
+      disabledReason: null,
+    });
+    await expect(
+      findRoute(routes, "task.workflows.create").handler(
+        makeCtx({
+          body: { charter: "x", taskKind: "general", contextPackage: {} },
+          principal: {
+            principalType: "user" as const,
+            principalId: "public:default",
+            tokenId: "00000000-0000-0000-0000-000000000002",
+            userId: "00000000-0000-0000-0000-000000000001",
+            role: "admin" as const,
+            scopes: [],
+            tokenKind: "access" as const,
+            issuedAt: "2026-05-16T00:00:00Z",
+          },
+        }) as never,
+      ),
+    ).rejects.toMatchObject({ httpStatus: 401 });
   });
 });


### PR DESCRIPTION
## Summary

Retires the TypeScript-owned, user-triggerable **task-workflow mutation** product logic by fail-closing all **15 POST routes** in `friday-task-workflow-routes.ts` behind a single test-oracle flag (`allowTestOnlyTaskWorkflowExecution` → `TS_RUNTIME_TASK_WORKFLOW_RETIRED`, 503), placed **after** the `TASK_WORKFLOWS_DISABLED` availability check, the bound-principal owner/session/channel check (401, where present), and request-body validation (400), and **immediately before** the TS service-mutation call:

`create` · `preview` · `revise` · `closeout` · claim `draft`/`block`/`evidence-attach`/`verify` · lane `executor-open`/`verifier-open`/`complete`/`verdict`/`cli-handoff-record` · channel-command `issue`/`confirm`.

The **16 GET reads stay `compat_shim`** (untouched). The two channel-command routes are `fail_closed` (they write the task-workflow DB), **not** `operator_external_adapter` — the external relay lives in the channel webhook/route surfaces already classified `operator_external_adapter`.

## Mechanism
- The flag rides through the **existing** `CreateFridayApiRuntimeDeps.taskWorkflows` passthrough (`friday-api-runtime.ts:3148`) — **no** `friday-api-runtime.ts` / `.types.ts` / hub edits needed.
- **15 additive** `fail_closed` manifest surfaces move these routes out of the `general_runtime_blocker_inventory` catch-all: `ts_runtime_blocker` **102 → 87**. Manifest diff is purely additive (0 deletions). Each proof's prose matches the route's actual guard order (Pattern A lists availability+principal(401)+body(400); `closeout` omits the body clause; `preview` notes it's public/non-mutating).

## RGG (advisory gate)
**No exclusion resolver needed.** Scanned `validation/real-world/`: the only task-workflow RGG scenarios are two **GET** http-probes (`boundaries`/`gates` catalog — stay `compat_shim`) and two **service-direct** in-process lifecycles (`evidence-fail-closed`, `rollback-matrix`) that build `createFridayTaskWorkflowService` and bypass the HTTP route layer. No live scenario POSTs a now-503 task-workflow route, so post-merge RGG stays green.

## Tests
- `allowTestOnlyTaskWorkflowExecution: true` added to the 7 happy-path route-test call sites (disabled-path 503 and negative-path 400/401 tests stay green unchanged — their pre-guard throw fires first).
- **New positive fail-close regression test**: asserts all guard-pattern representatives (preview/create/evidence-attach/closeout) return `TS_RUNTIME_TASK_WORKFLOW_RETIRED` 503 with the flag unset, and that availability (503) + bound-principal (401) still fire **before** the guard. No assertion weakened/skipped.

## Verification (local)
- `npm run build` ✅  ·  `FRIDAY_E2E_CORE=1 npm test` ✅ (12625 passed / 99 skipped / 0 failed)
- `npm run check:ts-runtime-retirement` ✅ (status passed, blocker 102→87)
- `npm run lint` ✅ (0 errors)  ·  `check:secret-patterns` ✅  ·  detect-secrets baseline ✅ (no drift)  ·  `git diff --check` ✅
- 5-dimension adversarial review (placement / integrity / manifest-honesty / RGG-coverage / test-completeness): **0 blockers**; the one major (no positive fail-close regression test) and one nit (preview proof wording) are **both addressed in this PR**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)