### PR TITLE
fix(skills): fail-close TS scan-migrate local-scan + batch-convert product logic

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -3515,6 +3515,32 @@
       "next_action": "Replace the fail-closed response with the Rust-owned skill-pack entrypoint when available."
     },
     {
+      "id": "skills_scan_local",
+      "route": {
+        "method": "POST",
+        "path": "/v1/skills/scan-local",
+        "operationId": "skills.scan.local"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-scan-migrate-routes.ts skills.scan.local wires default/live to assertScanMigrateTestOracleAllowed(deps) as the FIRST statement of the handler, immediately before deps.scanLocal() -> scanLocalSkills (src/skills/converter/discovery/friday-local-skill-scanner.ts). 503 TS_RUNTIME_SCAN_MIGRATE_RETIRED (classification fail_closed, replacement rust_owned_scan_migrate_entrypoint_required). This route is NON-mutating but classified fail_closed not compat_shim because scanLocalSkills executes Rust-ownable PRODUCT LOGIC — a multi-source filesystem DISCOVERY algorithm (scans ~/.claude, ~/.cursor, ~/.n8n, ~/.codex, ~/Projects, parses + format-detects skill candidates); it is not a thin read of Friday's own stored state, so a compat_shim 'does not execute product logic' assertion would be false (same precedent as cloud-worker package.generate, a stateless compute classified fail_closed). executes_product_logic:false: the scan does not run in default/live. scanLocalSkills has exactly ONE user-triggerable call site (this route — verified by grep), so legacy behavior is reachable only through explicit allowTestOnlyScanMigrateExecution test-oracle wiring (FridayHubConfig -> friday-hub-bootstrap createFridayScanMigrateRoutes).",
+      "next_action": "Replace the fail-closed response with the Rust-owned local-skill discovery entrypoint when available."
+    },
+    {
+      "id": "skills_convert_batch",
+      "route": {
+        "method": "POST",
+        "path": "/v1/skills/convert-batch",
+        "operationId": "skills.convert.batch"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-scan-migrate-routes.ts skills.convert.batch wires default/live to assertScanMigrateTestOracleAllowed(deps) as the FIRST statement of the handler, before the per-item deps.convertSkill loop (-> friday-hub-bootstrap converterService.convert dryRun preview). 503 TS_RUNTIME_SCAN_MIGRATE_RETIRED. fail_closed (transform/product logic, no third-party egress — same generated-code rationale as skills.convert); executes_product_logic:false: no conversion runs in default/live. deps.convertSkill has exactly ONE user-triggerable call site (this route — verified by grep), so legacy behavior is reachable only through explicit allowTestOnlyScanMigrateExecution test-oracle wiring. NOTE (route-scoped): this gates the convert-batch surface of converterService.convert; the /v1/skills/convert surface was retired in #558 (allowTestOnlySkillConverterExecution). With both ROUTES gated, the remaining callers of converterService.convert are NON-route: the operator-local CLI (friday-cli.ts), and the agent skill-import tool (src/agent/tools/friday-agent-skill-import-tool.ts -> converterService.convert dryRun), which is registered unconditionally on the agent runtime (friday-hub-bootstrap.ts agentRuntime.registerTool(skillImportTool)) and runs DURING an agent run. The agent-tool path is the TS runtime executing downstream of agentRuntime.executeRun, NOT a sibling user-triggerable route — whether it stays live in default/live is the POST-TS-TRUTH-RECONCILIATION question (is agentRuntime.executeRun reachable from an ungated user surface in production), already logged in the closure ledger; it is out of scope for this route retirement.",
+      "next_action": "Replace the fail-closed response with the Rust-owned batch-convert entrypoint when available."
+    },
+    {
       "id": "realtime_subscribe_read",
       "route": {
         "method": "POST",

--- a/src/api/http/routes/friday-scan-migrate-routes.ts
+++ b/src/api/http/routes/friday-scan-migrate-routes.ts
@@ -10,6 +10,7 @@
 import type { FridayHttpContext, FridayRouteDefinition } from "../../model/friday-api-common.types.js";
 import type { LocalSkillScanResult } from "../../../skills/converter/discovery/friday-local-skill-scanner.js";
 import type { CommunitySkillItem } from "../../../skills/converter/discovery/friday-community-skill-catalog.js";
+import { FridayDomainError } from "#errors";
 import {
   redactFridaySkillCandidateSourceUri,
   redactFridaySkillSourceText,
@@ -26,6 +27,41 @@ export interface FridayScanMigrateRoutesDeps {
     mode?: "preview";
     error?: string;
   }>;
+  /**
+   * Test-oracle only: allow the legacy TypeScript scan-migrate product logic
+   * (local-skill discovery scan + batch convert preview). Production/runtime
+   * callers must leave this unset so the two POST routes fail-close
+   * (503 TS_RUNTIME_SCAN_MIGRATE_RETIRED) until Rust owns local skill discovery
+   * and batch conversion. The GET community catalog is a pure read, never gated.
+   */
+  allowTestOnlyScanMigrateExecution?: boolean;
+}
+
+/**
+ * TS-runtime retirement guard for the scan-migrate product-logic routes. Both
+ * surfaces are non-mutating but execute Rust-ownable product logic
+ * (scanLocalSkills runs a multi-source filesystem discovery algorithm;
+ * convert-batch runs converterService.convert per item), so they fail-close
+ * rather than serve as compat_shim reads. Each underlying method has exactly one
+ * user-triggerable call site (its route), so the retirement is complete.
+ */
+function assertScanMigrateTestOracleAllowed(
+  deps: FridayScanMigrateRoutesDeps,
+): void {
+  if (deps.allowTestOnlyScanMigrateExecution === true) {
+    return;
+  }
+  throw new FridayDomainError(
+    "TS_RUNTIME_SCAN_MIGRATE_RETIRED",
+    "Local skill discovery scan and batch convert preview are fail-closed in the default/live runtime; the Rust-owned scan-migrate entrypoint is required.",
+    {
+      httpStatus: 503,
+      details: {
+        classification: "fail_closed",
+        replacement: "rust_owned_scan_migrate_entrypoint_required",
+      },
+    },
+  );
 }
 
 // ─── Helpers ───
@@ -46,6 +82,7 @@ export function createFridayScanMigrateRoutes(
       path: "/v1/skills/scan-local",
       auth: { public: true },
       handler: async (_ctx: Ctx) => {
+        assertScanMigrateTestOracleAllowed(deps);
         const result = deps.scanLocal();
         return { status: 200, body: result };
       },
@@ -72,6 +109,7 @@ export function createFridayScanMigrateRoutes(
       path: "/v1/skills/convert-batch",
       auth: { public: true },
       handler: async (ctx: Ctx) => {
+        assertScanMigrateTestOracleAllowed(deps);
         const body = (ctx.body ?? {}) as {
           items?: Array<{ sourcePath: string; formatHint?: string }>;
         };

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -1894,6 +1894,8 @@ export interface FridayHubConfig {
   allowTestOnlyRealtimeExecution?: boolean;
   /** Test-oracle only; production hub creation must leave skill-converter convert/import/pack mutations fail-closed. */
   allowTestOnlySkillConverterExecution?: boolean;
+  /** Test-oracle only; production hub creation must leave scan-migrate local-scan + batch-convert product logic fail-closed. */
+  allowTestOnlyScanMigrateExecution?: boolean;
 }
 
 // ─── Resolved Hub Config ───

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -7128,6 +7128,7 @@ export async function createFridayHub(
         };
       }
     },
+    allowTestOnlyScanMigrateExecution: config.allowTestOnlyScanMigrateExecution,
   });
   for (const route of scanMigrateRoutes) {
     apiRuntime.routes.register(route as Parameters<typeof apiRuntime.routes.register>[0]);

--- a/test/unit/api/http/routes/friday-scan-migrate-routes.test.ts
+++ b/test/unit/api/http/routes/friday-scan-migrate-routes.test.ts
@@ -41,6 +41,7 @@ describe("createFridayScanMigrateRoutes", () => {
       scanLocal: () => ({ items: [], scannedAt: "now", scanDurationMs: 0, directoriesScanned: [] }),
       getCommunitySkills: () => [],
       convertSkill,
+      allowTestOnlyScanMigrateExecution: true,
     });
     const route = routes.find((candidate) => candidate.operationId === "skills.convert.batch");
     expect(route).toBeTruthy();
@@ -76,6 +77,7 @@ describe("createFridayScanMigrateRoutes", () => {
       scanLocal: () => ({ items: [], scannedAt: "now", scanDurationMs: 0, directoriesScanned: [] }),
       getCommunitySkills: () => [],
       convertSkill,
+      allowTestOnlyScanMigrateExecution: true,
     });
     const route = routes.find((candidate) => candidate.operationId === "skills.convert.batch");
     expect(route).toBeTruthy();
@@ -99,6 +101,44 @@ describe("createFridayScanMigrateRoutes", () => {
       ],
       convertedCount: 0,
       failedCount: 1,
+    });
+  });
+
+  describe("TS-runtime retirement (default/live fail-close)", () => {
+    // Build routes WITHOUT the test-oracle flag = production/live wiring.
+    function makeRetiredDeps() {
+      const scanLocal = vi.fn(() => ({ items: [], scannedAt: "now", scanDurationMs: 0, directoriesScanned: [] }));
+      const convertSkill = vi.fn(async () => ({ success: true, skillId: "x", mode: "preview" as const }));
+      const getCommunitySkills = vi.fn(() => [{ id: "c1", name: "Community Skill" } as never]);
+      const routes = createFridayScanMigrateRoutes({ scanLocal, getCommunitySkills, convertSkill });
+      return { routes, scanLocal, convertSkill, getCommunitySkills };
+    }
+
+    it("fail-closes scan-local with 503 TS_RUNTIME_SCAN_MIGRATE_RETIRED and does not scan", async () => {
+      const { routes, scanLocal } = makeRetiredDeps();
+      const route = routes.find((r) => r.operationId === "skills.scan.local")!;
+      await expect(route.handler(makeCtx({}))).rejects.toMatchObject({
+        code: "TS_RUNTIME_SCAN_MIGRATE_RETIRED",
+        httpStatus: 503,
+      });
+      expect(scanLocal).not.toHaveBeenCalled();
+    });
+
+    it("fail-closes convert-batch with 503 and does not convert", async () => {
+      const { routes, convertSkill } = makeRetiredDeps();
+      const route = routes.find((r) => r.operationId === "skills.convert.batch")!;
+      await expect(
+        route.handler(makeCtx({ items: [{ sourcePath: "/tmp/SKILL.md" }] })),
+      ).rejects.toMatchObject({ code: "TS_RUNTIME_SCAN_MIGRATE_RETIRED", httpStatus: 503 });
+      expect(convertSkill).not.toHaveBeenCalled();
+    });
+
+    it("leaves the GET community catalog ungated (pure read)", async () => {
+      const { routes, getCommunitySkills } = makeRetiredDeps();
+      const route = routes.find((r) => r.operationId === "skills.catalog.community")!;
+      const response = await route.handler(makeCtx({}));
+      expect(response.status).toBe(200);
+      expect(getCommunitySkills).toHaveBeenCalledOnce();
     });
   });
 });


