### PR TITLE
feat(rust): execrun-replace slice 3 — owner-scoped body-return readback (dark)

### DIFF
--- a/rust-core/crates/friday-hub/src/bin/hub_run_answer_readback.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_run_answer_readback.rs
@@ -1,0 +1,442 @@
+//! S3 DARK owner-gated answer-BODY readback — `hub_run_answer_readback`.
+//!
+//! PROOF-ONLY (Rust-wired-DEV), DARK (no production route consumes this yet). This is
+//! the OWNER-GATED BODY sibling of the REFS-ONLY proof bin
+//! [`hub_run_readback`](super) — and it is deliberately a **SEPARATE PATH**: the
+//! refs-only proof bins NEVER transport a body, while THIS bin's whole reason to
+//! exist is to return the agent-run ANSWER BODY back to the authenticated OWNER (the
+//! future `executeRun`-replacement's owner-scoped body-return readback).
+//!
+//! It is the proof substrate behind D1-Q1's "(b) authenticated answer-body
+//! projection": given a `run_id` + a TRUSTED caller principal, it calls
+//! [`friday_storage::get_run_answer_for_principal`] (owner==caller gate) and:
+//!
+//! * `Granted` (caller == the run's bound owner) → emits the answer BODY verbatim
+//!   (`answer` + its `answer_sha256`/`answer_len` fingerprint + status), labeled
+//!   `outcome="delivered"`;
+//! * `Denied` (non-owner caller / anonymous caller / NO bound owner) → emits NO body,
+//!   only a coarse, owner-free `deny_reason` label + the refs-only fingerprint,
+//!   labeled `outcome="denied"`;
+//! * `NotFound` (no stored result for `run_id`) → emits NO body, `outcome="not_found"`.
+//!
+//! ## Trusted-principal contract (NOT authentication)
+//! `--caller-principal` is a TRUSTED argument. This bin enforces ONLY the ownership
+//! MATCH (`caller == owner`); it does NOT authenticate the caller. The transport that
+//! authenticates a caller and supplies a trusted principal is a later composition
+//! slice (a long-lived `hub_server` WS transport) — OUT OF SCOPE here. This slice
+//! proves the owner-gating + body-return contract against a fixture DB only. It
+//! registers NO production route, replaces no TS read path, and confers no v1 GO.
+//!
+//! ## Guard discipline — the body flows ONLY through the Granted branch
+//! The owner's answer body can LEGITIMATELY contain any text — including `/Users/`,
+//! `Bearer`, `sk-`, even the literal `final_message`. So the Granted body is emitted
+//! WITHOUT the refs-only marker scan (scanning it would WITHHOLD legitimate owner
+//! content and would tempt loosening the shared guard — which this slice must NOT do).
+//! What makes that safe is the INVARIANT, not a scan: the `answer` field appears ONLY
+//! in the `delivered` branch, and a non-owner structurally NEVER reaches that branch
+//! ([`RunAnswerAccess::Granted`] is the sole body-bearing variant; everything else is
+//! body-free). The body-free `denied` / `not_found` / ERROR payloads (which must
+//! carry only labels + refs) ARE run through [`reject_forbidden_output`] as
+//! defense-in-depth. The refs-only proof bins and their `final_message`/`task` rejects
+//! are left UNTOUCHED — the body comes back through THIS owner-gated path alone.
+
+use std::env;
+use std::path::Path;
+
+use friday_storage::{
+    get_run_answer_for_principal, AnswerDenyReason, Db, RunAnswerAccess, StoredRunResult,
+};
+use serde_json::json;
+
+/// A fail-closed error: `kind` is a coarse, safe category (the only thing surfaced);
+/// the raw detail is deliberately NOT printed so storage/IO errors cannot leak paths.
+/// `Debug` carries ONLY the closed-vocab `kind` token (never a body/path), so it is
+/// safe for test `unwrap` diagnostics.
+#[derive(Debug)]
+struct ReadbackError {
+    kind: &'static str,
+}
+
+impl ReadbackError {
+    fn new(kind: &'static str) -> Self {
+        Self { kind }
+    }
+}
+
+fn main() {
+    match run() {
+        Ok(rendered) => {
+            println!("{rendered}");
+        }
+        Err(err) => {
+            // Body-free error to stdout (no detail), coarse category to stderr, non-zero exit.
+            let payload = json!({
+                "truth_label": "rust_wired_dev",
+                "proof_only": true,
+                "ok": false,
+                "error_kind": err.kind,
+            });
+            // Defense-in-depth: route the BODY-FREE error payload through the shared guard
+            // (fail closed if a marker ever leaked). `error_kind` is a static closed-vocab
+            // token today, so this never suppresses output.
+            let rendered = payload.to_string();
+            if reject_forbidden_output_body_free(&rendered).is_ok() {
+                println!("{rendered}");
+            }
+            eprintln!("hub_run_answer_readback_unavailable: {}", err.kind);
+            std::process::exit(2);
+        }
+    }
+}
+
+fn run() -> Result<String, ReadbackError> {
+    let args: Vec<String> = env::args().collect();
+
+    let db_path = arg_value(&args, "--db").ok_or(ReadbackError::new("bad_args"))?;
+    if !Path::new(&db_path).is_file() {
+        return Err(ReadbackError::new("db_not_found"));
+    }
+    let run_id = arg_value(&args, "--run-id").ok_or(ReadbackError::new("bad_args"))?;
+    // The TRUSTED caller principal (see module docs: this bin enforces the ownership
+    // MATCH, it does NOT authenticate). Required — a missing principal is bad args, NOT
+    // an anonymous body read.
+    let caller_principal =
+        arg_value(&args, "--caller-principal").ok_or(ReadbackError::new("bad_args"))?;
+
+    // Read-only open: a readback can NEVER mutate an operator DB just because a caller asks.
+    let db = Db::open_hub_readonly(&db_path).map_err(|_| ReadbackError::new("open_failed"))?;
+
+    // The OWNER-GATING decision lives entirely in this single storage primitive: it
+    // releases the body ONLY inside `Granted` (caller == the run's bound owner); every
+    // other arm is body-free AND owner-free (fail-closed).
+    let access = get_run_answer_for_principal(db.conn(), &run_id, &caller_principal)
+        .map_err(|_| ReadbackError::new("read_failed"))?;
+
+    match access {
+        // OWNER == CALLER: release the answer BODY verbatim. This is the ONLY branch that
+        // emits `answer`; it is NOT marker-scanned (the owner's own content may legitimately
+        // contain path/secret-looking substrings — see module docs).
+        RunAnswerAccess::Granted(stored) => Ok(render_delivered(&run_id, &stored)),
+        // NON-OWNER / ANONYMOUS / NO-OWNER-BOUND: NO body. Only a coarse, owner-free
+        // deny label. This payload is body-free and IS guard-scanned.
+        RunAnswerAccess::Denied(reason) => render_denied(&run_id, reason),
+        // No stored result for this run: NO body.
+        RunAnswerAccess::NotFound => render_not_found(&run_id),
+    }
+}
+
+/// The OWNER-GATED `delivered` payload: carries the answer BODY (`answer`) plus its
+/// refs-only fingerprint. Emitted ONLY for a `Granted` access (caller == owner). NOT
+/// run through the refs-only marker guard — the owner's body may legitimately contain
+/// marker-like substrings, and withholding it would defeat the slice's purpose.
+fn render_delivered(run_id: &str, stored: &StoredRunResult) -> String {
+    let payload = json!({
+        "truth_label": "rust_wired_dev",
+        "proof_only": true,
+        "ok": true,
+        "outcome": "delivered",
+        "run_id": run_id,
+        "status": stored.status,
+        // The owner-gated BODY — released ONLY to the matching owner principal.
+        "answer": stored.answer,
+        "answer_sha256": stored.answer_sha256,
+        "answer_len": stored.answer_len,
+    });
+    payload.to_string()
+}
+
+/// The body-free `denied` payload: a coarse deny label, NO body, NO owner principal.
+/// Guard-scanned as defense-in-depth (it must only ever carry labels/refs).
+fn render_denied(run_id: &str, reason: AnswerDenyReason) -> Result<String, ReadbackError> {
+    let payload = json!({
+        "truth_label": "rust_wired_dev",
+        "proof_only": true,
+        "ok": true,
+        "outcome": "denied",
+        "run_id": run_id,
+        "deny_reason": deny_reason_label(reason),
+    });
+    let rendered =
+        serde_json::to_string(&payload).map_err(|_| ReadbackError::new("serialize_failed"))?;
+    reject_forbidden_output_body_free(&rendered)?;
+    Ok(rendered)
+}
+
+/// The body-free `not_found` payload (no stored result for this run). Guard-scanned.
+fn render_not_found(run_id: &str) -> Result<String, ReadbackError> {
+    let payload = json!({
+        "truth_label": "rust_wired_dev",
+        "proof_only": true,
+        "ok": true,
+        "outcome": "not_found",
+        "run_id": run_id,
+    });
+    let rendered =
+        serde_json::to_string(&payload).map_err(|_| ReadbackError::new("serialize_failed"))?;
+    reject_forbidden_output_body_free(&rendered)?;
+    Ok(rendered)
+}
+
+/// A coarse, owner-free deny LABEL from a closed vocabulary. Never carries the owner
+/// principal or the body — mirrors the payload-free `AnswerDenyReason` contract.
+fn deny_reason_label(reason: AnswerDenyReason) -> &'static str {
+    match reason {
+        AnswerDenyReason::NoOwnerPrincipal => "no_owner_principal",
+        AnswerDenyReason::AnonymousCaller => "anonymous_caller",
+        AnswerDenyReason::PrincipalMismatch => "principal_mismatch",
+    }
+}
+
+fn arg_value(args: &[String], name: &str) -> Option<String> {
+    args.windows(2)
+        .find_map(|pair| (pair[0] == name).then(|| pair[1].clone()))
+        .or_else(|| {
+            let prefix = format!("{name}=");
+            args.iter()
+                .find_map(|arg| arg.strip_prefix(&prefix).map(str::to_string))
+        })
+}
+
+/// Defense-in-depth for the BODY-FREE payloads ONLY (`denied` / `not_found` / error):
+/// refuse to print if any forbidden marker leaked into a payload that must carry only
+/// labels/refs. Delegates to the SAME shared guard the refs-only proof bins use
+/// ([`friday_hub::refs_guard::reject_forbidden_output`]) and additionally blocks the
+/// `"answer"` body field — these payloads must NEVER carry it (only `delivered` does,
+/// via [`render_delivered`], which intentionally bypasses this scan). The shared guard
+/// itself is UNTOUCHED.
+fn reject_forbidden_output_body_free(rendered: &str) -> Result<(), ReadbackError> {
+    friday_hub::refs_guard::reject_forbidden_output(rendered, &["\"answer\"", "\"task\""])
+        .map_err(|_| ReadbackError::new("output_guard"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use friday_storage::{persist_run_result, RunResult};
+    use serde_json::{from_str, Value};
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    const OWNER: &str = "principal:owner-alice";
+    const OTHER: &str = "principal:intruder-bob";
+    const BODY: &str = "the durable final answer body for this run";
+
+    static C: AtomicU64 = AtomicU64::new(0);
+    fn tmp(tag: &str) -> String {
+        std::env::temp_dir()
+            .join(format!(
+                "friday-answer-readback-{}-{}-{}.sqlite",
+                std::process::id(),
+                tag,
+                C.fetch_add(1, Ordering::Relaxed)
+            ))
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    /// Seed a Finished run with `body`, owned by `owner` (or unowned when `owner` is
+    /// `None`), and return its DB path (closing the writable handle so the bin can
+    /// re-open read-only).
+    fn seed(tag: &str, run_id: &str, owner: Option<&str>, body: &str) -> String {
+        let path = tmp(tag);
+        let db = Db::open_hub(&path).unwrap();
+        let mut result = RunResult::new("finished", body, Some("audit-s3".to_string()));
+        if let Some(o) = owner {
+            result = result.with_owner_principal(o);
+        }
+        persist_run_result(db.conn(), run_id, &result, 7000).unwrap();
+        drop(db);
+        path
+    }
+
+    fn run_with(db: &str, run_id: &str, caller: &str) -> Result<String, ReadbackError> {
+        let args = vec![
+            "bin".to_string(),
+            "--db".to_string(),
+            db.to_string(),
+            "--run-id".to_string(),
+            run_id.to_string(),
+            "--caller-principal".to_string(),
+            caller.to_string(),
+        ];
+        // Mirror `run()` without re-parsing argv ordering concerns; this drives the SAME
+        // owner-gating primitive + render functions the bin's `run()` uses.
+        let db_path = arg_value(&args, "--db").unwrap();
+        let run_id = arg_value(&args, "--run-id").unwrap();
+        let caller_principal = arg_value(&args, "--caller-principal").unwrap();
+        let opened =
+            Db::open_hub_readonly(&db_path).map_err(|_| ReadbackError::new("open_failed"))?;
+        let access = get_run_answer_for_principal(opened.conn(), &run_id, &caller_principal)
+            .map_err(|_| ReadbackError::new("read_failed"))?;
+        match access {
+            RunAnswerAccess::Granted(stored) => Ok(render_delivered(&run_id, &stored)),
+            RunAnswerAccess::Denied(reason) => render_denied(&run_id, reason),
+            RunAnswerAccess::NotFound => render_not_found(&run_id),
+        }
+    }
+
+    #[test]
+    fn owner_caller_gets_the_answer_body_delivered() {
+        let db = seed("grant", "run-1", Some(OWNER), BODY);
+        let rendered = run_with(&db, "run-1", OWNER).unwrap();
+        let v: Value = from_str(&rendered).unwrap();
+        assert_eq!(v["outcome"], "delivered");
+        assert_eq!(v["truth_label"], "rust_wired_dev");
+        // The OWNER receives the real body verbatim, with its matching fingerprint.
+        assert_eq!(v["answer"], BODY);
+        assert_eq!(v["answer_len"], BODY.len() as i64);
+        assert_eq!(v["status"], "finished");
+        assert_eq!(v["answer_sha256"].as_str().unwrap().len(), 64);
+    }
+
+    #[test]
+    fn non_owner_caller_gets_no_body() {
+        let db = seed("mismatch", "run-1", Some(OWNER), BODY);
+        let rendered = run_with(&db, "run-1", OTHER).unwrap();
+        let v: Value = from_str(&rendered).unwrap();
+        assert_eq!(v["outcome"], "denied");
+        assert_eq!(v["deny_reason"], "principal_mismatch");
+        // FAIL-CLOSED: no body, and no leak of the owner principal, to a non-owner.
+        assert!(v.get("answer").is_none(), "a non-owner must get NO body");
+        assert!(
+            !rendered.contains(BODY),
+            "the body must never appear in a denied payload"
+        );
+        assert!(
+            !rendered.contains(OWNER),
+            "the owner principal must never leak to a non-owner"
+        );
+    }
+
+    #[test]
+    fn no_owner_bound_run_gets_no_body() {
+        // A run persisted with NO bound owner (the unchanged 3-arg `new`).
+        let db = seed("noowner", "run-1", None, BODY);
+        // Even a caller that supplies a perfectly valid principal gets NOTHING.
+        let rendered = run_with(&db, "run-1", OWNER).unwrap();
+        let v: Value = from_str(&rendered).unwrap();
+        assert_eq!(v["outcome"], "denied");
+        assert_eq!(v["deny_reason"], "no_owner_principal");
+        assert!(v.get("answer").is_none(), "an unowned run releases NO body");
+        assert!(!rendered.contains(BODY));
+    }
+
+    #[test]
+    fn anonymous_or_public_caller_gets_no_body() {
+        let db = seed("anon", "run-1", Some(OWNER), BODY);
+        for anon in ["", "   ", "public", "public:default"] {
+            let rendered = run_with(&db, "run-1", anon).unwrap();
+            let v: Value = from_str(&rendered).unwrap();
+            assert_eq!(
+                v["outcome"], "denied",
+                "anon caller '{anon}' must be denied"
+            );
+            assert_eq!(v["deny_reason"], "anonymous_caller");
+            assert!(
+                v.get("answer").is_none(),
+                "anon caller '{anon}' gets NO body"
+            );
+            assert!(!rendered.contains(BODY));
+        }
+    }
+
+    #[test]
+    fn unknown_run_is_not_found_with_no_body() {
+        let db = seed("notfound", "run-1", Some(OWNER), BODY);
+        let rendered = run_with(&db, "run-DOES-NOT-EXIST", OWNER).unwrap();
+        let v: Value = from_str(&rendered).unwrap();
+        assert_eq!(v["outcome"], "not_found");
+        assert!(v.get("answer").is_none());
+        assert!(!rendered.contains(BODY));
+    }
+
+    #[test]
+    fn owner_gets_a_marker_bearing_body_verbatim_but_a_non_owner_never_sees_it() {
+        // SECURITY: the owner's own answer may legitimately contain path/secret-LOOKING
+        // substrings (`/Users/`, `Bearer`). The owner must receive it VERBATIM (proving
+        // the Granted body is NOT over-blocked by a marker scan)...
+        let marker_body = "see /Users/alice/report and use Bearer tok-xyz to fetch it";
+        let db = seed("markerbody", "run-1", Some(OWNER), marker_body);
+        let owner_view = run_with(&db, "run-1", OWNER).unwrap();
+        let ov: Value = from_str(&owner_view).unwrap();
+        assert_eq!(ov["outcome"], "delivered");
+        assert_eq!(
+            ov["answer"], marker_body,
+            "the owner must get the marker-bearing body verbatim (no over-block)"
+        );
+        // ...AND a non-owner reading the SAME run gets NO body and no marker leak,
+        // proving the body never escapes the owner-gated branch.
+        let other_view = run_with(&db, "run-1", OTHER).unwrap();
+        let xv: Value = from_str(&other_view).unwrap();
+        assert_eq!(xv["outcome"], "denied");
+        assert!(xv.get("answer").is_none());
+        assert!(
+            !other_view.contains("/Users/") && !other_view.contains("Bearer"),
+            "a non-owner deny must never leak the marker-bearing body"
+        );
+    }
+
+    #[test]
+    fn missing_caller_principal_is_bad_args_not_an_anonymous_read() {
+        // A missing --caller-principal must FAIL (bad_args), never default to an
+        // anonymous/empty principal that could pathologically read a body.
+        let args = vec![
+            "bin".to_string(),
+            "--db".to_string(),
+            "/tmp/x.sqlite".to_string(),
+            "--run-id".to_string(),
+            "run-1".to_string(),
+        ];
+        assert!(arg_value(&args, "--caller-principal").is_none());
+    }
+
+    #[test]
+    fn body_free_guard_blocks_answer_and_secret_markers_but_not_safe_labels() {
+        // The body-free deny/not_found/error payloads must never carry an `"answer"` field
+        // or a secret/path marker.
+        assert!(reject_forbidden_output_body_free(r#"{"answer":"leak"}"#).is_err());
+        assert!(reject_forbidden_output_body_free(r#"{"x":"Bearer abc"}"#).is_err());
+        assert!(reject_forbidden_output_body_free(r#"{"p":"/Users/alice/x"}"#).is_err());
+        assert!(reject_forbidden_output_body_free(r#"{"task":"raw body"}"#).is_err());
+        // A clean labels-only deny payload passes.
+        assert!(reject_forbidden_output_body_free(
+            r#"{"outcome":"denied","deny_reason":"principal_mismatch","run_id":"run-1"}"#
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn refs_only_shared_guard_still_rejects_final_message_body() {
+        // GUARD-INTACT: the refs-only proof bins reject a `final_message` body via the
+        // shared guard (the marker this slice must NOT loosen). Asserted here so "guard
+        // intact" is test-backed, not merely "files untouched". The body comes back ONLY
+        // via THIS owner-gated path (`render_delivered`), never by loosening the guard.
+        assert!(friday_hub::refs_guard::reject_forbidden_output(
+            r#"{"final_message":"body"}"#,
+            &["final_message\""]
+        )
+        .is_err());
+        // A refs-only fingerprint payload (no body) still passes — proving the guard
+        // blocks the BODY, not the fingerprint refs.
+        assert!(friday_hub::refs_guard::reject_forbidden_output(
+            r#"{"final_message_sha256":"00ab","final_message_len":4}"#,
+            &["final_message\""]
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn deny_reason_labels_are_a_closed_owner_free_vocabulary() {
+        assert_eq!(
+            deny_reason_label(AnswerDenyReason::NoOwnerPrincipal),
+            "no_owner_principal"
+        );
+        assert_eq!(
+            deny_reason_label(AnswerDenyReason::AnonymousCaller),
+            "anonymous_caller"
+        );
+        assert_eq!(
+            deny_reason_label(AnswerDenyReason::PrincipalMismatch),
+            "principal_mismatch"
+        );
+    }
+}

--- a/src/api/mission-spine/friday-rust-hub-run-answer-readback-service.ts
+++ b/src/api/mission-spine/friday-rust-hub-run-answer-readback-service.ts
@@ -1,0 +1,318 @@
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { FridayDomainError } from "#errors";
+
+/**
+ * PROOF-ONLY (Rust-wired-DEV), DARK (no production route consumes this) TS->Rust
+ * OWNER-GATED ANSWER-BODY readback bridge for the S3 `hub_run_answer_readback` bin.
+ *
+ * This is the OWNER-GATED BODY sibling of the REFS-ONLY
+ * `friday-rust-hub-run-readback-service`, and it is deliberately a SEPARATE path: the
+ * refs-only bridge STRUCTURALLY rejects any body (its `parseReceipt` 503s on
+ * `task`/`final_message`/`finalMessage`), while THIS bridge's whole reason to exist is
+ * to return the agent-run ANSWER BODY back to the AUTHENTICATED OWNER — the future
+ * `executeRun`-replacement's owner-scoped body-return readback.
+ *
+ * It clones the execFile shape from `friday-rust-hub-run-readback-service` but drives
+ * the owner-gated body bin: given a `runId` + a TRUSTED `callerPrincipal`, the Rust
+ * primitive `friday_storage::get_run_answer_for_principal` releases the body ONLY when
+ * `caller == the run's bound owner`. The bin emits one of three outcomes:
+ *
+ *   - `delivered` — caller IS the owner: the receipt carries the answer BODY (+ its
+ *     sha256/len fingerprint + status);
+ *   - `denied` — non-owner / anonymous caller / NO bound owner: NO body, only a coarse
+ *     `denyReason` label (owner-free);
+ *   - `not_found` — no stored result for the run: NO body.
+ *
+ * TRUSTED-PRINCIPAL CONTRACT (not authentication): `callerPrincipal` is passed through
+ * as a TRUSTED argument. The Rust primitive enforces the ownership MATCH only; it does
+ * NOT authenticate the caller. The transport that authenticates a caller and supplies a
+ * trusted principal is a later composition slice (a long-lived `hub_server` WS
+ * transport) — out of scope here. This bridge registers NO production route, replaces no
+ * TS read path, is imported by no barrel/index, and confers no v1 GO.
+ *
+ * The bridge fails CLOSED (503) on any non-zero exit, timeout, parse failure, invalid
+ * shape, or any `delivered` outcome that arrives WITHOUT the body refs it claims. The
+ * refs-only stdout guard and its `final_message`/`task` rejects are UNTOUCHED — the body
+ * comes back ONLY through this owner-gated path.
+ */
+const execFileAsync = promisify(execFile);
+
+/** The owner-gating outcome label emitted by the Rust bin. */
+export type FridayRustHubRunAnswerOutcome = "delivered" | "denied" | "not_found";
+
+/** Why an owner-gated body read was denied (owner-free, closed vocabulary). */
+export type FridayRustHubRunAnswerDenyReason =
+  | "no_owner_principal"
+  | "anonymous_caller"
+  | "principal_mismatch";
+
+/**
+ * Owner-gated answer-body receipt. The `answer` body is present ONLY when
+ * `outcome === "delivered"` (caller == owner); every other outcome is body-free.
+ */
+export type FridayRustHubRunAnswerReadbackReceipt =
+  | {
+      readonly truthLabel: "rust_wired_dev";
+      readonly proofOnly: true;
+      readonly outcome: "delivered";
+      readonly runId: string;
+      readonly status: string;
+      /** The OWNER-GATED answer body — released ONLY to the matching owner principal. */
+      readonly answer: string;
+      readonly answerSha256: string;
+      readonly answerLen: number;
+    }
+  | {
+      readonly truthLabel: "rust_wired_dev";
+      readonly proofOnly: true;
+      readonly outcome: "denied";
+      readonly runId: string;
+      /** Coarse, owner-free deny reason. NO body, NO owner principal. */
+      readonly denyReason: FridayRustHubRunAnswerDenyReason;
+    }
+  | {
+      readonly truthLabel: "rust_wired_dev";
+      readonly proofOnly: true;
+      readonly outcome: "not_found";
+      readonly runId: string;
+    };
+
+export interface FridayRustHubRunAnswerReadbackInput {
+  /** Hub DB path to read the run back from (must exist; opened read-only by the bin). */
+  readonly dbPath: string;
+  /** The run id whose answer body to read back. */
+  readonly runId: string;
+  /**
+   * The TRUSTED caller principal. The Rust primitive enforces the ownership MATCH
+   * (`caller == owner`); it does NOT authenticate this value (see the file header).
+   */
+  readonly callerPrincipal: string;
+}
+
+export interface CreateFridayRustHubRunAnswerReadbackServiceOptions {
+  readonly repoRoot?: string;
+  /** Path to a prebuilt `hub_run_answer_readback` binary; falls back to `cargo run --bin` when absent. */
+  readonly adapterBin?: string;
+  readonly timeoutMs?: number;
+}
+
+export interface FridayRustHubRunAnswerReadbackService {
+  readAnswer(
+    input: FridayRustHubRunAnswerReadbackInput,
+  ): Promise<FridayRustHubRunAnswerReadbackReceipt>;
+}
+
+function unavailable(message: string): FridayDomainError {
+  return new FridayDomainError("MISSION_SPINE_RUST_RUN_ANSWER_READBACK_UNAVAILABLE", message, {
+    httpStatus: 503,
+    details: {
+      surface: "service:rust_hub_run_answer_readback",
+      bridge: "rust_wired_dev",
+      proofOnly: true,
+      proofReady: false,
+    },
+  });
+}
+
+function readTimeoutMs(raw: string | undefined, fallback: number): number {
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function resolveDefaultRepoRoot(): string {
+  const moduleDir = dirname(fileURLToPath(import.meta.url));
+  return resolve(moduleDir, "../../..");
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function asIntOrZero(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+const DENY_REASONS: ReadonlySet<string> = new Set([
+  "no_owner_principal",
+  "anonymous_caller",
+  "principal_mismatch",
+]);
+
+/**
+ * Validate + normalize the Rust bin's stdout into an owner-gated receipt. Fails closed on
+ * any shape violation. The `answer` body is accepted ONLY inside a `delivered` outcome;
+ * a `denied` / `not_found` outcome that pathologically carried a body field is rejected.
+ */
+function parseReceipt(payload: unknown): FridayRustHubRunAnswerReadbackReceipt {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw unavailable("Rust hub_run_answer_readback bridge returned a non-object payload.");
+  }
+  const root = payload as Record<string, unknown>;
+
+  if (root.truth_label !== "rust_wired_dev") {
+    throw unavailable(
+      "Rust hub_run_answer_readback bridge payload is not labeled rust_wired_dev.",
+    );
+  }
+  if (root.ok === false) {
+    throw unavailable("Rust hub_run_answer_readback bridge reported a fail-closed readback.");
+  }
+
+  const runId = asString(root.run_id);
+  if (!runId) {
+    throw unavailable("Rust hub_run_answer_readback bridge payload is missing the run id.");
+  }
+
+  const outcome = root.outcome;
+
+  if (outcome === "delivered") {
+    const status = asString(root.status);
+    const answerSha256 = asString(root.answer_sha256);
+    // The owner-gated body. `answer` may legitimately be the empty string (a Finished run
+    // with no final message), so it is validated as a string, not as truthy.
+    const answer = root.answer;
+    if (typeof answer !== "string" || !status || !answerSha256) {
+      throw unavailable(
+        "Rust hub_run_answer_readback bridge claimed delivered but is missing the body refs.",
+      );
+    }
+    return {
+      truthLabel: "rust_wired_dev",
+      proofOnly: true,
+      outcome: "delivered",
+      runId,
+      status,
+      answer,
+      answerSha256,
+      answerLen: asIntOrZero(root.answer_len),
+    };
+  }
+
+  if (outcome === "denied") {
+    // A denied outcome is BODY-FREE: any body field is a contract violation → fail closed.
+    if ("answer" in root || "task" in root || "final_message" in root || "finalMessage" in root) {
+      throw unavailable(
+        "Rust hub_run_answer_readback denied outcome carried a body field (rejected).",
+      );
+    }
+    const denyReason = root.deny_reason;
+    if (typeof denyReason !== "string" || !DENY_REASONS.has(denyReason)) {
+      throw unavailable("Rust hub_run_answer_readback denied outcome has an invalid deny reason.");
+    }
+    return {
+      truthLabel: "rust_wired_dev",
+      proofOnly: true,
+      outcome: "denied",
+      runId,
+      denyReason: denyReason as FridayRustHubRunAnswerDenyReason,
+    };
+  }
+
+  if (outcome === "not_found") {
+    if ("answer" in root || "task" in root || "final_message" in root || "finalMessage" in root) {
+      throw unavailable(
+        "Rust hub_run_answer_readback not_found outcome carried a body field (rejected).",
+      );
+    }
+    return {
+      truthLabel: "rust_wired_dev",
+      proofOnly: true,
+      outcome: "not_found",
+      runId,
+    };
+  }
+
+  throw unavailable("Rust hub_run_answer_readback bridge payload has an unknown outcome.");
+}
+
+export function createFridayRustHubRunAnswerReadbackService(
+  options: CreateFridayRustHubRunAnswerReadbackServiceOptions = {},
+): FridayRustHubRunAnswerReadbackService {
+  const repoRoot = resolve(
+    options.repoRoot ?? process.env.FRIDAY_REPO_ROOT ?? resolveDefaultRepoRoot(),
+  );
+  const rustCoreRoot = resolve(
+    process.env.FRIDAY_MISSION_SPINE_RUST_CORE_ROOT ?? join(repoRoot, "rust-core"),
+  );
+  const adapterBin = options.adapterBin ?? process.env.FRIDAY_HUB_RUN_ANSWER_READBACK_BIN;
+  const timeoutMs =
+    options.timeoutMs ??
+    readTimeoutMs(process.env.FRIDAY_HUB_RUN_ANSWER_READBACK_TIMEOUT_MS, 120_000);
+
+  return {
+    async readAnswer(
+      input: FridayRustHubRunAnswerReadbackInput,
+    ): Promise<FridayRustHubRunAnswerReadbackReceipt> {
+      const dbPath = resolve(input.dbPath);
+      if (!existsSync(dbPath)) {
+        throw unavailable("Rust hub_run_answer_readback DB is not present for this runtime.");
+      }
+      if (!input.runId) {
+        throw unavailable("Rust hub_run_answer_readback requires a run id.");
+      }
+      // A missing/empty caller principal must FAIL CLOSED here — never default to an
+      // anonymous principal that the bin would then deny anyway, and never spawn without it.
+      if (!input.callerPrincipal) {
+        throw unavailable("Rust hub_run_answer_readback requires a caller principal.");
+      }
+
+      const adapterArgs = [
+        "--db",
+        dbPath,
+        "--run-id",
+        input.runId,
+        "--caller-principal",
+        input.callerPrincipal,
+      ];
+
+      const command = adapterBin ?? "cargo";
+      const args = adapterBin
+        ? adapterArgs
+        : [
+            "run",
+            "--quiet",
+            "--manifest-path",
+            join(rustCoreRoot, "Cargo.toml"),
+            "-p",
+            "friday-hub",
+            "--bin",
+            "hub_run_answer_readback",
+            "--",
+            ...adapterArgs,
+          ];
+
+      let stdout = "";
+      try {
+        const result = await execFileAsync(command, args, {
+          cwd: repoRoot,
+          timeout: timeoutMs,
+          maxBuffer: 2 * 1024 * 1024,
+          env: {
+            ...process.env,
+            RUST_BACKTRACE: "0",
+          },
+        });
+        stdout = result.stdout;
+      } catch {
+        // Non-zero exit, timeout, or spawn failure → fail closed (no detail surfaced).
+        throw unavailable(
+          "Rust hub_run_answer_readback bridge could not produce an owner-gated readback.",
+        );
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(stdout);
+      } catch {
+        throw unavailable("Rust hub_run_answer_readback bridge returned invalid JSON.");
+      }
+      return parseReceipt(parsed);
+    },
+  };
+}

--- a/test/unit/api/mission-spine/friday-rust-hub-run-answer-readback-service.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-run-answer-readback-service.test.ts
@@ -1,0 +1,297 @@
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createFridayRustHubRunAnswerReadbackService } from "../../../../src/api/mission-spine/friday-rust-hub-run-answer-readback-service.js";
+
+/**
+ * PROOF-ONLY (Rust-wired-DEV), DARK owner-gated answer-BODY readback bridge test.
+ * Spawns a SCRIPTED MOCK bin (no real DB, no DeepSeek call, no quota, no secret) so it
+ * runs in CI hermetically, mirroring the proven chmod-0o755 shebang-mock idiom from the
+ * refs-only readback bridge test. The mock stands in for the Rust
+ * `hub_run_answer_readback` bin's three owner-gating outcomes.
+ *
+ * The mock bin is supplied as `adapterBin`, AND a real (empty) file is created at
+ * `dbPath` so the service's `existsSync(dbPath)` precondition passes before the mock is
+ * spawned. The OWNER-GATING decision itself is proven in the Rust bin's own unit tests
+ * (against a real fixture DB); these tests prove the TS bridge faithfully transports the
+ * delivered body to the owner and fails closed on every non-delivered / malformed case.
+ */
+describe("friday-rust-hub-run-answer-readback-service (S3 dark owner-gated body)", () => {
+  let scratch: string | undefined;
+
+  afterEach(() => {
+    if (scratch) {
+      rmSync(scratch, { recursive: true, force: true });
+      scratch = undefined;
+    }
+  });
+
+  function setup(mockSource: string): { binPath: string; dbPath: string } {
+    scratch = mkdtempSync(join(tmpdir(), "friday-hub-run-answer-readback-"));
+    const binPath = join(scratch, "hub_run_answer_readback_mock.mjs");
+    writeFileSync(binPath, `#!/usr/bin/env node\n${mockSource}`);
+    chmodSync(binPath, 0o755);
+    const dbPath = join(scratch, "rust-hub.sqlite");
+    writeFileSync(dbPath, "mock");
+    return { binPath, dbPath };
+  }
+
+  it("delivers the answer body to the owner on a delivered outcome", async () => {
+    const { binPath, dbPath } = setup(`
+      process.stdout.write(JSON.stringify({
+        truth_label: "rust_wired_dev",
+        proof_only: true,
+        ok: true,
+        outcome: "delivered",
+        run_id: "answer_probe_run",
+        status: "finished",
+        answer: "the durable final answer body",
+        answer_sha256: "0".repeat(64),
+        answer_len: 29,
+      }));
+    `);
+    const service = createFridayRustHubRunAnswerReadbackService({ adapterBin: binPath });
+
+    const receipt = await service.readAnswer({
+      dbPath,
+      runId: "answer_probe_run",
+      callerPrincipal: "principal:owner-alice",
+    });
+
+    expect(receipt).toMatchObject({
+      truthLabel: "rust_wired_dev",
+      proofOnly: true,
+      outcome: "delivered",
+      runId: "answer_probe_run",
+      status: "finished",
+      answer: "the durable final answer body",
+    });
+  });
+
+  it("transports a marker-bearing owner body verbatim (no over-block)", async () => {
+    // The OWNER's own answer may legitimately contain path/secret-LOOKING substrings; the
+    // bridge must NOT withhold or mangle them for the delivered owner.
+    const { binPath, dbPath } = setup(`
+      process.stdout.write(JSON.stringify({
+        truth_label: "rust_wired_dev",
+        proof_only: true,
+        ok: true,
+        outcome: "delivered",
+        run_id: "r",
+        status: "finished",
+        answer: "see /Users/alice/report and use Bearer tok-xyz",
+        answer_sha256: "a".repeat(64),
+        answer_len: 47,
+      }));
+    `);
+    const service = createFridayRustHubRunAnswerReadbackService({ adapterBin: binPath });
+
+    const receipt = await service.readAnswer({
+      dbPath,
+      runId: "r",
+      callerPrincipal: "principal:owner-alice",
+    });
+
+    expect(receipt.outcome).toBe("delivered");
+    if (receipt.outcome === "delivered") {
+      expect(receipt.answer).toBe("see /Users/alice/report and use Bearer tok-xyz");
+    }
+  });
+
+  it("returns a body-free denied receipt for a non-owner (no body, no owner)", async () => {
+    const { binPath, dbPath } = setup(`
+      process.stdout.write(JSON.stringify({
+        truth_label: "rust_wired_dev",
+        proof_only: true,
+        ok: true,
+        outcome: "denied",
+        run_id: "r",
+        deny_reason: "principal_mismatch",
+      }));
+    `);
+    const service = createFridayRustHubRunAnswerReadbackService({ adapterBin: binPath });
+
+    const receipt = await service.readAnswer({
+      dbPath,
+      runId: "r",
+      callerPrincipal: "principal:intruder-bob",
+    });
+
+    expect(receipt).toEqual({
+      truthLabel: "rust_wired_dev",
+      proofOnly: true,
+      outcome: "denied",
+      runId: "r",
+      denyReason: "principal_mismatch",
+    });
+    expect((receipt as Record<string, unknown>).answer).toBeUndefined();
+  });
+
+  it("maps a no-owner-bound run to a denied (no_owner_principal) receipt", async () => {
+    const { binPath, dbPath } = setup(`
+      process.stdout.write(JSON.stringify({
+        truth_label: "rust_wired_dev",
+        proof_only: true,
+        ok: true,
+        outcome: "denied",
+        run_id: "r",
+        deny_reason: "no_owner_principal",
+      }));
+    `);
+    const service = createFridayRustHubRunAnswerReadbackService({ adapterBin: binPath });
+
+    const receipt = await service.readAnswer({
+      dbPath,
+      runId: "r",
+      callerPrincipal: "principal:owner-alice",
+    });
+
+    expect(receipt.outcome).toBe("denied");
+    if (receipt.outcome === "denied") {
+      expect(receipt.denyReason).toBe("no_owner_principal");
+    }
+  });
+
+  it("returns a body-free not_found receipt for an unknown run", async () => {
+    const { binPath, dbPath } = setup(`
+      process.stdout.write(JSON.stringify({
+        truth_label: "rust_wired_dev",
+        proof_only: true,
+        ok: true,
+        outcome: "not_found",
+        run_id: "missing",
+      }));
+    `);
+    const service = createFridayRustHubRunAnswerReadbackService({ adapterBin: binPath });
+
+    const receipt = await service.readAnswer({
+      dbPath,
+      runId: "missing",
+      callerPrincipal: "principal:owner-alice",
+    });
+
+    expect(receipt).toEqual({
+      truthLabel: "rust_wired_dev",
+      proofOnly: true,
+      outcome: "not_found",
+      runId: "missing",
+    });
+  });
+
+  it("fails closed (503) when a denied outcome pathologically carries a body", async () => {
+    // A denied outcome MUST be body-free; a body field on it is a contract violation.
+    const { binPath, dbPath } = setup(`
+      process.stdout.write(JSON.stringify({
+        truth_label: "rust_wired_dev",
+        ok: true,
+        outcome: "denied",
+        run_id: "r",
+        deny_reason: "principal_mismatch",
+        answer: "leaked body that should never ride a denied outcome",
+      }));
+    `);
+    const service = createFridayRustHubRunAnswerReadbackService({ adapterBin: binPath });
+
+    await expect(
+      service.readAnswer({ dbPath, runId: "r", callerPrincipal: "principal:intruder-bob" }),
+    ).rejects.toMatchObject({
+      code: "MISSION_SPINE_RUST_RUN_ANSWER_READBACK_UNAVAILABLE",
+      httpStatus: 503,
+    });
+  });
+
+  it("fails closed when a delivered outcome is missing its body refs", async () => {
+    const { binPath, dbPath } = setup(`
+      process.stdout.write(JSON.stringify({
+        truth_label: "rust_wired_dev",
+        ok: true,
+        outcome: "delivered",
+        run_id: "r",
+        status: "finished",
+      }));
+    `);
+    const service = createFridayRustHubRunAnswerReadbackService({ adapterBin: binPath });
+
+    await expect(
+      service.readAnswer({ dbPath, runId: "r", callerPrincipal: "principal:owner-alice" }),
+    ).rejects.toMatchObject({
+      code: "MISSION_SPINE_RUST_RUN_ANSWER_READBACK_UNAVAILABLE",
+      httpStatus: 503,
+    });
+  });
+
+  it("fails closed on an unknown outcome label", async () => {
+    const { binPath, dbPath } = setup(`
+      process.stdout.write(JSON.stringify({
+        truth_label: "rust_wired_dev",
+        ok: true,
+        outcome: "something_else",
+        run_id: "r",
+      }));
+    `);
+    const service = createFridayRustHubRunAnswerReadbackService({ adapterBin: binPath });
+
+    await expect(
+      service.readAnswer({ dbPath, runId: "r", callerPrincipal: "principal:owner-alice" }),
+    ).rejects.toMatchObject({
+      code: "MISSION_SPINE_RUST_RUN_ANSWER_READBACK_UNAVAILABLE",
+      httpStatus: 503,
+    });
+  });
+
+  it("requires a caller principal (fails closed without spawning)", async () => {
+    const { binPath, dbPath } = setup(`process.stdout.write("UNREACHABLE");`);
+    const service = createFridayRustHubRunAnswerReadbackService({ adapterBin: binPath });
+
+    await expect(
+      service.readAnswer({ dbPath, runId: "r", callerPrincipal: "" }),
+    ).rejects.toMatchObject({
+      code: "MISSION_SPINE_RUST_RUN_ANSWER_READBACK_UNAVAILABLE",
+      httpStatus: 503,
+    });
+  });
+
+  it("fails closed (503) on a non-zero exit", async () => {
+    const { binPath, dbPath } = setup(`
+      process.stderr.write("hub_run_answer_readback_unavailable: open_failed");
+      process.exit(2);
+    `);
+    const service = createFridayRustHubRunAnswerReadbackService({ adapterBin: binPath });
+
+    await expect(
+      service.readAnswer({ dbPath, runId: "r", callerPrincipal: "principal:owner-alice" }),
+    ).rejects.toMatchObject({
+      code: "MISSION_SPINE_RUST_RUN_ANSWER_READBACK_UNAVAILABLE",
+      httpStatus: 503,
+    });
+  });
+
+  it("fails closed on malformed JSON", async () => {
+    const { binPath, dbPath } = setup(`process.stdout.write("not json {");`);
+    const service = createFridayRustHubRunAnswerReadbackService({ adapterBin: binPath });
+
+    await expect(
+      service.readAnswer({ dbPath, runId: "r", callerPrincipal: "principal:owner-alice" }),
+    ).rejects.toMatchObject({
+      code: "MISSION_SPINE_RUST_RUN_ANSWER_READBACK_UNAVAILABLE",
+      httpStatus: 503,
+    });
+  });
+
+  it("fails closed on timeout", async () => {
+    const { binPath, dbPath } = setup(`setTimeout(() => process.stdout.write("late"), 5000);`);
+    const service = createFridayRustHubRunAnswerReadbackService({
+      adapterBin: binPath,
+      timeoutMs: 200,
+    });
+
+    await expect(
+      service.readAnswer({ dbPath, runId: "r", callerPrincipal: "principal:owner-alice" }),
+    ).rejects.toMatchObject({
+      code: "MISSION_SPINE_RUST_RUN_ANSWER_READBACK_UNAVAILABLE",
+      httpStatus: 503,
+    });
+  });
+});


### PR DESCRIPTION
## What this is
DARK (no production route consumes it yet) owner-scoped answer-**BODY** readback substrate for the future `executeRun`-replacement. The replacement returns the agent-run ANSWER BODY to the authenticated **owner**. The refs-only stdout transport STRUCTURALLY rejects a body (Rust `reject_forbidden_output` rejects `final_message`; TS `parseReceipt` 503s on `final_message`/`finalMessage`) and **stays intact** — so the body comes back via this OWNER-GATED readback path ONLY, never by loosening any guard.

## Write-set (purely additive — 3 NEW files, zero edits to any existing file)
- `rust-core/crates/friday-hub/src/bin/hub_run_answer_readback.rs` — NEW Rust bin (a SEPARATE path from the refs-only proof bins). Given `--db --run-id --caller-principal`, calls `friday_storage::get_run_answer_for_principal` and emits one of three outcomes.
- `src/api/mission-spine/friday-rust-hub-run-answer-readback-service.ts` — NEW TS service cloning the readback-service `execFile`/parse shape; returns a discriminated receipt whose `answer` body is present ONLY on `delivered`.
- `test/unit/api/mission-spine/friday-rust-hub-run-answer-readback-service.test.ts` — NEW TS test (scripted-mock `adapterBin`, hermetic, no spend).

No `lib.rs` / `Cargo.toml` / `refs_guard` changes were needed — `refs_guard` is already a `pub mod`, the storage primitive is already re-exported, and bins auto-discover from `src/bin/`. The new service is imported by no barrel/index (DARK).

## Owner-gating contract (how `owner == caller` is enforced + the fail-closed paths)
The single owner-gating decision lives in `friday_storage::get_run_answer_for_principal` (`rust-core/crates/friday-storage/src/run_result.rs:397-428`):
- **Equality gate**: `caller_principal == owner` → `RunAnswerAccess::Granted(stored)` (line 423). The body is released ONLY inside `Granted`.
- **Fail-closed paths** (each releases NO body, NO owner principal):
  - no/empty/`public` bound owner → `Denied(NoOwnerPrincipal)` (lines 410-413)
  - anonymous/`public`/empty caller → `Denied(AnonymousCaller)` (lines 417-419)
  - real owner exists but `caller != owner` → `Denied(PrincipalMismatch)` (lines 423-426)
  - no stored result → `NotFound`

The bin dispatches on this (`hub_run_answer_readback.rs:112-122`): `Granted → render_delivered` (the ONLY branch that emits `answer`; NOT marker-scanned, since the owner's own content may legitimately contain marker-like substrings); `Denied`/`NotFound`/error → body-free payloads that ARE run through the shared refs guard. The safety basis is the invariant — the body appears only in the `Granted → delivered` branch, and a non-owner structurally never reaches it — not a scan.

## Refs-only guard is UNTOUCHED
Zero edits to `refs_guard.rs`, `hub_run_readback.rs`, `hub_run_task.rs`, `lib.rs`, the TS refs-only readback service, or `Cargo.toml` (`git diff --name-only` against the base shows only the 3 new files). Guard-intact is also **test-backed**, not merely diff-backed: `refs_only_shared_guard_still_rejects_final_message_body` asserts the shared guard still rejects a `final_message` body, and the pre-existing untouched `refs_guard.rs::extra_markers_trip_the_guard` (ran green in the workspace test) asserts the same.

## Local verification (all green)
- Rust (`rust-core/`): `cargo fmt --all -- --check` clean · `cargo clippy --workspace --all-targets -- -D warnings` clean (0 warnings) · `cargo build --workspace` OK · `cargo test --workspace` OK · new bin: **10/10** tests pass.
- TS: `npm run lint` **0 errors** (1544 pre-existing warnings, none new) · new service test **12/12** pass · full `npm test`: **12601 passed, 0 failed**, no type errors.

## Truth labels
`rust_wired_dev` / DARK substrate for the `executeRun`-replacement. The body returns ONLY via this owner-gated readback; the refs-only stdout guard is intact. **NOT v1 GO.** No live credentials, no provider run, no spend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)