### PR TITLE
fix(providers): fail-close TS provider-detect probe (FINAL — ts_runtime_blocker → 0)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -341,7 +341,7 @@
         "filename": "src/api/http/routes/friday-setup-routes.ts",
         "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
         "is_verified": false,
-        "line_number": 2096
+        "line_number": 2130
       }
     ],
     "src/media-understanding/friday-media-doctor.ts": [
@@ -562,14 +562,14 @@
         "filename": "test/e2e/setup-wizard.e2e.test.ts",
         "hashed_secret": "9d6c140e80814290940bd258644431f5d4255fd4",
         "is_verified": false,
-        "line_number": 1491
+        "line_number": 1492
       },
       {
         "type": "Secret Keyword",
         "filename": "test/e2e/setup-wizard.e2e.test.ts",
         "hashed_secret": "1800af6e29fca70d9b324a27c567a5403d655429",
         "is_verified": false,
-        "line_number": 1513
+        "line_number": 1514
       }
     ],
     "test/integration/providers/friday-provider-service-lifecycle.test.ts": [
@@ -1124,5 +1124,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-06T16:02:17Z"
+  "generated_at": "2026-06-07T01:06:36Z"
 }

--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -3688,6 +3688,15 @@
       "next_action": "Replace the fail-closed response with the Rust-owned plugin uninstall entrypoint when available."
     },
     {
+      "id": "providers_detect",
+      "route": { "method": "POST", "path": "/v1/providers/detect", "operationId": "providers.detect" },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-setup-routes.ts providers.detect wires default/live to assertProviderDetectTestOracleAllowed(deps) AFTER all request validation (assertSetupBootstrapBoundary; body presence -> 400; kind/authMode/key/baseUrl validation -> 400) and IMMEDIATELY BEFORE the provider model-fetch egress (fetchOpenAiModels / fetchCompatibleModels / fetchAnthropicModels / fetchGoogleModels / fetchOllamaModels to the provider /v1/models). 503 TS_RUNTIME_PROVIDERS_DETECT_RETIRED (classification fail_closed, replacement rust_owned_provider_detect_entrypoint_required). fail_closed NOT operator_external_adapter: detect is a transient capability/key-validation PROBE (enumerate models + validate the key), Rust-ownable product logic whose provider calls move into Rust — the same shape as media-understanding/agent runs that call providers; it is not a permanent egress-delivery conduit, and when retired the guard fail-closes BEFORE any fetch so nothing egresses. executes_product_logic:false: no provider fetch runs in default/live. Flag allowTestOnlyProviderDetectExecution threaded inline (CreateFridayApiRuntimeDeps -> createFridaySetupRoutes) + hub-config (FridayHubConfig -> friday-hub-bootstrap) so the onboarding setup-wizard e2e (createFridayHub), the mock-parity e2e (createMockHubEnv), and the live real-journeys e2e (real-env) set it. OPERATOR/RECONCILIATION NOTE: retiring this route 503s the production onboarding/setup-wizard model-detection AND the release-GO closure harness scripts/e2e/run-friday-closure.mjs (POSTs /v1/providers/detect, throws on non-200) — these are NOT CI gates but need the Rust detect entrypoint (or an operator decision) before production onboarding/release-verify; recorded in the closure ledger. Reachable only through explicit allowTestOnlyProviderDetectExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned provider-detect entrypoint when available; this route is on the production onboarding + release-GO path — coordinate the Rust entrypoint with operator sign-off (see reconciliation note)."
+    },
+    {
       "id": "realtime_subscribe_read",
       "route": {
         "method": "POST",

--- a/src/api/http/routes/friday-setup-routes.ts
+++ b/src/api/http/routes/friday-setup-routes.ts
@@ -1911,9 +1911,43 @@ export interface FridaySetupRoutesDeps {
   onSetupCompleted?: (input: {
     userId: string;
   }) => Promise<void> | void;
+  /**
+   * Test-oracle only: allow the legacy TypeScript provider-detect probe
+   * (POST /v1/providers/detect -> fetchOpenAiModels/Anthropic/Google/Ollama/
+   * Compatible: a capability/key-validation probe that egresses to provider
+   * /v1/models). Production/runtime callers must leave this unset so the route
+   * fail-closes (503 TS_RUNTIME_PROVIDERS_DETECT_RETIRED) until Rust owns provider
+   * detection. NOTE: retiring this 503s the onboarding/setup-wizard model
+   * detection AND the release-GO closure harness — see the closeout / operator
+   * reconciliation note.
+   */
+  allowTestOnlyProviderDetectExecution?: boolean;
 }
 
 // ─── Factory ───
+
+/**
+ * TS-runtime retirement guard for the provider-detect probe. Placed AFTER all
+ * the request validation (bootstrap boundary, body, kind/authMode/key/baseUrl)
+ * and IMMEDIATELY BEFORE the provider model-fetch egress, so malformed requests
+ * still 400 and NO provider egress occurs when retired.
+ */
+function assertProviderDetectTestOracleAllowed(deps: FridaySetupRoutesDeps): void {
+  if (deps.allowTestOnlyProviderDetectExecution === true) {
+    return;
+  }
+  throw new FridayDomainError(
+    "TS_RUNTIME_PROVIDERS_DETECT_RETIRED",
+    "Provider detection is fail-closed in the default/live runtime; the Rust-owned provider-detect entrypoint is required.",
+    {
+      httpStatus: 503,
+      details: {
+        classification: "fail_closed",
+        replacement: "rust_owned_provider_detect_entrypoint_required",
+      },
+    },
+  );
+}
 
 export function createFridaySetupRoutes(
   deps: FridaySetupRoutesDeps,
@@ -2152,6 +2186,12 @@ export function createFridaySetupRoutes(
             { httpStatus: 400 },
           );
         }
+
+        // TS-runtime retirement: fail-close BEFORE the provider model-fetch
+        // egress (fetchOpenAiModels/Anthropic/Google/Ollama/Compatible), after
+        // all the request validation above, so no provider egress occurs when
+        // retired and malformed requests still 400.
+        assertProviderDetectTestOracleAllowed(deps);
 
         // Fetch models
         const warnings: string[] = [];

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -3198,6 +3198,7 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
       activateSavedChannels: deps.activateSavedChannels,
       onChannelsSaved: deps.onSetupChannelsSaved,
       onSetupCompleted: deps.onSetupCompleted,
+      allowTestOnlyProviderDetectExecution: deps.allowTestOnlyProviderDetectExecution,
     })) {
       routes.register(route);
     }

