### PR TITLE
feat(rust-hub): S1.2 agent loop BILLS + AUDITS like the ask path (usage-parity floor)

### DIFF
--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -236,6 +236,20 @@ pub struct TurnTrace {
     pub outcome: String,
 }
 
+/// One metered loop step (S1.2 billing seam): the parsed-step result PLUS the model-call
+/// usage the loop ledgers. The OUTER [`AgentError`] is a route/transport/discovery failure
+/// — the model call never produced usage, so NOTHING is billed (the ask path's `Route`
+/// error). On the OUTER `Ok`, the inner [`Result<AgentStep, AgentError>`] is the *parse* of
+/// a chat that ALREADY succeeded: an inner `Err` means the chat 200'd with real, billable
+/// usage but the content failed the tool-call contract — the loop BILLS the call (usage is
+/// `Some`) and THEN fails the run closed. This split is what makes the loop bill like the
+/// ask path (which has no parse step): a chat that spends tokens is billed even when the
+/// reply is unparseable (the S1.1 `parse_error` failure mode would otherwise under-bill).
+pub type MeteredStep = (
+    Result<AgentStep, AgentError>,
+    Option<friday_deepseek::ModelCallOutcome>,
+);
+
 /// The model-client seam (mirrors `friday-deepseek`'s `Transport` DI pattern). The
 /// turn loop dispatches through this so it is unit-testable with a mock; the live impl
 /// over `friday-deepseek` is the runtime-proven slice. It returns only the untrusted
@@ -252,6 +266,24 @@ pub trait AgentLlmClient {
     /// history-aware multi-turn + `Finish` termination.
     fn next_step(&self, task: &str, _history: &[TurnTrace]) -> Result<AgentStep, AgentError> {
         Ok(AgentStep::Tool(self.propose_tool_call(task)?))
+    }
+
+    /// Like [`AgentLlmClient::next_step`], but ALSO surfaces the model-call usage
+    /// ([`friday_deepseek::ModelCallOutcome`]: tokens + reported model) so [`run_loop`] can
+    /// LEDGER the call (S1.2 usage-parity). See [`MeteredStep`] for the route-vs-parse
+    /// error split.
+    ///
+    /// The DEFAULT meters NOTHING: it delegates to [`AgentLlmClient::next_step`] and returns
+    /// `(result, None)` — a client that does not report usage (mocks / scripted tests) bills
+    /// nothing, the honest default (no usage data ⇒ no ledger row), preserving every existing
+    /// loop test. The live [`DeepSeekAgentLlmClient`] OVERRIDES this to surface the real
+    /// outcome (and routes its own `next_step` through it, so there is ONE chat call site).
+    fn next_step_metered(
+        &self,
+        task: &str,
+        history: &[TurnTrace],
+    ) -> Result<MeteredStep, AgentError> {
+        Ok((self.next_step(task, history), None))
     }
 }
 
@@ -317,7 +349,26 @@ impl<T: friday_deepseek::Transport> AgentLlmClient for DeepSeekAgentLlmClient<T>
     /// History-aware multi-turn step: the prompt includes prior turns + their outcomes
     /// so the model can build on them or finish. `{"tool":"none","answer":"<final answer>"}`
     /// parses to `Finish { message: "<final answer>" }`.
+    ///
+    /// Routed through [`DeepSeekAgentLlmClient::next_step_metered`] so there is exactly ONE
+    /// chat call site (no drift between the metered and unmetered paths); the usage is
+    /// discarded here, surfaced there.
     fn next_step(&self, task: &str, history: &[TurnTrace]) -> Result<AgentStep, AgentError> {
+        self.next_step_metered(task, history)?.0
+    }
+
+    /// Metered multi-turn step (S1.2): does the SAME discover → select → chat as
+    /// [`DeepSeekAgentLlmClient::next_step`], then parses the reply — but returns the chat's
+    /// [`friday_deepseek::ModelCallOutcome`] (tokens + reported model) ALONGSIDE the parse
+    /// result so [`run_loop`] can ledger the call. A discover/select/chat failure is an OUTER
+    /// `Err` (route failure: nothing billed). A successful chat whose content does not parse
+    /// is an INNER `Err` with `Some(outcome)` — the chat spent tokens, so the loop bills it
+    /// and then fails the run closed. See [`MeteredStep`].
+    fn next_step_metered(
+        &self,
+        task: &str,
+        history: &[TurnTrace],
+    ) -> Result<MeteredStep, AgentError> {
         let models = self
             .client
             .discover_models()
@@ -329,7 +380,10 @@ impl<T: friday_deepseek::Transport> AgentLlmClient for DeepSeekAgentLlmClient<T>
             .client
             .chat(&model, &prompt, AGENTLOOP_MAX_TOKENS)
             .map_err(|e| AgentError::Model(format!("{e:?}")))?;
-        parse_agent_step(&outcome.content)
+        // The chat SUCCEEDED — `outcome` carries real, billable usage even if the content
+        // below fails to parse. Surface it so the loop bills the call regardless of parse.
+        let step = parse_agent_step(&outcome.content);
+        Ok((step, Some(outcome)))
     }
 }
 
@@ -1451,6 +1505,60 @@ fn format_executed_outcome(receipt: &ToolReceipt) -> String {
     }
 }
 
