### PR TITLE
fix(observability): fail-close TS observability mutation surfaces

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -2609,6 +2609,173 @@
       "executes_product_logic": false,
       "proof": "src/api/http/routes/friday-task-workflow-routes.ts fail-closes default/live task.workflows.channel.command.confirm to TS_RUNTIME_TASK_WORKFLOW_RETIRED after the TASK_WORKFLOWS_DISABLED availability check, the bound-principal owner/session/channel check (401), and request-body validation (400), and immediately before the TypeScript task-workflow service mutation; legacy behavior is reachable only through explicit allowTestOnlyTaskWorkflowExecution test-oracle wiring.",
       "next_action": "Replace the fail-closed response with the Rust-owned task-workflow execution entrypoint when available."
+    },
+    {
+      "id": "observability_slos_create",
+      "route": {
+        "method": "POST",
+        "path": "/v1/observability/slos",
+        "operationId": "observability.slos.create"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-observability-routes.ts fail-closes default/live observability.slos.create to TS_RUNTIME_OBSERVABILITY_RETIRED after request-body validation (400) and immediately before the TypeScript observability service mutation; the route is public/unauthenticated (no bound-principal step); legacy behavior is reachable only through explicit allowTestOnlyObservabilityExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned observability alert-engine entrypoint when available."
+    },
+    {
+      "id": "observability_slos_update",
+      "route": {
+        "method": "PUT",
+        "path": "/v1/observability/slos/:sloId",
+        "operationId": "observability.slos.update"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-observability-routes.ts fail-closes default/live observability.slos.update to TS_RUNTIME_OBSERVABILITY_RETIRED after request-body validation (400) and immediately before the TypeScript observability service mutation; the route is public/unauthenticated (no bound-principal step); legacy behavior is reachable only through explicit allowTestOnlyObservabilityExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned observability alert-engine entrypoint when available."
+    },
+    {
+      "id": "observability_slos_delete",
+      "route": {
+        "method": "DELETE",
+        "path": "/v1/observability/slos/:sloId",
+        "operationId": "observability.slos.delete"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-observability-routes.ts fail-closes default/live observability.slos.delete to TS_RUNTIME_OBSERVABILITY_RETIRED after request-body validation (400) and immediately before the TypeScript observability service mutation; the route is public/unauthenticated (no bound-principal step); legacy behavior is reachable only through explicit allowTestOnlyObservabilityExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned observability alert-engine entrypoint when available."
+    },
+    {
+      "id": "observability_alert_rules_create",
+      "route": {
+        "method": "POST",
+        "path": "/v1/observability/alert-rules",
+        "operationId": "observability.alert.rules.create"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-observability-routes.ts fail-closes default/live observability.alert.rules.create to TS_RUNTIME_OBSERVABILITY_RETIRED after request-body validation (422) and immediately before the TypeScript observability service mutation; the route is public/unauthenticated (no bound-principal step); legacy behavior is reachable only through explicit allowTestOnlyObservabilityExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned observability alert-engine entrypoint when available."
+    },
+    {
+      "id": "observability_alert_rules_update",
+      "route": {
+        "method": "PUT",
+        "path": "/v1/observability/alert-rules/:ruleId",
+        "operationId": "observability.alert.rules.update"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-observability-routes.ts fail-closes default/live observability.alert.rules.update to TS_RUNTIME_OBSERVABILITY_RETIRED after request-body validation (422) and immediately before the TypeScript observability service mutation; the route is public/unauthenticated (no bound-principal step); legacy behavior is reachable only through explicit allowTestOnlyObservabilityExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned observability alert-engine entrypoint when available."
+    },
+    {
+      "id": "observability_alert_rules_delete",
+      "route": {
+        "method": "DELETE",
+        "path": "/v1/observability/alert-rules/:ruleId",
+        "operationId": "observability.alert.rules.delete"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-observability-routes.ts fail-closes default/live observability.alert.rules.delete to TS_RUNTIME_OBSERVABILITY_RETIRED after request-body validation (422) and immediately before the TypeScript observability service mutation; the route is public/unauthenticated (no bound-principal step); legacy behavior is reachable only through explicit allowTestOnlyObservabilityExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned observability alert-engine entrypoint when available."
+    },
+    {
+      "id": "observability_alerts_acknowledge",
+      "route": {
+        "method": "POST",
+        "path": "/v1/observability/alerts/:alertId/acknowledge",
+        "operationId": "observability.alerts.acknowledge"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-observability-routes.ts fail-closes default/live observability.alerts.acknowledge to TS_RUNTIME_OBSERVABILITY_RETIRED immediately before the TypeScript observability service mutation (the route performs no route-level body validation); the route is public/unauthenticated (no bound-principal step); legacy behavior is reachable only through explicit allowTestOnlyObservabilityExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned observability alert-engine entrypoint when available."
+    },
+    {
+      "id": "observability_alert_destinations_create",
+      "route": {
+        "method": "POST",
+        "path": "/v1/observability/alert-destinations",
+        "operationId": "observability.alert.destinations.create"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-observability-routes.ts fail-closes default/live observability.alert.destinations.create to TS_RUNTIME_OBSERVABILITY_RETIRED immediately before the TypeScript observability service mutation (the route performs no route-level body validation); the route is public/unauthenticated (no bound-principal step); legacy behavior is reachable only through explicit allowTestOnlyObservabilityExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned observability alert-engine entrypoint when available."
+    },
+    {
+      "id": "observability_alert_destinations_update",
+      "route": {
+        "method": "PATCH",
+        "path": "/v1/observability/alert-destinations/:destinationId",
+        "operationId": "observability.alert.destinations.update"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-observability-routes.ts fail-closes default/live observability.alert.destinations.update to TS_RUNTIME_OBSERVABILITY_RETIRED immediately before the TypeScript observability service mutation (the route performs no route-level body validation); the route is public/unauthenticated (no bound-principal step); legacy behavior is reachable only through explicit allowTestOnlyObservabilityExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned observability alert-engine entrypoint when available."
+    },
+    {
+      "id": "observability_alert_destinations_delete",
+      "route": {
+        "method": "DELETE",
+        "path": "/v1/observability/alert-destinations/:destinationId",
+        "operationId": "observability.alert.destinations.delete"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-observability-routes.ts fail-closes default/live observability.alert.destinations.delete to TS_RUNTIME_OBSERVABILITY_RETIRED immediately before the TypeScript observability service mutation (the route performs no route-level body validation); the route is public/unauthenticated (no bound-principal step); legacy behavior is reachable only through explicit allowTestOnlyObservabilityExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned observability alert-engine entrypoint when available."
+    },
+    {
+      "id": "observability_heartbeat_trigger",
+      "route": {
+        "method": "POST",
+        "path": "/v1/heartbeat/trigger",
+        "operationId": "observability.heartbeat.trigger"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-observability-routes.ts fail-closes default/live observability.heartbeat.trigger to TS_RUNTIME_HEARTBEAT_TRIGGER_RETIRED as the first handler statement, before invoking the TypeScript heartbeat job that runs the agent runtime via executeRun; the route is public/unauthenticated, has no request body, and is only registered when deps.heartbeat.trigger is present; legacy behavior is reachable only through explicit allowTestOnlyHeartbeatExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned heartbeat trigger entrypoint when available."
+    },
+    {
+      "id": "observability_alerts_test_dispatch",
+      "route": {
+        "method": "POST",
+        "path": "/v1/observability/alerts/:alertId/test-dispatch",
+        "operationId": "observability.alerts.test.dispatch"
+      },
+      "classification": "operator_external_adapter",
+      "user_triggerable": true,
+      "trust_boundary": "Operator-triggered external alert egress (Slack webhook / SMTP); a test dispatch send is not completion and carries no runtime execution truth.",
+      "leak_controls": {
+        "raw_private_data_allowed": false,
+        "forbidden": [
+          "raw_transcripts",
+          "secrets",
+          "private_paths",
+          "provider_ids",
+          "channel_ids",
+          "raw_commands",
+          "private_reasoning"
+        ]
+      },
+      "next_action": "Keep operator alert test-dispatch as an external egress adapter and move any resulting runtime/alerting truth into Rust-owned observability surfaces."
     }
   ]
 }

--- a/scripts/ops/run-real-green-gate.mjs
+++ b/scripts/ops/run-real-green-gate.mjs
@@ -158,6 +158,17 @@ const AUTONOMY_SKILL_LIFECYCLE_DEPENDENT_SCENARIOS = [
   "l5-phase-06-skill-upgrade-lifecycle",
 ];
 
+// When observability.alert.destinations.create becomes fail_closed in the TS
+// runtime retirement manifest the route returns 503
+// TS_RUNTIME_OBSERVABILITY_RETIRED before the service-side webhook validation,
+// so the invalid-create contract scenario (which POSTs an empty webhookUrl and
+// asserts 400) now sees a fail-closed 503 envelope instead. The substantive
+// evidence still holds (fail-closed, no external send, nothing persisted); only
+// the status digit changed, so the scenario is honestly recorded as excluded.
+const OBSERVABILITY_ALERT_DEPENDENT_SCENARIOS = [
+  "l2-observability-alert-destination-create-invalid-fails-closed",
+];
+
 const CLAUDE_SKILL_TESTS = [
   "test/unit/skills/registry/friday-skill-discovery.test.ts",
   "test/unit/skills/manifest/friday-skill-package-loader.test.ts",
@@ -336,6 +347,26 @@ export function resolveRetiredAutonomySkillLifecycleScenarioExclusions(repoRoot)
   return AUTONOMY_SKILL_LIFECYCLE_DEPENDENT_SCENARIOS.map((scenarioId) => ({
     scenarioId,
     reason: "POST /v1/autonomy/skills/:skillId/{shadow,canary,promote,rollback} is classified fail_closed in the TS runtime retirement manifest.",
+  }));
+}
+
+export function isObservabilityAlertDestinationCreateFailClosed(manifest) {
+  const surfaces = Array.isArray(manifest?.surfaces) ? manifest.surfaces : [];
+  return surfaces.some((surface) =>
+    surface?.id === "observability_alert_destinations_create"
+    && surface?.classification === "fail_closed"
+    && surface?.executes_product_logic === false
+  );
+}
+
+export function resolveRetiredObservabilityScenarioExclusions(repoRoot) {
+  const manifest = readJsonFile(path.join(repoRoot, "docs", "ops", "ts-runtime-retirement-manifest.json"));
+  if (!isObservabilityAlertDestinationCreateFailClosed(manifest)) {
+    return [];
+  }
+  return OBSERVABILITY_ALERT_DEPENDENT_SCENARIOS.map((scenarioId) => ({
+    scenarioId,
+    reason: "POST /v1/observability/alert-destinations is classified fail_closed in the TS runtime retirement manifest.",
   }));
 }
 
@@ -663,6 +694,7 @@ export function buildSummary({
   retiredWorkflowRunScenarioExclusions,
   retiredWorkflowCatalogScenarioExclusions,
   retiredAutonomySkillLifecycleScenarioExclusions,
+  retiredObservabilityScenarioExclusions,
   error,
 }) {
   const summary = {
@@ -685,6 +717,7 @@ export function buildSummary({
     retiredWorkflowRunScenarioExclusions: retiredWorkflowRunScenarioExclusions ?? [],
     retiredWorkflowCatalogScenarioExclusions: retiredWorkflowCatalogScenarioExclusions ?? [],
     retiredAutonomySkillLifecycleScenarioExclusions: retiredAutonomySkillLifecycleScenarioExclusions ?? [],
+    retiredObservabilityScenarioExclusions: retiredObservabilityScenarioExclusions ?? [],
     error: error ?? null,
   };
   summary.gate = {
@@ -722,11 +755,13 @@ async function main() {
   const retiredWorkflowRunScenarioExclusions = resolveRetiredWorkflowRunScenarioExclusions(repoRoot);
   const retiredWorkflowCatalogScenarioExclusions = resolveRetiredWorkflowCatalogScenarioExclusions(repoRoot);
   const retiredAutonomySkillLifecycleScenarioExclusions = resolveRetiredAutonomySkillLifecycleScenarioExclusions(repoRoot);
+  const retiredObservabilityScenarioExclusions = resolveRetiredObservabilityScenarioExclusions(repoRoot);
   const excludedScenarioIds = [
     ...retiredAgentRunScenarioExclusions,
     ...retiredWorkflowRunScenarioExclusions,
     ...retiredWorkflowCatalogScenarioExclusions,
     ...retiredAutonomySkillLifecycleScenarioExclusions,
+    ...retiredObservabilityScenarioExclusions,
   ].map((entry) => entry.scenarioId);
   const runId = createRunId();
   const reportRoot = options.reportRoot
@@ -932,6 +967,7 @@ async function main() {
       retiredWorkflowRunScenarioExclusions,
       retiredWorkflowCatalogScenarioExclusions,
       retiredAutonomySkillLifecycleScenarioExclusions,
+      retiredObservabilityScenarioExclusions,
       error: terminalError,
     });
     flushTerminalArtifacts(reportRoot, summary);

--- a/src/api/http/routes/friday-observability-routes.ts
+++ b/src/api/http/routes/friday-observability-routes.ts
@@ -118,6 +118,69 @@ export interface FridayObservabilityRoutesDeps {
     getStatus?(): unknown | Promise<unknown>;
     trigger?(): unknown | Promise<unknown>;
   };
+  /**
+   * Test-oracle only: allow the legacy TypeScript observability alert/SLO
+   * mutations (SLO create/update/delete, alert acknowledge, alert-destination
+   * create/update/delete, alert-rule create/update/delete) in isolated
+   * mock/unit validation. Production/runtime callers must leave this unset so
+   * the observability alert engine stays fail-closed until Rust owns it.
+   */
+  allowTestOnlyObservabilityExecution?: boolean;
+  /**
+   * Test-oracle only: allow the legacy TypeScript heartbeat trigger (which runs
+   * an agent run via the heartbeat job) in isolated mock/unit validation.
+   * Production/runtime callers must leave this unset so heartbeat execution
+   * stays fail-closed until Rust owns it.
+   */
+  allowTestOnlyHeartbeatExecution?: boolean;
+}
+
+// ─── Retirement helpers ───
+//
+// The observability alert/SLO mutation surfaces write alert-engine state
+// (SecureStore destinations, alert rules, SLO records, acknowledgements) and
+// the heartbeat trigger runs an agent run; both fail-close by default/live
+// until Rust owns the corresponding entrypoints. The alert test-dispatch route
+// is a separate operator_external_adapter (real Slack/SMTP egress) and is NOT
+// guarded here. Legacy behavior is reachable only through the explicit
+// per-engine test-oracle flags above.
+
+function throwRetiredObservability(
+  code: string,
+  label: string,
+  replacement: string,
+): never {
+  throw new FridayDomainError(
+    code,
+    `${label} is fail-closed in default/live runtime; use the Rust-owned ${replacement} entrypoint.`,
+    {
+      httpStatus: 503,
+      details: {
+        classification: "fail_closed",
+        replacement: `rust_owned_${replacement}_entrypoint_required`,
+      },
+    },
+  );
+}
+
+function assertObservabilityTestOracleAllowed(deps: FridayObservabilityRoutesDeps): void {
+  if (deps.allowTestOnlyObservabilityExecution !== true) {
+    throwRetiredObservability(
+      "TS_RUNTIME_OBSERVABILITY_RETIRED",
+      "TypeScript observability alert/SLO mutation",
+      "observability_alert_engine",
+    );
+  }
+}
+
+function assertHeartbeatTestOracleAllowed(deps: FridayObservabilityRoutesDeps): void {
+  if (deps.allowTestOnlyHeartbeatExecution !== true) {
+    throwRetiredObservability(
+      "TS_RUNTIME_HEARTBEAT_TRIGGER_RETIRED",
+      "TypeScript heartbeat trigger execution",
+      "heartbeat_trigger",
+    );
+  }
 }
 
 // ─── Factory ───
@@ -228,6 +291,7 @@ export function createFridayObservabilityRoutes(
         if (typeof body.target !== "number" || body.target <= 0 || body.target > 100) {
           throw new FridayDomainError("VALIDATION_ERROR", "target must be between 0 and 100", { httpStatus: 400 });
         }
+        assertObservabilityTestOracleAllowed(deps);
         return deps.slos.create(body);
       },
     },
@@ -242,6 +306,7 @@ export function createFridayObservabilityRoutes(
         if (!body || typeof body.etag !== "string") {
           throw new FridayDomainError("VALIDATION_ERROR", "etag is required", { httpStatus: 400 });
         }
+        assertObservabilityTestOracleAllowed(deps);
         return deps.slos.update(sloId, body);
       },
     },
@@ -256,6 +321,7 @@ export function createFridayObservabilityRoutes(
         if (typeof etag !== "string" || etag.trim() === "") {
           throw new FridayDomainError("VALIDATION_ERROR", "etag is required", { httpStatus: 400 });
         }
+        assertObservabilityTestOracleAllowed(deps);
         return deps.slos.delete(sloId, etag);
       },
     },
@@ -291,6 +357,7 @@ export function createFridayObservabilityRoutes(
       async handler(ctx) {
         const { alertId } = ctx.params as { alertId: UUID };
         const body = (ctx.body ?? {}) as FridayAcknowledgeAlertRequest;
+        assertObservabilityTestOracleAllowed(deps);
         return deps.alerts.acknowledge(alertId, body);
       },
     },
@@ -327,6 +394,7 @@ export function createFridayObservabilityRoutes(
       path: "/v1/observability/alert-destinations",
       auth: { public: true },
       async handler(ctx) {
+        assertObservabilityTestOracleAllowed(deps);
         return deps.alertDestinations.create(ctx.body as FridayCreateAlertDestinationRequest);
       },
     },
@@ -337,6 +405,7 @@ export function createFridayObservabilityRoutes(
       auth: { public: true },
       async handler(ctx) {
         const { destinationId } = ctx.params as { destinationId: UUID };
+        assertObservabilityTestOracleAllowed(deps);
         return deps.alertDestinations.update(
           destinationId,
           ctx.body as FridayUpdateAlertDestinationRequest,
@@ -350,6 +419,7 @@ export function createFridayObservabilityRoutes(
       auth: { public: true },
       async handler(ctx) {
         const { destinationId } = ctx.params as { destinationId: UUID };
+        assertObservabilityTestOracleAllowed(deps);
         return deps.alertDestinations.delete(destinationId);
       },
     },
@@ -390,6 +460,7 @@ export function createFridayObservabilityRoutes(
         if (!body.condition) {
           throw new FridayDomainError("VALIDATION_ERROR", "condition is required");
         }
+        assertObservabilityTestOracleAllowed(deps);
         return deps.alertRules.create(body);
       },
     },
@@ -404,6 +475,7 @@ export function createFridayObservabilityRoutes(
         if (!body || typeof body.etag !== "string" || body.etag.trim() === "") {
           throw new FridayDomainError("VALIDATION_ERROR", "etag is required");
         }
+        assertObservabilityTestOracleAllowed(deps);
         return deps.alertRules.update(ruleId, body);
       },
     },
@@ -418,6 +490,7 @@ export function createFridayObservabilityRoutes(
         if (!body || typeof body.etag !== "string" || body.etag.trim() === "") {
           throw new FridayDomainError("VALIDATION_ERROR", "etag is required");
         }
+        assertObservabilityTestOracleAllowed(deps);
         return deps.alertRules.delete(ruleId, body);
       },
     },
@@ -457,6 +530,7 @@ export function createFridayObservabilityRoutes(
             path: "/v1/heartbeat/trigger",
             auth: { public: true } as const,
             async handler() {
+              assertHeartbeatTestOracleAllowed(deps);
               return deps.heartbeat!.trigger!();
             },
           },

--- a/test/unit/api/http/routes/friday-observability-routes.test.ts
+++ b/test/unit/api/http/routes/friday-observability-routes.test.ts
@@ -115,6 +115,8 @@ function makeDeps(): FridayObservabilityRoutesDeps {
         },
       }),
     },
+    allowTestOnlyObservabilityExecution: true,
+    allowTestOnlyHeartbeatExecution: true,
   };
 }
 
@@ -477,6 +479,78 @@ describe("B-005 FridayObservabilityRoutes", () => {
       expect(routes.filter((r) => r.method === "PATCH").length).toBe(1);
       expect(routes.filter((r) => r.method === "DELETE").length).toBe(3);
       expect(routes.length).toBe(26);
+    });
+  });
+
+  describe("TS runtime retirement — observability mutations fail-close by default", () => {
+    function failClosedDeps(): FridayObservabilityRoutesDeps {
+      return {
+        ...makeDeps(),
+        allowTestOnlyObservabilityExecution: false,
+        allowTestOnlyHeartbeatExecution: false,
+      };
+    }
+
+    it("alert/SLO mutations fail-close with TS_RUNTIME_OBSERVABILITY_RETIRED (503) when the flag is unset", async () => {
+      const deps = failClosedDeps();
+      const routes = createFridayObservabilityRoutes(deps);
+      const cases: Array<[string, FridayHttpContext<unknown, unknown, unknown>]> = [
+        ["observability.slos.create", makeCtx({ body: { name: "x", target: 99, sliMetric: {} } })],
+        ["observability.slos.update", makeCtx({ params: { sloId: "slo-1" }, body: { etag: "e" } })],
+        ["observability.slos.delete", makeCtx({ params: { sloId: "slo-1" }, query: { etag: "e" } })],
+        ["observability.alerts.acknowledge", makeCtx({ params: { alertId: "a-1" }, body: {} })],
+        ["observability.alert.destinations.create", makeCtx({ body: { type: "slack", name: "n", webhookUrl: "https://x" } })],
+        ["observability.alert.destinations.update", makeCtx({ params: { destinationId: "d-1" }, body: {} })],
+        ["observability.alert.destinations.delete", makeCtx({ params: { destinationId: "d-1" } })],
+        ["observability.alert.rules.create", makeCtx({ body: { name: "n", condition: { metric: "m" } } })],
+        ["observability.alert.rules.update", makeCtx({ params: { ruleId: "r-1" }, body: { etag: "e" } })],
+        ["observability.alert.rules.delete", makeCtx({ params: { ruleId: "r-1" }, body: { etag: "e" } })],
+      ];
+      for (const [op, ctx] of cases) {
+        await expect(findRoute(routes, op).handler(ctx)).rejects.toMatchObject({
+          code: "TS_RUNTIME_OBSERVABILITY_RETIRED",
+          httpStatus: 503,
+        });
+      }
+      // The TS service mutations were never reached.
+      expect(deps.slos.create).not.toHaveBeenCalled();
+      expect(deps.alerts.acknowledge).not.toHaveBeenCalled();
+      expect(deps.alertDestinations.create).not.toHaveBeenCalled();
+      expect(deps.alertRules.create).not.toHaveBeenCalled();
+    });
+
+    it("heartbeat.trigger fail-closes with TS_RUNTIME_HEARTBEAT_TRIGGER_RETIRED (503) when the flag is unset", async () => {
+      const deps = failClosedDeps();
+      const routes = createFridayObservabilityRoutes(deps);
+      await expect(findRoute(routes, "observability.heartbeat.trigger").handler(makeCtx())).rejects.toMatchObject({
+        code: "TS_RUNTIME_HEARTBEAT_TRIGGER_RETIRED",
+        httpStatus: 503,
+      });
+      expect(deps.heartbeat!.trigger).not.toHaveBeenCalled();
+    });
+
+    it("keeps alert test-dispatch functional (operator_external_adapter, not fail-closed)", async () => {
+      const deps = failClosedDeps();
+      const routes = createFridayObservabilityRoutes(deps);
+      await findRoute(routes, "observability.alerts.test.dispatch").handler(
+        makeCtx({ params: { alertId: "a-1" }, body: { destinationId: "dest-1" } }),
+      );
+      expect(deps.alerts.testDispatch).toHaveBeenCalledWith("a-1", { destinationId: "dest-1" });
+    });
+
+    it("still rejects with the validation error BEFORE the retirement guard (validation precedes the guard)", async () => {
+      const deps = failClosedDeps();
+      const routes = createFridayObservabilityRoutes(deps);
+      // The validation error (not the retirement 503) is what surfaces, proving
+      // request-body validation runs before the retirement guard. SLO create
+      // uses an explicit httpStatus 400; alert-rule create has no explicit
+      // status so VALIDATION_ERROR defaults to 422 (matches the manifest proofs).
+      await expect(
+        findRoute(routes, "observability.slos.create").handler(makeCtx({ body: { target: 99 } })),
+      ).rejects.toMatchObject({ code: "VALIDATION_ERROR", httpStatus: 400 });
+      await expect(
+        findRoute(routes, "observability.alert.rules.create").handler(makeCtx({ body: {} })),
+      ).rejects.toMatchObject({ code: "VALIDATION_ERROR", httpStatus: 422 });
     });
   });
 });

