### PR TITLE
feat(rust): owner-wiring for run_session_loop + DM/subagent user attribution fallbacks (session-memory/D1 parity)

### DIFF
--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -2608,8 +2608,14 @@ pub fn run_loop_with_policy(
 ///   [`friday_storage::ensure_session_with_owner`] (idempotent; an already-bound owner
 ///   is never clobbered, a NULL axis can be backfilled) — this is what makes a
 ///   loop-created session's memory namespace RESOLVABLE for the Rust inline extraction.
-///   `None` keeps the owner-less [`friday_storage::ensure_session`] exactly as before
-///   (the session carries NULL owner axes and extraction fails closed — unchanged).
+///   `None` keeps the OWNER-AXIS / session-ensure path exactly as before: it routes to
+///   the owner-less [`friday_storage::ensure_session`], the session carries NULL owner
+///   axes, and extraction fails closed — unchanged. (NOTE: this "unchanged" scopes to the
+///   ensure/owner-axis path only. The new Finished-persist step 5 below runs REGARDLESS of
+///   `session_owner` — with `session_owner: None` AND no bound principal it now writes an
+///   OWNERLESS `run_result` row the pre-wiring loop did not. That row is fail-closed:
+///   `get_run_answer_for_principal` Denies it to EVERYONE (`NoOwnerPrincipal`), so it
+///   leaks nothing — see `sessioned_run_without_principal_persists_ownerless_fail_closed_result`.)
 /// * A `Finished` outcome now PERSISTS the run's answer Hub-side
 ///   ([`friday_storage::persist_run_result`]) with the run's BOUND OWNER principal
 ///   (`policy.principal_id()`) recorded as `owner_principal` — the same D1 owner-wiring
@@ -6042,8 +6048,11 @@ mod tests {
         );
     }
 
-    /// `session_owner: None` keeps the pre-wiring behavior bit-for-bit: the session
-    /// carries NULL owner axes (extraction stays fail-closed for it).
+    /// `session_owner: None` keeps the OWNER-AXIS / session-ensure path bit-for-bit: the
+    /// session carries NULL owner axes (extraction stays fail-closed for it). HONEST scope
+    /// (review LOW-a): this only covers the ensure/owner-axis path. The Finished-persist
+    /// step now writes an OWNERLESS `run_result` row even for `None` — asserted here to be
+    /// fail-closed (unreadable to everyone), NOT absent.
     #[test]
     fn session_loop_without_owner_creates_unowned_session_unchanged() {
         let root = TempDir::new("s5-unowned");
@@ -6080,6 +6089,21 @@ mod tests {
             back.user_id.as_deref(),
         )
         .is_err());
+        // HONEST (review LOW-a): with `None` AND no bound principal the Finished-persist DOES
+        // write a run_result row (the pre-wiring loop wrote none here) — but it is OWNERLESS
+        // and so Denied to EVERYONE (fail-closed/leakless), NOT readable and NOT absent.
+        use friday_storage::{AnswerDenyReason, RunAnswerAccess};
+        let row = friday_storage::get_run_result(db.conn(), "r1").unwrap();
+        assert!(
+            row.is_some(),
+            "the Finished-persist writes a row even for session_owner: None"
+        );
+        assert_eq!(row.unwrap().owner_principal, None, "the row is ownerless");
+        assert_eq!(
+            friday_storage::get_run_answer_for_principal(db.conn(), "r1", "anyone").unwrap(),
+            RunAnswerAccess::Denied(AnswerDenyReason::NoOwnerPrincipal),
+            "an ownerless row is unreadable by everyone (fail-closed)"
+        );
     }
 }
 

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -2602,6 +2602,27 @@ pub fn run_loop_with_policy(
 /// A non-`Finished` outcome still records the `user` turn (the operator asked it) but
 /// no `assistant` answer (there is none). Single-shot runs that never call this keep
 /// using [`run_loop`] / [`run_loop_with_policy`] unchanged — no session row is touched.
+///
+/// ## Owner-wiring (session-memory/D1 parity)
+/// * `session_owner`: `Some(owner)` BINDS the session's owner axes at creation via
+///   [`friday_storage::ensure_session_with_owner`] (idempotent; an already-bound owner
+///   is never clobbered, a NULL axis can be backfilled) — this is what makes a
+///   loop-created session's memory namespace RESOLVABLE for the Rust inline extraction.
+///   `None` keeps the owner-less [`friday_storage::ensure_session`] exactly as before
+///   (the session carries NULL owner axes and extraction fails closed — unchanged).
+/// * A `Finished` outcome now PERSISTS the run's answer Hub-side
+///   ([`friday_storage::persist_run_result`]) with the run's BOUND OWNER principal
+///   (`policy.principal_id()`) recorded as `owner_principal` — the same D1 owner-wiring
+///   [`HubRuntime::run_task`] got in #587 — so the authenticated body projection
+///   ([`friday_storage::get_run_answer_for_principal`]) releases a sessioned run's
+///   answer ONLY to that owner. A run with NO bound principal records NO owner ⇒ the
+///   body stays unreadable to everyone (fail-closed, correct). Persist happens ONLY on
+///   `Finished`: a `Paused` run's `run_result` slot belongs to the resume completion
+///   leg ([`crate::resume`]), and `Errored`/`Bounded`/`Blocked` carry no deliverable
+///   answer (mirrors `run_task`).
+///
+/// Truth label: parity wiring inside the Rust loop (dev-bridge/test-provable). It does
+/// NOT flip any TS-retirement state and is NOT a v1 GO.
 #[allow(clippy::too_many_arguments)]
 pub fn run_session_loop(
     client: &dyn AgentLlmClient,
@@ -2609,6 +2630,7 @@ pub fn run_session_loop(
     conn: &Connection,
     run_id: &str,
     session_id: &str,
+    session_owner: Option<&friday_storage::SessionOwner>,
     task: &str,
     recall_preamble: &str,
     operator_vk: Option<&OperatorVerifyingKey>,
@@ -2618,8 +2640,13 @@ pub fn run_session_loop(
     now_ms: i64,
 ) -> Result<LoopOutcome, StorageError> {
     // 1. Ensure the session exists and LOAD its prior turns BEFORE persisting the
-    //    current task (so the task is never folded into its own preamble).
-    friday_storage::ensure_session(conn, session_id, now_ms)?;
+    //    current task (so the task is never folded into its own preamble). With a
+    //    supplied owner the session is created OWNED (or a NULL axis backfilled);
+    //    without one the owner-less ensure keeps the pre-wiring behavior bit-for-bit.
+    match session_owner {
+        Some(owner) => friday_storage::ensure_session_with_owner(conn, session_id, owner, now_ms)?,
+        None => friday_storage::ensure_session(conn, session_id, now_ms)?,
+    }
     let prior = friday_storage::load_session_messages(conn, session_id)?;
 
     // 2. Fold the BOUNDED prior-session history AHEAD of the recall preamble. The loop
@@ -2661,6 +2688,27 @@ pub fn run_session_loop(
                 now_ms,
             )?;
         }
+    }
+
+    // 5. D1 OWNER-WIRING (the run_task #587 parity for the sessioned path): a FINISHED
+    //    run produced a deliverable ANSWER; persist it Hub-side keyed by `run_id` with
+    //    the run's BOUND OWNER principal recorded (`policy.principal_id()` — the SAME
+    //    principal the gate Actor binds), so `get_run_answer_for_principal` releases the
+    //    body ONLY to that owner. No bound principal ⇒ NO owner recorded ⇒ the body
+    //    stays unreadable to everyone (fail-closed). Persist ONLY on `Finished` —
+    //    `Paused` belongs to the resume completion leg, and the other outcomes carry no
+    //    deliverable answer (mirrors `run_task`). A fresh `run_id` cannot already hold a
+    //    result, so a persist conflict here signals a real bug and is propagated.
+    if outcome.status == LoopStatus::Finished {
+        let mut result = friday_storage::RunResult::new(
+            "finished",
+            outcome.final_message.clone().unwrap_or_default(),
+            None,
+        );
+        if let Some(principal) = policy.principal_id() {
+            result = result.with_owner_principal(principal);
+        }
+        friday_storage::persist_run_result(conn, run_id, &result, now_ms)?;
     }
 
     // Refs-only session outcome event: the session id + the new message COUNT, never
@@ -5553,6 +5601,7 @@ mod tests {
             db.conn(),
             "r1",
             "sess-1",
+            None,
             "what number did I ask you to remember",
             "",
             None,
@@ -5619,6 +5668,7 @@ mod tests {
             db.conn(),
             "r1",
             "sess-x",
+            None,
             "remember my budget is 500",
             "",
             None,
@@ -5643,6 +5693,7 @@ mod tests {
             db.conn(),
             "r2",
             "sess-x",
+            None,
             "what is my budget",
             "",
             None,
@@ -5737,6 +5788,7 @@ mod tests {
             db.conn(),
             "r1",
             "big",
+            None,
             "summarize",
             "",
             None,
@@ -5753,6 +5805,281 @@ mod tests {
             "oversized session history must be bounded in the prompt, got {zcount}"
         );
         assert!(prompts[0].contains(SESSION_HISTORY_OMISSION_MARKER));
+    }
+
+    // ---- owner-wiring (D1 #587 parity for the sessioned path) -----------------
+
+    /// A sessioned run bound to principal P persists its answer with
+    /// `owner_principal == P`: the authenticated body projection Grants the body to P
+    /// and fail-closed-denies everyone else (mismatch / anonymous). The refs-only
+    /// projection stays body-free.
+    #[test]
+    fn sessioned_finished_run_answer_releasable_only_to_bound_owner() {
+        use friday_storage::{AnswerDenyReason, RunAnswerAccess};
+        let root = TempDir::new("s5-owner");
+        let db = Db::open_hub(&temp_path("s5-owner")).unwrap();
+        agent_run::create_run(db.conn(), "r1", "what is the answer", 10).unwrap();
+        let client = CapturingAgentLlmClient::new(vec![AgentStep::Finish {
+            message: "the answer is 47".into(),
+        }]);
+        let ex = FsToolExecutor::new(&root.0);
+        let policy = RunPolicy::new(Some("alice".to_string()), Vec::<String>::new(), false);
+        let out = run_session_loop(
+            &client,
+            &ex,
+            db.conn(),
+            "r1",
+            "sess-owned",
+            None,
+            "what is the answer",
+            "",
+            None,
+            &no_approval(),
+            &policy,
+            5,
+            10,
+        )
+        .unwrap();
+        assert_eq!(out.status, LoopStatus::Finished);
+
+        // The OWNER reads the body back (Granted), with the recorded owner principal.
+        match friday_storage::get_run_answer_for_principal(db.conn(), "r1", "alice").unwrap() {
+            RunAnswerAccess::Granted(stored) => {
+                assert_eq!(stored.answer, "the answer is 47");
+                assert_eq!(stored.status, "finished");
+                assert_eq!(stored.owner_principal.as_deref(), Some("alice"));
+            }
+            other => panic!("owner must be Granted the body, got {other:?}"),
+        }
+        // A NON-owner principal is denied (body withheld).
+        assert_eq!(
+            friday_storage::get_run_answer_for_principal(db.conn(), "r1", "mallory").unwrap(),
+            RunAnswerAccess::Denied(AnswerDenyReason::PrincipalMismatch)
+        );
+        // An anonymous / public caller never reads a body.
+        for anon in ["", "public", "public:default"] {
+            assert_eq!(
+                friday_storage::get_run_answer_for_principal(db.conn(), "r1", anon).unwrap(),
+                RunAnswerAccess::Denied(AnswerDenyReason::AnonymousCaller),
+                "anonymous caller {anon:?} must be denied"
+            );
+        }
+        // The refs-only proof projection is unchanged: fingerprint, never the body.
+        let r = friday_storage::get_run_result_ref(db.conn(), "r1")
+            .unwrap()
+            .unwrap();
+        assert_eq!(r.answer_len, "the answer is 47".len() as i64);
+        assert!(friday_storage::audit::verify_audit_chain(db.conn()).is_ok());
+    }
+
+    /// A sessioned run with NO bound principal records NO owner — its persisted answer
+    /// body is unreadable by EVERYONE (fail-closed; same as an ownerless legacy row).
+    #[test]
+    fn sessioned_run_without_principal_persists_ownerless_fail_closed_result() {
+        use friday_storage::{AnswerDenyReason, RunAnswerAccess};
+        let root = TempDir::new("s5-noowner");
+        let db = Db::open_hub(&temp_path("s5-noowner")).unwrap();
+        agent_run::create_run(db.conn(), "r1", "say hi", 10).unwrap();
+        let client = CapturingAgentLlmClient::new(vec![AgentStep::Finish {
+            message: "hi".into(),
+        }]);
+        let ex = FsToolExecutor::new(&root.0);
+        let out = run_session_loop(
+            &client,
+            &ex,
+            db.conn(),
+            "r1",
+            "sess-anon",
+            None,
+            "say hi",
+            "",
+            None,
+            &no_approval(),
+            &RunPolicy::default(), // no principal bound
+            5,
+            10,
+        )
+        .unwrap();
+        assert_eq!(out.status, LoopStatus::Finished);
+        // The result IS persisted (the answer store has the row)...
+        let stored = friday_storage::get_run_result(db.conn(), "r1")
+            .unwrap()
+            .unwrap();
+        assert_eq!(stored.owner_principal, None, "no principal ⇒ no owner");
+        // ...but the body is releasable to NO ONE — not even a real principal.
+        for caller in ["alice", "mallory", ""] {
+            assert_eq!(
+                friday_storage::get_run_answer_for_principal(db.conn(), "r1", caller).unwrap(),
+                RunAnswerAccess::Denied(AnswerDenyReason::NoOwnerPrincipal),
+                "ownerless row must deny caller {caller:?}"
+            );
+        }
+    }
+
+    /// A NON-Finished sessioned outcome persists NO run_result: the Paused run's
+    /// `run_result` slot belongs to the resume completion leg (collision discipline,
+    /// mirrors `run_task`). The user turn is still recorded for the session.
+    #[test]
+    fn paused_sessioned_run_persists_no_run_result() {
+        let root = TempDir::new("s5-paused");
+        let db = Db::open_hub(&temp_path("s5-paused")).unwrap();
+        agent_run::create_run(db.conn(), "r1", "delete the old backup db", 10).unwrap();
+        let client = CapturingAgentLlmClient::new(vec![AgentStep::Tool(raw(
+            "delete_file",
+            &[("path", "backups/old.db")],
+        ))]);
+        let ex = FsToolExecutor::new(&root.0);
+        let policy = RunPolicy::new(Some("alice".to_string()), Vec::<String>::new(), false);
+        let out = run_session_loop(
+            &client,
+            &ex,
+            db.conn(),
+            "r1",
+            "sess-paused",
+            None,
+            "delete the old backup db",
+            "",
+            None,
+            &no_approval(),
+            &policy,
+            5,
+            10,
+        )
+        .unwrap();
+        assert_eq!(
+            out.status,
+            LoopStatus::Paused,
+            "mutation w/o approval pauses"
+        );
+        assert_eq!(
+            friday_storage::get_run_result(db.conn(), "r1").unwrap(),
+            None,
+            "a paused run must leave its run_result slot to the resume leg"
+        );
+        // The session still recorded the user turn (the operator asked it).
+        assert_eq!(
+            friday_storage::session_message_count(db.conn(), "sess-paused").unwrap(),
+            1
+        );
+    }
+
+    /// `session_owner: Some(..)` BINDS the session's owner axes at creation, making the
+    /// memory namespace RESOLVABLE for the Rust inline extraction — and a later
+    /// owner-less run on the same session does not clobber the bound owner.
+    #[test]
+    fn session_loop_binds_supplied_owner_and_namespace_resolves() {
+        let root = TempDir::new("s5-bind");
+        let db = Db::open_hub(&temp_path("s5-bind")).unwrap();
+        let ex = FsToolExecutor::new(&root.0);
+        let owner = friday_storage::SessionOwner {
+            account_id: Some("default".into()),
+            channel: Some("discord".into()),
+            user_id: Some("alice".into()),
+            ..Default::default()
+        };
+        agent_run::create_run(db.conn(), "r1", "remember 47", 10).unwrap();
+        let c1 = CapturingAgentLlmClient::new(vec![AgentStep::Finish {
+            message: "noted".into(),
+        }]);
+        run_session_loop(
+            &c1,
+            &ex,
+            db.conn(),
+            "r1",
+            "sess-bound",
+            Some(&owner),
+            "remember 47",
+            "",
+            None,
+            &no_approval(),
+            &RunPolicy::default(),
+            5,
+            10,
+        )
+        .unwrap();
+        // The session was created OWNED...
+        let back = friday_storage::load_session_owner(db.conn(), "sess-bound")
+            .unwrap()
+            .unwrap();
+        assert_eq!(back.user_id.as_deref(), Some("alice"));
+        // ...and its memory namespace resolves (the extraction fail-closed gate opens).
+        let ns = crate::session_namespace::resolve_session_memory_namespace(
+            back.account_id.as_deref(),
+            back.channel.as_deref(),
+            back.user_id.as_deref(),
+        )
+        .unwrap();
+        assert_eq!(ns, "tenant.default.channel.discord.user.alice.shared");
+
+        // A second, owner-less run on the SAME session keeps the bound owner (no clobber).
+        agent_run::create_run(db.conn(), "r2", "and now?", 20).unwrap();
+        let c2 = CapturingAgentLlmClient::new(vec![AgentStep::Finish {
+            message: "still noted".into(),
+        }]);
+        run_session_loop(
+            &c2,
+            &ex,
+            db.conn(),
+            "r2",
+            "sess-bound",
+            None,
+            "and now?",
+            "",
+            None,
+            &no_approval(),
+            &RunPolicy::default(),
+            5,
+            20,
+        )
+        .unwrap();
+        let back = friday_storage::load_session_owner(db.conn(), "sess-bound")
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            back.user_id.as_deref(),
+            Some("alice"),
+            "owner-less re-run must not erase the bound owner"
+        );
+    }
+
+    /// `session_owner: None` keeps the pre-wiring behavior bit-for-bit: the session
+    /// carries NULL owner axes (extraction stays fail-closed for it).
+    #[test]
+    fn session_loop_without_owner_creates_unowned_session_unchanged() {
+        let root = TempDir::new("s5-unowned");
+        let db = Db::open_hub(&temp_path("s5-unowned")).unwrap();
+        let ex = FsToolExecutor::new(&root.0);
+        agent_run::create_run(db.conn(), "r1", "hello", 10).unwrap();
+        let client = CapturingAgentLlmClient::new(vec![AgentStep::Finish {
+            message: "hi".into(),
+        }]);
+        run_session_loop(
+            &client,
+            &ex,
+            db.conn(),
+            "r1",
+            "sess-null",
+            None,
+            "hello",
+            "",
+            None,
+            &no_approval(),
+            &RunPolicy::default(),
+            5,
+            10,
+        )
+        .unwrap();
+        let back = friday_storage::load_session_owner(db.conn(), "sess-null")
+            .unwrap()
+            .unwrap();
+        assert_eq!(back, friday_storage::SessionOwner::default());
+        // The namespace stays UNRESOLVABLE — fail-closed, exactly as before this lane.
+        assert!(crate::session_namespace::resolve_session_memory_namespace(
+            back.account_id.as_deref(),
+            back.channel.as_deref(),
+            back.user_id.as_deref(),
+        )
+        .is_err());
     }
 }
 

--- a/rust-core/crates/friday-hub/src/memory_extraction.rs
+++ b/rust-core/crates/friday-hub/src/memory_extraction.rs
@@ -962,6 +962,9 @@ mod tests {
                 chat_kind: Some("dm".into()),
                 chat_id: Some("dm-user-7".into()),
                 parent_session_id: None,
+                // Structural kind: a CONVERSATION (TS `parts.kind === "conversation"`) — what
+                // gates the DM-chatId fallback (NOT inferred from the parent link).
+                session_kind: Some("conversation".into()),
             },
             1,
         )
@@ -1035,6 +1038,9 @@ mod tests {
                 chat_kind: None,
                 chat_id: None,
                 parent_session_id: Some("parent-s".into()),
+                // Structural kind: a SUBAGENT (TS `parts.kind === "subagent"`) — what gates
+                // the parent-walk (NOT inferred from the parent link's presence).
+                session_kind: Some("subagent".into()),
             },
             2,
         )
@@ -1101,6 +1107,8 @@ mod tests {
                 chat_kind: Some("group".into()),
                 chat_id: Some("group-42".into()),
                 parent_session_id: None,
+                // A CONVERSATION (group): no DM fallback (group is multi-user) — fail closed.
+                session_kind: Some("conversation".into()),
             },
             1,
         )
