### PR TITLE
fix(ts-retirement): TS-R4/G4+G5 — method-guard workflow run-control (resume/retry/cancel) + channel session-mirror write (close LATENT bypasses)

### DIFF
--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -8243,10 +8243,45 @@ export async function createFridayHub(
       });
 
       // ── Channel Orchestration Engine (Initiative A-WIRE) ──
+      // TS Runtime Retirement (G5 completeness): this sessionDeps object is wired
+      // SOLELY into the channel orchestration engine (channelOrchestrationEngine
+      // below; the API/non-channel engine uses its own separate engineSessionDeps
+      // in friday-api-runtime). On the channel path the engine's run-executor
+      // control-plane writes (finalizeControlPlane / planning return+reject) and
+      // any turn-preparer write persist assistant/user session messages via this
+      // addMessage BEFORE the agent-runtime executeRun guard, so a deterministic /
+      // control-plane channel message would otherwise bypass the channel-mirror
+      // (G5) guard placed at the handler boundary. We close that bypass by applying
+      // the IDENTICAL fail-closed check here, with the SAME family + flag as the
+      // retired session route and the handler mirror (TS_RUNTIME_SESSION_RETIRED,
+      // allowTestOnlySessionExecution). The check returns a rejected promise (never
+      // throws synchronously) so the run-executor's `.catch(() => undefined)` on
+      // each control-plane write degrades cleanly under flag-unset — no half-state,
+      // no unhandled rejection, turn does not crash (mirrors the handler's chained
+      // non-fatal .catch). Production leaves the flag unset → channel-engine session
+      // writes fail-closed; test-oracle harnesses opt in. Guarding here (the
+      // channel-only caller boundary) — NOT addMessage itself — leaves the many
+      // legitimate non-channel addMessage callers untouched.
       const channelEngineSessionDeps = {
         getMessages: (key: string, limit?: number) => hubSessionService.getMessages(key, limit),
-        addMessage: (key: string, msg: Parameters<typeof hubSessionService.addMessage>[1]) =>
-          hubSessionService.addMessage(key, msg),
+        addMessage: (key: string, msg: Parameters<typeof hubSessionService.addMessage>[1]) => {
+          if (config.allowTestOnlySessionExecution !== true) {
+            return Promise.reject(
+              new FridayDomainError(
+                "TS_RUNTIME_SESSION_RETIRED",
+                "TypeScript session execution is fail-closed in default/live runtime; use the Rust-owned session_lifecycle entrypoint.",
+                {
+                  httpStatus: 503,
+                  details: {
+                    classification: "fail_closed",
+                    replacement: "rust_owned_session_lifecycle_entrypoint_required",
+                  },
+                },
+              ),
+            );
+          }
+          return hubSessionService.addMessage(key, msg);
+        },
         getConversationFocus: (key: string) => hubSessionService.getConversationFocus(key),
         setConversationFocus: (key: string, state: Parameters<typeof hubSessionService.setConversationFocus>[1]) =>
           hubSessionService.setConversationFocus(key, state).then(() => undefined),

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -8323,8 +8323,44 @@ export async function createFridayHub(
           classifyExecution: classifyFridayExecution,
           capabilitySnapshotGetter: getAgentCapabilitySnapshot as unknown as CreateFridayEngineTurnPreparerDeps["capabilitySnapshotGetter"],
           taskStatusSnapshotGetter: getAgentTaskStatusSnapshot as unknown as CreateFridayEngineTurnPreparerDeps["taskStatusSnapshotGetter"],
+          // persistCompactionEvidence is the THIRD channel-engine session/memory-state
+          // WRITE — separately wired (NOT part of channelEngineSessionDeps), so the
+          // addMessage / setConversationFocus guards above do NOT cover it. The
+          // turn-preparer runs BEFORE dispatch / before the agent-runtime executeRun
+          // guard and, when buildSelectedBlockCompactionEvidence(selectedBlocks) is
+          // non-null, calls this to write a session+runId-keyed derived-state row into
+          // friday_agent_context_replay_entries (summaryText / decisions / todos /
+          // openQuestions / toolFailures / fileOperations) via db.withWriteTransaction →
+          // appendCompactionSummary. Reachable on a bound channel turn even while
+          // addMessage / setConversationFocus reject (proven RED). Apply the IDENTICAL
+          // fail-closed check (SAME family + flag, no new flag) so the COMPLETE
+          // channel-engine session/memory-write surface is fenced under the production
+          // default. The check returns a rejected promise (never throws synchronously);
+          // the turn-preparer wraps the call in `.catch(() => undefined)`
+          // (friday-engine-turn-preparer.ts ~455-463) so flow degrades cleanly — no
+          // half-state, no unhandled rejection, the turn does not crash. Production leaves
+          // the flag unset → channel-engine compaction-evidence writes fail-closed;
+          // test-oracle harnesses opt in. The sink's OTHER consumers (agent runtime parent
+          // + sub-agent, bootstrap ~4851 / ~5172) are downstream of executeRun:803 and
+          // already fenced by allowTestOnlyAgentRunExecution — this closure is the only
+          // channel path to the sink BEFORE that guard.
           persistCompactionEvidence: agentCompactionContextReplaySink
             ? async (input) => {
+              if (config.allowTestOnlySessionExecution !== true) {
+                return Promise.reject(
+                  new FridayDomainError(
+                    "TS_RUNTIME_SESSION_RETIRED",
+                    "TypeScript session execution is fail-closed in default/live runtime; use the Rust-owned session_lifecycle entrypoint.",
+                    {
+                      httpStatus: 503,
+                      details: {
+                        classification: "fail_closed",
+                        replacement: "rust_owned_session_lifecycle_entrypoint_required",
+                      },
+                    },
+                  ),
+                );
+              }
               await agentCompactionContextReplaySink.persist({
                 sessionKey: input.sessionKey,
                 runId: input.runId,
@@ -8332,6 +8368,7 @@ export async function createFridayHub(
                 blocks: input.blocks,
                 compactedAt: nowIso(),
               });
+              return undefined;
             }
             : undefined,
         },

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -8602,6 +8602,39 @@ export async function createFridayHub(
               details: payload,
             }).catch((err: unknown) => warnHubBootstrapOnce(`[friday] audit-append: ${err instanceof Error ? err.message : String(err)}`));
           };
