### PR TITLE
feat(rust-storage): D1-Q1 — authenticated (owner-principal-gated) answer-body projection

### DIFF
--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -40,8 +40,9 @@ pub use pending_request::{
     set_pending_status, PendingApprovalRequest,
 };
 pub use run_result::{
-    get_run_result, get_run_result_ref, persist_run_result, PersistRunResultOutcome, RunResult,
-    RunResultRef, StoredRunResult,
+    get_run_answer_for_principal, get_run_result, get_run_result_ref, persist_run_result,
+    AnswerDenyReason, PersistRunResultOutcome, RunAnswerAccess, RunResult, RunResultRef,
+    StoredRunResult,
 };
 pub use schema::{hub_migrations, phone_migrations, HUB_ONLY_TABLES, PHONE_ONLY_TABLES};
 

--- a/rust-core/crates/friday-storage/src/run_result.rs
+++ b/rust-core/crates/friday-storage/src/run_result.rs
@@ -8,22 +8,30 @@
 //! per run so the answer can be read back later by the future production route, UI
 //! live-data, and device proof-capture.
 //!
-//! ## Two reads, one boundary (the refs-only wire contract is UNCHANGED)
-//! The store holds the answer TEXT Hub-side, but exposes TWO distinct reads:
+//! ## Three reads, one boundary (the refs-only wire contract is UNCHANGED)
+//! The store holds the answer TEXT Hub-side, but exposes THREE distinct reads —
+//! the security boundary is which one a surface is allowed to call:
 //!
 //! * [`get_run_result`] returns the full [`StoredRunResult`] INCLUDING the answer
-//!   body. This is **Hub-internal only** — for a future production route / UI
-//!   live-data path that runs ON the Hub and is entitled to the body. It must
-//!   never be piped to the `hub_run_readback` bin or any TS-facing/over-the-wire
-//!   surface.
+//!   body. This is **Hub-internal only** — for a Hub-side path entitled to the body.
+//!   It must never be piped to the `hub_run_readback` bin or any TS-facing surface.
 //! * [`get_run_result_ref`] returns the refs-only [`RunResultRef`] — `status` +
-//!   `answer_sha256` + `answer_len` (+ created/audit refs), and **NO answer body**.
-//!   This is the S2-style projection the TS-facing readback consumes, exactly like
-//!   [`crate::agent_run_read::get_run_summary`] omits the run `task` body.
+//!   `answer_sha256` + `answer_len` (+ created/audit refs), and **NO answer body**
+//!   (and **no owner principal**). This is the **(a) refs-only proof projection** the
+//!   public / unauthenticated readback consumes, exactly like
+//!   [`crate::agent_run_read::get_run_summary`] omits the run `task` body. UNCHANGED.
+//! * [`get_run_answer_for_principal`] (D1-Q1) is the **(b) authenticated answer-body
+//!   projection**: it returns the body ONLY to a caller whose principal matches the
+//!   run's bound OWNER principal (recorded in the `owner_principal` column), and
+//!   FAILS CLOSED otherwise (no owner / anonymous owner / anonymous caller / wrong
+//!   principal all DENY — body withheld). The denying / not-found outcomes carry
+//!   neither the body nor the owner id. The transport that authenticates the caller
+//!   and supplies a trusted `caller_principal` is a later slice (D1-Q4).
 //!
-//! Whether an answer body is EVER transported off-Hub is a deferred PRIVACY
-//! decision the operator owns; this module deliberately keeps the body Hub-side
-//! and gives the wire only fingerprints (sha256 + length + status).
+//! Whether an answer body is EVER transported off-Hub is a PRIVACY decision the
+//! operator owns; D1-Q1 admits exactly ONE off-Hub path — to the authenticated
+//! OWNER — while the wire's proof surface still gets only fingerprints (sha256 +
+//! length + status), never the body and never the owner principal.
 //!
 //! ## Fingerprint cannot drift from the body
 //! `answer_sha256` + `answer_len` are DERIVED from the answer bytes at the persist
