### PR TITLE
fix(mcp): fail-close TS MCP tools/call execution (method-scoped)

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -3616,6 +3616,15 @@
       "next_action": "Replace the fail-closed response with the Rust-owned discovery recommendation entrypoint when available."
     },
     {
+      "id": "mcp_server_rpc",
+      "route": { "method": "POST", "path": "/v1/mcp", "operationId": "mcp.server.rpc" },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-mcp-server-routes.ts mcp.server.rpc is a JSON-RPC dispatcher (POST /v1/mcp). The TS-runtime retirement guard is METHOD-SCOPED to the EXECUTION path: inside case 'tools/call', AFTER the name/params validation (-32602 on missing name) and IMMEDIATELY BEFORE services.callTool (which runs a safe-catalog tool incl. web_fetch/web_search egress = the product logic), it fail-closes by returning a JSON-RPC error frame (code -32000, errorCode TS_RUNTIME_MCP_TOOLS_CALL_RETIRED) — a frame, not a 503, because the dispatcher's outer catch maps thrown errors to JSON-RPC -32603 (same rationale as the realtime WS ack error frame). callTool is NOT invoked, so executes_product_logic:false for the tool-execution path. The READ/metadata sub-methods (initialize, tools/list, resources/list, resources/read, prompts/list, prompts/get) are INTENTIONALLY ungated and remain available — they serve catalog/metadata reads, not the Rust-ownable tool execution. So this fail_closed classification is scoped to the route's product-logic-EXECUTION path (tools/call), which is the only sub-method that runs Rust-ownable compute. fail_closed not operator_external_adapter: the tools' web_fetch/web_search is an env-allowlisted, audit-logged safe-catalog compute that Rust will reimplement, not a permanent egress-delivery conduit. Reachable only through explicit allowTestOnlyMcpToolCallExecution test-oracle wiring (set on the FridayMcpServerRoutesDeps / mcpServer object; production bootstrap leaves it unset).",
+      "next_action": "Replace the fail-closed tools/call response with the Rust-owned MCP tool-execution entrypoint when available; the read/metadata sub-methods can stay or move to Rust independently."
+    },
+    {
       "id": "realtime_subscribe_read",
       "route": {
         "method": "POST",

--- a/src/api/http/routes/friday-mcp-server-routes.ts
+++ b/src/api/http/routes/friday-mcp-server-routes.ts
@@ -84,6 +84,15 @@ export interface FridayMcpServerRoutesDeps {
       }>;
     }>;
   }>;
+  /**
+   * Test-oracle only: allow the legacy TypeScript MCP `tools/call` EXECUTION
+   * (services.callTool runs a safe-catalog tool incl. web_fetch/web_search).
+   * Production/runtime callers must leave this unset so tools/call fail-closes
+   * (JSON-RPC error TS_RUNTIME_MCP_TOOLS_CALL_RETIRED) until Rust owns MCP tool
+   * execution. The READ/metadata methods (initialize, tools/list, resources/*,
+   * prompts/*) are NOT gated — they remain available.
+   */
+  allowTestOnlyMcpToolCallExecution?: boolean;
 }
 
 type JsonRpcId = string | number | null;
@@ -282,6 +291,31 @@ export function createFridayMcpServerRoutes(
               const args = rawArgs && typeof rawArgs === "object" && !Array.isArray(rawArgs)
                 ? rawArgs as Record<string, unknown>
                 : {};
+
+              // TS-runtime retirement: the MCP tool EXECUTION path (callTool ->
+              // safe-catalog tool incl. web_fetch/web_search egress) fail-closes
+              // by default/live, returning a JSON-RPC error (the dispatcher maps
+              // thrown errors to -32603, so a frame is the correct shape here —
+              // analogous to the realtime WS ack frame). callTool is NOT invoked,
+              // so executes_product_logic:false. The read/metadata methods
+              // (initialize/tools.list/resources/prompts) are intentionally
+              // ungated. Reachable only through allowTestOnlyMcpToolCallExecution.
+              if (services.allowTestOnlyMcpToolCallExecution !== true) {
+                return {
+                  status: 200,
+                  body: makeJsonRpcError(
+                    id,
+                    -32000,
+                    "MCP tool execution is fail-closed in the default/live runtime (TS_RUNTIME_MCP_TOOLS_CALL_RETIRED); the Rust-owned MCP tool entrypoint is required.",
+                    makeErrorData({
+                      requestId: ctx.requestId,
+                      routeId,
+                      correlationId,
+                      errorCode: "TS_RUNTIME_MCP_TOOLS_CALL_RETIRED",
+                    }),
+                  ),
+                };
+              }
 
               const toolResult = await services.callTool({
                 name,

--- a/test/unit/api/http/routes/friday-mcp-server-routes.test.ts
+++ b/test/unit/api/http/routes/friday-mcp-server-routes.test.ts
@@ -54,6 +54,9 @@ function createDeps(): FridayMcpServerRoutesDeps {
         },
       ],
     }),
+    // Test-oracle flag: the tools/call proxy test exercises live tool execution.
+    // Production wiring leaves it unset (TS-runtime retirement of MCP tool exec).
+    allowTestOnlyMcpToolCallExecution: true,
   };
 }
 
