### PR TITLE
fix(rust-deepseek): terminal-classify client 4xx/429 instead of wastefully retrying (#593 LOW)

### DIFF
--- a/rust-core/crates/friday-deepseek/src/lib.rs
+++ b/rust-core/crates/friday-deepseek/src/lib.rs
@@ -47,9 +47,19 @@ pub enum DeepSeekError {
     /// Authentication rejected (HTTP 401/403). Never a fallback.
     #[error("DeepSeek authentication failed (HTTP {0})")]
     Auth(u16),
-    /// Route unavailable (network error, 5xx, rate limit, …). Never a fallback.
+    /// Route unavailable: a TRANSIENT failure that retrying the SAME route may
+    /// fix — network/transport error, request-timeout (HTTP 408), or a server-side
+    /// 5xx. Classified `Retryable` (bounded). Never a fallback.
     #[error("DeepSeek provider unavailable: {0}")]
     ProviderUnavailable(String),
+    /// A TERMINAL client-side HTTP error (other 4xx: 400 bad-request / 404 / 422,
+    /// and 429 rate-limit). Retrying cannot fix a malformed/unauthorized/not-found
+    /// request, and — absent any backoff mechanism — retrying a 429 would only
+    /// hammer a rate-limited provider, so 429 is treated as terminal here (a future
+    /// backoff slice could make 429 retryable-with-delay). Classified `Terminal`.
+    /// Never a fallback. Display is COARSE: status code only, never the response body.
+    #[error("DeepSeek client error (HTTP {status})")]
+    ClientError { status: u16 },
     /// Response did not match the documented shape.
     #[error("DeepSeek response shape unexpected: {0}")]
     BadResponse(String),
@@ -87,11 +97,18 @@ impl Default for UreqTransport {
 fn map_ureq_err(e: ureq::Error) -> DeepSeekError {
     match e {
         ureq::Error::Status(code, _resp) => {
-            // Do not read/echo the response body; classify by status only.
+            // Do not read/echo the response body; classify by status code ONLY.
             if code == 401 || code == 403 {
                 DeepSeekError::Auth(code)
-            } else {
+            } else if code == 408 || (500..=599).contains(&code) {
+                // Transient: request-timeout (408) or any server-side 5xx — retrying
+                // the SAME route may succeed.
                 DeepSeekError::ProviderUnavailable(format!("HTTP {code}"))
+            } else {
+                // Terminal client error: other 4xx (400/404/422) and 429 rate-limit.
+                // Retrying cannot fix the request, and (no backoff) retrying a 429 only
+                // hammers a rate-limited provider — so it fails closed, not retried.
+                DeepSeekError::ClientError { status: code }
             }
         }
         // Transport error (DNS/TLS/timeout). Its Display carries host/kind, not
@@ -597,7 +614,12 @@ mod tests {
     }
 
     #[test]
-    fn real_transport_maps_rate_limit_to_provider_unavailable_without_body_or_secret() {
+    fn real_transport_maps_rate_limit_to_terminal_client_error_without_body_or_secret() {
+        // 429 is now a TERMINAL ClientError (no backoff mechanism ⇒ treat as terminal
+        // rather than hammer a rate-limited provider). Display/Debug stays COARSE: the
+        // status code only — never the response body (which carries SECRET-QUOTA-BODY)
+        // nor the API key / Authorization header. This doubles as the leak-lens assertion
+        // for the new ClientError variant (#593 leak-lens LOW).
         let (base_url, handle) = serve_http_once(
             429,
             "Too Many Requests",
@@ -610,22 +632,56 @@ mod tests {
         );
         let err = c.discover_models().unwrap_err();
         handle.join().unwrap();
-        assert!(matches!(
-            err,
-            DeepSeekError::ProviderUnavailable(ref reason) if reason == "HTTP 429"
-        ));
-        let rendered = format!("{err:?}");
-        for forbidden in [
-            "SECRET-QUOTA-BODY",
-            "test-key-not-real",
-            "Authorization",
-            "Bearer",
-        ] {
+        assert!(matches!(err, DeepSeekError::ClientError { status: 429 }));
+        // Both Debug and Display must be coarse and secret-free.
+        for rendered in [format!("{err:?}"), format!("{err}")] {
+            for forbidden in [
+                "SECRET-QUOTA-BODY",
+                "test-key-not-real",
+                "Authorization",
+                "Bearer",
+            ] {
+                assert!(
+                    !rendered.contains(forbidden),
+                    "client-error render leaked {forbidden}: {rendered}"
+                );
+            }
+            // Positively: the status code IS present (a coarse, useful label).
+            assert!(rendered.contains("429"), "status code missing: {rendered}");
+        }
+    }
+
+    #[test]
+    fn map_ureq_status_partitions_transient_5xx_408_vs_terminal_4xx() {
+        // Synthetic ureq::Error::Status values drive map_ureq_err directly (no network),
+        // proving the exact partition: 5xx + 408 + transport ⇒ transient ProviderUnavailable
+        // (Retryable); other 4xx + 429 ⇒ terminal ClientError. ureq::Error::Status carries a
+        // Response; we synthesize one with the desired status line.
+        let status_err = |code: u16, reason: &str| {
+            let resp = ureq::Response::new(code, reason, "{}").unwrap();
+            map_ureq_err(ureq::Error::Status(code, resp))
+        };
+
+        // Transient — stays ProviderUnavailable (Retryable downstream).
+        for code in [500u16, 502, 503, 504, 599, 408] {
             assert!(
-                !rendered.contains(forbidden),
-                "rate-limit error leaked {forbidden}: {rendered}"
+                matches!(
+                    status_err(code, "x"),
+                    DeepSeekError::ProviderUnavailable(ref r) if r == &format!("HTTP {code}")
+                ),
+                "HTTP {code} must be transient ProviderUnavailable"
             );
         }
+        // Terminal client error — ClientError (Terminal downstream). 429 included.
+        for code in [400u16, 404, 409, 422, 429] {
+            assert!(
+                matches!(status_err(code, "x"), DeepSeekError::ClientError { status } if status == code),
+                "HTTP {code} must be terminal ClientError"
+            );
+        }
+        // 401/403 stay Auth (unchanged).
+        assert!(matches!(status_err(401, "x"), DeepSeekError::Auth(401)));
+        assert!(matches!(status_err(403, "x"), DeepSeekError::Auth(403)));
     }
 
     #[test]

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -198,12 +198,14 @@ pub struct RawToolCall {
 /// failures the caller fail-closes on — never a silent default.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum AgentError {
-    /// The provider/route call itself failed (network / 5xx / rate-limit / auth /
-    /// bad-response / no-models), carrying the STRUCTURED [`friday_deepseek::DeepSeekError`]
-    /// instead of stringifying it. This preserves the variant so the run_loop error site can
-    /// classify it via [`crate::retry::RetryDisposition::classify_deepseek`] and BOUND-retry
-    /// only the transient (`Retryable`) cases — a `Terminal` (auth/credential/validation) one
-    /// is surfaced immediately, exactly as before. The error's `Display`/`Debug` is the
+    /// The provider/route call itself failed (network / 5xx / request-timeout / auth /
+    /// client-4xx / rate-limit / bad-response / no-models), carrying the STRUCTURED
+    /// [`friday_deepseek::DeepSeekError`] instead of stringifying it. This preserves the
+    /// variant so the run_loop error site can classify it via
+    /// [`crate::retry::RetryDisposition::classify_deepseek`] and BOUND-retry only the
+    /// transient (`Retryable`: network/5xx/408) cases — a `Terminal` one (auth / credential /
+    /// client-4xx / 429-rate-limit / validation) is surfaced immediately. The error's
+    /// `Display`/`Debug` is the
     /// crate's own coarse, secret-free message (status code / kind only; never the API key
     /// or response body — see `map_ureq_err`), so this leaks no more than the prior
     /// `format!("{e:?}")` did.
@@ -4645,7 +4647,8 @@ mod tests {
         )
     }
 
-    /// A transient (Retryable) route error: `ProviderUnavailable` (network / 5xx / rate-limit).
+    /// A transient (Retryable) route error: `ProviderUnavailable` (network/transport,
+    /// request-timeout 408, or server-side 5xx) — retrying the SAME route may fix it.
     fn transient_route_err() -> Result<MeteredStep, AgentError> {
         Err(AgentError::Route(
             friday_deepseek::DeepSeekError::ProviderUnavailable("HTTP 503".to_string()),
@@ -4655,6 +4658,15 @@ mod tests {
     /// A Terminal route error: `Auth` (credential rejected) — must NEVER be retried.
     fn terminal_route_err() -> Result<MeteredStep, AgentError> {
         Err(AgentError::Route(friday_deepseek::DeepSeekError::Auth(401)))
+    }
+
+    /// A Terminal client-side route error: a 429 rate-limit (also covers 400/404/422).
+    /// Terminal because there is no backoff mechanism here — retrying would only hammer a
+    /// rate-limited provider — so it must fail closed after exactly ONE provider attempt.
+    fn client_error_route_err(status: u16) -> Result<MeteredStep, AgentError> {
+        Err(AgentError::Route(
+            friday_deepseek::DeepSeekError::ClientError { status },
+        ))
     }
 
     #[test]
@@ -4753,6 +4765,105 @@ mod tests {
             "a Terminal route error is NOT retried"
         );
         assert_eq!(db.count("token_ledger").unwrap(), 0, "nothing billed");
+    }
+
+    #[test]
+    fn loop_does_not_retry_terminal_client_4xx_or_429_but_does_retry_503() {
+        // (Test 2b) A terminal client error — 429 rate-limit (and 400/404/422) — fails
+        // closed IMMEDIATELY: exactly ONE provider call, run Errored, nothing billed. This is
+        // the #593 LOW fix: such errors were previously folded into ProviderUnavailable and
+        // wastefully retried up to RUN_LOOP_MAX_PROVIDER_ATTEMPTS (hammering a rate-limited
+        // provider with no backoff). The boundary partner (a 503) STILL retries — proving the
+        // change is a precise re-partition, not a blanket "stop retrying everything".
+        for terminal_status in [429u16, 400, 422] {
+            let label = format!("retry-client-{terminal_status}");
+            let root = TempDir::new(&label);
+            let db = Db::open_hub(&temp_path(&label)).unwrap();
+            agent_run::create_run(db.conn(), "r1", "do it", 1).unwrap();
+            let client = RetryScriptedClient::new(vec![
+                client_error_route_err(terminal_status),
+                // A success is scripted next; the loop must NEVER reach it for a terminal error.
+                Ok(ok_step(
+                    AgentStep::Finish {
+                        message: "should-not-reach".to_string(),
+                    },
+                    10,
+                    5,
+                )),
+            ]);
+            let executor = FsToolExecutor::new(&root.0);
+            let out = run_loop(
+                &client,
+                &executor,
+                db.conn(),
+                "r1",
+                "do it",
+                "",
+                SECRET,
+                &no_approval(),
+                5,
+                1000,
+            )
+            .unwrap();
+            assert_eq!(
+                out.status,
+                LoopStatus::Errored,
+                "terminal client error (HTTP {terminal_status}) fails closed"
+            );
+            assert_eq!(out.turns, 1);
+            assert_eq!(
+                client.provider_calls(),
+                1,
+                "a terminal client error (HTTP {terminal_status}) is NOT retried"
+            );
+            assert_eq!(
+                db.count("token_ledger").unwrap(),
+                0,
+                "nothing billed for HTTP {terminal_status}"
+            );
+            // The surfaced error string is coarse/secret-free: status + kind only.
+            let detail = format!(
+                "agent_error:{}",
+                AgentError::Route(friday_deepseek::DeepSeekError::ClientError {
+                    status: terminal_status
+                },)
+            );
+            assert!(detail.contains(&terminal_status.to_string()));
+            assert!(!detail.contains("Bearer") && !detail.contains("Authorization"));
+        }
+
+        // Boundary partner: a transient 503 IS still retried (bounded), confirming the
+        // re-partition did not over-broaden terminality.
+        {
+            let root = TempDir::new("retry-503-still-retries");
+            let db = Db::open_hub(&temp_path("retry-503-still-retries")).unwrap();
+            agent_run::create_run(db.conn(), "r1", "do it", 1).unwrap();
+            let client = RetryScriptedClient::new(vec![transient_route_err()]);
+            let executor = FsToolExecutor::new(&root.0);
+            let out = run_loop(
+                &client,
+                &executor,
+                db.conn(),
+                "r1",
+                "do it",
+                "",
+                SECRET,
+                &no_approval(),
+                5,
+                1000,
+            )
+            .unwrap();
+            assert_eq!(
+                out.status,
+                LoopStatus::Errored,
+                "exhausted retries fail closed"
+            );
+            assert_eq!(
+                client.provider_calls() as u32,
+                RUN_LOOP_MAX_PROVIDER_ATTEMPTS,
+                "a transient 503 IS retried up to the bound (terminality not over-broadened)"
+            );
+        }
     }
 
     #[test]

--- a/rust-core/crates/friday-hub/src/retry.rs
+++ b/rust-core/crates/friday-hub/src/retry.rs
@@ -42,15 +42,24 @@ impl RetryDisposition {
     }
 
     /// Classify a DeepSeek provider error. ONLY a transient
-    /// [`DeepSeekError::ProviderUnavailable`] (network / 5xx / rate-limit) is
-    /// `Retryable`; credential / auth / bad-response / no-models / core errors are
-    /// `Terminal` — retrying cannot fix them, and (per the crate's own variant docs)
-    /// none of them is ever a fallback trigger.
+    /// [`DeepSeekError::ProviderUnavailable`] (network/transport, request-timeout 408,
+    /// or server-side 5xx) is `Retryable`; everything else is `Terminal` — retrying
+    /// cannot fix it, and (per the crate's own variant docs) none is ever a fallback
+    /// trigger.
+    ///
+    /// In particular [`DeepSeekError::ClientError`] — a terminal client-side 4xx
+    /// (400/404/422) and **429 rate-limit** — is `Terminal`, NOT retried. A 4xx will
+    /// not become valid on a bare retry, and 429-as-terminal is deliberate: there is
+    /// no backoff mechanism here (the run_loop retry has no injected clock / no sleep),
+    /// so retrying a 429 would only HAMMER a rate-limited provider with no delay. A
+    /// future backoff slice could reclassify 429 as retryable-with-delay; until then,
+    /// fail closed.
     pub fn classify_deepseek(err: &DeepSeekError) -> Self {
         match err {
             DeepSeekError::ProviderUnavailable(_) => RetryDisposition::Retryable,
             DeepSeekError::CredentialMissing
             | DeepSeekError::Auth(_)
+            | DeepSeekError::ClientError { .. }
             | DeepSeekError::BadResponse(_)
             | DeepSeekError::NoModels
             | DeepSeekError::Core(_) => RetryDisposition::Terminal,
@@ -93,11 +102,17 @@ mod tests {
             RetryDisposition::classify_deepseek(&DeepSeekError::ProviderUnavailable("503".into())),
             RetryDisposition::Retryable
         );
-        // Everything else is Terminal — retrying cannot fix it. (All 5 non-transient
-        // variants pinned, incl. Core — exhaustive coverage of the mapping.)
+        // Everything else is Terminal — retrying cannot fix it. (All non-transient
+        // variants pinned, incl. Core and the new client-4xx/429 ClientError —
+        // exhaustive coverage of the mapping.)
         for terminal in [
             DeepSeekError::CredentialMissing,
             DeepSeekError::Auth(401),
+            // Terminal client errors: malformed/not-found 4xx AND 429 rate-limit (no
+            // backoff ⇒ terminal, not a hammering retry).
+            DeepSeekError::ClientError { status: 400 },
+            DeepSeekError::ClientError { status: 422 },
+            DeepSeekError::ClientError { status: 429 },
             DeepSeekError::BadResponse("garbage".into()),
             DeepSeekError::NoModels,
             DeepSeekError::Core(friday_core::CoreError::BlockedTransfer("x".into())),
@@ -108,6 +123,14 @@ mod tests {
                 "{terminal:?} must be terminal"
             );
         }
+        // And a transient 5xx-style ProviderUnavailable IS retryable (boundary partner
+        // to the 4xx terminal cases above).
+        assert_eq!(
+            RetryDisposition::classify_deepseek(&DeepSeekError::ProviderUnavailable(
+                "HTTP 503".into()
+            )),
+            RetryDisposition::Retryable
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What & why (refines #593's provider-error retry classification)

`map_ureq_err` (friday-deepseek) previously folded **every** non-401/403 HTTP status into `DeepSeekError::ProviderUnavailable`, which `classify_deepseek` (friday-hub `retry.rs`) maps to **Retryable**. So a **terminal client 4xx** (400 bad-request / 404 / 422) **and 429 rate-limit** were retried up to `RUN_LOOP_MAX_PROVIDER_ATTEMPTS = 3` before failing closed.

That is bounded/safe (no billing, no per-attempt audit, gate untouched) but **wasteful**, and retrying a **429 with NO backoff mechanism** only **hammers** a rate-limited provider. This PR fixes that #593 LOW.

## Change (minimal, scoped to friday-deepseek `lib.rs` + friday-hub `retry.rs` + a hub test)

- **5xx (500–599) + 408 request-timeout + transport/network/timeout** errors stay `ProviderUnavailable` (transient, **Retryable**) — retrying the same route may fix it.
- **Other 4xx (400/404/422) and 429** → new terminal variant `DeepSeekError::ClientError { status: u16 }`. `classify_deepseek` maps it to **Terminal** (not retried).
- **401/403 → `Auth`** unchanged.

**429-as-terminal is deliberate:** there is no backoff mechanism here (the run_loop retry has no injected clock / no sleep), so retrying a 429 would only hammer the provider with no delay. A future backoff slice could reclassify 429 as retryable-with-delay; documented in `classify_deepseek`.

**No secret leak:** `Display`/`Debug` of the new variant is **coarse — status code + kind label only**, never the response body (which can carry quota/secret strings) nor the `Authorization` header / API key.

## Blast-radius recon (why this is minimal/safe)

The only **exhaustive** match over `DeepSeekError` variants is `classify_deepseek` (updated here). Every other consumer is **variant-agnostic**, so a new variant changes nothing for them:
- `AgentError::Route(e)` renders via `DeepSeekError`'s own coarse `Display` (delegation).
- The client-facing `RecordAskError::Route(_)` → `ErrorCode::ProviderUnavailable` is a **wildcard** match — the client-facing error code is preserved automatically.
- `friday-ffi` never links `friday-deepseek` (arch boundary), so no ffi consumer.

No consumer relied on 4xx being folded into `ProviderUnavailable`.

## Tests

- **friday-deepseek** `map_ureq_status_partitions_…`: 500/502/503/504/599/**408** → `ProviderUnavailable`; 400/404/409/422/**429** → `ClientError { status }`; 401/403 → `Auth`.
- **friday-deepseek** flipped real-transport 429 test → `ClientError { status: 429 }`, and **kept + extended** its leak assertions (Debug **and** Display contain no `SECRET-QUOTA-BODY` / key / `Authorization` / `Bearer`; status code IS present) — doubles as the #593 leak-lens assertion for the new variant.
- **friday-hub `retry.rs`**: `ClientError` (400/422/429) → **Terminal**; `ProviderUnavailable` → **Retryable** (boundary partner pinned).
- **friday-hub `lib.rs`** run_loop-level: a 429/400/422 is **NOT retried** (`provider_calls == 1`, `Errored`, nothing billed) while a **503 still retries** to the bound — proving a precise re-partition, not a blanket "stop retrying everything".

## Scope / gate

- `git diff --name-only origin/main..HEAD`: `friday-deepseek/src/lib.rs`, `friday-hub/src/retry.rs`, `friday-hub/src/lib.rs` (hub test only — the run_loop retry loop, the gate, `FsToolExecutor`, and `friday-fs` are **untouched**).
- Off current `origin/main` (`59a5e920`), clean worktree.
- Local gate (actual): `cargo fmt --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` exit 0; `cargo test -p friday-deepseek -p friday-hub` **0 failures** (deepseek 15/0, hub 310/0 + sub-suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)