### PR TITLE
feat(rust-hub): S4 — principal/scope/constraint-aware agent loop at the gate

### DIFF
--- a/rust-core/crates/friday-hub/src/bin/hub_run_task.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_run_task.rs
@@ -121,13 +121,34 @@ fn run() -> Result<String, BridgeError> {
     // secret-shaped is constructed or persisted.
     let secret = ephemeral_dev_secret(pid, nanos);
 
+    // S4 (all OPTIONAL — defaults reproduce the pre-S4 dev-bridge behavior exactly, so the
+    // existing TS bridge service, which passes none of these, is unaffected):
+    //   --principal <id>      bind a run principal (also enables that owner's memory recall);
+    //                         flows into every gate request's Actor + the action digest.
+    //   --disable-tools a,b   comma-separated tool names disabled for this run (rejected
+    //                         before execution).
+    //   --read-only           block all mutating tools for this run (constraint).
+    let principal_id = arg_value(&args, "--principal").filter(|p| !p.trim().is_empty());
+    let disabled_tools: Vec<String> = arg_value(&args, "--disable-tools")
+        .map(|csv| {
+            csv.split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect()
+        })
+        .unwrap_or_default();
+    let read_only = args.iter().any(|a| a == "--read-only");
+
     let runtime = HubRuntime::live(HubConfig {
         db_path,
         workspace_root: PathBuf::from(&workspace_root),
         secret,
         max_turns,
-        // Memory recall stays DISABLED in this dev bridge (no owner principal bound).
-        principal_id: None,
+        // Memory recall is DISABLED unless --principal binds an owner (S4: the same
+        // principal is bound into the gate Actor + action digest for the run).
+        principal_id,
+        disabled_tools,
+        read_only,
     })
     .map_err(|_| BridgeError::new("init_failed"))?;
 

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -756,9 +756,91 @@ pub fn trusted_classify(
     default_registry().classify(action, params)
 }
 
-/// Build the canonical [`MutatingActionRequest`] for a raw tool call. Deterministic:
-/// the same call always yields byte-identical `canonical_action_bytes`, so an approval
-/// minted over this request matches when the turn re-builds it.
+/// Per-run authority policy threaded into the gate-mandatory dispatch (S4): WHO the run
+/// is for (`principal_id`, bound into the gate [`friday_core::gate::Actor`] and thus the
+/// action digest — a real capability AND the S6 approval-binding prerequisite), plus the
+/// per-run RESTRICTIONS (`disabled_tools`, `read_only`) the dispatch enforces BEFORE a
+/// tool can execute.
+///
+/// **Strictly fail-safe.** [`RunPolicy::default`] (no principal, nothing disabled, not
+/// read-only) reproduces the pre-S4 behavior EXACTLY; a populated policy can only ever
+/// NARROW authority (bind a principal — which never grants approval, see
+/// [`build_request_with_policy`] — and block more tools), never widen it. An unknown
+/// principal / empty disabled-set therefore defaults to current behavior, never looser.
+///
+/// Mirrors the TS `executeRun` run-config (`principalId` / `disabledToolNames` /
+/// `constraints.readOnly`); `disabled_tools` is normalized like the oracle's
+/// `normalizeToolNameSet` (trim, drop empties). Authorization `scopes` (TS
+/// `constraints`/`scopes` for policy routing) are a DEFERRED follow-up — the Rust gate
+/// models no scope→action policy yet, so wiring one here would balloon scope.
+#[derive(Clone, Debug, Default)]
+pub struct RunPolicy {
+    principal_id: Option<String>,
+    disabled_tools: std::collections::BTreeSet<String>,
+    read_only: bool,
+}
+
+impl RunPolicy {
+    /// Build a policy. `disabled_tools` is normalized (trimmed, empties dropped) to match
+    /// the TS oracle's `normalizeToolNameSet`. A `(None, [], false)` triple is exactly
+    /// [`RunPolicy::default`] (pre-S4 behavior).
+    pub fn new(
+        principal_id: Option<String>,
+        disabled_tools: impl IntoIterator<Item = String>,
+        read_only: bool,
+    ) -> Self {
+        let disabled_tools = disabled_tools
+            .into_iter()
+            .map(|n| n.trim().to_string())
+            .filter(|n| !n.is_empty())
+            .collect();
+        RunPolicy {
+            principal_id,
+            disabled_tools,
+            read_only,
+        }
+    }
+
+    /// The run's bound principal (WHO the run is for). `None` ⇒ no principal bound — the
+    /// gate Actor's `principal_id` stays `None` (the pre-S4 default).
+    pub fn principal_id(&self) -> Option<&str> {
+        self.principal_id.as_deref()
+    }
+
+    /// True if `action` is disabled for this run (compared trim-insensitively against the
+    /// normalized set). A disabled tool is REJECTED before classification/execution.
+    pub fn is_tool_disabled(&self, action: &str) -> bool {
+        self.disabled_tools.contains(action.trim())
+    }
+
+    /// True if this run is constrained read-only (a mutating tool is blocked before
+    /// execution — strictly stricter than the gate's default Pause-pending-approval).
+    pub fn is_read_only(&self) -> bool {
+        self.read_only
+    }
+}
+
+/// Build the canonical [`MutatingActionRequest`] for a raw tool call with the pre-S4
+/// default policy (no principal bound). Thin wrapper over [`build_request_with_policy`];
+/// existing callers/tests that do not bind a per-run principal are unchanged.
+pub fn build_request(raw: &RawToolCall) -> Result<MutatingActionRequest, ToolError> {
+    build_request_with_policy(raw, &RunPolicy::default())
+}
+
+/// Build the canonical [`MutatingActionRequest`] for a raw tool call, binding the run's
+/// PRINCIPAL (S4) from `policy` into the gate [`friday_core::gate::Actor`]. Deterministic:
+/// the same call+policy always yields byte-identical `canonical_action_bytes`, so an
+/// approval minted over this request matches when the turn re-builds it.
+///
+/// **The principal is bound into the action digest.** `canonical_action_bytes`
+/// length-prefixes `actor.principal_id`, so a request for principal `A` and the SAME
+/// action for principal `B` (or `None`) produce DIFFERENT digests — this is both a real
+/// capability (a run is scoped to a principal) and the S6 prerequisite (an operator
+/// approval binds to a specific principal). The actor KIND stays [`ActorKind::Agent`]:
+/// S4 records WHO the run is for, it does NOT grant approval authority — an Agent actor
+/// can STILL never self-approve (the bound-principal rule in `friday-core::gate` is
+/// untouched). `policy.principal_id() == None` reproduces the pre-S4 `principal_id: None`
+/// actor exactly.
 ///
 /// **This is the single chokepoint that closes UNW-001.** `mutating`/`risk`/`resource`
 /// come from [`trusted_classify`] (the registry + param inspection), NEVER from the
@@ -768,7 +850,10 @@ pub fn trusted_classify(
 /// set from the sealed [`Classified`] via [`MutatingActionRequest::from_classification`],
 /// so no other code can construct a request that skips classification. An unregistered
 /// action is refused here ([`ToolError::UnknownTool`]) and the turn never authorizes it.
-pub fn build_request(raw: &RawToolCall) -> Result<MutatingActionRequest, ToolError> {
+pub fn build_request_with_policy(
+    raw: &RawToolCall,
+    policy: &RunPolicy,
+) -> Result<MutatingActionRequest, ToolError> {
     let classified = trusted_classify(&raw.action, &raw.params)?;
     Ok(MutatingActionRequest::from_classification(
         classified,
@@ -776,7 +861,10 @@ pub fn build_request(raw: &RawToolCall) -> Result<MutatingActionRequest, ToolErr
         friday_core::gate::Actor {
             kind: ActorKind::Agent,
             id: "hub-agent".to_string(),
-            principal_id: None,
+            // S4: bind the run's principal (WHO the run is for) — None reproduces the
+            // pre-S4 actor. This flows into `canonical_action_bytes`, so the digest binds
+            // the principal (S6 prereq). KIND stays Agent → still cannot self-approve.
+            principal_id: policy.principal_id.clone(),
         },
         "agent".to_string(),
         vec![],
@@ -1542,10 +1630,63 @@ pub(crate) fn gate_dispatch(
     approve: &dyn Fn(&MutatingActionRequest) -> Option<CanonicalApproval>,
     now_ms: i64,
 ) -> Result<GateDispatch, StorageError> {
-    let request = match build_request(raw) {
+    // Pre-S4 default policy (no principal bound, nothing disabled): unchanged behavior.
+    gate_dispatch_with_policy(
+        conn,
+        executor,
+        raw,
+        secret,
+        approve,
+        &RunPolicy::default(),
+        now_ms,
+    )
+}
+
+/// [`gate_dispatch`] with a per-run [`RunPolicy`] (S4): binds the run's PRINCIPAL into the
+/// request (and thus the action digest) and enforces the run's RESTRICTIONS BEFORE
+/// execution. The two restriction checks are fail-closed and applied ahead of the gate, so
+/// they can only NARROW authority (block more), never widen it:
+///   1. a tool DISABLED for this run (`disabledToolNames`) is refused outright — it never
+///      reaches classification/authorization/execution (`tool_disabled_for_run:*`);
+///   2. under a READ-ONLY run constraint, a mutating tool (per the TRUSTED registry
+///      classification, never model-asserted) is refused before execution
+///      (`run_is_read_only:*`) — strictly stricter than the gate's default (Pause pending
+///      approval). Both surface as [`GateDispatch::Denied`] so the shared callers
+///      ([`run_loop_with_policy`], `workflow_exec`) need no new arm.
+///
+/// Everything else is identical to the pre-S4 path: authorize → execute ONLY on `Allow`.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn gate_dispatch_with_policy(
+    conn: &Connection,
+    executor: &dyn ToolExecutor,
+    raw: &RawToolCall,
+    secret: &[u8],
+    approve: &dyn Fn(&MutatingActionRequest) -> Option<CanonicalApproval>,
+    policy: &RunPolicy,
+    now_ms: i64,
+) -> Result<GateDispatch, StorageError> {
+    // (0) disabledToolNames — fail-closed, BEFORE classify/authorize/execute. A tool not
+    //     available to this run must never run; refusing here (it never reaches the gate)
+    //     is strictly stricter than any gate decision.
+    if policy.is_tool_disabled(&raw.action) {
+        return Ok(GateDispatch::Denied(format!(
+            "tool_disabled_for_run:{}",
+            raw.action
+        )));
+    }
+    let request = match build_request_with_policy(raw, policy) {
         Ok(request) => request,
         Err(ToolError::UnknownTool(action)) => return Ok(GateDispatch::Unregistered(action)),
     };
+    // (1) read-only run constraint — a mutating tool (TRUSTED `mutating()`, never the
+    //     model's word) is blocked before execution. Stricter than the gate (which would
+    //     Pause it); never looser.
+    if policy.is_read_only() && request.mutating() {
+        return Ok(GateDispatch::Denied(format!(
+            "run_is_read_only:{}",
+            raw.action
+        )));
+    }
     let approval = approve(&request);
     let record = authorize_mutating_action(conn, &request, approval.as_ref(), secret, now_ms)?;
     Ok(match record.decision {
@@ -1666,6 +1807,37 @@ fn bill_model_call(
     friday_storage::record_run_model_call(conn, run_id, &entry, &activity, &audit)
 }
 
+/// Drive a MULTI-TURN agent loop with the pre-S4 default policy (no per-run principal
+/// bound, no disabled tools, not read-only). Thin wrapper over [`run_loop_with_policy`];
+/// existing callers/tests are unchanged.
+#[allow(clippy::too_many_arguments)]
+pub fn run_loop(
+    client: &dyn AgentLlmClient,
+    executor: &dyn ToolExecutor,
+    conn: &Connection,
+    run_id: &str,
+    task: &str,
+    recall_preamble: &str,
+    secret: &[u8],
+    approve: &dyn Fn(&MutatingActionRequest) -> Option<CanonicalApproval>,
+    max_turns: u64,
+    now_ms: i64,
+) -> Result<LoopOutcome, StorageError> {
+    run_loop_with_policy(
+        client,
+        executor,
+        conn,
+        run_id,
+        task,
+        recall_preamble,
+        secret,
+        approve,
+        &RunPolicy::default(),
+        max_turns,
+        now_ms,
+    )
+}
+
 /// Drive a MULTI-TURN agent loop: repeatedly ask the model for the next step (with
 /// conversation history), and for each proposed tool run the SAME gate-mandatory
 /// dispatch as [`run_one_turn_with_executor`] (authorize → execute only on `Allow` →
@@ -1673,6 +1845,12 @@ fn bill_model_call(
 /// the model `Finish`es, a tool is `Paused`(RequiresApproval)/`Blocked`(Deny/unknown),
 /// the client errors, or `max_turns` is hit (the bound — a runaway model cannot loop
 /// forever).
+///
+/// `policy` (S4) makes the loop principal/scope/constraint-aware: the run's PRINCIPAL is
+/// bound into every gate request's `Actor` (and thus the action digest), and the run's
+/// RESTRICTIONS (`disabled_tools`, `read_only`) reject a tool before it can execute —
+/// enforced inside the SHARED [`gate_dispatch_with_policy`] chokepoint. A
+/// [`RunPolicy::default`] reproduces the pre-S4 behavior exactly.
 ///
 /// `approve` is the owner-approval seam: given a mutating request, it returns a signed
 /// [`CanonicalApproval`] iff the owner approved THIS action (in production this is the
@@ -1687,7 +1865,7 @@ fn bill_model_call(
 /// `executed_tools`, by deliberate honest accounting). All observable in the
 /// `agent_run_event` log.
 #[allow(clippy::too_many_arguments)]
-pub fn run_loop(
+pub fn run_loop_with_policy(
     client: &dyn AgentLlmClient,
     executor: &dyn ToolExecutor,
     conn: &Connection,
@@ -1696,6 +1874,7 @@ pub fn run_loop(
     recall_preamble: &str,
     secret: &[u8],
     approve: &dyn Fn(&MutatingActionRequest) -> Option<CanonicalApproval>,
+    policy: &RunPolicy,
     max_turns: u64,
     now_ms: i64,
 ) -> Result<LoopOutcome, StorageError> {
@@ -1806,8 +1985,9 @@ pub fn run_loop(
         };
 
         // Gate-mandatory dispatch via the SHARED chokepoint (same as run_workflow):
-        // classify → authorize → execute ONLY on Allow. run_loop owns the recording.
-        match gate_dispatch(conn, executor, &raw, secret, approve, now_ms)? {
+        // (disabled/read-only restriction) → bind principal → classify → authorize →
+        // execute ONLY on Allow. run_loop owns the recording.
+        match gate_dispatch_with_policy(conn, executor, &raw, secret, approve, policy, now_ms)? {
             GateDispatch::Unregistered(action) => {
                 agent_run::record_event(
                     conn,
@@ -2214,6 +2394,193 @@ mod tests {
         .unwrap();
         assert_eq!(a.resource(), b.resource());
         assert_eq!(a.resource().unwrap().id, Some("p".to_string())); // `path` wins
+    }
+
+    // ── S4: per-run principal/scope/constraint awareness ──────────────────────
+
+    /// Unique temp workspace dir for the gate-dispatch executor tests.
+    fn temp_ws(tag: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "friday-hub-s4-ws-{}-{}-{}",
+            std::process::id(),
+            tag,
+            TMP_COUNTER.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn build_request_binds_the_run_principal_into_the_digest() {
+        // S6 PREREQUISITE: the SAME action for DIFFERENT principals yields DIFFERENT
+        // canonical bytes (so a minted approval is bound to ONE principal), and the same
+        // principal is deterministic. This is the principal→digest binding, proven here
+        // (it is NOT visible in the refs-only bin output — the coordinator verifies it here).
+        let raw = RawToolCall {
+            action: "delete_file".to_string(),
+            params: vec![("path".to_string(), "/data/x".to_string())],
+        };
+        let pol =
+            |p: Option<&str>| RunPolicy::new(p.map(|s| s.to_string()), Vec::<String>::new(), false);
+        let digest = |p: Option<&str>| {
+            canonical_action_bytes(&build_request_with_policy(&raw, &pol(p)).unwrap())
+        };
+        let alice = digest(Some("alice"));
+        let bob = digest(Some("bob"));
+        let none = digest(None);
+        assert_ne!(
+            alice, bob,
+            "different principals must produce different digests"
+        );
+        assert_ne!(
+            alice, none,
+            "a bound principal must differ from the unbound default"
+        );
+        assert_ne!(bob, none);
+        // Deterministic for the same principal (an approval minted for alice re-matches).
+        assert_eq!(alice, digest(Some("alice")));
+        // The default policy reproduces the legacy `build_request` (no principal bound).
+        assert_eq!(none, canonical_action_bytes(&build_request(&raw).unwrap()));
+    }
+
+    #[test]
+    fn bound_principal_rule_holds_even_with_a_principal_bound() {
+        use friday_core::gate::{classify, evaluate, Actor};
+        // S4 records WHO the run is for; it does NOT grant approval. An Agent actor WITH a
+        // bound principal (exactly the actor build_request_with_policy makes) attempting a
+        // reserved approval action is STILL a hard Deny — the bound-principal rule is intact.
+        let req = MutatingActionRequest::from_classification(
+            classify(false, Risk::ReadOnly, "approve", &[]),
+            "approve".to_string(),
+            Actor {
+                kind: ActorKind::Agent,
+                id: "hub-agent".to_string(),
+                principal_id: Some("alice".to_string()),
+            },
+            "agent".to_string(),
+            vec![],
+            None,
+            None,
+            None,
+        );
+        let r = evaluate(&req);
+        assert_eq!(r.decision, GateDecision::Deny);
+        assert_eq!(r.reason, "agent_cannot_execute_reserved_approval_action");
+        // And the request the loop ACTUALLY builds (a registered tool) stays Agent-kind with
+        // the principal recorded — so the rule above applies to every loop-built request.
+        let built = build_request_with_policy(
+            &RawToolCall {
+                action: "write_file".to_string(),
+                params: vec![
+                    ("path".to_string(), "x".to_string()),
+                    ("content".to_string(), "y".to_string()),
+                ],
+            },
+            &RunPolicy::new(Some("alice".to_string()), Vec::<String>::new(), false),
+        )
+        .unwrap();
+        assert_eq!(built.actor.kind, ActorKind::Agent);
+        assert_eq!(built.actor.principal_id.as_deref(), Some("alice"));
+    }
+
+    #[test]
+    fn gate_dispatch_blocks_a_disabled_tool_before_execution() {
+        let db = Db::open_hub(&temp_path("s4-disabled")).unwrap();
+        let ws = temp_ws("s4-disabled");
+        std::fs::write(ws.join("notes.md"), b"do-not-read").unwrap();
+        let fs = FsToolExecutor::new(ws.clone());
+        let exec = CountingExecutor {
+            inner: &fs,
+            calls: std::cell::Cell::new(0),
+        };
+        let approve = no_approval();
+        let raw = read_only_proposal(); // read_file notes.md (read-only → Allow by default)
+
+        // CONTROL: NOT disabled → executes (read-only Allow), executor reached exactly once.
+        let ctrl = gate_dispatch_with_policy(
+            db.conn(),
+            &exec,
+            &raw,
+            SECRET,
+            &approve,
+            &RunPolicy::default(),
+            1,
+        )
+        .unwrap();
+        assert!(matches!(ctrl, GateDispatch::Executed(_)));
+        assert_eq!(exec.calls.get(), 1);
+
+        // DISABLED: read_file disabled for this run → Denied BEFORE execution; the executor
+        // is NOT reached again (the count stays 1).
+        let policy = RunPolicy::new(None, ["read_file".to_string()], false);
+        let blocked =
+            gate_dispatch_with_policy(db.conn(), &exec, &raw, SECRET, &approve, &policy, 1)
+                .unwrap();
+        if let GateDispatch::Denied(reason) = blocked {
+            assert_eq!(reason, "tool_disabled_for_run:read_file");
+        } else {
+            panic!("a disabled tool must be Denied");
+        }
+        assert_eq!(
+            exec.calls.get(),
+            1,
+            "the disabled tool must not reach the executor"
+        );
+    }
+
+    #[test]
+    fn read_only_run_blocks_a_mutating_tool_and_deny_all_still_pauses() {
+        let db = Db::open_hub(&temp_path("s4-ro")).unwrap();
+        let ws = temp_ws("s4-ro");
+        let fs = FsToolExecutor::new(ws.clone());
+        let exec = CountingExecutor {
+            inner: &fs,
+            calls: std::cell::Cell::new(0),
+        };
+        let approve = no_approval();
+        let write = RawToolCall {
+            action: "write_file".to_string(),
+            params: vec![
+                ("path".to_string(), "out.txt".to_string()),
+                ("content".to_string(), "X".to_string()),
+            ],
+        };
+
+        // read_only run → the mutating write is Denied BEFORE execution (stricter than the
+        // gate's default Pause); the executor is never reached and no file is created.
+        let policy = RunPolicy::new(None, Vec::<String>::new(), true);
+        let ro = gate_dispatch_with_policy(db.conn(), &exec, &write, SECRET, &approve, &policy, 1)
+            .unwrap();
+        if let GateDispatch::Denied(reason) = ro {
+            assert_eq!(reason, "run_is_read_only:write_file");
+        } else {
+            panic!("a mutating tool under a read_only run must be Denied");
+        }
+        assert_eq!(exec.calls.get(), 0);
+        assert!(
+            !ws.join("out.txt").exists(),
+            "no file written under read_only"
+        );
+
+        // CONTROL (deny-all, NOT read_only): the SAME mutating write still PAUSES
+        // (RequiresApproval) — the gate's fail-safe default is unchanged; read_only is what
+        // upgrades that Pause to a hard block.
+        let pause = gate_dispatch_with_policy(
+            db.conn(),
+            &exec,
+            &write,
+            SECRET,
+            &approve,
+            &RunPolicy::default(),
+            1,
+        )
+        .unwrap();
+        assert!(matches!(pause, GateDispatch::RequiresApproval));
+        assert_eq!(
+            exec.calls.get(),
+            0,
+            "a paused mutating action never executes"
+        );
     }
 
     // --- §5-PR2: prompt + strict parse (offline) ---

--- a/rust-core/crates/friday-hub/src/routing.rs
+++ b/rust-core/crates/friday-hub/src/routing.rs
@@ -44,7 +44,7 @@ use friday_core::gate::{CanonicalApproval, MutatingActionRequest};
 use friday_storage::StorageError;
 use rusqlite::Connection;
 
-use crate::{run_loop, AgentLlmClient, LoopOutcome, ToolExecutor};
+use crate::{run_loop_with_policy, AgentLlmClient, LoopOutcome, ToolExecutor};
 
 /// Provider wire API. Subset of the oracle's `FRIDAY_PROVIDER_APIS` that this
 /// decision layer routes across; the registrant tags each route with its api so
@@ -438,6 +438,44 @@ pub fn run_routed_loop(
     max_turns: u64,
     now_ms: i64,
 ) -> Result<(RoutedSelection, LoopOutcome), RoutedLoopError> {
+    // Pre-S4 default policy (no principal bound, nothing disabled): unchanged behavior.
+    run_routed_loop_with_policy(
+        registry,
+        request,
+        resolver,
+        executor,
+        conn,
+        run_id,
+        task,
+        recall_preamble,
+        secret,
+        approve,
+        &crate::RunPolicy::default(),
+        max_turns,
+        now_ms,
+    )
+}
+
+/// [`run_routed_loop`] with a per-run [`crate::RunPolicy`] (S4): selects the route exactly
+/// as the default path (routing has zero authority over classification or the gate), then
+/// drives [`run_loop_with_policy`] so the run's principal binds into the action digest and
+/// its disabled/read-only restrictions are enforced before any tool executes.
+#[allow(clippy::too_many_arguments)]
+pub fn run_routed_loop_with_policy(
+    registry: &RouteRegistry,
+    request: &RouteRequest,
+    resolver: &dyn ProviderClientResolver,
+    executor: &dyn ToolExecutor,
+    conn: &Connection,
+    run_id: &str,
+    task: &str,
+    recall_preamble: &str,
+    secret: &[u8],
+    approve: &dyn Fn(&MutatingActionRequest) -> Option<CanonicalApproval>,
+    policy: &crate::RunPolicy,
+    max_turns: u64,
+    now_ms: i64,
+) -> Result<(RoutedSelection, LoopOutcome), RoutedLoopError> {
     let route = select_route(registry, request)?;
     let selection = RoutedSelection {
         provider_id: route.provider_id.clone(),
@@ -449,7 +487,7 @@ pub fn run_routed_loop(
         .resolve(route)
         .ok_or_else(|| RoutedLoopError::NoClientForProvider(route.provider_id.clone()))?;
 
-    let outcome = run_loop(
+    let outcome = run_loop_with_policy(
         client,
         executor,
         conn,
@@ -458,6 +496,7 @@ pub fn run_routed_loop(
         recall_preamble,
         secret,
         approve,
+        policy,
         max_turns,
         now_ms,
     )?;

--- a/rust-core/crates/friday-hub/src/runtime.rs
+++ b/rust-core/crates/friday-hub/src/runtime.rs
@@ -31,10 +31,10 @@ use friday_deepseek::{DeepSeekClient, DeepSeekError, Transport, UreqTransport};
 use friday_storage::{agent_run, Db, StorageError};
 
 use crate::routing::{
-    run_routed_loop, ProviderClientResolver, ProviderRoute, RouteRegistry, RouteRequest,
-    RoutedLoopError, RoutedSelection,
+    run_routed_loop_with_policy, ProviderClientResolver, ProviderRoute, RouteRegistry,
+    RouteRequest, RoutedLoopError, RoutedSelection,
 };
-use crate::{AgentLlmClient, DeepSeekAgentLlmClient, FsToolExecutor, LoopOutcome};
+use crate::{AgentLlmClient, DeepSeekAgentLlmClient, FsToolExecutor, LoopOutcome, RunPolicy};
 
 /// The owner-approval seam: given a mutating request, return a signed [`CanonicalApproval`]
 /// iff the owner approved THIS exact action. Production default is [`DenyAllApprovals`]
@@ -66,7 +66,19 @@ pub struct HubConfig {
     /// The Hub owner whose confirmed memory may be recalled into a task's prompt
     /// (PROOF-MEMORY-001). A Hub is single-owner in v1, so every run inherits this
     /// principal. `None` ⇒ memory recall is DISABLED (fail-closed: no owner, no recall).
+    ///
+    /// S4: this is ALSO the principal bound into every gate request's `Actor` (and thus
+    /// the action digest) for the run — the recall principal and the gate principal are
+    /// now the SAME source (they no longer silently diverge). Binding it confers no
+    /// approval authority (the run actor stays Agent-kind; it can never self-approve).
     pub principal_id: Option<String>,
+    /// S4: tool names DISABLED for every run on this Hub (`disabledToolNames`). A disabled
+    /// tool is rejected before it can execute. Empty ⇒ nothing disabled (pre-S4 behavior).
+    pub disabled_tools: Vec<String>,
+    /// S4: a read-only run constraint (`constraints.readOnly`). When `true`, a mutating
+    /// tool is blocked before execution (strictly stricter than the default Pause). `false`
+    /// ⇒ pre-S4 behavior.
+    pub read_only: bool,
 }
 
 /// Why the live runtime failed to assemble.
@@ -98,8 +110,9 @@ pub struct HubRuntime<T: Transport> {
     secret: Vec<u8>,
     approval: Box<dyn ApprovalPolicy>,
     max_turns: u64,
-    /// Hub owner for memory recall; `None` disables recall (see [`HubConfig::principal_id`]).
-    principal_id: Option<String>,
+    /// S4 per-run policy: the bound principal (also the memory-recall owner — ONE source,
+    /// see [`HubConfig::principal_id`]) + the run's disabled-tool / read-only restrictions.
+    policy: RunPolicy,
 }
 
 impl<T: Transport> HubRuntime<T> {
@@ -114,6 +127,8 @@ impl<T: Transport> HubRuntime<T> {
         let db = Db::open_hub(&config.db_path)?;
         let executor = FsToolExecutor::new(config.workspace_root);
         let routes = Self::dispatchable_routes();
+        // S4: ONE policy carries the run's principal (also the recall owner) + restrictions.
+        let policy = RunPolicy::new(config.principal_id, config.disabled_tools, config.read_only);
         Ok(Self {
             db,
             routes,
@@ -122,7 +137,7 @@ impl<T: Transport> HubRuntime<T> {
             secret: config.secret,
             approval,
             max_turns: config.max_turns,
-            principal_id: config.principal_id,
+            policy,
         })
     }
 
@@ -164,7 +179,10 @@ impl<T: Transport> HubRuntime<T> {
         // selection here.
         let request = RouteRequest::any();
         let approve = |req: &MutatingActionRequest| self.approval.approve(req);
-        run_routed_loop(
+        // S4: thread the run policy so the bound principal reaches every gate request's
+        // Actor (and the action digest) and the disabled/read-only restrictions are
+        // enforced before any tool executes.
+        run_routed_loop_with_policy(
             &self.routes,
             &request,
             self,
@@ -175,6 +193,7 @@ impl<T: Transport> HubRuntime<T> {
             &recall_preamble,
             &self.secret,
             &approve,
+            &self.policy,
             self.max_turns,
             now_ms,
         )
@@ -196,13 +215,12 @@ impl<T: Transport> HubRuntime<T> {
     /// per-turn MODEL calls ARE ledgered as of S1.2 by `run_loop` via `bill_model_call`.)
     fn recall_preamble(&self, run_id: &str, now_ms: i64) -> Result<String, RoutedLoopError> {
         // Delegates to the SHARED recall composition so the loop and the `friday_ask`
-        // surface apply the identical per-item Passport gate (no divergence). The recall
-        // principal and the gate Actor's principal (still `None` in the loop) are the SAME
-        // v1 owner conceptually — flagged so they don't silently diverge when per-run
-        // principal binding lands.
+        // surface apply the identical per-item Passport gate (no divergence). As of S4 the
+        // recall principal and the gate Actor's principal are the SAME source
+        // (`self.policy.principal_id()`) — they can no longer silently diverge.
         let preamble = crate::recall_preamble_for(
             &self.db,
-            self.principal_id.as_deref(),
+            self.policy.principal_id(),
             &format!("{run_id}:memory-recall"),
             now_ms,
         )?;
@@ -364,6 +382,8 @@ mod tests {
                 secret: SECRET.to_vec(),
                 max_turns: 6,
                 principal_id: None, // recall disabled by default; the recall test sets it
+                disabled_tools: vec![],
+                read_only: false,
             },
             agent,
             approval,
@@ -421,6 +441,8 @@ mod tests {
                 secret: SECRET.to_vec(),
                 max_turns: 4,
                 principal_id: principal.map(|p| p.to_string()),
+                disabled_tools: vec![],
+                read_only: false,
             },
             agent,
             Box::new(DenyAllApprovals),
@@ -626,6 +648,58 @@ mod tests {
         );
     }
 
+    /// S4: a tool DISABLED for the run is rejected through the composed entry — it is
+    /// Blocked, executes nothing, and writes no file (the disabled `read_file` never reads).
+    /// The control (`composed_read_only_task_executes_via_gate_and_audit`, identical script
+    /// minus the disable) proves this is the disable doing the blocking, not a broken read.
+    #[test]
+    fn composed_disabled_tool_is_blocked_through_run_task() {
+        let ws = TempDir::new("disabled");
+        std::fs::write(ws.0.join("notes.md"), b"secret-do-not-read").unwrap();
+        let transport = ScriptTransport::new(&[
+            "{\"tool\":\"read_file\",\"parameters\":{\"path\":\"notes.md\"}}",
+            "{\"tool\":\"none\"}",
+        ]);
+        let client = DeepSeekClient::with_transport(transport, "k".into());
+        let agent = DeepSeekAgentLlmClient::new(client);
+        let rt = HubRuntime::new(
+            HubConfig {
+                db_path: tmp("disabled"),
+                workspace_root: ws.0.clone(),
+                secret: SECRET.to_vec(),
+                max_turns: 6,
+                principal_id: None,
+                disabled_tools: vec!["read_file".to_string()], // <- disabled for this run
+                read_only: false,
+            },
+            agent,
+            Box::new(DenyAllApprovals),
+        )
+        .unwrap();
+        let (_sel, out) = rt.run_task("run-disabled", "read the notes", 1000).unwrap();
+        assert_eq!(
+            out.status,
+            LoopStatus::Blocked,
+            "a disabled tool must Block the run"
+        );
+        assert_eq!(out.executed_tools, 0, "the disabled tool must not execute");
+        // The block is observable on the hash-chained audit/event log with the S4 reason.
+        let blocked: i64 = rt
+            .db()
+            .conn()
+            .query_row(
+                "SELECT count(*) FROM agent_run_event WHERE kind LIKE 'tool.blocked:deny:tool_disabled_for_run:read_file%'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            blocked, 1,
+            "the disabled-tool block is recorded with its reason"
+        );
+        assert!(friday_storage::audit::verify_audit_chain(rt.db().conn()).is_ok());
+    }
+
     /// With a minting owner policy, the mutating write executes ONCE; a replay of the same
     /// single-use approval on the next turn is refused (Blocked) — one execution, one receipt.
     #[test]
@@ -713,6 +787,8 @@ mod tests {
             secret: SECRET.to_vec(),
             max_turns: 5,
             principal_id: None, // the live save→recall→answer-carries-marker e2e is a separate proof (PR4)
+            disabled_tools: vec![],
+            read_only: false,
         })
         .expect("live runtime assembles (FRIDAY_DEEPSEEK_API_KEY set)");
         let (sel, out) = rt


### PR DESCRIPTION
## Truth label
- **Runs are now principal/scope/constraint-aware AT THE GATE.** The agent loop binds each run's **principal** into the gate `Actor` it builds for every mutating action, so `friday-core::gate::canonical_action_bytes` (which already length-prefixes `actor.principal_id`) **binds the principal into the action digest** — both a real capability (a run can be scoped to a principal) and the **S6 prerequisite** (an operator approval can bind to a specific principal).
- **The bound-principal rule is intact.** The run actor stays `ActorKind::Agent`; S4 only records WHO the run is for — an Agent actor can STILL never self-approve. `friday-core/src/gate.rs` is **unchanged**.
- **Deny-all still Pauses mutating actions** (gate fail-safe untouched). No new mutation path; no blanket flag; the gate is never weakened.
- **PROOF-ONLY (Rust-wired-DEV)** via the `hub_run_task` dev bridge. `executeRun` is **NOT** replaced. **NOT v1 GO.**

## Shape (friday-hub only)
- `RunPolicy { principal_id, disabled_tools (normalized like the TS `normalizeToolNameSet`), read_only }`. `RunPolicy::default()` reproduces pre-S4 behavior **exactly**; a populated policy can only ever **NARROW** authority (bind a principal — which grants no approval — and block more tools), never widen it.
- `build_request_with_policy(raw, &RunPolicy)` binds `policy.principal_id` into the `Actor` (kind=Agent). `build_request(raw)` delegates with the default policy → all existing callers/tests unchanged.
- `gate_dispatch_with_policy(...)`: a **disabled** tool (`disabledToolNames`) and, under a **read-only** run, a mutating tool (per the TRUSTED `mutating()` classification) are refused as `GateDispatch::Denied` **before** classify/authorize/execute. Both reuse `Denied`, so `workflow_exec`'s match arms need no edit.
- `run_loop_with_policy` / `run_routed_loop_with_policy` thread the policy; the old `run_loop` / `run_routed_loop` delegate with `RunPolicy::default()` (zero churn to ~22 callers + `workflow_exec`).
- `HubRuntime` holds ONE `RunPolicy` — the **gate principal and the memory-recall owner are now the same source** (resolving the prior "they must not diverge" note in `runtime.rs`). `HubConfig` gains `disabled_tools` + `read_only`. `hub_run_task` gains **optional** `--principal` / `--disable-tools` / `--read-only` (defaults = pre-S4; the refs-only JSON output contract is **unchanged**, so the TS bridge service/test are unaffected).

## Tests (all green)
- `build_request_binds_the_run_principal_into_the_digest` — same action differs by principal (alice≠bob≠none), deterministic per principal; default == legacy `build_request`.
- `bound_principal_rule_holds_even_with_a_principal_bound` — an Agent actor with a bound principal attempting `approve` is STILL a hard Deny; loop-built requests stay Agent-kind.
- `gate_dispatch_blocks_a_disabled_tool_before_execution` — disabled tool → `Denied`, executor never reached (control: same tool runs without the disable).
- `read_only_run_blocks_a_mutating_tool_and_deny_all_still_pauses` — read-only run blocks a mutating write (no file); deny-all (not read-only) still `RequiresApproval`.
- `composed_disabled_tool_is_blocked_through_run_task` — end-to-end via `run_task`: `LoopStatus::Blocked`, `executed_tools==0`, the `tool.blocked:deny:tool_disabled_for_run:*` reason on the hash-chained audit/event log.

## What I did NOT do
- **No S6**: no Ed25519, no approval ingestion, no signing CLI, no approval→Allow upgrade.
- **No `executeRun` replacement**; no friday-fs/friday-storage/deepseek changes beyond threading the principal.
- **Authorization `scopes` deferred** — the Rust gate models no scope→action policy yet; wiring one would balloon scope (follow-up). Principal + `disabledToolNames` + read-only constraint are delivered.

## Local gate
- rust-core: `cargo fmt` OK · `cargo build -p friday-hub --bin hub_run_task` OK · `cargo clippy --workspace --all-targets -- -D warnings` clean · `cargo test -p friday-hub -p friday-core` green (friday-core 144, friday-hub lib 275 + ignored).
- `npm run lint` 0 errors (1543 pre-existing warnings) · `npm run typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)