### PR TITLE
feat(execrun-b1-compose): repoint routeStartRun to the proven sealed client + SecureStore X25519 resolver (dark)

### DIFF
--- a/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
@@ -2022,4 +2022,150 @@ mod tests {
             "fail-closed surfaces a 503"
         );
     }
+
+    // === B1-compose interop scaffolding (additive, #[ignore]) — drives the REAL composition seam
+    // (X25519 resolver -> service adapter -> real sealed client) the B1 client interop did NOT cover.
+
+    /// The fixture master key the compose-adapter runner sees as FRIDAY_MASTER_KEY (64 hex). NON-secret
+    /// test material — a fixed value so the Rust side can re-derive the SAME client pubkey to enroll.
+    const COMPOSE_FIXTURE_MASTER_KEY: [u8; 32] = [0x42u8; 32]; // pragma: allowlist secret
+
+    /// The TS resolver's domain-separation tag (mirrors
+    /// `friday-rust-hub-agent-run-ws-client-x25519-secret.ts` `WS_X25519_SECRET_PURPOSE`). The Rust
+    /// side re-derives the client secret the SAME way the TS resolver does — so a passing handshake
+    /// LIVE-CHECKS that the resolver's derivation matches what 6b enrolls.
+    const COMPOSE_X25519_PURPOSE: &[u8] = b"friday.rust.agent_run.ws.x25519_secret.v1";
+
+    /// Re-derive the client X25519 pubkey the TS resolver produces for `master_key`:
+    /// `secret = sha256(purpose ‖ master_key)` (streaming `update(purpose).update(key)` ==
+    /// `digest(purpose ‖ key)`), `pubkey = DeviceKeypair::from_secret_bytes(secret).public_bytes()`.
+    fn compose_derive_client_pubkey(master_key: &[u8; 32]) -> [u8; 32] {
+        let mut input = COMPOSE_X25519_PURPOSE.to_vec();
+        input.extend_from_slice(master_key);
+        let secret: [u8; 32] = Sha256::digest(&input).into();
+        DeviceKeypair::from_secret_bytes(secret).public_bytes()
+    }
+
+    fn hex_of(bytes: &[u8]) -> String {
+        bytes.iter().map(|b| format!("{b:02x}")).collect()
+    }
+
+    /// Spawn the compose-adapter runner SUBPROCESS (FRIDAY_MASTER_KEY in env → real resolver → real
+    /// adapter → real sealed client). Requires the bundle built via
+    /// `node test/interop/build-compose-adapter-runner.mjs` and `node` on PATH.
+    fn spawn_compose_adapter_client(
+        port: u16,
+        master_key_hex: &str,
+        principal: &str,
+        run_id: &str,
+    ) -> std::process::Child {
+        let bundle = worktree_root().join("test/interop/.build/compose-adapter-runner.cjs");
+        assert!(
+            bundle.exists(),
+            "compose-adapter bundle missing at {bundle:?} — run `node test/interop/build-compose-adapter-runner.mjs` first"
+        );
+        std::process::Command::new("node")
+            .arg(bundle)
+            .env("FRIDAY_MASTER_KEY", master_key_hex)
+            .arg(format!("--port={port}"))
+            .arg(format!("--principal={principal}"))
+            .arg(format!("--run-id={run_id}"))
+            .arg("--task=ping")
+            .arg("--timeout-ms=15000")
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn node compose-adapter subprocess")
+    }
+
+    // (1) FULL COMPOSE-SEAM ROUND-TRIP: the REAL X25519 resolver (FRIDAY_MASTER_KEY fixture) → the REAL
+    // service adapter (default createClient = real sealed client) → the REAL server. The Rust side
+    // re-derives + enrolls the client pubkey, so a pass proves (a) the adapter's real construct+dispatch
+    // path handshakes end-to-end and (b) the resolver's derivation matches the enrolled pubkey. Refs-only
+    // (the adapter drops the in-band body; compose's body source is the proven slice-3 DB readback).
+    #[test]
+    #[ignore = "needs `node` + the prebuilt compose-adapter bundle; opt in with --ignored"]
+    fn interop_compose_adapter_resolver_full_round_trip() {
+        const ANSWER: &str = "PONG";
+        let (rt, _ws) = pong_runtime("interop-compose-ok", OWNER, ANSWER);
+        let server_kp = DeviceKeypair::generate();
+        let listener = AgentRunWsListener::bind_loopback(0).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let owner_allowlist = vec![OWNER.to_string()];
+        // Enroll the pubkey the TS resolver will derive from the fixture master key.
+        let peer_allowlist =
+            allowlist_of(compose_derive_client_pubkey(&COMPOSE_FIXTURE_MASTER_KEY));
+
+        let child = spawn_compose_adapter_client(
+            addr.port(),
+            &hex_of(&COMPOSE_FIXTURE_MASTER_KEY),
+            OWNER,
+            "run-compose-ok",
+        );
+        let processed = listener
+            .accept_one(&server_kp, &rt, &owner_allowlist, &peer_allowlist)
+            .expect("server serves the compose-adapter session");
+        assert_eq!(processed, 1, "one authed dispatch processed");
+
+        let v = read_client_json(child);
+        assert_eq!(
+            v["ok"],
+            serde_json::json!(true),
+            "compose adapter reports success: {v:?}"
+        );
+        assert_eq!(
+            v["status"],
+            serde_json::json!("finished"),
+            "wire status is the literal 'finished'"
+        );
+        assert_eq!(v["runId"], serde_json::json!("run-compose-ok"));
+        assert_eq!(
+            v["answerSha256"],
+            serde_json::json!(sha256_hex(ANSWER.as_bytes())),
+            "adapter surfaced the refs sha256"
+        );
+        assert_eq!(
+            v["answerLen"],
+            serde_json::json!(ANSWER.len()),
+            "adapter surfaced the refs len"
+        );
+    }
+
+    // (2) FAIL-CLOSED — the resolver-derived pubkey is NOT the one enrolled (forged): the server
+    // establishes NO session ⇒ the adapter surfaces a 503 (NOT a hang, NOT success).
+    #[test]
+    #[ignore = "needs `node` + the prebuilt compose-adapter bundle; opt in with --ignored"]
+    fn interop_compose_adapter_unenrolled_pubkey_fails_closed() {
+        let (rt, _ws) = pong_runtime("interop-compose-forged", OWNER, "PONG");
+        let server_kp = DeviceKeypair::generate();
+        let listener = AgentRunWsListener::bind_loopback(0).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let owner_allowlist = vec![OWNER.to_string()];
+        // Enroll a DIFFERENT pubkey (NOT the one the fixture master key derives).
+        let peer_allowlist = allowlist_of(DeviceKeypair::generate().public_bytes());
+
+        let child = spawn_compose_adapter_client(
+            addr.port(),
+            &hex_of(&COMPOSE_FIXTURE_MASTER_KEY),
+            OWNER,
+            "run-compose-forged",
+        );
+        let served = listener.accept_one(&server_kp, &rt, &owner_allowlist, &peer_allowlist);
+        assert!(
+            served.is_err(),
+            "an unenrolled derived pubkey establishes NO session"
+        );
+
+        let v = read_client_json(child);
+        assert_eq!(
+            v["ok"],
+            serde_json::json!(false),
+            "unenrolled pubkey ⇒ adapter fails closed: {v:?}"
+        );
+        assert_eq!(
+            v["httpStatus"],
+            serde_json::json!(503),
+            "fail-closed surfaces a 503"
+        );
+    }
 }

