### PR TITLE
feat(rust-workflow): S8 — workflow definition serde + storage + loader + linear-only TS-subset translation (dark)

### DIFF
--- a/.github/workflows/rust-core.yml
+++ b/.github/workflows/rust-core.yml
@@ -70,6 +70,14 @@ jobs:
         # separate live-proof), so it is never executed in CI. The unit tests use a
         # scripted MOCK provider (no key, no quota, no network).
         run: cargo build -p friday-hub --bin hub_extract_memory
+      - name: Build bins (incl. read-only hub_workflow_def_inspect surface)
+        # Read-only refs-only inspector of the S8 workflow_definition store: names the
+        # bin explicitly so a missing/compile-broken `hub_workflow_def_inspect` reds CI
+        # loudly. Only BUILT here — running it opens a hub DB read-only (strict
+        # schema-version equality) and emits refs-only counts/labels through the shared
+        # forbidden-marker guard (no bodies, no model call, no quota, no network, no
+        # secret), so it is safe but unnecessary to execute in CI.
+        run: cargo build -p friday-hub --bin hub_workflow_def_inspect
       - name: Test
         # The one live DeepSeek test is #[ignore]d, so this needs no network/secrets.
         run: cargo test --workspace

--- a/rust-core/crates/friday-hub/src/bin/hub_workflow_def_inspect.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_workflow_def_inspect.rs
@@ -1,0 +1,188 @@
+//! S8 dev inspect bin — `hub_workflow_def_inspect`.
+//!
+//! PROOF-ONLY (Rust-wired-DEV), mirroring the `hub_run_readback` house pattern:
+//! opens the hub DB READ-ONLY ([`friday_storage::Db::open_hub_readonly`]), emits
+//! a refs-only JSON projection of the stored workflow DEFINITIONS, and runs the
+//! output through the shared forbidden-marker guard before printing.
+//!
+//! This is NOT a production route, NOT a TS integration, and confers no v1 GO —
+//! workflow execution remains fenced in TS and is NOT product-replaced. It
+//! exists so a developer/coordinator can inspect the S8 definition store
+//! (versions, published flags, provenance, fingerprints) without ever
+//! transporting a definition body.
+//!
+//! ## Output contract — REFS ONLY (no bodies, no secrets, no PII)
+//! One JSON object on stdout carrying ONLY safe identifiers/labels:
+//! `truth_label="rust_wired_dev"`, the definition summaries (workflow_id /
+//! version / name label / sha256 checksum / source label / is_published /
+//! created_at_ms) and counts. The body-bearing columns (`definition_json`,
+//! `source_meta`) are NEVER selected (the storage summary type does not carry
+//! them), and the [`reject_forbidden_output`] guard fails the WHOLE projection
+//! closed if any forbidden marker ever appears.
+//!
+//! Usage: `hub_workflow_def_inspect --db <hub.sqlite> [--workflow-id <id>]`
+
+use std::env;
+use std::path::Path;
+
+use friday_storage::workflow_def::list_definitions;
+use friday_storage::Db;
+use serde_json::json;
+
+/// Fail-closed error: only a coarse, safe category is surfaced (no raw detail,
+/// so storage/IO errors cannot leak paths).
+struct InspectError {
+    kind: &'static str,
+}
+
+impl InspectError {
+    fn new(kind: &'static str) -> Self {
+        Self { kind }
+    }
+}
+
+fn main() {
+    match run() {
+        Ok(rendered) => println!("{rendered}"),
+        Err(err) => {
+            let payload = json!({
+                "truth_label": "rust_wired_dev",
+                "proof_only": true,
+                "ok": false,
+                "error_kind": err.kind,
+            });
+            let rendered = payload.to_string();
+            if reject_forbidden_output(&rendered).is_ok() {
+                println!("{rendered}");
+            }
+            eprintln!("hub_workflow_def_inspect_unavailable: {}", err.kind);
+            std::process::exit(2);
+        }
+    }
+}
+
+fn run() -> Result<String, InspectError> {
+    let args: Vec<String> = env::args().collect();
+    let db_path = arg_value(&args, "--db").ok_or(InspectError::new("bad_args"))?;
+    if !Path::new(&db_path).is_file() {
+        return Err(InspectError::new("db_not_found"));
+    }
+    let workflow_filter = arg_value(&args, "--workflow-id");
+
+    // Read-only open: inspection can NEVER mutate an operator DB.
+    let db = Db::open_hub_readonly(&db_path).map_err(|_| InspectError::new("open_failed"))?;
+
+    let mut summaries =
+        list_definitions(db.conn()).map_err(|_| InspectError::new("read_failed"))?;
+    if let Some(filter) = &workflow_filter {
+        summaries.retain(|s| &s.workflow_id == filter);
+    }
+
+    let definitions: Vec<serde_json::Value> = summaries
+        .iter()
+        .map(|s| {
+            json!({
+                "workflow_id": s.workflow_id,
+                "version": s.version,
+                "name": s.name,
+                "checksum_sha256": s.checksum,
+                "source": s.source.as_str(),
+                "is_published": s.is_published,
+                "created_at_ms": s.created_at,
+            })
+        })
+        .collect();
+    let published_count = summaries.iter().filter(|s| s.is_published).count();
+
+    let payload = json!({
+        "truth_label": "rust_wired_dev",
+        "proof_only": true,
+        "ok": true,
+        "definition_count": definitions.len(),
+        "published_count": published_count,
+        "definitions": definitions,
+    });
+
+    let rendered =
+        serde_json::to_string(&payload).map_err(|_| InspectError::new("serialize_failed"))?;
+    reject_forbidden_output(&rendered)?;
+    Ok(rendered)
+}
+
+fn arg_value(args: &[String], name: &str) -> Option<String> {
+    args.windows(2)
+        .find_map(|pair| (pair[0] == name).then(|| pair[1].clone()))
+        .or_else(|| {
+            let prefix = format!("{name}=");
+            args.iter()
+                .find_map(|arg| arg.strip_prefix(&prefix).map(str::to_string))
+        })
+}
+
+/// Defense-in-depth: refuse to print if any forbidden marker leaked into the
+/// refs-only projection. Beyond the shared secret/path markers, this bin's
+/// body-bearing fields (`definition_json`, `source_meta`) must never appear —
+/// only summaries do.
+fn reject_forbidden_output(rendered: &str) -> Result<(), InspectError> {
+    friday_hub::refs_guard::reject_forbidden_output(
+        rendered,
+        &["\"definition_json\"", "\"source_meta\""],
+    )
+    .map_err(|_| InspectError::new("output_guard"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{from_str, Value};
+
+    #[test]
+    fn arg_value_supports_space_and_equals_forms() {
+        let args = vec![
+            "bin".to_string(),
+            "--db".to_string(),
+            "/tmp/hub.sqlite".to_string(),
+            "--workflow-id=wf-1".to_string(),
+        ];
+        assert_eq!(arg_value(&args, "--db").as_deref(), Some("/tmp/hub.sqlite"));
+        assert_eq!(arg_value(&args, "--workflow-id").as_deref(), Some("wf-1"));
+        assert_eq!(arg_value(&args, "--missing"), None);
+    }
+
+    #[test]
+    fn forbidden_output_guard_blocks_bodies_and_secret_markers() {
+        assert!(reject_forbidden_output(r#"{"definition_json":"{...}"}"#).is_err());
+        assert!(reject_forbidden_output(r#"{"source_meta":"{...}"}"#).is_err());
+        assert!(reject_forbidden_output(r#"{"x":"Bearer abc"}"#).is_err());
+        assert!(reject_forbidden_output(r#"{"k":"/Users/jarvis/x"}"#).is_err());
+    }
+
+    #[test]
+    fn refs_only_payload_shape_passes_the_guard() {
+        let payload = json!({
+            "truth_label": "rust_wired_dev",
+            "proof_only": true,
+            "ok": true,
+            "definition_count": 1,
+            "published_count": 1,
+            "definitions": [{
+                "workflow_id": "wf-1",
+                "version": 2,
+                "name": "research",
+                "checksum_sha256": "ab".repeat(32),
+                "source": "ts_translated",
+                "is_published": true,
+                "created_at_ms": 100,
+            }],
+        });
+        let rendered = serde_json::to_string(&payload).unwrap();
+        assert!(reject_forbidden_output(&rendered).is_ok());
+        let parsed: Value = from_str(&rendered).unwrap();
+        assert!(
+            parsed.get("definitions").unwrap()[0]
+                .get("definition_json")
+                .is_none(),
+            "must never carry the definition body"
+        );
+    }
+}

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -109,6 +109,20 @@ pub mod planner;
 /// only (no skill/plugin exec). Resume-after-approval is a deferred follow-up.
 pub mod workflow_exec;
 
+/// S8 — workflow DEFINITION layer: versioned serde definition (LINEAR-only) +
+/// storage CRUD over `friday_storage::workflow_def` + the loader that produces the
+/// exact [`planner::WorkflowDefinition`] the EXISTING [`workflow_exec`] engine
+/// consumes (no second executor). DARK substrate: no production route, no
+/// scheduler (S10, operator-gated); workflow execution remains fenced in TS and is
+/// NOT product-replaced; NOT v1 GO.
+pub mod workflow_def;
+
+/// S8 — TS published-version → Rust LINEAR-ONLY workflow translator. Any
+/// DAG/branch/parallel/unsupported source feature fails CLOSED to an explicit
+/// `Unsupported { reasons, preserved_source_meta }` — never a silent flattening,
+/// never partial. Dark substrate; NOT v1 GO.
+pub mod workflow_ts_translate;
+
 /// PAIR-002 — Hub-side local pairing message handler. It consumes the structured
 /// QR payload from PAIR-001 and the first-slice protocol `Pair` message, writes a
 /// trusted device through the existing authenticated pairing proof, and never

--- a/rust-core/crates/friday-hub/src/tool_name_map.rs
+++ b/rust-core/crates/friday-hub/src/tool_name_map.rs
@@ -55,7 +55,10 @@
 //!   - `edit`: TS camelCase `oldText`/`newText` vs Rust snake_case `old_text`/`new_text`.
 //!   - `exec`: TS has `workdir`/`env`/`timeoutMs`/`background`; Rust `run_command` takes
 //!     `command` ONLY (the extras have no Rust executor surface yet → would be dropped).
-//!   - `read`/`write`: param names already align (`path`, `content`).
+//!   - `read`: TS also declares + honors line-window `offset`/`limit`; Rust `read_file`
+//!     reads ONLY `path` (the window args have no Rust surface → must fail closed, never
+//!     be dropped: dropping them silently reads the WHOLE file instead of a window).
+//!   - `write`: param names align (`path`, `content`).
 //!
 //! ## Truth labels
 //! Dark substrate for the executeRun-replacement. `rust_wired` at best: the map + resolver
@@ -193,7 +196,10 @@ pub const PARAM_SCHEMA_DIFFS: &[ParamSchemaDiff] = &[
     ParamSchemaDiff {
         ts: "read",
         rust: "read_file",
-        note: "params align: both use `path`.",
+        note: "both use `path`, but TS `read` also declares AND honors line-window \
+               `offset`/`limit` (1-indexed line slicing); the Rust `read_file` executor \
+               reads ONLY `path`, so the window args have no Rust surface — a forwarding \
+               slice must fail closed on them (dropping them silently reads the whole file).",
     },
     ParamSchemaDiff {
         ts: "write",

--- a/rust-core/crates/friday-hub/src/workflow_def.rs
+++ b/rust-core/crates/friday-hub/src/workflow_def.rs
@@ -1,0 +1,668 @@
+//! S8 — the Rust workflow DEFINITION layer: versioned serde definition format
+//! (LINEAR-only) + the loader that turns a stored definition into the exact
+//! executable form the EXISTING [`crate::workflow_exec`] engine consumes +
+//! definition CRUD over [`friday_storage::workflow_def`].
+//!
+//! ## Scope and truth labels (DARK substrate)
+//! - This is the DEFINITION layer only. It registers NO production route, NO
+//!   scheduler/trigger/daemon (that is S10, operator-gated), and changes NO TS
+//!   runtime file. Workflow execution remains fenced in TS and is NOT
+//!   product-replaced; NOT v1 GO.
+//! - There is NO second executor here: [`load_definition`] produces a
+//!   [`crate::planner::WorkflowDefinition`] — the SAME type
+//!   [`crate::workflow_exec::run_workflow`] already executes through the
+//!   planner + gate chokepoints. The step vocabulary is the planner's
+//!   ([`crate::planner::WorkflowStep`]); this module adds serde + storage on
+//!   top, never a parallel vocabulary.
+//!
+//! ## The stored format: `schema_version`-tagged, linear-only, fail-closed
+//! [`StoredWorkflowDefV1`] is the JSON body persisted in
+//! `workflow_definition.definition_json`. It is an ORDERED list of steps —
+//! linearity is structural (there is no edges/branches field to mis-parse).
+//! Parsing is fail-closed twice over:
+//! - an unknown/missing `schema_version` is an explicit
+//!   [`WorkflowDefError::UnsupportedSchemaVersion`] (a future v2 body never
+//!   half-parses), and
+//! - `deny_unknown_fields` rejects any body carrying fields this version does
+//!   not model (e.g. a DAG-shaped document with `edges`), so an unsupported
+//!   shape can never silently load as a linear workflow.
+//!
+//! The loader additionally re-validates the parsed definition (non-empty
+//! steps, unique non-empty step ids, non-empty actions) and cross-checks the
+//! stored row's `name` column against the body's `name` (a hand-edited
+//! divergent pair fails closed; the storage layer already fails closed on a
+//! checksum mismatch).
+
+use crate::planner::{WorkflowDefinition, WorkflowStep};
+use friday_storage::workflow_def::{
+    create_definition as store_create, get_definition as store_get,
+    get_published_definition as store_get_published, set_published as store_set_published,
+    DefinitionSource, NewWorkflowDefinition, WorkflowDefinitionRow,
+};
+use rusqlite::Connection;
+use serde::{Deserialize, Serialize};
+
+/// The definition-format version this build reads and writes.
+pub const WORKFLOW_DEF_SCHEMA_VERSION: u32 = 1;
+
+/// One stored step — the serde twin of [`crate::planner::WorkflowStep`] (same
+/// fields, same semantics; the planner/gate floors still decide disposition at
+/// run time, so nothing in this format can mark a mutating step "safe").
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct StoredWorkflowStepV1 {
+    pub id: String,
+    /// The Rust [`crate::ToolRegistry`] action name (e.g. `read_file`). An
+    /// unknown action is NOT rejected here — the planner fail-closes it to an
+    /// `Unclassifiable` checkpoint and the gate refuses to dispatch it, the
+    /// same path every other unknown action takes.
+    pub action: String,
+    #[serde(default)]
+    pub params: Vec<(String, String)>,
+    /// Template checkpoint policy — may only NARROW (add a checkpoint), never
+    /// widen; the planner enforces that (`crate::planner::plan_step`).
+    #[serde(default)]
+    pub force_checkpoint: bool,
+    #[serde(default)]
+    pub evidence_required: bool,
+}
+
+/// A versioned, LINEAR-only stored workflow definition (see module docs).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct StoredWorkflowDefV1 {
+    /// Must equal [`WORKFLOW_DEF_SCHEMA_VERSION`]; checked BEFORE strict
+    /// parsing so a future format yields an honest version error.
+    pub schema_version: u32,
+    pub name: String,
+    /// Ordered steps — executed first-to-last by `workflow_exec`. Linearity is
+    /// structural: there is no edge/branch/parallel field in this format.
+    pub steps: Vec<StoredWorkflowStepV1>,
+}
+
+/// Fail-closed errors of the definition layer.
+#[derive(Debug, thiserror::Error)]
+pub enum WorkflowDefError {
+    #[error("workflow definition JSON failed to parse: {0}")]
+    Parse(String),
+    #[error(
+        "unsupported workflow definition schema_version {found} \
+         (this build supports exactly {supported})"
+    )]
+    UnsupportedSchemaVersion { found: u32, supported: u32 },
+    #[error("workflow definition invalid: {0}")]
+    Invalid(String),
+    #[error("workflow definition not found: {0}")]
+    NotFound(String),
+    #[error("storage error: {0}")]
+    Storage(#[from] friday_storage::StorageError),
+}
+
+impl StoredWorkflowDefV1 {
+    /// Build the stored form from the planner's executable form (identity
+    /// mapping plus the schema tag).
+    pub fn from_executable(def: &WorkflowDefinition) -> Self {
+        StoredWorkflowDefV1 {
+            schema_version: WORKFLOW_DEF_SCHEMA_VERSION,
+            name: def.name.clone(),
+            steps: def
+                .steps
+                .iter()
+                .map(|s| StoredWorkflowStepV1 {
+                    id: s.id.clone(),
+                    action: s.action.clone(),
+                    params: s.params.clone(),
+                    force_checkpoint: s.force_checkpoint,
+                    evidence_required: s.evidence_required,
+                })
+                .collect(),
+        }
+    }
+
+    /// Produce the executable form the EXISTING engine
+    /// ([`crate::workflow_exec::run_workflow`]) consumes. Pure mapping — the
+    /// planner + gate still decide every step's disposition at run time.
+    pub fn to_executable(&self) -> WorkflowDefinition {
+        WorkflowDefinition {
+            name: self.name.clone(),
+            steps: self
+                .steps
+                .iter()
+                .map(|s| WorkflowStep {
+                    id: s.id.clone(),
+                    action: s.action.clone(),
+                    params: s.params.clone(),
+                    force_checkpoint: s.force_checkpoint,
+                    evidence_required: s.evidence_required,
+                })
+                .collect(),
+        }
+    }
+
+    /// Structural validation (beyond serde): version tag, non-empty name,
+    /// non-empty step list, unique non-empty step ids, non-empty actions.
+    pub fn validate(&self) -> Result<(), WorkflowDefError> {
+        if self.schema_version != WORKFLOW_DEF_SCHEMA_VERSION {
+            return Err(WorkflowDefError::UnsupportedSchemaVersion {
+                found: self.schema_version,
+                supported: WORKFLOW_DEF_SCHEMA_VERSION,
+            });
+        }
+        if self.name.trim().is_empty() {
+            return Err(WorkflowDefError::Invalid("name must be non-empty".into()));
+        }
+        if self.steps.is_empty() {
+            return Err(WorkflowDefError::Invalid(
+                "a definition must have at least one step (an empty workflow would \
+                 complete vacuously)"
+                    .into(),
+            ));
+        }
+        let mut seen = std::collections::HashSet::new();
+        for (i, step) in self.steps.iter().enumerate() {
+            if step.id.trim().is_empty() {
+                return Err(WorkflowDefError::Invalid(format!(
+                    "steps[{i}] has an empty id"
+                )));
+            }
+            if !seen.insert(step.id.as_str()) {
+                return Err(WorkflowDefError::Invalid(format!(
+                    "duplicate step id '{}'",
+                    step.id
+                )));
+            }
+            if step.action.trim().is_empty() {
+                return Err(WorkflowDefError::Invalid(format!(
+                    "steps[{i}] ('{}') has an empty action",
+                    step.id
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Serialize a validated definition to its canonical stored JSON.
+pub fn definition_to_json(def: &StoredWorkflowDefV1) -> Result<String, WorkflowDefError> {
+    def.validate()?;
+    serde_json::to_string(def).map_err(|e| WorkflowDefError::Parse(e.to_string()))
+}
+
+/// Parse + validate a stored definition body. Fail-closed: the version tag is
+/// probed FIRST (honest error for foreign versions), then the strict
+/// (`deny_unknown_fields`) parse rejects any unsupported shape, then
+/// [`StoredWorkflowDefV1::validate`] re-checks structure.
+pub fn parse_definition_json(json: &str) -> Result<StoredWorkflowDefV1, WorkflowDefError> {
+    #[derive(Deserialize)]
+    struct VersionProbe {
+        schema_version: Option<u32>,
+    }
+    let probe: VersionProbe =
+        serde_json::from_str(json).map_err(|e| WorkflowDefError::Parse(e.to_string()))?;
+    match probe.schema_version {
+        Some(v) if v == WORKFLOW_DEF_SCHEMA_VERSION => {}
+        Some(v) => {
+            return Err(WorkflowDefError::UnsupportedSchemaVersion {
+                found: v,
+                supported: WORKFLOW_DEF_SCHEMA_VERSION,
+            })
+        }
+        None => {
+            return Err(WorkflowDefError::Invalid(
+                "missing schema_version tag".into(),
+            ))
+        }
+    }
+    let def: StoredWorkflowDefV1 =
+        serde_json::from_str(json).map_err(|e| WorkflowDefError::Parse(e.to_string()))?;
+    def.validate()?;
+    Ok(def)
+}
+
+/// CREATE: persist a validated definition as a new immutable version
+/// (unpublished). Returns the derived checksum. A duplicate
+/// `(workflow_id, version)` fails closed at the storage PK.
+pub fn create_definition(
+    conn: &Connection,
+    workflow_id: &str,
+    version: i64,
+    def: &StoredWorkflowDefV1,
+    source: DefinitionSource,
+    source_meta: Option<&str>,
+    now_ms: i64,
+) -> Result<String, WorkflowDefError> {
+    let json = definition_to_json(def)?;
+    Ok(store_create(
+        conn,
+        &NewWorkflowDefinition {
+            workflow_id,
+            version,
+            name: &def.name,
+            definition_json: &json,
+            source,
+            source_meta,
+        },
+        now_ms,
+    )?)
+}
+
+/// CREATE + PUBLISH in one call — the "store-published-version" entry that
+/// mirrors ingesting a TS published version. Returns the derived checksum.
+pub fn store_published_version(
+    conn: &Connection,
+    workflow_id: &str,
+    version: i64,
+    def: &StoredWorkflowDefV1,
+    source: DefinitionSource,
+    source_meta: Option<&str>,
+    now_ms: i64,
+) -> Result<String, WorkflowDefError> {
+    let checksum = create_definition(conn, workflow_id, version, def, source, source_meta, now_ms)?;
+    store_set_published(conn, workflow_id, version)?;
+    Ok(checksum)
+}
+
+/// GET (parsed): read one stored version and parse its body fail-closed.
+pub fn get_parsed_definition(
+    conn: &Connection,
+    workflow_id: &str,
+    version: i64,
+) -> Result<StoredWorkflowDefV1, WorkflowDefError> {
+    let row = store_get(conn, workflow_id, version)?
+        .ok_or_else(|| WorkflowDefError::NotFound(format!("'{workflow_id}' v{version}")))?;
+    parse_row(row)
+}
+
+/// LOADER: load a stored definition by id/version and produce the executable
+/// [`WorkflowDefinition`] the EXISTING [`crate::workflow_exec`] engine consumes.
+pub fn load_definition(
+    conn: &Connection,
+    workflow_id: &str,
+    version: i64,
+) -> Result<WorkflowDefinition, WorkflowDefError> {
+    Ok(get_parsed_definition(conn, workflow_id, version)?.to_executable())
+}
+
+/// LOADER (published): load the PUBLISHED version of a workflow into the
+/// executable form. Fail-closed when no version is published.
+pub fn load_published_definition(
+    conn: &Connection,
+    workflow_id: &str,
+) -> Result<WorkflowDefinition, WorkflowDefError> {
+    let row = store_get_published(conn, workflow_id)?.ok_or_else(|| {
+        WorkflowDefError::NotFound(format!("'{workflow_id}' (no published version)"))
+    })?;
+    Ok(parse_row(row)?.to_executable())
+}
+
+/// Shared row→definition path: parse the body (version-probed, strict,
+/// validated) and cross-check the row's `name` column against the body (a
+/// divergent hand-edited pair fails closed — the column is derived from the
+/// body at create time, so they can only diverge outside the typed API).
+fn parse_row(row: WorkflowDefinitionRow) -> Result<StoredWorkflowDefV1, WorkflowDefError> {
+    let def = parse_definition_json(&row.definition_json)?;
+    if def.name != row.name {
+        return Err(WorkflowDefError::Invalid(format!(
+            "stored row name '{}' diverges from definition body name '{}' for '{}' v{} \
+             (refusing to load)",
+            row.name, def.name, row.workflow_id, row.version
+        )));
+    }
+    Ok(def)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ExecError, ToolExecutor, ToolReceipt};
+    use friday_core::gate::{CanonicalApproval, MutatingActionRequest};
+    use friday_storage::workflow_def::{delete_definition, list_definitions};
+    use friday_storage::Db;
+    use std::cell::Cell;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static C: AtomicU64 = AtomicU64::new(0);
+    fn tmp(tag: &str) -> String {
+        std::env::temp_dir()
+            .join(format!(
+                "friday-wfdef-{}-{}-{}.sqlite",
+                std::process::id(),
+                tag,
+                C.fetch_add(1, Ordering::Relaxed)
+            ))
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    fn step(id: &str, action: &str, params: &[(&str, &str)]) -> StoredWorkflowStepV1 {
+        StoredWorkflowStepV1 {
+            id: id.to_string(),
+            action: action.to_string(),
+            params: params
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+            force_checkpoint: false,
+            evidence_required: false,
+        }
+    }
+
+    fn linear_def() -> StoredWorkflowDefV1 {
+        StoredWorkflowDefV1 {
+            schema_version: WORKFLOW_DEF_SCHEMA_VERSION,
+            name: "research".into(),
+            steps: vec![
+                step("read", "read_file", &[("path", "notes.txt")]),
+                step("scan", "search", &[("query", "TODO")]),
+            ],
+        }
+    }
+
+    #[test]
+    fn serde_roundtrip_preserves_the_definition_exactly() {
+        let def = linear_def();
+        let json = definition_to_json(&def).unwrap();
+        let back = parse_definition_json(&json).unwrap();
+        assert_eq!(back, def);
+    }
+
+    #[test]
+    fn unknown_schema_version_fails_closed_with_an_honest_error() {
+        let json = r#"{"schema_version":2,"name":"x","steps":[],"edges":[]}"#;
+        match parse_definition_json(json) {
+            Err(WorkflowDefError::UnsupportedSchemaVersion { found, supported }) => {
+                assert_eq!(found, 2);
+                assert_eq!(supported, WORKFLOW_DEF_SCHEMA_VERSION);
+            }
+            other => panic!("expected UnsupportedSchemaVersion, got {other:?}"),
+        }
+        // a missing tag is also fail-closed (never defaulted to v1).
+        assert!(matches!(
+            parse_definition_json(r#"{"name":"x","steps":[]}"#),
+            Err(WorkflowDefError::Invalid(_))
+        ));
+    }
+
+    #[test]
+    fn unknown_fields_fail_closed_a_dag_shaped_body_never_loads_as_linear() {
+        // A v1-tagged body smuggling DAG fields must be rejected by the strict parse.
+        let json = r#"{"schema_version":1,"name":"x",
+            "steps":[{"id":"a","action":"read_file"}],
+            "edges":[{"from":"a","to":"b"}]}"#;
+        assert!(matches!(
+            parse_definition_json(json),
+            Err(WorkflowDefError::Parse(_))
+        ));
+        // unknown STEP fields are rejected too (e.g. a per-step branch target).
+        let json = r#"{"schema_version":1,"name":"x",
+            "steps":[{"id":"a","action":"read_file","on_failure":"b"}]}"#;
+        assert!(matches!(
+            parse_definition_json(json),
+            Err(WorkflowDefError::Parse(_))
+        ));
+    }
+
+    #[test]
+    fn validation_rejects_empty_and_duplicate_shapes() {
+        let mut def = linear_def();
+        def.steps.clear();
+        assert!(matches!(def.validate(), Err(WorkflowDefError::Invalid(_))));
+
+        let mut def = linear_def();
+        def.steps[1].id = "read".into(); // duplicate
+        assert!(matches!(def.validate(), Err(WorkflowDefError::Invalid(_))));
+
+        let mut def = linear_def();
+        def.steps[0].action = "  ".into();
+        assert!(matches!(def.validate(), Err(WorkflowDefError::Invalid(_))));
+
+        let mut def = linear_def();
+        def.name = "".into();
+        assert!(matches!(def.validate(), Err(WorkflowDefError::Invalid(_))));
+    }
+
+    #[test]
+    fn create_load_roundtrip_produces_the_executable_planner_form() {
+        let db = Db::open_hub(&tmp("load")).unwrap();
+        create_definition(
+            db.conn(),
+            "wf1",
+            1,
+            &linear_def(),
+            DefinitionSource::RustNative,
+            None,
+            100,
+        )
+        .unwrap();
+        let exec_def = load_definition(db.conn(), "wf1", 1).unwrap();
+        assert_eq!(exec_def, linear_def().to_executable());
+        assert_eq!(exec_def.name, "research");
+        assert_eq!(exec_def.steps.len(), 2);
+        assert_eq!(exec_def.steps[0].action, "read_file");
+        // loading a missing definition is fail-closed.
+        assert!(matches!(
+            load_definition(db.conn(), "wf1", 9),
+            Err(WorkflowDefError::NotFound(_))
+        ));
+    }
+
+    #[test]
+    fn store_published_version_is_loadable_via_the_published_loader() {
+        let db = Db::open_hub(&tmp("published")).unwrap();
+        // v1 unpublished, v2 stored-as-published.
+        create_definition(
+            db.conn(),
+            "wf1",
+            1,
+            &linear_def(),
+            DefinitionSource::RustNative,
+            None,
+            100,
+        )
+        .unwrap();
+        let mut v2 = linear_def();
+        v2.steps.pop();
+        store_published_version(
+            db.conn(),
+            "wf1",
+            2,
+            &v2,
+            DefinitionSource::RustNative,
+            None,
+            200,
+        )
+        .unwrap();
+
+        let loaded = load_published_definition(db.conn(), "wf1").unwrap();
+        assert_eq!(loaded.steps.len(), 1, "published v2 (one step) loads");
+        // a workflow with no published version is fail-closed.
+        create_definition(
+            db.conn(),
+            "wf2",
+            1,
+            &linear_def(),
+            DefinitionSource::RustNative,
+            None,
+            300,
+        )
+        .unwrap();
+        assert!(matches!(
+            load_published_definition(db.conn(), "wf2"),
+            Err(WorkflowDefError::NotFound(_))
+        ));
+    }
+
+    #[test]
+    fn row_name_divergence_fails_closed_on_load() {
+        let db = Db::open_hub(&tmp("name-diverge")).unwrap();
+        create_definition(
+            db.conn(),
+            "wf1",
+            1,
+            &linear_def(),
+            DefinitionSource::RustNative,
+            None,
+            100,
+        )
+        .unwrap();
+        // Hand-edit ONLY the name column (body + checksum still consistent).
+        db.conn()
+            .execute(
+                "UPDATE workflow_definition SET name = 'imposter' WHERE workflow_id = 'wf1'",
+                [],
+            )
+            .unwrap();
+        assert!(matches!(
+            load_definition(db.conn(), "wf1", 1),
+            Err(WorkflowDefError::Invalid(_))
+        ));
+    }
+
+    // --- the load-bearing seam test: stored definition → EXISTING engine ------
+
+    struct CountingExec {
+        calls: Cell<usize>,
+    }
+    impl ToolExecutor for CountingExec {
+        fn execute(
+            &self,
+            action: &str,
+            _params: &[(String, String)],
+        ) -> Result<ToolReceipt, ExecError> {
+            self.calls.set(self.calls.get() + 1);
+            Ok(ToolReceipt {
+                action: action.to_string(),
+                summary: format!("ran {action}"),
+                content: None,
+            })
+        }
+    }
+
+    fn deny_all(_r: &MutatingActionRequest) -> Option<CanonicalApproval> {
+        None
+    }
+
+    const SECRET: &[u8] = b"wf-def-secret-0123456789abcdef";
+
+    #[test]
+    fn loaded_definition_runs_through_the_existing_workflow_exec_engine() {
+        // Store → load → run through the UNMODIFIED `workflow_exec::run_workflow`:
+        // proves the loader's output IS the engine's input (no second executor,
+        // no adapter shim). Both read-only steps auto-advance; the run completes.
+        let db = Db::open_hub(&tmp("e2e")).unwrap();
+        store_published_version(
+            db.conn(),
+            "wf1",
+            1,
+            &linear_def(),
+            DefinitionSource::RustNative,
+            None,
+            100,
+        )
+        .unwrap();
+        let def = load_published_definition(db.conn(), "wf1").unwrap();
+        let exec = CountingExec {
+            calls: Cell::new(0),
+        };
+        let out = crate::workflow_exec::run_workflow(
+            &def,
+            &exec,
+            db.conn(),
+            "run1",
+            SECRET,
+            &deny_all,
+            200,
+        )
+        .unwrap();
+        assert_eq!(
+            out.status,
+            crate::workflow_exec::WorkflowRunStatus::Completed
+        );
+        assert_eq!(out.executed_steps, 2);
+        assert_eq!(exec.calls.get(), 2);
+    }
+
+    #[test]
+    fn loaded_mutating_step_still_pauses_at_the_gate_floor() {
+        // The stored format cannot weaken the floors: a stored write_file step
+        // loaded from the DB still checkpoints (planner Mutating) and is NOT
+        // executed without approval.
+        let db = Db::open_hub(&tmp("e2e-pause")).unwrap();
+        let def = StoredWorkflowDefV1 {
+            schema_version: WORKFLOW_DEF_SCHEMA_VERSION,
+            name: "ship".into(),
+            steps: vec![
+                step("read", "read_file", &[("path", "notes.txt")]),
+                step("write", "write_file", &[("path", "o"), ("content", "y")]),
+            ],
+        };
+        create_definition(
+            db.conn(),
+            "wf1",
+            1,
+            &def,
+            DefinitionSource::RustNative,
+            None,
+            100,
+        )
+        .unwrap();
+        let loaded = load_definition(db.conn(), "wf1", 1).unwrap();
+        let exec = CountingExec {
+            calls: Cell::new(0),
+        };
+        let out = crate::workflow_exec::run_workflow(
+            &loaded,
+            &exec,
+            db.conn(),
+            "run1",
+            SECRET,
+            &deny_all,
+            200,
+        )
+        .unwrap();
+        assert!(matches!(
+            out.status,
+            crate::workflow_exec::WorkflowRunStatus::AwaitingCheckpoint { .. }
+        ));
+        assert_eq!(
+            exec.calls.get(),
+            1,
+            "the mutating step must NOT execute without approval"
+        );
+    }
+
+    #[test]
+    fn crud_list_and_delete_compose_with_the_hub_wrappers() {
+        let db = Db::open_hub(&tmp("crud")).unwrap();
+        create_definition(
+            db.conn(),
+            "wf1",
+            1,
+            &linear_def(),
+            DefinitionSource::RustNative,
+            None,
+            100,
+        )
+        .unwrap();
+        store_published_version(
+            db.conn(),
+            "wf1",
+            2,
+            &linear_def(),
+            DefinitionSource::RustNative,
+            None,
+            200,
+        )
+        .unwrap();
+        let all = list_definitions(db.conn()).unwrap();
+        assert_eq!(all.len(), 2);
+        assert!(all.iter().any(|s| s.version == 2 && s.is_published));
+        // delete the unpublished v1; the published v2 stays loadable.
+        delete_definition(db.conn(), "wf1", 1).unwrap();
+        assert!(load_published_definition(db.conn(), "wf1").is_ok());
+        assert!(matches!(
+            get_parsed_definition(db.conn(), "wf1", 1),
+            Err(WorkflowDefError::NotFound(_))
+        ));
+    }
+}

--- a/rust-core/crates/friday-hub/src/workflow_ts_translate.rs
+++ b/rust-core/crates/friday-hub/src/workflow_ts_translate.rs
@@ -1,0 +1,1394 @@
+//! S8 — TS published-version → Rust LINEAR-ONLY workflow translator. DARK
+//! substrate: no production route, no scheduler, no TS runtime change; workflow
+//! execution remains fenced in TS and is NOT product-replaced; NOT v1 GO.
+//!
+//! ## Source format (cited from the TS oracle)
+//! A TS workflow's published version is `FridayWorkflowVersionEntity.graphJson`
+//! (`src/workflows/model/friday-workflow.types.ts`, persisted as
+//! `workflow_versions.graph_json` since `v001-initial.ts`). Its parsed shape is
+//! `FridayCompiledWorkflowGraphV2` (`src/workflows/model/friday-workflow-graph.types.ts`):
+//! `{ schemaVersion:"2.0", graph:{ nodes, edges, variables? }, failurePolicy,
+//! tests, checksum }` — and the TS `parseGraphJson` also accepts RAW graphs with
+//! top-level `nodes`/`edges`, which this translator mirrors. Node types are
+//! `trigger | action | condition | data | ai | approval` with the TS aliases
+//! `start→trigger`, `tool_call/skill_call→action`, `transform→data`,
+//! `human_approval→approval`. An `action` node names its callee via
+//! `config.skillId ?? config.ref` and passes `config.args`
+//! (`src/node-runner/engine/workflow-action-adapter.ts`); a STRING arg starting
+//! with `$` is an EXPRESSION the TS evaluator resolves at run time
+//! (`resolveValue` in `src/workflows/engine/friday-workflow-node-executor.ts`).
+//!
+//! ## HARD RULE (operator decision Q2, binding): LINEAR-ONLY, fail-closed
+//! Only the LINEAR subset translates. ANY DAG/branch/parallel/unsupported
+//! feature in the source produces an explicit, fail-closed
+//! [`TsTranslation::Unsupported`] carrying per-feature reasons + preserved
+//! refs-only source metadata — NEVER a silent flattening, NEVER a partial
+//! translation that drops nodes, NEVER misrepresented as supported. The full
+//! source is scanned (all blockers are reported, not just the first), so the
+//! honest gap list is complete.
+//!
+//! What fails closed (the chasm, kept visible — never claim DAG parity):
+//! - **branching/parallel topology**: fan-out, fan-in, multiple entry nodes,
+//!   disconnected islands, cycles, conditional edges, edge ports;
+//! - **node types** with no Rust executor semantics: `condition`, `data`
+//!   (incl. the `transform` alias), `ai`, `approval`, unknown types (the TS
+//!   parser defaults unknown types to `action`; this translator deliberately
+//!   does NOT — defaulting an unknown type would misrepresent it as supported);
+//! - **triggers** other than a single leading manual trigger (schedule/event
+//!   triggers are S10 scheduler scope, operator-gated);
+//! - **actions** whose callee does not canonicalize to a Rust
+//!   [`crate::ToolRegistry`] action via the single-source-of-truth
+//!   [`crate::tool_name_map::canonical_rust_name`] (a TS-only skill/tool must
+//!   not be stored as if runnable);
+//! - **expression args** (`$…`), non-scalar args, unsafe keys, and the
+//!   `exec`-only knobs (`workdir`/`env`/`timeoutMs`/`background`) recorded in
+//!   [`crate::tool_name_map::PARAM_SCHEMA_DIFFS`] as having no Rust surface;
+//! - **per-step retry policies** (maxAttempts > 1) and **timeouts** (the Rust
+//!   engine has no per-step retry/timeout; dropping them silently would remove
+//!   a bound the author set);
+//! - **failure policies** other than `fail_fast` (the Rust engine fails the
+//!   run on a step error; honoring `continue_on_error`/`fallback_step`/
+//!   `compensate`/`pause_for_approval` is unbuilt);
+//! - **graph variables** (no variable substitution exists in the Rust engine).
+//!
+//! What IS translated for a pure-linear source: the ordered `action` chain →
+//! [`crate::workflow_def::StoredWorkflowDefV1`] steps (TS aliases mapped to
+//! canonical Rust actions; `edit`'s `oldText`/`newText` renamed to
+//! `old_text`/`new_text` per the recorded param-schema diff; scalar args
+//! stringified). A single LEADING manual trigger contributes no step and is
+//! recorded in the metadata (`manual_trigger_elided`) — an explicit record,
+//! not a silent drop. `tests` in the source are fixtures, not executable
+//! semantics; their count is preserved in the metadata.
+
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+use serde_json::{Map, Value};
+
+use crate::tool_name_map::canonical_rust_name;
+use crate::workflow_def::{StoredWorkflowDefV1, StoredWorkflowStepV1, WORKFLOW_DEF_SCHEMA_VERSION};
+
+/// Refs-only provenance preserved from the TS source: ids / counts / coarse
+/// labels ONLY — never node configs, args, prompts, or secrets. Serializable so
+/// it can be persisted into `workflow_definition.source_meta`.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct TsSourceMeta {
+    /// `schemaVersion` of the compiled graph (e.g. `"2.0"`), when present.
+    pub source_schema_version: Option<String>,
+    pub workflow_id: Option<String>,
+    pub workflow_version_id: Option<String>,
+    /// The SOURCE graph's own checksum field (not the Rust row checksum).
+    pub source_checksum: Option<String>,
+    pub node_count: usize,
+    pub edge_count: usize,
+    /// Normalized node-type histogram (refs-only labels).
+    pub node_type_counts: BTreeMap<String, usize>,
+    pub test_count: usize,
+    /// True when a single LEADING manual trigger node was honestly elided (it
+    /// is an entry marker, not an executable step).
+    pub manual_trigger_elided: bool,
+}
+
+/// One explicit, per-feature blocker. `feature` is a closed-vocabulary label;
+/// `reason` is an honest human-readable explanation; `node_or_edge` names the
+/// offending element when there is one (an id/label — refs-only).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct UnsupportedFeature {
+    pub feature: &'static str,
+    pub node_or_edge: Option<String>,
+    pub reason: String,
+}
+
+/// The translator's fail-closed result.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TsTranslation {
+    /// The source is pure-linear and fully translated.
+    Linear {
+        definition: StoredWorkflowDefV1,
+        source_meta: TsSourceMeta,
+    },
+    /// The source uses at least one unsupported feature. NOTHING was
+    /// translated (never partial); every blocker is listed.
+    Unsupported {
+        reasons: Vec<UnsupportedFeature>,
+        preserved_source_meta: TsSourceMeta,
+    },
+}
+
+// --- normalized intermediate shapes ------------------------------------------
+
+struct TsNode {
+    id: String,
+    /// normalized type label, or the raw label when unknown (reported, never defaulted)
+    node_type: Result<&'static str, String>,
+    config: Map<String, Value>,
+    retry_policy: Option<Value>,
+    timeout_ms: Option<Value>,
+}
+
+struct TsEdge {
+    id: String,
+    source: Option<String>,
+    target: Option<String>,
+    condition: Option<String>,
+    has_ports: bool,
+}
+
+/// Mirror of the TS `normalizeWorkflowNodeType` alias table — minus its
+/// unknown→`action` default, which this translator deliberately fails closed.
+fn normalize_node_type(raw: &str) -> Result<&'static str, String> {
+    match raw.trim() {
+        "trigger" | "start" => Ok("trigger"),
+        "action" | "tool_call" | "skill_call" => Ok("action"),
+        "condition" => Ok("condition"),
+        "data" | "transform" => Ok("data"),
+        "ai" => Ok("ai"),
+        "approval" | "human_approval" => Ok("approval"),
+        other => Err(other.to_string()),
+    }
+}
+
+fn as_str(v: Option<&Value>) -> Option<String> {
+    v.and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+fn as_object(v: Option<&Value>) -> Option<&Map<String, Value>> {
+    v.and_then(Value::as_object)
+}
+
+/// The selected graph level: raw node/edge arrays plus the object that carries
+/// graph-level fields (e.g. `variables`).
+struct GraphSource<'a> {
+    nodes: &'a Vec<Value>,
+    edges: Vec<Value>,
+    graph_level: &'a Map<String, Value>,
+}
+
+/// Mirror of TS `parseGraphJson`'s source selection: `graph.nodes` (compiled
+/// v2) or top-level `nodes` (raw/generated), with edges from the same level.
+fn select_nodes_edges(raw: &Map<String, Value>) -> Option<GraphSource<'_>> {
+    if let Some(graph) = as_object(raw.get("graph")) {
+        if let Some(nodes) = graph.get("nodes").and_then(Value::as_array) {
+            let edges = graph
+                .get("edges")
+                .and_then(Value::as_array)
+                .cloned()
+                .unwrap_or_default();
+            return Some(GraphSource {
+                nodes,
+                edges,
+                graph_level: graph,
+            });
+        }
+    }
+    if let Some(nodes) = raw.get("nodes").and_then(Value::as_array) {
+        let edges = raw
+            .get("edges")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        return Some(GraphSource {
+            nodes,
+            edges,
+            graph_level: raw,
+        });
+    }
+    None
+}
+
+fn normalize_node(v: &Value, index: usize) -> TsNode {
+    let obj = v.as_object();
+    let id = obj
+        .and_then(|o| as_str(o.get("id")))
+        // mirror the TS parser's positional default id
+        .unwrap_or_else(|| format!("node-{}", index + 1));
+    let raw_type = obj
+        .and_then(|o| as_str(o.get("type")).or_else(|| as_str(o.get("kind"))))
+        .unwrap_or_default();
+    let node_type = normalize_node_type(&raw_type);
+    let config = obj
+        .and_then(|o| {
+            as_object(o.get("config"))
+                .or_else(|| as_object(o.get("data")))
+                .cloned()
+        })
+        .unwrap_or_default();
+    TsNode {
+        id,
+        node_type,
+        config,
+        retry_policy: obj.and_then(|o| o.get("retryPolicy")).cloned(),
+        timeout_ms: obj.and_then(|o| o.get("timeoutMs")).cloned(),
+    }
+}
+
+fn normalize_edge(v: &Value, index: usize) -> TsEdge {
+    let obj = v.as_object();
+    let pick = |keys: &[&str]| -> Option<String> {
+        obj.and_then(|o| keys.iter().find_map(|k| as_str(o.get(*k))))
+    };
+    let source = pick(&["sourceNodeId", "source", "from"]);
+    let target = pick(&["targetNodeId", "target", "to"]);
+    TsEdge {
+        id: pick(&["id"]).unwrap_or_else(|| format!("edge-{}", index + 1)),
+        source,
+        target,
+        condition: pick(&["condition", "when"]),
+        has_ports: obj
+            .is_some_and(|o| o.contains_key("sourcePort") || o.contains_key("targetPort")),
+    }
+}
+
+fn build_meta(raw: &Map<String, Value>, nodes: &[TsNode], edge_count: usize) -> TsSourceMeta {
+    let mut node_type_counts: BTreeMap<String, usize> = BTreeMap::new();
+    for n in nodes {
+        let label = match &n.node_type {
+            Ok(t) => (*t).to_string(),
+            Err(raw_label) if raw_label.is_empty() => "missing".to_string(),
+            Err(_) => "unknown".to_string(),
+        };
+        *node_type_counts.entry(label).or_insert(0) += 1;
+    }
+    TsSourceMeta {
+        source_schema_version: as_str(raw.get("schemaVersion")),
+        workflow_id: as_str(raw.get("workflowId")),
+        workflow_version_id: as_str(raw.get("workflowVersionId")),
+        source_checksum: as_str(raw.get("checksum")),
+        node_count: nodes.len(),
+        edge_count,
+        node_type_counts,
+        test_count: raw
+            .get("tests")
+            .and_then(Value::as_array)
+            .map(Vec::len)
+            .unwrap_or(0),
+        manual_trigger_elided: false,
+    }
+}
+
+fn empty_meta() -> TsSourceMeta {
+    TsSourceMeta {
+        source_schema_version: None,
+        workflow_id: None,
+        workflow_version_id: None,
+        source_checksum: None,
+        node_count: 0,
+        edge_count: 0,
+        node_type_counts: BTreeMap::new(),
+        test_count: 0,
+        manual_trigger_elided: false,
+    }
+}
+
+/// Keys whose presence in a trigger config means the trigger is NOT manual
+/// (schedule/event triggers are S10 scheduler scope — operator-gated, unbuilt).
+const NON_MANUAL_TRIGGER_KEYS: &[&str] = &["cron", "schedule", "interval", "event", "source"];
+
+/// TS `resolveArgs` drops these silently; the translator fails closed instead.
+const UNSAFE_ARG_KEYS: &[&str] = &["__proto__", "constructor", "prototype"];
+
+/// `exec`-only knobs with no Rust `run_command` surface
+/// ([`crate::tool_name_map::PARAM_SCHEMA_DIFFS`]); silently dropping them would
+/// change semantics (e.g. lose a cwd or a timeout), so they fail closed.
+const EXEC_ONLY_KEYS: &[&str] = &["workdir", "env", "timeoutMs", "background"];
+
+/// Translate a TS published-version workflow graph (the
+/// `FridayWorkflowVersionEntity.graphJson` value) into the Rust LINEAR-ONLY
+/// stored definition. `name` is the TS workflow's display name (it lives on
+/// the workflow entity, not inside the graph). See module docs for the binding
+/// fail-closed rules.
+pub fn translate_ts_published_version(graph_json: &Value, name: &str) -> TsTranslation {
+    let mut reasons: Vec<UnsupportedFeature> = Vec::new();
+
+    let Some(raw) = graph_json.as_object() else {
+        return TsTranslation::Unsupported {
+            reasons: vec![UnsupportedFeature {
+                feature: "unparseable_graph",
+                node_or_edge: None,
+                reason: "graph JSON must be a non-null object (mirrors the TS parseGraphJson \
+                         contract)"
+                    .into(),
+            }],
+            preserved_source_meta: empty_meta(),
+        };
+    };
+
+    let Some(GraphSource {
+        nodes: raw_nodes,
+        edges: raw_edges,
+        graph_level,
+    }) = select_nodes_edges(raw)
+    else {
+        return TsTranslation::Unsupported {
+            reasons: vec![UnsupportedFeature {
+                feature: "unparseable_graph",
+                node_or_edge: None,
+                reason: "graph must contain a 'nodes' array (top level or under 'graph')".into(),
+            }],
+            preserved_source_meta: build_meta(raw, &[], 0),
+        };
+    };
+
+    let nodes: Vec<TsNode> = raw_nodes
+        .iter()
+        .enumerate()
+        .map(|(i, v)| normalize_node(v, i))
+        .collect();
+    let edges: Vec<TsEdge> = raw_edges
+        .iter()
+        .enumerate()
+        .map(|(i, v)| normalize_edge(v, i))
+        .collect();
+    let mut meta = build_meta(raw, &nodes, edges.len());
+
+    if nodes.is_empty() {
+        reasons.push(UnsupportedFeature {
+            feature: "empty_graph",
+            node_or_edge: None,
+            reason: "the source graph has no nodes; an empty workflow is not translatable".into(),
+        });
+    }
+
+    // --- per-node feature scan ------------------------------------------------
+    let mut seen_ids = std::collections::HashSet::new();
+    let mut trigger_ids: Vec<&str> = Vec::new();
+    for node in &nodes {
+        if !seen_ids.insert(node.id.as_str()) {
+            reasons.push(UnsupportedFeature {
+                feature: "duplicate_node_id",
+                node_or_edge: Some(node.id.clone()),
+                reason: format!("node id '{}' appears more than once", node.id),
+            });
+        }
+        match &node.node_type {
+            Ok("trigger") => {
+                trigger_ids.push(&node.id);
+                scan_trigger(node, &mut reasons);
+            }
+            Ok("action") => scan_action(node, &mut reasons),
+            Ok("condition") => reasons.push(UnsupportedFeature {
+                feature: "branch_condition_node",
+                node_or_edge: Some(node.id.clone()),
+                reason: format!(
+                    "node '{}' is a condition node: branching is not supported (LINEAR-ONLY v1, \
+                     operator decision Q2); fail-closed, never flattened",
+                    node.id
+                ),
+            }),
+            Ok("data") => reasons.push(UnsupportedFeature {
+                feature: "transform_node",
+                node_or_edge: Some(node.id.clone()),
+                reason: format!(
+                    "node '{}' is a data/transform node: the Rust engine has no \
+                     transform/expression evaluator; fail-closed, never dropped",
+                    node.id
+                ),
+            }),
+            Ok("ai") => reasons.push(UnsupportedFeature {
+                feature: "ai_node",
+                node_or_edge: Some(node.id.clone()),
+                reason: format!(
+                    "node '{}' is an ai node: model-driven steps are not part of the linear \
+                     built-in-tool subset",
+                    node.id
+                ),
+            }),
+            Ok("approval") => reasons.push(UnsupportedFeature {
+                feature: "approval_node",
+                node_or_edge: Some(node.id.clone()),
+                reason: format!(
+                    "node '{}' is an approval node: TS approval semantics are not mapped in v1 \
+                     (the Rust planner/gate already checkpoint mutating steps, but an explicit \
+                     approval NODE is a distinct construct; fail-closed rather than approximated)",
+                    node.id
+                ),
+            }),
+            Ok(other) => reasons.push(UnsupportedFeature {
+                // unreachable with the current normalize table; fail closed anyway.
+                feature: "unknown_node_type",
+                node_or_edge: Some(node.id.clone()),
+                reason: format!("node '{}' has unhandled normalized type '{other}'", node.id),
+            }),
+            Err(raw_label) => reasons.push(UnsupportedFeature {
+                feature: "unknown_node_type",
+                node_or_edge: Some(node.id.clone()),
+                reason: format!(
+                    "node '{}' has unknown type '{raw_label}'; the TS parser would default it to \
+                     'action' but this translator fails closed (defaulting would misrepresent it \
+                     as supported)",
+                    node.id
+                ),
+            }),
+        }
+        if let Some(retry) = &node.retry_policy {
+            let single_attempt = retry
+                .as_object()
+                .and_then(|o| o.get("maxAttempts"))
+                .and_then(Value::as_i64)
+                .is_some_and(|n| n <= 1);
+            if !single_attempt {
+                reasons.push(UnsupportedFeature {
+                    feature: "step_retry_policy",
+                    node_or_edge: Some(node.id.clone()),
+                    reason: format!(
+                        "node '{}' carries a retryPolicy with retries: the Rust engine has no \
+                         per-step retry; silently dropping it would change semantics",
+                        node.id
+                    ),
+                });
+            }
+        }
+        if node.timeout_ms.as_ref().is_some_and(|v| !v.is_null()) {
+            reasons.push(UnsupportedFeature {
+                feature: "step_timeout",
+                node_or_edge: Some(node.id.clone()),
+                reason: format!(
+                    "node '{}' sets timeoutMs: the Rust engine has no per-step timeout; silently \
+                     dropping it would remove a bound the author set",
+                    node.id
+                ),
+            });
+        }
+    }
+    if trigger_ids.len() > 1 {
+        reasons.push(UnsupportedFeature {
+            feature: "multiple_triggers",
+            node_or_edge: Some(trigger_ids.join(",")),
+            reason: "more than one trigger node (parallel entry semantics)".into(),
+        });
+    }
+
+    // --- edge feature scan ------------------------------------------------------
+    let node_ids: std::collections::HashSet<&str> = nodes.iter().map(|n| n.id.as_str()).collect();
+    for edge in &edges {
+        if let Some(cond) = &edge.condition {
+            reasons.push(UnsupportedFeature {
+                feature: "conditional_edge",
+                node_or_edge: Some(edge.id.clone()),
+                reason: format!(
+                    "edge '{}' carries condition '{cond}': conditional routing is branching \
+                     (LINEAR-ONLY v1); fail-closed, never flattened",
+                    edge.id
+                ),
+            });
+        }
+        if edge.has_ports {
+            reasons.push(UnsupportedFeature {
+                feature: "edge_ports",
+                node_or_edge: Some(edge.id.clone()),
+                reason: format!(
+                    "edge '{}' uses sourcePort/targetPort: port-routed multi-output topology is \
+                     not part of the linear subset",
+                    edge.id
+                ),
+            });
+        }
+        match (&edge.source, &edge.target) {
+            (Some(s), Some(t))
+                if node_ids.contains(s.as_str()) && node_ids.contains(t.as_str()) => {}
+            _ => reasons.push(UnsupportedFeature {
+                feature: "edge_dangling",
+                node_or_edge: Some(edge.id.clone()),
+                reason: format!(
+                    "edge '{}' references a missing/empty endpoint (source: {:?}, target: {:?})",
+                    edge.id, edge.source, edge.target
+                ),
+            }),
+        }
+    }
+
+    // --- graph-level features ----------------------------------------------------
+    if graph_level
+        .get("variables")
+        .and_then(Value::as_object)
+        .is_some_and(|m| !m.is_empty())
+    {
+        reasons.push(UnsupportedFeature {
+            feature: "graph_variables",
+            node_or_edge: None,
+            reason: "the graph declares variables: the Rust engine has no variable \
+                     substitution; fail-closed"
+                .into(),
+        });
+    }
+    if let Some(policy) = raw.get("failurePolicy").and_then(Value::as_object) {
+        if let Some(strategy) = as_str(policy.get("onFailure")) {
+            if strategy != "fail_fast" {
+                reasons.push(UnsupportedFeature {
+                    feature: "failure_policy",
+                    node_or_edge: None,
+                    reason: format!(
+                        "failurePolicy.onFailure = '{strategy}': the Rust engine only fail-fasts \
+                         (continue_on_error/fallback_step/compensate/pause_for_approval are \
+                         unbuilt); translating it would misrepresent the policy as honored"
+                    ),
+                });
+            }
+        }
+    }
+
+    // --- topology: must be ONE linear chain covering every node -------------------
+    // Only meaningful when edges are structurally sound; dangling edges were
+    // already reported and would make degree counts misleading.
+    let chain: Option<Vec<&TsNode>> = if reasons.iter().any(|r| {
+        r.feature == "edge_dangling"
+            || r.feature == "duplicate_node_id"
+            || r.feature == "empty_graph"
+    }) {
+        None
+    } else {
+        check_linear_topology(&nodes, &edges, &mut reasons)
+    };
+
+    if !reasons.is_empty() {
+        return TsTranslation::Unsupported {
+            reasons,
+            preserved_source_meta: meta,
+        };
+    }
+    let chain = chain.expect("no reasons implies a resolved chain");
+
+    // --- build the linear definition (chain order) --------------------------------
+    let mut steps: Vec<StoredWorkflowStepV1> = Vec::with_capacity(chain.len());
+    for (pos, node) in chain.iter().enumerate() {
+        match node.node_type {
+            Ok("trigger") => {
+                if pos == 0 {
+                    // A single LEADING manual trigger is the entry marker, not an
+                    // executable step: elide it EXPLICITLY (recorded in metadata).
+                    meta.manual_trigger_elided = true;
+                } else {
+                    return TsTranslation::Unsupported {
+                        reasons: vec![UnsupportedFeature {
+                            feature: "trigger_not_entry",
+                            node_or_edge: Some(node.id.clone()),
+                            reason: format!(
+                                "trigger node '{}' is mid-chain (position {pos}); a trigger is \
+                                 only translatable as the single leading entry",
+                                node.id
+                            ),
+                        }],
+                        preserved_source_meta: meta,
+                    };
+                }
+            }
+            Ok("action") => {
+                // scan_action already validated; build_step cannot fail now.
+                steps.push(build_step(node));
+            }
+            // unreachable: every other type already produced an Unsupported reason.
+            _ => unreachable!("non-linear node type survived the feature scan"),
+        }
+    }
+    if steps.is_empty() {
+        return TsTranslation::Unsupported {
+            reasons: vec![UnsupportedFeature {
+                feature: "no_executable_steps",
+                node_or_edge: None,
+                reason: "the source contains no action steps after eliding the manual trigger"
+                    .into(),
+            }],
+            preserved_source_meta: meta,
+        };
+    }
+
+    TsTranslation::Linear {
+        definition: StoredWorkflowDefV1 {
+            schema_version: WORKFLOW_DEF_SCHEMA_VERSION,
+            name: name.to_string(),
+            steps,
+        },
+        source_meta: meta,
+    }
+}
+
+/// Trigger scan: only a MANUAL trigger is translatable (schedule/event = S10).
+fn scan_trigger(node: &TsNode, reasons: &mut Vec<UnsupportedFeature>) {
+    for key in NON_MANUAL_TRIGGER_KEYS {
+        if node.config.contains_key(*key) {
+            reasons.push(UnsupportedFeature {
+                feature: "trigger_not_manual",
+                node_or_edge: Some(node.id.clone()),
+                reason: format!(
+                    "trigger node '{}' config has '{key}': schedule/event triggers are S10 \
+                     scheduler scope (operator-gated, unbuilt); only a manual trigger is \
+                     translatable",
+                    node.id
+                ),
+            });
+            return;
+        }
+    }
+    let declared =
+        as_str(node.config.get("type")).or_else(|| as_str(node.config.get("triggerType")));
+    if let Some(kind) = declared {
+        if kind != "manual" {
+            reasons.push(UnsupportedFeature {
+                feature: "trigger_not_manual",
+                node_or_edge: Some(node.id.clone()),
+                reason: format!(
+                    "trigger node '{}' declares type '{kind}'; only 'manual' is translatable \
+                     (schedule/event = S10, operator-gated)",
+                    node.id
+                ),
+            });
+        }
+    }
+}
+
+/// Action scan: callee must canonicalize to a Rust registry action; args must
+/// be literal scalars with no expression markers / unsafe keys / exec-only knobs.
+fn scan_action(node: &TsNode, reasons: &mut Vec<UnsupportedFeature>) {
+    // callee: config.skillId ?? config.ref (faithful to the TS action adapter).
+    let Some(callee) =
+        as_str(node.config.get("skillId")).or_else(|| as_str(node.config.get("ref")))
+    else {
+        reasons.push(UnsupportedFeature {
+            feature: "action_missing_ref",
+            node_or_edge: Some(node.id.clone()),
+            reason: format!(
+                "action node '{}' has no skillId/ref in config (the TS adapter would reject it \
+                 too)",
+                node.id
+            ),
+        });
+        return;
+    };
+    let Some(rust_action) = canonical_rust_name(&callee) else {
+        reasons.push(UnsupportedFeature {
+            feature: "action_no_rust_executor",
+            node_or_edge: Some(node.id.clone()),
+            reason: format!(
+                "action node '{}' calls '{callee}', which has no Rust ToolRegistry executor \
+                 (tool_name_map fail-closed); storing it would misrepresent a TS-only \
+                 skill/tool as runnable",
+                node.id
+            ),
+        });
+        return;
+    };
+
+    match node.config.get("args") {
+        None => {}
+        Some(Value::Object(args)) => {
+            for (key, value) in args {
+                if UNSAFE_ARG_KEYS.contains(&key.as_str()) {
+                    reasons.push(UnsupportedFeature {
+                        feature: "unsafe_param_key",
+                        node_or_edge: Some(node.id.clone()),
+                        reason: format!(
+                            "action node '{}' arg key '{key}' is an unsafe prototype key (the TS \
+                             resolver drops it silently; this translator fails closed)",
+                            node.id
+                        ),
+                    });
+                    continue;
+                }
+                if rust_action == "run_command" && EXEC_ONLY_KEYS.contains(&key.as_str()) {
+                    reasons.push(UnsupportedFeature {
+                        feature: "exec_param_no_rust_surface",
+                        node_or_edge: Some(node.id.clone()),
+                        reason: format!(
+                            "action node '{}' exec arg '{key}' has no Rust run_command surface \
+                             (PARAM_SCHEMA_DIFFS); dropping it would change semantics",
+                            node.id
+                        ),
+                    });
+                    continue;
+                }
+                match value {
+                    Value::String(s) if s.starts_with('$') => {
+                        reasons.push(UnsupportedFeature {
+                            feature: "expression_param",
+                            node_or_edge: Some(node.id.clone()),
+                            reason: format!(
+                                "action node '{}' arg '{key}' is a TS runtime expression \
+                                 (starts with '$'); the Rust engine has no expression evaluator, \
+                                 so passing it literally would silently change semantics",
+                                node.id
+                            ),
+                        });
+                    }
+                    Value::String(_) | Value::Number(_) | Value::Bool(_) => {}
+                    _ => reasons.push(UnsupportedFeature {
+                        feature: "non_scalar_param",
+                        node_or_edge: Some(node.id.clone()),
+                        reason: format!(
+                            "action node '{}' arg '{key}' is not a literal scalar \
+                             (null/array/object args have no Rust tool-param mapping)",
+                            node.id
+                        ),
+                    }),
+                }
+            }
+        }
+        Some(_) => reasons.push(UnsupportedFeature {
+            feature: "action_args_not_object",
+            node_or_edge: Some(node.id.clone()),
+            reason: format!("action node '{}' has a non-object args value", node.id),
+        }),
+    }
+}
+
+/// Build the translated step for a SCANNED-CLEAN action node.
+fn build_step(node: &TsNode) -> StoredWorkflowStepV1 {
+    let callee = as_str(node.config.get("skillId"))
+        .or_else(|| as_str(node.config.get("ref")))
+        .expect("scan_action verified the callee");
+    let rust_action = canonical_rust_name(&callee).expect("scan_action verified the mapping");
+    let mut params: Vec<(String, String)> = Vec::new();
+    if let Some(Value::Object(args)) = node.config.get("args") {
+        for (key, value) in args {
+            // Recorded param-schema diff for `edit` → `edit_file`: TS camelCase →
+            // Rust snake_case (tool_name_map::PARAM_SCHEMA_DIFFS).
+            let mapped_key = if rust_action == "edit_file" {
+                match key.as_str() {
+                    "oldText" => "old_text".to_string(),
+                    "newText" => "new_text".to_string(),
+                    other => other.to_string(),
+                }
+            } else {
+                key.clone()
+            };
+            let rendered = match value {
+                Value::String(s) => s.clone(),
+                Value::Number(n) => n.to_string(),
+                Value::Bool(b) => b.to_string(),
+                _ => unreachable!("scan_action rejected non-scalar args"),
+            };
+            params.push((mapped_key, rendered));
+        }
+    }
+    StoredWorkflowStepV1 {
+        id: node.id.clone(),
+        action: rust_action.to_string(),
+        params,
+        // The planner floors (mutating/high-risk/sensitive/unclassifiable) decide
+        // checkpoints at run time; the translation adds no narrowing of its own.
+        force_checkpoint: false,
+        evidence_required: false,
+    }
+}
+
+/// Verify the graph is ONE linear chain covering every node, and return it in
+/// execution order. Reports `dag_fan_out` / `dag_fan_in` / `parallel_entries` /
+/// `cycle` / `disconnected_parallel` — each an explicit blocker, never flattened.
+fn check_linear_topology<'a>(
+    nodes: &'a [TsNode],
+    edges: &[TsEdge],
+    reasons: &mut Vec<UnsupportedFeature>,
+) -> Option<Vec<&'a TsNode>> {
+    use std::collections::HashMap;
+    let mut out: HashMap<&str, Vec<&str>> = HashMap::new();
+    let mut indeg: HashMap<&str, usize> = HashMap::new();
+    for n in nodes {
+        out.entry(n.id.as_str()).or_default();
+        indeg.entry(n.id.as_str()).or_insert(0);
+    }
+    for e in edges {
+        let (Some(s), Some(t)) = (e.source.as_deref(), e.target.as_deref()) else {
+            continue; // already reported as edge_dangling
+        };
+        out.entry(s).or_default().push(t);
+        *indeg.entry(t).or_insert(0) += 1;
+    }
+
+    let before = reasons.len();
+    for n in nodes {
+        let fan_out = out.get(n.id.as_str()).map_or(0, Vec::len);
+        if fan_out > 1 {
+            reasons.push(UnsupportedFeature {
+                feature: "dag_fan_out",
+                node_or_edge: Some(n.id.clone()),
+                reason: format!(
+                    "node '{}' has {fan_out} outbound edges: DAG fan-out is branching/parallel \
+                     topology (LINEAR-ONLY v1); fail-closed, never flattened",
+                    n.id
+                ),
+            });
+        }
+        let fan_in = *indeg.get(n.id.as_str()).unwrap_or(&0);
+        if fan_in > 1 {
+            reasons.push(UnsupportedFeature {
+                feature: "dag_fan_in",
+                node_or_edge: Some(n.id.clone()),
+                reason: format!(
+                    "node '{}' has {fan_in} inbound edges: DAG fan-in (join) is not part of the \
+                     linear subset",
+                    n.id
+                ),
+            });
+        }
+    }
+    let entries: Vec<&TsNode> = nodes
+        .iter()
+        .filter(|n| *indeg.get(n.id.as_str()).unwrap_or(&0) == 0)
+        .collect();
+    match entries.len() {
+        0 if !nodes.is_empty() => reasons.push(UnsupportedFeature {
+            feature: "cycle",
+            node_or_edge: None,
+            reason: "the graph has no entry node (every node has an inbound edge) — a cycle".into(),
+        }),
+        n if n > 1 => reasons.push(UnsupportedFeature {
+            feature: "parallel_entries",
+            node_or_edge: Some(
+                entries
+                    .iter()
+                    .map(|e| e.id.as_str())
+                    .collect::<Vec<_>>()
+                    .join(","),
+            ),
+            reason: format!(
+                "{n} entry nodes: multiple roots are parallel/disconnected topology \
+                 (LINEAR-ONLY v1); fail-closed, never flattened"
+            ),
+        }),
+        _ => {}
+    }
+    if reasons.len() > before {
+        return None;
+    }
+
+    // Walk the single chain from the single entry.
+    let by_id: HashMap<&str, &TsNode> = nodes.iter().map(|n| (n.id.as_str(), n)).collect();
+    let mut chain: Vec<&TsNode> = Vec::with_capacity(nodes.len());
+    let mut visited: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    let mut cursor = entries.first().map(|n| n.id.as_str());
+    while let Some(id) = cursor {
+        if !visited.insert(id) {
+            reasons.push(UnsupportedFeature {
+                feature: "cycle",
+                node_or_edge: Some(id.to_string()),
+                reason: format!("the chain revisits node '{id}' — a cycle"),
+            });
+            return None;
+        }
+        chain.push(by_id[id]);
+        cursor = out.get(id).and_then(|next| next.first().copied());
+    }
+    if chain.len() != nodes.len() {
+        let unreached: Vec<&str> = nodes
+            .iter()
+            .map(|n| n.id.as_str())
+            .filter(|id| !visited.contains(id))
+            .collect();
+        reasons.push(UnsupportedFeature {
+            feature: "disconnected_parallel",
+            node_or_edge: Some(unreached.join(",")),
+            reason: format!(
+                "{} node(s) are not on the entry chain (disconnected/parallel islands): {}",
+                unreached.len(),
+                unreached.join(", ")
+            ),
+        });
+        return None;
+    }
+    Some(chain)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn features(t: &TsTranslation) -> Vec<&'static str> {
+        match t {
+            TsTranslation::Unsupported { reasons, .. } => {
+                reasons.iter().map(|r| r.feature).collect()
+            }
+            TsTranslation::Linear { .. } => vec![],
+        }
+    }
+
+    fn meta(t: &TsTranslation) -> &TsSourceMeta {
+        match t {
+            TsTranslation::Unsupported {
+                preserved_source_meta,
+                ..
+            } => preserved_source_meta,
+            TsTranslation::Linear { source_meta, .. } => source_meta,
+        }
+    }
+
+    /// A compiled-v2 wrapper around nodes/edges, mirroring
+    /// `FridayCompiledWorkflowGraphV2`.
+    fn compiled_v2(nodes: Value, edges: Value) -> Value {
+        json!({
+            "schemaVersion": "2.0",
+            "workflowId": "wf-ts-1",
+            "workflowVersionId": "wfv-ts-1",
+            "sourceSpecSchemaVersion": "1.0",
+            "graph": { "nodes": nodes, "edges": edges },
+            "failurePolicy": { "onFailure": "fail_fast", "notifyUser": false },
+            "tests": [],
+            "checksum": "abc123"
+        })
+    }
+
+    fn action(id: &str, callee: &str, args: Value) -> Value {
+        json!({ "id": id, "type": "tool_call", "config": { "ref": callee, "args": args } })
+    }
+
+    fn edge(from: &str, to: &str) -> Value {
+        json!({ "id": format!("{from}->{to}"), "sourceNodeId": from, "targetNodeId": to })
+    }
+
+    // --- the four prompt-mandated fail-closed panels ---------------------------
+
+    #[test]
+    fn dag_fan_out_input_fails_closed_with_honest_reasons() {
+        // a → b, a → c : fan-out (DAG). Must be Unsupported, never flattened.
+        let g = compiled_v2(
+            json!([
+                action("a", "read", json!({"path": "x"})),
+                action("b", "read", json!({"path": "y"})),
+                action("c", "read", json!({"path": "z"})),
+            ]),
+            json!([edge("a", "b"), edge("a", "c")]),
+        );
+        let t = translate_ts_published_version(&g, "dag");
+        let f = features(&t);
+        assert!(f.contains(&"dag_fan_out"), "features: {f:?}");
+        // honest reason names the offending node.
+        match &t {
+            TsTranslation::Unsupported { reasons, .. } => {
+                let r = reasons.iter().find(|r| r.feature == "dag_fan_out").unwrap();
+                assert_eq!(r.node_or_edge.as_deref(), Some("a"));
+                assert!(r.reason.contains("LINEAR-ONLY"), "reason: {}", r.reason);
+            }
+            _ => panic!("must be Unsupported"),
+        }
+        // preserved source meta survives (refs-only counts + ids).
+        let m = meta(&t);
+        assert_eq!(m.node_count, 3);
+        assert_eq!(m.edge_count, 2);
+        assert_eq!(m.workflow_id.as_deref(), Some("wf-ts-1"));
+    }
+
+    #[test]
+    fn branch_input_condition_node_and_conditional_edges_fail_closed() {
+        // a → cond, cond --true--> b, cond --false--> c : a branch.
+        let g = compiled_v2(
+            json!([
+                action("a", "read", json!({"path": "x"})),
+                { "id": "cond", "type": "condition", "config": { "expression": "$a.ok == true" } },
+                action("b", "read", json!({"path": "y"})),
+                action("c", "read", json!({"path": "z"})),
+            ]),
+            json!([
+                edge("a", "cond"),
+                { "id": "e-t", "sourceNodeId": "cond", "targetNodeId": "b", "condition": "true" },
+                { "id": "e-f", "sourceNodeId": "cond", "targetNodeId": "c", "condition": "false" },
+            ]),
+        );
+        let t = translate_ts_published_version(&g, "branch");
+        let f = features(&t);
+        assert!(f.contains(&"branch_condition_node"), "features: {f:?}");
+        assert!(f.contains(&"conditional_edge"), "features: {f:?}");
+        // ALL blockers are reported, not just the first.
+        assert!(f.len() >= 3, "full honest gap list: {f:?}");
+    }
+
+    #[test]
+    fn parallel_input_two_disconnected_chains_fails_closed() {
+        let g = compiled_v2(
+            json!([
+                action("a", "read", json!({"path": "x"})),
+                action("b", "read", json!({"path": "y"})),
+                action("p", "read", json!({"path": "z"})),
+                action("q", "read", json!({"path": "w"})),
+            ]),
+            json!([edge("a", "b"), edge("p", "q")]),
+        );
+        let t = translate_ts_published_version(&g, "parallel");
+        let f = features(&t);
+        assert!(f.contains(&"parallel_entries"), "features: {f:?}");
+        match &t {
+            TsTranslation::Unsupported { reasons, .. } => {
+                let r = reasons
+                    .iter()
+                    .find(|r| r.feature == "parallel_entries")
+                    .unwrap();
+                assert!(r.reason.contains("never flattened"), "reason: {}", r.reason);
+            }
+            _ => panic!("must be Unsupported"),
+        }
+    }
+
+    #[test]
+    fn unsupported_transform_input_fails_closed() {
+        // a transform (data) node mid-chain — TS aliases `transform` → `data`.
+        let g = compiled_v2(
+            json!([
+                action("a", "read", json!({"path": "x"})),
+                { "id": "t1", "type": "transform", "config": { "expression": "$a.content" } },
+            ]),
+            json!([edge("a", "t1")]),
+        );
+        let t = translate_ts_published_version(&g, "transform");
+        let f = features(&t);
+        assert!(f.contains(&"transform_node"), "features: {f:?}");
+        match &t {
+            TsTranslation::Unsupported { reasons, .. } => {
+                let r = reasons
+                    .iter()
+                    .find(|r| r.feature == "transform_node")
+                    .unwrap();
+                assert_eq!(r.node_or_edge.as_deref(), Some("t1"));
+                assert!(
+                    r.reason.contains("no transform/expression evaluator"),
+                    "reason: {}",
+                    r.reason
+                );
+            }
+            _ => panic!("must be Unsupported"),
+        }
+    }
+
+    // --- the prompt-mandated round-trip panel -----------------------------------
+
+    #[test]
+    fn pure_linear_input_round_trips_correctly() {
+        // manual trigger → read → write, with TS alias names + scalar args.
+        let g = compiled_v2(
+            json!([
+                { "id": "start", "type": "trigger", "config": { "type": "manual" } },
+                action("read-notes", "read", json!({"path": "notes.txt"})),
+                action("write-out", "write", json!({"path": "out.txt", "content": "hello"})),
+            ]),
+            json!([edge("start", "read-notes"), edge("read-notes", "write-out")]),
+        );
+        let t = translate_ts_published_version(&g, "ship-notes");
+        let TsTranslation::Linear {
+            definition,
+            source_meta,
+        } = t
+        else {
+            panic!("pure-linear source must translate: {t:?}");
+        };
+        // TS aliases map to canonical Rust actions through tool_name_map.
+        assert_eq!(definition.name, "ship-notes");
+        assert_eq!(definition.steps.len(), 2);
+        assert_eq!(definition.steps[0].id, "read-notes");
+        assert_eq!(definition.steps[0].action, "read_file");
+        assert_eq!(
+            definition.steps[0].params,
+            vec![("path".to_string(), "notes.txt".to_string())]
+        );
+        assert_eq!(definition.steps[1].action, "write_file");
+        // the leading manual trigger is EXPLICITLY recorded as elided.
+        assert!(source_meta.manual_trigger_elided);
+        assert_eq!(source_meta.node_count, 3);
+        assert_eq!(source_meta.source_schema_version.as_deref(), Some("2.0"));
+
+        // ROUND TRIP through the stored serde format and into the executable form.
+        let json = crate::workflow_def::definition_to_json(&definition).unwrap();
+        let back = crate::workflow_def::parse_definition_json(&json).unwrap();
+        assert_eq!(back, definition);
+        let exec = back.to_executable();
+        assert_eq!(exec.steps.len(), 2);
+        assert_eq!(exec.steps[0].action, "read_file");
+        // run-time honesty is preserved: the mutating write still checkpoints.
+        assert!(exec.requires_any_checkpoint());
+    }
+
+    #[test]
+    fn raw_top_level_nodes_without_graph_wrapper_also_translate() {
+        // parseGraphJson accepts raw graphs with top-level nodes/edges; mirror it.
+        let g = json!({
+            "nodes": [ action("only", "read", json!({"path": "a.txt"})) ],
+            "edges": []
+        });
+        let t = translate_ts_published_version(&g, "raw");
+        let TsTranslation::Linear {
+            definition,
+            source_meta,
+        } = t
+        else {
+            panic!("raw linear graph must translate: {t:?}");
+        };
+        assert_eq!(definition.steps.len(), 1);
+        assert!(!source_meta.manual_trigger_elided);
+    }
+
+    // --- per-feature fail-closed panels -------------------------------------------
+
+    #[test]
+    fn schedule_trigger_fails_closed_scheduler_is_s10() {
+        let g = compiled_v2(
+            json!([
+                { "id": "cron", "type": "trigger", "config": { "cron": "0 9 * * *", "timezone": "UTC" } },
+                action("a", "read", json!({"path": "x"})),
+            ]),
+            json!([edge("cron", "a")]),
+        );
+        let f = features(&translate_ts_published_version(&g, "scheduled"));
+        assert!(f.contains(&"trigger_not_manual"), "features: {f:?}");
+
+        // declared non-manual type fails closed too.
+        let g = compiled_v2(
+            json!([
+                { "id": "ev", "type": "trigger", "config": { "type": "event" } },
+                action("a", "read", json!({"path": "x"})),
+            ]),
+            json!([edge("ev", "a")]),
+        );
+        let f = features(&translate_ts_published_version(&g, "evented"));
+        assert!(f.contains(&"trigger_not_manual"), "features: {f:?}");
+    }
+
+    #[test]
+    fn ai_and_approval_nodes_fail_closed() {
+        let g = compiled_v2(
+            json!([
+                action("a", "read", json!({"path": "x"})),
+                { "id": "brain", "type": "ai", "config": { "prompt": "summarize" } },
+                { "id": "ok", "type": "human_approval", "config": {} },
+            ]),
+            json!([edge("a", "brain"), edge("brain", "ok")]),
+        );
+        let f = features(&translate_ts_published_version(&g, "rich"));
+        assert!(f.contains(&"ai_node"), "features: {f:?}");
+        assert!(f.contains(&"approval_node"), "features: {f:?}");
+    }
+
+    #[test]
+    fn expression_args_fail_closed_never_passed_literally() {
+        // `$steps.read.output` is a TS runtime expression (resolveValue evaluates
+        // strings starting with '$'); Rust has no evaluator, so it must BLOCK.
+        let g = compiled_v2(
+            json!([
+                action("a", "read", json!({"path": "x"})),
+                action("b", "write", json!({"path": "y", "content": "$a.output"})),
+            ]),
+            json!([edge("a", "b")]),
+        );
+        let f = features(&translate_ts_published_version(&g, "expr"));
+        assert!(f.contains(&"expression_param"), "features: {f:?}");
+    }
+
+    #[test]
+    fn non_scalar_and_unsafe_args_fail_closed() {
+        let g = compiled_v2(
+            json!([action("a", "read", json!({"path": {"nested": "object"}})),]),
+            json!([]),
+        );
+        let f = features(&translate_ts_published_version(&g, "nonscalar"));
+        assert!(f.contains(&"non_scalar_param"), "features: {f:?}");
+
+        let g = compiled_v2(
+            json!([action("a", "read", json!({"__proto__": "x", "path": "ok"}))]),
+            json!([]),
+        );
+        let f = features(&translate_ts_published_version(&g, "unsafe"));
+        assert!(f.contains(&"unsafe_param_key"), "features: {f:?}");
+    }
+
+    #[test]
+    fn ts_only_skill_call_fails_closed_no_rust_executor() {
+        // `web_search` is on TS_ONLY_UNMAPPED — no Rust executor; storing it as a
+        // runnable step would be a misrepresentation.
+        let g = compiled_v2(
+            json!([ { "id": "s", "type": "skill_call", "config": { "skillId": "web_search",
+                       "args": { "query": "rust" } } } ]),
+            json!([]),
+        );
+        let t = translate_ts_published_version(&g, "skill");
+        let f = features(&t);
+        assert!(f.contains(&"action_no_rust_executor"), "features: {f:?}");
+        match &t {
+            TsTranslation::Unsupported { reasons, .. } => {
+                let r = reasons
+                    .iter()
+                    .find(|r| r.feature == "action_no_rust_executor")
+                    .unwrap();
+                assert!(r.reason.contains("web_search"), "reason: {}", r.reason);
+            }
+            _ => panic!("must be Unsupported"),
+        }
+    }
+
+    #[test]
+    fn edit_args_are_renamed_per_recorded_param_schema_diff() {
+        let g = compiled_v2(
+            json!([action(
+                "e",
+                "edit",
+                json!({"path": "f.txt", "oldText": "a", "newText": "b"})
+            )]),
+            json!([]),
+        );
+        let TsTranslation::Linear { definition, .. } = translate_ts_published_version(&g, "edit")
+        else {
+            panic!("linear edit must translate");
+        };
+        assert_eq!(definition.steps[0].action, "edit_file");
+        let keys: Vec<&str> = definition.steps[0]
+            .params
+            .iter()
+            .map(|(k, _)| k.as_str())
+            .collect();
+        assert!(keys.contains(&"old_text") && keys.contains(&"new_text"));
+        assert!(!keys.contains(&"oldText") && !keys.contains(&"newText"));
+    }
+
+    #[test]
+    fn exec_only_knobs_fail_closed() {
+        let g = compiled_v2(
+            json!([action(
+                "x",
+                "exec",
+                json!({"command": "ls", "workdir": "/tmp"})
+            )]),
+            json!([]),
+        );
+        let f = features(&translate_ts_published_version(&g, "exec"));
+        assert!(f.contains(&"exec_param_no_rust_surface"), "features: {f:?}");
+
+        // plain command-only exec IS linear-translatable (and still gate-governed
+        // at run time: run_command is mutating → checkpoint).
+        let g = compiled_v2(
+            json!([action("x", "exec", json!({"command": "ls"}))]),
+            json!([]),
+        );
+        let TsTranslation::Linear { definition, .. } =
+            translate_ts_published_version(&g, "exec-ok")
+        else {
+            panic!("command-only exec must translate");
+        };
+        assert_eq!(definition.steps[0].action, "run_command");
+        assert!(definition.to_executable().requires_any_checkpoint());
+    }
+
+    #[test]
+    fn retry_timeout_failure_policy_and_variables_fail_closed() {
+        let g = json!({
+            "schemaVersion": "2.0",
+            "graph": {
+                "nodes": [
+                    { "id": "a", "type": "action",
+                      "config": { "ref": "read", "args": { "path": "x" } },
+                      "retryPolicy": { "maxAttempts": 3, "backoff": "exponential",
+                                       "baseDelayMs": 100, "maxDelayMs": 1000, "retryOn": [] },
+                      "timeoutMs": 5000 }
+                ],
+                "edges": [],
+                "variables": { "env": "prod" }
+            },
+            "failurePolicy": { "onFailure": "continue_on_error", "notifyUser": true },
+            "tests": [], "checksum": ""
+        });
+        let f = features(&translate_ts_published_version(&g, "knobs"));
+        assert!(f.contains(&"step_retry_policy"), "features: {f:?}");
+        assert!(f.contains(&"step_timeout"), "features: {f:?}");
+        assert!(f.contains(&"failure_policy"), "features: {f:?}");
+        assert!(f.contains(&"graph_variables"), "features: {f:?}");
+
+        // single-attempt retry policy is NOT a blocker (semantics identical).
+        let g = compiled_v2(
+            json!([ { "id": "a", "type": "action",
+                      "config": { "ref": "read", "args": { "path": "x" } },
+                      "retryPolicy": { "maxAttempts": 1, "backoff": "none",
+                                       "baseDelayMs": 0, "maxDelayMs": 0, "retryOn": [] } } ]),
+            json!([]),
+        );
+        assert!(matches!(
+            translate_ts_published_version(&g, "one-attempt"),
+            TsTranslation::Linear { .. }
+        ));
+    }
+
+    #[test]
+    fn cycle_and_unknown_node_type_fail_closed() {
+        let g = compiled_v2(
+            json!([
+                action("a", "read", json!({"path": "x"})),
+                action("b", "read", json!({"path": "y"})),
+            ]),
+            json!([edge("a", "b"), edge("b", "a")]),
+        );
+        let f = features(&translate_ts_published_version(&g, "cycle"));
+        assert!(
+            f.contains(&"cycle") || f.contains(&"dag_fan_in"),
+            "features: {f:?}"
+        );
+
+        // unknown type is NOT defaulted to action (deliberate divergence from TS).
+        let g = compiled_v2(
+            json!([ { "id": "w", "type": "webhook_wait", "config": {} } ]),
+            json!([]),
+        );
+        let f = features(&translate_ts_published_version(&g, "unknown"));
+        assert!(f.contains(&"unknown_node_type"), "features: {f:?}");
+    }
+
+    #[test]
+    fn never_partial_one_good_action_plus_one_blocked_node_translates_nothing() {
+        let g = compiled_v2(
+            json!([
+                action("good", "read", json!({"path": "x"})),
+                { "id": "bad", "type": "ai", "config": { "prompt": "p" } },
+            ]),
+            json!([edge("good", "bad")]),
+        );
+        let t = translate_ts_published_version(&g, "partial");
+        assert!(
+            matches!(t, TsTranslation::Unsupported { .. }),
+            "a partially-supported graph must translate NOTHING (never silent dropping)"
+        );
+    }
+
+    #[test]
+    fn unparseable_and_empty_graphs_fail_closed() {
+        let f = features(&translate_ts_published_version(
+            &json!("not an object"),
+            "x",
+        ));
+        assert!(f.contains(&"unparseable_graph"), "features: {f:?}");
+
+        let f = features(&translate_ts_published_version(
+            &json!({"no_nodes": true}),
+            "x",
+        ));
+        assert!(f.contains(&"unparseable_graph"), "features: {f:?}");
+
+        let g = compiled_v2(json!([]), json!([]));
+        let f = features(&translate_ts_published_version(&g, "empty"));
+        assert!(f.contains(&"empty_graph"), "features: {f:?}");
+
+        // a trigger-only graph has no executable steps.
+        let g = compiled_v2(
+            json!([ { "id": "start", "type": "trigger", "config": {} } ]),
+            json!([]),
+        );
+        let f = features(&translate_ts_published_version(&g, "trigger-only"));
+        assert!(f.contains(&"no_executable_steps"), "features: {f:?}");
+    }
+
+    #[test]
+    fn source_meta_is_refs_only_and_serializable() {
+        let g = compiled_v2(
+            json!([
+                { "id": "start", "type": "trigger", "config": { "type": "manual" } },
+                action("a", "read", json!({"path": "SUPER-SECRET-PATH.txt"})),
+            ]),
+            json!([edge("start", "a")]),
+        );
+        let TsTranslation::Linear { source_meta, .. } = translate_ts_published_version(&g, "meta")
+        else {
+            panic!("must translate");
+        };
+        let rendered = serde_json::to_string(&source_meta).unwrap();
+        // counts + ids + labels only — never node configs/args.
+        assert!(rendered.contains("\"node_count\":2"));
+        assert!(rendered.contains("\"trigger\":1"));
+        assert!(rendered.contains("\"action\":1"));
+        assert!(
+            !rendered.contains("SUPER-SECRET-PATH"),
+            "source_meta must never carry arg values: {rendered}"
+        );
+    }
+}

--- a/rust-core/crates/friday-hub/src/workflow_ts_translate.rs
+++ b/rust-core/crates/friday-hub/src/workflow_ts_translate.rs
@@ -43,9 +43,19 @@
 //! - **expression args** (`$…`), non-scalar args, unsafe keys, and the
 //!   `exec`-only knobs (`workdir`/`env`/`timeoutMs`/`background`) recorded in
 //!   [`crate::tool_name_map::PARAM_SCHEMA_DIFFS`] as having no Rust surface;
-//! - **per-step retry policies** (maxAttempts > 1) and **timeouts** (the Rust
-//!   engine has no per-step retry/timeout; dropping them silently would remove
-//!   a bound the author set);
+//! - **per-step retry policies** (maxAttempts > 1, plus any retryPolicy shape
+//!   that cannot be parsed — never guessed) and **timeouts** — BOTH the
+//!   node-level `timeoutMs` (the compiler's emission) and `config.timeoutMs`
+//!   (the field the TS node executor ACTUALLY honors at run time,
+//!   `friday-workflow-node-executor.ts`): the Rust engine has no per-step
+//!   retry/timeout; dropping either silently would remove a bound the author
+//!   set. Known residual divergence, documented not hidden: when NO timeout is
+//!   set, TS still applies an implicit 120s default per action node; the Rust
+//!   engine has no counterpart, so a translated step has no per-step clock at
+//!   all (an authored bound fails closed above; the implicit default does not);
+//! - **TS `read` line-window args** `offset`/`limit` (the TS `read` tool slices
+//!   lines; the Rust `read_file` executor reads ONLY `path` — translating them
+//!   would silently change what the step reads);
 //! - **failure policies** other than `fail_fast` (the Rust engine fails the
 //!   run on a step error; honoring `continue_on_error`/`fallback_step`/
 //!   `compensate`/`pause_for_approval` is unbuilt);
@@ -130,8 +140,23 @@ struct TsEdge {
     id: String,
     source: Option<String>,
     target: Option<String>,
-    condition: Option<String>,
+    /// ANY non-null `condition`/`when` value (string or not) — the TS DAG
+    /// scheduler truthy-checks the raw value, so a non-string condition still
+    /// gates the edge in TS; only `null`/absent is unconditional.
+    condition: Option<Value>,
     has_ports: bool,
+}
+
+/// Refs-only JSON shape label for honest reasons (never the value itself).
+fn json_type_label(v: &Value) -> &'static str {
+    match v {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
 }
 
 /// Mirror of the TS `normalizeWorkflowNodeType` alias table — minus its
@@ -235,7 +260,16 @@ fn normalize_edge(v: &Value, index: usize) -> TsEdge {
         id: pick(&["id"]).unwrap_or_else(|| format!("edge-{}", index + 1)),
         source,
         target,
-        condition: pick(&["condition", "when"]),
+        // Capture the RAW value (any non-null shape), not just non-empty
+        // strings: a non-string condition would otherwise pass as a plain
+        // linear edge while the TS scheduler truthy-checks (and on evaluation
+        // failure DISABLES) it — a silent flatten of gating routing.
+        condition: obj.and_then(|o| {
+            ["condition", "when"]
+                .iter()
+                .find_map(|k| o.get(*k).filter(|v| !v.is_null()))
+                .cloned()
+        }),
         has_ports: obj
             .is_some_and(|o| o.contains_key("sourcePort") || o.contains_key("targetPort")),
     }
@@ -293,6 +327,14 @@ const UNSAFE_ARG_KEYS: &[&str] = &["__proto__", "constructor", "prototype"];
 /// ([`crate::tool_name_map::PARAM_SCHEMA_DIFFS`]); silently dropping them would
 /// change semantics (e.g. lose a cwd or a timeout), so they fail closed.
 const EXEC_ONLY_KEYS: &[&str] = &["workdir", "env", "timeoutMs", "background"];
+
+/// TS `read`-only line-window args with no Rust `read_file` surface: the TS
+/// `read` tool declares AND honors `offset`/`limit` (1-indexed line slicing in
+/// `friday-agent-file-tools.ts`), while the Rust `read_file` executor reads
+/// ONLY `path` and ignores everything else — passing them through would
+/// silently read the WHOLE file where TS reads a window, so they fail closed
+/// ([`crate::tool_name_map::PARAM_SCHEMA_DIFFS`]).
+const READ_WINDOW_KEYS: &[&str] = &["offset", "limit"];
 
 /// Translate a TS published-version workflow graph (the
 /// `FridayWorkflowVersionEntity.graphJson` value) into the Rust LINEAR-ONLY
@@ -422,14 +464,18 @@ pub fn translate_ts_published_version(graph_json: &Value, name: &str) -> TsTrans
                 ),
             }),
         }
-        if let Some(retry) = &node.retry_policy {
-            let single_attempt = retry
+        // An explicit `retryPolicy: null` is NOT a policy (same null guard as
+        // timeoutMs — JS serializers commonly emit null for absent optionals);
+        // a present policy must be an object with an integer maxAttempts <= 1,
+        // anything else fails closed with a reason that states the truth.
+        if let Some(retry) = node.retry_policy.as_ref().filter(|v| !v.is_null()) {
+            match retry
                 .as_object()
                 .and_then(|o| o.get("maxAttempts"))
                 .and_then(Value::as_i64)
-                .is_some_and(|n| n <= 1);
-            if !single_attempt {
-                reasons.push(UnsupportedFeature {
+            {
+                Some(n) if n <= 1 => {} // single attempt: semantics identical
+                Some(_) => reasons.push(UnsupportedFeature {
                     feature: "step_retry_policy",
                     node_or_edge: Some(node.id.clone()),
                     reason: format!(
@@ -437,7 +483,17 @@ pub fn translate_ts_published_version(graph_json: &Value, name: &str) -> TsTrans
                          per-step retry; silently dropping it would change semantics",
                         node.id
                     ),
-                });
+                }),
+                None => reasons.push(UnsupportedFeature {
+                    feature: "step_retry_policy",
+                    node_or_edge: Some(node.id.clone()),
+                    reason: format!(
+                        "node '{}' carries a retryPolicy whose shape is unparseable (expected an \
+                         object with an integer maxAttempts); fail-closed rather than guessing \
+                         its retry semantics",
+                        node.id
+                    ),
+                }),
             }
         }
         if node.timeout_ms.as_ref().is_some_and(|v| !v.is_null()) {
@@ -446,6 +502,23 @@ pub fn translate_ts_published_version(graph_json: &Value, name: &str) -> TsTrans
                 node_or_edge: Some(node.id.clone()),
                 reason: format!(
                     "node '{}' sets timeoutMs: the Rust engine has no per-step timeout; silently \
+                     dropping it would remove a bound the author set",
+                    node.id
+                ),
+            });
+        }
+        // CONFIG-level timeoutMs is the one the TS node executor ACTUALLY
+        // honors at run time (`config.timeoutMs` overrides its implicit 120s
+        // default and aborts the skill call); the compiler emits the node-level
+        // twin, but generated/raw graphs carry it here — dropping it silently
+        // would remove a runtime-enforced bound the author set.
+        if node.config.get("timeoutMs").is_some_and(|v| !v.is_null()) {
+            reasons.push(UnsupportedFeature {
+                feature: "step_timeout",
+                node_or_edge: Some(node.id.clone()),
+                reason: format!(
+                    "node '{}' sets config.timeoutMs — the per-node timeout the TS node executor \
+                     enforces at run time; the Rust engine has no per-step timeout; silently \
                      dropping it would remove a bound the author set",
                     node.id
                 ),
@@ -464,11 +537,20 @@ pub fn translate_ts_published_version(graph_json: &Value, name: &str) -> TsTrans
     let node_ids: std::collections::HashSet<&str> = nodes.iter().map(|n| n.id.as_str()).collect();
     for edge in &edges {
         if let Some(cond) = &edge.condition {
+            // ANY non-null condition value blocks (mirrors the timeoutMs null
+            // guard): the TS scheduler truthy-checks the raw value and treats
+            // an evaluation FAILURE as edge-disabled, so even a non-string
+            // condition gates the downstream node in TS — translating it as an
+            // unconditional edge would silently flatten that routing.
+            let rendered = match cond {
+                Value::String(s) => format!("condition '{s}'"),
+                other => format!("a non-string condition (JSON {})", json_type_label(other)),
+            };
             reasons.push(UnsupportedFeature {
                 feature: "conditional_edge",
                 node_or_edge: Some(edge.id.clone()),
                 reason: format!(
-                    "edge '{}' carries condition '{cond}': conditional routing is branching \
+                    "edge '{}' carries {rendered}: conditional routing is branching \
                      (LINEAR-ONLY v1); fail-closed, never flattened",
                     edge.id
                 ),
@@ -500,33 +582,67 @@ pub fn translate_ts_published_version(graph_json: &Value, name: &str) -> TsTrans
     }
 
     // --- graph-level features ----------------------------------------------------
-    if graph_level
-        .get("variables")
-        .and_then(Value::as_object)
-        .is_some_and(|m| !m.is_empty())
-    {
-        reasons.push(UnsupportedFeature {
+    // ANY present, non-null `variables` value blocks unless it is an EMPTY
+    // object (the TS type is a Record). An array/scalar shape used to bypass
+    // this blocker entirely — shape-guarded now, fail-closed.
+    match graph_level.get("variables") {
+        None | Some(Value::Null) => {}
+        Some(Value::Object(m)) if m.is_empty() => {}
+        Some(Value::Object(_)) => reasons.push(UnsupportedFeature {
             feature: "graph_variables",
             node_or_edge: None,
             reason: "the graph declares variables: the Rust engine has no variable \
                      substitution; fail-closed"
                 .into(),
-        });
+        }),
+        Some(other) => reasons.push(UnsupportedFeature {
+            feature: "graph_variables",
+            node_or_edge: None,
+            reason: format!(
+                "the graph carries a 'variables' value of unsupported shape (JSON {}; the TS \
+                 type is an object map): the Rust engine has no variable substitution; \
+                 fail-closed rather than guessing",
+                json_type_label(other)
+            ),
+        }),
     }
-    if let Some(policy) = raw.get("failurePolicy").and_then(Value::as_object) {
-        if let Some(strategy) = as_str(policy.get("onFailure")) {
-            if strategy != "fail_fast" {
-                reasons.push(UnsupportedFeature {
-                    feature: "failure_policy",
-                    node_or_edge: None,
-                    reason: format!(
-                        "failurePolicy.onFailure = '{strategy}': the Rust engine only fail-fasts \
-                         (continue_on_error/fallback_step/compensate/pause_for_approval are \
-                         unbuilt); translating it would misrepresent the policy as honored"
-                    ),
-                });
-            }
-        }
+    // Shape-guarded failure policy: only absent/null, or an object whose
+    // `onFailure` is absent/null (TS reads undefined → effectively fail_fast)
+    // or the literal string "fail_fast", translates. A non-object policy or a
+    // non-string onFailure used to bypass the blocker — fail-closed now.
+    match raw.get("failurePolicy") {
+        None | Some(Value::Null) => {}
+        Some(Value::Object(policy)) => match policy.get("onFailure") {
+            None | Some(Value::Null) => {}
+            Some(Value::String(s)) if s == "fail_fast" => {}
+            Some(Value::String(strategy)) => reasons.push(UnsupportedFeature {
+                feature: "failure_policy",
+                node_or_edge: None,
+                reason: format!(
+                    "failurePolicy.onFailure = '{strategy}': the Rust engine only fail-fasts \
+                     (continue_on_error/fallback_step/compensate/pause_for_approval are \
+                     unbuilt); translating it would misrepresent the policy as honored"
+                ),
+            }),
+            Some(other) => reasons.push(UnsupportedFeature {
+                feature: "failure_policy",
+                node_or_edge: None,
+                reason: format!(
+                    "failurePolicy.onFailure is a non-string value (JSON {}); only the literal \
+                     'fail_fast' is translatable; fail-closed rather than guessing",
+                    json_type_label(other)
+                ),
+            }),
+        },
+        Some(other) => reasons.push(UnsupportedFeature {
+            feature: "failure_policy",
+            node_or_edge: None,
+            reason: format!(
+                "failurePolicy is not an object (JSON {}); only an object with \
+                 onFailure = 'fail_fast' is translatable; fail-closed rather than guessing",
+                json_type_label(other)
+            ),
+        }),
     }
 
     // --- topology: must be ONE linear chain covering every node -------------------
@@ -693,6 +809,20 @@ fn scan_action(node: &TsNode, reasons: &mut Vec<UnsupportedFeature>) {
                         reason: format!(
                             "action node '{}' exec arg '{key}' has no Rust run_command surface \
                              (PARAM_SCHEMA_DIFFS); dropping it would change semantics",
+                            node.id
+                        ),
+                    });
+                    continue;
+                }
+                if rust_action == "read_file" && READ_WINDOW_KEYS.contains(&key.as_str()) {
+                    reasons.push(UnsupportedFeature {
+                        feature: "read_param_no_rust_surface",
+                        node_or_edge: Some(node.id.clone()),
+                        reason: format!(
+                            "action node '{}' read arg '{key}' is a TS line-window the Rust \
+                             read_file executor does not honor (it reads only 'path'); \
+                             translating it would silently read the whole file instead of the \
+                             requested window",
                             node.id
                         ),
                     });
@@ -1390,5 +1520,282 @@ mod tests {
             !rendered.contains("SUPER-SECRET-PATH"),
             "source_meta must never carry arg values: {rendered}"
         );
+    }
+
+    // --- review-panel fix panels (PR #623 adversarial review) -------------------
+
+    #[test]
+    fn config_level_timeout_ms_fails_closed_like_node_level() {
+        // HIGH: the TS node executor honors config.timeoutMs (it overrides the
+        // implicit 120s default); the translator used to scan only node-level.
+        // Exact panel repro: an exec step whose 50ms bound would vanish.
+        let g = json!({
+            "schemaVersion": "2.0",
+            "graph": { "nodes": [
+                { "id": "a", "type": "action",
+                  "config": { "ref": "exec", "args": { "command": "sleep 999" },
+                              "timeoutMs": 50 } }
+            ], "edges": [] },
+            "failurePolicy": { "onFailure": "fail_fast" }, "tests": [], "checksum": ""
+        });
+        let t = translate_ts_published_version(&g, "t");
+        let f = features(&t);
+        assert!(f.contains(&"step_timeout"), "features: {f:?}");
+        match &t {
+            TsTranslation::Unsupported { reasons, .. } => {
+                let r = reasons
+                    .iter()
+                    .find(|r| r.feature == "step_timeout")
+                    .unwrap();
+                assert!(
+                    r.reason.contains("config.timeoutMs"),
+                    "reason must name the config-level key: {}",
+                    r.reason
+                );
+            }
+            _ => panic!("must be Unsupported"),
+        }
+
+        // the read-tool twin from the MED finding blocks too...
+        let g = compiled_v2(
+            json!([ { "id": "a", "type": "action",
+                      "config": { "ref": "read", "args": { "path": "x" },
+                                  "timeoutMs": 5000 } } ]),
+            json!([]),
+        );
+        let f = features(&translate_ts_published_version(&g, "t"));
+        assert!(f.contains(&"step_timeout"), "features: {f:?}");
+
+        // ...while an explicit null mirrors the node-level null guard (no blocker).
+        let g = compiled_v2(
+            json!([ { "id": "a", "type": "action",
+                      "config": { "ref": "read", "args": { "path": "x" },
+                                  "timeoutMs": null } } ]),
+            json!([]),
+        );
+        assert!(matches!(
+            translate_ts_published_version(&g, "t"),
+            TsTranslation::Linear { .. }
+        ));
+    }
+
+    #[test]
+    fn read_offset_limit_args_fail_closed_no_rust_surface() {
+        // HIGH: TS `read` honors offset/limit line-windows; Rust read_file reads
+        // only `path` — a translated window-read would silently read the WHOLE
+        // file. Exact panel repro.
+        let g = json!({
+            "schemaVersion": "2.0",
+            "graph": { "nodes": [
+                { "id": "a", "type": "action",
+                  "config": { "ref": "read",
+                              "args": { "path": "big.log", "offset": 100, "limit": 5 } } }
+            ], "edges": [] },
+            "failurePolicy": { "onFailure": "fail_fast", "notifyUser": false },
+            "tests": [], "checksum": ""
+        });
+        let t = translate_ts_published_version(&g, "wf");
+        let f = features(&t);
+        assert!(f.contains(&"read_param_no_rust_surface"), "features: {f:?}");
+        // BOTH window args are reported (full honest gap list for this node).
+        match &t {
+            TsTranslation::Unsupported { reasons, .. } => {
+                let window: Vec<_> = reasons
+                    .iter()
+                    .filter(|r| r.feature == "read_param_no_rust_surface")
+                    .collect();
+                assert_eq!(
+                    window.len(),
+                    2,
+                    "offset AND limit each blocked: {reasons:?}"
+                );
+            }
+            _ => panic!("must be Unsupported"),
+        }
+
+        // a path-only read still translates (and offset/limit on a NON-read tool
+        // are not exec/read knobs — write has no such keys in its TS schema, so
+        // they fall through to the generic scalar handling, unchanged behavior).
+        let g = compiled_v2(
+            json!([action("a", "read", json!({"path": "big.log"}))]),
+            json!([]),
+        );
+        assert!(matches!(
+            translate_ts_published_version(&g, "wf"),
+            TsTranslation::Linear { .. }
+        ));
+    }
+
+    #[test]
+    fn non_string_edge_condition_fails_closed_never_unconditional() {
+        // MED: the TS DAG scheduler truthy-checks the RAW condition value and
+        // disables the edge when evaluation fails — a non-string condition still
+        // gates the downstream node in TS. Exact panel repro (object condition).
+        let g = compiled_v2(
+            json!([
+                action("a", "read", json!({"path": "x"})),
+                action("b", "read", json!({"path": "y"})),
+            ]),
+            json!([ { "id": "e", "sourceNodeId": "a", "targetNodeId": "b",
+                      "condition": { "expr": "$a.ok" } } ]),
+        );
+        let t = translate_ts_published_version(&g, "t");
+        let f = features(&t);
+        assert!(f.contains(&"conditional_edge"), "features: {f:?}");
+        match &t {
+            TsTranslation::Unsupported { reasons, .. } => {
+                let r = reasons
+                    .iter()
+                    .find(|r| r.feature == "conditional_edge")
+                    .unwrap();
+                assert!(
+                    r.reason.contains("non-string condition"),
+                    "honest shape in reason: {}",
+                    r.reason
+                );
+            }
+            _ => panic!("must be Unsupported"),
+        }
+
+        // the `when` alias with a non-string value blocks too.
+        let g = compiled_v2(
+            json!([
+                action("a", "read", json!({"path": "x"})),
+                action("b", "read", json!({"path": "y"})),
+            ]),
+            json!([ { "id": "e", "sourceNodeId": "a", "targetNodeId": "b", "when": 1 } ]),
+        );
+        let f = features(&translate_ts_published_version(&g, "t"));
+        assert!(f.contains(&"conditional_edge"), "features: {f:?}");
+
+        // an explicit null condition is NOT a condition (TS truthy check passes
+        // it as unconditional) — stays linear.
+        let g = compiled_v2(
+            json!([
+                action("a", "read", json!({"path": "x"})),
+                action("b", "read", json!({"path": "y"})),
+            ]),
+            json!([ { "id": "e", "sourceNodeId": "a", "targetNodeId": "b",
+                      "condition": null } ]),
+        );
+        assert!(matches!(
+            translate_ts_published_version(&g, "t"),
+            TsTranslation::Linear { .. }
+        ));
+    }
+
+    #[test]
+    fn retry_policy_null_is_not_a_blocker_and_shapes_get_accurate_reasons() {
+        // MED: an explicit `retryPolicy: null` used to raise a FALSE
+        // step_retry_policy blocker claiming the node "carries retries".
+        let g = compiled_v2(
+            json!([ { "id": "a", "type": "action",
+                      "config": { "ref": "read", "args": { "path": "x" } },
+                      "retryPolicy": null } ]),
+            json!([]),
+        );
+        assert!(
+            matches!(
+                translate_ts_published_version(&g, "t"),
+                TsTranslation::Linear { .. }
+            ),
+            "retryPolicy: null carries no retry semantics — not a blocker"
+        );
+
+        // an unparseable shape still fails closed, with a reason that states the
+        // truth (unparseable) instead of falsely claiming retries.
+        for bad in [
+            json!({}),
+            json!("retry-hard"),
+            json!({ "maxAttempts": 1.5 }),
+        ] {
+            let g = compiled_v2(
+                json!([ { "id": "a", "type": "action",
+                          "config": { "ref": "read", "args": { "path": "x" } },
+                          "retryPolicy": bad } ]),
+                json!([]),
+            );
+            let t = translate_ts_published_version(&g, "t");
+            match &t {
+                TsTranslation::Unsupported { reasons, .. } => {
+                    let r = reasons
+                        .iter()
+                        .find(|r| r.feature == "step_retry_policy")
+                        .expect("unparseable retryPolicy must block");
+                    assert!(
+                        r.reason.contains("unparseable"),
+                        "accurate reason, not 'with retries': {}",
+                        r.reason
+                    );
+                }
+                _ => panic!("must be Unsupported"),
+            }
+        }
+
+        // genuine retries still produce the original honest reason.
+        let g = compiled_v2(
+            json!([ { "id": "a", "type": "action",
+                      "config": { "ref": "read", "args": { "path": "x" } },
+                      "retryPolicy": { "maxAttempts": 3 } } ]),
+            json!([]),
+        );
+        match translate_ts_published_version(&g, "t") {
+            TsTranslation::Unsupported { reasons, .. } => {
+                let r = reasons
+                    .iter()
+                    .find(|r| r.feature == "step_retry_policy")
+                    .unwrap();
+                assert!(r.reason.contains("with retries"), "reason: {}", r.reason);
+            }
+            _ => panic!("must be Unsupported"),
+        }
+    }
+
+    #[test]
+    fn variables_and_failure_policy_shape_bypasses_fail_closed() {
+        // LOW: an array-shaped `variables` used to bypass the graph_variables
+        // blocker entirely (as_object returned None).
+        let g = json!({
+            "schemaVersion": "2.0",
+            "graph": {
+                "nodes": [ action("a", "read", json!({"path": "x"})) ],
+                "edges": [],
+                "variables": [ { "name": "env", "value": "prod" } ]
+            },
+            "failurePolicy": { "onFailure": "fail_fast" }, "tests": [], "checksum": ""
+        });
+        let f = features(&translate_ts_published_version(&g, "t"));
+        assert!(f.contains(&"graph_variables"), "features: {f:?}");
+
+        // LOW: a plain-string failurePolicy used to bypass the failure_policy
+        // blocker (as_object returned None)...
+        let g = json!({
+            "schemaVersion": "2.0",
+            "graph": { "nodes": [ action("a", "read", json!({"path": "x"})) ], "edges": [] },
+            "failurePolicy": "continue_on_error", "tests": [], "checksum": ""
+        });
+        let f = features(&translate_ts_published_version(&g, "t"));
+        assert!(f.contains(&"failure_policy"), "features: {f:?}");
+
+        // ...and so did a non-string onFailure.
+        let g = json!({
+            "schemaVersion": "2.0",
+            "graph": { "nodes": [ action("a", "read", json!({"path": "x"})) ], "edges": [] },
+            "failurePolicy": { "onFailure": 123 }, "tests": [], "checksum": ""
+        });
+        let f = features(&translate_ts_published_version(&g, "t"));
+        assert!(f.contains(&"failure_policy"), "features: {f:?}");
+
+        // null / empty-object shapes remain non-blocking (TS-faithful defaults).
+        let g = json!({
+            "schemaVersion": "2.0",
+            "graph": { "nodes": [ action("a", "read", json!({"path": "x"})) ], "edges": [],
+                       "variables": {} },
+            "failurePolicy": null, "tests": [], "checksum": ""
+        });
+        assert!(matches!(
+            translate_ts_published_version(&g, "t"),
+            TsTranslation::Linear { .. }
+        ));
     }
 }

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -30,6 +30,7 @@ pub mod provider_timeline_store;
 pub mod run_result;
 mod schema;
 pub mod workflow;
+pub mod workflow_def;
 
 pub use agent_session::{
     append_session_message, ensure_session, ensure_session_with_owner, load_session_messages,

--- a/rust-core/crates/friday-storage/src/schema.rs
+++ b/rust-core/crates/friday-storage/src/schema.rs
@@ -679,8 +679,12 @@ CREATE INDEX idx_provider_timeline_pending_session
 //   linear-only translator). `source_meta` preserves refs-only provenance for a
 //   translated definition (ids / counts / coarse labels — never raw node
 //   configs, prompts, or secrets).
-// * `is_published` marks at most one published version per `workflow_id`
-//   (enforced by the typed `set_published`, exercised by tests).
+// * `is_published` marks at most one published version per `workflow_id`. The
+//   invariant is DB-ENFORCED by the partial UNIQUE index
+//   `idx_workflow_definition_one_published` (a second `is_published = 1` row for
+//   the same `workflow_id` is unrepresentable, even via hand edits/raw SQL), in
+//   addition to the transactional typed `set_published`; the published reader
+//   additionally refuses an ambiguous multi-published state (defense in depth).
 const DDL_WORKFLOW_DEFINITION: &str = "
 CREATE TABLE workflow_definition (
     workflow_id     TEXT NOT NULL CHECK(length(trim(workflow_id)) > 0),
@@ -695,7 +699,9 @@ CREATE TABLE workflow_definition (
     PRIMARY KEY(workflow_id, version)
 );
 CREATE INDEX idx_workflow_definition_published
-    ON workflow_definition(workflow_id, is_published);";
+    ON workflow_definition(workflow_id, is_published);
+CREATE UNIQUE INDEX idx_workflow_definition_one_published
+    ON workflow_definition(workflow_id) WHERE is_published = 1;";
 
 // --- PNS-001 provider-session fragments (Hub-only) --------------------------
 

--- a/rust-core/crates/friday-storage/src/schema.rs
+++ b/rust-core/crates/friday-storage/src/schema.rs
@@ -73,6 +73,13 @@ pub const HUB_ONLY_TABLES: &[&str] = &[
     "provider_timeline",
     "provider_timeline_event",
     "provider_timeline_pending",
+    // S8: versioned workflow DEFINITION store (DARK substrate). Workflow runs are
+    // Hub-coordinated (gate 21 §9 / `08`), so their definitions are Hub-only too.
+    // `definition_json` is the executable linear definition body kept Hub-side
+    // (like `run_result.answer`); readbacks/projections are refs-only. The table
+    // holds NO secret/key material — step params are tool-call arguments whose
+    // execution is still governed by the gate at run time.
+    "workflow_definition",
 ];
 
 /// Tables present only on a phone (never created on the Hub).
@@ -304,6 +311,19 @@ pub fn hub_migrations() -> Vec<Migration> {
             name: "agent_session_owner",
             destructive: false,
             up: m0021_agent_session_owner,
+        },
+        // S8: Hub-only versioned `workflow_definition` store (DARK substrate — no
+        // production route, no scheduler/trigger work, no live flip; workflow
+        // execution remains fenced in TS and is NOT product-replaced). Storage
+        // previously persisted workflow runs/steps ONLY; this adds the DEFINITION
+        // layer the `friday-hub::workflow_def` loader feeds to the EXISTING
+        // `workflow_exec` engine. Purely additive (CREATE TABLE + INDEX only) —
+        // touches no existing table, so v21 rows/queries are unaffected.
+        Migration {
+            version: 22,
+            name: "workflow_definition",
+            destructive: false,
+            up: m0022_workflow_definition,
         },
     ]
 }
@@ -637,6 +657,45 @@ CREATE TABLE provider_timeline_pending (
 );
 CREATE INDEX idx_provider_timeline_pending_session
     ON provider_timeline_pending(session_id, request_id);";
+
+// --- S8 workflow-definition fragment (Hub-only) ------------------------------
+
+// Versioned workflow DEFINITION store (S8, DARK substrate). One row per
+// `(workflow_id, version)`; a version row is IMMUTABLE once created (the typed
+// API is create / read / publish-flag flip / delete — never UPDATE of the body),
+// mirroring the TS published-version model (`workflow_versions` in
+// `src/state/sqlite/migrations/v001-initial.ts`: id / workflow_id /
+// version_number / checksum / graph_json / is_published).
+//
+// * `definition_json` is the Rust LINEAR definition body (schema_version-tagged
+//   JSON, parsed fail-closed by `friday-hub::workflow_def`) kept Hub-side like
+//   `run_result.answer` — it never crosses a refs-only readback.
+// * `checksum` is the sha256 (lowercase hex, 64 chars) of `definition_json`,
+//   DERIVED by the typed `create_definition` API (like `run_result.answer_sha256`);
+//   the CHECK makes a malformed hand-built fingerprint unrepresentable, and the
+//   typed readers re-derive + compare so a tampered body fails closed on read.
+// * `source` records provenance: `rust_native` (authored against the Rust types)
+//   or `ts_translated` (ingested from a TS published-version graph by the
+//   linear-only translator). `source_meta` preserves refs-only provenance for a
+//   translated definition (ids / counts / coarse labels — never raw node
+//   configs, prompts, or secrets).
+// * `is_published` marks at most one published version per `workflow_id`
+//   (enforced by the typed `set_published`, exercised by tests).
+const DDL_WORKFLOW_DEFINITION: &str = "
+CREATE TABLE workflow_definition (
+    workflow_id     TEXT NOT NULL CHECK(length(trim(workflow_id)) > 0),
+    version         INTEGER NOT NULL CHECK(version >= 1),
+    name            TEXT NOT NULL CHECK(length(trim(name)) > 0),
+    definition_json TEXT NOT NULL CHECK(length(definition_json) > 0),
+    checksum        TEXT NOT NULL CHECK(length(checksum) = 64),
+    source          TEXT NOT NULL CHECK(source IN ('rust_native', 'ts_translated')),
+    source_meta     TEXT,
+    is_published    INTEGER NOT NULL CHECK(is_published IN (0, 1)),
+    created_at      INTEGER NOT NULL,
+    PRIMARY KEY(workflow_id, version)
+);
+CREATE INDEX idx_workflow_definition_published
+    ON workflow_definition(workflow_id, is_published);";
 
 // --- PNS-001 provider-session fragments (Hub-only) --------------------------
 
@@ -1407,4 +1466,11 @@ fn m0021_agent_session_owner(tx: &Transaction) -> rusqlite::Result<()> {
          ALTER TABLE agent_session ADD COLUMN channel TEXT;
          ALTER TABLE agent_session ADD COLUMN user_id TEXT;",
     )
+}
+
+// S8: additive Hub-only versioned `workflow_definition` store (see the DDL const's
+// docs). Purely additive (CREATE TABLE + INDEX only) — touches no existing table,
+// so pre-existing rows and every existing query are unaffected.
+fn m0022_workflow_definition(tx: &Transaction) -> rusqlite::Result<()> {
+    tx.execute_batch(DDL_WORKFLOW_DEFINITION)
 }

--- a/rust-core/crates/friday-storage/src/workflow_def.rs
+++ b/rust-core/crates/friday-storage/src/workflow_def.rs
@@ -1,0 +1,321 @@
+//! Workflow DEFINITION persistence (S8; Hub-only). DARK substrate.
+//!
+//! Storage previously persisted workflow RUNS/STEPS only ([`crate::workflow`]);
+//! this module adds the versioned DEFINITION layer underneath them. It is the
+//! storage half of the S8 slice: `friday-hub::workflow_def` owns the definition
+//! JSON format (serde, schema_version-tagged, linear-only) and the loader that
+//! turns a stored row into the executable form the EXISTING `workflow_exec`
+//! engine consumes; this module owns only rows + invariants:
+//!
+//! * **Versioned + immutable**: one row per `(workflow_id, version)` (PK); the
+//!   API offers create / read / publish-flip / delete — never an UPDATE of the
+//!   definition body. A duplicate version is a fail-closed insert (PK
+//!   violation), mirroring the TS `workflow_versions` published-version model.
+//! * **Derived checksum**: `checksum` is the sha256 of `definition_json`,
+//!   computed HERE (the single insert chokepoint, like
+//!   `run_result.answer_sha256`), and re-derived + compared on every body read —
+//!   a hand-edited/tampered body fails CLOSED instead of loading.
+//! * **At most one published version** per `workflow_id` ([`set_published`]
+//!   clears siblings in the same call; the target is pre-checked so a missing
+//!   version can never unpublish the current one as a side effect).
+//! * **Fail-closed deletes**: deleting the published version is refused
+//!   (publish a different version first), so a published pointer can never
+//!   dangle.
+//! * **Refs-only listing**: [`list_definitions`] returns summaries WITHOUT the
+//!   `definition_json` / `source_meta` bodies, so projections/readbacks built on
+//!   it are refs-only by construction.
+//!
+//! Truth label: DARK substrate — no production route or scheduler consumes
+//! this; workflow execution remains fenced in TS and is NOT product-replaced;
+//! NOT v1 GO.
+
+use crate::error::{Result, StorageError};
+use rusqlite::{params, Connection, OptionalExtension};
+use sha2::{Digest, Sha256};
+
+/// Provenance of a stored workflow definition.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DefinitionSource {
+    /// Authored directly against the Rust definition types.
+    RustNative,
+    /// Ingested from a TS published-version graph by the LINEAR-ONLY translator
+    /// (`friday-hub::workflow_ts_translate`); `source_meta` preserves refs-only
+    /// provenance.
+    TsTranslated,
+}
+
+impl DefinitionSource {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            DefinitionSource::RustNative => "rust_native",
+            DefinitionSource::TsTranslated => "ts_translated",
+        }
+    }
+
+    /// Parse a stored label. Unknown labels fail CLOSED (a definition whose
+    /// provenance cannot be named is never silently defaulted).
+    fn parse(s: &str) -> Result<Self> {
+        match s {
+            "rust_native" => Ok(DefinitionSource::RustNative),
+            "ts_translated" => Ok(DefinitionSource::TsTranslated),
+            other => Err(StorageError::Unsupported(format!(
+                "workflow_definition has unknown source label '{other}' (fail-closed)"
+            ))),
+        }
+    }
+}
+
+/// The full stored row (body-bearing; Hub-side only — never project this shape
+/// over a refs-only readback).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WorkflowDefinitionRow {
+    pub workflow_id: String,
+    pub version: i64,
+    pub name: String,
+    pub definition_json: String,
+    pub checksum: String,
+    pub source: DefinitionSource,
+    pub source_meta: Option<String>,
+    pub is_published: bool,
+    pub created_at: i64,
+}
+
+/// Refs-only summary (no `definition_json`, no `source_meta`): safe for
+/// projections/readbacks.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WorkflowDefinitionSummary {
+    pub workflow_id: String,
+    pub version: i64,
+    pub name: String,
+    pub checksum: String,
+    pub source: DefinitionSource,
+    pub is_published: bool,
+    pub created_at: i64,
+}
+
+/// Input to [`create_definition`]. `checksum` is intentionally absent — it is
+/// DERIVED from `definition_json` at the insert chokepoint, so a divergent
+/// `(body, fingerprint)` pair is unrepresentable through the API.
+#[derive(Clone, Copy, Debug)]
+pub struct NewWorkflowDefinition<'a> {
+    pub workflow_id: &'a str,
+    pub version: i64,
+    pub name: &'a str,
+    pub definition_json: &'a str,
+    pub source: DefinitionSource,
+    /// Refs-only provenance for a translated definition (ids/counts/labels —
+    /// never raw node configs/prompts/secrets). The caller (hub layer) owns
+    /// that discipline; storage persists it opaquely.
+    pub source_meta: Option<&'a str>,
+}
+
+fn sha256_hex(s: &str) -> String {
+    let mut h = Sha256::new();
+    h.update(s.as_bytes());
+    let out = h.finalize();
+    let mut hex = String::with_capacity(64);
+    for b in out {
+        use std::fmt::Write as _;
+        let _ = write!(hex, "{b:02x}");
+    }
+    hex
+}
+
+/// Create a new (unpublished) definition version. Returns the derived checksum.
+/// A duplicate `(workflow_id, version)` fails closed (PK violation) — a stored
+/// version is immutable and can never be silently overwritten.
+pub fn create_definition(
+    conn: &Connection,
+    def: &NewWorkflowDefinition<'_>,
+    now: i64,
+) -> Result<String> {
+    let checksum = sha256_hex(def.definition_json);
+    conn.execute(
+        "INSERT INTO workflow_definition
+            (workflow_id, version, name, definition_json, checksum, source,
+             source_meta, is_published, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 0, ?8)",
+        params![
+            def.workflow_id,
+            def.version,
+            def.name,
+            def.definition_json,
+            checksum,
+            def.source.as_str(),
+            def.source_meta,
+            now
+        ],
+    )?;
+    Ok(checksum)
+}
+
+fn row_from_sql(r: &rusqlite::Row<'_>) -> rusqlite::Result<(WorkflowDefinitionRow, String)> {
+    let source_label: String = r.get(5)?;
+    Ok((
+        WorkflowDefinitionRow {
+            workflow_id: r.get(0)?,
+            version: r.get(1)?,
+            name: r.get(2)?,
+            definition_json: r.get(3)?,
+            checksum: r.get(4)?,
+            // placeholder; parsed (fail-closed) by the caller from `source_label`
+            source: DefinitionSource::RustNative,
+            source_meta: r.get(6)?,
+            is_published: r.get::<_, i64>(7)? != 0,
+            created_at: r.get(8)?,
+        },
+        source_label,
+    ))
+}
+
+/// Integrity gate shared by the body-bearing readers: re-derive the checksum
+/// from the stored body and fail CLOSED on mismatch (tampered/hand-edited row).
+fn verify_row(mut row: WorkflowDefinitionRow, source_label: &str) -> Result<WorkflowDefinitionRow> {
+    row.source = DefinitionSource::parse(source_label)?;
+    let derived = sha256_hex(&row.definition_json);
+    if derived != row.checksum {
+        return Err(StorageError::Unsupported(format!(
+            "workflow_definition '{}' v{} failed its checksum integrity check (stored fingerprint \
+             does not match the stored body); refusing to load",
+            row.workflow_id, row.version
+        )));
+    }
+    Ok(row)
+}
+
+const SELECT_COLUMNS: &str = "workflow_id, version, name, definition_json, checksum, source,
+     source_meta, is_published, created_at";
+
+/// Read one definition version (checksum-verified, fail-closed).
+pub fn get_definition(
+    conn: &Connection,
+    workflow_id: &str,
+    version: i64,
+) -> Result<Option<WorkflowDefinitionRow>> {
+    let got = conn
+        .query_row(
+            &format!(
+                "SELECT {SELECT_COLUMNS} FROM workflow_definition
+                 WHERE workflow_id = ?1 AND version = ?2"
+            ),
+            params![workflow_id, version],
+            row_from_sql,
+        )
+        .optional()?;
+    match got {
+        Some((row, label)) => Ok(Some(verify_row(row, &label)?)),
+        None => Ok(None),
+    }
+}
+
+/// Read the published version of a workflow (checksum-verified, fail-closed),
+/// or `None` if the workflow has no published version.
+pub fn get_published_definition(
+    conn: &Connection,
+    workflow_id: &str,
+) -> Result<Option<WorkflowDefinitionRow>> {
+    let got = conn
+        .query_row(
+            &format!(
+                "SELECT {SELECT_COLUMNS} FROM workflow_definition
+                 WHERE workflow_id = ?1 AND is_published = 1"
+            ),
+            params![workflow_id],
+            row_from_sql,
+        )
+        .optional()?;
+    match got {
+        Some((row, label)) => Ok(Some(verify_row(row, &label)?)),
+        None => Ok(None),
+    }
+}
+
+/// Refs-only listing of every stored definition version (no bodies), newest
+/// first within a workflow.
+pub fn list_definitions(conn: &Connection) -> Result<Vec<WorkflowDefinitionSummary>> {
+    let mut stmt = conn.prepare(
+        "SELECT workflow_id, version, name, checksum, source, is_published, created_at
+         FROM workflow_definition
+         ORDER BY workflow_id, version DESC",
+    )?;
+    let rows = stmt.query_map([], |r| {
+        Ok((
+            WorkflowDefinitionSummary {
+                workflow_id: r.get(0)?,
+                version: r.get(1)?,
+                name: r.get(2)?,
+                checksum: r.get(3)?,
+                source: DefinitionSource::RustNative, // parsed below, fail-closed
+                is_published: r.get::<_, i64>(5)? != 0,
+                created_at: r.get(6)?,
+            },
+            r.get::<_, String>(4)?,
+        ))
+    })?;
+    let mut out = Vec::new();
+    for r in rows {
+        let (mut summary, label) = r?;
+        summary.source = DefinitionSource::parse(&label)?;
+        out.push(summary);
+    }
+    Ok(out)
+}
+
+/// Mark exactly one version of `workflow_id` published (clearing any sibling's
+/// flag in the same call). The target is pre-checked so publishing a missing
+/// version is a fail-closed `NotFound` that leaves the current published
+/// version UNTOUCHED (the unpublish never runs without a valid target).
+pub fn set_published(conn: &Connection, workflow_id: &str, version: i64) -> Result<()> {
+    let exists: bool = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM workflow_definition WHERE workflow_id = ?1 AND version = ?2)",
+        params![workflow_id, version],
+        |r| r.get(0),
+    )?;
+    if !exists {
+        return Err(StorageError::NotFound(format!(
+            "workflow_definition '{workflow_id}' v{version} (cannot publish a missing version)"
+        )));
+    }
+    conn.execute(
+        "UPDATE workflow_definition SET is_published = 0
+         WHERE workflow_id = ?1 AND is_published = 1",
+        params![workflow_id],
+    )?;
+    conn.execute(
+        "UPDATE workflow_definition SET is_published = 1
+         WHERE workflow_id = ?1 AND version = ?2",
+        params![workflow_id, version],
+    )?;
+    Ok(())
+}
+
+/// Delete one definition version. Fail-closed rules: a missing version is
+/// `NotFound` (never a silent no-op success), and the PUBLISHED version is
+/// refused (publish a different version first) so the published pointer can
+/// never dangle.
+pub fn delete_definition(conn: &Connection, workflow_id: &str, version: i64) -> Result<()> {
+    let published: Option<i64> = conn
+        .query_row(
+            "SELECT is_published FROM workflow_definition
+             WHERE workflow_id = ?1 AND version = ?2",
+            params![workflow_id, version],
+            |r| r.get(0),
+        )
+        .optional()?;
+    match published {
+        None => Err(StorageError::NotFound(format!(
+            "workflow_definition '{workflow_id}' v{version}"
+        ))),
+        Some(p) if p != 0 => Err(StorageError::Unsupported(format!(
+            "workflow_definition '{workflow_id}' v{version} is the PUBLISHED version; refusing to \
+             delete it (publish a different version first)"
+        ))),
+        Some(_) => {
+            conn.execute(
+                "DELETE FROM workflow_definition WHERE workflow_id = ?1 AND version = ?2",
+                params![workflow_id, version],
+            )?;
+            Ok(())
+        }
+    }
+}