+/// Ledger ONE agent-loop model call exactly as the ask path ledgers a single ask
+/// (`record_friday_ask`): build a Friday-route [`friday_core::LedgerEntry`] from the call's
+/// reported usage (`ModelCallOutcome::to_ledger_entry` ledgers the RESPONSE-reported model,
+/// never the requested one — no stale-model claims), an [`ActivityType::AskReceipt`] receipt
+/// (the same receipt shape the ask surface emits), and an `agent_loop.model_call` audit
+/// event, then write all three ATOMICALLY with the owning `run_id` via
+/// [`friday_storage::record_run_model_call`]. Per-turn ids are derived from
+/// `run_id`/`turn_index`, so N model calls leave N distinct, run-attributed rows.
+///
+/// The loop run is used as the ledger `session_id` (a loop run has no separate session; the
+/// AUTHORITATIVE run-attribution is the dedicated `run_id` column added in S1.2). Cost is
+/// left unestimated (`None`), matching the ask path. A construction failure (only possible
+/// on negative/overflowing usage — a hostile/buggy provider response) maps to a
+/// [`StorageError`] and fails the run closed; it never persists a malformed bill.
+fn bill_model_call(
+    conn: &Connection,
+    run_id: &str,
+    turn_index: u64,
+    outcome: &friday_deepseek::ModelCallOutcome,
+    now_ms: i64,
+) -> Result<(), StorageError> {
+    let ledger_id = format!("{run_id}:t{turn_index}:ledger");
+    let activity_id = format!("{run_id}:t{turn_index}:askreceipt");
+    let audit_id = format!("{run_id}:t{turn_index}:modelcall");
+    let entry = outcome
+        .to_ledger_entry(
+            ledger_id.as_str(),
+            run_id,
+            activity_id.as_str(),
+            None,
+            None,
+            now_ms,
+        )
+        .map_err(|e| StorageError::Unsupported(format!("loop ledger entry: {e:?}")))?;
+    let activity = ActivityRow {
+        activity_id,
+        session_id: Some(run_id.to_string()),
+        kind: ActivityType::AskReceipt,
+        state: ActivityState::Done,
+        summary: format!("{} tokens via {}", entry.total_tokens, entry.model),
+        created_at: now_ms,
+        updated_at: now_ms,
+        deep_link: None,
+    };
+    let audit = AuditEvent {
+        audit_id,
+        actor: "hub-agent".to_string(),
+        action: "agent_loop.model_call".to_string(),
+        payload_ref: Some(ledger_id),
+        created_at: now_ms,
+    };
+    friday_storage::record_run_model_call(conn, run_id, &entry, &activity, &audit)
+}
+
 /// Drive a MULTI-TURN agent loop: repeatedly ask the model for the next step (with
 /// conversation history), and for each proposed tool run the SAME gate-mandatory
 /// dispatch as [`run_one_turn_with_executor`] (authorize → execute only on `Allow` →
