### PR TITLE
feat(rust-workflow): S9 — manual workflow-run bridge + refs-only readback (dark)

### DIFF
--- a/.github/workflows/rust-core.yml
+++ b/.github/workflows/rust-core.yml
@@ -78,6 +78,23 @@ jobs:
         # forbidden-marker guard (no bodies, no model call, no quota, no network, no
         # secret), so it is safe but unnecessary to execute in CI.
         run: cargo build -p friday-hub --bin hub_workflow_def_inspect
+      - name: Build bins (incl. S9 hub_workflow_run write-bridge)
+        # S9 manual workflow-run dev write-bridge (stored definition → S8 loader → the
+        # EXISTING workflow_exec engine, hard-wired deny-all so mutating steps stay
+        # gate-paused): names the bin explicitly so a missing/compile-broken
+        # `hub_workflow_run` reds CI loudly. Only BUILT here — running it executes a
+        # stored workflow against a dev DB/workspace (refs-only receipt, no production
+        # route, no scheduler), and live manual PRODUCTION workflow runs remain
+        # operator-gated, so it is never executed in CI.
+        run: cargo build -p friday-hub --bin hub_workflow_run
+      - name: Build bins (incl. read-only hub_workflow_run_readback surface)
+        # Read-only refs-only projection of one workflow run's run/step rows (the rows
+        # workflow_exec persists): names the bin explicitly so a missing/compile-broken
+        # `hub_workflow_run_readback` reds CI loudly. Only BUILT here — running it opens
+        # a hub DB read-only and emits refs-only labels/counts through the shared
+        # forbidden-marker guard (no bodies, no params, no evidence text, no model call,
+        # no quota, no network, no secret), so it is safe but unnecessary to execute in CI.
+        run: cargo build -p friday-hub --bin hub_workflow_run_readback
       - name: Test
         # The one live DeepSeek test is #[ignore]d, so this needs no network/secrets.
         run: cargo test --workspace

--- a/rust-core/crates/friday-hub/src/bin/hub_workflow_run.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_workflow_run.rs
@@ -21,13 +21,31 @@
 //!
 //! ## Output contract — REFS ONLY (no bodies, no params, no prompts, no secrets)
 //! One JSON object on stdout carrying ONLY safe identifiers/labels/counts:
-//! `truth_label="rust_wired_dev"`, run/workflow/version identifiers, the
-//! workflow name label, closed-vocab status + a BOUNDED `status_detail` token
-//! (never the engine's free-form failure text, which can embed executor error
-//! detail), the paused/failed step REF (`<run_id>:s<seq>`), step counts by
-//! status, and the audit-chain-verified bool. Step params, definition bodies and
-//! evidence text are NEVER emitted; [`reject_forbidden_output`] fails the whole
-//! receipt closed if any forbidden marker appears.
+//! `truth_label="rust_wired_dev"`, run/workflow/version identifiers, a BOUNDED
+//! projection of the free-form workflow name (`workflow_name_sha256` +
+//! `workflow_name_len` — the raw DB string is NEVER emitted, so a marker-bearing
+//! name is structurally impossible in output), closed-vocab status + a BOUNDED
+//! `status_detail` token (never the engine's free-form failure text, which can
+//! embed executor error detail), the paused/failed step REF (`<run_id>:s<seq>`),
+//! step counts by status (`verified`/`pending`/`proof_pending`/`failed`/
+//! `running` — the FULL persisted `StepStatus` vocabulary, so the five counters
+//! PARTITION `step_count`; note the engine persists an exec-errored
+//! non-side-effect step as `running`), and `audit_rows_verified` (the COUNT of
+//! hash-chain-verified audit rows — honest: the workflow driver writes zero
+//! audit rows today, so this is 0, attesting chain integrity over whatever rows
+//! exist, not workflow coverage). Step params, definition bodies and evidence
+//! text are NEVER emitted; [`reject_forbidden_output`] fails the whole receipt
+//! closed if any forbidden marker appears.
+//!
+//! ## Bridge-success semantics + known coarseness + dev fence (consumer notes)
+//! - A run whose ENGINE status is `failed` still exits 0 with `ok: true` — exit
+//!   0 means "the bridge dispatched and reported"; consumers MUST key on
+//!   `status`, never on the exit code alone.
+//! - A duplicate `--run-id` (engine single-shot, dup PK at `create_run`) and a
+//!   genuine storage failure both surface as `storage_failed` (known
+//!   coarseness; acceptable for a dev bridge).
+//! - `Db::open_hub` MIGRATES the target DB on open. NEVER point `--db` at the
+//!   production hub DB — this bin is for dev/temp DBs and workspaces only.
 
 use std::env;
 use std::path::Path;
@@ -112,14 +130,17 @@ fn run(args: &[String]) -> Result<String, BridgeError> {
         .unwrap_or(0);
     let run_id = arg_value(args, "--run-id")
         .unwrap_or_else(|| format!("hub_workflow_run_dev_{pid}_{nanos}"));
-    let now_ms = arg_value(args, "--now-ms")
-        .and_then(|v| v.parse::<i64>().ok())
-        .unwrap_or_else(|| {
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .map(|d| d.as_millis() as i64)
-                .unwrap_or(0)
-        });
+    // A PRESENT but unparsable --now-ms is bad_args (fail-closed) — never a
+    // silent wall-clock fallback (the same posture as --version above).
+    let now_ms = match arg_value(args, "--now-ms") {
+        Some(raw) => raw
+            .parse::<i64>()
+            .map_err(|_| BridgeError::new("bad_args"))?,
+        None => SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis() as i64)
+            .unwrap_or(0),
+    };
 
     let db = Db::open_hub(&db_path).map_err(|_| BridgeError::new("open_failed"))?;
     let executor = FsToolExecutor::new(&workspace_root);
@@ -160,7 +181,11 @@ fn run(args: &[String]) -> Result<String, BridgeError> {
         .map_err(|_| BridgeError::new("read_failed"))?;
     let pending_seq =
         first_pending_seq(db.conn(), &run_id).map_err(|_| BridgeError::new("read_failed"))?;
-    let audit_chain_verified = verify_audit_chain(db.conn()).is_ok();
+    // HONEST attestation: the COUNT of hash-chain-verified audit rows (the
+    // workflow driver writes zero audit rows today, so this is 0 — a bool here
+    // would be vacuously true). A broken chain fails the receipt closed.
+    let audit_rows_verified =
+        verify_audit_chain(db.conn()).map_err(|_| BridgeError::new("audit_verify_failed"))?;
 
     let count_status =
         |status: &str| -> usize { steps.iter().filter(|s| s.status == status).count() };
@@ -191,20 +216,27 @@ fn run(args: &[String]) -> Result<String, BridgeError> {
         "run_id": run_id,
         "workflow_id": stored_run.workflow_id,
         "version": stored_run.version,
-        "workflow_name": summary.name,
+        // The workflow name is a FREE-FORM DB string — never emitted verbatim.
+        // Bounded refs-only projection: sha256 hex + UTF-8 byte length.
+        "workflow_name_sha256": sha256_hex(summary.name.as_bytes()),
+        "workflow_name_len": summary.name.len(),
         "run_state": summary.state,
         "status": status,
         "status_detail": status_detail,
         "step_ref": step_ref,
         "executed_steps": stored_run.outcome.executed_steps,
         "step_count": steps.len(),
+        // The FULL persisted StepStatus vocabulary — these five PARTITION
+        // step_count ('running' is how the engine persists an exec-errored
+        // non-side-effect step: resolve_step_completion(false, false, false)).
         "verified_count": count_status("verified"),
         "pending_count": count_status("pending"),
         "proof_pending_count": count_status("proof_pending"),
         "failed_count": count_status("failed"),
+        "running_count": count_status("running"),
         "side_effect_step_count": steps.iter().filter(|s| s.has_side_effect).count(),
         "first_pending_seq": pending_seq,
-        "audit_chain_verified": audit_chain_verified,
+        "audit_rows_verified": audit_rows_verified,
     });
 
     let rendered =
@@ -287,6 +319,19 @@ fn ephemeral_dev_secret(pid: u32, nanos: u128) -> Vec<u8> {
     let mut hasher = Sha256::new();
     hasher.update(format!("hub-workflow-run-dev-bridge:{pid}:{nanos}").as_bytes());
     hasher.finalize().to_vec()
+}
+
+/// Lowercase sha256 hex — the bounded projection of a free-form DB string
+/// (mirrors `hub_run_task::sha256_hex`).
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let digest = hasher.finalize();
+    let mut out = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        out.push_str(&format!("{byte:02x}"));
+    }
+    out
 }
 
 /// Defense-in-depth: refuse to print if any forbidden marker leaked into the
@@ -383,6 +428,21 @@ mod tests {
         args
     }
 
