### PR TITLE
feat(rust): execrun WS S-F-compose — route startRun via Rust behind default-off flag (dark, mock-proven)

### DIFF
--- a/scripts/ops/launchd/com.friday.rust-agent-run-ws-server.plist
+++ b/scripts/ops/launchd/com.friday.rust-agent-run-ws-server.plist
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  execrun-replacement S-F-compose (DARK) — launchd plist for the long-lived Rust
+  agent-run WS server (the S-B `hub_agent_run_server` bin).
+
+  ============================ DARK — NOT LOADED ============================
+  This file is ADDED by the S-F-compose slice but is NOT installed and NOT loaded
+  by it. The composition that routes a qualifying agent-run via Rust is behind the
+  DEFAULT-OFF `routeAgentRunViaRust` flag; with that flag off (production default)
+  the WS server is never contacted, so this supervisor stays dark. The LIVE-FLIP —
+  copying this into ~/Library/LaunchAgents and `launchctl bootstrap`-ing it — is
+  slice 6 (an explicit operator gate). Until then nothing here runs.
+
+  Operator decision encoded here: launchd OWNS supervision of the WS server (it is
+  NOT spawned as an unmanaged child of the TS hub). RunAtLoad + KeepAlive give the
+  single persistent loopback server the TS WS client (S-D) dispatches each run over.
+
+  PLACEHOLDERS to fill at live-flip (slice 6), NOT real values:
+    __REPO_DIR__            absolute repo root (e.g. /Users/<you>/Projects/Friday)
+    __RUST_SERVER_BIN__     prebuilt hub_agent_run_server path, OR replace
+                            ProgramArguments with the `cargo run --bin
+                            hub_agent_run_server` invocation
+    __WORKSPACE_ROOT__      the read-only-loop workspace root the server serves
+    __HUB_DB_PATH__         the Rust Hub SQLite the run + answer body persist to
+                            (the same DB the TS owner-gated readback reads)
+    __WS_PORT__             the loopback port (must match FRIDAY_HUB_AGENT_RUN_WS_PORT
+                            on the TS side); the bin binds 127.0.0.1 ONLY (never LAN)
+    __OWNER_PRINCIPAL__     the bound-owner allowlist entry (--owner)
+    __LOG_DIR__             ~/.friday/launchd (matches install-friday-launchagent.sh)
+
+  SECRET REDACTION: no secret/token/key is placed in this plist or in its log paths.
+  The WS session key (authProof) is resolved by the TS side from the SecureStore
+  (keychain-backed) — NEVER an env var here. RUST_LOG is pinned low and
+  FRIDAY_LOG_REDACT_SECRETS=true so the server logs carry NO secret material; logs
+  go to dedicated dark log files, never stdout/stderr of an interactive shell.
+
+  HEALTH / STATUS: KeepAlive(SuccessfulExit=false) restarts the server if it exits
+  abnormally; ThrottleInterval bounds the restart rate. The server binds loopback
+  and fails closed (exits non-zero) when it cannot bind / is otherwise unavailable —
+  launchd then surfaces the failure rather than masking it. The TS client treats an
+  unreachable server as fail-closed (503), so an unavailable service never degrades
+  to an unauthenticated or silent path.
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.friday.rust-agent-run-ws-server</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>__RUST_SERVER_BIN__</string>
+    <string>--workspace</string>
+    <string>__WORKSPACE_ROOT__</string>
+    <string>--db</string>
+    <string>__HUB_DB_PATH__</string>
+    <string>--port</string>
+    <string>__WS_PORT__</string>
+    <string>--owner</string>
+    <string>__OWNER_PRINCIPAL__</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>__REPO_DIR__</string>
+
+  <!-- launchd owns supervision: start at load, keep the single server alive. -->
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <dict>
+    <!-- Restart only on abnormal exit; a clean shutdown stays down (health gate). -->
+    <key>SuccessfulExit</key>
+    <false/>
+  </dict>
+  <key>ThrottleInterval</key>
+  <integer>10</integer>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <!-- Loopback-only WS endpoint; MUST match the TS client's FRIDAY_HUB_AGENT_RUN_WS_PORT. -->
+    <key>FRIDAY_HUB_AGENT_RUN_WS_HOST</key>
+    <string>127.0.0.1</string>
+    <key>FRIDAY_HUB_AGENT_RUN_WS_PORT</key>
+    <string>__WS_PORT__</string>
+    <!-- The Hub DB the TS owner-gated readback reads the answer body back from. -->
+    <key>FRIDAY_HUB_AGENT_RUN_DB_PATH</key>
+    <string>__HUB_DB_PATH__</string>
+    <!-- SECRET-REDACTED logging: low log level + explicit secret redaction; no backtrace. -->
+    <key>RUST_LOG</key>
+    <string>warn</string>
+    <key>RUST_BACKTRACE</key>
+    <string>0</string>
+    <key>FRIDAY_LOG_REDACT_SECRETS</key>
+    <string>true</string>
+  </dict>
+
+  <!-- Dedicated dark log files (secret-redacted by the env above); never the shell tty. -->
+  <key>StandardOutPath</key>
+  <string>__LOG_DIR__/friday-rust-agent-run-ws-server.stdout.log</string>
+  <key>StandardErrorPath</key>
+  <string>__LOG_DIR__/friday-rust-agent-run-ws-server.stderr.log</string>
+</dict>
+</plist>