--- a/src/api/mission-spine/friday-rust-hub-agent-run-sealed-client-service.ts
+++ b/src/api/mission-spine/friday-rust-hub-agent-run-sealed-client-service.ts
@@ -1,0 +1,185 @@
+import { FridayDomainError } from "#errors";
+
+import {
+  createFridayRustHubAgentRunSealedClient,
+  type CreateFridayRustHubAgentRunSealedClientOptions,
+  type FridayRustHubAgentRunSealedClient,
+} from "./friday-rust-hub-agent-run-ws-sealed-client.js";
+
+/**
+ * PROOF-ONLY (Rust-wired), DARK (no production route consumes this) SERVICE ADAPTER that lets
+ * the composition (`composeRustReadOnlyAgentRun`) drive the PROVEN sealed WS client
+ * (`friday-rust-hub-agent-run-ws-sealed-client.ts`) through the SAME `dispatchRun(...)` seam the
+ * old plain-WS client exposed — but over the REAL sealed ECDH protocol (sub-slice B1-compose).
+ *
+ * ## Why an adapter (and not a direct swap)
+ * The old `FridayRustHubAgentRunWsClientService.dispatchRun` took a pre-built SYMMETRIC
+ * `authProof` and returned a refs-only result. The sealed client instead takes the client's
+ * X25519 SECRET, runs the ECDH handshake, builds the `auth_proof` ITSELF, and returns refs PLUS
+ * an in-band owner-sealed body. This adapter bridges the two: it accepts the per-dispatch
+ * `clientSecret` (resolved by the SecureStore X25519 resolver in compose), constructs the
+ * underlying sealed client, dispatches, and maps the sealed result down to the REFS-ONLY shape
+ * the composition consumes. The sealed client's in-band `body` is DROPPED here — it is
+ * belt-and-suspenders for compose, whose authoritative body source stays the slice-3 owner-gated
+ * DB readback (the Rust loop persists the owner-sealed body to the Hub DB; readback reads it).
+ *
+ * ## Construction seam (load-bearing for flag-off byte-identical)
+ * The factory captures ONLY host/port/timeout; it does NOT resolve a secret and does NOT
+ * construct the underlying client. The underlying client is built LAZILY, INSIDE `dispatchRun`,
+ * via the injectable `createClient` seam (default = the real sealed-client factory). So the
+ * factory is side-effect-free — the route can construct it eagerly at startup with NO key
+ * resolution, NO socket, and NO `RangeError` from a not-yet-resolved secret — which is exactly
+ * what keeps the DEFAULT-OFF route byte-identical to today (the dark services are constructed but
+ * never consulted). Tests mock `createClient` to map/fail-closed WITHOUT a socket and WITHOUT
+ * re-proving the (already-proven) interop.
+ *
+ * ## Fail-closed contract
+ * The underlying sealed client already funnels EVERY non-clean settle (connect error, closed
+ * session, bad seal, missing ref, timeout, malformed frame, fingerprint mismatch) to a 503-shaped
+ * {@link FridayDomainError}. This adapter adds no new success path: any throw/reject from the
+ * underlying dispatch surfaces unchanged (503), and a result is mapped to refs-only.
+ *
+ * ## Truth labels
+ * - DARK substrate for the executeRun-replacement: no production route consumes it (until 6b).
+ * - `rust_wired` ceiling: confers NO v1 GO. Reversible / inert until the operator cutover.
+ */
+
+/** A sealed agent-run dispatch, TS-side. Carries the client's X25519 SECRET (NOT a pre-built proof). */
+export interface FridayRustHubAgentRunSealedClientServiceRequest {
+  /** Caller-chosen idempotency/run identifier for this agent-run. */
+  readonly runId: string;
+  /** The agent task/prompt to run on the Rust loop. */
+  readonly task: string;
+  /** The TS-token-resolved principal the trusted peer forwards (allowlist-checked by the server). */
+  readonly forwardedPrincipal: string;
+  /**
+   * The client's 32-byte X25519 SECRET scalar (resolved from SecureStore by compose). The matching
+   * pubkey MUST be enrolled in the server's peer-allowlist or the server establishes NO session
+   * (fail-closed). Held in-process only; never logged. A non-32-byte secret fails closed (503).
+   */
+  readonly clientSecret: Uint8Array;
+}
+
+/**
+ * REFS-ONLY agent-run result receipt — the answer FINGERPRINT only, NEVER the body. The sealed
+ * client's in-band opened `body` is intentionally NOT surfaced here (compose's body source is the
+ * slice-3 DB readback). Shape-identical to the old client's `FridayRustHubAgentRunWsResult` so the
+ * composition's downstream (projector loopStatus + finalMessage refs) is untouched.
+ */
+export interface FridayRustHubAgentRunSealedClientServiceResult {
+  /** Always `rust_wired` — a loud reminder this is a substrate path, not a product one. */
+  readonly truthLabel: "rust_wired";
+  /** The run this result terminates (echoes the request's run id). */
+  readonly runId: string;
+  /** Coarse loop-status label (e.g. `finished` / denied / no_answer). */
+  readonly status: string;
+  /** sha256 of the answer body — a REF, NEVER the body text. Absent when no answer. */
+  readonly answerSha256?: string;
+  /** Byte length of the answer body — a measure, NEVER the body text. Absent when no answer. */
+  readonly answerLen?: number;
+}
+
+export interface FridayRustHubAgentRunSealedClientService {
+  /**
+   * Dispatch one agent-run over a sealed ECDH session and await its REFS-ONLY result. Builds the
+   * underlying sealed client from the request's `clientSecret`, runs the handshake + auth_proof +
+   * send INTERNALLY, then maps the sealed result to refs-only. Fails closed (503) on any non-clean
+   * settle. The in-band owner-sealed body is dropped (compose uses the DB readback).
+   */
+  dispatchRun(
+    request: FridayRustHubAgentRunSealedClientServiceRequest,
+  ): Promise<FridayRustHubAgentRunSealedClientServiceResult>;
+}
+
+/**
+ * Factory seam for the underlying sealed client. Defaults to the real
+ * {@link createFridayRustHubAgentRunSealedClient}; tests inject a fake to map/fail-closed without
+ * a socket (and without re-proving the interop, which is already proven).
+ */
+export type CreateSealedClientFn = (
+  options: CreateFridayRustHubAgentRunSealedClientOptions,
+) => FridayRustHubAgentRunSealedClient;
+
+export interface CreateFridayRustHubAgentRunSealedClientServiceOptions {
+  /** Loopback host for the Rust agent-run WS server. Defaults to `127.0.0.1` (in the client). */
+  readonly host?: string;
+  /** Port the Rust agent-run WS server listens on. */
+  readonly port: number;
+  /** Bounded await (ms) for one dispatch before failing closed. */
+  readonly timeoutMs?: number;
+  /**
+   * Injectable factory for the underlying sealed client (test seam). Default = the real sealed
+   * client. Constructed LAZILY per-dispatch so the service factory itself is side-effect-free.
+   */
+  readonly createClient?: CreateSealedClientFn;
+}
+
+function unavailable(message: string): FridayDomainError {
+  return new FridayDomainError("MISSION_SPINE_RUST_AGENT_RUN_SEALED_WS_CLIENT_UNAVAILABLE", message, {
+    httpStatus: 503,
+    details: {
+      surface: "service:rust_hub_agent_run_sealed_ws_client_service",
+      bridge: "rust_wired",
+      proofOnly: true,
+      proofReady: false,
+    },
+  });
+}
+
+/**
+ * Build the sealed-client SERVICE adapter the composition wires in place of the old plain-WS
+ * client. SIDE-EFFECT-FREE: captures host/port/timeout/createClient only; resolves no secret and
+ * opens no socket until `dispatchRun` is actually called on a qualifying run.
+ */
+export function createFridayRustHubAgentRunSealedClientService(
+  options: CreateFridayRustHubAgentRunSealedClientServiceOptions,
+): FridayRustHubAgentRunSealedClientService {
+  const { host, port, timeoutMs } = options;
+  const createClient = options.createClient ?? createFridayRustHubAgentRunSealedClient;
+
+  return {
+    async dispatchRun(
+      request: FridayRustHubAgentRunSealedClientServiceRequest,
+    ): Promise<FridayRustHubAgentRunSealedClientServiceResult> {
+      // Build the underlying sealed client from the per-dispatch X25519 secret. A non-32-byte
+      // secret throws a RangeError from the sealed client constructor; map it to fail-closed (503)
+      // so a malformed resolve surfaces as today's 503 rather than an unhandled throw.
+      let client: FridayRustHubAgentRunSealedClient;
+      try {
+        client = createClient({
+          ...(host !== undefined ? { host } : {}),
+          port,
+          clientSecret: request.clientSecret,
+          ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+        });
+      } catch {
+        throw unavailable("Sealed agent-run client could not be constructed.");
+      }
+
+      // The sealed client's dispatch already fails closed (503) on every non-clean settle; surface
+      // its FridayDomainError unchanged, wrap any non-domain throw as fail-closed.
+      let sealed;
+      try {
+        sealed = await client.dispatchRun({
+          runId: request.runId,
+          task: request.task,
+          forwardedPrincipal: request.forwardedPrincipal,
+        });
+      } catch (error) {
+        throw error instanceof FridayDomainError
+          ? error
+          : unavailable("Sealed agent-run client dispatch failed.");
+      }
+
+      // Map to the REFS-ONLY shape the composition consumes — DROP the in-band `body` (compose's
+      // authoritative body source is the slice-3 owner-gated DB readback).
+      return {
+        truthLabel: "rust_wired",
+        runId: sealed.runId,
+        status: sealed.status,
+        ...(sealed.answerSha256 !== undefined ? { answerSha256: sealed.answerSha256 } : {}),
+        ...(sealed.answerLen !== undefined ? { answerLen: sealed.answerLen } : {}),
+      };
+    },
+  };
+}

--- a/src/api/mission-spine/friday-rust-hub-agent-run-ws-client-x25519-secret.ts
+++ b/src/api/mission-spine/friday-rust-hub-agent-run-ws-client-x25519-secret.ts
@@ -18,11 +18,16 @@
  * secret on the API host (the client) and the same pubkey the operator provisions on the Hub.
  *
  * ## Hard contracts enforced here (load-bearing — Directive-0i)
