### PR TITLE
feat(rust-provider): S7 — friday-anthropic (Claude) provider behind AgentLlmClient, no-fallback, dark default-off

### DIFF
--- a/rust-core/Cargo.lock
+++ b/rust-core/Cargo.lock
@@ -466,6 +466,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "friday-anthropic"
+version = "0.0.1"
+dependencies = [
+ "friday-core",
+ "friday-deepseek",
+ "serde_json",
+ "thiserror 1.0.69",
+ "ureq",
+]
+
+[[package]]
 name = "friday-arch-tests"
 version = "0.0.1"
 dependencies = [
@@ -531,6 +542,7 @@ dependencies = [
 name = "friday-hub"
 version = "0.0.1"
 dependencies = [
+ "friday-anthropic",
  "friday-core",
  "friday-crypto",
  "friday-deepseek",

--- a/rust-core/Cargo.toml
+++ b/rust-core/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "crates/friday-transport",
     "crates/friday-storage",
     "crates/friday-deepseek",
+    "crates/friday-anthropic",
     "crates/friday-providers",
     "crates/friday-fs",
     "crates/friday-hub",
@@ -62,6 +63,7 @@ friday-protocol = { path = "crates/friday-protocol" }
 friday-transport = { path = "crates/friday-transport" }
 friday-storage = { path = "crates/friday-storage" }
 friday-deepseek = { path = "crates/friday-deepseek" }
+friday-anthropic = { path = "crates/friday-anthropic" }
 friday-providers = { path = "crates/friday-providers" }
 friday-fs = { path = "crates/friday-fs" }
 friday-hub = { path = "crates/friday-hub" }

--- a/rust-core/crates/friday-anthropic/Cargo.toml
+++ b/rust-core/crates/friday-anthropic/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "friday-anthropic"
+description = "Friday Rust Core — Claude/Anthropic Friday-provider route (Hub-only, provider-secret-bearing). DARK / default-off."
+edition.workspace = true
+version.workspace = true
+license.workspace = true
+publish = false
+rust-version.workspace = true
+
+# Hub-only, provider-secret-bearing crate. It reads FRIDAY_ANTHROPIC_API_KEY from
+# the environment (set on the Hub only) and must stay OUT of friday-ffi's
+# dependency graph (asserted by friday-arch-tests, mirroring friday-deepseek).
+[dependencies]
+friday-core.workspace = true
+serde_json = "1"
+thiserror.workspace = true
+# Blocking HTTP client (rustls/webpki-roots; no async runtime, no system certs).
+# Same client + features friday-deepseek uses so the secret-bearing crates share
+# one audited transport surface.
+ureq = { version = "2", features = ["json"] }
+
+[dev-dependencies]
+# The PARITY harness (#[ignore]-d, built-not-run) drives the SAME prompt through
+# DeepSeek and Claude for the later live parity proof. friday-deepseek is a
+# dev-dependency ONLY (it never enters this crate's runtime/public graph), the
+# established pattern (friday-deepseek itself dev-deps friday-storage).
+friday-deepseek.workspace = true

--- a/rust-core/crates/friday-anthropic/src/lib.rs
+++ b/rust-core/crates/friday-anthropic/src/lib.rs
@@ -1,0 +1,693 @@
+//! friday-anthropic — the Claude/Anthropic Friday-provider route (Hub-only,
+//! secret-bearing). **Friday's SECOND live LLM provider**, mirroring the proven
+//! `friday-deepseek` crate behind the same `friday_hub::AgentLlmClient` seam.
+//!
+//! **DARK / default-off.** This crate is reachable only behind an explicit,
+//! default-OFF selection (see `friday_hub::HubRuntime::live`, env gate
+//! `FRIDAY_CLAUDE_ROUTE_ENABLED`, default off) AND a `claude`-kind route that the
+//! autonomous baseline registers as `available: false`. Prod default behavior is
+//! UNCHANGED; the DeepSeek path is untouched.
+//!
+//! The route:
+//! 1. reads `FRIDAY_ANTHROPIC_API_KEY` from the environment — **on the Hub only**
+//!    (the value is never printed/logged/committed);
+//! 2. calls `POST /v1/messages` (the Anthropic Messages API — no `/models`
+//!    discovery step; the model id comes from the route, e.g. `claude-opus-4-8`);
+//! 3. parses the assistant text from the `content[]` blocks + `stop_reason` +
+//!    `usage` (`input_tokens` / `output_tokens` — NOT OpenAI's
+//!    `prompt_tokens`/`completion_tokens`).
+//!
+//! **No fallback.** A failed route is a [`ClaudeError`] (`ProviderUnavailable` /
+//! `Auth` / `ClientError` / …) — never a silent substitute provider, local model,
+//! or canned answer. The only call-making method is [`ClaudeClient::chat`];
+//! everything else is pure and makes no network call.
+//!
+//! **Ledger/metering DEFERRED.** Unlike DeepSeek, this crate does NOT build a
+//! `friday_core::LedgerEntry`: `LedgerEntry::friday_route` hard-wires
+//! `ProviderKind::DeepSeek` + `api.deepseek.com`, so reusing it would
+//! mis-attribute a Claude call as DeepSeek (a latent honesty bug). The adapter in
+//! `friday-hub` therefore uses the trait's DEFAULT (no-usage ⇒ no ledger row)
+//! metering. A proper Claude ledger needs `ProviderKind::Anthropic` + a
+//! `MeteredStep` generalization — both out of this dark slice's scope.
+//!
+//! Trust boundary: this crate is provider-secret-bearing and must stay OUT of
+//! `friday-ffi`'s dependency graph (asserted by `friday-arch-tests`, mirroring
+//! the friday-deepseek assertion).
+
+use serde_json::{json, Value};
+use thiserror::Error;
+
+/// Anthropic API base URL (the Messages API root).
+pub const BASE_URL: &str = "https://api.anthropic.com";
+/// The host the route talks to (for evidence / leak-lens assertions).
+pub const BASE_URL_HOST: &str = "api.anthropic.com";
+/// Required Anthropic API version header value (pinned; see the Messages API contract).
+pub const ANTHROPIC_VERSION: &str = "2023-06-01";
+/// Default Claude model id when the route does not pin one. Current Claude model
+/// (`claude-opus-4-8`). The route registry pins the model explicitly; this is the
+/// crate-level fallback default only.
+pub const DEFAULT_MODEL: &str = "claude-opus-4-8";
+/// Hub-only environment variable holding the Anthropic API key.
+pub const ENV_KEY: &str = "FRIDAY_ANTHROPIC_API_KEY";
+
+// `Clone + PartialEq + Eq` mirrors `DeepSeekError` so the structured error could be
+// carried (not stringified) if a future slice adds an `AgentError::ClaudeRoute`
+// variant + classifier arm. In THIS dark slice the friday-hub adapter maps a
+// `ClaudeError` into the existing string-bearing `AgentError::Model(_)` (never
+// retried), so Claude-route retry-classification is DEFERRED — acceptable for a
+// never-selected default-off path. Error messages stay coarse + secret-free
+// (status code / kind only — see `map_ureq_err`).
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum ClaudeError {
+    /// Env var unset/empty. Adverse path: surfaces as a blocker, never a fallback.
+    #[error("Anthropic credential missing or empty (env {ENV_KEY})")]
+    CredentialMissing,
+    /// Authentication rejected (HTTP 401/403). Never a fallback.
+    #[error("Anthropic authentication failed (HTTP {0})")]
+    Auth(u16),
+    /// Route unavailable: a TRANSIENT failure that retrying the SAME route may
+    /// fix — network/transport error, request-timeout (HTTP 408), a server-side
+    /// 5xx, or Anthropic's 529 `overloaded_error`. Never a fallback.
+    #[error("Anthropic provider unavailable: {0}")]
+    ProviderUnavailable(String),
+    /// A TERMINAL client-side HTTP error: other 4xx (400 bad-request / 404 /
+    /// 413 request-too-large / 422) and 429 rate-limit. Retrying cannot fix a
+    /// malformed/unauthorized/not-found request, and — absent any backoff
+    /// mechanism — retrying a 429 would only hammer a rate-limited provider, so
+    /// 429 is treated as terminal here (mirrors DeepSeek's no-backoff choice).
+    /// Never a fallback. Display is COARSE: status code only, never the body.
+    #[error("Anthropic client error (HTTP {status})")]
+    ClientError { status: u16 },
+    /// Response did not match the documented Messages API shape.
+    #[error("Anthropic response shape unexpected: {0}")]
+    BadResponse(String),
+}
+
+/// HTTP transport seam. The real impl is [`UreqTransport`]; tests inject a mock
+/// so the no-hidden-call and no-fallback logic can be proven without network.
+///
+/// Anthropic auth differs from DeepSeek's `Authorization: Bearer`: it uses the
+/// `x-api-key` header + a required `anthropic-version` header. The transport owns
+/// those headers so the `ClaudeClient` never formats the secret into a request it
+/// might later log.
+pub trait Transport {
+    fn post_json(&self, url: &str, api_key: &str, body: &Value) -> Result<Value, ClaudeError>;
+}
+
+/// Real blocking HTTP transport (ureq + rustls). Maps errors to controlled
+/// [`ClaudeError`] messages — it never formats the request (which carries the
+/// `x-api-key` header) into an error string.
+pub struct UreqTransport;
+
+impl UreqTransport {
+    pub fn new() -> Self {
+        UreqTransport
+    }
+}
+
+impl Default for UreqTransport {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn map_ureq_err(e: ureq::Error) -> ClaudeError {
+    match e {
+        ureq::Error::Status(code, _resp) => {
+            // Do not read/echo the response body; classify by status code ONLY.
+            if code == 401 || code == 403 {
+                ClaudeError::Auth(code)
+            } else if code == 408 || code == 529 || (500..=599).contains(&code) {
+                // Transient: request-timeout (408), Anthropic's 529 overloaded_error,
+                // or any server-side 5xx — retrying the SAME route may succeed.
+                ClaudeError::ProviderUnavailable(format!("HTTP {code}"))
+            } else {
+                // Terminal client error: other 4xx (400/404/413/422) and 429 rate-limit.
+                ClaudeError::ClientError { status: code }
+            }
+        }
+        // Transport error (DNS/TLS/timeout). Its Display carries host/kind, not
+        // our x-api-key header, but keep the message terse and controlled.
+        ureq::Error::Transport(t) => {
+            ClaudeError::ProviderUnavailable(format!("transport: {}", t.kind()))
+        }
+    }
+}
+
+impl Transport for UreqTransport {
+    fn post_json(&self, url: &str, api_key: &str, body: &Value) -> Result<Value, ClaudeError> {
+        let resp = ureq::post(url)
+            .set("x-api-key", api_key)
+            .set("anthropic-version", ANTHROPIC_VERSION)
+            .set("content-type", "application/json")
+            .set("accept", "application/json")
+            .send_json(body.clone())
+            .map_err(map_ureq_err)?;
+        resp.into_json::<Value>()
+            .map_err(|e| ClaudeError::BadResponse(format!("invalid JSON: {e}")))
+    }
+}
+
+/// One model call's result (the bits Friday would show / later ledger). Mirrors
+/// `friday_deepseek::ModelCallOutcome` but uses Anthropic's usage field names so a
+/// Claude call is never mis-shaped into the DeepSeek outcome.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ModelCallOutcome {
+    /// The model id the response reported (report the *reported* model, not the
+    /// requested one, to avoid stale-model claims).
+    pub model: String,
+    /// Anthropic `usage.input_tokens` (the prompt-token equivalent).
+    pub input_tokens: i64,
+    /// Anthropic `usage.output_tokens` (the completion-token equivalent).
+    pub output_tokens: i64,
+    /// Checked sum of input + output (Anthropic returns no `total_tokens`).
+    pub total_tokens: i64,
+    /// Concatenated text from every `content[]` block whose `type == "text"`.
+    pub content: String,
+    /// Anthropic `stop_reason` (`end_turn` / `max_tokens` / `tool_use` / `refusal` / …).
+    pub stop_reason: String,
+}
+
+/// Read the API key from a specific env var (Hub-only). Empty/whitespace = missing.
+pub fn api_key_from_env_var(var: &str) -> Result<String, ClaudeError> {
+    match std::env::var(var) {
+        Ok(v) if !v.trim().is_empty() => Ok(v),
+        _ => Err(ClaudeError::CredentialMissing),
+    }
+}
+
+pub struct ClaudeClient<T: Transport> {
+    transport: T,
+    api_key: String,
+    base_url: String,
+}
+
+impl ClaudeClient<UreqTransport> {
+    /// Construct from the Hub environment (`FRIDAY_ANTHROPIC_API_KEY`). FAILS
+    /// CLOSED if the key is absent/empty — never a fallback. Mirrors
+    /// `DeepSeekClient::from_env`.
+    pub fn from_env() -> Result<Self, ClaudeError> {
+        let api_key = api_key_from_env_var(ENV_KEY)?;
+        Ok(ClaudeClient {
+            transport: UreqTransport::new(),
+            api_key,
+            base_url: BASE_URL.to_string(),
+        })
+    }
+}
+
+impl<T: Transport> ClaudeClient<T> {
+    /// For tests / alternate transports. (`api_key` is never logged.)
+    pub fn with_transport(transport: T, api_key: String) -> Self {
+        ClaudeClient {
+            transport,
+            api_key,
+            base_url: BASE_URL.to_string(),
+        }
+    }
+
+    /// For tests that need the real transport against a local HTTP endpoint.
+    /// Production construction uses [`ClaudeClient::from_env`] and the fixed
+    /// Anthropic base URL above.
+    pub fn with_transport_and_base_url(
+        transport: T,
+        api_key: String,
+        base_url: impl Into<String>,
+    ) -> Self {
+        ClaudeClient {
+            transport,
+            api_key,
+            base_url: base_url.into().trim_end_matches('/').to_string(),
+        }
+    }
+
+    fn endpoint(&self, path: &str) -> String {
+        format!("{}{}", self.base_url, path)
+    }
+
+    /// `POST /v1/messages` — a single non-streaming completion. `max_tokens` is
+    /// REQUIRED by the Anthropic Messages API; the caller always supplies it.
+    pub fn chat(
+        &self,
+        model: &str,
+        prompt: &str,
+        max_tokens: u32,
+    ) -> Result<ModelCallOutcome, ClaudeError> {
+        let body = json!({
+            "model": model,
+            "max_tokens": max_tokens,
+            "messages": [{"role": "user", "content": prompt}],
+        });
+        let v = self
+            .transport
+            .post_json(&self.endpoint("/v1/messages"), &self.api_key, &body)?;
+
+        let usage = v
+            .get("usage")
+            .ok_or_else(|| ClaudeError::BadResponse("missing `usage`".into()))?;
+        let input_tokens = usage
+            .get("input_tokens")
+            .and_then(Value::as_i64)
+            .ok_or_else(|| ClaudeError::BadResponse("usage.input_tokens".into()))?;
+        let output_tokens = usage
+            .get("output_tokens")
+            .and_then(Value::as_i64)
+            .ok_or_else(|| ClaudeError::BadResponse("usage.output_tokens".into()))?;
+        // Anthropic returns no `total_tokens`; sum the parts with a CHECKED add so a
+        // hostile/buggy `usage` yields a clean BadResponse, never an overflow panic.
+        let total_tokens = input_tokens
+            .checked_add(output_tokens)
+            .ok_or_else(|| ClaudeError::BadResponse("usage token total overflow".into()))?;
+
+        // Report the model id the response reports (avoids stale-model claims).
+        let reported_model = v
+            .get("model")
+            .and_then(Value::as_str)
+            .unwrap_or(model)
+            .to_string();
+
+        // The assistant reply is `content[]` — concatenate every `type == "text"`
+        // block (never index `content[0]`; a leading non-text block or an empty
+        // array must not panic).
+        let content = v
+            .get("content")
+            .and_then(Value::as_array)
+            .map(|blocks| {
+                blocks
+                    .iter()
+                    .filter(|b| b.get("type").and_then(Value::as_str) == Some("text"))
+                    .filter_map(|b| b.get("text").and_then(Value::as_str))
+                    .collect::<Vec<_>>()
+                    .join("")
+            })
+            .unwrap_or_default();
+
+        let stop_reason = v
+            .get("stop_reason")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
+
+        Ok(ModelCallOutcome {
+            model: reported_model,
+            input_tokens,
+            output_tokens,
+            total_tokens,
+            content,
+            stop_reason,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+
+    /// Mock transport that counts calls and returns canned results. Lets us
+    /// prove (offline) the call discipline and no-fallback behavior.
+    struct MockTransport {
+        post_calls: Cell<u32>,
+        post_result: Result<Value, ()>,
+        post_err: Option<ClaudeErrorKind>,
+    }
+
+    #[derive(Clone, Copy)]
+    enum ClaudeErrorKind {
+        Auth401,
+        Unavailable,
+    }
+
+    impl MockTransport {
+        fn new(post_result: Result<Value, ()>) -> Self {
+            MockTransport {
+                post_calls: Cell::new(0),
+                post_result,
+                post_err: None,
+            }
+        }
+        fn with_post_error(mut self, kind: ClaudeErrorKind) -> Self {
+            self.post_err = Some(kind);
+            self
+        }
+    }
+
+    impl Transport for MockTransport {
+        fn post_json(&self, _url: &str, _key: &str, _body: &Value) -> Result<Value, ClaudeError> {
+            self.post_calls.set(self.post_calls.get() + 1);
+            if let Some(kind) = self.post_err {
+                return Err(match kind {
+                    ClaudeErrorKind::Auth401 => ClaudeError::Auth(401),
+                    ClaudeErrorKind::Unavailable => {
+                        ClaudeError::ProviderUnavailable("HTTP 503".into())
+                    }
+                });
+            }
+            self.post_result
+                .clone()
+                .map_err(|_| ClaudeError::ProviderUnavailable("mock post error".into()))
+        }
+    }
+
+    /// A canonical Anthropic Messages API success response.
+    fn messages_json() -> Value {
+        json!({
+            "id": "msg_x",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-opus-4-8",
+            "content": [{"type": "text", "text": "PONG"}],
+            "stop_reason": "end_turn",
+            "stop_sequence": null,
+            "usage": {"input_tokens": 11, "output_tokens": 8}
+        })
+    }
+
+    fn client(mock: MockTransport) -> ClaudeClient<MockTransport> {
+        ClaudeClient::with_transport(mock, "test-key-not-real".to_string())
+    }
+
+    fn serve_http_once(
+        status: u16,
+        reason: &'static str,
+        body: &'static str,
+    ) -> (String, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut req = [0u8; 2048];
+            let _ = stream.read(&mut req);
+            let response = format!(
+                "HTTP/1.1 {status} {reason}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+        });
+        (format!("http://{addr}"), handle)
+    }
+
+    // ---- from_env fail-closed ----
+
+    #[test]
+    fn missing_credential_is_an_error_not_a_fallback() {
+        // Use a var name guaranteed unset, regardless of any sourced real key,
+        // and without mutating the process-global environment.
+        let err =
+            api_key_from_env_var("FRIDAY_ANTHROPIC_API_KEY_DEFINITELY_UNSET_a1b2c3").unwrap_err();
+        assert!(matches!(err, ClaudeError::CredentialMissing));
+    }
+
+    // ---- request shaping (golden request JSON) ----
+
+    #[test]
+    fn chat_builds_the_messages_request_with_required_max_tokens() {
+        // Capture the exact body the client posts and assert the golden shape:
+        // model + max_tokens (REQUIRED) + messages[{role:"user", content}].
+        struct CapturingTransport {
+            seen: std::cell::RefCell<Option<Value>>,
+        }
+        impl Transport for CapturingTransport {
+            fn post_json(&self, url: &str, _key: &str, body: &Value) -> Result<Value, ClaudeError> {
+                assert!(url.ends_with("/v1/messages"), "wrong endpoint: {url}");
+                *self.seen.borrow_mut() = Some(body.clone());
+                Ok(messages_json())
+            }
+        }
+        let c = ClaudeClient::with_transport(
+            CapturingTransport {
+                seen: std::cell::RefCell::new(None),
+            },
+            "test-key-not-real".to_string(),
+        );
+        let _ = c.chat("claude-opus-4-8", "ping", 64).unwrap();
+        let body = c.transport.seen.borrow().clone().unwrap();
+        assert_eq!(body["model"], "claude-opus-4-8");
+        assert_eq!(body["max_tokens"], 64);
+        assert_eq!(body["messages"][0]["role"], "user");
+        assert_eq!(body["messages"][0]["content"], "ping");
+        // No streaming, no thinking — kept simple.
+        assert!(body.get("stream").is_none());
+    }
+
+    // ---- response parsing (golden response → expected text/usage) ----
+
+    #[test]
+    fn chat_maps_usage_and_reported_model_and_text() {
+        let c = client(MockTransport::new(Ok(messages_json())));
+        let out = c.chat("claude-opus-4-8", "ping", 64).unwrap();
+        assert_eq!(out.model, "claude-opus-4-8");
+        assert_eq!(out.input_tokens, 11);
+        assert_eq!(out.output_tokens, 8);
+        assert_eq!(out.total_tokens, 19);
+        assert_eq!(out.content, "PONG");
+        assert_eq!(out.stop_reason, "end_turn");
+    }
+
+    #[test]
+    fn chat_concatenates_multiple_text_blocks_and_skips_non_text() {
+        // The reply is `content[]`; a leading non-text block (e.g. a tool_use) must
+        // be skipped and multiple text blocks concatenated — never index content[0].
+        let multi = json!({
+            "model": "claude-opus-4-8",
+            "content": [
+                {"type": "tool_use", "id": "tu_1", "name": "x", "input": {}},
+                {"type": "text", "text": "Hello "},
+                {"type": "text", "text": "world"}
+            ],
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 5, "output_tokens": 3}
+        });
+        let c = client(MockTransport::new(Ok(multi)));
+        let out = c.chat("claude-opus-4-8", "hi", 64).unwrap();
+        assert_eq!(out.content, "Hello world");
+        assert_eq!(out.total_tokens, 8);
+    }
+
+    #[test]
+    fn chat_empty_content_array_is_empty_string_not_panic() {
+        let empty = json!({
+            "model": "claude-opus-4-8",
+            "content": [],
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 5, "output_tokens": 0}
+        });
+        let c = client(MockTransport::new(Ok(empty)));
+        let out = c.chat("claude-opus-4-8", "hi", 64).unwrap();
+        assert_eq!(out.content, "");
+        assert_eq!(out.stop_reason, "end_turn");
+    }
+
+    #[test]
+    fn chat_missing_usage_is_bad_response() {
+        let no_usage = json!({
+            "model": "claude-opus-4-8",
+            "content": [{"type": "text", "text": "hi"}],
+            "stop_reason": "end_turn"
+        });
+        let c = client(MockTransport::new(Ok(no_usage)));
+        assert!(matches!(
+            c.chat("claude-opus-4-8", "hi", 64).unwrap_err(),
+            ClaudeError::BadResponse(_)
+        ));
+    }
+
+    #[test]
+    fn chat_missing_usage_field_is_bad_response() {
+        let partial = json!({
+            "model": "claude-opus-4-8",
+            "content": [{"type": "text", "text": "hi"}],
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 5}  // missing output_tokens
+        });
+        let c = client(MockTransport::new(Ok(partial)));
+        assert!(matches!(
+            c.chat("claude-opus-4-8", "hi", 64).unwrap_err(),
+            ClaudeError::BadResponse(_)
+        ));
+    }
+
+    #[test]
+    fn chat_overflow_usage_total_is_bad_response_not_panic() {
+        // Hostile/buggy usage: parts sum past i64::MAX → checked sum yields
+        // BadResponse (never a panic / overflow).
+        let overflow = json!({
+            "model": "claude-opus-4-8",
+            "content": [{"type": "text", "text": "x"}],
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": i64::MAX, "output_tokens": 1}
+        });
+        let c = client(MockTransport::new(Ok(overflow)));
+        assert!(matches!(
+            c.chat("claude-opus-4-8", "hi", 16).unwrap_err(),
+            ClaudeError::BadResponse(_)
+        ));
+    }
+
+    // ---- no-fallback / error mapping ----
+
+    #[test]
+    fn provider_error_does_not_fallback() {
+        // A failed chat returns an error after exactly one POST — there is no
+        // second provider/local/mock attempt.
+        let c = client(
+            MockTransport::new(Ok(messages_json())).with_post_error(ClaudeErrorKind::Unavailable),
+        );
+        let err = c.chat("claude-opus-4-8", "hi", 64).unwrap_err();
+        assert!(matches!(err, ClaudeError::ProviderUnavailable(_)));
+        assert_eq!(c.transport.post_calls.get(), 1, "must not retry/fallback");
+    }
+
+    #[test]
+    fn auth_failure_maps_to_auth_error() {
+        let c = client(
+            MockTransport::new(Ok(messages_json())).with_post_error(ClaudeErrorKind::Auth401),
+        );
+        assert!(matches!(
+            c.chat("claude-opus-4-8", "hi", 64).unwrap_err(),
+            ClaudeError::Auth(401)
+        ));
+    }
+
+    #[test]
+    fn map_ureq_status_partitions_transient_vs_terminal() {
+        // Synthetic ureq::Error::Status values drive map_ureq_err directly (no
+        // network), proving the exact partition: 5xx + 408 + 529 + transport ⇒
+        // transient ProviderUnavailable; other 4xx + 429 ⇒ terminal ClientError;
+        // 401/403 ⇒ Auth.
+        let status_err = |code: u16, reason: &str| {
+            let resp = ureq::Response::new(code, reason, "{}").unwrap();
+            map_ureq_err(ureq::Error::Status(code, resp))
+        };
+
+        // Transient — including Anthropic's 529 overloaded_error.
+        for code in [500u16, 502, 503, 504, 529, 408] {
+            assert!(
+                matches!(
+                    status_err(code, "x"),
+                    ClaudeError::ProviderUnavailable(ref r) if r == &format!("HTTP {code}")
+                ),
+                "HTTP {code} must be transient ProviderUnavailable"
+            );
+        }
+        // Terminal client error — 413 request-too-large + 429 rate-limit included.
+        for code in [400u16, 404, 413, 422, 429] {
+            assert!(
+                matches!(status_err(code, "x"), ClaudeError::ClientError { status } if status == code),
+                "HTTP {code} must be terminal ClientError"
+            );
+        }
+        // 401/403 stay Auth.
+        assert!(matches!(status_err(401, "x"), ClaudeError::Auth(401)));
+        assert!(matches!(status_err(403, "x"), ClaudeError::Auth(403)));
+    }
+
+    #[test]
+    fn real_transport_maps_rate_limit_to_terminal_client_error_without_body_or_secret() {
+        // 429 is a TERMINAL ClientError (no backoff ⇒ treat as terminal rather than
+        // hammer a rate-limited provider). Display/Debug stays COARSE: the status
+        // code only — never the response body nor the x-api-key. Leak-lens.
+        let (base_url, handle) = serve_http_once(
+            429,
+            "Too Many Requests",
+            r#"{"type":"error","error":{"type":"rate_limit_error","message":"SECRET-QUOTA-BODY"}}"#,
+        );
+        let c = ClaudeClient::with_transport_and_base_url(
+            UreqTransport::new(),
+            "test-key-not-real".to_string(),
+            base_url,
+        );
+        let err = c.chat("claude-opus-4-8", "hi", 16).unwrap_err();
+        handle.join().unwrap();
+        assert!(matches!(err, ClaudeError::ClientError { status: 429 }));
+        // Both Debug and Display must be coarse and secret-free.
+        for rendered in [format!("{err:?}"), format!("{err}")] {
+            for forbidden in ["SECRET-QUOTA-BODY", "test-key-not-real", "x-api-key"] {
+                assert!(
+                    !rendered.contains(forbidden),
+                    "client-error render leaked {forbidden}: {rendered}"
+                );
+            }
+            // Positively: the status code IS present (a coarse, useful label).
+            assert!(rendered.contains("429"), "status code missing: {rendered}");
+        }
+    }
+
+    #[test]
+    fn real_transport_maps_overloaded_529_to_transient_without_secret() {
+        let (base_url, handle) = serve_http_once(
+            529,
+            "Overloaded",
+            r#"{"type":"error","error":{"type":"overloaded_error","message":"SECRET-OVERLOAD"}}"#,
+        );
+        let c = ClaudeClient::with_transport_and_base_url(
+            UreqTransport::new(),
+            "test-key-not-real".to_string(),
+            base_url,
+        );
+        let err = c.chat("claude-opus-4-8", "hi", 16).unwrap_err();
+        handle.join().unwrap();
+        assert!(
+            matches!(err, ClaudeError::ProviderUnavailable(ref r) if r == "HTTP 529"),
+            "got {err:?}"
+        );
+        let rendered = format!("{err:?}");
+        for forbidden in ["SECRET-OVERLOAD", "test-key-not-real", "x-api-key"] {
+            assert!(
+                !rendered.contains(forbidden),
+                "leaked {forbidden}: {rendered}"
+            );
+        }
+    }
+
+    #[test]
+    fn real_transport_maps_tcp_network_fail_without_secret() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        let c = ClaudeClient::with_transport_and_base_url(
+            UreqTransport::new(),
+            "test-key-not-real".to_string(),
+            format!("http://{addr}"),
+        );
+        let err = c.chat("claude-opus-4-8", "hi", 16).unwrap_err();
+        assert!(matches!(
+            err,
+            ClaudeError::ProviderUnavailable(ref reason) if reason.starts_with("transport:")
+        ));
+        let rendered = format!("{err:?}");
+        for forbidden in ["test-key-not-real", "x-api-key"] {
+            assert!(
+                !rendered.contains(forbidden),
+                "network-fail error leaked {forbidden}: {rendered}"
+            );
+        }
+    }
+
+    #[test]
+    fn malformed_json_body_is_bad_response() {
+        // A 200 with a non-JSON body must be a clean BadResponse, not a panic.
+        let (base_url, handle) = serve_http_once(200, "OK", "this is not json");
+        let c = ClaudeClient::with_transport_and_base_url(
+            UreqTransport::new(),
+            "test-key-not-real".to_string(),
+            base_url,
+        );
+        let err = c.chat("claude-opus-4-8", "hi", 16).unwrap_err();
+        handle.join().unwrap();
+        assert!(matches!(err, ClaudeError::BadResponse(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn only_explicit_chat_hits_the_transport() {
+        // Constructing the client makes ZERO transport calls; only chat() does,
+        // and exactly one POST per call (no hidden retry/fallback).
+        let c = client(MockTransport::new(Ok(messages_json())));
+        assert_eq!(c.transport.post_calls.get(), 0);
+        let _ = c.chat("claude-opus-4-8", "hi", 64).unwrap();
+        assert_eq!(c.transport.post_calls.get(), 1);
+    }
+}

--- a/rust-core/crates/friday-anthropic/src/lib.rs
+++ b/rust-core/crates/friday-anthropic/src/lib.rs
@@ -370,22 +370,29 @@ mod tests {
         ClaudeClient::with_transport(mock, "test-key-not-real".to_string())
     }
 
+    /// Serve exactly one HTTP response on an ephemeral localhost port. The thread
+    /// returns the raw request bytes it captured off the wire (as a lossy String)
+    /// so a header KAT can assert what actually reached the socket. Callers that
+    /// only care about the response simply `handle.join().unwrap();` and discard
+    /// the returned String.
     fn serve_http_once(
         status: u16,
         reason: &'static str,
         body: &'static str,
-    ) -> (String, thread::JoinHandle<()>) {
+    ) -> (String, thread::JoinHandle<String>) {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
         let handle = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let mut req = [0u8; 2048];
-            let _ = stream.read(&mut req);
+            let n = stream.read(&mut req).unwrap_or(0);
+            let captured = String::from_utf8_lossy(&req[..n]).into_owned();
             let response = format!(
                 "HTTP/1.1 {status} {reason}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
                 body.len()
             );
             stream.write_all(response.as_bytes()).unwrap();
+            captured
         });
         (format!("http://{addr}"), handle)
     }
@@ -399,6 +406,41 @@ mod tests {
         let err =
             api_key_from_env_var("FRIDAY_ANTHROPIC_API_KEY_DEFINITELY_UNSET_a1b2c3").unwrap_err();
         assert!(matches!(err, ClaudeError::CredentialMissing));
+    }
+
+    #[test]
+    fn empty_or_whitespace_credential_fails_closed_no_client() {
+        // A var that is SET but empty / whitespace-only must FAIL CLOSED exactly
+        // like an absent var — never yielding a (blank-key) client. Use a unique
+        // bespoke var name so the (single) env-mutating test in this suite has no
+        // concurrent-mutation partner regardless of cargo's test parallelism, and
+        // never touches the real `FRIDAY_ANTHROPIC_API_KEY`.
+        let var = "FRIDAY_ANTHROPIC_API_KEY_EMPTY_WS_TEST_d4e5f6";
+
+        std::env::set_var(var, "");
+        assert!(
+            matches!(
+                api_key_from_env_var(var).unwrap_err(),
+                ClaudeError::CredentialMissing
+            ),
+            "empty key must fail closed"
+        );
+
+        std::env::set_var(var, "  \t\n ");
+        assert!(
+            matches!(
+                api_key_from_env_var(var).unwrap_err(),
+                ClaudeError::CredentialMissing
+            ),
+            "whitespace-only key must fail closed"
+        );
+
+        // A non-empty value IS accepted (positive control: the validator is not
+        // just always-Err) — and is returned verbatim, not trimmed.
+        std::env::set_var(var, " sk-real ");
+        assert_eq!(api_key_from_env_var(var).unwrap(), " sk-real ");
+
+        std::env::remove_var(var);
     }
 
     // ---- request shaping (golden request JSON) ----
@@ -431,6 +473,44 @@ mod tests {
         assert_eq!(body["messages"][0]["content"], "ping");
         // No streaming, no thinking — kept simple.
         assert!(body.get("stream").is_none());
+    }
+
+    #[test]
+    fn real_transport_sends_x_api_key_and_anthropic_version_headers_on_the_wire() {
+        // The Anthropic auth headers are set by the REAL transport (UreqTransport),
+        // not by ClaudeClient — so prove them where they're actually written: parse
+        // the raw request bytes captured off the socket and assert the request line
+        // + that the CONFIGURED x-api-key value and the pinned anthropic-version
+        // VALUE reach the wire. Dropping `.set("x-api-key", ..)` or changing
+        // ANTHROPIC_VERSION must turn this RED.
+        let (base_url, handle) = serve_http_once(
+            200,
+            "OK",
+            r#"{"model":"claude-opus-4-8","content":[{"type":"text","text":"PONG"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}"#,
+        );
+        let c = ClaudeClient::with_transport_and_base_url(
+            UreqTransport::new(),
+            "test-key-not-real".to_string(),
+            base_url,
+        );
+        let out = c.chat("claude-opus-4-8", "ping", 16).unwrap();
+        assert_eq!(out.content, "PONG"); // sanity: the round-trip completed
+
+        // ureq does not guarantee header-NAME casing on the wire; lowercase the
+        // haystack. The two asserted VALUES are case-stable.
+        let captured = handle.join().unwrap().to_ascii_lowercase();
+        assert!(
+            captured.contains("post /v1/messages"),
+            "request line missing POST /v1/messages: {captured}"
+        );
+        assert!(
+            captured.contains("x-api-key: test-key-not-real"),
+            "configured x-api-key did not reach the wire: {captured}"
+        );
+        assert!(
+            captured.contains("anthropic-version: 2023-06-01"),
+            "anthropic-version value did not reach the wire: {captured}"
+        );
     }
 
     // ---- response parsing (golden response → expected text/usage) ----

--- a/rust-core/crates/friday-anthropic/tests/live_round_trip.rs
+++ b/rust-core/crates/friday-anthropic/tests/live_round_trip.rs
@@ -1,0 +1,64 @@
+//! LIVE round-trip proof for the Claude/Anthropic route — BUILT but NOT RUN.
+//!
+//! This test is `#[ignore]`-d: it requires a real `FRIDAY_ANTHROPIC_API_KEY` and
+//! makes ONE real `POST /v1/messages` call that SPENDS QUOTA. No Claude credential
+//! is provisioned in this dark slice, so it must compile but is never run here.
+//!
+//! Run it LATER (with the key sourced on the Hub) exactly like this:
+//!
+//! ```text
+//! FRIDAY_ANTHROPIC_API_KEY=<key> \
+//!   cargo test -p friday-anthropic --test live_round_trip --ignored -- --nocapture
+//! ```
+//!
+//! It asserts a non-empty assistant reply through the FULL real path
+//! (from_env → UreqTransport → real api.anthropic.com), proving the route works
+//! end-to-end with NO fallback. SPENDS QUOTA — do not run in CI.
+
+use friday_anthropic::{ClaudeClient, DEFAULT_MODEL};
+
+#[test]
+#[ignore = "live: needs FRIDAY_ANTHROPIC_API_KEY and spends Anthropic quota; run with --ignored"]
+fn live_round_trip() {
+    // from_env FAILS CLOSED if the key is absent — this is the real Hub path.
+    let client = ClaudeClient::from_env()
+        .expect("FRIDAY_ANTHROPIC_API_KEY must be set to run this live test");
+
+    // One real, small completion. `max_tokens` is REQUIRED by the Messages API.
+    let outcome = client
+        .chat(
+            DEFAULT_MODEL,
+            "Reply with exactly the single word: PONG",
+            64,
+        )
+        .expect("live Anthropic /v1/messages round-trip must succeed (no fallback)");
+
+    // Prove a real, non-empty assistant reply came back through the full path.
+    assert!(
+        !outcome.content.trim().is_empty(),
+        "live reply must be non-empty; got stop_reason={:?}",
+        outcome.stop_reason
+    );
+    // Usage must be populated by a real call.
+    assert!(
+        outcome.input_tokens > 0,
+        "input_tokens must be > 0 on a real call"
+    );
+    assert!(
+        outcome.output_tokens > 0,
+        "output_tokens must be > 0 on a real call"
+    );
+    assert_eq!(
+        outcome.total_tokens,
+        outcome.input_tokens + outcome.output_tokens
+    );
+
+    eprintln!(
+        "LIVE OK: model={} stop_reason={} in={} out={} content={:?}",
+        outcome.model,
+        outcome.stop_reason,
+        outcome.input_tokens,
+        outcome.output_tokens,
+        outcome.content
+    );
+}

--- a/rust-core/crates/friday-anthropic/tests/parity_round_trip.rs
+++ b/rust-core/crates/friday-anthropic/tests/parity_round_trip.rs
@@ -1,0 +1,58 @@
+//! LIVE PARITY proof: the SAME prompt through DeepSeek AND Claude — BUILT, NOT RUN.
+//!
+//! This test is `#[ignore]`-d: it requires BOTH live credentials
+//! (`FRIDAY_DEEPSEEK_API_KEY` and `FRIDAY_ANTHROPIC_API_KEY`) and makes real calls
+//! to BOTH providers that SPEND QUOTA. It is the harness for the later live parity
+//! proof (S7 second-provider parity); it must compile but is never run in this dark
+//! slice (no Claude credential is provisioned).
+//!
+//! Run it LATER like this:
+//!
+//! ```text
+//! FRIDAY_DEEPSEEK_API_KEY=<ds> FRIDAY_ANTHROPIC_API_KEY=<an> \
+//!   cargo test -p friday-anthropic --test parity_round_trip --ignored -- --nocapture
+//! ```
+//!
+//! It asserts BOTH providers return a non-empty reply to the same prompt through
+//! their respective from_env → UreqTransport → real-endpoint paths, each with NO
+//! fallback. SPENDS QUOTA on BOTH providers — do not run in CI.
+//!
+//! Note: `friday-deepseek` is a DEV-dependency of this crate only (it never enters
+//! the runtime/public graph), so this parity harness lives here without changing the
+//! dark crate's dependency surface.
+
+use friday_anthropic::{ClaudeClient, DEFAULT_MODEL as CLAUDE_MODEL};
+use friday_deepseek::{select_model, DeepSeekClient};
+
+const PROMPT: &str = "Reply with exactly the single word: PONG";
+
+#[test]
+#[ignore = "live parity: needs BOTH FRIDAY_DEEPSEEK_API_KEY + FRIDAY_ANTHROPIC_API_KEY and spends quota on both; run with --ignored"]
+fn parity_round_trip() {
+    // --- DeepSeek leg (the proven first provider) ---
+    let ds = DeepSeekClient::from_env().expect("FRIDAY_DEEPSEEK_API_KEY must be set");
+    let ds_models = ds.discover_models().expect("DeepSeek model discovery");
+    let ds_model = select_model(&ds_models).expect("a DeepSeek model must be available");
+    let ds_out = ds
+        .chat(&ds_model, PROMPT, 64)
+        .expect("DeepSeek /chat/completions round-trip (no fallback)");
+    assert!(
+        !ds_out.content.trim().is_empty(),
+        "DeepSeek parity reply must be non-empty"
+    );
+
+    // --- Claude leg (the new second provider) ---
+    let claude = ClaudeClient::from_env().expect("FRIDAY_ANTHROPIC_API_KEY must be set");
+    let claude_out = claude
+        .chat(CLAUDE_MODEL, PROMPT, 64)
+        .expect("Claude /v1/messages round-trip (no fallback)");
+    assert!(
+        !claude_out.content.trim().is_empty(),
+        "Claude parity reply must be non-empty"
+    );
+
+    eprintln!(
+        "PARITY OK: deepseek(model={}, content={:?}) | claude(model={}, content={:?})",
+        ds_out.model, ds_out.content, claude_out.model, claude_out.content
+    );
+}

--- a/rust-core/crates/friday-arch-tests/tests/dep_boundary.rs
+++ b/rust-core/crates/friday-arch-tests/tests/dep_boundary.rs
@@ -104,7 +104,9 @@ fn ffi_dependency_closure_excludes_deepseek() {
     let ffi_closure = closure(&graph, "friday-ffi");
 
     // Hub-only, provider-secret-bearing crates must never reach the phone.
-    for hub_only in ["friday-deepseek", "friday-providers"] {
+    // friday-anthropic (S7, the Claude/Anthropic route) is secret-bearing exactly like
+    // friday-deepseek and must stay out of the phone FFI graph too.
+    for hub_only in ["friday-deepseek", "friday-anthropic", "friday-providers"] {
         assert!(graph.contains_key(hub_only), "{hub_only} crate not found");
         assert!(
             !ffi_closure.contains(hub_only),
@@ -169,7 +171,7 @@ fn hub_is_the_secret_bearing_composition_root_and_phone_is_not() {
     );
 
     let hub_closure = closure(&graph, "friday-hub");
-    for secret in ["friday-deepseek", "friday-providers"] {
+    for secret in ["friday-deepseek", "friday-anthropic", "friday-providers"] {
         assert!(
             hub_closure.contains(secret),
             "friday-hub closure must include the secret-bearing {secret}: {hub_closure:?}"
@@ -184,10 +186,27 @@ fn hub_is_the_secret_bearing_composition_root_and_phone_is_not() {
     }
     // And the phone STILL cannot reach the secret crates (re-asserted with hub present).
     let ffi_closure = closure(&graph, "friday-ffi");
-    for secret in ["friday-deepseek", "friday-providers", "friday-hub"] {
+    for secret in [
+        "friday-deepseek",
+        "friday-anthropic",
+        "friday-providers",
+        "friday-hub",
+    ] {
         assert!(
             !ffi_closure.contains(secret),
             "PHONE SECRET LEAK: friday-ffi depends on {secret}; closure = {ffi_closure:?}"
         );
     }
+}
+
+#[test]
+fn anthropic_does_not_depend_on_ffi_either() {
+    // S7: the secret-bearing Claude crate must not pull in the phone surface
+    // (mirrors `deepseek_does_not_depend_on_ffi_either`).
+    let graph = internal_dep_graph(&workspace_root());
+    let an_closure = closure(&graph, "friday-anthropic");
+    assert!(
+        !an_closure.contains("friday-ffi"),
+        "friday-anthropic must not depend on friday-ffi; closure = {an_closure:?}"
+    );
 }

--- a/rust-core/crates/friday-hub/Cargo.toml
+++ b/rust-core/crates/friday-hub/Cargo.toml
@@ -23,6 +23,10 @@ rusqlite.workspace = true
 # live. Depending on them here (and NOT in friday-ffi) is the compile-time
 # "no secret on phone" boundary, asserted by friday-arch-tests.
 friday-deepseek.workspace = true
+# S7 — the Claude/Anthropic route, DARK / default-off. Secret-bearing, Hub-only
+# (same boundary as friday-deepseek; asserted by friday-arch-tests). Reachable only
+# behind an explicit default-OFF selection; the DeepSeek path is unchanged.
+friday-anthropic.workspace = true
 friday-providers.workspace = true
 # The ToolExecutor's file read/write goes through the hardened workspace-root-contained
 # safe-open — NEVER std::fs on an agent-supplied path.

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -469,6 +469,76 @@ impl<T: friday_deepseek::Transport> AgentLlmClient for DeepSeekAgentLlmClient<T>
     }
 }
 
+/// S7 — Real model-client adapter over `friday-anthropic` (the Claude/Anthropic
+/// route), the SECOND live provider, mirroring [`DeepSeekAgentLlmClient`]. It builds
+/// the SAME tool-call / loop prompts, calls the live Claude model (`POST /v1/messages`,
+/// no fallback), and parses the reply STRICTLY back into a [`RawToolCall`]/[`AgentStep`].
+///
+/// **DARK / default-off.** This adapter is constructed only behind an explicit,
+/// default-OFF selection (see [`crate::runtime::HubRuntime::live`], env gate
+/// `FRIDAY_CLAUDE_ROUTE_ENABLED`). It is reachable from the routed loop ONLY when a
+/// `claude`-kind route is selected, which the autonomous baseline marks
+/// `available: false`. Prod default behavior is UNCHANGED; the DeepSeek path is untouched.
+///
+/// **No-fallback contract:** identical to DeepSeek — a route failure is an
+/// [`AgentError`], never a silent substitute. The model id is supplied by the caller
+/// (from the route), so there is no model-discovery step.
+///
+/// **Error mapping (retry-classification DEFERRED).** [`AgentError::Route`] carries a
+/// concrete `friday_deepseek::DeepSeekError`, so a [`friday_anthropic::ClaudeError`]
+/// cannot go there. The lowest-blast-radius mapping for this dark, never-selected path
+/// is the existing string-bearing [`AgentError::Model`] (never retried by the run-loop's
+/// `classify_deepseek`). A future non-dark slice that actually selects Claude would add
+/// an `AgentError::ClaudeRoute(ClaudeError)` variant + a classifier arm; out of scope here.
+///
+/// **Ledger/metering DEFERRED.** This adapter does NOT override `next_step_metered`, so
+/// it uses the trait DEFAULT (no usage ⇒ no ledger row). Reusing DeepSeek's `MeteredStep`
+/// (hardwired to `friday_deepseek::ModelCallOutcome`) or `LedgerEntry::friday_route`
+/// (hardwired to `ProviderKind::DeepSeek`/`api.deepseek.com`) would mis-attribute a Claude
+/// call as DeepSeek — a latent honesty bug. A proper Claude ledger needs
+/// `ProviderKind::Anthropic` + a `MeteredStep` generalization; both out of dark scope.
+pub struct ClaudeAgentLlmClient<T: friday_anthropic::Transport> {
+    client: friday_anthropic::ClaudeClient<T>,
+    /// The model id this adapter dispatches to (from the route; e.g. `claude-opus-4-8`).
+    /// Claude has no `/models` discovery step, so the model is supplied here.
+    model: String,
+}
+
+impl<T: friday_anthropic::Transport> ClaudeAgentLlmClient<T> {
+    pub fn new(client: friday_anthropic::ClaudeClient<T>, model: impl Into<String>) -> Self {
+        Self {
+            client,
+            model: model.into(),
+        }
+    }
+}
+
+impl<T: friday_anthropic::Transport> AgentLlmClient for ClaudeAgentLlmClient<T> {
+    fn propose_tool_call(&self, task: &str) -> Result<RawToolCall, AgentError> {
+        let prompt = build_tool_prompt(task);
+        let outcome = self
+            .client
+            .chat(&self.model, &prompt, AGENTLOOP_MAX_TOKENS)
+            // ClaudeError → string-bearing AgentError::Model (retry-classification deferred;
+            // see the adapter doc). Coarse, secret-free Display.
+            .map_err(|e| AgentError::Model(e.to_string()))?;
+        parse_tool_call(&outcome.content)
+    }
+
+    /// History-aware multi-turn step, identical contract to the DeepSeek adapter's
+    /// `next_step`. `{"tool":"none","answer":"<final>"}` parses to `Finish`.
+    fn next_step(&self, task: &str, history: &[TurnTrace]) -> Result<AgentStep, AgentError> {
+        let prompt = build_loop_prompt(task, history);
+        let outcome = self
+            .client
+            .chat(&self.model, &prompt, AGENTLOOP_MAX_TOKENS)
+            .map_err(|e| AgentError::Model(e.to_string()))?;
+        parse_agent_step(&outcome.content)
+    }
+    // `next_step_metered` is intentionally NOT overridden — see the adapter doc
+    // (ledger/metering deferred; the trait default returns `(result, None)`).
+}
+
 /// The process-wide DEFAULT (built-in) tool registry, built once and reused. The free
 /// `trusted_classify`/`build_tool_prompt` chokepoints call this on every turn; caching
 /// avoids rebuilding the `BTreeMap` + its ~10 `String`s per call (the UNW-002 reviewer

--- a/rust-core/crates/friday-hub/src/routing.rs
+++ b/rust-core/crates/friday-hub/src/routing.rs
@@ -220,12 +220,16 @@ impl RouteRegistry {
         });
         r.register(ProviderRoute {
             provider_id: "claude".to_string(),
+            // S7: the Claude route is now HTTP-backed (the `friday-anthropic`
+            // /v1/messages client), not CLI. It stays `available: false` (DARK /
+            // default-off): the operator pre-wires the live client behind the
+            // `FRIDAY_CLAUDE_ROUTE_ENABLED` gate, but the route is not yet selectable.
             api: ProviderApi::AnthropicMessages,
-            backend_kind: BackendKind::Cli,
-            model: "claude-opus-4".to_string(),
+            backend_kind: BackendKind::Http,
+            model: "claude-opus-4-8".to_string(),
             model_size: ModelSize::Large,
             capabilities: text_files,
-            available: false, // CLI auth-gated in this build
+            available: false, // DARK: not selectable until an operator enables S7 live
             validation_ok: false,
             priority: 3,
         });

--- a/rust-core/crates/friday-hub/src/runtime.rs
+++ b/rust-core/crates/friday-hub/src/runtime.rs
@@ -128,6 +128,11 @@ pub struct HubConfig {
 #[derive(Debug)]
 pub enum HubInitError {
     DeepSeek(DeepSeekError),
+    /// S7 — the DARK Claude route gate was ON but its client could not be built
+    /// (`FRIDAY_ANTHROPIC_API_KEY` missing/empty, etc.). A CLEAR failure: when the
+    /// operator explicitly enables the gate, a missing credential is a hard error, not a
+    /// silent degrade. With the gate OFF (the default) this is never reached.
+    Claude(friday_anthropic::ClaudeError),
     Storage(StorageError),
     /// S6d: an operator verify key SOURCE was configured (the env path is set) but could
     /// not be read/parsed. A CLEAR failure — a broken provisioning never silently degrades
@@ -141,6 +146,9 @@ impl std::fmt::Display for HubInitError {
         match self {
             // DeepSeekError's Debug carries no key (verified in friday-deepseek); never prints the secret.
             HubInitError::DeepSeek(e) => write!(f, "deepseek init failed: {e:?}"),
+            // ClaudeError's Debug carries no key (status code / kind only; verified by the
+            // friday-anthropic leak-lens tests); never prints the secret.
+            HubInitError::Claude(e) => write!(f, "claude init failed: {e:?}"),
             HubInitError::Storage(e) => write!(f, "storage init failed: {e}"),
             HubInitError::OperatorVk(e) => {
                 write!(f, "operator verify key provisioning failed: {e:?}")
@@ -157,6 +165,13 @@ pub struct HubRuntime<T: Transport> {
     db: Db,
     routes: RouteRegistry,
     deepseek: DeepSeekAgentLlmClient<T>,
+    /// S7 — DARK / default-off Claude/Anthropic route client. `None` in every build
+    /// EXCEPT a `live()` build whose `FRIDAY_CLAUDE_ROUTE_ENABLED` gate is on. It is a
+    /// boxed `dyn AgentLlmClient` (NOT generic over `T`, which is the *DeepSeek*
+    /// transport — Claude has its own). Default-off is enforced at two layers: this
+    /// field stays `None`, AND the `claude` route is registered `available: false` so
+    /// `select_route` never picks it. The DeepSeek path is unchanged.
+    claude: Option<Box<dyn AgentLlmClient>>,
     executor: FsToolExecutor,
     /// S6d: the operator's PUBLIC verify key (provisioned from an operator-controlled
     /// source). `None` ⇒ fail-closed (protected actions Pause, never Allow). The Hub holds
@@ -188,12 +203,26 @@ impl<T: Transport> HubRuntime<T> {
             db,
             routes,
             deepseek,
+            // S7: DARK — no Claude client by default. Only `live()` may populate this,
+            // and only when the default-OFF `FRIDAY_CLAUDE_ROUTE_ENABLED` gate is on
+            // (via [`Self::with_claude`]). Tests + the prod default leave it `None`.
+            claude: None,
             executor,
             operator_vk: config.operator_vk,
             approval,
             max_turns: config.max_turns,
             policy,
         })
+    }
+
+    /// S7 — attach the DARK Claude route client (builder, default-off). This is the
+    /// ONLY way the `claude` field becomes `Some`. It does NOT touch the DeepSeek path,
+    /// the route registry, or any default; selecting Claude still additionally requires
+    /// a dispatchable `claude` route (the autonomous baseline marks it `available: false`).
+    /// Consumes + returns `self` so `live()` can chain it behind the env gate.
+    pub fn with_claude(mut self, claude: Box<dyn AgentLlmClient>) -> Self {
+        self.claude = Some(claude);
+        self
     }
 
     /// The route registry reflecting THIS build's ACTUAL dispatch capability: only the live
@@ -417,21 +446,61 @@ impl HubRuntime<UreqTransport> {
         }
         let client = DeepSeekClient::from_env().map_err(HubInitError::DeepSeek)?;
         let agent = DeepSeekAgentLlmClient::new(client);
-        Self::new(config, agent, Box::new(DenyAllApprovals)).map_err(HubInitError::Storage)
+        let runtime =
+            Self::new(config, agent, Box::new(DenyAllApprovals)).map_err(HubInitError::Storage)?;
+        // S7 — DARK Claude route: wire the second-provider client ONLY when the
+        // operator explicitly opts in via the default-OFF env gate. Absent/empty/any
+        // non-`"1"` value ⇒ the gate is OFF and the Claude client is never constructed
+        // (so its `FRIDAY_ANTHROPIC_API_KEY` is never even read) — prod default behavior
+        // is UNCHANGED. Even when the gate is on, the `claude` route is still
+        // `available: false` in the autonomous baseline, so this only PRE-WIRES the
+        // client for a later live proof; it does not by itself make Claude selectable.
+        runtime.maybe_attach_claude_from_env()
+    }
+
+    /// S7 — read the default-OFF gate and, only when it is on, build the live Claude
+    /// client from its env key and attach it (DARK). Separated from `live()` so the
+    /// gate/credential logic is unit-testable. A missing/empty gate ⇒ OFF ⇒ unchanged.
+    fn maybe_attach_claude_from_env(self) -> Result<Self, HubInitError> {
+        if !claude_route_enabled_from_env() {
+            return Ok(self);
+        }
+        // Gate is ON: build the real Claude client (fails closed if the key is absent)
+        // and pin the route's model id.
+        let client = friday_anthropic::ClaudeClient::from_env().map_err(HubInitError::Claude)?;
+        let agent = crate::ClaudeAgentLlmClient::new(client, friday_anthropic::DEFAULT_MODEL);
+        Ok(self.with_claude(Box::new(agent)))
     }
 }
 
+/// S7 — the default-OFF environment gate that governs whether [`HubRuntime::live`]
+/// wires the DARK Claude route. ON only when `FRIDAY_CLAUDE_ROUTE_ENABLED` is exactly
+/// `"1"` (after trimming). UNSET / empty / `"0"` / any other value ⇒ OFF (unchanged
+/// prod default). Kept narrow + explicit so the dark path cannot be enabled by accident.
+pub const ENV_CLAUDE_ROUTE_ENABLED: &str = "FRIDAY_CLAUDE_ROUTE_ENABLED";
+
+fn claude_route_enabled_from_env() -> bool {
+    matches!(std::env::var(ENV_CLAUDE_ROUTE_ENABLED), Ok(v) if v.trim() == "1")
+}
+
 impl<T: Transport> ProviderClientResolver for HubRuntime<T> {
-    /// Only the live `deepseek` provider has a wired client in this build. Any other route
-    /// returns `None` → fail-closed `NoClientForProvider` (a defensive backstop; the route
-    /// registry already prevents selecting unavailable providers, so this never fires on
-    /// the happy path). Routing decides WHO answers; classification stays the trusted
-    /// chokepoint regardless — this resolver confers no classification authority.
+    /// The live `deepseek` provider always has a wired client. The `claude` provider has
+    /// one ONLY when the DARK route was enabled (`self.claude` is `Some` — see
+    /// [`HubRuntime::with_claude`] / [`HubRuntime::live`]'s `FRIDAY_CLAUDE_ROUTE_ENABLED`
+    /// gate); when disabled (the default) it returns `None`. Any other route returns
+    /// `None` → fail-closed `NoClientForProvider` (a defensive backstop; the route
+    /// registry already prevents selecting unavailable providers — `claude` is
+    /// `available: false` in the baseline — so this never fires on the happy path).
+    /// Routing decides WHO answers; classification stays the trusted chokepoint
+    /// regardless — this resolver confers no classification authority.
     fn resolve(&self, route: &ProviderRoute) -> Option<&dyn AgentLlmClient> {
-        if route.provider_id == "deepseek" {
-            Some(&self.deepseek)
-        } else {
-            None
+        match route.provider_id.as_str() {
+            "deepseek" => Some(&self.deepseek),
+            // DARK: `as_deref()` yields `None` whenever the Claude client was not wired
+            // (the default), so the default-off route fail-closes exactly like any
+            // other unwired provider.
+            "claude" => self.claude.as_deref(),
+            _ => None,
         }
     }
 }
@@ -568,6 +637,81 @@ mod tests {
         )
         .unwrap();
         (rt, ws, post_calls) // TempDir guard keeps the workspace alive; counter for the no-hidden test
+    }
+
+    // ---- S7: DARK Claude route default-off -----------------------------------
+
+    #[test]
+    fn claude_route_gate_is_off_by_default_and_on_only_for_exactly_1() {
+        // The default-off gate is the only thing that lets `live()` wire Claude.
+        // Verify the exact-`"1"` predicate WITHOUT mutating the process env: drive the
+        // matcher logic directly via the documented contract values.
+        let on = |v: &str| v.trim() == "1";
+        assert!(on("1"), "exactly \"1\" enables");
+        assert!(on(" 1 "), "trimmed \"1\" enables");
+        for off in ["", "0", "true", "yes", "01", "1 0", "enabled"] {
+            assert!(!on(off), "{off:?} must NOT enable the dark route");
+        }
+        // Sanity: the live env var is currently unset in the test process, so the real
+        // helper reports OFF — the prod default.
+        assert!(
+            !claude_route_enabled_from_env(),
+            "FRIDAY_CLAUDE_ROUTE_ENABLED must be unset/off in the test env"
+        );
+    }
+
+    #[test]
+    fn resolver_returns_none_for_claude_when_dark_some_when_wired() {
+        // Build a runtime with NO Claude client (the default). The baseline `claude`
+        // route must resolve to `None` (DARK fail-closed) while `deepseek` resolves to
+        // its live client and an unknown provider resolves to `None`.
+        let (rt, _ws, _c) = runtime_with(
+            "claude-dark",
+            &["{\"tool\":\"none\"}"],
+            Box::new(DenyAllApprovals),
+        );
+        let baseline = RouteRegistry::autonomous_baseline();
+        let claude_route = baseline
+            .get("claude")
+            .expect("baseline has a claude route")
+            .clone();
+        let deepseek_route = baseline
+            .get("deepseek")
+            .expect("baseline has deepseek")
+            .clone();
+
+        // DARK default: no Claude client wired ⇒ resolver yields None (fail-closed).
+        assert!(
+            rt.resolve(&claude_route).is_none(),
+            "claude must resolve to None by default (dark/off)"
+        );
+        // The baseline marks claude unavailable, so it is doubly fail-closed.
+        assert!(
+            !claude_route.is_dispatchable(),
+            "claude route stays available:false"
+        );
+        // DeepSeek path is unchanged — still resolves to a live client.
+        assert!(
+            rt.resolve(&deepseek_route).is_some(),
+            "deepseek path unchanged"
+        );
+
+        // Now wire the Claude client (what the gated `live()` path does). resolve("claude")
+        // becomes Some; deepseek is still Some; nothing else changes.
+        let wired = rt.with_claude(Box::new(crate::MockAgentLlmClient {
+            proposal: crate::RawToolCall {
+                action: "none".to_string(),
+                params: vec![],
+            },
+        }));
+        assert!(
+            wired.resolve(&claude_route).is_some(),
+            "claude resolves to the wired client once attached"
+        );
+        assert!(
+            wired.resolve(&deepseek_route).is_some(),
+            "deepseek still wired"
+        );
     }
 
     // ---- PROOF-MEMORY-001 recall→inject wiring -------------------------------


### PR DESCRIPTION
## S7 — Friday's second live LLM provider (Claude / Anthropic), DARK / default-off

Adds a new `friday-anthropic` crate mirroring the proven `friday-deepseek` crate, behind the **same `friday_hub::AgentLlmClient` seam**. This is a **DARK build**: prod default behavior is UNCHANGED and the DeepSeek path is untouched. The LIVE proof is a separate later step (no Claude credential is provisioned) — this PR BUILDS and mock/KAT-proves; no real network call is made.

### Dark / default-off (how it's enforced — two layers)
- `HubRuntime` gains a `claude: Option<Box<dyn AgentLlmClient>>` field, default `None`. The resolver routes `provider_id == "claude"` to it via `as_deref()` → `None` when unwired (fail-closed, same as any unwired provider).
- `HubRuntime::live` attaches the Claude client **only** behind the default-OFF env gate `FRIDAY_CLAUDE_ROUTE_ENABLED` (ON only when exactly `"1"`). Unset/empty/`"0"`/anything-else ⇒ OFF; the `FRIDAY_ANTHROPIC_API_KEY` is not even read.
- The autonomous-baseline `claude` route stays `available: false`, so `select_route` never picks it even if the client is wired. (Model id refreshed `claude-opus-4` → `claude-opus-4-8`; backend `Cli` → `Http`.)

### No-fallback contract
A route failure is a typed `ClaudeError` (`Auth` / `ProviderUnavailable` / `ClientError` / `BadResponse` / `CredentialMissing`) — never a silent substitute provider, local model, or canned answer. `from_env` FAILS CLOSED if `FRIDAY_ANTHROPIC_API_KEY` is absent/empty. Error partition mirrors DeepSeek (+ Anthropic's 529 overloaded → transient; 429 terminal, no backoff). Display/Debug are coarse and secret-free (status code / kind only — never the response body or `x-api-key`).

### Anthropic Messages API contract targeted
`POST /v1/messages` with `x-api-key` + `anthropic-version: 2023-06-01` + `content-type` headers; request `{model, max_tokens (REQUIRED), messages:[{role:"user",content}]}`; response parse concatenates every `content[]` block where `type=="text"`, maps `usage.input_tokens`/`output_tokens` (checked-add for the absent `total_tokens`), captures `stop_reason` + reported `model`. No streaming/thinking (kept simple). Default model `claude-opus-4-8`.

### Tested (PROVEN here — mock/KAT, no network)
- 16 unit/KAT in `friday-anthropic`: request shaping (golden request JSON), response parsing (golden response → text/usage/stop_reason; multi-text-block concat + non-text skip; empty array), error mapping (status partition 5xx/408/529 transient vs 4xx/429 terminal vs 401/403 auth; real-transport 429 + 529 + TCP-fail + malformed-JSON leak-lens — no body/key leak), `from_env` fail-closed.
- 2 hub dark tests: `resolver_returns_none_for_claude_when_dark_some_when_wired` (resolver `None` by default, `Some` after `with_claude`; DeepSeek path unchanged) and `claude_route_gate_is_off_by_default_and_on_only_for_exactly_1` (documents the gate contract + confirms OFF in the test env).
- `friday-arch-tests`: `friday-anthropic` added to the secret-bearing-out-of-FFI assertions + new `anthropic_does_not_depend_on_ffi_either`.
- Full suite green: friday-anthropic 16/0, friday-hub lib 432/0 (DeepSeek path unbroken), friday-arch-tests 4/0. `cargo build` (workspace), `cargo fmt --all --check`, and `cargo clippy --workspace --all-targets` all clean.

### DEFERRED (needs a Claude credential — pending operator)
- **Live round-trip proof** — `tests/live_round_trip.rs`, `#[ignore]`-d, BUILT but NOT RUN. Run later: `FRIDAY_ANTHROPIC_API_KEY=<key> cargo test -p friday-anthropic --test live_round_trip --ignored -- --nocapture` (spends Anthropic quota).
- **Parity proof** — `tests/parity_round_trip.rs`, `#[ignore]`-d, BUILT but NOT RUN. Run later: `FRIDAY_DEEPSEEK_API_KEY=<ds> FRIDAY_ANTHROPIC_API_KEY=<an> cargo test -p friday-anthropic --test parity_round_trip --ignored -- --nocapture` (spends quota on both). `friday-deepseek` is a **dev-dependency only** of this crate (invisible to the arch-test graph).
- **Retry classification** — `ClaudeError` maps into the existing string-bearing `AgentError::Model` (never retried) for this dark path; a future non-dark slice would add `AgentError::ClaudeRoute(ClaudeError)` + a classifier arm.
- **Ledger/metering** — adapter uses the trait DEFAULT (no usage ⇒ no ledger row). Reusing DeepSeek's `MeteredStep`/`LedgerEntry::friday_route` would mis-attribute a Claude call as `ProviderKind::DeepSeek`; a proper Claude ledger needs `ProviderKind::Anthropic` + a `MeteredStep` generalization.

### Files touched
**Added:** `rust-core/crates/friday-anthropic/{Cargo.toml, src/lib.rs, tests/live_round_trip.rs, tests/parity_round_trip.rs}`
**Changed:** `rust-core/Cargo.toml` + `Cargo.lock` (workspace member + dep), `rust-core/crates/friday-hub/Cargo.toml` (dep), `rust-core/crates/friday-hub/src/lib.rs` (`ClaudeAgentLlmClient` adapter), `rust-core/crates/friday-hub/src/runtime.rs` (`claude` field + `with_claude` + resolver + `live()` env gate + `HubInitError::Claude` + dark tests), `rust-core/crates/friday-hub/src/routing.rs` (claude route → Http/`claude-opus-4-8`, still `available:false`), `rust-core/crates/friday-arch-tests/tests/dep_boundary.rs` (secret-boundary assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)