### PR TITLE
fix(discovery): fail-close TS program-discovery scan + policy + integrate + recommend

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -3580,6 +3580,42 @@
       "next_action": "Replace the fail-closed response with the Rust-owned fleet remediation entrypoint when available."
     },
     {
+      "id": "discovery_scan",
+      "route": { "method": "POST", "path": "/v1/discovery/scan", "operationId": "discovery.scan" },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-discovery-routes.ts discovery.scan wires default/live to assertDiscoveryTestOracleAllowed(deps) as the FIRST handler statement, immediately before deps.discovery.discover(). 503 TS_RUNTIME_DISCOVERY_RETIRED (classification fail_closed, replacement rust_owned_discovery_entrypoint_required). Non-mutating but fail_closed not compat_shim: discover() runs a multi-source local-program DISCOVERY algorithm (FS enumeration + recommendation engine) — Rust-ownable product-logic compute, not a thin read of Friday stored state (same precedent as skills.scan-local #559). No third-party egress. executes_product_logic:false: the scanner FS-enumeration runs ONLY via discovery.discover(), whose callers are this scan route + recommend()'s cache-miss fallback (reached by the GET /v1/discovery/recommendations, ALSO gated under this flag — surface discovery_recommend) + integrate (which 404s on a cold cache before reaching recommend) — ALL gated, so no scan runs in default/live. Reachable only through explicit allowTestOnlyDiscoveryExecution test-oracle wiring (inline createFridayDiscoveryRoutes).",
+      "next_action": "Replace the fail-closed response with the Rust-owned program-discovery scan entrypoint when available."
+    },
+    {
+      "id": "discovery_policy_update",
+      "route": { "method": "PATCH", "path": "/v1/discovery/policy", "operationId": "discovery.policy.update" },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-discovery-routes.ts discovery.policy.update wires default/live to assertDiscoveryTestOracleAllowed(deps) AFTER the body field-validation (typed enabled/refresh/excluded-paths updates) and IMMEDIATELY BEFORE deps.discovery.setPolicy(updates). 503 TS_RUNTIME_DISCOVERY_RETIRED. User-triggerable mutation of the discovery policy (controls enable/disable of the discovery product logic), so fail_closed; GET /v1/discovery/policy read stays compat_shim. executes_product_logic:false: no policy mutation in default/live. setPolicy has one user-triggerable call site (this route). Reachable only through explicit allowTestOnlyDiscoveryExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned discovery policy entrypoint when available."
+    },
+    {
+      "id": "discovery_integrate",
+      "route": { "method": "POST", "path": "/v1/discovery/integrate", "operationId": "discovery.integrate" },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-discovery-integration-routes.ts discovery.integrate wires default/live to a TS_RUNTIME_DISCOVERY_RETIRED guard AFTER the availability check (!discovery/!converterService/!canonicalMutationGate -> 503 DISCOVERY_INTEGRATION_DISABLED), the catalog/program 404s, the recommend() lookup, AND the canonicalMutationGate.evaluate -> 403 (unapproved), IMMEDIATELY BEFORE deps.converterService.import (candidate staging). 503 TS_RUNTIME_DISCOVERY_RETIRED. fail_closed. SCOPE NOTE (route-scoped): the underlying converterService.import method is ALSO reached by /v1/skills/import (#558 GATED), /v1/skills/social-import, and /v1/deeplink/apply (their own slices) — this surface gates ONLY /v1/discovery/integrate and does NOT claim converterService.import globally unreachable. The GET /v1/discovery/recommendations (operationId discovery.recommend) is ALSO gated under this same flag (see surface discovery_recommend) because recommend() falls back to this.discover() (the scanner FS-enumeration) on a cache miss and scan can no longer warm the cache in default/live — so the discovery scan product logic is FULLY closed across scan + recommend-GET + integrate. Reachable only through explicit allowTestOnlyDiscoveryExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned discovery integration entrypoint when available; retire the sibling converterService.import routes (social-import, deeplink/apply) in their own slices to fully gate the method."
+    },
+    {
+      "id": "discovery_recommend",
+      "route": { "method": "GET", "path": "/v1/discovery/recommendations", "operationId": "discovery.recommend" },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-discovery-routes.ts discovery.recommend (GET /v1/discovery/recommendations) is EXACT-classified fail_closed (overriding the default GET=compat_shim family rule) because it is NOT a thin read: deps.discovery.recommend(filter) falls back to this.discover() (the scanner FS-enumeration product logic) on a cache MISS (friday-program-discovery-service.ts recommend -> cachedCatalog ?? this.discover()), and since discovery.scan is now fail-closed it can never warm the cache in default/live — so an unguarded GET would deterministically EXECUTE the retired scan after every restart. The handler wires assertDiscoveryTestOracleAllowed(deps) after the query-filter parse and IMMEDIATELY BEFORE deps.discovery.recommend(filter); 503 TS_RUNTIME_DISCOVERY_RETIRED. This closes the last default/live path to the scan product logic (so the discovery_scan proof's executes_product_logic:false holds). Caught by the slice's adversarial integrity review. With a warm cache (test-oracle flag set) it is a recommendation read-derive; in default/live it fail-closes. Reachable only through explicit allowTestOnlyDiscoveryExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned discovery recommendation entrypoint when available."
+    },
+    {
       "id": "realtime_subscribe_read",
       "route": {
         "method": "POST",

--- a/src/api/http/routes/friday-discovery-integration-routes.ts
+++ b/src/api/http/routes/friday-discovery-integration-routes.ts
@@ -30,6 +30,13 @@ export interface FridayDiscoveryIntegrationRoutesDeps {
   readonly converterService: FridaySkillConverterService | null;
   readonly canonicalMutationGate: FridayMutatingActionGate | null;
   readonly disabledReason: string | null;
+  /**
+   * Test-oracle only (shares the discovery flag): allow the legacy TypeScript
+   * discovery.integrate mutation (recommend + converterService.import staging).
+   * Production/runtime callers must leave this unset so the route fail-closes
+   * (503 TS_RUNTIME_DISCOVERY_RETIRED) until Rust owns discovery integration.
+   */
+  readonly allowTestOnlyDiscoveryExecution?: boolean;
 }
 
 const SURFACE = "api:/v1/discovery/integrate";
@@ -137,6 +144,25 @@ export function createFridayDiscoveryIntegrationRoutes(
           });
         }
 
+        // TS-runtime retirement: fail-close the integrate staging mutation AFTER
+        // the canonical-approval gate (above) and IMMEDIATELY BEFORE the
+        // converterService.import write. Route-scoped: this gates ONLY
+        // /v1/discovery/integrate; the same converterService.import method is
+        // reached by /v1/skills/import (#558, gated) + /v1/skills/social-import +
+        // /v1/deeplink/apply (their own slices). Shares allowTestOnlyDiscoveryExecution.
+        if (deps.allowTestOnlyDiscoveryExecution !== true) {
+          throw new FridayDomainError(
+            "TS_RUNTIME_DISCOVERY_RETIRED",
+            "Discovery program integration is fail-closed in the default/live runtime; the Rust-owned discovery entrypoint is required.",
+            {
+              httpStatus: 503,
+              details: {
+                classification: "fail_closed",
+                replacement: "rust_owned_discovery_entrypoint_required",
+              },
+            },
+          );
+        }
         const importResult = await deps.converterService.import({
           source: bridgeResult.source,
           formatHint: "friday-package",

--- a/src/api/http/routes/friday-discovery-routes.ts
+++ b/src/api/http/routes/friday-discovery-routes.ts
@@ -28,12 +28,45 @@ export interface FridayDiscoveryRoutesDeps {
     setPolicy(policy: Partial<FridayDiscoveryPolicy>): void;
     isEnabled(): boolean;
   };
+  /**
+   * Test-oracle only: allow the legacy TypeScript discovery product-logic
+   * mutations (scan = local-program discovery algorithm; policy.update =
+   * in-memory policy mutation; integrate is in friday-discovery-integration-
+   * routes.ts under the same flag). Production/runtime callers must leave this
+   * unset so those POST/PATCH routes fail-close (503 TS_RUNTIME_DISCOVERY_RETIRED)
+   * until Rust owns discovery. The GET catalog/programs/recommendations/policy/
+   * status reads are never gated (recommend() product-logic is still reachable
+   * via the GET /v1/discovery/recommendations read-derive — route-scoped).
+   */
+  allowTestOnlyDiscoveryExecution?: boolean;
 }
 
 // ─── Helpers ───
 
 type Ctx = FridayHttpContext<unknown, Record<string, string>, unknown>;
 type Route = FridayRouteDefinition<unknown, Record<string, string>, unknown, unknown>;
+
+/**
+ * TS-runtime retirement guard for the discovery product-logic routes (scan +
+ * policy.update here; integrate in the integration-routes file). Placed AFTER
+ * any body validation and IMMEDIATELY BEFORE the discovery service call.
+ */
+function assertDiscoveryTestOracleAllowed(deps: { allowTestOnlyDiscoveryExecution?: boolean }): void {
+  if (deps.allowTestOnlyDiscoveryExecution === true) {
+    return;
+  }
+  throw new FridayDomainError(
+    "TS_RUNTIME_DISCOVERY_RETIRED",
+    "Program discovery scan and policy mutation are fail-closed in the default/live runtime; the Rust-owned discovery entrypoint is required.",
+    {
+      httpStatus: 503,
+      details: {
+        classification: "fail_closed",
+        replacement: "rust_owned_discovery_entrypoint_required",
+      },
+    },
+  );
+}
 
 // ─── Factory ───
 
@@ -48,6 +81,7 @@ export function createFridayDiscoveryRoutes(
       path: "/v1/discovery/scan",
       auth: { public: true },
       handler: async (_ctx: Ctx) => {
+        assertDiscoveryTestOracleAllowed(deps);
         const catalog = await deps.discovery.discover();
         return {
           status: 200,
@@ -140,6 +174,13 @@ export function createFridayDiscoveryRoutes(
         if (query.integrationPath) filter.integrationPath = query.integrationPath as FridayDiscoveryFilterOptions["integrationPath"];
         if (query.q) filter.query = query.q;
 
+        // TS-runtime retirement: this GET is normally a read, but recommend() falls
+        // back to this.discover() (the scanner FS-enumeration) on a cache MISS — and
+        // since discovery.scan is now fail-closed it can never warm the cache in
+        // default/live, so an unguarded GET would deterministically execute the
+        // retired scan product logic after every restart. Gate it under the same
+        // discovery flag so the scan algorithm is fully closed in default/live.
+        assertDiscoveryTestOracleAllowed(deps);
         const result = await deps.discovery.recommend(filter);
         return { status: 200, body: result };
       },
@@ -174,6 +215,7 @@ export function createFridayDiscoveryRoutes(
         if (Array.isArray(body.excludedProgramIds)) updates.excludedProgramIds = body.excludedProgramIds;
         if (typeof body.redactSensitiveDetails === "boolean") updates.redactSensitiveDetails = body.redactSensitiveDetails;
 
+        assertDiscoveryTestOracleAllowed(deps);
         deps.discovery.setPolicy(updates as Partial<FridayDiscoveryPolicy>);
         const policy = deps.discovery.getPolicy();
         return { status: 200, body: { policy } };

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -3007,7 +3007,7 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
 
   // Register local discovery routes (optional)
   for (const route of deps.discovery
-    ? createFridayDiscoveryRoutes(deps.discovery)
+    ? createFridayDiscoveryRoutes({ ...deps.discovery, allowTestOnlyDiscoveryExecution: deps.allowTestOnlyDiscoveryExecution })
     : createFridayDiscoveryDisabledRoutes()) {
     routes.register(route as unknown as Parameters<typeof routes.register>[0]);
   }
@@ -3018,6 +3018,7 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
     converterService: deps.converterService ?? null,
     canonicalMutationGate: deps.discovery ? canonicalMutationGate : null,
     disabledReason: deps.discovery ? null : "discovery service not provided",
+    allowTestOnlyDiscoveryExecution: deps.allowTestOnlyDiscoveryExecution,
   })) {
     routes.register(route as unknown as Parameters<typeof routes.register>[0]);
   }

--- a/src/api/runtime/friday-api-runtime.types.ts
+++ b/src/api/runtime/friday-api-runtime.types.ts
@@ -369,6 +369,13 @@ export interface CreateFridayApiRuntimeDeps {
    * until Rust owns fleet remediation.
    */
   allowTestOnlyFleetRemediationExecution?: boolean;
+  /**
+   * Test-oracle only: allow the legacy TypeScript discovery product-logic
+   * routes (POST /v1/discovery/scan, PATCH /v1/discovery/policy, POST
+   * /v1/discovery/integrate). Production/runtime callers must leave this unset
+   * so those surfaces fail-close until Rust owns discovery.
+   */
+  allowTestOnlyDiscoveryExecution?: boolean;
   /** Optional: Reflex service for deterministic preference writes before agent runs. */
   reflexService?: FridayReflexService;
   /** Optional deterministic runtime capability getter used by context evidence selection. */

--- a/test/unit/api/http/routes/friday-discovery-routes.test.ts
+++ b/test/unit/api/http/routes/friday-discovery-routes.test.ts
@@ -55,6 +55,58 @@ describe("createFridayDiscoveryRoutes", () => {
     expect(byId.get("discovery.policy.get")?.auth).toMatchObject({ public: true });
     expect(byId.get("discovery.policy.update")?.auth).toMatchObject({ public: true });
   });
+
+  describe("TS-runtime retirement (default/live fail-close)", () => {
+    function makeDiscoveryStub() {
+      return {
+        discover: vi.fn(async () => ({ id: "c1", platform: "darwin", generatedAt: "t", scanDurationMs: 1, scanErrors: [], programs: [] })),
+        getCachedCatalog: vi.fn(() => null),
+        recommend: vi.fn(async () => ({ catalogId: "c1", generatedAt: "t", recommendations: [] })),
+        getPolicy: vi.fn(() => ({ enabled: true, scheduledRefreshEnabled: false, refreshIntervalMs: 0, excludedPaths: [], excludedProgramIds: [], redactSensitiveDetails: true })),
+        setPolicy: vi.fn(),
+        isEnabled: vi.fn(() => true),
+      };
+    }
+    const ctx = { params: {}, query: {}, body: {}, headers: {}, principal: { principalId: "u1" } } as never;
+
+    it("fail-closes discovery.scan with 503 TS_RUNTIME_DISCOVERY_RETIRED and does not scan", async () => {
+      const discovery = makeDiscoveryStub();
+      const routes = createFridayDiscoveryRoutes({ discovery });
+      const scan = routes.find((r) => r.operationId === "discovery.scan")!;
+      await expect(scan.handler(ctx)).rejects.toMatchObject({ code: "TS_RUNTIME_DISCOVERY_RETIRED", httpStatus: 503 });
+      expect(discovery.discover).not.toHaveBeenCalled();
+    });
+
+    it("fail-closes discovery.policy.update with 503 and does not mutate policy", async () => {
+      const discovery = makeDiscoveryStub();
+      const routes = createFridayDiscoveryRoutes({ discovery });
+      const policy = routes.find((r) => r.operationId === "discovery.policy.update")!;
+      await expect(policy.handler({ ...ctx, body: { enabled: false } } as never)).rejects.toMatchObject({ code: "TS_RUNTIME_DISCOVERY_RETIRED", httpStatus: 503 });
+      expect(discovery.setPolicy).not.toHaveBeenCalled();
+    });
+
+    it("runs scan + policy + recommendations when the test-oracle flag is set", async () => {
+      const discovery = makeDiscoveryStub();
+      const routes = createFridayDiscoveryRoutes({ discovery, allowTestOnlyDiscoveryExecution: true });
+      const scan = routes.find((r) => r.operationId === "discovery.scan")!;
+      await scan.handler(ctx);
+      expect(discovery.discover).toHaveBeenCalledOnce();
+      const recommend = routes.find((r) => r.operationId === "discovery.recommend")!;
+      const res = await recommend.handler(ctx) as { status: number };
+      expect(res.status).toBe(200);
+    });
+
+    it("fail-closes the GET recommendations (it falls back to discover() on cache-miss, which is the retired scan)", async () => {
+      // recommend() -> cachedCatalog ?? this.discover(): with scan retired the cache
+      // can never warm in default/live, so an unguarded GET would execute the scan.
+      const discovery = makeDiscoveryStub();
+      const routes = createFridayDiscoveryRoutes({ discovery });
+      const recommend = routes.find((r) => r.operationId === "discovery.recommend")!;
+      await expect(recommend.handler(ctx)).rejects.toMatchObject({ code: "TS_RUNTIME_DISCOVERY_RETIRED", httpStatus: 503 });
+      expect(discovery.recommend).not.toHaveBeenCalled();
+      expect(discovery.discover).not.toHaveBeenCalled();
+    });
+  });
 });
 
 describe("createFridayDiscoveryDisabledRoutes", () => {

--- a/test/unit/skills/converter/discovery/friday-discovery-integration.test.ts
+++ b/test/unit/skills/converter/discovery/friday-discovery-integration.test.ts
@@ -467,6 +467,9 @@ describe("createFridayDiscoveryIntegrationRoutes", () => {
       converterService,
       canonicalMutationGate: gate,
       disabledReason: null,
+      // Test-oracle flag: this success test exercises the live integrate staging.
+      // Production wiring leaves it unset (TS-runtime retirement).
+      allowTestOnlyDiscoveryExecution: true,
     };
     const routes = createFridayDiscoveryIntegrationRoutes(deps);
     const route = routes.find((r) => r.path === "/v1/discovery/integrate")!;
@@ -539,6 +542,7 @@ describe("createFridayDiscoveryIntegrationRoutes", () => {
       converterService,
       canonicalMutationGate: gate,
       disabledReason: null,
+      allowTestOnlyDiscoveryExecution: true,
     };
     const routes = createFridayDiscoveryIntegrationRoutes(deps);
     const route = routes.find((r) => r.path === "/v1/discovery/integrate")!;
@@ -583,6 +587,7 @@ describe("createFridayDiscoveryIntegrationRoutes", () => {
       converterService,
       canonicalMutationGate: gate,
       disabledReason: null,
+      allowTestOnlyDiscoveryExecution: true,
     };
     const routes = createFridayDiscoveryIntegrationRoutes(deps);
     const route = routes.find((r) => r.path === "/v1/discovery/integrate")!;
@@ -623,5 +628,41 @@ describe("createFridayDiscoveryIntegrationRoutes", () => {
 
     const paths = nextSteps.map((s) => s.path);
     expect(paths.some((p) => p.includes("/v1/autonomy/skills/"))).toBe(true);
+  });
+
+  it("TS-runtime retirement: fail-closes with 503 after a VALID approval and does not import", async () => {
+    const gate = makeGate();
+    const converterService = makeConverterService();
+    const discoveryService = makeDiscoveryService();
+    // Enabled deps WITHOUT the test-oracle flag = production/live wiring.
+    const deps: FridayDiscoveryIntegrationRoutesDeps = {
+      discovery: discoveryService,
+      converterService,
+      canonicalMutationGate: gate,
+      disabledReason: null,
+    };
+    const routes = createFridayDiscoveryIntegrationRoutes(deps);
+    const route = routes.find((r) => r.path === "/v1/discovery/integrate")!;
+
+    const program = makeProgram();
+    const recommendation = makeRecommendation({ programId: program.id });
+    const bridgeResult = buildDiscoveryIntegrationSource({ program, recommendation });
+    const stageRequest = createFridaySkillStageMutatingActionRequest({
+      source: bridgeResult.source,
+      formatHint: "friday-package",
+      actor: { kind: "api", id: "user-1", principalId: "user-1" },
+      surface: "api:/v1/discovery/integrate",
+      canonicalApproval: undefined,
+    });
+    const preEval = gate.evaluate(stageRequest);
+    const approval = signFridayCanonicalApproval(
+      { actionDigest: preEval.actionDigest, decision: "approved", decidedByPrincipalId: "user-1", approvalId: "approval-1", expiresAt: "2026-05-15T00:00:00.000Z" },
+      TOKEN_SECRET,
+    );
+    await expect(route.handler(makeCtx({ programId: "com.example.testapp", canonicalApproval: approval }))).rejects.toMatchObject({
+      code: "TS_RUNTIME_DISCOVERY_RETIRED",
+      httpStatus: 503,
+    });
+    expect(converterService.import).not.toHaveBeenCalled();
   });
 });

--- a/test/unit/skills/converter/discovery/friday-program-discovery.test.ts
+++ b/test/unit/skills/converter/discovery/friday-program-discovery.test.ts
@@ -462,6 +462,9 @@ describe("FridayDiscoveryRoutes", () => {
           }),
           isEnabled: vi.fn().mockReturnValue(true),
         },
+        // Test-oracle flag: these route tests exercise the live scan/policy
+        // product logic. Production wiring leaves it unset (TS-runtime retirement).
+        allowTestOnlyDiscoveryExecution: true,
       },
       setCachedCatalog: (cat: typeof catalog | null) => { cachedCatalog = cat; },
     };


### PR DESCRIPTION
## What

Retires the TypeScript-owned **discovery** product-logic routes under one flag `allowTestOnlyDiscoveryExecution` (503 `TS_RUNTIME_DISCOVERY_RETIRED`, fail_closed):
- `POST /v1/discovery/scan` → `discovery.discover` (multi-source local-program FS-enumeration + recommend engine)
- `PATCH /v1/discovery/policy` → `discovery.setPolicy` (policy mutation)
- `POST /v1/discovery/integrate` → recommend + `converterService.import` (candidate staging)
- `GET /v1/discovery/recommendations` → `discovery.recommend` (see below)

Guard ordering preserves prior contracts: disabled→`DISCOVERY_INTEGRATION_DISABLED`/`CAPABILITY_DISABLED`, malformed→400, catalog/program→404, unapproved→403 all win before the 503.

## Why the GET /recommendations is ALSO fail_closed — caught by the slice's adversarial integrity review

`discovery.recommend()` does `cachedCatalog ?? this.discover()`; `discover()` is the scanner FS-enumeration with **no flag check**. With `scan` now fail-closed it can never warm the cache in default/live, so an unguarded GET would **deterministically execute the retired scan after every restart** — which would falsify `discovery_scan`'s `executes_product_logic:false`. Gating the GET (exact surface overriding the GET=compat_shim family rule) closes the last default/live path to the scan product logic. (With a warm cache under the test-oracle flag it is a recommendation read-derive.)

## Classification / scope

All fail_closed (not compat_shim / operator_external_adapter): scan+recommend = Rust-ownable discovery compute; policy = mutation; integrate = import staging; no third-party egress. **Route-scoped proofs**: integrate's `converterService.import` is also reached by `/v1/skills/import` (#558 gated), `/v1/skills/social-import`, `/v1/deeplink/apply` (own slices) — gates only `/v1/discovery/integrate`.

## Wiring / tests / RGG

Flag inline api-runtime (threaded `CreateFridayApiRuntimeDeps` → both `createFridayDiscoveryRoutes` and `createFridayDiscoveryIntegrationRoutes`). **No RGG resolver** (no validation/real-world scenario POSTs these) and no e2e/hub plumbing — only unit tests drive these routes. Regression tests: scan/policy/recommend 503 + service-not-called; integrate 503-after-valid-approval + import-not-called; success-path tests set the flag (incl. the `friday-program-discovery.test.ts` `makeTestDeps` route describe — a driver the review caught).

Gate `ts_runtime_blocker` **12 → 9**; fail_closed 219 → 223 (recommend GET moved compat_shim→fail_closed). Local targeted tests (95) + gate + lint + build green; both secrets gates clean (no baseline change). **NOTE:** the local full suite could not complete this run due to a host-disk-full condition (unrelated to this change — other tracks' worktrees fill the disk); CI runs the full suite on a clean runner and is the authoritative check here.

## Review

correctness PASS; adversarial-integrity FAIL→FIXED (the recommend-GET scan-execution leak above) + driver-completeness PASS (the `friday-program-discovery.test.ts` route driver was caught and fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)