### PR TITLE
feat(rust-workflow): S10-A — scheduler substrate (schedule/fire/control/lease tables + cron-subset parser + WAL hardening, dark)

### DIFF
--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -130,6 +130,17 @@ pub mod workflow_ts_translate;
 /// workflow execution remains fenced in TS and is NOT product-replaced; NOT v1 GO.
 pub mod workflow_run;
 
+/// S10-A — workflow SCHEDULER substrate (DARK). The hub-layer half of slice A:
+/// the restricted CRON-SUBSET parser + the minute-granularity UTC `is_due` /
+/// `next_due` evaluator (no `chrono`, UTC-only), the deterministic
+/// `scheduled_run_id` helper (the at-most-once anchor for the future tick's
+/// `create_run` dup-PK claim), and `create_schedule` — the create boundary that
+/// validates the cron expression fail-closed BEFORE it reaches a born-disabled
+/// stored row. NO daemon, NO tick loop, NO firing (slices B/C); the storage rows
+/// live in `friday_storage::schedule`. WAL flip + plist install + enable are
+/// operator-gated. NOT v1 GO.
+pub mod scheduler;
+
 /// PAIR-002 — Hub-side local pairing message handler. It consumes the structured
 /// QR payload from PAIR-001 and the first-slice protocol `Pair` message, writes a
 /// trusted device through the existing authenticated pairing proof, and never

--- a/rust-core/crates/friday-hub/src/scheduler.rs
+++ b/rust-core/crates/friday-hub/src/scheduler.rs
@@ -7,7 +7,12 @@
 //! storage row CHECKs; storage cannot run this parser because it cannot depend on
 //! friday-hub).
 //!
-//! ## Cron subset (everything outside it FAILS CLOSED, at insert AND at read)
+//! ## Cron subset (everything outside it FAILS CLOSED)
+//! The fail-closed guard is WIRED NOW at the INSERT/create boundary
+//! (`create_schedule`): an expression outside this subset is rejected before it
+//! can reach a stored row. The SECOND guard — a due-check re-parse of the stored
+//! `cron_expr` on every tick — is NOT YET WIRED; it is deferred to the future
+//! tick engine (slice B). Until then there is no read-path re-validation.
 //! Five space-separated fields: `min hour dom mon dow`. Each field is one of:
 //! * `*`                — every value in range,
 //! * `*/n`              — every n-th value from the field's minimum (n >= 1, and
@@ -173,10 +178,12 @@ fn parse_field(spec: &FieldSpec, token: &str) -> Result<CronField, CronParseErro
             });
         }
         let values: Vec<u32> = (spec.min..=spec.max).step_by(step as usize).collect();
-        return Ok(CronField {
-            is_star: false,
-            values,
-        });
+        // A `*/n` whose produced set is the COMPLETE field range (only ever `*/1`,
+        // since `*/0` and `step > span` are already rejected and any step >= 2
+        // skips values) is semantically identical to `*` — normalize `is_star` so
+        // the Vixie dom/dow OR-vs-AND rule treats `*/1` exactly like `*`.
+        let is_star = values.len() == (span + 1) as usize;
+        return Ok(CronField { is_star, values });
     }
 
     // A bare number OR a comma list of bare numbers. Each element must parse as a
@@ -343,15 +350,17 @@ pub fn is_due(cron: &CronSchedule, slot_ms: i64) -> bool {
 /// ~2922 days. So `8 * 366` days (2928) covers it with margin; ~4.2M minute
 /// iterations is sub-second and this is off the firing hot path anyway.
 pub fn next_due(cron: &CronSchedule, after_ms: i64) -> Option<i64> {
-    // Start at the next minute boundary strictly after `after_ms`.
-    let start = slot_floor_ms(after_ms) + MIN_MS;
+    // Start at the next minute boundary strictly after `after_ms`. Use checked
+    // arithmetic so a near-`i64::MAX` instant returns None ("cannot fire") rather
+    // than panicking (debug) or wrapping (release); unreachable with real
+    // epoch-millis, defensive only — normal-range behavior is unchanged.
+    let mut slot = slot_floor_ms(after_ms).checked_add(MIN_MS)?;
     const MAX_MINUTES: i64 = 8 * 366 * 24 * 60;
-    let mut slot = start;
     for _ in 0..MAX_MINUTES {
         if matches(cron, &utc_minute_from_ms(slot)) {
             return Some(slot);
         }
-        slot += MIN_MS;
+        slot = slot.checked_add(MIN_MS)?;
     }
     None
 }
@@ -564,6 +573,64 @@ mod tests {
             parse_cron("0 0 0 * *"),
             Err(CronParseError::OutOfRange { value: 0, .. })
         ));
+    }
+
+    #[test]
+    fn rejects_pinned_fail_closed_families() {
+        // An empty element inside a comma list (NOT a wholly-empty token) is an
+        // unsupported form, not an EmptyField.
+        assert!(matches!(
+            parse_cron("0 9 1,,2 * *"),
+            Err(CronParseError::UnsupportedForm { .. })
+        ));
+        // A negative step fails the u32 parse BEFORE the step==0/BadStep check, so
+        // it is an unsupported form.
+        assert!(matches!(
+            parse_cron("*/-1 * * * *"),
+            Err(CronParseError::UnsupportedForm { .. })
+        ));
+        // A u32-overflowing bare numeric fails the integer parse before the range
+        // check, so it is an unsupported form (NOT OutOfRange).
+        assert!(matches!(
+            parse_cron("99999999999 9 * * *"),
+            Err(CronParseError::UnsupportedForm { .. })
+        ));
+        // Hour 24 is out of range 0..=23.
+        assert!(matches!(
+            parse_cron("0 24 * * *"),
+            Err(CronParseError::OutOfRange { value: 24, .. })
+        ));
+        // Month 13 is out of range 1..=12.
+        assert!(matches!(
+            parse_cron("0 9 * 13 *"),
+            Err(CronParseError::OutOfRange { value: 13, .. })
+        ));
+    }
+
+    #[test]
+    fn star_step_full_range_normalizes_to_star() {
+        // `*/1` covers the COMPLETE field range, so is_star must be true (identical
+        // to `*`); a skipping step like `*/5` stays is_star=false.
+        let c = parse_cron("*/1 */1 */1 */1 */1").unwrap();
+        assert!(c.minute.is_star);
+        assert!(c.hour.is_star);
+        assert!(c.dom.is_star);
+        assert!(c.month.is_star);
+        assert!(c.dow.is_star);
+        let c5 = parse_cron("*/5 * * * *").unwrap();
+        assert!(!c5.minute.is_star);
+        // Because `*/1` normalizes to is_star, the dom/dow rule for "0 0 13 * */1"
+        // (dow=*/1 full-range) matches "0 0 13 * *" exactly: dow is treated as the
+        // always-true `*`, so the day uses the AND-rule (only the 13th matches),
+        // NOT the both-restricted OR-rule.
+        let star = parse_cron("0 0 13 * *").unwrap();
+        let norm = parse_cron("0 0 13 * */1").unwrap();
+        assert!(is_due(&star, ymd_hm_to_ms(2026, 6, 13, 0, 0)));
+        assert!(is_due(&norm, ymd_hm_to_ms(2026, 6, 13, 0, 0)));
+        // 2026-06-12 is a Friday (dow=5) and the 12th: the AND-rule rejects it for
+        // both (a both-restricted OR-rule would have wrongly fired on the Friday).
+        assert!(!is_due(&star, ymd_hm_to_ms(2026, 6, 12, 0, 0)));
+        assert!(!is_due(&norm, ymd_hm_to_ms(2026, 6, 12, 0, 0)));
     }
 
     // --- is_due / matching KATs ---------------------------------------------

