### PR TITLE
fix(ts-retirement): TS-R4/G1 — method-guard friday-auto-fix-execution-service.execute() (close LIVE autofix auto-remediation bypass)

### DIFF
--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -4062,6 +4062,13 @@ export async function createFridayHub(
     // Lets the auto-fix planner capture the prior skill status at plan-build time for the
     // regenerate_skill rollback (restore-not-enable).
     getSkillLifecycleStatus: getPersistedSkillLifecycleStatus,
+    // TS Runtime Retirement (G1): forwards the same test-oracle flag the autofix
+    // ROUTE uses (config.allowTestOnlyAutoFixExecution) into the execution
+    // service's METHOD-level guard, so the live non-route self-healing path
+    // (reportStructuredFailure → agent-loop executeRun → execute()) fails closed
+    // in default/live runtime and stays exercised under the test/mock/real-env
+    // harnesses that opt in.
+    allowTestOnlyAutoFixExecution: config.allowTestOnlyAutoFixExecution,
   });
 
   // P1-01: Assign immediately so learningContextBuilder and communicationPromptBuilder

--- a/src/learning/runtime/friday-self-learning-runtime.ts
+++ b/src/learning/runtime/friday-self-learning-runtime.ts
@@ -136,6 +136,10 @@ export function createFridaySelfLearningRuntime(
     nowIso: deps.nowIso,
     stepExecutors: deps.stepExecutors,
     stepVerifiers: deps.stepVerifiers,
+    // TS Runtime Retirement (G1): method-level fail-closed guard on execute().
+    // Default/live runtime leaves this unset (fail closed); test/mock/real-env
+    // harnesses opt in via hub-config.
+    allowTestOnlyAutoFixExecution: deps.allowTestOnlyAutoFixExecution,
   });
 
   const approvals = createFridayApprovalWorkflowService({

--- a/src/learning/runtime/friday-self-learning-runtime.types.ts
+++ b/src/learning/runtime/friday-self-learning-runtime.types.ts
@@ -52,4 +52,12 @@ export interface CreateFridaySelfLearningRuntimeDeps {
    * to the durable skills store; optional elsewhere.
    */
   getSkillLifecycleStatus?: (skillId: string) => SkillLifecycleStatus | undefined;
+  /**
+   * Test-oracle only: forwarded to the auto-fix execution service so its
+   * METHOD-level retirement guard (`execute()`) is satisfied. Default/live
+   * runtime must leave this unset so auto-fix execution fails closed for all
+   * non-route callers (agent-loop self-healing, dispatcher, approval-workflow).
+   * Mirrors the route-layer `allowTestOnlyAutoFixExecution` flag.
+   */
+  allowTestOnlyAutoFixExecution?: boolean;
 }

--- a/src/learning/services/friday-agent-loop-service.ts
+++ b/src/learning/services/friday-agent-loop-service.ts
@@ -657,6 +657,31 @@ export function createFridayAgentLoopService(
     return nextDetails;
   };
 
+  // TS Runtime Retirement (G1): the loop run is persisted as `running` BEFORE
+  // `executionService.execute()` is called. With the new method-level
+  // retirement guard on `execute()`, a fail-closed 503 throw would otherwise
+  // orphan the run deterministically at `running`. Mirror #628's standing-agenda
+  // terminal-state treatment: reset the run to a terminal `failed` state and let
+  // the caller re-throw so retirement semantics are not swallowed. Any other
+  // execution throw is finalized the same way (it was previously unhandled).
+  const finalizeRunOnExecutionThrow = async (
+    run: FridayAgentLoopRunEntity,
+    error: unknown,
+  ): Promise<void> => {
+    const message = error instanceof FridayDomainError
+      ? error.message
+      : error instanceof Error
+        ? error.message
+        : String(error);
+    const failed = updateRun(run.loopRunId, {
+      status: "failed",
+      haltReason: "execution_failed",
+      lastError: message,
+      completedAt: deps.nowIso(),
+    });
+    await emitLoopEvent("agent-loop.run.failed", failed, buildRunDetails(failed));
+  };
+
   const executeRun = async (
     run: FridayAgentLoopRunEntity,
     trigger: FridayAgentLoopTrigger,
@@ -701,9 +726,19 @@ export function createFridayAgentLoopService(
         await emitLoopEvent("agent-loop.run.awaiting-approval", pending, details);
         return details;
       }
-      result = await deps.dispatcher.runApprovedAction(actionDetails.action.actionId);
+      try {
+        result = await deps.dispatcher.runApprovedAction(actionDetails.action.actionId);
+      } catch (error) {
+        await finalizeRunOnExecutionThrow(executing, error);
+        throw error;
+      }
     } else {
-      result = await deps.executionService.execute(actionDetails.action.actionId);
+      try {
+        result = await deps.executionService.execute(actionDetails.action.actionId);
+      } catch (error) {
+        await finalizeRunOnExecutionThrow(executing, error);
+        throw error;
+      }
     }
 
     return finalizeExecution({

--- a/src/learning/services/friday-auto-fix-execution-service.ts
+++ b/src/learning/services/friday-auto-fix-execution-service.ts
@@ -51,6 +51,18 @@ export interface CreateAutoFixExecutionServiceDeps {
   stepExecutors?: Partial<Record<FridayAutoFixStepKind, StepExecutor>>;
   /** Override verifiers per step kind for production use. */
   stepVerifiers?: Partial<Record<FridayAutoFixStepKind, StepVerifier>>;
+  /**
+   * Test-oracle only: allows the legacy TypeScript auto-fix self-healing
+   * EXECUTOR (`execute`) to run reversible remediation mutations in isolated
+   * test/validation harnesses. Default/live runtime must leave this unset so
+   * `execute()` fails closed for ALL callers — including the live agent-loop
+   * self-healing path (`reportStructuredFailure` → agent-loop `executeRun` →
+   * `executionService.execute()`), the dispatcher, and the approval-workflow —
+   * which bypass the HTTP route guard in `friday-auto-fix-routes.ts`. This
+   * mirrors the route-layer `allowTestOnlyAutoFixExecution` flag exactly; never
+   * default it on in production.
+   */
+  allowTestOnlyAutoFixExecution?: boolean;
 }
 
 /**
@@ -143,6 +155,40 @@ export function createFridayAutoFixExecutionService(
 ): FridayAutoFixExecutionService {
   const executors: Partial<Record<FridayAutoFixStepKind, StepExecutor>> = { ...DEFAULT_EXECUTORS, ...deps.stepExecutors };
   const verifiers = { ...DEFAULT_VERIFIERS, ...deps.stepVerifiers };
+
+  // ─── TS Runtime Retirement: METHOD-level fail-closed guard (HIDDEN-GAP G1) ───
+  // The autofix-execution route surface (`autofix.actions.execute`/`run.ready`/
+  // `rollback`) is advertised retired and is guarded at the HTTP route layer
+  // (`friday-auto-fix-routes.ts`, `allowTestOnlyAutoFixExecution`). But a
+  // NON-route caller still reaches the mutating executor: the live self-healing
+  // loop `selfHealing.reportStructuredFailure` (workflow deploy-catch +
+  // hub-bootstrap workflow-failure hook) → rule-based planner → agent-loop
+  // `executeRun` → `executionService.execute()`. The dispatcher and the
+  // approval-workflow service also call `execute()` directly. Default autofix
+  // policy is permissive (`autoApplyLowRisk:true`, `paused:false`), so this path
+  // is firing-capable on a default prod hub today (bounded to tier<2 reversible
+  // actions). Guarding here fails ALL callers closed BEFORE any state read/write,
+  // executor side effect, rollback, or lesson-extraction provider call — unless
+  // the explicit test-oracle flag is set. `run.ready` funnels per-action through
+  // this same `execute()`, and the standalone `rollback` route op
+  // (`rollbackService.rollback`) has no non-route caller (it is reached only via
+  // the already-route-guarded `rollbackAction` and internally from this now-
+  // guarded `execute()`), so this single guard closes the whole G1 surface.
+  function assertAutoFixExecutionAllowed(): void {
+    if (deps.allowTestOnlyAutoFixExecution !== true) {
+      throw new FridayDomainError(
+        "TS_RUNTIME_AUTOFIX_EXECUTION_RETIRED",
+        "TypeScript auto-fix execution is fail-closed in default/live runtime; use the Rust-owned auto-fix execution entrypoint.",
+        {
+          httpStatus: 503,
+          details: {
+            classification: "fail_closed",
+            replacement: "rust_owned_autofix_execution_entrypoint_required",
+          },
+        },
+      );
+    }
+  }
 
   function persistPlanEvidence(
     actionId: UUID,
@@ -266,6 +312,10 @@ export function createFridayAutoFixExecutionService(
 
   return {
     async execute(actionId) {
+      // Fail closed for ALL callers (route + non-route) before any state read,
+      // executor side effect, rollback, or provider call.
+      assertAutoFixExecutionAllowed();
+
       const nowIso = deps.nowIso();
 
       const action = deps.db.withReadConnection((db) =>

--- a/test/e2e/api/_helpers/friday-api-test-server.helper.ts
+++ b/test/e2e/api/_helpers/friday-api-test-server.helper.ts
@@ -236,6 +236,9 @@ export async function createFridayApiTestEnv(
       db,
       idGenerator,
       nowIso: () => NOW,
+      // TS Runtime Retirement (G1): opt in so the route-backed executeAction /
+      // run-ready / dispatcher paths reach the now-method-guarded execute().
+      allowTestOnlyAutoFixExecution: options.allowTestOnlyAutoFixExecution ?? true,
     })
     : undefined;
   const selfHealingService = selfLearningRuntime

--- a/test/e2e/api/friday-api-auto-fix-doctor.acceptance.test.ts
+++ b/test/e2e/api/friday-api-auto-fix-doctor.acceptance.test.ts
@@ -213,6 +213,9 @@ function buildAcceptanceSelfHealingApiService(
     nowIso: () => NOW,
     stepExecutors: support.stepExecutors,
     stepVerifiers: support.stepVerifiers,
+    // TS Runtime Retirement (G1): opt in so the route-backed executeAction /
+    // rollbackAction paths reach the now-method-guarded execute().
+    allowTestOnlyAutoFixExecution: true,
   });
   return createFridaySelfHealingApiService({
     db,
@@ -257,6 +260,8 @@ describe("Phase 14.5B module_28b: one-click repair / recovery doctor acceptance"
       nowIso: () => NOW,
     });
     const executionService = createFridayAutoFixExecutionService({
+      // TS Runtime Retirement (G1): opt in to the test-oracle so execute() runs.
+      allowTestOnlyAutoFixExecution: true,
       db,
       actionRepo,
       incidentRepo,
@@ -312,6 +317,8 @@ describe("Phase 14.5B module_28b: one-click repair / recovery doctor acceptance"
       nowIso: () => NOW,
     });
     const executionService = createFridayAutoFixExecutionService({
+      // TS Runtime Retirement (G1): opt in to the test-oracle so execute() runs.
+      allowTestOnlyAutoFixExecution: true,
       db,
       actionRepo,
       incidentRepo,

--- a/test/e2e/live/_helpers/real-env.ts
+++ b/test/e2e/live/_helpers/real-env.ts
@@ -339,6 +339,7 @@ async function startLocalRealHubEnv(
       allowTestOnlyWorkflowGeneratorExecution: true,
       allowTestOnlyWorkflowDeployExecution: true,
       allowTestOnlySystemIntentExecution: true,
+      allowTestOnlyAutoFixExecution: true,
       ...opts?.hubConfig,
     });
     await createdHub.start();

--- a/test/e2e/mock/_helpers/mock-env.ts
+++ b/test/e2e/mock/_helpers/mock-env.ts
@@ -373,6 +373,8 @@ export async function createMockHubEnv(opts?: {
   allowTestOnlyCapabilityAcquisitionExecution?: boolean;
   /** Test-oracle opt-in for the legacy TS system-service `executeIntent` method; set false to prove default fail-closed behavior. */
   allowTestOnlySystemIntentExecution?: boolean;
+  /** Test-oracle opt-in for the legacy TS auto-fix executor `execute()` method (route + non-route self-healing path); set false to prove default fail-closed behavior. */
+  allowTestOnlyAutoFixExecution?: boolean;
   /**
    * execrun-replacement slice 4 (DARK): per-run Rust-route flag. DEFAULT-FALSE here (honest
    * dark) — the predicate is unconsumed this slice so the value is cosmetic; the ui browser
@@ -444,6 +446,7 @@ export async function createMockHubEnv(opts?: {
       allowTestOnlyProviderRoutingControlsExecution: opts?.allowTestOnlyProviderRoutingControlsExecution ?? true,
       allowTestOnlyCapabilityAcquisitionExecution: opts?.allowTestOnlyCapabilityAcquisitionExecution ?? true,
       allowTestOnlySystemIntentExecution: opts?.allowTestOnlySystemIntentExecution ?? true,
+      allowTestOnlyAutoFixExecution: opts?.allowTestOnlyAutoFixExecution ?? true,
       // execrun-replacement slice 4 (DARK): default-FALSE (honest dark), unlike the
       // allowTestOnly* flags which default true. The predicate is unconsumed this slice.
       routeAgentRunViaRust: opts?.routeAgentRunViaRust ?? false,

--- a/test/unit/learning/runtime/friday-self-learning-runtime.test.ts
+++ b/test/unit/learning/runtime/friday-self-learning-runtime.test.ts
@@ -279,6 +279,8 @@ describe("FridaySelfLearningRuntime", () => {
       db,
       idGenerator: idGen,
       nowIso: () => NOW,
+      // TS Runtime Retirement (G1): opt in so autoFixExecution.execute() runs.
+      allowTestOnlyAutoFixExecution: true,
       stepExecutors: {
         retry_node: async (step) => {
           retryExecutorCalled.push(step.stepId);

--- a/test/unit/learning/services/friday-agent-loop-service.test.ts
+++ b/test/unit/learning/services/friday-agent-loop-service.test.ts
@@ -4,6 +4,7 @@ import {
   createFridayAgentLoopRepository,
   createFridayAgentLoopService,
 } from "#learning";
+import { FridayDomainError } from "#errors";
 import type { FridaySqliteLayer } from "#state";
 import { createTestDb } from "../../../helpers/friday-test-db.helper.js";
 
@@ -386,5 +387,67 @@ describe("createFridayAgentLoopService", () => {
     const policy = service.getPolicy();
     expect(policy.expertModeEnabled).toBe(false);
     expect(policy.probeBudget).toBe(4);
+  });
+
+  // TS Runtime Retirement (G1): when execute() fail-closes (503 retirement
+  // guard) on the live self-healing path, the loop run — persisted as 'running'
+  // before the call — must be finalized to a terminal 'failed' state, not
+  // orphaned at 'running', and the throw must propagate (semantics not
+  // swallowed) so the caller's `void ...catch()` logs it.
+  it("finalizes the loop run to 'failed' (not orphaned 'running') and re-throws when execute() fail-closes", async () => {
+    const details = buildIncidentDetails({ riskTier: 0 });
+    db = createTestDb();
+    const loopRepo = createFridayAgentLoopRepository();
+    const retirementError = new FridayDomainError(
+      "TS_RUNTIME_AUTOFIX_EXECUTION_RETIRED",
+      "fail closed",
+      { httpStatus: 503, details: { classification: "fail_closed" } },
+    );
+    const service = createFridayAgentLoopService({
+      db,
+      idGenerator: (() => {
+        let counter = 0;
+        return () => `loop-id-${++counter}`;
+      })(),
+      nowIso: () => NOW,
+      loopRepo,
+      incidentRepo: {} as never,
+      diagnosisRepo: {} as never,
+      actionRepo: {} as never,
+      lessonRepo: {} as never,
+      approvalService: { reject: vi.fn(async () => undefined) } as never,
+      executionService: {
+        execute: vi.fn(async () => {
+          throw retirementError;
+        }),
+      } as never,
+      dispatcher: { runApprovedAction: vi.fn() } as never,
+      selfHealing: {
+        getIncident: vi.fn(({ incidentId }: { incidentId: string }) =>
+          incidentId === details.incident.incidentId ? details : null),
+        getAction: vi.fn(({ actionId }: { actionId: string }) =>
+          actionId === details.action.action.actionId ? details.action : null),
+      } as never,
+      observability: { recordAgentLoopEvent: vi.fn(async () => undefined) } as never,
+      publishEvent: { publish: vi.fn() },
+    });
+
+    await expect(
+      service.handleProcessResults({
+        results: [{
+          incidentsCreated: [{ incidentId: "incident-1" } as never],
+          diagnosisCreated: [],
+        }],
+        correlationId: "corr-retire",
+      }),
+    ).rejects.toMatchObject({ code: "TS_RUNTIME_AUTOFIX_EXECUTION_RETIRED" });
+
+    const runs = db.withReadConnection((reader) =>
+      loopRepo.listRuns(reader, { userId: "user-1" }));
+    expect(runs.length).toBe(1);
+    expect(runs[0]?.status).toBe("failed");
+    expect(runs[0]?.haltReason).toBe("execution_failed");
+    expect(runs[0]?.completedAt).toBeTruthy();
+    expect(runs[0]?.lastError).toContain("fail closed");
   });
 });

--- a/test/unit/learning/services/friday-auto-fix-dispatcher-service.test.ts
+++ b/test/unit/learning/services/friday-auto-fix-dispatcher-service.test.ts
@@ -120,6 +120,8 @@ describe("FridayAutoFixDispatcherService", () => {
     });
 
     const executionService = createFridayAutoFixExecutionService({
+      // TS Runtime Retirement (G1): opt in to the test-oracle so execute() runs.
+      allowTestOnlyAutoFixExecution: true,
       db,
       actionRepo,
       incidentRepo,

--- a/test/unit/learning/services/friday-auto-fix-execution-retirement-guard.test.ts
+++ b/test/unit/learning/services/friday-auto-fix-execution-retirement-guard.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { FridaySqliteLayer } from "#state";
+import { FridayDomainError } from "#errors";
+import {
+  createFridayAutoFixExecutionService,
+  createFridayAutoFixRollbackService,
+  createFridayAutoFixActionRepository,
+  createFridayErrorIncidentRepository,
+  createFridayDiagnosisRecordRepository,
+} from "#learning";
+import type {
+  FridayAutoFixActionEntity,
+  FridayAutoFixActionRepository,
+  FridayAutoFixExecutionService,
+  FridayAutoFixPlan,
+  StepExecutor,
+} from "#learning";
+import { createTestDb } from "../../satellites/_helpers/create-test-db.helper.js";
+
+/**
+ * TS Runtime Retirement — METHOD-level guard for the auto-fix EXECUTOR (G1).
+ *
+ * The autofix-execution route surface (`autofix.actions.execute`/`run.ready`/
+ * `rollback`) is advertised retired and was guarded at the HTTP route layer
+ * (`friday-auto-fix-routes.ts`, `allowTestOnlyAutoFixExecution`). But the live
+ * self-healing loop reaches the mutating executor OFF-route:
+ * `selfHealing.reportStructuredFailure` (workflow deploy-catch + hub-bootstrap
+ * workflow-failure hook) → rule-based planner → agent-loop `executeRun` →
+ * `executionService.execute()`. The dispatcher and approval-workflow also call
+ * `execute()` directly. Default autofix policy is permissive
+ * (`autoApplyLowRisk:true`, `paused:false`), so this path was firing-capable on
+ * a default prod hub today (bounded to tier<2 reversible actions).
+ *
+ * These tests prove the guard now lives on the METHOD: in default/live config
+ * (test-oracle flag unset) `execute()` fails closed BEFORE any state read,
+ * executor side effect, rollback, or lesson-extraction provider call. With the
+ * explicit test-oracle flag enabled the legacy path still works.
+ */
+
+const RETIRED_CODE = "TS_RUNTIME_AUTOFIX_EXECUTION_RETIRED";
+const NOW = "2026-06-10T00:00:00.000Z";
+
+describe("FridayAutoFixExecutionService TS-retirement method guard", () => {
+  let db: FridaySqliteLayer;
+  let actionRepo: FridayAutoFixActionRepository;
+  let executorCalls: string[];
+
+  const plan: FridayAutoFixPlan = {
+    title: "Auto-fix: retry node",
+    summary: "Retry the failed operation",
+    steps: [
+      {
+        stepId: "step-001",
+        kind: "retry_node",
+        target: "tool",
+        payload: {},
+        verify: { method: "error_absent", timeoutMs: 5000 },
+      },
+    ],
+    evidence: {
+      fingerprint: "sig-guard",
+      matchedLessonIds: [],
+      diagnosisId: "diag-guard",
+      recurrenceCount: 1,
+    },
+  };
+
+  // Booby-trapped executor: if the guard ever lets execution proceed while the
+  // flag is unset, this records the call so the side-effect assertion fails.
+  const boobyTrappedExecutor: StepExecutor = (step) => {
+    executorCalls.push(step.stepId);
+    const payload = step.payload as Record<string, unknown> | null;
+    if (payload && typeof payload === "object") {
+      payload._retryRequested = true;
+    }
+    return true;
+  };
+
+  beforeEach(() => {
+    db = createTestDb();
+    executorCalls = [];
+
+    const incidentRepo = createFridayErrorIncidentRepository();
+    incidentRepo.insert(db.writer, {
+      incidentId: "inc-guard",
+      userId: "test-user",
+      ts: NOW,
+      category: "tool",
+      severity: "medium",
+      signature: "sig-guard",
+      context: {},
+      autoFixEligible: true,
+      status: "open",
+      createdAt: NOW,
+      updatedAt: NOW,
+    });
+
+    const diagnosisRepo = createFridayDiagnosisRecordRepository();
+    diagnosisRepo.insert(db.writer, {
+      id: "diag-guard",
+      incidentId: "inc-guard",
+      errorFingerprint: "sig-guard",
+      confidence: 0.8,
+      diagnosis: { summary: "test" },
+      createdAt: NOW,
+      updatedAt: NOW,
+    });
+
+    actionRepo = createFridayAutoFixActionRepository();
+    const action: FridayAutoFixActionEntity = {
+      actionId: "action-guard",
+      incidentId: "inc-guard",
+      userId: "test-user",
+      riskTier: 0,
+      plan,
+      status: "planned",
+      outcome: null,
+      createdAt: NOW,
+      updatedAt: NOW,
+    };
+    actionRepo.insert(db.writer, action);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  function buildService(allowTestOnlyAutoFixExecution?: boolean): FridayAutoFixExecutionService {
+    const incidentRepo = createFridayErrorIncidentRepository();
+    const diagnosisRepo = createFridayDiagnosisRecordRepository();
+    const rollbackService = createFridayAutoFixRollbackService({
+      db,
+      actionRepo,
+      nowIso: () => NOW,
+      stepExecutors: { retry_node: boobyTrappedExecutor },
+    });
+    return createFridayAutoFixExecutionService({
+      db,
+      actionRepo,
+      incidentRepo,
+      diagnosisRepo,
+      rollbackService,
+      nowIso: () => NOW,
+      stepExecutors: { retry_node: boobyTrappedExecutor },
+      ...(allowTestOnlyAutoFixExecution === undefined
+        ? {}
+        : { allowTestOnlyAutoFixExecution }),
+    });
+  }
+
+  function actionStatus(): string | undefined {
+    return db.withReadConnection((reader) =>
+      actionRepo.getById(reader, "action-guard")?.status);
+  }
+
+  it("execute() fails closed by default: throws 503 fail_closed and runs no executor / mutates nothing", async () => {
+    const service = buildService();
+
+    let caught: unknown;
+    try {
+      await service.execute("action-guard");
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(FridayDomainError);
+    const domainError = caught as FridayDomainError;
+    expect(domainError.code).toBe(RETIRED_CODE);
+    expect(domainError.httpStatus).toBe(503);
+    expect(domainError.details?.classification).toBe("fail_closed");
+
+    // Zero side effects: no executor call, action still 'planned'.
+    expect(executorCalls).toEqual([]);
+    expect(actionStatus()).toBe("planned");
+  });
+
+  it("execute() fails closed with the flag explicitly false (same zero side effects)", async () => {
+    const service = buildService(false);
+
+    await expect(service.execute("action-guard")).rejects.toMatchObject({
+      code: RETIRED_CODE,
+      httpStatus: 503,
+    });
+    expect(executorCalls).toEqual([]);
+    expect(actionStatus()).toBe("planned");
+  });
+
+  it("execute() runs the legacy path when the test-oracle flag is exactly true", async () => {
+    const service = buildService(true);
+
+    const result = await service.execute("action-guard");
+
+    expect(result.success).toBe(true);
+    expect(result.verificationPassed).toBe(true);
+    expect(executorCalls).toEqual(["step-001"]);
+    expect(actionStatus()).toBe("applied");
+  });
+
+  it("guard fires before the action read: a non-existent actionId still throws the retirement 503, not NOT_FOUND", async () => {
+    const service = buildService();
+
+    await expect(service.execute("does-not-exist")).rejects.toMatchObject({
+      code: RETIRED_CODE,
+    });
+  });
+});

--- a/test/unit/learning/services/friday-auto-fix-execution-service.test.ts
+++ b/test/unit/learning/services/friday-auto-fix-execution-service.test.ts
@@ -123,6 +123,8 @@ describe("FridayAutoFixExecutionService", () => {
       nowIso: () => NOW,
     });
     service = createFridayAutoFixExecutionService({
+      // TS Runtime Retirement (G1): opt in to the test-oracle so execute() runs.
+      allowTestOnlyAutoFixExecution: true,
       db,
       actionRepo,
       incidentRepo,
@@ -312,6 +314,8 @@ describe("FridayAutoFixExecutionService", () => {
     });
 
     const executionService = createFridayAutoFixExecutionService({
+      // TS Runtime Retirement (G1): opt in to the test-oracle so execute() runs.
+      allowTestOnlyAutoFixExecution: true,
       db,
       actionRepo,
       incidentRepo,
@@ -410,6 +414,8 @@ describe("FridayAutoFixExecutionService", () => {
       updatedAt: NOW,
     });
     const executionService = createFridayAutoFixExecutionService({
+      // TS Runtime Retirement (G1): opt in to the test-oracle so execute() runs.
+      allowTestOnlyAutoFixExecution: true,
       db,
       actionRepo,
       incidentRepo,
@@ -504,6 +510,8 @@ describe("FridayAutoFixExecutionService", () => {
     // must refuse this payload so the action cannot finalize as a verified
     // repair.
     const executionService = createFridayAutoFixExecutionService({
+      // TS Runtime Retirement (G1): opt in to the test-oracle so execute() runs.
+      allowTestOnlyAutoFixExecution: true,
       db,
       actionRepo,
       incidentRepo,
@@ -574,6 +582,8 @@ describe("FridayAutoFixExecutionService", () => {
     const executed: string[] = [];
     const verified: string[] = [];
     const overrideService = createFridayAutoFixExecutionService({
+      // TS Runtime Retirement (G1): opt in to the test-oracle so execute() runs.
+      allowTestOnlyAutoFixExecution: true,
       db,
       actionRepo,
       incidentRepo: createFridayErrorIncidentRepository(),
@@ -607,6 +617,8 @@ describe("FridayAutoFixExecutionService", () => {
 
   it("fails closed when an injected executor rejects a step kind", async () => {
     const failClosedService = createFridayAutoFixExecutionService({
+      // TS Runtime Retirement (G1): opt in to the test-oracle so execute() runs.
+      allowTestOnlyAutoFixExecution: true,
       db,
       actionRepo: createFridayAutoFixActionRepository(),
       incidentRepo: createFridayErrorIncidentRepository(),
@@ -664,6 +676,8 @@ describe("FridayAutoFixExecutionService", () => {
     const incidentRepo = createFridayErrorIncidentRepository();
     const diagnosisRepo = createFridayDiagnosisRecordRepository();
     const lessonAwareService = createFridayAutoFixExecutionService({
+      // TS Runtime Retirement (G1): opt in to the test-oracle so execute() runs.
+      allowTestOnlyAutoFixExecution: true,
       db,
       actionRepo,
       incidentRepo,
@@ -882,6 +896,8 @@ describe("FridayAutoFixExecutionService", () => {
 
       // Create service with a verifier that FAILS for apply_config_patch
       const failService = createFridayAutoFixExecutionService({
+      // TS Runtime Retirement (G1): opt in to the test-oracle so execute() runs.
+      allowTestOnlyAutoFixExecution: true,
         db,
         actionRepo,
         incidentRepo,
@@ -995,6 +1011,8 @@ describe("FridayAutoFixExecutionService", () => {
       };
 
       const executionService = createFridayAutoFixExecutionService({
+      // TS Runtime Retirement (G1): opt in to the test-oracle so execute() runs.
+      allowTestOnlyAutoFixExecution: true,
         db,
         actionRepo,
         incidentRepo,
@@ -1092,6 +1110,8 @@ describe("FridayAutoFixExecutionService", () => {
 
       // Create service with a verifier that FAILS for retry_node
       const failService = createFridayAutoFixExecutionService({
+      // TS Runtime Retirement (G1): opt in to the test-oracle so execute() runs.
+      allowTestOnlyAutoFixExecution: true,
         db,
         actionRepo,
         incidentRepo,
@@ -1225,6 +1245,8 @@ describe("FridayAutoFixExecutionService", () => {
       };
 
       const executionService = createFridayAutoFixExecutionService({
+      // TS Runtime Retirement (G1): opt in to the test-oracle so execute() runs.
+      allowTestOnlyAutoFixExecution: true,
         db,
         actionRepo,
         incidentRepo,
@@ -1354,6 +1376,8 @@ describe("FridayAutoFixExecutionService", () => {
       };
 
       const executionService = createFridayAutoFixExecutionService({
+      // TS Runtime Retirement (G1): opt in to the test-oracle so execute() runs.
+      allowTestOnlyAutoFixExecution: true,
         db,
         actionRepo,
         incidentRepo,
@@ -1463,6 +1487,8 @@ describe("FridayAutoFixExecutionService", () => {
       });
 
       const executionService = createFridayAutoFixExecutionService({
+      // TS Runtime Retirement (G1): opt in to the test-oracle so execute() runs.
+      allowTestOnlyAutoFixExecution: true,
         db,
         actionRepo,
         incidentRepo,

--- a/test/unit/learning/services/friday-self-learning-pipeline-service.test.ts
+++ b/test/unit/learning/services/friday-self-learning-pipeline-service.test.ts
@@ -801,6 +801,8 @@ describe("Approval → execution linkage", () => {
     });
 
     const executionService = createFridayAutoFixExecutionService({
+      // TS Runtime Retirement (G1): opt in to the test-oracle so execute() runs.
+      allowTestOnlyAutoFixExecution: true,
       db,
       actionRepo,
       incidentRepo,
@@ -939,6 +941,8 @@ describe("Approval → execution linkage", () => {
     });
 
     const executionService = createFridayAutoFixExecutionService({
+      // TS Runtime Retirement (G1): opt in to the test-oracle so execute() runs.
+      allowTestOnlyAutoFixExecution: true,
       db,
       actionRepo,
       incidentRepo,


### PR DESCRIPTION
## QUEUED FOR OPERATOR — DO NOT MERGE

This changes a **live autonomous behavior** (it stops autofix auto-remediation in prod). The operator must consciously approve before merge.

## (a) This closes a LIVE gap

Highest-priority **HIDDEN-GAP (G1)** from the TS→Rust reconciliation roadmap (`TS_RECON_TRUTH_ROADMAP_20260610.md` §2). The autofix-execution route surface (`autofix.actions.execute` / `run.ready` / `rollback`) is advertised retired and is guarded at the **HTTP route layer** (`friday-auto-fix-routes.ts`, `allowTestOnlyAutoFixExecution`) — but a **non-route caller still reached the mutating executor**, so autofix self-healing was executing reversible mutations behind a retired label. There was **no method-level guard** on `friday-auto-fix-execution-service.execute()`.

## (b) The firing path (LIVE today)

```
workflow deploy-catch (workflow-product-service.ts:625)
  + hub-bootstrap workflow-failure hook (friday-hub-bootstrap.ts:1624)
    → selfHealing.reportStructuredFailure
      → rule-based planner attaches a low-risk action
        → agent-loop handleProcessResults → executeRun   ← the agent-LOOP executeRun, NOT the guarded agent-RUNTIME one
          → friday-auto-fix-execution-service.execute()
```

Default autofix policy is permissive (`autoApplyLowRisk:true`, `paused:false`), so the path is **firing-capable on a default prod hub today**, bounded to tier<2 reversible actions (`disable_skill`, `apply_config_patch`, `pause_workflow`) with rollback + acceptance. The **dispatcher** (`friday-auto-fix-dispatcher-service.ts:104,141`) and the **approval-workflow** service (`:140`) also call `execute()` directly. A single method-level guard closes **all** of these doors at once.

## (c) BEHAVIOR CHANGE — stops autofix auto-remediation in prod on next deploy

On next deploy this **stops autofix auto-remediation in production**. Concretely: `execute()` fails closed for all callers, and the self-healing loop will deterministically emit `failed` / `execution_failed` loop runs (`lastError` = fail-closed) on the workflow-failure path instead of applying reversible repairs. **This is why it must be operator-approved.**

## (d) Fail-closed / flag-gated, mirroring `allowTestOnlyAutoFixExecution` + #628

`execute()` now throws `TS_RUNTIME_AUTOFIX_EXECUTION_RETIRED` (503, `classification:"fail_closed"`) as its **first statement** — BEFORE any state read/write, executor side effect, rollback, or lesson-extraction provider call — unless the test-oracle flag `allowTestOnlyAutoFixExecution` is exactly `true`. Same error code/shape as the existing route guard `throwRetiredAutoFixExecution()`. Idiom mirrors PR #628's 4-surface method-guard mirror exactly (same helper style, thrown before any effect, flag-gated, default OFF in prod / default TRUE in mock-env/real-env/full-e2e).

- `run.ready` funnels per-action through this same `execute()` → covered.
- The standalone `rollback` route op (`rollbackService.rollback`) has **no non-route caller** — reachable only via the already-route-guarded `rollbackAction` and internally from this now-guarded `execute()` — so it is **not** separately guarded (guarding it would not break the internal rollback, but it has no off-route door, and guarding only the funnel keeps scope minimal).

**Flag plumbing** (service ← runtime ← bootstrap, sourced from the same `config.allowTestOnlyAutoFixExecution` the route uses at bootstrap:6790):
- `CreateAutoFixExecutionServiceDeps` + `CreateFridaySelfLearningRuntimeDeps` gain `allowTestOnlyAutoFixExecution?`.
- `mock-env` / `real-env` default it `true`; the api-test-server helper + browser-e2e self-repair env forward it into the **runtime** construction (not just routes) so the chromium `test:e2e:ui` self-repair flow (`run-ready → dispatcher → execute`) stays green. **Checked `test/e2e/ui/`**: `friday-home-self-repair-real-browser.e2e.test.ts:331` passes the flag through `browser-env.ts:67` → `hubConfig` → `createRealHubEnvFromStateDir` → `createFridayHub` → `config.allowTestOnlyAutoFixExecution` → the new bootstrap:4056 forward.

### Caller touch (agent-loop-service) — necessary, not scope creep

The task said "only the executor method boundary," and the **guard itself** is exactly that. But the live agent-loop path persists the loop run as `running` **before** calling `execute()`, so a fail-closed 503 would orphan that run deterministically at `running` — the exact #628-class defect the adversarial panel flagged on standing-agenda. So `executeRun` (agent-loop-service.ts) is touched **solely** to mirror #628's `runAgendaItem` terminal-state treatment: wrap the `execute()`/`runApprovedAction` call so any throw resets the run to terminal `failed` (`execution_failed`, `lastError`) and **re-throws** (semantics not swallowed). No planner/emitter change. Other callers verified safe: approval-workflow already wraps `execute()` in a saga try/catch (approval stays committed, no orphan); the dispatcher records per-action `skipped`.

## (e) blocker=0 / routeCount unchanged / no manifest touched

- `check:ts-runtime-retirement`: **status=passed, blockerFamilies=[], routeCount=584 (UNCHANGED)**. No route added; `docs/ops/ts-runtime-retirement-manifest.json` not in the diff.
- This is a HIDDEN-GAP closure: the route-level validator was already blocker=0 (that is why this was a hidden gap). The **new fail-closed unit test** is what proves the method-level closure; the validator confirms only that no route regression was introduced.

## Local gates (from worktree root)

- `npm run build:api` (tsc): clean
- `npm run lint` (`eslint .`): **0 errors** (1546 pre-existing warnings)
- vitest default project — learning domain + agent-loop + runtime + pipeline + **acceptance e2e** (route→runtime→execute): **334 tests green**
- new `friday-auto-fix-execution-retirement-guard.test.ts`: 4/4 (default fail-closed zero-side-effect, explicit-false, flag-true legacy path, guard-before-read)
- detect-secrets-hook + `check:secret-patterns` denylist: clean
- **Not run locally:** full chromium `test:e2e:ui` (needs built UI + chromium). The bootstrap→runtime flag-forward is verified by inspection + tsc (same `config` field the route already uses) and integration-proven by the acceptance e2e; CI `test:e2e:ui` is the final integration check.

## Truth label

Autofix execution becomes **method-fenced live-pending-Rust-ownership** — nothing is replaced. This is **NOT v1 GO progress**. Durable fix = Rust-own auto-remediation execution (roadmap R14; G1 exec leg must be method-guarded now regardless of v1 scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)