### PR TITLE
feat(ts-retirement): TS-R4/G2 — default-OFF flag guard for UIX skillExecutor.execute + skill-gen mutators (zero-degradation lever, ready to enable)

### DIFF
--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -1909,6 +1909,20 @@ export interface FridayHubConfig {
   /** Test-oracle only; production hub creation must leave the system-service `executeIntent` method fail-closed. */
   allowTestOnlySystemIntentExecution?: boolean;
   /**
+   * TS Runtime Retirement — GAP G2: DEFAULT-OFF (INVERTED polarity) guard for the
+   * UIX starter-skill execution lane (`executeStarterSkillTemplate`, route
+   * POST /v1/uix/templates/:templateId/execute + assistant intent resolver) and
+   * the UIX-driven skill-generator session mutators. UIX starter-skill execution
+   * is an ACCEPTED-LIVE v1 feature (operator decision DEC-3a) and is NOT in the
+   * retirement set, so unlike the `allowTestOnly*` flags this DEFAULTS FALSE —
+   * the guard is INERT and starter skills keep working exactly as today (zero
+   * degradation). Set `true` only when the operator decides to Rust-own skill
+   * execution (R11): the lane then fails closed (503
+   * TS_RUNTIME_SKILL_RUNS_RETIRED / TS_RUNTIME_SKILL_GENERATOR_RETIRED).
+   * Production leaves this unset.
+   */
+  enforceUixSkillExecRetirement?: boolean;
+  /**
    * execrun-replacement slice 4 (DARK): per-run "route a qualifying agent-run via the
    * future Rust read-only loop" flag. DEFAULT-FALSE — production hub creation must leave
    * this unset so the startRun route stays byte-identical to today (it computes nothing

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -1400,6 +1400,12 @@ export async function createFridayHub(
         task: input.task,
         surface: input.surface,
       }),
+    // TS Runtime Retirement — GAP G2 (DEFAULT-OFF): production leaves this unset
+    // so the skill-generator session mutators behave exactly as today (the
+    // UIX-driven `generate-skill` flow + agent skill-generator tool keep
+    // working). Flip true only when the operator decides to Rust-own skill
+    // generation (R11) — then the mutators fail closed.
+    enforceUixSkillExecRetirement: config.enforceUixSkillExecRetirement,
   });
 
   // 9. Create converter service
@@ -5968,6 +5974,12 @@ export async function createFridayHub(
     sessionService: hubSessionService,
     skillGenerator,
     skillExecutor: executor,
+    // TS Runtime Retirement — GAP G2 (DEFAULT-OFF): production leaves this unset
+    // so UIX starter-skill execution (executeStarterSkillTemplate) behaves
+    // exactly as today — zero degradation. Flip true only when the operator
+    // decides to Rust-own skill execution (R11) — then the UIX skill-exec lane
+    // fails closed (TS_RUNTIME_SKILL_RUNS_RETIRED).
+    enforceUixSkillExecRetirement: config.enforceUixSkillExecRetirement,
     workflowGenerator,
     workflowProduct: workflowProductService,
     selfHealing: selfHealingApiService,

--- a/src/skills/generator/services/friday-skill-generator-service.ts
+++ b/src/skills/generator/services/friday-skill-generator-service.ts
@@ -589,6 +589,42 @@ function autoResolveSkillGeneratorClarifications(input: {
 export function createFridaySkillGeneratorService(
   deps: CreateFridaySkillGeneratorServiceDeps,
 ): FridaySkillGeneratorService {
+  // ─── TS Runtime Retirement — GAP G2: DEFAULT-OFF method-level guard ───
+  // INVERTED polarity vs the `allowTestOnly*` idiom. The UIX-driven
+  // skill-generator session mutators (startSession/submitTurn/generateDraft/
+  // approveAndSave) are NOT in the retirement set and are an ACCEPTED-LIVE v1
+  // feature (operator decision DEC-3a). They reach this service OFF-ROUTE — via
+  // the UIX `executeTemplate` `generate-skill` flow and the agent
+  // skill-generator tool — bypassing the route-level
+  // `allowTestOnlySkillGeneratorExecution` guard.
+  //
+  // This guard DEFAULTS OFF: when `enforceUixSkillExecRetirement` is
+  // false/undefined (the default, INCLUDING production today) it is INERT and
+  // these methods behave exactly as before — ZERO degradation, starter-skill
+  // generation keeps working. It is a dormant lever: flip
+  // `enforceUixSkillExecRetirement === true` later (when the operator decides to
+  // Rust-own skill generation — R11) and every mutator fails closed with a 503
+  // `TS_RUNTIME_SKILL_GENERATOR_RETIRED` BEFORE any session-row write or
+  // provider call. `cancelSession` is deliberately left live so an in-flight
+  // session can still be abandoned post-flip. Reads stay live. NOTE: flipping ON
+  // also fail-closes the agent skill-generator tool generator path (both share
+  // this service instance; R11 owns both).
+  function assertUixSkillGenerationExecutionAllowed(): void {
+    if (deps.enforceUixSkillExecRetirement === true) {
+      throw new FridayDomainError(
+        "TS_RUNTIME_SKILL_GENERATOR_RETIRED",
+        "Skill generator execution is fail-closed while generator ownership is being moved out of TypeScript.",
+        {
+          httpStatus: 503,
+          details: {
+            classification: "fail_closed",
+            replacement: "rust_owned_skill_generator_entrypoint_required",
+          },
+        },
+      );
+    }
+  }
+
   const repo: FridaySkillGenerationSessionRepository =
     createFridaySkillGenerationSessionRepository({
       db: deps.db,
@@ -1688,6 +1724,7 @@ export function createFridaySkillGeneratorService(
     async startSession(
       input: FridayStartSkillGenerationRequest,
     ): Promise<FridaySkillGenerationTurnResponse> {
+      assertUixSkillGenerationExecutionAllowed();
       assertSafeSkillGenerationGoal(input.goal);
       const now = deps.nowIso();
       const sessionId = deps.idGenerator();
@@ -1812,6 +1849,7 @@ export function createFridaySkillGeneratorService(
       sessionId: string,
       input: FridaySkillGenerationTurnRequest,
     ): Promise<FridaySkillGenerationTurnResponse> {
+      assertUixSkillGenerationExecutionAllowed();
       const session = requireSession(sessionId);
       assertSafeSkillGenerationGoal(`${session.goal}\n${input.message}`);
 
@@ -1955,6 +1993,7 @@ export function createFridaySkillGeneratorService(
       sessionId: string,
       requestedModel?: string,
     ): Promise<FridayGeneratedSkillDraft> {
+      assertUixSkillGenerationExecutionAllowed();
       const session = requireSession(sessionId);
       assertSafeSkillGenerationGoal(`${session.goal}\n${session.specSummary}`);
 
@@ -2071,6 +2110,7 @@ export function createFridaySkillGeneratorService(
     },
 
     async approveAndSave(sessionId: string, input = {}) {
+      assertUixSkillGenerationExecutionAllowed();
       const session = requireSession(sessionId);
 
       if (session.status !== "ready_for_review") {

--- a/src/skills/generator/services/friday-skill-generator-service.types.ts
+++ b/src/skills/generator/services/friday-skill-generator-service.types.ts
@@ -90,4 +90,25 @@ export interface CreateFridaySkillGeneratorServiceDeps {
     channel?: string;
     surface: "skill_generator";
   }) => string | null | Promise<string | null>;
+  /**
+   * TS Runtime Retirement — GAP G2 (DEFAULT-OFF / INVERTED polarity).
+   *
+   * Unlike the `allowTestOnly*` retirement flags (which DEFAULT the guard ON /
+   * fail-closed and require an explicit opt-in to run legacy TS), THIS flag
+   * DEFAULTS the guard OFF. The UIX-driven skill-generator session mutators
+   * (`startSession`/`submitTurn`/`generateDraft`/`approveAndSave`) are NOT in the
+   * retirement set and are an ACCEPTED-LIVE v1 feature (operator decision
+   * DEC-3a). They reach this service off-route (via UIX `executeTemplate`
+   * `generate-skill` and the agent skill-generator tool), bypassing the
+   * route-level `allowTestOnlySkillGeneratorExecution` guard.
+   *
+   * When `false`/undefined (the default, INCLUDING production today) the guard is
+   * INERT and these methods behave exactly as before — zero degradation. When
+   * explicitly `true` the methods fail closed with a 503
+   * `TS_RUNTIME_SKILL_GENERATOR_RETIRED` BEFORE any session write or provider
+   * call. This is the dormant lever to flip ON later when the operator decides
+   * to Rust-own skill generation (R11). Flipping it on also fail-closes the
+   * agent skill-generator tool path (both share this service / R11 owns both).
+   */
+  enforceUixSkillExecRetirement?: boolean;
 }

