### PR TITLE
fix(agent): move TS-retirement guard to executeRun method + complete RGG agent-run exclusions (Phase 3b)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -562,14 +562,14 @@
         "filename": "test/e2e/setup-wizard.e2e.test.ts",
         "hashed_secret": "9d6c140e80814290940bd258644431f5d4255fd4",
         "is_verified": false,
-        "line_number": 1492
+        "line_number": 1493
       },
       {
         "type": "Secret Keyword",
         "filename": "test/e2e/setup-wizard.e2e.test.ts",
         "hashed_secret": "1800af6e29fca70d9b324a27c567a5403d655429",
         "is_verified": false,
-        "line_number": 1514
+        "line_number": 1515
       }
     ],
     "test/integration/providers/friday-provider-service-lifecycle.test.ts": [
@@ -1124,5 +1124,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-07T01:06:36Z"
+  "generated_at": "2026-06-07T08:39:49Z"
 }

--- a/scripts/ops/run-real-green-gate.mjs
+++ b/scripts/ops/run-real-green-gate.mjs
@@ -138,9 +138,38 @@ export function resolveEffectiveExternalChannelScenarios(excludedScenarioIds) {
   return EXTERNAL_CHANNEL_SCENARIOS.filter((id) => !excluded.has(id));
 }
 
