### PR TITLE
fix(satellites): fail-close TS satellite runtime + pairing mutations

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -3138,6 +3138,160 @@
       "executes_product_logic": false,
       "proof": "src/api/http/routes/friday-system-routes.ts fail-closes default/live system.remote.sessions.delete to TS_RUNTIME_SYSTEM_REMOTE_RETIRED after the sessionId path-param extraction and immediately before the TypeScript remote-session close write; the route is public/unauthenticated (no bound-principal step); legacy behavior is reachable only through explicit allowTestOnlySystemRemoteExecution test-oracle wiring.",
       "next_action": "Replace the fail-closed response with the Rust-owned system remote-access (device/session/WebAuthn) entrypoint when available."
+    },
+    {
+      "id": "satellite_heartbeat",
+      "route": {
+        "method": "POST",
+        "path": "/v1/satellites/:satelliteId/heartbeat",
+        "operationId": "satellites.heartbeat"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-satellite-runtime-routes.ts fail-closes default/live satellites.heartbeat to TS_RUNTIME_SATELLITE_RUNTIME_RETIRED after requireSatellitePrincipal and the hoisted ts validation, immediately before the TypeScript recordHeartbeat write (friday-satellite-heartbeat-service.ts withWriteTransaction: heartbeat insert, pairing status + last-seen updates); legacy behavior is reachable only through explicit allowTestOnlySatelliteRuntimeExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned satellite runtime entrypoint when available."
+    },
+    {
+      "id": "satellite_capabilities_update",
+      "route": {
+        "method": "POST",
+        "path": "/v1/satellites/:satelliteId/capabilities",
+        "operationId": "satellites.capabilities.update"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-satellite-runtime-routes.ts fail-closes default/live satellites.capabilities.update to TS_RUNTIME_SATELLITE_RUNTIME_RETIRED after requireSatellitePrincipal and the hoisted revision/generatedAt/capabilities validation, immediately before the TypeScript updateCapabilities write (friday-satellite-capability-service.ts withWriteTransaction: capability upsert + monotonic revision persist); legacy behavior is reachable only through explicit allowTestOnlySatelliteRuntimeExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned satellite runtime entrypoint when available."
+    },
+    {
+      "id": "satellite_sync_pull",
+      "route": {
+        "method": "POST",
+        "path": "/v1/satellites/:satelliteId/sync/pull",
+        "operationId": "satellites.sync.pull"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-satellite-runtime-routes.ts fail-closes default/live satellites.sync.pull to TS_RUNTIME_SATELLITE_RUNTIME_RETIRED after requireSatellitePrincipal and the hoisted streamId/lastAckedSeq validation, immediately before the TypeScript pullSync write (friday-satellite-sync-service.ts withWriteTransaction: outbox leaseBatch + signed resume cursor — a write despite the pull name); legacy behavior is reachable only through explicit allowTestOnlySatelliteRuntimeExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned satellite runtime entrypoint when available."
+    },
+    {
+      "id": "satellite_sync_push",
+      "route": {
+        "method": "POST",
+        "path": "/v1/satellites/:satelliteId/sync/push",
+        "operationId": "satellites.sync.push"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-satellite-runtime-routes.ts fail-closes default/live satellites.sync.push to TS_RUNTIME_SATELLITE_RUNTIME_RETIRED after requireSatellitePrincipal, immediately before the TypeScript pushSync write (friday-satellite-sync-service.ts withWriteTransaction: checkpoint advance, outbox ackUpToSeq, learning events, remote node results); legacy behavior is reachable only through explicit allowTestOnlySatelliteRuntimeExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned satellite runtime entrypoint when available."
+    },
+    {
+      "id": "satellite_commands_poll",
+      "route": {
+        "method": "POST",
+        "path": "/v1/satellites/:satelliteId/commands/poll",
+        "operationId": "satellites.commands.poll"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-satellite-runtime-routes.ts fail-closes default/live satellites.commands.poll to TS_RUNTIME_SATELLITE_RUNTIME_RETIRED after requireSatellitePrincipal and limit/leaseMs normalization, immediately before the TypeScript pollCommands write (friday-outbox-queue-service.ts withWriteTransaction: leaseBatch marks outbox rows leased to this satellite); legacy behavior is reachable only through explicit allowTestOnlySatelliteRuntimeExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned satellite runtime entrypoint when available."
+    },
+    {
+      "id": "satellite_commands_ack",
+      "route": {
+        "method": "POST",
+        "path": "/v1/satellites/:satelliteId/commands/:commandId/ack",
+        "operationId": "satellites.commands.ack"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-satellite-runtime-routes.ts fail-closes default/live satellites.commands.ack to TS_RUNTIME_SATELLITE_RUNTIME_RETIRED after requireSatellitePrincipal, the status validation, and the hoisted terminal-result field validation (runId/nodeId/attemptId/attempt), immediately before the TypeScript reportCommandResult/ackCommand writes (workflow-run remote node result advance + friday-outbox-queue-service.ts withWriteTransaction ackById); legacy behavior is reachable only through explicit allowTestOnlySatelliteRuntimeExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned satellite runtime entrypoint when available."
+    },
+    {
+      "id": "satellite_events_poll_read",
+      "route": {
+        "method": "POST",
+        "path": "/v1/satellites/:satelliteId/events/poll",
+        "operationId": "satellites.events.poll"
+      },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "proof": "src/api/http/routes/friday-satellite-runtime-routes.ts satellites.events.poll is a pure read: deps.getCheckpoint and deps.pullEvents both run via withReadConnection (friday-realtime-subscription-service.ts) and the handler returns {streamId, checkpoint, events} with no lease, cursor advance, or write (cursor advancement lives in the separate ackEvent method, never invoked by this route). It stays a redacting compat_shim and is intentionally NOT gated by the retirement guard."
+    },
+    {
+      "id": "satellite_register",
+      "route": {
+        "method": "POST",
+        "path": "/v1/satellites/register",
+        "operationId": "satellites.register"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-satellite-pairing-routes.ts fail-closes default/live satellites.register to TS_RUNTIME_SATELLITE_PAIRING_RETIRED after the type/displayName/publicKey validation, immediately before the TypeScript registerSatellite write (friday-satellite-registration-service.ts withWriteTransaction: satellite insert + pairing request insert + optional capability upsert); the route is public/rate-limited and never auto-approves; legacy behavior is reachable only through explicit allowTestOnlySatellitePairingExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned satellite pairing entrypoint when available."
+    },
+    {
+      "id": "satellite_handshake",
+      "route": {
+        "method": "POST",
+        "path": "/v1/satellites/:satelliteId/handshake",
+        "operationId": "satellites.handshake"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-satellite-pairing-routes.ts fail-closes default/live satellites.handshake to TS_RUNTIME_SATELLITE_PAIRING_RETIRED after the token/signedChallenge/challengeNonce/clientEphemeralPublicKey validation, immediately before the TypeScript completeHandshake write (friday-satellite-pairing-service.ts withWriteTransaction: pairing status->online, last-seen, epoch bump); legacy behavior (including the handshake signature verifier) is reachable only through explicit allowTestOnlySatellitePairingExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned satellite pairing entrypoint when available."
+    },
+    {
+      "id": "satellite_pairing_approve",
+      "route": {
+        "method": "POST",
+        "path": "/v1/satellites/:satelliteId/pairing/approve",
+        "operationId": "satellites.pairing.approve"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-satellite-pairing-routes.ts fail-closes default/live satellites.pairing.approve to TS_RUNTIME_SATELLITE_PAIRING_RETIRED after assertBoundPrincipalForOperation and immediately before the TypeScript getPairingRequest lookup + approvePairing write (friday-satellite-pairing-service.ts withWriteTransaction: request->approved, satellite->paired, API token issuance); the bound-principal owner check still runs first; legacy behavior is reachable only through explicit allowTestOnlySatellitePairingExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned satellite pairing entrypoint when available."
+    },
+    {
+      "id": "satellite_pairing_reject",
+      "route": {
+        "method": "POST",
+        "path": "/v1/satellites/:satelliteId/pairing/reject",
+        "operationId": "satellites.pairing.reject"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-satellite-pairing-routes.ts fail-closes default/live satellites.pairing.reject to TS_RUNTIME_SATELLITE_PAIRING_RETIRED after assertBoundPrincipalForOperation and immediately before the TypeScript getPairingRequest lookup + rejectPairing write (friday-satellite-pairing-service.ts withWriteTransaction: request->rejected); the bound-principal owner check still runs first; legacy behavior is reachable only through explicit allowTestOnlySatellitePairingExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned satellite pairing entrypoint when available."
+    },
+    {
+      "id": "satellite_revoke",
+      "route": {
+        "method": "POST",
+        "path": "/v1/satellites/:satelliteId/revoke",
+        "operationId": "satellites.revoke"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-satellite-pairing-routes.ts fail-closes default/live satellites.revoke to TS_RUNTIME_SATELLITE_PAIRING_RETIRED after assertBoundPrincipalForOperation and immediately before the TypeScript revokeSatellite write (friday-satellite-pairing-service.ts withWriteTransaction: pairing->revoked, revokeAllForSatellite, token version bump); the bound-principal owner check still runs first; legacy behavior is reachable only through explicit allowTestOnlySatellitePairingExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned satellite pairing entrypoint when available."
     }
   ]
 }

--- a/src/api/http/routes/friday-satellite-pairing-routes.ts
+++ b/src/api/http/routes/friday-satellite-pairing-routes.ts
@@ -97,6 +97,40 @@ export interface FridaySatellitePairingRoutesDeps {
     createdAt: string;
     expiresAt: string;
   } | null>;
+  /**
+   * Test-oracle only: allow the legacy TypeScript satellite pairing mutations
+   * (register, approve, reject, handshake, revoke) in isolated mock/unit
+   * validation. Production/runtime callers must leave this unset so the satellite
+   * pairing engine stays fail-closed until Rust owns it. The read-only pairing
+   * list/get surfaces are never gated.
+   */
+  allowTestOnlySatellitePairingExecution?: boolean;
+}
+
+// ─── Retirement helper ───
+//
+// The satellite pairing mutation surfaces (register, approve, reject, handshake,
+// revoke) write hub pairing/token state inside withWriteTransaction (satellite
+// registration + pairing requests, pairing status transitions, API token
+// issuance/revocation, epoch bumps). They fail-close by default/live until Rust
+// owns the satellite pairing entrypoint; legacy behavior is reachable only
+// through the explicit allowTestOnlySatellitePairingExecution test-oracle flag.
+// The GET pairing list/get surfaces are pure reads and are NOT gated.
+
+function assertSatellitePairingTestOracleAllowed(deps: FridaySatellitePairingRoutesDeps): void {
+  if (deps.allowTestOnlySatellitePairingExecution !== true) {
+    throw new FridayDomainError(
+      "TS_RUNTIME_SATELLITE_PAIRING_RETIRED",
+      "TypeScript satellite pairing mutation is fail-closed in default/live runtime; use the Rust-owned satellite pairing entrypoint.",
+      {
+        httpStatus: 503,
+        details: {
+          classification: "fail_closed",
+          replacement: "rust_owned_satellite_pairing_entrypoint_required",
+        },
+      },
+    );
+  }
 }
 
 // ─── Factory ───
@@ -123,6 +157,8 @@ export function createFridaySatellitePairingRoutes(
             error: { code: "VALIDATION_FAILED", message: "type, displayName, publicKey are required" },
           };
         }
+
+        assertSatellitePairingTestOracleAllowed(deps);
 
         const rawRuntime = body.runtime as Record<string, unknown> | undefined;
         const runtime = {
@@ -191,6 +227,7 @@ export function createFridaySatellitePairingRoutes(
           "satellite.pairing.approve",
           "api",
         );
+        assertSatellitePairingTestOracleAllowed(deps);
         const pairingReq = await deps.getPairingRequest(params.satelliteId);
         if (!pairingReq) {
           throw new FridayDomainError("NOT_FOUND", "No pending pairing request", { httpStatus: 404 });
@@ -222,6 +259,7 @@ export function createFridaySatellitePairingRoutes(
           "satellite.pairing.reject",
           "api",
         );
+        assertSatellitePairingTestOracleAllowed(deps);
         const pairingReq = await deps.getPairingRequest(params.satelliteId);
         if (!pairingReq) {
           throw new FridayDomainError("NOT_FOUND", "No pending pairing request", { httpStatus: 404 });
@@ -264,6 +302,8 @@ export function createFridaySatellitePairingRoutes(
           };
         }
 
+        assertSatellitePairingTestOracleAllowed(deps);
+
         const result = await deps.completeHandshake({
           satelliteId: params.satelliteId,
           token,
@@ -291,6 +331,8 @@ export function createFridaySatellitePairingRoutes(
           "satellite.revoke",
           "api",
         );
+
+        assertSatellitePairingTestOracleAllowed(deps);
 
         const result = await deps.revokeSatellite({
           satelliteId: params.satelliteId,

--- a/src/api/http/routes/friday-satellite-runtime-routes.ts
+++ b/src/api/http/routes/friday-satellite-runtime-routes.ts
@@ -65,6 +65,40 @@ export interface FridaySatelliteRuntimeRoutesDeps {
     principalId: string;
     streamId: string;
   }) => Awaitable<{ lastAckedSeq: number; epoch: number; cursor?: string } | null>;
+  /**
+   * Test-oracle only: allow the legacy TypeScript satellite runtime mutations
+   * (heartbeat, capability report, sync pull/push, command poll/ack) in isolated
+   * mock/unit validation. Production/runtime callers must leave this unset so the
+   * satellite runtime engine stays fail-closed until Rust owns it. The read-only
+   * events poll surface is never gated.
+   */
+  allowTestOnlySatelliteRuntimeExecution?: boolean;
+}
+
+// ─── Retirement helper ───
+//
+// The satellite runtime mutation surfaces (heartbeat, capability report, sync
+// pull/push, command poll/ack) write hub state inside withWriteTransaction
+// (heartbeat/pairing status, capability revisions, outbox leases/acks, sync
+// checkpoints, remote node results). They fail-close by default/live until Rust
+// owns the satellite runtime entrypoint; legacy behavior is reachable only
+// through the explicit allowTestOnlySatelliteRuntimeExecution test-oracle flag.
+// satellites.events.poll is a pure read (withReadConnection) and is NOT gated.
+
+function assertSatelliteRuntimeTestOracleAllowed(deps: FridaySatelliteRuntimeRoutesDeps): void {
+  if (deps.allowTestOnlySatelliteRuntimeExecution !== true) {
+    throw new FridayDomainError(
+      "TS_RUNTIME_SATELLITE_RUNTIME_RETIRED",
+      "TypeScript satellite runtime mutation is fail-closed in default/live runtime; use the Rust-owned satellite runtime entrypoint.",
+      {
+        httpStatus: 503,
+        details: {
+          classification: "fail_closed",
+          replacement: "rust_owned_satellite_runtime_entrypoint_required",
+        },
+      },
+    );
+  }
 }
 
 const MAX_POLL_LIMIT = 100;
@@ -204,9 +238,11 @@ export function createFridaySatelliteRuntimeRoutes(
         const params = ctx.params as Record<string, string>;
         requireSatellitePrincipal(ctx as Ctx, params.satelliteId);
         const body = ctx.body as Record<string, unknown>;
+        const ts = requireString(body, "ts");
+        assertSatelliteRuntimeTestOracleAllowed(deps);
         return deps.recordHeartbeat({
           satelliteId: params.satelliteId,
-          ts: requireString(body, "ts"),
+          ts,
           metrics: body.metrics as FridaySatelliteHeartbeatInput["metrics"],
           queueDepth: typeof body.queueDepth === "number" ? body.queueDepth : undefined,
           activeRuns: typeof body.activeRuns === "number" ? body.activeRuns : undefined,
@@ -226,12 +262,16 @@ export function createFridaySatelliteRuntimeRoutes(
         const params = ctx.params as Record<string, string>;
         requireSatellitePrincipal(ctx as Ctx, params.satelliteId);
         const body = ctx.body as Record<string, unknown>;
+        const revision = requirePositiveInteger(body.revision, "revision");
+        const generatedAt = requireString(body, "generatedAt");
+        const capabilities = parseCapabilities(body);
+        assertSatelliteRuntimeTestOracleAllowed(deps);
         return deps.updateCapabilities({
           satelliteId: params.satelliteId,
-          revision: requirePositiveInteger(body.revision, "revision"),
-          generatedAt: requireString(body, "generatedAt"),
+          revision,
+          generatedAt,
           runtime: body.runtime as FridaySatelliteCapabilityReport["runtime"],
-          capabilities: parseCapabilities(body),
+          capabilities,
         });
       },
     },
@@ -244,10 +284,13 @@ export function createFridaySatelliteRuntimeRoutes(
         const params = ctx.params as Record<string, string>;
         requireSatellitePrincipal(ctx as Ctx, params.satelliteId);
         const body = ctx.body as Record<string, unknown>;
+        const streamId = requireString(body, "streamId");
+        const lastAckedSeq = requirePositiveInteger(body.lastAckedSeq, "lastAckedSeq", 0);
+        assertSatelliteRuntimeTestOracleAllowed(deps);
         return deps.pullSync({
           satelliteId: params.satelliteId,
-          streamId: requireString(body, "streamId"),
-          lastAckedSeq: requirePositiveInteger(body.lastAckedSeq, "lastAckedSeq", 0),
+          streamId,
+          lastAckedSeq,
           subscriptions: Array.isArray(body.subscriptions)
             ? body.subscriptions.filter((entry): entry is string => typeof entry === "string")
             : [],
@@ -264,6 +307,7 @@ export function createFridaySatelliteRuntimeRoutes(
         const params = ctx.params as Record<string, string>;
         requireSatellitePrincipal(ctx as Ctx, params.satelliteId);
         const body = ctx.body as Record<string, unknown>;
+        assertSatelliteRuntimeTestOracleAllowed(deps);
         return deps.pushSync({
           satelliteId: params.satelliteId,
           acks: Array.isArray(body.acks)
@@ -295,6 +339,7 @@ export function createFridaySatelliteRuntimeRoutes(
           5_000,
           requirePositiveInteger(body.leaseMs, "leaseMs", DEFAULT_COMMAND_LEASE_MS),
         );
+        assertSatelliteRuntimeTestOracleAllowed(deps);
         const commands = await deps.pollCommands({
           satelliteId: params.satelliteId,
           limit,
@@ -321,15 +366,24 @@ export function createFridaySatelliteRuntimeRoutes(
         const body = ctx.body as Record<string, unknown>;
         const status = requireString(body, "status");
         const hasTerminalResult = status === "completed" || status === "failed";
+        const reportTerminal = deps.reportCommandResult !== undefined && hasTerminalResult;
+        // Hoist terminal-ack field validation above the retirement guard so a
+        // malformed terminal ack still returns 400 (not 503) when the flag is unset.
+        const terminalRunId = reportTerminal ? requireString(body, "runId") : undefined;
+        const terminalNodeId = reportTerminal ? requireString(body, "nodeId") : undefined;
+        const terminalAttemptId = reportTerminal ? requireString(body, "attemptId") : undefined;
+        const terminalAttempt = reportTerminal ? requirePositiveInteger(body.attempt, "attempt") : undefined;
 
-        if (deps.reportCommandResult && hasTerminalResult) {
-          await deps.reportCommandResult({
+        assertSatelliteRuntimeTestOracleAllowed(deps);
+
+        if (reportTerminal) {
+          await deps.reportCommandResult!({
             satelliteId: params.satelliteId,
             commandId: params.commandId,
-            runId: requireString(body, "runId"),
-            nodeId: requireString(body, "nodeId"),
-            attemptId: requireString(body, "attemptId"),
-            attempt: requirePositiveInteger(body.attempt, "attempt"),
+            runId: terminalRunId!,
+            nodeId: terminalNodeId!,
+            attemptId: terminalAttemptId!,
+            attempt: terminalAttempt!,
             status: status as "completed" | "failed",
             output: body.output,
             error: status === "failed"

--- a/test/unit/api/http/routes/friday-satellite-runtime-routes.test.ts
+++ b/test/unit/api/http/routes/friday-satellite-runtime-routes.test.ts
@@ -30,6 +30,10 @@ describe("FridaySatelliteRuntimeRoutes", () => {
     reportCommandResult: vi.fn(async () => undefined),
     pullEvents: vi.fn(async () => []),
     getCheckpoint: vi.fn(async () => ({ lastAckedSeq: 4, epoch: 1, cursor: "cursor-1" })),
+    // Test-oracle: exercise the real TypeScript runtime logic in these unit
+    // tests. Default/live hub wiring leaves this unset so the surfaces fail-close
+    // (see the TS-runtime-retirement regression block below).
+    allowTestOnlySatelliteRuntimeExecution: true,
   };
 
   function makeCtx(
@@ -301,6 +305,70 @@ describe("FridaySatelliteRuntimeRoutes", () => {
       streamId: "fleet",
       checkpoint: { lastAckedSeq: 4, epoch: 1, cursor: "cursor-1" },
       events: [{ seq: 5, event: "fleet.summary.updated" }],
+    });
+  });
+
+  describe("TS runtime retirement (allowTestOnlySatelliteRuntimeExecution unset)", () => {
+    const retiredDeps = {
+      recordHeartbeat: vi.fn(async () => ({ accepted: true as const, now: NOW, expectedIntervalMs: 15_000, status: "online" })),
+      updateCapabilities: vi.fn(async () => ({ accepted: true })),
+      pullSync: vi.fn(async () => ({ streamId: "fleet", events: [], queueItems: [], nextCursor: undefined })),
+      pushSync: vi.fn(async () => ({ acceptedAcks: [], acceptedNodeResults: [], conflicts: [] })),
+      pollCommands: vi.fn(async () => []),
+      ackCommand: vi.fn(async () => ({ acked: true })),
+      reportCommandResult: vi.fn(async () => undefined),
+      pullEvents: vi.fn(async () => []),
+      getCheckpoint: vi.fn(async () => ({ lastAckedSeq: 4, epoch: 1, cursor: "cursor-1" })),
+      // allowTestOnlySatelliteRuntimeExecution intentionally unset → fail-closed.
+    };
+    let retiredRoutes: FridayRouteDefinition<unknown, unknown, unknown, unknown>[];
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      retiredRoutes = createFridaySatelliteRuntimeRoutes(retiredDeps);
+    });
+
+    function retiredRoute(operationId: string) {
+      return retiredRoutes.find((route) => route.operationId === operationId)!;
+    }
+
+    const cases: Array<{ op: string; body: Record<string, unknown>; service: keyof typeof retiredDeps }> = [
+      { op: "satellites.heartbeat", body: { ts: NOW }, service: "recordHeartbeat" },
+      { op: "satellites.capabilities.update", body: { revision: 1, generatedAt: NOW, capabilities: [{ key: "shell", available: true }] }, service: "updateCapabilities" },
+      { op: "satellites.sync.pull", body: { streamId: "fleet", lastAckedSeq: 0 }, service: "pullSync" },
+      { op: "satellites.sync.push", body: { acks: [] }, service: "pushSync" },
+      { op: "satellites.commands.poll", body: { limit: 10 }, service: "pollCommands" },
+      { op: "satellites.commands.ack", body: { status: "completed", runId: "r", nodeId: "n", attemptId: "a", attempt: 1 }, service: "ackCommand" },
+    ];
+
+    for (const { op, body, service } of cases) {
+      it(`fail-closes ${op} with 503 and never calls the service`, async () => {
+        await expect(
+          retiredRoute(op).handler(makeCtx("sat-1", { params: { satelliteId: "sat-1", commandId: "cmd-1" }, body })),
+        ).rejects.toMatchObject({
+          code: "TS_RUNTIME_SATELLITE_RUNTIME_RETIRED",
+          httpStatus: 503,
+        } satisfies Partial<FridayDomainError>);
+        expect(retiredDeps[service]).not.toHaveBeenCalled();
+        if (op === "satellites.commands.ack") {
+          expect(retiredDeps.reportCommandResult).not.toHaveBeenCalled();
+        }
+      });
+    }
+
+    it("validates the request body (400) before the retirement guard (heartbeat missing ts)", async () => {
+      await expect(
+        retiredRoute("satellites.heartbeat").handler(makeCtx("sat-1", { body: {} })),
+      ).rejects.toMatchObject({ code: "VALIDATION_ERROR", httpStatus: 400 } satisfies Partial<FridayDomainError>);
+      expect(retiredDeps.recordHeartbeat).not.toHaveBeenCalled();
+    });
+
+    it("still serves the read-only events poll (compat_shim, not gated by retirement)", async () => {
+      const result = await retiredRoute("satellites.events.poll").handler(
+        makeCtx("sat-1", { body: { streamId: "fleet", afterSeq: 0, limit: 10 } }),
+      );
+      expect(retiredDeps.pullEvents).toHaveBeenCalled();
+      expect(result).toMatchObject({ streamId: "fleet" });
     });
   });
 });

--- a/test/unit/api/routes/friday-satellite-pairing-routes.test.ts
+++ b/test/unit/api/routes/friday-satellite-pairing-routes.test.ts
@@ -53,6 +53,10 @@ function makeDeps(overrides: Partial<FridaySatellitePairingRoutesDeps> = {}): Fr
       createdAt: "2026-02-25T00:00:00Z",
       expiresAt: "2026-02-26T00:00:00Z",
     }),
+    // Test-oracle: exercise the real TypeScript pairing logic. Default/live hub
+    // wiring leaves this unset so the surfaces fail-close (see the
+    // TS-runtime-retirement regression block below).
+    allowTestOnlySatellitePairingExecution: true,
     ...overrides,
   };
 }
@@ -428,6 +432,86 @@ describe("createFridaySatellitePairingRoutes", () => {
       }) as any)).rejects.toMatchObject({ code: "OWNER_SESSION_CHANNEL_PRINCIPAL_REQUIRED" });
 
       expect(deps.revokeSatellite).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── TS runtime retirement ───
+
+  describe("TS runtime retirement (allowTestOnlySatellitePairingExecution unset)", () => {
+    function retiredDeps(overrides: Partial<FridaySatellitePairingRoutesDeps> = {}): FridaySatellitePairingRoutesDeps {
+      return makeDeps({ allowTestOnlySatellitePairingExecution: false, ...overrides });
+    }
+
+    it("fail-closes satellites.register with 503 and never calls registerSatellite", async () => {
+      const d = retiredDeps();
+      const route = findRoute(createFridaySatellitePairingRoutes(d), "satellites.register");
+      await expect(route.handler(makeCtx({
+        body: { type: "edge", displayName: "Test", publicKey: "pk-abc" },
+      }) as any)).rejects.toMatchObject({ code: "TS_RUNTIME_SATELLITE_PAIRING_RETIRED", httpStatus: 503 });
+      expect(d.registerSatellite).not.toHaveBeenCalled();
+    });
+
+    it("fail-closes satellites.handshake with 503 and never calls completeHandshake", async () => {
+      const d = retiredDeps();
+      const route = findRoute(createFridaySatellitePairingRoutes(d), "satellites.handshake");
+      await expect(route.handler(makeCtx({
+        params: { satelliteId: "sat-001" },
+        body: { token: "t", signedChallenge: "s", challengeNonce: "n", clientEphemeralPublicKey: "c" },
+      }) as any)).rejects.toMatchObject({ code: "TS_RUNTIME_SATELLITE_PAIRING_RETIRED", httpStatus: 503 });
+      expect(d.completeHandshake).not.toHaveBeenCalled();
+    });
+
+    it("fail-closes satellites.pairing.approve (after the owner check, before the pairing lookup)", async () => {
+      const d = retiredDeps();
+      const route = findRoute(createFridaySatellitePairingRoutes(d), "satellites.pairing.approve");
+      await expect(route.handler(makeCtx({
+        params: { satelliteId: "sat-001" },
+        body: {},
+        principal: { principalId: "user-001" },
+      }) as any)).rejects.toMatchObject({ code: "TS_RUNTIME_SATELLITE_PAIRING_RETIRED", httpStatus: 503 });
+      expect(d.approvePairing).not.toHaveBeenCalled();
+      expect(d.getPairingRequest).not.toHaveBeenCalled();
+    });
+
+    it("fail-closes satellites.pairing.reject (after the owner check) and never calls rejectPairing", async () => {
+      const d = retiredDeps();
+      const route = findRoute(createFridaySatellitePairingRoutes(d), "satellites.pairing.reject");
+      await expect(route.handler(makeCtx({
+        params: { satelliteId: "sat-001" },
+        body: {},
+        principal: { principalId: "user-001" },
+      }) as any)).rejects.toMatchObject({ code: "TS_RUNTIME_SATELLITE_PAIRING_RETIRED", httpStatus: 503 });
+      expect(d.rejectPairing).not.toHaveBeenCalled();
+    });
+
+    it("fail-closes satellites.revoke (after the owner check) and never calls revokeSatellite", async () => {
+      const d = retiredDeps();
+      const route = findRoute(createFridaySatellitePairingRoutes(d), "satellites.revoke");
+      await expect(route.handler(makeCtx({
+        params: { satelliteId: "sat-001" },
+        body: { reason: "x" },
+        principal: { principalId: "user-001" },
+      }) as any)).rejects.toMatchObject({ code: "TS_RUNTIME_SATELLITE_PAIRING_RETIRED", httpStatus: 503 });
+      expect(d.revokeSatellite).not.toHaveBeenCalled();
+    });
+
+    it("enforces the owner-binding check BEFORE the retirement guard on approve (synthetic public principal still rejected, not 503)", async () => {
+      const d = retiredDeps();
+      const route = findRoute(createFridaySatellitePairingRoutes(d), "satellites.pairing.approve");
+      await expect(route.handler(makeCtx({
+        params: { satelliteId: "sat-001" },
+        body: {},
+        principal: { principalId: "public:default" },
+      }) as any)).rejects.toMatchObject({ code: "OWNER_SESSION_CHANNEL_PRINCIPAL_REQUIRED" });
+      expect(d.approvePairing).not.toHaveBeenCalled();
+    });
+
+    it("returns the register validation error BEFORE the retirement guard (missing fields)", async () => {
+      const d = retiredDeps();
+      const route = findRoute(createFridaySatellitePairingRoutes(d), "satellites.register");
+      const result = await route.handler(makeCtx({ body: { type: "edge" } }) as any);
+      expect(result).toEqual({ error: expect.objectContaining({ code: "VALIDATION_FAILED" }) });
+      expect(d.registerSatellite).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## What

Retire the **12 user/device-triggerable TS-runtime mutation surfaces** across the two satellite route files (gate: `ts_runtime_blocker` **48 → 36**).

**`friday-satellite-runtime-routes.ts` — 6 fail_closed + 1 compat_shim:**
- `heartbeat`, `capabilities.update`, `sync.pull`, `sync.push`, `commands.poll`, `commands.ack` gated by `assertSatelliteRuntimeTestOracleAllowed(deps)` (flag `allowTestOnlySatelliteRuntimeExecution`).
- `events.poll` is a **pure read** (`getCheckpoint`/`pullEvents` via `withReadConnection`; the mutating `ackEvent` is never called here) → stays an **unguarded `compat_shim`**.

**`friday-satellite-pairing-routes.ts` — 5 fail_closed:**
- `register`, `handshake`, `pairing.approve`, `pairing.reject`, `revoke` gated by `assertSatellitePairingTestOracleAllowed(deps)` (flag `allowTestOnlySatellitePairingExecution`).

Each guard fires **after** availability/principal/validation checks and **immediately before** the real service write (all confirmed to mutate hub state inside `withWriteTransaction`), throwing 503 `TS_RUNTIME_SATELLITE_{RUNTIME,PAIRING}_RETIRED` with `classification=fail_closed`. `executes_product_logic:false` holds for all 11. For approve/reject/revoke the bound-principal owner check still runs first.

## Hoists (preserve 400-before-503)

Field validation that sat inside the service-call args is hoisted above each guard so a malformed request still 400s: `heartbeat` (ts); `capabilities` (revision/generatedAt/capabilities); `sync.pull` (streamId/lastAckedSeq); `commands.ack` (terminal runId/nodeId/attemptId/attempt).

## Manifest

11 additive `fail_closed` + 1 `compat_shim` surface, text-spliced (no reformat). `ts_runtime_blocker` 48→36, `fail_closed` 186→197, `compat_shim` 239→240. No `operator_external_adapter`: satellites are Friday's **internal fleet** (hub writes), not third-party egress.

## Tests (no weakening)

- `makeDeps`/inline deps default the 2 flags `true` so existing coverage still exercises real logic.
- New regression blocks assert genuine **503 + service-not-called** for each fail_closed route, **validation-400-before-guard** (heartbeat missing ts; register missing fields), **owner-check-before-guard** (approve synthetic principal → OWNER error, not 503), and that **events.poll still serves reads** with the flag unset.
- No skip/xfail/.only.

## Verification

- `npm run check:ts-runtime-retirement` → passed, blocker 48→36.
- `npm run build` → green. `npm run lint` → 0 errors.
- `FRIDAY_E2E_CORE=1 npm test` → **12659 passed / 99 skipped / 0 failed**, no type errors.
- `git diff --check` / `check:secret-patterns` / detect-secrets → clean (no baseline refresh needed).
- 6-dimension adversarial review (guard-placement, hoist, classification, manifest, test-honesty, wiring+RGG+leak): **0 major/blocker findings**.

Default/live hub wiring (`api-runtime` + `hub-bootstrap`) leaves both flags unset (set **nowhere** in `src/`), so the surfaces fail-close. No RGG-covered scenario auto-POSTs these routes (the only satellite scenario, `l6-satellite-pairing-manual`, is a manual checklist), so no gate resolver is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)