### PR TITLE
feat(rust-crypto): S6a — Ed25519 asymmetric approval primitive (operator-sign / hub-verify-only)

### DIFF
--- a/rust-core/Cargo.lock
+++ b/rust-core/Cargo.lock
@@ -106,6 +106,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "basic-toml"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,6 +270,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,6 +313,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
+ "digest",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -325,6 +338,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,6 +367,31 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -436,6 +484,8 @@ name = "friday-crypto"
 version = "0.0.1"
 dependencies = [
  "chacha20poly1305",
+ "ed25519-dalek",
+ "friday-core",
  "hkdf",
  "hmac",
  "sha2",
@@ -901,6 +951,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1236,6 +1296,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1258,6 +1327,16 @@ name = "smawk"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
 
 [[package]]
 name = "stable_deref_trait"

--- a/rust-core/Cargo.toml
+++ b/rust-core/Cargo.toml
@@ -48,6 +48,12 @@ libc = "0.2"
 # PII detection on the memory-recall path (Hub-only; ported from the oracle PII
 # guard). Pure computation, no I/O. Used only by friday-hub, never by the phone FFI.
 regex = "1.11.1"
+# Ed25519 asymmetric approval signatures (S6a). The OPERATOR holds the PRIVATE
+# signing key (offline, e.g. an S6c CLI); the Hub holds ONLY the PUBLIC verify
+# key — so the Hub (where the agent runs) can VERIFY an approval but can never
+# MINT one. Well-audited; v2.x over curve25519-dalek 4.x (already in the lock via
+# x25519-dalek). `rand_core` enables OsRng keygen; `zeroize` wipes the secret on drop.
+ed25519-dalek = { version = "2.1.1", features = ["rand_core", "zeroize"] }
 # internal crates
 friday-core = { path = "crates/friday-core" }
 friday-crypto = { path = "crates/friday-crypto" }

--- a/rust-core/crates/friday-crypto/Cargo.toml
+++ b/rust-core/crates/friday-crypto/Cargo.toml
@@ -18,3 +18,14 @@ x25519-dalek = { version = "2.0.1", features = ["static_secrets", "zeroize"] }
 hkdf = "0.12.4"
 hmac = "0.12.1"
 sha2.workspace = true
+# Ed25519 asymmetric approval primitive (S6a): operator-sign / hub-verify-only.
+ed25519-dalek.workspace = true
+
+[dev-dependencies]
+# DEV-ONLY (tests). friday-crypto stays domain-free in its shipped graph (no
+# normal friday-* dep, asserted by friday-arch-tests which scans only
+# `dependencies`/`build-dependencies`). The Ed25519 field-tamper test builds REAL
+# `CanonicalApproval` canonical bytes via the gate to prove every bound field
+# (principal/action/scope/expiry/nonce, transitively through the action digest) is
+# covered by the signature. friday-core only deps thiserror, so this is cycle-free.
+friday-core.workspace = true

--- a/rust-core/crates/friday-crypto/src/ed25519_approval.rs
+++ b/rust-core/crates/friday-crypto/src/ed25519_approval.rs
@@ -1,0 +1,472 @@
+//! Ed25519 **asymmetric** canonical-approval signatures (S6a).
+//!
+//! Today approvals use the symmetric HMAC path in [`crate::approval`]: the verify
+//! key IS the mint key, so any process that can verify (the Hub, where the agent
+//! runs) can also mint — the agent could structurally self-mint. This module adds
+//! the ASYMMETRIC alternative:
+//!
+//! - the **OPERATOR** holds the Ed25519 PRIVATE signing key, OFF the Hub (an
+//!   offline CLI signs approvals — that wiring is S6c), and
+//! - the **HUB** holds ONLY the PUBLIC verify key.
+//!
+//! The Hub can therefore VERIFY an operator-signed approval but can NEVER MINT
+//! one — the cryptographic foundation of the operator's hard rule "the agent must
+//! NEVER self-approve." This is the missing half-property of the HMAC scheme.
+//!
+//! Domain-free, exactly like [`crate::approval`]: `sign`/`verify` operate on the
+//! caller-provided canonical approval bytes — in production
+//! `friday-core::gate::canonical_approval_signature_bytes(approval)`, the SAME
+//! bytes the HMAC path covers, so nothing the HMAC path binds is left unbound
+//! here. Those bytes bind (length-prefixed) the decision, `approval_id` (the
+//! single-use nonce), the `action_digest` (= SHA-256 of `canonical_action_bytes`,
+//! which itself binds principal / actor / surface / resource(scope) / mutating /
+//! derived-risk / parameters / plan_digest / idempotency_key), the `expires_at`
+//! (expiry), and the issuer. Principal and scope are bound TRANSITIVELY through
+//! the action digest — the same property the HMAC path has.
+//!
+//! Scope (truth label): S6a adds the primitive + its verification + adversarial
+//! tests ONLY. It does NOT wire into `friday-core::gate` (that is S6b), adds NO
+//! ingestion entrypoint (S6d) and NO signing CLI (S6c). It is a STATELESS crypto
+//! verify: it (correctly) accepts the same (bytes, signature) twice — replay
+//! prevention is the gate's single-use `approval_id` store (S6b), which the signed
+//! `approval_id` here is what ENABLES. PROOF-ONLY; NOT v1 GO.
+//!
+//! Key types deliberately do not derive `Debug`, mirroring the rest of the crate,
+//! so secret bytes cannot be accidentally logged.
+
+use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey};
+use thiserror::Error;
+
+// `chacha20poly1305` re-exports a rand_core 0.6 `OsRng`, the same one
+// `session.rs` uses for X25519 keygen; it is compatible with ed25519-dalek 2.x's
+// `SigningKey::generate`. This is OS entropy (getrandom), not the JS sandbox RNG.
+use chacha20poly1305::aead::OsRng;
+
+/// Length of an Ed25519 secret seed (operator private key material).
+pub const SEED_LEN: usize = ed25519_dalek::SECRET_KEY_LENGTH; // 32
+/// Length of an Ed25519 public verify key.
+pub const VERIFYING_KEY_LEN: usize = ed25519_dalek::PUBLIC_KEY_LENGTH; // 32
+/// Length of an Ed25519 signature.
+pub const SIGNATURE_LEN: usize = ed25519_dalek::SIGNATURE_LENGTH; // 64
+
+/// Failure to parse externally-supplied Ed25519 key/signature bytes. Construction
+/// fails closed; it never panics on malformed input.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum Ed25519Error {
+    #[error("verifying-key bytes are not a valid Ed25519 public key")]
+    BadVerifyingKey,
+    #[error("signature bytes are not a valid Ed25519 signature")]
+    BadSignature,
+}
+
+/// The OPERATOR's Ed25519 PRIVATE signing key. Held OFFLINE by the operator (the
+/// S6c CLI), NEVER on the Hub. No `Debug` (key bytes cannot be logged); the inner
+/// `SigningKey` zeroizes on drop (ed25519-dalek `zeroize` feature).
+///
+/// This is the ONLY type that can produce a signature. There is no path from an
+/// [`OperatorVerifyingKey`] to this type, so holding only the verify key (as the
+/// Hub does) structurally cannot mint an approval.
+pub struct OperatorSigningKey(SigningKey);
+
+impl OperatorSigningKey {
+    /// Generate a fresh keypair from the OS CSPRNG (operator's machine).
+    pub fn generate() -> Self {
+        OperatorSigningKey(SigningKey::generate(&mut OsRng))
+    }
+
+    /// Reconstruct from a stored 32-byte secret seed (operator-side persistence,
+    /// e.g. unsealed from the operator's secure storage). Infallible: any 32 bytes
+    /// is a valid Ed25519 seed.
+    pub fn from_seed_bytes(seed: &[u8; SEED_LEN]) -> Self {
+        OperatorSigningKey(SigningKey::from_bytes(seed))
+    }
+
+    /// The 32-byte secret seed, for sealing into the OPERATOR's secure storage.
+    /// (Operator side only — the Hub never holds a signing key and never calls this.)
+    pub fn to_seed_bytes(&self) -> [u8; SEED_LEN] {
+        self.0.to_bytes()
+    }
+
+    /// The matching PUBLIC verify key — the ONLY half handed to the Hub.
+    pub fn verifying_key(&self) -> OperatorVerifyingKey {
+        OperatorVerifyingKey(self.0.verifying_key())
+    }
+
+    /// OPERATOR side: sign an approval's canonical bytes. `canonical_bytes` MUST be
+    /// `friday-core::gate::canonical_approval_signature_bytes(approval)` — the exact
+    /// bytes the HMAC path covers — so every bound field is signed. Ed25519 hashes
+    /// the message internally; the bytes are signed directly with no extra layer
+    /// (identical to the HMAC path's raw-bytes input).
+    pub fn sign(&self, canonical_bytes: &[u8]) -> ApprovalSig {
+        ApprovalSig(self.0.sign(canonical_bytes))
+    }
+}
+
+/// The OPERATOR's Ed25519 PUBLIC verify key. The Hub holds ONLY this.
+///
+/// Its API surface is deliberately minimal — `from_bytes` / `to_bytes` / `verify`
+/// — with NO method that yields a secret seed, an [`OperatorSigningKey`], or a
+/// signature. That minimal surface IS the structural "the Hub can verify but can
+/// never mint" guarantee (it is a type-level property, not a runtime check).
+#[derive(Clone)]
+pub struct OperatorVerifyingKey(VerifyingKey);
+
+impl OperatorVerifyingKey {
+    /// Parse a 32-byte public key. Fails closed (`BadVerifyingKey`) for bytes that
+    /// are not a valid Ed25519 point. Never panics.
+    pub fn from_bytes(bytes: &[u8; VERIFYING_KEY_LEN]) -> Result<Self, Ed25519Error> {
+        VerifyingKey::from_bytes(bytes)
+            .map(OperatorVerifyingKey)
+            .map_err(|_| Ed25519Error::BadVerifyingKey)
+    }
+
+    /// The 32-byte public key, e.g. to persist on the Hub.
+    pub fn to_bytes(&self) -> [u8; VERIFYING_KEY_LEN] {
+        self.0.to_bytes()
+    }
+
+    /// HUB side: verify `sig` over `canonical_bytes`. Uses `verify_strict`, which
+    /// rejects non-canonical encodings and small-order / torsion points (stronger
+    /// than the permissive `verify`). Verification is constant-time in the library.
+    /// Returns `false` on any verification failure — fails closed, never panics.
+    pub fn verify(&self, canonical_bytes: &[u8], sig: &ApprovalSig) -> bool {
+        self.0.verify_strict(canonical_bytes, &sig.0).is_ok()
+    }
+}
+
+/// An Ed25519 signature over an approval's canonical bytes. 64 bytes on the wire.
+#[derive(Clone)]
+pub struct ApprovalSig(Signature);
+
+impl ApprovalSig {
+    /// The 64 raw signature bytes (e.g. to store in `CanonicalApproval.signature`).
+    pub fn to_bytes(&self) -> [u8; SIGNATURE_LEN] {
+        self.0.to_bytes()
+    }
+
+    /// Construct from exactly 64 bytes. Infallible — any 64 bytes is a syntactic
+    /// signature; semantic validity is decided by [`OperatorVerifyingKey::verify`].
+    pub fn from_bytes(bytes: &[u8; SIGNATURE_LEN]) -> Self {
+        ApprovalSig(Signature::from_bytes(bytes))
+    }
+
+    /// Parse from an arbitrary-length slice (e.g. wire / ingestion bytes). `None`
+    /// for any length other than 64 — fails closed, never panics (this is what
+    /// makes empty / truncated / over-long signatures a clean reject upstream).
+    pub fn from_slice(bytes: &[u8]) -> Option<Self> {
+        Signature::try_from(bytes).ok().map(ApprovalSig)
+    }
+}
+
+/// HUB-side robust verify directly from raw bytes (e.g. an approval carried over
+/// the wire / read from storage). Returns `false` — never panics — for a malformed
+/// public key (wrong length / invalid point) or a malformed / empty / truncated /
+/// over-long signature. Internally `verify_strict`. Fails closed.
+pub fn verify_ed25519_approval(
+    canonical_bytes: &[u8],
+    verifying_key_bytes: &[u8],
+    signature_bytes: &[u8],
+) -> bool {
+    let vk_arr: [u8; VERIFYING_KEY_LEN] = match verifying_key_bytes.try_into() {
+        Ok(a) => a,
+        Err(_) => return false,
+    };
+    let vk = match OperatorVerifyingKey::from_bytes(&vk_arr) {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+    let sig = match ApprovalSig::from_slice(signature_bytes) {
+        Some(s) => s,
+        None => return false,
+    };
+    vk.verify(canonical_bytes, &sig)
+}
+
+/// Which signature scheme bound a canonical approval.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ApprovalScheme {
+    /// Symmetric HMAC-SHA256 ([`crate::approval`]): the verify key IS the mint key,
+    /// so any process that can verify can also mint.
+    Hmac,
+    /// Asymmetric Ed25519 (this module): the operator holds the private mint key;
+    /// the Hub holds ONLY the public verify key → the Hub cannot self-mint.
+    Ed25519,
+}
+
+/// A canonical approval's signature, TAGGED by scheme. Verification requires the
+/// key material matching the scheme, so an HMAC verify can never accept an Ed25519
+/// signature and an Ed25519 verify can never accept an HMAC signature: the
+/// mismatched-scheme call returns `false` without even consulting the key. This is
+/// the type-safe variant the gate (S6b) will branch on; S6a only defines + verifies
+/// it (it is NOT yet read by `friday-core::gate`).
+#[derive(Clone)]
+pub enum ApprovalSignature {
+    /// Hex HMAC-SHA256 (the existing [`crate::approval`] representation).
+    Hmac(String),
+    /// Ed25519 signature.
+    Ed25519(ApprovalSig),
+}
+
+impl ApprovalSignature {
+    /// The scheme this signature was produced with.
+    pub fn scheme(&self) -> ApprovalScheme {
+        match self {
+            ApprovalSignature::Hmac(_) => ApprovalScheme::Hmac,
+            ApprovalSignature::Ed25519(_) => ApprovalScheme::Ed25519,
+        }
+    }
+
+    /// Verify ONLY as HMAC, using the symmetric `secret`. An `Ed25519` variant
+    /// returns `false` (no cross-scheme acceptance) without consulting `secret`.
+    pub fn verify_hmac(&self, canonical_bytes: &[u8], secret: &[u8]) -> bool {
+        match self {
+            ApprovalSignature::Hmac(hex) => {
+                crate::approval::verify_approval_signature(canonical_bytes, secret, hex)
+            }
+            ApprovalSignature::Ed25519(_) => false,
+        }
+    }
+
+    /// Verify ONLY as Ed25519, using the operator's public verify key. An `Hmac`
+    /// variant returns `false` (no cross-scheme acceptance): a symmetric secret can
+    /// never satisfy the asymmetric path.
+    pub fn verify_ed25519(&self, canonical_bytes: &[u8], vk: &OperatorVerifyingKey) -> bool {
+        match self {
+            ApprovalSignature::Ed25519(sig) => vk.verify(canonical_bytes, sig),
+            ApprovalSignature::Hmac(_) => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MSG: &[u8] = b"friday.canonical_approval.v1|approved|ap-1|<digest>|<expiry>";
+
+    // ---- valid path -------------------------------------------------------
+
+    #[test]
+    fn valid_signature_verifies() {
+        let sk = OperatorSigningKey::generate();
+        let vk = sk.verifying_key();
+        let sig = sk.sign(MSG);
+        assert!(vk.verify(MSG, &sig), "matching key must accept");
+        // Robust raw-bytes path agrees.
+        assert!(verify_ed25519_approval(
+            MSG,
+            &vk.to_bytes(),
+            &sig.to_bytes()
+        ));
+    }
+
+    #[test]
+    fn verifying_key_round_trips_through_bytes() {
+        let sk = OperatorSigningKey::generate();
+        let vk = sk.verifying_key();
+        let vk2 = OperatorVerifyingKey::from_bytes(&vk.to_bytes()).unwrap();
+        let sig = sk.sign(MSG);
+        assert!(vk2.verify(MSG, &sig));
+    }
+
+    #[test]
+    fn signing_key_round_trips_through_seed() {
+        let sk = OperatorSigningKey::generate();
+        let seed = sk.to_seed_bytes();
+        let sk2 = OperatorSigningKey::from_seed_bytes(&seed);
+        // Same seed → same public key → signatures from either verify under either.
+        assert_eq!(
+            sk.verifying_key().to_bytes(),
+            sk2.verifying_key().to_bytes()
+        );
+        let sig = sk2.sign(MSG);
+        assert!(sk.verifying_key().verify(MSG, &sig));
+    }
+
+    // ---- forgery ----------------------------------------------------------
+
+    #[test]
+    fn random_garbage_signature_rejected() {
+        let vk = OperatorSigningKey::generate().verifying_key();
+        // 64 arbitrary (attacker-chosen) bytes are not a valid signature.
+        let garbage = [0xABu8; SIGNATURE_LEN];
+        assert!(!verify_ed25519_approval(MSG, &vk.to_bytes(), &garbage));
+        assert!(!vk.verify(MSG, &ApprovalSig::from_bytes(&garbage)));
+    }
+
+    #[test]
+    fn signature_from_a_different_key_rejected() {
+        let operator = OperatorSigningKey::generate();
+        let attacker = OperatorSigningKey::generate();
+        let sig = attacker.sign(MSG);
+        // Verifying the attacker's signature under the OPERATOR's key fails.
+        assert!(!operator.verifying_key().verify(MSG, &sig));
+        // And the operator's own signature does not verify under the attacker's key.
+        let real = operator.sign(MSG);
+        assert!(!attacker.verifying_key().verify(MSG, &real));
+    }
+
+    // ---- tamper (bytes level; field-level tamper is the integration test) --
+
+    #[test]
+    fn any_flipped_message_byte_rejected() {
+        let sk = OperatorSigningKey::generate();
+        let vk = sk.verifying_key();
+        let sig = sk.sign(MSG);
+        for i in 0..MSG.len() {
+            let mut tampered = MSG.to_vec();
+            tampered[i] ^= 0x01;
+            assert!(
+                !vk.verify(&tampered, &sig),
+                "flipping byte {i} of the signed message must reject"
+            );
+        }
+    }
+
+    // ---- malleability / malformed input (must not panic) ------------------
+
+    #[test]
+    fn empty_truncated_overlong_and_zero_signatures_rejected() {
+        let vk = OperatorSigningKey::generate().verifying_key();
+        let vkb = vk.to_bytes();
+        assert!(!verify_ed25519_approval(MSG, &vkb, b"")); // empty
+        assert!(!verify_ed25519_approval(MSG, &vkb, &[0u8; 32])); // truncated (too short)
+        assert!(!verify_ed25519_approval(MSG, &vkb, &[0u8; 63])); // 63 bytes
+        assert!(!verify_ed25519_approval(MSG, &vkb, &[0u8; 65])); // 65 bytes (over-long)
+        assert!(!verify_ed25519_approval(MSG, &vkb, &[0u8; SIGNATURE_LEN])); // all-zero
+                                                                             // from_slice also fails closed on the wrong length.
+        assert!(ApprovalSig::from_slice(b"").is_none());
+        assert!(ApprovalSig::from_slice(&[0u8; 63]).is_none());
+        assert!(ApprovalSig::from_slice(&[0u8; 65]).is_none());
+    }
+
+    #[test]
+    fn malformed_verifying_key_bytes_rejected() {
+        let sig = OperatorSigningKey::generate().sign(MSG).to_bytes();
+        assert!(!verify_ed25519_approval(MSG, b"", &sig)); // empty key
+        assert!(!verify_ed25519_approval(MSG, &[0u8; 16], &sig)); // wrong length
+        assert!(!verify_ed25519_approval(MSG, &[0u8; 33], &sig)); // wrong length
+                                                                  // An all-zero 32-byte string IS a valid (low-order) Ed25519 point, so
+                                                                  // from_bytes may succeed; verify_strict then rejects it for a real message.
+        assert!(!verify_ed25519_approval(MSG, &[0u8; 32], &sig));
+    }
+
+    /// Beyond the task's literal "malformed" list: TRUE signature malleability.
+    /// A valid signature is (R, S); replacing S with the non-canonical S + L (L =
+    /// the curve group order) satisfies the PERMISSIVE verification equation but is
+    /// a different 64-byte string. `verify_strict` rejects a non-canonical S, so the
+    /// malleated signature must NOT verify. Constructed + asserted empirically.
+    #[test]
+    fn non_canonical_s_malleability_rejected_by_verify_strict() {
+        // Little-endian encoding of L = 2^252 + 27742317777372353535851937790883648493.
+        const L_LE: [u8; 32] = [
+            0xed, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58, 0xd6, 0x9c, 0xf7, 0xa2, 0xde, 0xf9,
+            0xde, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x10,
+        ];
+        let sk = OperatorSigningKey::generate();
+        let vk = sk.verifying_key();
+        let sig = sk.sign(MSG);
+        let mut bytes = sig.to_bytes(); // [0..32]=R, [32..64]=S (LE)
+
+        // S' = S + L over the low 32 bytes (S < L < 2^253, so S+L < 2^254 fits).
+        let mut carry = 0u16;
+        for i in 0..32 {
+            let sum = bytes[32 + i] as u16 + L_LE[i] as u16 + carry;
+            bytes[32 + i] = (sum & 0xff) as u8;
+            carry = sum >> 8;
+        }
+
+        let malleated = ApprovalSig::from_bytes(&bytes);
+        // The mutated signature is a distinct byte string...
+        assert_ne!(bytes, sig.to_bytes());
+        // ...and verify_strict rejects the non-canonical S.
+        assert!(
+            !vk.verify(MSG, &malleated),
+            "verify_strict must reject a non-canonical (S + L) signature"
+        );
+    }
+
+    // ---- key separation (structural; this is a NEGATIVE test) -------------
+
+    /// NEGATIVE test (the real guarantee is STRUCTURAL — see the type docs):
+    /// `OperatorVerifyingKey`'s API exposes only {from_bytes, to_bytes, verify}, so
+    /// there is no code path from the Hub's public key to a signing key or a
+    /// signature. We cannot runtime-prove the absence of a mint path; we can show
+    /// that anything an attacker derives from ONLY the public key (here: the public
+    /// key bytes themselves, used as a candidate signature/seed) cannot mint.
+    #[test]
+    fn holding_only_the_verify_key_cannot_mint() {
+        let vk = OperatorSigningKey::generate().verifying_key();
+        let vkb = vk.to_bytes();
+
+        // Attacker has only vk bytes. Candidate "signatures" derived from them:
+        let mut padded = [0u8; SIGNATURE_LEN];
+        padded[..32].copy_from_slice(&vkb); // pubkey || zeros
+        assert!(!verify_ed25519_approval(MSG, &vkb, &padded));
+        let doubled = {
+            let mut b = [0u8; SIGNATURE_LEN];
+            b[..32].copy_from_slice(&vkb);
+            b[32..].copy_from_slice(&vkb); // pubkey || pubkey
+            b
+        };
+        assert!(!verify_ed25519_approval(MSG, &vkb, &doubled));
+
+        // And re-deriving a SIGNING key from a fresh seed yields an UNRELATED public
+        // key — i.e. the attacker cannot reconstruct the operator's signer to forge.
+        let unrelated = OperatorSigningKey::generate();
+        assert_ne!(unrelated.verifying_key().to_bytes(), vkb);
+        assert!(!vk.verify(MSG, &unrelated.sign(MSG)));
+    }
+
+    // ---- scheme separation (HMAC vs Ed25519 cannot be confused) -----------
+
+    #[test]
+    fn scheme_tag_is_reported() {
+        let sig = OperatorSigningKey::generate().sign(MSG);
+        assert_eq!(
+            ApprovalSignature::Ed25519(sig).scheme(),
+            ApprovalScheme::Ed25519
+        );
+        assert_eq!(
+            ApprovalSignature::Hmac("deadbeef".into()).scheme(),
+            ApprovalScheme::Hmac
+        );
+    }
+
+    #[test]
+    fn ed25519_signature_is_not_accepted_by_hmac_verify() {
+        let sk = OperatorSigningKey::generate();
+        let sig = sk.sign(MSG);
+        let tagged = ApprovalSignature::Ed25519(sig);
+        // Even with any HMAC secret, the Ed25519-tagged signature fails the HMAC verify.
+        assert!(!tagged.verify_hmac(MSG, b"any-hmac-secret"));
+        assert!(!tagged.verify_hmac(MSG, b""));
+    }
+
+    #[test]
+    fn hmac_signature_is_not_accepted_by_ed25519_verify() {
+        let secret = b"gate-signing-secret";
+        let hmac_hex = crate::approval::sign_approval(MSG, secret);
+        let tagged = ApprovalSignature::Hmac(hmac_hex);
+        let vk = OperatorSigningKey::generate().verifying_key();
+        // The HMAC-tagged signature fails the Ed25519 verify under any public key.
+        assert!(!tagged.verify_ed25519(MSG, &vk));
+    }
+
+    #[test]
+    fn correctly_tagged_signatures_verify_under_their_own_scheme() {
+        // Ed25519 tag + Ed25519 key → accept.
+        let sk = OperatorSigningKey::generate();
+        let vk = sk.verifying_key();
+        let ed = ApprovalSignature::Ed25519(sk.sign(MSG));
+        assert!(ed.verify_ed25519(MSG, &vk));
+        assert!(!ed.verify_hmac(MSG, b"secret"));
+
+        // HMAC tag + HMAC secret → accept.
+        let secret = b"gate-signing-secret";
+        let hm = ApprovalSignature::Hmac(crate::approval::sign_approval(MSG, secret));
+        assert!(hm.verify_hmac(MSG, secret));
+        assert!(!hm.verify_ed25519(MSG, &vk));
+    }
+}

--- a/rust-core/crates/friday-crypto/src/lib.rs
+++ b/rust-core/crates/friday-crypto/src/lib.rs
@@ -25,9 +25,14 @@ use thiserror::Error;
 use zeroize::ZeroizeOnDrop;
 
 pub mod approval;
+pub mod ed25519_approval;
 pub mod pairing;
 pub mod session;
 pub use approval::{action_digest, sign_approval, verify_approval_signature};
+pub use ed25519_approval::{
+    verify_ed25519_approval, ApprovalScheme, ApprovalSig, ApprovalSignature, Ed25519Error,
+    OperatorSigningKey, OperatorVerifyingKey,
+};
 pub use pairing::{pairing_proof, verify_pairing_proof};
 pub use session::DeviceKeypair;
 

--- a/rust-core/crates/friday-crypto/tests/ed25519_approval_adversarial.rs
+++ b/rust-core/crates/friday-crypto/tests/ed25519_approval_adversarial.rs
@@ -1,0 +1,270 @@
+//! S6a field-level adversarial proof: the Ed25519 signature over an approval's
+//! REAL canonical bytes (`friday-core::gate::canonical_approval_signature_bytes`)
+//! covers EVERY bound field — at both levels:
+//!
+//!  - approval-level (directly serialized): decision, approval_id (the single-use
+//!    nonce), action_digest (the action-hash), expires_at (expiry), issuer; and
+//!  - request-level (bound TRANSITIVELY through `action_digest =
+//!    SHA256(canonical_action_bytes)`): principal_id, action, surface, resource
+//!    (scope).
+//!
+//! For each field we sign a baseline approval, mutate exactly that field, rebuild
+//! the canonical bytes, and assert the ORIGINAL signature no longer verifies. This
+//! is the same coverage the symmetric HMAC path has — proven against the same
+//! gate-built bytes — but with operator-private-key / hub-public-key separation.
+//!
+//! `friday-core` is a DEV-only dependency here (tests build real domain bytes);
+//! `friday-crypto` stays domain-free in its shipped dependency graph.
+
+use friday_core::gate::{
+    canonical_action_bytes, canonical_approval_signature_bytes, classify, Actor, ActorKind,
+    ApprovalDecision, CanonicalApproval, MutatingActionRequest, CANONICAL_GATE_ISSUER,
+};
+use friday_core::Risk;
+use friday_crypto::ed25519_approval::OperatorSigningKey;
+
+const FUTURE: i64 = 2_000;
+
+/// Build a request through the SEALED constructor (the gate-decision trio comes
+/// from `classify`; `resource` is derived from the `path` param — mirrors the
+/// Hub's `build_request` and `friday-storage`'s authorize tests).
+fn req(action: &str, principal: &str, surface: &str, path: &str) -> MutatingActionRequest {
+    let params = vec![("path".to_string(), path.to_string())];
+    MutatingActionRequest::from_classification(
+        classify(true, Risk::Medium, action, &params),
+        action.to_string(),
+        Actor {
+            kind: ActorKind::Owner,
+            id: "owner-1".to_string(),
+            principal_id: Some(principal.to_string()),
+        },
+        surface.to_string(),
+        vec![],
+        None,
+        Some("idem-1".to_string()),
+        None,
+    )
+}
+
+fn baseline_req() -> MutatingActionRequest {
+    req("delete_file", "principal-A", "system", "/data/secret.db")
+}
+
+/// A canonical approval bound to `request`, with the given mutable fields.
+fn approval_for(
+    request: &MutatingActionRequest,
+    decision: ApprovalDecision,
+    approval_id: &str,
+    expires_at: Option<i64>,
+    issuer: Option<&str>,
+) -> CanonicalApproval {
+    CanonicalApproval {
+        decision,
+        approval_id: approval_id.to_string(),
+        action_digest: friday_crypto::action_digest(&canonical_action_bytes(request)),
+        expires_at,
+        issuer: issuer.map(|s| s.to_string()),
+        signature: None,
+    }
+}
+
+fn baseline_approval(request: &MutatingActionRequest) -> CanonicalApproval {
+    approval_for(
+        request,
+        ApprovalDecision::Approved,
+        "ap-1",
+        Some(FUTURE),
+        Some(CANONICAL_GATE_ISSUER),
+    )
+}
+
+#[test]
+fn baseline_operator_signed_approval_verifies() {
+    let sk = OperatorSigningKey::generate();
+    let vk = sk.verifying_key();
+    let req = baseline_req();
+    let appr = baseline_approval(&req);
+    let bytes = canonical_approval_signature_bytes(&appr);
+    let sig = sk.sign(&bytes);
+    assert!(
+        vk.verify(&bytes, &sig),
+        "operator-signed approval must verify"
+    );
+    // And the raw-bytes hub path agrees.
+    assert!(friday_crypto::verify_ed25519_approval(
+        &bytes,
+        &vk.to_bytes(),
+        &sig.to_bytes()
+    ));
+}
+
+/// The core proof: sign the baseline, then for each mutated approval assert the
+/// ORIGINAL signature fails — i.e. that field is bound by the signature.
+#[test]
+fn every_bound_field_is_covered_by_the_signature() {
+    let sk = OperatorSigningKey::generate();
+    let vk = sk.verifying_key();
+
+    let base_req = baseline_req();
+    let base_appr = baseline_approval(&base_req);
+    let base_bytes = canonical_approval_signature_bytes(&base_appr);
+    let sig = sk.sign(&base_bytes);
+    assert!(vk.verify(&base_bytes, &sig));
+
+    // Helper: assert the ORIGINAL signature does NOT verify over the bytes of a
+    // mutated approval (proves the mutated field is signature-bound).
+    let assert_rejected = |label: &str, mutated: &CanonicalApproval| {
+        let mutated_bytes = canonical_approval_signature_bytes(mutated);
+        assert_ne!(
+            mutated_bytes, base_bytes,
+            "{label}: mutation must change the canonical bytes"
+        );
+        assert!(
+            !vk.verify(&mutated_bytes, &sig),
+            "{label}: original signature must NOT verify over mutated bytes"
+        );
+    };
+
+    // ── approval-level fields (directly serialized) ──────────────────────────
+
+    // decision: Approved -> Denied
+    assert_rejected(
+        "decision",
+        &approval_for(
+            &base_req,
+            ApprovalDecision::Denied,
+            "ap-1",
+            Some(FUTURE),
+            Some(CANONICAL_GATE_ISSUER),
+        ),
+    );
+    // approval_id (the single-use NONCE)
+    assert_rejected(
+        "approval_id/nonce",
+        &approval_for(
+            &base_req,
+            ApprovalDecision::Approved,
+            "ap-DIFFERENT",
+            Some(FUTURE),
+            Some(CANONICAL_GATE_ISSUER),
+        ),
+    );
+    // expires_at (EXPIRY): different value
+    assert_rejected(
+        "expiry value",
+        &approval_for(
+            &base_req,
+            ApprovalDecision::Approved,
+            "ap-1",
+            Some(FUTURE + 1),
+            Some(CANONICAL_GATE_ISSUER),
+        ),
+    );
+    // expires_at: None (presence tag flips) — an attacker cannot strip the expiry.
+    assert_rejected(
+        "expiry presence",
+        &approval_for(
+            &base_req,
+            ApprovalDecision::Approved,
+            "ap-1",
+            None,
+            Some(CANONICAL_GATE_ISSUER),
+        ),
+    );
+    // issuer: different value
+    assert_rejected(
+        "issuer value",
+        &approval_for(
+            &base_req,
+            ApprovalDecision::Approved,
+            "ap-1",
+            Some(FUTURE),
+            Some("not_the_canonical_gate"),
+        ),
+    );
+    // issuer: None (presence tag flips)
+    assert_rejected(
+        "issuer presence",
+        &approval_for(
+            &base_req,
+            ApprovalDecision::Approved,
+            "ap-1",
+            Some(FUTURE),
+            None,
+        ),
+    );
+    // action_digest (ACTION-HASH) directly repointed to a different action's digest.
+    {
+        let other = req("delete_file", "principal-A", "system", "/data/OTHER.db");
+        let mut a = base_appr.clone();
+        a.action_digest = friday_crypto::action_digest(&canonical_action_bytes(&other));
+        assert_rejected("action_digest", &a);
+    }
+
+    // ── request-level fields (bound TRANSITIVELY via action_digest) ──────────
+    // Each mutates the REQUEST, recomputes action_digest, and rebuilds the approval.
+
+    // principal_id — the bound-principal field
+    assert_rejected(
+        "principal_id",
+        &baseline_approval(&req(
+            "delete_file",
+            "principal-B",
+            "system",
+            "/data/secret.db",
+        )),
+    );
+    // action (verb)
+    assert_rejected(
+        "action",
+        &baseline_approval(&req(
+            "write_file",
+            "principal-A",
+            "system",
+            "/data/secret.db",
+        )),
+    );
+    // surface
+    assert_rejected(
+        "surface",
+        &baseline_approval(&req(
+            "delete_file",
+            "principal-A",
+            "telegram",
+            "/data/secret.db",
+        )),
+    );
+    // resource / scope (the path → resource id in the digest)
+    assert_rejected(
+        "resource/scope",
+        &baseline_approval(&req(
+            "delete_file",
+            "principal-A",
+            "system",
+            "/data/OTHER.db",
+        )),
+    );
+}
+
+/// Cross-actor: an approval bound to one principal does not verify when re-pointed
+/// at a request from a DIFFERENT principal — even though the signature itself is
+/// internally valid for its own (other-principal) bytes. Proves principal binding
+/// is not bypassable by swapping the live request.
+#[test]
+fn approval_does_not_transfer_across_principals() {
+    let sk = OperatorSigningKey::generate();
+    let vk = sk.verifying_key();
+
+    let req_a = req("delete_file", "principal-A", "system", "/data/secret.db");
+    let appr_a = baseline_approval(&req_a);
+    let bytes_a = canonical_approval_signature_bytes(&appr_a);
+    let sig_a = sk.sign(&bytes_a);
+    assert!(vk.verify(&bytes_a, &sig_a)); // valid for principal-A's action
+
+    // The same approval id/expiry/issuer but bound to principal-B's action digest.
+    let req_b = req("delete_file", "principal-B", "system", "/data/secret.db");
+    let appr_b = baseline_approval(&req_b);
+    let bytes_b = canonical_approval_signature_bytes(&appr_b);
+    // principal-A's signature must NOT cover principal-B's action bytes.
+    assert!(!vk.verify(&bytes_b, &sig_a));
+}


### PR DESCRIPTION
## Truth label

S6a adds the **Ed25519 asymmetric approval primitive**: **operator-sign / hub-verify-only**. The OPERATOR holds the PRIVATE signing key (off the Hub, e.g. an offline S6c CLI); the Hub holds ONLY the PUBLIC verify key — so the Hub (where the agent runs) can VERIFY an operator-signed approval but can **never MINT** one. This is the structural foundation of the operator's hard rule "the agent must NEVER self-approve."

- **NOT yet wired into the gate** (that is S6b). No ingestion entrypoint (S6d), no signing CLI (S6c). No blanket flag.
- **HMAC path intact**: the symmetric `friday_crypto::approval` path and all existing approval/gate tests are unchanged. `friday-core/src/gate.rs` is **untouched**. Bound-principal rule unchanged.
- **Stateless verify**: it (correctly) accepts the same `(bytes, signature)` twice — replay prevention is the gate's single-use `approval_id` store (S6b), which the signed `approval_id` here is what ENABLES.
- **PROOF-ONLY; NOT v1 GO.**

## Crypto library

[`ed25519-dalek`](https://crates.io/crates/ed25519-dalek) v2.x (resolved 2.2.0), well-audited, over `curve25519-dalek` 4.1.3 (already in the lock via `x25519-dalek`). Added as a workspace dependency. Keygen reuses the rand_core 0.6 `OsRng` that `session.rs` already uses (OS entropy / `getrandom`, not the JS sandbox RNG). Verification uses `verify_strict` (rejects non-canonical encodings + small-order/torsion points).

## API shape (`friday_crypto::ed25519_approval`)

- `OperatorSigningKey` (PRIVATE, operator side; no `Debug`, zeroizes on drop): `generate` / `from_seed_bytes` / `to_seed_bytes` / `verifying_key` / `sign`. The ONLY type that can produce a signature.
- `OperatorVerifyingKey` (PUBLIC, Hub side): minimal surface `{from_bytes, to_bytes, verify}` — **no** method yielding a seed, a signing key, or a signature. That minimal surface IS the structural "verify-but-never-mint" guarantee.
- `verify_ed25519_approval(canonical_bytes, vk_bytes, sig_bytes) -> bool`: robust Hub-side raw-bytes verify; fails closed (no panic) on a malformed key or empty/truncated/over-long signature.
- `ApprovalSignature` scheme-tagged enum `{ Hmac(String), Ed25519(ApprovalSig) }` + `ApprovalScheme`: the type-safe Ed25519 approval variant. A mismatched-scheme verify returns `false`, so an HMAC verify can never accept an Ed25519 signature and vice-versa.

## Canonical-bytes coverage (every bound field)

`sign`/`verify` operate on the caller-supplied canonical bytes — in production `friday-core::gate::canonical_approval_signature_bytes(approval)` ([gate.rs:337-355](../blob/main/rust-core/crates/friday-core/src/gate.rs#L337)), the **exact same bytes the HMAC path covers**, signed directly (no extra hash layer; Ed25519 hashes internally). Those bytes bind (length-prefixed):

- **directly**: `decision`, `approval_id` (the single-use **nonce**), `action_digest` (the **action-hash**), `expires_at` (**expiry**), `issuer`.
- **transitively** via `action_digest = SHA256(canonical_action_bytes)` ([gate.rs:304-332](../blob/main/rust-core/crates/friday-core/src/gate.rs#L304)): `action`, actor `kind`/`id`/**`principal_id`**, `surface`, `resource` (**scope**), `mutating`, derived `risk`, `parameters`, `plan_digest`, `idempotency_key`.

Honest note: principal/scope are NOT separately-signed fields — they are bound through the action digest, exactly the property the HMAC path has.

## Adversarial tests (36 unit + 3 integration, all green)

- **valid**: matching key accepts; raw-bytes path agrees; key/seed round-trips.
- **forgery**: 64 attacker-chosen bytes → reject; signature from a DIFFERENT key → reject (both directions).
- **tamper (bytes)**: flipping any byte of the signed message → reject.
- **tamper (field-level, against REAL gate bytes)**: mutate exactly one field, rebuild canonical bytes, original signature fails — proven for `decision`, `approval_id`/nonce, expiry value + presence, issuer value + presence, `action_digest`, and request-level `principal_id` / `action` / `surface` / `resource`-scope; plus an approval does not transfer across principals.
- **malleability/malformed (no panic)**: empty / truncated / over-long / all-zero signature → reject; malformed verify-key bytes → reject; beyond-spec true malleability — non-canonical `S + L` → rejected by `verify_strict` (constructed + asserted empirically).
- **scheme-separation**: Ed25519-tagged sig fails HMAC verify and vice-versa; correctly-tagged sigs verify only under their own scheme.
- **key-separation** (negative test; the real guarantee is structural/type-level): anything derived from ONLY the public key cannot mint.

## Local gate (all green)

`cargo fmt --all` · `cargo build -p friday-crypto` · `cargo clippy --workspace --all-targets -- -D warnings` (exit 0) · `cargo test -p friday-crypto -p friday-core` (36 + 3 pass) · `cargo build --workspace` (lockfile resolves; additive only) · arch-tests + friday-storage tests green (HMAC path intact, dependency boundary unchanged — friday-core is a DEV-only dep of friday-crypto).

## Note for the adversarial verification pass

The canonical-bytes coverage is byte-identical to the HMAC path (same `canonical_approval_signature_bytes` input). Principal/scope binding is transitive through `action_digest` (stated honestly above). Replay across identical bytes is accepted by design (stateless verify) — that is the gate's S6b single-use store, not this primitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> **Foundation, not yet load-bearing:** until S6b restricts reserved / high-risk actions to the Ed25519-only scheme, the Hub can still mint via the symmetric HMAC path — S6a establishes the asymmetric primitive that S6b will enforce. This is the expected S6a gap, not a defect.
