### PR TITLE
fix(social-import): fail-close TS social skill import (guard hoisted above XHS egress)

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -3625,6 +3625,15 @@
       "next_action": "Replace the fail-closed tools/call response with the Rust-owned MCP tool-execution entrypoint when available; the read/metadata sub-methods can stay or move to Rust independently."
     },
     {
+      "id": "skills_social_import",
+      "route": { "method": "POST", "path": "/v1/skills/social-import", "operationId": "skills.social.import" },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-social-import-routes.ts skills.social.import wires default/live to assertSocialImportTestOracleAllowed(deps) AFTER the availability check (!service/!converterService/!canonicalMutationGate -> 503 SOCIAL_IMPORT_DISABLED) and parseSocialImportBody (malformed -> 400), and IMMEDIATELY BEFORE deps.service.prepareStageContext — i.e. HOISTED above the XHS real-browser extraction so NO extraction/egress occurs when retired. 503 TS_RUNTIME_SOCIAL_IMPORT_RETIRED (classification fail_closed, replacement rust_owned_social_import_entrypoint_required). executes_product_logic:false: neither the XHS extraction nor converterService.import runs in default/live. TRADEOFF (accepted): an unapproved request now gets this 503 rather than the downstream canonical-approval 403 — 'retired' is the correct response for a retired route regardless of approval state, and hoisting keeps the egress from running (the alternative, guarding after the approval gate, would let prepareStageContext navigate XHS before fail-closing). SCOPE NOTE (route-scoped): the underlying converterService.import is ALSO reached by /v1/skills/import (#558 GATED), /v1/discovery/integrate (#562 GATED), /v1/deeplink/apply (its own slice) — this surface gates ONLY /v1/skills/social-import and does NOT claim the import method globally unreachable. The GET /v1/skills/converters read stays compat_shim. Reachable only through explicit allowTestOnlySocialImportExecution test-oracle wiring (inline createFridaySocialImportRoutes).",
+      "next_action": "Replace the fail-closed response with the Rust-owned social-import entrypoint when available; with skills.import (#558) + discovery.integrate (#562) + social-import gated, only /v1/deeplink/apply remains to fully gate converterService.import (then CLI + agent-tool reconciliation-scope)."
+    },
+    {
       "id": "realtime_subscribe_read",
       "route": {
         "method": "POST",

--- a/src/api/http/routes/friday-social-import-routes.ts
+++ b/src/api/http/routes/friday-social-import-routes.ts
@@ -54,6 +54,41 @@ export interface FridaySocialImportRoutesRegistrationDeps extends FridaySocialIm
   readonly converterService: FridaySkillConverterService | null;
   /** Canonical mutation gate used to evaluate the stage-candidate request. */
   readonly canonicalMutationGate: FridayMutatingActionGate | null;
+  /**
+   * Test-oracle only: allow the legacy TypeScript social-import mutation
+   * (prepareStageContext XHS browser extraction -> canonical approval ->
+   * converterService.import candidate staging). Production/runtime callers must
+   * leave this unset so the route fail-closes (503 TS_RUNTIME_SOCIAL_IMPORT_RETIRED)
+   * until Rust owns social import. The guard is HOISTED above prepareStageContext
+   * so NO XHS browser extraction / egress occurs when retired.
+   */
+  readonly allowTestOnlySocialImportExecution?: boolean;
+}
+
+/**
+ * TS-runtime retirement guard for the social-import mutation. Placed AFTER the
+ * availability check + body parse and IMMEDIATELY BEFORE prepareStageContext
+ * (the XHS browser extraction / egress) so that when retired NOTHING is
+ * extracted or staged. Tradeoff (accepted): an unapproved request gets this
+ * 503 rather than the downstream canonical-approval 403 — but "retired" is the
+ * correct response for a retired route regardless of approval state, and this
+ * keeps the egress from running.
+ */
+function assertSocialImportTestOracleAllowed(deps: { allowTestOnlySocialImportExecution?: boolean }): void {
+  if (deps.allowTestOnlySocialImportExecution === true) {
+    return;
+  }
+  throw new FridayDomainError(
+    "TS_RUNTIME_SOCIAL_IMPORT_RETIRED",
+    "Social skill import is fail-closed in the default/live runtime; the Rust-owned social-import entrypoint is required.",
+    {
+      httpStatus: 503,
+      details: {
+        classification: "fail_closed",
+        replacement: "rust_owned_social_import_entrypoint_required",
+      },
+    },
+  );
 }
 
 // ─── Defaults ───
@@ -94,6 +129,10 @@ export function createFridaySocialImportRoutes(
         const request = parseSocialImportBody(ctx.body);
         const actorPrincipalId = ctx.principal?.principalId ?? "public:default";
         const actorPrincipalKind = ctx.principal?.principalType ?? "api";
+
+        // TS-runtime retirement: fail-close BEFORE prepareStageContext so the XHS
+        // browser extraction / egress never runs in default/live.
+        assertSocialImportTestOracleAllowed(deps);
 
         // 1. Pre-staging: URL allowlist, session check, real-browser
         //    extraction, source provenance, social-aware planDigest.

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -3178,6 +3178,7 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
     disabledReason: socialImportDeps.disabledReason,
     converterService: deps.converterService ?? null,
     canonicalMutationGate: socialImportDeps.service ? canonicalMutationGate : null,
+    allowTestOnlySocialImportExecution: deps.allowTestOnlySocialImportExecution,
   })) {
     routes.register(route);
   }

