### PR TITLE
feat(rust-hub): S6d — wire operator-approved mutating completion (HMAC→Ed25519 switch + resume ingestion)

### DIFF
--- a/rust-core/Cargo.lock
+++ b/rust-core/Cargo.lock
@@ -540,6 +540,7 @@ dependencies = [
  "friday-transport",
  "regex",
  "rusqlite",
+ "serde",
  "serde_json",
  "sha2",
  "thiserror 1.0.69",

--- a/rust-core/crates/friday-crypto/src/lib.rs
+++ b/rust-core/crates/friday-crypto/src/lib.rs
@@ -52,6 +52,26 @@ pub enum CryptoError {
     BadKey,
 }
 
+/// Generate a single-use approval **nonce** (the S6b/S6d pending-request
+/// `approval_id`) from the OS CSPRNG (`OsRng`, OS entropy via getrandom — NOT a
+/// counter, clock, or PID), hex-encoded. 32 bytes of entropy → 64 lowercase hex
+/// chars.
+///
+/// This is what makes the nonce the offline operator signs over UNPREDICTABLE: an
+/// attacker cannot pre-compute or guess a pending request's `approval_id`, and the
+/// gate's single-use `consumed_approval` store keys replay defense on it. Reuses the
+/// same `OsRng` source as [`DataKey::generate`] (XChaCha key material is 32 CSPRNG
+/// bytes), so no extra RNG surface is introduced.
+pub fn generate_approval_nonce() -> String {
+    let bytes = XChaCha20Poly1305::generate_key(&mut OsRng); // 32 CSPRNG bytes
+    let mut s = String::with_capacity(KEY_LEN * 2);
+    for b in bytes.as_slice() {
+        s.push(char::from_digit((b >> 4) as u32, 16).unwrap());
+        s.push(char::from_digit((b & 0x0f) as u32, 16).unwrap());
+    }
+    s
+}
+
 /// A 256-bit data key used to encrypt sensitive fields/blobs.
 #[derive(Clone, PartialEq, Eq, ZeroizeOnDrop)]
 pub struct DataKey([u8; KEY_LEN]);
@@ -274,6 +294,19 @@ mod tests {
             unwrap_data_key(&old, &wrapped_new),
             Err(CryptoError::Open)
         ));
