### PR TITLE
ci: enforce ts_runtime_blocker=0 via real validator gate (§6 future_work)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,11 +238,42 @@ jobs:
           echo "     detect-secrets audit .secrets.baseline"
           echo "  3. Commit the updated .secrets.baseline"
 
+  # ── MECHANISM-7: TS-Runtime-Retirement Gate — blocker==0 enforced ──
+  ts-runtime-retirement:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Setup Node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 22
+          cache: npm
+
+      # Validator runs over the REAL src/api/http/routes + real manifest and
+      # enforces classification completeness/well-formedness. It prints its JSON
+      # report to stdout (captured via `>` so the validator's own exit code still
+      # gates this step) and exits non-zero on any unclassified/malformed route.
+      - name: Validate TS-runtime-retirement classification
+        run: node scripts/quality/check-ts-runtime-retirement.mjs > ts-runtime-retirement-report.json
+
+      - name: Show validator report
+        run: cat ts-runtime-retirement-report.json
+
+      # The validator exits 0 even for a *validly* classified ts_runtime_blocker.
+      # This assertion enforces ts_runtime_blocker == 0 against silent regression
+      # by parsing summary.blockerFamilies from the validator's report.
+      - name: Assert ts_runtime_blocker count is zero
+        run: node scripts/quality/assert-ts-runtime-blocker-zero.mjs ts-runtime-retirement-report.json
+
   # ── Terminal CI Aggregator — single required check for branch protection ──
   quality-gate:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [build, test, migrations, security, contracts, ssd-lint, alignment-guard, agent-parity, secrets]
+    needs: [build, test, migrations, security, contracts, ssd-lint, alignment-guard, agent-parity, secrets, ts-runtime-retirement]
     if: ${{ always() }}
 
     steps:
@@ -257,6 +288,7 @@ jobs:
           echo "Alignment Guard:    ${{ needs.alignment-guard.result }}"
           echo "Agent Parity:       ${{ needs.agent-parity.result }}"
           echo "Secrets:            ${{ needs.secrets.result }}"
+          echo "TS Runtime Retire:  ${{ needs.ts-runtime-retirement.result }}"
           echo ""
 
           FAILED=0
@@ -270,6 +302,7 @@ jobs:
             "${{ needs.alignment-guard.result }}" \
             "${{ needs.agent-parity.result }}" \
             "${{ needs.secrets.result }}" \
+            "${{ needs.ts-runtime-retirement.result }}" \
           ; do
             if [ "$result" != "success" ]; then
               FAILED=1

--- a/scripts/quality/assert-ts-runtime-blocker-zero.mjs
+++ b/scripts/quality/assert-ts-runtime-blocker-zero.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/**
+ * TS-Runtime-Retirement: blocker==0 assertion.
+ *
+ * Companion gate to scripts/quality/check-ts-runtime-retirement.mjs.
+ *
+ * The validator enforces classification COMPLETENESS and WELL-FORMEDNESS: every
+ * discovered HTTP route must be classified, and each classification must carry
+ * its required metadata. It deliberately exits 0 even when a route is *validly*
+ * classified `ts_runtime_blocker` (with owner/blocker/next_action). So
+ * "validator green" does NOT by itself prove "ts_runtime_blocker == 0".
+ *
+ * This assertion closes that gap so a reintroduced / unclassified-then-caught
+ * route cannot silently regress `ts_runtime_blocker=0`. It parses the
+ * validator's JSON report and fails if ANY route is actually classified as a
+ * TS-runtime blocker (summary.blockerFamilies non-empty, or a
+ * ts_runtime_blocker bucket present in summary.byClassification).
+ *
+ * NOTE on why we do NOT grep the manifest for "ts_runtime_blocker": the
+ * manifest intentionally declares catch-all `ts_runtime_blocker` route families
+ * (e.g. agent_runtime_blockers) that currently match ZERO live routes. Grepping
+ * would false-positive against those definitions. The validator's summary
+ * reflects only routes that ACTUALLY match a blocker classification, which is
+ * the truth we must gate on.
+ *
+ * Node: builtins only — no dependencies, no `npm ci` required.
+ *
+ * Usage: node scripts/quality/assert-ts-runtime-blocker-zero.mjs <report.json>
+ *   where <report.json> is the stdout of check-ts-runtime-retirement.mjs.
+ */
+
+import fs from "node:fs";
+
+function fail(message) {
+  console.error(`❌ ts_runtime_blocker assertion FAILED: ${message}`);
+  process.exit(1);
+}
+
+const reportPath = process.argv[2];
+if (!reportPath) {
+  fail("usage: assert-ts-runtime-blocker-zero.mjs <validator-report.json>");
+}
+
+let report;
+try {
+  report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+} catch (error) {
+  fail(`could not read/parse validator report at ${reportPath}: ${error.message}`);
+}
+
+if (report.status !== "passed") {
+  fail(`validator status is "${report.status}", expected "passed" (run the validator first)`);
+}
+
+const summary = report.summary;
+if (!summary || typeof summary !== "object") {
+  fail("validator report has no summary object");
+}
+
+if (!Array.isArray(summary.blockerFamilies)) {
+  fail("summary.blockerFamilies is missing or not an array");
+}
+
+const blockerBucket = summary.byClassification?.ts_runtime_blocker ?? 0;
+
+if (summary.blockerFamilies.length !== 0 || blockerBucket !== 0) {
+  fail(
+    `${summary.blockerFamilies.length} blocker family/families and ${blockerBucket} `
+    + `ts_runtime_blocker route(s) present: ${JSON.stringify(summary.blockerFamilies)}. `
+    + "A route is classified ts_runtime_blocker — TS runtime is NOT retired for it. "
+    + "Resolve it (rust_delegated / fail_closed / etc.) before this gate can pass.",
+  );
+}
+
+console.log(
+  `✅ ts_runtime_blocker == 0 (routeCount=${report.routeCount}, `
+  + "blockerFamilies=[], no ts_runtime_blocker routes).",
+);