@@ -1123,6 +1131,8 @@ mod tests {
                 chat_kind: None,
                 chat_id: None,
                 parent_session_id: Some("ghost-parent".into()),
+                // A SUBAGENT whose parent link dangles — the walk ends fail closed.
+                session_kind: Some("subagent".into()),
             },
             1,
         )

--- a/rust-core/crates/friday-hub/src/memory_extraction.rs
+++ b/rust-core/crates/friday-hub/src/memory_extraction.rs
@@ -76,20 +76,23 @@
 //! — mirroring the TS `MEMORY_NAMESPACE_UNRESOLVABLE` throw. A session is never silently
 //! bound to a default/anonymous scope.
 //!
-//! **Deferred-parity (HONEST).** Only the DIRECT `session.userId` case is ported. The TS
-//! DM-chatId fallback and subagent parent-chain userId walk are DEFERRED — the Rust
-//! `agent_session` does not model `chatKind`/`chatId`/`parentSession` yet (see
-//! [`crate::session_namespace`]). Live sessions created via the production
-//! `run_session_loop` still call the OWNER-LESS `ensure_session`, so they carry a NULL
-//! owner and CANNOT be extracted until a follow-on wires the owner through — that wiring
-//! is out of scope for this slice (it lives in the off-limits loop entrypoint).
+//! **Effective-userId fallbacks (owner-wiring lane — now PORTED).** The TS
+//! `resolveEffectiveUserId` is fully ported in
+//! [`crate::session_namespace::resolve_effective_user_id`]: direct `user_id`, the
+//! DM-chatId fallback (`chat_kind == "dm"` conversation → `chat_id`), and the subagent
+//! parent-walk (`parent_session_id` chain → nearest ancestor userId / DM chat_id) — all
+//! DETERMINISTIC and FAIL-CLOSED when underivable (the v23 columns model the TS
+//! `chatKind`/`chatId`/`parentSessionKey` axes). `run_session_loop` can now BIND a
+//! session owner at creation (the owner-wiring lane), so loop-created sessions are
+//! extractable once their owner axes are supplied.
 //!
 //! - **Queue / auto mode still DEFERRED.** Only the inline manual path; the
 //!   queue/job-retry/auto machine is a follow-on slice.
 //!
-//! Truth label: Rust-owned INLINE extraction, slice-3 (dedup + transactional +
-//! ownership-binding). The TS extraction path STAYS LIVE (full parity — queue/auto +
-//! DM/subagent userId fallbacks — pending). PROOF-ONLY — NOT a v1 GO.
+//! Truth label: Rust-owned INLINE extraction, slice-3 + owner-wiring (dedup +
+//! transactional + ownership-binding + DM/subagent userId fallbacks). The TS extraction
+//! path STAYS LIVE (queue/auto parity pending; this flips NO TS-retirement state).
+//! PROOF-ONLY — NOT a v1 GO.
 
 use friday_core::MemoryScope;
 use friday_deepseek::{DeepSeekClient, DeepSeekError, Transport};
@@ -103,7 +106,9 @@ use serde_json::Value;
 use std::collections::HashSet;
 
 use crate::sensitive_guard::is_sensitive_learning_candidate;
-use crate::session_namespace::{resolve_session_memory_namespace, NamespaceError};
+use crate::session_namespace::{
+    resolve_effective_user_id, resolve_session_memory_namespace, NamespaceError,
+};
 
 /// The valid item kinds (ported from the TS `VALID_KINDS`).
 const VALID_KINDS: &[&str] = &["fact", "decision", "preference", "action_item"];
@@ -413,10 +418,12 @@ pub fn filter_sensitive(
 ///
 /// ## Slice-3 ownership-binding (the store SCOPE is DERIVED from the SESSION)
 /// There is NO caller-supplied principal: the store scope (`principal_id`) is DERIVED
-/// from the session's OWNER axes (`account_id`/`channel`/`user_id`, loaded via
-/// [`load_session_owner`]) through [`resolve_session_memory_namespace`] —
-/// `tenant.<account>.channel.<channel>.user.<user>.shared`. If the session has no
-/// `user_id` (the namespace is unresolvable), extraction FAILS CLOSED
+/// from the session's OWNER axes (loaded via [`load_session_owner`]) through
+/// [`resolve_effective_user_id`] (direct `user_id` → DM-chatId fallback → subagent
+/// parent-walk; the TS `resolveEffectiveUserId` port) and
+/// [`resolve_session_memory_namespace`] —
+/// `tenant.<account>.channel.<channel>.user.<user>.shared`. If NO userId is derivable
+/// (the namespace is unresolvable), extraction FAILS CLOSED
 /// ([`ExtractionError::NamespaceUnresolvable`]) BEFORE any provider call — parity with the
 /// TS `MEMORY_NAMESPACE_UNRESOLVABLE`. The derived namespace is echoed in
 /// [`ExtractionOutcome::derived_namespace`].
@@ -435,15 +442,21 @@ pub fn extract_inline<T: Transport>(
     }
 
     // Slice-3 ownership-binding: DERIVE the store scope from the SESSION (not a caller
-    // principal). Load the session's owner axes and resolve the composite namespace. A
-    // session with no `user_id` FAILS CLOSED here — BEFORE any provider call — mirroring
-    // the TS `MEMORY_NAMESPACE_UNRESOLVABLE` throw. An absent session row also has no
-    // owner, so it fails closed identically (None owner → unresolvable).
+    // principal). Load the session's owner axes, resolve the EFFECTIVE userId (direct →
+    // DM-chatId fallback → subagent parent-walk, the TS `resolveEffectiveUserId` port —
+    // deterministic, fail-closed when underivable), then resolve the composite namespace.
+    // A session with no derivable userId FAILS CLOSED here — BEFORE any provider call —
+    // mirroring the TS `MEMORY_NAMESPACE_UNRESOLVABLE` throw. An absent session row also
+    // has no owner, so it fails closed identically (None owner → unresolvable). The
+    // namespace's account/channel stay the SESSION'S OWN axes even when the userId came
+    // from a parent (faithful to the TS resolver).
     let owner = load_session_owner(db.conn(), session_id)?.unwrap_or_default();
+    let effective_user_id =
+        resolve_effective_user_id(&owner, &mut |key: &str| load_session_owner(db.conn(), key))?;
     let derived_namespace = resolve_session_memory_namespace(
         owner.account_id.as_deref(),
         owner.channel.as_deref(),
-        owner.user_id.as_deref(),
+        effective_user_id.as_deref(),
     )?;
     // The derived namespace IS the store key (the Rust recall axis is a single
     // `principal_id` string; slice-3 sets it to the composite namespace).
@@ -643,6 +656,7 @@ mod tests {
                 account_id: Some("default".into()),
                 channel: Some("discord".into()),
                 user_id: Some(user_id.into()),
+                ..Default::default()
             },
             1,
         )
@@ -834,6 +848,7 @@ mod tests {
                 account_id: Some("default".into()),
                 channel: Some("discord".into()),
                 user_id: Some("dave".into()),
+                ..Default::default()
             },
             1,
         )
@@ -882,6 +897,7 @@ mod tests {
                 account_id: Some("default".into()),
                 channel: Some("discord".into()),
                 user_id: None,
+                ..Default::default()
             },
             1,
         )
@@ -926,6 +942,224 @@ mod tests {
         assert_eq!(db.count("memory_item").unwrap(), 0);
         // ...and the message is NOT consumed (it stays pending for a retry once owned).
         assert_eq!(status_of(&db, "s1:m0"), "pending");
+    }
+
+    // --- owner-wiring (DM-chatId + subagent parent-walk userId fallbacks) ----
+
+    #[test]
+    fn dm_session_without_user_id_derives_namespace_from_chat_id() {
+        // DM fallback e2e: a `chat_kind == "dm"` conversation with NO user_id stores its
+        // candidates under the chat-id-derived namespace (TS: parts.chatId), end-to-end
+        // through the real extraction path.
+        let mut db = friday_storage::Db::open_hub(&tmp("dm-fallback")).unwrap();
+        ensure_session_with_owner(
+            db.conn(),
+            "dm-s",
+            &SessionOwner {
+                account_id: Some("default".into()),
+                channel: Some("telegram".into()),
+                user_id: None,
+                chat_kind: Some("dm".into()),
+                chat_id: Some("dm-user-7".into()),
+                parent_session_id: None,
+            },
+            1,
+        )
+        .unwrap();
+        let m0 = append_session_message(
+            db.conn(),
+            "dm-s",
+            &SessionMessage::new("user", "Call my project Codename Falcon.", None),
+            10,
+        )
+        .unwrap();
+        let content = json!({
+            "items": [{
+                "kind": "preference",
+                "content": "User's project codename is Falcon.",
+                "sourceMessageIds": [m0]
+            }]
+        })
+        .to_string();
+        let c = client(content);
+        let out = extract_inline(
+            &mut db,
+            "dm-s",
+            &c,
+            DEFAULT_MAX_ITEMS,
+            "dm-s:ex:100",
+            "led-dm",
+            100,
+        )
+        .unwrap();
+        assert_eq!(out.candidates_created, 1);
+        // The namespace user segment is the DM chat id — on the session's OWN channel.
+        let ns = crate::session_namespace::resolve_session_memory_namespace(
+            Some("default"),
+            Some("telegram"),
+            Some("dm-user-7"),
+        )
+        .unwrap();
+        assert_eq!(out.derived_namespace, ns);
+        let pending = pending_review(db.conn()).unwrap();
+        assert_eq!(pending[0].principal_id.as_deref(), Some(ns.as_str()));
+    }
+
+    #[test]
+    fn subagent_session_derives_user_from_parent_walk() {
+        // Subagent fallback e2e: a child session with NO user_id walks `parent_session_id`
+        // to the parent's user — and the namespace keeps the CHILD's own account/channel
+        // (only the userId comes from the parent, faithful to the TS resolver).
+        let mut db = friday_storage::Db::open_hub(&tmp("subagent-fallback")).unwrap();
+        // The parent session (a normal owned conversation).
+        ensure_session_with_owner(
+            db.conn(),
+            "parent-s",
+            &SessionOwner {
+                account_id: Some("default".into()),
+                channel: Some("discord".into()),
+                user_id: Some("alice".into()),
+                ..Default::default()
+            },
+            1,
+        )
+        .unwrap();
+        // The subagent child: no user_id, linked to the parent.
+        ensure_session_with_owner(
+            db.conn(),
+            "child-s",
+            &SessionOwner {
+                account_id: Some("default".into()),
+                channel: Some("discord".into()),
+                user_id: None,
+                chat_kind: None,
+                chat_id: None,
+                parent_session_id: Some("parent-s".into()),
+            },
+            2,
+        )
+        .unwrap();
+        let m0 = append_session_message(
+            db.conn(),
+            "child-s",
+            &SessionMessage::new("user", "Budget for the falcon task is 500.", None),
+            10,
+        )
+        .unwrap();
+        let content = json!({
+            "items": [{
+                "kind": "fact",
+                "content": "The falcon task budget is 500.",
+                "sourceMessageIds": [m0]
+            }]
+        })
+        .to_string();
+        let c = client(content);
+        let out = extract_inline(
+            &mut db,
+            "child-s",
+            &c,
+            DEFAULT_MAX_ITEMS,
+            "child-s:ex:100",
+            "led-sub",
+            100,
+        )
+        .unwrap();
+        assert_eq!(out.candidates_created, 1);
+        // Parent-derived user, CHILD's account/channel ("default"/"discord" here).
+        assert_eq!(out.derived_namespace, ns_for("alice"));
+        let pending = pending_review(db.conn()).unwrap();
+        assert_eq!(
+            pending[0].principal_id.as_deref(),
+            Some(ns_for("alice").as_str())
+        );
+    }
+
+    #[test]
+    fn underivable_fallbacks_fail_closed_before_any_provider_call() {
+        // The fallbacks NEVER guess: a group chat (chat_id present but kind != dm) and a
+        // dangling subagent parent both fail closed BEFORE the provider is contacted.
+        struct PanicTransport;
+        impl Transport for PanicTransport {
+            fn get_json(&self, _u: &str, _b: &str) -> Result<Value, DeepSeekError> {
+                panic!("underivable namespace must fail closed before discover");
+            }
+            fn post_json(&self, _u: &str, _b: &str, _body: &Value) -> Result<Value, DeepSeekError> {
+                panic!("underivable namespace must fail closed before provider call");
+            }
+        }
+
+        let mut db = friday_storage::Db::open_hub(&tmp("underivable")).unwrap();
+        // (a) A GROUP chat: multi-user — attributing it to the chat id would merge users.
+        ensure_session_with_owner(
+            db.conn(),
+            "group-s",
+            &SessionOwner {
+                account_id: Some("default".into()),
+                channel: Some("telegram".into()),
+                user_id: None,
+                chat_kind: Some("group".into()),
+                chat_id: Some("group-42".into()),
+                parent_session_id: None,
+            },
+            1,
+        )
+        .unwrap();
+        append_session_message(
+            db.conn(),
+            "group-s",
+            &SessionMessage::new("user", "remember 47", None),
+            10,
+        )
+        .unwrap();
+        // (b) A subagent whose parent link DANGLES (no such session row).
+        ensure_session_with_owner(
+            db.conn(),
+            "orphan-s",
+            &SessionOwner {
+                account_id: Some("default".into()),
+                channel: Some("discord".into()),
+                user_id: None,
+                chat_kind: None,
+                chat_id: None,
+                parent_session_id: Some("ghost-parent".into()),
+            },
+            1,
+        )
+        .unwrap();
+        append_session_message(
+            db.conn(),
+            "orphan-s",
+            &SessionMessage::new("user", "remember 48", None),
+            10,
+        )
+        .unwrap();
+
+        for sid in ["group-s", "orphan-s"] {
+            let c = DeepSeekClient::with_transport(PanicTransport, "test-key-not-real".into());
+            let err = extract_inline(
+                &mut db,
+                sid,
+                &c,
+                DEFAULT_MAX_ITEMS,
+                &format!("{sid}:ex:100"),
+                &format!("led-{sid}"),
+                100,
+            )
+            .unwrap_err();
+            assert!(
+                matches!(
+                    err,
+                    ExtractionError::NamespaceUnresolvable(NamespaceError::UnresolvableNoUserId)
+                ),
+                "{sid}: underivable fallback must fail closed, got {err:?}"
+            );
+        }
+        // No provider call, no ledger row, no candidate — and messages stay pending.
+        assert_eq!(db.count("token_ledger").unwrap(), 0);
+        assert_eq!(db.count("memory_item").unwrap(), 0);
+        assert_eq!(status_of(&db, "group-s:m0"), "pending");
+        assert_eq!(status_of(&db, "orphan-s:m0"), "pending");
     }
 
     /// Read one message's `memory_extract_status` (test-only helper for the slice-2

