### PR TITLE
feat(execrun-enablement): slice 1 — persistent encrypted file SecureStore (dark)

### DIFF
--- a/rust-core/Cargo.lock
+++ b/rust-core/Cargo.lock
@@ -488,6 +488,7 @@ dependencies = [
  "friday-core",
  "hkdf",
  "hmac",
+ "libc",
  "sha2",
  "thiserror 1.0.69",
  "x25519-dalek",

--- a/rust-core/crates/friday-crypto/Cargo.toml
+++ b/rust-core/crates/friday-crypto/Cargo.toml
@@ -11,6 +11,10 @@ rust-version.workspace = true
 chacha20poly1305.workspace = true
 thiserror.workspace = true
 zeroize.workspace = true
+# Unix file primitives for the persistent FileSecureStore backend: O_NOFOLLOW on
+# the atomic-write temp file (the temp is provably ours — never a pre-existing
+# symlink). Pure libc constants, no I/O surface beyond std::fs.
+libc.workspace = true
 # E2E session-key agreement (phone<->Hub). X25519 ECDH + HKDF-SHA256.
 # `zeroize` named explicitly so a future default-features change can't silently
 # disable StaticSecret wipe-on-drop.

--- a/rust-core/crates/friday-crypto/src/file_store.rs
+++ b/rust-core/crates/friday-crypto/src/file_store.rs
@@ -82,7 +82,7 @@
 
 use std::fs;
 use std::io::Write;
-use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -155,9 +155,15 @@ impl FileSecureStore {
     /// (each is written `0600` at `put` time).
     pub fn open(dir: impl AsRef<Path>, kek: Kek) -> Result<Self, FileStoreError> {
         let dir = dir.as_ref().to_path_buf();
-        fs::create_dir_all(&dir)?;
-        // Enforce 0700 explicitly (umask-safe; create_dir_all honors umask, and a
-        // pre-existing dir may have looser perms).
+        // Create with 0700 from the START so a freshly-created dir is never even
+        // briefly group/other-accessible (DirBuilder.mode applies the mode at
+        // creation, unlike create_dir_all which honors umask then needs a chmod).
+        fs::DirBuilder::new()
+            .recursive(true)
+            .mode(DIR_MODE)
+            .create(&dir)?;
+        // DirBuilder.mode only governs dirs IT creates; a pre-existing dir keeps
+        // its old (possibly looser) perms, so still enforce 0700 explicitly.
         fs::set_permissions(&dir, fs::Permissions::from_mode(DIR_MODE))?;
         Ok(Self { dir, kek })
     }
@@ -293,10 +299,13 @@ impl FileSecureStore {
             fs::rename(&tmp_path, target)?;
             // fsync the parent directory so the rename is durable across a power
             // loss (atomic alone only guarantees no torn read by a concurrent
-            // reader; durability needs the dir entry flushed).
-            if let Ok(dir) = fs::File::open(parent) {
-                let _ = dir.sync_all();
-            }
+            // reader; durability needs the dir entry flushed). Propagate failure
+            // so the durability guarantee is real rather than silently best-effort
+            // (the entry is already renamed into place; a post-rename Err signals
+            // "written but maybe not power-loss-durable" — safe for the idempotent
+            // enrollment caller to retry).
+            let dir = fs::File::open(parent)?;
+            dir.sync_all()?;
             Ok(())
         };
 

--- a/rust-core/crates/friday-crypto/src/file_store.rs
+++ b/rust-core/crates/friday-crypto/src/file_store.rs
@@ -1,0 +1,693 @@
+//! A persistent, encrypted, file-based [`SecureStore`] backend.
+//!
+//! This is the production-shaped counterpart to [`crate::InMemorySecureStore`]:
+//! it survives process restart by persisting each entry as an AEAD-sealed file on
+//! disk. It is the backend the execrun WS server reads its peer-pubkey allowlist
+//! from, and the backend the enrollment CLI writes that allowlist into.
+//!
+//! # Key boundary — the KEK is INJECTED, never read here
+//!
+//! [`FileSecureStore::open`] takes the [`Kek`] as a parameter. This backend is
+//! pure crypto + filesystem: it does NOT read a key file, the OS keychain, or any
+//! environment variable. Sourcing the KEK (Keychain / launchd-provisioned file /
+//! etc.) is a *separate* concern wired by a later slice. This keeps the backend
+//! fully testable with an in-test `Kek::generate()` and keeps the key-sourcing
+//! policy out of the crypto core.
+//!
+//! # On-disk format (per entry — one file per id)
+//!
+//! Each `(id, value)` pair is stored in its own file. The filename is
+//! `hex(sha256("friday-securestore-id-v1" || id))` so that arbitrary ids
+//! (which contain `:` and other bytes) map to a fixed-width, filesystem-safe,
+//! non-reversible name. The filename is **not** a security boundary — the id is
+//! bound cryptographically into the value AAD (see below), so a file moved to a
+//! different name still fails to open under a different id.
+//!
+//! File layout (all multi-byte lengths are `u32` little-endian; every
+//! length-prefixed field is bounds-checked against the remaining bytes before it
+//! is sliced, so a truncated or malformed file fails closed, never panics):
+//!
+//! ```text
+//! byte  0          : FORMAT_VERSION (currently 0x01)
+//! bytes 1..        : wrapped_data_key  — Sealed (KEK-wrapped random DataKey)
+//!                      u32 nonce_len, nonce[nonce_len], u32 ct_len, ct[ct_len]
+//! bytes ..end      : sealed_value      — Sealed (value under the DataKey)
+//!                      u32 nonce_len, nonce[nonce_len], u32 ct_len, ct[ct_len]
+//! ```
+//!
+//! ## Sealing scheme
+//!
+//! For each `put`, a fresh random [`DataKey`] is generated. The value is
+//! [`seal`]ed under that DataKey; the DataKey is [`wrap_data_key`]ped under the
+//! injected [`Kek`] and stored alongside the sealed value. On `get`, the DataKey
+//! is unwrapped with the KEK, then used to open the value. A wrong KEK fails to
+//! unwrap the DataKey (fail closed). This reuses the audited
+//! [`seal`]/[`open`]/[`wrap_data_key`]/[`unwrap_data_key`] primitives — no
+//! hand-rolled AEAD.
+//!
+//! ## AAD id-binding (replay / swap defense)
+//!
+//! The value seal authenticates an AAD of
+//! `"friday-securestore-entry-v1" || [FORMAT_VERSION] || id_bytes`.
+//!
+//! - Binding the **id** means a whole file copied from id `A` to id `B`'s name
+//!   fails `open` (the AAD carries `A`'s id, the read supplies `B`'s) → `get`
+//!   returns `None`. The filename is not trusted; the cryptographic binding is.
+//! - Binding the **version byte** into the AAD makes the header tamper-evident
+//!   for free and defeats a header-version downgrade: flipping the version byte
+//!   on disk changes the AAD and the value no longer opens.
+//!
+//! # Durability & permissions
+//!
+//! - Writes are atomic-and-durable: the entry is written to a temp file in the
+//!   SAME directory with `O_CREAT|O_EXCL|O_NOFOLLOW` mode `0600`, `fsync`ed, then
+//!   `rename(2)`d over the target (atomic replace — a crash mid-write leaves the
+//!   prior entry intact), and finally the parent directory is `fsync`ed so the
+//!   rename survives a power loss.
+//! - The containing directory is `0700` and each entry file is `0600`, enforced
+//!   on every [`FileSecureStore::open`] (even if the dir pre-existed).
+//!
+//! # NON-goals / documented residual risk
+//!
+//! - **Same-id rollback is NOT defended.** A *previously valid* file for id `A`
+//!   (same KEK, same id) restored over the current one opens cleanly — it is a
+//!   genuine prior value, indistinguishable here from the current one. Defending
+//!   rollback needs a monotonic counter or an external anchor and is out of scope
+//!   for this backend.
+//! - **Cross-process consistency is by read-through, not locking.** There is no
+//!   in-memory cache; every `get` reads disk, so a value enrolled by the CLI in a
+//!   separate process is visible to a later server `get`. Concurrent writers to
+//!   the *same id* are not coordinated (last atomic rename wins); the execrun use
+//!   (CLI enrolls, then server boots) is not concurrent.
+
+use std::fs;
+use std::io::Write;
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use sha2::{Digest, Sha256};
+
+use crate::{
+    open, seal, unwrap_data_key, wrap_data_key, CryptoError, DataKey, Kek, Sealed, SecureStore,
+};
+
+/// Current on-disk format version. An entry whose first byte is not this value is
+/// rejected fail-closed (`try_get` → `Err(Version)`, trait `get` → `None`). The
+/// version byte is ALSO folded into the value AAD, so it cannot be silently
+/// flipped on disk without breaking decryption.
+const FORMAT_VERSION: u8 = 0x01;
+
+/// Domain separation for the filename hash. Mixed in so a SecureStore id's hashed
+/// filename cannot collide with some other unrelated sha256(id) use.
+const FILENAME_DOMAIN: &[u8] = b"friday-securestore-id-v1";
+
+/// Domain tag prefixed to the value AAD (before the version byte and id). Binds
+/// every sealed value to "this is a Friday SecureStore entry".
+const ENTRY_AAD_DOMAIN: &[u8] = b"friday-securestore-entry-v1";
+
+/// Directory mode: owner rwx only.
+const DIR_MODE: u32 = 0o700;
+/// File mode: owner rw only.
+const FILE_MODE: u32 = 0o600;
+
+/// Errors from the fallible [`FileSecureStore`] methods. **Carries no key bytes,
+/// no plaintext, and no ciphertext** — only structural classification — so it is
+/// safe to log. (`Crypto` wraps [`CryptoError`], which is itself secret-free:
+/// it only names the failure mode, e.g. "decryption/authentication failed".)
+#[derive(Debug, thiserror::Error)]
+pub enum FileStoreError {
+    /// A filesystem error (open/read/write/rename/fsync/permissions). The inner
+    /// [`std::io::Error`] describes the OS failure (e.g. EACCES, ENOSPC), never
+    /// secret content.
+    #[error("secure-store io error")]
+    Io(#[from] std::io::Error),
+    /// The stored bytes are structurally malformed (truncated, a length prefix
+    /// that overruns the file, etc.). No secret content.
+    #[error("secure-store entry is malformed")]
+    Format,
+    /// The entry's on-disk format version is not understood by this build.
+    #[error("secure-store entry has an unsupported format version")]
+    Version,
+    /// An AEAD/key operation failed: wrong KEK, tampered ciphertext, AAD mismatch
+    /// (e.g. an entry-id swap). Fail closed. [`CryptoError`] is secret-free.
+    #[error("secure-store crypto error")]
+    Crypto(#[from] CryptoError),
+}
+
+/// A persistent, encrypted, file-based [`SecureStore`].
+///
+/// Holds ONLY the directory path and the injected [`Kek`]; there is no value
+/// cache, so every read goes through to disk. Deliberately does **not** derive
+/// `Debug` (it holds key material — see [`Kek`], which itself has no `Debug`).
+pub struct FileSecureStore {
+    dir: PathBuf,
+    kek: Kek,
+}
+
+impl FileSecureStore {
+    /// Open (creating if absent) the SecureStore rooted at `dir`, using the
+    /// injected `kek` to wrap/unwrap per-entry data keys.
+    ///
+    /// The directory is created if missing and its mode is set to `0700` on every
+    /// call (even if it pre-existed), so a store directory is never left
+    /// group/other-accessible. Existing entry files are NOT re-permissioned here
+    /// (each is written `0600` at `put` time).
+    pub fn open(dir: impl AsRef<Path>, kek: Kek) -> Result<Self, FileStoreError> {
+        let dir = dir.as_ref().to_path_buf();
+        fs::create_dir_all(&dir)?;
+        // Enforce 0700 explicitly (umask-safe; create_dir_all honors umask, and a
+        // pre-existing dir may have looser perms).
+        fs::set_permissions(&dir, fs::Permissions::from_mode(DIR_MODE))?;
+        Ok(Self { dir, kek })
+    }
+
+    /// Filesystem-safe, fixed-width, non-reversible filename for `id`.
+    fn entry_path(&self, id: &str) -> PathBuf {
+        let mut hasher = Sha256::new();
+        hasher.update(FILENAME_DOMAIN);
+        hasher.update(id.as_bytes());
+        let digest = hasher.finalize();
+        let mut name = String::with_capacity(digest.len() * 2);
+        for b in digest.iter() {
+            // Lowercase hex; no allocation per byte beyond the two chars.
+            name.push(char::from_digit((b >> 4) as u32, 16).unwrap());
+            name.push(char::from_digit((b & 0x0f) as u32, 16).unwrap());
+        }
+        self.dir.join(name)
+    }
+
+    /// The value AAD binding this entry to its id and format version:
+    /// `ENTRY_AAD_DOMAIN || [version] || id_bytes`.
+    ///
+    /// `version` is passed in (not the [`FORMAT_VERSION`] constant) so the AAD is
+    /// always computed from the version actually present. Today that is always
+    /// [`FORMAT_VERSION`] (a different version is rejected before this is called),
+    /// but when a future v2 reader accepts a v1 entry for migration it MUST seal/
+    /// open under the *parsed* version, not the current constant — otherwise the
+    /// migration read fails. Threading the value here keeps that invariant local.
+    fn value_aad(version: u8, id: &str) -> Vec<u8> {
+        let id_bytes = id.as_bytes();
+        let mut aad = Vec::with_capacity(ENTRY_AAD_DOMAIN.len() + 1 + id_bytes.len());
+        aad.extend_from_slice(ENTRY_AAD_DOMAIN);
+        aad.push(version);
+        aad.extend_from_slice(id_bytes);
+        aad
+    }
+
+    /// Fallible read. Returns `Ok(None)` ONLY when the entry file is absent. A
+    /// present-but-unreadable entry (malformed framing, bad version, wrong KEK,
+    /// tampered ciphertext, id-swap AAD mismatch) returns `Err`. The infallible
+    /// trait [`SecureStore::get`] collapses both `Ok(None)` and `Err` into `None`.
+    pub fn try_get(&self, id: &str) -> Result<Option<Vec<u8>>, FileStoreError> {
+        let path = self.entry_path(id);
+        // `fs::read` follows symlinks (unlike friday-fs's O_NOFOLLOW reads). That
+        // is acceptable HERE — and only here — because the store directory is
+        // owner-only `0700` (enforced on every `open`), so an untrusted party
+        // cannot plant a symlink inside it. friday-fs guards an *untrusted*
+        // workspace and must use O_NOFOLLOW; this dir is trusted, a deliberate
+        // divergence, not an oversight.
+        let bytes = match fs::read(&path) {
+            Ok(b) => b,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => return Err(FileStoreError::Io(e)),
+        };
+
+        let mut cur = Cursor::new(&bytes);
+        let version = cur.take_u8().ok_or(FileStoreError::Format)?;
+        if version != FORMAT_VERSION {
+            return Err(FileStoreError::Version);
+        }
+        let wrapped = read_sealed(&mut cur)?;
+        let sealed_value = read_sealed(&mut cur)?;
+        if !cur.is_empty() {
+            // Trailing garbage after the two sealed blobs → malformed.
+            return Err(FileStoreError::Format);
+        }
+
+        let data_key = unwrap_data_key(&self.kek, &wrapped)?;
+        // AAD uses the PARSED version (== FORMAT_VERSION here, since any other was
+        // already rejected above) so a future migration reader stays correct.
+        let aad = Self::value_aad(version, id);
+        let plaintext = open(&data_key, &sealed_value, &aad)?;
+        Ok(Some(plaintext))
+    }
+
+    /// Fallible write. Generates a fresh per-entry [`DataKey`], seals the value
+    /// under it (binding the id+version into the AAD), wraps the DataKey under the
+    /// KEK, frames the two, and atomically + durably replaces the entry file
+    /// (`0600`). Returns `Ok(())` only after the bytes are `fsync`ed and the
+    /// rename is durably committed — so the enrollment CLI can trust success.
+    pub fn try_put(&mut self, id: &str, bytes: &[u8]) -> Result<(), FileStoreError> {
+        let data_key = DataKey::generate();
+        // We write FORMAT_VERSION, so the AAD must seal under that same version.
+        let aad = Self::value_aad(FORMAT_VERSION, id);
+        let sealed_value = seal(&data_key, bytes, &aad)?;
+        let wrapped = wrap_data_key(&self.kek, &data_key)?;
+
+        let mut out = Vec::new();
+        out.push(FORMAT_VERSION);
+        write_sealed(&mut out, &wrapped);
+        write_sealed(&mut out, &sealed_value);
+
+        let target = self.entry_path(id);
+        self.atomic_write(&target, &out)
+    }
+
+    /// Fallible delete. Removing an absent entry is `Ok(())` (idempotent). Returns
+    /// `Err` only on a real filesystem error.
+    pub fn try_delete(&mut self, id: &str) -> Result<(), FileStoreError> {
+        let path = self.entry_path(id);
+        match fs::remove_file(&path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(FileStoreError::Io(e)),
+        }
+    }
+
+    /// Write `contents` to `target` atomically and durably: temp in the same dir
+    /// (`O_CREAT|O_EXCL|O_NOFOLLOW`, `0600`) → write → fsync temp → rename over
+    /// target → fsync parent dir. On any failure after temp creation the temp is
+    /// unlinked (a successful rename consumes the temp name, so we never unlink
+    /// post-rename).
+    fn atomic_write(&self, target: &Path, contents: &[u8]) -> Result<(), FileStoreError> {
+        static TMP_CTR: AtomicU64 = AtomicU64::new(0);
+        let parent = target.parent().unwrap_or(&self.dir);
+        let file_name = target
+            .file_name()
+            .and_then(|s| s.to_str())
+            .ok_or(FileStoreError::Format)?;
+        let nonce = TMP_CTR.fetch_add(1, Ordering::Relaxed);
+        let tmp_path = parent.join(format!(".{file_name}.tmp.{}.{nonce}", std::process::id()));
+
+        let write_then_rename = || -> std::io::Result<()> {
+            let mut tmp = fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .mode(FILE_MODE)
+                .custom_flags(libc::O_NOFOLLOW)
+                .open(&tmp_path)?;
+            tmp.write_all(contents)?;
+            tmp.sync_all()?;
+            drop(tmp);
+            fs::rename(&tmp_path, target)?;
+            // fsync the parent directory so the rename is durable across a power
+            // loss (atomic alone only guarantees no torn read by a concurrent
+            // reader; durability needs the dir entry flushed).
+            if let Ok(dir) = fs::File::open(parent) {
+                let _ = dir.sync_all();
+            }
+            Ok(())
+        };
+
+        match write_then_rename() {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                let _ = fs::remove_file(&tmp_path);
+                Err(FileStoreError::Io(e))
+            }
+        }
+    }
+}
+
+/// Serialize a [`Sealed`] into `out` with `u32`-LE length prefixes.
+fn write_sealed(out: &mut Vec<u8>, sealed: &Sealed) {
+    write_len_prefixed(out, &sealed.nonce);
+    write_len_prefixed(out, &sealed.ciphertext);
+}
+
+fn write_len_prefixed(out: &mut Vec<u8>, field: &[u8]) {
+    // A SecureStore value (and an XChaCha nonce/ciphertext) is far below u32::MAX;
+    // this cast is safe in practice and the read side bounds-checks regardless.
+    let len = field.len() as u32;
+    out.extend_from_slice(&len.to_le_bytes());
+    out.extend_from_slice(field);
+}
+
+/// Read a [`Sealed`] from `cur`, bounds-checking every length against the bytes
+/// that actually remain (a truncated/oversized length fails closed → `Format`).
+fn read_sealed(cur: &mut Cursor<'_>) -> Result<Sealed, FileStoreError> {
+    let nonce = cur
+        .take_len_prefixed()
+        .ok_or(FileStoreError::Format)?
+        .to_vec();
+    let ciphertext = cur
+        .take_len_prefixed()
+        .ok_or(FileStoreError::Format)?
+        .to_vec();
+    Ok(Sealed { nonce, ciphertext })
+}
+
+/// A tiny bounds-checked reader over a byte slice. No length read from the
+/// (unauthenticated) file is ever used to slice without checking it against the
+/// remaining bytes first — so a malformed/truncated file returns `None` (→
+/// `Format`), never panics.
+struct Cursor<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Cursor<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, pos: 0 }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.pos >= self.bytes.len()
+    }
+
+    fn take_u8(&mut self) -> Option<u8> {
+        let b = *self.bytes.get(self.pos)?;
+        self.pos += 1;
+        Some(b)
+    }
+
+    fn take(&mut self, n: usize) -> Option<&'a [u8]> {
+        let end = self.pos.checked_add(n)?;
+        if end > self.bytes.len() {
+            return None;
+        }
+        let out = &self.bytes[self.pos..end];
+        self.pos = end;
+        Some(out)
+    }
+
+    fn take_len_prefixed(&mut self) -> Option<&'a [u8]> {
+        let len_bytes = self.take(4)?;
+        let len = u32::from_le_bytes([len_bytes[0], len_bytes[1], len_bytes[2], len_bytes[3]]);
+        self.take(len as usize)
+    }
+}
+
+impl SecureStore for FileSecureStore {
+    /// Fail-closed read: returns the stored value or `None` on ANY error (missing
+    /// file, IO error, malformed framing, version mismatch, wrong KEK, tampered
+    /// ciphertext, id-swap AAD mismatch). Never panics, never surfaces the error —
+    /// this is exactly the server's reject-on-unprovisioned path.
+    fn get(&self, id: &str) -> Option<Vec<u8>> {
+        // Fail closed: `Ok(None)` (missing) and `Err(_)` (any structural/crypto
+        // failure) both collapse to `None`. `unwrap_or_default()` maps `Err` → the
+        // `Option` default (`None`) — the error is secret-free but the trait
+        // surface is infallible, so it is deliberately not surfaced here.
+        self.try_get(id).unwrap_or_default()
+    }
+
+    /// Fail-closed write: delegates to [`try_put`]. On error, logs a SECRET-FREE
+    /// classification to stderr and swallows — a trait method must not panic.
+    ///
+    /// **Real enrollment MUST use [`try_put`]**, which returns a `Result` so the
+    /// caller can confirm the write landed. This infallible shim is for callers
+    /// that hold the `SecureStore` trait object and have no error channel.
+    fn put(&mut self, id: &str, bytes: &[u8]) {
+        if let Err(e) = self.try_put(id, bytes) {
+            // `e` is secret-free by construction (FileStoreError carries no key
+            // bytes / plaintext / ciphertext). The id is a non-secret lookup key.
+            eprintln!("friday-crypto FileSecureStore: put failed for id={id}: {e}");
+        }
+    }
+
+    /// Fail-closed delete: delegates to [`try_delete`]. On error logs secret-free
+    /// and swallows (no panic in a trait method).
+    fn delete(&mut self, id: &str) {
+        if let Err(e) = self.try_delete(id) {
+            eprintln!("friday-crypto FileSecureStore: delete failed for id={id}: {e}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
+
+    /// Unique temp dir per test (no `tempfile` dep — workspace minimal-dep
+    /// convention). Created under the OS temp dir; cleaned at drop.
+    struct TempDir {
+        path: PathBuf,
+    }
+
+    impl TempDir {
+        fn new() -> Self {
+            static CTR: AtomicU64 = AtomicU64::new(0);
+            let n = CTR.fetch_add(1, AtomicOrdering::Relaxed);
+            let mut path = std::env::temp_dir();
+            path.push(format!(
+                "friday-securestore-test-{}-{}",
+                std::process::id(),
+                n,
+            ));
+            fs::create_dir_all(&path).unwrap();
+            Self { path }
+        }
+        fn child(&self, name: &str) -> PathBuf {
+            self.path.join(name)
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    const ID: &str = "friday:execrun:ws:s-f:peer-pubkey-allowlist:v1";
+
+    #[test]
+    fn round_trip_fallible_and_trait() {
+        let td = TempDir::new();
+        let dir = td.child("store");
+        let kek = Kek::generate();
+        let mut s = FileSecureStore::open(&dir, kek.clone()).unwrap();
+
+        // fallible path
+        s.try_put(ID, b"pubkey-allowlist-bytes").unwrap();
+        assert_eq!(
+            s.try_get(ID).unwrap().as_deref(),
+            Some(&b"pubkey-allowlist-bytes"[..])
+        );
+
+        // trait path
+        s.put("other", b"v2");
+        assert_eq!(s.get("other").as_deref(), Some(&b"v2"[..]));
+    }
+
+    #[test]
+    fn persists_across_reopen() {
+        let td = TempDir::new();
+        let dir = td.child("store");
+        let kek = Kek::generate();
+        {
+            let mut s = FileSecureStore::open(&dir, kek.clone()).unwrap();
+            s.try_put(ID, b"survives-restart").unwrap();
+        }
+        // Fresh instance, same dir + same KEK.
+        let s2 = FileSecureStore::open(&dir, kek.clone()).unwrap();
+        assert_eq!(
+            s2.try_get(ID).unwrap().as_deref(),
+            Some(&b"survives-restart"[..])
+        );
+    }
+
+    #[test]
+    fn wrong_kek_fails_closed() {
+        let td = TempDir::new();
+        let dir = td.child("store");
+        let kek = Kek::generate();
+        {
+            let mut s = FileSecureStore::open(&dir, kek).unwrap();
+            s.try_put(ID, b"secret-value").unwrap();
+        }
+        let wrong = Kek::generate();
+        let s2 = FileSecureStore::open(&dir, wrong).unwrap();
+        // try_get errors (present-but-unreadable); trait get → None.
+        assert!(matches!(s2.try_get(ID), Err(FileStoreError::Crypto(_))));
+        assert_eq!(s2.get(ID), None);
+    }
+
+    #[test]
+    fn tampered_ciphertext_fails_closed() {
+        let td = TempDir::new();
+        let dir = td.child("store");
+        let kek = Kek::generate();
+        let mut s = FileSecureStore::open(&dir, kek.clone()).unwrap();
+        s.try_put(ID, b"do-not-tamper").unwrap();
+
+        let path = s.entry_path(ID);
+        let mut bytes = fs::read(&path).unwrap();
+        // Flip the LAST byte — guaranteed to be inside the value ciphertext/tag,
+        // never the framing.
+        let last = bytes.len() - 1;
+        bytes[last] ^= 0x01;
+        fs::write(&path, &bytes).unwrap();
+
+        assert!(s.try_get(ID).is_err());
+        assert_eq!(s.get(ID), None);
+    }
+
+    #[test]
+    fn entry_id_swap_fails_closed() {
+        let td = TempDir::new();
+        let dir = td.child("store");
+        let kek = Kek::generate();
+        let mut s = FileSecureStore::open(&dir, kek.clone()).unwrap();
+
+        let id_a = "friday:secure:A";
+        let id_b = "friday:secure:B";
+        s.try_put(id_a, b"value-A").unwrap();
+        // Ensure B is absent.
+        assert_eq!(s.try_get(id_b).unwrap(), None);
+
+        // Whole-file copy A → B's filename. The bytes decrypt under the KEK (the
+        // wrapped key is fine) but the value AAD carries id_a; reading as id_b
+        // supplies a different AAD → open() fails on the AEAD tag.
+        let path_a = s.entry_path(id_a);
+        let path_b = s.entry_path(id_b);
+        fs::copy(&path_a, &path_b).unwrap();
+
+        match s.try_get(id_b) {
+            Err(FileStoreError::Crypto(CryptoError::Open)) => {}
+            other => panic!("expected AAD-bind Open failure under swapped id, got {other:?}"),
+        }
+        assert_eq!(s.get(id_b), None);
+        // A still reads fine.
+        assert_eq!(s.try_get(id_a).unwrap().as_deref(), Some(&b"value-A"[..]));
+    }
+
+    #[test]
+    fn bad_version_fails_closed() {
+        let td = TempDir::new();
+        let dir = td.child("store");
+        let kek = Kek::generate();
+        let mut s = FileSecureStore::open(&dir, kek.clone()).unwrap();
+        s.try_put(ID, b"v1-value").unwrap();
+
+        let path = s.entry_path(ID);
+        let mut bytes = fs::read(&path).unwrap();
+        bytes[0] = 0xFF; // unknown version
+        fs::write(&path, &bytes).unwrap();
+
+        assert!(matches!(s.try_get(ID), Err(FileStoreError::Version)));
+        assert_eq!(s.get(ID), None);
+    }
+
+    #[test]
+    fn truncated_file_fails_closed() {
+        let td = TempDir::new();
+        let dir = td.child("store");
+        let kek = Kek::generate();
+        let mut s = FileSecureStore::open(&dir, kek.clone()).unwrap();
+        s.try_put(ID, b"some-value").unwrap();
+
+        let path = s.entry_path(ID);
+        let bytes = fs::read(&path).unwrap();
+        // Keep only the version byte + a couple bytes: every length prefix now
+        // overruns → Format, no panic.
+        fs::write(&path, &bytes[..3]).unwrap();
+
+        assert!(matches!(s.try_get(ID), Err(FileStoreError::Format)));
+        assert_eq!(s.get(ID), None);
+    }
+
+    #[test]
+    fn missing_entry_is_none_not_error() {
+        let td = TempDir::new();
+        let dir = td.child("store");
+        let s = FileSecureStore::open(&dir, Kek::generate()).unwrap();
+        // try_get distinguishes missing (Ok(None)) from unreadable (Err).
+        assert!(matches!(s.try_get("never-written"), Ok(None)));
+        assert_eq!(s.get("never-written"), None);
+    }
+
+    #[test]
+    fn perms_are_0600_file_and_0700_dir() {
+        let td = TempDir::new();
+        let dir = td.child("store");
+        let mut s = FileSecureStore::open(&dir, Kek::generate()).unwrap();
+        s.try_put(ID, b"x").unwrap();
+
+        let dir_mode = fs::metadata(&dir).unwrap().permissions().mode() & 0o777;
+        assert_eq!(dir_mode, DIR_MODE, "dir must be 0700, got {dir_mode:o}");
+
+        let file_mode = fs::metadata(s.entry_path(ID)).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            file_mode, FILE_MODE,
+            "entry file must be 0600, got {file_mode:o}"
+        );
+    }
+
+    #[test]
+    fn open_repermissions_preexisting_loose_dir() {
+        let td = TempDir::new();
+        let dir = td.child("store");
+        fs::create_dir_all(&dir).unwrap();
+        fs::set_permissions(&dir, fs::Permissions::from_mode(0o755)).unwrap();
+
+        // open must tighten it to 0700.
+        let _s = FileSecureStore::open(&dir, Kek::generate()).unwrap();
+        let mode = fs::metadata(&dir).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, DIR_MODE, "open must enforce 0700, got {mode:o}");
+    }
+
+    #[test]
+    fn delete_removes_entry() {
+        let td = TempDir::new();
+        let dir = td.child("store");
+        let mut s = FileSecureStore::open(&dir, Kek::generate()).unwrap();
+        s.try_put(ID, b"to-be-deleted").unwrap();
+        assert!(s.try_get(ID).unwrap().is_some());
+
+        s.try_delete(ID).unwrap();
+        assert_eq!(s.try_get(ID).unwrap(), None);
+        assert_eq!(s.get(ID), None);
+        // delete of an absent entry is idempotent.
+        s.try_delete(ID).unwrap();
+        s.delete(ID); // trait delete, no panic
+    }
+
+    #[test]
+    fn trait_put_does_not_panic_on_error() {
+        let td = TempDir::new();
+        let dir = td.child("store");
+        let mut s = FileSecureStore::open(&dir, Kek::generate()).unwrap();
+
+        // Make the dir unwritable so create_new in the temp path hits EACCES.
+        fs::set_permissions(&dir, fs::Permissions::from_mode(0o500)).unwrap();
+
+        // The CORE invariant under test (the task requirement): the infallible
+        // trait methods must NOT panic on an error path. This holds regardless of
+        // uid.
+        s.put(ID, b"value"); // must not panic
+        s.delete(ID); // also must not panic on the read-only dir
+
+        // The stronger assertions below — that the error path is actually
+        // exercised (try_put errors, no entry written) — depend on DAC blocking
+        // the write. Root bypasses DAC (a 0o500 dir is still writable as root, so
+        // create_new would SUCCEED), which would make these spuriously fail in a
+        // root-based CI container. Guard them on euid != 0; the no-panic checks
+        // above already cover the task's actual requirement for the root case.
+        if unsafe { libc::geteuid() } != 0 {
+            // try_put surfaces the error...
+            assert!(s.try_put(ID, b"value").is_err());
+            // Restore perms so the entry (correctly) is still absent and TempDir can clean up.
+            fs::set_permissions(&dir, fs::Permissions::from_mode(0o700)).unwrap();
+            assert_eq!(
+                s.try_get(ID).unwrap(),
+                None,
+                "no entry should have been written"
+            );
+        } else {
+            // Restore perms so TempDir can clean up.
+            fs::set_permissions(&dir, fs::Permissions::from_mode(0o700)).unwrap();
+        }
+    }
+
+    #[test]
+    fn overwrite_replaces_value() {
+        let td = TempDir::new();
+        let dir = td.child("store");
+        let mut s = FileSecureStore::open(&dir, Kek::generate()).unwrap();
+        s.try_put(ID, b"first").unwrap();
+        s.try_put(ID, b"second").unwrap();
+        assert_eq!(s.try_get(ID).unwrap().as_deref(), Some(&b"second"[..]));
+    }
+}

--- a/rust-core/crates/friday-crypto/src/lib.rs
+++ b/rust-core/crates/friday-crypto/src/lib.rs
@@ -26,6 +26,7 @@ use zeroize::ZeroizeOnDrop;
 
 pub mod approval;
 pub mod ed25519_approval;
+pub mod file_store;
 pub mod pairing;
 pub mod session;
 pub use approval::{action_digest, sign_approval, verify_approval_signature};
@@ -33,6 +34,7 @@ pub use ed25519_approval::{
     verify_ed25519_approval, verify_ed25519_approval_hex, ApprovalScheme, ApprovalSig,
     ApprovalSignature, Ed25519Error, OperatorSigningKey, OperatorVerifyingKey,
 };
+pub use file_store::{FileSecureStore, FileStoreError};
 pub use pairing::{pairing_proof, verify_pairing_proof};
 pub use session::DeviceKeypair;
 


### PR DESCRIPTION
## What

First slice of the **execrun production-enablement substrate** (operator-chosen Option 1: build the reusable axis-2 substrate → one-time synthetic prod-vertical proof; real-traffic wiring queued separately). This adds `FileSecureStore` — a persistent, encrypted, file-based backend implementing the existing `SecureStore` trait in `friday-crypto`. It is the durable store that will hold the WS peer-pubkey allowlist (id `friday:execrun:ws:s-f:peer-pubkey-allowlist:v1`) that gates the Rust agent-run auth boundary. Replaces the process-local `InMemorySecureStore` for prod (a later slice wires the server `main`; an enrollment CLI writes to it).

**Fully DARK**: pure crypto+file component, not yet wired into any server `main` or route. Zero behavior change. `InMemorySecureStore` untouched.

## Design
- **KEK injected** (not read from any key file here) → slice is pure, testable crypto+file; key-sourcing lives in a later shared helper.
- **Two tiers**: fallible inherent `try_get/try_put/try_delete` (the enrollment CLI must know a write succeeded) + a **fail-closed** `SecureStore` trait (`get` → `None` on any IO/decrypt/version/AAD error; `put`/`delete` log secret-free + swallow, never panic).
- **On-disk**: one file per id (`hex(sha256("…id-v1"||id))`); `version(0x01) || Sealed(wrapped DataKey) || Sealed(value)`; every length prefix bounds-checked. Per-entry random `DataKey` `seal`ing the value, `wrap_data_key`ped under the KEK. **Value AAD binds id+version** → cross-id swap / header downgrade fail-closed. Reuses audited `seal`/`open`/`wrap_data_key` (no hand-rolled AEAD).
- **Durability/perms**: temp `O_CREAT|O_EXCL|O_NOFOLLOW` 0600 → write → fsync → atomic rename → parent-dir fsync; dir 0700, files 0600.

## Verification
- `cargo test -p friday-crypto`: 52 + 3 pass, 0 fail · `cargo fmt --all --check`: clean · `cargo clippy -p friday-crypto --all-targets -- -D warnings`: 0 · `cargo build --workspace`: clean.
- 15 adversarial unit tests (cross-id swap, tamper, wrong-KEK, version downgrade, truncated/oversized framing, perms, no-panic trait shims).

## Adversarial review
**CLEAR-TO-MERGE (0 HIGH, 0 merge-blocking MED).** The crypto construction held against every swap/downgrade/confusion variant; framing fully bounds-checked (no panic path); fail-closed `get`/`try_get` correct; no secret in any log/`Debug`/`Display`. The two LOW findings (dir-perm umask window; dir-fsync durability) are **hardened in `e0867e6b`**.

### ⚠️ Carry-forward (operator sign-off at cutover)
Same-id **rollback** is undefended by design — restoring a prior-valid same-id file opens cleanly = re-admitting a previously-revoked peer pubkey. Reduces to "owner/0700-dir compromised or a backup restorable by an adversary" under the single-owner model. Recorded as an acceptance criterion that graduates with the server-wiring slice + needs operator acknowledgment at cutover (NOT a slice-1 code fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)