### PR TITLE
feat(rust): S5 — inbound conversation history + minimal sessions/resume

### DIFF
--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -1825,6 +1825,81 @@ fn format_executed_outcome(receipt: &ToolReceipt) -> String {
     }
 }
 
+/// Max bytes of prior-session conversation CONTENT rendered into the model prompt
+/// preamble (S5 inbound history). Keeps the multi-turn context BOUNDED so a long
+/// session can never blow the completion-token budget — the session-level mirror of
+/// [`MAX_FEEDBACK_CONTENT_BYTES`] for per-turn tool content. The MOST RECENT messages
+/// are preserved; older ones are dropped (with [`SESSION_HISTORY_OMISSION_MARKER`])
+/// once the budget is exceeded.
+const MAX_SESSION_HISTORY_BYTES: usize = 6144;
+
+/// Per-message cap inside the session-history preamble: a single oversized message is
+/// head-sliced to this many bytes (with [`FEEDBACK_TRUNCATION_MARKER`]) so one huge
+/// turn cannot by itself exhaust [`MAX_SESSION_HISTORY_BYTES`]. Strictly smaller than
+/// the history budget, so the most-recent message ALWAYS fits.
+const MAX_SESSION_MESSAGE_BYTES: usize = 1024;
+
+/// Prepended to the rendered session history when older messages were dropped to fit
+/// [`MAX_SESSION_HISTORY_BYTES`], so the model knows the conversation began earlier.
+const SESSION_HISTORY_OMISSION_MARKER: &str = "[earlier session messages omitted]\n";
+
+/// Render a session's prior conversation messages (S5 inbound history) into a BOUNDED
+/// prompt preamble, prepended ahead of the recall preamble + task so the model sees
+/// the multi-turn context that preceded this run. Pure + deterministic.
+///
+/// Two bounding layers ensure a long/large session can never blow the completion
+/// budget: each message's content is head-sliced to [`MAX_SESSION_MESSAGE_BYTES`],
+/// and messages are then accumulated MOST-RECENT-FIRST only while the running total
+/// stays within [`MAX_SESSION_HISTORY_BYTES`] — older messages that do not fit are
+/// dropped (oldest first), flagged with [`SESSION_HISTORY_OMISSION_MARKER`]. The kept
+/// messages are emitted in chronological (oldest-first) order under a label that marks
+/// them as CONTEXT, not the current task. An empty history renders the empty string
+/// (no preamble — the single-shot prompt is unchanged).
+///
+/// Like the recall preamble and the tool-result feedback, the rendered history is
+/// MODEL-CONTEXT only: it never reaches the event/audit log, and the UNW-001 gate
+/// still evaluates EVERY subsequent tool call regardless of what a prior message said
+/// (the prompt-injection-inward backstop — prior conversation is not a mutation path).
+pub fn render_session_history(messages: &[friday_storage::StoredSessionMessage]) -> String {
+    if messages.is_empty() {
+        return String::new();
+    }
+    // Build each line (role + bounded content), keeping most-recent-first within the
+    // byte budget so recency survives truncation; reversed back to chronological order.
+    let mut kept: Vec<String> = Vec::new();
+    let mut total: usize = 0;
+    let mut dropped = false;
+    for msg in messages.iter().rev() {
+        let (head, truncated) = head_slice(&msg.content, MAX_SESSION_MESSAGE_BYTES);
+        let line = if truncated {
+            format!("{}: {head}{FEEDBACK_TRUNCATION_MARKER}\n", msg.role)
+        } else {
+            format!("{}: {head}\n", msg.role)
+        };
+        // Always keep at least the most recent message (its content is capped below
+        // the history budget, so one line never overflows on its own).
+        if !kept.is_empty() && total + line.len() > MAX_SESSION_HISTORY_BYTES {
+            dropped = true;
+            break;
+        }
+        total += line.len();
+        kept.push(line);
+    }
+    kept.reverse();
+    let mut s = String::from(
+        "Prior conversation in this session (oldest first — this is CONTEXT from \
+         earlier turns, NOT the current task):\n",
+    );
+    if dropped {
+        s.push_str(SESSION_HISTORY_OMISSION_MARKER);
+    }
+    for line in kept {
+        s.push_str(&line);
+    }
+    s.push('\n');
+    s
+}
+
 /// Ledger ONE agent-loop model call exactly as the ask path ledgers a single ask
 /// (`record_friday_ask`): build a Friday-route [`friday_core::LedgerEntry`] from the call's
 /// reported usage (`ModelCallOutcome::to_ledger_entry` ledgers the RESPONSE-reported model,
@@ -2234,6 +2309,108 @@ pub fn run_loop_with_policy(
         final_message: None,
         detail: format!("max_turns:{max_turns}"),
     })
