### PR TITLE
feat(rust-fs): S3 safe-fs primitives (list/stat/append/delete/move/edit) in friday-fs — NOT wired (proof-only)

### DIFF
--- a/rust-core/crates/friday-fs/src/lib.rs
+++ b/rust-core/crates/friday-fs/src/lib.rs
@@ -93,6 +93,7 @@
 //!   STRICTER than the oracle (which only rejects directories) — a safe hardening
 //!   for the tool surface.
 
+use std::ffi::OsString;
 use std::fs::{File, OpenOptions};
 use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
 use std::path::{Path, PathBuf};
@@ -144,9 +145,51 @@ pub enum FsError {
     #[error("root path is not valid UTF-8")]
     NonUtf8Root,
 
+    /// The resolved path is not a directory where one was required (e.g. `list_dir`
+    /// on a regular file → `open(O_DIRECTORY)` returns `ENOTDIR`). Distinct from
+    /// [`FsError::IsDirectory`], which rejects a directory where a *file* was wanted.
+    #[error("path is not a directory")]
+    NotADirectory,
+
+    /// `edit_file` could not apply its replacement: the `old_text` to replace was not
+    /// found in the file (or was empty). The file is left **byte-for-byte unchanged** —
+    /// no write is performed. (Mirrors a no-op `String::replace` on the oracle's `edit`.)
+    #[error("edit target text not found in file")]
+    EditNoMatch,
+
     /// An underlying I/O error not classified above.
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
+}
+
+/// The kind of a [`stat_file_within_root`] target, after the no-follow `lstat`. A
+/// final-component **symlink** is never reported (it is rejected as [`FsError::Symlink`]);
+/// anything that is neither a regular file nor a directory (FIFO/socket/device) is
+/// [`FileKind::Other`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FileKind {
+    /// A regular file.
+    File,
+    /// A directory.
+    Dir,
+    /// A non-regular, non-directory inode (FIFO, socket, device node, …).
+    Other,
+}
+
+/// Metadata for a contained path returned by [`stat_file_within_root`]. `mode` is the
+/// low 9 permission bits (`& 0o777`); `len` is the inode size (bytes for a file; the
+/// directory's own size for a directory). Reported from the single no-follow `lstat`,
+/// so it describes exactly the inode named (no symlink follow, no re-resolution).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FileStat {
+    /// File / directory / other.
+    pub kind: FileKind,
+    /// Inode size in bytes.
+    pub len: u64,
+    /// Low 9 permission bits (`mode & 0o777`).
+    pub mode: u32,
+    /// Whether the inode is not writable by anyone (std `Permissions::readonly`).
+    pub readonly: bool,
 }
 
 /// Open a contained file for **reading**, with the full hardening pipeline.
@@ -325,6 +368,289 @@ pub fn write_file_within_root(
             Err(FsError::from(e))
         }
     }
