### PR TITLE
feat(rust-fs): read-only `search` fs tool (safe-fs READ parity)

### DIFF
--- a/rust-core/crates/friday-fs/src/lib.rs
+++ b/rust-core/crates/friday-fs/src/lib.rs
@@ -675,6 +675,227 @@ pub fn edit_file_within_root(
     write_file_within_root(root, candidate, updated.as_bytes())
 }
 
+/// A single line that matched a [`search_within_root`] query.
+///
+/// `relative_path` is the path of the matching file **relative to the root**, with `/`
+/// separators (never absolute, never containing `..` — it is built only from `readdir`
+/// entry names under the contained root). `line_number` is 1-based. `line_text` is the
+/// matching line with its terminator stripped, **truncated to at most
+/// [`SEARCH_MAX_LINE_BYTES`] bytes on a UTF-8 char boundary** (so a single pathological
+/// long line can never blow the output bound).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SearchHit {
+    /// Path of the matching file, relative to the root (`/`-separated, no `..`/absolute).
+    pub relative_path: String,
+    /// 1-based line number of the match within the file.
+    pub line_number: u64,
+    /// The matching line (terminator stripped), truncated to [`SEARCH_MAX_LINE_BYTES`].
+    pub line_text: String,
+}
+
+/// Hard cap on the total number of [`SearchHit`]s a single search returns. The walk stops
+/// the instant this is reached, so output (and the `Vec` backing it) is bounded regardless
+/// of how many lines match across the tree.
+pub const SEARCH_MAX_HITS: usize = 200;
+/// Hard cap on the byte length of each [`SearchHit::line_text`] (truncated on a char
+/// boundary). Defends against a single multi-megabyte line.
+pub const SEARCH_MAX_LINE_BYTES: usize = 512;
+/// Hard cap on the number of files OPENED+scanned in a single search. Once reached the walk
+/// stops, so a tree with millions of files cannot make the search unbounded.
+pub const SEARCH_MAX_FILES: usize = 2_000;
+/// Hard cap on the number of directories DESCENDED into in a single search. Bounds traversal
+/// over a pathologically wide/deep tree.
+pub const SEARCH_MAX_DIRS: usize = 4_096;
+/// Hard cap on the bytes read from any ONE file (via `Read::take`, so it holds even if the
+/// file grows after we stat it — no TOCTOU on the size). Bounds per-file memory; bytes past
+/// this point are not scanned.
+pub const SEARCH_MAX_FILE_BYTES: u64 = 1_048_576; // 1 MiB
+
+/// READ-ONLY literal-substring search over the UTF-8 text files contained in `root`,
+/// recursive from the root (or, when `subpath` is `Some`, from that contained sub-directory
+/// or single file).
+///
+/// # Containment (no new attack surface)
+/// Every on-disk access goes through the EXISTING hardened primitives — there is no fresh
+/// `open`/`readdir` path here:
+/// - directory listing via [`list_dir_within_root`] (lexical gate + `O_NOFOLLOW` +
+///   realpath-ancestor; never lists *through* a symlink),
+/// - per-entry classification via [`stat_file_within_root`] (no-follow `lstat`; a
+///   final-component **symlink** is `Err(`[`FsError::Symlink`]`)`),
+/// - file reads via [`open_read_within_root`] (`O_NOFOLLOW` + fd-identity TOCTOU check).
+///
+/// Candidate paths are built ONLY from `readdir` entry names joined under the contained
+/// root, so each access is independently re-validated by `resolve_within_root`. We **stat
+/// every entry before touching it** and SKIP anything that is not a real regular file or
+/// real directory: a symlink (`Err(Symlink)`) is skipped — **we never follow it**, so a
+/// symlink pointing outside the root is never read and never descended into; FIFOs/sockets/
+/// devices ([`FileKind::Other`]) are skipped; and a non-UTF-8 entry name (which cannot form
+/// a `&str` candidate) is skipped. We therefore only ever call `list_dir` on REAL
+/// directories. The `subpath` argument itself is validated through the same pipeline, so an
+/// absolute / `..` / out-of-root / symlink `subpath` is REJECTED (`Err`).
+///
+/// # Bounds (never unbounded memory or output)
+/// Output is hard-capped: at most [`SEARCH_MAX_HITS`] hits, each line truncated to
+/// [`SEARCH_MAX_LINE_BYTES`] bytes; at most [`SEARCH_MAX_FILES`] files are scanned and
+/// [`SEARCH_MAX_DIRS`] directories descended; and at most [`SEARCH_MAX_FILE_BYTES`] bytes
+/// are read from any one file (via `Read::take`). The walk stops the moment the hit or file
+/// cap is hit.
+///
+/// # Text handling
+/// Binary / non-UTF-8 files are skipped gracefully: a file containing a NUL byte is treated
+/// as binary, and otherwise only the valid UTF-8 prefix is scanned (a multibyte char split
+/// by the size cap is tolerated). An empty `query` matches nothing and returns `Ok(vec![])`
+/// (an empty needle would otherwise match every line). Matching is a plain literal
+/// substring (`str::contains`), case-sensitive.
+///
+/// Results are sorted by `(relative_path, line_number)` for a deterministic order.
+pub fn search_within_root(
+    root: &Path,
+    query: &str,
+    subpath: Option<&str>,
+) -> Result<Vec<SearchHit>, FsError> {
+    use std::os::unix::ffi::OsStrExt;
+
+    let mut hits: Vec<SearchHit> = Vec::new();
+    // An empty needle would match every line — nothing meaningful to search for, and a
+    // guaranteed cap blow. Treat it as "no matches" (bounded, safe).
+    if query.is_empty() {
+        return Ok(hits);
+    }
+
+    let mut files_scanned: usize = 0;
+    let mut dirs_visited: usize = 0;
+
+    // Resolve the starting point. The root-denoting tokens start a full-tree walk; any other
+    // `subpath` is validated through `stat_file_within_root` (so absolute/`..`/out-of-root/
+    // symlink subpaths are rejected here) and may name either a directory (walk it) or a
+    // single regular file (scan just it).
+    let mut worklist: Vec<String> = Vec::new();
+    match subpath {
+        None => worklist.push(String::new()),
+        Some(s) if s.is_empty() || s == "." || s == "./" => worklist.push(String::new()),
+        Some(s) => match stat_file_within_root(root, s)?.kind {
+            FileKind::Dir => worklist.push(s.to_string()),
+            FileKind::File => {
+                files_scanned += 1;
+                scan_file_into(root, s, query, &mut hits);
+            }
+            FileKind::Other => {}
+        },
+    }
+
+    'walk: while let Some(dir) = worklist.pop() {
+        if dirs_visited >= SEARCH_MAX_DIRS {
+            break;
+        }
+        dirs_visited += 1;
+        // A directory that races out from under us (removed / perms) is skipped, not fatal —
+        // best-effort search. `dir == ""` lists the root itself (the contained root case).
+        let entries = match list_dir_within_root(root, &dir) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        for name_os in entries {
+            // A non-UTF-8 entry name cannot form a `&str` candidate for the lexical gate;
+            // skip it (the file is simply not searchable by this text tool).
+            let name = match std::str::from_utf8(name_os.as_bytes()) {
+                Ok(n) => n,
+                Err(_) => continue,
+            };
+            let child = if dir.is_empty() {
+                name.to_string()
+            } else {
+                format!("{dir}/{name}")
+            };
+            // Stat (no-follow) classifies the entry. A SYMLINK is `Err(Symlink)` → skipped:
+            // we never follow it, so an outside-pointing link is never read or descended.
+            match stat_file_within_root(root, &child) {
+                Ok(st) => match st.kind {
+                    FileKind::Dir => worklist.push(child),
+                    FileKind::File => {
+                        if files_scanned >= SEARCH_MAX_FILES {
+                            break 'walk;
+                        }
+                        files_scanned += 1;
+                        scan_file_into(root, &child, query, &mut hits);
+                        if hits.len() >= SEARCH_MAX_HITS {
+                            break 'walk;
+                        }
+                    }
+                    FileKind::Other => {}
+                },
+                Err(_) => continue,
+            }
+        }
+    }
+
+    hits.sort_by(|a, b| {
+        (a.relative_path.as_str(), a.line_number).cmp(&(b.relative_path.as_str(), b.line_number))
+    });
+    hits.truncate(SEARCH_MAX_HITS);
+    Ok(hits)
+}
+
+/// Scan ONE contained regular file (named by `rel`, relative to `root`) for literal
+/// `query`, appending up to the global [`SEARCH_MAX_HITS`] cap into `hits`. The read goes
+/// through [`open_read_within_root`] (full hardening) and is byte-capped via `Read::take`,
+/// so this opens no new path and bounds per-file memory. Any read/containment error (e.g. a
+/// TOCTOU swap detected by the hardened open) skips the file silently — best-effort, never
+/// fatal to the overall search.
+fn scan_file_into(root: &Path, rel: &str, query: &str, hits: &mut Vec<SearchHit>) {
+    use std::io::Read;
+    let file = match open_read_within_root(root, rel) {
+        Ok(f) => f,
+        Err(_) => return,
+    };
+    let mut bytes: Vec<u8> = Vec::new();
+    // HARD per-file byte cap via take — holds even if the file grew after we stat'd it.
+    if file
+        .take(SEARCH_MAX_FILE_BYTES)
+        .read_to_end(&mut bytes)
+        .is_err()
+    {
+        return;
+    }
+    // Binary heuristic: a NUL byte ⇒ treat as binary and skip (same screen git uses).
+    if bytes.contains(&0) {
+        return;
+    }
+    // Decode UTF-8; if the size cap split a trailing multibyte char, scan the valid prefix.
+    let text = match std::str::from_utf8(&bytes) {
+        Ok(s) => s,
+        Err(e) => match std::str::from_utf8(&bytes[..e.valid_up_to()]) {
+            Ok(s) => s,
+            Err(_) => return,
+        },
+    };
+    for (idx, line) in text.lines().enumerate() {
+        if hits.len() >= SEARCH_MAX_HITS {
+            return;
+        }
+        if line.contains(query) {
+            hits.push(SearchHit {
+                relative_path: rel.to_string(),
+                line_number: (idx as u64) + 1,
+                line_text: truncate_to_char_boundary(line, SEARCH_MAX_LINE_BYTES),
+            });
+        }
+    }
+}
+
+/// Truncate `s` to at most `max` bytes, backing up to the nearest UTF-8 char boundary so the
+/// result is always valid UTF-8 (never splits a multibyte char).
+fn truncate_to_char_boundary(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        return s.to_string();
+    }
+    let mut end = max;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    s[..end].to_string()
+}
+
 /// A candidate that has passed the lexical gate + canonicalized-root +
 /// realpath-ancestor containment checks. `full` is the absolute path to open
 /// (built from the *real* root so it is safe to hand to `open`).

