### PR TITLE
feat(rust): session-memory ownership-binding — composite namespace parity (slice 3)

### DIFF
--- a/rust-core/crates/friday-hub/src/bin/hub_extract_memory.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_extract_memory.rs
@@ -18,6 +18,17 @@
 //!   only counts. The persisted candidates are NON-DURABLE (`state = Candidate`) —
 //!   they require explicit confirm to become recallable.
 //!
+//! ## Slice-3 ownership-binding — `--principal` is now a PROOF-TIME ASSERTION
+//! The store SCOPE is DERIVED from the SESSION owner (the composite namespace
+//! `tenant.<account>.channel.<channel>.user.<user>.shared`), NOT a caller-supplied
+//! principal. The `--principal` arg is therefore OPTIONAL and, when supplied, is treated
+//! as an ASSERTION: it MUST equal the derived namespace, else the emit FAILS CLOSED
+//! (`error_kind="principal_mismatch"`, exit 2). This lets the coordinator's live-proof
+//! pin the expected store scope without ever overriding it. The derived namespace is
+//! echoed back as `principal_id` (a store-scope LABEL — composed from normalized ids,
+//! never a body) so the isolation proof is legible. A session with no resolvable owner
+//! `user_id` fails closed (`error_kind="namespace_unresolvable"`).
+//!
 //! ## CI vs live
 //! CI only BUILDS this bin (it names it explicitly so a compile break reds CI).
 //! Running it needs `FRIDAY_DEEPSEEK_API_KEY` + a real session DB and spends quota,
@@ -25,7 +36,8 @@
 //!
 //! ## Output contract — REFS ONLY
 //! A single JSON object: `truth_label="rust_inline_memory_extraction"`,
-//! `proof_only=true`, `ok`, the session/principal IDs (caller-supplied refs),
+//! `proof_only=true`, `ok`, the session ID (a ref), the DERIVED `principal_id`
+//! (= the composite namespace store scope — a label, never a body),
 //! `messages_read`, `items_parsed`, `sensitive_dropped`, `candidates_created`,
 //! `messages_marked_extracted` (the slice-2 dedup mark — how many source messages this
 //! run consumed so a re-run skips them), and token counts (`prompt`/`completion`/
@@ -84,7 +96,9 @@ fn run() -> Result<String, ExtractError> {
         return Err(ExtractError::new("db_not_found"));
     }
     let session_id = arg_value(&args, "--session").ok_or(ExtractError::new("bad_args"))?;
-    let principal_id = arg_value(&args, "--principal").ok_or(ExtractError::new("bad_args"))?;
+    // Slice-3: `--principal` is now OPTIONAL and is a proof-time ASSERTION (it must equal
+    // the SESSION-derived namespace), NOT the store key. Absent = no assertion.
+    let asserted_principal = arg_value(&args, "--principal");
 
     // Live provider client from the Hub env (FRIDAY_DEEPSEEK_API_KEY). A missing
     // credential fails CLOSED (never a fallback) — coarse category only.
@@ -100,7 +114,6 @@ fn run() -> Result<String, ExtractError> {
     let outcome = extract_inline(
         &mut db,
         &session_id,
-        &principal_id,
         &client,
         DEFAULT_MAX_ITEMS,
         &id_prefix,
@@ -109,14 +122,25 @@ fn run() -> Result<String, ExtractError> {
     )
     .map_err(map_extract_err)?;
 
+    // Slice-3 assertion: if the operator pinned an expected store scope via `--principal`,
+    // it MUST equal the derived namespace — else FAIL CLOSED (the proof would otherwise
+    // claim a scope the data is not actually stored under).
+    if let Some(expected) = asserted_principal.as_deref() {
+        if expected != outcome.derived_namespace {
+            return Err(ExtractError::new("principal_mismatch"));
+        }
+    }
+
     let payload = json!({
         "truth_label": "rust_inline_memory_extraction",
         "proof_only": true,
         "ts_path_live": true,
         "queue_auto_deferred": true,
+        "ownership_binding": true,
         "ok": true,
         "session_id": session_id,
-        "principal_id": principal_id,
+        // The DERIVED store scope (the composite namespace) — slice-3 ownership-binding.
+        "principal_id": outcome.derived_namespace,
         "messages_read": outcome.messages_read,
         "items_parsed": outcome.items_parsed,
         "sensitive_dropped": outcome.sensitive_dropped,
@@ -143,6 +167,8 @@ fn map_extract_err(e: friday_hub::memory_extraction::ExtractionError) -> Extract
         E::Provider(_) => ExtractError::new("provider_failed"),
         E::Parse => ExtractError::new("parse_failed"),
         E::BadInput(_) => ExtractError::new("bad_args"),
+        // Slice-3: the session's memory namespace is unresolvable (no owner user_id).
+        E::NamespaceUnresolvable(_) => ExtractError::new("namespace_unresolvable"),
     }
 }
 
@@ -252,5 +278,40 @@ mod tests {
         });
         let rendered = payload.to_string();
         assert!(reject_forbidden_output(&rendered).is_ok());
+    }
+
+    #[test]
+    fn derived_namespace_principal_is_guard_clean() {
+        // Slice-3: the echoed `principal_id` is the composite namespace store scope (a
+        // label of normalized ids + dots) — it must pass the refs-only guard.
+        let ns = "tenant.default.channel.discord.user.user-abc.shared";
+        let payload = json!({
+            "truth_label": "rust_inline_memory_extraction",
+            "proof_only": true,
+            "ownership_binding": true,
+            "ok": true,
+            "session_id": "s1",
+            "principal_id": ns,
+            "candidates_created": 1,
+            "token_total": 55,
+            "model": "deepseek-v4-flash",
+        });
+        let rendered = serde_json::to_string(&payload).unwrap();
+        assert!(reject_forbidden_output(&rendered).is_ok());
+        let parsed: Value = from_str(&rendered).unwrap();
+        assert_eq!(parsed["principal_id"], ns);
+    }
+
+    #[test]
+    fn namespace_unresolvable_error_payload_passes_guard() {
+        let payload = json!({
+            "truth_label": "rust_inline_memory_extraction",
+            "proof_only": true,
+            "ok": false,
+            "error_kind": "namespace_unresolvable",
+        });
+        assert!(reject_forbidden_output(&payload.to_string()).is_ok());
+        let mismatch = json!({"ok": false, "error_kind": "principal_mismatch"});
+        assert!(reject_forbidden_output(&mismatch.to_string()).is_ok());
     }
 }

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -178,6 +178,14 @@ pub mod sensitive_guard;
 /// path STAYS LIVE (parity pending); queue/auto deferred. PROOF-ONLY, NOT a v1 GO.
 pub mod memory_extraction;
 
