### PR TITLE
fix(media): fail-close TS media-understanding analyze + doctor product logic

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -3541,6 +3541,32 @@
       "next_action": "Replace the fail-closed response with the Rust-owned batch-convert entrypoint when available."
     },
     {
+      "id": "media_understanding_analyze",
+      "route": {
+        "method": "POST",
+        "path": "/v1/media-understanding/analyze",
+        "operationId": "media.understanding.analyze"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-media-understanding-routes.ts media.understanding.analyze wires default/live to assertMediaTestOracleAllowed() AFTER the availability check (if !deps.service -> throwDisabled MEDIA_UNDERSTANDING_DISABLED) and AFTER parseAnalyzeBody + per-attachment normalizeAttachment (so disabled -> its 503 and malformed/non-http(s)/data: scheme -> 400 still win), IMMEDIATELY BEFORE deps.service.processAttachments. 503 TS_RUNTIME_MEDIA_UNDERSTANDING_RETIRED (classification fail_closed, replacement rust_owned_media_understanding_entrypoint_required). fail_closed NOT operator_external_adapter: processAttachments is a media-understanding PIPELINE (applyAttachmentPolicy -> runProviderChain over deps.providers + deps.fetchContent -> enrichment/decisions) — Rust-ownable product logic that Rust will reimplement (the provider calls move INTO Rust), the same shape as agent runs which call LLM providers and are fail_closed; it is NOT a permanent authorized egress-delivery conduit (the only operator_external_adapter exact surfaces are alert test-dispatch + session outbound). When retired it 503s and nothing egresses, so no un-redacted user media leaves. executes_product_logic:false: the pipeline does not run in default/live. processAttachments has exactly ONE user-triggerable call site (this route — verified by grep), so legacy behavior is reachable only through explicit allowTestOnlyMediaUnderstandingExecution test-oracle wiring (threaded CreateFridayApiRuntimeDeps -> inline createFridayMediaUnderstandingRoutes).",
+      "next_action": "Replace the fail-closed response with the Rust-owned media-understanding analyze entrypoint when available."
+    },
+    {
+      "id": "media_understanding_doctor",
+      "route": {
+        "method": "POST",
+        "path": "/v1/media-understanding/doctor",
+        "operationId": "media.understanding.doctor"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-media-understanding-routes.ts media.understanding.doctor wires default/live to assertMediaTestOracleAllowed() AFTER the availability check (if !deps.doctorProvider -> throwDisabled) and AFTER parseDoctorBody (malformed -> 400), IMMEDIATELY BEFORE probeMediaUnderstandingProvider. 503 TS_RUNTIME_MEDIA_UNDERSTANDING_RETIRED. fail_closed: a provider CONNECTIVITY/capability probe is product logic (verifying the media-understanding capability), not a read of Friday's own stored state (so not compat_shim) and not an egress-delivery conduit (so not operator_external_adapter) — same fail_closed rule as the analyze pipeline. executes_product_logic:false: no probe runs in default/live. probeMediaUnderstandingProvider has exactly ONE user-triggerable call site (this route — verified by grep). Reachable only through explicit allowTestOnlyMediaUnderstandingExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned media-understanding doctor entrypoint when available."
+    },
+    {
       "id": "realtime_subscribe_read",
       "route": {
         "method": "POST",

--- a/src/api/http/routes/friday-media-understanding-routes.ts
+++ b/src/api/http/routes/friday-media-understanding-routes.ts
@@ -43,6 +43,18 @@ export interface FridayMediaUnderstandingRoutesDeps {
   readonly disabledReason: string | null;
   /** Optional clock injection for tests / determinism. */
   readonly nowIso?: () => string;
+  /**
+   * Test-oracle only: allow the legacy TypeScript media-understanding product
+   * logic (provider-orchestrating analyze pipeline + provider connectivity
+   * doctor probe) to execute. Production/runtime callers must leave this unset
+   * so both POST routes fail-close (503 TS_RUNTIME_MEDIA_UNDERSTANDING_RETIRED)
+   * until Rust owns media understanding. fail_closed (not operator_external_
+   * adapter): the route's purpose is media understanding product logic that
+   * Rust will reimplement — calling providers does NOT make it an external
+   * egress conduit (same as agent runs, which call LLM providers and are
+   * fail_closed); when retired it 503s and nothing egresses.
+   */
+  readonly allowTestOnlyMediaUnderstandingExecution?: boolean;
 }
 
 // ─── Request / response shapes ───
@@ -100,6 +112,27 @@ export function createFridayMediaUnderstandingRoutes(
     );
   }
 
+  // TS-runtime retirement: the media-understanding product logic (analyze
+  // pipeline + doctor provider probe) fail-closes by default/live. Placed AFTER
+  // the availability check and body parse, immediately before the provider call,
+  // so disabled -> MEDIA_UNDERSTANDING_DISABLED and malformed -> 400 still win.
+  function assertMediaTestOracleAllowed(): never | void {
+    if (deps.allowTestOnlyMediaUnderstandingExecution === true) {
+      return;
+    }
+    throw new FridayDomainError(
+      "TS_RUNTIME_MEDIA_UNDERSTANDING_RETIRED",
+      "Media understanding (attachment analysis + provider doctor) is fail-closed in the default/live runtime; the Rust-owned media-understanding entrypoint is required.",
+      {
+        httpStatus: 503,
+        details: {
+          classification: "fail_closed",
+          replacement: "rust_owned_media_understanding_entrypoint_required",
+        },
+      },
+    );
+  }
+
   return [
     {
       operationId: "media.understanding.doctor",
@@ -111,6 +144,7 @@ export function createFridayMediaUnderstandingRoutes(
           throwDisabled();
         }
         const body = parseDoctorBody(ctx.body);
+        assertMediaTestOracleAllowed();
         const report = await probeMediaUnderstandingProvider(deps.doctorProvider, {
           testImageBase64: body.testImageBase64,
           testImageMimeType: body.testImageMimeType,
@@ -133,6 +167,7 @@ export function createFridayMediaUnderstandingRoutes(
         const attachments = body.attachments.map((raw, index) =>
           normalizeAttachment(raw, index),
         );
+        assertMediaTestOracleAllowed();
         const result = await deps.service.processAttachments(attachments);
         return { result };
       },

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -3135,6 +3135,7 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
     doctorProvider: mediaUnderstandingDeps.doctorProvider,
     disabledReason: mediaUnderstandingDeps.disabledReason,
     nowIso: deps.nowIso,
+    allowTestOnlyMediaUnderstandingExecution: deps.allowTestOnlyMediaUnderstandingExecution,
   })) {
     routes.register(route);
   }

--- a/src/api/runtime/friday-api-runtime.types.ts
+++ b/src/api/runtime/friday-api-runtime.types.ts
@@ -355,6 +355,13 @@ export interface CreateFridayApiRuntimeDeps {
    * Rust owns skill conversion.
    */
   allowTestOnlySkillConverterExecution?: boolean;
+  /**
+   * Test-oracle only: allow the legacy TypeScript media-understanding product
+   * logic (POST /v1/media-understanding/analyze + /doctor). Production/runtime
+   * callers must leave this unset so those surfaces fail-close until Rust owns
+   * media understanding.
+   */
+  allowTestOnlyMediaUnderstandingExecution?: boolean;
   /** Optional: Reflex service for deterministic preference writes before agent runs. */
   reflexService?: FridayReflexService;
   /** Optional deterministic runtime capability getter used by context evidence selection. */

--- a/test/unit/api/routes/friday-media-understanding-routes.test.ts
+++ b/test/unit/api/routes/friday-media-understanding-routes.test.ts
@@ -43,6 +43,9 @@ function makeDeps(overrides: Partial<FridayMediaUnderstandingRoutesDeps> = {}): 
     doctorProvider: makeStubProvider(),
     disabledReason: null,
     nowIso: () => "2026-05-13T00:00:00Z",
+    // Test-oracle flag: the enabled-path tests below exercise the live provider
+    // pipeline. Production wiring leaves this unset (TS-runtime retirement).
+    allowTestOnlyMediaUnderstandingExecution: true,
     ...overrides,
   };
 }
@@ -390,5 +393,92 @@ describe("createFridayMediaUnderstandingRoutes — analyze enabled", () => {
     }) as never);
     const calledWith = (deps.service!.processAttachments as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(calledWith[0].mediaType).toBe("audio");
+  });
+});
+
+// ─── TS-runtime retirement (default/live fail-close) ───
+
+describe("createFridayMediaUnderstandingRoutes — TS-runtime retirement", () => {
+  // ENABLED deps but WITHOUT the test-oracle flag = production/live wiring.
+  function makeRetiredDeps(): FridayMediaUnderstandingRoutesDeps {
+    return {
+      service: makeStubService(),
+      doctorProvider: makeStubProvider(),
+      disabledReason: null,
+      nowIso: () => "2026-05-13T00:00:00Z",
+    };
+  }
+
+  it("fail-closes doctor with 503 TS_RUNTIME_MEDIA_UNDERSTANDING_RETIRED and does not probe", async () => {
+    const deps = makeRetiredDeps();
+    const routes = createFridayMediaUnderstandingRoutes(deps);
+    const doctor = findRoute(routes, "media.understanding.doctor");
+    let thrown: unknown = null;
+    try {
+      await doctor.handler(makeCtx({ body: {} }) as never);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(FridayDomainError);
+    const e = thrown as FridayDomainError;
+    expect(e.code).toBe("TS_RUNTIME_MEDIA_UNDERSTANDING_RETIRED");
+    expect(e.httpStatus).toBe(503);
+    expect(deps.doctorProvider!.process).not.toHaveBeenCalled();
+  });
+
+  it("fail-closes analyze with 503 and does not call processAttachments", async () => {
+    const deps = makeRetiredDeps();
+    const routes = createFridayMediaUnderstandingRoutes(deps);
+    const analyze = findRoute(routes, "media.understanding.analyze");
+    let thrown: unknown = null;
+    try {
+      await analyze.handler(makeCtx({
+        body: { attachments: [{ mimeType: "image/png", sizeBytes: 1, sourceUrl: "https://x/img.png" }] },
+      }) as never);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(FridayDomainError);
+    const e = thrown as FridayDomainError;
+    expect(e.code).toBe("TS_RUNTIME_MEDIA_UNDERSTANDING_RETIRED");
+    expect(e.httpStatus).toBe(503);
+    expect(deps.service!.processAttachments).not.toHaveBeenCalled();
+  });
+
+  it("still validates the analyze body (400) BEFORE the retirement guard", async () => {
+    const deps = makeRetiredDeps();
+    const routes = createFridayMediaUnderstandingRoutes(deps);
+    const analyze = findRoute(routes, "media.understanding.analyze");
+    let thrown: unknown = null;
+    try {
+      // non-http(s) scheme -> VALIDATION_ERROR 400 before the 503 guard
+      await analyze.handler(makeCtx({
+        body: { attachments: [{ mimeType: "image/png", sizeBytes: 1, sourceUrl: "file:///etc/passwd" }] },
+      }) as never);
+    } catch (err) {
+      thrown = err;
+    }
+    const e = thrown as FridayDomainError;
+    expect(e.code).toBe("VALIDATION_ERROR");
+    expect(e.httpStatus).toBe(400);
+    expect(deps.service!.processAttachments).not.toHaveBeenCalled();
+  });
+
+  it("still surfaces MEDIA_UNDERSTANDING_DISABLED (not the retirement 503) when disabled", async () => {
+    // Disabled (service/provider null) WITHOUT the flag: the availability check
+    // throws before the retirement guard.
+    const routes = createFridayMediaUnderstandingRoutes(makeDisabledDeps("FRIDAY_MEDIA_UNDERSTANDING_ENABLED is not set to true"));
+    const analyze = findRoute(routes, "media.understanding.analyze");
+    let thrown: unknown = null;
+    try {
+      await analyze.handler(makeCtx({
+        body: { attachments: [{ mimeType: "image/png", sizeBytes: 1, sourceUrl: "https://x/img.png" }] },
+      }) as never);
+    } catch (err) {
+      thrown = err;
+    }
+    const e = thrown as FridayDomainError;
+    expect(e.code).toBe("MEDIA_UNDERSTANDING_DISABLED");
+    expect(e.httpStatus).toBe(503);
   });
 });


### PR DESCRIPTION
## What

Retires the TypeScript-owned **media-understanding** routes in `friday-media-understanding-routes.ts`:
- `POST /v1/media-understanding/analyze` — provider-orchestrating analyze pipeline
- `POST /v1/media-understanding/doctor` — provider connectivity/capability probe

Both fail-close: **503 `TS_RUNTIME_MEDIA_UNDERSTANDING_RETIRED`** (`classification: fail_closed`, `replacement: rust_owned_media_understanding_entrypoint_required`) via `assertMediaTestOracleAllowed()`, placed AFTER the availability check (`if !deps.service/!deps.doctorProvider → throwDisabled MEDIA_UNDERSTANDING_DISABLED`) and AFTER body parse + attachment normalization, immediately before the provider call — so **disabled → its 503** and **malformed / non-http(s) / data: scheme → 400** still win.

## Classification = fail_closed (not operator_external_adapter) — advisor + adversarial-review validated

The discriminating constraint is *"permanent authorized egress conduit vs TS product logic Rust will reimplement"*. analyze runs a media-understanding **pipeline** (`applyAttachmentPolicy → runProviderChain over providers + fetchContent → enrichment/decisions`); doctor probes provider connectivity. Both are Rust-ownable product logic whose provider calls move *into* Rust — the **same shape as agent runs** (which ship user conversation to LLM providers and are fail_closed). The review confirmed against precedent: the only exact `operator_external_adapter` surfaces are `alerts.test.dispatch` + `sessions.outbound` (egress-**delivery** conduits, `next_action: keep as adapter`), while provider-calling *product-logic* routes like `observability.heartbeat.trigger` are fail_closed (`next_action: replace with Rust entrypoint`). Classifying media as operator_external_adapter would be the *dishonest* move (exempting product logic from retirement, leaving user media egressing to the provider from TS indefinitely). When retired the route 503s and nothing egresses — leak-controls are moot in the retired state.

## Single surface, wiring, tests

`processAttachments` and `probeMediaUnderstandingProvider` have exactly one caller each (their route — verified; no agent-tool/channel consumer). `allowTestOnlyMediaUnderstandingExecution` threaded `CreateFridayApiRuntimeDeps` → inline `createFridayMediaUnderstandingRoutes`. Production leaves it unset → fail-closes. **No RGG resolver / no e2e/hub plumbing** — the only handler-driver is the route unit test (the extra-route-registration test exercises only the disabled state; service-level tests call the service/probe directly).

4 retirement regression tests (doctor + analyze 503 + provider-not-called; validation-400-before-guard; disabled-still-`MEDIA_UNDERSTANDING_DISABLED`); enabled-path tests set the flag on `makeDeps()`.

## Review

correctness PASS; adversarial-integrity PASS (classification validated against precedent; no second ungated surface; disabled/400 ordering preserved; no test weakening; no CI-red driver).

Gate `ts_runtime_blocker` **15 → 13**; fail_closed 216 → 218. Full suite **12701 passed / 0 failed**, no type errors; lint clean; both secrets gates clean (no baseline change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)