--- a/src/api/runtime/friday-api-runtime.types.ts
+++ b/src/api/runtime/friday-api-runtime.types.ts
@@ -376,6 +376,13 @@ export interface CreateFridayApiRuntimeDeps {
    * so those surfaces fail-close until Rust owns discovery.
    */
   allowTestOnlyDiscoveryExecution?: boolean;
+  /**
+   * Test-oracle only: allow the legacy TypeScript social-import mutation
+   * (POST /v1/skills/social-import). Production/runtime callers must leave this
+   * unset so the route fail-closes (and the XHS extraction never runs) until
+   * Rust owns social import.
+   */
+  allowTestOnlySocialImportExecution?: boolean;
   /** Optional: Reflex service for deterministic preference writes before agent runs. */
   reflexService?: FridayReflexService;
   /** Optional deterministic runtime capability getter used by context evidence selection. */

--- a/test/unit/api/routes/friday-social-import-routes.test.ts
+++ b/test/unit/api/routes/friday-social-import-routes.test.ts
@@ -129,6 +129,9 @@ function makeDeps(overrides: Partial<FridaySocialImportRoutesRegistrationDeps> =
     converterService: makeConverter(),
     canonicalMutationGate: makeGate(),
     disabledReason: null,
+    // Test-oracle flag: success-path tests exercise the live staging pipeline.
+    // Production wiring leaves it unset (TS-runtime retirement; no XHS egress).
+    allowTestOnlySocialImportExecution: true,
     ...overrides,
   };
 }
@@ -444,5 +447,31 @@ describe("createFridaySocialImportRoutes — denied gate", () => {
       code: "CANONICAL_APPROVAL_DENIED",
       httpStatus: 403,
     });
