### PR TITLE
feat(rust): execrun WS substrate S-D — TS agent-run WS client service (dark, refs-only)

### DIFF
--- a/src/api/mission-spine/friday-rust-hub-agent-run-ws-client.ts
+++ b/src/api/mission-spine/friday-rust-hub-agent-run-ws-client.ts
@@ -1,0 +1,333 @@
+import WebSocket from "ws";
+
+import { FridayDomainError } from "#errors";
+
+/**
+ * PROOF-ONLY (Rust-wired), DARK (no production route consumes this) TS->Rust
+ * AGENT-RUN WS CLIENT for the executeRun-replacement (WS-transport substrate,
+ * sub-slice S-D).
+ *
+ * ## Why this exists
+ * Today every production agent-run is driven by a per-run `execFile` of a Rust bin
+ * (see `friday-rust-hub-run-task-bridge-service` — the thing being replaced). The
+ * target topology is a SINGLE long-lived Rust agent-run WS SERVER (sub-slice S-B):
+ * the TS API holds ONE persistent WebSocket and dispatches each agent-run as a
+ * message over it, instead of spawning a process per run. This file is the TS-side
+ * CLIENT of that server.
+ *
+ * It mirrors the per-run bridge's discipline — a service factory, a REFS-ONLY parse,
+ * and FAIL-CLOSED (503) error handling — but over a socket instead of a child
+ * process.
+ *
+ * ## Truth labels (read before trusting this)
+ * - **DARK substrate** for the executeRun-replacement: NO production route registers
+ *   or consumes this. It is imported by no barrel/index/bootstrap. The composition
+ *   slice (S-F) wires it; until then it is reversible and inert.
+ * - **`rust_wired` ceiling**: this speaks the S-A wire contract to a (later) Rust
+ *   server; it is NOT a product path and confers NO v1 GO. In tests it is driven by a
+ *   hermetic in-process loopback stub server — never a real Rust bin, never a
+ *   provider, never network egress beyond loopback.
+ *
+ * ## Wire contract (S-A) — what crosses the socket
+ * The wire messages are S-A's `Message::AgentRunRequest` / `Message::AgentRunResult`
+ * (rust-core/crates/friday-protocol/src/lib.rs). They are tagged JSON objects with a
+ * `kind` discriminator.
+ *
+ *   - Request  (TS -> server): `{ kind: "AgentRunRequest", run_id, task,
+ *     forwarded_principal, auth_proof }`. `forwarded_principal` / `auth_proof` are
+ *     SHAPE-ONLY on the wire and are VERIFIED by a later sub-slice (S-C) against the
+ *     sealed session; this client never asserts they are trusted.
+ *   - Result   (server -> TS): `{ kind: "AgentRunResult", run_id, status,
+ *     answer_sha256?, answer_len? }`. **REFS-ONLY**: it carries the answer
+ *     FINGERPRINT (sha256 + byte length) when an answer exists, and **NEVER** the
+ *     answer body / `final_message`. The body is delivered SEALED over the session by
+ *     a later sub-slice, never as a refs field.
+ *
+ * **Framing decision (documented per slice spec):** this dark client consumes the
+ * INNER `Message` JSON object (the `{ kind, ... }` payload), NOT the full versioned
+ * `Envelope` wrapper (`schema_version`/`msg_id`/`sent_at`) nor the sealed-session
+ * ciphertext. Envelope versioning and session sealing are the server/auth sub-slices'
+ * job (S-B/S-C); modeling only the inner message keeps this slice honest about what it
+ * owns. The client owns both ends against its hermetic stub, so this choice is
+ * test-faithful without pulling in the transport layer.
+ *
+ * ## Connection lifecycle (documented choice)
+ * The INTENT is a single PERSISTENT socket shared across dispatches; that is what the
+ * composition slice will hold. For this dark, single-call-shaped slice the client
+ * (re)connects PER CALL: `connect -> send one AgentRunRequest -> await exactly one
+ * AgentRunResult (bounded timeout) -> close`. Per-call connect keeps teardown trivial
+ * and each dispatch independently fail-closed; promoting it to a held socket is a
+ * mechanical change for S-F and does not alter the refs-only / fail-closed contract.
+ *
+ * ## Hard contracts enforced here (the load-bearing invariants)
+ * 1. **REFS-ONLY allowlist parse** — the result is read through a STRICT allowlist of
+ *    exactly `{ run_id, status, answer_sha256?, answer_len? }`. The receipt is built
+ *    as a FRESH object literal reading only those keys; the raw payload is NEVER
+ *    spread. If the server ever sent an `answer` / `final_message` / body field, this
+ *    client does NOT surface it — a body-bearing payload still yields a SUCCESSFUL
+ *    refs-only receipt with the body absent (it is dropped, not 503'd).
+ * 2. **FAIL-CLOSED (503)** on any non-clean settle: connection error, an unexpected
+ *    socket close before a result, a bounded timeout, malformed JSON, a wrong/missing
+ *    `kind` (unknown shape), or a result missing a required ref (`run_id` / `status`).
+ *    Every failure throws the same 503-shaped {@link FridayDomainError}; none surface a
+ *    body and none return a partial success.
+ * 3. **Single-settle** — the awaited result settles AT MOST ONCE. On the first of
+ *    {message, error, close, timeout} the timer is cleared and all listeners removed,
+ *    so a late frame can neither resolve a second time nor flip a rejection.
+ */
+
+/** Default sentinel port — the real server port is supplied by the composition slice. */
+const DEFAULT_AGENT_RUN_WS_PORT = 0;
+
+/** Default bounded await for one AgentRunResult before failing closed. */
+const DEFAULT_RESULT_TIMEOUT_MS = 30_000;
+
+/** The S-A request wire kind. */
+const REQUEST_KIND = "AgentRunRequest" as const;
+/** The S-A result wire kind. */
+const RESULT_KIND = "AgentRunResult" as const;
+
+/**
+ * A dispatched agent-run, TS-side. `forwardedPrincipal` / `authProof` are conveyed
+ * SHAPE-ONLY on the wire; the Rust server's later auth sub-slice (S-C) verifies them
+ * against the sealed session. This client never treats them as trusted.
+ */
+export interface FridayRustHubAgentRunWsRequest {
+  /** Caller-chosen idempotency/run identifier for this agent-run. */
+  readonly runId: string;
+  /** The agent task/prompt to run on the Rust loop. */
+  readonly task: string;
+  /** TS-token-resolved principal — SHAPE-ONLY on the wire (verified later by S-C). */
+  readonly forwardedPrincipal: string;
+  /** Sealed proof bytes — SHAPE-ONLY on the wire (opaque, verified later by S-C). */
+  readonly authProof: Uint8Array;
+}
+
+/**
+ * REFS-ONLY agent-run result receipt — the answer FINGERPRINT only, NEVER the body.
+ * `answerSha256` / `answerLen` are present only when the run produced an answer.
+ */
+export interface FridayRustHubAgentRunWsResult {
+  /** Always `rust_wired` — a loud reminder this is a substrate path, not a product one. */
+  readonly truthLabel: "rust_wired";
+  /** The run this result terminates (echoes the request's run id). */
+  readonly runId: string;
+  /** Coarse loop-status label (e.g. `completed` / `denied` / `no_answer`). */
+  readonly status: string;
+  /** sha256 of the answer body — a REF, NEVER the body text. Absent when no answer. */
+  readonly answerSha256?: string;
+  /** Byte length of the answer body — a measure, NEVER the body text. Absent when no answer. */
+  readonly answerLen?: number;
+}
+
+export interface CreateFridayRustHubAgentRunWsClientServiceOptions {
+  /** Loopback host for the Rust agent-run WS server. Defaults to `127.0.0.1`. */
+  readonly host?: string;
+  /** Port the Rust agent-run WS server listens on. Defaults to a sentinel (0). */
+  readonly port?: number;
+  /** Bounded await (ms) for one AgentRunResult before failing closed. */
+  readonly timeoutMs?: number;
+}
+
+export interface FridayRustHubAgentRunWsClientService {
+  /**
+   * Dispatch one agent-run over the WS connection and await its REFS-ONLY result.
+   * Fails closed (503) on any non-clean settle. Body-free by construction.
+   */
+  dispatchRun(
+    request: FridayRustHubAgentRunWsRequest,
+  ): Promise<FridayRustHubAgentRunWsResult>;
+}
+
+function unavailable(message: string): FridayDomainError {
+  return new FridayDomainError("MISSION_SPINE_RUST_AGENT_RUN_WS_CLIENT_UNAVAILABLE", message, {
+    httpStatus: 503,
+    details: {
+      surface: "service:rust_hub_agent_run_ws_client",
+      bridge: "rust_wired",
+      proofOnly: true,
+      proofReady: false,
+    },
+  });
+}
+
+function readTimeoutMs(raw: string | undefined, fallback: number): number {
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function readPort(raw: string | undefined, fallback: number): number {
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+/**
+ * Validate + normalize ONE inbound result frame into a refs-only receipt. Fails closed
+ * on malformed JSON, a wrong/missing `kind` (unknown shape), or a missing required ref.
+ *
+ * REFS-ONLY allowlist: the receipt is built as a FRESH object literal reading ONLY
+ * `run_id` / `status` / `answer_sha256` / `answer_len`. The raw payload is never
+ * spread, so a body/`answer`/`final_message` field — if the server ever sent one — is
+ * silently DROPPED (it never reaches the receipt), NOT 503'd. Surfacing a body is the
+ * one outcome this client structurally cannot produce.
+ */
+function parseResult(raw: string): FridayRustHubAgentRunWsResult {
+  let payload: unknown;
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    throw unavailable("Rust agent-run WS client received invalid JSON.");
+  }
+
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw unavailable("Rust agent-run WS client received a non-object frame.");
+  }
+  const root = payload as Record<string, unknown>;
+
+  // Unknown shape: anything that is not an AgentRunResult is rejected (the request
+  // kind, an Error kind, a typo'd kind, or a kind-less blob) — fail closed.
+  if (root.kind !== RESULT_KIND) {
+    throw unavailable("Rust agent-run WS client received an unknown message shape.");
+  }
+
+  const runId = asString(root.run_id);
+  const status = asString(root.status);
+  if (!runId || !status) {
+    throw unavailable("Rust agent-run WS client result is missing a required ref.");
+  }
+
+  // Strict allowlist: read ONLY the known refs. answer_sha256 / answer_len are
+  // optional (S-A `Option` + skip_serializing_if). Anything else on `root` —
+  // including any body field — is intentionally never read onto the receipt.
+  const answerSha256 = asString(root.answer_sha256);
+  const answerLen = asNumber(root.answer_len);
+
+  return {
+    truthLabel: "rust_wired",
+    runId,
+    status,
+    ...(answerSha256 !== undefined ? { answerSha256 } : {}),
+    ...(answerLen !== undefined ? { answerLen } : {}),
+  };
+}
+
+/** The S-A request frame, inner-message JSON (no envelope wrapper — see file header). */
+function encodeRequest(request: FridayRustHubAgentRunWsRequest): string {
+  return JSON.stringify({
+    kind: REQUEST_KIND,
+    run_id: request.runId,
+    task: request.task,
+    forwarded_principal: request.forwardedPrincipal,
+    // Wire the proof bytes as a plain number array (shape-only; never trusted here).
+    auth_proof: Array.from(request.authProof),
+  });
+}
+
+export function createFridayRustHubAgentRunWsClientService(
+  options: CreateFridayRustHubAgentRunWsClientServiceOptions = {},
+): FridayRustHubAgentRunWsClientService {
+  const host = options.host ?? process.env.FRIDAY_HUB_AGENT_RUN_WS_HOST ?? "127.0.0.1";
+  const port =
+    options.port ?? readPort(process.env.FRIDAY_HUB_AGENT_RUN_WS_PORT, DEFAULT_AGENT_RUN_WS_PORT);
+  const timeoutMs =
+    options.timeoutMs ??
+    readTimeoutMs(process.env.FRIDAY_HUB_AGENT_RUN_WS_TIMEOUT_MS, DEFAULT_RESULT_TIMEOUT_MS);
+
+  return {
+    dispatchRun(
+      request: FridayRustHubAgentRunWsRequest,
+    ): Promise<FridayRustHubAgentRunWsResult> {
+      if (!request.runId) {
+        return Promise.reject(unavailable("Rust agent-run WS client requires a run id."));
+      }
+
+      const url = `ws://${host}:${port}`;
+      return new Promise<FridayRustHubAgentRunWsResult>((resolve, reject) => {
+        let settled = false;
+        let socket: WebSocket;
+        const timer = setTimeout(() => {
+          fail(unavailable("Rust agent-run WS client timed out awaiting a result."));
+        }, timeoutMs);
+        // Never let the bounded timer keep the event loop (or a forked test worker) alive.
+        if (typeof timer.unref === "function") timer.unref();
+
+        /** Settle exactly once: clear the timer, drop listeners, close the socket. */
+        function teardown(): void {
+          clearTimeout(timer);
+          if (socket) {
+            socket.removeAllListeners();
+            try {
+              socket.close();
+            } catch {
+              // best-effort close; the result has already been decided.
+            }
+          }
+        }
+
+        function succeed(result: FridayRustHubAgentRunWsResult): void {
+          if (settled) return;
+          settled = true;
+          teardown();
+          resolve(result);
+        }
+
+        function fail(error: FridayDomainError): void {
+          if (settled) return;
+          settled = true;
+          teardown();
+          reject(error);
+        }
+
+        try {
+          socket = new WebSocket(url);
+        } catch {
+          fail(unavailable("Rust agent-run WS client could not open a connection."));
+          return;
+        }
+
+        socket.on("open", () => {
+          try {
+            socket.send(encodeRequest(request));
+          } catch {
+            fail(unavailable("Rust agent-run WS client failed to send the request."));
+          }
+        });
+
+        socket.on("message", (data: WebSocket.RawData) => {
+          let result: FridayRustHubAgentRunWsResult;
+          try {
+            result = parseResult(data.toString());
+          } catch (error) {
+            fail(
+              error instanceof FridayDomainError
+                ? error
+                : unavailable("Rust agent-run WS client could not parse a result."),
+            );
+            return;
+          }
+          succeed(result);
+        });
+
+        // Connection error (e.g. ECONNREFUSED) → fail closed, no detail surfaced.
+        socket.on("error", () => {
+          fail(unavailable("Rust agent-run WS client connection error."));
+        });
+
+        // An unexpected close before a result is delivered is a fail-closed condition.
+        socket.on("close", () => {
+          fail(unavailable("Rust agent-run WS client connection closed before a result."));
+        });
+      });
+    },
+  };
+}

