### PR TITLE
D1-transport: owner-wire run_task + internal authed single-provider agent-loop route

### DIFF
--- a/rust-core/crates/friday-hub/src/bin/hub_authed_run.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_authed_run.rs
@@ -1,0 +1,311 @@
+//! D1-Q4 — `hub_authed_run`: the internal AUTHENTICATED single-provider agent-loop route.
+//!
+//! PROOF-ONLY. A reachable (non-test) entrypoint that exposes the Rust agent loop
+//! ([`friday_hub::runtime::HubRuntime::run_task`]) to an AUTHENTICATED caller and returns the
+//! answer body ONLY to that authenticated OWNER. It reuses the EXISTING sealed-session
+//! authentication ([`friday_crypto::DeviceKeypair`] ECDH → a per-session [`friday_crypto::DataKey`],
+//! the same mechanism `HubServer::serve_connection` is fenced by): a caller proves possession
+//! of the shared session key by sealing the agreed challenge, which the Hub OPENS with its
+//! half of the session. A caller without the paired key produces a seal the Hub cannot open →
+//! no `AuthedPrincipal` → no run, no body (fail-closed).
+//!
+//! ## Truth label
+//! INTERNAL, authenticated, SINGLE-provider (`deepseek-flash`) route. NOT multi-provider, NOT
+//! provider-native, NOT a v1 GO; `executeRun` is NOT replaced. The answer BODY is delivered
+//! ONLY to the authenticated owner (here, SEALED back over the owner's session — the
+//! owner-only channel); the bin's stdout is a PROOF surface and carries refs-only.
+//!
+//! ## Demonstration harness honesty
+//! A real deployment authenticates an EXTERNAL paired device over the WS transport. This
+//! one-shot bin pairs an in-process device to demonstrate the boundary end-to-end without a
+//! live peer. The OWNER principal is HUB-SUPPLIED (`--principal`, an operator CLI arg) — NEVER
+//! client-controlled — so a caller can never self-assert another principal.
+//!
+//! ## Output contract — REFS ONLY (no bodies, no secrets, no PII)
+//! Emits ONE JSON object to stdout carrying ONLY safe identifiers/refs: `truth_label`, the
+//! authed-route outcome (`delivered_to_authenticated_owner` / `denied_not_owner` /
+//! `no_answer_safe_failure`), `run_id`, status, the answer's **sha256 + length** (NEVER the
+//! body), the length of the owner-sealed body ciphertext, and a static, redacted-safe
+//! provider/model family. A defensive output guard rejects any forbidden marker before
+//! printing. The `RunAnswerAccess::Granted` body Debug is NEVER printed (`AuthedAnswer`'s
+//! Debug is body-redacting, and the body is consumed only to seal it to the owner).
+//!
+//! ## Live key
+//! [`HubRuntime::live`] reads the DeepSeek key from the env (`DeepSeekClient::from_env`, never
+//! logged). Running this for real needs `FRIDAY_DEEPSEEK_API_KEY` and spends quota — the
+//! SEPARATE operator/coordinator live-proof step. CI only BUILDS this bin.
+
+use std::env;
+use std::io::Read;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use friday_crypto::{seal, DeviceKeypair};
+use friday_hub::hub_server::{run_authed_agent_loop, AuthedPrincipal};
+use friday_hub::runtime::{HubConfig, HubRuntime};
+use serde_json::json;
+
+/// The agreed authentication challenge (a fixed, public, non-secret constant — the security
+/// is in possessing the session key that seals it, not in the challenge value).
+const AUTH_CHALLENGE: &[u8] = b"friday:d1q4:authed-run:challenge:v1";
+/// The session AAD binding the sealed proof (and the owner-sealed body) to this exchange.
+const AUTH_AAD: &[u8] = b"friday:d1q4:authed-run:aad:v1";
+
+/// A fail-closed error: `kind` is a coarse, safe category (the only thing surfaced); the raw
+/// detail is deliberately NOT printed so storage/init errors cannot leak paths.
+struct BridgeError {
+    kind: &'static str,
+}
+
+impl BridgeError {
+    fn new(kind: &'static str) -> Self {
+        Self { kind }
+    }
+}
+
+fn main() {
+    match run() {
+        Ok(rendered) => println!("{rendered}"),
+        Err(err) => {
+            let payload = json!({
+                "truth_label": "internal_authenticated_single_provider",
+                "proof_only": true,
+                "ok": false,
+                "error_kind": err.kind,
+            });
+            println!("{payload}");
+            eprintln!("hub_authed_run_unavailable: {}", err.kind);
+            std::process::exit(2);
+        }
+    }
+}
+
+fn run() -> Result<String, BridgeError> {
+    let args: Vec<String> = env::args().collect();
+
+    // Task prompt: --task <prompt>, else stdin (the body-bearing channel stays off argv).
+    let task = match arg_value(&args, "--task") {
+        Some(task) => task,
+        None => {
+            let mut buf = String::new();
+            std::io::stdin()
+                .read_to_string(&mut buf)
+                .map_err(|_| BridgeError::new("bad_args"))?;
+            buf.trim().to_string()
+        }
+    };
+    if task.is_empty() {
+        return Err(BridgeError::new("bad_args"));
+    }
+
+    // The agent loop's fs tools are contained to this workspace root (required).
+    let workspace_root = arg_value(&args, "--workspace").ok_or(BridgeError::new("bad_args"))?;
+
+    // The OWNER principal is HUB-SUPPLIED here (operator CLI arg), never client-controlled.
+    let principal = arg_value(&args, "--principal")
+        .map(|p| p.trim().to_string())
+        .filter(|p| !p.is_empty())
+        .ok_or(BridgeError::new("bad_args"))?;
+
+    let pid = std::process::id();
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+
+    let db_path = arg_value(&args, "--db")
+        .unwrap_or_else(|| format!("{workspace_root}/.hub-authed-run-dev-{pid}-{nanos}.sqlite"));
+    let run_id =
+        arg_value(&args, "--run-id").unwrap_or_else(|| format!("hub_authed_run_{pid}_{nanos}"));
+    let max_turns = arg_value(&args, "--max-turns")
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(6);
+    let now_ms = arg_value(&args, "--now-ms")
+        .and_then(|v| v.parse::<i64>().ok())
+        .unwrap_or_else(|| {
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_millis() as i64)
+                .unwrap_or(0)
+        });
+
+    // (a) AUTHENTICATE via the existing sealed-session mechanism. We pair an in-process device
+    // (hub + caller DeviceKeypairs) and have the caller seal the agreed challenge; the Hub
+    // OPENS it with its half of the ECDH session. A caller without the paired key would fail
+    // here (the negative path is asserted by the hub_server unit tests). The authenticated
+    // principal is the HUB-SUPPLIED owner — never anything the caller sends.
+    let hub_kp = DeviceKeypair::generate();
+    let caller_kp = DeviceKeypair::generate();
+    let hub_session = hub_kp.agree(&caller_kp.public_bytes());
+    let caller_session = caller_kp.agree(&hub_kp.public_bytes());
+    let sealed_proof = seal(&caller_session, AUTH_CHALLENGE, AUTH_AAD)
+        .map_err(|_| BridgeError::new("auth_seal"))?;
+    let caller = AuthedPrincipal::authenticate(
+        &hub_session,
+        &sealed_proof,
+        AUTH_AAD,
+        AUTH_CHALLENGE,
+        &principal,
+    )
+    .ok_or(BridgeError::new("auth_denied"))?;
+
+    // (b) Build the LIVE single-provider runtime, configured with the SAME owner principal so
+    // owner-wiring records owner == caller and the answer is releasable to them.
+    let runtime = HubRuntime::live(HubConfig {
+        db_path,
+        workspace_root: PathBuf::from(&workspace_root),
+        secret: ephemeral_dev_secret(pid, nanos),
+        max_turns,
+        principal_id: Some(principal.clone()),
+        disabled_tools: vec![],
+        read_only: false,
+        operator_vk: None,
+    })
+    .map_err(|_| BridgeError::new("init_failed"))?;
+
+    // (b)+(c) Run the loop as the authenticated principal and project the answer ONLY to the
+    // authenticated owner.
+    let outcome = run_authed_agent_loop(&runtime, &caller, &run_id, &task, now_ms);
+
+    // (c) Deliver the body ONLY to the authenticated owner: SEAL it back over the owner's
+    // session (the owner-only channel). The plaintext body NEVER touches stdout — we record
+    // only the ciphertext length as proof that a sealed delivery occurred.
+    let sealed_body_len = match outcome.delivered_body() {
+        Some(body) => {
+            let sealed = seal(&caller_session, body.as_bytes(), AUTH_AAD)
+                .map_err(|_| BridgeError::new("deliver_seal"))?;
+            Some(sealed.ciphertext.len())
+        }
+        None => None,
+    };
+
+    // (d) REFS-ONLY proof to stdout: outcome + status + answer FINGERPRINT (sha256/len) — never
+    // the body, never a raw provider/secret/channel id. Provider/model is a static,
+    // redacted-safe family label for this single-provider build.
+    let mut payload = outcome.proof_refs_json();
+    if let Some(obj) = payload.as_object_mut() {
+        obj.insert(
+            "truth_label".into(),
+            json!("internal_authenticated_single_provider"),
+        );
+        obj.insert("proof_only".into(), json!(true));
+        obj.insert("ok".into(), json!(true));
+        obj.insert("provider_family".into(), json!("deepseek"));
+        obj.insert("model_class".into(), json!("flash"));
+        obj.insert("multi_provider".into(), json!(false));
+        obj.insert("v1_go".into(), json!(false));
+        obj.insert("execute_run_replaced".into(), json!(false));
+        obj.insert("authenticated".into(), json!(true));
+        obj.insert(
+            "auth_mechanism".into(),
+            json!("sealed_session_devicekeypair"),
+        );
+        // Proof that the body left over the owner-only sealed channel (length only).
+        obj.insert("owner_sealed_body_len".into(), json!(sealed_body_len));
+    }
+
+    let rendered =
+        serde_json::to_string(&payload).map_err(|_| BridgeError::new("serialize_failed"))?;
+    reject_forbidden_output(&rendered)?;
+    Ok(rendered)
+}
+
+fn arg_value(args: &[String], name: &str) -> Option<String> {
+    args.windows(2)
+        .find_map(|pair| (pair[0] == name).then(|| pair[1].clone()))
+        .or_else(|| {
+            let prefix = format!("{name}=");
+            args.iter()
+                .find_map(|arg| arg.strip_prefix(&prefix).map(str::to_string))
+        })
+}
+
+/// Ephemeral, non-secret bytes (dormant under deny-all). Derived, not read from any key store.
+fn ephemeral_dev_secret(pid: u32, nanos: u128) -> Vec<u8> {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(format!("hub-authed-run-dev:{pid}:{nanos}").as_bytes());
+    hasher.finalize().to_vec()
+}
+
+/// Defense-in-depth: refuse to print if any forbidden marker leaked into the refs-only
+/// payload. Mirrors `hub_run_task`'s guard; `answer"` (the body field) must never appear.
+fn reject_forbidden_output(rendered: &str) -> Result<(), BridgeError> {
+    for marker in [
+        "Authorization",
+        "Bearer",
+        "sk-",
+        "/Users/",
+        "/private/",
+        "\"answer\"", // the body text field must never appear (only the sha256/len do)
+    ] {
+        if rendered.contains(marker) {
+            return Err(BridgeError::new("output_guard"));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use friday_hub::hub_server::AuthedAnswer;
+    use serde_json::{from_str, Value};
+
+    #[test]
+    fn arg_value_supports_space_and_equals_forms() {
+        let args = vec![
+            "bin".to_string(),
+            "--task".to_string(),
+            "do a thing".to_string(),
+            "--principal=principal:owner".to_string(),
+        ];
+        assert_eq!(arg_value(&args, "--task").as_deref(), Some("do a thing"));
+        assert_eq!(
+            arg_value(&args, "--principal").as_deref(),
+            Some("principal:owner")
+        );
+        assert_eq!(arg_value(&args, "--missing"), None);
+    }
+
+    #[test]
+    fn forbidden_output_guard_blocks_body_and_secret_markers() {
+        assert!(reject_forbidden_output(r#"{"answer":"hi"}"#).is_err());
+        assert!(reject_forbidden_output(r#"{"x":"Bearer abc"}"#).is_err());
+        assert!(reject_forbidden_output(r#"{"x":"sk-xxx"}"#).is_err());
+        assert!(reject_forbidden_output(r#"{"answer_sha256":"00","answer_len":3}"#).is_ok());
+    }
+
+    /// The refs-only proof payload shape carries the fingerprint, the truth labels, and the
+    /// owner-sealed-body length — but NEVER the body field.
+    #[test]
+    fn refs_only_payload_shape_excludes_body_text() {
+        let answer = AuthedAnswer::Delivered {
+            run_id: "run-1".into(),
+            status: "finished".into(),
+            answer: "THE-SECRET-BODY".into(),
+            answer_sha256: "00".repeat(32),
+            answer_len: 15,
+        };
+        let mut payload = answer.proof_refs_json();
+        let obj = payload.as_object_mut().unwrap();
+        obj.insert(
+            "truth_label".into(),
+            json!("internal_authenticated_single_provider"),
+        );
+        obj.insert("owner_sealed_body_len".into(), json!(64));
+        let rendered = serde_json::to_string(&payload).unwrap();
+        // CANARY: the body never appears; the guard passes; the fingerprint does appear.
+        assert!(!rendered.contains("THE-SECRET-BODY"));
+        assert!(reject_forbidden_output(&rendered).is_ok());
+        let parsed: Value = from_str(&rendered).unwrap();
+        assert_eq!(parsed["outcome"], "delivered_to_authenticated_owner");
+        assert_eq!(parsed["answer_len"], 15);
+        assert!(parsed.get("answer").is_none(), "must never carry body text");
+    }
+
+    #[test]
+    fn ephemeral_secret_is_32_bytes() {
+        assert_eq!(ephemeral_dev_secret(1, 2).len(), 32);
+    }
+}

--- a/rust-core/crates/friday-hub/src/hub_server.rs
+++ b/rust-core/crates/friday-hub/src/hub_server.rs
@@ -19,6 +19,7 @@
 //! auth material, raw private reasoning, cwd, or external urls on the wire. The answer +
 //! usage live Hub-side in the token_ledger / Activity receipt. No UI code here.
 
+use friday_crypto::{open, DataKey, Sealed};
 use friday_deepseek::{DeepSeekClient, Transport};
 use friday_protocol::{
     Envelope, ErrorCode, Message, MissionIntakeRequestWire, MissionIntakeResultWire,
@@ -29,8 +30,12 @@ use friday_protocol::{
     ProviderWorkspaceActionResultWire, RouteDecisionProjectionWire, SUPPORTED,
 };
 use friday_providers::unified::{FallbackStatus, PlatformProvider, ProviderSession, SessionStatus};
-use friday_storage::Db;
+use friday_storage::{
+    get_run_answer_for_principal, get_run_result_ref, AnswerDenyReason, Db, RunAnswerAccess,
+    RunResultRef,
+};
 use friday_transport::{ws_recv_envelope, ws_send_envelope, TransportError, WireWebSocket};
+use serde_json::json;
 use std::collections::BTreeSet;
 use std::io::{Read, Write};
 
@@ -43,6 +48,7 @@ use crate::provider_dispatch::{
     dispatch_provider_action, DispatchContext, DispatchError, ProviderDispatchAdapter,
 };
 use crate::provider_workspace::ProviderWorkspaceCatalog;
+use crate::runtime::HubRuntime;
 use crate::RecordAskError;
 
 /// A headless Hub runtime serving one or more trusted client sessions. Generic over the
@@ -882,6 +888,244 @@ impl<T: Transport> HubServer<T> {
             ws_send_envelope(ws, session_key, &response, aad)?;
         }
     }
+}
+
+// ===========================================================================
+// D1-Q4 — internal AUTHENTICATED single-provider agent-loop route.
+// ===========================================================================
+//
+// Truth label: this is an INTERNAL, authenticated, SINGLE-provider (`deepseek-flash`) route.
+// It is NOT multi-provider, NOT provider-native, and NOT a v1 GO; `executeRun` is NOT
+// replaced. The answer BODY is delivered ONLY to the AUTHENTICATED OWNER of the run; every
+// proof/unauth surface gets refs-only (status + the answer's sha256 + length), never the
+// body, never a raw provider/secret/channel id.
+//
+// Authentication reuses the EXISTING sealed-session mechanism (`DeviceKeypair` ECDH →
+// per-session `DataKey`, the same one [`HubServer::serve_connection`] is fenced by): a caller
+// proves possession of the shared session key by sealing the agreed challenge, which the Hub
+// OPENS with its half of the session. A caller without the paired key produces a seal the Hub
+// cannot open → no [`AuthedPrincipal`] → no run, no body (fail-closed).
+
+/// An AUTHENTICATED caller principal, derived from a verified sealed session (D1-Q4).
+///
+/// Constructible ONLY by [`AuthedPrincipal::authenticate`]. The bound principal is the
+/// HUB-OWNER principal supplied by Hub config — NEVER a client-supplied string — so a caller
+/// can never self-assert another principal to read someone else's answer. There is no public
+/// constructor and no way to mint one without opening a caller-sealed proof.
+pub struct AuthedPrincipal(String);
+
+impl AuthedPrincipal {
+    /// Authenticate a caller over the established sealed session and bind the Hub's OWNER
+    /// principal to it.
+    ///
+    /// Authentication == the Hub can OPEN the caller's `sealed_proof` under the shared session
+    /// `DataKey` (proving the caller holds the paired session key — the SAME seal/open the WS
+    /// transport uses) AND the opened bytes equal the agreed `expected_challenge` (binding the
+    /// proof to THIS exchange). A different `DeviceKeypair` yields a seal that does not open →
+    /// `None`. The `owner_principal` is Hub-supplied (single-owner v1); an empty/blank one is
+    /// rejected (no anonymous owner). Returns `None` on ANY failure — fail-closed.
+    pub fn authenticate(
+        hub_session: &DataKey,
+        sealed_proof: &Sealed,
+        aad: &[u8],
+        expected_challenge: &[u8],
+        owner_principal: &str,
+    ) -> Option<AuthedPrincipal> {
+        // Possession of the shared session key is the authentication; opening fails closed for
+        // any caller that did not seal under it.
+        let opened = open(hub_session, sealed_proof, aad).ok()?;
+        if opened.as_slice() != expected_challenge {
+            return None;
+        }
+        let principal = owner_principal.trim();
+        if principal.is_empty() {
+            return None;
+        }
+        Some(AuthedPrincipal(principal.to_string()))
+    }
+
+    /// The bound, Hub-trusted principal (never client-supplied).
+    pub fn principal(&self) -> &str {
+        &self.0
+    }
+}
+
+/// The body-release outcome of the authenticated answer projection (D1-Q4).
+///
+/// The answer BODY is carried ONLY in [`AuthedAnswer::Delivered`] — for in-process hand-off
+/// to the authenticated owner. Every other variant is body-free. A MANUAL [`std::fmt::Debug`]
+/// (below) redacts the body, so an accidental `{:?}` can never leak it; the body is NEVER
+/// placed on a refs-only/proof surface (use [`AuthedAnswer::proof_refs_json`]).
+pub enum AuthedAnswer {
+    /// The authenticated caller IS the run's owner: the answer body is released to them,
+    /// alongside its refs-only fingerprint (sha256 + length) for proof.
+    Delivered {
+        run_id: String,
+        status: String,
+        answer: String,
+        answer_sha256: String,
+        answer_len: i64,
+    },
+    /// A stored answer exists but the authenticated caller is NOT its owner (or the run has no
+    /// owner): the body is WITHHELD. Carries only the coarse deny reason + the refs-only
+    /// fingerprint (never the body, never the owner principal).
+    Denied {
+        run_id: String,
+        reason: AnswerDenyReason,
+        refs: Option<RunResultRef>,
+    },
+    /// No stored answer for this run (provider unavailable / run not Finished): safe failure,
+    /// no body, no panic.
+    NoAnswer { run_id: String },
+}
+
+impl std::fmt::Debug for AuthedAnswer {
+    /// Body-redacting Debug: a `Delivered` renders only its fingerprint (sha256 + length),
+    /// NEVER the answer body. This is the structural guard behind the "never log the Granted
+    /// body" rule — even a stray `{:?}` on this type cannot leak the answer.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AuthedAnswer::Delivered {
+                run_id,
+                status,
+                answer_sha256,
+                answer_len,
+                ..
+            } => f
+                .debug_struct("AuthedAnswer::Delivered")
+                .field("run_id", run_id)
+                .field("status", status)
+                .field("answer_sha256", answer_sha256)
+                .field("answer_len", answer_len)
+                .field("answer", &"<redacted: owner-only body>")
+                .finish(),
+            AuthedAnswer::Denied {
+                run_id,
+                reason,
+                refs,
+            } => f
+                .debug_struct("AuthedAnswer::Denied")
+                .field("run_id", run_id)
+                .field("reason", reason)
+                .field("refs", refs)
+                .finish(),
+            AuthedAnswer::NoAnswer { run_id } => f
+                .debug_struct("AuthedAnswer::NoAnswer")
+                .field("run_id", run_id)
+                .finish(),
+        }
+    }
+}
+
+impl AuthedAnswer {
+    /// The answer body for the AUTHENTICATED OWNER (in-process hand-off ONLY). `None` for
+    /// every non-delivered variant. NEVER call this for a proof/log/wire surface.
+    pub fn delivered_body(&self) -> Option<&str> {
+        match self {
+            AuthedAnswer::Delivered { answer, .. } => Some(answer),
+            _ => None,
+        }
+    }
+
+    /// The (d) REFS-ONLY proof projection: outcome label + status + the answer FINGERPRINT
+    /// (sha256 + length) + run_id — and NEVER the answer body (and never an owner principal,
+    /// raw provider/secret/channel id). This is what a proof/unauth surface (e.g. the bin's
+    /// stdout) prints.
+    pub fn proof_refs_json(&self) -> serde_json::Value {
+        match self {
+            AuthedAnswer::Delivered {
+                run_id,
+                status,
+                answer_sha256,
+                answer_len,
+                ..
+            } => json!({
+                "outcome": "delivered_to_authenticated_owner",
+                "run_id": run_id,
+                "status": status,
+                "answer_sha256": answer_sha256,
+                "answer_len": answer_len,
+            }),
+            AuthedAnswer::Denied {
+                run_id,
+                reason,
+                refs,
+            } => json!({
+                "outcome": "denied_not_owner",
+                "run_id": run_id,
+                "deny_reason": format!("{reason:?}"),
+                "answer_sha256": refs.as_ref().map(|r| r.answer_sha256.clone()),
+                "answer_len": refs.as_ref().map(|r| r.answer_len),
+            }),
+            AuthedAnswer::NoAnswer { run_id } => json!({
+                "outcome": "no_answer_safe_failure",
+                "run_id": run_id,
+            }),
+        }
+    }
+}
+
+/// (b)/(c) The auditable BODY-RELEASE decision: project a run's answer to an AUTHENTICATED
+/// caller. Releases the body ONLY when the caller's authenticated principal matches the run's
+/// bound OWNER principal (via [`friday_storage::get_run_answer_for_principal`]); otherwise the
+/// body is WITHHELD and only the refs-only fingerprint is returned. A `RunAnswerAccess::Granted`
+/// is destructured IMMEDIATELY into [`AuthedAnswer::Delivered`] and never allowed to escape as
+/// a `{:?}` (it carries the body). A storage error fails closed to [`AuthedAnswer::NoAnswer`].
+pub fn project_answer_for_authed(
+    conn: &rusqlite::Connection,
+    run_id: &str,
+    caller: &AuthedPrincipal,
+) -> AuthedAnswer {
+    match get_run_answer_for_principal(conn, run_id, caller.principal()) {
+        Ok(RunAnswerAccess::Granted(stored)) => AuthedAnswer::Delivered {
+            run_id: run_id.to_string(),
+            status: stored.status,
+            answer: stored.answer,
+            answer_sha256: stored.answer_sha256,
+            answer_len: stored.answer_len,
+        },
+        Ok(RunAnswerAccess::Denied(reason)) => AuthedAnswer::Denied {
+            run_id: run_id.to_string(),
+            reason,
+            // refs-only fingerprint (body-free, owner-free) for the deny's proof surface.
+            refs: get_run_result_ref(conn, run_id).ok().flatten(),
+        },
+        Ok(RunAnswerAccess::NotFound) | Err(_) => AuthedAnswer::NoAnswer {
+            run_id: run_id.to_string(),
+        },
+    }
+}
+
+/// (a)+(b)+(c) The internal AUTHENTICATED single-provider agent-loop route (D1-Q4).
+///
+/// Runs the Rust agent loop ([`HubRuntime::run_task`]) for an ALREADY-AUTHENTICATED caller
+/// (the `caller` is produced ONLY by [`AuthedPrincipal::authenticate`] over the sealed
+/// session), then projects the answer body to that authenticated OWNER via
+/// [`project_answer_for_authed`]. The runtime is single-owner (v1): it MUST be configured with
+/// the SAME principal as `caller` so owner-wiring records `owner == caller` and the body is
+/// released to them.
+///
+/// SAFE FAILURE: a route/provider failure (`run_task` `Err`) OR a non-Finished run (e.g. a
+/// transport-errored loop, which persists no `run_result`) returns a body-free
+/// [`AuthedAnswer::NoAnswer`] — no panic, no partial/false success. The answer body, when
+/// delivered, is carried ONLY in [`AuthedAnswer::Delivered`] for in-process hand-off to the
+/// authed owner — it is NEVER placed on a refs-only/proof surface and NEVER logged.
+pub fn run_authed_agent_loop<T: Transport>(
+    runtime: &HubRuntime<T>,
+    caller: &AuthedPrincipal,
+    run_id: &str,
+    task: &str,
+    now_ms: i64,
+) -> AuthedAnswer {
+    // (a) the caller is already authenticated (typed proof). (b) run the loop as that
+    // principal; a route/provider failure is a SAFE FAILURE (no body, no panic).
+    if runtime.run_task(run_id, task, now_ms).is_err() {
+        return AuthedAnswer::NoAnswer {
+            run_id: run_id.to_string(),
+        };
+    }
+    // (c) release the answer ONLY to the authenticated owner (owner-wiring + ownership gate).
+    project_answer_for_authed(runtime.db().conn(), run_id, caller)
 }
 
 fn work_item_timeline_wire(item: friday_core::WorkItem) -> MissionTimelineWorkItemWire {
@@ -4824,5 +5068,327 @@ mod tests {
         }
         assert!(pages > 1);
         assert_eq!(provider_link_count, ask_count);
+    }
+}
+
+#[cfg(test)]
+mod authed_route_tests {
+    //! D1-Q4 adversarial tests: the auth boundary is the point.
+    //!
+    //! Authentication reuses the existing sealed-session mechanism (`DeviceKeypair` ECDH →
+    //! `DataKey`); the body is released ONLY to the authenticated owner; unauth / wrong-
+    //! principal / provider-unavailable are body-free; and no proof/log projection carries
+    //! the body or a secret.
+    use super::*;
+    use crate::runtime::{DenyAllApprovals, HubConfig, HubRuntime};
+    use crate::DeepSeekAgentLlmClient;
+    use friday_crypto::{seal, DeviceKeypair};
+    use friday_deepseek::{DeepSeekClient, DeepSeekError};
+    use friday_storage::{persist_run_result, RunResult};
+    use serde_json::Value;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static C: AtomicU64 = AtomicU64::new(0);
+    fn tmp(tag: &str) -> String {
+        std::env::temp_dir()
+            .join(format!(
+                "friday-authed-route-{}-{}-{}.sqlite",
+                std::process::id(),
+                tag,
+                C.fetch_add(1, Ordering::Relaxed)
+            ))
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    const AAD: &[u8] = b"d1q4-authed-route-aad";
+    const CHALLENGE: &[u8] = b"d1q4-authed-run-challenge";
+    const BODY: &str = "AUTHED-ROUTE-BODY-CANARY-only-owner-P";
+
+    /// Two halves of ONE shared session via DeviceKeypair ECDH (the existing pairing/session
+    /// mechanism): a challenge sealed by the caller opens for the hub == authenticated.
+    fn paired_sessions() -> (DataKey, DataKey) {
+        let hub = DeviceKeypair::generate();
+        let phone = DeviceKeypair::generate();
+        (
+            hub.agree(&phone.public_bytes()),
+            phone.agree(&hub.public_bytes()),
+        )
+    }
+
+    /// An authenticated caller bound to `principal` over a freshly paired session.
+    fn authed(principal: &str) -> AuthedPrincipal {
+        let (hub_session, caller_session) = paired_sessions();
+        let sealed = seal(&caller_session, CHALLENGE, AAD).unwrap();
+        AuthedPrincipal::authenticate(&hub_session, &sealed, AAD, CHALLENGE, principal).unwrap()
+    }
+
+    // --- authentication boundary (the existing sealed-session mechanism) ------
+
+    #[test]
+    fn authenticate_grants_principal_for_the_paired_caller() {
+        let (hub_session, caller_session) = paired_sessions();
+        let sealed = seal(&caller_session, CHALLENGE, AAD).unwrap();
+        let authed =
+            AuthedPrincipal::authenticate(&hub_session, &sealed, AAD, CHALLENGE, "principal:owner")
+                .expect("the paired caller authenticates");
+        assert_eq!(authed.principal(), "principal:owner");
+    }
+
+    #[test]
+    fn authenticate_denies_an_unpaired_attacker_keypair() {
+        // The attacker shares NO key with the hub → its seal does not open → None. THIS is the
+        // real auth boundary: no principal ⇒ no run, no body downstream (fail-closed).
+        let hub = DeviceKeypair::generate();
+        let real_phone = DeviceKeypair::generate();
+        let hub_session = hub.agree(&real_phone.public_bytes());
+
+        let attacker = DeviceKeypair::generate();
+        let attacker_session = attacker.agree(&hub.public_bytes()); // hub never shared with attacker
+        let sealed = seal(&attacker_session, CHALLENGE, AAD).unwrap();
+        assert!(
+            AuthedPrincipal::authenticate(&hub_session, &sealed, AAD, CHALLENGE, "principal:owner")
+                .is_none(),
+            "an unpaired attacker keypair must NOT authenticate"
+        );
+    }
+
+    #[test]
+    fn authenticate_denies_wrong_challenge_or_blank_principal() {
+        let (hub_session, caller_session) = paired_sessions();
+        // A seal of the WRONG bytes (opens, but is not the agreed challenge) is refused.
+        let sealed_wrong = seal(&caller_session, b"not-the-challenge", AAD).unwrap();
+        assert!(AuthedPrincipal::authenticate(
+            &hub_session,
+            &sealed_wrong,
+            AAD,
+            CHALLENGE,
+            "principal:owner"
+        )
+        .is_none());
+        // A blank/anonymous principal is refused (no anonymous owner).
+        let sealed_ok = seal(&caller_session, CHALLENGE, AAD).unwrap();
+        assert!(
+            AuthedPrincipal::authenticate(&hub_session, &sealed_ok, AAD, CHALLENGE, "   ")
+                .is_none()
+        );
+    }
+
+    // --- body-release projection (auditable, runtime-free) --------------------
+
+    fn seed_owned(tag: &str, run_id: &str, owner: &str) -> Db {
+        let db = Db::open_hub(&tmp(tag)).unwrap();
+        persist_run_result(
+            db.conn(),
+            run_id,
+            &RunResult::new("finished", BODY, None).with_owner_principal(owner),
+            10,
+        )
+        .unwrap();
+        db
+    }
+
+    #[test]
+    fn project_delivers_body_to_authed_owner_and_proof_is_body_free() {
+        let db = seed_owned("proj-owner", "run-x", "principal:P");
+        let owner = authed("principal:P");
+        let out = project_answer_for_authed(db.conn(), "run-x", &owner);
+        assert_eq!(
+            out.delivered_body(),
+            Some(BODY),
+            "the owner receives the body"
+        );
+        // CANARY: neither the refs-only proof projection nor the Debug carries the body.
+        let proof = out.proof_refs_json().to_string();
+        assert!(
+            !proof.contains(BODY),
+            "proof surface leaked the body: {proof}"
+        );
+        assert!(
+            !format!("{out:?}").contains(BODY),
+            "Debug leaked the owner-only body"
+        );
+    }
+
+    #[test]
+    fn project_denies_a_wrong_principal_with_no_body() {
+        let db = seed_owned("proj-wrong", "run-x", "principal:P");
+        let other = authed("principal:Q");
+        let out = project_answer_for_authed(db.conn(), "run-x", &other);
+        assert!(out.delivered_body().is_none(), "a non-owner gets NO body");
+        assert!(matches!(
+            out,
+            AuthedAnswer::Denied {
+                reason: AnswerDenyReason::PrincipalMismatch,
+                ..
+            }
+        ));
+        assert!(!out.proof_refs_json().to_string().contains(BODY));
+        assert!(!format!("{out:?}").contains(BODY));
+    }
+
+    #[test]
+    fn project_no_answer_for_an_unknown_run() {
+        let db = Db::open_hub(&tmp("proj-none")).unwrap();
+        let owner = authed("principal:P");
+        let out = project_answer_for_authed(db.conn(), "nope", &owner);
+        assert!(matches!(out, AuthedAnswer::NoAnswer { .. }));
+        assert!(out.delivered_body().is_none());
+    }
+
+    // --- end-to-end through the real HubRuntime agent loop --------------------
+
+    struct TempWs(PathBuf);
+    impl TempWs {
+        fn new(tag: &str) -> Self {
+            let p = std::env::temp_dir().join(format!(
+                "friday-authed-route-ws-{}-{}-{}",
+                std::process::id(),
+                tag,
+                C.fetch_add(1, Ordering::Relaxed)
+            ));
+            std::fs::create_dir_all(&p).unwrap();
+            TempWs(p)
+        }
+    }
+    impl Drop for TempWs {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    /// A transport that finishes the loop in one turn with `answer` as the final message.
+    struct FinishTransport {
+        answer: String,
+    }
+    impl Transport for FinishTransport {
+        fn get_json(&self, _u: &str, _b: &str) -> Result<Value, DeepSeekError> {
+            Ok(serde_json::json!({"data":[{"id":"deepseek-v4-flash"}]}))
+        }
+        fn post_json(&self, _u: &str, _b: &str, _body: &Value) -> Result<Value, DeepSeekError> {
+            let content = format!("{{\"tool\":\"none\",\"answer\":\"{}\"}}", self.answer);
+            Ok(serde_json::json!({
+                "model":"deepseek-v4-flash",
+                "choices":[{"message":{"content":content},"finish_reason":"stop"}],
+                "usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+            }))
+        }
+    }
+
+    /// A transport whose chat POST fails — the provider is unavailable mid-loop.
+    struct ProviderDownTransport;
+    impl Transport for ProviderDownTransport {
+        fn get_json(&self, _u: &str, _b: &str) -> Result<Value, DeepSeekError> {
+            Ok(serde_json::json!({"data":[{"id":"deepseek-v4-flash"}]}))
+        }
+        fn post_json(&self, _u: &str, _b: &str, _body: &Value) -> Result<Value, DeepSeekError> {
+            Err(DeepSeekError::ProviderUnavailable(
+                "network down".to_string(),
+            ))
+        }
+    }
+
+    fn runtime_with<T: Transport>(tag: &str, t: T, principal: &str) -> (HubRuntime<T>, TempWs) {
+        let ws = TempWs::new(tag);
+        let client = DeepSeekClient::with_transport(t, "k".into());
+        let agent = DeepSeekAgentLlmClient::new(client);
+        let rt = HubRuntime::new(
+            HubConfig {
+                db_path: tmp(tag),
+                workspace_root: ws.0.clone(),
+                secret: b"authed-route-test-secret-0123456789".to_vec(),
+                max_turns: 4,
+                principal_id: Some(principal.to_string()),
+                disabled_tools: vec![],
+                read_only: false,
+                operator_vk: None,
+            },
+            agent,
+            Box::new(DenyAllApprovals),
+        )
+        .unwrap();
+        (rt, ws)
+    }
+
+    #[test]
+    fn authed_loop_delivers_body_to_owner_and_proof_canary_is_clean() {
+        let (rt, _ws) = runtime_with(
+            "loop-owner",
+            FinishTransport {
+                answer: BODY.to_string(),
+            },
+            "principal:owner",
+        );
+        // The caller is authenticated as the SAME principal the runtime is configured with.
+        let caller = authed("principal:owner");
+        let out = run_authed_agent_loop(&rt, &caller, "run-authed-1", "answer me", 1000);
+        assert_eq!(
+            out.delivered_body(),
+            Some(BODY),
+            "the authenticated owner receives the answer body"
+        );
+        // CANARY: the body appears in NEITHER the refs-only proof NOR the Debug; and no secret.
+        let proof = out.proof_refs_json().to_string();
+        assert!(
+            !proof.contains(BODY),
+            "proof surface leaked the body: {proof}"
+        );
+        assert!(!proof.contains("authed-route-test-secret"));
+        assert!(!format!("{out:?}").contains(BODY));
+    }
+
+    #[test]
+    fn authed_loop_wrong_principal_caller_gets_no_body() {
+        // The run is OWNED by `principal:owner` (the runtime's principal); a caller
+        // authenticated as a DIFFERENT principal is denied the body.
+        let (rt, _ws) = runtime_with(
+            "loop-wrong",
+            FinishTransport {
+                answer: BODY.to_string(),
+            },
+            "principal:owner",
+        );
+        let _seed =
+            run_authed_agent_loop(&rt, &authed("principal:owner"), "run-authed-2", "go", 1000);
+        // Now a different authenticated principal projects the SAME run → Denied, no body.
+        let intruder = authed("principal:intruder");
+        let out = project_answer_for_authed(rt.db().conn(), "run-authed-2", &intruder);
+        assert!(
+            out.delivered_body().is_none(),
+            "a non-owner must get NO body"
+        );
+        assert!(matches!(
+            out,
+            AuthedAnswer::Denied {
+                reason: AnswerDenyReason::PrincipalMismatch,
+                ..
+            }
+        ));
+        assert!(!out.proof_refs_json().to_string().contains(BODY));
+    }
+
+    #[test]
+    fn authed_loop_provider_unavailable_is_safe_failure_no_body_no_panic() {
+        let (rt, _ws) = runtime_with("loop-down", ProviderDownTransport, "principal:owner");
+        let caller = authed("principal:owner");
+        let out = run_authed_agent_loop(&rt, &caller, "run-authed-down", "answer me", 1000);
+        assert!(
+            matches!(out, AuthedAnswer::NoAnswer { .. }),
+            "provider-unavailable must be a body-free safe failure, got {out:?}"
+        );
+        assert!(out.delivered_body().is_none());
+        // No run_result persisted for the errored (non-Finished) run.
+        assert_eq!(
+            rt.db()
+                .conn()
+                .query_row(
+                    "SELECT count(*) FROM run_result WHERE run_id = 'run-authed-down'",
+                    [],
+                    |r| r.get::<_, i64>(0)
+                )
+                .unwrap(),
+            0
+        );
     }
 }

--- a/rust-core/crates/friday-hub/src/runtime.rs
+++ b/rust-core/crates/friday-hub/src/runtime.rs
@@ -30,7 +30,7 @@ use friday_core::gate::{CanonicalApproval, MutatingActionRequest};
 use friday_core::WorkLane;
 use friday_crypto::OperatorVerifyingKey;
 use friday_deepseek::{DeepSeekClient, DeepSeekError, Transport, UreqTransport};
-use friday_storage::{agent_run, Db, StorageError};
+use friday_storage::{agent_run, persist_run_result, Db, RunResult, StorageError};
 
 use crate::mission_context::MissionContextLookup;
 use crate::mission_preflight::MissionAttachmentOutcome;
@@ -239,7 +239,7 @@ impl<T: Transport> HubRuntime<T> {
         // enforced before any tool executes. S6d: thread the provisioned operator verify
         // key so a protected action authorizes via the Ed25519 verify-only policy (never
         // HMAC); `None` ⇒ fail-closed Pause.
-        run_routed_loop_with_policy(
+        let (selection, outcome) = run_routed_loop_with_policy(
             &self.routes,
             &request,
             self,
@@ -253,7 +253,33 @@ impl<T: Transport> HubRuntime<T> {
             &self.policy,
             self.max_turns,
             now_ms,
-        )
+        )?;
+
+        // D1 OWNER-WIRING: a FINISHED run produced a deliverable ANSWER; persist it Hub-side
+        // keyed by `run_id` with the run's BOUND OWNER principal recorded
+        // (`self.policy.principal_id()` — the SAME principal S4 binds into the gate Actor), so
+        // the authenticated body projection [`friday_storage::get_run_answer_for_principal`]
+        // releases the answer body ONLY to that owner. A run with NO bound principal records
+        // NO owner ⇒ the body stays unreadable to everyone (fail-closed, correct).
+        //
+        // We persist ONLY on `Finished`: a `Paused` run's `run_result` slot belongs to the
+        // resume completion leg ([`crate::resume`]), and persisting an empty answer here would
+        // collide with that later immutable `mutation_completed` result; `Errored`/`Bounded`/
+        // `Blocked` carry no deliverable answer. A fresh `run_id` cannot already hold a
+        // result, so a persist conflict here would signal a real bug and is propagated.
+        if outcome.status == LoopStatus::Finished {
+            let mut result = RunResult::new(
+                "finished",
+                outcome.final_message.clone().unwrap_or_default(),
+                None,
+            );
+            if let Some(principal) = self.policy.principal_id() {
+                result = result.with_owner_principal(principal);
+            }
+            persist_run_result(self.db.conn(), run_id, &result, now_ms)?;
+        }
+
+        Ok((selection, outcome))
     }
 
     /// S1.3 — the Mission-BOUND agent-loop entry (the `executeRun` Mission-context parity,
@@ -1319,6 +1345,144 @@ mod tests {
             table_count(&rt, "mission_link"),
             0,
             "the unbound run_task must not bind to any mission"
+        );
+    }
+
+    // ---- D1 owner-wiring (run_task persists owner_principal) -----------------
+
+    /// D1 OWNER-WIRING: a FINISHED run owned by principal P persists its answer with
+    /// `owner_principal == P`, so the authenticated body projection Grants the body to P and
+    /// Denies a different principal Q — the owner axis is wired end-to-end through `run_task`.
+    #[test]
+    fn owner_wiring_finished_run_records_owner_and_gates_authed_body() {
+        use friday_storage::{get_run_answer_for_principal, AnswerDenyReason, RunAnswerAccess};
+
+        const ANSWER: &str = "OWNER-ANSWER-CANARY-d1q4-only-P-may-read";
+
+        let ws = TempDir::new("owner-wire");
+        let script = format!("{{\"tool\":\"none\",\"answer\":\"{ANSWER}\"}}");
+        let transport = ScriptTransport::new(&[script.as_str()]);
+        let client = DeepSeekClient::with_transport(transport, "k".into());
+        let agent = DeepSeekAgentLlmClient::new(client);
+        let rt = HubRuntime::new(
+            HubConfig {
+                db_path: tmp("owner-wire"),
+                workspace_root: ws.0.clone(),
+                secret: SECRET.to_vec(),
+                max_turns: 4,
+                principal_id: Some("alice".to_string()), // the run's bound OWNER principal
+                disabled_tools: vec![],
+                read_only: false,
+                operator_vk: None,
+            },
+            agent,
+            Box::new(DenyAllApprovals),
+        )
+        .unwrap();
+
+        let (_sel, out) = rt.run_task("run-owned", "answer me", 1000).unwrap();
+        assert_eq!(out.status, LoopStatus::Finished);
+        assert_eq!(out.final_message.as_deref(), Some(ANSWER));
+
+        // run_result recorded owner_principal == P.
+        let owner: Option<String> = rt
+            .db()
+            .conn()
+            .query_row(
+                "SELECT owner_principal FROM run_result WHERE run_id = 'run-owned'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(owner.as_deref(), Some("alice"));
+
+        // P (owner) is GRANTED the body; Q (≠P) is DENIED with no body.
+        match get_run_answer_for_principal(rt.db().conn(), "run-owned", "alice").unwrap() {
+            RunAnswerAccess::Granted(stored) => assert_eq!(stored.answer, ANSWER),
+            other => panic!("owner P must be Granted the body, got {other:?}"),
+        }
+        let denied = get_run_answer_for_principal(rt.db().conn(), "run-owned", "bob").unwrap();
+        assert_eq!(
+            denied,
+            RunAnswerAccess::Denied(AnswerDenyReason::PrincipalMismatch)
+        );
+        // Canary: the denied (non-owner) projection carries NEITHER the body NOR the owner.
+        let rendered = format!("{denied:?}");
+        assert!(!rendered.contains(ANSWER) && !rendered.contains("alice"));
+    }
+
+    /// A FINISHED run with NO bound principal records NO owner ⇒ the body is unreadable to
+    /// everyone (fail-closed), even though the body genuinely IS stored Hub-side.
+    #[test]
+    fn owner_wiring_unowned_run_records_no_owner_body_unreadable() {
+        use friday_storage::{get_run_answer_for_principal, AnswerDenyReason, RunAnswerAccess};
+
+        let (rt, _ws, _post) = runtime_with(
+            "owner-wire-none",
+            &["{\"tool\":\"none\",\"answer\":\"unowned-answer\"}"],
+            Box::new(DenyAllApprovals),
+        );
+        let (_sel, out) = rt.run_task("run-unowned", "answer me", 1000).unwrap();
+        assert_eq!(out.status, LoopStatus::Finished);
+
+        let owner: Option<String> = rt
+            .db()
+            .conn()
+            .query_row(
+                "SELECT owner_principal FROM run_result WHERE run_id = 'run-unowned'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(owner, None, "an unowned run must record no owner principal");
+
+        // No owner ⇒ body released to NO ONE, even a valid-looking principal.
+        assert_eq!(
+            get_run_answer_for_principal(rt.db().conn(), "run-unowned", "alice").unwrap(),
+            RunAnswerAccess::Denied(AnswerDenyReason::NoOwnerPrincipal)
+        );
+        // ...but the body IS stored Hub-side (the deny is authorization, not missing data).
+        assert_eq!(
+            friday_storage::get_run_result(rt.db().conn(), "run-unowned")
+                .unwrap()
+                .unwrap()
+                .answer,
+            "unowned-answer"
+        );
+    }
+
+    /// A non-Finished run (here a Paused mutating action) persists NO `run_result` from
+    /// `run_task` — leaving the slot free for the resume completion leg (no immutable-result
+    /// collision) and meaning the authed projection safely finds NO answer.
+    #[test]
+    fn owner_wiring_paused_run_persists_no_result() {
+        use friday_storage::{get_run_answer_for_principal, RunAnswerAccess};
+
+        let (rt, _root, _post) = runtime_with(
+            "owner-wire-paused",
+            &["{\"tool\":\"write_file\",\"parameters\":{\"path\":\"out.txt\",\"content\":\"X\"}}"],
+            Box::new(DenyAllApprovals),
+        );
+        let (_sel, out) = rt.run_task("run-paused", "write a file", 2000).unwrap();
+        assert!(matches!(
+            out.status,
+            LoopStatus::Paused | LoopStatus::Blocked
+        ));
+        // No run_result row was written by run_task (the resume leg owns a Paused run's slot).
+        assert_eq!(
+            rt.db()
+                .conn()
+                .query_row(
+                    "SELECT count(*) FROM run_result WHERE run_id = 'run-paused'",
+                    [],
+                    |r| r.get::<_, i64>(0)
+                )
+                .unwrap(),
+            0
+        );
+        assert_eq!(
+            get_run_answer_for_principal(rt.db().conn(), "run-paused", "alice").unwrap(),
+            RunAnswerAccess::NotFound
         );
     }
 


### PR DESCRIPTION
## Truth label
INTERNAL, **authenticated**, **SINGLE-provider** (`deepseek-flash`) route. The answer **body is delivered ONLY to the authenticated owner**; every proof/unauth surface gets **refs-only** (status + sha256 + length). NOT multi-provider, NOT provider-native, NOT a v1 GO; `executeRun` is **NOT** replaced. PROOF-ONLY. Coordinator runs the live proof; no live credentials used here.

## 1. Owner-wiring (`runtime.rs`)
`HubRuntime::run_task` now persists the run's answer **on `Finished`**, keyed by `run_id`, recording `owner_principal = self.policy.principal_id()` — the SAME principal S4 binds into the gate `Actor`. So `friday_storage::get_run_answer_for_principal(run_id, P)` returns the body iff caller `== P`. A run with **no** principal records **no** owner ⇒ body unreadable to everyone (fail-closed).

Persist is gated on `Finished` so a **Paused** run's `run_result` slot stays free for the resume completion leg (`resume.rs`), avoiding an immutable-result collision (`s6d_resume_ingestion` is the tripwire — green). `Errored`/`Bounded`/`Blocked` carry no deliverable answer.

## 2. D1-Q4 internal authed route (`hub_server.rs` + new bin `hub_authed_run`)
**Auth mechanism reused:** the existing sealed-session mechanism — `friday_crypto::DeviceKeypair` ECDH → per-session `DataKey`, the same auth `HubServer::serve_connection` is fenced by.

- `AuthedPrincipal::authenticate(hub_session, sealed_proof, aad, challenge, owner_principal)` opens the caller-sealed challenge with the Hub's half of the session. A caller without the paired key produces a seal the Hub **cannot open** → `None` → no run, no body. The bound principal is **Hub-supplied** (never client-supplied), so a caller cannot self-assert another principal.
- `run_authed_agent_loop(runtime, caller, run_id, task, now_ms)` runs `run_task` as the authenticated principal, then **delivers the answer ONLY to the authed owner** via `project_answer_for_authed` → `get_run_answer_for_principal`. The body is carried ONLY in `AuthedAnswer::Delivered`; the `RunAnswerAccess::Granted` is destructured immediately and never `{:?}`-logged.
- **Refs-only for proof/unauth:** `AuthedAnswer::proof_refs_json` and the bin's stdout emit only `outcome`/`status`/`answer_sha256`/`answer_len` — never the body, never a raw provider/secret/channel id. `AuthedAnswer`'s `Debug` is **body-redacting**.
- The bin seals the delivered body back over the **owner-only session channel** (records ciphertext length only); single-provider truth-labeled (`provider_family=deepseek`, `model_class=flash`, `multi_provider=false`, `v1_go=false`). CI only builds the bin (live key = separate coordinator step).

## Adversarial tests
- owner-authenticated caller → **gets the body** (`owner_wiring_finished_run_...`, `authed_loop_delivers_body_to_owner_...`)
- unpaired attacker keypair → `authenticate()` returns **None** (the real boundary)
- wrong-principal caller → **Denied, no body** (`project_denies_a_wrong_principal_...`, `authed_loop_wrong_principal_...`)
- provider-unavailable (chat POST fails → loop Errored → no persist) → **safe `NoAnswer`, no panic, no body**
- **canary:** a known body string appears in neither the proof JSON nor the `Debug`, on every variant
- owner-wiring: run with principal P → `run_result.owner_principal == P` → Granted; Q≠P → Denied; unowned → NoOwnerPrincipal deny

## What I did NOT do
- Did **NOT** edit `lib.rs` run-loop or add a `friday-storage` schema migration (Lane B owns those). `git diff --name-only` = only `runtime.rs`, `hub_server.rs`, and the new bin.
- Did **NOT** add a wire `Message` variant (that needs `friday-protocol`, outside write-set) — the production wire route is deferred; this is the bin + library boundary.
- No multi-provider / provider-native / v1-GO claim. No live credentials. `executeRun` not replaced. No body on any refs-only/proof surface.

## Local green gate
`cargo fmt` clean · `cargo build -p friday-hub --bins` ok · `cargo clippy --workspace --all-targets -- -D warnings` clean · `cargo test -p friday-hub` 295+9 passed, 0 failed (incl. `s6d_resume_ingestion` tripwire). No TS touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Auth boundary honesty (for review)

- **The enforceable boundary is the library function + its unit tests, not the bin.** `hub_authed_run` owns both keypairs, so it can only demonstrate the happy path — it *structurally cannot* exhibit the unauth / wrong-principal denial. The denial property lives in `authenticate_denies_an_unpaired_attacker_keypair` (authenticate() → None) and `project_denies_a_wrong_principal_with_no_body` (Denied, no body). The live bin proof shows "authed owner gets its answer"; the "unauth/wrong-principal cannot" half is the unit tests.
- **No-key smoke run verified the bin's auth path is reachable:** `hub_authed_run --task ping --workspace … --principal principal:owner` (no DeepSeek key) exits 2 with `init_failed` (NOT `auth_denied`) — i.e. seal → authenticate succeeds with matching aad/challenge and reaches `HubRuntime::live`, which then fails closed on the missing credential. Clean JSON, no panic.
- **Fixed challenge, no per-session freshness — replay-safe by design.** The auth challenge is a fixed public constant; the actual secret is possession of the session `DataKey`. Replaying a captured proof grants nothing to someone who cannot seal new envelopes or open the owner-sealed body.