+}
+
+/// List the entries of a contained directory, **TOCTOU-free**.
+///
+/// Containment mirrors the read path's *final-component-swap* defense (not merely the
+/// lexical gate): the directory is opened `O_NOFOLLOW | O_NONBLOCK` so a final-component
+/// **symlink** is rejected (`ELOOP` → [`FsError::Symlink`]) exactly as for [`open_read_within_root`];
+/// the realpath-ancestor parent check has already run ([`resolve_within_root`]); a post-open
+/// `fstat` then requires the fd to be a **directory** ([`FsError::NotADirectory`] otherwise —
+/// `open(O_NOFOLLOW)` succeeds on a regular file / FIFO too, so this mirrors the read path's
+/// post-open directory check); and the listing is finally read from the **validated open fd**
+/// via `fdopendir`/`readdir` — never by re-resolving the path string. So the entries returned
+/// are exactly those of the inode we validated: a name swapped *after* the open cannot redirect
+/// the listing — the parity guarantee a plain `std::fs::read_dir(path)` (which re-resolves the
+/// name) would NOT give.
+///
+/// (`O_DIRECTORY` is deliberately NOT used: combined with `O_NOFOLLOW` on a symlink-to-a-dir
+/// some platforms return `ENOTDIR` instead of `ELOOP`, which would misclassify a rejected
+/// final-component symlink. The post-open `fstat` gives a platform-stable `NotADirectory`.)
+///
+/// Returns each entry name (excluding `.` and `..`), **sorted** for deterministic output.
+///
+/// # Residual (same posture as the read/write paths)
+/// The ancestor-directory TOCTOU window documented on [`open_read_within_root`] (an
+/// *ancestor* swapped for an outside-pointing symlink in the check→open window) is not
+/// closed here; the **final** component IS fully closed by `O_NOFOLLOW` + the held fd.
+/// Naming the root itself (`""`/`"."`) is a lexical rejection (parity with read/write):
+/// this API lists a *sub-path* of the trusted root, not the root.
+pub fn list_dir_within_root(root: &Path, candidate: &str) -> Result<Vec<OsString>, FsError> {
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::io::IntoRawFd;
+
+    let resolved = resolve_within_root(root, candidate, /* parent_must_exist */ true)?;
+
+    // O_NOFOLLOW rejects a final-component symlink (ELOOP → Symlink, via classify_open_err);
+    // O_NONBLOCK so the open never blocks; read(true) to read the directory's entries. We do
+    // NOT pass O_DIRECTORY (see the doc comment) — the post-open fstat enforces "is a dir".
+    let dir = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
+        .open(&resolved.full)
+        .map_err(classify_open_err)?;
+
+    // Post-open fstat: open(O_NOFOLLOW) succeeds on a regular file / FIFO as well, so require
+    // the validated fd to actually be a directory (platform-stable, mirrors the read path).
+    if !dir.metadata()?.is_dir() {
+        return Err(FsError::NotADirectory);
+    }
+
+    // Hand the validated fd to fdopendir, which takes ownership of it; `closedir` (below)
+    // closes that fd. We `into_raw_fd` so the `File`'s own Drop will NOT also close it.
+    let fd = dir.into_raw_fd();
+    // SAFETY: `fd` is a freshly-opened, owned directory fd. On success fdopendir adopts it.
+    let dirp = unsafe { libc::fdopendir(fd) };
+    if dirp.is_null() {
+        let e = std::io::Error::last_os_error();
+        // fdopendir did NOT adopt the fd on failure → we must close it ourselves.
+        // SAFETY: `fd` is still our owned, open fd (fdopendir failed).
+        unsafe {
+            libc::close(fd);
+        }
+        return Err(FsError::from(e));
+    }
+
+    let mut entries: Vec<OsString> = Vec::new();
+    // Read entries directly from the validated fd — no path re-resolution, so the
+    // directory's identity cannot be swapped out from under us. A null return ends the
+    // stream (errors during iteration are rare and also surface as a null terminator).
+    loop {
+        // SAFETY: `dirp` is the live DIR* from the successful fdopendir above.
+        let ent = unsafe { libc::readdir(dirp) };
+        if ent.is_null() {
+            break;
+        }
+        // SAFETY: `ent` is a valid `*mut dirent` until the next readdir/closedir; its
+        // `d_name` is a NUL-terminated C string embedded in that record.
+        let name = unsafe { std::ffi::CStr::from_ptr((*ent).d_name.as_ptr()) };
+        let bytes = name.to_bytes();
+        if bytes == b"." || bytes == b".." {
+            continue;
+        }
+        entries.push(std::ffi::OsStr::from_bytes(bytes).to_os_string());
+    }
+    // closedir closes the underlying fd we adopted via into_raw_fd → exactly one close,
+    // no leak and no double-close.
+    // SAFETY: `dirp` is the live DIR* and is not used after this call.
+    unsafe {
+        libc::closedir(dirp);
+    }
+
+    entries.sort();
+    Ok(entries)
+}
+
+/// Metadata of a contained path (file OR directory), via a no-follow `lstat`.
+///
+/// The final component is `lstat`'d (no symlink follow): a final-component **symlink** is
+/// rejected ([`FsError::Symlink`]) exactly as the read path's `O_NOFOLLOW` would — so this
+/// never reports *through* a symlink and never escapes the root via one — and the parent is
+/// realpath-ancestor-contained (shared [`resolve_within_root`]). Because the result IS the
+/// single `lstat` we performed (not a re-resolution), there is no final-component TOCTOU:
+/// the returned [`FileStat`] describes exactly the inode named. Unlike the read path this
+/// does NOT open the file, so it can stat any kind (including FIFO/socket/device, reported
+/// as [`FileKind::Other`]) without the open-side regular-file restriction.
+pub fn stat_file_within_root(root: &Path, candidate: &str) -> Result<FileStat, FsError> {
+    let resolved = resolve_within_root(root, candidate, /* parent_must_exist */ true)?;
+    let meta = std::fs::symlink_metadata(&resolved.full).map_err(classify_open_err)?;
+    let ft = meta.file_type();
+    if ft.is_symlink() {
+        return Err(FsError::Symlink);
+    }
+    let kind = if ft.is_dir() {
+        FileKind::Dir
+    } else if ft.is_file() {
+        FileKind::File
+    } else {
+        FileKind::Other
+    };
+    Ok(FileStat {
+        kind,
+        len: meta.len(),
+        mode: meta.mode() & 0o777,
+        readonly: meta.permissions().readonly(),
+    })
+}
+
+/// Append `contents` to a contained file (creating it `0o600` if absent), with the full
+/// read/write open hardening. Mirrors [`open_write_within_root`] but opens `O_APPEND` (every
+/// write lands at the current end-of-file) and does NOT truncate.
+///
+/// # Atomicity (truth-labeled)
+/// This is a **positional append, not an atomic replace** — the slice's "atomic temp+rename
+/// where applicable" deliberately does NOT apply to append. A mid-append I/O failure can
+/// leave a partial *tail* of `contents` appended, but can never corrupt or truncate the
+/// file's pre-existing bytes (`O_APPEND` only ever extends). We intentionally do NOT
+/// implement append as read+concat+temp-rename "atomic append": that would silently
+/// normalize the file mode to `0o600` and break hardlinks on **every** append — a surprising
+/// side effect for a primitive named "append" (and a whole-file rewrite per call).
+///
+/// Safety is identical to the write path: `O_NOFOLLOW` refuses a final-component symlink
+/// (`ELOOP`), `O_NONBLOCK` avoids a FIFO hang, and [`verify_fd_identity`] rejects a
+/// directory / non-regular fd / TOCTOU swap **before** any bytes are appended.
+pub fn append_file_within_root(
+    root: &Path,
+    candidate: &str,
+    contents: &[u8],
+) -> Result<(), FsError> {
+    use std::io::Write;
+    let resolved = resolve_within_root(root, candidate, /* parent_must_exist */ true)?;
+    let mut file = OpenOptions::new()
+        .append(true) // O_APPEND (implies write); positional append, no truncate
+        .create(true) // create-if-absent
+        .mode(0o600) // owner-only on create (applied only with O_CREAT)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
+        .open(&resolved.full)
+        .map_err(classify_open_err)?;
+    // Reject a directory / non-regular fd / TOCTOU swap BEFORE appending any bytes.
+    verify_fd_identity(&file, &resolved.full)?;
+    file.write_all(contents)?;
+    Ok(())
+}
+
+/// Delete a contained **regular file** (`unlink`), without following a final-component
+/// symlink.
+///
+/// Pipeline: lexical gate + canonicalized-root + realpath-ancestor parent check (shared
+/// [`resolve_within_root`]), then a no-follow `lstat` don't-clobber policy mirroring the
+/// write path — a **symlink** target is refused ([`FsError::Symlink`]) (we never remove a
+/// link the model named as a "file"), a **directory** is refused ([`FsError::IsDirectory`])
+/// (this is a file primitive; there is no `rmdir` here), and any non-regular inode is refused
+/// ([`FsError::NotRegularFile`]). A missing target is [`FsError::NotFound`].
+///
+/// The `lstat`→`unlink` TOCTOU is harmless: `unlink(2)` never follows a symlink, so even a
+/// final-component swap to an outside-pointing symlink in the window would remove only the
+/// *link*, never the outside target — there is no escape, only the don't-clobber policy.
+pub fn delete_file_within_root(root: &Path, candidate: &str) -> Result<(), FsError> {
+    let resolved = resolve_within_root(root, candidate, /* parent_must_exist */ true)?;
+    let meta = std::fs::symlink_metadata(&resolved.full).map_err(classify_open_err)?;
+    let ft = meta.file_type();
+    if ft.is_symlink() {
+        return Err(FsError::Symlink);
+    }
+    if ft.is_dir() {
+        return Err(FsError::IsDirectory);
+    }
+    if !ft.is_file() {
+        return Err(FsError::NotRegularFile);
+    }
+    std::fs::remove_file(&resolved.full)?;
+    Ok(())
+}
+
+/// Move/rename a contained **regular file** to another contained path via `rename(2)`
+/// (atomic within a filesystem). BOTH endpoints are independently hardened.
+///
+/// - **Source**: shared [`resolve_within_root`] + a no-follow `lstat` requiring a regular
+///   file — a symlink source is refused ([`FsError::Symlink`]), a directory
+///   ([`FsError::IsDirectory`]), any non-regular inode ([`FsError::NotRegularFile`]), and a
+///   missing source ([`FsError::NotFound`]).
+/// - **Destination**: shared [`resolve_within_root`] (so its parent is realpath-ancestor-
+///   contained) + a no-follow `lstat` don't-clobber — an existing **symlink** or
+///   **directory** at the destination is refused (we never replace a link/dir); an existing
+///   regular file IS replaced (the atomic same-name replace `rename` provides).
+///
+/// `rename(2)` follows no symlinks on either end (it operates on the names), is atomic, and
+/// both parents are realpath-contained, so neither endpoint can escape the root. Residual: a
+/// parent-*directory* swap between the realpath check and the rename is the same path-based
+/// TOCTOU tracked for [`open_write_within_root`] (hardening = `renameat`/dir-fd-relative ops).
+pub fn move_file_within_root(root: &Path, src: &str, dst: &str) -> Result<(), FsError> {
+    let src_res = resolve_within_root(root, src, /* parent_must_exist */ true)?;
+    let dst_res = resolve_within_root(root, dst, /* parent_must_exist */ true)?;
+
+    // Source must be an existing regular file (no symlink / dir / special).
+    let src_meta = std::fs::symlink_metadata(&src_res.full).map_err(classify_open_err)?;
+    let sft = src_meta.file_type();
+    if sft.is_symlink() {
+        return Err(FsError::Symlink);
+    }
+    if sft.is_dir() {
+        return Err(FsError::IsDirectory);
+    }
+    if !sft.is_file() {
+        return Err(FsError::NotRegularFile);
+    }
+
+    // Don't-clobber a non-regular destination (symlink / dir); a regular file is replaced.
+    match std::fs::symlink_metadata(&dst_res.full) {
+        Ok(dmeta) => {
+            let dft = dmeta.file_type();
+            if dft.is_symlink() {
+                return Err(FsError::Symlink);
+            }
+            if dft.is_dir() {
+                return Err(FsError::IsDirectory);
+            }
+            if !dft.is_file() {
+                return Err(FsError::NotRegularFile);
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => return Err(classify_open_err(e)),
+    }
+
+    std::fs::rename(&src_res.full, &dst_res.full)?;
+    Ok(())
+}
+
+/// Replace the **first** occurrence of `old_text` with `new_text` in a contained file, then
+/// write the result back **atomically** (temp+rename via [`write_file_within_root`]).
+///
+/// Faithful to the TS oracle's `edit` tool (`content.replace(oldText, newText)` — first match
+/// only). This is a thin composition: the read goes through [`open_read_within_root`] and the
+/// write through [`write_file_within_root`], so it inherits ALL of their containment + atomicity
+/// guarantees and adds no new open path of its own (no fresh attack surface).
+///
+/// # Errors
+/// - The file must be valid UTF-8; a binary file surfaces as [`FsError::Io`] (`InvalidData`).
+/// - If `old_text` is empty or not present, the file is left **byte-for-byte unchanged** and
+///   [`FsError::EditNoMatch`] is returned — no write occurs.
+/// - Containment / symlink / not-found failures surface from the underlying read or atomic
+///   write exactly as for those primitives.
+pub fn edit_file_within_root(
+    root: &Path,
+    candidate: &str,
+    old_text: &str,
+    new_text: &str,
+) -> Result<(), FsError> {
+    use std::io::Read;
+    // Hardened read (lexical gate + O_NOFOLLOW + realpath-ancestor + fd-identity).
+    let mut file = open_read_within_root(root, candidate)?;
+    let mut content = String::new();
+    // read_to_string returns ErrorKind::InvalidData for non-UTF-8 content → FsError::Io.
+    file.read_to_string(&mut content).map_err(FsError::Io)?;
+
+    // First-occurrence replace, faithful to the oracle. An empty `old_text` would otherwise
+    // prepend at every position; treat it as a no-match for predictability.
+    if old_text.is_empty() || !content.contains(old_text) {
+        return Err(FsError::EditNoMatch);
+    }
+    let updated = content.replacen(old_text, new_text, 1);
+
+    // Atomic replace (temp+rename): a mid-write failure leaves the original file intact.
+    write_file_within_root(root, candidate, updated.as_bytes())
 }
 
 /// A candidate that has passed the lexical gate + canonicalized-root +

--- a/rust-core/crates/friday-fs/tests/fs_primitives.rs
+++ b/rust-core/crates/friday-fs/tests/fs_primitives.rs
@@ -1,0 +1,473 @@
+//! REAL adverse/security tests for the S3-substrate safe-fs PRIMITIVES added to
+//! `friday-fs`: `list_dir`, `stat_file`, `append_file`, `delete_file`, `move_file`,
+//! and `edit_file`.
+//!
+//! Like `adverse_fs.rs`, every test operates on a real, unique temp directory with real
+//! files and **real symlinks created on disk** (`std::os::unix::fs::symlink`) — no mocks,
+//! no abstractly-asserted escapes. For each new primitive we prove: a happy path, lexical
+//! rejection (absolute / `..` traversal), a real **final-component symlink** rejection (no
+//! escape via symlink), a real **ancestor-directory symlink** rejection where the pipeline
+//! resolves a parent, and — where applicable — atomicity (no partial file / no temp
+//! leftover / original intact on a refused mutation).
+//!
+//! NOTE (truth label): none of these primitives are wired into the agent-loop
+//! `FsToolExecutor` yet — they are library functions with adverse tests only (PROOF-ONLY,
+//! Rust-wired-DEV). Wiring is a deferred serial follow-up.
+
+use std::fs;
+use std::io::{Read, Write};
+use std::os::unix::fs::{symlink, MetadataExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use friday_core::PathError;
+use friday_fs::{
+    append_file_within_root, delete_file_within_root, edit_file_within_root, list_dir_within_root,
+    move_file_within_root, stat_file_within_root, FileKind, FsError,
+};
+
+/// A real, unique temp directory that is recursively removed on drop. Std-only (no
+/// `tempfile` dependency) per the workspace's minimal-dependency convention.
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new() -> Self {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "friday-fs-prim-{}-{}-{}",
+            std::process::id(),
+            n,
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        fs::create_dir_all(&path).expect("create temp dir");
+        TempDir { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+fn write_file(path: &Path, contents: &str) {
+    let mut f = fs::File::create(path).expect("create file");
+    f.write_all(contents.as_bytes()).expect("write file");
+}
+
+fn read_file(path: &Path) -> String {
+    let mut f = fs::File::open(path).expect("open");
+    let mut s = String::new();
+    f.read_to_string(&mut s).expect("read");
+    s
+}
+
+/// Count temp files (`.<name>.tmp.*`) left in a dir — must be zero after an atomic write.
+fn temp_leftovers(dir: &Path) -> usize {
+    fs::read_dir(dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_name().to_string_lossy().contains(".tmp."))
+        .count()
+}
+
+// ════════════════════════════ list_dir ════════════════════════════
+
+#[test]
+fn list_dir_happy_lists_sorted_entries_without_dot_dot() {
+    let root = TempDir::new();
+    let dir = root.path().join("sub");
+    fs::create_dir(&dir).unwrap();
+    write_file(&dir.join("b.txt"), "b");
+    write_file(&dir.join("a.txt"), "a");
+    fs::create_dir(dir.join("nested")).unwrap();
+
+    let entries = list_dir_within_root(root.path(), "sub").expect("list contained dir");
+    let names: Vec<String> = entries
+        .iter()
+        .map(|e| e.to_string_lossy().into_owned())
+        .collect();
+    // Sorted, and `.`/`..` excluded.
+    assert_eq!(names, vec!["a.txt", "b.txt", "nested"]);
+}
+
+#[test]
+fn list_dir_absolute_and_traversal_are_rejected_lexically() {
+    let root = TempDir::new();
+    assert!(matches!(
+        list_dir_within_root(root.path(), "/etc").unwrap_err(),
+        FsError::Lexical(PathError::Absolute)
+    ));
+    assert!(matches!(
+        list_dir_within_root(root.path(), "../..").unwrap_err(),
+        FsError::Lexical(PathError::Traversal)
+    ));
+}
+
+#[test]
+fn list_dir_final_component_symlink_to_outside_dir_is_rejected() {
+    let root = TempDir::new();
+    let outside = TempDir::new();
+    // Real outside directory with a real entry, so a non-hardened readdir WOULD list it.
+    write_file(&outside.path().join("leaked.txt"), "x");
+    // <root>/link -> <outside>
+    symlink(outside.path(), root.path().join("link")).expect("final-component dir symlink");
+
+    let err = list_dir_within_root(root.path(), "link").unwrap_err();
+    assert!(
+        matches!(err, FsError::Symlink),
+        "a final-component symlink dir must be rejected by O_NOFOLLOW, got {err:?}"
+    );
+}
+
+#[test]
+fn list_dir_ancestor_symlink_escape_is_rejected() {
+    let root = TempDir::new();
+    let outside = TempDir::new();
+    let outside_dir = outside.path().join("realdir");
+    fs::create_dir_all(outside_dir.join("inner")).unwrap();
+    // <root>/sub -> <outside>/realdir  (sub is a non-final symlink component)
+    symlink(&outside_dir, root.path().join("sub")).expect("ancestor symlink");
+
+    let err = list_dir_within_root(root.path(), "sub/inner").unwrap_err();
+    assert!(
+        matches!(err, FsError::Escape),
+        "an ancestor-dir symlink escape must be rejected, got {err:?}"
+    );
+}
+
+#[test]
+fn list_dir_on_a_regular_file_is_not_a_directory() {
+    let root = TempDir::new();
+    write_file(&root.path().join("f.txt"), "data");
+    let err = list_dir_within_root(root.path(), "f.txt").unwrap_err();
+    assert!(
+        matches!(err, FsError::NotADirectory),
+        "listing a regular file must be NotADirectory, got {err:?}"
+    );
+}
+
+// ════════════════════════════ stat_file ════════════════════════════
+
+#[test]
+fn stat_file_happy_reports_regular_file_kind_size_mode() {
+    let root = TempDir::new();
+    let p = root.path().join("f.txt");
+    write_file(&p, "hello world"); // 11 bytes
+    fs::set_permissions(&p, fs::Permissions::from_mode(0o640)).unwrap();
+
+    let st = stat_file_within_root(root.path(), "f.txt").expect("stat contained file");
+    assert_eq!(st.kind, FileKind::File);
+    assert_eq!(st.len, 11);
+    assert_eq!(st.mode, 0o640);
+    assert!(!st.readonly);
+}
+
+#[test]
+fn stat_file_reports_directory_kind() {
+    let root = TempDir::new();
+    fs::create_dir(root.path().join("d")).unwrap();
+    let st = stat_file_within_root(root.path(), "d").expect("stat contained dir");
+    assert_eq!(st.kind, FileKind::Dir);
+}
+
+#[test]
+fn stat_file_final_component_symlink_is_rejected() {
+    let root = TempDir::new();
+    let outside = TempDir::new();
+    let secret = outside.path().join("secret.txt");
+    write_file(&secret, "OUTSIDE");
+    symlink(&secret, root.path().join("link.txt")).expect("symlink");
+
+    let err = stat_file_within_root(root.path(), "link.txt").unwrap_err();
+    assert!(
+        matches!(err, FsError::Symlink),
+        "stat must refuse a final-component symlink (no follow), got {err:?}"
+    );
+}
+
+#[test]
+fn stat_file_absolute_and_traversal_rejected_and_missing_is_not_found() {
+    let root = TempDir::new();
+    assert!(matches!(
+        stat_file_within_root(root.path(), "/etc/passwd").unwrap_err(),
+        FsError::Lexical(PathError::Absolute)
+    ));
+    assert!(matches!(
+        stat_file_within_root(root.path(), "../x").unwrap_err(),
+        FsError::Lexical(PathError::Traversal)
+    ));
+    assert!(matches!(
+        stat_file_within_root(root.path(), "nope.txt").unwrap_err(),
+        FsError::NotFound
+    ));
+}
+
+// ════════════════════════════ append_file ════════════════════════════
+
+#[test]
+fn append_file_creates_then_appends_and_is_owner_only() {
+    let root = TempDir::new();
+    // Create-if-absent.
+    append_file_within_root(root.path(), "log.txt", b"AAA").unwrap();
+    assert_eq!(read_file(&root.path().join("log.txt")), "AAA");
+    // Owner-only on create (oracle parity).
+    assert_eq!(
+        fs::metadata(root.path().join("log.txt")).unwrap().mode() & 0o777,
+        0o600
+    );
+    // Append extends, does not replace.
+    append_file_within_root(root.path(), "log.txt", b"BBB").unwrap();
+    assert_eq!(read_file(&root.path().join("log.txt")), "AAABBB");
+    assert_eq!(
+        temp_leftovers(root.path()),
+        0,
+        "append is in-place, no temp"
+    );
+}
+
+#[test]
+fn append_file_through_final_symlink_is_rejected_outside_intact() {
+    let root = TempDir::new();
+    let outside = TempDir::new();
+    let target = outside.path().join("t.txt");
+    write_file(&target, "ORIGINAL");
+    symlink(&target, root.path().join("a.txt")).expect("symlink");
+
+    let err = append_file_within_root(root.path(), "a.txt", b"PWN").unwrap_err();
+    assert!(matches!(err, FsError::Symlink), "got {err:?}");
+    // Never appended through the symlink.
+    assert_eq!(read_file(&target), "ORIGINAL");
+}
+
+#[test]
+fn append_file_traversal_and_directory_target_rejected() {
+    let root = TempDir::new();
+    assert!(matches!(
+        append_file_within_root(root.path(), "../x.txt", b"x").unwrap_err(),
+        FsError::Lexical(PathError::Traversal)
+    ));
+    fs::create_dir(root.path().join("d")).unwrap();
+    assert!(matches!(
+        append_file_within_root(root.path(), "d", b"x").unwrap_err(),
+        FsError::IsDirectory
+    ));
+}
+
+// ════════════════════════════ delete_file ════════════════════════════
+
+#[test]
+fn delete_file_happy_removes_regular_file() {
+    let root = TempDir::new();
+    let p = root.path().join("gone.txt");
+    write_file(&p, "bye");
+    delete_file_within_root(root.path(), "gone.txt").unwrap();
+    assert!(!p.exists(), "file must be removed");
+}
+
+#[test]
+fn delete_file_refuses_symlink_leaving_link_and_target_intact() {
+    let root = TempDir::new();
+    let outside = TempDir::new();
+    let target = outside.path().join("keep.txt");
+    write_file(&target, "KEEP ME");
+    let link = root.path().join("link.txt");
+    symlink(&target, &link).expect("symlink");
+
+    let err = delete_file_within_root(root.path(), "link.txt").unwrap_err();
+    assert!(matches!(err, FsError::Symlink), "got {err:?}");
+    // The link itself and the outside target both survive (we removed neither).
+    assert!(fs::symlink_metadata(&link)
+        .unwrap()
+        .file_type()
+        .is_symlink());
+    assert_eq!(read_file(&target), "KEEP ME");
+}
+
+#[test]
+fn delete_file_refuses_directory_and_traversal_and_reports_missing() {
+    let root = TempDir::new();
+    fs::create_dir(root.path().join("d")).unwrap();
+    assert!(matches!(
+        delete_file_within_root(root.path(), "d").unwrap_err(),
+        FsError::IsDirectory
+    ));
+    assert!(root.path().join("d").is_dir(), "dir must be untouched");
+    assert!(matches!(
+        delete_file_within_root(root.path(), "../escape").unwrap_err(),
+        FsError::Lexical(PathError::Traversal)
+    ));
+    assert!(matches!(
+        delete_file_within_root(root.path(), "nope.txt").unwrap_err(),
+        FsError::NotFound
+    ));
+}
+
+// ════════════════════════════ move_file ════════════════════════════
+
+#[test]
+fn move_file_happy_renames_and_replaces_existing_regular_dst() {
+    let root = TempDir::new();
+    write_file(&root.path().join("src.txt"), "PAYLOAD");
+    move_file_within_root(root.path(), "src.txt", "dst.txt").unwrap();
+    assert!(!root.path().join("src.txt").exists(), "source must be gone");
+    assert_eq!(read_file(&root.path().join("dst.txt")), "PAYLOAD");
+
+    // Replacing an existing regular destination is allowed (atomic same-name replace).
+    write_file(&root.path().join("src2.txt"), "NEW");
+    move_file_within_root(root.path(), "src2.txt", "dst.txt").unwrap();
+    assert_eq!(read_file(&root.path().join("dst.txt")), "NEW");
+}
+
+#[test]
+fn move_file_into_nested_contained_dir_ok() {
+    let root = TempDir::new();
+    fs::create_dir(root.path().join("sub")).unwrap();
+    write_file(&root.path().join("a.txt"), "X");
+    move_file_within_root(root.path(), "a.txt", "sub/b.txt").unwrap();
+    assert_eq!(read_file(&root.path().join("sub/b.txt")), "X");
+}
+
+#[test]
+fn move_file_rejects_absolute_or_traversal_src_or_dst() {
+    let root = TempDir::new();
+    write_file(&root.path().join("s.txt"), "x");
+    // Escaping destination (absolute) refused — no write outside root.
+    let outside = TempDir::new();
+    let abs_dst = outside.path().join("leak.txt");
+    assert!(matches!(
+        move_file_within_root(root.path(), "s.txt", abs_dst.to_str().unwrap()).unwrap_err(),
+        FsError::Lexical(PathError::Absolute)
+    ));
+    assert!(!abs_dst.exists(), "must not have escaped to absolute dst");
+    // Traversal source refused.
+    assert!(matches!(
+        move_file_within_root(root.path(), "../s.txt", "d.txt").unwrap_err(),
+        FsError::Lexical(PathError::Traversal)
+    ));
+}
+
+#[test]
+fn move_file_refuses_symlink_src_and_symlink_dst() {
+    let root = TempDir::new();
+    let outside = TempDir::new();
+    let outside_file = outside.path().join("o.txt");
+    write_file(&outside_file, "OUTSIDE");
+
+    // Symlink SOURCE refused.
+    symlink(&outside_file, root.path().join("slink.txt")).unwrap();
+    write_file(&root.path().join("real.txt"), "REAL");
+    assert!(matches!(
+        move_file_within_root(root.path(), "slink.txt", "out.txt").unwrap_err(),
+        FsError::Symlink
+    ));
+
+    // Symlink DESTINATION refused (don't replace a link), outside target intact.
+    symlink(&outside_file, root.path().join("dlink.txt")).unwrap();
+    let err = move_file_within_root(root.path(), "real.txt", "dlink.txt").unwrap_err();
+    assert!(matches!(err, FsError::Symlink), "got {err:?}");
+    assert_eq!(
+        read_file(&outside_file),
+        "OUTSIDE",
+        "outside target untouched"
+    );
+    assert_eq!(
+        read_file(&root.path().join("real.txt")),
+        "REAL",
+        "src intact"
+    );
+}
+
+#[test]
+fn move_file_refuses_dir_dst_and_missing_src() {
+    let root = TempDir::new();
+    write_file(&root.path().join("s.txt"), "x");
+    fs::create_dir(root.path().join("ddir")).unwrap();
+    assert!(matches!(
+        move_file_within_root(root.path(), "s.txt", "ddir").unwrap_err(),
+        FsError::IsDirectory
+    ));
+    assert!(matches!(
+        move_file_within_root(root.path(), "missing.txt", "d.txt").unwrap_err(),
+        FsError::NotFound
+    ));
+}
+
+// ════════════════════════════ edit_file ════════════════════════════
+
+#[test]
+fn edit_file_happy_replaces_first_occurrence_atomically() {
+    let root = TempDir::new();
+    write_file(&root.path().join("doc.txt"), "hello world, hello moon");
+    edit_file_within_root(root.path(), "doc.txt", "hello", "bye").unwrap();
+    // First occurrence only (oracle parity).
+    assert_eq!(
+        read_file(&root.path().join("doc.txt")),
+        "bye world, hello moon"
+    );
+    // Atomic write via temp+rename: no temp leftover.
+    assert_eq!(temp_leftovers(root.path()), 0);
+}
+
+#[test]
+fn edit_file_no_match_leaves_file_unchanged() {
+    let root = TempDir::new();
+    write_file(&root.path().join("doc.txt"), "unchanged content");
+    let err = edit_file_within_root(root.path(), "doc.txt", "absent", "X").unwrap_err();
+    assert!(matches!(err, FsError::EditNoMatch), "got {err:?}");
+    assert_eq!(read_file(&root.path().join("doc.txt")), "unchanged content");
+    assert_eq!(temp_leftovers(root.path()), 0, "no write on no-match");
+
+    // Empty old_text is treated as a no-match too (no prepend surprise).
+    assert!(matches!(
+        edit_file_within_root(root.path(), "doc.txt", "", "X").unwrap_err(),
+        FsError::EditNoMatch
+    ));
+    assert_eq!(read_file(&root.path().join("doc.txt")), "unchanged content");
+}
+
+#[test]
+fn edit_file_binary_content_is_invalid_data() {
+    let root = TempDir::new();
+    // Invalid UTF-8 bytes on disk.
+    fs::write(root.path().join("bin.dat"), [0xff, 0xfe, 0x00, 0x01]).unwrap();
+    let err = edit_file_within_root(root.path(), "bin.dat", "a", "b").unwrap_err();
+    assert!(
+        matches!(&err, FsError::Io(e) if e.kind() == std::io::ErrorKind::InvalidData),
+        "non-UTF8 file must surface InvalidData, got {err:?}"
+    );
+}
+
+#[test]
+fn edit_file_through_symlink_or_traversal_is_rejected_outside_intact() {
+    let root = TempDir::new();
+    let outside = TempDir::new();
+    let target = outside.path().join("t.txt");
+    write_file(&target, "OUTSIDE SECRET");
+    symlink(&target, root.path().join("link.txt")).unwrap();
+
+    // The hardened read path refuses the final-component symlink.
+    let err = edit_file_within_root(root.path(), "link.txt", "OUTSIDE", "X").unwrap_err();
+    assert!(matches!(err, FsError::Symlink), "got {err:?}");
+    assert_eq!(
+        read_file(&target),
+        "OUTSIDE SECRET",
+        "outside file untouched"
+    );
+
+    assert!(matches!(
+        edit_file_within_root(root.path(), "../t.txt", "a", "b").unwrap_err(),
+        FsError::Lexical(PathError::Traversal)
+    ));
+}


### PR DESCRIPTION
## Truth label
**PROOF-ONLY (Rust-wired-DEV).** This slice adds the missing safe-fs PRIMITIVES to the `friday-fs` crate **as library functions only**. They are **NOT wired into the agent-loop `FsToolExecutor`** (friday-hub/lib.rs) — so there is **no broadened live tool surface**: nothing in the loop can reach these yet, and the mutating gate-pause is preserved by construction. **NOT a v1 GO.**

## What this is
The agent-loop tool registry (`ToolRegistry::default` in friday-hub/lib.rs) declares ~10 tools, of which only `read_file` + `write_file` had backing safe-fs primitives in `friday-fs`. S3-substrate implements the **missing fs-path primitives** as hardened library functions with adverse/security tests, deliberately WITHOUT the executor wiring (which broadens the live surface, is gate-paused until S6, and is serial on `lib.rs` owned by another lane).

## Primitives added (existed before: `read_file`, `write_file`)
- `list_dir_within_root` → `Vec<OsString>` — **TOCTOU-free**: opens `O_NOFOLLOW|O_NONBLOCK`, post-open `fstat` requires a directory, then lists from the **validated fd** via `fdopendir`/`readdir` (never re-resolves the path string), excludes `.`/`..`, sorted.
- `stat_file_within_root` → `FileStat { kind, len, mode, readonly }` — no-follow `lstat`; final-component symlink rejected.
- `append_file_within_root` — `O_APPEND` in-place, create-if-absent `0o600`.
- `delete_file_within_root` — `unlink` with `lstat` don't-clobber (refuses symlink/dir/non-regular).
- `move_file_within_root` — atomic `rename(2)`; **both** endpoints contained; refuses symlink/dir endpoints.
- `edit_file_within_root` — first-occurrence `old_text`→`new_text` replace (faithful to the TS `edit` oracle), then atomic temp+rename write.

New error variants (`NotADirectory`, `EditNoMatch`) + types (`FileKind`, `FileStat`). Verified safe to add: the only out-of-crate `FsError` use is the `ExecError::Fs(..)` wrapper + a `Display` delegation — no exhaustive `match` on its variants anywhere, so no out-of-crate compile break.

## Excluded (deliberate, not forgotten)
`search` (workspace query, not a single-path op) and `run_command` (shell exec) are not fs-path primitives. `mkdir`/`copy`/`exists` are illustrative in the task text but are **not in the registry/enum**, so they are not implemented — this follows the codebase's actual tool set.

## Containment + atomicity guarantees
- **Containment** mirrors the existing read/write pipeline exactly: lexical gate (`..`/absolute/`.`/empty rejected) + canonicalized root + realpath-ancestor parent check + `O_NOFOLLOW` final component (+ fd-identity on the write/append paths). No escape via `..`, absolute path, final-component symlink, or ancestor-directory symlink. `list_dir` additionally lists from the held validated fd so a final-component swap cannot redirect the listing.
- **Atomicity**: `edit` uses temp+rename; `move` uses atomic `rename(2)`. `append` is positional `O_APPEND` (truth-labeled: **not** replace-atomic by design — avoids silently normalizing mode/breaking hardlinks on every append).

## Tests
`crates/friday-fs/tests/fs_primitives.rs` (24 real, on-disk adverse/security tests: happy path + absolute/traversal rejection + real final-component symlink + real ancestor-dir symlink + not-a-dir + atomicity/no-temp-leftover/original-intact). Existing friday-fs tests stay green.

## Local CI gate (rust-core.yml — all green)
- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo build -p friday-hub --bin hub_run_task` + `hub_run_readback` ✅
- `cargo test --workspace` ✅ (incl. 44 friday-fs tests: 6 unit + 14 adverse + 24 new)

## Deferred (serial follow-up, NOT this slice)
Wiring these into `FsToolExecutor` (friday-hub/lib.rs) is a **deferred serial follow-up** (broadens the live tool surface; gate-paused until S6; serial on `lib.rs` owned by another lane). Handoff notes for the wiring lane: (1) `list_dir`/`stat_file` reject `""`/`"."`, so the registered `list_dir` tool called with `path="."` (list workspace root) needs a root-allowed branch added at wiring time; (2) the `FsToolExecutor` "later slice" comment and the friday-fs module-doc "read/write/edit surface" line are now stale — reconcile at S6 wiring (left untouched here to respect the write-set boundary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)