--- a/test/unit/api/mission-spine/friday-rust-hub-agent-run-ws-client.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-agent-run-ws-client.test.ts
@@ -1,0 +1,288 @@
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import { WebSocketServer, type WebSocket as WsSocket } from "ws";
+
+import { FridayDomainError } from "../../../../src/errors/friday-domain-error.js";
+import {
+  createFridayRustHubAgentRunWsClientService,
+  type FridayRustHubAgentRunWsRequest,
+} from "../../../../src/api/mission-spine/friday-rust-hub-agent-run-ws-client.js";
+
+/**
+ * WS-transport substrate sub-slice S-D (DARK, refs-only) — TS agent-run WS CLIENT test.
+ *
+ * Hermetic: every test drives a REAL in-process `ws` `WebSocketServer` bound to
+ * `127.0.0.1:0` (ephemeral port) — NO real Rust bin, NO provider, NO network egress
+ * beyond loopback-to-stub. The stub server scripts the server side of the S-A
+ * `AgentRunRequest`/`AgentRunResult` exchange so each fail-closed branch (connection
+ * error / unexpected close / timeout / malformed JSON / unknown shape / missing ref)
+ * is exercised against a REAL socket, and the refs-only / body-drop contract is proven
+ * end-to-end.
+ *
+ * The composition slice (S-F) wires this client into a route; this test only proves
+ * the dark client parses the wire faithfully and fails closed.
+ */
+
+/** A request fixture — the proof bytes are shape-only on the wire (not trusted here). */
+const REQUEST: FridayRustHubAgentRunWsRequest = {
+  runId: "agent_run_probe",
+  task: "summarize the changelog",
+  forwardedPrincipal: "principal:owner-alice",
+  authProof: new Uint8Array([1, 2, 3, 4]),
+};
+
+/** A server-side scripted handler: given the inbound raw request, return a reply or null. */
+type ScriptedServer = {
+  readonly port: number;
+  close(): Promise<void>;
+};
+
+/**
+ * Start a stub WS server on an ephemeral loopback port. `onMessage` receives the raw
+ * inbound frame and returns the raw string to send back (or `null` to send nothing).
+ * If `onConnect` is provided it runs first (e.g. to close the socket abruptly).
+ */
+async function startStubServer(opts: {
+  onMessage?: (raw: string, socket: WsSocket) => string | null;
+  onConnect?: (socket: WsSocket) => void;
+}): Promise<ScriptedServer> {
+  const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+  await new Promise<void>((resolve) => server.once("listening", () => resolve()));
+  server.on("connection", (socket) => {
+    opts.onConnect?.(socket);
+    socket.on("message", (data) => {
+      const reply = opts.onMessage?.(data.toString(), socket);
+      if (reply !== null && reply !== undefined) socket.send(reply);
+    });
+  });
+  const port = (server.address() as AddressInfo).port;
+  return {
+    port,
+    close: () =>
+      new Promise<void>((resolve) => {
+        for (const c of server.clients) c.terminate();
+        server.close(() => resolve());
+      }),
+  };
+}
+
+/** Assert a thrown value is the slice's 503-shaped fail-closed error. */
+function expectFailClosed(error: unknown): FridayDomainError {
+  expect(error).toBeInstanceOf(FridayDomainError);
+  const domain = error as FridayDomainError;
+  expect(domain.httpStatus).toBe(503);
+  expect(domain.code).toBe("MISSION_SPINE_RUST_AGENT_RUN_WS_CLIENT_UNAVAILABLE");
+  return domain;
+}
+
+describe("friday-rust-hub-agent-run-ws-client (S-D dark refs-only WS client)", () => {
+  let stub: ScriptedServer | undefined;
+
+  afterEach(async () => {
+    if (stub) {
+      await stub.close();
+      stub = undefined;
+    }
+  });
+
+  it("round-trips a well-formed AgentRunResult to exactly the refs fields", async () => {
+    stub = await startStubServer({
+      onMessage: () =>
+        JSON.stringify({
+          kind: "AgentRunResult",
+          run_id: "agent_run_probe",
+          status: "completed",
+          answer_sha256: "a".repeat(64),
+          answer_len: 1234,
+        }),
+    });
+    const service = createFridayRustHubAgentRunWsClientService({ port: stub.port });
+
+    const result = await service.dispatchRun(REQUEST);
+
+    expect(result).toEqual({
+      truthLabel: "rust_wired",
+      runId: "agent_run_probe",
+      status: "completed",
+      answerSha256: "a".repeat(64),
+      answerLen: 1234,
+    });
+    // The wire keys surfaced are EXACTLY the refs set (+ the local truth label).
+    expect(Object.keys(result).sort()).toEqual(
+      ["answerLen", "answerSha256", "runId", "status", "truthLabel"].sort(),
+    );
+  });
+
+  it("accepts a well-formed result with NO answer refs (optional fields absent)", async () => {
+    stub = await startStubServer({
+      onMessage: () =>
+        JSON.stringify({
+          kind: "AgentRunResult",
+          run_id: "agent_run_probe",
+          status: "no_answer",
+        }),
+    });
+    const service = createFridayRustHubAgentRunWsClientService({ port: stub.port });
+
+    const result = await service.dispatchRun(REQUEST);
+
+    expect(result).toEqual({
+      truthLabel: "rust_wired",
+      runId: "agent_run_probe",
+      status: "no_answer",
+    });
+    expect("answerSha256" in result).toBe(false);
+    expect("answerLen" in result).toBe(false);
+  });
+
+  it("sends an AgentRunRequest-shaped frame (refs-only request, shape-only proof)", async () => {
+    let received: unknown;
+    stub = await startStubServer({
+      onMessage: (raw) => {
+        received = JSON.parse(raw);
+        return JSON.stringify({ kind: "AgentRunResult", run_id: "agent_run_probe", status: "completed" });
+      },
+    });
+    const service = createFridayRustHubAgentRunWsClientService({ port: stub.port });
+
+    await service.dispatchRun(REQUEST);
+
+    expect(received).toEqual({
+      kind: "AgentRunRequest",
+      run_id: "agent_run_probe",
+      task: "summarize the changelog",
+      forwarded_principal: "principal:owner-alice",
+      auth_proof: [1, 2, 3, 4],
+    });
+  });
+
+  it("does NOT leak a body when the server smuggles one — only refs surface", async () => {
+    const SECRET = "TOP-SECRET ANSWER BODY THAT MUST NEVER REACH THE CLIENT";
+    stub = await startStubServer({
+      onMessage: () =>
+        JSON.stringify({
+          kind: "AgentRunResult",
+          run_id: "agent_run_probe",
+          status: "completed",
+          answer_sha256: "b".repeat(64),
+          answer_len: SECRET.length,
+          // Pathological body-bearing fields the client must DROP (not 503 on).
+          answer: SECRET,
+          final_message: SECRET,
+          body: SECRET,
+        }),
+    });
+    const service = createFridayRustHubAgentRunWsClientService({ port: stub.port });
+
+    // Body-bearing is a SUCCESS that drops the body — NOT a fail-closed error.
+    const result = await service.dispatchRun(REQUEST);
+
+    expect(result).toEqual({
+      truthLabel: "rust_wired",
+      runId: "agent_run_probe",
+      status: "completed",
+      answerSha256: "b".repeat(64),
+      answerLen: SECRET.length,
+    });
+    // The secret body appears NOWHERE in the surfaced receipt.
+    expect(JSON.stringify(result)).not.toContain(SECRET);
+    expect("answer" in result).toBe(false);
+    expect("final_message" in result).toBe(false);
+    expect("body" in result).toBe(false);
+  });
+
+  // ── Fail-closed branches: each → a 503-shaped error with NO body. ──
+
+  it("fails closed on a connection error (server refused)", async () => {
+    // Bind a server, capture its port, then close it so the connect is refused.
+    const ephemeral = await startStubServer({});
+    const port = ephemeral.port;
+    await ephemeral.close();
+    const service = createFridayRustHubAgentRunWsClientService({ port, timeoutMs: 2_000 });
+
+    const error = await service.dispatchRun(REQUEST).catch((e: unknown) => e);
+    expectFailClosed(error);
+  });
+
+  it("fails closed on an unexpected close before a result", async () => {
+    stub = await startStubServer({
+      // Accept the connection, then close it abruptly without ever replying.
+      onConnect: (socket) => socket.close(),
+    });
+    const service = createFridayRustHubAgentRunWsClientService({ port: stub.port, timeoutMs: 2_000 });
+
+    const error = await service.dispatchRun(REQUEST).catch((e: unknown) => e);
+    expectFailClosed(error);
+  });
+
+  it("fails closed on a bounded timeout (server never replies)", async () => {
+    stub = await startStubServer({
+      // Accept + read the request but never send a result.
+      onMessage: () => null,
+    });
+    const service = createFridayRustHubAgentRunWsClientService({ port: stub.port, timeoutMs: 50 });
+
+    const error = await service.dispatchRun(REQUEST).catch((e: unknown) => e);
+    const domain = expectFailClosed(error);
+    expect(domain.message).toContain("timed out");
+  });
+
+  it("fails closed on malformed JSON", async () => {
+    stub = await startStubServer({ onMessage: () => "{not valid json" });
+    const service = createFridayRustHubAgentRunWsClientService({ port: stub.port, timeoutMs: 2_000 });
+
+    const error = await service.dispatchRun(REQUEST).catch((e: unknown) => e);
+    const domain = expectFailClosed(error);
+    expect(domain.message).toContain("invalid JSON");
+  });
+
+  it("fails closed on an unknown message shape (wrong kind)", async () => {
+    stub = await startStubServer({
+      onMessage: () =>
+        JSON.stringify({ kind: "SomethingElse", run_id: "agent_run_probe", status: "completed" }),
+    });
+    const service = createFridayRustHubAgentRunWsClientService({ port: stub.port, timeoutMs: 2_000 });
+
+    const error = await service.dispatchRun(REQUEST).catch((e: unknown) => e);
+    const domain = expectFailClosed(error);
+    expect(domain.message).toContain("unknown message shape");
+  });
+
+  it("fails closed when a required ref is missing (no status)", async () => {
+    stub = await startStubServer({
+      onMessage: () =>
+        JSON.stringify({ kind: "AgentRunResult", run_id: "agent_run_probe" }),
+    });
+    const service = createFridayRustHubAgentRunWsClientService({ port: stub.port, timeoutMs: 2_000 });
+
+    const error = await service.dispatchRun(REQUEST).catch((e: unknown) => e);
+    const domain = expectFailClosed(error);
+    expect(domain.message).toContain("missing a required ref");
+  });
+
+  it("fails closed (no spawn) when the request has no run id", async () => {
+    // No server needed — the precondition guard fails closed before any connect.
+    const service = createFridayRustHubAgentRunWsClientService({ port: 1, timeoutMs: 2_000 });
+    const error = await service
+      .dispatchRun({ ...REQUEST, runId: "" })
+      .catch((e: unknown) => e);
+    const domain = expectFailClosed(error);
+    expect(domain.message).toContain("requires a run id");
+  });
+
+  it("surfaces NO body on ANY fail-closed branch (error carries no answer text)", async () => {
+    const SECRET = "leaked-body-should-never-appear";
+    stub = await startStubServer({
+      // A body-bearing frame that ALSO has a wrong kind → fail closed, body must not leak.
+      onMessage: () =>
+        JSON.stringify({ kind: "Error", run_id: "agent_run_probe", answer: SECRET, body: SECRET }),
+    });
+    const service = createFridayRustHubAgentRunWsClientService({ port: stub.port, timeoutMs: 2_000 });
+
+    const error = await service.dispatchRun(REQUEST).catch((e: unknown) => e);
+    const domain = expectFailClosed(error);
+    expect(JSON.stringify({ message: domain.message, details: domain.details })).not.toContain(
+      SECRET,
+    );
+  });
+});

