### PR TITLE
fix(rust): execrun compose carry-forwards — apiIdempotencyKey replay + planReviewOverride parse (dark)

### DIFF
--- a/src/api/http/routes/friday-agent-routes.ts
+++ b/src/api/http/routes/friday-agent-routes.ts
@@ -909,6 +909,11 @@ export interface FridayAgentRoutesDeps {
     // Additive + optional; forwarded straight to the route-bound startRun wrapper, which
     // (only when the default-OFF Rust-route flag is on) uses it as the clause-4 qualifier.
     allowedRustRouteTools?: string[];
+    // execrun S-F carry-forward (DARK): a plan-review OVERRIDE marker (predicate clause-5
+    // disqualifier). Additive + optional; PRESENCE alone disqualifies the Rust route (→ the
+    // unchanged 503). Forwarded RAW — presence-only, never coerced/injected (route-not-method
+    // pin: it may only DISQUALIFY, never grant). Absent for every existing caller.
+    planReviewOverride?: unknown;
   }) => Promise<FridayAgentRuntimeResult>;
   getRun: (runId: string) => FridayAgentRunRecord | null;
   listRuns: (query: {
@@ -1402,6 +1407,16 @@ export function createFridayAgentRoutes(
           ? body.allowedRustRouteTools
           : undefined;
 
+        // execrun S-F carry-forward (DARK): forward `body.planReviewOverride` RAW into the
+        // route-bound startRun wrapper so the Rust-route predicate's clause-5 plan-review
+        // disqualifier can fire (PRESENCE → disqualified → today's unchanged 503). Parsed
+        // presence-only (`"planReviewOverride" in body`) — NEVER coerced, validated, or
+        // injected: the route-not-method pin requires this field may ONLY disqualify, never
+        // grant. Absent for every existing caller (conditional spread → omitted → byte-
+        // identical), so the only HTTP-observable change is: a run carrying this marker is now
+        // disqualified instead of (incorrectly) qualifying.
+        const hasPlanReviewOverride = "planReviewOverride" in body;
+
         const result = await deps.startRun({
           task: body.task,
           taskPrompt,
@@ -1417,6 +1432,9 @@ export function createFridayAgentRoutes(
           taskProfile,
           executionContext,
           ...(allowedRustRouteTools ? { allowedRustRouteTools } : {}),
+          ...(hasPlanReviewOverride
+            ? { planReviewOverride: (body as Record<string, unknown>).planReviewOverride }
+            : {}),
           ...(apiIdempotencyKey
             ? {
               apiIdempotencyKey,

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -4301,7 +4301,12 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
           return composeRustReadOnlyAgentRun({
             runId: deps.idGenerator(),
             task: input.task,
-            principalId: input.principalId,
+            // Owner-binding keys on the NORMALIZED principal — the SAME value the idempotency
+            // lookup (above), the owner-gated readback, and the stamp use — so all four agree on
+            // one canonical owner string (a blank/whitespace principal ⇒ undefined ⇒ fail-closed,
+            // matching the bare startRun which normalizes throughout). Robust to future auth
+            // issuance even if a principalId ever arrives non-canonical.
+            principalId: normalizedPrincipalId,
             providerId: input.providerId ?? RUST_ROUTE_DEEPSEEK_PROVIDER_ID,
             model: input.model ?? RUST_ROUTE_DEEPSEEK_FLASH_MODEL,
             wsClient: rustWsClient,

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -1096,6 +1096,28 @@ export function qualifiesForRustReadOnlyRoute(input: RustRouteQualificationInput
  *
  * Truth label: `rust_wired` — dark, mock-proven, no real spend; NOT v1 GO.
  */
+/**
+ * The SOLE 503 the Rust read-only compose path raises on ANY fail-closed condition
+ * (missing session key, missing owner principal / Hub DB path, WS error, non-delivered
+ * readback, projector throw). Byte-identical to the disqualified / flag-off `startRun`
+ * 503 (same code, message, status, classification, replacement) so the route stays
+ * indistinguishable from today on every non-routed path. Hoisted to module scope so the
+ * compose path AND the route-level idempotency-replay guard share one definition.
+ */
+function failClosedRustAgentRun(): FridayDomainError {
+  return new FridayDomainError(
+    "TS_RUNTIME_AGENT_RUNS_RETIRED",
+    "Agent run execution is fail-closed while runtime ownership is being moved out of TypeScript.",
+    {
+      httpStatus: 503,
+      details: {
+        classification: "fail_closed",
+        replacement: "rust_owned_agent_run_entrypoint_required",
+      },
+    },
+  );
+}
+
 async function composeRustReadOnlyAgentRun(args: {
   readonly runId: string;
   readonly task: string;
@@ -1109,19 +1131,22 @@ async function composeRustReadOnlyAgentRun(args: {
   readonly hubDbPath: string | undefined;
   readonly db: FridaySqliteLayer;
   readonly nowIso: () => string;
+  /**
+   * execrun S-F carry-forward (DARK) — optional apiRequest idempotency descriptor. When
+   * present, the projected continuity row is stamped with
+   * `metadata.apiRequest.{principalId,idempotencyKey,payloadHash}` (the EXACT shape the
+   * bare `startRun` persists) so a SUBSEQUENT request sharing the key REPLAYS this run
+   * instead of minting a second runId. Absent ⇒ no stamp (unchanged).
+   */
+  readonly apiRequestIdempotency?: {
+    readonly operationId: string;
+    readonly principalId: string;
+    readonly idempotencyKey: string;
+    readonly payloadHash: string;
+    readonly receivedAt: string;
+  };
 }): Promise<FridayAgentRuntimeResult> {
-  const failClosed = (): FridayDomainError =>
-    new FridayDomainError(
-      "TS_RUNTIME_AGENT_RUNS_RETIRED",
-      "Agent run execution is fail-closed while runtime ownership is being moved out of TypeScript.",
-      {
-        httpStatus: 503,
-        details: {
-          classification: "fail_closed",
-          replacement: "rust_owned_agent_run_entrypoint_required",
-        },
-      },
-    );
+  const failClosed = failClosedRustAgentRun;
 
   // (1) SecureStore session key — MISSING/invalid ⇒ fail closed BEFORE any WS connection.
   // Never open an unauthenticated WS call; never log the key.
@@ -1164,8 +1189,8 @@ async function composeRustReadOnlyAgentRun(args: {
   // WS result carries no token totals (S-D is refs-only and untouched), so usage is 0 here
   // and `pricingResolved:false` stands — truth label dark, no fabricated numbers.
   const completedAtIso = args.nowIso();
-  const projection = args.db.withWriteTransaction((db) =>
-    args.projector.project(db, {
+  const projection = args.db.withWriteTransaction((db) => {
+    const result = args.projector.project(db, {
       truthLabel: "rust_wired_dev",
       proofOnly: true,
       ok: true,
@@ -1183,8 +1208,28 @@ async function composeRustReadOnlyAgentRun(args: {
       usageCompletionTokens: 0,
       usageTotalTokens: 0,
       completedAtIso,
-    }),
-  );
+    });
+    // execrun S-F carry-forward (DARK): MERGE the apiRequest idempotency descriptor into the
+    // projected row's metadata so a subsequent request sharing the key replays this run.
+    // `json_set('$.apiRequest', json(?))` MERGES — it preserves the projector's
+    // `surface`/`rustContinuity` telemetry (an `agentRepo.update({metadata})` would clobber
+    // metadata_json wholesale). Stamped in the SAME write transaction as the projection.
+    if (args.apiRequestIdempotency) {
+      db.prepare(
+        "UPDATE friday_agent_runs SET metadata_json = json_set(metadata_json, '$.apiRequest', json(?)) WHERE id = ?",
+      ).run(
+        JSON.stringify({
+          operationId: args.apiRequestIdempotency.operationId,
+          idempotencyKey: args.apiRequestIdempotency.idempotencyKey,
+          payloadHash: args.apiRequestIdempotency.payloadHash,
+          receivedAt: args.apiRequestIdempotency.receivedAt,
+          principalId: args.apiRequestIdempotency.principalId,
+        }),
+        args.runId,
+      );
+    }
+    return result;
+  });
 
   // (5) Return the owner-released body as the run's final response.
   return {
@@ -4190,6 +4235,65 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
           planReviewOverride: input.planReviewOverride,
         });
         if (qualifies) {
+          // execrun S-F carry-forward (DARK) — apiRequestIdempotencyKey REPLAY precedence.
+          // The compose path mints a FRESH runId; without this guard two requests sharing
+          // one `apiIdempotencyKey` would each mint a new runId → two agent_run/usage rows
+          // (the projector's run_id-keyed dedup is per-run and does NOT catch this cross-
+          // request case). So BEFORE minting + routing, mirror the SAME idempotency path the
+          // bare `startRun` uses: if a prior run exists for this key, REPLAY it (no new WS
+          // dispatch, no second projection) instead of routing a new run.
+          const normalizedPrincipalId =
+            typeof input.principalId === "string" && input.principalId.trim().length > 0
+              ? input.principalId.trim()
+              : undefined;
+          if (input.apiIdempotencyKey && input.apiIdempotencyPayloadHash) {
+            const scopedPrincipalId = normalizedPrincipalId ?? "anonymous";
+            const existingRun = deps.db.withReadConnection((db) =>
+              agentRepo.findLatestByApiRequestIdempotencyKey(db, {
+                principalId: scopedPrincipalId,
+                idempotencyKey: input.apiIdempotencyKey!,
+              }),
+            );
+            if (existingRun) {
+              const existingHash = readStoredIdempotencyPayloadHash(existingRun.metadata);
+              if (existingHash && existingHash !== input.apiIdempotencyPayloadHash) {
+                throwIdempotencyConflict(input.apiIdempotencyKey, "agent.runs.start");
+              }
+              // Faithful compose-path replay: the projector NEVER stores the answer body
+              // (projector contract #3 — the row carries only a body REF), so we cannot
+              // `replayAgentRunResult(existingRun)` (that would hand the caller the internal
+              // `rust-run-body-ref:…` string, not their answer). Instead re-run the SAME
+              // owner-gated readback (slice-3) for the EXISTING runId — no WS dispatch, no
+              // re-projection — and return the owner-released body. Owner principal absent /
+              // body non-delivered ⇒ fail closed (same 503 the compose raises).
+              const callerPrincipal = normalizedPrincipalId;
+              if (!callerPrincipal) {
+                throw failClosedRustAgentRun();
+              }
+              if (!rustHubDbPath) {
+                throw failClosedRustAgentRun();
+              }
+              const replayReadback = await rustAnswerReadback.readAnswer({
+                dbPath: rustHubDbPath,
+                runId: existingRun.id,
+                callerPrincipal,
+              });
+              if (replayReadback.outcome !== "delivered") {
+                throw failClosedRustAgentRun();
+              }
+              return {
+                runId: existingRun.id,
+                status: existingRun.status,
+                response: replayReadback.answer,
+                toolCallCount: 0,
+                durationMs: existingRun.durationMs ?? 0,
+                usageInput: existingRun.usageInput ?? 0,
+                usageOutput: existingRun.usageOutput ?? 0,
+                finalResponse: replayReadback.answer,
+              };
+            }
+          }
+
           // Qualifying run: route via Rust. Fail-closed on missing key / WS / readback /
           // projector — this NEVER falls through to the TS `startRun`. providerId/model
           // are guaranteed defined here (the predicate required the exact deepseek-flash
@@ -4207,6 +4311,22 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
             hubDbPath: rustHubDbPath,
             db: deps.db,
             nowIso: deps.nowIso,
+            // Stamp the apiRequest idempotency descriptor onto the projected row so a
+            // SUBSEQUENT request sharing this key REPLAYS this run (the lookup above) rather
+            // than minting a second runId. Mirrors the EXACT shape the bare startRun persists
+            // (`metadata.apiRequest.{principalId,idempotencyKey,payloadHash}`), so both
+            // `findLatestByApiRequestIdempotencyKey` and the `payloadHash` conflict check work.
+            ...(input.apiIdempotencyKey && input.apiIdempotencyPayloadHash
+              ? {
+                apiRequestIdempotency: {
+                  operationId: "agent.runs.start",
+                  principalId: normalizedPrincipalId ?? "anonymous",
+                  idempotencyKey: input.apiIdempotencyKey,
+                  payloadHash: input.apiIdempotencyPayloadHash,
+                  receivedAt: input.apiIdempotencyReceivedAt ?? deps.nowIso(),
+                },
+              }
+              : {}),
           });
         }
       }

--- a/test/unit/api/runtime/friday-api-runtime-rust-route-compose.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-rust-route-compose.test.ts
@@ -36,6 +36,24 @@ function makeIdGenerator(runId: string): () => string {
   return () => runId;
 }
 
+/**
+ * A generator that returns each id in `ids` in turn, then throws once exhausted. Used to
+ * PROVE the cross-request idempotency replay path NEVER mints the second runId — if the
+ * compose-path replay regressed and minted a fresh runId for request #2, this generator
+ * would hand out R2 (and the test's row/WS assertions would catch the double-run).
+ */
+function makeSequenceIdGenerator(...ids: string[]): () => string {
+  let i = 0;
+  return () => {
+    if (i >= ids.length) {
+      throw new Error("idGenerator exhausted — a second runId was minted unexpectedly");
+    }
+    return ids[i++];
+  };
+}
+
+const RUN_ID_2 = "fixed-run-id-2";
+
 function makeProviderService(): FridayProviderService {
   return {
     listProviders: vi.fn(async () => []),
@@ -199,6 +217,7 @@ const OWNER_PRINCIPAL = "rust-route-compose-owner";
 async function callStartRoute(
   runtime: ReturnType<typeof createFridayApiRuntime>,
   body: Record<string, unknown>,
+  opts: { headers?: Record<string, string>; principalId?: string } = {},
 ) {
   const startRoute = runtime.routes
     .getRoutes()
@@ -206,7 +225,9 @@ async function callStartRoute(
   expect(startRoute).toBeDefined();
   return startRoute!.handler({
     body,
-    principal: makeBoundPrincipal(OWNER_PRINCIPAL),
+    principal: makeBoundPrincipal(opts.principalId ?? OWNER_PRINCIPAL),
+    ...(opts.headers ? { headers: opts.headers } : {}),
+    receivedAt: NOW,
   } as never);
 }
 
@@ -348,5 +369,161 @@ describe("FridayApiRuntime — execrun S-F-compose (DARK) Rust-route composition
     expect(ws.calls).toHaveLength(2);
     expect(countRows(db, "friday_agent_runs", RUN_ID)).toBe(1);
     expect(countRows(db, "llm_usage_records", RUN_ID)).toBe(1);
+  });
+
+  // ── Fix 1 — apiRequestIdempotencyKey REPLAY in the compose path ──
+  // Two requests sharing ONE Idempotency-Key, each minting a DISTINCT runId (the real
+  // cross-request case test (e) masks by reusing one fixed id). The SECOND must REPLAY the
+  // first's result (no second WS dispatch, no second runId, no second row), returning the
+  // SAME owner body.
+  it("(f) two requests sharing one Idempotency-Key → SECOND replays the first (no second run / no second row)", async () => {
+    db = createTestDb();
+    const ws = makeStubWsClient();
+    const readback = makeStubReadback(OWNER_PRINCIPAL);
+    const runtime = makeRuntime(db, {
+      routeAgentRunViaRust: true,
+      wsClient: ws.service,
+      readback: readback.service,
+      // Distinct ids: R1 for request #1; if the replay regressed and minted a second runId,
+      // R2 would be handed out (and the row/WS assertions below would catch it).
+      idGenerator: makeSequenceIdGenerator(RUN_ID, RUN_ID_2),
+    });
+    const headers = { "idempotency-key": "shared-key-abc" }; // pragma: allowlist secret
+
+    const first = (await callStartRoute(runtime, { ...QUALIFYING_BODY }, { headers })) as {
+      runId: string;
+      response: string;
+    };
+    const second = (await callStartRoute(runtime, { ...QUALIFYING_BODY }, { headers })) as {
+      runId: string;
+      response: string;
+      finalResponse?: string;
+    };
+
+    // Both return the owner body…
+    expect(first.response).toBe(OWNER_BODY);
+    expect(second.response).toBe(OWNER_BODY);
+    expect(second.finalResponse).toBe(OWNER_BODY);
+    // …but the SECOND replays the FIRST run id — it did NOT mint a fresh runId.
+    expect(first.runId).toBe(RUN_ID);
+    expect(second.runId).toBe(RUN_ID);
+
+    // The WS path was dispatched exactly ONCE (the replay does NOT re-dispatch).
+    expect(ws.calls).toHaveLength(1);
+    // The first run was the only run projected; the second runId was NEVER created.
+    expect(countRows(db, "friday_agent_runs", RUN_ID)).toBe(1);
+    expect(countRows(db, "llm_usage_records", RUN_ID)).toBe(1);
+    expect(countRows(db, "friday_agent_runs", RUN_ID_2)).toBe(0);
+    expect(countRows(db, "llm_usage_records", RUN_ID_2)).toBe(0);
+  });
+
+  it("(g) same Idempotency-Key but DIFFERENT principal → no replay (scoped per principal)", async () => {
+    db = createTestDb();
+    const ws = makeStubWsClient();
+    // Readback delivers to whichever principal is the caller (both are owners of their run).
+    const readback: FridayRustHubRunAnswerReadbackService = {
+      readAnswer: vi.fn(async (input: FridayRustHubRunAnswerReadbackInput): Promise<FridayRustHubRunAnswerReadbackReceipt> => ({
+        truthLabel: "rust_wired_dev",
+        proofOnly: true,
+        outcome: "delivered",
+        runId: input.runId,
+        status: "completed",
+        answer: OWNER_BODY,
+        answerSha256: ANSWER_SHA256,
+        answerLen: OWNER_BODY.length,
+      })),
+    };
+    const runtime = makeRuntime(db, {
+      routeAgentRunViaRust: true,
+      wsClient: ws.service,
+      readback,
+      idGenerator: makeSequenceIdGenerator(RUN_ID, RUN_ID_2),
+    });
+    const headers = { "idempotency-key": "shared-key-xyz" }; // pragma: allowlist secret
+
+    await callStartRoute(runtime, { ...QUALIFYING_BODY }, { headers, principalId: "principal-A" });
+    const second = (await callStartRoute(runtime, { ...QUALIFYING_BODY }, {
+      headers,
+      principalId: "principal-B",
+    })) as { runId: string };
+
+    // The key is scoped to (principalId, idempotencyKey): principal-B finds no prior run,
+    // so it routes a NEW run (second runId minted) — NOT a replay.
+    expect(second.runId).toBe(RUN_ID_2);
+    expect(ws.calls).toHaveLength(2);
+    expect(countRows(db, "friday_agent_runs", RUN_ID)).toBe(1);
+    expect(countRows(db, "friday_agent_runs", RUN_ID_2)).toBe(1);
+  });
+
+  it("(g2) same Idempotency-Key + SAME principal but DIFFERENT payload → idempotency CONFLICT (409)", async () => {
+    db = createTestDb();
+    const ws = makeStubWsClient();
+    const readback = makeStubReadback(OWNER_PRINCIPAL);
+    const runtime = makeRuntime(db, {
+      routeAgentRunViaRust: true,
+      wsClient: ws.service,
+      readback: readback.service,
+      idGenerator: makeSequenceIdGenerator(RUN_ID, RUN_ID_2),
+    });
+    const headers = { "idempotency-key": "shared-key-conflict" }; // pragma: allowlist secret
+
+    // First request establishes the run under the key with payload-hash(A).
+    await callStartRoute(runtime, { ...QUALIFYING_BODY }, { headers });
+    // Second request reuses the key but a DIFFERENT task → different payload hash → the
+    // mirrored conflict check fires (same precedence the bare startRun enforces).
+    await expect(
+      callStartRoute(runtime, { ...QUALIFYING_BODY, task: "A DIFFERENT read-only task." }, { headers }),
+    ).rejects.toMatchObject({ httpStatus: 409 });
+    // The conflict fired BEFORE any second WS dispatch / second run.
+    expect(ws.calls).toHaveLength(1);
+    expect(countRows(db, "friday_agent_runs", RUN_ID_2)).toBe(0);
+  });
+
+  // ── Fix 2 — body.planReviewOverride now reaches the predicate's clause-5 disqualifier ──
+  // A run that otherwise FULLY qualifies but carries a plan-review override marker must be
+  // DISQUALIFIED via HTTP → today's unchanged 503 (the slice-4 clause-5 now fires).
+  it("(h) qualifying body + planReviewOverride → DISQUALIFIED → byte-identical 503; WS never touched", async () => {
+    db = createTestDb();
+    const ws = makeStubWsClient();
+    const readback = makeStubReadback(OWNER_PRINCIPAL);
+    const runtime = makeRuntime(db, {
+      routeAgentRunViaRust: true,
+      wsClient: ws.service,
+      readback: readback.service,
+    });
+
+    await expect(
+      callStartRoute(runtime, {
+        ...QUALIFYING_BODY,
+        planReviewOverride: { decision: "force-review" },
+      }),
+    ).rejects.toMatchObject({
+      code: "TS_RUNTIME_AGENT_RUNS_RETIRED",
+      httpStatus: 503,
+    });
+    // The plan-review override disqualified the run BEFORE any Rust route was touched.
+    expect(ws.calls).toHaveLength(0);
+    expect(readback.calls).toHaveLength(0);
+    expect(countRows(db, "friday_agent_runs", RUN_ID)).toBe(0);
+  });
+
+  it("(i) planReviewOverride is presence-only — even a falsy value disqualifies", async () => {
+    db = createTestDb();
+    const ws = makeStubWsClient();
+    const readback = makeStubReadback(OWNER_PRINCIPAL);
+    const runtime = makeRuntime(db, {
+      routeAgentRunViaRust: true,
+      wsClient: ws.service,
+      readback: readback.service,
+    });
+
+    // A FALSY value is still PRESENT → clause-5 disqualifies (presence-only contract).
+    await expect(
+      callStartRoute(runtime, { ...QUALIFYING_BODY, planReviewOverride: null }),
+    ).rejects.toMatchObject({
+      code: "TS_RUNTIME_AGENT_RUNS_RETIRED",
+      httpStatus: 503,
+    });
+    expect(ws.calls).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## What

Two compose-path correctness fixes the merged **S-F-compose** adversarial verify flagged as **slice-6 prerequisites** — both **DARK**, gated behind the unchanged **default-OFF** `routeAgentRunViaRust` flag. Flag-off / disqualified paths remain **byte-identical 503**.

## Write-set (TS-only)
- `src/api/runtime/friday-api-runtime.ts` — compose idempotency-replay precedence + the projected-row `apiRequest` stamp + the qualification-input `planReviewOverride` forward (already wired into the predicate call)
- `src/api/http/routes/friday-agent-routes.ts` — parse + forward `body.planReviewOverride`
- `test/unit/api/runtime/friday-api-runtime-rust-route-compose.test.ts` — tests

No Rust crate, no projector service, no 503-stub logic, **flag default unchanged (FALSE)**.

## Fix 1 — honor `apiRequestIdempotencyKey` replay in the compose path
The qualifying compose branch minted a **FRESH** `runId` and returned **BEFORE** the bare `startRun`'s replay logic, so two requests sharing one `apiIdempotencyKey` each minted a new `runId` → two `agent_run`/`usage` rows (the projector's `run_id`-keyed dedup is per-run and does **not** catch this cross-request case).

Now, **before** minting + routing, `routeStartRun` mirrors the bare path's precedence: `findLatestByApiRequestIdempotencyKey` (scoped `principalId`+key) → `payloadHash` conflict check (409 on mismatch) → **REPLAY**. Because the projector **never** stores the body (projector contract #3 — the row carries only a body REF), the replay is an **owner-gated re-readback** of the **existing** `runId` (no WS dispatch, no re-projection) returning the owner body — **not** `replayAgentRunResult` (which would hand back the internal `rust-run-body-ref:…` string). The first compose stamps `metadata.apiRequest.{operationId,principalId,idempotencyKey,payloadHash,receivedAt}` onto the projected row via `json_set('$.apiRequest', json(?))` (a **merge** — preserves the projector's `surface`/`rustContinuity` telemetry) so the subsequent request finds it.

## Fix 2 — wire `body.planReviewOverride` into the qualification input so the slice-4 disqualifier fires
The predicate (`qualifiesForRustReadOnlyRoute`) already has a clause-5 disqualifier for `planReviewOverride`, but the route never parsed `body.planReviewOverride`, so the disqualifier was **INERT via HTTP** (a plan-review run via `planReviewOverride` alone would QUALIFY). Now `agent-routes` parses it **presence-only** (`"planReviewOverride" in body`), forwards it **RAW** via a conditional spread, and `routeStartRun` feeds it to the predicate. A run carrying `planReviewOverride` → **disqualified → 503**. Presence-only, never coerced/injected: like `allowedRustRouteTools`, this field may **ONLY disqualify, never grant** (route-not-method pin; it is **not** the route-pin marker).

## Tests (compose, existing mock-WS-stub pattern)
- **(f)** two requests sharing one `Idempotency-Key`, distinct `idGenerator` (R1 then R2, throws on exhaustion) → the **SECOND replays the first** (1 WS dispatch, second `runId` never minted, no second `agent_run`/`usage` row, same owner body)
- **(g)** same key, **different principal** → no replay (per-principal scope, new run routed)
- **(g2)** same key + same principal, **different payload** → idempotency **conflict (409)**, no second run
- **(h)** qualifying body + `planReviewOverride` → **disqualified → byte-identical 503**; WS never touched
- **(i)** presence-only — a **falsy** `planReviewOverride` value still disqualifies

Prior compose/flag/predicate/agent-routes tests unchanged + green.

## Verification
- `npm run lint` — **0 errors** (project-wide; pre-existing warnings only)
- `npm test` (default + typecheck + llm-e2e) — **12652 passed / 258 skipped / 0 failed, no type errors** (llm-e2e skips: no `DEEPSEEK_API_KEY`, no provider run)
- Both `secrets`-job halves clean (`detect-secrets-hook` + `check-provider-key-patterns`)
- Mock-env `routeAgentRunViaRust` default-FALSE untouched (ui browser-e2e unaffected)

## Truth labels
Slice-6 prerequisites; **dark**; `rust_wired` at best; **NOT v1 GO**. Reversible — gated behind the default-off flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)