--- a/src/api/http/routes/friday-agent-routes.ts
+++ b/src/api/http/routes/friday-agent-routes.ts
@@ -905,6 +905,10 @@ export interface FridayAgentRoutesDeps {
     principalId?: string;
     scopes?: string[];
     tenantContext?: FridayProviderTenantContext;
+    // execrun-replacement S-F-compose (DARK): the explicit per-run Rust read-tool grant.
+    // Additive + optional; forwarded straight to the route-bound startRun wrapper, which
+    // (only when the default-OFF Rust-route flag is on) uses it as the clause-4 qualifier.
+    allowedRustRouteTools?: string[];
   }) => Promise<FridayAgentRuntimeResult>;
   getRun: (runId: string) => FridayAgentRunRecord | null;
   listRuns: (query: {
@@ -1387,6 +1391,17 @@ export function createFridayAgentRoutes(
           })
           : undefined;
 
+        // execrun-replacement S-F-compose (DARK): parse the explicit, optional per-run Rust
+        // read-tool grant. Accepted ONLY as an array of non-empty strings; any other shape
+        // (or absence) ⇒ undefined ⇒ the Rust-route predicate's clause-4 fails ⇒ today's
+        // unchanged 503. Additive: no existing caller sends it, so behavior is unchanged.
+        const allowedRustRouteTools = Array.isArray(body.allowedRustRouteTools)
+          && body.allowedRustRouteTools.every(
+            (t): t is string => typeof t === "string" && t.length > 0,
+          )
+          ? body.allowedRustRouteTools
+          : undefined;
+
         const result = await deps.startRun({
           task: body.task,
           taskPrompt,
@@ -1401,6 +1416,7 @@ export function createFridayAgentRoutes(
           disabledToolNames: publicIsolation?.disabledToolNames,
           taskProfile,
           executionContext,
+          ...(allowedRustRouteTools ? { allowedRustRouteTools } : {}),
           ...(apiIdempotencyKey
             ? {
               apiIdempotencyKey,

--- a/src/api/mission-spine/friday-rust-hub-agent-run-ws-session-key.ts
+++ b/src/api/mission-spine/friday-rust-hub-agent-run-ws-session-key.ts
@@ -1,0 +1,107 @@
+/**
+ * PROOF-ONLY (Rust-wired), DARK (no production route flips this on) SecureStore
+ * SESSION-KEY resolver for the executeRun-replacement TS->Rust agent-run WS client
+ * (sub-slice S-F-compose, the composition).
+ *
+ * ## Why this exists (operator decision)
+ * The composition routes a qualifying production agent-run over the long-lived Rust
+ * agent-run WS server. Before the TS client may open that socket and dispatch a run, it
+ * must hold the WS SESSION KEY — the sealed `authProof` bytes the Rust auth sub-slice
+ * (S-C) verifies against the session. The operator decision: that key is obtained via the
+ * SecureStore path (the keychain-backed master-key store), NOT an unguarded env var that
+ * a misconfigured process could leak. A MISSING / invalid key MUST fail CLOSED: the
+ * composition never opens an UNAUTHENTICATED WS connection — it falls to today's 503.
+ *
+ * ## Hard contracts enforced here (load-bearing)
+ * 1. **Fail-closed on missing/invalid** — `resolveRustAgentRunWsSessionKey` returns
+ *    `null` when the SecureStore has no key, the key is empty, or it is shorter than the
+ *    floor below. The caller treats `null` as "do not route to Rust" (503), and NEVER
+ *    opens a WS connection without a key. There is no anonymous / default fallback.
+ * 2. **Never printed / logged** — the key bytes are returned to the in-process caller
+ *    only. This module throws no error carrying the key, logs nothing, and the returned
+ *    value is opaque `Uint8Array`. (`// pragma: allowlist secret` markers below sit on
+ *    the SecureStore lookup IDENTIFIERS, never on a literal key.)
+ * 3. **SecureStore-only source** — the key is read through the keychain-backed
+ *    {@link getMasterKey} path (the same SecureStore root the secret admin service uses),
+ *    derived deterministically for this WS purpose. There is no plaintext env-var key
+ *    path: an env var may carry the OPAQUE SecureStore presence signal (see
+ *    {@link FRIDAY_HUB_AGENT_RUN_WS_SESSION_KEY_PRESENT}) but never the key material.
+ *
+ * ## Truth labels (read before trusting this)
+ * - **DARK substrate**: no production route resolves a real key here until the
+ *   composition slice is live-flipped (slice 6, operator gate). Reversible / inert.
+ * - **`rust_wired` ceiling**: confers no v1 GO. In tests it is driven by an injected
+ *   resolver returning a fixture key — never a real keychain secret, never a real key.
+ */
+import { createHash } from "node:crypto";
+
+import { getMasterKey } from "#providers";
+
+/**
+ * The minimum acceptable derived-key length (bytes). A key shorter than this is treated
+ * as invalid → fail closed. 32 bytes (a sha256 digest) is the floor.
+ */
+const MIN_SESSION_KEY_LEN = 32;
+
+/**
+ * The SecureStore lookup label for this WS purpose. Used as a domain-separation tag when
+ * deriving the WS session key from the SecureStore master key, so the WS key is never the
+ * raw master key and never collides with another SecureStore-derived purpose.
+ */
+const WS_SESSION_KEY_PURPOSE = "friday.rust.agent_run.ws.session_key.v1"; // pragma: allowlist secret
+
+/**
+ * An opt-in presence signal. The composition treats SecureStore as the source of truth;
+ * this env var lets a deployment DISABLE the SecureStore lookup (force fail-closed) WITHOUT
+ * carrying any key material. Set to exactly `"0"` / `"false"` to force a `null` resolve.
+ * It NEVER carries the key — only a boolean presence intent.
+ */
+export const FRIDAY_HUB_AGENT_RUN_WS_SESSION_KEY_PRESENT =
+  "FRIDAY_HUB_AGENT_RUN_WS_SESSION_KEY_PRESENT"; // pragma: allowlist secret
+
+/**
+ * Resolve the Rust agent-run WS session key from the SecureStore. Returns the opaque
+ * key bytes when present + valid, or `null` to fail closed (missing/invalid/disabled).
+ *
+ * NEVER throws an error that carries the key; NEVER logs the key.
+ */
+export type FridayRustAgentRunWsSessionKeyResolver = () => Uint8Array | null;
+
+/**
+ * Default SecureStore-backed resolver. Derives the WS session key from the keychain master
+ * key with a purpose tag (domain separation) so the raw master key never crosses the wire.
+ * Fails closed (returns `null`) when:
+ *   - the presence env signal is explicitly off, or
+ *   - the SecureStore master key is unavailable / throws, or
+ *   - the derived key is shorter than the floor (defensive; sha256 is always 32 bytes).
+ */
+export function resolveRustAgentRunWsSessionKey(): Uint8Array | null {
+  // Read the presence signal via a literal env key (the exported constant names the same
+  // var for callers/tests). A static literal avoids the dynamic object-injection lint sink.
+  const presence = process.env.FRIDAY_HUB_AGENT_RUN_WS_SESSION_KEY_PRESENT;
+  if (presence === "0" || presence === "false") {
+    // Operator/deployment explicitly disabled the SecureStore lookup → fail closed.
+    return null;
+  }
+
+  let masterKey: Buffer;
+  try {
+    // SecureStore root (keychain-backed). Throws when no key is provisioned → fail closed.
+    masterKey = getMasterKey();
+  } catch {
+    return null;
+  }
+  if (!masterKey || masterKey.length === 0) {
+    return null;
+  }
+
+  // Domain-separated derivation: never expose the raw master key as the WS auth proof.
+  const derived = createHash("sha256")
+    .update(WS_SESSION_KEY_PURPOSE)
+    .update(masterKey)
+    .digest();
+  if (derived.length < MIN_SESSION_KEY_LEN) {
+    return null;
+  }
+  return new Uint8Array(derived);
+}

--- a/src/api/model/friday-api-agent.types.ts
+++ b/src/api/model/friday-api-agent.types.ts
@@ -25,6 +25,15 @@ export interface FridayStartAgentRunRequest {
   constraints?: FridayAgentRunConstraints;
   taskProfile?: FridayAgentTaskProfileInput;
   executionContext?: FridayAgentExecutionContext;
+  /**
+   * execrun-replacement S-F-compose (DARK): the explicit, positive, per-run grant of the
+   * Rust read-tool set. Additive + optional — every existing caller omits it. When the
+   * default-OFF `routeAgentRunViaRust` flag is on, ONLY a request that positively grants
+   * exactly the 4 Rust read tools (read_file/list_dir/stat_file/search) can qualify for the
+   * Rust read-only route. Absent ⇒ disqualified ⇒ today's unchanged 503. Never derived from
+   * readOnly — this is the independent clause-4 gate.
+   */
+  allowedRustRouteTools?: string[];
 }
 
 export interface FridayAgentRunExecutionResponse {

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -136,6 +136,14 @@ import { createFridayChannelWebhookRoutes } from "../http/routes/friday-channel-
 import { createFridayPackagingRoutes } from "../http/routes/friday-packaging-routes.js";
 import { createFridayCloudWorkerSetupRoutes } from "../http/routes/friday-cloud-worker-setup-routes.js";
 import { createFridayCloudWorkerSetupService } from "#cloud-workers";
+import { createFridayRustHubAgentRunWsClientService } from "../mission-spine/friday-rust-hub-agent-run-ws-client.js";
+import type { FridayRustHubAgentRunWsClientService } from "../mission-spine/friday-rust-hub-agent-run-ws-client.js";
+import { createFridayRustHubRunContinuityProjectorService } from "../mission-spine/friday-rust-hub-run-continuity-projector-service.js";
+import type { FridayRustHubRunContinuityProjectorService } from "../mission-spine/friday-rust-hub-run-continuity-projector-service.js";
+import { createFridayRustHubRunAnswerReadbackService } from "../mission-spine/friday-rust-hub-run-answer-readback-service.js";
+import type { FridayRustHubRunAnswerReadbackService } from "../mission-spine/friday-rust-hub-run-answer-readback-service.js";
+import { resolveRustAgentRunWsSessionKey } from "../mission-spine/friday-rust-hub-agent-run-ws-session-key.js";
+import type { FridayRustAgentRunWsSessionKeyResolver } from "../mission-spine/friday-rust-hub-agent-run-ws-session-key.js";
 import { createFridayStudioService } from "../../studio/index.js";
 import {
   createFridayMutatingActionDigest,
@@ -1062,6 +1070,133 @@ export function qualifiesForRustReadOnlyRoute(input: RustRouteQualificationInput
   // Subagents + Pause-able/mutating-approval actions are precluded structurally
   // (route marker + readOnly + reads-only allow-list); no separate field to check.
   return true;
+}
+
+/**
+ * execrun-replacement S-F-compose (DARK) — the qualifying-run composition that routes ONE
+ * agent-run through the Rust read-only loop. This is only ever reached when the
+ * default-OFF `routeAgentRunViaRust` flag is ON AND {@link qualifiesForRustReadOnlyRoute}
+ * returned true (see {@link createFridayApiRuntime}'s route wrapper). Flag-off /
+ * disqualified NEVER reaches here — those fall to today's unchanged 503 path, byte-identical.
+ *
+ * The wired path (operator decision):
+ *   1. Resolve the WS session key from the SecureStore. MISSING/invalid → fail CLOSED:
+ *      throw the SAME 503 the disqualified path would have raised, WITHOUT ever opening a
+ *      WS connection (no unauthenticated egress). The key bytes become the WS `authProof`.
+ *   2. WS client (S-D) `dispatchRun` → the REFS-ONLY result (sha256 + len; NEVER the body).
+ *   3. Owner-gated readback (slice-3) `readAnswer({ runId, callerPrincipal })` → the body,
+ *      released ONLY to the authenticated owner principal. `callerPrincipal` is the bound
+ *      `principalId`; absent → fail closed.
+ *   4. Continuity projector (slice-2) writes the SOLE TS agent_run + run_result + usage row
+ *      (idempotent on run_id; no double-count). It is the only DB write here.
+ *   5. Return a `FridayAgentRuntimeResult` carrying the owner-released body as `finalResponse`.
+ *
+ * Fail-closed: ANY failure (missing key, WS error, readback non-delivered, projector throw)
+ * throws a 503-shaped {@link FridayDomainError}; it NEVER falls through to the TS `startRun`.
+ *
+ * Truth label: `rust_wired` — dark, mock-proven, no real spend; NOT v1 GO.
+ */
+async function composeRustReadOnlyAgentRun(args: {
+  readonly runId: string;
+  readonly task: string;
+  readonly principalId: string | undefined;
+  readonly providerId: string;
+  readonly model: string;
+  readonly wsClient: FridayRustHubAgentRunWsClientService;
+  readonly projector: FridayRustHubRunContinuityProjectorService;
+  readonly readback: FridayRustHubRunAnswerReadbackService;
+  readonly sessionKeyResolver: FridayRustAgentRunWsSessionKeyResolver;
+  readonly hubDbPath: string | undefined;
+  readonly db: FridaySqliteLayer;
+  readonly nowIso: () => string;
+}): Promise<FridayAgentRuntimeResult> {
+  const failClosed = (): FridayDomainError =>
+    new FridayDomainError(
+      "TS_RUNTIME_AGENT_RUNS_RETIRED",
+      "Agent run execution is fail-closed while runtime ownership is being moved out of TypeScript.",
+      {
+        httpStatus: 503,
+        details: {
+          classification: "fail_closed",
+          replacement: "rust_owned_agent_run_entrypoint_required",
+        },
+      },
+    );
+
+  // (1) SecureStore session key — MISSING/invalid ⇒ fail closed BEFORE any WS connection.
+  // Never open an unauthenticated WS call; never log the key.
+  const sessionKey = args.sessionKeyResolver();
+  if (!sessionKey || sessionKey.length === 0) {
+    throw failClosed();
+  }
+  // The owner principal must be present to gate the body readback (slice-3). Absent ⇒ 503.
+  const callerPrincipal = args.principalId;
+  if (!callerPrincipal) {
+    throw failClosed();
+  }
+  // The owner-gated body readback needs a Hub DB path. Absent ⇒ fail closed (no body).
+  const hubDbPath = args.hubDbPath;
+  if (!hubDbPath) {
+    throw failClosed();
+  }
+
+  // (2) Dispatch the run over the WS client (S-D). Refs-only result; fail-closed on error.
+  const wsResult = await args.wsClient.dispatchRun({
+    runId: args.runId,
+    task: args.task,
+    forwardedPrincipal: callerPrincipal,
+    authProof: sessionKey,
+  });
+
+  // (3) Owner-gated body readback (slice-3). The body is released ONLY to the matching
+  // owner; a non-`delivered` outcome carries no body ⇒ fail closed.
+  const readbackReceipt = await args.readback.readAnswer({
+    dbPath: hubDbPath,
+    runId: args.runId,
+    callerPrincipal,
+  });
+  if (readbackReceipt.outcome !== "delivered") {
+    throw failClosed();
+  }
+
+  // (4) Project the ONE TS continuity row (slice-2). SOLE TS usage writer; idempotent on
+  // run_id (re-projection adds no second row — the no-double-count contract). The refs-only
+  // WS result carries no token totals (S-D is refs-only and untouched), so usage is 0 here
+  // and `pricingResolved:false` stands — truth label dark, no fabricated numbers.
+  const completedAtIso = args.nowIso();
+  const projection = args.db.withWriteTransaction((db) =>
+    args.projector.project(db, {
+      truthLabel: "rust_wired_dev",
+      proofOnly: true,
+      ok: true,
+      runId: args.runId,
+      routeId: `${args.providerId}:${args.model}`,
+      providerId: args.providerId,
+      model: args.model,
+      loopStatus: wsResult.status === "completed" ? "Finished" : "Errored",
+      turns: 0,
+      executedTools: 0,
+      finalMessageSha256: readbackReceipt.answerSha256,
+      finalMessageLen: readbackReceipt.answerLen,
+      auditChainVerified: false,
+      usagePromptTokens: 0,
+      usageCompletionTokens: 0,
+      usageTotalTokens: 0,
+      completedAtIso,
+    }),
+  );
+
+  // (5) Return the owner-released body as the run's final response.
+  return {
+    runId: args.runId,
+    status: projection.status as FridayAgentRuntimeResult["status"],
+    response: readbackReceipt.answer,
+    toolCallCount: 0,
+    durationMs: 0,
+    usageInput: 0,
+    usageOutput: 0,
+    finalResponse: readbackReceipt.answer,
+  };
 }
 
 export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): FridayApiRuntime {
@@ -3904,6 +4039,15 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
       apiIdempotencyKey?: string;
       apiIdempotencyPayloadHash?: string;
       apiIdempotencyReceivedAt?: string;
+      // execrun-replacement S-F-compose (DARK): the explicit, positive, per-run grant of
+      // the Rust read-tool set. Purely additive + optional — every existing caller omits
+      // it (→ undefined → predicate clause-4 fails → disqualified → byte-identical 503).
+      // The HTTP route forwards `body.allowedRustRouteTools`; no other route behavior
+      // changes. NEVER derived from readOnly/operationalMode — clause-4 is an explicit gate.
+      allowedRustRouteTools?: string[];
+      // S-F-compose (DARK): an explicit plan-review override marker (clause-5 disqualifier).
+      // Additive + optional; absent for every existing caller.
+      planReviewOverride?: unknown;
     }) => {
       if (deps.allowTestOnlyAgentRunStartExecution !== true) {
         void input;
@@ -4003,19 +4147,38 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
           run: async () => throwRetiredAgentRunControl(),
         };
 
-    // execrun-replacement slice 4 (DARK): route-only Rust-route qualification.
+    // execrun-replacement S-F-compose (DARK): route a QUALIFYING agent-run through the
+    // Rust read-only loop — behind the DEFAULT-OFF `routeAgentRunViaRust` flag.
+    //
     // This wrapper is handed ONLY to createFridayAgentRoutes (the single startRun HTTP
     // route) — NOT to the automation-service copy (a non-route caller) above, and NOT to
     // the executeRun path the 7 non-route callers use. That is the structural half of the
     // route-not-method pin; the explicit `invokedFromHttpStartRunRoute: true` marker below
-    // is the testable half. The flag is checked FIRST and short-circuits; with the flag off
-    // (default) or the predicate disqualified, the wrapper just calls the unchanged startRun
-    // → byte-identical to today (the existing fail-closed 503 still applies inside startRun).
-    // The computed boolean is consumed by NOBODY yet; the composition slice will route on it.
+    // is the testable half.
+    //
+    // BYTE-IDENTICAL 503 GUARANTEE: the flag is checked FIRST. With the flag OFF (the
+    // default), the predicate is not even evaluated and the wrapper calls the unchanged
+    // `startRun(input)` → byte-identical to today (today's fail-closed 503 fires inside).
+    // With the flag ON but the predicate DISQUALIFIED (e.g. no allowedRustRouteTools
+    // grant, not DeepSeek-flash, sessioned, plan-review), the wrapper ALSO calls the
+    // unchanged `startRun(input)` → the same 503. The ONLY divergence from today is a
+    // flag-ON + fully-qualifying run, which is routed to Rust and NEVER touches `startRun`.
+    //
+    // Dark-substrate services are lazily constructed once (real constructors), overridable
+    // via deps for mock-proven tests. They are consulted ONLY on the qualifying branch.
+    const rustWsClient =
+      deps.rustAgentRunWsClient ?? createFridayRustHubAgentRunWsClientService();
+    const rustContinuityProjector =
+      deps.rustAgentRunContinuityProjector ?? createFridayRustHubRunContinuityProjectorService();
+    const rustAnswerReadback =
+      deps.rustAgentRunAnswerReadback ?? createFridayRustHubRunAnswerReadbackService();
+    const rustWsSessionKeyResolver =
+      deps.rustAgentRunWsSessionKeyResolver ?? resolveRustAgentRunWsSessionKey;
+    const rustHubDbPath = deps.rustAgentRunHubDbPath ?? process.env.FRIDAY_HUB_AGENT_RUN_DB_PATH;
+
     const routeStartRun: typeof startRun = async (input) => {
       if (deps.routeAgentRunViaRust === true) {
-        // DARK: compute qualification and discard. No routing wired in this slice.
-        void qualifiesForRustReadOnlyRoute({
+        const qualifies = qualifiesForRustReadOnlyRoute({
           invokedFromHttpStartRunRoute: true,
           providerId: input.providerId,
           model: input.model,
@@ -4023,8 +4186,31 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
           requireReview: input.requireReview,
           constraints: input.constraints,
           taskProfile: input.taskProfile,
+          allowedRustRouteTools: input.allowedRustRouteTools,
+          planReviewOverride: input.planReviewOverride,
         });
+        if (qualifies) {
+          // Qualifying run: route via Rust. Fail-closed on missing key / WS / readback /
+          // projector — this NEVER falls through to the TS `startRun`. providerId/model
+          // are guaranteed defined here (the predicate required the exact deepseek-flash
+          // identifiers), but coalesce defensively to satisfy the type.
+          return composeRustReadOnlyAgentRun({
+            runId: deps.idGenerator(),
+            task: input.task,
+            principalId: input.principalId,
+            providerId: input.providerId ?? RUST_ROUTE_DEEPSEEK_PROVIDER_ID,
+            model: input.model ?? RUST_ROUTE_DEEPSEEK_FLASH_MODEL,
+            wsClient: rustWsClient,
+            projector: rustContinuityProjector,
+            readback: rustAnswerReadback,
+            sessionKeyResolver: rustWsSessionKeyResolver,
+            hubDbPath: rustHubDbPath,
+            db: deps.db,
+            nowIso: deps.nowIso,
+          });
+        }
       }
+      // Flag off OR disqualified → today's unchanged path (byte-identical 503 inside).
       return startRun(input);
     };
 

--- a/src/api/runtime/friday-api-runtime.types.ts
+++ b/src/api/runtime/friday-api-runtime.types.ts
@@ -27,6 +27,10 @@ import type {
   FridayStandingAgendaService,
 } from "../../autonomy/index.js";
 import type { FridayProviderService } from "#providers";
+import type { FridayRustHubAgentRunWsClientService } from "../mission-spine/friday-rust-hub-agent-run-ws-client.js";
+import type { FridayRustHubRunContinuityProjectorService } from "../mission-spine/friday-rust-hub-run-continuity-projector-service.js";
+import type { FridayRustHubRunAnswerReadbackService } from "../mission-spine/friday-rust-hub-run-answer-readback-service.js";
+import type { FridayRustAgentRunWsSessionKeyResolver } from "../mission-spine/friday-rust-hub-agent-run-ws-session-key.js";
 import type { FridayMediaUnderstandingRoutesDeps } from "../http/routes/friday-media-understanding-routes.js";
 import type { FridaySocialImportRoutesDeps } from "../http/routes/friday-social-import-routes.js";
 import type { FridayTaskWorkflowRoutesDeps } from "../http/routes/friday-task-workflow-routes.js";
@@ -323,6 +327,32 @@ export interface CreateFridayApiRuntimeDeps {
    * flag holds the gate; it does not turn anything on.
    */
   routeAgentRunViaRust?: boolean;
+  /**
+   * execrun-replacement slice S-F-compose (DARK): the three dark-substrate services the
+   * composition wires together when {@link routeAgentRunViaRust} is on AND a run qualifies.
+   * ALL OPTIONAL — when omitted the composition lazily constructs the real services. Tests
+   * inject a scripted-stub WS client + a `delivered` readback + the real projector so the
+   * full path is mock-proven (no real Rust bin, no provider, no spend, no network egress).
+   * None of these is consulted while the flag is off / a run is disqualified (byte-identical
+   * 503 path is untouched).
+   */
+  rustAgentRunWsClient?: FridayRustHubAgentRunWsClientService;
+  /** S-F-compose (DARK): the slice-2 Rust→TS continuity projector (SOLE TS usage writer). */
+  rustAgentRunContinuityProjector?: FridayRustHubRunContinuityProjectorService;
+  /** S-F-compose (DARK): the slice-3 owner-gated body readback (returns body to the owner). */
+  rustAgentRunAnswerReadback?: FridayRustHubRunAnswerReadbackService;
+  /**
+   * S-F-compose (DARK): the SecureStore resolver for the WS session key (the WS `authProof`).
+   * Default = the keychain-backed resolver. A `null` resolve (missing/invalid key) fails
+   * closed → no WS call, today's 503. Tests inject a fixture resolver. NEVER logs the key.
+   */
+  rustAgentRunWsSessionKeyResolver?: FridayRustAgentRunWsSessionKeyResolver;
+  /**
+   * S-F-compose (DARK): filesystem path to the Rust Hub DB the owner-gated body readback
+   * reads from. Default = `process.env.FRIDAY_HUB_AGENT_RUN_DB_PATH`. Absent → the readback
+   * fails closed (no body) → 503. Tests point this at a hermetic fixture DB / stub readback.
+   */
+  rustAgentRunHubDbPath?: string;
   /**
    * Test-oracle only: allows legacy TypeScript agent run controls in isolated
    * mock/unit validation. Production/runtime callers must leave this unset so

--- a/test/unit/api/mission-spine/friday-rust-hub-agent-run-ws-session-key.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-agent-run-ws-session-key.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  FRIDAY_HUB_AGENT_RUN_WS_SESSION_KEY_PRESENT,
+  resolveRustAgentRunWsSessionKey,
+} from "../../../../src/api/mission-spine/friday-rust-hub-agent-run-ws-session-key.js";
+
+// execrun-replacement S-F-compose (DARK): the SecureStore-backed WS session-key resolver.
+// Fail-closed contract: a MISSING / disabled SecureStore key resolves to `null` so the
+// composition never opens an unauthenticated WS connection. The key is NEVER logged.
+
+describe("resolveRustAgentRunWsSessionKey (S-F-compose, dark, SecureStore-backed)", () => {
+  const savedPresence = process.env[FRIDAY_HUB_AGENT_RUN_WS_SESSION_KEY_PRESENT];
+
+  beforeEach(() => {
+    delete process.env[FRIDAY_HUB_AGENT_RUN_WS_SESSION_KEY_PRESENT];
+  });
+
+  afterEach(() => {
+    if (savedPresence === undefined) {
+      delete process.env[FRIDAY_HUB_AGENT_RUN_WS_SESSION_KEY_PRESENT];
+    } else {
+      process.env[FRIDAY_HUB_AGENT_RUN_WS_SESSION_KEY_PRESENT] = savedPresence;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("explicit disable via the presence env signal → fail closed (null), no SecureStore read", () => {
+    process.env[FRIDAY_HUB_AGENT_RUN_WS_SESSION_KEY_PRESENT] = "0";
+    expect(resolveRustAgentRunWsSessionKey()).toBeNull();
+    process.env[FRIDAY_HUB_AGENT_RUN_WS_SESSION_KEY_PRESENT] = "false";
+    expect(resolveRustAgentRunWsSessionKey()).toBeNull();
+  });
+
+  it("never throws an error that carries the key, and never logs", () => {
+    // The presence signal off forces the no-read path; assert no console output leaks.
+    process.env[FRIDAY_HUB_AGENT_RUN_WS_SESSION_KEY_PRESENT] = "0";
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(() => resolveRustAgentRunWsSessionKey()).not.toThrow();
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(errSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("when the SecureStore master key is unavailable → fail closed (null)", () => {
+    // With no keychain master key + no master-key env provisioned, the SecureStore lookup
+    // throws internally and the resolver returns null (fail closed) rather than propagating.
+    // (The presence signal is unset here, so the SecureStore path is attempted.)
+    const result = resolveRustAgentRunWsSessionKey();
+    // Either null (no key provisioned) or a >=32-byte derived key (a key was provisioned in
+    // this environment) — but NEVER a short/invalid value, and NEVER a throw.
+    if (result !== null) {
+      expect(result.length).toBeGreaterThanOrEqual(32);
+    } else {
+      expect(result).toBeNull();
+    }
+  });
+});

--- a/test/unit/api/runtime/friday-api-runtime-rust-route-compose.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-rust-route-compose.test.ts
@@ -1,0 +1,352 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createFridayApiRuntime } from "#api";
+import {
+  createFridayAgentEventEmitter,
+  type FridayAgentRuntime,
+} from "#agent";
+import type { FridayProviderService } from "#providers";
+import type { FridaySqliteLayer } from "#state";
+import { createFridayRustHubRunContinuityProjectorService } from "../../../../src/api/mission-spine/friday-rust-hub-run-continuity-projector-service.js";
+import type {
+  FridayRustHubAgentRunWsClientService,
+  FridayRustHubAgentRunWsRequest,
+} from "../../../../src/api/mission-spine/friday-rust-hub-agent-run-ws-client.js";
+import type {
+  FridayRustHubRunAnswerReadbackInput,
+  FridayRustHubRunAnswerReadbackReceipt,
+  FridayRustHubRunAnswerReadbackService,
+} from "../../../../src/api/mission-spine/friday-rust-hub-run-answer-readback-service.js";
+import { createTestDb } from "../../../helpers/friday-test-db.helper.js";
+
+// execrun-replacement S-F-compose (DARK): the composition wires the dark substrate
+// (WS client S-D → owner-gated readback slice-3 → continuity projector slice-2) into the
+// ONE startRun route, behind the DEFAULT-OFF `routeAgentRunViaRust` flag. MOCK-PROVEN: a
+// scripted-stub WS client + a `delivered` readback + the REAL projector against a test db.
+// No real Rust bin, no provider, no spend, no network egress.
+
+const NOW = "2026-06-08T09:00:00.000Z";
+
+// The owner-gated answer body the slice-3 readback releases to the matching owner.
+const OWNER_BODY = "README.md lists: src/, test/, package.json.";
+const ANSWER_SHA256 = "a".repeat(64); // pragma: allowlist secret
+const RUN_ID = "fixed-run-id";
+
+function makeIdGenerator(runId: string): () => string {
+  return () => runId;
+}
+
+function makeProviderService(): FridayProviderService {
+  return {
+    listProviders: vi.fn(async () => []),
+    getProvider: vi.fn(async () => null),
+    createProvider: vi.fn(async () => ({} as never)),
+    updateProvider: vi.fn(async () => ({} as never)),
+    deleteProvider: vi.fn(async () => undefined),
+    validateProvider: vi.fn(async () => ({ status: "ok" as const, checkedAt: NOW })),
+    getRoutingConfig: vi.fn(async () => ({ defaultProviderId: "p-1", fallbackProviderIds: [] })),
+    setRoutingConfig: vi.fn(async (input) => input),
+    resolveRoute: vi.fn(async () => ({
+      provider: {
+        id: "p-1",
+        kind: "deepseek" as const,
+        name: "DeepSeek",
+        baseUrl: "https://api.deepseek.com",
+        enabled: true,
+        config: {
+          api: "openai-completions" as const,
+          authMode: "api-key" as const,
+          keySource: { kind: "env-ref" as const, envVar: "DEEPSEEK_API_KEY" },
+          supportedModels: ["deepseek-v4-flash"],
+          validation: { status: "ok" as const, checkedAt: NOW },
+        },
+        createdAt: NOW,
+        updatedAt: NOW,
+      },
+      model: "deepseek-v4-flash",
+    })),
+    runWithFallback: vi.fn(async () => ({} as never)),
+  } as unknown as FridayProviderService;
+}
+
+function makeBoundPrincipal(principalId: string) {
+  return {
+    principalType: "user",
+    principalId,
+    userId: principalId,
+    tokenId: `${principalId}-token`,
+    tokenKind: "access",
+    scopes: ["agent.write"],
+    issuedAt: NOW,
+  };
+}
+
+function makeAgentRuntime(): FridayAgentRuntime {
+  return {
+    executeRun: vi.fn(async () => {
+      throw new Error("executeRun must not be reached on the Rust-route compose path");
+    }),
+    registerTool: vi.fn(),
+    resumeStaleRunsOnBoot: vi.fn(() => 0),
+  } as unknown as FridayAgentRuntime;
+}
+
+/** A scripted-stub WS client that records every dispatch (refs-only result). */
+function makeStubWsClient() {
+  const calls: FridayRustHubAgentRunWsRequest[] = [];
+  const service: FridayRustHubAgentRunWsClientService = {
+    dispatchRun: vi.fn(async (request: FridayRustHubAgentRunWsRequest) => {
+      calls.push(request);
+      return {
+        truthLabel: "rust_wired" as const,
+        runId: request.runId,
+        status: "completed",
+        answerSha256: ANSWER_SHA256,
+        answerLen: OWNER_BODY.length,
+      };
+    }),
+  };
+  return { service, calls };
+}
+
+/** A stub readback that returns the owner-gated body to the matching owner principal. */
+function makeStubReadback(owner: string) {
+  const calls: FridayRustHubRunAnswerReadbackInput[] = [];
+  const service: FridayRustHubRunAnswerReadbackService = {
+    readAnswer: vi.fn(
+      async (input: FridayRustHubRunAnswerReadbackInput): Promise<FridayRustHubRunAnswerReadbackReceipt> => {
+        calls.push(input);
+        if (input.callerPrincipal === owner) {
+          return {
+            truthLabel: "rust_wired_dev",
+            proofOnly: true,
+            outcome: "delivered",
+            runId: input.runId,
+            status: "completed",
+            answer: OWNER_BODY,
+            answerSha256: ANSWER_SHA256,
+            answerLen: OWNER_BODY.length,
+          };
+        }
+        return {
+          truthLabel: "rust_wired_dev",
+          proofOnly: true,
+          outcome: "denied",
+          runId: input.runId,
+          denyReason: "principal_mismatch",
+        };
+      },
+    ),
+  };
+  return { service, calls };
+}
+
+interface ComposeDeps {
+  routeAgentRunViaRust?: boolean;
+  wsClient?: FridayRustHubAgentRunWsClientService;
+  readback?: FridayRustHubRunAnswerReadbackService;
+  sessionKeyResolver?: () => Uint8Array | null;
+  hubDbPath?: string;
+  idGenerator?: () => string;
+}
+
+function makeRuntime(db: FridaySqliteLayer, opts: ComposeDeps) {
+  return createFridayApiRuntime({
+    db,
+    idGenerator: opts.idGenerator ?? makeIdGenerator(RUN_ID),
+    nowIso: () => NOW,
+    providerService: makeProviderService(),
+    agentRuntime: makeAgentRuntime(),
+    agentEventEmitter: createFridayAgentEventEmitter(),
+    tokenSecret: "test-secret-key-that-is-at-least-32-chars-long!!", // pragma: allowlist secret
+    computeChecksum: (content: string) => `checksum-${content.length}`,
+    resolveSkill: () => null,
+    invokeSkill: async () => ({}),
+    // allowTestOnlyAgentRunStartExecution intentionally UNSET → production fail-closed 503
+    // on the disqualified / flag-off path (matches production + slice-4).
+    ...(opts.routeAgentRunViaRust === undefined ? {} : { routeAgentRunViaRust: opts.routeAgentRunViaRust }),
+    ...(opts.wsClient ? { rustAgentRunWsClient: opts.wsClient } : {}),
+    ...(opts.readback ? { rustAgentRunAnswerReadback: opts.readback } : {}),
+    // The REAL projector is used so the no-double-count contract is exercised against a db.
+    rustAgentRunContinuityProjector: createFridayRustHubRunContinuityProjectorService(),
+    // SecureStore resolver: fixture key by default; tests override to prove fail-closed.
+    rustAgentRunWsSessionKeyResolver:
+      opts.sessionKeyResolver ?? (() => new Uint8Array(32).fill(7)),
+    rustAgentRunHubDbPath: opts.hubDbPath ?? "/tmp/friday-test-hub.db",
+  });
+}
+
+// A request body that fully SATISFIES the predicate (read-only DeepSeek-flash + the
+// explicit 4-tool grant + no session + no plan-review).
+const QUALIFYING_BODY = {
+  task: "List the files in the workspace and read README.md.",
+  providerId: "deepseek",
+  model: "deepseek-v4-flash",
+  constraints: { readOnly: true },
+  allowedRustRouteTools: ["read_file", "list_dir", "stat_file", "search"],
+};
+
+// Same content clauses but NO read-tool grant → disqualified (clause-4 fails).
+const DISQUALIFYING_BODY = {
+  task: "List the files in the workspace and read README.md.",
+  providerId: "deepseek",
+  model: "deepseek-v4-flash",
+  constraints: { readOnly: true },
+};
+
+const OWNER_PRINCIPAL = "rust-route-compose-owner";
+
+async function callStartRoute(
+  runtime: ReturnType<typeof createFridayApiRuntime>,
+  body: Record<string, unknown>,
+) {
+  const startRoute = runtime.routes
+    .getRoutes()
+    .find((route) => route.operationId === "agent.runs.start");
+  expect(startRoute).toBeDefined();
+  return startRoute!.handler({
+    body,
+    principal: makeBoundPrincipal(OWNER_PRINCIPAL),
+  } as never);
+}
+
+function countRows(db: FridaySqliteLayer, table: string, runId: string): number {
+  if (table === "friday_agent_runs") {
+    return db.withReadConnection((d) =>
+      (d.prepare("SELECT COUNT(*) AS c FROM friday_agent_runs WHERE id = ?").get(runId) as { c: number }).c,
+    );
+  }
+  // llm_usage_records keyed on the deterministic per-run id.
+  return db.withReadConnection((d) =>
+    (d
+      .prepare("SELECT COUNT(*) AS c FROM llm_usage_records WHERE id = ?")
+      .get(`rust-continuity-usage:${runId}`) as { c: number }).c,
+  );
+}
+
+describe("FridayApiRuntime — execrun S-F-compose (DARK) Rust-route composition", () => {
+  let db: FridaySqliteLayer;
+
+  afterEach(() => {
+    db?.close();
+  });
+
+  it("(a) flag ON + qualifying run → WS→readback→projector path; ONE continuity row; body to owner", async () => {
+    db = createTestDb();
+    const ws = makeStubWsClient();
+    const readback = makeStubReadback(OWNER_PRINCIPAL);
+    const runtime = makeRuntime(db, {
+      routeAgentRunViaRust: true,
+      wsClient: ws.service,
+      readback: readback.service,
+    });
+
+    const result = (await callStartRoute(runtime, { ...QUALIFYING_BODY })) as {
+      runId: string;
+      response: string;
+      finalResponse?: string;
+      status: string;
+    };
+
+    // The full path was invoked.
+    expect(ws.calls).toHaveLength(1);
+    expect(ws.calls[0].runId).toBe(RUN_ID);
+    expect(ws.calls[0].forwardedPrincipal).toBe(OWNER_PRINCIPAL);
+    expect(ws.calls[0].authProof.length).toBeGreaterThanOrEqual(32);
+    expect(readback.calls).toHaveLength(1);
+    expect(readback.calls[0].callerPrincipal).toBe(OWNER_PRINCIPAL);
+
+    // The owner-gated body was returned to the authenticated owner.
+    expect(result.runId).toBe(RUN_ID);
+    expect(result.response).toBe(OWNER_BODY);
+    expect(result.finalResponse).toBe(OWNER_BODY);
+    expect(result.status).toBe("completed");
+
+    // Exactly ONE TS continuity agent_run + usage row.
+    expect(countRows(db, "friday_agent_runs", RUN_ID)).toBe(1);
+    expect(countRows(db, "llm_usage_records", RUN_ID)).toBe(1);
+  });
+
+  it("(b) flag OFF (default) → byte-identical 503; the WS path is NEVER touched", async () => {
+    db = createTestDb();
+    const ws = makeStubWsClient();
+    const readback = makeStubReadback(OWNER_PRINCIPAL);
+    const runtime = makeRuntime(db, {
+      // routeAgentRunViaRust omitted → default false.
+      wsClient: ws.service,
+      readback: readback.service,
+    });
+
+    await expect(callStartRoute(runtime, { ...QUALIFYING_BODY })).rejects.toMatchObject({
+      code: "TS_RUNTIME_AGENT_RUNS_RETIRED",
+      httpStatus: 503,
+    });
+    expect(ws.calls).toHaveLength(0);
+    expect(readback.calls).toHaveLength(0);
+    expect(countRows(db, "friday_agent_runs", RUN_ID)).toBe(0);
+  });
+
+  it("(c) flag ON but DISQUALIFIED (no read-tool grant) → byte-identical 503; WS never touched", async () => {
+    db = createTestDb();
+    const ws = makeStubWsClient();
+    const readback = makeStubReadback(OWNER_PRINCIPAL);
+    const runtime = makeRuntime(db, {
+      routeAgentRunViaRust: true,
+      wsClient: ws.service,
+      readback: readback.service,
+    });
+
+    await expect(callStartRoute(runtime, { ...DISQUALIFYING_BODY })).rejects.toMatchObject({
+      code: "TS_RUNTIME_AGENT_RUNS_RETIRED",
+      httpStatus: 503,
+    });
+    expect(ws.calls).toHaveLength(0);
+    expect(readback.calls).toHaveLength(0);
+  });
+
+  it("(d) flag ON + qualifying but MISSING SecureStore key → fail closed (503); NO WS call", async () => {
+    db = createTestDb();
+    const ws = makeStubWsClient();
+    const readback = makeStubReadback(OWNER_PRINCIPAL);
+    const runtime = makeRuntime(db, {
+      routeAgentRunViaRust: true,
+      wsClient: ws.service,
+      readback: readback.service,
+      // SecureStore returns null → fail closed before any WS connection.
+      sessionKeyResolver: () => null,
+    });
+
+    await expect(callStartRoute(runtime, { ...QUALIFYING_BODY })).rejects.toMatchObject({
+      code: "TS_RUNTIME_AGENT_RUNS_RETIRED",
+      httpStatus: 503,
+    });
+    // The fail-closed branch fired BEFORE the WS client was ever dispatched.
+    expect(ws.calls).toHaveLength(0);
+    expect(readback.calls).toHaveLength(0);
+    expect(countRows(db, "friday_agent_runs", RUN_ID)).toBe(0);
+  });
+
+  it("(e) re-running the same run_id is idempotent — no double-count (projector contract)", async () => {
+    db = createTestDb();
+    const ws = makeStubWsClient();
+    const readback = makeStubReadback(OWNER_PRINCIPAL);
+    // Both routes generate the SAME run id → re-projection of the same run.
+    const runtime = makeRuntime(db, {
+      routeAgentRunViaRust: true,
+      wsClient: ws.service,
+      readback: readback.service,
+      idGenerator: makeIdGenerator(RUN_ID),
+    });
+
+    const first = (await callStartRoute(runtime, { ...QUALIFYING_BODY })) as { response: string };
+    const second = (await callStartRoute(runtime, { ...QUALIFYING_BODY })) as { response: string };
+
+    expect(first.response).toBe(OWNER_BODY);
+    expect(second.response).toBe(OWNER_BODY);
+
+    // The path ran twice, but the projector wrote exactly ONE row per surface (no double-count).
+    expect(ws.calls).toHaveLength(2);
+    expect(countRows(db, "friday_agent_runs", RUN_ID)).toBe(1);
+    expect(countRows(db, "llm_usage_records", RUN_ID)).toBe(1);
+  });
+});


### PR DESCRIPTION
## What this slice does (S-F-compose — DARK)

Composes the dark execrun-replacement substrate so that a **qualifying** production agent-run routes through Rust — behind the **DEFAULT-OFF `routeAgentRunViaRust` flag**. Production behavior is unchanged (byte-identical 503) until the slice-6 live-flip.

It wires three already-built dark pieces into the ONE startRun HTTP route:
- **WS client (S-D)** `friday-rust-hub-agent-run-ws-client.ts` — sends the AgentRunRequest, parses the refs-only AgentRunResult, fail-closed.
- **Continuity projector (slice-2)** — projects a Rust run receipt → ONE TS `agent_run` + `run_result` + usage row (idempotent, no double-count).
- **Owner-gated readback (slice-3)** — returns the answer body ONLY to the authenticated owner principal.

## Compose path

`src/api/runtime/friday-api-runtime.ts` — the `routeStartRun` wrapper (the structural route-not-method pin) now USES the predicate result instead of discarding it. When the flag is ON **and** `qualifiesForRustReadOnlyRoute` returns true, it calls `composeRustReadOnlyAgentRun`:

1. **SecureStore session key** (the WS `authProof`) — MISSING/invalid → **fail closed BEFORE any WS connection** (never an unauthenticated WS call).
2. **WS client (S-D)** `dispatchRun` → refs-only result (sha256 + len, **never** the body).
3. **Owner-gated readback (slice-3)** `readAnswer({ runId, callerPrincipal })` → the body, released ONLY to the authenticated owner (`callerPrincipal = principalId`; absent → fail closed). The S-D result is refs-only by construction, so the body comes from slice-3, not the WS frame.
4. **Continuity projector (slice-2)** writes the SOLE TS agent_run + run_result + usage row (idempotent on run_id; no double-count — the only DB write here).
5. Returns the owner-released body as the run's `finalResponse`.

## Flag-off-byte-identical-503 guarantee

The flag is checked FIRST. Flag OFF (default) → the predicate is not even evaluated → the wrapper calls the unchanged `startRun(input)` → today's fail-closed 503. Flag ON but **disqualified** (no read-tool grant / not DeepSeek-flash / sessioned / plan-review) → ALSO the unchanged `startRun(input)` → the same 503. The ONLY divergence from today is a flag-ON + fully-qualifying run, which is routed to Rust and **never touches `startRun`**. Any WS/readback/projector failure throws 503 and never falls through to the TS path.

## Fail-closed on missing key

`src/api/mission-spine/friday-rust-hub-agent-run-ws-session-key.ts` resolves the WS session key from the **SecureStore** (keychain-backed master key, domain-separated derivation — never the raw master key on the wire). A MISSING / invalid / explicitly-disabled key resolves to `null`; the compose then throws the 503 **before** `dispatchRun` is called (test (d) asserts the WS stub got zero connections). The key is **never printed or logged**.

## Dark launchd plist (FILE only — NOT loaded)

`scripts/ops/launchd/com.friday.rust-agent-run-ws-server.plist` — the launchd supervisor for the long-lived Rust WS server (`hub_agent_run_server`, S-B). Operator decision: **launchd owns supervision** (not an unmanaged child). RunAtLoad + KeepAlive, **loopback-only**, **SECRET-REDACTED logging** (`RUST_LOG=warn` + `FRIDAY_LOG_REDACT_SECRETS=true`, no key in the plist), a health gate via `KeepAlive(SuccessfulExit=false)`, and fail-closed-on-unavailable. It is **added, not installed/loaded** by this slice — **slice-6 loads it** (operator gate).

## Write-set note (documented deviation)

Slice-4's own comment assigned the read-tool-grant body-parse to "the composition slice": *"the composition slice wires the HTTP-body parse that populates [`allowedRustRouteTools`]."* A body-parse lives in the routes file, and no positive-grant field flows through `startRun`'s input today — so this slice makes ONE **additive, optional** touch to `friday-agent-routes.ts`: forward `body.allowedRustRouteTools`. **Absent → `undefined` → predicate clause-4 fails → disqualified → byte-identical 503.** Every existing caller omits it; slice-4's three existing tests stay green. The grant is **never derived from `readOnly`** — clause-4 stays an independent positive gate. A one-field revert if the coordinator objects.

## Write-set

- `src/api/runtime/friday-api-runtime.ts` — `composeRustReadOnlyAgentRun` + the `routeStartRun` compose
- `src/api/runtime/friday-api-runtime.types.ts` — optional injectable deps (WS client / projector / readback / SecureStore resolver / hub db path)
- `src/api/mission-spine/friday-rust-hub-agent-run-ws-session-key.ts` — SecureStore WS session-key resolver
- `src/api/http/routes/friday-agent-routes.ts` — additive `allowedRustRouteTools` parse + forward
- `src/api/model/friday-api-agent.types.ts` — additive request field
- `scripts/ops/launchd/com.friday.rust-agent-run-ws-server.plist` — dark plist
- `test/unit/api/runtime/friday-api-runtime-rust-route-compose.test.ts` — (a) full path + ONE row + body-to-owner, (b) flag-off byte-identical 503 (WS untouched), (c) disqualified 503, (d) missing-key fail-closed (no WS call), (e) idempotent no-double-count
- `test/unit/api/mission-spine/friday-rust-hub-agent-run-ws-session-key.test.ts`

## Mock-proven / dark

Tests inject a scripted-stub WS client + a `delivered` readback + the REAL projector against an in-memory test DB. No real Rust bin, no provider, no spend, no network egress beyond loopback. mock-env keeps the flag default-false so the ui browser-e2e stays green (the agent-run route is not exercised by it; `/v1/workflow-runs` is).

## Truth labels

WS S-F-compose; **dark** (flag default-off, plist not loaded, no real spend); the **live-flip is slice-6** (operator gate); `rust_wired` at best; **NOT v1 GO**.

## Local verification

- `npm run lint` (`eslint .`): **0 errors** (pre-existing warnings only)
- typecheck (`tsc --noEmit`): **0 errors**
- targeted tests: 5 compose + 3 session-key + 3 slice-4 (byte-identical preserved) = **11/11 pass**; broader api/runtime + mission-spine + agent-routes suites **253/253 pass**
- secret scanners (`check-provider-key-patterns.mjs`, `detect-secrets-hook`): clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)