@@ -152,6 +155,35 @@ describe("createFridayMcpServerRoutes", () => {
       requestId: "req-1",
       correlationId: "mcp.server:req-1:tools/call:3",
     }));
+  });
+
+  describe("TS-runtime retirement (tools/call fail-close; reads stay live)", () => {
+    it("fail-closes tools/call with a JSON-RPC error (TS_RUNTIME_MCP_TOOLS_CALL_RETIRED) and does not call the tool", async () => {
+      // Enabled deps WITHOUT the test-oracle flag = production/live wiring.
+      const deps = { ...createDeps(), allowTestOnlyMcpToolCallExecution: false };
+      const route = createFridayMcpServerRoutes(deps)[0]!;
+      const response = await route.handler(buildCtx({
+        jsonrpc: "2.0", id: 7, method: "tools/call", params: { name: "echo", arguments: { text: "hi" } },
+      }) as never);
+      // Dispatcher maps errors to JSON-RPC frames, so the fail-close is a frame (HTTP 200 envelope).
+      expect(response.status).toBe(200);
+      const body = response.body as { error?: { code?: number } };
+      expect(body.error?.code).toBe(-32000);
+      expect(JSON.stringify(body)).toContain("TS_RUNTIME_MCP_TOOLS_CALL_RETIRED");
+      expect(deps.callTool).not.toHaveBeenCalled();
+    });
+
+    it("leaves tools/list and initialize UNGATED even without the flag (reads stay live)", async () => {
+      const deps = { ...createDeps(), allowTestOnlyMcpToolCallExecution: false };
+      const route = createFridayMcpServerRoutes(deps)[0]!;
+      const listResponse = await route.handler(buildCtx({ jsonrpc: "2.0", id: 8, method: "tools/list", params: {} }) as never);
+      expect(listResponse.status).toBe(200);
+      expect((listResponse.body as { error?: unknown }).error).toBeUndefined();
+      expect(deps.listTools).toHaveBeenCalledTimes(1);
+      const initResponse = await route.handler(buildCtx({ jsonrpc: "2.0", id: 9, method: "initialize", params: {} }) as never);
+      expect(initResponse.status).toBe(200);
+      expect((initResponse.body as { error?: unknown }).error).toBeUndefined();
+    });
   });
 
   it("validates required params", async () => {


### PR DESCRIPTION
## What

Retires the TypeScript-owned MCP **tool-EXECUTION** path of the JSON-RPC dispatcher `POST /v1/mcp` (operationId `mcp.server.rpc`).

The guard is **method-scoped**: inside `case "tools/call"`, after name/params validation and immediately before `services.callTool` (which runs a safe-catalog tool incl. `web_fetch`/`web_search` egress = the Rust-ownable product logic), it fail-closes by returning a **JSON-RPC error frame** (`code -32000`, `errorCode TS_RUNTIME_MCP_TOOLS_CALL_RETIRED`) when `allowTestOnlyMcpToolCallExecution` is unset. A frame (not a 503) is the correct shape because the dispatcher's outer `catch` maps thrown errors to `-32603` (same rationale as the realtime WS ack error frame). `callTool` is **not** invoked → `executes_product_logic:false`.

The **read/metadata** sub-methods (`initialize`, `tools/list`, `resources/list`, `resources/read`, `prompts/list`, `prompts/get`) are **intentionally ungated** and stay available — they serve catalog/metadata reads, not tool execution (the review confirmed `getPrompt` embeds the tool name as a *string* without executing it, and `listAllowedTools` is an in-memory filter). So the route's `fail_closed` classification is scoped to its only product-logic-EXECUTION sub-method.

## Classification / scope

`fail_closed` not `operator_external_adapter`: the tools' `web_fetch`/`web_search` is an env-allowlisted, audit-logged safe-catalog compute Rust will reimplement, not a permanent egress-delivery conduit. `services.callTool` (the route's safe-catalog execution) has **no second user-triggerable surface** (the agent's `mcpAdapter.callTool` targets EXTERNAL servers — opposite direction).

## Wiring / tests / RGG

Flag `allowTestOnlyMcpToolCallExecution` on `FridayMcpServerRoutesDeps`; production bootstrap builds the `mcpServer` object without it → tools/call fail-closes. **Inline-only** (`createFridayMcpServerRoutes(deps.mcpServer)`); **no RGG resolver and no hub plumbing** — the only route driver is the unit test (the agent-side mcp tests + the live-e2e/contract test an EXTERNAL self-upgrade MCP server, not `/v1/mcp`).

2 retirement regression tests (tools/call → `-32000` frame + `TS_RUNTIME_MCP_TOOLS_CALL_RETIRED` + callTool-not-called; tools/list + initialize stay `200`/ungated without the flag); the tools/call proxy test sets the flag.

## Review

correctness PASS + adversarial-integrity PASS + driver-completeness PASS.

Gate `ts_runtime_blocker` **9 → 8**. Full suite **12705 passed / 0 failed**, no type errors; lint clean; both secrets gates clean (no baseline change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)