### PR TITLE
ci(ts-retirement): extend validator with method-guard coverage + manifest-count anti-shrinkage (closes the route-blind gap)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,6 +269,18 @@ jobs:
       - name: Assert ts_runtime_blocker count is zero
         run: node scripts/quality/assert-ts-runtime-blocker-zero.mjs ts-runtime-retirement-report.json
 
+      # SECOND validation phase: the route validator above is structurally blind
+      # to service-METHOD guards. Surfaces that are route-retired but still reach
+      # their mutating service methods off-route (agent tools, UIX/reflex callers,
+      # standing-agenda) are fenced by method-head fail-closed guards (TS-R1 / #628
+      # / #597) that the route validator cannot see — so stripping one would
+      # un-retire a live surface while route blocker stays 0. This gate scans the
+      # configured service files (manifest.methodRetiredSurfaces) and asserts every
+      # declared mutating method still carries its guard, and that the manifest
+      # entry counts have not silently shrunk. Builtins-only; own non-zero exit.
+      - name: Assert TS-runtime method-guard coverage + no manifest shrinkage
+        run: node scripts/quality/assert-ts-runtime-method-guards.mjs
+
   # ── Terminal CI Aggregator — single required check for branch protection ──
   quality-gate:
     runs-on: ubuntu-latest

--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -45,14 +45,28 @@
     "private_reasoning"
   ],
   "methodRetiredSurfaces": {
-    "doc": "Config-driven method-guard coverage for surfaces that are ROUTE-retired but reach their mutating service methods OFF-route (agent tools, UIX/reflex callers, background jobs, standing-agenda). The route validator (discoverRoutes) is structurally blind to these: it only sees src/api/http/routes/**. scripts/quality/assert-ts-runtime-method-guards.mjs SCANS each listed service file and asserts every declared mutating method carries its method-head fail-closed guard (a reference to its `flag`, directly or via `guardHelper`). This closes the route-only-guard defect (POST_TS_RECONCILIATION_LEDGER §1) and the #628 near-miss: original commit ad45080e added guards to only a SUBSET of each surface's mutating methods (it shipped a 31-line generator change / 34-line product change vs. the e6b39186 fixup's 38 / 63), leaving submitTurn, cancelSession, and materializeGeneratedSession route-retired-but-unguarded while the route validator stayed blocker=0. THIS LIST MUST GROW as more surfaces are method-fenced; surfaces that are guarded only at the HTTP route (e.g. standing-agenda, whose runAgendaItem inherits protection from the now-guarded acquisitionService.startRun) are NOT listed here because the route validator already covers them.",
+    "doc": "Config-driven method-guard STRUCTURAL-PRESENCE coverage for surfaces that are ROUTE-retired but reach their mutating service methods OFF-route (agent tools, UIX/reflex callers, background jobs, standing-agenda). The route validator (discoverRoutes) is structurally blind to these: it only sees src/api/http/routes/**. scripts/quality/assert-ts-runtime-method-guards.mjs strips comments + string/template literals, then asserts (A) every declared mutatingMethod shows its method-head fail-closed guard within its OWN brace-matched body (the `flag` directly or via `guardHelper`); (B) every PUBLIC verb-prefixed (mutating-named) method on each service file is either a declared mutatingMethod or a justified allowlistMutators entry (forces NEW mutators to be registered/allowlisted); (C) a behavioralTest file exists per surface. HONEST LIMIT: this is TEXTUAL — it verifies guard PRESENCE, not fail-closed BEHAVIOR (a neutered/inverted guard whose tokens survive reads as present); behavior is proven by the per-surface behavioralTest in the CI `test` job. It also cannot discover a brand-new off-route surface in a NEW file (covered by the route validator + behavioralTest once registered), nor a mutator whose name is not verb-prefixed in mutatorVerbs. This closes the route-only-guard defect (POST_TS_RECONCILIATION_LEDGER §1) and the #628 near-miss (ad45080e left submitTurn/cancelSession/materializeGeneratedSession route-retired-but-unguarded while the route validator stayed blocker=0). THIS LIST MUST GROW as more surfaces are method-fenced; route-only-guarded surfaces (e.g. standing-agenda) are NOT listed here because the route validator already covers them.",
+    "mutatorVerbs": [
+      "run", "execute", "start", "resume", "retry", "cancel", "create", "update",
+      "delete", "approve", "deny", "generate", "submit", "materialize", "sweep",
+      "extract", "remember", "dispatch", "publish", "deploy", "apply", "rollback"
+    ],
+    "mutatorVerbsDoc": "A PUBLIC method (declared in an exported `...Service` interface, or an object-method shorthand with a body in the factory return) is treated as a MUTATOR if its first camelCase segment (lower-cased) is one of these verbs. VERB-PREFIX, not substring: `getRun` => `get` (not a mutator), `startRun` => `start` (mutator). Widen this list as new mutating naming appears; a mutator whose name is not verb-prefixed here (e.g. `upsertApprovalRule`) is a documented heuristic gap.",
     "countFloor": {
-      "doc": "Anti-shrinkage floor: a CI-comparable baseline of manifest entry counts + the count of declared method-guard assertions. The assertion fails if any count drops BELOW its baseline, forcing a conscious, reviewable baseline edit in the same PR when a surface is legitimately removed/reclassified or a guard is intentionally retired. byClassification is EMITTED for review but NOT floored: fail_closed legitimately shrinks as surfaces move to Rust ownership, so flooring it would false-fail real progress.",
+      "doc": "Anti-shrinkage floor: a CI-comparable baseline of manifest entry counts + per-surface method-guard counts. The assertion fails if any count drops BELOW its baseline, forcing a conscious, reviewable baseline edit in the same PR when a surface is legitimately removed/reclassified or a guard is intentionally retired. perSurfaceMethodsMin floors EACH registered surface (present + >= its method count) so 'drop a surface + add filler' cannot hold the grand total. behavioralTestsMin floors the count of surfaces backed by an existing behavioral test so one documented missing-test gap cannot be copied to null out the others. byClassification is EMITTED for review but NOT floored: fail_closed legitimately shrinks as surfaces move to Rust ownership.",
       "surfacesMin": 279,
       "routeFamiliesMin": 18,
       "guardedMethodsMin": 12,
+      "perSurfaceMethodsMin": {
+        "capability_acquisition": 3,
+        "workflow_generator": 5,
+        "system_intent": 1,
+        "workflow_deploy": 2,
+        "autonomy_policy": 1
+      },
+      "behavioralTestsMin": 5,
       "baselineCommit": "e6b39186",
-      "baselineNote": "Set from origin/main e6b39186 (post-#628 TS-R1 4-surface mirror + #597 autonomy-policy). Lower a *Min only in a PR that also removes the corresponding entry/guard, so the reviewer sees the de-retirement."
+      "baselineNote": "Set from origin/main e6b39186 (post-#628 TS-R1 4-surface mirror + #597 autonomy-policy). Lower a *Min / drop a perSurfaceMethodsMin entry only in a PR that also removes the corresponding entry/guard, so the reviewer sees the de-retirement."
     },
     "surfaces": [
       {
@@ -62,8 +76,9 @@
         "flag": "allowTestOnlyCapabilityAcquisitionExecution",
         "guardHelper": "assertCapabilityAcquisitionExecutionAllowed",
         "mutatingMethods": ["startRun", "approveRun", "cancelRun"],
+        "behavioralTest": "test/unit/autonomy/friday-capability-acquisition-retirement-guard.test.ts",
         "off_route_callers": "agent controlled-autonomy tool (acquisition_start/approve/cancel) + standing-agenda runAgendaItem",
-        "note": "Reads plan/getRun stay live; only run mutations are method-fenced. Guard added in #628/ad45080e."
+        "note": "Reads plan/getRun stay live (verb-prefix `get` is not a mutator, so the registration scan does not flag them); only run mutations are method-fenced. Guard added in #628/ad45080e."
       },
       {
         "id": "workflow_generator",
@@ -72,8 +87,9 @@
         "flag": "allowTestOnlyWorkflowGeneratorExecution",
         "guardHelper": "assertWorkflowGeneratorExecutionAllowed",
         "mutatingMethods": ["startSession", "submitTurn", "generateDraft", "approveAndSave", "cancelSession"],
+        "behavioralTest": "test/unit/workflows/generator/services/friday-workflow-generator-retirement-guard.test.ts",
         "off_route_callers": "agent tool 'turn' / UIX continueWorkflowSession",
-        "note": "submitTurn + cancelSession were the unguarded route-retired mutators the e6b39186 fixup of #628 closed; getSession/getQaVerdict/getHarnessSummary stay live."
+        "note": "submitTurn + cancelSession were the unguarded route-retired mutators the e6b39186 fixup of #628 closed; getSession/getQaVerdict/getHarnessSummary stay live (read prefixes, not flagged). deleteDraft is a factory-internal helper (not a returned/interface member) called by the guarded methods, so it is correctly NOT flagged as a public mutator."
       },
       {
         "id": "system_intent",
@@ -81,8 +97,15 @@
         "serviceFile": "src/system/engine/friday-system-service.ts",
         "flag": "allowTestOnlySystemIntentExecution",
         "mutatingMethods": ["executeIntent"],
+        "behavioralTest": "test/unit/system/friday-system-intent-retirement-guard.test.ts",
+        "allowlistMutators": [
+          {
+            "method": "updateApprovalRule",
+            "reason": "Public mutator on this service file, but NOT a test-oracle retirement surface. Its route (`system_approvals_update`, /v1/system/approvals/:approvalId) is independently classified fail_closed and covered by the route validator. At the METHOD boundary it carries the canonical-approval gate `assertLegacyApprovalRuleMutationAllowed`, which is a DIFFERENT mechanism AND polarity than test-oracle retirement: it is open-by-default and throws only when the canonical mutation gate is engaged (`if (!canonicalMutationGate) return; throw ...`), whereas methodRetiredSurfaces guards are fail-closed-by-default (`if (flag !== true) throw`). Registering it would falsely assert a fail-closed property it does not have. Allowlisted (not folded into mutatingMethods) so this conscious de-coverage decision is visible in the manifest diff."
+          }
+        ],
         "off_route_callers": "agent system tool (executeIntent only)",
-        "note": "Inline guard on the executeIntent wrapper (NOT executeIntentInternal); getSession/getState/listEvents stay live. Guard added in #628/ad45080e."
+        "note": "Inline guard on the executeIntent wrapper (NOT executeIntentInternal — that internal helper is not a returned/interface member, so the scan does not flag it); getSession/getState/listEvents stay live. Guard added in #628/ad45080e. updateApprovalRule is a public mutator handled via allowlistMutators (different guard mechanism — see reason)."
       },
       {
         "id": "workflow_deploy",
@@ -90,8 +113,9 @@
         "serviceFile": "src/workflows/services/friday-workflow-product-service.ts",
         "flag": "allowTestOnlyWorkflowDeployExecution",
         "mutatingMethods": ["deployDraft", "materializeGeneratedSession"],
+        "behavioralTest": "test/unit/workflows/friday-workflow-product-retirement-guard.test.ts",
         "off_route_callers": "UIX start/continue/generate-workflow",
-        "note": "materializeGeneratedSession persists a workflow row + draft in both branches (was mislabeled a 'stays-live read' in ad45080e); the e6b39186 fixup guarded it. getOverview/getVisualization stay live."
+        "note": "materializeGeneratedSession persists a workflow row + draft in both branches (was mislabeled a 'stays-live read' in ad45080e); the e6b39186 fixup guarded it. getOverview/getVisualization stay live. Inline-guarded (no helper) with TWO independent `allowTestOnlyWorkflowDeployExecution !== true` throws — the brace-matched per-method body check requires EACH method to show its own throw (a sibling's no longer satisfies the other)."
       },
       {
         "id": "autonomy_policy",
@@ -99,8 +123,9 @@
         "serviceFile": "src/autonomy/services/friday-autonomy-policy-service.ts",
         "flag": "allowTestOnlyAutonomyPolicyMutation",
         "mutatingMethods": ["updatePolicy"],
+        "behavioralTest": "test/unit/autonomy/friday-controlled-autonomy-services.test.ts",
         "off_route_callers": "agent controlled-autonomy tool (policy_update)",
-        "note": "Inline guard; synchronous (non-async) method. Reads getPolicy/evaluateRisks stay live. Guard added in #597."
+        "note": "Inline guard; synchronous (non-async) method. Reads getPolicy/evaluateRisks stay live. Guard added in #597. behavioralTest points to friday-controlled-autonomy-services.test.ts (its 'updatePolicy METHOD-level fail-closed' describe block) rather than a `*-retirement-guard*` file because the naming convention is non-uniform here."
       }
     ]
   },

