### PR TITLE
fix(workflows): move TS-retirement guard to startRun method (closes route-only defect §1)

### DIFF
--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -1130,6 +1130,10 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
       publishEvent: publishWorkflowRealtimeEvent,
       triggerRepo,
       resolveWebhookSecretRef: createWorkflowWebhookSecretResolver(deps.db),
+      // Keep the fallback runtime's execution `startRun` method consistent with the
+      // route-level guard: it honors the same `allowTestOnlyWorkflowRunExecution`
+      // flag so a caller that enables the route guard also enables the method.
+      allowTestOnlyWorkflowRunExecution: deps.allowTestOnlyWorkflowRunExecution,
     });
   })();
 

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -1660,6 +1660,11 @@ export async function createFridayHub(
     publishEvent: publishWorkflowRealtimeEvent,
     triggerRepo,
     resolveWebhookSecretRef: resolveWorkflowWebhookSecretRef,
+    // TS Runtime Retirement (§1 method-level guard): production leaves this unset
+    // (config flag undefined) so the workflow execution `startRun` method is
+    // fail-closed for the scheduler/cron/webhook/event trigger paths, not just the
+    // HTTP route. Test-oracle hub configs set it true to exercise legacy execution.
+    allowTestOnlyWorkflowRunExecution: config.allowTestOnlyWorkflowRunExecution,
     onRunIntake: async (input) => {
       const workflow = workflowRuntimeRef?.crud.getWorkflow(input.workflowId) ?? null;
       if (!workflow?.ownerUserId || !crossBorderPackServiceRef) {

--- a/src/workflows/runtime/friday-workflow-runtime.ts
+++ b/src/workflows/runtime/friday-workflow-runtime.ts
@@ -517,6 +517,13 @@ export interface CreateFridayWorkflowRuntimeDeps {
   }) => string | null | Promise<string | null>;
   publishEvent?: (event: string, payload: unknown) => Promise<void>;
   triggerRepo?: FridayWorkflowTriggerRepository;
+  /**
+   * Test-oracle ONLY. Threaded into the workflow execution service so its
+   * `startRun` method fails closed for every non-route caller (scheduler/cron,
+   * webhook, event, channel) unless explicitly enabled. Production hub bootstrap
+   * leaves this unset → fail-closed. Mirrors the route-level guard flag.
+   */
+  allowTestOnlyWorkflowRunExecution?: boolean;
   onRunIntake?: (input: {
     runId: string;
     workflowId: string;
@@ -1671,6 +1678,7 @@ export function createFridayWorkflowRuntime(
     expressionEvaluator,
     idGenerator: deps.idGenerator,
     nowIso: deps.nowIso,
+    allowTestOnlyWorkflowRunExecution: deps.allowTestOnlyWorkflowRunExecution,
     publishEvent: deps.publishEvent,
     onRunIntake: pipelineEnabled || deps.onRunIntake ? async (input) => {
       let contextPatch: JsonObject | undefined;

--- a/src/workflows/services/friday-workflow-execution-service.ts
+++ b/src/workflows/services/friday-workflow-execution-service.ts
@@ -145,6 +145,16 @@ export interface CreateWorkflowExecutionServiceDeps {
   expressionEvaluator: FridayExpressionEvaluator;
   idGenerator: () => string;
   nowIso: () => string;
+  /**
+   * Test-oracle ONLY. When not explicitly `true`, the workflow run execution
+   * `startRun` method fails closed at the METHOD boundary (not just the HTTP
+   * route), so every non-route caller — scheduler/cron, webhook, event, channel,
+   * and any future autonomous caller — is fenced out of TS workflow runtime while
+   * runtime ownership is moved to Rust. Production hub bootstrap leaves this unset
+   * → fail-closed. Mirrors the route-level `allowTestOnlyWorkflowRunExecution`
+   * guard in `friday-api-runtime.ts` so both layers honor the same flag.
+   */
+  allowTestOnlyWorkflowRunExecution?: boolean;
   publishEvent?: (event: string, payload: unknown) => Promise<void>;
   onRunIntake?: (input: {
     runId: UUID;
@@ -1190,6 +1200,28 @@ export function createFridayWorkflowExecutionService(
     },
 
     async startRun(input) {
+      // ─── TS Runtime Retirement: METHOD-level fail-closed guard ───
+      // Phase 2 reconciliation (§1) found the retirement guard was ROUTE-only
+      // (POST /v1/workflow-runs). The scheduler/cron trigger job (@60s), webhook,
+      // event, and channel trigger paths all reach this method directly via
+      // `executionService.startRun(...)`, bypassing the HTTP route guard. Guarding
+      // here fails ALL non-route callers closed BEFORE any DB read, run-row
+      // creation, node execution, provider call, or tool call — unless the
+      // explicit test-oracle flag is set. Never default this flag on in prod.
+      if (deps.allowTestOnlyWorkflowRunExecution !== true) {
+        void input;
+        throw new FridayDomainError(
+          "TS_RUNTIME_WORKFLOW_RUNS_RETIRED",
+          "Workflow run execution and controls are fail-closed while runtime ownership is being moved out of TypeScript.",
+          {
+            httpStatus: 503,
+            details: {
+              classification: "fail_closed",
+              replacement: "rust_owned_workflow_run_entrypoint_required",
+            },
+          },
+        );
+      }
       const workflowState = deps.db.withReadConnection((db) =>
         db
           .prepare("SELECT is_archived, deleted_at, owner_user_id FROM workflows WHERE id = ? LIMIT 1")

--- a/test/adversarial/concurrency-race.test.ts
+++ b/test/adversarial/concurrency-race.test.ts
@@ -73,6 +73,7 @@ describe("TEST-27: Workflow Run Double-Submit Race", () => {
     const nowIso = "2025-06-15T10:00:00.000Z";
 
     const runtime = createFridayWorkflowRuntime({
+      allowTestOnlyWorkflowRunExecution: true, // TS-retirement method guard: test-oracle opt-in
       db,
       idGenerator,
       nowIso: () => nowIso,

--- a/test/e2e/api/friday-api-dp10-reflex-organic-candidate.probe.test.ts
+++ b/test/e2e/api/friday-api-dp10-reflex-organic-candidate.probe.test.ts
@@ -366,6 +366,7 @@ describe("DP-10 probe — repeated sessions.run tasks create Reflex candidates b
     });
 
     const workflowRuntime = createFridayWorkflowRuntime({
+      allowTestOnlyWorkflowRunExecution: true, // TS-retirement method guard: test-oracle opt-in
       db,
       idGenerator,
       nowIso: () => NOW,
@@ -513,6 +514,7 @@ describe("DP-10 probe — repeated sessions.run tasks create Reflex candidates b
     }> = [];
 
     const workflowRuntime = createFridayWorkflowRuntime({
+      allowTestOnlyWorkflowRunExecution: true, // TS-retirement method guard: test-oracle opt-in
       db,
       idGenerator,
       nowIso: () => NOW,

--- a/test/e2e/api/friday-api-dp10-sop-memory-workflow.probe.test.ts
+++ b/test/e2e/api/friday-api-dp10-sop-memory-workflow.probe.test.ts
@@ -249,6 +249,7 @@ describe("DP-10 probe — SOP memory triggers workflow execution", () => {
     }> = [];
 
     const workflowRuntime = createFridayWorkflowRuntime({
+      allowTestOnlyWorkflowRunExecution: true, // TS-retirement method guard: test-oracle opt-in
       db,
       idGenerator,
       nowIso: () => NOW,

--- a/test/e2e/api/friday-api-task-workflow-rollback-matrix.acceptance.test.ts
+++ b/test/e2e/api/friday-api-task-workflow-rollback-matrix.acceptance.test.ts
@@ -76,6 +76,7 @@ function makeGraph(
 
 function createRuntime(db: FridaySqliteLayer): FridayWorkflowRuntime {
   return createFridayWorkflowRuntime({
+    allowTestOnlyWorkflowRunExecution: true, // TS-retirement method guard: test-oracle opt-in
     db,
     idGenerator: createTestIdGenerator(),
     nowIso: () => NOW,

--- a/test/e2e/api/friday-api-workflow-completion-verification-enforcement.acceptance.test.ts
+++ b/test/e2e/api/friday-api-workflow-completion-verification-enforcement.acceptance.test.ts
@@ -120,6 +120,7 @@ describe("Audit C part-2: workflow completion-verification run-level enforcement
 
   function buildRuntime(db: FridaySqliteLayer, opts?: { gate?: Promise<void> }): FridayWorkflowRuntime {
     return createFridayWorkflowRuntime({
+      allowTestOnlyWorkflowRunExecution: true, // TS-retirement method guard: test-oracle opt-in
       db,
       idGenerator: createTestIdGenerator(),
       nowIso: () => NOW,
@@ -306,6 +307,7 @@ describe("Audit C Stage 2A: filesystem-write evidence → verified, end-to-end t
 
   function buildFsRuntime(db: FridaySqliteLayer, honest: boolean): FridayWorkflowRuntime {
     return createFridayWorkflowRuntime({
+      allowTestOnlyWorkflowRunExecution: true, // TS-retirement method guard: test-oracle opt-in
       db,
       idGenerator: createTestIdGenerator(),
       nowIso: () => NOW,

--- a/test/e2e/api/friday-api-workflow-evidence-fail-closed.acceptance.test.ts
+++ b/test/e2e/api/friday-api-workflow-evidence-fail-closed.acceptance.test.ts
@@ -85,6 +85,7 @@ function makeGraph(
 
 function createRuntime(db: FridaySqliteLayer): FridayWorkflowRuntime {
   return createFridayWorkflowRuntime({
+    allowTestOnlyWorkflowRunExecution: true, // TS-retirement method guard: test-oracle opt-in
     db,
     idGenerator: createTestIdGenerator(),
     nowIso: () => NOW,

--- a/test/e2e/ui/friday-reflex-review-center-real-browser.e2e.test.ts
+++ b/test/e2e/ui/friday-reflex-review-center-real-browser.e2e.test.ts
@@ -972,6 +972,7 @@ describe.skipIf(!CHROMIUM_AVAILABLE)("Friday Reflex Review Center real-browser f
 
       const createDogfoodWorkflowRuntime = () =>
         createFridayWorkflowRuntime({
+          allowTestOnlyWorkflowRunExecution: true, // TS-retirement method guard: test-oracle opt-in
           db,
           idGenerator,
           nowIso: () => DP10_DOGFOOD_NOW,

--- a/test/e2e/workflows/friday-workflow-timeout-chain.test.ts
+++ b/test/e2e/workflows/friday-workflow-timeout-chain.test.ts
@@ -120,6 +120,7 @@ describe("Workflow timeout job", () => {
 
     // Skill invocations never resolve (hang forever — simulates long-running node)
     runtime = createFridayWorkflowRuntime({
+      allowTestOnlyWorkflowRunExecution: true, // TS-retirement method guard: test-oracle opt-in
       db: sqlite,
       idGenerator: idGen,
       nowIso: () => time.get(),

--- a/test/integration/hub/friday-hub-bootstrap-integration.test.ts
+++ b/test/integration/hub/friday-hub-bootstrap-integration.test.ts
@@ -199,6 +199,7 @@ describe("FridayHub Bootstrap Integration", () => {
     managedSkillsDir: string,
   ): Promise<FridayHub> {
     const hub = await createFridayHub({
+      allowTestOnlyWorkflowRunExecution: true, // TS-retirement method guard: test-oracle opt-in
       stateDir,
       skillDirs: [bundledSkillsDir, managedSkillsDir],
     });
@@ -817,6 +818,7 @@ describe("FridayHub Bootstrap Integration", () => {
     });
 
     const hub = await createFridayHub({
+      allowTestOnlyWorkflowRunExecution: true, // TS-retirement method guard: test-oracle opt-in
       stateDir,
       skillDirs: [bundledSkillsDir, managedSkillsDir],
       tokenSecret: PHASE32_TOKEN_SECRET,

--- a/test/integration/workflows/friday-workflow-approval-chain.test.ts
+++ b/test/integration/workflows/friday-workflow-approval-chain.test.ts
@@ -78,6 +78,7 @@ describe("Workflow Approval Chain (Integration)", () => {
     invokeSkill = vi.fn().mockResolvedValue({ result: "ok" });
 
     runtime = createFridayWorkflowRuntime({
+      allowTestOnlyWorkflowRunExecution: true, // TS-retirement method guard: test-oracle opt-in
       db,
       idGenerator: createTestIdGenerator(),
       nowIso: () => NOW,

--- a/test/integration/workflows/friday-workflow-execution-lifecycle.test.ts
+++ b/test/integration/workflows/friday-workflow-execution-lifecycle.test.ts
@@ -67,6 +67,7 @@ describe("Workflow Execution Lifecycle (Integration)", () => {
     invokeSkill = vi.fn().mockResolvedValue({ result: "ok" });
 
     runtime = createFridayWorkflowRuntime({
+      allowTestOnlyWorkflowRunExecution: true, // TS-retirement method guard: test-oracle opt-in
       db,
       idGenerator: createTestIdGenerator(),
       nowIso: () => NOW,

--- a/test/integration/workflows/friday-workflow-pipeline-mode.test.ts
+++ b/test/integration/workflows/friday-workflow-pipeline-mode.test.ts
@@ -111,6 +111,7 @@ function createRuntimeWithOptions(
   },
 ): FridayWorkflowRuntime {
   return createFridayWorkflowRuntime({
+    allowTestOnlyWorkflowRunExecution: true, // TS-retirement method guard: test-oracle opt-in
     db,
     idGenerator: createTestIdGenerator(),
     nowIso: () => NOW,

--- a/test/integration/workflows/friday-workflow-playbook-persistence.test.ts
+++ b/test/integration/workflows/friday-workflow-playbook-persistence.test.ts
@@ -57,6 +57,7 @@ function makeGraph(
 
 function createRuntime(db: FridaySqliteLayer): FridayWorkflowRuntime {
   return createFridayWorkflowRuntime({
+    allowTestOnlyWorkflowRunExecution: true, // TS-retirement method guard: test-oracle opt-in
     db,
     idGenerator: createTestIdGenerator(),
     nowIso: () => "2026-02-28T12:00:00.000Z",

--- a/test/integration/workflows/friday-workflow-run-evidence.test.ts
+++ b/test/integration/workflows/friday-workflow-run-evidence.test.ts
@@ -57,6 +57,7 @@ function makeGraph(
 
 function createRuntime(db: FridaySqliteLayer): FridayWorkflowRuntime {
   return createFridayWorkflowRuntime({
+    allowTestOnlyWorkflowRunExecution: true, // TS-retirement method guard: test-oracle opt-in
     db,
     idGenerator: createTestIdGenerator(),
     nowIso: () => NOW,

--- a/test/integration/workflows/friday-workflow-trigger-chain.test.ts
+++ b/test/integration/workflows/friday-workflow-trigger-chain.test.ts
@@ -65,6 +65,7 @@ describe("Workflow Trigger Chain (Integration)", () => {
     invokeSkill = vi.fn().mockResolvedValue({ result: "ok" });
 
     runtime = createFridayWorkflowRuntime({
+      allowTestOnlyWorkflowRunExecution: true, // TS-retirement method guard: test-oracle opt-in
       db,
       idGenerator: createTestIdGenerator(),
       nowIso: () => NOW,

--- a/test/integration/workflows/friday-workflow-trigger-retirement-guard.test.ts
+++ b/test/integration/workflows/friday-workflow-trigger-retirement-guard.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createHash, createHmac } from "node:crypto";
+import type { FridaySqliteLayer } from "#state";
+import {
+  createFridayWorkflowRuntime,
+  createFridayWorkflowTriggerRepository,
+} from "#workflows";
+import type {
+  FridayWorkflowRuntime,
+  FridayWorkflowTriggerRepository,
+  FridayCompiledWorkflowGraphV2,
+} from "#workflows";
+import { createTestDb, createTestIdGenerator } from "../../helpers/friday-test-db.helper.js";
+
+/**
+ * Phase 3 guard-placement fix (POST_TS_RECONCILIATION_LEDGER §1).
+ *
+ * TS Runtime Retirement was ROUTE-only: POST /v1/workflow-runs fails closed at the
+ * HTTP route wrapper, but the underlying `workflowExecution.startRun` METHOD had no
+ * retirement guard. Non-route callers — the default-on 60s cron scheduler, webhook
+ * ingress, event ingress, and direct manual fire — reach `startRun` directly,
+ * bypassing the route guard.
+ *
+ * These tests prove the guard now lives on the METHOD: in default/live config
+ * (test-oracle flag unset) every non-route trigger vector fails closed and creates
+ * NO workflow_runs row — even when a valid published, triggered workflow exists
+ * (the exact §1 firing condition). With the explicit test-oracle flag enabled, the
+ * legacy path still works (so existing harnesses are preserved).
+ */
+
+const NOW = "2026-02-18T10:00:00.000Z";
+const PAST = "2020-01-01T00:00:00.000Z"; // ensures cron registration is "due" at NOW
+const RETIRED_CODE = "TS_RUNTIME_WORKFLOW_RUNS_RETIRED";
+const WEBHOOK_TOKEN = "tok_phase3_guard_placement_webhook_token_value";
+const WEBHOOK_SECRET_REF = "ref://workflow-webhook-secret";
+const WEBHOOK_SECRET = "phase3-guard-placement-webhook-shared-secret";
+
+function makeGraph(
+  workflowId: string,
+  versionId: string,
+): FridayCompiledWorkflowGraphV2 {
+  return {
+    schemaVersion: "2.0",
+    workflowId,
+    workflowVersionId: versionId,
+    sourceSpecSchemaVersion: "1.0",
+    graph: {
+      nodes: [
+        { id: "trigger", type: "trigger", label: "Trigger", config: {} },
+        {
+          id: "action1",
+          type: "action",
+          label: "Action 1",
+          config: { skillId: "test-skill" },
+        },
+      ],
+      edges: [{ id: "e1", sourceNodeId: "trigger", targetNodeId: "action1" }],
+    },
+    failurePolicy: { onFailure: "fail_fast", notifyUser: false },
+    tests: [],
+    checksum: "placeholder",
+  };
+}
+
+describe("Workflow trigger/scheduler retirement guard (method-level, §1)", () => {
+  let db: FridaySqliteLayer;
+  let triggerRepo: FridayWorkflowTriggerRepository;
+  let invokeSkill: ReturnType<typeof vi.fn>;
+
+  function buildRuntime(opts: { allowTestOnly: boolean }): FridayWorkflowRuntime {
+    return createFridayWorkflowRuntime({
+      // The whole point of §1: production leaves this unset → method fail-closed.
+      ...(opts.allowTestOnly ? { allowTestOnlyWorkflowRunExecution: true } : {}),
+      db,
+      idGenerator: createTestIdGenerator(),
+      nowIso: () => NOW,
+      computeChecksum: (content: string) =>
+        createHash("sha256").update(content).digest("hex"),
+      resolveSkill: () => ({ id: "test-skill" }),
+      invokeSkill,
+      triggerRepo,
+      resolveWebhookSecretRef: (ref: string) =>
+        ref === WEBHOOK_SECRET_REF ? WEBHOOK_SECRET : null,
+    });
+  }
+
+  function publishWorkflow(runtime: FridayWorkflowRuntime, slug: string): {
+    workflowId: string;
+    versionId: string;
+  } {
+    const wf = runtime.crud.createWorkflow({ slug, name: slug });
+    const version = runtime.crud.createVersion(wf.id, makeGraph(wf.id, "placeholder"));
+    runtime.crud.publishVersion(wf.id, version.versionNumber);
+    return { workflowId: wf.id, versionId: version.id };
+  }
+
+  function persistCronReg(workflowId: string, versionId: string): void {
+    triggerRepo.upsertManyForVersion([
+      {
+        id: `cron-${workflowId}`,
+        workflowId,
+        workflowVersionId: versionId,
+        triggerNodeId: "trigger",
+        triggerType: "cron",
+        enabled: true,
+        cronExpression: "* * * * *",
+        dedupeWindowSec: 0,
+        nextFireAt: PAST,
+        createdAt: NOW,
+        updatedAt: NOW,
+      },
+    ]);
+  }
+
+  function persistEventReg(workflowId: string, versionId: string): void {
+    triggerRepo.upsertManyForVersion([
+      {
+        id: `event-${workflowId}`,
+        workflowId,
+        workflowVersionId: versionId,
+        triggerNodeId: "trigger",
+        triggerType: "event",
+        enabled: true,
+        eventSource: "sys",
+        eventName: "thing.happened",
+        dedupeWindowSec: 0,
+        createdAt: NOW,
+        updatedAt: NOW,
+      },
+    ]);
+  }
+
+  function persistWebhookReg(workflowId: string, versionId: string): void {
+    triggerRepo.upsertManyForVersion([
+      {
+        id: `webhook-${workflowId}`,
+        workflowId,
+        workflowVersionId: versionId,
+        triggerNodeId: "trigger",
+        triggerType: "webhook",
+        enabled: true,
+        webhookPathToken: WEBHOOK_TOKEN,
+        webhookSecretRef: WEBHOOK_SECRET_REF,
+        dedupeWindowSec: 0,
+        createdAt: NOW,
+        updatedAt: NOW,
+      },
+    ]);
+  }
+
+  function signedWebhookInput() {
+    const body = { hello: "world" };
+    const rawBody = JSON.stringify(body);
+    const signature =
+      "sha256=" + createHmac("sha256", WEBHOOK_SECRET).update(rawBody).digest("hex");
+    return {
+      pathToken: WEBHOOK_TOKEN,
+      body,
+      rawBody,
+      headers: { "x-hub-signature-256": signature },
+    };
+  }
+
+  function runRowCount(): number {
+    return db.withReadConnection(
+      (conn) =>
+        (conn.prepare("SELECT COUNT(*) AS n FROM workflow_runs").get() as { n: number }).n,
+    );
+  }
+
+  beforeEach(() => {
+    db = createTestDb();
+    triggerRepo = createFridayWorkflowTriggerRepository({ db });
+    invokeSkill = vi.fn().mockResolvedValue({ result: "ok" });
+  });
+
+  afterEach(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    db.close();
+  });
+
+  // ─── Default/live config (flag unset): every non-route vector fails closed ───
+
+  describe("default config (test-oracle flag UNSET) — fail closed, no mutation", () => {
+    it("direct startRun method throws retired error and creates NO run row", async () => {
+      const runtime = buildRuntime({ allowTestOnly: false });
+      const { workflowId, versionId } = publishWorkflow(runtime, "direct-wf");
+
+      await expect(
+        runtime.execution.startRun({
+          workflowId,
+          workflowVersionId: versionId,
+          triggerType: "manual",
+        }),
+      ).rejects.toMatchObject({ code: RETIRED_CODE });
+
+      expect(runRowCount()).toBe(0);
+      expect(runtime.execution.listActiveRuns()).toHaveLength(0);
+    });
+
+    it("cron scheduler tick (the default-on 60s path) starts 0 runs and creates NO run row even with a due, published, triggered workflow", async () => {
+      const runtime = buildRuntime({ allowTestOnly: false });
+      const { workflowId, versionId } = publishWorkflow(runtime, "cron-wf");
+      persistCronReg(workflowId, versionId);
+
+      const started = await runtime.triggers.tickCron(NOW);
+
+      expect(started).toBe(0);
+      expect(runRowCount()).toBe(0);
+    });
+
+    it("event ingress (DB handleEvent + in-memory matchEvent) starts 0 runs and creates NO run row", async () => {
+      const runtime = buildRuntime({ allowTestOnly: false });
+      const { workflowId, versionId } = publishWorkflow(runtime, "event-wf");
+      persistEventReg(workflowId, versionId);
+      runtime.triggers.register(workflowId, versionId, {
+        type: "event",
+        source: "sys",
+        event: "thing.happened",
+      });
+
+      const dbStarted = await runtime.triggers.handleEvent({
+        source: "sys",
+        event: "thing.happened",
+        payload: { itemId: "1" },
+      });
+      const inMemRunIds = await runtime.triggers.matchEvent({
+        source: "sys",
+        event: "thing.happened",
+        payload: { itemId: "1" },
+      });
+
+      expect(dbStarted).toBe(0);
+      expect(inMemRunIds).toHaveLength(0);
+      expect(runRowCount()).toBe(0);
+    });
+
+    it("webhook ingress (valid HMAC signature) is not accepted and creates NO run row", async () => {
+      const runtime = buildRuntime({ allowTestOnly: false });
+      const { workflowId, versionId } = publishWorkflow(runtime, "webhook-wf");
+      persistWebhookReg(workflowId, versionId);
+
+      const result = await runtime.triggers.handleWebhook(signedWebhookInput());
+
+      // Reaches startRun past the HMAC gate, then fails closed → not accepted.
+      expect(result.accepted).toBe(false);
+      expect(result.runId).toBeUndefined();
+      expect(runRowCount()).toBe(0);
+    });
+
+    it("manual fire throws retired error and creates NO run row", async () => {
+      const runtime = buildRuntime({ allowTestOnly: false });
+      const { workflowId, versionId } = publishWorkflow(runtime, "manual-wf");
+
+      await expect(
+        runtime.triggers.fireManual({
+          workflowId,
+          workflowVersionId: versionId,
+          triggerType: "manual",
+        }),
+      ).rejects.toMatchObject({ code: RETIRED_CODE });
+
+      expect(runRowCount()).toBe(0);
+    });
+  });
+
+  // ─── Explicit test-oracle flag ON: legacy path still works ───
+
+  describe("test-oracle flag ON — legacy path preserved", () => {
+    it("direct startRun creates a run row", async () => {
+      const runtime = buildRuntime({ allowTestOnly: true });
+      const { workflowId, versionId } = publishWorkflow(runtime, "oracle-direct-wf");
+
+      const run = await runtime.execution.startRun({
+        workflowId,
+        workflowVersionId: versionId,
+        triggerType: "manual",
+      });
+
+      expect(run).not.toBeNull();
+      expect(run.workflowId).toBe(workflowId);
+      expect(runRowCount()).toBeGreaterThanOrEqual(1);
+    });
+
+    it("cron scheduler tick starts the due run", async () => {
+      const runtime = buildRuntime({ allowTestOnly: true });
+      const { workflowId, versionId } = publishWorkflow(runtime, "oracle-cron-wf");
+      persistCronReg(workflowId, versionId);
+
+      const started = await runtime.triggers.tickCron(NOW);
+
+      expect(started).toBe(1);
+      expect(runRowCount()).toBeGreaterThanOrEqual(1);
+    });
+  });
+});

--- a/test/integration/workflows/friday-workflow-trigger-retirement-guard.test.ts
+++ b/test/integration/workflows/friday-workflow-trigger-retirement-guard.test.ts
@@ -32,8 +32,8 @@ const NOW = "2026-02-18T10:00:00.000Z";
 const PAST = "2020-01-01T00:00:00.000Z"; // ensures cron registration is "due" at NOW
 const RETIRED_CODE = "TS_RUNTIME_WORKFLOW_RUNS_RETIRED";
 const WEBHOOK_TOKEN = "tok_phase3_guard_placement_webhook_token_value";
-const WEBHOOK_SECRET_REF = "ref://workflow-webhook-secret";
-const WEBHOOK_SECRET = "phase3-guard-placement-webhook-shared-secret";
+const WEBHOOK_SECRET_REF = "ref://workflow-webhook-secret"; // pragma: allowlist secret
+const WEBHOOK_SECRET = "phase3-guard-placement-webhook-shared-secret"; // pragma: allowlist secret
 
 function makeGraph(
   workflowId: string,

--- a/test/unit/api/runtime/friday-api-runtime-workflow-generator-registration.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-workflow-generator-registration.test.ts
@@ -133,6 +133,9 @@ describe("API Runtime — Workflow Generator Registration", () => {
     );
     const runtime = createFridayApiRuntime({
       ...makeBaseDeps(),
+      // TS-retirement method guard: this test exercises the fallback workflow
+      // runtime's startRun, so opt the fallback into the test-oracle path.
+      allowTestOnlyWorkflowRunExecution: true,
       idGenerator: () => `fallback-ai-id-${String(++idCounter)}`,
       invokeSkill,
       resolveSkill: () => ({ id: "ai-inference" }),

--- a/test/unit/hub/friday-channel-natural-trigger-runtime.test.ts
+++ b/test/unit/hub/friday-channel-natural-trigger-runtime.test.ts
@@ -108,6 +108,7 @@ async function createIsolatedHub(stateDir: string): Promise<FridayHub> {
   const skillsDir = path.join(stateDir, "skills-empty");
   await fs.mkdir(skillsDir, { recursive: true });
   return createFridayHub({
+    allowTestOnlyWorkflowRunExecution: true, // TS-retirement method guard: test-oracle opt-in
     skillDirs: [skillsDir],
     stateDir,
     channels: { enabled: false, instances: [] },

--- a/test/unit/hub/friday-hub-bootstrap.test.ts
+++ b/test/unit/hub/friday-hub-bootstrap.test.ts
@@ -698,7 +698,7 @@ describe("createFridayHub", () => {
   }, 20_000);
 
   it("rejects and approves workflow Reflex candidates from channel commands before running the published workflow", async () => {
-    hub = await createIsolatedHub();
+    hub = await createIsolatedHub({ allowTestOnlyWorkflowRunExecution: true });
     const channel = createTestChannelPlugin();
     hub.channelRegistry.register(channel.plugin);
 
@@ -929,7 +929,7 @@ describe("createFridayHub", () => {
       return mockLlmFetch(input, init);
     }) as typeof fetch;
 
-    hub = await createIsolatedHub();
+    hub = await createIsolatedHub({ allowTestOnlyWorkflowRunExecution: true });
     const channel = createTestChannelPlugin();
     hub.channelRegistry.register(channel.plugin);
 

--- a/test/unit/workflows/friday-workflow-execution-service-distributed.test.ts
+++ b/test/unit/workflows/friday-workflow-execution-service-distributed.test.ts
@@ -119,6 +119,7 @@ describe("FridayWorkflowExecutionService — distributed execution", () => {
     });
 
     return createFridayWorkflowExecutionService({
+      allowTestOnlyWorkflowRunExecution: true, // TS-retirement method guard: test-oracle opt-in
       db,
       workflowRepo,
       runRepo,

--- a/test/unit/workflows/friday-workflow-execution-service-edge-cases.test.ts
+++ b/test/unit/workflows/friday-workflow-execution-service-edge-cases.test.ts
@@ -755,6 +755,7 @@ describe("Issue 3 (R2): End-to-end workflow execution flows", () => {
     });
 
     return createFridayWorkflowExecutionService({
+      allowTestOnlyWorkflowRunExecution: true, // TS-retirement method guard: test-oracle opt-in
       db,
       workflowRepo,
       runRepo,

--- a/test/unit/workflows/runtime/friday-workflow-acceptance-run-enforcement.test.ts
+++ b/test/unit/workflows/runtime/friday-workflow-acceptance-run-enforcement.test.ts
@@ -49,6 +49,7 @@ function graph(workflowId: string): FridayCompiledWorkflowGraphV2 {
 
 function runtimeWith(db: FridaySqliteLayer, grants: Array<{ action: string }>, output: unknown = { ok: true }): FridayWorkflowRuntime {
   return createFridayWorkflowRuntime({
+    allowTestOnlyWorkflowRunExecution: true, // TS-retirement method guard: test-oracle opt-in
     db, idGenerator: createTestIdGenerator(), nowIso: () => NOW,
     computeChecksum: (c: string) => createHash("sha256").update(c).digest("hex"),
     resolveSkill: () => ({ id: "the-skill", manifest: { permissions: { grants } } }),

--- a/test/unit/workflows/runtime/friday-workflow-completion-verification-persistence.test.ts
+++ b/test/unit/workflows/runtime/friday-workflow-completion-verification-persistence.test.ts
@@ -48,6 +48,7 @@ function graph(workflowId: string): FridayCompiledWorkflowGraphV2 {
 
 function runtimeOn(db: FridaySqliteLayer, grants: Array<{ action: string }>): FridayWorkflowRuntime {
   return createFridayWorkflowRuntime({
+    allowTestOnlyWorkflowRunExecution: true, // TS-retirement method guard: test-oracle opt-in
     db, idGenerator: createTestIdGenerator(), nowIso: () => NOW,
     computeChecksum: (c: string) => createHash("sha256").update(c).digest("hex"),
     resolveSkill: () => ({ id: "the-skill", manifest: { permissions: { grants } } }),

--- a/test/unit/workflows/runtime/friday-workflow-runtime.test.ts
+++ b/test/unit/workflows/runtime/friday-workflow-runtime.test.ts
@@ -69,6 +69,7 @@ function makeGraph(
 
 function createRuntime(db: FridaySqliteLayer): FridayWorkflowRuntime {
   return createFridayWorkflowRuntime({
+    allowTestOnlyWorkflowRunExecution: true, // TS-retirement method guard: test-oracle opt-in
     db,
     idGenerator: createTestIdGenerator(),
     nowIso: () => NOW,
@@ -340,6 +341,7 @@ describe("audit C Stage 2A — runtime fs-write verification (real fs delta → 
 
   function buildRuntime(specs: Record<string, SkillSpec>): FridayWorkflowRuntime {
     return createFridayWorkflowRuntime({
+      allowTestOnlyWorkflowRunExecution: true, // TS-retirement method guard: test-oracle opt-in
       db: createTestDb(),
       idGenerator: createTestIdGenerator(),
       nowIso: () => NOW,


### PR DESCRIPTION
## Defect (POST_TS_RECONCILIATION_LEDGER §1)

TS Runtime Retirement was **ROUTE-only**. `POST /v1/workflow-runs` is fail-closed at the HTTP route wrapper (`allowTestOnlyWorkflowRunExecution` check in `src/api/runtime/friday-api-runtime.ts`), but the underlying workflow execution **`startRun` METHOD** (`src/workflows/services/friday-workflow-execution-service.ts`) had **no** retirement guard. Every non-route caller reaches it directly and bypasses the route guard:

- the **default-on 60s cron scheduler** (`workflow-cron-trigger` job → `tickCron` → `fireCronRegistration` → `startRun`)
- **webhook** ingress (`handleWebhook` → `startRun`, past the HMAC gate)
- **event** ingress (`handleEvent` / `matchEvent` → `startRun`)
- **channel** natural-trigger resolver (`friday-channel-natural-trigger-resolver.ts` → `startRun`)
- **agent `workflow_run` tool** (`friday-agent-workflow-tool.ts` → `startRun`)
- manual fire (`fireManual`) and workflow deploy `runNow` (`friday-workflow-product-service.ts`)

Latent today (live hub has 0 trigger registrations) but fires the moment any cron/webhook/event-triggered published workflow row exists. v1 structural product/safety blocker.

## Chosen fix shape: TS method-level fail-closed guard (Rust wiring deferred)

Preferred shape was wiring scheduler/trigger execution into the existing Rust `workflow_exec.rs`. **Deferred** because the TS trigger service (`tickCron`/`handleWebhook`/`handleEvent`/cron job/channel resolver/agent tool) is pure-TS and the Rust `workflow_exec`/`mission_runtime` engine is Mission-bound with a different input/state and gate/checkpoint/evidence contract; bridging the TS trigger-registration loaders + run-state into Rust is a large lane that would balloon scope. Per the prompt's ESTIMATE-FIRST guidance, this lane takes the **stopgap** and labels the Rust wiring as a follow-up.

The guard is placed at the **METHOD / non-route execution boundary**, not another HTTP route guard. Because every caller above funnels through `executionService.startRun`, a single guard at the top of `startRun` (BEFORE any DB read, run-row creation, node execution, provider/tool call) fences **all** of them. It throws the same `FridayDomainError("TS_RUNTIME_WORKFLOW_RUNS_RETIRED", 503, classification: fail_closed)` the route layer uses.

The existing `allowTestOnlyWorkflowRunExecution` flag is threaded through all production construction points so both layers honor the same flag:
- `src/hub/friday-hub-bootstrap.ts` (`config.allowTestOnlyWorkflowRunExecution` → workflow runtime) — **production leaves it unset → fail-closed**
- `src/workflows/runtime/friday-workflow-runtime.ts` (runtime deps → execution service)
- `src/api/runtime/friday-api-runtime.ts` (fallback runtime constructor → consistent with route flag)
- `src/workflows/services/friday-workflow-execution-service.ts` (the guard)

## Files changed

Production (4): `friday-workflow-execution-service.ts` (deps field + method guard), `friday-workflow-runtime.ts` (deps field + thread), `friday-hub-bootstrap.ts` (config → runtime), `friday-api-runtime.ts` (fallback thread).

Tests: 1 new focused file `test/integration/workflows/friday-workflow-trigger-retirement-guard.test.ts`; 23 existing workflow/runtime/hub/api/ui tests that legitimately exercise TS execution opt in via the same flag (one line each). `git diff --name-only main..HEAD` for the full list.

## Caller paths covered (all proven fail-closed, zero `workflow_runs` rows)

cron scheduler `tickCron` · webhook `handleWebhook` · event `handleEvent` + `matchEvent` · `fireManual` · direct `startRun` method · (also covered transitively: channel resolver, agent `workflow_run` tool, deploy `runNow`).

New tests assert **no mutation** (0 rows in `workflow_runs`, `listActiveRuns()` empty) even with a valid published, triggered workflow present (the exact §1 firing condition) — not just the thrown code — and that the flag-on test-oracle path still works (direct `startRun` + cron tick start a run).

## Decision recorded: `workflow-timeout-sweep` left unguarded (intentional)

The scheduler registers a second default-on job, `workflow-timeout-sweep` @30s (`reapExpiredLeases`/`sweepTimedOutRuns`/`sweepTimedOutNodes`). Left **unguarded** on purpose: it is terminal GC (marks stale leases/runs timed-out), executes no nodes and makes no provider/tool calls, and only acts on pre-existing rows. Guarding it would strand legacy runs as "running" forever. It is not part of the §1 trigger→start defect.

## Gates / tests run (results)

- `check:ts-runtime-retirement -- --json` → **status: passed, blocker=0, fail_closed=232, blockerFamilies=[]** (manifest truth unchanged)
- `typecheck` → no errors · `lint` → **0 errors** (1541 pre-existing warnings) · `check:secret-patterns` → clean · `git diff --check` → clean
- vitest **default** project → 925 files / 12567 passed, 0 failed
- vitest **browser-e2e** (`test:e2e:ui`, real chromium) → 13 files / 28 passed, 2 skipped — includes the reflex-review-center "fresh trigger execution" dogfood test (initially caught a missed direct-construction; now fixed + green)
- vitest **llm-e2e** → skips without credentials (the two workflow-exercising members set the flag; `friday-llm-e2e` does not touch workflow execution)
- new focused test file → 7/7 passed

## Scope / honesty

This lane closes the Phase 2 **route-only guard defect** for the workflow trigger→start path only. It does **not** claim Friday v1 GO and does **not** change closure GO/NO-GO semantics, write prod DBs, or boot a prod hub.

## Remaining follow-up lanes

- **Rust ownership** of scheduler/trigger workflow execution (wire into `workflow_exec.rs`/`mission_runtime.rs`) — the preferred long-term shape, deferred here.
- **`executeRun` heartbeat/autonomous path** (ledger §1 UNPROVEN) — separate lane.
- **Execution-surface completeness**: `resumeRun`/`retryRun`/`reportRemoteNodeResult` advancing a pre-existing/imported run row (route-guarded today; non-route callers = approval auto-resume, managed-async-dispatch, self-healing retry — only reachable for runs `startRun` created, which is now fail-closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)