### PR TITLE
docs(mission-spine): correct stale DARK truth-labels on live-consumed sealed-WS chain (no-false-info)

### DIFF
--- a/src/api/mission-spine/friday-rust-hub-agent-run-sealed-client-service.ts
+++ b/src/api/mission-spine/friday-rust-hub-agent-run-sealed-client-service.ts
@@ -7,10 +7,16 @@ import {
 } from "./friday-rust-hub-agent-run-ws-sealed-client.js";
 
 /**
- * PROOF-ONLY (Rust-wired), DARK (no production route consumes this) SERVICE ADAPTER that lets
- * the composition (`composeRustReadOnlyAgentRun`) drive the PROVEN sealed WS client
+ * WIRED into the production read-only Rust agent-run route, gated DEFAULT-OFF — SERVICE
+ * ADAPTER that lets the composition (`composeRustReadOnlyAgentRun` in friday-api-runtime.ts,
+ * reached from the live `routeStartRun`) drive the PROVEN sealed WS client
  * (`friday-rust-hub-agent-run-ws-sealed-client.ts`) through the SAME `dispatchRun(...)` seam the
  * old plain-WS client exposed — but over the REAL sealed ECDH protocol (sub-slice B1-compose).
+ * As of B1-compose this adapter IS imported + constructed by friday-api-runtime.ts and its
+ * `dispatchRun(...)` runs on the live route path, so the prior "no production route consumes
+ * this" claim is no longer true. It does NOT run in default prod: the route branch is gated
+ * DEFAULT-OFF behind `FRIDAY_ROUTE_AGENT_RUN_VIA_RUST` (operator cutover pending) and only fires
+ * for a qualifying read-only run.
  *
  * ## Why an adapter (and not a direct swap)
  * The old `FridayRustHubAgentRunWsClientService.dispatchRun` took a pre-built SYMMETRIC
@@ -40,8 +46,13 @@ import {
  * underlying dispatch surfaces unchanged (503), and a result is mapped to refs-only.
  *
  * ## Truth labels
- * - DARK substrate for the executeRun-replacement: no production route consumes it (until 6b).
- * - `rust_wired` ceiling: confers NO v1 GO. Reversible / inert until the operator cutover.
+ * - WIRED into the production route handler but gated DEFAULT-OFF: friday-api-runtime.ts imports
+ *   + constructs this adapter and `composeRustReadOnlyAgentRun` calls `dispatchRun(...)` on the
+ *   live `routeStartRun` path, so it IS consumed by a production route (NOT "no production route
+ *   consumes it"). It stays inert in default prod until the operator flips
+ *   `FRIDAY_ROUTE_AGENT_RUN_VIA_RUST` (6b cutover pending) and a run qualifies.
+ * - `rust_wired` ceiling: confers NO v1 GO. Narrow (read-only / refs-only); not a full
+ *   executeRun replacement.
  */
 
 /** A sealed agent-run dispatch, TS-side. Carries the client's X25519 SECRET (NOT a pre-built proof). */

--- a/src/api/mission-spine/friday-rust-hub-agent-run-ws-client.ts
+++ b/src/api/mission-spine/friday-rust-hub-agent-run-ws-client.ts
@@ -20,9 +20,12 @@ import { FridayDomainError } from "#errors";
  * process.
  *
  * ## Truth labels (read before trusting this)
- * - **DARK substrate** for the executeRun-replacement: NO production route registers
- *   or consumes this. It is imported by no barrel/index/bootstrap. The composition
- *   slice (S-F) wires it; until then it is reversible and inert.
+ * - **DARK — and SUPERSEDED.** This S-D plain/unsealed stub is consumed by NO production
+ *   route and by no barrel/index/bootstrap; its ONLY importer is its own unit test. B1-compose
+ *   did NOT wire this stub — it wired the REAL sealed client
+ *   (`friday-rust-hub-agent-run-ws-sealed-client.ts`, via the sealed-client service adapter)
+ *   into `composeRustReadOnlyAgentRun` instead, bypassing this file. So this stub stays dark /
+ *   reversible / inert; it was kept as the S-A wire-contract reference, not on any live path.
  * - **`rust_wired` ceiling**: this speaks the S-A wire contract to a (later) Rust
  *   server; it is NOT a product path and confers NO v1 GO. In tests it is driven by a
  *   hermetic in-process loopback stub server — never a real Rust bin, never a

