### PR TITLE
fix(realtime): fail-close TS realtime checkpoint-ack mutation (HTTP + WS)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -763,7 +763,7 @@
         "filename": "test/unit/api/http/routes/friday-realtime-routes.test.ts",
         "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
         "is_verified": false,
-        "line_number": 45
+        "line_number": 46
       }
     ],
     "test/unit/api/http/routes/friday-skill-converter-routes.test.ts": [
@@ -781,7 +781,7 @@
         "filename": "test/unit/api/realtime/friday-realtime-ws-gateway.test.ts",
         "hashed_secret": "71df888bc5fbf8e09f797e223d70eebfabada055",
         "is_verified": false,
-        "line_number": 30
+        "line_number": 33
       }
     ],
     "test/unit/api/runtime/friday-api-runtime-memory-guard-registration.test.ts": [
@@ -1124,5 +1124,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-06T06:22:42Z"
+  "generated_at": "2026-06-06T14:58:15Z"
 }

--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -3461,6 +3461,41 @@
       "executes_product_logic": false,
       "proof": "src/api/http/routes/friday-diagnosis-routes.ts fail-closes default/live diagnosis.patterns.demote to TS_RUNTIME_DIAGNOSIS_RETIRED after requireUserId and the factor-finite-number validation, immediately before the TypeScript demotePattern write (friday-self-healing-api-service.ts withWriteTransaction: factRepo.upsert of the pattern_demotion fact). Legacy behavior is reachable only through explicit allowTestOnlyDiagnosisExecution test-oracle wiring.",
       "next_action": "Replace the fail-closed response with the Rust-owned diagnosis entrypoint when available."
+    },
+    {
+      "id": "realtime_ack",
+      "route": {
+        "method": "POST",
+        "path": "/v1/realtime/ack",
+        "operationId": "realtime.ack"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "The TypeScript checkpoint-ack mutation (friday-realtime-subscription-service.ts ackEvent -> withWriteTransaction checkpointRepo.upsert advances/persists the delivery cursor) has TWO user-triggerable call sites and BOTH fail-close by default/live: (1) the HTTP route src/api/http/routes/friday-realtime-routes.ts realtime.ack -> assertRealtimeTestOracleAllowed(deps) after streamId/seq/epoch validation + isStreamAuthorized + cursor HMAC, immediately before ackEvent (503 TS_RUNTIME_REALTIME_RETIRED); (2) the WS gateway ack frame src/api/realtime/friday-realtime-ws-gateway.ts (createFridayRealtimeWsGateway, served at /v1/realtime/ws) returns a DEGRADED_MODE error frame (TS_RUNTIME_REALTIME_RETIRED) after the same auth/epoch/cursor checks, immediately before ackEvent. Both call sites are gated by the single top-level allowTestOnlyRealtimeExecution flag (threaded into CreateFridayApiRuntimeDeps -> both the inline createFridayRealtimeRoutes and createFridayRealtimeWsGateway). executes_product_logic:false: no checkpoint write occurs in default/live. Legacy behavior is reachable only through explicit allowTestOnlyRealtimeExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned realtime delivery entrypoint when available."
+    },
+    {
+      "id": "realtime_subscribe_read",
+      "route": {
+        "method": "POST",
+        "path": "/v1/realtime/subscriptions",
+        "operationId": "realtime.subscribe"
+      },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "proof": "src/api/http/routes/friday-realtime-routes.ts realtime.subscribe is a pure read: deps.subscriptionService.validateSubscriptions performs in-memory RBAC scope + topic->stream-prefix binding validation only (friday-realtime-subscription-service.ts:145-183) and returns the resolved bindings; it reads/writes NO persisted state (the live subscription set lives in the WS-gateway connection map, not this route). It stays a redacting compat_shim and is intentionally NOT gated by the retirement guard."
+    },
+    {
+      "id": "realtime_pull_read",
+      "route": {
+        "method": "POST",
+        "path": "/v1/realtime/pull",
+        "operationId": "realtime.pull"
+      },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "proof": "src/api/http/routes/friday-realtime-routes.ts realtime.pull is a pure read: deps.subscriptionService.pullEvents runs via withReadConnection (eventRepo.listAfterSeq) and the handler returns the events with no lease, cursor advance, or write (cursor advancement is the separate ackEvent method, used by realtime.ack). It stays a redacting compat_shim and is intentionally NOT gated by the retirement guard."
     }
   ]
 }