+    }
+
+    #[test]
+    fn approval_nonce_is_csprng_unique_and_64_hex() {
+        let a = generate_approval_nonce();
+        let b = generate_approval_nonce();
+        assert_eq!(a.len(), KEY_LEN * 2, "32 bytes => 64 hex chars");
+        assert!(a
+            .bytes()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
+        // Two draws from the CSPRNG must differ (a counter/clock-derived nonce would
+        // be predictable; this is the unpredictability property S6d requires).
+        assert_ne!(a, b, "two CSPRNG nonces must not collide");
     }
 
     #[test]

--- a/rust-core/crates/friday-hub/Cargo.toml
+++ b/rust-core/crates/friday-hub/Cargo.toml
@@ -27,6 +27,9 @@ friday-fs.workspace = true
 # The live model returns free-text content; the tool-call protocol is a JSON object
 # the Hub parses back into a RawToolCall. serde_json is the strict parser for that.
 serde_json.workspace = true
+# S6d: the resume bridge bin (`hub_resume_approval`) deserializes the S6c CLI's
+# operator-signed approval JSON. Derive only; no I/O.
+serde.workspace = true
 # Refs-only hashing for the S0 dev write-bridge bin (`hub_run_task`): the final
 # message is emitted as a sha256 hash + length, never as body text. Pure hashing,
 # no I/O; already in the Hub closure via friday-storage/friday-crypto.

--- a/rust-core/crates/friday-hub/src/bin/hub_resume_approval.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_resume_approval.rs
@@ -1,0 +1,255 @@
+//! S6d dev resume bridge — `hub_resume_approval`.
+//!
+//! PROOF-ONLY (Rust-wired-DEV, the COMPLETION leg). A thin one-shot bin around
+//! [`friday_hub::resume::resume_with_approval`]: given a run that Paused on a mutating
+//! action (the loop persisted a `pending_approval_request`) and an operator-Ed25519-signed
+//! approval (the S6c CLI stdout JSON), it INGESTS the approval, VERIFIES it against the
+//! operator's PUBLIC verify key (provisioned from an OPERATOR-CONTROLLED source — never a
+//! Hub-generated key), executes the ONE approved mutation, and records a truth-labeled,
+//! proof-linked result.
+//!
+//! It NEVER mints — only verifies + consumes. A replayed / expired / wrong-digest /
+//! HMAC-signed approval is refused, and no mutation runs.
+//!
+//! ## Operator verify key (the linchpin)
+//! Resolved from `--operator-vk-path <file>` or the `FRIDAY_OPERATOR_VK_PATH` env (a file
+//! the operator wrote from the S6c CLI `keygen`). UNSET/absent ⇒ fail-closed (the bin
+//! refuses — there is no operator key to verify against, so nothing can be Allowed). The
+//! Hub never generates the key it verifies against.
+//!
+//! ## Output contract — REFS ONLY (no bodies, no secrets, no PII)
+//! Emits ONE JSON object to stdout: `truth_label="rust_wired_dev"`, `run_id`,
+//! `approval_id`, the gate decision + reason, `executed`, `result_status`, the answer
+//! fingerprint (sha256 + length) of the persisted result, and `audit_chain_verified` —
+//! NEVER any body text. A defensive output guard rejects forbidden markers before printing.
+//!
+//! ## LIVE proof is S6e
+//! This bin BUILDS in CI and is mechanism-tested via the library function. The LIVE
+//! operator-approved mutating-completion proof (with a real operator-held key) is S6e (the
+//! key-custody gate). PROOF-ONLY; NOT a v1 GO.
+
+use std::env;
+use std::io::Read;
+use std::path::Path;
+
+use friday_core::gate::{ApprovalDecision, CanonicalApproval, CANONICAL_GATE_ISSUER};
+use friday_hub::operator_vk::load_operator_vk_from_path;
+use friday_hub::resume::{resume_with_approval, ResumeError};
+use friday_hub::FsToolExecutor;
+use friday_storage::{audit::verify_audit_chain, get_run_result_ref, Db};
+use serde::Deserialize;
+use serde_json::json;
+
+/// A fail-closed error: `kind` is a coarse, safe category (the only thing surfaced).
+struct BridgeError {
+    kind: &'static str,
+}
+impl BridgeError {
+    fn new(kind: &'static str) -> Self {
+        Self { kind }
+    }
+}
+
+/// The operator-signed approval JSON the S6c CLI emits (mirrors its `SignedApproval`).
+/// Unknown fields tolerated. `scheme` is echoed for operator review; the Hub verifies it
+/// as Ed25519 regardless (it never trusts a wire-supplied scheme to pick a code path).
+#[derive(Debug, Deserialize)]
+struct SignedApprovalIn {
+    decision: String,
+    approval_id: String,
+    action_digest: String,
+    expires_at: i64,
+    #[serde(default)]
+    issuer: Option<String>,
+    signature: String,
+}
+
+fn main() {
+    match run() {
+        Ok(rendered) => println!("{rendered}"),
+        Err(err) => {
+            let payload = json!({
+                "truth_label": "rust_wired_dev",
+                "proof_only": true,
+                "ok": false,
+                "error_kind": err.kind,
+            });
+            println!("{payload}");
+            eprintln!("hub_resume_approval_unavailable: {}", err.kind);
+            std::process::exit(2);
+        }
+    }
+}
+
+fn run() -> Result<String, BridgeError> {
+    let args: Vec<String> = env::args().collect();
+
+    // The Hub DB the run Paused on (carries the pending_approval_request), and the
+    // workspace the fs tools are contained to.
+    let db_path = arg_value(&args, "--db").ok_or(BridgeError::new("bad_args"))?;
+    let workspace_root = arg_value(&args, "--workspace").ok_or(BridgeError::new("bad_args"))?;
+
+    // The operator-signed approval JSON: --approval-json <file>, else stdin.
+    let approval_json = match arg_value(&args, "--approval-json") {
+        Some(p) => std::fs::read_to_string(&p).map_err(|_| BridgeError::new("bad_args"))?,
+        None => {
+            let mut buf = String::new();
+            std::io::stdin()
+                .read_to_string(&mut buf)
+                .map_err(|_| BridgeError::new("bad_args"))?;
+            buf
+        }
+    };
+    let signed: SignedApprovalIn =
+        serde_json::from_str(approval_json.trim()).map_err(|_| BridgeError::new("bad_approval"))?;
+
+    // The OPERATOR-controlled verify key: --operator-vk-path <file>, else the env path.
+    // Absent ⇒ fail-closed (no key to verify against ⇒ nothing can be Allowed).
+    let vk_path = arg_value(&args, "--operator-vk-path")
+        .or_else(|| env::var(friday_hub::operator_vk::OPERATOR_VK_PATH_ENV).ok())
+        .filter(|p| !p.trim().is_empty())
+        .ok_or(BridgeError::new("operator_vk_unprovisioned"))?;
+    let operator_vk = load_operator_vk_from_path(Path::new(vk_path.trim()))
+        .map_err(|_| BridgeError::new("operator_vk_malformed"))?;
+
+    let now_ms = arg_value(&args, "--now-ms")
+        .and_then(|v| v.parse::<i64>().ok())
+        .unwrap_or_else(|| {
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis() as i64)
+                .unwrap_or(0)
+        });
+
+    // Build the CanonicalApproval from the signed JSON. The signature is ALWAYS treated as
+    // Ed25519 by the verify-only policy; an issuer/decision are mapped fail-closed.
+    let approval = CanonicalApproval {
+        decision: parse_decision(&signed.decision).ok_or(BridgeError::new("bad_approval"))?,
+        approval_id: signed.approval_id.clone(),
+        action_digest: signed.action_digest.clone(),
+        expires_at: Some(signed.expires_at),
+        issuer: Some(
+            signed
+                .issuer
+                .clone()
+                .unwrap_or_else(|| CANONICAL_GATE_ISSUER.to_string()),
+        ),
+        signature: Some(signed.signature.clone()),
+    };
+
+    let db = Db::open_hub(&db_path).map_err(|_| BridgeError::new("init_failed"))?;
+    let executor = FsToolExecutor::new(&workspace_root);
+
+    let outcome = resume_with_approval(db.conn(), &executor, &operator_vk, &approval, now_ms)
+        .map_err(|e| BridgeError::new(resume_error_kind(&e)))?;
+
+    // Refs-only result fingerprint (sha256 + length), never the body.
+    let result_ref = get_run_result_ref(db.conn(), &outcome.run_id)
+        .map_err(|_| BridgeError::new("storage_failed"))?;
+    let (answer_sha256, answer_len) = match &result_ref {
+        Some(r) => (r.answer_sha256.clone(), r.answer_len),
+        None => (String::new(), 0),
+    };
+    let audit_chain_verified = verify_audit_chain(db.conn()).is_ok();
+
+    let payload = json!({
+        "truth_label": "rust_wired_dev",
+        "proof_only": true,
+        "ok": true,
+        "run_id": outcome.run_id,
+        "approval_id": outcome.approval_id,
+        "gate_decision": format!("{:?}", outcome.decision),
+        "gate_reason": outcome.reason,
+        "executed": outcome.executed,
+        "result_status": outcome.result_status,
+        "result_answer_sha256": answer_sha256,
+        "result_answer_len": answer_len,
+        "audit_chain_verified": audit_chain_verified,
+    });
+    let rendered =
+        serde_json::to_string(&payload).map_err(|_| BridgeError::new("serialize_failed"))?;
+    reject_forbidden_output(&rendered)?;
+    Ok(rendered)
+}
+
+fn arg_value(args: &[String], name: &str) -> Option<String> {
+    args.windows(2)
+        .find_map(|pair| (pair[0] == name).then(|| pair[1].clone()))
+        .or_else(|| {
+            let prefix = format!("{name}=");
+            args.iter()
+                .find_map(|arg| arg.strip_prefix(&prefix).map(str::to_string))
+        })
+}
+
+fn parse_decision(s: &str) -> Option<ApprovalDecision> {
+    match s {
+        "approved" => Some(ApprovalDecision::Approved),
+        "denied" => Some(ApprovalDecision::Denied),
+        _ => None,
+    }
+}
+
+/// Map a [`ResumeError`] to ONE bounded, refs-only category token (never embeds detail).
+fn resume_error_kind(err: &ResumeError) -> &'static str {
+    match err {
+        ResumeError::UnknownNonce => "unknown_nonce",
+        ResumeError::NoToolCall => "no_tool_call",
+        ResumeError::Unregistered(_) => "unregistered_tool",
+        ResumeError::DigestMismatch => "digest_mismatch",
+        ResumeError::Storage(_) => "storage_failed",
+    }
+}
+
+/// Refuse to print if any forbidden marker leaked into the refs-only payload.
+fn reject_forbidden_output(rendered: &str) -> Result<(), BridgeError> {
+    for marker in [
+        "Authorization",
+        "Bearer",
+        "sk-",
+        "/Users/",
+        "/private/",
+        "answer\":\"", // a result body field must never appear (only the hash/len do)
+    ] {
+        if rendered.contains(marker) {
+            return Err(BridgeError::new("output_guard"));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_decision_is_fail_closed() {
+        assert_eq!(parse_decision("approved"), Some(ApprovalDecision::Approved));
+        assert_eq!(parse_decision("denied"), Some(ApprovalDecision::Denied));
+        assert_eq!(parse_decision("maybe"), None);
+        assert_eq!(parse_decision(""), None);
+    }
+
+    #[test]
+    fn output_guard_blocks_body_and_secret_markers() {
+        assert!(reject_forbidden_output(r#"{"answer":"hi"}"#).is_err());
+        assert!(reject_forbidden_output(r#"{"x":"Bearer abc"}"#).is_err());
+        assert!(reject_forbidden_output(r#"{"result_answer_sha256":"00","ok":true}"#).is_ok());
+    }
+
+    #[test]
+    fn resume_error_kinds_are_bounded_tokens() {
+        assert_eq!(
+            resume_error_kind(&ResumeError::UnknownNonce),
+            "unknown_nonce"
+        );
+        assert_eq!(
+            resume_error_kind(&ResumeError::DigestMismatch),
+            "digest_mismatch"
+        );
+        assert_eq!(
+            resume_error_kind(&ResumeError::Unregistered("zzz".into())),
+            "unregistered_tool"
+        );
+    }
+}

--- a/rust-core/crates/friday-hub/src/bin/hub_run_task.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_run_task.rs
@@ -149,6 +149,11 @@ fn run() -> Result<String, BridgeError> {
         principal_id,
         disabled_tools,
         read_only,
+        // S6d: no operator key set inline. `HubRuntime::live` resolves it from the
+        // operator-controlled env path (`FRIDAY_OPERATOR_VK_PATH`): UNSET ⇒ fail-closed
+        // (protected actions Pause — the read-mostly dev bridge's behavior is unchanged);
+        // SET ⇒ the loop authorizes via the Ed25519 verify-only policy.
+        operator_vk: None,
     })
     .map_err(|_| BridgeError::new("init_failed"))?;
 

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -33,6 +33,10 @@
 /// Routing decides *who answers*; it has zero authority over tool-call
 /// classification, which stays the trusted [`build_request`]/`trusted_classify`
 /// chokepoint regardless of the routed provider.
+pub mod operator_vk;
+
+pub mod resume;
+
 pub mod routing;
 
 /// UNW-004 — Hub composition root: wires the built graph (Db + RouteRegistry + live
@@ -164,8 +168,10 @@ use friday_core::gate::{
 // The risk-escalation primitives (`shell_risk`/`is_destructive_request`) now live behind
 // the sealed `friday_core::gate::classify`; `Resource` is constructed there too.
 use friday_core::{ActivityState, ActivityType, Risk};
+use friday_crypto::OperatorVerifyingKey;
 use friday_storage::{
-    agent_run, authorize_mutating_action, ActivityRow, AuditEvent, Db, StorageError,
+    agent_run, authorize_mutating_action, authorize_mutating_action_ed25519, ActivityRow,
+    AuditEvent, Db, StorageError,
 };
 use rusqlite::Connection;
 
@@ -1617,6 +1623,28 @@ pub(crate) enum GateDispatch {
     Unregistered(String),
 }
 
+/// How a protected (`RequiresApproval`) action is authorized at the dispatch chokepoint.
+/// This makes the authorization scheme EXPLICIT at each call site — there is no implicit
+/// fallback that could let a protected action be Allowed by the wrong scheme.
+///
+/// S6d switched the LOOP to [`AuthzMode::Ed25519`] / [`AuthzMode::DenyAll`] — the loop's
+/// protected path is NEVER [`AuthzMode::Hmac`], so it can never be Allowed by an HMAC
+/// approval (the latent self-Allow is closed). The legacy symmetric [`AuthzMode::Hmac`]
+/// remains ONLY for the separate `workflow_exec` driver (its Ed25519 switch is a follow-up
+/// lane); the loop never selects it.
+#[derive(Clone, Copy)]
+pub(crate) enum AuthzMode<'a> {
+    /// S6d loop path: verify a protected action's approval as Ed25519 under the operator's
+    /// PUBLIC key (verify-only — the Hub can never mint). No HMAC code path is reachable.
+    Ed25519(&'a OperatorVerifyingKey),
+    /// S6d loop path, unprovisioned: NO operator key ⇒ fail-closed. The base gate decision
+    /// stands and a `RequiresApproval` is NEVER upgraded — a protected action Pauses.
+    DenyAll,
+    /// Legacy symmetric HMAC authorize (the `workflow_exec` driver only). Retained so this
+    /// slice does not change workflow behavior; the loop NEVER uses this variant.
+    Hmac(&'a [u8]),
+}
+
 /// Classify → authorize → execute-ONLY-on-`Allow`, the gate-mandatory dispatch for a
 /// single raw tool call. The executor is invoked EXACTLY once, and ONLY on a gate
 /// `Allow`; `RequiresApproval`/`Deny`/unregistered never reach the executor. Records
@@ -1630,12 +1658,14 @@ pub(crate) fn gate_dispatch(
     approve: &dyn Fn(&MutatingActionRequest) -> Option<CanonicalApproval>,
     now_ms: i64,
 ) -> Result<GateDispatch, StorageError> {
-    // Pre-S4 default policy (no principal bound, nothing disabled): unchanged behavior.
+    // Pre-S4 default policy (no principal bound, nothing disabled). The `workflow_exec`
+    // driver keeps its existing legacy HMAC authorization (S6d switched the LOOP, not the
+    // workflow driver — that is a separate follow-up lane). Behavior here is unchanged.
     gate_dispatch_with_policy(
         conn,
         executor,
         raw,
-        secret,
+        AuthzMode::Hmac(secret),
         approve,
         &RunPolicy::default(),
         now_ms,
@@ -1654,13 +1684,32 @@ pub(crate) fn gate_dispatch(
 ///      approval). Both surface as [`GateDispatch::Denied`] so the shared callers
 ///      ([`run_loop_with_policy`], `workflow_exec`) need no new arm.
 ///
+/// ## S6d — the protected-path authorization, made explicit ([`AuthzMode`])
+/// `authz` selects HOW a protected (`RequiresApproval`) action is authorized:
+///   - [`AuthzMode::Ed25519`] (the LOOP, operator key provisioned): the approval signature
+///     is ALWAYS verified as Ed25519 under the operator's PUBLIC key
+///     ([`authorize_mutating_action_ed25519`]). An HMAC-signed approval over the same
+///     canonical bytes is REJECTED (an HMAC hex is not a 64-byte Ed25519 signature, and
+///     even a right-sized value is invalid without the operator's offline private key) —
+///     closing the latent self-Allow (the Hub holds only a verify key + the HMAC secret,
+///     yet cannot get a protected action Allowed).
+///   - [`AuthzMode::DenyAll`] (the LOOP, unprovisioned): fail-closed — the base gate
+///     decision stands and a `RequiresApproval` is NEVER upgraded, so a protected action
+///     Pauses. No approval, no HMAC path.
+///   - [`AuthzMode::Hmac`] (the `workflow_exec` driver ONLY): the legacy symmetric
+///     authorize, unchanged by this slice. The loop NEVER selects this variant.
+///
+/// The base decision ([`friday_core::gate::evaluate`]) is authoritative for read-only
+/// (Allow) / reserved (Deny) and the bound-principal rule (an Agent/Channel can never
+/// self-approve) — decided BEFORE any signature is examined, in every mode.
+///
 /// Everything else is identical to the pre-S4 path: authorize → execute ONLY on `Allow`.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn gate_dispatch_with_policy(
     conn: &Connection,
     executor: &dyn ToolExecutor,
     raw: &RawToolCall,
-    secret: &[u8],
+    authz: AuthzMode<'_>,
     approve: &dyn Fn(&MutatingActionRequest) -> Option<CanonicalApproval>,
     policy: &RunPolicy,
     now_ms: i64,
@@ -1687,8 +1736,24 @@ pub(crate) fn gate_dispatch_with_policy(
             raw.action
         )));
     }
-    let approval = approve(&request);
-    let record = authorize_mutating_action(conn, &request, approval.as_ref(), secret, now_ms)?;
+    // (2) S6d protected-path authorization (explicit per `authz`):
+    let record = match authz {
+        // LOOP: verify a protected action's approval as Ed25519 under the operator's key.
+        // An HMAC-signed approval over the same bytes is rejected here (downgrade closed).
+        AuthzMode::Ed25519(vk) => {
+            let approval = approve(&request);
+            authorize_mutating_action_ed25519(conn, &request, approval.as_ref(), vk, now_ms)?
+        }
+        // LOOP, unprovisioned: DenyAll-equivalent. The base decision stands; a
+        // RequiresApproval is never upgraded (no approval consulted, no HMAC path), so a
+        // protected action Pauses. Read-only Allows, reserved/agent-self-approve Denies.
+        AuthzMode::DenyAll => friday_core::gate::evaluate(&request),
+        // workflow_exec ONLY: the legacy symmetric HMAC authorize, unchanged by S6d.
+        AuthzMode::Hmac(secret) => {
+            let approval = approve(&request);
+            authorize_mutating_action(conn, &request, approval.as_ref(), secret, now_ms)?
+        }
+    };
     Ok(match record.decision {
         // Execute ONLY on Allow — the single chokepoint both drivers rely on.
         GateDecision::Allow => match executor.execute(&raw.action, &raw.params) {
@@ -1707,6 +1772,13 @@ pub(crate) fn gate_dispatch_with_policy(
 /// feedback would cause. 2 KiB comfortably covers a notes / config file's salient head;
 /// anything larger is truncated with [`FEEDBACK_TRUNCATION_MARKER`].
 const MAX_FEEDBACK_CONTENT_BYTES: usize = 2048;
+
+/// TTL (ms) for a `pending_approval_request` the loop persists when a mutating action
+/// Pauses (S6d): the `expires_at` the OFFLINE operator signs over and the resume
+/// entrypoint re-checks (an expired approval is fail-closed Denied). 24h gives the
+/// operator a realistic offline-signing window without leaving an approval valid
+/// indefinitely.
+const PENDING_APPROVAL_TTL_MS: i64 = 24 * 60 * 60 * 1000;
 
 /// Appended to fed-back content when it was truncated to [`MAX_FEEDBACK_CONTENT_BYTES`],
 /// so the model knows the file continues beyond what it can see.
@@ -1810,6 +1882,12 @@ fn bill_model_call(
 /// Drive a MULTI-TURN agent loop with the pre-S4 default policy (no per-run principal
 /// bound, no disabled tools, not read-only). Thin wrapper over [`run_loop_with_policy`];
 /// existing callers/tests are unchanged.
+///
+/// S6d: this wrapper fail-closes with NO operator verify key (`operator_vk = None`), so a
+/// mutating action Pauses (DenyAll-equivalent) — the pre-S6d behavior for callers that do
+/// not provision an operator key. The legacy HMAC `_secret` is no longer consulted on the
+/// dispatch path. Callers that DO provision an operator key drive
+/// [`run_loop_with_policy`] directly with `Some(vk)`.
 #[allow(clippy::too_many_arguments)]
 pub fn run_loop(
     client: &dyn AgentLlmClient,
@@ -1818,7 +1896,7 @@ pub fn run_loop(
     run_id: &str,
     task: &str,
     recall_preamble: &str,
-    secret: &[u8],
+    _secret: &[u8],
     approve: &dyn Fn(&MutatingActionRequest) -> Option<CanonicalApproval>,
     max_turns: u64,
     now_ms: i64,
@@ -1830,7 +1908,7 @@ pub fn run_loop(
         run_id,
         task,
         recall_preamble,
-        secret,
+        None, // operator_vk: unprovisioned ⇒ fail-closed Pause for protected actions
         approve,
         &RunPolicy::default(),
         max_turns,
@@ -1852,10 +1930,19 @@ pub fn run_loop(
 /// enforced inside the SHARED [`gate_dispatch_with_policy`] chokepoint. A
 /// [`RunPolicy::default`] reproduces the pre-S4 behavior exactly.
 ///
-/// `approve` is the owner-approval seam: given a mutating request, it returns a signed
-/// [`CanonicalApproval`] iff the owner approved THIS action (in production this is the
-/// phone-relayed owner-approval leg + Hub mint; in tests it mints-or-`None`). A
-/// read-only action needs no approval (the gate `Allow`s it directly).
+/// `operator_vk` (S6d) is the operator's PUBLIC Ed25519 verify key. When `Some`, a
+/// protected (mutating) action authorizes against it via the Ed25519 verify-only policy —
+/// NEVER the legacy HMAC authorize (an HMAC approval over the same bytes is rejected). On
+/// the Pause path the loop persists a `pending_approval_request` (CSPRNG nonce + the exact
+/// tool call) so the OFFLINE operator can sign an approval the resume entrypoint
+/// re-executes. When `None`, no operator key is provisioned ⇒ fail-closed: every mutating
+/// action Pauses, none is ever Allowed.
+///
+/// `approve` is the in-loop approval seam: given a mutating request, it returns a
+/// [`CanonicalApproval`] iff one is available WITHOUT pausing (in production this is
+/// deny-all `None` — the operator approves OFFLINE, ingested by the resume entrypoint; in
+/// tests it can mint an operator-Ed25519 approval to exercise the Allow path). A read-only
+/// action needs no approval (the gate `Allow`s it directly).
 ///
 /// No-hidden-call invariant: the model is called EXACTLY once per loop turn (via
 /// `next_step` — count == `turns`), and the executor EXACTLY once per `Allow`ed tool;
@@ -1872,7 +1959,7 @@ pub fn run_loop_with_policy(
     run_id: &str,
     task: &str,
     recall_preamble: &str,
-    secret: &[u8],
+    operator_vk: Option<&OperatorVerifyingKey>,
     approve: &dyn Fn(&MutatingActionRequest) -> Option<CanonicalApproval>,
     policy: &RunPolicy,
     max_turns: u64,
@@ -1910,6 +1997,14 @@ pub fn run_loop_with_policy(
 
     let mut history: Vec<TurnTrace> = Vec::new();
     let mut executed_tools: u64 = 0;
+
+    // S6d: the loop's protected path authorizes via the operator's Ed25519 verify key when
+    // provisioned, else fail-closed (DenyAll). The loop NEVER uses the HMAC authorize, so a
+    // protected action can never be Allowed by an HMAC approval.
+    let authz = match operator_vk {
+        Some(vk) => AuthzMode::Ed25519(vk),
+        None => AuthzMode::DenyAll,
+    };
 
     for turn_index in 0..max_turns {
         let ev = |suffix: &str| format!("{run_id}:t{turn_index}:{suffix}");
@@ -1986,8 +2081,9 @@ pub fn run_loop_with_policy(
 
         // Gate-mandatory dispatch via the SHARED chokepoint (same as run_workflow):
         // (disabled/read-only restriction) → bind principal → classify → authorize →
-        // execute ONLY on Allow. run_loop owns the recording.
-        match gate_dispatch_with_policy(conn, executor, &raw, secret, approve, policy, now_ms)? {
+        // execute ONLY on Allow. run_loop owns the recording. S6d: the protected path
+        // authorizes via `authz` (Ed25519 verify-only or fail-closed), never HMAC.
+        match gate_dispatch_with_policy(conn, executor, &raw, authz, approve, policy, now_ms)? {
             GateDispatch::Unregistered(action) => {
                 agent_run::record_event(
                     conn,
@@ -2068,13 +2164,35 @@ pub fn run_loop_with_policy(
                 }
             }
             GateDispatch::RequiresApproval => {
-                agent_run::record_event(
-                    conn,
-                    &ev("outcome"),
-                    run_id,
-                    &format!("tool.paused:requires_approval:{}", raw.action),
-                    now_ms,
-                )?;
+                // S6d Pause persistence: record everything the OFFLINE operator needs to
+                // sign an approval for THIS exact action — and everything the resume
+                // entrypoint needs to RE-EXECUTE it — and nothing the Hub could use to
+                // mint one. The `approval_id` nonce is CSPRNG (unpredictable); the
+                // `action_digest` is recomputed from the SAME deterministic request build,
+                // so it binds the exact tool call (incl. params + principal). The raw tool
+                // call is persisted (Hub-side only) so the resume can replay the one
+                // mutation. A persistence failure does NOT fabricate progress — the run
+                // still Pauses (resumable once the pending row exists); we record the
+                // outcome with the nonce so it is recoverable.
+                let nonce = friday_crypto::generate_approval_nonce();
+                let pending_recorded = match build_request_with_policy(&raw, policy) {
+                    Ok(request) => {
+                        let expires_at = now_ms.saturating_add(PENDING_APPROVAL_TTL_MS);
+                        let tool_params = serde_json::to_string(&raw.params).ok();
+                        let pending = friday_storage::PendingApprovalRequest::for_request(
+                            &request, &nonce, run_id, expires_at, now_ms,
+                        )
+                        .with_tool_params(tool_params);
+                        friday_storage::persist_pending_request(conn, &pending).is_ok()
+                    }
+                    Err(_) => false,
+                };
+                let outcome = if pending_recorded {
+                    format!("tool.paused:requires_approval:{}:{}", raw.action, nonce)
+                } else {
+                    format!("tool.paused:requires_approval:{}", raw.action)
+                };
+                agent_run::record_event(conn, &ev("outcome"), run_id, &outcome, now_ms)?;
                 return Ok(LoopOutcome {
                     status: LoopStatus::Paused,
                     turns: turn_index + 1,
@@ -2501,7 +2619,7 @@ mod tests {
             db.conn(),
             &exec,
             &raw,
-            SECRET,
+            AuthzMode::DenyAll, // read_file is base-Allow (read-only); authz irrelevant
             &approve,
             &RunPolicy::default(),
             1,
@@ -2513,9 +2631,16 @@ mod tests {
         // DISABLED: read_file disabled for this run → Denied BEFORE execution; the executor
         // is NOT reached again (the count stays 1).
         let policy = RunPolicy::new(None, ["read_file".to_string()], false);
-        let blocked =
-            gate_dispatch_with_policy(db.conn(), &exec, &raw, SECRET, &approve, &policy, 1)
-                .unwrap();
+        let blocked = gate_dispatch_with_policy(
+            db.conn(),
+            &exec,
+            &raw,
+            AuthzMode::DenyAll,
+            &approve,
+            &policy,
+            1,
+        )
+        .unwrap();
         if let GateDispatch::Denied(reason) = blocked {
             assert_eq!(reason, "tool_disabled_for_run:read_file");
         } else {
@@ -2549,8 +2674,16 @@ mod tests {
         // read_only run → the mutating write is Denied BEFORE execution (stricter than the
         // gate's default Pause); the executor is never reached and no file is created.
         let policy = RunPolicy::new(None, Vec::<String>::new(), true);
-        let ro = gate_dispatch_with_policy(db.conn(), &exec, &write, SECRET, &approve, &policy, 1)
-            .unwrap();
+        let ro = gate_dispatch_with_policy(
+            db.conn(),
+            &exec,
+            &write,
+            AuthzMode::DenyAll,
+            &approve,
+            &policy,
+            1,
+        )
+        .unwrap();
         if let GateDispatch::Denied(reason) = ro {
             assert_eq!(reason, "run_is_read_only:write_file");
         } else {
@@ -2569,7 +2702,7 @@ mod tests {
             db.conn(),
             &exec,
             &write,
-            SECRET,
+            AuthzMode::DenyAll, // deny-all (no operator key) ⇒ the mutating write Pauses
             &approve,
             &RunPolicy::default(),
             1,
@@ -3827,8 +3960,15 @@ mod tests {
         assert!(friday_storage::audit::verify_audit_chain(db.conn()).is_ok());
     }
 
+    /// S6d HMAC-DOWNGRADE CLOSED + Pause persistence (loop level): `run_loop` provisions NO
+    /// operator key, so even with an HMAC-minting `approve` closure a mutating write CANNOT
+    /// be Allowed — the read executes (base Allow), the write Pauses (fail-closed), no file
+    /// is written, and the loop persists a `pending_approval_request` (CSPRNG nonce) the
+    /// offline operator can later sign. The positive Ed25519-approved write is the
+    /// integration test `s6d_resume_ingestion` (it needs an operator signing key, banned in
+    /// `friday-hub/src/**`).
     #[test]
-    fn loop_mutating_with_approval_across_turns_writes_to_disk() {
+    fn loop_hmac_minted_approval_cannot_execute_a_mutation_and_pause_persists_pending() {
         let root = TempDir::new("loop-mut");
         std::fs::write(root.0.join("in.md"), b"input").unwrap();
         let db = Db::open_hub(&temp_path("loop-mut")).unwrap();
@@ -3852,17 +3992,38 @@ mod tests {
             "read input then write output",
             "",
             SECRET,
-            &mint_for_each(),
+            &mint_for_each(), // an HMAC-minting owner seam — must NOT drive the mutation
             10,
             1000,
         )
         .unwrap();
-        assert_eq!(out.status, LoopStatus::Finished);
-        assert_eq!(out.executed_tools, 2); // a read AND an approved mutating write, across two turns
         assert_eq!(
-            std::fs::read_to_string(root.0.join("out.md")).unwrap(),
-            "produced"
+            out.status,
+            LoopStatus::Paused,
+            "the mutating write must Pause (no operator key ⇒ HMAC can't Allow it)"
         );
+        assert_eq!(
+            out.executed_tools, 1,
+            "only the read executed; the write Paused"
+        );
+        assert!(
+            !root.0.join("out.md").exists(),
+            "an HMAC approval must not complete the mutating write (downgrade closed)"
+        );
+        // The Pause persisted a pending request bound to THIS action, with a 64-hex CSPRNG
+        // nonce, status pending.
+        let (count, nonce_len): (i64, i64) = db
+            .conn()
+            .query_row(
+                "SELECT count(*), COALESCE(length(MAX(approval_id)),0) \
+                 FROM pending_approval_request WHERE run_id='r1' AND action='write_file' \
+                 AND status='pending'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(count, 1);
+        assert_eq!(nonce_len, 64, "CSPRNG nonce is 32 bytes => 64 hex chars");
         assert!(friday_storage::audit::verify_audit_chain(db.conn()).is_ok());
     }
 
@@ -4119,60 +4280,13 @@ mod tests {
         assert!(friday_storage::audit::verify_audit_chain(db.conn()).is_ok());
     }
 
-    #[test]
-    fn loop_approval_double_spend_across_turns_is_refused() {
-        // Reviewer-B's highest-value gap: ONE pre-minted approval reused for two
-        // IDENTICAL mutating writes on turns 0 and 1. Turn 0 writes; turn 1's same
-        // single-use key is replay-refused → Deny → Blocked. One execution, one receipt.
-        let root = TempDir::new("loop-dup");
-        let db = Db::open_hub(&temp_path("loop-dup")).unwrap();
-        agent_run::create_run(db.conn(), "r1", "write twice", 1).unwrap();
-        let write = raw("write_file", &[("path", "x.txt"), ("content", "C")]);
-        let request = build_request(&write).unwrap();
-        let appr = mint_approval(&request, "ap-dup", SECRET, 1_000_000);
-        let approve = move |_req: &MutatingActionRequest| Some(appr.clone());
-        let client = ScriptedAgentLlmClient::new(vec![
-            AgentStep::Tool(write.clone()),
-            AgentStep::Tool(write.clone()),
-            AgentStep::Finish {
-                message: "x".to_string(),
-            }, // never reached
-        ]);
-        let executor = FsToolExecutor::new(&root.0);
-        let out = run_loop(
-            &client,
-            &executor,
-            db.conn(),
-            "r1",
-            "write twice",
-            "",
-            SECRET,
-            &approve,
-            5,
-            1000,
-        )
-        .unwrap();
-        assert_eq!(out.status, LoopStatus::Blocked);
-        assert_eq!(
-            out.executed_tools, 1,
-            "the single-use approval executes once; the replay is refused"
-        );
-        assert!(out.detail.contains("replay_refused"));
-        let receipts: i64 = db
-            .conn()
-            .query_row(
-                "SELECT count(*) FROM audit_ledger WHERE audit_id LIKE 'r1:t%:receipt'",
-                [],
-                |r| r.get(0),
-            )
-            .unwrap();
-        assert_eq!(
-            receipts, 1,
-            "exactly one receipt — the replayed turn produced none"
-        );
-        assert_eq!(std::fs::read_to_string(root.0.join("x.txt")).unwrap(), "C");
-        assert!(friday_storage::audit::verify_audit_chain(db.conn()).is_ok());
-    }
+    // NOTE: the former `loop_approval_double_spend_across_turns_is_refused` (HMAC-mint
+    // executes-once-then-replay-refused at the loop level) is superseded by S6d: the loop's
+    // protected path is Ed25519-only, so an HMAC mint can no longer execute a mutation. The
+    // execute-once + replay-refused property is now proven with an OPERATOR Ed25519 approval
+    // in the integration test `tests/s6d_resume_ingestion.rs` (both at the loop level and
+    // via the resume entrypoint) — it requires an operator SIGNING key, which
+    // `friday-hub/src/**` is forbidden from referencing (the key-substitution defense).
 
     #[test]
     fn build_loop_prompt_renders_history() {

--- a/rust-core/crates/friday-hub/src/operator_vk.rs
+++ b/rust-core/crates/friday-hub/src/operator_vk.rs
@@ -1,0 +1,265 @@
+//! S6d — operator-controlled provisioning of the approval **verify** key.
+//!
+//! The linchpin of the asymmetric approval spine: the Hub authorizes a protected
+//! (mutating) action against the operator's Ed25519 PUBLIC verify key
+//! ([`friday_crypto::OperatorVerifyingKey`]). For that guarantee to mean anything, the
+//! Hub MUST load that key from a source the OPERATOR controls — and MUST NOT be able to
+//! generate, derive, or substitute its own keypair as the operator key. If it could, it
+//! would sign with its own private key and verify with its own public key (full
+//! self-mint), defeating the entire "the agent can never self-approve" property.
+//!
+//! ## The key-substitution defense (structural, not a runtime check)
+//! This module only ever PARSES operator-supplied bytes via
+//! [`friday_crypto::OperatorVerifyingKey::from_bytes`]. It never references
+//! [`friday_crypto::OperatorSigningKey`] — there is no keygen here, so there is no path
+//! by which the Hub produces the key it then verifies against. The provisioning input is
+//! always external:
+//!   - a 64-hex-char file the operator wrote from the S6c CLI `keygen` output
+//!     ([`load_operator_vk_from_path`]), or
+//!   - a 32-raw-byte entry the operator provisioned into OS secure storage
+//!     ([`friday_crypto::SecureStore`], [`load_operator_vk_from_store`]).
+//! A source-scan test ([`tests::hub_crate_never_references_a_signing_key`]) asserts the
+//! whole `friday-hub` source tree contains no `OperatorSigningKey`, so the absence of a
+//! mint path is enforced, not merely asserted in prose.
+//!
+//! ## Fail-closed when unprovisioned
+//! "No operator key" is `Ok(None)` at the call site (the env / store / path is simply
+//! absent) and the loop then treats every protected action as a Pause (DenyAll-
+//! equivalent) — never an Allow. A source that IS configured but malformed is a hard
+//! [`OperatorVkError`] (a clear failure), so a broken provisioning never silently
+//! degrades to "no key" and the operator notices.
+//!
+//! Truth label: this is the load-from-operator-controlled-source MECHANISM. The KEY
+//! VALUE itself is set by the operator at S6e (the key-custody gate). PROOF-ONLY; the
+//! live mutating-completion proof with a real operator-held key is S6e. NOT v1 GO.
+
+use std::path::Path;
+
+use friday_crypto::ed25519_approval::VERIFYING_KEY_LEN;
+use friday_crypto::{OperatorVerifyingKey, SecureStore};
+
+/// The `SecureStore` id under which the operator provisions their 32-byte public verify
+/// key (raw bytes). Namespaced so it cannot collide with KEK / pairing entries.
+pub const OPERATOR_VK_SECURE_STORE_ID: &str = "friday.operator.approval.verify_key.ed25519";
+
+/// The env var naming an operator-controlled FILE that holds the 64-hex public verify
+/// key (the `keygen` stdout from the S6c CLI). UNSET ⇒ no operator key provisioned ⇒
+/// fail-closed (protected actions Pause). SET-but-unreadable/malformed ⇒ a hard error.
+pub const OPERATOR_VK_PATH_ENV: &str = "FRIDAY_OPERATOR_VK_PATH";
+
+/// Why provisioning the operator verify key failed. Fail-closed: never substitutes a
+/// Hub-generated key, never panics on malformed input. The error is deliberately coarse
+/// (no bytes echoed) — the public key is not secret, but keeping errors content-free
+/// matches the rest of the crate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OperatorVkError {
+    /// The configured source file could not be read (absent/permissions/IO). Distinct
+    /// from "no source configured" (which is `Ok(None)` at the call site, fail-closed).
+    Read,
+    /// The provisioned bytes are not a 32-byte hex string / not 32 raw bytes, or are not
+    /// a valid Ed25519 public key point.
+    Malformed,
+}
+
+fn hex_val(c: u8) -> Option<u8> {
+    match c {
+        b'0'..=b'9' => Some(c - b'0'),
+        b'a'..=b'f' => Some(c - b'a' + 10),
+        b'A'..=b'F' => Some(c - b'A' + 10),
+        _ => None,
+    }
+}
+
+/// Decode a hex string into exactly [`VERIFYING_KEY_LEN`] bytes. `None` for any non-hex,
+/// odd-length, or wrong-length input (fail-closed; never panics).
+fn decode_vk_hex(s: &str) -> Option<[u8; VERIFYING_KEY_LEN]> {
+    let b = s.trim().as_bytes();
+    if b.len() != VERIFYING_KEY_LEN * 2 {
+        return None;
+    }
+    let mut out = [0u8; VERIFYING_KEY_LEN];
+    for (i, pair) in b.chunks_exact(2).enumerate() {
+        out[i] = (hex_val(pair[0])? << 4) | hex_val(pair[1])?;
+    }
+    Some(out)
+}
+
+/// Parse a 32-byte verify key from raw bytes, failing closed for the wrong length or a
+/// non-canonical Ed25519 point.
+fn vk_from_raw(bytes: &[u8]) -> Result<OperatorVerifyingKey, OperatorVkError> {
+    let arr: [u8; VERIFYING_KEY_LEN] = bytes.try_into().map_err(|_| OperatorVkError::Malformed)?;
+    OperatorVerifyingKey::from_bytes(&arr).map_err(|_| OperatorVkError::Malformed)
+}
+
+/// Load the operator's PUBLIC verify key from an operator-controlled FILE holding the
+/// 64-hex `keygen` output. The Hub only ever PARSES these bytes — it never generates a
+/// keypair — so there is no path by which the Hub produces the key it verifies against.
+///
+/// Fail-closed: unreadable ⇒ [`OperatorVkError::Read`]; not 64-hex / not a valid Ed25519
+/// point ⇒ [`OperatorVkError::Malformed`]. Never panics.
+pub fn load_operator_vk_from_path(path: &Path) -> Result<OperatorVerifyingKey, OperatorVkError> {
+    let contents = std::fs::read_to_string(path).map_err(|_| OperatorVkError::Read)?;
+    let bytes = decode_vk_hex(&contents).ok_or(OperatorVkError::Malformed)?;
+    OperatorVerifyingKey::from_bytes(&bytes).map_err(|_| OperatorVkError::Malformed)
+}
+
+/// Load the operator's PUBLIC verify key from an operator-provisioned [`SecureStore`]
+/// entry (32 RAW bytes under [`OPERATOR_VK_SECURE_STORE_ID`]). Same structural guarantee
+/// as the path loader: parse-only, never keygen.
+///
+/// `Ok(None)` when the entry is ABSENT (no operator key provisioned ⇒ fail-closed Pause).
+/// `Err(Malformed)` when present but not a valid 32-byte Ed25519 public key.
+pub fn load_operator_vk_from_store(
+    store: &dyn SecureStore,
+    id: &str,
+) -> Result<Option<OperatorVerifyingKey>, OperatorVkError> {
+    match store.get(id) {
+        None => Ok(None),
+        Some(bytes) => vk_from_raw(&bytes).map(Some),
+    }
+}
+
+/// Resolve the operator verify key from the standard operator-controlled source: the
+/// [`OPERATOR_VK_PATH_ENV`] file path.
+///
+/// - env UNSET ⇒ `Ok(None)` — NO operator key provisioned ⇒ the loop fail-closes
+///   (protected actions Pause, never Allow).
+/// - env SET ⇒ load the file; a read/parse failure is a hard `Err` (a clear failure, so a
+///   broken provisioning never silently degrades to "no key").
+///
+/// This is the ONLY env read; it names a FILE the operator writes (the public key is not
+/// secret, but it is operator-controlled), never the key bytes inline.
+pub fn provision_operator_vk_from_env() -> Result<Option<OperatorVerifyingKey>, OperatorVkError> {
+    match std::env::var(OPERATOR_VK_PATH_ENV) {
+        Err(_) => Ok(None),
+        Ok(path) if path.trim().is_empty() => Ok(None),
+        Ok(path) => load_operator_vk_from_path(Path::new(path.trim())).map(Some),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use friday_crypto::{InMemorySecureStore, OperatorSigningKey};
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static C: AtomicU64 = AtomicU64::new(0);
+    fn tmp(tag: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!(
+            "friday-operator-vk-{}-{}-{}",
+            std::process::id(),
+            tag,
+            C.fetch_add(1, Ordering::Relaxed)
+        ))
+    }
+
+    fn vk_hex(vk: &OperatorVerifyingKey) -> String {
+        vk.to_bytes()
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect::<String>()
+    }
+
+    #[test]
+    fn round_trips_an_operator_keygen_public_key_from_a_file() {
+        // The OPERATOR generates the keypair (off-Hub, here standing in for the S6c CLI)
+        // and writes ONLY the public key hex. The Hub loads it back and it matches.
+        let sk = OperatorSigningKey::generate();
+        let vk = sk.verifying_key();
+        let path = tmp("ok.vk");
+        std::fs::write(&path, format!("{}\n", vk_hex(&vk))).unwrap();
+
+        let loaded = load_operator_vk_from_path(&path).unwrap();
+        assert_eq!(loaded.to_bytes(), vk.to_bytes());
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn missing_file_is_read_error_and_malformed_is_malformed() {
+        // NB: `OperatorVerifyingKey` deliberately has no `Debug`/`PartialEq` (key bytes are
+        // never logged/compared), so we `matches!` the error rather than `unwrap_err()`.
+        assert!(matches!(
+            load_operator_vk_from_path(&tmp("absent.vk")),
+            Err(OperatorVkError::Read)
+        ));
+        let p = tmp("bad.vk");
+        std::fs::write(&p, b"not-hex").unwrap();
+        assert!(matches!(
+            load_operator_vk_from_path(&p),
+            Err(OperatorVkError::Malformed)
+        ));
+        // An HMAC-length (64-byte / 128-hex) value is NOT a 32-byte verify key ⇒ malformed.
+        let p2 = tmp("len.vk");
+        std::fs::write(&p2, "ab".repeat(64)).unwrap();
+        assert!(matches!(
+            load_operator_vk_from_path(&p2),
+            Err(OperatorVkError::Malformed)
+        ));
+        std::fs::remove_file(&p).ok();
+        std::fs::remove_file(&p2).ok();
+    }
+
+    #[test]
+    fn secure_store_absent_is_none_present_round_trips() {
+        let mut store = InMemorySecureStore::new();
+        // Absent ⇒ None (fail-closed: no operator key provisioned).
+        assert!(matches!(
+            load_operator_vk_from_store(&store, OPERATOR_VK_SECURE_STORE_ID),
+            Ok(None)
+        ));
+        // The operator provisions the 32 RAW public-key bytes.
+        let vk = OperatorSigningKey::generate().verifying_key();
+        store.put(OPERATOR_VK_SECURE_STORE_ID, &vk.to_bytes());
+        let loaded = match load_operator_vk_from_store(&store, OPERATOR_VK_SECURE_STORE_ID) {
+            Ok(Some(k)) => k,
+            _ => panic!("a provisioned key must load"),
+        };
+        assert_eq!(loaded.to_bytes(), vk.to_bytes());
+        // A malformed entry (wrong length) is a hard error, never silently None.
+        store.put(OPERATOR_VK_SECURE_STORE_ID, b"too-short");
+        assert!(matches!(
+            load_operator_vk_from_store(&store, OPERATOR_VK_SECURE_STORE_ID),
+            Err(OperatorVkError::Malformed)
+        ));
+    }
+
+    /// KEY-SUBSTITUTION DEFENSE (structural): the entire `friday-hub` source tree must
+    /// never reference `OperatorSigningKey`. The Hub holds ONLY a verify key; if any Hub
+    /// code could construct/derive a signing key, it could mint the very approvals it
+    /// verifies (self-mint). We cannot runtime-prove the absence of a mint path, but we
+    /// CAN prove the type that produces signatures is never named in the Hub crate.
+    #[test]
+    fn hub_crate_never_references_a_signing_key() {
+        let src = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let mut offenders = Vec::new();
+        scan_for(&src, "OperatorSigningKey", &mut offenders);
+        assert!(
+            offenders.is_empty(),
+            "friday-hub must never reference OperatorSigningKey (a Hub-generated operator \
+             key would be full self-mint); found in: {offenders:?}"
+        );
+    }
+
+    fn scan_for(dir: &std::path::Path, needle: &str, offenders: &mut Vec<String>) {
+        let entries = match std::fs::read_dir(dir) {
+            Ok(e) => e,
+            Err(_) => return,
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                scan_for(&path, needle, offenders);
+            } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+                // Skip THIS file — it names the type only in this defensive test/docs.
+                if path.file_name().and_then(|n| n.to_str()) == Some("operator_vk.rs") {
+                    continue;
+                }
+                if let Ok(contents) = std::fs::read_to_string(&path) {
+                    if contents.contains(needle) {
+                        offenders.push(path.display().to_string());
+                    }
+                }
+            }
+        }
+    }
+}

--- a/rust-core/crates/friday-hub/src/resume.rs
+++ b/rust-core/crates/friday-hub/src/resume.rs
@@ -1,0 +1,259 @@
+//! S6d — the resume/ingestion entrypoint (dev bridge, completion leg).
+//!
+//! Given a run that Paused on a mutating action (the loop persisted a
+//! `pending_approval_request` with a CSPRNG nonce + the exact tool call) and an
+//! operator-Ed25519-signed approval (the S6c CLI output), this INGESTS the approval,
+//! VERIFIES it against the operator's PUBLIC key (the S6b Ed25519 verify-only policy),
+//! executes the ONE approved mutation, and records a truth-labeled, proof-linked result.
+//!
+//! It NEVER mints — it only verifies + consumes:
+//!   - the approval is looked up by its `approval_id` NONCE against the persisted pending
+//!     request (an unknown nonce is refused);
+//!   - the reconstructed action digest must equal BOTH the pending row's digest AND the
+//!     approval's digest (a wrong-digest / wrong-principal approval is refused — the
+//!     digest binds principal/scope/params transitively);
+//!   - [`authorize_mutating_action_ed25519`] then verifies the signature as Ed25519 under
+//!     the operator's key, checks expiry, and CONSUMES the nonce (single-use). A second
+//!     ingest of the same approval is replay-refused by the `consumed_approval` store;
+//!   - an HMAC-signed approval for the protected action is rejected (it is never a valid
+//!     Ed25519 signature) — the same downgrade defense the loop uses.
+//!
+//! Truth label: operator-approved mutating completion is now WIRED + mechanism-tested.
+//! The LIVE proof with a real operator-held key is S6e (key-custody gate); `executeRun`
+//! is NOT replaced (this is the dev-bridge completion leg). PROOF-ONLY; NOT v1 GO.
+
+use friday_core::gate::{canonical_action_bytes, CanonicalApproval, GateDecision};
+use friday_crypto::OperatorVerifyingKey;
+use friday_storage::{
+    audit, authorize_mutating_action_ed25519, get_pending_request, persist_run_result,
+    set_pending_status, PendingApprovalRequest, RunResult, StorageError,
+};
+use rusqlite::Connection;
+
+use crate::{build_request_with_policy, RawToolCall, RunPolicy, ToolError, ToolExecutor};
+
+/// The result of an ingest+resume attempt. Refs-friendly: it carries the gate decision,
+/// a coarse status, whether the one mutation executed, and a soft link to the audit
+/// receipt — never a body. The bin layers the refs-only JSON (sha/len) on top.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ResumeOutcome {
+    pub run_id: String,
+    pub approval_id: String,
+    /// The gate's decision on the ingested approval (`Allow` ⇒ the mutation ran;
+    /// `Deny` ⇒ refused — replay/expired/bad-signature/etc).
+    pub decision: GateDecision,
+    /// The gate's reason string (e.g. `canonical_approval_granted`,
+    /// `canonical_approval_replay_refused`).
+    pub reason: String,
+    /// True iff the ONE approved mutation executed (gate `Allow` + executor `Ok`).
+    pub executed: bool,
+    /// Coarse, safe result status persisted to `run_result` (never a body).
+    pub result_status: String,
+    /// Soft link to the hash-chained audit receipt for this resume.
+    pub audit_ref: Option<String>,
+}
+
+/// Why an ingest+resume could not be processed at all (distinct from a gate `Deny`, which
+/// is a processed-and-refused [`ResumeOutcome`]). Fail-closed: every arm means NO mutation
+/// ran.
+#[derive(Debug)]
+pub enum ResumeError {
+    /// No pending request matches the approval's `approval_id` nonce (never persisted, or
+    /// already cleared) — nothing to resume.
+    UnknownNonce,
+    /// The pending row carries no replayable tool call (a pre-S6d row, or absent params).
+    NoToolCall,
+    /// The persisted tool call is not a registered tool (cannot be rebuilt/executed).
+    Unregistered(String),
+    /// The reconstructed action digest does not match the pending row and/or the
+    /// approval — the approval does not authorize THIS exact action (wrong
+    /// digest/principal/scope/params). A hard refusal; no nonce is consumed.
+    DigestMismatch,
+    Storage(StorageError),
+}
+
+impl From<StorageError> for ResumeError {
+    fn from(e: StorageError) -> Self {
+        ResumeError::Storage(e)
+    }
+}
+
+impl std::fmt::Display for ResumeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ResumeError::UnknownNonce => write!(f, "unknown_nonce"),
+            ResumeError::NoToolCall => write!(f, "no_tool_call"),
+            ResumeError::Unregistered(a) => write!(f, "unregistered_tool:{a}"),
+            ResumeError::DigestMismatch => write!(f, "digest_mismatch"),
+            ResumeError::Storage(e) => write!(f, "storage:{e}"),
+        }
+    }
+}
+
+impl std::error::Error for ResumeError {}
+
+/// Reconstruct the exact [`RawToolCall`] a run Paused on from its persisted pending
+/// request (the raw key/value params stored as JSON).
+fn reconstruct_tool_call(pending: &PendingApprovalRequest) -> Result<RawToolCall, ResumeError> {
+    let json = pending
+        .tool_params
+        .as_deref()
+        .ok_or(ResumeError::NoToolCall)?;
+    let params: Vec<(String, String)> =
+        serde_json::from_str(json).map_err(|_| ResumeError::NoToolCall)?;
+    Ok(RawToolCall {
+        action: pending.action.clone(),
+        params,
+    })
+}
+
+/// Ingest an operator-signed approval and resume the paused run: verify (digest /
+/// principal / expiry / nonce, single-use) against the operator's PUBLIC verify key, then
+/// execute the ONE approved mutation and record a truth-labeled, proof-linked result.
+///
+/// `operator_vk` MUST come from an operator-controlled source ([`crate::operator_vk`]) —
+/// this function only ever VERIFIES with it (never mints). Returns a [`ResumeOutcome`]
+/// (gate `Allow` ⇒ executed; gate `Deny` ⇒ refused) or a [`ResumeError`] for a structural
+/// failure (unknown nonce / unreplayable call / digest mismatch). In every refusal path,
+/// NO mutation runs.
+pub fn resume_with_approval(
+    conn: &Connection,
+    executor: &dyn ToolExecutor,
+    operator_vk: &OperatorVerifyingKey,
+    approval: &CanonicalApproval,
+    now_ms: i64,
+) -> Result<ResumeOutcome, ResumeError> {
+    // (1) Look up the pending request by the approval's NONCE. An unknown nonce is a hard
+    //     refusal — there is no paused action this approval applies to.
+    let pending =
+        get_pending_request(conn, &approval.approval_id)?.ok_or(ResumeError::UnknownNonce)?;
+    let run_id = pending.run_id.clone();
+
+    // (2) Reconstruct the EXACT tool call + request (with the run's bound principal, so the
+    //     digest binds the principal the loop bound). build_request_with_policy is
+    //     deterministic, so the rebuilt digest equals what the loop authorized.
+    let raw = reconstruct_tool_call(&pending)?;
+    let policy = RunPolicy::new(pending.principal_id.clone(), Vec::<String>::new(), false);
+    let request = match build_request_with_policy(&raw, &policy) {
+        Ok(r) => r,
+        Err(ToolError::UnknownTool(action)) => return Err(ResumeError::Unregistered(action)),
+    };
+
+    // (3) Digest cross-check: the reconstructed action digest must equal BOTH the persisted
+    //     pending digest AND the approval's digest. This is defense-in-depth on top of the
+    //     authorize digest check: a tampered tool_params (different mutation) cannot match,
+    //     and an approval for a different action/principal is refused before any signature
+    //     verification touches the nonce.
+    let digest = friday_crypto::action_digest(&canonical_action_bytes(&request));
+    if digest != pending.action_digest || approval.action_digest != pending.action_digest {
+        return Err(ResumeError::DigestMismatch);
+    }
+
+    // (4) Authorize via the Ed25519 verify-only policy: verify the signature as Ed25519
+    //     under the operator's key, check expiry, and CONSUME the nonce (single-use). NEVER
+    //     mints. A replay/expired/HMAC/forged approval returns Deny here.
+    let record =
+        authorize_mutating_action_ed25519(conn, &request, Some(approval), operator_vk, now_ms)?;
+
+    // A per-ATTEMPT CSPRNG tag keys the event/receipt ids so repeated resume attempts on the
+    // same nonce (e.g. a replay that is refused, or a wrong-key retry) never PK-collide on
+    // `agent_run_event.event_id` — each refused attempt still leaves its own audit trail.
+    let attempt = friday_crypto::generate_approval_nonce();
+    let event_id = format!("{run_id}:resume:{attempt}:outcome");
+    let receipt_id = format!("{run_id}:resume:{attempt}:receipt");
+
+    if record.decision != GateDecision::Allow {
+        // Processed but refused (replay/expired/bad-signature/owner-denied). No execution.
+        // The refusal IS audited (its own receipt), but we deliberately do NOT touch the
+        // pending status or the run_result: a replay refusal must not relabel an already
+        // `consumed` pending or clobber a completed run's immutable result, and an
+        // expired/bad-signature refusal leaves the request `pending` so the operator can
+        // re-sign a fresh (future-dated, correctly-signed) approval on the SAME nonce.
+        let summary = format!("resume.refused:{}", record.reason);
+        write_receipt(conn, &event_id, &receipt_id, &run_id, &summary, now_ms)?;
+        return Ok(ResumeOutcome {
+            run_id,
+            approval_id: approval.approval_id.clone(),
+            decision: record.decision,
+            reason: record.reason,
+            executed: false,
+            result_status: "approval_refused".to_string(),
+            audit_ref: Some(receipt_id),
+        });
+    }
+
+    // (5) Allow → execute the ONE approved mutation. The nonce is already consumed, so a
+    //     second ingest of this approval is replay-refused regardless of what happens here.
+    match executor.execute(&raw.action, &raw.params) {
+        Ok(receipt) => {
+            let summary = format!("resume.executed:{}", receipt.summary);
+            write_receipt(conn, &event_id, &receipt_id, &run_id, &summary, now_ms)?;
+            set_pending_status(conn, &approval.approval_id, "consumed")?;
+            persist_run_result(
+                conn,
+                &run_id,
+                &RunResult::new(
+                    "mutation_completed",
+                    &receipt.summary,
+                    Some(receipt_id.clone()),
+                ),
+                now_ms,
+            )?;
+            Ok(ResumeOutcome {
+                run_id,
+                approval_id: approval.approval_id.clone(),
+                decision: GateDecision::Allow,
+                reason: record.reason,
+                executed: true,
+                result_status: "mutation_completed".to_string(),
+                audit_ref: Some(receipt_id),
+            })
+        }
+        Err(e) => {
+            let err_text = format!("{e}");
+            let summary = format!("resume.exec_failed:{err_text}");
+            write_receipt(conn, &event_id, &receipt_id, &run_id, &summary, now_ms)?;
+            set_pending_status(conn, &approval.approval_id, "consumed")?;
+            persist_run_result(
+                conn,
+                &run_id,
+                &RunResult::new("mutation_exec_failed", &err_text, Some(receipt_id.clone())),
+                now_ms,
+            )?;
+            Ok(ResumeOutcome {
+                run_id,
+                approval_id: approval.approval_id.clone(),
+                decision: GateDecision::Allow,
+                reason: format!("exec_error:{err_text}"),
+                executed: false,
+                result_status: "mutation_exec_failed".to_string(),
+                audit_ref: Some(receipt_id),
+            })
+        }
+    }
+}
+
+/// Write the event-log line + the hash-chained audit receipt in ONE transaction (so the
+/// event log can never get ahead of the ledger on a partial commit) — the same coupling
+/// the loop uses for an executed tool.
+fn write_receipt(
+    conn: &Connection,
+    event_id: &str,
+    receipt_id: &str,
+    run_id: &str,
+    summary: &str,
+    now_ms: i64,
+) -> Result<(), StorageError> {
+    let tx = conn.unchecked_transaction()?;
+    friday_storage::agent_run::record_event(&tx, event_id, run_id, summary, now_ms)?;
+    audit::append_audit(
+        &tx,
+        receipt_id,
+        "operator-resume",
+        summary,
+        Some(run_id),
+        now_ms,
+    )?;
+    tx.commit()?;
+    Ok(())
+}

--- a/rust-core/crates/friday-hub/src/routing.rs
+++ b/rust-core/crates/friday-hub/src/routing.rs
@@ -44,6 +44,8 @@ use friday_core::gate::{CanonicalApproval, MutatingActionRequest};
 use friday_storage::StorageError;
 use rusqlite::Connection;
 
+use friday_crypto::OperatorVerifyingKey;
+
 use crate::{run_loop_with_policy, AgentLlmClient, LoopOutcome, ToolExecutor};
 
 /// Provider wire API. Subset of the oracle's `FRIDAY_PROVIDER_APIS` that this
@@ -433,12 +435,15 @@ pub fn run_routed_loop(
     run_id: &str,
     task: &str,
     recall_preamble: &str,
-    secret: &[u8],
+    _secret: &[u8],
     approve: &dyn Fn(&MutatingActionRequest) -> Option<CanonicalApproval>,
     max_turns: u64,
     now_ms: i64,
 ) -> Result<(RoutedSelection, LoopOutcome), RoutedLoopError> {
-    // Pre-S4 default policy (no principal bound, nothing disabled): unchanged behavior.
+    // Pre-S4 default policy (no principal bound, nothing disabled). S6d: this wrapper
+    // fail-closes with NO operator verify key — a mutating action Pauses (the pre-S6d
+    // deny-all behavior). Callers that provision an operator key drive
+    // [`run_routed_loop_with_policy`] directly with `Some(vk)`.
     run_routed_loop_with_policy(
         registry,
         request,
@@ -448,7 +453,7 @@ pub fn run_routed_loop(
         run_id,
         task,
         recall_preamble,
-        secret,
+        None, // operator_vk: unprovisioned ⇒ fail-closed Pause for protected actions
         approve,
         &crate::RunPolicy::default(),
         max_turns,
@@ -470,7 +475,7 @@ pub fn run_routed_loop_with_policy(
     run_id: &str,
     task: &str,
     recall_preamble: &str,
-    secret: &[u8],
+    operator_vk: Option<&OperatorVerifyingKey>,
     approve: &dyn Fn(&MutatingActionRequest) -> Option<CanonicalApproval>,
     policy: &crate::RunPolicy,
     max_turns: u64,
@@ -487,6 +492,8 @@ pub fn run_routed_loop_with_policy(
         .resolve(route)
         .ok_or_else(|| RoutedLoopError::NoClientForProvider(route.provider_id.clone()))?;
 
+    // S6d: thread the operator verify key so the loop authorizes a protected action via the
+    // Ed25519 verify-only policy (never the HMAC authorize). `None` ⇒ fail-closed Pause.
     let outcome = run_loop_with_policy(
         client,
         executor,
@@ -494,7 +501,7 @@ pub fn run_routed_loop_with_policy(
         run_id,
         task,
         recall_preamble,
-        secret,
+        operator_vk,
         approve,
         policy,
         max_turns,

--- a/rust-core/crates/friday-hub/src/runtime.rs
+++ b/rust-core/crates/friday-hub/src/runtime.rs
@@ -27,6 +27,7 @@
 use std::path::PathBuf;
 
 use friday_core::gate::{CanonicalApproval, MutatingActionRequest};
+use friday_crypto::OperatorVerifyingKey;
 use friday_deepseek::{DeepSeekClient, DeepSeekError, Transport, UreqTransport};
 use friday_storage::{agent_run, Db, StorageError};
 
@@ -79,6 +80,19 @@ pub struct HubConfig {
     /// tool is blocked before execution (strictly stricter than the default Pause). `false`
     /// ⇒ pre-S4 behavior.
     pub read_only: bool,
+    /// S6d: the operator's PUBLIC Ed25519 verify key — the linchpin. When `Some`, a
+    /// protected (mutating) action authorizes against it via the Ed25519 verify-only
+    /// policy (NEVER the legacy HMAC authorize), and on Pause the loop persists a
+    /// `pending_approval_request` the offline operator can sign + the resume entrypoint
+    /// re-executes. When `None` (NO operator key provisioned), the loop is fail-closed:
+    /// every mutating action Pauses and is NEVER Allowed.
+    ///
+    /// This MUST be loaded from an OPERATOR-CONTROLLED source ([`crate::operator_vk`] — a
+    /// file the operator wrote from the S6c CLI `keygen`, or a `SecureStore` entry the
+    /// operator provisioned). The Hub MUST NOT generate/derive its own keypair here: a
+    /// Hub-minted operator key would be full self-mint. [`HubRuntime::live`] resolves it
+    /// from the operator-controlled env path; tests provision a test key directly.
+    pub operator_vk: Option<OperatorVerifyingKey>,
 }
 
 /// Why the live runtime failed to assemble.
@@ -86,6 +100,11 @@ pub struct HubConfig {
 pub enum HubInitError {
     DeepSeek(DeepSeekError),
     Storage(StorageError),
+    /// S6d: an operator verify key SOURCE was configured (the env path is set) but could
+    /// not be read/parsed. A CLEAR failure — a broken provisioning never silently degrades
+    /// to "no key" (which would be a different, fail-closed-Pause state). An UNSET source
+    /// is NOT an error (it is `operator_vk = None` ⇒ fail-closed Pause).
+    OperatorVk(crate::operator_vk::OperatorVkError),
 }
 
 impl std::fmt::Display for HubInitError {
@@ -94,6 +113,9 @@ impl std::fmt::Display for HubInitError {
             // DeepSeekError's Debug carries no key (verified in friday-deepseek); never prints the secret.
             HubInitError::DeepSeek(e) => write!(f, "deepseek init failed: {e:?}"),
             HubInitError::Storage(e) => write!(f, "storage init failed: {e}"),
+            HubInitError::OperatorVk(e) => {
+                write!(f, "operator verify key provisioning failed: {e:?}")
+            }
         }
     }
 }
@@ -107,7 +129,11 @@ pub struct HubRuntime<T: Transport> {
     routes: RouteRegistry,
     deepseek: DeepSeekAgentLlmClient<T>,
     executor: FsToolExecutor,
-    secret: Vec<u8>,
+    /// S6d: the operator's PUBLIC verify key (provisioned from an operator-controlled
+    /// source). `None` ⇒ fail-closed (protected actions Pause, never Allow). The Hub holds
+    /// ONLY a verify key — never a signing key — so it can verify an operator approval but
+    /// never mint one.
+    operator_vk: Option<OperatorVerifyingKey>,
     approval: Box<dyn ApprovalPolicy>,
     max_turns: u64,
     /// S4 per-run policy: the bound principal (also the memory-recall owner — ONE source,
@@ -134,7 +160,7 @@ impl<T: Transport> HubRuntime<T> {
             routes,
             deepseek,
             executor,
-            secret: config.secret,
+            operator_vk: config.operator_vk,
             approval,
             max_turns: config.max_turns,
             policy,
@@ -181,7 +207,9 @@ impl<T: Transport> HubRuntime<T> {
         let approve = |req: &MutatingActionRequest| self.approval.approve(req);
         // S4: thread the run policy so the bound principal reaches every gate request's
         // Actor (and the action digest) and the disabled/read-only restrictions are
-        // enforced before any tool executes.
+        // enforced before any tool executes. S6d: thread the provisioned operator verify
+        // key so a protected action authorizes via the Ed25519 verify-only policy (never
+        // HMAC); `None` ⇒ fail-closed Pause.
         run_routed_loop_with_policy(
             &self.routes,
             &request,
@@ -191,7 +219,7 @@ impl<T: Transport> HubRuntime<T> {
             run_id,
             task,
             &recall_preamble,
-            &self.secret,
+            self.operator_vk.as_ref(),
             &approve,
             &self.policy,
             self.max_turns,
@@ -237,7 +265,17 @@ impl HubRuntime<UreqTransport> {
     /// Assemble the LIVE runtime: the real DeepSeek client from the env key
     /// (`DeepSeekClient::from_env`, never logs the key) + deny-all approval (safe default).
     /// This is the bootstrap the live e2e proof drives.
-    pub fn live(config: HubConfig) -> Result<Self, HubInitError> {
+    ///
+    /// S6d: if the caller did not pre-provision `config.operator_vk`, resolve it from the
+    /// OPERATOR-CONTROLLED env path ([`crate::operator_vk::provision_operator_vk_from_env`]):
+    /// UNSET ⇒ `None` (fail-closed Pause for protected actions); SET-but-broken ⇒ a hard
+    /// [`HubInitError::OperatorVk`]. The Hub NEVER generates its own operator key here — it
+    /// only loads operator-supplied bytes — so a Hub-minted self-approval is impossible.
+    pub fn live(mut config: HubConfig) -> Result<Self, HubInitError> {
+        if config.operator_vk.is_none() {
+            config.operator_vk = crate::operator_vk::provision_operator_vk_from_env()
+                .map_err(HubInitError::OperatorVk)?;
+        }
         let client = DeepSeekClient::from_env().map_err(HubInitError::DeepSeek)?;
         let agent = DeepSeekAgentLlmClient::new(client);
         Self::new(config, agent, Box::new(DenyAllApprovals)).map_err(HubInitError::Storage)
@@ -384,6 +422,7 @@ mod tests {
                 principal_id: None, // recall disabled by default; the recall test sets it
                 disabled_tools: vec![],
                 read_only: false,
+                operator_vk: None, // S6d: no operator key in these tests ⇒ fail-closed Pause
             },
             agent,
             approval,
@@ -443,6 +482,7 @@ mod tests {
                 principal_id: principal.map(|p| p.to_string()),
                 disabled_tools: vec![],
                 read_only: false,
+                operator_vk: None,
             },
             agent,
             Box::new(DenyAllApprovals),
@@ -671,6 +711,7 @@ mod tests {
                 principal_id: None,
                 disabled_tools: vec!["read_file".to_string()], // <- disabled for this run
                 read_only: false,
+                operator_vk: None,
             },
             agent,
             Box::new(DenyAllApprovals),
@@ -700,35 +741,57 @@ mod tests {
         assert!(friday_storage::audit::verify_audit_chain(rt.db().conn()).is_ok());
     }
 
-    /// With a minting owner policy, the mutating write executes ONCE; a replay of the same
-    /// single-use approval on the next turn is refused (Blocked) — one execution, one receipt.
+    /// S6d HMAC-DOWNGRADE CLOSED (composed level): a Hub that CAN mint a valid HMAC
+    /// approval (the [`MintPolicy`] holds the symmetric secret) still cannot complete a
+    /// protected mutation through the composed runtime when NO operator verify key is
+    /// provisioned (`operator_vk: None`, the runtime_with default). The loop's protected
+    /// path is Ed25519-only / fail-closed — it never consults the HMAC authorize — so the
+    /// write Pauses, executes nothing, and writes no file. The positive Ed25519-approved
+    /// completion + replay-refusal is the integration test `s6d_resume_ingestion` (it needs
+    /// an operator SIGNING key, which `friday-hub/src/**` must never reference — see
+    /// `operator_vk::tests::hub_crate_never_references_a_signing_key`).
     #[test]
-    fn composed_mutating_with_approval_executes_then_replay_refused() {
-        // Two IDENTICAL writes: identical action+params → identical digest → the SAME
-        // single-use approval. Turn 0 consumes it (Allow→execute); turn 1's replay of the
-        // same digest is refused. (Different content would be a DIFFERENT digest → a fresh
-        // approval → not a replay at all, so the writes must be identical for this scenario.)
+    fn composed_hmac_minted_approval_cannot_complete_a_protected_mutation_fail_closed() {
         let write =
             "{\"tool\":\"write_file\",\"parameters\":{\"path\":\"out.txt\",\"content\":\"C\"}}";
         let (rt, root, _post) = runtime_with(
-            "approve",
-            &[write, write, "{\"tool\":\"none\"}"],
+            "downgrade",
+            &[write, "{\"tool\":\"none\"}"],
             Box::new(MintPolicy {
                 secret: SECRET.to_vec(),
                 id: "ap-rt".to_string(),
                 expires_at: 1_000_000,
             }),
         );
-        let (_sel, out) = rt.run_task("run-appr", "write twice", 1000).unwrap();
+        let (_sel, out) = rt.run_task("run-appr", "write once", 1000).unwrap();
         assert_eq!(
-            out.executed_tools, 1,
-            "single-use approval executes once; replay refused"
+            out.executed_tools, 0,
+            "an HMAC-minted approval must NOT complete a protected mutation (downgrade closed)"
         );
-        assert!(matches!(out.status, LoopStatus::Blocked));
-        assert_eq!(std::fs::read_to_string(root.join("out.txt")).unwrap(), "C");
-        // Discriminating witness (Finding B): EXACTLY ONE execution receipt on the hash-chain
-        // — the replayed second write produced none. This distinguishes single-vs-double
-        // execution without changing the (necessarily-identical) replay writes.
+        assert!(
+            matches!(out.status, LoopStatus::Paused),
+            "no operator key ⇒ the protected write Pauses, got {:?}",
+            out.status
+        );
+        assert!(
+            !root.join("out.txt").exists(),
+            "the gate withheld the write — no file created (fail-closed, no bypass)"
+        );
+        // The Pause persisted a `pending_approval_request` with a CSPRNG nonce (S6d req 4),
+        // bound to THIS exact action, status `pending` — the offline operator's to-sign item.
+        let (count, nonce_len): (i64, i64) = rt
+            .db()
+            .conn()
+            .query_row(
+                "SELECT count(*), COALESCE(length(MAX(approval_id)),0) \
+                 FROM pending_approval_request WHERE run_id='run-appr' AND status='pending'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(count, 1, "exactly one pending request persisted on Pause");
+        assert_eq!(nonce_len, 64, "CSPRNG nonce is 32 bytes => 64 hex chars");
+        // No execution receipt on the hash-chain.
         let receipts: i64 = rt
             .db()
             .conn()
@@ -738,10 +801,7 @@ mod tests {
                 |r| r.get(0),
             )
             .unwrap();
-        assert_eq!(
-            receipts, 1,
-            "one execution receipt; the replay produced none"
-        );
+        assert_eq!(receipts, 0, "no mutation executed ⇒ no execution receipt");
         assert!(friday_storage::audit::verify_audit_chain(rt.db().conn()).is_ok());
     }
 
@@ -789,6 +849,7 @@ mod tests {
             principal_id: None, // the live save→recall→answer-carries-marker e2e is a separate proof (PR4)
             disabled_tools: vec![],
             read_only: false,
+            operator_vk: None, // the live operator-approved mutating-completion proof is S6e
         })
         .expect("live runtime assembles (FRIDAY_DEEPSEEK_API_KEY set)");
         let (sel, out) = rt

--- a/rust-core/crates/friday-hub/tests/s6d_resume_ingestion.rs
+++ b/rust-core/crates/friday-hub/tests/s6d_resume_ingestion.rs
@@ -1,0 +1,495 @@
+//! S6d adversarial suite — the protected-path switch (HMAC → Ed25519 verify-only), the
+//! operator-controlled verify-key provisioning, the resume/ingestion entrypoint, and the
+//! CSPRNG Pause nonce.
+//!
+//! This lives in `tests/` (NOT `src/`) BECAUSE it must construct an operator SIGNING key to
+//! play the offline operator — and `friday-hub/src/**` is forbidden from ever referencing
+//! `OperatorSigningKey` (the key-substitution defense, asserted by
+//! `operator_vk::tests::hub_crate_never_references_a_signing_key`). The Hub never holds a
+//! signing key; here the TEST holds it, exactly as the real operator does off-Hub.
+//!
+//! Coverage:
+//!   - protected action + NO approval → Pauses, executes nothing, persists a pending
+//!     request with a CSPRNG nonce (DenyAll-equivalent);
+//!   - protected action + VALID operator-Ed25519 approval → completes EXACTLY ONE mutation;
+//!     a SECOND ingest of the same approval → replay-refused (single-use), no 2nd mutation;
+//!   - HMAC downgrade: a protected action canNOT be Allowed by an HMAC approval, at the loop
+//!     AND at the resume entrypoint, even with an operator key provisioned;
+//!   - key-substitution: a DIFFERENT (attacker) operator key cannot resume; the operator's
+//!     signature only verifies under the operator's provisioned key;
+//!   - wrong-digest / expired / unknown-nonce → refused, no mutation.
+
+use std::cell::RefCell;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use friday_core::gate::{
+    canonical_action_bytes, canonical_approval_signature_bytes, ApprovalDecision,
+    CanonicalApproval, GateDecision, MutatingActionRequest, CANONICAL_GATE_ISSUER,
+};
+use friday_crypto::{OperatorSigningKey, OperatorVerifyingKey};
+use friday_hub::resume::{resume_with_approval, ResumeError};
+use friday_hub::{
+    build_request_with_policy, run_loop_with_policy, AgentError, AgentLlmClient, AgentStep,
+    FsToolExecutor, LoopStatus, RawToolCall, RunPolicy, TurnTrace,
+};
+use friday_storage::{agent_run, get_run_result, list_pending_requests_for_run, Db};
+
+static C: AtomicU64 = AtomicU64::new(0);
+
+fn unique(tag: &str) -> String {
+    format!(
+        "{}-{}-{}",
+        std::process::id(),
+        tag,
+        C.fetch_add(1, Ordering::Relaxed)
+    )
+}
+
+fn temp_db(tag: &str) -> String {
+    std::env::temp_dir()
+        .join(format!("friday-s6d-{}.sqlite", unique(tag)))
+        .to_string_lossy()
+        .into_owned()
+}
+
+struct Workspace(std::path::PathBuf);
+impl Workspace {
+    fn new(tag: &str) -> Self {
+        let p = std::env::temp_dir().join(format!("friday-s6d-ws-{}", unique(tag)));
+        std::fs::create_dir_all(&p).unwrap();
+        Workspace(p)
+    }
+    fn join(&self, n: &str) -> std::path::PathBuf {
+        self.0.join(n)
+    }
+}
+impl Drop for Workspace {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+/// A scripted model client: returns the next pre-canned `AgentStep` each turn, finishing
+/// when the script runs out. (Bills nothing — the default `next_step_metered`.)
+struct Script {
+    steps: RefCell<std::vec::IntoIter<AgentStep>>,
+}
+impl Script {
+    fn new(steps: Vec<AgentStep>) -> Self {
+        Script {
+            steps: RefCell::new(steps.into_iter()),
+        }
+    }
+}
+impl AgentLlmClient for Script {
+    fn propose_tool_call(&self, _task: &str) -> Result<RawToolCall, AgentError> {
+        // Unused: we override next_step. Fail closed if ever called.
+        Err(AgentError::Model("propose_tool_call unused".into()))
+    }
+    fn next_step(&self, _task: &str, _history: &[TurnTrace]) -> Result<AgentStep, AgentError> {
+        Ok(self.steps.borrow_mut().next().unwrap_or(AgentStep::Finish {
+            message: "done".into(),
+        }))
+    }
+}
+
+fn raw(action: &str, params: &[(&str, &str)]) -> RawToolCall {
+    RawToolCall {
+        action: action.to_string(),
+        params: params
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect(),
+    }
+}
+
+/// A fresh operator keypair; the Hub gets ONLY the verify key (the test plays the operator
+/// holding the signing key off-Hub).
+fn operator() -> (OperatorSigningKey, OperatorVerifyingKey) {
+    let sk = OperatorSigningKey::generate();
+    let vk = sk.verifying_key();
+    (sk, vk)
+}
+
+/// Build a correctly-signed operator Ed25519 approval bound to `req`'s exact digest.
+fn ed_approval(
+    req: &MutatingActionRequest,
+    sk: &OperatorSigningKey,
+    approval_id: &str,
+    expires_at: Option<i64>,
+) -> CanonicalApproval {
+    let digest = friday_crypto::action_digest(&canonical_action_bytes(req));
+    let mut a = CanonicalApproval {
+        decision: ApprovalDecision::Approved,
+        approval_id: approval_id.to_string(),
+        action_digest: digest,
+        expires_at,
+        issuer: Some(CANONICAL_GATE_ISSUER.to_string()),
+        signature: None,
+    };
+    a.signature = Some(sk.sign(&canonical_approval_signature_bytes(&a)).to_hex());
+    a
+}
+
+/// An HMAC-signed approval over the SAME canonical bytes — what a self-minting Hub would
+/// produce. The verify-only Ed25519 path must reject it.
+fn hmac_approval(
+    req: &MutatingActionRequest,
+    hub_secret: &[u8],
+    approval_id: &str,
+    expires_at: Option<i64>,
+) -> CanonicalApproval {
+    let digest = friday_crypto::action_digest(&canonical_action_bytes(req));
+    let mut a = CanonicalApproval {
+        decision: ApprovalDecision::Approved,
+        approval_id: approval_id.to_string(),
+        action_digest: digest,
+        expires_at,
+        issuer: Some(CANONICAL_GATE_ISSUER.to_string()),
+        signature: None,
+    };
+    a.signature = Some(friday_crypto::sign_approval(
+        &canonical_approval_signature_bytes(&a),
+        hub_secret,
+    ));
+    a
+}
+
+fn no_approval() -> impl Fn(&MutatingActionRequest) -> Option<CanonicalApproval> {
+    |_req| None
+}
+
+const NOW: i64 = 1_000;
+const FUTURE: i64 = 5_000_000_000_000;
+
+// ─────────────────────────── loop-level: the protected-path switch ───────────────────────────
+
+/// Protected action + NO approval → the loop Pauses, executes nothing, and persists a
+/// pending request with a CSPRNG nonce (DenyAll-equivalent), EVEN WITH an operator key
+/// provisioned. (No approval is presented in-loop; the operator approves OFFLINE.)
+#[test]
+fn loop_protected_no_approval_pauses_and_persists_csprng_pending() {
+    let db = Db::open_hub(&temp_db("pause")).unwrap();
+    let ws = Workspace::new("pause");
+    agent_run::create_run(db.conn(), "run-pause", "write a file", 1).unwrap();
+    let (_sk, vk) = operator();
+    let client = Script::new(vec![AgentStep::Tool(raw(
+        "write_file",
+        &[("path", "out.txt"), ("content", "X")],
+    ))]);
+    let exec = FsToolExecutor::new(&ws.0);
+
+    let out = run_loop_with_policy(
+        &client,
+        &exec,
+        db.conn(),
+        "run-pause",
+        "write a file",
+        "",
+        Some(&vk), // operator key provisioned, but NO in-loop approval is presented
+        &no_approval(),
+        &RunPolicy::default(),
+        5,
+        NOW,
+    )
+    .unwrap();
+
+    assert_eq!(out.status, LoopStatus::Paused);
+    assert_eq!(
+        out.executed_tools, 0,
+        "nothing executes without an approval"
+    );
+    assert!(!ws.join("out.txt").exists(), "no file written on Pause");
+
+    let pending = list_pending_requests_for_run(db.conn(), "run-pause").unwrap();
+    assert_eq!(pending.len(), 1, "one pending request persisted on Pause");
+    let p = &pending[0];
+    assert_eq!(
+        p.approval_id.len(),
+        64,
+        "CSPRNG nonce is 32 bytes => 64 hex"
+    );
+    assert!(
+        p.approval_id.bytes().all(|c| c.is_ascii_hexdigit()),
+        "nonce is hex"
+    );
+    assert_eq!(p.action, "write_file");
+    assert_eq!(p.status, "pending");
+    assert!(
+        p.tool_params.is_some(),
+        "the executable tool call is persisted"
+    );
+}
+
+/// Protected action + a VALID in-loop operator-Ed25519 approval → the mutation executes
+/// EXACTLY once (the file is written). The positive control for the switch.
+#[test]
+fn loop_valid_ed25519_approval_executes_the_mutation() {
+    let db = Db::open_hub(&temp_db("loop-ok")).unwrap();
+    let ws = Workspace::new("loop-ok");
+    agent_run::create_run(db.conn(), "run-ok", "write a file", 1).unwrap();
+    let (sk, vk) = operator();
+    let exec = FsToolExecutor::new(&ws.0);
+    let client = Script::new(vec![
+        AgentStep::Tool(raw("write_file", &[("path", "out.txt"), ("content", "OK")])),
+        AgentStep::Finish {
+            message: "done".into(),
+        },
+    ]);
+    // In-loop "operator" approval seam: sign an Ed25519 approval bound to THIS request.
+    let approve =
+        |req: &MutatingActionRequest| Some(ed_approval(req, &sk, "ap-loop", Some(FUTURE)));
+
+    let out = run_loop_with_policy(
+        &client,
+        &exec,
+        db.conn(),
+        "run-ok",
+        "write a file",
+        "",
+        Some(&vk),
+        &approve,
+        &RunPolicy::default(),
+        5,
+        NOW,
+    )
+    .unwrap();
+    assert_eq!(out.status, LoopStatus::Finished);
+    assert_eq!(out.executed_tools, 1, "the approved mutation executed once");
+    assert_eq!(std::fs::read_to_string(ws.join("out.txt")).unwrap(), "OK");
+}
+
+/// HMAC downgrade closed AT THE LOOP, even WITH an operator key provisioned: an in-loop
+/// HMAC-signed approval over the same bytes can NOT Allow the protected write — it is a
+/// gate Deny → the loop Blocks, executes nothing, writes no file.
+#[test]
+fn loop_hmac_approval_cannot_execute_even_with_operator_key() {
+    let db = Db::open_hub(&temp_db("loop-hmac")).unwrap();
+    let ws = Workspace::new("loop-hmac");
+    agent_run::create_run(db.conn(), "run-h", "write a file", 1).unwrap();
+    let (_sk, vk) = operator();
+    let hub_secret = b"hub-held-hmac-secret-0123456789ab";
+    let exec = FsToolExecutor::new(&ws.0);
+    let client = Script::new(vec![AgentStep::Tool(raw(
+        "write_file",
+        &[("path", "out.txt"), ("content", "X")],
+    ))]);
+    let approve =
+        |req: &MutatingActionRequest| Some(hmac_approval(req, hub_secret, "ap-h", Some(FUTURE)));
+
+    let out = run_loop_with_policy(
+        &client,
+        &exec,
+        db.conn(),
+        "run-h",
+        "write a file",
+        "",
+        Some(&vk),
+        &approve,
+        &RunPolicy::default(),
+        5,
+        NOW,
+    )
+    .unwrap();
+    assert_eq!(
+        out.status,
+        LoopStatus::Blocked,
+        "an HMAC approval is a gate Deny ⇒ the loop Blocks"
+    );
+    assert_eq!(out.executed_tools, 0);
+    assert!(
+        !ws.join("out.txt").exists(),
+        "the HMAC approval did not complete the mutation (downgrade closed)"
+    );
+}
+
+// ─────────────────────────── resume/ingestion entrypoint ───────────────────────────
+
+/// Drive a run to a Pause, return (db, ws, pending nonce, the reconstructed request) so a
+/// resume test can sign + ingest an approval for the EXACT paused action.
+fn pause_a_run(
+    tag: &str,
+    vk: &OperatorVerifyingKey,
+) -> (Db, Workspace, String, MutatingActionRequest) {
+    let db = Db::open_hub(&temp_db(tag)).unwrap();
+    let ws = Workspace::new(tag);
+    let run_id = "run-resume";
+    agent_run::create_run(db.conn(), run_id, "write a file", 1).unwrap();
+    let call = raw("write_file", &[("path", "out.txt"), ("content", "RESUMED")]);
+    let client = Script::new(vec![AgentStep::Tool(call.clone())]);
+    let exec = FsToolExecutor::new(&ws.0);
+    let out = run_loop_with_policy(
+        &client,
+        &exec,
+        db.conn(),
+        run_id,
+        "write a file",
+        "",
+        Some(vk),
+        &no_approval(),
+        &RunPolicy::default(),
+        5,
+        NOW,
+    )
+    .unwrap();
+    assert_eq!(out.status, LoopStatus::Paused);
+    let pending = list_pending_requests_for_run(db.conn(), run_id).unwrap();
+    let nonce = pending[0].approval_id.clone();
+    let request = build_request_with_policy(&call, &RunPolicy::default()).unwrap();
+    (db, ws, nonce, request)
+}
+
+/// THE core S6d flow: resume with a valid operator approval executes EXACTLY ONE mutation;
+/// a SECOND ingest of the same approval is replay-refused (single-use), with NO 2nd mutation.
+#[test]
+fn resume_executes_one_mutation_then_replay_is_refused() {
+    let (sk, vk) = operator();
+    let (db, ws, nonce, request) = pause_a_run("resume-ok", &vk);
+    let exec = FsToolExecutor::new(&ws.0);
+
+    // The offline operator signs the pending nonce's exact digest.
+    let approval = ed_approval(&request, &sk, &nonce, Some(FUTURE));
+
+    // First ingest → Allow → executes the one mutation.
+    let r1 = resume_with_approval(db.conn(), &exec, &vk, &approval, NOW).unwrap();
+    assert_eq!(r1.decision, GateDecision::Allow);
+    assert!(r1.executed, "the approved mutation executed");
+    assert_eq!(r1.result_status, "mutation_completed");
+    assert_eq!(
+        std::fs::read_to_string(ws.join("out.txt")).unwrap(),
+        "RESUMED",
+        "the file the operator approved was written"
+    );
+    // Truth-labeled, proof-linked result persisted, linking the audit receipt.
+    let stored = get_run_result(db.conn(), &r1.run_id).unwrap().unwrap();
+    assert_eq!(stored.status, "mutation_completed");
+    assert!(stored.audit_ref.is_some(), "result links the audit receipt");
+
+    // Tamper the file so a (refused) second execution would be detectable.
+    std::fs::write(ws.join("out.txt"), b"TAMPERED").unwrap();
+
+    // Second ingest of the SAME approval → replay-refused (consumed nonce), no 2nd mutation.
+    let r2 = resume_with_approval(db.conn(), &exec, &vk, &approval, NOW).unwrap();
+    assert_eq!(r2.decision, GateDecision::Deny);
+    assert_eq!(r2.reason, "canonical_approval_replay_refused");
+    assert!(!r2.executed, "replay must not execute a second mutation");
+    assert_eq!(
+        std::fs::read_to_string(ws.join("out.txt")).unwrap(),
+        "TAMPERED",
+        "the file was NOT re-written by the replay"
+    );
+}
+
+/// HMAC downgrade closed at the RESUME entrypoint: an HMAC-signed approval over the paused
+/// action's exact digest is refused (never a valid Ed25519 signature); no mutation runs.
+#[test]
+fn resume_refuses_an_hmac_signed_approval() {
+    let (_sk, vk) = operator();
+    let (db, ws, nonce, request) = pause_a_run("resume-hmac", &vk);
+    let exec = FsToolExecutor::new(&ws.0);
+    let hub_secret = b"hub-held-hmac-secret-0123456789ab";
+
+    let approval = hmac_approval(&request, hub_secret, &nonce, Some(FUTURE));
+    let r = resume_with_approval(db.conn(), &exec, &vk, &approval, NOW).unwrap();
+    assert_eq!(r.decision, GateDecision::Deny);
+    assert_eq!(r.reason, "canonical_approval_signature_invalid");
+    assert!(!r.executed);
+    assert!(
+        !ws.join("out.txt").exists(),
+        "no mutation on an HMAC approval"
+    );
+}
+
+/// Key-substitution impossible: the operator signs, but resume is asked to verify under a
+/// DIFFERENT (attacker) operator key → refused. The Hub can only verify under the key it
+/// was provisioned with; it never generates the key it verifies against (the provisioning
+/// + source-scan guarantees are in `operator_vk`).
+#[test]
+fn resume_refuses_under_a_substituted_operator_key() {
+    let (operator_sk, operator_vk) = operator();
+    let (attacker_sk, attacker_vk) = operator();
+    let (db, ws, nonce, request) = pause_a_run("resume-subst", &operator_vk);
+    let exec = FsToolExecutor::new(&ws.0);
+
+    // The REAL operator signs. Resume under the ATTACKER's key → invalid signature.
+    let approval = ed_approval(&request, &operator_sk, &nonce, Some(FUTURE));
+    let r = resume_with_approval(db.conn(), &exec, &attacker_vk, &approval, NOW).unwrap();
+    assert_eq!(r.decision, GateDecision::Deny);
+    assert_eq!(r.reason, "canonical_approval_signature_invalid");
+    assert!(!r.executed);
+
+    // And an approval the ATTACKER signs is refused under the OPERATOR's provisioned key.
+    let forged = ed_approval(&request, &attacker_sk, &nonce, Some(FUTURE));
+    let r2 = resume_with_approval(db.conn(), &exec, &operator_vk, &forged, NOW).unwrap();
+    assert_eq!(r2.decision, GateDecision::Deny);
+    assert_eq!(r2.reason, "canonical_approval_signature_invalid");
+    assert!(
+        !ws.join("out.txt").exists(),
+        "no mutation under any wrong key"
+    );
+}
+
+/// An EXPIRED operator approval is refused (fail-closed); no mutation runs.
+#[test]
+fn resume_refuses_an_expired_approval() {
+    let (sk, vk) = operator();
+    let (db, ws, nonce, request) = pause_a_run("resume-exp", &vk);
+    let exec = FsToolExecutor::new(&ws.0);
+
+    let approval = ed_approval(&request, &sk, &nonce, Some(500)); // past (< NOW)
+    let r = resume_with_approval(db.conn(), &exec, &vk, &approval, NOW).unwrap();
+    assert_eq!(r.decision, GateDecision::Deny);
+    assert_eq!(r.reason, "canonical_approval_expired");
+    assert!(!r.executed);
+    assert!(!ws.join("out.txt").exists());
+}
+
+/// A WRONG-DIGEST approval (the operator signs a DIFFERENT action's digest, but the
+/// approval carries the paused nonce) is refused at the digest cross-check — before any
+/// signature verification consumes the nonce. (Wrong-principal manifests identically: the
+/// principal is bound INTO the digest.)
+#[test]
+fn resume_refuses_a_wrong_digest_approval() {
+    let (sk, vk) = operator();
+    let (db, ws, nonce, _request) = pause_a_run("resume-digest", &vk);
+    let exec = FsToolExecutor::new(&ws.0);
+
+    // Sign an approval for a DIFFERENT action, but carry the paused nonce + a bogus digest.
+    let other = build_request_with_policy(
+        &raw("write_file", &[("path", "OTHER.txt"), ("content", "Z")]),
+        &RunPolicy::default(),
+    )
+    .unwrap();
+    let mut approval = ed_approval(&other, &sk, &nonce, Some(FUTURE));
+    // The approval's digest is `other`'s — different from the pending row's. Cross-check fails.
+    let err = resume_with_approval(db.conn(), &exec, &vk, &approval, NOW).unwrap_err();
+    assert!(matches!(err, ResumeError::DigestMismatch));
+    assert!(!ws.join("out.txt").exists());
+
+    // Sanity: even if an attacker overwrites the digest to match the pending row, the
+    // SIGNATURE (over the other digest) no longer matches the claimed digest ⇒ gate Deny.
+    let pending = list_pending_requests_for_run(db.conn(), "run-resume").unwrap();
+    approval.action_digest = pending[0].action_digest.clone();
+    let r = resume_with_approval(db.conn(), &exec, &vk, &approval, NOW).unwrap();
+    assert_eq!(r.decision, GateDecision::Deny);
+    assert_eq!(r.reason, "canonical_approval_signature_invalid");
+    assert!(!ws.join("out.txt").exists());
+}
+
+/// An approval whose nonce matches NO pending request is refused (nothing to resume).
+#[test]
+fn resume_refuses_an_unknown_nonce() {
+    let (sk, vk) = operator();
+    let (db, ws, _nonce, request) = pause_a_run("resume-unknown", &vk);
+    let exec = FsToolExecutor::new(&ws.0);
+
+    let approval = ed_approval(
+        &request,
+        &sk,
+        "nonce-that-was-never-persisted",
+        Some(FUTURE),
+    );
+    let err = resume_with_approval(db.conn(), &exec, &vk, &approval, NOW).unwrap_err();
+    assert!(matches!(err, ResumeError::UnknownNonce));
+    assert!(!ws.join("out.txt").exists());
+}

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -37,7 +37,7 @@ pub use migrate::{
 };
 pub use pending_request::{
     get_pending_request, list_pending_requests_for_run, persist_pending_request,
-    PendingApprovalRequest,
+    set_pending_status, PendingApprovalRequest,
 };
 pub use run_result::{
     get_run_result, get_run_result_ref, persist_run_result, PersistRunResultOutcome, RunResult,

--- a/rust-core/crates/friday-storage/src/pending_request.rs
+++ b/rust-core/crates/friday-storage/src/pending_request.rs
@@ -51,6 +51,14 @@ pub struct PendingApprovalRequest {
     /// here).
     pub status: String,
     pub created_at: i64,
+    /// S6d: the raw tool-call key/value pairs (JSON `[[k,v],...]`) the run Paused on, so
+    /// the resume entrypoint can re-execute the EXACT approved mutation. `None` for a
+    /// pre-S6d row (the column is a nullable additive ALTER). The `action_digest` already
+    /// binds these params transitively — the resume path recomputes the digest from the
+    /// reconstructed call and cross-checks it, so a tampered `tool_params` cannot make a
+    /// DIFFERENT mutation match the operator's signed approval. Hub-side only (never the
+    /// wire).
+    pub tool_params: Option<String>,
 }
 
 impl PendingApprovalRequest {
@@ -84,7 +92,16 @@ impl PendingApprovalRequest {
             issuer: CANONICAL_GATE_ISSUER.to_string(),
             status: "pending".to_string(),
             created_at,
+            tool_params: None,
         }
+    }
+
+    /// Attach the raw tool-call params (JSON) the run Paused on (S6d), so the resume
+    /// entrypoint can re-execute the EXACT approved mutation. Returns `self` for a
+    /// builder-style call right after [`PendingApprovalRequest::for_request`].
+    pub fn with_tool_params(mut self, tool_params: Option<String>) -> Self {
+        self.tool_params = tool_params;
+        self
     }
 }
 
@@ -94,8 +111,8 @@ pub fn persist_pending_request(conn: &Connection, req: &PendingApprovalRequest) 
     conn.execute(
         "INSERT INTO pending_approval_request (
             approval_id, run_id, action, action_digest, principal_id, surface,
-            resource_type, resource_id, expires_at, issuer, status, created_at
-         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+            resource_type, resource_id, expires_at, issuer, status, created_at, tool_params
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
         params![
             req.approval_id,
             req.run_id,
@@ -109,9 +126,23 @@ pub fn persist_pending_request(conn: &Connection, req: &PendingApprovalRequest) 
             req.issuer,
             req.status,
             req.created_at,
+            req.tool_params,
         ],
     )?;
     Ok(())
+}
+
+/// Mark a pending request resolved (S6d), e.g. `consumed` after a successful resume or
+/// `denied` after a refused one. Idempotent bookkeeping ONLY — the load-bearing
+/// single-use guarantee is the gate's `consumed_approval` nonce store, which already
+/// makes a second ingest of the same approval a replay-refused Deny regardless of this
+/// status. Returns the number of rows updated (0 if the nonce is unknown).
+pub fn set_pending_status(conn: &Connection, approval_id: &str, status: &str) -> Result<usize> {
+    let n = conn.execute(
+        "UPDATE pending_approval_request SET status = ?2 WHERE approval_id = ?1",
+        params![approval_id, status],
+    )?;
+    Ok(n)
 }
 
 fn row_to_pending(row: &rusqlite::Row) -> rusqlite::Result<PendingApprovalRequest> {
@@ -128,11 +159,12 @@ fn row_to_pending(row: &rusqlite::Row) -> rusqlite::Result<PendingApprovalReques
         issuer: row.get(9)?,
         status: row.get(10)?,
         created_at: row.get(11)?,
+        tool_params: row.get(12)?,
     })
 }
 
 const SELECT_COLS: &str = "approval_id, run_id, action, action_digest, principal_id, surface, \
-     resource_type, resource_id, expires_at, issuer, status, created_at";
+     resource_type, resource_id, expires_at, issuer, status, created_at, tool_params";
 
 /// Read a pending request by its `approval_id` nonce. `None` if absent.
 pub fn get_pending_request(

--- a/rust-core/crates/friday-storage/src/schema.rs
+++ b/rust-core/crates/friday-storage/src/schema.rs
@@ -200,6 +200,20 @@ pub fn hub_migrations() -> Vec<Migration> {
             destructive: false,
             up: m0015_run_result,
         },
+        // S6d: add the executable tool call (`tool_params`, the raw key/value pairs as
+        // JSON) to a Hub-only pending request, so the resume/ingestion entrypoint can
+        // re-execute the EXACT mutation the operator approved after the run Paused. The
+        // `action_digest` already binds these params transitively, so the resume path
+        // cross-checks the reconstructed digest against the stored one; this column only
+        // makes the call REPLAYABLE Hub-side (it never crosses the wire). Purely additive
+        // (a nullable ALTER) — pre-S6d `pending_approval_request` rows read back with
+        // `tool_params = NULL` and every existing query is unaffected.
+        Migration {
+            version: 16,
+            name: "pending_approval_tool_params",
+            destructive: false,
+            up: m0016_pending_approval_tool_params,
+        },
     ]
 }
 
@@ -1103,4 +1117,12 @@ fn m0014_pending_approval_request(tx: &Transaction) -> rusqlite::Result<()> {
 fn m0015_run_result(tx: &Transaction) -> rusqlite::Result<()> {
     tx.execute_batch(DDL_RUN_RESULT)?;
     Ok(())
+}
+
+// S6d: additive nullable `tool_params` column on `pending_approval_request` (the raw
+// tool-call key/value pairs as JSON), so the resume entrypoint can re-execute the exact
+// approved mutation. `ALTER TABLE ... ADD COLUMN` with no default is additive and
+// back-compatible: existing v14 rows read back as `NULL`.
+fn m0016_pending_approval_tool_params(tx: &Transaction) -> rusqlite::Result<()> {
+    tx.execute_batch("ALTER TABLE pending_approval_request ADD COLUMN tool_params TEXT;")
 }

--- a/rust-core/crates/friday-storage/tests/authorize_ed25519.rs
+++ b/rust-core/crates/friday-storage/tests/authorize_ed25519.rs
@@ -519,3 +519,55 @@ fn pending_request_persists_with_correct_binding_and_rejects_duplicate_nonce() {
         "duplicate approval_id (nonce) must be refused"
     );
 }
+
+/// S6d: the persisted tool call (`tool_params`, JSON) round-trips, and `set_pending_status`
+/// updates the lifecycle status — the substrate the resume entrypoint relies on to
+/// re-execute the EXACT approved mutation and mark it consumed.
+#[test]
+fn pending_tool_params_round_trip_and_status_update() {
+    use friday_storage::set_pending_status;
+    let db = Db::open_hub(&temp_db_path("ed-toolparams")).unwrap();
+    let req = mutating_req();
+
+    let pending = PendingApprovalRequest::for_request(&req, "ap-tp", "run-tp", FUTURE, NOW)
+        .with_tool_params(Some(r#"[["path","/data/secret.db"]]"#.to_string()));
+    persist_pending_request(db.conn(), &pending).unwrap();
+
+    let got = get_pending_request(db.conn(), "ap-tp").unwrap().unwrap();
+    assert_eq!(
+        got.tool_params.as_deref(),
+        Some(r#"[["path","/data/secret.db"]]"#),
+        "the executable tool call round-trips Hub-side"
+    );
+    assert_eq!(got.status, "pending");
+
+    // A pre-S6d row (built without tool_params) reads back NULL — the additive column is
+    // back-compatible.
+    let legacy = PendingApprovalRequest::for_request(&req, "ap-legacy", "run-tp", FUTURE, NOW);
+    persist_pending_request(db.conn(), &legacy).unwrap();
+    assert_eq!(
+        get_pending_request(db.conn(), "ap-legacy")
+            .unwrap()
+            .unwrap()
+            .tool_params,
+        None
+    );
+
+    // Status update (bookkeeping; the load-bearing single-use guard is consumed_approval).
+    assert_eq!(
+        set_pending_status(db.conn(), "ap-tp", "consumed").unwrap(),
+        1
+    );
+    assert_eq!(
+        get_pending_request(db.conn(), "ap-tp")
+            .unwrap()
+            .unwrap()
+            .status,
+        "consumed"
+    );
+    // Unknown nonce updates nothing.
+    assert_eq!(
+        set_pending_status(db.conn(), "nope", "consumed").unwrap(),
+        0
+    );
+}


### PR DESCRIPTION
## Truth label
**Operator-approved mutating completion is now WIRED + mechanism-tested.** The agent loop's protected (mutating) path authorizes against an operator-provisioned Ed25519 PUBLIC key (verify-only), and a new resume/ingestion entrypoint verifies an operator-signed approval and executes the ONE approved mutation. The **LIVE proof with a real operator-held key is S6e** (key-custody gate). `executeRun` is NOT replaced (this is the dev-bridge completion leg). **PROOF-ONLY; NOT v1 GO.**

## The protected-path switch (HMAC → Ed25519)
`gate_dispatch_with_policy` now takes an explicit `AuthzMode`:
- **`Ed25519(operator_vk)`** — the LOOP, operator key provisioned: a protected (`RequiresApproval`) action is authorized by `authorize_mutating_action_ed25519` (signature ALWAYS verified as Ed25519 under the operator's PUBLIC key).
- **`DenyAll`** — the LOOP, unprovisioned: fail-closed, the base decision stands, a `RequiresApproval` is never upgraded (Pause).
- **`Hmac(secret)`** — the **`workflow_exec` driver only**, unchanged by this slice (its Ed25519 switch is a separate follow-up lane).

The loop **never** selects `Hmac`, so **a protected action can no longer be Allowed by an HMAC approval** — closing the latent self-Allow the S6a/S6b adversarial passes flagged. An HMAC hex isn't a 64-byte Ed25519 signature, and even a right-sized value is invalid without the operator's offline private key.

## operator_vk provisioning — operator-controlled (the linchpin) + fail-closed
New `operator_vk` module loads the operator PUBLIC verify key from an **operator-controlled source**: a file the operator wrote from the S6c CLI `keygen` (`FRIDAY_OPERATOR_VK_PATH` / `--operator-vk-path`) or a `SecureStore` entry the operator provisioned. Threaded through `HubConfig`/`HubRuntime`; `HubRuntime::live` resolves it from the env path.
- **No operator key provisioned ⇒ fail-closed**: protected actions Pause, never Allow.
- A configured-but-malformed source ⇒ a **hard error** (never silently degrades to "no key").
- **Key-substitution prevented structurally**: the Hub only ever PARSES operator-supplied bytes via `OperatorVerifyingKey::from_bytes` — it never generates/derives a keypair as `operator_vk`. A source-scan test asserts `friday-hub/src/**` never references `OperatorSigningKey` (a Hub-generated operator key would be full self-mint).

## Resume / ingestion entrypoint
`resume::resume_with_approval` (+ thin `hub_resume_approval` bin): looks up the pending request by its CSPRNG **nonce**, reconstructs the exact tool call, **cross-checks the digest** (reconstructed == pending == approval), verifies the Ed25519 approval (expiry + single-use), executes the ONE approved mutation, and records a **truth-labeled, proof-linked** result (refs-only readback). It **never mints — only verifies + consumes**. Refuses: replay (single-use nonce), wrong digest/principal, expired, and HMAC-for-protected.

## CSPRNG nonce
`friday_crypto::generate_approval_nonce` (OsRng) generates the pending-request `approval_id` (32 bytes → 64 hex; unpredictable, not a counter/clock).

## Storage
Additive v16 migration adds a nullable `tool_params` column to `pending_approval_request` so the resume can replay the EXACT approved mutation (Hub-side only; never over the wire — the digest already binds it). + `set_pending_status`.

## Adversarial tests (`tests/s6d_resume_ingestion.rs`, 9 tests)
- protected + NO approval → Pauses, executes nothing, persists a CSPRNG-nonce pending request;
- protected + VALID operator-Ed25519 approval → completes EXACTLY ONE mutation; **second ingest → replay-refused**, no 2nd mutation;
- **HMAC-downgrade closed** at the loop AND the resume entrypoint, even with an operator key provisioned;
- **key-substitution impossible** (a different/attacker key cannot resume);
- wrong-digest / expired / unknown-nonce → refused, no mutation.

Plus: `operator_vk` unit tests (path/SecureStore load, fail-closed, source-scan); storage `tool_params` round-trip; composed-runtime fail-closed (an HMAC mint cannot complete a protected mutation).

## Scope / honesty
- The bound-principal rule (Agent/Channel can never self-approve) is intact (decided before any signature). No blanket flag. The wire/refs-only contract is unchanged; no answer-body-over-wire (Q1 later slice).
- **Residual (out of scope, separate lanes, documented):** `workflow_exec` keeps its legacy HMAC path; `skill_catalog` and the `run_one_turn*` test tracers still use the HMAC authorize. None is the live loop (HubRuntime → run_loop), which is fully switched.
- No live mutating-completion proof here (no real operator key — that is S6e).

## Local gate (all green)
`cargo fmt` clean · `cargo build -p friday-hub --bins` clean · `cargo clippy --workspace --all-targets -- -D warnings` clean · `cargo test -p friday-hub -p friday-core -p friday-storage -p friday-crypto` all pass · `npm run lint` 0 errors · `npm run typecheck` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)