### PR TITLE
feat(rust-workflow): R2 slice-2 — retry/cancel run-control + friday-core Cancelled/retry-edge (additive) + m0027 (dark)

### DIFF
--- a/rust-core/crates/friday-core/src/workflow.rs
+++ b/rust-core/crates/friday-core/src/workflow.rs
@@ -12,6 +12,15 @@ use crate::error::CoreError;
 
 /// Lifecycle of a workflow run. Checkpoints requiring user action pause the run
 /// in `AwaitingCheckpoint` (those go to Activity, `08` §1/§4).
+///
+/// R2 slice-2 (additive): `Cancelled` is a NEW terminal state (mirrors the TS
+/// `WorkflowRunStatus` `cancelled`, distinct from `failed`), and a `Failed ->
+/// Running` retry edge + `{Pending,Running,AwaitingCheckpoint} -> Cancelled`
+/// cancel edges are added. NO existing variant is changed/removed and NO existing
+/// transition edge is altered — `Pending`/`Running`/`AwaitingCheckpoint`/`Done`/
+/// `Failed` and every prior edge behave byte-identically (the LIVE S9 engine,
+/// `skill.rs`/`planning.rs`/`workflow_read.rs` only reference the type in docs and
+/// `as_str`/`is_terminal` predicates, none of which change for the old variants).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum WorkflowRunState {
     Pending,
@@ -19,6 +28,12 @@ pub enum WorkflowRunState {
     AwaitingCheckpoint,
     Done,
     Failed,
+    /// Terminal: the run was cancelled by the owner/operator (distinct from
+    /// `Failed` — a cancel is an intentional stop, not an error). NEW in R2
+    /// slice-2; mirrors TS `cancelled`. Coercing a cancel onto `Failed` would
+    /// erase this distinction (the data-fudge the hard rules forbid), so the
+    /// state is first-class.
+    Cancelled,
 }
 
 impl WorkflowRunState {
@@ -29,17 +44,24 @@ impl WorkflowRunState {
             WorkflowRunState::AwaitingCheckpoint => "awaiting_checkpoint",
             WorkflowRunState::Done => "done",
             WorkflowRunState::Failed => "failed",
+            WorkflowRunState::Cancelled => "cancelled",
         }
     }
 
     pub fn is_terminal(&self) -> bool {
-        matches!(self, WorkflowRunState::Done | WorkflowRunState::Failed)
+        // `Cancelled` is terminal alongside `Done`/`Failed` (a cancelled run is a
+        // finished run). The existing `Done`/`Failed` classification is unchanged.
+        matches!(
+            self,
+            WorkflowRunState::Done | WorkflowRunState::Failed | WorkflowRunState::Cancelled
+        )
     }
 
     pub fn can_transition_to(&self, next: WorkflowRunState) -> bool {
         use WorkflowRunState::*;
         matches!(
             (self, next),
+            // --- Pre-R2 edges (UNCHANGED — byte-identical to slice-1) ---
             (Pending, Running)
                 | (Pending, Failed)
                 | (Running, AwaitingCheckpoint)
@@ -47,6 +69,18 @@ impl WorkflowRunState {
                 | (Running, Failed)
                 | (AwaitingCheckpoint, Running)
                 | (AwaitingCheckpoint, Failed)
+                // --- R2 slice-2 retry edge: a Failed run may be re-driven ---
+                // (mirrors TS `retryRun`'s `assertTransition(status,"running")`).
+                // This is the ONLY new edge into `Running`; it does NOT widen
+                // resume (which stays the `AwaitingCheckpoint -> Running` edge).
+                | (Failed, Running)
+                // --- R2 slice-2 cancel edges into the terminal Cancelled state ---
+                // (mirror TS `cancelRun`'s `assertTransition(status,"cancelled")`).
+                // ONLY non-terminal sources may cancel; `Done`/`Failed`/`Cancelled`
+                // are terminal and have NO `-> Cancelled` edge (no terminal reopen).
+                | (Pending, Cancelled)
+                | (Running, Cancelled)
+                | (AwaitingCheckpoint, Cancelled)
         )
     }
 
@@ -202,6 +236,72 @@ mod tests {
         assert!(s.is_terminal());
         assert!(Pending.try_transition(Done).is_err()); // must run first
         assert!(Done.try_transition(Running).is_err()); // terminal
+    }
+
+    #[test]
+    fn r2_additive_change_preserves_every_pre_existing_edge_and_classification() {
+        // PROOF-OF-NO-REGRESSION for the R2 slice-2 additive core change: every
+        // edge/classification the LIVE S9 engine relies on behaves byte-identically.
+        // Existing edges still ALLOWED (each was legal before slice-2):
+        for (a, b) in [
+            (Pending, Running),
+            (Pending, Failed),
+            (Running, AwaitingCheckpoint),
+            (Running, Done),
+            (Running, Failed),
+            (AwaitingCheckpoint, Running),
+            (AwaitingCheckpoint, Failed),
+        ] {
+            assert!(
+                a.can_transition_to(b),
+                "pre-existing edge {a:?}->{b:?} lost"
+            );
+        }
+        // Existing rejections still REJECTED (no widening of the old states):
+        assert!(!Pending.try_transition(Done).is_ok_and(|_| true)); // must run first
+        assert!(Done.try_transition(Running).is_err()); // Done terminal
+        assert!(Done.try_transition(Failed).is_err()); // Done terminal
+        assert!(Failed.try_transition(Done).is_err()); // Failed not -> Done
+        assert!(Failed.try_transition(AwaitingCheckpoint).is_err()); // retry routes via Running only
+                                                                     // Existing classifications unchanged: Done/Failed terminal; the rest not.
+        assert!(Done.is_terminal());
+        assert!(Failed.is_terminal());
+        assert!(!Pending.is_terminal());
+        assert!(!Running.is_terminal());
+        assert!(!AwaitingCheckpoint.is_terminal());
+        // Existing string labels unchanged.
+        assert_eq!(Pending.as_str(), "pending");
+        assert_eq!(Running.as_str(), "running");
+        assert_eq!(AwaitingCheckpoint.as_str(), "awaiting_checkpoint");
+        assert_eq!(Done.as_str(), "done");
+        assert_eq!(Failed.as_str(), "failed");
+    }
+
+    #[test]
+    fn r2_cancelled_state_and_retry_edge_are_additive_and_terminal() {
+        // The NEW terminal `Cancelled` state: distinct label, terminal, and (the
+        // catch the advisor flagged) MUST survive a string round-trip distinct from
+        // Failed — the storage `parse_run_state` round-trip is exercised in the
+        // storage crate; here we lock the core-level contract.
+        assert_eq!(Cancelled.as_str(), "cancelled");
+        assert!(Cancelled.is_terminal());
+        assert_ne!(Cancelled, Failed, "cancelled is NOT failed");
+
+        // The NEW retry edge: Failed -> Running (the only new edge into Running).
+        assert!(Failed.try_transition(Running).is_ok());
+        // The NEW cancel edges: every NON-terminal state -> Cancelled.
+        assert!(Pending.try_transition(Cancelled).is_ok());
+        assert!(Running.try_transition(Cancelled).is_ok());
+        assert!(AwaitingCheckpoint.try_transition(Cancelled).is_ok());
+        // Terminal states have NO -> Cancelled edge (no terminal reopen / no
+        // cancel->cancel re-entry).
+        assert!(Done.try_transition(Cancelled).is_err());
+        assert!(Failed.try_transition(Cancelled).is_err());
+        assert!(Cancelled.try_transition(Cancelled).is_err());
+        // Cancelled is fully terminal: no edge OUT of it.
+        assert!(Cancelled.try_transition(Running).is_err());
+        assert!(Cancelled.try_transition(Done).is_err());
+        assert!(Cancelled.try_transition(Failed).is_err());
     }
 
     #[test]

--- a/rust-core/crates/friday-hub/src/workflow_exec.rs
+++ b/rust-core/crates/friday-hub/src/workflow_exec.rs
@@ -370,6 +370,150 @@ fn find_paused_seq(conn: &Connection, run_id: &str, n_steps: usize) -> Result<us
     )))
 }
 