--- a/src/api/http/routes/friday-realtime-routes.ts
+++ b/src/api/http/routes/friday-realtime-routes.ts
@@ -16,6 +16,39 @@ const REALTIME_MAX_PULL_LIMIT = 200;
 export interface FridayRealtimeRoutesDeps {
   subscriptionService: FridayRealtimeSubscriptionService;
   currentEpoch: number;
+  /**
+   * Test-oracle only: allow the legacy TypeScript realtime checkpoint-ack
+   * mutation (POST /v1/realtime/ack) in isolated mock/unit validation.
+   * Production/runtime callers must leave this unset so the ack surface
+   * fail-closes until Rust owns the realtime delivery engine. The
+   * subscribe/pull surfaces are pure reads and are never gated.
+   */
+  allowTestOnlyRealtimeExecution?: boolean;
+}
+
+// ─── Retirement helper ───
+//
+// POST /v1/realtime/ack advances/persists the realtime checkpoint cursor via
+// withWriteTransaction (checkpointRepo.upsert). It fail-closes by default/live
+// until Rust owns the realtime delivery entrypoint; legacy behavior is reachable
+// only through the explicit allowTestOnlyRealtimeExecution test-oracle flag. The
+// realtime.subscribe (in-memory RBAC validation) and realtime.pull (read via
+// withReadConnection) surfaces are pure reads and stay compat_shim, NOT gated.
+
+function assertRealtimeTestOracleAllowed(deps: FridayRealtimeRoutesDeps): void {
+  if (deps.allowTestOnlyRealtimeExecution !== true) {
+    throw new FridayDomainError(
+      "TS_RUNTIME_REALTIME_RETIRED",
+      "TypeScript realtime checkpoint-ack is fail-closed in default/live runtime; use the Rust-owned realtime delivery entrypoint.",
+      {
+        httpStatus: 503,
+        details: {
+          classification: "fail_closed",
+          replacement: "rust_owned_realtime_delivery_entrypoint_required",
+        },
+      },
+    );
+  }
 }
 
 export function createFridayRealtimeRoutes(
@@ -140,6 +173,7 @@ export function createFridayRealtimeRoutes(
           });
         }
 
+        assertRealtimeTestOracleAllowed(deps);
         const ackResult = deps.subscriptionService.ackEvent(
           ctx.principal!.principalId,
           streamId,

--- a/src/api/realtime/friday-realtime-ws-gateway.ts
+++ b/src/api/realtime/friday-realtime-ws-gateway.ts
@@ -49,6 +49,14 @@ export interface CreateFridayRealtimeWsGatewayDeps {
   serverVersion: string;
   currentEpoch: number;
   frameCrypto?: FridayRealtimeFrameCrypto;
+  /**
+   * Test-oracle only: allow the legacy TypeScript realtime checkpoint-ack
+   * mutation via the WS ack frame. Production/runtime callers must leave this
+   * unset so the ack frame fail-closes (matching POST /v1/realtime/ack) until
+   * Rust owns realtime delivery. Hello/subscribe/pull frames are reads and are
+   * never gated.
+   */
+  allowTestOnlyRealtimeExecution?: boolean;
 }
 
 // ─── Factory ───
@@ -222,6 +230,24 @@ export function createFridayRealtimeWsGateway(
                 streamId: frame.streamId,
                 reason: "CURSOR_INVALID",
                 snapshotEndpoint: `/v1/realtime/pull?streamId=${frame.streamId}`,
+              },
+            ];
+          }
+
+          // TS-runtime retirement: the checkpoint-ack mutation (ackEvent ->
+          // withWriteTransaction checkpointRepo.upsert) fail-closes by
+          // default/live, matching POST /v1/realtime/ack. This is the second
+          // call site of ackEvent; both are gated so the mutation is fully
+          // retired. Legacy behavior is reachable only through the explicit
+          // allowTestOnlyRealtimeExecution test-oracle flag.
+          if (deps.allowTestOnlyRealtimeExecution !== true) {
+            return [
+              {
+                type: "error",
+                code: FRIDAY_ERROR_CODES.DEGRADED_MODE,
+                message:
+                  "Realtime checkpoint-ack is fail-closed in default/live runtime (TS_RUNTIME_REALTIME_RETIRED); use the Rust-owned realtime delivery entrypoint.",
+                retryable: false,
               },
             ];
           }

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -1079,6 +1079,9 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
     nowIso: deps.nowIso,
     serverVersion,
     currentEpoch: CURRENT_EPOCH,