--- a/src/api/runtime/friday-api-runtime.types.ts
+++ b/src/api/runtime/friday-api-runtime.types.ts
@@ -396,6 +396,14 @@ export interface CreateFridayApiRuntimeDeps {
    * this unset so those routes fail-close until Rust owns the plugin lifecycle.
    */
   allowTestOnlyPluginExecution?: boolean;
+  /**
+   * Test-oracle only: allow the legacy TypeScript provider-detect probe
+   * (POST /v1/providers/detect). Production/runtime callers must leave this
+   * unset so the route fail-closes until Rust owns provider detection. NOTE:
+   * retiring this 503s onboarding model-detection + the release-GO closure
+   * harness (operator reconciliation item).
+   */
+  allowTestOnlyProviderDetectExecution?: boolean;
   /** Optional: Reflex service for deterministic preference writes before agent runs. */
   reflexService?: FridayReflexService;
   /** Optional deterministic runtime capability getter used by context evidence selection. */

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -1898,6 +1898,8 @@ export interface FridayHubConfig {
   allowTestOnlyScanMigrateExecution?: boolean;
   /** Test-oracle only; production hub creation must leave plugin install/enable/disable/uninstall fail-closed. */
   allowTestOnlyPluginExecution?: boolean;
+  /** Test-oracle only; production hub creation must leave the provider-detect probe fail-closed. */
+  allowTestOnlyProviderDetectExecution?: boolean;
 }
 
 // ─── Resolved Hub Config ───

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -6927,6 +6927,7 @@ export async function createFridayHub(
     allowTestOnlyRealtimeExecution: config.allowTestOnlyRealtimeExecution,
     allowTestOnlySkillConverterExecution: config.allowTestOnlySkillConverterExecution,
     allowTestOnlyPluginExecution: config.allowTestOnlyPluginExecution,
+    allowTestOnlyProviderDetectExecution: config.allowTestOnlyProviderDetectExecution,
     reflexService,
     agentEventEmitter,
     resolveToolApproval,

--- a/test/e2e/live/_helpers/real-env.ts
+++ b/test/e2e/live/_helpers/real-env.ts
@@ -328,6 +328,7 @@ async function startLocalRealHubEnv(
       allowTestOnlyRealtimeExecution: true,
       allowTestOnlySkillConverterExecution: true,
       allowTestOnlyPluginExecution: true,
+      allowTestOnlyProviderDetectExecution: true,
       ...opts?.hubConfig,
     });
     await createdHub.start();

--- a/test/e2e/mock/_helpers/mock-env.ts
+++ b/test/e2e/mock/_helpers/mock-env.ts
@@ -361,6 +361,8 @@ export async function createMockHubEnv(opts?: {
   allowTestOnlyRealtimeExecution?: boolean;
   /** Test-oracle opt-in for legacy TS skill-converter convert/import/pack mutations; set false to prove default fail-closed behavior. */
   allowTestOnlySkillConverterExecution?: boolean;
+  /** Test-oracle opt-in for the legacy TS provider-detect probe; set false to prove default fail-closed behavior. */
+  allowTestOnlyProviderDetectExecution?: boolean;
 }): Promise<MockHubEnv> {
   // Reset deterministic counters
   resetMockCounters();
@@ -419,6 +421,7 @@ export async function createMockHubEnv(opts?: {
       allowTestOnlyDiagnosisExecution: opts?.allowTestOnlyDiagnosisExecution ?? true,
       allowTestOnlyRealtimeExecution: opts?.allowTestOnlyRealtimeExecution ?? true,
       allowTestOnlySkillConverterExecution: opts?.allowTestOnlySkillConverterExecution ?? true,
+      allowTestOnlyProviderDetectExecution: opts?.allowTestOnlyProviderDetectExecution ?? true,
       // Allow private-network targets so mock E2E tests don't require DNS resolution
       ssrfPolicy: opts?.ssrfPolicy ?? { allowPrivateNetwork: true },
     });

--- a/test/e2e/setup-wizard.e2e.test.ts
+++ b/test/e2e/setup-wizard.e2e.test.ts
@@ -161,6 +161,7 @@ describe("Setup Wizard E2E", () => {
         allowTestOnlySessionRunExecution: true,
         allowTestOnlySessionMemoryExtractionExecution: true,
         allowTestOnlySkillConverterExecution: true,
+        allowTestOnlyProviderDetectExecution: true,
       });
       await hub.start();
     } finally {

--- a/test/unit/api/http/routes/friday-setup-routes.test.ts
+++ b/test/unit/api/http/routes/friday-setup-routes.test.ts
@@ -99,6 +99,9 @@ function makeDeps(opts: DepsOptions = {}): DepsAndSpies {
     activateSavedChannels,
     onChannelsSaved,
     onSetupCompleted,
+    // Test-oracle flag: detect handler tests exercise the live provider probe.
+    // Production wiring leaves it unset (TS-runtime retirement).
+    allowTestOnlyProviderDetectExecution: true,
   } as unknown as FridaySetupRoutesDeps;
 
   return { deps, writeTxn, listProviders, activateSavedChannels, onChannelsSaved, onSetupCompleted };
@@ -576,5 +579,28 @@ describe("createFridaySetupRoutes — B0 Slice A3 bootstrap boundary", () => {
     expect(writeTxn).not.toHaveBeenCalled();
     expect(activateSavedChannels).not.toHaveBeenCalled();
     expect(onChannelsSaved).not.toHaveBeenCalled();
+  });
+});
+
+describe("createFridaySetupRoutes — providers.detect TS-runtime retirement", () => {
+  // Enabled deps but WITHOUT the test-oracle flag = production/live wiring.
+  function retiredRoutes() {
+    const { deps } = makeDeps({ setupCompletedAt: null });
+    return createFridaySetupRoutes({ ...deps, allowTestOnlyProviderDetectExecution: false } as FridaySetupRoutesDeps);
+  }
+
+  it("fail-closes providers.detect with 503 TS_RUNTIME_PROVIDERS_DETECT_RETIRED (before any provider fetch)", async () => {
+    const route = findMutatingRoute(retiredRoutes(), "providers.detect");
+    // Valid body + localhost (bootstrap boundary holds) -> reaches the guard, not a 400/boundary error.
+    await expect(route.handler(makeCtx({ body: { kind: "ollama" }, ip: "127.0.0.1" }))).rejects.toMatchObject({
+      code: "TS_RUNTIME_PROVIDERS_DETECT_RETIRED",
+      httpStatus: 503,
+    });
+  });
+
+  it("still 400s a malformed detect body BEFORE the retirement guard", async () => {
+    const route = findMutatingRoute(retiredRoutes(), "providers.detect");
+    // No apiKey/kind/baseUrl -> VALIDATION_ERROR 400 fires before the 503.
+    await expect(route.handler(makeCtx({ body: {}, ip: "127.0.0.1" }))).rejects.toMatchObject({ httpStatus: 400 });
   });
 });