--- a/rust-core/crates/friday-fs/src/lib.rs
+++ b/rust-core/crates/friday-fs/src/lib.rs
@@ -734,12 +734,36 @@ pub const SEARCH_MAX_FILE_BYTES: u64 = 1_048_576; // 1 MiB
 /// directories. The `subpath` argument itself is validated through the same pipeline, so an
 /// absolute / `..` / out-of-root / symlink `subpath` is REJECTED (`Err`).
 ///
-/// # Bounds (never unbounded memory or output)
-/// Output is hard-capped: at most [`SEARCH_MAX_HITS`] hits, each line truncated to
-/// [`SEARCH_MAX_LINE_BYTES`] bytes; at most [`SEARCH_MAX_FILES`] files are scanned and
-/// [`SEARCH_MAX_DIRS`] directories descended; and at most [`SEARCH_MAX_FILE_BYTES`] bytes
-/// are read from any one file (via `Read::take`). The walk stops the moment the hit or file
-/// cap is hit.
+/// # Bounds (truth-labeled: what is and is NOT bounded)
+/// Every accumulator and every read is hard-capped by a constant:
+/// - **Output** — at most [`SEARCH_MAX_HITS`] hits in the returned `Vec`, each
+///   [`SearchHit::line_text`] truncated to [`SEARCH_MAX_LINE_BYTES`] bytes on a char boundary.
+/// - **Files opened** — at most [`SEARCH_MAX_FILES`] files are opened+scanned.
+/// - **Per-file bytes** — at most [`SEARCH_MAX_FILE_BYTES`] bytes are read from any ONE file,
+///   enforced by `Read::take` on the open fd (so the bound holds even if the file grows after
+///   we stat it — no size TOCTOU); bytes past the cap are never read into memory.
+/// - **Directories listed** — at most [`SEARCH_MAX_DIRS`] directories are popped+listed.
+/// - **Pending worklist** — the iterative descent's `worklist` of pending directories is
+///   capped: a directory is enqueued only while `dirs_enqueued < SEARCH_MAX_DIRS`, so
+///   `worklist.len()` is O([`SEARCH_MAX_DIRS`]) at ALL times and its peak memory is a constant
+///   × the max enqueued path length — it can NEVER accumulate the full cross-directory fanout
+///   of the on-disk tree. This is **bounded descent**: search still visits up to
+///   [`SEARCH_MAX_DIRS`] directories; directories beyond the budget are simply not enqueued.
+///
+/// The walk stops the moment the hit or file cap is hit.
+///
+/// **The ONE remaining (inherited) residual — a single directory's listing.** Each directory
+/// is listed via the shared [`list_dir_within_root`] primitive, which materializes that one
+/// directory's entry names into a `Vec` in full before this walk processes them (it is the
+/// IDENTICAL allocation the `list_dir` tool itself makes — search adds no new listing path).
+/// So peak memory for processing a single directory scales with THAT directory's entry count;
+/// a single adversarial mega-directory (millions of entries) would make that one `Vec` large
+/// even though everything else here is constant-bounded. This is a pre-existing property of
+/// the shared listing primitive, NOT introduced by search, and is deliberately left to
+/// `list_dir_within_root` rather than worked around here (changing the shared primitive is
+/// riskier than documenting the inherited residual). Mitigation is operational, exactly as for
+/// the hardlink residual above: host workspace roots should not contain adversarial
+/// mega-directories.
 ///
 /// # Text handling
 /// Binary / non-UTF-8 files are skipped gracefully: a file containing a NUL byte is treated
