### PR TITLE
feat(rust): execrun-replace slice 2 — TS continuity projector (fork ii, dark)

### DIFF
--- a/src/api/mission-spine/friday-rust-hub-run-continuity-projector-service.ts
+++ b/src/api/mission-spine/friday-rust-hub-run-continuity-projector-service.ts
@@ -1,0 +1,338 @@
+import type Database from "better-sqlite3";
+
+import { FridayDomainError } from "#errors";
+
+/**
+ * PROOF-ONLY (Rust-wired-DEV), DARK (no production route consumes this) Rust→TS
+ * CONTINUITY PROJECTOR for the future `executeRun`-replacement (executeRun-replace
+ * slice 2, fork ii).
+ *
+ * ## Why this exists
+ * The executeRun-replacement routes production agent-runs through the Rust Hub loop.
+ * The Rust loop writes its OWN narrow Hub SQLite (`agent_run` = run_id/task/state/
+ * created_at/updated_at, the answer body in a separate result store) and its OWN
+ * `token_ledger` (`bill_model_call`). But the TS READ surface (getRun/listRuns) and the
+ * TS usage/cost ledger (`llm_usage_records`, read by `querySummary`) speak the RICH TS
+ * `friday_agent_runs` schema. So when a Rust run completes, SOMETHING must make it
+ * VISIBLE + BILLED on the TS side.
+ *
+ * The operator's fork decision (ii): a TS-side PROJECTOR reads a Rust run RECEIPT and
+ * writes the TS continuity rows — NOT Rust writing directly into TS tables. This file is
+ * that projector.
+ *
+ * ## Truth labels (read before trusting this)
+ * - **DARK substrate** for the executeRun-replacement: NO production route registers or
+ *   consumes this; it is driven by a STATIC FIXTURE receipt in tests. Reversible —
+ *   unreferenced by any barrel/route until the composition slice wires it.
+ * - **`rust_wired` ceiling**: this projects a Rust-produced receipt; it is NOT a product
+ *   path and confers no v1 GO.
+ * - **Usage token source wiring is DEFERRED to the composition slice.** This dark slice
+ *   models the receipt as ALREADY carrying the token totals as a fixture field
+ *   ({@link FridayRustHubRunReceipt.usagePromptTokens} / `usageCompletionTokens` /
+ *   `usageTotalTokens}`). In production those totals live in the Rust `token_ledger`
+ *   (`bill_model_call`); plumbing the real Rust token source onto the receipt is the
+ *   composition slice's job, NOT this slice's.
+ *
+ * ## Hard contracts enforced here (the load-bearing invariants)
+ * 1. **No double-count** — the projector is the SOLE TS-VISIBLE usage writer per Rust
+ *    run. It writes EXACTLY ONE `llm_usage_records` row per run, keyed on a PK
+ *    DETERMINISTICALLY derived from `run_id` ({@link usageLedgerIdForRun}). The Rust-side
+ *    `bill_model_call`/`token_ledger` row stays Rust-internal; the TS cost READ route
+ *    (`querySummary`) reads this projected row, never re-deriving usage from the receipt.
+ *    Re-projecting the same `run_id` adds NO second ledger row.
+ * 2. **Idempotent on run_id** — both writes are `INSERT … ON CONFLICT DO NOTHING`
+ *    keyed on a deterministic PK (`friday_agent_runs.id` = `run_id`;
+ *    `llm_usage_records.id` = {@link usageLedgerIdForRun}). Projecting the same receipt
+ *    twice yields the SAME single set of rows.
+ * 3. **No body** — the projected row NEVER carries the answer body. `task` is a
+ *    non-body placeholder, `responseText` is a body REF (the receipt's
+ *    `finalMessageSha256` + len), never the body text. The body stays owner-gated
+ *    (slice 3).
+ */
+
+/**
+ * A completed Rust run RECEIPT, REFS-ONLY (no body, no secrets, no PII).
+ *
+ * This mirrors the `hub_run_task` Rust bin's refs-only stdout
+ * (rust-core/crates/friday-hub/src/bin/hub_run_task.rs) and ADDITIONALLY models the
+ * per-run token totals as fixture fields — see the file header: wiring the real Rust
+ * `token_ledger` (`bill_model_call`) source onto these fields is the composition slice's
+ * job, deferred here.
+ */
+export interface FridayRustHubRunReceipt {
+  /** Always the dev tier — this is NOT a product/proven receipt. */
+  readonly truthLabel: "rust_wired_dev";
+  /** Always true — a loud reminder this is a dev bridge, not a product path. */
+  readonly proofOnly: true;
+  readonly ok: true;
+  readonly runId: string;
+  /** Non-secret composite of provider + model (`provider_id:model`). */
+  readonly routeId: string;
+  readonly providerId: string;
+  readonly model: string;
+  /** Debug-formatted model size token from the Rust selection (e.g. `Flash`). */
+  readonly modelSize?: string;
+  /** Debug-formatted backend kind from the Rust selection (e.g. `Http`). */
+  readonly backendKind?: string;
+  /**
+   * Debug-formatted Rust `LoopStatus` (`Finished` | `Errored` | `Bounded` | `Paused`
+   * | `Blocked`). Mapped to a terminal TS run status by {@link mapLoopStatusToTsStatus}.
+   */
+  readonly loopStatus: string;
+  /** Bounded refs-only error category when the loop errored, else `null`/omitted. */
+  readonly errorCategory?: string | null;
+  readonly turns: number;
+  readonly executedTools: number;
+  /** sha256 of the answer body — a REF, NEVER the body text. */
+  readonly finalMessageSha256: string;
+  /** Length (bytes) of the answer body — a measure, NEVER the body text. */
+  readonly finalMessageLen: number;
+  readonly auditChainVerified: boolean;
+  /**
+   * Per-run prompt token total. FIXTURE field for this dark slice — in production this
+   * comes from the Rust `token_ledger` (`bill_model_call`); see file header.
+   */
+  readonly usagePromptTokens: number;
+  /** Per-run completion token total. FIXTURE field — see {@link usagePromptTokens}. */
+  readonly usageCompletionTokens: number;
+  /** Per-run total tokens. FIXTURE field — see {@link usagePromptTokens}. */
+  readonly usageTotalTokens: number;
+  /** ISO timestamp the Rust run completed (drives the TS continuity timestamps). */
+  readonly completedAtIso: string;
+}
+
+/** What the projector wrote/found (refs-only — no body). */
+export interface FridayRustHubRunProjectionResult {
+  readonly runId: string;
+  /** The TS `friday_agent_runs.id` (== `run_id`). */
+  readonly agentRunId: string;
+  /** The deterministic `llm_usage_records.id` for this run. */
+  readonly usageLedgerId: string;
+  /** Terminal TS run status the loop status mapped to. */
+  readonly status: string;
+  /** True when THIS call inserted the agent_run row (false ⇒ already present). */
+  readonly insertedAgentRun: boolean;
+  /** True when THIS call inserted the usage ledger row (false ⇒ already present). */
+  readonly insertedUsageLedger: boolean;
+}
+
+export interface FridayRustHubRunContinuityProjectorService {
+  /**
+   * Project a completed Rust run receipt onto the TS continuity surfaces. Idempotent on
+   * `run_id`: a second call with the same receipt makes no second row. Body-free.
+   */
+  project(
+    db: Database.Database,
+    receipt: FridayRustHubRunReceipt,
+  ): FridayRustHubRunProjectionResult;
+}
+
+/**
+ * The DETERMINISTIC primary key for this run's TS usage-ledger row. `llm_usage_records`
+ * has NO `run_id` column, so a deterministic PK derived from `run_id` is the SOLE dedup
+ * mechanism that enforces the no-double-count invariant — a random id would silently add
+ * a second ledger row on re-projection. The `run_id` is ALSO stashed in `metadata_json`
+ * for traceability, but the PK is what guarantees one-row-per-run.
+ */
+export function usageLedgerIdForRun(runId: string): string {
+  return `rust-continuity-usage:${runId}`;
+}
+
+/**
+ * Map a Rust `LoopStatus` debug token to a TERMINAL TS run status. The TS projection is
+ * a completed Rust run, so only terminal statuses are produced (never an active one).
+ */
+export function mapLoopStatusToTsStatus(loopStatus: string): string {
+  switch (loopStatus) {
+    case "Finished":
+      return "completed";
+    case "Paused":
+      // Owner-approval pause: the loop stopped resumably, but the projected TS row is a
+      // terminal snapshot of THIS receipt — surface it as cancelled (non-error stop).
+      return "cancelled";
+    case "Bounded":
+      // max_turns reached without finishing — an incomplete terminal stop.
+      return "failed";
+    case "Blocked":
+    case "Errored":
+    default:
+      return "failed";
+  }
+}
+
+/** Reject a receipt that carries (or smuggles) a raw body. Fails closed (500). */
+function rejectBodyBearingReceipt(receipt: FridayRustHubRunReceipt): void {
+  const root = receipt as unknown as Record<string, unknown>;
+  if ("task" in root || "final_message" in root || "finalMessage" in root) {
+    throw new FridayDomainError(
+      "MISSION_SPINE_RUST_CONTINUITY_BODY_REJECTED",
+      "Rust run receipt carried a raw body — refused to project.",
+      {
+        httpStatus: 500,
+        details: {
+          surface: "service:rust_hub_run_continuity_projector",
+          bridge: "rust_wired_dev",
+          proofOnly: true,
+        },
+      },
+    );
+  }
+}
+
+/**
+ * Render the body REF stored in `responseText`. NEVER the body — only the receipt's
+ * sha256 fingerprint + byte length, which the owner-gated slice-3 readback can later
+ * resolve to the real answer for the bound owner.
+ */
+function bodyRefFromReceipt(receipt: FridayRustHubRunReceipt): string {
+  return `rust-run-body-ref:sha256=${receipt.finalMessageSha256};len=${receipt.finalMessageLen}`;
+}
+
+export function createFridayRustHubRunContinuityProjectorService(): FridayRustHubRunContinuityProjectorService {
+  return {
+    project(db, receipt) {
+      if (receipt.truthLabel !== "rust_wired_dev") {
+        throw new FridayDomainError(
+          "MISSION_SPINE_RUST_CONTINUITY_NOT_DEV",
+          "Rust run receipt is not labeled rust_wired_dev — refused to project.",
+          { httpStatus: 500 },
+        );
+      }
+      rejectBodyBearingReceipt(receipt);
+
+      const runId = receipt.runId;
+      if (!runId) {
+        throw new FridayDomainError(
+          "MISSION_SPINE_RUST_CONTINUITY_MISSING_RUN_ID",
+          "Rust run receipt is missing a run id — refused to project.",
+          { httpStatus: 500 },
+        );
+      }
+
+      const status = mapLoopStatusToTsStatus(receipt.loopStatus);
+      const usageLedgerId = usageLedgerIdForRun(runId);
+      const completedAtIso = receipt.completedAtIso;
+      // Synthesize a deterministic session key — the refs-only receipt carries none.
+      const sessionKey = `rust-projection:${runId}`;
+      // `task` is NOT NULL and body-class: NEVER the real task text. A fixed placeholder.
+      const taskPlaceholder = "[rust-projected run]";
+      const responseTextRef = bodyRefFromReceipt(receipt);
+      const summary = `Projected Rust run (${receipt.loopStatus}) — refs-only, body owner-gated.`;
+      const errorCode = status === "completed" ? null : (receipt.errorCategory ?? "rust_loop_non_finished");
+
+      // Continuity telemetry that fits the existing `metadata_json` (an open JSON column).
+      // We do NOT widen the typed FridayAgentRunMetadata interface — these refs live as
+      // JSON only, alongside the `surface` label the typed interface already carries.
+      const metadataJson = JSON.stringify({
+        surface: "rust_continuity_projection",
+        rustContinuity: {
+          truthLabel: receipt.truthLabel,
+          routeId: receipt.routeId,
+          loopStatus: receipt.loopStatus,
+          turns: receipt.turns,
+          executedTools: receipt.executedTools,
+          auditChainVerified: receipt.auditChainVerified,
+          finalMessageSha256: receipt.finalMessageSha256,
+          finalMessageLen: receipt.finalMessageLen,
+          ...(receipt.errorCategory ? { errorCategory: receipt.errorCategory } : {}),
+        },
+      });
+
+      // NOTE: `context_cost_summary_json` is left UNSET. That column is read via
+      // `safeJsonParse<FridayAgentContextCostSummary>` ({ totalEstimatedChars,
+      // totalEstimatedInputTokens, components }) — a system-prompt context-cost summary the
+      // refs-only receipt does NOT carry. Writing a non-conforming shape there would be a
+      // type-lie; the per-run token totals already live on usage_input/usage_output and in
+      // the projected ledger row. Leave it null rather than fabricate a conforming summary.
+
+      // ── (1) ONE TS agent_run row — idempotent on run_id (PK). ──
+      // INSERT OR IGNORE: a second projection of the same run_id is a no-op (no dup, no
+      // throw). `create()` in the agent-run repo is a plain INSERT hardcoded to
+      // 'pending', so it cannot be reused for an idempotent terminal projected row.
+      const agentRunInsert = db
+        .prepare(
+          `INSERT OR IGNORE INTO friday_agent_runs (
+             id, task, status, session_key, provider_id, model,
+             attempt, max_attempts, created_at, started_at, completed_at,
+             duration_ms, usage_input, usage_output,
+             error_code, response_text, summary,
+             metadata_json
+           ) VALUES (?, ?, ?, ?, ?, ?, 0, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          runId,
+          taskPlaceholder,
+          status,
+          sessionKey,
+          receipt.providerId,
+          receipt.model,
+          completedAtIso,
+          completedAtIso,
+          completedAtIso,
+          // duration_ms: 0 PLACEHOLDER — the refs-only receipt carries `completedAtIso`
+          // but NO start time, so a real duration is not derivable here.
+          0,
+          receipt.usagePromptTokens,
+          receipt.usageCompletionTokens,
+          errorCode,
+          responseTextRef,
+          summary,
+          metadataJson,
+        );
+
+      // ── (2) ONE TS-visible usage/cost ledger row — idempotent + no double-count. ──
+      // Deterministic PK derived from run_id is the ONLY dedup key (`llm_usage_records`
+      // has no run_id column). INSERT OR IGNORE ⇒ exactly one ledger row per run, even on
+      // re-projection. This projected row is the SOLE TS-visible usage write for the run;
+      // the Rust-side bill_model_call/token_ledger row stays Rust-internal and the TS cost
+      // read route (querySummary) reads THIS row, never re-deriving from the receipt.
+      const usageDay = completedAtIso.slice(0, 10);
+      const usageMonth = completedAtIso.slice(0, 7);
+      const usageMetadataJson = JSON.stringify({
+        source: "rust_continuity_projection",
+        runId,
+        routeId: receipt.routeId,
+        // Truth signal: cost was NOT resolved from a pricing catalog here (token source
+        // wiring is deferred), so pricing is unresolved by definition.
+        pricingResolved: false,
+      });
+      const usageInsert = db
+        .prepare(
+          `INSERT OR IGNORE INTO llm_usage_records (
+             id, occurred_at, usage_day, usage_month, provider_id, provider_kind,
+             provider_api, model, route_strategy, task_complexity,
+             input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+             total_tokens, cost_usd, currency, metadata_json, created_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'configured', 'medium', ?, ?, 0, 0, ?, 0, 'USD', ?, ?)`,
+        )
+        .run(
+          usageLedgerId,
+          completedAtIso,
+          usageDay,
+          usageMonth,
+          receipt.providerId,
+          // provider_kind: the receipt carries a provider_id, not a typed kind — record
+          // the honest "unknown" rather than fabricating a kind attribution.
+          "unknown",
+          // provider_api: DeepSeek (the Rust loop's only provider) speaks the
+          // openai-completions wire API.
+          "openai-completions",
+          receipt.model,
+          receipt.usagePromptTokens,
+          receipt.usageCompletionTokens,
+          receipt.usageTotalTokens,
+          usageMetadataJson,
+          completedAtIso,
+        );
+
+      return {
+        runId,
+        agentRunId: runId,
+        usageLedgerId,
+        status,
+        insertedAgentRun: agentRunInsert.changes > 0,
+        insertedUsageLedger: usageInsert.changes > 0,
+      };
+    },
+  };
+}

--- a/test/unit/api/mission-spine/friday-rust-hub-run-continuity-projector-service.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-run-continuity-projector-service.test.ts
@@ -1,0 +1,265 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type Database from "better-sqlite3";
+
+import { createFridayAgentRunRepository } from "#agent";
+import { createTestDb } from "../../satellites/_helpers/create-test-db.helper.js";
+import {
+  createFridayRustHubRunContinuityProjectorService,
+  usageLedgerIdForRun,
+  mapLoopStatusToTsStatus,
+  type FridayRustHubRunReceipt,
+} from "../../../../src/api/mission-spine/friday-rust-hub-run-continuity-projector-service.js";
+
+// A STATIC FIXTURE Rust run receipt — this slice is DARK/fixture-driven: no production
+// route produces or consumes it. Refs-only: it carries the answer body sha256/len, NEVER
+// the body text.
+const FIXTURE_RECEIPT: FridayRustHubRunReceipt = {
+  truthLabel: "rust_wired_dev",
+  proofOnly: true,
+  ok: true,
+  runId: "hub_run_task_dev_42_1717800000000000000",
+  routeId: "deepseek:deepseek-v4-flash",
+  providerId: "deepseek",
+  model: "deepseek-v4-flash",
+  modelSize: "Flash",
+  backendKind: "Http",
+  loopStatus: "Finished",
+  errorCategory: null,
+  turns: 3,
+  executedTools: 2,
+  finalMessageSha256: "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+  finalMessageLen: 128,
+  auditChainVerified: true,
+  usagePromptTokens: 1500,
+  usageCompletionTokens: 420,
+  usageTotalTokens: 1920,
+  completedAtIso: "2026-06-08T12:00:00.000Z",
+};
+
+interface AgentRunRow {
+  id: string;
+  task: string;
+  status: string;
+  session_key: string;
+  provider_id: string | null;
+  model: string | null;
+  usage_input: number | null;
+  usage_output: number | null;
+  response_text: string | null;
+  summary: string | null;
+  metadata_json: string | null;
+  context_cost_summary_json: string | null;
+}
+
+function countAgentRuns(db: Database.Database, runId: string): number {
+  return (db.prepare("SELECT COUNT(*) AS n FROM friday_agent_runs WHERE id = ?").get(runId) as { n: number }).n;
+}
+
+function countUsageRows(db: Database.Database, usageId: string): number {
+  return (db.prepare("SELECT COUNT(*) AS n FROM llm_usage_records WHERE id = ?").get(usageId) as { n: number }).n;
+}
+
+describe("FridayRustHubRunContinuityProjector (executeRun-replace slice 2, fork ii, dark)", () => {
+  const layers: ReturnType<typeof createTestDb>[] = [];
+
+  function freshDb(): Database.Database {
+    const layer = createTestDb();
+    layers.push(layer);
+    return layer.writer;
+  }
+
+  afterEach(() => {
+    for (const layer of layers) {
+      try {
+        layer.close();
+      } catch {
+        // no-op
+      }
+    }
+    layers.length = 0;
+  });
+
+  it("loop-status → terminal TS status mapping is exhaustive and terminal", () => {
+    expect(mapLoopStatusToTsStatus("Finished")).toBe("completed");
+    expect(mapLoopStatusToTsStatus("Paused")).toBe("cancelled");
+    expect(mapLoopStatusToTsStatus("Bounded")).toBe("failed");
+    expect(mapLoopStatusToTsStatus("Blocked")).toBe("failed");
+    expect(mapLoopStatusToTsStatus("Errored")).toBe("failed");
+    // No mapping yields an ACTIVE (non-terminal) status — a projected run is complete.
+    for (const s of ["Finished", "Paused", "Bounded", "Blocked", "Errored", "anything"]) {
+      expect(["completed", "failed", "cancelled"]).toContain(mapLoopStatusToTsStatus(s));
+    }
+  });
+
+  it("projects ONE agent_run + ONE usage row with the correct Rust→TS column mapping", () => {
+    const db = freshDb();
+    const projector = createFridayRustHubRunContinuityProjectorService();
+
+    const result = projector.project(db, FIXTURE_RECEIPT);
+    expect(result.insertedAgentRun).toBe(true);
+    expect(result.insertedUsageLedger).toBe(true);
+    expect(result.status).toBe("completed");
+    expect(result.agentRunId).toBe(FIXTURE_RECEIPT.runId);
+    expect(result.usageLedgerId).toBe(usageLedgerIdForRun(FIXTURE_RECEIPT.runId));
+
+    // Exactly one agent_run row.
+    expect(countAgentRuns(db, FIXTURE_RECEIPT.runId)).toBe(1);
+    const run = db
+      .prepare("SELECT * FROM friday_agent_runs WHERE id = ?")
+      .get(FIXTURE_RECEIPT.runId) as AgentRunRow;
+    expect(run.status).toBe("completed");
+    expect(run.session_key).toBe(`rust-projection:${FIXTURE_RECEIPT.runId}`);
+    expect(run.provider_id).toBe("deepseek");
+    expect(run.model).toBe("deepseek-v4-flash");
+    // The per-run mirror onto the agent_run row matches the receipt totals.
+    expect(run.usage_input).toBe(1500);
+    expect(run.usage_output).toBe(420);
+
+    // Exactly one ledger row, keyed on the deterministic run-derived PK.
+    const usageId = usageLedgerIdForRun(FIXTURE_RECEIPT.runId);
+    expect(countUsageRows(db, usageId)).toBe(1);
+    const usage = db
+      .prepare("SELECT * FROM llm_usage_records WHERE id = ?")
+      .get(usageId) as {
+      input_tokens: number;
+      output_tokens: number;
+      total_tokens: number;
+      provider_id: string;
+      provider_api: string;
+      route_strategy: string;
+      task_complexity: string;
+      model: string;
+    };
+    // Usage totals MATCH the receipt — no double-count, no re-derivation.
+    expect(usage.input_tokens).toBe(1500);
+    expect(usage.output_tokens).toBe(420);
+    expect(usage.total_tokens).toBe(1920);
+    expect(usage.provider_id).toBe("deepseek");
+    expect(usage.provider_api).toBe("openai-completions");
+    expect(usage.route_strategy).toBe("configured");
+    expect(usage.task_complexity).toBe("medium");
+    expect(usage.model).toBe("deepseek-v4-flash");
+  });
+
+  it("is idempotent on run_id — re-projecting adds NO second agent_run or usage row", () => {
+    const db = freshDb();
+    const projector = createFridayRustHubRunContinuityProjectorService();
+    const usageId = usageLedgerIdForRun(FIXTURE_RECEIPT.runId);
+
+    const first = projector.project(db, FIXTURE_RECEIPT);
+    expect(first.insertedAgentRun).toBe(true);
+    expect(first.insertedUsageLedger).toBe(true);
+
+    // Re-project the SAME receipt — must NOT throw and must be a no-op insert.
+    const second = projector.project(db, FIXTURE_RECEIPT);
+    expect(second.insertedAgentRun).toBe(false);
+    expect(second.insertedUsageLedger).toBe(false);
+
+    // Still exactly one row in EACH surface.
+    expect(countAgentRuns(db, FIXTURE_RECEIPT.runId)).toBe(1);
+    expect(countUsageRows(db, usageId)).toBe(1);
+
+    // And the SOLE ledger row's totals are unchanged (no additive double-count).
+    const total = db
+      .prepare("SELECT SUM(total_tokens) AS t FROM llm_usage_records WHERE id = ?")
+      .get(usageId) as { t: number };
+    expect(total.t).toBe(1920);
+  });
+
+  it("is the SOLE TS-visible usage writer per run — one ledger row across the whole table", () => {
+    const db = freshDb();
+    const projector = createFridayRustHubRunContinuityProjectorService();
+
+    projector.project(db, FIXTURE_RECEIPT);
+    projector.project(db, FIXTURE_RECEIPT);
+    projector.project(db, FIXTURE_RECEIPT);
+
+    // The cost READ route (querySummary) reads llm_usage_records; assert the WHOLE table
+    // has exactly one row for this run — the no-double-count invariant at the read surface.
+    const all = db
+      .prepare("SELECT COUNT(*) AS n, COALESCE(SUM(total_tokens), 0) AS t FROM llm_usage_records")
+      .get() as { n: number; t: number };
+    expect(all.n).toBe(1);
+    expect(all.t).toBe(1920);
+  });
+
+  it("getRun (repository getById) and listRuns (list) read the projected row back", () => {
+    const db = freshDb();
+    const projector = createFridayRustHubRunContinuityProjectorService();
+    projector.project(db, FIXTURE_RECEIPT);
+
+    const repo = createFridayAgentRunRepository();
+
+    // getRun path.
+    const got = repo.getById(db, FIXTURE_RECEIPT.runId);
+    expect(got).not.toBeNull();
+    expect(got?.id).toBe(FIXTURE_RECEIPT.runId);
+    expect(got?.status).toBe("completed");
+    expect(got?.usageInput).toBe(1500);
+    expect(got?.usageOutput).toBe(420);
+
+    // listRuns path.
+    const listed = repo.list(db, { limit: 50 });
+    expect(listed.some((r) => r.id === FIXTURE_RECEIPT.runId)).toBe(true);
+  });
+
+  it("the projected row carries NO answer body — responseText is a ref, never the body", () => {
+    const db = freshDb();
+    const projector = createFridayRustHubRunContinuityProjectorService();
+    projector.project(db, FIXTURE_RECEIPT);
+
+    const run = db
+      .prepare("SELECT * FROM friday_agent_runs WHERE id = ?")
+      .get(FIXTURE_RECEIPT.runId) as AgentRunRow;
+
+    // task is a non-body placeholder — NEVER the real task text.
+    expect(run.task).toBe("[rust-projected run]");
+
+    // responseText is a body REF (sha256 + len), never the body.
+    expect(run.response_text).toContain("rust-run-body-ref");
+    expect(run.response_text).toContain(FIXTURE_RECEIPT.finalMessageSha256);
+    expect(run.response_text).toContain(String(FIXTURE_RECEIPT.finalMessageLen));
+
+    // No column in the projected row carries a `final_message`/body field, and the metadata
+    // carries only refs (sha/len), not the body text.
+    const serialized = JSON.stringify(run);
+    expect(serialized).not.toContain("final_message\"");
+    expect(serialized).not.toContain("finalMessage\"");
+  });
+
+  it("maps a non-Finished receipt to a terminal failed status with an error code", () => {
+    const db = freshDb();
+    const projector = createFridayRustHubRunContinuityProjectorService();
+
+    const errored: FridayRustHubRunReceipt = {
+      ...FIXTURE_RECEIPT,
+      runId: "hub_run_task_dev_99_errored",
+      loopStatus: "Errored",
+      errorCategory: "provider_http_error",
+    };
+    const result = projector.project(db, errored);
+    expect(result.status).toBe("failed");
+
+    const run = db
+      .prepare("SELECT status, error_code FROM friday_agent_runs WHERE id = ?")
+      .get(errored.runId) as { status: string; error_code: string | null };
+    expect(run.status).toBe("failed");
+    expect(run.error_code).toBe("provider_http_error");
+  });
+
+  it("refuses to project a receipt that smuggles a raw body (fails closed)", () => {
+    const db = freshDb();
+    const projector = createFridayRustHubRunContinuityProjectorService();
+
+    const bodyBearing = {
+      ...FIXTURE_RECEIPT,
+      runId: "hub_run_task_dev_body_smuggle",
+      // A smuggled raw body field that must never be projected.
+      final_message: "the secret answer body",
+    } as unknown as FridayRustHubRunReceipt;
+
+    expect(() => projector.project(db, bodyBearing)).toThrow();
+    // Nothing was written — fail-closed leaves no partial rows.
+    expect(countAgentRuns(db, "hub_run_task_dev_body_smuggle")).toBe(0);
+  });
+});

--- a/test/unit/api/mission-spine/friday-rust-hub-run-continuity-projector-service.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-run-continuity-projector-service.test.ts
@@ -27,7 +27,7 @@ const FIXTURE_RECEIPT: FridayRustHubRunReceipt = {
   errorCategory: null,
   turns: 3,
   executedTools: 2,
-  finalMessageSha256: "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+  finalMessageSha256: "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", // pragma: allowlist secret
   finalMessageLen: 128,
   auditChainVerified: true,
   usagePromptTokens: 1500,


### PR DESCRIPTION
## What this is

A **DARK, fixture-driven** Rust→TS **continuity projector** for the future `executeRun`-replacement (slice 2, fork **(ii)**). When a production agent-run is routed through the Rust Hub loop, the Rust side writes its OWN narrow Hub SQLite (`agent_run` + a separate body store) and its OWN `token_ledger` (`bill_model_call`). But the TS read surface (`getRun`/`listRuns`) and the TS usage/cost ledger (`llm_usage_records`, read by `querySummary`) speak the RICH TS `friday_agent_runs` schema. So a completed Rust run must be made **VISIBLE + BILLED** on the TS side.

Per the operator's fork decision **(ii)**: a TS-side projector reads a Rust run **RECEIPT** and writes the TS continuity rows — Rust never writes TS tables.

## Write-set

| File | Change |
| --- | --- |
| `src/api/mission-spine/friday-rust-hub-run-continuity-projector-service.ts` | NEW projector service |
| `test/unit/api/mission-spine/friday-rust-hub-run-continuity-projector-service.test.ts` | NEW unit test (8 cases) |

No other files touched. **No migration** (see below). No Rust crate touched (Rust side reused unchanged). `friday-agent-runtime.ts` and the 503 stubs untouched. `FridayAgentRunMetadata` typed interface NOT widened — rust telemetry lives in `metadata_json` JSON alongside the existing `surface` label.

## Rust receipt → TS column mapping

The receipt mirrors the `hub_run_task` Rust bin's refs-only stdout and ADDITIONALLY models the per-run token totals as **fixture fields** — wiring the real Rust `token_ledger` (`bill_model_call`) source onto them is the **composition slice's** job, deferred here.

### `friday_agent_runs` (the TS `agent_run` + `run_result` equivalent — TS has no separate `run_result` table; `response_text`/`summary` are the result columns)

| Receipt field | TS column | Notes |
| --- | --- | --- |
| `runId` | `id` (PK) | deterministic dedup key |
| — | `task` | `"[rust-projected run]"` PLACEHOLDER — `task` is NOT NULL **and body-class**; never the real task text |
| `loopStatus` | `status` | terminal map: `Finished`→`completed`, `Errored`/`Bounded`/`Blocked`→`failed`, `Paused`→`cancelled` |
| — | `session_key` | synthesized `rust-projection:${runId}` (receipt carries none) |
| `providerId` | `provider_id` | |
| `model` | `model` | |
| `completedAtIso` | `created_at` / `started_at` / `completed_at` | |
| — | `duration_ms` | `0` PLACEHOLDER — receipt has `completedAtIso` but no start time, so a real duration is not derivable |
| `usagePromptTokens` | `usage_input` | per-run mirror onto the run row |
| `usageCompletionTokens` | `usage_output` | per-run mirror onto the run row |
| `errorCategory` (non-finished) | `error_code` | `null` when completed; `rust_loop_non_finished` fallback |
| `finalMessageSha256` + `finalMessageLen` | `response_text` | a body **REF** (`rust-run-body-ref:sha256=…;len=…`), **NEVER the body** |
| — | `summary` | refs-only label, no body |
| `routeId`, `loopStatus`, `turns`, `executedTools`, `auditChainVerified`, `finalMessageSha256`/`Len` | `metadata_json.rustContinuity` | refs-only telemetry; `metadata.surface = "rust_continuity_projection"` |
| — | `context_cost_summary_json` | **left UNSET** — that column is read via `safeJsonParse<FridayAgentContextCostSummary>` (a system-prompt context-cost summary the refs-only receipt does not carry); writing a non-conforming shape would be a type-lie |

### `llm_usage_records` (the authoritative TS-visible usage/cost ledger — read by `querySummary`)

| Receipt field | TS column | Notes |
| --- | --- | --- |
| `usageLedgerIdForRun(runId)` | `id` (PK) | `rust-continuity-usage:${runId}` — DETERMINISTIC, the sole dedup key (`llm_usage_records` has NO `run_id` column) |
| `usagePromptTokens` | `input_tokens` | |
| `usageCompletionTokens` | `output_tokens` | |
| `usageTotalTokens` | `total_tokens` | matches the receipt; no re-derivation |
| `providerId` | `provider_id` | |
| — | `provider_kind` | `"unknown"` — receipt carries a `provider_id`, not a typed kind; honest non-attribution rather than fabricated kind |
| — | `provider_api` | `openai-completions` (the Rust loop's DeepSeek provider's wire API) |
| `model` | `model` | |
| — | `route_strategy` / `task_complexity` | `configured` / `medium` (CHECK-constrained columns) |
| — | `cost_usd` | `0` + `metadata.pricingResolved=false` — honest: token-source/pricing wiring is deferred |
| `runId`, `routeId` | `metadata_json` | traceability (the PK is the dedup mechanism) |

## Contracts (the load-bearing invariants)

- **No double-count** — the projector is the SOLE TS-visible usage writer per run. Enforced by the deterministic ledger PK `usageLedgerIdForRun(run_id)` + `INSERT OR IGNORE` (`friday-rust-hub-run-continuity-projector-service.ts` — `usageLedgerIdForRun` ~L138, the `INSERT OR IGNORE INTO llm_usage_records` ~L262). The Rust-side `bill_model_call`/`token_ledger` row stays Rust-internal; the TS cost read route (`querySummary`) reads THIS projected row, never re-deriving from the receipt. Proven: 3× projection ⇒ whole-table `COUNT(*)=1`, `SUM(total_tokens)=1920`.
- **Idempotent on run_id** — both writes are `INSERT OR IGNORE` on a deterministic PK (`friday_agent_runs.id = run_id` ~L228; `llm_usage_records.id = usageLedgerIdForRun(run_id)`). Re-projecting the same receipt is a no-op (no throw, no dup); `insertedAgentRun`/`insertedUsageLedger` flag whether THIS call inserted. (The repo's own `create()`/`insert()` are plain INSERTs that would THROW on a dup PK — hence the projector writes its own idempotent INSERTs.)
- **No body** — `task` is a placeholder, `responseText` is a sha256+len REF, never the body; body stays owner-gated (slice 3). The projector also fails closed (500) on a receipt that smuggles a `final_message`/`finalMessage`/`task` field.

## No migration (and why)

Zero schema change. Both idempotency keys are EXISTING PRIMARY KEYs (`friday_agent_runs.id`, `llm_usage_records.id`) and every receipt field maps into an EXISTING column. Adding a `run_id` column to `llm_usage_records` was the tempting move and was deliberately resisted — it touches the migrations CI job for no contract benefit. All four contracts are met with no migration. (`INSERT OR IGNORE` masks ALL constraint failures, so the `inserted* === true` assertions on first projection empirically validate the CHECK-constraint mapping — a silently-skipped row would have failed the test.)

## Dark / fixture-driven / truth labels

- No production route registers or consumes the projector; it is driven by a STATIC FIXTURE receipt in the test. Reversible — unreferenced by any barrel/route until the composition slice wires it.
- `rust_wired` ceiling; usage token source wiring deferred to the composition slice; **NOT v1 GO**.
- `getRun`/`listRuns` are tested at the **repository** layer (`createFridayAgentRunRepository().getById`/`.list`) — the correct altitude for a dark slice whose write-set cannot register an HTTP route. Intel for the composition slice: the HTTP route's `filterVisibleAgentRuns` (`isUserVisibleAgentRun`) would NOT drop the projected row — `surface = "rust_continuity_projection"` is not `autonomous_internal_*` and `session_key = rust-projection:${runId}` starts with neither `autonomous:` nor `subagent:`, so it surfaces in the HTTP `listRuns`.

## Local verification

- `npm run lint` → **0 errors** (1544 pre-existing warnings, none from the new service file).
- `npm run build:api` (tsc) → clean.
- New test → **8/8 passing**.
- `test/unit/state/sqlite/**` → **163/163 passing** (no migration, migrations job stays green).
- Regression isolation: the new module is imported by nothing and `build:api` (tsc) is clean, so it cannot regress other tests at type or runtime level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)