@@ -45,6 +53,7 @@
 //! capture are NOT wired (later tracks). PROOF-ONLY; NOT a v1 GO.
 
 use crate::error::{Result, StorageError};
+use friday_core::gate::{is_anonymous_principal, Actor, ActorKind};
 use rusqlite::{params, Connection, OptionalExtension};
 use sha2::{Digest, Sha256};
 
@@ -65,10 +74,21 @@ pub struct RunResult {
     /// Optional soft link to the audit-ledger receipt for this run (a `TEXT` ref,
     /// no FK — matches the established `*_ref` soft-link convention).
     pub audit_ref: Option<String>,
+    /// D1-Q1: the run's bound OWNER principal — WHO is entitled to read the answer
+    /// BODY back via the authenticated projection ([`get_run_answer_for_principal`]).
+    /// `None` (the default) means NO owner is recorded, which FAILS CLOSED on the
+    /// body read (an unowned answer is never released to anyone). S4 binds this
+    /// principal at runtime into the gate `Actor`/digest; a persist caller that
+    /// knows the run's principal records it here via [`RunResult::with_owner_principal`]
+    /// so the authenticated readback can enforce `caller == owner`.
+    pub owner_principal: Option<String>,
 }
 
 impl RunResult {
-    /// Convenience constructor.
+    /// Convenience constructor. The owner principal defaults to `None`
+    /// (fail-closed: no authenticated body read until an owner is recorded via
+    /// [`RunResult::with_owner_principal`]). This signature is deliberately
+    /// unchanged so existing callers compile untouched.
     pub fn new(
         status: impl Into<String>,
         answer: impl Into<String>,
@@ -78,12 +98,23 @@ impl RunResult {
             status: status.into(),
             answer: answer.into(),
             audit_ref,
+            owner_principal: None,
         }
+    }
+
+    /// Record the run's bound OWNER principal (D1-Q1). This is the principal the
+    /// authenticated answer-body read ([`get_run_answer_for_principal`]) matches
+    /// `caller_principal` against; without it the body read fails closed.
+    #[must_use]
+    pub fn with_owner_principal(mut self, owner_principal: impl Into<String>) -> Self {
+        self.owner_principal = Some(owner_principal.into());
+        self
     }
 }
 
 /// A full Hub-side run-result record, INCLUDING the answer body. Returned by
-/// [`get_run_result`] for Hub-internal callers only — never the wire.
+/// [`get_run_result`] for Hub-internal callers only — never the wire. Also the
+/// payload of an ownership-GRANTED authenticated read ([`RunAnswerAccess::Granted`]).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct StoredRunResult {
     pub run_id: String,
@@ -96,6 +127,9 @@ pub struct StoredRunResult {
     pub answer_len: i64,
     pub audit_ref: Option<String>,
     pub created_at: i64,
+    /// D1-Q1: the run's bound OWNER principal (the axis the authenticated body read
+    /// keys on). `None` ⇒ no owner recorded ⇒ fail-closed on the body read.
+    pub owner_principal: Option<String>,
 }
 
 /// A REFS-ONLY projection of a run result: status + the answer fingerprint
