### PR TITLE
fix(ts-retire): method-level fail-closed guard on autonomy policy updatePolicy

### DIFF
--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -1490,6 +1490,11 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
   const autonomyPolicyService = createFridayAutonomyPolicyService({
     db: deps.db,
     nowIso: deps.nowIso,
+    // METHOD-level retirement guard: plumb the same test-oracle flag the route
+    // honors so the shared service instance (also wired into the agent
+    // controlled-autonomy tool's `policy_update`) fails closed for every
+    // non-route caller unless explicitly enabled. Production leaves this unset.
+    allowTestOnlyAutonomyPolicyMutation: deps.allowTestOnlyAutonomyPolicyMutation,
   });
   const capabilityAcquisitionService = createFridayCapabilityAcquisitionService({
     db: deps.db,

--- a/src/autonomy/services/friday-autonomy-policy-service.ts
+++ b/src/autonomy/services/friday-autonomy-policy-service.ts
@@ -12,6 +12,18 @@ import type {
 export interface CreateFridayAutonomyPolicyServiceDeps {
   db: FridaySqliteLayer;
   nowIso: () => string;
+  /**
+   * Test-oracle ONLY. When not explicitly `true`, the autonomy-policy mutation
+   * `updatePolicy` method fails closed at the METHOD boundary (not just the HTTP
+   * route), so every non-route caller — the agent controlled-autonomy tool
+   * (`policy_update`) and any future autonomous caller — is fenced out of TS
+   * autonomy-policy mutation while runtime ownership is moved to Rust. Production
+   * hub bootstrap leaves this unset → fail-closed. Mirrors the route-level
+   * `allowTestOnlyAutonomyPolicyMutation` guard
+   * (`assertAutonomyPolicyMutationTestOracleAllowed` in `friday-autonomy-routes.ts`)
+   * so both layers honor the same flag.
+   */
+  allowTestOnlyAutonomyPolicyMutation?: boolean;
 }
 
 export interface FridayUpdateAutonomyPolicyInput {
@@ -235,6 +247,30 @@ export function createFridayAutonomyPolicyService(
   }
 
   function updatePolicy(input: FridayUpdateAutonomyPolicyInput): FridayAutonomyPolicy {
+    // ─── TS Runtime Retirement: METHOD-level fail-closed guard ───
+    // Phase 3 (route-only-guard defect) found the retirement guard was ROUTE-only
+    // (PATCH /v1/autonomy/policy via assertAutonomyPolicyMutationTestOracleAllowed).
+    // The agent controlled-autonomy tool (`policy_update`) reaches this method
+    // directly via `policyService.updatePolicy(...)`, bypassing the HTTP route
+    // guard, so an autonomous agent run could mutate the autonomy policy in prod.
+    // Guarding here fails ALL non-route callers closed BEFORE any DB read or
+    // policy persist — unless the explicit test-oracle flag is set. Never default
+    // this flag on in prod. Reads (getPolicy/evaluateRisks) stay live; only
+    // mutation is retired, mirroring the route which asserts only on mutation.
+    if (deps.allowTestOnlyAutonomyPolicyMutation !== true) {
+      void input;
+      throw new FridayDomainError(
+        "TS_RUNTIME_AUTONOMY_POLICY_MUTATION_RETIRED",
+        "TypeScript autonomy policy mutation is fail-closed in default/live runtime; use the Rust-owned autonomy_policy_mutation entrypoint.",
+        {
+          httpStatus: 503,
+          details: {
+            classification: "fail_closed",
+            replacement: "rust_owned_autonomy_policy_mutation_entrypoint_required",
+          },
+        },
+      );
+    }
     const current = getPolicy();
     const nextMode = input.mode ?? current.mode;
     const modeSwitches = input.mode === "max_autonomy"

--- a/test/unit/autonomy/friday-controlled-autonomy-services.test.ts
+++ b/test/unit/autonomy/friday-controlled-autonomy-services.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { FridaySqliteLayer } from "#state";
 import type { FridayRuntimeCapabilityId, FridayRuntimeCapabilityMatrix } from "#providers";
+import { FridayDomainError } from "#errors";
 import {
   createFridayAutonomyPolicyService,
   createFridayCapabilityAcquisitionService,
@@ -358,15 +359,69 @@ describe("controlled autonomy closed loops", () => {
   });
 
   it("keeps OAuth, payment, CAPTCHA, and sensitive permissions human-gated even in max autonomy", () => {
-    const policy = policyService.updatePolicy({ mode: "max_autonomy" });
+    // updatePolicy is METHOD-level fail-closed (TS-runtime retirement) unless the
+    // explicit test-oracle flag is set, so this behavioral assertion uses a local
+    // flagged service. The default-off behavior is covered by the dedicated
+    // fail-closed tests below; the shared `policyService` stays unflagged.
+    const flaggedPolicyService = createFridayAutonomyPolicyService({
+      db,
+      nowIso: () => `2026-04-25T00:00:${String(++nowCounter).padStart(2, "0")}.000Z`,
+      allowTestOnlyAutonomyPolicyMutation: true,
+    });
+    const policy = flaggedPolicyService.updatePolicy({ mode: "max_autonomy" });
 
     expect(policy.mode).toBe("max_autonomy");
     expect(policy.riskSwitches.external_download).toBe(true);
     expect(policy.riskSwitches.oauth).toBe(false);
 
-    const decision = policyService.evaluateRisks(["oauth", "payment", "captcha", "sensitive_permission"]);
+    const decision = flaggedPolicyService.evaluateRisks(["oauth", "payment", "captcha", "sensitive_permission"]);
     expect(decision.allowed).toBe(false);
     expect(decision.hardHumanBlockers.length).toBe(4);
+  });
+
+  describe("TS-runtime retirement: updatePolicy METHOD-level fail-closed guard", () => {
+    it("fails closed for non-route callers when the test-oracle flag is unset and does NOT mutate the policy", () => {
+      // The shared `policyService` is constructed without
+      // allowTestOnlyAutonomyPolicyMutation (mirrors production/runtime + the
+      // agent controlled-autonomy tool's `policy_update` path). Mutation must be
+      // fenced BEFORE any persist.
+      const before = policyService.getPolicy();
+      expect(before.mode).toBe("low_risk_auto");
+
+      let thrown: unknown;
+      try {
+        policyService.updatePolicy({ mode: "max_autonomy", paused: true });
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeInstanceOf(FridayDomainError);
+      expect(thrown).toMatchObject({
+        code: "TS_RUNTIME_AUTONOMY_POLICY_MUTATION_RETIRED",
+        httpStatus: 503,
+      });
+
+      // No persist/mutation happened: reads stay live and unchanged.
+      const after = policyService.getPolicy();
+      expect(after.mode).toBe("low_risk_auto");
+      expect(after.paused).toBe(false);
+    });
+
+    it("allows the test-oracle path to mutate the policy when the flag is set to true", () => {
+      const flaggedPolicyService = createFridayAutonomyPolicyService({
+        db,
+        nowIso: () => `2026-04-25T00:00:${String(++nowCounter).padStart(2, "0")}.000Z`,
+        allowTestOnlyAutonomyPolicyMutation: true,
+      });
+
+      const updated = flaggedPolicyService.updatePolicy({ mode: "max_autonomy", paused: true });
+      expect(updated.mode).toBe("max_autonomy");
+      expect(updated.paused).toBe(true);
+
+      // The mutation persisted: a fresh read reflects it.
+      expect(flaggedPolicyService.getPolicy().mode).toBe("max_autonomy");
+      expect(flaggedPolicyService.getPolicy().paused).toBe(true);
+    });
   });
 
   it("creates standing-goal agenda and records strategy-only improvement after a low-risk run", async () => {


### PR DESCRIPTION
## Defect (route-only-guard class, Phase-3)

The TS-runtime-retirement guard for autonomy-policy mutation was **ROUTE-only**: `assertAutonomyPolicyMutationTestOracleAllowed` (flag `allowTestOnlyAutonomyPolicyMutation`, const `TS_RUNTIME_AUTONOMY_POLICY_MUTATION_RETIRED`) is asserted only in the HTTP route handler (`src/api/http/routes/friday-autonomy-routes.ts`, def ~309, call ~855). The underlying mutating method `FridayAutonomyPolicyService.updatePolicy` had **no guard**.

The agent controlled-autonomy tool (`src/agent/tools/friday-agent-controlled-autonomy-tool.ts:129`, `case "policy_update"`) reaches `deps.policyService.updatePolicy(...)` directly. That `policyService` is the **same shared instance** (`apiRuntime.autonomyPolicyService`, constructed at `friday-api-runtime.ts:1490`, wired into the tool at `friday-hub-bootstrap.ts:7945`), and the tool is registered unconditionally into the live agentRuntime — so an LLM agent run could mutate the autonomy policy in default/live runtime, **bypassing the 503 route fence**.

## Fix (sanctioned Phase-3 shape — TS method-level fail-closed)

Extend the retirement guard to the **METHOD boundary** so all callers fail closed BEFORE any read/persist, unless the explicit test-oracle flag is set. Mirrors the established method-guard pattern for workflow `startRun` (`friday-workflow-execution-service.ts` ~1211) and the route's own error family (`throwRetiredAutonomyRuntime`).

- Add `allowTestOnlyAutonomyPolicyMutation?: boolean` to `CreateFridayAutonomyPolicyServiceDeps`.
- Guard the **top of `updatePolicy`**: throw `FridayDomainError("TS_RUNTIME_AUTONOMY_POLICY_MUTATION_RETIRED", ..., { httpStatus: 503, details: { classification: "fail_closed", replacement: "rust_owned_autonomy_policy_mutation_entrypoint_required" } })` when the flag is not `true`. (Throws `FridayDomainError` directly — does NOT import the routes helper, to avoid a service→routes dependency.)
- Plumb the flag into the single construction site (`friday-api-runtime.ts:1490`) from `deps.allowTestOnlyAutonomyPolicyMutation`, the same flag the route already receives.
- Reads (`getPolicy`/`evaluateRisks`) stay live; only **mutation** is retired, matching the route (which asserts only on the mutation handler). The route path is unaffected (belt-and-suspenders); the agent-tool path now fail-closes.

## Tests

- **New** — non-route fail-closed: with the flag unset, `updatePolicy` throws `TS_RUNTIME_AUTONOMY_POLICY_MUTATION_RETIRED` (503) and a follow-up `getPolicy()` proves **no mutation persisted**.
- **New** — test-oracle path: with the flag set to `true`, `updatePolicy` succeeds and the change persists.
- **Adapted** — the existing "keeps OAuth/payment/CAPTCHA/sensitive human-gated even in max autonomy" test now constructs a local flagged service (the only prior unguarded `updatePolicy` caller); behavioral assertion preserved (Directive 0b — not weakened/skipped).

## Verification (run in clean worktree off `origin/main` 79d3efb3)

- `npm run check:ts-runtime-retirement -- --json`: `status: passed`, `blockerFamilies: []`, `failures: []` — blocker=0, unchanged from pre-edit baseline.
- Targeted vitest `test/unit/autonomy/friday-controlled-autonomy-services.test.ts`: **12/12 passed**, "Type Errors: no errors" (includes both new tests + adapted test).
- `npm run check:secret-patterns`: no secrets found.
- `git diff --check`: clean.
- `npx eslint` on the 3 changed files: **0 errors** (only pre-existing warnings on untouched lines; `eslint .` = no `--max-warnings`).
- `git diff --name-only origin/main..HEAD`: exactly 3 files (service, runtime plumbing, test) — no workflow runtime files, no other surfaces.
- Note: a full `tsc --noEmit` reports 4 errors, all in the **untouched** file `src/channels/lark/internal/lark-ws-client.ts` (missing `@types/ws` in this worktree's borrowed node_modules) — pre-existing, absent from green main CI (#596), not introduced here; the 3 changed files typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)