### PR DESCRIPTION
## What — the FINAL TS-runtime-retirement slice (ts_runtime_blocker → 0)

Retires `POST /v1/providers/detect` (operationId `providers.detect`, `friday-setup-routes.ts`): 503 `TS_RUNTIME_PROVIDERS_DETECT_RETIRED` (fail_closed) via `assertProviderDetectTestOracleAllowed(deps)`, placed **after all request validation** (bootstrap boundary + body/kind/authMode/key/baseUrl 400s) and **immediately before the provider model-fetch egress** (`fetchOpenAiModels`/`fetchAnthropicModels`/`fetchGoogleModels`/`fetchOllamaModels`/`fetchCompatibleModels`) — so malformed requests still 400 and **the user's API key never egresses when retired**.

## Classification = fail_closed (not operator_external_adapter)

detect is a **transient capability/key-validation PROBE** (model enumeration + key validation), Rust-ownable product logic whose provider calls move into Rust — the same precedent as `media_understanding_doctor`/`analyze` (fail_closed despite calling a provider), **not** a permanent egress-delivery conduit. When retired the guard fail-closes before any fetch.

## Wiring (4 harnesses) / tests / RGG

Flag `allowTestOnlyProviderDetectExecution` threaded: inline `CreateFridayApiRuntimeDeps` → `createFridaySetupRoutes` + hub-config (`FridayHubConfig` → bootstrap). Set true in the 4 driving harnesses: setup-routes unit test (`makeDeps`), onboarding setup-wizard e2e (`createFridayHub`), mock-parity e2e (`createMockHubEnv`), live real-journeys e2e (`real-env`). **No RGG resolver** (no validation/real-world scenario POSTs it). 2 retirement regression tests (valid body → 503 before any fetch; malformed → 400 before the guard).

Gate `ts_runtime_blocker` **1 → 0** (route enumeration confirms ZERO blocker routes). Full suite **12718 passed / 0 failed**, no type errors; lint clean; both secrets gates clean.

## Review (Stage-5, two isolated reviewers)

Reviewer A (correctness/driver) PASS + Reviewer B (integrity) PASS. Both independently confirmed blocker == 0 (live gate `failures:[]`, `blockerFamilies:[]`).

## ⚠️ OPERATOR / RECONCILIATION NOTE (binding — honest closeout)

`ts_runtime_blocker == 0` is a **route-count milestone, not Rust product completion** (fail_closed = TS route shutoff). Specifically for this route:
- Retiring `providers.detect` **503s the production onboarding/setup-wizard model detection** (a user-facing flow) and **the release-GO closure harness** `scripts/e2e/run-friday-closure.mjs` (POSTs detect, throws on non-200; also POSTs other now-retired routes). These are **NOT CI gates** (CI stays green) but need the Rust detect entrypoint or an explicit operator decision before production onboarding / release-verify.
- Per Reviewer B: **37 `operator_external_adapter` routes** (provider create/update/validate/doctor, etc.) **deliberately stay live in TS** — so this is not elimination of all TS provider egress, by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)