--- a/rust-core/crates/friday-hub/src/resume.rs
+++ b/rust-core/crates/friday-hub/src/resume.rs
@@ -192,10 +192,13 @@ pub fn resume_with_approval(
             persist_run_result(
                 conn,
                 &run_id,
-                &RunResult::new(
-                    "mutation_completed",
-                    &receipt.summary,
-                    Some(receipt_id.clone()),
+                &with_owner(
+                    RunResult::new(
+                        "mutation_completed",
+                        &receipt.summary,
+                        Some(receipt_id.clone()),
+                    ),
+                    pending.principal_id.as_deref(),
                 ),
                 now_ms,
             )?;
@@ -217,7 +220,10 @@ pub fn resume_with_approval(
             persist_run_result(
                 conn,
                 &run_id,
-                &RunResult::new("mutation_exec_failed", &err_text, Some(receipt_id.clone())),
+                &with_owner(
+                    RunResult::new("mutation_exec_failed", &err_text, Some(receipt_id.clone())),
+                    pending.principal_id.as_deref(),
+                ),
                 now_ms,
             )?;
             Ok(ResumeOutcome {
@@ -230,6 +236,29 @@ pub fn resume_with_approval(
                 audit_ref: Some(receipt_id),
             })
         }
+    }
+}
+
+/// Record the run's BOUND OWNER principal on the resume-completion `RunResult`, mirroring
+/// the Finished-leg owner-wiring in [`crate::run_session_loop`] (lib.rs) and
+/// [`crate::HubRuntime::run_task`] (runtime.rs, #587).
+///
+/// The Paused→resume completion leg is the ONLY writer of a paused run's `run_result`
+/// slot (the loop deliberately defers it). Recording the run's principal (reconstructed
+/// at the resume entry as `pending.principal_id`) is what lets
+/// [`friday_storage::get_run_answer_for_principal`] release the resumed mutation's body to
+/// the LEGITIMATE owner — without it the result is OWNERLESS and the authenticated body
+/// projection Denies EVERYONE (over-deny: even the owner cannot read their own approved
+/// mutation's result). FAIL-CLOSED unchanged: a run with NO bound principal records NO
+/// owner ⇒ the body stays unreadable to everyone (correct — no widening). The coarse
+/// `result_status` / audit `audit_ref` / refs-only projections are unaffected (this only
+/// sets the `owner_principal` axis used by the authenticated body read).
+fn with_owner(result: RunResult, principal_id: Option<&str>) -> RunResult {
+    match principal_id {
+        Some(p) if !p.is_empty() => result.with_owner_principal(p),
+        // No bound principal (or an empty one) ⇒ leave the result OWNERLESS (fail-closed:
+        // unreadable to everyone), never substitute a default/anonymous owner.
+        _ => result,
     }
 }
 

--- a/rust-core/crates/friday-hub/src/session_namespace.rs
+++ b/rust-core/crates/friday-hub/src/session_namespace.rs
@@ -29,20 +29,35 @@
 //! `user_id` (or an empty one) CANNOT produce a namespace, so its extraction FAILS CLOSED
 //! — it is never silently bound to a default/anonymous scope.
 //!
-//! ## Deferred-parity gaps (HONEST — documented, not implemented this slice)
-//! The TS `resolveEffectiveUserId` resolves the userId in THREE ways:
-//!   1. `session.userId` directly — **ported here**.
-//!   2. (DM conversation) fall back to the `chatId` when `chatKind == "dm"` — **DEFERRED**.
-//!   3. (subagent) walk the parent-session chain to find a userId — **DEFERRED**.
-//! The Rust `agent_session` does not yet model `chatKind` / `chatId` / `parentSession`, so
-//! cases (2) and (3) are not representable here. Until a follow-on slice adds those axes, a
-//! session whose userId would ONLY have been resolvable via the DM-chatId fallback or the
-//! subagent parent-walk will FAIL CLOSED here rather than resolve — which is the
-//! conservative direction (no wrong-scope binding), but is a real parity gap vs the TS.
+//! ## Effective-userId fallbacks (owner-wiring lane — now PORTED)
+//! The TS `resolveEffectiveUserId` resolves the userId in THREE ways, all now ported:
+//!   1. `session.userId` directly — slice-3.
+//!   2. (DM conversation) fall back to the `chatId` when `chatKind == "dm"` —
+//!      [`resolve_effective_user_id`]. The Rust `agent_session` now models `chat_kind` /
+//!      `chat_id` (v23 additive columns); a NON-subagent session with `chat_kind == "dm"`
+//!      and a non-empty `chat_id` resolves to that `chat_id`.
+//!   3. (subagent) walk the parent-session chain (`parent_session_id`, v23) to the nearest
+//!      ancestor with a userId (or a DM-conversation ancestor's `chat_id`) —
+//!      [`resolve_effective_user_id`], cycle-safe via a visited set like the TS.
+//! Both fallbacks are DETERMINISTIC and FAIL CLOSED when underivable (missing chat_id,
+//! unknown/other chat_kind, dangling parent link, exhausted/cyclic chain → no namespace,
+//! never a guessed/default scope).
 //!
-//! Truth label: byte-identical namespace + normalization port for the DIRECT-userId case;
-//! DM-chatId + subagent parent-walk userId fallbacks are DEFERRED-PARITY. PROOF-ONLY —
-//! NOT a v1 GO; the TS extraction path stays LIVE pending full parity.
+//! HONEST mapping note (Rust vs TS representation, not a semantic change): TS derives the
+//! conversation/subagent KIND and the parent link from the structured session KEY
+//! (`parseFridaySessionKey`); the Rust `agent_session_id` is opaque, so the Rust port
+//! carries those axes as explicit columns — `parent_session_id IS NOT NULL` ⇔ the TS
+//! `kind == "subagent"`, and the parent link is the TS `session.parentSessionKey` leg of
+//! its `parentSessionKey ?? parts.parentKey` (there is no key-embedded parent to fall back
+//! to, so a missing link ends the walk fail-closed).
+//!
+//! Truth label: byte-identical namespace + normalization port; DM-chatId + subagent
+//! parent-walk userId fallbacks ported (column-modeled). This improves PARITY only — it
+//! does NOT flip any TS-retirement state; the TS extraction path stays LIVE. PROOF-ONLY —
+//! NOT a v1 GO.
+
+use friday_storage::agent_session::SessionOwner;
+use friday_storage::StorageError;
 
 /// Namespace segment constants — ported from `src/sessions/friday-session.constants.ts`
 /// (`FRIDAY_SESSION_MEMORY_NAMESPACE_*_SEGMENT`).
@@ -124,6 +139,100 @@ pub fn resolve_session_memory_namespace(
         SHARED_SEGMENT,
     ]
     .join("."))
+}
+
+/// Resolve the EFFECTIVE userId for a session — the faithful port of the TS
+/// `resolveEffectiveUserId` (owner-wiring lane; closes the slice-3 deferred-parity gap):
+///
+/// 1. **Direct**: `owner.user_id` (JS-falsy: an empty string counts as absent).
+/// 2. **DM-chatId fallback**: a NON-subagent (conversation-analog: `parent_session_id`
+///    is `None`) session with `chat_kind == "dm"` resolves to its `chat_id`. The TS
+///    condition is `parts.kind === "conversation" && session.chatKind === "dm"` →
+///    `parts.chatId`; the Rust port keys on the explicit v23 columns. A DM with no
+///    stored `chat_id` is UNDERIVABLE → `None` (fail-closed, no guessing).
+/// 3. **Subagent parent-walk**: a subagent (`parent_session_id` is `Some`) walks its
+///    parent chain via `lookup`, returning the FIRST ancestor `user_id` — or, for a
+///    conversation-analog DM ancestor, its `chat_id` — exactly like the TS walk.
+///    Cycle-safe via a visited set (TS `visited`); a dangling link (`lookup` → `None`)
+///    ends the walk (TS `if (!parentSession) break`). Exhausted chain → `None`.
+///
+/// DETERMINISTIC: the result depends only on the stored owner rows reachable through
+/// `lookup`. FAIL-CLOSED: every underivable shape returns `Ok(None)` (the caller's
+/// namespace resolution then fails closed); a `lookup` STORAGE error PROPAGATES (it is
+/// never swallowed as "no parent", which could silently widen to fail-open elsewhere).
+pub fn resolve_effective_user_id<F>(
+    owner: &SessionOwner,
+    lookup: &mut F,
+) -> Result<Option<String>, StorageError>
+where
+    F: FnMut(&str) -> Result<Option<SessionOwner>, StorageError>,
+{
+    // 1. Direct userId (TS `if (session.userId) return session.userId`).
+    if let Some(u) = non_empty(owner.user_id.as_deref()) {
+        return Ok(Some(u.to_string()));
+    }
+
+    // The Rust kind mapping: `parent_session_id IS NOT NULL` ⇔ TS `parts.kind ==
+    // "subagent"`; otherwise the session is the conversation analog.
+    let is_subagent = non_empty(owner.parent_session_id.as_deref()).is_some();
+
+    // 2. DM-chatId fallback (TS `parts.kind === "conversation" && chatKind === "dm"`).
+    //    EXACT `"dm"` match only — any other / unknown kind gets no fallback. A subagent
+    //    session NEVER uses its own chat axes here (TS: its parts.kind is "subagent").
+    if !is_subagent && is_dm(owner) {
+        if let Some(c) = non_empty(owner.chat_id.as_deref()) {
+            return Ok(Some(c.to_string()));
+        }
+        // DM with no stored chat_id: underivable → fail closed (the TS key always carries
+        // a chatId segment; the Rust column may be NULL — we never substitute a default).
+        return Ok(None);
+    }
+
+    // 3. Subagent parent-walk (TS `parts.kind === "subagent" && sessionLookup`).
+    if is_subagent {
+        let mut visited: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut current = owner.parent_session_id.clone();
+        while let Some(key) = current {
+            // Cycle guard (TS `visited`): a revisited key ends the walk fail-closed.
+            if !visited.insert(key.clone()) {
+                break;
+            }
+            // Dangling soft link: no such session → walk ends (TS `if (!parent) break`).
+            let parent = match lookup(&key)? {
+                Some(p) => p,
+                None => break,
+            };
+            if let Some(u) = non_empty(parent.user_id.as_deref()) {
+                return Ok(Some(u.to_string()));
+            }
+            // A conversation-analog DM ancestor resolves to its chat_id (TS
+            // `parentParts.kind === "conversation" && parent.chatKind === "dm"`).
+            let parent_is_subagent = non_empty(parent.parent_session_id.as_deref()).is_some();
+            if !parent_is_subagent && is_dm(&parent) {
+                if let Some(c) = non_empty(parent.chat_id.as_deref()) {
+                    return Ok(Some(c.to_string()));
+                }
+            }
+            // Move up (TS `currentKey = parent.parentSessionKey ?? parentParts.parentKey`;
+            // the Rust column is the only modeled link — None ends the walk fail-closed).
+            current = parent.parent_session_id;
+        }
+    }
+
+    Ok(None)
+}
+
+/// Exact-match TS `chatKind === "dm"` (case-sensitive; the TS type is a literal union).
+fn is_dm(owner: &SessionOwner) -> bool {
+    owner.chat_kind.as_deref() == Some("dm")
+}
+
+/// `Some` only for a present, non-empty value (JS-falsy parity for `""`).
+fn non_empty(v: Option<&str>) -> Option<&str> {
+    match v {
+        Some(s) if !s.is_empty() => Some(s),
+        _ => None,
+    }
 }
 
 /// The JS `value || fallback` semantics: a `None` or empty-string value takes the
