### PR TITLE
fix(cross-border): fail-close TS cross-border pack mutations

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -3292,6 +3292,97 @@
       "executes_product_logic": false,
       "proof": "src/api/http/routes/friday-satellite-pairing-routes.ts fail-closes default/live satellites.revoke to TS_RUNTIME_SATELLITE_PAIRING_RETIRED after assertBoundPrincipalForOperation and immediately before the TypeScript revokeSatellite write (friday-satellite-pairing-service.ts withWriteTransaction: pairing->revoked, revokeAllForSatellite, token version bump); the bound-principal owner check still runs first; legacy behavior is reachable only through explicit allowTestOnlySatellitePairingExecution test-oracle wiring.",
       "next_action": "Replace the fail-closed response with the Rust-owned satellite pairing entrypoint when available."
+    },
+    {
+      "id": "cross_border_profile_put",
+      "route": {
+        "method": "PUT",
+        "path": "/v1/packs/cross-border/profile",
+        "operationId": "packs.cross.border.profile.put"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-cross-border-pack-routes.ts fail-closes default/live packs.cross.border.profile.put to TS_RUNTIME_CROSS_BORDER_PACK_RETIRED after requireUserId and the hoisted profile-body validation, immediately before the TypeScript upsertProfile write (friday-cross-border-pack-service.ts writePreference PROFILE_KEY); legacy behavior is reachable only through explicit allowTestOnlyCrossBorderPackExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned cross-border pack entrypoint when available."
+    },
+    {
+      "id": "cross_border_import_post",
+      "route": {
+        "method": "POST",
+        "path": "/v1/packs/cross-border/import",
+        "operationId": "packs.cross.border.import.post"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-cross-border-pack-routes.ts fail-closes default/live packs.cross.border.import.post to TS_RUNTIME_CROSS_BORDER_PACK_RETIRED after requireUserId and the hoisted batch-body validation, immediately before the TypeScript importBatch write (friday-cross-border-pack-service.ts writePreference IMPORTS_KEY). publicLinks/fileNames/rawText are RECORDED locally, never fetched or sent — no third-party egress. Legacy behavior is reachable only through explicit allowTestOnlyCrossBorderPackExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned cross-border pack entrypoint when available."
+    },
+    {
+      "id": "cross_border_workflow_presets_apply",
+      "route": {
+        "method": "POST",
+        "path": "/v1/packs/cross-border/workflow-presets/apply",
+        "operationId": "packs.cross.border.workflow.presets.apply"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-cross-border-pack-routes.ts fail-closes default/live packs.cross.border.workflow.presets.apply to TS_RUNTIME_CROSS_BORDER_PACK_RETIRED after requireUserId and the hoisted preset-body validation (timezone), immediately before the TypeScript applyWorkflowPreset write (friday-cross-border-pack-service.ts managed-workflow create/deployDraft + writeWorkflowAutomations — product-internal workflow-runtime orchestration, not a third-party send). Legacy behavior is reachable only through explicit allowTestOnlyCrossBorderPackExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned cross-border pack entrypoint when available."
+    },
+    {
+      "id": "cross_border_workflow_presets_toggle",
+      "route": {
+        "method": "PATCH",
+        "path": "/v1/packs/cross-border/workflow-presets/:workflowId",
+        "operationId": "packs.cross.border.workflow.presets.toggle"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-cross-border-pack-routes.ts fail-closes default/live packs.cross.border.workflow.presets.toggle to TS_RUNTIME_CROSS_BORDER_PACK_RETIRED after requireUserId, the enabled-boolean check, and the hoisted workflowId param validation, immediately before the TypeScript setWorkflowPresetEnabled write (friday-cross-border-pack-service.ts cron trigger setRegistrationEnabled + writeWorkflowAutomations). Legacy behavior is reachable only through explicit allowTestOnlyCrossBorderPackExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned cross-border pack entrypoint when available."
+    },
+    {
+      "id": "cross_border_run_evidence_capture",
+      "route": {
+        "method": "POST",
+        "path": "/v1/packs/cross-border/run-evidence",
+        "operationId": "packs.cross.border.run.evidence.capture"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-cross-border-pack-routes.ts fail-closes default/live packs.cross.border.run.evidence.capture to TS_RUNTIME_CROSS_BORDER_PACK_RETIRED after requireUserId and the hoisted evidence-body validation, immediately before the TypeScript captureRunEvidence write (friday-cross-border-pack-service.ts writePreference RUN_EVIDENCE_KEY + profile adaptationState update). Records locally, no external egress. Legacy behavior is reachable only through explicit allowTestOnlyCrossBorderPackExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned cross-border pack entrypoint when available."
+    },
+    {
+      "id": "cross_border_import_stale",
+      "route": {
+        "method": "PATCH",
+        "path": "/v1/packs/cross-border/imports/:importBatchId/stale",
+        "operationId": "packs.cross.border.import.stale"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-cross-border-pack-routes.ts fail-closes default/live packs.cross.border.import.stale to TS_RUNTIME_CROSS_BORDER_PACK_RETIRED after requireUserId and the hoisted importBatchId param validation, immediately before the TypeScript markImportStale write (friday-cross-border-pack-service.ts writePreference IMPORTS_KEY). Legacy behavior is reachable only through explicit allowTestOnlyCrossBorderPackExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned cross-border pack entrypoint when available."
+    },
+    {
+      "id": "cross_border_workflows_disable_all",
+      "route": {
+        "method": "POST",
+        "path": "/v1/packs/cross-border/workflows/disable-all",
+        "operationId": "packs.cross.border.workflows.disable.all"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-cross-border-pack-routes.ts fail-closes default/live packs.cross.border.workflows.disable.all to TS_RUNTIME_CROSS_BORDER_PACK_RETIRED after requireUserId, immediately before the TypeScript disableAllWorkflows write (friday-cross-border-pack-service.ts disable cron trigger registrations + writeWorkflowAutomations). Legacy behavior is reachable only through explicit allowTestOnlyCrossBorderPackExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned cross-border pack entrypoint when available."
     }
   ]
 }

--- a/src/api/http/routes/friday-cross-border-pack-routes.ts
+++ b/src/api/http/routes/friday-cross-border-pack-routes.ts
@@ -18,6 +18,41 @@ import type { FridayCrossBorderWorkflowId } from "../../../packs/cross-border/fr
 
 export interface FridayCrossBorderPackRoutesDeps {
   service: FridayCrossBorderPackService;
+  /**
+   * Test-oracle only: allow the legacy TypeScript cross-border pack mutations
+   * (profile upsert, import, run-evidence capture, workflow-preset apply/toggle/
+   * disable-all, import stale) in isolated mock/unit validation. Production/
+   * runtime callers must leave this unset so these surfaces fail-close until Rust
+   * owns the cross-border pack engine. The GET profile/snapshot reads are never
+   * gated.
+   */
+  allowTestOnlyCrossBorderPackExecution?: boolean;
+}
+
+// ─── Retirement helper ───
+//
+// Every cross-border pack mutation surface writes user-scoped state (operating
+// profile, import batches, run-evidence records, managed-workflow preset/trigger
+// registrations) to the local preference store via writePreference /
+// workflow-runtime CRUD. They fail-close by default/live until Rust owns the
+// cross-border pack entrypoint; legacy behavior is reachable only through the
+// explicit allowTestOnlyCrossBorderPackExecution test-oracle flag. The GET
+// profile/snapshot reads stay compat_shim and are NOT gated.
+
+function assertCrossBorderPackTestOracleAllowed(deps: FridayCrossBorderPackRoutesDeps): void {
+  if (deps.allowTestOnlyCrossBorderPackExecution !== true) {
+    throw new FridayDomainError(
+      "TS_RUNTIME_CROSS_BORDER_PACK_RETIRED",
+      "TypeScript cross-border pack mutation is fail-closed in default/live runtime; use the Rust-owned cross-border pack entrypoint.",
+      {
+        httpStatus: 503,
+        details: {
+          classification: "fail_closed",
+          replacement: "rust_owned_cross_border_pack_entrypoint_required",
+        },
+      },
+    );
+  }
 }
 
 function requireUserId(principal: { userId?: string } | null): string {
@@ -72,23 +107,24 @@ export function createFridayCrossBorderPackRoutes(
       async handler(ctx): Promise<FridayCrossBorderProfileResponse> {
         const userId = requireUserId(ctx.principal);
         const body = readBodyObject(ctx.body);
+        // Hoist body validation above the retirement guard so a malformed profile
+        // still returns 400 (not 503) when the flag is unset.
+        const profile = {
+          regionFocus: readString(body, "regionFocus") as FridayCrossBorderProfileUpdateRequest["regionFocus"],
+          storeStage: readString(body, "storeStage") as FridayCrossBorderProfileUpdateRequest["storeStage"],
+          categoryL1: readString(body, "categoryL1"),
+          categoryL2: readString(body, "categoryL2"),
+          fulfillmentMode: readString(body, "fulfillmentMode") as FridayCrossBorderProfileUpdateRequest["fulfillmentMode"],
+          priceBand: readString(body, "priceBand"),
+          adUsage: readString(body, "adUsage") as FridayCrossBorderProfileUpdateRequest["adUsage"],
+          customerServiceMode: readString(body, "customerServiceMode") as FridayCrossBorderProfileUpdateRequest["customerServiceMode"],
+          monitoringDepth: readString(body, "monitoringDepth") as FridayCrossBorderProfileUpdateRequest["monitoringDepth"],
+          watchTargets: Array.isArray(body.watchTargets) ? body.watchTargets as FridayCrossBorderProfileUpdateRequest["watchTargets"] : [],
+          competitorTargets: Array.isArray(body.competitorTargets) ? body.competitorTargets as FridayCrossBorderProfileUpdateRequest["competitorTargets"] : [],
+        };
+        assertCrossBorderPackTestOracleAllowed(deps);
         return {
-          profile: deps.service.upsertProfile({
-            userId,
-            profile: {
-              regionFocus: readString(body, "regionFocus") as FridayCrossBorderProfileUpdateRequest["regionFocus"],
-              storeStage: readString(body, "storeStage") as FridayCrossBorderProfileUpdateRequest["storeStage"],
-              categoryL1: readString(body, "categoryL1"),
-              categoryL2: readString(body, "categoryL2"),
-              fulfillmentMode: readString(body, "fulfillmentMode") as FridayCrossBorderProfileUpdateRequest["fulfillmentMode"],
-              priceBand: readString(body, "priceBand"),
-              adUsage: readString(body, "adUsage") as FridayCrossBorderProfileUpdateRequest["adUsage"],
-              customerServiceMode: readString(body, "customerServiceMode") as FridayCrossBorderProfileUpdateRequest["customerServiceMode"],
-              monitoringDepth: readString(body, "monitoringDepth") as FridayCrossBorderProfileUpdateRequest["monitoringDepth"],
-              watchTargets: Array.isArray(body.watchTargets) ? body.watchTargets as FridayCrossBorderProfileUpdateRequest["watchTargets"] : [],
-              competitorTargets: Array.isArray(body.competitorTargets) ? body.competitorTargets as FridayCrossBorderProfileUpdateRequest["competitorTargets"] : [],
-            },
-          }),
+          profile: deps.service.upsertProfile({ userId, profile }),
         };
       },
     },
@@ -112,21 +148,22 @@ export function createFridayCrossBorderPackRoutes(
       async handler(ctx): Promise<FridayCrossBorderImportResponse> {
         const userId = requireUserId(ctx.principal);
         const body = readBodyObject(ctx.body);
-        const importBatch = deps.service.importBatch({
-          userId,
-          batch: {
-            kind: readString(body, "kind") as FridayCrossBorderImportRequest["kind"],
-            source: readString(body, "source") as FridayCrossBorderImportRequest["source"],
-            title: readString(body, "title"),
-            ...(typeof body.rawText === "string" ? { rawText: body.rawText } : {}),
-            publicLinks: Array.isArray(body.publicLinks)
-              ? body.publicLinks.filter((value): value is string => typeof value === "string")
-              : [],
-            fileNames: Array.isArray(body.fileNames)
-              ? body.fileNames.filter((value): value is string => typeof value === "string")
-              : [],
-          },
-        });
+        // Hoist body validation above the retirement guard so a malformed import
+        // still returns 400 (not 503) when the flag is unset.
+        const batch = {
+          kind: readString(body, "kind") as FridayCrossBorderImportRequest["kind"],
+          source: readString(body, "source") as FridayCrossBorderImportRequest["source"],
+          title: readString(body, "title"),
+          ...(typeof body.rawText === "string" ? { rawText: body.rawText } : {}),
+          publicLinks: Array.isArray(body.publicLinks)
+            ? body.publicLinks.filter((value): value is string => typeof value === "string")
+            : [],
+          fileNames: Array.isArray(body.fileNames)
+            ? body.fileNames.filter((value): value is string => typeof value === "string")
+            : [],
+        };
+        assertCrossBorderPackTestOracleAllowed(deps);
+        const importBatch = deps.service.importBatch({ userId, batch });
         return {
           importBatch,
           snapshot: deps.service.getSnapshot({ userId }),
@@ -141,16 +178,16 @@ export function createFridayCrossBorderPackRoutes(
       async handler(ctx): Promise<FridayCrossBorderWorkflowPresetResponse> {
         const userId = requireUserId(ctx.principal);
         const body = readBodyObject(ctx.body);
+        // Hoist body validation above the retirement guard (timezone is required).
+        const preset = {
+          workflowIds: Array.isArray(body.workflowIds)
+            ? body.workflowIds.filter((value): value is FridayCrossBorderWorkflowId => typeof value === "string")
+            : undefined,
+          timezone: readString(body, "timezone") as FridayCrossBorderWorkflowPresetApplyRequest["timezone"],
+        };
+        assertCrossBorderPackTestOracleAllowed(deps);
         return {
-          snapshot: await deps.service.applyWorkflowPreset({
-            userId,
-            preset: {
-              workflowIds: Array.isArray(body.workflowIds)
-                ? body.workflowIds.filter((value): value is FridayCrossBorderWorkflowId => typeof value === "string")
-                : undefined,
-              timezone: readString(body, "timezone") as FridayCrossBorderWorkflowPresetApplyRequest["timezone"],
-            },
-          }),
+          snapshot: await deps.service.applyWorkflowPreset({ userId, preset }),
         };
       },
     },
@@ -165,17 +202,17 @@ export function createFridayCrossBorderPackRoutes(
         if (typeof body.enabled !== "boolean") {
           throw new FridayDomainError("VALIDATION_ERROR", "enabled is required", { httpStatus: 400 });
         }
+        // Hoist param/body validation above the retirement guard (workflowId).
+        const preset = {
+          workflowId: readWorkflowIdParam(ctx.params as Record<string, unknown>),
+          enabled: body.enabled as FridayCrossBorderWorkflowPresetToggleRequest["enabled"],
+          ...(typeof body.timezone === "string" && body.timezone.trim().length > 0
+            ? { timezone: body.timezone.trim() as FridayCrossBorderWorkflowPresetToggleRequest["timezone"] }
+            : {}),
+        };
+        assertCrossBorderPackTestOracleAllowed(deps);
         return {
-          snapshot: await deps.service.setWorkflowPresetEnabled({
-            userId,
-            preset: {
-              workflowId: readWorkflowIdParam(ctx.params as Record<string, unknown>),
-              enabled: body.enabled as FridayCrossBorderWorkflowPresetToggleRequest["enabled"],
-              ...(typeof body.timezone === "string" && body.timezone.trim().length > 0
-                ? { timezone: body.timezone.trim() as FridayCrossBorderWorkflowPresetToggleRequest["timezone"] }
-                : {}),
-            },
-          }),
+          snapshot: await deps.service.setWorkflowPresetEnabled({ userId, preset }),
         };
       },
     },
@@ -187,15 +224,16 @@ export function createFridayCrossBorderPackRoutes(
       async handler(ctx): Promise<FridayCrossBorderRunEvidenceCaptureResponse> {
         const userId = requireUserId(ctx.principal);
         const body = readBodyObject(ctx.body);
-        const evidence = deps.service.captureRunEvidence({
-          userId,
-          evidence: {
-            workflowId: readString(body, "workflowId") as FridayCrossBorderWorkflowId,
-            managedWorkflowId: readString(body, "managedWorkflowId"),
-            status: readString(body, "status") as "completed" | "failed" | "skipped",
-            summary: readString(body, "summary"),
-          },
-        });
+        // Hoist body validation above the retirement guard so a malformed capture
+        // still returns 400 (not 503) when the flag is unset.
+        const evidenceInput = {
+          workflowId: readString(body, "workflowId") as FridayCrossBorderWorkflowId,
+          managedWorkflowId: readString(body, "managedWorkflowId"),
+          status: readString(body, "status") as "completed" | "failed" | "skipped",
+          summary: readString(body, "summary"),
+        };
+        assertCrossBorderPackTestOracleAllowed(deps);
+        const evidence = deps.service.captureRunEvidence({ userId, evidence: evidenceInput });
         return {
           evidence,
           snapshot: deps.service.getSnapshot({ userId }),
@@ -209,11 +247,11 @@ export function createFridayCrossBorderPackRoutes(
       auth: { public: true },
       async handler(ctx): Promise<FridayCrossBorderImportStaleResponse> {
         const userId = requireUserId(ctx.principal);
+        // Hoist param validation above the retirement guard (importBatchId).
+        const importBatchId = readString(ctx.params as Record<string, unknown>, "importBatchId");
+        assertCrossBorderPackTestOracleAllowed(deps);
         return {
-          snapshot: deps.service.markImportStale({
-            userId,
-            importBatchId: readString(ctx.params as Record<string, unknown>, "importBatchId"),
-          }),
+          snapshot: deps.service.markImportStale({ userId, importBatchId }),
         };
       },
     },
@@ -224,6 +262,7 @@ export function createFridayCrossBorderPackRoutes(
       auth: { public: true },
       async handler(ctx): Promise<FridayCrossBorderDisableAllResponse> {
         const userId = requireUserId(ctx.principal);
+        assertCrossBorderPackTestOracleAllowed(deps);
         return {
           snapshot: await deps.service.disableAllWorkflows({ userId }),
         };

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -1886,6 +1886,8 @@ export interface FridayHubConfig {
   allowTestOnlySessionRunExecution?: boolean;
   /** Test-oracle only; production hub creation must leave session memory extraction mutations fail-closed. */
   allowTestOnlySessionMemoryExtractionExecution?: boolean;
+  /** Test-oracle only; production hub creation must leave cross-border pack mutations fail-closed. */
+  allowTestOnlyCrossBorderPackExecution?: boolean;
 }
 
 // ─── Resolved Hub Config ───

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -6778,6 +6778,11 @@ export async function createFridayHub(
     },
     crossBorderPack: {
       service: crossBorderPackService,
+      // Test-oracle only: production/live config leaves this unset, so the
+      // cross-border pack mutation surfaces fail-close. Test harnesses
+      // (mock-env/browser-env/api-test-server) set it true to exercise legacy
+      // logic.
+      allowTestOnlyCrossBorderPackExecution: config.allowTestOnlyCrossBorderPackExecution,
     },
     searchHealth: resolveWebSearchHealth,
     systemHealth: getPublicSystemHealth,

--- a/test/e2e/api/_helpers/friday-api-test-server.helper.ts
+++ b/test/e2e/api/_helpers/friday-api-test-server.helper.ts
@@ -184,6 +184,7 @@ export interface CreateFridayApiTestEnvOptions {
   allowTestOnlySessionExecution?: boolean;
   allowTestOnlySessionRunExecution?: boolean;
   allowTestOnlySessionMemoryExtractionExecution?: boolean;
+  allowTestOnlyCrossBorderPackExecution?: boolean;
   resolveSkill?: (skillId: string) => unknown | null;
   invokeSkill?: (
     skillId: string,
@@ -299,6 +300,7 @@ export async function createFridayApiTestEnv(
     allowTestOnlySessionExecution: options.allowTestOnlySessionExecution ?? true,
     allowTestOnlySessionRunExecution: options.allowTestOnlySessionRunExecution ?? true,
     allowTestOnlySessionMemoryExtractionExecution: options.allowTestOnlySessionMemoryExtractionExecution ?? true,
+    allowTestOnlyCrossBorderPackExecution: options.allowTestOnlyCrossBorderPackExecution ?? true,
     computeChecksum: (content: string) =>
       crypto.createHash("sha256").update(content).digest("hex"),
     resolveSkill: options.resolveSkill ?? ((_skillId: string) => ({ id: _skillId })),

--- a/test/e2e/mock/_helpers/mock-env.ts
+++ b/test/e2e/mock/_helpers/mock-env.ts
@@ -353,6 +353,8 @@ export async function createMockHubEnv(opts?: {
   allowTestOnlySessionRunExecution?: boolean;
   /** Test-oracle opt-in for legacy TS session memory extraction mutations; set false to prove default fail-closed behavior. */
   allowTestOnlySessionMemoryExtractionExecution?: boolean;
+  /** Test-oracle opt-in for legacy TS cross-border pack mutations; set false to prove default fail-closed behavior. */
+  allowTestOnlyCrossBorderPackExecution?: boolean;
 }): Promise<MockHubEnv> {
   // Reset deterministic counters
   resetMockCounters();
@@ -407,6 +409,7 @@ export async function createMockHubEnv(opts?: {
       allowTestOnlySessionExecution: opts?.allowTestOnlySessionExecution ?? true,
       allowTestOnlySessionRunExecution: opts?.allowTestOnlySessionRunExecution ?? true,
       allowTestOnlySessionMemoryExtractionExecution: opts?.allowTestOnlySessionMemoryExtractionExecution ?? true,
+      allowTestOnlyCrossBorderPackExecution: opts?.allowTestOnlyCrossBorderPackExecution ?? true,
       // Allow private-network targets so mock E2E tests don't require DNS resolution
       ssrfPolicy: opts?.ssrfPolicy ?? { allowPrivateNetwork: true },
     });

--- a/test/unit/api/http/routes/friday-cross-border-pack-routes.test.ts
+++ b/test/unit/api/http/routes/friday-cross-border-pack-routes.test.ts
@@ -101,7 +101,11 @@ function makeService() {
 
 function findRoute(operationId: string) {
   const service = makeService();
-  const route = createFridayCrossBorderPackRoutes({ service }).find((entry) => entry.operationId === operationId);
+  // Test-oracle: exercise the real TypeScript logic. Default/live wiring leaves
+  // this unset so the mutation surfaces fail-close (see the TS-runtime-retirement
+  // regression block below).
+  const route = createFridayCrossBorderPackRoutes({ service, allowTestOnlyCrossBorderPackExecution: true })
+    .find((entry) => entry.operationId === operationId);
   if (!route) {
     throw new Error(`Route ${operationId} not found`);
   }
@@ -276,5 +280,62 @@ describe("createFridayCrossBorderPackRoutes", () => {
       userId: "test-user",
     });
     expect(result.snapshot.generatedAt).toBe("2026-04-08T12:00:00.000Z");
+  });
+
+  describe("TS runtime retirement (allowTestOnlyCrossBorderPackExecution unset)", () => {
+    function retiredRoute(operationId: string) {
+      const service = makeService();
+      const route = createFridayCrossBorderPackRoutes({ service })
+        .find((entry) => entry.operationId === operationId);
+      if (!route) {
+        throw new Error(`Route ${operationId} not found`);
+      }
+      return { route, service };
+    }
+
+    const cases: Array<{ op: string; ctx: Record<string, unknown>; svc: string }> = [
+      { op: "packs.cross.border.profile.put", ctx: { body: { regionFocus: "sea_tiktok", storeStage: "scaling", categoryL1: "Beauty", categoryL2: "Hair Dryers", fulfillmentMode: "platform_fulfilled", priceBand: "US$19-29", adUsage: "active", customerServiceMode: "solo_inbox", monitoringDepth: "standard" } }, svc: "upsertProfile" },
+      { op: "packs.cross.border.import.post", ctx: { body: { kind: "store_report", source: "paste", title: "x" } }, svc: "importBatch" },
+      { op: "packs.cross.border.workflow.presets.apply", ctx: { body: { timezone: "America/Los_Angeles" } }, svc: "applyWorkflowPreset" },
+      { op: "packs.cross.border.workflow.presets.toggle", ctx: { params: { workflowId: "daily-price-gap-watch" }, body: { enabled: false } }, svc: "setWorkflowPresetEnabled" },
+      { op: "packs.cross.border.run.evidence.capture", ctx: { body: { workflowId: "daily-store-health-check", managedWorkflowId: "wf-1", status: "completed", summary: "s" } }, svc: "captureRunEvidence" },
+      { op: "packs.cross.border.import.stale", ctx: { params: { importBatchId: "import-1" } }, svc: "markImportStale" },
+      { op: "packs.cross.border.workflows.disable.all", ctx: {}, svc: "disableAllWorkflows" },
+    ];
+
+    for (const { op, ctx, svc } of cases) {
+      it(`fail-closes ${op} with 503 and never calls the service`, async () => {
+        const { route, service } = retiredRoute(op);
+        await expect(route.handler(makeCtx(ctx))).rejects.toMatchObject({
+          code: "TS_RUNTIME_CROSS_BORDER_PACK_RETIRED",
+          httpStatus: 503,
+        } satisfies Partial<FridayDomainError>);
+        expect((service as Record<string, ReturnType<typeof vi.fn>>)[svc]).not.toHaveBeenCalled();
+      });
+    }
+
+    it("validates the body (400) before the retirement guard (profile.put missing regionFocus)", async () => {
+      const { route, service } = retiredRoute("packs.cross.border.profile.put");
+      await expect(route.handler(makeCtx({ body: { storeStage: "scaling" } }))).rejects.toMatchObject({
+        code: "VALIDATION_ERROR",
+        httpStatus: 400,
+      } satisfies Partial<FridayDomainError>);
+      expect(service.upsertProfile).not.toHaveBeenCalled();
+    });
+
+    it("enforces the user-principal check (401) before the retirement guard (import.post, no principal)", async () => {
+      const { route, service } = retiredRoute("packs.cross.border.import.post");
+      await expect(route.handler(makeCtx({ principal: null, body: { kind: "store_report", source: "paste", title: "x" } }))).rejects.toMatchObject({
+        code: "UNAUTHORIZED",
+        httpStatus: 401,
+      } satisfies Partial<FridayDomainError>);
+      expect(service.importBatch).not.toHaveBeenCalled();
+    });
+
+    it("still serves the GET profile read (compat_shim, not gated by retirement)", async () => {
+      const { route, service } = retiredRoute("packs.cross.border.profile.get");
+      await route.handler(makeCtx());
+      expect(service.getProfile).toHaveBeenCalledWith({ userId: "test-user" });
+    });
   });
 });


### PR DESCRIPTION
## What

Retire the **7 user-triggerable TS-runtime mutation surfaces** in `friday-cross-border-pack-routes.ts` (gate: `ts_runtime_blocker` **36 → 29**): `profile.put`, `import.post`, `workflow-presets apply/toggle`, `run-evidence.capture`, `import.stale`, `workflows.disable-all`.

Each handler gains an `assertCrossBorderPackTestOracleAllowed(deps)` guard (flag `allowTestOnlyCrossBorderPackExecution`) placed **after** `requireUserId` (and any pre-existing validation) and **immediately before** the real service write, throwing 503 `TS_RUNTIME_CROSS_BORDER_PACK_RETIRED` with `classification=fail_closed`. `executes_product_logic:false` holds for all 7.

**Classification (audited + adversarially reviewed):** all 7 service methods mutate user-scoped local state (`writePreference` PROFILE/IMPORTS/RUN_EVIDENCE_KEY + workflow-runtime cron-trigger/automation writes). **None performs third-party egress** — `importBatch` *records* `publicLinks`/`fileNames` locally, never fetches or sends — so none is `operator_external_adapter`. The 2 GET profile/snapshot reads stay `compat_shim`.

## Hoists (preserve 400-before-503)

6 of 7 handlers hoist their body/param validation above the guard so a malformed request still 400s: profile fields; import batch kind/source/title; preset timezone; toggle workflowId param; evidence fields; stale importBatchId. `disable-all` has no body.

## Test-oracle wiring (browser-e2e)

Unlike the prior interface-only slices, cross-border has a **chromium browser E2E** (`test/e2e/ui/friday-cross-border-pack-setup.e2e.test.ts`) that drives these routes against a real mock hub in CI's `browser-e2e` project. Mirroring every other retired route, the flag is plumbed through the hub config (`hub-helpers` config type → `friday-hub-bootstrap` reads `config.*` into the `crossBorderPack` deps) and **defaulted to `true` in the test harnesses** (`mock-env`, `api-test-server`). **Production/live hub creation leaves the config field unset → fail-closes.** Proven via a temporary integration test against the real hub HTTP server: default-true harness → non-503; flag explicitly `false` → 503 `TS_RUNTIME_CROSS_BORDER_PACK_RETIRED`.

## Manifest & tests

7 additive `fail_closed` surfaces. The unit test's `findRoute` defaults the flag `true`; a new regression block asserts **503 + service-not-called** per route, **validation-400-before-guard**, **principal-401-before-guard**, and that the GET read still serves with the flag unset.

## Verification

- `npm run check:ts-runtime-retirement` → blocker 36→29.
- `npm run build` green; `npm run lint` 0 errors; `git diff --check` / secret-patterns / detect-secrets clean.
- `FRIDAY_E2E_CORE=1 npm test` → **12669 passed / 99 skipped / 0 failed**, no type errors.
- 6-dimension adversarial review: the one finding it raised (browser-e2e CI break) is **fixed in this PR** via the harness plumbing above and proven by the throwaway hub test.

No RGG resolver needed: the only cross-border RGG scenarios are passive UI probes that hit just the compat_shim GET reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)