--- a/test/unit/ops/run-real-green-gate.test.ts
+++ b/test/unit/ops/run-real-green-gate.test.ts
@@ -5,12 +5,14 @@ import {
   buildSummary,
   isAgentRunStartFailClosed,
   isAutonomySkillLifecycleFailClosed,
+  isObservabilityAlertDestinationCreateFailClosed,
   isWorkflowCatalogCreateFailClosed,
   isWorkflowRunStartFailClosed,
   normalizeLiveProviderMode,
   resolveGateSuiteReportRoot,
   resolveRetiredAgentRunScenarioExclusions,
   resolveRetiredAutonomySkillLifecycleScenarioExclusions,
+  resolveRetiredObservabilityScenarioExclusions,
   resolveRetiredWorkflowCatalogScenarioExclusions,
   resolveRetiredWorkflowRunScenarioExclusions,
   shouldExcludeProviderScenarios,
@@ -181,6 +183,37 @@ describe("run-real-green-gate helpers", () => {
     ]);
   });
 
+  it("detects fail-closed observability alert-destination create retirement from the manifest", () => {
+    expect(isObservabilityAlertDestinationCreateFailClosed({
+      surfaces: [
+        {
+          id: "observability_alert_destinations_create",
+          classification: "fail_closed",
+          executes_product_logic: false,
+        },
+      ],
+    })).toBe(true);
+    expect(isObservabilityAlertDestinationCreateFailClosed({
+      surfaces: [
+        {
+          id: "observability_alert_destinations_create",
+          classification: "ts_runtime_blocker",
+          executes_product_logic: true,
+        },
+      ],
+    })).toBe(false);
+    expect(isObservabilityAlertDestinationCreateFailClosed({ surfaces: [] })).toBe(false);
+  });
+
+  it("excludes the invalid-alert-destination-create RGG scenario while observability alert create is fail-closed", () => {
+    expect(resolveRetiredObservabilityScenarioExclusions(process.cwd())).toEqual([
+      {
+        scenarioId: "l2-observability-alert-destination-create-invalid-fails-closed",
+        reason: "POST /v1/observability/alert-destinations is classified fail_closed in the TS runtime retirement manifest.",
+      },
+    ]);
+  });
+
   it("preserves retired runtime scenario exclusions in the terminal summary", () => {
     const summary = buildSummary({
       runId: "run-1",
@@ -234,8 +267,20 @@ describe("run-real-green-gate helpers", () => {
           reason: "POST /v1/autonomy/skills/:skillId/{shadow,canary,promote,rollback} is classified fail_closed in the TS runtime retirement manifest.",
         },
       ],
+      retiredObservabilityScenarioExclusions: [
+        {
+          scenarioId: "l2-observability-alert-destination-create-invalid-fails-closed",
+          reason: "POST /v1/observability/alert-destinations is classified fail_closed in the TS runtime retirement manifest.",
+        },
+      ],
     });
 
+    expect(summary.retiredObservabilityScenarioExclusions).toEqual([
+      {
+        scenarioId: "l2-observability-alert-destination-create-invalid-fails-closed",
+        reason: "POST /v1/observability/alert-destinations is classified fail_closed in the TS runtime retirement manifest.",
+      },
+    ]);
     expect(summary.retiredWorkflowCatalogScenarioExclusions).toEqual([
       {
         scenarioId: "l3-workflow-browser-authoring",


### PR DESCRIPTION
## Summary

Retires the TypeScript-owned, user-triggerable **observability mutation** product logic in `friday-observability-routes.ts`:

- **10 alert/SLO mutations** (SLO create/update/delete, alert acknowledge, alert-destination create/update/delete, alert-rule create/update/delete) fail-close behind `allowTestOnlyObservabilityExecution` → `TS_RUNTIME_OBSERVABILITY_RETIRED`, **after** request-body validation (where present) and **immediately before** the TS service mutation. Routes are `auth:{public:true}` (no bound-principal step).
- **`heartbeat.trigger`** (runs an agent run via the heartbeat job) fail-closes behind a **separate** `allowTestOnlyHeartbeatExecution` → `TS_RUNTIME_HEARTBEAT_TRIGGER_RETIRED` (genuinely distinct engine).
- **`alerts.test.dispatch` → `operator_external_adapter`** (NOT `fail_closed`, NO guard): it performs real Slack webhook `fetch` + SMTP send, so it's an operator external-egress adapter (`leak_controls.raw_private_data_allowed:false` + all 7 forbidden controls), kept functional. This also preserves its existing RGG **404** contract.

The **15 GET reads stay `compat_shim`** (untouched). Flags ride the existing `CreateFridayApiRuntimeDeps.observability` passthrough — **no** runtime/hub edits. 11 additive `fail_closed` surfaces + 1 `operator_external_adapter` surface move these out of the `general_runtime_blocker_inventory` catch-all: `ts_runtime_blocker` **87 → 75**.

## RGG (advisory gate) — one same-PR exclusion
`resolveRetiredObservabilityScenarioExclusions` honestly excludes `l2-observability-alert-destination-create-invalid-fails-closed` (it POSTs an empty-`webhookUrl` destination asserting **400**; with create fail-closed the guard returns 503 first — fail-closed envelope, no external send, nothing persisted; only the status digit changed). Every other observability scenario is a GET read, service-direct, or the `test-dispatch` **404** (preserved by leaving `test.dispatch` unguarded). Resolver + unit test included.

## Tests
- `makeDeps` defaults both flags `true` (existing happy-path tests stay green).
- **New positive fail-close regression block**: asserts `TS_RUNTIME_OBSERVABILITY_RETIRED` / `TS_RUNTIME_HEARTBEAT_TRIGGER_RETIRED` 503 with flags unset + service-not-called; that `test.dispatch` stays functional; and that validation precedes the guard (SLO create → 400, alert-rule create → 422). No assertion weakened/skipped.

## Verification (local)
- `npm run build` ✅  ·  `FRIDAY_E2E_CORE=1 npm test` ✅ (12631 passed / 99 skipped / 0 failed)
- `npm run check:ts-runtime-retirement` ✅ (status passed, blocker 87→75)
- `npm run lint` ✅ (0 errors)  ·  `check:secret-patterns` ✅  ·  detect-secrets baseline ✅ (no drift)  ·  `git diff --check` ✅
- **6-dimension adversarial review** (placement / external-adapter-classification / rgg-resolver / integrity / manifest-honesty / test-completeness): **0 blockers**; external-adapter + rgg-resolver dimensions PASS clean. One major (3 alert-rule proofs said "(400)" but those throws default to 422) — **fixed**: proofs corrected to "(422)" and the regression test now pins SLO→400 / alert-rule→422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)