### PR TITLE
fix(system): fail-close TS system mutation surfaces

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -2982,6 +2982,162 @@
         ]
       },
       "next_action": "Keep session outbound as an external egress adapter and move resulting runtime truth into Rust-owned session/mission surfaces."
+    },
+    {
+      "id": "system_intents_execute",
+      "route": {
+        "method": "POST",
+        "path": "/v1/system/intents",
+        "operationId": "system.intents.execute"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-system-routes.ts fail-closes default/live system.intents.execute to TS_RUNTIME_SYSTEM_INTENT_RETIRED after the idempotency-key validation and immediately before the TypeScript system intent execution (canonical-gate eval, control-lease acquisition, companion-bridge local desktop control); the route is public/unauthenticated (no bound-principal step); legacy behavior is reachable only through explicit allowTestOnlySystemIntentExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned system intent execution entrypoint when available."
+    },
+    {
+      "id": "system_approvals_update",
+      "route": {
+        "method": "PATCH",
+        "path": "/v1/system/approvals/:approvalId",
+        "operationId": "system.approvals.update"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-system-routes.ts fail-closes default/live system.approvals.update to TS_RUNTIME_SYSTEM_APPROVAL_RETIRED after the idempotency-key validation and immediately before the TypeScript approval-rule mutation deps.approvals.update (the live hub wires this dep to a canonical-gate stub); the route is public/unauthenticated (no bound-principal step); legacy behavior is reachable only through explicit allowTestOnlySystemApprovalExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned system approval-rule entrypoint when available."
+    },
+    {
+      "id": "system_remote_devices_register",
+      "route": {
+        "method": "POST",
+        "path": "/v1/system/remote/devices/register",
+        "operationId": "system.remote.devices.register"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-system-routes.ts fail-closes default/live system.remote.devices.register to TS_RUNTIME_SYSTEM_REMOTE_RETIRED after the idempotency-key validation and immediately before the TypeScript remote-device registration write; the route is public/unauthenticated (no bound-principal step); legacy behavior is reachable only through explicit allowTestOnlySystemRemoteExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned system remote-access (device/session/WebAuthn) entrypoint when available."
+    },
+    {
+      "id": "system_remote_devices_delete",
+      "route": {
+        "method": "DELETE",
+        "path": "/v1/system/remote/devices/:deviceId",
+        "operationId": "system.remote.devices.delete"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-system-routes.ts fail-closes default/live system.remote.devices.delete to TS_RUNTIME_SYSTEM_REMOTE_RETIRED after the deviceId path-param extraction and immediately before the TypeScript remote-device revoke write; the route is public/unauthenticated (no bound-principal step); legacy behavior is reachable only through explicit allowTestOnlySystemRemoteExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned system remote-access (device/session/WebAuthn) entrypoint when available."
+    },
+    {
+      "id": "system_remote_devices_passkey_delete",
+      "route": {
+        "method": "DELETE",
+        "path": "/v1/system/remote/devices/:deviceId/passkey",
+        "operationId": "system.remote.devices.passkey.delete"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-system-routes.ts fail-closes default/live system.remote.devices.passkey.delete to TS_RUNTIME_SYSTEM_REMOTE_RETIRED after the deviceId path-param extraction and immediately before the TypeScript remote-device passkey clear write; the route is public/unauthenticated (no bound-principal step); legacy behavior is reachable only through explicit allowTestOnlySystemRemoteExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned system remote-access (device/session/WebAuthn) entrypoint when available."
+    },
+    {
+      "id": "system_remote_auth_register_options",
+      "route": {
+        "method": "POST",
+        "path": "/v1/system/remote/auth/register/options",
+        "operationId": "system.remote.auth.register.options"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-system-routes.ts fail-closes default/live system.remote.auth.register.options to TS_RUNTIME_SYSTEM_REMOTE_RETIRED after the idempotency-key validation and immediately before the TypeScript WebAuthn registration challenge-write (beginRegistration); the route is public/unauthenticated (no bound-principal step); legacy behavior is reachable only through explicit allowTestOnlySystemRemoteExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned system remote-access (device/session/WebAuthn) entrypoint when available."
+    },
+    {
+      "id": "system_remote_auth_register_verify",
+      "route": {
+        "method": "POST",
+        "path": "/v1/system/remote/auth/register/verify",
+        "operationId": "system.remote.auth.register.verify"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-system-routes.ts fail-closes default/live system.remote.auth.register.verify to TS_RUNTIME_SYSTEM_REMOTE_RETIRED after the idempotency-key validation and immediately before the TypeScript WebAuthn registration verification (passkey upsert + device credential write); the route is public/unauthenticated (no bound-principal step); legacy behavior is reachable only through explicit allowTestOnlySystemRemoteExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned system remote-access (device/session/WebAuthn) entrypoint when available."
+    },
+    {
+      "id": "system_remote_auth_assert_options",
+      "route": {
+        "method": "POST",
+        "path": "/v1/system/remote/auth/assert/options",
+        "operationId": "system.remote.auth.assert.options"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-system-routes.ts fail-closes default/live system.remote.auth.assert.options to TS_RUNTIME_SYSTEM_REMOTE_RETIRED after the idempotency-key validation and immediately before the TypeScript WebAuthn assertion challenge-write (beginAssertion); the route is public/unauthenticated (no bound-principal step); legacy behavior is reachable only through explicit allowTestOnlySystemRemoteExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned system remote-access (device/session/WebAuthn) entrypoint when available."
+    },
+    {
+      "id": "system_remote_auth_assert_verify",
+      "route": {
+        "method": "POST",
+        "path": "/v1/system/remote/auth/assert/verify",
+        "operationId": "system.remote.auth.assert.verify"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-system-routes.ts fail-closes default/live system.remote.auth.assert.verify to TS_RUNTIME_SYSTEM_REMOTE_RETIRED after the idempotency-key validation and immediately before the TypeScript WebAuthn assertion verification (assertion grant + token mint); the route is public/unauthenticated (no bound-principal step); legacy behavior is reachable only through explicit allowTestOnlySystemRemoteExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned system remote-access (device/session/WebAuthn) entrypoint when available."
+    },
+    {
+      "id": "system_remote_sessions_create",
+      "route": {
+        "method": "POST",
+        "path": "/v1/system/remote/sessions",
+        "operationId": "system.remote.sessions.create"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-system-routes.ts fail-closes default/live system.remote.sessions.create to TS_RUNTIME_SYSTEM_REMOTE_RETIRED after the idempotency-key validation and immediately before the TypeScript remote-session open write; the route is public/unauthenticated (no bound-principal step); legacy behavior is reachable only through explicit allowTestOnlySystemRemoteExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned system remote-access (device/session/WebAuthn) entrypoint when available."
+    },
+    {
+      "id": "system_remote_sessions_heartbeat",
+      "route": {
+        "method": "POST",
+        "path": "/v1/system/remote/sessions/:sessionId/heartbeat",
+        "operationId": "system.remote.sessions.heartbeat"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-system-routes.ts fail-closes default/live system.remote.sessions.heartbeat to TS_RUNTIME_SYSTEM_REMOTE_RETIRED after the idempotency-key validation and immediately before the TypeScript remote-session liveness write; the route is public/unauthenticated (no bound-principal step); legacy behavior is reachable only through explicit allowTestOnlySystemRemoteExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned system remote-access (device/session/WebAuthn) entrypoint when available."
+    },
+    {
+      "id": "system_remote_sessions_delete",
+      "route": {
+        "method": "DELETE",
+        "path": "/v1/system/remote/sessions/:sessionId",
+        "operationId": "system.remote.sessions.delete"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-system-routes.ts fail-closes default/live system.remote.sessions.delete to TS_RUNTIME_SYSTEM_REMOTE_RETIRED after the sessionId path-param extraction and immediately before the TypeScript remote-session close write; the route is public/unauthenticated (no bound-principal step); legacy behavior is reachable only through explicit allowTestOnlySystemRemoteExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned system remote-access (device/session/WebAuthn) entrypoint when available."
     }
   ]
 }

--- a/src/api/http/routes/friday-system-routes.ts
+++ b/src/api/http/routes/friday-system-routes.ts
@@ -101,6 +101,83 @@ export interface FridaySystemRoutesDeps {
       meta: { origin?: string; ipAddress?: string; userAgent?: string },
     ): Promise<FridayVerifySystemRemotePasskeyAssertionResponse>;
   };
+  /**
+   * Test-oracle only: allow the legacy TypeScript system-intent execution in
+   * isolated mock/unit validation. Production/runtime callers must leave this
+   * unset so POST /v1/system/intents stays fail-closed until Rust owns it.
+   */
+  allowTestOnlySystemIntentExecution?: boolean;
+  /**
+   * Test-oracle only: allow the legacy TypeScript system approval-rule mutation
+   * in isolated validation. Production/runtime callers must leave this unset so
+   * PATCH /v1/system/approvals/:id stays fail-closed until Rust owns it.
+   */
+  allowTestOnlySystemApprovalExecution?: boolean;
+  /**
+   * Test-oracle only: allow the legacy TypeScript remote device/session/WebAuthn
+   * mutations (register/revoke/passkey, register/assert options+verify, session
+   * open/heartbeat/close) in isolated validation. Production/runtime callers must
+   * leave this unset so the remote-access engine stays fail-closed until Rust
+   * owns it.
+   */
+  allowTestOnlySystemRemoteExecution?: boolean;
+}
+
+// ─── Retirement helpers ───
+//
+// The system intent execution, approval-rule mutation, and remote
+// device/session/WebAuthn surfaces run TypeScript product logic or write
+// system state (control leases, approval rules, remote device/session/challenge
+// records). They fail-close by default/live until Rust owns the corresponding
+// entrypoints; legacy behavior is reachable only through the explicit
+// per-engine test-oracle flags above.
+
+function throwRetiredSystem(
+  code: string,
+  label: string,
+  replacement: string,
+): never {
+  throw new FridayDomainError(
+    code,
+    `${label} is fail-closed in default/live runtime; use the Rust-owned ${replacement} entrypoint.`,
+    {
+      httpStatus: 503,
+      details: {
+        classification: "fail_closed",
+        replacement: `rust_owned_${replacement}_entrypoint_required`,
+      },
+    },
+  );
+}
+
+function assertSystemIntentTestOracleAllowed(deps: FridaySystemRoutesDeps): void {
+  if (deps.allowTestOnlySystemIntentExecution !== true) {
+    throwRetiredSystem(
+      "TS_RUNTIME_SYSTEM_INTENT_RETIRED",
+      "TypeScript system intent execution",
+      "system_intent_execution",
+    );
+  }
+}
+
+function assertSystemApprovalTestOracleAllowed(deps: FridaySystemRoutesDeps): void {
+  if (deps.allowTestOnlySystemApprovalExecution !== true) {
+    throwRetiredSystem(
+      "TS_RUNTIME_SYSTEM_APPROVAL_RETIRED",
+      "TypeScript system approval-rule mutation",
+      "system_approval_rule",
+    );
+  }
+}
+
+function assertSystemRemoteTestOracleAllowed(deps: FridaySystemRoutesDeps): void {
+  if (deps.allowTestOnlySystemRemoteExecution !== true) {
+    throwRetiredSystem(
+      "TS_RUNTIME_SYSTEM_REMOTE_RETIRED",
+      "TypeScript system remote device/session/WebAuthn execution",
+      "system_remote_access",
+    );
+  }
 }
 
 function requireString(body: unknown, field: string): void {
@@ -198,6 +275,7 @@ export function createFridaySystemRoutes(
         requireIdempotencyKey(body);
         const { canonicalApproval: _ignoredCanonicalApproval, ...safeBody } =
           body as FridayExecuteSystemIntentRequest & { canonicalApproval?: unknown };
+        assertSystemIntentTestOracleAllowed(deps);
         return deps.intents.execute(safeBody);
       },
     },
@@ -223,6 +301,7 @@ export function createFridaySystemRoutes(
         const { approvalId } = ctx.params as { approvalId: string };
         const body = ctx.body as FridayUpdateSystemApprovalRequest;
         requireIdempotencyKey(body);
+        assertSystemApprovalTestOracleAllowed(deps);
         return deps.approvals.update(approvalId, body);
       },
     },
@@ -301,6 +380,7 @@ export function createFridaySystemRoutes(
         requireString(body, "fingerprint");
         requireTrustedDevicePlatform(body, "platform");
         requireIdempotencyKey(body);
+        assertSystemRemoteTestOracleAllowed(deps);
         return deps.remote.register(body);
       },
     },
@@ -311,6 +391,7 @@ export function createFridaySystemRoutes(
       auth: { public: true },
       async handler(ctx) {
         const { deviceId } = ctx.params as { deviceId: string };
+        assertSystemRemoteTestOracleAllowed(deps);
         return deps.remote.revoke(deviceId);
       },
     },
@@ -321,6 +402,7 @@ export function createFridaySystemRoutes(
       auth: { public: true },
       async handler(ctx) {
         const { deviceId } = ctx.params as { deviceId: string };
+        assertSystemRemoteTestOracleAllowed(deps);
         return deps.remote.clearPasskey(deviceId);
       },
     },
@@ -342,6 +424,7 @@ export function createFridaySystemRoutes(
         const body = ctx.body as FridayBeginSystemRemotePasskeyRegistrationRequest;
         requireString(body, "deviceId");
         requireIdempotencyKey(body);
+        assertSystemRemoteTestOracleAllowed(deps);
         return deps.remoteAuth.beginRegistration(body, {
           origin: readOrigin(ctx),
         });
@@ -364,6 +447,7 @@ export function createFridaySystemRoutes(
         requireString(body, "deviceId");
         requireString(body, "challengeId");
         requireIdempotencyKey(body);
+        assertSystemRemoteTestOracleAllowed(deps);
         return deps.remoteAuth.verifyRegistration(body, {
           origin: readOrigin(ctx),
         });
@@ -384,6 +468,7 @@ export function createFridaySystemRoutes(
         const body = ctx.body as FridayBeginSystemRemotePasskeyAssertionRequest;
         requireString(body, "deviceId");
         requireIdempotencyKey(body);
+        assertSystemRemoteTestOracleAllowed(deps);
         return deps.remoteAuth.beginAssertion(body, {
           origin: readOrigin(ctx),
         });
@@ -406,6 +491,7 @@ export function createFridaySystemRoutes(
         requireString(body, "deviceId");
         requireString(body, "challengeId");
         requireIdempotencyKey(body);
+        assertSystemRemoteTestOracleAllowed(deps);
         return deps.remoteAuth.verifyAssertion(body, {
           origin: readOrigin(ctx),
           ipAddress: readClientIp(ctx),
@@ -442,6 +528,7 @@ export function createFridaySystemRoutes(
         requireString(body, "deviceId");
         requireString(body, "assertionToken");
         requireIdempotencyKey(body);
+        assertSystemRemoteTestOracleAllowed(deps);
         return deps.remote.openSession(body, {
           ipAddress: readClientIp(ctx),
           userAgent: readUserAgent(ctx),
@@ -470,6 +557,7 @@ export function createFridaySystemRoutes(
         const { sessionId } = ctx.params as { sessionId: string };
         const body = ctx.body as FridayHeartbeatSystemRemoteSessionRequest;
         requireIdempotencyKey(body);
+        assertSystemRemoteTestOracleAllowed(deps);
         return deps.remote.heartbeatSession(sessionId, body, {
           ipAddress: readClientIp(ctx),
           userAgent: readUserAgent(ctx),
@@ -492,6 +580,7 @@ export function createFridaySystemRoutes(
       auth: { public: true, allowUnauthenticatedMutation: true },
       async handler(ctx) {
         const { sessionId } = ctx.params as { sessionId: string };
+        assertSystemRemoteTestOracleAllowed(deps);
         return deps.remote.closeSession(sessionId);
       },
     },

--- a/test/integration/hub/friday-hub-bootstrap-integration.test.ts
+++ b/test/integration/hub/friday-hub-bootstrap-integration.test.ts
@@ -1070,7 +1070,11 @@ describe("FridayHub Bootstrap Integration", () => {
         headers: {},
         principal: null,
       } as never)).rejects.toMatchObject({
-        code: "SYSTEM_CANONICAL_APPROVAL_REQUIRED",
+        // TS runtime retirement: the route-level fail-close guard now rejects
+        // system.approvals.update (503) BEFORE the hub canonical-approval stub
+        // (deps.approvals.update) would run; the route is blocked even harder.
+        code: "TS_RUNTIME_SYSTEM_APPROVAL_RETIRED",
+        httpStatus: 503,
       });
     } finally {
       if (previousEnabled === undefined) {
@@ -1091,11 +1095,16 @@ describe("FridayHub Bootstrap Integration", () => {
     }
   });
 
-  it("enforces canonical system mutation gate by default in production profile", async () => {
+  it("fail-closes the system approval-rule route by default in the production profile (retirement guard precedes the canonical gate)", async () => {
     const previousNodeEnv = process.env.NODE_ENV;
     const previousEnabled = process.env.FRIDAY_SYSTEM_ENABLED;
     const previousTransport = process.env.FRIDAY_SYSTEM_COMPANION_TRANSPORT;
     const previousCanonicalGate = process.env.FRIDAY_CANONICAL_GATE;
+    // NODE_ENV=production with FRIDAY_CANONICAL_GATE unset previously asserted the
+    // canonical-approval default; after TS runtime retirement the route-level
+    // fail-close guard rejects the route regardless of these env vars, so this
+    // env scaffolding is retained only to prove the production profile is still
+    // blocked (now by the retirement guard, not the canonical gate).
     process.env.NODE_ENV = "production";
     process.env.FRIDAY_SYSTEM_ENABLED = "true";
     process.env.FRIDAY_SYSTEM_COMPANION_TRANSPORT = "in_process";
@@ -1115,7 +1124,8 @@ describe("FridayHub Bootstrap Integration", () => {
         headers: {},
         principal: null,
       } as never)).rejects.toMatchObject({
-        code: "SYSTEM_CANONICAL_APPROVAL_REQUIRED",
+        code: "TS_RUNTIME_SYSTEM_APPROVAL_RETIRED",
+        httpStatus: 503,
       });
     } finally {
       if (previousNodeEnv === undefined) {

--- a/test/unit/api/http/routes/friday-system-routes.test.ts
+++ b/test/unit/api/http/routes/friday-system-routes.test.ts
@@ -75,6 +75,9 @@ function makeDeps(overrides?: Partial<FridaySystemRoutesDeps>): FridaySystemRout
         verifiedAt: "2026-03-06T00:01:00.000Z",
       }),
     },
+    allowTestOnlySystemIntentExecution: true,
+    allowTestOnlySystemApprovalExecution: true,
+    allowTestOnlySystemRemoteExecution: true,
     ...overrides,
   };
 }
@@ -747,5 +750,74 @@ describe("createFridaySystemRoutes", () => {
     expect(deps.remoteAuth.beginAssertion).toHaveBeenCalledTimes(1);
     expect(deps.remote.heartbeatSession).toHaveBeenCalledTimes(1);
     expect(deps.remote.closeSession).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("TS runtime retirement — system mutations fail-close by default", () => {
+  function failClosedDeps() {
+    return makeDeps({
+      allowTestOnlySystemIntentExecution: false,
+      allowTestOnlySystemApprovalExecution: false,
+      allowTestOnlySystemRemoteExecution: false,
+    });
+  }
+
+  it("intents.execute fail-closes with TS_RUNTIME_SYSTEM_INTENT_RETIRED (503) when the flag is unset", async () => {
+    const deps = failClosedDeps();
+    const routes = createFridaySystemRoutes(deps);
+    await expect(
+      findRoute(routes, "system.intents.execute").handler(
+        makeCtx({ body: { action: "open_url", target: "https://example.com", idempotencyKey: "k-1" } }),
+      ),
+    ).rejects.toMatchObject({ code: "TS_RUNTIME_SYSTEM_INTENT_RETIRED", httpStatus: 503 });
+    expect(deps.intents.execute).not.toHaveBeenCalled();
+  });
+
+  it("approvals.update fail-closes with TS_RUNTIME_SYSTEM_APPROVAL_RETIRED (503) when the flag is unset", async () => {
+    const deps = failClosedDeps();
+    const routes = createFridaySystemRoutes(deps);
+    await expect(
+      findRoute(routes, "system.approvals.update").handler(
+        makeCtx({ params: { approvalId: "approval-1" }, body: { idempotencyKey: "k-1", decision: "approved" } }),
+      ),
+    ).rejects.toMatchObject({ code: "TS_RUNTIME_SYSTEM_APPROVAL_RETIRED", httpStatus: 503 });
+    expect(deps.approvals.update).not.toHaveBeenCalled();
+  });
+
+  it("remote device/session/WebAuthn mutations fail-close with TS_RUNTIME_SYSTEM_REMOTE_RETIRED (503) when the flag is unset", async () => {
+    const deps = failClosedDeps();
+    const routes = createFridaySystemRoutes(deps);
+    const cases: Array<[string, Record<string, unknown>]> = [
+      ["system.remote.devices.register", { body: { label: "iPhone", fingerprint: "fp-ios", platform: "ios", idempotencyKey: "k-1" } }],
+      ["system.remote.devices.delete", { params: { deviceId: "device-1" } }],
+      ["system.remote.devices.passkey.delete", { params: { deviceId: "device-1" } }],
+      ["system.remote.auth.register.options", { body: { deviceId: "device-1", idempotencyKey: "reg-options-key" } }],
+      ["system.remote.auth.assert.options", { body: { deviceId: "device-1", idempotencyKey: "assert-options-key" } }],
+      ["system.remote.sessions.create", { body: { deviceId: "device-1", assertionToken: "assertion-token", idempotencyKey: "create-key" } }],
+      ["system.remote.sessions.heartbeat", { params: { sessionId: "remote-session-1" }, body: { idempotencyKey: "hb-key" } }],
+      ["system.remote.sessions.delete", { params: { sessionId: "remote-session-1" } }],
+    ];
+    for (const [op, ctx] of cases) {
+      await expect(findRoute(routes, op).handler(makeCtx(ctx))).rejects.toMatchObject({
+        code: "TS_RUNTIME_SYSTEM_REMOTE_RETIRED",
+        httpStatus: 503,
+      });
+    }
+    // The remote service mutations were never reached.
+    expect(deps.remote.register).not.toHaveBeenCalled();
+    expect(deps.remoteAuth.beginRegistration).not.toHaveBeenCalled();
+    expect(deps.remote.openSession).not.toHaveBeenCalled();
+  });
+
+  it("still 400s on invalid input BEFORE the retirement guard (validation precedes the guard)", async () => {
+    const routes = createFridaySystemRoutes(failClosedDeps());
+    // intents.execute missing action => 400, not 503
+    await expect(
+      findRoute(routes, "system.intents.execute").handler(makeCtx({ body: { idempotencyKey: "k-1" } })),
+    ).rejects.toMatchObject({ httpStatus: 400 });
+    // remote.auth.register.options missing deviceId => 400, not 503
+    await expect(
+      findRoute(routes, "system.remote.auth.register.options").handler(makeCtx({ body: { idempotencyKey: "k-1" } })),
+    ).rejects.toMatchObject({ httpStatus: 400 });
   });
 });


### PR DESCRIPTION
## What

Adds `fail_closed` TS-runtime-retirement guards to the **12 user-triggerable system mutation surfaces** in `src/api/http/routes/friday-system-routes.ts`:

- `intents.execute`, `approvals.update`
- remote device: `register`, `revoke`, `passkey delete`
- remote webauthn: `register options`/`verify`, `assert options`/`verify`
- remote session: `create`, `heartbeat`, `close`

Each handler gains an `assertSystem{Intent,Approval,Remote}TestOracleAllowed(deps)` guard placed **after** availability/principal/validation/approval checks and **immediately before** the real service mutation. When the matching `allowTestOnlySystem*` dep flag is unset (default/live hub wiring leaves it unset), the guard throws a 503 `FridayDomainError` with `classification="fail_closed"` and `replacement="rust_owned_*"`. `executes_product_logic:false` holds for all 12.

## Manifest

12 additive `fail_closed` surfaces (text-spliced, not reformatted). Gate: `ts_runtime_blocker` **60 → 48**, `fail_closed` 174 → 186. No `operator_external_adapter` here — every one of these 12 is an internal device-pairing / auth / session-lifecycle mutation, not external egress.

## Tests (no weakening)

- `makeDeps` defaults the 3 `allowTestOnly*` flags to `true` before `...overrides`, so all existing system-route tests still exercise real logic (not the 503 path).
- New regression block asserts genuine fail-close = **503** + the service method was **not called** + a **malformed request still 400s before the guard**.
- `friday-hub-bootstrap-integration.test.ts` assertions updated `SYSTEM_CANONICAL_APPROVAL_REQUIRED` → `TS_RUNTIME_SYSTEM_APPROVAL_RETIRED` (honest: the hub approval stub is now dead code behind the guard); the production-profile test renamed accordingly.
- No skip/xfail/.only/commented assertions.

## Verification

- `npm run check:ts-runtime-retirement` → passed, blocker 60→48, fail_closed 174→186.
- `npm run build` → green. `npm run lint` → 0 errors.
- `FRIDAY_E2E_CORE=1 npx vitest run` system-routes + hub-bootstrap → **62 passed, no type errors**.
- `git diff --check` / `check:secret-patterns` / detect-secrets → clean.
- 6-dimension adversarial review (guard-placement, manifest, classification, test-honesty, leak-exposure, completeness): **0 major/blocker findings**.

Interface-only wiring (`createFridaySystemRoutes(deps.system)` passthrough) — no runtime/types/hub/e2e behavior change beyond the guards. No RGG resolver needed (no RGG-covered scenario depends on these routes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)