@@ -765,17 +789,38 @@ pub fn search_within_root(
 
     let mut files_scanned: usize = 0;
     let mut dirs_visited: usize = 0;
+    // Total directories EVER enqueued onto `worklist`. Every push is guarded by
+    // `dirs_enqueued < SEARCH_MAX_DIRS`, so `worklist.len() <= dirs_enqueued <= SEARCH_MAX_DIRS`
+    // holds at ALL times — the pending worklist can never accumulate the full cross-directory
+    // fanout of the on-disk tree. Peak worklist memory is therefore bounded by a constant
+    // (SEARCH_MAX_DIRS) × the max enqueued path length, not by the size of the tree. (Before
+    // this cap the worklist was pushed to for every subdirectory child with no budget, so its
+    // peak scaled with the tree.) This is BOUNDED DESCENT: search still visits up to
+    // SEARCH_MAX_DIRS directories; deeper/wider directories beyond the budget are simply not
+    // enqueued. A `push_dir` closure centralizes the guarded push so the invariant cannot drift.
+    let mut dirs_enqueued: usize = 0;
 
     // Resolve the starting point. The root-denoting tokens start a full-tree walk; any other
     // `subpath` is validated through `stat_file_within_root` (so absolute/`..`/out-of-root/
     // symlink subpaths are rejected here) and may name either a directory (walk it) or a
     // single regular file (scan just it).
     let mut worklist: Vec<String> = Vec::new();
+    // Guarded push: enqueue `d` only if the total-ever-enqueued budget is not exhausted, so
+    // `worklist.len()` is O(SEARCH_MAX_DIRS) for the whole walk. Returns whether it enqueued
+    // (callers ignore it — a dropped directory is just not descended into).
+    let push_dir = |worklist: &mut Vec<String>, dirs_enqueued: &mut usize, d: String| {
+        if *dirs_enqueued < SEARCH_MAX_DIRS {
+            worklist.push(d);
+            *dirs_enqueued += 1;
+        }
+    };
     match subpath {
-        None => worklist.push(String::new()),
-        Some(s) if s.is_empty() || s == "." || s == "./" => worklist.push(String::new()),
+        None => push_dir(&mut worklist, &mut dirs_enqueued, String::new()),
+        Some(s) if s.is_empty() || s == "." || s == "./" => {
+            push_dir(&mut worklist, &mut dirs_enqueued, String::new())
+        }
         Some(s) => match stat_file_within_root(root, s)?.kind {
-            FileKind::Dir => worklist.push(s.to_string()),
+            FileKind::Dir => push_dir(&mut worklist, &mut dirs_enqueued, s.to_string()),
             FileKind::File => {
                 files_scanned += 1;
                 scan_file_into(root, s, query, &mut hits);
@@ -785,6 +830,9 @@ pub fn search_within_root(
     }
 
     'walk: while let Some(dir) = worklist.pop() {
+        // Now subsumed by the enqueue cap (`push_dir` enforces dirs_enqueued < SEARCH_MAX_DIRS,
+        // and we can never pop more than we pushed) — kept as a defensive floor so the visit
+        // count is bounded even if the enqueue invariant were ever weakened.
         if dirs_visited >= SEARCH_MAX_DIRS {
             break;
         }
@@ -811,7 +859,11 @@ pub fn search_within_root(
             // we never follow it, so an outside-pointing link is never read or descended.
             match stat_file_within_root(root, &child) {
                 Ok(st) => match st.kind {
-                    FileKind::Dir => worklist.push(child),
+                    // Guarded push: a child directory is enqueued only while the
+                    // total-ever-enqueued budget (SEARCH_MAX_DIRS) is not exhausted, so the
+                    // pending worklist stays O(SEARCH_MAX_DIRS). Beyond the budget the child
+                    // is simply not descended into (bounded descent).
+                    FileKind::Dir => push_dir(&mut worklist, &mut dirs_enqueued, child),
                     FileKind::File => {
                         if files_scanned >= SEARCH_MAX_FILES {
                             break 'walk;

--- a/rust-core/crates/friday-fs/tests/search_fs.rs
+++ b/rust-core/crates/friday-fs/tests/search_fs.rs
@@ -22,7 +22,10 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use friday_core::PathError;
-use friday_fs::{search_within_root, FsError, SearchHit, SEARCH_MAX_HITS, SEARCH_MAX_LINE_BYTES};
+use friday_fs::{
+    search_within_root, FsError, SearchHit, SEARCH_MAX_DIRS, SEARCH_MAX_FILES,
+    SEARCH_MAX_FILE_BYTES, SEARCH_MAX_HITS, SEARCH_MAX_LINE_BYTES,
+};
 
 /// A real, unique temp directory that is recursively removed on drop (std-only).
 struct TempDir {
@@ -284,5 +287,150 @@ fn search_skips_binary_and_non_utf8_files_gracefully() {
     assert!(
         !hits.iter().any(|h| h.relative_path == "bin.dat"),
         "a NUL-bearing binary file must be skipped, got {hits:?}"
+    );
+}
+
+// ════════════════════════════ cap enforcement (per-file, files, dirs) ════════════════════════════
+
+#[test]
+fn search_file_byte_cap_truncates_the_read_so_a_match_beyond_the_cap_is_not_returned() {
+    // SEARCH_MAX_FILE_BYTES: `scan_file_into` reads at most this many bytes via `Read::take`,
+    // so a match positioned BEYOND the cap is NEVER read and never returned, while a match
+    // within the cap IS. This proves `Read::take` truly bounds the read (not just the output).
+    let root = TempDir::new();
+
+    let cap = SEARCH_MAX_FILE_BYTES as usize;
+    // Line 1 holds an EARLY marker (well within the cap → must be returned).
+    let mut body: Vec<u8> = Vec::with_capacity(cap + 64);
+    body.extend_from_slice(b"EARLYMARK on line one\n");
+    // NUL-free ASCII padding ('a' lines) so the binary heuristic does NOT skip the file, and so
+    // the file's length comfortably exceeds the per-file cap. We pad until the byte offset is
+    // strictly past `cap`, THEN append the LATE marker — so every byte of LATEMARK lands beyond
+    // SEARCH_MAX_FILE_BYTES and is truncated away by `take`.
+    while body.len() <= cap {
+        // 64 'a' + newline; cheap, NUL-free, guaranteed to step past the cap.
+        body.extend_from_slice(&[b'a'; 64]);
+        body.push(b'\n');
+    }
+    assert!(
+        body.len() > cap,
+        "padding must push the file past the per-file byte cap"
+    );
+    body.extend_from_slice(b"LATEMARK beyond the cap\n");
+    write_file(&root.path().join("big.txt"), &body);
+
+    let early = search_within_root(root.path(), "EARLYMARK", None).expect("search ok");
+    assert_eq!(
+        locs(&early),
+        vec![("big.txt".to_string(), 1)],
+        "a match within the per-file byte cap must be returned"
+    );
+
+    let late = search_within_root(root.path(), "LATEMARK", None).expect("search ok");
+    assert!(
+        late.is_empty(),
+        "a match positioned BEYOND SEARCH_MAX_FILE_BYTES must NOT be returned (Read::take \
+         bounds the read), got {late:?}"
+    );
+}
+
+#[test]
+fn search_caps_files_opened_so_a_late_sorted_match_beyond_the_file_cap_is_not_scanned() {
+    // SEARCH_MAX_FILES: at most this many files are opened+scanned. We place a CONTROL match in
+    // the first file (sort order) and a SENTINEL match in a file that sorts AFTER the cap, with
+    // SEARCH_MAX_FILES non-matching filler files in between. The walk scans files in
+    // `list_dir_within_root` SORTED order and breaks at the file cap, so the control is scanned
+    // and the sentinel never is. (Filler files are non-matching, so the much smaller hit cap —
+    // SEARCH_MAX_HITS ≪ SEARCH_MAX_FILES — is NOT what stops the walk: only the file cap is.)
+    let root = TempDir::new();
+
+    // Control: sorts first, matches.
+    write_file(&root.path().join("f0000000.txt"), b"CTRLMARK control\n");
+    // Exactly SEARCH_MAX_FILES non-matching filler files, named so they sort between the control
+    // and the sentinel (f0000001 .. ). One byte each ⇒ fast even at the cap.
+    for i in 1..=SEARCH_MAX_FILES {
+        write_file(&root.path().join(format!("f{i:07}.txt")), b"x\n");
+    }
+    // Sentinel: a 'z'-prefixed name sorts AFTER every filler, so it is at sort position
+    // SEARCH_MAX_FILES + 2 — past the cap → never opened.
+    write_file(
+        &root.path().join("zzz_sentinel.txt"),
+        b"SENTMARK sentinel\n",
+    );
+
+    let ctrl = search_within_root(root.path(), "CTRLMARK", None).expect("search ok");
+    assert_eq!(
+        locs(&ctrl),
+        vec![("f0000000.txt".to_string(), 1)],
+        "the control file (within the file cap) must be scanned and matched"
+    );
+
+    let sent = search_within_root(root.path(), "SENTMARK", None).expect("search ok");
+    assert!(
+        sent.is_empty(),
+        "a match in a file sorted BEYOND SEARCH_MAX_FILES must NOT be scanned (file cap), \
+         got {sent:?}"
+    );
+}
+
+#[test]
+fn search_caps_dirs_and_keeps_the_pending_worklist_bounded() {
+    // SEARCH_MAX_DIRS: at most this many directories are listed, AND — the fix under test — the
+    // pending `worklist` is bounded because a directory is enqueued only while
+    // `dirs_enqueued < SEARCH_MAX_DIRS`. We build a WIDE FLAT tree (a deep chain would blow past
+    // PATH_MAX): SEARCH_MAX_DIRS + margin EMPTY child directories directly under the root, with
+    // exactly TWO matching files (control + sentinel) so neither the hit cap nor the file cap
+    // can interfere — only the directory enqueue cap decides what is searched.
+    //
+    // Mechanics: the walk lists `root`, enqueueing children in `list_dir_within_root` SORTED
+    // order; the root itself already consumed one enqueue slot, so only SEARCH_MAX_DIRS - 1
+    // children are enqueued — the LOWEST that-many in sort order (`d000000` … `d{cap-2}`) — and
+    // every higher-sorted directory is DROPPED at enqueue (bounded descent). The pops are LIFO,
+    // but with only two matching files no early cap fires, so EVERY enqueued directory is still
+    // visited. Therefore:
+    //   - CONTROL match lives in `d000000` (definitely enqueued) → searched & returned.
+    //   - SENTINEL match lives in the HIGHEST-sorted dir (definitely dropped) → never searched.
+    //
+    // We assert the bound via observable behavior (the dropped sentinel) rather than peeking at
+    // `worklist.len()`: if the worklist were UNbounded (the old code), every child would be
+    // enqueued and the sentinel WOULD be found. Its absence is the proof the enqueue cap held.
+    let root = TempDir::new();
+
+    // A comfortable margin past the cap so the sentinel is unambiguously in the dropped set and
+    // the test is not off-by-one fragile.
+    let total_dirs = SEARCH_MAX_DIRS + 64;
+    // Zero-padded names ⇒ lexicographic sort == numeric order (matching `list_dir`'s sort).
+    let control_rel = format!("d{:06}/m.txt", 0);
+    let sentinel_rel = format!("d{:06}/m.txt", total_dirs - 1);
+    for i in 0..total_dirs {
+        let d = root.path().join(format!("d{i:06}"));
+        fs::create_dir(&d).unwrap();
+        // Only the lowest- and highest-sorted dirs hold a matching file; the rest are empty, so
+        // neither the hit cap (SEARCH_MAX_HITS) nor the file cap (SEARCH_MAX_FILES) can fire and
+        // pre-empt the walk — the directory enqueue cap is the sole determinant.
+        if i == 0 || i == total_dirs - 1 {
+            write_file(&d.join("m.txt"), b"DIRMARK here\n");
+        }
+    }
+
+    let hits = search_within_root(root.path(), "DIRMARK", None).expect("search ok");
+
+    // The lowest-sorted directory is within the enqueue budget → its file is searched.
+    assert!(
+        hits.iter().any(|h| h.relative_path == control_rel),
+        "the control file in the lowest-sorted dir must be searched, got hits {hits:?}"
+    );
+    // The highest-sorted directory is beyond the enqueue budget → dropped → never searched.
+    assert!(
+        !hits.iter().any(|h| h.relative_path == sentinel_rel),
+        "a file in a directory beyond SEARCH_MAX_DIRS must NOT be searched (the pending \
+         worklist is bounded — enqueue cap held), but {sentinel_rel} was matched"
+    );
+    // With exactly two matching files, the control is the ONLY hit — confirming the walk neither
+    // descended the dropped sentinel dir nor blew any cap.
+    assert_eq!(
+        locs(&hits),
+        vec![(control_rel.clone(), 1)],
+        "exactly the control match (sentinel dir dropped at the enqueue cap)"
     );
 }

--- a/rust-core/crates/friday-fs/tests/search_fs.rs
+++ b/rust-core/crates/friday-fs/tests/search_fs.rs
@@ -1,0 +1,288 @@
+//! REAL adverse/security + bounds tests for the READ-ONLY `search_within_root`
+//! primitive added to `friday-fs` (the `search` agent-loop fs tool).
+//!
+//! Like `fs_primitives.rs` / `adverse_fs.rs`, every test operates on a real, unique temp
+//! directory with real files and **real symlinks created on disk**
+//! (`std::os::unix::fs::symlink`) — no mocks, no abstractly-asserted escapes. We prove:
+//! a recursive happy path; lexical rejection of an absolute / `..` `subpath`; a real
+//! out-of-root `subpath` (ancestor-symlink escape → `Escape`, final-component symlink →
+//! `Symlink`); that a real **symlink entry pointing outside the root is NEVER followed**
+//! during the walk (its outside target is not read); and that every output bound (hit cap,
+//! per-line byte cap, binary-skip, empty-query) holds.
+//!
+//! NOTE (truth label): `search_within_root` reuses the EXISTING containment primitives
+//! (`list_dir_within_root` / `stat_file_within_root` / `open_read_within_root`) for every
+//! on-disk access and adds no new `open`/`readdir` path of its own — the hardening pipeline
+//! is unchanged. PROOF-ONLY for the read-only `search` tool wiring.
+
+use std::fs;
+use std::io::Write;
+use std::os::unix::fs::symlink;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use friday_core::PathError;
+use friday_fs::{search_within_root, FsError, SearchHit, SEARCH_MAX_HITS, SEARCH_MAX_LINE_BYTES};
+
+/// A real, unique temp directory that is recursively removed on drop (std-only).
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new() -> Self {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "friday-fs-search-{}-{}-{}",
+            std::process::id(),
+            n,
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        fs::create_dir_all(&path).expect("create temp dir");
+        TempDir { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+fn write_file(path: &Path, contents: &[u8]) {
+    let mut f = fs::File::create(path).expect("create file");
+    f.write_all(contents).expect("write file");
+}
+
+/// Convenience: collect just the `(relative_path, line_number)` pairs.
+fn locs(hits: &[SearchHit]) -> Vec<(String, u64)> {
+    hits.iter()
+        .map(|h| (h.relative_path.clone(), h.line_number))
+        .collect()
+}
+
+// ════════════════════════════ happy path ════════════════════════════
+
+#[test]
+fn search_finds_literal_matches_recursively_sorted() {
+    let root = TempDir::new();
+    fs::create_dir(root.path().join("sub")).unwrap();
+    write_file(
+        &root.path().join("a.txt"),
+        b"first line\nhas NEEDLE here\nlast\n",
+    );
+    write_file(&root.path().join("b.txt"), b"nothing relevant\n");
+    write_file(
+        &root.path().join("sub/c.txt"),
+        b"x\ny\nNEEDLE again on three\nNEEDLE four\n",
+    );
+
+    let hits = search_within_root(root.path(), "NEEDLE", None).expect("search ok");
+    // Sorted by (relative_path, line_number): a.txt:2, sub/c.txt:3, sub/c.txt:4.
+    assert_eq!(
+        locs(&hits),
+        vec![
+            ("a.txt".to_string(), 2),
+            ("sub/c.txt".to_string(), 3),
+            ("sub/c.txt".to_string(), 4),
+        ]
+    );
+    // The matching line text is carried, terminator stripped.
+    assert_eq!(hits[0].line_text, "has NEEDLE here");
+    // A non-matching file contributes nothing.
+    assert!(!hits.iter().any(|h| h.relative_path == "b.txt"));
+}
+
+#[test]
+fn search_subpath_scopes_to_a_contained_subdir() {
+    let root = TempDir::new();
+    fs::create_dir(root.path().join("sub")).unwrap();
+    write_file(&root.path().join("top.txt"), b"TARGET at top\n");
+    write_file(&root.path().join("sub/inner.txt"), b"a\nTARGET inside\n");
+
+    let hits = search_within_root(root.path(), "TARGET", Some("sub")).expect("scoped search ok");
+    // ONLY the file under `sub` is searched — the top-level match is excluded.
+    assert_eq!(locs(&hits), vec![("sub/inner.txt".to_string(), 2)]);
+}
+
+#[test]
+fn search_subpath_may_name_a_single_file() {
+    let root = TempDir::new();
+    write_file(&root.path().join("only.txt"), b"WORD one\nno\nWORD two\n");
+    write_file(&root.path().join("other.txt"), b"WORD elsewhere\n");
+
+    let hits = search_within_root(root.path(), "WORD", Some("only.txt")).expect("file search ok");
+    assert_eq!(
+        locs(&hits),
+        vec![("only.txt".to_string(), 1), ("only.txt".to_string(), 3)]
+    );
+}
+
+// ════════════════════════════ containment / rejection ════════════════════════════
+
+#[test]
+fn search_absolute_and_traversal_subpath_are_rejected_lexically() {
+    let root = TempDir::new();
+    write_file(&root.path().join("a.txt"), b"NEEDLE\n");
+
+    assert!(matches!(
+        search_within_root(root.path(), "NEEDLE", Some("/etc")).unwrap_err(),
+        FsError::Lexical(PathError::Absolute)
+    ));
+    assert!(matches!(
+        search_within_root(root.path(), "NEEDLE", Some("../..")).unwrap_err(),
+        FsError::Lexical(PathError::Traversal)
+    ));
+}
+
+#[test]
+fn search_out_of_root_subpath_via_ancestor_symlink_is_rejected() {
+    let root = TempDir::new();
+    let outside = TempDir::new();
+    let outside_dir = outside.path().join("realdir");
+    fs::create_dir_all(outside_dir.join("inner")).unwrap();
+    write_file(&outside_dir.join("inner/secret.txt"), b"NEEDLE outside\n");
+    // <root>/sub -> <outside>/realdir  (an ancestor symlink in the candidate)
+    symlink(&outside_dir, root.path().join("sub")).expect("ancestor symlink");
+
+    // A subpath whose ANCESTOR escapes the root resolves outside → Escape (never searched).
+    let err = search_within_root(root.path(), "NEEDLE", Some("sub/inner")).unwrap_err();
+    assert!(
+        matches!(err, FsError::Escape),
+        "an ancestor-symlink subpath escape must be rejected, got {err:?}"
+    );
+}
+
+#[test]
+fn search_final_component_symlink_subpath_is_rejected() {
+    let root = TempDir::new();
+    let outside = TempDir::new();
+    write_file(&outside.path().join("o.txt"), b"NEEDLE outside\n");
+    // <root>/link -> <outside>/o.txt  (final-component symlink as the subpath)
+    symlink(outside.path().join("o.txt"), root.path().join("link")).expect("file symlink");
+
+    let err = search_within_root(root.path(), "NEEDLE", Some("link")).unwrap_err();
+    assert!(
+        matches!(err, FsError::Symlink),
+        "a final-component symlink subpath must be rejected (never followed), got {err:?}"
+    );
+}
+
+#[test]
+fn search_does_not_follow_a_symlink_entry_pointing_outside_root() {
+    let root = TempDir::new();
+    let outside = TempDir::new();
+    // Real outside content that a NON-hardened recursive grep WOULD read & match.
+    fs::create_dir(outside.path().join("od")).unwrap();
+    write_file(&outside.path().join("od/leaked.txt"), b"NEEDLE leaked\n");
+    write_file(&outside.path().join("ofile.txt"), b"NEEDLE leaked file\n");
+
+    // In-root, legitimately searchable match.
+    write_file(&root.path().join("inside.txt"), b"NEEDLE inside\n");
+    // A symlink to an outside DIRECTORY and a symlink to an outside FILE — both must be
+    // SKIPPED by the walk (stat → Symlink → not followed), so their targets are never read.
+    symlink(outside.path().join("od"), root.path().join("dirlink")).expect("dir symlink");
+    symlink(
+        outside.path().join("ofile.txt"),
+        root.path().join("filelink"),
+    )
+    .expect("file symlink");
+
+    let hits = search_within_root(root.path(), "NEEDLE", None).expect("search ok");
+    // ONLY the in-root file matched; neither symlink target leaked.
+    assert_eq!(locs(&hits), vec![("inside.txt".to_string(), 1)]);
+    assert!(
+        !hits.iter().any(|h| h.line_text.contains("leaked")),
+        "a symlink pointing outside the root was followed — outside content leaked: {hits:?}"
+    );
+}
+
+// ════════════════════════════ bounds / graceful skips ════════════════════════════
+
+#[test]
+fn search_empty_query_returns_no_matches() {
+    let root = TempDir::new();
+    write_file(&root.path().join("a.txt"), b"line one\nline two\n");
+    let hits = search_within_root(root.path(), "", None).expect("search ok");
+    assert!(hits.is_empty(), "empty query matches nothing (bounded)");
+}
+
+#[test]
+fn search_caps_total_hits() {
+    let root = TempDir::new();
+    // Far more matching lines than the cap, in one file.
+    let mut body = String::new();
+    for _ in 0..(SEARCH_MAX_HITS + 250) {
+        body.push_str("HIT line\n");
+    }
+    write_file(&root.path().join("many.txt"), body.as_bytes());
+
+    let hits = search_within_root(root.path(), "HIT", None).expect("search ok");
+    assert_eq!(
+        hits.len(),
+        SEARCH_MAX_HITS,
+        "total hits must be hard-capped at SEARCH_MAX_HITS"
+    );
+}
+
+#[test]
+fn search_truncates_an_overlong_matching_line_on_a_char_boundary() {
+    let root = TempDir::new();
+    // A single matching line far longer than the per-line cap, with a multibyte char
+    // straddling the cap boundary to prove we back up to a char boundary (valid UTF-8).
+    let mut line = String::from("NEEDLE ");
+    line.push_str(&"é".repeat(SEARCH_MAX_LINE_BYTES)); // 2 bytes each ⇒ well over the cap
+    line.push('\n');
+    write_file(&root.path().join("long.txt"), line.as_bytes());
+
+    let hits = search_within_root(root.path(), "NEEDLE", None).expect("search ok");
+    assert_eq!(hits.len(), 1);
+    let text = &hits[0].line_text;
+    assert!(
+        text.len() <= SEARCH_MAX_LINE_BYTES,
+        "line_text must be capped at SEARCH_MAX_LINE_BYTES, got {} bytes",
+        text.len()
+    );
+    // Truncation backed up to a UTF-8 char boundary ⇒ the String is valid by construction
+    // (it IS a String); assert it begins with the real prefix and is non-trivial.
+    assert!(text.starts_with("NEEDLE "), "prefix preserved: {text:?}");
+    assert!(
+        text.len() >= SEARCH_MAX_LINE_BYTES - 1,
+        "filled near the cap"
+    );
+}
+
+#[test]
+fn search_skips_binary_and_non_utf8_files_gracefully() {
+    let root = TempDir::new();
+    // A "binary" file: the needle bytes are present but so is a NUL ⇒ skipped as binary.
+    write_file(&root.path().join("bin.dat"), b"MARK\x00\x01\x02MARK\n");
+    // An invalid-UTF-8 (no NUL) file: lone continuation byte ⇒ valid prefix only is scanned;
+    // here the prefix has no match, so nothing leaks from the garbage tail.
+    write_file(
+        &root.path().join("bad.txt"),
+        b"clean\n\xff\xfe MARK trailing\n",
+    );
+    // A genuine UTF-8 text file with the needle ⇒ matched.
+    write_file(&root.path().join("good.txt"), b"a MARK b\n");
+
+    let hits = search_within_root(root.path(), "MARK", None).expect("search ok");
+    // ONLY the real text file matched; the binary file was skipped wholesale.
+    assert!(
+        hits.iter().any(|h| h.relative_path == "good.txt"),
+        "the UTF-8 text file must match"
+    );
+    assert!(
+        !hits.iter().any(|h| h.relative_path == "bin.dat"),
+        "a NUL-bearing binary file must be skipped, got {hits:?}"
+    );
+}

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -1251,17 +1251,18 @@ pub trait ToolExecutor {
 /// safe-open primitive, contained to a workspace `root` (NEVER `std::fs` on an
 /// agent-supplied path). Wired tools (S3-wiring):
 ///   - **read-type** (`mutating=false` in the registry → gate `Allow`s directly): `read_file`,
-///     `list_dir`, `stat_file`. Each sets [`ToolReceipt::content`] with its result (file bytes /
-///     entry names / stat line) so the loop feeds it back to the model (bounded — see
-///     [`MAX_FEEDBACK_CONTENT_BYTES`]).
+///     `list_dir`, `stat_file`, `search`. Each sets [`ToolReceipt::content`] with its result (file
+///     bytes / entry names / stat line / matching lines) so the loop feeds it back to the model
+///     (bounded — see [`MAX_FEEDBACK_CONTENT_BYTES`]).
 ///   - **mutating** (`mutating=true` → the gate withholds them pending owner approval; under the
 ///     default deny-all policy they Pause, never execute here): `write_file`, `append_file`,
 ///     `edit_file`, `delete_file`, `move_file`. They set `content: None`.
 ///
 /// The executor is reached ONLY on a gate `Allow` (see [`gate_dispatch`]), so a mutating arm runs
 /// IFF a signed approval was minted — the executor itself never decides; the gate does.
-/// `search` and `run_command` are registered but have no friday-fs primitive, so they remain
-/// `Unsupported` here. Fail-closed in every arm.
+/// `search` is a read-type tool wired to `friday_fs::search_within_root` (sets `content` with the
+/// matches; `summary` is a count only). `run_command` is registered but has no friday-fs primitive,
+/// so it remains `Unsupported` here. Fail-closed in every arm.
 pub struct FsToolExecutor {
     root: std::path::PathBuf,
 }
@@ -1352,6 +1353,30 @@ impl ToolExecutor for FsToolExecutor {
                     action: action.to_string(),
                     summary: format!("stat {detail}"),
                     content: Some(detail),
+                })
+            }
+            "search" => {
+                let query = Self::param(params, "query")?;
+                // Optional scope: a contained sub-directory or single file. Absent ⇒ whole
+                // workspace root. (The backend REJECTS an absolute/`..`/out-of-root/symlink
+                // subpath via the same containment pipeline.)
+                let subpath = Self::param(params, "path").ok();
+                let hits = friday_fs::search_within_root(&self.root, query, subpath)
+                    .map_err(ExecError::Fs)?;
+                // Read-type ⇒ the matches are model-facing `content`; the `summary` (which
+                // reaches the hash-chained audit ledger) is a COUNT ONLY — the matched lines
+                // never enter the ledger, mirroring list_dir/read_file keeping their payload
+                // out of the summary. Each match renders as `relpath:line:text` (the model's
+                // grep-style grounding; bounded by the backend caps + feed-back truncation).
+                let content = hits
+                    .iter()
+                    .map(|h| format!("{}:{}:{}", h.relative_path, h.line_number, h.line_text))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                Ok(ToolReceipt {
+                    action: action.to_string(),
+                    summary: format!("search matched {} line(s)", hits.len()),
+                    content: Some(content),
                 })
             }
             // --- mutating tools (gate withholds under deny-all; reached ONLY on Allow) ---
@@ -3282,14 +3307,18 @@ mod tests {
     }
 
     #[test]
-    fn unsupported_tool_errors_after_allow_without_panicking() {
-        let root = TempDir::new("unsup");
-        let db = Db::open_hub(&temp_path("exec-unsup")).unwrap();
-        agent_run::create_run(db.conn(), "r1", "search the workspace", 1).unwrap();
-        // search is registered + read-only → Allow → executor has no friday-fs primitive
-        // for it → returns Unsupported (list_dir/stat_file are now wired, so they execute).
+    fn read_tool_exec_error_after_allow_records_failed_receipt() {
+        let root = TempDir::new("execerr");
+        let db = Db::open_hub(&temp_path("exec-execerr")).unwrap();
+        agent_run::create_run(db.conn(), "r1", "read a missing file", 1).unwrap();
+        // A read-only tool (read_file) is gate-Allowed, reaches the executor, then FAILS at
+        // execution because the named file does not exist (the root exists → resolve_within_root
+        // succeeds → open ENOENT → FsError::NotFound → ExecError::Fs). This exercises the
+        // gate-Allowed-but-exec-FAILED path: an exec_error is recorded AND a hash-chained
+        // exec_failed audit receipt is written atomically with it, and the chain still verifies.
+        // (search is now WIRED and would succeed, so it is no longer the exec-failure example.)
         let client = MockAgentLlmClient {
-            proposal: raw("search", &[("query", "needle")]),
+            proposal: raw("read_file", &[("path", "does-not-exist.txt")]),
         };
         let executor = FsToolExecutor::new(&root.0);
         let out = run_one_turn_with_executor(
@@ -3305,10 +3334,10 @@ mod tests {
         )
         .unwrap();
         assert_eq!(out.decision, GateDecision::Allow);
-        assert!(!out.executed, "unsupported tool did not complete");
+        assert!(!out.executed, "the exec failure did not complete");
         assert!(
-            out.reason.starts_with("exec_error:"),
-            "reason was {:?}",
+            out.reason.starts_with("exec_error:") && out.reason.contains("fs_error"),
+            "expected an fs exec_error, reason was {:?}",
             out.reason
         );
         // #30: the gate-Allowed-but-failed dispatch records a hash-chained exec_failed
@@ -3380,6 +3409,117 @@ mod tests {
         assert!(
             scontent.contains("sub/beta.txt: file, 2 bytes"),
             "stat content was {scontent:?}"
+        );
+    }
+
+    /// `search` wiring (this slice): a direct execute returns the matching lines in `content`
+    /// (model-facing, `relpath:line:text`) and a COUNT-ONLY `summary` — the matched text never
+    /// enters the ledger summary, mirroring list_dir/read_file. Containment is honored by the
+    /// underlying friday-fs primitive (proven exhaustively in friday-fs/tests/search_fs.rs).
+    #[test]
+    fn search_arm_executes_and_carries_matches_in_content_with_count_summary() {
+        let root = TempDir::new("search-arm");
+        std::fs::create_dir(root.0.join("sub")).unwrap();
+        std::fs::write(root.0.join("a.txt"), b"alpha needle one\nbeta\n").unwrap();
+        std::fs::write(
+            root.0.join("sub/b.txt"),
+            b"no match here\nanother needle line\n",
+        )
+        .unwrap();
+        let executor = FsToolExecutor::new(&root.0);
+
+        let r = executor
+            .execute("search", &[("query".to_string(), "needle".to_string())])
+            .unwrap();
+        assert_eq!(r.action, "search");
+        // summary is a COUNT ONLY (ledger-safe) — never the matched line text.
+        assert_eq!(r.summary, "search matched 2 line(s)");
+        assert!(
+            !r.summary.contains("needle"),
+            "matched text must NOT be in the ledger summary, only in content"
+        );
+        let content = r.content.expect("search is read-type → content set");
+        // Deterministic (sorted by relative_path, then line): a.txt before sub/b.txt.
+        assert_eq!(
+            content,
+            "a.txt:1:alpha needle one\nsub/b.txt:2:another needle line"
+        );
+
+        // A query with no matches → empty content, zero count (still a clean read-type receipt).
+        let none = executor
+            .execute("search", &[("query".to_string(), "zzz-absent".to_string())])
+            .unwrap();
+        assert_eq!(none.summary, "search matched 0 line(s)");
+        assert_eq!(none.content.as_deref(), Some(""));
+
+        // Optional `path` scopes the search to a contained sub-directory.
+        let scoped = executor
+            .execute(
+                "search",
+                &[
+                    ("query".to_string(), "needle".to_string()),
+                    ("path".to_string(), "sub".to_string()),
+                ],
+            )
+            .unwrap();
+        assert_eq!(scoped.summary, "search matched 1 line(s)");
+        assert_eq!(
+            scoped.content.as_deref(),
+            Some("sub/b.txt:2:another needle line")
+        );
+    }
+
+    /// `search` is registered non-mutating + read-only, so it reaches the gate as `Allow` AND
+    /// now EXECUTES (the wiring this slice adds) — proven through the FULL turn loop, not just a
+    /// direct call. (This replaces the prior `search`-as-Unsupported coverage now that it runs.)
+    #[test]
+    fn search_through_loop_is_allowed_and_executes() {
+        let root = TempDir::new("search-loop");
+        std::fs::write(root.0.join("notes.txt"), b"todo: needle here\n").unwrap();
+        let db = Db::open_hub(&temp_path("exec-search-loop")).unwrap();
+        agent_run::create_run(db.conn(), "r1", "search the workspace", 1).unwrap();
+        let client = MockAgentLlmClient {
+            proposal: raw("search", &[("query", "needle")]),
+        };
+        let executor = FsToolExecutor::new(&root.0);
+        let out = run_one_turn_with_executor(
+            &client,
+            &executor,
+            db.conn(),
+            "r1",
+            0,
+            "search the workspace",
+            SECRET,
+            None,
+            1000,
+        )
+        .unwrap();
+        assert_eq!(
+            out.decision,
+            GateDecision::Allow,
+            "search is read-only → Allow"
+        );
+        assert!(
+            out.executed,
+            "search is wired → it executes (no longer Unsupported)"
+        );
+        assert!(friday_storage::audit::verify_audit_chain(db.conn()).is_ok());
+    }
+
+    /// `run_command` is registered but has NO friday-fs primitive, so the executor's fall-through
+    /// arm still returns `Unsupported`. (After wiring `search`, this arm is no longer reachable
+    /// through the loop — run_command is mutating and Pauses — so this DIRECT call is the only
+    /// remaining coverage of the fail-closed `other =>` arm.)
+    #[test]
+    fn executor_run_command_is_unsupported() {
+        let root = TempDir::new("unsup-runcmd");
+        let executor = FsToolExecutor::new(&root.0);
+        let err = executor
+            .execute("run_command", &[("command".to_string(), "ls".to_string())])
+            .unwrap_err();
+        assert!(
+            matches!(err, ExecError::Unsupported(ref a) if a == "run_command"),
+            "run_command must be Unsupported (no fs primitive), got {err:?}"
         );
     }
 
@@ -4411,9 +4551,12 @@ mod tests {
     fn loop_exec_error_threads_back_and_continues() {
         let root = TempDir::new("loop-execerr");
         let db = Db::open_hub(&temp_path("loop-execerr")).unwrap();
-        agent_run::create_run(db.conn(), "r1", "search then finish", 1).unwrap();
+        agent_run::create_run(db.conn(), "r1", "read missing then finish", 1).unwrap();
         let client = ScriptedAgentLlmClient::new(vec![
-            AgentStep::Tool(raw("search", &[("query", "needle")])), // turn 0: Allow but Unsupported (no fs primitive) → exec_error → continue
+            // turn 0: a read-only tool that is Allowed but FAILS at execution (missing file →
+            // FsError::NotFound → exec_error) — the loop threads the error back and continues.
+            // (search is now wired and would succeed, so read_file-on-missing is the failure.)
+            AgentStep::Tool(raw("read_file", &[("path", "does-not-exist.txt")])),
             AgentStep::Finish {
                 message: "ok".to_string(),
             }, // turn 1: finish (loop did NOT wedge on the error)
@@ -4424,7 +4567,7 @@ mod tests {
             &executor,
             db.conn(),
             "r1",
-            "search then finish",
+            "read missing then finish",
             "",
             SECRET,
             &no_approval(),


### PR DESCRIPTION
## What

Wires the registered-but-unimplemented `search` agent-loop fs tool to a new **READ-ONLY** `friday_fs::search_within_root` backend — a literal-substring grep contained to the workspace root. Completes safe-fs **READ** parity (read_file / list_dir / stat_file / **search**).

## friday-fs (`crates/friday-fs/src/lib.rs`)
- `search_within_root(root, query, Option<subpath>) -> Result<Vec<SearchHit>, FsError>`: recursive literal-substring (`str::contains`, case-sensitive) search over UTF-8 text files.
- **Containment (no new attack surface):** every on-disk access reuses the EXISTING hardened primitives — `list_dir_within_root` (O_NOFOLLOW + realpath-ancestor), `stat_file_within_root` (no-follow lstat), `open_read_within_root` (O_NOFOLLOW + fd-identity TOCTOU). Candidate paths are built only from `readdir` entry names under the contained root, so each access is independently re-validated by `resolve_within_root`. **No change to the containment pipeline or the gate.**
- **Symlinks never followed:** every entry is stat'd before it is touched; a symlink → `Err(Symlink)` → SKIPPED, so an outside-pointing link is never read or descended. An absolute / `..` / out-of-root / final-symlink `subpath` argument is rejected (`Err`). Binary/non-UTF-8 files skipped (NUL screen + valid-UTF-8-prefix decode).
- **Bounded output (documented consts):** `SEARCH_MAX_HITS=200`, `SEARCH_MAX_LINE_BYTES=512` (char-boundary truncation), `SEARCH_MAX_FILES=2000`, `SEARCH_MAX_DIRS=4096`, `SEARCH_MAX_FILE_BYTES=1 MiB` via `Read::take` (holds even if a file grows after stat — never unbounded memory/output).
- `tests/search_fs.rs`: 11 real-fs adverse/bounds tests (recursive happy path; scoped subpath; single-file subpath; absolute/`..`/ancestor-symlink/final-symlink subpath rejection; **real symlink-entry-not-followed, outside content not leaked**; hit cap; per-line char-boundary truncation; binary skip; empty query).

## friday-hub (`crates/friday-hub/src/lib.rs`)
- `"search"` arm in `FsToolExecutor::execute` → **read-type receipt**: matches in `content` (`relpath:line:text`, model-facing); `summary` is a **COUNT only** so matched lines never enter the hash-chained audit ledger (mirrors list_dir/read_file). Optional `path` param scopes the search. `search` was already registered `mutating=false` / `Risk::ReadOnly` → **gate Allows, no approval path**.
- The two tests that used `search` as the gate-Allowed-but-Unsupported example now trigger the exec-error path via `read_file`-on-missing (search is wired). New tests: search executes through the full turn loop (`Allow` + `executed`), direct search receipt (content matches + count-only summary), and `run_command` still `Unsupported` (preserves the fail-closed `other =>` arm coverage).

## Truth label
Read-only `search` completes safe-fs **READ** parity; gate-Allowed (non-mutating); honors the full workspace containment pipeline; bounded output. **PROOF-ONLY — not v1 GO.** `executeRun` is not replaced; no gate / schema / migration / mutating change; **no TS**; `run_command` remains a separate later slice. Known test-coverage boundary: the files-scanned / dirs / per-file-byte caps are implemented + documented but not externally observable through the public API, so only the hit + per-line caps are unit-asserted.

## Base
Branched off `origin/main` `d8ddf4e8`; `origin/main` advanced to `d8792e70` (#588, friday-storage Debug-redaction, non-overlapping) during the work, so this is **rebased onto `d8792e70`**. `git diff --name-only origin/main..HEAD` = the 3 files above.

## Local gates (actual)
- `cargo fmt --check`: clean
- `cargo clippy -p friday-fs -p friday-hub --all-targets -- -D warnings`: clean
- `cargo test -p friday-fs -p friday-hub`: **0 failures** (friday-fs search_fs.rs 11/11; friday-hub lib 303/0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)