@@ -1520,9 +1628,45 @@ pub fn run_loop(
     for turn_index in 0..max_turns {
         let ev = |suffix: &str| format!("{run_id}:t{turn_index}:{suffix}");
 
-        let step = match client.next_step(&prompt_task, &history) {
+        // S1.2 usage-parity: ONE metered model call per turn. An OUTER `Err` is a
+        // route/transport/discovery failure — the chat produced no usage, so NOTHING is
+        // billed (exactly the ask path's `Route` error: no half-billed row). The inner
+        // parse result is handled AFTER billing below.
+        let (step_result, usage) = match client.next_step_metered(&prompt_task, &history) {
+            Ok(metered) => metered,
+            Err(e) => {
+                agent_run::record_event(
+                    conn,
+                    &ev("outcome"),
+                    run_id,
+                    &format!("agent.error:{e}"),
+                    now_ms,
+                )?;
+                return Ok(LoopOutcome {
+                    status: LoopStatus::Errored,
+                    turns: turn_index + 1,
+                    executed_tools,
+                    final_message: None,
+                    detail: format!("agent_error:{e}"),
+                });
+            }
+        };
+
+        // BILL the call like the ask path: a chat that returned usage writes exactly ONE
+        // run-attributed token_ledger row + ONE AskReceipt receipt + ONE hash-chained audit
+        // event, atomically — REGARDLESS of how the loop then treats the step (finish, tool,
+        // block) or whether the reply even parsed (the S1.1 parse-error mode still spent
+        // tokens). A client that does not meter (mocks/tests) yields `None` and bills
+        // nothing — the honest default (no usage data ⇒ no ledger row).
+        if let Some(outcome) = usage {
+            bill_model_call(conn, run_id, turn_index, &outcome, now_ms)?;
+        }
+
+        let step = match step_result {
             Ok(step) => step,
             Err(e) => {
+                // Chat SUCCEEDED (already billed above) but the reply violated the tool-call
+                // contract — fail the run closed; the model call stays ledgered.
                 agent_run::record_event(
                     conn,
                     &ev("outcome"),
@@ -2541,6 +2685,231 @@ mod tests {
         }
     }
 
+    /// A scripted client that ALSO meters each turn (overrides `next_step_metered`) — the
+    /// S1.2 billing harness. Each turn returns the next scripted (parse) result PLUS a
+    /// synthetic `ModelCallOutcome` with fixed usage, so the loop bills exactly as the live
+    /// path would, without a network call. Scripting a `Err(parse)` step with `Some(outcome)`
+    /// models a chat that 200'd (billable) but produced unparseable content.
+    struct MeteringScriptedClient {
+        steps: Vec<Result<AgentStep, AgentError>>,
+        calls: std::cell::Cell<usize>,
+        prompt_tokens: i64,
+        completion_tokens: i64,
+    }
+    impl MeteringScriptedClient {
+        fn new(
+            steps: Vec<Result<AgentStep, AgentError>>,
+            prompt_tokens: i64,
+            completion_tokens: i64,
+        ) -> Self {
+            Self {
+                steps,
+                calls: std::cell::Cell::new(0),
+                prompt_tokens,
+                completion_tokens,
+            }
+        }
+    }
+    impl AgentLlmClient for MeteringScriptedClient {
+        fn propose_tool_call(&self, _task: &str) -> Result<RawToolCall, AgentError> {
+            Err(AgentError::Parse(
+                "metering: single-turn path unused by run_loop".to_string(),
+            ))
+        }
+        fn next_step_metered(
+            &self,
+            _task: &str,
+            _history: &[TurnTrace],
+        ) -> Result<MeteredStep, AgentError> {
+            let i = self.calls.get();
+            self.calls.set(i + 1);
+            let step = self.steps.get(i).cloned().unwrap_or(Ok(AgentStep::Finish {
+                message: "script exhausted".to_string(),
+            }));
+            let outcome = friday_deepseek::ModelCallOutcome {
+                model: "deepseek-v4-flash".to_string(),
+                prompt_tokens: self.prompt_tokens,
+                completion_tokens: self.completion_tokens,
+                total_tokens: self.prompt_tokens + self.completion_tokens,
+                content: String::new(),
+                finish_reason: "stop".to_string(),
+            };
+            Ok((step, Some(outcome)))
+        }
+    }
+
+    #[test]
+    fn loop_bills_each_model_call_run_attributed_like_ask_path() {
+        // S1.2 usage-parity FLOOR: a loop run with N model calls writes N run-attributed
+        // token_ledger rows + N AskReceipt receipts + a verifying hash-chained audit —
+        // the same accounting the single-shot ask path produces per call.
+        let root = TempDir::new("loop-bill");
+        std::fs::write(root.0.join("notes.md"), b"answer is 47").unwrap();
+        let db = Db::open_hub(&temp_path("loop-bill")).unwrap();
+        agent_run::create_run(db.conn(), "r1", "read notes.md", 1).unwrap();
+        // Two model calls: a read tool turn, then a finish turn.
+        let client = MeteringScriptedClient::new(
+            vec![
+                Ok(AgentStep::Tool(raw("read_file", &[("path", "notes.md")]))),
+                Ok(AgentStep::Finish {
+                    message: "47".to_string(),
+                }),
+            ],
+            10,
+            5,
+        );
+        let executor = FsToolExecutor::new(&root.0);
+        let out = run_loop(
+            &client,
+            &executor,
+            db.conn(),
+            "r1",
+            "read notes.md",
+            "",
+            SECRET,
+            &no_approval(),
+            10,
+            1000,
+        )
+        .unwrap();
+        assert_eq!(out.status, LoopStatus::Finished);
+        // N model calls (2) -> N run-attributed token_ledger rows.
+        assert_eq!(
+            db.count("token_ledger").unwrap(),
+            2,
+            "one ledger row per model call"
+        );
+        let n_for_run: i64 = db
+            .conn()
+            .query_row(
+                "SELECT count(*) FROM token_ledger WHERE run_id = 'r1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(n_for_run, 2, "both rows attributed to the run");
+        // N AskReceipt receipts (the same shape the ask surface emits).
+        assert_eq!(db.count("activity_item").unwrap(), 2);
+        let n_receipts: i64 = db
+            .conn()
+            .query_row(
+                "SELECT count(*) FROM activity_item WHERE type = 'ask_receipt'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(n_receipts, 2);
+        // Hash-chained audit verifies (2 model-call audits + the tool-receipt audit).
+        assert!(friday_storage::audit::verify_audit_chain(db.conn()).unwrap() >= 2);
+        let n_modelcall_audits: i64 = db
+            .conn()
+            .query_row(
+                "SELECT count(*) FROM audit_ledger WHERE action = 'agent_loop.model_call'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(n_modelcall_audits, 2);
+        // Run-attributed total == 2 calls * (10 prompt + 5 completion).
+        let run_tot = friday_storage::agent_run_read::run_token_totals(db.conn(), "r1").unwrap();
+        assert_eq!(run_tot.total, 30);
+        assert_eq!(run_tot.prompt, 20);
+        assert_eq!(run_tot.completion, 10);
+        // Ledgered the RESPONSE-reported model (not the requested one).
+        let model: String = db
+            .conn()
+            .query_row(
+                "SELECT model FROM token_ledger WHERE ledger_id = 'r1:t0:ledger'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(model, "deepseek-v4-flash");
+    }
+
+    #[test]
+    fn loop_bills_a_chat_that_then_failed_to_parse() {
+        // A chat that 200'd with usage but produced unparseable content (the S1.1 mode) is
+        // STILL billed — the call spent tokens — then the run fails closed. Billing must not
+        // hinge on the loop's parse, exactly like the ask path (which has no parse step).
+        let root = TempDir::new("loop-bill-parsefail");
+        let db = Db::open_hub(&temp_path("loop-bill-parsefail")).unwrap();
+        agent_run::create_run(db.conn(), "r1", "do a thing", 1).unwrap();
+        let client = MeteringScriptedClient::new(
+            vec![Err(AgentError::Parse(
+                "not a single JSON object".to_string(),
+            ))],
+            7,
+            3,
+        );
+        let executor = FsToolExecutor::new(&root.0);
+        let out = run_loop(
+            &client,
+            &executor,
+            db.conn(),
+            "r1",
+            "do a thing",
+            "",
+            SECRET,
+            &no_approval(),
+            10,
+            1000,
+        )
+        .unwrap();
+        assert_eq!(
+            out.status,
+            LoopStatus::Errored,
+            "unparseable reply fails the run closed"
+        );
+        // ...but the spent call WAS billed (one run-attributed row); audit chain intact.
+        assert_eq!(
+            db.count("token_ledger").unwrap(),
+            1,
+            "the chat that spent tokens is billed even though it didn't parse"
+        );
+        let tot = friday_storage::agent_run_read::run_token_totals(db.conn(), "r1").unwrap();
+        assert_eq!(tot.total, 10);
+        assert!(friday_storage::audit::verify_audit_chain(db.conn()).unwrap() >= 1);
+    }
+
+    #[test]
+    fn loop_with_non_metering_client_bills_nothing() {
+        // The honest default: a client without a `next_step_metered` override reports no
+        // usage, so the loop writes NO token_ledger rows — billing requires real usage data.
+        // (This is why every pre-S1.2 loop test stays green.)
+        let root = TempDir::new("loop-nobill");
+        std::fs::write(root.0.join("a.md"), b"alpha").unwrap();
+        let db = Db::open_hub(&temp_path("loop-nobill")).unwrap();
+        agent_run::create_run(db.conn(), "r1", "read a", 1).unwrap();
+        let client = ScriptedAgentLlmClient::new(vec![
+            AgentStep::Tool(raw("read_file", &[("path", "a.md")])),
+            AgentStep::Finish {
+                message: "ok".to_string(),
+            },
+        ]);
+        let executor = FsToolExecutor::new(&root.0);
+        let out = run_loop(
+            &client,
+            &executor,
+            db.conn(),
+            "r1",
+            "read a",
+            "",
+            SECRET,
+            &no_approval(),
+            10,
+            1000,
+        )
+        .unwrap();
+        assert_eq!(out.status, LoopStatus::Finished);
+        assert_eq!(
+            db.count("token_ledger").unwrap(),
+            0,
+            "non-metering client bills nothing"
+        );
+        assert_eq!(db.count("activity_item").unwrap(), 0);
+    }
+
     #[test]
     fn head_slice_respects_utf8_boundary() {
         // Under cap: returned whole, not truncated.
@@ -3109,6 +3478,42 @@ mod ask_coupling_tests {
         fn new(post_fails: bool) -> Self {
             Self { post_fails }
         }
+    }
+
+    #[test]
+    fn deepseek_metered_surfaces_usage_even_when_content_does_not_parse() {
+        // DeepSeek-client-level proof of bill-on-chat-success: MockTransport's chat 200s
+        // with usage {10,5,15} but content "hello" — NOT a tool-call object. The metered
+        // seam returns (Err(parse), Some(outcome)) so the loop bills the spent call (the
+        // S1.1 parse-error mode) instead of dropping the usage with the parse error.
+        let client = DeepSeekAgentLlmClient::new(friday_deepseek::DeepSeekClient::with_transport(
+            MockTransport::new(false),
+            "k".into(),
+        ));
+        let (parsed, usage) = client.next_step_metered("task", &[]).unwrap();
+        assert!(
+            matches!(parsed, Err(AgentError::Parse(_))),
+            "non-tool-call content must fail the contract parse"
+        );
+        let outcome = usage.expect("a successful chat must surface usage to bill");
+        assert_eq!(outcome.prompt_tokens, 10);
+        assert_eq!(outcome.completion_tokens, 5);
+        assert_eq!(outcome.total_tokens, 15);
+        assert_eq!(outcome.model, "deepseek-v4-flash");
+    }
+
+    #[test]
+    fn deepseek_metered_route_failure_surfaces_no_usage() {
+        // A transport/route failure is an OUTER Err: no usage produced, nothing to bill
+        // (the ask path's `Route` error — no half-billed row).
+        let client = DeepSeekAgentLlmClient::new(friday_deepseek::DeepSeekClient::with_transport(
+            MockTransport::new(true),
+            "k".into(),
+        ));
+        assert!(matches!(
+            client.next_step_metered("task", &[]),
+            Err(AgentError::Model(_))
+        ));
     }
 
     #[test]

--- a/rust-core/crates/friday-storage/src/agent_run_read.rs
+++ b/rust-core/crates/friday-storage/src/agent_run_read.rs
@@ -30,11 +30,12 @@ pub struct AgentRunSummary {
 
 /// DB-wide token totals summed over `token_ledger`.
 ///
-/// HONEST SCOPE: these are **DB-wide**, NOT run-attributable. `token_ledger` has
-/// no `run_id` column, and the agent loop does not write `token_ledger` rows
-/// (loop-level token ledgering is a known gap — see `friday_hub::runtime`). For a
-/// run-only Hub DB these are therefore `0`. Surfaced anyway so the readback shape
-/// is stable, but the caller must label them as DB-wide, never as this run's cost.
+/// HONEST SCOPE: these are **DB-wide**, NOT run-attributable — every ledger row
+/// across all runs and the single-shot ask path. As of S1.2 the agent loop DOES
+/// write `token_ledger` rows (each carries the owning `run_id`); for per-run cost
+/// use [`run_token_totals`], not this. For a run-only Hub DB with no model calls
+/// these are still `0`. Surfaced anyway so the readback shape is stable, but the
+/// caller must label them as DB-wide, never as one run's cost.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub struct DbWideTokenTotals {
     pub prompt: i64,
@@ -86,6 +87,30 @@ pub fn db_wide_token_totals(conn: &Connection) -> Result<DbWideTokenTotals> {
                 COALESCE(SUM(total_tokens), 0)
          FROM token_ledger",
         [],
+        |r| {
+            Ok(DbWideTokenTotals {
+                prompt: r.get(0)?,
+                completion: r.get(1)?,
+                total: r.get(2)?,
+            })
+        },
+    )?;
+    Ok(totals)
+}
+
+/// Run-attributable token totals over `token_ledger` for a single `run_id` (S1.2).
+///
+/// Sums ONLY the rows the agent loop billed for this run (`WHERE run_id = ?1`), so —
+/// unlike [`db_wide_token_totals`] — this IS this run's cost. Ask-path rows (NULL
+/// `run_id`) are excluded. `COALESCE(..., 0)` so an unknown / not-yet-billed run reads
+/// `0`, never NULL. Read-only.
+pub fn run_token_totals(conn: &Connection, run_id: &str) -> Result<DbWideTokenTotals> {
+    let totals = conn.query_row(
+        "SELECT COALESCE(SUM(prompt_tokens), 0),
+                COALESCE(SUM(completion_tokens), 0),
+                COALESCE(SUM(total_tokens), 0)
+         FROM token_ledger WHERE run_id = ?1",
+        [run_id],
         |r| {
             Ok(DbWideTokenTotals {
                 prompt: r.get(0)?,

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -767,7 +767,9 @@ impl Db {
     }
 
     pub fn insert_token_ledger(&self, e: &LedgerEntry) -> Result<()> {
-        insert_token_ledger_conn(&self.conn, e)?;
+        // No run attribution on the raw single-row insert (the run-scoped loop path is
+        // `record_run_model_call`); the row's `run_id` is NULL.
+        insert_token_ledger_conn(&self.conn, e, None)?;
         Ok(())
     }
 
@@ -787,7 +789,8 @@ impl Db {
             ));
         }
         let tx = self.conn.transaction()?;
-        insert_token_ledger_conn(&tx, entry)?;
+        // Ask path: DB-wide ledger row (no owning run) — `run_id` is NULL.
+        insert_token_ledger_conn(&tx, entry, None)?;
         insert_activity_conn(&tx, activity)?;
         audit::append_audit(
             &tx,
@@ -842,6 +845,43 @@ impl Db {
     }
 }
 
+/// Atomic write performed by ONE agent-loop model call — the run-attributed sibling of
+/// [`Db::record_model_call`] (the ask path). Writes a `token_ledger` row (with the owning
+/// `run_id`, S1.2 attribution), an `activity_item` receipt, and a hash-chained
+/// `audit_ledger` event in ONE transaction; if any insert fails, none persist (gate 21
+/// §2.3), so the loop can never half-bill a turn.
+///
+/// It takes a bare `&Connection` (not `&mut Db`) because the agent loop holds the Hub
+/// connection by shared reference — so it opens an `unchecked_transaction` (the same
+/// mechanism `run_loop`'s receipt writes already use). Reuses the SAME insert chokepoints
+/// as the ask path (`insert_token_ledger_conn`/`insert_activity_conn`/`append_audit`), so
+/// the loop's billing can never drift from the single-shot path's invariants
+/// (total==prompt+completion, non-negative tokens, the audit hash chain).
+///
+/// Hub-only: `audit_ledger` does not exist on a phone, so a phone connection fails closed
+/// on the audit insert. The agent loop runs only on a Hub DB by construction.
+pub fn record_run_model_call(
+    conn: &Connection,
+    run_id: &str,
+    entry: &LedgerEntry,
+    activity: &ActivityRow,
+    audit: &AuditEvent,
+) -> Result<()> {
+    let tx = conn.unchecked_transaction()?;
+    insert_token_ledger_conn(&tx, entry, Some(run_id))?;
+    insert_activity_conn(&tx, activity)?;
+    audit::append_audit(
+        &tx,
+        &audit.audit_id,
+        &audit.actor,
+        &audit.action,
+        audit.payload_ref.as_deref(),
+        audit.created_at,
+    )?;
+    tx.commit()?;
+    Ok(())
+}
+
 fn quote_existing_table(conn: &Connection, table: &str) -> Result<String> {
     if table.is_empty()
         || !table
@@ -871,7 +911,11 @@ fn quote_existing_table(conn: &Connection, table: &str) -> Result<String> {
 // Free fns so the same insert logic runs against either a Connection or a
 // Transaction (Transaction derefs to Connection).
 
-fn insert_token_ledger_conn(conn: &Connection, e: &LedgerEntry) -> Result<()> {
+fn insert_token_ledger_conn(
+    conn: &Connection,
+    e: &LedgerEntry,
+    run_id: Option<&str>,
+) -> Result<()> {
     // Persistence-boundary invariant (audit 10A Q3 / finding 3c): REJECT any row whose
     // `total_tokens` is not exactly `prompt_tokens + completion_tokens`. The
     // `LedgerEntry` constructors already recompute the total, but the struct has `pub`
@@ -920,8 +964,8 @@ fn insert_token_ledger_conn(conn: &Connection, e: &LedgerEntry) -> Result<()> {
         "INSERT INTO token_ledger
             (ledger_id, session_id, activity_id, provider_kind, model, base_url_host,
              prompt_tokens, completion_tokens, total_tokens, cost_estimate, fallback,
-             result_link, created_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+             result_link, created_at, run_id)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
         rusqlite::params![
             e.ledger_id,
             e.session_id,
@@ -935,7 +979,8 @@ fn insert_token_ledger_conn(conn: &Connection, e: &LedgerEntry) -> Result<()> {
             e.cost_estimate,
             e.fallback as i64,
             e.result_link,
-            e.created_at
+            e.created_at,
+            run_id
         ],
     )?;
     Ok(())

--- a/rust-core/crates/friday-storage/src/schema.rs
+++ b/rust-core/crates/friday-storage/src/schema.rs
@@ -157,16 +157,40 @@ pub fn hub_migrations() -> Vec<Migration> {
             destructive: false,
             up: m0012_surface_event_trace,
         },
+        // S1.2 loop-billing: run-attributable `token_ledger`. Adds a nullable `run_id`
+        // column so an agent-loop model call's ledger row can be attributed to its run
+        // (S2 readback flagged `token_ledger` had NO run_id ⇒ DB-wide, not
+        // run-attributable). Purely additive: the ask path keeps writing rows with a
+        // NULL `run_id` (no run), pre-existing rows backfill to NULL, and every existing
+        // query (incl. `db_wide_token_totals` / `list_token_usage`) is unchanged.
+        Migration {
+            version: 13,
+            name: "token_ledger_run_id",
+            destructive: false,
+            up: m0013_token_ledger_run_id,
+        },
     ]
 }
 
 pub fn phone_migrations() -> Vec<Migration> {
-    vec![Migration {
-        version: 1,
-        name: "init_phone",
-        destructive: false,
-        up: m0001_init_phone,
-    }]
+    vec![
+        Migration {
+            version: 1,
+            name: "init_phone",
+            destructive: false,
+            up: m0001_init_phone,
+        },
+        // S1.2: `token_ledger` is a SHARED table (both profiles) and the single insert
+        // chokepoint now writes a `run_id` column. The phone never runs the agent loop, so
+        // its rows always carry `run_id = NULL` — the column exists ONLY so the shared insert
+        // has the same shape on both profiles. Same additive ALTER as hub v13.
+        Migration {
+            version: 2,
+            name: "token_ledger_run_id",
+            destructive: false,
+            up: m0013_token_ledger_run_id,
+        },
+    ]
 }
 
 // --- shared table fragments -------------------------------------------------
@@ -978,4 +1002,18 @@ fn m0011_route_decision_trace(tx: &Transaction) -> rusqlite::Result<()> {
 fn m0012_surface_event_trace(tx: &Transaction) -> rusqlite::Result<()> {
     tx.execute_batch(DDL_SURFACE_EVENT_TRACE)?;
     Ok(())
+}
+
+// S1.2: run-attributable token ledger. `ALTER TABLE ... ADD COLUMN` appends a
+// nullable `run_id` at the END of the row, so positional reads of the existing 13
+// columns are unaffected and every existing explicit-column query keeps working.
+// The ask path (single-shot `record_model_call`) writes NULL `run_id` (no run); the
+// agent loop (`record_run_model_call`) writes the owning `run_id` so per-run billing
+// becomes queryable. Pre-existing rows backfill to NULL. The index keeps the
+// per-run total (`run_token_totals`) cheap.
+fn m0013_token_ledger_run_id(tx: &Transaction) -> rusqlite::Result<()> {
+    tx.execute_batch(
+        "ALTER TABLE token_ledger ADD COLUMN run_id TEXT;
+         CREATE INDEX idx_ledger_run ON token_ledger(run_id);",
+    )
 }

--- a/rust-core/crates/friday-storage/tests/atomic.rs
+++ b/rust-core/crates/friday-storage/tests/atomic.rs
@@ -87,6 +87,91 @@ fn record_model_call_rolls_back_all_three_on_failure() {
 }
 
 #[test]
+fn record_run_model_call_writes_run_attributed_ledger_activity_audit() {
+    // S1.2 loop-billing sibling of record_model_call: same atomic 3-write, but the
+    // token_ledger row carries the owning run_id (run-attributable), and it works off a
+    // bare &Connection (the agent loop holds the conn by shared ref).
+    let p = temp_db_path("run-atomic-ok");
+    let db = Db::open_hub(&p).unwrap();
+    friday_storage::record_run_model_call(
+        db.conn(),
+        "run-1",
+        &ledger("l1"),
+        &activity("a1"),
+        &audit_event("au1"),
+    )
+    .unwrap();
+    assert_eq!(db.count("token_ledger").unwrap(), 1);
+    assert_eq!(db.count("activity_item").unwrap(), 1);
+    assert_eq!(db.count("audit_ledger").unwrap(), 1);
+    assert_eq!(audit::verify_audit_chain(db.conn()).unwrap(), 1);
+    // The ledger row is attributed to the run (the S1.2 column).
+    let run_id: Option<String> = db
+        .conn()
+        .query_row(
+            "SELECT run_id FROM token_ledger WHERE ledger_id = 'l1'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(run_id.as_deref(), Some("run-1"));
+    // run-scoped total sees this row; a different run sees nothing.
+    let mine = friday_storage::agent_run_read::run_token_totals(db.conn(), "run-1").unwrap();
+    assert_eq!(mine.total, 19);
+    let other = friday_storage::agent_run_read::run_token_totals(db.conn(), "run-X").unwrap();
+    assert_eq!(other.total, 0);
+}
+
+#[test]
+fn record_run_model_call_rolls_back_all_three_on_failure() {
+    let p = temp_db_path("run-atomic-fail");
+    let db = Db::open_hub(&p).unwrap();
+    // Seed an audit row whose id the call collides with (PK clash on the audit insert),
+    // forcing the whole transaction to roll back — no half-billed run row.
+    {
+        let tx = db.conn().unchecked_transaction().unwrap();
+        audit::append_audit(&tx, "dup", "x", "seed", None, 1).unwrap();
+        tx.commit().unwrap();
+    }
+    let res = friday_storage::record_run_model_call(
+        db.conn(),
+        "run-1",
+        &ledger("l1"),
+        &activity("a1"),
+        &audit_event("dup"),
+    );
+    assert!(res.is_err(), "duplicate audit_id must fail the call");
+    assert_eq!(db.count("token_ledger").unwrap(), 0);
+    assert_eq!(db.count("activity_item").unwrap(), 0);
+    assert_eq!(db.count("audit_ledger").unwrap(), 1);
+    assert_eq!(audit::verify_audit_chain(db.conn()).unwrap(), 1);
+}
+
+#[test]
+fn ask_path_row_has_null_run_id_and_is_excluded_from_run_totals() {
+    // Backward-safety: the ask path (insert_token_ledger / record_model_call) writes
+    // NULL run_id, so an additive run_id column never mis-attributes ask-path billing to
+    // any run, and db_wide_token_totals still sees every row.
+    let p = temp_db_path("null-run");
+    let mut db = Db::open_hub(&p).unwrap();
+    db.record_model_call(&ledger("ask1"), &activity("aa1"), &audit_event("aau1"))
+        .unwrap();
+    let run_id: Option<String> = db
+        .conn()
+        .query_row(
+            "SELECT run_id FROM token_ledger WHERE ledger_id = 'ask1'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(run_id, None, "ask-path row carries no run attribution");
+    let wide = friday_storage::agent_run_read::db_wide_token_totals(db.conn()).unwrap();
+    assert_eq!(wide.total, 19, "db-wide total still sees the ask-path row");
+    let run = friday_storage::agent_run_read::run_token_totals(db.conn(), "run-1").unwrap();
+    assert_eq!(run.total, 0, "no run owns the ask-path row");
+}
+
+#[test]
 fn record_model_call_rejected_on_phone_profile() {
     let p = temp_db_path("atomic-phone");
     let mut db = Db::open_phone(&p).unwrap();

--- a/rust-core/crates/friday-storage/tests/migration.rs
+++ b/rust-core/crates/friday-storage/tests/migration.rs
@@ -5,8 +5,10 @@
 mod common;
 
 use common::temp_db_path;
-use friday_core::{ActivityState, ActivityType, SessionState};
-use friday_storage::{hub_migrations, ActivityRow, Db, Migration, Profile, StorageError};
+use friday_core::{ActivityState, ActivityType, LedgerEntry, SessionState};
+use friday_storage::{
+    hub_migrations, ActivityRow, AuditEvent, Db, Migration, Profile, StorageError,
+};
 use rusqlite::Transaction;
 
 /// The max migration version the current hub migration set reaches. Derived
@@ -41,6 +43,84 @@ fn fresh_hub_db_has_all_foundation_tables() {
             "missing table {t}: have {tables:?}"
         );
     }
+}
+
+#[test]
+fn forward_migration_adds_run_id_preserving_pre_v13_ledger_rows() {
+    // S1.2 additive migration v13: token_ledger gains a nullable run_id. A pre-v13 row
+    // (the ask path's shape) must survive forward migration with run_id backfilled to NULL
+    // (never mis-attributed to a run), and a new run-attributed loop bill must then work.
+    let p = temp_db_path("ledger-run-id-mig");
+    {
+        let mut migs = hub_migrations();
+        migs.retain(|m| m.version <= 12);
+        let db = Db::open(&p, Profile::Hub, &migs, "v12").unwrap();
+        assert_eq!(db.version().unwrap(), 12);
+        assert!(
+            db.conn()
+                .prepare("SELECT run_id FROM token_ledger")
+                .is_err(),
+            "run_id column must not exist before v13"
+        );
+        // Seed a row with the pre-v13 13-column shape (no run_id).
+        db.conn()
+            .execute(
+                "INSERT INTO token_ledger
+                    (ledger_id, session_id, activity_id, provider_kind, model, base_url_host,
+                     prompt_tokens, completion_tokens, total_tokens, cost_estimate, fallback,
+                     result_link, created_at)
+                 VALUES ('old1','s1','a1','deepseek','deepseek-v4-flash','api.deepseek.com',
+                         11, 8, 19, NULL, 0, NULL, 100)",
+                [],
+            )
+            .unwrap();
+    }
+    // Reopen with the full set -> forward-migrate to v13 (adds run_id + index).
+    let db = Db::open_hub(&p).unwrap();
+    assert_eq!(db.version().unwrap(), hub_max_version());
+    assert_eq!(db.count("token_ledger").unwrap(), 1, "pre-v13 row survived");
+    let run_id: Option<String> = db
+        .conn()
+        .query_row(
+            "SELECT run_id FROM token_ledger WHERE ledger_id = 'old1'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(run_id, None, "pre-v13 row backfills to NULL run_id");
+    // A new run-attributed loop bill works against the migrated DB.
+    let entry = LedgerEntry::friday_route(
+        "new1",
+        "run-1",
+        "a2",
+        "deepseek-v4-flash",
+        5,
+        5,
+        None,
+        None,
+        200,
+    )
+    .unwrap();
+    let activity = ActivityRow {
+        activity_id: "a2".into(),
+        session_id: Some("run-1".into()),
+        kind: ActivityType::AskReceipt,
+        state: ActivityState::Done,
+        summary: "10 tokens via deepseek-v4-flash".into(),
+        created_at: 200,
+        updated_at: 200,
+        deep_link: None,
+    };
+    let audit = AuditEvent {
+        audit_id: "au-new".into(),
+        actor: "hub-agent".into(),
+        action: "agent_loop.model_call".into(),
+        payload_ref: None,
+        created_at: 200,
+    };
+    friday_storage::record_run_model_call(db.conn(), "run-1", &entry, &activity, &audit).unwrap();
+    let mine = friday_storage::agent_run_read::run_token_totals(db.conn(), "run-1").unwrap();
+    assert_eq!(mine.total, 10);
 }
 
 #[test]


### PR DESCRIPTION
## Truth label
The Rust agent loop (`run_loop`) now **BILLS + AUDITS like the single-shot ask path** — the executeRun usage-parity FLOOR. Every model call in the loop writes ONE `token_ledger` row + ONE `AskReceipt`-equivalent receipt + ONE hash-chained audit event, atomically, reusing the ask path's proven `record_model_call` template (no new ledger semantics).

Still **PROOF-ONLY, Rust-wired-DEV** (reached via the dev `hub_run_task` bridge): `executeRun` is **NOT** replaced, the loop runs under the dev composition root, and this is **NOT a v1 GO**. The coordinator runs the live N-model-calls → N-ledger-rows proof before merge.

## Shape: additive friday-storage schema migration + REUSE of the atomic pattern
S2's readback flagged `token_ledger` has **no `run_id`** ⇒ DB-wide, not run-attributable. S1.2 needs run-scoped billing, so:

- **Migration (additive, backward-safe):** `token_ledger` gains a nullable `run_id` column + `idx_ledger_run` index. Hub **v13**, phone **v2** (the table is shared across both profiles; phone never loops, so its rows always carry `run_id = NULL` — the column exists only for shared-insert shape parity). Ask-path rows keep `run_id = NULL`; pre-existing rows backfill to NULL; `db_wide_token_totals` / `list_token_usage` are unchanged. *(`rust-core/crates/friday-storage/src/schema.rs`)*
- **`run_id` is kept OFF `friday_core::LedgerEntry`** (out of write-set — friday-core untouched). It's passed as a **separate param** to a new `friday_storage::record_run_model_call(conn, run_id, entry, activity, audit)` — the run-attributed sibling of `Db::record_model_call`, working off a bare `&Connection` (the loop holds the conn by shared ref). It reuses the SAME `insert_token_ledger_conn` / `insert_activity_conn` / `append_audit` chokepoints, so the loop's billing can never drift from the ask path's invariants (total==prompt+completion, non-negative, hash chain).
- **Billing seam:** `AgentLlmClient::next_step_metered` surfaces the chat's `ModelCallOutcome` (tokens + RESPONSE-reported model) alongside the parse result. The loop **bills on chat-success, independent of the parse** — a chat that 200'd with usage but unparseable content (the S1.1 `parse_error` mode) is still billed, exactly like the ask path (which has no parse step). The default trait impl meters nothing (mocks/tests bill nothing — every pre-S1.2 loop test stays green); the live `DeepSeekAgentLlmClient` overrides it and routes `next_step` through it (one chat call site). Gate unchanged; no new mutation path; no secrets logged.
- Added `run_token_totals(conn, run_id)` read helper + refreshed the now-stale `DbWideTokenTotals` doc comment.

Receipts are **per-model-call** (N receipts for N calls), faithfully mirroring the ask path's one-receipt-per-call.

## Base / migration-collision note
Branched off `836ffeae`, which **is `origin/main`'s tip** (PR #574, S2 readback). `origin/main`'s max hub migration is **v12**, so this PR's hub **v13** is clean — no migration-version collision.

## What I did NOT do
- **Mission-binding (`run_agent_loop_for_mission`) — DEFERRED to S1.3.** Not implemented.
- **`friday-fs` — untouched** (a concurrent lane owns it). Write-set was strictly `friday-hub/src/lib.rs` + `friday-storage/*`.
- `runtime.rs` / `friday-deepseek` / `friday-core` untouched. (Follow-up: `runtime.rs:194`'s doc comment "run_loop does not write token_ledger rows" is now stale — left for the owning lane.)

## Tests
- Loop with N model calls → N run-attributed `token_ledger` rows + N `AskReceipt` receipts + verifying audit chain (`run_token_totals` == N×tokens).
- Parse-failure-after-chat-success still bills (one row) then fails the run closed.
- Non-metering client bills nothing (the honest default).
- DeepSeek-client-level: `next_step_metered` surfaces usage even when content doesn't parse; route failure surfaces no usage.
- `record_run_model_call` writes all three atomically + rolls back on PK collision.
- Ask-path NULL `run_id` excluded from run totals; forward migration preserves pre-v13 rows (run_id backfills NULL).
- Ask-path ledger tests + S2 `db_wide_token_totals` unchanged and green.

## Local gate (actual)
- `cargo build -p friday-hub --bins`: OK
- `cargo test --workspace`: all green
- `cargo clippy --workspace --all-targets`: clean
- `npm run lint`: 0 errors (1543 pre-existing warnings on untouched files)
- `npm run typecheck`: no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)