### PR TITLE
feat(execrun-enablement): slice 4 — env knob for routeAgentRunViaRust (dark, default-off)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -905,14 +905,14 @@
         "filename": "test/unit/hub/friday-hub-bootstrap-env.test.ts",
         "hashed_secret": "5c5a15a8b0b3e154d77746945e563ba40100681b",
         "is_verified": false,
-        "line_number": 127
+        "line_number": 131
       },
       {
         "type": "Secret Keyword",
         "filename": "test/unit/hub/friday-hub-bootstrap-env.test.ts",
         "hashed_secret": "8a8281cec699f5e51330e21dd7fab3531af6ef0c",
         "is_verified": false,
-        "line_number": 128
+        "line_number": 132
       }
     ],
     "test/unit/media-understanding/friday-openai-vision-provider.test.ts": [
@@ -1124,5 +1124,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-07T08:39:49Z"
+  "generated_at": "2026-06-09T17:28:28Z"
 }

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -4254,6 +4254,17 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
       deps.rustAgentRunWsClientSecretResolver ?? resolveRustAgentRunWsClientX25519Secret;
     const rustHubDbPath = deps.rustAgentRunHubDbPath ?? process.env.FRIDAY_HUB_AGENT_RUN_DB_PATH;
 
+    // OPERATOR ENV KNOBS for this dark Rust read-only execrun route (kept discoverable
+    // together here, alongside the WS host/port + DB path siblings above):
+    //   FRIDAY_HUB_AGENT_RUN_WS_HOST  — sealed-WS host  (default 127.0.0.1)        [above]
+    //   FRIDAY_HUB_AGENT_RUN_WS_PORT  — sealed-WS port                              [above]
+    //   FRIDAY_HUB_AGENT_RUN_DB_PATH  — Rust hub DB path for answer readback        [above]
+    //   FRIDAY_ROUTE_AGENT_RUN_VIA_RUST — the master ON/OFF for routing a qualifying
+    //     run to Rust (execrun slice 4). DEFAULT-OFF: unset/""/"0"/"false"/garbage → off;
+    //     case-insensitive "1"/"true" → on. It is NOT read here — its resolve + precedence
+    //     (an explicit HubConfig.routeAgentRunViaRust wins over the env) live in ONE place,
+    //     `resolveRouteAgentRunViaRust` in friday-hub-bootstrap.ts, which feeds
+    //     `deps.routeAgentRunViaRust`. The gate just below checks that resolved boolean.
     const routeStartRun: typeof startRun = async (input) => {
       if (deps.routeAgentRunViaRust === true) {
         const qualifies = qualifiesForRustReadOnlyRoute({

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -891,6 +891,38 @@ export function resolveFridayCanonicalMutatingActionGate(
   return protectedProfile;
 }
 
+/**
+ * execrun-replacement slice 4 (DARK): single source of truth resolving the per-run
+ * `routeAgentRunViaRust` flag from (1) an EXPLICIT {@link FridayHubConfig.routeAgentRunViaRust}
+ * and, only as a fallback, (2) the `FRIDAY_ROUTE_AGENT_RUN_VIA_RUST` env var — the operator
+ * knob that lets the Rust read-only execrun route be flipped WITHOUT a source edit.
+ *
+ * PRECEDENCE: an explicit config boolean (true OR false) ALWAYS wins; the env is consulted
+ * ONLY when config does not specify (the previously-unsettable gap). This preserves the
+ * prior `config.routeAgentRunViaRust` precedence exactly.
+ *
+ * PARSE (fail-safe OFF): case-insensitive, trimmed `"1"` or `"true"` ⇒ true; ABSENT, `""`,
+ * `"0"`, `"false"`, or ANY other value ⇒ false. DEFAULT (env unset, config unset) ⇒ false,
+ * so the downstream `deps.routeAgentRunViaRust === true` gate stays off → byte-identical to
+ * today's fail-closed 503. Intentionally NARROWER than the canonical-gate true-set
+ * (no yes/on/enabled) so any ambiguity resolves OFF.
+ *
+ * The sibling `FRIDAY_HUB_AGENT_RUN_*` knobs (WS host/port, DB path) are read and documented
+ * at the deps/runtime construction point in `friday-api-runtime.ts`; this flag's resolve +
+ * precedence live here, at the bootstrap point where the value flows into the runtime deps.
+ */
+export function resolveRouteAgentRunViaRust(
+  configValue: boolean | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  // Config explicit (true OR false) wins — env is the fallback for the unset gap only.
+  if (typeof configValue === "boolean") {
+    return configValue;
+  }
+  const raw = (env.FRIDAY_ROUTE_AGENT_RUN_VIA_RUST ?? "").trim().toLowerCase();
+  return raw === "1" || raw === "true";
+}
+
 function normalizeFridayHubPort(value: number | undefined): number | undefined {
   if (typeof value !== "number" || !Number.isInteger(value) || value < 1 || value > 65535) {
     return undefined;
@@ -6931,9 +6963,13 @@ export async function createFridayHub(
     allowTestOnlyWorkflowBuilderDraftExecution: config.allowTestOnlyWorkflowBuilderDraftExecution,
     agentRuntime,
     allowTestOnlyAgentRunStartExecution: config.allowTestOnlyAgentRunStartExecution,
-    // execrun-replacement slice 4 (DARK): default-false per-run Rust-route flag. Unset in
-    // production → predicate never evaluated → byte-identical to today.
-    routeAgentRunViaRust: config.routeAgentRunViaRust,
+    // execrun-replacement slice 4 (DARK): default-false per-run Rust-route flag. SINGLE
+    // SOURCE OF TRUTH for its resolution = `resolveRouteAgentRunViaRust`: an explicit config
+    // boolean wins; otherwise the `FRIDAY_ROUTE_AGENT_RUN_VIA_RUST` env knob fills the gap
+    // (case-insensitive "1"/"true" → true; anything else, incl. unset → false). With nothing
+    // set (the default) this is `false`, so the `=== true` gate is never satisfied → the
+    // predicate is never evaluated → byte-identical to today's fail-closed 503.
+    routeAgentRunViaRust: resolveRouteAgentRunViaRust(config.routeAgentRunViaRust),
     allowTestOnlyAgentRunControlExecution: config.allowTestOnlyAgentRunControlExecution,
     allowTestOnlyAutonomyLifecycleExecution: config.allowTestOnlyAutonomyLifecycleExecution,
     allowTestOnlyStandingAgendaExecution: config.allowTestOnlyStandingAgendaExecution,

--- a/src/hub/index.ts
+++ b/src/hub/index.ts
@@ -37,6 +37,7 @@ export {
   resolveFridayChannelDisabledToolNames,
   resolveFridayChannelSessionKey,
   resolveFridayHubConfig,
+  resolveRouteAgentRunViaRust,
   sanitizeFridayChannelVisibleReply,
   shouldFailClosedForFridayWorkspaceContext,
   resolveTokenSecret,

--- a/test/unit/hub/friday-hub-bootstrap-env.test.ts
+++ b/test/unit/hub/friday-hub-bootstrap-env.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { createRequire } from "node:module";
-import { resolveFridayCanonicalMutatingActionGate, resolveFridayHubConfig } from "#hub";
+import {
+  resolveFridayCanonicalMutatingActionGate,
+  resolveFridayHubConfig,
+  resolveRouteAgentRunViaRust,
+} from "#hub";
 import type { FridayHubConfig } from "#hub";
 
 // ─── Helpers ───
@@ -341,5 +345,55 @@ describe("resolveFridayHubConfig", () => {
     expect(() => resolveFridayCanonicalMutatingActionGate({
       FRIDAY_CANONICAL_GATE: "sometimes",
     })).toThrow(/Invalid FRIDAY_CANONICAL_GATE/);
+  });
+});
+
+// ─── execrun slice 4: routeAgentRunViaRust env knob (DARK, default-off) ───
+
+describe("resolveRouteAgentRunViaRust", () => {
+  // DEFAULT-OFF: env unset (nothing set) → false → byte-identical to today's gated-off 503.
+  it("defaults to false when neither config nor env is set", () => {
+    expect(resolveRouteAgentRunViaRust(undefined, emptyEnv())).toBe(false);
+  });
+
+  it("parses FRIDAY_ROUTE_AGENT_RUN_VIA_RUST=1 as true", () => {
+    expect(resolveRouteAgentRunViaRust(undefined, { FRIDAY_ROUTE_AGENT_RUN_VIA_RUST: "1" })).toBe(true);
+  });
+
+  it("parses FRIDAY_ROUTE_AGENT_RUN_VIA_RUST=true as true", () => {
+    expect(resolveRouteAgentRunViaRust(undefined, { FRIDAY_ROUTE_AGENT_RUN_VIA_RUST: "true" })).toBe(true);
+  });
+
+  it("parses the env case-insensitively (TRUE, True) and trims surrounding whitespace", () => {
+    expect(resolveRouteAgentRunViaRust(undefined, { FRIDAY_ROUTE_AGENT_RUN_VIA_RUST: "TRUE" })).toBe(true);
+    expect(resolveRouteAgentRunViaRust(undefined, { FRIDAY_ROUTE_AGENT_RUN_VIA_RUST: "True" })).toBe(true);
+    expect(resolveRouteAgentRunViaRust(undefined, { FRIDAY_ROUTE_AGENT_RUN_VIA_RUST: "  1  " })).toBe(true);
+    expect(resolveRouteAgentRunViaRust(undefined, { FRIDAY_ROUTE_AGENT_RUN_VIA_RUST: " true " })).toBe(true);
+  });
+
+  // Fail-safe OFF: everything that is not exactly "1"/"true" → false.
+  it("treats 0, false, empty, and garbage env values as false (fail-safe off)", () => {
+    expect(resolveRouteAgentRunViaRust(undefined, { FRIDAY_ROUTE_AGENT_RUN_VIA_RUST: "0" })).toBe(false);
+    expect(resolveRouteAgentRunViaRust(undefined, { FRIDAY_ROUTE_AGENT_RUN_VIA_RUST: "false" })).toBe(false);
+    expect(resolveRouteAgentRunViaRust(undefined, { FRIDAY_ROUTE_AGENT_RUN_VIA_RUST: "" })).toBe(false);
+    expect(resolveRouteAgentRunViaRust(undefined, { FRIDAY_ROUTE_AGENT_RUN_VIA_RUST: "yes" })).toBe(false);
+    expect(resolveRouteAgentRunViaRust(undefined, { FRIDAY_ROUTE_AGENT_RUN_VIA_RUST: "on" })).toBe(false);
+    expect(resolveRouteAgentRunViaRust(undefined, { FRIDAY_ROUTE_AGENT_RUN_VIA_RUST: "enabled" })).toBe(false);
+    expect(resolveRouteAgentRunViaRust(undefined, { FRIDAY_ROUTE_AGENT_RUN_VIA_RUST: "truthy" })).toBe(false);
+    expect(resolveRouteAgentRunViaRust(undefined, { FRIDAY_ROUTE_AGENT_RUN_VIA_RUST: "2" })).toBe(false);
+  });
+
+  // PRECEDENCE: an explicit config boolean ALWAYS wins over the env.
+  it("uses explicit config true over the env (even when env says false)", () => {
+    expect(resolveRouteAgentRunViaRust(true, { FRIDAY_ROUTE_AGENT_RUN_VIA_RUST: "false" })).toBe(true);
+    expect(resolveRouteAgentRunViaRust(true, { FRIDAY_ROUTE_AGENT_RUN_VIA_RUST: "0" })).toBe(true);
+    expect(resolveRouteAgentRunViaRust(true, emptyEnv())).toBe(true);
+  });
+
+  // The discriminating case: config=false MUST beat env=true (a `||` would wrongly return true here).
+  it("uses explicit config false over the env (config false beats env true)", () => {
+    expect(resolveRouteAgentRunViaRust(false, { FRIDAY_ROUTE_AGENT_RUN_VIA_RUST: "1" })).toBe(false);
+    expect(resolveRouteAgentRunViaRust(false, { FRIDAY_ROUTE_AGENT_RUN_VIA_RUST: "true" })).toBe(false);
+    expect(resolveRouteAgentRunViaRust(false, emptyEnv())).toBe(false);
   });
 });


### PR DESCRIPTION
## What
Slice 4 of the execrun production-enablement substrate (operator-chosen Option 1). Gives the operator an **env knob** to flip the Rust read-only execrun route without a source edit: `FRIDAY_ROUTE_AGENT_RUN_VIA_RUST`. **Default OFF** (fail-safe = today's 503).

Until now `routeAgentRunViaRust` (the HubConfig flag gating the Rust route) had no env/config source — only a source edit could set it. This adds a single resolver:

```ts
// src/hub/friday-hub-bootstrap.ts
export function resolveRouteAgentRunViaRust(configValue, env = process.env): boolean {
  if (typeof configValue === "boolean") return configValue;       // explicit config wins (true OR false)
  const raw = (env.FRIDAY_ROUTE_AGENT_RUN_VIA_RUST ?? "").trim().toLowerCase();
  return raw === "1" || raw === "true";                            // else fail-safe-off env parse
}
```
Wired at the bootstrap deps-construction point (`:6972`, was the bare `config.routeAgentRunViaRust`).

## Default-off is byte-identical (the safety guarantee)
`deps.routeAgentRunViaRust` is read at **exactly one place** — `src/api/runtime/friday-api-runtime.ts:4269`, `if (deps.routeAgentRunViaRust === true)`. With the env unset the resolver returns `false`; at a strict `=== true` gate `false` and today's `undefined` are indistinguishable → the predicate is never evaluated → today's fail-closed 503 fires unchanged. (Independently grep-verified: the only other reference is the `:6972` assignment.)

## Precedence + parse
- **Config wins over env** via `typeof configValue === "boolean"` (so an explicit config `false` correctly beats env `"1"` — a `||` would get this wrong; a dedicated test asserts it).
- **Fail-safe-off parse**: trimmed/case-insensitive `"1"`/`"true"` → true; unset/`""`/`"0"`/`"false"`/garbage → false.

## Verification
- `npm run typecheck`: clean. `npm run lint` (eslint): **0 errors** (only pre-existing warnings, none in touched files). `vitest test/unit/hub/friday-hub-bootstrap-env.test.ts`: **48 passed** (41 pre-existing + 7 new covering default-off, on/off/case/trim/garbage, config-wins-both-directions).
- The `=== true` gate and the qualifying predicate are untouched; this slice only fills the previously-unsettable env gap. `.env.example` intentionally not touched (the dark `FRIDAY_HUB_AGENT_RUN_*` siblings are omitted there by convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)