### PR TITLE
feat(rust): R5 slice-1 — friday-system-remote device + remote-session foundation (dark, WebAuthn seam fail-closed, no hub wiring)

### DIFF
--- a/rust-core/Cargo.lock
+++ b/rust-core/Cargo.lock
@@ -595,6 +595,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "friday-system-remote"
+version = "0.0.1"
+dependencies = [
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "friday-transport"
 version = "0.0.1"
 dependencies = [

--- a/rust-core/Cargo.toml
+++ b/rust-core/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "crates/friday-deepseek",
     "crates/friday-providers",
     "crates/friday-fs",
+    "crates/friday-system-remote",
     "crates/friday-hub",
     "crates/friday-ffi",
     "crates/friday-operator-cli",

--- a/rust-core/crates/friday-system-remote/Cargo.toml
+++ b/rust-core/crates/friday-system-remote/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "friday-system-remote"
+description = "Friday Rust Core — R5 system.remote.* foundation (DARK): WebAuthn-ceremony typed state machines (fail-closed verifier seam), registered-device + remote-session in-memory store. NO hub wiring, NO production caller, NO persistence (deferred). NOT v1 GO."
+edition.workspace = true
+version.workspace = true
+license.workspace = true
+publish = false
+rust-version.workspace = true
+
+# DARK crate. No production caller, no hub route, no FFI exposure. It is a
+# self-contained R5 slice-1 foundation; it deliberately depends on NOTHING in the
+# workspace (not even friday-core) so it cannot contend with concurrent lanes and
+# carries no migration / schema coupling. Persistence is an explicit deferred
+# slice (see lib.rs) — there is no rusqlite dependency by design this slice.
+[dependencies]
+thiserror.workspace = true

--- a/rust-core/crates/friday-system-remote/src/device.rs
+++ b/rust-core/crates/friday-system-remote/src/device.rs
@@ -1,0 +1,305 @@
+//! Registered-device data model + in-memory store (R5 slice-1).
+//!
+//! A `RegisteredDevice` is a WebAuthn-credentialed device bound to an owner
+//! principal. This is DISTINCT from `friday-storage`'s `trusted_device` /
+//! QR-pairing surface: that is out-of-band QR-secret pairing; this is the
+//! `system.remote.*` WebAuthn/passkey surface (register/assert/delete). The two
+//! are intentionally not merged — they are different ceremonies with different
+//! trust roots.
+//!
+//! ## Storage choice (this slice)
+//! In-memory only. Persistence (a `friday-storage` migration `m00NN` registering
+//! `remote_device` in `HUB_ONLY_TABLES` with a forward-migration KAT) is an
+//! EXPLICIT deferred slice — see `lib.rs`. Keeping it in-crate means this dark
+//! lane touches no shared schema file and cannot collide with concurrent
+//! migration lanes.
+//!
+//! ## Fail-closed
+//! [`DeviceStore::register`] accepts ONLY a [`VerifiedAttestation`] — a value
+//! that, by the `webauthn` typestate, can only have come from a successful
+//! [`crate::webauthn::WebAuthnVerifier`]. There is no `register_unverified`. With
+//! the [`crate::webauthn::DeferredVerifier`] in place, no attestation verifies,
+//! so no device can be registered yet — fail closed.
+
+use crate::error::{RemoteError, Result};
+use crate::webauthn::VerifiedAttestation;
+use std::collections::HashMap;
+
+/// A registered WebAuthn device row.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RegisteredDevice {
+    /// Stable device id (caller-assigned; unique within the store).
+    pub device_id: String,
+    /// Owner principal the device is bound to.
+    pub owner: String,
+    /// Relying-party id the credential is scoped to.
+    pub rp_id: String,
+    /// WebAuthn credential id (from the verified attestation).
+    pub credential_id: Vec<u8>,
+    /// Credential public key (from the verified attestation). A real verifier
+    /// extracts this from the COSE key in `authData`.
+    pub public_key: Vec<u8>,
+    /// Optional human label (e.g. "Jarvis's iPhone").
+    pub label: String,
+    /// Creation timestamp (ms since epoch; caller-supplied clock).
+    pub created_at: i64,
+    /// Last time the device was seen (an assertion succeeded / a session
+    /// heartbeat referenced it). Starts equal to `created_at`.
+    pub last_seen_at: i64,
+}
+
+/// In-memory registered-device store keyed by `device_id`.
+#[derive(Debug, Default)]
+pub struct DeviceStore {
+    by_id: HashMap<String, RegisteredDevice>,
+}
+
+impl DeviceStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a device from a VERIFIED attestation. Because the only source of
+    /// a [`VerifiedAttestation`] is a successful verifier run, an unverified
+    /// ceremony can never reach here. A duplicate `device_id` fails closed
+    /// (registration is not an upsert).
+    ///
+    /// The device's `owner`/`rp_id`/`credential_id`/`public_key` come from the
+    /// verified attestation, NOT from caller-supplied free input — the caller
+    /// cannot smuggle a different owner past verification.
+    pub fn register(
+        &mut self,
+        device_id: &str,
+        attestation: &VerifiedAttestation,
+        label: &str,
+        now: i64,
+    ) -> Result<RegisteredDevice> {
+        if device_id.trim().is_empty() {
+            return Err(RemoteError::InvalidInput("device_id is empty".into()));
+        }
+        if self.by_id.contains_key(device_id) {
+            return Err(RemoteError::DeviceAlreadyRegistered(device_id.to_string()));
+        }
+        let device = RegisteredDevice {
+            device_id: device_id.to_string(),
+            owner: attestation.owner().to_string(),
+            rp_id: attestation.rp_id().to_string(),
+            credential_id: attestation.credential_id().to_vec(),
+            public_key: attestation.public_key().to_vec(),
+            label: label.to_string(),
+            created_at: now,
+            last_seen_at: now,
+        };
+        self.by_id.insert(device_id.to_string(), device.clone());
+        Ok(device)
+    }
+
+    /// Look up a device, enforcing owner-scoping. A device that exists but is
+    /// owned by a different principal is [`RemoteError::OwnerMismatch`], NOT
+    /// found-vs-not-found ambiguity that depends on ownership — existence is only
+    /// revealed after the owner check passes.
+    pub fn get_for_owner(&self, device_id: &str, owner: &str) -> Result<&RegisteredDevice> {
+        let device = self
+            .by_id
+            .get(device_id)
+            .ok_or_else(|| RemoteError::DeviceNotFound(device_id.to_string()))?;
+        if device.owner != owner {
+            return Err(RemoteError::OwnerMismatch);
+        }
+        Ok(device)
+    }
+
+    /// Internal owner-agnostic lookup (used by the session layer, which has
+    /// already established the owner via its own check). Not public.
+    pub(crate) fn get(&self, device_id: &str) -> Option<&RegisteredDevice> {
+        self.by_id.get(device_id)
+    }
+
+    /// List a single owner's devices, ordered by `created_at` then `device_id`.
+    /// Never returns another owner's devices.
+    pub fn list_for_owner(&self, owner: &str) -> Vec<RegisteredDevice> {
+        let mut out: Vec<RegisteredDevice> = self
+            .by_id
+            .values()
+            .filter(|d| d.owner == owner)
+            .cloned()
+            .collect();
+        out.sort_by(|a, b| {
+            a.created_at
+                .cmp(&b.created_at)
+                .then_with(|| a.device_id.cmp(&b.device_id))
+        });
+        out
+    }
+
+    /// Update `last_seen_at` (forward-only — refuses to move it backwards, so a
+    /// stale/replayed timestamp cannot rewind it). Owner-scoped.
+    pub fn touch_for_owner(&mut self, device_id: &str, owner: &str, now: i64) -> Result<()> {
+        let device = self
+            .by_id
+            .get_mut(device_id)
+            .ok_or_else(|| RemoteError::DeviceNotFound(device_id.to_string()))?;
+        if device.owner != owner {
+            return Err(RemoteError::OwnerMismatch);
+        }
+        if now > device.last_seen_at {
+            device.last_seen_at = now;
+        }
+        Ok(())
+    }
+
+    /// Delete a device, owner-scoped. A missing device is
+    /// [`RemoteError::DeviceNotFound`]; another owner's device is
+    /// [`RemoteError::OwnerMismatch`] and is NOT deleted.
+    pub fn delete_for_owner(&mut self, device_id: &str, owner: &str) -> Result<()> {
+        match self.by_id.get(device_id) {
+            None => Err(RemoteError::DeviceNotFound(device_id.to_string())),
+            Some(d) if d.owner != owner => Err(RemoteError::OwnerMismatch),
+            Some(_) => {
+                self.by_id.remove(device_id);
+                Ok(())
+            }
+        }
+    }
+
+    /// Number of registered devices (all owners). Test/introspection helper.
+    pub fn len(&self) -> usize {
+        self.by_id.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.by_id.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::webauthn::{
+        begin_registration, AcceptingTestVerifier, AttestationResponse, WebAuthnVerifier,
+    };
+
+    fn verified_attestation(owner: &str, cred: Vec<u8>) -> VerifiedAttestation {
+        let chal = begin_registration(owner, "friday.local", vec![1, 2, 3]).unwrap();
+        let resp = AttestationResponse {
+            credential_id: cred,
+            attestation_object: vec![0xa0],
+            client_data_json: b"{}".to_vec(),
+        };
+        AcceptingTestVerifier
+            .verify_registration(&chal, &resp)
+            .expect("test verifier accepts")
+    }
+
+    #[test]
+    fn register_then_lookup_happy_path() {
+        let mut store = DeviceStore::new();
+        let att = verified_attestation("owner-1", vec![7, 7, 7]);
+        let dev = store.register("dev-1", &att, "Phone", 1000).unwrap();
+        assert_eq!(dev.owner, "owner-1");
+        assert_eq!(dev.credential_id, vec![7, 7, 7]);
+        assert_eq!(dev.created_at, 1000);
+        assert_eq!(dev.last_seen_at, 1000);
+        // Lookup by the right owner succeeds.
+        let got = store.get_for_owner("dev-1", "owner-1").unwrap();
+        assert_eq!(got.device_id, "dev-1");
+        assert_eq!(store.len(), 1);
+    }
+
+    #[test]
+    fn register_rejects_duplicate_device_id() {
+        let mut store = DeviceStore::new();
+        let att = verified_attestation("owner-1", vec![1]);
+        store.register("dev-1", &att, "", 1).unwrap();
+        let att2 = verified_attestation("owner-1", vec![2]);
+        assert_eq!(
+            store.register("dev-1", &att2, "", 2),
+            Err(RemoteError::DeviceAlreadyRegistered("dev-1".into()))
+        );
+    }
+
+    #[test]
+    fn register_rejects_empty_device_id() {
+        let mut store = DeviceStore::new();
+        let att = verified_attestation("owner-1", vec![1]);
+        assert!(matches!(
+            store.register("", &att, "", 1),
+            Err(RemoteError::InvalidInput(_))
+        ));
+    }
+
+    #[test]
+    fn lookup_other_owner_is_mismatch_not_found() {
+        let mut store = DeviceStore::new();
+        let att = verified_attestation("owner-1", vec![1]);
+        store.register("dev-1", &att, "", 1).unwrap();
+        // Wrong owner ⇒ OwnerMismatch (refused), not a leak of existence as found.
+        assert_eq!(
+            store.get_for_owner("dev-1", "owner-2"),
+            Err(RemoteError::OwnerMismatch)
+        );
+        // Missing id ⇒ DeviceNotFound.
+        assert!(matches!(
+            store.get_for_owner("nope", "owner-1"),
+            Err(RemoteError::DeviceNotFound(_))
+        ));
+    }
+
+    #[test]
+    fn touch_is_forward_only_and_owner_scoped() {
+        let mut store = DeviceStore::new();
+        let att = verified_attestation("owner-1", vec![1]);
+        store.register("dev-1", &att, "", 100).unwrap();
+        // Backwards timestamp does not rewind last_seen_at.
+        store.touch_for_owner("dev-1", "owner-1", 50).unwrap();
+        assert_eq!(store.get_for_owner("dev-1", "owner-1").unwrap().last_seen_at, 100);
+        // Forward timestamp advances it.
+        store.touch_for_owner("dev-1", "owner-1", 200).unwrap();
+        assert_eq!(store.get_for_owner("dev-1", "owner-1").unwrap().last_seen_at, 200);
+        // Wrong owner refused.
+        assert_eq!(
+            store.touch_for_owner("dev-1", "owner-2", 300),
+            Err(RemoteError::OwnerMismatch)
+        );
+    }
+
+    #[test]
+    fn delete_owner_scoped() {
+        let mut store = DeviceStore::new();
+        let att = verified_attestation("owner-1", vec![1]);
+        store.register("dev-1", &att, "", 1).unwrap();
+        // Another owner cannot delete it.
+        assert_eq!(
+            store.delete_for_owner("dev-1", "owner-2"),
+            Err(RemoteError::OwnerMismatch)
+        );
+        assert_eq!(store.len(), 1);
+        // The real owner can.
+        store.delete_for_owner("dev-1", "owner-1").unwrap();
+        assert!(store.is_empty());
+        // Re-delete ⇒ not found.
+        assert!(matches!(
+            store.delete_for_owner("dev-1", "owner-1"),
+            Err(RemoteError::DeviceNotFound(_))
+        ));
+    }
+
+    #[test]
+    fn list_for_owner_isolates_owners() {
+        let mut store = DeviceStore::new();
+        store
+            .register("a", &verified_attestation("owner-1", vec![1]), "", 1)
+            .unwrap();
+        store
+            .register("b", &verified_attestation("owner-2", vec![2]), "", 2)
+            .unwrap();
+        store
+            .register("c", &verified_attestation("owner-1", vec![3]), "", 3)
+            .unwrap();
+        let o1 = store.list_for_owner("owner-1");
+        assert_eq!(o1.len(), 2);
+        assert!(o1.iter().all(|d| d.owner == "owner-1"));
+        assert_eq!(store.list_for_owner("owner-2").len(), 1);
+        assert_eq!(store.list_for_owner("owner-3").len(), 0);
+    }
+}

--- a/rust-core/crates/friday-system-remote/src/device.rs
+++ b/rust-core/crates/friday-system-remote/src/device.rs
@@ -252,10 +252,22 @@ mod tests {
         store.register("dev-1", &att, "", 100).unwrap();
         // Backwards timestamp does not rewind last_seen_at.
         store.touch_for_owner("dev-1", "owner-1", 50).unwrap();
-        assert_eq!(store.get_for_owner("dev-1", "owner-1").unwrap().last_seen_at, 100);
+        assert_eq!(
+            store
+                .get_for_owner("dev-1", "owner-1")
+                .unwrap()
+                .last_seen_at,
+            100
+        );
         // Forward timestamp advances it.
         store.touch_for_owner("dev-1", "owner-1", 200).unwrap();
-        assert_eq!(store.get_for_owner("dev-1", "owner-1").unwrap().last_seen_at, 200);
+        assert_eq!(
+            store
+                .get_for_owner("dev-1", "owner-1")
+                .unwrap()
+                .last_seen_at,
+            200
+        );
         // Wrong owner refused.
         assert_eq!(
             store.touch_for_owner("dev-1", "owner-2", 300),

--- a/rust-core/crates/friday-system-remote/src/error.rs
+++ b/rust-core/crates/friday-system-remote/src/error.rs
@@ -1,0 +1,68 @@
+//! Error type for the R5 `system.remote.*` foundation.
+//!
+//! Every variant is a CLOSED rejection: there is no "soft accept" path. In
+//! particular [`RemoteError::WebAuthnVerifierNotWired`] is the fail-closed signal
+//! the deferred verifier stub returns — it is an `Err`, never a panic, so a
+//! caller that has not wired a real verifier is REFUSED rather than crashing.
+
+use thiserror::Error;
+
+/// The closed set of reasons a `system.remote.*` operation can be rejected.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum RemoteError {
+    /// A WebAuthn ceremony could not be advanced because no real attestation /
+    /// assertion verifier has been wired yet. This is the DELIBERATE deferred
+    /// stub's response — it FAILS CLOSED (an unverified ceremony is rejected,
+    /// never accepted). See [`crate::webauthn`].
+    #[error("webauthn verifier not wired: refusing to accept an unverified ceremony (deferred)")]
+    WebAuthnVerifierNotWired,
+
+    /// A real verifier was wired but rejected the attestation/assertion (bad
+    /// signature, challenge mismatch, unknown credential, etc.).
+    #[error("webauthn verification failed: {0}")]
+    WebAuthnRejected(String),
+
+    /// The presented credential id does not match the challenge's expected
+    /// credential, or the device for an assertion is not registered.
+    #[error("unknown or mismatched credential")]
+    UnknownCredential,
+
+    /// A ceremony was advanced out of order (e.g. verifying before a challenge
+    /// was issued). The typed states make most of these unrepresentable; this
+    /// covers the residual runtime cases.
+    #[error("webauthn ceremony out of order: {0}")]
+    CeremonyOutOfOrder(String),
+
+    /// A device with this id is already registered. Registration is not an
+    /// upsert — a re-register must go through an explicit rotation slice (not in
+    /// this slice).
+    #[error("device already registered: {0}")]
+    DeviceAlreadyRegistered(String),
+
+    /// No device with this id is registered.
+    #[error("device not found: {0}")]
+    DeviceNotFound(String),
+
+    /// No remote session with this id exists.
+    #[error("remote session not found: {0}")]
+    SessionNotFound(String),
+
+    /// The caller's owner principal does not match the row's owner. Cross-owner
+    /// access is REFUSED (never silently scoped away or treated as not-found in
+    /// a way that leaks existence beyond the owner check).
+    #[error("owner mismatch: principal not authorized for this resource")]
+    OwnerMismatch,
+
+    /// The remote session has expired. An expired session is DEAD — it cannot be
+    /// heartbeated back to life, only deleted. Fail-closed.
+    #[error("remote session expired")]
+    SessionExpired,
+
+    /// A bound input was malformed (empty id, non-positive ttl, etc.). Inputs are
+    /// validated rather than silently coerced.
+    #[error("invalid input: {0}")]
+    InvalidInput(String),
+}
+
+/// Crate result alias.
+pub type Result<T> = std::result::Result<T, RemoteError>;

--- a/rust-core/crates/friday-system-remote/src/lib.rs
+++ b/rust-core/crates/friday-system-remote/src/lib.rs
@@ -1,0 +1,66 @@
+//! `friday-system-remote` — R5 `system.remote.*` foundation (DARK, slice 1).
+//!
+//! Roadmap ref: `TS_RECON_TRUTH_ROADMAP_20260610.md` §3 R5 (`system.remote.*` ×11
+//! — WebAuthn register/assert, passkey, device register/delete, remote sessions
+//! create/heartbeat/delete). Substrate before this slice = NONE; this is the
+//! first slice.
+//!
+//! # Truth label — DARK, NOT v1 GO
+//! This crate is FULLY DARK:
+//! * NO friday-hub wiring. `friday-hub/src/lib.rs` and all hub routing/bootstrap
+//!   are UNTOUCHED. There is no production caller, no route, no FFI export.
+//! * NOTHING is replaced. The R5 capability does not exist in production today;
+//!   this slice neither replaces a TS surface nor moves the live product.
+//! * It is a self-contained foundation that other slices build on. It is NOT a
+//!   v1 GO of device/sync; it is the typed skeleton + fail-closed seams.
+//!
+//! # What this slice BUILDS (real)
+//! * [`webauthn`] — the two WebAuthn ceremonies (registration / assertion) as
+//!   TYPED state machines, plus the verification SEAM ([`webauthn::WebAuthnVerifier`]).
+//! * [`device`] — `RegisteredDevice` model + in-memory `DeviceStore`
+//!   (register/lookup/list/touch/delete), owner-scoped.
+//! * [`session`] — `RemoteSession` model + in-memory `SessionStore`
+//!   (create/heartbeat/delete) with monotonic-expiry, fail-closed lifecycle.
+//!
+//! # What is STUB / DEFERRED (explicit)
+//! 1. **Real WebAuthn cryptographic verification.** [`webauthn::DeferredVerifier`]
+//!    FAILS CLOSED (`Err(WebAuthnVerifierNotWired)`) for every ceremony. COSE key
+//!    parsing, attestation-statement validation, signature/sign-count/origin/
+//!    rp-id/challenge checks are NOT implemented — a future slice wires a real
+//!    `WebAuthnVerifier` (e.g. over `webauthn-rs`). Until then NO device can be
+//!    registered and NO verified-path session can be opened.
+//! 2. **Persistence.** Both stores are IN-MEMORY. A `friday-storage` migration
+//!    (`m00NN`) registering `remote_device` / `remote_session` in
+//!    `HUB_ONLY_TABLES` + a forward-migration KAT is DEFERRED. Rationale: that
+//!    migration edits the shared `friday-storage::schema` file (the
+//!    `hub_migrations()` vector + `HUB_ONLY_TABLES` + a new `m00NN` fn) — the
+//!    single highest-contention merge point for ANY concurrent migration lane
+//!    (m0024 just landed). Keeping storage in-crate keeps this dark lane
+//!    collision-free, per the slice brief's escape hatch.
+//! 3. **Hub route wiring.** Binding these stores/ceremonies to the 11
+//!    `system.remote.*` routes, principal/gate integration, challenge issuance
+//!    via a CSPRNG, and FFI exposure are all DEFERRED (later slices, operator-gated).
+//! 4. **Passkey-specific flows** (discoverable credentials / resident keys /
+//!    user-verification policy) beyond the shared register/assert shape.
+//!
+//! # Fail-closed seams (summary)
+//! * WebAuthn: only a [`webauthn::WebAuthnVerifier`] result can mint a
+//!   `VerifiedAttestation`/`VerifiedAssertion` (typestate); the deferred verifier
+//!   rejects; `device::DeviceStore::register` accepts ONLY a verified attestation.
+//! * Sessions: heartbeat on an expired session is REFUSED (an expired session is
+//!   dead, not revivable); cross-owner device/session ops are REFUSED.
+//! * No `unwrap`/`expect` on external input; empty/negative inputs are rejected.
+
+pub mod device;
+pub mod error;
+pub mod session;
+pub mod webauthn;
+
+pub use device::{DeviceStore, RegisteredDevice};
+pub use error::{RemoteError, Result};
+pub use session::{RemoteSession, SessionState, SessionStore};
+pub use webauthn::{
+    begin_assertion, begin_registration, AssertionChallenge, AssertionResponse,
+    AttestationResponse, Bytes, DeferredVerifier, RegistrationChallenge, VerifiedAssertion,
+    VerifiedAttestation, WebAuthnVerifier,
+};

--- a/rust-core/crates/friday-system-remote/src/session.rs
+++ b/rust-core/crates/friday-system-remote/src/session.rs
@@ -252,9 +252,7 @@ mod tests {
         assert_eq!(s.state_at(1_400), SessionState::Active);
 
         // heartbeat while live: refresh expiry forward, bump heartbeat_at.
-        let s2 = sessions
-            .heartbeat("sess-1", "owner-1", 1_400, 500)
-            .unwrap();
+        let s2 = sessions.heartbeat("sess-1", "owner-1", 1_400, 500).unwrap();
         assert_eq!(s2.heartbeat_at, 1_400);
         assert_eq!(s2.expires_at, 1_900);
 

--- a/rust-core/crates/friday-system-remote/src/session.rs
+++ b/rust-core/crates/friday-system-remote/src/session.rs
@@ -1,0 +1,404 @@
+//! Remote-session lifecycle + in-memory store (R5 slice-1).
+//!
+//! A `RemoteSession` is a live remote-control session bound to a registered
+//! device and its owner. Lifecycle: **create → heartbeat (refresh expiry) →
+//! delete**, with explicit expiry. The expiry discipline mirrors the
+//! lease/watermark discipline in `friday-storage::schedule` (monotonic, refuses
+//! to rewind, an expired holder is dead).
+//!
+//! ## Expiry semantics (fail-closed)
+//! * `create(now, ttl)` sets `expires_at = now + ttl`.
+//! * `heartbeat(now, ttl)` on a LIVE session (now < expires_at) extends
+//!   `expires_at = now + ttl` and bumps `heartbeat_at`.
+//! * `heartbeat(now, ttl)` on an EXPIRED session (now >= expires_at) is REFUSED
+//!   with [`RemoteError::SessionExpired`] — an expired session is DEAD and cannot
+//!   be revived; it can only be deleted. This is the fail-closed rule the KAT
+//!   pins.
+//! * Any read/op on an expired session is treated as expired (fail-closed),
+//!   never as a still-live session.
+//!
+//! ## Storage choice
+//! In-memory only; persistence deferred (see `lib.rs`), same rationale as
+//! [`crate::device`].
+
+use crate::device::DeviceStore;
+use crate::error::{RemoteError, Result};
+use std::collections::HashMap;
+
+/// Lifecycle state of a remote session.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SessionState {
+    /// Created and within its expiry window.
+    Active,
+    /// Past `expires_at` (computed against a supplied clock). Terminal for
+    /// liveness — only deletion is valid.
+    Expired,
+}
+
+/// A remote-control session row.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RemoteSession {
+    pub session_id: String,
+    /// The registered device this session controls.
+    pub device_id: String,
+    /// Owner principal (must match the device's owner at create time).
+    pub owner: String,
+    pub created_at: i64,
+    /// Last heartbeat timestamp (starts equal to `created_at`).
+    pub heartbeat_at: i64,
+    /// Absolute expiry (ms since epoch). `now >= expires_at` ⇒ expired.
+    pub expires_at: i64,
+}
+
+impl RemoteSession {
+    /// Derive the lifecycle state against a clock. An expired session reports
+    /// [`SessionState::Expired`] (fail-closed; never silently Active).
+    pub fn state_at(&self, now: i64) -> SessionState {
+        if now >= self.expires_at {
+            SessionState::Expired
+        } else {
+            SessionState::Active
+        }
+    }
+
+    /// Convenience: is this session expired at `now`?
+    pub fn is_expired_at(&self, now: i64) -> bool {
+        self.state_at(now) == SessionState::Expired
+    }
+}
+
+/// In-memory remote-session store keyed by `session_id`.
+#[derive(Debug, Default)]
+pub struct SessionStore {
+    by_id: HashMap<String, RemoteSession>,
+}
+
+impl SessionStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a remote session for a registered device. Fails closed if:
+    /// * the device is not registered ([`RemoteError::DeviceNotFound`]);
+    /// * the device is owned by a different principal
+    ///   ([`RemoteError::OwnerMismatch`]) — a session cannot be opened against
+    ///   another owner's device;
+    /// * the `ttl_ms` is non-positive ([`RemoteError::InvalidInput`]);
+    /// * the `session_id` is empty or already exists.
+    ///
+    /// The `devices` store is consulted to bind the session to a REAL,
+    /// owner-matched device — a session id alone never grants control.
+    pub fn create(
+        &mut self,
+        devices: &DeviceStore,
+        session_id: &str,
+        device_id: &str,
+        owner: &str,
+        now: i64,
+        ttl_ms: i64,
+    ) -> Result<RemoteSession> {
+        if session_id.trim().is_empty() {
+            return Err(RemoteError::InvalidInput("session_id is empty".into()));
+        }
+        if ttl_ms <= 0 {
+            return Err(RemoteError::InvalidInput("ttl_ms must be positive".into()));
+        }
+        // Bind to a real, owner-matched device.
+        let device = devices
+            .get(device_id)
+            .ok_or_else(|| RemoteError::DeviceNotFound(device_id.to_string()))?;
+        if device.owner != owner {
+            return Err(RemoteError::OwnerMismatch);
+        }
+        if self.by_id.contains_key(session_id) {
+            return Err(RemoteError::InvalidInput(format!(
+                "session_id '{session_id}' already exists"
+            )));
+        }
+        let expires_at = now.saturating_add(ttl_ms);
+        let session = RemoteSession {
+            session_id: session_id.to_string(),
+            device_id: device_id.to_string(),
+            owner: owner.to_string(),
+            created_at: now,
+            heartbeat_at: now,
+            expires_at,
+        };
+        self.by_id.insert(session_id.to_string(), session.clone());
+        Ok(session)
+    }
+
+    /// Read a session, owner-scoped. Does NOT consider expiry (caller can check
+    /// [`RemoteSession::state_at`]); existence is revealed only after the owner
+    /// check passes.
+    pub fn get_for_owner(&self, session_id: &str, owner: &str) -> Result<&RemoteSession> {
+        let s = self
+            .by_id
+            .get(session_id)
+            .ok_or_else(|| RemoteError::SessionNotFound(session_id.to_string()))?;
+        if s.owner != owner {
+            return Err(RemoteError::OwnerMismatch);
+        }
+        Ok(s)
+    }
+
+    /// Heartbeat a session: refresh its expiry to `now + ttl_ms` and bump
+    /// `heartbeat_at`. Fails closed if:
+    /// * the session does not exist ([`RemoteError::SessionNotFound`]);
+    /// * the owner does not match ([`RemoteError::OwnerMismatch`]);
+    /// * `ttl_ms` is non-positive;
+    /// * the session is ALREADY EXPIRED at `now` ([`RemoteError::SessionExpired`])
+    ///   — an expired session is dead and cannot be revived by heartbeat.
+    pub fn heartbeat(
+        &mut self,
+        session_id: &str,
+        owner: &str,
+        now: i64,
+        ttl_ms: i64,
+    ) -> Result<RemoteSession> {
+        if ttl_ms <= 0 {
+            return Err(RemoteError::InvalidInput("ttl_ms must be positive".into()));
+        }
+        let s = self
+            .by_id
+            .get_mut(session_id)
+            .ok_or_else(|| RemoteError::SessionNotFound(session_id.to_string()))?;
+        if s.owner != owner {
+            return Err(RemoteError::OwnerMismatch);
+        }
+        if now >= s.expires_at {
+            // Dead. Do not revive. Fail closed.
+            return Err(RemoteError::SessionExpired);
+        }
+        s.heartbeat_at = now;
+        s.expires_at = now.saturating_add(ttl_ms);
+        Ok(s.clone())
+    }
+
+    /// Delete a session, owner-scoped. A missing session is
+    /// [`RemoteError::SessionNotFound`]; another owner's session is
+    /// [`RemoteError::OwnerMismatch`] and is NOT deleted. An EXPIRED session CAN
+    /// be deleted (deletion is the valid terminal op for a dead session).
+    pub fn delete_for_owner(&mut self, session_id: &str, owner: &str) -> Result<()> {
+        match self.by_id.get(session_id) {
+            None => Err(RemoteError::SessionNotFound(session_id.to_string())),
+            Some(s) if s.owner != owner => Err(RemoteError::OwnerMismatch),
+            Some(_) => {
+                self.by_id.remove(session_id);
+                Ok(())
+            }
+        }
+    }
+
+    /// List an owner's sessions ordered by `created_at` then `session_id`. Never
+    /// returns another owner's sessions.
+    pub fn list_for_owner(&self, owner: &str) -> Vec<RemoteSession> {
+        let mut out: Vec<RemoteSession> = self
+            .by_id
+            .values()
+            .filter(|s| s.owner == owner)
+            .cloned()
+            .collect();
+        out.sort_by(|a, b| {
+            a.created_at
+                .cmp(&b.created_at)
+                .then_with(|| a.session_id.cmp(&b.session_id))
+        });
+        out
+    }
+
+    pub fn len(&self) -> usize {
+        self.by_id.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.by_id.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::webauthn::{
+        begin_registration, AcceptingTestVerifier, AttestationResponse, WebAuthnVerifier,
+    };
+
+    /// Build a DeviceStore holding one registered device for `owner`/`device_id`.
+    fn store_with_device(owner: &str, device_id: &str) -> DeviceStore {
+        let mut devices = DeviceStore::new();
+        let chal = begin_registration(owner, "friday.local", vec![1, 2, 3]).unwrap();
+        let resp = AttestationResponse {
+            credential_id: vec![7, 7, 7],
+            attestation_object: vec![0xa0],
+            client_data_json: b"{}".to_vec(),
+        };
+        let att = AcceptingTestVerifier
+            .verify_registration(&chal, &resp)
+            .unwrap();
+        devices.register(device_id, &att, "", 0).unwrap();
+        devices
+    }
+
+    #[test]
+    fn create_heartbeat_expire_delete_lifecycle() {
+        let devices = store_with_device("owner-1", "dev-1");
+        let mut sessions = SessionStore::new();
+
+        // create: expires_at = now + ttl
+        let s = sessions
+            .create(&devices, "sess-1", "dev-1", "owner-1", 1_000, 500)
+            .unwrap();
+        assert_eq!(s.expires_at, 1_500);
+        assert_eq!(s.state_at(1_400), SessionState::Active);
+
+        // heartbeat while live: refresh expiry forward, bump heartbeat_at.
+        let s2 = sessions
+            .heartbeat("sess-1", "owner-1", 1_400, 500)
+            .unwrap();
+        assert_eq!(s2.heartbeat_at, 1_400);
+        assert_eq!(s2.expires_at, 1_900);
+
+        // at/after expires_at ⇒ Expired (fail-closed read).
+        let s3 = sessions.get_for_owner("sess-1", "owner-1").unwrap();
+        assert_eq!(s3.state_at(1_900), SessionState::Expired);
+        assert!(s3.is_expired_at(2_000));
+
+        // delete the (now-dead) session.
+        sessions.delete_for_owner("sess-1", "owner-1").unwrap();
+        assert!(sessions.is_empty());
+    }
+
+    #[test]
+    fn heartbeat_on_expired_session_is_refused() {
+        let devices = store_with_device("owner-1", "dev-1");
+        let mut sessions = SessionStore::new();
+        sessions
+            .create(&devices, "sess-1", "dev-1", "owner-1", 1_000, 100)
+            .unwrap();
+        // expires_at = 1_100; heartbeat at exactly 1_100 (>=) ⇒ expired, refused.
+        assert_eq!(
+            sessions.heartbeat("sess-1", "owner-1", 1_100, 100),
+            Err(RemoteError::SessionExpired)
+        );
+        // and well past expiry too.
+        assert_eq!(
+            sessions.heartbeat("sess-1", "owner-1", 5_000, 100),
+            Err(RemoteError::SessionExpired)
+        );
+        // An expired session can still be DELETED (valid terminal op).
+        sessions.delete_for_owner("sess-1", "owner-1").unwrap();
+    }
+
+    #[test]
+    fn create_requires_real_owner_matched_device() {
+        let devices = store_with_device("owner-1", "dev-1");
+        let mut sessions = SessionStore::new();
+        // Unknown device ⇒ DeviceNotFound.
+        assert!(matches!(
+            sessions.create(&devices, "s", "nope", "owner-1", 1, 10),
+            Err(RemoteError::DeviceNotFound(_))
+        ));
+        // Real device, WRONG owner ⇒ OwnerMismatch (cannot open a session against
+        // another owner's device).
+        assert_eq!(
+            sessions.create(&devices, "s", "dev-1", "owner-2", 1, 10),
+            Err(RemoteError::OwnerMismatch)
+        );
+        assert!(sessions.is_empty());
+    }
+
+    #[test]
+    fn create_rejects_bad_inputs_and_duplicate() {
+        let devices = store_with_device("owner-1", "dev-1");
+        let mut sessions = SessionStore::new();
+        // empty session id
+        assert!(matches!(
+            sessions.create(&devices, "", "dev-1", "owner-1", 1, 10),
+            Err(RemoteError::InvalidInput(_))
+        ));
+        // non-positive ttl
+        assert!(matches!(
+            sessions.create(&devices, "s", "dev-1", "owner-1", 1, 0),
+            Err(RemoteError::InvalidInput(_))
+        ));
+        assert!(matches!(
+            sessions.create(&devices, "s", "dev-1", "owner-1", 1, -5),
+            Err(RemoteError::InvalidInput(_))
+        ));
+        // duplicate id
+        sessions
+            .create(&devices, "s", "dev-1", "owner-1", 1, 10)
+            .unwrap();
+        assert!(matches!(
+            sessions.create(&devices, "s", "dev-1", "owner-1", 1, 10),
+            Err(RemoteError::InvalidInput(_))
+        ));
+    }
+
+    #[test]
+    fn session_ops_are_owner_scoped() {
+        let devices = store_with_device("owner-1", "dev-1");
+        let mut sessions = SessionStore::new();
+        sessions
+            .create(&devices, "sess-1", "dev-1", "owner-1", 1_000, 1_000)
+            .unwrap();
+        // Wrong owner cannot read, heartbeat, or delete.
+        assert_eq!(
+            sessions.get_for_owner("sess-1", "owner-2"),
+            Err(RemoteError::OwnerMismatch)
+        );
+        assert_eq!(
+            sessions.heartbeat("sess-1", "owner-2", 1_100, 1_000),
+            Err(RemoteError::OwnerMismatch)
+        );
+        assert_eq!(
+            sessions.delete_for_owner("sess-1", "owner-2"),
+            Err(RemoteError::OwnerMismatch)
+        );
+        // still present
+        assert_eq!(sessions.len(), 1);
+    }
+
+    #[test]
+    fn heartbeat_and_delete_missing_session_fail_closed() {
+        let mut sessions = SessionStore::new();
+        assert!(matches!(
+            sessions.heartbeat("ghost", "owner-1", 1, 10),
+            Err(RemoteError::SessionNotFound(_))
+        ));
+        assert!(matches!(
+            sessions.delete_for_owner("ghost", "owner-1"),
+            Err(RemoteError::SessionNotFound(_))
+        ));
+    }
+
+    #[test]
+    fn list_for_owner_isolates_owners() {
+        let mut devices = store_with_device("owner-1", "dev-1");
+        // second device for owner-2
+        let chal = begin_registration("owner-2", "friday.local", vec![9]).unwrap();
+        let resp = AttestationResponse {
+            credential_id: vec![8],
+            attestation_object: vec![0xa0],
+            client_data_json: b"{}".to_vec(),
+        };
+        let att = AcceptingTestVerifier
+            .verify_registration(&chal, &resp)
+            .unwrap();
+        devices.register("dev-2", &att, "", 0).unwrap();
+
+        let mut sessions = SessionStore::new();
+        sessions
+            .create(&devices, "s1", "dev-1", "owner-1", 1, 100)
+            .unwrap();
+        sessions
+            .create(&devices, "s2", "dev-2", "owner-2", 2, 100)
+            .unwrap();
+        assert_eq!(sessions.list_for_owner("owner-1").len(), 1);
+        assert_eq!(sessions.list_for_owner("owner-2").len(), 1);
+        assert!(sessions
+            .list_for_owner("owner-1")
+            .iter()
+            .all(|s| s.owner == "owner-1"));
+    }
+}

--- a/rust-core/crates/friday-system-remote/src/webauthn.rs
+++ b/rust-core/crates/friday-system-remote/src/webauthn.rs
@@ -1,0 +1,359 @@
+//! WebAuthn ceremony SHAPE as typed state machines (R5 slice-1).
+//!
+//! This module models the two WebAuthn ceremonies — **registration**
+//! (`navigator.credentials.create`, attestation) and **assertion**
+//! (`navigator.credentials.get`, authentication) — as typed state machines:
+//!
+//! ```text
+//!   register:  RegistrationChallenge --(verify attestation)--> VerifiedAttestation
+//!   assert:    AssertionChallenge     --(verify assertion)----> VerifiedAssertion
+//! ```
+//!
+//! ## What is REAL vs STUB this slice
+//! * REAL: the typed ceremony states, the legal transitions, and the
+//!   verification SEAM (the [`WebAuthnVerifier`] trait).
+//! * STUB (deferred): the actual cryptographic verification — COSE key parsing,
+//!   attestation-statement validation, signature checks over
+//!   `authenticatorData || sha256(clientDataJSON)`, sign-count regression
+//!   checks, RP-ID / origin / challenge binding. None of that is implemented
+//!   here. The provided [`DeferredVerifier`] FAILS CLOSED: it returns
+//!   `Err(RemoteError::WebAuthnVerifierNotWired)` for every ceremony.
+//!
+//! ## Fail-closed by construction (typestate)
+//! [`VerifiedAttestation`] and [`VerifiedAssertion`] have NO public constructor.
+//! The ONLY way to obtain one is as the `Ok` result of a [`WebAuthnVerifier`]
+//! method. A caller therefore cannot fabricate a "verified" token and hand it to
+//! the device/session store: an unverified ceremony is unrepresentable as a
+//! verified value. Swapping in a real verifier is the only thing that makes the
+//! accept-path reachable — exactly the seam this slice defines.
+
+use crate::error::{RemoteError, Result};
+
+/// Opaque bytes carried through a ceremony (challenge, client data, attestation
+/// object, authenticator data, signature). We do not interpret them this slice;
+/// a real verifier will. Stored as owned `Vec<u8>` to keep the states `'static`.
+pub type Bytes = Vec<u8>;
+
+/// Server-issued registration challenge (the `create()` ceremony, step 1).
+///
+/// In a real flow the RP generates a fresh random `challenge`, scopes it to
+/// `rp_id` + `owner`, and remembers it pending the client's attestation. Here it
+/// is an inert typed token; the transition to [`VerifiedAttestation`] only
+/// happens through a [`WebAuthnVerifier`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RegistrationChallenge {
+    /// Owner principal the eventual credential will be bound to.
+    pub owner: String,
+    /// Relying-party id (effective domain) the credential is scoped to.
+    pub rp_id: String,
+    /// Fresh server-random challenge bytes the authenticator must sign over.
+    pub challenge: Bytes,
+}
+
+/// The client's attestation response to a [`RegistrationChallenge`] (step 2,
+/// pre-verification). This is UNTRUSTED input straight off the wire.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AttestationResponse {
+    /// Credential id the authenticator minted.
+    pub credential_id: Bytes,
+    /// CBOR attestation object (`fmt`, `attStmt`, `authData`). Opaque here.
+    pub attestation_object: Bytes,
+    /// `clientDataJSON` the authenticator signed over. Opaque here.
+    pub client_data_json: Bytes,
+}
+
+/// A registration attestation that a [`WebAuthnVerifier`] has ACCEPTED. No
+/// public constructor — only [`WebAuthnVerifier::verify_registration`] can mint
+/// one. Carries the verified credential material a device row is built from.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VerifiedAttestation {
+    owner: String,
+    rp_id: String,
+    credential_id: Bytes,
+    /// The credential public key extracted/verified from the attestation. A real
+    /// verifier fills this from the COSE key in `authData`; the stub never
+    /// reaches here.
+    public_key: Bytes,
+}
+
+impl VerifiedAttestation {
+    pub fn owner(&self) -> &str {
+        &self.owner
+    }
+    pub fn rp_id(&self) -> &str {
+        &self.rp_id
+    }
+    pub fn credential_id(&self) -> &[u8] {
+        &self.credential_id
+    }
+    pub fn public_key(&self) -> &[u8] {
+        &self.public_key
+    }
+}
+
+/// Server-issued assertion challenge (the `get()` ceremony, step 1).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AssertionChallenge {
+    /// Owner principal expected to satisfy this challenge.
+    pub owner: String,
+    pub rp_id: String,
+    /// The credential id the server expects to authenticate (allow-list of one).
+    pub expected_credential_id: Bytes,
+    pub challenge: Bytes,
+}
+
+/// The client's assertion response to an [`AssertionChallenge`] (step 2,
+/// pre-verification). UNTRUSTED input.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AssertionResponse {
+    pub credential_id: Bytes,
+    pub authenticator_data: Bytes,
+    pub client_data_json: Bytes,
+    pub signature: Bytes,
+}
+
+/// An assertion that a [`WebAuthnVerifier`] has ACCEPTED. No public constructor —
+/// only [`WebAuthnVerifier::verify_assertion`] can mint one.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VerifiedAssertion {
+    owner: String,
+    credential_id: Bytes,
+}
+
+impl VerifiedAssertion {
+    pub fn owner(&self) -> &str {
+        &self.owner
+    }
+    pub fn credential_id(&self) -> &[u8] {
+        &self.credential_id
+    }
+}
+
+/// The verification SEAM. A real WebAuthn implementation (e.g. a future port
+/// over the `webauthn-rs` crate) implements this trait; the device/session layer
+/// depends only on the trait, never on a concrete verifier. The trait is the
+/// single choke point through which a verified token can come into existence.
+pub trait WebAuthnVerifier {
+    /// Verify a registration attestation against the challenge it answers.
+    /// Returns a [`VerifiedAttestation`] ONLY on cryptographic success.
+    fn verify_registration(
+        &self,
+        challenge: &RegistrationChallenge,
+        response: &AttestationResponse,
+    ) -> Result<VerifiedAttestation>;
+
+    /// Verify an authentication assertion against the challenge it answers and
+    /// the stored credential public key. Returns a [`VerifiedAssertion`] ONLY on
+    /// cryptographic success.
+    fn verify_assertion(
+        &self,
+        challenge: &AssertionChallenge,
+        response: &AssertionResponse,
+        stored_public_key: &[u8],
+    ) -> Result<VerifiedAssertion>;
+}
+
+/// The DEFERRED verifier shipped this slice. It implements the seam but performs
+/// NO cryptography: every ceremony is REJECTED with
+/// [`RemoteError::WebAuthnVerifierNotWired`]. This is the fail-closed default —
+/// until a real verifier is wired, no attestation or assertion can be accepted,
+/// so no device can be registered and no remote session can be created through
+/// the verified path.
+///
+/// It returns `Err`, never `panic!`/`todo!()`: a missing verifier is a REFUSAL,
+/// not a crash.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct DeferredVerifier;
+
+impl WebAuthnVerifier for DeferredVerifier {
+    fn verify_registration(
+        &self,
+        _challenge: &RegistrationChallenge,
+        _response: &AttestationResponse,
+    ) -> Result<VerifiedAttestation> {
+        // DEFERRED: real attestation verification (fmt/attStmt validation, COSE
+        // key extraction, challenge/origin/rp-id binding) is not implemented.
+        // Fail closed.
+        Err(RemoteError::WebAuthnVerifierNotWired)
+    }
+
+    fn verify_assertion(
+        &self,
+        _challenge: &AssertionChallenge,
+        _response: &AssertionResponse,
+        _stored_public_key: &[u8],
+    ) -> Result<VerifiedAssertion> {
+        // DEFERRED: real assertion verification (signature over
+        // authenticatorData||sha256(clientDataJSON), sign-count regression,
+        // challenge/origin/rp-id binding) is not implemented. Fail closed.
+        Err(RemoteError::WebAuthnVerifierNotWired)
+    }
+}
+
+/// Issue a registration challenge. Validates the owner/rp-id/challenge are
+/// non-empty (a real RP would generate `challenge` from a CSPRNG; here the caller
+/// supplies bytes and we only enforce non-emptiness — fail closed on empty).
+pub fn begin_registration(
+    owner: &str,
+    rp_id: &str,
+    challenge: Bytes,
+) -> Result<RegistrationChallenge> {
+    if owner.trim().is_empty() {
+        return Err(RemoteError::InvalidInput("owner is empty".into()));
+    }
+    if rp_id.trim().is_empty() {
+        return Err(RemoteError::InvalidInput("rp_id is empty".into()));
+    }
+    if challenge.is_empty() {
+        return Err(RemoteError::InvalidInput("challenge is empty".into()));
+    }
+    Ok(RegistrationChallenge {
+        owner: owner.to_string(),
+        rp_id: rp_id.to_string(),
+        challenge,
+    })
+}
+
+/// Issue an assertion challenge for a known credential id.
+pub fn begin_assertion(
+    owner: &str,
+    rp_id: &str,
+    expected_credential_id: Bytes,
+    challenge: Bytes,
+) -> Result<AssertionChallenge> {
+    if owner.trim().is_empty() {
+        return Err(RemoteError::InvalidInput("owner is empty".into()));
+    }
+    if rp_id.trim().is_empty() {
+        return Err(RemoteError::InvalidInput("rp_id is empty".into()));
+    }
+    if expected_credential_id.is_empty() {
+        return Err(RemoteError::InvalidInput(
+            "expected_credential_id is empty".into(),
+        ));
+    }
+    if challenge.is_empty() {
+        return Err(RemoteError::InvalidInput("challenge is empty".into()));
+    }
+    Ok(AssertionChallenge {
+        owner: owner.to_string(),
+        rp_id: rp_id.to_string(),
+        expected_credential_id,
+        challenge,
+    })
+}
+
+/// TEST-ONLY accepting verifier. Compiled ONLY under `cfg(test)`, so it is
+/// absent from every production build — it can never be the wired verifier in
+/// shipped code. It mints verified tokens (via the private constructors that are
+/// in-module) so the device/session HAPPY-PATH KATs can exercise the
+/// post-verification flow without real cryptography. Its existence does NOT open
+/// a public fabrication path: a non-test caller has no way to reach it or to
+/// construct a `VerifiedAttestation`/`VerifiedAssertion` directly.
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct AcceptingTestVerifier;
+
+#[cfg(test)]
+impl WebAuthnVerifier for AcceptingTestVerifier {
+    fn verify_registration(
+        &self,
+        challenge: &RegistrationChallenge,
+        response: &AttestationResponse,
+    ) -> Result<VerifiedAttestation> {
+        Ok(VerifiedAttestation {
+            owner: challenge.owner.clone(),
+            rp_id: challenge.rp_id.clone(),
+            credential_id: response.credential_id.clone(),
+            // A real verifier extracts this from the COSE key in authData; the
+            // test verifier fabricates a deterministic placeholder.
+            public_key: vec![0x04, 0xAA, 0xBB, 0xCC],
+        })
+    }
+
+    fn verify_assertion(
+        &self,
+        challenge: &AssertionChallenge,
+        response: &AssertionResponse,
+        _stored_public_key: &[u8],
+    ) -> Result<VerifiedAssertion> {
+        // Even the test verifier still enforces the credential-id binding, so the
+        // owner-scoping/mismatch KATs are meaningful.
+        if response.credential_id != challenge.expected_credential_id {
+            return Err(RemoteError::UnknownCredential);
+        }
+        Ok(VerifiedAssertion {
+            owner: challenge.owner.clone(),
+            credential_id: response.credential_id.clone(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepting_test_verifier_mints_attestation_for_happy_path() {
+        let chal = begin_registration("owner-1", "friday.local", vec![1, 2, 3]).unwrap();
+        let resp = AttestationResponse {
+            credential_id: vec![7, 7, 7],
+            attestation_object: vec![0xa0],
+            client_data_json: b"{}".to_vec(),
+        };
+        let att = AcceptingTestVerifier
+            .verify_registration(&chal, &resp)
+            .expect("test verifier accepts");
+        assert_eq!(att.owner(), "owner-1");
+        assert_eq!(att.credential_id(), &[7, 7, 7]);
+    }
+
+    fn reg_challenge() -> RegistrationChallenge {
+        begin_registration("owner-1", "friday.local", vec![1, 2, 3, 4]).unwrap()
+    }
+
+    fn att_response() -> AttestationResponse {
+        AttestationResponse {
+            credential_id: vec![9, 9, 9],
+            attestation_object: vec![0xa0],
+            client_data_json: br#"{"type":"webauthn.create"}"#.to_vec(),
+        }
+    }
+
+    #[test]
+    fn deferred_verifier_rejects_registration_fail_closed() {
+        let out = DeferredVerifier.verify_registration(&reg_challenge(), &att_response());
+        assert_eq!(out, Err(RemoteError::WebAuthnVerifierNotWired));
+        assert!(out.is_err(), "deferred verifier must reject, never accept");
+    }
+
+    #[test]
+    fn deferred_verifier_rejects_assertion_fail_closed() {
+        let chal =
+            begin_assertion("owner-1", "friday.local", vec![9, 9, 9], vec![5, 6, 7]).unwrap();
+        let resp = AssertionResponse {
+            credential_id: vec![9, 9, 9],
+            authenticator_data: vec![1],
+            client_data_json: br#"{"type":"webauthn.get"}"#.to_vec(),
+            signature: vec![0xde, 0xad],
+        };
+        let stored_public_key = [0x04u8, 0x01, 0x02];
+        let out = DeferredVerifier.verify_assertion(&chal, &resp, &stored_public_key);
+        assert_eq!(out, Err(RemoteError::WebAuthnVerifierNotWired));
+        assert!(out.is_err(), "deferred verifier must reject, never accept");
+    }
+
+    #[test]
+    fn begin_registration_rejects_empty_inputs() {
+        assert!(begin_registration("", "rp", vec![1]).is_err());
+        assert!(begin_registration("o", "", vec![1]).is_err());
+        assert!(begin_registration("o", "rp", vec![]).is_err());
+    }
+
+    #[test]
+    fn begin_assertion_rejects_empty_inputs() {
+        assert!(begin_assertion("", "rp", vec![1], vec![1]).is_err());
+        assert!(begin_assertion("o", "rp", vec![], vec![1]).is_err());
+        assert!(begin_assertion("o", "rp", vec![1], vec![]).is_err());
+    }
+}

--- a/rust-core/crates/friday-system-remote/tests/fail_closed.rs
+++ b/rust-core/crates/friday-system-remote/tests/fail_closed.rs
@@ -1,0 +1,78 @@
+//! Integration KATs over the PUBLIC API of `friday-system-remote`.
+//!
+//! These run as an external crate, so they see ONLY the public surface — exactly
+//! what a future hub caller would. Crucially, an external crate has NO way to
+//! construct a `VerifiedAttestation`/`VerifiedAssertion` (no public constructor)
+//! and the test-only accepting verifier is `cfg(test)`-gated INSIDE the crate, so
+//! it is invisible here. The only verifier an external caller can reach is the
+//! shipped [`DeferredVerifier`], which fails closed. This file pins that the
+//! default production path REJECTS.
+
+use friday_system_remote::{
+    begin_assertion, begin_registration, AssertionResponse, AttestationResponse, DeferredVerifier,
+    DeviceStore, RemoteError, SessionStore, WebAuthnVerifier,
+};
+
+#[test]
+fn shipped_verifier_rejects_registration_fail_closed() {
+    let chal = begin_registration("owner-1", "friday.local", vec![1, 2, 3]).unwrap();
+    let resp = AttestationResponse {
+        credential_id: vec![7, 7, 7],
+        attestation_object: vec![0xa0],
+        client_data_json: b"{}".to_vec(),
+    };
+    let out = DeferredVerifier.verify_registration(&chal, &resp);
+    assert_eq!(out, Err(RemoteError::WebAuthnVerifierNotWired));
+    assert!(
+        out.is_err(),
+        "shipped verifier must reject (Err), never accept or panic"
+    );
+}
+
+#[test]
+fn shipped_verifier_rejects_assertion_fail_closed() {
+    let chal = begin_assertion("owner-1", "friday.local", vec![7, 7, 7], vec![4, 5, 6]).unwrap();
+    let resp = AssertionResponse {
+        credential_id: vec![7, 7, 7],
+        authenticator_data: vec![1],
+        client_data_json: b"{}".to_vec(),
+        signature: vec![0xde, 0xad],
+    };
+    let out = DeferredVerifier.verify_assertion(&chal, &resp, &[0x04, 0x01]);
+    assert_eq!(out, Err(RemoteError::WebAuthnVerifierNotWired));
+}
+
+#[test]
+fn no_device_can_be_registered_through_the_default_path() {
+    // An external caller cannot mint a VerifiedAttestation: the verifier they can
+    // reach (DeferredVerifier) returns Err, and DeviceStore::register accepts ONLY
+    // a VerifiedAttestation. So the device store stays empty — fail closed end to
+    // end: no verified attestation ⇒ no registration is even expressible.
+    let store = DeviceStore::new();
+    assert!(store.is_empty());
+    // (We cannot construct a VerifiedAttestation here to even attempt register(),
+    // which is the point: the type system blocks the unverified path.)
+}
+
+#[test]
+fn public_input_validation_rejects_empty() {
+    assert!(matches!(
+        begin_registration("", "rp", vec![1]),
+        Err(RemoteError::InvalidInput(_))
+    ));
+    assert!(matches!(
+        begin_assertion("o", "rp", vec![], vec![1]),
+        Err(RemoteError::InvalidInput(_))
+    ));
+}
+
+#[test]
+fn session_store_is_empty_without_a_device() {
+    // SessionStore::create requires a real owner-matched device in the DeviceStore;
+    // with none registered (the fail-closed default), create yields DeviceNotFound.
+    let devices = DeviceStore::new();
+    let mut sessions = SessionStore::new();
+    let out = sessions.create(&devices, "s", "dev-1", "owner-1", 1, 10);
+    assert!(matches!(out, Err(RemoteError::DeviceNotFound(_))));
+    assert!(sessions.is_empty());
+}


### PR DESCRIPTION
## R5 slice-1 — `system.remote.*` foundation (DARK)

Roadmap ref: `TS_RECON_TRUTH_ROADMAP_20260610.md` §3 R5 (`system.remote.*` ×11 — WebAuthn register/assert, passkey, device register/delete, remote sessions create/heartbeat/delete). Substrate before this slice = **NONE**; this is the first slice.

### Truth label — DARK, NOT v1 GO
- **No friday-hub wiring.** `friday-hub/src/lib.rs` and all hub routing/bootstrap are UNTOUCHED. No production caller, no route, no FFI export. (Kept fully dark so it cannot contend with the in-flight S7 friday-hub changes.)
- **Nothing is replaced.** The R5 capability does not exist in production today; this neither replaces a TS surface nor moves the live product.
- It is the typed skeleton + fail-closed seams a later slice builds on — **not** a v1 GO of device/sync.

### What this slice BUILDS (real)
- **`webauthn`** — the two WebAuthn ceremonies (registration / assertion) as TYPED state machines (`RegistrationChallenge → VerifiedAttestation`, `AssertionChallenge → VerifiedAssertion`), plus the verification SEAM (`WebAuthnVerifier` trait).
- **`device`** — `RegisteredDevice` model (id, owner, rp_id, credential_id, public_key, label, created_at, last_seen_at) + in-memory `DeviceStore`: register / lookup / list / touch (forward-only last_seen) / delete, all owner-scoped.
- **`session`** — `RemoteSession` model (id, device_id, owner, created_at, heartbeat_at, expires_at) + in-memory `SessionStore`: create / heartbeat / delete, with monotonic expiry and a fail-closed lifecycle.

### Fail-closed seams
- **WebAuthn (compile-enforced).** `VerifiedAttestation`/`VerifiedAssertion` have NO public constructor — the ONLY way to obtain one is as the `Ok` result of a `WebAuthnVerifier` method. So a caller (even an external `impl WebAuthnVerifier`) cannot fabricate a "verified" token. The shipped `DeferredVerifier` returns `Err(WebAuthnVerifierNotWired)` for every ceremony (an `Err`, **never** a panic/`todo!()`). `DeviceStore::register` accepts ONLY a `VerifiedAttestation`, so with no real verifier wired, **no device can be registered** through the default path.
- **Sessions.** Heartbeat on an EXPIRED session is REFUSED (`SessionExpired`) — an expired session is dead, not revivable. `create` binds to a REAL, owner-matched device (a session id alone never grants control). Cross-owner device/session ops are REFUSED (`OwnerMismatch`).
- No `unwrap`/`expect` on external input; empty/non-positive inputs rejected.

### Explicitly DEFERRED (stub vs real)
1. **Real WebAuthn cryptographic verification.** COSE key parsing, attestation-statement validation, signature / sign-count / origin / rp-id / challenge binding — NONE implemented. A future slice wires a real `WebAuthnVerifier` (e.g. over `webauthn-rs`).
2. **Persistence.** Both stores are IN-MEMORY. A `friday-storage` migration registering `remote_device` / `remote_session` in `HUB_ONLY_TABLES` + a forward-migration KAT is deferred. **Rationale:** that migration edits the shared `friday-storage::schema` file (the `hub_migrations()` vector + `HUB_ONLY_TABLES` + a new `m00NN` fn) — the single highest-contention merge point for ANY concurrent migration lane (m0024 just landed). Keeping storage in-crate keeps this dark lane collision-free.
3. **Assert→session/presence linkage.** The assertion ceremony's output (`VerifiedAssertion`) is DEFINED but currently UNCONSUMED: `session::create` authorizes off the `DeviceStore` owner-match directly, and `device::touch_for_owner` is not yet driven by a successful assertion. The register path is coherent end-to-end (verify → register); the assert path is a defined-but-unassembled skeleton this slice.
4. **Hub route wiring / FFI / CSPRNG challenge issuance / gate+principal integration** for the 11 `system.remote.*` routes — deferred, operator-gated.
5. **Passkey-specific flows** (discoverable credentials / resident keys / UV policy) beyond the shared register/assert shape.

### Verification
- `cargo build --workspace` ✅ (45s, clean)
- `cargo test -p friday-system-remote` ✅ **24 passed / 0 failed** (19 unit + 5 integration)
- `cargo clippy -p friday-system-remote --all-targets -- -D warnings` ✅ 0 warnings
- `cargo test -p friday-storage -p friday-arch-tests` ✅ green (storage 62/0, no migration added)
- `cargo test --workspace` ✅ 0 failures across the workspace
- Changed files: only `rust-core/Cargo.toml` (one `members` line), `Cargo.lock` (the one new package entry), and the new `crates/friday-system-remote/` crate. **Zero friday-hub touch.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)