### PR TITLE
fix(rgg): record empty external-channel suite as trivially passed

### DIFF
--- a/scripts/ops/run-real-green-gate.mjs
+++ b/scripts/ops/run-real-green-gate.mjs
@@ -126,6 +126,18 @@ const EXTERNAL_CHANNEL_SCENARIOS = [
   "l6-discord-channel-roundtrip",
 ];
 
+// The external-channel suite is the fixed EXTERNAL_CHANNEL_SCENARIOS list minus
+// any scenarios excluded by TS-runtime-retirement resolvers (e.g.
+// l6-discord-channel-roundtrip depends on sessions.create, which is now
+// fail-closed). When EVERY external-channel scenario is excluded the suite has
+// nothing left to run; the scenario runner throws "No scenarios selected" on an
+// empty selection, so the gate must detect this and record the suite as
+// trivially passed instead of letting the run terminate.
+export function resolveEffectiveExternalChannelScenarios(excludedScenarioIds) {
+  const excluded = new Set(excludedScenarioIds ?? []);
+  return EXTERNAL_CHANNEL_SCENARIOS.filter((id) => !excluded.has(id));
+}
+
 const AGENT_RUN_START_DEPENDENT_SCENARIOS = [
   "l3-destructive-request-visible-approval-gate",
   "l3-channel-origin-unified-task-state-contract",
@@ -922,22 +934,42 @@ async function main() {
     completePhase("publicSurface", { reportRoot: publicSurface.reportRoot });
 
     if (preflight?.envTruth?.prerequisites?.externalChannels?.status === "ready") {
-      startPhase("externalChannels");
-      externalChannels = await withTimeout(
-        "external channel validation",
-        options.validationTimeoutMs,
-        () => runRealWorldValidation({
-          ...validationBaseOptions,
+      const effectiveExternalChannelScenarios = resolveEffectiveExternalChannelScenarios(excludedScenarioIds);
+      const externalChannelsReportRoot = resolveGateSuiteReportRoot(reportRoot, "external-channels");
+      if (effectiveExternalChannelScenarios.length === 0) {
+        // Every external-channel scenario is excluded by TS runtime retirement
+        // (l6-discord-channel-roundtrip depends on the now-fail-closed
+        // sessions.create). Record the suite as trivially passed (0 scenarios)
+        // rather than invoking the runner, which throws "No scenarios selected"
+        // on an empty selection and terminates the whole gate.
+        startPhase("externalChannels");
+        externalChannels = {
+          runId,
           suite: "weekly",
-          scenarioIds: EXTERNAL_CHANNEL_SCENARIOS,
-          repetitions: 1,
-          reportRoot: resolveGateSuiteReportRoot(reportRoot, "external-channels"),
-        }),
-        async () => {
-          await closeSharedUiProbeSession();
-        },
-      );
-      completePhase("externalChannels", { reportRoot: externalChannels.reportRoot });
+          reportRoot: externalChannelsReportRoot,
+          scenarioCount: 0,
+          resultCounts: { passed: 0 },
+          allExternalChannelScenariosExcludedByRetirement: true,
+        };
+        completePhase("externalChannels", { reportRoot: externalChannelsReportRoot });
+      } else {
+        startPhase("externalChannels");
+        externalChannels = await withTimeout(
+          "external channel validation",
+          options.validationTimeoutMs,
+          () => runRealWorldValidation({
+            ...validationBaseOptions,
+            suite: "weekly",
+            scenarioIds: effectiveExternalChannelScenarios,
+            repetitions: 1,
+            reportRoot: externalChannelsReportRoot,
+          }),
+          async () => {
+            await closeSharedUiProbeSession();
+          },
+        );
+        completePhase("externalChannels", { reportRoot: externalChannels.reportRoot });
+      }
     } else {
       markPhase(phaseStatus, "externalChannels", "skipped", {
         reason: "external_channels.ready is not true",

--- a/test/unit/ops/run-real-green-gate.test.ts
+++ b/test/unit/ops/run-real-green-gate.test.ts
@@ -10,6 +10,7 @@ import {
   isWorkflowCatalogCreateFailClosed,
   isWorkflowRunStartFailClosed,
   normalizeLiveProviderMode,
+  resolveEffectiveExternalChannelScenarios,
   resolveGateSuiteReportRoot,
   resolveRetiredAgentRunScenarioExclusions,
   resolveRetiredAutonomySkillLifecycleScenarioExclusions,
@@ -183,6 +184,52 @@ describe("run-real-green-gate helpers", () => {
         reason: "POST /v1/autonomy/skills/:skillId/{shadow,canary,promote,rollback} is classified fail_closed in the TS runtime retirement manifest.",
       },
     ]);
+  });
+
+  it("drops external-channel scenarios that are retirement-excluded, leaving the suite empty when all are excluded", () => {
+    // No exclusions -> the full external-channel scenario set remains.
+    expect(resolveEffectiveExternalChannelScenarios([])).toEqual(["l6-discord-channel-roundtrip"]);
+    expect(resolveEffectiveExternalChannelScenarios(undefined)).toEqual(["l6-discord-channel-roundtrip"]);
+    // Excluding l6-discord-channel-roundtrip (sessions.create fail-closed) empties
+    // the external-channel suite; the gate must treat this as trivially passed
+    // rather than letting the runner throw "No scenarios selected".
+    expect(resolveEffectiveExternalChannelScenarios(["l6-discord-channel-roundtrip"])).toEqual([]);
+    expect(
+      resolveEffectiveExternalChannelScenarios(["unrelated-scenario", "l6-discord-channel-roundtrip"]),
+    ).toEqual([]);
+  });
+
+  it("passes the gate when external channels are ready but every scenario is retirement-excluded (0 passed)", () => {
+    const summary = buildSummary({
+      runId: "run-extch-empty",
+      repoRoot: "/tmp/friday",
+      branch: "main",
+      liveProviderMode: "economy",
+      phaseStatus: {
+        preflight: { status: "completed" },
+        smoke: { status: "completed" },
+        dailyCore: { status: "completed" },
+        publicSurface: { status: "completed" },
+        externalChannels: { status: "completed" },
+        branchConformance: { status: "completed" },
+        skillConformance: { status: "completed" },
+      },
+      preflight: {
+        envTruth: {
+          auth: { ok: true },
+          providerLaneRequirements: { fallbackRequired: false },
+          providerLanes: { default: true },
+          prerequisites: { externalChannels: { status: "ready" } },
+        },
+      },
+      smoke: { resultCounts: { passed: 1 } },
+      dailyCore: { resultCounts: { passed: 1 } },
+      publicSurface: { resultCounts: { passed: 1 } },
+      externalChannels: { resultCounts: { passed: 0 }, allExternalChannelScenariosExcludedByRetirement: true },
+      branchConformance: { shouldMerge: true },
+      skillConformance: { ok: true },
+    });
+    expect(summary.gate).toEqual({ passed: true, reasons: [] });
   });
 
   it("detects fail-closed observability alert-destination create retirement from the manifest", () => {


### PR DESCRIPTION
## Why

Main RGG (Real Green Gate) is **RED** on `34626da0` (the merged sessions slice #550). Verified via `gh run view 27055589959 --json conclusion` => `completed/failure`.

**Root cause:** The external-channel suite is the fixed `EXTERNAL_CHANNEL_SCENARIOS` list, whose only member is `l6-discord-channel-roundtrip`. That scenario depends on `sessions.create`, which PR #550 correctly fail-closes (503). The retirement resolver therefore excludes it — emptying the suite — and `validation/real-world/lib/runner.mjs` throws `"No scenarios selected"` on an empty selection, terminating the whole gate run (cascade: `branchConformance` / `skillConformance` "did not complete"). `smoke(15)`/`dailyCore(7)`/`publicSurface(34)` all passed.

## What

Fix at the **gate boundary**, not the runner:

- Add `resolveEffectiveExternalChannelScenarios(excludedScenarioIds)` = full list minus retirement exclusions.
- When none remain, record the suite as **trivially passed** (`scenarioCount: 0`, `resultCounts: { passed: 0 }`, `allExternalChannelScenariosExcludedByRetirement: true`) and complete the phase instead of invoking the runner with zero scenarios.
- When some scenarios survive, run exactly those.

This restores main RGG to green while **honestly recording that external-channel RGG coverage is currently 0 scenarios** — a real coverage gap to track, not hide.

## Verification

- `npx vitest run test/unit/ops/run-real-green-gate.test.ts` → 18 passed, no type errors (added resolver test + buildSummary empty-suite-passed test).
- `npm run build` → green. `npm run lint` → 0 errors. `git diff --check` clean. `check:secret-patterns` clean. `detect-secrets-hook` clean.
- Touches only `scripts/ops/run-real-green-gate.mjs` + its unit test. No manifest/route changes; TS retirement blocker count unchanged (60).

## Post-merge

Trigger a fresh RGG run on post-merge main and confirm `gh run view <id> --json conclusion == success`, with `externalChannels` passed-0 and `branchConformance`/`skillConformance` now completing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)