--- a/src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.ts
+++ b/src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.ts
@@ -19,9 +19,13 @@ import {
 } from "./friday-rust-hub-agent-run-ws-sealed-crypto.js";
 
 /**
- * PROOF-ONLY (Rust-wired), DARK (no production route consumes this) TS->Rust AGENT-RUN
- * SEALED WS CLIENT for the executeRun-replacement (sub-slice B1) — the REAL sealed-protocol
- * client half.
+ * WIRED into the production read-only Rust agent-run route, gated DEFAULT-OFF — TS->Rust
+ * AGENT-RUN SEALED WS CLIENT for the executeRun-replacement (sub-slice B1) — the REAL
+ * sealed-protocol client half. As of B1-compose this client is constructed by the sealed-client
+ * service adapter that `composeRustReadOnlyAgentRun` drives on the live `routeStartRun` path —
+ * so the prior "no production route consumes this" claim is no longer true. It does NOT run in
+ * default prod: the route branch is gated DEFAULT-OFF behind `FRIDAY_ROUTE_AGENT_RUN_VIA_RUST`
+ * (operator cutover pending) and only fires for a qualifying read-only run.
  *
  * ## What this is (and how it differs from the S-D stub)
  * The S-D client (`friday-rust-hub-agent-run-ws-client.ts`) is a DARK STUB: it opens a plain
@@ -58,9 +62,13 @@ import {
  * error — never a hang, never a partial success, never a surfaced body on an error.
  *
  * ## Truth labels
- * - DARK substrate for the executeRun-replacement: no production route consumes it.
- * - `rust_wired` ceiling: confers NO v1 GO. Reversible / inert until the composition slice
- *   live-flips it (operator gate).
+ * - Consumed by the production route handler, gated DEFAULT-OFF: the sealed-client service
+ *   adapter constructs this client and `composeRustReadOnlyAgentRun` drives its `dispatchRun`
+ *   on the live `routeStartRun` path, so it IS reached by a production route (NOT "no production
+ *   route consumes it"). It stays inert in default prod until the operator flips
+ *   `FRIDAY_ROUTE_AGENT_RUN_VIA_RUST` (cutover pending).
+ * - `rust_wired` ceiling: confers NO v1 GO. Narrow (read-only); not a full executeRun
+ *   replacement until the operator cutover.
  */
 
 /**

--- a/src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-crypto.ts
+++ b/src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-crypto.ts
@@ -1,6 +1,11 @@
 /**
- * PROOF-ONLY (Rust-wired), DARK (no production route consumes this) CLIENT-HALF of
- * the friday-crypto sealed WS handshake for the executeRun-replacement (sub-slice B1).
+ * TRANSITIVELY WIRED into the production read-only Rust agent-run route, gated DEFAULT-OFF —
+ * CLIENT-HALF of the friday-crypto sealed WS handshake for the executeRun-replacement
+ * (sub-slice B1). As of B1-compose its primitives (`agree`/`seal`/`open`/`encodeSealed`/
+ * `buildAuthProof`/...) are imported by `friday-rust-hub-agent-run-ws-sealed-client.ts`, which
+ * the live route's `composeRustReadOnlyAgentRun` drives — so the prior "no production route
+ * consumes this" claim is no longer true. It does NOT run in default prod: the route branch is
+ * gated DEFAULT-OFF behind `FRIDAY_ROUTE_AGENT_RUN_VIA_RUST` (operator cutover pending).
  *
  * ## What this is
  * The byte-exact TS port of the friday-crypto / friday-transport client primitives the
@@ -33,9 +38,13 @@
  * defend confidentiality against a non-existent relay.
  *
  * ## Truth labels
- * - DARK substrate for the executeRun-replacement: no production route consumes it.
- * - `rust_wired` ceiling: confers NO v1 GO. It speaks the real sealed protocol; it is not
- *   a product path until the composition slice live-flips it (operator gate).
+ * - TRANSITIVELY consumed by the production route handler, gated DEFAULT-OFF: its primitives
+ *   are imported by the sealed WS client that `composeRustReadOnlyAgentRun` drives on the live
+ *   `routeStartRun` path, so it IS reached by a production route (NOT "no production route
+ *   consumes it"). It stays inert in default prod until the operator flips
+ *   `FRIDAY_ROUTE_AGENT_RUN_VIA_RUST` (cutover pending).
+ * - `rust_wired` ceiling: confers NO v1 GO. It speaks the real sealed protocol; it is not a
+ *   full product path until the operator cutover.
  */
 import { createHash, createPrivateKey, createPublicKey, diffieHellman, hkdfSync, randomBytes } from "node:crypto";
 