+  });
+});
+
+describe("createFridaySocialImportRoutes — TS-runtime retirement (default/live fail-close)", () => {
+  it("fail-closes with 503 and runs NO XHS extraction (prepareStageContext) or import", async () => {
+    const service = makeService();
+    const converterService = makeConverter();
+    // Enabled deps WITHOUT the test-oracle flag = production/live wiring.
+    const deps = makeDeps({ service, converterService, allowTestOnlySocialImportExecution: false });
+    const route = findRoute(createFridaySocialImportRoutes(deps), "skills.social.import");
+    await expect(route.handler(makeCtx() as never)).rejects.toMatchObject({
+      code: "TS_RUNTIME_SOCIAL_IMPORT_RETIRED",
+      httpStatus: 503,
+    });
+    // The guard is hoisted above prepareStageContext, so the XHS extraction never runs.
+    expect(service.prepareStageContext).not.toHaveBeenCalled();
+    expect(converterService.import).not.toHaveBeenCalled();
+  });
+
+  it("still 503 SOCIAL_IMPORT_DISABLED (not the retirement code) when disabled, and 400 on malformed body before the guard", async () => {
+    const disabledRoute = findRoute(createFridaySocialImportRoutes(makeDisabledDeps("deps absent")), "skills.social.import");
+    await expect(disabledRoute.handler(makeCtx() as never)).rejects.toMatchObject({ code: "SOCIAL_IMPORT_DISABLED", httpStatus: 503 });
+
+    const enabledNoFlag = makeDeps({ allowTestOnlySocialImportExecution: false });
+    const route = findRoute(createFridaySocialImportRoutes(enabledNoFlag), "skills.social.import");
+    await expect(route.handler(makeCtx({ body: "not-an-object" }) as never)).rejects.toMatchObject({ code: "VALIDATION_ERROR", httpStatus: 400 });
   });
 });


### PR DESCRIPTION
## What

Retires the TypeScript-owned social-import mutation: `POST /v1/skills/social-import` (operationId `skills.social.import`).

Fail-closes by default/live: **503 `TS_RUNTIME_SOCIAL_IMPORT_RETIRED`** (fail_closed, replacement `rust_owned_social_import_entrypoint_required`) via `assertSocialImportTestOracleAllowed(deps)`, placed **after** the availability check (`!service/!converterService/!canonicalMutationGate` → 503 `SOCIAL_IMPORT_DISABLED`) and `parseSocialImportBody` (malformed → 400), and **HOISTED immediately before `deps.service.prepareStageContext`** — so the **XHS real-browser extraction / egress never runs** when retired.

## Why the hoist (tradeoff, accepted)

`prepareStageContext` (the XHS extraction) runs *before* the canonical-approval gate, so to avoid egress-when-retired the guard sits above it. Consequence: an unapproved request now gets the 503 rather than the downstream `CANONICAL_APPROVAL_REQUIRED` 403 — but "retired" is the correct response for a retired route regardless of approval state, and hoisting keeps the egress from running (guarding *after* the approval gate would let `prepareStageContext` navigate XHS first). Disclosed in the manifest proof + code comment. `executes_product_logic:false`: neither the XHS extraction nor `converterService.import` runs in default/live.

## Classification / scope

`fail_closed` not `operator_external_adapter`: the XHS egress is fetch-to-import product logic that fail-closes (no egress when retired), like media-understanding/discovery.integrate. **Route-scoped proof**: `converterService.import` is also reached by `/v1/skills/import` (#558 gated), `/v1/discovery/integrate` (#562 gated), `/v1/deeplink/apply` (own slice) — gates **only** `/v1/skills/social-import`; with those three gated, only deeplink/apply remains to fully gate the method. `prepareStageContext` has a single caller (this route). `GET /v1/skills/converters` stays compat_shim.

## Wiring / tests / RGG

Flag inline api-runtime (`allowTestOnlySocialImportExecution` → `CreateFridayApiRuntimeDeps` → `createFridaySocialImportRoutes`). **No RGG resolver** (no scenario POSTs it) and no e2e/hub plumbing — only the route unit test drives it (extra-route-reg is metadata/disabled-state; the service test calls the service directly).

2 retirement regression tests (503 + **prepareStageContext-not-called** + import-not-called proving no egress; disabled-still-`SOCIAL_IMPORT_DISABLED` + malformed-400-before-guard); success-path tests set the flag.

## Review

correctness PASS + adversarial-integrity PASS + driver-completeness PASS.

Gate `ts_runtime_blocker` **8 → 7**. Full suite **12707 passed / 0 failed**, no type errors; lint clean; both secrets gates clean (no baseline change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)