### PR TITLE
feat(rust-workflow): R3 — workflow catalog CRUD + deploy on workflow_def storage (dark, no route flip)

### DIFF
--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -148,6 +148,17 @@ pub mod workflow_exec;
 /// NOT product-replaced; NOT v1 GO.
 pub mod workflow_def;
 
+/// R3 — workflow CATALOG mutation + deploy layer (DARK). The per-WORKFLOW catalog
+/// ENTRY layer the TS `workflows.*` mutation surface maps to
+/// (`workflows.create/update/archive/publish/deploy`), orchestrating
+/// [`friday_storage::workflow_catalog`] (the entry) + [`workflow_def`] (the
+/// version bodies). `publish` delegates to the S8 single-published flip (the
+/// catalog never records the published pointer); `deploy` sets the catalog deploy
+/// pointer to the S8-published version WITHOUT firing a runtime trigger (that is
+/// R2/S10, gated). DARK substrate: no production route, the live TS `workflows.*`
+/// routes are NOT flipped; NOT v1 GO.
+pub mod workflow_catalog;
+
 /// S8 — TS published-version → Rust LINEAR-ONLY workflow translator. Any
 /// DAG/branch/parallel/unsupported source feature fails CLOSED to an explicit
 /// `Unsupported { reasons, preserved_source_meta }` — never a silent flattening,

