### PR TITLE
fix(ts-retirement): method-level fail-closed guards on 4 live non-route-reachable surfaces (TS-R1)

### DIFF
--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -1662,6 +1662,10 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
     db: deps.db,
     idGenerator: deps.idGenerator,
     nowIso: deps.nowIso,
+    // METHOD-level retirement guard: plumb the same test-oracle flag the route
+    // honors so `deployDraft` fails closed for every non-route caller unless
+    // explicitly enabled. Production leaves this unset.
+    allowTestOnlyWorkflowDeployExecution: deps.allowTestOnlyWorkflowDeployExecution,
   });
   const deepLinkApplyService = createFridayDeepLinkApplyService({
     idGenerator: deps.idGenerator,
@@ -1891,6 +1895,12 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
     nowIso: deps.nowIso,
     policyService: autonomyPolicyService,
     capabilitySnapshotGetter: deps.capabilitySnapshotGetter,
+    // METHOD-level retirement guard: plumb the same test-oracle flag the route
+    // honors so the shared service instance (also wired into the agent
+    // controlled-autonomy tool's acquisition_* actions and the standing-agenda
+    // service) fails closed for every non-route caller unless explicitly
+    // enabled. Production leaves this unset.
+    allowTestOnlyCapabilityAcquisitionExecution: deps.allowTestOnlyCapabilityAcquisitionExecution,
   });
   const standingAgendaService = createFridayStandingAgendaService({
     db: deps.db,

--- a/src/autonomy/services/friday-capability-acquisition-service.ts
+++ b/src/autonomy/services/friday-capability-acquisition-service.ts
@@ -34,6 +34,14 @@ export interface CreateFridayCapabilityAcquisitionServiceDeps {
   policyService: FridayAutonomyPolicyService;
   capabilitySnapshotGetter?: (input: { readOnly: boolean }) =>
     Promise<FridayAgentCapabilitiesSnapshot> | FridayAgentCapabilitiesSnapshot;
+  /**
+   * Test-oracle only: allows legacy TypeScript capability-acquisition run
+   * mutations (`startRun`/`approveRun`/`cancelRun`) in isolated test/validation
+   * harnesses. Default/live runtime must leave this unset so the methods fail
+   * closed for ALL callers — including the agent controlled-autonomy tool and
+   * the standing-agenda service, which bypass the HTTP route guard.
+   */
+  allowTestOnlyCapabilityAcquisitionExecution?: boolean;
 }
 
 export interface FridayCapabilityAcquisitionService {
@@ -77,6 +85,33 @@ export function createFridayCapabilityAcquisitionService(
 ): FridayCapabilityAcquisitionService {
   const { db, idGenerator, nowIso, policyService } = deps;
 
+  // ─── TS Runtime Retirement: METHOD-level fail-closed guard ───
+  // Phase 3 (route-only-guard defect): the capability-acquisition retirement
+  // was ROUTE-only (friday-autonomy-routes asserts the test-oracle flag before
+  // the acquisition routes). The agent controlled-autonomy tool
+  // (`acquisition_start`/`acquisition_approve`/`acquisition_cancel`) and the
+  // standing-agenda service (`runAgendaItem` → `acquisitionService.startRun`)
+  // reach these methods directly, bypassing the HTTP route guard. Guarding here
+  // fails ALL non-route callers closed BEFORE any run-row write, capability
+  // probe, or verification side effect — unless the explicit test-oracle flag
+  // is set. Never default this flag on in production. Reads (`plan`/`getRun`)
+  // stay live; only run mutations are retired, mirroring the route surface.
+  function assertCapabilityAcquisitionExecutionAllowed(): void {
+    if (deps.allowTestOnlyCapabilityAcquisitionExecution !== true) {
+      throw new FridayDomainError(
+        "TS_RUNTIME_CAPABILITY_ACQUISITION_RETIRED",
+        "TypeScript capability-acquisition execution is fail-closed in default/live runtime; use the Rust-owned capability_acquisition entrypoint.",
+        {
+          httpStatus: 503,
+          details: {
+            classification: "fail_closed",
+            replacement: "rust_owned_capability_acquisition_entrypoint_required",
+          },
+        },
+      );
+    }
+  }
+
   async function resolveMatrix(readOnly: boolean): Promise<FridayRuntimeCapabilityMatrix> {
     if (!deps.capabilitySnapshotGetter) {
       return buildFridayRuntimeCapabilityMatrix({
@@ -116,6 +151,7 @@ export function createFridayCapabilityAcquisitionService(
   }
 
   async function startRun(input: FridayStartCapabilityAcquisitionInput): Promise<FridayCapabilityAcquisitionRun> {
+    assertCapabilityAcquisitionExecutionAllowed();
     const policy = policyService.getPolicy();
     const matrix = await resolveMatrix(input.readOnly ?? false);
     const run = buildRun({
@@ -142,6 +178,7 @@ export function createFridayCapabilityAcquisitionService(
   }
 
   async function approveRun(runId: string): Promise<FridayCapabilityAcquisitionRun> {
+    assertCapabilityAcquisitionExecutionAllowed();
     const current = getRun(runId);
     if (!current) {
       throw new FridayDomainError("CAPABILITY_ACQUISITION_RUN_NOT_FOUND", "Capability acquisition run not found", {
@@ -279,6 +316,7 @@ export function createFridayCapabilityAcquisitionService(
   }
 
   function cancelRun(runId: string): FridayCapabilityAcquisitionRun {
+    assertCapabilityAcquisitionExecutionAllowed();
     const current = getRun(runId);
     if (!current) {
       throw new FridayDomainError("CAPABILITY_ACQUISITION_RUN_NOT_FOUND", "Capability acquisition run not found", {

--- a/src/autonomy/services/friday-standing-agenda-service.ts
+++ b/src/autonomy/services/friday-standing-agenda-service.ts
@@ -206,6 +206,36 @@ export function createFridayStandingAgendaService(
     };
     saveAgendaItem(running);
 
+    // ─── TS Runtime Retirement: terminal-state on throw ───
+    // The item is persisted as `running` BEFORE the capability-acquisition
+    // startRun call below. startRun is now method-guarded and fail-closes (503
+    // TS_RUNTIME_CAPABILITY_ACQUISITION_RETIRED) in default/live runtime; without
+    // this guard the item would be committed stuck at `running` forever (no
+    // terminal transition, no agenda-run record). Any throw from the run body
+    // (the retirement guard, or a pre-existing startRun/persist failure) must
+    // move the item OUT of `running` to the terminal `failed` status so the
+    // friday_agenda_items row is never left poisoned. The retirement semantics
+    // are NOT swallowed — the original error is re-thrown so the agent
+    // controlled-autonomy tool's outer try/catch surfaces it as a tool error.
+    try {
+      return await runAgendaItemBody({ item, running, input, startedAt });
+    } catch (error) {
+      saveAgendaItem({
+        ...running,
+        status: "failed",
+        updatedAt: nowIso(),
+      });
+      throw error;
+    }
+  }
+
+  async function runAgendaItemBody(args: {
+    item: FridayAgendaItem;
+    running: FridayAgendaItem;
+    input: { agendaItemId: string; userId: string };
+    startedAt: string;
+  }): Promise<FridayAgendaRun> {
+    const { item, running, input, startedAt } = args;
     const capabilityCheck = await acquisitionService.startRun({
       userId: input.userId,
       goal: `${item.title}\n${item.summary}`,

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -1906,6 +1906,8 @@ export interface FridayHubConfig {
   allowTestOnlyProviderProbeExecution?: boolean;
   /** Test-oracle only; production hub creation must leave the provider routing-controls surfaces (routing.pin/routing.penalty.clear) fail-closed. */
   allowTestOnlyProviderRoutingControlsExecution?: boolean;
+  /** Test-oracle only; production hub creation must leave the system-service `executeIntent` method fail-closed. */
+  allowTestOnlySystemIntentExecution?: boolean;
   /**
    * execrun-replacement slice 4 (DARK): per-run "route a qualifying agent-run via the
    * future Rust read-only loop" flag. DEFAULT-FALSE — production hub creation must leave

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -2137,6 +2137,12 @@ export async function createFridayHub(
 	      canonicalMutationGate: canonicalMutatingActionGateEnabled,
 	      canonicalApprovalSecret: tokenSecret,
 	      cloudPlanningMode: systemCloudPlanningMode,
+      // TS Runtime Retirement (§1 method-level guard): production leaves this
+      // unset (config flag undefined) so the `executeIntent` method is
+      // fail-closed for the agent system tool path, not just the HTTP route
+      // (whose own flag is never threaded in hub bootstrap). Test-oracle hub
+      // configs set it true to exercise legacy intent execution.
+      allowTestOnlySystemIntentExecution: config.allowTestOnlySystemIntentExecution,
       remoteAuth: {
         rpName: systemRemoteAuthRpName,
         rpId: systemRemoteAuthRpId,
@@ -4143,6 +4149,12 @@ export async function createFridayHub(
     nowIso,
     computeChecksum,
     userRulesContextProvider: buildWorkflowGeneratorPromptContext,
+    // TS Runtime Retirement (§1 method-level guard): production leaves this
+    // unset (config flag undefined) so startSession/generateDraft/approveAndSave
+    // are fail-closed for the agent tool, UIX assistant, and reflex candidate
+    // paths, not just the HTTP routes. Test-oracle hub configs set it true to
+    // exercise legacy generation.
+    allowTestOnlyWorkflowGeneratorExecution: config.allowTestOnlyWorkflowGeneratorExecution,
   });
 
   // ─── Tool approval gates (GAP 2) ───
@@ -5885,6 +5897,12 @@ export async function createFridayHub(
     db: stateRuntime.sqlite,
     idGenerator,
     nowIso,
+    // TS Runtime Retirement (§1 method-level guard): production leaves this
+    // unset (config flag undefined) so the `deployDraft` method is fail-closed
+    // for the UIX deploy-workflow card and cross-border pack paths (this hub
+    // instance is the one wired into both), not just the HTTP route.
+    // Test-oracle hub configs set it true to exercise legacy deployment.
+    allowTestOnlyWorkflowDeployExecution: config.allowTestOnlyWorkflowDeployExecution,
   });
 
   const enrichAgentRunForUi = (run: FridayAgentRunRecord): FridayAgentRunRecord => {

--- a/src/system/engine/friday-system-service.ts
+++ b/src/system/engine/friday-system-service.ts
@@ -182,6 +182,13 @@ export interface CreateFridaySystemServiceDeps {
     challengeTtlMs?: number;
     assertionTtlMs?: number;
   };
+  /**
+   * Test-oracle only: allows legacy TypeScript system intent execution
+   * (`executeIntent`) in isolated test/validation harnesses. Default/live
+   * runtime must leave this unset so the method fails closed for ALL callers —
+   * including the agent system tool, which bypasses the HTTP route guard.
+   */
+  allowTestOnlySystemIntentExecution?: boolean;
 }
 
 export type FridaySystemEventListener = (event: FridaySystemEvent) => void;
@@ -2400,9 +2407,36 @@ export async function createFridaySystemService(
       }
     };
 
+  // ─── TS Runtime Retirement: METHOD-level fail-closed guard ───
+  // Phase 3 (route-only-guard defect): the system-intent retirement was
+  // ROUTE-only (friday-system-routes asserts the test-oracle flag before
+  // POST /v1/system/intents). The agent system tool reaches this method
+  // directly via `systemService.executeIntent(...)`, bypassing the HTTP route
+  // guard, so an agent run could drive desktop/system intents in prod.
+  // Guarding here fails ALL non-route callers closed BEFORE any approval-rule
+  // read, lease mutation, companion call, or exec side effect — unless the
+  // explicit test-oracle flag is set. Never default this flag on in
+  // production. Reads (getSession/getState/listEvents/...) stay live; only
+  // intent execution is retired, mirroring the route surface.
   const executeIntent = async (
     input: FridaySystemIntentInput,
-  ): Promise<FridaySystemIntentResult> => executeIntentInternal(input);
+  ): Promise<FridaySystemIntentResult> => {
+    if (deps.allowTestOnlySystemIntentExecution !== true) {
+      void input;
+      throw new FridayDomainError(
+        "TS_RUNTIME_SYSTEM_INTENT_RETIRED",
+        "TypeScript system intent execution is fail-closed in default/live runtime; use the Rust-owned system_intent_execution entrypoint.",
+        {
+          httpStatus: 503,
+          details: {
+            classification: "fail_closed",
+            replacement: "rust_owned_system_intent_execution_entrypoint_required",
+          },
+        },
+      );
+    }
+    return executeIntentInternal(input);
+  };
 
   return {
     getSession,

--- a/src/workflows/generator/services/friday-workflow-generator-service.ts
+++ b/src/workflows/generator/services/friday-workflow-generator-service.ts
@@ -427,6 +427,39 @@ function normalizeGeneratedSpec(spec: FridayWorkflowSpecV1): FridayWorkflowSpecV
 export function createFridayWorkflowGeneratorService(
   deps: CreateFridayWorkflowGeneratorServiceDeps,
 ): FridayWorkflowGeneratorService {
+  // ─── TS Runtime Retirement: METHOD-level fail-closed guard ───
+  // Phase 3 (route-only-guard defect): the workflow-generator retirement was
+  // ROUTE-only (friday-workflow-generator-routes asserts the test-oracle flag
+  // before EVERY handler — the route surface retires the WHOLE session
+  // lifecycle). The agent workflow-generator tool (start/turn/generate/approve/
+  // cancel actions), the UIX assistant surface (`startWorkflowSession`/
+  // `continueWorkflowSession`), and the reflex candidate pipeline
+  // (`generateWorkflowDraft`/`approveGeneratedCandidate`) reach these methods
+  // directly, bypassing the HTTP route guard. Guarding here fails ALL non-route
+  // callers closed BEFORE any session-row write, provider call, or workflow
+  // save — unless the explicit test-oracle flag is set. Never default this flag
+  // on in production. ALL mutating session-lifecycle methods are guarded:
+  // startSession, submitTurn (turn append + requirements-analyzer provider call
+  // + on ready_for_generation the full generation pipeline + draft persist),
+  // generateDraft, approveAndSave, and cancelSession (status flip + draft
+  // delete) — mirroring the route surface exactly. Reads
+  // (`getSession`/`getQaVerdict`/`getHarnessSummary`) stay live.
+  function assertWorkflowGeneratorExecutionAllowed(): void {
+    if (deps.allowTestOnlyWorkflowGeneratorExecution !== true) {
+      throw new FridayDomainError(
+        "TS_RUNTIME_WORKFLOW_GENERATOR_RETIRED",
+        "TypeScript workflow generator sessions are retired in default/live runtime; use the Rust-owned workflow generator entrypoint.",
+        {
+          httpStatus: 503,
+          details: {
+            classification: "fail_closed",
+            replacement: "rust_owned_workflow_generator_entrypoint_required",
+          },
+        },
+      );
+    }
+  }
+
   const repo: FridayWorkflowGenerationSessionRepository =
     createFridayWorkflowGenerationSessionRepository({
       db: deps.db,
@@ -1344,6 +1377,7 @@ export function createFridayWorkflowGeneratorService(
     async startSession(
       input: FridayStartWorkflowGenerationRequest,
     ): Promise<FridayWorkflowGenerationTurnResponse> {
+      assertWorkflowGeneratorExecutionAllowed();
       const now = deps.nowIso();
       const sessionId = deps.idGenerator();
       const maintenanceTarget = input.targetWorkflowId
@@ -1465,6 +1499,7 @@ export function createFridayWorkflowGeneratorService(
       sessionId: string,
       input: FridayWorkflowGenerationTurnRequest,
     ): Promise<FridayWorkflowGenerationTurnResponse> {
+      assertWorkflowGeneratorExecutionAllowed();
       const session = requireSession(sessionId);
 
       if (
@@ -1596,6 +1631,7 @@ export function createFridayWorkflowGeneratorService(
       sessionId: string,
       requestedModel?: string,
     ): Promise<FridayGeneratedWorkflowDraft> {
+      assertWorkflowGeneratorExecutionAllowed();
       const session = requireSession(sessionId);
 
       if (
@@ -1686,6 +1722,7 @@ export function createFridayWorkflowGeneratorService(
     },
 
     async approveAndSave(sessionId: string) {
+      assertWorkflowGeneratorExecutionAllowed();
       const session = requireSession(sessionId);
 
       if (session.status !== "ready_for_review") {
@@ -1808,6 +1845,7 @@ export function createFridayWorkflowGeneratorService(
     },
 
     async cancelSession(sessionId: string): Promise<void> {
+      assertWorkflowGeneratorExecutionAllowed();
       const session = requireSession(sessionId);
 
       if (session.status === "saved") {

--- a/src/workflows/generator/services/friday-workflow-generator-service.types.ts
+++ b/src/workflows/generator/services/friday-workflow-generator-service.types.ts
@@ -79,4 +79,13 @@ export interface CreateFridayWorkflowGeneratorServiceDeps {
     channel?: string;
     surface: "workflow_generator";
   }) => string | null | Promise<string | null>;
+  /**
+   * Test-oracle only: allows legacy TypeScript workflow-generator session
+   * mutations (`startSession`/`submitTurn`/`generateDraft`/`approveAndSave`/
+   * `cancelSession`) in isolated test/validation harnesses. Default/live runtime
+   * must leave this unset so the methods fail closed for ALL callers — including
+   * the agent workflow-generator tool, the UIX assistant surface, and the reflex
+   * candidate pipeline, which bypass the HTTP route guard.
+   */
+  allowTestOnlyWorkflowGeneratorExecution?: boolean;
 }

--- a/src/workflows/services/friday-workflow-product-service.ts
+++ b/src/workflows/services/friday-workflow-product-service.ts
@@ -69,6 +69,16 @@ export interface CreateFridayWorkflowProductServiceDeps {
   };
   idGenerator: () => string;
   nowIso: () => string;
+  /**
+   * Test-oracle only: allows the legacy TypeScript workflow deploy mutations
+   * (`deployDraft` and `materializeGeneratedSession`, which persists a workflow/
+   * draft as the deploy-preparation step) in isolated test/validation harnesses.
+   * Default/live runtime must leave this unset so the methods fail closed for
+   * ALL callers — including the UIX deploy-workflow card, the UIX assistant
+   * create/continue/generate-workflow flows, and the cross-border pack service,
+   * which bypass the HTTP route guard.
+   */
+  allowTestOnlyWorkflowDeployExecution?: boolean;
 }
 
 function sortDraftsByUpdatedAtDescending(
@@ -393,6 +403,32 @@ export function createFridayWorkflowProductService(
 
   return {
     async materializeGeneratedSession(input) {
+      // ─── TS Runtime Retirement: METHOD-level fail-closed guard ───
+      // materializeGeneratedSession is NOT a read: in the draft-present branch
+      // it persists a NEW workflow row (deps.workflowRuntime.crud.createWorkflow)
+      // and a draft (createDraftFromVisualization), and in the restore branch it
+      // persists a draft from a saved-approval/session record — both DB writes.
+      // It has no HTTP route; its only callers are the UIX assistant
+      // create/continue/generate-workflow flows (startWorkflowSession /
+      // continueWorkflowSession / the `generate-workflow` action), which are part
+      // of the retired generation+deploy lifecycle and bypass the HTTP route
+      // guard. Guarding here with the SAME deploy test-oracle flag fails ALL
+      // these non-route callers closed BEFORE any workflow/draft persist unless
+      // the flag is explicitly set. Never default this flag on in production.
+      if (deps.allowTestOnlyWorkflowDeployExecution !== true) {
+        void input;
+        throw new FridayDomainError(
+          "TS_RUNTIME_WORKFLOW_DEPLOY_RETIRED",
+          "TypeScript workflow deploy execution is retired in default/live runtime; use the Rust-owned workflow deployment entrypoint.",
+          {
+            httpStatus: 503,
+            details: {
+              classification: "fail_closed",
+              replacement: "rust_owned_workflow_deployment_entrypoint_required",
+            },
+          },
+        );
+      }
       if (!deps.workflowGenerator) {
         throw new FridayDomainError(
           "WORKFLOW_GENERATOR_UNAVAILABLE",
@@ -485,6 +521,33 @@ export function createFridayWorkflowProductService(
     },
 
     async deployDraft(input) {
+      // ─── TS Runtime Retirement: METHOD-level fail-closed guard ───
+      // Phase 3 (route-only-guard defect): the workflow-deploy retirement was
+      // ROUTE-only (friday-workflow-product-routes asserts the test-oracle
+      // flag before POST .../deploy). The UIX deploy-workflow card
+      // (`deployWorkflowCard`) and the cross-border pack service
+      // (`enableWorkflow` preset deployment) reach this method directly,
+      // bypassing the HTTP route guard. Guarding here fails ALL non-route
+      // callers closed BEFORE any lock acquisition, draft compile, publish,
+      // trigger resync, or run start — unless the explicit test-oracle flag is
+      // set. Never default this flag on in production. Reads
+      // (getOverview/getVisualization) stay live. NOTE:
+      // materializeGeneratedSession is NOT a read — it persists a workflow/draft
+      // and is guarded with this SAME deploy flag at its own method head.
+      if (deps.allowTestOnlyWorkflowDeployExecution !== true) {
+        void input;
+        throw new FridayDomainError(
+          "TS_RUNTIME_WORKFLOW_DEPLOY_RETIRED",
+          "TypeScript workflow deploy execution is retired in default/live runtime; use the Rust-owned workflow deployment entrypoint.",
+          {
+            httpStatus: 503,
+            details: {
+              classification: "fail_closed",
+              replacement: "rust_owned_workflow_deployment_entrypoint_required",
+            },
+          },
+        );
+      }
       const workflow = getWorkflowOrThrow(input.workflowId);
       const draft = getDraftOrThrow(input.workflowId, input.draftId);
       let acquiredLockToken: string | undefined;

--- a/test/e2e/live/_helpers/real-env.ts
+++ b/test/e2e/live/_helpers/real-env.ts
@@ -333,6 +333,12 @@ async function startLocalRealHubEnv(
       allowTestOnlyProviderDetectExecution: true,
       allowTestOnlyProviderProbeExecution: true,
       allowTestOnlyProviderRoutingControlsExecution: true,
+      // Method-level retirement guards (TS-R1): the real-env harness opts in so
+      // live e2e can exercise the legacy in-process generator/deploy/system
+      // paths; production leaves these unset (fail-closed).
+      allowTestOnlyWorkflowGeneratorExecution: true,
+      allowTestOnlyWorkflowDeployExecution: true,
+      allowTestOnlySystemIntentExecution: true,
       ...opts?.hubConfig,
     });
     await createdHub.start();

--- a/test/e2e/mock/_helpers/mock-env.ts
+++ b/test/e2e/mock/_helpers/mock-env.ts
@@ -369,6 +369,10 @@ export async function createMockHubEnv(opts?: {
   allowTestOnlyProviderProbeExecution?: boolean;
   /** Test-oracle opt-in for the legacy TS provider routing-controls surfaces (routing.pin/routing.penalty.clear); set false to prove default fail-closed behavior. */
   allowTestOnlyProviderRoutingControlsExecution?: boolean;
+  /** Test-oracle opt-in for legacy TS capability-acquisition run mutations; set false to prove default fail-closed behavior. */
+  allowTestOnlyCapabilityAcquisitionExecution?: boolean;
+  /** Test-oracle opt-in for the legacy TS system-service `executeIntent` method; set false to prove default fail-closed behavior. */
+  allowTestOnlySystemIntentExecution?: boolean;
   /**
    * execrun-replacement slice 4 (DARK): per-run Rust-route flag. DEFAULT-FALSE here (honest
    * dark) — the predicate is unconsumed this slice so the value is cosmetic; the ui browser
@@ -438,6 +442,8 @@ export async function createMockHubEnv(opts?: {
       allowTestOnlyProviderDetectExecution: opts?.allowTestOnlyProviderDetectExecution ?? true,
       allowTestOnlyProviderProbeExecution: opts?.allowTestOnlyProviderProbeExecution ?? true,
       allowTestOnlyProviderRoutingControlsExecution: opts?.allowTestOnlyProviderRoutingControlsExecution ?? true,
+      allowTestOnlyCapabilityAcquisitionExecution: opts?.allowTestOnlyCapabilityAcquisitionExecution ?? true,
+      allowTestOnlySystemIntentExecution: opts?.allowTestOnlySystemIntentExecution ?? true,
       // execrun-replacement slice 4 (DARK): default-FALSE (honest dark), unlike the
       // allowTestOnly* flags which default true. The predicate is unconsumed this slice.
       routeAgentRunViaRust: opts?.routeAgentRunViaRust ?? false,

--- a/test/unit/agent/runtime/friday-agent-runtime.test.ts
+++ b/test/unit/agent/runtime/friday-agent-runtime.test.ts
@@ -4599,6 +4599,9 @@ describe("FridayAgentRuntime", () => {
       canonicalApprovalSecret: "test-canonical-secret", // pragma: allowlist secret
       companionReconnectIntervalMs: 60_000,
       warn: vi.fn(),
+      // Test-oracle opt-in: this test drives the real `executeIntent` through
+      // the agent system tool; the method is fail-closed by default (TS-R1).
+      allowTestOnlySystemIntentExecution: true,
     });
     const llmClient = createMockLlmClient([
       [

--- a/test/unit/autonomy/friday-capability-acquisition-retirement-guard.test.ts
+++ b/test/unit/autonomy/friday-capability-acquisition-retirement-guard.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { FridaySqliteLayer } from "#state";
+import { FridayDomainError } from "#errors";
+import {
+  createFridayAutonomyPolicyService,
+  createFridayCapabilityAcquisitionService,
+  type FridayAutonomyPolicyService,
+  type FridayStandingAgendaService,
+} from "../../../src/autonomy/index.js";
+import { createFridayAgentControlledAutonomyTool } from "#agent";
+import { createTestDb, createTestIdGenerator } from "../satellites/_helpers/create-test-db.helper.js";
+
+/**
+ * TS Runtime Retirement — METHOD-level guard for capability acquisition.
+ *
+ * The capability-acquisition retirement was ROUTE-only
+ * (friday-autonomy-routes asserts `allowTestOnlyCapabilityAcquisitionExecution`
+ * before the acquisition routes). The agent controlled-autonomy tool
+ * (`acquisition_start`/`acquisition_approve`/`acquisition_cancel`) and the
+ * standing-agenda service (`runAgendaItem` → `acquisitionService.startRun`)
+ * reach the service methods directly, bypassing the route guard.
+ *
+ * These tests prove the guard now lives on the METHODS: in default/live config
+ * (test-oracle flag unset) `startRun`/`approveRun`/`cancelRun` fail closed
+ * BEFORE any run-row write. With the explicit test-oracle flag enabled the
+ * legacy paths still work. Reads (`plan`/`getRun`) stay live, mirroring the
+ * route surface (which asserts only on the run-mutation routes).
+ */
+
+const RETIRED_CODE = "TS_RUNTIME_CAPABILITY_ACQUISITION_RETIRED";
+
+describe("FridayCapabilityAcquisitionService TS-retirement method guard", () => {
+  let db: FridaySqliteLayer;
+  let policyService: FridayAutonomyPolicyService;
+
+  beforeEach(() => {
+    db = createTestDb();
+    policyService = createFridayAutonomyPolicyService({
+      db,
+      nowIso: () => "2026-06-09T00:00:00.000Z",
+    });
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  function buildService(allowTestOnlyCapabilityAcquisitionExecution?: boolean) {
+    // No capabilitySnapshotGetter: the service falls back to the canonical
+    // empty runtime capability matrix, which is enough for guard placement
+    // proofs (run creation/cancellation, not capability competence).
+    return createFridayCapabilityAcquisitionService({
+      db,
+      idGenerator: createTestIdGenerator(),
+      nowIso: () => "2026-06-09T00:00:00.000Z",
+      policyService,
+      ...(allowTestOnlyCapabilityAcquisitionExecution === undefined
+        ? {}
+        : { allowTestOnlyCapabilityAcquisitionExecution }),
+    });
+  }
+
+  function countAcquisitionRunRows(): number {
+    return db.withReadConnection((reader) =>
+      (reader
+        .prepare("SELECT COUNT(*) AS c FROM friday_capability_acquisition_runs")
+        .get() as { c: number }).c,
+    );
+  }
+
+  it("startRun fails closed by default: throws 503 fail_closed and writes no run row", async () => {
+    const service = buildService();
+
+    let caught: unknown;
+    try {
+      await service.startRun({ userId: "test-user", goal: "do a thing", requiredCapabilities: ["text"] });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(FridayDomainError);
+    const domainError = caught as FridayDomainError;
+    expect(domainError.code).toBe(RETIRED_CODE);
+    expect(domainError.httpStatus).toBe(503);
+    expect(domainError.details).toMatchObject({
+      classification: "fail_closed",
+      replacement: "rust_owned_capability_acquisition_entrypoint_required",
+    });
+    expect(countAcquisitionRunRows()).toBe(0);
+  });
+
+  it("approveRun and cancelRun fail closed by default and when the flag is explicitly false", async () => {
+    const defaultService = buildService();
+    await expect(defaultService.approveRun("run-1")).rejects.toMatchObject({
+      code: RETIRED_CODE,
+      httpStatus: 503,
+    });
+
+    let cancelCaught: unknown;
+    try {
+      defaultService.cancelRun("run-1");
+    } catch (error) {
+      cancelCaught = error;
+    }
+    expect(cancelCaught).toBeInstanceOf(FridayDomainError);
+    expect((cancelCaught as FridayDomainError).code).toBe(RETIRED_CODE);
+
+    const explicitlyOff = buildService(false);
+    await expect(
+      explicitlyOff.startRun({ userId: "test-user", goal: "do a thing", requiredCapabilities: ["text"] }),
+    ).rejects.toMatchObject({ code: RETIRED_CODE, httpStatus: 503 });
+    expect(countAcquisitionRunRows()).toBe(0);
+  });
+
+  it("plan and getRun stay live without the flag (reads are not retired)", async () => {
+    const service = buildService();
+    const planned = await service.plan({ userId: "test-user", goal: "do a thing", requiredCapabilities: ["text"] });
+    expect(planned.id.startsWith("plan-")).toBe(true);
+    expect(service.getRun("missing-run")).toBeNull();
+    expect(countAcquisitionRunRows()).toBe(0);
+  });
+
+  it("runs normally when the test-oracle flag is enabled (legacy path preserved)", async () => {
+    const service = buildService(true);
+    const run = await service.startRun({
+      userId: "test-user",
+      goal: "do a thing",
+      requiredCapabilities: ["text"],
+    });
+    expect(countAcquisitionRunRows()).toBe(1);
+    const cancelled = service.cancelRun(run.id);
+    expect(cancelled.status).toBe("cancelled");
+  });
+
+  it("agent controlled-autonomy tool caller observes the 503-class error as a tool error, not a crash", async () => {
+    const service = buildService();
+    const tool = createFridayAgentControlledAutonomyTool({
+      policyService,
+      acquisitionService: service,
+      standingAgendaService: {} as unknown as FridayStandingAgendaService,
+      defaultUserId: "test-user",
+    });
+
+    const result = await tool.execute(
+      { action: "acquisition_start", goal: "do a thing" },
+      new AbortController().signal,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(String(result.content)).toContain("fail-closed");
+    expect(countAcquisitionRunRows()).toBe(0);
+  });
+});

--- a/test/unit/autonomy/friday-controlled-autonomy-services.test.ts
+++ b/test/unit/autonomy/friday-controlled-autonomy-services.test.ts
@@ -31,6 +31,9 @@ describe("controlled autonomy closed loops", () => {
       nowIso,
       policyService,
       capabilitySnapshotGetter: () => ({ readOnly: false, ...emptyAgentSnapshot(), runtime: matrixWith() }),
+      // Test-oracle opt-in: these tests exercise the legacy acquisition run
+      // mutations, which are method-level fail-closed by default (TS-R1).
+      allowTestOnlyCapabilityAcquisitionExecution: true,
     });
     standingAgendaService = createFridayStandingAgendaService({
       db,
@@ -72,6 +75,7 @@ describe("controlled autonomy closed loops", () => {
       nowIso: () => `2026-04-25T00:00:${String(++nowCounter).padStart(2, "0")}.000Z`,
       policyService,
       capabilitySnapshotGetter: () => ({ readOnly: false, ...emptyAgentSnapshot(), runtime: currentMatrix }),
+      allowTestOnlyCapabilityAcquisitionExecution: true,
     });
 
     const run = await mutableService.startRun({
@@ -114,6 +118,7 @@ describe("controlled autonomy closed loops", () => {
       nowIso: () => `2026-04-25T00:00:${String(++nowCounter).padStart(2, "0")}.000Z`,
       policyService,
       capabilitySnapshotGetter: () => ({ readOnly: false, ...emptyAgentSnapshot(), runtime: currentMatrix }),
+      allowTestOnlyCapabilityAcquisitionExecution: true,
     });
 
     const run = await mutableService.startRun({
@@ -464,6 +469,53 @@ describe("controlled autonomy closed loops", () => {
     expect(run.status).toBe("blocked");
     expect(run.verification.passed).toBe(false);
     expect(run.rollback.summary).toContain("No side effects");
+  });
+
+  describe("TS-runtime retirement: agenda item reaches a terminal state (not stuck 'running') when startRun fails closed", () => {
+    it("rethrows the retirement 503 and leaves the item 'failed', never committed at 'running'", async () => {
+      // A fail-closed acquisition service (flag UNSET) — exactly the prod/live
+      // posture. runAgendaItem persists the item as 'running' BEFORE calling
+      // acquisitionService.startRun, which now throws the retirement error.
+      const failClosedAcquisition = createFridayCapabilityAcquisitionService({
+        db,
+        idGenerator: createTestIdGenerator(),
+        nowIso: () => `2026-04-26T00:00:${String(++nowCounter).padStart(2, "0")}.000Z`,
+        policyService,
+        capabilitySnapshotGetter: () => ({ readOnly: false, ...emptyAgentSnapshot(), runtime: matrixWith() }),
+        // No allowTestOnlyCapabilityAcquisitionExecution → fail-closed.
+      });
+      const agendaService = createFridayStandingAgendaService({
+        db,
+        idGenerator: createTestIdGenerator(),
+        nowIso: () => `2026-04-26T01:00:${String(++nowCounter).padStart(2, "0")}.000Z`,
+        policyService,
+        acquisitionService: failClosedAcquisition,
+      });
+
+      const { agendaItem } = await agendaService.createStandingGoal({
+        userId: "test-user",
+        objective: "每天搜索最新 AI 新闻并总结",
+        title: "AI news monitor (retired)",
+      });
+      // Low-risk item — no approval gate; runAgendaItem reaches startRun.
+      expect(agendaItem.approvalRequired).toBe(false);
+
+      // The retirement semantics are NOT swallowed — the 503 propagates.
+      await expect(
+        agendaService.runAgendaItem({ agendaItemId: agendaItem.id, userId: "test-user" }),
+      ).rejects.toMatchObject({
+        code: "TS_RUNTIME_CAPABILITY_ACQUISITION_RETIRED",
+        httpStatus: 503,
+      });
+
+      // The PERSISTED item must NOT be stuck 'running' — it reaches a terminal
+      // 'failed' state so the row is never poisoned.
+      const [persisted] = agendaService
+        .listAgenda({ userId: "test-user" })
+        .filter((item) => item.id === agendaItem.id);
+      expect(persisted?.status).toBe("failed");
+      expect(persisted?.status).not.toBe("running");
+    });
   });
 });
 

--- a/test/unit/system/friday-system-intent-retirement-guard.test.ts
+++ b/test/unit/system/friday-system-intent-retirement-guard.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { FridaySqliteLayer } from "#state";
+import { FridayDomainError } from "#errors";
+import { createFridaySystemService } from "../../../src/system/engine/friday-system-service.js";
+import type { FridaySystemService } from "../../../src/system/engine/friday-system-service.js";
+import { createFridaySystemUnavailableCompanionBridge } from "../../../src/system/companion/friday-system-local-companion-bridge.js";
+import { createFridayAgentSystemTool } from "#agent";
+import { createTestDb, createTestIdGenerator } from "../../helpers/friday-test-db.helper.js";
+
+/**
+ * TS Runtime Retirement — METHOD-level guard for system intent execution.
+ *
+ * The system-intent retirement was ROUTE-only (friday-system-routes asserts
+ * `allowTestOnlySystemIntentExecution` before POST /v1/system/intents). The
+ * agent system tool reaches `executeIntent` directly via
+ * `systemService.executeIntent(...)`, bypassing the route guard.
+ *
+ * These tests prove the guard now lives on the METHOD: in default/live config
+ * (test-oracle flag unset) `executeIntent` fails closed BEFORE any
+ * approval-rule read, lease mutation, companion call, or exec side effect —
+ * no system event is emitted. With the explicit test-oracle flag enabled the
+ * legacy path proceeds past the guard. Reads (getSession/getState/listEvents)
+ * stay live, mirroring the route surface.
+ */
+
+const RETIRED_CODE = "TS_RUNTIME_SYSTEM_INTENT_RETIRED";
+
+function createNowIso() {
+  let tick = 0;
+  const start = Date.parse("2026-06-09T00:00:00.000Z");
+  return () => new Date(start + tick++ * 1000).toISOString();
+}
+
+describe("FridaySystemService TS-retirement method guard (executeIntent)", () => {
+  const allocatedDbs: FridaySqliteLayer[] = [];
+
+  afterEach(() => {
+    while (allocatedDbs.length > 0) {
+      allocatedDbs.pop()!.close();
+    }
+  });
+
+  async function buildService(
+    allowTestOnlySystemIntentExecution?: boolean,
+  ): Promise<FridaySystemService> {
+    const db = createTestDb();
+    allocatedDbs.push(db);
+    const nowIso = createNowIso();
+    const companionBridge = createFridaySystemUnavailableCompanionBridge({
+      id: "companion-retirement-guard",
+      platform: "darwin",
+      nowIso,
+      launchAtLoginEnabled: false,
+      panicHotkey: "cmd+shift+escape",
+      menuBarEnabled: false,
+      overlayEnabled: false,
+      unavailableReason: "companion unavailable in guard test",
+    });
+    return createFridaySystemService({
+      db,
+      idGenerator: createTestIdGenerator(),
+      nowIso,
+      workspaceRoot: "/tmp/friday-system-retirement-guard-workspace",
+      companionBridge,
+      execCommand: async () => {
+        throw new Error("execCommand must not run when executeIntent is fail-closed");
+      },
+      ...(allowTestOnlySystemIntentExecution === undefined
+        ? {}
+        : { allowTestOnlySystemIntentExecution }),
+    });
+  }
+
+  it("fails closed by default: throws 503 fail_closed and emits no intent event", async () => {
+    const service = await buildService();
+    const eventsBefore = service.listEvents().length;
+
+    let caught: unknown;
+    try {
+      await service.executeIntent({
+        action: "recover_ui",
+        actorId: "agent-1",
+        actorKind: "agent",
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(FridayDomainError);
+    const domainError = caught as FridayDomainError;
+    expect(domainError.code).toBe(RETIRED_CODE);
+    expect(domainError.httpStatus).toBe(503);
+    expect(domainError.details).toMatchObject({
+      classification: "fail_closed",
+      replacement: "rust_owned_system_intent_execution_entrypoint_required",
+    });
+    const intentEvents = service
+      .listEvents()
+      .slice(eventsBefore)
+      .filter((event) => event.event.startsWith("system.intent."));
+    expect(intentEvents).toEqual([]);
+  });
+
+  it("fails closed when the flag is explicitly false (only exact `true` opts in)", async () => {
+    const service = await buildService(false);
+    await expect(
+      service.executeIntent({ action: "recover_ui", actorId: "agent-1", actorKind: "agent" }),
+    ).rejects.toMatchObject({ code: RETIRED_CODE, httpStatus: 503 });
+  });
+
+  it("reads stay live without the flag (getSession/getState/listEvents are not retired)", async () => {
+    const service = await buildService();
+    const session = await service.getSession();
+    expect(session.id).toBeTruthy();
+    const state = await service.getState();
+    expect(state).toBeTruthy();
+    expect(Array.isArray(service.listEvents())).toBe(true);
+  });
+
+  it("proceeds past the guard when the test-oracle flag is enabled (legacy execution path)", async () => {
+    const service = await buildService(true);
+
+    // The unavailable companion bridge makes recover_ui FAIL inside the legacy
+    // path — a legacy 'failed' intent result, not the retirement throw — which
+    // proves the guard no longer blocks the method.
+    const result = await service.executeIntent({
+      action: "recover_ui",
+      actorId: "agent-1",
+      actorKind: "agent",
+    });
+    expect(result.status).toBe("failed");
+    expect(result.message).toBe("companion unavailable in guard test");
+  });
+
+  it("agent system tool caller observes the 503-class error as a tool error, not a crash", async () => {
+    const service = await buildService();
+    const tool = createFridayAgentSystemTool({ systemService: service });
+
+    const result = await tool.execute(
+      { action: "recover_ui" },
+      new AbortController().signal,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(String(result.content)).toContain("fail-closed");
+  });
+});

--- a/test/unit/system/friday-system-service.test.ts
+++ b/test/unit/system/friday-system-service.test.ts
@@ -303,6 +303,9 @@ async function createServiceFixtureWithOptions(options?: {
       rpId: "localhost",
       origin: "http://localhost:3141",
     },
+    // Test-oracle opt-in: these tests exercise legacy `executeIntent`, which is
+    // method-level fail-closed by default (TS-R1).
+    allowTestOnlySystemIntentExecution: true,
   });
   return {
     db,

--- a/test/unit/uix/services/friday-uix-surface-service.test.ts
+++ b/test/unit/uix/services/friday-uix-surface-service.test.ts
@@ -801,6 +801,122 @@ describe("createFridayUixSurfaceService", () => {
     warnSpy.mockRestore();
   });
 
+  it("propagates the workflow-deploy retirement 503 from materializeGeneratedSession (generate-workflow caller path, no crash)", async () => {
+    // The method-level guard (TS-R1) makes materializeGeneratedSession fail
+    // closed in default/live runtime. The UIX generate-workflow action reaches
+    // it directly (with a caller-supplied sessionId), bypassing the HTTP route
+    // guard — this proves the UIX layer surfaces the 503 rather than crashing,
+    // and (since materialize is a no-op when fail-closed and UIX writes nothing
+    // before the call) leaves no poisoned state.
+    const retirementError = new FridayDomainError(
+      "TS_RUNTIME_WORKFLOW_DEPLOY_RETIRED",
+      "TypeScript workflow deploy execution is retired in default/live runtime; use the Rust-owned workflow deployment entrypoint.",
+      {
+        httpStatus: 503,
+        details: {
+          classification: "fail_closed",
+          replacement: "rust_owned_workflow_deployment_entrypoint_required",
+        },
+      },
+    );
+    const materializeGeneratedSession = vi.fn(async () => {
+      throw retirementError;
+    });
+    const service = createFridayUixSurfaceService({
+      idGenerator: () => "assistant-retire-1",
+      selfHealing: {
+        reportStructuredFailure: vi.fn(),
+        listIssueCards: vi.fn(() => []),
+      } as never,
+      workflowProduct: { materializeGeneratedSession } as never,
+    });
+
+    await expect(
+      service.executeTemplate({
+        templateId: "generate-workflow",
+        userId: "user-1",
+        parameters: { sessionId: "pre-deploy-persisted-session" },
+      }),
+    ).rejects.toMatchObject({
+      code: "TS_RUNTIME_WORKFLOW_DEPLOY_RETIRED",
+      httpStatus: 503,
+    } satisfies Partial<FridayDomainError>);
+
+    expect(materializeGeneratedSession).toHaveBeenCalledWith({
+      sessionId: "pre-deploy-persisted-session",
+      actorUserId: "user-1",
+    });
+  });
+
+  it("propagates the workflow-generator retirement 503 from submitTurn (continueWizard caller path, no crash)", async () => {
+    // The continueWizard clarification step reaches continueWorkflowSession ->
+    // workflowGenerator.submitTurn, which is now method-guarded. Proves the UIX
+    // wizard surface propagates the 503 instead of crashing, and never reaches
+    // the downstream materialize since submitTurn fail-closes first.
+    const retirementError = new FridayDomainError(
+      "TS_RUNTIME_WORKFLOW_GENERATOR_RETIRED",
+      "TypeScript workflow generator sessions are retired in default/live runtime; use the Rust-owned workflow generator entrypoint.",
+      {
+        httpStatus: 503,
+        details: {
+          classification: "fail_closed",
+          replacement: "rust_owned_workflow_generator_entrypoint_required",
+        },
+      },
+    );
+    const submitTurn = vi.fn(async () => {
+      throw retirementError;
+    });
+    const materializeGeneratedSession = vi.fn();
+    const service = createFridayUixSurfaceService({
+      idGenerator: () => "assistant-retire-2",
+      selfHealing: {
+        reportStructuredFailure: vi.fn(),
+        listIssueCards: vi.fn(() => []),
+      } as never,
+      workflowGenerator: {
+        startSession: vi.fn(async () => ({
+          session: { sessionId: "workflow-session-1" },
+          mode: "clarification_required",
+          questions: ["Which repository should Friday change first?"],
+        })),
+        submitTurn,
+      } as never,
+      workflowProduct: { materializeGeneratedSession } as never,
+    });
+
+    const started = service.startWizard({
+      wizardId: "guided-assistant",
+      userId: "user-1",
+    });
+
+    await expect(
+      service.continueWizard({
+        wizardId: "guided-assistant",
+        contextId: started.wizard.contextId,
+        userId: "user-1",
+        values: { goal: "Generate a release workflow" },
+      }),
+    ).resolves.toBeDefined();
+
+    // Advance to the clarification step, which drives submitTurn (fail-closed).
+    await expect(
+      service.continueWizard({
+        wizardId: "guided-assistant",
+        contextId: started.wizard.contextId,
+        userId: "user-1",
+        values: { answer: "the release repo" },
+      }),
+    ).rejects.toMatchObject({
+      code: "TS_RUNTIME_WORKFLOW_GENERATOR_RETIRED",
+      httpStatus: 503,
+    } satisfies Partial<FridayDomainError>);
+
+    expect(submitTurn).toHaveBeenCalled();
+    // submitTurn fail-closed BEFORE the downstream materialize.
+    expect(materializeGeneratedSession).not.toHaveBeenCalled();
+  });
+
   it("routes review-issues through the bundled starter skill when a skill executor is available", async () => {
     const execute = vi.fn(() => ({
       runId: "skill-run-1",

--- a/test/unit/workflows/friday-workflow-product-retirement-guard.test.ts
+++ b/test/unit/workflows/friday-workflow-product-retirement-guard.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { FridayWorkflowBuilderRuntime, FridayWorkflowRuntime } from "#workflows";
+import { FridayDomainError } from "#errors";
+import { createFridayWorkflowProductService } from "../../../src/workflows/services/friday-workflow-product-service.js";
+
+/**
+ * TS Runtime Retirement — METHOD-level guard for workflow deployment.
+ *
+ * The workflow-deploy retirement was ROUTE-only
+ * (friday-workflow-product-routes asserts `allowTestOnlyWorkflowDeployExecution`
+ * before POST .../deploy). The UIX deploy-workflow card (`deployWorkflowCard`)
+ * and the cross-border pack service (preset `deployDraft` during pack
+ * enablement) reach the method directly, bypassing the route guard.
+ *
+ * `materializeGeneratedSession` shares the same deploy flag: it is NOT a read —
+ * it persists a workflow row + draft (the deploy-preparation step) and is
+ * reached only via the UIX assistant create/continue/generate-workflow flows,
+ * which also bypass the route guard.
+ *
+ * These tests prove the guard now lives on the METHODS: in default/live config
+ * (test-oracle flag unset) `deployDraft` and `materializeGeneratedSession` fail
+ * closed BEFORE any workflow read, lock acquisition, compile, publish, trigger
+ * resync, run start, or workflow/draft persist. With the explicit test-oracle
+ * flag enabled the legacy path proceeds past the guard (full legacy deployment
+ * behavior is covered by friday-workflow-product-service.test.ts, which now
+ * opts in explicitly).
+ */
+
+const RETIRED_CODE = "TS_RUNTIME_WORKFLOW_DEPLOY_RETIRED";
+const NOW = "2026-06-09T00:00:00.000Z";
+
+function makeGuardDeps() {
+  const builderRuntime = {
+    collaboration: {
+      acquireLock: vi.fn(),
+      releaseLock: vi.fn(),
+    },
+    compositor: {
+      compileDraft: vi.fn(),
+      publishDraft: vi.fn(),
+    },
+    drafts: {
+      getDraft: vi.fn(),
+      // materializeGeneratedSession persists a draft via this in both branches.
+      createDraft: vi.fn(() => {
+        throw new Error("createDraft must not run when materialize is fail-closed");
+      }),
+    },
+    importExport: {
+      exportDraft: vi.fn(),
+    },
+  } as unknown as FridayWorkflowBuilderRuntime;
+  const workflowRuntime = {
+    crud: {
+      getWorkflow: vi.fn(() => null),
+      // materializeGeneratedSession persists a workflow row via this in the
+      // draft-present branch — must never run while fail-closed.
+      createWorkflow: vi.fn(() => {
+        throw new Error("createWorkflow must not run when materialize is fail-closed");
+      }),
+    },
+    triggers: {
+      syncPublishedVersionTriggers: vi.fn(),
+    },
+    execution: {
+      startRun: vi.fn(),
+    },
+  } as unknown as FridayWorkflowRuntime;
+  return { builderRuntime, workflowRuntime };
+}
+
+function buildService(input: {
+  builderRuntime: FridayWorkflowBuilderRuntime;
+  workflowRuntime: FridayWorkflowRuntime;
+  allowTestOnlyWorkflowDeployExecution?: boolean;
+  workflowGenerator?: unknown;
+}) {
+  return createFridayWorkflowProductService({
+    builderRuntime: input.builderRuntime,
+    workflowRuntime: input.workflowRuntime,
+    db: {
+      withReadConnection: () => {
+        throw new Error("db must not be read when deployDraft is fail-closed");
+      },
+    },
+    idGenerator: () => "id-1",
+    nowIso: () => NOW,
+    ...(input.workflowGenerator === undefined ? {} : { workflowGenerator: input.workflowGenerator as never }),
+    ...(input.allowTestOnlyWorkflowDeployExecution === undefined
+      ? {}
+      : { allowTestOnlyWorkflowDeployExecution: input.allowTestOnlyWorkflowDeployExecution }),
+  });
+}
+
+describe("FridayWorkflowProductService TS-retirement method guard (deployDraft)", () => {
+  it("fails closed by default: throws 503 fail_closed before any read, lock, compile, or run", async () => {
+    const { builderRuntime, workflowRuntime } = makeGuardDeps();
+    const service = buildService({ builderRuntime, workflowRuntime });
+
+    let caught: unknown;
+    try {
+      await service.deployDraft({
+        workflowId: "wf-1",
+        draftId: "draft-1",
+        actorUserId: "user-1",
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(FridayDomainError);
+    const domainError = caught as FridayDomainError;
+    expect(domainError.code).toBe(RETIRED_CODE);
+    expect(domainError.httpStatus).toBe(503);
+    expect(domainError.details).toMatchObject({
+      classification: "fail_closed",
+      replacement: "rust_owned_workflow_deployment_entrypoint_required",
+    });
+
+    // The guard runs BEFORE any state read or side effect.
+    expect(workflowRuntime.crud.getWorkflow).not.toHaveBeenCalled();
+    expect(builderRuntime.collaboration.acquireLock).not.toHaveBeenCalled();
+    expect(builderRuntime.compositor.compileDraft).not.toHaveBeenCalled();
+    expect(builderRuntime.compositor.publishDraft).not.toHaveBeenCalled();
+    expect(workflowRuntime.triggers.syncPublishedVersionTriggers).not.toHaveBeenCalled();
+    expect(workflowRuntime.execution.startRun).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the flag is explicitly false (only exact `true` opts in)", async () => {
+    const { builderRuntime, workflowRuntime } = makeGuardDeps();
+    const service = buildService({
+      builderRuntime,
+      workflowRuntime,
+      allowTestOnlyWorkflowDeployExecution: false,
+    });
+
+    await expect(
+      service.deployDraft({ workflowId: "wf-1", draftId: "draft-1", actorUserId: "user-1" }),
+    ).rejects.toMatchObject({ code: RETIRED_CODE, httpStatus: 503 });
+    expect(workflowRuntime.crud.getWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("proceeds past the guard when the test-oracle flag is enabled (legacy errors, not the retirement code)", async () => {
+    const { builderRuntime, workflowRuntime } = makeGuardDeps();
+    const service = buildService({
+      builderRuntime,
+      workflowRuntime,
+      allowTestOnlyWorkflowDeployExecution: true,
+    });
+
+    // With the flag on, the next failure is the legacy domain error for an
+    // unknown workflow — proving the guard no longer blocks the method.
+    await expect(
+      service.deployDraft({ workflowId: "wf-missing", draftId: "draft-1", actorUserId: "user-1" }),
+    ).rejects.toMatchObject({ code: "WORKFLOW_NOT_FOUND", httpStatus: 404 });
+    expect(workflowRuntime.crud.getWorkflow).toHaveBeenCalledWith("wf-missing");
+  });
+});
+
+describe("FridayWorkflowProductService TS-retirement method guard (materializeGeneratedSession)", () => {
+  it("fails closed by default: throws 503 fail_closed before any generator read or workflow/draft persist", async () => {
+    const { builderRuntime, workflowRuntime } = makeGuardDeps();
+    // A generator stub whose getSession is booby-trapped — proves the guard
+    // fires BEFORE the generator is even consulted.
+    const getSession = vi.fn(() => {
+      throw new Error("generator.getSession must not run when materialize is fail-closed");
+    });
+    const service = buildService({
+      builderRuntime,
+      workflowRuntime,
+      workflowGenerator: { getSession },
+    });
+
+    let caught: unknown;
+    try {
+      await service.materializeGeneratedSession({ sessionId: "sess-1", actorUserId: "user-1" });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(FridayDomainError);
+    const domainError = caught as FridayDomainError;
+    expect(domainError.code).toBe(RETIRED_CODE);
+    expect(domainError.httpStatus).toBe(503);
+    expect(domainError.details).toMatchObject({
+      classification: "fail_closed",
+      replacement: "rust_owned_workflow_deployment_entrypoint_required",
+    });
+
+    // The guard runs BEFORE any generator read or persist side effect.
+    expect(getSession).not.toHaveBeenCalled();
+    expect(workflowRuntime.crud.createWorkflow).not.toHaveBeenCalled();
+    expect(builderRuntime.drafts.createDraft).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the flag is explicitly false (only exact `true` opts in)", async () => {
+    const { builderRuntime, workflowRuntime } = makeGuardDeps();
+    const getSession = vi.fn(() => {
+      throw new Error("generator.getSession must not run when materialize is fail-closed");
+    });
+    const service = buildService({
+      builderRuntime,
+      workflowRuntime,
+      workflowGenerator: { getSession },
+      allowTestOnlyWorkflowDeployExecution: false,
+    });
+
+    await expect(
+      service.materializeGeneratedSession({ sessionId: "sess-1", actorUserId: "user-1" }),
+    ).rejects.toMatchObject({ code: RETIRED_CODE, httpStatus: 503 });
+    expect(getSession).not.toHaveBeenCalled();
+    expect(workflowRuntime.crud.createWorkflow).not.toHaveBeenCalled();
+    expect(builderRuntime.drafts.createDraft).not.toHaveBeenCalled();
+  });
+
+  it("proceeds past the guard when the test-oracle flag is enabled (reaches the legacy generator-availability check, not the retirement code)", async () => {
+    const { builderRuntime, workflowRuntime } = makeGuardDeps();
+    // No workflowGenerator wired: with the flag on, the guard is passed and the
+    // method reaches its legacy WORKFLOW_GENERATOR_UNAVAILABLE check — proving
+    // the guard no longer blocks the method.
+    const service = buildService({
+      builderRuntime,
+      workflowRuntime,
+      allowTestOnlyWorkflowDeployExecution: true,
+    });
+
+    await expect(
+      service.materializeGeneratedSession({ sessionId: "sess-1", actorUserId: "user-1" }),
+    ).rejects.toMatchObject({ code: "WORKFLOW_GENERATOR_UNAVAILABLE", httpStatus: 503 });
+  });
+});

--- a/test/unit/workflows/friday-workflow-product-service.test.ts
+++ b/test/unit/workflows/friday-workflow-product-service.test.ts
@@ -252,6 +252,9 @@ function makeDeps() {
       },
       idGenerator: () => "id-1",
       nowIso: () => NOW,
+      // Test-oracle opt-in: these tests exercise the legacy `deployDraft`
+      // mutation, which is method-level fail-closed by default (TS-R1).
+      allowTestOnlyWorkflowDeployExecution: true,
     }),
     builderRuntime,
     workflowRuntime,

--- a/test/unit/workflows/generator/services/friday-workflow-generator-retirement-guard.test.ts
+++ b/test/unit/workflows/generator/services/friday-workflow-generator-retirement-guard.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { FridaySqliteLayer } from "#state";
+import { FridayDomainError } from "#errors";
+import { createFridayWorkflowGeneratorService } from "#workflows";
+import type {
+  CreateFridayWorkflowGeneratorServiceDeps,
+  FridayWorkflowGeneratorService,
+} from "#workflows";
+import { createFridayAgentWorkflowGeneratorTool } from "#agent";
+import { createTestDb, createTestIdGenerator } from "../../../satellites/_helpers/create-test-db.helper.js";
+
+/**
+ * TS Runtime Retirement — METHOD-level guard for the workflow generator.
+ *
+ * The workflow-generator retirement was ROUTE-only
+ * (friday-workflow-generator-routes asserts `allowTestOnlyWorkflowGeneratorExecution`
+ * before each handler). The agent workflow-generator tool, the UIX assistant
+ * surface (`startWorkflowSession`), and the reflex candidate pipeline
+ * (`generateWorkflowDraft`/`approveGeneratedCandidate`) reach
+ * `startSession`/`generateDraft`/`approveAndSave` directly, bypassing the
+ * route guard.
+ *
+ * These tests prove the guard now lives on the METHODS: in default/live config
+ * (test-oracle flag unset) the three mutation methods fail closed BEFORE any
+ * session-row write or provider call. With the explicit test-oracle flag the
+ * legacy path proceeds past the guard (the full legacy behavior is covered by
+ * friday-workflow-generator-service.test.ts, which now opts in explicitly).
+ */
+
+const RETIRED_CODE = "TS_RUNTIME_WORKFLOW_GENERATOR_RETIRED";
+const NOW = "2026-06-09T00:00:00.000Z";
+
+describe("FridayWorkflowGeneratorService TS-retirement method guard", () => {
+  let db: FridaySqliteLayer;
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    db = createTestDb();
+    // Any provider call would go through fetch — fail loudly if the guard ever
+    // lets a default-config mutation reach the LLM client.
+    globalThis.fetch = (() => {
+      throw new Error("fetch must not be called when the generator is fail-closed");
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    db.close();
+  });
+
+  function buildService(allowTestOnlyWorkflowGeneratorExecution?: boolean): FridayWorkflowGeneratorService {
+    const deps = {
+      db,
+      providerService: {} as never,
+      workflowCrud: {} as never,
+      skillRegistry: { listSkills: () => [] } as never,
+      idGenerator: createTestIdGenerator(),
+      nowIso: () => NOW,
+      computeChecksum: (content: string) => `checksum-${content.length}`,
+      ...(allowTestOnlyWorkflowGeneratorExecution === undefined
+        ? {}
+        : { allowTestOnlyWorkflowGeneratorExecution }),
+    } satisfies CreateFridayWorkflowGeneratorServiceDeps;
+    return createFridayWorkflowGeneratorService(deps);
+  }
+
+  function countMemoryItemRows(): number {
+    return db.withReadConnection((reader) =>
+      (reader.prepare("SELECT COUNT(*) AS c FROM memory_items").get() as { c: number }).c,
+    );
+  }
+
+  it("startSession fails closed by default: throws 503 fail_closed and persists nothing", async () => {
+    const service = buildService();
+    const rowsBefore = countMemoryItemRows();
+
+    let caught: unknown;
+    try {
+      await service.startSession({ goal: "Build a workflow", userId: "u-1", channel: "test" });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(FridayDomainError);
+    const domainError = caught as FridayDomainError;
+    expect(domainError.code).toBe(RETIRED_CODE);
+    expect(domainError.httpStatus).toBe(503);
+    expect(domainError.details).toMatchObject({
+      classification: "fail_closed",
+      replacement: "rust_owned_workflow_generator_entrypoint_required",
+    });
+    expect(countMemoryItemRows()).toBe(rowsBefore);
+  });
+
+  it("generateDraft and approveAndSave fail closed by default and when the flag is explicitly false", async () => {
+    const defaultService = buildService();
+    await expect(defaultService.generateDraft("session-1")).rejects.toMatchObject({
+      code: RETIRED_CODE,
+      httpStatus: 503,
+    });
+    await expect(defaultService.approveAndSave("session-1")).rejects.toMatchObject({
+      code: RETIRED_CODE,
+      httpStatus: 503,
+    });
+
+    const explicitlyOff = buildService(false);
+    await expect(
+      explicitlyOff.startSession({ goal: "Build a workflow", userId: "u-1", channel: "test" }),
+    ).rejects.toMatchObject({ code: RETIRED_CODE, httpStatus: 503 });
+  });
+
+  it("proceeds past the guard when the test-oracle flag is enabled (legacy errors, not the retirement code)", async () => {
+    const service = buildService(true);
+
+    // With the flag on, the next failure is the legacy domain error for an
+    // unknown session — proving the guard no longer blocks the method.
+    await expect(service.generateDraft("missing-session")).rejects.toMatchObject({
+      code: "GENERATOR_SESSION_NOT_FOUND",
+      httpStatus: 404,
+    });
+    await expect(service.approveAndSave("missing-session")).rejects.toMatchObject({
+      code: "GENERATOR_SESSION_NOT_FOUND",
+      httpStatus: 404,
+    });
+  });
+
+  it("agent workflow-generator tool caller observes the 503-class error as a tool error, not a crash", async () => {
+    const service = buildService();
+    const tool = createFridayAgentWorkflowGeneratorTool({ generatorService: service });
+
+    const result = await tool.execute(
+      { action: "start", goal: "Build a workflow" },
+      new AbortController().signal,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(String(result.content)).toContain("retired");
+  });
+
+  // ── submitTurn (the off-route generation + provider-spend bypass) ──
+
+  it("submitTurn fails closed by default: throws 503 fail_closed, persists nothing, and never calls the provider", async () => {
+    const service = buildService();
+    const rowsBefore = countMemoryItemRows();
+
+    let caught: unknown;
+    try {
+      // fetch is booby-trapped in beforeEach; if the guard let submitTurn reach
+      // the requirements analyzer this would throw the fetch error instead.
+      await service.submitTurn("any-session", { message: "hello" });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(FridayDomainError);
+    const domainError = caught as FridayDomainError;
+    expect(domainError.code).toBe(RETIRED_CODE);
+    expect(domainError.httpStatus).toBe(503);
+    expect(domainError.details).toMatchObject({
+      classification: "fail_closed",
+      replacement: "rust_owned_workflow_generator_entrypoint_required",
+    });
+    // No turn appended, no session row mutated.
+    expect(countMemoryItemRows()).toBe(rowsBefore);
+  });
+
+  it("submitTurn fails closed when the flag is explicitly false", async () => {
+    const explicitlyOff = buildService(false);
+    await expect(
+      explicitlyOff.submitTurn("any-session", { message: "hello" }),
+    ).rejects.toMatchObject({ code: RETIRED_CODE, httpStatus: 503 });
+  });
+
+  it("submitTurn proceeds past the guard when the test-oracle flag is enabled (legacy not-found, not the retirement code)", async () => {
+    const service = buildService(true);
+    // With the flag on, the next failure is requireSession's legacy not-found —
+    // proving the guard no longer blocks the method (and it runs before any
+    // provider call, so the booby-trapped fetch is never reached).
+    await expect(
+      service.submitTurn("missing-session", { message: "hello" }),
+    ).rejects.toMatchObject({ code: "GENERATOR_SESSION_NOT_FOUND", httpStatus: 404 });
+  });
+
+  it("agent workflow-generator tool 'turn' caller observes the 503-class error as a tool error, not a crash", async () => {
+    const service = buildService();
+    const tool = createFridayAgentWorkflowGeneratorTool({ generatorService: service });
+
+    const result = await tool.execute(
+      { action: "turn", sessionId: "persisted-session", message: "more detail" },
+      new AbortController().signal,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(String(result.content)).toContain("retired");
+  });
+
+  // ── cancelSession (status flip + draft delete) ──
+
+  it("cancelSession fails closed by default and when the flag is explicitly false", async () => {
+    const rowsBefore = countMemoryItemRows();
+    await expect(buildService().cancelSession("any-session")).rejects.toMatchObject({
+      code: RETIRED_CODE,
+      httpStatus: 503,
+    });
+    await expect(buildService(false).cancelSession("any-session")).rejects.toMatchObject({
+      code: RETIRED_CODE,
+      httpStatus: 503,
+    });
+    // Nothing mutated/deleted while fail-closed.
+    expect(countMemoryItemRows()).toBe(rowsBefore);
+  });
+
+  it("cancelSession proceeds past the guard when the test-oracle flag is enabled (legacy not-found, not the retirement code)", async () => {
+    const service = buildService(true);
+    await expect(service.cancelSession("missing-session")).rejects.toMatchObject({
+      code: "GENERATOR_SESSION_NOT_FOUND",
+      httpStatus: 404,
+    });
+  });
+
+  it("agent workflow-generator tool 'cancel' caller observes the 503-class error as a tool error, not a crash", async () => {
+    const service = buildService();
+    const tool = createFridayAgentWorkflowGeneratorTool({ generatorService: service });
+
+    const result = await tool.execute(
+      { action: "cancel", sessionId: "persisted-session" },
+      new AbortController().signal,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(String(result.content)).toContain("retired");
+  });
+});

--- a/test/unit/workflows/generator/services/friday-workflow-generator-service.test.ts
+++ b/test/unit/workflows/generator/services/friday-workflow-generator-service.test.ts
@@ -378,6 +378,9 @@ describe("FridayWorkflowGeneratorService", () => {
       idGenerator: () => `id-${++idCounter}`,
       nowIso: () => NOW,
       computeChecksum: (content: string) => `checksum-${content.length}`,
+      // Test-oracle opt-in: these tests exercise the legacy generator
+      // mutations, which are method-level fail-closed by default (TS-R1).
+      allowTestOnlyWorkflowGeneratorExecution: true,
     };
     service = createFridayWorkflowGeneratorService(deps);
   });


### PR DESCRIPTION
## What

Phase-3 route-only-guard-defect closure for 4 surfaces whose retirement was route-fenced but method-open, completing the method-level mirror after the 11-agent adversarial review (`wk4f0gmv2`) found the original commit's mirror **INCOMPLETE** and that it had silently un-retired a separate provider surface.

Each guarded method throws its family retirement `FridayDomainError` (HTTP 503, `classification: fail_closed`) BEFORE any state read/write, provider call, lock, or tool effect, unless the matching `allowTestOnly*` flag is exactly `true`. Flags thread service ← hub-config ← bootstrap, default OFF in production, default TRUE in mock-env/real-env/full-e2e/llm-e2e. No route changes; mirrors merged #570/#597.

## Adversarial-review findings fixed

| # | Severity | Finding | Fix |
|---|---|---|---|
| 1 | HIGH | `submitTurn` (generator) — route-retired mutator (turn append + requirements-analyzer **provider call** + on `ready_for_generation` the full generation pipeline + draft persist) was unguarded; reachable off-route via agent tool `'turn'` and UIX `continueWorkflowSession` on a pre-deploy-persisted session | guarded with `assertWorkflowGeneratorExecutionAllowed()` as first statement |
| 2 | HIGH | `cancelSession` (generator) — route-retired mutator (status flip + draft delete) unguarded; reachable via agent tool `'cancel'` | guarded |
| 3 | MED | `materializeGeneratedSession` (workflow product) — falsely commented as a "stays-live read"; actually **persists a workflow row + draft** in both branches; reachable off-route via UIX start/continue/generate-workflow | guarded with the deploy family code; false comment corrected |
| 4 | MED | standing-agenda stuck `'running'` — `runAgendaItem` persisted the item `'running'` before the now-guarded `startRun`, leaving it deterministically stuck on the live agent-tool `agenda_run` path | run body extracted to `runAgendaItemBody`, wrapped so any throw resets the item to terminal `'failed'` and **re-throws** (retirement semantics not swallowed) |

## ⚠️ Reverted: accidental provider-retirement regression in the prior commit

The original commit (`ad45080e`) reused the two mock-env typed-option slots `allowTestOnlyProviderProbeExecution` / `allowTestOnlyProviderRoutingControlsExecution` for the new Capability/SystemIntent flags, then **deleted everything downstream** to keep CI + `check:ts-runtime-retirement` green — stripping the route guards from `providers.validate` / `doctor` / `capabilities.doctor` / `routing.pin` / `routing.penalty.clear`, the assert helpers, 11 manifest entries, and 10 provider retirement assertions. That un-retired previously-fail-closed provider mutators (the "weaken a guard to make a test pass" anti-pattern). This fixup reverted that removal; the branch is now **rebased onto main `909e8830` (#629 TS-R3)** which re-established that exact provider retirement, so the provider files are byte-identical to main and the regression is fully gone from this PR's diff.

## Per-service mirror (route handler → method → mutating? → guarded? was/now)

**CapabilityAcquisitionService** (`TS_RUNTIME_CAPABILITY_ACQUISITION_RETIRED`) — off-route callers: agent controlled-autonomy tool, standing-agenda `runAgendaItem`

| Route handler | Method | Mutating? | Guarded was → now |
|---|---|---|---|
| acquisition.runs.create | `startRun` | yes (run row write) | guarded → guarded |
| acquisition.runs.approve | `approveRun` | yes | guarded → guarded |
| acquisition.runs.cancel | `cancelRun` | yes | guarded → guarded |
| acquisition.plan | `plan` | no (in-memory preview) | live → live |
| acquisition.runs.get | `getRun` | no | live → live |

**WorkflowGeneratorService** (`TS_RUNTIME_WORKFLOW_GENERATOR_RETIRED`) — off-route callers: agent workflow-generator tool, UIX assistant (start/continueWorkflowSession), reflex candidate pipeline

| Route handler | Method | Mutating? | Guarded was → now |
|---|---|---|---|
| sessions.create | `startSession` | yes | guarded → guarded |
| **sessions.messages.create** | **`submitTurn`** | **yes (provider call + pipeline + persist)** | **UNGUARDED → guarded** |
| sessions.generate | `generateDraft` | yes | guarded → guarded |
| sessions.approve | `approveAndSave` | yes | guarded → guarded |
| **sessions.cancel** | **`cancelSession`** | **yes (status flip + draft delete)** | **UNGUARDED → guarded** |
| sessions.get | `getSession` | no | live → live |
| sessions.evidence.get | `getQaVerdict` / `getHarnessSummary` | no | live → live |

**SystemService** (`TS_RUNTIME_SYSTEM_INTENT_RETIRED`) — off-route caller: agent system tool (calls `executeIntent` only)

| Route handler | Method | Mutating? | Guarded was → now |
|---|---|---|---|
| system.intents.create | `executeIntent` | yes | guarded → guarded |
| system.sessions/state/events.get | `getSession` / `getState` / `listEvents` | no | live → live |

(Other system mutators — `updateApprovalRule`, `registerRemoteDevice`, etc. — have no off-route caller; reachable only via their route-guarded HTTP routes. Out of the non-route-reachable scope.)

**WorkflowProductService** (`TS_RUNTIME_WORKFLOW_DEPLOY_RETIRED`) — off-route callers: UIX deploy-workflow card, UIX assistant create/continue/generate-workflow, cross-border pack

| Route handler | Method | Mutating? | Guarded was → now |
|---|---|---|---|
| workflows.product.deploy | `deployDraft` | yes | guarded → guarded |
| (no HTTP route — UIX-only) | **`materializeGeneratedSession`** | **yes (createWorkflow + createDraft)** | **UNGUARDED → guarded** |
| workflows.product.overview/visualization | `getOverview` / `getVisualization` | no | live → live |

The mirror is now **complete** — every route-retired mutating method on the 4 surfaces is method-guarded; reads stay live. UIX off-route caller paths (`startWorkflowSession`, `continueWorkflowSession`, generate-workflow action) verified thin propagators with no DB/session/card write between function entry and the guarded call, so the 503 propagates with no poisoned state; `FridayDomainError` is preserved by the deploy-workflow try/catch.

## Tests

- 4 method-guard suites + new `submitTurn`/`cancelSession`/`materialize` cases: default fail-closed with zero side effects (booby-trapped `fetch` proves no provider call; booby-trapped `createWorkflow`/`createDraft`/`getSession` prove no persist), explicit-`false`, flag-`true` legacy path, agent tool `'turn'`/`'cancel'` caller path observes the 503 as a tool error (no crash).
- standing-agenda terminal-state test: proves the item reaches `'failed'` (not stuck `'running'`) and the 503 is re-thrown; verified regression-sensitive (temporarily removing the reset → item stuck `'running'`).
- 2 UIX caller-path tests: generate-workflow → `materialize` 503 propagates; continueWizard → `submitTurn` 503 propagates and never reaches downstream `materialize`.
- Existing suites opt in explicitly.

## Gates (full suites measured on base `909e8830`; final head `b05e3888` rebased onto main `086c08e9`)

- `npm run typecheck` ✅
- affected vitest ✅ (incl. provider-routes 10 retirement tests + 2 new UIX caller-path tests)
- full `npm test`: 942 files / **12742 passed**; **1 failure = pre-existing `friday-secret-crypto` keychain machine-env artifact** (byte-identical to main, fails only on this Mac's keychain; CI Linux unaffected; no security/crypto file touched)
- full browser-e2e (chromium): 13 files / **28 passed** ✅
- `npm run lint` ✅ 0 errors
- detect-secrets-hook + provider-key denylist ✅
- `check:ts-runtime-retirement` ✅ `status=passed`, `blockerFamilies=[]`, fail_closed 237 / compat_shim 247 (provider retirement intact via #629)

> Gate-base note: full `npm test` + browser-e2e were measured on base `909e8830`. The final base shift to `086c08e9` adds only #627 (`rust-core/`-only, **zero TS-file overlap** with this diff), where typecheck + `check:ts-runtime-retirement` + the 7 guard suites were re-confirmed on the final head `b05e3888`; a rust-core base shift cannot enter the TypeScript test graph. CI runs the full suite on the pushed head against the exact base.

## Truth label

These 4 surfaces become **method-fenced live-pending-Rust-ownership** — nothing is replaced (no Rust owner exists yet), this is fail-closing only. **NOT v1 GO progress.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
