### PR TITLE
fix(ts-retirement): TS-R4/G3 — method-guard session sweep + memory-extraction (close ARMED quota-spending bypass)

### DIFF
--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -3727,6 +3727,12 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
     db: deps.db,
     idGenerator: deps.idGenerator,
     nowIso: deps.nowIso,
+    // TS Runtime Retirement (TS-R4/G3 method-level guard): plumb the same
+    // test-oracle flag the route honors so `sweepLifecycle` fails closed for
+    // every non-route caller unless explicitly enabled. Only used when the hub
+    // does not pass its own sessionService (e.g. standalone API runtime / the
+    // api-test-server helper). Production leaves this unset.
+    allowTestOnlySessionExecution: deps.allowTestOnlySessionExecution,
   });
 
   async function loadSessionHistoryMessages(sessionKey: string): Promise<FridaySessionMessageRecord[]> {
@@ -4005,6 +4011,13 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
       providerService: deps.providerService,
       idGenerator: deps.idGenerator,
       nowIso: deps.nowIso,
+      // TS Runtime Retirement (TS-R4/G3 method-level guard): plumb the same
+      // test-oracle flag the route honors so the extraction mutators fail closed
+      // for every non-route caller (this is the route-facing instance; the
+      // scheduler uses a separate instance in hub bootstrap) unless explicitly
+      // enabled. Production leaves this unset.
+      allowTestOnlySessionMemoryExtractionExecution:
+        deps.allowTestOnlySessionMemoryExtractionExecution,
     });
   }
 

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -2363,6 +2363,13 @@ export async function createFridayHub(
     db: stateRuntime!.sqlite,
     idGenerator,
     nowIso,
+    // TS Runtime Retirement (TS-R4/G3 method-level guard): production leaves
+    // this unset (config flag undefined) so `sweepLifecycle` is fail-closed for
+    // the `session-lifecycle-sweep` scheduler job (which bypasses the HTTP route
+    // guard), not just the route. This same instance is also passed to the API
+    // runtime, so the route guard and the method guard stay consistent.
+    // Test-oracle hub configs set it true to exercise the legacy sweep.
+    allowTestOnlySessionExecution: config.allowTestOnlySessionExecution,
   });
 
   // Build agent tool registry (exec, read, write, edit, web_fetch, browser, xhs, + new tools)
@@ -7233,6 +7240,15 @@ export async function createFridayHub(
       providerService,
       idGenerator,
       nowIso,
+      // TS Runtime Retirement (TS-R4/G3 method-level guard): production leaves
+      // this unset so extractFromSession/extractSpecificMessages/
+      // retryFailedExtractions are fail-closed for the `session-memory-extraction`
+      // worker job, the `session-lifecycle-sweep` job, and the agent
+      // memory-extract tool — all of which reach this instance off-route,
+      // bypassing the HTTP route guard. This stops the armed quota-spending
+      // inline extraction on next deploy. Test-oracle hub configs set it true.
+      allowTestOnlySessionMemoryExtractionExecution:
+        config.allowTestOnlySessionMemoryExtractionExecution,
     });
   }
 

