### PR TITLE
fix(diagnosis): fail-close TS self-healing diagnosis mutations

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -3422,6 +3422,45 @@
       "executes_product_logic": false,
       "proof": "src/api/http/routes/friday-cloud-worker-setup-routes.ts fail-closes default/live cloud.workers.teardown.receipt to TS_RUNTIME_CLOUD_WORKER_SETUP_RETIRED after the bound-principal gate and the providerId/ownerRunId/resourceTag validation, immediately before the TypeScript teardown.issueReceipt compute (friday-cloud-worker-teardown.ts: in-memory receipt with sha256 receiptId + manual cleanup steps; no DB write and no external egress). Legacy behavior is reachable only through explicit allowTestOnlyCloudWorkerSetupExecution test-oracle wiring.",
       "next_action": "Replace the fail-closed response with the Rust-owned cloud-worker setup entrypoint when available."
+    },
+    {
+      "id": "diagnosis_incidents_manual_resolve",
+      "route": {
+        "method": "POST",
+        "path": "/v1/diagnosis/incidents/:incidentId/manual-resolve",
+        "operationId": "diagnosis.incidents.manual.resolve"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-diagnosis-routes.ts fail-closes default/live diagnosis.incidents.manual.resolve to TS_RUNTIME_DIAGNOSIS_RETIRED after requireUserId and the required-fix validation, immediately before the TypeScript manualResolveIncident write (friday-self-healing-api-service.ts withWriteTransaction: actionRepo.markRejected, lessonRepo.upsertByFingerprint, incidentRepo.updateStatus). Legacy behavior is reachable only through explicit allowTestOnlyDiagnosisExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned diagnosis entrypoint when available."
+    },
+    {
+      "id": "diagnosis_lessons_enabled_set",
+      "route": {
+        "method": "POST",
+        "path": "/v1/diagnosis/lessons/:lessonId/enabled",
+        "operationId": "diagnosis.lessons.enabled.set"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-diagnosis-routes.ts fail-closes default/live diagnosis.lessons.enabled.set to TS_RUNTIME_DIAGNOSIS_RETIRED after requireUserId and the enabled-boolean validation, immediately before the TypeScript setLessonEnabled write (friday-self-healing-api-service.ts withWriteTransaction: factRepo delete/upsert of the lesson_disabled fact). Legacy behavior is reachable only through explicit allowTestOnlyDiagnosisExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned diagnosis entrypoint when available."
+    },
+    {
+      "id": "diagnosis_patterns_demote",
+      "route": {
+        "method": "POST",
+        "path": "/v1/diagnosis/patterns/:patternId/demote",
+        "operationId": "diagnosis.patterns.demote"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-diagnosis-routes.ts fail-closes default/live diagnosis.patterns.demote to TS_RUNTIME_DIAGNOSIS_RETIRED after requireUserId and the factor-finite-number validation, immediately before the TypeScript demotePattern write (friday-self-healing-api-service.ts withWriteTransaction: factRepo.upsert of the pattern_demotion fact). Legacy behavior is reachable only through explicit allowTestOnlyDiagnosisExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned diagnosis entrypoint when available."
     }
   ]
 }

--- a/src/api/http/routes/friday-diagnosis-routes.ts
+++ b/src/api/http/routes/friday-diagnosis-routes.ts
@@ -22,6 +22,40 @@ export interface FridayDiagnosisRoutesDeps {
   agentLoop?: {
     findRunByIncidentId(incidentId: string): { loopRunId: string } | null;
   };
+  /**
+   * Test-oracle only: allow the legacy TypeScript diagnosis mutations (manual
+   * incident resolve, lesson enable/disable, pattern demote) in isolated
+   * mock/unit validation. Production/runtime callers must leave this unset so
+   * these surfaces fail-close until Rust owns the self-healing diagnosis engine.
+   * The GET incident/diagnosis/learning reads are never gated.
+   */
+  allowTestOnlyDiagnosisExecution?: boolean;
+}
+
+// ─── Retirement helper ───
+//
+// The diagnosis mutation surfaces (manual incident resolve, lesson
+// enable/disable, pattern demote) write user-scoped self-healing state inside a
+// write transaction (incident status + diagnosis + lessons + rejected actions;
+// lesson_disabled facts; pattern_demotion facts). They fail-close by
+// default/live until Rust owns the diagnosis entrypoint; legacy behavior is
+// reachable only through the explicit allowTestOnlyDiagnosisExecution
+// test-oracle flag. The GET incident/diagnosis/learning reads stay compat_shim.
+
+function assertDiagnosisTestOracleAllowed(deps: FridayDiagnosisRoutesDeps): void {
+  if (deps.allowTestOnlyDiagnosisExecution !== true) {
+    throw new FridayDomainError(
+      "TS_RUNTIME_DIAGNOSIS_RETIRED",
+      "TypeScript diagnosis mutation is fail-closed in default/live runtime; use the Rust-owned diagnosis entrypoint.",
+      {
+        httpStatus: 503,
+        details: {
+          classification: "fail_closed",
+          replacement: "rust_owned_diagnosis_entrypoint_required",
+        },
+      },
+    );
+  }
 }
 
 function readPositiveInt(value: unknown): number | undefined {
@@ -228,6 +262,7 @@ export function createFridayDiagnosisRoutes(
             httpStatus: 400,
           });
         }