@@ -121,6 +155,54 @@ pub struct RunResultRef {
 pub enum PersistRunResultOutcome {
     Persisted,
     DuplicateIdentical,
+}
+
+/// The outcome of an OWNERSHIP-GATED answer-body read ([`get_run_answer_for_principal`]).
+///
+/// This is the **(b) authenticated answer-body projection** — distinct from the
+/// **(a) refs-only proof projection** ([`get_run_result_ref`]). The answer BODY is
+/// released ONLY in [`RunAnswerAccess::Granted`]; every other variant is BODY-free
+/// AND OWNER-ID-free, so a denied (non-owner / anonymous) caller learns nothing
+/// about the answer or who owns it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RunAnswerAccess {
+    /// The caller's principal matched the run's bound owner principal: the full
+    /// [`StoredRunResult`] (INCLUDING the answer body) is released to this
+    /// authenticated owner.
+    Granted(StoredRunResult),
+    /// Access denied — the answer body is WITHHELD. Carries only a coarse,
+    /// body-free, owner-id-free [`AnswerDenyReason`]; never the answer or the owner.
+    Denied(AnswerDenyReason),
+    /// No stored result exists for this `run_id` (nothing to read).
+    NotFound,
+}
+
+/// Why an ownership-gated answer-body read was denied. Deliberately PAYLOAD-FREE:
+/// it carries neither the answer body nor the run's owner principal, so a denied
+/// caller learns nothing beyond "denied, for this coarse reason".
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AnswerDenyReason {
+    /// The run has NO bound owner principal (NULL / empty / `public` / `public:default`).
+    /// Fail-closed: an answer with no real owner is released to NO ONE (no anonymous
+    /// body access).
+    NoOwnerPrincipal,
+    /// The CALLER's principal is anonymous / public / empty — a public caller never
+    /// reads an answer body.
+    AnonymousCaller,
+    /// The caller is a known, non-anonymous principal but is NOT the run's owner.
+    PrincipalMismatch,
+}
+
+/// True if `principal` is anonymous / public / empty under the SAME sentinel set
+/// the gate uses ([`friday_core::gate::is_anonymous_principal`]), so `""`, `"public"`,
+/// and `"public:default"` all fail closed. The actor `kind`/`id` are irrelevant to
+/// that check (it inspects only `principal_id`); we pass a placeholder.
+fn is_anonymous_principal_str(principal: &str) -> bool {
+    is_anonymous_principal(&Actor {
+        kind: ActorKind::Owner,
+        id: String::new(),
+        principal_id: Some(principal.to_string()),
+    })
 }
 
 /// Lowercase-hex SHA-256 of `bytes`.