--- a/src/sessions/services/friday-session-memory-extraction-service.ts
+++ b/src/sessions/services/friday-session-memory-extraction-service.ts
@@ -334,8 +334,38 @@ export function createFridaySessionMemoryExtractionService(
 
   // ─── Service implementation ───
 
+  // ─── TS Runtime Retirement (TS-R4/G3): METHOD-level fail-closed guard ───
+  // The `session-memory-extraction` worker job and the `session-lifecycle-sweep`
+  // job (via createFridaySessionLifecycleJob → extractFromSession) reach these
+  // mutators directly, bypassing the HTTP route guard
+  // (assertSessionMemoryExtractionTestOracleAllowed in friday-session-routes);
+  // the agent memory-extract tool is a further off-route caller. This fails ALL
+  // non-route callers closed BEFORE any session read, provider/LLM call
+  // (worker inline path → processInline → llmClient), or memory/job DB write,
+  // unless the explicit test-oracle flag is set. The worker job's per-job
+  // try/catch records markFailed (terminal) on this throw, so dormant-but-armed
+  // queued jobs churn to failed under fail-closed rather than spending quota.
+  // Never default this flag on in production. getExtractionStatus (read) stays
+  // live, mirroring the route surface.
+  function assertMemoryExtractionAllowed(): void {
+    if (deps.allowTestOnlySessionMemoryExtractionExecution !== true) {
+      throw new FridayDomainError(
+        "TS_RUNTIME_SESSION_MEMORY_EXTRACTION_RETIRED",
+        "TypeScript session memory extraction is fail-closed in default/live runtime; use the Rust-owned session_memory_extraction entrypoint.",
+        {
+          httpStatus: 503,
+          details: {
+            classification: "fail_closed",
+            replacement: "rust_owned_session_memory_extraction_entrypoint_required",
+          },
+        },
+      );
+    }
+  }
+
   return {
     async extractFromSession(sessionKey, options) {
+      assertMemoryExtractionAllowed();
       const session = await deps.sessionService.getSession(sessionKey);
       if (!session) {
         throw new FridayDomainError(
@@ -436,6 +466,7 @@ export function createFridaySessionMemoryExtractionService(
     },
 
     async extractSpecificMessages(sessionKey, messageIds, options) {
+      assertMemoryExtractionAllowed();
       if (!messageIds.length) {
         throw new FridayDomainError(
           FRIDAY_SESSION_MEMORY_EXTRACTION_ERROR_CODES.INVALID_INPUT,
@@ -561,6 +592,7 @@ export function createFridaySessionMemoryExtractionService(
     },
 
     async retryFailedExtractions(sessionKey) {
+      assertMemoryExtractionAllowed();
       const result: FridaySessionMemoryRetryResult = {
         sessionsQueued: [],
         resetMessageCount: 0,

--- a/src/sessions/services/friday-session-memory-extraction-service.types.ts
+++ b/src/sessions/services/friday-session-memory-extraction-service.types.ts
@@ -40,4 +40,19 @@ export interface CreateFridaySessionMemoryExtractionServiceDeps {
   providerService: FridayProviderService;
   idGenerator: () => string;
   nowIso: () => string;
+  /**
+   * TS Runtime Retirement (TS-R4/G3) — METHOD-level fail-closed guard for the
+   * memory-extraction mutators (`extractFromSession`, `extractSpecificMessages`,
+   * `retryFailedExtractions`). Default/live runtime must leave this unset so
+   * these methods fail closed for ALL callers — including the
+   * `session-memory-extraction` worker job and the `session-lifecycle-sweep`
+   * job (both bypass the HTTP route guard
+   * `assertSessionMemoryExtractionTestOracleAllowed`), plus the agent
+   * memory-extract tool. Guarding here stops the armed, quota-spending inline
+   * extraction (worker → inline → processInline → LLM provider call) before any
+   * provider call or memory/job DB write. Test-oracle harnesses set it `true` to
+   * exercise the legacy extraction. `getExtractionStatus` (read) stays live;
+   * only the mutators are retired, mirroring the route surface.
+   */
+  allowTestOnlySessionMemoryExtractionExecution?: boolean;
 }

--- a/src/sessions/services/friday-session-service.ts
+++ b/src/sessions/services/friday-session-service.ts
@@ -541,6 +541,29 @@ export function createFridaySessionService(
     },
 
     async sweepLifecycle(): Promise<FridaySessionSweepResult> {
+      // ─── TS Runtime Retirement (TS-R4/G3): METHOD-level fail-closed guard ───
+      // The `session-lifecycle-sweep` scheduler job (friday-hub-bootstrap →
+      // createFridaySessionLifecycleJob) reaches this method directly,
+      // bypassing the HTTP route guard (assertSessionTestOracleAllowed in
+      // friday-session-routes). Guarding here fails ALL non-route callers closed
+      // BEFORE the lifecycle write transaction (idle/archive/prune/hard-delete)
+      // unless the explicit test-oracle flag is set. The scheduler's executeJob
+      // catches this throw, records markFailed, and reschedules — no crash, no
+      // partial sweep. Never default this flag on in production.
+      if (deps.allowTestOnlySessionExecution !== true) {
+        throw new FridayDomainError(
+          "TS_RUNTIME_SESSION_RETIRED",
+          "TypeScript session execution is fail-closed in default/live runtime; use the Rust-owned session_lifecycle entrypoint.",
+          {
+            httpStatus: 503,
+            details: {
+              classification: "fail_closed",
+              replacement: "rust_owned_session_lifecycle_entrypoint_required",
+            },
+          },
+        );
+      }
+
       const now = deps.nowIso();
       const nowMs = new Date(now).getTime();
 

--- a/src/sessions/services/friday-session-service.types.ts
+++ b/src/sessions/services/friday-session-service.types.ts
@@ -73,4 +73,14 @@ export interface CreateFridaySessionServiceDeps {
   db: FridaySqliteLayer;
   idGenerator: () => string;
   nowIso: () => string;
+  /**
+   * TS Runtime Retirement (TS-R4/G3) — METHOD-level fail-closed guard for the
+   * mutating session-lifecycle sweep. Default/live runtime must leave this unset
+   * so `sweepLifecycle` fails closed for ALL callers — including the
+   * `session-lifecycle-sweep` scheduler job, which bypasses the HTTP route guard
+   * (`assertSessionTestOracleAllowed` in friday-session-routes). Test-oracle
+   * harnesses set it `true` to exercise the legacy in-process sweep. Reads stay
+   * live; only the sweep mutation is retired, mirroring the route surface.
+   */
+  allowTestOnlySessionExecution?: boolean;
 }

--- a/test/integration/sessions/friday-session-memory-extraction-integration.test.ts
+++ b/test/integration/sessions/friday-session-memory-extraction-integration.test.ts
@@ -223,6 +223,9 @@ describe("Session memory extraction — integration", () => {
       providerService: createMockProviderService(),
       idGenerator,
       nowIso: () => NOW,
+      // TS-R4/G3: opt in to the legacy extraction mutators (fail-closed by
+      // default in live runtime).
+      allowTestOnlySessionMemoryExtractionExecution: true,
     });
   });
 

--- a/test/unit/jobs/sessions/friday-session-lifecycle-job.test.ts
+++ b/test/unit/jobs/sessions/friday-session-lifecycle-job.test.ts
@@ -21,6 +21,9 @@ describe("FridaySessionLifecycleJob", () => {
       db,
       idGenerator: idGen,
       nowIso: () => new Date(BASE_TIME).toISOString(),
+      // TS-R4/G3: the lifecycle job drives sweepLifecycle, which is fail-closed
+      // by default in live runtime; opt in so the job test exercises the sweep.
+      allowTestOnlySessionExecution: true,
     });
 
     mockExtractionService = {
@@ -67,6 +70,7 @@ describe("FridaySessionLifecycleJob", () => {
       db,
       idGenerator: idGen,
       nowIso: futureIso,
+      allowTestOnlySessionExecution: true,
     });
 
     const job = createFridaySessionLifecycleJob({
@@ -95,6 +99,7 @@ describe("FridaySessionLifecycleJob", () => {
       db,
       idGenerator: idGen,
       nowIso: futureIso,
+      allowTestOnlySessionExecution: true,
     });
 
     vi.mocked(mockExtractionService.extractFromSession).mockRejectedValue(

--- a/test/unit/sessions/services/friday-session-memory-extraction-service.test.ts
+++ b/test/unit/sessions/services/friday-session-memory-extraction-service.test.ts
@@ -100,6 +100,10 @@ describe("FridaySessionMemoryExtractionService", () => {
       providerService,
       idGenerator: idGen,
       nowIso: () => NOW,
+      // TS-R4/G3: opt in to the legacy extraction mutators so this suite
+      // exercises the real path. Default/live runtime leaves this unset
+      // (fail-closed) — see the dedicated retirement-guard suite.
+      allowTestOnlySessionMemoryExtractionExecution: true,
     });
 
     // Create a test session with messages

--- a/test/unit/sessions/services/friday-session-memory-retirement-guard.test.ts
+++ b/test/unit/sessions/services/friday-session-memory-retirement-guard.test.ts
@@ -1,0 +1,287 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { FridaySqliteLayer } from "#state";
+import { FridayDomainError } from "#errors";
+import { createTestDb, createTestIdGenerator } from "../../satellites/_helpers/create-test-db.helper.js";
+import {
+  createFridaySessionService,
+  createFridaySessionMemoryExtractionService,
+  createFridaySessionMemoryExtractionRepository,
+  FRIDAY_SESSION_IDLE_TIMEOUT_MS,
+} from "#sessions";
+import type {
+  FridaySessionService,
+  FridaySessionMemoryExtractionService,
+} from "#sessions";
+import type { FridayMemoryService } from "#memory";
+import type { FridayProviderService } from "#providers";
+
+/**
+ * TS Runtime Retirement (TS-R4/G3) — METHOD-level guards for the session
+ * lifecycle sweep and the memory-extraction mutators.
+ *
+ * The route-level retirement (friday-session-routes) only guarded the HTTP
+ * surface. Two default-on scheduler jobs reach these service methods directly,
+ * bypassing the route guard:
+ *   - `session-lifecycle-sweep` (120s) → sessionService.sweepLifecycle()
+ *   - `session-memory-extraction` worker (60s) →
+ *      extractionService.extractFromSession / extractSpecificMessages
+ *   - lifecycle job also → extractionService.extractFromSession (enqueue)
+ * Plus the agent memory-extract tool, an off-route caller of the extraction
+ * mutators. These jobs are dormant only because there are zero idle sessions;
+ * they fire and spend provider quota the instant a session idles.
+ *
+ * These tests prove the guard now lives on the METHOD: in default/live config
+ * (test-oracle flags unset) the methods fail closed BEFORE any provider/LLM
+ * call or DB write — no extraction job is enqueued, no memory item is stored,
+ * no session is transitioned. The explicit test-oracle flag re-opens the legacy
+ * path. Reads (getExtractionStatus, listSessions, getSession) stay live.
+ */
+
+const NOW = "2026-02-18T10:00:00.000Z";
+const SESSION_KEY = "discord:default:user1";
+
+function createBoobyTrappedProviderService(): FridayProviderService {
+  return {
+    listProviders: vi.fn().mockResolvedValue([]),
+    getProvider: vi.fn().mockResolvedValue(null),
+    createProvider: vi.fn(),
+    updateProvider: vi.fn(),
+    deleteProvider: vi.fn(),
+    validateProvider: vi.fn(),
+    getRoutingConfig: vi.fn(),
+    setRoutingConfig: vi.fn(),
+    resolveRoute: vi.fn(),
+    // Any provider/LLM call while fail-closed is a leak — blow up loudly.
+    runWithFallback: vi.fn(() => {
+      throw new Error("runWithFallback must not run when extraction is fail-closed");
+    }),
+    recordUsage: vi.fn(),
+    getUsageSummary: vi.fn(),
+    getBudgetStatus: vi.fn(),
+    setBudgetConfig: vi.fn(),
+  } as unknown as FridayProviderService;
+}
+
+function createBoobyTrappedMemoryService(): FridayMemoryService {
+  return {
+    store: vi.fn(() => {
+      throw new Error("memoryService.store must not run when extraction is fail-closed");
+    }),
+    search: vi.fn().mockResolvedValue([]),
+    get: vi.fn().mockResolvedValue(null),
+    list: vi.fn().mockResolvedValue([]),
+    delete: vi.fn().mockResolvedValue(true),
+    prune: vi.fn().mockResolvedValue({ deletedCount: 0, deletedIds: [], dryRun: false }),
+  } as unknown as FridayMemoryService;
+}
+
+describe("Session lifecycle sweep TS-retirement method guard", () => {
+  const allocatedDbs: FridaySqliteLayer[] = [];
+
+  afterEach(() => {
+    while (allocatedDbs.length > 0) {
+      allocatedDbs.pop()!.close();
+    }
+    vi.restoreAllMocks();
+  });
+
+  function buildSessionService(
+    nowIso: () => string,
+    allowTestOnlySessionExecution?: boolean,
+    existingDb?: FridaySqliteLayer,
+  ): { db: FridaySqliteLayer; service: FridaySessionService } {
+    const db = existingDb ?? createTestDb();
+    if (!existingDb) {
+      allocatedDbs.push(db);
+    }
+    const service = createFridaySessionService({
+      db,
+      idGenerator: createTestIdGenerator(),
+      nowIso,
+      ...(allowTestOnlySessionExecution === undefined
+        ? {}
+        : { allowTestOnlySessionExecution }),
+    });
+    return { db, service };
+  }
+
+  async function seedIdleEligibleSession(service: FridaySessionService): Promise<void> {
+    await service.createSession({ channel: "discord", chatId: "user1", userId: "user1" });
+    await service.addMessage(SESSION_KEY, { role: "user", content: "Hello" });
+  }
+
+  it("fails closed by default: throws 503 fail_closed and transitions no session", async () => {
+    // Seed an active session whose last activity is at the BASE clock, then run
+    // the guarded sweep under a clock well past the idle timeout (default
+    // fail-closed). A live sweep WOULD transition it active→idle; the guard
+    // must prevent any such transition.
+    const { db, service: baseService } = buildSessionService(() => NOW, true);
+    await seedIdleEligibleSession(baseService);
+
+    const futureIso = () =>
+      new Date(Date.parse(NOW) + FRIDAY_SESSION_IDLE_TIMEOUT_MS + 60_000).toISOString();
+    // Reuse the same db; default fail-closed (flag unset) on the sweep service.
+    const { service: futureService } = buildSessionService(futureIso, undefined, db);
+
+    const activeBefore = await futureService.listSessions({ status: "active" });
+    expect(activeBefore.length).toBe(1);
+
+    let caught: unknown;
+    try {
+      await futureService.sweepLifecycle();
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(FridayDomainError);
+    const domainError = caught as FridayDomainError;
+    expect(domainError.code).toBe("TS_RUNTIME_SESSION_RETIRED");
+    expect(domainError.httpStatus).toBe(503);
+    expect(domainError.details?.classification).toBe("fail_closed");
+
+    // No session transitioned: the idle-eligible session is still active.
+    const activeAfter = await futureService.listSessions({ status: "active" });
+    expect(activeAfter.length).toBe(1);
+    const idleAfter = await futureService.listSessions({ status: "idle" });
+    expect(idleAfter.length).toBe(0);
+  });
+
+  it("fails closed with explicit allowTestOnlySessionExecution=false", async () => {
+    const { service } = buildSessionService(() => NOW, false);
+    await expect(service.sweepLifecycle()).rejects.toMatchObject({
+      code: "TS_RUNTIME_SESSION_RETIRED",
+    });
+  });
+
+  it("runs the legacy sweep when allowTestOnlySessionExecution=true", async () => {
+    const { service } = buildSessionService(() => NOW, true);
+    // No throw; returns a sweep result with the expected counter shape.
+    const result = await service.sweepLifecycle();
+    expect(result).toMatchObject({
+      idledCount: expect.any(Number),
+      archivedCount: expect.any(Number),
+      prunedCount: expect.any(Number),
+      hardDeletedCount: expect.any(Number),
+    });
+  });
+});
+
+describe("Session memory extraction TS-retirement method guard", () => {
+  let db: FridaySqliteLayer;
+  let sessionService: FridaySessionService;
+  let providerService: FridayProviderService;
+  let memoryService: FridayMemoryService;
+  const extractionRepo = createFridaySessionMemoryExtractionRepository();
+
+  beforeEach(async () => {
+    db = createTestDb();
+    const idGen = createTestIdGenerator();
+    sessionService = createFridaySessionService({
+      db,
+      idGenerator: idGen,
+      nowIso: () => NOW,
+      allowTestOnlySessionExecution: true,
+    });
+    providerService = createBoobyTrappedProviderService();
+    memoryService = createBoobyTrappedMemoryService();
+    // Seed a session with pending messages so the inline path would have work.
+    await sessionService.createSession({ channel: "discord", chatId: "user1", userId: "user1" });
+    await sessionService.addMessage(SESSION_KEY, { role: "user", content: "remember dark mode" });
+  });
+
+  afterEach(() => {
+    db.close();
+    vi.restoreAllMocks();
+  });
+
+  function buildExtractionService(
+    allowTestOnlySessionMemoryExtractionExecution?: boolean,
+  ): FridaySessionMemoryExtractionService {
+    return createFridaySessionMemoryExtractionService({
+      db,
+      sessionService,
+      memoryService,
+      providerService,
+      idGenerator: createTestIdGenerator(),
+      nowIso: () => NOW,
+      ...(allowTestOnlySessionMemoryExtractionExecution === undefined
+        ? {}
+        : { allowTestOnlySessionMemoryExtractionExecution }),
+    });
+  }
+
+  function queuedJobCount(): number {
+    return db.withReadConnection((d) =>
+      extractionRepo.countBySessionAndStatus(d, SESSION_KEY, ["queued", "running"]),
+    );
+  }
+
+  it("extractFromSession fails closed by default: 503, no provider call, no job enqueued, no memory store", async () => {
+    const extractionService = buildExtractionService();
+
+    let caught: unknown;
+    try {
+      await extractionService.extractFromSession(SESSION_KEY, { trigger: "auto", mode: "queue" });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(FridayDomainError);
+    const domainError = caught as FridayDomainError;
+    expect(domainError.code).toBe("TS_RUNTIME_SESSION_MEMORY_EXTRACTION_RETIRED");
+    expect(domainError.httpStatus).toBe(503);
+    expect(domainError.details?.classification).toBe("fail_closed");
+
+    expect(providerService.runWithFallback).not.toHaveBeenCalled();
+    expect(memoryService.store).not.toHaveBeenCalled();
+    expect(queuedJobCount()).toBe(0);
+  });
+
+  it("extractFromSession inline mode fails closed before any provider/LLM call", async () => {
+    const extractionService = buildExtractionService();
+    await expect(
+      extractionService.extractFromSession(SESSION_KEY, { trigger: "manual", mode: "inline" }),
+    ).rejects.toMatchObject({ code: "TS_RUNTIME_SESSION_MEMORY_EXTRACTION_RETIRED" });
+    expect(providerService.runWithFallback).not.toHaveBeenCalled();
+    expect(memoryService.store).not.toHaveBeenCalled();
+  });
+
+  it("extractSpecificMessages fails closed by default before any side effect", async () => {
+    const extractionService = buildExtractionService();
+    await expect(
+      extractionService.extractSpecificMessages(SESSION_KEY, ["msg-1"], { mode: "inline" }),
+    ).rejects.toMatchObject({ code: "TS_RUNTIME_SESSION_MEMORY_EXTRACTION_RETIRED" });
+    expect(providerService.runWithFallback).not.toHaveBeenCalled();
+    expect(memoryService.store).not.toHaveBeenCalled();
+    expect(queuedJobCount()).toBe(0);
+  });
+
+  it("retryFailedExtractions fails closed by default and queues no retry job", async () => {
+    const extractionService = buildExtractionService();
+    await expect(
+      extractionService.retryFailedExtractions(SESSION_KEY),
+    ).rejects.toMatchObject({ code: "TS_RUNTIME_SESSION_MEMORY_EXTRACTION_RETIRED" });
+    expect(queuedJobCount()).toBe(0);
+  });
+
+  it("fails closed with explicit allowTestOnlySessionMemoryExtractionExecution=false", async () => {
+    const extractionService = buildExtractionService(false);
+    await expect(
+      extractionService.extractFromSession(SESSION_KEY, { trigger: "auto", mode: "queue" }),
+    ).rejects.toMatchObject({ code: "TS_RUNTIME_SESSION_MEMORY_EXTRACTION_RETIRED" });
+  });
+
+  it("enqueues a job when allowTestOnlySessionMemoryExtractionExecution=true (legacy path)", async () => {
+    const extractionService = buildExtractionService(true);
+    const result = await extractionService.extractFromSession(SESSION_KEY, {
+      trigger: "auto",
+      mode: "queue",
+    });
+    // Queue mode only writes a job row — no provider/LLM call, no memory store.
+    expect(result.queued).toBe(true);
+    expect(queuedJobCount()).toBe(1);
+    expect(providerService.runWithFallback).not.toHaveBeenCalled();
+    expect(memoryService.store).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/sessions/services/friday-session-service.test.ts
+++ b/test/unit/sessions/services/friday-session-service.test.ts
@@ -26,6 +26,10 @@ describe("FridaySessionService", () => {
       db,
       idGenerator: createTestIdGenerator(),
       nowIso: () => NOW,
+      // TS-R4/G3: opt in to the legacy sweep so the sweepLifecycle suites
+      // exercise the real path. Default/live runtime leaves this unset
+      // (fail-closed) — see the dedicated retirement-guard suite below.
+      allowTestOnlySessionExecution: true,
     });
   });
 


### PR DESCRIPTION
## Gap G3 (TS_RECON_TRUTH_ROADMAP_20260610 §2 row G3) — ARMED, quota-spending

Two **default-on scheduler jobs** reach the session lifecycle / memory-extraction service methods **directly, bypassing the HTTP route guards** (the route-only-guard defect). They are dormant now only because there are zero idle sessions — they fire and spend provider quota the instant a session idles:

- `session-lifecycle-sweep` (120s, `friday-hub-bootstrap.ts` → `createFridaySessionLifecycleJob`) → `sessionService.sweepLifecycle()` + `extractionService.extractFromSession` (enqueue on newly-idle sessions)
- `session-memory-extraction` worker (60s) → `extractionService.extractFromSession` / `extractSpecificMessages` (**inline mode → `processInline` → LLM provider call**, the actual quota spend)

The agent memory-extract tool is a further off-route caller of the extraction mutators.

## Fix — METHOD-level fail-closed guards, mirroring #628 (`e6b39186`)

- `sessionService.sweepLifecycle` → throws **`TS_RUNTIME_SESSION_RETIRED`** (503, `classification: fail_closed`) **before the lifecycle write transaction**, gated by the existing `allowTestOnlySessionExecution` flag.
- `extractionService.extractFromSession` / `extractSpecificMessages` / `retryFailedExtractions` → throw **`TS_RUNTIME_SESSION_MEMORY_EXTRACTION_RETIRED`** (503, `fail_closed`) **before any session read, provider/LLM call, or memory/job DB write**, gated by the existing `allowTestOnlySessionMemoryExtractionExecution` flag. `getExtractionStatus` (read) stays live, mirroring the route surface.

Error families + replacement strings match the existing route guards in `friday-session-routes.ts` exactly.

## Flag plumbing (no new flags)

Both flags already thread `service ← FridayHubConfig ← bootstrap` and through `mock-env`/`real-env`/`api-test-server` (default **TRUE** in test, **unset/FALSE (fail-closed)** in prod) — they previously only fed the route guards. This slice consumes them at the **four** service construction sites so the method guard and route guard stay consistent:
- hub bootstrap: `hubSessionService` (2362), `sessionExtractionService` (7229)
- api-runtime: session-service fallback (3726), extraction-service (4001)

**No scheduler registration change. No happy-path change beyond the guard.**

## Scheduler safety (no crash)

The scheduler's `executeJob` fully catches a thrown retirement error (`markFailed` + reschedule) — no unhandled rejection, no scheduler crash. The worker job's per-job try/catch records `markFailed` (terminal), so any pre-existing **queued** extraction jobs churn to *failed* under fail-closed rather than spending quota.

## CI / chromium e2e

The flags default **true** in `mock-env` (`allowTestOnlySession*`), which flow into the new bootstrap service threading, so a scheduler-fired sweep inside any mock-env-booted **`test:e2e:ui` (chromium)** test will not throw. No `test/e2e/ui/` test hits the sweep/memory routes. (Verified by grep + the flag chain; chromium not run locally.)

## Behavior change on next deploy (honest)

- **Stops** the armed quota-spending **inline** memory extraction.
- **Freezes** TS session lifecycle maintenance (idle/archive/prune/hard-delete) in prod — broader than "stop quota". Both pending Rust ownership.
- Reads stay live. `createSession`/`addMessage` (live channel-ingestion path) intentionally **not** guarded.

## Gates

- `tsc` + UI build clean; `lint` **0 errors**.
- New retirement-guard suite (9 cases: default fail-closed w/ booby-trapped provider+memory + no-job-enqueued + no-session-transition, explicit-false, flag-true legacy path — both surfaces). Existing session/extraction/job suites opt in explicitly.
- Full default-project `npm test`: **943 files / 12751 passed**, 1 fail = the **pre-existing** `friday-secret-crypto` keychain machine-env artifact (test + crypto source byte-identical to `origin/main`; no security/crypto file touched; green in CI).
- `check:secret-patterns` + `detect-secrets-hook` clean.
- `check:ts-runtime-retirement`: **status=passed, routeCount=584 unchanged, fail_closed=237 unchanged, blockerFamilies=[]**, **manifest byte-unchanged** (adds no route).

## Truth label

These methods become method-fenced **live-pending-Rust-ownership**; nothing is replaced and this is **NOT v1 GO** progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>