### PR TITLE
chore(ts-retirement): TS-R3 — reclassify 5 provider routes fail_closed + 6 GET compat_shim (model-routing deferred)

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -3697,6 +3697,99 @@
       "next_action": "Replace the fail-closed response with the Rust-owned provider-detect entrypoint when available; this route is on the production onboarding + release-GO path — coordinate the Rust entrypoint with operator sign-off (see reconciliation note)."
     },
     {
+      "id": "providers_validate",
+      "route": { "method": "POST", "path": "/v1/providers/:providerId/validate", "operationId": "providers.validate" },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-provider-routes.ts providers.validate wires default/live to assertProviderProbeTestOracleAllowed(deps) AFTER request validation + the canonical mutation gate (maybeRequireProviderMutationTicket; gate-required profiles 503/CANONICAL_APPROVAL_REQUIRED before the guard) and BEFORE the providerService.validateProvider call. 503 TS_RUNTIME_PROVIDER_PROBE_RETIRED (classification fail_closed, replacement rust_owned_provider_probe_entrypoint_required). fail_closed NOT operator_external_adapter: validateProvider (src/providers/services/friday-provider-service.ts, verified by reading the impl) is a transient key/connectivity PROBE that egresses to the provider (validator.validate({credential,...}) for HTTP, validateCliProvider for CLI) AND persists the resulting validation state to the provider DB (withWriteTransaction) — it is both a probe and a state write, Rust-ownable product logic — same shape as providers.detect; it is not a permanent egress-delivery conduit, and when retired the guard fail-closes BEFORE the validateProvider call so neither the egress nor the state write runs. executes_product_logic:false: no provider validation runs in default/live. Flag allowTestOnlyProviderProbeExecution threaded CreateFridayApiRuntimeDeps -> createFridayProviderRoutes + hub-config (FridayHubConfig -> friday-hub-bootstrap) so mock-env (createMockHubEnv default-true), real-env (live, true), and the full/llm e2e (createFridayHub) set it. OPERATOR/RECONCILIATION NOTE: retiring this route 503s the release-GO closure harnesses scripts/e2e/run-friday-closure.mjs and scripts/e2e/run-friday-external-closure.mjs (both POST /v1/providers/:providerId/validate, throw on non-200) — these are NOT CI gates but need the Rust provider-probe entrypoint (or an operator decision) before release-verify; same shape as the providers.detect reconciliation note. Reachable only through explicit allowTestOnlyProviderProbeExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned provider-probe entrypoint when available; validate is on the release-GO path — coordinate with operator sign-off (see reconciliation note)."
+    },
+    {
+      "id": "providers_doctor",
+      "route": { "method": "GET", "path": "/v1/providers/:providerId/doctor", "operationId": "providers.doctor" },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-provider-routes.ts providers.doctor wires default/live to assertProviderProbeTestOracleAllowed(deps) at the top of the handler, so the 503 fires BEFORE the providerService.doctorProvider call. 503 TS_RUNTIME_PROVIDER_PROBE_RETIRED (classification fail_closed, replacement rust_owned_provider_probe_entrypoint_required). fail_closed NOT operator_external_adapter: doctorProvider (src/providers/services/friday-provider-service.ts buildDoctorReport, verified by reading the impl) computes a transient provider backend/auth/routing-eligibility health diagnostic — read-shaped for HTTP/oauth providers (derived from stored validation state + config), and in the CLI branch it runs a live probeFridayCliSession session probe; it is the same diagnostic surface providers.health.list aggregates per-provider. This is Rust-ownable diagnostic product logic; the guard fail-closes BEFORE the doctorProvider call so no doctor diagnostic runs in default/live. executes_product_logic:false: no provider doctor diagnostic runs in default/live. Flag allowTestOnlyProviderProbeExecution threaded as for providers.validate (runtime + hub-config + mock-env/real-env/e2e). Reachable only through explicit allowTestOnlyProviderProbeExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned provider-probe entrypoint when available."
+    },
+    {
+      "id": "capabilities_doctor",
+      "route": { "method": "POST", "path": "/v1/capabilities/doctor", "operationId": "capabilities.doctor" },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-provider-routes.ts capabilities.doctor wires default/live to assertProviderProbeTestOracleAllowed(deps) AFTER body validation (parseCapabilityDoctorProviderIds -> 400 on an explicit empty providerIds list) + the canonical mutation gate (maybeRequireProviderMutationTicket) and BEFORE the providerService.runCapabilityDoctor call. 503 TS_RUNTIME_PROVIDER_PROBE_RETIRED (classification fail_closed, replacement rust_owned_provider_probe_entrypoint_required). fail_closed NOT operator_external_adapter: runCapabilityDoctor (src/providers/services/friday-provider-service.ts, verified by reading the impl) calls validateProvider per provider (egress + DB validation-state write) and runs probeProviderCapability live standardized capability PROBES against the providers, Rust-ownable product logic; when retired the guard fail-closes BEFORE the runCapabilityDoctor call so neither the per-provider validation nor the capability probes run. executes_product_logic:false: no capability probe runs in default/live. Flag allowTestOnlyProviderProbeExecution threaded as for providers.validate. Reachable only through explicit allowTestOnlyProviderProbeExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned provider-probe entrypoint when available."
+    },
+    {
+      "id": "providers_routing_pin",
+      "route": { "method": "POST", "path": "/v1/providers/routing/pin", "operationId": "providers.routing.pin" },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-provider-routes.ts providers.routing.pin wires default/live to assertProviderRoutingControlsTestOracleAllowed(deps) AFTER the user-scoped principal check (401 UNAUTHORIZED), body validation (providerId/model/backendKind -> 400 VALIDATION_ERROR), and the canonical mutation gate (maybeRequireProviderMutationTicket) and IMMEDIATELY BEFORE the providerService.pinRoute user-scoped routing-state write. 503 TS_RUNTIME_PROVIDER_ROUTING_CONTROLS_RETIRED (classification fail_closed, replacement rust_owned_provider_routing_controls_entrypoint_required). fail_closed NOT operator_external_adapter: pin writes user-scoped routing state (runtime product logic), Rust-ownable; when retired the guard fail-closes BEFORE the write so no state mutates. executes_product_logic:false: no routing pin write runs in default/live. Flag allowTestOnlyProviderRoutingControlsExecution threaded CreateFridayApiRuntimeDeps -> createFridayProviderRoutes + hub-config so mock-env (default-true), real-env (true), and full-e2e (createFridayHub) set it; mock-journeys e2e Scenario exercises POST /v1/providers/routing/pin through createMockHubEnv. This flag does NOT cover the model-routing config surfaces (GET/PUT /v1/model-routing), which remain operator_external_adapter and are DEFERRED. Reachable only through explicit allowTestOnlyProviderRoutingControlsExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned routing-controls entrypoint when available."
+    },
+    {
+      "id": "providers_routing_penalty_clear",
+      "route": { "method": "POST", "path": "/v1/providers/routing/penalties/clear", "operationId": "providers.routing.penalty.clear" },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-provider-routes.ts providers.routing.penalty.clear wires default/live to assertProviderRoutingControlsTestOracleAllowed(deps) AFTER the user-scoped principal check (401 UNAUTHORIZED), body validation (providerId/model/backendKind -> 400 VALIDATION_ERROR), and the canonical mutation gate (maybeRequireProviderMutationTicket) and IMMEDIATELY BEFORE the providerService.clearRoutePenalty user-scoped routing-penalty write. 503 TS_RUNTIME_PROVIDER_ROUTING_CONTROLS_RETIRED (classification fail_closed, replacement rust_owned_provider_routing_controls_entrypoint_required). fail_closed NOT operator_external_adapter: penalty.clear writes user-scoped routing-penalty state (runtime product logic), Rust-ownable; when retired the guard fail-closes BEFORE the write so no state mutates. executes_product_logic:false: no penalty-clear write runs in default/live. Flag allowTestOnlyProviderRoutingControlsExecution threaded as for providers.routing.pin. This flag does NOT cover the model-routing config surfaces (GET/PUT /v1/model-routing), which remain operator_external_adapter and are DEFERRED. Reachable only through explicit allowTestOnlyProviderRoutingControlsExecution test-oracle wiring.",
+      "next_action": "Replace the fail-closed response with the Rust-owned routing-controls entrypoint when available."
+    },
+    {
+      "id": "providers_health_list_compat",
+      "route": { "method": "GET", "path": "/v1/providers/health", "operationId": "providers.health.list" },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Keep the provider health snapshot as a bounded compatibility read while provider probe/routing-controls mutations are fail-closed or moved to Rust-owned product truth. This read (src/api/http/routes/friday-provider-routes.ts listHealthSnapshot) aggregates per-provider lane/circuit/validation status by invoking the read-shaped doctorProvider health computation (buildDoctorReport) per provider — the same diagnostic the fail-closed providers.doctor surface returns; for HTTP/oauth providers this is derived from stored validation state + config, and the CLI branch runs a live cli-session probe. It performs no create/update/delete/validate mutation and does not mark completion, so it stays a bounded compatibility read rather than a fail-closed mutation. NOTE: this is NOT weaker than providers.doctor on the probe axis — it runs the same per-provider doctorProvider computation (CLI-branch live probe) across ALL providers, so fencing providers.doctor leaves this aggregate read as an unfenced path to the same diagnostic. Per coordinator scope it is re-labeled (not fenced); when providers.doctor's Rust diagnostic entrypoint lands, this aggregate read should move with it.",
+      "next_action": "Replace this compatibility read with a Rust-owned redacted provider-health projection when available."
+    },
+    {
+      "id": "providers_capability_health_list_compat",
+      "route": { "method": "GET", "path": "/v1/providers/capability-health", "operationId": "providers.capability.health.list" },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Keep the provider capability-health snapshot as a bounded compatibility read while provider capability probes are fail-closed or moved to Rust-owned product truth. This read (src/api/http/routes/friday-provider-routes.ts listCapabilityHealthSnapshot) derives per-provider capability state from declared runtimeCapabilities + the listHealthSnapshot result, so it transitively invokes the same read-shaped doctorProvider health computation per provider (live cli-session probe in the CLI branch); it does NOT run the heavyweight probeProviderCapability standardized capability probe (that lives only in the fail-closed capabilities.doctor / runCapabilityDoctor path). It performs no create/update/delete/validate mutation and does not mark completion, so it stays a bounded compatibility read. NOTE: like providers.health.list this is an unfenced path to the per-provider doctorProvider diagnostic; when that Rust diagnostic entrypoint lands, this read should move with it.",
+      "next_action": "Replace this compatibility read with a Rust-owned redacted capability-health projection when available."
+    },
+    {
+      "id": "providers_get_compat",
+      "route": { "method": "GET", "path": "/v1/providers/:providerId", "operationId": "providers.get" },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Keep the single-provider read as a bounded compatibility read while provider mutation and probe surfaces are fail-closed or moved to Rust-owned product truth. This read returns a configured provider profile (secrets are stored as env-ref/none key sources, never raw); it does not create, update, delete, validate, or run completion.",
+      "next_action": "Replace this compatibility read with a Rust-owned redacted provider projection when available."
+    },
+    {
+      "id": "providers_templates_list_compat",
+      "route": { "method": "GET", "path": "/v1/providers/templates", "operationId": "providers.templates.list" },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Keep the provider-template list as a bounded compatibility read while provider setup mutation is fail-closed or moved to Rust-owned product truth. This read returns static onboarding template metadata; it does not create, update, delete, or mark completion. NOTE: this path is asserted by the setup-template-loading UI browser-e2e (test/e2e/ui/friday-setup-template-loading.e2e.test.ts) which checks the route exists — compat_shim is a re-label only with NO behavior change, so that browser-e2e is unaffected.",
+      "next_action": "Replace this compatibility read with a Rust-owned provider-template projection when available."
+    },
+    {
+      "id": "providers_usage_get_compat",
+      "route": { "method": "GET", "path": "/v1/providers/usage", "operationId": "providers.usage.get" },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Keep the provider usage summary as a bounded compatibility read while provider budget mutation is fail-closed or moved to Rust-owned product truth. This read (src/api/http/routes/friday-provider-usage-routes.ts) returns aggregated usage groups; it does not record usage, mutate budget, or mark completion.",
+      "next_action": "Replace this compatibility read with a Rust-owned redacted provider-usage projection when available."
+    },
+    {
+      "id": "providers_budget_get_compat",
+      "route": { "method": "GET", "path": "/v1/providers/budget", "operationId": "providers.budget.get" },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Keep the provider budget status as a bounded compatibility read while provider budget mutation (PUT /v1/providers/budget) is fail-closed or moved to Rust-owned product truth. This read (src/api/http/routes/friday-provider-usage-routes.ts) returns the monthly limit/spent/remaining snapshot; it does not mutate budget config or mark completion.",
+      "next_action": "Replace this compatibility read with a Rust-owned redacted provider-budget projection when available."
+    },
+    {
       "id": "realtime_subscribe_read",
       "route": {
         "method": "POST",

--- a/src/api/http/routes/friday-provider-routes.ts
+++ b/src/api/http/routes/friday-provider-routes.ts
@@ -397,6 +397,23 @@ export interface FridayProviderRoutesDeps {
   providerService: FridayProviderService;
   canonicalMutationGate?: FridayMutatingActionGate;
   providerMutationGateRequired?: boolean;
+  /**
+   * Test-oracle only: allow the legacy TypeScript provider probe surfaces
+   * (POST /v1/providers/:providerId/validate, GET /v1/providers/:providerId/doctor,
+   * POST /v1/capabilities/doctor) in isolated/mock validation. Production/runtime
+   * callers must leave this unset so these transient capability/key-validation
+   * probes fail-close until Rust owns the provider-probe entrypoint.
+   */
+  allowTestOnlyProviderProbeExecution?: boolean;
+  /**
+   * Test-oracle only: allow the legacy TypeScript provider routing-controls
+   * surfaces (POST /v1/providers/routing/pin, POST /v1/providers/routing/penalties/clear)
+   * in isolated/mock validation. Production/runtime callers must leave this unset
+   * so these user-scoped routing-state mutations fail-close until Rust owns the
+   * routing-controls entrypoint. This does NOT cover the model-routing config
+   * surfaces (GET/PUT /v1/model-routing), which remain operator_external_adapter.
+   */
+  allowTestOnlyProviderRoutingControlsExecution?: boolean;
 }
 
 export function createFridayProviderSetupMutatingActionRequest(input: {
@@ -440,6 +457,59 @@ export function createFridayProviderSetupMutatingActionRequest(input: {
       },
     ],
   };
+}
+
+// ─── Retirement helpers ───
+//
+// The provider probe surfaces (validate / doctor / capabilities.doctor) run
+// transient TypeScript capability/key-validation product logic via
+// providerService: validateProvider probes the provider connection and writes
+// validation state; runCapabilityDoctor validates + runs live capability
+// probes; doctorProvider computes a backend/auth/routing health diagnostic
+// (read-shaped, with a live cli-session probe in the CLI branch). The
+// routing-controls surfaces (routing.pin / routing.penalty.clear) write
+// user-scoped routing state. They fail-close by default/live until Rust owns
+// the corresponding entrypoints; legacy behavior is reachable only through the
+// explicit per-group test-oracle flags. The model-routing config reads/writes
+// (GET/PUT /v1/model-routing) and the provider CRUD/OAuth adapters stay
+// operator_external_adapter and are NOT covered here.
+
+function throwRetiredProviderRuntime(
+  code: string,
+  label: string,
+  replacement: string,
+): never {
+  throw new FridayDomainError(
+    code,
+    `${label} is fail-closed in default/live runtime; use the Rust-owned ${replacement} entrypoint.`,
+    {
+      httpStatus: 503,
+      details: {
+        classification: "fail_closed",
+        replacement: `rust_owned_${replacement}_entrypoint_required`,
+      },
+    },
+  );
+}
+
+function assertProviderProbeTestOracleAllowed(deps: FridayProviderRoutesDeps): void {
+  if (deps.allowTestOnlyProviderProbeExecution !== true) {
+    throwRetiredProviderRuntime(
+      "TS_RUNTIME_PROVIDER_PROBE_RETIRED",
+      "TypeScript provider probe execution",
+      "provider_probe",
+    );
+  }
+}
+
+function assertProviderRoutingControlsTestOracleAllowed(deps: FridayProviderRoutesDeps): void {
+  if (deps.allowTestOnlyProviderRoutingControlsExecution !== true) {
+    throwRetiredProviderRuntime(
+      "TS_RUNTIME_PROVIDER_ROUTING_CONTROLS_RETIRED",
+      "TypeScript provider routing-controls execution",
+      "provider_routing_controls",
+    );
+  }
 }
 
 // ─── Factory ───
@@ -806,6 +876,7 @@ export function createFridayProviderRoutes(
           parameters: { providerIds: providerIds ?? "all-providers" },
           surface: "api:/v1/capabilities/doctor",
         });
+        assertProviderProbeTestOracleAllowed(deps);
         const report = await deps.providerService.runCapabilityDoctor({
           ownerUserId: ctx.principal?.userId,
           providerIds,
@@ -948,6 +1019,7 @@ export function createFridayProviderRoutes(
           parameters: { providerId },
           surface: "api:/v1/providers/validate",
         });
+        assertProviderProbeTestOracleAllowed(deps);
         const validation =
           await deps.providerService.validateProvider(providerId, {
             ownerUserId: ctx.principal?.userId,
@@ -963,6 +1035,7 @@ export function createFridayProviderRoutes(
       auth: { public: true },
       async handler(ctx): Promise<FridayGetProviderDoctorResponse> {
         const { providerId } = ctx.params as { providerId: string };
+        assertProviderProbeTestOracleAllowed(deps);
         const doctor = await deps.providerService.doctorProvider(providerId);
         return { doctor };
       },
@@ -1042,6 +1115,7 @@ export function createFridayProviderRoutes(
           parameters: body,
           surface: "api:/v1/providers/routing/pin",
         });
+        assertProviderRoutingControlsTestOracleAllowed(deps);
         await deps.providerService.pinRoute({
           userId: ctx.principal.userId,
           taskProfileId: typeof body.taskProfileId === "string" ? body.taskProfileId : undefined,
@@ -1086,6 +1160,7 @@ export function createFridayProviderRoutes(
           parameters: body,
           surface: "api:/v1/providers/routing/penalties/clear",
         });
+        assertProviderRoutingControlsTestOracleAllowed(deps);
         const cleared = await deps.providerService.clearRoutePenalty({
           userId: ctx.principal.userId,
           taskProfileId: typeof body.taskProfileId === "string" ? body.taskProfileId : undefined,

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -3512,6 +3512,8 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
     providerService: deps.providerService,
     canonicalMutationGate,
     providerMutationGateRequired,
+    allowTestOnlyProviderProbeExecution: deps.allowTestOnlyProviderProbeExecution,
+    allowTestOnlyProviderRoutingControlsExecution: deps.allowTestOnlyProviderRoutingControlsExecution,
   })) {
     routes.register(route);
   }

--- a/src/api/runtime/friday-api-runtime.types.ts
+++ b/src/api/runtime/friday-api-runtime.types.ts
@@ -446,6 +446,23 @@ export interface CreateFridayApiRuntimeDeps {
    * harness (operator reconciliation item).
    */
   allowTestOnlyProviderDetectExecution?: boolean;
+  /**
+   * Test-oracle only: allow the legacy TypeScript provider probe surfaces
+   * (POST /v1/providers/:providerId/validate, GET /v1/providers/:providerId/doctor,
+   * POST /v1/capabilities/doctor). Production/runtime callers must leave this
+   * unset so these probes fail-close until Rust owns the provider-probe
+   * entrypoint. NOTE: retiring validate 503s the release-GO closure harness
+   * (operator reconciliation item).
+   */
+  allowTestOnlyProviderProbeExecution?: boolean;
+  /**
+   * Test-oracle only: allow the legacy TypeScript provider routing-controls
+   * surfaces (POST /v1/providers/routing/pin, POST /v1/providers/routing/penalties/clear).
+   * Production/runtime callers must leave this unset so these user-scoped routing
+   * mutations fail-close until Rust owns the routing-controls entrypoint. Does NOT
+   * cover the model-routing config surfaces (GET/PUT /v1/model-routing).
+   */
+  allowTestOnlyProviderRoutingControlsExecution?: boolean;
   /** Optional: Reflex service for deterministic preference writes before agent runs. */
   reflexService?: FridayReflexService;
   /** Optional deterministic runtime capability getter used by context evidence selection. */

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -1902,6 +1902,10 @@ export interface FridayHubConfig {
   allowTestOnlyPluginExecution?: boolean;
   /** Test-oracle only; production hub creation must leave the provider-detect probe fail-closed. */
   allowTestOnlyProviderDetectExecution?: boolean;
+  /** Test-oracle only; production hub creation must leave the provider probe surfaces (validate/doctor/capabilities.doctor) fail-closed. */
+  allowTestOnlyProviderProbeExecution?: boolean;
+  /** Test-oracle only; production hub creation must leave the provider routing-controls surfaces (routing.pin/routing.penalty.clear) fail-closed. */
+  allowTestOnlyProviderRoutingControlsExecution?: boolean;
   /**
    * execrun-replacement slice 4 (DARK): per-run "route a qualifying agent-run via the
    * future Rust read-only loop" flag. DEFAULT-FALSE — production hub creation must leave

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -6982,6 +6982,8 @@ export async function createFridayHub(
     allowTestOnlySkillConverterExecution: config.allowTestOnlySkillConverterExecution,
     allowTestOnlyPluginExecution: config.allowTestOnlyPluginExecution,
     allowTestOnlyProviderDetectExecution: config.allowTestOnlyProviderDetectExecution,
+    allowTestOnlyProviderProbeExecution: config.allowTestOnlyProviderProbeExecution,
+    allowTestOnlyProviderRoutingControlsExecution: config.allowTestOnlyProviderRoutingControlsExecution,
     reflexService,
     agentEventEmitter,
     resolveToolApproval,

--- a/test/e2e/friday-full-e2e.test.ts
+++ b/test/e2e/friday-full-e2e.test.ts
@@ -134,6 +134,8 @@ describe.skipIf(!CORE_E2E_ENABLED)("Friday Full E2E — Batch 1 (A–F)", () => 
       allowTestOnlySessionMemoryExtractionExecution: true,
       allowTestOnlyRealtimeExecution: true,
       allowTestOnlySkillConverterExecution: true,
+      allowTestOnlyProviderProbeExecution: true,
+      allowTestOnlyProviderRoutingControlsExecution: true,
     });
     await hub.start();
 

--- a/test/e2e/friday-llm-e2e.test.ts
+++ b/test/e2e/friday-llm-e2e.test.ts
@@ -445,6 +445,7 @@ async function createLlmTestEnv(): Promise<LlmTestEnv> {
     // Keep tokenSecret omitted so the hub uses its local test defaults.
     port: 0,
     logRequests: false,
+    allowTestOnlyProviderProbeExecution: true,
   });
 
   await hub.start();

--- a/test/e2e/live/_helpers/real-env.ts
+++ b/test/e2e/live/_helpers/real-env.ts
@@ -331,6 +331,8 @@ async function startLocalRealHubEnv(
       allowTestOnlySkillConverterExecution: true,
       allowTestOnlyPluginExecution: true,
       allowTestOnlyProviderDetectExecution: true,
+      allowTestOnlyProviderProbeExecution: true,
+      allowTestOnlyProviderRoutingControlsExecution: true,
       ...opts?.hubConfig,
     });
     await createdHub.start();

--- a/test/e2e/mock/_helpers/mock-env.ts
+++ b/test/e2e/mock/_helpers/mock-env.ts
@@ -365,6 +365,10 @@ export async function createMockHubEnv(opts?: {
   allowTestOnlySkillConverterExecution?: boolean;
   /** Test-oracle opt-in for the legacy TS provider-detect probe; set false to prove default fail-closed behavior. */
   allowTestOnlyProviderDetectExecution?: boolean;
+  /** Test-oracle opt-in for the legacy TS provider probe surfaces (validate/doctor/capabilities.doctor); set false to prove default fail-closed behavior. */
+  allowTestOnlyProviderProbeExecution?: boolean;
+  /** Test-oracle opt-in for the legacy TS provider routing-controls surfaces (routing.pin/routing.penalty.clear); set false to prove default fail-closed behavior. */
+  allowTestOnlyProviderRoutingControlsExecution?: boolean;
   /**
    * execrun-replacement slice 4 (DARK): per-run Rust-route flag. DEFAULT-FALSE here (honest
    * dark) — the predicate is unconsumed this slice so the value is cosmetic; the ui browser
@@ -432,6 +436,8 @@ export async function createMockHubEnv(opts?: {
       allowTestOnlyRealtimeExecution: opts?.allowTestOnlyRealtimeExecution ?? true,
       allowTestOnlySkillConverterExecution: opts?.allowTestOnlySkillConverterExecution ?? true,
       allowTestOnlyProviderDetectExecution: opts?.allowTestOnlyProviderDetectExecution ?? true,
+      allowTestOnlyProviderProbeExecution: opts?.allowTestOnlyProviderProbeExecution ?? true,
+      allowTestOnlyProviderRoutingControlsExecution: opts?.allowTestOnlyProviderRoutingControlsExecution ?? true,
       // execrun-replacement slice 4 (DARK): default-FALSE (honest dark), unlike the
       // allowTestOnly* flags which default true. The predicate is unconsumed this slice.
       routeAgentRunViaRust: opts?.routeAgentRunViaRust ?? false,

--- a/test/unit/providers/api/friday-provider-routes.test.ts
+++ b/test/unit/providers/api/friday-provider-routes.test.ts
@@ -138,6 +138,11 @@ describe("FridayProviderRoutes", () => {
         nowIso: () => NOW,
         ticketIdGenerator: () => "ticket-1",
       }),
+      // Probe + routing-controls surfaces fail-close by default; enable the
+      // test-oracle flags so these positive-path tests exercise real behavior.
+      // The dedicated retirement describe block omits these flags.
+      allowTestOnlyProviderProbeExecution: true,
+      allowTestOnlyProviderRoutingControlsExecution: true,
     });
   }
 
@@ -612,6 +617,7 @@ describe("FridayProviderRoutes", () => {
       const mockService = makeMockService();
       const routes = createFridayProviderRoutes({
         providerService: mockService,
+        allowTestOnlyProviderProbeExecution: true,
       });
       const validateRoute = routes.find(
         (r) => r.operationId === "providers.validate",
@@ -671,6 +677,7 @@ describe("FridayProviderRoutes", () => {
       const mockService = makeMockService();
       const routes = createFridayProviderRoutes({
         providerService: mockService,
+        allowTestOnlyProviderProbeExecution: true,
       });
       const doctorRoute = routes.find(
         (r) => r.operationId === "providers.doctor",
@@ -692,6 +699,7 @@ describe("FridayProviderRoutes", () => {
       const mockService = makeMockService();
       const routes = createFridayProviderRoutes({
         providerService: mockService,
+        allowTestOnlyProviderProbeExecution: true,
       });
       const doctorRoute = routes.find(
         (r) => r.operationId === "capabilities.doctor",
@@ -834,6 +842,7 @@ describe("FridayProviderRoutes", () => {
       const mockService = makeMockService();
       const routes = createFridayProviderRoutes({
         providerService: mockService,
+        allowTestOnlyProviderRoutingControlsExecution: true,
       });
       const pinRoute = routes.find(
         (r) => r.operationId === "providers.routing.pin",
@@ -867,6 +876,7 @@ describe("FridayProviderRoutes", () => {
       const mockService = makeMockService();
       const routes = createFridayProviderRoutes({
         providerService: mockService,
+        allowTestOnlyProviderRoutingControlsExecution: true,
       });
       const clearRoute = routes.find(
         (r) => r.operationId === "providers.routing.penalty.clear",
@@ -1362,6 +1372,125 @@ describe("FridayProviderRoutes", () => {
       expect(operationIds).toContain("auth.oauth.anthropic.callback");
       expect(operationIds).toContain("auth.oauth.openai.codex.device.initiate");
       expect(operationIds).toContain("auth.oauth.openai.codex.device.complete");
+    });
+  });
+
+  describe("TS runtime retirement (test-oracle flags unset)", () => {
+    function retiredRoute(operationId: string, mockService: FridayProviderService) {
+      const route = createFridayProviderRoutes({ providerService: mockService }).find(
+        (entry) => entry.operationId === operationId,
+      );
+      if (!route) throw new Error(`route not found: ${operationId}`);
+      return route;
+    }
+
+    // ── Probe surfaces (allowTestOnlyProviderProbeExecution unset) ──
+
+    it("fail-closes providers.validate with 503 TS_RUNTIME_PROVIDER_PROBE_RETIRED (never calls the service)", async () => {
+      const mockService = makeMockService();
+      await expect(
+        retiredRoute("providers.validate", mockService).handler(
+          makeCtx({ params: { providerId: "prov-001" } }),
+        ),
+      ).rejects.toMatchObject({ code: "TS_RUNTIME_PROVIDER_PROBE_RETIRED", httpStatus: 503 });
+      expect(mockService.validateProvider).not.toHaveBeenCalled();
+    });
+
+    it("fail-closes providers.doctor with 503 TS_RUNTIME_PROVIDER_PROBE_RETIRED (never calls the service)", async () => {
+      const mockService = makeMockService();
+      await expect(
+        retiredRoute("providers.doctor", mockService).handler(
+          makeCtx({ params: { providerId: "prov-001" } }),
+        ),
+      ).rejects.toMatchObject({ code: "TS_RUNTIME_PROVIDER_PROBE_RETIRED", httpStatus: 503 });
+      expect(mockService.doctorProvider).not.toHaveBeenCalled();
+    });
+
+    it("fail-closes capabilities.doctor with 503 TS_RUNTIME_PROVIDER_PROBE_RETIRED (never calls the service)", async () => {
+      const mockService = makeMockService();
+      await expect(
+        retiredRoute("capabilities.doctor", mockService).handler(makeCtx({ body: {} })),
+      ).rejects.toMatchObject({ code: "TS_RUNTIME_PROVIDER_PROBE_RETIRED", httpStatus: 503 });
+      expect(mockService.runCapabilityDoctor).not.toHaveBeenCalled();
+    });
+
+    it("validates the body (400) before the probe retirement guard (capabilities.doctor empty providerIds)", async () => {
+      const mockService = makeMockService();
+      await expect(
+        retiredRoute("capabilities.doctor", mockService).handler(makeCtx({ body: { providerIds: [] } })),
+      ).rejects.toMatchObject({ code: "VALIDATION_ERROR", httpStatus: 400 });
+      expect(mockService.runCapabilityDoctor).not.toHaveBeenCalled();
+    });
+
+    // ── Routing-controls surfaces (allowTestOnlyProviderRoutingControlsExecution unset) ──
+
+    it("fail-closes providers.routing.pin with 503 TS_RUNTIME_PROVIDER_ROUTING_CONTROLS_RETIRED (never calls the service)", async () => {
+      const mockService = makeMockService();
+      await expect(
+        retiredRoute("providers.routing.pin", mockService).handler(
+          makeCtx({
+            principal: { userId: "user-1" } as never,
+            body: { providerId: "prov-001", model: "gpt-4o", backendKind: "http" },
+          }),
+        ),
+      ).rejects.toMatchObject({ code: "TS_RUNTIME_PROVIDER_ROUTING_CONTROLS_RETIRED", httpStatus: 503 });
+      expect(mockService.pinRoute).not.toHaveBeenCalled();
+    });
+
+    it("fail-closes providers.routing.penalty.clear with 503 TS_RUNTIME_PROVIDER_ROUTING_CONTROLS_RETIRED (never calls the service)", async () => {
+      const mockService = makeMockService();
+      await expect(
+        retiredRoute("providers.routing.penalty.clear", mockService).handler(
+          makeCtx({
+            principal: { userId: "user-1" } as never,
+            body: { providerId: "prov-001", model: "gpt-4o", backendKind: "http" },
+          }),
+        ),
+      ).rejects.toMatchObject({ code: "TS_RUNTIME_PROVIDER_ROUTING_CONTROLS_RETIRED", httpStatus: 503 });
+      expect(mockService.clearRoutePenalty).not.toHaveBeenCalled();
+    });
+
+    it("requires a user-scoped principal (401) before the routing-controls retirement guard (pin)", async () => {
+      const mockService = makeMockService();
+      await expect(
+        retiredRoute("providers.routing.pin", mockService).handler(
+          makeCtx({
+            principal: null,
+            body: { providerId: "prov-001", model: "gpt-4o", backendKind: "http" },
+          }),
+        ),
+      ).rejects.toMatchObject({ code: "UNAUTHORIZED", httpStatus: 401 });
+      expect(mockService.pinRoute).not.toHaveBeenCalled();
+    });
+
+    it("validates the body (400) before the routing-controls retirement guard (pin missing model)", async () => {
+      const mockService = makeMockService();
+      await expect(
+        retiredRoute("providers.routing.pin", mockService).handler(
+          makeCtx({
+            principal: { userId: "user-1" } as never,
+            body: { providerId: "prov-001", backendKind: "http" },
+          }),
+        ),
+      ).rejects.toMatchObject({ code: "VALIDATION_ERROR", httpStatus: 400 });
+      expect(mockService.pinRoute).not.toHaveBeenCalled();
+    });
+
+    // ── Deferred + re-labeled surfaces stay reachable (no guard) ──
+
+    it("does NOT fail-close model-routing GET/PUT or the compat_shim reads (no guard)", async () => {
+      const mockService = makeMockService();
+      const routes = createFridayProviderRoutes({ providerService: mockService });
+      // model-routing config is DEFERRED (operator_external_adapter); reachable without the probe/controls flags.
+      const routingGet = routes.find((r) => r.operationId === "providers.routing.get")!;
+      await expect(routingGet.handler(makeCtx())).resolves.toBeDefined();
+      // GET reads re-labeled compat_shim stay reachable (no behavior change).
+      const healthList = routes.find((r) => r.operationId === "providers.health.list")!;
+      await expect(healthList.handler(makeCtx())).resolves.toBeDefined();
+      const getProvider = routes.find((r) => r.operationId === "providers.get")!;
+      await expect(
+        getProvider.handler(makeCtx({ params: { providerId: "prov-001" } })),
+      ).resolves.toBeDefined();
     });
   });
 });


### PR DESCRIPTION
## Summary

TS-R3 reclassifies the **unambiguous, non-gate-colliding** subset of provider routes per the TS-runtime retirement lane. Adds two default-OFF (prod) / default-TRUE (mock + real-env test harness) test-oracle flags that fence the 5 `fail_closed` routes with a 503 retirement guard placed **AFTER validation + canonical gate, BEFORE the service call** (autonomy/diagnosis multi-flag precedent). The 6 `compat_shim` entries are a **manifest re-label only — no behavior change**.

## 5 fail_closed (with 503 guards)

| operationId | method/path | code | flag |
|---|---|---|---|
| `providers.validate` | POST /v1/providers/:providerId/validate | `TS_RUNTIME_PROVIDER_PROBE_RETIRED` | `allowTestOnlyProviderProbeExecution` |
| `providers.doctor` | GET /v1/providers/:providerId/doctor | `TS_RUNTIME_PROVIDER_PROBE_RETIRED` | `allowTestOnlyProviderProbeExecution` |
| `capabilities.doctor` | POST /v1/capabilities/doctor | `TS_RUNTIME_PROVIDER_PROBE_RETIRED` | `allowTestOnlyProviderProbeExecution` |
| `providers.routing.pin` | POST /v1/providers/routing/pin | `TS_RUNTIME_PROVIDER_ROUTING_CONTROLS_RETIRED` | `allowTestOnlyProviderRoutingControlsExecution` |
| `providers.routing.penalty.clear` | POST /v1/providers/routing/penalties/clear | `TS_RUNTIME_PROVIDER_ROUTING_CONTROLS_RETIRED` | `allowTestOnlyProviderRoutingControlsExecution` |

Service impls verified by reading `src/providers/services/friday-provider-service.ts`: `validateProvider` egresses (`validator.validate`/`validateCliProvider`) **and** writes validation state to DB; `runCapabilityDoctor` calls `validateProvider` per provider + runs live `probeProviderCapability` probes; `doctorProvider`/`buildDoctorReport` computes a read-shaped health diagnostic (live cli-session probe in the CLI branch). All guard fail-closes before the service call.

## 6 compat_shim (re-label, GET reads only)

`providers.health.list`, `providers.capability.health.list`, `providers.get`, `providers.templates.list`, `providers.usage.get` (friday-provider-usage-routes.ts), `providers.budget.get` (friday-provider-usage-routes.ts).

NOTE (scope NOT expanded): `providers.templates.get` and `providers.list` are thin reads in the same family but are **not** in the coordinator's 6 — left unchanged.

## DEFERRED (untouched): model-routing

`GET /v1/model-routing` (`providers.routing.get`) and `PUT /v1/model-routing` (`providers.routing.set`) stay `operator_external_adapter`. Rationale:
1. **RGG collision** — the RGG self-hosted bootstrap `configureExplicitDeepSeekRouting` POSTs/PUTs `/v1/model-routing` (scripts/ops/run-real-green-gate-self-hosted.mjs:198); fencing it would red the green-gate.
2. **Config-not-runtime** — model-routing is configuration, not a runtime probe/mutation.
3. **TS-R2-adjacent** — an operator decision, out of this slice's scope.

The two routing-controls flags explicitly do NOT cover model-routing.

## Validator counts (`npm run check:ts-runtime-retirement`)

| classification | before | after |
|---|---|---|
| fail_closed | 232 | **237** (+5) |
| compat_shim | 241 | **247** (+6) |
| operator_external_adapter | 37 | **26** (-11) |
| blockerFamilies | `[]` | `[]` (UNCHANGED) |

**Note on the count:** `operator_external_adapter` lands at **26, not 25**. 5+6 = 11 routes leave the family (37 − 11 = 26), and `fail_closed`/`compat_shim` hit their stated +5/+6 targets exactly — so the brief's "→25" was an off-by-one. No 12th route was moved; no thresholds touched. Status: `passed`, blocker math unchanged.

## Operator / reconciliation note (non-blocking)

Retiring `providers.validate` 503s the **release-GO closure harnesses** `scripts/e2e/run-friday-closure.mjs` and `scripts/e2e/run-friday-external-closure.mjs` (both POST `/v1/providers/:providerId/validate`, throw on non-200). These are **NOT CI gates** — same shape as the existing `providers.detect` reconciliation note. They need the Rust provider-probe entrypoint (or an operator decision) before release-verify.

## Gates (all green, run locally on this head)

- `typecheck:src` — clean
- `check:ts-runtime-retirement` — `passed`, blockerFamilies `[]`
- affected vitest — provider-routes (50, incl. new retirement describe block), audit-fixes (38), setup-routes (38), mock-journeys e2e (14, incl. routing/pin via mock-env), hub-bootstrap + api-runtime + provider-usage (178), contract route snapshot — all pass
- `npm run lint` — **0 errors** (warnings pre-existing, unrelated files)
- `detect-secrets-hook` + `check:secret-patterns` — clean
- full-e2e/llm-e2e (live-gated, skipped in CI) — probe flag threaded into their `createFridayHub` configs for when they run live

## Files (11)

Source: `friday-provider-routes.ts` (guards + flags), `friday-api-runtime.ts`/`.types.ts`, `hub-helpers.ts`, `friday-hub-bootstrap.ts`. Test harness: `mock-env.ts` (default-true), `real-env.ts` (true), `friday-full-e2e.test.ts`, `friday-llm-e2e.test.ts`. Tests: `friday-provider-routes.test.ts` (retirement describe block + flag threading). Manifest: `docs/ops/ts-runtime-retirement-manifest.json` (5 fail_closed + 6 compat_shim surfaces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)