### PR TITLE
fix(fleet): fail-close TS satellite remediation execute mutation

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -3567,6 +3567,19 @@
       "next_action": "Replace the fail-closed response with the Rust-owned media-understanding doctor entrypoint when available."
     },
     {
+      "id": "fleet_satellite_remediation_execute",
+      "route": {
+        "method": "POST",
+        "path": "/v1/fleet/satellites/:satelliteId/remediation/:actionId/execute",
+        "operationId": "fleet.execute.satellite.remediation"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-fleet-routes.ts fleet.execute.satellite.remediation wires default/live to assertFleetRemediationTestOracleAllowed(deps) AFTER the canonical-approval gate requireFleetRemediationTicket (unapproved -> 403 CANONICAL_APPROVAL_REQUIRED/DENIED) and IMMEDIATELY BEFORE deps.fleetService.executeSatelliteRemediationAction. 503 TS_RUNTIME_FLEET_REMEDIATION_RETIRED (classification fail_closed, replacement rust_owned_fleet_remediation_entrypoint_required). The mutation performs non-destructive local SQLite remediation status updates (requeue/expire leases) — a user-triggerable mutation, no third-party egress, so fail_closed not operator_external_adapter; GET fleet reads stay compat_shim. executes_product_logic:false: no remediation runs in default/live. executeSatelliteRemediationAction has exactly ONE user-triggerable call site (this route — verified by grep; the full-e2e + closure fleet steps are GET reads, they do NOT POST remediation), so legacy behavior is reachable only through explicit allowTestOnlyFleetRemediationExecution test-oracle wiring (threaded CreateFridayApiRuntimeDeps -> inline createFridayFleetRoutes).",
+      "next_action": "Replace the fail-closed response with the Rust-owned fleet remediation entrypoint when available."
+    },
+    {
       "id": "realtime_subscribe_read",
       "route": {
         "method": "POST",

--- a/src/api/http/routes/friday-fleet-routes.ts
+++ b/src/api/http/routes/friday-fleet-routes.ts
@@ -20,6 +20,36 @@ const FLEET_MAX_LIST_LIMIT = 100;
 export interface FridayFleetRoutesDeps {
   fleetService: FridayFleetDashboardService;
   canonicalMutationGate?: FridayMutatingActionGate;
+  /**
+   * Test-oracle only: allow the legacy TypeScript fleet satellite remediation
+   * execute mutation. Production/runtime callers must leave this unset so the
+   * route fail-closes (503 TS_RUNTIME_FLEET_REMEDIATION_RETIRED) until Rust owns
+   * fleet remediation. GET fleet reads are never gated.
+   */
+  allowTestOnlyFleetRemediationExecution?: boolean;
+}
+
+/**
+ * TS-runtime retirement guard for the fleet remediation execute mutation.
+ * Placed AFTER the canonical-approval gate (requireFleetRemediationTicket -> 403)
+ * and IMMEDIATELY BEFORE executeSatelliteRemediationAction, so an unapproved
+ * request still surfaces its 403 rather than this 503.
+ */
+function assertFleetRemediationTestOracleAllowed(deps: FridayFleetRoutesDeps): void {
+  if (deps.allowTestOnlyFleetRemediationExecution === true) {
+    return;
+  }
+  throw new FridayDomainError(
+    "TS_RUNTIME_FLEET_REMEDIATION_RETIRED",
+    "Fleet satellite remediation execution is fail-closed in the default/live runtime; the Rust-owned fleet remediation entrypoint is required.",
+    {
+      httpStatus: 503,
+      details: {
+        classification: "fail_closed",
+        replacement: "rust_owned_fleet_remediation_entrypoint_required",
+      },
+    },
+  );
 }
 
 export function createFridayFleetRemediationMutatingActionRequest(input: {
@@ -239,6 +269,7 @@ export function createFridayFleetRoutes(
           actor: createActorFromPrincipal(ctx.principal, `api:${ctx.requestId}`),
           surface: "api:/v1/fleet/satellites/remediation/execute",
         });
+        assertFleetRemediationTestOracleAllowed(deps);
         const result = await deps.fleetService.executeSatelliteRemediationAction({
           satelliteId,
           actionId,

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -2828,7 +2828,7 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
   }
 
   // Register fleet routes
-  for (const route of createFridayFleetRoutes({ fleetService: fleet, canonicalMutationGate })) {
+  for (const route of createFridayFleetRoutes({ fleetService: fleet, canonicalMutationGate, allowTestOnlyFleetRemediationExecution: deps.allowTestOnlyFleetRemediationExecution })) {
     routes.register(route);
   }
 

--- a/src/api/runtime/friday-api-runtime.types.ts
+++ b/src/api/runtime/friday-api-runtime.types.ts
@@ -362,6 +362,13 @@ export interface CreateFridayApiRuntimeDeps {
    * media understanding.
    */
   allowTestOnlyMediaUnderstandingExecution?: boolean;
+  /**
+   * Test-oracle only: allow the legacy TypeScript fleet satellite remediation
+   * execute mutation (POST /v1/fleet/satellites/:id/remediation/:actionId/execute).
+   * Production/runtime callers must leave this unset so the route fail-closes
+   * until Rust owns fleet remediation.
+   */
+  allowTestOnlyFleetRemediationExecution?: boolean;
   /** Optional: Reflex service for deterministic preference writes before agent runs. */
   reflexService?: FridayReflexService;
   /** Optional deterministic runtime capability getter used by context evidence selection. */

--- a/test/unit/api/http/routes/friday-fleet-routes.test.ts
+++ b/test/unit/api/http/routes/friday-fleet-routes.test.ts
@@ -141,6 +141,9 @@ describe("FridayFleetRoutes", () => {
         nowIso: () => NOW,
         ticketIdGenerator: () => "ticket-1",
       }),
+      // Test-oracle flag: the remediation-execute success test below exercises the
+      // live mutation. Production wiring leaves this unset (TS-runtime retirement).
+      allowTestOnlyFleetRemediationExecution: true,
     });
   });
 
@@ -315,5 +318,62 @@ describe("FridayFleetRoutes", () => {
     expect((result as FridayFleetRemediationActionExecutionResult).status).toBe("completed");
     expect((result as FridayFleetRemediationActionExecutionResult).canonicalGate?.ticketId).toBe("ticket-1");
     expect(outboxQueueService.requeueExpiredLeases).toHaveBeenCalledTimes(1);
+  });
+
+  describe("TS-runtime retirement (default/live fail-close)", () => {
+    // Build routes WITHOUT the test-oracle flag = production/live wiring.
+    function makeRetiredRoutes() {
+      return createFridayFleetRoutes({
+        fleetService,
+        canonicalMutationGate: createFridayMutatingActionGate({
+          nowIso: () => NOW,
+          ticketIdGenerator: () => "ticket-1",
+        }),
+      });
+    }
+
+    it("fail-closes remediation execute with 503 (after a VALID approval) and does not run the action", async () => {
+      insertSatellite("sat-1", "degraded");
+      insertOutboxMessage("msg-exec", "sat-1", "failed");
+      const retiredRoutes = makeRetiredRoutes();
+      const route = retiredRoutes.find((r) => r.operationId === "fleet.execute.satellite.remediation")!;
+      const ctx = makeCtx({
+        params: { satelliteId: "sat-1", actionId: "requeue_expired_leases" },
+        body: {
+          planDigest: PLAN_DIGEST,
+          canonicalApproval: makeApproval({
+            satelliteId: "sat-1",
+            actionId: "requeue_expired_leases",
+            surface: "api:/v1/fleet/satellites/remediation/execute",
+          }),
+        },
+        principal: {
+          principalType: "user", principalId: "user-1", userId: "user-1", role: "admin",
+          scopes: ["hub.admin"], tokenId: "tok-1", tokenKind: "access", issuedAt: NOW,
+        },
+      });
+      await expect(route.handler(ctx)).rejects.toMatchObject({
+        code: "TS_RUNTIME_FLEET_REMEDIATION_RETIRED",
+        httpStatus: 503,
+      });
+      expect(outboxQueueService.requeueExpiredLeases).not.toHaveBeenCalled();
+    });
+
+    it("still enforces canonical approval (403) BEFORE the retirement guard", async () => {
+      insertSatellite("sat-1", "degraded");
+      const retiredRoutes = makeRetiredRoutes();
+      const route = retiredRoutes.find((r) => r.operationId === "fleet.execute.satellite.remediation")!;
+      // No canonicalApproval -> approval gate rejects before the 503.
+      const ctx = makeCtx({
+        params: { satelliteId: "sat-1", actionId: "requeue_expired_leases" },
+        body: { planDigest: PLAN_DIGEST },
+        principal: {
+          principalType: "user", principalId: "user-1", userId: "user-1", role: "admin",
+          scopes: ["hub.admin"], tokenId: "tok-1", tokenKind: "access", issuedAt: NOW,
+        },
+      });
+      await expect(route.handler(ctx)).rejects.toMatchObject({ httpStatus: 403 });
+      expect(outboxQueueService.requeueExpiredLeases).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## What

Retires the TypeScript-owned fleet remediation execute route in `friday-fleet-routes.ts`:
- `POST /v1/fleet/satellites/:satelliteId/remediation/:actionId/execute`

Fail-closes by default/live: **503 `TS_RUNTIME_FLEET_REMEDIATION_RETIRED`** (`classification: fail_closed`, `replacement: rust_owned_fleet_remediation_entrypoint_required`) via `assertFleetRemediationTestOracleAllowed(deps)`, placed **AFTER** the canonical-approval gate `requireFleetRemediationTicket` (unapproved → 403) and **immediately before** `deps.fleetService.executeSatelliteRemediationAction`. GET fleet reads stay ungated.

## Classification = fail_closed

A user-triggerable mutation that does non-destructive local SQLite remediation status updates (requeue/expire leases), **no third-party egress** → fail_closed, not operator_external_adapter; not a read so not compat_shim. `executeSatelliteRemediationAction` has **exactly one** user-triggerable call site (this route — the full-e2e + closure fleet steps are GET reads, not POST execute).

## Wiring / tests / RGG

`allowTestOnlyFleetRemediationExecution` threaded `CreateFridayApiRuntimeDeps` → inline `createFridayFleetRoutes`. Production leaves it unset → fail-closes. **No RGG resolver** (no validation/real-world scenario POSTs this route) and **no e2e/hub plumbing** (only the unit test drives the route; the service-level test calls the service directly).

2 retirement regression tests (approved → 503 + action-not-run; unapproved → 403 before the guard); the success test sets the flag in `beforeEach`.

## Review

correctness PASS + adversarial-integrity PASS (local-only mutation; single route caller; no ungated WS/channel/scheduler path; no other CI driver POSTs the route; no test weakening).

Gate `ts_runtime_blocker` **13 → 12**. Full suite **12703 passed / 0 failed**, no type errors; lint clean; both secrets gates clean (no baseline change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)