--- a/rust-core/crates/friday-storage/src/workflow_def.rs
+++ b/rust-core/crates/friday-storage/src/workflow_def.rs
@@ -15,12 +15,18 @@
 //!   computed HERE (the single insert chokepoint, like
 //!   `run_result.answer_sha256`), and re-derived + compared on every body read —
 //!   a hand-edited/tampered body fails CLOSED instead of loading.
-//! * **At most one published version** per `workflow_id` ([`set_published`]
-//!   clears siblings in the same call; the target is pre-checked so a missing
-//!   version can never unpublish the current one as a side effect).
+//! * **At most one published version** per `workflow_id`, enforced at THREE
+//!   layers: a partial UNIQUE index in the schema makes a second published row
+//!   unrepresentable even via raw SQL; [`set_published`] is a transaction that
+//!   clears siblings and sets the target atomically (a missing/concurrently
+//!   deleted target rolls back — the current published version is never
+//!   unpublished as a side effect, and a crash mid-call can never leave the
+//!   clear committed without the set); and [`get_published_definition`] fails
+//!   CLOSED if it ever observes more than one published row (defense in depth).
 //! * **Fail-closed deletes**: deleting the published version is refused
 //!   (publish a different version first), so a published pointer can never
-//!   dangle.
+//!   dangle. [`delete_definition`] runs its published-check and DELETE in one
+//!   transaction, so a concurrent publish cannot slip between them.
 //! * **Refs-only listing**: [`list_definitions`] returns summaries WITHOUT the
 //!   `definition_json` / `source_meta` bodies, so projections/readbacks built on
 //!   it are refs-only by construction.