### PR DESCRIPTION
## Lane
Wire the REAL TS-runtime-retirement validator into CI so `ts_runtime_blocker=0` cannot silently regress (ledger §6 future_work; `NEXT_LANES_READINESS_SCOUT.md` §C). **CANDIDATE for coordinator verification — do not auto-merge.**

## Problem (scout-confirmed)
`scripts/quality/check-ts-runtime-retirement.mjs` (npm `check:ts-runtime-retirement`) was **never invoked by any `.github/workflows/*.yml`**. CI only ran the synthetic-manifest unit test, so a reintroduced/unclassified route or manifest drift would not red any gate. Current main blocker count = 0.

## Changes (CI-config + tiny assertion helper ONLY)
- `.github/workflows/ci.yml`: new `ts-runtime-retirement` job — `actions/checkout@v5` + `actions/setup-node@v6` (node 22), **no `npm ci`/build** (validator uses `node:` builtins only). Runs the real validator over real `src/api/http/routes` + real manifest, then asserts blocker=0.
- Registered in the `quality-gate` aggregator (the single required branch-protection check) in **all three sites**: `needs:`, the echo block, AND the `FAILED` for-loop.
- `scripts/quality/assert-ts-runtime-blocker-zero.mjs`: parses the validator's JSON report; fails if `summary.blockerFamilies` is non-empty (or a `ts_runtime_blocker` bucket exists).

## Precision (why not grep the manifest)
The validator exits 0 even for a *validly* classified `ts_runtime_blocker`, so "validator green" alone does NOT prove blocker=0. The manifest declares **catch-all `ts_runtime_blocker` families that match zero live routes** (8 definitions, 0 matched) — a manifest grep would false-positive. The assertion therefore uses `summary.blockerFamilies` (only routes that ACTUALLY match a blocker classification).

## Verification (local, node 22)
- **Positive (main):** validator exit 0; assertion exit 0 — `routeCount=584`, `blockerFamilies=[]`, no `ts_runtime_blocker` routes.
- **Negative (end-to-end, `/tmp`-only sim, worktree untouched):** a well-formed `ts_runtime_blocker` family (via `--manifest /tmp/copy`, real route discovery) → validator **still exits 0** (`status=passed`, `blockerFamilies=["mission_spine_rust_projection"]`, `byClassification.ts_runtime_blocker=1`) but the **assertion exits 1**. This reproduces the exact silent-regression the gate closes.
- YAML parses; `git diff --check` clean.

## Constraints honored
No product src, no RGG scenario, no manifest edits, no loosening/skipping of any existing gate. Does not touch RGG (post-merge RGG unaffected by ci.yml). Does not claim Friday v1 GO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)