--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -44,6 +44,66 @@
     "raw_commands",
     "private_reasoning"
   ],
+  "methodRetiredSurfaces": {
+    "doc": "Config-driven method-guard coverage for surfaces that are ROUTE-retired but reach their mutating service methods OFF-route (agent tools, UIX/reflex callers, background jobs, standing-agenda). The route validator (discoverRoutes) is structurally blind to these: it only sees src/api/http/routes/**. scripts/quality/assert-ts-runtime-method-guards.mjs SCANS each listed service file and asserts every declared mutating method carries its method-head fail-closed guard (a reference to its `flag`, directly or via `guardHelper`). This closes the route-only-guard defect (POST_TS_RECONCILIATION_LEDGER §1) and the #628 near-miss: original commit ad45080e added guards to only a SUBSET of each surface's mutating methods (it shipped a 31-line generator change / 34-line product change vs. the e6b39186 fixup's 38 / 63), leaving submitTurn, cancelSession, and materializeGeneratedSession route-retired-but-unguarded while the route validator stayed blocker=0. THIS LIST MUST GROW as more surfaces are method-fenced; surfaces that are guarded only at the HTTP route (e.g. standing-agenda, whose runAgendaItem inherits protection from the now-guarded acquisitionService.startRun) are NOT listed here because the route validator already covers them.",
+    "countFloor": {
+      "doc": "Anti-shrinkage floor: a CI-comparable baseline of manifest entry counts + the count of declared method-guard assertions. The assertion fails if any count drops BELOW its baseline, forcing a conscious, reviewable baseline edit in the same PR when a surface is legitimately removed/reclassified or a guard is intentionally retired. byClassification is EMITTED for review but NOT floored: fail_closed legitimately shrinks as surfaces move to Rust ownership, so flooring it would false-fail real progress.",
+      "surfacesMin": 279,
+      "routeFamiliesMin": 18,
+      "guardedMethodsMin": 12,
+      "baselineCommit": "e6b39186",
+      "baselineNote": "Set from origin/main e6b39186 (post-#628 TS-R1 4-surface mirror + #597 autonomy-policy). Lower a *Min only in a PR that also removes the corresponding entry/guard, so the reviewer sees the de-retirement."
+    },
+    "surfaces": [
+      {
+        "id": "capability_acquisition",
+        "family_code": "TS_RUNTIME_CAPABILITY_ACQUISITION_RETIRED",
+        "serviceFile": "src/autonomy/services/friday-capability-acquisition-service.ts",
+        "flag": "allowTestOnlyCapabilityAcquisitionExecution",
+        "guardHelper": "assertCapabilityAcquisitionExecutionAllowed",
+        "mutatingMethods": ["startRun", "approveRun", "cancelRun"],
+        "off_route_callers": "agent controlled-autonomy tool (acquisition_start/approve/cancel) + standing-agenda runAgendaItem",
+        "note": "Reads plan/getRun stay live; only run mutations are method-fenced. Guard added in #628/ad45080e."
+      },
+      {
+        "id": "workflow_generator",
+        "family_code": "TS_RUNTIME_WORKFLOW_GENERATOR_RETIRED",
+        "serviceFile": "src/workflows/generator/services/friday-workflow-generator-service.ts",
+        "flag": "allowTestOnlyWorkflowGeneratorExecution",
+        "guardHelper": "assertWorkflowGeneratorExecutionAllowed",
+        "mutatingMethods": ["startSession", "submitTurn", "generateDraft", "approveAndSave", "cancelSession"],
+        "off_route_callers": "agent tool 'turn' / UIX continueWorkflowSession",
+        "note": "submitTurn + cancelSession were the unguarded route-retired mutators the e6b39186 fixup of #628 closed; getSession/getQaVerdict/getHarnessSummary stay live."
+      },
+      {
+        "id": "system_intent",
+        "family_code": "TS_RUNTIME_SYSTEM_INTENT_RETIRED",
+        "serviceFile": "src/system/engine/friday-system-service.ts",
+        "flag": "allowTestOnlySystemIntentExecution",
+        "mutatingMethods": ["executeIntent"],
+        "off_route_callers": "agent system tool (executeIntent only)",
+        "note": "Inline guard on the executeIntent wrapper (NOT executeIntentInternal); getSession/getState/listEvents stay live. Guard added in #628/ad45080e."
+      },
+      {
+        "id": "workflow_deploy",
+        "family_code": "TS_RUNTIME_WORKFLOW_DEPLOY_RETIRED",
+        "serviceFile": "src/workflows/services/friday-workflow-product-service.ts",
+        "flag": "allowTestOnlyWorkflowDeployExecution",
+        "mutatingMethods": ["deployDraft", "materializeGeneratedSession"],
+        "off_route_callers": "UIX start/continue/generate-workflow",
+        "note": "materializeGeneratedSession persists a workflow row + draft in both branches (was mislabeled a 'stays-live read' in ad45080e); the e6b39186 fixup guarded it. getOverview/getVisualization stay live."
+      },
+      {
+        "id": "autonomy_policy",
+        "family_code": "TS_RUNTIME_AUTONOMY_POLICY_MUTATION_RETIRED",
+        "serviceFile": "src/autonomy/services/friday-autonomy-policy-service.ts",
+        "flag": "allowTestOnlyAutonomyPolicyMutation",
+        "mutatingMethods": ["updatePolicy"],
+        "off_route_callers": "agent controlled-autonomy tool (policy_update)",
+        "note": "Inline guard; synchronous (non-async) method. Reads getPolicy/evaluateRisks stay live. Guard added in #597."
+      }
+    ]
+  },
   "routeFamilies": [
     {
       "id": "mission_spine_rust_projection",

--- a/scripts/quality/assert-ts-runtime-method-guards.mjs
+++ b/scripts/quality/assert-ts-runtime-method-guards.mjs
@@ -1,0 +1,376 @@
+#!/usr/bin/env node
+/**
+ * TS-Runtime-Retirement: method-guard coverage + manifest anti-shrinkage gate.
+ *
+ * Second-phase companion to scripts/quality/check-ts-runtime-retirement.mjs.
+ *
+ * WHY THIS EXISTS (the route-blind gap):
+ *   The route validator discovers HTTP routes (discoverRoutes over
+ *   src/api/http/routes/**) and classifies each one. Its blocker==0 guarantee is
+ *   therefore ROUTE-scoped. It is structurally blind to service-method guards:
+ *   when a surface is route-retired but its mutating service methods are still
+ *   reachable OFF-route (agent tools, UIX/reflex callers, background jobs,
+ *   standing-agenda), the route validator sees nothing. The retirement of those
+ *   surfaces lives in METHOD-head fail-closed guards (TS-R1 / #628 / #597) that
+ *   the route validator cannot see — so a future regression that strips one of
+ *   those method guards would un-retire a live surface while the route validator
+ *   stays blocker=0. PR #628's original commit ad45080e was exactly this near
+ *   miss: it added guards to only a SUBSET of each surface's mutating methods
+ *   (submitTurn, cancelSession, materializeGeneratedSession were left
+ *   route-retired-but-unguarded), and nothing gated on it.
+ *
+ * WHAT THIS ASSERTS (additive; does NOT touch route classification):
+ *   PHASE A — method-guard coverage. For each surface in
+ *     manifest.methodRetiredSurfaces.surfaces, scan its serviceFile and assert
+ *     EVERY declared mutatingMethod carries its method-head fail-closed guard:
+ *       - the method's definition head can be located (else FAIL — stale config
+ *         or matcher bug, never silently skip), AND
+ *       - within that method's body window, the surface's guard token appears
+ *         (the guardHelper call for helper-services, or a direct `flag` ref for
+ *         inline-guarded ones).
+ *     Backstops: (1) the serviceFile must contain the literal
+ *       `<flag> !== true` throw at least once (so gutting a shared helper body is
+ *       caught, not just removing a call); (2) for helper-services, the count of
+ *       guardHelper call-sites must be >= the count of declared mutating methods.
+ *
+ *   PHASE B — manifest anti-shrinkage floor. Emit manifest.surfaces.length,
+ *     manifest.routeFamilies.length, and the total declared guarded-method count,
+ *     and assert none has dropped below its baseline floor in
+ *     methodRetiredSurfaces.countFloor. byClassification is EMITTED for review
+ *     but intentionally NOT floored (fail_closed legitimately shrinks on Rust
+ *     takeover). A legitimate removal forces a conscious baseline-lower in the
+ *     same PR, which the reviewer sees.
+ *
+ * Node: builtins only — no dependencies, no `npm ci` required (the CI job that
+ * runs this has no install step).
+ *
+ * Usage: node scripts/quality/assert-ts-runtime-method-guards.mjs [--repo-root <dir>] [--manifest <path>] [--json]
+ *   Exits 0 on full coverage + no shrinkage, non-zero otherwise.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_MANIFEST = "docs/ops/ts-runtime-retirement-manifest.json";
+
+export function parseArgs(argv) {
+  const args = { repoRoot: process.cwd(), manifestPath: DEFAULT_MANIFEST, json: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const entry = argv[index];
+    if (entry === "--manifest") {
+      args.manifestPath = argv[index + 1];
+      index += 1;
+    } else if (entry === "--repo-root") {
+      args.repoRoot = argv[index + 1];
+      index += 1;
+    } else if (entry === "--json") {
+      args.json = true;
+    } else if (!entry.startsWith("--")) {
+      args.repoRoot = entry;
+    }
+  }
+  return args;
+}
+
+/**
+ * Locate every definition-head line for `methodName` in `lines`.
+ * A definition head is the method name immediately followed by `(`, in one of
+ * the forms actually used across the guarded services:
+ *   - `async function startRun(` / `function cancelRun(` / `function updatePolicy(`
+ *   - object-method shorthand: `async submitTurn(` / `async deployDraft(input) {`
+ *   - assigned arrow: `const executeIntent = async (`
+ * We exclude:
+ *   - calls and longer identifiers (word-boundary on both sides of the name),
+ *   - interface signature lines (no body — they have neither `async`, `function`,
+ *     `=>`/`= async`, nor a trailing `{`; e.g. `executeIntent(input): Promise<X>;`).
+ *     Interface object-param sigs like `deployDraft(input: {` ARE tolerated as
+ *     candidate heads: they simply won't contain the guard token in their window,
+ *     and the impl head (which does) satisfies the per-method requirement.
+ */
+function findDefinitionHeadLines(lines, methodName) {
+  const heads = [];
+  // name as a standalone identifier (not preceded/followed by identifier chars)
+  // immediately followed by optional whitespace then `(`.
+  const nameCall = new RegExp(`(?<![A-Za-z0-9_$])${escapeRegExp(methodName)}\\s*\\(`);
+  const assignedArrow = new RegExp(
+    `(?:const|let|var)\\s+${escapeRegExp(methodName)}\\s*=\\s*async\\b`,
+  );
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (assignedArrow.test(line)) {
+      heads.push(index);
+      continue;
+    }
+    if (!nameCall.test(line)) {
+      continue;
+    }
+    const isFunctionForm = /\b(?:async\s+)?function\s+/.test(line)
+      || /^\s*(?:public|private|protected\s+)?(?:async\s+)?[A-Za-z0-9_$]+\s*\(/.test(line);
+    if (!isFunctionForm) {
+      // A bare `methodName(...)` call site inside other code — skip it.
+      continue;
+    }
+    heads.push(index);
+  }
+  return heads;
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+/**
+ * The body window for the head at `headLine` runs until the next definition head
+ * (of ANY declared mutating method in this file) or +`maxWindow` lines, whichever
+ * is first. Using the next declared head as the bound prevents one method's
+ * window from false-passing on a neighbouring method's guard.
+ */
+function windowEnd(headLine, allHeadLines, maxWindow, totalLines) {
+  let bound = Math.min(headLine + maxWindow, totalLines);
+  for (const other of allHeadLines) {
+    if (other > headLine && other < bound) {
+      bound = other;
+    }
+  }
+  return bound;
+}
+
+export function evaluateSurface(repoRoot, surface) {
+  const failures = [];
+  const details = { id: surface.id, serviceFile: surface.serviceFile, methods: {} };
+  const absolute = path.join(repoRoot, surface.serviceFile);
+  if (!fs.existsSync(absolute)) {
+    failures.push(`surface ${surface.id}: serviceFile ${surface.serviceFile} not found`);
+    return { failures, details };
+  }
+  const source = fs.readFileSync(absolute, "utf8");
+  const lines = source.split("\n");
+
+  const flag = surface.flag;
+  if (typeof flag !== "string" || flag.length === 0) {
+    failures.push(`surface ${surface.id}: config missing 'flag'`);
+    return { failures, details };
+  }
+
+  // Backstop 1: the actual fail-closed throw must exist at least once, so gutting
+  // a shared guard helper's body (while keeping its callers) is still caught.
+  const throwRegex = new RegExp(`${escapeRegExp(flag)}\\s*!==\\s*true`);
+  details.hasFlagThrow = throwRegex.test(source);
+  if (!details.hasFlagThrow) {
+    failures.push(
+      `surface ${surface.id}: no \`${flag} !== true\` fail-closed throw in ${surface.serviceFile} `
+      + "(the method-head guard body is missing or was gutted)",
+    );
+  }
+
+  // The token each guarded method body must contain: the guardHelper call if the
+  // surface uses a named helper, else a direct reference to the flag.
+  const guardHelper = surface.guardHelper;
+  const guardTokenRegex = guardHelper
+    ? new RegExp(`(?<![A-Za-z0-9_$])${escapeRegExp(guardHelper)}\\s*\\(`)
+    : new RegExp(`(?<![A-Za-z0-9_$])${escapeRegExp(flag)}(?![A-Za-z0-9_$])`);
+
+  // Collect every declared method's definition heads up front so each window can
+  // be bounded by the next declared head.
+  const allHeads = [];
+  const headsByMethod = {};
+  for (const methodName of surface.mutatingMethods ?? []) {
+    const heads = findDefinitionHeadLines(lines, methodName);
+    headsByMethod[methodName] = heads;
+    for (const head of heads) {
+      allHeads.push(head);
+    }
+  }
+  allHeads.sort((left, right) => left - right);
+
+  for (const methodName of surface.mutatingMethods ?? []) {
+    const heads = headsByMethod[methodName];
+    if (heads.length === 0) {
+      failures.push(
+        `surface ${surface.id}: declared mutating method '${methodName}' has no locatable `
+        + `definition head in ${surface.serviceFile} (stale config or matcher needs updating — `
+        + "investigate, do NOT remove the method from config to make this pass)",
+      );
+      details.methods[methodName] = { located: false, guarded: false };
+      continue;
+    }
+    // At least ONE definition head of this method must carry the guard token in
+    // its window (the impl head; interface sigs won't).
+    let guarded = false;
+    let guardedAtLine = null;
+    for (const head of heads) {
+      const end = windowEnd(head, allHeads, 24, lines.length);
+      const windowText = lines.slice(head, end).join("\n");
+      if (guardTokenRegex.test(windowText)) {
+        guarded = true;
+        guardedAtLine = head + 1;
+        break;
+      }
+    }
+    details.methods[methodName] = { located: true, guarded, guardedAtLine, headLines: heads.map((h) => h + 1) };
+    if (!guarded) {
+      const tokenLabel = guardHelper ? `${guardHelper}()` : flag;
+      failures.push(
+        `surface ${surface.id}: mutating method '${methodName}' is route-retired but its `
+        + `method-head guard (${tokenLabel}) is MISSING — a regression un-retired this surface `
+        + `off-route while the route validator stays blocker=0 (${surface.serviceFile})`,
+      );
+    }
+  }
+
+  // Backstop 2: for helper-services, guard-call-site count must cover the
+  // declared mutators (catches dropping a guard from one of several methods even
+  // if some other path keeps the helper referenced).
+  if (guardHelper) {
+    const callSiteRegex = new RegExp(`(?<![A-Za-z0-9_$])${escapeRegExp(guardHelper)}\\s*\\(`, "gu");
+    const callSites = (source.match(callSiteRegex) ?? []).length;
+    // The helper's own declaration (`function assert...() {`) is one occurrence;
+    // subtract it so we count true call-sites.
+    const declRegex = new RegExp(`function\\s+${escapeRegExp(guardHelper)}\\s*\\(`);
+    const declCount = declRegex.test(source) ? 1 : 0;
+    const effectiveCalls = callSites - declCount;
+    const required = (surface.mutatingMethods ?? []).length;
+    details.guardHelperCallSites = effectiveCalls;
+    details.guardHelperRequired = required;
+    if (effectiveCalls < required) {
+      failures.push(
+        `surface ${surface.id}: ${effectiveCalls} ${guardHelper}() call-site(s) but ${required} `
+        + "declared mutating method(s) — a guard call was dropped from at least one method",
+      );
+    }
+  }
+
+  return { failures, details };
+}
+
+export function evaluateManifest(repoRoot, manifest) {
+  const failures = [];
+  const config = manifest.methodRetiredSurfaces;
+  if (!config || typeof config !== "object") {
+    failures.push("manifest is missing methodRetiredSurfaces config (method-guard coverage cannot run)");
+    return { failures, report: { phaseA: {}, phaseB: {} } };
+  }
+
+  // ── PHASE A: method-guard coverage ──
+  const surfaceReports = [];
+  let totalDeclaredMethods = 0;
+  for (const surface of config.surfaces ?? []) {
+    totalDeclaredMethods += (surface.mutatingMethods ?? []).length;
+    const { failures: surfaceFailures, details } = evaluateSurface(repoRoot, surface);
+    failures.push(...surfaceFailures);
+    surfaceReports.push(details);
+  }
+
+  // ── PHASE B: manifest anti-shrinkage floor ──
+  const floor = config.countFloor ?? {};
+  const surfacesLength = Array.isArray(manifest.surfaces) ? manifest.surfaces.length : 0;
+  const routeFamiliesLength = Array.isArray(manifest.routeFamilies) ? manifest.routeFamilies.length : 0;
+
+  const byClassification = {};
+  for (const surface of manifest.surfaces ?? []) {
+    const c = surface.classification ?? "<unclassified>";
+    byClassification[c] = (byClassification[c] ?? 0) + 1;
+  }
+
+  assertFloor(failures, "surfaces.length", surfacesLength, floor.surfacesMin);
+  assertFloor(failures, "routeFamilies.length", routeFamiliesLength, floor.routeFamiliesMin);
+  assertFloor(failures, "declared guarded methods", totalDeclaredMethods, floor.guardedMethodsMin);
+
+  return {
+    failures,
+    report: {
+      phaseA: {
+        surfaceCount: (config.surfaces ?? []).length,
+        totalDeclaredMethods,
+        surfaces: surfaceReports,
+      },
+      phaseB: {
+        surfacesLength,
+        surfacesMin: floor.surfacesMin ?? null,
+        routeFamiliesLength,
+        routeFamiliesMin: floor.routeFamiliesMin ?? null,
+        guardedMethodsTotal: totalDeclaredMethods,
+        guardedMethodsMin: floor.guardedMethodsMin ?? null,
+        byClassification,
+        baselineCommit: floor.baselineCommit ?? null,
+      },
+    },
+  };
+}
+
+function assertFloor(failures, label, actual, min) {
+  if (typeof min !== "number") {
+    failures.push(`anti-shrinkage: countFloor is missing a numeric floor for ${label}`);
+    return;
+  }
+  if (actual < min) {
+    failures.push(
+      `anti-shrinkage: ${label} dropped to ${actual}, below baseline floor ${min}. `
+      + "A retirement surface/guard was silently removed. If this removal is intentional, "
+      + "LOWER the corresponding *Min in methodRetiredSurfaces.countFloor IN THIS PR so the "
+      + "de-retirement is consciously reviewed — do not let it pass invisibly.",
+    );
+  }
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const repoRoot = path.resolve(args.repoRoot);
+  const manifestPath = path.isAbsolute(args.manifestPath)
+    ? args.manifestPath
+    : path.join(repoRoot, args.manifestPath);
+  let manifest;
+  try {
+    manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  } catch (error) {
+    console.error(`❌ ts-runtime method-guard gate FAILED: cannot read/parse manifest at ${manifestPath}: ${error.message}`);
+    process.exit(1);
+  }
+
+  const { failures, report } = evaluateManifest(repoRoot, manifest);
+  const status = failures.length === 0 ? "passed" : "failed";
+  const output = {
+    generatedAt: new Date().toISOString(),
+    repoRoot,
+    manifestPath,
+    status,
+    report,
+    failures,
+  };
+
+  if (args.json) {
+    console.log(JSON.stringify(output, null, 2));
+  } else {
+    const a = report.phaseA;
+    const b = report.phaseB;
+    console.log("── TS-runtime method-guard coverage (Phase A) ──");
+    for (const s of a.surfaces ?? []) {
+      const methodLines = Object.entries(s.methods)
+        .map(([name, m]) => `${name}=${m.guarded ? "guarded" : (m.located ? "UNGUARDED" : "NOT-FOUND")}`)
+        .join(", ");
+      console.log(`  ${s.id} (${s.serviceFile}): ${methodLines}`);
+    }
+    console.log(`  surfaces=${a.surfaceCount}, declared guarded methods=${a.totalDeclaredMethods}`);
+    console.log("── Manifest anti-shrinkage (Phase B) ──");
+    console.log(`  surfaces.length=${b.surfacesLength} (floor ${b.surfacesMin})`);
+    console.log(`  routeFamilies.length=${b.routeFamiliesLength} (floor ${b.routeFamiliesMin})`);
+    console.log(`  declared guarded methods=${b.guardedMethodsTotal} (floor ${b.guardedMethodsMin})`);
+    console.log(`  byClassification (emitted, not floored): ${JSON.stringify(b.byClassification)}`);
+  }
+
+  if (failures.length > 0) {
+    console.error(`\n❌ ts-runtime method-guard gate FAILED (${failures.length} finding(s)):`);
+    for (const failure of failures) {
+      console.error(`  - ${failure}`);
+    }
+    process.exit(1);
+  }
+  console.log("\n✅ ts-runtime method-guard coverage complete + no manifest shrinkage.");
+  process.exit(0);
+}
+
+const currentFile = fileURLToPath(import.meta.url);
+if (process.argv[1] && path.resolve(process.argv[1]) === currentFile) {
+  main();
+}

--- a/scripts/quality/assert-ts-runtime-method-guards.mjs
+++ b/scripts/quality/assert-ts-runtime-method-guards.mjs
@@ -9,12 +9,18 @@
  *
  * This is a TEXTUAL gate. It verifies the STRUCTURAL PRESENCE of method-head
  * fail-closed guards (after stripping comments + string/template literals so a
- * commented-out or JSDoc'd guard cannot false-pass). It does NOT, and a textual
- * gate CANNOT, verify fail-closed BEHAVIOR — a neutered or inverted guard whose
- * tokens survive (e.g. `if (flag === true) throw`) would still read as "present".
- * Behavior is covered by the per-surface BEHAVIORAL TESTS that this gate requires
- * to EXIST (manifest `behavioralTest`); those run in the CI `test` job and are the
- * real proof that the guard fails closed.
+ * commented-out or JSDoc'd guard cannot false-pass). For INLINE surfaces it now
+ * requires the actual fail-closed FORM `<flag> !== true` within the method's own
+ * body (the same form Backstop 1 checks) — NOT a bare mention of the flag — so a
+ * benign reference (`logger.debug({ x: deps.<flag> })`) can no longer be mistaken
+ * for a guard. That closes the bare-mention false-GREEN (the ad45080e class), where
+ * a method's real throw is dropped but an incidental flag reference keeps it reading
+ * as "guarded". It does NOT, and a textual gate CANNOT, verify fail-closed BEHAVIOR:
+ * the `<flag> !== true` form can be PRESENT yet not actually fail closed (e.g.
+ * `if (deps.<flag> !== true) return;` instead of `throw`) — still a FORM check, not
+ * a behavior proof. Behavior is covered by the per-surface BEHAVIORAL TESTS that this
+ * gate requires to EXIST (manifest `behavioralTest`); those run in the CI `test` job
+ * and are the real proof that the guard fails closed.
  *
  * WHAT THIS GATE GUARANTEES:
  *   - STRUCTURAL guard presence: every declared mutating method on a registered
@@ -510,9 +516,17 @@ export function evaluateSurface(repoRoot, surface, mutatorVerbs) {
     return { failures, details };
   }
 
+  // The fail-closed FORM pattern, shared between Backstop 1 (file-level presence)
+  // and the inline per-method guard token below, so the two stay in lockstep and
+  // cannot drift. This is `<flag> !== true` — the exact form every inline guard
+  // uses (`if (deps.<flag> !== true) throw`). A bare flag mention (e.g. a telemetry
+  // `logger.debug({ x: deps.<flag> })`) does NOT match, which is the point: a bare
+  // mention must not be accepted as a per-method guard (the ad45080e false-GREEN).
+  const failClosedFormPattern = `${escapeRegExp(flag)}\\s*!==\\s*true`;
+
   // Backstop 1: the actual fail-closed throw must exist at least once (post strip),
   // so gutting a shared guard helper's body (while keeping callers) is still caught.
-  const throwRegex = new RegExp(`${escapeRegExp(flag)}\\s*!==\\s*true`);
+  const throwRegex = new RegExp(failClosedFormPattern);
   details.hasFlagThrow = throwRegex.test(source);
   if (!details.hasFlagThrow) {
     failures.push(
@@ -522,11 +536,15 @@ export function evaluateSurface(repoRoot, surface, mutatorVerbs) {
   }
 
   // The token each guarded method body must contain: the guardHelper call if the
-  // surface uses a named helper, else a direct reference to the flag.
+  // surface uses a named helper, else the `<flag> !== true` fail-closed FORM (NOT a
+  // bare reference to the flag). Requiring the form — the same one Backstop 1 uses —
+  // means a benign mention of the flag (telemetry, logging, a destructured option)
+  // can no longer satisfy the per-method guard, closing the bare-mention false-GREEN
+  // that let an off-route method read as guarded while its real throw was removed.
   const guardHelper = surface.guardHelper;
   const guardTokenRegex = guardHelper
     ? new RegExp(`(?<![A-Za-z0-9_$])${escapeRegExp(guardHelper)}\\s*\\(`)
-    : new RegExp(`(?<![A-Za-z0-9_$])${escapeRegExp(flag)}(?![A-Za-z0-9_$])`);
+    : new RegExp(failClosedFormPattern);
 
   // ── PHASE A.1: every declared mutating method shows its guard in its OWN body ──
   for (const methodName of surface.mutatingMethods ?? []) {
@@ -824,8 +842,9 @@ function main() {
   // human success line so the output stays machine-parseable.
   if (!args.json) {
     console.log(
-      "\n✅ ts-runtime method-guard STRUCTURAL presence verified + all public mutators registered/allowlisted "
-      + "+ behavioral-test files present + no manifest shrinkage. (Structural presence only — fail-closed BEHAVIOR "
+      "\n✅ ts-runtime method-guard STRUCTURAL presence verified (inline surfaces require the `<flag> !== true` "
+      + "fail-closed FORM in each method body, not a bare flag mention) + all public mutators registered/allowlisted "
+      + "+ behavioral-test files present + no manifest shrinkage. (FORM/structural presence only — fail-closed BEHAVIOR "
       + "is proven by the per-surface behavioral tests in the `test` job; brand-new-file off-route surfaces and "
       + "non-verb-prefixed mutator names are documented textual-gate limits.)",
     );

--- a/scripts/quality/assert-ts-runtime-method-guards.mjs
+++ b/scripts/quality/assert-ts-runtime-method-guards.mjs
@@ -1,8 +1,63 @@
 #!/usr/bin/env node
 /**
- * TS-Runtime-Retirement: method-guard coverage + manifest anti-shrinkage gate.
+ * TS-Runtime-Retirement: method-guard STRUCTURAL-PRESENCE + manifest anti-shrinkage gate.
  *
  * Second-phase companion to scripts/quality/check-ts-runtime-retirement.mjs.
+ *
+ * ───────────────────────────────────────────────────────────────────────────
+ * HONEST SCOPE — read this before trusting a green run.
+ *
+ * This is a TEXTUAL gate. It verifies the STRUCTURAL PRESENCE of method-head
+ * fail-closed guards (after stripping comments + string/template literals so a
+ * commented-out or JSDoc'd guard cannot false-pass). It does NOT, and a textual
+ * gate CANNOT, verify fail-closed BEHAVIOR — a neutered or inverted guard whose
+ * tokens survive (e.g. `if (flag === true) throw`) would still read as "present".
+ * Behavior is covered by the per-surface BEHAVIORAL TESTS that this gate requires
+ * to EXIST (manifest `behavioralTest`); those run in the CI `test` job and are the
+ * real proof that the guard fails closed.
+ *
+ * WHAT THIS GATE GUARANTEES:
+ *   - STRUCTURAL guard presence: every declared mutating method on a registered
+ *     service file shows its guard token within its OWN brace-matched body (post
+ *     comment/string strip) — not borrowed from a sibling method.
+ *   - REGISTRATION of mutators: any PUBLIC verb-prefixed (mutating-named) method
+ *     on a registered service file that is NOT in that surface's declared method
+ *     list (and not in its justified `allowlistMutators`) FAILS — forcing a new
+ *     mutator to be consciously registered or consciously allowlisted.
+ *   - PER-SURFACE anti-shrinkage: each registered surface keeps >= its declared
+ *     method-count floor, and the set of registered surface IDs cannot shrink —
+ *     so "drop a surface + add filler to hold the grand total" is caught.
+ *   - A behavioral-test FILE exists for every registered surface (existence only).
+ *
+ * WHAT THIS GATE DOES *NOT* GUARANTEE (documented limits, by design):
+ *   1. Fail-closed BEHAVIOR (see above) — structural presence only; behavior is on
+ *      the mandatory behavioral tests in the `test` job.
+ *   2. A brand-new off-route surface in a NEW service file — a textual gate has no
+ *      seed to discover it. Covered by the route validator (for its route) + the
+ *      mandatory behavioral test when the surface is registered. New off-route
+ *      surfaces MUST be added here as they are method-fenced.
+ *   3. A mutator whose name does NOT match the configurable verb-prefix list
+ *      (e.g. `upsertApprovalRule`, `doStartRun`) can evade the registration scan.
+ *      The verb list (`mutatorVerbs`) is the heuristic boundary; widen it as new
+ *      naming shows up. Reads (`getRun`, `getSession`) are excluded because the
+ *      match is VERB-PREFIX (first camelCase segment), not substring.
+ *   4. `allowlistMutators` is a conscious escape hatch: a bogus justification on an
+ *      allowlist entry would hide a real mutator. The protection is that the entry
+ *      is VISIBLE in the manifest diff and reviewed (same model as lowering a floor).
+ *   5. The registration scan detects public methods via (a) exported `...Service`
+ *      interface members and (b) object-method-shorthand-with-body in the factory
+ *      return. A new mutator added to an INTERFACE-based service as a `const`-arrow
+ *      that is shorthand-returned but NOT added to the interface would evade (a) and
+ *      (b). That shape is rejected by `tsc` in the `build` job (the factory's typed
+ *      return performs excess-property checking against the `...Service` interface),
+ *      so the build job is the backstop for interface-based services.
+ *   6. Regex literals ARE handled by the comment/string stripper (recognized in
+ *      regex position and their bodies blanked), so a quote/brace inside a regex
+ *      class cannot corrupt scanning. Division `/` stays code (conservative). No
+ *      currently-registered service file contains a regex literal that would matter;
+ *      if a future one is mis-disambiguated it surfaces as a false-RED (safe), fixed
+ *      by extending the tokenizer — never as a silent false-GREEN.
+ * ───────────────────────────────────────────────────────────────────────────
  *
  * WHY THIS EXISTS (the route-blind gap):
  *   The route validator discovers HTTP routes (discoverRoutes over
@@ -10,42 +65,17 @@
  *   therefore ROUTE-scoped. It is structurally blind to service-method guards:
  *   when a surface is route-retired but its mutating service methods are still
  *   reachable OFF-route (agent tools, UIX/reflex callers, background jobs,
- *   standing-agenda), the route validator sees nothing. The retirement of those
- *   surfaces lives in METHOD-head fail-closed guards (TS-R1 / #628 / #597) that
- *   the route validator cannot see — so a future regression that strips one of
- *   those method guards would un-retire a live surface while the route validator
- *   stays blocker=0. PR #628's original commit ad45080e was exactly this near
- *   miss: it added guards to only a SUBSET of each surface's mutating methods
- *   (submitTurn, cancelSession, materializeGeneratedSession were left
- *   route-retired-but-unguarded), and nothing gated on it.
- *
- * WHAT THIS ASSERTS (additive; does NOT touch route classification):
- *   PHASE A — method-guard coverage. For each surface in
- *     manifest.methodRetiredSurfaces.surfaces, scan its serviceFile and assert
- *     EVERY declared mutatingMethod carries its method-head fail-closed guard:
- *       - the method's definition head can be located (else FAIL — stale config
- *         or matcher bug, never silently skip), AND
- *       - within that method's body window, the surface's guard token appears
- *         (the guardHelper call for helper-services, or a direct `flag` ref for
- *         inline-guarded ones).
- *     Backstops: (1) the serviceFile must contain the literal
- *       `<flag> !== true` throw at least once (so gutting a shared helper body is
- *       caught, not just removing a call); (2) for helper-services, the count of
- *       guardHelper call-sites must be >= the count of declared mutating methods.
- *
- *   PHASE B — manifest anti-shrinkage floor. Emit manifest.surfaces.length,
- *     manifest.routeFamilies.length, and the total declared guarded-method count,
- *     and assert none has dropped below its baseline floor in
- *     methodRetiredSurfaces.countFloor. byClassification is EMITTED for review
- *     but intentionally NOT floored (fail_closed legitimately shrinks on Rust
- *     takeover). A legitimate removal forces a conscious baseline-lower in the
- *     same PR, which the reviewer sees.
+ *   standing-agenda), the route validator sees nothing. PR #628's original commit
+ *   ad45080e was exactly this near miss: it added guards to only a SUBSET of each
+ *   surface's mutating methods (submitTurn, cancelSession,
+ *   materializeGeneratedSession were left route-retired-but-unguarded), and
+ *   nothing gated on it.
  *
  * Node: builtins only — no dependencies, no `npm ci` required (the CI job that
  * runs this has no install step).
  *
  * Usage: node scripts/quality/assert-ts-runtime-method-guards.mjs [--repo-root <dir>] [--manifest <path>] [--json]
- *   Exits 0 on full coverage + no shrinkage, non-zero otherwise.
+ *   Exits 0 on full STRUCTURAL coverage + registration + no shrinkage, non-zero otherwise.
  */
 
 import fs from "node:fs";
@@ -53,6 +83,15 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const DEFAULT_MANIFEST = "docs/ops/ts-runtime-retirement-manifest.json";
+
+// Fallback mutating-verb list if the manifest does not configure `mutatorVerbs`.
+// A method name "mutates" if its first camelCase segment (lower-cased) is one of
+// these — VERB-PREFIX, not substring (so `getRun` => "get" is NOT a mutator).
+const DEFAULT_MUTATOR_VERBS = [
+  "run", "execute", "start", "resume", "retry", "cancel", "create", "update",
+  "delete", "approve", "deny", "generate", "submit", "materialize", "sweep",
+  "extract", "remember", "dispatch", "publish", "deploy", "apply", "rollback",
+];
 
 export function parseArgs(argv) {
   const args = { repoRoot: process.cwd(), manifestPath: DEFAULT_MANIFEST, json: false };
@@ -73,25 +112,212 @@ export function parseArgs(argv) {
   return args;
 }
 
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
 /**
- * Locate every definition-head line for `methodName` in `lines`.
- * A definition head is the method name immediately followed by `(`, in one of
- * the forms actually used across the guarded services:
+ * Strip line comments, block comments, and string/template literals from TS/JS
+ * source, REPLACING their content with spaces while PRESERVING newlines (so line
+ * numbers and brace structure outside literals are unchanged). A single
+ * left-to-right state machine — NOT sequential regex passes — so `//` inside a
+ * "https://..." string, or a `{` inside a string/comment, cannot corrupt the
+ * result. Regex literals ARE recognized (in regex position, via the previous
+ * significant token) and their bodies blanked, so a quote or brace inside a
+ * regex class (e.g. /["{]/) cannot flip the scanner into string mode or delete
+ * braces. Ambiguous `/` (division) falls through as code. Code structure
+ * (braces, identifiers) outside literals is kept.
+ *
+ * States: code | line-comment | block-comment | s-string('") | t-string(`) | regex.
+ * Template `${...}` expressions are kept as code (so a guard ref inside one is
+ * still visible) by tracking brace depth within the template.
+ */
+export function stripCommentsAndStrings(source) {
+  const out = [];
+  const n = source.length;
+  let i = 0;
+  // template stack: each entry tracks `${` brace depth so we know when the
+  // expression closes and we re-enter the template string body.
+  const templateBraceDepth = [];
+  let inTemplateExpr = false;
+  // Last significant (non-whitespace, non-comment) source char emitted as code —
+  // used to decide whether a `/` begins a regex literal or is a division op.
+  let lastSignificant = "";
+
+  while (i < n) {
+    const c = source[i];
+    const next = i + 1 < n ? source[i + 1] : "";
+
+    // Line comment: blank to end of line, keep the newline.
+    if (c === "/" && next === "/") {
+      while (i < n && source[i] !== "\n") {
+        out.push(source[i] === "\t" ? "\t" : " ");
+        i += 1;
+      }
+      continue;
+    }
+    // Block comment: blank everything (preserve newlines) until */.
+    if (c === "/" && next === "*") {
+      out.push(" ");
+      out.push(" ");
+      i += 2;
+      while (i < n && !(source[i] === "*" && source[i + 1] === "/")) {
+        out.push(source[i] === "\n" ? "\n" : (source[i] === "\t" ? "\t" : " "));
+        i += 1;
+      }
+      if (i < n) {
+        out.push(" ");
+        out.push(" ");
+        i += 2;
+      }
+      continue;
+    }
+    // Regex literal: a `/` is a regex start (not division) when it appears in
+    // "regex position" — i.e. the previous significant code char is one that
+    // cannot end an expression: `(`, `,`, `=`, `:`, `;`, `[`, `{`, `}`, `!`, `&`,
+    // `|`, `?`, `+`, `-`, `*`, `%`, `<`, `>`, `^`, `~`, or nothing (start of
+    // input). Otherwise `/` is division and falls through as code. We blank the
+    // regex body (preserving the delimiters + length) so an embedded quote/brace
+    // cannot flip us into string mode or corrupt brace-matching. Conservative:
+    // ambiguous cases stay code (a stray division never blanks a guard).
+    if (c === "/" && (lastSignificant === "" || "(,=:;[{}!&|?+-*%<>^~".includes(lastSignificant))) {
+      out.push("/");
+      i += 1;
+      let inClass = false;
+      while (i < n) {
+        const rc = source[i];
+        if (rc === "\\") { out.push(" "); out.push(" "); i += 2; continue; }
+        if (rc === "\n") { break; } // unterminated regex on this line — bail safely
+        if (rc === "[") { inClass = true; out.push(" "); i += 1; continue; }
+        if (rc === "]") { inClass = false; out.push(" "); i += 1; continue; }
+        if (rc === "/" && !inClass) { break; }
+        out.push(" ");
+        i += 1;
+      }
+      if (i < n && source[i] === "/") {
+        out.push("/");
+        i += 1;
+        // consume + emit flags (letters) as-is so they remain code.
+        while (i < n && /[a-z]/i.test(source[i])) { out.push(source[i]); i += 1; }
+      }
+      lastSignificant = "/";
+      continue;
+    }
+    // Single/double-quoted string: blank contents, keep quotes + newlines.
+    if (c === "'" || c === '"') {
+      const quote = c;
+      out.push(quote);
+      i += 1;
+      while (i < n) {
+        if (source[i] === "\\") {
+          out.push(" ");
+          out.push(" ");
+          i += 2;
+          continue;
+        }
+        if (source[i] === quote) {
+          break;
+        }
+        out.push(source[i] === "\n" ? "\n" : " ");
+        i += 1;
+      }
+      if (i < n) {
+        out.push(quote);
+        i += 1;
+      }
+      // A `/` after a string value is division, not a regex start.
+      lastSignificant = quote;
+      continue;
+    }
+    // Template literal: blank the literal text, but KEEP ${...} expression code.
+    if (c === "`") {
+      out.push("`");
+      i += 1;
+      while (i < n) {
+        if (source[i] === "\\") {
+          out.push(" ");
+          out.push(" ");
+          i += 2;
+          continue;
+        }
+        if (source[i] === "`") {
+          break;
+        }
+        if (source[i] === "$" && source[i + 1] === "{") {
+          // Enter expression: emit `${`, then recurse via the main loop by
+          // pushing a brace-depth tracker and breaking out to code mode.
+          out.push("$");
+          out.push("{");
+          i += 2;
+          templateBraceDepth.push(1);
+          inTemplateExpr = true;
+          break;
+        }
+        out.push(source[i] === "\n" ? "\n" : " ");
+        i += 1;
+      }
+      if (!inTemplateExpr && i < n && source[i] === "`") {
+        out.push("`");
+        i += 1;
+      }
+      continue;
+    }
+
+    // Inside a template expression: keep code, track braces so we know when the
+    // expression closes and we should resume blanking the template body.
+    if (inTemplateExpr) {
+      if (c === "{") {
+        templateBraceDepth[templateBraceDepth.length - 1] += 1;
+      } else if (c === "}") {
+        templateBraceDepth[templateBraceDepth.length - 1] -= 1;
+        if (templateBraceDepth[templateBraceDepth.length - 1] === 0) {
+          templateBraceDepth.pop();
+          inTemplateExpr = templateBraceDepth.length > 0;
+          out.push("}");
+          i += 1;
+          // Resume template body blanking until the next ` or ${.
+          while (i < n) {
+            if (source[i] === "\\") { out.push(" "); out.push(" "); i += 2; continue; }
+            if (source[i] === "`") { out.push("`"); i += 1; break; }
+            if (source[i] === "$" && source[i + 1] === "{") {
+              out.push("$"); out.push("{"); i += 2;
+              templateBraceDepth.push(1);
+              inTemplateExpr = true;
+              break;
+            }
+            out.push(source[i] === "\n" ? "\n" : " ");
+            i += 1;
+          }
+          continue;
+        }
+      }
+      if (c.trim() !== "") lastSignificant = c;
+      out.push(c);
+      i += 1;
+      continue;
+    }
+
+    if (c.trim() !== "") lastSignificant = c;
+    out.push(c);
+    i += 1;
+  }
+  return out.join("");
+}
+
+/**
+ * Locate every definition-head line for `methodName` in `lines` (already
+ * comment/string-stripped). A definition head is the method name immediately
+ * followed by `(`, in one of the forms used across the guarded services:
  *   - `async function startRun(` / `function cancelRun(` / `function updatePolicy(`
  *   - object-method shorthand: `async submitTurn(` / `async deployDraft(input) {`
  *   - assigned arrow: `const executeIntent = async (`
- * We exclude:
- *   - calls and longer identifiers (word-boundary on both sides of the name),
- *   - interface signature lines (no body — they have neither `async`, `function`,
- *     `=>`/`= async`, nor a trailing `{`; e.g. `executeIntent(input): Promise<X>;`).
- *     Interface object-param sigs like `deployDraft(input: {` ARE tolerated as
- *     candidate heads: they simply won't contain the guard token in their window,
- *     and the impl head (which does) satisfies the per-method requirement.
+ * We exclude bare call sites (a `methodName(` not preceded by async/function and
+ * not at a method-definition column). Interface signature lines are tolerated as
+ * candidate heads: they simply won't contain the guard token in their body
+ * window, and the impl head (which does) satisfies the per-method requirement.
  */
 function findDefinitionHeadLines(lines, methodName) {
   const heads = [];
-  // name as a standalone identifier (not preceded/followed by identifier chars)
-  // immediately followed by optional whitespace then `(`.
   const nameCall = new RegExp(`(?<![A-Za-z0-9_$])${escapeRegExp(methodName)}\\s*\\(`);
   const assignedArrow = new RegExp(
     `(?:const|let|var)\\s+${escapeRegExp(methodName)}\\s*=\\s*async\\b`,
@@ -108,7 +334,6 @@ function findDefinitionHeadLines(lines, methodName) {
     const isFunctionForm = /\b(?:async\s+)?function\s+/.test(line)
       || /^\s*(?:public|private|protected\s+)?(?:async\s+)?[A-Za-z0-9_$]+\s*\(/.test(line);
     if (!isFunctionForm) {
-      // A bare `methodName(...)` call site inside other code — skip it.
       continue;
     }
     heads.push(index);
@@ -116,27 +341,158 @@ function findDefinitionHeadLines(lines, methodName) {
   return heads;
 }
 
-function escapeRegExp(value) {
-  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+/**
+ * Find the brace-matched body extent for a method head, on comment/string-stripped
+ * lines. Scans forward from headLine to the first `{` that opens the body, then
+ * brace-matches to its close. Returns [startLine, endLineExclusive].
+ *
+ * Robustness: this replaces the old fixed 24-line window. A correctly-placed guard
+ * any distance down the body is now in-scope (fixes the head-anchored false-RED),
+ * AND the body ends at the method's OWN closing brace, so a sibling method's guard
+ * cannot leak into this method's scope (fixes the sibling-borrow false-pass).
+ *
+ * Interface signature heads (no body — `name(...): T;`) have no `{` before the
+ * line's terminating `;`/EOL and yield an empty single-line body; that's fine, the
+ * impl head provides the real body. `maxScan` bounds a pathological no-brace case.
+ */
+function methodBodyRange(lines, headLine, maxScan) {
+  const total = lines.length;
+  const hardEnd = Math.min(headLine + maxScan, total);
+  let openLine = -1;
+  let openCol = -1;
+  // Find the `{` that opens the body. The head may span multiple lines (long
+  // param list); the body `{` is the first unmatched `{` after the param `(`.
+  let parenDepth = 0;
+  let seenParen = false;
+  for (let li = headLine; li < hardEnd; li += 1) {
+    const text = lines[li];
+    for (let ci = 0; ci < text.length; ci += 1) {
+      const ch = text[ci];
+      if (ch === "(") { parenDepth += 1; seenParen = true; }
+      else if (ch === ")") { parenDepth -= 1; }
+      else if (ch === ";" && seenParen && parenDepth <= 0) {
+        // Signature line (`name(...): T;`) — no body.
+        return [headLine, headLine + 1];
+      }
+      else if (ch === "{" && seenParen && parenDepth <= 0) {
+        openLine = li;
+        openCol = ci;
+        break;
+      }
+      else if (ch === "=" && li === headLine) {
+        // assigned-arrow form `const x = async (...) => {` — keep scanning for `{`.
+      }
+    }
+    if (openLine >= 0) break;
+  }
+  if (openLine < 0) {
+    // No body brace located within maxScan — fall back to a bounded window so we
+    // never silently skip; the per-method check will just look in this slice.
+    return [headLine, hardEnd];
+  }
+  // Brace-match from openLine/openCol to the matching close.
+  let depth = 0;
+  for (let li = openLine; li < total; li += 1) {
+    const text = lines[li];
+    const startCol = li === openLine ? openCol : 0;
+    for (let ci = startCol; ci < text.length; ci += 1) {
+      const ch = text[ci];
+      if (ch === "{") depth += 1;
+      else if (ch === "}") {
+        depth -= 1;
+        if (depth === 0) {
+          return [headLine, li + 1];
+        }
+      }
+    }
+  }
+  return [headLine, total];
 }
 
 /**
- * The body window for the head at `headLine` runs until the next definition head
- * (of ANY declared mutating method in this file) or +`maxWindow` lines, whichever
- * is first. Using the next declared head as the bound prevents one method's
- * window from false-passing on a neighbouring method's guard.
+ * Extract the set of PUBLIC method names declared on a service file. Public =
+ * declared in an exported `... Service` interface signature block (covers the
+ * services whose factory returns shorthand property refs), OR an object-method
+ * shorthand WITH A BODY (covers services whose factory returns inline methods,
+ * e.g. workflow_generator's `async startSession(...) { ... }`). Internal
+ * factory-scope `function`/`const`-arrow helpers (executeIntentInternal,
+ * runDesktopAction, deleteDraft, runDeploy, createDraftFromVisualization,
+ * extractRunFailurePath) are NOT in either form and are correctly excluded.
+ *
+ * Operates on comment/string-stripped lines.
  */
-function windowEnd(headLine, allHeadLines, maxWindow, totalLines) {
-  let bound = Math.min(headLine + maxWindow, totalLines);
-  for (const other of allHeadLines) {
-    if (other > headLine && other < bound) {
-      bound = other;
+function collectPublicMethodNames(lines) {
+  const names = new Set();
+  const total = lines.length;
+
+  // (a) exported `...Service` interface signature members.
+  for (let li = 0; li < total; li += 1) {
+    const m = lines[li].match(/^export\s+interface\s+([A-Za-z0-9_$]+Service)\s*\{/);
+    if (!m) continue;
+    // Walk the interface body via brace-match; collect `NAME(` and `NAME:` members.
+    let depth = 0;
+    let started = false;
+    for (let bi = li; bi < total; bi += 1) {
+      const text = lines[bi];
+      for (let ci = 0; ci < text.length; ci += 1) {
+        if (text[ci] === "{") { depth += 1; started = true; }
+        else if (text[ci] === "}") { depth -= 1; }
+      }
+      if (started && bi > li) {
+        const sig = text.match(/^\s*([A-Za-z0-9_$]+)\s*[(<:]/);
+        if (sig) names.add(sig[1]);
+      }
+      if (started && depth === 0) break;
     }
   }
-  return bound;
+
+  // (b) object-method shorthand WITH a body: `async NAME(...) {` or `NAME(...) {`
+  //     or a multiline head whose line is `async NAME(` / `NAME(` at a returned-
+  //     object indentation. Distinguish from CALL sites: a call site is `NAME(`
+  //     used as an expression (e.g. `foo: createX({` or `await runDeploy()`);
+  //     a definition has either `async` immediately before the name, or the line
+  //     is purely a method head (indentation + name + `(` and nothing that makes
+  //     it an argument/assignment). We require the name to be the first token on
+  //     the (trimmed) line OR preceded only by `async`.
+  for (let li = 0; li < total; li += 1) {
+    const text = lines[li];
+    // `async NAME(` definition (object-method, async)
+    let m = text.match(/^\s*async\s+([A-Za-z0-9_$]+)\s*\(/);
+    if (m) { names.add(m[1]); continue; }
+    // plain `NAME(...)` as the FIRST token on the line, NOT a control keyword,
+    // NOT followed by `=>` (that'd be inside a call), and the body opens with `{`
+    // somewhere — i.e. an object-method shorthand. We additionally require the
+    // line not to look like a call argument by excluding a leading `.`/`,`/`(`/`=`
+    // context: since it's the first non-space token, that's already satisfied.
+    m = text.match(/^\s*([A-Za-z0-9_$]+)\s*\(/);
+    if (m) {
+      const name = m[1];
+      if (["if", "for", "while", "switch", "catch", "return", "await", "function",
+        "const", "let", "var", "export", "import", "throw", "new", "typeof",
+        "void", "yield", "do", "else"].includes(name)) {
+        continue;
+      }
+      // Must end the head with `{` on this line or be a multiline head; and must
+      // NOT be an assignment/property-value call. Heuristic: the line, after the
+      // closing `)` (if present), ends with `{` or `:` (return-type then body) or
+      // is just `NAME(` (multiline). A trailing `;` or `,` or `)` indicates a call.
+      const tail = text.slice(text.indexOf("(") );
+      if (/\)\s*(?::[^=]*)?\s*\{?\s*$/.test(tail) && !/=>/.test(text)) {
+        names.add(name);
+      }
+    }
+  }
+  return names;
 }
 
-export function evaluateSurface(repoRoot, surface) {
+/** First camelCase segment, lower-cased (e.g. startRun => "start", getRun => "get"). */
+function leadingVerb(name) {
+  const stripped = name.replace(/^[_$]+/, "");
+  const seg = stripped.match(/^[a-z]+/);
+  return seg ? seg[0].toLowerCase() : null;
+}
+
+export function evaluateSurface(repoRoot, surface, mutatorVerbs) {
   const failures = [];
   const details = { id: surface.id, serviceFile: surface.serviceFile, methods: {} };
   const absolute = path.join(repoRoot, surface.serviceFile);
@@ -144,7 +500,8 @@ export function evaluateSurface(repoRoot, surface) {
     failures.push(`surface ${surface.id}: serviceFile ${surface.serviceFile} not found`);
     return { failures, details };
   }
-  const source = fs.readFileSync(absolute, "utf8");
+  const rawSource = fs.readFileSync(absolute, "utf8");
+  const source = stripCommentsAndStrings(rawSource);
   const lines = source.split("\n");
 
   const flag = surface.flag;
@@ -153,8 +510,8 @@ export function evaluateSurface(repoRoot, surface) {
     return { failures, details };
   }
 
-  // Backstop 1: the actual fail-closed throw must exist at least once, so gutting
-  // a shared guard helper's body (while keeping its callers) is still caught.
+  // Backstop 1: the actual fail-closed throw must exist at least once (post strip),
+  // so gutting a shared guard helper's body (while keeping callers) is still caught.
   const throwRegex = new RegExp(`${escapeRegExp(flag)}\\s*!==\\s*true`);
   details.hasFlagThrow = throwRegex.test(source);
   if (!details.hasFlagThrow) {
@@ -171,21 +528,9 @@ export function evaluateSurface(repoRoot, surface) {
     ? new RegExp(`(?<![A-Za-z0-9_$])${escapeRegExp(guardHelper)}\\s*\\(`)
     : new RegExp(`(?<![A-Za-z0-9_$])${escapeRegExp(flag)}(?![A-Za-z0-9_$])`);
 
-  // Collect every declared method's definition heads up front so each window can
-  // be bounded by the next declared head.
-  const allHeads = [];
-  const headsByMethod = {};
+  // ── PHASE A.1: every declared mutating method shows its guard in its OWN body ──
   for (const methodName of surface.mutatingMethods ?? []) {
     const heads = findDefinitionHeadLines(lines, methodName);
-    headsByMethod[methodName] = heads;
-    for (const head of heads) {
-      allHeads.push(head);
-    }
-  }
-  allHeads.sort((left, right) => left - right);
-
-  for (const methodName of surface.mutatingMethods ?? []) {
-    const heads = headsByMethod[methodName];
     if (heads.length === 0) {
       failures.push(
         `surface ${surface.id}: declared mutating method '${methodName}' has no locatable `
@@ -195,14 +540,12 @@ export function evaluateSurface(repoRoot, surface) {
       details.methods[methodName] = { located: false, guarded: false };
       continue;
     }
-    // At least ONE definition head of this method must carry the guard token in
-    // its window (the impl head; interface sigs won't).
     let guarded = false;
     let guardedAtLine = null;
     for (const head of heads) {
-      const end = windowEnd(head, allHeads, 24, lines.length);
-      const windowText = lines.slice(head, end).join("\n");
-      if (guardTokenRegex.test(windowText)) {
+      const [bodyStart, bodyEnd] = methodBodyRange(lines, head, 600);
+      const bodyText = lines.slice(bodyStart, bodyEnd).join("\n");
+      if (guardTokenRegex.test(bodyText)) {
         guarded = true;
         guardedAtLine = head + 1;
         break;
@@ -213,20 +556,47 @@ export function evaluateSurface(repoRoot, surface) {
       const tokenLabel = guardHelper ? `${guardHelper}()` : flag;
       failures.push(
         `surface ${surface.id}: mutating method '${methodName}' is route-retired but its `
-        + `method-head guard (${tokenLabel}) is MISSING — a regression un-retired this surface `
-        + `off-route while the route validator stays blocker=0 (${surface.serviceFile})`,
+        + `method-head guard (${tokenLabel}) is MISSING from its own body — a regression `
+        + `un-retired this surface off-route while the route validator stays blocker=0 (${surface.serviceFile})`,
       );
     }
   }
 
-  // Backstop 2: for helper-services, guard-call-site count must cover the
-  // declared mutators (catches dropping a guard from one of several methods even
-  // if some other path keeps the helper referenced).
+  // ── PHASE A.2: detect UNREGISTERED public mutators on this file ──
+  // Any PUBLIC verb-prefixed (mutating-named) method that is neither declared in
+  // mutatingMethods nor in allowlistMutators FAILS — forcing conscious registration
+  // (real new retired mutator) or conscious, justified allowlisting (intentionally
+  // live / route-only-covered / different-mechanism guard).
+  const declared = new Set(surface.mutatingMethods ?? []);
+  const allowlist = new Set((surface.allowlistMutators ?? []).map((a) => a.method));
+  const publicNames = collectPublicMethodNames(lines);
+  const unregistered = [];
+  for (const name of publicNames) {
+    const verb = leadingVerb(name);
+    if (verb && mutatorVerbs.has(verb) && !declared.has(name) && !allowlist.has(name)) {
+      unregistered.push(name);
+    }
+  }
+  unregistered.sort();
+  details.unregisteredMutators = unregistered;
+  details.allowlistedMutators = [...allowlist].sort();
+  for (const name of unregistered) {
+    failures.push(
+      `surface ${surface.id}: public mutating-named method '${name}' on ${surface.serviceFile} is `
+      + "NEITHER a declared mutatingMethod NOR in allowlistMutators. A new off-route mutator may have "
+      + "been added unguarded. Register it in mutatingMethods (with its guard) OR, if it is intentionally "
+      + "live / route-only-covered / guarded by a different mechanism, add it to allowlistMutators with a "
+      + "reason so the de-coverage is consciously reviewed — do NOT rename it to dodge the verb-prefix scan.",
+    );
+  }
+
+  // Backstop 2: for helper-services, guard-call-site count must cover the declared
+  // mutators (catches dropping a guard from one of several methods even if some
+  // other path keeps the helper referenced). Counted on the stripped source so a
+  // commented-out call no longer inflates the count.
   if (guardHelper) {
     const callSiteRegex = new RegExp(`(?<![A-Za-z0-9_$])${escapeRegExp(guardHelper)}\\s*\\(`, "gu");
     const callSites = (source.match(callSiteRegex) ?? []).length;
-    // The helper's own declaration (`function assert...() {`) is one occurrence;
-    // subtract it so we count true call-sites.
     const declRegex = new RegExp(`function\\s+${escapeRegExp(guardHelper)}\\s*\\(`);
     const declCount = declRegex.test(source) ? 1 : 0;
     const effectiveCalls = callSites - declCount;
@@ -241,6 +611,28 @@ export function evaluateSurface(repoRoot, surface) {
     }
   }
 
+  // ── PHASE A.3: behavioral-test FILE existence (structural; existence only) ──
+  if (typeof surface.behavioralTest === "string" && surface.behavioralTest.length > 0) {
+    const testAbs = path.join(repoRoot, surface.behavioralTest);
+    const exists = fs.existsSync(testAbs);
+    details.behavioralTest = surface.behavioralTest;
+    details.behavioralTestExists = exists;
+    if (!exists) {
+      failures.push(
+        `surface ${surface.id}: declared behavioralTest ${surface.behavioralTest} does NOT exist. `
+        + "Behavior (fail-closed) is NOT verifiable textually; the behavioral test in the `test` job is "
+        + "the proof. Restore the test file (do not drop the pointer to make this pass).",
+      );
+    }
+  } else {
+    details.behavioralTest = null;
+    details.behavioralTestExists = false;
+    failures.push(
+      `surface ${surface.id}: no behavioralTest declared. Every method-retired surface MUST point to a `
+      + "behavioral test that proves the guard FAILS CLOSED (this gate only checks structural presence).",
+    );
+  }
+
   return { failures, details };
 }
 
@@ -252,17 +644,27 @@ export function evaluateManifest(repoRoot, manifest) {
     return { failures, report: { phaseA: {}, phaseB: {} } };
   }
 
-  // ── PHASE A: method-guard coverage ──
+  const mutatorVerbs = new Set(
+    (Array.isArray(config.mutatorVerbs) && config.mutatorVerbs.length > 0
+      ? config.mutatorVerbs
+      : DEFAULT_MUTATOR_VERBS).map((v) => String(v).toLowerCase()),
+  );
+
+  // ── PHASE A: per-surface structural guard presence + registration ──
   const surfaceReports = [];
   let totalDeclaredMethods = 0;
+  let surfacesWithBehavioralTest = 0;
+  const registeredIds = new Set();
   for (const surface of config.surfaces ?? []) {
+    registeredIds.add(surface.id);
     totalDeclaredMethods += (surface.mutatingMethods ?? []).length;
-    const { failures: surfaceFailures, details } = evaluateSurface(repoRoot, surface);
+    const { failures: surfaceFailures, details } = evaluateSurface(repoRoot, surface, mutatorVerbs);
     failures.push(...surfaceFailures);
     surfaceReports.push(details);
+    if (details.behavioralTestExists) surfacesWithBehavioralTest += 1;
   }
 
-  // ── PHASE B: manifest anti-shrinkage floor ──
+  // ── PHASE B: manifest anti-shrinkage floors ──
   const floor = config.countFloor ?? {};
   const surfacesLength = Array.isArray(manifest.surfaces) ? manifest.surfaces.length : 0;
   const routeFamiliesLength = Array.isArray(manifest.routeFamilies) ? manifest.routeFamilies.length : 0;
@@ -277,12 +679,53 @@ export function evaluateManifest(repoRoot, manifest) {
   assertFloor(failures, "routeFamilies.length", routeFamiliesLength, floor.routeFamiliesMin);
   assertFloor(failures, "declared guarded methods", totalDeclaredMethods, floor.guardedMethodsMin);
 
+  // PER-SURFACE floor (#5): each registered surface ID must still be present AND
+  // keep >= its declared method count. A flat grand total lets "drop a surface +
+  // add filler" hold the total; this keyed floor forbids that.
+  const perSurface = floor.perSurfaceMethodsMin ?? {};
+  const declaredById = {};
+  for (const surface of config.surfaces ?? []) {
+    declaredById[surface.id] = (surface.mutatingMethods ?? []).length;
+  }
+  for (const [id, minMethods] of Object.entries(perSurface)) {
+    if (!registeredIds.has(id)) {
+      failures.push(
+        `anti-shrinkage: registered surface '${id}' (floored at ${minMethods} method(s)) was REMOVED from `
+        + "methodRetiredSurfaces.surfaces. If intentional, delete its perSurfaceMethodsMin entry IN THIS PR "
+        + "so the de-retirement is consciously reviewed — do not drop the surface and backfill the total with filler.",
+      );
+      continue;
+    }
+    if ((declaredById[id] ?? 0) < minMethods) {
+      failures.push(
+        `anti-shrinkage: surface '${id}' declares ${declaredById[id] ?? 0} mutating method(s), below its `
+        + `per-surface floor ${minMethods}. A guarded method was removed from this surface. Lower its `
+        + "perSurfaceMethodsMin IN THIS PR if intentional.",
+      );
+    }
+  }
+
+  // Anti-shrinkage on behavioral-test coverage: the count of surfaces backed by a
+  // real (existing) behavioral test cannot drop below its floor, so one documented
+  // missing-test gap can't be copied to null out the others.
+  if (typeof floor.behavioralTestsMin === "number") {
+    if (surfacesWithBehavioralTest < floor.behavioralTestsMin) {
+      failures.push(
+        `anti-shrinkage: ${surfacesWithBehavioralTest} surface(s) have an existing behavioral test, below `
+        + `floor ${floor.behavioralTestsMin}. A behavioral test was removed/unpointed. Restore it or lower `
+        + "behavioralTestsMin IN THIS PR.",
+      );
+    }
+  }
+
   return {
     failures,
     report: {
       phaseA: {
         surfaceCount: (config.surfaces ?? []).length,
         totalDeclaredMethods,
+        surfacesWithBehavioralTest,
+        mutatorVerbs: [...mutatorVerbs].sort(),
         surfaces: surfaceReports,
       },
       phaseB: {
@@ -292,6 +735,8 @@ export function evaluateManifest(repoRoot, manifest) {
         routeFamiliesMin: floor.routeFamiliesMin ?? null,
         guardedMethodsTotal: totalDeclaredMethods,
         guardedMethodsMin: floor.guardedMethodsMin ?? null,
+        perSurfaceMethodsMin: perSurface,
+        behavioralTestsMin: floor.behavioralTestsMin ?? null,
         byClassification,
         baselineCommit: floor.baselineCommit ?? null,
       },
@@ -344,29 +789,47 @@ function main() {
   } else {
     const a = report.phaseA;
     const b = report.phaseB;
-    console.log("── TS-runtime method-guard coverage (Phase A) ──");
+    console.log("── TS-runtime method-guard STRUCTURAL presence (Phase A) ──");
     for (const s of a.surfaces ?? []) {
       const methodLines = Object.entries(s.methods)
         .map(([name, m]) => `${name}=${m.guarded ? "guarded" : (m.located ? "UNGUARDED" : "NOT-FOUND")}`)
         .join(", ");
-      console.log(`  ${s.id} (${s.serviceFile}): ${methodLines}`);
+      const extras = [];
+      if ((s.unregisteredMutators ?? []).length > 0) extras.push(`UNREGISTERED:[${s.unregisteredMutators.join(",")}]`);
+      if ((s.allowlistedMutators ?? []).length > 0) extras.push(`allowlisted:[${s.allowlistedMutators.join(",")}]`);
+      extras.push(`behavioralTest=${s.behavioralTestExists ? "present" : "MISSING"}`);
+      console.log(`  ${s.id} (${s.serviceFile}): ${methodLines} | ${extras.join(" ")}`);
     }
-    console.log(`  surfaces=${a.surfaceCount}, declared guarded methods=${a.totalDeclaredMethods}`);
+    console.log(`  surfaces=${a.surfaceCount}, declared methods=${a.totalDeclaredMethods}, with-behavioral-test=${a.surfacesWithBehavioralTest}`);
+    console.log(`  mutator verbs (prefix-matched): ${a.mutatorVerbs.join(",")}`);
     console.log("── Manifest anti-shrinkage (Phase B) ──");
     console.log(`  surfaces.length=${b.surfacesLength} (floor ${b.surfacesMin})`);
     console.log(`  routeFamilies.length=${b.routeFamiliesLength} (floor ${b.routeFamiliesMin})`);
-    console.log(`  declared guarded methods=${b.guardedMethodsTotal} (floor ${b.guardedMethodsMin})`);
+    console.log(`  declared methods=${b.guardedMethodsTotal} (floor ${b.guardedMethodsMin})`);
+    console.log(`  per-surface floors: ${JSON.stringify(b.perSurfaceMethodsMin)}`);
+    console.log(`  behavioral tests present=${a.surfacesWithBehavioralTest} (floor ${b.behavioralTestsMin})`);
     console.log(`  byClassification (emitted, not floored): ${JSON.stringify(b.byClassification)}`);
   }
 
   if (failures.length > 0) {
-    console.error(`\n❌ ts-runtime method-guard gate FAILED (${failures.length} finding(s)):`);
-    for (const failure of failures) {
-      console.error(`  - ${failure}`);
+    if (!args.json) {
+      console.error(`\n❌ ts-runtime method-guard gate FAILED (${failures.length} finding(s)):`);
+      for (const failure of failures) {
+        console.error(`  - ${failure}`);
+      }
     }
     process.exit(1);
   }
-  console.log("\n✅ ts-runtime method-guard coverage complete + no manifest shrinkage.");
+  // In --json mode the JSON object above is the sole stdout payload; suppress the
+  // human success line so the output stays machine-parseable.
+  if (!args.json) {
+    console.log(
+      "\n✅ ts-runtime method-guard STRUCTURAL presence verified + all public mutators registered/allowlisted "
+      + "+ behavioral-test files present + no manifest shrinkage. (Structural presence only — fail-closed BEHAVIOR "
+      + "is proven by the per-surface behavioral tests in the `test` job; brand-new-file off-route surfaces and "
+      + "non-verb-prefixed mutator names are documented textual-gate limits.)",
+    );
+  }
   process.exit(0);
 }
 


### PR DESCRIPTION
## The gap: route-only blindness

The TS-runtime-retirement validator (`scripts/quality/check-ts-runtime-retirement.mjs`) discovers HTTP routes via `discoverRoutes(repoRoot, "src/api/http/routes")` and classifies each one. Its **`blocker==0` guarantee is therefore ROUTE-scoped.** It is structurally blind to **service-METHOD** guards.

When a surface is route-retired but its mutating service methods are still reachable **off-route** — agent tools (`src/agent/tools/**`), UIX/reflex callers, background jobs/cron, standing-agenda — the route validator sees nothing. The actual retirement of those surfaces lives in **method-head fail-closed guards** (TS-R1 / #628 / #597) that the route validator *cannot see*. A future regression that strips one of those method guards would silently **un-retire a live surface while the route validator stays `blocker=0`**.

### The #628 near-miss (motivation)

PR #628's original commit **`ad45080e`** was exactly this defect. It added method guards to only a **subset** of each surface's mutating methods — `git show ad45080e --stat` shows generator **+31** / product **+34** lines, versus the `e6b39186` adversarial-review fixup's **+38** / **+63**. It left `submitTurn`, `cancelSession`, and `materializeGeneratedSession` **route-retired-but-unguarded**, and **nothing gated on it** — the 11-agent adversarial review (`wk4f0gmv2`) caught it by hand, not CI.

## What this adds (additive — does NOT touch route classification)

A **second validation phase** as a sibling gate (`scripts/quality/assert-ts-runtime-method-guards.mjs`), wired into the **same `ts-runtime-retirement` CI job**, after the route validator + the `assert-ts-runtime-blocker-zero` step. Builtins-only (the job has no `npm ci`), own non-zero exit.

### Phase A — method-guard coverage
For each surface in `manifest.methodRetiredSurfaces.surfaces`, scan its `serviceFile` and assert **every** declared `mutatingMethod` carries its method-head guard:
- the guard token (the `guardHelper` call for helper-services, or a direct `flag` reference for inline-guarded ones) appears within the method's body window;
- matched by **method name + guard-call presence** — no brittle line numbers;
- **fail-loud** if a declared method head can't be located (stale config or matcher bug — never silently skip).
- Backstops: the `serviceFile` must contain the literal `<flag> !== true` throw at least once (so gutting a shared helper body is caught, not just removing a call); helper-service guard call-sites must be `>=` the declared mutator count.

### Phase B — manifest anti-shrinkage floor
Emit `surfaces.length` / `routeFamilies.length` / declared-guarded-method count and assert none has dropped below its baseline floor (`methodRetiredSurfaces.countFloor`, baseline `e6b39186`: 279 / 18 / 12). `byClassification` is **emitted for review but NOT floored** — `fail_closed` legitimately shrinks on Rust takeover, so flooring it would false-fail real progress. A legitimate removal forces a conscious **same-PR baseline-lower**, which the reviewer sees — the human checkpoint that was missing.

## Config-driven surface list

Declared in the manifest under `methodRetiredSurfaces` (co-located with route-retirement for review). **5 seed surfaces**:

| surface | serviceFile | guard | methods |
|---|---|---|---|
| `capability_acquisition` | `friday-capability-acquisition-service.ts` | `assertCapabilityAcquisitionExecutionAllowed` (helper) | startRun, approveRun, cancelRun |
| `workflow_generator` | `friday-workflow-generator-service.ts` | `assertWorkflowGeneratorExecutionAllowed` (helper) | startSession, submitTurn, generateDraft, approveAndSave, cancelSession |
| `system_intent` | `friday-system-service.ts` | `allowTestOnlySystemIntentExecution` (inline) | executeIntent |
| `workflow_deploy` | `friday-workflow-product-service.ts` | `allowTestOnlyWorkflowDeployExecution` (inline) | deployDraft, materializeGeneratedSession |
| `autonomy_policy` | `friday-autonomy-policy-service.ts` | `allowTestOnlyAutonomyPolicyMutation` (inline, sync) | updatePolicy |

`#628` four + `#597` autonomy. **This list must grow** as more surfaces are method-fenced (documented in the manifest `doc` field). Route-only-guarded surfaces (e.g. standing-agenda, whose `runAgendaItem` inherits protection from the now-guarded `acquisitionService.startRun`) are intentionally **not** listed here — the route validator already covers them. A grep (`assert.*ExecutionAllowed` in `src/`) confirms the helper-pattern seed set is complete (helpers exist in exactly the 2 listed files).

## How it would have caught ad45080e

- **method-coverage (Phase A) catches the ad45080e class:** an incomplete guard set. With `submitTurn` / `cancelSession` / `materializeGeneratedSession` declared in config but unguarded, Phase A fails — even though the route stays `blocker=0`.
- **manifest-count (Phase B) is orthogonal protection** against silent surface-entry shrinkage/reclassification. (Honest note: `ad45080e` itself never touched the manifest — empty diff on that path — so manifest-count would *not* have caught ad45080e specifically; it complements Phase A for a different un-retirement vector.)

## Verified

On current main (`e6b39186`):
- route validator: `passed`, `blocker=0`, 584 routes (unchanged);
- method-guard gate: **passed** — 5 surfaces / 12 methods all guarded; floors 279/18/12.

**Regression-proven** (strip → RED → restore → GREEN):
- strip `submitTurn`'s helper-guard call → RED (both the per-method coverage failure *and* the call-site backstop);
- strip `materializeGeneratedSession`'s inline guard **alone** (keeping `deployDraft`'s) → RED via the per-method window check (the exact ad45080e one-of-N shape, on the inline path);
- drop 5 surface entries from the manifest → RED (Phase B `surfaces.length 274 < 279`).

Gates: `detect-secrets-hook` + provider-key denylist clean; no TS touched (tooling `.mjs` + manifest JSON + ci.yml only), and eslint flat-config targets only `src/**/*.ts` so `npm run lint` is N/A here.

## Limitations (intentional)
- Checks guard **presence** in the method-head window, not its **position before side-effects** — per the task's "match by name + guard-call presence, no brittle line numbers."
- The floor is **exact-current by design**: a legitimate surface/guard removal *requires* a conscious same-PR baseline edit (feature, not bug — the error message says so).

Truth label: this is **tooling/CI only** — no product code changed, no surface newly retired. It closes a detection gap; it is not v1-GO progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review fixup (commit `4ef9ca19`) — hardening after a second adversarial pass

A follow-up adversarial review found the first cut **defeatable** in several ways. This fixup closes the textually-closable holes and **reframes the gate honestly**. The table below is the load-bearing summary.

### What the gate DOES guarantee (after this fixup)
- **Structural guard PRESENCE** — every declared `mutatingMethod` shows its guard token within its **own brace-matched body** (not a fixed line window, and not borrowed from a sibling method), scanned on source that has had **comments + string/template/regex literals stripped** first. A commented-out guard call or a JSDoc naming the flag no longer false-passes.
- **Registration of new mutators** — any **public** verb-prefixed (mutating-named) method on a registered service file that is neither a declared `mutatingMethod` nor a justified `allowlistMutators` entry **fails the gate**, forcing a new off-route mutator to be consciously registered or allowlisted. (Public = exported `…Service` interface member, or object-method-with-body in the factory return. Verb match is **prefix** on the first camelCase segment, not substring, so reads like `getRun`/`getSession` are not flagged.) `mutatorVerbs` is manifest-configurable.
- **Per-surface anti-shrinkage** — each registered surface must stay **present** and keep **≥ its declared method count** (`perSurfaceMethodsMin`), so "drop a surface + add filler to hold the grand total" is now caught (the old floor was a single grand total). The count of surfaces backed by an existing behavioral test is also floored (`behavioralTestsMin`).
- **Behavioral-test FILE existence** — each surface declares a `behavioralTest`; the gate asserts that file **exists** (failing if missing), so the behavioral coverage that actually proves fail-closed cannot be silently dropped.

### What the gate DOES NOT guarantee (documented textual-gate limits)
- **Fail-closed BEHAVIOR.** This is a TEXTUAL gate: it verifies guard **presence**, not behavior. A neutered/inverted guard whose tokens survive (e.g. `if (flag === true) throw`, or a `throw` swapped for a no-op) reads as "present" and passes. **Behavior is proven by the per-surface behavioral tests** (`behavioralTest`) which run in the CI `test` job — that is the real fail-closed proof. *(Demonstrated: a token-surviving neuter of `updatePolicy` keeps this gate GREEN; the `friday-controlled-autonomy-services.test.ts` fail-closed assertion is what catches it.)*
- **Brand-new off-route surface in a NEW service file.** A textual gate has no seed to discover it. Covered by the route validator (for its route) + the mandatory `behavioralTest` once it is registered here. New off-route surfaces **must** be added to `methodRetiredSurfaces` as they are method-fenced.
- **Mutators whose names are not verb-prefixed** in `mutatorVerbs` (e.g. `upsertApprovalRule`). The verb list is the heuristic boundary; widen it as new naming appears.
- **Bogus-justification allowlist entries.** `allowlistMutators` is a conscious escape hatch; a fake reason would hide a real mutator. The protection is that the entry is **visible in the manifest diff and reviewed** (same model as lowering a floor).
- **Interface-skipping `const`-arrow return members** on interface-based services are not seen by the public-method scan, but are rejected by `tsc` in the `build` job (the factory's typed return excess-property-checks against the `…Service` interface) — the build job is the backstop there.

### A real coverage gap the scan found
The registration scan flagged `system_intent.updateApprovalRule` — a **public mutator** on `friday-system-service.ts` that was not in any surface's method list. It is now explicitly **allowlisted with a reason**: its route (`system_approvals_update`) is independently `fail_closed` (route-validator-covered), and at the method boundary it carries the **canonical-approval gate** (`assertLegacyApprovalRuleMutationAllowed`) — a *different mechanism and opposite polarity* (open-by-default, throws only when the canonical gate is engaged) than the fail-closed-by-default test-oracle retirement guards. Registering it would falsely assert a fail-closed property it does not have, so it is allowlisted (not folded into `mutatingMethods`) to keep the decision visible.

### Regression-proven (scratch edits, reverted — not committed)
- (a) comment out a real guard call inside `materializeGeneratedSession` → **RED** (comment-strip + per-method body, while sibling `deployDraft` stays guarded — proves no sibling-borrow);
- (b) add an unregistered public mutator (`createNewThing`) to `workflow_generator`'s return object → **RED** (registration scan);
- (c) drop the `autonomy_policy` surface + add filler to hold the grand total at 12 → **RED** (per-surface floor + behavioral-test floor; the old grand-total-only floor would have passed);
- (d) neuter a guard so its tokens survive but it no longer throws → **GREEN** (documented limit — the behavioral test in the `test` job is what catches this);
- stripper unit-checked on regex-with-quote / division / escaped-slash / string-then-regex / template-`${}` / string-brace cases (all brace-balanced; guard tokens preserved in code, blanked in comments).

Clean tree: method-guard gate exits **0**; route validator + `blocker-zero` still pass; manifest JSON valid. Still **tooling/CI only — not v1-GO progress.**


---

## Review fixup (commit `669965b0`) — close inline-surface bare-mention false-GREEN (ad45080e class)

A re-review found a **MED false-GREEN** in the **inline-surface** (guardHelper=null: `system_intent`, `workflow_deploy`, `autonomy_policy`) per-method guard-token check. The token was a **bare flag-identifier** regex (`(?<![A-Za-z0-9_$])<flag>(?![A-Za-z0-9_$])`), so **any** mention of the flag satisfied it — e.g. a benign `logger.debug({ testMode: deps.allowTestOnlyWorkflowDeployExecution })`. Reviewer repro: drop the real `if (deps.<flag> !== true) throw` from `workflow_deploy.materializeGeneratedSession`, keep `deployDraft`'s real throw (satisfies the file-level Backstop 1), leave a telemetry mention in `materializeGeneratedSession` → the gate reported **both** methods `guarded:true` (FALSE-GREEN) while `materializeGeneratedSession` was un-retired off-route. This is exactly the ad45080e class the gate exists to catch.

**Fix:** for inline surfaces, the per-method `guardTokenRegex` now requires the actual fail-closed **FORM** `<flag>\s*!==\s*true` — the **same pattern Backstop 1 uses**, now factored into a shared `failClosedFormPattern` const so the two **cannot drift**. A bare flag reference no longer counts as a guard. The helper-surface check (call-token + call-site backstop) is **unchanged** — it was already sound. Comment/string stripping and per-method brace-matching are unchanged.

**Honesty note (unchanged scope):** the inline-surface check now requires the `!== true` fail-closed **FORM** (not a bare mention), closing the bare-mention false-GREEN. It remains a **textual FORM check, not a behavior proof** — the form can be PRESENT yet not fail closed (e.g. `if (deps.<flag> !== true) return;` instead of `throw`). Fail-closed **behavior** is still proven only by the per-surface behavioral tests in the `test` job. (Supersedes the Phase A description's earlier "a direct `flag` reference for inline-guarded ones" and the `if (flag === true) throw` inline-neuter illustration — the tightened token now rejects a bare reference and an `=== true` form outright.)

### Verified (this fixup)
- **Clean tree:** method-guard gate exits **0** — 5 surfaces / 12 methods all `guarded`, zero false-RED; the 3 inline surfaces (`system_intent`, `workflow_deploy`, `autonomy_policy`) pass with their real `deps.<flag> !== true` guards.
- **False-GREEN now RED (3-state scratch repro, tracked files untouched):**
  - OLD script (pre-fix, bare-flag token) + repro'd source → **exit 0 (FALSE-GREEN)**, `materializeGeneratedSession=guarded`.
  - NEW script + **same** repro'd source → **exit 1 (RED)**, single finding naming `materializeGeneratedSession=UNGUARDED` ("method-head guard MISSING from its own body") while `deployDraft=guarded`; Backstop 1 stays green off `deployDraft`'s surviving throw and Backstop 2 doesn't fire (guardHelper=null), so the RED is purely Phase A.1 — i.e. the token is the discriminator.
  - NEW script + clean source → **exit 0**.
- Route validator + `assert-ts-runtime-blocker-zero`: still **passed** / `blocker=0`. Manifest JSON valid. `node --check` clean.

Still **tooling/CI only — not v1-GO progress.**