@@ -269,8 +378,9 @@ mod tests {
     #[test]
     fn fails_closed_when_no_user_id() {
         // TS throws MEMORY_NAMESPACE_UNRESOLVABLE; we return the typed error. This is the
-        // parity for the "no userId, not DM" case (and — since DM/subagent fallbacks are
-        // DEFERRED here — also covers what TS would have resolved via those paths).
+        // parity for the "no userId available" case (the DM/subagent fallbacks — now
+        // ported in `resolve_effective_user_id` — run BEFORE this resolver; when they
+        // also derive nothing, this is the fail-closed end state).
         assert_eq!(
             resolve_session_memory_namespace(Some("default"), Some("discord"), None),
             Err(NamespaceError::UnresolvableNoUserId)
@@ -394,5 +504,162 @@ mod tests {
         let msg = NamespaceError::UnresolvableNoUserId.to_string();
         assert!(msg.contains("unresolvable"));
         assert!(!msg.contains("Bearer"));
+    }
+
+    // ─── resolve_effective_user_id (the TS resolveEffectiveUserId port) ───
+
+    fn owner(
+        user_id: Option<&str>,
+        chat_kind: Option<&str>,
+        chat_id: Option<&str>,
+        parent: Option<&str>,
+    ) -> SessionOwner {
+        SessionOwner {
+            account_id: Some("default".into()),
+            channel: Some("telegram".into()),
+            user_id: user_id.map(str::to_string),
+            chat_kind: chat_kind.map(str::to_string),
+            chat_id: chat_id.map(str::to_string),
+            parent_session_id: parent.map(str::to_string),
+        }
+    }
+
+    /// A lookup over a fixed in-memory map (the TS `sessionLookup` analog).
+    fn map_lookup<'a>(
+        entries: &'a [(&'a str, SessionOwner)],
+    ) -> impl FnMut(&str) -> Result<Option<SessionOwner>, StorageError> + 'a {
+        move |key: &str| {
+            Ok(entries
+                .iter()
+                .find(|(k, _)| *k == key)
+                .map(|(_, v)| v.clone()))
+        }
+    }
+
+    /// A lookup that PANICS if called — proves the direct/DM paths never walk.
+    fn no_lookup(key: &str) -> Result<Option<SessionOwner>, StorageError> {
+        panic!("lookup must not be called, got key {key}");
+    }
+
+    #[test]
+    fn effective_user_direct_user_id_wins_without_lookup() {
+        // TS case 1: session.userId returns immediately (no key parse, no walk).
+        let o = owner(Some("alice"), Some("dm"), Some("chat-1"), None);
+        let got = resolve_effective_user_id(&o, &mut no_lookup).unwrap();
+        assert_eq!(got.as_deref(), Some("alice"));
+        // JS-falsy parity: an EMPTY user_id is absent, so the DM fallback applies instead.
+        let o = owner(Some(""), Some("dm"), Some("chat-1"), None);
+        let got = resolve_effective_user_id(&o, &mut no_lookup).unwrap();
+        assert_eq!(got.as_deref(), Some("chat-1"));
+    }
+
+    #[test]
+    fn effective_user_dm_falls_back_to_chat_id_only_for_exact_dm_kind() {
+        // TS case 2: conversation + chatKind === "dm" → chatId.
+        let dm = owner(None, Some("dm"), Some("chat-77"), None);
+        assert_eq!(
+            resolve_effective_user_id(&dm, &mut no_lookup)
+                .unwrap()
+                .as_deref(),
+            Some("chat-77")
+        );
+        // A NON-dm kind gets NO fallback (group/channel/thread chats are multi-user —
+        // attributing them to the chat id would merge users into one scope).
+        for kind in ["group", "channel", "thread"] {
+            let o = owner(None, Some(kind), Some("chat-77"), None);
+            assert_eq!(resolve_effective_user_id(&o, &mut no_lookup).unwrap(), None);
+        }
+        // Unknown/absent kind: fail closed too.
+        let o = owner(None, None, Some("chat-77"), None);
+        assert_eq!(resolve_effective_user_id(&o, &mut no_lookup).unwrap(), None);
+        // DM with NO stored chat_id is UNDERIVABLE → fail closed (no guessing).
+        let o = owner(None, Some("dm"), None, None);
+        assert_eq!(resolve_effective_user_id(&o, &mut no_lookup).unwrap(), None);
+    }
+
+    #[test]
+    fn effective_user_subagent_walks_to_parent_user_id() {
+        // TS case 3: subagent → nearest ancestor userId. One hop...
+        let entries = [("p1", owner(Some("alice"), None, None, None))];
+        let child = owner(None, None, None, Some("p1"));
+        let got = resolve_effective_user_id(&child, &mut map_lookup(&entries)).unwrap();
+        assert_eq!(got.as_deref(), Some("alice"));
+
+        // ...and multi-hop through a userId-less intermediate subagent.
+        let entries = [
+            ("mid", owner(None, None, None, Some("root"))),
+            ("root", owner(Some("bob"), None, None, None)),
+        ];
+        let child = owner(None, None, None, Some("mid"));
+        let got = resolve_effective_user_id(&child, &mut map_lookup(&entries)).unwrap();
+        assert_eq!(got.as_deref(), Some("bob"));
+    }
+
+    #[test]
+    fn effective_user_subagent_resolves_via_dm_conversation_ancestor() {
+        // TS: a conversation-DM PARENT without a userId resolves to ITS chatId.
+        let entries = [("p1", owner(None, Some("dm"), Some("chat-9"), None))];
+        let child = owner(None, None, None, Some("p1"));
+        let got = resolve_effective_user_id(&child, &mut map_lookup(&entries)).unwrap();
+        assert_eq!(got.as_deref(), Some("chat-9"));
+    }
+
+    #[test]
+    fn effective_user_subagent_own_dm_axes_are_not_used() {
+        // A SUBAGENT session never uses its own chat axes (TS: its parts.kind is
+        // "subagent", not "conversation") — the walk decides, and here it finds nothing.
+        let entries = [("p1", owner(None, None, None, None))];
+        let child = owner(None, Some("dm"), Some("chat-self"), Some("p1"));
+        let got = resolve_effective_user_id(&child, &mut map_lookup(&entries)).unwrap();
+        assert_eq!(got, None, "subagent must not DM-resolve from its own axes");
+    }
+
+    #[test]
+    fn effective_user_walk_fails_closed_on_dangling_missing_or_cyclic_chain() {
+        // Dangling parent link (no such session): fail closed.
+        let child = owner(None, None, None, Some("ghost"));
+        assert_eq!(
+            resolve_effective_user_id(&child, &mut map_lookup(&[])).unwrap(),
+            None
+        );
+        // Exhausted chain (ancestors exist but none derivable): fail closed.
+        let entries = [
+            ("p1", owner(None, Some("group"), Some("g-1"), Some("p2"))),
+            ("p2", owner(None, None, None, None)),
+        ];
+        let child = owner(None, None, None, Some("p1"));
+        assert_eq!(
+            resolve_effective_user_id(&child, &mut map_lookup(&entries)).unwrap(),
+            None
+        );
+        // CYCLE (p1 -> p2 -> p1): the visited set terminates the walk, fail closed.
+        let entries = [
+            ("p1", owner(None, None, None, Some("p2"))),
+            ("p2", owner(None, None, None, Some("p1"))),
+        ];
+        let child = owner(None, None, None, Some("p1"));
+        assert_eq!(
+            resolve_effective_user_id(&child, &mut map_lookup(&entries)).unwrap(),
+            None
+        );
+        // SELF-cycle (a session whose parent is itself — pathological but storable).
+        let entries = [("s", owner(None, None, None, Some("s")))];
+        let child = owner(None, None, None, Some("s"));
+        assert_eq!(
+            resolve_effective_user_id(&child, &mut map_lookup(&entries)).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn effective_user_lookup_error_propagates_not_swallowed() {
+        // A STORAGE error during the walk must propagate (never be treated as "no
+        // parent" — that would mis-report a locked/corrupt DB as an unresolvable
+        // namespace downstream, the same discipline as load_session_owner's .optional()).
+        let child = owner(None, None, None, Some("p1"));
+        let mut failing = |_key: &str| -> Result<Option<SessionOwner>, StorageError> {
+            Err(StorageError::Unsupported("disk on fire".into()))
+        };
+        assert!(resolve_effective_user_id(&child, &mut failing).is_err());
     }
 }

--- a/rust-core/crates/friday-hub/src/session_namespace.rs
+++ b/rust-core/crates/friday-hub/src/session_namespace.rs
@@ -46,10 +46,21 @@
 //! HONEST mapping note (Rust vs TS representation, not a semantic change): TS derives the
 //! conversation/subagent KIND and the parent link from the structured session KEY
 //! (`parseFridaySessionKey`); the Rust `agent_session_id` is opaque, so the Rust port
-//! carries those axes as explicit columns — `parent_session_id IS NOT NULL` ⇔ the TS
-//! `kind == "subagent"`, and the parent link is the TS `session.parentSessionKey` leg of
-//! its `parentSessionKey ?? parts.parentKey` (there is no key-embedded parent to fall back
-//! to, so a missing link ends the walk fail-closed).
+//! carries those axes as explicit columns. The KIND is carried by the explicit
+//! `session_kind` column (the faithful carrier of the TS `parts.kind`): `session_kind ==
+//! "subagent"` ⇔ the TS `kind == "subagent"`, `session_kind == "conversation"` ⇔ the TS
+//! `kind == "conversation"`; the parent link (`parent_session_id`) is the TS
+//! `session.parentSessionKey` leg of its `parentSessionKey ?? parts.parentKey` — a CHAIN
+//! POINTER, NOT the discriminant (there is no key-embedded parent to fall back to, so a
+//! missing link ends the walk fail-closed). KIND is INTENTIONALLY decoupled from the chain
+//! pointer: the prior port inferred subagent-ness from `parent_session_id IS NOT NULL`,
+//! which DIVERGED from TS (a subagent's parent can live in its key, so its
+//! `parentSessionKey` column may be NULL while its kind is still "subagent") — that
+//! divergence opened a cross-user mis-attribution window for a subagent-kind row with a
+//! null parent + `chat_kind == "dm"` (it took the DM-chatId leg instead of the walk). With
+//! the explicit `session_kind` the DM-chatId fallback is gated on `kind == "conversation"`
+//! and the parent-walk on `kind == "subagent"` — faithful to the TS; `None`/unknown kind
+//! (legacy/unset) enables NEITHER fallback (fail-closed by construction).
 //!
 //! Truth label: byte-identical namespace + normalization port; DM-chatId + subagent
 //! parent-walk userId fallbacks ported (column-modeled). This improves PARITY only — it
@@ -145,16 +156,24 @@ pub fn resolve_session_memory_namespace(
 /// `resolveEffectiveUserId` (owner-wiring lane; closes the slice-3 deferred-parity gap):
 ///
 /// 1. **Direct**: `owner.user_id` (JS-falsy: an empty string counts as absent).
-/// 2. **DM-chatId fallback**: a NON-subagent (conversation-analog: `parent_session_id`
-///    is `None`) session with `chat_kind == "dm"` resolves to its `chat_id`. The TS
-///    condition is `parts.kind === "conversation" && session.chatKind === "dm"` →
-///    `parts.chatId`; the Rust port keys on the explicit v23 columns. A DM with no
-///    stored `chat_id` is UNDERIVABLE → `None` (fail-closed, no guessing).
-/// 3. **Subagent parent-walk**: a subagent (`parent_session_id` is `Some`) walks its
-///    parent chain via `lookup`, returning the FIRST ancestor `user_id` — or, for a
-///    conversation-analog DM ancestor, its `chat_id` — exactly like the TS walk.
-///    Cycle-safe via a visited set (TS `visited`); a dangling link (`lookup` → `None`)
-///    ends the walk (TS `if (!parentSession) break`). Exhausted chain → `None`.
+/// 2. **DM-chatId fallback**: a CONVERSATION (`session_kind == "conversation"`) session
+///    with `chat_kind == "dm"` resolves to its `chat_id`. The TS condition is
+///    `parts.kind === "conversation" && session.chatKind === "dm"` → `parts.chatId`; the
+///    Rust port keys on the explicit `session_kind` discriminant (NOT on
+///    `parent_session_id` presence). A DM with no stored `chat_id` is UNDERIVABLE → `None`
+///    (fail-closed, no guessing).
+/// 3. **Subagent parent-walk**: a subagent (`session_kind == "subagent"`) walks its
+///    parent chain via `lookup` (following the `parent_session_id` pointer), returning the
+///    FIRST ancestor `user_id` — or, for a conversation DM ancestor, its `chat_id` —
+///    exactly like the TS walk. Cycle-safe via a visited set (TS `visited`); a dangling
+///    link (`lookup` → `None`) ends the walk (TS `if (!parentSession) break`). Exhausted
+///    chain → `None`. A subagent with a NULL `parent_session_id` simply has no chain to
+///    walk ⇒ `None` (fail-closed) — it NEVER falls through to the DM-chatId leg.
+/// 4. **Neither (fail-closed by construction)**: any other `session_kind` — `None`
+///    (legacy/unset), an empty string, or any unknown value — enables NO fallback; only a
+///    direct `user_id` could have resolved (step 1), else `None`. This is the structural
+///    property that makes the contradictory shape (a subagent-kind row with a null parent
+///    + `chat_kind == "dm"`) and any un-kinded row fail closed rather than DM-attribute.
 ///
 /// DETERMINISTIC: the result depends only on the stored owner rows reachable through
 /// `lookup`. FAIL-CLOSED: every underivable shape returns `Ok(None)` (the caller's
@@ -172,14 +191,12 @@ where
         return Ok(Some(u.to_string()));
     }
 
-    // The Rust kind mapping: `parent_session_id IS NOT NULL` ⇔ TS `parts.kind ==
-    // "subagent"`; otherwise the session is the conversation analog.
-    let is_subagent = non_empty(owner.parent_session_id.as_deref()).is_some();
-
     // 2. DM-chatId fallback (TS `parts.kind === "conversation" && chatKind === "dm"`).
-    //    EXACT `"dm"` match only — any other / unknown kind gets no fallback. A subagent
-    //    session NEVER uses its own chat axes here (TS: its parts.kind is "subagent").
-    if !is_subagent && is_dm(owner) {
+    //    Gated on the EXPLICIT `session_kind == "conversation"` discriminant (faithful to
+    //    the TS `parts.kind`), NOT on `parent_session_id` presence — a subagent-kind row
+    //    NEVER reaches this leg even if its own `chat_kind == "dm"`. EXACT `"dm"` match
+    //    only; any other / unknown chat_kind gets no fallback.
+    if is_conversation(owner) && is_dm(owner) {
         if let Some(c) = non_empty(owner.chat_id.as_deref()) {
             return Ok(Some(c.to_string()));
         }
@@ -188,8 +205,12 @@ where
         return Ok(None);
     }
 
-    // 3. Subagent parent-walk (TS `parts.kind === "subagent" && sessionLookup`).
-    if is_subagent {
+    // 3. Subagent parent-walk (TS `parts.kind === "subagent" && sessionLookup`). Gated on
+    //    the EXPLICIT `session_kind == "subagent"` discriminant; the walk FOLLOWS the
+    //    `parent_session_id` chain pointer (TS `parentSessionKey ?? parts.parentKey` — the
+    //    Rust column is the only modeled link, so a NULL pointer simply has no chain to walk
+    //    and falls through to the fail-closed end state, NEVER to the DM-chatId leg above).
+    if is_subagent(owner) {
         let mut visited: std::collections::HashSet<String> = std::collections::HashSet::new();
         let mut current = owner.parent_session_id.clone();
         while let Some(key) = current {
@@ -205,10 +226,10 @@ where
             if let Some(u) = non_empty(parent.user_id.as_deref()) {
                 return Ok(Some(u.to_string()));
             }
-            // A conversation-analog DM ancestor resolves to its chat_id (TS
-            // `parentParts.kind === "conversation" && parent.chatKind === "dm"`).
-            let parent_is_subagent = non_empty(parent.parent_session_id.as_deref()).is_some();
-            if !parent_is_subagent && is_dm(&parent) {
+            // A conversation DM ancestor resolves to its chat_id (TS
+            // `parentParts.kind === "conversation" && parent.chatKind === "dm"`) — gated on
+            // the parent's OWN explicit kind, not on its parent-link presence.
+            if is_conversation(&parent) && is_dm(&parent) {
                 if let Some(c) = non_empty(parent.chat_id.as_deref()) {
                     return Ok(Some(c.to_string()));
                 }
@@ -219,12 +240,28 @@ where
         }
     }
 
+    // 4. Neither conversation-DM nor subagent (incl. `session_kind` None/unknown): no
+    //    fallback derivable → fail closed (TS falls through to `return undefined`).
     Ok(None)
 }
 
 /// Exact-match TS `chatKind === "dm"` (case-sensitive; the TS type is a literal union).
 fn is_dm(owner: &SessionOwner) -> bool {
     owner.chat_kind.as_deref() == Some("dm")
+}
+
+/// Exact-match TS `parts.kind === "conversation"` — the structural discriminant carried by
+/// the explicit `session_kind` column (case-sensitive). `None`/empty/unknown is NOT a
+/// conversation (no DM-chatId fallback — fail-closed).
+fn is_conversation(owner: &SessionOwner) -> bool {
+    owner.session_kind.as_deref() == Some("conversation")
+}
+
+/// Exact-match TS `parts.kind === "subagent"` — the structural discriminant carried by the
+/// explicit `session_kind` column (case-sensitive), DECOUPLED from `parent_session_id`
+/// presence. `None`/empty/unknown is NOT a subagent (no parent-walk — fail-closed).
+fn is_subagent(owner: &SessionOwner) -> bool {
+    owner.session_kind.as_deref() == Some("subagent")
 }
 
 /// `Some` only for a present, non-empty value (JS-falsy parity for `""`).
@@ -508,11 +545,15 @@ mod tests {
 
     // ─── resolve_effective_user_id (the TS resolveEffectiveUserId port) ───
 
+    /// Build a `SessionOwner` with an EXPLICIT `session_kind` (the structural discriminant),
+    /// NEVER derived from `parent` — re-deriving kind from the parent link would re-import
+    /// the exact bug this fix closes into the tests.
     fn owner(
         user_id: Option<&str>,
         chat_kind: Option<&str>,
         chat_id: Option<&str>,
         parent: Option<&str>,
+        kind: Option<&str>,
     ) -> SessionOwner {
         SessionOwner {
             account_id: Some("default".into()),
@@ -521,7 +562,19 @@ mod tests {
             chat_kind: chat_kind.map(str::to_string),
             chat_id: chat_id.map(str::to_string),
             parent_session_id: parent.map(str::to_string),
+            session_kind: kind.map(str::to_string),
         }
+    }
+
+    /// A CONVERSATION-kind owner (TS `parts.kind === "conversation"`).
+    fn conv(user_id: Option<&str>, chat_kind: Option<&str>, chat_id: Option<&str>) -> SessionOwner {
+        owner(user_id, chat_kind, chat_id, None, Some("conversation"))
+    }
+
+    /// A SUBAGENT-kind owner (TS `parts.kind === "subagent"`); `parent` is the chain
+    /// pointer (may be `None` — a subagent whose parent lives only in its key).
+    fn sub(user_id: Option<&str>, parent: Option<&str>) -> SessionOwner {
+        owner(user_id, None, None, parent, Some("subagent"))
     }
 
     /// A lookup over a fixed in-memory map (the TS `sessionLookup` analog).
@@ -544,11 +597,11 @@ mod tests {
     #[test]
     fn effective_user_direct_user_id_wins_without_lookup() {
         // TS case 1: session.userId returns immediately (no key parse, no walk).
-        let o = owner(Some("alice"), Some("dm"), Some("chat-1"), None);
+        let o = conv(Some("alice"), Some("dm"), Some("chat-1"));
         let got = resolve_effective_user_id(&o, &mut no_lookup).unwrap();
         assert_eq!(got.as_deref(), Some("alice"));
         // JS-falsy parity: an EMPTY user_id is absent, so the DM fallback applies instead.
-        let o = owner(Some(""), Some("dm"), Some("chat-1"), None);
+        let o = conv(Some(""), Some("dm"), Some("chat-1"));
         let got = resolve_effective_user_id(&o, &mut no_lookup).unwrap();
         assert_eq!(got.as_deref(), Some("chat-1"));
     }
@@ -556,7 +609,7 @@ mod tests {
     #[test]
     fn effective_user_dm_falls_back_to_chat_id_only_for_exact_dm_kind() {
         // TS case 2: conversation + chatKind === "dm" → chatId.
-        let dm = owner(None, Some("dm"), Some("chat-77"), None);
+        let dm = conv(None, Some("dm"), Some("chat-77"));
         assert_eq!(
             resolve_effective_user_id(&dm, &mut no_lookup)
                 .unwrap()
@@ -566,31 +619,40 @@ mod tests {
         // A NON-dm kind gets NO fallback (group/channel/thread chats are multi-user —
         // attributing them to the chat id would merge users into one scope).
         for kind in ["group", "channel", "thread"] {
-            let o = owner(None, Some(kind), Some("chat-77"), None);
+            let o = conv(None, Some(kind), Some("chat-77"));
             assert_eq!(resolve_effective_user_id(&o, &mut no_lookup).unwrap(), None);
         }
-        // Unknown/absent kind: fail closed too.
-        let o = owner(None, None, Some("chat-77"), None);
+        // Unknown/absent chat_kind: fail closed too.
+        let o = conv(None, None, Some("chat-77"));
         assert_eq!(resolve_effective_user_id(&o, &mut no_lookup).unwrap(), None);
         // DM with NO stored chat_id is UNDERIVABLE → fail closed (no guessing).
-        let o = owner(None, Some("dm"), None, None);
+        let o = conv(None, Some("dm"), None);
         assert_eq!(resolve_effective_user_id(&o, &mut no_lookup).unwrap(), None);
+        // A row with NO `session_kind` (legacy/unset) gets NO DM fallback even with
+        // `chat_kind == "dm"` and a stored chat_id — fail closed by construction (the
+        // structural gate is on the explicit kind, never inferred).
+        let unkinded = owner(None, Some("dm"), Some("chat-77"), None, None);
+        assert_eq!(
+            resolve_effective_user_id(&unkinded, &mut no_lookup).unwrap(),
+            None,
+            "an un-kinded DM-shaped row must fail closed, never DM-attribute"
+        );
     }
 
     #[test]
     fn effective_user_subagent_walks_to_parent_user_id() {
         // TS case 3: subagent → nearest ancestor userId. One hop...
-        let entries = [("p1", owner(Some("alice"), None, None, None))];
-        let child = owner(None, None, None, Some("p1"));
+        let entries = [("p1", conv(Some("alice"), None, None))];
+        let child = sub(None, Some("p1"));
         let got = resolve_effective_user_id(&child, &mut map_lookup(&entries)).unwrap();
         assert_eq!(got.as_deref(), Some("alice"));
 
         // ...and multi-hop through a userId-less intermediate subagent.
         let entries = [
-            ("mid", owner(None, None, None, Some("root"))),
-            ("root", owner(Some("bob"), None, None, None)),
+            ("mid", sub(None, Some("root"))),
+            ("root", conv(Some("bob"), None, None)),
         ];
-        let child = owner(None, None, None, Some("mid"));
+        let child = sub(None, Some("mid"));
         let got = resolve_effective_user_id(&child, &mut map_lookup(&entries)).unwrap();
         assert_eq!(got.as_deref(), Some("bob"));
     }
@@ -598,8 +660,8 @@ mod tests {
     #[test]
     fn effective_user_subagent_resolves_via_dm_conversation_ancestor() {
         // TS: a conversation-DM PARENT without a userId resolves to ITS chatId.
-        let entries = [("p1", owner(None, Some("dm"), Some("chat-9"), None))];
-        let child = owner(None, None, None, Some("p1"));
+        let entries = [("p1", conv(None, Some("dm"), Some("chat-9")))];
+        let child = sub(None, Some("p1"));
         let got = resolve_effective_user_id(&child, &mut map_lookup(&entries)).unwrap();
         assert_eq!(got.as_deref(), Some("chat-9"));
     }
@@ -608,43 +670,92 @@ mod tests {
     fn effective_user_subagent_own_dm_axes_are_not_used() {
         // A SUBAGENT session never uses its own chat axes (TS: its parts.kind is
         // "subagent", not "conversation") — the walk decides, and here it finds nothing.
-        let entries = [("p1", owner(None, None, None, None))];
-        let child = owner(None, Some("dm"), Some("chat-self"), Some("p1"));
+        let entries = [("p1", sub(None, None))];
+        // A subagent that ALSO carries its own dm chat axes — gated out of the DM leg by
+        // its explicit `session_kind == "subagent"`.
+        let child = owner(
+            None,
+            Some("dm"),
+            Some("chat-self"),
+            Some("p1"),
+            Some("subagent"),
+        );
         let got = resolve_effective_user_id(&child, &mut map_lookup(&entries)).unwrap();
         assert_eq!(got, None, "subagent must not DM-resolve from its own axes");
     }
 
     #[test]
+    fn effective_user_subagent_kind_with_null_parent_and_dm_axes_fails_closed_not_dm() {
+        // THE review's exact missing test (MED-1, cross-user mis-attribution window): a row
+        // that is SEMANTICALLY a subagent (`session_kind == "subagent"`) but has a NULL
+        // parent link AND `chat_kind == "dm"` + a stored chat_id MUST take the parent-walk
+        // leg (not the DM-chatId leg) and — with no chain to walk — fail closed. The prior
+        // port (inferring subagent-ness from `parent_session_id IS NOT NULL`) treated this
+        // shape as a conversation and returned the chat_id "C" — a WRONG-principal namespace
+        // write if "C" belongs to a different user than this subagent's true ancestor.
+        let null_parent = owner(None, Some("dm"), Some("C"), None, Some("subagent"));
+        let got = resolve_effective_user_id(&null_parent, &mut no_lookup).unwrap();
+        assert_eq!(
+            got, None,
+            "a null-parent subagent-kind dm-shaped row must fail closed, NEVER return the chat_id"
+        );
+        assert_ne!(
+            got.as_deref(),
+            Some("C"),
+            "must NOT DM-attribute the subagent to a foreign chat id (the closed mis-attribution window)"
+        );
+
+        // The SIBLING positive control: the SAME subagent shape but WITH a parent link to an
+        // ancestor that carries the true userId walks to that ancestor "U" — never to "C".
+        let entries = [("anc", conv(Some("U"), None, None))];
+        let with_parent = owner(None, Some("dm"), Some("C"), Some("anc"), Some("subagent"));
+        let walked = resolve_effective_user_id(&with_parent, &mut map_lookup(&entries)).unwrap();
+        assert_eq!(
+            walked.as_deref(),
+            Some("U"),
+            "the subagent resolves to its ancestor userId via the walk, not its own dm chat id"
+        );
+        assert_ne!(walked.as_deref(), Some("C"));
+    }
+
+    #[test]
     fn effective_user_walk_fails_closed_on_dangling_missing_or_cyclic_chain() {
         // Dangling parent link (no such session): fail closed.
-        let child = owner(None, None, None, Some("ghost"));
+        let child = sub(None, Some("ghost"));
         assert_eq!(
             resolve_effective_user_id(&child, &mut map_lookup(&[])).unwrap(),
             None
         );
-        // Exhausted chain (ancestors exist but none derivable): fail closed.
+        // Exhausted chain (ancestors exist but none derivable): fail closed. The
+        // intermediate is a subagent-kind group conversation analog (no derivable userId).
         let entries = [
-            ("p1", owner(None, Some("group"), Some("g-1"), Some("p2"))),
-            ("p2", owner(None, None, None, None)),
+            (
+                "p1",
+                owner(
+                    None,
+                    Some("group"),
+                    Some("g-1"),
+                    Some("p2"),
+                    Some("subagent"),
+                ),
+            ),
+            ("p2", sub(None, None)),
         ];
-        let child = owner(None, None, None, Some("p1"));
+        let child = sub(None, Some("p1"));
         assert_eq!(
             resolve_effective_user_id(&child, &mut map_lookup(&entries)).unwrap(),
             None
         );
         // CYCLE (p1 -> p2 -> p1): the visited set terminates the walk, fail closed.
-        let entries = [
-            ("p1", owner(None, None, None, Some("p2"))),
-            ("p2", owner(None, None, None, Some("p1"))),
-        ];
-        let child = owner(None, None, None, Some("p1"));
+        let entries = [("p1", sub(None, Some("p2"))), ("p2", sub(None, Some("p1")))];
+        let child = sub(None, Some("p1"));
         assert_eq!(
             resolve_effective_user_id(&child, &mut map_lookup(&entries)).unwrap(),
             None
         );
         // SELF-cycle (a session whose parent is itself — pathological but storable).
-        let entries = [("s", owner(None, None, None, Some("s")))];
-        let child = owner(None, None, None, Some("s"));
+        let entries = [("s", sub(None, Some("s")))];
+        let child = sub(None, Some("s"));
         assert_eq!(
             resolve_effective_user_id(&child, &mut map_lookup(&entries)).unwrap(),
             None
@@ -656,7 +767,7 @@ mod tests {
         // A STORAGE error during the walk must propagate (never be treated as "no
         // parent" — that would mis-report a locked/corrupt DB as an unresolvable
         // namespace downstream, the same discipline as load_session_owner's .optional()).
-        let child = owner(None, None, None, Some("p1"));
+        let child = sub(None, Some("p1"));
         let mut failing = |_key: &str| -> Result<Option<SessionOwner>, StorageError> {
             Err(StorageError::Unsupported("disk on fire".into()))
         };

--- a/rust-core/crates/friday-hub/tests/s6d_resume_ingestion.rs
+++ b/rust-core/crates/friday-hub/tests/s6d_resume_ingestion.rs
@@ -32,7 +32,10 @@ use friday_hub::{
     build_request_with_policy, run_loop_with_policy, AgentError, AgentLlmClient, AgentStep,
     FsToolExecutor, LoopStatus, RawToolCall, RunPolicy, TurnTrace,
 };
-use friday_storage::{agent_run, get_run_result, list_pending_requests_for_run, Db};
+use friday_storage::{
+    agent_run, get_run_answer_for_principal, get_run_result, list_pending_requests_for_run,
+    AnswerDenyReason, Db, RunAnswerAccess,
+};
 
 static C: AtomicU64 = AtomicU64::new(0);
 
@@ -305,11 +308,14 @@ fn loop_hmac_approval_cannot_execute_even_with_operator_key() {
 
 // ─────────────────────────── resume/ingestion entrypoint ───────────────────────────
 
-/// Drive a run to a Pause, return (db, ws, pending nonce, the reconstructed request) so a
-/// resume test can sign + ingest an approval for the EXACT paused action.
-fn pause_a_run(
+/// Drive a run to a Pause under the supplied `policy`, return (db, ws, pending nonce, the
+/// reconstructed request) so a resume test can sign + ingest an approval for the EXACT
+/// paused action. The pending row carries the policy's `principal_id` (the digest binds
+/// it), so the reconstructed request used to sign MUST be built with the SAME policy.
+fn pause_a_run_with_policy(
     tag: &str,
     vk: &OperatorVerifyingKey,
+    policy: &RunPolicy,
 ) -> (Db, Workspace, String, MutatingActionRequest) {
     let db = Db::open_hub(&temp_db(tag)).unwrap();
     let ws = Workspace::new(tag);
@@ -327,7 +333,7 @@ fn pause_a_run(
         "",
         Some(vk),
         &no_approval(),
-        &RunPolicy::default(),
+        policy,
         5,
         NOW,
     )
@@ -335,8 +341,16 @@ fn pause_a_run(
     assert_eq!(out.status, LoopStatus::Paused);
     let pending = list_pending_requests_for_run(db.conn(), run_id).unwrap();
     let nonce = pending[0].approval_id.clone();
-    let request = build_request_with_policy(&call, &RunPolicy::default()).unwrap();
+    let request = build_request_with_policy(&call, policy).unwrap();
     (db, ws, nonce, request)
+}
+
+/// The default (no-principal) Pause helper used by the existing refusal/replay tests.
+fn pause_a_run(
+    tag: &str,
+    vk: &OperatorVerifyingKey,
+) -> (Db, Workspace, String, MutatingActionRequest) {
+    pause_a_run_with_policy(tag, vk, &RunPolicy::default())
 }
 
 /// THE core S6d flow: resume with a valid operator approval executes EXACTLY ONE mutation;
@@ -377,6 +391,90 @@ fn resume_executes_one_mutation_then_replay_is_refused() {
         std::fs::read_to_string(ws.join("out.txt")).unwrap(),
         "TAMPERED",
         "the file was NOT re-written by the replay"
+    );
+}
+
+/// Owner-wiring completeness (review MED-2): a BOUND paused run, resumed with a valid
+/// operator approval, persists its `mutation_completed` run_result WITH the run's owner
+/// principal — so the authenticated body projection RELEASES the resumed mutation's body
+/// to the legitimate owner and DENIES every other caller. Before the fix the resume leg
+/// dropped the owner ⇒ the result was ownerless ⇒ even the owner was Denied
+/// (`NoOwnerPrincipal`). This also covers the identical gap on the `run_task` resume path
+/// (resume.rs IS that path; runtime.rs only persists the already-owned Finished leg).
+#[test]
+fn resume_completion_persists_owner_principal_readable_only_to_owner() {
+    let (sk, vk) = operator();
+    // The paused run is BOUND to principal "alice" (the digest binds it, so the signed
+    // approval and the reconstructed request must use the SAME policy — they do via the
+    // helper).
+    let policy = RunPolicy::new(Some("alice".to_string()), Vec::<String>::new(), false);
+    let (db, ws, nonce, request) = pause_a_run_with_policy("resume-owner", &vk, &policy);
+    let exec = FsToolExecutor::new(&ws.0);
+
+    let approval = ed_approval(&request, &sk, &nonce, Some(FUTURE));
+    let r = resume_with_approval(db.conn(), &exec, &vk, &approval, NOW).unwrap();
+    assert_eq!(r.decision, GateDecision::Allow);
+    assert!(r.executed, "the approved mutation executed");
+    assert_eq!(r.result_status, "mutation_completed");
+    assert_eq!(
+        std::fs::read_to_string(ws.join("out.txt")).unwrap(),
+        "RESUMED"
+    );
+
+    // The OWNER reads the resumed mutation's body back (Granted), with the recorded owner.
+    match get_run_answer_for_principal(db.conn(), &r.run_id, "alice").unwrap() {
+        RunAnswerAccess::Granted(stored) => {
+            assert_eq!(stored.status, "mutation_completed");
+            assert_eq!(
+                stored.owner_principal.as_deref(),
+                Some("alice"),
+                "the resume leg recorded the run's bound owner principal"
+            );
+            assert!(
+                stored.audit_ref.is_some(),
+                "result still links the audit receipt"
+            );
+        }
+        other => panic!("owner must be Granted the resumed body, got {other:?}"),
+    }
+    // A DIFFERENT principal is denied (body withheld) — not over-denied to the owner, but
+    // closed to everyone else.
+    assert_eq!(
+        get_run_answer_for_principal(db.conn(), &r.run_id, "mallory").unwrap(),
+        RunAnswerAccess::Denied(AnswerDenyReason::PrincipalMismatch)
+    );
+    // An anonymous / public caller never reads a body.
+    for anon in ["", "public", "public:default"] {
+        assert_eq!(
+            get_run_answer_for_principal(db.conn(), &r.run_id, anon).unwrap(),
+            RunAnswerAccess::Denied(AnswerDenyReason::AnonymousCaller),
+            "anonymous caller {anon:?} must be denied"
+        );
+    }
+}
+
+/// The fail-closed direction is preserved: an UNBOUND (no-principal) paused run resumed to
+/// completion records NO owner ⇒ the resumed body is unreadable by EVERYONE
+/// (`NoOwnerPrincipal`) — never widened to a default/anonymous owner.
+#[test]
+fn resume_completion_without_principal_is_ownerless_fail_closed() {
+    let (sk, vk) = operator();
+    let (db, ws, nonce, request) = pause_a_run("resume-noowner", &vk); // RunPolicy::default()
+    let exec = FsToolExecutor::new(&ws.0);
+
+    let approval = ed_approval(&request, &sk, &nonce, Some(FUTURE));
+    let r = resume_with_approval(db.conn(), &exec, &vk, &approval, NOW).unwrap();
+    assert_eq!(r.decision, GateDecision::Allow);
+    assert!(r.executed);
+    // No bound principal ⇒ ownerless ⇒ every caller (incl. any principal) is Denied.
+    let stored = get_run_result(db.conn(), &r.run_id).unwrap().unwrap();
+    assert_eq!(
+        stored.owner_principal, None,
+        "no bound principal ⇒ no owner recorded (fail-closed)"
+    );
+    assert_eq!(
+        get_run_answer_for_principal(db.conn(), &r.run_id, "anyone").unwrap(),
+        RunAnswerAccess::Denied(AnswerDenyReason::NoOwnerPrincipal)
     );
 }
 

--- a/rust-core/crates/friday-storage/src/agent_session.rs
+++ b/rust-core/crates/friday-storage/src/agent_session.rs
@@ -66,7 +66,8 @@ pub struct StoredSessionMessage {
 /// The session OWNER axes (slice-3 ownership-binding + owner-wiring conversation axes)
 /// — the `agent_session` fields the memory namespace is DERIVED from, mirroring the TS
 /// `FridaySessionRecord` `accountId` / `channel` / `userId` plus the `chatKind` /
-/// `chatId` / `parentSessionKey` axes the TS `resolveEffectiveUserId` fallbacks key on.
+/// `chatId` / `parentSessionKey` axes the TS `resolveEffectiveUserId` fallbacks key on,
+/// AND the structural `session_kind` discriminant (the TS `parseFridaySessionKey(...).kind`).
 /// All optional: a pre-slice-3 session (or one created via the no-owner
 /// [`ensure_session`]) reads back `None` for each. A `None` (or empty) `user_id` with no
 /// derivable fallback (DM-chatId / subagent parent-walk) is what FAILS the
@@ -84,10 +85,29 @@ pub struct SessionOwner {
     /// user-bound chat identity the userId fallback resolves to.
     pub chat_id: Option<String>,
     /// The TS `parentSessionKey`: a SUBAGENT session's soft link to its parent
-    /// `agent_session_id` (no FK). `Some` marks the session as a subagent — the
-    /// parent-walk userId fallback follows this chain; a dangling/absent link fails the
-    /// walk closed.
+    /// `agent_session_id` (no FK). The parent-walk userId fallback FOLLOWS this chain (it
+    /// is the chain POINTER, the TS `parentSessionKey ?? parts.parentKey`); a
+    /// dangling/absent link fails the walk closed. NOTE: this is the chain pointer, NOT
+    /// the subagent DISCRIMINANT — that is [`SessionOwner::session_kind`] (see its doc).
     pub parent_session_id: Option<String>,
+    /// The STRUCTURAL kind discriminant — the faithful Rust carrier for the TS
+    /// `parseFridaySessionKey(session.key).kind` (`"conversation"` / `"subagent"`).
+    ///
+    /// The TS derives kind from the session KEY's prefix (`subagent:<parentKey>:<taskId>`
+    /// ⇒ `"subagent"`, else `"conversation"`); the Rust `agent_session_id` is opaque, so we
+    /// carry the kind EXPLICITLY instead of inferring it from `parent_session_id` presence
+    /// (which is the chain pointer and is NOT a faithful kind signal — a subagent's key
+    /// can carry its parent in the key itself, so `parentSessionKey` may be absent while
+    /// the kind is still `"subagent"`).
+    ///
+    /// FAIL-CLOSED default: only the EXACT value `"conversation"` enables the DM-chatId
+    /// fallback (TS line 94) and only `"subagent"` enables the parent-walk (TS line 99).
+    /// `None` (unset / legacy / pre-v23) or any unknown value enables NEITHER fallback —
+    /// only a direct `user_id` resolves, else the namespace fails closed. This is the
+    /// structural property that makes a contradictory shape (a subagent-kind row with a
+    /// null parent + `chat_kind == "dm"`) never silently DM-attribute. Enforced by a
+    /// vocabulary CHECK at the column.
+    pub session_kind: Option<String>,
 }
 
 /// Ensure an `agent_session` row exists (idempotent). A new session is created at
@@ -150,6 +170,7 @@ pub fn ensure_session_with_owner(
     let chat_kind = none_if_blank(owner.chat_kind.as_deref());
     let chat_id = none_if_blank(owner.chat_id.as_deref());
     let parent_session_id = none_if_blank(owner.parent_session_id.as_deref());
+    let session_kind = none_if_blank(owner.session_kind.as_deref());
     // INSERT-or-bump in one statement: a fresh id INSERTs with the owner; an existing id
     // keeps its created_at + already-bound owner (COALESCE keeps the existing non-NULL,
     // else accepts the incoming value as a backfill) and only advances updated_at — no row
@@ -157,8 +178,8 @@ pub fn ensure_session_with_owner(
     conn.execute(
         "INSERT INTO agent_session
             (agent_session_id, created_at, updated_at, account_id, channel, user_id,
-             chat_kind, chat_id, parent_session_id)
-         VALUES (?1, ?2, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+             chat_kind, chat_id, parent_session_id, session_kind)
+         VALUES (?1, ?2, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
          ON CONFLICT(agent_session_id) DO UPDATE SET
             updated_at = ?2,
             account_id = COALESCE(account_id, excluded.account_id),
@@ -166,7 +187,8 @@ pub fn ensure_session_with_owner(
             user_id    = COALESCE(user_id, excluded.user_id),
             chat_kind  = COALESCE(chat_kind, excluded.chat_kind),
             chat_id    = COALESCE(chat_id, excluded.chat_id),
-            parent_session_id = COALESCE(parent_session_id, excluded.parent_session_id)",
+            parent_session_id = COALESCE(parent_session_id, excluded.parent_session_id),
+            session_kind = COALESCE(session_kind, excluded.session_kind)",
         params![
             agent_session_id,
             now_ms,
@@ -175,7 +197,8 @@ pub fn ensure_session_with_owner(
             user_id,
             chat_kind,
             chat_id,
-            parent_session_id
+            parent_session_id,
+            session_kind
         ],
     )?;
     Ok(())
@@ -194,7 +217,8 @@ pub fn load_session_owner(
     // "no owner" (which would mis-report as an unresolvable namespace downstream).
     let row = conn
         .query_row(
-            "SELECT account_id, channel, user_id, chat_kind, chat_id, parent_session_id
+            "SELECT account_id, channel, user_id, chat_kind, chat_id, parent_session_id,
+                    session_kind
              FROM agent_session
              WHERE agent_session_id = ?1",
             [agent_session_id],
@@ -206,6 +230,7 @@ pub fn load_session_owner(
                     chat_kind: none_if_blank(r.get::<_, Option<String>>(3)?.as_deref()),
                     chat_id: none_if_blank(r.get::<_, Option<String>>(4)?.as_deref()),
                     parent_session_id: none_if_blank(r.get::<_, Option<String>>(5)?.as_deref()),
+                    session_kind: none_if_blank(r.get::<_, Option<String>>(6)?.as_deref()),
                 })
             },
         )
@@ -670,19 +695,23 @@ mod tests {
             chat_kind: Some("dm".into()),
             chat_id: Some("chat-77".into()),
             parent_session_id: None,
+            session_kind: Some("conversation".into()),
         };
         ensure_session_with_owner(db.conn(), "s1", &owner, 1).unwrap();
         assert_eq!(load_session_owner(db.conn(), "s1").unwrap(), Some(owner));
 
         // A subagent-shaped session links its parent (soft link, no FK — a not-yet-
-        // existing parent id is accepted; the WALK fails closed, not the row).
+        // existing parent id is accepted; the WALK fails closed, not the row) and carries
+        // its STRUCTURAL kind explicitly (round-trips like the other axes).
         let sub = SessionOwner {
             parent_session_id: Some("s1".into()),
+            session_kind: Some("subagent".into()),
             ..Default::default()
         };
         ensure_session_with_owner(db.conn(), "s2", &sub, 2).unwrap();
         let back = load_session_owner(db.conn(), "s2").unwrap().unwrap();
         assert_eq!(back.parent_session_id.as_deref(), Some("s1"));
+        assert_eq!(back.session_kind.as_deref(), Some("subagent"));
         assert_eq!(back.chat_kind, None);
         assert_eq!(back.user_id, None);
     }
@@ -704,6 +733,31 @@ mod tests {
                 ..Default::default()
             };
             ensure_session_with_owner(db.conn(), &format!("k{i}"), &ok, 1).unwrap();
+        }
+    }
+
+    #[test]
+    fn session_kind_outside_ts_vocabulary_is_rejected_by_check() {
+        // The structural-kind CHECK admits NULL or the exact TS `parts.kind` vocabulary
+        // only ("conversation" | "subagent") — an unknown value cannot be stored to LOOK
+        // like (or later be confused with) a conversation/subagent and trigger a fallback.
+        let db = Db::open_hub(&tmp("sessionkind-check")).unwrap();
+        let bad = SessionOwner {
+            session_kind: Some("agent".into()),
+            ..Default::default()
+        };
+        assert!(ensure_session_with_owner(db.conn(), "s1", &bad, 1).is_err());
+        // The valid vocabulary is accepted and round-trips.
+        for (i, kind) in ["conversation", "subagent"].iter().enumerate() {
+            let ok = SessionOwner {
+                session_kind: Some((*kind).to_string()),
+                ..Default::default()
+            };
+            ensure_session_with_owner(db.conn(), &format!("sk{i}"), &ok, 1).unwrap();
+            let back = load_session_owner(db.conn(), &format!("sk{i}"))
+                .unwrap()
+                .unwrap();
+            assert_eq!(back.session_kind.as_deref(), Some(*kind));
         }
     }
 

--- a/rust-core/crates/friday-storage/src/agent_session.rs
+++ b/rust-core/crates/friday-storage/src/agent_session.rs
@@ -63,16 +63,31 @@ pub struct StoredSessionMessage {
     pub created_at: i64,
 }
 
-/// The session OWNER axes (slice-3 ownership-binding) — the three `agent_session`
-/// fields the memory namespace is DERIVED from, mirroring the TS `FridaySessionRecord`
-/// `accountId` / `channel` / `userId`. All optional: a pre-slice-3 session (or one
-/// created via the no-owner [`ensure_session`]) reads back `None` for each. A `None`
-/// (or empty) `user_id` is what FAILS the memory-namespace resolution closed.
+/// The session OWNER axes (slice-3 ownership-binding + owner-wiring conversation axes)
+/// — the `agent_session` fields the memory namespace is DERIVED from, mirroring the TS
+/// `FridaySessionRecord` `accountId` / `channel` / `userId` plus the `chatKind` /
+/// `chatId` / `parentSessionKey` axes the TS `resolveEffectiveUserId` fallbacks key on.
+/// All optional: a pre-slice-3 session (or one created via the no-owner
+/// [`ensure_session`]) reads back `None` for each. A `None` (or empty) `user_id` with no
+/// derivable fallback (DM-chatId / subagent parent-walk) is what FAILS the
+/// memory-namespace resolution closed.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct SessionOwner {
     pub account_id: Option<String>,
     pub channel: Option<String>,
     pub user_id: Option<String>,
+    /// The TS `chatKind` (`"dm"` / `"group"` / `"channel"` / `"thread"`). Only the EXACT
+    /// value `"dm"` enables the DM-chatId userId fallback; `None` (or any other kind)
+    /// means no DM fallback (fail-closed). Enforced by a CHECK at the column.
+    pub chat_kind: Option<String>,
+    /// The TS conversation `chatId`. For a `chat_kind == "dm"` conversation this is the
+    /// user-bound chat identity the userId fallback resolves to.
+    pub chat_id: Option<String>,
+    /// The TS `parentSessionKey`: a SUBAGENT session's soft link to its parent
+    /// `agent_session_id` (no FK). `Some` marks the session as a subagent — the
+    /// parent-walk userId fallback follows this chain; a dangling/absent link fails the
+    /// walk closed.
+    pub parent_session_id: Option<String>,
 }
 
 /// Ensure an `agent_session` row exists (idempotent). A new session is created at
@@ -81,15 +96,16 @@ pub struct SessionOwner {
 ///
 /// This is the OWNER-LESS form (no `account_id`/`channel`/`user_id`): a session created
 /// this way reads back [`SessionOwner::default`] (all `None`), so its memory namespace
-/// is UNRESOLVABLE (fail-closed) until an owner is set. Existing callers (e.g. the
-/// production `run_session_loop`) keep using this unchanged. To bind an owner, use
-/// [`ensure_session_with_owner`].
+/// is UNRESOLVABLE (fail-closed) until an owner is set. Callers without an owner in
+/// hand (e.g. `run_session_loop` with `session_owner: None`) keep using this unchanged.
+/// To bind an owner, use [`ensure_session_with_owner`].
 ///
 /// IMPORTANT: this owner-less form references ONLY the pre-v21 columns (it never names
-/// `account_id`/`channel`/`user_id`), so it works against a DB at ANY version that has the
-/// base `agent_session` table — including a v≤20 DB seeded in a migration test BEFORE the
-/// v21 owner columns exist. Owner binding is the sole concern of
-/// [`ensure_session_with_owner`], which requires the v21 columns.
+/// `account_id`/`channel`/`user_id` or the v23 conversation axes), so it works against a
+/// DB at ANY version that has the base `agent_session` table — including a v≤20 DB seeded
+/// in a migration test BEFORE the owner columns exist. Owner binding is the sole concern
+/// of [`ensure_session_with_owner`], which requires the v21 owner columns AND the v23
+/// conversation-axis columns.
 pub fn ensure_session(conn: &Connection, agent_session_id: &str, now_ms: i64) -> Result<()> {
     if agent_session_id.trim().is_empty() {
         return Err(StorageError::Unsupported(
@@ -131,20 +147,36 @@ pub fn ensure_session_with_owner(
     let account_id = none_if_blank(owner.account_id.as_deref());
     let channel = none_if_blank(owner.channel.as_deref());
     let user_id = none_if_blank(owner.user_id.as_deref());
+    let chat_kind = none_if_blank(owner.chat_kind.as_deref());
+    let chat_id = none_if_blank(owner.chat_id.as_deref());
+    let parent_session_id = none_if_blank(owner.parent_session_id.as_deref());
     // INSERT-or-bump in one statement: a fresh id INSERTs with the owner; an existing id
     // keeps its created_at + already-bound owner (COALESCE keeps the existing non-NULL,
     // else accepts the incoming value as a backfill) and only advances updated_at — no row
     // is ever clobbered and no bound owner is ever erased.
     conn.execute(
         "INSERT INTO agent_session
-            (agent_session_id, created_at, updated_at, account_id, channel, user_id)
-         VALUES (?1, ?2, ?2, ?3, ?4, ?5)
+            (agent_session_id, created_at, updated_at, account_id, channel, user_id,
+             chat_kind, chat_id, parent_session_id)
+         VALUES (?1, ?2, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
          ON CONFLICT(agent_session_id) DO UPDATE SET
             updated_at = ?2,
             account_id = COALESCE(account_id, excluded.account_id),
             channel    = COALESCE(channel, excluded.channel),
-            user_id    = COALESCE(user_id, excluded.user_id)",
-        params![agent_session_id, now_ms, account_id, channel, user_id],
+            user_id    = COALESCE(user_id, excluded.user_id),
+            chat_kind  = COALESCE(chat_kind, excluded.chat_kind),
+            chat_id    = COALESCE(chat_id, excluded.chat_id),
+            parent_session_id = COALESCE(parent_session_id, excluded.parent_session_id)",
+        params![
+            agent_session_id,
+            now_ms,
+            account_id,
+            channel,
+            user_id,
+            chat_kind,
+            chat_id,
+            parent_session_id
+        ],
     )?;
     Ok(())
 }
@@ -162,7 +194,8 @@ pub fn load_session_owner(
     // "no owner" (which would mis-report as an unresolvable namespace downstream).
     let row = conn
         .query_row(
-            "SELECT account_id, channel, user_id FROM agent_session
+            "SELECT account_id, channel, user_id, chat_kind, chat_id, parent_session_id
+             FROM agent_session
              WHERE agent_session_id = ?1",
             [agent_session_id],
             |r| {
@@ -170,6 +203,9 @@ pub fn load_session_owner(
                     account_id: none_if_blank(r.get::<_, Option<String>>(0)?.as_deref()),
                     channel: none_if_blank(r.get::<_, Option<String>>(1)?.as_deref()),
                     user_id: none_if_blank(r.get::<_, Option<String>>(2)?.as_deref()),
+                    chat_kind: none_if_blank(r.get::<_, Option<String>>(3)?.as_deref()),
+                    chat_id: none_if_blank(r.get::<_, Option<String>>(4)?.as_deref()),
+                    parent_session_id: none_if_blank(r.get::<_, Option<String>>(5)?.as_deref()),
                 })
             },
         )
@@ -616,9 +652,59 @@ mod tests {
             account_id: Some("acct-1".into()),
             channel: Some("discord".into()),
             user_id: Some("user-abc".into()),
+            ..Default::default()
         };
         ensure_session_with_owner(db.conn(), "s1", &owner, 1).unwrap();
         assert_eq!(load_session_owner(db.conn(), "s1").unwrap(), Some(owner));
+    }
+
+    #[test]
+    fn conversation_axes_store_and_load_round_trip() {
+        // Owner-wiring: the DM/subagent fallback axes (`chat_kind`/`chat_id`/
+        // `parent_session_id`) round-trip through ensure/load like the owner axes.
+        let db = Db::open_hub(&tmp("convaxes")).unwrap();
+        let owner = SessionOwner {
+            account_id: Some("default".into()),
+            channel: Some("telegram".into()),
+            user_id: None,
+            chat_kind: Some("dm".into()),
+            chat_id: Some("chat-77".into()),
+            parent_session_id: None,
+        };
+        ensure_session_with_owner(db.conn(), "s1", &owner, 1).unwrap();
+        assert_eq!(load_session_owner(db.conn(), "s1").unwrap(), Some(owner));
+
+        // A subagent-shaped session links its parent (soft link, no FK — a not-yet-
+        // existing parent id is accepted; the WALK fails closed, not the row).
+        let sub = SessionOwner {
+            parent_session_id: Some("s1".into()),
+            ..Default::default()
+        };
+        ensure_session_with_owner(db.conn(), "s2", &sub, 2).unwrap();
+        let back = load_session_owner(db.conn(), "s2").unwrap().unwrap();
+        assert_eq!(back.parent_session_id.as_deref(), Some("s1"));
+        assert_eq!(back.chat_kind, None);
+        assert_eq!(back.user_id, None);
+    }
+
+    #[test]
+    fn chat_kind_outside_ts_vocabulary_is_rejected_by_check() {
+        // The CHECK admits NULL or the exact TS vocabulary only — an unknown kind cannot
+        // be stored to LOOK like (or later be confused with) a DM.
+        let db = Db::open_hub(&tmp("chatkind-check")).unwrap();
+        let bad = SessionOwner {
+            chat_kind: Some("direct-message".into()),
+            ..Default::default()
+        };
+        assert!(ensure_session_with_owner(db.conn(), "s1", &bad, 1).is_err());
+        // The valid vocabulary is accepted.
+        for (i, kind) in ["dm", "group", "channel", "thread"].iter().enumerate() {
+            let ok = SessionOwner {
+                chat_kind: Some((*kind).to_string()),
+                ..Default::default()
+            };
+            ensure_session_with_owner(db.conn(), &format!("k{i}"), &ok, 1).unwrap();
+        }
     }
 
     #[test]
@@ -630,6 +716,7 @@ mod tests {
             account_id: Some("".into()),
             channel: Some("   ".into()),
             user_id: Some("u".into()),
+            ..Default::default()
         };
         ensure_session_with_owner(db.conn(), "s1", &owner, 1).unwrap();
         let back = load_session_owner(db.conn(), "s1").unwrap().unwrap();
@@ -649,6 +736,7 @@ mod tests {
             account_id: Some("acct-1".into()),
             channel: None,
             user_id: Some("user-abc".into()),
+            ..Default::default()
         };
         ensure_session_with_owner(db.conn(), "s1", &owner, 1).unwrap();
         // A no-owner re-ensure must NOT erase the bound account/user.
@@ -665,6 +753,7 @@ mod tests {
                 account_id: Some("ignored-acct".into()),
                 channel: Some("slack".into()),
                 user_id: None,
+                ..Default::default()
             },
             3,
         )

--- a/rust-core/crates/friday-storage/src/schema.rs
+++ b/rust-core/crates/friday-storage/src/schema.rs
@@ -325,6 +325,21 @@ pub fn hub_migrations() -> Vec<Migration> {
             destructive: false,
             up: m0022_workflow_definition,
         },
+        // Owner-wiring follow-on to v21 (session-memory DM/subagent userId fallbacks): add
+        // the CONVERSATION axes (`chat_kind`, `chat_id`, `parent_session_id`) the TS
+        // `resolveEffectiveUserId` derives a fallback userId from — (DM) a `chatKind ==
+        // "dm"` conversation falls back to its `chatId`; (subagent) a child session walks
+        // its parent chain to the nearest userId. All three columns are NULLABLE additive
+        // `ALTER`s: every existing v22 row reads back NULL, which simply means "no fallback
+        // available" — namespace resolution for such a session stays exactly as fail-closed
+        // as before (NULL `user_id` + no derivable fallback ⇒ MEMORY_NAMESPACE_UNRESOLVABLE
+        // parity). Purely additive — touches no other table. Hub-only table.
+        Migration {
+            version: 23,
+            name: "agent_session_conversation_axes",
+            destructive: false,
+            up: m0023_agent_session_conversation_axes,
+        },
     ]
 }
 
@@ -1479,4 +1494,28 @@ fn m0021_agent_session_owner(tx: &Transaction) -> rusqlite::Result<()> {
 // so pre-existing rows and every existing query are unaffected.
 fn m0022_workflow_definition(tx: &Transaction) -> rusqlite::Result<()> {
     tx.execute_batch(DDL_WORKFLOW_DEFINITION)
+}
+
+// Owner-wiring (session-memory DM/subagent userId-fallback parity): additive NULLABLE
+// conversation axes on the Hub-only `agent_session` table, mirroring the TS
+// `FridaySessionRecord` fields the `resolveEffectiveUserId` fallbacks key on:
+//   * `chat_kind`  — the TS `chatKind` ("dm" | "group" | "channel" | "thread"). Only the
+//     exact value 'dm' enables the DM-chatId fallback; the CHECK admits NULL or the full
+//     TS vocabulary so an unknown kind cannot be smuggled in to LOOK like a DM. NULL ⇒
+//     kind unknown ⇒ no DM fallback (fail-closed).
+//   * `chat_id`    — the TS conversation `chatId` (for a DM chat this is the user-bound
+//     chat identity the fallback resolves to).
+//   * `parent_session_id` — the TS `parentSessionKey`: a SUBAGENT session's link to its
+//     parent `agent_session_id`, walked (cycle-safe, fail-closed on a missing link) to
+//     find the nearest ancestor userId. Soft link (no FK) per the `*_ref` convention —
+//     a dangling parent fails the walk closed rather than rejecting the row.
+// Every existing v22 row reads back NULL for all three ⇒ no fallback available ⇒ namespace
+// resolution stays exactly as fail-closed as v21 (never a silently-broadened scope).
+fn m0023_agent_session_conversation_axes(tx: &Transaction) -> rusqlite::Result<()> {
+    tx.execute_batch(
+        "ALTER TABLE agent_session ADD COLUMN chat_kind TEXT
+            CHECK(chat_kind IS NULL OR chat_kind IN ('dm', 'group', 'channel', 'thread'));
+         ALTER TABLE agent_session ADD COLUMN chat_id TEXT;
+         ALTER TABLE agent_session ADD COLUMN parent_session_id TEXT;",
+    )
 }

--- a/rust-core/crates/friday-storage/src/schema.rs
+++ b/rust-core/crates/friday-storage/src/schema.rs
@@ -326,10 +326,14 @@ pub fn hub_migrations() -> Vec<Migration> {
             up: m0022_workflow_definition,
         },
         // Owner-wiring follow-on to v21 (session-memory DM/subagent userId fallbacks): add
-        // the CONVERSATION axes (`chat_kind`, `chat_id`, `parent_session_id`) the TS
-        // `resolveEffectiveUserId` derives a fallback userId from — (DM) a `chatKind ==
-        // "dm"` conversation falls back to its `chatId`; (subagent) a child session walks
-        // its parent chain to the nearest userId. All three columns are NULLABLE additive
+        // the CONVERSATION axes (`chat_kind`, `chat_id`, `parent_session_id`) plus the
+        // structural `session_kind` discriminant the TS `resolveEffectiveUserId` keys its
+        // fallbacks on — (DM) a `kind == "conversation"` + `chatKind == "dm"` session falls
+        // back to its `chatId`; (subagent) a `kind == "subagent"` child walks its parent
+        // chain to the nearest userId. `session_kind` is the faithful carrier of the TS
+        // `parseFridaySessionKey(...).kind` (the prior port INFERRED subagent-ness from
+        // `parent_session_id` presence — a different signal, the source of the cross-user
+        // mis-attribution window the review flagged). All FOUR columns are NULLABLE additive
         // `ALTER`s: every existing v22 row reads back NULL, which simply means "no fallback
         // available" — namespace resolution for such a session stays exactly as fail-closed
         // as before (NULL `user_id` + no derivable fallback ⇒ MEMORY_NAMESPACE_UNRESOLVABLE
@@ -1508,14 +1512,32 @@ fn m0022_workflow_definition(tx: &Transaction) -> rusqlite::Result<()> {
 //   * `parent_session_id` — the TS `parentSessionKey`: a SUBAGENT session's link to its
 //     parent `agent_session_id`, walked (cycle-safe, fail-closed on a missing link) to
 //     find the nearest ancestor userId. Soft link (no FK) per the `*_ref` convention —
-//     a dangling parent fails the walk closed rather than rejecting the row.
-// Every existing v22 row reads back NULL for all three ⇒ no fallback available ⇒ namespace
+//     a dangling parent fails the walk closed rather than rejecting the row. This is the
+//     walk CHAIN POINTER, NOT the subagent discriminant (see `session_kind`).
+//   * `session_kind` — the STRUCTURAL kind discriminant: the faithful carrier of the TS
+//     `parseFridaySessionKey(session.key).kind` ("conversation" | "subagent"). The TS
+//     derives kind from the session KEY's prefix; the Rust `agent_session_id` is opaque,
+//     so we carry kind EXPLICITLY instead of INFERRING subagent-ness from
+//     `parent_session_id` presence (the prior port's bug — those are different signals:
+//     a TS subagent's parent can live in the key, so its `parentSessionKey` column may be
+//     NULL while kind is still "subagent"). Only the EXACT 'conversation' enables the
+//     DM-chatId fallback and only 'subagent' the parent-walk; the CHECK admits NULL or the
+//     exact TS vocabulary so an unknown value cannot masquerade as either. NULL/unknown ⇒
+//     no fallback derivable (fail-closed). The contradictory shape the review flagged (a
+//     'subagent'-kind row with a NULL `parent_session_id` and `chat_kind == 'dm'`) is
+//     intentionally REPRESENTABLE (faithful to TS, where a subagent's parent may be in the
+//     key) but RESOLVES FAIL-CLOSED: kind == 'subagent' takes the parent-walk leg (NOT the
+//     DM-chatId leg), and a NULL chain pointer ends that walk with no derivable userId ⇒
+//     the namespace fails closed — it is NEVER silently DM-attributed to a foreign chat id.
+// Every existing v22 row reads back NULL for all four ⇒ no fallback available ⇒ namespace
 // resolution stays exactly as fail-closed as v21 (never a silently-broadened scope).
 fn m0023_agent_session_conversation_axes(tx: &Transaction) -> rusqlite::Result<()> {
     tx.execute_batch(
         "ALTER TABLE agent_session ADD COLUMN chat_kind TEXT
             CHECK(chat_kind IS NULL OR chat_kind IN ('dm', 'group', 'channel', 'thread'));
          ALTER TABLE agent_session ADD COLUMN chat_id TEXT;
-         ALTER TABLE agent_session ADD COLUMN parent_session_id TEXT;",
+         ALTER TABLE agent_session ADD COLUMN parent_session_id TEXT;
+         ALTER TABLE agent_session ADD COLUMN session_kind TEXT
+            CHECK(session_kind IS NULL OR session_kind IN ('conversation', 'subagent'));",
     )
 }

--- a/rust-core/crates/friday-storage/tests/migration.rs
+++ b/rust-core/crates/friday-storage/tests/migration.rs
@@ -228,9 +228,69 @@ fn forward_migration_v20_to_v21_backfills_owner_to_null_and_fresh_has_columns() 
         account_id: Some("default".into()),
         channel: Some("discord".into()),
         user_id: Some("user-abc".into()),
+        ..Default::default()
     };
     ensure_session_with_owner(db.conn(), "s2", &bound, 2).unwrap();
     assert_eq!(load_session_owner(db.conn(), "s2").unwrap(), Some(bound));
+}
+
+#[test]
+fn forward_migration_v22_to_v23_backfills_conversation_axes_to_null() {
+    // Owner-wiring additive migration v23: agent_session gains nullable `chat_kind`,
+    // `chat_id`, `parent_session_id` (the DM/subagent userId-fallback axes). A
+    // PRE-EXISTING v22 session row must survive the forward ALTER reading back NULL for
+    // all three — i.e. NO fallback is derivable for it, so its namespace resolution stays
+    // exactly as fail-closed as before (never silently DM-attributed). A fresh bind with
+    // the new axes then round-trips on the migrated DB.
+    use friday_storage::agent_session::{
+        ensure_session, ensure_session_with_owner, load_session_owner, SessionOwner,
+    };
+
+    let p = temp_db_path("agent-session-conv-axes-mig");
+    {
+        let mut migs = hub_migrations();
+        migs.retain(|m| m.version <= 22);
+        let db = Db::open(&p, Profile::Hub, &migs, "v22").unwrap();
+        assert_eq!(db.version().unwrap(), 22);
+        assert!(
+            db.conn()
+                .prepare("SELECT chat_kind FROM agent_session")
+                .is_err(),
+            "conversation-axis columns must not exist before v23"
+        );
+        // Seed a session with the pre-v23 owner shape (slice-3 axes only). The current
+        // `ensure_session_with_owner` names the v23 columns (it requires the latest
+        // schema), so the v22-era owner bind is reproduced with base ensure + raw UPDATE.
+        ensure_session(db.conn(), "s1", 1).unwrap();
+        db.conn()
+            .execute(
+                "UPDATE agent_session
+                 SET account_id = 'default', channel = 'discord', user_id = 'user-abc'
+                 WHERE agent_session_id = 's1'",
+                [],
+            )
+            .unwrap();
+    }
+    // Reopen with the full set -> forward-migrate to v23 (the additive ALTERs).
+    let db = Db::open_hub(&p).unwrap();
+    assert_eq!(db.version().unwrap(), hub_max_version());
+    let owner = load_session_owner(db.conn(), "s1").unwrap().unwrap();
+    assert_eq!(owner.user_id.as_deref(), Some("user-abc"), "owner survived");
+    assert_eq!(owner.chat_kind, None, "pre-v23 row backfills to NULL");
+    assert_eq!(owner.chat_id, None);
+    assert_eq!(owner.parent_session_id, None);
+
+    // A fresh bind with the new axes round-trips on the migrated DB.
+    let dm = SessionOwner {
+        account_id: Some("default".into()),
+        channel: Some("telegram".into()),
+        user_id: None,
+        chat_kind: Some("dm".into()),
+        chat_id: Some("chat-9".into()),
+        parent_session_id: None,
+    };
+    ensure_session_with_owner(db.conn(), "s2", &dm, 2).unwrap();
+    assert_eq!(load_session_owner(db.conn(), "s2").unwrap(), Some(dm));
 }
 
 #[test]

--- a/rust-core/crates/friday-storage/tests/migration.rs
+++ b/rust-core/crates/friday-storage/tests/migration.rs
@@ -279,8 +279,13 @@ fn forward_migration_v22_to_v23_backfills_conversation_axes_to_null() {
     assert_eq!(owner.chat_kind, None, "pre-v23 row backfills to NULL");
     assert_eq!(owner.chat_id, None);
     assert_eq!(owner.parent_session_id, None);
+    assert_eq!(
+        owner.session_kind, None,
+        "pre-v23 row backfills `session_kind` to NULL ⇒ no fallback derivable (fail-closed)"
+    );
 
-    // A fresh bind with the new axes round-trips on the migrated DB.
+    // A fresh bind with the new axes (incl. the structural `session_kind`) round-trips on
+    // the migrated DB.
     let dm = SessionOwner {
         account_id: Some("default".into()),
         channel: Some("telegram".into()),
@@ -288,6 +293,7 @@ fn forward_migration_v22_to_v23_backfills_conversation_axes_to_null() {
         chat_kind: Some("dm".into()),
         chat_id: Some("chat-9".into()),
         parent_session_id: None,
+        session_kind: Some("conversation".into()),
     };
     ensure_session_with_owner(db.conn(), "s2", &dm, 2).unwrap();
     assert_eq!(load_session_owner(db.conn(), "s2").unwrap(), Some(dm));


### PR DESCRIPTION
## What

Closes the two recorded session-memory/D1 parity residuals (coordinator lane **owner-wiring**, dispatched off `25249f68`, rebased onto S9 `3efcdcee`):

### 1. `run_session_loop` owner-wiring (the #587 parity for the sessioned path)
- A **Finished** sessioned run now persists its answer Hub-side (`persist_run_result`) with `owner_principal = policy.principal_id()` — the same D1 owner-wiring `run_task` got in #587 — so `get_run_answer_for_principal` releases a sessioned run's body **only** to the bound owner. No bound principal ⇒ no owner recorded ⇒ body unreadable by everyone (fail-closed, unchanged for ownerless rows). Persist happens **only on Finished**: `Paused` leaves the `run_result` slot to the resume completion leg (collision discipline mirrors `run_task`).
- New `session_owner: Option<&SessionOwner>` parameter: `Some` binds the session's owner axes at creation via `ensure_session_with_owner` (idempotent, COALESCE non-clobber — a later owner-less run never erases a bound owner), making loop-created sessions' memory namespace **resolvable** for the Rust inline extraction. `None` keeps the owner-less `ensure_session` path bit-for-bit (fail-closed extraction unchanged).

### 2. DM-chatId + subagent parent-walk userId fallbacks (TS `resolveEffectiveUserId` port)
- `session_namespace::resolve_effective_user_id`: direct `user_id` → DM fallback (non-subagent conversation with `chat_kind == "dm"` resolves to its `chat_id`) → subagent parent-walk (`parent_session_id` chain to the nearest ancestor `user_id`, or a conversation-DM ancestor's `chat_id`). **Deterministic**; **cycle-safe** (visited set, like the TS); **fail-closed** on every underivable shape (missing chat_id, non-dm/unknown kind, dangling parent, exhausted/cyclic chain — never a guessed/default scope). A lookup **storage error propagates** (never swallowed as "no parent").
- `extract_inline` now derives its namespace user through this resolver; account/channel stay the session's **own** axes even when the userId came from a parent (faithful to the TS).
- **Honest mapping note** (representation, not semantics): TS derives kind/parent from the structured session key; the Rust `agent_session_id` is opaque, so the axes are explicit v23 columns — `parent_session_id IS NOT NULL` ⇔ TS `kind == "subagent"`, and the link is the TS `session.parentSessionKey` leg of its `?? parts.parentKey` (no key-embedded parent to fall back to → missing link ends the walk fail-closed).

### Storage (strictly additive)
- v23 migration `agent_session_conversation_axes`: nullable `chat_kind` (CHECK-bound to the exact TS vocabulary `dm|group|channel|thread`), `chat_id`, `parent_session_id` on the Hub-only `agent_session`. Pre-v23 rows read back NULL ⇒ no fallback derivable ⇒ exactly as fail-closed as before.
- `SessionOwner` extended with the three axes; `ensure_session_with_owner`/`load_session_owner` carry them (blank→NULL + COALESCE non-clobber semantics preserved).

## Tests (all new behavior adversarially covered)
- Sessioned run, bound principal: owner **Granted** the body; non-owner **Denied(PrincipalMismatch)**; anonymous (`""`/`public`/`public:default`) **Denied(AnonymousCaller)**; refs-only projection still body-free.
- Sessioned run, no principal: result persisted **ownerless** → **Denied(NoOwnerPrincipal)** for every caller (ownerless rows stay fail-closed).
- Paused sessioned run persists **no** run_result (resume-leg collision discipline).
- Owner binding: `Some(owner)` → owned session, namespace resolves; owner-less re-run doesn't clobber; `None` → unowned session, namespace unresolvable (unchanged).
- Resolver units: direct-wins (no lookup), JS-falsy empty user_id, DM exact-kind only (group/channel/thread/unknown → None), DM without chat_id → None, one-hop + multi-hop parent walk, DM-conversation ancestor, subagent's own DM axes never used, dangling/exhausted/cyclic/self-cycle chains fail closed, lookup error propagates.
- Extraction e2e: DM-derived namespace (chat_id user segment, session's own channel), subagent-derived (parent user, child account/channel), underivable (group / dangling parent) fails closed **before any provider call** (panic transport), messages stay pending.
- Migration: v22→v23 forward backfills NULL (no silent DM attribution for legacy rows); fresh bind round-trips; chat_kind CHECK rejects out-of-vocabulary values.
- No regression: full workspace suite **1133 passed / 0 failed** on the rebased head.

## Gates
- `cargo test --workspace`: 1133 passed, 0 failed
- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo fmt --check`: clean
- `detect-secrets-hook` on all changed files: clean

## Truth labels (HONEST)
This is **parity wiring inside the Rust loop** — dev-bridge/test-provable (`run_session_loop` has no production callers; the recon's premise correction stands). It does **NOT** flip any TS-retirement state, does **NOT** make the live product extract via Rust, and is **NOT** a v1 GO. The TS extraction path **stays LIVE** (queue/auto machine remains operator-gated). Schema change is strictly additive (v23, nullable columns only).

Known adjacent gap (out of lane scope, surfaced for the coordinator): the resume completion leg (`resume.rs` `persist_run_result` for `mutation_completed`/`mutation_exec_failed`) still records **no** `owner_principal` even though `pending.principal_id` is available there — same one-line shape as this fix if a follow-on wants it. **→ NOW CLOSED in the review-fix commit below (MED-2).**

---

## Adversarial-review fixes (`ec9760bb` — closes the review's 2 MED + LOW-a before merge)

Review found 0 HIGH, 2 MED + 3 LOW. No degradation / no fallback-faking — each fix either closes a mis-attribution window or lets an owner read their OWN body; fail-closed direction unchanged. Faithfulness preserved on all prior cases (conversation/subagent results unchanged; only the contradictory shape flipped to fail-closed).

| Finding | Severity | Fix |
|---|---|---|
| **Subagent classification diverged from the TS oracle** — Rust inferred subagent-ness from `parent_session_id IS NOT NULL`; TS derives it structurally from the session key (`parts.kind`). A `{user_id:None, chat_kind:"dm", chat_id:"C", parent_session_id:None}` row that is semantically a subagent took the DM-chatId leg → returned "C" (cross-user mis-attribution) where TS walks to ancestor userId "U". | MED-1 | **Structural** (not contract): added an explicit `session_kind` discriminant to `SessionOwner` — the faithful carrier of the TS `parts.kind`. v23 column **amended in place** (no v24) with a vocabulary CHECK `('conversation'\|'subagent')`. DM-chatId fallback now gated on `kind=="conversation"` (TS line 94); parent-walk on `kind=="subagent"` (TS line 99); ancestor-DM check uses the parent's explicit kind. `None`/unknown ⇒ NEITHER fallback (fail-closed by construction): the contradictory shape takes the walk leg and, with a null chain pointer, fails closed — **never DM-attributes**. New test `effective_user_subagent_kind_with_null_parent_and_dm_axes_fails_closed_not_dm` (the exact missing test) + sibling positive control (walks to ancestor with a parent link). |
| **Resume completion leg persisted `run_result` WITHOUT `owner_principal`** — the resumed mutation body was unreadable by the legitimate owner (`NoOwnerPrincipal` over-deny). | MED-2 | Thread `pending.principal_id` into both `persist_run_result` calls via a `with_owner` helper (mirrors the lib.rs Finished leg + #587 `run_task` pattern). **`resume.rs` IS the `run_task` resume path** (runtime.rs only persists the already-owned Finished leg), so this also closes the identical #587 gap. New tests: bound paused run → resume → body **Granted** to owner, **Denied** to others; unbound → ownerless/fail-closed. |
| **"`session_owner: None` == bit-identical" overclaim** — the Finished-persist writes an ownerless row even for `None`, which the pre-PR loop did not. | LOW-a | Scoped the "bit-identical" doc to the ensure/owner-axis path; documented + **asserted** the row is written, ownerless, and `Denied(NoOwnerPrincipal)` to everyone (fail-closed/leakless). |
| **DM-chatId fallback contract dependencies** (b)(c) | LOW | **Decomposed honestly — NOT "subsumed".** MED-1 closed the *kind-inference* fragility (structural). The *chat_id-VALUE* contract is untouched: the resolver still returns the raw `chat_id` column, while TS's `buildFridayDmSessionKey` collapses a DM's chatId→userId. This remains a documented dark-producer acceptance criterion — **non-divergent in the reachable path, fail-closed in direction** (a wrong/missing chat_id mis-attributes *within-session* at worst, never cross-owner). See carry-forward. |

### STOP-condition was NOT hit (shipped the structural version, not the contract-only one)
Verified every `SessionOwner {…}` construction site is a test (the sole producer, `run_session_loop`, is dark — all callers are in `#[cfg(test)]`). The new `session_kind` field defaults to `None` (fail-closed) with **no non-dark producer change required**, so MED-1 is closed structurally rather than by a producer contract.

### Carry-forward (explicit acceptance criteria for the eventual producer-wiring slice)
When a live producer populates these axes it MUST: (1) set `session_kind` faithfully to the TS `parseFridaySessionKey(key).kind`, **and** (2) store the TS-**collapsed** (user-bound) `chat_id` for a DM — both as acceptance criteria. (2) is the residual value-contract from LOW (b)/(c).

### Re-run gates (on `ec9760bb`)
- `cargo test --workspace` green incl. the two new discriminator tests (storage 62 lib + migration; hub 430 lib + s6d now 11). `--test-threads=1` full workspace: 83 result-groups OK, 0 failed.
- `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt --check` clean; `detect-secrets-hook` + `check-provider-key-patterns.mjs` clean on changed files (no new key literals).
- **Pre-existing flake (NOT a regression, untouched crate):** multi-threaded `cargo test --workspace` can red on `friday-providers::codex_appserver::tests::schema_drift_missing_thread_turn_methods_fails_closed` — a temp-dir parallelism race in `friday-providers` (byte-for-byte unchanged in this diff). Passes single-threaded and on retry. Triage a red there as the known flake, do not attribute it to this lane.
- Minor honest note: `with_owner` adds a `!p.is_empty()` guard the lib.rs Finished pattern lacks — strictly safer (empty principal → ownerless; the read side coalesces empty→`NoOwnerPrincipal` anyway, so behavior is identical), kept deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
