### PR TITLE
fix(plugins): fail-close TS plugin lifecycle mutations (install/enable/disable/uninstall)

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -3652,6 +3652,42 @@
       "next_action": "Replace the fail-closed response with the Rust-owned deep-link apply entrypoint when available."
     },
     {
+      "id": "plugins_install",
+      "route": { "method": "POST", "path": "/v1/plugins/:id/install", "operationId": "plugins.install" },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-plugin-routes.ts plugins.install wires default/live to assertPluginTestOracleAllowed(deps) AFTER validateInstallBody (malformed/missing installPath -> 400) and IMMEDIATELY BEFORE the manifest filesystem load (manifestLoader.loadFromDirectory) AND pluginService.installPlugin — so when retired NOTHING is read from the install dir or installed. 503 TS_RUNTIME_PLUGIN_RETIRED (classification fail_closed, replacement rust_owned_plugin_lifecycle_entrypoint_required). Local plugin-registry mutation + manifest FS read, no third-party egress, so fail_closed; GET plugin reads (list/get/versions) stay compat_shim. executes_product_logic:false: no install (and no manifest FS read) in default/live. Flag allowTestOnlyPluginExecution threaded inline (CreateFridayApiRuntimeDeps -> createFridayPluginRoutes) + hub-config (FridayHubConfig -> friday-hub-bootstrap, for the live self-upgrade-plugin e2e which boots a real hub via createFridayDeepProofHubEnv -> real-env). Reachable only through explicit allowTestOnlyPluginExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned plugin install entrypoint when available."
+    },
+    {
+      "id": "plugins_enable",
+      "route": { "method": "POST", "path": "/v1/plugins/:id/enable", "operationId": "plugins.enable" },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-plugin-routes.ts plugins.enable wires default/live to assertPluginTestOracleAllowed(deps) as the first handler statement, before pluginService.enablePlugin(id) (loads/activates the plugin). 503 TS_RUNTIME_PLUGIN_RETIRED. Local mutation, no egress, fail_closed. executes_product_logic:false. SCOPE NOTE (route-scoped): pluginService.enablePlugin/disablePlugin are ALSO reached by the autonomy lifecycle routes /v1/autonomy/plugins/:id/{review-enable,canary,promote,rollback} (via pluginRuntime=deps.pluginService) — but those are INDEPENDENTLY gated under allowTestOnlyAutonomyLifecycleExecution (#547, TS_RUNTIME_AUTONOMY_LIFECYCLE_RETIRED), so the enable/disable methods are fail-closed system-wide in production (both flags unset). This surface gates ONLY the /v1/plugins/:id/enable route via allowTestOnlyPluginExecution.",
+      "next_action": "Replace the fail-closed response with the Rust-owned plugin enable entrypoint when available."
+    },
+    {
+      "id": "plugins_disable",
+      "route": { "method": "POST", "path": "/v1/plugins/:id/disable", "operationId": "plugins.disable" },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-plugin-routes.ts plugins.disable wires default/live to assertPluginTestOracleAllowed(deps) as the first handler statement, before pluginService.disablePlugin(id). 503 TS_RUNTIME_PLUGIN_RETIRED. Local mutation, no egress, fail_closed. executes_product_logic:false. SCOPE NOTE (route-scoped): like plugins.enable, pluginService.disablePlugin is ALSO reached by the autonomy lifecycle routes /v1/autonomy/plugins/:id/{...} (pluginRuntime=deps.pluginService), independently gated under allowTestOnlyAutonomyLifecycleExecution (#547) — so disable is fail-closed system-wide in production. This surface gates ONLY the /v1/plugins/:id/disable route.",
+      "next_action": "Replace the fail-closed response with the Rust-owned plugin disable entrypoint when available."
+    },
+    {
+      "id": "plugins_uninstall",
+      "route": { "method": "DELETE", "path": "/v1/plugins/:id", "operationId": "plugins.uninstall" },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-plugin-routes.ts plugins.uninstall wires default/live to assertPluginTestOracleAllowed(deps) as the first handler statement, before pluginService.uninstallPlugin(id, force) (removes the plugin from the registry). 503 TS_RUNTIME_PLUGIN_RETIRED. Local mutation, no egress, fail_closed. executes_product_logic:false. Reachable only through explicit allowTestOnlyPluginExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned plugin uninstall entrypoint when available."
+    },
+    {
       "id": "realtime_subscribe_read",
       "route": {
         "method": "POST",

--- a/src/api/http/routes/friday-plugin-routes.ts
+++ b/src/api/http/routes/friday-plugin-routes.ts
@@ -26,6 +26,37 @@ import {
 export interface FridayPluginRoutesDeps {
   pluginService: FridayPluginService;
   manifestLoader: FridayPluginManifestLoader;
+  /**
+   * Test-oracle only: allow the legacy TypeScript plugin lifecycle mutations
+   * (install / enable / disable / uninstall). Production/runtime callers must
+   * leave this unset so those POST/DELETE routes fail-close (503
+   * TS_RUNTIME_PLUGIN_RETIRED) until Rust owns the plugin lifecycle. The GET
+   * plugin reads (list / get / versions) are never gated.
+   */
+  allowTestOnlyPluginExecution?: boolean;
+}
+
+/**
+ * TS-runtime retirement guard for the plugin lifecycle mutation routes. Placed
+ * AFTER body validation and IMMEDIATELY BEFORE the pluginService mutation (for
+ * install, before the manifest filesystem load too, so nothing is read/mutated
+ * when retired).
+ */
+function assertPluginTestOracleAllowed(deps: FridayPluginRoutesDeps): void {
+  if (deps.allowTestOnlyPluginExecution === true) {
+    return;
+  }
+  throw new FridayDomainError(
+    "TS_RUNTIME_PLUGIN_RETIRED",
+    "Plugin install/enable/disable/uninstall is fail-closed in the default/live runtime; the Rust-owned plugin lifecycle entrypoint is required.",
+    {
+      httpStatus: 503,
+      details: {
+        classification: "fail_closed",
+        replacement: "rust_owned_plugin_lifecycle_entrypoint_required",
+      },
+    },
+  );
 }
 
 // ─── Validation Helpers ───
@@ -127,6 +158,7 @@ export function createFridayPluginRoutes(
       async handler(ctx): Promise<FridayInstallPluginResponse> {
         const { id } = ctx.params as { id: string };
         validateInstallBody(ctx.body);
+        assertPluginTestOracleAllowed(deps);
         const body = ctx.body;
 
         // Read and validate the real manifest from installPath
@@ -160,6 +192,7 @@ export function createFridayPluginRoutes(
       auth: { public: true },
       async handler(ctx): Promise<FridayEnablePluginResponse> {
         const { id } = ctx.params as { id: string };
+        assertPluginTestOracleAllowed(deps);
         const plugin = await pluginService.enablePlugin(id);
         return { plugin };
       },
@@ -173,6 +206,7 @@ export function createFridayPluginRoutes(
       auth: { public: true },
       async handler(ctx): Promise<FridayDisablePluginResponse> {
         const { id } = ctx.params as { id: string };
+        assertPluginTestOracleAllowed(deps);
         const plugin = await pluginService.disablePlugin(id);
         return { plugin };
       },
@@ -186,6 +220,7 @@ export function createFridayPluginRoutes(
       auth: { public: true },
       async handler(ctx): Promise<FridayUninstallPluginResponse> {
         const { id } = ctx.params as { id: string };
+        assertPluginTestOracleAllowed(deps);
         const query = ctx.query as Record<string, string | undefined>;
         const force = query.force === "true";
         await pluginService.uninstallPlugin(id, force);

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -3679,6 +3679,7 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
     for (const route of createFridayPluginRoutes({
       pluginService: deps.pluginService,
       manifestLoader: deps.pluginManifestLoader,
+      allowTestOnlyPluginExecution: deps.allowTestOnlyPluginExecution,
     })) {
       routes.register(route);
     }

--- a/src/api/runtime/friday-api-runtime.types.ts
+++ b/src/api/runtime/friday-api-runtime.types.ts
@@ -390,6 +390,12 @@ export interface CreateFridayApiRuntimeDeps {
    * fail-close until Rust owns deep-link handling.
    */
   allowTestOnlyDeepLinkExecution?: boolean;
+  /**
+   * Test-oracle only: allow the legacy TypeScript plugin lifecycle mutations
+   * (install/enable/disable/uninstall). Production/runtime callers must leave
+   * this unset so those routes fail-close until Rust owns the plugin lifecycle.
+   */
+  allowTestOnlyPluginExecution?: boolean;
   /** Optional: Reflex service for deterministic preference writes before agent runs. */
   reflexService?: FridayReflexService;
   /** Optional deterministic runtime capability getter used by context evidence selection. */

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -1896,6 +1896,8 @@ export interface FridayHubConfig {
   allowTestOnlySkillConverterExecution?: boolean;
   /** Test-oracle only; production hub creation must leave scan-migrate local-scan + batch-convert product logic fail-closed. */
   allowTestOnlyScanMigrateExecution?: boolean;
+  /** Test-oracle only; production hub creation must leave plugin install/enable/disable/uninstall fail-closed. */
+  allowTestOnlyPluginExecution?: boolean;
 }
 
 // ─── Resolved Hub Config ───

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -6926,6 +6926,7 @@ export async function createFridayHub(
     allowTestOnlySessionMemoryExtractionExecution: config.allowTestOnlySessionMemoryExtractionExecution,
     allowTestOnlyRealtimeExecution: config.allowTestOnlyRealtimeExecution,
     allowTestOnlySkillConverterExecution: config.allowTestOnlySkillConverterExecution,
+    allowTestOnlyPluginExecution: config.allowTestOnlyPluginExecution,
     reflexService,
     agentEventEmitter,
     resolveToolApproval,

--- a/test/e2e/live/_helpers/real-env.ts
+++ b/test/e2e/live/_helpers/real-env.ts
@@ -327,6 +327,7 @@ async function startLocalRealHubEnv(
       allowTestOnlyDiagnosisExecution: true,
       allowTestOnlyRealtimeExecution: true,
       allowTestOnlySkillConverterExecution: true,
+      allowTestOnlyPluginExecution: true,
       ...opts?.hubConfig,
     });
     await createdHub.start();

--- a/test/unit/api/http/routes/friday-plugin-routes.test.ts
+++ b/test/unit/api/http/routes/friday-plugin-routes.test.ts
@@ -100,7 +100,10 @@ describe("FridayPluginRoutes", () => {
       validate: vi.fn((raw: unknown) => raw as FridayPluginManifest),
     };
 
-    routes = createFridayPluginRoutes({ pluginService, manifestLoader });
+    // Test-oracle flag: the install/enable/disable/uninstall handler tests below
+    // exercise the live plugin lifecycle. Production wiring leaves it unset
+    // (TS-runtime retirement).
+    routes = createFridayPluginRoutes({ pluginService, manifestLoader, allowTestOnlyPluginExecution: true });
   });
 
   // ─── Route registration ───
@@ -289,6 +292,44 @@ describe("FridayPluginRoutes", () => {
     await expect(
       route.handler(makeCtx({ query: { kind: "not_a_kind" } })),
     ).rejects.toThrow(FridayDomainError);
+  });
+
+  // ─── TS-runtime retirement (default/live fail-close) ───
+
+  describe("TS-runtime retirement", () => {
+    // Build routes WITHOUT the test-oracle flag = production/live wiring.
+    function retired() {
+      return createFridayPluginRoutes({ pluginService, manifestLoader });
+    }
+    const find = (opId: string) => retired().find((r) => r.operationId === opId)!;
+
+    it("fail-closes install with 503 (before the manifest load) and does not install", async () => {
+      const route = find("plugins.install");
+      await expect(route.handler(makeCtx({ params: { id: "friday.test.new" }, body: { installPath: "/plugins/new" } }))).rejects.toMatchObject({
+        code: "TS_RUNTIME_PLUGIN_RETIRED",
+        httpStatus: 503,
+      });
+      expect(manifestLoader.loadFromDirectory).not.toHaveBeenCalled();
+      expect(pluginService.installPlugin).not.toHaveBeenCalled();
+    });
+
+    it("fail-closes enable / disable / uninstall with 503 and does not mutate", async () => {
+      await expect(find("plugins.enable").handler(makeCtx({ params: { id: "friday.test.alpha" } }))).rejects.toMatchObject({ code: "TS_RUNTIME_PLUGIN_RETIRED", httpStatus: 503 });
+      await expect(find("plugins.disable").handler(makeCtx({ params: { id: "friday.test.alpha" } }))).rejects.toMatchObject({ code: "TS_RUNTIME_PLUGIN_RETIRED", httpStatus: 503 });
+      await expect(find("plugins.uninstall").handler(makeCtx({ params: { id: "friday.test.alpha" } }))).rejects.toMatchObject({ code: "TS_RUNTIME_PLUGIN_RETIRED", httpStatus: 503 });
+      expect(pluginService.enablePlugin).not.toHaveBeenCalled();
+      expect(pluginService.disablePlugin).not.toHaveBeenCalled();
+      expect(pluginService.uninstallPlugin).not.toHaveBeenCalled();
+    });
+
+    it("still 400s a malformed install body BEFORE the retirement guard", async () => {
+      await expect(find("plugins.install").handler(makeCtx({ params: { id: "friday.test.new" }, body: {} }))).rejects.toMatchObject({ httpStatus: 400 });
+    });
+
+    it("leaves the GET plugin reads ungated (no retirement 503)", async () => {
+      // The GET list resolves (does not throw the retirement 503) even without the flag.
+      await expect(find("plugins.list").handler(makeCtx())).resolves.toBeDefined();
+    });
   });
 
 });


### PR DESCRIPTION
## What

Retires the TS-owned plugin lifecycle routes in `friday-plugin-routes.ts` under one flag `allowTestOnlyPluginExecution` (503 `TS_RUNTIME_PLUGIN_RETIRED`, fail_closed):
- `POST /v1/plugins/:id/install`
- `POST /v1/plugins/:id/enable`
- `POST /v1/plugins/:id/disable`
- `DELETE /v1/plugins/:id` (uninstall)

**install** guards after `validateInstallBody` (400) and **before the manifest FS load + installPlugin** (so a retired install reads nothing from the install dir and installs nothing). enable/disable/uninstall guard first, before the `pluginService` mutation. The 3 GET reads (list/get/versions) stay ungated/compat_shim.

## Classification / scope

`fail_closed`: local plugin-registry mutations + manifest FS read, no third-party egress (reviewer-verified the service has no fetch/http egress). **Route-scoped (per Reviewer B)**: `enablePlugin`/`disablePlugin` are also reached by the autonomy lifecycle routes `/v1/autonomy/plugins/:id/{review-enable,canary,promote,rollback}` (via `pluginRuntime=pluginService`) — but those are **independently gated** under `allowTestOnlyAutonomyLifecycleExecution` (#547), so the methods are fail-closed system-wide; the manifest proofs carry a scope note.

## Wiring / tests / RGG

Flag inline api-runtime **+ hub-config** (`FridayHubConfig` → bootstrap) so the live self-upgrade-plugin e2e (real hub via `createFridayDeepProofHubEnv → createRealHubEnv`) sets it. **No RGG resolver** (the only validation/real-world plugin scenarios are GET `/v1/plugins` reads). 4 retirement regression tests (install/enable/disable/uninstall 503 + service-not-called + manifest-not-loaded; install 400-before-guard; GET ungated); success-path tests set the flag in `beforeEach`.

## Review (Stage-5, two isolated reviewers)

Reviewer A (correctness/driver) PASS + Reviewer B (integrity) PASS — Reviewer B's scope-note nit (enable/disable also reached via the independently-gated autonomy surface) was applied to the manifest proofs.

Gate `ts_runtime_blocker` **5 → 1** (only providers/detect remains). Full suite **12716 passed / 0 failed**, no type errors; lint clean; both secrets gates clean.

## Operator note

`scripts/e2e/run-friday-closure.mjs` (NOT a CI gate) POSTs `/v1/plugins/:id/install` + `/disable` — like providers/detect + external-closure, those steps will 503 when the operator runs closure; flagged for reconciliation (not silently changing the closure GO/NO-GO semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)