+    /// The five status counters (the FULL persisted StepStatus vocabulary) must
+    /// PARTITION step_count — no persisted step status is ever invisible to the
+    /// receipt (the original four-counter set silently dropped 'running').
+    fn assert_counters_partition_step_count(v: &Value) {
+        let sum = ["verified", "pending", "proof_pending", "failed", "running"]
+            .iter()
+            .map(|s| v[&format!("{s}_count")].as_u64().unwrap())
+            .sum::<u64>();
+        assert_eq!(
+            sum,
+            v["step_count"].as_u64().unwrap(),
+            "status counters must partition step_count: {v}"
+        );
+    }
+
     #[test]
     fn arg_value_supports_space_and_equals_forms() {
         let args = vec![
@@ -421,7 +481,10 @@ mod tests {
         assert_eq!(v["run_id"], "run1");
         assert_eq!(v["workflow_id"], "wf1");
         assert_eq!(v["version"], 3, "published version resolved + reported");
-        assert_eq!(v["workflow_name"], "research");
+        // The free-form name is projected BOUNDED (hash + byte length), never verbatim.
+        assert_eq!(v["workflow_name_sha256"], sha256_hex(b"research"));
+        assert_eq!(v["workflow_name_len"], "research".len());
+        assert!(v.get("workflow_name").is_none(), "raw name never emitted");
         assert_eq!(v["status"], "completed");
         assert_eq!(v["run_state"], "done");
         assert_eq!(v["status_detail"], Value::Null);
@@ -430,10 +493,17 @@ mod tests {
         assert_eq!(v["step_count"], 2);
         assert_eq!(v["verified_count"], 2);
         assert_eq!(v["pending_count"], 0);
+        assert_eq!(v["running_count"], 0);
+        assert_counters_partition_step_count(&v);
         assert_eq!(v["first_pending_seq"], Value::Null);
+        // Honest audit attestation: a COUNT (0 — the workflow driver writes no
+        // audit rows), never a vacuous bool.
+        assert_eq!(v["audit_rows_verified"], 0);
+        assert!(v.get("audit_chain_verified").is_none());
         // Refs-only: no step params / definition body / evidence text fields.
         assert!(v.get("steps").is_none());
         assert!(!rendered.contains("notes.txt"), "no path/body text leaks");
+        assert!(!rendered.contains("research"), "name label not verbatim");
         assert!(reject_forbidden_output(&rendered).is_ok());
     }
 
@@ -458,6 +528,27 @@ mod tests {
             .err()
             .unwrap();
         assert_eq!(err.kind, "bad_args");
+    }
+
+    #[test]
+    fn unparsable_now_ms_is_bad_args_never_a_silent_wall_clock_fallback() {
+        let (db, ws) = seeded(
+            "badnow",
+            &def(
+                "research",
+                vec![step("read", "read_file", &[("path", "notes.txt")])],
+            ),
+            1,
+        );
+        let err = run(&bin_args(&db, &ws, &["--now-ms=soon"])).err().unwrap();
+        assert_eq!(err.kind, "bad_args");
+        // And the parsable form still works (the fail-closed check is on
+        // PRESENT-but-unparsable, not on presence).
+        let rendered = run(&bin_args(&db, &ws, &["--now-ms=500", "--run-id=run-now"]))
+            .map_err(|e| e.kind)
+            .unwrap();
+        let v: Value = from_str(&rendered).unwrap();
+        assert_eq!(v["status"], "completed");
     }
 
     #[test]
@@ -489,6 +580,8 @@ mod tests {
         assert_eq!(v["step_ref"], "run1:s1");
         assert_eq!(v["executed_steps"], 1);
         assert_eq!(v["pending_count"], 1);
+        assert_eq!(v["running_count"], 0);
+        assert_counters_partition_step_count(&v);
         assert_eq!(v["first_pending_seq"], 1);
         assert_eq!(v["side_effect_step_count"], 1);
         assert!(
@@ -497,6 +590,50 @@ mod tests {
         );
         // The mutating step's params ("content"="y") are never in the receipt.
         assert!(!rendered.contains("out.txt"));
+        assert!(reject_forbidden_output(&rendered).is_ok());
+    }
+
+    #[test]
+    fn exec_errored_step_is_persisted_running_and_counted_running_count() {
+        // THE counter-vocabulary repro: a stored READ-ONLY def run against a
+        // NONEXISTENT workspace exec-errors at s0. The engine persists that
+        // step via resolve_step_completion(false, false, false) == Running and
+        // fails the run — so the receipt must show status=failed AND
+        // running_count=1, with the five counters still partitioning
+        // step_count (the original four counters made this step invisible).
+        let (db, _ws) = seeded(
+            "execerr",
+            &def(
+                "research",
+                vec![
+                    step("read", "read_file", &[("path", "notes.txt")]),
+                    step("ls", "list_dir", &[("path", ".")]),
+                ],
+            ),
+            1,
+        );
+        let ghost_ws = tmp("execerr-ghost-ws").to_string_lossy().into_owned();
+        let rendered = run(&bin_args(&db, &ghost_ws, &["--run-id=run-err"]))
+            .map_err(|e| e.kind)
+            .unwrap();
+        let v: Value = from_str(&rendered).unwrap();
+        assert_eq!(
+            v["ok"], true,
+            "bridge-success semantics: ok keys on the bridge"
+        );
+        assert_eq!(v["status"], "failed");
+        assert_eq!(v["run_state"], "failed");
+        assert_eq!(v["status_detail"], "exec_error");
+        assert_eq!(v["step_ref"], "run-err:s0");
+        assert_eq!(v["executed_steps"], 0);
+        // Step rows are added lazily as the loop reaches them: only s0 exists.
+        assert_eq!(v["step_count"], 1);
+        assert_eq!(v["running_count"], 1, "the exec-errored step is VISIBLE");
+        assert_eq!(v["verified_count"], 0);
+        assert_eq!(v["failed_count"], 0);
+        assert_counters_partition_step_count(&v);
+        // The fs error text (which embeds the ghost path) never leaks.
+        assert!(!rendered.contains("ghost-ws"));
         assert!(reject_forbidden_output(&rendered).is_ok());
     }
 
@@ -540,20 +677,49 @@ mod tests {
     }
 
     #[test]
-    fn forbidden_output_canary_fails_the_whole_receipt_closed() {
-        // CANARY through the REAL path: a definition whose NAME embeds a secret
-        // marker would put "Bearer …" into the receipt's workflow_name — the
-        // output guard must refuse to print anything (fail-closed), proving the
-        // guard sits between the projection and stdout.
+    fn marker_bearing_name_is_structurally_impossible_in_output() {
+        // STRUCTURAL (not canary-caught): a definition whose NAME embeds a
+        // secret marker still produces a SUCCESSFUL receipt, because the name
+        // is never emitted verbatim — only its sha256 + byte length. The marker
+        // cannot reach stdout through the name field at all.
+        let name = "Bearer canary-name";
         let (db, ws) = seeded(
-            "canary",
+            "canary-name",
             &def(
-                "Bearer canary-name",
+                name,
                 vec![step("read", "read_file", &[("path", "notes.txt")])],
             ),
             1,
         );
-        let err = run(&bin_args(&db, &ws, &["--run-id=run1"])).err().unwrap();
+        let rendered = run(&bin_args(&db, &ws, &["--run-id=run1"]))
+            .map_err(|e| e.kind)
+            .unwrap();
+        assert!(!rendered.contains("Bearer"), "marker never in output");
+        let v: Value = from_str(&rendered).unwrap();
+        assert_eq!(v["status"], "completed");
+        assert_eq!(v["workflow_name_sha256"], sha256_hex(name.as_bytes()));
+        assert_eq!(v["workflow_name_len"], name.len());
+        assert!(v.get("workflow_name").is_none());
+    }
+
+    #[test]
+    fn forbidden_output_canary_fails_the_whole_receipt_closed() {
+        // CANARY through the REAL path (defense-in-depth on the OTHER verbatim
+        // fields): a marker-bearing --run-id flows verbatim into the receipt's
+        // run_id/step_ref — the output guard must refuse to print anything
+        // (fail-closed), proving the guard still sits between the projection
+        // and stdout for every field that is not structurally bounded.
+        let (db, ws) = seeded(
+            "canary-runid",
+            &def(
+                "research",
+                vec![step("read", "read_file", &[("path", "notes.txt")])],
+            ),
+            1,
+        );
+        let err = run(&bin_args(&db, &ws, &["--run-id=run-Bearer-1"]))
+            .err()
+            .unwrap();
         assert_eq!(err.kind, "output_guard");
     }
 

--- a/rust-core/crates/friday-hub/src/bin/hub_workflow_run.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_workflow_run.rs
@@ -1,0 +1,621 @@
+//! S9 dev write-bridge — `hub_workflow_run`.
+//!
+//! PROOF-ONLY (Rust-wired-DEV). The workflow sibling of the S0 `hub_run_task`
+//! write-bridge: a thin one-shot bin around the S9 seam
+//! ([`friday_hub::workflow_run`]) that loads a STORED workflow definition (by
+//! `--workflow-id` + `--version`, or its published version) from `--db` and
+//! executes it through the EXISTING [`friday_hub::workflow_exec`] engine against
+//! the `--workspace` root, emitting a refs-only JSON receipt.
+//!
+//! This is NOT a replacement for the (fail-closed-fenced) TS workflow runtime.
+//! It registers NO production route, NO scheduler/trigger/cron (S10,
+//! operator-gated), and confers no v1 GO. Live/manual PRODUCTION workflow runs
+//! remain operator-gated — this bin exists for dev/temp DBs and workspaces.
+//!
+//! ## Gate posture (unchanged — no gate/approval code is touched)
+//! The approval policy is hard-wired DENY-ALL: no approval is ever minted, so a
+//! mutating/checkpoint step PAUSES the run (`AwaitingCheckpoint`) and is never
+//! executed — the engine's existing posture. The gate-approval signing secret is
+//! therefore DORMANT; like `hub_run_task`, ephemeral non-secret bytes are
+//! derived from pid+nanos rather than reading any real key.
+//!
+//! ## Output contract — REFS ONLY (no bodies, no params, no prompts, no secrets)
+//! One JSON object on stdout carrying ONLY safe identifiers/labels/counts:
+//! `truth_label="rust_wired_dev"`, run/workflow/version identifiers, the
+//! workflow name label, closed-vocab status + a BOUNDED `status_detail` token
+//! (never the engine's free-form failure text, which can embed executor error
+//! detail), the paused/failed step REF (`<run_id>:s<seq>`), step counts by
+//! status, and the audit-chain-verified bool. Step params, definition bodies and
+//! evidence text are NEVER emitted; [`reject_forbidden_output`] fails the whole
+//! receipt closed if any forbidden marker appears.
+
+use std::env;
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use friday_core::gate::{CanonicalApproval, MutatingActionRequest};
+use friday_hub::workflow_def::WorkflowDefError;
+use friday_hub::workflow_exec::WorkflowRunStatus;
+use friday_hub::workflow_run::{run_stored_published_workflow, run_stored_workflow};
+use friday_hub::FsToolExecutor;
+use friday_storage::audit::verify_audit_chain;
+use friday_storage::workflow::first_pending_seq;
+use friday_storage::workflow_read::{get_workflow_run_summary, list_workflow_step_summaries};
+use friday_storage::Db;
+use serde_json::json;
+use sha2::{Digest, Sha256};
+
+/// A fail-closed error: `kind` is a coarse, safe category (the only thing
+/// surfaced); the raw detail is deliberately NOT printed so storage/loader
+/// errors cannot leak paths or definition content.
+struct BridgeError {
+    kind: &'static str,
+}
+
+impl BridgeError {
+    fn new(kind: &'static str) -> Self {
+        Self { kind }
+    }
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    match run(&args) {
+        Ok(rendered) => {
+            println!("{rendered}");
+        }
+        Err(err) => {
+            // Refs-only error to stdout (no detail), coarse category to stderr, non-zero exit.
+            let payload = json!({
+                "truth_label": "rust_wired_dev",
+                "proof_only": true,
+                "ok": false,
+                "error_kind": err.kind,
+            });
+            // Defense-in-depth: route the error payload through the SAME guard as the
+            // success path (fail closed if a marker ever leaked). `error_kind` is a
+            // static closed-vocab token today, so this never suppresses output.
+            let rendered = payload.to_string();
+            if reject_forbidden_output(&rendered).is_ok() {
+                println!("{rendered}");
+            }
+            eprintln!("hub_workflow_run_unavailable: {}", err.kind);
+            std::process::exit(2);
+        }
+    }
+}
+
+fn run(args: &[String]) -> Result<String, BridgeError> {
+    // The hub DB must ALREADY exist and hold the stored definition — a missing
+    // DB is fail-closed (`db_not_found`), never silently created.
+    let db_path = arg_value(args, "--db").ok_or(BridgeError::new("bad_args"))?;
+    if !Path::new(&db_path).is_file() {
+        return Err(BridgeError::new("db_not_found"));
+    }
+    // Workspace root: the engine's fs tools are contained to this root (required).
+    let workspace_root = arg_value(args, "--workspace").ok_or(BridgeError::new("bad_args"))?;
+    let workflow_id = arg_value(args, "--workflow-id").ok_or(BridgeError::new("bad_args"))?;
+    // Optional explicit version; absent ⇒ the PUBLISHED version. A present but
+    // unparsable value is bad_args (fail-closed, never silently "published").
+    let version = match arg_value(args, "--version") {
+        Some(raw) => Some(
+            raw.parse::<i64>()
+                .map_err(|_| BridgeError::new("bad_args"))?,
+        ),
+        None => None,
+    };
+
+    let pid = std::process::id();
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let run_id = arg_value(args, "--run-id")
+        .unwrap_or_else(|| format!("hub_workflow_run_dev_{pid}_{nanos}"));
+    let now_ms = arg_value(args, "--now-ms")
+        .and_then(|v| v.parse::<i64>().ok())
+        .unwrap_or_else(|| {
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_millis() as i64)
+                .unwrap_or(0)
+        });
+
+    let db = Db::open_hub(&db_path).map_err(|_| BridgeError::new("open_failed"))?;
+    let executor = FsToolExecutor::new(&workspace_root);
+    // Gate-approval signing secret: DORMANT under the hard-wired deny-all policy
+    // below (no approval is ever minted/verified), so ephemeral, non-secret bytes
+    // are derived from pid+nanos — nothing secret-shaped is read or persisted.
+    let secret = ephemeral_dev_secret(pid, nanos);
+
+    let stored_run = match version {
+        Some(version) => run_stored_workflow(
+            db.conn(),
+            &executor,
+            &workflow_id,
+            version,
+            &run_id,
+            &secret,
+            &deny_all,
+            now_ms,
+        ),
+        None => run_stored_published_workflow(
+            db.conn(),
+            &executor,
+            &workflow_id,
+            &run_id,
+            &secret,
+            &deny_all,
+            now_ms,
+        ),
+    }
+    .map_err(|err| BridgeError::new(workflow_def_error_kind(&err)))?;
+
+    // Refs-only projection of what the engine persisted (read helpers never
+    // select evidence text; step params are not stored at all).
+    let summary = get_workflow_run_summary(db.conn(), &run_id)
+        .map_err(|_| BridgeError::new("read_failed"))?
+        .ok_or(BridgeError::new("read_failed"))?;
+    let steps = list_workflow_step_summaries(db.conn(), &run_id)
+        .map_err(|_| BridgeError::new("read_failed"))?;
+    let pending_seq =
+        first_pending_seq(db.conn(), &run_id).map_err(|_| BridgeError::new("read_failed"))?;
+    let audit_chain_verified = verify_audit_chain(db.conn()).is_ok();
+
+    let count_status =
+        |status: &str| -> usize { steps.iter().filter(|s| s.status == status).count() };
+
+    // Closed-vocab status + BOUNDED detail token + step REF. CRITICAL: the
+    // engine's pause/fail `reason` strings can embed free-form executor error
+    // detail; only fixed `&'static str` tokens from a closed vocabulary are
+    // emitted (the `hub_run_task` classify_error_category discipline).
+    let (status, status_detail, step_ref): (&'static str, Option<&'static str>, Option<&str>) =
+        match &stored_run.outcome.status {
+            WorkflowRunStatus::Completed => ("completed", None, None),
+            WorkflowRunStatus::AwaitingCheckpoint { step_id, reason } => (
+                "awaiting_checkpoint",
+                Some(classify_pause_reason(reason)),
+                Some(step_id.as_str()),
+            ),
+            WorkflowRunStatus::Failed { step_id, reason } => (
+                "failed",
+                Some(classify_failure_reason(reason)),
+                Some(step_id.as_str()),
+            ),
+        };
+
+    let payload = json!({
+        "truth_label": "rust_wired_dev",
+        "proof_only": true,
+        "ok": true,
+        "run_id": run_id,
+        "workflow_id": stored_run.workflow_id,
+        "version": stored_run.version,
+        "workflow_name": summary.name,
+        "run_state": summary.state,
+        "status": status,
+        "status_detail": status_detail,
+        "step_ref": step_ref,
+        "executed_steps": stored_run.outcome.executed_steps,
+        "step_count": steps.len(),
+        "verified_count": count_status("verified"),
+        "pending_count": count_status("pending"),
+        "proof_pending_count": count_status("proof_pending"),
+        "failed_count": count_status("failed"),
+        "side_effect_step_count": steps.iter().filter(|s| s.has_side_effect).count(),
+        "first_pending_seq": pending_seq,
+        "audit_chain_verified": audit_chain_verified,
+    });
+
+    let rendered =
+        serde_json::to_string(&payload).map_err(|_| BridgeError::new("serialize_failed"))?;
+    reject_forbidden_output(&rendered)?;
+    Ok(rendered)
+}
+
+/// Hard-wired DENY-ALL approval policy: no approval is ever minted, so mutating
+/// steps stay gate-paused — the engine's existing posture, unchanged.
+fn deny_all(_r: &MutatingActionRequest) -> Option<CanonicalApproval> {
+    None
+}
+
+fn arg_value(args: &[String], name: &str) -> Option<String> {
+    args.windows(2)
+        .find_map(|pair| (pair[0] == name).then(|| pair[1].clone()))
+        .or_else(|| {
+            let prefix = format!("{name}=");
+            args.iter()
+                .find_map(|arg| arg.strip_prefix(&prefix).map(str::to_string))
+        })
+}
+
+/// Map a loader/seam error to ONE coarse, closed-vocab kind (never the detail —
+/// a parse error can quote definition content; a storage error can embed paths).
+fn workflow_def_error_kind(err: &WorkflowDefError) -> &'static str {
+    match err {
+        WorkflowDefError::NotFound(_) => "def_not_found",
+        WorkflowDefError::Parse(_)
+        | WorkflowDefError::Invalid(_)
+        | WorkflowDefError::UnsupportedSchemaVersion { .. } => "def_invalid",
+        WorkflowDefError::Storage(_) => "storage_failed",
+    }
+}
+
+/// Map an `AwaitingCheckpoint` reason to ONE bounded, refs-only token.
+///
+/// Today these reasons are static closed-vocab strings (`CheckpointReason::as_str`
+/// or `"gate_requires_approval"`), but this classifier makes leakage structurally
+/// impossible if a future engine change ever embeds dynamic text: it returns ONLY
+/// a fixed `&'static str`, never any slice of `reason`.
+fn classify_pause_reason(reason: &str) -> &'static str {
+    if reason.contains("gate_requires_approval") {
+        "gate_requires_approval"
+    } else if reason.contains("mutating") {
+        "checkpoint_mutating"
+    } else if reason.contains("high-risk") {
+        "checkpoint_high_risk"
+    } else if reason.contains("sensitive resource") {
+        "checkpoint_sensitive_resource"
+    } else if reason.contains("template") {
+        "checkpoint_template_policy"
+    } else if reason.contains("unclassifiable") {
+        "checkpoint_unclassifiable"
+    } else {
+        "checkpoint_other"
+    }
+}
+
+/// Map a `Failed` reason to ONE bounded, refs-only token. CRITICAL leak boundary:
+/// the engine's failure reason embeds free-form detail (`exec_error:<ExecError>`
+/// can carry fs error text; `unregistered:<action>` carries the raw action
+/// string) — only the fixed prefix-derived token is ever emitted.
+fn classify_failure_reason(reason: &str) -> &'static str {
+    if reason.starts_with("denied:") {
+        "denied"
+    } else if reason.starts_with("exec_error:") {
+        "exec_error"
+    } else if reason.starts_with("unregistered:") {
+        "unregistered_action"
+    } else {
+        "failed_other"
+    }
+}
+
+/// Ephemeral, non-secret bytes (dormant under deny-all — see module docs).
+/// Derived, not read — mirrors `hub_run_task`.
+fn ephemeral_dev_secret(pid: u32, nanos: u128) -> Vec<u8> {
+    let mut hasher = Sha256::new();
+    hasher.update(format!("hub-workflow-run-dev-bridge:{pid}:{nanos}").as_bytes());
+    hasher.finalize().to_vec()
+}
+
+/// Defense-in-depth: refuse to print if any forbidden marker leaked into the
+/// refs-only receipt. Beyond the shared secret/path markers, this bin's
+/// body-bearing fields must never appear: step `"params"`, the stored
+/// `"definition_json"` / `"source_meta"` bodies, and the `"evidence_ref"` text.
+fn reject_forbidden_output(rendered: &str) -> Result<(), BridgeError> {
+    friday_hub::refs_guard::reject_forbidden_output(
+        rendered,
+        &[
+            "\"params\"",
+            "\"definition_json\"",
+            "\"source_meta\"",
+            "\"evidence_ref\"",
+        ],
+    )
+    .map_err(|_| BridgeError::new("output_guard"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use friday_hub::workflow_def::{
+        store_published_version, StoredWorkflowDefV1, StoredWorkflowStepV1,
+        WORKFLOW_DEF_SCHEMA_VERSION,
+    };
+    use friday_storage::workflow_def::DefinitionSource;
+    use serde_json::{from_str, Value};
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static C: AtomicU64 = AtomicU64::new(0);
+    fn tmp(tag: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!(
+            "friday-wfrunbin-{}-{}-{}",
+            std::process::id(),
+            tag,
+            C.fetch_add(1, Ordering::Relaxed)
+        ))
+    }
+
+    fn step(id: &str, action: &str, params: &[(&str, &str)]) -> StoredWorkflowStepV1 {
+        StoredWorkflowStepV1 {
+            id: id.to_string(),
+            action: action.to_string(),
+            params: params
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+            force_checkpoint: false,
+            evidence_required: false,
+        }
+    }
+
+    fn def(name: &str, steps: Vec<StoredWorkflowStepV1>) -> StoredWorkflowDefV1 {
+        StoredWorkflowDefV1 {
+            schema_version: WORKFLOW_DEF_SCHEMA_VERSION,
+            name: name.into(),
+            steps,
+        }
+    }
+
+    /// A temp hub DB seeded with one PUBLISHED definition + a temp workspace
+    /// containing `notes.txt`. Returns (db_path, workspace_path).
+    fn seeded(tag: &str, d: &StoredWorkflowDefV1, version: i64) -> (String, String) {
+        let db_path = tmp(tag)
+            .with_extension("sqlite")
+            .to_string_lossy()
+            .into_owned();
+        let db = friday_storage::Db::open_hub(&db_path).unwrap();
+        store_published_version(
+            db.conn(),
+            "wf1",
+            version,
+            d,
+            DefinitionSource::RustNative,
+            None,
+            100,
+        )
+        .unwrap();
+        let ws = tmp(&format!("{tag}-ws"));
+        std::fs::create_dir_all(&ws).unwrap();
+        std::fs::write(ws.join("notes.txt"), b"hello").unwrap();
+        (db_path, ws.to_string_lossy().into_owned())
+    }
+
+    fn bin_args(db: &str, ws: &str, extra: &[&str]) -> Vec<String> {
+        let mut args = vec![
+            "hub_workflow_run".to_string(),
+            format!("--db={db}"),
+            format!("--workspace={ws}"),
+            "--workflow-id=wf1".to_string(),
+        ];
+        args.extend(extra.iter().map(|s| s.to_string()));
+        args
+    }
+
+    #[test]
+    fn arg_value_supports_space_and_equals_forms() {
+        let args = vec![
+            "bin".to_string(),
+            "--db".to_string(),
+            "/tmp/hub.sqlite".to_string(),
+            "--workflow-id=wf-1".to_string(),
+        ];
+        assert_eq!(arg_value(&args, "--db").as_deref(), Some("/tmp/hub.sqlite"));
+        assert_eq!(arg_value(&args, "--workflow-id").as_deref(), Some("wf-1"));
+        assert_eq!(arg_value(&args, "--missing"), None);
+    }
+
+    #[test]
+    fn read_only_published_workflow_runs_to_completed_with_a_refs_only_receipt() {
+        // The full BIN path (not a mock): seeded stored def → run(args) → the
+        // EXISTING engine executes both read-only steps → refs-only receipt.
+        let (db, ws) = seeded(
+            "ok",
+            &def(
+                "research",
+                vec![
+                    step("read", "read_file", &[("path", "notes.txt")]),
+                    step("ls", "list_dir", &[("path", ".")]),
+                ],
+            ),
+            3,
+        );
+        let rendered = run(&bin_args(&db, &ws, &["--run-id=run1", "--now-ms=500"]))
+            .map_err(|e| e.kind)
+            .unwrap();
+        let v: Value = from_str(&rendered).unwrap();
+        assert_eq!(v["truth_label"], "rust_wired_dev");
+        assert_eq!(v["proof_only"], true);
+        assert_eq!(v["ok"], true);
+        assert_eq!(v["run_id"], "run1");
+        assert_eq!(v["workflow_id"], "wf1");
+        assert_eq!(v["version"], 3, "published version resolved + reported");
+        assert_eq!(v["workflow_name"], "research");
+        assert_eq!(v["status"], "completed");
+        assert_eq!(v["run_state"], "done");
+        assert_eq!(v["status_detail"], Value::Null);
+        assert_eq!(v["step_ref"], Value::Null);
+        assert_eq!(v["executed_steps"], 2);
+        assert_eq!(v["step_count"], 2);
+        assert_eq!(v["verified_count"], 2);
+        assert_eq!(v["pending_count"], 0);
+        assert_eq!(v["first_pending_seq"], Value::Null);
+        // Refs-only: no step params / definition body / evidence text fields.
+        assert!(v.get("steps").is_none());
+        assert!(!rendered.contains("notes.txt"), "no path/body text leaks");
+        assert!(reject_forbidden_output(&rendered).is_ok());
+    }
+
+    #[test]
+    fn explicit_version_flag_runs_that_version() {
+        let (db, ws) = seeded(
+            "ver",
+            &def(
+                "research",
+                vec![step("read", "read_file", &[("path", "notes.txt")])],
+            ),
+            7,
+        );
+        let rendered = run(&bin_args(&db, &ws, &["--version=7", "--run-id=run-v"]))
+            .map_err(|e| e.kind)
+            .unwrap();
+        let v: Value = from_str(&rendered).unwrap();
+        assert_eq!(v["version"], 7);
+        assert_eq!(v["status"], "completed");
+        // An unparsable version is bad_args (never silently falls back to published).
+        let err = run(&bin_args(&db, &ws, &["--version=seven"]))
+            .err()
+            .unwrap();
+        assert_eq!(err.kind, "bad_args");
+    }
+
+    #[test]
+    fn mutating_step_gate_pauses_and_the_workspace_is_unchanged() {
+        // THE safety witness at the bin level: a stored write step pauses under
+        // the hard-wired deny-all; the write never executes; out.txt is absent.
+        let (db, ws) = seeded(
+            "pause",
+            &def(
+                "ship",
+                vec![
+                    step("read", "read_file", &[("path", "notes.txt")]),
+                    step(
+                        "write",
+                        "write_file",
+                        &[("path", "out.txt"), ("content", "y")],
+                    ),
+                ],
+            ),
+            1,
+        );
+        let rendered = run(&bin_args(&db, &ws, &["--run-id=run1"]))
+            .map_err(|e| e.kind)
+            .unwrap();
+        let v: Value = from_str(&rendered).unwrap();
+        assert_eq!(v["status"], "awaiting_checkpoint");
+        assert_eq!(v["run_state"], "awaiting_checkpoint");
+        assert_eq!(v["status_detail"], "checkpoint_mutating");
+        assert_eq!(v["step_ref"], "run1:s1");
+        assert_eq!(v["executed_steps"], 1);
+        assert_eq!(v["pending_count"], 1);
+        assert_eq!(v["first_pending_seq"], 1);
+        assert_eq!(v["side_effect_step_count"], 1);
+        assert!(
+            !std::path::Path::new(&ws).join("out.txt").exists(),
+            "the gate-paused write must NOT touch the workspace"
+        );
+        // The mutating step's params ("content"="y") are never in the receipt.
+        assert!(!rendered.contains("out.txt"));
+        assert!(reject_forbidden_output(&rendered).is_ok());
+    }
+
+    #[test]
+    fn missing_db_and_missing_definition_fail_closed() {
+        // Missing DB file: fail-closed, never silently created.
+        let ghost_db = tmp("ghost").with_extension("sqlite");
+        let err = run(&[
+            "bin".to_string(),
+            format!("--db={}", ghost_db.to_string_lossy()),
+            "--workspace=/tmp/x".to_string(),
+            "--workflow-id=wf1".to_string(),
+        ])
+        .err()
+        .unwrap();
+        assert_eq!(err.kind, "db_not_found");
+        assert!(!ghost_db.exists(), "a missing DB must not be created");
+
+        // DB exists but the definition does not.
+        let (db, ws) = seeded(
+            "nodef",
+            &def(
+                "research",
+                vec![step("read", "read_file", &[("path", "notes.txt")])],
+            ),
+            1,
+        );
+        let mut args = bin_args(&db, &ws, &[]);
+        args[3] = "--workflow-id=ghost-wf".to_string();
+        assert_eq!(run(&args).err().unwrap().kind, "def_not_found");
+        // Known id, missing version.
+        assert_eq!(
+            run(&bin_args(&db, &ws, &["--version=9"]))
+                .err()
+                .unwrap()
+                .kind,
+            "def_not_found"
+        );
+        // Missing required args.
+        assert_eq!(run(&["bin".to_string()]).err().unwrap().kind, "bad_args");
+    }
+
+    #[test]
+    fn forbidden_output_canary_fails_the_whole_receipt_closed() {
+        // CANARY through the REAL path: a definition whose NAME embeds a secret
+        // marker would put "Bearer …" into the receipt's workflow_name — the
+        // output guard must refuse to print anything (fail-closed), proving the
+        // guard sits between the projection and stdout.
+        let (db, ws) = seeded(
+            "canary",
+            &def(
+                "Bearer canary-name",
+                vec![step("read", "read_file", &[("path", "notes.txt")])],
+            ),
+            1,
+        );
+        let err = run(&bin_args(&db, &ws, &["--run-id=run1"])).err().unwrap();
+        assert_eq!(err.kind, "output_guard");
+    }
+
+    #[test]
+    fn forbidden_output_guard_blocks_bodies_params_and_secret_markers() {
+        assert!(reject_forbidden_output(r#"{"params":[["path","x"]]}"#).is_err());
+        assert!(reject_forbidden_output(r#"{"definition_json":"{}"}"#).is_err());
+        assert!(reject_forbidden_output(r#"{"source_meta":"{}"}"#).is_err());
+        assert!(reject_forbidden_output(r#"{"evidence_ref":"read 3 bytes"}"#).is_err());
+        assert!(reject_forbidden_output(r#"{"x":"Bearer abc"}"#).is_err());
+        assert!(reject_forbidden_output(r#"{"k":"/Users/jarvis/x"}"#).is_err());
+        // The refs-only key shapes pass.
+        assert!(reject_forbidden_output(
+            r#"{"status":"completed","step_count":2,"verified_count":2}"#
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn reason_classifiers_return_only_bounded_tokens_never_detail_slices() {
+        // Pause reasons (today: closed-vocab planner/gate strings).
+        assert_eq!(
+            classify_pause_reason("mutating action (gate floor)"),
+            "checkpoint_mutating"
+        );
+        assert_eq!(
+            classify_pause_reason("high-risk action (gate floor)"),
+            "checkpoint_high_risk"
+        );
+        assert_eq!(
+            classify_pause_reason("sensitive resource access (gate floor)"),
+            "checkpoint_sensitive_resource"
+        );
+        assert_eq!(
+            classify_pause_reason("template checkpoint policy"),
+            "checkpoint_template_policy"
+        );
+        assert_eq!(
+            classify_pause_reason("unclassifiable/unregistered action (fail-closed)"),
+            "checkpoint_unclassifiable"
+        );
+        assert_eq!(
+            classify_pause_reason("gate_requires_approval (resume without a valid approval)"),
+            "gate_requires_approval"
+        );
+        assert_eq!(classify_pause_reason("something new"), "checkpoint_other");
+
+        // Failure reasons embed free-form detail — the token must never carry it.
+        let leaky = "exec_error:fs error LEAK_CANARY_path_9f3 /somewhere/deep";
+        let token = classify_failure_reason(leaky);
+        assert_eq!(token, "exec_error");
+        assert!(!token.contains("LEAK_CANARY_path_9f3"));
+        assert_eq!(classify_failure_reason("denied:reserved"), "denied");
+        assert_eq!(
+            classify_failure_reason("unregistered:frobnicate"),
+            "unregistered_action"
+        );
+        assert_eq!(classify_failure_reason("???"), "failed_other");
+    }
+
+    #[test]
+    fn ephemeral_secret_is_32_bytes_and_not_a_read_key() {
+        assert_eq!(ephemeral_dev_secret(123, 456).len(), 32);
+    }
+}

--- a/rust-core/crates/friday-hub/src/bin/hub_workflow_run_readback.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_workflow_run_readback.rs
@@ -1,0 +1,384 @@
+//! S9 dev read-bridge — `hub_workflow_run_readback`.
+//!
+//! PROOF-ONLY (Rust-wired-DEV). The workflow sibling of the S2 `hub_run_readback`
+//! read-bridge: opens the hub DB READ-ONLY
+//! ([`friday_storage::Db::open_hub_readonly`]) and emits a refs-only JSON
+//! projection of ONE workflow run's `workflow_run` + `workflow_step` records (the
+//! rows the EXISTING [`friday_hub::workflow_exec`] engine persists), by
+//! `--run-id`.
+//!
+//! This is NOT a production route, NOT a TS integration, and confers no v1 GO —
+//! workflow execution remains fenced in TS and is NOT product-replaced.
+//!
+//! ## Output contract — REFS ONLY (no bodies, no params, no evidence text)
+//! One JSON object on stdout carrying ONLY safe identifiers/labels/counts:
+//! `truth_label="rust_wired_dev"`, the run summary (run id / workflow name label
+//! / persisted state label / timestamps), per-step summaries (step REF
+//! `<run_id>:s<seq>`, seq, side-effect flag, status label, `has_evidence` BOOL),
+//! step counts by status, `first_pending_seq` (the paused checkpoint of an
+//! `awaiting_checkpoint` run), and the audit-chain-verified bool. The
+//! `evidence_ref` TEXT (a tool-receipt summary that can embed a relative
+//! filename) is structurally unselectable — the storage read helper only ever
+//! projects its presence — and step params / definition bodies are not stored on
+//! run rows at all. [`reject_forbidden_output`] fails the WHOLE projection closed
+//! if any forbidden marker ever appears.
+//!
+//! Usage: `hub_workflow_run_readback --db <hub.sqlite> --run-id <id>`
+
+use std::env;
+use std::path::Path;
+
+use friday_storage::audit::verify_audit_chain;
+use friday_storage::workflow::first_pending_seq;
+use friday_storage::workflow_read::{get_workflow_run_summary, list_workflow_step_summaries};
+use friday_storage::Db;
+use serde_json::json;
+
+/// A fail-closed error: `kind` is a coarse, safe category (the only thing
+/// surfaced); the raw detail is deliberately NOT printed so storage/IO errors
+/// cannot leak paths.
+struct ReadbackError {
+    kind: &'static str,
+}
+
+impl ReadbackError {
+    fn new(kind: &'static str) -> Self {
+        Self { kind }
+    }
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    match run(&args) {
+        Ok(rendered) => println!("{rendered}"),
+        Err(err) => {
+            // Refs-only error to stdout (no detail), coarse category to stderr, non-zero exit.
+            let payload = json!({
+                "truth_label": "rust_wired_dev",
+                "proof_only": true,
+                "ok": false,
+                "error_kind": err.kind,
+            });
+            // Defense-in-depth: route the error payload through the SAME guard as the
+            // success path. `error_kind` is a static closed-vocab token today, so this
+            // never suppresses output.
+            let rendered = payload.to_string();
+            if reject_forbidden_output(&rendered).is_ok() {
+                println!("{rendered}");
+            }
+            eprintln!("hub_workflow_run_readback_unavailable: {}", err.kind);
+            std::process::exit(2);
+        }
+    }
+}
+
+fn run(args: &[String]) -> Result<String, ReadbackError> {
+    let db_path = arg_value(args, "--db").ok_or(ReadbackError::new("bad_args"))?;
+    if !Path::new(&db_path).is_file() {
+        return Err(ReadbackError::new("db_not_found"));
+    }
+    let run_id = arg_value(args, "--run-id").ok_or(ReadbackError::new("bad_args"))?;
+
+    // Read-only open: a readback can NEVER mutate an operator DB just because TS asks.
+    let db = Db::open_hub_readonly(&db_path).map_err(|_| ReadbackError::new("open_failed"))?;
+
+    let summary = get_workflow_run_summary(db.conn(), &run_id)
+        .map_err(|_| ReadbackError::new("read_failed"))?
+        .ok_or(ReadbackError::new("run_not_found"))?;
+    let steps = list_workflow_step_summaries(db.conn(), &run_id)
+        .map_err(|_| ReadbackError::new("read_failed"))?;
+    let pending_seq =
+        first_pending_seq(db.conn(), &run_id).map_err(|_| ReadbackError::new("read_failed"))?;
+
+    // Audit chain verification over the readback DB (a bool, never the rows).
+    let audit_chain_verified = verify_audit_chain(db.conn()).is_ok();
+
+    let count_status =
+        |status: &str| -> usize { steps.iter().filter(|s| s.status == status).count() };
+
+    let step_objects: Vec<serde_json::Value> = steps
+        .iter()
+        .map(|s| {
+            json!({
+                "step_ref": s.step_id,
+                "seq": s.seq,
+                "has_side_effect": s.has_side_effect,
+                "status": s.status,
+                "has_evidence": s.has_evidence,
+                "created_at_ms": s.created_at,
+                "updated_at_ms": s.updated_at,
+            })
+        })
+        .collect();
+
+    let payload = json!({
+        "truth_label": "rust_wired_dev",
+        "proof_only": true,
+        "ok": true,
+        "run_id": summary.run_id,
+        "workflow_name": summary.name,
+        "run_state": summary.state,
+        "created_at_ms": summary.created_at,
+        "updated_at_ms": summary.updated_at,
+        "step_count": steps.len(),
+        "verified_count": count_status("verified"),
+        "pending_count": count_status("pending"),
+        "proof_pending_count": count_status("proof_pending"),
+        "failed_count": count_status("failed"),
+        "side_effect_step_count": steps.iter().filter(|s| s.has_side_effect).count(),
+        "first_pending_seq": pending_seq,
+        "steps": step_objects,
+        "audit_chain_verified": audit_chain_verified,
+    });
+
+    let rendered =
+        serde_json::to_string(&payload).map_err(|_| ReadbackError::new("serialize_failed"))?;
+    reject_forbidden_output(&rendered)?;
+    Ok(rendered)
+}
+
+fn arg_value(args: &[String], name: &str) -> Option<String> {
+    args.windows(2)
+        .find_map(|pair| (pair[0] == name).then(|| pair[1].clone()))
+        .or_else(|| {
+            let prefix = format!("{name}=");
+            args.iter()
+                .find_map(|arg| arg.strip_prefix(&prefix).map(str::to_string))
+        })
+}
+
+/// Defense-in-depth: refuse to print if any forbidden marker leaked into the
+/// refs-only projection. Beyond the shared secret/path markers, this bin's
+/// body-bearing fields must never appear: the `"evidence_ref"` text, step
+/// `"params"`, and the stored `"definition_json"` body.
+fn reject_forbidden_output(rendered: &str) -> Result<(), ReadbackError> {
+    friday_hub::refs_guard::reject_forbidden_output(
+        rendered,
+        &["\"evidence_ref\"", "\"params\"", "\"definition_json\""],
+    )
+    .map_err(|_| ReadbackError::new("output_guard"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use friday_core::gate::{CanonicalApproval, MutatingActionRequest};
+    use friday_hub::workflow_def::{
+        store_published_version, StoredWorkflowDefV1, StoredWorkflowStepV1,
+        WORKFLOW_DEF_SCHEMA_VERSION,
+    };
+    use friday_hub::workflow_run::run_stored_published_workflow;
+    use friday_hub::FsToolExecutor;
+    use friday_storage::workflow_def::DefinitionSource;
+    use serde_json::{from_str, Value};
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static C: AtomicU64 = AtomicU64::new(0);
+    fn tmp(tag: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!(
+            "friday-wfrbk-{}-{}-{}",
+            std::process::id(),
+            tag,
+            C.fetch_add(1, Ordering::Relaxed)
+        ))
+    }
+
+    const SECRET: &[u8] = b"wf-readback-secret-0123456789ab";
+
+    fn deny_all(_r: &MutatingActionRequest) -> Option<CanonicalApproval> {
+        None
+    }
+
+    fn step(id: &str, action: &str, params: &[(&str, &str)]) -> StoredWorkflowStepV1 {
+        StoredWorkflowStepV1 {
+            id: id.to_string(),
+            action: action.to_string(),
+            params: params
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+            force_checkpoint: false,
+            evidence_required: false,
+        }
+    }
+
+    /// Seed a temp hub DB with a published definition, run it through the REAL
+    /// S9 seam (stored def → loader → existing engine) against a real temp
+    /// workspace, and return the DB path. This makes the readback test a genuine
+    /// end-to-end: it projects rows the ENGINE persisted, not hand-inserted ones.
+    fn seeded_run(tag: &str, steps: Vec<StoredWorkflowStepV1>, run_id: &str) -> String {
+        let db_path = tmp(tag)
+            .with_extension("sqlite")
+            .to_string_lossy()
+            .into_owned();
+        let db = friday_storage::Db::open_hub(&db_path).unwrap();
+        store_published_version(
+            db.conn(),
+            "wf1",
+            1,
+            &StoredWorkflowDefV1 {
+                schema_version: WORKFLOW_DEF_SCHEMA_VERSION,
+                name: "research".into(),
+                steps,
+            },
+            DefinitionSource::RustNative,
+            None,
+            100,
+        )
+        .unwrap();
+        let ws = tmp(&format!("{tag}-ws"));
+        std::fs::create_dir_all(&ws).unwrap();
+        std::fs::write(ws.join("notes.txt"), b"hello readback").unwrap();
+        let exec = FsToolExecutor::new(&ws);
+        run_stored_published_workflow(db.conn(), &exec, "wf1", run_id, SECRET, &deny_all, 200)
+            .unwrap();
+        db_path
+    }
+
+    fn bin_args(db: &str, run_id: &str) -> Vec<String> {
+        vec![
+            "hub_workflow_run_readback".to_string(),
+            format!("--db={db}"),
+            format!("--run-id={run_id}"),
+        ]
+    }
+
+    #[test]
+    fn arg_value_supports_space_and_equals_forms() {
+        let args = vec![
+            "bin".to_string(),
+            "--db".to_string(),
+            "/tmp/hub.sqlite".to_string(),
+            "--run-id=run-xyz".to_string(),
+        ];
+        assert_eq!(arg_value(&args, "--db").as_deref(), Some("/tmp/hub.sqlite"));
+        assert_eq!(arg_value(&args, "--run-id").as_deref(), Some("run-xyz"));
+        assert_eq!(arg_value(&args, "--missing"), None);
+    }
+
+    #[test]
+    fn completed_run_projects_refs_only_and_never_the_evidence_text() {
+        // End-to-end: engine-persisted rows (via the real seam) → readback. The
+        // verified steps carry evidence_ref TEXT in the DB ("read N bytes from
+        // notes.txt") — the projection must surface ONLY the has_evidence bool.
+        let db = seeded_run(
+            "done",
+            vec![
+                step("read", "read_file", &[("path", "notes.txt")]),
+                step("ls", "list_dir", &[("path", ".")]),
+            ],
+            "run1",
+        );
+        let rendered = run(&bin_args(&db, "run1")).map_err(|e| e.kind).unwrap();
+        let v: Value = from_str(&rendered).unwrap();
+        assert_eq!(v["truth_label"], "rust_wired_dev");
+        assert_eq!(v["proof_only"], true);
+        assert_eq!(v["ok"], true);
+        assert_eq!(v["run_id"], "run1");
+        assert_eq!(v["workflow_name"], "research");
+        assert_eq!(v["run_state"], "done");
+        assert_eq!(v["step_count"], 2);
+        assert_eq!(v["verified_count"], 2);
+        assert_eq!(v["first_pending_seq"], Value::Null);
+        let steps = v["steps"].as_array().unwrap();
+        assert_eq!(steps.len(), 2);
+        assert_eq!(steps[0]["step_ref"], "run1:s0");
+        assert_eq!(steps[0]["status"], "verified");
+        assert_eq!(steps[0]["has_evidence"], true);
+        assert_eq!(steps[1]["seq"], 1);
+        // THE refs-only assertion: the DB row's evidence text embeds the
+        // filename; the projection must not.
+        assert!(
+            !rendered.contains("notes.txt") && !rendered.contains("bytes from"),
+            "evidence text must never be projected: {rendered}"
+        );
+        assert!(steps[0].get("evidence_ref").is_none());
+        assert!(reject_forbidden_output(&rendered).is_ok());
+    }
+
+    #[test]
+    fn paused_run_projects_the_pending_checkpoint_step() {
+        let db = seeded_run(
+            "paused",
+            vec![
+                step("read", "read_file", &[("path", "notes.txt")]),
+                step(
+                    "write",
+                    "write_file",
+                    &[("path", "out.txt"), ("content", "y")],
+                ),
+            ],
+            "run1",
+        );
+        let rendered = run(&bin_args(&db, "run1")).map_err(|e| e.kind).unwrap();
+        let v: Value = from_str(&rendered).unwrap();
+        assert_eq!(v["run_state"], "awaiting_checkpoint");
+        assert_eq!(v["pending_count"], 1);
+        assert_eq!(v["first_pending_seq"], 1);
+        let steps = v["steps"].as_array().unwrap();
+        assert_eq!(steps[1]["status"], "pending");
+        assert_eq!(steps[1]["has_side_effect"], true);
+        assert_eq!(steps[1]["has_evidence"], false);
+        // The paused write's params (path/content) are not stored on run rows
+        // and must not appear.
+        assert!(!rendered.contains("out.txt"));
+    }
+
+    #[test]
+    fn missing_db_and_unknown_run_fail_closed() {
+        let ghost = tmp("ghost").with_extension("sqlite");
+        let err = run(&bin_args(&ghost.to_string_lossy(), "run1"))
+            .err()
+            .unwrap();
+        assert_eq!(err.kind, "db_not_found");
+        assert!(!ghost.exists(), "a readback must never create a DB");
+
+        let db = seeded_run(
+            "unknown-run",
+            vec![step("read", "read_file", &[("path", "notes.txt")])],
+            "run1",
+        );
+        assert_eq!(
+            run(&bin_args(&db, "ghost-run")).err().unwrap().kind,
+            "run_not_found"
+        );
+        assert_eq!(run(&["bin".to_string()]).err().unwrap().kind, "bad_args");
+    }
+
+    #[test]
+    fn forbidden_output_canary_fails_the_whole_projection_closed() {
+        // CANARY through the REAL path: hand-corrupt the persisted run name so an
+        // absolute path would enter the projection — the guard must refuse to
+        // print (fail-closed), proving it sits between the DB and stdout.
+        let db = seeded_run(
+            "canary",
+            vec![step("read", "read_file", &[("path", "notes.txt")])],
+            "run1",
+        );
+        {
+            let w = friday_storage::Db::open_hub(&db).unwrap();
+            w.conn()
+                .execute(
+                    "UPDATE workflow_run SET name = '/Users/jarvis/leak' WHERE run_id = 'run1'",
+                    [],
+                )
+                .unwrap();
+        }
+        let err = run(&bin_args(&db, "run1")).err().unwrap();
+        assert_eq!(err.kind, "output_guard");
+    }
+
+    #[test]
+    fn forbidden_output_guard_blocks_evidence_text_params_and_secret_markers() {
+        assert!(reject_forbidden_output(r#"{"evidence_ref":"read 3 bytes from x"}"#).is_err());
+        assert!(reject_forbidden_output(r#"{"params":[["path","x"]]}"#).is_err());
+        assert!(reject_forbidden_output(r#"{"definition_json":"{}"}"#).is_err());
+        assert!(reject_forbidden_output(r#"{"x":"Bearer abc"}"#).is_err());
+        assert!(reject_forbidden_output(r#"{"k":"/Users/jarvis/x"}"#).is_err());
+        // The refs-only step shape passes.
+        assert!(reject_forbidden_output(
+            r#"{"steps":[{"step_ref":"run1:s0","status":"verified","has_evidence":true}]}"#
+        )
+        .is_ok());
+    }
+}

--- a/rust-core/crates/friday-hub/src/bin/hub_workflow_run_readback.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_workflow_run_readback.rs
@@ -12,16 +12,25 @@
 //!
 //! ## Output contract — REFS ONLY (no bodies, no params, no evidence text)
 //! One JSON object on stdout carrying ONLY safe identifiers/labels/counts:
-//! `truth_label="rust_wired_dev"`, the run summary (run id / workflow name label
-//! / persisted state label / timestamps), per-step summaries (step REF
-//! `<run_id>:s<seq>`, seq, side-effect flag, status label, `has_evidence` BOOL),
-//! step counts by status, `first_pending_seq` (the paused checkpoint of an
-//! `awaiting_checkpoint` run), and the audit-chain-verified bool. The
-//! `evidence_ref` TEXT (a tool-receipt summary that can embed a relative
-//! filename) is structurally unselectable — the storage read helper only ever
-//! projects its presence — and step params / definition bodies are not stored on
-//! run rows at all. [`reject_forbidden_output`] fails the WHOLE projection closed
-//! if any forbidden marker ever appears.
+//! `truth_label="rust_wired_dev"`, the run summary (run id / a BOUNDED
+//! projection of the free-form workflow name as `workflow_name_sha256` +
+//! `workflow_name_len` — the raw DB string is NEVER emitted, so a marker-bearing
+//! name is structurally impossible in output / persisted state label /
+//! timestamps), per-step summaries (step REF `<run_id>:s<seq>`, seq, side-effect
+//! flag, status label, `has_evidence` BOOL — step `status` and `step_ref` are
+//! RE-VALIDATED fail-closed against the engine's closed vocabulary/shape by the
+//! storage read helper, never passed through from a tampered DB), step counts by
+//! status (`verified`/`pending`/`proof_pending`/`failed`/`running` — the FULL
+//! persisted `StepStatus` vocabulary, so the five counters PARTITION
+//! `step_count`), `first_pending_seq` (the paused checkpoint of an
+//! `awaiting_checkpoint` run), and `audit_rows_verified` (the COUNT of
+//! hash-chain-verified audit rows — honest: the workflow driver writes zero
+//! audit rows today, so this is 0). The `evidence_ref` TEXT (a tool-receipt
+//! summary that can embed a relative filename) is structurally unselectable —
+//! the storage read helper only ever projects its presence — and step params /
+//! definition bodies are not stored on run rows at all.
+//! [`reject_forbidden_output`] fails the WHOLE projection closed if any
+//! forbidden marker ever appears.
 //!
 //! Usage: `hub_workflow_run_readback --db <hub.sqlite> --run-id <id>`
 
@@ -33,6 +42,7 @@ use friday_storage::workflow::first_pending_seq;
 use friday_storage::workflow_read::{get_workflow_run_summary, list_workflow_step_summaries};
 use friday_storage::Db;
 use serde_json::json;
+use sha2::{Digest, Sha256};
 
 /// A fail-closed error: `kind` is a coarse, safe category (the only thing
 /// surfaced); the raw detail is deliberately NOT printed so storage/IO errors
@@ -90,8 +100,11 @@ fn run(args: &[String]) -> Result<String, ReadbackError> {
     let pending_seq =
         first_pending_seq(db.conn(), &run_id).map_err(|_| ReadbackError::new("read_failed"))?;
 
-    // Audit chain verification over the readback DB (a bool, never the rows).
-    let audit_chain_verified = verify_audit_chain(db.conn()).is_ok();
+    // HONEST attestation: the COUNT of hash-chain-verified audit rows (the
+    // workflow driver writes zero audit rows today, so this is 0 — a bool here
+    // would be vacuously true). A broken chain fails the projection closed.
+    let audit_rows_verified =
+        verify_audit_chain(db.conn()).map_err(|_| ReadbackError::new("audit_verify_failed"))?;
 
     let count_status =
         |status: &str| -> usize { steps.iter().filter(|s| s.status == status).count() };
@@ -116,19 +129,26 @@ fn run(args: &[String]) -> Result<String, ReadbackError> {
         "proof_only": true,
         "ok": true,
         "run_id": summary.run_id,
-        "workflow_name": summary.name,
+        // The workflow name is a FREE-FORM DB string — never emitted verbatim.
+        // Bounded refs-only projection: sha256 hex + UTF-8 byte length.
+        "workflow_name_sha256": sha256_hex(summary.name.as_bytes()),
+        "workflow_name_len": summary.name.len(),
         "run_state": summary.state,
         "created_at_ms": summary.created_at,
         "updated_at_ms": summary.updated_at,
         "step_count": steps.len(),
+        // The FULL persisted StepStatus vocabulary — these five PARTITION
+        // step_count ('running' is how the engine persists an exec-errored
+        // non-side-effect step: resolve_step_completion(false, false, false)).
         "verified_count": count_status("verified"),
         "pending_count": count_status("pending"),
         "proof_pending_count": count_status("proof_pending"),
         "failed_count": count_status("failed"),
+        "running_count": count_status("running"),
         "side_effect_step_count": steps.iter().filter(|s| s.has_side_effect).count(),
         "first_pending_seq": pending_seq,
         "steps": step_objects,
-        "audit_chain_verified": audit_chain_verified,
+        "audit_rows_verified": audit_rows_verified,
     });
 
     let rendered =
@@ -147,14 +167,34 @@ fn arg_value(args: &[String], name: &str) -> Option<String> {
         })
 }
 
+/// Lowercase sha256 hex — the bounded projection of a free-form DB string
+/// (mirrors `hub_run_task::sha256_hex`).
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let digest = hasher.finalize();
+    let mut out = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        out.push_str(&format!("{byte:02x}"));
+    }
+    out
+}
+
 /// Defense-in-depth: refuse to print if any forbidden marker leaked into the
 /// refs-only projection. Beyond the shared secret/path markers, this bin's
 /// body-bearing fields must never appear: the `"evidence_ref"` text, step
-/// `"params"`, and the stored `"definition_json"` body.
+/// `"params"`, and the stored `"definition_json"` / `"source_meta"` bodies
+/// (the same extras set as the `hub_workflow_run` write-bridge — kept in
+/// lockstep so the two S9 bins cannot drift).
 fn reject_forbidden_output(rendered: &str) -> Result<(), ReadbackError> {
     friday_hub::refs_guard::reject_forbidden_output(
         rendered,
-        &["\"evidence_ref\"", "\"params\"", "\"definition_json\""],
+        &[
+            "\"evidence_ref\"",
+            "\"params\"",
+            "\"definition_json\"",
+            "\"source_meta\"",
+        ],
     )
     .map_err(|_| ReadbackError::new("output_guard"))
 }
@@ -206,7 +246,14 @@ mod tests {
     /// S9 seam (stored def → loader → existing engine) against a real temp
     /// workspace, and return the DB path. This makes the readback test a genuine
     /// end-to-end: it projects rows the ENGINE persisted, not hand-inserted ones.
-    fn seeded_run(tag: &str, steps: Vec<StoredWorkflowStepV1>, run_id: &str) -> String {
+    /// `create_workspace: false` leaves the workspace path NONEXISTENT — the
+    /// exec-error repro (the engine persists the errored step as 'running').
+    fn seeded_run_in(
+        tag: &str,
+        steps: Vec<StoredWorkflowStepV1>,
+        run_id: &str,
+        create_workspace: bool,
+    ) -> String {
         let db_path = tmp(tag)
             .with_extension("sqlite")
             .to_string_lossy()
@@ -227,12 +274,33 @@ mod tests {
         )
         .unwrap();
         let ws = tmp(&format!("{tag}-ws"));
-        std::fs::create_dir_all(&ws).unwrap();
-        std::fs::write(ws.join("notes.txt"), b"hello readback").unwrap();
+        if create_workspace {
+            std::fs::create_dir_all(&ws).unwrap();
+            std::fs::write(ws.join("notes.txt"), b"hello readback").unwrap();
+        }
         let exec = FsToolExecutor::new(&ws);
         run_stored_published_workflow(db.conn(), &exec, "wf1", run_id, SECRET, &deny_all, 200)
             .unwrap();
         db_path
+    }
+
+    fn seeded_run(tag: &str, steps: Vec<StoredWorkflowStepV1>, run_id: &str) -> String {
+        seeded_run_in(tag, steps, run_id, true)
+    }
+
+    /// The five status counters (the FULL persisted StepStatus vocabulary) must
+    /// PARTITION step_count — no persisted step status is ever invisible to the
+    /// projection (the original four-counter set silently dropped 'running').
+    fn assert_counters_partition_step_count(v: &Value) {
+        let sum = ["verified", "pending", "proof_pending", "failed", "running"]
+            .iter()
+            .map(|s| v[&format!("{s}_count")].as_u64().unwrap())
+            .sum::<u64>();
+        assert_eq!(
+            sum,
+            v["step_count"].as_u64().unwrap(),
+            "status counters must partition step_count: {v}"
+        );
     }
 
     fn bin_args(db: &str, run_id: &str) -> Vec<String> {
@@ -275,11 +343,20 @@ mod tests {
         assert_eq!(v["proof_only"], true);
         assert_eq!(v["ok"], true);
         assert_eq!(v["run_id"], "run1");
-        assert_eq!(v["workflow_name"], "research");
+        // The free-form name is projected BOUNDED (hash + byte length), never verbatim.
+        assert_eq!(v["workflow_name_sha256"], sha256_hex(b"research"));
+        assert_eq!(v["workflow_name_len"], "research".len());
+        assert!(v.get("workflow_name").is_none(), "raw name never emitted");
         assert_eq!(v["run_state"], "done");
         assert_eq!(v["step_count"], 2);
         assert_eq!(v["verified_count"], 2);
+        assert_eq!(v["running_count"], 0);
+        assert_counters_partition_step_count(&v);
         assert_eq!(v["first_pending_seq"], Value::Null);
+        // Honest audit attestation: a COUNT (0 — the workflow driver writes no
+        // audit rows), never a vacuous bool.
+        assert_eq!(v["audit_rows_verified"], 0);
+        assert!(v.get("audit_chain_verified").is_none());
         let steps = v["steps"].as_array().unwrap();
         assert_eq!(steps.len(), 2);
         assert_eq!(steps[0]["step_ref"], "run1:s0");
@@ -314,6 +391,8 @@ mod tests {
         let v: Value = from_str(&rendered).unwrap();
         assert_eq!(v["run_state"], "awaiting_checkpoint");
         assert_eq!(v["pending_count"], 1);
+        assert_eq!(v["running_count"], 0);
+        assert_counters_partition_step_count(&v);
         assert_eq!(v["first_pending_seq"], 1);
         let steps = v["steps"].as_array().unwrap();
         assert_eq!(steps[1]["status"], "pending");
@@ -322,6 +401,37 @@ mod tests {
         // The paused write's params (path/content) are not stored on run rows
         // and must not appear.
         assert!(!rendered.contains("out.txt"));
+    }
+
+    #[test]
+    fn exec_errored_step_reads_back_as_running_count_and_counters_partition() {
+        // THE counter-vocabulary repro at the readback side: the engine ran a
+        // READ-ONLY def against a NONEXISTENT workspace, persisting the
+        // exec-errored step as 'running' (resolve_step_completion(false, false,
+        // false)) and the run as failed. The projection must make that step
+        // VISIBLE (running_count=1) and the five counters must still partition
+        // step_count.
+        let db = seeded_run_in(
+            "execerr",
+            vec![
+                step("read", "read_file", &[("path", "notes.txt")]),
+                step("ls", "list_dir", &[("path", ".")]),
+            ],
+            "run-err",
+            false,
+        );
+        let rendered = run(&bin_args(&db, "run-err")).map_err(|e| e.kind).unwrap();
+        let v: Value = from_str(&rendered).unwrap();
+        assert_eq!(v["run_state"], "failed");
+        // Step rows are added lazily as the engine loop reaches them: only s0.
+        assert_eq!(v["step_count"], 1);
+        assert_eq!(v["running_count"], 1, "the exec-errored step is VISIBLE");
+        assert_eq!(v["verified_count"], 0);
+        assert_eq!(v["failed_count"], 0);
+        assert_counters_partition_step_count(&v);
+        let steps = v["steps"].as_array().unwrap();
+        assert_eq!(steps[0]["status"], "running");
+        assert_eq!(steps[0]["has_evidence"], false);
     }
 
     #[test]
@@ -346,12 +456,14 @@ mod tests {
     }
 
     #[test]
-    fn forbidden_output_canary_fails_the_whole_projection_closed() {
-        // CANARY through the REAL path: hand-corrupt the persisted run name so an
-        // absolute path would enter the projection — the guard must refuse to
-        // print (fail-closed), proving it sits between the DB and stdout.
+    fn marker_bearing_name_is_structurally_impossible_in_output() {
+        // STRUCTURAL (not canary-caught): hand-corrupt the persisted run name
+        // with an absolute-path marker — the projection still SUCCEEDS, because
+        // the name is never emitted verbatim, only its sha256 + byte length.
+        // The marker cannot reach stdout through the name field at all.
+        let tampered_name = "/Users/jarvis/leak";
         let db = seeded_run(
-            "canary",
+            "canary-name",
             vec![step("read", "read_file", &[("path", "notes.txt")])],
             "run1",
         );
@@ -364,8 +476,85 @@ mod tests {
                 )
                 .unwrap();
         }
+        let rendered = run(&bin_args(&db, "run1")).map_err(|e| e.kind).unwrap();
+        assert!(!rendered.contains("/Users/"), "marker never in output");
+        let v: Value = from_str(&rendered).unwrap();
+        assert_eq!(
+            v["workflow_name_sha256"],
+            sha256_hex(tampered_name.as_bytes())
+        );
+        assert_eq!(v["workflow_name_len"], tampered_name.len());
+        assert!(v.get("workflow_name").is_none());
+    }
+
+    #[test]
+    fn forbidden_output_canary_fails_the_whole_projection_closed() {
+        // CANARY through the REAL path (defense-in-depth on the OTHER verbatim
+        // fields): hand-corrupt the persisted run STATE (a label emitted
+        // verbatim) so an absolute path would enter the projection — the guard
+        // must refuse to print (fail-closed), proving it still sits between the
+        // DB and stdout for every field that is not structurally bounded.
+        let db = seeded_run(
+            "canary-state",
+            vec![step("read", "read_file", &[("path", "notes.txt")])],
+            "run1",
+        );
+        {
+            let w = friday_storage::Db::open_hub(&db).unwrap();
+            w.conn()
+                .execute(
+                    "UPDATE workflow_run SET state = '/Users/jarvis/leak' WHERE run_id = 'run1'",
+                    [],
+                )
+                .unwrap();
+        }
         let err = run(&bin_args(&db, "run1")).err().unwrap();
         assert_eq!(err.kind, "output_guard");
+    }
+
+    #[test]
+    fn tampered_step_status_or_step_ref_fails_the_readback_closed() {
+        // DB strings are NOT trusted: the storage read helper re-validates step
+        // `status` (engine closed vocabulary) and `step_id` (`<run_id>:s<seq>`
+        // shape) and fails CLOSED — the readback surfaces the coarse
+        // `read_failed`, never a free-form passthrough.
+        let db = seeded_run(
+            "tamper-status",
+            vec![step("read", "read_file", &[("path", "notes.txt")])],
+            "run1",
+        );
+        {
+            let w = friday_storage::Db::open_hub(&db).unwrap();
+            w.conn()
+                .execute(
+                    "UPDATE workflow_step SET status = 'sk-totally-bogus' WHERE step_id = 'run1:s0'",
+                    [],
+                )
+                .unwrap();
+        }
+        assert_eq!(
+            run(&bin_args(&db, "run1")).err().unwrap().kind,
+            "read_failed"
+        );
+
+        let db2 = seeded_run(
+            "tamper-ref",
+            vec![step("read", "read_file", &[("path", "notes.txt")])],
+            "run1",
+        );
+        {
+            let w = friday_storage::Db::open_hub(&db2).unwrap();
+            w.conn()
+                .execute(
+                    "UPDATE workflow_step SET step_id = 'Bearer evil' WHERE step_id = 'run1:s0'",
+                    [],
+                )
+                .unwrap();
+        }
+        assert_eq!(
+            run(&bin_args(&db2, "run1")).err().unwrap().kind,
+            "read_failed"
+        );
     }
 
     #[test]
@@ -373,6 +562,7 @@ mod tests {
         assert!(reject_forbidden_output(r#"{"evidence_ref":"read 3 bytes from x"}"#).is_err());
         assert!(reject_forbidden_output(r#"{"params":[["path","x"]]}"#).is_err());
         assert!(reject_forbidden_output(r#"{"definition_json":"{}"}"#).is_err());
+        assert!(reject_forbidden_output(r#"{"source_meta":"{}"}"#).is_err());
         assert!(reject_forbidden_output(r#"{"x":"Bearer abc"}"#).is_err());
         assert!(reject_forbidden_output(r#"{"k":"/Users/jarvis/x"}"#).is_err());
         // The refs-only step shape passes.

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -123,6 +123,13 @@ pub mod workflow_def;
 /// never partial. Dark substrate; NOT v1 GO.
 pub mod workflow_ts_translate;
 
+/// S9 — manual workflow-RUN bridge seam: load a STORED definition (S8 loader)
+/// and execute it through the EXISTING [`workflow_exec`] engine (no engine
+/// change, no second executor; mutating steps stay gate-paused under deny-all).
+/// DARK substrate: no production route, no scheduler (S10, operator-gated);
+/// workflow execution remains fenced in TS and is NOT product-replaced; NOT v1 GO.
+pub mod workflow_run;
+
 /// PAIR-002 — Hub-side local pairing message handler. It consumes the structured
 /// QR payload from PAIR-001 and the first-slice protocol `Pair` message, writes a
 /// trusted device through the existing authenticated pairing proof, and never

--- a/rust-core/crates/friday-hub/src/workflow_run.rs
+++ b/rust-core/crates/friday-hub/src/workflow_run.rs
@@ -1,0 +1,396 @@
+//! S9 — the manual workflow-RUN bridge seam: load a STORED workflow definition
+//! (S8, [`crate::workflow_def`]) by `workflow_id`/`version` (or its published
+//! version) and execute it through the EXISTING, UNMODIFIED
+//! [`crate::workflow_exec`] engine.
+//!
+//! ## Scope and truth labels (DARK substrate)
+//! - This is the non-test dispatch seam the S9 lane adds: before it, the
+//!   engine's `run_workflow` entrypoint had only `#[cfg(test)]` callers. It
+//!   registers NO production route, NO scheduler/trigger/cron/daemon (that is
+//!   S10, operator-gated), and changes NO TS runtime file. Workflow execution
+//!   remains fenced in TS and is NOT product-replaced; NOT v1 GO.
+//! - There is NO second executor and NO engine change: the loader's output
+//!   ([`crate::planner::WorkflowDefinition`]) IS the engine's input, and every
+//!   step still goes through the engine's planner + `gate_dispatch` chokepoints
+//!   with the SAME gate posture the engine already has — under the default
+//!   deny-all approval policy a mutating/checkpoint step PAUSES the run
+//!   (`AwaitingCheckpoint`) and is never executed. No gate/approval/crypto code
+//!   is touched here.
+//! - Mission/WorkItem binding: the existing engine does not model it — a
+//!   workflow run is keyed by `run_id` only (`workflow_run` has no
+//!   mission/work-item column). This seam therefore does NOT invent one; if a
+//!   later slice adds Mission binding to the engine, this seam inherits it.
+//! - Single-shot is inherited from the engine: re-invoking with an already-used
+//!   `run_id` fails closed at `create_run` (duplicate PK, no double-dispatch).
+//!
+//! ## Fail-closed posture
+//! A missing definition / missing published version / unparsable or
+//! name-divergent stored body all fail closed in the S8 loader BEFORE any run
+//! row is created — a run is only ever created for a definition that loaded and
+//! validated.
+
+use friday_core::gate::{CanonicalApproval, MutatingActionRequest};
+use rusqlite::Connection;
+
+use crate::workflow_def::{load_definition, WorkflowDefError};
+use crate::workflow_exec::{run_workflow, WorkflowOutcome};
+use crate::ToolExecutor;
+
+/// The outcome of running a STORED workflow definition: which definition ran
+/// (id + the resolved version — meaningful for published-version dispatch) plus
+/// the engine's own [`WorkflowOutcome`], unchanged.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StoredWorkflowRun {
+    pub workflow_id: String,
+    /// The definition version that actually ran (explicit, or the resolved
+    /// published version).
+    pub version: i64,
+    pub outcome: WorkflowOutcome,
+}
+
+/// Run a STORED workflow definition (exact `workflow_id` + `version`) through
+/// the EXISTING engine: S8 loader (fail-closed parse/validate/name-crosscheck)
+/// → [`crate::workflow_exec::run_workflow`] (planner + gate per step, pause at
+/// the first checkpoint, evidence-gated completion). Pure composition — no
+/// engine change, no second executor.
+#[allow(clippy::too_many_arguments)]
+pub fn run_stored_workflow(
+    conn: &Connection,
+    executor: &dyn ToolExecutor,
+    workflow_id: &str,
+    version: i64,
+    run_id: &str,
+    secret: &[u8],
+    approve: &dyn Fn(&MutatingActionRequest) -> Option<CanonicalApproval>,
+    now_ms: i64,
+) -> Result<StoredWorkflowRun, WorkflowDefError> {
+    // Fail-closed load FIRST: no run row is created for a definition that does
+    // not load + validate.
+    let def = load_definition(conn, workflow_id, version)?;
+    let outcome = run_workflow(&def, executor, conn, run_id, secret, approve, now_ms)?;
+    Ok(StoredWorkflowRun {
+        workflow_id: workflow_id.to_string(),
+        version,
+        outcome,
+    })
+}
+
+/// Run the PUBLISHED version of a stored workflow. Resolves the published
+/// version fail-closed (no published version ⇒ [`WorkflowDefError::NotFound`]),
+/// then dispatches through [`run_stored_workflow`] so both entrypoints share
+/// one load→engine path.
+pub fn run_stored_published_workflow(
+    conn: &Connection,
+    executor: &dyn ToolExecutor,
+    workflow_id: &str,
+    run_id: &str,
+    secret: &[u8],
+    approve: &dyn Fn(&MutatingActionRequest) -> Option<CanonicalApproval>,
+    now_ms: i64,
+) -> Result<StoredWorkflowRun, WorkflowDefError> {
+    let version = published_version(conn, workflow_id)?;
+    run_stored_workflow(
+        conn,
+        executor,
+        workflow_id,
+        version,
+        run_id,
+        secret,
+        approve,
+        now_ms,
+    )
+}
+
+/// Resolve a workflow's PUBLISHED version number (read-only). Fail-closed when
+/// the workflow has no published version.
+pub fn published_version(conn: &Connection, workflow_id: &str) -> Result<i64, WorkflowDefError> {
+    let row = friday_storage::workflow_def::get_published_definition(conn, workflow_id)?
+        .ok_or_else(|| {
+            WorkflowDefError::NotFound(format!("'{workflow_id}' (no published version)"))
+        })?;
+    Ok(row.version)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workflow_def::{
+        create_definition, store_published_version, StoredWorkflowDefV1, StoredWorkflowStepV1,
+        WORKFLOW_DEF_SCHEMA_VERSION,
+    };
+    use crate::workflow_exec::WorkflowRunStatus;
+    use crate::FsToolExecutor;
+    use friday_storage::workflow_def::DefinitionSource;
+    use friday_storage::workflow_read::{get_workflow_run_summary, list_workflow_step_summaries};
+    use friday_storage::Db;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static C: AtomicU64 = AtomicU64::new(0);
+    fn tmp(tag: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!(
+            "friday-wfrun-{}-{}-{}",
+            std::process::id(),
+            tag,
+            C.fetch_add(1, Ordering::Relaxed)
+        ))
+    }
+
+    fn tmp_db(tag: &str) -> String {
+        tmp(tag)
+            .with_extension("sqlite")
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    /// A real temp WORKSPACE (not a mock): contains `notes.txt` so a read-only
+    /// stored workflow has something genuine to read through `FsToolExecutor`.
+    fn tmp_workspace(tag: &str) -> std::path::PathBuf {
+        let ws = tmp(tag);
+        std::fs::create_dir_all(&ws).unwrap();
+        std::fs::write(ws.join("notes.txt"), b"hello workflow").unwrap();
+        ws
+    }
+
+    const SECRET: &[u8] = b"wf-run-secret-0123456789abcdef";
+
+    fn deny_all(_r: &MutatingActionRequest) -> Option<CanonicalApproval> {
+        None
+    }
+
+    fn step(id: &str, action: &str, params: &[(&str, &str)]) -> StoredWorkflowStepV1 {
+        StoredWorkflowStepV1 {
+            id: id.to_string(),
+            action: action.to_string(),
+            params: params
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+            force_checkpoint: false,
+            evidence_required: false,
+        }
+    }
+
+    fn read_only_def() -> StoredWorkflowDefV1 {
+        StoredWorkflowDefV1 {
+            schema_version: WORKFLOW_DEF_SCHEMA_VERSION,
+            name: "research".into(),
+            steps: vec![
+                step("read", "read_file", &[("path", "notes.txt")]),
+                step("ls", "list_dir", &[("path", ".")]),
+            ],
+        }
+    }
+
+    fn mutating_def() -> StoredWorkflowDefV1 {
+        StoredWorkflowDefV1 {
+            schema_version: WORKFLOW_DEF_SCHEMA_VERSION,
+            name: "ship".into(),
+            steps: vec![
+                step("read", "read_file", &[("path", "notes.txt")]),
+                step(
+                    "write",
+                    "write_file",
+                    &[("path", "out.txt"), ("content", "y")],
+                ),
+            ],
+        }
+    }
+
+    #[test]
+    fn stored_published_definition_runs_end_to_end_through_the_existing_engine() {
+        // THE seam test: stored def → S8 loader → UNMODIFIED engine executes a
+        // read-only linear workflow against a REAL temp workspace via the REAL
+        // FsToolExecutor → run/step rows persisted → readback helpers project
+        // refs-only summaries.
+        let db = Db::open_hub(&tmp_db("e2e")).unwrap();
+        let ws = tmp_workspace("e2e-ws");
+        store_published_version(
+            db.conn(),
+            "wf1",
+            3,
+            &read_only_def(),
+            DefinitionSource::RustNative,
+            None,
+            100,
+        )
+        .unwrap();
+
+        let exec = FsToolExecutor::new(&ws);
+        let run =
+            run_stored_published_workflow(db.conn(), &exec, "wf1", "run1", SECRET, &deny_all, 200)
+                .unwrap();
+
+        assert_eq!(run.workflow_id, "wf1");
+        assert_eq!(
+            run.version, 3,
+            "the published version is resolved + reported"
+        );
+        assert_eq!(run.outcome.status, WorkflowRunStatus::Completed);
+        assert_eq!(run.outcome.executed_steps, 2);
+
+        // Run + step rows persisted by the EXISTING engine, projectable refs-only.
+        let summary = get_workflow_run_summary(db.conn(), "run1")
+            .unwrap()
+            .unwrap();
+        assert_eq!(summary.name, "research");
+        assert_eq!(summary.state, "done");
+        let steps = list_workflow_step_summaries(db.conn(), "run1").unwrap();
+        assert_eq!(steps.len(), 2);
+        assert!(steps.iter().all(|s| s.status == "verified"));
+        assert!(
+            steps.iter().all(|s| s.has_evidence),
+            "executed steps complete WITH their tool receipt as evidence"
+        );
+        // refs-only at the type level: the summary struct has no evidence text field.
+        assert_eq!(steps[0].step_id, "run1:s0");
+        assert_eq!(steps[1].seq, 1);
+    }
+
+    #[test]
+    fn explicit_version_dispatch_runs_that_exact_version() {
+        let db = Db::open_hub(&tmp_db("ver")).unwrap();
+        let ws = tmp_workspace("ver-ws");
+        // v1 = two steps (unpublished), v2 = one step (published).
+        create_definition(
+            db.conn(),
+            "wf1",
+            1,
+            &read_only_def(),
+            DefinitionSource::RustNative,
+            None,
+            100,
+        )
+        .unwrap();
+        let mut v2 = read_only_def();
+        v2.steps.pop();
+        store_published_version(
+            db.conn(),
+            "wf1",
+            2,
+            &v2,
+            DefinitionSource::RustNative,
+            None,
+            200,
+        )
+        .unwrap();
+
+        let exec = FsToolExecutor::new(&ws);
+        // Explicit v1 runs the TWO-step definition even though v2 is published.
+        let run = run_stored_workflow(db.conn(), &exec, "wf1", 1, "run-v1", SECRET, &deny_all, 300)
+            .unwrap();
+        assert_eq!(run.version, 1);
+        assert_eq!(run.outcome.executed_steps, 2);
+    }
+
+    #[test]
+    fn mutating_step_gate_pauses_and_the_workspace_is_unchanged() {
+        // The S9 safety witness: a stored mutating step loaded from the DB still
+        // checkpoints under deny-all — the run pauses, the write NEVER executes,
+        // and the workspace file is NOT created.
+        let db = Db::open_hub(&tmp_db("pause")).unwrap();
+        let ws = tmp_workspace("pause-ws");
+        store_published_version(
+            db.conn(),
+            "wf-ship",
+            1,
+            &mutating_def(),
+            DefinitionSource::RustNative,
+            None,
+            100,
+        )
+        .unwrap();
+
+        let exec = FsToolExecutor::new(&ws);
+        let run = run_stored_published_workflow(
+            db.conn(),
+            &exec,
+            "wf-ship",
+            "run1",
+            SECRET,
+            &deny_all,
+            200,
+        )
+        .unwrap();
+
+        match &run.outcome.status {
+            WorkflowRunStatus::AwaitingCheckpoint { step_id, reason } => {
+                assert_eq!(step_id, "run1:s1");
+                assert!(reason.contains("mutating"), "reason: {reason}");
+            }
+            other => panic!("expected AwaitingCheckpoint, got {other:?}"),
+        }
+        assert_eq!(run.outcome.executed_steps, 1, "only the read step ran");
+        assert!(
+            !ws.join("out.txt").exists(),
+            "the gate-paused write must NOT touch the workspace"
+        );
+        let summary = get_workflow_run_summary(db.conn(), "run1")
+            .unwrap()
+            .unwrap();
+        assert_eq!(summary.state, "awaiting_checkpoint");
+        let steps = list_workflow_step_summaries(db.conn(), "run1").unwrap();
+        assert_eq!(steps[1].status, "pending");
+        assert!(!steps[1].has_evidence);
+        assert!(steps[1].has_side_effect);
+    }
+
+    #[test]
+    fn missing_definition_or_version_fails_closed_before_any_run_row() {
+        let db = Db::open_hub(&tmp_db("missing")).unwrap();
+        let ws = tmp_workspace("missing-ws");
+        let exec = FsToolExecutor::new(&ws);
+        // Unknown workflow id.
+        assert!(matches!(
+            run_stored_workflow(db.conn(), &exec, "ghost", 1, "r1", SECRET, &deny_all, 100),
+            Err(WorkflowDefError::NotFound(_))
+        ));
+        // Known id, missing version.
+        create_definition(
+            db.conn(),
+            "wf1",
+            1,
+            &read_only_def(),
+            DefinitionSource::RustNative,
+            None,
+            100,
+        )
+        .unwrap();
+        assert!(matches!(
+            run_stored_workflow(db.conn(), &exec, "wf1", 9, "r2", SECRET, &deny_all, 200),
+            Err(WorkflowDefError::NotFound(_))
+        ));
+        // No published version (v1 exists but is unpublished).
+        assert!(matches!(
+            run_stored_published_workflow(db.conn(), &exec, "wf1", "r3", SECRET, &deny_all, 300),
+            Err(WorkflowDefError::NotFound(_))
+        ));
+        // Fail-closed BEFORE the run: no run row was ever created.
+        assert!(get_workflow_run_summary(db.conn(), "r1").unwrap().is_none());
+        assert!(get_workflow_run_summary(db.conn(), "r2").unwrap().is_none());
+        assert!(get_workflow_run_summary(db.conn(), "r3").unwrap().is_none());
+    }
+
+    #[test]
+    fn duplicate_run_id_fails_closed_single_shot_is_inherited() {
+        let db = Db::open_hub(&tmp_db("dup")).unwrap();
+        let ws = tmp_workspace("dup-ws");
+        store_published_version(
+            db.conn(),
+            "wf1",
+            1,
+            &read_only_def(),
+            DefinitionSource::RustNative,
+            None,
+            100,
+        )
+        .unwrap();
+        let exec = FsToolExecutor::new(&ws);
+        run_stored_published_workflow(db.conn(), &exec, "wf1", "run1", SECRET, &deny_all, 200)
+            .unwrap();
+        // Re-dispatching the SAME run_id is a fail-closed dup (engine `create_run` PK).
+        assert!(matches!(
+            run_stored_published_workflow(db.conn(), &exec, "wf1", "run1", SECRET, &deny_all, 300),
+            Err(WorkflowDefError::Storage(_))
+        ));
+    }
+}

--- a/rust-core/crates/friday-hub/src/workflow_run.rs
+++ b/rust-core/crates/friday-hub/src/workflow_run.rs
@@ -22,6 +22,10 @@
 //!   later slice adds Mission binding to the engine, this seam inherits it.
 //! - Single-shot is inherited from the engine: re-invoking with an already-used
 //!   `run_id` fails closed at `create_run` (duplicate PK, no double-dispatch).
+//! - Definition-source axis: the seam is source-agnostic — `RustNative` and
+//!   `TsTranslated` stored definitions load and run through the SAME
+//!   load→engine path (the source label is refs-only provenance metadata, never
+//!   a dispatch fork), and both are exercised by tests below.
 //!
 //! ## Fail-closed posture
 //! A missing definition / missing published version / unparsable or
@@ -285,10 +289,15 @@ mod tests {
     #[test]
     fn mutating_step_gate_pauses_and_the_workspace_is_unchanged() {
         // The S9 safety witness: a stored mutating step loaded from the DB still
-        // checkpoints under deny-all — the run pauses, the write NEVER executes,
-        // and the workspace file is NOT created.
+        // checkpoints under deny-all — the run pauses, the write NEVER executes.
+        // The write TARGET pre-exists with known bytes (the overwrite-existing
+        // case): "unchanged" is asserted as BYTE EQUALITY of its content, not
+        // merely absence/count (a truncate-then-pause bug would pass an
+        // absence-style check; it cannot pass this one).
         let db = Db::open_hub(&tmp_db("pause")).unwrap();
         let ws = tmp_workspace("pause-ws");
+        let pre_existing = b"pre-existing target content the paused write must not touch";
+        std::fs::write(ws.join("out.txt"), pre_existing).unwrap();
         store_published_version(
             db.conn(),
             "wf-ship",
@@ -320,9 +329,10 @@ mod tests {
             other => panic!("expected AwaitingCheckpoint, got {other:?}"),
         }
         assert_eq!(run.outcome.executed_steps, 1, "only the read step ran");
-        assert!(
-            !ws.join("out.txt").exists(),
-            "the gate-paused write must NOT touch the workspace"
+        assert_eq!(
+            std::fs::read(ws.join("out.txt")).unwrap(),
+            pre_existing,
+            "the gate-paused write must leave the pre-existing target BYTE-IDENTICAL"
         );
         let summary = get_workflow_run_summary(db.conn(), "run1")
             .unwrap()
@@ -332,6 +342,44 @@ mod tests {
         assert_eq!(steps[1].status, "pending");
         assert!(!steps[1].has_evidence);
         assert!(steps[1].has_side_effect);
+    }
+
+    #[test]
+    fn ts_translated_sourced_definition_runs_end_to_end_like_a_native_one() {
+        // The definition-source axis: a stored definition whose provenance is
+        // `TsTranslated` (the S8 linear-only translator's output shape, with
+        // refs-only source_meta) loads and runs through the IDENTICAL
+        // load→engine path as a RustNative one — the source label is
+        // provenance, never a dispatch fork.
+        let db = Db::open_hub(&tmp_db("tssrc")).unwrap();
+        let ws = tmp_workspace("tssrc-ws");
+        store_published_version(
+            db.conn(),
+            "wf-ts",
+            1,
+            &read_only_def(),
+            DefinitionSource::TsTranslated,
+            Some(r#"{"ts_workflow_ref":"wf-ts","ts_version":4}"#),
+            100,
+        )
+        .unwrap();
+
+        let exec = FsToolExecutor::new(&ws);
+        let run = run_stored_published_workflow(
+            db.conn(),
+            &exec,
+            "wf-ts",
+            "run-ts",
+            SECRET,
+            &deny_all,
+            200,
+        )
+        .unwrap();
+        assert_eq!(run.outcome.status, WorkflowRunStatus::Completed);
+        assert_eq!(run.outcome.executed_steps, 2);
+        let steps = list_workflow_step_summaries(db.conn(), "run-ts").unwrap();
+        assert_eq!(steps.len(), 2);
+        assert!(steps.iter().all(|s| s.status == "verified"));
     }
 
     #[test]

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -31,6 +31,7 @@ pub mod run_result;
 mod schema;
 pub mod workflow;
 pub mod workflow_def;
+pub mod workflow_read;
 
 pub use agent_session::{
     append_session_message, ensure_session, ensure_session_with_owner, load_session_messages,

--- a/rust-core/crates/friday-storage/src/workflow_read.rs
+++ b/rust-core/crates/friday-storage/src/workflow_read.rs
@@ -1,0 +1,106 @@
+//! Read-only projection helpers for `workflow_run` + `workflow_step` (S9 readback).
+//!
+//! Additive, READ-ONLY sibling of the write path in [`crate::workflow`] — the
+//! exact split [`crate::agent_run_read`] established for `agent_run` (S2). These
+//! helpers exist so a refs-only projection (the `hub_workflow_run_readback` dev
+//! bin) can read back a workflow run's state by `run_id` WITHOUT touching any
+//! write path. Nothing here mutates state; every function only `SELECT`s.
+//!
+//! ## Refs-only / no-body discipline
+//! [`WorkflowStepSummary`] deliberately NEVER carries the `evidence_ref` TEXT —
+//! that column holds a tool-receipt summary which can embed a (relative)
+//! filename, i.e. body-adjacent content. Only its **presence** is projected
+//! (`has_evidence`, computed in SQL as `evidence_ref IS NOT NULL`), so the
+//! evidence text is structurally unselectable through this module. The run
+//! `name` IS returned (a definition-name label, the same field the S8
+//! `hub_workflow_def_inspect` projection already emits), but the caller MUST
+//! still run everything through an output guard before emitting off-process.
+
+use crate::error::Result;
+use rusqlite::{Connection, OptionalExtension};
+
+/// A read-only summary of a `workflow_run` row. `state` is the persisted
+/// `WorkflowRunState` string (a safe closed-vocab label, e.g.
+/// `awaiting_checkpoint`); the timestamps are ints; `name` is the workflow
+/// definition's name label.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WorkflowRunSummary {
+    pub run_id: String,
+    pub name: String,
+    pub state: String,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+/// A read-only summary of one `workflow_step` row. Carries the step's
+/// identifiers/labels/flags ONLY — the `evidence_ref` text is unselectable here
+/// (see the module docs); its presence is the `has_evidence` bool.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WorkflowStepSummary {
+    /// The engine's step id (`<run_id>:s<seq>` — an identifier, never a body).
+    pub step_id: String,
+    pub seq: i64,
+    pub has_side_effect: bool,
+    /// The persisted `StepStatus` string (closed vocab, e.g. `verified`).
+    pub status: String,
+    /// Whether deterministic evidence is attached (`evidence_ref IS NOT NULL`).
+    /// The evidence text itself is never selected.
+    pub has_evidence: bool,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+/// Fetch a workflow run's refs-only summary by id (read-only). `None` if the
+/// run is unknown.
+pub fn get_workflow_run_summary(
+    conn: &Connection,
+    run_id: &str,
+) -> Result<Option<WorkflowRunSummary>> {
+    let row = conn
+        .query_row(
+            "SELECT run_id, name, state, created_at, updated_at
+             FROM workflow_run WHERE run_id = ?1",
+            [run_id],
+            |r| {
+                Ok(WorkflowRunSummary {
+                    run_id: r.get(0)?,
+                    name: r.get(1)?,
+                    state: r.get(2)?,
+                    created_at: r.get(3)?,
+                    updated_at: r.get(4)?,
+                })
+            },
+        )
+        .optional()?;
+    Ok(row)
+}
+
+/// The ordered (by `seq` ascending) refs-only summaries of a run's steps.
+/// `evidence_ref` is projected ONLY as the `has_evidence` bool — the text is
+/// never selected (refs-only at the SQL layer, not just at the emit layer).
+pub fn list_workflow_step_summaries(
+    conn: &Connection,
+    run_id: &str,
+) -> Result<Vec<WorkflowStepSummary>> {
+    let mut stmt = conn.prepare(
+        "SELECT step_id, seq, has_side_effect, status, evidence_ref IS NOT NULL,
+                created_at, updated_at
+         FROM workflow_step WHERE run_id = ?1 ORDER BY seq ASC",
+    )?;
+    let rows = stmt.query_map([run_id], |r| {
+        Ok(WorkflowStepSummary {
+            step_id: r.get(0)?,
+            seq: r.get(1)?,
+            has_side_effect: r.get::<_, i64>(2)? != 0,
+            status: r.get(3)?,
+            has_evidence: r.get::<_, i64>(4)? != 0,
+            created_at: r.get(5)?,
+            updated_at: r.get(6)?,
+        })
+    })?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row?);
+    }
+    Ok(out)
+}

--- a/rust-core/crates/friday-storage/src/workflow_read.rs
+++ b/rust-core/crates/friday-storage/src/workflow_read.rs
@@ -12,12 +12,34 @@
 //! filename, i.e. body-adjacent content. Only its **presence** is projected
 //! (`has_evidence`, computed in SQL as `evidence_ref IS NOT NULL`), so the
 //! evidence text is structurally unselectable through this module. The run
-//! `name` IS returned (a definition-name label, the same field the S8
-//! `hub_workflow_def_inspect` projection already emits), but the caller MUST
-//! still run everything through an output guard before emitting off-process.
+//! `name` IS returned (a free-form definition-name label) — callers MUST treat
+//! it as body-adjacent and project it bounded (hash + length), never verbatim,
+//! and still run everything through an output guard before emitting off-process.
+//!
+//! ## DB strings are NOT trusted (fail-closed re-validation)
+//! [`list_workflow_step_summaries`] re-validates the two step fields that flow
+//! into projections as strings: `status` must be in the engine's CLOSED
+//! [`StepStatus`] vocabulary, and `step_id` must have the engine's
+//! `<run_id>:s<seq>` shape. A row that violates either fails the WHOLE listing
+//! CLOSED (error, not passthrough) — a tampered-DB-only channel, but cheap to
+//! close at the projection layer rather than relying on downstream guards.
 
-use crate::error::Result;
+use crate::error::{Result, StorageError};
+use friday_core::StepStatus;
 use rusqlite::{Connection, OptionalExtension};
+
+/// The engine's CLOSED step-status vocabulary, derived from [`StepStatus`]
+/// itself (never a hand-maintained string list, so it cannot drift).
+fn is_engine_step_status(s: &str) -> bool {
+    const VOCAB: [StepStatus; 5] = [
+        StepStatus::Pending,
+        StepStatus::Running,
+        StepStatus::ProofPending,
+        StepStatus::Verified,
+        StepStatus::Failed,
+    ];
+    VOCAB.iter().any(|v| v.as_str() == s)
+}
 
 /// A read-only summary of a `workflow_run` row. `state` is the persisted
 /// `WorkflowRunState` string (a safe closed-vocab label, e.g.
@@ -38,10 +60,12 @@ pub struct WorkflowRunSummary {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct WorkflowStepSummary {
     /// The engine's step id (`<run_id>:s<seq>` — an identifier, never a body).
+    /// Re-validated against that exact shape at read time (fail-closed).
     pub step_id: String,
     pub seq: i64,
     pub has_side_effect: bool,
-    /// The persisted `StepStatus` string (closed vocab, e.g. `verified`).
+    /// The persisted `StepStatus` string. Re-validated at read time against the
+    /// engine's CLOSED vocabulary (fail-closed) — never a free-form passthrough.
     pub status: String,
     /// Whether deterministic evidence is attached (`evidence_ref IS NOT NULL`).
     /// The evidence text itself is never selected.
@@ -78,6 +102,12 @@ pub fn get_workflow_run_summary(
 /// The ordered (by `seq` ascending) refs-only summaries of a run's steps.
 /// `evidence_ref` is projected ONLY as the `has_evidence` bool — the text is
 /// never selected (refs-only at the SQL layer, not just at the emit layer).
+///
+/// Fail-closed re-validation (DB strings are not trusted): every row's `status`
+/// must be in the engine's closed [`StepStatus`] vocabulary and its `step_id`
+/// must be exactly `<run_id>:s<seq>`. One bad row fails the WHOLE listing —
+/// the tampered value is deliberately NOT quoted in the error (it is the
+/// untrusted content being rejected).
 pub fn list_workflow_step_summaries(
     conn: &Connection,
     run_id: &str,
@@ -100,7 +130,22 @@ pub fn list_workflow_step_summaries(
     })?;
     let mut out = Vec::new();
     for row in rows {
-        out.push(row?);
+        let s: WorkflowStepSummary = row?;
+        if !is_engine_step_status(&s.status) {
+            return Err(StorageError::Unsupported(format!(
+                "workflow_step seq {} of run '{run_id}' has a status outside the \
+                 engine vocabulary (fail-closed; refusing to project)",
+                s.seq
+            )));
+        }
+        if s.step_id != format!("{run_id}:s{}", s.seq) {
+            return Err(StorageError::Unsupported(format!(
+                "workflow_step seq {} of run '{run_id}' has a step_id that is not \
+                 '<run_id>:s<seq>'-shaped (fail-closed; refusing to project)",
+                s.seq
+            )));
+        }
+        out.push(s);
     }
     Ok(out)
 }

--- a/rust-core/crates/friday-storage/tests/workflow_read_projection.rs
+++ b/rust-core/crates/friday-storage/tests/workflow_read_projection.rs
@@ -74,3 +74,47 @@ fn step_summaries_are_seq_ordered_and_project_evidence_presence_never_its_text()
         .unwrap()
         .is_empty());
 }
+
+#[test]
+fn tampered_step_status_outside_the_engine_vocabulary_fails_the_listing_closed() {
+    // DB strings are NOT trusted: a hand-tampered status (free-form text that
+    // could carry anything into a projection) fails the WHOLE listing closed —
+    // error, not passthrough.
+    let db = Db::open_hub(&temp_db_path("wfread-badstatus")).unwrap();
+    workflow::create_run(db.conn(), "r1", "qa", 1).unwrap();
+    workflow::add_step(db.conn(), "r1:s0", "r1", 0, false, 1).unwrap();
+    db.conn()
+        .execute(
+            "UPDATE workflow_step SET status = '/Users/jarvis/leak' WHERE step_id = 'r1:s0'",
+            [],
+        )
+        .unwrap();
+    let err = list_workflow_step_summaries(db.conn(), "r1").unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("outside the engine vocabulary"),
+        "expected the closed-vocab rejection, got: {msg}"
+    );
+    // The tampered value itself is never echoed into the error.
+    assert!(!msg.contains("/Users/jarvis/leak"));
+}
+
+#[test]
+fn tampered_step_id_not_run_seq_shaped_fails_the_listing_closed() {
+    let db = Db::open_hub(&temp_db_path("wfread-badref")).unwrap();
+    workflow::create_run(db.conn(), "r1", "qa", 1).unwrap();
+    workflow::add_step(db.conn(), "r1:s0", "r1", 0, false, 1).unwrap();
+    db.conn()
+        .execute(
+            "UPDATE workflow_step SET step_id = 'Bearer not-a-ref' WHERE step_id = 'r1:s0'",
+            [],
+        )
+        .unwrap();
+    let err = list_workflow_step_summaries(db.conn(), "r1").unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("not '<run_id>:s<seq>'-shaped"),
+        "expected the step_id-shape rejection, got: {msg}"
+    );
+    assert!(!msg.contains("Bearer"), "tampered value never echoed");
+}

--- a/rust-core/crates/friday-storage/tests/workflow_read_projection.rs
+++ b/rust-core/crates/friday-storage/tests/workflow_read_projection.rs
@@ -1,0 +1,76 @@
+//! S9 read-only workflow-run projection helpers (`workflow_read`): refs-only
+//! summaries of `workflow_run` + `workflow_step` for the readback bridge. The
+//! discriminating property: the `evidence_ref` TEXT is structurally
+//! unselectable — only its presence (`has_evidence`) is projected.
+
+mod common;
+
+use common::temp_db_path;
+use friday_core::WorkflowRunState;
+use friday_storage::workflow_read::{get_workflow_run_summary, list_workflow_step_summaries};
+use friday_storage::{workflow, Db};
+
+#[test]
+fn run_summary_projects_labels_and_is_none_for_an_unknown_run() {
+    let db = Db::open_hub(&temp_db_path("wfread-run")).unwrap();
+    workflow::create_run(db.conn(), "r1", "research", 100).unwrap();
+    workflow::set_run_state(db.conn(), "r1", WorkflowRunState::Running, 200).unwrap();
+
+    let s = get_workflow_run_summary(db.conn(), "r1").unwrap().unwrap();
+    assert_eq!(s.run_id, "r1");
+    assert_eq!(s.name, "research");
+    assert_eq!(s.state, "running");
+    assert_eq!(s.created_at, 100);
+    assert_eq!(s.updated_at, 200);
+
+    assert!(get_workflow_run_summary(db.conn(), "ghost")
+        .unwrap()
+        .is_none());
+}
+
+#[test]
+fn step_summaries_are_seq_ordered_and_project_evidence_presence_never_its_text() {
+    let db = Db::open_hub(&temp_db_path("wfread-steps")).unwrap();
+    workflow::create_run(db.conn(), "r1", "qa", 1).unwrap();
+
+    // s0: side-effect step verified WITH evidence (the ref text embeds a
+    // relative filename, exactly what the engine's tool receipts store).
+    workflow::add_step(db.conn(), "r1:s0", "r1", 0, true, 1).unwrap();
+    workflow::complete_step(
+        db.conn(),
+        "r1:s0",
+        Some("read 14 bytes from notes.txt"),
+        true,
+        2,
+    )
+    .unwrap();
+    // s1: pending checkpoint (no evidence).
+    workflow::add_step(db.conn(), "r1:s1", "r1", 1, true, 3).unwrap();
+
+    let steps = list_workflow_step_summaries(db.conn(), "r1").unwrap();
+    assert_eq!(steps.len(), 2);
+    assert_eq!(steps[0].step_id, "r1:s0");
+    assert_eq!(steps[0].seq, 0);
+    assert!(steps[0].has_side_effect);
+    assert_eq!(steps[0].status, "verified");
+    assert!(steps[0].has_evidence, "evidence presence IS projected");
+    assert_eq!(steps[1].step_id, "r1:s1");
+    assert_eq!(steps[1].status, "pending");
+    assert!(!steps[1].has_evidence);
+
+    // The refs-only property: the summary type has no evidence-text field, so
+    // the stored filename cannot travel through this projection. (Compile-time
+    // structural; asserted here over the debug rendering as a belt-and-braces
+    // canary.)
+    let rendered = format!("{steps:?}");
+    assert!(
+        !rendered.contains("notes.txt") && !rendered.contains("bytes from"),
+        "evidence text must be unselectable through workflow_read: {rendered}"
+    );
+
+    // An unknown run projects an empty list (not an error — the run-existence
+    // decision belongs to the run-summary lookup).
+    assert!(list_workflow_step_summaries(db.conn(), "ghost")
+        .unwrap()
+        .is_empty());
+}


### PR DESCRIPTION
## S9 — manual workflow-run bridge + refs-only readback (DARK)

Operator-approved lane after S8 (#623). Base: `25249f68` (rebased onto latest main incl. #624/#625).

### Truth labels (read first)
- **DARK substrate / `rust_wired_dev` / proof-only.** No production HTTP route, no TS change, no scheduler/trigger/cron/daemon (that is S10, operator-gated). Workflow execution remains fenced in TS and is **NOT product-replaced**; **NOT v1 GO**.
- Live/manual **production** workflow runs stay operator-gated — everything here runs against dev/temp DBs + workspaces only (tests + a local process-level smoke).
- **No gate/approval/crypto change and no engine change**: `workflow_exec` is untouched; the bins hard-wire **deny-all**, so a mutating step still gate-pauses (`AwaitingCheckpoint`) and never executes.

### What this adds
1. **Run-dispatch seam** — `friday-hub/src/workflow_run.rs`: `run_stored_workflow` / `run_stored_published_workflow` load a STORED definition via the S8 loader (fail-closed parse/validate/name-crosscheck, no run row on a failed load) and execute it through the EXISTING `workflow_exec::run_workflow` (previously `#[cfg(test)]`-only callers). No second executor — the loader's output IS the engine's input. Single-shot (dup `run_id` fails closed) is inherited. *Mission/WorkItem binding: the engine does not model it (runs keyed by `run_id` only), so per lane scope it is NOT invented here.*
2. **Dev write-bridge bin** — `hub_workflow_run` (mirrors `hub_run_task`): `--db` (must pre-exist, fail-closed `db_not_found`) + `--workspace` + `--workflow-id` [+ `--version`, else published]. Emits a refs-only JSON receipt: ids/version/name label, closed-vocab `status` + **bounded `status_detail` token** (the engine's free-form pause/fail reasons are classified to `&'static str` tokens — leakage structurally impossible), step ref (`<run_id>:s<seq>`), step counts by status, `audit_chain_verified`. Shared `reject_forbidden_output` guard + bin-specific markers (`"params"`, `"definition_json"`, `"source_meta"`, `"evidence_ref"`). Deny-all approval policy; ephemeral non-secret gate bytes (dormant), mirroring S0.
3. **Readback** — `hub_workflow_run_readback` (mirrors `hub_run_readback`): read-only DB open, refs-only projection of the run/step rows `workflow_exec` persists (run summary, per-step `step_ref`/seq/side-effect/status/`has_evidence` bool, counts, `first_pending_seq`, audit bool). New `friday-storage/src/workflow_read.rs` helpers make the `evidence_ref` TEXT **structurally unselectable** (only `evidence_ref IS NOT NULL` is projected) — the read-only sibling split `agent_run_read` established.
4. **CI** — `rust-core.yml` gains two named **build-only** bin steps (house pattern, same as S0/S2/S8 bins); never executed in CI.
5. `lib.rs` deltas: module exports only (`workflow_run` in friday-hub, `workflow_read` in friday-storage).

### Test evidence (all local, post-rebase on 25249f68)
- `cargo test --workspace`: **exit 0, 1106 passed** (22 new: 5 seam + 9 write-bin + 6 readback-bin + 2 storage projection).
- `cargo clippy --workspace --all-targets -- -D warnings`: exit 0 (0 warnings). `cargo fmt --all -- --check`: clean.
- `detect-secrets-hook` (baseline) + `check-provider-key-patterns.mjs` on all changed files: clean, no pragmas needed.
- Required tests per lane spec:
  - **end-to-end seam**: stored published def → S8 loader → UNMODIFIED engine executes a read-only linear workflow via the REAL `FsToolExecutor` against a real temp workspace → run/step rows persisted → readback projects refs-only (`stored_published_definition_runs_end_to_end_through_the_existing_engine`, plus the same path at bin level).
  - **mutating-step workflow → gate-paused**: run pauses at `s1`, executor never called for it, **workspace unchanged** (`out.txt` absent) — at seam AND bin level.
  - **missing definition / missing DB fail-closed**: `NotFound` before any run row; `db_not_found` without creating a DB; unknown run → `run_not_found`; unparsable `--version` → `bad_args`.
  - **forbidden-output canaries through the REAL path**: a definition name embedding `Bearer …` fail-closes the write receipt (`output_guard`); a hand-corrupted run name embedding `/Users/…` fail-closes the readback. Plus guard unit tests and a leak-boundary test that classifier tokens never carry detail slices.
- **Process-level smoke** (temp DB/workspace, then deleted): both real binaries exercised — completed read-only run receipt, gate-paused mutating run (workspace untouched), both readbacks, and fail-closed exits (2) for missing DB/unknown run.

### Changed files
- `rust-core/crates/friday-hub/src/workflow_run.rs` (new — seam + tests)
- `rust-core/crates/friday-hub/src/bin/hub_workflow_run.rs` (new — write-bridge bin + tests)
- `rust-core/crates/friday-hub/src/bin/hub_workflow_run_readback.rs` (new — readback bin + tests)
- `rust-core/crates/friday-storage/src/workflow_read.rs` (new — refs-only read helpers)
- `rust-core/crates/friday-storage/tests/workflow_read_projection.rs` (new)
- `rust-core/crates/friday-hub/src/lib.rs`, `rust-core/crates/friday-storage/src/lib.rs` (module exports only)
- `.github/workflows/rust-core.yml` (two named build-only bin steps)

### Out of scope (unchanged)
Resume/live owner-approval leg (separate inventory row, operator-gated), S10 daemon/scheduler, any TS integration, any production run.

---

## Review-closure fix-up — commit `95991a73` (supersedes the bullets it amends above)

Two review passes (4-lens panel + a dedicated leak-boundary lens) confirmed 8 pre-merge findings; all are closed by `95991a73`. Where this table conflicts with the original description above (receipt fields `workflow_name` / `audit_chain_verified`, the name-canary wording, the seam pause test's `out.txt absent` wording, 1106 test count), **this table is current**.

| # | Finding | Fix |
|---|---------|-----|
| 1 | **MED** — counter vocabulary missed the persisted `running` status (the engine persists an exec-errored non-side-effect step as `running` via `resolve_step_completion(false,false,false)`; the 4 counters made it invisible) | `running_count` added to BOTH bins; tests assert the five counters **partition** `step_count` (sum equality), incl. the exec-error repro: stored read-only def vs nonexistent workspace → `status:"failed"` + `running_count:1` at write-bridge AND readback |
| 2 | **MED** — `workflow_name` (free-form DB string) emitted verbatim by BOTH bins | Replaced with bounded refs-only `workflow_name_sha256` (hex) + `workflow_name_len` (UTF-8 bytes). A marker-bearing name is now **structurally impossible** in output (tests assert success + marker absent), not merely canary-caught. Output-guard canaries retargeted to the remaining verbatim fields as defense-in-depth: marker-bearing `--run-id` (write-bridge) / tampered run `state` (readback) still fail the whole payload closed |
| 3 | `audit_chain_verified` vacuously true (driver writes zero audit rows) | Replaced with honest `audit_rows_verified: <count>` (0 today); a broken chain now fails the payload closed (`audit_verify_failed`) |
| 4 | unparsable `--now-ms` silently fell back to wall clock (inconsistent with fail-closed `--version`) | Present-but-unparsable `--now-ms` → `bad_args` (fail-closed); tested both ways |
| 5 | readback guard extras omitted `"source_meta"` | Added (lockstep with the write-bridge extras; drift prevention) + guard unit test |
| 6 | readback projections trusted DB strings for step `status` / `step_ref` | `workflow_read::list_workflow_step_summaries` re-validates fail-closed: `status` against the engine's CLOSED `StepStatus` vocabulary (derived from the enum, never a hand list), `step_id` against the `<run_id>:s<seq>` shape — **error, never passthrough**; tampered values never echoed into errors; tampered-DB tests at storage AND bin level |
| 7 | `ts_translated` source never exercised | Seam test runs a `TsTranslated`-sourced stored def end-to-end through the identical load→engine path; scope note added to `workflow_run.rs` docs (source label = provenance, never a dispatch fork) |
| 8 | "workspace unchanged" asserted only absence | Seam gate-pause test now pre-creates the write target and asserts **byte-equality** after the pause (overwrite-existing case); the bin test keeps the creation/absence case |

**Doc-only consumer notes added to the `hub_workflow_run` header** (no behavior change): a `Failed` run still exits 0 with `ok:true` — bridge-success semantics, consumers must key on `status`; duplicate `run_id` and genuine storage failure share `storage_failed` (known coarseness); `Db::open_hub` MIGRATES the target DB — never point `--db` at the production hub DB (dev fence).

**Gates at `95991a73`**: `cargo test --workspace` **1115 passed / 0 failed** (+9 tests vs a0c387d4); `clippy --all-targets -D warnings` clean; `fmt --check` clean; `detect-secrets-hook` + provider-key denylist clean on changed files; `origin/main` unmoved (`25249f68`, no rebase needed).

### Carry-forwards (recorded, deliberately NOT fixed here)
- **S8 `hub_workflow_def_inspect` emits the raw definition name** — same MED class as finding 2, but MERGED code (#623); follow-up slice, not touched by this PR.
- Published dispatch resolve-then-reload double-read (benign TOCTOU under the bins' usage).
- `AuthzMode::Hmac` legacy dormant posture (S6d-class debt).
- Guard-is-canary residual (characterized; the structural fixes above shrank, not eliminated, the guard-dependent surface — `run_id`/`workflow_id`/`run_state` remain verbatim-but-guarded).
- `main()` process glue not executed in CI (build-only bins; local process-level smoke only).
- Output guard is **output-position-only**: the run executes before a receipt refusal (a refused receipt does not undo the run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