+    // Test-oracle only: undefined in default/live runtime, so the WS ack frame
+    // fail-closes (matching POST /v1/realtime/ack). Same top-level flag.
+    allowTestOnlyRealtimeExecution: deps.allowTestOnlyRealtimeExecution,
   });
 
   const publishWorkflowRealtimeEvent = async (
@@ -3086,6 +3089,9 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
   for (const route of createFridayRealtimeRoutes({
     subscriptionService: subscriptions,
     currentEpoch: CURRENT_EPOCH,
+    // Test-oracle only: undefined in default/live runtime, so realtime.ack
+    // fail-closes; test harnesses thread it true via hub config.
+    allowTestOnlyRealtimeExecution: deps.allowTestOnlyRealtimeExecution,
   })) {
     routes.register(route);
   }

--- a/src/api/runtime/friday-api-runtime.types.ts
+++ b/src/api/runtime/friday-api-runtime.types.ts
@@ -342,6 +342,12 @@ export interface CreateFridayApiRuntimeDeps {
    * fail-closed until Rust owns the session memory extraction entrypoint.
    */
   allowTestOnlySessionMemoryExtractionExecution?: boolean;
+  /**
+   * Test-oracle only: allow the legacy TypeScript realtime checkpoint-ack
+   * mutation (POST /v1/realtime/ack). Production/runtime callers must leave this
+   * unset so the ack surface stays fail-closed until Rust owns realtime delivery.
+   */
+  allowTestOnlyRealtimeExecution?: boolean;
   /** Optional: Reflex service for deterministic preference writes before agent runs. */
   reflexService?: FridayReflexService;
   /** Optional deterministic runtime capability getter used by context evidence selection. */

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -1890,6 +1890,8 @@ export interface FridayHubConfig {
   allowTestOnlyCrossBorderPackExecution?: boolean;
   /** Test-oracle only; production hub creation must leave self-healing diagnosis mutations fail-closed. */
   allowTestOnlyDiagnosisExecution?: boolean;
+  /** Test-oracle only; production hub creation must leave the realtime checkpoint-ack mutation fail-closed. */
+  allowTestOnlyRealtimeExecution?: boolean;
 }
 
 // ─── Resolved Hub Config ───

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -6924,6 +6924,7 @@ export async function createFridayHub(
     allowTestOnlySessionExecution: config.allowTestOnlySessionExecution,
     allowTestOnlySessionRunExecution: config.allowTestOnlySessionRunExecution,
     allowTestOnlySessionMemoryExtractionExecution: config.allowTestOnlySessionMemoryExtractionExecution,
+    allowTestOnlyRealtimeExecution: config.allowTestOnlyRealtimeExecution,
     reflexService,
     agentEventEmitter,
     resolveToolApproval,

--- a/test/e2e/api/_helpers/friday-api-test-server.helper.ts
+++ b/test/e2e/api/_helpers/friday-api-test-server.helper.ts
@@ -185,6 +185,7 @@ export interface CreateFridayApiTestEnvOptions {
   allowTestOnlySessionRunExecution?: boolean;
   allowTestOnlySessionMemoryExtractionExecution?: boolean;
   allowTestOnlyCrossBorderPackExecution?: boolean;
+  allowTestOnlyRealtimeExecution?: boolean;
   resolveSkill?: (skillId: string) => unknown | null;
   invokeSkill?: (
     skillId: string,
@@ -301,6 +302,7 @@ export async function createFridayApiTestEnv(
     allowTestOnlySessionRunExecution: options.allowTestOnlySessionRunExecution ?? true,
     allowTestOnlySessionMemoryExtractionExecution: options.allowTestOnlySessionMemoryExtractionExecution ?? true,
     allowTestOnlyCrossBorderPackExecution: options.allowTestOnlyCrossBorderPackExecution ?? true,
+    allowTestOnlyRealtimeExecution: options.allowTestOnlyRealtimeExecution ?? true,
     computeChecksum: (content: string) =>
       crypto.createHash("sha256").update(content).digest("hex"),
     resolveSkill: options.resolveSkill ?? ((_skillId: string) => ({ id: _skillId })),

--- a/test/e2e/friday-full-e2e.test.ts
+++ b/test/e2e/friday-full-e2e.test.ts
@@ -131,6 +131,7 @@ describe.skipIf(!CORE_E2E_ENABLED)("Friday Full E2E — Batch 1 (A–F)", () => 
       allowTestOnlySessionExecution: true,
       allowTestOnlySessionRunExecution: true,
       allowTestOnlySessionMemoryExtractionExecution: true,
+      allowTestOnlyRealtimeExecution: true,
     });
     await hub.start();
 

--- a/test/e2e/live/_helpers/real-env.ts
+++ b/test/e2e/live/_helpers/real-env.ts
@@ -325,6 +325,7 @@ async function startLocalRealHubEnv(
       allowTestOnlySessionRunExecution: true,
       allowTestOnlySessionMemoryExtractionExecution: true,
       allowTestOnlyDiagnosisExecution: true,
+      allowTestOnlyRealtimeExecution: true,
       ...opts?.hubConfig,
     });
     await createdHub.start();

--- a/test/e2e/mock/_helpers/mock-env.ts
+++ b/test/e2e/mock/_helpers/mock-env.ts
@@ -357,6 +357,8 @@ export async function createMockHubEnv(opts?: {
   allowTestOnlyCrossBorderPackExecution?: boolean;
   /** Test-oracle opt-in for legacy TS self-healing diagnosis mutations; set false to prove default fail-closed behavior. */
   allowTestOnlyDiagnosisExecution?: boolean;
+  /** Test-oracle opt-in for legacy TS realtime checkpoint-ack mutation; set false to prove default fail-closed behavior. */
+  allowTestOnlyRealtimeExecution?: boolean;
 }): Promise<MockHubEnv> {
   // Reset deterministic counters
   resetMockCounters();
@@ -413,6 +415,7 @@ export async function createMockHubEnv(opts?: {
       allowTestOnlySessionMemoryExtractionExecution: opts?.allowTestOnlySessionMemoryExtractionExecution ?? true,
       allowTestOnlyCrossBorderPackExecution: opts?.allowTestOnlyCrossBorderPackExecution ?? true,
       allowTestOnlyDiagnosisExecution: opts?.allowTestOnlyDiagnosisExecution ?? true,
+      allowTestOnlyRealtimeExecution: opts?.allowTestOnlyRealtimeExecution ?? true,
       // Allow private-network targets so mock E2E tests don't require DNS resolution
       ssrfPolicy: opts?.ssrfPolicy ?? { allowPrivateNetwork: true },
     });

--- a/test/unit/api/http/routes/friday-realtime-routes.test.ts
+++ b/test/unit/api/http/routes/friday-realtime-routes.test.ts
@@ -8,6 +8,7 @@ import {
   createFridayRealtimeCheckpointRepository,
 } from "#api";
 import type { FridayAuthPrincipal } from "#api";
+import { FridayDomainError } from "#errors";
 
 describe("FridayRealtimeRoutes", () => {
   let db: FridaySqliteLayer;
@@ -159,5 +160,73 @@ describe("FridayRealtimeRoutes", () => {
     expect(result.streamId).toBe("workflow:wf-1");
     expect(result.epoch).toBe(EPOCH);
     expect(result.items.map((item) => item.eventId)).toEqual(["evt-offline-1", "evt-offline-2"]);
+  });
+
+  describe("TS runtime retirement (allowTestOnlyRealtimeExecution)", () => {
+    function makeAckRoute(allow?: boolean) {
+      const subscriptionService = createFridayRealtimeSubscriptionService({
+        db,
+        eventRepo: createFridayRealtimeEventRepository(),
+        checkpointRepo: createFridayRealtimeCheckpointRepository(),
+        nowIso: () => NOW,
+        currentEpoch: EPOCH,
+        cursorSecret: "test-secret",
+      });
+      return createFridayRealtimeRoutes({ subscriptionService, currentEpoch: EPOCH, allowTestOnlyRealtimeExecution: allow })
+        .find((r) => r.operationId === "realtime.ack")!;
+    }
+
+    const ackCtx = {
+      requestId: "req-ack",
+      receivedAt: NOW,
+      params: {},
+      query: {},
+      body: { streamId: "workflow:wf-1", seq: 1, epoch: EPOCH },
+      headers: {},
+      principal: adminPrincipal,
+    };
+
+    it("fail-closes realtime.ack with 503 for an authorized request when the flag is unset", async () => {
+      await expect(makeAckRoute(undefined).handler({ ...ackCtx })).rejects.toMatchObject({
+        code: "TS_RUNTIME_REALTIME_RETIRED",
+        httpStatus: 503,
+      } satisfies Partial<FridayDomainError>);
+    });
+
+    it("does NOT fail-close realtime.ack when the flag is true (reaches ackEvent, accepted)", async () => {
+      const result = await makeAckRoute(true).handler({ ...ackCtx }) as { accepted: boolean };
+      expect(result.accepted).toBe(true);
+    });
+
+    it("enforces stream authorization (403) BEFORE the retirement guard (flag unset)", async () => {
+      const restrictedPrincipal: FridayAuthPrincipal = { ...adminPrincipal, scopes: ["fleet.read"] };
+      await expect(makeAckRoute(undefined).handler({ ...ackCtx, principal: restrictedPrincipal }))
+        .rejects.toThrow(/Not authorized/);
+    });
+
+    it("leaves the read surfaces (subscribe/pull) ungated when the flag is unset", async () => {
+      const routes = createFridayRealtimeRoutes({
+        subscriptionService: createFridayRealtimeSubscriptionService({
+          db,
+          eventRepo: createFridayRealtimeEventRepository(),
+          checkpointRepo: createFridayRealtimeCheckpointRepository(),
+          nowIso: () => NOW,
+          currentEpoch: EPOCH,
+          cursorSecret: "test-secret",
+        }),
+        currentEpoch: EPOCH,
+      });
+      const pull = routes.find((r) => r.operationId === "realtime.pull")!;
+      const result = await pull.handler({
+        requestId: "req-pull",
+        receivedAt: NOW,
+        params: {},
+        query: {},
+        body: { streamId: "workflow:wf-1", afterSeq: 0, limit: 10 },
+        headers: {},
+        principal: adminPrincipal,
+      }) as { streamId: string };
+      expect(result.streamId).toBe("workflow:wf-1");
+    });
   });
 });

--- a/test/unit/api/realtime/friday-realtime-ws-gateway.test.ts
+++ b/test/unit/api/realtime/friday-realtime-ws-gateway.test.ts
@@ -25,6 +25,9 @@ import type { FridayAccessTokenClaims } from "#api";
 describe("FridayRealtimeWsGateway", () => {
   let db: FridaySqliteLayer;
   let gateway: FridayRealtimeWsGateway;
+  let subscriptionService: ReturnType<typeof createFridayRealtimeSubscriptionService>;
+  let eventBus: ReturnType<typeof createFridayRealtimeEventBus>;
+  let tokenValidator: ReturnType<typeof createFridayTokenValidator>;
   const NOW = "2025-06-15T10:00:00.000Z";
   const NOW_MS = new Date(NOW).getTime();
   const TOKEN_SECRET = "test-secret-for-ws";
@@ -60,18 +63,18 @@ describe("FridayRealtimeWsGateway", () => {
     db = createTestDb();
     const eventRepo = createFridayRealtimeEventRepository();
     const checkpointRepo = createFridayRealtimeCheckpointRepository();
-    const subscriptionService = createFridayRealtimeSubscriptionService({
+    subscriptionService = createFridayRealtimeSubscriptionService({
       db,
       eventRepo,
       checkpointRepo,
       nowIso: () => NOW,
       currentEpoch: EPOCH,
     });
-    const eventBus = createFridayRealtimeEventBus({
+    eventBus = createFridayRealtimeEventBus({
       idGenerator: () => "bus-evt-1",
       nowIso: () => NOW,
     });
-    const tokenValidator = createFridayTokenValidator({
+    tokenValidator = createFridayTokenValidator({
       tokenSecret: TOKEN_SECRET,
       nowMs: () => NOW_MS,
       lookupTokenRevocation: () => false,
@@ -84,6 +87,9 @@ describe("FridayRealtimeWsGateway", () => {
       nowIso: () => NOW,
       serverVersion: "1.0.0-test",
       currentEpoch: EPOCH,
+      // Test-oracle: exercise the real WS checkpoint-ack logic. Default/live
+      // leaves this unset so the ack frame fail-closes (see retirement test).
+      allowTestOnlyRealtimeExecution: true,
     });
   });
 
@@ -156,6 +162,7 @@ describe("FridayRealtimeWsGateway", () => {
       serverVersion: "1.0.0-test",
       currentEpoch: EPOCH,
       frameCrypto,
+      allowTestOnlyRealtimeExecution: true,
     });
     const conn = encryptedGateway.createConnection("conn-encrypted");
 
@@ -319,6 +326,58 @@ describe("FridayRealtimeWsGateway", () => {
     const ackOk = responses[0] as Extract<FridayRealtimeServerFrame, { type: "ack_ok" }>;
     expect(ackOk.streamId).toBe("workflow:wf-1");
     expect(ackOk.seq).toBe(5);
+  });
+
+  it("TS runtime retirement: ack frame fail-closes (error frame) when allowTestOnlyRealtimeExecution is unset", () => {
+    // Default/live wiring leaves the flag unset; the WS ack frame is the second
+    // ackEvent call site (the first is POST /v1/realtime/ack) and must also
+    // fail-close so the checkpoint-cursor mutation is fully retired.
+    const retiredGateway = createFridayRealtimeWsGateway({
+      tokenValidator,
+      subscriptionService,
+      eventBus,
+      nowIso: () => NOW,
+      serverVersion: "1.0.0-test",
+      currentEpoch: EPOCH,
+      // allowTestOnlyRealtimeExecution intentionally unset.
+    });
+    const conn = retiredGateway.createConnection("conn-retired");
+    retiredGateway.handleClientFrame(conn, { type: "hello", token: makeToken() });
+    retiredGateway.handleClientFrame(conn, {
+      type: "subscribe",
+      subscriptions: [
+        { subscriptionId: "sub-1", streamId: "workflow:wf-1", topic: "workflow" },
+      ],
+    });
+
+    const responses = retiredGateway.handleClientFrame(conn, {
+      type: "ack",
+      streamId: "workflow:wf-1",
+      seq: 5,
+      epoch: EPOCH,
+    });
+
+    expect(responses).toHaveLength(1);
+    expect(responses[0].type).toBe("error");
+    expect((responses[0] as Extract<FridayRealtimeServerFrame, { type: "error" }>).message)
+      .toContain("TS_RUNTIME_REALTIME_RETIRED");
+    // The cursor was NOT advanced: a fresh authorized ack via a flag-enabled
+    // gateway still succeeds (proving the retirement is the only thing blocking).
+    const okConn = gateway.createConnection("conn-ok");
+    gateway.handleClientFrame(okConn, { type: "hello", token: makeToken() });
+    gateway.handleClientFrame(okConn, {
+      type: "subscribe",
+      subscriptions: [
+        { subscriptionId: "sub-1", streamId: "workflow:wf-1", topic: "workflow" },
+      ],
+    });
+    const okResponses = gateway.handleClientFrame(okConn, {
+      type: "ack",
+      streamId: "workflow:wf-1",
+      seq: 5,
+      epoch: EPOCH,
+    });
+    expect(okResponses[0].type).toBe("ack_ok");
   });
 
   it("ack with stale epoch returns resync_required", () => {


### PR DESCRIPTION
## What

Retires the TypeScript-owned realtime **checkpoint-ack mutation** (`FridayRealtimeSubscriptionService.ackEvent` → `withWriteTransaction` → `checkpointRepo.upsert`, which advances the per-principal stream cursor). Both user-triggerable call sites now fail-close by default/live runtime; legacy behavior is reachable only through an explicit test-oracle flag.

This is the **realtime** slice of the TS Runtime Retirement lane. Reads (`hello`/`subscribe`/`pull`/`resume` replay) are unchanged.

## Why two call sites

`ackEvent` is reachable from **two** user-triggerable surfaces:
1. **HTTP** `POST /v1/realtime/ack` (`friday-realtime-routes.ts`)
2. **WS** `/v1/realtime/ws` `ack` frame (`friday-realtime-ws-gateway.ts`)

Gating only the route would leave the mutation reachable over the WS frame — a false retirement proof. Both are gated by the single top-level `allowTestOnlyRealtimeExecution` flag.

## Fail-close shape

- **HTTP route** → `503 FridayDomainError` `TS_RUNTIME_REALTIME_RETIRED`, `classification: fail_closed`, `replacement: rust_owned_realtime_delivery_entrypoint_required`. Guard sits after auth / stream-authorization / epoch / cursor-HMAC checks, immediately before `ackEvent` (so malformed/unauthorized requests still 401/403/resync, not 503).
- **WS ack frame** → error frame `DEGRADED_MODE` with message `...TS_RUNTIME_REALTIME_RETIRED...` (a frame, not an HTTP status). Same guard position — after auth/stream-auth/epoch/cursor checks.

## Flag wiring

`allowTestOnlyRealtimeExecution?: boolean` threaded: `FridayHubConfig` → `friday-hub-bootstrap` (api-runtime deps) → `CreateFridayApiRuntimeDeps` → inline `createFridayRealtimeRoutes` **and** `createFridayRealtimeWsGateway`. Default unset (fail-closed). Test harnesses (mock-env, api-test-server, real-env, full-e2e) set it `true` so existing realtime e2e/unit coverage still drives the live path.

## Manifest

`docs/ops/ts-runtime-retirement-manifest.json`: added the realtime ack route + WS surface; proof documents BOTH call sites and the single shared flag. Gate `ts_runtime_blocker` 23 → 20.

## Tests

- `friday-realtime-routes.test.ts`: flag-unset → 503; flag-true → `ackEvent` accepted; auth-403 fires before the guard; subscribe/pull ungated.
- `friday-realtime-ws-gateway.test.ts`: ack frame fail-closes (error frame, `TS_RUNTIME_REALTIME_RETIRED`) when flag unset; flag-true gateway still `ack_ok`.
- Full local suite: 12685 passed / 99 skipped, no type errors; lint clean; both secrets gates clean; gate blocker 20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)