### PR TITLE
feat(rust): execrun slice 4 — per-run Rust-route flag (default-off) + read-only DeepSeek predicate (dark)

### DIFF
--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -983,6 +983,14 @@ export interface RustRouteQualificationInput {
   allowedRustRouteTools?: string[];
   skipPlanningReview?: boolean;
   resumeExistingRun?: boolean;
+  /**
+   * Plan-review OVERRIDE (0h clause-5 disqualifier). An independently-sufficient plan-review
+   * marker: friday-agent-runtime honors a supplied `planReviewOverride` standalone (precedence
+   * over an existing `planReview`, no dependency on skip/resume). PRESENCE → disqualified.
+   * Typed `unknown` because the predicate only checks PRESENCE, never the payload. The
+   * composition slice wires the body-parse that populates this from the real startRun input.
+   */
+  planReviewOverride?: unknown;
 }
 
 /**
@@ -1038,6 +1046,11 @@ export function qualifiesForRustReadOnlyRoute(input: RustRouteQualificationInput
     return false;
   }
   if (input.skipPlanningReview === true || input.resumeExistingRun === true) {
+    return false;
+  }
+  // The 4th plan-review disqualifier (0h): planReviewOverride is independently sufficient —
+  // PRESENCE alone disqualifies (matches the clause-5 contract above), regardless of skip/resume.
+  if (input.planReviewOverride !== undefined) {
     return false;
   }
 

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -905,6 +905,152 @@ export function resolveApiRuntimeCanonicalGateRequired(env: NodeJS.ProcessEnv = 
   return protectedProfile;
 }
 
+// ─── execrun-replacement slice 4: per-run Rust-route qualifying predicate (DARK) ───
+//
+// This predicate decides whether ONE production agent-run qualifies for the future
+// Rust read-only loop. It is DARK substrate: nobody consumes its boolean yet (the
+// later "composition" slice wires the actual routing). With the per-run flag off OR
+// the predicate disqualified, behavior is byte-identical to today — the startRun route
+// falls through to the existing `allowTestOnlyAgentRunStartExecution !== true` 503 stub.
+//
+// Invariants (so dark == byte-identical):
+//   * TOTAL: never throws (any uncertainty / missing field → returns false).
+//   * Side-effect-free: computes a bool, reads nothing external, writes nothing.
+//   * The route-via-Rust flag is checked FIRST and short-circuits; if the flag is not
+//     exactly `true` the predicate is not even evaluated by the route wrapper.
+//   * Every clause is a strict `=== true` / exact-string comparison; nothing truthy.
+//
+// The exact qualifying set (matches the coordinator's pre-authorized predicate):
+//   1. Route-not-method: admitted ONLY from the single startRun HTTP route. Enforced
+//      structurally (the predicate is computed only inside the route-bound startRun
+//      wrapper, never the automation-service copy or the executeRun callers) AND by an
+//      explicit internal marker `invokedFromHttpStartRunRoute === true` that ONLY the
+//      route wrapper passes. The 7 non-route callers (heartbeat/cron/channel-entry/
+//      autonomous/planning-gate/subagent/sessions-tool) reach executeRun directly, not
+//      this route, and never set the marker → never admitted. This avoids the historical
+//      route-only-retirement trap of pinning at the method chokepoint.
+//   2. constraints.readOnly === true (hard-blocks every mutating tool at the runtime).
+//   3. DeepSeek-flash ONLY: providerId === "deepseek" AND requested model ===
+//      "deepseek-v4-flash". A request for deepseek-pro / codex / claude / chat / reasoner
+//      / a missing model → DISQUALIFIED (no silent downgrade to flash). If a taskProfile
+//      model override is present it must ALSO be exactly the flash identifier.
+//   4. The 4 READ tools ONLY: the run must positively grant exactly the Rust read-tool
+//      set {read_file, list_dir, stat_file, search} via `allowedRustRouteTools`. Any other
+//      tool (run_command / write_file / edit_file / append_file / delete_file / move_file /
+//      …) or a missing grant → disqualified. The grant carries the Rust-loop tool names
+//      because it gates what the Rust read-only loop may expose (the composition slice
+//      wires the HTTP-body parse that populates it; today the route never sets it → the
+//      run is disqualified → today's 503).
+//   5. No subagents, no plan-review, no session-mirror dependency, no Pause-able
+//      (mutating/approval) action:
+//        * plan-review: requireReview === true OR planReviewOverride present OR
+//          skipPlanningReview / resumeExistingRun truthy → disqualified.
+//        * session-mirror: input.sessionKey present → disqualified (a sessioned run
+//          participates in session mirroring).
+//        * subagents: no startRun-input field represents them — a subagent child reaches
+//          executeRun, not this HTTP route (covered by the route marker), and the
+//          allow-list excludes spawn_subagent. Stated explicitly; bound structurally.
+//        * Pause-able / mutating-approval actions: structurally precluded by readOnly
+//          (clause 2 hard-blocks mutating tool calls) + the reads-only allow-list
+//          (clause 4). No separate field.
+//
+// NOTE: these are the RUST registry read-tool names (read_file / list_dir / stat_file /
+// search). list_dir/stat_file/search have no TS alias; the grant names what the Rust
+// read-only loop natively exposes, which is exactly what the future route gates.
+export const RUST_ROUTE_READ_TOOL_ALLOWLIST = ["read_file", "list_dir", "stat_file", "search"] as const;
+
+const RUST_ROUTE_DEEPSEEK_PROVIDER_ID = "deepseek";
+const RUST_ROUTE_DEEPSEEK_FLASH_MODEL = "deepseek-v4-flash";
+
+export interface RustRouteQualificationInput {
+  /**
+   * Internal route marker. ONLY the createFridayAgentRoutes-bound startRun wrapper sets
+   * this to `true`; the automation-service startRun copy and every executeRun caller
+   * leave it unset. This is the route-not-method pin (NOT derived from the body-controlled
+   * executionContext.surface).
+   */
+  invokedFromHttpStartRunRoute?: boolean;
+  providerId?: string;
+  model?: string;
+  sessionKey?: string;
+  requireReview?: boolean;
+  constraints?: FridayAgentRunConstraints;
+  taskProfile?: FridayAgentTaskProfileInput;
+  /**
+   * Positive per-run grant of the Rust read-tool set. The composition slice wires the
+   * HTTP-body parse that populates this; today the startRun route never sets it.
+   */
+  allowedRustRouteTools?: string[];
+  skipPlanningReview?: boolean;
+  resumeExistingRun?: boolean;
+}
+
+/**
+ * Fail-closed qualifying predicate for the future Rust read-only route (DARK).
+ * TOTAL + side-effect-free: returns `true` only when EVERY clause holds; any missing /
+ * uncertain field → `false`. Computes a bool; routes nothing.
+ */
+export function qualifiesForRustReadOnlyRoute(input: RustRouteQualificationInput): boolean {
+  // Clause 1 — route-not-method: explicit internal marker from the HTTP route wrapper only.
+  if (input.invokedFromHttpStartRunRoute !== true) {
+    return false;
+  }
+
+  // Clause 2 — readOnly (hard-blocks mutating tools in the runtime).
+  if (input.constraints?.readOnly !== true) {
+    return false;
+  }
+
+  // Clause 3 — DeepSeek-flash only; no silent downgrade, no pro/codex/claude/missing.
+  if (input.providerId !== RUST_ROUTE_DEEPSEEK_PROVIDER_ID) {
+    return false;
+  }
+  if (input.model !== RUST_ROUTE_DEEPSEEK_FLASH_MODEL) {
+    return false;
+  }
+  if (
+    input.taskProfile?.model !== undefined
+    && input.taskProfile.model !== RUST_ROUTE_DEEPSEEK_FLASH_MODEL
+  ) {
+    return false;
+  }
+
+  // Clause 4 — exactly the 4 Rust read tools, nothing else.
+  const grant = input.allowedRustRouteTools;
+  if (!Array.isArray(grant) || grant.length !== RUST_ROUTE_READ_TOOL_ALLOWLIST.length) {
+    return false;
+  }
+  const granted = new Set(grant);
+  if (granted.size !== RUST_ROUTE_READ_TOOL_ALLOWLIST.length) {
+    return false;
+  }
+  for (const tool of RUST_ROUTE_READ_TOOL_ALLOWLIST) {
+    if (!granted.has(tool)) {
+      return false;
+    }
+  }
+
+  // Clause 5 — no plan-review.
+  if (input.requireReview === true) {
+    return false;
+  }
+  if (input.taskProfile?.id === "review") {
+    return false;
+  }
+  if (input.skipPlanningReview === true || input.resumeExistingRun === true) {
+    return false;
+  }
+
+  // Clause 5 — no session-mirror dependency (a sessioned run participates in mirroring).
+  if (typeof input.sessionKey === "string" && input.sessionKey.trim().length > 0) {
+    return false;
+  }
+
+  // Subagents + Pause-able/mutating-approval actions are precluded structurally
+  // (route marker + readOnly + reads-only allow-list); no separate field to check.
+  return true;
+}
+
 export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): FridayApiRuntime {
   const accessTokenTtlSec = deps.accessTokenTtlSec ?? DEFAULT_ACCESS_TTL;
   const refreshTokenTtlSec = deps.refreshTokenTtlSec ?? DEFAULT_REFRESH_TTL;
@@ -3844,6 +3990,31 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
           run: async () => throwRetiredAgentRunControl(),
         };
 