+          // ─── TS Runtime Retirement (G5): channel-mirror write boundary guard ───
+          // The channel webhook ingress → channelMessageHandler path mirrors
+          // inbound/outbound channel traffic into the TS session store via
+          // FridaySessionService.addMessage (withWriteTransaction). The session
+          // ROUTE write is already retired (assertSessionTestOracleAllowed →
+          // TS_RUNTIME_SESSION_RETIRED), but this off-route mirror entry was
+          // unguarded. We guard at THIS caller boundary — never on addMessage
+          // itself — because addMessage has many legitimate non-channel callers
+          // (API session routes, agent sessions tool, engine turn-preparer /
+          // run-executor, subagent lineage, parent-summary writes). Guarding the
+          // method globally would break those; guarding here closes the
+          // channel-mirror bypass with the SAME family + flag as the retired
+          // route. Production leaves the flag unset → mirror writes fail-closed;
+          // test-oracle harnesses opt in. Returns the addMessage promise so every
+          // call site (await / await+catch / void async) behaves identically.
+          const mirrorChannelSessionMessage: typeof hubSessionService.addMessage = (key, message) => {
+            if (config.allowTestOnlySessionExecution !== true) {
+              return Promise.reject(
+                new FridayDomainError(
+                  "TS_RUNTIME_SESSION_RETIRED",
+                  "TypeScript session execution is fail-closed in default/live runtime; use the Rust-owned session_lifecycle entrypoint.",
+                  {
+                    httpStatus: 503,
+                    details: {
+                      classification: "fail_closed",
+                      replacement: "rust_owned_session_lifecycle_entrypoint_required",
+                    },
+                  },
+                ),
+              );
+            }
+            return hubSessionService.addMessage(key, message);
+          };
           if (taskText.length === 0) return;
           channelApprovalRoutesBySession.set(sessionKey, {
             channelKind: msg.channelKind,
@@ -8664,7 +8697,7 @@ export async function createFridayHub(
           const reflexCandidateCommand = text.length > 0 ? parseReflexCandidateDecisionCommand(text) : null;
           if (reflexCandidateCommand) {
             void (async () => {
-              await hubSessionService.addMessage(sessionKey, {
+              await mirrorChannelSessionMessage(sessionKey, {
                 role: "user",
                 content: text,
                 contentText: text,
@@ -8736,7 +8769,7 @@ export async function createFridayHub(
                 text: ackText,
                 replyTo: msg.id,
               });
-              await hubSessionService.addMessage(sessionKey, {
+              await mirrorChannelSessionMessage(sessionKey, {
                 role: "assistant",
                 content: ackText,
                 contentText: ackText,
@@ -8772,7 +8805,7 @@ export async function createFridayHub(
           });
           if (reflexPreferenceResult.applied > 0 || reflexPreferenceResult.pendingConfirmation > 0) {
             void (async () => {
-              await hubSessionService.addMessage(sessionKey, {
+              await mirrorChannelSessionMessage(sessionKey, {
                 role: "user",
                 content: text,
                 contentText: text,
@@ -8803,7 +8836,7 @@ export async function createFridayHub(
                 text: ackText,
                 replyTo: msg.id,
               });
-              await hubSessionService.addMessage(sessionKey, {
+              await mirrorChannelSessionMessage(sessionKey, {
                 role: "assistant",
                 content: ackText,
                 contentText: ackText,
@@ -8855,7 +8888,7 @@ export async function createFridayHub(
           if (approvalCommand) {
             if (shouldRouteToolApprovalCommand) {
               void (async () => {
-                await hubSessionService.addMessage(sessionKey, {
+                await mirrorChannelSessionMessage(sessionKey, {
                   role: "user",
                   content: text,
                   contentText: text,
@@ -8938,7 +8971,7 @@ export async function createFridayHub(
                   text: ackText,
                   replyTo: msg.id,
                 });
-                await hubSessionService.addMessage(sessionKey, {
+                await mirrorChannelSessionMessage(sessionKey, {
                   role: "assistant",
                   content: ackText,
                   contentText: ackText,
@@ -9050,7 +9083,7 @@ export async function createFridayHub(
               sourceText: taskText,
             });
             try {
-              const inboundMessage = await hubSessionService.addMessage(sessionKey, {
+              const inboundMessage = await mirrorChannelSessionMessage(sessionKey, {
                 role: "user",
                 content: taskText,
                 contentText: taskText,
@@ -9088,7 +9121,7 @@ export async function createFridayHub(
                     text: outboundText,
                     runId,
                   });
-                  await hubSessionService.addMessage(sessionKey, {
+                  await mirrorChannelSessionMessage(sessionKey, {
                     role: "assistant",
                     content: outboundText,
                     contentText: outboundText,
@@ -9216,7 +9249,7 @@ export async function createFridayHub(
                   error: err,
                 });
                 const fallbackText = buildFridayChannelDeliveryFailureText(result.runId, taskText);
-                await hubSessionService.addMessage(sessionKey, {
+                await mirrorChannelSessionMessage(sessionKey, {
                   role: "assistant",
                   content: fallbackText,
                   contentText: fallbackText,

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -8283,8 +8283,35 @@ export async function createFridayHub(
           return hubSessionService.addMessage(key, msg);
         },
         getConversationFocus: (key: string) => hubSessionService.getConversationFocus(key),
-        setConversationFocus: (key: string, state: Parameters<typeof hubSessionService.setConversationFocus>[1]) =>
-          hubSessionService.setConversationFocus(key, state).then(() => undefined),
+        // setConversationFocus is the SECOND session-state WRITE on this channel-only
+        // dep (a sibling of addMessage). It rewrites conversation focus (currentTopicSummary,
+        // assistantAnchorSummary, lastRunId, reply anchors, fingerprints, task ledger) on
+        // pre-existing channel session rows. The run-executor's control-plane finalize does
+        // addMessage THEN setConversationFocus per branch, each `.catch(() => undefined)`-
+        // swallowed — so the addMessage fail-closed rejection is caught and flow STILL reaches
+        // this write. setConversationFocus is retirement-in-scope (the /v1/sessions/:key/compact
+        // focus route is gated behind assertSessionTestOracleAllowed). Apply the IDENTICAL
+        // fail-closed check (same family + flag, no new flag) so the COMPLETE channel-engine
+        // session-write surface is fenced under the production default. getConversationFocus /
+        // getMessages are READS → left live per the retirement (reads stay live).
+        setConversationFocus: (key: string, state: Parameters<typeof hubSessionService.setConversationFocus>[1]) => {
+          if (config.allowTestOnlySessionExecution !== true) {
+            return Promise.reject(
+              new FridayDomainError(
+                "TS_RUNTIME_SESSION_RETIRED",
+                "TypeScript session execution is fail-closed in default/live runtime; use the Rust-owned session_lifecycle entrypoint.",
+                {
+                  httpStatus: 503,
+                  details: {
+                    classification: "fail_closed",
+                    replacement: "rust_owned_session_lifecycle_entrypoint_required",
+                  },
+                },
+              ),
+            );
+          }
+          return hubSessionService.setConversationFocus(key, state).then(() => undefined);
+        },
       };
       const channelOrchestrationEngine = createFridayOrchestrationEngine({
         turnPreparerDeps: {

--- a/src/workflows/services/friday-workflow-execution-service.ts
+++ b/src/workflows/services/friday-workflow-execution-service.ts
@@ -1384,6 +1384,29 @@ export function createFridayWorkflowExecutionService(
     },
 
     async resumeRun(runId, options) {
+      // ─── TS Runtime Retirement: METHOD-level fail-closed guard ───
+      // Sibling of `startRun` (§1 reconciliation). The route guard is POST-only;
+      // `resumeRun` is reached off-route via `dispatchManagedAsync` ← channel
+      // orchestration and via workflow-approval approve → resumeRun, re-entering
+      // node execution and persisting run state. Guard here fails ALL non-route
+      // callers closed BEFORE any DB read, plan rebuild, node re-entry, provider
+      // call, or write — unless the explicit test-oracle flag is set. Same flag
+      // and family as `startRun`. Never default this flag on in prod.
+      if (deps.allowTestOnlyWorkflowRunExecution !== true) {
+        void runId;
+        void options;
+        throw new FridayDomainError(
+          "TS_RUNTIME_WORKFLOW_RUNS_RETIRED",
+          "Workflow run execution and controls are fail-closed while runtime ownership is being moved out of TypeScript.",
+          {
+            httpStatus: 503,
+            details: {
+              classification: "fail_closed",
+              replacement: "rust_owned_workflow_run_entrypoint_required",
+            },
+          },
+        );
+      }
       const runEntity = deps.db.withReadConnection((db) =>
         deps.runRepo.getRunById(db, runId),
       );
@@ -1581,6 +1604,29 @@ export function createFridayWorkflowExecutionService(
     },
 
     async cancelRun(runId, reason) {
+      // ─── TS Runtime Retirement: METHOD-level fail-closed guard ───
+      // Sibling of `startRun` (§1 reconciliation). Lower severity than
+      // resume/retry (no node re-entry) but it still aborts in-flight
+      // controllers and writes terminal run/node state via withWriteTransaction,
+      // reachable off-route via `dispatchManagedAsync` ← channel orchestration.
+      // Guarded for consistency so EVERY route-retired run-control mutator is
+      // method-fenced. Same flag and family as `startRun`; never default on in
+      // prod.
+      if (deps.allowTestOnlyWorkflowRunExecution !== true) {
+        void runId;
+        void reason;
+        throw new FridayDomainError(
+          "TS_RUNTIME_WORKFLOW_RUNS_RETIRED",
+          "Workflow run execution and controls are fail-closed while runtime ownership is being moved out of TypeScript.",
+          {
+            httpStatus: 503,
+            details: {
+              classification: "fail_closed",
+              replacement: "rust_owned_workflow_run_entrypoint_required",
+            },
+          },
+        );
+      }
       const runEntity = deps.db.withReadConnection((db) =>
         deps.runRepo.getRunById(db, runId),
       );
@@ -1625,6 +1671,29 @@ export function createFridayWorkflowExecutionService(
     },
 
     async retryRun(runId, nodeIds) {
+      // ─── TS Runtime Retirement: METHOD-level fail-closed guard ───
+      // Sibling of `startRun` (§1 reconciliation). The route guard is POST-only;
+      // `retryRun` is reached off-route via `dispatchManagedAsync` ← channel
+      // orchestration, re-creating retry attempts and re-entering node execution
+      // (provider/tool calls + persist). Guard here fails ALL non-route callers
+      // closed BEFORE any DB read, retry-attempt creation, node re-entry, or
+      // write — unless the explicit test-oracle flag is set. Same flag and family
+      // as `startRun`. Never default this flag on in prod.
+      if (deps.allowTestOnlyWorkflowRunExecution !== true) {
+        void runId;
+        void nodeIds;
+        throw new FridayDomainError(
+          "TS_RUNTIME_WORKFLOW_RUNS_RETIRED",
+          "Workflow run execution and controls are fail-closed while runtime ownership is being moved out of TypeScript.",
+          {
+            httpStatus: 503,
+            details: {
+              classification: "fail_closed",
+              replacement: "rust_owned_workflow_run_entrypoint_required",
+            },
+          },
+        );
+      }
       const runEntity = deps.db.withReadConnection((db) =>
         deps.runRepo.getRunById(db, runId),
       );

--- a/test/e2e/live/friday-discord-channel-live.e2e.test.ts
+++ b/test/e2e/live/friday-discord-channel-live.e2e.test.ts
@@ -119,6 +119,9 @@ describe.skipIf(!RUN_LIVE_DISCORD || !DISCORD_SETUP_USER_ID || !DISCORD_GUILD_ID
       skillDirs: [],
       port: 0,
       logRequests: false,
+      // G5 channel-mirror write guard (TS-retirement): live channel run mirrors
+      // inbound/outbound into the session store; opt in to keep that path live.
+      allowTestOnlySessionExecution: true,
     });
     await hub.start();
 
@@ -246,6 +249,8 @@ describe.skipIf(!RUN_LIVE_DISCORD || !DISCORD_SETUP_USER_ID || !DISCORD_GUILD_ID
       skillDirs: [],
       port: 0,
       logRequests: false,
+      // G5 channel-mirror write guard (TS-retirement): keep the mirror live on restart too.
+      allowTestOnlySessionExecution: true,
     });
     await restartedHub.start();
 

--- a/test/integration/hub/friday-phase24-trusted-inbound-session-read-auth.test.ts
+++ b/test/integration/hub/friday-phase24-trusted-inbound-session-read-auth.test.ts
@@ -90,6 +90,10 @@ describe("phase24 trusted-inbound session read requires an authenticated princip
       port: 0,
       logRequests: false,
       channels: { enabled: false, instances: [] },
+      // G5 channel-mirror write guard (TS-retirement): this test asserts the
+      // channelMessageHandler mirrors the inbound message into the session store
+      // and reads it back; opt in to keep the mirror write path live.
+      allowTestOnlySessionExecution: true,
     } as Parameters<typeof createFridayHub>[0]);
     cleanups.push(() => hub.stop?.());
 

--- a/test/integration/workflows/friday-workflow-trigger-retirement-guard.test.ts
+++ b/test/integration/workflows/friday-workflow-trigger-retirement-guard.test.ts
@@ -262,6 +262,45 @@ describe("Workflow trigger/scheduler retirement guard (method-level, §1)", () =
 
       expect(runRowCount()).toBe(0);
     });
+
+    // ─── G4: run-control siblings of startRun (resume/retry/cancel) ───
+    // Reached off-route via dispatchManagedAsync ← channel orchestration and
+    // workflow-approval approve → resumeRun. Each must fail closed at the METHOD
+    // boundary BEFORE any DB read (getRunById) or write, so the guard fires even
+    // for a non-existent runId (proving it precedes the WORKFLOW_RUN_NOT_FOUND
+    // lookup). No run row is created.
+    it("direct resumeRun method throws retired error before any DB read", async () => {
+      const runtime = buildRuntime({ allowTestOnly: false });
+      publishWorkflow(runtime, "resume-wf");
+
+      await expect(
+        runtime.execution.resumeRun("00000000-0000-0000-0000-000000000001"),
+      ).rejects.toMatchObject({ code: RETIRED_CODE });
+
+      expect(runRowCount()).toBe(0);
+    });
+
+    it("direct retryRun method throws retired error before any DB read", async () => {
+      const runtime = buildRuntime({ allowTestOnly: false });
+      publishWorkflow(runtime, "retry-wf");
+
+      await expect(
+        runtime.execution.retryRun("00000000-0000-0000-0000-000000000002"),
+      ).rejects.toMatchObject({ code: RETIRED_CODE });
+
+      expect(runRowCount()).toBe(0);
+    });
+
+    it("direct cancelRun method throws retired error before any DB read", async () => {
+      const runtime = buildRuntime({ allowTestOnly: false });
+      publishWorkflow(runtime, "cancel-wf");
+
+      await expect(
+        runtime.execution.cancelRun("00000000-0000-0000-0000-000000000003"),
+      ).rejects.toMatchObject({ code: RETIRED_CODE });
+
+      expect(runRowCount()).toBe(0);
+    });
   });
 
   // ─── Explicit test-oracle flag ON: legacy path still works ───
@@ -291,6 +330,24 @@ describe("Workflow trigger/scheduler retirement guard (method-level, §1)", () =
 
       expect(started).toBe(1);
       expect(runRowCount()).toBeGreaterThanOrEqual(1);
+    });
+
+    // G4: with the flag ON, the run-control siblings pass the retirement guard
+    // and reach their bodies — proven by the DOWNSTREAM not-found error (NOT the
+    // retirement code), confirming the guard is the only thing fenced by the flag.
+    it("resume/retry/cancel reach the body (downstream not-found, NOT retired) when flag is on", async () => {
+      const runtime = buildRuntime({ allowTestOnly: true });
+      publishWorkflow(runtime, "oracle-control-wf");
+
+      await expect(
+        runtime.execution.resumeRun("00000000-0000-0000-0000-0000000000a1"),
+      ).rejects.toMatchObject({ code: "WORKFLOW_RUN_NOT_FOUND" });
+      await expect(
+        runtime.execution.retryRun("00000000-0000-0000-0000-0000000000a2"),
+      ).rejects.toMatchObject({ code: "WORKFLOW_RUN_NOT_FOUND" });
+      await expect(
+        runtime.execution.cancelRun("00000000-0000-0000-0000-0000000000a3"),
+      ).rejects.toMatchObject({ code: "WORKFLOW_RUN_NOT_FOUND" });
     });
   });
 });

--- a/test/unit/hub/friday-channel-natural-trigger-runtime.test.ts
+++ b/test/unit/hub/friday-channel-natural-trigger-runtime.test.ts
@@ -671,3 +671,144 @@ describe("channel session-mirror write guard (G5, default fail-closed)", () => {
     expect(mirrorRejections).toHaveLength(0);
   });
 });
+
+// ─── G5 completeness: channel ENGINE control-plane write guard — fail-closed ───
+// The G5 handler-boundary guard above only fences the 9 DIRECT channelMessageHandler
+// mirror sites (the inbound user write + natural-trigger / delivery mirrors). It does
+// NOT cover the channel orchestration ENGINE, which writes session messages through a
+// SEPARATE binding (channelEngineSessionDeps.addMessage → run-executor.finalizeControlPlane
+// for deterministic / managed-async dispatch responses, and the planning-gate
+// return/reject branches). A DETERMINISTIC / control-plane channel message (e.g. a
+// workflow-control command whose denial response is persisted as an assistant message)
+// reaches finalizeControlPlane BEFORE the agent-runtime executeRun guard, so it would
+// otherwise persist an assistant session row even with the handler guard in place — the
+// exact bypass the review's empirical probe missed. With the flag UNSET (production
+// default) the engine's control-plane addMessage must fail closed: NO assistant session
+// row, and (because every control-plane write is `.catch(() => undefined)`) no crash /
+// unhandled rejection — while the deterministic denial response is still delivered
+// outbound (proving the control-plane path actually executed).
+describe("channel ENGINE control-plane write guard (G5 completeness, default fail-closed)", () => {
+  let stateDir: string | null = null;
+  let hub: FridayHub | null = null;
+  let autoDetectEnvSnapshot: FridayAutoDetectProviderEnvSnapshot | null = null;
+  const originalSuppression = process.env.FRIDAY_SUPPRESS_TEST_ENV_SECURITY_WARNINGS;
+  const unhandled: unknown[] = [];
+  const onUnhandled = (reason: unknown): void => {
+    unhandled.push(reason);
+  };
+
+  beforeEach(async () => {
+    unhandled.length = 0;
+    process.on("unhandledRejection", onUnhandled);
+    process.env.FRIDAY_SUPPRESS_TEST_ENV_SECURITY_WARNINGS = "1";
+    process.env.FRIDAY_CHANNEL_DEBOUNCE_MS = "0";
+    autoDetectEnvSnapshot = clearAutoDetectProviderEnv();
+    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "friday-channel-engine-failclosed-"));
+    const skillsDir = path.join(stateDir, "skills-empty");
+    await fs.mkdir(skillsDir, { recursive: true });
+    // Deliberately omit allowTestOnlySessionExecution → channel session writes
+    // (handler mirror AND engine control-plane) fail closed (production default).
+    // The workflow-run flag IS set so the workflow-control dispatch reaches the
+    // run-control body (→ genuine WORKFLOW_RUN_NOT_FOUND → denial response →
+    // finalizeControlPlane) and the SESSION write is the only variable under test.
+    hub = await createFridayHub({
+      allowTestOnlyWorkflowRunExecution: true,
+      skillDirs: [skillsDir],
+      stateDir,
+      channels: { enabled: false, instances: [] },
+    });
+  });
+
+  afterEach(async () => {
+    process.off("unhandledRejection", onUnhandled);
+    if (hub) {
+      await hub.stop();
+      hub = null;
+    }
+    if (stateDir) {
+      await fs.rm(stateDir, { recursive: true, force: true });
+      stateDir = null;
+    }
+    if (autoDetectEnvSnapshot) {
+      restoreAutoDetectProviderEnv(autoDetectEnvSnapshot);
+      autoDetectEnvSnapshot = null;
+    }
+    if (originalSuppression === undefined) {
+      delete process.env.FRIDAY_SUPPRESS_TEST_ENV_SECURITY_WARNINGS;
+    } else {
+      process.env.FRIDAY_SUPPRESS_TEST_ENV_SECURITY_WARNINGS = originalSuppression;
+    }
+    delete process.env.FRIDAY_CHANNEL_DEBOUNCE_MS;
+  });
+
+  it("does NOT persist an assistant session row for a deterministic control-plane channel message, and does not crash", async () => {
+    const channel = createTestChannelPlugin();
+    hub!.channelRegistry.register(channel.plugin);
+    await hub!.start();
+    const onMessage = channel.getStartedHandler();
+    expect(onMessage).toBeTypeOf("function");
+
+    // Spy on the underlying session-store addMessage. Both the handler mirror and
+    // the channel-engine binding ultimately call this same FridaySessionService
+    // instance; under the unset flag BOTH guards fence the call BEFORE it reaches
+    // the store, so this spy must see 0 calls.
+    const addMessageSpy = vi.spyOn(hub!.apiRuntime.sessionService, "addMessage");
+
+    // "daemon status" is a DETERMINISTIC (sync_immediate / daemon_status) turn that
+    // is NOT intercepted by the channel handler's pre-engine approval/reflex routing
+    // — it is delegated to channelEntryAdapter → the channel orchestration engine.
+    // dispatchDeterministic returns a handled response → run-executor.finalizeControlPlane
+    // attempts the assistant session write via channelEngineSessionDeps.addMessage,
+    // BEFORE the agent-runtime executeRun guard. This is the engine control-plane
+    // bypass that the handler-boundary G5 guard does NOT cover. (Empirically proven
+    // RED with the binding guard removed: an assistant row persists / the spy fires.)
+    const inbound: FridayChannelMessage = {
+      id: "msg-engine-controlplane-failclosed",
+      channelKind: "testchannel",
+      senderId: "sender-cp-1",
+      senderName: "Bob",
+      chatId: "chat-engine-controlplane",
+      chatType: "direct",
+      text: "daemon status",
+      timestamp: Date.now(),
+    };
+    const sessionKey = resolveFridayChannelSessionKey(inbound, {
+      crossChannelIdentityEnabled: false,
+      identityMap: {},
+    });
+
+    // Drive the message through the real channelMessageHandler → channel engine.
+    onMessage!(inbound);
+
+    // Give the async handler + engine control-plane path time to run (fail-closed).
+    await new Promise((resolve) => setTimeout(resolve, 400));
+
+    // PRIMARY (store-level, instance-agnostic): the control-plane assistant write is
+    // fail-closed → NO assistant session row. (The review's missed probe checked only
+    // user rows; the engine control-plane write is an ASSISTANT row.)
+    const messages = await hub!.apiRuntime.sessionService.getMessages(sessionKey).catch(() => []);
+    expect(messages.filter((m) => m.role === "assistant")).toHaveLength(0);
+    // The inbound user mirror is likewise fenced by the handler-boundary guard.
+    expect(messages.filter((m) => m.role === "user")).toHaveLength(0);
+
+    // Prove the control-plane path ACTUALLY executed (not short-circuited as a
+    // full-agent turn, in which case the session write would happen inside the
+    // already-guarded agentRuntime.executeRun and the 0-rows result would be a
+    // tautology): the deterministic daemon-status reply is delivered outbound.
+    expect(channel.sentMessages.some((t) => /daemon/iu.test(t))).toBe(true);
+
+    // The fail-closed guard fences EVERY channel session write before it reaches the
+    // shared store → the underlying addMessage is never called.
+    expect(addMessageSpy).not.toHaveBeenCalled();
+
+    // Every fenced control-plane write is `.catch(() => undefined)` → no unhandled rejection.
+    const mirrorRejections = unhandled.filter((r) => {
+      const code = (r as { code?: unknown } | null)?.code;
+      const message = r instanceof Error ? r.message : "";
+      return code === "TS_RUNTIME_SESSION_RETIRED" || /session execution is fail-closed/u.test(message);
+    });
+    expect(mirrorRejections).toHaveLength(0);
+
+    addMessageSpy.mockRestore();
+  });
+});

--- a/test/unit/hub/friday-channel-natural-trigger-runtime.test.ts
+++ b/test/unit/hub/friday-channel-natural-trigger-runtime.test.ts
@@ -109,6 +109,7 @@ async function createIsolatedHub(stateDir: string): Promise<FridayHub> {
   await fs.mkdir(skillsDir, { recursive: true });
   return createFridayHub({
     allowTestOnlyWorkflowRunExecution: true, // TS-retirement method guard: test-oracle opt-in
+    allowTestOnlySessionExecution: true, // G5 channel-mirror write guard: test-oracle opt-in
     skillDirs: [skillsDir],
     stateDir,
     channels: { enabled: false, instances: [] },
@@ -568,5 +569,105 @@ describe("channel natural-trigger parent runtime resolver", () => {
     ].join("\n"));
 
     expect(sanitized).toBe("Here is the useful answer.");
+  });
+});
+
+// ─── G5: channel-mirror write guard — DEFAULT fail-closed proof ───
+// When the test-oracle flag `allowTestOnlySessionExecution` is left UNSET
+// (production default), the channel webhook ingress → channelMessageHandler
+// session-mirror writes (FridaySessionService.addMessage) must fail closed: no
+// session message is persisted, and the handler does NOT crash / leak an
+// unhandled rejection (every mirror call site has a non-fatal `.catch`).
+describe("channel session-mirror write guard (G5, default fail-closed)", () => {
+  let stateDir: string | null = null;
+  let hub: FridayHub | null = null;
+  let autoDetectEnvSnapshot: FridayAutoDetectProviderEnvSnapshot | null = null;
+  const originalSuppression = process.env.FRIDAY_SUPPRESS_TEST_ENV_SECURITY_WARNINGS;
+  const unhandled: unknown[] = [];
+  const onUnhandled = (reason: unknown): void => {
+    unhandled.push(reason);
+  };
+
+  beforeEach(async () => {
+    unhandled.length = 0;
+    process.on("unhandledRejection", onUnhandled);
+    process.env.FRIDAY_SUPPRESS_TEST_ENV_SECURITY_WARNINGS = "1";
+    process.env.FRIDAY_CHANNEL_DEBOUNCE_MS = "0";
+    autoDetectEnvSnapshot = clearAutoDetectProviderEnv();
+    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "friday-channel-mirror-failclosed-"));
+    const skillsDir = path.join(stateDir, "skills-empty");
+    await fs.mkdir(skillsDir, { recursive: true });
+    // Deliberately omit allowTestOnlySessionExecution → channel-mirror writes
+    // fail closed (production default). Workflow-run flag is set so the absence
+    // of mirror writes is the only variable under test.
+    hub = await createFridayHub({
+      allowTestOnlyWorkflowRunExecution: true,
+      skillDirs: [skillsDir],
+      stateDir,
+      channels: { enabled: false, instances: [] },
+    });
+  });
+
+  afterEach(async () => {
+    process.off("unhandledRejection", onUnhandled);
+    if (hub) {
+      await hub.stop();
+      hub = null;
+    }
+    if (stateDir) {
+      await fs.rm(stateDir, { recursive: true, force: true });
+      stateDir = null;
+    }
+    if (autoDetectEnvSnapshot) {
+      restoreAutoDetectProviderEnv(autoDetectEnvSnapshot);
+      autoDetectEnvSnapshot = null;
+    }
+    if (originalSuppression === undefined) {
+      delete process.env.FRIDAY_SUPPRESS_TEST_ENV_SECURITY_WARNINGS;
+    } else {
+      process.env.FRIDAY_SUPPRESS_TEST_ENV_SECURITY_WARNINGS = originalSuppression;
+    }
+    delete process.env.FRIDAY_CHANNEL_DEBOUNCE_MS;
+  });
+
+  it("does NOT mirror an inbound channel message into the session store and does not crash the handler", async () => {
+    const channel = createTestChannelPlugin();
+    hub!.channelRegistry.register(channel.plugin);
+    await hub!.start();
+    const onMessage = channel.getStartedHandler();
+    expect(onMessage).toBeTypeOf("function");
+
+    const inbound: FridayChannelMessage = {
+      id: "msg-mirror-failclosed",
+      channelKind: "testchannel",
+      senderId: "sender-1",
+      senderName: "Alice",
+      chatId: "chat-mirror-failclosed",
+      chatType: "direct",
+      text: "hello friday, mirror me",
+      timestamp: Date.now(),
+    };
+    const sessionKey = resolveFridayChannelSessionKey(inbound, {
+      crossChannelIdentityEnabled: false,
+      identityMap: {},
+    });
+
+    // Drive the message through the real channelMessageHandler.
+    onMessage!(inbound);
+
+    // Give the async handler time to run its (fail-closed) mirror path.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    // The mirror write is fail-closed → no session message persisted.
+    const messages = await hub!.apiRuntime.sessionService.getMessages(sessionKey).catch(() => []);
+    expect(messages.filter((m) => m.role === "user")).toHaveLength(0);
+
+    // The fenced mirror rejection is caught non-fatally → no unhandled rejection.
+    const mirrorRejections = unhandled.filter((r) => {
+      const code = (r as { code?: unknown } | null)?.code;
+      const message = r instanceof Error ? r.message : "";
+      return code === "TS_RUNTIME_SESSION_RETIRED" || /session execution is fail-closed/u.test(message);
+    });
+    expect(mirrorRejections).toHaveLength(0);
   });
 });

--- a/test/unit/hub/friday-channel-natural-trigger-runtime.test.ts
+++ b/test/unit/hub/friday-channel-natural-trigger-runtime.test.ts
@@ -811,4 +811,106 @@ describe("channel ENGINE control-plane write guard (G5 completeness, default fai
 
     addMessageSpy.mockRestore();
   });
+
+  // ── setConversationFocus completeness: the SIBLING control-plane write ──
+  // The run-executor's control-plane finalize does TWO awaited writes per branch:
+  // channelEngineSessionDeps.addMessage THEN channelEngineSessionDeps.setConversationFocus,
+  // each `.catch(() => undefined)`-swallowed. With ONLY addMessage guarded, the addMessage
+  // fail-closed rejection is caught and flow STILL reaches setConversationFocus — which (if
+  // unguarded) rewrites focus state (currentTopicSummary, assistantAnchorSummary, lastRunId,
+  // reply anchors, fingerprints, task ledger) on a PRE-EXISTING channel session row. This is
+  // the residual control-plane focus-state write the re-review proved. Seed a real session
+  // row + a sentinel focus via the RAW service (the raw FridaySessionService has no guard —
+  // only the channel-engine dep closure does — so seeding succeeds with the flag unset), drive
+  // the same deterministic 'daemon status' turn under the unset flag, and assert focus is byte-
+  // identical to the seed (setConversationFocus never ran) — while the reply is still delivered
+  // and no unhandled rejection escapes. Empirically RED with the setConversationFocus guard
+  // removed: finalizeFridayConversationFocus rewrites the focus → focusMutated true → FAIL.
+  it("does NOT mutate conversation focus on a pre-existing channel session row for a deterministic control-plane turn, and does not crash", async () => {
+    const channel = createTestChannelPlugin();
+    hub!.channelRegistry.register(channel.plugin);
+    await hub!.start();
+    const onMessage = channel.getStartedHandler();
+    expect(onMessage).toBeTypeOf("function");
+
+    const inbound: FridayChannelMessage = {
+      id: "msg-engine-focus-failclosed",
+      channelKind: "testchannel",
+      senderId: "sender-focus-1",
+      senderName: "Bob",
+      chatId: "chat-engine-focus",
+      chatType: "direct",
+      text: "daemon status",
+      timestamp: Date.now(),
+    };
+    const sessionKey = resolveFridayChannelSessionKey(inbound, {
+      crossChannelIdentityEnabled: false,
+      identityMap: {},
+    });
+
+    // Seed a PRE-EXISTING session row + a distinctive sentinel focus through the raw
+    // session service (no guard on the raw instance). Every field finalizeFridayConversationFocus
+    // would deterministically rewrite (currentTopicSummary / assistantAnchorSummary / lastRunId /
+    // taskLedger / fingerprints) is set to an unmistakable sentinel so any write is detectable.
+    await hub!.apiRuntime.sessionService.getOrCreateSession(sessionKey);
+    const seededFocus = {
+      currentTopicFingerprint: "SENTINEL_TOPIC_FP",
+      currentTopicSummary: "SENTINEL_TOPIC_SUMMARY_DO_NOT_OVERWRITE",
+      currentTopicStartSequence: 1,
+      assistantAnchorSummary: "SENTINEL_ANCHOR_SUMMARY",
+      assistantAnchorFingerprint: "SENTINEL_ANCHOR_FP",
+      lastAnsweredQuestion: "SENTINEL_LAST_ANSWERED",
+      lastRunId: "SENTINEL_LAST_RUN_ID",
+      lastTurnKind: "new_topic" as const,
+      updatedAt: "2020-01-01T00:00:00.000Z",
+    };
+    await hub!.apiRuntime.sessionService.setConversationFocus(sessionKey, seededFocus);
+
+    // Confirm the seed landed (raw write is NOT guarded; only the channel-engine dep is).
+    const focusBefore = await hub!.apiRuntime.sessionService.getConversationFocus(sessionKey);
+    expect(focusBefore?.currentTopicSummary).toBe("SENTINEL_TOPIC_SUMMARY_DO_NOT_OVERWRITE");
+    expect(focusBefore?.lastRunId).toBe("SENTINEL_LAST_RUN_ID");
+
+    // Spy on the raw setConversationFocus to also prove the channel-engine dep's write is
+    // fenced before it reaches the store. (The seed call above is captured then cleared.)
+    const setFocusSpy = vi.spyOn(hub!.apiRuntime.sessionService, "setConversationFocus");
+
+    // Drive the deterministic daemon-status turn through the real channelMessageHandler →
+    // channel orchestration engine → run-executor.finalizeControlPlane. With the flag unset,
+    // addMessage rejects (caught), and the SIBLING setConversationFocus is the write under test.
+    onMessage!(inbound);
+    await new Promise((resolve) => setTimeout(resolve, 400));
+
+    // PRIMARY (instance-agnostic): the seeded focus is BYTE-UNCHANGED → the control-plane
+    // setConversationFocus write was fenced before it could rewrite focus state.
+    const focusAfter = await hub!.apiRuntime.sessionService.getConversationFocus(sessionKey);
+    const focusMutated = JSON.stringify(focusAfter) !== JSON.stringify(focusBefore);
+    expect(focusMutated).toBe(false);
+    expect(focusAfter?.currentTopicSummary).toBe("SENTINEL_TOPIC_SUMMARY_DO_NOT_OVERWRITE");
+    expect(focusAfter?.assistantAnchorSummary).toBe("SENTINEL_ANCHOR_SUMMARY");
+    expect(focusAfter?.lastRunId).toBe("SENTINEL_LAST_RUN_ID");
+
+    // SECONDARY (store-level): the channel-engine dep's setConversationFocus never reached
+    // the store after the seed.
+    expect(setFocusSpy).not.toHaveBeenCalled();
+
+    // Regression: addMessage (the already-guarded sibling) is likewise fenced → no rows.
+    const messages = await hub!.apiRuntime.sessionService.getMessages(sessionKey).catch(() => []);
+    expect(messages.filter((m) => m.role === "assistant")).toHaveLength(0);
+    expect(messages.filter((m) => m.role === "user")).toHaveLength(0);
+
+    // Prove the control-plane path ACTUALLY executed (not a tautology): the deterministic
+    // daemon-status reply is still delivered outbound.
+    expect(channel.sentMessages.some((t) => /daemon/iu.test(t))).toBe(true);
+
+    // Every fenced control-plane write is `.catch(() => undefined)` → no unhandled rejection.
+    const focusRejections = unhandled.filter((r) => {
+      const code = (r as { code?: unknown } | null)?.code;
+      const message = r instanceof Error ? r.message : "";
+      return code === "TS_RUNTIME_SESSION_RETIRED" || /session execution is fail-closed/u.test(message);
+    });
+    expect(focusRejections).toHaveLength(0);
+
+    setFocusSpy.mockRestore();
+  });
 });

--- a/test/unit/hub/friday-channel-natural-trigger-runtime.test.ts
+++ b/test/unit/hub/friday-channel-natural-trigger-runtime.test.ts
@@ -3,7 +3,9 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 
+import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createFridayAgentContextReplayRepository } from "../../../src/agent/persistence/friday-agent-context-replay-repository.js";
 import type { FridayChannelMessage, FridayChannelPlugin } from "#channels";
 import {
   createFridayChannelNaturalTriggerResolver,
@@ -912,5 +914,127 @@ describe("channel ENGINE control-plane write guard (G5 completeness, default fai
     expect(focusRejections).toHaveLength(0);
 
     setFocusSpy.mockRestore();
+  });
+
+  // ── persistCompactionEvidence completeness: the THIRD (separately-wired) write ──
+  // The channel orchestration engine's turn-preparer is wired with a SEPARATE
+  // `persistCompactionEvidence` dep (bootstrap ~8326 → agentCompactionContextReplaySink.persist)
+  // that is NOT routed through channelEngineSessionDeps and so is NOT covered by the
+  // addMessage / setConversationFocus guards. The turn-preparer runs BEFORE dispatch /
+  // before the agent-runtime executeRun guard, and when buildSelectedBlockCompactionEvidence
+  // (over the prepared turn's selectedBlocks) is non-null it calls persistCompactionEvidence,
+  // which writes a session+runId-keyed row into friday_agent_context_replay_entries
+  // (summaryText / decisions / todos / openQuestions / toolFailures / fileOperations) via
+  // db.withWriteTransaction → appendCompactionSummary. This is a derived session/memory-state
+  // WRITE reachable on a bound channel turn even though addMessage / setConversationFocus
+  // reject. We seed a PRE-EXISTING session with rich history + a focus state whose
+  // currentTopicStartSequence covers the seeded turns, so prepareTurn yields focus_topic /
+  // topic blocks → compaction evidence is non-null and persistCompactionEvidence WOULD fire.
+  // With the flag UNSET (production default) the channel-engine persistCompactionEvidence
+  // closure must fail closed → ZERO new rows in friday_agent_context_replay_entries — while
+  // the deterministic daemon-status reply is still delivered outbound and no unhandled
+  // rejection escapes (the turn-preparer wraps the call in `.catch(() => undefined)`).
+  // Empirically RED with the persistCompactionEvidence guard removed: a replay row lands.
+  it("does NOT persist a compaction-evidence replay row for a channel turn with rich seeded context, and does not crash", async () => {
+    const channel = createTestChannelPlugin();
+    hub!.channelRegistry.register(channel.plugin);
+    await hub!.start();
+    const onMessage = channel.getStartedHandler();
+    expect(onMessage).toBeTypeOf("function");
+
+    const inbound: FridayChannelMessage = {
+      id: "msg-engine-replay-failclosed",
+      channelKind: "testchannel",
+      senderId: "sender-replay-1",
+      senderName: "Bob",
+      chatId: "chat-engine-replay",
+      chatType: "direct",
+      text: "daemon status",
+      timestamp: Date.now(),
+    };
+    const sessionKey = resolveFridayChannelSessionKey(inbound, {
+      crossChannelIdentityEnabled: false,
+      identityMap: {},
+    });
+
+    // Seed a PRE-EXISTING session with a multi-turn topic history (raw service, no guard).
+    // The seeded turns establish a "deployment" topic so prepareTurn produces focus_topic /
+    // topic_block selectedBlocks (gated on focusState.currentTopicStartSequence), which is
+    // what makes buildSelectedBlockCompactionEvidence non-null → persistCompactionEvidence
+    // fires in the turn-preparer (before dispatch / before the executeRun guard).
+    await hub!.apiRuntime.sessionService!.getOrCreateSession(sessionKey);
+    await hub!.apiRuntime.sessionService!.addMessage(sessionKey, {
+      role: "user",
+      content: "Let's plan the production deployment. Decision: deploy to AWS ECS.",
+      contentText: "Let's plan the production deployment. Decision: deploy to AWS ECS.",
+    });
+    await hub!.apiRuntime.sessionService!.addMessage(sessionKey, {
+      role: "assistant",
+      content: "Plan recorded. Decision: deploy to AWS ECS. TODO: run smoke tests. Open question: use Redis?",
+      contentText: "Plan recorded. Decision: deploy to AWS ECS. TODO: run smoke tests. Open question: use Redis?",
+    });
+    await hub!.apiRuntime.sessionService!.addMessage(sessionKey, {
+      role: "user",
+      content: "Continue with the deployment topic and the ECS plan.",
+      contentText: "Continue with the deployment topic and the ECS plan.",
+    });
+    // Focus whose currentTopicStartSequence covers the seeded turns → topic-window /
+    // focus_topic blocks are eligible. Seeded via the raw (unguarded) service.
+    await hub!.apiRuntime.sessionService!.setConversationFocus(sessionKey, {
+      currentTopicFingerprint: "deployment-topic",
+      currentTopicSummary: "Production deployment to AWS ECS",
+      currentTopicStartSequence: 1,
+      assistantAnchorSummary: "Plan recorded; deploy to AWS ECS",
+      lastTurnKind: "new_topic" as const,
+      updatedAt: "2020-01-01T00:00:00.000Z",
+    });
+
+    // Read-only snapshot of replay rows BEFORE the channel turn (instance-agnostic,
+    // store-level): open the hub's SQLite file directly (WAL → concurrent reader OK).
+    const dbPath = path.join(stateDir!, "friday.db");
+    const replayRepo = createFridayAgentContextReplayRepository();
+    const readReplayRowCount = (): number => {
+      const reader = new Database(dbPath, { readonly: true });
+      try {
+        return replayRepo.listCompactionSummariesBySession(reader, { sessionKey, limit: 100 }).length;
+      } finally {
+        reader.close();
+      }
+    };
+    const replayRowsBefore = readReplayRowCount();
+
+    // Drive the deterministic daemon-status turn through the real channelMessageHandler →
+    // channel orchestration engine. The turn-preparer runs FIRST (before dispatch) and is
+    // where persistCompactionEvidence would fire. With the flag unset it fails closed.
+    onMessage!(inbound);
+    await new Promise((resolve) => setTimeout(resolve, 400));
+
+    // PRIMARY (store-level, instance-agnostic): NO new compaction-evidence replay row.
+    const replayRowsAfter = readReplayRowCount();
+    expect(replayRowsAfter).toBe(replayRowsBefore);
+    expect(replayRowsAfter).toBe(0);
+
+    // Prove the channel turn ACTUALLY executed the engine path (not a tautology where the
+    // compaction evidence was simply null): the deterministic daemon-status reply is
+    // delivered outbound. (The same proof the sibling control-plane tests use.)
+    expect(channel.sentMessages.some((t) => /daemon/iu.test(t))).toBe(true);
+
+    // Regression: the sibling guarded writes (addMessage / setConversationFocus) remain
+    // fenced too → no NEW assistant/user rows beyond the 3 seeded, and the seeded focus
+    // is byte-unchanged.
+    const messages = await hub!.apiRuntime.sessionService!.getMessages(sessionKey).catch(() => []);
+    expect(messages.filter((m) => m.role === "assistant")).toHaveLength(1); // only the seed
+    expect(messages.filter((m) => m.role === "user")).toHaveLength(2); // only the seeds
+    const focusAfter = await hub!.apiRuntime.sessionService!.getConversationFocus(sessionKey);
+    expect(focusAfter?.currentTopicSummary).toBe("Production deployment to AWS ECS");
+
+    // The fenced persistCompactionEvidence call is wrapped in `.catch(() => undefined)` in the
+    // turn-preparer → no unhandled rejection escapes.
+    const replayRejections = unhandled.filter((r) => {
+      const code = (r as { code?: unknown } | null)?.code;
+      const message = r instanceof Error ? r.message : "";
+      return code === "TS_RUNTIME_SESSION_RETIRED" || /session execution is fail-closed/u.test(message);
+    });
+    expect(replayRejections).toHaveLength(0);
   });
 });

--- a/test/unit/hub/friday-hub-bootstrap.test.ts
+++ b/test/unit/hub/friday-hub-bootstrap.test.ts
@@ -163,6 +163,11 @@ describe("createFridayHub", () => {
     await fs.mkdir(bundledSkillsDir, { recursive: true });
     await fs.mkdir(managedSkillsDir, { recursive: true });
     hub = await createFridayHub({
+      // G5 channel-mirror write guard (TS-retirement): these hub tests drive the
+      // real channelMessageHandler and assert mirrored session messages; opt in
+      // to the test-oracle flag so the channel-mirror addMessage path stays live.
+      // Overridable per-test (e.g. to prove default fail-closed).
+      allowTestOnlySessionExecution: true,
       skillDirs: [bundledSkillsDir, managedSkillsDir],
       stateDir,
       ...overrides,


### PR DESCRIPTION
Closes two **LATENT** (channel-bindings=0) route-only-guard defects from `TS_RECON_TRUTH_ROADMAP_20260610.md` §2 rows **G4** and **G5**, mirroring the #628 family method-guard idiom. Both surfaces become method-fenced live-pending-Rust-ownership; nothing is replaced and **this is NOT v1 GO progress**.

> **Adversarial-review fixup (commit `85e70785`):** the original G5 was found INCOMPLETE — it guarded only the 9 handler-direct mirror sites and explicitly (and incorrectly) left the channel **engine** session writes out of scope. The engine's **control-plane** writes are session-mirror-family and were a real bypass. This is now fixed: G5 covers **both** the handler-direct mirror **and** the engine control-plane channel session writes. See the corrected "G5 — both layers" section below.

> **Re-review fixup (commit `63cf0398`):** the engine-layer fix (`85e70785`) guarded `channelEngineSessionDeps.addMessage` but left a **SIBLING write** — `channelEngineSessionDeps.setConversationFocus` — on the **same dep object** unguarded. The run-executor's control-plane finalize does TWO awaited writes per branch (`addMessage` THEN `setConversationFocus`, each `.catch(() => undefined)`-swallowed); because the addMessage rejection is caught, flow STILL reached the unguarded `setConversationFocus`, which rewrites focus state (currentTopicSummary, assistantAnchorSummary, lastRunId, anchors, fingerprints, task ledger) on pre-existing channel session rows — a residual TS session-state write surviving the retirement flag. Now fixed: G5 fences the **COMPLETE** channel-engine session-write surface (`addMessage` + `setConversationFocus`). The `getConversationFocus` / `getMessages` **reads** stay live (reads are not retirement-in-scope).

## G4 — workflow run-control method guards (resume/retry/cancel)
`startRun` already had a METHOD-level fail-closed guard (`workflow-execution-service.ts:1202-1223`), but its three run-control siblings did **not**.

**Bypass paths:** `resumeRun` / `retryRun` / `cancelRun` are reachable off-route via `dispatchManagedAsync` (`managed-async-dispatch.ts:48,57,66`) ← channel orchestration (`friday-hub-bootstrap.ts`), and `resumeRun` additionally via workflow-approval approve → resumeRun — all bypassing the POST-only HTTP route guard. **Latent until channel-bound** (current hub has 0 channel trigger registrations).

Added the **identical** guard block to each: throws `TS_RUNTIME_WORKFLOW_RUNS_RETIRED` (503, `classification: fail_closed`, `replacement: rust_owned_workflow_run_entrypoint_required`) **before** the first `getRunById` / plan rebuild / node re-entry / retry-attempt creation / write — unless `deps.allowTestOnlyWorkflowRunExecution === true`. `cancelRun` is lower-severity (no node re-entry) but still aborts in-flight controllers + writes terminal state, so guarded for consistency. **Same flag + family as startRun → no new plumbing** (flag already threads service ← hub-config ← bootstrap, OFF in prod, default-true in mock-env). startRun's existing message already reads *"execution **and controls** are fail-closed"*, written for exactly this.

**G4 is unchanged by either fixup** — it was reviewed CLEAN and is not touched by commits `85e70785` / `63cf0398`.

## G5 — channel session-mirror write guard (BOTH layers, fail-closed)
**Bypass path:** the channel webhook ingress → `channelMessageHandler` path persists channel traffic into the TS session store via `FridaySessionService.addMessage` (`session-service.ts:334`, `withWriteTransaction`). The session **route** write is already retired (`assertSessionTestOracleAllowed` → `TS_RUNTIME_SESSION_RETIRED`), but the off-route channel writes were unguarded. **Latent until channel-bound.** There are **two distinct channel-write layers**, both now fail-closed:

### Layer 1 — handler-direct mirror (9 sites)
`addMessage` is **shared** — legitimate non-channel callers include API session routes, the agent sessions tool, engine turn-preparer/run-executor, subagent lineage, and parent-summary writes. **Guarding the method globally would break those.** So the guard is placed at the **channel-mirror caller boundary**: a single typed local `mirrorChannelSessionMessage` inside `channelMessageHandler` that fail-closes with the **same family + flag** as the retired session route (`TS_RUNTIME_SESSION_RETIRED`, `replacement: rust_owned_session_lifecycle_entrypoint_required`, gated by `config.allowTestOnlySessionExecution`). All **9** channel-mirror addMessage call sites (`routeId: hub.channel.session.mirror.*`) route through it. Each of the 9 already has a chained non-fatal `.catch` (`W-CH-SESSION-MIRROR-001`), so under flag-unset the fenced rejection is caught gracefully — no unhandled rejection, handler does not crash.

### Layer 2 — channel ENGINE control-plane writes (fixup `85e70785` + re-review fixup `63cf0398`)
**Corrects the prior commits' mis-scope.** The channel orchestration **engine** writes session state through a SEPARATE binding — `channelEngineSessionDeps` (`friday-hub-bootstrap.ts:~8265`). This dep has **exactly two WRITE methods** plus two READS:

| method | kind | guarded? |
|---|---|---|
| `getMessages` | READ | live (reads stay live) |
| `addMessage` | **WRITE** | fail-closed (`85e70785`) |
| `getConversationFocus` | READ | live (reads stay live) |
| `setConversationFocus` | **WRITE** | fail-closed (`63cf0398`) |

On the channel path the run-executor's **control-plane** finalize does TWO awaited writes per branch — `sessionDeps.addMessage` THEN `sessionDeps.setConversationFocus` — **BEFORE** the agent-runtime executeRun guard, at:
- `finalizeControlPlane` (`friday-engine-run-executor.ts:261/269`) — deterministic-classified + managed-async dispatch responses (incl. a workflow-control **denial** response)
- planning-gate **return** branch (`:371/:383`), **approve** branch (`:427`), and **reject** branch (`:459/:467`)
- post-agent-runtime finalize (`:538`)

All **5** `setConversationFocus` call sites on the channel engine path are `.catch(() => undefined)`-wrapped, so the fail-closed rejection is swallowed cleanly (no half-state, no unhandled rejection, turn does not crash).

**Why both methods matter:** the original `85e70785` fix guarded `addMessage` only. Because each control-plane `addMessage` is `.catch`-swallowed, its fail-closed rejection was caught and flow STILL reached the unguarded **sibling** `setConversationFocus`, which rewrote focus state (currentTopicSummary, assistantAnchorSummary, lastRunId, reply anchors, fingerprints, task ledger) on pre-existing channel session rows. `setConversationFocus` is retirement-in-scope (the `/v1/sessions/:key/compact` focus route is gated behind `assertSessionTestOracleAllowed`). `63cf0398` applies the **identical** fail-closed check (`TS_RUNTIME_SESSION_RETIRED`, 503, `classification: fail_closed`, `replacement: rust_owned_session_lifecycle_entrypoint_required`, gated by `config.allowTestOnlySessionExecution`) to the `setConversationFocus` binding. **No new flag.** The `getConversationFocus` / `getMessages` **reads** stay live per the retirement.

`channelEngineSessionDeps` is **channel-only** (definition + turnPreparer/runExecutor sessionDeps → `channelOrchestrationEngine`); the API/non-channel engine uses a **separate** `engineSessionDeps` (`friday-api-runtime.ts:3806`, bound to `sessionService`) — **unaffected** by either guard.

**After this fix, the COMPLETE channel-path session-write surface (handler-direct mirror AND engine control-plane addMessage AND engine control-plane setConversationFocus) fails-closed when `allowTestOnlySessionExecution` is unset (prod default); channel-engine reads stay live.**

## CI plumbing
G4 reuses the already-plumbed `allowTestOnlyWorkflowRunExecution`; G5 (both layers, both write methods) reuses the already-plumbed `allowTestOnlySessionExecution` (both default-true in `mock-env`). **No new hub-config / mock-env flags.** Test hubs that drive the real `channelMessageHandler` and assert mirrored messages opt in (`friday-hub-bootstrap.test` `createIsolatedHub`, `friday-channel-natural-trigger-runtime` `createIsolatedHub`, phase24 trusted-inbound integration, discord-live e2e). The reflex-review-center **ui browser-e2e** already sets the flag true (verified — no browser-e2e drives a channel session write with the flag unset) → `test:e2e:ui` (chromium) stays green.

## Tests (default fail-closed + flag-on, per #628)
- **G4** (`friday-workflow-trigger-retirement-guard.test`): resume/retry/cancel each throw `TS_RUNTIME_WORKFLOW_RUNS_RETIRED` before any DB read (flag unset, non-existent runId proves the guard precedes the not-found lookup, 0 run rows); flag-on positive proves they reach the body (downstream `WORKFLOW_RUN_NOT_FOUND`, not the retired code). **11/11.**
- **G5 Layer 1** (`friday-channel-natural-trigger-runtime.test`): a channel message driven through the real handler with the flag **UNSET** mirrors **0** session messages and emits **no** unhandledRejection.
- **G5 Layer 2 — addMessage KAT** (`friday-channel-natural-trigger-runtime.test`): a **deterministic control-plane** channel message (`"daemon status"` → `sync_immediate` / `daemon_status`, delegated to the channel engine and **not** intercepted by the handler's pre-engine approval/reflex routing → reaches `finalizeControlPlane`) with the flag **UNSET** persists **0 assistant** + **0 user** session rows; the shared `sessionService.addMessage` spy is never called; the deterministic reply is still delivered outbound (proving the control-plane path actually executed, not a short-circuited full-agent tautology); no `TS_RUNTIME_SESSION_RETIRED` unhandledRejection. Proven RED with the binding guard removed, GREEN with it in place.
- **G5 Layer 2 — setConversationFocus KAT — NEW (`63cf0398`)** (`friday-channel-natural-trigger-runtime.test`): on a **SEEDED pre-existing session row** (`getOrCreateSession` + a sentinel focus written via the raw unguarded service), the same deterministic `"daemon status"` control-plane turn with the flag **UNSET** leaves the seeded focus **BYTE-UNCHANGED** (PRIMARY, instance-agnostic: `JSON.stringify(focusAfter) === JSON.stringify(focusBefore)`; sentinel `currentTopicSummary` / `assistantAnchorSummary` / `lastRunId` intact), the raw `setConversationFocus` spy sees **0** post-seed calls (SECONDARY), `addMessage` still **0** rows (regression), the deterministic reply is still delivered outbound, and **no** `TS_RUNTIME_SESSION_RETIRED` unhandledRejection. **Empirically proven RED with the `setConversationFocus` guard removed (`finalizeFridayConversationFocus` rewrites the focus → `focusMutated` true → FAIL), GREEN with the guard in place.** Channel-engine guard suite now **3/3** (inbound mirror + control-plane addMessage + control-plane focus); channel-natural-trigger file **13/13**.

## Gates
- build (api `tsc` + ui) clean
- lint **0 errors**
- vitest: channel-natural-trigger **13/13** (incl. new setConversationFocus KAT), trigger-retirement-guard 11/11, engine run-executor 3/3, hub-bootstrap 20/20, sessions+session-routes 488/488
- `check:ts-runtime-retirement`: **status=passed, blockerFamilies=[] (blocker=0), routeCount=584 unchanged, manifest byte-unchanged (adds no route)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Cycle 4 (`6b254f44`) — COMPLETE channel-engine write-sink enumeration (close the surface)

The third review cycle found a **third** channel-engine session/memory write sink — `persistCompactionEvidence` — that was separately wired (NOT through `channelEngineSessionDeps`) and so bypassed `allowTestOnlySessionExecution`. To end the whack-a-mole, this cycle enumerates **every** method injected into the channel orchestration engine (`createFridayOrchestrationEngine` at bootstrap ~8316: `turnPreparerDeps` + `runExecutorDeps`; the channel engine wires **no** `resumeDeps` and **no** `markStaleRunsFailed`, so `resumeRun`/`cancelRun`/`resumeStaleRunsOnBoot` are inert no-ops for this engine) and classifies each as WRITE/READ + guarded.

### COMPLETE write-sink enumeration (every method injected into the channel engine)

**turnPreparerDeps**

| Dep method | Write/Read | Guarded? |
|---|---|---|
| `sessionDeps.getMessages` | READ (session history) | live (reads stay live) |
| `sessionDeps.addMessage` | **WRITE** (session message) | ✅ guarded (cycle 1/2, channelEngineSessionDeps closure) |
| `sessionDeps.getConversationFocus` | READ (focus) | live |
| `sessionDeps.setConversationFocus` | **WRITE** (conversation focus) | ✅ guarded (cycle 3 `63cf0398`, channelEngineSessionDeps closure) |
| `persistCompactionEvidence` → `agentCompactionContextReplaySink.persist` → `appendCompactionSummary` (`friday_agent_context_replay_entries`) | **WRITE** (derived session/memory context-replay evidence) | ✅ **guarded THIS cycle `6b254f44`** (bootstrap ~8326 closure, same family+flag) |
| `nowIso` | READ (clock) | n/a |
| `prepareTurn` (`prepareFridayConversationTurn`) | READ/pure (turn classification over in-memory records) | n/a |
| `buildEvidenceBlocks` (`buildFridayEvidenceBlocks`) | READ/pure | n/a |
| `classifyExecution` (`classifyFridayExecution`) | READ/pure | n/a |
| `capabilitySnapshotGetter` (`getAgentCapabilitySnapshot`) | READ (snapshot) | live |
| `taskStatusSnapshotGetter` (`getAgentTaskStatusSnapshot`) | READ (snapshot) | live |

**runExecutorDeps**

| Dep method | Write/Read | Guarded? |
|---|---|---|
| `sessionDeps.addMessage` / `setConversationFocus` / `getConversationFocus` | same `channelEngineSessionDeps` object as above | ✅ writes guarded; reads live |
| `agentRuntime.executeRun` | WRITE (full agent run) | downstream, fenced by `allowTestOnlyAgentRunExecution` at executeRun:803 (not this surface) |
| `planningGate.handleTurn` | READ/pure (returns a decision) | n/a |
| `planningGate.approvePlan` | WRITE — but delegates into `agentRuntime` | downstream, fenced at executeRun:803 |
| `planningGate.rejectPlan` + its `repo.update` / `runEventRepository.append` (`agent_runs` / `run_events`) | **WRITE — different surface (agent-run-lifecycle)** | not fenced under the session flag **by design** (own surface: `allowTestOnlyAgentRunExecution`) — explicit out-of-scope |
| `persistImmediateRunResult` (`repo.create/update` + `runEventRepository.append`, `agent_runs` / `run_events`) | **WRITE — different surface (agent-run-lifecycle)** | not fenced under the session flag **by design** — explicit out-of-scope |
| `dispatchDeterministic` (+ `deterministicDispatchDeps`) — incl. `approvalService.approve/reject` | **WRITE — different surface (workflow approval / run-control, G4)** | not fenced under the session flag **by design** (G4: `TS_RUNTIME_WORKFLOW_RUNS_RETIRED`) — explicit out-of-scope |
| `dispatchManagedAsync` (+ `managedAsyncDispatchDeps`) — `workflowExecutionService.cancelRun/retryRun/resumeRun` | **WRITE — different surface (workflow run-control, G4)** | already fenced by **G4** (`TS_RUNTIME_WORKFLOW_RUNS_RETIRED`) — explicit out-of-scope here |
| `finalizeFocus` (`finalizeFridayConversationFocus`) | READ/pure (returns a focus object; the actual write is `sessionDeps.setConversationFocus`, already guarded) | n/a |
| `resolveIdempotencyKey` (`resolveAgentMirrorIdempotencyKey`) | READ/pure (computes a key) | n/a |

**Result: every session/memory-state WRITE injected into the channel engine is now fenced under `allowTestOnlySessionExecution` (addMessage, setConversationFocus, persistCompactionEvidence). The remaining WRITEs are explicitly classified as either downstream of the executeRun:803 agent-run guard or belonging to a different retirement surface (agent-run-lifecycle / G4 workflow run-control) — not silently omitted.**

**Sink completeness:** `agentCompactionContextReplaySink` has exactly three consumers — the parent agent runtime and the sub-agent runtime (bootstrap ~4851 / ~5172, both **inside** `createFridayAgentRuntime`, downstream of executeRun:803, already fenced) and this turn-preparer closure. The turn-preparer closure is the **only** channel path to the sink **before** the executeRun guard, so guarding it closes the surface.

### Graceful degradation (per new guard)
`persistCompactionEvidence` is invoked at `friday-engine-turn-preparer.ts` ~455–463 as `await Promise.resolve(persistCompactionEvidence({...})).catch(() => undefined)`. The new guard returns a **rejected promise** (never throws synchronously), so the `.catch(() => undefined)` swallows it → no half-state, no unhandled rejection, the turn does not crash; the deterministic reply is still delivered.

### Test — NEW KAT (`6b254f44`)
`friday-channel-natural-trigger-runtime.test` → "does NOT persist a compaction-evidence replay row for a channel turn with rich seeded context": seed a pre-existing session with a multi-turn deployment topic + a focus whose `currentTopicStartSequence` covers the seeded turns (raw unguarded service), so `prepareTurn` yields `focus_topic`/`topic_block` selectedBlocks → `buildSelectedBlockCompactionEvidence` non-null → `persistCompactionEvidence` fires in the turn-preparer (before dispatch / before executeRun). With the flag **UNSET**: open the hub's `friday.db` directly (WAL → concurrent reader) and assert **0** rows in `friday_agent_context_replay_entries` (PRIMARY, instance-agnostic), the deterministic `"daemon status"` reply is still delivered outbound, the sibling addMessage/setConversationFocus writes are still fenced (only the 3 seeded rows; seeded focus intact), and **no** `TS_RUNTIME_SESSION_RETIRED` unhandledRejection. **Empirically proven RED with the guard removed (1 replay row lands → FAIL), GREEN with it in place.** Channel-engine guard suite now **4/4**; channel-natural-trigger file **14/14**.

### Gates (cycle 4)
- build (api `tsc` + ui) clean
- lint **0 errors**
- vitest: channel-natural-trigger **14/14** (incl. new persistCompactionEvidence KAT), trigger-retirement-guard (G4) **11/11**, engine **48/48**, sessions **404/404**
- `check:ts-runtime-retirement`: **status=passed, blockerFamilies=[] (blocker=0), routeCount=584 unchanged, manifest byte-unchanged**
- Scope: CHANNEL-only (the non-channel API engine uses separate `engineSessionDeps` + `engineCompactionContextReplaySink` + route-layer guards — untouched). G4 run-control guards + the 9 handler mirror sites — untouched.
