### PR TITLE
fix(rust-hub): agent loop reliability on flash + real finish answer (S1.1)

### DIFF
--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -1949,8 +1949,8 @@ mod tests {
         // The finish contract `{"tool":"none","answer":"<text>"}` lifts the model's final
         // natural-language answer into `Finish.message` (Fix 2 — the loop's `final_message`
         // is no longer always empty on success).
-        let step = parse_agent_step("{\"tool\":\"none\",\"answer\":\"all done: 3 files read\"}")
-            .unwrap();
+        let step =
+            parse_agent_step("{\"tool\":\"none\",\"answer\":\"all done: 3 files read\"}").unwrap();
         assert_eq!(
             step,
             AgentStep::Finish {
@@ -1991,8 +1991,8 @@ mod tests {
     fn parse_agent_step_tool_branch_is_unchanged() {
         // A non-`none` tool call is still a `Tool` step (the answer extraction touches only
         // the finish branch); an `answer` field on a tool call is ignored, not an error.
-        let step =
-            parse_agent_step("{\"tool\":\"read_file\",\"parameters\":{\"path\":\"a.md\"}}").unwrap();
+        let step = parse_agent_step("{\"tool\":\"read_file\",\"parameters\":{\"path\":\"a.md\"}}")
+            .unwrap();
         assert_eq!(
             step,
             AgentStep::Tool(RawToolCall {

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -210,12 +210,15 @@ impl std::fmt::Display for AgentError {
 
 /// One step the model takes in a multi-turn loop: either propose a tool call
 /// (untrusted) or declare the task finished. Termination is the model's `Finish` (the
-/// `{"tool":"none"}` contract), bounded by `max_turns` in [`run_loop`].
+/// `{"tool":"none","answer":"<final answer>"}` contract), bounded by `max_turns` in
+/// [`run_loop`].
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum AgentStep {
     /// Propose an (untrusted) tool call — classified by the Hub, not trusted as-is.
     Tool(RawToolCall),
     /// The model considers the task complete; the loop stops (not a tool, not a no-op).
+    /// `message` carries the model's final natural-language answer (the `answer` field of
+    /// the finish object); it is empty if the model omitted one.
     Finish { message: String },
 }
 
@@ -279,6 +282,18 @@ impl<T: friday_deepseek::Transport> DeepSeekAgentLlmClient<T> {
     }
 }
 
+/// Completion-token budget for the agent-loop reasoning calls (`propose_tool_call` and
+/// `next_step`). The routed `deepseek-v4-*` models are REASONING models: their
+/// chain-of-thought goes in `reasoning_content` and the answer in `content`, but BOTH
+/// share this single `max_tokens` completion budget. At 512, reasoning routinely
+/// exhausted the budget → the response truncated (`finish_reason="length"`) with an EMPTY
+/// `content`, so parsing `""` produced `agent.error:parse_error: not a single JSON object:
+/// EOF`. 4096 is coordinator-proven (flash & pro live matrix) to eliminate the truncation
+/// — it comfortably holds the reasoning plus a tool-call object or a short finish answer.
+/// This is the agent-loop path ONLY; the single-shot mission-ask (`run_friday_ask`)
+/// carries its own caller-supplied budget and is unaffected.
+const AGENTLOOP_MAX_TOKENS: u32 = 4096;
+
 impl<T: friday_deepseek::Transport> AgentLlmClient for DeepSeekAgentLlmClient<T> {
     fn propose_tool_call(&self, task: &str) -> Result<RawToolCall, AgentError> {
         let models = self
@@ -288,16 +303,16 @@ impl<T: friday_deepseek::Transport> AgentLlmClient for DeepSeekAgentLlmClient<T>
         let model = friday_deepseek::select_model(&models)
             .ok_or_else(|| AgentError::Model("no model available".to_string()))?;
         let prompt = build_tool_prompt(task);
-        // 512 tokens is ample for one tool-call JSON object.
         let outcome = self
             .client
-            .chat(&model, &prompt, 512)
+            .chat(&model, &prompt, AGENTLOOP_MAX_TOKENS)
             .map_err(|e| AgentError::Model(format!("{e:?}")))?;
         parse_tool_call(&outcome.content)
     }
 
     /// History-aware multi-turn step: the prompt includes prior turns + their outcomes
-    /// so the model can build on them or finish. `{"tool":"none"}` parses to `Finish`.
+    /// so the model can build on them or finish. `{"tool":"none","answer":"<final answer>"}`
+    /// parses to `Finish { message: "<final answer>" }`.
     fn next_step(&self, task: &str, history: &[TurnTrace]) -> Result<AgentStep, AgentError> {
         let models = self
             .client
@@ -308,7 +323,7 @@ impl<T: friday_deepseek::Transport> AgentLlmClient for DeepSeekAgentLlmClient<T>
         let prompt = build_loop_prompt(task, history);
         let outcome = self
             .client
-            .chat(&model, &prompt, 512)
+            .chat(&model, &prompt, AGENTLOOP_MAX_TOKENS)
             .map_err(|e| AgentError::Model(format!("{e:?}")))?;
         parse_agent_step(&outcome.content)
     }
@@ -347,7 +362,9 @@ pub fn build_tool_prompt_with(task: &str, registry: &ToolRegistry) -> String {
         "\nReply with EXACTLY ONE JSON object and nothing else (no prose, no code fence \
          is required but tolerated), of the form:\n\
          {\"tool\": \"<tool name>\", \"parameters\": {\"<key>\": \"<value>\"}}\n\
-         All parameter values must be strings. If no tool is needed, reply {\"tool\": \"none\"}.\n\n",
+         All parameter values must be strings. When the task is complete (or no tool is \
+         needed), reply with a finish object that INCLUDES your final answer:\n\
+         {\"tool\": \"none\", \"answer\": \"<your final answer in natural language>\"}\n\n",
     );
     s.push_str("Task: ");
     s.push_str(task);
@@ -420,21 +437,36 @@ pub fn build_loop_prompt(task: &str, history: &[TurnTrace]) -> String {
         for (i, t) in history.iter().enumerate() {
             s.push_str(&format!("{}. {} → {}\n", i + 1, t.action, t.outcome));
         }
-        s.push_str("If the task is now complete, reply {\"tool\": \"none\"}.\n");
+        s.push_str(
+            "If the task is now complete, reply with your final answer in a finish object: \
+             {\"tool\": \"none\", \"answer\": \"<your final answer>\"}.\n",
+        );
     }
     s
 }
 
 /// Parse a model reply into an [`AgentStep`]: a strict [`parse_tool_call`] whose
-/// sentinel `"none"` action (the finish contract) maps to [`AgentStep::Finish`];
+/// sentinel `"none"` action (the finish contract) maps to [`AgentStep::Finish`], with the
+/// model's final answer lifted from the top-level `answer` field into `Finish.message`;
 /// every other (parsed) tool is a [`AgentStep::Tool`]. Fail-closed identically to
 /// `parse_tool_call` on any contract violation.
+///
+/// The `answer` extraction is deliberately LENIENT (and never panics): a finish object
+/// that omits `answer`, or whose `answer` is non-string, still parses to a `Finish` with
+/// an empty `message` — a missing answer is an honest empty answer, not a parse error.
+/// (`parse_tool_call` already validated the de-fenced content is exactly one JSON object,
+/// so the second parse here is guaranteed to succeed; `.ok()` keeps it total regardless.)
 pub fn parse_agent_step(content: &str) -> Result<AgentStep, AgentError> {
     let raw = parse_tool_call(content)?;
     if raw.action == "none" {
-        Ok(AgentStep::Finish {
-            message: String::new(),
-        })
+        let message = serde_json::from_str::<serde_json::Value>(strip_code_fence(content))
+            .ok()
+            .as_ref()
+            .and_then(|v| v.get("answer"))
+            .and_then(|a| a.as_str())
+            .unwrap_or_default()
+            .to_string();
+        Ok(AgentStep::Finish { message })
     } else {
         Ok(AgentStep::Tool(raw))
     }
@@ -1856,6 +1888,8 @@ mod tests {
         assert!(p.contains("delete_file"));
         assert!(p.contains("\"tool\""));
         assert!(p.contains("\"parameters\""));
+        // The finish contract advertises the answer-carrying shape (Fix 2).
+        assert!(p.contains("\"answer\""));
         assert!(p.contains("read notes.md")); // the task is included
     }
 
@@ -1908,6 +1942,69 @@ mod tests {
                 "must fail-closed on: {bad:?}"
             );
         }
+    }
+
+    #[test]
+    fn parse_agent_step_finish_carries_the_answer() {
+        // The finish contract `{"tool":"none","answer":"<text>"}` lifts the model's final
+        // natural-language answer into `Finish.message` (Fix 2 — the loop's `final_message`
+        // is no longer always empty on success).
+        let step = parse_agent_step("{\"tool\":\"none\",\"answer\":\"all done: 3 files read\"}")
+            .unwrap();
+        assert_eq!(
+            step,
+            AgentStep::Finish {
+                message: "all done: 3 files read".to_string()
+            }
+        );
+        // A code-fenced finish object is tolerated too (same as tool calls).
+        let fenced =
+            parse_agent_step("```json\n{\"tool\":\"none\",\"answer\":\"ok\"}\n```").unwrap();
+        assert_eq!(
+            fenced,
+            AgentStep::Finish {
+                message: "ok".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn parse_agent_step_finish_is_robust_to_missing_or_nonstring_answer() {
+        // ROBUST: a finish object missing `answer`, or whose `answer` is non-string, still
+        // parses to a `Finish` with an EMPTY message — never a panic, never a parse error.
+        for c in [
+            "{\"tool\":\"none\"}",                 // no answer field (old contract shape)
+            "{\"tool\":\"none\",\"answer\":42}",   // non-string answer
+            "{\"tool\":\"none\",\"answer\":null}", // null answer
+        ] {
+            assert_eq!(
+                parse_agent_step(c).unwrap(),
+                AgentStep::Finish {
+                    message: String::new()
+                },
+                "must parse to an empty-message Finish: {c:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_agent_step_tool_branch_is_unchanged() {
+        // A non-`none` tool call is still a `Tool` step (the answer extraction touches only
+        // the finish branch); an `answer` field on a tool call is ignored, not an error.
+        let step =
+            parse_agent_step("{\"tool\":\"read_file\",\"parameters\":{\"path\":\"a.md\"}}").unwrap();
+        assert_eq!(
+            step,
+            AgentStep::Tool(RawToolCall {
+                action: "read_file".to_string(),
+                params: vec![("path".to_string(), "a.md".to_string())],
+            })
+        );
+        // Contract violations still fail-closed through `parse_agent_step`.
+        assert!(matches!(
+            parse_agent_step("Sure! {\"tool\":\"none\"}"),
+            Err(AgentError::Parse(_))
+        ));
     }
 
     #[test]

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -223,8 +223,12 @@ pub enum AgentStep {
 }
 
 /// A record of one completed turn, threaded back to the model as conversation history
-/// so the next step is informed by what already happened. `outcome` is a short,
-/// Hub-authored summary (never raw secret material).
+/// so the next step is informed by what already happened. `outcome` is the Hub-authored
+/// per-turn result: the short summary PLUS, for read-type tools, a BOUNDED head slice of
+/// the actual tool-result content (so the model can ground its answer on what it read —
+/// see [`format_executed_outcome`]). It is MODEL-CONTEXT only: it is never persisted and
+/// never carries Hub secret/approval-key material; the compact `summary` (not `outcome`)
+/// is what reaches the event log and the hash-chained audit ledger.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TurnTrace {
     pub action: String,
@@ -433,7 +437,11 @@ pub fn parse_tool_call(content: &str) -> Result<RawToolCall, AgentError> {
 pub fn build_loop_prompt(task: &str, history: &[TurnTrace]) -> String {
     let mut s = build_tool_prompt(task);
     if !history.is_empty() {
-        s.push_str("\nSo far this run:\n");
+        s.push_str(
+            "\nSo far this run (each line is a completed step; any text after \"content:\" \
+             is the ACTUAL tool result — read and USE it to answer, do NOT re-run the same \
+             tool just to see it again):\n",
+        );
         for (i, t) in history.iter().enumerate() {
             s.push_str(&format!("{}. {} → {}\n", i + 1, t.action, t.outcome));
         }
@@ -1030,12 +1038,23 @@ pub fn run_one_turn(
 
 // --- the tool executor (real, friday-fs-backed dispatch) ---------------------
 
-/// A receipt of a tool execution: what ran + a short outcome summary. Recorded to the
-/// agent_run event log AND the hash-chained audit ledger.
+/// A receipt of a tool execution: what ran + a short outcome `summary`, plus the OPTIONAL
+/// real tool-result `content` (e.g. the bytes a `read_file` produced).
+///
+/// `summary` is the short, Hub-authored, log-safe line ("read 47 bytes from notes.md");
+/// it — and ONLY it — is recorded to the agent_run event log AND the hash-chained audit
+/// ledger. `content` is the actual result the model needs to USE what a tool produced;
+/// it is fed back into the model's next-turn context (bounded) via [`TurnTrace::outcome`]
+/// and is NEVER written to the event log or audit ledger (so the ledger stays a compact,
+/// content-free chain). `content` is `None` for tools with nothing meaningful to feed
+/// back (e.g. `write_file`, whose `summary` already says what happened).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ToolReceipt {
     pub action: String,
     pub summary: String,
+    /// The real tool-result payload to thread back to the model (bounded at feed-back
+    /// time, see [`MAX_FEEDBACK_CONTENT_BYTES`]); `None` when there is nothing to feed back.
+    pub content: Option<String>,
 }
 
 /// Why a tool EXECUTION failed — distinct from the GATE refusing it. The gate runs
@@ -1108,6 +1127,10 @@ impl ToolExecutor for FsToolExecutor {
                 Ok(ToolReceipt {
                     action: action.to_string(),
                     summary: format!("read {n} bytes from {path}"),
+                    // Carry the ACTUAL file content so the loop can feed it back to the
+                    // model (bounded at feed-back time); the byte-count `summary` alone is
+                    // what made the model re-read & hallucinate (S1.2 grounding bug).
+                    content: Some(buf),
                 })
             }
             "write_file" => {
@@ -1121,6 +1144,8 @@ impl ToolExecutor for FsToolExecutor {
                 Ok(ToolReceipt {
                     action: action.to_string(),
                     summary: format!("wrote {} bytes to {path}", content.len()),
+                    // A write has no result payload to feed back; the summary suffices.
+                    content: None,
                 })
             }
             other => Err(ExecError::Unsupported(other.to_string())),
@@ -1373,6 +1398,59 @@ pub(crate) fn gate_dispatch(
     })
 }
 
+/// Max bytes of real tool-result CONTENT fed back into the model's next-turn context
+/// (the [`TurnTrace::outcome`] history). Read-type tools (e.g. `read_file`) load the
+/// whole file, but only this BOUNDED head slice is threaded back so the model can USE
+/// what it read WITHOUT re-creating the completion-budget / cost blow-up an unbounded
+/// feedback would cause. 2 KiB comfortably covers a notes / config file's salient head;
+/// anything larger is truncated with [`FEEDBACK_TRUNCATION_MARKER`].
+const MAX_FEEDBACK_CONTENT_BYTES: usize = 2048;
+
+/// Appended to fed-back content when it was truncated to [`MAX_FEEDBACK_CONTENT_BYTES`],
+/// so the model knows the file continues beyond what it can see.
+const FEEDBACK_TRUNCATION_MARKER: &str = " …[content truncated]";
+
+/// The largest UTF-8 prefix of `s` whose byte length is `<= max_bytes`, and whether any
+/// bytes were dropped. Never splits a multi-byte char: walks back to the nearest char
+/// boundary, so the returned slice is always valid `&str` and never panics.
+fn head_slice(s: &str, max_bytes: usize) -> (&str, bool) {
+    if s.len() <= max_bytes {
+        return (s, false);
+    }
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    (&s[..end], true)
+}
+
+/// Format a completed tool execution into the [`TurnTrace::outcome`] threaded back to the
+/// model as conversation history. The byte-count `summary` is ALWAYS included (it is what
+/// the audit ledger also records). When the executor returned real `content` (e.g. the
+/// bytes a `read_file` produced), a BOUNDED head slice of that content is appended so the
+/// model can actually USE what it read — WITHOUT this the model sees only "read N bytes
+/// from X", re-reads the same file, and hallucinates (the S1.2 grounding bug). The content
+/// is capped at [`MAX_FEEDBACK_CONTENT_BYTES`] on a UTF-8 char boundary, with a clear
+/// truncation marker. `summary` (and thus the audit/event log) is NEVER widened — raw
+/// content lives ONLY in the model-facing history outcome, never on the hash-chained ledger.
+fn format_executed_outcome(receipt: &ToolReceipt) -> String {
+    match receipt.content.as_deref() {
+        Some(content) => {
+            let (head, truncated) = head_slice(content, MAX_FEEDBACK_CONTENT_BYTES);
+            if truncated {
+                format!(
+                    "executed: {} | content (first {} bytes shown):\n{head}{FEEDBACK_TRUNCATION_MARKER}",
+                    receipt.summary,
+                    head.len()
+                )
+            } else {
+                format!("executed: {} | content:\n{head}", receipt.summary)
+            }
+        }
+        None => format!("executed: {}", receipt.summary),
+    }
+}
+
 /// Drive a MULTI-TURN agent loop: repeatedly ask the model for the next step (with
 /// conversation history), and for each proposed tool run the SAME gate-mandatory
 /// dispatch as [`run_one_turn_with_executor`] (authorize → execute only on `Allow` →
@@ -1425,6 +1503,11 @@ pub fn run_loop(
     // surface. The backstop is genuine: the UNW-001 mutating-action gate evaluates EVERY
     // tool call regardless of prompt text, and the recalled memory is user-CONFIRMED
     // (not raw channel text), so it is trusted context, not arbitrary injection.
+    // The bounded tool-result CONTENT now threaded back into history (the S1.2 grounding
+    // fix, see `format_executed_outcome`) is ANOTHER prompt-injection-inward surface — a
+    // read file could contain adversarial instructions. The SAME backstop holds: that
+    // content only ever reaches the prompt, and the gate still evaluates every subsequent
+    // tool call regardless of what the file said; it is not a new mutation path.
     let prompt_task = if recall_preamble.is_empty() {
         task.to_string()
     } else {
@@ -1515,7 +1598,10 @@ pub fn run_loop(
                     history.push(TurnTrace {
                         action: raw.action.clone(),
                         params: raw.params.clone(),
-                        outcome: format!("executed: {}", receipt.summary),
+                        // Feed the REAL (bounded) tool-result content back to the model so it
+                        // can ground its answer on what the tool produced — not just the
+                        // byte-count summary recorded above to the event log / audit ledger.
+                        outcome: format_executed_outcome(&receipt),
                     });
                 }
             }
@@ -2417,6 +2503,143 @@ mod tests {
         // an instant owner approval). Distinct requests → distinct digests → distinct
         // single-use keys.
         |req| Some(mint_approval(req, "ap-loop", SECRET, 1_000_000))
+    }
+
+    /// A scripted client that ALSO captures the exact loop prompt
+    /// (`build_loop_prompt(task, history)`) it is handed each turn — so a test can assert
+    /// what the model actually SEES, including tool-result content threaded back into
+    /// history. (The live `next_step` renders precisely this prompt before calling `chat`.)
+    struct CapturingAgentLlmClient {
+        steps: Vec<AgentStep>,
+        calls: std::cell::Cell<usize>,
+        prompts: std::cell::RefCell<Vec<String>>,
+    }
+    impl CapturingAgentLlmClient {
+        fn new(steps: Vec<AgentStep>) -> Self {
+            Self {
+                steps,
+                calls: std::cell::Cell::new(0),
+                prompts: std::cell::RefCell::new(Vec::new()),
+            }
+        }
+    }
+    impl AgentLlmClient for CapturingAgentLlmClient {
+        fn propose_tool_call(&self, _task: &str) -> Result<RawToolCall, AgentError> {
+            Err(AgentError::Parse(
+                "capturing: single-turn path unused by run_loop".to_string(),
+            ))
+        }
+        fn next_step(&self, task: &str, history: &[TurnTrace]) -> Result<AgentStep, AgentError> {
+            self.prompts
+                .borrow_mut()
+                .push(build_loop_prompt(task, history));
+            let i = self.calls.get();
+            self.calls.set(i + 1);
+            Ok(self.steps.get(i).cloned().unwrap_or(AgentStep::Finish {
+                message: "script exhausted".to_string(),
+            }))
+        }
+    }
+
+    #[test]
+    fn head_slice_respects_utf8_boundary() {
+        // Under cap: returned whole, not truncated.
+        let (whole, t0) = head_slice("hello", 10);
+        assert_eq!(whole, "hello");
+        assert!(!t0);
+        // 'é' is 2 bytes; a cap that lands mid-char must walk back, never split / panic.
+        let s = "aé"; // 'a'(1) + 'é'(2) = 3 bytes
+        let (slice, truncated) = head_slice(s, 2);
+        assert_eq!(slice, "a"); // dropped the partial 'é'
+        assert!(truncated);
+        let (exact, t2) = head_slice(s, 3);
+        assert_eq!(exact, "aé");
+        assert!(!t2);
+    }
+
+    #[test]
+    fn format_executed_outcome_carries_bounded_content() {
+        // read-type receipt under cap: summary + the ACTUAL content, no truncation marker.
+        let r = ToolReceipt {
+            action: "read_file".to_string(),
+            summary: "read 26 bytes from notes.md".to_string(),
+            content: Some("...Remember the number 47.".to_string()),
+        };
+        let out = format_executed_outcome(&r);
+        assert!(out.contains("read 26 bytes from notes.md"));
+        assert!(out.contains("Remember the number 47."));
+        assert!(!out.contains(FEEDBACK_TRUNCATION_MARKER));
+
+        // oversized content: capped to <= MAX_FEEDBACK_CONTENT_BYTES, truncation marker present.
+        // Sentinel 'Z' is absent from the boilerplate ("executed"/"content"/... ) so its
+        // count == exactly the number of fed-back content bytes.
+        let big = "Z".repeat(MAX_FEEDBACK_CONTENT_BYTES + 500);
+        let r2 = ToolReceipt {
+            action: "read_file".to_string(),
+            summary: format!("read {} bytes from big.md", big.len()),
+            content: Some(big),
+        };
+        let out2 = format_executed_outcome(&r2);
+        assert!(out2.contains(FEEDBACK_TRUNCATION_MARKER));
+        // The fed-back content slice never exceeds the cap.
+        let fed = out2.chars().filter(|&c| c == 'Z').count();
+        assert!(fed > 0 && fed <= MAX_FEEDBACK_CONTENT_BYTES, "fed={fed}");
+
+        // no-content receipt (e.g. write): plain summary only, unchanged from before.
+        let r3 = ToolReceipt {
+            action: "write_file".to_string(),
+            summary: "wrote 8 bytes to out.md".to_string(),
+            content: None,
+        };
+        assert_eq!(
+            format_executed_outcome(&r3),
+            "executed: wrote 8 bytes to out.md"
+        );
+    }
+
+    #[test]
+    fn loop_feeds_bounded_tool_content_back_into_model_prompt() {
+        // The S1.2 grounding fix end-to-end: after a read, the NEXT model turn's prompt
+        // must contain the file's ACTUAL content (not just the byte-count summary).
+        let root = TempDir::new("loop-grounding");
+        std::fs::write(root.0.join("notes.md"), b"...Remember the number 47.").unwrap();
+        let db = Db::open_hub(&temp_path("loop-grounding")).unwrap();
+        agent_run::create_run(db.conn(), "r1", "what is the number in notes.md", 1).unwrap();
+        let client = CapturingAgentLlmClient::new(vec![
+            AgentStep::Tool(raw("read_file", &[("path", "notes.md")])),
+            AgentStep::Finish {
+                message: "47".to_string(),
+            },
+        ]);
+        let executor = FsToolExecutor::new(&root.0);
+        let out = run_loop(
+            &client,
+            &executor,
+            db.conn(),
+            "r1",
+            "what is the number in notes.md",
+            "",
+            SECRET,
+            &no_approval(),
+            10,
+            1000,
+        )
+        .unwrap();
+        assert_eq!(out.status, LoopStatus::Finished);
+        assert_eq!(out.final_message.as_deref(), Some("47"));
+
+        let prompts = client.prompts.borrow();
+        assert_eq!(prompts.len(), 2); // turn 1 (read) + turn 2 (finish)
+                                      // Turn 1 had no history → no content yet.
+        assert!(!prompts[0].contains("Remember the number 47."));
+        // Turn 2 (AFTER the read) sees the real file content AND the summary.
+        assert!(
+            prompts[1].contains("Remember the number 47."),
+            "second prompt must carry the read content, got: {}",
+            prompts[1]
+        );
+        assert!(prompts[1].contains("from notes.md"));
+        assert!(friday_storage::audit::verify_audit_chain(db.conn()).is_ok());
     }
 
     #[test]

--- a/rust-core/crates/friday-hub/src/mission_runtime.rs
+++ b/rust-core/crates/friday-hub/src/mission_runtime.rs
@@ -542,6 +542,7 @@ mod tests {
             Ok(ToolReceipt {
                 action: action.to_string(),
                 summary: format!("ran {action}"),
+                content: None,
             })
         }
     }

--- a/rust-core/crates/friday-hub/src/routing.rs
+++ b/rust-core/crates/friday-hub/src/routing.rs
@@ -814,6 +814,7 @@ mod tests {
             Ok(ToolReceipt {
                 action: action.to_string(),
                 summary: format!("ran {action}"),
+                content: None,
             })
         }
     }

--- a/rust-core/crates/friday-hub/src/workflow_exec.rs
+++ b/rust-core/crates/friday-hub/src/workflow_exec.rs
@@ -408,6 +408,7 @@ mod tests {
             Ok(ToolReceipt {
                 action: action.to_string(),
                 summary: format!("ran {action}"),
+                content: None,
             })
         }
     }


### PR DESCRIPTION
## Truth label
This makes the Rust **agent loop RELIABLE** (no more `parse_error: EOF`), makes it **return a real natural-language answer** on `deepseek-v4-flash`, and makes it **grounded on its tool results** (it now USES the content it reads instead of re-reading and hallucinating). It is still **PROOF-ONLY Rust-wired-DEV** — NOT `executeRun`-replaced, NOT a v1 GO. The live `Finished` + correct-answer proof (e.g. "Finished contains 47") is a **separate coordinator-run step** (no live creds were used here).

## Root cause (wire-confirmed by the coordinator)
`HubRuntime::run_task` → `run_loop` → `DeepSeekAgentLlmClient::next_step` was failing with `agent.error:parse_error: not a single JSON object: EOF`. `deepseek-v4-*` are **reasoning models**: chain-of-thought goes in `reasoning_content`, the answer in `content`, but **both share the single `max_tokens` completion budget**. At 512, reasoning exhausted the budget → the response truncated (`finish_reason=\"length\"`) with an **empty `content`** → parsing `\"\"` → parse_error. Separately, even a clean finish returned an empty answer because the `{\"tool\":\"none\"}` finish contract carried no answer text and `parse_agent_step` hardcoded `Finish { message: String::new() }`. And **even when it finished, the answer was WRONG**: after a tool ran, the loop threaded back only `receipt.summary` (a byte-count like `\"read 69 bytes from notes.md\"`), never the file CONTENT — so the model re-read the same file and hallucinated (one run echoed `\"69\"`, the exact byte count = proof it only ever saw the summary).

## Fix 1 — raise agent-loop max_tokens 512 → 4096
- Introduced `const AGENTLOOP_MAX_TOKENS: u32 = 4096` (documented: reasoning_content shares the budget; 512 truncated content to empty; 4096 is coordinator-proven, flash & pro, to eliminate truncation).
- Applied to **both** `DeepSeekAgentLlmClient` reasoning calls: `propose_tool_call` and `next_step` (identical truncation risk; both on the agent-client path).
- Deleted the now-false `// 512 tokens is ample…` comment.

## Fix 2 — capture the model's final answer into `Finish.message`
- **Finish-protocol shape chosen:** `{\"tool\":\"none\",\"answer\":\"<final answer>\"}`.
- Updated the model-facing prompts to describe it: `build_tool_prompt_with` and `build_loop_prompt`.
- `parse_agent_step` now lifts the top-level `answer` string into `Finish.message`. The extraction is **lenient/robust**: a finish object missing `answer`, or with a non-string `answer`, still parses to a `Finish` with an empty message and never panics. The `Tool` branch is unchanged. `run_loop` already propagates `final_message: Some(message)`, so no loop change was needed.
- Tests: added `parse_agent_step_finish_carries_the_answer`, `parse_agent_step_finish_is_robust_to_missing_or_nonstring_answer`, `parse_agent_step_tool_branch_is_unchanged`; extended the prompt-contract test to assert the `\"answer\"` shape. No existing test asserted the old empty-finish behavior.

## Fix 3 — feed BOUNDED tool-result content back to the model (grounding)
The loop read a file but answered wrong because it only ever saw the byte-count `summary`, never the bytes (`FsToolExecutor::read_file` loaded the content into `buf` then **discarded** it). Fix shape was **MEDIUM** (executor discards content → the receipt must carry it); it stays within **loop + executor + receipt**.
- Added `ToolReceipt.content: Option<String>` carrying the real tool output; `read_file` sets `Some(buf)`, `write_file` sets `None`.
- `run_loop` now threads a **bounded** head slice of that content into `TurnTrace.outcome` via a new `format_executed_outcome` helper: cap **2 KiB** (`MAX_FEEDBACK_CONTENT_BYTES`) on a UTF-8 char boundary (`head_slice`), with a clear ` …[content truncated]` marker. Bounding is critical — unbounded feedback would re-create the completion-budget/cost blow-up from the other side.
- The byte-count `summary` is **unchanged** and remains the **only** thing written to the agent_run event log + hash-chained audit ledger. Raw content is **model-context-only** (the sole `outcome` consumer is `build_loop_prompt`); the ledger stays compact/content-free.
- `build_loop_prompt` header now tells the model the text after `content:` is the actual tool result and not to re-run the tool just to see it again.
- **Security:** the UNW-001 mutating-action gate still evaluates **every** tool call; fed-back file content is a prompt-injection-inward surface explicitly documented as backstopped by that gate — **no gate weakening, no new mutation path, no secrets logged**.
- Tests: `format_executed_outcome_carries_bounded_content` (content present + truncation marker + bound ≤ cap), `head_slice_respects_utf8_boundary`, and end-to-end `loop_feeds_bounded_tool_content_back_into_model_prompt` (the model turn AFTER a read renders the file content into the prompt). Sibling test-mock executors updated for the new field.

## What I did NOT change (out of scope)
- No pro routing; the `runtime.rs` pro-availability guard is untouched — **flash stays the agent-loop model**. (`runtime.rs`, `friday-deepseek`, and the S2-owned `friday-storage`/new bins were not touched.)
- The single-shot **mission-ask** path (`run_friday_ask` / `record_friday_ask`) keeps its caller-supplied `max_tokens` — untouched.
- No env knob, no `length`-tolerance/retry, no changes to the `hub_run_task` bin stdout contract.

## Local gates (actual, post-Fix-3)
- `cargo build -p friday-hub --bin hub_run_task` — OK
- `cargo test -p friday-hub -p friday-deepseek` — **all pass** (friday-hub lib 261 passed / 0 failed / 8 ignored; hub_run_task bin 6/0; friday-deepseek 14/0; live tests left ignored)
- `npm run lint` — **0 errors** (1542 pre-existing warnings in untouched TS)
- `npm run typecheck` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)