+/// Session-memory slice-3 (ownership-binding): faithful Rust port of the TS
+/// `resolveFridaySessionMemoryNamespace` — the composite memory store SCOPE
+/// (`tenant.<account>.channel.<channel>.user.<user>.shared`) DERIVED from a session's
+/// owner axes, fail-closed when no userId. This is what binds extraction's store scope to
+/// the SESSION (not a caller-supplied principal). DM-chatId + subagent parent-walk userId
+/// fallbacks are DEFERRED-PARITY. PROOF-ONLY, NOT a v1 GO.
+pub mod session_namespace;
+
 use friday_core::gate::{
     canonical_action_bytes, canonical_approval_signature_bytes, ActorKind, ApprovalDecision,
     CanonicalApproval, GateDecision, MutatingActionRequest, CANONICAL_GATE_ISSUER,

--- a/rust-core/crates/friday-hub/src/memory_extraction.rs
+++ b/rust-core/crates/friday-hub/src/memory_extraction.rs
@@ -185,7 +185,9 @@ pub struct ExtractionOutcome {
     /// The DERIVED memory namespace (slice-3) under which candidates were stored as
     /// `principal_id` — `tenant.<account>.channel.<channel>.user.<user>.shared`. This is a
     /// store-scope LABEL (composed from normalized session-owner ids), NOT a body, so it is
-    /// refs-only safe to render. Empty for the no-pending early return (nothing was stored).
+    /// refs-only safe to render. ALWAYS non-empty on a successful return: it is resolved
+    /// (fail-closed if unresolvable) BEFORE the no-pending early return, so even the
+    /// nothing-to-extract path reports the namespace the session WOULD store under.
     pub derived_namespace: String,
 }
 

--- a/rust-core/crates/friday-hub/src/memory_extraction.rs
+++ b/rust-core/crates/friday-hub/src/memory_extraction.rs
@@ -60,18 +60,42 @@
 //!   time — faithful to the TS, which stores raw non-keyword PII and redacts on
 //!   recall. The sensitivity guard here drops KEYWORD-bearing items (passwords,
 //!   tokens, SSN/credit-card words, medical/financial/…), matching the TS guard.
-//! - **Queue / auto mode + ownership-binding still DEFERRED.** Only the inline manual
-//!   path; the queue/job-retry/auto machine and ownership-claim binding are follow-on
-//!   slices (the principal is a caller-supplied ref).
 //!
-//! Truth label: Rust-owned INLINE extraction, slice-2 (dedup + transactional). The TS
-//! extraction path STAYS LIVE (full parity — queue/auto + ownership-binding — pending).
-//! PROOF-ONLY — NOT a v1 GO.
+//! ## Slice-3 (ownership-binding) — the store SCOPE is DERIVED from the SESSION
+//! The extraction's memory store scope is no longer a caller-supplied principal: it is
+//! DERIVED from the session's OWNER axes via [`crate::session_namespace`], a faithful port
+//! of the TS `resolveFridaySessionMemoryNamespace`. The Rust recall axis is a single
+//! `principal_id` string, so slice-3 sets **`principal_id` := the composite namespace**
+//! `tenant.<account>.channel.<channel>.user.<user>.shared` (with `scope` still
+//! `MemoryScope::Session`). This preserves per-(account, channel, user) isolation on the
+//! existing recall axis — faithful to the TS production model where extraction is
+//! job-driven (there is NO caller principal) and the session is the source of truth.
+//!
+//! **Fail-closed on no userId (PARITY).** If the session has no `user_id`, the namespace
+//! is UNRESOLVABLE and extraction FAILS CLOSED ([`ExtractionError::NamespaceUnresolvable`])
+//! — mirroring the TS `MEMORY_NAMESPACE_UNRESOLVABLE` throw. A session is never silently
+//! bound to a default/anonymous scope.
+//!
+//! **Deferred-parity (HONEST).** Only the DIRECT `session.userId` case is ported. The TS
+//! DM-chatId fallback and subagent parent-chain userId walk are DEFERRED — the Rust
+//! `agent_session` does not model `chatKind`/`chatId`/`parentSession` yet (see
+//! [`crate::session_namespace`]). Live sessions created via the production
+//! `run_session_loop` still call the OWNER-LESS `ensure_session`, so they carry a NULL
+//! owner and CANNOT be extracted until a follow-on wires the owner through — that wiring
+//! is out of scope for this slice (it lives in the off-limits loop entrypoint).
+//!
+//! - **Queue / auto mode still DEFERRED.** Only the inline manual path; the
+//!   queue/job-retry/auto machine is a follow-on slice.
+//!
+//! Truth label: Rust-owned INLINE extraction, slice-3 (dedup + transactional +
+//! ownership-binding). The TS extraction path STAYS LIVE (full parity — queue/auto +
+//! DM/subagent userId fallbacks — pending). PROOF-ONLY — NOT a v1 GO.
 
 use friday_core::MemoryScope;
 use friday_deepseek::{DeepSeekClient, DeepSeekError, Transport};
 use friday_storage::agent_session::{
-    load_pending_session_messages, mark_messages_extracted, StoredSessionMessage,
+    load_pending_session_messages, load_session_owner, mark_messages_extracted,
+    StoredSessionMessage,
 };
 use friday_storage::memory::{record_candidate, NewMemoryCandidate};
 use friday_storage::StorageError;
@@ -79,6 +103,7 @@ use serde_json::Value;
 use std::collections::HashSet;
 
 use crate::sensitive_guard::is_sensitive_learning_candidate;
+use crate::session_namespace::{resolve_session_memory_namespace, NamespaceError};
 
 /// The valid item kinds (ported from the TS `VALID_KINDS`).
 const VALID_KINDS: &[&str] = &["fact", "decision", "preference", "action_item"];
@@ -157,6 +182,11 @@ pub struct ExtractionOutcome {
     pub total_tokens: i64,
     /// The reported model id (a safe label — never a secret).
     pub model: String,
+    /// The DERIVED memory namespace (slice-3) under which candidates were stored as
+    /// `principal_id` — `tenant.<account>.channel.<channel>.user.<user>.shared`. This is a
+    /// store-scope LABEL (composed from normalized session-owner ids), NOT a body, so it is
+    /// refs-only safe to render. Empty for the no-pending early return (nothing was stored).
+    pub derived_namespace: String,
 }
 
 /// Errors specific to the extraction engine (provider/storage/parse). Coarse and
@@ -169,8 +199,12 @@ pub enum ExtractionError {
     /// The model output did not parse into the documented `{ "items": [...] }`
     /// shape. Carries NO model text (coarse, never echoes the body).
     Parse,
-    /// `--principal` / session id was blank.
+    /// session id was blank.
     BadInput(&'static str),
+    /// Slice-3: the session's memory namespace could not be resolved (no `user_id` on the
+    /// session). FAILS CLOSED — parity with the TS `MEMORY_NAMESPACE_UNRESOLVABLE` throw.
+    /// Carries the typed [`NamespaceError`] (coarse + secret-free by construction).
+    NamespaceUnresolvable(NamespaceError),
 }
 
 impl std::fmt::Display for ExtractionError {
@@ -180,6 +214,7 @@ impl std::fmt::Display for ExtractionError {
             ExtractionError::Provider(e) => write!(f, "provider error: {e}"),
             ExtractionError::Parse => write!(f, "model output parse error"),
             ExtractionError::BadInput(w) => write!(f, "bad input: {w}"),
+            ExtractionError::NamespaceUnresolvable(e) => write!(f, "{e}"),
         }
     }
 }
@@ -194,6 +229,11 @@ impl From<StorageError> for ExtractionError {
 impl From<DeepSeekError> for ExtractionError {
     fn from(e: DeepSeekError) -> Self {
         ExtractionError::Provider(e)
+    }
+}
+impl From<NamespaceError> for ExtractionError {
+    fn from(e: NamespaceError) -> Self {
+        ExtractionError::NamespaceUnresolvable(e)
     }
 }
 
@@ -355,8 +395,8 @@ pub fn filter_sensitive(
     (safe, dropped)
 }
 
-/// Run one INLINE manual extraction for a session: read messages → prompt →
-/// provider call (ledgered) → parse → sensitivity-filter → persist candidates.
+/// Run one INLINE manual extraction for a session: derive namespace → read messages →
+/// prompt → provider call (ledgered) → parse → sensitivity-filter → persist candidates.
 ///
 /// `client` is generic over [`Transport`] so tests inject a mock provider and the
 /// bin passes a live `DeepSeekClient::from_env()`. The call+ledger reuses
@@ -368,11 +408,20 @@ pub fn filter_sensitive(
 /// `"<session>:extract:<now_ms>"`). Slice-2 makes re-runs IDEMPOTENT at the source:
 /// only PENDING messages are read, and a successful run marks the processed messages
 /// `'extracted'`, so a second run reads no pending and creates no duplicate candidates.
+///
+/// ## Slice-3 ownership-binding (the store SCOPE is DERIVED from the SESSION)
+/// There is NO caller-supplied principal: the store scope (`principal_id`) is DERIVED
+/// from the session's OWNER axes (`account_id`/`channel`/`user_id`, loaded via
+/// [`load_session_owner`]) through [`resolve_session_memory_namespace`] —
+/// `tenant.<account>.channel.<channel>.user.<user>.shared`. If the session has no
+/// `user_id` (the namespace is unresolvable), extraction FAILS CLOSED
+/// ([`ExtractionError::NamespaceUnresolvable`]) BEFORE any provider call — parity with the
+/// TS `MEMORY_NAMESPACE_UNRESOLVABLE`. The derived namespace is echoed in
+/// [`ExtractionOutcome::derived_namespace`].
 #[allow(clippy::too_many_arguments)]
 pub fn extract_inline<T: Transport>(
     db: &mut friday_storage::Db,
     session_id: &str,
-    principal_id: &str,
     client: &DeepSeekClient<T>,
     max_items: usize,
     candidate_id_prefix: &str,
@@ -382,9 +431,21 @@ pub fn extract_inline<T: Transport>(
     if session_id.trim().is_empty() {
         return Err(ExtractionError::BadInput("session_id"));
     }
-    if principal_id.trim().is_empty() {
-        return Err(ExtractionError::BadInput("principal_id"));
-    }
+
+    // Slice-3 ownership-binding: DERIVE the store scope from the SESSION (not a caller
+    // principal). Load the session's owner axes and resolve the composite namespace. A
+    // session with no `user_id` FAILS CLOSED here — BEFORE any provider call — mirroring
+    // the TS `MEMORY_NAMESPACE_UNRESOLVABLE` throw. An absent session row also has no
+    // owner, so it fails closed identically (None owner → unresolvable).
+    let owner = load_session_owner(db.conn(), session_id)?.unwrap_or_default();
+    let derived_namespace = resolve_session_memory_namespace(
+        owner.account_id.as_deref(),
+        owner.channel.as_deref(),
+        owner.user_id.as_deref(),
+    )?;
+    // The derived namespace IS the store key (the Rust recall axis is a single
+    // `principal_id` string; slice-3 sets it to the composite namespace).
+    let principal_id = derived_namespace.as_str();
 
     // Slice-2 dedup: read only the messages not yet consumed by a prior extraction.
     let messages = load_pending_session_messages(db.conn(), session_id)?;
@@ -404,6 +465,7 @@ pub fn extract_inline<T: Transport>(
             completion_tokens: 0,
             total_tokens: 0,
             model: String::new(),
+            derived_namespace,
         });
     }
 
@@ -462,6 +524,8 @@ pub fn extract_inline<T: Transport>(
                 // The recallable inline text; raw PII (non-keyword) is redacted at
                 // RECALL time by cognition::rank_recall (parity with the TS).
                 content: Some(item.content.as_str()),
+                // Slice-3: the store scope is the SESSION-DERIVED namespace (not a caller
+                // principal). This is what makes recall isolated per (account, channel, user).
                 principal_id: Some(principal_id),
                 // Sensitive items are DROPPED above (never persisted), so the column is
                 // always false for a stored candidate.
@@ -484,6 +548,7 @@ pub fn extract_inline<T: Transport>(
         completion_tokens: outcome.completion_tokens,
         total_tokens: outcome.total_tokens,
         model: outcome.model,
+        derived_namespace,
     })
 }
 
@@ -491,10 +556,24 @@ pub fn extract_inline<T: Transport>(
 mod tests {
     use super::*;
     use friday_deepseek::{DeepSeekClient, Transport};
-    use friday_storage::agent_session::{append_session_message, ensure_session, SessionMessage};
+    use friday_storage::agent_session::{
+        append_session_message, ensure_session_with_owner, SessionMessage, SessionOwner,
+    };
     use friday_storage::memory::{confirm, pending_review, recall_confirmed};
     use serde_json::{json, Value};
     use std::sync::atomic::{AtomicU64, Ordering};
+
+    /// The namespace a `seed_session`-created session resolves to (its owner is
+    /// account="default", channel="discord", user=<user_id>). Centralized so the slice-3
+    /// derived-`principal_id` assertions stay byte-aligned with the resolver.
+    fn ns_for(user_id: &str) -> String {
+        crate::session_namespace::resolve_session_memory_namespace(
+            Some("default"),
+            Some("discord"),
+            Some(user_id),
+        )
+        .unwrap()
+    }
 
     static C: AtomicU64 = AtomicU64::new(0);
     fn tmp(tag: &str) -> String {
@@ -551,8 +630,21 @@ mod tests {
         DeepSeekClient::with_transport(ScriptedTransport::new(content), "test-key-not-real".into())
     }
 
-    fn seed_session(db: &friday_storage::Db, session: &str) -> Vec<String> {
-        ensure_session(db.conn(), session, 1).unwrap();
+    /// Seed a session WITH an owner (slice-3: extraction now requires a resolvable
+    /// namespace). The owner is account="default", channel="discord", user=`user_id`, so
+    /// the derived store scope is `ns_for(user_id)`.
+    fn seed_session(db: &friday_storage::Db, session: &str, user_id: &str) -> Vec<String> {
+        ensure_session_with_owner(
+            db.conn(),
+            session,
+            &SessionOwner {
+                account_id: Some("default".into()),
+                channel: Some("discord".into()),
+                user_id: Some(user_id.into()),
+            },
+            1,
+        )
+        .unwrap();
         let m0 = append_session_message(
             db.conn(),
             session,
@@ -573,7 +665,9 @@ mod tests {
     #[test]
     fn extract_persists_candidates_and_recall_reads_them_back_after_confirm() {
         let mut db = friday_storage::Db::open_hub(&tmp("consistency")).unwrap();
-        let ids = seed_session(&db, "s1");
+        let ids = seed_session(&db, "s1", "alice");
+        // Slice-3: the store scope is the SESSION-DERIVED namespace, not a caller principal.
+        let ns = ns_for("alice");
         // Mock extraction returns one valid item referencing a real message id.
         let content = json!({
             "items": [{
@@ -589,7 +683,6 @@ mod tests {
         let out = extract_inline(
             &mut db,
             "s1",
-            "alice",
             &c,
             DEFAULT_MAX_ITEMS,
             "s1:ex:100",
@@ -605,33 +698,41 @@ mod tests {
         // single item referenced) — the dedup mark.
         assert_eq!(out.messages_marked_extracted, 2);
         assert_eq!(out.total_tokens, 55);
+        // slice-3: the outcome echoes the derived namespace (the store scope).
+        assert_eq!(out.derived_namespace, ns);
 
         // The token ledger row was written (the extraction call is ledgered).
         let ledger_rows = db.count("token_ledger").unwrap();
         assert_eq!(ledger_rows, 1);
 
-        // Existing spine: the candidate shows up as pending_review (NOT durable yet).
+        // Existing spine: the candidate shows up as pending_review (NOT durable yet), stored
+        // under the DERIVED namespace as its `principal_id` (slice-3 ownership-binding).
         let pending = pending_review(db.conn()).unwrap();
         assert_eq!(pending.len(), 1);
         assert_eq!(pending[0].memory_id, "s1:ex:100:c0");
-        assert_eq!(pending[0].principal_id.as_deref(), Some("alice"));
+        assert_eq!(pending[0].principal_id.as_deref(), Some(ns.as_str()));
         // recall_confirmed returns NOTHING until the candidate is confirmed.
-        assert!(recall_confirmed(db.conn(), "alice").unwrap().is_empty());
+        assert!(recall_confirmed(db.conn(), &ns).unwrap().is_empty());
 
-        // Confirm via the existing path → it becomes recallable (consistency proof).
+        // Confirm via the existing path → it becomes recallable under the namespace
+        // (consistency proof: store→confirm→recall keyed by the SESSION-derived scope).
         confirm(db.conn(), "s1:ex:100:c0", 200).unwrap();
-        let recalled = recall_confirmed(db.conn(), "alice").unwrap();
+        let recalled = recall_confirmed(db.conn(), &ns).unwrap();
         assert_eq!(recalled.len(), 1);
         assert_eq!(
             recalled[0].content.as_deref(),
             Some("User's project codename is Falcon.")
         );
+        // ISOLATION: a DIFFERENT user's namespace recalls nothing (per-(account,channel,user)).
+        assert!(recall_confirmed(db.conn(), &ns_for("mallory"))
+            .unwrap()
+            .is_empty());
     }
 
     #[test]
     fn sensitive_item_is_dropped_not_stored() {
         let mut db = friday_storage::Db::open_hub(&tmp("sensitive")).unwrap();
-        let ids = seed_session(&db, "s2");
+        let ids = seed_session(&db, "s2", "bob");
         // Two items: one benign, one whose content carries a sensitive KEYWORD.
         let content = json!({
             "items": [
@@ -645,7 +746,6 @@ mod tests {
         let out = extract_inline(
             &mut db,
             "s2",
-            "bob",
             &c,
             DEFAULT_MAX_ITEMS,
             "s2:ex:100",
@@ -680,7 +780,8 @@ mod tests {
         // it via cognition::rank_recall. This proves the store→confirm→recall→redact
         // loop is consistent end-to-end with no new store-time redaction.
         let mut db = friday_storage::Db::open_hub(&tmp("pii")).unwrap();
-        let ids = seed_session(&db, "s3");
+        let ids = seed_session(&db, "s3", "carol");
+        let ns = ns_for("carol");
         let content = json!({
             "items": [{
                 "kind":"fact",
@@ -694,7 +795,6 @@ mod tests {
         let out = extract_inline(
             &mut db,
             "s3",
-            "carol",
             &c,
             DEFAULT_MAX_ITEMS,
             "s3:ex:100",
@@ -707,7 +807,7 @@ mod tests {
         assert_eq!(out.sensitive_dropped, 0);
 
         confirm(db.conn(), "s3:ex:100:c0", 200).unwrap();
-        let rows = recall_confirmed(db.conn(), "carol").unwrap();
+        let rows = recall_confirmed(db.conn(), &ns).unwrap();
         let ranked = crate::cognition::rank_recall(
             &rows,
             300,
@@ -723,7 +823,19 @@ mod tests {
     #[test]
     fn empty_session_extracts_nothing_without_calling_provider() {
         let mut db = friday_storage::Db::open_hub(&tmp("empty")).unwrap();
-        ensure_session(db.conn(), "s4", 1).unwrap();
+        // Slice-3: the session must have a RESOLVABLE owner (else it fails closed BEFORE
+        // the empty-message early-return). Bind an owner, then leave the session message-less.
+        ensure_session_with_owner(
+            db.conn(),
+            "s4",
+            &SessionOwner {
+                account_id: Some("default".into()),
+                channel: Some("discord".into()),
+                user_id: Some("dave".into()),
+            },
+            1,
+        )
+        .unwrap();
         // A transport that PANICS if posted to — proves the empty-session path makes
         // ZERO provider calls (it must early-return before any chat/discover).
         struct PanicTransport;
@@ -739,7 +851,6 @@ mod tests {
         let out = extract_inline(
             &mut db,
             "s4",
-            "dave",
             &c,
             DEFAULT_MAX_ITEMS,
             "s4:ex:100",
@@ -751,6 +862,68 @@ mod tests {
         assert_eq!(out.candidates_created, 0);
         assert_eq!(out.messages_marked_extracted, 0);
         assert_eq!(db.count("token_ledger").unwrap(), 0);
+        // Even with no messages, the derived namespace is echoed (it was resolved first).
+        assert_eq!(out.derived_namespace, ns_for("dave"));
+    }
+
+    #[test]
+    fn session_without_user_id_fails_closed_before_any_provider_call() {
+        // Slice-3 PARITY: a session with NO owner user_id has an UNRESOLVABLE memory
+        // namespace, so extraction FAILS CLOSED (mirrors the TS MEMORY_NAMESPACE_UNRESOLVABLE
+        // throw) BEFORE the provider is ever contacted — even though the session has messages.
+        let mut db = friday_storage::Db::open_hub(&tmp("nouser")).unwrap();
+        // Owner-less session (account/channel set but user_id absent) WITH a message.
+        ensure_session_with_owner(
+            db.conn(),
+            "s1",
+            &SessionOwner {
+                account_id: Some("default".into()),
+                channel: Some("discord".into()),
+                user_id: None,
+            },
+            1,
+        )
+        .unwrap();
+        append_session_message(
+            db.conn(),
+            "s1",
+            &SessionMessage::new("user", "remember 47", None),
+            10,
+        )
+        .unwrap();
+
+        struct PanicTransport;
+        impl Transport for PanicTransport {
+            fn get_json(&self, _u: &str, _b: &str) -> Result<Value, DeepSeekError> {
+                panic!("unresolvable namespace must fail closed before discover");
+            }
+            fn post_json(&self, _u: &str, _b: &str, _body: &Value) -> Result<Value, DeepSeekError> {
+                panic!("unresolvable namespace must fail closed before provider call");
+            }
+        }
+        let c = DeepSeekClient::with_transport(PanicTransport, "test-key-not-real".into());
+        let err = extract_inline(
+            &mut db,
+            "s1",
+            &c,
+            DEFAULT_MAX_ITEMS,
+            "s1:ex:100",
+            "led-1",
+            100,
+        )
+        .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                ExtractionError::NamespaceUnresolvable(NamespaceError::UnresolvableNoUserId)
+            ),
+            "no user_id must be a fail-closed namespace error, got {err:?}"
+        );
+        // No provider call, no ledger row, no candidate.
+        assert_eq!(db.count("token_ledger").unwrap(), 0);
+        assert_eq!(db.count("memory_item").unwrap(), 0);
+        // ...and the message is NOT consumed (it stays pending for a retry once owned).
+        assert_eq!(status_of(&db, "s1:m0"), "pending");
     }
 
     /// Read one message's `memory_extract_status` (test-only helper for the slice-2
@@ -772,7 +945,7 @@ mod tests {
         // calls the provider). seed_session gives a referenced + an unreferenced message,
         // so the unchanged-ledger assertion catches "marked only the referenced id".
         let mut db = friday_storage::Db::open_hub(&tmp("dedup")).unwrap();
-        let ids = seed_session(&db, "s1");
+        let ids = seed_session(&db, "s1", "alice");
         let content = json!({
             "items": [{
                 "kind": "preference",
@@ -788,7 +961,6 @@ mod tests {
         let out1 = extract_inline(
             &mut db,
             "s1",
-            "alice",
             &c,
             DEFAULT_MAX_ITEMS,
             "s1:ex:100",
@@ -823,7 +995,6 @@ mod tests {
         let out2 = extract_inline(
             &mut db,
             "s1",
-            "alice",
             &c2,
             DEFAULT_MAX_ITEMS,
             "s1:ex:200",
@@ -855,7 +1026,7 @@ mod tests {
         // the PRIMARY KEY mid-loop → the whole tx drops → BOTH the c0 candidate AND the
         // extracted-marks roll back (all-or-nothing). No test seam in `extract_inline`.
         let mut db = friday_storage::Db::open_hub(&tmp("rollback")).unwrap();
-        let ids = seed_session(&db, "s1");
+        let ids = seed_session(&db, "s1", "alice");
         let content = json!({
             "items": [
                 {"kind":"fact","content":"first item","sourceMessageIds":[ids[0]]},
@@ -865,7 +1036,8 @@ mod tests {
         .to_string();
         let c = client(content);
 
-        // Pre-seed the row the loop will try to mint at i==1, forcing a PK collision.
+        // Pre-seed the row the loop will try to mint at i==1, forcing a PK collision. The
+        // pre-seeded `principal_id` is arbitrary (the collision is on the memory_id PK).
         record_candidate(
             db.conn(),
             &NewMemoryCandidate {
@@ -873,7 +1045,7 @@ mod tests {
                 scope: MemoryScope::Session,
                 content_ref: None,
                 content: Some("pre-existing collision row"),
-                principal_id: Some("alice"),
+                principal_id: Some("pre-seeded"),
                 sensitive: false,
                 created_at: 50,
             },
@@ -883,7 +1055,6 @@ mod tests {
         let err = extract_inline(
             &mut db,
             "s1",
-            "alice",
             &c,
             DEFAULT_MAX_ITEMS,
             "s1:ex:100",
@@ -930,7 +1101,7 @@ mod tests {
         // source messages: they are marked extracted so a re-run does not re-extract them
         // (matches the TS — a dropped item still leaves the pending set).
         let mut db = friday_storage::Db::open_hub(&tmp("dropped")).unwrap();
-        let ids = seed_session(&db, "s1");
+        let ids = seed_session(&db, "s1", "bob");
         let content = json!({
             "items": [
                 {"kind":"fact","content":"User's API key rotation is monthly.","sourceMessageIds":[ids[0]]}
@@ -942,7 +1113,6 @@ mod tests {
         let out = extract_inline(
             &mut db,
             "s1",
-            "bob",
             &c,
             DEFAULT_MAX_ITEMS,
             "s1:ex:100",
@@ -977,7 +1147,6 @@ mod tests {
         let out2 = extract_inline(
             &mut db,
             "s1",
-            "bob",
             &c2,
             DEFAULT_MAX_ITEMS,
             "s1:ex:200",
@@ -989,16 +1158,14 @@ mod tests {
     }
 
     #[test]
-    fn blank_session_or_principal_is_bad_input() {
+    fn blank_session_is_bad_input() {
+        // Slice-3 removed the caller `principal_id` arg (the store scope is now session-
+        // derived), so only the blank-session-id bad-input remains.
         let mut db = friday_storage::Db::open_hub(&tmp("blank")).unwrap();
         let c = client(r#"{"items":[]}"#);
         assert!(matches!(
-            extract_inline(&mut db, "  ", "x", &c, DEFAULT_MAX_ITEMS, "p", "l", 1),
+            extract_inline(&mut db, "  ", &c, DEFAULT_MAX_ITEMS, "p", "l", 1),
             Err(ExtractionError::BadInput("session_id"))
-        ));
-        assert!(matches!(
-            extract_inline(&mut db, "s", "  ", &c, DEFAULT_MAX_ITEMS, "p", "l", 1),
-            Err(ExtractionError::BadInput("principal_id"))
         ));
     }
 

--- a/rust-core/crates/friday-hub/src/session_namespace.rs
+++ b/rust-core/crates/friday-hub/src/session_namespace.rs
@@ -7,7 +7,8 @@
 //! user's memory is isolated PER (account, channel) instead of being shared across every
 //! channel for the same user.
 //!
-//! Format (byte-identical to the TS for ASCII inputs — see the normalization caveat below):
+//! Format (byte-identical to the TS — including the Unicode-aware lowercasing; see the
+//! normalization note on the dot-join residual that is SHARED with the TS oracle):
 //! ```text
 //! tenant.<accountId>.channel.<channel>.user.<normalizedUserId>.shared
 //! ```
@@ -146,16 +147,30 @@ fn falsy_or<'a>(value: Option<&'a str>, fallback: &'a str) -> &'a str {
 /// We implement it with explicit char filtering (no `regex` dependency needed) and verify
 /// equivalence with the ported TS test vectors (`tests` below).
 ///
-/// PARITY CAVEAT (honest): this is byte-identical to the TS for ASCII inputs — the only
-/// inputs real session userIds/accountIds/channels take. The lowercasing uses
-/// `to_ascii_lowercase`, whereas JS `String.toLowerCase()` is Unicode-aware. They diverge
-/// ONLY for the rare non-ASCII char that JS lowercases INTO a kept ASCII char (e.g. the
-/// Kelvin sign `K` → ASCII `k`, or `İ` → `i`): JS would keep it, this port maps it to `-`
-/// (outside the ASCII keep-set). For every other non-ASCII char both map to `-`. This is a
-/// documented parity gap, not a silent divergence; it is irrelevant for ASCII ids.
+/// LOWERCASING (byte-parity with JS `String.toLowerCase()`): Step 1 uses Rust
+/// `str::to_lowercase()`, which — like JS `.toLowerCase()` — implements the Unicode
+/// DEFAULT case mapping (NOT plain ASCII lowering). So a non-ASCII char that JS lowercases
+/// INTO a kept ASCII char also lowers here BEFORE the keep-set filter, and is therefore
+/// kept identically: e.g. the Kelvin sign `K` (U+212A) → `k`, which is in `[a-z0-9._-]` and
+/// survives in BOTH impls (closing the earlier `to_ascii_lowercase` divergence where Rust
+/// would have mapped it to `-` and merged it with a plain `user` id — an isolation MERGE in
+/// the dangerous direction). Any char that lowers to something OUTSIDE the keep-set (most
+/// non-ASCII, e.g. `é`, CJK) maps to `-` in both. Both use Unicode default case mapping, so
+/// they agree on the single-codepoint mappings relevant to the keep-set; this is now a
+/// faithful port, not a documented gap.
+///
+/// Residual (genuinely shared with the TS, not a Rust divergence): the dot is in the
+/// keep-set and segments are `.`-joined, so an id literally containing the joiner/segment
+/// words could in principle collide with a different (account, channel, user) triple. This
+/// is byte-faithful to the TS oracle (same unescaped join + same keep-set), so it is NOT a
+/// Rust regression; closing it is a SHARED TS+Rust hardening follow-on (segment-escape /
+/// dot-reject), out of scope for this parity slice.
 pub fn normalize_namespace_segment(value: &str) -> String {
-    // Step 1: toLowerCase() then replace each char NOT in [a-z0-9._-] with '-'.
-    let lowered = value.to_ascii_lowercase();
+    // Step 1: toLowerCase() then replace each char NOT in [a-z0-9._-] with '-'. Use the
+    // Unicode-aware `to_lowercase` (matches JS `.toLowerCase()`), NOT `to_ascii_lowercase`,
+    // so a non-ASCII char JS folds into a kept ASCII char (e.g. Kelvin U+212A -> 'k') is
+    // kept identically here instead of collapsing to '-'.
+    let lowered = value.to_lowercase();
     let mut mapped = String::with_capacity(lowered.len());
     for ch in lowered.chars() {
         if is_kept(ch) {
@@ -334,6 +349,43 @@ mod tests {
         // Non-ASCII is outside the keep-set and becomes '-' (then collapses/trims).
         assert_eq!(normalize_namespace_segment("héllo"), "h-llo");
         assert_eq!(normalize_namespace_segment("名前"), "default");
+    }
+
+    #[test]
+    fn unicode_lowercasing_matches_js_tolowercase_no_isolation_merge() {
+        // REGRESSION GUARD for the closed Rust!=TS divergence: a non-ASCII char that JS
+        // `.toLowerCase()` folds INTO a kept ASCII char must be KEPT here too (Unicode-aware
+        // `to_lowercase`), NOT mapped to '-'. The Kelvin sign U+212A 'K' lowercases to 'k'.
+        // With the old `to_ascii_lowercase` it stayed non-ASCII -> '-' -> "user-k" actually
+        // collapsing to merge distinct ids; the fix keeps it as 'k'.
+        assert_eq!(normalize_namespace_segment("user\u{212A}"), "userk");
+        // It must therefore NOT collide with a plainly-distinct id...
+        assert_ne!(
+            normalize_namespace_segment("user\u{212A}"), // -> "userk"
+            normalize_namespace_segment("user")          // -> "user"
+        );
+        // ...and it must be IDENTICAL to the already-ASCII spelling JS would have produced.
+        assert_eq!(
+            normalize_namespace_segment("user\u{212A}"),
+            normalize_namespace_segment("userK") // ASCII 'K' -> 'k' -> "userk"
+        );
+        // End-to-end through the resolver: the Kelvin id and the ASCII 'k' id land in the
+        // SAME namespace (correct — they ARE the same user once case-folded), while a plain
+        // "user" id stays in a DIFFERENT namespace (no dangerous merge).
+        let ns_kelvin = resolve_session_memory_namespace(
+            Some("default"),
+            Some("discord"),
+            Some("user\u{212A}"),
+        )
+        .unwrap();
+        let ns_ascii_k =
+            resolve_session_memory_namespace(Some("default"), Some("discord"), Some("userK"))
+                .unwrap();
+        let ns_plain =
+            resolve_session_memory_namespace(Some("default"), Some("discord"), Some("user"))
+                .unwrap();
+        assert_eq!(ns_kelvin, ns_ascii_k);
+        assert_ne!(ns_kelvin, ns_plain);
     }
 
     #[test]

--- a/rust-core/crates/friday-hub/src/session_namespace.rs
+++ b/rust-core/crates/friday-hub/src/session_namespace.rs
@@ -1,0 +1,346 @@
+//! Session memory NAMESPACE resolution (session-memory slice-3, ownership-binding).
+//!
+//! A faithful Rust port of the TS oracle
+//! `src/sessions/services/friday-session-memory-namespace.ts`
+//! (`resolveFridaySessionMemoryNamespace`). The namespace is the memory store SCOPE
+//! derived DETERMINISTICALLY from a session's `(accountId, channel, userId)` axes, so a
+//! user's memory is isolated PER (account, channel) instead of being shared across every
+//! channel for the same user.
+//!
+//! Format (byte-identical to the TS for ASCII inputs — see the normalization caveat below):
+//! ```text
+//! tenant.<accountId>.channel.<channel>.user.<normalizedUserId>.shared
+//! ```
+//!
+//! ## How this binds to the Rust recall axis
+//! The Rust memory recall axis is a single `principal_id` string
+//! (`friday_storage::memory::recall_confirmed` filters `WHERE principal_id = ?`).
+//! `MemoryScope` is a coarse enum and is NOT a namespace. So slice-3 sets the Rust
+//! **`principal_id` := this composite namespace string**, preserving per-(account,
+//! channel, user) isolation on the existing recall axis (`scope` stays
+//! `MemoryScope::Session`). The extraction derives this from the SESSION owner, NOT from a
+//! caller-supplied principal — faithful to the TS production model where extraction is
+//! job-driven and the session is the source of truth.
+//!
+//! ## Fail-closed on missing userId (PARITY, not just hardening)
+//! The TS throws `MEMORY_NAMESPACE_UNRESOLVABLE` when no `userId` is available. This port
+//! mirrors that with the typed [`NamespaceError::UnresolvableNoUserId`]: a session with no
+//! `user_id` (or an empty one) CANNOT produce a namespace, so its extraction FAILS CLOSED
+//! — it is never silently bound to a default/anonymous scope.
+//!
+//! ## Deferred-parity gaps (HONEST — documented, not implemented this slice)
+//! The TS `resolveEffectiveUserId` resolves the userId in THREE ways:
+//!   1. `session.userId` directly — **ported here**.
+//!   2. (DM conversation) fall back to the `chatId` when `chatKind == "dm"` — **DEFERRED**.
+//!   3. (subagent) walk the parent-session chain to find a userId — **DEFERRED**.
+//! The Rust `agent_session` does not yet model `chatKind` / `chatId` / `parentSession`, so
+//! cases (2) and (3) are not representable here. Until a follow-on slice adds those axes, a
+//! session whose userId would ONLY have been resolvable via the DM-chatId fallback or the
+//! subagent parent-walk will FAIL CLOSED here rather than resolve — which is the
+//! conservative direction (no wrong-scope binding), but is a real parity gap vs the TS.
+//!
+//! Truth label: byte-identical namespace + normalization port for the DIRECT-userId case;
+//! DM-chatId + subagent parent-walk userId fallbacks are DEFERRED-PARITY. PROOF-ONLY —
+//! NOT a v1 GO; the TS extraction path stays LIVE pending full parity.
+
+/// Namespace segment constants — ported from `src/sessions/friday-session.constants.ts`
+/// (`FRIDAY_SESSION_MEMORY_NAMESPACE_*_SEGMENT`).
+const TENANT_SEGMENT: &str = "tenant";
+const CHANNEL_SEGMENT: &str = "channel";
+const USER_SEGMENT: &str = "user";
+const SHARED_SEGMENT: &str = "shared";
+
+/// The TS account/channel defaults (`session.accountId || "default"`,
+/// `session.channel || "unknown"`). NOTE: these defaults go THROUGH
+/// [`normalize_namespace_segment`] afterward (which leaves them unchanged, but the order
+/// is faithful to the TS).
+const DEFAULT_ACCOUNT_ID: &str = "default";
+const DEFAULT_CHANNEL: &str = "unknown";
+
+/// The empty-result fallback of [`normalize_namespace_segment`] (TS: `"default"`).
+const NORMALIZE_EMPTY_FALLBACK: &str = "default";
+
+/// A typed namespace-resolution error. The single variant mirrors the TS
+/// `FRIDAY_SESSION_ERROR_CODES.MEMORY_NAMESPACE_UNRESOLVABLE`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum NamespaceError {
+    /// No `userId` was available to resolve a namespace (the session has no `user_id`, or
+    /// it is empty). FAIL CLOSED — parity with the TS throw.
+    UnresolvableNoUserId,
+}
+
+impl std::fmt::Display for NamespaceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            NamespaceError::UnresolvableNoUserId => write!(
+                f,
+                "memory namespace unresolvable: no userId available for session"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for NamespaceError {}
+
+/// Resolve the memory namespace (the composite store scope) for a session from its OWNER
+/// axes, mirroring the TS `resolveFridaySessionMemoryNamespace` for the DIRECT-userId case.
+///
+/// * `account_id`: falsy (`None` or empty) → `"default"`, then normalized.
+/// * `channel`: falsy (`None` or empty) → `"unknown"`, then normalized.
+/// * `user_id`: falsy (`None` or empty) → FAIL CLOSED ([`NamespaceError::UnresolvableNoUserId`]).
+///
+/// Returns `tenant.<account>.channel.<channel>.user.<user>.shared`.
+pub fn resolve_session_memory_namespace(
+    account_id: Option<&str>,
+    channel: Option<&str>,
+    user_id: Option<&str>,
+) -> Result<String, NamespaceError> {
+    // FAIL CLOSED when no userId (TS: `if (!userId) throw MEMORY_NAMESPACE_UNRESOLVABLE`).
+    // JS `!userId` is falsy on `undefined` AND the empty string, so an empty `user_id`
+    // also fails here.
+    let user_id = match user_id {
+        Some(u) if !u.is_empty() => u,
+        _ => return Err(NamespaceError::UnresolvableNoUserId),
+    };
+
+    // TS: `session.accountId || "default"` and `session.channel || "unknown"`. JS `||` is
+    // falsy on the empty string too, so `Some("")` takes the default — NOT a naive
+    // `unwrap_or` (which would only handle `None`). Then each goes THROUGH the normalizer.
+    let account = falsy_or(account_id, DEFAULT_ACCOUNT_ID);
+    let chan = falsy_or(channel, DEFAULT_CHANNEL);
+
+    let normalized_account = normalize_namespace_segment(account);
+    let normalized_channel = normalize_namespace_segment(chan);
+    let normalized_user = normalize_namespace_segment(user_id);
+
+    Ok([
+        TENANT_SEGMENT,
+        &normalized_account,
+        CHANNEL_SEGMENT,
+        &normalized_channel,
+        USER_SEGMENT,
+        &normalized_user,
+        SHARED_SEGMENT,
+    ]
+    .join("."))
+}
+
+/// The JS `value || fallback` semantics: a `None` or empty-string value takes the
+/// fallback (JS treats `""` as falsy, unlike a naive `Option::unwrap_or`).
+fn falsy_or<'a>(value: Option<&'a str>, fallback: &'a str) -> &'a str {
+    match value {
+        Some(v) if !v.is_empty() => v,
+        _ => fallback,
+    }
+}
+
+/// Byte-identical port of the TS `normalizeNamespaceSegment`:
+/// ```js
+/// value.toLowerCase()
+///   .replace(/[^a-z0-9._-]/g, "-")
+///   .replace(/-+/g, "-")
+///   .replace(/^-|-$/g, "");
+/// // empty result -> "default"
+/// ```
+///
+/// We implement it with explicit char filtering (no `regex` dependency needed) and verify
+/// equivalence with the ported TS test vectors (`tests` below).
+///
+/// PARITY CAVEAT (honest): this is byte-identical to the TS for ASCII inputs — the only
+/// inputs real session userIds/accountIds/channels take. The lowercasing uses
+/// `to_ascii_lowercase`, whereas JS `String.toLowerCase()` is Unicode-aware. They diverge
+/// ONLY for the rare non-ASCII char that JS lowercases INTO a kept ASCII char (e.g. the
+/// Kelvin sign `K` → ASCII `k`, or `İ` → `i`): JS would keep it, this port maps it to `-`
+/// (outside the ASCII keep-set). For every other non-ASCII char both map to `-`. This is a
+/// documented parity gap, not a silent divergence; it is irrelevant for ASCII ids.
+pub fn normalize_namespace_segment(value: &str) -> String {
+    // Step 1: toLowerCase() then replace each char NOT in [a-z0-9._-] with '-'.
+    let lowered = value.to_ascii_lowercase();
+    let mut mapped = String::with_capacity(lowered.len());
+    for ch in lowered.chars() {
+        if is_kept(ch) {
+            mapped.push(ch);
+        } else {
+            // Any character outside the keep-set (including multi-byte/non-ASCII) becomes a
+            // SINGLE '-', exactly as the JS regex replaces each unmatched char with "-".
+            mapped.push('-');
+        }
+    }
+
+    // Step 2: replace(/-+/g, "-") — collapse runs of '-' to one.
+    let mut collapsed = String::with_capacity(mapped.len());
+    let mut prev_dash = false;
+    for ch in mapped.chars() {
+        if ch == '-' {
+            if !prev_dash {
+                collapsed.push('-');
+            }
+            prev_dash = true;
+        } else {
+            collapsed.push(ch);
+            prev_dash = false;
+        }
+    }
+
+    // Step 3: replace(/^-|-$/g, "") — trim a single leading and a single trailing '-'.
+    // The JS alternation `^-|-$` removes AT MOST one leading and one trailing dash; after
+    // the `-+ -> -` collapse there can be at most one of each, so trimming all leading and
+    // trailing dashes here is equivalent.
+    let trimmed = collapsed.trim_matches('-');
+
+    // Step 4: empty -> "default".
+    if trimmed.is_empty() {
+        NORMALIZE_EMPTY_FALLBACK.to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+/// The TS keep-set `[a-z0-9._-]` (applied AFTER `toLowerCase`, so uppercase A-Z is already
+/// lowered and never reaches here as uppercase).
+fn is_kept(ch: char) -> bool {
+    ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '.' || ch == '_' || ch == '-'
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ─── Differential vectors ported from
+    //     test/unit/sessions/services/friday-session-memory-namespace.test.ts
+    //     (the DIRECT-userId cases — the only ones this slice ports). ───
+
+    #[test]
+    fn resolves_namespace_from_user_id() {
+        // TS: makeSession({ userId: "user-abc" }) on account "default", channel "discord".
+        let ns =
+            resolve_session_memory_namespace(Some("default"), Some("discord"), Some("user-abc"))
+                .unwrap();
+        assert_eq!(ns, "tenant.default.channel.discord.user.user-abc.shared");
+    }
+
+    #[test]
+    fn normalizes_user_id_to_lowercase() {
+        // TS: userId "User-ABC" -> "user-abc".
+        let ns =
+            resolve_session_memory_namespace(Some("default"), Some("discord"), Some("User-ABC"))
+                .unwrap();
+        assert_eq!(ns, "tenant.default.channel.discord.user.user-abc.shared");
+    }
+
+    #[test]
+    fn same_user_across_channels_resolves_to_different_namespaces() {
+        let ns1 =
+            resolve_session_memory_namespace(Some("default"), Some("discord"), Some("user-x"))
+                .unwrap();
+        let ns2 = resolve_session_memory_namespace(Some("default"), Some("slack"), Some("user-x"))
+            .unwrap();
+        assert_eq!(ns1, "tenant.default.channel.discord.user.user-x.shared");
+        assert_eq!(ns2, "tenant.default.channel.slack.user.user-x.shared");
+        assert_ne!(ns1, ns2);
+    }
+
+    #[test]
+    fn different_user_ids_resolve_to_different_namespaces() {
+        let ns1 =
+            resolve_session_memory_namespace(Some("default"), Some("discord"), Some("user-a"))
+                .unwrap();
+        let ns2 =
+            resolve_session_memory_namespace(Some("default"), Some("discord"), Some("user-b"))
+                .unwrap();
+        assert_ne!(ns1, ns2);
+    }
+
+    #[test]
+    fn fails_closed_when_no_user_id() {
+        // TS throws MEMORY_NAMESPACE_UNRESOLVABLE; we return the typed error. This is the
+        // parity for the "no userId, not DM" case (and — since DM/subagent fallbacks are
+        // DEFERRED here — also covers what TS would have resolved via those paths).
+        assert_eq!(
+            resolve_session_memory_namespace(Some("default"), Some("discord"), None),
+            Err(NamespaceError::UnresolvableNoUserId)
+        );
+        // An EMPTY user id is also falsy in JS (`!userId`), so it fails closed too.
+        assert_eq!(
+            resolve_session_memory_namespace(Some("default"), Some("discord"), Some("")),
+            Err(NamespaceError::UnresolvableNoUserId)
+        );
+    }
+
+    #[test]
+    fn replaces_special_characters_in_user_id() {
+        // TS: "user@example.com" -> "user-example.com" ('@' -> '-', dots PRESERVED).
+        let ns = resolve_session_memory_namespace(
+            Some("default"),
+            Some("discord"),
+            Some("user@example.com"),
+        )
+        .unwrap();
+        assert_eq!(
+            ns,
+            "tenant.default.channel.discord.user.user-example.com.shared"
+        );
+    }
+
+    #[test]
+    fn normalizes_account_and_channel_segments() {
+        // TS: accountId "Ops Team" -> "ops-team", channel "Slack Connect" -> "slack-connect",
+        // userId "User-ABC" -> "user-abc".
+        let ns = resolve_session_memory_namespace(
+            Some("Ops Team"),
+            Some("Slack Connect"),
+            Some("User-ABC"),
+        )
+        .unwrap();
+        assert_eq!(
+            ns,
+            "tenant.ops-team.channel.slack-connect.user.user-abc.shared"
+        );
+    }
+
+    // ─── account/channel default behavior (TS `|| "default"` / `|| "unknown"`) ───
+
+    #[test]
+    fn empty_or_absent_account_takes_default_and_channel_takes_unknown() {
+        // None and Some("") are both falsy in JS — both take the default. (The TS defaults
+        // then go THROUGH the normalizer, which leaves "default"/"unknown" unchanged.)
+        for account in [None, Some("")] {
+            for channel in [None, Some("")] {
+                let ns = resolve_session_memory_namespace(account, channel, Some("u")).unwrap();
+                assert_eq!(ns, "tenant.default.channel.unknown.user.u.shared");
+            }
+        }
+    }
+
+    // ─── normalize_namespace_segment unit vectors ───
+
+    #[test]
+    fn normalize_collapses_runs_and_trims_edges_and_empty_to_default() {
+        assert_eq!(normalize_namespace_segment("User-ABC"), "user-abc");
+        assert_eq!(normalize_namespace_segment("Ops Team"), "ops-team");
+        // Leading/trailing special chars are mapped to '-' then trimmed.
+        assert_eq!(normalize_namespace_segment("  spaced  "), "spaced");
+        assert_eq!(normalize_namespace_segment("@@@"), "default");
+        assert_eq!(normalize_namespace_segment(""), "default");
+        // Runs of disallowed chars collapse to ONE '-'.
+        assert_eq!(normalize_namespace_segment("a   b---c"), "a-b-c");
+        // Dots, underscores, hyphens are KEPT.
+        assert_eq!(normalize_namespace_segment("a.b_c-d"), "a.b_c-d");
+        // user@example.com (the segment-level vector).
+        assert_eq!(
+            normalize_namespace_segment("user@example.com"),
+            "user-example.com"
+        );
+        // Non-ASCII is outside the keep-set and becomes '-' (then collapses/trims).
+        assert_eq!(normalize_namespace_segment("héllo"), "h-llo");
+        assert_eq!(normalize_namespace_segment("名前"), "default");
+    }
+
+    #[test]
+    fn error_display_is_secret_free_and_coarse() {
+        // The error message must never carry a session body — a fixed coarse string.
+        let msg = NamespaceError::UnresolvableNoUserId.to_string();
+        assert!(msg.contains("unresolvable"));
+        assert!(!msg.contains("Bearer"));
+    }
+}

--- a/rust-core/crates/friday-storage/src/agent_session.rs
+++ b/rust-core/crates/friday-storage/src/agent_session.rs
@@ -24,7 +24,7 @@
 //! PROOF-ONLY; NOT a v1 GO.
 
 use crate::error::{Result, StorageError};
-use rusqlite::{params, Connection};
+use rusqlite::{params, Connection, OptionalExtension};
 
 /// A conversation message as supplied to [`append_session_message`]. `seq`,
 /// `message_id` and `created_at` are assigned by the store, not the caller.
@@ -63,17 +63,42 @@ pub struct StoredSessionMessage {
     pub created_at: i64,
 }
 
+/// The session OWNER axes (slice-3 ownership-binding) — the three `agent_session`
+/// fields the memory namespace is DERIVED from, mirroring the TS `FridaySessionRecord`
+/// `accountId` / `channel` / `userId`. All optional: a pre-slice-3 session (or one
+/// created via the no-owner [`ensure_session`]) reads back `None` for each. A `None`
+/// (or empty) `user_id` is what FAILS the memory-namespace resolution closed.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct SessionOwner {
+    pub account_id: Option<String>,
+    pub channel: Option<String>,
+    pub user_id: Option<String>,
+}
+
 /// Ensure an `agent_session` row exists (idempotent). A new session is created at
 /// `now_ms`; an existing session has its `updated_at` bumped. Safe to call at the
 /// start of every run in the session.
+///
+/// This is the OWNER-LESS form (no `account_id`/`channel`/`user_id`): a session created
+/// this way reads back [`SessionOwner::default`] (all `None`), so its memory namespace
+/// is UNRESOLVABLE (fail-closed) until an owner is set. Existing callers (e.g. the
+/// production `run_session_loop`) keep using this unchanged. To bind an owner, use
+/// [`ensure_session_with_owner`].
+///
+/// IMPORTANT: this owner-less form references ONLY the pre-v21 columns (it never names
+/// `account_id`/`channel`/`user_id`), so it works against a DB at ANY version that has the
+/// base `agent_session` table — including a v≤20 DB seeded in a migration test BEFORE the
+/// v21 owner columns exist. Owner binding is the sole concern of
+/// [`ensure_session_with_owner`], which requires the v21 columns.
 pub fn ensure_session(conn: &Connection, agent_session_id: &str, now_ms: i64) -> Result<()> {
     if agent_session_id.trim().is_empty() {
         return Err(StorageError::Unsupported(
             "agent_session_id must be non-empty".into(),
         ));
     }
-    // INSERT-or-bump in one statement: a fresh id INSERTs, an existing id keeps its
-    // created_at and only advances updated_at (no row is ever clobbered).
+    // INSERT-or-bump in one statement, naming ONLY the base columns: a fresh id INSERTs, an
+    // existing id keeps its created_at + any already-bound owner (those columns are not
+    // touched here) and only advances updated_at — no row is ever clobbered.
     conn.execute(
         "INSERT INTO agent_session (agent_session_id, created_at, updated_at)
          VALUES (?1, ?2, ?2)
@@ -81,6 +106,85 @@ pub fn ensure_session(conn: &Connection, agent_session_id: &str, now_ms: i64) ->
         params![agent_session_id, now_ms],
     )?;
     Ok(())
+}
+
+/// Ensure an `agent_session` row exists (idempotent), binding its OWNER axes
+/// (slice-3). A fresh id INSERTs with the supplied owner fields; an existing id keeps
+/// its `created_at` AND its already-bound owner fields (never clobbered), advancing only
+/// `updated_at`. `COALESCE(existing, new)` on conflict means a later no-owner ensure
+/// never erases a previously-bound owner, and a later ensure can BACKFILL an owner that
+/// was `NULL` (e.g. a session first created owner-less). A blank owner field is stored as
+/// `NULL` so the falsy-empty case is represented identically to absent (the namespace
+/// resolver treats `None` and `Some("")` the same).
+pub fn ensure_session_with_owner(
+    conn: &Connection,
+    agent_session_id: &str,
+    owner: &SessionOwner,
+    now_ms: i64,
+) -> Result<()> {
+    if agent_session_id.trim().is_empty() {
+        return Err(StorageError::Unsupported(
+            "agent_session_id must be non-empty".into(),
+        ));
+    }
+    // Normalize blank-string owner fields to NULL so "absent" and "empty" are one case.
+    let account_id = none_if_blank(owner.account_id.as_deref());
+    let channel = none_if_blank(owner.channel.as_deref());
+    let user_id = none_if_blank(owner.user_id.as_deref());
+    // INSERT-or-bump in one statement: a fresh id INSERTs with the owner; an existing id
+    // keeps its created_at + already-bound owner (COALESCE keeps the existing non-NULL,
+    // else accepts the incoming value as a backfill) and only advances updated_at — no row
+    // is ever clobbered and no bound owner is ever erased.
+    conn.execute(
+        "INSERT INTO agent_session
+            (agent_session_id, created_at, updated_at, account_id, channel, user_id)
+         VALUES (?1, ?2, ?2, ?3, ?4, ?5)
+         ON CONFLICT(agent_session_id) DO UPDATE SET
+            updated_at = ?2,
+            account_id = COALESCE(account_id, excluded.account_id),
+            channel    = COALESCE(channel, excluded.channel),
+            user_id    = COALESCE(user_id, excluded.user_id)",
+        params![agent_session_id, now_ms, account_id, channel, user_id],
+    )?;
+    Ok(())
+}
+
+/// Load a session's OWNER axes (slice-3). Returns `None` if the session row is absent
+/// (so a caller can distinguish "no such session" from "session with no owner", which is
+/// `Some(SessionOwner::default())`). A blank-string column reads back as `None` (matching
+/// how [`ensure_session_with_owner`] stores blanks as `NULL`).
+pub fn load_session_owner(
+    conn: &Connection,
+    agent_session_id: &str,
+) -> Result<Option<SessionOwner>> {
+    // `.optional()` maps ONLY `QueryReturnedNoRows` (absent session) to `Ok(None)` and
+    // PROPAGATES any real storage error (locked/corrupt DB) — never swallowing it as
+    // "no owner" (which would mis-report as an unresolvable namespace downstream).
+    let row = conn
+        .query_row(
+            "SELECT account_id, channel, user_id FROM agent_session
+             WHERE agent_session_id = ?1",
+            [agent_session_id],
+            |r| {
+                Ok(SessionOwner {
+                    account_id: none_if_blank(r.get::<_, Option<String>>(0)?.as_deref()),
+                    channel: none_if_blank(r.get::<_, Option<String>>(1)?.as_deref()),
+                    user_id: none_if_blank(r.get::<_, Option<String>>(2)?.as_deref()),
+                })
+            },
+        )
+        .optional()?;
+    Ok(row)
+}
+
+/// `None` for an absent or strictly-empty (`""`) value; a whitespace-only value is kept
+/// VERBATIM (the strictly-empty check only — normalization/trimming is the namespace
+/// resolver's job, not the store's).
+fn none_if_blank(v: Option<&str>) -> Option<String> {
+    match v {
+        Some(s) if !s.is_empty() => Some(s.to_string()),
+        _ => None,
+    }
 }
 
 /// Whether an `agent_session` row exists.
@@ -388,16 +492,24 @@ mod tests {
     }
 
     #[test]
-    fn fresh_db_defaults_messages_to_pending_and_reaches_v20() {
+    fn fresh_db_defaults_messages_to_pending_and_reaches_latest() {
         let db = Db::open_hub(&tmp("pending-default")).unwrap();
-        // The fresh-DB migration chain reaches the slice-2 version.
+        // The fresh-DB migration chain reaches at least the slice-2 version (the
+        // `memory_extract_status` column exists). Derived from the migration set so a new
+        // additive migration (e.g. slice-3 v21) does not break this assertion.
         let v: i64 = db
             .conn()
             .query_row("SELECT version FROM schema_version WHERE id = 1", [], |r| {
                 r.get(0)
             })
             .unwrap();
-        assert_eq!(v, 20, "fresh migration reaches the slice-2 version");
+        let expected = crate::hub_migrations()
+            .iter()
+            .map(|m| m.version)
+            .max()
+            .unwrap();
+        assert_eq!(v, expected, "fresh migration reaches the latest version");
+        assert!(v >= 20, "the slice-2 memory_extract_status column exists");
 
         ensure_session(db.conn(), "s1", 1).unwrap();
         let id = append_session_message(
@@ -479,5 +591,113 @@ mod tests {
         assert!(load_pending_session_messages(db.conn(), "nope")
             .unwrap()
             .is_empty());
+    }
+
+    // --- slice-3 (ownership-binding) -----------------------------------------
+
+    #[test]
+    fn owner_less_ensure_session_reads_back_no_owner() {
+        // A session created via the owner-less `ensure_session` has all owner axes NULL —
+        // its memory namespace is UNRESOLVABLE (fail-closed) until an owner is set.
+        let db = Db::open_hub(&tmp("noowner")).unwrap();
+        ensure_session(db.conn(), "s1", 1).unwrap();
+        let owner = load_session_owner(db.conn(), "s1").unwrap();
+        assert_eq!(owner, Some(SessionOwner::default()));
+        let o = owner.unwrap();
+        assert_eq!(o.account_id, None);
+        assert_eq!(o.channel, None);
+        assert_eq!(o.user_id, None);
+    }
+
+    #[test]
+    fn ensure_with_owner_stores_and_loads_owner_axes() {
+        let db = Db::open_hub(&tmp("owner")).unwrap();
+        let owner = SessionOwner {
+            account_id: Some("acct-1".into()),
+            channel: Some("discord".into()),
+            user_id: Some("user-abc".into()),
+        };
+        ensure_session_with_owner(db.conn(), "s1", &owner, 1).unwrap();
+        assert_eq!(load_session_owner(db.conn(), "s1").unwrap(), Some(owner));
+    }
+
+    #[test]
+    fn blank_owner_fields_store_as_none() {
+        // A blank-string owner field is indistinguishable from absent (the namespace
+        // resolver treats None and Some("") identically).
+        let db = Db::open_hub(&tmp("blankowner")).unwrap();
+        let owner = SessionOwner {
+            account_id: Some("".into()),
+            channel: Some("   ".into()),
+            user_id: Some("u".into()),
+        };
+        ensure_session_with_owner(db.conn(), "s1", &owner, 1).unwrap();
+        let back = load_session_owner(db.conn(), "s1").unwrap().unwrap();
+        assert_eq!(back.account_id, None, "empty account stored as NULL");
+        // A whitespace-only value is stored verbatim (non-empty), but blank trimming is
+        // the resolver's job — here we only normalize the strictly-empty string.
+        assert_eq!(back.channel.as_deref(), Some("   "));
+        assert_eq!(back.user_id.as_deref(), Some("u"));
+    }
+
+    #[test]
+    fn re_ensure_does_not_clobber_bound_owner_but_backfills_null() {
+        // Once an owner is bound, a later no-owner ensure keeps it; a later ensure can
+        // BACKFILL a field that was NULL.
+        let db = Db::open_hub(&tmp("clobber")).unwrap();
+        let owner = SessionOwner {
+            account_id: Some("acct-1".into()),
+            channel: None,
+            user_id: Some("user-abc".into()),
+        };
+        ensure_session_with_owner(db.conn(), "s1", &owner, 1).unwrap();
+        // A no-owner re-ensure must NOT erase the bound account/user.
+        ensure_session(db.conn(), "s1", 2).unwrap();
+        let back = load_session_owner(db.conn(), "s1").unwrap().unwrap();
+        assert_eq!(back.account_id.as_deref(), Some("acct-1"));
+        assert_eq!(back.user_id.as_deref(), Some("user-abc"));
+        assert_eq!(back.channel, None);
+        // A later ensure backfills the previously-NULL channel.
+        ensure_session_with_owner(
+            db.conn(),
+            "s1",
+            &SessionOwner {
+                account_id: Some("ignored-acct".into()),
+                channel: Some("slack".into()),
+                user_id: None,
+            },
+            3,
+        )
+        .unwrap();
+        let back = load_session_owner(db.conn(), "s1").unwrap().unwrap();
+        assert_eq!(
+            back.account_id.as_deref(),
+            Some("acct-1"),
+            "bound account is not clobbered by a new ensure"
+        );
+        assert_eq!(
+            back.channel.as_deref(),
+            Some("slack"),
+            "the previously-NULL channel is backfilled"
+        );
+        assert_eq!(back.user_id.as_deref(), Some("user-abc"));
+        // created_at immutable, updated_at advanced — owner binding preserves the existing
+        // idempotency contract.
+        let (created, updated): (i64, i64) = db
+            .conn()
+            .query_row(
+                "SELECT created_at, updated_at FROM agent_session WHERE agent_session_id='s1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(created, 1, "created_at immutable across owner re-ensure");
+        assert_eq!(updated, 3, "updated_at advances");
+    }
+
+    #[test]
+    fn load_owner_of_absent_session_is_none() {
+        let db = Db::open_hub(&tmp("absent")).unwrap();
+        assert_eq!(load_session_owner(db.conn(), "ghost").unwrap(), None);
     }
 }

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -32,8 +32,9 @@ mod schema;
 pub mod workflow;
 
 pub use agent_session::{
-    append_session_message, ensure_session, load_session_messages, session_exists,
-    session_message_count, SessionMessage, StoredSessionMessage,
+    append_session_message, ensure_session, ensure_session_with_owner, load_session_messages,
+    load_session_owner, session_exists, session_message_count, SessionMessage, SessionOwner,
+    StoredSessionMessage,
 };
 pub use authorize::authorize_mutating_action;
 pub use authorize_ed25519::{authorize_mutating_action_ed25519, Ed25519VerifyOnlyPolicy};

--- a/rust-core/crates/friday-storage/src/schema.rs
+++ b/rust-core/crates/friday-storage/src/schema.rs
@@ -284,6 +284,27 @@ pub fn hub_migrations() -> Vec<Migration> {
             destructive: false,
             up: m0020_session_message_memory_extract_status,
         },
+        // Session-memory slice-3 (ownership-binding): add the session OWNER fields
+        // (`account_id`, `channel`, `user_id`) to `agent_session`, mirroring the TS
+        // `FridaySessionRecord` axes the memory namespace is DERIVED from. This is what
+        // lets the inline extraction compute its store SCOPE from the SESSION (a composite
+        // `tenant.<account>.channel.<channel>.user.<user>.shared` namespace) instead of
+        // trusting a caller-supplied principal — faithful to the TS production model where
+        // extraction is job-driven and the session is the source of truth.
+        //
+        // All three columns are NULLABLE additive `ALTER`s: every existing v20
+        // `agent_session` row reads back `account_id = NULL`, `channel = NULL`,
+        // `user_id = NULL`. A NULL `user_id` FAILS CLOSED at namespace resolution (the TS
+        // throws `MEMORY_NAMESPACE_UNRESOLVABLE`), so a pre-slice-3 session is never
+        // silently bound to a default/anonymous scope — it simply cannot be extracted until
+        // its owner is set. Purely additive (ALTER only) — touches no other table, so v20
+        // rows/queries are unaffected. Hub-only — `agent_session` is a Hub-only table.
+        Migration {
+            version: 21,
+            name: "agent_session_owner",
+            destructive: false,
+            up: m0021_agent_session_owner,
+        },
     ]
 }
 
@@ -1365,5 +1386,25 @@ fn m0020_session_message_memory_extract_status(tx: &Transaction) -> rusqlite::Re
          CREATE INDEX idx_agent_session_message_pending
             ON agent_session_message(agent_session_id, seq)
             WHERE memory_extract_status = 'pending';",
+    )
+}
+
+// Session-memory slice-3 (ownership-binding): additive NULLABLE owner columns on the
+// Hub-only `agent_session` table (`account_id`, `channel`, `user_id`). These mirror the
+// TS `FridaySessionRecord` axes the memory namespace is derived from. The memory store
+// SCOPE (the `principal_id` recall axis) is now DERIVED from these — a composite
+// `tenant.<account>.channel.<channel>.user.<user>.shared` namespace — instead of a
+// caller-supplied principal. `ALTER TABLE ... ADD COLUMN` with no default is additive and
+// back-compatible: every existing v20 row reads back NULL for all three. A NULL `user_id`
+// FAILS CLOSED at namespace resolution (TS throws `MEMORY_NAMESPACE_UNRESOLVABLE`), so a
+// pre-slice-3 session is never bound to a default scope — it cannot be extracted until its
+// owner is set. The `agent_session` CREATE-DDL const stays FROZEN at its pre-v21 shape, so
+// a fresh install runs the base CREATE then this ALTER (no duplicate-column on fresh
+// install) — mirrors how m0017 added `run_result.owner_principal`.
+fn m0021_agent_session_owner(tx: &Transaction) -> rusqlite::Result<()> {
+    tx.execute_batch(
+        "ALTER TABLE agent_session ADD COLUMN account_id TEXT;
+         ALTER TABLE agent_session ADD COLUMN channel TEXT;
+         ALTER TABLE agent_session ADD COLUMN user_id TEXT;",
     )
 }

--- a/rust-core/crates/friday-storage/tests/migration.rs
+++ b/rust-core/crates/friday-storage/tests/migration.rs
@@ -182,6 +182,58 @@ fn forward_migration_v19_to_v20_backfills_existing_messages_to_pending() {
 }
 
 #[test]
+fn forward_migration_v20_to_v21_backfills_owner_to_null_and_fresh_has_columns() {
+    // Session-memory slice-3 additive migration v21: agent_session gains nullable
+    // `account_id`, `channel`, `user_id`. A PRE-EXISTING v20 session row (seeded before the
+    // columns existed) must survive the forward ALTER reading back NULL for all three (so a
+    // pre-slice-3 session is never silently bound to a default scope — it fails closed at
+    // namespace resolution until an owner is set). A FRESH install has the columns.
+    use friday_storage::agent_session::{
+        ensure_session, ensure_session_with_owner, load_session_owner, SessionOwner,
+    };
+
+    let p = temp_db_path("agent-session-owner-mig");
+    {
+        let mut migs = hub_migrations();
+        migs.retain(|m| m.version <= 20);
+        let db = Db::open(&p, Profile::Hub, &migs, "v20").unwrap();
+        assert_eq!(db.version().unwrap(), 20);
+        assert!(
+            db.conn()
+                .prepare("SELECT user_id FROM agent_session")
+                .is_err(),
+            "owner columns must not exist before v21"
+        );
+        // Seed a session with the pre-v21 shape (no owner columns).
+        ensure_session(db.conn(), "s1", 1).unwrap();
+    }
+    // Reopen with the full set -> forward-migrate to v21 (the additive owner ALTERs).
+    let db = Db::open_hub(&p).unwrap();
+    assert_eq!(db.version().unwrap(), hub_max_version());
+    assert_eq!(
+        db.count("agent_session").unwrap(),
+        1,
+        "pre-v21 session row survived the migration"
+    );
+    // The pre-existing row reads back ALL owner axes as NULL (fail-closed at resolution).
+    let owner = load_session_owner(db.conn(), "s1").unwrap();
+    assert_eq!(
+        owner,
+        Some(SessionOwner::default()),
+        "pre-v21 row backfills to no-owner (all NULL)"
+    );
+
+    // A fresh ensure_session_with_owner on the migrated DB stores + reads back the owner.
+    let bound = SessionOwner {
+        account_id: Some("default".into()),
+        channel: Some("discord".into()),
+        user_id: Some("user-abc".into()),
+    };
+    ensure_session_with_owner(db.conn(), "s2", &bound, 2).unwrap();
+    assert_eq!(load_session_owner(db.conn(), "s2").unwrap(), Some(bound));
+}
+
+#[test]
 fn reopen_is_idempotent_and_preserves_rows() {
     let p = temp_db_path("seeded");
     {


### PR DESCRIPTION
## What this is

Slice 3 of Rust-owning the session-memory feature toward TS parity (slices 1–2: inline extraction engine; dedup + transactional persist — already merged). This slice = **ownership-binding**: the extraction's memory STORE SCOPE is now DERIVED FROM THE SESSION (a composite namespace) instead of trusting a caller-supplied principal — faithful to the TS production model where extraction is job-driven (there is no caller principal) and the session is the source of truth.

## TS parity mapping (`principal_id` := namespace)

Ported faithfully from `src/sessions/services/friday-session-memory-namespace.ts` (`resolveFridaySessionMemoryNamespace`) + `src/sessions/friday-session.constants.ts`.

- The Rust memory recall axis is a single `principal_id` string (`recall_confirmed` filters `WHERE principal_id = ?`); `MemoryScope` is a coarse enum, NOT a namespace. So this slice sets **`principal_id` := the composite namespace** `tenant.<account>.channel.<channel>.user.<user>.shared`, preserving per-(account, channel, user) isolation on the existing recall axis. `scope` stays `MemoryScope::Session`.
- `normalizeNamespaceSegment` ported byte-identical for ASCII inputs (lowercase → replace `[^a-z0-9._-]`→`-` → collapse `-+`→`-` → trim edge `-` → empty→`"default"`), verified against the ported TS assertion vectors (incl. `user@example.com` → `user-example.com`, `Ops Team`/`Slack Connect` segment normalization).
- account default `"default"`, channel default `"unknown"` via JS-`||` (falsy on empty string, not just `None`).
- **FAIL-CLOSED when no userId** — TS throws `MEMORY_NAMESPACE_UNRESOLVABLE`; the port returns the typed `NamespaceError::UnresolvableNoUserId` and extraction fails closed BEFORE any provider call. This is PARITY.

## Write-set (files changed)

- `rust-core/crates/friday-storage/src/schema.rs` — additive **migration v21** (`agent_session` gains NULLABLE `account_id`, `channel`, `user_id`; create-DDL const frozen at pre-v21 shape so a fresh install runs base-create then the v21 ALTERs).
- `rust-core/crates/friday-storage/src/agent_session.rs` — `SessionOwner` struct + `ensure_session_with_owner` (COALESCE on conflict — never clobbers a bound owner, backfills NULLs) + `load_session_owner` (uses `.optional()?` — propagates real storage errors, only absent-row → `None`). `ensure_session` kept owner-less and references ONLY the base columns (so it works at any schema version, incl. a v≤20 migration-test seed).
- `rust-core/crates/friday-hub/src/session_namespace.rs` (**NEW**) — `resolve_session_memory_namespace` + `normalize_namespace_segment` + ported differential test vectors.
- `rust-core/crates/friday-hub/src/memory_extraction.rs` — `extract_inline` now derives the namespace from the session owner and records candidates under it as `principal_id`; the caller `principal_id` arg is REMOVED. Fails closed (`ExtractionError::NamespaceUnresolvable`) if unresolvable.
- `rust-core/crates/friday-hub/src/bin/hub_extract_memory.rs` — `--principal` is now an OPTIONAL proof-time ASSERTION (must equal the derived namespace, else `principal_mismatch` exit 2); the bin echoes the derived namespace as `principal_id`. Stays refs-only (reuses `reject_forbidden_output`). Still builds (CI names it).
- `rust-core/crates/friday-storage/tests/migration.rs` — v20→v21 backfill test (existing rows read back NULL owner; fresh install has the columns + round-trips an owner).
- `rust-core/crates/friday-hub/src/lib.rs` — touched ONLY to register the new module (`pub mod session_namespace;`) per write-set step 3; **no loop/caller logic changed** (`run_session_loop` / `ensure_session` callers untouched).

Migration version: **v21** (`agent_session_owner`).

## Deferred-parity / honesty (truth labels)

- DM-chatId fallback + subagent parent-chain userId walk are **DEFERRED** (the Rust `agent_session` does not model `chatKind`/`chatId`/`parentSession`); a session resolvable only via those paths fails closed here — conservative, but a real parity gap.
- Queue/auto machine still deferred (inline manual path only).
- Production `run_session_loop` still uses the owner-less `ensure_session`, so **live sessions carry a NULL owner** until a follow-on wires the owner through (out of scope — that lives in the off-limits loop entrypoint).
- `normalize` is byte-identical for ASCII inputs; non-ASCII may diverge from JS Unicode `toLowerCase()` — documented parity gap.
- The TS extraction path STAYS LIVE. PROOF-ONLY — **NOT a v1 GO**.

## Coordinator live-proof notes (this slice changes the invocation)

1. **Extraction now requires an OWNED session.** Owner is set only via `ensure_session_with_owner` (a storage API) — no bin and no production path sets it — so running the bin against a normally-created session fails closed with `namespace_unresolvable`. The live-proof must seed an owned session first.
2. **`--principal` is now an assertion, not the key.** The slice-1/2 invocation `--principal alice` will fail with `principal_mismatch`. Clean path: run WITHOUT `--principal`, then read the derived `principal_id` (the namespace) from the output — or pass the exact derived namespace to assert it.

## Local verification (CI gates, exact)

- `cargo fmt --all -- --check` → clean
- `cargo clippy --workspace --all-targets -- -D warnings` → clean
- `cargo build -p friday-hub --bin hub_extract_memory` → builds
- `cargo test --workspace` → all green (75 test-suites ok, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)