@@ -174,8 +256,9 @@ pub fn persist_run_result(
         None => {
             tx.execute(
                 "INSERT INTO run_result
-                    (run_id, status, answer, answer_sha256, answer_len, audit_ref, created_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                    (run_id, status, answer, answer_sha256, answer_len, audit_ref, created_at,
+                     owner_principal)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
                 params![
                     run_id,
                     result.status,
@@ -184,6 +267,7 @@ pub fn persist_run_result(
                     answer_len,
                     result.audit_ref,
                     now_ms,
+                    result.owner_principal,
                 ],
             )?;
             PersistRunResultOutcome::Persisted
@@ -202,7 +286,8 @@ pub fn persist_run_result(
 pub fn get_run_result(conn: &Connection, run_id: &str) -> Result<Option<StoredRunResult>> {
     let row = conn
         .query_row(
-            "SELECT run_id, status, answer, answer_sha256, answer_len, audit_ref, created_at
+            "SELECT run_id, status, answer, answer_sha256, answer_len, audit_ref, created_at,
+                    owner_principal
              FROM run_result WHERE run_id = ?1",
             [run_id],
             |r| {
@@ -214,6 +299,7 @@ pub fn get_run_result(conn: &Connection, run_id: &str) -> Result<Option<StoredRu
                     answer_len: r.get(4)?,
                     audit_ref: r.get(5)?,
                     created_at: r.get(6)?,
+                    owner_principal: r.get(7)?,
                 })
             },
         )
@@ -246,6 +332,62 @@ pub fn get_run_result_ref(conn: &Connection, run_id: &str) -> Result<Option<RunR
         )
         .optional()?;
     Ok(row)
+}
+
+/// AUTHENTICATED, ownership-gated read of a run's answer BODY by `run_id`.
+///
+/// This is the **(b) authenticated answer-body projection** (D1-Q1). It releases the
+/// answer body ONLY when `caller_principal` matches the run's bound OWNER principal
+/// (the `owner_principal` recorded at persist time). The **(a) refs-only proof
+/// projection** is [`get_run_result_ref`] (unchanged — body-free AND owner-free, for
+/// public / unauthenticated proof surfaces).
+///
+/// Fail-closed on every ambiguity (an over-deny is safe; releasing a body is not):
+/// * no stored result for `run_id` → [`RunAnswerAccess::NotFound`];
+/// * stored result has NO / empty / `public` / `public:default` owner →
+///   [`RunAnswerAccess::Denied`]`(`[`AnswerDenyReason::NoOwnerPrincipal`]`)` — an
+///   unowned answer is released to NO ONE (no anonymous body access);
+/// * `caller_principal` is empty / `public` / `public:default` →
+///   [`AnswerDenyReason::AnonymousCaller`] (a public caller never reads a body);
+/// * a real owner exists but `caller_principal` != owner →
+///   [`AnswerDenyReason::PrincipalMismatch`].
+///
+/// The body is returned ONLY inside [`RunAnswerAccess::Granted`]. This function never
+/// logs or prints the body (or the owner principal), and the `Denied` / `NotFound`
+/// variants carry neither. The transport that AUTHENTICATES the caller and supplies a
+/// TRUSTED `caller_principal` is a later slice (D1-Q4); this projection takes
+/// `caller_principal` as a trusted argument and enforces only the ownership match.
+pub fn get_run_answer_for_principal(
+    conn: &Connection,
+    run_id: &str,
+    caller_principal: &str,
+) -> Result<RunAnswerAccess> {
+    // Read the full record Hub-side; the body never leaves this function except via Granted.
+    let stored = match get_run_result(conn, run_id)? {
+        Some(s) => s,
+        None => return Ok(RunAnswerAccess::NotFound),
+    };
+
+    // Fail-closed: a run with no real (non-anonymous) bound owner releases its body to
+    // NO ONE. A NULL/empty/`public` owner is treated identically — no anonymous owner.
+    let owner = match stored.owner_principal.as_deref() {
+        Some(o) if !is_anonymous_principal_str(o) => o.to_string(),
+        _ => return Ok(RunAnswerAccess::Denied(AnswerDenyReason::NoOwnerPrincipal)),
+    };
+
+    // Fail-closed: an anonymous / public / empty caller never reads an answer body,
+    // even if (pathologically) a stored owner string compared equal.
+    if is_anonymous_principal_str(caller_principal) {
+        return Ok(RunAnswerAccess::Denied(AnswerDenyReason::AnonymousCaller));
+    }
+
+    // The ownership match: exact principal equality. A mismatch (including incidental
+    // whitespace) over-denies, which is the safe direction.
+    if caller_principal == owner {
+        Ok(RunAnswerAccess::Granted(stored))
+    } else {
+        Ok(RunAnswerAccess::Denied(AnswerDenyReason::PrincipalMismatch))
+    }
 }
 
 #[cfg(test)]
@@ -392,5 +534,141 @@ mod tests {
         let db = Db::open_hub(&tmp("missing")).unwrap();
         assert!(get_run_result(db.conn(), "nope").unwrap().is_none());
         assert!(get_run_result_ref(db.conn(), "nope").unwrap().is_none());
+    }
+
+    // --- D1-Q1: authenticated (ownership-gated) answer-body projection ----------
+
+    const Q1_BODY: &str = "ANSWER-BODY-CANARY-only-the-owner-may-read-this";
+    const Q1_OWNER: &str = "principal:alice";
+    const Q1_OTHER: &str = "principal:bob";
+
+    /// Persist a run owned by `owner` (or unowned when `owner` is `None`) and return the db.
+    fn seed_owned(tag: &str, run_id: &str, owner: Option<&str>) -> Db {
+        let db = Db::open_hub(&tmp(tag)).unwrap();
+        let mut result = RunResult::new("finished", Q1_BODY, Some("audit-q1".to_string()));
+        if let Some(o) = owner {
+            result = result.with_owner_principal(o);
+        }
+        persist_run_result(db.conn(), run_id, &result, 4242).unwrap();
+        db
+    }
+
+    #[test]
+    fn owner_principal_reads_its_own_answer_body() {
+        let db = seed_owned("q1-grant", "run-q1", Some(Q1_OWNER));
+        match get_run_answer_for_principal(db.conn(), "run-q1", Q1_OWNER).unwrap() {
+            RunAnswerAccess::Granted(stored) => {
+                assert_eq!(
+                    stored.answer, Q1_BODY,
+                    "the owner must receive the real body"
+                );
+                assert_eq!(stored.owner_principal.as_deref(), Some(Q1_OWNER));
+                assert_eq!(stored.answer_sha256, sha256_hex(Q1_BODY.as_bytes()));
+            }
+            other => panic!("owner must be Granted the body, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn different_principal_is_denied_and_gets_no_body_or_owner() {
+        let db = seed_owned("q1-mismatch", "run-q1", Some(Q1_OWNER));
+        let access = get_run_answer_for_principal(db.conn(), "run-q1", Q1_OTHER).unwrap();
+        assert_eq!(
+            access,
+            RunAnswerAccess::Denied(AnswerDenyReason::PrincipalMismatch)
+        );
+        // Canary: a denied (non-owner) caller learns NEITHER the answer body NOR who owns it.
+        let rendered = format!("{access:?}");
+        assert!(
+            !rendered.contains(Q1_BODY),
+            "a deny result must never carry the answer body: {rendered}"
+        );
+        assert!(
+            !rendered.contains(Q1_OWNER),
+            "a deny result must never leak the owner principal: {rendered}"
+        );
+    }
+
+    #[test]
+    fn run_with_no_owner_fails_closed_no_anonymous_body() {
+        // The run was persisted via the unchanged 3-arg `new` -> owner_principal = None.
+        let db = seed_owned("q1-noowner", "run-q1", None);
+        // Even the (correct) status etc. is stored, but the body is released to NO ONE,
+        // including a caller that supplies a perfectly valid-looking principal.
+        let access = get_run_answer_for_principal(db.conn(), "run-q1", Q1_OWNER).unwrap();
+        assert_eq!(
+            access,
+            RunAnswerAccess::Denied(AnswerDenyReason::NoOwnerPrincipal)
+        );
+        assert!(
+            !format!("{access:?}").contains(Q1_BODY),
+            "the no-owner fail-closed deny must never carry the body"
+        );
+        // ...and the body genuinely IS still stored Hub-side (the Hub-internal read sees it),
+        // proving the deny is an AUTHORIZATION decision, not missing data.
+        assert_eq!(
+            get_run_result(db.conn(), "run-q1").unwrap().unwrap().answer,
+            Q1_BODY
+        );
+    }
+
+    #[test]
+    fn anonymous_or_public_caller_is_denied_even_for_an_owned_run() {
+        let db = seed_owned("q1-anoncaller", "run-q1", Some(Q1_OWNER));
+        for anon in ["", "   ", "public", "public:default", "PUBLIC"] {
+            let access = get_run_answer_for_principal(db.conn(), "run-q1", anon).unwrap();
+            assert_eq!(
+                access,
+                RunAnswerAccess::Denied(AnswerDenyReason::AnonymousCaller),
+                "anonymous/public caller '{anon}' must be denied"
+            );
+            assert!(
+                !format!("{access:?}").contains(Q1_BODY),
+                "an anonymous-caller deny must never carry the body (caller '{anon}')"
+            );
+        }
+    }
+
+    #[test]
+    fn owner_recorded_as_public_is_treated_as_no_owner() {
+        // A run whose recorded owner is itself an anonymous/public sentinel must NOT be
+        // readable by a caller passing that same sentinel — it is still NO real owner.
+        let db = seed_owned("q1-pubowner", "run-q1", Some("public"));
+        let access = get_run_answer_for_principal(db.conn(), "run-q1", "public").unwrap();
+        // Caller-anonymity is checked, but no-owner is the governing fail-closed reason here;
+        // either way the body is withheld. We assert the body never escapes.
+        assert!(
+            matches!(access, RunAnswerAccess::Denied(_)),
+            "got {access:?}"
+        );
+        assert!(!format!("{access:?}").contains(Q1_BODY));
+    }
+
+    #[test]
+    fn unknown_run_is_not_found_not_a_silent_grant() {
+        let db = Db::open_hub(&tmp("q1-missing")).unwrap();
+        assert_eq!(
+            get_run_answer_for_principal(db.conn(), "nope", Q1_OWNER).unwrap(),
+            RunAnswerAccess::NotFound
+        );
+    }
+
+    #[test]
+    fn refs_only_projection_still_carries_no_body_and_no_owner() {
+        // Regression: the refs-only proof projection is UNCHANGED — no body, and it
+        // must not leak the new owner_principal column either.
+        let db = seed_owned("q1-refs", "run-q1", Some(Q1_OWNER));
+        let refs = get_run_result_ref(db.conn(), "run-q1").unwrap().unwrap();
+        let rendered = format!("{refs:?}");
+        assert!(
+            !rendered.contains(Q1_BODY),
+            "refs-only must never carry the answer body: {rendered}"
+        );
+        assert!(
+            !rendered.contains(Q1_OWNER),
+            "refs-only must never carry the owner principal: {rendered}"
+        );
+        // It does still expose the body-free fingerprint.
+        assert_eq!(refs.answer_sha256, sha256_hex(Q1_BODY.as_bytes()));
     }
 }

--- a/rust-core/crates/friday-storage/src/schema.rs
+++ b/rust-core/crates/friday-storage/src/schema.rs
@@ -214,6 +214,17 @@ pub fn hub_migrations() -> Vec<Migration> {
             destructive: false,
             up: m0016_pending_approval_tool_params,
         },
+        // D1-Q1: add the run's bound OWNER principal to `run_result` so the
+        // authenticated answer-body read can enforce `caller_principal == owner`.
+        // `ALTER TABLE ... ADD COLUMN` with no default is additive and back-compatible:
+        // existing v15 `run_result` rows read back as `owner_principal = NULL`, which
+        // FAILS CLOSED on the body read (an unowned answer is released to no one).
+        Migration {
+            version: 17,
+            name: "run_result_owner_principal",
+            destructive: false,
+            up: m0017_run_result_owner_principal,
+        },
     ]
 }
 
@@ -1125,4 +1136,14 @@ fn m0015_run_result(tx: &Transaction) -> rusqlite::Result<()> {
 // back-compatible: existing v14 rows read back as `NULL`.
 fn m0016_pending_approval_tool_params(tx: &Transaction) -> rusqlite::Result<()> {
     tx.execute_batch("ALTER TABLE pending_approval_request ADD COLUMN tool_params TEXT;")
+}
+
+// D1-Q1: additive nullable `owner_principal` column on `run_result` — the run's bound
+// OWNER principal the authenticated answer-body read (`get_run_answer_for_principal`)
+// matches the caller against. `ALTER TABLE ... ADD COLUMN` with no default is additive
+// and back-compatible: existing v15 rows read back as `owner_principal = NULL`. A NULL
+// (or empty / `public`) owner FAILS CLOSED on the body read, so the column never weakens
+// the refs-only proof projection (which does not select it at all).
+fn m0017_run_result_owner_principal(tx: &Transaction) -> rusqlite::Result<()> {
+    tx.execute_batch("ALTER TABLE run_result ADD COLUMN owner_principal TEXT;")
 }

--- a/rust-core/crates/friday-storage/tests/run_result_persist.rs
+++ b/rust-core/crates/friday-storage/tests/run_result_persist.rs
@@ -13,8 +13,9 @@ mod common;
 use common::temp_db_path;
 use friday_core::SessionState;
 use friday_storage::{
-    get_run_result, get_run_result_ref, hub_migrations, persist_run_result, Db,
-    PersistRunResultOutcome, Profile, RunResult, HUB_ONLY_TABLES,
+    get_run_answer_for_principal, get_run_result, get_run_result_ref, hub_migrations,
+    persist_run_result, AnswerDenyReason, Db, PersistRunResultOutcome, Profile, RunAnswerAccess,
+    RunResult, HUB_ONLY_TABLES,
 };
 
 /// The max migration version the current hub migration set reaches.
@@ -111,4 +112,96 @@ fn public_api_round_trips_and_refs_only_read_has_no_body() {
         !format!("{refs:?}").contains("BODY-CANARY"),
         "the refs-only readback must never carry the answer body"
     );
+}
+
+/// D1-Q1 end-to-end through the public crate API + a real forward migration: the
+/// authenticated answer-body projection releases the body ONLY to the bound owner,
+/// fails closed for everyone else, and never leaks the body via a deny.
+#[test]
+fn authenticated_answer_body_projection_gates_on_owner_principal() {
+    let p = temp_db_path("run-result-q1");
+    // Open at pre-v17 and seed a GENUINE pre-owner-column run_result row via raw SQL (the
+    // v15 column set has no owner_principal). This proves the v17 forward migration adds
+    // the column to a table WITH data, and that a real legacy row reads back fail-closed.
+    {
+        let mut migs = hub_migrations();
+        migs.retain(|m| m.version <= 16);
+        let db = Db::open(&p, Profile::Hub, &migs, "v16").unwrap();
+        assert_eq!(db.version().unwrap(), 16);
+        db.conn()
+            .execute(
+                "INSERT INTO run_result
+                    (run_id, status, answer, answer_sha256, answer_len, audit_ref, created_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                rusqlite::params![
+                    "run-legacy",
+                    "finished",
+                    "LEGACY-BODY-pre-owner-column",
+                    // sha256("LEGACY-BODY-pre-owner-column"); value is irrelevant to the gate.
+                    "0000000000000000000000000000000000000000000000000000000000000000",
+                    28_i64,
+                    Option::<String>::None,
+                    10_i64,
+                ],
+            )
+            .unwrap();
+    }
+    // Forward-migrate to the full set (adds owner_principal) and seed an OWNED run.
+    let db = Db::open_hub(&p).unwrap();
+    assert_eq!(db.version().unwrap(), hub_max_version());
+    let body = "Q1-BODY-CANARY-only-owner-may-read";
+    let owner = "principal:owner-1";
+    persist_run_result(
+        db.conn(),
+        "run-owned",
+        &RunResult::new("finished", body, None).with_owner_principal(owner),
+        20,
+    )
+    .unwrap();
+
+    // Owner -> Granted with the real body.
+    match get_run_answer_for_principal(db.conn(), "run-owned", owner).unwrap() {
+        RunAnswerAccess::Granted(s) => assert_eq!(s.answer, body),
+        other => panic!("owner must be Granted, got {other:?}"),
+    }
+
+    // Wrong principal -> Denied, no body, no owner id.
+    let mismatch =
+        get_run_answer_for_principal(db.conn(), "run-owned", "principal:intruder").unwrap();
+    assert_eq!(
+        mismatch,
+        RunAnswerAccess::Denied(AnswerDenyReason::PrincipalMismatch)
+    );
+    let rendered = format!("{mismatch:?}");
+    assert!(!rendered.contains(body), "deny leaked the body: {rendered}");
+    assert!(
+        !rendered.contains(owner),
+        "deny leaked the owner: {rendered}"
+    );
+
+    // Anonymous caller -> Denied.
+    assert_eq!(
+        get_run_answer_for_principal(db.conn(), "run-owned", "public").unwrap(),
+        RunAnswerAccess::Denied(AnswerDenyReason::AnonymousCaller)
+    );
+
+    // The migrated legacy row (owner = NULL) fails closed for everyone, even though the
+    // body is still stored Hub-side.
+    assert_eq!(
+        get_run_answer_for_principal(db.conn(), "run-legacy", owner).unwrap(),
+        RunAnswerAccess::Denied(AnswerDenyReason::NoOwnerPrincipal)
+    );
+    assert_eq!(
+        get_run_result(db.conn(), "run-legacy")
+            .unwrap()
+            .unwrap()
+            .answer,
+        "LEGACY-BODY-pre-owner-column"
+    );
+
+    // The refs-only proof projection is UNCHANGED — still no body and no owner.
+    let refs = get_run_result_ref(db.conn(), "run-owned").unwrap().unwrap();
+    let refs_rendered = format!("{refs:?}");
+    assert!(!refs_rendered.contains(body));
+    assert!(!refs_rendered.contains(owner));
 }


### PR DESCRIPTION
## Truth label
**Authenticated (principal-ownership-gated) answer-body projection.** The user gets the real answer via an AUTHENTICATED readback that returns the `run_result` BODY only to the run's bound OWNER principal; the refs-only proof projection stays body-free for public/unauth surfaces. The authenticating transport (supplies a trusted `caller_principal`) is a later slice (**D1-Q4**). PROOF-ONLY; **NOT v1 GO.**

## The shape — where ownership is checked (investigation finding)
S4 (#578) binds a run's principal **only at runtime** in friday-hub (`RunPolicy` → gate `Actor` → action digest). It persists **no** queryable run→owner link in friday-storage: `agent_run` and `run_result` had no principal column (only the narrow, wrong-semantic `pending_approval_request.run_id` + `principal_id`, present only for paused-for-approval runs). So D1-Q1 records the owner **into the answer store itself** and gates the body read on it — **entirely within friday-storage** (no friday-hub read/edit needed, so the STOP-clause does not trigger).

## What changed (friday-storage only)
- **schema v17** (additive `ALTER TABLE run_result ADD COLUMN owner_principal TEXT`): existing v15 rows read back `NULL` → **fail-closed**. The released v15 DDL is untouched.
- **`RunResult`** gains `owner_principal` (default `None`); **`RunResult::new` stays 3-arg** so the out-of-write-set friday-hub caller (`resume.rs`) compiles untouched; new `with_owner_principal` builder records it; `persist_run_result` writes the column.
- **`get_run_answer_for_principal(conn, run_id, caller_principal) -> RunAnswerAccess`**: `Granted(StoredRunResult)` (with body) **only** when `caller == owner`; otherwise `Denied(reason)` where reason ∈ {`NoOwnerPrincipal`, `AnonymousCaller`, `PrincipalMismatch`} — the `Denied`/`NotFound` variants are **body-free AND owner-id-free**. Fail-closed: NULL/empty/`public` owner, anonymous/public caller, and mismatch all DENY. Reuses `friday_core::gate::is_anonymous_principal` for the sentinel set (`""`/`public`/`public:default`).
- **`get_run_result_ref` (refs-only proof projection) UNCHANGED** — no body, and verified it still leaks no owner principal.
- The body is **never logged/printed**; it is returned only inside `Granted`.

## Adversarial tests (the auth boundary is the point)
- owner P reads run owned by P → **gets the body**
- different principal Q → **DENIED** (`PrincipalMismatch`), canary asserts deny carries **neither the body nor the owner id**
- run with **no bound owner** → **DENIED** (`NoOwnerPrincipal`, fail-closed) while the body is provably still stored Hub-side (deny is an authorization decision, not missing data)
- anonymous/public caller (`""`, `"   "`, `public`, `public:default`, `PUBLIC`) → **DENIED** (`AnonymousCaller`)
- owner recorded as `public` → treated as no-owner; body withheld
- refs-only proof projection → **still body-free and owner-free** (regression)
- e2e through a **real v16→v17 forward migration** over a genuine pre-column legacy row → reads back fail-closed

## Honest boundary
There was **no** pre-existing queryable run→owner link; this PR adds `owner_principal`. The persist callers (`resume.rs`, future `runtime.rs`) **do not populate it yet**, so every authenticated body read **fails closed in production** until the agent-core lane wires the run's principal into persist. The grant path is proven by tests that record the owner directly. This is the true proven/unproven line.

## Local green gate (actual)
`cargo fmt --all` OK · `cargo build -p friday-storage` OK · `cargo clippy --workspace --all-targets -- -D warnings` clean (friday-hub compiled untouched → backward-compat confirmed) · `cargo test -p friday-storage` all pass. No TS touched → npm gate N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)