### PR TITLE
feat(rust-hub): S3-wiring — agent loop can invoke the friday-fs primitives (read-type grounded; mutating gate-paused)

### DIFF
--- a/rust-core/crates/friday-fs/src/lib.rs
+++ b/rust-core/crates/friday-fs/src/lib.rs
@@ -394,21 +394,43 @@ pub fn write_file_within_root(
 /// The ancestor-directory TOCTOU window documented on [`open_read_within_root`] (an
 /// *ancestor* swapped for an outside-pointing symlink in the check→open window) is not
 /// closed here; the **final** component IS fully closed by `O_NOFOLLOW` + the held fd.
-/// Naming the root itself (`""`/`"."`) is a lexical rejection (parity with read/write):
-/// this API lists a *sub-path* of the trusted root, not the root.
+///
+/// Listing the trusted root ITSELF is supported: a candidate that denotes the root
+/// (`""`, `.`, or `./`) lists the canonicalized root's direct entries. This is the ONE
+/// primitive that accepts the root (read/write/stat/edit/append/delete/move still reject
+/// it via [`resolve_within_root`]) — the root is the containment boundary, not a path
+/// *above* it, so listing its children is escape-safe: `readdir` on the root fd yields the
+/// root's direct children only, with `..` excluded, so nothing above the root is ever
+/// surfaced. The root case gets the SAME final-component hardening as a sub-dir (real root
+/// opened `O_NOFOLLOW | O_NONBLOCK`, post-open `fstat` is-dir, `fdopendir`/`readdir` from
+/// the validated fd). Every NON-root candidate still flows through [`resolve_within_root`],
+/// so `..` / absolute / final-component-symlink / ancestor-symlink escapes stay rejected.
 pub fn list_dir_within_root(root: &Path, candidate: &str) -> Result<Vec<OsString>, FsError> {
     use std::os::unix::ffi::OsStrExt;
     use std::os::unix::io::IntoRawFd;
 
-    let resolved = resolve_within_root(root, candidate, /* parent_must_exist */ true)?;
+    // A candidate that denotes the root (`""`, `.`, `./`) lists the root itself. We
+    // canonicalize the root — the IDENTICAL call resolve_within_root step 2 makes (handles
+    // /tmp → /private/tmp; a non-existent root is NotFound) — and open THAT. The realpath-
+    // ancestor PARENT check is skipped here ONLY because the root has no in-bound parent to
+    // validate against (it IS the boundary), NOT because containment is relaxed: every
+    // non-root candidate still flows through resolve_within_root, so `..`/absolute/symlink/
+    // sub-path escapes remain rejected exactly as before.
+    let full = if candidate.is_empty() || candidate == "." || candidate == "./" {
+        std::fs::canonicalize(root).map_err(classify_open_err)?
+    } else {
+        resolve_within_root(root, candidate, /* parent_must_exist */ true)?.full
+    };
 
     // O_NOFOLLOW rejects a final-component symlink (ELOOP → Symlink, via classify_open_err);
     // O_NONBLOCK so the open never blocks; read(true) to read the directory's entries. We do
     // NOT pass O_DIRECTORY (see the doc comment) — the post-open fstat enforces "is a dir".
+    // (For the root case `full` is the canonicalized real root — itself never a symlink — so
+    // O_NOFOLLOW on it is correct and the dir it opens IS the trusted boundary.)
     let dir = OpenOptions::new()
         .read(true)
         .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
-        .open(&resolved.full)
+        .open(&full)
         .map_err(classify_open_err)?;
 
     // Post-open fstat: open(O_NOFOLLOW) succeeds on a regular file / FIFO as well, so require

--- a/rust-core/crates/friday-fs/tests/fs_primitives.rs
+++ b/rust-core/crates/friday-fs/tests/fs_primitives.rs
@@ -158,6 +158,48 @@ fn list_dir_on_a_regular_file_is_not_a_directory() {
     );
 }
 
+#[test]
+fn list_dir_root_candidate_lists_the_root_entries() {
+    let root = TempDir::new();
+    write_file(&root.path().join("b.txt"), "b");
+    write_file(&root.path().join("a.txt"), "a");
+    fs::create_dir(root.path().join("sub")).unwrap();
+
+    // All three root-denoting tokens (`.`, ``, `./`) list the ROOT's own direct entries,
+    // sorted, with `.`/`..` excluded — the workspace-root listing the agent loop needs.
+    let expected = vec!["a.txt".to_string(), "b.txt".to_string(), "sub".to_string()];
+    for token in [".", "", "./"] {
+        let entries = list_dir_within_root(root.path(), token)
+            .unwrap_or_else(|e| panic!("root token {token:?} must list the root, got {e:?}"));
+        let names: Vec<String> = entries
+            .iter()
+            .map(|e| e.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(names, expected, "root token {token:?}");
+    }
+
+    // Escape-safety is preserved: only the literal root tokens bypass resolve_within_root;
+    // `..` / absolute / a final-component dir-symlink are STILL rejected.
+    assert!(matches!(
+        list_dir_within_root(root.path(), "..").unwrap_err(),
+        FsError::Lexical(PathError::Traversal)
+    ));
+    assert!(matches!(
+        list_dir_within_root(root.path(), "/etc").unwrap_err(),
+        FsError::Lexical(PathError::Absolute)
+    ));
+    let outside = TempDir::new();
+    write_file(&outside.path().join("leaked.txt"), "x");
+    symlink(outside.path(), root.path().join("link")).expect("final-component dir symlink");
+    assert!(
+        matches!(
+            list_dir_within_root(root.path(), "link").unwrap_err(),
+            FsError::Symlink
+        ),
+        "a final-component dir symlink must still be rejected even with root-listing support"
+    );
+}
+
 // ════════════════════════════ stat_file ════════════════════════════
 
 #[test]

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -634,7 +634,7 @@ impl Default for ToolRegistry {
             "edit_file",
             true,
             Risk::Medium,
-            "modify part of a file (params: path, ...)",
+            "replace the first occurrence of old_text with new_text in a file (params: path, old_text, new_text)",
         );
         r.register(
             "append_file",
@@ -1145,12 +1145,21 @@ pub trait ToolExecutor {
     fn execute(&self, action: &str, params: &[(String, String)]) -> Result<ToolReceipt, ExecError>;
 }
 
-/// The real executor: file reads/writes go through `friday-fs` hardened safe-open,
-/// contained to a workspace `root` (NEVER `std::fs` on an agent-supplied path). This
-/// slice implements `read_file` + the replace-write `write_file`; higher-risk
-/// registered tools (`delete_file`, `run_command`, `list_dir`, ...) are intentionally
-/// `Unsupported` here — they get their own safe primitives + adverse tests in a later
-/// slice. Fail-closed in every arm.
+/// The real executor: every file operation goes through a `friday-fs` hardened
+/// safe-open primitive, contained to a workspace `root` (NEVER `std::fs` on an
+/// agent-supplied path). Wired tools (S3-wiring):
+///   - **read-type** (`mutating=false` in the registry → gate `Allow`s directly): `read_file`,
+///     `list_dir`, `stat_file`. Each sets [`ToolReceipt::content`] with its result (file bytes /
+///     entry names / stat line) so the loop feeds it back to the model (bounded — see
+///     [`MAX_FEEDBACK_CONTENT_BYTES`]).
+///   - **mutating** (`mutating=true` → the gate withholds them pending owner approval; under the
+///     default deny-all policy they Pause, never execute here): `write_file`, `append_file`,
+///     `edit_file`, `delete_file`, `move_file`. They set `content: None`.
+///
+/// The executor is reached ONLY on a gate `Allow` (see [`gate_dispatch`]), so a mutating arm runs
+/// IFF a signed approval was minted — the executor itself never decides; the gate does.
+/// `search` and `run_command` are registered but have no friday-fs primitive, so they remain
+/// `Unsupported` here. Fail-closed in every arm.
 pub struct FsToolExecutor {
     root: std::path::PathBuf,
 }
@@ -1199,6 +1208,96 @@ impl ToolExecutor for FsToolExecutor {
                     action: action.to_string(),
                     summary: format!("wrote {} bytes to {path}", content.len()),
                     // A write has no result payload to feed back; the summary suffices.
+                    content: None,
+                })
+            }
+            // --- read-type tools (non-mutating → gate Allows → execute here) ---
+            "list_dir" => {
+                let path = Self::param(params, "path")?;
+                let entries =
+                    friday_fs::list_dir_within_root(&self.root, path).map_err(ExecError::Fs)?;
+                let names: Vec<String> = entries
+                    .iter()
+                    .map(|e| e.to_string_lossy().into_owned())
+                    .collect();
+                Ok(ToolReceipt {
+                    action: action.to_string(),
+                    // summary = count ONLY (it reaches the hash-chained audit ledger); the
+                    // entry NAMES go in `content` (model-facing feedback, never the ledger) —
+                    // mirrors read_file keeping the file bytes out of the ledger summary.
+                    summary: format!("listed {} entries in {path}", names.len()),
+                    content: Some(names.join("\n")),
+                })
+            }
+            "stat_file" => {
+                let path = Self::param(params, "path")?;
+                let st =
+                    friday_fs::stat_file_within_root(&self.root, path).map_err(ExecError::Fs)?;
+                let kind = match st.kind {
+                    friday_fs::FileKind::File => "file",
+                    friday_fs::FileKind::Dir => "dir",
+                    friday_fs::FileKind::Other => "other",
+                };
+                // stat metadata is small + non-sensitive, so the same line is both the log
+                // summary and the model-facing content (read-type ⇒ content MUST be set).
+                let detail = format!(
+                    "{path}: {kind}, {} bytes, mode {:o}{}",
+                    st.len,
+                    st.mode,
+                    if st.readonly { ", readonly" } else { "" }
+                );
+                Ok(ToolReceipt {
+                    action: action.to_string(),
+                    summary: format!("stat {detail}"),
+                    content: Some(detail),
+                })
+            }
+            // --- mutating tools (gate withholds under deny-all; reached ONLY on Allow) ---
+            "append_file" => {
+                let path = Self::param(params, "path")?;
+                let content = Self::param(params, "content")?;
+                friday_fs::append_file_within_root(&self.root, path, content.as_bytes())
+                    .map_err(ExecError::Fs)?;
+                Ok(ToolReceipt {
+                    action: action.to_string(),
+                    summary: format!("appended {} bytes to {path}", content.len()),
+                    content: None,
+                })
+            }
+            "edit_file" => {
+                let path = Self::param(params, "path")?;
+                let old_text = Self::param(params, "old_text")?;
+                let new_text = Self::param(params, "new_text")?;
+                // First-occurrence replace via the atomic (temp+rename) friday-fs edit.
+                friday_fs::edit_file_within_root(&self.root, path, old_text, new_text)
+                    .map_err(ExecError::Fs)?;
+                Ok(ToolReceipt {
+                    action: action.to_string(),
+                    summary: format!(
+                        "edited {path}: replaced {} bytes with {} bytes",
+                        old_text.len(),
+                        new_text.len()
+                    ),
+                    content: None,
+                })
+            }
+            "delete_file" => {
+                let path = Self::param(params, "path")?;
+                friday_fs::delete_file_within_root(&self.root, path).map_err(ExecError::Fs)?;
+                Ok(ToolReceipt {
+                    action: action.to_string(),
+                    summary: format!("deleted {path}"),
+                    content: None,
+                })
+            }
+            "move_file" => {
+                let path = Self::param(params, "path")?;
+                let target = Self::param(params, "target")?;
+                friday_fs::move_file_within_root(&self.root, path, target)
+                    .map_err(ExecError::Fs)?;
+                Ok(ToolReceipt {
+                    action: action.to_string(),
+                    summary: format!("moved {path} to {target}"),
                     content: None,
                 })
             }
@@ -2121,6 +2220,21 @@ mod tests {
         // The finish contract advertises the answer-carrying shape (Fix 2).
         assert!(p.contains("\"answer\""));
         assert!(p.contains("read notes.md")); // the task is included
+
+        // S3-wiring: every newly wired fs tool is advertised to the model (the prompt menu
+        // is derived from the SAME registry the executor + gate use), so the model is told
+        // the new tools — and their params — exist.
+        for tool in [
+            "list_dir",
+            "stat_file",
+            "append_file",
+            "edit_file",
+            "move_file",
+        ] {
+            assert!(p.contains(tool), "prompt must advertise {tool}, got: {p}");
+        }
+        // edit_file's params are spelled out so the model emits the right keys.
+        assert!(p.contains("old_text") && p.contains("new_text"));
     }
 
     #[test]
@@ -2486,10 +2600,11 @@ mod tests {
     fn unsupported_tool_errors_after_allow_without_panicking() {
         let root = TempDir::new("unsup");
         let db = Db::open_hub(&temp_path("exec-unsup")).unwrap();
-        agent_run::create_run(db.conn(), "r1", "list the dir", 1).unwrap();
-        // list_dir is registered + read-only → Allow → executor returns Unsupported.
+        agent_run::create_run(db.conn(), "r1", "search the workspace", 1).unwrap();
+        // search is registered + read-only → Allow → executor has no friday-fs primitive
+        // for it → returns Unsupported (list_dir/stat_file are now wired, so they execute).
         let client = MockAgentLlmClient {
-            proposal: raw("list_dir", &[("path", ".")]),
+            proposal: raw("search", &[("query", "needle")]),
         };
         let executor = FsToolExecutor::new(&root.0);
         let out = run_one_turn_with_executor(
@@ -2540,6 +2655,129 @@ mod tests {
             matches!(err, ExecError::Fs(_)),
             "expected Fs containment error, got {err:?}"
         );
+    }
+
+    /// S3-wiring: the read-type tools just wired (`list_dir`, `stat_file`) execute via real
+    /// friday-fs and set [`ToolReceipt::content`] with their result, so the loop can feed it
+    /// back to the model (the read_file grounding contract, extended to the new read tools).
+    /// The `summary` (which reaches the audit ledger) carries a count/metadata line only —
+    /// the entry NAMES live in `content`, which never reaches the ledger.
+    #[test]
+    fn list_dir_and_stat_file_execute_and_carry_content_in_receipt() {
+        let root = TempDir::new("readtype");
+        std::fs::create_dir(root.0.join("sub")).unwrap();
+        std::fs::write(root.0.join("sub/alpha.txt"), b"a").unwrap();
+        std::fs::write(root.0.join("sub/beta.txt"), b"bb").unwrap();
+        let executor = FsToolExecutor::new(&root.0);
+
+        // list_dir → sorted entry names in `content`; summary is a count only (ledger-safe).
+        let r = executor
+            .execute("list_dir", &[("path".to_string(), "sub".to_string())])
+            .unwrap();
+        assert_eq!(r.action, "list_dir");
+        assert_eq!(r.summary, "listed 2 entries in sub");
+        let content = r.content.expect("list_dir is read-type → content set");
+        assert_eq!(content, "alpha.txt\nbeta.txt");
+        assert!(
+            !r.summary.contains("alpha.txt"),
+            "entry names must NOT be in the ledger summary, only in content"
+        );
+
+        // stat_file → metadata line in `content` (read-type ⇒ content set).
+        let s = executor
+            .execute(
+                "stat_file",
+                &[("path".to_string(), "sub/beta.txt".to_string())],
+            )
+            .unwrap();
+        assert_eq!(s.action, "stat_file");
+        let scontent = s.content.expect("stat_file is read-type → content set");
+        assert!(
+            scontent.contains("sub/beta.txt: file, 2 bytes"),
+            "stat content was {scontent:?}"
+        );
+    }
+
+    /// S3-wiring ARM CORRECTNESS: each newly wired MUTATING arm (append/edit/move/delete)
+    /// actually performs its friday-fs side effect when invoked directly (bypassing the gate
+    /// — a legitimate unit test of the arm, exactly how `write_file`'s arm is proven). The
+    /// gate-PAUSE behavior is proven separately in
+    /// `each_mutating_fs_tool_pauses_under_deny_all_and_never_executes`; this is the ONLY
+    /// place the EXECUTION wiring of these arms is verified (the coordinator's live proof
+    /// only ever PAUSES a mutation, never executes one — that is S6).
+    #[test]
+    fn mutating_fs_arms_perform_real_side_effects_when_executed() {
+        let root = TempDir::new("mutate-arms");
+        let executor = FsToolExecutor::new(&root.0);
+
+        // append_file: create-if-absent, then positional append.
+        executor
+            .execute(
+                "append_file",
+                &[
+                    ("path".to_string(), "log.txt".to_string()),
+                    ("content".to_string(), "one\n".to_string()),
+                ],
+            )
+            .unwrap();
+        executor
+            .execute(
+                "append_file",
+                &[
+                    ("path".to_string(), "log.txt".to_string()),
+                    ("content".to_string(), "two\n".to_string()),
+                ],
+            )
+            .unwrap();
+        assert_eq!(
+            std::fs::read_to_string(root.0.join("log.txt")).unwrap(),
+            "one\ntwo\n"
+        );
+
+        // edit_file: replace the FIRST occurrence of old_text with new_text.
+        std::fs::write(root.0.join("doc.txt"), b"hello OLD world OLD").unwrap();
+        let e = executor
+            .execute(
+                "edit_file",
+                &[
+                    ("path".to_string(), "doc.txt".to_string()),
+                    ("old_text".to_string(), "OLD".to_string()),
+                    ("new_text".to_string(), "NEW".to_string()),
+                ],
+            )
+            .unwrap();
+        assert_eq!(e.action, "edit_file");
+        assert_eq!(
+            std::fs::read_to_string(root.0.join("doc.txt")).unwrap(),
+            "hello NEW world OLD"
+        );
+
+        // move_file: src → target (src gone, target carries the bytes).
+        std::fs::write(root.0.join("from.txt"), b"payload").unwrap();
+        executor
+            .execute(
+                "move_file",
+                &[
+                    ("path".to_string(), "from.txt".to_string()),
+                    ("target".to_string(), "to.txt".to_string()),
+                ],
+            )
+            .unwrap();
+        assert!(!root.0.join("from.txt").exists());
+        assert_eq!(
+            std::fs::read_to_string(root.0.join("to.txt")).unwrap(),
+            "payload"
+        );
+
+        // delete_file: remove the regular file.
+        std::fs::write(root.0.join("trash.txt"), b"x").unwrap();
+        executor
+            .execute(
+                "delete_file",
+                &[("path".to_string(), "trash.txt".to_string())],
+            )
+            .unwrap();
+        assert!(!root.0.join("trash.txt").exists());
     }
 
     /// LIVE end-to-end (runtime-proven, the UNW-001 read-only path). Ignored in CI (no
@@ -3011,6 +3249,168 @@ mod tests {
         assert!(friday_storage::audit::verify_audit_chain(db.conn()).is_ok());
     }
 
+    /// S3-wiring: a read-type `list_dir` result is fed BACK into the next model turn's prompt
+    /// (bounded), exactly like `read_file` — so the model can ground its answer on the listing
+    /// instead of re-running the tool. (stat_file's content rides the SAME path; this proves
+    /// the read-type feedback wiring end-to-end through the loop.)
+    #[test]
+    fn loop_feeds_list_dir_content_back_into_model_prompt() {
+        let root = TempDir::new("loop-listdir");
+        std::fs::create_dir(root.0.join("sub")).unwrap();
+        std::fs::write(root.0.join("sub/report.md"), b"x").unwrap();
+        std::fs::write(root.0.join("sub/budget.csv"), b"y").unwrap();
+        let db = Db::open_hub(&temp_path("loop-listdir")).unwrap();
+        agent_run::create_run(db.conn(), "r1", "what files are in sub", 1).unwrap();
+        let client = CapturingAgentLlmClient::new(vec![
+            AgentStep::Tool(raw("list_dir", &[("path", "sub")])),
+            AgentStep::Finish {
+                message: "report.md, budget.csv".to_string(),
+            },
+        ]);
+        let executor = FsToolExecutor::new(&root.0);
+        let out = run_loop(
+            &client,
+            &executor,
+            db.conn(),
+            "r1",
+            "what files are in sub",
+            "",
+            SECRET,
+            &no_approval(),
+            10,
+            1000,
+        )
+        .unwrap();
+        assert_eq!(out.status, LoopStatus::Finished);
+        let prompts = client.prompts.borrow();
+        assert_eq!(prompts.len(), 2);
+        // Turn 1 had no history yet.
+        assert!(!prompts[0].contains("budget.csv"));
+        // Turn 2 (after the list_dir) sees the ACTUAL sorted entries fed back.
+        assert!(
+            prompts[1].contains("budget.csv") && prompts[1].contains("report.md"),
+            "second prompt must carry the listing, got: {}",
+            prompts[1]
+        );
+        assert!(friday_storage::audit::verify_audit_chain(db.conn()).is_ok());
+    }
+
+    /// S3-wiring SAFETY (the load-bearing test): EACH newly wired mutating fs tool is
+    /// classified `mutating` in the registry, so under DenyAllApprovals (`no_approval`) the
+    /// gate withholds it (`RequiresApproval`) and `run_loop` PAUSES — the executor is NEVER
+    /// invoked (the `CountingExecutor` records ZERO calls) and NO filesystem side effect
+    /// occurs. The agent can never self-complete a mutation; only a signed owner approval
+    /// (S6) ever reaches the arm. Covers write_file + the four new arms append/edit/move/delete.
+    #[test]
+    fn each_mutating_fs_tool_pauses_under_deny_all_and_never_executes() {
+        // Drive ONE proposed mutating tool through the whole loop under DenyAllApprovals,
+        // returning the outcome AND the executor-call count (must be 0 — gate before dispatch).
+        fn run_one(root: &std::path::Path, call: RawToolCall) -> (LoopOutcome, usize) {
+            let db = Db::open_hub(&temp_path("mutpause")).unwrap();
+            agent_run::create_run(db.conn(), "r1", "mutate", 1).unwrap();
+            let client = ScriptedAgentLlmClient::new(vec![AgentStep::Tool(call)]);
+            let fs_exec = FsToolExecutor::new(root);
+            let counting = CountingExecutor {
+                inner: &fs_exec,
+                calls: std::cell::Cell::new(0),
+            };
+            let out = run_loop(
+                &client,
+                &counting,
+                db.conn(),
+                "r1",
+                "mutate",
+                "",
+                SECRET,
+                &no_approval(),
+                5,
+                1000,
+            )
+            .unwrap();
+            (out, counting.calls.get())
+        }
+
+        // write_file: would create a file → must NOT exist after a pause.
+        {
+            let root = TempDir::new("pause-write");
+            let (out, calls) = run_one(
+                &root.0,
+                raw("write_file", &[("path", "w.txt"), ("content", "X")]),
+            );
+            assert_eq!(out.status, LoopStatus::Paused, "write_file must pause");
+            assert_eq!(calls, 0, "executor never invoked for a withheld mutation");
+            assert!(!root.0.join("w.txt").exists(), "no file written");
+        }
+        // append_file: create-if-absent → the file must NOT exist after a pause.
+        {
+            let root = TempDir::new("pause-append");
+            let (out, calls) = run_one(
+                &root.0,
+                raw("append_file", &[("path", "a.txt"), ("content", "X")]),
+            );
+            assert_eq!(out.status, LoopStatus::Paused, "append_file must pause");
+            assert_eq!(calls, 0);
+            assert!(
+                !root.0.join("a.txt").exists(),
+                "append must not have created the file"
+            );
+        }
+        // edit_file: an existing file must be byte-for-byte unchanged.
+        {
+            let root = TempDir::new("pause-edit");
+            std::fs::write(root.0.join("e.txt"), b"ORIGINAL").unwrap();
+            let (out, calls) = run_one(
+                &root.0,
+                raw(
+                    "edit_file",
+                    &[
+                        ("path", "e.txt"),
+                        ("old_text", "ORIGINAL"),
+                        ("new_text", "PWNED"),
+                    ],
+                ),
+            );
+            assert_eq!(out.status, LoopStatus::Paused, "edit_file must pause");
+            assert_eq!(calls, 0);
+            assert_eq!(
+                std::fs::read_to_string(root.0.join("e.txt")).unwrap(),
+                "ORIGINAL",
+                "edit must not have modified the file"
+            );
+        }
+        // delete_file: an existing file must STILL exist.
+        {
+            let root = TempDir::new("pause-delete");
+            std::fs::write(root.0.join("d.txt"), b"KEEP").unwrap();
+            let (out, calls) = run_one(&root.0, raw("delete_file", &[("path", "d.txt")]));
+            assert_eq!(out.status, LoopStatus::Paused, "delete_file must pause");
+            assert_eq!(calls, 0);
+            assert!(
+                root.0.join("d.txt").exists(),
+                "delete must not have removed the file"
+            );
+        }
+        // move_file: source must remain, target must not be created.
+        {
+            let root = TempDir::new("pause-move");
+            std::fs::write(root.0.join("m.txt"), b"DATA").unwrap();
+            let (out, calls) = run_one(
+                &root.0,
+                raw("move_file", &[("path", "m.txt"), ("target", "moved.txt")]),
+            );
+            assert_eq!(out.status, LoopStatus::Paused, "move_file must pause");
+            assert_eq!(calls, 0);
+            assert!(
+                root.0.join("m.txt").exists(),
+                "move must not have moved the source"
+            );
+            assert!(
+                !root.0.join("moved.txt").exists(),
+                "move must not have created the target"
+            );
+        }
+    }
+
     #[test]
     fn loop_multi_turn_read_only_finishes_with_no_hidden_calls() {
         let root = TempDir::new("loop-ro");
@@ -3298,9 +3698,9 @@ mod tests {
     fn loop_exec_error_threads_back_and_continues() {
         let root = TempDir::new("loop-execerr");
         let db = Db::open_hub(&temp_path("loop-execerr")).unwrap();
-        agent_run::create_run(db.conn(), "r1", "list then finish", 1).unwrap();
+        agent_run::create_run(db.conn(), "r1", "search then finish", 1).unwrap();
         let client = ScriptedAgentLlmClient::new(vec![
-            AgentStep::Tool(raw("list_dir", &[("path", ".")])), // turn 0: Allow but Unsupported → exec_error → continue
+            AgentStep::Tool(raw("search", &[("query", "needle")])), // turn 0: Allow but Unsupported (no fs primitive) → exec_error → continue
             AgentStep::Finish {
                 message: "ok".to_string(),
             }, // turn 1: finish (loop did NOT wedge on the error)
@@ -3311,7 +3711,7 @@ mod tests {
             &executor,
             db.conn(),
             "r1",
-            "list then finish",
+            "search then finish",
             "",
             SECRET,
             &no_approval(),

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -490,6 +490,14 @@ pub fn parse_tool_call(content: &str) -> Result<RawToolCall, AgentError> {
 /// can build on what already happened or finish. Pure + deterministic.
 pub fn build_loop_prompt(task: &str, history: &[TurnTrace]) -> String {
     let mut s = build_tool_prompt(task);
+    // Root-listing hint (unconditional — the loop calls this on turn 1 with EMPTY history,
+    // which is exactly when the model first tries to list the workspace). Pass path `"."`
+    // EXPLICITLY: an omitted `path` param errors (MissingParam), so steer to `"."`/empty
+    // rather than telling the model to drop the param.
+    s.push_str(
+        "Note: to list the workspace ROOT directory, call list_dir with path \".\" \
+         (an empty path \"\" also denotes the root).\n",
+    );
     if !history.is_empty() {
         s.push_str(
             "\nSo far this run (each line is a completed step; any text after \"content:\" \

--- a/rust-core/crates/friday-hub/src/runtime.rs
+++ b/rust-core/crates/friday-hub/src/runtime.rs
@@ -191,9 +191,9 @@ impl<T: Transport> HubRuntime<T> {
     /// answer-carries-marker proof is the separate live e2e). `None` principal ⇒ empty
     /// preamble, no recall.
     ///
-    /// SCOPE: this records the audit RECEIPT; it does NOT ledger tokens — `run_loop` does
-    /// not write `token_ledger` rows (loop-level token ledgering is a separate gap), so no
-    /// token-accounting claim is made here.
+    /// SCOPE: this records the audit RECEIPT; it does NOT ledger tokens — the recall step
+    /// itself spends no model call, so no token-accounting claim is made here. (The loop's
+    /// per-turn MODEL calls ARE ledgered as of S1.2 by `run_loop` via `bill_model_call`.)
     fn recall_preamble(&self, run_id: &str, now_ms: i64) -> Result<String, RoutedLoopError> {
         // Delegates to the SHARED recall composition so the loop and the `friday_ask`
         // surface apply the identical per-item Passport gate (no divergence). The recall


### PR DESCRIPTION
## Truth label

**PROOF-ONLY, Rust-wired-DEV.** This connects the already-merged S3-substrate friday-fs primitives to the agent loop's `FsToolExecutor`. Read-type fs tools are now reachable by the loop **and grounded** (their result feeds back to the model, bounded). Mutating fs tools are **WIRED but gate-paused** under the default DenyAllApprovals policy — there is **no self-completion** (signed approval is S6's job). `executeRun` is **NOT** replaced; this is **NOT a v1 GO**.

## Tool set wired (enumerated from `friday-fs/src/lib.rs`)

| tool | friday-fs primitive | classification | receipt.content |
|---|---|---|---|
| `read_file` | `open_read_within_root` | read-type (non-mutating) | file bytes *(already wired)* |
| `list_dir` | `list_dir_within_root` | read-type (non-mutating) | sorted entry names **(new)** |
| `stat_file` | `stat_file_within_root` | read-type (non-mutating) | metadata line **(new)** |
| `write_file` | `write_file_within_root` | **mutating** (Medium) | `None` *(already wired)* |
| `append_file` | `append_file_within_root` | **mutating** (Medium) | `None` **(new)** |
| `edit_file` | `edit_file_within_root` | **mutating** (Medium) | `None` **(new)** |
| `delete_file` | `delete_file_within_root` | **mutating** (High) | `None` **(new)** |
| `move_file` | `move_file_within_root` | **mutating** (High) | `None` **(new)** |

There is **no `mkdir` or `copy` primitive** in friday-fs (the task speculated "likely mkdir/copy"); only move/delete exist, so those are the only structural mutators wired. `open_read_within_root`/`open_write_within_root` are the lower-level primitives behind the `read_file`/`write_file` tools, not separate tools. `search`/`run_command` are registered but have no fs primitive, so they stay `Unsupported`.

## Read-vs-mutating classification (how mutating tools are forced to Pause)

Classification is **not** introduced here — it already lives in the trusted `ToolRegistry::default()` (`crates/friday-hub/src/lib.rs`): each tool's `mutating` flag comes from the registry, never from model output. The gate keys `requires_approval` on that flag, and `gate_dispatch` (`crates/friday-hub/src/lib.rs`, the `GateDecision::Allow` arm is the **only** call site of `executor.execute`) reaches the executor **iff `Allow`**. So under DenyAllApprovals every mutating tool returns `RequiresApproval` → `run_loop` returns `LoopStatus::Paused` and the executor is never invoked. This PR only adds the executor dispatch arms; the safety boundary was already in place.

## Confirmation: mutating tools Pause (not execute)

`each_mutating_fs_tool_pauses_under_deny_all_and_never_executes` drives write/append/edit/delete/move through `run_loop` under `no_approval`, wrapping `FsToolExecutor` in a `CountingExecutor`, and asserts for each: `LoopStatus::Paused`, **zero** executor calls, and **no filesystem side effect** (file not created / unchanged / still present / not moved). Arm execution correctness (the wiring itself, which the Pause tests never exercise) is proven separately by direct `execute()` unit tests asserting real fs side effects, and read-type content feedback by `list_dir_and_stat_file_execute_and_carry_content_in_receipt` + `loop_feeds_list_dir_content_back_into_model_prompt`.

## Local green gate

- `cargo fmt --all` clean
- `cargo build -p friday-hub --bin hub_run_task` OK
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test -p friday-hub` — lib 270 passed / 0 failed / 8 ignored (live)
- `npm run lint` — 0 errors (pre-existing warnings only; no TS touched) · `npm run typecheck` — no errors

Files: `rust-core/crates/friday-hub/src/lib.rs` (executor dispatch + registry edit_file param spec + tests), `rust-core/crates/friday-hub/src/runtime.rs` (stale doc clause fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up fix (commit 4fc7f895): `list_dir` supports the workspace ROOT

Live diagnosis after the wiring landed: an agent asked to *"list the files in the workspace"* failed **every time** — the model calls `list_dir` on the root and gets `fs_error:lexical path rejection: Traversal`, because `resolve_within_root` rejects an empty/`.`/`./` candidate. The loop could list a *sub-dir* but never the workspace root, the primary directory op.

- **friday-fs (`list_dir_within_root`):** when the candidate denotes the root (`""`, `.`, `./`), list the **canonicalized root's** direct entries via the **SAME** hardening used for sub-dirs (open the real root `O_NOFOLLOW|O_NONBLOCK`, post-open `fstat` is-dir, `fdopendir`/`readdir` from the validated fd, `.`/`..` excluded, sorted). This is the **ONE** primitive that accepts the root — `read/write/stat/edit/append/delete/move` still reject it via `resolve_within_root`.
- **Escape-safety preserved:** the root is the containment boundary (not a path *above* it); `canonicalize(root)` is the identical call `resolve_within_root` step 2 already makes; `readdir` on the root fd yields the root's children only. Every **non-root** candidate still flows through `resolve_within_root`, so `..`/absolute/symlink/sub-path escapes stay rejected. New `fs_primitives` test covers `.`/``/`./` listing the root **and** `..`/`/etc`/final-symlink still rejected.
- **friday-hub (`build_loop_prompt`):** unconditionally (so turn 1 with empty history sees it) tells the model it can list the workspace root with `list_dir` path `"."` (or empty). The executor arm already passed the model's path through; the **mutating-tool gate classification is unchanged**.

Re-ran the full local green gate on this commit: `cargo fmt`/`build`/`clippy -D warnings` clean; `cargo test -p friday-fs -p friday-hub` — friday-fs 25+14+4 passed (incl. new `list_dir_root_candidate_lists_the_root_entries`), friday-hub 270 passed / 0 failed / 8 ignored; `npm run lint` 0 errors; `npm run typecheck` no errors. Files changed by this commit: `friday-fs/src/lib.rs`, `friday-fs/tests/fs_primitives.rs`, `friday-hub/src/lib.rs`.
