### PR TITLE
fix(execrun): qualify Rust agent-run route by resolved provider kind (prod UUID-id shape) (dark)

### DIFF
--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -941,10 +941,16 @@ export function resolveApiRuntimeCanonicalGateRequired(env: NodeJS.ProcessEnv = 
 //      this route, and never set the marker → never admitted. This avoids the historical
 //      route-only-retirement trap of pinning at the method chokepoint.
 //   2. constraints.readOnly === true (hard-blocks every mutating tool at the runtime).
-//   3. DeepSeek-flash ONLY: providerId === "deepseek" AND requested model ===
-//      "deepseek-v4-flash". A request for deepseek-pro / codex / claude / chat / reasoner
-//      / a missing model → DISQUALIFIED (no silent downgrade to flash). If a taskProfile
-//      model override is present it must ALSO be exactly the flash identifier.
+//   3. DeepSeek-flash ONLY: the provider identity must be DeepSeek via EITHER real shape —
+//      providerId === "deepseek" (the literal id the test/RGG envs seed), OR the requested
+//      providerId RESOLVES to an enabled provider record whose kind === "deepseek"
+//      (production rows carry UUID ids, e.g. kind="deepseek", id="fa15f1fe-…"; the route
+//      wrapper populates `resolvedProvider` from ONE cheap providerService.getProvider
+//      read). Fail-closed: unresolvable / disabled / non-deepseek kind → DISQUALIFIED.
+//      AND requested model === "deepseek-v4-flash" (still LITERAL). A request for
+//      deepseek-pro / codex / claude / chat / reasoner / a missing model → DISQUALIFIED
+//      (no silent downgrade to flash). If a taskProfile model override is present it must
+//      ALSO be exactly the flash identifier.
 //   4. The 4 READ tools ONLY: the run must positively grant exactly the Rust read-tool
 //      set {read_file, list_dir, stat_file, search} via `allowedRustRouteTools`. Any other
 //      tool (run_command / write_file / edit_file / append_file / delete_file / move_file /
@@ -982,6 +988,18 @@ export interface RustRouteQualificationInput {
    */
   invokedFromHttpStartRunRoute?: boolean;
   providerId?: string;
+  /**
+   * Resolved provider RECORD identity for `providerId` (execrun prod-provider-shape fix).
+   * Production provider rows carry UUID ids with kind="deepseek"; only test/RGG envs seed
+   * the literal id "deepseek". The route wrapper populates this from ONE cheap
+   * `providerService.getProvider` read-by-id, ONLY when the literal id doesn't already
+   * match. Fail-closed: absent (unresolvable / lookup threw) OR `enabled !== true` OR
+   * `kind !== "deepseek"` → clause 3 disqualifies (falls to today's TS path; never throws).
+   */
+  resolvedProvider?: {
+    kind?: string;
+    enabled?: boolean;
+  };
   model?: string;
   sessionKey?: string;
   requireReview?: boolean;
@@ -1021,7 +1039,18 @@ export function qualifiesForRustReadOnlyRoute(input: RustRouteQualificationInput
   }
 
   // Clause 3 — DeepSeek-flash only; no silent downgrade, no pro/codex/claude/missing.
-  if (input.providerId !== RUST_ROUTE_DEEPSEEK_PROVIDER_ID) {
+  // Provider identity qualifies via EITHER real shape:
+  //   (a) the literal provider id "deepseek" (test/RGG envs seed the row with that id), OR
+  //   (b) a NON-EMPTY requested providerId whose RESOLVED record (route wrapper's cheap
+  //       getProvider read) has kind === "deepseek" AND enabled === true (production rows
+  //       carry UUID ids). Fail-closed: no resolved record / disabled / non-deepseek kind
+  //       → disqualified. A resolved record can never rescue a missing/blank providerId.
+  const resolvedDeepseekProvider =
+    typeof input.providerId === "string"
+    && input.providerId.trim().length > 0
+    && input.resolvedProvider?.kind === RUST_ROUTE_DEEPSEEK_PROVIDER_ID
+    && input.resolvedProvider.enabled === true;
+  if (input.providerId !== RUST_ROUTE_DEEPSEEK_PROVIDER_ID && !resolvedDeepseekProvider) {
     return false;
   }
   if (input.model !== RUST_ROUTE_DEEPSEEK_FLASH_MODEL) {
@@ -4267,9 +4296,35 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
     //     `deps.routeAgentRunViaRust`. The gate just below checks that resolved boolean.
     const routeStartRun: typeof startRun = async (input) => {
       if (deps.routeAgentRunViaRust === true) {
+        // execrun prod-provider-shape fix: production provider rows carry UUID ids with
+        // kind="deepseek", while test/RGG envs seed the literal id "deepseek". Clause 3 of
+        // the predicate accepts EITHER the literal id OR a resolved record whose kind is
+        // "deepseek" AND which is enabled. Resolve the record here — ONE cheap
+        // read-by-id (`providerService.getProvider` → profile-repo getById; far cheaper
+        // than the `resolveRoute` validation this same request already ran) — ONLY when
+        // the literal doesn't already match (literal-id envs stay byte-identical, zero
+        // extra reads). Fail-closed: unresolvable / lookup-throw / disabled /
+        // non-deepseek-kind ⇒ the predicate disqualifies ⇒ today's unchanged TS path
+        // (this resolution NEVER raises a new error class of its own).
+        let resolvedProvider: { kind: string; enabled: boolean } | undefined;
+        if (
+          typeof input.providerId === "string"
+          && input.providerId.trim().length > 0
+          && input.providerId !== RUST_ROUTE_DEEPSEEK_PROVIDER_ID
+        ) {
+          try {
+            const providerRecord = await deps.providerService.getProvider(input.providerId);
+            if (providerRecord) {
+              resolvedProvider = { kind: providerRecord.kind, enabled: providerRecord.enabled };
+            }
+          } catch {
+            // Unresolvable ⇒ resolvedProvider stays undefined ⇒ clause 3 disqualifies.
+          }
+        }
         const qualifies = qualifiesForRustReadOnlyRoute({
           invokedFromHttpStartRunRoute: true,
           providerId: input.providerId,
+          resolvedProvider,
           model: input.model,
           sessionKey: input.sessionKey,
           requireReview: input.requireReview,

--- a/test/unit/api/runtime/friday-api-runtime-rust-route-compose.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-rust-route-compose.test.ts
@@ -697,4 +697,33 @@ describe("FridayApiRuntime — execrun S-F-compose (DARK) Rust-route composition
     expect(ws.calls).toHaveLength(0);
     expect(readback.calls).toHaveLength(0);
   });
+
+  it("(p) VALID resolved deepseek record + one EXTRA tool in the grant → DISQUALIFIED → byte-identical 503; WS never touched (clause-bypass guard)", async () => {
+    // Review-MED regression guard: a valid resolved record must not short-circuit the
+    // LATER predicate clauses at the compose level — the allowlist-exactness clause still
+    // disqualifies even though the provider record fully qualifies.
+    db = createTestDb();
+    const ws = makeStubWsClient();
+    const readback = makeStubReadback(OWNER_PRINCIPAL);
+    const getProvider = vi.fn(async (providerId: string) =>
+      providerId === PROD_UUID_PROVIDER_ID ? makeProdProviderRecord() : null,
+    );
+    const runtime = makeRuntime(db, {
+      routeAgentRunViaRust: true,
+      wsClient: ws.service,
+      readback: readback.service,
+      providerService: makeProviderService({ getProvider }),
+    });
+
+    await expect(
+      callStartRoute(runtime, {
+        ...QUALIFYING_BODY,
+        providerId: PROD_UUID_PROVIDER_ID,
+        allowedRustRouteTools: [...QUALIFYING_BODY.allowedRustRouteTools, "run_command"],
+      }),
+    ).rejects.toMatchObject({ code: "TS_RUNTIME_AGENT_RUNS_RETIRED", httpStatus: 503 });
+    expect(ws.calls).toHaveLength(0);
+    expect(readback.calls).toHaveLength(0);
+    expect(countRows(db, "friday_agent_runs", RUN_ID)).toBe(0);
+  });
 });

--- a/test/unit/api/runtime/friday-api-runtime-rust-route-compose.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-rust-route-compose.test.ts
@@ -54,10 +54,12 @@ function makeSequenceIdGenerator(...ids: string[]): () => string {
 
 const RUN_ID_2 = "fixed-run-id-2";
 
-function makeProviderService(): FridayProviderService {
+function makeProviderService(
+  overrides: { getProvider?: (providerId: string) => Promise<unknown> } = {},
+): FridayProviderService {
   return {
     listProviders: vi.fn(async () => []),
-    getProvider: vi.fn(async () => null),
+    getProvider: overrides.getProvider ?? vi.fn(async () => null),
     createProvider: vi.fn(async () => ({} as never)),
     updateProvider: vi.fn(async () => ({} as never)),
     deleteProvider: vi.fn(async () => undefined),
@@ -166,6 +168,7 @@ interface ComposeDeps {
   clientSecretResolver?: () => Uint8Array | null;
   hubDbPath?: string;
   idGenerator?: () => string;
+  providerService?: FridayProviderService;
 }
 
 function makeRuntime(db: FridaySqliteLayer, opts: ComposeDeps) {
@@ -173,7 +176,7 @@ function makeRuntime(db: FridaySqliteLayer, opts: ComposeDeps) {
     db,
     idGenerator: opts.idGenerator ?? makeIdGenerator(RUN_ID),
     nowIso: () => NOW,
-    providerService: makeProviderService(),
+    providerService: opts.providerService ?? makeProviderService(),
     agentRuntime: makeAgentRuntime(),
     agentEventEmitter: createFridayAgentEventEmitter(),
     tokenSecret: "test-secret-key-that-is-at-least-32-chars-long!!", // pragma: allowlist secret
@@ -527,5 +530,171 @@ describe("FridayApiRuntime — execrun S-F-compose (DARK) Rust-route composition
       httpStatus: 503,
     });
     expect(ws.calls).toHaveLength(0);
+  });
+
+  // ── execrun prod-provider-shape fix — qualification by RESOLVED provider kind ──
+  // Production provider rows carry UUID ids (kind="deepseek", id="fa15f1fe-…"); only
+  // test/RGG envs seed the literal id "deepseek". Before this fix the predicate's literal
+  // clause + resolveRoute's id-only match were mutually unsatisfiable on prod data: the
+  // literal id 404'd at validation, the UUID id failed the literal clause → 503 always.
+  const PROD_UUID_PROVIDER_ID = "fa15f1fe-7e64-4d2c-9a1b-3c5d7e9f0a2b";
+
+  /** A prod-shaped provider PROFILE row: UUID id, kind="deepseek". */
+  function makeProdProviderRecord(overrides: { kind?: string; enabled?: boolean } = {}) {
+    return {
+      id: PROD_UUID_PROVIDER_ID,
+      kind: (overrides.kind ?? "deepseek") as never,
+      name: "DeepSeek (prod-shaped row)",
+      baseUrl: "https://api.deepseek.com",
+      enabled: overrides.enabled ?? true,
+      config: {
+        api: "openai-completions" as const,
+        authMode: "api-key" as const,
+        keySource: { kind: "env-ref" as const, envVar: "DEEPSEEK_API_KEY" },
+        supportedModels: ["deepseek-v4-flash"],
+        validation: { status: "ok" as const, checkedAt: NOW },
+      },
+      createdAt: NOW,
+      updatedAt: NOW,
+    };
+  }
+
+  function readProjectedProviderId(database: FridaySqliteLayer, runId: string): string | undefined {
+    return database.withReadConnection((d) =>
+      (d.prepare("SELECT provider_id AS p FROM friday_agent_runs WHERE id = ?").get(runId) as
+        | { p: string }
+        | undefined)?.p,
+    );
+  }
+
+  it("(j) prod UUID-id deepseek provider row → QUALIFIES and routes via Rust (the prod-shape fix)", async () => {
+    db = createTestDb();
+    const ws = makeStubWsClient();
+    const readback = makeStubReadback(OWNER_PRINCIPAL);
+    const getProvider = vi.fn(async (providerId: string) =>
+      providerId === PROD_UUID_PROVIDER_ID ? makeProdProviderRecord() : null,
+    );
+    const runtime = makeRuntime(db, {
+      routeAgentRunViaRust: true,
+      wsClient: ws.service,
+      readback: readback.service,
+      providerService: makeProviderService({ getProvider }),
+    });
+
+    const result = (await callStartRoute(runtime, {
+      ...QUALIFYING_BODY,
+      providerId: PROD_UUID_PROVIDER_ID,
+    })) as { runId: string; response: string; finalResponse?: string };
+
+    // The cheap read-by-id resolved the record, the run qualified, and the full Rust
+    // path was invoked.
+    expect(getProvider).toHaveBeenCalledWith(PROD_UUID_PROVIDER_ID);
+    expect(ws.calls).toHaveLength(1);
+    expect(result.runId).toBe(RUN_ID);
+    expect(result.response).toBe(OWNER_BODY);
+    expect(result.finalResponse).toBe(OWNER_BODY);
+    // Truth-labeling: the projected continuity row carries the REAL provider row id (the
+    // UUID the request used), not the literal — providerId downstream is labeling only.
+    expect(readProjectedProviderId(db, RUN_ID)).toBe(PROD_UUID_PROVIDER_ID);
+  });
+
+  it("(k) literal providerId \"deepseek\" still qualifies WITHOUT any record read (no regression, zero extra reads)", async () => {
+    db = createTestDb();
+    const ws = makeStubWsClient();
+    const readback = makeStubReadback(OWNER_PRINCIPAL);
+    const getProvider = vi.fn(async () => null);
+    const runtime = makeRuntime(db, {
+      routeAgentRunViaRust: true,
+      wsClient: ws.service,
+      readback: readback.service,
+      providerService: makeProviderService({ getProvider }),
+    });
+
+    const result = (await callStartRoute(runtime, { ...QUALIFYING_BODY })) as { response: string };
+
+    expect(result.response).toBe(OWNER_BODY);
+    expect(ws.calls).toHaveLength(1);
+    // The literal shape short-circuits BEFORE the record read → byte-identical for the
+    // existing test/RGG envs.
+    expect(getProvider).not.toHaveBeenCalled();
+  });
+
+  it("(l) UUID provider row of a NON-deepseek kind → DISQUALIFIED → byte-identical 503; WS never touched", async () => {
+    db = createTestDb();
+    const ws = makeStubWsClient();
+    const readback = makeStubReadback(OWNER_PRINCIPAL);
+    const runtime = makeRuntime(db, {
+      routeAgentRunViaRust: true,
+      wsClient: ws.service,
+      readback: readback.service,
+      providerService: makeProviderService({
+        getProvider: vi.fn(async () => makeProdProviderRecord({ kind: "anthropic" })),
+      }),
+    });
+
+    await expect(
+      callStartRoute(runtime, { ...QUALIFYING_BODY, providerId: PROD_UUID_PROVIDER_ID }),
+    ).rejects.toMatchObject({ code: "TS_RUNTIME_AGENT_RUNS_RETIRED", httpStatus: 503 });
+    expect(ws.calls).toHaveLength(0);
+    expect(readback.calls).toHaveLength(0);
+  });
+
+  it("(m) DISABLED deepseek-kind provider row → DISQUALIFIED → byte-identical 503; WS never touched", async () => {
+    db = createTestDb();
+    const ws = makeStubWsClient();
+    const readback = makeStubReadback(OWNER_PRINCIPAL);
+    const runtime = makeRuntime(db, {
+      routeAgentRunViaRust: true,
+      wsClient: ws.service,
+      readback: readback.service,
+      providerService: makeProviderService({
+        getProvider: vi.fn(async () => makeProdProviderRecord({ enabled: false })),
+      }),
+    });
+
+    await expect(
+      callStartRoute(runtime, { ...QUALIFYING_BODY, providerId: PROD_UUID_PROVIDER_ID }),
+    ).rejects.toMatchObject({ code: "TS_RUNTIME_AGENT_RUNS_RETIRED", httpStatus: 503 });
+    expect(ws.calls).toHaveLength(0);
+    expect(readback.calls).toHaveLength(0);
+  });
+
+  it("(n) UNRESOLVABLE providerId (no record) → DISQUALIFIED → byte-identical 503, no new error class", async () => {
+    db = createTestDb();
+    const ws = makeStubWsClient();
+    const readback = makeStubReadback(OWNER_PRINCIPAL);
+    const runtime = makeRuntime(db, {
+      routeAgentRunViaRust: true,
+      wsClient: ws.service,
+      readback: readback.service,
+      providerService: makeProviderService({ getProvider: vi.fn(async () => null) }),
+    });
+
+    await expect(
+      callStartRoute(runtime, { ...QUALIFYING_BODY, providerId: PROD_UUID_PROVIDER_ID }),
+    ).rejects.toMatchObject({ code: "TS_RUNTIME_AGENT_RUNS_RETIRED", httpStatus: 503 });
+    expect(ws.calls).toHaveLength(0);
+  });
+
+  it("(o) getProvider THROWS → resolution fails closed → byte-identical 503 (never a new error)", async () => {
+    db = createTestDb();
+    const ws = makeStubWsClient();
+    const readback = makeStubReadback(OWNER_PRINCIPAL);
+    const runtime = makeRuntime(db, {
+      routeAgentRunViaRust: true,
+      wsClient: ws.service,
+      readback: readback.service,
+      providerService: makeProviderService({
+        getProvider: vi.fn(async () => {
+          throw new Error("provider repo unavailable");
+        }),
+      }),
+    });
+
+    await expect(
+      callStartRoute(runtime, { ...QUALIFYING_BODY, providerId: PROD_UUID_PROVIDER_ID }),
+    ).rejects.toMatchObject({ code: "TS_RUNTIME_AGENT_RUNS_RETIRED", httpStatus: 503 });
+    expect(ws.calls).toHaveLength(0);
+    expect(readback.calls).toHaveLength(0);
   });
 });

--- a/test/unit/api/runtime/friday-api-runtime-rust-route-predicate.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-rust-route-predicate.test.ts
@@ -56,6 +56,85 @@ describe("qualifiesForRustReadOnlyRoute (execrun slice 4, dark predicate)", () =
     expect(qualifiesForRustReadOnlyRoute({ ...qualifyingInput(), providerId: undefined })).toBe(false);
   });
 
+  // ── Clause 3 (prod provider shape): resolved provider RECORD kind ────────────
+  // Production provider rows carry UUID ids (kind="deepseek", id="fa15f1fe-…"); only
+  // test/RGG envs seed the literal id "deepseek". The route wrapper resolves the record
+  // and passes `resolvedProvider`; the predicate must accept BOTH shapes, fail-closed.
+  const PROD_UUID_PROVIDER_ID = "fa15f1fe-7e64-4d2c-9a1b-3c5d7e9f0a2b";
+
+  it("admits a prod-shaped UUID provider id whose RESOLVED record is an enabled deepseek", () => {
+    expect(
+      qualifiesForRustReadOnlyRoute({
+        ...qualifyingInput(),
+        providerId: PROD_UUID_PROVIDER_ID,
+        resolvedProvider: { kind: "deepseek", enabled: true },
+      }),
+    ).toBe(true);
+  });
+
+  it("still admits the literal provider id \"deepseek\" WITHOUT any resolved record (test/RGG envs)", () => {
+    // The literal shape never depends on a record resolution (the route wrapper does not
+    // even perform the read when the literal matches).
+    expect(
+      qualifiesForRustReadOnlyRoute({ ...qualifyingInput(), resolvedProvider: undefined }),
+    ).toBe(true);
+  });
+
+  it("disqualifies a UUID provider id whose resolved record kind is NOT deepseek", () => {
+    expect(
+      qualifiesForRustReadOnlyRoute({
+        ...qualifyingInput(),
+        providerId: PROD_UUID_PROVIDER_ID,
+        resolvedProvider: { kind: "anthropic", enabled: true },
+      }),
+    ).toBe(false);
+  });
+
+  it("disqualifies a UUID provider id whose resolved deepseek record is DISABLED (or enabled-unknown)", () => {
+    expect(
+      qualifiesForRustReadOnlyRoute({
+        ...qualifyingInput(),
+        providerId: PROD_UUID_PROVIDER_ID,
+        resolvedProvider: { kind: "deepseek", enabled: false },
+      }),
+    ).toBe(false);
+    // enabled missing → uncertain → fail-closed
+    expect(
+      qualifiesForRustReadOnlyRoute({
+        ...qualifyingInput(),
+        providerId: PROD_UUID_PROVIDER_ID,
+        resolvedProvider: { kind: "deepseek" },
+      }),
+    ).toBe(false);
+  });
+
+  it("disqualifies an UNRESOLVABLE UUID provider id (no record) — fail-closed, never throws", () => {
+    const input: RustRouteQualificationInput = {
+      ...qualifyingInput(),
+      providerId: PROD_UUID_PROVIDER_ID,
+      // resolvedProvider intentionally absent (route wrapper found no record / lookup threw)
+    };
+    expect(() => qualifiesForRustReadOnlyRoute(input)).not.toThrow();
+    expect(qualifiesForRustReadOnlyRoute(input)).toBe(false);
+  });
+
+  it("a resolved deepseek record can NOT rescue a missing/blank providerId", () => {
+    expect(
+      qualifiesForRustReadOnlyRoute({
+        ...qualifyingInput(),
+        providerId: undefined,
+        resolvedProvider: { kind: "deepseek", enabled: true },
+      }),
+    ).toBe(false);
+    expect(
+      qualifiesForRustReadOnlyRoute({
+        ...qualifyingInput(),
+        providerId: "   ",
+        resolvedProvider: { kind: "deepseek", enabled: true },
+      }),
+    ).toBe(false);
+  });
+
   it("disqualifies deepseek-pro / codex / claude / a missing model (no downgrade to flash)", () => {
     for (const model of ["deepseek-v4-pro", "deepseek-chat", "deepseek-reasoner", "codex", "claude-3-7", undefined]) {
       expect(qualifiesForRustReadOnlyRoute({ ...qualifyingInput(), model })).toBe(false);

--- a/test/unit/api/runtime/friday-api-runtime-rust-route-predicate.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-rust-route-predicate.test.ts
@@ -135,6 +135,67 @@ describe("qualifiesForRustReadOnlyRoute (execrun slice 4, dark predicate)", () =
     ).toBe(false);
   });
 
+  // ── Clause-bypass regression guards (review MED) ─────────────────────────────
+  // A VALID resolved deepseek record must NOT short-circuit the LATER clauses: each test
+  // takes the fully-qualifying UUID+valid-resolved-record input (proven to qualify above)
+  // and flips exactly ONE later clause → still disqualified. Guards against a refactor
+  // that early-returns true once the resolved record is valid, skipping model-literal /
+  // taskProfile-override / 4-tool-allowlist / plan-review / no-session checks.
+
+  /** UUID providerId + valid resolved deepseek record; every other clause qualifying. */
+  function prodResolvedQualifyingInput(): RustRouteQualificationInput {
+    return {
+      ...qualifyingInput(),
+      providerId: PROD_UUID_PROVIDER_ID,
+      resolvedProvider: { kind: "deepseek", enabled: true },
+    };
+  }
+
+  it("a valid resolved record does NOT bypass the model-literal clause (deepseek-v4-pro)", () => {
+    expect(
+      qualifiesForRustReadOnlyRoute({ ...prodResolvedQualifyingInput(), model: "deepseek-v4-pro" }),
+    ).toBe(false);
+  });
+
+  it("a valid resolved record does NOT bypass the taskProfile model-override clause", () => {
+    expect(
+      qualifiesForRustReadOnlyRoute({
+        ...prodResolvedQualifyingInput(),
+        taskProfile: { model: "deepseek-v4-pro" },
+      }),
+    ).toBe(false);
+  });
+
+  it("a valid resolved record does NOT bypass allowlist exactness — one EXTRA tool", () => {
+    expect(
+      qualifiesForRustReadOnlyRoute({
+        ...prodResolvedQualifyingInput(),
+        allowedRustRouteTools: [...RUST_ROUTE_READ_TOOL_ALLOWLIST, "run_command"],
+      }),
+    ).toBe(false);
+  });
+
+  it("a valid resolved record does NOT bypass allowlist exactness — one MISSING tool", () => {
+    expect(
+      qualifiesForRustReadOnlyRoute({
+        ...prodResolvedQualifyingInput(),
+        allowedRustRouteTools: ["read_file", "list_dir", "stat_file"],
+      }),
+    ).toBe(false);
+  });
+
+  it("a valid resolved record does NOT bypass the no-session clause", () => {
+    expect(
+      qualifiesForRustReadOnlyRoute({ ...prodResolvedQualifyingInput(), sessionKey: "some-session" }),
+    ).toBe(false);
+  });
+
+  it("a valid resolved record does NOT bypass the plan-review clause (requireReview)", () => {
+    expect(
+      qualifiesForRustReadOnlyRoute({ ...prodResolvedQualifyingInput(), requireReview: true }),
+    ).toBe(false);
+  });
+
   it("disqualifies deepseek-pro / codex / claude / a missing model (no downgrade to flash)", () => {
     for (const model of ["deepseek-v4-pro", "deepseek-chat", "deepseek-reasoner", "codex", "claude-3-7", undefined]) {
       expect(qualifiesForRustReadOnlyRoute({ ...qualifyingInput(), model })).toBe(false);


### PR DESCRIPTION
## Defect (mutually unsatisfiable qualification on production data)

The dark Rust agent-run route could NEVER be taken on a prod-shaped DB — the two gates it must pass demanded contradictory provider identities:

1. **Literal-id predicate clause** — `src/api/runtime/friday-api-runtime.ts:973` defines `RUST_ROUTE_DEEPSEEK_PROVIDER_ID = "deepseek"`, and `qualifiesForRustReadOnlyRoute` clause 3 (previously `:1024`) required `input.providerId === "deepseek"` (the literal string).
2. **Id-only route validation** — the startRun HTTP route calls `validateRequestedRoute` (`src/api/http/routes/friday-agent-routes.ts:1233-1235`) → `providerService.resolveRoute` → `assertRequestedProviderAvailable` (`src/providers/services/friday-provider-service.ts:311-334`), which matches ONLY `candidate.id === requestedProviderId` (`:315`).

Production provider rows carry UUID ids (e.g. `kind="deepseek"`, `id="fa15f1fe-…"`). So:
- request `providerId="deepseek"` → 404 `PROVIDER_NOT_FOUND` at validation (no row with that literal id);
- request `providerId=<UUID>` → passes validation, then fails the literal predicate clause → falls to the TS 503 fence.

The route was only ever proven in envs where the provider row id IS literally `"deepseek"` (test/RGG seeds).

## Fix design (minimal, fail-closed, inside friday-api-runtime.ts only)

- `routeStartRun` (flag-ON branch only): when the requested `providerId` is a non-empty string that is NOT the literal `"deepseek"`, perform ONE cheap read-by-id — `deps.providerService.getProvider(providerId)` (profile-repo `getById`; far cheaper than the `resolveRoute` autoValidate the same request already ran) — and pass `{ kind, enabled }` to the predicate as `resolvedProvider`. The literal id short-circuits BEFORE the read → literal-id envs stay byte-identical with zero extra reads.
- Predicate clause 3 now qualifies the provider identity via EITHER real shape:
  - (a) literal `providerId === "deepseek"` (existing test/RGG envs — unchanged), OR
  - (b) non-empty `providerId` whose resolved record has `kind === "deepseek"` AND `enabled === true`.
- **Fail-closed guarantees**:
  - unresolvable id (no record) → disqualified (TS path);
  - `getProvider` THROWS → caught, disqualified (the resolution NEVER raises a new error class; byte-identical 503);
  - disabled record → disqualified;
  - `kind !== "deepseek"` → disqualified;
  - a resolved deepseek record can NOT rescue a missing/blank `providerId`;
  - flag OFF (default) → resolution code never runs → byte-identical to today.
- **No other predicate clause weakened**: readOnly, exact 4-tool allowlist, literal `"deepseek-v4-flash"` model (+ taskProfile override), no-session, no plan-review/override, `invokedFromHttpStartRunRoute` — all untouched.
- **Downstream verified**: `composeRustReadOnlyAgentRun` uses `providerId` only for projection truth-labeling (`routeId` + `provider_id` columns; the projector's `provider_kind` is the honest hardcoded `"unknown"`). No literal comparison exists downstream — the Rust server routes deepseek/flash itself. A UUID `providerId` on the projected row is MORE correct on prod shape (matches the real provider row id). Test (j) pins this.
- NO changes to `friday-provider-service.ts` semantics, NO Rust changes, NO other routes, no `.types.ts` change needed (`RustRouteQualificationInput` lives in `friday-api-runtime.ts`).

## Test evidence

New tests (12):
- Predicate (`friday-api-runtime-rust-route-predicate.test.ts`, 15→21):
  - UUID id + resolved `{kind:"deepseek", enabled:true}` → QUALIFIES;
  - literal `"deepseek"` WITHOUT any resolved record → still QUALIFIES (no regression);
  - resolved kind !== deepseek → disqualified;
  - disabled (and enabled-unknown) deepseek record → disqualified;
  - unresolvable UUID (no record) → disqualified, never throws;
  - resolved record cannot rescue missing/blank providerId.
- Route-level seam (`friday-api-runtime-rust-route-compose.test.ts`, 10→16):
  - (j) prod UUID-id deepseek row → qualifies, routes via Rust, projected row carries the UUID;
  - (k) literal id routes WITHOUT any `getProvider` call (zero extra reads, no regression);
  - (l) non-deepseek kind → byte-identical 503, WS never touched;
  - (m) disabled deepseek row → byte-identical 503, WS never touched;
  - (n) unresolvable id → byte-identical 503 (no new error class);
  - (o) `getProvider` throws → fail-closed → byte-identical 503.

Gates (all in the worktree off origin/main `75a75d7d`):
- `npm run typecheck` — clean.
- Targeted vitest (predicate + compose + flag files): 40/40 pass.
- `test/unit/api` suite: 1803/1803 pass.
- Full `--project default` suite: 12695 passed / 159 skipped / 1 failed — the single failure (`test/unit/providers/security/friday-secret-crypto.test.ts > getMasterKey > does not generate and write a keychain master key through process arguments`) is PRE-EXISTING and machine-local: it reproduces identically on CLEAN origin/main `75a75d7d` in this environment (this Mac's real keychain holds a Friday master key entry, so `getMasterKey()` resolves instead of throwing; CI ubuntu has no macOS keychain → expected green there). Unrelated to this diff (providers/security path untouched).
- `npm run lint`: 0 errors.
- `detect-secrets-hook` on changed files + `check-provider-key-patterns.mjs`: PASS.

## Truth label

Still **DARK / default-off** (`routeAgentRunViaRust` resolves default-false; mock-env pins false). This fix makes the qualification satisfiable on prod-shaped data once the operator flips the flag (6b production cutover remains an OPERATOR GATE). NOT v1 GO; no product-needle claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
