### PR TITLE
fix(cloud-workers): fail-close TS cloud-worker setup compute

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -3383,6 +3383,45 @@
       "executes_product_logic": false,
       "proof": "src/api/http/routes/friday-cross-border-pack-routes.ts fail-closes default/live packs.cross.border.workflows.disable.all to TS_RUNTIME_CROSS_BORDER_PACK_RETIRED after requireUserId, immediately before the TypeScript disableAllWorkflows write (friday-cross-border-pack-service.ts disable cron trigger registrations + writeWorkflowAutomations). Legacy behavior is reachable only through explicit allowTestOnlyCrossBorderPackExecution test-oracle wiring.",
       "next_action": "Replace the fail-closed response with the Rust-owned cross-border pack entrypoint when available."
+    },
+    {
+      "id": "cloud_worker_dns_validate",
+      "route": {
+        "method": "POST",
+        "path": "/v1/cloud-workers/dns/validate",
+        "operationId": "cloud.workers.dns.validate"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-cloud-worker-setup-routes.ts fail-closes default/live cloud.workers.dns.validate to TS_RUNTIME_CLOUD_WORKER_SETUP_RETIRED after the bound-principal gate and the dnsProviderId/dnsName/rootDomain validation, immediately before the TypeScript dnsValidator.validate compute (friday-cloud-worker-dns-validator.ts: stateless acceptance-policy verdict; no DB write and no external DNS/network egress). Legacy behavior is reachable only through explicit allowTestOnlyCloudWorkerSetupExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned cloud-worker setup entrypoint when available."
+    },
+    {
+      "id": "cloud_worker_package_generate",
+      "route": {
+        "method": "POST",
+        "path": "/v1/cloud-workers/package",
+        "operationId": "cloud.workers.package.generate"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-cloud-worker-setup-routes.ts fail-closes default/live cloud.workers.package.generate to TS_RUNTIME_CLOUD_WORKER_SETUP_RETIRED after the bound-principal gate and the providerId/httpsHost/dnsName/dnsProviderId/ownerRunId validation, immediately before (and ABOVE the try/catch that maps errors to 400) the TypeScript packageService.generate compute (friday-cloud-worker-package.ts: in-memory deployment bundle render + secret-leak scan + sha256 bundleId; no DB write and no external egress). Legacy behavior is reachable only through explicit allowTestOnlyCloudWorkerSetupExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned cloud-worker setup entrypoint when available."
+    },
+    {
+      "id": "cloud_worker_teardown_receipt",
+      "route": {
+        "method": "POST",
+        "path": "/v1/cloud-workers/teardown-receipt",
+        "operationId": "cloud.workers.teardown.receipt"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-cloud-worker-setup-routes.ts fail-closes default/live cloud.workers.teardown.receipt to TS_RUNTIME_CLOUD_WORKER_SETUP_RETIRED after the bound-principal gate and the providerId/ownerRunId/resourceTag validation, immediately before the TypeScript teardown.issueReceipt compute (friday-cloud-worker-teardown.ts: in-memory receipt with sha256 receiptId + manual cleanup steps; no DB write and no external egress). Legacy behavior is reachable only through explicit allowTestOnlyCloudWorkerSetupExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned cloud-worker setup entrypoint when available."
     }
   ]
 }

--- a/src/api/http/routes/friday-cloud-worker-setup-routes.ts
+++ b/src/api/http/routes/friday-cloud-worker-setup-routes.ts
@@ -30,6 +30,40 @@ type Route = FridayRouteDefinition<unknown, Record<string, string>, unknown, unk
 
 export interface FridayCloudWorkerSetupRoutesDeps {
   readonly setupService: FridayCloudWorkerSetupService;
+  /**
+   * Test-oracle only: allow the legacy TypeScript cloud-worker setup compute
+   * (DNS acceptance validation, deployment package generation, teardown receipt
+   * issuance) in isolated mock/unit validation. Production/runtime callers must
+   * leave this unset so these surfaces fail-close until Rust owns the cloud-worker
+   * setup engine. The GET catalog/preview/doctor reads are never gated.
+   */
+  readonly allowTestOnlyCloudWorkerSetupExecution?: boolean;
+}
+
+// ─── Retirement helper ───
+//
+// The cloud-worker setup POST surfaces (DNS validate, package generate, teardown
+// receipt) run user-triggerable TS-runtime product logic that produces the
+// cloud-worker setup deliverables (acceptance verdicts, deployment bundles,
+// teardown receipts). They fail-close by default/live until Rust owns the
+// cloud-worker setup entrypoint; legacy behavior is reachable only through the
+// explicit allowTestOnlyCloudWorkerSetupExecution test-oracle flag. The GET
+// catalog/preview/doctor reads stay compat_shim and are NOT gated.
+
+function assertCloudWorkerSetupTestOracleAllowed(deps: FridayCloudWorkerSetupRoutesDeps): void {
+  if (deps.allowTestOnlyCloudWorkerSetupExecution !== true) {
+    throw new FridayDomainError(
+      "TS_RUNTIME_CLOUD_WORKER_SETUP_RETIRED",
+      "TypeScript cloud-worker setup is fail-closed in default/live runtime; use the Rust-owned cloud-worker setup entrypoint.",
+      {
+        httpStatus: 503,
+        details: {
+          classification: "fail_closed",
+          replacement: "rust_owned_cloud_worker_setup_entrypoint_required",
+        },
+      },
+    );
+  }
 }
 
 function asString(value: unknown): string {
@@ -136,6 +170,7 @@ export function createFridayCloudWorkerSetupRoutes(
         const dnsProviderId = asString(body.dnsProviderId);
         const dnsName = asString(body.dnsName);
         const rootDomain = asString(body.rootDomain);
+        assertCloudWorkerSetupTestOracleAllowed(deps);
         return deps.setupService.dnsValidator.validate({
           dnsProviderId,
           dnsName,
@@ -162,6 +197,9 @@ export function createFridayCloudWorkerSetupRoutes(
           dnsProviderId: asDnsProviderId(body.dnsProviderId),
           ownerRunId: asString(body.ownerRunId),
         };
+        // Guard ABOVE the try: the catch below maps any thrown FridayDomainError
+        // to a 400 VALIDATION_ERROR, which would otherwise swallow this 503.
+        assertCloudWorkerSetupTestOracleAllowed(deps);
         try {
           return deps.setupService.packageService.generate(input);
         } catch (error) {
@@ -192,6 +230,7 @@ export function createFridayCloudWorkerSetupRoutes(
           typeof body.satelliteId === "string" && body.satelliteId.trim().length > 0
             ? body.satelliteId.trim()
             : undefined;
+        assertCloudWorkerSetupTestOracleAllowed(deps);
         return deps.setupService.teardown.issueReceipt({
           providerId,
           ownerRunId,

--- a/test/unit/api/http/routes/friday-cloud-worker-setup-routes.test.ts
+++ b/test/unit/api/http/routes/friday-cloud-worker-setup-routes.test.ts
@@ -17,11 +17,22 @@ const NOW = "2026-05-17T20:00:00.000Z";
 const setupService = createFridayCloudWorkerSetupService({ nowIso: () => NOW });
 
 function makeDeps(): FridayCloudWorkerSetupRoutesDeps {
-  return { setupService };
+  // Test-oracle: exercise the real TypeScript logic. Default/live wiring leaves
+  // this unset so the mutation surfaces fail-close (see the TS-runtime-retirement
+  // regression block below).
+  return { setupService, allowTestOnlyCloudWorkerSetupExecution: true };
 }
 
 function findRoute(operationId: string) {
   const routes = createFridayCloudWorkerSetupRoutes(makeDeps());
+  const route = routes.find((r) => r.operationId === operationId);
+  if (!route) throw new Error(`route not found: ${operationId}`);
+  return route;
+}
+
+function retiredFindRoute(operationId: string) {
+  // No allowTestOnlyCloudWorkerSetupExecution → default/live fail-closed.
+  const routes = createFridayCloudWorkerSetupRoutes({ setupService });
   const route = routes.find((r) => r.operationId === operationId);
   if (!route) throw new Error(`route not found: ${operationId}`);
   return route;
@@ -157,5 +168,48 @@ describe("Phase 17A — cloud-worker setup routes", () => {
     })) as { proofTier: string; liveTeardownStatus: string };
     expect(result.proofTier).toBe("fixture");
     expect(result.liveTeardownStatus).toBe("blocked_by_env");
+  });
+
+  describe("TS runtime retirement (allowTestOnlyCloudWorkerSetupExecution unset)", () => {
+    const cases: Array<{ op: string; body: Record<string, unknown> }> = [
+      { op: "cloud.workers.dns.validate", body: { dnsProviderId: "dnspod", dnsName: "worker.friday-test.example.com", rootDomain: "example.com" } },
+      { op: "cloud.workers.package.generate", body: { providerId: "aliyun-ecs", httpsHost: "https://worker.friday-test.example.com", dnsName: "worker.friday-test.example.com", dnsProviderId: "dnspod", ownerRunId: "owner-run-1" } },
+      { op: "cloud.workers.teardown.receipt", body: { providerId: "aliyun-ecs", ownerRunId: "r", resourceTag: "t" } },
+    ];
+
+    for (const { op, body } of cases) {
+      it(`fail-closes ${op} with 503`, async () => {
+        await expect(retiredFindRoute(op).handler(boundCtx({ body }))).rejects.toMatchObject({
+          code: "TS_RUNTIME_CLOUD_WORKER_SETUP_RETIRED",
+          httpStatus: 503,
+        } satisfies Partial<FridayDomainError>);
+      });
+    }
+
+    it("package.generate fail-close is a real 503 (NOT swallowed to 400 by the wrapping catch — guard sits above the try)", async () => {
+      await expect(retiredFindRoute("cloud.workers.package.generate").handler(boundCtx({
+        body: { providerId: "aliyun-ecs", httpsHost: "https://worker.friday-test.example.com", dnsName: "worker.friday-test.example.com", dnsProviderId: "dnspod", ownerRunId: "owner-run-1" },
+      }))).rejects.toMatchObject({ code: "TS_RUNTIME_CLOUD_WORKER_SETUP_RETIRED", httpStatus: 503 } satisfies Partial<FridayDomainError>);
+    });
+
+    it("enforces the bound-principal gate BEFORE the retirement guard (synthetic public principal → not 503)", async () => {
+      let caught: unknown;
+      try {
+        await retiredFindRoute("cloud.workers.dns.validate").handler(unauthenticatedCtx({
+          body: { dnsProviderId: "dnspod", dnsName: "worker.friday-test.example.com", rootDomain: "example.com" },
+        }));
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).toBeInstanceOf(FridayDomainError);
+      expect((caught as FridayDomainError).code).not.toBe("TS_RUNTIME_CLOUD_WORKER_SETUP_RETIRED");
+      expect((caught as FridayDomainError).code).toBe("OWNER_SESSION_CHANNEL_PRINCIPAL_REQUIRED");
+    });
+
+    it("validates the body (400) BEFORE the retirement guard (dns.validate missing rootDomain)", async () => {
+      await expect(retiredFindRoute("cloud.workers.dns.validate").handler(boundCtx({
+        body: { dnsProviderId: "dnspod", dnsName: "worker.friday-test.example.com" },
+      }))).rejects.toMatchObject({ code: "VALIDATION_ERROR", httpStatus: 400 } satisfies Partial<FridayDomainError>);
+    });
   });
 });


### PR DESCRIPTION
## What

Retire the **3 user-triggerable TS-runtime POST surfaces** in `friday-cloud-worker-setup-routes.ts` (gate: `ts_runtime_blocker` **29 → 26**): `dns.validate`, `package.generate`, `teardown.receipt`.

Each handler gains an `assertCloudWorkerSetupTestOracleAllowed(deps)` guard (flag `allowTestOnlyCloudWorkerSetupExecution`) after the bound-principal gate + body validation and **immediately before** the setup compute, throwing 503 `TS_RUNTIME_CLOUD_WORKER_SETUP_RETIRED`, `classification=fail_closed`. `executes_product_logic:false` holds for all 3.

**Classification (audited + reviewed):** all 3 are stateless setup-deliverable computes (DNS acceptance verdict; in-memory deployment bundle render + sha256 bundleId; teardown receipt) — **no DB/preference write, no external DNS/network egress** (service tree has zero `fetch`/`dns.resolve`/`http`). So none is `operator_external_adapter`; they're `fail_closed` because they execute Rust-ownable product logic. The 3 GET catalog/preview/doctor reads stay `compat_shim` (GET family rule).

**Key correctness detail:** for `package.generate` the guard is placed **above** the handler's `try/catch`, because that catch maps any thrown `FridayDomainError` to a 400 `VALIDATION_ERROR` and would otherwise swallow the 503. No field hoist needed — each handler's body validation already produces locals before the service call.

## Wiring / RGG / tests

Wiring is **inline** in `friday-api-runtime.ts` (`createFridayCloudWorkerSetupRoutes({ setupService })`) with the flag omitted → default/live fail-closes; the flag appears nowhere else in `src/`. **No RGG scenario and no integration/e2e/ui test drive these routes** (verified — the new per-slice `test/e2e/ui/` grep step), so no resolver and no hub-config/mock-env plumbing are needed; only the unit test's `makeDeps` sets the flag true.

A new regression block asserts **503 per route**, that `package.generate`'s 503 is **not swallowed to 400**, **bound-principal-before-guard** (`OWNER_SESSION_CHANNEL_PRINCIPAL_REQUIRED`), and **validation-400-before-guard**.

## Verification

- `npm run check:ts-runtime-retirement` → blocker 29→26.
- `npm run build` green; `npm run lint` 0 errors; `git diff --check` / secret-patterns / detect-secrets clean.
- `FRIDAY_E2E_CORE=1 npm test` → **12675 passed / 99 skipped / 0 failed**, no type errors.
- 6-dimension adversarial review: **0 findings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)