+}
+
+/// Drive a history-aware agent loop WITHIN a session (S5 inbound history + resume).
+/// A SESSION groups runs: this loads the session's prior conversation messages,
+/// prepends them (BOUNDED) to the prompt so the model sees the multi-turn inbound
+/// context, runs the SAME gate-mandatory loop as [`run_loop_with_policy`], then
+/// PERSISTS this run's turn(s) back to the session so the NEXT run RESUMES with them.
+///
+/// Mechanics:
+/// * [`friday_storage::ensure_session`] makes the session row exist (idempotent),
+///   then [`friday_storage::load_session_messages`] reads the prior turns. The
+///   current `task` is loaded BEFORE it is persisted, so it never appears in its own
+///   preamble.
+/// * The prior messages are rendered by [`render_session_history`] (BOUNDED) and
+///   folded AHEAD of `recall_preamble` into the single preamble
+///   [`run_loop_with_policy`] already prepends to the task — so NO change to the loop
+///   body or its signature is needed, and the session preamble inherits the proven
+///   "preamble augments only the prompt, never the run row / classification / events"
+///   property. The model sees `[session history][recall preamble][task]`.
+/// * After the loop returns, the current `task` is appended as a `user` message and,
+///   when the loop `Finish`ed with a final answer, that answer is appended as an
+///   `assistant` message — both soft-linked to `run_id` (the `refs`). The message
+///   bodies stay Hub-side (like `run_result.answer`); only a REFS-ONLY session event
+///   (session id + message count, never the text) is logged. There is NO
+///   answer-body-over-wire here (that is the transport lane).
+///
+/// A non-`Finished` outcome still records the `user` turn (the operator asked it) but
+/// no `assistant` answer (there is none). Single-shot runs that never call this keep
+/// using [`run_loop`] / [`run_loop_with_policy`] unchanged — no session row is touched.
+#[allow(clippy::too_many_arguments)]
+pub fn run_session_loop(
+    client: &dyn AgentLlmClient,
+    executor: &dyn ToolExecutor,
+    conn: &Connection,
+    run_id: &str,
+    session_id: &str,
+    task: &str,
+    recall_preamble: &str,
+    operator_vk: Option<&OperatorVerifyingKey>,
+    approve: &dyn Fn(&MutatingActionRequest) -> Option<CanonicalApproval>,
+    policy: &RunPolicy,
+    max_turns: u64,
+    now_ms: i64,
+) -> Result<LoopOutcome, StorageError> {
+    // 1. Ensure the session exists and LOAD its prior turns BEFORE persisting the
+    //    current task (so the task is never folded into its own preamble).
+    friday_storage::ensure_session(conn, session_id, now_ms)?;
+    let prior = friday_storage::load_session_messages(conn, session_id)?;
+
+    // 2. Fold the BOUNDED prior-session history AHEAD of the recall preamble. The loop
+    //    already builds `prompt_task = preamble + task`, so passing the combined
+    //    preamble threads inbound history into the model WITHOUT any loop change.
+    let session_preamble = render_session_history(&prior);
+    let combined_preamble = format!("{session_preamble}{recall_preamble}");
+
+    // 3. Run the SAME gate-mandatory loop (principal/scope/operator-key aware).
+    let outcome = run_loop_with_policy(
+        client,
+        executor,
+        conn,
+        run_id,
+        task,
+        &combined_preamble,
+        operator_vk,
+        approve,
+        policy,
+        max_turns,
+        now_ms,
+    )?;
+
+    // 4. Persist this run's turn(s) so the next run in the session resumes with them:
+    //    the user task always, the assistant answer only when the loop finished with
+    //    one. Bodies are Hub-side; the event below is refs-only.
+    friday_storage::append_session_message(
+        conn,
+        session_id,
+        &friday_storage::SessionMessage::new("user", task, Some(run_id.to_string())),
+        now_ms,
+    )?;
+    if outcome.status == LoopStatus::Finished {
+        if let Some(answer) = outcome.final_message.as_deref() {
+            friday_storage::append_session_message(
+                conn,
+                session_id,
+                &friday_storage::SessionMessage::new("assistant", answer, Some(run_id.to_string())),
+                now_ms,
+            )?;
+        }
+    }
+
+    // Refs-only session outcome event: the session id + the new message COUNT, never
+    // any message text (the refs-only / answer-body boundary; no secret/PII logged).
+    let count = friday_storage::session_message_count(conn, session_id)?;
+    agent_run::record_event(
+        conn,
+        &format!("{run_id}:session"),
+        run_id,
+        &format!("session.appended:{session_id}:count={count}"),
+        now_ms,
+    )?;
+
+    Ok(outcome)
 }
 
 #[cfg(test)]