--- a/rust-core/crates/friday-hub/src/workflow_catalog.rs
+++ b/rust-core/crates/friday-hub/src/workflow_catalog.rs
@@ -1,0 +1,692 @@
+//! R3 — the Rust workflow CATALOG mutation + deploy DOMAIN layer (DARK).
+//!
+//! The S8 [`crate::workflow_def`] layer is the DEFINITION layer (versioned
+//! immutable bodies + the single-published flip). This module is the per-WORKFLOW
+//! CATALOG layer the TS `workflows.*` mutation surface maps to —
+//! `workflows.create / update / archive / publish / deploy` — orchestrating
+//! [`friday_storage::workflow_catalog`] (the entry row) and
+//! [`crate::workflow_def`] (the version bodies) into the five catalog operations.
+//!
+//! ## Scope and truth labels (DARK substrate)
+//! - This is the catalog-MUTATION layer only. It registers NO production route,
+//!   NO scheduler/trigger/daemon (that is R2/S10, operator-gated), and changes NO
+//!   TS runtime file. The live TS `workflows.*` routes stay fail-closed/retired;
+//!   workflow execution remains fenced in TS and is NOT product-replaced; NOT v1 GO.
+//! - There is NO runtime trigger here: [`deploy`] sets the catalog DEPLOY POINTER
+//!   (`deployed_version`) to a PUBLISHED version after confirming it is published
+//!   in S8 — it does NOT start a run, register a schedule, or fire a trigger.
+//!   "Deployable state at the storage/domain level" is the explicit R3 boundary;
+//!   wiring a runtime trigger is R2/S10 (gated).
+//!
+//! ## The single source of published truth stays in S8
+//! `publish` delegates to [`friday_storage::workflow_def::set_published`] — the
+//! catalog NEVER persists "which version is published" (that is the
+//! `workflow_definition.is_published` flag, protected by the S8 partial-unique
+//! index + atomic flip). The catalog's only version pointer is the R3 deploy
+//! pointer, which `deploy` sets only AFTER reading back the S8-published version.
+//! This keeps the at-most-one-published invariant in exactly one place.
+//!
+//! ## Fail-closed posture
+//! Every op fail-closes: a missing entry, a stale `expected_revision` (optimistic
+//! concurrency), an invalid definition body, publishing/deploying a non-existent
+//! version, deploying a version that is not the published one, or mutating an
+//! archived entry. No `unwrap`/`expect` on caller input; no panics.
+
+use crate::workflow_def::{
+    create_definition as def_create, get_parsed_definition as def_get_parsed, StoredWorkflowDefV1,
+    WorkflowDefError,
+};
+use friday_storage::workflow_catalog::{
+    archive_entry as cat_archive, create_entry as cat_create, get_entry as cat_get,
+    list_entries as cat_list, set_deployed_version as cat_set_deployed, update_entry as cat_update,
+    NewWorkflowCatalogEntry, WorkflowCatalogRow, WorkflowCatalogUpdate,
+};
+use friday_storage::workflow_def::{
+    get_definition as def_get, get_published_definition as def_get_published,
+    set_published as def_set_published, DefinitionSource,
+};
+use rusqlite::Connection;
+
+/// The maximum slug length the catalog accepts (mirrors the TS
+/// `workflows.create` `slug` bound).
+pub const MAX_SLUG_LEN: usize = 128;
+/// The maximum name length the catalog accepts (mirrors the TS `name` bound).
+pub const MAX_NAME_LEN: usize = 255;
+
+/// Fail-closed errors of the catalog-mutation layer.
+#[derive(Debug, thiserror::Error)]
+pub enum WorkflowCatalogError {
+    /// Caller input failed a fail-closed validation (empty/over-long slug or
+    /// name, etc.) — never persisted.
+    #[error("workflow catalog input invalid: {0}")]
+    Invalid(String),
+    /// A targeted catalog entry / version does not exist.
+    #[error("workflow catalog not found: {0}")]
+    NotFound(String),
+    /// The version named for publish/deploy is not the workflow's PUBLISHED
+    /// version (deploy requires a published target — fail-closed).
+    #[error("workflow catalog conflict: {0}")]
+    Conflict(String),
+    /// The definition body failed the S8 definition-layer validation.
+    #[error("workflow definition error: {0}")]
+    Definition(#[from] WorkflowDefError),
+    /// A storage-layer failure (incl. a stale-revision optimistic-concurrency
+    /// conflict, a duplicate slug, or an archived-entry refusal — all surfaced
+    /// fail-closed, never silently swallowed).
+    #[error("storage error: {0}")]
+    Storage(#[from] friday_storage::StorageError),
+}
+
+type Result<T> = std::result::Result<T, WorkflowCatalogError>;
+
+/// The version number a freshly-created workflow's first definition gets.
+pub const INITIAL_VERSION: i64 = 1;
+
+/// What a catalog mutation returns: the new optimistic-concurrency token.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CatalogMutation {
+    pub revision: i64,
+    pub etag: String,
+}
+
+/// Fail-closed validation of the caller-facing identity fields shared by
+/// create. Bounds mirror the TS `workflows.create` route guards.
+fn validate_identity(slug: &str, name: &str) -> Result<()> {
+    let s = slug.trim();
+    if s.is_empty() {
+        return Err(WorkflowCatalogError::Invalid(
+            "slug is required and must be a non-empty string".into(),
+        ));
+    }
+    if s.len() > MAX_SLUG_LEN {
+        return Err(WorkflowCatalogError::Invalid(format!(
+            "slug must be at most {MAX_SLUG_LEN} characters"
+        )));
+    }
+    let n = name.trim();
+    if n.is_empty() {
+        return Err(WorkflowCatalogError::Invalid(
+            "name is required and must be a non-empty string".into(),
+        ));
+    }
+    if n.len() > MAX_NAME_LEN {
+        return Err(WorkflowCatalogError::Invalid(format!(
+            "name must be at most {MAX_NAME_LEN} characters"
+        )));
+    }
+    Ok(())
+}
+
+/// CREATE: mint a new catalog entry AND its initial (unpublished) definition
+/// version v1, in one transaction so a half-created workflow (entry without its
+/// v1 body, or vice versa) can never persist — a duplicate id/slug rolls the
+/// whole thing back.
+///
+/// Mirrors TS `workflows.create` (mints the entry + the first version). The
+/// `def` body is validated by the S8 definition layer; a duplicate `workflow_id`
+/// or `slug` fails closed at the storage layer. Returns the entry's birth
+/// `(revision = 1, etag)`.
+#[allow(clippy::too_many_arguments)]
+pub fn create(
+    conn: &Connection,
+    workflow_id: &str,
+    slug: &str,
+    name: &str,
+    description: Option<&str>,
+    tags_json: Option<&str>,
+    def: &StoredWorkflowDefV1,
+    now_ms: i64,
+) -> Result<CatalogMutation> {
+    validate_identity(slug, name)?;
+    if workflow_id.trim().is_empty() {
+        return Err(WorkflowCatalogError::Invalid(
+            "workflow_id must be a non-empty string".into(),
+        ));
+    }
+    // The body's own schema/structure must validate BEFORE we touch the DB.
+    def.validate()?;
+
+    // One transaction over BOTH tables: the entry + its v1 body land together or
+    // not at all (no half-created workflow). A duplicate workflow_id/slug rolls
+    // the whole thing back (no dangling v1 body), and a concurrent create on the
+    // same single connection cannot interleave between the two inserts.
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(friday_storage::StorageError::from)?;
+    cat_create(
+        &tx,
+        &NewWorkflowCatalogEntry {
+            workflow_id,
+            slug,
+            name,
+            description,
+            tags_json,
+        },
+        now_ms,
+    )?;
+    def_create(
+        &tx,
+        workflow_id,
+        INITIAL_VERSION,
+        def,
+        DefinitionSource::RustNative,
+        None,
+        now_ms,
+    )?;
+    // The catalog `etag` is derived inside `cat_create`; re-read it back so the
+    // returned token matches the persisted row exactly (no second derivation).
+    let etag = read_etag(&tx, workflow_id)?;
+    tx.commit().map_err(friday_storage::StorageError::from)?;
+    Ok(CatalogMutation { revision: 1, etag })
+}
+
+/// Read the just-written etag inside a transaction (the catalog derived it; we
+/// surface the persisted value rather than re-deriving it).
+fn read_etag(conn: &Connection, workflow_id: &str) -> Result<String> {
+    let row = cat_get(conn, workflow_id)?
+        .ok_or_else(|| WorkflowCatalogError::NotFound(format!("'{workflow_id}'")))?;
+    Ok(row.etag)
+}
+
+/// UPDATE catalog metadata (name / description / tags) under optimistic
+/// concurrency. A `None` field is left unchanged; `description: Some(None)`
+/// clears it. Fail-closed on missing entry, stale revision, archived entry, or
+/// an invalid name. Returns the new `(revision, etag)`.
+///
+/// Per S8, a definition body is IMMUTABLE — "updating the workflow's steps" is a
+/// NEW version via [`add_version`], not an in-place edit, so this op never
+/// touches a definition body.
+pub fn update(
+    conn: &Connection,
+    workflow_id: &str,
+    expected_revision: i64,
+    name: Option<&str>,
+    description: Option<Option<&str>>,
+    tags_json: Option<&str>,
+    now_ms: i64,
+) -> Result<CatalogMutation> {
+    if let Some(n) = name {
+        let t = n.trim();
+        if t.is_empty() {
+            return Err(WorkflowCatalogError::Invalid(
+                "name must be a non-empty string".into(),
+            ));
+        }
+        if t.len() > MAX_NAME_LEN {
+            return Err(WorkflowCatalogError::Invalid(format!(
+                "name must be at most {MAX_NAME_LEN} characters"
+            )));
+        }
+    }
+    let (revision, etag) = cat_update(
+        conn,
+        workflow_id,
+        expected_revision,
+        &WorkflowCatalogUpdate {
+            name,
+            description,
+            tags_json,
+        },
+        now_ms,
+    )?;
+    Ok(CatalogMutation { revision, etag })
+}
+
+/// ADD a new immutable definition version to an existing (non-archived) catalog
+/// entry. Definitions are immutable (S8), so "editing a workflow's steps" mints
+/// a new version; publishing/deploying it are separate explicit ops. The
+/// `version` must be unused (a duplicate fails closed at the S8 PK). The catalog
+/// entry must exist and not be archived. This does NOT bump the catalog revision
+/// (the catalog row's identity is unchanged; only a new version body is added).
+pub fn add_version(
+    conn: &Connection,
+    workflow_id: &str,
+    version: i64,
+    def: &StoredWorkflowDefV1,
+    now_ms: i64,
+) -> Result<String> {
+    require_active_entry(conn, workflow_id)?; // existence + non-archived
+    Ok(def_create(
+        conn,
+        workflow_id,
+        version,
+        def,
+        DefinitionSource::RustNative,
+        None,
+        now_ms,
+    )?)
+}
+
+/// ARCHIVE (soft-delete) a catalog entry under optimistic concurrency. The entry
+/// is never hard-deleted, so a deployed/published pointer can never dangle.
+/// Fail-closed on missing entry, stale revision, or an already-archived entry.
+/// Returns the new `(revision, etag)`.
+pub fn archive(
+    conn: &Connection,
+    workflow_id: &str,
+    expected_revision: i64,
+    now_ms: i64,
+) -> Result<CatalogMutation> {
+    let (revision, etag) = cat_archive(conn, workflow_id, expected_revision, now_ms)?;
+    Ok(CatalogMutation { revision, etag })
+}
+
+/// PUBLISH a specific definition version of a workflow. Delegates the
+/// at-most-one-published flip to the S8 [`def_set_published`] (the single source
+/// of truth — the catalog never records the published pointer). Fail-closed on a
+/// missing entry, an archived entry, or a non-existent version (S8
+/// `set_published` returns `NotFound`). Publishing does NOT touch the deploy
+/// pointer (deploy is a separate explicit op) and does NOT bump the catalog
+/// revision (the published flag lives in S8, not the catalog row).
+pub fn publish(conn: &Connection, workflow_id: &str, version: i64) -> Result<()> {
+    let _ = require_active_entry(conn, workflow_id)?;
+    // The version must EXIST before we flip it (S8 `set_published` already
+    // fail-closes a missing version, but we surface a catalog-shaped NotFound so
+    // the caller sees a consistent error vocabulary).
+    if def_get(conn, workflow_id, version)?.is_none() {
+        return Err(WorkflowCatalogError::NotFound(format!(
+            "'{workflow_id}' v{version} (cannot publish a version that does not exist)"
+        )));
+    }
+    def_set_published(conn, workflow_id, version)?;
+    Ok(())
+}
+
+/// DEPLOY (R3 boundary): set the catalog DEPLOY POINTER to the workflow's
+/// currently-PUBLISHED version, after confirming a published version exists in
+/// S8. This is "published def → deployable state at the storage/domain level"
+/// and NOTHING more — it does NOT start a run, register a schedule, or fire a
+/// runtime trigger (that is R2/S10, gated).
+///
+/// Fail-closed on a missing/archived entry or a workflow with NO published
+/// version (`Conflict` — there is nothing deployable). The deploy pointer is set
+/// to whatever S8 reports as published, so the catalog can never deploy an
+/// unpublished version. Returns the new catalog `(revision, etag)`.
+pub fn deploy(
+    conn: &Connection,
+    workflow_id: &str,
+    expected_revision: i64,
+    now_ms: i64,
+) -> Result<CatalogMutation> {
+    require_active_entry(conn, workflow_id)?;
+    // The deployable target is the S8-PUBLISHED version (single source of truth).
+    let published = def_get_published(conn, workflow_id)?.ok_or_else(|| {
+        WorkflowCatalogError::Conflict(format!(
+            "'{workflow_id}' has no published version; publish a version before deploying"
+        ))
+    })?;
+    // Defense in depth: re-parse the published body through the S8 loader, which
+    // fail-closes on a foreign/unparseable definition (an unsupported
+    // `schema_version`, a smuggled DAG shape, or a row whose `name` column
+    // diverges from the body). `get_published_definition` already checksum-verifies
+    // the body, but a tampered row can carry a SELF-CONSISTENT foreign body (a
+    // recomputed sha256 over a v2 document); this parse refuses to mark such a
+    // body deployable — only a supported (linear, v1) definition reaches a
+    // deployable state. Errors surface as `WorkflowCatalogError::Definition`.
+    def_get_parsed(conn, workflow_id, published.version)?;
+    let (revision, etag) = cat_set_deployed(
+        conn,
+        workflow_id,
+        expected_revision,
+        published.version,
+        now_ms,
+    )?;
+    Ok(CatalogMutation { revision, etag })
+}
+
+/// READ one catalog entry (refs-only; no definition body). `None` if unknown.
+pub fn get(conn: &Connection, workflow_id: &str) -> Result<Option<WorkflowCatalogRow>> {
+    Ok(cat_get(conn, workflow_id)?)
+}
+
+/// LIST all catalog entries (refs-only), newest-created first.
+pub fn list(conn: &Connection) -> Result<Vec<WorkflowCatalogRow>> {
+    Ok(cat_list(conn)?)
+}
+
+/// Load a catalog entry and fail closed if it is missing or archived (the shared
+/// precondition for publish/deploy/add_version — an archived workflow is
+/// read-only).
+fn require_active_entry(conn: &Connection, workflow_id: &str) -> Result<WorkflowCatalogRow> {
+    let entry = cat_get(conn, workflow_id)?
+        .ok_or_else(|| WorkflowCatalogError::NotFound(format!("'{workflow_id}'")))?;
+    if entry.is_archived {
+        return Err(WorkflowCatalogError::Conflict(format!(
+            "'{workflow_id}' is archived (an archived workflow is read-only)"
+        )));
+    }
+    Ok(entry)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use friday_storage::Db;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static C: AtomicU64 = AtomicU64::new(0);
+    fn tmp(tag: &str) -> String {
+        std::env::temp_dir()
+            .join(format!(
+                "friday-wfcat-{}-{}-{}.sqlite",
+                std::process::id(),
+                tag,
+                C.fetch_add(1, Ordering::Relaxed)
+            ))
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    fn step(id: &str, action: &str) -> crate::workflow_def::StoredWorkflowStepV1 {
+        crate::workflow_def::StoredWorkflowStepV1 {
+            id: id.to_string(),
+            action: action.to_string(),
+            params: vec![],
+            force_checkpoint: false,
+            evidence_required: false,
+        }
+    }
+
+    fn def(name: &str) -> StoredWorkflowDefV1 {
+        StoredWorkflowDefV1 {
+            schema_version: crate::workflow_def::WORKFLOW_DEF_SCHEMA_VERSION,
+            name: name.into(),
+            steps: vec![step("read", "read_file"), step("scan", "search")],
+        }
+    }
+
+    #[test]
+    fn create_update_publish_archive_lifecycle() {
+        let db = Db::open_hub(&tmp("lifecycle")).unwrap();
+        let conn = db.conn();
+
+        // CREATE: entry + v1 body land together; born revision 1, not archived.
+        let created = create(
+            conn,
+            "wf1",
+            "research-wf",
+            "Research",
+            Some("a research workflow"),
+            None,
+            &def("Research"),
+            100,
+        )
+        .unwrap();
+        assert_eq!(created.revision, 1);
+        assert_eq!(created.etag.len(), 64);
+        let entry = get(conn, "wf1").unwrap().unwrap();
+        assert_eq!(entry.slug, "research-wf");
+        assert!(!entry.is_archived);
+        assert_eq!(entry.deployed_version, None);
+        // The v1 definition body was created alongside the entry.
+        assert!(def_get(conn, "wf1", 1).unwrap().is_some());
+
+        // UPDATE metadata under optimistic concurrency (revision bumps to 2).
+        let updated = update(
+            conn,
+            "wf1",
+            1,
+            Some("Research v2"),
+            Some(Some("updated description")),
+            Some(r#"["ai","research"]"#),
+            200,
+        )
+        .unwrap();
+        assert_eq!(updated.revision, 2);
+        assert_ne!(updated.etag, created.etag);
+        let entry = get(conn, "wf1").unwrap().unwrap();
+        assert_eq!(entry.name, "Research v2");
+        assert_eq!(entry.description.as_deref(), Some("updated description"));
+        assert_eq!(entry.tags_json, r#"["ai","research"]"#);
+
+        // PUBLISH v1 (delegates the flip to S8; catalog revision unchanged).
+        publish(conn, "wf1", 1).unwrap();
+        assert_eq!(def_get_published(conn, "wf1").unwrap().unwrap().version, 1);
+        assert_eq!(
+            get(conn, "wf1").unwrap().unwrap().revision,
+            2,
+            "publish does not bump the catalog revision (published flag lives in S8)"
+        );
+
+        // ARCHIVE under optimistic concurrency (revision bumps to 3).
+        let archived = archive(conn, "wf1", 2, 300).unwrap();
+        assert_eq!(archived.revision, 3);
+        assert!(get(conn, "wf1").unwrap().unwrap().is_archived);
+    }
+
+    #[test]
+    fn single_published_invariant_v2_unpublishes_v1() {
+        let db = Db::open_hub(&tmp("single-pub")).unwrap();
+        let conn = db.conn();
+        create(conn, "wf1", "wf", "WF", None, None, &def("WF"), 100).unwrap();
+        add_version(conn, "wf1", 2, &def("WF"), 200).unwrap();
+
+        publish(conn, "wf1", 1).unwrap();
+        assert_eq!(def_get_published(conn, "wf1").unwrap().unwrap().version, 1);
+        // Publishing v2 unpublishes v1 in the same S8 flip (at most ONE published).
+        publish(conn, "wf1", 2).unwrap();
+        assert_eq!(def_get_published(conn, "wf1").unwrap().unwrap().version, 2);
+        let published_count = friday_storage::workflow_def::list_definitions(conn)
+            .unwrap()
+            .into_iter()
+            .filter(|s| s.is_published)
+            .count();
+        assert_eq!(
+            published_count, 1,
+            "the S8 single-published invariant holds"
+        );
+    }
+
+    #[test]
+    fn deploy_of_a_published_def_sets_the_pointer() {
+        let db = Db::open_hub(&tmp("deploy")).unwrap();
+        let conn = db.conn();
+        create(conn, "wf1", "wf", "WF", None, None, &def("WF"), 100).unwrap();
+        add_version(conn, "wf1", 2, &def("WF"), 150).unwrap();
+        publish(conn, "wf1", 2).unwrap();
+
+        // DEPLOY sets the pointer to whatever S8 reports as published (v2).
+        let entry_before = get(conn, "wf1").unwrap().unwrap();
+        let deployed = deploy(conn, "wf1", entry_before.revision, 200).unwrap();
+        assert_eq!(deployed.revision, entry_before.revision + 1);
+        let entry = get(conn, "wf1").unwrap().unwrap();
+        assert_eq!(
+            entry.deployed_version,
+            Some(2),
+            "deploy points at the S8-published version, never an arbitrary one"
+        );
+
+        // Re-publishing v1 then re-deploying moves the pointer to v1 (always the
+        // published target, never a stale one).
+        publish(conn, "wf1", 1).unwrap();
+        let entry = get(conn, "wf1").unwrap().unwrap();
+        deploy(conn, "wf1", entry.revision, 300).unwrap();
+        assert_eq!(get(conn, "wf1").unwrap().unwrap().deployed_version, Some(1));
+    }
+
+    #[test]
+    fn deploy_without_a_published_version_fails_closed() {
+        let db = Db::open_hub(&tmp("deploy-nopub")).unwrap();
+        let conn = db.conn();
+        create(conn, "wf1", "wf", "WF", None, None, &def("WF"), 100).unwrap();
+        // No version published yet → nothing deployable.
+        let rev = get(conn, "wf1").unwrap().unwrap().revision;
+        assert!(matches!(
+            deploy(conn, "wf1", rev, 200),
+            Err(WorkflowCatalogError::Conflict(_))
+        ));
+        assert_eq!(get(conn, "wf1").unwrap().unwrap().deployed_version, None);
+    }
+
+    #[test]
+    fn deploy_of_a_self_consistent_foreign_body_fails_closed() {
+        // Defense in depth: a tampered row can carry a SELF-CONSISTENT foreign
+        // body (a recomputed sha256 over an unsupported `schema_version=2`
+        // document) that slips the S8 checksum gate. The deploy re-parse must
+        // refuse to mark such a body deployable, and the pointer must stay None.
+        use sha2::{Digest, Sha256};
+        let db = Db::open_hub(&tmp("deploy-foreign")).unwrap();
+        let conn = db.conn();
+        create(conn, "wf1", "wf", "WF", None, None, &def("WF"), 100).unwrap();
+        publish(conn, "wf1", 1).unwrap();
+
+        // Hand-edit the published v1 body to a FOREIGN (v2) document and recompute
+        // its checksum so the S8 checksum gate passes (a tampered-but-consistent
+        // row). `name` is kept so only the schema_version probe fails.
+        let foreign = r#"{"schema_version":2,"name":"WF","steps":[],"edges":[]}"#;
+        let mut h = Sha256::new();
+        h.update(foreign.as_bytes());
+        let checksum = h
+            .finalize()
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect::<String>();
+        conn.execute(
+            "UPDATE workflow_definition SET definition_json = ?1, checksum = ?2
+             WHERE workflow_id = 'wf1' AND version = 1",
+            rusqlite::params![foreign, checksum],
+        )
+        .unwrap();
+
+        let rev = get(conn, "wf1").unwrap().unwrap().revision;
+        assert!(
+            matches!(
+                deploy(conn, "wf1", rev, 200),
+                Err(WorkflowCatalogError::Definition(_))
+            ),
+            "a foreign published body must fail closed at the deploy re-parse"
+        );
+        assert_eq!(
+            get(conn, "wf1").unwrap().unwrap().deployed_version,
+            None,
+            "deploy of a foreign body must not set the pointer"
+        );
+    }
+
+    #[test]
+    fn publish_nonexistent_version_fails_closed() {
+        let db = Db::open_hub(&tmp("pub-missing")).unwrap();
+        let conn = db.conn();
+        create(conn, "wf1", "wf", "WF", None, None, &def("WF"), 100).unwrap();
+        assert!(matches!(
+            publish(conn, "wf1", 99),
+            Err(WorkflowCatalogError::NotFound(_))
+        ));
+        assert!(def_get_published(conn, "wf1").unwrap().is_none());
+    }
+
+    #[test]
+    fn mutations_on_unknown_or_stale_or_archived_entries_fail_closed() {
+        let db = Db::open_hub(&tmp("fail-closed")).unwrap();
+        let conn = db.conn();
+
+        // unknown entry → NotFound for every op that touches one.
+        assert!(matches!(
+            update(conn, "ghost", 1, Some("x"), None, None, 1),
+            Err(WorkflowCatalogError::Storage(
+                friday_storage::StorageError::NotFound(_)
+            ))
+        ));
+        assert!(matches!(
+            publish(conn, "ghost", 1),
+            Err(WorkflowCatalogError::NotFound(_))
+        ));
+        assert!(matches!(
+            deploy(conn, "ghost", 1, 1),
+            Err(WorkflowCatalogError::NotFound(_))
+        ));
+
+        create(conn, "wf1", "wf", "WF", None, None, &def("WF"), 100).unwrap();
+
+        // STALE revision (optimistic concurrency) fails closed, no write.
+        assert!(matches!(
+            update(conn, "wf1", 99, Some("x"), None, None, 200),
+            Err(WorkflowCatalogError::Storage(
+                friday_storage::StorageError::Unsupported(_)
+            ))
+        ));
+        assert_eq!(get(conn, "wf1").unwrap().unwrap().name, "WF", "no write");
+
+        // duplicate slug fails closed.
+        assert!(create(
+            conn,
+            "wf2",
+            "wf",
+            "Another",
+            None,
+            None,
+            &def("Another"),
+            300
+        )
+        .is_err());
+
+        // ARCHIVED entry is read-only: update / publish / deploy / add_version all refuse.
+        archive(conn, "wf1", 1, 400).unwrap();
+        assert!(matches!(
+            update(conn, "wf1", 2, Some("x"), None, None, 500),
+            Err(WorkflowCatalogError::Storage(
+                friday_storage::StorageError::Unsupported(_)
+            ))
+        ));
+        assert!(matches!(
+            publish(conn, "wf1", 1),
+            Err(WorkflowCatalogError::Conflict(_))
+        ));
+        assert!(matches!(
+            deploy(conn, "wf1", 2, 500),
+            Err(WorkflowCatalogError::Conflict(_))
+        ));
+        assert!(matches!(
+            add_version(conn, "wf1", 2, &def("WF"), 500),
+            Err(WorkflowCatalogError::Conflict(_))
+        ));
+        // archiving twice fails closed.
+        assert!(archive(conn, "wf1", 2, 600).is_err());
+    }
+
+    #[test]
+    fn create_rejects_invalid_identity_and_body() {
+        let db = Db::open_hub(&tmp("invalid")).unwrap();
+        let conn = db.conn();
+        // empty slug.
+        assert!(matches!(
+            create(conn, "wf1", "  ", "WF", None, None, &def("WF"), 1),
+            Err(WorkflowCatalogError::Invalid(_))
+        ));
+        // over-long slug.
+        let long = "s".repeat(MAX_SLUG_LEN + 1);
+        assert!(matches!(
+            create(conn, "wf1", &long, "WF", None, None, &def("WF"), 1),
+            Err(WorkflowCatalogError::Invalid(_))
+        ));
+        // empty name.
+        assert!(matches!(
+            create(conn, "wf1", "wf", "  ", None, None, &def("WF"), 1),
+            Err(WorkflowCatalogError::Invalid(_))
+        ));
+        // invalid body (no steps) → S8 definition error; nothing persists.
+        let mut bad = def("WF");
+        bad.steps.clear();
+        assert!(matches!(
+            create(conn, "wf1", "wf", "WF", None, None, &bad, 1),
+            Err(WorkflowCatalogError::Definition(_))
+        ));
+        assert!(get(conn, "wf1").unwrap().is_none(), "no half-created entry");
+    }
+
+    #[test]
+    fn create_is_atomic_entry_and_v1_body_land_together() {
+        // A duplicate workflow_id on the SECOND create must not leave a dangling
+        // v1 body, and the FIRST create's entry+body are both present.
+        let db = Db::open_hub(&tmp("atomic")).unwrap();
+        let conn = db.conn();
+        create(conn, "wf1", "wf", "WF", None, None, &def("WF"), 100).unwrap();
+        assert!(get(conn, "wf1").unwrap().is_some());
+        assert!(def_get(conn, "wf1", 1).unwrap().is_some());
+        // second create with same id (different slug) fails closed at the entry PK,
+        // and rolls back so no spurious v1 body for a non-entry is left behind.
+        assert!(create(conn, "wf1", "wf-other", "WF2", None, None, &def("WF2"), 200).is_err());
+        // the original is intact.
+        assert_eq!(get(conn, "wf1").unwrap().unwrap().name, "WF");
+    }
+}

--- a/rust-core/crates/friday-hub/src/workflow_catalog.rs
+++ b/rust-core/crates/friday-hub/src/workflow_catalog.rs
@@ -45,7 +45,7 @@ use friday_storage::workflow_def::{
     get_definition as def_get, get_published_definition as def_get_published,
     set_published as def_set_published, DefinitionSource,
 };
-use rusqlite::Connection;
+use rusqlite::{Connection, Transaction, TransactionBehavior};
 
 /// The maximum slug length the catalog accepts (mirrors the TS
 /// `workflows.create` `slug` bound).
@@ -238,6 +238,17 @@ pub fn update(
 /// `version` must be unused (a duplicate fails closed at the S8 PK). The catalog
 /// entry must exist and not be archived. This does NOT bump the catalog revision
 /// (the catalog row's identity is unchanged; only a new version body is added).
+///
+/// The archived (read-only) fence is re-checked INSIDE an IMMEDIATE transaction
+/// that also performs the `def_create` insert — mirroring how the storage layer's
+/// `update_entry` / `archive_entry` / `set_deployed_version` re-check `is_archived`
+/// inside their own IMMEDIATE tx (`workflow_def::write_tx` pattern). IMMEDIATE
+/// takes the write lock at BEGIN, so a concurrent `archive` cannot land between
+/// the archived-check and the version insert: a workflow archived between a
+/// caller's read and this call can never gain a new version (the TOCTOU is
+/// closed, uniformly with the other mutating ops). Both statements live in one
+/// `def_create`-bearing tx, so the new version body is never written for an entry
+/// that was concurrently archived.
 pub fn add_version(
     conn: &Connection,
     workflow_id: &str,
@@ -245,16 +256,23 @@ pub fn add_version(
     def: &StoredWorkflowDefV1,
     now_ms: i64,
 ) -> Result<String> {
-    require_active_entry(conn, workflow_id)?; // existence + non-archived
-    Ok(def_create(
-        conn,
+    // IMMEDIATE (write lock at BEGIN), exactly like the storage `write_tx` the
+    // other mutating ops use — NOT the DEFERRED `unchecked_transaction`, whose
+    // lock would not yet be held when the archived SELECT runs.
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)
+        .map_err(friday_storage::StorageError::from)?;
+    require_active_entry_tx(&tx, workflow_id)?; // existence + non-archived, IN-TX (authoritative)
+    let checksum = def_create(
+        &tx,
         workflow_id,
         version,
         def,
         DefinitionSource::RustNative,
         None,
         now_ms,
-    )?)
+    )?;
+    tx.commit().map_err(friday_storage::StorageError::from)?;
+    Ok(checksum)
 }
 
 /// ARCHIVE (soft-delete) a catalog entry under optimistic concurrency. The entry
@@ -345,10 +363,35 @@ pub fn list(conn: &Connection) -> Result<Vec<WorkflowCatalogRow>> {
 }
 
 /// Load a catalog entry and fail closed if it is missing or archived (the shared
-/// precondition for publish/deploy/add_version — an archived workflow is
-/// read-only).
+/// precondition for publish/deploy — an archived workflow is read-only). This is
+/// the HUB-LAYER (pre-tx) check; for `deploy` the authoritative in-tx archived
+/// re-check still lives in the storage `set_deployed_version` IMMEDIATE tx, and
+/// for `add_version` in [`require_active_entry_tx`]. `publish` relies on this
+/// pre-tx check only: a uniform in-tx fence for publish would require a
+/// tx-composable variant of the S8 `set_published` (which opens its own
+/// transaction — nesting fails closed), and altering that delegation is out of
+/// scope here (filed as a follow-up).
 fn require_active_entry(conn: &Connection, workflow_id: &str) -> Result<WorkflowCatalogRow> {
     let entry = cat_get(conn, workflow_id)?
+        .ok_or_else(|| WorkflowCatalogError::NotFound(format!("'{workflow_id}'")))?;
+    if entry.is_archived {
+        return Err(WorkflowCatalogError::Conflict(format!(
+            "'{workflow_id}' is archived (an archived workflow is read-only)"
+        )));
+    }
+    Ok(entry)
+}
+
+/// In-transaction variant of [`require_active_entry`]: load the catalog entry
+/// using the open IMMEDIATE transaction (`cat_get` reads through the `Transaction`
+/// deref to `&Connection`) and fail closed if it is missing or archived. Because
+/// the surrounding tx holds the write lock from BEGIN (IMMEDIATE), this check and
+/// the caller's subsequent write are TOCTOU-safe against a concurrent `archive` —
+/// the authoritative fence for `add_version`, mirroring the storage layer's
+/// in-tx `is_archived` re-check in `update_entry` / `archive_entry` /
+/// `set_deployed_version`.
+fn require_active_entry_tx(tx: &Transaction<'_>, workflow_id: &str) -> Result<WorkflowCatalogRow> {
+    let entry = cat_get(tx, workflow_id)?
         .ok_or_else(|| WorkflowCatalogError::NotFound(format!("'{workflow_id}'")))?;
     if entry.is_archived {
         return Err(WorkflowCatalogError::Conflict(format!(
@@ -621,6 +664,9 @@ mod tests {
         .is_err());
 
         // ARCHIVED entry is read-only: update / publish / deploy / add_version all refuse.
+        // (update/deploy/add_version refuse via an IN-TX archived re-check;
+        // publish refuses via the HUB-LAYER pre-tx check — see `publish` /
+        // `require_active_entry` docs for why publish's fence is not in-tx.)
         archive(conn, "wf1", 1, 400).unwrap();
         assert!(matches!(
             update(conn, "wf1", 2, Some("x"), None, None, 500),
@@ -628,6 +674,7 @@ mod tests {
                 friday_storage::StorageError::Unsupported(_)
             ))
         ));
+        // publish on an archived entry → Conflict (via the hub-layer check).
         assert!(matches!(
             publish(conn, "wf1", 1),
             Err(WorkflowCatalogError::Conflict(_))
@@ -688,5 +735,93 @@ mod tests {
         assert!(create(conn, "wf1", "wf-other", "WF2", None, None, &def("WF2"), 200).is_err());
         // the original is intact.
         assert_eq!(get(conn, "wf1").unwrap().unwrap().name, "WF");
+    }
+
+    #[test]
+    fn create_rolls_back_catalog_entry_when_v1_body_insert_fails() {
+        // CROSS-TABLE atomicity: `create` inserts the catalog entry (cat_create)
+        // FIRST, then the v1 definition body (def_create), in one
+        // `unchecked_transaction` (DropBehavior::Rollback). The other atomicity
+        // KAT exercises a failure at the FIRST insert (duplicate workflow_id at
+        // cat_create), so def_create never runs and the cross-table rollback path
+        // is NOT exercised. This KAT drives the REACHABLE second-insert failure:
+        //
+        // S8 permits a (workflow_id, version) definition row with NO catalog entry
+        // (the layers are decoupled — no FK; the S8 module docs + tests create
+        // bare definitions). So pre-seed an ORPHAN (wf1, v1) definition via the S8
+        // layer with no catalog row, then call create(wf1, ...):
+        //   - cat_create SUCCEEDS (no catalog row for wf1 yet), then
+        //   - def_create FAILS on the workflow_definition PK ((wf1, v1) exists),
+        //   - so the `?` early-return DROPS the tx → rollback → the catalog insert
+        //     is undone.
+        //
+        // Red-green meaning: if the tx were NOT rollback-on-drop (e.g. an
+        // autocommit insert, or a commit-on-drop tx), the cat_create row would
+        // survive and get(wf1) would return Some → this assertion fails. The
+        // None assertion is therefore the empirical witness that the cross-table
+        // rollback path fires.
+        let db = Db::open_hub(&tmp("rollback-xtable")).unwrap();
+        let conn = db.conn();
+
+        // Pre-seed the orphan (wf1, v1) definition via the S8 layer — no catalog
+        // entry exists for wf1.
+        def_create(
+            conn,
+            "wf1",
+            INITIAL_VERSION,
+            &def("WF"),
+            DefinitionSource::RustNative,
+            None,
+            50,
+        )
+        .unwrap();
+        assert!(
+            get(conn, "wf1").unwrap().is_none(),
+            "precondition: no catalog entry for the orphan definition"
+        );
+
+        // create(wf1, ...): cat_create succeeds, def_create fails on the (wf1, v1)
+        // PK, the cross-table transaction rolls back.
+        let err = create(conn, "wf1", "wf", "WF", None, None, &def("WF"), 100);
+        assert!(
+            matches!(err, Err(WorkflowCatalogError::Definition(_))),
+            "create must fail closed when the v1 body insert collides on the S8 PK, got {err:?}"
+        );
+
+        // The catalog insert MUST have rolled back — no orphan catalog entry.
+        assert!(
+            get(conn, "wf1").unwrap().is_none(),
+            "the cat_create insert must roll back when def_create fails; no orphan catalog entry"
+        );
+        // And the pre-seeded orphan definition is untouched (still exactly v1).
+        assert!(def_get(conn, "wf1", 1).unwrap().is_some());
+    }
+
+    #[test]
+    fn add_version_on_archived_entry_fails_closed_in_tx() {
+        // The archived (read-only) fence for `add_version` is re-checked INSIDE
+        // the IMMEDIATE transaction that also performs the def_create insert. This
+        // KAT proves it fails CLOSED for an archived entry and writes NO new
+        // version body. (Single-threaded, this cannot ISOLATE the in-tx check
+        // firing from a pre-tx check — both would fire; what it proves is the
+        // fail-closed behavior. The in-tx authoritativeness/TOCTOU-uniformity is a
+        // structural property of using the IMMEDIATE write_tx, not something a
+        // single-threaded test isolates.)
+        let db = Db::open_hub(&tmp("addver-archived")).unwrap();
+        let conn = db.conn();
+        create(conn, "wf1", "wf", "WF", None, None, &def("WF"), 100).unwrap();
+        archive(conn, "wf1", 1, 200).unwrap();
+
+        let r = add_version(conn, "wf1", 2, &def("WF"), 300);
+        assert!(
+            matches!(r, Err(WorkflowCatalogError::Conflict(_))),
+            "add_version on an archived entry must fail closed (Conflict), got {r:?}"
+        );
+        // No v2 body was written (the in-tx fence fired before def_create, and the
+        // tx never committed).
+        assert!(
+            def_get(conn, "wf1", 2).unwrap().is_none(),
+            "no new version body may be written for an archived entry"
+        );
     }
 }

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -31,6 +31,7 @@ pub mod run_result;
 pub mod schedule;
 mod schema;
 pub mod workflow;
+pub mod workflow_catalog;
 pub mod workflow_def;
 pub mod workflow_read;
 

--- a/rust-core/crates/friday-storage/src/schema.rs
+++ b/rust-core/crates/friday-storage/src/schema.rs
@@ -92,6 +92,14 @@ pub const HUB_ONLY_TABLES: &[&str] = &[
     "workflow_schedule_fire",
     "scheduler_control",
     "scheduler_lease",
+    // R3: per-workflow CATALOG entry (DARK substrate). Holds the workflow's
+    // identity (slug/name/tags), soft-delete state, an optimistic-concurrency
+    // (revision, etag) pair, and the deploy pointer — never a definition body
+    // (that is the Hub-only `workflow_definition`) and never "which version is
+    // published" (the S8 `is_published` flag remains the single source of
+    // truth). Hub-only: a catalog entry is the Hub-coordinated workflow's
+    // identity record. Holds NO secret/key material.
+    "workflow_catalog",
 ];
 
 /// Tables present only on a phone (never created on the Hub).
@@ -371,6 +379,22 @@ pub fn hub_migrations() -> Vec<Migration> {
             name: "workflow_scheduler_substrate",
             destructive: false,
             up: m0024_workflow_scheduler_substrate,
+        },
+        // R3: per-workflow CATALOG entry store (DARK substrate — no production
+        // route, no scheduler/runtime trigger, no live TS `workflows.*` flip).
+        // The S8 `workflow_definition` store (v22) holds versioned immutable
+        // DEFINITION bodies + the single-published flag; this adds the per-WORKFLOW
+        // catalog ENTRY the `workflows.create/update/archive/publish/deploy`
+        // mutation surface operates over (identity, soft-delete, optimistic
+        // concurrency, deploy pointer). It deliberately does NOT persist the
+        // published-version pointer — that stays in `workflow_definition.is_published`
+        // (the single source of truth). Purely additive (CREATE TABLE + INDEX only)
+        // — touches no existing table, so v24 rows/queries are unaffected. NOT v1 GO.
+        Migration {
+            version: 25,
+            name: "workflow_catalog",
+            destructive: false,
+            up: m0025_workflow_catalog,
         },
     ]
 }
@@ -827,6 +851,50 @@ CREATE TABLE scheduler_lease (
     expires_at INTEGER NOT NULL,
     updated_at INTEGER NOT NULL
 );";
+
+// --- R3 workflow CATALOG fragment (Hub-only) --------------------------------
+
+// DARK catalog substrate (R3). One Hub-only table the catalog-CRUD + deploy
+// surface (`friday-hub::workflow_catalog`) operates over; nothing in production
+// reads or writes it (the live TS `workflows.*` routes are NOT flipped). It is
+// the per-WORKFLOW ENTRY layer ON TOP of the S8 `workflow_definition` versions.
+//
+// * `workflow_id` PK — the catalog entry's identity.
+// * `slug` — UNIQUE (the DB index makes two entries sharing a slug
+//   unrepresentable, even via raw SQL). `name` — display label. Both non-empty.
+// * `description` — nullable free-form label. `tags_json` — opaque JSON tag
+//   array (coarse labels only; the hub layer owns the shape), DEFAULT '[]'.
+// * `is_archived` — soft-delete flag (the `workflows.archive` end state); a
+//   catalog row is NEVER hard-deleted by the typed API, so a deployed/published
+//   pointer can never dangle behind a vanished entry.
+// * `revision` — optimistic-concurrency counter (>= 1; born 1, every mutation
+//   bumps by 1). `etag` — DERIVED (sha256 of identity fields + revision) by the
+//   typed API at the write chokepoint; the CHECK makes a malformed hand-built
+//   token unrepresentable. A mutation carrying a stale `expected_revision` fails
+//   CLOSED at the hub layer's read-then-write IMMEDIATE transaction.
+// * `deployed_version` — the R3 DEPLOY pointer (nullable; the version made the
+//   deployable target). NOTE: this is NOT "which version is published" — that
+//   stays in `workflow_definition.is_published` (the single source of truth);
+//   the hub deploy op confirms a version is published BEFORE setting this. NO FK
+//   to `workflow_definition`: the layers are intentionally decoupled (a catalog
+//   entry may exist before any version), and cross-table consistency is enforced
+//   by the hub layer querying both, not by a schema FK.
+const DDL_WORKFLOW_CATALOG: &str = "
+CREATE TABLE workflow_catalog (
+    workflow_id      TEXT PRIMARY KEY CHECK(length(trim(workflow_id)) > 0),
+    slug             TEXT NOT NULL CHECK(length(trim(slug)) > 0),
+    name             TEXT NOT NULL CHECK(length(trim(name)) > 0),
+    description      TEXT,
+    tags_json        TEXT NOT NULL DEFAULT '[]',
+    is_archived      INTEGER NOT NULL DEFAULT 0 CHECK(is_archived IN (0, 1)),
+    revision         INTEGER NOT NULL CHECK(revision >= 1),
+    etag             TEXT NOT NULL CHECK(length(etag) = 64),
+    deployed_version INTEGER CHECK(deployed_version IS NULL OR deployed_version >= 1),
+    created_at       INTEGER NOT NULL,
+    updated_at       INTEGER NOT NULL
+);
+CREATE UNIQUE INDEX idx_workflow_catalog_slug ON workflow_catalog(slug);
+CREATE INDEX idx_workflow_catalog_archived ON workflow_catalog(is_archived);";
 
 // --- PNS-001 provider-session fragments (Hub-only) --------------------------
 
@@ -1661,4 +1729,11 @@ fn m0024_workflow_scheduler_substrate(tx: &Transaction) -> rusqlite::Result<()> 
         [],
     )?;
     Ok(())
+}
+
+// R3: additive Hub-only per-workflow CATALOG store (see the DDL const's doc
+// comment). Purely additive (CREATE TABLE + INDEX only, no existing table
+// touched). Nothing in production reads or writes it (DARK).
+fn m0025_workflow_catalog(tx: &Transaction) -> rusqlite::Result<()> {
+    tx.execute_batch(DDL_WORKFLOW_CATALOG)
 }

--- a/rust-core/crates/friday-storage/src/workflow_catalog.rs
+++ b/rust-core/crates/friday-storage/src/workflow_catalog.rs
@@ -1,0 +1,400 @@
+//! Workflow CATALOG persistence (R3; Hub-only). DARK substrate.
+//!
+//! The S8 [`crate::workflow_def`] layer stores versioned, immutable DEFINITION
+//! bodies keyed by `(workflow_id, version)` plus the single-published flip. This
+//! module adds the per-WORKFLOW catalog ENTRY that the TS `workflows.*` mutation
+//! surface operates over (`workflows.create / update / archive / publish /
+//! deploy`): the catalog row carries the workflow's identity (slug/name), its
+//! soft-delete state (`is_archived`), an optimistic-concurrency `(revision,
+//! etag)` pair, and the R3 DEPLOY pointer (`deployed_version`). It is the
+//! storage half of R3; the catalog-CRUD + deploy DOMAIN orchestration (delegate
+//! publish to S8, fail-closed-on-archived, version-existence validation) lives
+//! ABOVE this layer in `friday-hub::workflow_catalog`, exactly as the linear-only
+//! semantic gate lives above `workflow_def`'s row CHECKs.
+//!
+//! Invariants this module owns:
+//!
+//! * **Single source of published truth stays in S8.** The catalog deliberately
+//!   does NOT persist "which version is published" — that is `workflow_definition
+//!   .is_published`, protected by the S8 partial-unique index + atomic
+//!   `set_published`. Duplicating it here would create a dual-write atomicity
+//!   hazard and a second place the at-most-one invariant could drift. The catalog
+//!   row's only version pointer is [`WorkflowCatalogRow::deployed_version`] (the
+//!   R3 deploy pointer), set by the hub deploy op AFTER it confirms a published
+//!   version exists.
+//! * **Optimistic concurrency.** Every mutation carries an `expected_revision`;
+//!   a stale value fails CLOSED ([`StorageError::Unsupported`] "revision
+//!   conflict") rather than clobbering a concurrent edit. The check-then-write
+//!   runs in one IMMEDIATE transaction so a concurrent writer cannot slip between
+//!   the read and the UPDATE (the TOCTOU is closed), and a successful mutation
+//!   BUMPS `revision` and re-derives `etag`.
+//! * **`etag` is derived, never caller-supplied.** It is the sha256 of the
+//!   identity-bearing fields + revision, computed at the single write chokepoint
+//!   (like `workflow_def.checksum`), so a divergent `(state, etag)` pair is
+//!   unrepresentable through the typed API.
+//! * **Slug uniqueness** is DB-enforced (UNIQUE index): two catalog entries can
+//!   never share a slug (a duplicate insert fails closed).
+//! * **No FK to `workflow_definition`.** The catalog row is additive and
+//!   independent — a catalog entry can exist before any version is created
+//!   (mirroring `workflows.create` which mints the entry), and the existing S8
+//!   definition tests create definitions with no catalog row. Cross-table
+//!   consistency (publish/deploy require a version) is enforced by the HUB layer
+//!   querying both, not by a schema FK that would couple the layers.
+//!
+//! Truth label: DARK substrate — no production route or scheduler consumes this;
+//! the live TS `workflows.*` routes are NOT flipped; workflow execution remains
+//! fenced in TS and is NOT product-replaced; NOT v1 GO.
+
+use crate::error::{Result, StorageError};
+use rusqlite::{params, Connection, OptionalExtension, Transaction, TransactionBehavior};
+use sha2::{Digest, Sha256};
+
+/// Open an IMMEDIATE write transaction on a shared `&Connection`. IMMEDIATE
+/// acquires the write lock at BEGIN, so the read-then-write (optimistic
+/// concurrency) sequences below cannot interleave with another writer between
+/// their statements (mirrors `workflow_def::write_tx` / `schedule::write_tx`).
+fn write_tx(conn: &Connection) -> Result<Transaction<'_>> {
+    Ok(Transaction::new_unchecked(
+        conn,
+        TransactionBehavior::Immediate,
+    )?)
+}
+
+/// A stored catalog entry. The catalog carries IDENTITY + soft-state +
+/// concurrency token + the deploy pointer — never the definition body (that is
+/// in `workflow_definition`) and never "which version is published" (that is the
+/// S8 `is_published` flag, the single source of truth).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WorkflowCatalogRow {
+    pub workflow_id: String,
+    pub slug: String,
+    pub name: String,
+    pub description: Option<String>,
+    /// Opaque JSON array of tag strings (the hub layer owns the shape). Never a
+    /// secret/body — coarse labels only. Defaults to `"[]"`.
+    pub tags_json: String,
+    pub is_archived: bool,
+    /// Optimistic-concurrency counter. Starts at 1 on create; every successful
+    /// mutation bumps it by 1.
+    pub revision: i64,
+    /// Derived (sha256 of identity fields + revision) at the write chokepoint —
+    /// never caller-supplied.
+    pub etag: String,
+    /// R3 DEPLOY pointer: the version number that was deployed (made the
+    /// deployable target for a future R2/S10 runtime). `None` until the workflow
+    /// is deployed. The deploy op sets this only after confirming the version is
+    /// the S8-published one.
+    pub deployed_version: Option<i64>,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+/// Input to [`create_entry`]. `revision` / `etag` / `deployed_version` /
+/// `is_archived` are intentionally absent — a created entry is born at
+/// `revision = 1`, `is_archived = 0`, `deployed_version = NULL`, with a derived
+/// `etag`, so an inconsistent birth state is unrepresentable through the API.
+#[derive(Clone, Copy, Debug)]
+pub struct NewWorkflowCatalogEntry<'a> {
+    pub workflow_id: &'a str,
+    pub slug: &'a str,
+    pub name: &'a str,
+    pub description: Option<&'a str>,
+    /// Opaque JSON tag array; pass `None` for the default empty array `"[]"`.
+    pub tags_json: Option<&'a str>,
+}
+
+/// Mutable identity/metadata fields settable by [`update_entry`]. A `None` field
+/// LEAVES the stored value unchanged (a partial PATCH, matching the TS
+/// `workflows.update` optional-field shape). `slug` is intentionally NOT
+/// mutable here — re-slugging a catalog entry is out of R3 scope and would
+/// reopen the uniqueness window.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct WorkflowCatalogUpdate<'a> {
+    pub name: Option<&'a str>,
+    /// `Some(Some(d))` sets the description; `Some(None)` clears it to NULL;
+    /// `None` leaves it unchanged.
+    pub description: Option<Option<&'a str>>,
+    pub tags_json: Option<&'a str>,
+}
+
+fn sha256_hex(s: &str) -> String {
+    let mut h = Sha256::new();
+    h.update(s.as_bytes());
+    let out = h.finalize();
+    let mut hex = String::with_capacity(64);
+    for b in out {
+        use std::fmt::Write as _;
+        let _ = write!(hex, "{b:02x}");
+    }
+    hex
+}
+
+/// The identity-bearing fields the etag is derived over (the full mutable
+/// state + revision). Borrowed so both a [`WorkflowCatalogRow`] and the
+/// birth-state in [`create_entry`] can derive without cloning.
+struct EtagInput<'a> {
+    workflow_id: &'a str,
+    slug: &'a str,
+    name: &'a str,
+    description: Option<&'a str>,
+    tags_json: &'a str,
+    is_archived: bool,
+    deployed_version: Option<i64>,
+    revision: i64,
+}
+
+/// Derive the etag from the identity-bearing fields + revision. Field-separated
+/// by a control char that cannot appear in the inputs we accept, so distinct
+/// field tuples cannot collide by concatenation.
+fn derive_etag(i: &EtagInput<'_>) -> String {
+    let mut material = String::new();
+    use std::fmt::Write as _;
+    let _ = write!(
+        material,
+        "{}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}",
+        i.workflow_id,
+        i.slug,
+        i.name,
+        i.description.unwrap_or("\u{0}"),
+        i.tags_json,
+        i.is_archived as i64,
+        i.deployed_version
+            .map(|v| v.to_string())
+            .unwrap_or_default(),
+        i.revision,
+    );
+    sha256_hex(&material)
+}
+
+/// CREATE a new catalog entry, born at `revision = 1`, `is_archived = 0`,
+/// `deployed_version = NULL`, with a derived `etag`. Returns the derived etag.
+/// A duplicate `workflow_id` (PK) or `slug` (UNIQUE) fails closed.
+pub fn create_entry(
+    conn: &Connection,
+    entry: &NewWorkflowCatalogEntry<'_>,
+    now: i64,
+) -> Result<String> {
+    let tags_json = entry.tags_json.unwrap_or("[]");
+    let etag = derive_etag(&EtagInput {
+        workflow_id: entry.workflow_id,
+        slug: entry.slug,
+        name: entry.name,
+        description: entry.description,
+        tags_json,
+        is_archived: false,
+        deployed_version: None,
+        revision: 1,
+    });
+    conn.execute(
+        "INSERT INTO workflow_catalog
+            (workflow_id, slug, name, description, tags_json, is_archived,
+             revision, etag, deployed_version, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, 0, 1, ?6, NULL, ?7, ?7)",
+        params![
+            entry.workflow_id,
+            entry.slug,
+            entry.name,
+            entry.description,
+            tags_json,
+            etag,
+            now
+        ],
+    )?;
+    Ok(etag)
+}
+
+fn row_from_sql(r: &rusqlite::Row<'_>) -> rusqlite::Result<WorkflowCatalogRow> {
+    Ok(WorkflowCatalogRow {
+        workflow_id: r.get(0)?,
+        slug: r.get(1)?,
+        name: r.get(2)?,
+        description: r.get(3)?,
+        tags_json: r.get(4)?,
+        is_archived: r.get::<_, i64>(5)? != 0,
+        revision: r.get(6)?,
+        etag: r.get(7)?,
+        deployed_version: r.get(8)?,
+        created_at: r.get(9)?,
+        updated_at: r.get(10)?,
+    })
+}
+
+const SELECT_COLUMNS: &str = "workflow_id, slug, name, description, tags_json, is_archived,
+     revision, etag, deployed_version, created_at, updated_at";
+
+/// READ one catalog entry by id. `None` if unknown (not an error).
+pub fn get_entry(conn: &Connection, workflow_id: &str) -> Result<Option<WorkflowCatalogRow>> {
+    Ok(conn
+        .query_row(
+            &format!("SELECT {SELECT_COLUMNS} FROM workflow_catalog WHERE workflow_id = ?1"),
+            params![workflow_id],
+            row_from_sql,
+        )
+        .optional()?)
+}
+
+/// LIST all catalog entries, newest-created first. The catalog carries no body,
+/// so the listing is refs-only by construction (identity + state only).
+pub fn list_entries(conn: &Connection) -> Result<Vec<WorkflowCatalogRow>> {
+    let mut stmt = conn.prepare(&format!(
+        "SELECT {SELECT_COLUMNS} FROM workflow_catalog ORDER BY created_at DESC, workflow_id ASC"
+    ))?;
+    let rows = stmt.query_map([], row_from_sql)?;
+    Ok(rows.collect::<rusqlite::Result<_>>()?)
+}
+
+/// Shared optimistic-concurrency read: load the current row inside the
+/// transaction, fail CLOSED on a missing entry (`NotFound`) or a stale
+/// `expected_revision` (`Unsupported` "revision conflict"). Returns the live row
+/// so the caller can compute the next state.
+fn load_for_mutation(
+    tx: &Transaction<'_>,
+    workflow_id: &str,
+    expected_revision: i64,
+) -> Result<WorkflowCatalogRow> {
+    let row = tx
+        .query_row(
+            &format!("SELECT {SELECT_COLUMNS} FROM workflow_catalog WHERE workflow_id = ?1"),
+            params![workflow_id],
+            row_from_sql,
+        )
+        .optional()?
+        .ok_or_else(|| StorageError::NotFound(format!("workflow_catalog '{workflow_id}'")))?;
+    if row.revision != expected_revision {
+        return Err(StorageError::Unsupported(format!(
+            "workflow_catalog '{workflow_id}' revision conflict (expected {expected_revision}, \
+             stored {}); refusing to overwrite a concurrent edit",
+            row.revision
+        )));
+    }
+    Ok(row)
+}
+
+/// Persist the next state of a row (revision-bumped, etag re-derived) inside an
+/// open transaction. Shared by every mutating op so the bump + derive are a
+/// single chokepoint.
+fn write_next_state(tx: &Transaction<'_>, next: &WorkflowCatalogRow, now: i64) -> Result<()> {
+    tx.execute(
+        "UPDATE workflow_catalog
+         SET name = ?2, description = ?3, tags_json = ?4, is_archived = ?5,
+             revision = ?6, etag = ?7, deployed_version = ?8, updated_at = ?9
+         WHERE workflow_id = ?1",
+        params![
+            next.workflow_id,
+            next.name,
+            next.description,
+            next.tags_json,
+            next.is_archived as i64,
+            next.revision,
+            next.etag,
+            next.deployed_version,
+            now
+        ],
+    )?;
+    Ok(())
+}
+
+/// Recompute `etag` for a (mutated) row at its NEW revision and stamp it.
+fn stamp(row: &mut WorkflowCatalogRow, next_revision: i64) {
+    row.revision = next_revision;
+    row.etag = derive_etag(&EtagInput {
+        workflow_id: &row.workflow_id,
+        slug: &row.slug,
+        name: &row.name,
+        description: row.description.as_deref(),
+        tags_json: &row.tags_json,
+        is_archived: row.is_archived,
+        deployed_version: row.deployed_version,
+        revision: next_revision,
+    });
+}
+
+/// UPDATE catalog metadata (name / description / tags) under optimistic
+/// concurrency. Fail-closed on missing entry, stale revision, or an ARCHIVED
+/// entry (an archived workflow is read-only; un-archive is out of R3 scope).
+/// Returns the new `(revision, etag)`.
+pub fn update_entry(
+    conn: &Connection,
+    workflow_id: &str,
+    expected_revision: i64,
+    patch: &WorkflowCatalogUpdate<'_>,
+    now: i64,
+) -> Result<(i64, String)> {
+    let tx = write_tx(conn)?;
+    let mut row = load_for_mutation(&tx, workflow_id, expected_revision)?;
+    if row.is_archived {
+        return Err(StorageError::Unsupported(format!(
+            "workflow_catalog '{workflow_id}' is archived; refusing to update an archived entry"
+        )));
+    }
+    if let Some(name) = patch.name {
+        row.name = name.to_string();
+    }
+    if let Some(desc) = patch.description {
+        row.description = desc.map(|d| d.to_string());
+    }
+    if let Some(tags) = patch.tags_json {
+        row.tags_json = tags.to_string();
+    }
+    let next_revision = row.revision + 1;
+    stamp(&mut row, next_revision);
+    write_next_state(&tx, &row, now)?;
+    tx.commit()?;
+    Ok((next_revision, row.etag))
+}
+
+/// ARCHIVE (soft-delete): flip `is_archived = 1` under optimistic concurrency.
+/// Idempotent on the END STATE is NOT assumed — archiving an already-archived
+/// entry fails closed (the caller should not re-issue). Fail-closed on missing
+/// entry or stale revision. Returns the new `(revision, etag)`.
+pub fn archive_entry(
+    conn: &Connection,
+    workflow_id: &str,
+    expected_revision: i64,
+    now: i64,
+) -> Result<(i64, String)> {
+    let tx = write_tx(conn)?;
+    let mut row = load_for_mutation(&tx, workflow_id, expected_revision)?;
+    if row.is_archived {
+        return Err(StorageError::Unsupported(format!(
+            "workflow_catalog '{workflow_id}' is already archived"
+        )));
+    }
+    row.is_archived = true;
+    let next_revision = row.revision + 1;
+    stamp(&mut row, next_revision);
+    write_next_state(&tx, &row, now)?;
+    tx.commit()?;
+    Ok((next_revision, row.etag))
+}
+
+/// Set the R3 DEPLOY pointer to `version` under optimistic concurrency.
+///
+/// Storage-level primitive: it records WHICH version is the deployed target on
+/// the catalog row; the HUB deploy op is responsible for first confirming
+/// (against [`crate::workflow_def`]) that `version` is the workflow's PUBLISHED
+/// version — storage cannot cross-check S8 publish state without coupling the
+/// layers (mirrors how `schedule::insert_schedule` trusts a hub-validated cron).
+/// Fail-closed on missing entry, stale revision, or an ARCHIVED entry (an
+/// archived workflow can never be deployed). Returns the new `(revision, etag)`.
+pub fn set_deployed_version(
+    conn: &Connection,
+    workflow_id: &str,
+    expected_revision: i64,
+    version: i64,
+    now: i64,
+) -> Result<(i64, String)> {
+    let tx = write_tx(conn)?;
+    let mut row = load_for_mutation(&tx, workflow_id, expected_revision)?;
+    if row.is_archived {
+        return Err(StorageError::Unsupported(format!(
+            "workflow_catalog '{workflow_id}' is archived; refusing to deploy an archived entry"
+        )));
+    }
+    row.deployed_version = Some(version);
+    let next_revision = row.revision + 1;
+    stamp(&mut row, next_revision);
+    write_next_state(&tx, &row, now)?;
+    tx.commit()?;
+    Ok((next_revision, row.etag))
+}

--- a/rust-core/crates/friday-storage/tests/workflow_catalog_persist.rs
+++ b/rust-core/crates/friday-storage/tests/workflow_catalog_persist.rs
@@ -1,0 +1,268 @@
+//! R3 workflow-catalog persistence tests (DARK substrate): created birth state,
+//! derived + bound etag, slug uniqueness, optimistic-concurrency conflict,
+//! fail-closed mutations on missing/archived entries, the deploy pointer, and the
+//! additive v24→v25 forward migration. Mirrors the S8 `workflow_def_persist`
+//! style.
+
+mod common;
+
+use common::temp_db_path;
+use friday_storage::workflow_catalog::{
+    archive_entry, create_entry, get_entry, list_entries, set_deployed_version, update_entry,
+    NewWorkflowCatalogEntry, WorkflowCatalogUpdate,
+};
+use friday_storage::{hub_migrations, Db, Profile, StorageError};
+
+fn hub_max_version() -> i64 {
+    hub_migrations().iter().map(|m| m.version).max().unwrap()
+}
+
+fn entry<'a>(workflow_id: &'a str, slug: &'a str) -> NewWorkflowCatalogEntry<'a> {
+    NewWorkflowCatalogEntry {
+        workflow_id,
+        slug,
+        name: "Workflow",
+        description: None,
+        tags_json: None,
+    }
+}
+
+#[test]
+fn create_births_revision_1_unarchived_with_derived_etag() {
+    let db = Db::open_hub(&temp_db_path("wfcat-create")).unwrap();
+    let etag = create_entry(db.conn(), &entry("wf1", "slug-1"), 100).unwrap();
+    assert_eq!(etag.len(), 64, "sha256 lowercase hex etag");
+
+    let row = get_entry(db.conn(), "wf1").unwrap().unwrap();
+    assert_eq!(row.workflow_id, "wf1");
+    assert_eq!(row.slug, "slug-1");
+    assert_eq!(row.name, "Workflow");
+    assert_eq!(row.tags_json, "[]", "tags default to empty array");
+    assert!(!row.is_archived, "born unarchived");
+    assert_eq!(row.revision, 1, "born at revision 1");
+    assert_eq!(row.etag, etag);
+    assert_eq!(row.deployed_version, None, "born with no deploy pointer");
+    assert_eq!(row.created_at, 100);
+    assert_eq!(row.updated_at, 100);
+
+    // missing entry reads back as None (not an error).
+    assert!(get_entry(db.conn(), "ghost").unwrap().is_none());
+}
+
+#[test]
+fn slug_uniqueness_is_db_enforced() {
+    let db = Db::open_hub(&temp_db_path("wfcat-slug")).unwrap();
+    create_entry(db.conn(), &entry("wf1", "shared"), 100).unwrap();
+    // a second entry with the SAME slug fails closed (unique index).
+    let err = create_entry(db.conn(), &entry("wf2", "shared"), 200).unwrap_err();
+    assert!(
+        err.to_string().to_lowercase().contains("unique"),
+        "duplicate slug must violate the unique index: {err}"
+    );
+    // a different slug inserts fine.
+    create_entry(db.conn(), &entry("wf2", "other"), 200).unwrap();
+    // a duplicate workflow_id (PK) also fails closed.
+    assert!(create_entry(db.conn(), &entry("wf1", "fresh"), 300).is_err());
+}
+
+#[test]
+fn update_bumps_revision_rederives_etag_and_partial_patches() {
+    let db = Db::open_hub(&temp_db_path("wfcat-update")).unwrap();
+    let e0 = create_entry(db.conn(), &entry("wf1", "slug-1"), 100).unwrap();
+
+    // PATCH name only (description/tags untouched).
+    let (rev, etag) = update_entry(
+        db.conn(),
+        "wf1",
+        1,
+        &WorkflowCatalogUpdate {
+            name: Some("Renamed"),
+            description: None,
+            tags_json: None,
+        },
+        200,
+    )
+    .unwrap();
+    assert_eq!(rev, 2, "revision bumps on update");
+    assert_ne!(etag, e0, "etag re-derived");
+    let row = get_entry(db.conn(), "wf1").unwrap().unwrap();
+    assert_eq!(row.name, "Renamed");
+    assert_eq!(row.description, None);
+    assert_eq!(row.etag, etag);
+    assert_eq!(row.updated_at, 200);
+
+    // set description, then clear it (Some(None) clears to NULL).
+    update_entry(
+        db.conn(),
+        "wf1",
+        2,
+        &WorkflowCatalogUpdate {
+            name: None,
+            description: Some(Some("desc")),
+            tags_json: Some(r#"["x"]"#),
+        },
+        300,
+    )
+    .unwrap();
+    let row = get_entry(db.conn(), "wf1").unwrap().unwrap();
+    assert_eq!(row.description.as_deref(), Some("desc"));
+    assert_eq!(row.tags_json, r#"["x"]"#);
+
+    update_entry(
+        db.conn(),
+        "wf1",
+        3,
+        &WorkflowCatalogUpdate {
+            name: None,
+            description: Some(None),
+            tags_json: None,
+        },
+        400,
+    )
+    .unwrap();
+    assert_eq!(
+        get_entry(db.conn(), "wf1").unwrap().unwrap().description,
+        None
+    );
+}
+
+#[test]
+fn stale_revision_fails_closed_and_writes_nothing() {
+    let db = Db::open_hub(&temp_db_path("wfcat-stale")).unwrap();
+    create_entry(db.conn(), &entry("wf1", "slug-1"), 100).unwrap();
+    // expected revision 99 != stored 1 → conflict, no write.
+    let err = update_entry(
+        db.conn(),
+        "wf1",
+        99,
+        &WorkflowCatalogUpdate {
+            name: Some("Renamed"),
+            ..Default::default()
+        },
+        200,
+    )
+    .unwrap_err();
+    assert!(matches!(err, StorageError::Unsupported(_)));
+    assert!(err.to_string().contains("revision conflict"));
+    let row = get_entry(db.conn(), "wf1").unwrap().unwrap();
+    assert_eq!(row.name, "Workflow", "stale update wrote nothing");
+    assert_eq!(row.revision, 1);
+}
+
+#[test]
+fn mutations_on_missing_entries_are_notfound() {
+    let db = Db::open_hub(&temp_db_path("wfcat-missing")).unwrap();
+    assert!(matches!(
+        update_entry(db.conn(), "ghost", 1, &WorkflowCatalogUpdate::default(), 1),
+        Err(StorageError::NotFound(_))
+    ));
+    assert!(matches!(
+        archive_entry(db.conn(), "ghost", 1, 1),
+        Err(StorageError::NotFound(_))
+    ));
+    assert!(matches!(
+        set_deployed_version(db.conn(), "ghost", 1, 1, 1),
+        Err(StorageError::NotFound(_))
+    ));
+}
+
+#[test]
+fn archive_is_soft_state_and_makes_the_entry_read_only() {
+    let db = Db::open_hub(&temp_db_path("wfcat-archive")).unwrap();
+    create_entry(db.conn(), &entry("wf1", "slug-1"), 100).unwrap();
+    let (rev, _) = archive_entry(db.conn(), "wf1", 1, 200).unwrap();
+    assert_eq!(rev, 2);
+    let row = get_entry(db.conn(), "wf1").unwrap().unwrap();
+    assert!(row.is_archived, "soft-deleted, row still present");
+
+    // an archived entry refuses update / deploy / re-archive (fail-closed).
+    assert!(matches!(
+        update_entry(
+            db.conn(),
+            "wf1",
+            2,
+            &WorkflowCatalogUpdate {
+                name: Some("x"),
+                ..Default::default()
+            },
+            300
+        ),
+        Err(StorageError::Unsupported(_))
+    ));
+    assert!(matches!(
+        set_deployed_version(db.conn(), "wf1", 2, 1, 300),
+        Err(StorageError::Unsupported(_))
+    ));
+    assert!(matches!(
+        archive_entry(db.conn(), "wf1", 2, 300),
+        Err(StorageError::Unsupported(_))
+    ));
+}
+
+#[test]
+fn set_deployed_version_records_the_pointer_under_concurrency() {
+    let db = Db::open_hub(&temp_db_path("wfcat-deploy")).unwrap();
+    create_entry(db.conn(), &entry("wf1", "slug-1"), 100).unwrap();
+    let (rev, etag) = set_deployed_version(db.conn(), "wf1", 1, 3, 200).unwrap();
+    assert_eq!(rev, 2);
+    let row = get_entry(db.conn(), "wf1").unwrap().unwrap();
+    assert_eq!(row.deployed_version, Some(3));
+    assert_eq!(row.etag, etag);
+    // a non-positive version is unrepresentable (the row CHECK rejects < 1).
+    let err = set_deployed_version(db.conn(), "wf1", 2, 0, 300).unwrap_err();
+    assert!(matches!(err, StorageError::Sqlite(_)));
+}
+
+#[test]
+fn list_is_refs_only_and_newest_created_first() {
+    let db = Db::open_hub(&temp_db_path("wfcat-list")).unwrap();
+    create_entry(db.conn(), &entry("wf1", "slug-1"), 100).unwrap();
+    create_entry(db.conn(), &entry("wf2", "slug-2"), 200).unwrap();
+    create_entry(db.conn(), &entry("wf3", "slug-3"), 300).unwrap();
+    let all = list_entries(db.conn()).unwrap();
+    assert_eq!(all.len(), 3);
+    assert_eq!(
+        all.iter()
+            .map(|r| r.workflow_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["wf3", "wf2", "wf1"],
+        "newest-created first"
+    );
+}
+
+#[test]
+fn forward_migration_v24_to_v25_adds_workflow_catalog_table() {
+    let p = temp_db_path("wfcat-mig");
+    {
+        let mut migs = hub_migrations();
+        migs.retain(|m| m.version <= 24);
+        let db = Db::open(&p, Profile::Hub, &migs, "v24").unwrap();
+        assert_eq!(db.version().unwrap(), 24);
+        assert!(
+            !db.table_names()
+                .unwrap()
+                .iter()
+                .any(|t| t == "workflow_catalog"),
+            "pre-v25 DB must not have workflow_catalog"
+        );
+    }
+    // Re-open with the full set: the additive migration applies and the table works.
+    let db = Db::open_hub(&p).unwrap();
+    assert_eq!(db.version().unwrap(), hub_max_version());
+    create_entry(db.conn(), &entry("wf1", "slug-1"), 100).unwrap();
+    assert!(get_entry(db.conn(), "wf1").unwrap().is_some());
+    // The migrated DB carries the unique slug index.
+    let idx: i64 = db
+        .conn()
+        .query_row(
+            "SELECT count(*) FROM sqlite_master WHERE type = 'index'
+             AND name = 'idx_workflow_catalog_slug'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        idx, 1,
+        "v24→v25 migration must create the slug unique index"
+    );
+}


### PR DESCRIPTION
## R3 — Workflow catalog mutation + deploy (DARK build)

Roadmap ref: `TS_RECON_TRUTH_ROADMAP_20260610.md` §3 Tier-1 R3 (GATE-WF-REPLACE; prereq for R2). Builds the catalog-CRUD + deploy MECHANISM on the existing S8 `workflow_def` storage.

### Dark / no route flip
- No production route registered; the live TS `workflows.*` routes are NOT flipped; no default change. Verified: `workflow_catalog` does not appear in `hub_server.rs` / `routing.rs`. The hub/storage lib.rs diffs are `pub mod` declarations only.
- Workflow execution remains fenced in TS and is NOT product-replaced. **NOT v1 GO.**

### Operations built
`friday-hub::workflow_catalog` (domain) over `friday-storage::workflow_catalog` (storage):

| op | semantics |
|---|---|
| `create` | mints a catalog entry + its initial unpublished v1 definition body in one transaction (no half-created workflow); validates slug/name bounds + the S8 body |
| `update` | catalog metadata (name/description/tags) under optimistic concurrency (`expectedRevision` + derived `etag`); fail-closed on stale revision |
| `archive` | soft-delete (`is_archived`); row never hard-deleted, so a published/deployed pointer can never dangle |
| `publish` | delegates the at-most-one-published flip to the S8 `set_published` (catalog never records the published pointer) |
| `deploy` | sets the catalog deploy pointer to the S8-**published** version after re-parsing its body fail-closed — deployable state at the storage/domain level **only** (no run, no schedule, no runtime trigger) |

### S8 invariants respected (not weakened)
- **Single-published** stays the sole truth in `workflow_definition.is_published` (the catalog does **not** duplicate it — no dual-write hazard). `publish` delegates to S8; KAT proves publishing v2 unpublishes v1.
- **Definitions stay immutable** — a new graph is a new version (`add_version`), never an in-place edit.
- **Deploy re-parses** the published body through the S8 loader (linear-only, v1 schema), so a tampered *self-consistent foreign body* (recomputed sha256 over a `schema_version=2` doc) cannot reach a deployable state — covered by a negative KAT.
- **No FK** to `workflow_definition` (layers stay decoupled; the existing S8 definition tests create defs with no catalog row). Cross-table consistency is the hub layer's job.
- Fail-closed on all invalid input; no `unwrap`/`expect` on input; no panics.

### Migration
- Additive **`m0025_workflow_catalog` (version 25)** — next free after the S10-A `m0024` (registry checked; **no collision**). `CREATE TABLE` + 2 `INDEX` only; touches no existing table.
- `workflow_catalog` added to `HUB_ONLY_TABLES` (Hub-only; holds no secret/key material). Covered by the forward-migration v24→v25 KAT + the `schema_profile` hub/phone-split test.

### Verify (from `rust-core/`)
- `cargo build` (workspace) — green
- `cargo test -p friday-storage -p friday-hub` — all green, no existing test broke (9 hub-domain KATs + 9 storage persist KATs added)
- `cargo clippy --workspace --all-targets` — 0 warnings
- `cargo fmt --all -- --check` — clean

### Proven vs deferred
- **PROVEN:** create→update→publish→archive lifecycle; single-published invariant; deploy of a published def; deploy-without-published / publish-missing / stale-revision / archived-entry / invalid-input / foreign-body all fail closed; atomic create; forward migration.
- **DEFERRED (gated, NOT in this slice):** route cutover / live TS `workflows.*` flip, and the runtime trigger (start-a-run on deploy / scheduler binding) = **R2/S10, operator-gated.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)