- * 1. **Fail-closed on missing/invalid** — {@link resolveRustAgentRunWsClientX25519Secret}
- *    returns `null` when the SecureStore has no master key, the key is empty, or the derived
- *    secret is not exactly 32 bytes. The caller (compose) treats `null` as "do not route to
- *    Rust" → today's 503. There is no anonymous / default-key fallback: the composition never
- *    opens an UNAUTHENTICATED WS connection.
+ * 1. **Fail-closed (no weak/zero/predictable key, ever)** — the resolver returns `null` (compose
+ *    → today's 503) when: the presence env signal is explicitly off, {@link getMasterKey} THROWS
+ *    (misconfig, e.g. an invalid `FRIDAY_MASTER_KEY`), the key is empty, or the derived secret is
+ *    not 32 bytes. There is no anonymous / default-key fallback. **IMPORTANT (6b):** `getMasterKey`
+ *    AUTO-GENERATES + persists a random key on a fresh host, so a *merely-absent* master key does
+ *    NOT fail closed HERE — it yields a valid secret from a random key, and the fail-closed is then
+ *    enforced SERVER-side (the derived pubkey is not in the peer-allowlist → no session). So 6b must
+ *    enroll the pubkey derived from the prod host's STABLE master key, and RE-ENROLL on key rotation
+ *    (a rotated master key changes the derived secret → changes the pubkey → the stale allowlist
+ *    entry no longer matches → fail-closed until re-provisioned).
  * 2. **SecureStore-derived, never an env-var key** — the secret is derived through the
  *    keychain-backed {@link getMasterKey} path (the SecureStore root the secret admin uses),
  *    domain-separated with {@link WS_X25519_SECRET_PURPOSE}. An env var may carry only the
@@ -97,7 +102,12 @@ export function resolveRustAgentRunWsClientX25519Secret(): Uint8Array | null {
 
   let masterKey: Buffer;
   try {
-    // SecureStore root (keychain-backed). Throws when no key is provisioned → fail closed.
+    // SecureStore root (keychain-backed). NOTE: on a fresh host getMasterKey AUTO-GENERATES +
+    // persists a random key — it does NOT throw on a merely-absent key. It throws only on
+    // MISCONFIG (e.g. an invalid `FRIDAY_MASTER_KEY`), which this catch fail-closes. A
+    // merely-absent key therefore yields a VALID secret from a fresh random key; the resulting
+    // pubkey simply will not be in the server peer-allowlist (until 6b enrollment) → no session
+    // (fail-closed SERVER-side). The client never opens a weak/zero/predictable-key session.
     masterKey = getMasterKey();
   } catch {
     return null;

--- a/src/api/mission-spine/friday-rust-hub-agent-run-ws-client-x25519-secret.ts
+++ b/src/api/mission-spine/friday-rust-hub-agent-run-ws-client-x25519-secret.ts
@@ -1,0 +1,131 @@
+/**
+ * PROOF-ONLY (Rust-wired), DARK (no production route flips this on) SecureStore
+ * X25519-SECRET resolver for the executeRun-replacement TS->Rust agent-run SEALED WS
+ * client (sub-slice B1-compose, the composition repoint to the sealed client).
+ *
+ * ## Why this exists (and why it is NOT the #612 symmetric resolver)
+ * The PROVEN sealed client (`friday-rust-hub-agent-run-ws-sealed-client.ts`) speaks the
+ * server's REAL ECDH handshake: it holds the client's X25519 SECRET scalar, performs the
+ * X25519+HKDF agreement against the server pubkey, and BUILDS the per-request `auth_proof`
+ * itself. So — unlike the old plain-WS client, which took a pre-built SYMMETRIC key AS the
+ * `authProof` (#612's `resolveRustAgentRunWsSessionKey`) — the composition must resolve a
+ * stable 32-byte X25519 SECRET, NOT a symmetric auth-proof key.
+ *
+ * The pubkey derived from this secret (`deviceKeypairFromSecret(secret).publicKey`, exposed
+ * via {@link deriveRustAgentRunWsClientX25519PublicKey}) is EXACTLY what the operator enrolls
+ * in the server's SecureStore peer-allowlist at 6b. B1-compose and 6b share this key material:
+ * the same SecureStore master key + the same purpose tag deterministically yield the same
+ * secret on the API host (the client) and the same pubkey the operator provisions on the Hub.
+ *
+ * ## Hard contracts enforced here (load-bearing — Directive-0i)
+ * 1. **Fail-closed on missing/invalid** — {@link resolveRustAgentRunWsClientX25519Secret}
+ *    returns `null` when the SecureStore has no master key, the key is empty, or the derived
+ *    secret is not exactly 32 bytes. The caller (compose) treats `null` as "do not route to
+ *    Rust" → today's 503. There is no anonymous / default-key fallback: the composition never
+ *    opens an UNAUTHENTICATED WS connection.
+ * 2. **SecureStore-derived, never an env-var key** — the secret is derived through the
+ *    keychain-backed {@link getMasterKey} path (the SecureStore root the secret admin uses),
+ *    domain-separated with {@link WS_X25519_SECRET_PURPOSE}. An env var may carry only the
+ *    OPAQUE presence signal ({@link FRIDAY_HUB_AGENT_RUN_WS_X25519_SECRET_PRESENT}); it NEVER
+ *    carries key material. The raw master key NEVER crosses the wire.
+ * 3. **Never printed / logged** — the secret bytes are returned to the in-process caller only.
+ *    This module logs nothing and throws no error carrying the secret; the returned value is an
+ *    opaque `Uint8Array`. (`// pragma: allowlist secret` markers below sit on the SecureStore
+ *    lookup IDENTIFIERS / domain-separation tag, never on a literal key.)
+ *
+ * ## Truth labels (read before trusting this)
+ * - **DARK substrate**: no production route resolves a real secret here until the composition
+ *   is live-flipped (6b, operator gate). Reversible / inert.
+ * - **`rust_wired` ceiling**: confers no v1 GO. In tests it is driven by an injected resolver
+ *   returning a fixture secret — never a real keychain secret, never a real key.
+ */
+import { createHash } from "node:crypto";
+
+import { getMasterKey } from "#providers";
+
+import {
+  deviceKeypairFromSecret,
+  X25519_SECRET_LEN,
+} from "./friday-rust-hub-agent-run-ws-sealed-crypto.js";
+
+/**
+ * The SecureStore domain-separation tag for the WS X25519 client secret. Derives a secret
+ * distinct from the raw master key AND from every other SecureStore-derived purpose (including
+ * #612's symmetric `friday.rust.agent_run.ws.session_key.v1`) — so the sealed-client secret can
+ * never collide with the old symmetric auth-proof key.
+ */
+const WS_X25519_SECRET_PURPOSE = "friday.rust.agent_run.ws.x25519_secret.v1"; // pragma: allowlist secret
+
+/**
+ * An opt-in presence signal. The composition treats SecureStore as the source of truth; this
+ * env var lets a deployment DISABLE the SecureStore lookup (force fail-closed) WITHOUT carrying
+ * any key material. Set to exactly `"0"` / `"false"` to force a `null` resolve. It NEVER carries
+ * the secret — only a boolean presence intent.
+ */
+export const FRIDAY_HUB_AGENT_RUN_WS_X25519_SECRET_PRESENT =
+  "FRIDAY_HUB_AGENT_RUN_WS_X25519_SECRET_PRESENT"; // pragma: allowlist secret
+
+/**
+ * Resolve the Rust agent-run sealed-WS-client X25519 SECRET scalar from the SecureStore.
+ * Returns the opaque 32-byte secret when present + valid, or `null` to fail closed
+ * (missing/invalid/disabled).
+ *
+ * NEVER throws an error that carries the secret; NEVER logs the secret.
+ */
+export type FridayRustAgentRunWsClientX25519SecretResolver = () => Uint8Array | null;
+
+/**
+ * Default SecureStore-backed resolver. Derives a stable 32-byte X25519 SECRET from the keychain
+ * master key with a purpose tag (domain separation), so the raw master key never crosses the
+ * wire and the same secret is reproduced deterministically on every call (so the derived pubkey
+ * the operator enrolls at 6b stays stable). Fails closed (returns `null`) when:
+ *   - the presence env signal is explicitly off, or
+ *   - the SecureStore master key is unavailable / throws, or
+ *   - the derived secret is not exactly 32 bytes (defensive; sha256 is always 32 bytes).
+ *
+ * NOTE: a sha256 digest is a uniformly-random 32-byte string; X25519 clamps the scalar at use
+ * (verified against `deviceKeypairFromSecret`), so any 32-byte digest is a valid X25519 secret.
+ */
+export function resolveRustAgentRunWsClientX25519Secret(): Uint8Array | null {
+  // Read the presence signal via a literal env key (the exported constant names the same var
+  // for callers/tests). A static literal avoids the dynamic object-injection lint sink.
+  const presence = process.env.FRIDAY_HUB_AGENT_RUN_WS_X25519_SECRET_PRESENT;
+  if (presence === "0" || presence === "false") {
+    // Operator/deployment explicitly disabled the SecureStore lookup → fail closed.
+    return null;
+  }
+
+  let masterKey: Buffer;
+  try {
+    // SecureStore root (keychain-backed). Throws when no key is provisioned → fail closed.
+    masterKey = getMasterKey();
+  } catch {
+    return null;
+  }
+  if (!masterKey || masterKey.length === 0) {
+    return null;
+  }
+
+  // Domain-separated derivation: never expose the raw master key as the X25519 secret.
+  const derived = createHash("sha256")
+    .update(WS_X25519_SECRET_PURPOSE)
+    .update(masterKey)
+    .digest();
+  if (derived.length !== X25519_SECRET_LEN) {
+    return null;
+  }
+  return new Uint8Array(derived);
+}
+
+/**
+ * Derive the raw 32-byte X25519 PUBLIC key from a resolved client SECRET. This is the value the
+ * operator enrolls in the server's SecureStore peer-allowlist at 6b (the only key material that
+ * leaves this host — and it is PUBLIC, never the secret). Does NOT call any server / network.
+ *
+ * Throws (via `deviceKeypairFromSecret`) on a non-32-byte secret — callers pass a resolved
+ * secret, which is always 32 bytes; a malformed secret is a programming error, not a runtime
+ * condition (the compose path fails closed on a non-32-byte resolve BEFORE this is reached).
+ */
+export function deriveRustAgentRunWsClientX25519PublicKey(secret: Uint8Array): Uint8Array {
+  return deviceKeypairFromSecret(secret).publicKey;
+}

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -136,14 +136,17 @@ import { createFridayChannelWebhookRoutes } from "../http/routes/friday-channel-
 import { createFridayPackagingRoutes } from "../http/routes/friday-packaging-routes.js";
 import { createFridayCloudWorkerSetupRoutes } from "../http/routes/friday-cloud-worker-setup-routes.js";
 import { createFridayCloudWorkerSetupService } from "#cloud-workers";
-import { createFridayRustHubAgentRunWsClientService } from "../mission-spine/friday-rust-hub-agent-run-ws-client.js";
-import type { FridayRustHubAgentRunWsClientService } from "../mission-spine/friday-rust-hub-agent-run-ws-client.js";
+// execrun B1-compose (DARK): the composition repoints routeStartRun to the PROVEN sealed WS
+// client (the real ECDH handshake) via its service adapter + a SecureStore X25519-SECRET resolver
+// (the ECDH model — REPLACES #612's symmetric session-key resolver, which was the wrong shape).
+import { createFridayRustHubAgentRunSealedClientService } from "../mission-spine/friday-rust-hub-agent-run-sealed-client-service.js";
+import type { FridayRustHubAgentRunSealedClientService } from "../mission-spine/friday-rust-hub-agent-run-sealed-client-service.js";
 import { createFridayRustHubRunContinuityProjectorService } from "../mission-spine/friday-rust-hub-run-continuity-projector-service.js";
 import type { FridayRustHubRunContinuityProjectorService } from "../mission-spine/friday-rust-hub-run-continuity-projector-service.js";
 import { createFridayRustHubRunAnswerReadbackService } from "../mission-spine/friday-rust-hub-run-answer-readback-service.js";
 import type { FridayRustHubRunAnswerReadbackService } from "../mission-spine/friday-rust-hub-run-answer-readback-service.js";
-import { resolveRustAgentRunWsSessionKey } from "../mission-spine/friday-rust-hub-agent-run-ws-session-key.js";
-import type { FridayRustAgentRunWsSessionKeyResolver } from "../mission-spine/friday-rust-hub-agent-run-ws-session-key.js";
+import { resolveRustAgentRunWsClientX25519Secret } from "../mission-spine/friday-rust-hub-agent-run-ws-client-x25519-secret.js";
+import type { FridayRustAgentRunWsClientX25519SecretResolver } from "../mission-spine/friday-rust-hub-agent-run-ws-client-x25519-secret.js";
 import { createFridayStudioService } from "../../studio/index.js";
 import {
   createFridayMutatingActionDigest,
@@ -1118,16 +1121,27 @@ function failClosedRustAgentRun(): FridayDomainError {
   );
 }
 
+/**
+ * B1-compose (DARK): parse the Rust agent-run WS server port from its env var. Defaults to a
+ * sentinel `0` (the same sentinel the old plain-WS client used) when unset / non-numeric — on the
+ * default-off route this port is never dialed, and 6b provisions the real port via env.
+ */
+function readRustAgentRunWsPort(raw: string | undefined): number {
+  if (!raw) return 0;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+}
+
 async function composeRustReadOnlyAgentRun(args: {
   readonly runId: string;
   readonly task: string;
   readonly principalId: string | undefined;
   readonly providerId: string;
   readonly model: string;
-  readonly wsClient: FridayRustHubAgentRunWsClientService;
+  readonly wsClient: FridayRustHubAgentRunSealedClientService;
   readonly projector: FridayRustHubRunContinuityProjectorService;
   readonly readback: FridayRustHubRunAnswerReadbackService;
-  readonly sessionKeyResolver: FridayRustAgentRunWsSessionKeyResolver;
+  readonly clientSecretResolver: FridayRustAgentRunWsClientX25519SecretResolver;
   readonly hubDbPath: string | undefined;
   readonly db: FridaySqliteLayer;
   readonly nowIso: () => string;
@@ -1148,10 +1162,12 @@ async function composeRustReadOnlyAgentRun(args: {
 }): Promise<FridayAgentRuntimeResult> {
   const failClosed = failClosedRustAgentRun;
 
-  // (1) SecureStore session key — MISSING/invalid ⇒ fail closed BEFORE any WS connection.
-  // Never open an unauthenticated WS call; never log the key.
-  const sessionKey = args.sessionKeyResolver();
-  if (!sessionKey || sessionKey.length === 0) {
+  // (1) SecureStore X25519 client SECRET — MISSING/invalid ⇒ fail closed BEFORE any WS
+  // connection. The sealed client runs the ECDH handshake with this secret and builds the
+  // auth_proof itself; a non-32-byte secret fails closed here (the 503), never escaping as a
+  // RangeError from the sealed client. Never open an unauthenticated WS call; never log the key.
+  const clientSecret = args.clientSecretResolver();
+  if (!clientSecret || clientSecret.length !== 32) {
     throw failClosed();
   }
   // The owner principal must be present to gate the body readback (slice-3). Absent ⇒ 503.
@@ -1165,12 +1181,13 @@ async function composeRustReadOnlyAgentRun(args: {
     throw failClosed();
   }
 
-  // (2) Dispatch the run over the WS client (S-D). Refs-only result; fail-closed on error.
+  // (2) Dispatch the run over the SEALED WS client (B1). The client runs the ECDH handshake +
+  // builds the auth_proof from `clientSecret` INTERNALLY; refs-only result; fail-closed on error.
   const wsResult = await args.wsClient.dispatchRun({
     runId: args.runId,
     task: args.task,
     forwardedPrincipal: callerPrincipal,
-    authProof: sessionKey,
+    clientSecret,
   });
 
   // (3) Owner-gated body readback (slice-3). The body is released ONLY to the matching
@@ -4211,14 +4228,26 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
     //
     // Dark-substrate services are lazily constructed once (real constructors), overridable
     // via deps for mock-proven tests. They are consulted ONLY on the qualifying branch.
+    // B1-compose (DARK): the PROVEN sealed WS client (real ECDH handshake) via its service
+    // adapter. SIDE-EFFECT-FREE construction (no secret resolved, no socket opened here) — so the
+    // DEFAULT-OFF route stays byte-identical to today (these services are built but never
+    // consulted while the flag is off / a run is disqualified). host/port from config/env (default
+    // 127.0.0.1 + the existing WS port env); the sealed client opens the socket lazily per dispatch.
     const rustWsClient =
-      deps.rustAgentRunWsClient ?? createFridayRustHubAgentRunWsClientService();
+      deps.rustAgentRunWsClient
+      ?? createFridayRustHubAgentRunSealedClientService({
+        host: process.env.FRIDAY_HUB_AGENT_RUN_WS_HOST ?? "127.0.0.1",
+        port: readRustAgentRunWsPort(process.env.FRIDAY_HUB_AGENT_RUN_WS_PORT),
+      });
     const rustContinuityProjector =
       deps.rustAgentRunContinuityProjector ?? createFridayRustHubRunContinuityProjectorService();
     const rustAnswerReadback =
       deps.rustAgentRunAnswerReadback ?? createFridayRustHubRunAnswerReadbackService();
-    const rustWsSessionKeyResolver =
-      deps.rustAgentRunWsSessionKeyResolver ?? resolveRustAgentRunWsSessionKey;
+    // B1-compose (DARK): the SecureStore X25519-SECRET resolver (the ECDH model) REPLACES #612's
+    // symmetric session-key resolver. Default = the keychain-backed resolver; a null/short resolve
+    // fails closed → no WS call, today's 503. Tests inject a fixture secret.
+    const rustWsClientSecretResolver =
+      deps.rustAgentRunWsClientSecretResolver ?? resolveRustAgentRunWsClientX25519Secret;
     const rustHubDbPath = deps.rustAgentRunHubDbPath ?? process.env.FRIDAY_HUB_AGENT_RUN_DB_PATH;
 
     const routeStartRun: typeof startRun = async (input) => {
@@ -4312,7 +4341,7 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
             wsClient: rustWsClient,
             projector: rustContinuityProjector,
             readback: rustAnswerReadback,
-            sessionKeyResolver: rustWsSessionKeyResolver,
+            clientSecretResolver: rustWsClientSecretResolver,
             hubDbPath: rustHubDbPath,
             db: deps.db,
             nowIso: deps.nowIso,

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -1215,7 +1215,11 @@ async function composeRustReadOnlyAgentRun(args: {
       routeId: `${args.providerId}:${args.model}`,
       providerId: args.providerId,
       model: args.model,
-      loopStatus: wsResult.status === "completed" ? "Finished" : "Errored",
+      // The Rust server's wire `AgentRunResult.status` echoes the persisted RunResult status,
+      // which for a finished loop is the literal "finished" (rust-core lib.rs `detail: "finished"`,
+      // asserted by hub_server.rs `status == "finished"`) — NOT "completed". A delivered readback
+      // (gated above) implies the loop finished, so map "finished" → Finished, else Errored.
+      loopStatus: wsResult.status === "finished" ? "Finished" : "Errored",
       turns: 0,
       executedTools: 0,
       finalMessageSha256: readbackReceipt.answerSha256,

--- a/src/api/runtime/friday-api-runtime.types.ts
+++ b/src/api/runtime/friday-api-runtime.types.ts
@@ -27,10 +27,10 @@ import type {
   FridayStandingAgendaService,
 } from "../../autonomy/index.js";
 import type { FridayProviderService } from "#providers";
-import type { FridayRustHubAgentRunWsClientService } from "../mission-spine/friday-rust-hub-agent-run-ws-client.js";
+import type { FridayRustHubAgentRunSealedClientService } from "../mission-spine/friday-rust-hub-agent-run-sealed-client-service.js";
 import type { FridayRustHubRunContinuityProjectorService } from "../mission-spine/friday-rust-hub-run-continuity-projector-service.js";
 import type { FridayRustHubRunAnswerReadbackService } from "../mission-spine/friday-rust-hub-run-answer-readback-service.js";
-import type { FridayRustAgentRunWsSessionKeyResolver } from "../mission-spine/friday-rust-hub-agent-run-ws-session-key.js";
+import type { FridayRustAgentRunWsClientX25519SecretResolver } from "../mission-spine/friday-rust-hub-agent-run-ws-client-x25519-secret.js";
 import type { FridayMediaUnderstandingRoutesDeps } from "../http/routes/friday-media-understanding-routes.js";
 import type { FridaySocialImportRoutesDeps } from "../http/routes/friday-social-import-routes.js";
 import type { FridayTaskWorkflowRoutesDeps } from "../http/routes/friday-task-workflow-routes.js";
@@ -336,17 +336,19 @@ export interface CreateFridayApiRuntimeDeps {
    * None of these is consulted while the flag is off / a run is disqualified (byte-identical
    * 503 path is untouched).
    */
-  rustAgentRunWsClient?: FridayRustHubAgentRunWsClientService;
+  rustAgentRunWsClient?: FridayRustHubAgentRunSealedClientService;
   /** S-F-compose (DARK): the slice-2 Rust→TS continuity projector (SOLE TS usage writer). */
   rustAgentRunContinuityProjector?: FridayRustHubRunContinuityProjectorService;
   /** S-F-compose (DARK): the slice-3 owner-gated body readback (returns body to the owner). */
   rustAgentRunAnswerReadback?: FridayRustHubRunAnswerReadbackService;
   /**
-   * S-F-compose (DARK): the SecureStore resolver for the WS session key (the WS `authProof`).
-   * Default = the keychain-backed resolver. A `null` resolve (missing/invalid key) fails
-   * closed → no WS call, today's 503. Tests inject a fixture resolver. NEVER logs the key.
+   * B1-compose (DARK): the SecureStore resolver for the sealed WS client's X25519 SECRET (the
+   * ECDH model — REPLACES the old symmetric session-key resolver). The sealed client runs the
+   * handshake with this secret and builds the auth_proof itself; its derived pubkey is what 6b
+   * enrolls in the server peer-allowlist. Default = the keychain-backed resolver. A `null`/short
+   * resolve fails closed → no WS call, today's 503. Tests inject a fixture secret. NEVER logs it.
    */
-  rustAgentRunWsSessionKeyResolver?: FridayRustAgentRunWsSessionKeyResolver;
+  rustAgentRunWsClientSecretResolver?: FridayRustAgentRunWsClientX25519SecretResolver;
   /**
    * S-F-compose (DARK): filesystem path to the Rust Hub DB the owner-gated body readback
    * reads from. Default = `process.env.FRIDAY_HUB_AGENT_RUN_DB_PATH`. Absent → the readback

--- a/test/interop/build-compose-adapter-runner.mjs
+++ b/test/interop/build-compose-adapter-runner.mjs
@@ -1,0 +1,50 @@
+/**
+ * B1-compose interop runner BUILD STEP. Bundles the REAL resolver + service adapter + sealed
+ * client + the runner into a single `.cjs` that `node` runs without the repo's import map / a
+ * prior `tsc` build. The Rust interop test invokes this first, then spawns `node <out>`.
+ *
+ * Aliases (to SOURCE, so no `tsc` build is needed):
+ *   - `#errors`    → src/errors/index.ts (FridayDomainError; reached by the adapter + resolver chain)
+ *   - `#providers` → src/security/friday-secret-crypto.ts (the resolver imports ONLY `getMasterKey`
+ *                    from `#providers`, which is defined+exported there; aliasing to that lean source
+ *                    avoids bundling the heavy providers barrel — same function, faithful).
+ */
+import { build } from "esbuild";
+import { existsSync } from "node:fs";
+import { dirname, resolve as resolvePath } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const entry = resolvePath(here, "friday-rust-hub-agent-run-compose-adapter-runner.ts");
+const outfile = resolvePath(here, ".build/compose-adapter-runner.cjs");
+
+const tsFromJsPlugin = {
+  name: "ts-from-js",
+  setup(b) {
+    b.onResolve({ filter: /^\.{1,2}\/.*\.js$/ }, (args) => {
+      const tsCandidate = resolvePath(args.resolveDir, args.path.replace(/\.js$/, ".ts"));
+      if (existsSync(tsCandidate)) {
+        return { path: tsCandidate };
+      }
+      return undefined;
+    });
+  },
+};
+
+const repoRoot = resolvePath(here, "..", "..");
+const errorsSource = resolvePath(repoRoot, "src/errors/index.ts");
+const providersGetMasterKeySource = resolvePath(repoRoot, "src/security/friday-secret-crypto.ts");
+
+await build({
+  entryPoints: [entry],
+  outfile,
+  bundle: true,
+  platform: "node",
+  format: "cjs",
+  target: "node22",
+  alias: { "#errors": errorsSource, "#providers": providersGetMasterKeySource },
+  plugins: [tsFromJsPlugin],
+  logLevel: "info",
+});
+
+process.stdout.write(`built ${outfile}\n`);

--- a/test/interop/friday-rust-hub-agent-run-compose-adapter-runner.ts
+++ b/test/interop/friday-rust-hub-agent-run-compose-adapter-runner.ts
@@ -1,0 +1,75 @@
+/**
+ * B1-compose interop RUNNER — drives the REAL composition seam end-to-end as a subprocess of the
+ * Rust interop test: the REAL X25519 SECRET resolver (`resolveRustAgentRunWsClientX25519Secret`,
+ * reading FRIDAY_MASTER_KEY via the real `getMasterKey`) → the REAL service adapter
+ * (`createFridayRustHubAgentRunSealedClientService`, DEFAULT `createClient` = the real sealed
+ * client) → the REAL sealed client → the REAL Rust server. This is the ONE path the B1 client
+ * interop did NOT cover (it drove the raw client; the adapter's own tests inject a MOCK client).
+ *
+ * The Rust test sets FRIDAY_MASTER_KEY to a fixture, re-derives the SAME pubkey via
+ * `sha256(purpose ‖ key)` and enrolls it in the server peer-allowlist — so a passing dispatch
+ * also LIVE-CHECKS that the resolver's derivation matches what the operator enrolls at 6b.
+ *
+ * Output contract (stdout, exactly one JSON line):
+ *   success:     {"ok":true,"status":"finished","runId":"…","answerSha256":"…","answerLen":…}
+ *   fail-closed: {"ok":false,"code":"…","httpStatus":503}
+ *   no-secret:   {"ok":false,"code":"RESOLVER_NULL","httpStatus":0}
+ *
+ * NOTE: the adapter returns REFS-ONLY (no body — compose's body source is the slice-3 DB readback,
+ * proven separately). So this runner asserts the refs (status/sha256/len), not a body.
+ */
+import { resolveRustAgentRunWsClientX25519Secret } from "../../src/api/mission-spine/friday-rust-hub-agent-run-ws-client-x25519-secret.js";
+import { createFridayRustHubAgentRunSealedClientService } from "../../src/api/mission-spine/friday-rust-hub-agent-run-sealed-client-service.js";
+
+function arg(name: string): string | undefined {
+  const prefix = `--${name}=`;
+  const hit = process.argv.find((a) => a.startsWith(prefix));
+  return hit ? hit.slice(prefix.length) : undefined;
+}
+
+async function main(): Promise<void> {
+  const port = Number.parseInt(arg("port") ?? "", 10);
+  const principal = arg("principal") ?? "";
+  const runId = arg("run-id") ?? "run-compose-interop";
+  const task = arg("task") ?? "ping";
+  const timeoutMs = Number.parseInt(arg("timeout-ms") ?? "15000", 10);
+
+  if (!Number.isFinite(port) || port <= 0) {
+    process.stdout.write(JSON.stringify({ ok: false, code: "BAD_ARGS", httpStatus: 0 }) + "\n");
+    process.exit(1);
+    return;
+  }
+
+  // (1) REAL resolver — derives the X25519 secret from FRIDAY_MASTER_KEY via the real getMasterKey.
+  const secret = resolveRustAgentRunWsClientX25519Secret();
+  if (!secret || secret.length === 0) {
+    process.stdout.write(JSON.stringify({ ok: false, code: "RESOLVER_NULL", httpStatus: 0 }) + "\n");
+    process.exit(2);
+    return;
+  }
+
+  // (2) REAL service adapter (default createClient = the real sealed client) → REAL server.
+  const service = createFridayRustHubAgentRunSealedClientService({ host: "127.0.0.1", port, timeoutMs });
+
+  try {
+    const result = await service.dispatchRun({ runId, task, forwardedPrincipal: principal, clientSecret: secret });
+    process.stdout.write(
+      JSON.stringify({
+        ok: true,
+        status: result.status,
+        runId: result.runId,
+        answerSha256: result.answerSha256 ?? null,
+        answerLen: result.answerLen ?? null,
+      }) + "\n",
+    );
+    process.exit(0);
+  } catch (error) {
+    const code = error && typeof error === "object" && "code" in error ? String((error as { code: unknown }).code) : "UNKNOWN";
+    const httpStatus =
+      error && typeof error === "object" && "httpStatus" in error ? Number((error as { httpStatus: unknown }).httpStatus) : 0;
+    process.stdout.write(JSON.stringify({ ok: false, code, httpStatus }) + "\n");
+    process.exit(3);
+  }
+}
+
+void main();

--- a/test/unit/api/mission-spine/friday-rust-hub-agent-run-sealed-client-service.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-agent-run-sealed-client-service.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { FridayDomainError } from "../../../../src/errors/friday-domain-error.js";
+import { createFridayRustHubAgentRunSealedClientService } from "../../../../src/api/mission-spine/friday-rust-hub-agent-run-sealed-client-service.js";
+import type {
+  CreateFridayRustHubAgentRunSealedClientOptions,
+  FridayRustHubAgentRunSealedClient,
+  FridayRustHubAgentRunSealedResult,
+} from "../../../../src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.js";
+
+// execrun B1-compose (DARK): the service ADAPTER that lets compose drive the PROVEN sealed WS
+// client through a `dispatchRun({...,clientSecret})` seam over the REAL ECDH protocol. These tests
+// mock the underlying sealed client at the `createClient` seam — so we exercise the adapter's
+// wiring / refs-mapping / fail-closed WITHOUT a socket and WITHOUT re-proving the (already-proven)
+// interop. The RAW sealed client↔server interop is proven elsewhere (KAT 9/9 + interop 3/3 + live).
+
+const SECRET = new Uint8Array(32).fill(7);
+
+/** A fake underlying sealed client + a recorder of how it was constructed/dispatched. */
+function makeFakeClient(behavior: {
+  result?: FridayRustHubAgentRunSealedResult;
+  reject?: unknown;
+}) {
+  const constructed: CreateFridayRustHubAgentRunSealedClientOptions[] = [];
+  const dispatched: Array<{ runId: string; task: string; forwardedPrincipal: string }> = [];
+  const createClient = vi.fn(
+    (options: CreateFridayRustHubAgentRunSealedClientOptions): FridayRustHubAgentRunSealedClient => {
+      constructed.push(options);
+      return {
+        dispatchRun: vi.fn(async (req) => {
+          dispatched.push(req);
+          if (behavior.reject !== undefined) {
+            throw behavior.reject;
+          }
+          return behavior.result!;
+        }),
+      };
+    },
+  );
+  return { createClient, constructed, dispatched };
+}
+
+describe("createFridayRustHubAgentRunSealedClientService (B1-compose, dark, adapter)", () => {
+  it("factory is SIDE-EFFECT-FREE: constructs no underlying client until dispatchRun is called", () => {
+    const fake = makeFakeClient({ result: deliveredResult() });
+    createFridayRustHubAgentRunSealedClientService({
+      host: "127.0.0.1",
+      port: 4123,
+      createClient: fake.createClient,
+    });
+    // No socket, no underlying client, no secret touched at construction time.
+    expect(fake.createClient).not.toHaveBeenCalled();
+  });
+
+  it("threads host/port/timeout + the per-dispatch clientSecret into the underlying client", async () => {
+    const fake = makeFakeClient({ result: deliveredResult() });
+    const service = createFridayRustHubAgentRunSealedClientService({
+      host: "127.0.0.1",
+      port: 4123,
+      timeoutMs: 5_000,
+      createClient: fake.createClient,
+    });
+
+    await service.dispatchRun({
+      runId: "run-1",
+      task: "read README.md",
+      forwardedPrincipal: "owner-1",
+      clientSecret: SECRET,
+    });
+
+    expect(fake.createClient).toHaveBeenCalledTimes(1);
+    const opts = fake.constructed[0];
+    expect(opts.host).toBe("127.0.0.1");
+    expect(opts.port).toBe(4123);
+    expect(opts.timeoutMs).toBe(5_000);
+    expect(Buffer.from(opts.clientSecret).equals(Buffer.from(SECRET))).toBe(true);
+    // The dispatch carried the run fields (NOT the secret — the secret is on the constructor).
+    expect(fake.dispatched).toHaveLength(1);
+    expect(fake.dispatched[0]).toMatchObject({
+      runId: "run-1",
+      task: "read README.md",
+      forwardedPrincipal: "owner-1",
+    });
+  });
+
+  it("maps the sealed result to REFS-ONLY and DROPS the in-band body", async () => {
+    const fake = makeFakeClient({
+      result: {
+        truthLabel: "rust_wired",
+        runId: "run-1",
+        status: "finished",
+        answerSha256: "a".repeat(64),
+        answerLen: 4,
+        body: "PONG", // the sealed client's belt-and-suspenders in-band body — must be DROPPED.
+      },
+    });
+    const service = createFridayRustHubAgentRunSealedClientService({
+      port: 4123,
+      createClient: fake.createClient,
+    });
+
+    const result = await service.dispatchRun({
+      runId: "run-1",
+      task: "ping",
+      forwardedPrincipal: "owner-1",
+      clientSecret: SECRET,
+    });
+
+    expect(result).toEqual({
+      truthLabel: "rust_wired",
+      runId: "run-1",
+      status: "finished",
+      answerSha256: "a".repeat(64),
+      answerLen: 4,
+    });
+    // The in-band body is NOT surfaced (compose's body source is the slice-3 DB readback).
+    expect("body" in result).toBe(false);
+  });
+
+  it("maps a no-answer result (no fingerprint) to refs-only with the bare status", async () => {
+    const fake = makeFakeClient({
+      result: { truthLabel: "rust_wired", runId: "run-1", status: "no_answer" },
+    });
+    const service = createFridayRustHubAgentRunSealedClientService({
+      port: 4123,
+      createClient: fake.createClient,
+    });
+
+    const result = await service.dispatchRun({
+      runId: "run-1",
+      task: "ping",
+      forwardedPrincipal: "owner-1",
+      clientSecret: SECRET,
+    });
+
+    expect(result).toEqual({ truthLabel: "rust_wired", runId: "run-1", status: "no_answer" });
+    expect(result.answerSha256).toBeUndefined();
+    expect(result.answerLen).toBeUndefined();
+  });
+
+  it("surfaces the underlying client's FridayDomainError (503) unchanged on a closed session", async () => {
+    const domainErr = new FridayDomainError(
+      "MISSION_SPINE_RUST_AGENT_RUN_SEALED_WS_CLIENT_UNAVAILABLE",
+      "Sealed agent-run client connection closed before a result.",
+      { httpStatus: 503 },
+    );
+    const fake = makeFakeClient({ reject: domainErr });
+    const service = createFridayRustHubAgentRunSealedClientService({
+      port: 4123,
+      createClient: fake.createClient,
+    });
+
+    await expect(
+      service.dispatchRun({
+        runId: "run-1",
+        task: "ping",
+        forwardedPrincipal: "owner-1",
+        clientSecret: SECRET,
+      }),
+    ).rejects.toBe(domainErr);
+  });
+
+  it("wraps a NON-domain throw as a fail-closed 503", async () => {
+    const fake = makeFakeClient({ reject: new Error("raw socket boom") });
+    const service = createFridayRustHubAgentRunSealedClientService({
+      port: 4123,
+      createClient: fake.createClient,
+    });
+
+    await expect(
+      service.dispatchRun({
+        runId: "run-1",
+        task: "ping",
+        forwardedPrincipal: "owner-1",
+        clientSecret: SECRET,
+      }),
+    ).rejects.toMatchObject({ httpStatus: 503 });
+  });
+
+  it("fails closed (503) when the underlying client construction throws (e.g. a non-32-byte secret)", async () => {
+    // The default REAL sealed client throws a RangeError on a non-32-byte secret. Prove the adapter
+    // maps a construction throw to a 503 (rather than letting the RangeError escape).
+    const service = createFridayRustHubAgentRunSealedClientService({
+      port: 4123,
+      createClient: () => {
+        throw new RangeError("clientSecret must be 32 bytes");
+      },
+    });
+
+    await expect(
+      service.dispatchRun({
+        runId: "run-1",
+        task: "ping",
+        forwardedPrincipal: "owner-1",
+        clientSecret: new Uint8Array(16),
+      }),
+    ).rejects.toMatchObject({ httpStatus: 503 });
+  });
+});
+
+function deliveredResult(): FridayRustHubAgentRunSealedResult {
+  return {
+    truthLabel: "rust_wired",
+    runId: "run-1",
+    status: "finished",
+    answerSha256: "a".repeat(64),
+    answerLen: 4,
+    body: "PONG",
+  };
+}

--- a/test/unit/api/mission-spine/friday-rust-hub-agent-run-ws-client-x25519-secret.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-agent-run-ws-client-x25519-secret.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  deriveRustAgentRunWsClientX25519PublicKey,
+  FRIDAY_HUB_AGENT_RUN_WS_X25519_SECRET_PRESENT,
+  resolveRustAgentRunWsClientX25519Secret,
+} from "../../../../src/api/mission-spine/friday-rust-hub-agent-run-ws-client-x25519-secret.js";
+import { deviceKeypairFromSecret } from "../../../../src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-crypto.js";
+import { resetMasterKeyCache } from "../../../../src/security/friday-secret-crypto.js";
+
+// execrun B1-compose (DARK): the SecureStore-backed X25519 client-SECRET resolver for the PROVEN
+// sealed WS client (the ECDH model — REPLACES #612's symmetric session-key resolver). Fail-closed
+// contract: a MISSING / disabled / short SecureStore secret resolves to `null` so the composition
+// never opens an unauthenticated WS connection. The secret is NEVER logged. The pubkey helper
+// derives the value 6b enrolls in the server peer-allowlist.
+
+const SAVED_PRESENCE = process.env[FRIDAY_HUB_AGENT_RUN_WS_X25519_SECRET_PRESENT];
+const SAVED_MASTER_KEY = process.env.FRIDAY_MASTER_KEY;
+// A deterministic 32-byte hex master key so getMasterKey() returns a known value in-process.
+const FIXTURE_MASTER_KEY_HEX = "11".repeat(32); // pragma: allowlist secret
+
+function restoreEnv(name: string, saved: string | undefined): void {
+  if (saved === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = saved;
+  }
+}
+
+describe("resolveRustAgentRunWsClientX25519Secret (B1-compose, dark, SecureStore-backed)", () => {
+  beforeEach(() => {
+    delete process.env[FRIDAY_HUB_AGENT_RUN_WS_X25519_SECRET_PRESENT];
+    // Hermetic: clear any inherited/leaked master-key env so each test controls it explicitly.
+    delete process.env.FRIDAY_MASTER_KEY;
+    // getMasterKey() caches the master key for a TTL; reset it so a per-test FRIDAY_MASTER_KEY
+    // takes effect deterministically (and the suite never inherits a real provisioned key).
+    resetMasterKeyCache();
+  });
+
+  afterEach(() => {
+    restoreEnv(FRIDAY_HUB_AGENT_RUN_WS_X25519_SECRET_PRESENT, SAVED_PRESENCE);
+    restoreEnv("FRIDAY_MASTER_KEY", SAVED_MASTER_KEY);
+    resetMasterKeyCache();
+    vi.restoreAllMocks();
+  });
+
+  it("explicit disable via the presence env signal → fail closed (null), no SecureStore read", () => {
+    process.env[FRIDAY_HUB_AGENT_RUN_WS_X25519_SECRET_PRESENT] = "0";
+    expect(resolveRustAgentRunWsClientX25519Secret()).toBeNull();
+    process.env[FRIDAY_HUB_AGENT_RUN_WS_X25519_SECRET_PRESENT] = "false"; // pragma: allowlist secret
+    expect(resolveRustAgentRunWsClientX25519Secret()).toBeNull();
+  });
+
+  it("never throws an error that carries the secret, and never logs", () => {
+    // The presence signal off forces the no-read path; assert no console output leaks.
+    process.env[FRIDAY_HUB_AGENT_RUN_WS_X25519_SECRET_PRESENT] = "0";
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(() => resolveRustAgentRunWsClientX25519Secret()).not.toThrow();
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(errSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("when the SecureStore master key is unavailable → fail closed (null), never a throw", () => {
+    // With no keychain master key + no master-key env provisioned, the SecureStore lookup either
+    // throws internally (→ null) or yields a key; in BOTH cases the resolver never throws and never
+    // returns a short/invalid value.
+    delete process.env.FRIDAY_MASTER_KEY;
+    const result = resolveRustAgentRunWsClientX25519Secret();
+    if (result !== null) {
+      expect(result.length).toBe(32);
+    } else {
+      expect(result).toBeNull();
+    }
+  });
+
+  it("derives a STABLE 32-byte secret from a fixture master key (idempotent across calls)", () => {
+    process.env.FRIDAY_MASTER_KEY = FIXTURE_MASTER_KEY_HEX;
+    const a = resolveRustAgentRunWsClientX25519Secret();
+    const b = resolveRustAgentRunWsClientX25519Secret();
+    expect(a).not.toBeNull();
+    expect(b).not.toBeNull();
+    expect(a!.length).toBe(32);
+    // Same SecureStore master key + same purpose tag ⇒ same secret on every call (so the derived
+    // pubkey the operator enrolls at 6b is stable).
+    expect(Buffer.from(a!).equals(Buffer.from(b!))).toBe(true);
+  });
+
+  it("is domain-separated: a DIFFERENT master key yields a DIFFERENT secret", () => {
+    process.env.FRIDAY_MASTER_KEY = FIXTURE_MASTER_KEY_HEX;
+    const first = resolveRustAgentRunWsClientX25519Secret();
+    process.env.FRIDAY_MASTER_KEY = "22".repeat(32); // pragma: allowlist secret
+    resetMasterKeyCache(); // drop the cached first key so the new master key takes effect.
+    const second = resolveRustAgentRunWsClientX25519Secret();
+    expect(first).not.toBeNull();
+    expect(second).not.toBeNull();
+    expect(Buffer.from(first!).equals(Buffer.from(second!))).toBe(false);
+  });
+
+  it("derived secret is a valid X25519 scalar (deviceKeypairFromSecret accepts it; 32B pubkey)", () => {
+    process.env.FRIDAY_MASTER_KEY = FIXTURE_MASTER_KEY_HEX;
+    const secret = resolveRustAgentRunWsClientX25519Secret();
+    expect(secret).not.toBeNull();
+    const keypair = deviceKeypairFromSecret(secret!);
+    expect(keypair.publicKey.length).toBe(32);
+  });
+});
+
+describe("deriveRustAgentRunWsClientX25519PublicKey (the 6b peer-allowlist enrollment value)", () => {
+  const SECRET_A = new Uint8Array(32).fill(7);
+  const SECRET_B = new Uint8Array(32).fill(9);
+
+  it("derives a STABLE 32-byte pubkey from a secret (matches deviceKeypairFromSecret)", () => {
+    const pub = deriveRustAgentRunWsClientX25519PublicKey(SECRET_A);
+    expect(pub.length).toBe(32);
+    // Identical to the sealed-crypto keypair derivation (the value the server allowlist holds).
+    const direct = deviceKeypairFromSecret(SECRET_A).publicKey;
+    expect(Buffer.from(pub).equals(Buffer.from(direct))).toBe(true);
+    // Stable across calls.
+    const again = deriveRustAgentRunWsClientX25519PublicKey(SECRET_A);
+    expect(Buffer.from(pub).equals(Buffer.from(again))).toBe(true);
+  });
+
+  it("distinct secrets yield distinct pubkeys", () => {
+    const pubA = deriveRustAgentRunWsClientX25519PublicKey(SECRET_A);
+    const pubB = deriveRustAgentRunWsClientX25519PublicKey(SECRET_B);
+    expect(Buffer.from(pubA).equals(Buffer.from(pubB))).toBe(false);
+  });
+
+  it("throws on a non-32-byte secret (programming-error guard; compose fails closed before this)", () => {
+    expect(() => deriveRustAgentRunWsClientX25519PublicKey(new Uint8Array(16))).toThrow();
+  });
+});

--- a/test/unit/api/runtime/friday-api-runtime-rust-route-compose.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-rust-route-compose.test.ts
@@ -9,9 +9,9 @@ import type { FridayProviderService } from "#providers";
 import type { FridaySqliteLayer } from "#state";
 import { createFridayRustHubRunContinuityProjectorService } from "../../../../src/api/mission-spine/friday-rust-hub-run-continuity-projector-service.js";
 import type {
-  FridayRustHubAgentRunWsClientService,
-  FridayRustHubAgentRunWsRequest,
-} from "../../../../src/api/mission-spine/friday-rust-hub-agent-run-ws-client.js";
+  FridayRustHubAgentRunSealedClientService,
+  FridayRustHubAgentRunSealedClientServiceRequest,
+} from "../../../../src/api/mission-spine/friday-rust-hub-agent-run-sealed-client-service.js";
 import type {
   FridayRustHubRunAnswerReadbackInput,
   FridayRustHubRunAnswerReadbackReceipt,
@@ -109,11 +109,11 @@ function makeAgentRuntime(): FridayAgentRuntime {
   } as unknown as FridayAgentRuntime;
 }
 
-/** A scripted-stub WS client that records every dispatch (refs-only result). */
+/** A scripted-stub sealed WS client that records every dispatch (refs-only result). */
 function makeStubWsClient() {
-  const calls: FridayRustHubAgentRunWsRequest[] = [];
-  const service: FridayRustHubAgentRunWsClientService = {
-    dispatchRun: vi.fn(async (request: FridayRustHubAgentRunWsRequest) => {
+  const calls: FridayRustHubAgentRunSealedClientServiceRequest[] = [];
+  const service: FridayRustHubAgentRunSealedClientService = {
+    dispatchRun: vi.fn(async (request: FridayRustHubAgentRunSealedClientServiceRequest) => {
       calls.push(request);
       return {
         truthLabel: "rust_wired" as const,
@@ -161,9 +161,9 @@ function makeStubReadback(owner: string) {
 
 interface ComposeDeps {
   routeAgentRunViaRust?: boolean;
-  wsClient?: FridayRustHubAgentRunWsClientService;
+  wsClient?: FridayRustHubAgentRunSealedClientService;
   readback?: FridayRustHubRunAnswerReadbackService;
-  sessionKeyResolver?: () => Uint8Array | null;
+  clientSecretResolver?: () => Uint8Array | null;
   hubDbPath?: string;
   idGenerator?: () => string;
 }
@@ -187,9 +187,10 @@ function makeRuntime(db: FridaySqliteLayer, opts: ComposeDeps) {
     ...(opts.readback ? { rustAgentRunAnswerReadback: opts.readback } : {}),
     // The REAL projector is used so the no-double-count contract is exercised against a db.
     rustAgentRunContinuityProjector: createFridayRustHubRunContinuityProjectorService(),
-    // SecureStore resolver: fixture key by default; tests override to prove fail-closed.
-    rustAgentRunWsSessionKeyResolver:
-      opts.sessionKeyResolver ?? (() => new Uint8Array(32).fill(7)),
+    // SecureStore X25519-secret resolver: fixture 32-byte secret by default (a valid X25519
+    // scalar); tests override to prove fail-closed.
+    rustAgentRunWsClientSecretResolver:
+      opts.clientSecretResolver ?? (() => new Uint8Array(32).fill(7)),
     rustAgentRunHubDbPath: opts.hubDbPath ?? "/tmp/friday-test-hub.db",
   });
 }
@@ -273,7 +274,8 @@ describe("FridayApiRuntime — execrun S-F-compose (DARK) Rust-route composition
     expect(ws.calls).toHaveLength(1);
     expect(ws.calls[0].runId).toBe(RUN_ID);
     expect(ws.calls[0].forwardedPrincipal).toBe(OWNER_PRINCIPAL);
-    expect(ws.calls[0].authProof.length).toBeGreaterThanOrEqual(32);
+    // The sealed client receives the resolved 32-byte X25519 SECRET (NOT a pre-built authProof).
+    expect(ws.calls[0].clientSecret.length).toBe(32);
     expect(readback.calls).toHaveLength(1);
     expect(readback.calls[0].callerPrincipal).toBe(OWNER_PRINCIPAL);
 
@@ -334,7 +336,7 @@ describe("FridayApiRuntime — execrun S-F-compose (DARK) Rust-route composition
       wsClient: ws.service,
       readback: readback.service,
       // SecureStore returns null → fail closed before any WS connection.
-      sessionKeyResolver: () => null,
+      clientSecretResolver: () => null,
     });
 
     await expect(callStartRoute(runtime, { ...QUALIFYING_BODY })).rejects.toMatchObject({

--- a/test/unit/api/runtime/friday-api-runtime-rust-route-compose.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-rust-route-compose.test.ts
@@ -118,7 +118,7 @@ function makeStubWsClient() {
       return {
         truthLabel: "rust_wired" as const,
         runId: request.runId,
-        status: "completed",
+        status: "finished",
         answerSha256: ANSWER_SHA256,
         answerLen: OWNER_BODY.length,
       };
@@ -140,7 +140,7 @@ function makeStubReadback(owner: string) {
             proofOnly: true,
             outcome: "delivered",
             runId: input.runId,
-            status: "completed",
+            status: "finished",
             answer: OWNER_BODY,
             answerSha256: ANSWER_SHA256,
             answerLen: OWNER_BODY.length,
@@ -429,7 +429,7 @@ describe("FridayApiRuntime — execrun S-F-compose (DARK) Rust-route composition
         proofOnly: true,
         outcome: "delivered",
         runId: input.runId,
-        status: "completed",
+        status: "finished",
         answer: OWNER_BODY,
         answerSha256: ANSWER_SHA256,
         answerLen: OWNER_BODY.length,


### PR DESCRIPTION
## What
Repoints the production `routeStartRun` compose path to the **proven** sealed WS client (merged in #614) and adds a SecureStore→X25519-secret resolver. The bridge slice to 6b. **DARK / flag-off** (`routeAgentRunViaRust` default-false); flag-off is byte-identical to today.

## Files
- **NEW** `friday-rust-hub-agent-run-ws-client-x25519-secret.ts` — derives a stable 32-byte X25519 SECRET from the SecureStore master key (`sha256(purpose ‖ getMasterKey())`, domain-separated; distinct from #612's symmetric purpose). Fail-closed (Directive-0i). Exposes `deriveRustAgentRunWsClientX25519PublicKey` — the pubkey the operator enrolls at 6b.
- **NEW** `friday-rust-hub-agent-run-sealed-client-service.ts` — service adapter exposing the old `dispatchRun` seam over the sealed ECDH protocol; takes `{clientSecret}`, returns REFS-ONLY (compose's body source stays the slice-3 DB readback); side-effect-free factory (lazy per-dispatch client) so flag-off constructs nothing live.
- **MOD** `friday-api-runtime.ts` / `.types.ts` — compose wiring + `routeStartRun` construction + resolver rename. Status-mapping fix (see below).
- **NEW** compose-through interop harness (`test/interop/…compose-adapter-runner.ts` + build) + additive `#[ignore]` Rust tests.

## A real bug fixed in-slice
Compose mapped the wire status `=== "completed"` → `Finished`, but the Rust server sends the persisted RunResult status `"finished"` (rust-core `lib.rs` `detail:"finished"`). A real delivered run would have been mislabeled `Errored` in the projected continuity row. Fixed `=== "finished"`; the compose-test stubs were mock-green/real-wrong (caught + made faithful).

## Proof
- Resolver 9/9, adapter 7/7, compose 10/10, flag 3/3 unit tests.
- **Compose-through interop (NEW, `#[ignore]`):** real resolver (FRIDAY_MASTER_KEY fixture) → real adapter (default real `createClient`) → real sealed client → real server: dispatch ACCEPTED, refs `status:"finished"` + sha256/len; unenrolled pubkey → fail-closed 503. The Rust side re-derives the same pubkey via `sha256(purpose ‖ key)` and enrolls it — live-checking that the resolver derivation == the 6b enrollment.
- Adversarial security review: **CLEAR** (key-derivation fail-closed/no-collision/no-leak; no fail-open; flag-off byte-identical). One LOW doc note corrected (6b enrollment semantics).
- Full gate: tsc 0, eslint 0 errors, vitest 12,677/0, cargo default green, fmt/clippy/secrets clean.

## Truth labels
- **DARK** `rust_wired_dev` ceiling — NO production route consumes it (flag default-off). **NOT v1 GO.**
- **6b acceptance criterion (deferred, NOT dropped):** the full compose-through-WITH-BODY path (native-sqlite DB readback of the server-persisted owner-sealed body + the projector row) is validated at 6b against the real provisioned server (it can't be esbuild-bundled into the interop subprocess). Until then covered by composition: this compose-through e2e + the proven slice-3 readback + the B1 transport e2e+live.
- 6b operational note: the resolver does NOT fail-closed on a *merely-absent* master key (`getMasterKey` auto-generates one) — fail-closed is server-side (unenrolled pubkey). 6b must enroll the pubkey from the prod host's STABLE master key + re-enroll on rotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)