@@ -30,8 +36,19 @@
 //! NOT v1 GO.
 
 use crate::error::{Result, StorageError};
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{params, Connection, OptionalExtension, Transaction, TransactionBehavior};
 use sha2::{Digest, Sha256};
+
+/// Open a write transaction on a shared `&Connection` (the module API takes
+/// `&Connection`, so the checked `Connection::transaction` is unavailable).
+/// IMMEDIATE acquires the write lock at BEGIN, so the read-then-write sequences
+/// below cannot interleave with another writer's between their statements.
+fn write_tx(conn: &Connection) -> Result<Transaction<'_>> {
+    Ok(Transaction::new_unchecked(
+        conn,
+        TransactionBehavior::Immediate,
+    )?)
+}
 
 /// Provenance of a stored workflow definition.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -210,23 +227,32 @@ pub fn get_definition(
 
 /// Read the published version of a workflow (checksum-verified, fail-closed),
 /// or `None` if the workflow has no published version.
+///
+/// Fail-closed on AMBIGUITY: if more than one published row matches (a state
+/// the partial unique index makes unrepresentable, but a hand-rebuilt DB could
+/// carry), this refuses to load rather than silently returning an arbitrary
+/// row — consistent with the tamper posture of the checksum/name gates.
 pub fn get_published_definition(
     conn: &Connection,
     workflow_id: &str,
 ) -> Result<Option<WorkflowDefinitionRow>> {
-    let got = conn
-        .query_row(
-            &format!(
-                "SELECT {SELECT_COLUMNS} FROM workflow_definition
-                 WHERE workflow_id = ?1 AND is_published = 1"
-            ),
-            params![workflow_id],
-            row_from_sql,
-        )
-        .optional()?;
-    match got {
-        Some((row, label)) => Ok(Some(verify_row(row, &label)?)),
-        None => Ok(None),
+    let mut stmt = conn.prepare(&format!(
+        "SELECT {SELECT_COLUMNS} FROM workflow_definition
+         WHERE workflow_id = ?1 AND is_published = 1"
+    ))?;
+    let mut rows: Vec<(WorkflowDefinitionRow, String)> = stmt
+        .query_map(params![workflow_id], row_from_sql)?
+        .collect::<rusqlite::Result<_>>()?;
+    match rows.len() {
+        0 => Ok(None),
+        1 => {
+            let (row, label) = rows.pop().expect("len checked");
+            Ok(Some(verify_row(row, &label)?))
+        }
+        n => Err(StorageError::Unsupported(format!(
+            "workflow_definition '{workflow_id}' has {n} published versions (the at-most-one \
+             invariant is violated — tampered/hand-rebuilt DB?); refusing to pick one"
+        ))),
     }
 }
 
@@ -262,39 +288,46 @@ pub fn list_definitions(conn: &Connection) -> Result<Vec<WorkflowDefinitionSumma
 }
 
 /// Mark exactly one version of `workflow_id` published (clearing any sibling's