+// Every catalog scenario whose execution depends on POST /v1/agent/runs — i.e.
+// every scenario built with execution.kind === "agent_run" (the executeAgentRun
+// executor calls client.startAgentRun -> POST /v1/agent/runs). Once
+// agent_runs_start is classified fail_closed in the TS runtime retirement
+// manifest that route returns 503 TS_RUNTIME_AGENT_RUNS_RETIRED before any
+// product logic, so these scenarios cannot drive a TS agent run and are honestly
+// recorded as excluded (not a fake pass). In economy mode the provider-lane
+// scenarios were already excluded as provider scenarios; the two lane="none"
+// scenarios (destructive-approval-gate, channel-origin-task-state) needed the
+// explicit exclusion. In full mode (LIVE_PROVIDER_MODE=full) the provider-lane
+// agent_run scenarios DO run, so every one must be enumerated here or the gate
+// reds with ~21 agent-run failures (smoke + daily-core instances). The set below
+// is the complete agent_run catalog enumeration; sessions_run has no dependent
+// scenario (no catalog scenario drives POST /v1/sessions/:sessionKey/run).
 const AGENT_RUN_START_DEPENDENT_SCENARIOS = [
+  "l3-memory-api-store-agent-recall-proof",
+  "l3-chat-direct-answer",
+  "l3-agent-replayable-evidence-receipt",
+  "l3-summary-misroute-guard",
+  "l3-vague-goal-awaiting-user-state",
   "l3-destructive-request-visible-approval-gate",
   "l3-channel-origin-unified-task-state-contract",
+  "l3-long-summary-direct",
+  "l3-json-extraction",
+  "l3-multi-turn-memory",
+  "l4-file-tool-roundtrip",
+  "l4-missing-file-no-verified-success",
+  "l4-exec-outside-workspace-boundary",
+  "l4-tool-search-deferred-tool-discovery",
+  "l4-context-cost-control-evidence",
+  "l4-tool-guardrail-pre-post-evidence",
+  "l8-agent-core-soak",
 ];
 
 const WORKFLOW_RUN_START_DEPENDENT_SCENARIOS = [

--- a/src/agent/runtime/friday-agent-runtime.ts
+++ b/src/agent/runtime/friday-agent-runtime.ts
@@ -789,6 +789,31 @@ export function createFridayAgentRuntime(
     emitRunEvent,
 
     async executeRun(params) {
+      // ─── TS Runtime Retirement: METHOD-level fail-closed guard ───
+      // Phase 3b reconciliation: the agent-run retirement was ROUTE-only
+      // (POST /v1/agent/runs and POST /v1/sessions/:sessionKey/run). Every
+      // non-route caller reaches this method directly via
+      // `agentRuntime.executeRun(...)` / child `executeChildRun`, bypassing the
+      // HTTP route guards: heartbeat runner, channel entry adapter, cron
+      // dynamic-job runner, autonomous engine, planning gate, subagent child
+      // runtime, and the agent-sessions tool. Guarding here fails ALL non-route
+      // callers closed BEFORE any DB read, run-row creation, provider call, or
+      // tool call — unless the explicit test-oracle flag is set. Never default
+      // this flag on in production.
+      if (deps.allowTestOnlyAgentRunExecution !== true) {
+        void params;
+        throw new FridayDomainError(
+          "TS_RUNTIME_AGENT_RUN_RETIRED",
+          "Agent run execution is fail-closed while runtime ownership is being moved out of TypeScript.",
+          {
+            httpStatus: 503,
+            details: {
+              classification: "fail_closed",
+              replacement: "rust_owned_agent_run_entrypoint_required",
+            },
+          },
+        );
+      }
       const runId = params.runId ?? idGenerator();
       const runCorrelationId = runId;
       const sessionKey = params.sessionKey ?? `${FRIDAY_AGENT_SESSION_KEY_PREFIX}${runId}`;

--- a/src/agent/runtime/friday-agent-runtime.types.ts
+++ b/src/agent/runtime/friday-agent-runtime.types.ts
@@ -439,6 +439,19 @@ export interface CreateFridayAgentRuntimeDeps {
     decidedByPrincipalType?: string;
     approvalSurface?: string;
   }>;
+  /**
+   * Test-oracle ONLY. When not explicitly `true`, the agent run loop
+   * `executeRun` method fails closed at the METHOD boundary (not just the HTTP
+   * agent-run / session-run routes), so every non-route caller — heartbeat
+   * runner, channel entry adapter, cron dynamic-job runner, autonomous engine,
+   * planning gate, subagent child runtime, and any future autonomous caller — is
+   * fenced out of the TypeScript agent runtime while runtime ownership is moved
+   * to Rust. Production hub bootstrap leaves this unset → fail-closed. Mirrors
+   * the route-level `allowTestOnlyAgentRunStartExecution` /
+   * `allowTestOnlySessionRunExecution` guards so the method honors the same
+   * test-oracle contract. NEVER default this on in production.
+   */
+  allowTestOnlyAgentRunExecution?: boolean;
   /** Enforce the canonical mutating action gate for tool calls before side effects. */
   canonicalMutatingActionGate?: boolean;
   /** Server-owned secret used to sign canonical approvals passed to downstream runtimes. */

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -1872,6 +1872,8 @@ export interface FridayHubConfig {
   allowTestOnlyAgentRunStartExecution?: boolean;
   /** Test-oracle only; production hub creation must leave agent run controls fail-closed. */
   allowTestOnlyAgentRunControlExecution?: boolean;
+  /** Test-oracle only; production hub creation must leave the agent run loop executeRun method fail-closed. */
+  allowTestOnlyAgentRunExecution?: boolean;
   /** Test-oracle only; production hub creation must leave autonomy subject upgrade-lifecycle fail-closed. */
   allowTestOnlyAutonomyLifecycleExecution?: boolean;
   /** Test-oracle only; production hub creation must leave standing-goal/agenda mutations fail-closed. */

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -4786,6 +4786,10 @@ export async function createFridayHub(
   });
 
   const agentRuntime = createFridayAgentRuntime({
+    // TS Runtime Retirement (method-level guard): production leaves this unset
+    // (config flag undefined) so the agent run loop `executeRun` method is
+    // fail-closed for every non-route caller. Test-oracle hub configs set it true.
+    allowTestOnlyAgentRunExecution: config.allowTestOnlyAgentRunExecution,
     db: stateRuntime!.sqlite,
     llmClient: agentLlmClient,
     model: agentDefaultModel,
@@ -5101,6 +5105,12 @@ export async function createFridayHub(
         subagentForkModeEnabled,
       });
       const childRuntime = createFridayAgentRuntime({
+        // TS Runtime Retirement (method-level guard): the child/subagent runtime
+        // must receive the SAME test-oracle flag as the parent factory, otherwise
+        // a flag-on parent run would fail-closed mid-run when it spawns a
+        // subagent (child `executeChildRun` -> childRuntime.executeRun).
+        // Production leaves config undefined → fail-closed.
+        allowTestOnlyAgentRunExecution: config.allowTestOnlyAgentRunExecution,
         db: stateRuntime!.sqlite,
         llmClient: agentLlmClient,
         model: params.model ?? agentDefaultModel,

--- a/test/adversarial/approval-boundary-structure.test.ts
+++ b/test/adversarial/approval-boundary-structure.test.ts
@@ -164,6 +164,7 @@ describe("Structural approval-boundary adversarial coverage", () => {
       ]);
 
       const runtime = createFridayAgentRuntime({
+        allowTestOnlyAgentRunExecution: true,
         db,
         llmClient,
         model: "test-model",

--- a/test/adversarial/truth-alignment.test.ts
+++ b/test/adversarial/truth-alignment.test.ts
@@ -135,6 +135,7 @@ describe("Structural truth alignment adversarial coverage", () => {
       ]);
 
       const runtime = createFridayAgentRuntime({
+        allowTestOnlyAgentRunExecution: true,
         db,
         llmClient,
         model: "test-model",
@@ -226,6 +227,7 @@ describe("Structural truth alignment adversarial coverage", () => {
       ]);
 
       const runtime = createFridayAgentRuntime({
+        allowTestOnlyAgentRunExecution: true,
         db,
         llmClient,
         model: "test-model",

--- a/test/e2e/api/friday-api-dp10-cross-session-sop-memory.probe.test.ts
+++ b/test/e2e/api/friday-api-dp10-cross-session-sop-memory.probe.test.ts
@@ -155,6 +155,7 @@ describe("DP-10 probe — cross-session SOP trigger memory", () => {
     };
 
     const agentRuntime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "dp10-deterministic-model",

--- a/test/e2e/api/friday-api-dp10-reflex-organic-candidate.probe.test.ts
+++ b/test/e2e/api/friday-api-dp10-reflex-organic-candidate.probe.test.ts
@@ -349,6 +349,7 @@ describe("DP-10 probe — repeated sessions.run tasks create Reflex candidates b
 
     const eventEmitter = createFridayAgentEventEmitter();
     const agentRuntime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "dp10-c2-deterministic-model",
@@ -766,6 +767,7 @@ describe("DP-10 probe — repeated sessions.run tasks create Reflex candidates b
 
     const eventEmitter = createFridayAgentEventEmitter();
     const agentRuntime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "dp10-c5-deterministic-model",

--- a/test/e2e/api/friday-api-dp10-sop-memory-workflow.probe.test.ts
+++ b/test/e2e/api/friday-api-dp10-sop-memory-workflow.probe.test.ts
@@ -360,6 +360,7 @@ describe("DP-10 probe — SOP memory triggers workflow execution", () => {
     };
 
     const agentRuntime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "dp10-deterministic-model",

--- a/test/e2e/friday-full-e2e.test.ts
+++ b/test/e2e/friday-full-e2e.test.ts
@@ -130,6 +130,7 @@ describe.skipIf(!CORE_E2E_ENABLED)("Friday Full E2E — Batch 1 (A–F)", () => 
       allowTestOnlyWorkflowDeployExecution: true,
       allowTestOnlySessionExecution: true,
       allowTestOnlySessionRunExecution: true,
+      allowTestOnlyAgentRunExecution: true,
       allowTestOnlySessionMemoryExtractionExecution: true,
       allowTestOnlyRealtimeExecution: true,
       allowTestOnlySkillConverterExecution: true,

--- a/test/e2e/friday-real-scenarios-e2e.test.ts
+++ b/test/e2e/friday-real-scenarios-e2e.test.ts
@@ -145,6 +145,7 @@ describe.skipIf(!CORE_E2E_ENABLED)("Friday Real Scenarios E2E (NON-LLM)", () => 
       allowTestOnlyWorkflowDeployExecution: true,
       allowTestOnlySessionExecution: true,
       allowTestOnlySessionRunExecution: true,
+      allowTestOnlyAgentRunExecution: true,
       allowTestOnlySessionMemoryExtractionExecution: true,
       allowTestOnlySkillConverterExecution: true,
     });
@@ -1671,6 +1672,7 @@ describe.skipIf(!ANTHROPIC_E2E_ENABLED || !HAS_LLM_CREDENTIAL)(
         allowTestOnlyWorkflowDeployExecution: true,
         allowTestOnlySessionExecution: true,
         allowTestOnlySessionRunExecution: true,
+        allowTestOnlyAgentRunExecution: true,
         allowTestOnlySessionMemoryExtractionExecution: true,
       });
       await hub.start();

--- a/test/e2e/live/_helpers/real-env.ts
+++ b/test/e2e/live/_helpers/real-env.ts
@@ -323,6 +323,8 @@ async function startLocalRealHubEnv(
       allowTestOnlyCapabilityAcquisitionExecution: true,
       allowTestOnlySessionExecution: true,
       allowTestOnlySessionRunExecution: true,
+      // Session-run reaches the agent loop executeRun method, now method-guarded.
+      allowTestOnlyAgentRunExecution: true,
       allowTestOnlySessionMemoryExtractionExecution: true,
       allowTestOnlyDiagnosisExecution: true,
       allowTestOnlyRealtimeExecution: true,

--- a/test/e2e/live/friday-execution-voice-live.e2e.test.ts
+++ b/test/e2e/live/friday-execution-voice-live.e2e.test.ts
@@ -156,6 +156,7 @@ async function createLiveVoiceRuntime(db: FridaySqliteLayer, idGenerator: () => 
   const llmClient = createLiveVoiceLlmClient();
 
   return createFridayAgentRuntime({
+    allowTestOnlyAgentRunExecution: true,
     db,
     llmClient,
     model: FAST_MODEL,

--- a/test/e2e/mock/_helpers/mock-env.ts
+++ b/test/e2e/mock/_helpers/mock-env.ts
@@ -347,6 +347,8 @@ export async function createMockHubEnv(opts?: {
   allowTestOnlyAgentRunStartExecution?: boolean;
   /** Test-oracle opt-in for legacy TS agent-run controls; set false to prove default fail-closed behavior. */
   allowTestOnlyAgentRunControlExecution?: boolean;
+  /** Test-oracle opt-in for the legacy TS agent run loop executeRun method; set false to prove default fail-closed behavior. */
+  allowTestOnlyAgentRunExecution?: boolean;
   /** Test-oracle opt-in for legacy TS session lifecycle/message mutations; set false to prove default fail-closed behavior. */
   allowTestOnlySessionExecution?: boolean;
   /** Test-oracle opt-in for legacy TS session agent-run execution; set false to prove default fail-closed behavior. */
@@ -414,6 +416,7 @@ export async function createMockHubEnv(opts?: {
       allowTestOnlyWorkflowDeployExecution: opts?.allowTestOnlyWorkflowDeployExecution ?? true,
       allowTestOnlyAgentRunStartExecution: opts?.allowTestOnlyAgentRunStartExecution ?? true,
       allowTestOnlyAgentRunControlExecution: opts?.allowTestOnlyAgentRunControlExecution ?? true,
+      allowTestOnlyAgentRunExecution: opts?.allowTestOnlyAgentRunExecution ?? true,
       allowTestOnlySessionExecution: opts?.allowTestOnlySessionExecution ?? true,
       allowTestOnlySessionRunExecution: opts?.allowTestOnlySessionRunExecution ?? true,
       allowTestOnlySessionMemoryExtractionExecution: opts?.allowTestOnlySessionMemoryExtractionExecution ?? true,

--- a/test/e2e/setup-wizard.e2e.test.ts
+++ b/test/e2e/setup-wizard.e2e.test.ts
@@ -159,6 +159,7 @@ describe("Setup Wizard E2E", () => {
         allowTestOnlyWorkflowBuilderDraftExecution: true,
         allowTestOnlySessionExecution: true,
         allowTestOnlySessionRunExecution: true,
+        allowTestOnlyAgentRunExecution: true,
         allowTestOnlySessionMemoryExtractionExecution: true,
         allowTestOnlySkillConverterExecution: true,
         allowTestOnlyProviderDetectExecution: true,

--- a/test/e2e/ui/friday-reflex-review-center-real-browser.e2e.test.ts
+++ b/test/e2e/ui/friday-reflex-review-center-real-browser.e2e.test.ts
@@ -1265,6 +1265,7 @@ describe.skipIf(!CHROMIUM_AVAILABLE)("Friday Reflex Review Center real-browser f
 
         const eventEmitter = createFridayAgentEventEmitter();
         const agentRuntime = createFridayAgentRuntime({
+          allowTestOnlyAgentRunExecution: true,
           db,
           llmClient,
           model: "dp10-dogfood-deterministic-model",

--- a/test/integration/agent/friday-agent-parity-acceptance.test.ts
+++ b/test/integration/agent/friday-agent-parity-acceptance.test.ts
@@ -118,6 +118,7 @@ describe("Agent parity acceptance (integration)", () => {
     };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -193,6 +194,7 @@ describe("Agent parity acceptance (integration)", () => {
     };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -225,6 +227,7 @@ describe("Agent parity acceptance (integration)", () => {
     };
 
     const agentRuntime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",

--- a/test/integration/agent/friday-browser-resilience-integration.test.ts
+++ b/test/integration/agent/friday-browser-resilience-integration.test.ts
@@ -120,6 +120,7 @@ describe("Browser Resilience Integration", () => {
     }
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient: createMockLlmClient(opts.llmEvents),
       model: "test-model",

--- a/test/integration/agent/friday-subagent-integration.test.ts
+++ b/test/integration/agent/friday-subagent-integration.test.ts
@@ -81,6 +81,7 @@ describe("FridaySubagentIntegration", () => {
         });
 
         const childRuntime = createFridayAgentRuntime({
+          allowTestOnlyAgentRunExecution: true,
           db,
           llmClient: childLlmClient,
           model: params.model ?? "test-model",
@@ -114,6 +115,7 @@ describe("FridaySubagentIntegration", () => {
 
     // Parent runtime
     const parentRuntime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient: parentLlmClient,
       model: "test-model",

--- a/test/unit/agent/runtime/friday-agent-benchmark-regressions.test.ts
+++ b/test/unit/agent/runtime/friday-agent-benchmark-regressions.test.ts
@@ -110,6 +110,7 @@ describe("Friday agent benchmark regressions", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -148,6 +149,7 @@ describe("Friday agent benchmark regressions", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -225,6 +227,7 @@ describe("Friday agent benchmark regressions", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -319,6 +322,7 @@ describe("Friday agent benchmark regressions", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",

--- a/test/unit/agent/runtime/friday-agent-evidence-durability.test.ts
+++ b/test/unit/agent/runtime/friday-agent-evidence-durability.test.ts
@@ -40,6 +40,7 @@ describe("FridayAgentRuntime evidence-durability fail-closed", () => {
           toolApprovalResolver: vi.fn(async () => ({ approved: true, decidedByPrincipalId: "p1" })) }
       : {};
     return createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db, llmClient: mockLlm(events), model: "m", providerId: "p", systemPrompt: "test",
       tools: [namedTool("write")],
       eventEmitter: createFridayAgentEventEmitter(), idGenerator, nowIso: () => NOW,

--- a/test/unit/agent/runtime/friday-agent-execution-voice-eval.test.ts
+++ b/test/unit/agent/runtime/friday-agent-execution-voice-eval.test.ts
@@ -86,6 +86,7 @@ describe("Friday execution voice eval", () => {
       };
 
       const runtime = createFridayAgentRuntime({
+        allowTestOnlyAgentRunExecution: true,
         db,
         llmClient,
         model: "test-model",

--- a/test/unit/agent/runtime/friday-agent-runtime-compaction-budget.test.ts
+++ b/test/unit/agent/runtime/friday-agent-runtime-compaction-budget.test.ts
@@ -57,6 +57,7 @@ describe("FridayAgentRuntime compaction budget", () => {
 
   function createRuntime(compactionBridge: { compact: ReturnType<typeof vi.fn> }) {
     return createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient: createMockLlmClient([
         [
@@ -113,6 +114,7 @@ describe("FridayAgentRuntime compaction budget", () => {
   it("returns context cost token estimates and includes them in provider routing", async () => {
     const routingContexts: Array<FridayAgentLlmStreamParams["routingContext"]> = [];
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient: createMockLlmClient(
         [
@@ -182,6 +184,7 @@ describe("FridayAgentRuntime compaction budget", () => {
       },
     }));
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient: createMockLlmClient([]),
       model: "test-model",

--- a/test/unit/agent/runtime/friday-agent-runtime-delegation.test.ts
+++ b/test/unit/agent/runtime/friday-agent-runtime-delegation.test.ts
@@ -35,6 +35,7 @@ describe("FridayAgentRuntime delegation", () => {
       },
     }));
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",

--- a/test/unit/agent/runtime/friday-agent-runtime-retirement-guard.test.ts
+++ b/test/unit/agent/runtime/friday-agent-runtime-retirement-guard.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { FridaySqliteLayer } from "#state";
+import { createTestDb, createTestIdGenerator } from "../../satellites/_helpers/create-test-db.helper.js";
+import {
+  createFridayAgentRuntime,
+  createFridayAgentEventEmitter,
+  createFridayAgentRunRepository,
+} from "#agent";
+import type { FridayAgentLlmClient, CreateFridayAgentRuntimeDeps } from "#agent";
+import { FridayDomainError } from "#errors";
+
+/**
+ * Phase 3b guard-placement fix.
+ *
+ * TS Runtime Retirement for agent runs was ROUTE-only: POST /v1/agent/runs and
+ * POST /v1/sessions/:sessionKey/run fail closed at the HTTP route wrappers, but
+ * the underlying agent run loop `executeRun` METHOD had no retirement guard.
+ * Non-route callers — heartbeat runner, channel entry adapter, cron dynamic-job
+ * runner, autonomous engine, planning gate, subagent child runtime, and the
+ * agent-sessions tool — reach `executeRun` directly, bypassing the route guards.
+ *
+ * These tests prove the guard now lives on the METHOD: in default/live config
+ * (test-oracle flag unset) `executeRun` fails closed BEFORE any DB read or
+ * run-row creation, creating NO friday_agent_runs row. With the explicit
+ * test-oracle flag enabled the legacy path still works (so existing harnesses
+ * and the mock/test env are preserved). A runtime built WITHOUT the flag — the
+ * exact failure mode if the hub child/subagent factory forgot to thread it —
+ * also fails closed, documenting why both the parent and child factories must
+ * propagate the flag.
+ */
+
+const NOW = "2026-02-18T10:00:00.000Z";
+const RETIRED_CODE = "TS_RUNTIME_AGENT_RUN_RETIRED";
+
+function makeHappyLlmClient(): FridayAgentLlmClient {
+  return {
+    async *stream() {
+      yield { type: "text_delta" as const, text: "Hello" };
+      yield {
+        type: "message_end" as const,
+        stopReason: "end_turn",
+        inputTokens: 1,
+        outputTokens: 1,
+      };
+    },
+  };
+}
+
+describe("FridayAgentRuntime TS-retirement method guard (executeRun)", () => {
+  let db: FridaySqliteLayer;
+  let idGenerator: () => string;
+
+  beforeEach(() => {
+    db = createTestDb();
+    idGenerator = createTestIdGenerator();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  function baseDeps(
+    overrides?: Partial<CreateFridayAgentRuntimeDeps>,
+  ): CreateFridayAgentRuntimeDeps {
+    return {
+      db,
+      llmClient: makeHappyLlmClient(),
+      model: "test-model",
+      providerId: "test-provider",
+      systemPrompt: "You are a test agent.",
+      tools: [],
+      eventEmitter: createFridayAgentEventEmitter(),
+      idGenerator,
+      nowIso: () => NOW,
+      ...overrides,
+    };
+  }
+
+  function countAgentRunRows(): number {
+    return db.withReadConnection((reader) =>
+      (reader
+        .prepare("SELECT COUNT(*) AS c FROM friday_agent_runs")
+        .get() as { c: number }).c,
+    );
+  }
+
+  it("fails closed by default (flag unset): throws TS_RUNTIME_AGENT_RUN_RETIRED 503 and creates no run row", async () => {
+    const runtime = createFridayAgentRuntime(baseDeps());
+    const fixedRunId = "agent-run-retired-0001";
+
+    let caught: unknown;
+    try {
+      await runtime.executeRun({ runId: fixedRunId, task: "Say hello" });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(FridayDomainError);
+    const domainError = caught as FridayDomainError;
+    expect(domainError.code).toBe(RETIRED_CODE);
+    expect(domainError.httpStatus).toBe(503);
+    expect(domainError.details).toMatchObject({
+      classification: "fail_closed",
+      replacement: "rust_owned_agent_run_entrypoint_required",
+    });
+
+    // The guard runs BEFORE any run-row creation: zero friday_agent_runs rows.
+    expect(countAgentRunRows()).toBe(0);
+    const repo = createFridayAgentRunRepository();
+    expect(db.withReadConnection((reader) => repo.getById(reader, fixedRunId))).toBeNull();
+  });
+
+  it("fails closed when the flag is explicitly false (only exact `true` opts in)", async () => {
+    const runtime = createFridayAgentRuntime(
+      baseDeps({ allowTestOnlyAgentRunExecution: false }),
+    );
+
+    await expect(
+      runtime.executeRun({ task: "Say hello" }),
+    ).rejects.toMatchObject({ code: RETIRED_CODE, httpStatus: 503 });
+    expect(countAgentRunRows()).toBe(0);
+  });
+
+  it("fails closed for a child/subagent-style runtime built WITHOUT the flag (threading contract)", async () => {
+    // A child runtime that does not receive `allowTestOnlyAgentRunExecution`
+    // (e.g. if the hub child factory forgot to thread it) must fail closed when
+    // a flag-on parent spawns it — this is why both factories must propagate it.
+    const childRuntime = createFridayAgentRuntime(
+      baseDeps({ systemPrompt: "You are a sub-agent." }),
+    );
+
+    await expect(
+      childRuntime.executeRun({ task: "Do the delegated work" }),
+    ).rejects.toMatchObject({ code: RETIRED_CODE, httpStatus: 503 });
+    expect(countAgentRunRows()).toBe(0);
+  });
+
+  it("runs normally when the test-oracle flag is enabled (legacy path preserved)", async () => {
+    const runtime = createFridayAgentRuntime(
+      baseDeps({ allowTestOnlyAgentRunExecution: true }),
+    );
+
+    const result = await runtime.executeRun({ task: "Say hello" });
+    expect(result.status).toBe("completed");
+    expect(countAgentRunRows()).toBeGreaterThan(0);
+  });
+});

--- a/test/unit/agent/runtime/friday-agent-runtime.test.ts
+++ b/test/unit/agent/runtime/friday-agent-runtime.test.ts
@@ -629,6 +629,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -660,6 +661,7 @@ describe("FridayAgentRuntime", () => {
     const llmClient: FridayAgentLlmClient = { stream: streamSpy };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "default",
@@ -704,6 +706,7 @@ describe("FridayAgentRuntime", () => {
     const llmClient: FridayAgentLlmClient = { stream: streamSpy };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "route-default-model",
@@ -760,6 +763,7 @@ describe("FridayAgentRuntime", () => {
     });
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -803,6 +807,7 @@ describe("FridayAgentRuntime", () => {
     };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -861,6 +866,7 @@ describe("FridayAgentRuntime", () => {
     };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -916,6 +922,7 @@ describe("FridayAgentRuntime", () => {
     };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -1001,6 +1008,7 @@ describe("FridayAgentRuntime", () => {
     };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -1044,6 +1052,7 @@ describe("FridayAgentRuntime", () => {
     };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -1124,6 +1133,7 @@ describe("FridayAgentRuntime", () => {
     };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -1183,6 +1193,7 @@ describe("FridayAgentRuntime", () => {
     };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -1243,6 +1254,7 @@ describe("FridayAgentRuntime", () => {
     };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -1293,6 +1305,7 @@ describe("FridayAgentRuntime", () => {
     };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -1358,6 +1371,7 @@ describe("FridayAgentRuntime", () => {
     };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -1442,6 +1456,7 @@ describe("FridayAgentRuntime", () => {
     };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -1513,6 +1528,7 @@ describe("FridayAgentRuntime", () => {
     };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -1597,6 +1613,7 @@ describe("FridayAgentRuntime", () => {
     };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -1681,6 +1698,7 @@ describe("FridayAgentRuntime", () => {
     };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -1762,6 +1780,7 @@ describe("FridayAgentRuntime", () => {
     };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -1832,6 +1851,7 @@ describe("FridayAgentRuntime", () => {
     };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -1909,6 +1929,7 @@ describe("FridayAgentRuntime", () => {
     };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -1966,6 +1987,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -2036,6 +2058,7 @@ describe("FridayAgentRuntime", () => {
     const usageRecorder = vi.fn(async () => {});
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -2071,6 +2094,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -2098,6 +2122,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -2129,6 +2154,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -2170,6 +2196,7 @@ describe("FridayAgentRuntime", () => {
     const webFetchSpy = vi.fn();
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -2208,6 +2235,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -2250,6 +2278,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -2298,6 +2327,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -2348,6 +2378,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -2404,6 +2435,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -2445,6 +2477,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -2509,6 +2542,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -2583,6 +2617,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -2660,6 +2695,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -2727,6 +2763,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -2770,6 +2807,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -2819,6 +2857,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -2868,6 +2907,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -2938,6 +2978,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -2992,6 +3033,7 @@ describe("FridayAgentRuntime", () => {
     };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -3053,6 +3095,7 @@ describe("FridayAgentRuntime", () => {
     };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -3120,6 +3163,7 @@ describe("FridayAgentRuntime", () => {
     };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -3172,6 +3216,7 @@ describe("FridayAgentRuntime", () => {
     };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -3235,6 +3280,7 @@ describe("FridayAgentRuntime", () => {
     };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -3278,6 +3324,7 @@ describe("FridayAgentRuntime", () => {
     };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -3316,6 +3363,7 @@ describe("FridayAgentRuntime", () => {
     };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -3372,6 +3420,7 @@ describe("FridayAgentRuntime", () => {
     };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -3434,6 +3483,7 @@ describe("FridayAgentRuntime", () => {
     };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -3484,6 +3534,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -3530,6 +3581,7 @@ describe("FridayAgentRuntime", () => {
     });
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -3577,6 +3629,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -3614,6 +3667,7 @@ describe("FridayAgentRuntime", () => {
     const feedbackSpy = vi.fn();
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -3658,6 +3712,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -3703,6 +3758,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -3751,6 +3807,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -3795,6 +3852,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -3839,6 +3897,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -3883,6 +3942,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -3927,6 +3987,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -3968,6 +4029,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -4024,6 +4086,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -4056,6 +4119,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -4115,6 +4179,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -4208,6 +4273,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -4265,6 +4331,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -4311,6 +4378,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -4363,6 +4431,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -4410,6 +4479,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -4462,6 +4532,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -4553,6 +4624,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -4614,6 +4686,7 @@ describe("FridayAgentRuntime", () => {
     });
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -4661,6 +4734,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -4706,6 +4780,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -4790,6 +4865,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -4833,6 +4909,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -4866,6 +4943,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -4905,6 +4983,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -4943,6 +5022,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -4974,6 +5054,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -5013,6 +5094,7 @@ describe("FridayAgentRuntime", () => {
     emitter.on("agent.run.mode_changed", (p) => modeChangedEvents.push(p));
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -5049,6 +5131,7 @@ describe("FridayAgentRuntime", () => {
     emitter.on("agent.run.completed", (p) => events.push({ event: "completed", payload: p }));
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -5099,6 +5182,7 @@ describe("FridayAgentRuntime", () => {
       });
 
       const runtime = createFridayAgentRuntime({
+        allowTestOnlyAgentRunExecution: true,
         db,
         llmClient,
         model: "test-model",
@@ -5160,6 +5244,7 @@ describe("FridayAgentRuntime", () => {
     });
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient: createMockLlmClient([]),
       model: "test-model",
@@ -5219,6 +5304,7 @@ describe("FridayAgentRuntime", () => {
     }));
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient: createMockLlmClient([]),
       model: "test-model",
@@ -5325,6 +5411,7 @@ describe("FridayAgentRuntime", () => {
     });
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient: createMockLlmClient([]),
       model: "test-model",
@@ -5404,6 +5491,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -5440,6 +5528,7 @@ describe("FridayAgentRuntime", () => {
     });
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -5485,6 +5574,7 @@ describe("FridayAgentRuntime", () => {
     };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -5540,6 +5630,7 @@ describe("FridayAgentRuntime", () => {
       },
     };
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -5603,6 +5694,7 @@ describe("FridayAgentRuntime", () => {
     });
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -5653,6 +5745,7 @@ describe("FridayAgentRuntime", () => {
     });
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -5710,6 +5803,7 @@ describe("FridayAgentRuntime", () => {
 
     const desktopSpy = vi.fn();
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -5750,6 +5844,7 @@ describe("FridayAgentRuntime", () => {
 
     const desktopSpy = vi.fn();
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -5797,6 +5892,7 @@ describe("FridayAgentRuntime", () => {
     });
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -5845,6 +5941,7 @@ describe("FridayAgentRuntime", () => {
     });
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -5891,6 +5988,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -5945,6 +6043,7 @@ describe("FridayAgentRuntime", () => {
     });
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -5992,6 +6091,7 @@ describe("FridayAgentRuntime", () => {
     emitter.on("agent.run.tool_end", (p) => toolEndEvents.push({ content: p.summary ?? "" }));
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -6031,6 +6131,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -6059,6 +6160,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -6091,6 +6193,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -6140,6 +6243,7 @@ describe("FridayAgentRuntime", () => {
     const eventRepo = createFridayAgentRunEventRepository();
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -6204,6 +6308,7 @@ describe("FridayAgentRuntime", () => {
     };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -6303,6 +6408,7 @@ describe("FridayAgentRuntime", () => {
     });
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -6418,6 +6524,7 @@ describe("FridayAgentRuntime", () => {
     });
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -6487,6 +6594,7 @@ describe("FridayAgentRuntime", () => {
     });
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -6539,6 +6647,7 @@ describe("FridayAgentRuntime", () => {
       }));
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -6590,6 +6699,7 @@ describe("FridayAgentRuntime", () => {
     const repo = createFridayAgentRunRepository();
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -6624,6 +6734,7 @@ describe("FridayAgentRuntime", () => {
     const repo = createFridayAgentRunRepository();
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -6702,6 +6813,7 @@ describe("FridayAgentRuntime", () => {
     const toolApprovalResolver = vi.fn(async () => ({ approved: true }));
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -6747,6 +6859,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -6816,6 +6929,7 @@ describe("FridayAgentRuntime", () => {
     });
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -6894,6 +7008,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -6928,6 +7043,7 @@ describe("FridayAgentRuntime", () => {
     });
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -7001,6 +7117,7 @@ describe("FridayAgentRuntime", () => {
     });
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -7069,6 +7186,7 @@ describe("FridayAgentRuntime", () => {
     };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -7126,6 +7244,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -7178,6 +7297,7 @@ describe("FridayAgentRuntime", () => {
     let selfTestCalls = 0;
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -7231,6 +7351,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -7265,6 +7386,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -7307,6 +7429,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -7388,6 +7511,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -7491,6 +7615,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -7601,6 +7726,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -7680,6 +7806,7 @@ describe("FridayAgentRuntime", () => {
     });
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -7737,6 +7864,7 @@ describe("FridayAgentRuntime", () => {
     const autonomousSpy = vi.fn(async () => ({ content: "autonomous should not be invoked during planning" }));
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -7805,6 +7933,7 @@ describe("FridayAgentRuntime", () => {
     const autonomousSpy = vi.fn(async () => ({ content: "autonomous should not be invoked for internal action runs" }));
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -7920,6 +8049,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -8042,6 +8172,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -8164,6 +8295,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -8225,6 +8357,7 @@ describe("FridayAgentRuntime", () => {
     emitter.on("agent.run.completed", (p) => completedEvents.push({ testsPassed: p.testsPassed }));
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -8258,6 +8391,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -8294,6 +8428,7 @@ describe("FridayAgentRuntime", () => {
     });
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -8334,6 +8469,7 @@ describe("FridayAgentRuntime", () => {
     };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -8380,6 +8516,7 @@ describe("FridayAgentRuntime", () => {
     };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -8442,6 +8579,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -8483,6 +8621,7 @@ describe("FridayAgentRuntime", () => {
     ]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "route-default-model",
@@ -8518,6 +8657,7 @@ describe("FridayAgentRuntime", () => {
     };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "route-default-model",
@@ -8584,6 +8724,7 @@ describe("FridayAgentRuntime", () => {
     });
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -8611,6 +8752,7 @@ describe("FridayAgentRuntime", () => {
     const llmClient = createMockLlmClient([]);
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -8650,6 +8792,7 @@ describe("FridayAgentRuntime", () => {
     };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient: infiniteToolClient,
       model: "test-model",
@@ -8693,6 +8836,7 @@ describe("FridayAgentRuntime", () => {
     };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -8743,6 +8887,7 @@ describe("FridayAgentRuntime", () => {
     };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -8780,6 +8925,7 @@ describe("FridayAgentRuntime", () => {
     });
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -8812,6 +8958,7 @@ describe("FridayAgentRuntime", () => {
     const communicationPromptBuilder = vi.fn().mockResolvedValue("[Learned Preferences]\n- Remember canary: COMPACTION_CANARY");
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -8860,6 +9007,7 @@ describe("FridayAgentRuntime", () => {
     const eventRepo = createFridayAgentRunEventRepository();
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -8919,6 +9067,7 @@ describe("FridayAgentRuntime", () => {
     });
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -9022,6 +9171,7 @@ describe("FridayAgentRuntime", () => {
     };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -9104,6 +9254,7 @@ describe("FridayAgentRuntime", () => {
     };
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -9172,6 +9323,7 @@ describe("FridayAgentRuntime", () => {
     });
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -9218,6 +9370,7 @@ describe("FridayAgentRuntime", () => {
     const learningContextBuilder = vi.fn();
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -9246,6 +9399,7 @@ describe("FridayAgentRuntime", () => {
     const afterTurn = vi.fn();
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -9290,6 +9444,7 @@ describe("FridayAgentRuntime", () => {
     const learningContextBuilder = vi.fn().mockReturnValue({ preferences: {} });
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -9324,6 +9479,7 @@ describe("FridayAgentRuntime", () => {
     });
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -9376,6 +9532,7 @@ describe("FridayAgentRuntime", () => {
 
     try {
       const runtimeA = createFridayAgentRuntime({
+        allowTestOnlyAgentRunExecution: true,
         db,
         llmClient,
         model: "test-model",
@@ -9394,6 +9551,7 @@ describe("FridayAgentRuntime", () => {
       expect(runtimeA.hasRollbackCheckpoint(result.runId)).toBe(true);
 
       const runtimeB = createFridayAgentRuntime({
+        allowTestOnlyAgentRunExecution: true,
         db,
         llmClient: createMockLlmClient([]),
         model: "test-model",
@@ -9429,6 +9587,7 @@ describe("FridayAgentRuntime", () => {
     const runRepo = createFridayAgentRunRepository();
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",
@@ -9470,6 +9629,7 @@ describe("FridayAgentRuntime", () => {
     const runRepo = createFridayAgentRunRepository();
 
     const runtime = createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db,
       llmClient,
       model: "test-model",

--- a/test/unit/agent/runtime/friday-agent-side-effect-evidence-gate.test.ts
+++ b/test/unit/agent/runtime/friday-agent-side-effect-evidence-gate.test.ts
@@ -39,6 +39,7 @@ describe("FridayAgentRuntime side-effect evidence gate", () => {
         }
       : {};
     return createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
       db, llmClient: mockLlm(events), model: "test-model", providerId: "test-provider",
       systemPrompt: "You are a test agent.",
       tools: [namedTool("write"), namedTool("edit"), namedTool("message"), namedTool("web_search")],

--- a/test/unit/hub/friday-hub-bootstrap.test.ts
+++ b/test/unit/hub/friday-hub-bootstrap.test.ts
@@ -929,7 +929,10 @@ describe("createFridayHub", () => {
       return mockLlmFetch(input, init);
     }) as typeof fetch;
 
-    hub = await createIsolatedHub({ allowTestOnlyWorkflowRunExecution: true });
+    hub = await createIsolatedHub({
+      allowTestOnlyWorkflowRunExecution: true,
+      allowTestOnlyAgentRunExecution: true,
+    });
     const channel = createTestChannelPlugin();
     hub.channelRegistry.register(channel.plugin);
 

--- a/test/unit/ops/run-real-green-gate.test.ts
+++ b/test/unit/ops/run-real-green-gate.test.ts
@@ -79,16 +79,27 @@ describe("run-real-green-gate helpers", () => {
     })).toBe(false);
   });
 
-  it("excludes agent-run-start-dependent RGG scenarios while the route is fail-closed", () => {
+  it("excludes every agent-run-dependent RGG scenario while the route is fail-closed", () => {
+    const reason =
+      "POST /v1/agent/runs is classified fail_closed in the TS runtime retirement manifest.";
     expect(resolveRetiredAgentRunScenarioExclusions(process.cwd())).toEqual([
-      {
-        scenarioId: "l3-destructive-request-visible-approval-gate",
-        reason: "POST /v1/agent/runs is classified fail_closed in the TS runtime retirement manifest.",
-      },
-      {
-        scenarioId: "l3-channel-origin-unified-task-state-contract",
-        reason: "POST /v1/agent/runs is classified fail_closed in the TS runtime retirement manifest.",
-      },
+      { scenarioId: "l3-memory-api-store-agent-recall-proof", reason },
+      { scenarioId: "l3-chat-direct-answer", reason },
+      { scenarioId: "l3-agent-replayable-evidence-receipt", reason },
+      { scenarioId: "l3-summary-misroute-guard", reason },
+      { scenarioId: "l3-vague-goal-awaiting-user-state", reason },
+      { scenarioId: "l3-destructive-request-visible-approval-gate", reason },
+      { scenarioId: "l3-channel-origin-unified-task-state-contract", reason },
+      { scenarioId: "l3-long-summary-direct", reason },
+      { scenarioId: "l3-json-extraction", reason },
+      { scenarioId: "l3-multi-turn-memory", reason },
+      { scenarioId: "l4-file-tool-roundtrip", reason },
+      { scenarioId: "l4-missing-file-no-verified-success", reason },
+      { scenarioId: "l4-exec-outside-workspace-boundary", reason },
+      { scenarioId: "l4-tool-search-deferred-tool-discovery", reason },
+      { scenarioId: "l4-context-cost-control-evidence", reason },
+      { scenarioId: "l4-tool-guardrail-pre-post-evidence", reason },
+      { scenarioId: "l8-agent-core-soak", reason },
     ]);
   });
 


### PR DESCRIPTION
## Summary (Phase 3b, operator Option A — CANDIDATE, do NOT merge)

Adds a METHOD-level TS-runtime-retirement fail-closed guard to the agent run loop `agentRuntime.executeRun`, mirroring #568 (workflow `startRun` method guard) + #569 (RGG harness adaptation). Closes the symmetric method-level gap for agent runs: the HTTP routes (`POST /v1/agent/runs`, `POST /v1/sessions/:sessionKey/run`) were already route-retired, but every non-route + transitive caller reaches `executeRun` directly (heartbeat runner, channel entry adapter, cron dynamic-job runner, autonomous engine, planning gate, subagent child runtime, agent-sessions tool), bypassing the route guards.

### Part 1 — production guard
- `executeRun` now throws `TS_RUNTIME_AGENT_RUN_RETIRED` / HTTP 503 / `classification: fail_closed` / `replacement: rust_owned_agent_run_entrypoint_required` at the TOP of the method (before any DB read, run-row creation, provider call, or tool call) unless the new test-oracle flag `allowTestOnlyAgentRunExecution` is exactly `true`.
- Flag threaded from hub config (`FridayHubConfig.allowTestOnlyAgentRunExecution`) into BOTH the main agent runtime factory AND the child/subagent runtime factory in `friday-hub-bootstrap.ts` (so a flag-on parent run can still spawn a subagent under `executeChildRun`). Production hub bootstrap leaves the config flag unset → fail-closed. Default-on only in the test/mock env (`mock-env`) + the real-hub e2e configs that open session-run (which reaches `executeRun`): real-env, friday-full-e2e, friday-real-scenarios, setup-wizard.

### Part 2 — RGG harness (the 21-failure gap)
- Extended the named, manifest-gated `AGENT_RUN_START_DEPENDENT_SCENARIOS` exclusion from 2 → the complete 17 (every `execution.kind === "agent_run"` catalog scenario; the `executeAgentRun` executor calls `client.startAgentRun` → `POST /v1/agent/runs`). In full mode every agent_run scenario drives the 503'd route; the prior list excluded only the 2 lane="none" ones, so full-mode RGG red with 21 failures (13 smoke + 8 daily-core). NOT a broad skip — every excluded scenario is enumerated and tied to the fail_closed manifest classification. `sessions_run` has no dependent catalog scenario (no change needed). Updated the matching unit assertion.

## Verification
- typecheck PASS; lint 0 errors; `check:ts-runtime-retirement` blocker=0 (unchanged, manifest not weakened); `check:secret-patterns` clean; detect-secrets baseline refreshed; `git diff --check` clean.
- Focused guard test `friday-agent-runtime-retirement-guard.test.ts`: default fail-closed throws + no `friday_agent_runs` row; explicit-`false` fail-closed; child-without-flag fail-closed (threading contract); flag-on works. Modified-file suites (589 tests) + mock-e2e agent runs (25) + subagent integration green.
- BRANCH RGG: full-mode (workflow_dispatch) run 27087680531 GREEN 56/56, `blocked_reasons:[]`, all suites 0-failed, 17 agent exclusions active (baseline 27085877015 = 77 scenarios / 21 failed → 21 agent_run instances now excluded). Economy push-event run 27087678029 GREEN 56/56 (guard does not break economy).

## Honest note / boundary
This formally fences the core TS agent loop with no live Rust replacement (the Rust agent engine exists but is unbridged) — owner-approved deferral per operator Option A. Not a v1 GO. The production child factory threading (hub-bootstrap child runtime) is proven by code inspection + typecheck + the direct-construction subagent integration test; no end-to-end mock-hub parent-spawns-child-under-flag-on exists in CI (all live agent RGG scenarios are now excluded), so that specific path is inspection/unit-proven, not e2e-proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)