### PR TITLE
feat(rust-system): R4 — system-intent Rust ownership + m0026 intent/control-lease tables (dark, no route flip)

### DIFF
--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -279,6 +279,14 @@ pub mod tool_name_map;
 /// Dark substrate: NOTHING routes through it yet, NOT a v1 GO.
 pub mod key_source;
 
+/// R4 — the Rust-owned SYSTEM-INTENT execution domain layer (DARK). Mirrors the
+/// fenced TS `friday-system-service.executeIntent` (whose declared replacement is
+/// `rust_owned_system_intent_execution_entrypoint_required`): intent dispatch with
+/// canonical-gate approval-gating (fail-closed; an agent/channel/remote actor can
+/// never self-approve), the control-lease lifecycle, and an honest deferred-OS-action
+/// seam. No production route, no runtime caller, no live flip. NOT v1 GO.
+pub mod system_intent;
+
 use friday_core::gate::{
     canonical_action_bytes, canonical_approval_signature_bytes, ActorKind, ApprovalDecision,
     CanonicalApproval, GateDecision, MutatingActionRequest, CANONICAL_GATE_ISSUER,

--- a/rust-core/crates/friday-hub/src/system_intent.rs
+++ b/rust-core/crates/friday-hub/src/system_intent.rs
@@ -1,0 +1,925 @@
+//! R4 — the Rust-owned SYSTEM-INTENT execution DOMAIN layer (DARK).
+//!
+//! The Rust home for the TS `friday-system-service.executeIntent`
+//! (`src/system/engine/friday-system-service.ts`), whose live runtime is already
+//! fenced fail-closed: the TS `executeIntent` throws
+//! `TS_RUNTIME_SYSTEM_INTENT_RETIRED` (HTTP 503, classification `fail_closed`)
+//! for every non-test caller, declaring its replacement to be
+//! `rust_owned_system_intent_execution_entrypoint_required`. This module IS that
+//! entrypoint's domain layer; it orchestrates [`friday_storage::system_intent`]
+//! (the m0026 substrate) and [`friday_core::gate`] (the canonical mutating-action
+//! gate) into a faithful, fail-closed intent dispatch.
+//!
+//! ## Mirrored TS semantics (READ from the source, not invented)
+//! * The 23 [`friday_storage::system_intent::IntentAction`] vocabulary
+//!   (`FRIDAY_SYSTEM_INTENT_ACTIONS`).
+//! * The MUTATING set (TS `MUTATING_INTENTS`) — a mutating intent auto-acquires a
+//!   control lease for its actor and is gated by the canonical gate.
+//! * The HIGH-RISK set (TS `HIGH_RISK_INTENTS` = close_app / clipboard_read /
+//!   notification_act) and `resolveRiskLevel` (close_app/notification_act/
+//!   clipboard_read = high; clipboard_write/launch_app = medium; else low).
+//! * The control-lease lifecycle (`request_control` / `release_control` +
+//!   `ensureControlLease` auto-acquire), with owner-exclusivity (the TS
+//!   `SYSTEM_CONTROL_BUSY` / 409) and TTL expiry-revoke.
+//! * Emission of intent REQUEST + RESULT records (refs-only) per dispatch.
+//!
+//! ## Fail-closed posture (the security core)
+//! * Mutating control intents are APPROVAL-GATED through [`friday_core::gate::evaluate`],
+//!   which by construction has NO Allow-for-a-mutating-action path — a mutating /
+//!   `risk >= High` action resolves only to `RequiresApproval` or `Deny`. So a
+//!   mutating intent here ALWAYS resolves to a `blocked` result (the verified
+//!   approval→Allow upgrade is a DEFERRED seam — see below) — it is NEVER executed
+//!   without a canonical approval, and the gate's decision is persisted as an
+//!   approval-record (the durable evidence the action fail-closed).
+//! * `approve` / `deny` by an `Agent` or `Channel` actor is a HARD `Deny` (the
+//!   gate's reserved-approval-action rule) — an untrusted actor can NEVER
+//!   self-approve. This is the "never self-approve" invariant.
+//! * The flag is fail-closed: dispatch is refused unless the entrypoint was built
+//!   with the explicit opt-in, mirroring the TS `allowTestOnlySystemIntentExecution`
+//!   exactly-`true` opt-in.
+//!
+//! ## DARK + no route flip (the boundary)
+//! This registers NO production route, NO runtime caller, NO companion/desktop
+//! wiring. It exposes a pub [`SystemIntentEntrypoint`] with no caller (mirrors
+//! `workflow_catalog`). The live TS system-intent path stays fail-closed; this is
+//! ADDITIVE substrate, not a product cutover. NOT v1 GO.
+//!
+//! ## DEFERRED / UNIMPLEMENTED seams (explicitly NOT faked green)
+//! * **The actual OS effect** of every "do something to the desktop" action
+//!   (launch_app/open_url/close_app/focus/clipboard*/notification*/handoff*/
+//!   arrange_windows/snapshot) — i.e. the TS `executeIntentInternal` switch
+//!   bodies that call `execCommand` / `companionBridge` / `desktopSessionManager`.
+//!   Here those route to the [`SystemActionExecutor`] trait, whose only provided
+//!   impl is [`UnavailableExecutor`] (the precedent is the TS
+//!   `createFridaySystemUnavailableCompanionBridge`). A deferred action records a
+//!   `unavailable` result with the coarse marker
+//!   [`UNIMPLEMENTED_EXECUTION_MARKER`] — it NEVER records `completed` for an
+//!   effect it did not perform.
+//! * **The verified canonical approval → Allow → EXECUTE happy path** for a
+//!   mutating intent. `friday_core::gate::evaluate` cannot grant a mutating action;
+//!   the upgrade lives in `friday-storage::authorize_mutating_action` (PR-3b). This
+//!   module wires only the fail-closed BLOCK path (which is what "fail-closed"
+//!   requires); composing the verified-approval execute path is a documented
+//!   follow-on seam (an Allow would, today, hit the unavailable executor anyway).
+
+use friday_core::gate::{self, Actor, ActorKind, GateDecision, MutatingActionRequest};
+use friday_core::Risk;
+use friday_storage::system_intent::{
+    acquire_control_lease, insert_approval_record, insert_intent_request, insert_intent_result,
+    normalize_active_lease, revoke_active_lease, ApprovalRecord, DecisionLabel, IntentAction,
+    IntentRequest, IntentResultRecord, IntentStatus, LeaseAcquireError, LeaseAcquireOutcome,
+    NewControlLease, OwnerKind, RiskLabel,
+};
+use rusqlite::Connection;
+
+/// The coarse marker a DEFERRED (unimplemented) OS-action execution records as its
+/// result `message`. It is NEVER `completed` — a deferred action is honestly
+/// `unavailable`. Adversarial review can grep for this to confirm no faked success.
+pub const UNIMPLEMENTED_EXECUTION_MARKER: &str = "rust_system_action_execution_unimplemented";
+
+/// The TS retirement guard's declared replacement id. The Rust entrypoint IS this
+/// replacement; exported so the boundary is greppable across the two trees.
+pub const RUST_ENTRYPOINT_REPLACEMENT_ID: &str =
+    "rust_owned_system_intent_execution_entrypoint_required";
+
+/// The default control-lease TTL (10 min), mirroring the TS `DEFAULT_LEASE_TTL_MS`.
+pub const DEFAULT_LEASE_TTL_MS: i64 = 10 * 60 * 1000;
+
+/// Fail-closed errors of the system-intent domain layer. Distinct from a
+/// non-throwing intent RESULT (`blocked`/`unavailable`/`failed`): these are the
+/// `throw`-class outcomes (the TS `FridayDomainError` cases that propagate rather
+/// than becoming a result row), plus the retirement fail-closed guard.
+#[derive(Debug, thiserror::Error)]
+pub enum SystemIntentError {
+    /// The entrypoint was built WITHOUT the explicit opt-in flag — dispatch is
+    /// fail-closed (mirrors the TS `TS_RUNTIME_SYSTEM_INTENT_RETIRED` 503).
+    #[error("system intent execution is fail-closed (flag not enabled); replacement = {RUST_ENTRYPOINT_REPLACEMENT_ID}")]
+    FailClosed,
+    /// Caller input failed a fail-closed validation (e.g. an empty required field)
+    /// — never persisted, never executed.
+    #[error("system intent input invalid: {0}")]
+    Invalid(String),
+    /// A storage-layer failure (surfaced fail-closed, never swallowed).
+    #[error("storage error: {0}")]
+    Storage(#[from] friday_storage::StorageError),
+}
+
+type Result<T> = std::result::Result<T, SystemIntentError>;
+
+/// A system-intent dispatch INPUT (the subset of the TS `FridaySystemIntentInput`
+/// this dark domain layer mirrors — refs-only, no raw bodies). The hub binds the
+/// `intent_id` and `now_ms`; the caller supplies the action + actor + a coarse
+/// target ref.
+#[derive(Clone, Debug)]
+pub struct IntentInput {
+    pub intent_id: String,
+    pub action: IntentAction,
+    pub actor_id: String,
+    pub actor_kind: OwnerKind,
+    /// A coarse REF/id of the target (app bundle id, project-path ref, notification
+    /// id, etc.) — NEVER a raw url/clipboard/notification body.
+    pub target_ref: Option<String>,
+    /// Optional explicit lease reason; defaults to `auto:<action>` / the explicit
+    /// control reason, mirroring the TS.
+    pub reason: Option<String>,
+    /// Optional lease TTL override (ms); defaults to [`DEFAULT_LEASE_TTL_MS`].
+    pub lease_ttl_ms: Option<i64>,
+}
+
+/// The (refs-only) outcome of a dispatch — the persisted [`IntentResultRecord`]
+/// plus, for diagnostics, whether the OS effect was actually performed or DEFERRED
+/// to the unimplemented seam.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DispatchOutcome {
+    pub result: IntentResultRecord,
+    /// `true` when the result reflects a DEFERRED (unimplemented) OS action — i.e.
+    /// the executor is the [`UnavailableExecutor`] seam, not a real effect.
+    pub execution_deferred: bool,
+}
+
+/// The boundary to the actual OS effect of a desktop-affecting action. The TS
+/// equivalent is the `companionBridge` / `desktopSessionManager` / `execCommand`
+/// surface. The ONLY provided impl is [`UnavailableExecutor`] (precedent: the TS
+/// `createFridaySystemUnavailableCompanionBridge`); a real impl (companion/Swift
+/// app / AppleScript) is out of scope for this dark slice.
+pub trait SystemActionExecutor {
+    /// Attempt to perform `action`'s OS effect on `target_ref`. Returns the coarse
+    /// outcome the result row records. A real executor returns `Completed`; the
+    /// unavailable seam returns `Unavailable` with the unimplemented marker. An
+    /// executor MUST NOT return `Completed` for an effect it did not perform.
+    fn execute(&self, action: IntentAction, target_ref: Option<&str>) -> ExecOutcome;
+}
+
+/// What a [`SystemActionExecutor`] reports back (a coarse, refs-only outcome).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ExecOutcome {
+    pub status: IntentStatus,
+    pub message: String,
+}
+
+/// The DEFAULT executor: every desktop-affecting action is reported `unavailable`
+/// with the unimplemented marker. This is the honest dark-slice seam — it never
+/// fakes a `completed` effect. Mirrors the TS unavailable companion bridge used in
+/// the retirement-guard test.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct UnavailableExecutor;
+
+impl SystemActionExecutor for UnavailableExecutor {
+    fn execute(&self, _action: IntentAction, _target_ref: Option<&str>) -> ExecOutcome {
+        ExecOutcome {
+            status: IntentStatus::Unavailable,
+            message: UNIMPLEMENTED_EXECUTION_MARKER.to_string(),
+        }
+    }
+}
+
+/// The DARK system-intent entrypoint. Built with `enabled = false` by default
+/// (fail-closed); only [`SystemIntentEntrypoint::with_execution_enabled`] opts in,
+/// mirroring the TS exactly-`true` `allowTestOnlySystemIntentExecution` flag. The
+/// `id_seq` makes the per-dispatch ids it mints (intent_id / lease_id / record_id)
+/// deterministic for tests without a clock/uuid dep.
+pub struct SystemIntentEntrypoint<E: SystemActionExecutor> {
+    enabled: bool,
+    executor: E,
+}
+
+impl SystemIntentEntrypoint<UnavailableExecutor> {
+    /// A fail-closed entrypoint (dispatch refused) with the unavailable executor.
+    /// This is the production-faithful default: nothing executes.
+    pub fn fail_closed() -> Self {
+        SystemIntentEntrypoint {
+            enabled: false,
+            executor: UnavailableExecutor,
+        }
+    }
+}
+
+impl<E: SystemActionExecutor> SystemIntentEntrypoint<E> {
+    /// Build an entrypoint with execution opted IN (the test-oracle / future
+    /// flagged path) and a given executor. NEVER call this on a production path
+    /// with a real executor until the cutover gate is taken.
+    pub fn with_execution_enabled(executor: E) -> Self {
+        SystemIntentEntrypoint {
+            enabled: true,
+            executor,
+        }
+    }
+
+    /// True if the OS effect would actually be attempted (flag on). Diagnostics.
+    pub fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// Dispatch a system intent, fail-closed.
+    ///
+    /// 1. If the flag is not enabled → [`SystemIntentError::FailClosed`] BEFORE any
+    ///    persistence/lease/gate side effect (mirrors the TS method guard).
+    /// 2. Validate the input (fail-closed).
+    /// 3. Persist the immutable REQUEST record.
+    /// 4. For `approve`/`deny`/mutating actions: run the canonical gate
+    ///    ([`friday_core::gate::evaluate`]); persist the gate decision as an
+    ///    approval-record; a non-`Allow` decision becomes a `blocked` result and
+    ///    NOTHING is executed (the gate cannot Allow a mutating action — the
+    ///    verified-approval execute path is a deferred seam).
+    /// 5. For lease intents (`request_control`/`release_control`): drive the lease
+    ///    lifecycle (owner-exclusive acquire / release).
+    /// 6. For a non-mutating, gate-clear action: auto-acquire the lease if mutating
+    ///    (it is not, here) and run the OS effect through the executor (the
+    ///    unavailable seam by default → `unavailable`, never faked `completed`).
+    pub fn dispatch(
+        &self,
+        conn: &Connection,
+        input: &IntentInput,
+        now_ms: i64,
+    ) -> Result<DispatchOutcome> {
+        // (1) Flag fail-closed — BEFORE any side effect, mirroring the TS guard.
+        if !self.enabled {
+            return Err(SystemIntentError::FailClosed);
+        }
+
+        // (2) Validate (fail-closed). Actions that name a target require one.
+        self.validate(input)?;
+
+        let mutating = is_mutating(input.action);
+        let risk = resolve_risk(input.action);
+
+        // (3) Persist the immutable REQUEST record.
+        let request = IntentRequest {
+            intent_id: input.intent_id.clone(),
+            action: input.action,
+            actor_id: input.actor_id.clone(),
+            actor_kind: input.actor_kind,
+            target_ref: input.target_ref.clone(),
+            mutating,
+            risk: risk_label(risk),
+            created_at: now_ms,
+        };
+        insert_intent_request(conn, &request)?;
+
+        // (4) approve/deny + every mutating action go through the canonical gate.
+        //     The gate runs FIRST for approve/deny so an Agent/Channel/remote
+        //     reserved action hard-Denies before any lease mutation or execution.
+        //     Because `friday_core::gate::evaluate` has NO Allow-for-a-mutating-action
+        //     path, EVERY mutating intent (incl. recover_ui) resolves to a `blocked`
+        //     result here and returns — it never reaches the lease/execute body
+        //     below. The gate can only CLEAR (return None) for a NON-mutating
+        //     approve/deny by an Owner/Api actor (the reserved-action rule does not
+        //     bind them and the action is not classified mutating); such an
+        //     approve/deny then proceeds to the dispatch body. The verified
+        //     approval→Allow→execute upgrade for a mutating intent is a DEFERRED seam
+        //     (see the module-level note); recover_ui's TS lease-revoke side effect is
+        //     part of that deferred execute path, not performed on the block path.
+        if matches!(input.action, IntentAction::Approve | IntentAction::Deny) || mutating {
+            if let Some(outcome) = self.gate_and_maybe_block(conn, input, mutating, risk, now_ms)? {
+                return Ok(outcome);
+            }
+        }
+
+        // (5) Lease lifecycle intents (NOT in the TS MUTATING_INTENTS set, so they are
+        //     not gate-blocked — they are owner-exclusivity-gated by the lease itself).
+        match input.action {
+            IntentAction::RequestControl => {
+                return self.handle_request_control(conn, input, now_ms);
+            }
+            IntentAction::ReleaseControl => {
+                return self.handle_release_control(conn, input, now_ms);
+            }
+            _ => {}
+        }
+
+        // (6) Auto-acquire the control lease for a mutating action. (Unreachable for
+        //     a mutating action today — they all blocked at the gate in step (4) —
+        //     but kept faithful to the TS `ensureControlLease` ordering so a future
+        //     verified-approval execute path slots in here unchanged.)
+        let lease_id = if mutating {
+            match self.ensure_lease(conn, input, now_ms) {
+                Ok(id) => id,
+                Err(LeaseAcquireError::Busy {
+                    owner_kind,
+                    owner_id,
+                }) => {
+                    return self.persist_blocked(
+                        conn,
+                        input,
+                        format!(
+                            "control lease is currently held by {}:{}",
+                            owner_kind.as_str(),
+                            owner_id
+                        ),
+                        Some("system_control_busy".to_string()),
+                        now_ms,
+                    );
+                }
+                Err(LeaseAcquireError::Storage(e)) => return Err(SystemIntentError::Storage(e)),
+            }
+        } else {
+            // A read-only/non-mutating action still observes the active lease.
+            normalize_active_lease(conn, now_ms)?.map(|l| l.lease_id)
+        };
+
+        // Run the OS effect through the executor (the unavailable seam by default).
+        let exec = self
+            .executor
+            .execute(input.action, input.target_ref.as_deref());
+        let execution_deferred = exec.status == IntentStatus::Unavailable
+            && exec.message == UNIMPLEMENTED_EXECUTION_MARKER;
+        let result = IntentResultRecord {
+            intent_id: input.intent_id.clone(),
+            action: input.action,
+            status: exec.status,
+            message: exec.message,
+            control_lease_id: lease_id,
+            gate_reason: None,
+            created_at: now_ms,
+        };
+        insert_intent_result(conn, &result)?;
+        Ok(DispatchOutcome {
+            result,
+            execution_deferred,
+        })
+    }
+
+    // ─── internals ────────────────────────────────────────────────────────────
+
+    fn validate(&self, input: &IntentInput) -> Result<()> {
+        if input.intent_id.trim().is_empty() {
+            return Err(SystemIntentError::Invalid("intent_id is required".into()));
+        }
+        if input.actor_id.trim().is_empty() {
+            return Err(SystemIntentError::Invalid("actor_id is required".into()));
+        }
+        // Actions that operate on a named target require a (coarse) target ref. This
+        // mirrors the TS `requireNonEmpty(...)` for the corresponding fields.
+        let needs_target = matches!(
+            input.action,
+            IntentAction::LaunchApp
+                | IntentAction::CloseApp
+                | IntentAction::OpenUrl
+                | IntentAction::OpenProject
+                | IntentAction::SearchFile
+                | IntentAction::ReadNotification
+                | IntentAction::NotificationAct
+                | IntentAction::ClipboardWrite
+                | IntentAction::ResumeTask
+                | IntentAction::Approve
+                | IntentAction::Deny
+        );
+        if needs_target
+            && input
+                .target_ref
+                .as_deref()
+                .map(str::trim)
+                .unwrap_or("")
+                .is_empty()
+        {
+            return Err(SystemIntentError::Invalid(format!(
+                "{} requires a target_ref",
+                input.action.as_str()
+            )));
+        }
+        Ok(())
+    }
+
+    /// Build the gate request, evaluate it, persist the decision as an
+    /// approval-record, and (for any non-`Allow` decision) persist a `blocked`
+    /// result and return it — NOTHING is executed. Returns `Ok(None)` only when the
+    /// gate cleared (`Allow`), which for a mutating action is impossible by the
+    /// gate's construction, so the caller may proceed only for a non-mutating
+    /// approve/deny by an unbound actor.
+    fn gate_and_maybe_block(
+        &self,
+        conn: &Connection,
+        input: &IntentInput,
+        mutating: bool,
+        risk: Risk,
+        now_ms: i64,
+    ) -> Result<Option<DispatchOutcome>> {
+        let request = build_gate_request(input, mutating, risk);
+        let evidence = gate::evaluate(&request);
+
+        // Persist the gate decision as durable approval-record evidence (refs-only).
+        insert_approval_record(
+            conn,
+            &ApprovalRecord {
+                record_id: format!("{}::gate", input.intent_id),
+                intent_id: input.intent_id.clone(),
+                action: input.action,
+                decision: decision_label(evidence.decision),
+                reason: evidence.reason.clone(),
+                risk: risk_label(evidence.risk),
+                approval_required: evidence.approval_required,
+                created_at: now_ms,
+            },
+        )?;
+
+        match evidence.decision {
+            GateDecision::Allow => Ok(None),
+            GateDecision::Deny | GateDecision::RequiresApproval => {
+                let message = match evidence.decision {
+                    GateDecision::Deny => format!(
+                        "Canonical gate denied {}: {}",
+                        input.action.as_str(),
+                        evidence.reason
+                    ),
+                    _ => format!("Canonical approval required for {}", input.action.as_str()),
+                };
+                Ok(Some(self.persist_blocked(
+                    conn,
+                    input,
+                    message,
+                    Some(evidence.reason),
+                    now_ms,
+                )?))
+            }
+        }
+    }
+
+    fn handle_request_control(
+        &self,
+        conn: &Connection,
+        input: &IntentInput,
+        now_ms: i64,
+    ) -> Result<DispatchOutcome> {
+        match self.ensure_lease(conn, input, now_ms) {
+            Ok(lease_id) => self.persist_result(
+                conn,
+                input,
+                IntentStatus::Completed,
+                "Control lease acquired".to_string(),
+                lease_id,
+                None,
+                now_ms,
+            ),
+            Err(LeaseAcquireError::Busy {
+                owner_kind,
+                owner_id,
+            }) => self.persist_blocked(
+                conn,
+                input,
+                format!(
+                    "control lease is currently held by {}:{}",
+                    owner_kind.as_str(),
+                    owner_id
+                ),
+                Some("system_control_busy".to_string()),
+                now_ms,
+            ),
+            Err(LeaseAcquireError::Storage(e)) => Err(SystemIntentError::Storage(e)),
+        }
+    }
+
+    fn handle_release_control(
+        &self,
+        conn: &Connection,
+        input: &IntentInput,
+        now_ms: i64,
+    ) -> Result<DispatchOutcome> {
+        let revoked = revoke_active_lease(
+            conn,
+            now_ms,
+            input.reason.as_deref().unwrap_or("released_by_request"),
+        )?;
+        let (message, lease_id) = match revoked {
+            Some(lease) => ("Control lease released".to_string(), Some(lease.lease_id)),
+            None => ("No active control lease".to_string(), None),
+        };
+        self.persist_result(
+            conn,
+            input,
+            IntentStatus::Completed,
+            message,
+            lease_id,
+            None,
+            now_ms,
+        )
+    }
+
+    fn ensure_lease(
+        &self,
+        conn: &Connection,
+        input: &IntentInput,
+        now_ms: i64,
+    ) -> std::result::Result<Option<String>, LeaseAcquireError> {
+        let new_lease = NewControlLease {
+            lease_id: format!("{}::lease", input.intent_id),
+            owner_id: input.actor_id.clone(),
+            owner_kind: input.actor_kind,
+            reason: Some(
+                input
+                    .reason
+                    .clone()
+                    .unwrap_or_else(|| format!("auto:{}", input.action.as_str())),
+            ),
+            ttl_ms: Some(input.lease_ttl_ms.unwrap_or(DEFAULT_LEASE_TTL_MS)),
+        };
+        match acquire_control_lease(conn, &new_lease, now_ms)? {
+            LeaseAcquireOutcome::Acquired(l) | LeaseAcquireOutcome::Reused(l) => {
+                Ok(Some(l.lease_id))
+            }
+        }
+    }
+
+    fn persist_blocked(
+        &self,
+        conn: &Connection,
+        input: &IntentInput,
+        message: String,
+        gate_reason: Option<String>,
+        now_ms: i64,
+    ) -> Result<DispatchOutcome> {
+        self.persist_result(
+            conn,
+            input,
+            IntentStatus::Blocked,
+            message,
+            None,
+            gate_reason,
+            now_ms,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn persist_result(
+        &self,
+        conn: &Connection,
+        input: &IntentInput,
+        status: IntentStatus,
+        message: String,
+        control_lease_id: Option<String>,
+        gate_reason: Option<String>,
+        now_ms: i64,
+    ) -> Result<DispatchOutcome> {
+        let result = IntentResultRecord {
+            intent_id: input.intent_id.clone(),
+            action: input.action,
+            status,
+            message,
+            control_lease_id,
+            gate_reason,
+            created_at: now_ms,
+        };
+        insert_intent_result(conn, &result)?;
+        Ok(DispatchOutcome {
+            result,
+            execution_deferred: false,
+        })
+    }
+}
+
+// ─── TS-mirrored classification (port of the TS const sets + resolveRiskLevel) ─
+
+/// The TS `MUTATING_INTENTS` set — actions that mutate state, auto-acquire a lease,
+/// and go through the canonical gate.
+fn is_mutating(action: IntentAction) -> bool {
+    matches!(
+        action,
+        IntentAction::Open
+            | IntentAction::Focus
+            | IntentAction::ArrangeWindows
+            | IntentAction::LaunchApp
+            | IntentAction::CloseApp
+            | IntentAction::OpenUrl
+            | IntentAction::OpenProject
+            | IntentAction::HandoffToBrowser
+            | IntentAction::HandoffToTerminal
+            | IntentAction::NotificationAct
+            | IntentAction::ResumeTask
+            | IntentAction::RecoverUi
+            | IntentAction::ClipboardRead
+            | IntentAction::ClipboardWrite
+            | IntentAction::Approve
+            | IntentAction::Deny
+    )
+}
+
+/// The TS `resolveRiskLevel`: close_app/notification_act/clipboard_read = high;
+/// clipboard_write/launch_app = medium; everything else = low.
+fn resolve_risk(action: IntentAction) -> Risk {
+    match action {
+        IntentAction::CloseApp | IntentAction::NotificationAct | IntentAction::ClipboardRead => {
+            Risk::High
+        }
+        IntentAction::ClipboardWrite | IntentAction::LaunchApp => Risk::Medium,
+        _ => Risk::Low,
+    }
+}
+
+fn risk_label(risk: Risk) -> RiskLabel {
+    match risk {
+        Risk::ReadOnly => RiskLabel::ReadOnly,
+        Risk::Low => RiskLabel::Low,
+        Risk::Medium => RiskLabel::Medium,
+        Risk::High => RiskLabel::High,
+        Risk::Critical => RiskLabel::Critical,
+    }
+}
+
+fn decision_label(decision: GateDecision) -> DecisionLabel {
+    match decision {
+        GateDecision::Allow => DecisionLabel::Allow,
+        GateDecision::Deny => DecisionLabel::Deny,
+        GateDecision::RequiresApproval => DecisionLabel::RequiresApproval,
+    }
+}
+
+fn gate_actor_kind(kind: OwnerKind) -> ActorKind {
+    match kind {
+        // The untrusted-origin agent maps to the gate's bound `Agent` (reserved-action
+        // hard-deny applies). `remote` is an external/untrusted origin → treat as
+        // `Agent` so a remote actor can NEVER self-approve either (fail-safe: this only
+        // ever ADDS the reserved-action deny, never removes it).
+        OwnerKind::Agent | OwnerKind::Remote => ActorKind::Agent,
+        OwnerKind::Api => ActorKind::Api,
+        OwnerKind::System => ActorKind::Api,
+        OwnerKind::Owner => ActorKind::Owner,
+    }
+}
+
+/// Build the canonical-gate request for an intent. `approve`/`deny` carry the TS
+/// reserved-action verb so an Agent/Channel/remote actor hard-denies; mutating
+/// actions are classified `mutating = true` (so the gate requires approval). The
+/// action string passed to the gate is the intent action verb (so `approve`/`deny`
+/// hit the reserved-action set).
+fn build_gate_request(input: &IntentInput, mutating: bool, risk: Risk) -> MutatingActionRequest {
+    let actor = Actor {
+        kind: gate_actor_kind(input.actor_kind),
+        id: input.actor_id.clone(),
+        principal_id: Some(input.actor_id.clone()),
+    };
+    // The classification is sealed (built via `classify`), so the gate-decision trio
+    // can only come from here — no struct-literal can assert `mutating: false` for a
+    // mutating action. We pass no params (the target is a coarse ref, not a path the
+    // classifier escalates on); the base risk carries the TS-resolved risk.
+    let classification = gate::classify(mutating, risk, input.action.as_str(), &[]);
+    MutatingActionRequest::from_classification(
+        classification,
+        input.action.as_str().to_string(),
+        actor,
+        "system".to_string(),
+        Vec::new(),
+        None,
+        None,
+        None,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use friday_storage::system_intent::{get_intent_result, list_approval_records};
+    use friday_storage::Db;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static C: AtomicU64 = AtomicU64::new(0);
+    fn tmp(tag: &str) -> String {
+        std::env::temp_dir()
+            .join(format!(
+                "friday-hub-system-intent-{}-{}-{}.sqlite",
+                std::process::id(),
+                tag,
+                C.fetch_add(1, Ordering::Relaxed)
+            ))
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    fn input(intent_id: &str, action: IntentAction, actor: &str, kind: OwnerKind) -> IntentInput {
+        IntentInput {
+            intent_id: intent_id.to_string(),
+            action,
+            actor_id: actor.to_string(),
+            actor_kind: kind,
+            target_ref: None,
+            reason: None,
+            lease_ttl_ms: None,
+        }
+    }
+
+    #[test]
+    fn fail_closed_by_default_refuses_dispatch_with_no_side_effect() {
+        let db = Db::open_hub(&tmp("failclosed")).unwrap();
+        let ep = SystemIntentEntrypoint::fail_closed();
+        let mut inp = input("i1", IntentAction::LaunchApp, "agent-1", OwnerKind::Agent);
+        inp.target_ref = Some("Safari".to_string());
+        let err = ep.dispatch(db.conn(), &inp, 100);
+        assert!(matches!(err, Err(SystemIntentError::FailClosed)));
+        // No request row, no result, no lease, no approval-record was written.
+        assert_eq!(db.count("system_intent_request").unwrap(), 0);
+        assert_eq!(db.count("system_intent_result").unwrap(), 0);
+        assert_eq!(db.count("system_control_lease").unwrap(), 0);
+        assert_eq!(db.count("system_intent_approval_record").unwrap(), 0);
+    }
+
+    #[test]
+    fn agent_cannot_self_approve_reserved_action_hard_deny() {
+        // The "never self-approve" invariant: an Agent actor doing approve/deny is a
+        // HARD gate deny, becomes a `blocked` result, and NOTHING is executed.
+        let db = Db::open_hub(&tmp("self-approve")).unwrap();
+        let ep = SystemIntentEntrypoint::with_execution_enabled(UnavailableExecutor);
+        for action in [IntentAction::Approve, IntentAction::Deny] {
+            let id = format!("i-{}", action.as_str());
+            let mut inp = input(&id, action, "agent-1", OwnerKind::Agent);
+            inp.target_ref = Some("close_app".to_string());
+            let outcome = ep.dispatch(db.conn(), &inp, 100).unwrap();
+            assert_eq!(
+                outcome.result.status,
+                IntentStatus::Blocked,
+                "{action:?} must block"
+            );
+            assert!(!outcome.execution_deferred);
+            // The persisted approval-record proves the gate hard-denied with the
+            // reserved-action reason (the bound-principal rule).
+            let trail = list_approval_records(db.conn(), &id).unwrap();
+            assert_eq!(trail.len(), 1);
+            assert_eq!(trail[0].decision, DecisionLabel::Deny);
+            assert_eq!(
+                trail[0].reason,
+                "agent_cannot_execute_reserved_approval_action"
+            );
+            // No success event / completed result.
+            assert_eq!(
+                get_intent_result(db.conn(), &id).unwrap().unwrap().status,
+                IntentStatus::Blocked
+            );
+        }
+    }
+
+    #[test]
+    fn remote_actor_also_cannot_self_approve() {
+        // A `remote` actor maps to the gate's bound Agent → reserved-action hard-deny.
+        let db = Db::open_hub(&tmp("remote-approve")).unwrap();
+        let ep = SystemIntentEntrypoint::with_execution_enabled(UnavailableExecutor);
+        let mut inp = input("i-r", IntentAction::Approve, "remote-7", OwnerKind::Remote);
+        inp.target_ref = Some("close_app".to_string());
+        let outcome = ep.dispatch(db.conn(), &inp, 100).unwrap();
+        assert_eq!(outcome.result.status, IntentStatus::Blocked);
+    }
+
+    #[test]
+    fn mutating_action_is_gate_blocked_never_executed() {
+        // A mutating action (launch_app) goes through the gate, which CANNOT allow a
+        // mutating action -> RequiresApproval -> blocked. The executor is NEVER reached,
+        // so no `unavailable`/`completed` execution result is produced.
+        let db = Db::open_hub(&tmp("mutating-block")).unwrap();
+        let ep = SystemIntentEntrypoint::with_execution_enabled(UnavailableExecutor);
+        let mut inp = input("i-launch", IntentAction::LaunchApp, "api-1", OwnerKind::Api);
+        inp.target_ref = Some("com.apple.Safari".to_string());
+        let outcome = ep.dispatch(db.conn(), &inp, 100).unwrap();
+        assert_eq!(outcome.result.status, IntentStatus::Blocked);
+        assert!(
+            !outcome.execution_deferred,
+            "the executor must not be reached"
+        );
+        let trail = list_approval_records(db.conn(), "i-launch").unwrap();
+        assert_eq!(trail.len(), 1);
+        assert_eq!(trail[0].decision, DecisionLabel::RequiresApproval);
+        assert!(trail[0].approval_required);
+        assert_eq!(trail[0].risk, RiskLabel::Medium);
+        // No lease was minted (the gate blocked before the auto-acquire).
+        assert_eq!(db.count("system_control_lease").unwrap(), 0);
+    }
+
+    #[test]
+    fn snapshot_is_non_mutating_and_routes_to_unavailable_executor_not_faked_complete() {
+        // `snapshot` is NOT mutating -> no gate block. Its OS effect is deferred, so the
+        // result is honestly `unavailable` with the unimplemented marker — NEVER `completed`.
+        let db = Db::open_hub(&tmp("snapshot")).unwrap();
+        let ep = SystemIntentEntrypoint::with_execution_enabled(UnavailableExecutor);
+        let inp = input("i-snap", IntentAction::Snapshot, "api-1", OwnerKind::Api);
+        let outcome = ep.dispatch(db.conn(), &inp, 100).unwrap();
+        assert_eq!(outcome.result.status, IntentStatus::Unavailable);
+        assert_eq!(outcome.result.message, UNIMPLEMENTED_EXECUTION_MARKER);
+        assert!(outcome.execution_deferred);
+        assert_ne!(outcome.result.status, IntentStatus::Completed);
+    }
+
+    #[test]
+    fn request_then_release_control_lifecycle() {
+        // request_control / release_control are NOT mutating (not in MUTATING_INTENTS),
+        // so they are lease-lifecycle ops, not gate-blocked. request_control acquires;
+        // a foreign owner is refused Busy; release_control revokes.
+        let db = Db::open_hub(&tmp("lease-lifecycle")).unwrap();
+        let ep = SystemIntentEntrypoint::with_execution_enabled(UnavailableExecutor);
+
+        // Agent acquires.
+        let acq = ep
+            .dispatch(
+                db.conn(),
+                &input(
+                    "i-req",
+                    IntentAction::RequestControl,
+                    "agent-1",
+                    OwnerKind::Agent,
+                ),
+                100,
+            )
+            .unwrap();
+        assert_eq!(acq.result.status, IntentStatus::Completed);
+        assert_eq!(acq.result.message, "Control lease acquired");
+        assert!(acq.result.control_lease_id.is_some());
+
+        // A DIFFERENT owner requesting control is refused Busy -> blocked.
+        let busy = ep
+            .dispatch(
+                db.conn(),
+                &input(
+                    "i-req2",
+                    IntentAction::RequestControl,
+                    "api-9",
+                    OwnerKind::Api,
+                ),
+                150,
+            )
+            .unwrap();
+        assert_eq!(busy.result.status, IntentStatus::Blocked);
+        assert_eq!(
+            busy.result.gate_reason.as_deref(),
+            Some("system_control_busy")
+        );
+
+        // The original owner releases.
+        let rel = ep
+            .dispatch(
+                db.conn(),
+                &input(
+                    "i-rel",
+                    IntentAction::ReleaseControl,
+                    "agent-1",
+                    OwnerKind::Agent,
+                ),
+                200,
+            )
+            .unwrap();
+        assert_eq!(rel.result.status, IntentStatus::Completed);
+        assert_eq!(rel.result.message, "Control lease released");
+
+        // After release a fresh owner CAN now acquire.
+        let acq2 = ep
+            .dispatch(
+                db.conn(),
+                &input(
+                    "i-req3",
+                    IntentAction::RequestControl,
+                    "api-9",
+                    OwnerKind::Api,
+                ),
+                250,
+            )
+            .unwrap();
+        assert_eq!(acq2.result.status, IntentStatus::Completed);
+    }
+
+    #[test]
+    fn release_control_with_no_active_lease_is_completed_noop() {
+        let db = Db::open_hub(&tmp("release-noop")).unwrap();
+        let ep = SystemIntentEntrypoint::with_execution_enabled(UnavailableExecutor);
+        let rel = ep
+            .dispatch(
+                db.conn(),
+                &input(
+                    "i-rel",
+                    IntentAction::ReleaseControl,
+                    "agent-1",
+                    OwnerKind::Agent,
+                ),
+                100,
+            )
+            .unwrap();
+        assert_eq!(rel.result.status, IntentStatus::Completed);
+        assert_eq!(rel.result.message, "No active control lease");
+    }
+
+    #[test]
+    fn validation_fails_closed_for_missing_target() {
+        let db = Db::open_hub(&tmp("validate")).unwrap();
+        let ep = SystemIntentEntrypoint::with_execution_enabled(UnavailableExecutor);
+        // launch_app needs a target_ref.
+        let inp = input("i-bad", IntentAction::LaunchApp, "api-1", OwnerKind::Api);
+        assert!(matches!(
+            ep.dispatch(db.conn(), &inp, 100),
+            Err(SystemIntentError::Invalid(_))
+        ));
+        // ...and nothing was persisted (validation runs before the request insert).
+        assert_eq!(db.count("system_intent_request").unwrap(), 0);
+    }
+
+    #[test]
+    fn classification_mirrors_ts_high_risk_and_mutating_sets() {
+        // resolveRiskLevel parity.
+        assert_eq!(resolve_risk(IntentAction::CloseApp), Risk::High);
+        assert_eq!(resolve_risk(IntentAction::ClipboardRead), Risk::High);
+        assert_eq!(resolve_risk(IntentAction::NotificationAct), Risk::High);
+        assert_eq!(resolve_risk(IntentAction::ClipboardWrite), Risk::Medium);
+        assert_eq!(resolve_risk(IntentAction::LaunchApp), Risk::Medium);
+        assert_eq!(resolve_risk(IntentAction::Snapshot), Risk::Low);
+        // MUTATING_INTENTS parity (a representative subset; snapshot/search/list NOT mutating).
+        assert!(is_mutating(IntentAction::LaunchApp));
+        assert!(is_mutating(IntentAction::ClipboardRead));
+        assert!(is_mutating(IntentAction::Approve));
+        assert!(!is_mutating(IntentAction::Snapshot));
+        assert!(!is_mutating(IntentAction::SearchFile));
+        assert!(!is_mutating(IntentAction::NotificationList));
+        assert!(!is_mutating(IntentAction::RequestControl));
+        assert!(!is_mutating(IntentAction::ReleaseControl));
+    }
+}

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -30,6 +30,7 @@ pub mod provider_timeline_store;
 pub mod run_result;
 pub mod schedule;
 mod schema;
+pub mod system_intent;
 pub mod workflow;
 pub mod workflow_catalog;
 pub mod workflow_def;

--- a/rust-core/crates/friday-storage/src/schema.rs
+++ b/rust-core/crates/friday-storage/src/schema.rs
@@ -100,6 +100,17 @@ pub const HUB_ONLY_TABLES: &[&str] = &[
     // truth). Hub-only: a catalog entry is the Hub-coordinated workflow's
     // identity record. Holds NO secret/key material.
     "workflow_catalog",
+    // R4: Rust-owned system-intent substrate (DARK). The four Hub-only tables the
+    // Rust system-intent entrypoint (`friday-hub::system_intent`) operates over —
+    // the immutable intent REQUEST record, its 1:1 RESULT record, the
+    // control-lease lifecycle store, and the approval-decision trail. Hub-only:
+    // system-intent execution is a Hub-coordinated, desktop-affecting surface
+    // that must never exist on a phone. Refs-only — they hold NO raw
+    // url/clipboard/notification body and NO secret/key/approval-mint material.
+    "system_intent_request",
+    "system_intent_result",
+    "system_control_lease",
+    "system_intent_approval_record",
 ];
 
 /// Tables present only on a phone (never created on the Hub).
@@ -395,6 +406,19 @@ pub fn hub_migrations() -> Vec<Migration> {
             name: "workflow_catalog",
             destructive: false,
             up: m0025_workflow_catalog,
+        },
+        // R4: Rust-owned system-intent substrate (DARK — no production route, no
+        // runtime caller, no live TS flip; the TS `executeIntent` is already
+        // fenced fail-closed). Adds the four Hub-only tables the Rust
+        // system-intent entrypoint operates over: the immutable intent REQUEST
+        // record, its 1:1 RESULT record, the control-lease lifecycle store, and
+        // the approval-decision trail. Purely additive (CREATE TABLE + INDEX only)
+        // — touches no existing table, so v25 rows/queries are unaffected. NOT v1 GO.
+        Migration {
+            version: 26,
+            name: "system_intent_substrate",
+            destructive: false,
+            up: m0026_system_intent_substrate,
         },
     ]
 }
@@ -895,6 +919,199 @@ CREATE TABLE workflow_catalog (
 );
 CREATE UNIQUE INDEX idx_workflow_catalog_slug ON workflow_catalog(slug);
 CREATE INDEX idx_workflow_catalog_archived ON workflow_catalog(is_archived);";
+
+// --- R4 system-intent substrate fragment (Hub-only) -------------------------
+
+// DARK system-intent substrate (R4). The Rust-owned equivalent of the TS
+// `friday-system-service` intent/control-lease/approval persistence
+// (`src/system/engine/friday-system-service.ts`). Nothing in production reads
+// or writes these tables — the TS `executeIntent` is already fenced fail-closed
+// (`TS_RUNTIME_SYSTEM_INTENT_RETIRED`, replacement
+// `rust_owned_system_intent_execution_entrypoint_required`), and this substrate
+// is the Rust home for that entrypoint, behind a flagged hub entrypoint with no
+// route/runtime caller. ALL FOUR tables are Hub-only: system-intent execution is
+// a Hub-coordinated, desktop-affecting surface that must never exist on a phone.
+//
+// * `system_intent_request` — the immutable INPUT record of an intent dispatch:
+//   the `action` (closed vocabulary of the 23 TS `FRIDAY_SYSTEM_INTENT_ACTIONS`,
+//   so a bogus action is unrepresentable even via raw SQL), the requesting actor
+//   (`actor_kind` ∈ the TS `FridaySystemControlLeaseOwnerKind` set + the gate's
+//   `owner`, so the gate Actor is faithfully recordable), classification flags
+//   (`mutating`, `risk` ∈ the closed `Risk` vocabulary), and the refs-only
+//   `target_ref` (NEVER raw url/clipboard/notification bodies — a coarse ref/id
+//   only). PK = `intent_id`.
+// * `system_intent_result` — the OUTCOME record keyed 1:1 by `intent_id` (PK ⇒
+//   one result per request; a re-dispatch is a new request). `status` is the
+//   closed TS `FRIDAY_SYSTEM_INTENT_STATUSES` vocabulary. A DEFERRED OS action
+//   (the unimplemented executor seam) records `unavailable` with a coarse
+//   `message` — NEVER a faked `completed`. `control_lease_id` / `gate_reason`
+//   are refs/labels. No body column.
+// * `system_control_lease` — the control-lease lifecycle store (mirrors the TS
+//   `FridaySystemControlLease`): `owner_id` + `owner_kind` exclusivity, optional
+//   `expires_at` (TTL), `revoked_at` + `revoked_reason` for release/expiry/panic.
+//   At most ONE active (non-revoked) lease is enforced by the typed acquire path
+//   (read-then-insert in one IMMEDIATE transaction) — the schema records the full
+//   history (a revoked lease row is retained as an audit trail), so the "active"
+//   notion is "the lease whose `revoked_at IS NULL`", not a row-deletion.
+// * `system_intent_approval_record` — the approval DECISION trail for a mutating
+//   intent (refs-only): the `intent_id` it bound to, the gate `decision`
+//   (`allow`/`deny`/`requires_approval`), the coarse `reason`, the derived
+//   `risk`, and whether `approval_required`. This is the durable evidence the
+//   gate fail-closed a mutating action; it carries NO key/secret/approval-mint
+//   material (the verified approval→Allow upgrade is a deferred seam, owned by
+//   `friday-storage::authorize_mutating_action`, not minted here).
+//
+// REFS-ONLY discipline (mirrors run_result / channel_event / provider_timeline):
+// NO raw url / clipboard text / notification body / app-output is stored.
+// `target_ref` / `control_lease_id` are refs/ids; `action` / `actor_kind` /
+// `status` / `risk` / `decision` are coarse closed-vocabulary labels; `message`
+// / `reason` / `gate_reason` are coarse human reasons (same shape as
+// `work_item.blocking_reason`).
+const DDL_SYSTEM_INTENT: &str = "
+CREATE TABLE system_intent_request (
+    intent_id    TEXT PRIMARY KEY CHECK(length(trim(intent_id)) > 0),
+    action       TEXT NOT NULL CHECK(action IN (
+        'snapshot',
+        'open',
+        'focus',
+        'arrange_windows',
+        'launch_app',
+        'close_app',
+        'open_url',
+        'open_project',
+        'search_file',
+        'handoff_to_browser',
+        'handoff_to_terminal',
+        'read_notification',
+        'notification_list',
+        'notification_act',
+        'triage_notifications',
+        'resume_task',
+        'recover_ui',
+        'clipboard_read',
+        'clipboard_write',
+        'request_control',
+        'release_control',
+        'approve',
+        'deny'
+    )),
+    actor_id     TEXT NOT NULL CHECK(length(trim(actor_id)) > 0),
+    actor_kind   TEXT NOT NULL CHECK(actor_kind IN (
+        'agent',
+        'api',
+        'remote',
+        'system',
+        'owner'
+    )),
+    target_ref   TEXT,
+    mutating     INTEGER NOT NULL CHECK(mutating IN (0, 1)),
+    risk         TEXT NOT NULL CHECK(risk IN (
+        'read_only',
+        'low',
+        'medium',
+        'high',
+        'critical'
+    )),
+    created_at   INTEGER NOT NULL
+);
+CREATE INDEX idx_system_intent_request_created
+    ON system_intent_request(created_at, intent_id);
+
+CREATE TABLE system_intent_result (
+    intent_id        TEXT PRIMARY KEY,
+    action           TEXT NOT NULL CHECK(action IN (
+        'snapshot',
+        'open',
+        'focus',
+        'arrange_windows',
+        'launch_app',
+        'close_app',
+        'open_url',
+        'open_project',
+        'search_file',
+        'handoff_to_browser',
+        'handoff_to_terminal',
+        'read_notification',
+        'notification_list',
+        'notification_act',
+        'triage_notifications',
+        'resume_task',
+        'recover_ui',
+        'clipboard_read',
+        'clipboard_write',
+        'request_control',
+        'release_control',
+        'approve',
+        'deny'
+    )),
+    status           TEXT NOT NULL CHECK(status IN (
+        'completed',
+        'blocked',
+        'failed',
+        'unavailable',
+        'queued'
+    )),
+    message          TEXT NOT NULL DEFAULT '',
+    control_lease_id TEXT,
+    gate_reason      TEXT,
+    created_at       INTEGER NOT NULL,
+    FOREIGN KEY(intent_id) REFERENCES system_intent_request(intent_id)
+);
+CREATE INDEX idx_system_intent_result_created
+    ON system_intent_result(created_at, intent_id);
+
+CREATE TABLE system_control_lease (
+    lease_id        TEXT PRIMARY KEY CHECK(length(trim(lease_id)) > 0),
+    owner_id        TEXT NOT NULL CHECK(length(trim(owner_id)) > 0),
+    owner_kind      TEXT NOT NULL CHECK(owner_kind IN (
+        'agent',
+        'api',
+        'remote',
+        'system',
+        'owner'
+    )),
+    reason          TEXT,
+    acquired_at     INTEGER NOT NULL,
+    expires_at      INTEGER,
+    revoked_at      INTEGER,
+    revoked_reason  TEXT
+);
+CREATE INDEX idx_system_control_lease_active
+    ON system_control_lease(revoked_at, acquired_at);
+-- At-most-ONE active (non-revoked) lease, DB-ENFORCED (mirrors the S8
+-- `idx_workflow_definition_one_published` partial-unique discipline). The unique
+-- key is the constant `1` restricted to non-revoked rows, so a SECOND active lease
+-- is unrepresentable even via raw SQL — the at-most-one-active invariant the
+-- acquire path upholds is now also a schema guarantee, while any number of REVOKED
+-- rows (the retained audit history) are unconstrained. The typed `Reused` path
+-- inserts NO row, so reuse never trips this; a foreign-owner acquire fails Busy
+-- before INSERT, so it never trips it either.
+CREATE UNIQUE INDEX idx_system_control_lease_one_active
+    ON system_control_lease((1)) WHERE revoked_at IS NULL;
+
+CREATE TABLE system_intent_approval_record (
+    record_id         TEXT PRIMARY KEY CHECK(length(trim(record_id)) > 0),
+    intent_id         TEXT NOT NULL,
+    action            TEXT NOT NULL CHECK(length(trim(action)) > 0),
+    decision          TEXT NOT NULL CHECK(decision IN (
+        'allow',
+        'deny',
+        'requires_approval'
+    )),
+    reason            TEXT NOT NULL DEFAULT '',
+    risk              TEXT NOT NULL CHECK(risk IN (
+        'read_only',
+        'low',
+        'medium',
+        'high',
+        'critical'
+    )),
+    approval_required INTEGER NOT NULL CHECK(approval_required IN (0, 1)),
+    created_at        INTEGER NOT NULL,
+    FOREIGN KEY(intent_id) REFERENCES system_intent_request(intent_id)
+);
+CREATE INDEX idx_system_intent_approval_intent
+    ON system_intent_approval_record(intent_id, created_at);";
 
 // --- PNS-001 provider-session fragments (Hub-only) --------------------------
 
@@ -1736,4 +1953,13 @@ fn m0024_workflow_scheduler_substrate(tx: &Transaction) -> rusqlite::Result<()> 
 // touched). Nothing in production reads or writes it (DARK).
 fn m0025_workflow_catalog(tx: &Transaction) -> rusqlite::Result<()> {
     tx.execute_batch(DDL_WORKFLOW_CATALOG)
+}
+
+// R4: additive Hub-only system-intent substrate (see `DDL_SYSTEM_INTENT`'s doc
+// comment) — the four tables the Rust system-intent entrypoint operates over.
+// Purely additive (CREATE TABLE + INDEX only, no existing table touched), so
+// every pre-existing v25 row and query is unaffected. Nothing in production
+// reads or writes these tables (DARK).
+fn m0026_system_intent_substrate(tx: &Transaction) -> rusqlite::Result<()> {
+    tx.execute_batch(DDL_SYSTEM_INTENT)
 }

--- a/rust-core/crates/friday-storage/src/system_intent.rs
+++ b/rust-core/crates/friday-storage/src/system_intent.rs
@@ -1,0 +1,1100 @@
+//! Rust-owned SYSTEM-INTENT persistence substrate (R4, DARK). Hub-only.
+//!
+//! The Rust home for the system-intent state the TS `friday-system-service`
+//! (`src/system/engine/friday-system-service.ts`) owns: the intent
+//! REQUEST/RESULT records, the control-lease lifecycle, and the approval
+//! decision trail. The TS `executeIntent` is already fenced fail-closed in live
+//! runtime (`TS_RUNTIME_SYSTEM_INTENT_RETIRED`, whose declared replacement is
+//! literally `rust_owned_system_intent_execution_entrypoint_required`); this
+//! module + [`crate::system_intent`]'s hub-layer counterpart
+//! (`friday-hub::system_intent`) are that entrypoint's storage + domain home.
+//!
+//! ## What this layer IS (and is NOT)
+//! This is the STORAGE substrate only: typed request/result/lease/approval rows
+//! over the m0026 Hub-only tables, plus the control-lease LIFECYCLE
+//! (acquire-with-owner-exclusivity, release, expiry-revoke, panic-revoke,
+//! read-active). It mirrors the TS lease semantics faithfully:
+//!
+//! * a mutating intent auto-acquires a lease for its actor; an actor that
+//!   already holds the active lease REUSES it; a DIFFERENT actor is refused
+//!   ([`LeaseAcquireError::Busy`], the TS `SYSTEM_CONTROL_BUSY` / HTTP 409);
+//! * a lease past its `expires_at` is REVOKED (`lease_expired`) on the next
+//!   normalize, exactly as the TS `normalizeActiveLease` does;
+//! * `release_control` / `recover_ui` / companion-panic revoke the active lease.
+//!
+//! The at-most-one-ACTIVE-lease invariant is enforced by a read-then-insert in a
+//! single IMMEDIATE transaction (the same discipline as
+//! `workflow_catalog`'s optimistic-concurrency write): a concurrent second
+//! acquire either reuses the same-owner lease or fails Busy. The schema retains a
+//! REVOKED lease row as audit history, so "active" means `revoked_at IS NULL`.
+//!
+//! ## Refs-only discipline
+//! NO raw url / clipboard text / notification body / app output is ever stored.
+//! `target_ref` / `control_lease_id` are refs/ids; `action` / `actor_kind` /
+//! `status` / `risk` / `decision` are coarse closed-vocabulary labels;
+//! `message` / `reason` / `gate_reason` are coarse human reasons (the shape of
+//! `work_item.blocking_reason`). The approval trail holds NO secret/key/mint
+//! material — the verified approval→Allow upgrade is a DEFERRED seam owned by
+//! `friday-storage::authorize_mutating_action`, not minted here.
+//!
+//! Truth label: STORAGE substrate + lifecycle API + tests only. DARK — nothing in
+//! production reads or writes these tables; no route, no runtime caller, no live
+//! TS flip. NOT a v1 GO.
+
+use crate::error::{Result, StorageError};
+use rusqlite::{params, Connection, OptionalExtension, Transaction, TransactionBehavior};
+
+// ─── closed vocabularies (faithful ports of the TS const arrays) ──────────────
+
+/// The 23 system-intent ACTIONS — a faithful port of the TS
+/// `FRIDAY_SYSTEM_INTENT_ACTIONS`. The string form is what the schema CHECK
+/// enumerates, so a row's `action` can only be one of these (a bogus action is
+/// unrepresentable even via raw SQL).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum IntentAction {
+    Snapshot,
+    Open,
+    Focus,
+    ArrangeWindows,
+    LaunchApp,
+    CloseApp,
+    OpenUrl,
+    OpenProject,
+    SearchFile,
+    HandoffToBrowser,
+    HandoffToTerminal,
+    ReadNotification,
+    NotificationList,
+    NotificationAct,
+    TriageNotifications,
+    ResumeTask,
+    RecoverUi,
+    ClipboardRead,
+    ClipboardWrite,
+    RequestControl,
+    ReleaseControl,
+    Approve,
+    Deny,
+}
+
+impl IntentAction {
+    /// The on-disk / on-wire string (matches the TS action vocabulary verbatim).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            IntentAction::Snapshot => "snapshot",
+            IntentAction::Open => "open",
+            IntentAction::Focus => "focus",
+            IntentAction::ArrangeWindows => "arrange_windows",
+            IntentAction::LaunchApp => "launch_app",
+            IntentAction::CloseApp => "close_app",
+            IntentAction::OpenUrl => "open_url",
+            IntentAction::OpenProject => "open_project",
+            IntentAction::SearchFile => "search_file",
+            IntentAction::HandoffToBrowser => "handoff_to_browser",
+            IntentAction::HandoffToTerminal => "handoff_to_terminal",
+            IntentAction::ReadNotification => "read_notification",
+            IntentAction::NotificationList => "notification_list",
+            IntentAction::NotificationAct => "notification_act",
+            IntentAction::TriageNotifications => "triage_notifications",
+            IntentAction::ResumeTask => "resume_task",
+            IntentAction::RecoverUi => "recover_ui",
+            IntentAction::ClipboardRead => "clipboard_read",
+            IntentAction::ClipboardWrite => "clipboard_write",
+            IntentAction::RequestControl => "request_control",
+            IntentAction::ReleaseControl => "release_control",
+            IntentAction::Approve => "approve",
+            IntentAction::Deny => "deny",
+        }
+    }
+
+    /// Parse an action from its string form, fail-closed on an unknown value.
+    pub fn parse(s: &str) -> Result<Self> {
+        let action = match s {
+            "snapshot" => IntentAction::Snapshot,
+            "open" => IntentAction::Open,
+            "focus" => IntentAction::Focus,
+            "arrange_windows" => IntentAction::ArrangeWindows,
+            "launch_app" => IntentAction::LaunchApp,
+            "close_app" => IntentAction::CloseApp,
+            "open_url" => IntentAction::OpenUrl,
+            "open_project" => IntentAction::OpenProject,
+            "search_file" => IntentAction::SearchFile,
+            "handoff_to_browser" => IntentAction::HandoffToBrowser,
+            "handoff_to_terminal" => IntentAction::HandoffToTerminal,
+            "read_notification" => IntentAction::ReadNotification,
+            "notification_list" => IntentAction::NotificationList,
+            "notification_act" => IntentAction::NotificationAct,
+            "triage_notifications" => IntentAction::TriageNotifications,
+            "resume_task" => IntentAction::ResumeTask,
+            "recover_ui" => IntentAction::RecoverUi,
+            "clipboard_read" => IntentAction::ClipboardRead,
+            "clipboard_write" => IntentAction::ClipboardWrite,
+            "request_control" => IntentAction::RequestControl,
+            "release_control" => IntentAction::ReleaseControl,
+            "approve" => IntentAction::Approve,
+            "deny" => IntentAction::Deny,
+            other => {
+                return Err(StorageError::Unsupported(format!(
+                    "unknown system intent action '{other}'"
+                )))
+            }
+        };
+        Ok(action)
+    }
+}
+
+/// The system-intent RESULT statuses — a faithful port of the TS
+/// `FRIDAY_SYSTEM_INTENT_STATUSES`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum IntentStatus {
+    Completed,
+    Blocked,
+    Failed,
+    Unavailable,
+    Queued,
+}
+
+impl IntentStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            IntentStatus::Completed => "completed",
+            IntentStatus::Blocked => "blocked",
+            IntentStatus::Failed => "failed",
+            IntentStatus::Unavailable => "unavailable",
+            IntentStatus::Queued => "queued",
+        }
+    }
+
+    pub fn parse(s: &str) -> Result<Self> {
+        let status = match s {
+            "completed" => IntentStatus::Completed,
+            "blocked" => IntentStatus::Blocked,
+            "failed" => IntentStatus::Failed,
+            "unavailable" => IntentStatus::Unavailable,
+            "queued" => IntentStatus::Queued,
+            other => {
+                return Err(StorageError::Unsupported(format!(
+                    "unknown system intent status '{other}'"
+                )))
+            }
+        };
+        Ok(status)
+    }
+}
+
+/// The control-lease OWNER kind — a faithful port of the TS
+/// `FridaySystemControlLeaseOwnerKind` (`agent`/`api`/`remote`/`system`),
+/// extended with `owner` so the gate's `ActorKind::Owner` is recordable on a
+/// request row. The schema CHECK enumerates exactly this set.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OwnerKind {
+    Agent,
+    Api,
+    Remote,
+    System,
+    Owner,
+}
+
+impl OwnerKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            OwnerKind::Agent => "agent",
+            OwnerKind::Api => "api",
+            OwnerKind::Remote => "remote",
+            OwnerKind::System => "system",
+            OwnerKind::Owner => "owner",
+        }
+    }
+
+    pub fn parse(s: &str) -> Result<Self> {
+        let kind = match s {
+            "agent" => OwnerKind::Agent,
+            "api" => OwnerKind::Api,
+            "remote" => OwnerKind::Remote,
+            "system" => OwnerKind::System,
+            "owner" => OwnerKind::Owner,
+            other => {
+                return Err(StorageError::Unsupported(format!(
+                    "unknown control-lease owner kind '{other}'"
+                )))
+            }
+        };
+        Ok(kind)
+    }
+}
+
+/// The risk LABEL stored on a request/approval row — the same closed vocabulary
+/// as `friday_core::tool_policy::Risk::as_str`. Stored as a string so the
+/// substrate has no compile dependency on the gate's enum shape; the hub layer
+/// derives it from the gate.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RiskLabel {
+    ReadOnly,
+    Low,
+    Medium,
+    High,
+    Critical,
+}
+
+impl RiskLabel {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            RiskLabel::ReadOnly => "read_only",
+            RiskLabel::Low => "low",
+            RiskLabel::Medium => "medium",
+            RiskLabel::High => "high",
+            RiskLabel::Critical => "critical",
+        }
+    }
+}
+
+/// The gate decision LABEL stored on an approval record — `allow`/`deny`/
+/// `requires_approval`, mirroring `friday_core::gate::GateDecision::as_str`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DecisionLabel {
+    Allow,
+    Deny,
+    RequiresApproval,
+}
+
+impl DecisionLabel {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            DecisionLabel::Allow => "allow",
+            DecisionLabel::Deny => "deny",
+            DecisionLabel::RequiresApproval => "requires_approval",
+        }
+    }
+}
+
+// ─── intent request + result records ──────────────────────────────────────────
+
+/// The immutable INPUT record of an intent dispatch (refs-only).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct IntentRequest {
+    pub intent_id: String,
+    pub action: IntentAction,
+    pub actor_id: String,
+    pub actor_kind: OwnerKind,
+    /// A coarse REF/id of the target (e.g. an app bundle id, a project path ref,
+    /// a notification id) — NEVER a raw url/clipboard/notification BODY.
+    pub target_ref: Option<String>,
+    pub mutating: bool,
+    pub risk: RiskLabel,
+    pub created_at: i64,
+}
+
+/// The OUTCOME record keyed 1:1 by `intent_id` (refs-only).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct IntentResultRecord {
+    pub intent_id: String,
+    pub action: IntentAction,
+    pub status: IntentStatus,
+    /// A coarse human-readable outcome message (e.g. the lease-busy reason, or
+    /// the deferred-executor `rust_system_action_execution_unimplemented`
+    /// marker). NEVER a raw body.
+    pub message: String,
+    pub control_lease_id: Option<String>,
+    /// The gate's coarse reason when the result was a gate BLOCK (e.g.
+    /// `canonical_approval_required` / `agent_cannot_execute_reserved_approval_action`).
+    pub gate_reason: Option<String>,
+    pub created_at: i64,
+}
+
+/// Persist an intent REQUEST record. Immutable: a duplicate `intent_id` is a
+/// fail-closed PK violation (never silently overwritten).
+pub fn insert_intent_request(conn: &Connection, req: &IntentRequest) -> Result<()> {
+    conn.execute(
+        "INSERT INTO system_intent_request
+            (intent_id, action, actor_id, actor_kind, target_ref, mutating, risk, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        params![
+            req.intent_id,
+            req.action.as_str(),
+            req.actor_id,
+            req.actor_kind.as_str(),
+            req.target_ref,
+            req.mutating as i64,
+            req.risk.as_str(),
+            req.created_at,
+        ],
+    )?;
+    Ok(())
+}
+
+/// Persist an intent RESULT record (1:1 with its request). Immutable: a duplicate
+/// `intent_id` is a fail-closed PK violation. The FK to `system_intent_request`
+/// means a result can only be recorded for a request that exists.
+pub fn insert_intent_result(conn: &Connection, result: &IntentResultRecord) -> Result<()> {
+    conn.execute(
+        "INSERT INTO system_intent_result
+            (intent_id, action, status, message, control_lease_id, gate_reason, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        params![
+            result.intent_id,
+            result.action.as_str(),
+            result.status.as_str(),
+            result.message,
+            result.control_lease_id,
+            result.gate_reason,
+            result.created_at,
+        ],
+    )?;
+    Ok(())
+}
+
+/// Read an intent RESULT by `intent_id`. `None` if no result was recorded.
+pub fn get_intent_result(conn: &Connection, intent_id: &str) -> Result<Option<IntentResultRecord>> {
+    let row = conn
+        .query_row(
+            "SELECT intent_id, action, status, message, control_lease_id, gate_reason, created_at
+             FROM system_intent_result WHERE intent_id = ?1",
+            [intent_id],
+            |r| {
+                let action: String = r.get(1)?;
+                let status: String = r.get(2)?;
+                Ok((
+                    r.get::<_, String>(0)?,
+                    action,
+                    status,
+                    r.get::<_, String>(3)?,
+                    r.get::<_, Option<String>>(4)?,
+                    r.get::<_, Option<String>>(5)?,
+                    r.get::<_, i64>(6)?,
+                ))
+            },
+        )
+        .optional()?;
+    match row {
+        None => Ok(None),
+        Some((intent_id, action, status, message, control_lease_id, gate_reason, created_at)) => {
+            Ok(Some(IntentResultRecord {
+                intent_id,
+                action: IntentAction::parse(&action)?,
+                status: IntentStatus::parse(&status)?,
+                message,
+                control_lease_id,
+                gate_reason,
+                created_at,
+            }))
+        }
+    }
+}
+
+// ─── approval-decision trail ──────────────────────────────────────────────────
+
+/// The approval DECISION record for a mutating intent (refs-only evidence the
+/// gate fail-closed or allowed a mutating action). Holds NO key/secret/mint
+/// material.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ApprovalRecord {
+    pub record_id: String,
+    pub intent_id: String,
+    pub action: IntentAction,
+    pub decision: DecisionLabel,
+    pub reason: String,
+    pub risk: RiskLabel,
+    pub approval_required: bool,
+    pub created_at: i64,
+}
+
+/// Persist an approval-decision record. The FK to `system_intent_request` means a
+/// decision can only be recorded against a request that exists.
+pub fn insert_approval_record(conn: &Connection, record: &ApprovalRecord) -> Result<()> {
+    conn.execute(
+        "INSERT INTO system_intent_approval_record
+            (record_id, intent_id, action, decision, reason, risk, approval_required, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        params![
+            record.record_id,
+            record.intent_id,
+            record.action.as_str(),
+            record.decision.as_str(),
+            record.reason,
+            record.risk.as_str(),
+            record.approval_required as i64,
+            record.created_at,
+        ],
+    )?;
+    Ok(())
+}
+
+/// List the approval-decision records for an intent (oldest first).
+pub fn list_approval_records(conn: &Connection, intent_id: &str) -> Result<Vec<ApprovalRecord>> {
+    let mut stmt = conn.prepare(
+        "SELECT record_id, intent_id, action, decision, reason, risk, approval_required, created_at
+         FROM system_intent_approval_record WHERE intent_id = ?1
+         ORDER BY created_at ASC, record_id ASC",
+    )?;
+    let rows = stmt.query_map([intent_id], |r| {
+        Ok((
+            r.get::<_, String>(0)?,
+            r.get::<_, String>(1)?,
+            r.get::<_, String>(2)?,
+            r.get::<_, String>(3)?,
+            r.get::<_, String>(4)?,
+            r.get::<_, String>(5)?,
+            r.get::<_, i64>(6)?,
+            r.get::<_, i64>(7)?,
+        ))
+    })?;
+    let mut out = Vec::new();
+    for row in rows {
+        let (record_id, intent_id, action, decision, reason, risk, approval_required, created_at) =
+            row?;
+        out.push(ApprovalRecord {
+            record_id,
+            intent_id,
+            action: IntentAction::parse(&action)?,
+            decision: parse_decision(&decision)?,
+            reason,
+            risk: parse_risk(&risk)?,
+            approval_required: approval_required != 0,
+            created_at,
+        });
+    }
+    Ok(out)
+}
+
+fn parse_decision(s: &str) -> Result<DecisionLabel> {
+    match s {
+        "allow" => Ok(DecisionLabel::Allow),
+        "deny" => Ok(DecisionLabel::Deny),
+        "requires_approval" => Ok(DecisionLabel::RequiresApproval),
+        other => Err(StorageError::Unsupported(format!(
+            "unknown approval decision '{other}'"
+        ))),
+    }
+}
+
+fn parse_risk(s: &str) -> Result<RiskLabel> {
+    match s {
+        "read_only" => Ok(RiskLabel::ReadOnly),
+        "low" => Ok(RiskLabel::Low),
+        "medium" => Ok(RiskLabel::Medium),
+        "high" => Ok(RiskLabel::High),
+        "critical" => Ok(RiskLabel::Critical),
+        other => Err(StorageError::Unsupported(format!(
+            "unknown risk label '{other}'"
+        ))),
+    }
+}
+
+// ─── control-lease lifecycle ──────────────────────────────────────────────────
+
+/// A control lease (mirrors the TS `FridaySystemControlLease`). A REVOKED lease
+/// (`revoked_at.is_some()`) is retained as audit history; the ACTIVE lease (if
+/// any) is the one with `revoked_at == None` and a non-elapsed `expires_at`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ControlLease {
+    pub lease_id: String,
+    pub owner_id: String,
+    pub owner_kind: OwnerKind,
+    pub reason: Option<String>,
+    pub acquired_at: i64,
+    pub expires_at: Option<i64>,
+    pub revoked_at: Option<i64>,
+    pub revoked_reason: Option<String>,
+}
+
+impl ControlLease {
+    /// True if the lease is past its TTL at `now_ms` (an absent `expires_at`
+    /// never expires — matches the TS `isLeaseExpired`).
+    pub fn is_expired(&self, now_ms: i64) -> bool {
+        matches!(self.expires_at, Some(exp) if exp <= now_ms)
+    }
+}
+
+/// The outcome of [`acquire_control_lease`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LeaseAcquireOutcome {
+    /// A fresh lease was minted for the requesting actor.
+    Acquired(ControlLease),
+    /// The requesting actor already held the active lease — it is REUSED (no new
+    /// row), matching the TS `current.ownerId == actorId && ownerKind == actorKind`
+    /// reuse path.
+    Reused(ControlLease),
+}
+
+/// Why a control-lease acquire was refused. (`StorageError` is neither `Clone`
+/// nor `Eq`, so this enum carries only `Debug` — tests `match` on it.)
+#[derive(Debug)]
+pub enum LeaseAcquireError {
+    /// The active lease is held by a DIFFERENT owner (the TS `SYSTEM_CONTROL_BUSY`
+    /// / HTTP 409). Carries the holder's owner kind+id (the TS reason string
+    /// shape `"<ownerKind>:<ownerId>"`).
+    Busy {
+        owner_kind: OwnerKind,
+        owner_id: String,
+    },
+    /// A storage-layer failure (surfaced fail-closed, never swallowed).
+    Storage(StorageError),
+}
+
+impl From<StorageError> for LeaseAcquireError {
+    fn from(e: StorageError) -> Self {
+        LeaseAcquireError::Storage(e)
+    }
+}
+
+impl std::fmt::Display for LeaseAcquireError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LeaseAcquireError::Busy {
+                owner_kind,
+                owner_id,
+            } => write!(
+                f,
+                "control lease is currently held by {}:{}",
+                owner_kind.as_str(),
+                owner_id
+            ),
+            LeaseAcquireError::Storage(e) => write!(f, "storage error: {e}"),
+        }
+    }
+}
+
+/// What [`acquire_control_lease`] needs to mint a lease.
+#[derive(Clone, Debug)]
+pub struct NewControlLease {
+    pub lease_id: String,
+    pub owner_id: String,
+    pub owner_kind: OwnerKind,
+    pub reason: Option<String>,
+    /// TTL in ms; `Some(ttl)` makes `expires_at = now_ms + ttl`. `None` is a
+    /// never-expiring lease (the TS default TTL is applied by the hub layer, so
+    /// this stays explicit at the storage boundary).
+    pub ttl_ms: Option<i64>,
+}
+
+/// Read the currently-active control lease (NOT revoked, NOT expired at `now_ms`),
+/// REVOKING it in place if it is expired (mirrors the TS `normalizeActiveLease`).
+/// Returns `None` when no live lease exists. Runs in one transaction so the
+/// expiry-revoke is atomic with the read.
+pub fn normalize_active_lease(conn: &Connection, now_ms: i64) -> Result<Option<ControlLease>> {
+    let tx = conn.unchecked_transaction()?;
+    let active = read_active_lease_tx(&tx)?;
+    let result = match active {
+        Some(lease) if lease.is_expired(now_ms) => {
+            revoke_lease_tx(&tx, &lease.lease_id, now_ms, "lease_expired")?;
+            None
+        }
+        other => other,
+    };
+    tx.commit()?;
+    Ok(result)
+}
+
+/// Acquire (or reuse) the control lease for an actor, fail-closed.
+///
+/// Faithful to the TS `acquireExplicitControlLease` / `ensureControlLease`:
+/// * an EXPIRED active lease is revoked first (so a new owner can take over);
+/// * if the active lease is held by the SAME `(owner_kind, owner_id)`, it is
+///   REUSED ([`LeaseAcquireOutcome::Reused`]) — never a second row;
+/// * if held by a DIFFERENT owner, the acquire is refused
+///   ([`LeaseAcquireError::Busy`], the TS 409);
+/// * otherwise a fresh lease is minted ([`LeaseAcquireOutcome::Acquired`]).
+///
+/// The read-then-insert runs in one IMMEDIATE transaction, so two concurrent
+/// acquires cannot both mint a lease — the loser sees the winner's row and either
+/// reuses (same owner) or fails Busy.
+pub fn acquire_control_lease(
+    conn: &Connection,
+    new_lease: &NewControlLease,
+    now_ms: i64,
+) -> std::result::Result<LeaseAcquireOutcome, LeaseAcquireError> {
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)
+        .map_err(|e| LeaseAcquireError::Storage(StorageError::from(e)))?;
+
+    let current = read_active_lease_tx(&tx).map_err(LeaseAcquireError::Storage)?;
+    let current = match current {
+        Some(lease) if lease.is_expired(now_ms) => {
+            revoke_lease_tx(&tx, &lease.lease_id, now_ms, "lease_expired")
+                .map_err(LeaseAcquireError::Storage)?;
+            None
+        }
+        other => other,
+    };
+
+    if let Some(lease) = current {
+        if lease.owner_id == new_lease.owner_id && lease.owner_kind == new_lease.owner_kind {
+            tx.commit()
+                .map_err(|e| LeaseAcquireError::Storage(StorageError::from(e)))?;
+            return Ok(LeaseAcquireOutcome::Reused(lease));
+        }
+        // A DIFFERENT owner holds the lease — refuse (do NOT commit any change).
+        return Err(LeaseAcquireError::Busy {
+            owner_kind: lease.owner_kind,
+            owner_id: lease.owner_id,
+        });
+    }
+
+    let expires_at = new_lease.ttl_ms.map(|ttl| now_ms + ttl);
+    let minted = ControlLease {
+        lease_id: new_lease.lease_id.clone(),
+        owner_id: new_lease.owner_id.clone(),
+        owner_kind: new_lease.owner_kind,
+        reason: new_lease.reason.clone(),
+        acquired_at: now_ms,
+        expires_at,
+        revoked_at: None,
+        revoked_reason: None,
+    };
+    tx.execute(
+        "INSERT INTO system_control_lease
+            (lease_id, owner_id, owner_kind, reason, acquired_at, expires_at,
+             revoked_at, revoked_reason)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, NULL, NULL)",
+        params![
+            minted.lease_id,
+            minted.owner_id,
+            minted.owner_kind.as_str(),
+            minted.reason,
+            minted.acquired_at,
+            minted.expires_at,
+        ],
+    )
+    .map_err(|e| LeaseAcquireError::Storage(StorageError::from(e)))?;
+    tx.commit()
+        .map_err(|e| LeaseAcquireError::Storage(StorageError::from(e)))?;
+    Ok(LeaseAcquireOutcome::Acquired(minted))
+}
+
+/// Revoke the currently-active lease (release_control / recover_ui / panic). A
+/// no-op returning `Ok(None)` when no active lease exists (the TS
+/// `release_control` "No active control lease" path). Returns the revoked lease.
+pub fn revoke_active_lease(
+    conn: &Connection,
+    now_ms: i64,
+    reason: &str,
+) -> Result<Option<ControlLease>> {
+    let tx = conn.unchecked_transaction()?;
+    let active = read_active_lease_tx(&tx)?;
+    let result = match active {
+        Some(lease) => {
+            revoke_lease_tx(&tx, &lease.lease_id, now_ms, reason)?;
+            Some(ControlLease {
+                revoked_at: Some(now_ms),
+                revoked_reason: Some(reason.to_string()),
+                ..lease
+            })
+        }
+        None => None,
+    };
+    tx.commit()?;
+    Ok(result)
+}
+
+/// Read a lease by id (active or revoked), for audit/diagnostics.
+pub fn get_lease(conn: &Connection, lease_id: &str) -> Result<Option<ControlLease>> {
+    let row = conn
+        .query_row(
+            "SELECT lease_id, owner_id, owner_kind, reason, acquired_at, expires_at,
+                    revoked_at, revoked_reason
+             FROM system_control_lease WHERE lease_id = ?1",
+            [lease_id],
+            map_lease_row,
+        )
+        .optional()?;
+    match row {
+        None => Ok(None),
+        Some((
+            id,
+            owner_id,
+            owner_kind,
+            reason,
+            acquired_at,
+            expires_at,
+            revoked_at,
+            revoked_reason,
+        )) => Ok(Some(ControlLease {
+            lease_id: id,
+            owner_id,
+            owner_kind: OwnerKind::parse(&owner_kind)?,
+            reason,
+            acquired_at,
+            expires_at,
+            revoked_at,
+            revoked_reason,
+        })),
+    }
+}
+
+#[allow(clippy::type_complexity)]
+fn map_lease_row(
+    r: &rusqlite::Row<'_>,
+) -> rusqlite::Result<(
+    String,
+    String,
+    String,
+    Option<String>,
+    i64,
+    Option<i64>,
+    Option<i64>,
+    Option<String>,
+)> {
+    Ok((
+        r.get(0)?,
+        r.get(1)?,
+        r.get(2)?,
+        r.get(3)?,
+        r.get(4)?,
+        r.get(5)?,
+        r.get(6)?,
+        r.get(7)?,
+    ))
+}
+
+/// Read the at-most-one non-revoked lease inside a transaction. The active-lease
+/// invariant is upheld by the acquire path (this returns the single
+/// `revoked_at IS NULL` row, or `None`). Two non-revoked rows would be a substrate
+/// bug — we return the most recently acquired and the acquire path never mints a
+/// second concurrent active row.
+fn read_active_lease_tx(tx: &rusqlite::Transaction<'_>) -> Result<Option<ControlLease>> {
+    let row = tx
+        .query_row(
+            "SELECT lease_id, owner_id, owner_kind, reason, acquired_at, expires_at,
+                    revoked_at, revoked_reason
+             FROM system_control_lease
+             WHERE revoked_at IS NULL
+             ORDER BY acquired_at DESC, lease_id DESC
+             LIMIT 1",
+            [],
+            map_lease_row,
+        )
+        .optional()?;
+    match row {
+        None => Ok(None),
+        Some((
+            id,
+            owner_id,
+            owner_kind,
+            reason,
+            acquired_at,
+            expires_at,
+            revoked_at,
+            revoked_reason,
+        )) => Ok(Some(ControlLease {
+            lease_id: id,
+            owner_id,
+            owner_kind: OwnerKind::parse(&owner_kind)?,
+            reason,
+            acquired_at,
+            expires_at,
+            revoked_at,
+            revoked_reason,
+        })),
+    }
+}
+
+fn revoke_lease_tx(
+    tx: &rusqlite::Transaction<'_>,
+    lease_id: &str,
+    now_ms: i64,
+    reason: &str,
+) -> Result<()> {
+    tx.execute(
+        "UPDATE system_control_lease
+            SET revoked_at = ?2, revoked_reason = ?3
+            WHERE lease_id = ?1 AND revoked_at IS NULL",
+        params![lease_id, now_ms, reason],
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Db;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static C: AtomicU64 = AtomicU64::new(0);
+    fn tmp(tag: &str) -> String {
+        std::env::temp_dir()
+            .join(format!(
+                "friday-system-intent-{}-{}-{}.sqlite",
+                std::process::id(),
+                tag,
+                C.fetch_add(1, Ordering::Relaxed)
+            ))
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    fn req(intent_id: &str, action: IntentAction, owner: &str, kind: OwnerKind) -> IntentRequest {
+        IntentRequest {
+            intent_id: intent_id.to_string(),
+            action,
+            actor_id: owner.to_string(),
+            actor_kind: kind,
+            target_ref: None,
+            mutating: true,
+            risk: RiskLabel::Medium,
+            created_at: 100,
+        }
+    }
+
+    #[test]
+    fn intent_request_then_result_round_trips() {
+        let db = Db::open_hub(&tmp("req-result")).unwrap();
+        let request = req("i1", IntentAction::LaunchApp, "agent-1", OwnerKind::Agent);
+        insert_intent_request(db.conn(), &request).unwrap();
+
+        let result = IntentResultRecord {
+            intent_id: "i1".to_string(),
+            action: IntentAction::LaunchApp,
+            status: IntentStatus::Unavailable,
+            message: "rust_system_action_execution_unimplemented".to_string(),
+            control_lease_id: Some("lease-1".to_string()),
+            gate_reason: None,
+            created_at: 110,
+        };
+        insert_intent_result(db.conn(), &result).unwrap();
+
+        assert_eq!(get_intent_result(db.conn(), "i1").unwrap(), Some(result));
+        assert!(get_intent_result(db.conn(), "nope").unwrap().is_none());
+    }
+
+    #[test]
+    fn duplicate_intent_request_id_fails_closed() {
+        let db = Db::open_hub(&tmp("dup-req")).unwrap();
+        let request = req("i1", IntentAction::Focus, "api", OwnerKind::Api);
+        insert_intent_request(db.conn(), &request).unwrap();
+        // A second insert with the same intent_id is a fail-closed PK violation.
+        assert!(insert_intent_request(db.conn(), &request).is_err());
+    }
+
+    #[test]
+    fn result_without_request_fails_closed_on_fk() {
+        let db = Db::open_hub(&tmp("fk-result")).unwrap();
+        // No request row for "ghost" -> the FK refuses an orphan result.
+        let result = IntentResultRecord {
+            intent_id: "ghost".to_string(),
+            action: IntentAction::Snapshot,
+            status: IntentStatus::Completed,
+            message: String::new(),
+            control_lease_id: None,
+            gate_reason: None,
+            created_at: 1,
+        };
+        assert!(insert_intent_result(db.conn(), &result).is_err());
+    }
+
+    #[test]
+    fn invalid_action_string_parse_fails_closed() {
+        assert!(IntentAction::parse("not_an_action").is_err());
+        assert!(IntentStatus::parse("not_a_status").is_err());
+        assert!(OwnerKind::parse("not_a_kind").is_err());
+        // Round-trip every action through parse(as_str()).
+        for a in [
+            IntentAction::Snapshot,
+            IntentAction::RequestControl,
+            IntentAction::ReleaseControl,
+            IntentAction::Approve,
+            IntentAction::Deny,
+            IntentAction::ClipboardRead,
+        ] {
+            assert_eq!(IntentAction::parse(a.as_str()).unwrap(), a);
+        }
+    }
+
+    #[test]
+    fn acquire_then_same_owner_reuses_not_remints() {
+        let db = Db::open_hub(&tmp("lease-reuse")).unwrap();
+        let nl = NewControlLease {
+            lease_id: "L1".to_string(),
+            owner_id: "agent-1".to_string(),
+            owner_kind: OwnerKind::Agent,
+            reason: Some("auto:launch_app".to_string()),
+            ttl_ms: Some(1000),
+        };
+        match acquire_control_lease(db.conn(), &nl, 100).unwrap() {
+            LeaseAcquireOutcome::Acquired(l) => {
+                assert_eq!(l.lease_id, "L1");
+                assert_eq!(l.expires_at, Some(1100));
+            }
+            other => panic!("expected Acquired, got {other:?}"),
+        }
+        // The SAME owner acquiring again REUSES the existing lease (no new row).
+        let nl2 = NewControlLease {
+            lease_id: "L2-would-be-new".to_string(),
+            ..nl.clone()
+        };
+        match acquire_control_lease(db.conn(), &nl2, 200).unwrap() {
+            LeaseAcquireOutcome::Reused(l) => assert_eq!(l.lease_id, "L1"),
+            other => panic!("expected Reused, got {other:?}"),
+        }
+        assert_eq!(
+            db.count("system_control_lease").unwrap(),
+            1,
+            "no second row minted"
+        );
+    }
+
+    #[test]
+    fn different_owner_is_refused_busy() {
+        let db = Db::open_hub(&tmp("lease-busy")).unwrap();
+        let agent = NewControlLease {
+            lease_id: "L-agent".to_string(),
+            owner_id: "agent-1".to_string(),
+            owner_kind: OwnerKind::Agent,
+            reason: None,
+            ttl_ms: Some(10_000),
+        };
+        acquire_control_lease(db.conn(), &agent, 100).unwrap();
+
+        let other = NewControlLease {
+            lease_id: "L-api".to_string(),
+            owner_id: "api-7".to_string(),
+            owner_kind: OwnerKind::Api,
+            reason: None,
+            ttl_ms: Some(10_000),
+        };
+        match acquire_control_lease(db.conn(), &other, 200) {
+            Err(LeaseAcquireError::Busy {
+                owner_kind,
+                owner_id,
+            }) => {
+                assert_eq!(owner_kind, OwnerKind::Agent);
+                assert_eq!(owner_id, "agent-1");
+            }
+            other => panic!("expected Busy, got {other:?}"),
+        }
+        // The busy acquire minted NO row.
+        assert_eq!(db.count("system_control_lease").unwrap(), 1);
+    }
+
+    #[test]
+    fn expired_lease_is_revoked_then_new_owner_can_acquire() {
+        let db = Db::open_hub(&tmp("lease-expire")).unwrap();
+        let agent = NewControlLease {
+            lease_id: "L-agent".to_string(),
+            owner_id: "agent-1".to_string(),
+            owner_kind: OwnerKind::Agent,
+            reason: None,
+            ttl_ms: Some(50),
+        };
+        acquire_control_lease(db.conn(), &agent, 100).unwrap(); // expires at 150
+
+        // normalize_active_lease at t=200 finds it expired -> revokes it, returns None.
+        assert!(normalize_active_lease(db.conn(), 200).unwrap().is_none());
+        let revoked = get_lease(db.conn(), "L-agent").unwrap().unwrap();
+        assert_eq!(revoked.revoked_at, Some(200));
+        assert_eq!(revoked.revoked_reason.as_deref(), Some("lease_expired"));
+
+        // A DIFFERENT owner can now acquire (the prior lease expired).
+        let other = NewControlLease {
+            lease_id: "L-api".to_string(),
+            owner_id: "api-7".to_string(),
+            owner_kind: OwnerKind::Api,
+            reason: None,
+            ttl_ms: Some(1000),
+        };
+        match acquire_control_lease(db.conn(), &other, 250).unwrap() {
+            LeaseAcquireOutcome::Acquired(l) => assert_eq!(l.lease_id, "L-api"),
+            other => panic!("expected Acquired, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn revoke_active_lease_releases_and_is_noop_when_none() {
+        let db = Db::open_hub(&tmp("lease-release")).unwrap();
+        // No active lease -> Ok(None) (TS "No active control lease").
+        assert!(revoke_active_lease(db.conn(), 10, "released_by_request")
+            .unwrap()
+            .is_none());
+
+        let nl = NewControlLease {
+            lease_id: "L1".to_string(),
+            owner_id: "agent-1".to_string(),
+            owner_kind: OwnerKind::Agent,
+            reason: None,
+            ttl_ms: Some(10_000),
+        };
+        acquire_control_lease(db.conn(), &nl, 100).unwrap();
+        let released = revoke_active_lease(db.conn(), 300, "released_by_request")
+            .unwrap()
+            .unwrap();
+        assert_eq!(released.lease_id, "L1");
+        assert_eq!(
+            released.revoked_reason.as_deref(),
+            Some("released_by_request")
+        );
+        // After release there is no active lease.
+        assert!(normalize_active_lease(db.conn(), 400).unwrap().is_none());
+    }
+
+    #[test]
+    fn second_active_lease_is_db_rejected_even_via_raw_insert() {
+        // Defense-in-depth: the at-most-one-active invariant is DB-ENFORCED by the
+        // partial unique index `idx_system_control_lease_one_active`. A second
+        // non-revoked row is rejected even by a hand-built raw INSERT that bypasses
+        // the typed acquire path.
+        let db = Db::open_hub(&tmp("one-active-guard")).unwrap();
+        let nl = NewControlLease {
+            lease_id: "L1".to_string(),
+            owner_id: "agent-1".to_string(),
+            owner_kind: OwnerKind::Agent,
+            reason: None,
+            ttl_ms: Some(10_000),
+        };
+        acquire_control_lease(db.conn(), &nl, 100).unwrap();
+        // A raw second ACTIVE (revoked_at NULL) lease is refused by the index.
+        let raw = db.conn().execute(
+            "INSERT INTO system_control_lease
+                (lease_id, owner_id, owner_kind, reason, acquired_at, expires_at,
+                 revoked_at, revoked_reason)
+             VALUES ('L2', 'attacker', 'api', NULL, 200, NULL, NULL, NULL)",
+            [],
+        );
+        assert!(raw.is_err(), "a second active lease must be DB-rejected");
+        // A REVOKED row, by contrast, is allowed (audit history is unconstrained).
+        db.conn()
+            .execute(
+                "INSERT INTO system_control_lease
+                    (lease_id, owner_id, owner_kind, reason, acquired_at, expires_at,
+                     revoked_at, revoked_reason)
+                 VALUES ('L3-revoked', 'agent-1', 'agent', NULL, 90, NULL, 95, 'old')",
+                [],
+            )
+            .unwrap();
+        assert_eq!(db.count("system_control_lease").unwrap(), 2);
+    }
+
+    #[test]
+    fn approval_record_trail_round_trips() {
+        let db = Db::open_hub(&tmp("approval")).unwrap();
+        let request = req("i1", IntentAction::CloseApp, "agent-1", OwnerKind::Agent);
+        insert_intent_request(db.conn(), &request).unwrap();
+
+        let record = ApprovalRecord {
+            record_id: "ar1".to_string(),
+            intent_id: "i1".to_string(),
+            action: IntentAction::CloseApp,
+            decision: DecisionLabel::RequiresApproval,
+            reason: "canonical_approval_required".to_string(),
+            risk: RiskLabel::High,
+            approval_required: true,
+            created_at: 120,
+        };
+        insert_approval_record(db.conn(), &record).unwrap();
+        let trail = list_approval_records(db.conn(), "i1").unwrap();
+        assert_eq!(trail, vec![record]);
+    }
+
+    #[test]
+    fn approval_record_without_request_fails_closed_on_fk() {
+        let db = Db::open_hub(&tmp("approval-fk")).unwrap();
+        let record = ApprovalRecord {
+            record_id: "ar1".to_string(),
+            intent_id: "ghost".to_string(),
+            action: IntentAction::CloseApp,
+            decision: DecisionLabel::Deny,
+            reason: "x".to_string(),
+            risk: RiskLabel::High,
+            approval_required: false,
+            created_at: 1,
+        };
+        assert!(insert_approval_record(db.conn(), &record).is_err());
+    }
+}

--- a/rust-core/crates/friday-storage/tests/migration.rs
+++ b/rust-core/crates/friday-storage/tests/migration.rs
@@ -300,6 +300,103 @@ fn forward_migration_v22_to_v23_backfills_conversation_axes_to_null() {
 }
 
 #[test]
+fn forward_migration_v25_to_v26_adds_system_intent_tables_and_preserves_v25_rows() {
+    // R4 additive migration v26: four NEW Hub-only system-intent tables
+    // (`system_intent_request`, `system_intent_result`, `system_control_lease`,
+    // `system_intent_approval_record`). This is the NEW-TABLE migration pattern
+    // (like m0015 run_result / m0005 agent_run), NOT an ALTER. A fresh v25 DB must
+    // NOT have any of the tables; a v25 row seeded in a pre-existing table must
+    // survive the forward migration untouched; and after reopen the schema reaches
+    // the current max version with all four new tables present + usable.
+    use friday_storage::system_intent::{
+        acquire_control_lease, get_intent_result, insert_intent_request, IntentAction,
+        IntentRequest, LeaseAcquireOutcome, NewControlLease, OwnerKind, RiskLabel,
+    };
+
+    let p = temp_db_path("system-intent-mig");
+    {
+        let mut migs = hub_migrations();
+        migs.retain(|m| m.version <= 25);
+        let db = Db::open(&p, Profile::Hub, &migs, "v25").unwrap();
+        assert_eq!(db.version().unwrap(), 25);
+        // None of the four R4 tables exist before v26.
+        for t in [
+            "system_intent_request",
+            "system_intent_result",
+            "system_control_lease",
+            "system_intent_approval_record",
+        ] {
+            assert!(
+                db.conn()
+                    .prepare(&format!("SELECT 1 FROM {t} LIMIT 1"))
+                    .is_err(),
+                "table {t} must not exist before v26"
+            );
+        }
+        // Seed a row in a PRE-EXISTING table (workflow_catalog, v25) to prove the
+        // additive migration touches nothing.
+        db.conn()
+            .execute(
+                "INSERT INTO workflow_catalog
+                    (workflow_id, slug, name, description, tags_json, is_archived,
+                     revision, etag, deployed_version, created_at, updated_at)
+                 VALUES ('wf-pre-v26', 'pre-v26-slug', 'Pre v26', NULL, '[]', 0, 1,
+                         '0000000000000000000000000000000000000000000000000000000000000000',
+                         NULL, 10, 10)",
+                [],
+            )
+            .unwrap();
+    }
+    // Reopen with the full set -> forward-migrate to v26 (the four additive CREATE TABLEs).
+    let db = Db::open_hub(&p).unwrap();
+    assert_eq!(db.version().unwrap(), hub_max_version());
+    // The pre-existing v25 row survived the additive migration untouched.
+    assert_eq!(
+        db.count("workflow_catalog").unwrap(),
+        1,
+        "pre-v26 workflow_catalog row survived the migration"
+    );
+    // All four new tables are present and START EMPTY.
+    for t in [
+        "system_intent_request",
+        "system_intent_result",
+        "system_control_lease",
+        "system_intent_approval_record",
+    ] {
+        let n: i64 = db
+            .conn()
+            .query_row(&format!("SELECT count(*) FROM {t}"), [], |r| r.get(0))
+            .unwrap_or_else(|e| panic!("table {t} must exist + be queryable after v26: {e}"));
+        assert_eq!(n, 0, "new table {t} starts empty");
+    }
+    // The typed API works against the migrated DB end-to-end: a request persists,
+    // a lease acquires, and a deferred-action result reads back honestly.
+    let request = IntentRequest {
+        intent_id: "i-mig".to_string(),
+        action: IntentAction::LaunchApp,
+        actor_id: "agent-1".to_string(),
+        actor_kind: OwnerKind::Agent,
+        target_ref: Some("com.apple.Safari".to_string()),
+        mutating: true,
+        risk: RiskLabel::Medium,
+        created_at: 100,
+    };
+    insert_intent_request(db.conn(), &request).unwrap();
+    let nl = NewControlLease {
+        lease_id: "L-mig".to_string(),
+        owner_id: "agent-1".to_string(),
+        owner_kind: OwnerKind::Agent,
+        reason: Some("auto:launch_app".to_string()),
+        ttl_ms: Some(1000),
+    };
+    assert!(matches!(
+        acquire_control_lease(db.conn(), &nl, 100).unwrap(),
+        LeaseAcquireOutcome::Acquired(_)
+    ));
+    assert!(get_intent_result(db.conn(), "i-mig").unwrap().is_none());
+}
+
+#[test]
 fn reopen_is_idempotent_and_preserves_rows() {
     let p = temp_db_path("seeded");
     {


### PR DESCRIPTION
## What & why

Builds the **Rust-owned equivalent of the SYSTEM-INTENT path**, DARK. The TypeScript `friday-system-service.executeIntent` is already fenced fail-closed in live runtime — it throws `TS_RUNTIME_SYSTEM_INTENT_RETIRED` (HTTP 503, `classification: fail_closed`) for every non-test caller and literally declares its replacement to be `rust_owned_system_intent_execution_entrypoint_required`. This PR is that replacement's storage + domain home.

**Dark / no route flip:** additive substrate only, behind a fail-closed flagged entrypoint. NO production route, NO runtime caller, NO live flip, NO companion/desktop wiring, NO change to any TS runtime file. The live TS system-intent path stays fail-closed. **NOT v1 GO.**

## Mirrored TS semantics (read from `src/system/engine/friday-system-service.ts` + `src/system/model/friday-system.types.ts`, not invented)

- The 23 `FRIDAY_SYSTEM_INTENT_ACTIONS` action vocabulary + the 5 `FRIDAY_SYSTEM_INTENT_STATUSES`.
- The `MUTATING_INTENTS` set → `mutating=true` (auto-acquire lease + canonical-gate).
- The `HIGH_RISK_INTENTS` set + `resolveRiskLevel` (close_app/notification_act/clipboard_read = high; clipboard_write/launch_app = medium; else low).
- The control-lease lifecycle (`request_control`/`release_control` + `ensureControlLease` auto-acquire): owner-exclusive acquire, same-owner **reuse**, foreign-owner **`SYSTEM_CONTROL_BUSY` (409)**, TTL **expiry-revoke** (`normalizeActiveLease`), release/recover/panic revoke.
- Per-dispatch intent REQUEST + RESULT records.

## Fail-closed posture (the security core)

- **Mutating intents are approval-gated** through `friday_core::gate::evaluate`, which by construction has **no Allow-for-a-mutating-action path** — a mutating / `risk>=High` action resolves only to `RequiresApproval` or `Deny`. So a mutating intent here **always** becomes a `blocked` result and is **never executed**; the gate decision is persisted as a durable approval-record.
- **`approve`/`deny` by an `Agent`/`Channel`/`remote` actor is a HARD `Deny`** (the gate's reserved-approval-action rule). An untrusted actor can **never self-approve** — tested explicitly (decision = Deny, reason `agent_cannot_execute_reserved_approval_action`, no success event, no rule mutation).
- **The flag is fail-closed:** dispatch is refused with `SystemIntentError::FailClosed` **before any side effect** unless built with the explicit opt-in (mirrors the TS exactly-`true` `allowTestOnlySystemIntentExecution`).

## Write-set (tight, matches the plan)

| File | Change |
|------|--------|
| `rust-core/crates/friday-storage/src/schema.rs` | **m0026/v26** — 4 additive Hub-only tables + a partial-unique active-lease index; all 4 registered in `HUB_ONLY_TABLES` |
| `rust-core/crates/friday-storage/src/system_intent.rs` | **NEW** — typed request/result/approval stores + control-lease lifecycle (11 unit tests) |
| `rust-core/crates/friday-storage/src/lib.rs` | `pub mod system_intent;` |
| `rust-core/crates/friday-storage/tests/migration.rs` | v25→v26 forward-migration KAT (new-table pattern) |
| `rust-core/crates/friday-hub/src/system_intent.rs` | **NEW** — dispatch domain layer: gate approval-gating + lease lifecycle + deferred-OS-action seam (9 unit tests) |
| `rust-core/crates/friday-hub/src/lib.rs` | `pub mod system_intent;` |

`friday-core` was NOT modified (the gate `Actor`/`ActorKind`/`Risk`/`evaluate` it needed already exist).

## m0026 tables (v26, additive — no ALTER of any existing table)

- `system_intent_request` — immutable INPUT record (action ∈ closed 23-vocab, actor_id/kind, refs-only `target_ref`, `mutating`, `risk`).
- `system_intent_result` — 1:1 OUTCOME by `intent_id` (status ∈ closed 5-vocab, coarse `message`, `control_lease_id`, `gate_reason`). FK → request.
- `system_control_lease` — lease lifecycle (owner_id/kind, acquired/expires/revoked + reason). **At-most-one-active lease is DB-ENFORCED** by partial unique index `idx_system_control_lease_one_active … WHERE revoked_at IS NULL` (mirrors `idx_workflow_definition_one_published`).
- `system_intent_approval_record` — refs-only gate-decision trail (decision/reason/risk/approval_required). FK → request. Holds NO secret/key/approval-mint material.

## Migration-KAT evidence

`forward_migration_v25_to_v26_adds_system_intent_tables_and_preserves_v25_rows`: on a fresh v25 DB the 4 tables are ABSENT; a seeded v25 `workflow_catalog` row survives the forward migration untouched; after reopen `version == hub_max_version()`, all 4 tables present + empty + usable end-to-end. ✅

## Test results (in-worktree, `cargo` on the 3 touched crates)

- `cargo build -p friday-storage -p friday-hub -p friday-core` — Finished, clean.
- `friday-storage` lib: **73 passed** (incl. 11 new `system_intent`), 1 ignored, 0 failed.
- `friday-storage` migration KAT: **10 passed**, 0 failed.
- `friday-hub` lib: **489 passed** (incl. 9 new `system_intent`), 8 ignored, 0 failed.
- `friday-core` lib: **144 passed**, 0 failed.
- `friday-arch-tests` (HUB_ONLY_TABLES / secret-boundary): all green.
- `cargo clippy -p friday-storage -p friday-hub -p friday-core --all-targets -- -D warnings` — clean. `cargo fmt` applied.

## Explicit DEFERRED / UNIMPLEMENTED seams (NOT faked green)

1. **The actual OS effect** of every desktop-affecting action (launch_app/open_url/close_app/focus/clipboard*/notification*/handoff*/arrange_windows/snapshot) — the TS `executeIntentInternal` switch bodies that call `execCommand`/`companionBridge`/`desktopSessionManager`. Here those route to the `SystemActionExecutor` trait whose only impl is `UnavailableExecutor` (precedent: TS `createFridaySystemUnavailableCompanionBridge`). A deferred action records `unavailable` + the coarse marker `rust_system_action_execution_unimplemented` — **never `completed`**.
2. **The verified canonical-approval → Allow → EXECUTE happy path** for a mutating intent. `gate::evaluate` cannot grant a mutating action; the upgrade lives in `friday-storage::authorize_mutating_action` (PR-3b). This PR wires only the fail-closed BLOCK path. (An Allow would, today, hit the unavailable executor anyway.) recover_ui's TS lease-revoke side effect is part of that deferred execute path.
3. **The legacy approval-RULE mechanism** is NOT ported: TS `approve`/`deny` upsert a `FridaySystemApprovalRule` and `assertApprovalAllowed` + `DEFAULT_APPROVAL_RULES` gate high-risk intents against those rules. Here approve/deny gate via the **canonical gate only** (and are classified mutating, so they always block); the `system_intent_approval_record` is a decision **trail**, not a policy **rule** store. Faithful to TS canonical-gate-on mode; the rule mechanism is a deferred seam.
4. **No separate system-EVENT subscription stream.** TS emits `FRIDAY_SYSTEM_EVENT_NAMES` (system.control.acquired/released, system.intent.completed/blocked, …) to live subscribers. Here the durable trail is the result + approval rows (refs-only); a separate event-emission/subscription surface is deferred.
5. Remote-device/passkey/WebAuthn, companion reconnect, desktop-session-manager, browser diagnostics — **out of scope** for this dark slice (not started).

🤖 Generated with [Claude Code](https://claude.com/claude-code)