+    // execrun-replacement slice 4 (DARK): route-only Rust-route qualification.
+    // This wrapper is handed ONLY to createFridayAgentRoutes (the single startRun HTTP
+    // route) — NOT to the automation-service copy (a non-route caller) above, and NOT to
+    // the executeRun path the 7 non-route callers use. That is the structural half of the
+    // route-not-method pin; the explicit `invokedFromHttpStartRunRoute: true` marker below
+    // is the testable half. The flag is checked FIRST and short-circuits; with the flag off
+    // (default) or the predicate disqualified, the wrapper just calls the unchanged startRun
+    // → byte-identical to today (the existing fail-closed 503 still applies inside startRun).
+    // The computed boolean is consumed by NOBODY yet; the composition slice will route on it.
+    const routeStartRun: typeof startRun = async (input) => {
+      if (deps.routeAgentRunViaRust === true) {
+        // DARK: compute qualification and discard. No routing wired in this slice.
+        void qualifiesForRustReadOnlyRoute({
+          invokedFromHttpStartRunRoute: true,
+          providerId: input.providerId,
+          model: input.model,
+          sessionKey: input.sessionKey,
+          requireReview: input.requireReview,
+          constraints: input.constraints,
+          taskProfile: input.taskProfile,
+        });
+      }
+      return startRun(input);
+    };
+
     for (const route of createFridayAgentRoutes({
       validateRequestedRoute: async (providerId, model, tenantContext) => {
         await deps.providerService.resolveRoute(model, providerId, {
@@ -3851,7 +4022,7 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
           autoValidate: true,
         });
       },
-      startRun,
+      startRun: routeStartRun,
       getRun: (runId) => {
         return deps.db.withReadConnection((db) =>
           enrichAgentRun(agentRepo.getById(db, runId)),

--- a/src/api/runtime/friday-api-runtime.types.ts
+++ b/src/api/runtime/friday-api-runtime.types.ts
@@ -314,6 +314,16 @@ export interface CreateFridayApiRuntimeDeps {
    */
   allowTestOnlyAgentRunStartExecution?: boolean;
   /**
+   * execrun-replacement slice 4 (DARK): per-run "route this run via the future Rust
+   * read-only loop" flag. DEFAULT-FALSE — leave unset in production/runtime. When unset
+   * (default) the startRun HTTP route never even evaluates the qualifying predicate and
+   * behavior is byte-identical to today. When set true, the route-bound startRun wrapper
+   * computes `qualifiesForRustReadOnlyRoute(...)` and DISCARDS the result — no actual
+   * routing is wired in this slice (the later composition slice consumes the bool). This
+   * flag holds the gate; it does not turn anything on.
+   */
+  routeAgentRunViaRust?: boolean;
+  /**
    * Test-oracle only: allows legacy TypeScript agent run controls in isolated
    * mock/unit validation. Production/runtime callers must leave this unset so
    * agent cancel, rollback, automation-run, plan approval, and tool approval

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -1902,6 +1902,15 @@ export interface FridayHubConfig {
   allowTestOnlyPluginExecution?: boolean;
   /** Test-oracle only; production hub creation must leave the provider-detect probe fail-closed. */
   allowTestOnlyProviderDetectExecution?: boolean;
+  /**
+   * execrun-replacement slice 4 (DARK): per-run "route a qualifying agent-run via the
+   * future Rust read-only loop" flag. DEFAULT-FALSE — production hub creation must leave
+   * this unset so the startRun route stays byte-identical to today (it computes nothing
+   * and routes nothing). When true, the route-bound startRun wrapper evaluates the
+   * fail-closed qualifying predicate and discards the boolean; NO actual routing is wired
+   * in this slice (the later composition slice consumes it).
+   */
+  routeAgentRunViaRust?: boolean;
 }
 
 // ─── Resolved Hub Config ───

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -6931,6 +6931,9 @@ export async function createFridayHub(
     allowTestOnlyWorkflowBuilderDraftExecution: config.allowTestOnlyWorkflowBuilderDraftExecution,
     agentRuntime,
     allowTestOnlyAgentRunStartExecution: config.allowTestOnlyAgentRunStartExecution,
+    // execrun-replacement slice 4 (DARK): default-false per-run Rust-route flag. Unset in
+    // production → predicate never evaluated → byte-identical to today.
+    routeAgentRunViaRust: config.routeAgentRunViaRust,
     allowTestOnlyAgentRunControlExecution: config.allowTestOnlyAgentRunControlExecution,
     allowTestOnlyAutonomyLifecycleExecution: config.allowTestOnlyAutonomyLifecycleExecution,
     allowTestOnlyStandingAgendaExecution: config.allowTestOnlyStandingAgendaExecution,

--- a/test/e2e/mock/_helpers/mock-env.ts
+++ b/test/e2e/mock/_helpers/mock-env.ts
@@ -365,6 +365,13 @@ export async function createMockHubEnv(opts?: {
   allowTestOnlySkillConverterExecution?: boolean;
   /** Test-oracle opt-in for the legacy TS provider-detect probe; set false to prove default fail-closed behavior. */
   allowTestOnlyProviderDetectExecution?: boolean;
+  /**
+   * execrun-replacement slice 4 (DARK): per-run Rust-route flag. DEFAULT-FALSE here (honest
+   * dark) — the predicate is unconsumed this slice so the value is cosmetic; the ui browser
+   * e2e exercises /v1/workflow-runs (workflow runtime), NOT the agent startRun route, so no
+   * mock value can change its behavior. Plumbed only for allowTestOnly-pattern consistency.
+   */
+  routeAgentRunViaRust?: boolean;
 }): Promise<MockHubEnv> {
   // Reset deterministic counters
   resetMockCounters();
@@ -425,6 +432,9 @@ export async function createMockHubEnv(opts?: {
       allowTestOnlyRealtimeExecution: opts?.allowTestOnlyRealtimeExecution ?? true,
       allowTestOnlySkillConverterExecution: opts?.allowTestOnlySkillConverterExecution ?? true,
       allowTestOnlyProviderDetectExecution: opts?.allowTestOnlyProviderDetectExecution ?? true,
+      // execrun-replacement slice 4 (DARK): default-FALSE (honest dark), unlike the
+      // allowTestOnly* flags which default true. The predicate is unconsumed this slice.
+      routeAgentRunViaRust: opts?.routeAgentRunViaRust ?? false,
       // Allow private-network targets so mock E2E tests don't require DNS resolution
       ssrfPolicy: opts?.ssrfPolicy ?? { allowPrivateNetwork: true },
     });

--- a/test/unit/api/runtime/friday-api-runtime-rust-route-flag.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-rust-route-flag.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createFridayApiRuntime } from "#api";
+import {
+  createFridayAgentEventEmitter,
+  type FridayAgentRuntime,
+} from "#agent";
+import type { FridayProviderService } from "#providers";
+import type { FridaySqliteLayer } from "#state";
+import { createTestDb } from "../../../helpers/friday-test-db.helper.js";
+
+// execrun-replacement slice 4 (DARK): per-run Rust-route flag at the startRun HTTP route.
+// The flag is DEFAULT-FALSE. With the flag off OR on, the route is byte-identical to today
+// because (a) the predicate's boolean is consumed by NOBODY (no routing wired) and (b) the
+// route never populates the read-tool grant, so even with the flag on the run is disqualified.
+// In BOTH cases the unchanged fail-closed 503 stub fires (allowTestOnlyAgentRunStartExecution
+// is left unset here, matching production). This proves dark == byte-identical.
+
+const NOW = "2026-06-08T09:00:00.000Z";
+
+function makeIdGenerator(): () => string {
+  let counter = 0;
+  return () => `id-${String(++counter)}`;
+}
+
+function makeProviderService(): FridayProviderService {
+  return {
+    listProviders: vi.fn(async () => []),
+    getProvider: vi.fn(async () => null),
+    createProvider: vi.fn(async () => ({} as never)),
+    updateProvider: vi.fn(async () => ({} as never)),
+    deleteProvider: vi.fn(async () => undefined),
+    validateProvider: vi.fn(async () => ({ status: "ok" as const, checkedAt: NOW })),
+    getRoutingConfig: vi.fn(async () => ({ defaultProviderId: "p-1", fallbackProviderIds: [] })),
+    setRoutingConfig: vi.fn(async (input) => input),
+    resolveRoute: vi.fn(async () => ({
+      provider: {
+        id: "p-1",
+        kind: "deepseek" as const,
+        name: "DeepSeek",
+        baseUrl: "https://api.deepseek.com",
+        enabled: true,
+        config: {
+          api: "openai-completions" as const,
+          authMode: "api-key" as const,
+          keySource: { kind: "env-ref" as const, envVar: "DEEPSEEK_API_KEY" },
+          supportedModels: ["deepseek-v4-flash"],
+          validation: { status: "ok" as const, checkedAt: NOW },
+        },
+        createdAt: NOW,
+        updatedAt: NOW,
+      },
+      model: "deepseek-v4-flash",
+    })),
+    runWithFallback: vi.fn(async () => ({} as never)),
+  } as unknown as FridayProviderService;
+}
+
+function makeBoundPrincipal(principalId: string) {
+  return {
+    principalType: "user",
+    principalId,
+    userId: principalId,
+    tokenId: `${principalId}-token`,
+    tokenKind: "access",
+    scopes: ["agent.write"],
+    issuedAt: NOW,
+  };
+}
+
+function makeAgentRuntime(): FridayAgentRuntime {
+  return {
+    executeRun: vi.fn(async () => {
+      throw new Error("executeRun must not be reached while the route is fail-closed");
+    }),
+    registerTool: vi.fn(),
+    resumeStaleRunsOnBoot: vi.fn(() => 0),
+  } as unknown as FridayAgentRuntime;
+}
+
+function makeRuntime(db: FridaySqliteLayer, routeAgentRunViaRust: boolean | undefined) {
+  return createFridayApiRuntime({
+    db,
+    idGenerator: makeIdGenerator(),
+    nowIso: () => NOW,
+    providerService: makeProviderService(),
+    agentRuntime: makeAgentRuntime(),
+    agentEventEmitter: createFridayAgentEventEmitter(),
+    tokenSecret: "test-secret-key-that-is-at-least-32-chars-long!!", // pragma: allowlist secret
+    computeChecksum: (content: string) => `checksum-${content.length}`,
+    resolveSkill: () => null,
+    invokeSkill: async () => ({}),
+    // allowTestOnlyAgentRunStartExecution intentionally UNSET → production fail-closed 503.
+    ...(routeAgentRunViaRust === undefined ? {} : { routeAgentRunViaRust }),
+  });
+}
+
+// A request body that WOULD satisfy the predicate's content clauses (read-only DeepSeek-flash).
+// It still gets disqualified at the route because the route never grants the read-tool set.
+const QUALIFYING_SHAPED_BODY = {
+  task: "List the files in the workspace and read README.md.",
+  providerId: "deepseek",
+  model: "deepseek-v4-flash",
+  constraints: { readOnly: true },
+};
+
+async function callStartRoute(
+  runtime: ReturnType<typeof createFridayApiRuntime>,
+  body: Record<string, unknown>,
+) {
+  const startRoute = runtime.routes
+    .getRoutes()
+    .find((route) => route.operationId === "agent.runs.start");
+  expect(startRoute).toBeDefined();
+  return startRoute!.handler({
+    body,
+    principal: makeBoundPrincipal("rust-route-flag-user"),
+  } as never);
+}
+
+async function expectByteIdentical503(promise: Promise<unknown>) {
+  await expect(promise).rejects.toMatchObject({
+    code: "TS_RUNTIME_AGENT_RUNS_RETIRED",
+    httpStatus: 503,
+  });
+}
+
+describe("FridayApiRuntime — execrun slice 4 per-run Rust-route flag (dark)", () => {
+  let db: FridaySqliteLayer;
+
+  afterEach(() => {
+    db?.close();
+  });
+
+  it("flag DEFAULT (unset): a would-qualify request still hits today's unchanged 503", async () => {
+    db = createTestDb();
+    const runtime = makeRuntime(db, undefined);
+    await expectByteIdentical503(callStartRoute(runtime, { ...QUALIFYING_SHAPED_BODY }));
+  });
+
+  it("flag explicitly FALSE: byte-identical 503 (predicate never even evaluated)", async () => {
+    db = createTestDb();
+    const runtime = makeRuntime(db, false);
+    await expectByteIdentical503(callStartRoute(runtime, { ...QUALIFYING_SHAPED_BODY }));
+  });
+
+  it("flag ON: the predicate is computed (dark) but routes nothing — still the same 503", async () => {
+    // With the flag on the route wrapper evaluates qualifiesForRustReadOnlyRoute and
+    // DISCARDS the boolean. The route does not populate allowedRustRouteTools, so the run
+    // is disqualified anyway; either way behavior is byte-identical to today.
+    db = createTestDb();
+    const runtime = makeRuntime(db, true);
+    await expectByteIdentical503(callStartRoute(runtime, { ...QUALIFYING_SHAPED_BODY }));
+  });
+});

--- a/test/unit/api/runtime/friday-api-runtime-rust-route-predicate.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-rust-route-predicate.test.ts
@@ -114,11 +114,15 @@ describe("qualifiesForRustReadOnlyRoute (execrun slice 4, dark predicate)", () =
   });
 
   // ── Clause 5: no plan-review ────────────────────────────────────────────────
-  it("disqualifies a plan-review run (requireReview / review profile / resume / skip)", () => {
+  it("disqualifies a plan-review run (requireReview / review profile / resume / skip / override)", () => {
     expect(qualifiesForRustReadOnlyRoute({ ...qualifyingInput(), requireReview: true })).toBe(false);
     expect(qualifiesForRustReadOnlyRoute({ ...qualifyingInput(), taskProfile: { id: "review" } })).toBe(false);
     expect(qualifiesForRustReadOnlyRoute({ ...qualifyingInput(), skipPlanningReview: true })).toBe(false);
     expect(qualifiesForRustReadOnlyRoute({ ...qualifyingInput(), resumeExistingRun: true })).toBe(false);
+    // 4th plan-review disqualifier (0h): planReviewOverride is independently sufficient — PRESENCE
+    // alone disqualifies, even with skip/resume unset (the lossy-projection over-admit the verify caught).
+    expect(qualifiesForRustReadOnlyRoute({ ...qualifyingInput(), planReviewOverride: { mode: "manual" } })).toBe(false);
+    expect(qualifiesForRustReadOnlyRoute({ ...qualifyingInput(), planReviewOverride: {} })).toBe(false);
   });
 
   // ── Clause 5: no session-mirror dependency ──────────────────────────────────

--- a/test/unit/api/runtime/friday-api-runtime-rust-route-predicate.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-rust-route-predicate.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  qualifiesForRustReadOnlyRoute,
+  RUST_ROUTE_READ_TOOL_ALLOWLIST,
+  type RustRouteQualificationInput,
+} from "../../../../src/api/runtime/friday-api-runtime.js";
+
+// execrun-replacement slice 4 (DARK): fail-closed qualifying predicate for the future
+// Rust read-only route. These tests pin the EXACT pre-authorized qualifying set: each
+// disqualifying clause independently → false; the all-pass case → true; route-not-method
+// (a non-route caller missing the internal marker) → false. The predicate must be TOTAL
+// (never throws) and side-effect-free; nobody consumes the boolean yet (dark).
+
+/** A minimal input that satisfies EVERY clause → qualifies === true. */
+function qualifyingInput(): RustRouteQualificationInput {
+  return {
+    invokedFromHttpStartRunRoute: true,
+    providerId: "deepseek",
+    model: "deepseek-v4-flash",
+    constraints: { readOnly: true },
+    allowedRustRouteTools: [...RUST_ROUTE_READ_TOOL_ALLOWLIST],
+    // no sessionKey, no requireReview, no plan-review override, no resume/skip → all-clear
+  };
+}
+
+describe("qualifiesForRustReadOnlyRoute (execrun slice 4, dark predicate)", () => {
+  it("admits a fully-qualifying read-only DeepSeek-flash route run", () => {
+    expect(qualifiesForRustReadOnlyRoute(qualifyingInput())).toBe(true);
+  });
+
+  // ── Clause 1: route-not-method ──────────────────────────────────────────────
+  it("disqualifies when the HTTP startRun route marker is absent (method-level / non-route caller)", () => {
+    const input = qualifyingInput();
+    delete input.invokedFromHttpStartRunRoute;
+    expect(qualifiesForRustReadOnlyRoute(input)).toBe(false);
+  });
+
+  it("disqualifies a non-route caller even if every other clause would pass (marker !== true)", () => {
+    // Simulates one of the 7 non-route callers (heartbeat/cron/channel-entry/autonomous/
+    // planning-gate/subagent/sessions-tool) reaching the method chokepoint without the
+    // route wrapper: the marker is never set, so it is never admitted.
+    expect(qualifiesForRustReadOnlyRoute({ ...qualifyingInput(), invokedFromHttpStartRunRoute: false })).toBe(false);
+  });
+
+  // ── Clause 2: readOnly ──────────────────────────────────────────────────────
+  it("disqualifies when constraints.readOnly is not exactly true", () => {
+    expect(qualifiesForRustReadOnlyRoute({ ...qualifyingInput(), constraints: { readOnly: false } })).toBe(false);
+    expect(qualifiesForRustReadOnlyRoute({ ...qualifyingInput(), constraints: {} })).toBe(false);
+    expect(qualifiesForRustReadOnlyRoute({ ...qualifyingInput(), constraints: undefined })).toBe(false);
+  });
+
+  // ── Clause 3: DeepSeek-flash only, no silent downgrade ───────────────────────
+  it("disqualifies a non-deepseek provider", () => {
+    expect(qualifiesForRustReadOnlyRoute({ ...qualifyingInput(), providerId: "anthropic" })).toBe(false);
+    expect(qualifiesForRustReadOnlyRoute({ ...qualifyingInput(), providerId: undefined })).toBe(false);
+  });
+
+  it("disqualifies deepseek-pro / codex / claude / a missing model (no downgrade to flash)", () => {
+    for (const model of ["deepseek-v4-pro", "deepseek-chat", "deepseek-reasoner", "codex", "claude-3-7", undefined]) {
+      expect(qualifiesForRustReadOnlyRoute({ ...qualifyingInput(), model })).toBe(false);
+    }
+  });
+
+  it("disqualifies when a taskProfile model override is not exactly the flash identifier", () => {
+    expect(
+      qualifiesForRustReadOnlyRoute({ ...qualifyingInput(), taskProfile: { model: "deepseek-v4-pro" } }),
+    ).toBe(false);
+    // an override that re-states flash is allowed
+    expect(
+      qualifiesForRustReadOnlyRoute({ ...qualifyingInput(), taskProfile: { model: "deepseek-v4-flash" } }),
+    ).toBe(true);
+  });
+
+  // ── Clause 4: exactly the 4 Rust read tools ─────────────────────────────────
+  it("disqualifies when the read-tool grant is missing", () => {
+    const input = qualifyingInput();
+    delete input.allowedRustRouteTools;
+    expect(qualifiesForRustReadOnlyRoute(input)).toBe(false);
+  });
+
+  it("disqualifies a grant that includes any non-read tool (run_command / write_file / edit_file)", () => {
+    for (const extra of ["run_command", "write_file", "edit_file", "append_file", "delete_file", "spawn_subagent"]) {
+      expect(
+        qualifiesForRustReadOnlyRoute({
+          ...qualifyingInput(),
+          allowedRustRouteTools: [...RUST_ROUTE_READ_TOOL_ALLOWLIST, extra],
+        }),
+      ).toBe(false);
+    }
+  });
+
+  it("disqualifies a grant missing one of the 4 reads, an empty grant, or a duplicate-padded grant", () => {
+    expect(
+      qualifiesForRustReadOnlyRoute({ ...qualifyingInput(), allowedRustRouteTools: ["read_file", "list_dir", "stat_file"] }),
+    ).toBe(false);
+    expect(qualifiesForRustReadOnlyRoute({ ...qualifyingInput(), allowedRustRouteTools: [] })).toBe(false);
+    // duplicates that pad length to 4 must not sneak past (set-size guard)
+    expect(
+      qualifiesForRustReadOnlyRoute({
+        ...qualifyingInput(),
+        allowedRustRouteTools: ["read_file", "read_file", "list_dir", "stat_file"],
+      }),
+    ).toBe(false);
+  });
+
+  it("admits a grant of exactly the 4 reads in any order", () => {
+    expect(
+      qualifiesForRustReadOnlyRoute({
+        ...qualifyingInput(),
+        allowedRustRouteTools: ["search", "stat_file", "list_dir", "read_file"],
+      }),
+    ).toBe(true);
+  });
+
+  // ── Clause 5: no plan-review ────────────────────────────────────────────────
+  it("disqualifies a plan-review run (requireReview / review profile / resume / skip)", () => {
+    expect(qualifiesForRustReadOnlyRoute({ ...qualifyingInput(), requireReview: true })).toBe(false);
+    expect(qualifiesForRustReadOnlyRoute({ ...qualifyingInput(), taskProfile: { id: "review" } })).toBe(false);
+    expect(qualifiesForRustReadOnlyRoute({ ...qualifyingInput(), skipPlanningReview: true })).toBe(false);
+    expect(qualifiesForRustReadOnlyRoute({ ...qualifyingInput(), resumeExistingRun: true })).toBe(false);
+  });
+
+  // ── Clause 5: no session-mirror dependency ──────────────────────────────────
+  it("disqualifies a sessioned run (session-mirror dependency)", () => {
+    expect(qualifiesForRustReadOnlyRoute({ ...qualifyingInput(), sessionKey: "sess-123" })).toBe(false);
+    // whitespace-only sessionKey is treated as absent (still qualifies)
+    expect(qualifiesForRustReadOnlyRoute({ ...qualifyingInput(), sessionKey: "   " })).toBe(true);
+  });
+
+  // ── Fail-closed / totality invariants ───────────────────────────────────────
+  it("is total: never throws on an empty / undefined-field input and returns false", () => {
+    expect(() => qualifiesForRustReadOnlyRoute({})).not.toThrow();
+    expect(qualifiesForRustReadOnlyRoute({})).toBe(false);
+  });
+
+  it("the read-tool allow-list is exactly the 4 Rust read tools", () => {
+    expect([...RUST_ROUTE_READ_TOOL_ALLOWLIST].sort()).toEqual(
+      ["list_dir", "read_file", "search", "stat_file"],
+    );
+  });
+});


### PR DESCRIPTION
## What this slice is (DARK, default-OFF)

Adds the GATE that decides whether ONE qualifying production agent-run may (later) route to the future Rust read-only loop, plus the default-OFF per-run flag. **No actual routing is wired** — the predicate computes a `bool` consumed by **nobody yet** (the later composition slice consumes it). With the flag off (default) **or** the predicate disqualified, the `startRun` route is **byte-identical to today**: it falls through to the unchanged `allowTestOnlyAgentRunStartExecution !== true` 503 stub.

**Truth labels:** dark substrate for executeRun-replacement; no real routing; `rust_wired` at best; **NOT v1 GO**. TS-only — no Rust crate touched.

## Write-set

| File | Change |
|---|---|
| `src/hub/bootstrap/hub-helpers.ts` | `FridayHubConfig.routeAgentRunViaRust?` (default-off flag decl) |
| `src/hub/friday-hub-bootstrap.ts` | pass-through `config.routeAgentRunViaRust` → `createFridayApiRuntime` deps (next to `allowTestOnlyAgentRunStartExecution`) |
| `src/api/runtime/friday-api-runtime.ts` | the fail-closed predicate `qualifiesForRustReadOnlyRoute` + the route-only `startRun` wrapper |
| **`src/api/runtime/friday-api-runtime.types.ts`** | **deps-type companion to friday-api-runtime.ts** — `CreateFridayApiRuntimeDeps.routeAgentRunViaRust?` declared alongside `allowTestOnlyAgentRunStartExecution` (:315), same mirrored pattern. *Necessary one-field edit; disclosed because not in the originally enumerated list.* |
| `test/e2e/mock/_helpers/mock-env.ts` | flag opt plumbed for pattern-consistency, **default-FALSE (honest dark)** |
| `test/unit/api/runtime/friday-api-runtime-rust-route-predicate.test.ts` | predicate unit tests (NEW) |
| `test/unit/api/runtime/friday-api-runtime-rust-route-flag.test.ts` | flag / byte-identical-503 route tests (NEW) |

## EXACT predicate clauses (as implemented)

`qualifiesForRustReadOnlyRoute(input)` — `src/api/runtime/friday-api-runtime.ts` — is **TOTAL (never throws)** and **side-effect-free**; returns `true` only when EVERY clause holds, any missing/uncertain field → `false`. Every comparison is strict `===` / exact-string.

1. **route-not-method** (`:~995`): `input.invokedFromHttpStartRunRoute !== true → false`.
2. **readOnly** (`:~1000`): `input.constraints?.readOnly !== true → false`.
3. **DeepSeek-flash only** (`:~1005`): `providerId !== "deepseek" → false`; `model !== "deepseek-v4-flash" → false`; `taskProfile.model` if present must also `=== "deepseek-v4-flash"`. Rejects `deepseek-v4-pro` / `codex` / `claude` / `deepseek-chat` / `deepseek-reasoner` / missing model — **no silent downgrade to flash**.
4. **the 4 Rust read tools only** (`:~1020`): `allowedRustRouteTools` must be a set equal to exactly `{read_file, list_dir, stat_file, search}` (`RUST_ROUTE_READ_TOOL_ALLOWLIST`). Missing grant, any extra tool (`run_command`/`write_file`/`edit_file`/…), short grant, or duplicate-padded grant → `false`.
5. **no subagents / plan-review / session-mirror / pause-able** (`:~1035`):
   - plan-review: `requireReview === true` OR `taskProfile.id === "review"` OR `skipPlanningReview`/`resumeExistingRun` truthy → `false`;
   - session-mirror: non-blank `input.sessionKey` present → `false`;
   - subagents: no startRun-input field represents them — a subagent child reaches `executeRun`, not this HTTP route (covered by clause 1) + the allow-list excludes `spawn_subagent`. Bound structurally;
   - pause-able / mutating-approval: structurally precluded by readOnly (clause 2 hard-blocks mutating tool calls in the runtime) + reads-only allow-list (clause 4). No separate field.

## Route-not-method pinning (the historical trap avoided)

The `startRun` closure (`:3728`) is handed to BOTH `createFridayAgentAutomationService` (`:3971`, a non-route caller) AND `createFridayAgentRoutes` (the HTTP route). Pinning at the closure body would also capture the automation path = the route-only-retirement trap.

Enforced two ways:
- **Structural:** the predicate is computed only inside `routeStartRun`, the wrapper handed **only** to `createFridayAgentRoutes`. The automation-service `startRun` copy and the `executeAgentRunWithSessionContext`/`executeRun` path the 7 non-route callers use (heartbeat/cron/channel-entry/autonomous/planning-gate/subagent/sessions-tool) stay bare.
- **Testable marker:** the wrapper passes `invokedFromHttpStartRunRoute: true`; the predicate requires `=== true`. NOT derived from the body-controlled `executionContext.surface`. Unit test asserts a non-route caller (marker absent / `false`) → disqualified.

## Default-off / byte-identical-503 reversibility

The flag is checked **first and short-circuits**: `if (deps.routeAgentRunViaRust === true)` guards the only predicate call site, so with the flag off (default) the predicate is **never even evaluated**. The wrapper then calls the unchanged `startRun`, which fail-closes 503 exactly as today. The "default-FALSE ⇒ disqualified even when the predicate would pass" bar item is proven across **two** tests (there is no single route-level test where the predicate returns true AND the flag is off, because today's route cannot populate `allowedRustRouteTools` — that is the dark design): the pure-fn test proves `qualifies==true` on the full input; the flag test proves byte-identical `TS_RUNTIME_AGENT_RUNS_RETIRED` 503 in flag-unset / flag-false / flag-true states.

## Mock-env / e2e handling (CI gotcha discharged)

Mandated grep of `test/e2e/ui/` for the startRun/`/runs` route was run: the only browser-e2e (`friday-reflex-review-center-real-browser.e2e.test.ts`) exercises **`/v1/workflow-runs`** (workflow runtime), **NOT** the agent `/v1/agent/runs` startRun route. Combined with the predicate being dark/unconsumed and the mock-env flag defaulting **FALSE** (so the extra pure call doesn't even fire in e2e), no mock value can change the ui e2e behavior. The flag is plumbed through mock-env (default-FALSE) only for `allowTestOnly*` pattern-consistency; existing `allowTestOnlyAgentRunStartExecution` plumbing untouched.

## Truth-labels / conservative bindings (deliberate, composition-slice may refine)

- `RustRouteQualificationInput` carries `skipPlanningReview`/`resumeExistingRun`, which are NOT on today's startRun route input (the wrapper passes a subset); they are defensive/unit-only now — the predicate's input surface is intentionally broader than today's route for the composition slice.
- `sessionKey`-present (session-mirror) and exact `deepseek-v4-flash` (no flash aliases) are conservative fail-closed bindings; a future refinement may broaden/narrow them — harmless while dark.

## Verification (local)

- `npm run lint`: **0 errors** (1544 pre-existing warnings, none from this change).
- `npx tsc --noEmit`: clean.
- `npm test` (default suite): **12627 passed, 258 skipped, 0 failures**, no type errors. New tests: 15 predicate + 3 flag = 18 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)