@@ -4304,6 +4481,293 @@ mod tests {
         assert!(p.contains("\"none\"")); // the finish hint
                                          // No history → no history section.
         assert!(!build_loop_prompt("t", &[]).contains("So far this run"));
+    }
+
+    // --- S5: inbound conversation history + minimal sessions/resume -------------
+
+    fn stored_msg(seq: i64, role: &str, content: &str) -> friday_storage::StoredSessionMessage {
+        friday_storage::StoredSessionMessage {
+            message_id: format!("s:m{seq}"),
+            agent_session_id: "s".to_string(),
+            seq,
+            role: role.to_string(),
+            content: content.to_string(),
+            refs: None,
+            created_at: seq,
+        }
+    }
+
+    #[test]
+    fn render_session_history_is_bounded_and_drops_oldest() {
+        // Empty history → empty preamble (single-shot prompt unchanged).
+        assert!(render_session_history(&[]).is_empty());
+
+        // A short history renders both turns, labeled as CONTEXT (not the task).
+        let small = render_session_history(&[
+            stored_msg(0, "user", "remember 47"),
+            stored_msg(1, "assistant", "noted 47"),
+        ]);
+        assert!(small.contains("Prior conversation in this session"));
+        assert!(small.contains("user: remember 47"));
+        assert!(small.contains("assistant: noted 47"));
+        assert!(!small.contains(SESSION_HISTORY_OMISSION_MARKER));
+
+        // Many LARGE messages → per-message + total caps hold; oldest dropped + flagged.
+        let big: Vec<_> = (0..12)
+            .map(|i| stored_msg(i, "user", &"Z".repeat(5000)))
+            .collect();
+        let rendered = render_session_history(&big);
+        let zcount = rendered.chars().filter(|&c| c == 'Z').count();
+        assert!(
+            zcount <= MAX_SESSION_HISTORY_BYTES,
+            "rendered history content must stay within the byte budget, got {zcount}"
+        );
+        assert!(
+            rendered.contains(SESSION_HISTORY_OMISSION_MARKER),
+            "older messages over budget must be flagged omitted"
+        );
+        // Per-message content was head-sliced (each 5000-byte message > the per-message
+        // cap), so the truncation marker is present.
+        assert!(rendered.contains(FEEDBACK_TRUNCATION_MARKER));
+    }
+
+    #[test]
+    fn session_loop_prepends_prior_history_into_model_prompt() {
+        let root = TempDir::new("s5-prompt");
+        let db = Db::open_hub(&temp_path("s5-prompt")).unwrap();
+        // Seed a session with prior turns (as a prior run would have left them).
+        friday_storage::ensure_session(db.conn(), "sess-1", 1).unwrap();
+        friday_storage::append_session_message(
+            db.conn(),
+            "sess-1",
+            &friday_storage::SessionMessage::new(
+                "user",
+                "remember the number 47",
+                Some("r0".into()),
+            ),
+            2,
+        )
+        .unwrap();
+        friday_storage::append_session_message(
+            db.conn(),
+            "sess-1",
+            &friday_storage::SessionMessage::new("assistant", "noted: 47", Some("r0".into())),
+            3,
+        )
+        .unwrap();
+        // A new run that finishes on turn 1.
+        agent_run::create_run(db.conn(), "r1", "what number did I ask you to remember", 10)
+            .unwrap();
+        let client = CapturingAgentLlmClient::new(vec![AgentStep::Finish {
+            message: "47".into(),
+        }]);
+        let executor = FsToolExecutor::new(&root.0);
+        let out = run_session_loop(
+            &client,
+            &executor,
+            db.conn(),
+            "r1",
+            "sess-1",
+            "what number did I ask you to remember",
+            "",
+            None,
+            &no_approval(),
+            &RunPolicy::default(),
+            10,
+            10,
+        )
+        .unwrap();
+        assert_eq!(out.status, LoopStatus::Finished);
+        let prompts = client.prompts.borrow();
+        assert_eq!(prompts.len(), 1);
+        // The turn-1 prompt carries the prior session history, labeled as context...
+        assert!(
+            prompts[0].contains("Prior conversation in this session"),
+            "got: {}",
+            prompts[0]
+        );
+        assert!(prompts[0].contains("remember the number 47"));
+        assert!(prompts[0].contains("noted: 47"));
+        // ...AND the current task is still present.
+        assert!(prompts[0].contains("what number did I ask you to remember"));
+        // This run appended its own user + assistant turns (2 -> 4 total), refs to r1.
+        assert_eq!(
+            friday_storage::session_message_count(db.conn(), "sess-1").unwrap(),
+            4
+        );
+        let msgs = friday_storage::load_session_messages(db.conn(), "sess-1").unwrap();
+        assert_eq!(msgs[2].role, "user");
+        assert_eq!(msgs[2].content, "what number did I ask you to remember");
+        assert_eq!(msgs[2].refs.as_deref(), Some("r1"));
+        assert_eq!(msgs[3].role, "assistant");
+        assert_eq!(msgs[3].content, "47");
+        // The session event is REFS-ONLY: it carries the count, never the message text.
+        let session_ev: String = db
+            .conn()
+            .query_row(
+                "SELECT kind FROM agent_run_event WHERE event_id = 'r1:session'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(session_ev.contains("session.appended:sess-1:count=4"));
+        assert!(
+            !session_ev.contains("47"),
+            "the event must not carry message text"
+        );
+        assert!(friday_storage::audit::verify_audit_chain(db.conn()).is_ok());
+    }
+
+    #[test]
+    fn session_resume_run2_sees_run1_message() {
+        let root = TempDir::new("s5-resume");
+        let db = Db::open_hub(&temp_path("s5-resume")).unwrap();
+        let ex = FsToolExecutor::new(&root.0);
+        // Run 1: fresh session, model finishes with an answer.
+        agent_run::create_run(db.conn(), "r1", "remember my budget is 500", 10).unwrap();
+        let c1 = CapturingAgentLlmClient::new(vec![AgentStep::Finish {
+            message: "got it, budget 500".into(),
+        }]);
+        let o1 = run_session_loop(
+            &c1,
+            &ex,
+            db.conn(),
+            "r1",
+            "sess-x",
+            "remember my budget is 500",
+            "",
+            None,
+            &no_approval(),
+            &RunPolicy::default(),
+            5,
+            10,
+        )
+        .unwrap();
+        assert_eq!(o1.status, LoopStatus::Finished);
+        // Run 1's prompt had NO prior history (fresh session).
+        assert!(!c1.prompts.borrow()[0].contains("Prior conversation in this session"));
+
+        // Run 2: SAME session, a new run — it must SEE run 1's turns (resume/continue).
+        agent_run::create_run(db.conn(), "r2", "what is my budget", 20).unwrap();
+        let c2 = CapturingAgentLlmClient::new(vec![AgentStep::Finish {
+            message: "your budget is 500".into(),
+        }]);
+        let o2 = run_session_loop(
+            &c2,
+            &ex,
+            db.conn(),
+            "r2",
+            "sess-x",
+            "what is my budget",
+            "",
+            None,
+            &no_approval(),
+            &RunPolicy::default(),
+            5,
+            20,
+        )
+        .unwrap();
+        assert_eq!(o2.status, LoopStatus::Finished);
+        let p2 = c2.prompts.borrow();
+        assert_eq!(p2.len(), 1);
+        // Continuity: run 2's prompt carries run 1's user task AND its assistant answer.
+        assert!(
+            p2[0].contains("remember my budget is 500"),
+            "run 2 must see run 1's user turn, got: {}",
+            p2[0]
+        );
+        assert!(
+            p2[0].contains("got it, budget 500"),
+            "run 2 must see run 1's assistant turn"
+        );
+        // Session now holds 4 messages: (user, assistant) x 2 runs, in order.
+        let msgs = friday_storage::load_session_messages(db.conn(), "sess-x").unwrap();
+        assert_eq!(msgs.len(), 4);
+        assert_eq!(msgs[0].content, "remember my budget is 500");
+        assert_eq!(msgs[0].refs.as_deref(), Some("r1"));
+        assert_eq!(msgs[3].content, "your budget is 500");
+        assert_eq!(msgs[3].refs.as_deref(), Some("r2"));
+        assert!(friday_storage::audit::verify_audit_chain(db.conn()).is_ok());
+    }
+
+    #[test]
+    fn single_shot_run_loop_creates_no_session_state() {
+        // The non-session entrypoint is UNCHANGED: it touches NO agent_session table.
+        let root = TempDir::new("s5-single");
+        std::fs::write(root.0.join("notes.md"), b"answer is 47").unwrap();
+        let db = Db::open_hub(&temp_path("s5-single")).unwrap();
+        agent_run::create_run(db.conn(), "r1", "read notes.md", 1).unwrap();
+        let client = CapturingAgentLlmClient::new(vec![
+            AgentStep::Tool(raw("read_file", &[("path", "notes.md")])),
+            AgentStep::Finish {
+                message: "47".into(),
+            },
+        ]);
+        let executor = FsToolExecutor::new(&root.0);
+        let out = run_loop(
+            &client,
+            &executor,
+            db.conn(),
+            "r1",
+            "read notes.md",
+            "",
+            SECRET,
+            &no_approval(),
+            10,
+            1000,
+        )
+        .unwrap();
+        assert_eq!(out.status, LoopStatus::Finished);
+        // No session rows created by the single-shot path.
+        assert_eq!(db.count("agent_session").unwrap(), 0);
+        assert_eq!(db.count("agent_session_message").unwrap(), 0);
+        // And no session prompt label leaked into the single-shot prompts.
+        assert!(!client.prompts.borrow()[0].contains("Prior conversation in this session"));
+    }
+
+    #[test]
+    fn session_loop_bounds_oversized_history_in_prompt() {
+        // End-to-end bound: a session with many LARGE prior messages must not blow the
+        // prompt — the rendered history is capped and the oldest are flagged omitted.
+        let root = TempDir::new("s5-bound");
+        let db = Db::open_hub(&temp_path("s5-bound")).unwrap();
+        friday_storage::ensure_session(db.conn(), "big", 1).unwrap();
+        for i in 0..12 {
+            friday_storage::append_session_message(
+                db.conn(),
+                "big",
+                &friday_storage::SessionMessage::new("user", "Z".repeat(5000), None),
+                2 + i,
+            )
+            .unwrap();
+        }
+        agent_run::create_run(db.conn(), "r1", "summarize", 100).unwrap();
+        let client = CapturingAgentLlmClient::new(vec![AgentStep::Finish {
+            message: "ok".into(),
+        }]);
+        let ex = FsToolExecutor::new(&root.0);
+        run_session_loop(
+            &client,
+            &ex,
+            db.conn(),
+            "r1",
+            "big",
+            "summarize",
+            "",
+            None,
+            &no_approval(),
+            &RunPolicy::default(),
+            5,
+            100,
+        )
+        .unwrap();
+        let prompts = client.prompts.borrow();
+        let zcount = prompts[0].chars().filter(|&c| c == 'Z').count();
+        assert!(
+            zcount <= MAX_SESSION_HISTORY_BYTES,
+            "oversized session history must be bounded in the prompt, got {zcount}"
+        );
+        assert!(prompts[0].contains(SESSION_HISTORY_OMISSION_MARKER));
     }
 }
 