--- a/test/unit/api/mission-spine/friday-rust-hub-agent-run-ws-client.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-agent-run-ws-client.test.ts
@@ -157,7 +157,7 @@ describe("friday-rust-hub-agent-run-ws-client (S-D dark refs-only WS client)", (
   });
 
   it("does NOT leak a body when the server smuggles one — only refs surface", async () => {
-    const SECRET = "TOP-SECRET ANSWER BODY THAT MUST NEVER REACH THE CLIENT";
+    const SECRET = "TOP-SECRET ANSWER BODY THAT MUST NEVER REACH THE CLIENT"; // pragma: allowlist secret
     stub = await startStubServer({
       onMessage: () =>
         JSON.stringify({
@@ -271,7 +271,7 @@ describe("friday-rust-hub-agent-run-ws-client (S-D dark refs-only WS client)", (
   });
 
   it("surfaces NO body on ANY fail-closed branch (error carries no answer text)", async () => {
-    const SECRET = "leaked-body-should-never-appear";
+    const SECRET = "leaked-body-should-never-appear"; // pragma: allowlist secret
     stub = await startStubServer({
       // A body-bearing frame that ALSO has a wrong kind → fail closed, body must not leak.
       onMessage: () =>


### PR DESCRIPTION
WS-transport substrate sub-slice **S-D** for the executeRun-replacement: the TS-side **CLIENT** of the long-lived Rust agent-run WS server (S-B). It dispatches one agent-run as an S-A `AgentRunRequest` over a WebSocket and awaits exactly one **REFS-ONLY** `AgentRunResult`, replacing the per-run `execFile` bridge's transport.

Lands **DARK** — no production route/barrel/bootstrap registers or consumes it; the composition slice (S-F) wires it. The intent is one persistent socket; this dark slice (re)connects per call.

## Write-set (exactly 2 NEW files; no existing file touched; no Rust crate touched)
- `src/api/mission-spine/friday-rust-hub-agent-run-ws-client.ts` (NEW)
- `test/unit/api/mission-spine/friday-rust-hub-agent-run-ws-client.test.ts` (NEW)

## Refs-only contract
The result is read through a **strict allowlist** of exactly `{ run_id, status, answer_sha256?, answer_len? }` — built as a FRESH object literal, **never** a spread of the raw payload. If the server ever sent an `answer` / `final_message` / `body` field it is **dropped**, not surfaced. A body-bearing payload is therefore a **SUCCESS** that drops the body (it does NOT 503). `answer_sha256` / `answer_len` are optional (S-A `Option` + `skip_serializing_if`); the required refs are `run_id` + `status`.

## Fail-closed (503) branches — each proven against a real loopback stub `WebSocketServer`
- connection error (ECONNREFUSED — server bound then closed)
- unexpected socket close before a result
- bounded timeout (server never replies; `timeoutMs` configurable)
- malformed JSON
- unknown shape (`kind` != `AgentRunResult`)
- missing required ref (`run_id` / `status`)
- no-run-id precondition (fails closed before any connect)

The awaited result **settles at most once** (timer cleared + listeners removed on first settle). No 503 path surfaces a body or a partial success.

## Framing / lifecycle (documented in the file header)
Consumes the **inner** S-A `Message` JSON (`{ kind, ... }`) — NOT the full versioned `Envelope` wrapper nor the sealed session (those are S-B / S-C). (Re)connects per call for this dark slice; the persistent socket is the stated S-F intent.

## Dark / not-route-wired
Imported by no barrel/index/bootstrap. Reversible and inert until S-F wires it.

## Truth labels
WS substrate S-D for executeRun-replacement; refs-only; `rust_wired` at best; **NO production route consumes it; NOT v1 GO.**

## Local gates
- `npm run lint` 0 errors (new file 0 warnings)
- `tsc --noEmit` clean
- new test **12/12** (stable across 3 runs); full mission-spine suite **44/44**
- hermetic: real in-process `ws` server on `127.0.0.1:0` — no Rust bin, no provider, no egress beyond loopback

🤖 Generated with [Claude Code](https://claude.com/claude-code)