+        assertDiagnosisTestOracleAllowed(deps);
         const details = deps.service.manualResolveIncident({
           incidentId,
           userId: resolvedBy,
@@ -260,6 +295,7 @@ export function createFridayDiagnosisRoutes(
             httpStatus: 400,
           });
         }
+        assertDiagnosisTestOracleAllowed(deps);
         return {
           lesson: deps.service.setLessonEnabled({
             userId,
@@ -285,6 +321,7 @@ export function createFridayDiagnosisRoutes(
             httpStatus: 400,
           });
         }
+        assertDiagnosisTestOracleAllowed(deps);
         return {
           pattern: deps.service.demotePattern({
             userId,

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -1888,6 +1888,8 @@ export interface FridayHubConfig {
   allowTestOnlySessionMemoryExtractionExecution?: boolean;
   /** Test-oracle only; production hub creation must leave cross-border pack mutations fail-closed. */
   allowTestOnlyCrossBorderPackExecution?: boolean;
+  /** Test-oracle only; production hub creation must leave self-healing diagnosis mutations fail-closed. */
+  allowTestOnlyDiagnosisExecution?: boolean;
 }
 
 // ─── Resolved Hub Config ───

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -6711,7 +6711,14 @@ export async function createFridayHub(
     pluginService: runtimePluginService,
     pluginManifestLoader,
     deterministicPipeline,
-    diagnosis: { service: selfHealingApiService, agentLoop: agentLoopService },
+    diagnosis: {
+      service: selfHealingApiService,
+      agentLoop: agentLoopService,
+      // Test-oracle only: production/live config leaves this unset, so the
+      // diagnosis mutation surfaces fail-close. Test harnesses (real-env live
+      // proof, mock-env) set it true to exercise legacy logic.
+      allowTestOnlyDiagnosisExecution: config.allowTestOnlyDiagnosisExecution,
+    },
     autoFix: {
       service: selfHealingApiService,
       agentLoop: agentLoopService,

--- a/test/e2e/api/_helpers/friday-api-test-server.helper.ts
+++ b/test/e2e/api/_helpers/friday-api-test-server.helper.ts
@@ -278,7 +278,7 @@ export async function createFridayApiTestEnv(
     converterService: options.converterService,
     skillGenerator: options.skillGenerator,
     skillRegistry: options.skillRegistry,
-    diagnosis: selfHealingService ? { service: selfHealingService } : undefined,
+    diagnosis: selfHealingService ? { service: selfHealingService, allowTestOnlyDiagnosisExecution: true } : undefined,
     autoFix: selfHealingService
       ? {
           service: selfHealingService,

--- a/test/e2e/live/_helpers/real-env.ts
+++ b/test/e2e/live/_helpers/real-env.ts
@@ -324,6 +324,7 @@ async function startLocalRealHubEnv(
       allowTestOnlySessionExecution: true,
       allowTestOnlySessionRunExecution: true,
       allowTestOnlySessionMemoryExtractionExecution: true,
+      allowTestOnlyDiagnosisExecution: true,
       ...opts?.hubConfig,
     });
     await createdHub.start();

--- a/test/e2e/mock/_helpers/mock-env.ts
+++ b/test/e2e/mock/_helpers/mock-env.ts
@@ -355,6 +355,8 @@ export async function createMockHubEnv(opts?: {
   allowTestOnlySessionMemoryExtractionExecution?: boolean;
   /** Test-oracle opt-in for legacy TS cross-border pack mutations; set false to prove default fail-closed behavior. */
   allowTestOnlyCrossBorderPackExecution?: boolean;
+  /** Test-oracle opt-in for legacy TS self-healing diagnosis mutations; set false to prove default fail-closed behavior. */
+  allowTestOnlyDiagnosisExecution?: boolean;
 }): Promise<MockHubEnv> {
   // Reset deterministic counters
   resetMockCounters();
@@ -410,6 +412,7 @@ export async function createMockHubEnv(opts?: {
       allowTestOnlySessionRunExecution: opts?.allowTestOnlySessionRunExecution ?? true,
       allowTestOnlySessionMemoryExtractionExecution: opts?.allowTestOnlySessionMemoryExtractionExecution ?? true,
       allowTestOnlyCrossBorderPackExecution: opts?.allowTestOnlyCrossBorderPackExecution ?? true,
+      allowTestOnlyDiagnosisExecution: opts?.allowTestOnlyDiagnosisExecution ?? true,
       // Allow private-network targets so mock E2E tests don't require DNS resolution
       ssrfPolicy: opts?.ssrfPolicy ?? { allowPrivateNetwork: true },
     });

--- a/test/unit/api/http/routes/friday-diagnosis-routes.test.ts
+++ b/test/unit/api/http/routes/friday-diagnosis-routes.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createFridayDiagnosisRoutes } from "#api";
 import type { FridayHttpContext } from "#api";
 import type { FridaySelfHealingApiService } from "#learning";
+import { FridayDomainError } from "#errors";
 
 const NOW = "2026-03-07T10:00:00.000Z";
 
@@ -189,7 +190,7 @@ describe("FridayDiagnosisRoutes", () => {
 
   it("manually resolves an incident with the authenticated user", async () => {
     const service = makeService();
-    const routes = createFridayDiagnosisRoutes({ service });
+    const routes = createFridayDiagnosisRoutes({ service, allowTestOnlyDiagnosisExecution: true });
     const route = routes.find((entry) => entry.operationId === "diagnosis.incidents.manual.resolve")!;
 
     const result = await route.handler(
@@ -274,7 +275,7 @@ describe("FridayDiagnosisRoutes", () => {
 
   it("toggles lesson enabled state with a boolean body", async () => {
     const service = makeService();
-    const routes = createFridayDiagnosisRoutes({ service });
+    const routes = createFridayDiagnosisRoutes({ service, allowTestOnlyDiagnosisExecution: true });
     const route = routes.find((entry) => entry.operationId === "diagnosis.lessons.enabled.set")!;
 
     const result = await route.handler(
@@ -299,7 +300,7 @@ describe("FridayDiagnosisRoutes", () => {
 
   it("demotes a learned pattern with bounded factor", async () => {
     const service = makeService();
-    const routes = createFridayDiagnosisRoutes({ service });
+    const routes = createFridayDiagnosisRoutes({ service, allowTestOnlyDiagnosisExecution: true });
     const route = routes.find((entry) => entry.operationId === "diagnosis.patterns.demote")!;
 
     const result = await route.handler(
@@ -320,5 +321,46 @@ describe("FridayDiagnosisRoutes", () => {
     });
     expect(result.pattern.patternId).toBe("pattern-1");
     expect(result.pattern.factor).toBe(0.25);
+  });
+
+  describe("TS runtime retirement (allowTestOnlyDiagnosisExecution unset)", () => {
+    function retiredRoute(operationId: string, service: FridaySelfHealingApiService) {
+      const route = createFridayDiagnosisRoutes({ service }).find((entry) => entry.operationId === operationId);
+      if (!route) throw new Error(`route not found: ${operationId}`);
+      return route;
+    }
+
+    const cases: Array<{ op: string; ctx: Partial<FridayHttpContext<unknown, unknown, unknown>>; svc: string }> = [
+      { op: "diagnosis.incidents.manual.resolve", ctx: { params: { incidentId: "incident-1" } as never, body: { fix: "patched" } as never }, svc: "manualResolveIncident" },
+      { op: "diagnosis.lessons.enabled.set", ctx: { params: { lessonId: "lesson-1" } as never, body: { enabled: false } as never }, svc: "setLessonEnabled" },
+      { op: "diagnosis.patterns.demote", ctx: { params: { patternId: "pattern-1" } as never, body: { factor: 0.25 } as never }, svc: "demotePattern" },
+    ];
+
+    for (const { op, ctx, svc } of cases) {
+      it(`fail-closes ${op} with 503 and never calls the service`, async () => {
+        const service = makeService();
+        await expect(retiredRoute(op, service).handler(makeCtx(ctx))).rejects.toMatchObject({
+          code: "TS_RUNTIME_DIAGNOSIS_RETIRED",
+          httpStatus: 503,
+        } satisfies Partial<FridayDomainError>);
+        expect((service as unknown as Record<string, ReturnType<typeof vi.fn>>)[svc]).not.toHaveBeenCalled();
+      });
+    }
+
+    it("validates the body (400) before the retirement guard (manual.resolve missing fix)", async () => {
+      const service = makeService();
+      await expect(retiredRoute("diagnosis.incidents.manual.resolve", service).handler(
+        makeCtx({ params: { incidentId: "incident-1" } as never, body: {} as never }),
+      )).rejects.toMatchObject({ code: "VALIDATION_ERROR", httpStatus: 400 } satisfies Partial<FridayDomainError>);
+      expect(service.manualResolveIncident).not.toHaveBeenCalled();
+    });
+
+    it("requires a user-scoped principal (401) before the retirement guard", async () => {
+      const service = makeService();
+      await expect(retiredRoute("diagnosis.incidents.manual.resolve", service).handler(
+        makeCtx({ principal: null as never, params: { incidentId: "incident-1" } as never, body: { fix: "patched" } as never }),
+      )).rejects.toMatchObject({ code: "UNAUTHORIZED", httpStatus: 401 } satisfies Partial<FridayDomainError>);
+      expect(service.manualResolveIncident).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## What

Retire the **3 user-triggerable TS-runtime POST surfaces** in `friday-diagnosis-routes.ts` (gate: `ts_runtime_blocker` **26 → 23**): `incidents.manual.resolve`, `lessons.enabled.set`, `patterns.demote`.

Each handler gains an `assertDiagnosisTestOracleAllowed(deps)` guard (flag `allowTestOnlyDiagnosisExecution`) after `requireUserId` + the required-field validation (`fix` / `enabled`-boolean / `factor`-finite-number) and **immediately before** the service write, throwing 503 `TS_RUNTIME_DIAGNOSIS_RETIRED`, `classification=fail_closed`. `executes_product_logic:false` holds for all 3.

**Classification:** all 3 service methods write user-scoped self-healing state inside a `withWriteTransaction` (incident status + diagnosis + lessons + rejected actions; `lesson_disabled` fact; `pattern_demotion` fact) → `fail_closed`; no third-party egress, no read. The GET incident/diagnosis/learning reads stay `compat_shim`. No hoist needed.

## Test-oracle wiring

Production/live hub creation leaves the flag unset → fail-closes. The flag is plumbed through the hub config (`hub-helpers` `FridayHubConfig` → `friday-hub-bootstrap` `diagnosis` deps reads `config.allowTestOnlyDiagnosisExecution`) and set true in the test harnesses that build a hub and drive these routes:
- the **api e2e** (`friday-api-test-server.helper.ts`, which builds api-runtime directly and POSTs `manual-resolve`),
- the **gated live self-healing proof** (`test/e2e/live/_helpers/real-env.ts` `createFridayHub`, whose anti-learning test POSTs `lessons.enabled.set`),
- `mock-env` for consistency.

The 6-dim review **caught** that the live self-healing e2e (`skipIf`-gated, not standard CI) drives `lessons.enabled.set` against a real hub and would 503 without this plumbing — my initial driver enumeration missed `test/e2e/live/`. **Proven fixed** via a throwaway integration test against the real hub (`createMockHubEnv` → the same `createFridayHub`→hub-bootstrap chain): default → non-503; flag explicitly false → 503 `TS_RUNTIME_DIAGNOSIS_RETIRED`.

> ⚠️ **Pre-existing, out-of-scope note (disclosed, not fixed here):** the same live self-healing matrix's `test 802` ("deep self-healing proof") drives the **auto-fix** `execute`/`approve`/`rollback` routes, which an earlier session retired without plumbing `allowTestOnlyAutoFixExecution` into `real-env.ts`. So that gated live test is already partly red on parent main, independent of this PR. The auto-fix family needs the same `real-env` plumbing in a follow-up.

## Verification

- `npm run check:ts-runtime-retirement` → blocker 26→23.
- `npm run build` green; `npm run lint` 0 errors; `git diff --check` / secrets clean.
- `FRIDAY_E2E_CORE=1 npm test` → **12680 passed / 99 skipped / 0 failed**, no type errors (re-run after the hub-bootstrap/harness wiring).
- Unit test sets the flag in the 3 mutation tests; new regression block asserts 503 + service-not-called per route, validation-400-before-guard, principal-401-before-guard. api e2e (`manual-resolve` over real HTTP) passes.

No RGG scenario auto-POSTs these routes. The home-self-repair ui browser-e2e drives the auto-fix routes, not diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)