--- a/rust-core/crates/friday-storage/src/agent_session.rs
+++ b/rust-core/crates/friday-storage/src/agent_session.rs
@@ -1,0 +1,308 @@
+//! Minimal Hub-side agent-loop SESSION store (S5). Hub-only.
+//!
+//! The Rust agent loop (`friday_hub::run_loop`) runs a SINGLE task with no inbound
+//! conversation history. S5 adds a minimal SESSION: an `agent_session` groups runs
+//! and stores their prior conversation messages (role + content + refs) keyed by
+//! `agent_session_id`, so a later run in the same session can RESUME with the prior
+//! multi-turn context.
+//!
+//! ## Boundary (the refs-only / answer-body discipline is UNCHANGED)
+//! A session message's `content` is a BODY kept Hub-side, exactly like
+//! [`crate::run_result::RunResult::answer`]. It is fed BACK into the model prompt
+//! Hub-side (the loop's existing recall-preamble seam) but is NEVER transported
+//! off-Hub: there is no answer-body-over-wire read here (that is the transport
+//! lane). The compact event/audit log records only refs (session id + counts),
+//! never the message text — the Hub keeps the body, the wire keeps fingerprints.
+//!
+//! ## Ordering
+//! Each message carries a per-session monotonic `seq` (0-based), so
+//! [`load_session_messages`] returns the conversation in turn order regardless of
+//! insert timing. `UNIQUE(agent_session_id, seq)` makes a duplicate ordinal a
+//! fail-closed insert rather than a silent reorder.
+//!
+//! Truth label: minimal sessions/resume storage substrate + API + tests only.
+//! PROOF-ONLY; NOT a v1 GO.
+
+use crate::error::{Result, StorageError};
+use rusqlite::{params, Connection};
+
+/// A conversation message as supplied to [`append_session_message`]. `seq`,
+/// `message_id` and `created_at` are assigned by the store, not the caller.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SessionMessage {
+    /// The speaker role, e.g. `"user"` / `"assistant"`. Free-form but non-empty
+    /// (the schema CHECK rejects a blank role).
+    pub role: String,
+    /// The message text. A BODY kept Hub-side (never an answer-body-over-wire).
+    pub content: String,
+    /// Optional soft-link ref (e.g. the producing `run_id`). No FK — the `*_ref`
+    /// soft-link convention.
+    pub refs: Option<String>,
+}
+
+impl SessionMessage {
+    pub fn new(role: impl Into<String>, content: impl Into<String>, refs: Option<String>) -> Self {
+        SessionMessage {
+            role: role.into(),
+            content: content.into(),
+            refs,
+        }
+    }
+}
+
+/// A stored conversation message read back by [`load_session_messages`], including
+/// its assigned `seq` and `message_id`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StoredSessionMessage {
+    pub message_id: String,
+    pub agent_session_id: String,
+    pub seq: i64,
+    pub role: String,
+    pub content: String,
+    pub refs: Option<String>,
+    pub created_at: i64,
+}
+
+/// Ensure an `agent_session` row exists (idempotent). A new session is created at
+/// `now_ms`; an existing session has its `updated_at` bumped. Safe to call at the
+/// start of every run in the session.
+pub fn ensure_session(conn: &Connection, agent_session_id: &str, now_ms: i64) -> Result<()> {
+    if agent_session_id.trim().is_empty() {
+        return Err(StorageError::Unsupported(
+            "agent_session_id must be non-empty".into(),
+        ));
+    }
+    // INSERT-or-bump in one statement: a fresh id INSERTs, an existing id keeps its
+    // created_at and only advances updated_at (no row is ever clobbered).
+    conn.execute(
+        "INSERT INTO agent_session (agent_session_id, created_at, updated_at)
+         VALUES (?1, ?2, ?2)
+         ON CONFLICT(agent_session_id) DO UPDATE SET updated_at = ?2",
+        params![agent_session_id, now_ms],
+    )?;
+    Ok(())
+}
+
+/// Whether an `agent_session` row exists.
+pub fn session_exists(conn: &Connection, agent_session_id: &str) -> Result<bool> {
+    let exists: bool = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM agent_session WHERE agent_session_id = ?1)",
+        [agent_session_id],
+        |r| r.get(0),
+    )?;
+    Ok(exists)
+}
+
+/// Append one conversation message to a session, returning the assigned
+/// `message_id`. The `seq` is assigned as `max(seq) + 1` for the session (0 for the
+/// first message), computed and inserted in ONE transaction so concurrent appends
+/// on a single connection never collide on an ordinal. The parent session must
+/// already exist (call [`ensure_session`] first) — the FK rejects an orphan message.
+pub fn append_session_message(
+    conn: &Connection,
+    agent_session_id: &str,
+    message: &SessionMessage,
+    now_ms: i64,
+) -> Result<String> {
+    if message.role.trim().is_empty() {
+        return Err(StorageError::Unsupported(
+            "session message role must be non-empty".into(),
+        ));
+    }
+    let tx = conn.unchecked_transaction()?;
+    let exists: bool = tx.query_row(
+        "SELECT EXISTS(SELECT 1 FROM agent_session WHERE agent_session_id = ?1)",
+        [agent_session_id],
+        |r| r.get(0),
+    )?;
+    if !exists {
+        return Err(StorageError::NotFound(format!(
+            "agent_session '{agent_session_id}' (call ensure_session first)"
+        )));
+    }
+    let next_seq: i64 = tx.query_row(
+        "SELECT COALESCE(MAX(seq) + 1, 0) FROM agent_session_message
+         WHERE agent_session_id = ?1",
+        [agent_session_id],
+        |r| r.get(0),
+    )?;
+    let message_id = format!("{agent_session_id}:m{next_seq}");
+    tx.execute(
+        "INSERT INTO agent_session_message
+            (message_id, agent_session_id, seq, role, content, refs, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        params![
+            message_id,
+            agent_session_id,
+            next_seq,
+            message.role,
+            message.content,
+            message.refs,
+            now_ms,
+        ],
+    )?;
+    // Keep the session's updated_at current with its latest message.
+    tx.execute(
+        "UPDATE agent_session SET updated_at = ?2 WHERE agent_session_id = ?1",
+        params![agent_session_id, now_ms],
+    )?;
+    tx.commit()?;
+    Ok(message_id)
+}
+
+/// Load a session's conversation messages in `seq` order (oldest first). An unknown
+/// or empty session returns an empty Vec (not an error) — a fresh session simply has
+/// no prior history.
+pub fn load_session_messages(
+    conn: &Connection,
+    agent_session_id: &str,
+) -> Result<Vec<StoredSessionMessage>> {
+    let mut stmt = conn.prepare(
+        "SELECT message_id, agent_session_id, seq, role, content, refs, created_at
+         FROM agent_session_message
+         WHERE agent_session_id = ?1
+         ORDER BY seq ASC",
+    )?;
+    let rows = stmt.query_map([agent_session_id], |r| {
+        Ok(StoredSessionMessage {
+            message_id: r.get(0)?,
+            agent_session_id: r.get(1)?,
+            seq: r.get(2)?,
+            role: r.get(3)?,
+            content: r.get(4)?,
+            refs: r.get(5)?,
+            created_at: r.get(6)?,
+        })
+    })?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row?);
+    }
+    Ok(out)
+}
+
+/// Count of messages in a session (refs-only — no body). Convenience for refs-only
+/// event/observability that must never carry message text.
+pub fn session_message_count(conn: &Connection, agent_session_id: &str) -> Result<i64> {
+    let n: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM agent_session_message WHERE agent_session_id = ?1",
+        [agent_session_id],
+        |r| r.get(0),
+    )?;
+    Ok(n)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Db;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static C: AtomicU64 = AtomicU64::new(0);
+    fn tmp(tag: &str) -> String {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir()
+            .join(format!(
+                "friday-agent-session-{}-{}-{}-{nanos}.sqlite",
+                std::process::id(),
+                tag,
+                C.fetch_add(1, Ordering::Relaxed),
+            ))
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    #[test]
+    fn ensure_session_is_idempotent_and_bumps_updated_at() {
+        let db = Db::open_hub(&tmp("ensure")).unwrap();
+        ensure_session(db.conn(), "s1", 1000).unwrap();
+        assert!(session_exists(db.conn(), "s1").unwrap());
+        let (created, updated): (i64, i64) = db
+            .conn()
+            .query_row(
+                "SELECT created_at, updated_at FROM agent_session WHERE agent_session_id='s1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!((created, updated), (1000, 1000));
+        // Re-ensure bumps updated_at but keeps created_at and does not duplicate.
+        ensure_session(db.conn(), "s1", 2000).unwrap();
+        let (created2, updated2): (i64, i64) = db
+            .conn()
+            .query_row(
+                "SELECT created_at, updated_at FROM agent_session WHERE agent_session_id='s1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(created2, 1000, "created_at is immutable");
+        assert_eq!(updated2, 2000, "updated_at advances");
+        assert_eq!(db.count("agent_session").unwrap(), 1, "no duplicate row");
+    }
+
+    #[test]
+    fn append_assigns_monotonic_seq_and_loads_in_order() {
+        let db = Db::open_hub(&tmp("append")).unwrap();
+        ensure_session(db.conn(), "s1", 1).unwrap();
+        let id0 = append_session_message(
+            db.conn(),
+            "s1",
+            &SessionMessage::new("user", "remember 47", Some("r1".into())),
+            10,
+        )
+        .unwrap();
+        let id1 = append_session_message(
+            db.conn(),
+            "s1",
+            &SessionMessage::new("assistant", "noted 47", Some("r1".into())),
+            11,
+        )
+        .unwrap();
+        assert_ne!(id0, id1);
+        let msgs = load_session_messages(db.conn(), "s1").unwrap();
+        assert_eq!(msgs.len(), 2);
+        assert_eq!((msgs[0].seq, msgs[1].seq), (0, 1));
+        assert_eq!(msgs[0].role, "user");
+        assert_eq!(msgs[0].content, "remember 47");
+        assert_eq!(msgs[0].refs.as_deref(), Some("r1"));
+        assert_eq!(msgs[1].role, "assistant");
+        assert_eq!(session_message_count(db.conn(), "s1").unwrap(), 2);
+    }
+
+    #[test]
+    fn append_to_unknown_session_fails_closed() {
+        let db = Db::open_hub(&tmp("orphan")).unwrap();
+        let err = append_session_message(
+            db.conn(),
+            "ghost",
+            &SessionMessage::new("user", "hi", None),
+            1,
+        )
+        .unwrap_err();
+        assert!(matches!(err, StorageError::NotFound(_)));
+        assert_eq!(session_message_count(db.conn(), "ghost").unwrap(), 0);
+    }
+
+    #[test]
+    fn load_unknown_session_is_empty_not_error() {
+        let db = Db::open_hub(&tmp("empty")).unwrap();
+        let msgs = load_session_messages(db.conn(), "nope").unwrap();
+        assert!(msgs.is_empty());
+        assert!(!session_exists(db.conn(), "nope").unwrap());
+    }
+
+    #[test]
+    fn blank_role_and_blank_session_id_rejected() {
+        let db = Db::open_hub(&tmp("blank")).unwrap();
+        assert!(ensure_session(db.conn(), "  ", 1).is_err());
+        ensure_session(db.conn(), "s1", 1).unwrap();
+        assert!(
+            append_session_message(db.conn(), "s1", &SessionMessage::new("  ", "x", None), 1)
+                .is_err()
+        );
+    }
+}

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -11,6 +11,7 @@
 
 pub mod agent_run;
 pub mod agent_run_read;
+pub mod agent_session;
 pub mod audit;
 pub mod authorize;
 pub mod authorize_ed25519;
@@ -29,6 +30,10 @@ pub mod run_result;
 mod schema;
 pub mod workflow;
 
+pub use agent_session::{
+    append_session_message, ensure_session, load_session_messages, session_exists,
+    session_message_count, SessionMessage, StoredSessionMessage,
+};
 pub use authorize::authorize_mutating_action;
 pub use authorize_ed25519::{authorize_mutating_action_ed25519, Ed25519VerifyOnlyPolicy};
 pub use error::{Result, StorageError};

--- a/rust-core/crates/friday-storage/src/schema.rs
+++ b/rust-core/crates/friday-storage/src/schema.rs
@@ -55,6 +55,13 @@ pub const HUB_ONLY_TABLES: &[&str] = &[
     // phone never runs the agent loop and the TS-facing readback is refs-only, so
     // the body-bearing table is never created on a phone.
     "run_result",
+    // S5: minimal agent-loop SESSION + its conversation messages. A session groups
+    // runs and stores their prior messages (role + content + refs) Hub-side so a
+    // session can RESUME with multi-turn inbound history. The message `content` is
+    // a body kept Hub-side (like `run_result.answer`); the phone never runs the loop
+    // and there is no answer-body-over-wire, so the tables are never on a phone.
+    "agent_session",
+    "agent_session_message",
 ];
 
 /// Tables present only on a phone (never created on the Hub).
@@ -224,6 +231,17 @@ pub fn hub_migrations() -> Vec<Migration> {
             name: "run_result_owner_principal",
             destructive: false,
             up: m0017_run_result_owner_principal,
+        },
+        // S5: Hub-only minimal agent-loop `agent_session` + `agent_session_message`
+        // tables. A session groups runs and stores their prior conversation messages
+        // (role + content + refs) so a session can RESUME with multi-turn inbound
+        // history. Purely additive (CREATE TABLE + INDEX only) — touches no existing
+        // table, so v17 rows/queries are unaffected.
+        Migration {
+            version: 18,
+            name: "agent_session",
+            destructive: false,
+            up: m0018_agent_session,
         },
     ]
 }
