### PR TITLE
feat(rust-hub): S2 hub_run_readback dev read-bridge (Rust-wired-DEV, proof-only)

### DIFF
--- a/.github/workflows/rust-core.yml
+++ b/.github/workflows/rust-core.yml
@@ -43,6 +43,11 @@ jobs:
         # only BUILT here; running it needs FRIDAY_DEEPSEEK_API_KEY (the separate live-proof
         # step), so it is never executed in CI.
         run: cargo build -p friday-hub --bin hub_run_task
+      - name: Build bins (incl. S2 hub_run_readback read-bridge)
+        # Read-only sibling of S0's hub_run_task: names the S2 dev read-bridge explicitly so
+        # a missing/compile-broken `hub_run_readback` reds CI loudly. Only BUILT here — the
+        # TS bridge test spawns a scripted MOCK bin instead (no DB, no key, no quota).
+        run: cargo build -p friday-hub --bin hub_run_readback
       - name: Test
         # The one live DeepSeek test is #[ignore]d, so this needs no network/secrets.
         run: cargo test --workspace

--- a/rust-core/crates/friday-hub/src/bin/hub_run_readback.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_run_readback.rs
@@ -1,0 +1,285 @@
+//! S2 dev read-bridge — `hub_run_readback`.
+//!
+//! PROOF-ONLY (Rust-wired-DEV). The READ-ONLY sibling of the S0 `hub_run_task`
+//! write-bridge: it lets the TS side SEE a completed Rust run's result by
+//! `run_id`, refs-only. It mirrors the existing read-only precedent
+//! `mission_workbench_projection` (opens the hub DB with
+//! [`friday_storage::Db::open_hub_readonly`], emits redacted/refs-only JSON, and
+//! runs the output through a forbidden-marker guard before printing).
+//!
+//! This is NOT a replacement for the TS run-result read path, registers NO
+//! production route, and confers no v1 GO. It exists to prove the read transport +
+//! refs-only boundary: that a Rust run's outcome can be projected to TS without
+//! ever transporting a body/secret/PII.
+//!
+//! ## Output contract — REFS ONLY (no bodies, no secrets, no PII)
+//! Emits a single JSON object to stdout carrying ONLY safe identifiers/labels:
+//! `truth_label="rust_wired_dev"`, `run_id`, the run `state` label (NOT the run
+//! `task` text), created/updated timestamps (ints), a `loop_status_derived` label
+//! computed from the event log, turn/tool counts, the **ordered list of event
+//! `kind` strings**, and the `audit_chain_verified` bool.
+//!
+//! ### Event-kind sensitivity
+//! The event `kind` strings are safe labels (`plan.none`, `agent.finished`,
+//! `tool.blocked:...`) but a `tool.executed:` kind CAN embed a relative filename
+//! (e.g. `tool.executed:read 15 bytes from notes.md`). Relative names are accepted;
+//! the [`reject_forbidden_output`] guard fails the WHOLE projection closed if any
+//! forbidden marker (Authorization/Bearer/sk-/absolute `/Users/`,`/private/` path)
+//! ever appears — so an absolute-path or secret leak is structurally impossible to
+//! emit (non-zero exit + refs-only error JSON), exactly like S0's bin.
+//!
+//! ### Token totals — DB-wide, NOT run-attributable
+//! `db_wide_token_*` are summed over the whole `token_ledger`. They are NOT this
+//! run's tokens: `token_ledger` has no `run_id`, and the agent loop does not
+//! ledger tokens (a known gap), so for a run DB they are `0`. The field name says
+//! `db_wide_` so it is never misread as run-scoped cost. `route_decision` is
+//! intentionally OMITTED — it is mission/work-item-keyed and never written by a
+//! run, so it is not run-attributable.
+
+use std::env;
+use std::path::Path;
+
+use friday_storage::agent_run_read::{db_wide_token_totals, get_run_summary, list_event_kinds};
+use friday_storage::audit::verify_audit_chain;
+use friday_storage::Db;
+use serde_json::json;
+
+/// A fail-closed error: `kind` is a coarse, safe category (the only thing
+/// surfaced); the raw detail is deliberately NOT printed so storage/IO errors
+/// cannot leak paths.
+struct ReadbackError {
+    kind: &'static str,
+}
+
+impl ReadbackError {
+    fn new(kind: &'static str) -> Self {
+        Self { kind }
+    }
+}
+
+fn main() {
+    match run() {
+        Ok(rendered) => {
+            println!("{rendered}");
+        }
+        Err(err) => {
+            // Refs-only error to stdout (no detail), coarse category to stderr, non-zero exit.
+            let payload = json!({
+                "truth_label": "rust_wired_dev",
+                "proof_only": true,
+                "ok": false,
+                "error_kind": err.kind,
+            });
+            println!("{payload}");
+            eprintln!("hub_run_readback_unavailable: {}", err.kind);
+            std::process::exit(2);
+        }
+    }
+}
+
+fn run() -> Result<String, ReadbackError> {
+    let args: Vec<String> = env::args().collect();
+
+    let db_path = arg_value(&args, "--db").ok_or(ReadbackError::new("bad_args"))?;
+    if !Path::new(&db_path).is_file() {
+        return Err(ReadbackError::new("db_not_found"));
+    }
+    let run_id = arg_value(&args, "--run-id").ok_or(ReadbackError::new("bad_args"))?;
+
+    // Read-only open: a readback can NEVER mutate an operator DB just because TS asks.
+    let db = Db::open_hub_readonly(&db_path).map_err(|_| ReadbackError::new("open_failed"))?;
+
+    let summary = get_run_summary(db.conn(), &run_id)
+        .map_err(|_| ReadbackError::new("read_failed"))?
+        .ok_or(ReadbackError::new("run_not_found"))?;
+
+    let event_kinds =
+        list_event_kinds(db.conn(), &run_id).map_err(|_| ReadbackError::new("read_failed"))?;
+
+    let loop_status_derived = derive_loop_status(&event_kinds);
+    let turn_count = event_kinds
+        .iter()
+        .filter(|kind| kind.starts_with("plan."))
+        .count();
+    let executed_tool_count = event_kinds
+        .iter()
+        .filter(|kind| kind.starts_with("tool.executed:"))
+        .count();
+
+    // Audit chain verification over the readback DB (a bool, never the rows).
+    let audit_chain_verified = verify_audit_chain(db.conn()).is_ok();
+
+    // DB-wide token totals (NOT run-attributable — see module docs). Ints only.
+    let totals = db_wide_token_totals(db.conn()).map_err(|_| ReadbackError::new("read_failed"))?;
+
+    let payload = json!({
+        "truth_label": "rust_wired_dev",
+        "proof_only": true,
+        "ok": true,
+        "run_id": summary.run_id,
+        "run_state": summary.state,
+        "created_at_ms": summary.created_at,
+        "updated_at_ms": summary.updated_at,
+        "loop_status_derived": loop_status_derived,
+        "turn_count": turn_count,
+        "executed_tool_count": executed_tool_count,
+        "event_count": event_kinds.len(),
+        "event_kinds": event_kinds,
+        "audit_chain_verified": audit_chain_verified,
+        "db_wide_token_prompt_total": totals.prompt,
+        "db_wide_token_completion_total": totals.completion,
+        "db_wide_token_total": totals.total,
+    });
+
+    let rendered =
+        serde_json::to_string(&payload).map_err(|_| ReadbackError::new("serialize_failed"))?;
+    reject_forbidden_output(&rendered)?;
+    Ok(rendered)
+}
+
+fn arg_value(args: &[String], name: &str) -> Option<String> {
+    args.windows(2)
+        .find_map(|pair| (pair[0] == name).then(|| pair[1].clone()))
+        .or_else(|| {
+            let prefix = format!("{name}=");
+            args.iter()
+                .find_map(|arg| arg.strip_prefix(&prefix).map(str::to_string))
+        })
+}
+
+/// Derive a coarse, refs-only loop-status LABEL from the ordered event kinds.
+///
+/// The readback opens the DB read-only and does NOT re-run the loop, so the status
+/// is reconstructed from terminal markers in the event log. Returns ONLY a fixed
+/// `&'static str` from a closed vocabulary — never any slice of an event kind — so
+/// no event-embedded text can leak through this label.
+fn derive_loop_status(kinds: &[String]) -> &'static str {
+    if kinds.iter().any(|kind| kind == "agent.finished") {
+        "finished"
+    } else if kinds.iter().any(|kind| kind.starts_with("agent.error:")) {
+        "errored"
+    } else if kinds.iter().any(|kind| kind == "agent.loop_bounded") {
+        "bounded"
+    } else if kinds.iter().any(|kind| kind.starts_with("tool.paused")) {
+        "paused"
+    } else if kinds.iter().any(|kind| kind.starts_with("tool.blocked")) {
+        "blocked"
+    } else if kinds.is_empty() {
+        "no_events"
+    } else {
+        "in_progress"
+    }
+}
+
+/// Defense-in-depth: refuse to print if any forbidden marker leaked into the
+/// refs-only projection. Mirrors `mission_workbench_projection` / `hub_run_task`.
+/// Note: relative filenames inside a `tool.executed:` kind are NOT forbidden —
+/// only absolute paths (`/Users/`, `/private/`) and secret markers are.
+fn reject_forbidden_output(rendered: &str) -> Result<(), ReadbackError> {
+    for marker in [
+        "Authorization",
+        "Bearer",
+        "sk-",
+        "/Users/",
+        "/private/",
+        "\"task\"", // the run task body must never appear (only run_id/state/labels do)
+    ] {
+        if rendered.contains(marker) {
+            return Err(ReadbackError::new("output_guard"));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{from_str, Value};
+
+    #[test]
+    fn arg_value_supports_space_and_equals_forms() {
+        let args = vec![
+            "bin".to_string(),
+            "--db".to_string(),
+            "/tmp/hub.sqlite".to_string(),
+            "--run-id=run-xyz".to_string(),
+        ];
+        assert_eq!(arg_value(&args, "--db").as_deref(), Some("/tmp/hub.sqlite"));
+        assert_eq!(arg_value(&args, "--run-id").as_deref(), Some("run-xyz"));
+        assert_eq!(arg_value(&args, "--missing"), None);
+    }
+
+    #[test]
+    fn derive_loop_status_maps_terminal_markers_to_bounded_labels() {
+        assert_eq!(
+            derive_loop_status(&["plan.none".into(), "agent.finished".into()]),
+            "finished"
+        );
+        // finished wins even if an error appears earlier (terminal success marker present).
+        assert_eq!(
+            derive_loop_status(&["agent.error:x".into(), "agent.finished".into()]),
+            "finished"
+        );
+        assert_eq!(
+            derive_loop_status(&["plan.none".into(), "agent.error:parse_error".into()]),
+            "errored"
+        );
+        assert_eq!(
+            derive_loop_status(&["plan.none".into(), "agent.loop_bounded".into()]),
+            "bounded"
+        );
+        assert_eq!(
+            derive_loop_status(&["tool.paused:requires_approval:write_file".into()]),
+            "paused"
+        );
+        assert_eq!(
+            derive_loop_status(&["tool.blocked:deny:reason".into()]),
+            "blocked"
+        );
+        assert_eq!(derive_loop_status(&[]), "no_events");
+        assert_eq!(derive_loop_status(&["plan.none".into()]), "in_progress");
+        // The returned label is always from the closed vocabulary (never an event slice).
+        let label = derive_loop_status(&["agent.error:LEAK_CANARY_modeltext".into()]);
+        assert_eq!(label, "errored");
+        assert!(!label.contains("LEAK_CANARY_modeltext"));
+    }
+
+    #[test]
+    fn forbidden_output_guard_blocks_task_body_and_secret_markers() {
+        assert!(reject_forbidden_output(r#"{"task":"raw run body"}"#).is_err());
+        assert!(reject_forbidden_output(r#"{"x":"Bearer abc"}"#).is_err());
+        assert!(reject_forbidden_output(r#"{"k":"/Users/jarvis/secret"}"#).is_err());
+        // A RELATIVE filename inside an event kind is allowed (not over-redacted).
+        assert!(reject_forbidden_output(
+            r#"{"event_kinds":["tool.executed:read 15 bytes from notes.md"],"ok":true}"#
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn refs_only_payload_shape_excludes_task_body() {
+        // Mirror the success payload shape and assert the refs-only contract holds.
+        let payload = json!({
+            "truth_label": "rust_wired_dev",
+            "proof_only": true,
+            "ok": true,
+            "run_id": "run-xyz",
+            "run_state": "awaiting_clarification",
+            "loop_status_derived": "finished",
+            "turn_count": 2,
+            "executed_tool_count": 1,
+            "event_count": 3,
+            "event_kinds": ["plan.none", "tool.executed:read 15 bytes from notes.md", "agent.finished"],
+            "audit_chain_verified": true,
+            "db_wide_token_total": 0,
+        });
+        let rendered = serde_json::to_string(&payload).unwrap();
+        assert!(reject_forbidden_output(&rendered).is_ok());
+        let parsed: Value = from_str(&rendered).unwrap();
+        assert_eq!(parsed["truth_label"], "rust_wired_dev");
+        assert!(
+            parsed.get("task").is_none(),
+            "must never carry the run task body"
+        );
+    }
+}

--- a/rust-core/crates/friday-storage/src/agent_run_read.rs
+++ b/rust-core/crates/friday-storage/src/agent_run_read.rs
@@ -1,0 +1,219 @@
+//! Read-only projection helpers for `agent_run` + `agent_run_event` (S2 readback).
+//!
+//! Additive, READ-ONLY sibling of the write path in [`crate::agent_run`]. These
+//! helpers exist so a refs-only projection (the `hub_run_readback` dev bin) can
+//! read back a completed run's result by `run_id` WITHOUT touching any write
+//! path. Nothing here mutates state; every function only `SELECT`s.
+//!
+//! ## Refs-only / no-body discipline
+//! [`AgentRunSummary`] deliberately OMITS the run `task` text — the run's task is
+//! a body, and the S2 readback is refs-only (it never transports bodies). The
+//! event `kind` strings ARE returned, but a `tool.executed:` kind can embed a
+//! (relative) filename, so the caller MUST run them through an output guard
+//! before emitting them off-process.
+
+use crate::error::Result;
+use rusqlite::{Connection, OptionalExtension};
+
+/// A read-only summary of an `agent_run` row.
+///
+/// Deliberately OMITS the run `task` text (a body) — the S2 readback is refs-only
+/// and never transports bodies. `state` is the persisted `PlanState` string
+/// (a safe label, e.g. `awaiting_clarification`); the timestamps are ints.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AgentRunSummary {
+    pub run_id: String,
+    pub state: String,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+/// DB-wide token totals summed over `token_ledger`.
+///
+/// HONEST SCOPE: these are **DB-wide**, NOT run-attributable. `token_ledger` has
+/// no `run_id` column, and the agent loop does not write `token_ledger` rows
+/// (loop-level token ledgering is a known gap — see `friday_hub::runtime`). For a
+/// run-only Hub DB these are therefore `0`. Surfaced anyway so the readback shape
+/// is stable, but the caller must label them as DB-wide, never as this run's cost.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub struct DbWideTokenTotals {
+    pub prompt: i64,
+    pub completion: i64,
+    pub total: i64,
+}
+
+/// Fetch a run's refs-only summary by id (read-only). `None` if the run is unknown.
+pub fn get_run_summary(conn: &Connection, run_id: &str) -> Result<Option<AgentRunSummary>> {
+    let row = conn
+        .query_row(
+            "SELECT run_id, state, created_at, updated_at FROM agent_run WHERE run_id = ?1",
+            [run_id],
+            |r| {
+                Ok(AgentRunSummary {
+                    run_id: r.get(0)?,
+                    state: r.get(1)?,
+                    created_at: r.get(2)?,
+                    updated_at: r.get(3)?,
+                })
+            },
+        )
+        .optional()?;
+    Ok(row)
+}
+
+/// The ordered (by `seq` ascending) list of an `agent_run`'s event `kind` strings.
+///
+/// These are safe labels (`plan.none`, `agent.finished`, `tool.blocked:...`) BUT a
+/// `tool.executed:` kind can embed a (relative) filename, so the caller MUST run
+/// them through an output guard before emitting them off-process.
+pub fn list_event_kinds(conn: &Connection, run_id: &str) -> Result<Vec<String>> {
+    let mut stmt =
+        conn.prepare("SELECT kind FROM agent_run_event WHERE run_id = ?1 ORDER BY seq ASC")?;
+    let rows = stmt.query_map([run_id], |r| r.get::<_, String>(0))?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row?);
+    }
+    Ok(out)
+}
+
+/// DB-wide token totals over `token_ledger` (see [`DbWideTokenTotals`] for the
+/// honest-scope caveat). `COALESCE(..., 0)` so an empty ledger reads `0`, not NULL.
+pub fn db_wide_token_totals(conn: &Connection) -> Result<DbWideTokenTotals> {
+    let totals = conn.query_row(
+        "SELECT COALESCE(SUM(prompt_tokens), 0),
+                COALESCE(SUM(completion_tokens), 0),
+                COALESCE(SUM(total_tokens), 0)
+         FROM token_ledger",
+        [],
+        |r| {
+            Ok(DbWideTokenTotals {
+                prompt: r.get(0)?,
+                completion: r.get(1)?,
+                total: r.get(2)?,
+            })
+        },
+    )?;
+    Ok(totals)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent_run::{create_run, record_event};
+    use crate::Db;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static C: AtomicU64 = AtomicU64::new(0);
+    fn tmp(tag: &str) -> String {
+        std::env::temp_dir()
+            .join(format!(
+                "friday-agent-run-read-{}-{}-{}.sqlite",
+                std::process::id(),
+                tag,
+                C.fetch_add(1, Ordering::Relaxed)
+            ))
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    #[test]
+    fn get_run_summary_returns_refs_only_row_without_task_body() {
+        let db = Db::open_hub(&tmp("summary")).unwrap();
+        create_run(db.conn(), "run-1", "BODY-the-secret-task-text", 100).unwrap();
+
+        let summary = get_run_summary(db.conn(), "run-1").unwrap().unwrap();
+        assert_eq!(summary.run_id, "run-1");
+        assert_eq!(summary.state, "awaiting_clarification");
+        assert_eq!(summary.created_at, 100);
+        assert_eq!(summary.updated_at, 100);
+        // The struct has no field that could carry the task body — assert the
+        // Debug rendering never echoes it (defense against an accidental future field).
+        assert!(!format!("{summary:?}").contains("BODY-the-secret-task-text"));
+    }
+
+    #[test]
+    fn get_run_summary_is_none_for_unknown_run() {
+        let db = Db::open_hub(&tmp("missing")).unwrap();
+        assert!(get_run_summary(db.conn(), "nope").unwrap().is_none());
+    }
+
+    #[test]
+    fn list_event_kinds_is_ordered_by_seq() {
+        let db = Db::open_hub(&tmp("events")).unwrap();
+        create_run(db.conn(), "run-2", "task", 1).unwrap();
+        record_event(db.conn(), "run-2:e0", "run-2", "plan.none", 2).unwrap();
+        record_event(
+            db.conn(),
+            "run-2:e1",
+            "run-2",
+            "tool.executed:read 15 bytes from notes.md",
+            3,
+        )
+        .unwrap();
+        record_event(db.conn(), "run-2:e2", "run-2", "agent.finished", 4).unwrap();
+
+        let kinds = list_event_kinds(db.conn(), "run-2").unwrap();
+        assert_eq!(
+            kinds,
+            vec![
+                "plan.none".to_string(),
+                "tool.executed:read 15 bytes from notes.md".to_string(),
+                "agent.finished".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn list_event_kinds_is_empty_for_run_with_no_events() {
+        let db = Db::open_hub(&tmp("noevents")).unwrap();
+        create_run(db.conn(), "run-3", "task", 1).unwrap();
+        assert!(list_event_kinds(db.conn(), "run-3").unwrap().is_empty());
+    }
+
+    #[test]
+    fn db_wide_token_totals_is_zero_for_a_run_only_db() {
+        // The agent loop does not ledger tokens, so a run-only DB has 0 totals.
+        let db = Db::open_hub(&tmp("tokens")).unwrap();
+        create_run(db.conn(), "run-4", "task", 1).unwrap();
+        let totals = db_wide_token_totals(db.conn()).unwrap();
+        assert_eq!(totals, DbWideTokenTotals::default());
+        assert_eq!(totals.total, 0);
+    }
+
+    /// Reproducibility probe (mirrors `mission_workbench_projection`'s probe): when
+    /// `FRIDAY_AGENT_RUN_READBACK_PROBE_DB` is set, write an isolated v-current hub
+    /// DB with one `agent_run` (`run_id = readback_probe_run`) + a representative
+    /// ordered event log, so `hub_run_readback --db <path> --run-id readback_probe_run`
+    /// can be run to capture the real refs-only JSON. `#[ignore]`d so it never runs
+    /// in CI; writes ONLY to the operator-supplied path.
+    #[test]
+    #[ignore = "writes an isolated probe DB only when FRIDAY_AGENT_RUN_READBACK_PROBE_DB is set"]
+    fn write_agent_run_readback_probe_db() {
+        let path = std::env::var("FRIDAY_AGENT_RUN_READBACK_PROBE_DB")
+            .expect("FRIDAY_AGENT_RUN_READBACK_PROBE_DB required");
+        let db = Db::open_hub(&path).unwrap();
+        let run_id = "readback_probe_run";
+        create_run(
+            db.conn(),
+            run_id,
+            "read the file notes.md and summarize it",
+            1000,
+        )
+        .unwrap();
+        // A representative read-only run: plan -> tool.executed (embeds a RELATIVE
+        // filename, which the readback guard accepts) -> finish.
+        for (slot, kind, ts) in [
+            ("t0:plan", "plan.none", 1001),
+            (
+                "t0:outcome",
+                "tool.executed:read 15 bytes from notes.md",
+                1002,
+            ),
+            ("t1:plan", "plan.none", 1003),
+            ("t1:finish", "agent.finished", 1004),
+        ] {
+            record_event(db.conn(), &format!("{run_id}:{slot}"), run_id, kind, ts).unwrap();
+        }
+    }
+}

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -10,6 +10,7 @@
 //! repositories for every domain are deferred to their owning units (gate 21 §9).
 
 pub mod agent_run;
+pub mod agent_run_read;
 pub mod audit;
 pub mod authorize;
 pub mod blob;

--- a/src/api/mission-spine/friday-rust-hub-run-readback-service.ts
+++ b/src/api/mission-spine/friday-rust-hub-run-readback-service.ts
@@ -1,0 +1,244 @@
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { FridayDomainError } from "#errors";
+
+/**
+ * PROOF-ONLY (Rust-wired-DEV) TS->Rust READ bridge for the S2 `hub_run_readback`
+ * read-bridge. The read-only sibling of the S0 `hub_run_task` write bridge: it lets
+ * the TS side SEE a completed Rust run's result by `run_id`, refs-only.
+ *
+ * It clones the READ-ONLY execFile shape from
+ * `friday-rust-hub-workbench-projection-service` / `friday-rust-hub-run-task-bridge-service`
+ * to prove a Rust run's outcome can be projected to TS WITHOUT ever transporting a
+ * body/secret/PII. It is NOT a replacement for any TS run-result read path, registers
+ * NO production route, and confers no v1 GO.
+ *
+ * Every value it returns is REFS-ONLY: the run id + a `state` label (NEVER the run
+ * `task` text), timestamps, a derived loop-status label, turn/tool counts, the ordered
+ * list of event `kind` strings, and the audit-chain-verified bool. The bridge fails
+ * CLOSED (503) on any non-zero exit, timeout, parse failure, invalid shape, or any
+ * payload that carries a raw run/message body (the boundary this slice exists to prove).
+ *
+ * Token totals are surfaced as `dbWideToken*` and are DB-WIDE, NOT run-attributable
+ * (the agent loop does not ledger tokens, and `token_ledger` has no `run_id`).
+ */
+const execFileAsync = promisify(execFile);
+
+/** Refs-only readback receipt — no run/message body, no secrets, no PII. */
+export interface FridayRustHubRunReadbackReceipt {
+  /** Always the dev tier — this is NOT a product/proven receipt. */
+  readonly truthLabel: "rust_wired_dev";
+  /** Always true — a loud reminder this is a dev bridge, not a product path. */
+  readonly proofOnly: true;
+  readonly runId: string;
+  /** The persisted PlanState label (e.g. `awaiting_clarification`) — NOT the task text. */
+  readonly runState: string;
+  readonly createdAtMs?: number;
+  readonly updatedAtMs?: number;
+  /**
+   * Coarse loop-status label DERIVED from the event log by the Rust bin (one of
+   * `finished` | `errored` | `bounded` | `paused` | `blocked` | `no_events` |
+   * `in_progress`). Reconstructed from terminal markers; never a raw event slice.
+   */
+  readonly loopStatusDerived?: string;
+  readonly turnCount: number;
+  readonly executedToolCount: number;
+  readonly eventCount: number;
+  /**
+   * The ORDERED list of event `kind` strings (`plan.none`, `agent.finished`, ...).
+   * These are safe labels; a `tool.executed:` kind may embed a RELATIVE filename
+   * (accepted). The Rust bin already fails closed on any absolute-path/secret marker
+   * before emitting, and this service re-checks the no-body boundary defensively.
+   */
+  readonly eventKinds: readonly string[];
+  readonly auditChainVerified: boolean;
+  /** DB-wide token totals (NOT run-attributable — see the file header). */
+  readonly dbWideTokenPromptTotal: number;
+  readonly dbWideTokenCompletionTotal: number;
+  readonly dbWideTokenTotal: number;
+}
+
+export interface FridayRustHubRunReadbackInput {
+  /** Hub DB path to read the run back from (must exist; opened read-only by the bin). */
+  readonly dbPath: string;
+  /** The run id to read back. */
+  readonly runId: string;
+}
+
+export interface CreateFridayRustHubRunReadbackServiceOptions {
+  readonly repoRoot?: string;
+  /** Path to a prebuilt `hub_run_readback` binary; falls back to `cargo run --bin` when absent. */
+  readonly adapterBin?: string;
+  readonly timeoutMs?: number;
+}
+
+export interface FridayRustHubRunReadbackService {
+  readRun(input: FridayRustHubRunReadbackInput): Promise<FridayRustHubRunReadbackReceipt>;
+}
+
+function unavailable(message: string): FridayDomainError {
+  return new FridayDomainError("MISSION_SPINE_RUST_RUN_READBACK_UNAVAILABLE", message, {
+    httpStatus: 503,
+    details: {
+      surface: "service:rust_hub_run_readback",
+      bridge: "rust_wired_dev",
+      proofOnly: true,
+      proofReady: false,
+    },
+  });
+}
+
+function readTimeoutMs(raw: string | undefined, fallback: number): number {
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function resolveDefaultRepoRoot(): string {
+  const moduleDir = dirname(fileURLToPath(import.meta.url));
+  return resolve(moduleDir, "../../..");
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function asIntOrZero(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+/**
+ * Validate + normalize the Rust bin's refs-only stdout into a receipt. Fails closed on
+ * any shape violation AND on any attempt to carry a raw run/message body (the boundary
+ * this slice exists to prove).
+ */
+function parseReceipt(payload: unknown): FridayRustHubRunReadbackReceipt {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw unavailable("Rust hub_run_readback bridge returned a non-object payload.");
+  }
+  const root = payload as Record<string, unknown>;
+
+  // Hard boundary: a run/message body must NEVER cross the bridge — only labels/refs may.
+  if ("task" in root || "final_message" in root || "finalMessage" in root) {
+    throw unavailable("Rust hub_run_readback bridge payload carried a raw body (rejected).");
+  }
+  if (root.truth_label !== "rust_wired_dev") {
+    throw unavailable("Rust hub_run_readback bridge payload is not labeled rust_wired_dev.");
+  }
+  if (root.ok === false) {
+    throw unavailable("Rust hub_run_readback bridge reported a fail-closed readback.");
+  }
+
+  const runId = asString(root.run_id);
+  const runState = asString(root.run_state);
+  const auditChainVerified = root.audit_chain_verified;
+  const eventKindsRaw = root.event_kinds;
+
+  if (!runId || !runState) {
+    throw unavailable("Rust hub_run_readback bridge payload is missing required refs.");
+  }
+  if (typeof auditChainVerified !== "boolean") {
+    throw unavailable("Rust hub_run_readback bridge payload is missing audit_chain_verified.");
+  }
+  if (!Array.isArray(eventKindsRaw) || !eventKindsRaw.every((kind) => typeof kind === "string")) {
+    throw unavailable("Rust hub_run_readback bridge payload has an invalid event_kinds list.");
+  }
+  const eventKinds = eventKindsRaw as string[];
+
+  return {
+    truthLabel: "rust_wired_dev",
+    proofOnly: true,
+    runId,
+    runState,
+    createdAtMs: asNumber(root.created_at_ms),
+    updatedAtMs: asNumber(root.updated_at_ms),
+    loopStatusDerived: asString(root.loop_status_derived),
+    turnCount: asIntOrZero(root.turn_count),
+    executedToolCount: asIntOrZero(root.executed_tool_count),
+    eventCount: asIntOrZero(root.event_count),
+    eventKinds,
+    auditChainVerified,
+    dbWideTokenPromptTotal: asIntOrZero(root.db_wide_token_prompt_total),
+    dbWideTokenCompletionTotal: asIntOrZero(root.db_wide_token_completion_total),
+    dbWideTokenTotal: asIntOrZero(root.db_wide_token_total),
+  };
+}
+
+export function createFridayRustHubRunReadbackService(
+  options: CreateFridayRustHubRunReadbackServiceOptions = {},
+): FridayRustHubRunReadbackService {
+  const repoRoot = resolve(
+    options.repoRoot ?? process.env.FRIDAY_REPO_ROOT ?? resolveDefaultRepoRoot(),
+  );
+  const rustCoreRoot = resolve(
+    process.env.FRIDAY_MISSION_SPINE_RUST_CORE_ROOT ?? join(repoRoot, "rust-core"),
+  );
+  const adapterBin = options.adapterBin ?? process.env.FRIDAY_HUB_RUN_READBACK_BIN;
+  const timeoutMs =
+    options.timeoutMs ?? readTimeoutMs(process.env.FRIDAY_HUB_RUN_READBACK_TIMEOUT_MS, 120_000);
+
+  return {
+    async readRun(
+      input: FridayRustHubRunReadbackInput,
+    ): Promise<FridayRustHubRunReadbackReceipt> {
+      const dbPath = resolve(input.dbPath);
+      if (!existsSync(dbPath)) {
+        throw unavailable("Rust hub_run_readback DB is not present for this runtime.");
+      }
+      if (!input.runId) {
+        throw unavailable("Rust hub_run_readback requires a run id.");
+      }
+
+      const adapterArgs = ["--db", dbPath, "--run-id", input.runId];
+
+      const command = adapterBin ?? "cargo";
+      const args = adapterBin
+        ? adapterArgs
+        : [
+            "run",
+            "--quiet",
+            "--manifest-path",
+            join(rustCoreRoot, "Cargo.toml"),
+            "-p",
+            "friday-hub",
+            "--bin",
+            "hub_run_readback",
+            "--",
+            ...adapterArgs,
+          ];
+
+      let stdout = "";
+      try {
+        const result = await execFileAsync(command, args, {
+          cwd: repoRoot,
+          timeout: timeoutMs,
+          maxBuffer: 2 * 1024 * 1024,
+          env: {
+            ...process.env,
+            RUST_BACKTRACE: "0",
+          },
+        });
+        stdout = result.stdout;
+      } catch {
+        // Non-zero exit, timeout, or spawn failure → fail closed (no detail surfaced).
+        throw unavailable("Rust hub_run_readback bridge could not produce a refs-only readback.");
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(stdout);
+      } catch {
+        throw unavailable("Rust hub_run_readback bridge returned invalid JSON.");
+      }
+      return parseReceipt(parsed);
+    },
+  };
+}

--- a/test/unit/api/mission-spine/friday-rust-hub-run-readback-service.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-run-readback-service.test.ts
@@ -1,0 +1,166 @@
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createFridayRustHubRunReadbackService } from "../../../../src/api/mission-spine/friday-rust-hub-run-readback-service.js";
+
+/**
+ * PROOF-ONLY (Rust-wired-DEV) readback bridge test. Spawns a SCRIPTED MOCK bin (no real
+ * DB, no DeepSeek call, no quota, no secret) so it runs in CI hermetically, mirroring the
+ * proven chmod-0o755 shebang-mock idiom from the S0 run-task bridge test. Covers: happy
+ * path, non-zero exit, malformed JSON, timeout, and a raw-body-leak rejection.
+ *
+ * The mock bin is supplied as `adapterBin`, AND a real (empty) file is created at `dbPath`
+ * so the service's `existsSync(dbPath)` precondition passes before the mock is spawned.
+ */
+describe("friday-rust-hub-run-readback-service (S2 dev read-bridge)", () => {
+  let scratch: string | undefined;
+
+  afterEach(() => {
+    if (scratch) {
+      rmSync(scratch, { recursive: true, force: true });
+      scratch = undefined;
+    }
+  });
+
+  function setup(mockSource: string): { binPath: string; dbPath: string } {
+    scratch = mkdtempSync(join(tmpdir(), "friday-hub-run-readback-"));
+    const binPath = join(scratch, "hub_run_readback_mock.mjs");
+    writeFileSync(binPath, `#!/usr/bin/env node\n${mockSource}`);
+    chmodSync(binPath, 0o755);
+    // A present (content-irrelevant) DB file so the existsSync precondition passes; the
+    // mock bin never opens it.
+    const dbPath = join(scratch, "rust-hub.sqlite");
+    writeFileSync(dbPath, "mock");
+    return { binPath, dbPath };
+  }
+
+  it("parses a valid refs-only readback on the happy path", async () => {
+    const { binPath, dbPath } = setup(`
+      process.stdout.write(JSON.stringify({
+        truth_label: "rust_wired_dev",
+        proof_only: true,
+        ok: true,
+        run_id: "readback_probe_run",
+        run_state: "awaiting_clarification",
+        created_at_ms: 1000,
+        updated_at_ms: 1004,
+        loop_status_derived: "finished",
+        turn_count: 2,
+        executed_tool_count: 1,
+        event_count: 4,
+        event_kinds: [
+          "plan.none",
+          "tool.executed:read 15 bytes from notes.md",
+          "plan.none",
+          "agent.finished",
+        ],
+        audit_chain_verified: true,
+        db_wide_token_prompt_total: 0,
+        db_wide_token_completion_total: 0,
+        db_wide_token_total: 0,
+      }));
+    `);
+    const service = createFridayRustHubRunReadbackService({ adapterBin: binPath });
+
+    const receipt = await service.readRun({ dbPath, runId: "readback_probe_run" });
+
+    expect(receipt).toMatchObject({
+      truthLabel: "rust_wired_dev",
+      proofOnly: true,
+      runId: "readback_probe_run",
+      runState: "awaiting_clarification",
+      loopStatusDerived: "finished",
+      turnCount: 2,
+      executedToolCount: 1,
+      eventCount: 4,
+      auditChainVerified: true,
+      dbWideTokenTotal: 0,
+    });
+    // The ordered event-kind list is preserved verbatim (a relative filename is allowed).
+    expect(receipt.eventKinds).toEqual([
+      "plan.none",
+      "tool.executed:read 15 bytes from notes.md",
+      "plan.none",
+      "agent.finished",
+    ]);
+    // The run task body must never appear on the receipt.
+    expect((receipt as Record<string, unknown>).task).toBeUndefined();
+  });
+
+  it("fails closed (503) on a non-zero exit", async () => {
+    const { binPath, dbPath } = setup(`
+      process.stderr.write("hub_run_readback_unavailable: run_not_found");
+      process.exit(2);
+    `);
+    const service = createFridayRustHubRunReadbackService({ adapterBin: binPath });
+
+    await expect(service.readRun({ dbPath, runId: "nope" })).rejects.toMatchObject({
+      code: "MISSION_SPINE_RUST_RUN_READBACK_UNAVAILABLE",
+      httpStatus: 503,
+    });
+  });
+
+  it("fails closed on malformed JSON", async () => {
+    const { binPath, dbPath } = setup(`process.stdout.write("not json {");`);
+    const service = createFridayRustHubRunReadbackService({ adapterBin: binPath });
+
+    await expect(service.readRun({ dbPath, runId: "r" })).rejects.toMatchObject({
+      code: "MISSION_SPINE_RUST_RUN_READBACK_UNAVAILABLE",
+      httpStatus: 503,
+    });
+  });
+
+  it("fails closed on timeout", async () => {
+    const { binPath, dbPath } = setup(`setTimeout(() => process.stdout.write("late"), 5000);`);
+    const service = createFridayRustHubRunReadbackService({ adapterBin: binPath, timeoutMs: 200 });
+
+    await expect(service.readRun({ dbPath, runId: "r" })).rejects.toMatchObject({
+      code: "MISSION_SPINE_RUST_RUN_READBACK_UNAVAILABLE",
+      httpStatus: 503,
+    });
+  });
+
+  it("rejects a payload that carries a raw run body (no-body boundary)", async () => {
+    const { binPath, dbPath } = setup(`
+      process.stdout.write(JSON.stringify({
+        truth_label: "rust_wired_dev",
+        ok: true,
+        run_id: "leak",
+        run_state: "awaiting_clarification",
+        task: "the raw run task body that must never cross the bridge",
+        turn_count: 0,
+        executed_tool_count: 0,
+        event_count: 0,
+        event_kinds: [],
+        audit_chain_verified: true,
+      }));
+    `);
+    const service = createFridayRustHubRunReadbackService({ adapterBin: binPath });
+
+    await expect(service.readRun({ dbPath, runId: "leak" })).rejects.toMatchObject({
+      code: "MISSION_SPINE_RUST_RUN_READBACK_UNAVAILABLE",
+      httpStatus: 503,
+    });
+  });
+
+  it("fails closed on an invalid event_kinds shape", async () => {
+    const { binPath, dbPath } = setup(`
+      process.stdout.write(JSON.stringify({
+        truth_label: "rust_wired_dev",
+        ok: true,
+        run_id: "bad",
+        run_state: "awaiting_clarification",
+        event_kinds: [1, 2, 3],
+        audit_chain_verified: true,
+      }));
+    `);
+    const service = createFridayRustHubRunReadbackService({ adapterBin: binPath });
+
+    await expect(service.readRun({ dbPath, runId: "bad" })).rejects.toMatchObject({
+      code: "MISSION_SPINE_RUST_RUN_READBACK_UNAVAILABLE",
+      httpStatus: 503,
+    });
+  });
+});


### PR DESCRIPTION
## Truth label
**PROOF-ONLY (Rust-wired-DEV): TS can read back a Rust run's result by `run_id`, refs-only.** This is the READ sibling of S0's `hub_run_task` write-bridge and mirrors the existing read-only precedent `mission_workbench_projection`. It is **NOT** `executeRun`-replaced, registers **NO** production HTTP route, uses **NO** live credentials, and confers **NO** v1 GO.

## What this slice does
Adds a read-only projection so the TS side can see a completed Rust run's outcome (the run was written to the hub SQLite by `HubRuntime::run_task` via S0). Everything crosses the boundary refs-only — never a body, secret, or PII.

## Deliverables
1. **NEW Rust bin** `rust-core/crates/friday-hub/src/bin/hub_run_readback.rs` — opens the hub DB **read-only** (`Db::open_hub_readonly`), takes `--db <path> --run-id <id>`, reads the `agent_run` row + ordered `agent_run_event` rows (by `seq`), derives a loop-status label from the event log, verifies the audit chain (`friday_storage::audit::verify_audit_chain`), and emits refs-only JSON. Fails closed (non-zero exit + refs-only error JSON) on bad args / missing DB / unknown run / output-guard trip, exactly like S0.
2. **NEW additive friday-storage read helper** `rust-core/crates/friday-storage/src/agent_run_read.rs` (+ one `pub mod` line in `lib.rs`): `get_run_summary` (omits the run `task` body), `list_event_kinds` (seq-ordered), `db_wide_token_totals`. Read-only `SELECT`s only — no write path touched.
3. **NEW TS service** `src/api/mission-spine/friday-rust-hub-run-readback-service.ts` — clones the read-only execFile bridge shape from the workbench/run-task services; refs-only receipt; **fail-closed 503** on non-zero exit / timeout / parse failure / invalid shape; rejects any payload carrying a raw body.
4. **NEW TS test** `test/unit/api/mission-spine/friday-rust-hub-run-readback-service.test.ts` — scripted MOCK bin (chmod 0o755 shebang idiom): happy path, non-zero exit → 503, malformed JSON → 503, timeout → 503, raw-body-leak → rejected, invalid `event_kinds` → 503. No live call, no secret.
5. **CI** — one additive build line for the new bin in `.github/workflows/rust-core.yml`.

## Refs-only contract + redaction guard
Emitted JSON fields (refs-only): `truth_label:"rust_wired_dev"`, `proof_only`, `ok`, `run_id`, `run_state` (the `PlanState` label — **not** the run `task` text), `created_at_ms`, `updated_at_ms`, `loop_status_derived`, `turn_count`, `executed_tool_count`, `event_count`, `event_kinds` (the ordered list), `audit_chain_verified`, and `db_wide_token_{prompt,completion,}_total`.

- **Event-kind sensitivity:** kinds are safe labels (`plan.none`, `agent.finished`, `tool.blocked:...`) but a `tool.executed:` kind can embed a **relative** filename (e.g. `tool.executed:read 15 bytes from notes.md`). Relative names are accepted; `reject_forbidden_output` fails the whole projection closed if any forbidden marker ever appears — `Authorization` / `Bearer` / `sk-` / absolute `/Users/` / `/private/` paths / the `task` body field. The run task body is never emitted.
- **Token totals** are named `db_wide_*` because they are **DB-wide, NOT run-attributable** (`token_ledger` has no `run_id`, and the agent loop does not ledger tokens), so for a run DB they are `0`. `route_decision` is intentionally **omitted** — it is mission/work-item-keyed, never written by a run.

Real captured output (probe DB):
```json
{"audit_chain_verified":true,"created_at_ms":1000,"db_wide_token_completion_total":0,"db_wide_token_prompt_total":0,"db_wide_token_total":0,"event_count":4,"event_kinds":["plan.none","tool.executed:read 15 bytes from notes.md","plan.none","agent.finished"],"executed_tool_count":1,"loop_status_derived":"finished","ok":true,"proof_only":true,"run_id":"readback_probe_run","run_state":"awaiting_clarification","truth_label":"rust_wired_dev","turn_count":2,"updated_at_ms":1000}
```
(`audit_chain_verified:true` here reflects a trivially-valid empty chain in the probe — the probe wrote agent_run/events but no audit rows.)

## What I did NOT touch
Per the parallel-lane write-set discipline, this PR does **not** edit `rust-core/crates/friday-hub/src/lib.rs`, `rust-core/crates/friday-hub/src/runtime.rs`, or `rust-core/crates/friday-deepseek/src/lib.rs` (another lane owns those). No production route, no closure-semantics / mechanism_matrix change, no new model calls, no live creds. Cargo.lock unchanged (no new deps).

## Local gates (all green)
`cargo fmt --check` · `cargo clippy --workspace --all-targets -D warnings` · `cargo build -p friday-hub --bin hub_run_readback` · `cargo test --workspace` · `npm run lint` (0 errors) · `npm run typecheck` (0 errors) · focused vitest (6/6) · `detect-secrets-hook` clean · `check-provider-key-patterns.mjs` clean · `ts-runtime-retirement` blocker==0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)