### PR TITLE
feat(rust-hub): S0 hub_run_task dev write-bridge (Rust-wired-DEV, proof-only)

### DIFF
--- a/.github/workflows/rust-core.yml
+++ b/.github/workflows/rust-core.yml
@@ -36,6 +36,13 @@ jobs:
         run: cargo fmt --all -- --check
       - name: Clippy (-D warnings)
         run: cargo clippy --workspace --all-targets -- -D warnings
+      - name: Build bins (incl. S0 hub_run_task write-bridge)
+        # `cargo clippy --all-targets` / `cargo test --workspace` already compile every
+        # bin, so this is technically redundant — but it names the S0 dev write-bridge
+        # explicitly so a missing/compile-broken `hub_run_task` reds CI loudly. The bin is
+        # only BUILT here; running it needs FRIDAY_DEEPSEEK_API_KEY (the separate live-proof
+        # step), so it is never executed in CI.
+        run: cargo build -p friday-hub --bin hub_run_task
       - name: Test
         # The one live DeepSeek test is #[ignore]d, so this needs no network/secrets.
         run: cargo test --workspace

--- a/rust-core/Cargo.lock
+++ b/rust-core/Cargo.lock
@@ -491,6 +491,7 @@ dependencies = [
  "regex",
  "rusqlite",
  "serde_json",
+ "sha2",
  "thiserror 1.0.69",
  "ureq",
 ]