@@ -438,6 +456,38 @@ CREATE TABLE run_result (
     created_at    INTEGER NOT NULL
 );
 CREATE INDEX idx_run_result_created ON run_result(created_at);";
+
+// --- S5 agent-session fragments (Hub-only) ----------------------------------
+
+// A session groups agent-loop runs and stores their prior conversation messages so
+// a session can RESUME with multi-turn inbound history. `agent_session` is the
+// lightweight parent row (timestamps only — the foundation `session` table is a
+// separate UI/activity grouping and is NOT reused). `agent_session_message` holds
+// the ordered conversation turns: `role` (e.g. user/assistant), the message `content`
+// kept Hub-side (like `run_result.answer`; NEVER an answer-body-over-wire), an
+// optional `refs` soft-link (e.g. the producing run id — no FK, the `*_ref`
+// convention), and a per-session monotonic `seq` so the prior history loads in order.
+// `UNIQUE(agent_session_id, seq)` makes a duplicate ordinal a fail-closed insert.
+const DDL_AGENT_SESSION: &str = "
+CREATE TABLE agent_session (
+    agent_session_id TEXT PRIMARY KEY,
+    created_at       INTEGER NOT NULL,
+    updated_at       INTEGER NOT NULL
+);
+
+CREATE TABLE agent_session_message (
+    message_id       TEXT PRIMARY KEY,
+    agent_session_id TEXT NOT NULL,
+    seq              INTEGER NOT NULL CHECK(seq >= 0),
+    role             TEXT NOT NULL CHECK(length(trim(role)) > 0),
+    content          TEXT NOT NULL DEFAULT '',
+    refs             TEXT,
+    created_at       INTEGER NOT NULL,
+    UNIQUE(agent_session_id, seq),
+    FOREIGN KEY(agent_session_id) REFERENCES agent_session(agent_session_id)
+);
+CREATE INDEX idx_agent_session_message_seq
+    ON agent_session_message(agent_session_id, seq);";
 
 // --- PNS-001 provider-session fragments (Hub-only) --------------------------
 