-/// flag in the same call). The target is pre-checked so publishing a missing
-/// version is a fail-closed `NotFound` that leaves the current published
-/// version UNTOUCHED (the unpublish never runs without a valid target).
+/// flag in the same transaction).
+///
+/// ATOMIC + fail-closed: both UPDATEs run in one IMMEDIATE transaction, and the
+/// set-UPDATE's changed-row count is checked — publishing a missing (or
+/// concurrently deleted) version is `NotFound` and ROLLS BACK the clear, so the
+/// current published version is never unpublished as a side effect, a crash
+/// mid-call can never commit the clear without the set, and a 0-row target can
+/// never return a silent `Ok`. The schema's partial unique index independently
+/// makes a double-published end state unrepresentable.
 pub fn set_published(conn: &Connection, workflow_id: &str, version: i64) -> Result<()> {
-    let exists: bool = conn.query_row(
-        "SELECT EXISTS(SELECT 1 FROM workflow_definition WHERE workflow_id = ?1 AND version = ?2)",
-        params![workflow_id, version],
-        |r| r.get(0),
-    )?;
-    if !exists {
-        return Err(StorageError::NotFound(format!(
-            "workflow_definition '{workflow_id}' v{version} (cannot publish a missing version)"
-        )));
-    }
-    conn.execute(
+    let tx = write_tx(conn)?;
+    tx.execute(
         "UPDATE workflow_definition SET is_published = 0
          WHERE workflow_id = ?1 AND is_published = 1",
         params![workflow_id],
     )?;
-    conn.execute(
+    let set = tx.execute(
         "UPDATE workflow_definition SET is_published = 1
          WHERE workflow_id = ?1 AND version = ?2",
         params![workflow_id, version],
     )?;
+    if set != 1 {
+        // drop(tx) rolls back the clear: the previous published row survives.
+        return Err(StorageError::NotFound(format!(
+            "workflow_definition '{workflow_id}' v{version} (cannot publish a missing version)"
+        )));
+    }
+    tx.commit()?;
     Ok(())
 }
 
 /// Delete one definition version. Fail-closed rules: a missing version is
 /// `NotFound` (never a silent no-op success), and the PUBLISHED version is
 /// refused (publish a different version first) so the published pointer can
-/// never dangle.
+/// never dangle. The published-check and the DELETE run in one IMMEDIATE
+/// transaction, so a concurrent `set_published` of this version cannot land
+/// between them (the check-then-delete TOCTOU is closed).
 pub fn delete_definition(conn: &Connection, workflow_id: &str, version: i64) -> Result<()> {
-    let published: Option<i64> = conn
+    let tx = write_tx(conn)?;
+    let published: Option<i64> = tx
         .query_row(
             "SELECT is_published FROM workflow_definition
              WHERE workflow_id = ?1 AND version = ?2",
@@ -311,10 +344,11 @@ pub fn delete_definition(conn: &Connection, workflow_id: &str, version: i64) -> 
              delete it (publish a different version first)"
         ))),
         Some(_) => {
-            conn.execute(
+            tx.execute(
                 "DELETE FROM workflow_definition WHERE workflow_id = ?1 AND version = ?2",
                 params![workflow_id, version],
             )?;
+            tx.commit()?;
             Ok(())
         }
     }

--- a/rust-core/crates/friday-storage/tests/workflow_def_persist.rs
+++ b/rust-core/crates/friday-storage/tests/workflow_def_persist.rs
@@ -131,6 +131,79 @@ fn publish_is_exclusive_and_publish_missing_version_changes_nothing() {
 }
 
 #[test]
+fn double_publish_end_state_is_unrepresentable_at_the_db_layer() {
+    // Review finding (PR #623 panel): the single-published invariant was
+    // app-layer only — an interleaved second writer (or raw SQL) could leave
+    // TWO is_published=1 rows. The partial UNIQUE index in m0022 makes that end
+    // state unrepresentable even OUTSIDE the typed API.
+    let db = Db::open_hub(&temp_db_path("wfdef-unique")).unwrap();
+    create_definition(db.conn(), &def("wf1", 1, JSON_V1), 100).unwrap();
+    create_definition(db.conn(), &def("wf1", 2, JSON_V2), 200).unwrap();
+    set_published(db.conn(), "wf1", 1).unwrap();
+
+    // The raw-SQL equivalent of the interleaved second publisher's final SET.
+    let err = db
+        .conn()
+        .execute(
+            "UPDATE workflow_definition SET is_published = 1
+             WHERE workflow_id = 'wf1' AND version = 2",
+            [],
+        )
+        .unwrap_err();
+    assert!(
+        err.to_string().to_lowercase().contains("unique"),
+        "second published row must violate the partial unique index: {err}"
+    );
+    // ...while a DIFFERENT workflow's published row coexists fine.
+    create_definition(db.conn(), &def("wf2", 1, JSON_V1), 300).unwrap();
+    set_published(db.conn(), "wf2", 1).unwrap();
+}
+
+#[test]
+fn get_published_fails_closed_on_an_ambiguous_multi_published_state() {
+    // Defense in depth: even if the unique index is gone (hand-rebuilt DB), the
+    // reader must refuse an ambiguous state instead of returning an arbitrary row.
+    let db = Db::open_hub(&temp_db_path("wfdef-ambiguous")).unwrap();
+    create_definition(db.conn(), &def("wf1", 1, JSON_V1), 100).unwrap();
+    create_definition(db.conn(), &def("wf1", 2, JSON_V2), 200).unwrap();
+    db.conn()
+        .execute_batch(
+            "DROP INDEX idx_workflow_definition_one_published;
+             UPDATE workflow_definition SET is_published = 1 WHERE workflow_id = 'wf1';",
+        )
+        .unwrap();
+    let err = get_published_definition(db.conn(), "wf1").unwrap_err();
+    assert!(
+        err.to_string().contains("2 published versions"),
+        "ambiguous published state must fail closed, never resolve silently: {err}"
+    );
+}
+
+#[test]
+fn set_published_is_transactional_failed_target_rolls_back_the_clear() {
+    // Review finding: the clear-UPDATE and set-UPDATE used to be separate
+    // autocommit statements (crash window → ZERO published; deleted target →
+    // silent Ok). Now: one transaction + changed-row check, so a 0-row target
+    // rolls the clear back and the previous published version SURVIVES.
+    let db = Db::open_hub(&temp_db_path("wfdef-atomic")).unwrap();
+    create_definition(db.conn(), &def("wf1", 1, JSON_V1), 100).unwrap();
+    set_published(db.conn(), "wf1", 1).unwrap();
+
+    assert!(matches!(
+        set_published(db.conn(), "wf1", 99),
+        Err(StorageError::NotFound(_))
+    ));
+    assert_eq!(
+        get_published_definition(db.conn(), "wf1")
+            .unwrap()
+            .unwrap()
+            .version,
+        1,
+        "the failed publish must roll back its sibling-clear (v1 stays published)"
+    );
+}
+
+#[test]
 fn delete_is_fail_closed_for_missing_and_published_versions() {
     let db = Db::open_hub(&temp_db_path("wfdef-delete")).unwrap();
     create_definition(db.conn(), &def("wf1", 1, JSON_V1), 100).unwrap();
@@ -210,4 +283,19 @@ fn forward_migration_v21_to_v22_adds_workflow_definition_table() {
     assert_eq!(db.version().unwrap(), hub_max_version());
     create_definition(db.conn(), &def("wf1", 1, JSON_V1), 100).unwrap();
     assert!(get_definition(db.conn(), "wf1", 1).unwrap().is_some());
+    // The MIGRATED DB carries the single-published partial unique index too
+    // (m0022 was amended pre-ship; forward-only migrations make a later fix a v23).
+    let idx: i64 = db
+        .conn()
+        .query_row(
+            "SELECT count(*) FROM sqlite_master WHERE type = 'index'
+             AND name = 'idx_workflow_definition_one_published'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        idx, 1,
+        "v21→v22 migration must create the partial unique index"
+    );
 }

--- a/rust-core/crates/friday-storage/tests/workflow_def_persist.rs
+++ b/rust-core/crates/friday-storage/tests/workflow_def_persist.rs
@@ -1,0 +1,213 @@
+//! S8 workflow-definition persistence tests (DARK substrate): versioned
+//! immutable rows, derived + verified checksum, single-published invariant,
+//! fail-closed deletes, refs-only listing, and the additive v21→v22 forward
+//! migration.
+
+mod common;
+
+use common::temp_db_path;
+use friday_storage::workflow_def::{
+    create_definition, delete_definition, get_definition, get_published_definition,
+    list_definitions, set_published, DefinitionSource, NewWorkflowDefinition,
+};
+use friday_storage::{hub_migrations, Db, Profile, StorageError};
+
+fn hub_max_version() -> i64 {
+    hub_migrations().iter().map(|m| m.version).max().unwrap()
+}
+
+fn def<'a>(workflow_id: &'a str, version: i64, json: &'a str) -> NewWorkflowDefinition<'a> {
+    NewWorkflowDefinition {
+        workflow_id,
+        version,
+        name: "research",
+        definition_json: json,
+        source: DefinitionSource::RustNative,
+        source_meta: None,
+    }
+}
+
+const JSON_V1: &str = r#"{"schema_version":1,"name":"research","steps":[]}"#;
+const JSON_V2: &str = r#"{"schema_version":1,"name":"research","steps":[{"id":"a"}]}"#;
+
+#[test]
+fn create_get_roundtrip_with_derived_checksum() {
+    let db = Db::open_hub(&temp_db_path("wfdef-roundtrip")).unwrap();
+    let checksum = create_definition(db.conn(), &def("wf1", 1, JSON_V1), 100).unwrap();
+    assert_eq!(checksum.len(), 64, "sha256 lowercase hex");
+
+    let row = get_definition(db.conn(), "wf1", 1).unwrap().unwrap();
+    assert_eq!(row.workflow_id, "wf1");
+    assert_eq!(row.version, 1);
+    assert_eq!(row.name, "research");
+    assert_eq!(row.definition_json, JSON_V1);
+    assert_eq!(row.checksum, checksum);
+    assert_eq!(row.source, DefinitionSource::RustNative);
+    assert!(!row.is_published, "a new version starts unpublished");
+    assert_eq!(row.created_at, 100);
+
+    // missing version reads back as None (not an error).
+    assert!(get_definition(db.conn(), "wf1", 99).unwrap().is_none());
+}
+
+#[test]
+fn duplicate_version_fails_closed_immutable() {
+    let db = Db::open_hub(&temp_db_path("wfdef-dup")).unwrap();
+    create_definition(db.conn(), &def("wf1", 1, JSON_V1), 100).unwrap();
+    // The same (workflow_id, version) can never be overwritten (PK violation).
+    assert!(create_definition(db.conn(), &def("wf1", 1, JSON_V2), 200).is_err());
+    // ...but a NEW version and a different workflow both insert fine.
+    create_definition(db.conn(), &def("wf1", 2, JSON_V2), 200).unwrap();
+    create_definition(db.conn(), &def("wf2", 1, JSON_V1), 300).unwrap();
+}
+
+#[test]
+fn tampered_body_fails_closed_on_read() {
+    let db = Db::open_hub(&temp_db_path("wfdef-tamper")).unwrap();
+    create_definition(db.conn(), &def("wf1", 1, JSON_V1), 100).unwrap();
+    // Hand-edit the body OUTSIDE the typed API (checksum now stale).
+    db.conn()
+        .execute(
+            "UPDATE workflow_definition SET definition_json = ?1 WHERE workflow_id = 'wf1'",
+            [JSON_V2],
+        )
+        .unwrap();
+    let err = get_definition(db.conn(), "wf1", 1).unwrap_err();
+    assert!(
+        err.to_string().contains("integrity"),
+        "tampered row must fail closed: {err}"
+    );
+}
+
+#[test]
+fn publish_is_exclusive_and_publish_missing_version_changes_nothing() {
+    let db = Db::open_hub(&temp_db_path("wfdef-publish")).unwrap();
+    create_definition(db.conn(), &def("wf1", 1, JSON_V1), 100).unwrap();
+    create_definition(db.conn(), &def("wf1", 2, JSON_V2), 200).unwrap();
+
+    // no published version yet.
+    assert!(get_published_definition(db.conn(), "wf1")
+        .unwrap()
+        .is_none());
+
+    set_published(db.conn(), "wf1", 1).unwrap();
+    assert_eq!(
+        get_published_definition(db.conn(), "wf1")
+            .unwrap()
+            .unwrap()
+            .version,
+        1
+    );
+
+    // publishing v2 unpublishes v1 in the same call (at most ONE published).
+    set_published(db.conn(), "wf1", 2).unwrap();
+    let published = get_published_definition(db.conn(), "wf1").unwrap().unwrap();
+    assert_eq!(published.version, 2);
+    let flags: Vec<bool> = list_definitions(db.conn())
+        .unwrap()
+        .into_iter()
+        .map(|s| s.is_published)
+        .collect();
+    assert_eq!(
+        flags.iter().filter(|p| **p).count(),
+        1,
+        "exactly one published version"
+    );
+
+    // publishing a MISSING version is fail-closed AND leaves v2 published
+    // (the unpublish never runs without a valid target).
+    assert!(matches!(
+        set_published(db.conn(), "wf1", 99),
+        Err(StorageError::NotFound(_))
+    ));
+    assert_eq!(
+        get_published_definition(db.conn(), "wf1")
+            .unwrap()
+            .unwrap()
+            .version,
+        2,
+        "failed publish must not unpublish the current version"
+    );
+}
+
+#[test]
+fn delete_is_fail_closed_for_missing_and_published_versions() {
+    let db = Db::open_hub(&temp_db_path("wfdef-delete")).unwrap();
+    create_definition(db.conn(), &def("wf1", 1, JSON_V1), 100).unwrap();
+    create_definition(db.conn(), &def("wf1", 2, JSON_V2), 200).unwrap();
+    set_published(db.conn(), "wf1", 2).unwrap();
+
+    // deleting a missing version is NotFound, never a silent success.
+    assert!(matches!(
+        delete_definition(db.conn(), "wf1", 99),
+        Err(StorageError::NotFound(_))
+    ));
+    // deleting the PUBLISHED version is refused (the pointer can never dangle).
+    assert!(delete_definition(db.conn(), "wf1", 2).is_err());
+    assert!(get_published_definition(db.conn(), "wf1")
+        .unwrap()
+        .is_some());
+
+    // deleting an unpublished version works.
+    delete_definition(db.conn(), "wf1", 1).unwrap();
+    assert!(get_definition(db.conn(), "wf1", 1).unwrap().is_none());
+    assert!(get_definition(db.conn(), "wf1", 2).unwrap().is_some());
+}
+
+#[test]
+fn list_is_refs_only_summary_and_ordered() {
+    let db = Db::open_hub(&temp_db_path("wfdef-list")).unwrap();
+    create_definition(db.conn(), &def("wf1", 1, JSON_V1), 100).unwrap();
+    create_definition(db.conn(), &def("wf1", 2, JSON_V2), 200).unwrap();
+    create_definition(
+        db.conn(),
+        &NewWorkflowDefinition {
+            workflow_id: "wf2",
+            version: 1,
+            name: "ship",
+            definition_json: JSON_V1,
+            source: DefinitionSource::TsTranslated,
+            source_meta: Some(r#"{"node_count":3}"#),
+        },
+        300,
+    )
+    .unwrap();
+
+    let all = list_definitions(db.conn()).unwrap();
+    assert_eq!(all.len(), 3);
+    // ordered by workflow_id, then newest version first.
+    assert_eq!(
+        all.iter()
+            .map(|s| (s.workflow_id.as_str(), s.version))
+            .collect::<Vec<_>>(),
+        vec![("wf1", 2), ("wf1", 1), ("wf2", 1)]
+    );
+    assert_eq!(all[2].source, DefinitionSource::TsTranslated);
+    assert_eq!(all[2].name, "ship");
+    // The summary type carries NO body fields — enforced at compile time by the
+    // struct shape; here we assert the checksum is the only body-derived field.
+    assert_eq!(all[0].checksum.len(), 64);
+}
+
+#[test]
+fn forward_migration_v21_to_v22_adds_workflow_definition_table() {
+    let p = temp_db_path("wfdef-mig");
+    {
+        let mut migs = hub_migrations();
+        migs.retain(|m| m.version <= 21);
+        let db = Db::open(&p, Profile::Hub, &migs, "v21").unwrap();
+        assert_eq!(db.version().unwrap(), 21);
+        assert!(
+            !db.table_names()
+                .unwrap()
+                .iter()
+                .any(|t| t == "workflow_definition"),
+            "pre-v22 DB must not have workflow_definition"
+        );
+    }
+    // Re-open with the full set: the additive migration applies and the table works.
+    let db = Db::open_hub(&p).unwrap();
+    assert_eq!(db.version().unwrap(), hub_max_version());
+    create_definition(db.conn(), &def("wf1", 1, JSON_V1), 100).unwrap();
+    assert!(get_definition(db.conn(), "wf1", 1).unwrap().is_some());
+}


### PR DESCRIPTION
## Truth labels (read first)

**DARK substrate.** This PR registers NO production route, NO scheduler/trigger/daemon (that is S10, operator-gated), and changes NO TS runtime file. Workflow execution remains **fenced in TS and is NOT product-replaced**. This is **NOT v1 GO** — it is the S8 definition layer under the existing, already-merged Rust `workflow_exec` engine. Per slice-plan risk note: S8–S10 only ever cover LINEAR workflows; rich TS DAGs stay unrunnable — **never claim workflow parity**.

## Scope (slice plan S8 / inventory group C `S8-workflow-def`)

1. **Rust workflow-definition types + serde** (`friday-hub/src/workflow_def.rs`): `StoredWorkflowDefV1` — `schema_version`-tagged, LINEAR-only (ordered steps; linearity is structural — no edges field exists), `deny_unknown_fields`, version probed before strict parse. The step shape is the serde twin of the EXISTING `planner::WorkflowStep` — **no parallel step vocabulary, no second executor**.
2. **Storage** (`friday-storage`): additive hub migration **v21→v22** adding `workflow_definition` (versioned immutable rows, PK `(workflow_id, version)`; sha256 checksum DERIVED at the insert chokepoint and re-verified on read — tampered bodies fail closed; at-most-one published version per workflow; deleting the published version refused; refs-only `list_definitions` summary). Table registered in `HUB_ONLY_TABLES`. Follows the house additive-migration pattern (CREATE TABLE + INDEX only; forward-migration test included). Refs-only discipline: bodies (`definition_json`, `source_meta`) never cross a refs-only projection; no secrets/keys in any column.
3. **Loader**: `load_definition` / `load_published_definition` produce the exact `planner::WorkflowDefinition` the EXISTING `workflow_exec::run_workflow` consumes — proven by in-process seam tests that store → load → run through the **unmodified** engine (read-only steps auto-advance to Completed; a stored mutating step still pauses at the gate floor).
4. **TS-subset translation** (`friday-hub/src/workflow_ts_translate.rs`): ingests the TS published-version `graphJson` (`FridayCompiledWorkflowGraphV2`, plus the raw top-level `nodes`/`edges` shape `parseGraphJson` accepts). **HARD RULE (operator decision Q2, binding): LINEAR-ONLY, fail-closed** — see below.
5. **Definition CRUD**: create / get / get-published / list / delete + `store_published_version` (create+publish in one call), plus the dev-only refs-only inspect bin `hub_workflow_def_inspect` (mirrors the `hub_run_readback` house pattern: read-only DB open, forbidden-marker output guard; live-smoked locally). No production HTTP route; zero TS changes.

## Explicitly NOT supported → fail-closed `Unsupported { reasons, preserved_source_meta }` (never silent flattening, never partial)

- DAG topology: fan-out, fan-in, multiple entries, disconnected/parallel islands, cycles
- branching: `condition` nodes, conditional edges (`condition`/`when`), edge ports
- node types with no Rust executor semantics: `data`/`transform`, `ai`, `approval`, unknown types (TS defaults unknown→action; the translator deliberately fails closed instead)
- non-manual triggers (schedule/event/cron = S10 scheduler scope, operator-gated)
- actions not canonicalizable via the existing `tool_name_map::canonical_rust_name` single source of truth (TS-only skills/tools are never stored as runnable)
- expression args (`$…` — TS `resolveValue` evaluates these; Rust has no evaluator), non-scalar args, unsafe prototype keys, `exec`-only knobs (`workdir`/`env`/`timeoutMs`/`background`, per `PARAM_SCHEMA_DIFFS`)
- per-step retry policies (maxAttempts>1, plus any unparseable retryPolicy shape — `null` is honestly treated as absent) and timeouts — BOTH node-level `timeoutMs` and the `config.timeoutMs` the TS node executor actually honors at run time; TS `read` line-window args `offset`/`limit` (Rust `read_file` reads only `path`); failure policies other than `fail_fast` (shape-guarded: non-object policies and non-string `onFailure` also block); graph `variables` (shape-guarded: any non-null, non-empty-object value blocks)

ALL blockers in a source are reported (full honest gap list), and a partially-supported graph translates NOTHING. The only honest elision: a single LEADING manual trigger contributes no step and is explicitly recorded in `source_meta.manual_trigger_elided`.

## TS source format citations

- `src/workflows/model/friday-workflow.types.ts` — `FridayWorkflowVersionEntity.graphJson` (rows in `workflow_versions`, `v001-initial.ts`)
- `src/workflows/model/friday-workflow-graph.types.ts` — `FridayCompiledWorkflowGraphV2` + `parseGraphJson` (both accepted shapes; node-type alias table mirrored)
- `src/node-runner/engine/workflow-action-adapter.ts` — action callee = `config.skillId ?? config.ref`, args = `config.args`
- `src/workflows/engine/friday-workflow-node-executor.ts` — `resolveValue`: string args starting with `$` are runtime expressions

## Test evidence (local, head `dea0cc3e` on `75a75d7d` / #590)

- `cargo test --workspace`: **1084 passed, 0 failed** (incl. friday-arch-tests)
- New: **33 hub module tests** (28 original + 5 review-fix panels, see below) — incl. the four mandated fail-closed panels (`dag_fan_out_input_fails_closed_with_honest_reasons`, `branch_input_condition_node_and_conditional_edges_fail_closed`, `parallel_input_two_disconnected_chains_fails_closed`, `unsupported_transform_input_fails_closed`) + `pure_linear_input_round_trips_correctly` + engine-seam proofs (`loaded_definition_runs_through_the_existing_workflow_exec_engine`, `loaded_mutating_step_still_pauses_at_the_gate_floor`) + `never_partial_…`, `expression_args_…`, `ts_only_skill_call_…`, `schedule_trigger_…`, `source_meta_is_refs_only_and_serializable`
- New: **10 storage tests** (`workflow_def_persist.rs`) — checksum derivation + tamper fail-closed, immutability, publish exclusivity (+ failed-publish leaves state untouched + transactional rollback), **partial-unique-index double-publish unrepresentability**, **fail-closed ambiguous-published reader**, fail-closed deletes, refs-only listing, **v21→v22 forward migration (now also asserts the partial unique index exists post-migration)**
- New: **3 bin tests** + live smoke of `hub_workflow_def_inspect` (refs-only success payload; fail-closed `db_not_found`, exit 2)
- `cargo clippy --all-targets`: **0 warnings**; `cargo fmt --check`: clean
- `detect-secrets-hook` on all changed files vs `.secrets.baseline`: clean (baseline untouched); `check-provider-key-patterns.mjs`: clean
- No TS file touched (npm lint not applicable)

## Review fixes (adversarial panel on head `5d013af` — all confirmed HIGH/MED fixed in `dea0cc3e`, pre-merge while v22 was unshipped)

| Finding (severity) | Fix | Test |
|---|---|---|
| **HIGH** config-level `timeoutMs` silently dropped (TS node executor honors `config.timeoutMs`, translator scanned only node-level — incl. on `exec`) | per-node scan now blocks ANY non-null `config.timeoutMs` as `step_timeout` (same null guard as node-level); module docs record the TS implicit-120s-default residual divergence (no Rust counterpart) | `config_level_timeout_ms_fails_closed_like_node_level` (incl. the exact `exec`+`sleep 999`+50ms panel repro; null stays linear) |
| **HIGH** TS `read` `offset`/`limit` silently dropped (TS slices lines; Rust `read_file` reads ONLY `path` — verified, NOT equivalent → fail-closed chosen) | `READ_WINDOW_KEYS` blocked as `read_param_no_rust_surface` (mirrors the exec-only-knobs pattern); factually-wrong `PARAM_SCHEMA_DIFFS` "params align" note for `read` corrected | `read_offset_limit_args_fail_closed_no_rust_surface` (exact panel repro; both args reported; path-only read still linear) |
| **MED** single-published invariant app-layer-only, non-transactional, fail-open ambiguity | m0022 DDL (unshipped) amended: partial **UNIQUE** index `idx_workflow_definition_one_published ON workflow_definition(workflow_id) WHERE is_published = 1`; `set_published` = ONE IMMEDIATE transaction + changed-row-count check (0-row target ⇒ `NotFound` + rollback of the clear — never silent Ok, no crash window leaving zero published, pre-check TOCTOU closed); `delete_definition` check+DELETE in one transaction; `get_published_definition` fails CLOSED on >1 published rows | `double_publish_end_state_is_unrepresentable_at_the_db_layer`, `set_published_is_transactional_failed_target_rolls_back_the_clear`, `get_published_fails_closed_on_an_ambiguous_multi_published_state`, extended forward-migration test |
| **MED** non-string edge `condition` treated as unconditional (TS truthy-checks the raw value; eval failure DISABLES the edge) | edge `condition`/`when` captured as raw `Value`; ANY non-null value blocks as `conditional_edge` (timeoutMs-style null guard), reason names the JSON shape honestly | `non_string_edge_condition_fails_closed_never_unconditional` (exact panel repro: object condition; `when: 1`; `condition: null` stays linear) |
| **MED** `retryPolicy: null` raised a FALSE `step_retry_policy` blocker with a wrong reason | null ⇒ not a blocker (aligned with the timeoutMs null guard); non-object / non-integer-`maxAttempts` shapes block with an accurate "unparseable" reason; real retries keep the original reason | `retry_policy_null_is_not_a_blocker_and_shapes_get_accurate_reasons` |
| **LOW** `graph_variables` bypassed by array/non-object shapes | shape guard: any present non-null value other than an empty object blocks | `variables_and_failure_policy_shape_bypasses_fail_closed` |
| **LOW** `failure_policy` bypassed by non-object policy / non-string `onFailure` | shape guard: non-object policy and non-string `onFailure` block; absent/null `onFailure` stays non-blocking (TS reads undefined ⇒ effectively fail_fast) | same test |
| **LOW** `hub_workflow_def_inspect` never named in CI bin-build steps | added to `rust-core.yml` following the exact house pattern of the other five named bins | CI step (yaml-parse sanity checked) |

## Review carry-forwards (documented, deliberately NOT fixed here)

Remaining panel LOWs, kept visible for a follow-up slice rather than scope-crept into this fix-up: checksum identity-binding (body-only sha256, no workflow_id/version domain separation — accident detection, not tamper-proofing), `list_definitions` all-or-nothing on one bad source label (no per-row quarantine), doc-narrative nits (TS unknown-type default claim for non-empty labels; "all blockers reported" early-exit qualifiers), `UnsupportedFeature.reason` strings embedding raw source expression text (nothing persists them in this PR), translator accepting Rust-native/Rust-only callee names a TS run would 404 (still registry/gate-governed), translate-Linear-then-`validate`-rejects divergence for whitespace-only ids, integrity envelope not covering `is_published`/`source`/`source_meta` (the new unique index + fail-closed ambiguous reader close the worst case), `store_published_version` create+publish still two transactions (orphan unpublished version on mid-failure — fail-closed direction), and the pre-existing forward-only binary-rollback operational note.

## Changed files

- `rust-core/crates/friday-storage/src/schema.rs` (migration v22 + DDL + HUB_ONLY_TABLES)
- `rust-core/crates/friday-storage/src/workflow_def.rs` (new — typed CRUD)
- `rust-core/crates/friday-storage/src/lib.rs` (+1 line module export)
- `rust-core/crates/friday-storage/tests/workflow_def_persist.rs` (new)
- `rust-core/crates/friday-hub/src/workflow_def.rs` (new — serde + loader + CRUD wrappers)
- `rust-core/crates/friday-hub/src/workflow_ts_translate.rs` (new — linear-only translator)
- `rust-core/crates/friday-hub/src/lib.rs` (minimal delta: two `pub mod` blocks; rebased onto #590)
- `rust-core/crates/friday-hub/src/bin/hub_workflow_def_inspect.rs` (new — dev-only refs-only inspect)
- `rust-core/crates/friday-hub/src/tool_name_map.rs` (review fix: corrected factually-wrong `read` PARAM_SCHEMA_DIFFS note — TS `read` has offset/limit)
- `.github/workflows/rust-core.yml` (review fix: named bin-build step for `hub_workflow_def_inspect`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Re-verify carry-forwards (2-skeptic panel on fix-up dea0cc3e — verdict CLEAR_TO_MERGE, 0 blocking)

1. **store_published_version stays two-transaction** (create_definition autocommit + set_published tx). Crash between them leaves a committed UNPUBLISHED row with the prior published intact (fail-safe direction, strictly better than pre-fix); retry then hits the immutable-row PK violation and recovery needs a bare `set_published`. Deliberate non-fix; documented here.
2. **Falsy non-null edge conditions over-close**: `""`/`0`/`false` conditions are UNCONDITIONAL in TS (truthy-check / raw-path readString drop) but now block as `conditional_edge`. Safe direction (refuse-to-translate, never mis-execute); the in-code comment overclaims TS behavior for these shapes.
3. **`failurePolicy: {}` / `{onFailure: null}` translates on a wrong premise**: the code comment says TS treats undefined as effectively fail_fast, but the TS execution service's `switch(policy.onFailure)` has no default arm → undefined falls through = continue_on_error semantics. Translated workflow fail-fasts in Rust where TS would continue past failures (stricter/safer direction, pre-existing acceptance from the base commit). Revisit when S9 runtime semantics land.
4. **config.timeoutMs guard over-closes** on string/0/negative shapes that TS would ignore (falls back to its implicit 120s default); reason text slightly overclaims for those shapes. Fail-closed direction.