--- a/src/api/mission-spine/friday-rust-hub-run-answer-readback-service.ts
+++ b/src/api/mission-spine/friday-rust-hub-run-answer-readback-service.ts
@@ -7,8 +7,15 @@ import { promisify } from "node:util";
 import { FridayDomainError } from "#errors";
 
 /**
- * PROOF-ONLY (Rust-wired-DEV), DARK (no production route consumes this) TS->Rust
- * OWNER-GATED ANSWER-BODY readback bridge for the S3 `hub_run_answer_readback` bin.
+ * WIRED into the production read-only Rust agent-run route, gated DEFAULT-OFF — TS->Rust
+ * OWNER-GATED ANSWER-BODY readback bridge for the S3 `hub_run_answer_readback` bin. As of
+ * B1-compose this bridge IS imported + constructed by friday-api-runtime.ts and its
+ * `readAnswer(...)` is the authoritative body source inside `composeRustReadOnlyAgentRun`
+ * (and on the idempotency-replay branch) on the live `routeStartRun` path — so the prior
+ * "no production route consumes this / registers NO production route / imported by no
+ * barrel/index" claim is no longer true. It does NOT run in default prod: the route branch is
+ * gated DEFAULT-OFF behind `FRIDAY_ROUTE_AGENT_RUN_VIA_RUST` (operator cutover pending) and
+ * only fires for a qualifying read-only run. `rust_wired_dev` ceiling — confers no v1 GO.
  *
  * This is the OWNER-GATED BODY sibling of the REFS-ONLY
  * `friday-rust-hub-run-readback-service`, and it is deliberately a SEPARATE path: the
@@ -30,10 +37,11 @@ import { FridayDomainError } from "#errors";
  *
  * TRUSTED-PRINCIPAL CONTRACT (not authentication): `callerPrincipal` is passed through
  * as a TRUSTED argument. The Rust primitive enforces the ownership MATCH only; it does
- * NOT authenticate the caller. The transport that authenticates a caller and supplies a
- * trusted principal is a later composition slice (a long-lived `hub_server` WS
- * transport) — out of scope here. This bridge registers NO production route, replaces no
- * TS read path, is imported by no barrel/index, and confers no v1 GO.
+ * NOT authenticate the caller. The trusted principal is now supplied by the live route's
+ * compose step (`composeRustReadOnlyAgentRun` passes the normalized owner principalId as
+ * `callerPrincipal`); this bridge still performs NO authentication of its own. It does not
+ * (yet) replace any TS read path and confers no v1 GO; the route that drives it is gated
+ * DEFAULT-OFF (operator cutover pending).
  *
  * The bridge fails CLOSED (503) on any non-zero exit, timeout, parse failure, invalid
  * shape, or any `delivered` outcome that arrives WITHOUT the body refs it claims. The

--- a/src/api/mission-spine/friday-rust-hub-run-continuity-projector-service.ts
+++ b/src/api/mission-spine/friday-rust-hub-run-continuity-projector-service.ts
@@ -3,9 +3,13 @@ import type Database from "better-sqlite3";
 import { FridayDomainError } from "#errors";
 
 /**
- * PROOF-ONLY (Rust-wired-DEV), DARK (no production route consumes this) Rust→TS
- * CONTINUITY PROJECTOR for the future `executeRun`-replacement (executeRun-replace
- * slice 2, fork ii).
+ * WIRED into the production read-only Rust agent-run route (`routeStartRun` →
+ * `composeRustReadOnlyAgentRun` in friday-api-runtime.ts) as of B1-compose — this is the
+ * `projector` passed to compose and its `project(...)` runs on the live route path. NOT yet
+ * live in default prod: that route is GATED DEFAULT-OFF (`FRIDAY_ROUTE_AGENT_RUN_VIA_RUST`,
+ * operator cutover pending). Rust→TS CONTINUITY PROJECTOR for the `executeRun`-replacement
+ * (executeRun-replace slice 2, fork ii). `rust_wired_dev` ceiling — narrow (read-only /
+ * refs-only, no fabricated token totals); NOT a full executeRun replacement; confers no v1 GO.
  *
  * ## Why this exists
  * The executeRun-replacement routes production agent-runs through the Rust Hub loop.
@@ -21,10 +25,15 @@ import { FridayDomainError } from "#errors";
  * that projector.
  *
  * ## Truth labels (read before trusting this)
- * - **DARK substrate** for the executeRun-replacement: NO production route registers or
- *   consumes this; it is driven by a STATIC FIXTURE receipt in tests. Reversible —
- *   unreferenced by any barrel/route until the composition slice wires it.
- * - **`rust_wired` ceiling**: this projects a Rust-produced receipt; it is NOT a product
+ * - **WIRED into the production route handler, gated DEFAULT-OFF.** As of B1-compose this
+ *   projector IS imported + constructed by friday-api-runtime.ts and its `project(...)` runs
+ *   inside `composeRustReadOnlyAgentRun` on the live `routeStartRun` path — so the prior
+ *   "no production route consumes this / unreferenced by any barrel/route" claim is no longer
+ *   true. It does NOT execute in default prod: the route branch is gated DEFAULT-OFF behind
+ *   `FRIDAY_ROUTE_AGENT_RUN_VIA_RUST` (operator cutover pending), and even when on it only
+ *   fires for a qualifying read-only Rust run. In tests it is also driven by a STATIC FIXTURE
+ *   receipt.
+ * - **`rust_wired` ceiling**: this projects a Rust-produced receipt; it is NOT a full product
  *   path and confers no v1 GO.
  * - **Usage token source wiring is DEFERRED to the composition slice.** This dark slice
  *   models the receipt as ALREADY carrying the token totals as a fixture field


### PR DESCRIPTION
## Why

Six files in `src/api/mission-spine/` carried the header label `PROOF-ONLY (...), DARK (no production route consumes this)`. Since **B1-compose**, the production read-only Rust agent-run route — `routeStartRun` → `composeRustReadOnlyAgentRun` in `src/api/runtime/friday-api-runtime.ts` — imports, constructs, and invokes **five** of them. So "no production route consumes this" is now **FALSE** for those five (a no-false-info correctness defect).

**Comment/doc-string changes ONLY — ZERO behavior change.** No executable line touched. `tsc --noEmit` clean; `eslint` 0 errors (1 pre-existing, untouched `existsSync` warning on line 261 of the readback service).

Each new label states **BOTH halves** of the truth to avoid a symmetric overclaim: the file **is** wired into the production route handler (corrects the stale claim), **and** that route branch is gated **DEFAULT-OFF** behind `FRIDAY_ROUTE_AGENT_RUN_VIA_RUST` (operator 6b cutover pending), narrow (read-only / owner-gated readback / refs-only), confers no v1 GO.

## Consumption evidence (the live chain)

`friday-api-runtime.ts`:
- L142/144/146: imports `createFridayRustHubAgentRunSealedClientService`, `createFridayRustHubRunContinuityProjectorService`, `createFridayRustHubRunAnswerReadbackService`.
- L4296/4300/4303: constructs `rustWsClient` / `rustContinuityProjector` / `rustAnswerReadback` (unconditional, side-effect-free).
- L4322 `routeStartRun` → (flag on + run qualifies) → L4425 `composeRustReadOnlyAgentRun({ wsClient, projector, readback, ... })`.
- `composeRustReadOnlyAgentRun` (L1164+): step 2 `args.wsClient.dispatchRun` (L1215), step 3 `args.readback.readAnswer` (L1224), step 4 `args.projector.project` (L1239); also the idempotency-replay branch calls `rustAnswerReadback.readAnswer` (L4400).
- Transitive: `sealed-client-service` → imports `ws-sealed-client` (L7) → imports `ws-sealed-crypto` (`agree`/`seal`/`open`/`buildAuthProof`/...) (L8-19).
- Gate: the whole branch is behind `deps.routeAgentRunViaRust === true`, resolved from `FRIDAY_ROUTE_AGENT_RUN_VIA_RUST` which is **DEFAULT-OFF** (L4316-4321, and "B1-compose (DARK)" markers at L139/L4304).

## Per-file verdict / OLD vs NEW label

| File | Verdict | Consumption evidence | Label change |
|---|---|---|---|
| `friday-rust-hub-run-continuity-projector-service.ts` | **LIVE-CONSUMED** | imported runtime L144 → built L4300 → passed `projector` L4437 → `project(...)` at compose step 4 (L1239) | OLD: `DARK (no production route consumes this)` / `unreferenced by any barrel/route until the composition slice wires it`. NEW: WIRED into the prod route handler (`routeStartRun`→compose), gated DEFAULT-OFF; `rust_wired_dev` ceiling, no v1 GO. |
| `friday-rust-hub-agent-run-sealed-client-service.ts` | **LIVE-CONSUMED** | imported runtime L142 → built L4296 → passed `wsClient` L4436 → `dispatchRun(...)` at compose step 2 (L1215) | OLD: `DARK (no production route consumes this)` / `no production route consumes it (until 6b)`. NEW: WIRED into the prod route handler, gated DEFAULT-OFF; narrow read-only/refs-only, no v1 GO. |
| `friday-rust-hub-run-answer-readback-service.ts` | **LIVE-CONSUMED** | imported runtime L146 → built L4303 → passed `readback` L4438 → `readAnswer(...)` at compose step 3 (L1224) + replay branch (L4400) | OLD: `DARK (no production route consumes this)` / `registers NO production route ... imported by no barrel/index`. NEW: WIRED (authoritative body source in compose), gated DEFAULT-OFF; still performs no auth of its own; `rust_wired_dev`, no v1 GO. |
| `friday-rust-hub-agent-run-ws-sealed-crypto.ts` | **LIVE-CONSUMED (transitive)** | imported by `ws-sealed-client` (L8-19), which the live compose drives | OLD: `DARK (no production route consumes this)` / `no production route consumes it`. NEW: TRANSITIVELY consumed by the prod route handler, gated DEFAULT-OFF; `rust_wired`, no v1 GO. (threat-model section kept intact) |
| `friday-rust-hub-agent-run-ws-sealed-client.ts` | **LIVE-CONSUMED** | imported by `sealed-client-service` (L3-7), constructed by it, `dispatchRun` driven by live compose | OLD: `DARK (no production route consumes this)` / `no production route consumes it`. NEW: WIRED via the sealed-client adapter into compose, gated DEFAULT-OFF; narrow read-only, no v1 GO. (S-D-stub comparison + threat-model kept intact) |
| `friday-rust-hub-agent-run-ws-client.ts` | **GENUINELY DARK** | **only** importer = `test/unit/api/mission-spine/friday-rust-hub-agent-run-ws-client.test.ts`; no `src/` importer; the live chain uses the *sealed* client, not this S-D plain stub (only a comment mention at `ws-sealed-client.ts` L27) | DARK header KEPT (accurate). Corrected only the false sub-claim `The composition slice (S-F) wires it` → now states B1-compose wired the **sealed** client instead and **bypassed/superseded** this stub; kept as the S-A wire-contract reference, off any live path. |

## Honesty notes

- "LIVE-CONSUMED" here means **imported + invoked by the production route handler**; the branch is gated DEFAULT-OFF (cutover pending) and only fires for a qualifying read-only DeepSeek run, so these do not execute in default prod today. Both facts are stated in every relabeled header.
- The one ambiguity worth flagging: `ws-sealed-crypto` is **transitively** (not directly) consumed — its label says so explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
