### PR TITLE
feat(rust-providers): R7 — live key-validation probe + composite capability-doctor (dark; live harness ignored)

### DIFF
--- a/rust-core/crates/friday-hub/src/capability_doctor.rs
+++ b/rust-core/crates/friday-hub/src/capability_doctor.rs
@@ -1,0 +1,333 @@
+//! R7 — composite capability-doctor (the `capabilities.doctor` aggregate). DARK.
+//!
+//! ## What this composes (and the taxonomy reality)
+//! R6's [`crate::provider_doctor::ProviderDoctor`] answers the LOCAL onboarding
+//! question (does each CLI report logged-in?) over the CLI providers
+//! `{Codex, Claude}`. R7 adds the orthogonal LIVE signal — does each API credential
+//! actually work? — over the key providers `{DeepSeek, Anthropic}`. This module
+//! composes BOTH into one truth-labeled readiness report, as TWO clearly-separate
+//! per-provider sections.
+//!
+//! The two signals do NOT line up one-to-one (the taxonomy is genuinely different),
+//! so they are kept as DISTINCT sections rather than fused per provider:
+//! - `Codex` has a CLI login but NO HTTP key-validation path → it appears ONLY in the
+//!   CLI-detect section (no synthesized key verdict — there is nothing to validate).
+//! - `DeepSeek` has an API key but is NOT a CLI provider → it appears ONLY in the
+//!   key-validation section (no CLI-detect signal).
+//! - `Claude` (CLI subscription login) and `Anthropic` (API key) are DISTINCT
+//!   credentials. They are reported SEPARATELY — the CLI signal in the CLI-detect
+//!   section, the key signal in the key-validation section — and are NEVER folded into
+//!   one "Claude ready" verdict (that would be a false collapse).
+//!
+//! ## No-fallback / no opaque collapse (Friday invariant `04` §2/§4.5)
+//! Every signal is carried VERBATIM and labeled with WHICH provider it belongs to. A
+//! down/absent provider is surfaced as its own honest state, NEVER substituted by a
+//! ready one and NEVER hidden inside a single aggregate bool. The within-taxonomy
+//! readiness helpers ([`CapabilityDoctor::cli_logged_in`] /
+//! [`CapabilityDoctor::confirmed_valid_keys`]) are DERIVED from the per-provider truth
+//! and never hide which signal is down — and a transient `Unavailable` key-validation
+//! is NOT counted as a confirmed valid key (you cannot route to a credential you could
+//! not confirm). There is deliberately NO cross-taxonomy aggregate bool: the two enums
+//! are disjoint, so any AND/OR across them would mis-state readiness (a no-key-needed
+//! CLI provider like Codex would be under-reported). Callers read each section.
+//!
+//! ## DARK — built ready, NOT routed (library-only)
+//! Registers NO production route, is NOT in [`crate::capability`]'s route table, does
+//! NOT flip the live TS `capabilities.doctor`/`providers.validate`/`providers.doctor`
+//! paths. Unlike R6's `hub_providers_detect` bin, this composite has NO entrypoint bin
+//! — it is library-only, reachable today only by future Rust callers + its unit tests.
+//! Generic over both probes so production injects the real
+//! [`friday_providers::CliProbe`] + [`crate::provider_key_validation::LiveKeyValidationProbe`]
+//! and tests inject mocks through the IDENTICAL path. Confers no v1 GO.
+//!
+//! ## Secret hygiene
+//! Carries ONLY the secret-safe parsed [`friday_providers::ProviderAuthStatus`]
+//! fields + the coarse [`friday_providers::KeyValidationOutcome`] (status code / static
+//! label at most). It never touches a raw CLI `ProbeOutput`, request, response body,
+//! or key.
+
+use friday_providers::{
+    detect, KeyProvider, KeyValidationProbe, Provider, ProviderAuthStatus, ProviderProbe,
+};
+
+/// The per-credential live key-validation signal in the composite report. Distinct
+/// from a CLI-detect status: it answers "does the API credential actually work?".
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct KeyValidationSignal {
+    /// Which API credential this signal is about (`deepseek` / `anthropic`).
+    pub provider: KeyProvider,
+    /// The typed live-validation outcome (valid / invalid / missing / unavailable).
+    pub outcome: friday_providers::KeyValidationOutcome,
+}
+
+/// The composite `capabilities.doctor` result: the R6 CLI-detect statuses PLUS the
+/// R7 per-credential live key-validation signals, as TWO separate sections — composed
+/// without collapse.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CapabilityDoctor {
+    /// Per-CLI-provider local auth-readiness (`codex`, `claude`), in `Provider::all()`
+    /// order — the R6 `detect` signal, carried verbatim.
+    pub cli_statuses: Vec<ProviderAuthStatus>,
+    /// Per-API-credential live key-validation signals (`deepseek`, `anthropic`), in
+    /// `KeyProvider::all()` order — the R7 signal. Standalone, since these credentials
+    /// are not CLI providers and share no identity with the CLI section.
+    pub key_signals: Vec<KeyValidationSignal>,
+}
+
+impl CapabilityDoctor {
+    /// Run the composite doctor over the canonical full sets (`Provider::all()` for
+    /// CLI detect + `KeyProvider::all()` for key-validation) — the onboarding
+    /// default. Generic over both probes so production injects the real probes and
+    /// tests inject mocks through the identical path.
+    pub fn run<P: ProviderProbe, K: KeyValidationProbe>(cli_probe: &P, key_probe: &K) -> Self {
+        let cli_statuses = Provider::all()
+            .iter()
+            .map(|&p| detect(cli_probe, p))
+            .collect();
+
+        let key_signals = KeyProvider::all()
+            .iter()
+            .map(|&kp| KeyValidationSignal {
+                provider: kp,
+                outcome: key_probe.validate(kp),
+            })
+            .collect();
+
+        Self {
+            cli_statuses,
+            key_signals,
+        }
+    }
+
+    /// Look up one CLI provider's auth-readiness, if it was probed.
+    pub fn cli_status_for(&self, provider: Provider) -> Option<&ProviderAuthStatus> {
+        self.cli_statuses.iter().find(|s| s.provider == provider)
+    }
+
+    /// Look up one API credential's key-validation signal, if it was probed.
+    pub fn key_signal_for(&self, provider: KeyProvider) -> Option<&KeyValidationSignal> {
+        self.key_signals.iter().find(|s| s.provider == provider)
+    }
+
+    /// The CLI providers whose CLI reports logged-in. Truth-labeled: a provider
+    /// absent here is genuinely not CLI-authenticated (its full status stays in
+    /// [`Self::cli_statuses`]); never substituted.
+    pub fn cli_logged_in(&self) -> Vec<Provider> {
+        self.cli_statuses
+            .iter()
+            .filter(|s| s.authenticated)
+            .map(|s| s.provider)
+            .collect()
+    }
+
+    /// The API credentials CONFIRMED valid by a live round-trip — ONLY
+    /// [`friday_providers::KeyValidationOutcome::Valid`]. An `Unavailable`
+    /// (could-not-confirm) is NOT counted: you cannot route to a credential you could
+    /// not confirm. Truth-labeled: a credential absent here is not confirmed-valid (its
+    /// exact outcome stays in [`Self::key_signals`]); never substituted.
+    pub fn confirmed_valid_keys(&self) -> Vec<KeyProvider> {
+        self.key_signals
+            .iter()
+            .filter(|s| s.outcome.is_confirmed_valid())
+            .map(|s| s.provider)
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use friday_providers::{
+        KeyValidationOutcome, MockKeyValidationProbe, ProbeOutput, ProviderError,
+    };
+    use std::collections::HashMap;
+
+    /// CLI probe mock (mirrors the R6 doctor's mock).
+    struct MockCliProbe {
+        out: HashMap<&'static str, Result<ProbeOutput, ()>>,
+    }
+    impl MockCliProbe {
+        fn new() -> Self {
+            Self {
+                out: HashMap::new(),
+            }
+        }
+        fn set(mut self, p: Provider, stdout: &str) -> Self {
+            self.out.insert(
+                p.as_str(),
+                Ok(ProbeOutput {
+                    stdout: stdout.to_string(),
+                    stderr: String::new(),
+                }),
+            );
+            self
+        }
+        fn set_missing(mut self, p: Provider) -> Self {
+            self.out.insert(p.as_str(), Err(()));
+            self
+        }
+    }
+    impl ProviderProbe for MockCliProbe {
+        fn status(&self, provider: Provider) -> Result<ProbeOutput, ProviderError> {
+            match self.out.get(provider.as_str()) {
+                Some(Ok(o)) => Ok(o.clone()),
+                _ => Err(ProviderError::NotInstalled("mock".into())),
+            }
+        }
+    }
+
+    #[test]
+    fn composite_covers_both_taxonomies_in_canonical_order_no_collapse() {
+        // CLI: codex logged-in, claude logged-out. Keys: deepseek valid, anthropic
+        // invalid. The composite must carry BOTH sets, each per-provider, side by
+        // side — never merging claude-CLI with anthropic-key.
+        let cli = MockCliProbe::new()
+            .set(Provider::Codex, "Logged in using ChatGPT")
+            .set(Provider::Claude, "{\n  \"loggedIn\": false\n}");
+        let keys = MockKeyValidationProbe::new()
+            .with(KeyProvider::DeepSeek, KeyValidationOutcome::Valid)
+            .with(
+                KeyProvider::Anthropic,
+                KeyValidationOutcome::Invalid { status: 401 },
+            );
+
+        let doc = CapabilityDoctor::run(&cli, &keys);
+
+        // CLI section: 2 providers in Provider::all() order, carried verbatim.
+        assert_eq!(doc.cli_statuses.len(), 2);
+        assert_eq!(doc.cli_statuses[0].provider, Provider::Codex);
+        assert!(doc.cli_statuses[0].authenticated);
+        assert_eq!(doc.cli_statuses[1].provider, Provider::Claude);
+        assert!(!doc.cli_statuses[1].authenticated);
+
+        // Key section: 2 credentials in KeyProvider::all() order, each its own outcome.
+        assert_eq!(doc.key_signals.len(), 2);
+        assert_eq!(doc.key_signals[0].provider, KeyProvider::DeepSeek);
+        assert_eq!(doc.key_signals[0].outcome, KeyValidationOutcome::Valid);
+        assert_eq!(doc.key_signals[1].provider, KeyProvider::Anthropic);
+        assert_eq!(
+            doc.key_signals[1].outcome,
+            KeyValidationOutcome::Invalid { status: 401 }
+        );
+    }
+
+    #[test]
+    fn claude_cli_and_anthropic_key_are_reported_separately_never_merged() {
+        // The false-collapse guard: claude CLI logged-IN but the anthropic API key is
+        // INVALID. A naive "Claude ready" bool would hide one of these. The composite
+        // keeps them distinct: claude CLI shows authenticated, anthropic key shows
+        // Invalid — and there is NO single field that merges them.
+        let cli = MockCliProbe::new()
+            .set(Provider::Codex, "Not logged in")
+            .set(Provider::Claude, "{\n  \"loggedIn\": true\n}");
+        let keys = MockKeyValidationProbe::new()
+            .with(KeyProvider::DeepSeek, KeyValidationOutcome::Valid)
+            .with(
+                KeyProvider::Anthropic,
+                KeyValidationOutcome::Invalid { status: 403 },
+            );
+        let doc = CapabilityDoctor::run(&cli, &keys);
+
+        let claude_cli = doc.cli_status_for(Provider::Claude).unwrap();
+        assert!(claude_cli.authenticated, "claude CLI is logged in");
+
+        let anthropic_key = doc.key_signal_for(KeyProvider::Anthropic).unwrap();
+        assert_eq!(
+            anthropic_key.outcome,
+            KeyValidationOutcome::Invalid { status: 403 },
+            "the anthropic API key is independently INVALID — not hidden by the CLI login"
+        );
+    }
+
+    #[test]
+    fn unavailable_key_is_not_counted_as_confirmed_valid() {
+        // THE honesty core at the aggregate level: a transient Unavailable must NOT be
+        // counted as a confirmed-valid key. deepseek Unavailable + anthropic Valid →
+        // only anthropic is confirmed valid.
+        let cli = MockCliProbe::new()
+            .set(Provider::Codex, "Logged in using ChatGPT")
+            .set(Provider::Claude, "{\n  \"loggedIn\": false\n}");
+        let keys = MockKeyValidationProbe::new()
+            .with(
+                KeyProvider::DeepSeek,
+                KeyValidationOutcome::Unavailable { detail: "HTTP 503" },
+            )
+            .with(KeyProvider::Anthropic, KeyValidationOutcome::Valid);
+        let doc = CapabilityDoctor::run(&cli, &keys);
+
+        assert_eq!(
+            doc.confirmed_valid_keys(),
+            vec![KeyProvider::Anthropic],
+            "an Unavailable deepseek must NOT count as confirmed valid"
+        );
+        // But its exact outcome is still queryable (truth preserved, never dropped).
+        assert_eq!(
+            doc.key_signal_for(KeyProvider::DeepSeek).unwrap().outcome,
+            KeyValidationOutcome::Unavailable { detail: "HTTP 503" }
+        );
+    }
+
+    #[test]
+    fn cli_login_alone_needs_no_key_and_a_valid_key_alone_needs_no_cli() {
+        // The within-taxonomy aggregates are independent and honest: a CLI provider
+        // that needs no API key (codex) reads logged-in on the CLI axis regardless of
+        // any key state; and a valid key reads confirmed-valid regardless of any CLI
+        // login. There is deliberately NO cross-taxonomy bool that would AND these and
+        // thereby under-report a usable-but-single-axis provider.
+        let cli = MockCliProbe::new()
+            .set(Provider::Codex, "Logged in using ChatGPT")
+            .set_missing(Provider::Claude);
+        // No keys valid (deepseek unavailable, anthropic unset).
+        let keys = MockKeyValidationProbe::new().with(
+            KeyProvider::DeepSeek,
+            KeyValidationOutcome::Unavailable {
+                detail: "transport",
+            },
+        );
+        let doc = CapabilityDoctor::run(&cli, &keys);
+
+        // codex is logged in on the CLI axis even though NO key is confirmed valid.
+        assert_eq!(doc.cli_logged_in(), vec![Provider::Codex]);
+        assert!(doc.confirmed_valid_keys().is_empty());
+
+        // Mirror: a valid key with no CLI login reads confirmed-valid on the key axis.
+        let cli_none = MockCliProbe::new()
+            .set_missing(Provider::Codex)
+            .set(Provider::Claude, "{\n  \"loggedIn\": false\n}");
+        let keys_ok =
+            MockKeyValidationProbe::new().with(KeyProvider::DeepSeek, KeyValidationOutcome::Valid);
+        let doc2 = CapabilityDoctor::run(&cli_none, &keys_ok);
+        assert!(doc2.cli_logged_in().is_empty());
+        assert_eq!(doc2.confirmed_valid_keys(), vec![KeyProvider::DeepSeek]);
+    }
+
+    #[test]
+    fn fully_logged_out_and_no_keys_is_honest_not_ready() {
+        // Everything down: no CLI login, both keys missing. The doctor must read NOT
+        // ready everywhere — never a fabricated ready.
+        let cli = MockCliProbe::new()
+            .set_missing(Provider::Codex)
+            .set(Provider::Claude, "{\n  \"loggedIn\": false\n}");
+        let keys = MockKeyValidationProbe::new(); // both unset → CredentialMissing
+        let doc = CapabilityDoctor::run(&cli, &keys);
+
+        assert!(doc.cli_logged_in().is_empty());
+        assert!(doc.confirmed_valid_keys().is_empty());
+        // Truth-labeled: each absent key is CredentialMissing (distinct from Invalid).
+        for kp in KeyProvider::all() {
+            assert_eq!(
+                doc.key_signal_for(*kp).unwrap().outcome,
+                KeyValidationOutcome::CredentialMissing
+            );
+        }
+        // And codex is not_installed, claude is not_logged_in (distinct, never folded).
+        assert_eq!(
+            doc.cli_status_for(Provider::Codex).unwrap().detail,
+            "not_installed"
+        );
+        assert_eq!(
+            doc.cli_status_for(Provider::Claude).unwrap().detail,
+            "not_logged_in"
+        );
+    }
+}

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -92,6 +92,25 @@ pub mod diagnostics;
 /// [`capability`] route table; confers no v1 GO.
 pub mod provider_doctor;
 
+/// R7 — LIVE provider key-validation (`providers.validate`), DARK + secret-bearing.
+/// The real impl of the call-free [`friday_providers::key_validation`] seam: it
+/// constructs the `friday-anthropic`/`friday-deepseek` clients `from_env` and runs ONE
+/// minimal authenticated round-trip, mapping the typed provider error into a
+/// [`friday_providers::KeyValidationOutcome`] (no-fallback: only an auth rejection is
+/// `Invalid`; a 5xx/429/transport is `Unavailable`, never a bad-key signal). The
+/// error→outcome mapping is pure + fully unit-tested; the network side is exercised
+/// only by an `#[ignore]`'d live harness. Registers NO route; confers no v1 GO.
+pub mod provider_key_validation;
+
+/// R7 — composite capability-doctor (`capabilities.doctor`/`providers.doctor`), DARK.
+/// Composes R6's CLI-detect [`provider_doctor::ProviderDoctor`] signal with R7's live
+/// key-validation signal into one per-provider truth-labeled readiness report — the
+/// two taxonomies (`{Codex, Claude}` CLI logins vs `{DeepSeek, Anthropic}` API keys)
+/// reported side-by-side, NEVER collapsed (claude CLI login and the anthropic API key
+/// are distinct credentials, surfaced separately). Generic over both probes for
+/// mockable testing. Registers NO route; confers no v1 GO.
+pub mod capability_doctor;
+
 /// Step-3 — setup-readiness blocker labels (truth-labeled): the runtime analog of the file-57
 /// external-prep checklist. Every prep item is `Ready { evidence }` ONLY when verified, else
 /// `NotReady { blocker }` — never falsely ready. `is_release_ready()` is the prep half of the

--- a/rust-core/crates/friday-hub/src/provider_key_validation.rs
+++ b/rust-core/crates/friday-hub/src/provider_key_validation.rs
@@ -193,9 +193,10 @@ mod tests {
     #[test]
     fn deepseek_transient_failures_are_unavailable_never_invalid() {
         // THE honesty guard: a 5xx / 408 / 529 / transport (ProviderUnavailable), a
-        // 429 rate-limit, a non-auth 4xx, a bad response, and no-models are ALL
-        // Unavailable — never Invalid. A good key must NOT be branded bad on a server
-        // hiccup or a rate-limit (a rate-limit means we DID authenticate).
+        // 429 rate-limit, a non-auth 4xx, a bad response, no-models, AND an internal
+        // Core error are ALL Unavailable — never Invalid. A good key must NOT be
+        // branded bad on a server hiccup, a rate-limit (a rate-limit means we DID
+        // authenticate), or an internal error (which says nothing about the key).
         for (err, expect_detail) in [
             (
                 DeepSeekError::ProviderUnavailable("HTTP 503".into()),
@@ -206,6 +207,14 @@ mod tests {
             (DeepSeekError::ClientError { status: 404 }, "client_error"),
             (DeepSeekError::BadResponse("x".into()), "bad_response"),
             (DeepSeekError::NoModels, "no_models"),
+            // An internal Core error is NOT a credential rejection: it must map to
+            // Unavailable("internal_error"), never Invalid. Locks the safe direction
+            // so a future `Core => Invalid` edit (dishonestly branding a good key bad
+            // on an internal error) turns this test RED.
+            (
+                DeepSeekError::Core(friday_core::CoreError::InvalidLedger("x".into())),
+                "internal_error",
+            ),
         ] {
             let outcome = map_deepseek_result::<()>(Err(err));
             assert_eq!(
@@ -233,6 +242,13 @@ mod tests {
         assert_eq!(
             map_claude_result::<()>(Err(ClaudeError::Auth(401))),
             KeyValidationOutcome::Invalid { status: 401 }
+        );
+        // Symmetry with DeepSeek: ClaudeError::Auth covers both 401 and 403 (per the
+        // enum doc, "HTTP 401/403"), and 403 is likewise a credential rejection ⇒
+        // Invalid — never Unavailable.
+        assert_eq!(
+            map_claude_result::<()>(Err(ClaudeError::Auth(403))),
+            KeyValidationOutcome::Invalid { status: 403 }
         );
     }
 

--- a/rust-core/crates/friday-hub/src/provider_key_validation.rs
+++ b/rust-core/crates/friday-hub/src/provider_key_validation.rs
@@ -1,0 +1,305 @@
+//! R7 — the LIVE provider key-validation impl (Hub-only, secret-bearing). DARK.
+//!
+//! This is the real, network-touching side of the call-free
+//! [`friday_providers::key_validation`] seam. It lives in `friday-hub` (not
+//! `friday-providers`) for two reasons:
+//! 1. `friday-providers`' own contract is "runs ONLY each provider's read-only
+//!    status command — never a prompt/send — so no model call occurs and nothing is
+//!    charged." A live round-trip would break that. The Hub is where provider
+//!    secrets already live (it depends on `friday-anthropic`/`friday-deepseek`,
+//!    asserted by `friday-arch-tests` to stay off the phone).
+//! 2. It mirrors R6: `ProviderDoctor` lives in the Hub and composes
+//!    `friday_providers::detect`; the key-validation impl is the symmetric Hub-side
+//!    real impl of a `friday-providers` seam.
+//!
+//! ## What "validate" means per provider (and the quota asymmetry)
+//! - **DeepSeek** — an authenticated `GET /models` ([`friday_deepseek::DeepSeekClient::discover_models`]).
+//!   Authenticated but spends NO completion quota — the ideal validation: 401/403 ⇒
+//!   bad key, 200 ⇒ key works.
+//! - **Anthropic/Claude** — a minimal `POST /v1/messages` with `max_tokens=1`
+//!   ([`friday_anthropic::ClaudeClient::chat`]). Anthropic has no `/models` discovery
+//!   in-crate, so this spends a tiny amount of quota (~one or two tokens). Documented
+//!   in the live harness run-doc.
+//!
+//! ## No-fallback + honesty mapping (the core of this module)
+//! The mapping deliberately partitions a genuinely-bad credential from a transient
+//! failure — a `5xx`/`429`/network error MUST NEVER read as `Invalid` (that would
+//! brand a good key bad on a server hiccup):
+//! - `Ok(_)` ⇒ [`KeyValidationOutcome::Valid`]
+//! - `Auth(401|403)` ⇒ [`KeyValidationOutcome::Invalid`] (the ONLY bad-key path)
+//! - `CredentialMissing` ⇒ [`KeyValidationOutcome::CredentialMissing`]
+//! - `ProviderUnavailable` (5xx/408/529/transport), `ClientError` (4xx incl. 429
+//!   rate-limit), `BadResponse`, `NoModels` ⇒ [`KeyValidationOutcome::Unavailable`]
+//!   (could-not-confirm; the key may be fine).
+//!
+//! The mapping is exposed as PURE functions ([`map_deepseek_result`] /
+//! [`map_claude_result`]) so every arm is unit-tested WITHOUT a network call or any
+//! quota spend. The network side ([`LiveKeyValidationProbe::validate`]) is exercised
+//! ONLY by the `#[ignore]`'d live harness.
+//!
+//! ## DARK — built ready, NOT routed
+//! Registers NO production route, is NOT in [`crate::capability`]'s route table, and
+//! does NOT flip the live TS `providers.validate` path. Reachable today only by
+//! future Rust callers + the composite [`crate::capability_doctor`] + the ignored
+//! live harness. Confers no v1 GO.
+//!
+//! ## Secret hygiene
+//! The provider errors are already coarse (status code only — never the key, the
+//! request, or the response body; see each crate's `map_ureq_err`). The mapping
+//! carries through ONLY a coarse status code / static detail, so no secret can reach
+//! a [`KeyValidationOutcome`].
+
+use friday_anthropic::{ClaudeClient, ClaudeError, DEFAULT_MODEL as CLAUDE_DEFAULT_MODEL};
+use friday_deepseek::{DeepSeekClient, DeepSeekError};
+use friday_providers::{KeyProvider, KeyValidationOutcome, KeyValidationProbe};
+
+/// Map a DeepSeek `discover_models` result into a typed key-validation outcome.
+/// PURE (no network) so every arm is unit-tested directly.
+///
+/// Only `Auth` is `Invalid`. A `ClientError` (incl. 429), `ProviderUnavailable`,
+/// `BadResponse`, `NoModels`, or `Core` error is `Unavailable` — we authenticated
+/// or could-not-tell, but did NOT see a credential rejection, so we must not brand
+/// the key bad.
+pub fn map_deepseek_result<T>(result: Result<T, DeepSeekError>) -> KeyValidationOutcome {
+    match result {
+        Ok(_) => KeyValidationOutcome::Valid,
+        Err(DeepSeekError::Auth(status)) => KeyValidationOutcome::Invalid { status },
+        Err(DeepSeekError::CredentialMissing) => KeyValidationOutcome::CredentialMissing,
+        // 429 means we AUTHENTICATED and got rate-limited — never a bad-key signal.
+        Err(DeepSeekError::ClientError { status: 429 }) => KeyValidationOutcome::Unavailable {
+            detail: "rate_limited",
+        },
+        Err(DeepSeekError::ClientError { .. }) => KeyValidationOutcome::Unavailable {
+            detail: "client_error",
+        },
+        Err(DeepSeekError::ProviderUnavailable(_)) => KeyValidationOutcome::Unavailable {
+            detail: "provider_unavailable",
+        },
+        Err(DeepSeekError::BadResponse(_)) => KeyValidationOutcome::Unavailable {
+            detail: "bad_response",
+        },
+        Err(DeepSeekError::NoModels) => KeyValidationOutcome::Unavailable {
+            detail: "no_models",
+        },
+        Err(DeepSeekError::Core(_)) => KeyValidationOutcome::Unavailable {
+            detail: "internal_error",
+        },
+    }
+}
+
+/// Map an Anthropic `chat` result into a typed key-validation outcome. PURE (no
+/// network). Same partition as DeepSeek: only `Auth` is `Invalid`.
+pub fn map_claude_result<T>(result: Result<T, ClaudeError>) -> KeyValidationOutcome {
+    match result {
+        Ok(_) => KeyValidationOutcome::Valid,
+        Err(ClaudeError::Auth(status)) => KeyValidationOutcome::Invalid { status },
+        Err(ClaudeError::CredentialMissing) => KeyValidationOutcome::CredentialMissing,
+        Err(ClaudeError::ClientError { status: 429 }) => KeyValidationOutcome::Unavailable {
+            detail: "rate_limited",
+        },
+        Err(ClaudeError::ClientError { .. }) => KeyValidationOutcome::Unavailable {
+            detail: "client_error",
+        },
+        Err(ClaudeError::ProviderUnavailable(_)) => KeyValidationOutcome::Unavailable {
+            detail: "provider_unavailable",
+        },
+        Err(ClaudeError::BadResponse(_)) => KeyValidationOutcome::Unavailable {
+            detail: "bad_response",
+        },
+    }
+}
+
+/// The real, secret-bearing key-validation probe. Constructs the provider client
+/// `from_env` (FAILS CLOSED to [`KeyValidationOutcome::CredentialMissing`] if the
+/// key is absent — never a fallback) and runs ONE minimal authenticated round-trip,
+/// mapping the typed provider error into a [`KeyValidationOutcome`].
+///
+/// DARK: not registered as a route; reachable only by explicit Rust callers + the
+/// ignored live harness. The only methods that touch the network are the per-provider
+/// `validate` arms; constructing the probe makes ZERO calls.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct LiveKeyValidationProbe;
+
+impl LiveKeyValidationProbe {
+    pub fn new() -> Self {
+        LiveKeyValidationProbe
+    }
+
+    /// Validate DeepSeek via an authenticated `GET /models` (no completion quota).
+    fn validate_deepseek(&self) -> KeyValidationOutcome {
+        match DeepSeekClient::from_env() {
+            Err(e) => map_deepseek_result::<()>(Err(e)),
+            Ok(client) => map_deepseek_result(client.discover_models()),
+        }
+    }
+
+    /// Validate Anthropic via a minimal `POST /v1/messages` (`max_tokens=1`). Spends
+    /// a tiny amount of quota (Anthropic has no in-crate `/models` discovery).
+    fn validate_anthropic(&self) -> KeyValidationOutcome {
+        match ClaudeClient::from_env() {
+            Err(e) => map_claude_result::<()>(Err(e)),
+            Ok(client) => {
+                // Minimal validation prompt; max_tokens=1 keeps the spend ~nil. We
+                // care only about WHETHER the key was accepted, not the reply text.
+                map_claude_result(client.chat(CLAUDE_DEFAULT_MODEL, "ping", 1))
+            }
+        }
+    }
+}
+
+impl KeyValidationProbe for LiveKeyValidationProbe {
+    fn validate(&self, provider: KeyProvider) -> KeyValidationOutcome {
+        match provider {
+            KeyProvider::DeepSeek => self.validate_deepseek(),
+            KeyProvider::Anthropic => self.validate_anthropic(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- DeepSeek mapping: every arm, no network ----
+
+    #[test]
+    fn deepseek_ok_is_valid() {
+        assert_eq!(
+            map_deepseek_result(Ok(vec!["m".to_string()])),
+            KeyValidationOutcome::Valid
+        );
+    }
+
+    #[test]
+    fn deepseek_auth_is_invalid_with_status() {
+        assert_eq!(
+            map_deepseek_result::<()>(Err(DeepSeekError::Auth(401))),
+            KeyValidationOutcome::Invalid { status: 401 }
+        );
+        assert_eq!(
+            map_deepseek_result::<()>(Err(DeepSeekError::Auth(403))),
+            KeyValidationOutcome::Invalid { status: 403 }
+        );
+    }
+
+    #[test]
+    fn deepseek_credential_missing_maps_through() {
+        assert_eq!(
+            map_deepseek_result::<()>(Err(DeepSeekError::CredentialMissing)),
+            KeyValidationOutcome::CredentialMissing
+        );
+    }
+
+    #[test]
+    fn deepseek_transient_failures_are_unavailable_never_invalid() {
+        // THE honesty guard: a 5xx / 408 / 529 / transport (ProviderUnavailable), a
+        // 429 rate-limit, a non-auth 4xx, a bad response, and no-models are ALL
+        // Unavailable — never Invalid. A good key must NOT be branded bad on a server
+        // hiccup or a rate-limit (a rate-limit means we DID authenticate).
+        for (err, expect_detail) in [
+            (
+                DeepSeekError::ProviderUnavailable("HTTP 503".into()),
+                "provider_unavailable",
+            ),
+            (DeepSeekError::ClientError { status: 429 }, "rate_limited"),
+            (DeepSeekError::ClientError { status: 400 }, "client_error"),
+            (DeepSeekError::ClientError { status: 404 }, "client_error"),
+            (DeepSeekError::BadResponse("x".into()), "bad_response"),
+            (DeepSeekError::NoModels, "no_models"),
+        ] {
+            let outcome = map_deepseek_result::<()>(Err(err));
+            assert_eq!(
+                outcome,
+                KeyValidationOutcome::Unavailable {
+                    detail: expect_detail
+                },
+            );
+            assert!(
+                !matches!(outcome, KeyValidationOutcome::Invalid { .. }),
+                "transient/non-auth must NEVER be Invalid"
+            );
+        }
+    }
+
+    // ---- Anthropic mapping: every arm, no network ----
+
+    #[test]
+    fn claude_ok_is_valid() {
+        assert_eq!(map_claude_result(Ok(())), KeyValidationOutcome::Valid);
+    }
+
+    #[test]
+    fn claude_auth_is_invalid_with_status() {
+        assert_eq!(
+            map_claude_result::<()>(Err(ClaudeError::Auth(401))),
+            KeyValidationOutcome::Invalid { status: 401 }
+        );
+    }
+
+    #[test]
+    fn claude_credential_missing_maps_through() {
+        assert_eq!(
+            map_claude_result::<()>(Err(ClaudeError::CredentialMissing)),
+            KeyValidationOutcome::CredentialMissing
+        );
+    }
+
+    #[test]
+    fn claude_transient_failures_are_unavailable_never_invalid() {
+        for (err, expect_detail) in [
+            (
+                ClaudeError::ProviderUnavailable("HTTP 529".into()),
+                "provider_unavailable",
+            ),
+            (ClaudeError::ClientError { status: 429 }, "rate_limited"),
+            (ClaudeError::ClientError { status: 400 }, "client_error"),
+            (ClaudeError::BadResponse("x".into()), "bad_response"),
+        ] {
+            let outcome = map_claude_result::<()>(Err(err));
+            assert_eq!(
+                outcome,
+                KeyValidationOutcome::Unavailable {
+                    detail: expect_detail
+                },
+            );
+            assert!(!matches!(outcome, KeyValidationOutcome::Invalid { .. }));
+        }
+    }
+
+    // ---- secret-safety leak-lens on the outcome shape ----
+
+    #[test]
+    fn outcome_debug_renders_carry_no_body_or_secret_markers() {
+        // The mapping consumes ALREADY-coarse provider errors (status code only) and
+        // carries through only a status / static detail. Even when the SOURCE error
+        // carried a (here, synthetic) detail string, the outcome's Debug must hold no
+        // body/secret marker — only the coarse status / static label.
+        let from_unavailable = map_deepseek_result::<()>(Err(DeepSeekError::ProviderUnavailable(
+            "SECRET-BODY-LEAK".into(),
+        )));
+        let from_bad =
+            map_claude_result::<()>(Err(ClaudeError::BadResponse("Bearer sk-SECRET-KEY".into())));
+        for outcome in [from_unavailable, from_bad] {
+            let rendered = format!("{outcome:?}");
+            for forbidden in ["SECRET-BODY-LEAK", "SECRET-KEY", "Bearer", "sk-"] {
+                assert!(
+                    !rendered.contains(forbidden),
+                    "outcome render leaked {forbidden}: {rendered}"
+                );
+            }
+        }
+        // Positive control: an Invalid DOES carry the coarse status code (a useful,
+        // non-secret label).
+        let invalid = map_deepseek_result::<()>(Err(DeepSeekError::Auth(401)));
+        assert!(format!("{invalid:?}").contains("401"));
+    }
+
+    #[test]
+    fn live_probe_construction_is_call_free() {
+        // Constructing the probe makes ZERO network calls (no from_env, no request).
+        // Only validate() touches the network — proven structurally: this builds a
+        // probe and never calls validate.
+        let _probe = LiveKeyValidationProbe::new();
+        let _probe2 = LiveKeyValidationProbe;
+    }
+}

--- a/rust-core/crates/friday-hub/tests/key_validation_live.rs
+++ b/rust-core/crates/friday-hub/tests/key_validation_live.rs
@@ -1,0 +1,62 @@
+//! LIVE key-validation proof for the R7 provider-probe — BUILT but NOT RUN.
+//!
+//! These tests are `#[ignore]`-d: each requires a real provider API key in the
+//! environment and makes ONE minimal authenticated round-trip that may SPEND QUOTA.
+//! No key is provisioned in this dark slice, so they must COMPILE but are never run
+//! here (mirrors `friday-anthropic`'s `tests/live_round_trip.rs`).
+//!
+//! ## Quota asymmetry (read before running)
+//! - **DeepSeek** — validation is an authenticated `GET /models`, which spends NO
+//!   completion quota. Cheap + safe to run.
+//! - **Anthropic/Claude** — validation is a minimal `POST /v1/messages`
+//!   (`max_tokens=1`), which spends a TINY amount of quota (~one or two tokens), as
+//!   Anthropic has no in-crate `/models` discovery.
+//!
+//! ## How to run later (with the key sourced on the Hub)
+//! ```text
+//! # DeepSeek (no completion quota):
+//! FRIDAY_DEEPSEEK_API_KEY=<key> \
+//!   cargo test -p friday-hub --test key_validation_live deepseek -- --ignored --nocapture
+//!
+//! # Anthropic/Claude (spends ~1-2 tokens):
+//! FRIDAY_ANTHROPIC_API_KEY=<key> \
+//!   cargo test -p friday-hub --test key_validation_live anthropic -- --ignored --nocapture
+//!
+//! # Both at once (operator-authorized DeepSeek + Claude live):
+//! FRIDAY_DEEPSEEK_API_KEY=<k1> FRIDAY_ANTHROPIC_API_KEY=<k2> \
+//!   cargo test -p friday-hub --test key_validation_live -- --ignored --nocapture
+//! ```
+//!
+//! Each asserts the live outcome is `Valid` (the real key is accepted) through the
+//! FULL real path (`from_env` → real transport → real provider), proving the
+//! key-validation mechanism works end-to-end with NO fallback. SPENDS QUOTA — do not
+//! run in CI.
+
+use friday_hub::provider_key_validation::LiveKeyValidationProbe;
+use friday_providers::{KeyProvider, KeyValidationOutcome, KeyValidationProbe};
+
+#[test]
+#[ignore = "live: needs FRIDAY_DEEPSEEK_API_KEY; authenticated GET /models (no completion quota); run with --ignored"]
+fn deepseek_live_key_is_valid() {
+    let probe = LiveKeyValidationProbe::new();
+    let outcome = probe.validate(KeyProvider::DeepSeek);
+    assert_eq!(
+        outcome,
+        KeyValidationOutcome::Valid,
+        "live DeepSeek key-validation must be Valid with a real key (got {outcome:?})"
+    );
+    eprintln!("LIVE OK: deepseek key-validation = {outcome:?}");
+}
+
+#[test]
+#[ignore = "live: needs FRIDAY_ANTHROPIC_API_KEY; POST /v1/messages max_tokens=1 (spends ~1-2 tokens); run with --ignored"]
+fn anthropic_live_key_is_valid() {
+    let probe = LiveKeyValidationProbe::new();
+    let outcome = probe.validate(KeyProvider::Anthropic);
+    assert_eq!(
+        outcome,
+        KeyValidationOutcome::Valid,
+        "live Anthropic key-validation must be Valid with a real key (got {outcome:?})"
+    );
+    eprintln!("LIVE OK: anthropic key-validation = {outcome:?}");
+}

--- a/rust-core/crates/friday-providers/src/key_validation.rs
+++ b/rust-core/crates/friday-providers/src/key_validation.rs
@@ -1,0 +1,259 @@
+//! R7 — provider key-validation abstraction (the call-free seam + typed result).
+//!
+//! ## The gap this closes (and how it differs from `detect`)
+//! [`crate::detect`] / [`crate::CliProbe`] answer a LOCAL question: does the
+//! provider CLI report itself logged-in? That is NOT proof the credential actually
+//! works against the provider — a stale/revoked token, a wrong key, or an account
+//! with no quota can all still read "logged in" locally. R7 adds the orthogonal
+//! LIVE signal: a minimal authenticated round-trip to the provider that confirms
+//! the credential is accepted. The roadmap states it plainly: this is "distinct
+//! from CLI reports logged-in."
+//!
+//! ## Taxonomy: this is a DIFFERENT provider notion than the CLI [`crate::Provider`]
+//! The CLI providers are `{Codex, Claude}` (local CLI logins). The credentials that
+//! have a live HTTP key-validation path are `{DeepSeek, Anthropic}` — the
+//! secret-bearing Hub route keys (`FRIDAY_DEEPSEEK_API_KEY` /
+//! `FRIDAY_ANTHROPIC_API_KEY`). These sets barely intersect:
+//! - `Codex` has a CLI login but NO HTTP client → no key-validation path exists.
+//! - `DeepSeek` has an HTTP key but is not a CLI provider → no `detect`.
+//! - `Claude` (CLI subscription login) and `Anthropic` (API key) are DISTINCT
+//!   credentials and must never be collapsed into one "Claude ready" verdict.
+//!
+//! So key-validation has its own [`KeyProvider`] enum (the API-key identity), kept
+//! separate from [`crate::Provider`] (the CLI identity). The composite
+//! capability-doctor (in `friday-hub`) reports BOTH signals side-by-side,
+//! truth-labeled, never merged.
+//!
+//! ## Where the abstraction lives vs the real impl
+//! This crate is the CLI-control crate: its own contract is "runs ONLY each
+//! provider's read-only status command — never a prompt/send — so no model call
+//! occurs and nothing is charged." A live key-validation round-trip would BREAK
+//! that contract, so this module ships ONLY the call-free seam: the
+//! [`KeyValidationProbe`] trait + the provider-agnostic typed [`KeyValidationOutcome`]
+//! + a [`MockKeyValidationProbe`] for tests. The REAL, secret-bearing,
+//! quota-touching impl (driving `friday-anthropic`/`friday-deepseek`) lives in
+//! `friday-hub`, where provider secrets already live — mirroring how R6's
+//! `ProviderDoctor` lives in the hub and composes this crate's `detect`.
+//!
+//! ## No-fallback / truth-labeled (Friday invariant `04` §2/§4.5)
+//! A failed validation is an EXPLICIT typed [`KeyValidationOutcome`] — never
+//! substituted by a different provider's key, never silently treated as valid. The
+//! outcome partitions transient failures from a genuinely-bad credential: a `5xx` /
+//! `429` / network error is [`KeyValidationOutcome::Unavailable`] (the key may be
+//! fine; we could not tell), and ONLY an auth rejection is
+//! [`KeyValidationOutcome::Invalid`]. Reporting a transient error as a bad key would
+//! be a dishonesty bug, so the mapping guards against it.
+//!
+//! ## Secret hygiene
+//! [`KeyValidationOutcome`] carries NO key, NO request/response body, and NO account
+//! identifier — at most a coarse HTTP status code (a useful, non-secret label). The
+//! real impl maps the already-coarse `ClaudeError`/`DeepSeekError` (status-code only)
+//! into these variants, so no body/secret can reach the outcome.
+
+/// The credential identity for live key-validation — the secret-bearing Hub route
+/// keys. DISTINCT from the CLI [`crate::Provider`] (`Codex`/`Claude`): these are the
+/// providers that have an actual HTTP client + API key to validate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyProvider {
+    /// DeepSeek route key (`FRIDAY_DEEPSEEK_API_KEY`). Validated by an authenticated
+    /// `GET /models` — spends NO completion quota.
+    DeepSeek,
+    /// Anthropic/Claude API route key (`FRIDAY_ANTHROPIC_API_KEY`). Validated by a
+    /// minimal `POST /v1/messages` (`max_tokens=1`) — spends a tiny amount of quota.
+    /// NOTE: this is a DIFFERENT credential than the `claude` CLI login that
+    /// [`crate::detect`] checks for [`crate::Provider::Claude`].
+    Anthropic,
+}
+
+impl KeyProvider {
+    /// Stable, secret-safe label.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            KeyProvider::DeepSeek => "deepseek",
+            KeyProvider::Anthropic => "anthropic",
+        }
+    }
+
+    /// The Hub-only environment variable that holds this provider's API key.
+    /// (The value is never read here — this is only the var NAME, for evidence.)
+    pub fn env_key(&self) -> &'static str {
+        match self {
+            KeyProvider::DeepSeek => "FRIDAY_DEEPSEEK_API_KEY",
+            KeyProvider::Anthropic => "FRIDAY_ANTHROPIC_API_KEY",
+        }
+    }
+
+    /// The canonical, ordered set of every credential that has a key-validation
+    /// path. The composite capability-doctor iterates this. Order is stable
+    /// (`deepseek`, `anthropic`) so a doctor result is deterministic.
+    pub fn all() -> &'static [KeyProvider] {
+        &[KeyProvider::DeepSeek, KeyProvider::Anthropic]
+    }
+}
+
+/// The typed result of a live key-validation round-trip. No-fallback + truth-labeled:
+/// every distinct real-world state is its OWN variant, and a transient failure is
+/// NEVER conflated with a bad credential.
+///
+/// Secret-safe: carries only an `Invalid`/`Unavailable` HTTP status code at most —
+/// never the key, the request, or the response body.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyValidationOutcome {
+    /// The credential was ACCEPTED by the provider (authenticated round-trip
+    /// succeeded). The key works.
+    Valid,
+    /// The credential was REJECTED by the provider (HTTP 401/403). The key is bad —
+    /// a genuine, terminal validation failure (carries the coarse status code).
+    Invalid { status: u16 },
+    /// The credential env var is unset / empty. Distinct from `Invalid`: there is no
+    /// key to validate (a setup blocker, never a fallback to another provider).
+    CredentialMissing,
+    /// Could NOT determine validity: a TRANSIENT failure (server 5xx / 408 / 529,
+    /// rate-limit 429, or a network/transport error). The key may well be fine — we
+    /// simply could not tell. This MUST NEVER be reported as `Invalid` (that would
+    /// dishonestly brand a good key bad on a server hiccup). `detail` is a coarse,
+    /// secret-free label (e.g. `"HTTP 503"` / `"transport"`).
+    Unavailable { detail: &'static str },
+}
+
+impl KeyValidationOutcome {
+    /// True ONLY for [`KeyValidationOutcome::Valid`]. An `Unavailable` is NOT valid
+    /// (we could not confirm) and NOT invalid (we did not see a rejection) — callers
+    /// must read the variant, not coerce to a bool. This helper exists only for the
+    /// narrow "is this credential confirmed usable" question.
+    pub fn is_confirmed_valid(&self) -> bool {
+        matches!(self, KeyValidationOutcome::Valid)
+    }
+
+    /// A stable, secret-safe label for the outcome (for reports / evidence). Carries
+    /// the coarse status / detail where present, never a body or key.
+    pub fn label(&self) -> &'static str {
+        match self {
+            KeyValidationOutcome::Valid => "valid",
+            KeyValidationOutcome::Invalid { .. } => "invalid",
+            KeyValidationOutcome::CredentialMissing => "credential_missing",
+            KeyValidationOutcome::Unavailable { .. } => "unavailable",
+        }
+    }
+}
+
+/// The call-free seam for a live key-validation round-trip. The REAL impl lives in
+/// `friday-hub` (it is secret-bearing + makes a network call); tests inject
+/// [`MockKeyValidationProbe`] so the result-shaping / no-fallback / secret-safety
+/// logic is provable here WITHOUT a network call or any quota spend.
+///
+/// This is a NEW trait, distinct from [`crate::ProviderProbe`] (which returns CLI
+/// `ProbeOutput` for a LOCAL status check). A key-validation probe answers the LIVE
+/// question and returns a typed [`KeyValidationOutcome`].
+pub trait KeyValidationProbe {
+    /// Validate the given provider's credential via a minimal live round-trip.
+    /// Returns a typed outcome; NEVER substitutes another provider, NEVER returns a
+    /// fabricated `Valid`.
+    fn validate(&self, provider: KeyProvider) -> KeyValidationOutcome;
+}
+
+/// A canned key-validation probe for tests: returns a preset outcome per provider
+/// (or [`KeyValidationOutcome::CredentialMissing`] for an unset one). Makes ZERO
+/// network calls, so the composite-report composition + no-fallback logic is
+/// provable without spending quota.
+#[derive(Debug, Default, Clone)]
+pub struct MockKeyValidationProbe {
+    deepseek: Option<KeyValidationOutcome>,
+    anthropic: Option<KeyValidationOutcome>,
+}
+
+impl MockKeyValidationProbe {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Preset the outcome a given provider will report.
+    pub fn with(mut self, provider: KeyProvider, outcome: KeyValidationOutcome) -> Self {
+        match provider {
+            KeyProvider::DeepSeek => self.deepseek = Some(outcome),
+            KeyProvider::Anthropic => self.anthropic = Some(outcome),
+        }
+        self
+    }
+}
+
+impl KeyValidationProbe for MockKeyValidationProbe {
+    fn validate(&self, provider: KeyProvider) -> KeyValidationOutcome {
+        // An UNSET provider reports CredentialMissing — never a fallback to another
+        // provider's preset outcome.
+        match provider {
+            KeyProvider::DeepSeek => self.deepseek,
+            KeyProvider::Anthropic => self.anthropic,
+        }
+        .unwrap_or(KeyValidationOutcome::CredentialMissing)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn key_provider_all_is_stable_complete_and_labeled() {
+        assert_eq!(
+            KeyProvider::all(),
+            &[KeyProvider::DeepSeek, KeyProvider::Anthropic]
+        );
+        assert_eq!(KeyProvider::DeepSeek.as_str(), "deepseek");
+        assert_eq!(KeyProvider::Anthropic.as_str(), "anthropic");
+        assert_eq!(KeyProvider::DeepSeek.env_key(), "FRIDAY_DEEPSEEK_API_KEY");
+        assert_eq!(KeyProvider::Anthropic.env_key(), "FRIDAY_ANTHROPIC_API_KEY");
+        // Every variant the match in `as_str` knows about is present in `all()`.
+        for p in [KeyProvider::DeepSeek, KeyProvider::Anthropic] {
+            assert!(KeyProvider::all().contains(&p));
+        }
+    }
+
+    #[test]
+    fn is_confirmed_valid_is_true_only_for_valid_never_for_unavailable() {
+        // The honesty core: only Valid is "confirmed usable". Unavailable is NEITHER
+        // valid NOR invalid — it must NOT coerce to valid (that would pass a key we
+        // could not confirm).
+        assert!(KeyValidationOutcome::Valid.is_confirmed_valid());
+        assert!(!KeyValidationOutcome::Invalid { status: 401 }.is_confirmed_valid());
+        assert!(!KeyValidationOutcome::CredentialMissing.is_confirmed_valid());
+        assert!(!KeyValidationOutcome::Unavailable { detail: "HTTP 503" }.is_confirmed_valid());
+    }
+
+    #[test]
+    fn labels_are_coarse_and_carry_no_secret() {
+        assert_eq!(KeyValidationOutcome::Valid.label(), "valid");
+        assert_eq!(
+            KeyValidationOutcome::Invalid { status: 403 }.label(),
+            "invalid"
+        );
+        assert_eq!(
+            KeyValidationOutcome::CredentialMissing.label(),
+            "credential_missing"
+        );
+        assert_eq!(
+            KeyValidationOutcome::Unavailable {
+                detail: "transport"
+            }
+            .label(),
+            "unavailable"
+        );
+    }
+
+    #[test]
+    fn mock_returns_preset_per_provider_and_missing_for_unset_no_fallback() {
+        // DeepSeek preset Valid, Anthropic UNSET. Validating anthropic must report
+        // CredentialMissing — NEVER fall back to deepseek's Valid.
+        let probe =
+            MockKeyValidationProbe::new().with(KeyProvider::DeepSeek, KeyValidationOutcome::Valid);
+        assert_eq!(
+            probe.validate(KeyProvider::DeepSeek),
+            KeyValidationOutcome::Valid
+        );
+        assert_eq!(
+            probe.validate(KeyProvider::Anthropic),
+            KeyValidationOutcome::CredentialMissing,
+            "an unset provider must NOT inherit another provider's Valid"
+        );
+    }
+}

--- a/rust-core/crates/friday-providers/src/lib.rs
+++ b/rust-core/crates/friday-providers/src/lib.rs
@@ -20,8 +20,16 @@ use thiserror::Error;
 
 pub mod claude_control;
 pub mod codex_appserver;
+/// R7 — the call-free key-validation seam: the [`key_validation::KeyValidationProbe`]
+/// trait + provider-agnostic typed [`key_validation::KeyValidationOutcome`] +
+/// a mock. The LIVE round-trip impl lives in `friday-hub` (secret-bearing); this
+/// crate keeps its "no model call, nothing charged" contract intact.
+pub mod key_validation;
 pub mod session;
 pub mod unified;
+pub use key_validation::{
+    KeyProvider, KeyValidationOutcome, KeyValidationProbe, MockKeyValidationProbe,
+};
 pub use session::{send_to_provider, CliSession, MockSession, SessionOutcome, SessionRunner};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
## R7 — provider-probe (live key-validation + composite capability-doctor)

Tier-1 R7 from `TS_RECON_TRUTH_ROADMAP_20260610.md` §3: `providers.validate` / `providers.doctor` / `capabilities.doctor`. **DARK build** — builds the mechanism + report; flips NO live route.

### Dark / no-route-flip
- Registers **NO production route**; NOT added to `friday_hub::capability`'s route table.
- Does **NOT** flip the live TS `providers.validate` / `providers.doctor` / `capabilities.doctor` paths (those stay the production surface); no prod default change.
- The live round-trip is exercised **only** by an `#[ignore]`'d harness (built, compiles, NOT run here — spends quota). Route cutover is operator-gated. Confers no v1 GO.

### What's built
**`friday-providers` (call-free seam; keeps its "no model call, nothing charged" contract):** new `key_validation` module —
- `KeyProvider` `{DeepSeek, Anthropic}` — the **API-key identity**, deliberately DISTINCT from the CLI `Provider` `{Codex, Claude}`.
- typed `KeyValidationOutcome` `{Valid, Invalid{status}, CredentialMissing, Unavailable{detail}}`.
- `KeyValidationProbe` trait + `MockKeyValidationProbe`.

**`friday-hub` (secret-bearing real impl + composite; where provider secrets live):**
- `provider_key_validation`: `LiveKeyValidationProbe` constructs the existing `friday-deepseek` / `friday-anthropic` clients `from_env` and runs ONE minimal authenticated round-trip — DeepSeek via `GET /models` (no completion quota), Anthropic via `POST /v1/messages` `max_tokens=1` (~1-2 tokens). Pure `map_deepseek_result` / `map_claude_result` map the (already-coarse) provider errors into outcomes.
- `capability_doctor`: `CapabilityDoctor::run` composes the R6 CLI-detect statuses (`Provider::all`) + R7 key-validation signals (`KeyProvider::all`) as **two separate per-provider sections**. Library-only (no entrypoint bin, unlike R6's `hub_providers_detect`).
- `tests/key_validation_live.rs`: the `#[ignore]`'d live harness (run-doc + quota asymmetry documented inline).

### No-fallback + secret-safety
- **No-fallback:** a failed validation is an explicit typed outcome, never substituted. Mapping is deliberate — ONLY an auth `401/403` is `Invalid`; a `5xx`/`408`/`529`/`429`/transport error is `Unavailable` (could-not-confirm), so a transient hiccup or a rate-limit NEVER brands a good key bad. An `Unavailable` key is NOT counted as confirmed-valid.
- **No collapse:** the `claude` CLI subscription login and the `anthropic` API key are DISTINCT credentials, reported in separate sections — never folded into one "Claude ready" verdict. There is no cross-taxonomy aggregate bool (the two enums are disjoint; an AND/OR would under-report a single-axis provider like Codex).
- **Secret-safe:** outcomes carry at most a coarse HTTP status / static label — no key, request, or response body. Leak-lens KAT included.

### Substrate-gap honesty
The roadmap calls R7 "PARTIAL". In one direction it is arguably LESS of a gap: the live HTTP clients (`friday-deepseek`/`friday-anthropic`) already exist and are round-trip-proven, so R7 *wraps* them with a typed key-validation outcome + composite, rather than building a round-trip from scratch. The real complication found is the **taxonomy mismatch**: the CLI providers `{Codex, Claude}` and the API-key providers `{DeepSeek, Anthropic}` barely intersect (Codex has no HTTP key path; DeepSeek is not a CLI provider; Claude-CLI ≠ Anthropic-key), which is why the two signals are reported as separate sections, not fused.

### Verification (from `rust-core/`)
- `cargo build --workspace` ✅
- `cargo test -p friday-providers -p friday-hub` ✅ (19 new mock/KAT tests + 2 `#[ignore]`'d live tests built-not-run; nothing else broke)
- `cargo clippy -p friday-providers -p friday-hub --all-targets -- -D warnings` ✅ (0 warnings)
- `cargo fmt --all -- --check` ✅
- `cargo test -p friday-arch-tests` ✅ (phone boundary intact — no Cargo.toml dep change; `friday-providers`/`friday-anthropic`/`friday-deepseek` stay out of the `friday-ffi` graph)

### Files
- `rust-core/crates/friday-providers/src/key_validation.rs` (new)
- `rust-core/crates/friday-providers/src/lib.rs` (module wiring)
- `rust-core/crates/friday-hub/src/provider_key_validation.rs` (new)
- `rust-core/crates/friday-hub/src/capability_doctor.rs` (new)
- `rust-core/crates/friday-hub/src/lib.rs` (module wiring)
- `rust-core/crates/friday-hub/tests/key_validation_live.rs` (new, `#[ignore]`'d)

🤖 Generated with [Claude Code](https://claude.com/claude-code)