### PR DESCRIPTION
## What

Retires the TypeScript-owned **scan-migrate** routes in `friday-scan-migrate-routes.ts`:
- `POST /v1/skills/scan-local` — multi-source local-skill discovery scan
- `POST /v1/skills/convert-batch` — per-item convert preview

Both fail-close by default/live: **503 `TS_RUNTIME_SCAN_MIGRATE_RETIRED`** (`classification: fail_closed`, `replacement: rust_owned_scan_migrate_entrypoint_required`) via `assertScanMigrateTestOracleAllowed(deps)` as the first handler statement. The `GET /v1/skills/catalog/community` read stays ungated.

## Classification = fail_closed (not compat_shim) — advisor-validated

Both routes are **non-mutating but execute Rust-ownable product logic**, so `compat_shim` (which asserts "does not execute product logic") would be a false assertion:
- `scan-local` → `scanLocalSkills` runs a multi-source filesystem **discovery algorithm** (scans `~/.claude`, `~/.cursor`, `~/.n8n`, `~/.codex`, `~/Projects`, parses + format-detects candidates, explicitly **excludes** Friday's own roots — it discovers third-party tools' skills, the opposite of a thin read of Friday state).
- `convert-batch` → `converterService.convert` per item (transform/codegen).

Precedent: `compat_shim` = thin read of Friday's stored state (e.g. `satellites.events.poll`); `fail_closed` = product-logic compute (e.g. cloud-worker `package.generate`, also non-mutating). Neither does third-party egress during the call (the n8n converter `fetch` is template-literal generated code, runs at skill-run time).