--- a/rust-core/crates/friday-hub/src/scheduler.rs
+++ b/rust-core/crates/friday-hub/src/scheduler.rs
@@ -1,0 +1,660 @@
+//! S10-A — Rust workflow SCHEDULER substrate (DARK). The hub-layer half of slice
+//! A: the restricted CRON-SUBSET parser + the minute-granularity UTC `is_due` /
+//! `next_due` evaluator, the deterministic `scheduled_run_id` helper (the
+//! at-most-once anchor), and `create_schedule` — the create boundary that
+//! validates the cron expression FAIL-CLOSED before it ever reaches a stored row
+//! (mirroring how `workflow_def`'s linear-only semantic gate lives above the
+//! storage row CHECKs; storage cannot run this parser because it cannot depend on
+//! friday-hub).
+//!
+//! ## Cron subset (everything outside it FAILS CLOSED, at insert AND at read)
+//! Five space-separated fields: `min hour dom mon dow`. Each field is one of:
+//! * `*`                — every value in range,
+//! * `*/n`              — every n-th value from the field's minimum (n >= 1, and
+//!                        n must not exceed the field's range — `*/0` and an
+//!                        oversized step fail closed),
+//! * a bare numeric     — a single value, in range,
+//! * a comma list of bare numerics (`v1,v2,...`) — each in range.
+//!
+//! REJECTED (explicit reason, never guessed): names (`MON`, `JAN`), ranges
+//! (`1-5`), step-on-a-range or step-in-a-list (`1-3/2`, `*/5,10`), a seconds
+//! field (6+ fields), and the extensions `L` / `W` / `#`. Field ranges:
+//! minute 0-59, hour 0-23, day-of-month 1-31, month 1-12, day-of-week 0-6
+//! (0 = Sunday; 7 is NOT accepted — the one canonical spelling, fail-closed).
+//!
+//! ## dom/dow OR-rule (the most-gotten-wrong cron behavior, pinned + KAT'd)
+//! Standard Vixie cron: when BOTH day-of-month and day-of-week are RESTRICTED
+//! (neither is `*`), a slot matches if EITHER the dom OR the dow matches. When at
+//! least one of them is `*`, the day matches only if BOTH the (possibly-`*`) dom
+//! and dow match (i.e. the unrestricted one is always-true). Minute/hour/month
+//! are always ANDed.
+//!
+//! ## UTC + minute granularity
+//! A "slot" is a UTC minute. Epoch-millis are floored to the minute; the calendar
+//! decomposition (year/month/day/day-of-week) uses a vetted civil-from-days
+//! algorithm (leap-year correct) — there is no `chrono` dependency in this
+//! workspace and tz support is a deliberate v1 deferral (UTC only).
+//!
+//! Truth label: DARK substrate — no daemon, no tick loop, nothing fires here
+//! (the firing tick is slice B). `create_schedule` writes a BORN-DISABLED row;
+//! enabling + deploy + WAL flip are operator-gated. NOT v1 GO.
+
+use friday_storage::schedule::{insert_schedule, NewSchedule};
+use friday_storage::StorageError;
+use rusqlite::Connection;
+
+/// Milliseconds in one minute (a slot).
+const MIN_MS: i64 = 60_000;
+
+/// A parsed cron field: the explicit set of matching values for that position.
+/// Built once at parse time so matching is a membership test.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct CronField {
+    /// `true` iff the field was a bare `*` (needed for the dom/dow OR-rule).
+    is_star: bool,
+    /// The matching values (sorted, deduped) within the field's range.
+    values: Vec<u32>,
+}
+
+/// A fully parsed restricted cron expression (5 fields).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CronSchedule {
+    minute: CronField,
+    hour: CronField,
+    dom: CronField,
+    month: CronField,
+    dow: CronField,
+}
+
+/// Why a cron expression was rejected. Always carries an explicit, bounded
+/// reason — a malformed expression is NEVER guessed/coerced.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum CronParseError {
+    #[error("cron expression must have exactly 5 fields (min hour dom mon dow), found {found}")]
+    WrongFieldCount { found: usize },
+    #[error("cron field {field} ('{token}') is empty")]
+    EmptyField { field: &'static str, token: String },
+    #[error(
+        "cron field {field} ('{token}') uses an unsupported form; only '*', '*/n', a bare \
+         number, or a comma list of bare numbers are allowed (no names, ranges, '/' on a \
+         range or list, seconds, or L/W/# extensions)"
+    )]
+    UnsupportedForm { field: &'static str, token: String },
+    #[error("cron field {field} ('{token}') step must be >= 1 and <= the field range")]
+    BadStep { field: &'static str, token: String },
+    #[error("cron field {field} value {value} is out of range {min}..={max}")]
+    OutOfRange {
+        field: &'static str,
+        value: u32,
+        min: u32,
+        max: u32,
+    },
+}
+
+/// Errors creating a schedule: a fail-closed cron parse, or a storage failure.
+#[derive(Debug, thiserror::Error)]
+pub enum CreateScheduleError {
+    #[error("schedule id must be non-empty")]
+    EmptyScheduleId,
+    #[error("workflow id must be non-empty")]
+    EmptyWorkflowId,
+    #[error("cron expression rejected: {0}")]
+    Cron(#[from] CronParseError),
+    #[error("storage error: {0}")]
+    Storage(#[from] StorageError),
+}
+
+struct FieldSpec {
+    name: &'static str,
+    min: u32,
+    max: u32,
+}
+
+const MINUTE: FieldSpec = FieldSpec {
+    name: "minute",
+    min: 0,
+    max: 59,
+};
+const HOUR: FieldSpec = FieldSpec {
+    name: "hour",
+    min: 0,
+    max: 23,
+};
+const DOM: FieldSpec = FieldSpec {
+    name: "day-of-month",
+    min: 1,
+    max: 31,
+};
+const MONTH: FieldSpec = FieldSpec {
+    name: "month",
+    min: 1,
+    max: 12,
+};
+const DOW: FieldSpec = FieldSpec {
+    name: "day-of-week",
+    min: 0,
+    max: 6,
+};
+
+/// Parse one cron field against its [`FieldSpec`], fail-closed.
+fn parse_field(spec: &FieldSpec, token: &str) -> Result<CronField, CronParseError> {
+    if token.is_empty() {
+        return Err(CronParseError::EmptyField {
+            field: spec.name,
+            token: token.to_string(),
+        });
+    }
+
+    // `*` — every value in range.
+    if token == "*" {
+        return Ok(CronField {
+            is_star: true,
+            values: (spec.min..=spec.max).collect(),
+        });
+    }
+
+    // `*/n` — every n-th value from the field minimum. ONLY a bare `*/n` (no
+    // range step, no list step) is supported.
+    if let Some(step_str) = token.strip_prefix("*/") {
+        let step: u32 = step_str
+            .parse()
+            .map_err(|_| CronParseError::UnsupportedForm {
+                field: spec.name,
+                token: token.to_string(),
+            })?;
+        // step >= 1 and not larger than the span (a step bigger than the range
+        // would only ever match the minimum — reject as almost-certainly a typo,
+        // fail-closed rather than silently degenerate).
+        let span = spec.max - spec.min;
+        if step == 0 || step > span {
+            return Err(CronParseError::BadStep {
+                field: spec.name,
+                token: token.to_string(),
+            });
+        }
+        let values: Vec<u32> = (spec.min..=spec.max).step_by(step as usize).collect();
+        return Ok(CronField {
+            is_star: false,
+            values,
+        });
+    }
+
+    // A bare number OR a comma list of bare numbers. Each element must parse as a
+    // plain integer in range — anything else (names, ranges, embedded steps)
+    // fails closed.
+    let mut values: Vec<u32> = Vec::new();
+    for element in token.split(',') {
+        if element.is_empty() {
+            return Err(CronParseError::UnsupportedForm {
+                field: spec.name,
+                token: token.to_string(),
+            });
+        }
+        // Reject any non-digit byte explicitly (so `1-3`, `MON`, `*/2` inside a
+        // list, `+5`, ` 5` all fail closed rather than parse-erroring ambiguously).
+        if !element.bytes().all(|b| b.is_ascii_digit()) {
+            return Err(CronParseError::UnsupportedForm {
+                field: spec.name,
+                token: token.to_string(),
+            });
+        }
+        let v: u32 = element
+            .parse()
+            .map_err(|_| CronParseError::UnsupportedForm {
+                field: spec.name,
+                token: token.to_string(),
+            })?;
+        if v < spec.min || v > spec.max {
+            return Err(CronParseError::OutOfRange {
+                field: spec.name,
+                value: v,
+                min: spec.min,
+                max: spec.max,
+            });
+        }
+        values.push(v);
+    }
+    values.sort_unstable();
+    values.dedup();
+    Ok(CronField {
+        is_star: false,
+        values,
+    })
+}
+
+/// Parse a restricted 5-field cron expression, fail-closed. The single
+/// chokepoint used at BOTH insert-time validation and the due-check (so a row
+/// can never become live with an expression the evaluator would later choke on).
+pub fn parse_cron(expr: &str) -> Result<CronSchedule, CronParseError> {
+    let fields: Vec<&str> = expr.split_whitespace().collect();
+    if fields.len() != 5 {
+        return Err(CronParseError::WrongFieldCount {
+            found: fields.len(),
+        });
+    }
+    Ok(CronSchedule {
+        minute: parse_field(&MINUTE, fields[0])?,
+        hour: parse_field(&HOUR, fields[1])?,
+        dom: parse_field(&DOM, fields[2])?,
+        month: parse_field(&MONTH, fields[3])?,
+        dow: parse_field(&DOW, fields[4])?,
+    })
+}
+
+/// A UTC wall-clock decomposition of a minute slot.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct UtcMinute {
+    minute: u32,
+    hour: u32,
+    /// day-of-month, 1..=31
+    dom: u32,
+    /// month, 1..=12
+    month: u32,
+    /// day-of-week, 0=Sunday .. 6=Saturday
+    dow: u32,
+}
+
+/// Decompose an epoch-millis instant into its UTC minute fields. Uses Howard
+/// Hinnant's `civil_from_days` algorithm (public-domain, leap-year correct for
+/// the full proleptic Gregorian range) for the date part; the day-of-week is the
+/// same algorithm's well-known epoch anchor (1970-01-01 was a Thursday).
+fn utc_minute_from_ms(ms: i64) -> UtcMinute {
+    // Floor-divide to seconds then to days/seconds-of-day (works for negatives).
+    let total_secs = ms.div_euclid(1000);
+    let secs_of_day = total_secs.rem_euclid(86_400);
+    let days = total_secs.div_euclid(86_400); // days since 1970-01-01 (can be negative)
+
+    let minute = ((secs_of_day / 60) % 60) as u32;
+    let hour = (secs_of_day / 3600) as u32;
+
+    // day-of-week: 1970-01-01 is a Thursday (=4 in 0=Sun..6=Sat).
+    let dow = (days.rem_euclid(7) + 4).rem_euclid(7) as u32;
+
+    // civil_from_days (Hinnant): days are relative to 1970-01-01.
+    let z = days + 719_468; // shift epoch to 0000-03-01
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097; // [0, 146096]
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365; // [0, 399]
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365]
+    let mp = (5 * doy + 2) / 153; // [0, 11]
+    let d = doy - (153 * mp + 2) / 5 + 1; // [1, 31]
+    let m = if mp < 10 { mp + 3 } else { mp - 9 }; // [1, 12]
+                                                   // (the calendar YEAR is intentionally not retained — cron has no year field,
+                                                   // so matching never needs it; the `era`/`yoe` intermediates exist only to
+                                                   // resolve month + day-of-month correctly across leap years.)
+
+    UtcMinute {
+        minute,
+        hour,
+        dom: d as u32,
+        month: m as u32,
+        dow,
+    }
+}
+
+/// Does this cron schedule match the given UTC minute slot? Applies the standard
+/// Vixie dom/dow OR-rule (see module docs).
+fn matches(cron: &CronSchedule, t: &UtcMinute) -> bool {
+    if !cron.minute.values.contains(&t.minute) {
+        return false;
+    }
+    if !cron.hour.values.contains(&t.hour) {
+        return false;
+    }
+    if !cron.month.values.contains(&t.month) {
+        return false;
+    }
+    let dom_match = cron.dom.values.contains(&t.dom);
+    let dow_match = cron.dow.values.contains(&t.dow);
+    if !cron.dom.is_star && !cron.dow.is_star {
+        // Both restricted → OR.
+        dom_match || dow_match
+    } else {
+        // At least one is `*` (always-true) → AND (the unrestricted one is true).
+        dom_match && dow_match
+    }
+}
+
+/// Floor an epoch-millis instant to its minute slot (epoch-millis at second 0 of
+/// the minute). The canonical slot identity used for receipts + deterministic
+/// run ids.
+pub fn slot_floor_ms(ms: i64) -> i64 {
+    ms.div_euclid(MIN_MS) * MIN_MS
+}
+
+/// Is the schedule due AT the minute slot containing `slot_ms`? (Floors to the
+/// minute first.)
+pub fn is_due(cron: &CronSchedule, slot_ms: i64) -> bool {
+    let floored = slot_floor_ms(slot_ms);
+    matches(cron, &utc_minute_from_ms(floored))
+}
+
+/// The next minute slot (epoch-millis, floored) STRICTLY AFTER `after_ms` at
+/// which the schedule is due, or `None` if none occurs within the forward search
+/// bound. The bound exists so a GENUINELY-impossible expression (e.g. Feb 30,
+/// which the dom/dow rule can never satisfy) returns `None` instead of looping
+/// forever — and `None` therefore unambiguously means "never fires," NOT "I
+/// didn't look far enough."
+///
+/// The bound must exceed the LONGEST gap between consecutive firings of any
+/// SATISFIABLE expression. That worst case is a leap-day schedule
+/// (`"0 0 29 2 *"`): consecutive Feb-29s can be up to 8 years apart across a
+/// non-leap century boundary (e.g. 2096 → 2104, since 2100 is not a leap year),
+/// ~2922 days. So `8 * 366` days (2928) covers it with margin; ~4.2M minute
+/// iterations is sub-second and this is off the firing hot path anyway.
+pub fn next_due(cron: &CronSchedule, after_ms: i64) -> Option<i64> {
+    // Start at the next minute boundary strictly after `after_ms`.
+    let start = slot_floor_ms(after_ms) + MIN_MS;
+    const MAX_MINUTES: i64 = 8 * 366 * 24 * 60;
+    let mut slot = start;
+    for _ in 0..MAX_MINUTES {
+        if matches(cron, &utc_minute_from_ms(slot)) {
+            return Some(slot);
+        }
+        slot += MIN_MS;
+    }
+    None
+}
+
+/// The DETERMINISTIC run id for a scheduled fire: `sched:<schedule_id>:<slot_ts>`
+/// where `slot_ts` is the floored UTC-minute epoch-millis of the due slot. This
+/// is the at-most-once ANCHOR — the future tick (slice B) passes this id to the
+/// engine's `run_workflow`, whose first act is `create_run` with `run_id` as the
+/// PRIMARY KEY, so two daemons racing the same slot produce exactly one winning
+/// INSERT and the loser fails closed on the duplicate PK. This slice builds and
+/// tests the FORMATTER ONLY; it wires NO firing.
+pub fn scheduled_run_id(schedule_id: &str, slot_ts: i64) -> String {
+    format!("sched:{schedule_id}:{slot_ts}")
+}
+
+/// Create a schedule at the only legitimate create boundary: validate the cron
+/// expression FAIL-CLOSED (rejecting anything outside the restricted subset)
+/// BEFORE it reaches a stored row, then insert a BORN-DISABLED schedule. This is
+/// the hub-layer create gate; callers MUST use it rather than
+/// `friday_storage::schedule::insert_schedule` directly so a row can never be
+/// created with an expression the due-check evaluator would later reject.
+///
+/// Born disabled: creating a schedule never starts firing; enabling is a
+/// separate explicit operator act (`friday_storage::schedule::set_enabled`).
+pub fn create_schedule(
+    conn: &Connection,
+    schedule_id: &str,
+    workflow_id: &str,
+    cron_expr: &str,
+    now: i64,
+) -> Result<(), CreateScheduleError> {
+    if schedule_id.trim().is_empty() {
+        return Err(CreateScheduleError::EmptyScheduleId);
+    }
+    if workflow_id.trim().is_empty() {
+        return Err(CreateScheduleError::EmptyWorkflowId);
+    }
+    // Fail-closed cron validation at insert time (the second guard is the
+    // due-check re-parse in the future tick).
+    parse_cron(cron_expr)?;
+    insert_schedule(
+        conn,
+        &NewSchedule {
+            schedule_id,
+            workflow_id,
+            cron_expr,
+        },
+        now,
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- date decomposition KATs (the off-by-one trap) ----------------------
+
+    fn ymd_hm_to_ms(y: i64, m: i64, d: i64, h: i64, min: i64) -> i64 {
+        // Inverse civil_from_days (days_from_civil, Hinnant) for building test
+        // instants independently of the code under test.
+        let yy = if m <= 2 { y - 1 } else { y };
+        let era = if yy >= 0 { yy } else { yy - 399 } / 400;
+        let yoe = yy - era * 400;
+        let mp = if m > 2 { m - 3 } else { m + 9 };
+        let doy = (153 * mp + 2) / 5 + d - 1;
+        let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+        let days = era * 146_097 + doe - 719_468;
+        (days * 86_400 + h * 3600 + min * 60) * 1000
+    }
+
+    #[test]
+    fn utc_minute_decomposition_known_dates() {
+        // 1970-01-01 00:00 UTC = epoch 0, Thursday (dow=4).
+        let t0 = utc_minute_from_ms(0);
+        assert_eq!(
+            (t0.minute, t0.hour, t0.dom, t0.month, t0.dow),
+            (0, 0, 1, 1, 4)
+        );
+        // 2000-02-29 (leap day) 13:37 UTC — leap-year correctness.
+        let leap = utc_minute_from_ms(ymd_hm_to_ms(2000, 2, 29, 13, 37));
+        assert_eq!(
+            (leap.minute, leap.hour, leap.dom, leap.month),
+            (37, 13, 29, 2)
+        );
+        // 2021-03-01 is a Monday (dow=1); 2026-06-10 is a Wednesday (dow=3).
+        let mon = utc_minute_from_ms(ymd_hm_to_ms(2021, 3, 1, 0, 0));
+        assert_eq!(mon.dow, 1);
+        let wed = utc_minute_from_ms(ymd_hm_to_ms(2026, 6, 10, 0, 0));
+        assert_eq!(wed.dow, 3);
+        // A pre-epoch instant decomposes correctly (negative days path).
+        let pre = utc_minute_from_ms(ymd_hm_to_ms(1969, 12, 31, 23, 59));
+        assert_eq!((pre.dom, pre.month, pre.minute, pre.hour), (31, 12, 59, 23));
+    }
+
+    // --- parser ACCEPT KATs --------------------------------------------------
+
+    #[test]
+    fn parses_star_step_numeric_and_list() {
+        // every minute
+        assert!(parse_cron("* * * * *").is_ok());
+        // top of every hour
+        let c = parse_cron("0 * * * *").unwrap();
+        assert_eq!(c.minute.values, vec![0]);
+        assert!(c.hour.is_star);
+        // */15 minute -> 0,15,30,45
+        let c = parse_cron("*/15 * * * *").unwrap();
+        assert_eq!(c.minute.values, vec![0, 15, 30, 45]);
+        // comma list, deduped + sorted
+        let c = parse_cron("30,0,30 9,17 * * *").unwrap();
+        assert_eq!(c.minute.values, vec![0, 30]);
+        assert_eq!(c.hour.values, vec![9, 17]);
+        // dow 0..6 incl Sunday=0
+        let c = parse_cron("0 0 * * 0").unwrap();
+        assert_eq!(c.dow.values, vec![0]);
+        // boundary values
+        assert!(parse_cron("59 23 31 12 6").is_ok());
+        assert!(parse_cron("0 0 1 1 0").is_ok());
+    }
+
+    // --- parser FAIL-CLOSED KATs (one per rejected family) -------------------
+
+    #[test]
+    fn rejects_wrong_field_count() {
+        assert!(matches!(
+            parse_cron("* * * *"),
+            Err(CronParseError::WrongFieldCount { found: 4 })
+        ));
+        // a seconds field (6 fields) fails closed
+        assert!(matches!(
+            parse_cron("0 * * * * *"),
+            Err(CronParseError::WrongFieldCount { found: 6 })
+        ));
+        assert!(matches!(
+            parse_cron(""),
+            Err(CronParseError::WrongFieldCount { found: 0 })
+        ));
+    }
+
+    #[test]
+    fn rejects_names() {
+        assert!(matches!(
+            parse_cron("0 0 * JAN *"),
+            Err(CronParseError::UnsupportedForm { .. })
+        ));
+        assert!(matches!(
+            parse_cron("0 0 * * MON"),
+            Err(CronParseError::UnsupportedForm { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_ranges() {
+        assert!(matches!(
+            parse_cron("0 0 * * 1-5"),
+            Err(CronParseError::UnsupportedForm { .. })
+        ));
+        // step-on-a-range
+        assert!(matches!(
+            parse_cron("0 0-10/2 * * *"),
+            Err(CronParseError::UnsupportedForm { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_step_inside_a_list_and_bad_steps() {
+        // a `*/n` element inside a comma list is not a bare numeric
+        assert!(matches!(
+            parse_cron("*/5,10 * * * *"),
+            Err(CronParseError::UnsupportedForm { .. })
+        ));
+        // */0 is a bad step
+        assert!(matches!(
+            parse_cron("*/0 * * * *"),
+            Err(CronParseError::BadStep { .. })
+        ));
+        // a step larger than the field range fails closed
+        assert!(matches!(
+            parse_cron("*/60 * * * *"),
+            Err(CronParseError::BadStep { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_lwhash_and_out_of_range() {
+        assert!(matches!(
+            parse_cron("0 0 L * *"),
+            Err(CronParseError::UnsupportedForm { .. })
+        ));
+        assert!(matches!(
+            parse_cron("0 0 15W * *"),
+            Err(CronParseError::UnsupportedForm { .. })
+        ));
+        assert!(matches!(
+            parse_cron("0 0 * * 1#2"),
+            Err(CronParseError::UnsupportedForm { .. })
+        ));
+        // dow=7 is NOT accepted (one canonical Sunday spelling = 0)
+        assert!(matches!(
+            parse_cron("0 0 * * 7"),
+            Err(CronParseError::OutOfRange { value: 7, .. })
+        ));
+        // minute 60 out of range
+        assert!(matches!(
+            parse_cron("60 0 * * *"),
+            Err(CronParseError::OutOfRange { value: 60, .. })
+        ));
+        // dom 0 out of range (dom is 1-based)
+        assert!(matches!(
+            parse_cron("0 0 0 * *"),
+            Err(CronParseError::OutOfRange { value: 0, .. })
+        ));
+    }
+
+    // --- is_due / matching KATs ---------------------------------------------
+
+    #[test]
+    fn is_due_minute_hour_match() {
+        // "30 9 * * *" -> 09:30 UTC daily.
+        let c = parse_cron("30 9 * * *").unwrap();
+        assert!(is_due(&c, ymd_hm_to_ms(2026, 6, 10, 9, 30)));
+        // not due at 09:31, not at 10:30
+        assert!(!is_due(&c, ymd_hm_to_ms(2026, 6, 10, 9, 31)));
+        assert!(!is_due(&c, ymd_hm_to_ms(2026, 6, 10, 10, 30)));
+        // floors within-minute timestamps to the slot (second 45 still due)
+        assert!(is_due(&c, ymd_hm_to_ms(2026, 6, 10, 9, 30) + 45_000));
+    }
+
+    #[test]
+    fn dom_dow_or_rule_when_both_restricted() {
+        // "0 0 13 * 5": midnight on the 13th OR on a Friday (dow=5). 2026-06-10
+        // is a Wednesday (dow=3) and the 10th — neither matches.
+        let c = parse_cron("0 0 13 * 5").unwrap();
+        assert!(!is_due(&c, ymd_hm_to_ms(2026, 6, 10, 0, 0)));
+        // 2026-06-12 is a Friday (dow=5) but the 12th -> dow matches => due (OR).
+        assert!(is_due(&c, ymd_hm_to_ms(2026, 6, 12, 0, 0)));
+        // 2026-06-13 is the 13th (a Saturday, dow=6) -> dom matches => due (OR).
+        assert!(is_due(&c, ymd_hm_to_ms(2026, 6, 13, 0, 0)));
+    }
+
+    #[test]
+    fn dom_dow_and_rule_when_one_is_star() {
+        // "0 0 13 * *": only the 13th, any weekday (dow=*) -> AND with always-true.
+        let c = parse_cron("0 0 13 * *").unwrap();
+        assert!(is_due(&c, ymd_hm_to_ms(2026, 6, 13, 0, 0)));
+        assert!(!is_due(&c, ymd_hm_to_ms(2026, 6, 12, 0, 0)));
+        // "0 0 * * 5": only Friday, any dom -> AND with always-true.
+        let c = parse_cron("0 0 * * 5").unwrap();
+        assert!(is_due(&c, ymd_hm_to_ms(2026, 6, 12, 0, 0))); // Friday
+        assert!(!is_due(&c, ymd_hm_to_ms(2026, 6, 13, 0, 0))); // Saturday
+    }
+
+    // --- next_due KATs incl. the bounded never-fires case --------------------
+
+    #[test]
+    fn next_due_finds_following_slot() {
+        let c = parse_cron("30 9 * * *").unwrap();
+        // strictly AFTER 09:30 today -> 09:30 tomorrow.
+        let at = ymd_hm_to_ms(2026, 6, 10, 9, 30);
+        let next = next_due(&c, at).unwrap();
+        assert_eq!(next, ymd_hm_to_ms(2026, 6, 11, 9, 30));
+        // strictly after means the same-slot is skipped even if currently due.
+        assert!(next > at);
+    }
+
+    #[test]
+    fn next_due_returns_none_for_impossible_expr() {
+        // Feb 30 never exists, and with dow=* the AND-rule requires BOTH dom and
+        // dow, so day 30 in month 2 never matches -> bounded search returns None
+        // (the bound is sized so None means "genuinely never," not "I gave up").
+        let c = parse_cron("0 0 30 2 *").unwrap();
+        assert_eq!(next_due(&c, 0), None);
+    }
+
+    #[test]
+    fn next_due_finds_leap_day_across_a_multi_year_gap() {
+        // "0 0 29 2 *" (midnight on Feb 29) fires only in leap years. From a
+        // non-leap-year instant the next firing can be YEARS away — the bound MUST
+        // be large enough that this returns a real slot and NOT a false None (the
+        // bug a one-year bound would cause). From 1970-01-01 the next Feb 29 is in
+        // 1972.
+        let c = parse_cron("0 0 29 2 *").unwrap();
+        let next =
+            next_due(&c, 0).expect("a leap-day schedule DOES fire — must not be a false None");
+        assert_eq!(next, ymd_hm_to_ms(1972, 2, 29, 0, 0));
+        // And across a NON-leap century boundary (the 8-year worst case): the next
+        // Feb 29 strictly after 2096-02-29 is 2104-02-29 (2100 is not a leap year).
+        let after_2096 = ymd_hm_to_ms(2096, 2, 29, 0, 0);
+        let next = next_due(&c, after_2096).expect("8-year gap must still resolve");
+        assert_eq!(next, ymd_hm_to_ms(2104, 2, 29, 0, 0));
+    }
+
+    // --- scheduled_run_id KAT (the at-most-once anchor) ----------------------
+
+    #[test]
+    fn scheduled_run_id_is_deterministic_and_exact() {
+        assert_eq!(
+            scheduled_run_id("daily", 1_700_000_040_000),
+            "sched:daily:1700000040000"
+        );
+        // same inputs -> identical id (the dup-PK claim depends on this).
+        assert_eq!(scheduled_run_id("s", 60_000), scheduled_run_id("s", 60_000));
+        // distinct slots -> distinct ids.
+        assert_ne!(scheduled_run_id("s", 0), scheduled_run_id("s", 60_000));
+    }
+}

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -28,6 +28,7 @@ pub mod process_registry;
 pub mod provider_session;
 pub mod provider_timeline_store;
 pub mod run_result;
+pub mod schedule;
 mod schema;
 pub mod workflow;
 pub mod workflow_def;
@@ -146,6 +147,45 @@ impl Db {
             &schema::hub_migrations(),
             "unit2-foundation",
         )
+    }
+
+    /// Open (and migrate) a Hub database in SHARED-WRITER (concurrent) mode for
+    /// the S10 scheduler daemon.
+    ///
+    /// Identical to [`Db::open_hub`] except it additionally sets, on ITS OWN
+    /// connection only:
+    /// * `PRAGMA journal_mode = WAL` — so a second process (the agent-run WS
+    ///   server) can read while the scheduler writes;
+    /// * `PRAGMA busy_timeout = 5000` — so a contended write retries for 5s
+    ///   instead of failing immediately with `SQLITE_BUSY`.
+    ///
+    /// DARK / operator-gated: this is ADDITIVE and is NOT called by any existing
+    /// `open_hub` caller (the WS server, hub bootstrap, every read adapter still
+    /// use [`Db::open_hub`] / [`Db::open_hub_readonly`]). It exists for the future
+    /// scheduler bin (slice C). `journal_mode = WAL` is a PERSISTENT file-mode
+    /// change the instant a connection runs it, so flipping it on the PRODUCTION
+    /// `rust-hub.sqlite` is an OPERATOR-GATED deploy step (design §2/§7 G1) — slice
+    /// A only sets the pragma on connections it opens itself (tests / a future
+    /// daemon), never on a prod path. Keep this method off every production caller
+    /// until that gate is taken.
+    pub fn open_hub_concurrent(path: &str) -> Result<Db> {
+        let mut conn = Connection::open(path)?;
+        conn.pragma_update(None, "foreign_keys", true)?;
+        // WAL is a no-op (returns "memory") on an in-memory DB; on a file DB it
+        // converts the journal mode persistently. busy_timeout is per-connection.
+        conn.pragma_update(None, "journal_mode", "WAL")?;
+        conn.pragma_update(None, "busy_timeout", 5000)?;
+        apply_migrations(
+            &mut conn,
+            path,
+            &schema::hub_migrations(),
+            "unit2-foundation",
+        )?;
+        Ok(Db {
+            conn,
+            path: path.to_string(),
+            profile: Profile::Hub,
+        })
     }
 
     /// Open a Hub database for pure-read projections without applying migrations.

--- a/rust-core/crates/friday-storage/src/schedule.rs
+++ b/rust-core/crates/friday-storage/src/schedule.rs
@@ -269,15 +269,13 @@ pub fn record_fire(
     );
     match res {
         Ok(_) => Ok(RecordFireOutcome::Recorded),
-        // Only a PRIMARY KEY / UNIQUE conflict is the benign already-considered
-        // case; a CHECK (bad outcome vocab) or any other constraint propagates.
+        // Only the `(schedule_id, slot_ts)` PRIMARY KEY conflict is the benign
+        // already-considered case. A CHECK (bad outcome vocab) propagates; and a
+        // future UNIQUE index MUST also fail closed rather than be masked as an
+        // idempotent Duplicate — so match the PK extended-code ONLY, never UNIQUE.
         Err(rusqlite::Error::SqliteFailure(err, _))
             if err.code == rusqlite::ErrorCode::ConstraintViolation
-                && matches!(
-                    err.extended_code,
-                    rusqlite::ffi::SQLITE_CONSTRAINT_PRIMARYKEY
-                        | rusqlite::ffi::SQLITE_CONSTRAINT_UNIQUE
-                ) =>
+                && err.extended_code == rusqlite::ffi::SQLITE_CONSTRAINT_PRIMARYKEY =>
         {
             Ok(RecordFireOutcome::Duplicate)
         }

--- a/rust-core/crates/friday-storage/src/schedule.rs
+++ b/rust-core/crates/friday-storage/src/schedule.rs
@@ -1,0 +1,476 @@
+//! Workflow SCHEDULE persistence (S10-A; Hub-only). DARK substrate.
+//!
+//! Storage half of the S10 scheduler slice A. This module owns ONLY rows +
+//! structural invariants over the four m0024 tables; the SEMANTIC cron
+//! validation (the restricted 5-field subset, fail-closed) lives ABOVE this
+//! layer in `friday-hub::scheduler` — exactly as `workflow_def`'s linear-only
+//! semantic gate lives in the hub layer above the row CHECKs (storage cannot
+//! depend on friday-hub, so a fail-closed cron parse cannot run here). Callers
+//! that want the create-time cron validation MUST go through the hub
+//! `create_schedule`, not `insert_schedule` directly.
+//!
+//! What storage guarantees here:
+//! * **Born disabled**: [`insert_schedule`] always writes `enabled = 0`; enabling
+//!   is the separate explicit [`set_enabled`].
+//! * **UTC-only**: the row CHECK makes a non-UTC timezone unrepresentable; this
+//!   module never writes anything but `'UTC'`.
+//! * **Refs-only listing**: [`list_schedules`] returns the operational fields
+//!   (id / workflow_id / cron / enabled / watermark / timestamps) — there is no
+//!   body to omit (a schedule references a workflow_id, it does not embed a
+//!   definition), so the listing is refs-only by construction.
+//! * **Watermark monotonicity**: [`set_last_slot`] REFUSES to lower the
+//!   watermark (a backwards clock / re-presented slot can never rewind it), the
+//!   storage primitive the slice-B tick relies on.
+//! * **Lease**: a singleton (`id=1`) acquired/refreshed/released in an IMMEDIATE
+//!   transaction; acquire SUPERSEDES an EXPIRED holder but refuses a LIVE one
+//!   (the single-instance containment layer — the hard at-most-once guarantee is
+//!   the engine's deterministic-run-id `create_run` PK, not this lease).
+//! * **Control**: the `scheduler_control` singleton seeded by the migration; a
+//!   pause read is always defined.
+//!
+//! Truth label: DARK substrate — no daemon, no tick loop, no production route
+//! consumes this; workflow execution remains fenced in TS and is NOT
+//! product-replaced; the WAL flip + plist install + enable are operator-gated;
+//! NOT v1 GO.
+
+use crate::error::{Result, StorageError};
+use rusqlite::{params, Connection, OptionalExtension, Transaction, TransactionBehavior};
+
+/// Open an IMMEDIATE write transaction on a shared `&Connection`. IMMEDIATE
+/// acquires the write lock at BEGIN, so a read-then-write sequence below cannot
+/// interleave with another writer between its statements (mirrors
+/// `workflow_def::write_tx`).
+fn write_tx(conn: &Connection) -> Result<Transaction<'_>> {
+    Ok(Transaction::new_unchecked(
+        conn,
+        TransactionBehavior::Immediate,
+    )?)
+}
+
+/// A stored schedule row (operational state; refs-only — there is no body).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ScheduleRow {
+    pub schedule_id: String,
+    pub workflow_id: String,
+    pub cron_expr: String,
+    /// Always `"UTC"` in v1 (the row CHECK makes anything else unrepresentable).
+    pub timezone: String,
+    pub enabled: bool,
+    /// Watermark: the last UTC-minute slot CONSIDERED (fired or skipped). `None`
+    /// until the first tick considers this schedule.
+    pub last_slot_ts: Option<i64>,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+/// Input to [`insert_schedule`]. No `enabled` field — born disabled is enforced
+/// here (enabling is the separate [`set_enabled`]). `cron_expr` is persisted
+/// opaquely; the caller (hub `create_schedule`) owns fail-closed cron validation
+/// BEFORE calling this (storage cannot run the parser — see module docs).
+#[derive(Clone, Copy, Debug)]
+pub struct NewSchedule<'a> {
+    pub schedule_id: &'a str,
+    pub workflow_id: &'a str,
+    /// A cron expression the caller has ALREADY validated against the restricted
+    /// subset. Storage only structurally guarantees non-emptiness.
+    pub cron_expr: &'a str,
+}
+
+/// Insert a new schedule, BORN DISABLED. A duplicate `schedule_id` fails closed
+/// (PK violation). `timezone` is always `'UTC'` (v1 restriction). `last_slot_ts`
+/// starts NULL (no slot considered yet).
+pub fn insert_schedule(conn: &Connection, sched: &NewSchedule<'_>, now: i64) -> Result<()> {
+    conn.execute(
+        "INSERT INTO workflow_schedule
+            (schedule_id, workflow_id, cron_expr, timezone, enabled, last_slot_ts,
+             created_at, updated_at)
+         VALUES (?1, ?2, ?3, 'UTC', 0, NULL, ?4, ?4)",
+        params![sched.schedule_id, sched.workflow_id, sched.cron_expr, now],
+    )?;
+    Ok(())
+}
+
+fn schedule_from_row(r: &rusqlite::Row<'_>) -> rusqlite::Result<ScheduleRow> {
+    Ok(ScheduleRow {
+        schedule_id: r.get(0)?,
+        workflow_id: r.get(1)?,
+        cron_expr: r.get(2)?,
+        timezone: r.get(3)?,
+        enabled: r.get::<_, i64>(4)? != 0,
+        last_slot_ts: r.get(5)?,
+        created_at: r.get(6)?,
+        updated_at: r.get(7)?,
+    })
+}
+
+const SCHEDULE_COLUMNS: &str =
+    "schedule_id, workflow_id, cron_expr, timezone, enabled, last_slot_ts, created_at, updated_at";
+
+/// Read one schedule by id, or `None`.
+pub fn get_schedule(conn: &Connection, schedule_id: &str) -> Result<Option<ScheduleRow>> {
+    Ok(conn
+        .query_row(
+            &format!("SELECT {SCHEDULE_COLUMNS} FROM workflow_schedule WHERE schedule_id = ?1"),
+            params![schedule_id],
+            schedule_from_row,
+        )
+        .optional()?)
+}
+
+/// List every schedule (refs-only), ordered by `schedule_id`.
+pub fn list_schedules(conn: &Connection) -> Result<Vec<ScheduleRow>> {
+    let mut stmt = conn.prepare(&format!(
+        "SELECT {SCHEDULE_COLUMNS} FROM workflow_schedule ORDER BY schedule_id"
+    ))?;
+    let rows = stmt.query_map([], schedule_from_row)?;
+    let mut out = Vec::new();
+    for r in rows {
+        out.push(r?);
+    }
+    Ok(out)
+}
+
+/// List only the ENABLED schedules (refs-only) — the set a future tick reads.
+pub fn list_enabled_schedules(conn: &Connection) -> Result<Vec<ScheduleRow>> {
+    let mut stmt = conn.prepare(&format!(
+        "SELECT {SCHEDULE_COLUMNS} FROM workflow_schedule WHERE enabled = 1 ORDER BY schedule_id"
+    ))?;
+    let rows = stmt.query_map([], schedule_from_row)?;
+    let mut out = Vec::new();
+    for r in rows {
+        out.push(r?);
+    }
+    Ok(out)
+}
+
+/// Enable/disable a schedule. A missing `schedule_id` is `NotFound` (never a
+/// silent no-op). Bumps `updated_at`.
+pub fn set_enabled(conn: &Connection, schedule_id: &str, enabled: bool, now: i64) -> Result<()> {
+    let changed = conn.execute(
+        "UPDATE workflow_schedule SET enabled = ?2, updated_at = ?3 WHERE schedule_id = ?1",
+        params![schedule_id, enabled as i64, now],
+    )?;
+    if changed != 1 {
+        return Err(StorageError::NotFound(format!(
+            "workflow_schedule '{schedule_id}' (cannot set enabled on a missing schedule)"
+        )));
+    }
+    Ok(())
+}
+
+/// Advance the watermark to `slot_ts`, REFUSING to lower it (watermark
+/// monotonicity). The current value is read and the UPDATE applied in ONE
+/// IMMEDIATE transaction, so a concurrent advance cannot slip between the read
+/// and the write. A backwards move (a re-presented / clock-skewed slot) is
+/// `Unsupported` and the row is left untouched; equal is a no-op success (an
+/// idempotent re-consider of the same slot). A missing schedule is `NotFound`.
+///
+/// This is the storage primitive the slice-B tick uses to record "last slot
+/// considered"; slice A neither calls it from a loop nor fires anything.
+pub fn set_last_slot(conn: &Connection, schedule_id: &str, slot_ts: i64, now: i64) -> Result<()> {
+    let tx = write_tx(conn)?;
+    let current: Option<Option<i64>> = tx
+        .query_row(
+            "SELECT last_slot_ts FROM workflow_schedule WHERE schedule_id = ?1",
+            params![schedule_id],
+            |r| r.get(0),
+        )
+        .optional()?;
+    match current {
+        None => Err(StorageError::NotFound(format!(
+            "workflow_schedule '{schedule_id}' (cannot advance the watermark of a missing schedule)"
+        ))),
+        Some(existing) => {
+            if let Some(prev) = existing {
+                if slot_ts < prev {
+                    // drop(tx) rolls back (nothing was written anyway).
+                    return Err(StorageError::Unsupported(format!(
+                        "workflow_schedule '{schedule_id}' watermark would move backwards \
+                         ({prev} -> {slot_ts}); refusing to lower it"
+                    )));
+                }
+            }
+            tx.execute(
+                "UPDATE workflow_schedule SET last_slot_ts = ?2, updated_at = ?3
+                 WHERE schedule_id = ?1",
+                params![schedule_id, slot_ts, now],
+            )?;
+            tx.commit()?;
+            Ok(())
+        }
+    }
+}
+
+/// Delete a schedule. A missing `schedule_id` is `NotFound` (never a silent
+/// no-op success). Per-slot fire receipts are intentionally NOT cascaded — the
+/// receipt history is an append-only audit trail keyed by `(schedule_id,
+/// slot_ts)` and outlives the schedule row (no FK is declared, so a fire row is
+/// not orphaned into an integrity error).
+pub fn delete_schedule(conn: &Connection, schedule_id: &str) -> Result<()> {
+    let changed = conn.execute(
+        "DELETE FROM workflow_schedule WHERE schedule_id = ?1",
+        params![schedule_id],
+    )?;
+    if changed != 1 {
+        return Err(StorageError::NotFound(format!(
+            "workflow_schedule '{schedule_id}'"
+        )));
+    }
+    Ok(())
+}
+
+// --- per-slot fire receipts -------------------------------------------------
+
+/// A per-slot fire receipt (refs-only). `run_id` is set only when `outcome ==
+/// "fired"`; `detail_token` is a bounded closed-vocab token (never engine free
+/// text), enforced by the slice-B writer.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FireReceipt {
+    pub schedule_id: String,
+    pub slot_ts: i64,
+    pub outcome: String,
+    pub run_id: Option<String>,
+    pub detail_token: Option<String>,
+    pub created_at: i64,
+}
+
+/// Outcome of [`record_fire`]: a fresh receipt was written, or a receipt for
+/// this `(schedule_id, slot_ts)` already existed and was refused idempotently
+/// (nothing written). The PK makes the duplicate a uniqueness violation, so the
+/// per-slot decision is recorded AT MOST ONCE even under a daemon race.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RecordFireOutcome {
+    Recorded,
+    Duplicate,
+}
+
+/// Insert one per-slot receipt. ONLY a duplicate `(schedule_id, slot_ts)` PK is
+/// benign — it returns [`RecordFireOutcome::Duplicate`] (the slot was already
+/// considered; the first decision stands), the per-slot at-most-once complement
+/// to the engine's deterministic-run-id `create_run` PK. Every OTHER constraint
+/// failure propagates: in particular an `outcome` outside the closed vocabulary
+/// fails CLOSED (the CHECK error is NOT swallowed — `INSERT OR IGNORE` is
+/// deliberately avoided here precisely because it would mask a bad-vocab CHECK as
+/// a no-op).
+pub fn record_fire(
+    conn: &Connection,
+    schedule_id: &str,
+    slot_ts: i64,
+    outcome: &str,
+    run_id: Option<&str>,
+    detail_token: Option<&str>,
+    now: i64,
+) -> Result<RecordFireOutcome> {
+    let res = conn.execute(
+        "INSERT INTO workflow_schedule_fire
+            (schedule_id, slot_ts, outcome, run_id, detail_token, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        params![schedule_id, slot_ts, outcome, run_id, detail_token, now],
+    );
+    match res {
+        Ok(_) => Ok(RecordFireOutcome::Recorded),
+        // Only a PRIMARY KEY / UNIQUE conflict is the benign already-considered
+        // case; a CHECK (bad outcome vocab) or any other constraint propagates.
+        Err(rusqlite::Error::SqliteFailure(err, _))
+            if err.code == rusqlite::ErrorCode::ConstraintViolation
+                && matches!(
+                    err.extended_code,
+                    rusqlite::ffi::SQLITE_CONSTRAINT_PRIMARYKEY
+                        | rusqlite::ffi::SQLITE_CONSTRAINT_UNIQUE
+                ) =>
+        {
+            Ok(RecordFireOutcome::Duplicate)
+        }
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// Read one fire receipt for a `(schedule_id, slot_ts)`, or `None`.
+pub fn get_fire(conn: &Connection, schedule_id: &str, slot_ts: i64) -> Result<Option<FireReceipt>> {
+    Ok(conn
+        .query_row(
+            "SELECT schedule_id, slot_ts, outcome, run_id, detail_token, created_at
+             FROM workflow_schedule_fire WHERE schedule_id = ?1 AND slot_ts = ?2",
+            params![schedule_id, slot_ts],
+            |r| {
+                Ok(FireReceipt {
+                    schedule_id: r.get(0)?,
+                    slot_ts: r.get(1)?,
+                    outcome: r.get(2)?,
+                    run_id: r.get(3)?,
+                    detail_token: r.get(4)?,
+                    created_at: r.get(5)?,
+                })
+            },
+        )
+        .optional()?)
+}
+
+// --- scheduler control (pause kill-switch) ----------------------------------
+
+/// The `scheduler_control` singleton (id=1). `paused` is the runtime
+/// kill-switch a future tick checks BEFORE reading due schedules.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SchedulerControl {
+    pub paused: bool,
+    pub reason: Option<String>,
+    pub updated_at: i64,
+}
+
+/// Read the control singleton. The migration seeds the row, so this is always
+/// defined; a missing row (hand-rebuilt DB) fails closed as `NotFound` rather
+/// than defaulting to "running".
+pub fn get_control(conn: &Connection) -> Result<SchedulerControl> {
+    conn.query_row(
+        "SELECT paused, reason, updated_at FROM scheduler_control WHERE id = 1",
+        [],
+        |r| {
+            Ok(SchedulerControl {
+                paused: r.get::<_, i64>(0)? != 0,
+                reason: r.get(1)?,
+                updated_at: r.get(2)?,
+            })
+        },
+    )
+    .optional()?
+    .ok_or_else(|| {
+        StorageError::NotFound(
+            "scheduler_control singleton (id=1) is missing; refusing to assume 'running'".into(),
+        )
+    })
+}
+
+/// Set the pause flag + reason on the control singleton. The row is the seeded
+/// singleton; a missing row (hand-rebuilt DB) is `NotFound` (never silently
+/// recreated under a different state).
+pub fn set_paused(conn: &Connection, paused: bool, reason: Option<&str>, now: i64) -> Result<()> {
+    let changed = conn.execute(
+        "UPDATE scheduler_control SET paused = ?1, reason = ?2, updated_at = ?3 WHERE id = 1",
+        params![paused as i64, reason, now],
+    )?;
+    if changed != 1 {
+        return Err(StorageError::NotFound(
+            "scheduler_control singleton (id=1) is missing; cannot set pause state".into(),
+        ));
+    }
+    Ok(())
+}
+
+// --- scheduler lease (single-instance containment) --------------------------
+
+/// The `scheduler_lease` singleton (id=1): an opaque holder token + expiry.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SchedulerLease {
+    pub holder: String,
+    pub expires_at: i64,
+    pub updated_at: i64,
+}
+
+/// Outcome of [`acquire_lease`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LeaseAcquireOutcome {
+    /// The lease was free (no row) or EXPIRED and is now held by the caller.
+    Acquired,
+    /// A DIFFERENT holder's lease is still LIVE (`expires_at > now`); the caller
+    /// must refuse to boot. The containment layer's "refuse a second instance".
+    HeldByOther,
+}
+
+/// Acquire (or supersede an EXPIRED) lease for `holder`, expiring at
+/// `expires_at`. Runs the read-decide-write in ONE IMMEDIATE transaction so two
+/// racing acquirers cannot both observe "free" and both win — IMMEDIATE
+/// serializes them and exactly one acquires.
+///
+/// Rules:
+/// * No lease row → INSERT (Acquired).
+/// * Existing row, same `holder` → refresh expiry (Acquired; idempotent
+///   re-acquire by the live owner).
+/// * Existing row, DIFFERENT holder, `expires_at <= now` (EXPIRED) → supersede
+///   (Acquired; a crashed holder is reclaimed without operator surgery).
+/// * Existing row, DIFFERENT holder, still LIVE → `HeldByOther` (no write).
+pub fn acquire_lease(
+    conn: &Connection,
+    holder: &str,
+    expires_at: i64,
+    now: i64,
+) -> Result<LeaseAcquireOutcome> {
+    let tx = write_tx(conn)?;
+    let existing: Option<(String, i64)> = tx
+        .query_row(
+            "SELECT holder, expires_at FROM scheduler_lease WHERE id = 1",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .optional()?;
+    match existing {
+        None => {
+            tx.execute(
+                "INSERT INTO scheduler_lease (id, holder, expires_at, updated_at)
+                 VALUES (1, ?1, ?2, ?3)",
+                params![holder, expires_at, now],
+            )?;
+            tx.commit()?;
+            Ok(LeaseAcquireOutcome::Acquired)
+        }
+        Some((cur_holder, cur_expires)) => {
+            if cur_holder != holder && cur_expires > now {
+                // Live lease held by another instance → refuse (no write).
+                return Ok(LeaseAcquireOutcome::HeldByOther);
+            }
+            // Same holder (refresh) OR a different but EXPIRED holder (supersede).
+            tx.execute(
+                "UPDATE scheduler_lease SET holder = ?1, expires_at = ?2, updated_at = ?3
+                 WHERE id = 1",
+                params![holder, expires_at, now],
+            )?;
+            tx.commit()?;
+            Ok(LeaseAcquireOutcome::Acquired)
+        }
+    }
+}
+
+/// Refresh the lease expiry for `holder` (a heartbeat). Succeeds only if the
+/// caller STILL holds the lease; if another instance superseded it (the caller's
+/// holder no longer matches), this is `NotFound` and the caller should stand
+/// down rather than keep running believing it holds the lease.
+pub fn refresh_lease(conn: &Connection, holder: &str, expires_at: i64, now: i64) -> Result<()> {
+    let changed = conn.execute(
+        "UPDATE scheduler_lease SET expires_at = ?2, updated_at = ?3
+         WHERE id = 1 AND holder = ?1",
+        params![holder, expires_at, now],
+    )?;
+    if changed != 1 {
+        return Err(StorageError::NotFound(format!(
+            "scheduler_lease is not held by '{holder}' (superseded or absent); refusing to refresh"
+        )));
+    }
+    Ok(())
+}
+
+/// Release the lease IF `holder` still holds it (a clean shutdown). Releasing a
+/// lease the caller no longer holds is a no-op success (it was already
+/// superseded — nothing to release). Returns whether a row was deleted.
+pub fn release_lease(conn: &Connection, holder: &str) -> Result<bool> {
+    let changed = conn.execute(
+        "DELETE FROM scheduler_lease WHERE id = 1 AND holder = ?1",
+        params![holder],
+    )?;
+    Ok(changed == 1)
+}
+
+/// Read the lease singleton (refs-only), or `None` if unheld.
+pub fn get_lease(conn: &Connection) -> Result<Option<SchedulerLease>> {
+    Ok(conn
+        .query_row(
+            "SELECT holder, expires_at, updated_at FROM scheduler_lease WHERE id = 1",
+            [],
+            |r| {
+                Ok(SchedulerLease {
+                    holder: r.get(0)?,
+                    expires_at: r.get(1)?,
+                    updated_at: r.get(2)?,
+                })
+            },
+        )
+        .optional()?)
+}

--- a/rust-core/crates/friday-storage/src/schema.rs
+++ b/rust-core/crates/friday-storage/src/schema.rs
@@ -760,8 +760,9 @@ CREATE UNIQUE INDEX idx_workflow_definition_one_published
 //   non-empty. `workflow_id` names the workflow whose PUBLISHED version a fire
 //   resolves at fire time (no version pinned). `cron_expr` is a RESTRICTED 5-field
 //   subset (min hour dom mon dow; `*`, `*/n`, numeric, comma-lists only) validated
-//   FAIL-CLOSED by the friday-hub `cron_subset` parser at the create boundary AND
-//   re-parsed at every due check — the schema can only structurally guarantee
+//   FAIL-CLOSED by the friday-hub `cron_subset` parser at the create boundary NOW
+//   (a FUTURE due-check re-parse on every tick is a slice-B guard, not yet wired)
+//   — the schema can only structurally guarantee
 //   non-emptiness; the semantic gate is the parser (mirrors how `workflow_def`'s
 //   linear-only semantic gate lives above the row CHECK). `timezone` is UTC-only,
 //   made unrepresentable otherwise by the CHECK (v1 honest restriction — no DST

--- a/rust-core/crates/friday-storage/src/schema.rs
+++ b/rust-core/crates/friday-storage/src/schema.rs
@@ -80,6 +80,18 @@ pub const HUB_ONLY_TABLES: &[&str] = &[
     // holds NO secret/key material — step params are tool-call arguments whose
     // execution is still governed by the gate at run time.
     "workflow_definition",
+    // S10-A: Rust workflow SCHEDULER substrate (DARK — no daemon, no tick loop, no
+    // production route yet; tables created additively, nothing reads/writes them in
+    // production). All four are Hub-only: a schedule references a Hub-only published
+    // workflow definition and a scheduled fire goes through the Hub-coordinated run
+    // engine; the lease/control singletons coordinate a future Hub-side daemon. They
+    // hold NO secret/key material (schedule = workflow_id + restricted cron + flags;
+    // fire = a closed-vocab outcome receipt; control = pause flag/reason; lease = an
+    // opaque holder token + expiry).
+    "workflow_schedule",
+    "workflow_schedule_fire",
+    "scheduler_control",
+    "scheduler_lease",
 ];
 
 /// Tables present only on a phone (never created on the Hub).
@@ -343,6 +355,22 @@ pub fn hub_migrations() -> Vec<Migration> {
             name: "agent_session_conversation_axes",
             destructive: false,
             up: m0023_agent_session_conversation_axes,
+        },
+        // S10-A: Rust workflow SCHEDULER substrate (DARK). Adds the four Hub-only
+        // tables a future scheduler daemon will use — `workflow_schedule` (operator
+        // schedule rows, born disabled, UTC-only, restricted cron), the per-slot
+        // `workflow_schedule_fire` receipt (PK `(schedule_id, slot_ts)` so a slot's
+        // outcome is recorded at-most-once), and the `scheduler_control` /
+        // `scheduler_lease` singletons (runtime pause kill-switch + single-instance
+        // lease). Purely additive (CREATE TABLE + INDEX + one control-singleton seed
+        // INSERT) — touches no existing table, so v23 rows/queries are unaffected. NO
+        // daemon, NO tick loop, NO production route consumes these yet (slices B/C);
+        // the WAL file-mode flip + plist install + enable are operator-gated. NOT v1 GO.
+        Migration {
+            version: 24,
+            name: "workflow_scheduler_substrate",
+            destructive: false,
+            up: m0024_workflow_scheduler_substrate,
         },
     ]
 }
@@ -721,6 +749,83 @@ CREATE INDEX idx_workflow_definition_published
     ON workflow_definition(workflow_id, is_published);
 CREATE UNIQUE INDEX idx_workflow_definition_one_published
     ON workflow_definition(workflow_id) WHERE is_published = 1;";
+
+// --- S10-A workflow-scheduler substrate fragment (Hub-only) -----------------
+
+// DARK scheduler substrate (S10-A). Four Hub-only tables a FUTURE Rust daemon
+// (slices B/C, operator-gated) will use; nothing reads or writes them in
+// production now. Design: `S10_DAEMON_SCHEDULER_DESIGN_20260609.md` §1.3/§1.4/§3.
+//
+// * `workflow_schedule` — operator-assigned schedule rows. `schedule_id` PK,
+//   non-empty. `workflow_id` names the workflow whose PUBLISHED version a fire
+//   resolves at fire time (no version pinned). `cron_expr` is a RESTRICTED 5-field
+//   subset (min hour dom mon dow; `*`, `*/n`, numeric, comma-lists only) validated
+//   FAIL-CLOSED by the friday-hub `cron_subset` parser at the create boundary AND
+//   re-parsed at every due check — the schema can only structurally guarantee
+//   non-emptiness; the semantic gate is the parser (mirrors how `workflow_def`'s
+//   linear-only semantic gate lives above the row CHECK). `timezone` is UTC-only,
+//   made unrepresentable otherwise by the CHECK (v1 honest restriction — no DST
+//   math). `enabled` is BORN DISABLED (DEFAULT 0): creating a schedule never starts
+//   firing; enabling is a second explicit operator act. `last_slot_ts` is the
+//   watermark (last UTC-minute slot CONSIDERED — fired or skipped); NULL until the
+//   first tick considers it, and a future writer advances it monotonically.
+// * `workflow_schedule_fire` — one receipt row per CONSIDERED slot, PK
+//   `(schedule_id, slot_ts)` so a slot's outcome is recorded AT MOST ONCE even
+//   under a daemon race (the per-slot dedupe complement to the engine's
+//   deterministic-run-id `create_run` PK). `outcome` is a CLOSED vocabulary
+//   (anything else is unrepresentable). `run_id` is set only on `'fired'`.
+//   `detail_token` is a bounded closed-vocab token (NEVER engine free text); v1
+//   leaves the column nullable TEXT with the closed vocabulary enforced by the
+//   slice-B tick writer (no value vocab is fixed at the storage layer yet).
+// * `scheduler_control` — singleton (`id=1` CHECK) runtime kill-switch: `paused`
+//   (0/1) checked at the top of every future tick. Seeded `(1, 0, NULL, 0)` by this
+//   migration so a read is always defined (never a missing-row fail).
+// * `scheduler_lease` — singleton (`id=1` CHECK) single-instance lease: an opaque
+//   `holder` token + `expires_at`. NOT seeded (a NULL holder is disallowed); a row
+//   appears only when a daemon acquires the lease at runtime (slice C).
+const DDL_WORKFLOW_SCHEDULER: &str = "
+CREATE TABLE workflow_schedule (
+    schedule_id   TEXT PRIMARY KEY CHECK(length(trim(schedule_id)) > 0),
+    workflow_id   TEXT NOT NULL CHECK(length(trim(workflow_id)) > 0),
+    cron_expr     TEXT NOT NULL CHECK(length(trim(cron_expr)) > 0),
+    timezone      TEXT NOT NULL DEFAULT 'UTC' CHECK(timezone = 'UTC'),
+    enabled       INTEGER NOT NULL DEFAULT 0 CHECK(enabled IN (0, 1)),
+    last_slot_ts  INTEGER,
+    created_at    INTEGER NOT NULL,
+    updated_at    INTEGER NOT NULL
+);
+CREATE INDEX idx_workflow_schedule_enabled ON workflow_schedule(enabled);
+CREATE TABLE workflow_schedule_fire (
+    schedule_id   TEXT NOT NULL,
+    slot_ts       INTEGER NOT NULL,
+    outcome       TEXT NOT NULL CHECK(outcome IN (
+        'fired',
+        'skipped_missed',
+        'skipped_paused',
+        'skipped_no_published',
+        'skipped_previous_awaiting',
+        'invalid_schedule',
+        'error'
+    )),
+    run_id        TEXT,
+    detail_token  TEXT,
+    created_at    INTEGER NOT NULL,
+    PRIMARY KEY(schedule_id, slot_ts)
+);
+CREATE INDEX idx_workflow_schedule_fire_outcome
+    ON workflow_schedule_fire(schedule_id, outcome);
+CREATE TABLE scheduler_control (
+    id         INTEGER PRIMARY KEY CHECK(id = 1),
+    paused     INTEGER NOT NULL CHECK(paused IN (0, 1)),
+    reason     TEXT,
+    updated_at INTEGER NOT NULL
+);
+CREATE TABLE scheduler_lease (
+    id         INTEGER PRIMARY KEY CHECK(id = 1),
+    holder     TEXT NOT NULL CHECK(length(trim(holder)) > 0),
+    expires_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+);";
 
 // --- PNS-001 provider-session fragments (Hub-only) --------------------------
 
@@ -1540,4 +1645,19 @@ fn m0023_agent_session_conversation_axes(tx: &Transaction) -> rusqlite::Result<(
          ALTER TABLE agent_session ADD COLUMN session_kind TEXT
             CHECK(session_kind IS NULL OR session_kind IN ('conversation', 'subagent'));",
     )
+}
+
+// S10-A: DARK Rust workflow-scheduler substrate (the four Hub-only tables in
+// `DDL_WORKFLOW_SCHEDULER` + the `scheduler_control` singleton seed). Purely
+// additive (CREATE TABLE + INDEX, no existing table touched). Seeds the
+// `scheduler_control` row so a pause-check read is always defined (the lease
+// singleton is intentionally left empty — its `holder` cannot be a placeholder).
+// Nothing in production reads or writes these tables in slice A.
+fn m0024_workflow_scheduler_substrate(tx: &Transaction) -> rusqlite::Result<()> {
+    tx.execute_batch(DDL_WORKFLOW_SCHEDULER)?;
+    tx.execute(
+        "INSERT INTO scheduler_control (id, paused, reason, updated_at) VALUES (1, 0, NULL, 0)",
+        [],
+    )?;
+    Ok(())
 }

--- a/rust-core/crates/friday-storage/tests/schedule_persist.rs
+++ b/rust-core/crates/friday-storage/tests/schedule_persist.rs
@@ -1,0 +1,387 @@
+//! S10-A workflow-SCHEDULER substrate persistence tests (DARK substrate):
+//! the additive v23→v24 forward migration (table presence + CHECK constraints +
+//! the seeded control singleton), schedule CRUD (born disabled, missing = error),
+//! watermark monotonicity (refuses to lower), per-slot fire receipt PK dedupe,
+//! control pause read/write, and the single-instance lease (acquire / refresh /
+//! release / supersede-on-expiry, including a real two-connection file-backed
+//! race proving exactly-one acquirer).
+
+mod common;
+
+use common::temp_db_path;
+use friday_storage::schedule::{
+    acquire_lease, delete_schedule, get_control, get_fire, get_lease, get_schedule,
+    insert_schedule, list_enabled_schedules, list_schedules, record_fire, refresh_lease,
+    release_lease, set_enabled, set_last_slot, set_paused, LeaseAcquireOutcome, NewSchedule,
+    RecordFireOutcome,
+};
+use friday_storage::{hub_migrations, Db, Profile, StorageError, HUB_ONLY_TABLES};
+use rusqlite::Connection;
+
+fn hub_max_version() -> i64 {
+    hub_migrations().iter().map(|m| m.version).max().unwrap()
+}
+
+fn new_sched<'a>(id: &'a str, wf: &'a str, cron: &'a str) -> NewSchedule<'a> {
+    NewSchedule {
+        schedule_id: id,
+        workflow_id: wf,
+        cron_expr: cron,
+    }
+}
+
+// --- forward migration v23 -> v24: presence + CHECKs + seeded singleton -----
+
+#[test]
+fn forward_migration_v23_to_v24_adds_scheduler_tables_and_constraints() {
+    let p = temp_db_path("sched-mig");
+    {
+        let mut migs = hub_migrations();
+        migs.retain(|m| m.version <= 23);
+        let db = Db::open(&p, Profile::Hub, &migs, "v23").unwrap();
+        assert_eq!(db.version().unwrap(), 23);
+        for t in [
+            "workflow_schedule",
+            "workflow_schedule_fire",
+            "scheduler_control",
+            "scheduler_lease",
+        ] {
+            assert!(
+                !db.table_names().unwrap().iter().any(|x| x == t),
+                "pre-v24 DB must not have {t}"
+            );
+        }
+    }
+    // Re-open with the full set -> the additive m0024 applies.
+    let db = Db::open_hub(&p).unwrap();
+    assert_eq!(db.version().unwrap(), hub_max_version());
+    let conn = db.conn();
+
+    // The migration SEEDED the control singleton (id=1, paused=0) so a pause read
+    // is always defined.
+    let ctrl = get_control(conn).unwrap();
+    assert!(!ctrl.paused);
+    assert_eq!(ctrl.reason, None);
+
+    // A valid born-disabled insert works on the migrated DB.
+    insert_schedule(conn, &new_sched("s1", "wf1", "*/5 * * * *"), 100).unwrap();
+    assert!(get_schedule(conn, "s1").unwrap().is_some());
+
+    // --- CHECK constraints are enforced by the migrated schema (raw SQL) ---
+    // non-UTC timezone is unrepresentable
+    assert!(
+        conn.execute(
+            "INSERT INTO workflow_schedule
+                (schedule_id, workflow_id, cron_expr, timezone, enabled, created_at, updated_at)
+             VALUES ('bad-tz', 'wf', '* * * * *', 'America/New_York', 0, 1, 1)",
+            [],
+        )
+        .is_err(),
+        "non-UTC timezone must violate the CHECK"
+    );
+    // enabled outside {0,1}
+    assert!(
+        conn.execute(
+            "INSERT INTO workflow_schedule
+                (schedule_id, workflow_id, cron_expr, enabled, created_at, updated_at)
+             VALUES ('bad-en', 'wf', '* * * * *', 2, 1, 1)",
+            [],
+        )
+        .is_err(),
+        "enabled=2 must violate the CHECK"
+    );
+    // empty schedule_id
+    assert!(
+        conn.execute(
+            "INSERT INTO workflow_schedule
+                (schedule_id, workflow_id, cron_expr, created_at, updated_at)
+             VALUES ('   ', 'wf', '* * * * *', 1, 1)",
+            [],
+        )
+        .is_err(),
+        "blank schedule_id must violate the CHECK"
+    );
+    // fire outcome outside the closed vocab
+    assert!(
+        conn.execute(
+            "INSERT INTO workflow_schedule_fire
+                (schedule_id, slot_ts, outcome, created_at)
+             VALUES ('s1', 60000, 'wat', 1)",
+            [],
+        )
+        .is_err(),
+        "an unknown fire outcome must violate the CHECK"
+    );
+    // a valid outcome is accepted
+    conn.execute(
+        "INSERT INTO workflow_schedule_fire
+            (schedule_id, slot_ts, outcome, created_at)
+         VALUES ('s1', 60000, 'fired', 1)",
+        [],
+    )
+    .unwrap();
+    // duplicate (schedule_id, slot_ts) PK is unrepresentable
+    assert!(
+        conn.execute(
+            "INSERT INTO workflow_schedule_fire
+                (schedule_id, slot_ts, outcome, created_at)
+             VALUES ('s1', 60000, 'error', 1)",
+            [],
+        )
+        .is_err(),
+        "duplicate fire PK must be rejected"
+    );
+    // control / lease singleton id must be 1
+    assert!(
+        conn.execute(
+            "INSERT INTO scheduler_control (id, paused, updated_at) VALUES (2, 0, 1)",
+            [],
+        )
+        .is_err(),
+        "scheduler_control id must be 1"
+    );
+    assert!(
+        conn.execute(
+            "INSERT INTO scheduler_lease (id, holder, expires_at, updated_at)
+             VALUES (2, 'h', 1, 1)",
+            [],
+        )
+        .is_err(),
+        "scheduler_lease id must be 1"
+    );
+}
+
+#[test]
+fn scheduler_tables_are_hub_only() {
+    for t in [
+        "workflow_schedule",
+        "workflow_schedule_fire",
+        "scheduler_control",
+        "scheduler_lease",
+    ] {
+        assert!(HUB_ONLY_TABLES.contains(&t), "{t} must be Hub-only");
+    }
+}
+
+// --- schedule CRUD ----------------------------------------------------------
+
+#[test]
+fn insert_is_born_disabled_and_set_enabled_toggles() {
+    let p = temp_db_path("sched-crud");
+    let db = Db::open_hub(&p).unwrap();
+    let conn = db.conn();
+
+    insert_schedule(conn, &new_sched("s1", "wf1", "0 9 * * *"), 100).unwrap();
+    let row = get_schedule(conn, "s1").unwrap().unwrap();
+    assert!(!row.enabled, "a fresh schedule is BORN DISABLED");
+    assert_eq!(row.timezone, "UTC");
+    assert_eq!(row.last_slot_ts, None);
+    assert!(list_enabled_schedules(conn).unwrap().is_empty());
+
+    set_enabled(conn, "s1", true, 200).unwrap();
+    assert!(get_schedule(conn, "s1").unwrap().unwrap().enabled);
+    assert_eq!(list_enabled_schedules(conn).unwrap().len(), 1);
+
+    // a duplicate schedule_id fails closed (PK)
+    assert!(insert_schedule(conn, &new_sched("s1", "wf2", "* * * * *"), 300).is_err());
+
+    // set_enabled / delete on a missing id is NotFound, never a silent no-op
+    assert!(matches!(
+        set_enabled(conn, "ghost", true, 1),
+        Err(StorageError::NotFound(_))
+    ));
+    assert!(matches!(
+        delete_schedule(conn, "ghost"),
+        Err(StorageError::NotFound(_))
+    ));
+
+    delete_schedule(conn, "s1").unwrap();
+    assert!(get_schedule(conn, "s1").unwrap().is_none());
+}
+
+#[test]
+fn list_schedules_is_ordered_and_refs_only() {
+    let p = temp_db_path("sched-list");
+    let db = Db::open_hub(&p).unwrap();
+    let conn = db.conn();
+    insert_schedule(conn, &new_sched("b", "wf", "* * * * *"), 1).unwrap();
+    insert_schedule(conn, &new_sched("a", "wf", "* * * * *"), 1).unwrap();
+    let ids: Vec<String> = list_schedules(conn)
+        .unwrap()
+        .into_iter()
+        .map(|r| r.schedule_id)
+        .collect();
+    assert_eq!(ids, vec!["a", "b"]);
+}
+
+// --- watermark monotonicity -------------------------------------------------
+
+#[test]
+fn set_last_slot_advances_but_refuses_to_lower() {
+    let p = temp_db_path("sched-watermark");
+    let db = Db::open_hub(&p).unwrap();
+    let conn = db.conn();
+    insert_schedule(conn, &new_sched("s1", "wf", "* * * * *"), 1).unwrap();
+
+    set_last_slot(conn, "s1", 60_000, 2).unwrap();
+    assert_eq!(
+        get_schedule(conn, "s1").unwrap().unwrap().last_slot_ts,
+        Some(60_000)
+    );
+    // advancing forward is fine
+    set_last_slot(conn, "s1", 120_000, 3).unwrap();
+    assert_eq!(
+        get_schedule(conn, "s1").unwrap().unwrap().last_slot_ts,
+        Some(120_000)
+    );
+    // equal is an idempotent no-op success
+    set_last_slot(conn, "s1", 120_000, 4).unwrap();
+    // moving BACKWARD is refused (the backwards-clock / re-presented-slot guard)
+    assert!(matches!(
+        set_last_slot(conn, "s1", 60_000, 5),
+        Err(StorageError::Unsupported(_))
+    ));
+    assert_eq!(
+        get_schedule(conn, "s1").unwrap().unwrap().last_slot_ts,
+        Some(120_000),
+        "a refused lower must leave the watermark untouched"
+    );
+    // a missing schedule is NotFound
+    assert!(matches!(
+        set_last_slot(conn, "ghost", 1, 1),
+        Err(StorageError::NotFound(_))
+    ));
+}
+
+// --- per-slot fire receipts (PK dedupe) -------------------------------------
+
+#[test]
+fn record_fire_dedupes_by_slot_pk() {
+    let p = temp_db_path("sched-fire");
+    let db = Db::open_hub(&p).unwrap();
+    let conn = db.conn();
+    insert_schedule(conn, &new_sched("s1", "wf", "* * * * *"), 1).unwrap();
+
+    let first = record_fire(conn, "s1", 60_000, "fired", Some("sched:s1:60000"), None, 2).unwrap();
+    assert_eq!(first, RecordFireOutcome::Recorded);
+    // a SECOND attempt for the same slot is an idempotent Duplicate (the first
+    // decision stands) — the per-slot at-most-once complement to the engine PK.
+    let second = record_fire(conn, "s1", 60_000, "error", None, Some("clock_skew"), 3).unwrap();
+    assert_eq!(second, RecordFireOutcome::Duplicate);
+
+    let got = get_fire(conn, "s1", 60_000).unwrap().unwrap();
+    assert_eq!(got.outcome, "fired", "the first receipt is preserved");
+    assert_eq!(got.run_id.as_deref(), Some("sched:s1:60000"));
+
+    // a different slot records cleanly
+    assert_eq!(
+        record_fire(conn, "s1", 120_000, "skipped_paused", None, None, 4).unwrap(),
+        RecordFireOutcome::Recorded
+    );
+    // an unknown outcome string fails closed at the CHECK
+    assert!(record_fire(conn, "s1", 180_000, "bogus", None, None, 5).is_err());
+}
+
+// --- control (pause kill-switch) --------------------------------------------
+
+#[test]
+fn control_pause_round_trips() {
+    let p = temp_db_path("sched-control");
+    let db = Db::open_hub(&p).unwrap();
+    let conn = db.conn();
+    // seeded by the migration
+    assert!(!get_control(conn).unwrap().paused);
+    set_paused(conn, true, Some("operator drained"), 10).unwrap();
+    let c = get_control(conn).unwrap();
+    assert!(c.paused);
+    assert_eq!(c.reason.as_deref(), Some("operator drained"));
+    set_paused(conn, false, None, 11).unwrap();
+    assert!(!get_control(conn).unwrap().paused);
+}
+
+// --- lease (single-instance) ------------------------------------------------
+
+#[test]
+fn lease_acquire_refresh_release_and_supersede_on_expiry() {
+    let p = temp_db_path("sched-lease");
+    let db = Db::open_hub(&p).unwrap();
+    let conn = db.conn();
+
+    // free lease -> A acquires
+    assert_eq!(
+        acquire_lease(conn, "A", 1_000, 0).unwrap(),
+        LeaseAcquireOutcome::Acquired
+    );
+    assert_eq!(get_lease(conn).unwrap().unwrap().holder, "A");
+
+    // B sees A's LIVE lease (now=500 < expires 1000) and is refused
+    assert_eq!(
+        acquire_lease(conn, "B", 2_000, 500).unwrap(),
+        LeaseAcquireOutcome::HeldByOther
+    );
+    assert_eq!(
+        get_lease(conn).unwrap().unwrap().holder,
+        "A",
+        "A still holds"
+    );
+
+    // A refreshes its own lease (heartbeat)
+    refresh_lease(conn, "A", 3_000, 600).unwrap();
+    assert_eq!(get_lease(conn).unwrap().unwrap().expires_at, 3_000);
+    // B cannot refresh a lease it does not hold
+    assert!(matches!(
+        refresh_lease(conn, "B", 9_000, 600),
+        Err(StorageError::NotFound(_))
+    ));
+
+    // once A's lease EXPIRES (now >= expires_at), B supersedes it
+    assert_eq!(
+        acquire_lease(conn, "B", 5_000, 3_500).unwrap(),
+        LeaseAcquireOutcome::Acquired
+    );
+    assert_eq!(get_lease(conn).unwrap().unwrap().holder, "B");
+
+    // A's stale release is a no-op (it no longer holds); B's release frees it
+    assert!(!release_lease(conn, "A").unwrap());
+    assert!(release_lease(conn, "B").unwrap());
+    assert!(get_lease(conn).unwrap().is_none());
+}
+
+#[test]
+fn lease_two_connection_race_yields_exactly_one_acquirer() {
+    // A REAL two-connection race on a file-backed concurrent (WAL) DB: two
+    // separate connections both try to acquire the free lease "at once". The
+    // IMMEDIATE transaction inside acquire_lease serializes them, so exactly one
+    // observes "free" and wins; the other observes the live lease and is refused.
+    let p = temp_db_path("sched-lease-race");
+    // migrate via the concurrent (WAL + busy_timeout) open path the daemon uses
+    let db = Db::open_hub_concurrent(&p).unwrap();
+    drop(db);
+
+    // Two independent connections (NOT shared) over the same file, both in WAL +
+    // busy_timeout so a contended writer retries instead of erroring.
+    let open = |path: &str| -> Connection {
+        let c = Connection::open(path).unwrap();
+        c.pragma_update(None, "journal_mode", "WAL").unwrap();
+        c.pragma_update(None, "busy_timeout", 5000).unwrap();
+        c
+    };
+    let c1 = open(&p);
+    let c2 = open(&p);
+
+    let r1 = acquire_lease(&c1, "inst-1", 10_000, 0).unwrap();
+    let r2 = acquire_lease(&c2, "inst-2", 10_000, 0).unwrap();
+
+    // Exactly one acquired; the other was refused (HeldByOther).
+    let acquired = [r1, r2]
+        .iter()
+        .filter(|&&o| o == LeaseAcquireOutcome::Acquired)
+        .count();
+    assert_eq!(
+        acquired, 1,
+        "exactly one instance may hold the lease: {r1:?} / {r2:?}"
+    );
+    // the winner is whoever the DB row names; the loser must be HeldByOther
+    let holder = get_lease(&c1).unwrap().unwrap().holder;
+    assert!(holder == "inst-1" || holder == "inst-2");
+}


### PR DESCRIPTION
## Scope — slice A ONLY (DARK substrate)

The storage substrate + cron-subset parser + concurrency hardening for the future S10 Rust workflow-scheduler daemon. **NO daemon process, NO tick loop, NO bin, NO firing, NO production route, NO TS change.** The daemon bin + tick loop + ops + TS-translation tooling are slices B/C/D. **NOT v1 GO.**

Design: `S10_DAEMON_SCHEDULER_DESIGN_20260609.md` §1.3/§1.4 (single-instance + at-most-once), §2 (shared-DB prerequisite), §3 (DDL sketch + cron subset rules + UTC-only + born-disabled), §7 (deploy gates).

## What landed

**friday-storage**
- **Additive migration m0024** — four Hub-only tables (all registered in `HUB_ONLY_TABLES`):
  - `workflow_schedule` — `schedule_id` PK, `workflow_id`, `cron_expr`, `timezone` CHECK=`'UTC'`, `enabled` DEFAULT 0 CHECK(0,1) (**born disabled**), nullable `last_slot_ts` watermark, timestamps.
  - `workflow_schedule_fire` — PK `(schedule_id, slot_ts)` per-slot receipt; `outcome` CHECK in the design's closed vocab; nullable `run_id` (set only on `'fired'`); `detail_token` nullable closed-vocab token (never free text).
  - `scheduler_control` — `id=1` singleton pause kill-switch, **seeded `(1,0,NULL,0)`** so a pause read is always defined.
  - `scheduler_lease` — `id=1` singleton single-instance lease (opaque holder + expiry; not seeded).
- `schedule.rs` — raw row CRUD (refs-only listing), lease acquire/refresh/release (IMMEDIATE-tx, supersede-an-EXPIRED holder, refuse a LIVE one), control read/write, watermark-monotonic `set_last_slot` (refuses to lower), `record_fire`.
- `Db::open_hub_concurrent` — `PRAGMA journal_mode=WAL` + `busy_timeout=5000` on **its own connection only**; additive, **not called by any existing `open_hub` caller**.

**friday-hub**
- `scheduler.rs` — the restricted cron-subset parser + UTC minute-granularity `is_due`/`next_due` evaluator + deterministic `scheduled_run_id` helper + `create_schedule` (the hub-layer create boundary that validates cron fail-closed, then inserts a born-disabled row — semantic validation lives above storage's row CHECKs, mirroring `workflow_def`).

## Cron subset + what FAILS CLOSED

5-field `min hour dom mon dow`, each field one of: `*`, `*/n` (1 ≤ n ≤ field span), a bare numeric, or a comma list of bare numerics. **Fails closed (explicit reason) at BOTH insert-time validation AND the parse-for-due re-check** for: names (`MON`/`JAN`), ranges (`1-5`), step-on-a-range / step-in-a-list (`1-3/2`, `*/5,10`), a seconds field (6+ fields), `L`/`W`/`#`, `*/0`, oversized steps, out-of-range values, and `dow=7` (one canonical Sunday spelling = 0). No external cron crate (the translator's build-the-narrow-subset precedent).

- **dom/dow OR-rule**: standard Vixie — when BOTH dom and dow are restricted, a slot matches if EITHER matches; if either is `*`, AND (the unrestricted one is always-true). KAT'd both ways.
- **`next_due` is bounded** so a genuinely-impossible expr returns `None` (never loops forever); the bound is sized for the **8-year leap-day worst case** (`"0 0 29 2 *"` across a non-leap century like 2100) so `None` means *genuinely never*, not *didn't look far enough*. (This bug — a 1-year bound silently dropping leap-day schedules — was caught in review and fixed + KAT'd.)
- **No `chrono`** in the workspace; the epoch→UTC-fields decomposition uses Hinnant's leap-year-correct `civil_from_days`, KAT'd against known/leap/pre-epoch dates. TZ support is a deliberate v1 deferral (UTC-only CHECK).

## At-most-once design anchor

`scheduled_run_id(schedule_id, slot_ts)` → deterministic `sched:<schedule_id>:<slot_ts>`. The future tick (slice B) will pass this to the **unmodified** engine `run_workflow`, whose first act is `create_run` with `run_id` as PRIMARY KEY (`workflow_exec.rs:115-116`) — so two daemons racing the same slot produce exactly one winning INSERT, the loser fails closed. The `workflow_schedule_fire` PK `(schedule_id, slot_ts)` is the per-slot receipt complement. **This slice builds + tests the FORMATTER + the receipt PK only; it wires NO firing and does not touch the engine.**

`record_fire` distinguishes a benign PK-conflict (→ idempotent `Duplicate`) from a CHECK/bad-vocab failure (→ propagates fail-closed); `INSERT OR IGNORE` is deliberately avoided so a bad outcome vocab can't be masked as a no-op.

## Migration number + forward-migration test

m0024 — verified the highest migration on origin/main is m0023 (#627); **#628 merged on top during this work but is TS-only and does not touch `schema.rs`, so no renumber was needed** (rebased onto #628's `e6b39186`, suite re-run green). The forward-migration test drives a v23 DB → m0024 and asserts table presence **and the CHECK constraints** (non-UTC rejected, `enabled=2` rejected, blank id rejected, bad `outcome` rejected, dup fire-PK rejected, `id=2` rejected on both singletons) + the seeded control singleton.

## Truth labels

DARK substrate — no scheduler running, nothing fires, no production route or daemon consumes these tables; workflow execution remains fenced in TS and is NOT product-replaced. The WAL file-mode flip on prod `rust-hub.sqlite`, the plist install, and enabling any schedule are operator-gated deploy steps (design §7 G1-G5). **NOT v1 GO.**

## Deferred to later slices / operator gates

- **Slice B**: tick engine (pause-check → due-slot computation → claim+fire via the S9 seam under deny-all → receipts).
- **Slice C**: daemon bin + status bin + launchd plist template + CUTOVER doc.
- **Slice D**: TS-translation report + import tooling.
- **Operator deploy gates (design §7)**: G1 WAL flip on prod `rust-hub.sqlite`, G2 plist install, G3 enable flag, G4 translation import, G5 first enabled schedule (the real needle).

## Gates

`cargo test --workspace` (1160 passed / 0 failed), `cargo clippy --all-targets -D warnings` (clean), `cargo fmt --check` (clean), `detect-secrets-hook` on changed files (clean).

Note: the §8 "receipt PK race" is covered by the single-connection dup-PK KAT (`record_fire` → `Duplicate`) + the lease's real two-connection file-backed race proof (identical IMMEDIATE-tx + PK semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)