+/// Find the RETRY frontier step's seq for a `Failed` run: the first NON-`Verified`
+/// registered step. This generalizes [`find_paused_seq`] (which is `Pending`-only)
+/// to the real engine-produced failure states — because the engine never persists a
+/// `Failed` *step* status: an exec-error on a side-effect step leaves it
+/// `ProofPending`, an exec-error on a pure step leaves it `Running`, and a denied/
+/// unregistered checkpoint leaves it `Pending`. Earlier steps are `Verified` (the
+/// engine fails fast at the first non-passing step), so the first non-`Verified`
+/// registered step IS the failure point. Fail-closed if every registered step is
+/// `Verified` or none was registered (mirrors TS `WORKFLOW_NO_FAILED_NODES_TO_RETRY`).
+fn find_retry_frontier_seq(
+    conn: &Connection,
+    run_id: &str,
+    n_steps: usize,
+) -> Result<usize, StorageError> {
+    for seq in 0..n_steps {
+        let step_id = format!("{run_id}:s{seq}");
+        match workflow::step_status(conn, &step_id)? {
+            Some(StepStatus::Verified) => continue, // already done — never re-driven
+            Some(_) => return Ok(seq),              // first non-Verified = the frontier
+            None => break,                          // no more registered steps
+        }
+    }
+    Err(StorageError::Unsupported(format!(
+        "no retryable (non-verified) step found for failed run '{run_id}' (nothing to retry)"
+    )))
+}
+
+/// RETRY a `Failed` workflow run by re-driving its frontier step (operator-authorized).
+/// This is the RETRY counterpart to [`resume_workflow`], mirroring its STRUCTURE
+/// (manual re-dispatch of the frontier step THROUGH THE GATE, then [`advance_from`]
+/// continues the rest) so it REUSES the engine's execution path and never
+/// re-implements it. The only differences from resume: it prechecks the run is
+/// `Failed` (not `AwaitingCheckpoint`), it reopens the frontier step
+/// ([`workflow::reopen_failed_step`]: -> `Pending`, `attempt += 1`) so
+/// `complete_step` accepts it again, and it transitions `Failed -> Running` (the R2
+/// slice-2 core retry edge).
+///
+/// It must NOT call `advance_from(frontier, ..)` (that re-`add_step`s the frontier →
+/// `step_id` PK collision); like resume it manually re-dispatches the existing
+/// frontier step then `advance_from(frontier + 1, ..)`. Already-`Verified` earlier
+/// steps are NEVER re-executed.
+///
+/// HONEST LIMITATION (documented dark-substrate sub-AC): there are NO idempotency
+/// keys (TS `retryRun` has per-attempt idempotency keys). Re-driving the frontier
+/// step is correct for a TRANSIENT failure (the common retry case); a step whose
+/// side effect *partially* applied before failing could double-run on retry.
+/// Idempotency-keyed re-execution is a deferred follow-up — see the PR body.
+#[allow(clippy::too_many_arguments)]
+pub fn retry_workflow(
+    def: &WorkflowDefinition,
+    executor: &dyn ToolExecutor,
+    conn: &Connection,
+    run_id: &str,
+    secret: &[u8],
+    approve: &dyn Fn(&MutatingActionRequest) -> Option<CanonicalApproval>,
+    now_ms: i64,
+) -> Result<WorkflowOutcome, StorageError> {
+    let state = workflow::run_state(conn, run_id)?
+        .ok_or_else(|| StorageError::Unsupported(format!("workflow_run '{run_id}' not found")))?;
+    if state != WorkflowRunState::Failed {
+        return Err(StorageError::Unsupported(format!(
+            "cannot retry workflow_run '{run_id}': state is {} (only a Failed run is retryable)",
+            state.as_str()
+        )));
+    }
+    let frontier_seq = find_retry_frontier_seq(conn, run_id, def.steps.len())?;
+    let step = &def.steps[frontier_seq];
+    let step_id = format!("{run_id}:s{frontier_seq}");
+    // Reopen the frontier step (-> Pending, attempt += 1) BEFORE the run transition, so
+    // a failure to reopen (e.g. it is unexpectedly Verified) aborts without mutating run
+    // state.
+    workflow::reopen_failed_step(conn, &step_id, now_ms)?;
+    // Failed -> Running (the R2 slice-2 core retry edge).
+    workflow::set_run_state(conn, run_id, WorkflowRunState::Running, now_ms)?;
+    // Re-dispatch the frontier step through the gate — the SAME authorization path as
+    // resume/run. A mutating step needs a valid `approve`; otherwise it re-pauses (it
+    // does NOT execute unapproved). Failure arms mirror `resume_workflow` exactly.
+    let raw = RawToolCall {
+        action: step.action.clone(),
+        params: step.params.clone(),
+    };
+    match gate_dispatch(conn, executor, &raw, secret, approve, now_ms)? {
+        GateDispatch::Executed(receipt) => {
+            workflow::complete_step(conn, &step_id, Some(&receipt.summary), true, now_ms)?;
+        }
+        GateDispatch::RequiresApproval => {
+            // The frontier is a mutating step with no valid approval → pause (do not
+            // execute unapproved). The retried run is now AwaitingCheckpoint, resumable.
+            workflow::set_run_state(conn, run_id, WorkflowRunState::AwaitingCheckpoint, now_ms)?;
+            return Ok(WorkflowOutcome {
+                status: WorkflowRunStatus::AwaitingCheckpoint {
+                    step_id,
+                    reason: "gate_requires_approval (retry of a mutating step without an approval)"
+                        .to_string(),
+                },
+                executed_steps: 0,
+            });
+        }
+        GateDispatch::Denied(reason) => {
+            workflow::set_run_state(conn, run_id, WorkflowRunState::Failed, now_ms)?;
+            return Ok(WorkflowOutcome {
+                status: WorkflowRunStatus::Failed {
+                    step_id,
+                    reason: format!("denied:{reason}"),
+                },
+                executed_steps: 0,
+            });
+        }
+        GateDispatch::ExecError(e) => {
+            workflow::complete_step(conn, &step_id, None, false, now_ms)?;
+            workflow::set_run_state(conn, run_id, WorkflowRunState::Failed, now_ms)?;
+            return Ok(WorkflowOutcome {
+                status: WorkflowRunStatus::Failed {
+                    step_id,
+                    reason: format!("exec_error:{e}"),
+                },
+                executed_steps: 0,
+            });
+        }
+        GateDispatch::Unregistered(action) => {
+            workflow::set_run_state(conn, run_id, WorkflowRunState::Failed, now_ms)?;
+            return Ok(WorkflowOutcome {
+                status: WorkflowRunStatus::Failed {
+                    step_id,
+                    reason: format!("unregistered:{action}"),
+                },
+                executed_steps: 0,
+            });
+        }
+    }
+    // Frontier re-executed → continue auto-advancing the rest (count seeded at 1).
+    advance_from(
+        def,
+        frontier_seq + 1,
+        executor,
+        conn,
+        run_id,
+        secret,
+        approve,
+        1,
+        now_ms,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust-core/crates/friday-hub/src/workflow_run_control.rs
+++ b/rust-core/crates/friday-hub/src/workflow_run_control.rs
@@ -6,88 +6,84 @@
 //! every non-route caller is fenced out with a 503 `TS_RUNTIME_WORKFLOW_RUNS_RETIRED`
 //! while runtime ownership moves to Rust). This module is the Rust-owned
 //! equivalent of that control surface, built DARK: NO production route, NO
-//! scheduler/trigger/daemon, NO migration, NO route flip, and it changes NO TS
-//! runtime file. It is purely additive over the existing Rust run model.
+//! scheduler/trigger/daemon, NO route flip, and it changes NO TS runtime file. It
+//! is purely additive over the existing Rust run model. (R2 slice-2 DOES land one
+//! additive dark migration — m0027, two `ALTER ADD COLUMN`s on the already-Hub-only
+//! workflow tables — to back retry/cancel; it adds no new table and nothing reads
+//! it in production.)
 //!
 //! ## What it mirrors, and the run-model it maps onto
 //! The TS service uses an 8-state `WorkflowRunStatus`
 //! (`queued/running/pausing/paused/compensating/completed/failed/cancelled`) with
 //! a `failed -> running` retry edge and `* -> cancelled`. The Rust hub does NOT
-//! own that TS schema; it owns the `friday-core` 5-state [`WorkflowRunState`]
-//! (`Pending/Running/AwaitingCheckpoint/Done/Failed`) persisted in
-//! [`friday_storage::workflow`] and driven by the LIVE S9 engine
-//! ([`crate::workflow_exec`]). So this module mirrors the TS control *logic*
-//! (validation order, fail-closed error vocabulary, run effects) mapped onto the
-//! Rust model — TS `paused` ≈ Rust `AwaitingCheckpoint` — rather than porting the
-//! 8 TS state-strings into the Rust `state` column (which would silently corrupt
-//! every 5-state reader, since [`friday_storage::workflow`]'s `parse_run_state`
-//! coerces an unknown string to `Failed`).
+//! own that TS schema; it owns the `friday-core` 6-state [`WorkflowRunState`]
+//! (`Pending/Running/AwaitingCheckpoint/Done/Failed/Cancelled` — `Cancelled` added
+//! additively in R2 slice-2) persisted in [`friday_storage::workflow`] and driven
+//! by the LIVE S9 engine ([`crate::workflow_exec`]). So this module mirrors the TS
+//! control *logic* (validation order, fail-closed error vocabulary, run effects)
+//! mapped onto the Rust model — TS `paused` ≈ Rust `AwaitingCheckpoint`, TS
+//! `cancelled` = Rust `Cancelled` — rather than porting the remaining TS-only
+//! state-strings (`queued`/`pausing`/`compensating`) into the Rust `state` column
+//! (which would silently corrupt every closed-vocab reader, since
+//! [`friday_storage::workflow`]'s `parse_run_state` coerces an UNKNOWN string to
+//! `Failed` — `cancelled` is now a KNOWN string and round-trips faithfully).
 //!
-//! ## Per-op scope (HONEST — two ops fail closed by representability, not by choice)
-//! - **`resume`** — fully built. It is the missing RESUME control bridge: S9
-//!   ([`crate::workflow_run`]) added a START bridge (`run_stored_workflow`) but no
-//!   resume bridge. [`resume`] loads the STORED definition fail-closed, prechecks
-//!   the run is `AwaitingCheckpoint` (the only resumable state — surfacing a
-//!   precise fail-closed error otherwise, matching the TS
-//!   `INVALID_RUN_TRANSITION`/`WORKFLOW_RUN_NOT_FOUND` posture), then DELEGATES to
-//!   the existing [`crate::workflow_exec::resume_workflow`] engine entrypoint
-//!   (real node re-entry through the SAME gate; mutating steps stay approval-gated
-//!   exactly as in the engine). It does NOT re-implement execution and does NOT
-//!   flip state and return hollow (which, in this dark substrate with no tick
-//!   loop, would strand a run in `Running` with nothing driving it).
-//! - **`retry`** — fails closed with [`RunControlError::NotRepresentable`]. TS
-//!   `retryRun` is `failed -> running` plus per-node retry-attempt rows
-//!   (`attempt+1`, idempotency key, `retrying` status). The `friday-core` machine
-//!   has NO `Failed -> Running` edge and the `workflow_step` schema has no
-//!   attempt/idempotency/`retrying` concept. Representing it requires changing
-//!   `friday-core/src/workflow.rs` (a shared core type the LIVE S9 engine +
-//!   `skill.rs`/`planning.rs`/`workflow_read.rs` all match on) and an m0027
-//!   migration — a cross-cutting, non-additive change outside R2's write-set that
-//!   would touch live behavior. See the PR body's DEFERRED ACCEPTANCE CRITERIA.
-//! - **`cancel`** — fails closed with [`RunControlError::NotRepresentable`]. TS
-//!   `cancelRun` writes a terminal `cancelled` run state (distinct from `failed`)
-//!   + cancels pending nodes + records a cancel reason. `friday-core` has NO
-//!   `Cancelled` run state and NO `Cancelled` step status; mapping cancel onto
-//!   `Failed` would erase the cancelled/failed distinction (a data-fudge the hard
-//!   rules forbid). Representing it faithfully requires the same cross-cutting
-//!   `friday-core` change + an m0027 `cancel_reason`. See the PR body.
+//! ## Per-op scope (R2 slice-2: all three ops are now BUILT over the additive
+//! `friday-core` `Cancelled`/retry-edge extension + m0027 columns)
+//! - **`resume`** — the RESUME control bridge (slice-1). [`resume`] loads the
+//!   STORED definition fail-closed, prechecks the run is `AwaitingCheckpoint` (the
+//!   only resumable state), then DELEGATES to
+//!   [`crate::workflow_exec::resume_workflow`] (real node re-entry through the SAME
+//!   gate). It does NOT re-implement execution and does NOT flip-and-abandon state.
+//! - **`retry`** — the RETRY control bridge (slice-2). Mirrors TS `retryRun`
+//!   (`failed -> running` + per-node retry attempt). [`retry`] loads the STORED
+//!   definition fail-closed, prechecks the run is `Failed` (the only retryable
+//!   state), then DELEGATES to [`crate::workflow_exec::retry_workflow`], which
+//!   reopens the failed run's frontier step (-> `Pending`, `attempt += 1` via the
+//!   m0027 column), transitions `Failed -> Running` (the new core edge), and
+//!   re-drives the frontier THROUGH THE SAME GATE then continues — REUSING the
+//!   engine path, not re-implementing it. A mutating frontier with no approval
+//!   re-pauses (never executes unapproved). HONEST: no idempotency keys yet (a
+//!   partial side-effect could double-run on retry) — a documented deferred sub-AC.
+//! - **`cancel`** — the CANCEL control bridge (slice-2). Mirrors TS `cancelRun`
+//!   (terminal `cancelled`, distinct from `failed`, + a reason). [`cancel`]
+//!   prechecks the run exists and is non-terminal, then writes the terminal
+//!   `Cancelled` state + `cancel_reason` (m0027) atomically via
+//!   [`friday_storage::workflow::cancel_run`] — NEVER coercing onto `Failed` (the
+//!   cancelled/failed distinction is preserved end-to-end: the write is `Cancelled`
+//!   and `parse_run_state` reads it back as `Cancelled`). Cancel does NOT load a
+//!   definition (no node re-entry) and does NOT spend executor effort.
 //!
 //! ## Fail-closed posture
-//! Every entrypoint fail-closes: an unknown run, a non-resumable run state, a
-//! missing/unparsable stored definition, and the two not-yet-representable ops
-//! all return an explicit [`RunControlError`] — never a panic, never a silent
-//! success, never a coerced state write. No `unwrap`/`expect` on caller input.
+//! Every entrypoint fail-closes: an unknown run, a non-actionable run state (a
+//! non-`AwaitingCheckpoint` resume, a non-`Failed` retry, a terminal cancel), and a
+//! missing/unparsable stored definition all return an explicit [`RunControlError`]
+//! — never a panic, never a silent success, never a coerced state write. No
+//! `unwrap`/`expect` on caller input.
 
 use friday_core::gate::{CanonicalApproval, MutatingActionRequest};
-use friday_storage::workflow::run_control_state;
+use friday_storage::workflow::{cancel_run, run_control_state};
 use rusqlite::Connection;
 
 use crate::workflow_def::{load_definition, WorkflowDefError};
-use crate::workflow_exec::{resume_workflow, WorkflowOutcome};
+use crate::workflow_exec::{resume_workflow, retry_workflow, WorkflowOutcome};
 use crate::ToolExecutor;
 
 /// Fail-closed errors of the R2 run-control plane. Mirrors the TS service's
-/// error *vocabulary* (run-not-found, invalid-transition) and adds the explicit
-/// not-representable signal for the two ops the Rust run model cannot yet honor.
+/// error *vocabulary* (run-not-found, invalid-transition).
 #[derive(Debug, thiserror::Error)]
 pub enum RunControlError {
     /// The targeted run does not exist (TS `WORKFLOW_RUN_NOT_FOUND`, 404).
     #[error("workflow run not found: {0}")]
     NotFound(String),
     /// The run is not in a state this control op may act on — e.g. a resume of a
-    /// non-`AwaitingCheckpoint` run (TS `INVALID_RUN_TRANSITION`, 400). Carries
-    /// the current state and the attempted control op for an explicit message.
+    /// non-`AwaitingCheckpoint` run, a retry of a non-`Failed` run, or a cancel of
+    /// a terminal run (TS `INVALID_RUN_TRANSITION`, 400). Carries the current state
+    /// and the attempted control op for an explicit message.
     #[error("invalid run-control transition: {0}")]
     InvalidTransition(String),
-    /// The control op is NOT representable in the current Rust run model without
-    /// a cross-cutting `friday-core` change outside R2's additive write-set. This
-    /// is the honest, documented fail-closed for `retry`/`cancel` — NOT a stub,
-    /// NOT a silent no-op, NOT a coercion onto `Failed`. The message names the
-    /// exact missing capability so the acceptance criterion is unambiguous.
-    #[error("workflow run-control op not representable in the Rust run model: {0}")]
-    NotRepresentable(String),
     /// The stored definition failed to load/parse/validate (fail-closed before
-    /// any control effect — a run is never resumed against an invalid body).
+    /// any control effect — a run is never resumed/retried against an invalid body).
     #[error("workflow definition error: {0}")]
     Definition(#[from] WorkflowDefError),
     /// A storage-layer failure surfaced fail-closed (never swallowed).
@@ -173,42 +169,144 @@ pub fn resume(
     Ok(outcome)
 }
 
-/// RETRY a run's failed nodes — NOT representable in the current Rust run model
-/// (fail-closed). See the module docs and the PR's DEFERRED ACCEPTANCE CRITERIA:
-/// faithfully mirroring TS `retryRun` needs a `friday-core` `Failed -> Running`
-/// edge + per-attempt `workflow_step` columns (m0027), a cross-cutting change
-/// outside R2's additive write-set that would touch the live S9 engine. This
-/// returns an explicit, documented [`RunControlError::NotRepresentable`] — it
-/// performs NO write and NO coercion. `nodes` is accepted to pin the intended TS
-/// signature (selective-node retry) so the future representable version is a
-/// drop-in; it is intentionally unused here.
+/// RETRY a `Failed` workflow run — the R2 slice-2 control bridge mirroring TS
+/// `retryRun(runId, nodeIds)`.
+///
+/// It loads the STORED definition (`workflow_id` + `version`) fail-closed,
+/// prechecks the run is `Failed` (the only retryable state — surfacing a precise
+/// fail-closed error otherwise, matching the TS `INVALID_RUN_TRANSITION`/
+/// `WORKFLOW_RUN_NOT_FOUND` posture), then DELEGATES to
+/// [`crate::workflow_exec::retry_workflow`], which reopens the failed run's
+/// frontier step (-> `Pending`, `attempt += 1`), transitions `Failed -> Running`
+/// (the new core retry edge), and re-drives the frontier THROUGH THE SAME GATE then
+/// continues — the SAME re-entry chokepoint as resume. No execution is
+/// re-implemented here and no state is flipped-and-abandoned (a hollow
+/// `Failed -> Running` flip in this dark, tick-loop-less substrate would strand the
+/// run in `Running`).
+///
+/// Fail-closed order (mirrors the TS `retryRun` posture):
+/// 1. Unknown run → [`RunControlError::NotFound`] (TS `WORKFLOW_RUN_NOT_FOUND`).
+/// 2. Run not `Failed` → [`RunControlError::InvalidTransition`] (TS
+///    `INVALID_RUN_TRANSITION`) — checked BEFORE the definition load.
+/// 3. Stored definition missing/unparsable → [`RunControlError::Definition`].
+///
+/// ## Divergences from TS `retryRun` (explicit, documented)
+/// - **Selective-node retry (`nodes`) is NOT modeled.** TS retries a chosen subset
+///   of failed nodes; the Rust engine is a LINEAR step run with a single failure
+///   frontier (it fails fast at the first non-passing step), so "retry" is "re-drive
+///   from the frontier". `nodes` is accepted to pin the TS signature but, if
+///   supplied, MUST name exactly the frontier step (`{run_id}:s{frontier}`) — any
+///   other selection is a fail-closed [`RunControlError::InvalidTransition`] (we do
+///   NOT silently ignore a caller's node selection). A future DAG engine would honor
+///   arbitrary subsets — a deferred sub-AC.
+/// - **No idempotency keys** (TS has per-attempt idempotency keys). Re-driving the
+///   frontier is correct for a TRANSIENT failure; a partially-applied side effect
+///   could double-run. A documented deferred sub-AC (see the module docs / PR body).
+#[allow(clippy::too_many_arguments)]
 pub fn retry(
-    _conn: &Connection,
+    conn: &Connection,
+    executor: &dyn ToolExecutor,
+    workflow_id: &str,
+    version: i64,
     run_id: &str,
-    _nodes: Option<&[String]>,
+    secret: &[u8],
+    approve: &dyn Fn(&MutatingActionRequest) -> Option<CanonicalApproval>,
+    nodes: Option<&[String]>,
+    now_ms: i64,
 ) -> Result<WorkflowOutcome> {
-    Err(RunControlError::NotRepresentable(format!(
-        "retry of run '{run_id}': the friday-core run-state machine has no 'Failed -> Running' \
-         retry edge and the workflow_step schema has no per-attempt (attempt/idempotency/retrying) \
-         columns. Representing TS retryRun requires a cross-cutting friday-core change + an m0027 \
-         migration, outside R2's additive write-set (it would touch the live S9 engine). Deferred."
-    )))
+    // (1)/(2) Fail-closed precheck FIRST: unknown run → NotFound; a non-Failed run →
+    // InvalidTransition. This runs BEFORE the definition load so a non-retryable run
+    // never pays a parse.
+    let control = run_control_state(conn, run_id)?
+        .ok_or_else(|| RunControlError::NotFound(format!("'{run_id}'")))?;
+    if control.state != friday_core::WorkflowRunState::Failed {
+        return Err(RunControlError::InvalidTransition(format!(
+            "cannot retry run '{run_id}': state is '{}' (only a Failed run is retryable)",
+            control.state.as_str(),
+        )));
+    }
+
+    // (3) Fail-closed definition load BEFORE any mutation.
+    let def = load_definition(conn, workflow_id, version)?;
+
+    // Selective-node retry guard: if a node selection is supplied, it must name
+    // exactly the engine's single failure frontier — we never silently drop a
+    // caller's selection (that would be a quiet semantic divergence).
+    if let Some(sel) = nodes {
+        let frontier_id = frontier_step_id(conn, run_id, def.steps.len())?;
+        let ok = sel.len() == 1 && sel[0] == frontier_id;
+        if !ok {
+            return Err(RunControlError::InvalidTransition(format!(
+                "selective-node retry of run '{run_id}' is limited to the single failure frontier \
+                 step '{frontier_id}' in the linear Rust engine; got {sel:?} (arbitrary-subset \
+                 retry is a deferred sub-AC)"
+            )));
+        }
+    }
+
+    // DELEGATE to the engine: reopen the frontier, Failed -> Running, re-drive
+    // through the gate, continue. The engine owns every state write from here.
+    let outcome = retry_workflow(&def, executor, conn, run_id, secret, approve, now_ms)?;
+    Ok(outcome)
 }
 
-/// CANCEL a run — NOT representable in the current Rust run model (fail-closed).
-/// See the module docs and the PR's DEFERRED ACCEPTANCE CRITERIA: `friday-core`
-/// has no terminal `Cancelled` run state (and no `Cancelled` step status);
-/// mapping cancel onto `Failed` would erase the cancelled/failed distinction (a
-/// data-fudge the hard rules forbid). A faithful cancel needs the same
-/// cross-cutting `friday-core` change + an m0027 `cancel_reason`, outside R2's
-/// write-set. Returns an explicit [`RunControlError::NotRepresentable`]; performs
-/// NO write and NO coercion. `reason` is accepted to pin the TS signature.
-pub fn cancel(_conn: &Connection, run_id: &str, _reason: Option<&str>) -> Result<WorkflowOutcome> {
-    Err(RunControlError::NotRepresentable(format!(
-        "cancel of run '{run_id}': the friday-core run-state machine has no terminal 'Cancelled' \
-         state (and no 'Cancelled' step status); coercing cancel onto 'Failed' would erase the \
-         cancelled/failed distinction. Representing TS cancelRun requires a cross-cutting \
-         friday-core change + an m0027 cancel_reason, outside R2's additive write-set. Deferred."
+/// CANCEL a workflow run terminally — the R2 slice-2 control bridge mirroring TS
+/// `cancelRun(runId, reason)`.
+///
+/// It writes the terminal `Cancelled` state + `cancel_reason` (m0027) atomically via
+/// [`friday_storage::workflow::cancel_run`], which validates the transition through
+/// the SAME `friday-core` machine `set_run_state` uses — so only a non-terminal run
+/// (`Pending`/`Running`/`AwaitingCheckpoint`) cancels and a terminal
+/// (`Done`/`Failed`/`Cancelled`) run is REFUSED (no reopen). It NEVER coerces a run
+/// onto `Failed`: the cancelled/failed distinction is preserved end-to-end (the
+/// write is `Cancelled` and `parse_run_state` reads it back as `Cancelled`).
+///
+/// Unlike TS `cancelRun` (which also aborts in-flight node `AbortController`s),
+/// there is NO in-flight async run to abort in this dark, tick-loop-less substrate —
+/// a Rust run is driven synchronously by an explicit `run_workflow`/`resume_workflow`/
+/// `retry_workflow` call, never a background controller — so the cancel is purely the
+/// terminal state+reason write. Cancel does NOT load a definition (no node re-entry)
+/// and spends NO executor effort.
+///
+/// Fail-closed order (mirrors the TS `cancelRun` posture):
+/// 1. Unknown run → [`RunControlError::NotFound`] (TS `WORKFLOW_RUN_NOT_FOUND`).
+/// 2. Terminal run (no `-> Cancelled` edge) → [`RunControlError::InvalidTransition`]
+///    (TS `INVALID_RUN_TRANSITION` from `assertTransition(status,"cancelled")`).
+///
+/// Returns a [`WorkflowRunStatus::Cancelled`] outcome on success.
+pub fn cancel(conn: &Connection, run_id: &str, reason: Option<&str>, now_ms: i64) -> Result<()> {
+    // (1) Unknown run → NotFound (the explicit not-found posture, before the
+    // transition check, so a ghost run is a NotFound rather than a generic storage
+    // error). (2) The terminal-state refusal is enforced inside `cancel_run` via the
+    // core machine — surfaced as a storage error and mapped to InvalidTransition for
+    // the precise TS-mirrored vocabulary.
+    let control = run_control_state(conn, run_id)?
+        .ok_or_else(|| RunControlError::NotFound(format!("'{run_id}'")))?;
+    if control.terminal {
+        return Err(RunControlError::InvalidTransition(format!(
+            "cannot cancel run '{run_id}': state is '{}' (a terminal run cannot be cancelled)",
+            control.state.as_str(),
+        )));
+    }
+    cancel_run(conn, run_id, reason, now_ms)?;
+    Ok(())
+}
+
+/// The `step_id` of the engine's single failure frontier (first non-`Verified`
+/// registered step) — the only node a selective-node `retry` may name. Mirrors the
+/// engine's `find_retry_frontier_seq` without re-exporting it.
+fn frontier_step_id(conn: &Connection, run_id: &str, n_steps: usize) -> Result<String> {
+    use friday_core::StepStatus;
+    for seq in 0..n_steps {
+        let step_id = format!("{run_id}:s{seq}");
+        match friday_storage::workflow::step_status(conn, &step_id)? {
+            Some(StepStatus::Verified) => continue,
+            Some(_) => return Ok(step_id),
+            None => break,
+        }
+    }
+    Err(RunControlError::InvalidTransition(format!(
+        "run '{run_id}' has no retryable (non-verified) frontier step"
     )))
 }
 
@@ -456,48 +554,225 @@ mod tests {
         assert_eq!(run_state_str(&db, "r1"), "awaiting_checkpoint");
     }
 
-    #[test]
-    fn retry_is_fail_closed_not_representable() {
-        // Documented deferral: retry returns an explicit NotRepresentable error,
-        // performs NO write, and names the exact missing capability.
-        let db = Db::open_hub(&tmp_db("retry-defer")).unwrap();
-        let conn = db.conn();
-        workflow::create_run(conn, "r1", "wf", 100).unwrap();
-        workflow::set_run_state(conn, "r1", WorkflowRunState::Running, 110).unwrap();
-        workflow::set_run_state(conn, "r1", WorkflowRunState::Failed, 120).unwrap();
-
-        let r = retry(conn, "r1", Some(&["n1".to_string()]));
-        match r {
-            Err(RunControlError::NotRepresentable(msg)) => {
-                assert!(
-                    msg.contains("Failed -> Running"),
-                    "names the missing edge: {msg}"
-                );
+    /// Executor that ERRS on its first call and SUCCEEDS thereafter — the witness
+    /// that retry resolves an ENGINE-PRODUCED failure (a transient error), with NO
+    /// injected step state. Mirrors a real transient tool failure.
+    struct TransientExec {
+        calls: Cell<usize>,
+    }
+    impl ToolExecutor for TransientExec {
+        fn execute(
+            &self,
+            action: &str,
+            _params: &[(String, String)],
+        ) -> std::result::Result<ToolReceipt, ExecError> {
+            let n = self.calls.get() + 1;
+            self.calls.set(n);
+            if n == 1 {
+                // Simulate a transient tool failure (any ExecError fails the run).
+                Err(ExecError::Unsupported("transient boom".to_string()))
+            } else {
+                Ok(ToolReceipt {
+                    action: action.to_string(),
+                    summary: format!("ran {action} (attempt {n})"),
+                    content: None,
+                })
             }
-            other => panic!("expected NotRepresentable, got {other:?}"),
         }
-        // The run state is untouched by the fail-closed retry (no coercion).
-        assert_eq!(run_state_str(&db, "r1"), "failed");
+    }
+
+    /// A single read-only step (auto-advances through the gate; no checkpoint).
+    fn single_read_def() -> WorkflowDefinition {
+        WorkflowDefinition {
+            name: "probe".into(),
+            steps: vec![step("read", "read_file", &[("path", "x")], false)],
+        }
     }
 
     #[test]
-    fn cancel_is_fail_closed_not_representable_and_never_coerces_to_failed() {
-        // Documented deferral: cancel returns NotRepresentable, performs NO write,
-        // and does NOT coerce a running run onto Failed (the data-fudge the hard
-        // rules forbid).
-        let db = Db::open_hub(&tmp_db("cancel-defer")).unwrap();
+    fn retry_re_drives_a_real_engine_failure_to_done_through_the_gate() {
+        // The end-to-end happy path with NO injected state: a transient executor
+        // error fails the run on the FIRST drive (engine-produced Failed); retry
+        // THROUGH THE BRIDGE reopens the frontier, transitions Failed -> Running,
+        // re-dispatches (executor now succeeds) → Done. The step's attempt is bumped.
+        let db = Db::open_hub(&tmp_db("retry-ok")).unwrap();
+        let conn = db.conn();
+        let def = single_read_def();
+        store_def(conn, "wf1", &def);
+        let exec = TransientExec {
+            calls: Cell::new(0),
+        };
+
+        // First drive: gate allows the read, executor errs → run Failed.
+        let started = run_workflow(&def, &exec, conn, "r1", SECRET, &mint_all, 100).unwrap();
+        assert!(matches!(started.status, WorkflowRunStatus::Failed { .. }));
+        assert_eq!(run_state_str(&db, "r1"), "failed");
+        assert_eq!(exec.calls.get(), 1);
+        // The engine left the frontier step NON-Verified — here `Running` (an
+        // exec-error on a NON-side-effect step leaves it Running, never a `Failed`
+        // step status). This is the real engine failure shape retry must handle; it
+        // is NOT a `StepStatus::Failed` (the engine has no path that writes that).
+        assert_eq!(
+            workflow::step_status(conn, "r1:s0").unwrap(),
+            Some(friday_core::StepStatus::Running),
+            "exec-error on a pure step leaves it Running (the real frontier), not Failed"
+        );
+
+        // Retry THROUGH THE BRIDGE: reopen + Failed->Running + re-drive → Done.
+        let out = retry(conn, &exec, "wf1", 1, "r1", SECRET, &mint_all, None, 200).unwrap();
+        assert_eq!(out.status, WorkflowRunStatus::Completed);
+        assert_eq!(run_state_str(&db, "r1"), "done");
+        assert_eq!(exec.calls.get(), 2, "the frontier was re-dispatched once");
+        assert_eq!(
+            workflow::step_attempt(conn, "r1:s0").unwrap(),
+            Some(2),
+            "the retried step's attempt was bumped to 2"
+        );
+    }
+
+    #[test]
+    fn retry_of_a_mutating_frontier_re_pauses_without_an_approval_and_never_executes_unapproved() {
+        // Safety witness for retry: a run whose mutating frontier failed, retried
+        // with NO valid approval, RE-pauses (AwaitingCheckpoint) and the executor is
+        // NOT called for the mutating step — the gate, not the bridge, authorizes.
+        // Construct an engine-real Failed run with a mutating frontier: a read then a
+        // write; deny-all pauses at the write; we then fail the paused run, then retry.
+        let db = Db::open_hub(&tmp_db("retry-mut")).unwrap();
+        let conn = db.conn();
+        let def = read_then_write_def();
+        store_def(conn, "wf1", &def);
+        let exec = CountingExec {
+            calls: Cell::new(0),
+        };
+        // Drive: read runs, write checkpoints → AwaitingCheckpoint.
+        run_workflow(&def, &exec, conn, "r1", SECRET, &deny_all, 100).unwrap();
+        assert_eq!(run_state_str(&db, "r1"), "awaiting_checkpoint");
+        assert_eq!(exec.calls.get(), 1);
+        // Fail the run (AwaitingCheckpoint -> Failed is a legal core edge) to model a
+        // run that failed at the mutating frontier (the write step is still Pending).
+        workflow::set_run_state(conn, "r1", WorkflowRunState::Failed, 150).unwrap();
+        assert_eq!(
+            workflow::step_status(conn, "r1:s1").unwrap(),
+            Some(friday_core::StepStatus::Pending),
+            "the mutating frontier is Pending (registered, never executed)"
+        );
+
+        // Retry with deny-all: the mutating frontier needs an approval → re-pause.
+        let out = retry(conn, &exec, "wf1", 1, "r1", SECRET, &deny_all, None, 200).unwrap();
+        assert!(matches!(
+            out.status,
+            WorkflowRunStatus::AwaitingCheckpoint { .. }
+        ));
+        assert_eq!(run_state_str(&db, "r1"), "awaiting_checkpoint");
+        assert_eq!(
+            exec.calls.get(),
+            1,
+            "the unapproved mutating frontier must NOT execute on retry"
+        );
+    }
+
+    #[test]
+    fn retry_fail_closed_unknown_non_failed_and_bad_node_selection() {
+        let db = Db::open_hub(&tmp_db("retry-closed")).unwrap();
+        let conn = db.conn();
+        let def = single_read_def();
+        store_def(conn, "wf1", &def);
+        let exec = CountingExec {
+            calls: Cell::new(0),
+        };
+
+        // Unknown run → NotFound, no execution.
+        let r = retry(conn, &exec, "wf1", 1, "ghost", SECRET, &mint_all, None, 100);
+        assert!(matches!(r, Err(RunControlError::NotFound(_))), "got {r:?}");
+        assert_eq!(exec.calls.get(), 0);
+
+        // A non-Failed (Done) run is not retryable → InvalidTransition, untouched.
+        let out = run_workflow(&def, &exec, conn, "r1", SECRET, &mint_all, 100).unwrap();
+        assert_eq!(out.status, WorkflowRunStatus::Completed);
+        let calls_after_done = exec.calls.get();
+        let r = retry(conn, &exec, "wf1", 1, "r1", SECRET, &mint_all, None, 200);
+        assert!(
+            matches!(r, Err(RunControlError::InvalidTransition(_))),
+            "got {r:?}"
+        );
+        assert_eq!(run_state_str(&db, "r1"), "done");
+        assert_eq!(
+            exec.calls.get(),
+            calls_after_done,
+            "no re-execution of a Done run"
+        );
+
+        // A Failed run with a node selection that is NOT the frontier → InvalidTransition.
+        let exec2 = TransientExec {
+            calls: Cell::new(0),
+        };
+        run_workflow(&def, &exec2, conn, "r2", SECRET, &mint_all, 100).unwrap();
+        assert_eq!(run_state_str(&db, "r2"), "failed");
+        let r = retry(
+            conn,
+            &exec2,
+            "wf1",
+            1,
+            "r2",
+            SECRET,
+            &mint_all,
+            Some(&["not-the-frontier".to_string()]),
+            200,
+        );
+        assert!(
+            matches!(r, Err(RunControlError::InvalidTransition(_))),
+            "a bad node selection is fail-closed, not silently ignored: {r:?}"
+        );
+        assert_eq!(
+            run_state_str(&db, "r2"),
+            "failed",
+            "untouched by the refused retry"
+        );
+    }
+
+    #[test]
+    fn cancel_writes_terminal_cancelled_with_reason_and_never_coerces_to_failed() {
+        // Real cancel: a Running run is cancelled THROUGH THE BRIDGE → terminal
+        // Cancelled (NOT Failed) with the reason recorded; reads back as Cancelled.
+        let db = Db::open_hub(&tmp_db("cancel-ok")).unwrap();
         let conn = db.conn();
         workflow::create_run(conn, "r1", "wf", 100).unwrap();
         workflow::set_run_state(conn, "r1", WorkflowRunState::Running, 110).unwrap();
 
-        let r = cancel(conn, "r1", Some("operator requested"));
-        match r {
-            Err(RunControlError::NotRepresentable(msg)) => {
-                assert!(msg.contains("Cancelled"), "names the missing state: {msg}");
-            }
-            other => panic!("expected NotRepresentable, got {other:?}"),
-        }
-        // The running run is NOT coerced to Failed (or anything) — untouched.
-        assert_eq!(run_state_str(&db, "r1"), "running");
+        cancel(conn, "r1", Some("operator requested"), 120).unwrap();
+        assert_eq!(run_state_str(&db, "r1"), "cancelled");
+        assert_ne!(run_state_str(&db, "r1"), "failed");
+        assert_eq!(
+            workflow::run_cancel_reason(conn, "r1").unwrap(),
+            Some("operator requested".to_string())
+        );
+    }
+
+    #[test]
+    fn cancel_fail_closed_unknown_and_terminal_runs() {
+        let db = Db::open_hub(&tmp_db("cancel-closed")).unwrap();
+        let conn = db.conn();
+
+        // Unknown run → NotFound.
+        assert!(matches!(
+            cancel(conn, "ghost", None, 100),
+            Err(RunControlError::NotFound(_))
+        ));
+
+        // A terminal Failed run cannot be cancelled → InvalidTransition; the run is
+        // NOT coerced — it stays Failed (the cancelled/failed distinction holds).
+        workflow::create_run(conn, "r1", "wf", 100).unwrap();
+        workflow::set_run_state(conn, "r1", WorkflowRunState::Failed, 110).unwrap();
+        let r = cancel(conn, "r1", Some("too late"), 120);
+        assert!(
+            matches!(r, Err(RunControlError::InvalidTransition(_))),
+            "got {r:?}"
+        );
+        assert_eq!(run_state_str(&db, "r1"), "failed");
+        assert_eq!(
+            workflow::run_cancel_reason(conn, "r1").unwrap(),
+            None,
+            "a refused cancel writes no reason"
+        );
     }
 }

--- a/rust-core/crates/friday-storage/src/schema.rs
+++ b/rust-core/crates/friday-storage/src/schema.rs
@@ -420,6 +420,20 @@ pub fn hub_migrations() -> Vec<Migration> {
             destructive: false,
             up: m0026_system_intent_substrate,
         },
+        // R2 slice-2: workflow run-CONTROL columns (DARK substrate). Two ADDITIVE
+        // `ALTER ADD COLUMN`s — `workflow_step.attempt` (retry-attempt counter,
+        // NOT NULL DEFAULT 1 = the base attempt, mirroring TS's 1-based node
+        // attempt) and `workflow_run.cancel_reason` (nullable; only a cancel
+        // writes it). No new table (so HUB_ONLY_TABLES is untouched — both columns
+        // hang off the already-Hub-only workflow_step/workflow_run). The DEFAULT
+        // backfills every pre-v27 step to attempt 1 and leaves every pre-v27 run's
+        // cancel_reason NULL, so v26 rows/queries are unaffected.
+        Migration {
+            version: 27,
+            name: "workflow_run_control_columns",
+            destructive: false,
+            up: m0027_workflow_run_control_columns,
+        },
     ]
 }
 
@@ -1962,4 +1976,18 @@ fn m0025_workflow_catalog(tx: &Transaction) -> rusqlite::Result<()> {
 // reads or writes these tables (DARK).
 fn m0026_system_intent_substrate(tx: &Transaction) -> rusqlite::Result<()> {
     tx.execute_batch(DDL_SYSTEM_INTENT)
+}
+
+/// R2 slice-2: two ADDITIVE columns on the already-Hub-only workflow tables for
+/// the dark run-control plane (retry/cancel). No new table; nothing reads/writes
+/// these in production (DARK). `workflow_step.attempt` is the retry-attempt counter
+/// (NOT NULL DEFAULT 1 — the base attempt, so every pre-v27 step backfills to 1,
+/// matching TS's 1-based node attempt; `reopen_failed_step` bumps it on a retry).
+/// `workflow_run.cancel_reason` is the cancel message (nullable; only `cancel_run`
+/// writes it, so every pre-v27 run reads back NULL — never mis-attributed a reason).
+fn m0027_workflow_run_control_columns(tx: &Transaction) -> rusqlite::Result<()> {
+    tx.execute_batch(
+        "ALTER TABLE workflow_step ADD COLUMN attempt INTEGER NOT NULL DEFAULT 1;
+         ALTER TABLE workflow_run ADD COLUMN cancel_reason TEXT;",
+    )
 }

--- a/rust-core/crates/friday-storage/src/workflow.rs
+++ b/rust-core/crates/friday-storage/src/workflow.rs
@@ -17,6 +17,12 @@ fn parse_run_state(s: &str) -> WorkflowRunState {
         "running" => WorkflowRunState::Running,
         "awaiting_checkpoint" => WorkflowRunState::AwaitingCheckpoint,
         "done" => WorkflowRunState::Done,
+        // R2 slice-2: `cancelled` is a NEW first-class state. It MUST parse back to
+        // `Cancelled` (NOT fall through to the `_ => Failed` catch-all) — otherwise
+        // a cancel write would silently read back as `Failed`, reintroducing the
+        // cancelled/failed erasure the hard rules forbid. The compiler does NOT
+        // enforce this arm (the catch-all absorbs it), so it is explicit + tested.
+        "cancelled" => WorkflowRunState::Cancelled,
         _ => WorkflowRunState::Failed,
     }
 }
@@ -269,4 +275,118 @@ pub fn complete_step(
         params![status.as_str(), stored_ref, now, step_id],
     )?;
     Ok(status)
+}
+
+// --- R2 slice-2: run-CONTROL persistence (retry / cancel). Hub-only, additive. ---
+//
+// These compose the same `friday-core` machine `set_run_state` enforces; they add
+// NO second transition table. They are the storage primitives the dark R2
+// run-control plane (`friday-hub::workflow_run_control`) delegates to, mirroring
+// the TS `friday-workflow-execution-service` `retryRun`/`cancelRun` writes.
+
+/// The persisted retry-attempt count of a step (the `attempt` column, m0027). `1`
+/// is the base attempt (matching TS, which starts a node at `attempt = 1` and a
+/// retry at `attempt + 1`). Returns `None` for an unknown `step_id`.
+pub fn step_attempt(conn: &Connection, step_id: &str) -> Result<Option<i64>> {
+    let a: Option<i64> = conn
+        .query_row(
+            "SELECT attempt FROM workflow_step WHERE step_id = ?1",
+            [step_id],
+            |r| r.get(0),
+        )
+        .optional()?;
+    Ok(a)
+}
+
+/// REOPEN the non-terminal frontier step of a failed run for retry (the retry
+/// primitive). Mirrors TS `retryRun`'s per-node retry-attempt creation: it returns
+/// the step to `Pending` and bumps `attempt` (the m0027 column) so a re-drive
+/// re-dispatches it through the gate and `complete_step` accepts it again.
+///
+/// Unlike TS — which INSERTs a new attempt *row* (its `workflow_run_node` keys on
+/// `(runId, nodeId, attempt)`) — the Rust `workflow_step` keys on a single
+/// `step_id` PK, so this is an in-place UPDATE that bumps the attempt counter
+/// (inserting a new row would collide on the PK). The attempt counter still
+/// records the retry, faithful to the TS `attempt + 1` semantics, without a schema
+/// reshape outside m0027's additive column.
+///
+/// ## Which step state is the retry frontier (HONEST — the engine never writes a
+/// `Failed` *step* status)
+/// A failed run's frontier step is NOT `StepStatus::Failed` — the engine has no
+/// path that persists that status. Tracing the failure arms in
+/// [`crate::workflow_exec`]: an exec-error on a side-effect step persists
+/// `ProofPending` (`complete_step(None,..)`), an exec-error on a non-side-effect
+/// step leaves it `Running`, and a denied/unregistered checkpoint leaves it
+/// `Pending` (it was registered but never executed). So this reopens any
+/// **non-`Verified`** step (`Pending`/`Running`/`ProofPending`/the injected-only
+/// `Failed`) — the real engine-produced frontier. It REFUSES a `Verified` step:
+/// completed (evidence-verified) side-effect work must never be silently redone
+/// (that would be the data-fudge the hard rules forbid). Returns the new attempt.
+pub fn reopen_failed_step(conn: &Connection, step_id: &str, now: i64) -> Result<i64> {
+    let cur: Option<String> = conn
+        .query_row(
+            "SELECT status FROM workflow_step WHERE step_id = ?1",
+            [step_id],
+            |r| r.get(0),
+        )
+        .optional()?;
+    let cur = cur
+        .ok_or_else(|| StorageError::Unsupported(format!("workflow_step '{step_id}' not found")))?;
+    if parse_step_status(&cur) == StepStatus::Verified {
+        return Err(StorageError::Unsupported(format!(
+            "workflow_step '{step_id}' is 'verified'; completed work is not re-driveable on retry"
+        )));
+    }
+    // Reopen: -> Pending, attempt += 1, clear any stale evidence_ref (a failed/partial
+    // attempt's ref is invalid — a fresh attempt re-earns it).
+    conn.execute(
+        "UPDATE workflow_step
+            SET status = ?1, attempt = attempt + 1, evidence_ref = NULL, updated_at = ?2
+          WHERE step_id = ?3",
+        params![StepStatus::Pending.as_str(), now, step_id],
+    )?;
+    let new_attempt: i64 = conn.query_row(
+        "SELECT attempt FROM workflow_step WHERE step_id = ?1",
+        [step_id],
+        |r| r.get(0),
+    )?;
+    Ok(new_attempt)
+}
+
+/// CANCEL a run terminally, recording the reason (the cancel primitive). Mirrors
+/// TS `cancelRun`'s `finalizeRun(runId, "cancelled", …, {message: reason})`: it
+/// transitions the run to the terminal `Cancelled` state THROUGH the `friday-core`
+/// machine (so `{Pending,Running,AwaitingCheckpoint} -> Cancelled` is validated and
+/// a terminal `Done`/`Failed`/`Cancelled` run is REFUSED — never reopened) and
+/// writes `cancel_reason` (m0027) in the SAME statement (atomic state+reason).
+///
+/// This NEVER coerces a run onto `Failed` — the cancelled/failed distinction is
+/// preserved end-to-end (the write is `Cancelled`, and `parse_run_state` reads it
+/// back as `Cancelled`). Fail-closed: an unknown run, or a run in a non-cancellable
+/// (terminal) state, returns an error and writes nothing.
+pub fn cancel_run(conn: &Connection, run_id: &str, reason: Option<&str>, now: i64) -> Result<()> {
+    let cur = run_state(conn, run_id)?
+        .ok_or_else(|| StorageError::Unsupported(format!("workflow_run '{run_id}' not found")))?;
+    // Validate the transition through the SAME core machine set_run_state uses — a
+    // terminal run (Done/Failed/Cancelled) has no -> Cancelled edge and fails here.
+    let next = cur.try_transition(WorkflowRunState::Cancelled)?;
+    conn.execute(
+        "UPDATE workflow_run SET state = ?1, cancel_reason = ?2, updated_at = ?3 WHERE run_id = ?4",
+        params![next.as_str(), reason, now, run_id],
+    )?;
+    Ok(())
+}
+
+/// Read a run's `cancel_reason` (m0027), or `None` if unset / the run is unknown.
+/// A non-cancelled run carries `NULL` (the column defaults NULL); only a cancel
+/// writes it.
+pub fn run_cancel_reason(conn: &Connection, run_id: &str) -> Result<Option<String>> {
+    let r: Option<Option<String>> = conn
+        .query_row(
+            "SELECT cancel_reason FROM workflow_run WHERE run_id = ?1",
+            [run_id],
+            |r| r.get(0),
+        )
+        .optional()?;
+    Ok(r.flatten())
 }

--- a/rust-core/crates/friday-storage/tests/migration.rs
+++ b/rust-core/crates/friday-storage/tests/migration.rs
@@ -397,6 +397,84 @@ fn forward_migration_v25_to_v26_adds_system_intent_tables_and_preserves_v25_rows
 }
 
 #[test]
+fn forward_migration_v26_to_v27_adds_run_control_columns_and_preserves_v26_rows() {
+    // R2 slice-2 additive migration v27: two ADDITIVE columns on the already-Hub-only
+    // workflow tables — `workflow_step.attempt` (NOT NULL DEFAULT 1) and
+    // `workflow_run.cancel_reason` (nullable). This is the ALTER ADD COLUMN pattern
+    // (like m0013 token_ledger run_id / m0020 memory_extract_status), NOT a new table.
+    // A PRE-EXISTING v26 run+step (seeded before the columns existed) must survive the
+    // forward ALTER: the step's `attempt` BACKFILLS to the DEFAULT 1 (so a pre-v27 step
+    // is the base attempt, never mis-counted as a retry), and the run's `cancel_reason`
+    // reads back NULL (so a pre-v27 run is never silently attributed a cancel reason).
+    use friday_core::WorkflowRunState;
+    use friday_storage::workflow;
+
+    let p = temp_db_path("wf-run-control-cols-mig");
+    {
+        let mut migs = hub_migrations();
+        migs.retain(|m| m.version <= 26);
+        let db = Db::open(&p, Profile::Hub, &migs, "v26").unwrap();
+        assert_eq!(db.version().unwrap(), 26);
+        // Neither column exists before v27.
+        assert!(
+            db.conn()
+                .prepare("SELECT attempt FROM workflow_step")
+                .is_err(),
+            "workflow_step.attempt must not exist before v27"
+        );
+        assert!(
+            db.conn()
+                .prepare("SELECT cancel_reason FROM workflow_run")
+                .is_err(),
+            "workflow_run.cancel_reason must not exist before v27"
+        );
+        // Seed a run + a step with the pre-v27 shape (no attempt / cancel_reason).
+        workflow::create_run(db.conn(), "r-pre-v27", "QA", 10).unwrap();
+        workflow::add_step(db.conn(), "st-pre-v27", "r-pre-v27", 1, true, 10).unwrap();
+    }
+    // Reopen with the full set -> forward-migrate to v27 (the two additive ALTERs).
+    let db = Db::open_hub(&p).unwrap();
+    assert_eq!(db.version().unwrap(), hub_max_version());
+    assert_eq!(
+        db.count("workflow_run").unwrap(),
+        1,
+        "pre-v27 run row survived the migration"
+    );
+    assert_eq!(
+        db.count("workflow_step").unwrap(),
+        1,
+        "pre-v27 step survived"
+    );
+    // The ALTER's DEFAULT backfilled the PRE-EXISTING step to attempt 1 (base attempt).
+    assert_eq!(
+        workflow::step_attempt(db.conn(), "st-pre-v27").unwrap(),
+        Some(1),
+        "pre-v27 step backfills to the base attempt (1)"
+    );
+    // The pre-existing run reads back NULL cancel_reason (never mis-attributed).
+    assert_eq!(
+        workflow::run_cancel_reason(db.conn(), "r-pre-v27").unwrap(),
+        None,
+        "pre-v27 run backfills to NULL cancel_reason"
+    );
+    // The typed run-control API works against the migrated DB end-to-end: cancel
+    // writes the NEW terminal `Cancelled` state + a reason (NOT Failed) and reads
+    // back faithfully — proving the v27 columns + the friday-core Cancelled state +
+    // the parse_run_state round-trip all compose on a migrated DB.
+    workflow::set_run_state(db.conn(), "r-pre-v27", WorkflowRunState::Running, 11).unwrap();
+    workflow::cancel_run(db.conn(), "r-pre-v27", Some("operator requested"), 12).unwrap();
+    assert_eq!(
+        workflow::run_state(db.conn(), "r-pre-v27").unwrap(),
+        Some(WorkflowRunState::Cancelled),
+        "cancel writes terminal Cancelled (NOT Failed) and round-trips on the migrated DB"
+    );
+    assert_eq!(
+        workflow::run_cancel_reason(db.conn(), "r-pre-v27").unwrap(),
+        Some("operator requested".to_string()),
+    );
+}
+
+#[test]
 fn reopen_is_idempotent_and_preserves_rows() {
     let p = temp_db_path("seeded");
     {

--- a/rust-core/crates/friday-storage/tests/workflow_persist.rs
+++ b/rust-core/crates/friday-storage/tests/workflow_persist.rs
@@ -334,3 +334,158 @@ fn proof_pending_verifies_when_evidence_arrives_but_verified_cannot_downgrade() 
         .unwrap();
     assert_eq!(ev_after.as_deref(), Some("evidence://late"));
 }
+
+// --- R2 slice-2 run-control persistence (cancel / retry primitives) ----------
+
+#[test]
+fn cancel_run_writes_terminal_cancelled_with_reason_and_never_coerces_to_failed() {
+    // The cancel primitive writes the NEW terminal `Cancelled` state (NOT Failed),
+    // records the reason atomically, and — the data-fudge guard — reads back as
+    // Cancelled (the parse_run_state round-trip), distinct from Failed.
+    let p = temp_db_path("wf-cancel");
+    let db = Db::open_hub(&p).unwrap();
+    workflow::create_run(db.conn(), "r1", "QA", 1).unwrap();
+    workflow::set_run_state(db.conn(), "r1", WorkflowRunState::Running, 2).unwrap();
+
+    workflow::cancel_run(db.conn(), "r1", Some("operator requested"), 3).unwrap();
+    assert_eq!(
+        workflow::run_state(db.conn(), "r1").unwrap(),
+        Some(WorkflowRunState::Cancelled),
+        "cancel writes terminal Cancelled, NOT Failed"
+    );
+    assert_ne!(
+        workflow::run_state(db.conn(), "r1").unwrap(),
+        Some(WorkflowRunState::Failed),
+        "the cancelled/failed distinction is preserved end-to-end"
+    );
+    assert_eq!(
+        workflow::run_cancel_reason(db.conn(), "r1").unwrap(),
+        Some("operator requested".to_string())
+    );
+    // The raw column stores the exact string "cancelled" (not "failed").
+    let raw: String = db
+        .conn()
+        .query_row(
+            "SELECT state FROM workflow_run WHERE run_id = 'r1'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(raw, "cancelled");
+}
+
+#[test]
+fn cancel_run_fail_closed_on_terminal_and_unknown_runs() {
+    let p = temp_db_path("wf-cancel-closed");
+    let db = Db::open_hub(&p).unwrap();
+    // Unknown run -> error, no write.
+    assert!(workflow::cancel_run(db.conn(), "ghost", None, 1).is_err());
+
+    // A terminal Done run cannot be cancelled (no Done -> Cancelled edge).
+    workflow::create_run(db.conn(), "r-done", "QA", 1).unwrap();
+    workflow::set_run_state(db.conn(), "r-done", WorkflowRunState::Running, 2).unwrap();
+    workflow::set_run_state(db.conn(), "r-done", WorkflowRunState::Done, 3).unwrap();
+    assert!(
+        workflow::cancel_run(db.conn(), "r-done", Some("too late"), 4).is_err(),
+        "a terminal Done run is not cancellable"
+    );
+    assert_eq!(
+        workflow::run_state(db.conn(), "r-done").unwrap(),
+        Some(WorkflowRunState::Done),
+        "the terminal run is untouched by the refused cancel"
+    );
+
+    // A terminal Failed run cannot be cancelled (preserves failed, never coerced).
+    workflow::create_run(db.conn(), "r-failed", "QA", 1).unwrap();
+    workflow::set_run_state(db.conn(), "r-failed", WorkflowRunState::Failed, 2).unwrap();
+    assert!(workflow::cancel_run(db.conn(), "r-failed", None, 3).is_err());
+    assert_eq!(
+        workflow::run_state(db.conn(), "r-failed").unwrap(),
+        Some(WorkflowRunState::Failed)
+    );
+
+    // A cancelled run cannot be re-cancelled (Cancelled is terminal).
+    workflow::create_run(db.conn(), "r-cx", "QA", 1).unwrap();
+    workflow::set_run_state(db.conn(), "r-cx", WorkflowRunState::Running, 2).unwrap();
+    workflow::cancel_run(db.conn(), "r-cx", Some("first"), 3).unwrap();
+    assert!(workflow::cancel_run(db.conn(), "r-cx", Some("again"), 4).is_err());
+    assert_eq!(
+        workflow::run_cancel_reason(db.conn(), "r-cx").unwrap(),
+        Some("first".to_string()),
+        "the original reason is preserved; a re-cancel writes nothing"
+    );
+}
+
+#[test]
+fn reopen_step_accepts_real_engine_frontier_states_and_refuses_verified() {
+    // The retry primitive reopens the NON-Verified frontier step (-> Pending,
+    // attempt += 1) so a re-drive can re-dispatch + re-complete it. CRITICAL: the
+    // engine never persists a `Failed` STEP status — a failed run's frontier is
+    // ProofPending (side-effect exec-error) / Running (pure exec-error) / Pending
+    // (denied checkpoint), so those are the states that must be retryable. Only a
+    // `Verified` step is refused (completed work must not be silently redone).
+    let p = temp_db_path("wf-reopen-step");
+    let db = Db::open_hub(&p).unwrap();
+    workflow::create_run(db.conn(), "r1", "QA", 1).unwrap();
+
+    // Frontier as ProofPending (the real side-effect exec-error state): retryable.
+    workflow::add_step(db.conn(), "st1", "r1", 1, true, 1).unwrap();
+    assert_eq!(workflow::step_attempt(db.conn(), "st1").unwrap(), Some(1)); // m0027 base
+    workflow::complete_step(db.conn(), "st1", None, false, 2).unwrap(); // -> ProofPending
+    assert_eq!(
+        workflow::step_status(db.conn(), "st1").unwrap(),
+        Some(StepStatus::ProofPending)
+    );
+    let a = workflow::reopen_failed_step(db.conn(), "st1", 3).unwrap();
+    assert_eq!(
+        a, 2,
+        "attempt bumped to 2 on the first retry of a ProofPending step"
+    );
+    assert_eq!(
+        workflow::step_status(db.conn(), "st1").unwrap(),
+        Some(StepStatus::Pending),
+        "reopened step is back to Pending (so complete_step accepts it again)"
+    );
+
+    // Frontier still Pending (denied-checkpoint state): retryable too.
+    workflow::add_step(db.conn(), "st2", "r1", 2, true, 1).unwrap();
+    assert_eq!(
+        workflow::reopen_failed_step(db.conn(), "st2", 4).unwrap(),
+        2
+    );
+
+    // A Verified step is REFUSED — completed (evidence-verified) work is not re-driveable.
+    workflow::add_step(db.conn(), "st3", "r1", 3, true, 1).unwrap();
+    workflow::complete_step(db.conn(), "st3", Some("evidence://done"), false, 5).unwrap();
+    assert_eq!(
+        workflow::step_status(db.conn(), "st3").unwrap(),
+        Some(StepStatus::Verified)
+    );
+    assert!(
+        workflow::reopen_failed_step(db.conn(), "st3", 6).is_err(),
+        "a Verified step is not re-driveable on retry"
+    );
+
+    // The injected-only `Failed` step status is also accepted (defensive).
+    db.conn()
+        .execute(
+            "UPDATE workflow_step SET status = 'failed', evidence_ref = 'stale' WHERE step_id = 'st2'",
+            [],
+        )
+        .unwrap();
+    let a2 = workflow::reopen_failed_step(db.conn(), "st2", 7).unwrap();
+    assert_eq!(a2, 3, "attempt accumulates across retries");
+    // The stale evidence_ref from the failed attempt is cleared (a fresh attempt re-earns it).
+    let ev: Option<String> = db
+        .conn()
+        .query_row(
+            "SELECT evidence_ref FROM workflow_step WHERE step_id = 'st2'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(ev, None, "stale evidence cleared on reopen");
+
+    // Unknown step -> fail-closed.
+    assert!(workflow::reopen_failed_step(db.conn(), "ghost", 8).is_err());
+}

--- a/rust-core/crates/friday-storage/tests/workflow_read_projection.rs
+++ b/rust-core/crates/friday-storage/tests/workflow_read_projection.rs
@@ -29,6 +29,27 @@ fn run_summary_projects_labels_and_is_none_for_an_unknown_run() {
 }
 
 #[test]
+fn run_summary_projects_the_cancelled_state_faithfully_not_coerced_to_failed() {
+    // R2 slice-2 readback contract: a CANCELLED run must project `state =
+    // "cancelled"` through the readback bridge — not silently coerced/dropped to
+    // "failed". The run-state projection is a pass-through string today, but this
+    // locks the contract so a future closed-vocab tightening of the run state can't
+    // re-introduce the cancelled/failed erasure on the read side.
+    let db = Db::open_hub(&temp_db_path("wfread-cancelled")).unwrap();
+    workflow::create_run(db.conn(), "r1", "research", 100).unwrap();
+    workflow::set_run_state(db.conn(), "r1", WorkflowRunState::Running, 150).unwrap();
+    workflow::cancel_run(db.conn(), "r1", Some("operator requested"), 200).unwrap();
+
+    let s = get_workflow_run_summary(db.conn(), "r1").unwrap().unwrap();
+    assert_eq!(
+        s.state, "cancelled",
+        "a cancelled run projects 'cancelled', NOT coerced to 'failed'"
+    );
+    assert_ne!(s.state, "failed");
+    assert_eq!(s.updated_at, 200);
+}
+
+#[test]
 fn step_summaries_are_seq_ordered_and_project_evidence_presence_never_its_text() {
     let db = Db::open_hub(&temp_db_path("wfread-steps")).unwrap();
     workflow::create_run(db.conn(), "r1", "qa", 1).unwrap();


### PR DESCRIPTION
## What this does
Completes the **dark** Rust workflow **run-control plane**. R2 slice-1 (#643) shipped `resume()` and returned `retry()`/`cancel()` as `NotRepresentable` no-write deferrals; the R2 review pinned the exact blocker — `friday-core`'s `WorkflowRunState` had no terminal `Cancelled` and no `Failed->Running` edge, and `workflow_step` had no per-attempt / `cancel_reason` columns. This slice makes the **minimal additive** core + storage extension and builds both ops over it. **DARK: no production route, no flag, no scheduler/trigger, no TS file touched.**

## 1. friday-core — the additive core change (and proof of no behavior change)
`crates/friday-core/src/workflow.rs`, **ADDITIVE ONLY**:
- New terminal variant `WorkflowRunState::Cancelled` (distinct from `Failed`).
- New edges: `Failed -> Running` (retry, the only new edge into `Running` — does **not** widen resume) and `{Pending, Running, AwaitingCheckpoint} -> Cancelled` (cancel; terminal `Done`/`Failed`/`Cancelled` have **no** `-> Cancelled` edge → no terminal reopen).
- `as_str()`/`is_terminal()` extended for `Cancelled`.

**No existing variant or edge changed.** The shared enum is consumed by the LIVE S9 engine + `skill.rs`/`planning.rs`/`workflow_read.rs`, but those reference the type only in docs and via `as_str`/`is_terminal`/`matches!` predicates — the **only** exhaustive `match` is `as_str()` in the core file itself (verified by grep). Proof tests:
- `r2_additive_change_preserves_every_pre_existing_edge_and_classification` — every pre-slice-2 edge still ALLOWED, every pre-existing rejection still REJECTED (`Pending->Done`, `Done->Running/Failed`, `Failed->Done`, `Failed->AwaitingCheckpoint`), every label + terminal classification unchanged.
- `r2_cancelled_state_and_retry_edge_are_additive_and_terminal` — `Cancelled` distinct/terminal, new edges allowed, terminal states have no `-> Cancelled` edge, no edge out of `Cancelled`.
- Pre-existing `run_state_machine` is untouched and still passes.

## 2. friday-storage — parse round-trip + m0027 (additive)
- **`parse_run_state`** adds `"cancelled" => Cancelled` — NOT the `_ => Failed` catch-all. This is the **non-compiler-enforced** correctness condition: without it, a cancel write would silently read back as `Failed`, reintroducing the cancelled/failed erasure the hard rules forbid.
- **m0027 (v27)** — two ADDITIVE `ALTER ADD COLUMN`s on the **already-Hub-only** workflow tables: `workflow_step.attempt INTEGER NOT NULL DEFAULT 1` (base attempt = 1, matching TS's 1-based node attempt) and `workflow_run.cancel_reason TEXT` (nullable). **No new table → `HUB_ONLY_TABLES` is correctly untouched** (both columns hang off tables already registered Hub-only). No ALTER that breaks v26 rows.
- New fns: `cancel_run` (atomic terminal `Cancelled` + `cancel_reason`, transition validated through the **same** core machine `set_run_state` uses), `reopen_failed_step` (reopens the non-`Verified` frontier → `Pending`, `attempt += 1`, clears stale evidence_ref; refuses a `Verified` step), `step_attempt` / `run_cancel_reason` readers.
- **KAT** `forward_migration_v26_to_v27_adds_run_control_columns_and_preserves_v26_rows`: seeds a v26 run+step, asserts both columns absent at v26, reopens → v27, asserts pre-existing rows survive with `attempt` backfilled to 1 and `cancel_reason` NULL, then cancels through the typed API and confirms terminal `Cancelled` (NOT Failed) round-trips on the migrated DB.

## 3. friday-hub — retry/cancel over the extended core
- **`retry_workflow`** (new engine entrypoint in `workflow_exec.rs`) mirrors `resume_workflow`'s STRUCTURE — it **reuses** `gate_dispatch` + `advance_from`, does **not** re-implement execution. **Key correctness finding:** the engine **never persists a `Failed` *step* status** — an exec-error on a side-effect step leaves it `ProofPending`, on a pure step `Running`, and a denied checkpoint stays `Pending`. So the retry frontier is the **first non-`Verified`** step (generalizing resume's Pending-only finder). Sequence: precheck run is `Failed` → reopen frontier (`attempt+1`) → `Failed->Running` → manual re-dispatch of the frontier THROUGH THE GATE (no `add_step` → no PK collision) → `advance_from(frontier+1)`. A mutating frontier with no approval **re-pauses** (never executes unapproved). Verified earlier steps are never re-run.
- **`retry()` / `cancel()`** in `workflow_run_control.rs` delegate over the extended core, mirroring `resume()`'s fail-closed precheck pattern (NotFound → InvalidTransition → Definition). `cancel()` never loads a definition or spends executor effort; it writes terminal `Cancelled` + reason and **never coerces onto `Failed`**. `RunControlError::NotRepresentable` removed (now dead).

## retry/cancel semantics vs TS (`friday-workflow-execution-service.ts`)
- `cancelRun(runId, reason)`: TS `assertTransition(status,"cancelled")` + `finalizeRun(...,"cancelled",{message: reason})`. Rust matches: terminal-state refusal + atomic `Cancelled`+reason write. TS also aborts in-flight `AbortController`s; Rust runs are driven synchronously (no background controller), so there is nothing to abort — documented.
- `retryRun(runId, nodeIds)`: TS `assertTransition(status,"running")` + per-node `attempt+1`/idempotency-key retry rows. Rust matches the `Failed->Running` transition + `attempt+1` (in-place UPDATE, since `workflow_step` keys on a single `step_id` PK rather than `(runId,nodeId,attempt)`). Selective-node retry: the linear Rust engine has a single failure frontier, so a supplied `nodes` selection must name exactly that frontier step or it is fail-closed `InvalidTransition` (never silently ignored).

## Deferred ACs (explicit, not stubbed)
- **No idempotency keys** — retry re-drives the frontier (correct for a transient failure); a *partially-applied* side effect could double-run. Documented in the engine + control docs.
- **Arbitrary-subset node retry** — needs a DAG engine; the linear engine has one frontier.

## Test evidence (worktree, base `01e9d591`)
```
cargo build              Finished dev profile
cargo fmt --check        clean (exit 0)
cargo clippy --workspace --all-targets -- -D warnings   Finished (no warnings)

friday-core      test result: ok. 146 passed; 0 failed   (incl. the 2 additive-proof tests)
friday-storage   v26_to_v27 KAT ok · cancel_run_writes... ok · cancel_run_fail_closed... ok · reopen_step... ok
friday-hub       test result: ok. 499 passed; 0 failed
  retry_re_drives_a_real_engine_failure_to_done_through_the_gate ... ok   (transient exec, NO injected state)
  retry_of_a_mutating_frontier_re_pauses_without_an_approval_and_never_executes_unapproved ... ok
  retry_fail_closed_unknown_non_failed_and_bad_node_selection ... ok
  cancel_writes_terminal_cancelled_with_reason_and_never_coerces_to_failed ... ok
  cancel_fail_closed_unknown_and_terminal_runs ... ok
friday-arch-tests  all green
```

DARK substrate — NOT v1 GO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)