## Single user-triggerable surface each

`scanLocalSkills` and the `convertSkill` dep have **exactly one caller** (their route — verified by grep), so the proofs use the clean form. `convert-batch` is the **2nd of `converterService.convert`'s 3 surfaces** to be gated (`POST /v1/skills/convert` was retired in #558); remaining non-route callers are the operator-local CLI and the agent `skill_import` tool (the latter runs during an agent run — `agentRuntime.executeRun` reconciliation-scope, logged in the closure ledger; not a sibling route).

## Wiring / tests

`allowTestOnlyScanMigrateExecution` on the route deps; routes are hub-wired (`friday-hub-bootstrap` reads `config.allowTestOnlyScanMigrateExecution`); `FridayHubConfig` carries it. Production leaves it unset → fail-closes. **No RGG resolver and no e2e/hub-config plumbing needed** — the only driver is the unit test (verified: no e2e/integration/RGG/closure scenario POSTs these routes).

3 retirement regression tests (scan-local + convert-batch 503 + service-not-called; GET community catalog ungated); existing convert-batch happy-path tests set the flag.

## Review

correctness PASS; adversarial-integrity FAIL→FIXED (the convert_batch proof note initially said "only the CLI caller remains" — corrected to also acknowledge the agent `skill_import` tool, an agentRuntime reconciliation-scope caller).

Gate `ts_runtime_blocker` **17 → 15**; fail_closed 214 → 216. Full suite **12697 passed / 0 failed**, no type errors; lint clean; both secrets gates clean (no baseline change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)