@@ -1146,4 +1196,12 @@ fn m0016_pending_approval_tool_params(tx: &Transaction) -> rusqlite::Result<()> 
 // the refs-only proof projection (which does not select it at all).
 fn m0017_run_result_owner_principal(tx: &Transaction) -> rusqlite::Result<()> {
     tx.execute_batch("ALTER TABLE run_result ADD COLUMN owner_principal TEXT;")
+}
+
+// S5: additive Hub-only `agent_session` + `agent_session_message` tables. A session
+// groups runs and stores their prior conversation messages (role + content + refs)
+// keyed by `agent_session_id`, so a session can RESUME with multi-turn inbound
+// history. Purely additive (CREATE TABLE + INDEX only) — touches no existing table.
+fn m0018_agent_session(tx: &Transaction) -> rusqlite::Result<()> {
+    tx.execute_batch(DDL_AGENT_SESSION)
 }


### PR DESCRIPTION
## Truth label
Multi-turn **inbound** conversation history + **minimal sessions/resume** for the Rust agent loop. **PROOF-ONLY; NOT a v1 GO.** This is substrate + API + tests; it is NOT wired into the live `run_task` path (that wiring lives in `runtime.rs`, owned by the concurrent Lane A).

## What this adds
The Rust agent loop (`run_loop` / `run_loop_with_policy`) previously ran a SINGLE task with no inbound conversation history. S5 adds:

**friday-storage** (`agent_session.rs` + additive migration **v18**)
- Hub-only `agent_session` + `agent_session_message` tables (role + content + refs, keyed by `agent_session_id`, ordered by a per-session monotonic `seq`; `UNIQUE(session_id, seq)`). Both added to `HUB_ONLY_TABLES` (the phone profile omits them; enforced by `schema_profile.rs`).
- Repo API: `ensure_session` (idempotent), `append_session_message` (FK-guarded, auto-seq), `load_session_messages` (ordered), `session_message_count`, `session_exists`.
- Message `content` is a BODY kept **Hub-side** (exactly like `run_result.answer`) — there is **no answer-body-over-wire**.

**friday-hub** (`lib.rs`)
- `render_session_history` — renders prior session messages into a **BOUNDED** prompt preamble: per-message head-slice cap (1 KiB) + total cap (6 KiB), oldest messages dropped with an omission marker, **recency preserved**, labeled as CONTEXT (not the current task). Empty history → empty preamble (single-shot prompt unchanged).
- `run_session_loop` — history-aware loop entry: `ensure_session` → `load_session_messages` (BEFORE persisting the current task) → fold the bounded history **ahead of** the recall preamble into the SAME prompt `run_loop_with_policy` already prepends (**no loop signature change**) → run the gate-mandatory loop → persist this run's `user` task + (on finish) `assistant` answer back to the session, with a **refs-only** outcome event (session id + message count, never the text).