--- a/src/uix/services/friday-uix-surface-service.ts
+++ b/src/uix/services/friday-uix-surface-service.ts
@@ -149,6 +149,31 @@ export interface CreateFridayUixSurfaceServiceDeps {
   /** Optional writer to emit learning events when preferences are updated via API. */
   learningEventWriter?: (events: Array<{ eventId: string; ts: string; userId: string; kind: "user_correction"; payload: Record<string, unknown> }>) => void;
   nowIso?: () => string;
+  /**
+   * TS Runtime Retirement — GAP G2 (DEFAULT-OFF / INVERTED polarity).
+   *
+   * Gates ONLY the UIX starter-skill execution lane on THIS service
+   * (`executeStarterSkillTemplate` → `skillExecutor.execute`, reached from the
+   * public route POST /v1/uix/templates/:templateId/execute and the assistant
+   * intent resolver). `uix.templates.execute` is NOT in the retirement set; UIX
+   * starter-skill execution is an ACCEPTED-LIVE v1 feature (operator decision
+   * DEC-3a). The UIX-driven skill-generator session mutators are gated by the
+   * skill-generator SERVICE's own `enforceUixSkillExecRetirement` instance (NOT
+   * this UIX flag); both read the same hub-config value so they flip together,
+   * but the guard for each lives on the service that owns the mutation.
+   *
+   * Unlike the `allowTestOnly*` retirement flags (default guard ON / fail-closed,
+   * opt-in to run legacy TS), this flag DEFAULTS the guard OFF. When
+   * `false`/undefined (the default, INCLUDING production today) the guard is
+   * INERT and starter skills execute exactly as before — ZERO degradation. When
+   * explicitly `true` the lane fails closed with a 503
+   * `TS_RUNTIME_SKILL_RUNS_RETIRED` BEFORE any skill execution. This is the
+   * dormant lever to flip ON later when the operator decides to Rust-own skill
+   * execution (R11). NOTE: the guard lives in the UIX `executeStarterSkillTemplate`
+   * wrapper (NOT in the shared `skillExecutor.execute` method) so flipping it on
+   * does NOT fail-close the agent skill-tool execution path — only the UIX lane.
+   */
+  enforceUixSkillExecRetirement?: boolean;
 }
 
 const TEMPLATE_DEFINITIONS: FridayActionTemplateSummary[] = [
@@ -1447,6 +1472,33 @@ export function createFridayUixSurfaceService(
     defaultSummary: string;
     tenantContext?: FridayProviderTenantContext;
   }) {
+    // ─── TS Runtime Retirement — GAP G2: DEFAULT-OFF lane guard ───
+    // INVERTED polarity vs the `allowTestOnly*` idiom. This is the single
+    // chokepoint for every UIX starter-skill execution call site (the public
+    // route POST /v1/uix/templates/:templateId/execute via `executeTemplate`,
+    // and the assistant intent resolver `uix.intents.resolve`). UIX starter-skill
+    // execution is NOT in the retirement set — it is an ACCEPTED-LIVE v1 feature
+    // (operator decision DEC-3a), so this guard DEFAULTS OFF and is INERT:
+    // when `enforceUixSkillExecRetirement` is false/undefined (the default,
+    // INCLUDING production today) starter skills execute exactly as before —
+    // ZERO degradation. Flip the flag `=== true` later (when the operator decides
+    // to Rust-own skill execution — R11) and the lane fails closed BEFORE any
+    // `skillExecutor.execute` call. The guard is placed in THIS wrapper, not in
+    // the shared `skillExecutor.execute` method, so flipping it on does NOT
+    // fail-close the agent skill-tool execution path — only the UIX lane.
+    if (deps.enforceUixSkillExecRetirement === true) {
+      throw new FridayDomainError(
+        "TS_RUNTIME_SKILL_RUNS_RETIRED",
+        "Skill run execution is fail-closed while runtime ownership is being moved out of TypeScript.",
+        {
+          httpStatus: 503,
+          details: {
+            classification: "fail_closed",
+            replacement: "rust_owned_skill_run_entrypoint_required",
+          },
+        },
+      );
+    }
     if (!deps.skillExecutor) {
       throw new FridayDomainError(
         "UIX_STARTER_SKILL_UNAVAILABLE",

--- a/test/e2e/mock/_helpers/mock-env.ts
+++ b/test/e2e/mock/_helpers/mock-env.ts
@@ -371,6 +371,18 @@ export async function createMockHubEnv(opts?: {
   allowTestOnlyProviderRoutingControlsExecution?: boolean;
   /** Test-oracle opt-in for legacy TS capability-acquisition run mutations; set false to prove default fail-closed behavior. */
   allowTestOnlyCapabilityAcquisitionExecution?: boolean;
+  /**
+   * TS Runtime Retirement — GAP G2: DEFAULT-OFF (INVERTED polarity) guard for the
+   * UIX starter-skill execution lane + UIX-driven skill-generator mutators. Unlike
+   * the `allowTestOnly*` flags (which default TRUE here so legacy TS runs in
+   * tests), this DEFAULTS FALSE — the guard stays INERT so UIX starter-skill
+   * execution keeps working exactly as today (zero degradation, all current green
+   * preserved). Set true to PROVE the lever fires (503
+   * TS_RUNTIME_SKILL_RUNS_RETIRED / TS_RUNTIME_SKILL_GENERATOR_RETIRED).
+   * (Anchored above `allowTestOnlySystemIntentExecution` to leave intervening
+   * context vs the concurrent G1 sibling PR's adjacent flag insertion.)
+   */
+  enforceUixSkillExecRetirement?: boolean;
   /** Test-oracle opt-in for the legacy TS system-service `executeIntent` method; set false to prove default fail-closed behavior. */
   allowTestOnlySystemIntentExecution?: boolean;
   /**
@@ -443,6 +455,13 @@ export async function createMockHubEnv(opts?: {
       allowTestOnlyProviderProbeExecution: opts?.allowTestOnlyProviderProbeExecution ?? true,
       allowTestOnlyProviderRoutingControlsExecution: opts?.allowTestOnlyProviderRoutingControlsExecution ?? true,
       allowTestOnlyCapabilityAcquisitionExecution: opts?.allowTestOnlyCapabilityAcquisitionExecution ?? true,
+      // TS Runtime Retirement — GAP G2: DEFAULT-FALSE (INVERTED polarity), unlike
+      // the allowTestOnly* flags which default true. Default-off keeps UIX
+      // starter-skill execution + skill-gen mutators live (zero degradation);
+      // a focused test passes true to prove the 503 lever fires. (Anchored above
+      // allowTestOnlySystemIntentExecution to leave intervening context vs the
+      // concurrent G1 sibling PR's adjacent flag insertion.)
+      enforceUixSkillExecRetirement: opts?.enforceUixSkillExecRetirement ?? false,
       allowTestOnlySystemIntentExecution: opts?.allowTestOnlySystemIntentExecution ?? true,
       // execrun-replacement slice 4 (DARK): default-FALSE (honest dark), unlike the
       // allowTestOnly* flags which default true. The predicate is unconsumed this slice.

--- a/test/unit/skills/generator/services/friday-skill-generator-service.test.ts
+++ b/test/unit/skills/generator/services/friday-skill-generator-service.test.ts
@@ -1486,4 +1486,100 @@ describe("FridaySkillGeneratorService", () => {
       }
     });
   });
+
+  // ─── TS Runtime Retirement — GAP G2: DEFAULT-OFF flag guard ───
+  // Pins the INVERTED-polarity lever for the UIX-driven skill-generator session
+  // mutators. Default-off = no behavior change today (current generation works,
+  // zero degradation); flag-on = the mutators fail closed with a 503
+  // TS_RUNTIME_SKILL_GENERATOR_RETIRED BEFORE any session write or provider call.
+  // Lever to flip ON only when skill generation is Rust-owned (R11).
+  describe("GAP G2 skill-generator retirement guard (DEFAULT-OFF)", () => {
+    it("default (enforceUixSkillExecRetirement unset): startSession proceeds exactly as before", async () => {
+      // Sanity: with the guard inert, startSession runs the analyzer (NOT a 503).
+      // We assert it is NOT the retirement error; behavior is the legacy path.
+      mockFetchForLlm([
+        { state: "needs_clarification", questions: ["What format?"], spec: { goal: "Build a timer" } },
+      ]);
+      try {
+        const result = await service.startSession({
+          goal: "Build a timer skill",
+          userId: "user-1",
+          channel: "discord",
+        });
+        expect(result.session.sessionId).toBe("id-1");
+        expect(result.mode).toBe("clarification_required");
+      } finally {
+        restoreFetch();
+      }
+    });
+
+    it("explicit false: startSession proceeds (identical to default, no throw)", async () => {
+      const idGen = vi.fn(() => "id-explicit-false-1");
+      const offDeps: CreateFridaySkillGeneratorServiceDeps = {
+        ...deps,
+        idGenerator: idGen,
+        enforceUixSkillExecRetirement: false,
+      };
+      const offService = createFridaySkillGeneratorService(offDeps);
+      mockFetchForLlm([
+        { state: "needs_clarification", questions: ["What format?"], spec: { goal: "x" } },
+      ]);
+      try {
+        const result = await offService.startSession({
+          goal: "Build a timer skill",
+          userId: "user-1",
+          channel: "discord",
+        });
+        expect(result.mode).toBe("clarification_required");
+        expect(idGen).toHaveBeenCalled();
+      } finally {
+        restoreFetch();
+      }
+    });
+
+    it("flag ON (enforceUixSkillExecRetirement=true): all 4 mutators fail closed 503 TS_RUNTIME_SKILL_GENERATOR_RETIRED with zero side effects", async () => {
+      const idGen = vi.fn(() => "id-guarded-1");
+      const guardedDeps: CreateFridaySkillGeneratorServiceDeps = {
+        ...deps,
+        idGenerator: idGen,
+        enforceUixSkillExecRetirement: true,
+      };
+      const guarded = createFridaySkillGeneratorService(guardedDeps);
+
+      const expected = {
+        code: "TS_RUNTIME_SKILL_GENERATOR_RETIRED",
+        httpStatus: 503,
+        details: {
+          classification: "fail_closed",
+          replacement: "rust_owned_skill_generator_entrypoint_required",
+        },
+      };
+
+      await expect(
+        guarded.startSession({ goal: "Build a timer skill", userId: "user-1", channel: "discord" }),
+      ).rejects.toMatchObject(expected);
+      await expect(
+        guarded.submitTurn("any-session", { message: "go" }),
+      ).rejects.toMatchObject(expected);
+      await expect(
+        guarded.generateDraft("any-session"),
+      ).rejects.toMatchObject(expected);
+      await expect(
+        guarded.approveAndSave("any-session"),
+      ).rejects.toMatchObject(expected);
+
+      // Zero side effects: the guard fires before id allocation / session write /
+      // provider call on every mutator.
+      expect(idGen).not.toHaveBeenCalled();
+    });
+
+    it("flag ON: a read (getSession) stays live (reads are not retired)", async () => {
+      const guarded = createFridaySkillGeneratorService({
+        ...deps,
+        enforceUixSkillExecRetirement: true,
+      });
+      // Unknown session id returns null rather than throwing the retirement 503.
+      await expect(guarded.getSession("missing-session")).resolves.toBeNull();
+    });
+  });
 });

--- a/test/unit/uix/services/friday-uix-surface-service.test.ts
+++ b/test/unit/uix/services/friday-uix-surface-service.test.ts
@@ -1375,4 +1375,115 @@ describe("createFridayUixSurfaceService", () => {
     );
     expect(response.summary).toContain("bounded title fix");
   });
+
+  // ─── TS Runtime Retirement — GAP G2: DEFAULT-OFF flag guard ───
+  // These two tests pin the INVERTED-polarity lever for the UIX starter-skill
+  // execution lane (executeStarterSkillTemplate). Default-off = no behavior
+  // change today (starter skills execute, zero degradation); flag-on = the lane
+  // fails closed with a 503 TS_RUNTIME_SKILL_RUNS_RETIRED BEFORE skillExecutor
+  // runs. This is the lever to flip ON only when skill exec is Rust-owned (R11).
+  describe("GAP G2 UIX skill-exec retirement guard (DEFAULT-OFF)", () => {
+    it("default (enforceUixSkillExecRetirement unset): starter-skill template executes exactly as before", async () => {
+      const execute = vi.fn(() => ({
+        runId: "skill-run-g2-default",
+        result: Promise.resolve({
+          runId: "skill-run-g2-default",
+          status: "completed",
+          output: {
+            summary: "Friday has 0 open issue card(s).",
+            nextStep: "Nothing to review.",
+            details: {},
+          },
+          stdout: "",
+          stderr: "",
+          durationMs: 7,
+        }),
+      }));
+      const service = createFridayUixSurfaceService({
+        selfHealing: {
+          listIssueCards: vi.fn(() => []),
+        } as never,
+        skillExecutor: {
+          execute,
+          cancel: vi.fn(),
+        },
+        // enforceUixSkillExecRetirement intentionally omitted → default OFF.
+      });
+
+      const response = await service.executeTemplate({
+        templateId: "review-issues",
+        userId: "user-1",
+        parameters: {},
+      });
+
+      // Guard is INERT by default: the starter skill runs, current behavior preserved.
+      expect(execute).toHaveBeenCalledOnce();
+      expect(response.status).toBe("executed");
+      expect(response.summary).toContain("open issue");
+    });
+
+    it("explicit false: behaves identically to default (no throw, skill executes)", async () => {
+      const execute = vi.fn(() => ({
+        runId: "skill-run-g2-false",
+        result: Promise.resolve({
+          runId: "skill-run-g2-false",
+          status: "completed",
+          output: { summary: "Friday has 0 open issue card(s).", details: {} },
+          stdout: "",
+          stderr: "",
+          durationMs: 7,
+        }),
+      }));
+      const service = createFridayUixSurfaceService({
+        selfHealing: { listIssueCards: vi.fn(() => []) } as never,
+        skillExecutor: { execute, cancel: vi.fn() },
+        enforceUixSkillExecRetirement: false,
+      });
+
+      const response = await service.executeTemplate({
+        templateId: "review-issues",
+        userId: "user-1",
+        parameters: {},
+      });
+
+      expect(execute).toHaveBeenCalledOnce();
+      expect(response.status).toBe("executed");
+    });
+
+    it("flag ON (enforceUixSkillExecRetirement=true): lane fails closed 503 TS_RUNTIME_SKILL_RUNS_RETIRED before skillExecutor runs", async () => {
+      const execute = vi.fn(() => {
+        throw new Error("skillExecutor.execute must NOT be reached when the retirement guard is on");
+      });
+      const service = createFridayUixSurfaceService({
+        selfHealing: { listIssueCards: vi.fn(() => []) } as never,
+        skillExecutor: {
+          execute,
+          cancel: vi.fn(),
+        },
+        enforceUixSkillExecRetirement: true,
+      });
+
+      let caught: unknown;
+      try {
+        await service.executeTemplate({
+          templateId: "review-issues",
+          userId: "user-1",
+          parameters: {},
+        });
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(caught).toBeInstanceOf(FridayDomainError);
+      const domainError = caught as FridayDomainError;
+      expect(domainError.code).toBe("TS_RUNTIME_SKILL_RUNS_RETIRED");
+      expect(domainError.httpStatus).toBe(503);
+      expect(domainError.details).toMatchObject({
+        classification: "fail_closed",
+        replacement: "rust_owned_skill_run_entrypoint_required",
+      });
+      // Zero side effects: the executor was never invoked.
+      expect(execute).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
## TS-R4 / GAP G2 — DEFAULT-OFF (inverted-polarity) guard

Roadmap ref: `TS_RECON_TRUTH_ROADMAP_20260610.md` §2 row **G2**.

### What G2 is
`uix.templates.execute` (POST `/v1/uix/templates/:templateId/execute`, auth public) + `uix.intents.resolve` → `executeStarterSkillTemplate` → `skillExecutor.execute`, plus the UIX-driven skill-generator session mutators `skills.generator.sessions.{create,generate,approve,messages.create}` (= `startSession`/`generateDraft`/`approveAndSave`/`submitTurn`). These are **NOT** in the 269 retirement set and reach the services **off-route**, bypassing the route-level `allowTestOnlySkillGeneratorExecution` / `allowTestOnlySkillRunExecution` guards.

### DEC-3a — why this guard DEFAULTS OFF
Operator decision **DEC-3a**: G2's UIX starter-skill execution is an **ACCEPTED-LIVE v1 feature**. This PR must **NOT** break it. So — unlike every other gap guard and the `allowTestOnly*` idiom (default ON / fail-closed) — this guard has **INVERTED polarity** and **DEFAULTS OFF**.

### The new flag
**`enforceUixSkillExecRetirement`** (boolean, **DEFAULT FALSE**):
- **FALSE / undefined** (the default, **including production today**): the guard is **INERT**. Starter-skill execution + skill-gen mutators behave **EXACTLY as today** — **zero degradation**, no behavior change.
- **TRUE**: the lane fails closed with a **503** *before* any skill exec / session write / provider call:
  - UIX skill exec (`executeStarterSkillTemplate`) → `TS_RUNTIME_SKILL_RUNS_RETIRED`
  - skill-gen mutators → `TS_RUNTIME_SKILL_GENERATOR_RETIRED`

This is the **dormant lever** to flip ON later when the operator decides to **Rust-own skill execution / generation (R11)**.

### How to enable later
Set `enforceUixSkillExecRetirement: true` in hub-config (threaded `FridayHubConfig` → bootstrap → both the skill-generator service and the UIX surface service). Production leaves it unset.

### Placement (and scope of flip-on)
- **Executor guard** lives in the UIX `executeStarterSkillTemplate` **wrapper** (single chokepoint for ~13 template + intent-resolver call sites), **NOT** in the shared `skillExecutor.execute` method — so flip-on does **not** fail-close the agent skill-tool execution path; only the UIX lane.
- **Generator guards** live on the 4 service methods `startSession`/`submitTurn`/`generateDraft`/`approveAndSave` (the only placement covering all 4 as the gap enumerates — `submitTurn`/`generateDraft`/`approveAndSave` are also reached via the agent skill-generator tool). Flip-on therefore also fail-closes the agent-tool generator path (acceptable — R11 owns both).
- **`cancelSession` is deliberately LEFT LIVE** so an in-flight session can still be abandoned post-flip.

### Tests (both surfaces × both polarities)
- **default-off** (and **explicit-false**): no throw, skill executes / generator proceeds exactly as before.
- **flag-on**: 503 with the correct family code and **zero side effects** (executor never invoked / `idGenerator` never called).
- **flag-on read** (`getSession`) stays live.

### Gates
- `npm run build` clean (tsc + vite); `npm run lint` **0 errors**.
- Full `npm test` (default + typecheck): **12749 passed**, 158 skipped, **1 failure = pre-existing `friday-secret-crypto` keychain machine-env artifact** (byte-identical on origin/main; no security/crypto file touched — confirmed not in this diff).
- uix + skills unit suites 1124 passed; mock validation-chains 22 passed; api-skills routes + agent generator-tools 10 passed.
- **browser-e2e starter-skills closeout 2 passed** — all ~13 starter templates execute end-to-end through the public route with default-off (the CI ui-browser-e2e path).
- `check:secret-patterns` clean.
- **`check:ts-runtime-retirement` status=passed, routeCount=584, blockerFamilies=[]** — IDENTICAL to origin/main baseline. **Manifest NOT modified** (`uix.templates.execute` is NOT added to the set; this is a dormant guard only).

### Concurrency note
Sibling lane **PR #634** (TS-R4/G1 autofix) also adds a new flag to `friday-hub-bootstrap.ts` + `mock-env.ts`. mock-env insertions here are **re-anchored above `allowTestOnlySystemIntentExecution`** (leaving intervening context vs #634's adjacent flag) so the two PRs merge cleanly regardless of order.

### Truth label
DEFAULT-OFF = **no current behavior change** (starter-skills preserved). This is a ready-to-enable lever, not a retirement; **NOT v1 GO progress**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)