--- a/rust-core/crates/friday-core/src/mechanism_matrix.rs
+++ b/rust-core/crates/friday-core/src/mechanism_matrix.rs
@@ -37,8 +37,16 @@ impl MechanismOwner {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MechanismStatus {
+    /// Rust owns the product logic AND it is proven through every product entrypoint
+    /// (the only v1-GO tier). The "RustProvenProduct" tier.
     RustOwnedProven,
     RustOwnedPartial,
+    /// Reachable in Rust ONLY via a dev/test bridge or test-only entrypoint — NOT a
+    /// production product path. STRICTLY BELOW `RustOwnedPartial`: it makes no partial
+    /// product-ownership claim, only "the mechanism runs when poked by a dev harness."
+    /// Never v1-GO. Introduced for the S0 `hub_run_task` write-bridge: it proves the
+    /// agent loop is *reachable*, not that any product entrypoint is wired.
+    RustWiredDev,
     NoGo,
     OperatorGated,
     ExternalBlocked,
@@ -51,6 +59,7 @@ impl MechanismStatus {
         match self {
             MechanismStatus::RustOwnedProven => "rust_owned_proven",
             MechanismStatus::RustOwnedPartial => "rust_owned_partial",
+            MechanismStatus::RustWiredDev => "rust_wired_dev",
             MechanismStatus::NoGo => "NO-GO",
             MechanismStatus::OperatorGated => "operator_gated",
             MechanismStatus::ExternalBlocked => "external_blocked",
@@ -133,23 +142,35 @@ pub fn friday_v1_mechanism_matrix() -> Vec<MechanismRow> {
             user_triggerable_product_logic: true,
         },
         MechanismRow {
+            // De-inflated: was RustOwnedPartial (implied partial PRODUCT ownership). The
+            // truth is the loop has only a dev write-bridge (S0 `hub_run_task`, Rust-wired-
+            // DEV) — NO production transport: the TS `executeRun`/`startRun` paths are now
+            // fail-closed-FENCED (PRs #568/#570), and only 2/10 fs tools exist. The blocker
+            // KEEPS the "real multi-turn live agent/tool execution" substring the v1 NO-GO
+            // gate asserts, so this stays a NO-GO blocker (closure semantics unchanged).
             id: "agent_tool_execution",
             title: "Agent loop + tool execution",
             owner: RustHub,
-            status: RustOwnedPartial,
+            status: RustWiredDev,
             rust_entrypoint: "friday_hub::runtime::HubRuntime::run_task",
             proof_gate: "cargo test -p friday-hub run_loop",
-            blocker: "real multi-turn live agent/tool execution is not fully proven through every product entrypoint",
+            blocker: "real multi-turn live agent/tool execution is dev-bridge-only (hub_run_task = Rust-wired-DEV); only 2/10 fs tools exist and the TS executeRun/startRun product paths stay fail-closed-fenced — no production transport, not proven through any product entrypoint",
             user_triggerable_product_logic: true,
         },
         MechanismRow {
+            // De-inflated: was RustOwnedPartial. The workflow runtime is reachable only
+            // through a TEST-ONLY entrypoint (the TS `startRun` product path is fail-closed-
+            // fenced, #570) — i.e. Rust-wired-DEV, not a production product wrapper.
+            // `user_triggerable_product_logic` stays TRUE so the row REMAINS a NO-GO blocker
+            // (flipping it to false would remove it from friday_v1_no_go_blockers() and shift
+            // the blocker set — forbidden by the S0 brief; closure semantics unchanged).
             id: "workflow_runtime",
             title: "Workflow runtime",
             owner: RustHub,
-            status: RustOwnedPartial,
+            status: RustWiredDev,
             rust_entrypoint: "friday_hub::mission_runtime::run_workflow_for_mission",
             proof_gate: "cargo test -p friday-hub mission_runtime",
-            blocker: "workflow product entrypoints must all use Mission-bound wrappers",
+            blocker: "workflow runtime is reachable only via a test-only entrypoint (TS startRun product path is fail-closed-fenced) — no production transport; product entrypoints must all use Mission-bound wrappers",
             user_triggerable_product_logic: true,
         },
         MechanismRow {
@@ -312,6 +333,48 @@ mod tests {
         assert!(
             blockers.iter().any(|b| b.contains("live supervisor")),
             "process/workspace control remains NO-GO until live control proof"
+        );
+    }
+
+    #[test]
+    fn rust_wired_dev_is_an_honest_non_go_tier_below_partial() {
+        // The new dev-bridge tier is never v1-GO and renders as the documented string.
+        assert!(!MechanismStatus::RustWiredDev.is_v1_go());
+        assert_eq!(MechanismStatus::RustWiredDev.as_str(), "rust_wired_dev");
+    }
+
+    #[test]
+    fn agent_loop_and_workflow_are_rust_wired_dev_after_s0() {
+        let rows = friday_v1_mechanism_matrix();
+        for id in ["agent_tool_execution", "workflow_runtime"] {
+            let row = rows.iter().find(|r| r.id == id).unwrap();
+            assert_eq!(
+                row.status,
+                MechanismStatus::RustWiredDev,
+                "{id} must honestly be Rust-wired-DEV (dev/test bridge only), not partial-product"
+            );
+            // Still user-triggerable product logic with a Rust owner+entrypoint, so the
+            // row keeps contributing to the v1 NO-GO blocker set.
+            assert!(row.user_triggerable_product_logic);
+            assert!(row.owner.can_own_product_logic());
+        }
+    }
+
+    #[test]
+    fn s0_does_not_shift_the_v1_no_go_blocker_set() {
+        // CLOSURE-SEMANTICS GUARD: both rebadged rows MUST remain NO-GO blockers — the
+        // truth-fix lowers the claim (RustWiredDev) without removing either from
+        // friday_v1_no_go_blockers(), so the GO/NO-GO verdict is unchanged.
+        let blockers = friday_v1_no_go_blockers();
+        assert!(
+            blockers
+                .iter()
+                .any(|b| b.contains("real multi-turn live agent/tool execution")),
+            "agent_tool_execution must stay a NO-GO blocker"
+        );
+        assert!(
+            blockers.iter().any(|b| b.contains("test-only entrypoint")),
+            "workflow_runtime must stay a NO-GO blocker (now flagged test-only)"
         );
     }
 

--- a/rust-core/crates/friday-hub/Cargo.toml
+++ b/rust-core/crates/friday-hub/Cargo.toml
@@ -27,6 +27,10 @@ friday-fs.workspace = true
 # The live model returns free-text content; the tool-call protocol is a JSON object
 # the Hub parses back into a RawToolCall. serde_json is the strict parser for that.
 serde_json.workspace = true
+# Refs-only hashing for the S0 dev write-bridge bin (`hub_run_task`): the final
+# message is emitted as a sha256 hash + length, never as body text. Pure hashing,
+# no I/O; already in the Hub closure via friday-storage/friday-crypto.
+sha2.workspace = true
 thiserror.workspace = true
 # Memory-recall PII redaction (Hub-only — recall is Hub-side, the phone never
 # recalls). Pure computation, no I/O. NOT depended on by friday-ffi (phone).

--- a/rust-core/crates/friday-hub/src/bin/hub_run_task.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_run_task.rs
@@ -29,6 +29,7 @@ use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use friday_hub::runtime::{HubConfig, HubRuntime};
+use friday_hub::LoopStatus;
 use friday_storage::audit::verify_audit_chain;
 use serde_json::json;
 use sha2::{Digest, Sha256};
@@ -145,6 +146,18 @@ fn run() -> Result<String, BridgeError> {
     // route_id is a non-secret composite of provider + model identifiers.
     let route_id = format!("{}:{}", selection.provider_id, selection.model);
 
+    // Diagnosability without leakage: when the loop RAN but a turn errored
+    // (`Ok(_)` + `LoopStatus::Errored`), surface a BOUNDED, refs-only category token so the
+    // receipt itself carries the failure cause — instead of forcing recovery from the audit
+    // DB. CRITICAL: this is the classifier's `&'static str` token ONLY; the raw
+    // `outcome.detail` (which can embed model output) is NEVER placed in the payload. Any
+    // non-error status maps to JSON `null` (explicit "no error category").
+    let error_category: Option<&'static str> = if outcome.status == LoopStatus::Errored {
+        Some(classify_error_category(&outcome.detail))
+    } else {
+        None
+    };
+
     let payload = json!({
         "truth_label": "rust_wired_dev",
         "proof_only": true,
@@ -156,6 +169,7 @@ fn run() -> Result<String, BridgeError> {
         "model_size": format!("{:?}", selection.model_size),
         "backend_kind": format!("{:?}", selection.backend_kind),
         "loop_status": format!("{:?}", outcome.status),
+        "error_category": error_category,
         "turns": outcome.turns,
         "executed_tools": outcome.executed_tools,
         "final_message_sha256": final_message_sha256,
@@ -185,6 +199,29 @@ fn routed_loop_error_kind(err: &friday_hub::routing::RoutedLoopError) -> &'stati
         Route(_) => "route_failed",
         NoClientForProvider(_) => "no_client",
         Storage(_) => "storage_failed",
+    }
+}
+
+/// Map an errored loop's free-form `detail` to ONE bounded, refs-only error-category token.
+///
+/// CRITICAL leak boundary: this returns ONLY a fixed `&'static str` drawn from a closed
+/// vocabulary. It NEVER returns or embeds any slice of `detail` — a parse/serde error
+/// message can contain a snippet of the model's output, and `reject_forbidden_output`
+/// would NOT catch that (it is not a forbidden marker). Returning a literal makes leakage
+/// structurally impossible, not merely unlikely. Substrings are matched in priority order.
+fn classify_error_category(detail: &str) -> &'static str {
+    if detail.contains("parse_error") {
+        "parse_error"
+    } else if detail.contains("timeout") || detail.contains("timed out") {
+        "timeout"
+    } else if detail.contains("http")
+        || detail.contains("status")
+        || detail.contains("request")
+        || detail.contains("reqwest")
+    {
+        "provider_http_error"
+    } else {
+        "agent_error_other"
     }
 }
 
@@ -262,6 +299,51 @@ mod tests {
     fn ephemeral_secret_is_32_bytes_and_not_a_read_key() {
         let s = ephemeral_dev_secret(123, 456);
         assert_eq!(s.len(), 32);
+    }
+
+    #[test]
+    fn classify_error_category_maps_to_bounded_tokens_and_never_leaks_detail() {
+        // Each representative detail maps to its bounded token (priority order respected).
+        assert_eq!(
+            classify_error_category("agent_error:parse_error: not a single JSON object: EOF"),
+            "parse_error"
+        );
+        assert_eq!(
+            classify_error_category("connection timed out after 30s"),
+            "timeout"
+        );
+        // `request` would also match the http branch, but the timeout branch precedes it.
+        assert_eq!(classify_error_category("request timeout"), "timeout");
+        assert_eq!(
+            classify_error_category("reqwest error: status 500"),
+            "provider_http_error"
+        );
+        assert_eq!(
+            classify_error_category("http 503 from the upstream provider"),
+            "provider_http_error"
+        );
+        assert_eq!(
+            classify_error_category("something nobody anticipated"),
+            "agent_error_other"
+        );
+
+        // Leak boundary: a raw model-body snippet embedded in `detail` must NEVER appear in
+        // the returned token, and the token must always be from the closed vocabulary.
+        let fake_model_body =
+            "parse_error: LEAK_CANARY_modeltext_9f3 {\"answer\":\"42\"} <-- raw model output";
+        let token = classify_error_category(fake_model_body);
+        assert_eq!(token, "parse_error");
+        assert!(
+            !token.contains("LEAK_CANARY_modeltext_9f3"),
+            "classifier output must never carry any slice of detail"
+        );
+        assert!(
+            matches!(
+                token,
+                "parse_error" | "timeout" | "provider_http_error" | "agent_error_other"
+            ),
+            "token must be one of the closed vocabulary"
+        );
     }
 
     #[test]

--- a/rust-core/crates/friday-hub/src/bin/hub_run_task.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_run_task.rs
@@ -1,0 +1,289 @@
+//! S0 dev write-bridge — `hub_run_task`.
+//!
+//! PROOF-ONLY (Rust-wired-DEV). A thin one-shot bin around
+//! [`friday_hub::runtime::HubRuntime::live`] + `run_task`, cloning the shape of the
+//! read-only `mission_workbench_projection` bin so the Rust agent loop is reachable
+//! end-to-end for a READ-MOSTLY task through a new TS→Rust transport.
+//!
+//! This is NOT a replacement for the (now fail-closed-fenced) TS `executeRun`. It does
+//! NOT register a production route and confers no v1 GO. It exists to de-risk the
+//! transport + secret boundary: prove the loop runs and emits a refs-only receipt.
+//!
+//! ## Output contract — REFS ONLY (no bodies, no secrets, no PII)
+//! Emits a single JSON object to stdout carrying ONLY safe identifiers/refs:
+//! `truth_label="rust_wired_dev"`, `run_id`, `route_id`, provider/model/route telemetry,
+//! loop status + counts, the audit-chain-verified bool, and a **sha256 hash + length**
+//! of the final message — NEVER the message text itself. A defensive output guard
+//! rejects any forbidden marker before printing.
+//!
+//! ## Live key
+//! [`HubRuntime::live`] reads the DeepSeek key from the env (`DeepSeekClient::from_env`,
+//! never logged). Running this bin for real therefore needs `FRIDAY_DEEPSEEK_API_KEY`
+//! and spends quota — that is the SEPARATE operator/coordinator live-proof step. CI only
+//! BUILDS this bin; the TS bridge test spawns a scripted MOCK bin instead (no key, no
+//! quota).
+
+use std::env;
+use std::io::Read;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use friday_hub::runtime::{HubConfig, HubRuntime};
+use friday_storage::audit::verify_audit_chain;
+use serde_json::json;
+use sha2::{Digest, Sha256};
+
+/// A fail-closed error: `kind` is a coarse, safe category (the only thing surfaced); the
+/// raw detail is deliberately NOT printed so storage/init errors cannot leak paths.
+struct BridgeError {
+    kind: &'static str,
+}
+
+impl BridgeError {
+    fn new(kind: &'static str) -> Self {
+        Self { kind }
+    }
+}
+
+fn main() {
+    match run() {
+        Ok(rendered) => {
+            println!("{rendered}");
+        }
+        Err(err) => {
+            // Refs-only error to stdout (no detail), coarse category to stderr, non-zero exit.
+            let payload = json!({
+                "truth_label": "rust_wired_dev",
+                "proof_only": true,
+                "ok": false,
+                "error_kind": err.kind,
+            });
+            println!("{payload}");
+            eprintln!("hub_run_task_unavailable: {}", err.kind);
+            std::process::exit(2);
+        }
+    }
+}
+
+fn run() -> Result<String, BridgeError> {
+    let args: Vec<String> = env::args().collect();
+
+    // Task prompt: --task <prompt>, else read all of stdin (like the projection bin reads
+    // its config from argv; stdin is the body-bearing channel so it stays off the argv).
+    let task = match arg_value(&args, "--task") {
+        Some(task) => task,
+        None => {
+            let mut buf = String::new();
+            std::io::stdin()
+                .read_to_string(&mut buf)
+                .map_err(|_| BridgeError::new("bad_args"))?;
+            buf.trim().to_string()
+        }
+    };
+    if task.is_empty() {
+        return Err(BridgeError::new("bad_args"));
+    }
+
+    // Workspace root: the agent loop's fs tools are contained to this root (required).
+    let workspace_root = arg_value(&args, "--workspace").ok_or(BridgeError::new("bad_args"))?;
+
+    let pid = std::process::id();
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+
+    // Hub DB path: --db, else an isolated per-invocation dev DB under the workspace.
+    let db_path = arg_value(&args, "--db")
+        .unwrap_or_else(|| format!("{workspace_root}/.hub-run-task-dev-{pid}-{nanos}.sqlite"));
+
+    let run_id =
+        arg_value(&args, "--run-id").unwrap_or_else(|| format!("hub_run_task_dev_{pid}_{nanos}"));
+
+    let max_turns = arg_value(&args, "--max-turns")
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(6);
+
+    let now_ms = arg_value(&args, "--now-ms")
+        .and_then(|v| v.parse::<i64>().ok())
+        .unwrap_or_else(|| {
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_millis() as i64)
+                .unwrap_or(0)
+        });
+
+    // Gate-approval signing secret: this is a DEV bridge driving a read-mostly task under
+    // the deny-all approval policy baked into `HubRuntime::live`, where the secret is
+    // DORMANT (no approval is ever minted/verified). We therefore derive ephemeral,
+    // non-secret bytes from pid+nanos rather than reading any real key — nothing
+    // secret-shaped is constructed or persisted.
+    let secret = ephemeral_dev_secret(pid, nanos);
+
+    let runtime = HubRuntime::live(HubConfig {
+        db_path,
+        workspace_root: PathBuf::from(&workspace_root),
+        secret,
+        max_turns,
+        // Memory recall stays DISABLED in this dev bridge (no owner principal bound).
+        principal_id: None,
+    })
+    .map_err(|_| BridgeError::new("init_failed"))?;
+
+    let (selection, outcome) = runtime
+        .run_task(&run_id, &task, now_ms)
+        .map_err(|err| BridgeError::new(routed_loop_error_kind(&err)))?;
+
+    // Audit chain verification over the composed run's DB (a bool, never the rows).
+    let audit_chain_verified = verify_audit_chain(runtime.db().conn()).is_ok();
+
+    // The final message is hashed + measured; the TEXT is never emitted.
+    let final_message = outcome.final_message.unwrap_or_default();
+    let final_message_len = final_message.len();
+    let final_message_sha256 = sha256_hex(final_message.as_bytes());
+
+    // route_id is a non-secret composite of provider + model identifiers.
+    let route_id = format!("{}:{}", selection.provider_id, selection.model);
+
+    let payload = json!({
+        "truth_label": "rust_wired_dev",
+        "proof_only": true,
+        "ok": true,
+        "run_id": run_id,
+        "route_id": route_id,
+        "provider_id": selection.provider_id,
+        "model": selection.model,
+        "model_size": format!("{:?}", selection.model_size),
+        "backend_kind": format!("{:?}", selection.backend_kind),
+        "loop_status": format!("{:?}", outcome.status),
+        "turns": outcome.turns,
+        "executed_tools": outcome.executed_tools,
+        "final_message_sha256": final_message_sha256,
+        "final_message_len": final_message_len,
+        "audit_chain_verified": audit_chain_verified,
+    });
+
+    let rendered =
+        serde_json::to_string(&payload).map_err(|_| BridgeError::new("serialize_failed"))?;
+    reject_forbidden_output(&rendered)?;
+    Ok(rendered)
+}
+
+fn arg_value(args: &[String], name: &str) -> Option<String> {
+    args.windows(2)
+        .find_map(|pair| (pair[0] == name).then(|| pair[1].clone()))
+        .or_else(|| {
+            let prefix = format!("{name}=");
+            args.iter()
+                .find_map(|arg| arg.strip_prefix(&prefix).map(str::to_string))
+        })
+}
+
+fn routed_loop_error_kind(err: &friday_hub::routing::RoutedLoopError) -> &'static str {
+    use friday_hub::routing::RoutedLoopError::*;
+    match err {
+        Route(_) => "route_failed",
+        NoClientForProvider(_) => "no_client",
+        Storage(_) => "storage_failed",
+    }
+}
+
+/// Ephemeral, non-secret bytes (dormant under deny-all — see `run`). Derived, not read.
+fn ephemeral_dev_secret(pid: u32, nanos: u128) -> Vec<u8> {
+    let mut hasher = Sha256::new();
+    hasher.update(format!("hub-run-task-dev-bridge:{pid}:{nanos}").as_bytes());
+    hasher.finalize().to_vec()
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let digest = hasher.finalize();
+    let mut out = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        out.push_str(&format!("{byte:02x}"));
+    }
+    out
+}
+
+/// Defense-in-depth: refuse to print if any forbidden marker leaked into the refs-only
+/// payload. Mirrors `mission_workbench_projection`'s `reject_forbidden_output`.
+fn reject_forbidden_output(rendered: &str) -> Result<(), BridgeError> {
+    for marker in [
+        "Authorization",
+        "Bearer",
+        "sk-",
+        "/Users/",
+        "/private/",
+        "final_message\"", // the body text field must never appear (only the hash/len do)
+    ] {
+        if rendered.contains(marker) {
+            return Err(BridgeError::new("output_guard"));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{from_str, Value};
+
+    #[test]
+    fn arg_value_supports_space_and_equals_forms() {
+        let args = vec![
+            "bin".to_string(),
+            "--task".to_string(),
+            "do a thing".to_string(),
+            "--workspace=/tmp/ws".to_string(),
+        ];
+        assert_eq!(arg_value(&args, "--task").as_deref(), Some("do a thing"));
+        assert_eq!(arg_value(&args, "--workspace").as_deref(), Some("/tmp/ws"));
+        assert_eq!(arg_value(&args, "--missing"), None);
+    }
+
+    #[test]
+    fn sha256_hex_is_64_lowercase_hex_chars() {
+        let hex = sha256_hex(b"friday composed dev e2e");
+        assert_eq!(hex.len(), 64);
+        assert!(hex
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
+    }
+
+    #[test]
+    fn forbidden_output_guard_blocks_body_and_secret_markers() {
+        assert!(reject_forbidden_output(r#"{"final_message":"hi"}"#).is_err());
+        assert!(reject_forbidden_output(r#"{"x":"Bearer abc"}"#).is_err());
+        assert!(reject_forbidden_output(r#"{"final_message_sha256":"00","ok":true}"#).is_ok());
+    }
+
+    #[test]
+    fn ephemeral_secret_is_32_bytes_and_not_a_read_key() {
+        let s = ephemeral_dev_secret(123, 456);
+        assert_eq!(s.len(), 32);
+    }
+
+    #[test]
+    fn refs_only_payload_shape_excludes_body_text() {
+        // Mirror the success payload shape and assert the refs-only contract holds.
+        let payload = json!({
+            "truth_label": "rust_wired_dev",
+            "proof_only": true,
+            "ok": true,
+            "run_id": "hub_run_task_dev_1_2",
+            "route_id": "deepseek:deepseek-v4-flash",
+            "final_message_sha256": sha256_hex(b"body"),
+            "final_message_len": 4,
+            "audit_chain_verified": true,
+        });
+        let rendered = serde_json::to_string(&payload).unwrap();
+        assert!(reject_forbidden_output(&rendered).is_ok());
+        let parsed: Value = from_str(&rendered).unwrap();
+        assert_eq!(parsed["truth_label"], "rust_wired_dev");
+        assert!(
+            parsed.get("final_message").is_none(),
+            "must never carry body text"
+        );
+    }
+}

--- a/src/api/mission-spine/friday-rust-hub-run-task-bridge-service.ts
+++ b/src/api/mission-spine/friday-rust-hub-run-task-bridge-service.ts
@@ -1,0 +1,237 @@
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { FridayDomainError } from "#errors";
+
+/**
+ * PROOF-ONLY (Rust-wired-DEV) TS→Rust bridge for the S0 `hub_run_task` write-bridge.
+ *
+ * This clones the READ-ONLY `friday-rust-hub-workbench-projection-service` execFile shape
+ * to prove the Rust agent loop (`HubRuntime::run_task`) is reachable end-to-end for a
+ * READ-MOSTLY task. It is NOT a replacement for the (now fail-closed-fenced) TS
+ * `executeRun`/`startRun`, it registers NO production route, and it confers no v1 GO.
+ * Every value it returns is REFS-ONLY: a sha256 hash + length of the final message
+ * (never the body text), plus safe identifiers. The bridge fails CLOSED (503) on any
+ * non-zero exit, timeout, parse failure, invalid shape, or any payload that carries a
+ * raw message body.
+ *
+ * The single live proof (real DeepSeek call, spends quota) is a SEPARATE operator step —
+ * this service inherits `FRIDAY_DEEPSEEK_API_KEY` from the ambient env (it never reads or
+ * constructs a secret itself) and the Rust bin reads it via `DeepSeekClient::from_env`.
+ */
+const execFileAsync = promisify(execFile);
+
+/** Refs-only receipt — no message body, no secrets, no PII. */
+export interface FridayRustHubRunTaskBridgeReceipt {
+  /** Always the dev tier — this is NOT a product/proven receipt. */
+  readonly truthLabel: "rust_wired_dev";
+  /** Always true — a loud reminder this is a dev bridge, not a product path. */
+  readonly proofOnly: true;
+  readonly runId: string;
+  readonly routeId: string;
+  readonly providerId?: string;
+  readonly model?: string;
+  readonly modelSize?: string;
+  readonly backendKind?: string;
+  readonly loopStatus?: string;
+  readonly turns?: number;
+  readonly executedTools?: number;
+  /** sha256 of the final message body (the body itself is never transported). */
+  readonly finalMessageSha256: string;
+  readonly finalMessageLen: number;
+  readonly auditChainVerified: boolean;
+}
+
+export interface FridayRustHubRunTaskBridgeInput {
+  /** The read-mostly task prompt to drive through the Rust agent loop. */
+  readonly task: string;
+  /** Workspace root the loop's fs tools are contained to (must exist). */
+  readonly workspaceRoot: string;
+  /** Optional Hub DB path; the bin derives an isolated dev DB under the workspace if absent. */
+  readonly dbPath?: string;
+  readonly runId?: string;
+  readonly maxTurns?: number;
+}
+
+export interface CreateFridayRustHubRunTaskBridgeServiceOptions {
+  readonly repoRoot?: string;
+  /** Path to a prebuilt `hub_run_task` binary; falls back to `cargo run --bin` when absent. */
+  readonly adapterBin?: string;
+  readonly timeoutMs?: number;
+}
+
+export interface FridayRustHubRunTaskBridgeService {
+  runReadMostlyTask(
+    input: FridayRustHubRunTaskBridgeInput,
+  ): Promise<FridayRustHubRunTaskBridgeReceipt>;
+}
+
+function unavailable(message: string): FridayDomainError {
+  return new FridayDomainError("MISSION_SPINE_RUST_RUN_TASK_BRIDGE_UNAVAILABLE", message, {
+    httpStatus: 503,
+    details: {
+      surface: "service:rust_hub_run_task_bridge",
+      bridge: "rust_wired_dev",
+      proofOnly: true,
+      proofReady: false,
+    },
+  });
+}
+
+function readTimeoutMs(raw: string | undefined, fallback: number): number {
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function resolveDefaultRepoRoot(): string {
+  const moduleDir = dirname(fileURLToPath(import.meta.url));
+  return resolve(moduleDir, "../../..");
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+/**
+ * Validate + normalize the Rust bin's refs-only stdout into a receipt. Fails closed on
+ * any shape violation AND on any attempt to carry a raw message body (the boundary this
+ * slice exists to prove).
+ */
+function parseReceipt(payload: unknown): FridayRustHubRunTaskBridgeReceipt {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw unavailable("Rust hub_run_task bridge returned a non-object payload.");
+  }
+  const root = payload as Record<string, unknown>;
+
+  // Hard boundary: the body text must NEVER cross the bridge — only a hash/length may.
+  if ("final_message" in root || "finalMessage" in root) {
+    throw unavailable("Rust hub_run_task bridge payload carried a raw message body (rejected).");
+  }
+  if (root.truth_label !== "rust_wired_dev") {
+    throw unavailable("Rust hub_run_task bridge payload is not labeled rust_wired_dev.");
+  }
+  if (root.ok === false) {
+    throw unavailable("Rust hub_run_task bridge reported a fail-closed run.");
+  }
+
+  const runId = asString(root.run_id);
+  const routeId = asString(root.route_id);
+  // sha256/len are validated as a non-empty string / finite number ONLY — NOT for
+  // high-entropy hex shape (keeps test fixtures off detect-secrets' entropy heuristics).
+  const finalMessageSha256 = asString(root.final_message_sha256);
+  const finalMessageLen = asNumber(root.final_message_len);
+  const auditChainVerified = root.audit_chain_verified;
+
+  if (!runId || !routeId || !finalMessageSha256) {
+    throw unavailable("Rust hub_run_task bridge payload is missing required refs.");
+  }
+  if (finalMessageLen === undefined) {
+    throw unavailable("Rust hub_run_task bridge payload is missing final_message_len.");
+  }
+  if (typeof auditChainVerified !== "boolean") {
+    throw unavailable("Rust hub_run_task bridge payload is missing audit_chain_verified.");
+  }
+
+  return {
+    truthLabel: "rust_wired_dev",
+    proofOnly: true,
+    runId,
+    routeId,
+    providerId: asString(root.provider_id),
+    model: asString(root.model),
+    modelSize: asString(root.model_size),
+    backendKind: asString(root.backend_kind),
+    loopStatus: asString(root.loop_status),
+    turns: asNumber(root.turns),
+    executedTools: asNumber(root.executed_tools),
+    finalMessageSha256,
+    finalMessageLen,
+    auditChainVerified,
+  };
+}
+
+export function createFridayRustHubRunTaskBridgeService(
+  options: CreateFridayRustHubRunTaskBridgeServiceOptions = {},
+): FridayRustHubRunTaskBridgeService {
+  const repoRoot = resolve(
+    options.repoRoot ?? process.env.FRIDAY_REPO_ROOT ?? resolveDefaultRepoRoot(),
+  );
+  const rustCoreRoot = resolve(
+    process.env.FRIDAY_MISSION_SPINE_RUST_CORE_ROOT ?? join(repoRoot, "rust-core"),
+  );
+  const adapterBin = options.adapterBin ?? process.env.FRIDAY_HUB_RUN_TASK_BRIDGE_BIN;
+  const timeoutMs =
+    options.timeoutMs ??
+    readTimeoutMs(process.env.FRIDAY_HUB_RUN_TASK_BRIDGE_TIMEOUT_MS, 120_000);
+
+  return {
+    async runReadMostlyTask(
+      input: FridayRustHubRunTaskBridgeInput,
+    ): Promise<FridayRustHubRunTaskBridgeReceipt> {
+      const workspaceRoot = resolve(input.workspaceRoot);
+      if (!existsSync(workspaceRoot)) {
+        throw unavailable("Rust hub_run_task bridge workspace root is not present.");
+      }
+
+      const adapterArgs = ["--task", input.task, "--workspace", workspaceRoot];
+      if (input.dbPath) {
+        adapterArgs.push("--db", resolve(input.dbPath));
+      }
+      if (input.runId) {
+        adapterArgs.push("--run-id", input.runId);
+      }
+      if (typeof input.maxTurns === "number") {
+        adapterArgs.push("--max-turns", String(input.maxTurns));
+      }
+
+      const command = adapterBin ?? "cargo";
+      const args = adapterBin
+        ? adapterArgs
+        : [
+            "run",
+            "--quiet",
+            "--manifest-path",
+            join(rustCoreRoot, "Cargo.toml"),
+            "-p",
+            "friday-hub",
+            "--bin",
+            "hub_run_task",
+            "--",
+            ...adapterArgs,
+          ];
+
+      let stdout = "";
+      try {
+        const result = await execFileAsync(command, args, {
+          cwd: repoRoot,
+          timeout: timeoutMs,
+          maxBuffer: 2 * 1024 * 1024,
+          env: {
+            ...process.env,
+            RUST_BACKTRACE: "0",
+          },
+        });
+        stdout = result.stdout;
+      } catch {
+        // Non-zero exit, timeout, or spawn failure → fail closed (no detail surfaced).
+        throw unavailable("Rust hub_run_task bridge could not produce a refs-only receipt.");
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(stdout);
+      } catch {
+        throw unavailable("Rust hub_run_task bridge returned invalid JSON.");
+      }
+      return parseReceipt(parsed);
+    },
+  };
+}

--- a/src/api/mission-spine/friday-rust-hub-run-task-bridge-service.ts
+++ b/src/api/mission-spine/friday-rust-hub-run-task-bridge-service.ts
@@ -37,6 +37,13 @@ export interface FridayRustHubRunTaskBridgeReceipt {
   readonly modelSize?: string;
   readonly backendKind?: string;
   readonly loopStatus?: string;
+  /**
+   * Bounded, refs-only error-category token (one of `parse_error` | `timeout` |
+   * `provider_http_error` | `agent_error_other`). Present ONLY when the loop ran but a turn
+   * errored (`loopStatus === "Errored"`); absent otherwise. NEVER carries raw model text —
+   * the Rust bin emits a fixed token, never `outcome.detail`.
+   */
+  readonly errorCategory?: string;
   readonly turns?: number;
   readonly executedTools?: number;
   /** sha256 of the final message body (the body itself is never transported). */
@@ -150,6 +157,8 @@ function parseReceipt(payload: unknown): FridayRustHubRunTaskBridgeReceipt {
     modelSize: asString(root.model_size),
     backendKind: asString(root.backend_kind),
     loopStatus: asString(root.loop_status),
+    // Optional bounded token; coerced to undefined unless a non-empty string is present.
+    errorCategory: asString(root.error_category),
     turns: asNumber(root.turns),
     executedTools: asNumber(root.executed_tools),
     finalMessageSha256,

--- a/test/unit/api/mission-spine/friday-rust-hub-run-task-bridge-service.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-run-task-bridge-service.test.ts
@@ -1,0 +1,139 @@
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createFridayRustHubRunTaskBridgeService } from "../../../../src/api/mission-spine/friday-rust-hub-run-task-bridge-service.js";
+
+/**
+ * PROOF-ONLY (Rust-wired-DEV) bridge test. Spawns a SCRIPTED MOCK bin (no real DeepSeek
+ * call, no quota, no secret) so it runs in CI hermetically, mirroring the proven
+ * chmod-0o755 shebang-mock idiom from friday-provider-cli-backend.test.ts. Covers: happy
+ * path, non-zero exit, malformed JSON, timeout, and a raw-body-leak rejection.
+ */
+describe("friday-rust-hub-run-task-bridge-service (S0 dev write-bridge)", () => {
+  let scratch: string | undefined;
+
+  afterEach(() => {
+    if (scratch) {
+      rmSync(scratch, { recursive: true, force: true });
+      scratch = undefined;
+    }
+  });
+
+  function setup(mockSource: string): { binPath: string; workspaceRoot: string } {
+    scratch = mkdtempSync(join(tmpdir(), "friday-hub-run-task-bridge-"));
+    const binPath = join(scratch, "hub_run_task_mock.mjs");
+    writeFileSync(binPath, `#!/usr/bin/env node\n${mockSource}`);
+    chmodSync(binPath, 0o755);
+    const workspaceRoot = join(scratch, "ws");
+    mkdirSync(workspaceRoot, { recursive: true });
+    return { binPath, workspaceRoot };
+  }
+
+  it("parses a valid refs-only receipt on the happy path", async () => {
+    const { binPath, workspaceRoot } = setup(`
+      process.stdout.write(JSON.stringify({
+        truth_label: "rust_wired_dev",
+        proof_only: true,
+        ok: true,
+        run_id: "hub_run_task_dev_mock",
+        route_id: "deepseek:deepseek-v4-flash",
+        provider_id: "deepseek",
+        model: "deepseek-v4-flash",
+        model_size: "Small",
+        backend_kind: "Http",
+        loop_status: "Finished",
+        turns: 2,
+        executed_tools: 1,
+        final_message_sha256: "0".repeat(64),
+        final_message_len: 42,
+        audit_chain_verified: true,
+      }));
+    `);
+    const service = createFridayRustHubRunTaskBridgeService({ adapterBin: binPath });
+
+    const receipt = await service.runReadMostlyTask({
+      task: "read the file notes.md and summarize it",
+      workspaceRoot,
+    });
+
+    expect(receipt).toMatchObject({
+      truthLabel: "rust_wired_dev",
+      proofOnly: true,
+      runId: "hub_run_task_dev_mock",
+      routeId: "deepseek:deepseek-v4-flash",
+      providerId: "deepseek",
+      loopStatus: "Finished",
+      turns: 2,
+      executedTools: 1,
+      finalMessageLen: 42,
+      auditChainVerified: true,
+    });
+    expect(receipt.finalMessageSha256).toBe("0".repeat(64));
+    // The body text must never appear on the receipt.
+    expect((receipt as Record<string, unknown>).finalMessage).toBeUndefined();
+  });
+
+  it("fails closed (503) on a non-zero exit", async () => {
+    const { binPath, workspaceRoot } = setup(`
+      process.stderr.write("hub_run_task_unavailable: init_failed");
+      process.exit(2);
+    `);
+    const service = createFridayRustHubRunTaskBridgeService({ adapterBin: binPath });
+
+    await expect(
+      service.runReadMostlyTask({ task: "do a thing", workspaceRoot }),
+    ).rejects.toMatchObject({
+      code: "MISSION_SPINE_RUST_RUN_TASK_BRIDGE_UNAVAILABLE",
+      httpStatus: 503,
+    });
+  });
+
+  it("fails closed on malformed JSON", async () => {
+    const { binPath, workspaceRoot } = setup(`process.stdout.write("not json {");`);
+    const service = createFridayRustHubRunTaskBridgeService({ adapterBin: binPath });
+
+    await expect(
+      service.runReadMostlyTask({ task: "do a thing", workspaceRoot }),
+    ).rejects.toMatchObject({
+      code: "MISSION_SPINE_RUST_RUN_TASK_BRIDGE_UNAVAILABLE",
+      httpStatus: 503,
+    });
+  });
+
+  it("fails closed on timeout", async () => {
+    const { binPath, workspaceRoot } = setup(`setTimeout(() => process.stdout.write("late"), 5000);`);
+    const service = createFridayRustHubRunTaskBridgeService({ adapterBin: binPath, timeoutMs: 200 });
+
+    await expect(
+      service.runReadMostlyTask({ task: "do a thing", workspaceRoot }),
+    ).rejects.toMatchObject({
+      code: "MISSION_SPINE_RUST_RUN_TASK_BRIDGE_UNAVAILABLE",
+      httpStatus: 503,
+    });
+  });
+
+  it("rejects a payload that carries a raw message body (no-body boundary)", async () => {
+    const { binPath, workspaceRoot } = setup(`
+      process.stdout.write(JSON.stringify({
+        truth_label: "rust_wired_dev",
+        ok: true,
+        run_id: "leak",
+        route_id: "deepseek:deepseek-v4-flash",
+        final_message: "the raw model output that must never cross the bridge",
+        final_message_sha256: "0".repeat(64),
+        final_message_len: 51,
+        audit_chain_verified: true,
+      }));
+    `);
+    const service = createFridayRustHubRunTaskBridgeService({ adapterBin: binPath });
+
+    await expect(
+      service.runReadMostlyTask({ task: "do a thing", workspaceRoot }),
+    ).rejects.toMatchObject({
+      code: "MISSION_SPINE_RUST_RUN_TASK_BRIDGE_UNAVAILABLE",
+      httpStatus: 503,
+    });
+  });
+});

--- a/test/unit/api/mission-spine/friday-rust-hub-run-task-bridge-service.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-run-task-bridge-service.test.ts
@@ -75,6 +75,41 @@ describe("friday-rust-hub-run-task-bridge-service (S0 dev write-bridge)", () => 
     expect((receipt as Record<string, unknown>).finalMessage).toBeUndefined();
   });
 
+  it("surfaces a bounded error_category on an Ok-but-Errored loop", async () => {
+    // ok:true + loop_status:"Errored" must PARSE (parseReceipt fail-closes only on
+    // ok===false, never on a loop_status value), carrying the bounded token through.
+    const { binPath, workspaceRoot } = setup(`
+      process.stdout.write(JSON.stringify({
+        truth_label: "rust_wired_dev",
+        proof_only: true,
+        ok: true,
+        run_id: "hub_run_task_dev_errored",
+        route_id: "deepseek:deepseek-v4-flash",
+        provider_id: "deepseek",
+        model: "deepseek-v4-flash",
+        loop_status: "Errored",
+        error_category: "parse_error",
+        turns: 1,
+        executed_tools: 0,
+        final_message_sha256: "0".repeat(64),
+        final_message_len: 0,
+        audit_chain_verified: true,
+      }));
+    `);
+    const service = createFridayRustHubRunTaskBridgeService({ adapterBin: binPath });
+
+    const receipt = await service.runReadMostlyTask({
+      task: "read the file notes.md and summarize it",
+      workspaceRoot,
+    });
+
+    expect(receipt).toMatchObject({
+      truthLabel: "rust_wired_dev",
+      loopStatus: "Errored",
+      errorCategory: "parse_error",
+    });
+  });
+
   it("fails closed (503) on a non-zero exit", async () => {
     const { binPath, workspaceRoot } = setup(`
       process.stderr.write("hub_run_task_unavailable: init_failed");


### PR DESCRIPTION
## Truth label — PROOF-ONLY (Rust-wired-DEV)

This slice proves the Rust agent loop (`HubRuntime::run_task`) is **reachable end-to-end** for a read-mostly task through a NEW one-shot TS→Rust write-bridge, cloning the proven READ-ONLY `mission_workbench_projection` bridge shape. It is the cheapest de-risk of the transport + secret boundary now that the TS `executeRun`/`startRun` paths are fail-closed-fenced (#568/#570) and the Rust engines have zero production callers.

**This is NOT product and NOT v1 GO.** It does NOT replace `executeRun` — that path stays **FENCED-not-replaced**. It registers **no production route** (service function + test only). Everything that crosses the bridge is **refs-only** (hashes/ids/bools), never message bodies or secrets.

## Deliverables (exactly the three S0 deliverables + CI)

**D1 — new Rust bin `rust-core/crates/friday-hub/src/bin/hub_run_task.rs`**
- Thin `main` around `HubRuntime::live(...).run_task(<read-mostly task>)`.
- Input from argv/stdin like the projection bin: `--task` (or stdin), `--workspace`, optional `--db`/`--run-id`/`--max-turns`/`--now-ms`.
- Emits **refs-only JSON** to stdout: `truth_label="rust_wired_dev"`, `run_id`, `route_id`, provider/model/route telemetry, loop status + counts, `audit_chain_verified` (bool), and a **sha256 hash + length** of the final message — **never the body text**.
- Fail-closed: refs-only JSON error (coarse `error_kind` only — no path/secret detail) + non-zero exit on any error; defensive `reject_forbidden_output` guard (incl. a `final_message"` body marker) before printing.
- Gate-approval secret is **ephemeral/derived** (dormant under the deny-all policy baked into `HubRuntime::live` for a read-mostly task) — no real key is read or persisted. Bin auto-discovered from `src/bin/` (matches `mission_workbench_projection`, which has no `[[bin]]` entry). Adds `sha2` to friday-hub deps (already in the Hub closure via friday-storage/friday-crypto).

**D2 — new TS service `src/api/mission-spine/friday-rust-hub-run-task-bridge-service.ts`**
- Clones the projection execFile bridge: locate prebuilt `hub_run_task` (`adapterBin`/env, else `cargo run --bin`), spawn with timeout + bounded `maxBuffer`, parse + validate refs-only JSON, map non-zero/timeout/parse/invalid → fail-closed `FridayDomainError` (503), and **reject any payload carrying a raw `final_message`/`finalMessage` body** (the boundary this slice exists to prove).
- Clearly labeled PROOF-ONLY / Rust-wired-DEV; returns `truthLabel: "rust_wired_dev"` + `proofOnly: true`. **No prod route added.**
- Focused unit test `test/unit/api/mission-spine/friday-rust-hub-run-task-bridge-service.test.ts` spawns a **scripted mock bin** (chmod-0o755 shebang idiom from `friday-provider-cli-backend.test.ts`) — **no DeepSeek, no quota, no secret**. Covers happy path, non-zero exit, malformed JSON, timeout, and raw-body-leak rejection. Fake hash fixtures use `"0".repeat(64)` (no high-entropy literal → no detect-secrets FP).

**D3 — `mechanism_matrix` truth-fix (`rust-core/crates/friday-core/src/mechanism_matrix.rs`)**
- New tier `MechanismStatus::RustWiredDev` (renders `rust_wired_dev`; **never `is_v1_go`**) distinguishing dev-bridge reachability from `RustOwnedProven` (the "RustProvenProduct" tier).
- De-inflated `agent_tool_execution`: `RustOwnedPartial → RustWiredDev`; blocker now states dev-bridge-only (hub_run_task), only 2/10 fs tools, executeRun/startRun fenced — **retains the `"real multi-turn live agent/tool execution"` substring** the v1 NO-GO gate asserts.
- De-inflated `workflow_runtime`: `RustOwnedPartial → RustWiredDev`; blocker now states test-only entrypoint (TS startRun fenced), no production transport.

### mechanism_matrix readers checked + closure semantics
Grepped `rust-core/ src/ test/ scripts/ validation/ .github/` for every reader. Readers: the in-file tests + `rust-core/scripts/mission-spine-objective-coverage-gate.sh` (runs `cargo test -p friday-core mechanism_matrix`). No external code matches on `MechanismStatus::` variants or asserts the status strings. **Deviation noted explicitly:** the brief said `workflow_runtime` is "marked user-triggerable at a test-only entrypoint" — I corrected this via **status + blocker text**, NOT by flipping `user_triggerable_product_logic` to false, because that would remove the row from `friday_v1_no_go_blockers()` and shift the blocker set (forbidden). **Both rows stay `user_triggerable=true` and REMAIN v1 NO-GO blockers** — closure GO/NO-GO semantics unchanged, asserted by the new `s0_does_not_shift_the_v1_no_go_blocker_set` test.

## CI
`.github/workflows/rust-core.yml` adds an explicit `cargo build -p friday-hub --bin hub_run_task` step (technically redundant with `clippy --all-targets` / `test --workspace`, but names the bin so a missing/broken `hub_run_task` reds CI loudly). The bin is only BUILT in CI; it is never executed (no key, no quota).

## Local checks (all PASS in worktree, off base 2c806fa6)
- Rust: `cargo fmt --all --check` ✓ · `cargo clippy --workspace --all-targets -- -D warnings` ✓ · `cargo build -p friday-hub --bin hub_run_task` ✓ · `cargo test --workspace` ✓ (incl. friday-arch-tests dep_boundary, 7 mechanism_matrix tests, 5 hub_run_task bin tests).
- TS: `npm run lint` 0 errors ✓ (1542 pre-existing repo warnings; my `existsSync` warning matches the precedent's accepted one) · `npm run typecheck` ✓ · focused vitest 5/5 ✓.
- Secrets gate: `detect-secrets-hook` exit 0 ✓ · `check-provider-key-patterns.mjs` clean ✓.

## Separate live DeepSeek proof (NOT run here — needs a credential I do not have)
This PR only PREPARES for the single live proof. The operator/coordinator runs it AFTER merge, with the Hub DeepSeek key in the env, e.g.:

```
cd rust-core
cargo build -p friday-hub --bin hub_run_task
mkdir -p /tmp/hub-run-task-live-ws && printf 'Friday composed live e2e.' > /tmp/hub-run-task-live-ws/notes.md
FRIDAY_DEEPSEEK_API_KEY=<hub key from env, NOT committed> \
  ./target/debug/hub_run_task \
  --task "read the file notes.md and summarize it" \
  --workspace /tmp/hub-run-task-live-ws
# expect: exit 0 + refs-only JSON {truth_label:"rust_wired_dev", run_id, route_id:"deepseek:...", audit_chain_verified:true, final_message_sha256, final_message_len, ...}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)