## Where inbound history is injected (the bound)
`prompt = [bounded session history][recall preamble][task]`, threaded through the existing `prompt_task = preamble + task` seam in `run_loop_with_policy`. The bound is `MAX_SESSION_HISTORY_BYTES = 6144` (content) with a `MAX_SESSION_MESSAGE_BYTES = 1024` per-message cap, so a long/large session cannot blow the completion-token budget.

## Tests
- `session_loop_prepends_prior_history_into_model_prompt` — a session with prior messages → the loop's rendered prompt includes them (and the current task); the outcome event is refs-only (asserts message text is NOT in the event).
- `session_resume_run2_sees_run1_message` — run 1 then run 2 in the same session; run 2's prompt carries run 1's user task AND assistant answer; session holds 4 ordered messages refs-linked to the right runs.
- `single_shot_run_loop_creates_no_session_state` — `run_loop` (no session) finishes and touches zero `agent_session*` rows / no session prompt label.
- `render_session_history_is_bounded_and_drops_oldest` + `session_loop_bounds_oversized_history_in_prompt` — oversized history is capped and oldest-flagged, end-to-end through the loop.
- `agent_session` storage unit tests (idempotent ensure, monotonic seq, orphan fail-closed, empty-not-error, blank-rejected).

## Local gate
- `cargo fmt --all` clean; `cargo build -p friday-hub --bin hub_run_task` OK; `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo test -p friday-hub -p friday-storage` all green (288 hub lib + all integration/storage suites).
- `npm run lint`: **0 errors** (pre-existing warnings only; no TS touched). `npm run typecheck`: the only errors are pre-existing in `src/channels/lark/internal/lark-ws-client.ts` (a file this PR does not touch) — an artifact of running against a newer dep tree that dropped `@types/ws`; verified identical on pristine base `1f60c2e6`.

## What this did NOT do
- Did **not** edit `runtime.rs` / `hub_server.rs` (Lane A) or `routing.rs` (out of write-set). `git diff --name-only` = `friday-hub/src/lib.rs` + `friday-storage/{agent_session,lib,schema}.rs` only.
- No **answer-body-over-wire** (transport lane); session content stays Hub-side.
- No plan-review / rollback / subagents / MCP; no UI (design-handoff gated).
- Not wired into live `run_task`; coordinator runs the live proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)